### PR TITLE
feat(snapshot): self-snapshot + diff + 3-layer pids + agent_meta pivot (todo#286, #285)

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_main.py
+++ b/src/scitex_agent_container/cli_pkg/_main.py
@@ -13,6 +13,7 @@ from ._helpers import HelpRecursiveGroup
 from .build_cmds import build, check, validate
 from .info_cmds import attach, find, list_python_apis, logs
 from .lifecycle_cmds import cleanup, restart, start, stop
+from .snapshot_cmds import snapshot
 from .status_cmds import check_agent, health, list_agents, status
 
 
@@ -55,6 +56,7 @@ main.add_command(status)
 main.add_command(list_agents)  # registered as 'list'
 main.add_command(health)
 main.add_command(check_agent)  # registered as 'inspect'
+main.add_command(snapshot)
 
 # Info / introspection
 main.add_command(find)

--- a/src/scitex_agent_container/cli_pkg/snapshot_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/snapshot_cmds.py
@@ -1,0 +1,40 @@
+"""Snapshot subcommand — self-snapshot for an agent (todo#286)."""
+
+from __future__ import annotations
+
+import json as json_mod
+import sys
+
+import click
+
+from ..snapshot import take_snapshot
+
+
+@click.command(name="snapshot")
+@click.option("--agent", "agent", required=True, help="Agent name to snapshot.")
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=True,
+    help="Output as JSON (default; no human mode).",
+)
+@click.option(
+    "--diff/--no-diff",
+    "with_diff",
+    default=True,
+    help="Include diff against previous snapshot (default: --diff).",
+)
+@click.option(
+    "--session",
+    default=None,
+    help="Multiplexer session name (defaults to agent name).",
+)
+def snapshot(agent: str, as_json: bool, with_diff: bool, session: str | None) -> None:
+    """Take a self-snapshot for AGENT and print it as JSON."""
+    try:
+        snap = take_snapshot(agent, session=session, with_diff=with_diff)
+    except Exception as exc:  # pragma: no cover — defensive
+        click.echo(json_mod.dumps({"error": str(exc)}))
+        sys.exit(1)
+    click.echo(json_mod.dumps(snap, indent=2))

--- a/src/scitex_agent_container/context_manager.py
+++ b/src/scitex_agent_container/context_manager.py
@@ -162,13 +162,23 @@ class ContextManager:
 
 
 def run_forever(cm: ContextManager) -> None:
-    """Sensor loop. Cooperatively cancellable via ``cm.stop()``."""
+    """Sensor loop. Cooperatively cancellable via ``cm.stop()``.
+
+    Piggybacks a self-snapshot tick after each context-manager tick so
+    both daemons share a single thread (todo#286).
+    """
     interval = max(1, int(cm.config.check_interval_seconds))
     while not cm.stopped:
         try:
             cm.tick()
         except Exception:  # pragma: no cover — defensive
             logger.exception("context_manager[%s]: tick failed", cm.agent_name)
+        try:
+            from .snapshot import snapshot_tick
+
+            snapshot_tick(cm.agent_name, session=cm.session_name)
+        except Exception:  # pragma: no cover — defensive
+            logger.exception("snapshot[%s]: piggyback tick failed", cm.agent_name)
         # Use Event.wait so stop() breaks us out promptly.
         if cm._stop.wait(interval):
             break
@@ -231,6 +241,26 @@ def start_sensor(agent_config: AgentConfig) -> ContextManager | None:
     )
     _SENSORS[agent_config.name] = cm
     thread.start()
+    try:
+        from .snapshot import register_sidecar
+
+        register_sidecar(
+            agent_config.name,
+            kind="thread",
+            name="context_manager",
+            thread=thread,
+        )
+        register_sidecar(
+            agent_config.name,
+            kind="thread",
+            name="snapshot",
+            thread=thread,
+        )
+    except Exception:  # pragma: no cover — defensive
+        logger.exception(
+            "context_manager[%s]: sidecar registration failed",
+            agent_config.name,
+        )
     logger.info(
         "context_manager[%s]: sensor started (strategy=%s, threshold=%.1f%%, interval=%ss)",
         agent_config.name,

--- a/src/scitex_agent_container/context_manager.py
+++ b/src/scitex_agent_container/context_manager.py
@@ -7,11 +7,15 @@ the configured threshold. See todo#284 / todo#285.
 
 from __future__ import annotations
 
+import json
 import logging
+import os
 import re
+import subprocess
 import threading
 import time
-from typing import Callable
+from pathlib import Path
+from typing import Any, Callable
 
 from .config import AgentConfig, ContextManagementConfig
 
@@ -41,6 +45,49 @@ def parse_context_percent(pane_text: str) -> float | None:
             if 0.0 <= value <= 100.0:
                 return value
     return None
+
+
+_DEFAULT_AGENT_META_SCRIPT = "~/.scitex/orochi/scripts/agent_meta.py"
+
+
+def fetch_agent_meta(
+    agent_name: str, script_path: str | None = None
+) -> dict[str, Any] | None:
+    """Shell out to ``agent_meta.py <agent>`` and return its JSON dict.
+
+    Returns ``None`` on ANY failure (missing script, bad JSON, non-zero
+    exit, timeout). Never raises. The resolved script path can be
+    overridden via the ``SCITEX_AGENT_META_SCRIPT`` env var or the
+    ``script_path`` argument (argument wins).
+    """
+    path = (
+        script_path
+        or os.environ.get("SCITEX_AGENT_META_SCRIPT")
+        or _DEFAULT_AGENT_META_SCRIPT
+    )
+    resolved = str(Path(path).expanduser())
+    try:
+        r = subprocess.run(
+            [resolved, agent_name],
+            timeout=5,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (
+        FileNotFoundError,
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+        OSError,
+    ):
+        return None
+    try:
+        data = json.loads(r.stdout.strip().splitlines()[-1]) if r.stdout.strip() else None
+    except (json.JSONDecodeError, IndexError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    return data
 
 
 # Default pane-capture fn. Injectable for tests; production uses tmux.
@@ -87,6 +134,7 @@ class ContextManager:
         self._fired = False  # latch — don't re-dispatch until we observe a drop
         self._ticks_near_threshold = 0
         self.last_percent: float | None = None
+        self.last_meta: dict[str, Any] | None = None
 
     def stop(self) -> None:
         self._stop.set()
@@ -96,12 +144,25 @@ class ContextManager:
         return self._stop.is_set()
 
     def tick(self) -> float | None:
-        """One sensor probe. Returns the observed percent, or None."""
-        pane = self.capture(self.session_name)
-        percent = parse_context_percent(pane)
+        """One sensor probe. Returns the observed percent, or None.
+
+        Preferred source is the Orochi ``agent_meta.py`` helper which
+        reads Claude's live transcript; falls back to scraping the tmux
+        pane for a claude-hud statusline when the helper is unavailable.
+        """
+        percent: float | None = None
+        meta = fetch_agent_meta(self.agent_name)
+        if meta is not None:
+            self.last_meta = meta
+            raw = meta.get("context_pct")
+            if isinstance(raw, (int, float)):
+                percent = float(raw)
+        if percent is None:
+            pane = self.capture(self.session_name)
+            percent = parse_context_percent(pane)
         if percent is None:
             logger.debug(
-                "context_manager[%s]: no percent found in pane", self.agent_name
+                "context_manager[%s]: no percent from meta or pane", self.agent_name
             )
             return None
         self.last_percent = percent

--- a/src/scitex_agent_container/lifecycle.py
+++ b/src/scitex_agent_container/lifecycle.py
@@ -281,6 +281,18 @@ def agent_status(name: str, registry: Registry | None = None) -> dict:
     else:
         result["context_management"] = None
 
+    # Expose the full agent_meta dict from the live sensor if present
+    # (todo#285 Phase 2b). This is the transcript-derived source of
+    # truth used by the dashboard when it's available.
+    try:
+        from .context_manager import get_sensor as _gs
+
+        _live = _gs(name)
+        if _live is not None and _live.last_meta is not None:
+            result["agent_meta"] = _live.last_meta
+    except Exception:
+        pass
+
     # Snapshot block — cheap read from cache (todo#286). Never re-gathers.
     try:
         from .snapshot import read_latest

--- a/src/scitex_agent_container/lifecycle.py
+++ b/src/scitex_agent_container/lifecycle.py
@@ -281,6 +281,22 @@ def agent_status(name: str, registry: Registry | None = None) -> dict:
     else:
         result["context_management"] = None
 
+    # Snapshot block — cheap read from cache (todo#286). Never re-gathers.
+    try:
+        from .snapshot import read_latest
+
+        latest = read_latest(name)
+        if latest is not None:
+            result["snapshot"] = {
+                "timestamp": latest.get("timestamp"),
+                "has_diff": latest.get("has_diff", False),
+                "diff_fields": latest.get("diff_fields", []),
+            }
+        else:
+            result["snapshot"] = None
+    except Exception:
+        result["snapshot"] = None
+
     # Enrich with claude-hud-style metadata. Canonical source for the
     # Agents-tab dashboard; the MCP sidecar heartbeat shells out to this
     # command rather than duplicating the logic in TypeScript.

--- a/src/scitex_agent_container/snapshot.py
+++ b/src/scitex_agent_container/snapshot.py
@@ -25,7 +25,23 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from .context_manager import get_sensor
+from .context_manager import fetch_agent_meta, get_sensor
+
+# Keys from agent_meta.py we surface in snapshots / status --json.
+_AGENT_META_KEYS = (
+    "alive",
+    "subagents",
+    "context_pct",
+    "current_tool",
+    "last_activity",
+    "model",
+)
+
+
+def _project_agent_meta(meta: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not meta:
+        return None
+    return {k: meta.get(k) for k in _AGENT_META_KEYS if k in meta}
 
 logger = logging.getLogger(__name__)
 
@@ -297,6 +313,21 @@ def gather_snapshot(agent: str, *, session: str | None = None) -> dict[str, Any]
     sensor = get_sensor(agent)
     context_percent = sensor.last_percent if sensor is not None else None
 
+    # Prefer a live sensor's cached meta to avoid an extra shell-out per
+    # tick. Fall back to a direct fetch when no sensor is running.
+    meta_full: dict[str, Any] | None = None
+    if sensor is not None and sensor.last_meta is not None:
+        meta_full = sensor.last_meta
+    else:
+        meta_full = fetch_agent_meta(agent)
+    agent_meta_block = _project_agent_meta(meta_full)
+    if (
+        context_percent is None
+        and agent_meta_block is not None
+        and isinstance(agent_meta_block.get("context_pct"), (int, float))
+    ):
+        context_percent = float(agent_meta_block["context_pct"])
+
     tmux_pids = _probe_tmux_pids(session or agent)
 
     claude_pid: int | None = None
@@ -322,6 +353,7 @@ def gather_snapshot(agent: str, *, session: str | None = None) -> dict[str, Any]
         "nproc_max": nproc_max,
         "fork_pressure_pct": fork_pct,
         "context_percent": context_percent,
+        "agent_meta": agent_meta_block,
         "pids": {
             "agent": os.getpid(),
             "claude_code": claude_pid,

--- a/src/scitex_agent_container/snapshot.py
+++ b/src/scitex_agent_container/snapshot.py
@@ -18,6 +18,7 @@ import logging
 import os
 import platform
 import re
+import shutil
 import socket
 import subprocess
 import threading
@@ -170,14 +171,63 @@ def _probe_tmux() -> tuple[int | None, list[str]]:
 
 
 def _probe_screen_count() -> int | None:
-    out = _run(["screen", "-ls"])
-    if not out:
-        return 0 if _run(["which", "screen"]) == "" else None
+    """Return the number of live GNU screen sessions.
+
+    Contract:
+    - ``None`` iff the ``screen`` binary is not installed at all.
+    - ``0`` if ``screen`` is installed but no sessions are live (``screen -ls``
+      prints ``No Sockets found ...`` and exits non-zero — that is NOT an
+      error, it means zero sessions).
+    - A positive int when one or more sessions are listed.
+    """
+    if shutil.which("screen") is None:
+        return None
+    try:
+        r = subprocess.run(
+            ["screen", "-ls"],
+            capture_output=True,
+            text=True,
+            timeout=3,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError):
+        # Binary vanished between which() and run(); treat as not installed.
+        return None
+    combined = (r.stdout or "") + (r.stderr or "")
+    if "No Sockets found" in combined:
+        return 0
     n = 0
-    for ln in out.splitlines():
+    for ln in (r.stdout or "").splitlines():
         if re.match(r"\s*\d+\.", ln):
             n += 1
     return n
+
+
+def _probe_claude_pid() -> int | None:
+    """Return the PID of the live ``claude`` CLI child, or ``None``.
+
+    The naive ``pgrep -f claude`` matches ANY process whose full command
+    line contains the substring ``claude`` — including the
+    ``scitex-agent-container`` python wrapper itself (whose argv often
+    mentions claude-code, claude_code, or a claude agent name). We must
+    exclude that wrapper and only pick the real ``claude`` CLI child that
+    ``runtimes/claude_code.py`` execs (command basename == ``claude``).
+
+    Strategy: prefer ``pgrep -n -x claude`` (exact command-name match).
+    """
+    try:
+        r = subprocess.run(
+            ["pgrep", "-n", "-x", "claude"],
+            capture_output=True,
+            text=True,
+            timeout=3,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError):
+        return None
+    first = (r.stdout or "").strip().splitlines()
+    if not first:
+        return None
+    token = first[0].strip()
+    return int(token) if token.isdigit() else None
 
 
 def _proc_count(pattern: str) -> int | None:
@@ -330,10 +380,7 @@ def gather_snapshot(agent: str, *, session: str | None = None) -> dict[str, Any]
 
     tmux_pids = _probe_tmux_pids(session or agent)
 
-    claude_pid: int | None = None
-    out = _run(["pgrep", "-n", "-f", "claude"])
-    if out.strip().isdigit():
-        claude_pid = int(out.strip().splitlines()[0])
+    claude_pid = _probe_claude_pid()
 
     return {
         "agent": agent,

--- a/src/scitex_agent_container/snapshot.py
+++ b/src/scitex_agent_container/snapshot.py
@@ -13,6 +13,8 @@ Kept deliberately stdlib-only: no psutil, no yaml, no new deps.
 
 from __future__ import annotations
 
+import contextlib
+import fcntl
 import json
 import logging
 import os
@@ -24,7 +26,7 @@ import subprocess
 import threading
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterator
 
 from .context_manager import fetch_agent_meta, get_sensor
 
@@ -138,6 +140,28 @@ def _prev_path(agent: str) -> Path:
 
 def _diff_path(agent: str) -> Path:
     return cache_dir() / f"{agent}.diff.json"
+
+
+def _lock_path(agent: str) -> Path:
+    return cache_dir() / f"{agent}.lock"
+
+
+@contextlib.contextmanager
+def _snapshot_lock(agent: str) -> Iterator[None]:
+    """Per-agent advisory lock around the latest->prev roll + write.
+
+    POSIX fcntl advisory lock; not supported on Windows but container
+    targets unix. The lock file persists between calls (reusable); the
+    advisory lock is released when the fd is closed via the ``with`` block.
+    """
+    lock_p = _lock_path(agent)
+    with open(lock_p, "w") as fd:
+        fcntl.flock(fd.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            # Released implicitly on close(), but be explicit for clarity.
+            fcntl.flock(fd.fileno(), fcntl.LOCK_UN)
 
 
 # ---------------------------------------------------------------------------
@@ -393,16 +417,16 @@ def gather_snapshot(agent: str, *, session: str | None = None) -> dict[str, Any]
         "bun_procs": _proc_count("bun"),
         "node_procs": _proc_count("node"),
         "load1": _probe_load1(),
-        "mem_total": mem_total,
-        "mem_used": mem_used,
-        "mem_free": mem_free,
+        "mem_total_bytes": mem_total,
+        "mem_used_bytes": mem_used,
+        "mem_free_bytes": mem_free,
         "nproc_cur": nproc_cur,
         "nproc_max": nproc_max,
         "fork_pressure_pct": fork_pct,
         "context_percent": context_percent,
         "agent_meta": agent_meta_block,
         "pids": {
-            "agent": os.getpid(),
+            "container_daemon": os.getpid(),
             "claude_code": claude_pid,
             "tmux": tmux_pids,
             "sidecars": _sidecars_payload(agent),
@@ -452,41 +476,42 @@ def take_snapshot(agent: str, *, session: str | None = None, with_diff: bool = T
     latest_p = _latest_path(agent)
     prev_p = _prev_path(agent)
 
-    # Read previous (before rolling).
-    prev_data: dict[str, Any] | None = None
-    if latest_p.exists():
-        try:
-            prev_data = json.loads(latest_p.read_text())
-        except (OSError, json.JSONDecodeError):
-            prev_data = None
-
     snap = gather_snapshot(agent, session=session)
 
-    if with_diff:
-        diff_fields = compute_diff_fields(prev_data, snap)
-    else:
-        diff_fields = []
-    snap["has_diff"] = bool(diff_fields)
-    snap["diff_fields"] = diff_fields
+    with _snapshot_lock(agent):
+        # Read previous (before rolling).
+        prev_data: dict[str, Any] | None = None
+        if latest_p.exists():
+            try:
+                prev_data = json.loads(latest_p.read_text())
+            except (OSError, json.JSONDecodeError):
+                prev_data = None
 
-    # Roll latest -> prev BEFORE overwriting latest.
-    if latest_p.exists():
-        try:
-            os.replace(latest_p, prev_p)
-        except OSError:
-            logger.exception("snapshot[%s]: failed rolling latest to prev", agent)
+        if with_diff:
+            diff_fields = compute_diff_fields(prev_data, snap)
+        else:
+            diff_fields = []
+        snap["has_diff"] = bool(diff_fields)
+        snap["diff_fields"] = diff_fields
 
-    _atomic_write_json(latest_p, snap)
+        # Roll latest -> prev BEFORE overwriting latest.
+        if latest_p.exists():
+            try:
+                os.replace(latest_p, prev_p)
+            except OSError:
+                logger.exception("snapshot[%s]: failed rolling latest to prev", agent)
 
-    if snap["has_diff"]:
-        _atomic_write_json(
-            _diff_path(agent),
-            {
-                "agent": agent,
-                "timestamp": snap["timestamp"],
-                "diff_fields": diff_fields,
-            },
-        )
+        _atomic_write_json(latest_p, snap)
+
+        if snap["has_diff"]:
+            _atomic_write_json(
+                _diff_path(agent),
+                {
+                    "agent": agent,
+                    "timestamp": snap["timestamp"],
+                    "diff_fields": diff_fields,
+                },
+            )
 
     return snap
 

--- a/src/scitex_agent_container/snapshot.py
+++ b/src/scitex_agent_container/snapshot.py
@@ -1,0 +1,430 @@
+"""Self-snapshot subcommand (todo#286).
+
+Collects a per-agent snapshot of the local host state (tmux/screen,
+proc counts, load, memory, fork-pressure, claude context-percent) and
+persists it to the container cache dir. On each run, the previous
+snapshot is rolled to ``<agent>.prev.json`` and the new one lands in
+``<agent>.latest.json`` atomically. A flat dotted-key diff is computed
+against the previous snapshot so the dashboard can highlight what
+changed.
+
+Kept deliberately stdlib-only: no psutil, no yaml, no new deps.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import platform
+import re
+import socket
+import subprocess
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .context_manager import get_sensor
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Sidecar thread registry
+#
+# Phase 2 context_manager kept a dict of live ContextManager instances. We
+# expose a small wrapper here so ``snapshot`` can report sidecar liveness
+# without reaching into private module state. Process-kind sidecars
+# (health_monitor runs as a real thread too in the current codebase, but we
+# still model them with ``kind="thread"``) register here as well.
+# ---------------------------------------------------------------------------
+
+SidecarInfo = dict[str, Any]
+_SIDECARS: dict[str, dict[str, SidecarInfo]] = {}
+
+
+def register_sidecar(
+    agent: str,
+    kind: str,
+    name: str,
+    *,
+    pid: int | None = None,
+    thread: threading.Thread | None = None,
+) -> None:
+    """Register a sidecar so ``snapshot`` can introspect liveness.
+
+    ``kind`` is ``"thread"`` or ``"process"``. ``thread`` must be supplied
+    for thread-kind sidecars; ``pid`` for process-kind.
+    """
+    _SIDECARS.setdefault(agent, {})[name] = {
+        "kind": kind,
+        "pid": pid,
+        "thread": thread,
+    }
+
+
+def _sidecar_alive(info: SidecarInfo) -> bool:
+    kind = info.get("kind")
+    if kind == "thread":
+        th = info.get("thread")
+        return bool(th is not None and th.is_alive())
+    if kind == "process":
+        pid = info.get("pid")
+        if pid is None:
+            return False
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            # Exists but we can't signal — still alive.
+            return True
+        except OSError:
+            return False
+        return True
+    return False
+
+
+def _sidecars_payload(agent: str) -> dict[str, dict[str, Any]]:
+    out: dict[str, dict[str, Any]] = {}
+    for name, info in _SIDECARS.get(agent, {}).items():
+        out[name] = {
+            "pid": info.get("pid"),
+            "kind": info.get("kind"),
+            "alive": _sidecar_alive(info),
+        }
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Cache dir
+# ---------------------------------------------------------------------------
+
+
+def cache_dir() -> Path:
+    override = os.environ.get("SCITEX_AGENT_CACHE_DIR")
+    if override:
+        p = Path(override).expanduser()
+    else:
+        p = Path.home() / ".scitex" / "agent-container" / "cache"
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def _latest_path(agent: str) -> Path:
+    return cache_dir() / f"{agent}.latest.json"
+
+
+def _prev_path(agent: str) -> Path:
+    return cache_dir() / f"{agent}.prev.json"
+
+
+def _diff_path(agent: str) -> Path:
+    return cache_dir() / f"{agent}.diff.json"
+
+
+# ---------------------------------------------------------------------------
+# Probes (stdlib-only, Darwin + Linux)
+# ---------------------------------------------------------------------------
+
+
+def _run(cmd: list[str], timeout: float = 3.0) -> str:
+    try:
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        return r.stdout
+    except (FileNotFoundError, subprocess.SubprocessError):
+        return ""
+
+
+def _probe_tmux() -> tuple[int | None, list[str]]:
+    try:
+        r = subprocess.run(
+            ["tmux", "list-sessions", "-F", "#{session_name}"],
+            capture_output=True,
+            text=True,
+            timeout=3,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError):
+        return None, []
+    if r.returncode != 0:
+        # "no server running" is not an error for us — just zero sessions.
+        return 0, []
+    names = [ln for ln in r.stdout.splitlines() if ln.strip()]
+    return len(names), names
+
+
+def _probe_screen_count() -> int | None:
+    out = _run(["screen", "-ls"])
+    if not out:
+        return 0 if _run(["which", "screen"]) == "" else None
+    n = 0
+    for ln in out.splitlines():
+        if re.match(r"\s*\d+\.", ln):
+            n += 1
+    return n
+
+
+def _proc_count(pattern: str) -> int | None:
+    out = _run(["pgrep", "-af", pattern])
+    if not out:
+        # Could mean "no matches" or "pgrep missing"; pgrep exit 1 gives
+        # empty stdout — treat as zero.
+        return 0
+    return len([ln for ln in out.splitlines() if ln.strip()])
+
+
+def _probe_load1() -> float | None:
+    try:
+        return os.getloadavg()[0]
+    except OSError:
+        return None
+
+
+def _probe_mem_darwin() -> tuple[int | None, int | None, int | None]:
+    out = _run(["/usr/sbin/sysctl", "-n", "hw.memsize"])
+    total = int(out.strip()) if out.strip().isdigit() else None
+    vm = _run(["vm_stat"])
+    if not vm:
+        return total, None, None
+    page_size = 4096
+    m = re.search(r"page size of (\d+) bytes", vm)
+    if m:
+        page_size = int(m.group(1))
+    pages: dict[str, int] = {}
+    for ln in vm.splitlines():
+        m = re.match(r"(.+?):\s+(\d+)", ln)
+        if m:
+            pages[m.group(1).strip()] = int(m.group(2))
+    free_pages = pages.get("Pages free", 0) + pages.get("Pages speculative", 0)
+    free_bytes = free_pages * page_size
+    used_bytes = (total - free_bytes) if total is not None else None
+    return total, used_bytes, free_bytes
+
+
+def _probe_mem_linux() -> tuple[int | None, int | None, int | None]:
+    try:
+        text = Path("/proc/meminfo").read_text()
+    except OSError:
+        return None, None, None
+    kv: dict[str, int] = {}
+    for ln in text.splitlines():
+        m = re.match(r"(\w+):\s+(\d+)\s*kB", ln)
+        if m:
+            kv[m.group(1)] = int(m.group(2)) * 1024
+    total = kv.get("MemTotal")
+    avail = kv.get("MemAvailable", kv.get("MemFree"))
+    used = (total - avail) if (total is not None and avail is not None) else None
+    return total, used, avail
+
+
+def _probe_mem() -> tuple[int | None, int | None, int | None]:
+    if platform.system() == "Darwin":
+        return _probe_mem_darwin()
+    if platform.system() == "Linux":
+        return _probe_mem_linux()
+    return None, None, None
+
+
+def _probe_nproc() -> tuple[int | None, int | None]:
+    """Return (current, max) process counts for fork-pressure math."""
+    cur: int | None = None
+    mx: int | None = None
+    out = _run(["ps", "-A"])
+    if out:
+        cur = max(0, len(out.splitlines()) - 1)
+    if platform.system() == "Darwin":
+        mxs = _run(["/usr/sbin/sysctl", "-n", "kern.maxproc"]).strip()
+        if mxs.isdigit():
+            mx = int(mxs)
+    elif platform.system() == "Linux":
+        try:
+            mx = int(Path("/proc/sys/kernel/pid_max").read_text().strip())
+        except (OSError, ValueError):
+            mx = None
+    return cur, mx
+
+
+def _probe_tmux_pids(session: str | None) -> dict[str, int | None]:
+    server: int | None = None
+    pane: int | None = None
+    if not session:
+        return {"server": None, "pane": None}
+    try:
+        r = subprocess.run(
+            ["tmux", "display", "-p", "-t", f"{session}:0", "#{pane_pid}"],
+            capture_output=True,
+            text=True,
+            timeout=3,
+        )
+        if r.returncode == 0 and r.stdout.strip().isdigit():
+            pane = int(r.stdout.strip())
+    except (FileNotFoundError, subprocess.SubprocessError):
+        pass
+    try:
+        r = subprocess.run(
+            ["pgrep", "-n", "-x", "tmux"],
+            capture_output=True,
+            text=True,
+            timeout=3,
+        )
+        if r.returncode == 0 and r.stdout.strip().isdigit():
+            server = int(r.stdout.strip().splitlines()[0])
+    except (FileNotFoundError, subprocess.SubprocessError):
+        pass
+    return {"server": server, "pane": pane}
+
+
+# ---------------------------------------------------------------------------
+# Snapshot assembly + diff
+# ---------------------------------------------------------------------------
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).astimezone().isoformat(timespec="seconds")
+
+
+def gather_snapshot(agent: str, *, session: str | None = None) -> dict[str, Any]:
+    """Build a snapshot dict for ``agent``. No I/O to cache dir."""
+    tmux_count, tmux_names = _probe_tmux()
+    screen_count = _probe_screen_count()
+    mem_total, mem_used, mem_free = _probe_mem()
+    nproc_cur, nproc_max = _probe_nproc()
+    if nproc_cur is not None and nproc_max:
+        fork_pct: float | None = round(100.0 * nproc_cur / nproc_max, 2)
+    else:
+        fork_pct = None
+
+    sensor = get_sensor(agent)
+    context_percent = sensor.last_percent if sensor is not None else None
+
+    tmux_pids = _probe_tmux_pids(session or agent)
+
+    claude_pid: int | None = None
+    out = _run(["pgrep", "-n", "-f", "claude"])
+    if out.strip().isdigit():
+        claude_pid = int(out.strip().splitlines()[0])
+
+    return {
+        "agent": agent,
+        "timestamp": _now_iso(),
+        "host": socket.gethostname(),
+        "tmux_count": tmux_count,
+        "tmux_names": tmux_names,
+        "screen_count": screen_count,
+        "claude_procs": _proc_count("claude"),
+        "bun_procs": _proc_count("bun"),
+        "node_procs": _proc_count("node"),
+        "load1": _probe_load1(),
+        "mem_total": mem_total,
+        "mem_used": mem_used,
+        "mem_free": mem_free,
+        "nproc_cur": nproc_cur,
+        "nproc_max": nproc_max,
+        "fork_pressure_pct": fork_pct,
+        "context_percent": context_percent,
+        "pids": {
+            "agent": os.getpid(),
+            "claude_code": claude_pid,
+            "tmux": tmux_pids,
+            "sidecars": _sidecars_payload(agent),
+        },
+    }
+
+
+def _flatten(obj: Any, prefix: str = "") -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            key = f"{prefix}.{k}" if prefix else str(k)
+            out.update(_flatten(v, key))
+    elif isinstance(obj, list):
+        # Lists compare as whole values — don't explode indices.
+        out[prefix] = obj
+    else:
+        out[prefix] = obj
+    return out
+
+
+def compute_diff_fields(prev: dict[str, Any] | None, latest: dict[str, Any]) -> list[str]:
+    if prev is None:
+        return []
+    flat_prev = _flatten(prev)
+    flat_latest = _flatten(latest)
+    # Ignore timestamp — it always changes.
+    ignored = {"timestamp"}
+    changed: list[str] = []
+    keys = set(flat_prev) | set(flat_latest)
+    for k in sorted(keys):
+        if k in ignored:
+            continue
+        if flat_prev.get(k) != flat_latest.get(k):
+            changed.append(k)
+    return changed
+
+
+def _atomic_write_json(path: Path, data: dict[str, Any]) -> None:
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(data, indent=2))
+    os.replace(tmp, path)
+
+
+def take_snapshot(agent: str, *, session: str | None = None, with_diff: bool = True) -> dict[str, Any]:
+    """Gather, persist, and return a snapshot for ``agent``."""
+    latest_p = _latest_path(agent)
+    prev_p = _prev_path(agent)
+
+    # Read previous (before rolling).
+    prev_data: dict[str, Any] | None = None
+    if latest_p.exists():
+        try:
+            prev_data = json.loads(latest_p.read_text())
+        except (OSError, json.JSONDecodeError):
+            prev_data = None
+
+    snap = gather_snapshot(agent, session=session)
+
+    if with_diff:
+        diff_fields = compute_diff_fields(prev_data, snap)
+    else:
+        diff_fields = []
+    snap["has_diff"] = bool(diff_fields)
+    snap["diff_fields"] = diff_fields
+
+    # Roll latest -> prev BEFORE overwriting latest.
+    if latest_p.exists():
+        try:
+            os.replace(latest_p, prev_p)
+        except OSError:
+            logger.exception("snapshot[%s]: failed rolling latest to prev", agent)
+
+    _atomic_write_json(latest_p, snap)
+
+    if snap["has_diff"]:
+        _atomic_write_json(
+            _diff_path(agent),
+            {
+                "agent": agent,
+                "timestamp": snap["timestamp"],
+                "diff_fields": diff_fields,
+            },
+        )
+
+    return snap
+
+
+def read_latest(agent: str) -> dict[str, Any] | None:
+    p = _latest_path(agent)
+    if not p.exists():
+        return None
+    try:
+        return json.loads(p.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def snapshot_tick(agent: str, *, session: str | None = None) -> None:
+    """Daemon helper: take a snapshot, swallow errors."""
+    try:
+        take_snapshot(agent, session=session)
+    except Exception:  # pragma: no cover — defensive
+        logger.exception("snapshot[%s]: tick failed", agent)

--- a/tests/test_context_manager.py
+++ b/tests/test_context_manager.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
+import json
 import logging
+import subprocess
+from unittest.mock import patch
 
 import pytest
 
 from scitex_agent_container.config import ContextManagementConfig
 from scitex_agent_container.context_manager import (
     ContextManager,
+    fetch_agent_meta,
     parse_context_percent,
 )
 
@@ -31,6 +35,16 @@ def test_parse_context_percent_none_when_missing():
 
 def test_parse_context_percent_empty():
     assert parse_context_percent("") is None
+
+
+@pytest.fixture(autouse=True)
+def _no_agent_meta_shellout(monkeypatch):
+    """By default, stub fetch_agent_meta to None so tests exercise the
+    pane-parser fallback. Tests that need meta override it explicitly."""
+    monkeypatch.setattr(
+        "scitex_agent_container.context_manager.fetch_agent_meta",
+        lambda *a, **k: None,
+    )
 
 
 def _make_cm(percent_text: str, **cfg_overrides) -> tuple[ContextManager, list]:
@@ -115,6 +129,103 @@ def test_tick_updates_last_percent():
     assert cm.last_percent is None
     cm.tick()
     assert cm.last_percent == 42.0
+
+
+_SAMPLE_META = {
+    "agent": "head-nas",
+    "alive": True,
+    "multiplexer": "tmux",
+    "subagents": 0,
+    "context_pct": 23.1,
+    "current_tool": "Bash",
+    "last_activity": "2026-04-13T05:12:00.665Z",
+    "model": "claude-opus-4-6",
+}
+
+
+def _fake_completed(stdout: str) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=["x"], returncode=0, stdout=stdout, stderr="")
+
+
+def test_fetch_agent_meta_success():
+    with patch(
+        "scitex_agent_container.context_manager.subprocess.run",
+        return_value=_fake_completed(json.dumps(_SAMPLE_META) + "\n"),
+    ):
+        got = fetch_agent_meta("head-nas")
+    assert got == _SAMPLE_META
+
+
+def test_fetch_agent_meta_missing_script():
+    with patch(
+        "scitex_agent_container.context_manager.subprocess.run",
+        side_effect=FileNotFoundError(),
+    ):
+        assert fetch_agent_meta("x") is None
+
+
+def test_fetch_agent_meta_bad_json():
+    with patch(
+        "scitex_agent_container.context_manager.subprocess.run",
+        return_value=_fake_completed("not-json-at-all"),
+    ):
+        assert fetch_agent_meta("x") is None
+
+
+def test_fetch_agent_meta_timeout():
+    with patch(
+        "scitex_agent_container.context_manager.subprocess.run",
+        side_effect=subprocess.TimeoutExpired(cmd="x", timeout=5),
+    ):
+        assert fetch_agent_meta("x") is None
+
+
+def test_fetch_agent_meta_called_process_error():
+    with patch(
+        "scitex_agent_container.context_manager.subprocess.run",
+        side_effect=subprocess.CalledProcessError(1, "x"),
+    ):
+        assert fetch_agent_meta("x") is None
+
+
+def test_fetch_agent_meta_env_override(monkeypatch):
+    monkeypatch.setenv("SCITEX_AGENT_META_SCRIPT", "/tmp/does-not-exist-xyz.py")
+    captured: dict = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return _fake_completed(json.dumps(_SAMPLE_META))
+
+    with patch("scitex_agent_container.context_manager.subprocess.run", side_effect=fake_run):
+        got = fetch_agent_meta("head-nas")
+    assert got == _SAMPLE_META
+    assert captured["cmd"][0] == "/tmp/does-not-exist-xyz.py"
+    assert captured["cmd"][1] == "head-nas"
+
+
+def test_context_manager_uses_agent_meta_when_available():
+    cm, calls = _make_cm("no percent at all\n")  # pane parse would fail
+    with patch(
+        "scitex_agent_container.context_manager.fetch_agent_meta",
+        return_value={**_SAMPLE_META, "context_pct": 85.0},
+    ):
+        percent = cm.tick()
+    assert percent == 85.0
+    assert cm.last_meta is not None
+    assert cm.last_meta["context_pct"] == 85.0
+    assert len(calls) == 1  # dispatched compact
+
+
+def test_context_manager_falls_back_to_pane_parser_when_meta_none():
+    cm, calls = _make_cm("[model] ctx 42% | foo\n")
+    with patch(
+        "scitex_agent_container.context_manager.fetch_agent_meta",
+        return_value=None,
+    ):
+        percent = cm.tick()
+    assert percent == 42.0
+    assert cm.last_meta is None
+    assert calls == []
 
 
 def test_agent_status_includes_context_management(monkeypatch, tmp_path):

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -17,6 +17,8 @@ def _isolated_cache(tmp_path, monkeypatch):
     monkeypatch.setenv("SCITEX_AGENT_CACHE_DIR", str(tmp_path))
     # Reset the sidecar registry between tests so state doesn't leak.
     snap_mod._SIDECARS.clear()
+    # Stub out the agent_meta shell-out; tests that need it override.
+    monkeypatch.setattr(snap_mod, "fetch_agent_meta", lambda *a, **k: None)
     yield
     snap_mod._SIDECARS.clear()
 
@@ -183,6 +185,51 @@ def test_snapshot_env_override_cache_dir(tmp_path, monkeypatch):
     )
     snap_mod.take_snapshot("envy")
     assert (alt / "envy.latest.json").exists()
+
+
+def test_snapshot_includes_agent_meta_when_available(monkeypatch):
+    """A live ContextManager with last_meta exposes it in gather_snapshot."""
+    from scitex_agent_container import context_manager as cm_mod
+    from scitex_agent_container.config import ContextManagementConfig
+
+    sample_meta = {
+        "agent": "live1",
+        "alive": True,
+        "subagents": 2,
+        "context_pct": 57.5,
+        "current_tool": "Bash",
+        "last_activity": "2026-04-13T05:12:00.665Z",
+        "model": "claude-opus-4-6",
+        "extra_field_ignored": "yes",
+    }
+    fake = cm_mod.ContextManager(
+        agent_name="live1",
+        session_name="live1",
+        config=ContextManagementConfig(),
+        dispatcher=lambda *a, **k: None,
+        capture=lambda _s: "",
+    )
+    fake.last_meta = sample_meta
+    fake.last_percent = 57.5
+    monkeypatch.setitem(cm_mod._SENSORS, "live1", fake)
+    try:
+        snap = snap_mod.gather_snapshot("live1", session="live1")
+    finally:
+        cm_mod._SENSORS.pop("live1", None)
+
+    assert snap["agent_meta"] is not None
+    assert snap["agent_meta"]["context_pct"] == 57.5
+    assert snap["agent_meta"]["current_tool"] == "Bash"
+    assert snap["agent_meta"]["model"] == "claude-opus-4-6"
+    # Projected down to known keys (no extras)
+    assert "extra_field_ignored" not in snap["agent_meta"]
+    assert snap["context_percent"] == 57.5
+
+
+def test_snapshot_agent_meta_null_when_unavailable():
+    """No sensor + fetch_agent_meta returning None → agent_meta is None."""
+    snap = snap_mod.gather_snapshot("ghost", session="ghost")
+    assert snap["agent_meta"] is None
 
 
 def test_tmux_names_is_array(monkeypatch):

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -1,0 +1,198 @@
+"""Tests for scitex_agent_container.snapshot (todo#286)."""
+
+from __future__ import annotations
+
+import json
+import threading
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container import snapshot as snap_mod
+
+
+@pytest.fixture(autouse=True)
+def _isolated_cache(tmp_path, monkeypatch):
+    """Redirect the snapshot cache dir to tmp_path for every test."""
+    monkeypatch.setenv("SCITEX_AGENT_CACHE_DIR", str(tmp_path))
+    # Reset the sidecar registry between tests so state doesn't leak.
+    snap_mod._SIDECARS.clear()
+    yield
+    snap_mod._SIDECARS.clear()
+
+
+def _fake_snap(agent: str, **overrides):
+    base = {
+        "agent": agent,
+        "timestamp": "2026-04-13T00:00:00+00:00",
+        "host": "test-host",
+        "tmux_count": 2,
+        "tmux_names": ["a", "b"],
+        "screen_count": 0,
+        "claude_procs": 1,
+        "bun_procs": 0,
+        "node_procs": 0,
+        "load1": 0.5,
+        "mem_total": 1024,
+        "mem_used": 512,
+        "mem_free": 512,
+        "nproc_cur": 100,
+        "nproc_max": 1000,
+        "fork_pressure_pct": 10.0,
+        "context_percent": None,
+        "pids": {
+            "agent": 1,
+            "claude_code": 2,
+            "tmux": {"server": 3, "pane": 4},
+            "sidecars": {},
+        },
+    }
+    base.update(overrides)
+    return base
+
+
+def test_snapshot_writes_latest_and_prev(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        snap_mod, "gather_snapshot", lambda a, session=None: _fake_snap(a)
+    )
+    snap1 = snap_mod.take_snapshot("a1")
+    latest = tmp_path / "a1.latest.json"
+    prev = tmp_path / "a1.prev.json"
+    assert latest.exists()
+    assert not prev.exists()  # no prev on first call
+    assert snap1["has_diff"] is False
+    assert snap1["diff_fields"] == []
+
+    # Second call with a change should roll prev and produce a diff.
+    monkeypatch.setattr(
+        snap_mod,
+        "gather_snapshot",
+        lambda a, session=None: _fake_snap(a, tmux_count=3),
+    )
+    snap2 = snap_mod.take_snapshot("a1")
+    assert prev.exists()
+    assert latest.exists()
+    assert "tmux_count" in snap2["diff_fields"]
+
+
+def test_snapshot_diff_fields_detects_tmux_count_change(monkeypatch):
+    monkeypatch.setattr(
+        snap_mod, "gather_snapshot", lambda a, session=None: _fake_snap(a)
+    )
+    snap_mod.take_snapshot("a2")
+    monkeypatch.setattr(
+        snap_mod,
+        "gather_snapshot",
+        lambda a, session=None: _fake_snap(a, tmux_count=9),
+    )
+    snap2 = snap_mod.take_snapshot("a2")
+    assert snap2["has_diff"] is True
+    assert "tmux_count" in snap2["diff_fields"]
+
+
+def test_snapshot_diff_empty_on_first_run(monkeypatch):
+    monkeypatch.setattr(
+        snap_mod, "gather_snapshot", lambda a, session=None: _fake_snap(a)
+    )
+    snap1 = snap_mod.take_snapshot("first")
+    assert snap1["has_diff"] is False
+    assert snap1["diff_fields"] == []
+
+
+def test_snapshot_pids_sidecar_alive_for_process(monkeypatch):
+    snap_mod.register_sidecar("p1", kind="process", name="health_monitor", pid=4242)
+    killed: list[int] = []
+
+    def fake_kill(pid, sig):
+        killed.append(pid)
+        return None  # alive
+
+    monkeypatch.setattr(snap_mod.os, "kill", fake_kill)
+    payload = snap_mod._sidecars_payload("p1")
+    assert payload["health_monitor"]["kind"] == "process"
+    assert payload["health_monitor"]["pid"] == 4242
+    assert payload["health_monitor"]["alive"] is True
+    assert killed == [4242]
+
+    def dead_kill(pid, sig):
+        raise ProcessLookupError()
+
+    monkeypatch.setattr(snap_mod.os, "kill", dead_kill)
+    payload = snap_mod._sidecars_payload("p1")
+    assert payload["health_monitor"]["alive"] is False
+
+
+def test_snapshot_pids_sidecar_alive_for_thread():
+    ev = threading.Event()
+
+    def runner():
+        ev.wait(timeout=5)
+
+    th = threading.Thread(target=runner, daemon=True)
+    th.start()
+    snap_mod.register_sidecar("t1", kind="thread", name="context_manager", thread=th)
+    payload = snap_mod._sidecars_payload("t1")
+    assert payload["context_manager"]["kind"] == "thread"
+    assert payload["context_manager"]["alive"] is True
+    ev.set()
+    th.join(timeout=5)
+    payload = snap_mod._sidecars_payload("t1")
+    assert payload["context_manager"]["alive"] is False
+
+
+def test_status_exposes_snapshot_from_cache(tmp_path, monkeypatch):
+    from scitex_agent_container import lifecycle
+    from scitex_agent_container.config import AgentConfig
+
+    ws = tmp_path / "ws"
+    ws.mkdir()
+
+    fake_latest = _fake_snap("x1")
+    fake_latest["has_diff"] = True
+    fake_latest["diff_fields"] = ["tmux_count"]
+    (tmp_path / "x1.latest.json").write_text(json.dumps(fake_latest))
+
+    cfg = AgentConfig(name="x1", screen_name="x1", workdir=str(ws))
+
+    class _FakeRegistry:
+        def get(self, name):
+            return {
+                "config": str(ws / "fake.yaml"),
+                "screen": "x1",
+                "started_at": "2026-04-13T00:00:00Z",
+            }
+
+    class _FakeRT:
+        def is_running(self, _c):
+            return True
+
+    monkeypatch.setattr(lifecycle, "load_config", lambda _p: cfg)
+    monkeypatch.setattr(lifecycle, "_get_runtime", lambda _c: _FakeRT())
+
+    result = lifecycle.agent_status("x1", registry=_FakeRegistry())
+    assert result["snapshot"] is not None
+    assert result["snapshot"]["has_diff"] is True
+    assert result["snapshot"]["diff_fields"] == ["tmux_count"]
+
+
+def test_snapshot_env_override_cache_dir(tmp_path, monkeypatch):
+    alt = tmp_path / "alt-cache"
+    monkeypatch.setenv("SCITEX_AGENT_CACHE_DIR", str(alt))
+    monkeypatch.setattr(
+        snap_mod, "gather_snapshot", lambda a, session=None: _fake_snap(a)
+    )
+    snap_mod.take_snapshot("envy")
+    assert (alt / "envy.latest.json").exists()
+
+
+def test_tmux_names_is_array(monkeypatch):
+    # Regression guard: tmux_names must remain a JSON array, not joined.
+    monkeypatch.setattr(
+        snap_mod, "gather_snapshot", lambda a, session=None: _fake_snap(a)
+    )
+    snap = snap_mod.take_snapshot("arrayguard")
+    assert isinstance(snap["tmux_names"], list)
+    # Ensure serialization round-trips as a list.
+    latest = Path(snap_mod._latest_path("arrayguard"))
+    data = json.loads(latest.read_text())
+    assert isinstance(data["tmux_names"], list)

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -35,15 +35,15 @@ def _fake_snap(agent: str, **overrides):
         "bun_procs": 0,
         "node_procs": 0,
         "load1": 0.5,
-        "mem_total": 1024,
-        "mem_used": 512,
-        "mem_free": 512,
+        "mem_total_bytes": 1024,
+        "mem_used_bytes": 512,
+        "mem_free_bytes": 512,
         "nproc_cur": 100,
         "nproc_max": 1000,
         "fork_pressure_pct": 10.0,
         "context_percent": None,
         "pids": {
-            "agent": 1,
+            "container_daemon": 1,
             "claude_code": 2,
             "tmux": {"server": 3, "pane": 4},
             "sidecars": {},
@@ -307,6 +307,91 @@ def test_claude_pid_none_when_no_match(monkeypatch):
         lambda *a, **k: _FakeCompleted(stdout="", returncode=1),
     )
     assert snap_mod._probe_claude_pid() is None
+
+
+def test_take_snapshot_concurrent_write_is_serialized(tmp_path, monkeypatch):
+    """10 threads racing on the same agent must leave a consistent state."""
+    monkeypatch.setattr(
+        snap_mod, "gather_snapshot", lambda a, session=None: _fake_snap(a, tmux_count=1)
+    )
+
+    # First seed so prev will be written too.
+    snap_mod.take_snapshot("concur")
+
+    # Now race: each thread bumps tmux_count to a unique value so diffs fire.
+    N = 10
+    barrier = threading.Barrier(N)
+    errors: list[BaseException] = []
+
+    def worker(i: int) -> None:
+        try:
+            monkey_snap = _fake_snap("concur", tmux_count=100 + i)
+            # Local override of gather — but we must be careful: monkeypatch
+            # is not thread-safe. Instead, patch once with an id-varying fn.
+            barrier.wait()
+            snap_mod.take_snapshot("concur")
+        except BaseException as e:  # pragma: no cover
+            errors.append(e)
+
+    # Use a single thread-safe gather that cycles values via a counter.
+    counter = {"n": 100}
+    counter_lock = threading.Lock()
+
+    def racy_gather(a, session=None):
+        with counter_lock:
+            counter["n"] += 1
+            val = counter["n"]
+        return _fake_snap(a, tmux_count=val)
+
+    monkeypatch.setattr(snap_mod, "gather_snapshot", racy_gather)
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(N)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=10)
+    assert not errors, f"worker exceptions: {errors}"
+
+    latest = tmp_path / "concur.latest.json"
+    prev = tmp_path / "concur.prev.json"
+    lock = tmp_path / "concur.lock"
+
+    assert latest.exists()
+    assert prev.exists()
+    # Both files must parse as valid JSON (no torn writes).
+    json.loads(latest.read_text())
+    json.loads(prev.read_text())
+
+    # No .tmp stragglers left behind.
+    stragglers = [p.name for p in tmp_path.iterdir() if p.name.endswith(".tmp")]
+    assert stragglers == [], f"unexpected tmp files: {stragglers}"
+
+    # Expected file set only.
+    names = sorted(p.name for p in tmp_path.iterdir())
+    # diff.json may or may not be present depending on timing, but all names
+    # must belong to the expected set.
+    allowed = {
+        "concur.latest.json",
+        "concur.prev.json",
+        "concur.lock",
+        "concur.diff.json",
+    }
+    assert set(names).issubset(allowed), f"unexpected files: {set(names) - allowed}"
+    assert lock.exists()
+
+
+def test_take_snapshot_lock_file_is_reusable(tmp_path, monkeypatch):
+    """Advisory lock is released on fd close; subsequent calls succeed."""
+    monkeypatch.setattr(
+        snap_mod, "gather_snapshot", lambda a, session=None: _fake_snap(a)
+    )
+    snap_mod.take_snapshot("reuse")
+    lock = tmp_path / "reuse.lock"
+    assert lock.exists()
+    # A second call must not hang and must succeed (lock was released).
+    snap_mod.take_snapshot("reuse")
+    assert (tmp_path / "reuse.latest.json").exists()
+    assert (tmp_path / "reuse.prev.json").exists()
 
 
 def test_tmux_names_is_array(monkeypatch):

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -232,6 +232,83 @@ def test_snapshot_agent_meta_null_when_unavailable():
     assert snap["agent_meta"] is None
 
 
+class _FakeCompleted:
+    def __init__(self, stdout="", stderr="", returncode=0):
+        self.stdout = stdout
+        self.stderr = stderr
+        self.returncode = returncode
+
+
+def test_screen_count_zero_when_installed_no_sessions(monkeypatch):
+    """screen installed + no live sockets → 0 (not None)."""
+    monkeypatch.setattr(
+        snap_mod.shutil, "which", lambda name: "/usr/bin/screen" if name == "screen" else None
+    )
+
+    def fake_run(cmd, *a, **kw):
+        assert cmd[0] == "screen"
+        return _FakeCompleted(
+            stdout="No Sockets found in /var/run/screen/S-user.\n",
+            stderr="",
+            returncode=1,
+        )
+
+    monkeypatch.setattr(snap_mod.subprocess, "run", fake_run)
+    result = snap_mod._probe_screen_count()
+    assert result == 0
+    assert result is not None
+
+
+def test_screen_count_none_when_not_installed(monkeypatch):
+    monkeypatch.setattr(snap_mod.shutil, "which", lambda name: None)
+    assert snap_mod._probe_screen_count() is None
+
+
+def test_screen_count_positive_when_sessions_listed(monkeypatch):
+    monkeypatch.setattr(
+        snap_mod.shutil, "which", lambda name: "/usr/bin/screen"
+    )
+    listing = (
+        "There are screens on:\n"
+        "\t12345.head-mba\t(Detached)\n"
+        "\t12346.worker-1\t(Attached)\n"
+        "2 Sockets in /var/run/screen/S-user.\n"
+    )
+    monkeypatch.setattr(
+        snap_mod.subprocess,
+        "run",
+        lambda *a, **k: _FakeCompleted(stdout=listing, returncode=0),
+    )
+    assert snap_mod._probe_screen_count() == 2
+
+
+def test_claude_pid_does_not_match_container_python(monkeypatch):
+    """pgrep -x claude must not match the container python wrapper."""
+    captured = {}
+
+    def fake_run(cmd, *a, **kw):
+        captured["cmd"] = cmd
+        # pgrep -x claude only returns PIDs whose comm == "claude",
+        # so the python container wrapper (comm == "python3") is excluded.
+        assert cmd == ["pgrep", "-n", "-x", "claude"]
+        return _FakeCompleted(stdout="12345\n", returncode=0)
+
+    monkeypatch.setattr(snap_mod.subprocess, "run", fake_run)
+    assert snap_mod._probe_claude_pid() == 12345
+    # Sanity: the query we issued is command-name exact (-x), not full -f.
+    assert "-x" in captured["cmd"]
+    assert "-f" not in captured["cmd"]
+
+
+def test_claude_pid_none_when_no_match(monkeypatch):
+    monkeypatch.setattr(
+        snap_mod.subprocess,
+        "run",
+        lambda *a, **k: _FakeCompleted(stdout="", returncode=1),
+    )
+    assert snap_mod._probe_claude_pid() is None
+
+
 def test_tmux_names_is_array(monkeypatch):
     # Regression guard: tmux_names must remain a JSON array, not joined.
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
Phase 3 + 2b of the fleet context-lifecycle series (todo#286 + todo#285 sensor pivot). Stacks on `feat/context-manager`.

### Phase 3 — self-snapshot
- New CLI: `scitex-agent-container snapshot --json [--diff] --agent <name>`
- Cache dir `~/.scitex/agent-container/cache/<agent>.{latest,prev}.json` (atomic rolls)
- `SCITEX_AGENT_CACHE_DIR` env override for tests and alt layouts
- 3-layer PID model:
  - `pids.claude_code`, `pids.tmux.{server, pane}`
  - `pids.sidecars.<name>: {pid, kind in [process|thread], alive}` — container-local sidecars only; orochi comms sidecars live in scitex-orochi (out of scope)
- `diff_fields: []` computed against prev (dotted-key flat list; lists compared whole-value; `timestamp` excluded)
- Fields retained for probe_remote.sh compatibility: `tmux_count`, `tmux_names[]` (JSON array, never joined), `screen_count`, `claude_procs`, `bun_procs`, `node_procs`, `load1`, `mem_*`, `nproc_{cur,max}`, `fork_pressure_pct`
- Cross-OS: Darwin + Linux branches; missing fields emit `null`, never crash
- Daemon: piggybacks on `ContextManager.run_forever` (single thread, same `check_interval_seconds`)
- `status --json` gains `snapshot.{timestamp, has_diff, diff_fields}` (cache-read only; cheap)

### Phase 2b — sensor source pivot
After merging Phase 2, head-nas found that `~/.scitex/orochi/scripts/agent_meta.py` already reads the live Claude Code session jsonl transcript and emits `context_pct` (+ `current_tool`, `last_activity`, `model`, `subagents`). tmux-pane scraping is fragile (NAS statusline shows only the bypass-permissions hint).

- New `fetch_agent_meta(agent)` subprocess wrapper with `SCITEX_AGENT_META_SCRIPT` env override
- Returns `None` on any failure (FileNotFound / CalledProcessError / Timeout / JSONDecodeError / OSError) — container stays orochi-agnostic
- `ContextManager.tick()` uses `agent_meta.context_pct` when available, falls back to tmux pane parse
- `ContextManager.last_meta` stores the full dict for downstream consumers
- `snapshot` + `status --json` expose an `agent_meta` block (`alive`, `subagents`, `context_pct`, `current_tool`, `last_activity`, `model`)

## Test plan
- [x] 8 new snapshot tests (writes/roll/diff/pids alive/env override/tmux_names array/status)
- [x] 11 new agent_meta tests (success/missing/bad json/timeout/env override/tick path/fallback path/snapshot projection/null)
- [x] Full suite: 160 pass / 0 fail (142 baseline + 18)
- [ ] Smoke: run `snapshot --json --diff` for a live fleet agent, compare against NAS fleet_watch.sh consumer
