### PR TITLE
Release v0.6.0 — SoC refactor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-agent-container"
-version = "0.5.0"
+version = "0.6.0"
 description = "Declarative YAML-based framework for defining, managing, and orchestrating AI coding agent instances"
 readme = "README.md"
 license = "AGPL-3.0"


### PR DESCRIPTION
## Summary
- refactor: remove all Orochi-specific code (SoC)
- refactor: rename env vars to SCITEX_AGENT_CONTAINER_* prefix
- refactor: remove claude-code-telegrammer references
- fix: screen stop escalates to SIGKILL on timeout
- fix: ssh_remote propagate --force across SSH boundary
- docs: scrub Orochi references from README/docs/skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)