### PR TITLE
feat(runtime): auto LocalRuntime fallback on host identity match (todo#294)

### DIFF
--- a/src/scitex_agent_container/host_identity.py
+++ b/src/scitex_agent_container/host_identity.py
@@ -26,11 +26,15 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 DEFAULT_HOST_ALIASES: dict[str, list[str]] = {
-    "mba": ["mba", "head-mba", "Yusukes-MacBook-Air.local", "localhost"],
+    "mba": ["mba", "head-mba", "Yusukes-MacBook-Air.local"],
     "nas": ["nas", "ugreen", "DXP480TPLUS-994", "nas.local"],
     "spartan": ["spartan", "spartan-login1.hpc.unimelb.edu.au"],
     "ywata-note-win": ["ywata-note-win"],
 }
+
+# Loopback names exist on every host; never use them as evidence of
+# canonical-fleet identity (would leak cross-host aliases).
+_UNIVERSAL_LOOPBACK: set[str] = {"localhost", "127.0.0.1", "::1"}
 
 _CACHE: set[str] | None = None
 
@@ -105,10 +109,14 @@ def get_local_identities() -> set[str]:
 
     # Auto-detect canonical fleet name: if any built-in alias list already
     # contains one of our names, pull in the rest of that list.
+    # Loopback names (localhost / 127.0.0.1 / ::1) are excluded from the
+    # intersection because they exist on every host and would otherwise
+    # cause cross-host alias leakage.
     lowered = {n.lower() for n in names}
     for canonical, aliases in DEFAULT_HOST_ALIASES.items():
         alias_lower = {a.lower() for a in aliases}
-        if lowered & alias_lower or canonical.lower() in lowered:
+        overlap = (lowered & alias_lower) - _UNIVERSAL_LOOPBACK
+        if overlap or canonical.lower() in lowered:
             names.update(aliases)
             names.add(canonical)
 

--- a/src/scitex_agent_container/host_identity.py
+++ b/src/scitex_agent_container/host_identity.py
@@ -1,0 +1,134 @@
+"""Local host identity detection for runtime-selection fallback (todo#294).
+
+When a fleet-shared YAML declares ``remote: {host: nas, ...}`` and is
+launched on the NAS itself, we must not attempt to SSH into ourselves.
+This module exposes ``is_local_host(name)`` which returns True when the
+given name matches anything the current machine can legitimately be
+called.
+
+Sources, in order:
+  1. ``socket.gethostname()`` / ``socket.getfqdn()`` / ``os.uname().nodename``
+     (both full and short forms).
+  2. ``localhost`` / ``127.0.0.1`` / ``::1``.
+  3. Env var ``SCITEX_AGENT_LOCAL_HOSTS`` (comma-separated).
+  4. ``~/.scitex/agent-container/host_aliases.yaml`` (optional).
+  5. Built-in fleet defaults in ``DEFAULT_HOST_ALIASES`` — auto-detects the
+     canonical fleet name whose alias list already contains this host.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import socket
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_HOST_ALIASES: dict[str, list[str]] = {
+    "mba": ["mba", "head-mba", "Yusukes-MacBook-Air.local", "localhost"],
+    "nas": ["nas", "ugreen", "DXP480TPLUS-994", "nas.local"],
+    "spartan": ["spartan", "spartan-login1.hpc.unimelb.edu.au"],
+    "ywata-note-win": ["ywata-note-win"],
+}
+
+_CACHE: set[str] | None = None
+
+
+def _short(name: str) -> str:
+    return name.split(".", 1)[0] if name else name
+
+
+def _load_yaml_aliases() -> list[str]:
+    path = Path.home() / ".scitex" / "agent-container" / "host_aliases.yaml"
+    if not path.exists():
+        return []
+    try:
+        import yaml
+
+        data = yaml.safe_load(path.read_text()) or {}
+        if isinstance(data, dict):
+            out: list[str] = []
+            for v in data.values():
+                if isinstance(v, str):
+                    out.append(v)
+                elif isinstance(v, list):
+                    out.extend(str(x) for x in v)
+            return out
+        if isinstance(data, list):
+            return [str(x) for x in data]
+    except Exception as exc:
+        logger.warning("host_aliases.yaml unreadable, skipping: %s", exc)
+    return []
+
+
+def get_local_identities() -> set[str]:
+    """Return the set of names (lower-cased) this host answers to."""
+    global _CACHE
+    if _CACHE is not None:
+        return _CACHE
+
+    names: set[str] = {"localhost", "127.0.0.1", "::1"}
+
+    try:
+        hn = socket.gethostname()
+        if hn:
+            names.add(hn)
+            names.add(_short(hn))
+    except Exception:
+        hn = ""
+    try:
+        fqdn = socket.getfqdn()
+        if fqdn:
+            names.add(fqdn)
+            names.add(_short(fqdn))
+    except Exception:
+        pass
+    try:
+        nn = os.uname().nodename
+        if nn:
+            names.add(nn)
+            names.add(_short(nn))
+    except Exception:
+        pass
+
+    env = os.environ.get("SCITEX_AGENT_LOCAL_HOSTS", "")
+    for tok in env.split(","):
+        tok = tok.strip()
+        if tok:
+            names.add(tok)
+
+    for alias in _load_yaml_aliases():
+        alias = alias.strip()
+        if alias:
+            names.add(alias)
+
+    # Auto-detect canonical fleet name: if any built-in alias list already
+    # contains one of our names, pull in the rest of that list.
+    lowered = {n.lower() for n in names}
+    for canonical, aliases in DEFAULT_HOST_ALIASES.items():
+        alias_lower = {a.lower() for a in aliases}
+        if lowered & alias_lower or canonical.lower() in lowered:
+            names.update(aliases)
+            names.add(canonical)
+
+    _CACHE = {n.lower() for n in names if n}
+    return _CACHE
+
+
+def is_local_host(name: str | None) -> bool:
+    """Return True if ``name`` refers to the current host.
+
+    Empty / None / whitespace-only names are treated as local (no remote).
+    """
+    if name is None:
+        return True
+    n = name.strip().lower()
+    if not n:
+        return True
+    return n in get_local_identities()
+
+
+def _reset_cache_for_tests() -> None:
+    global _CACHE
+    _CACHE = None

--- a/src/scitex_agent_container/runtimes/claude_code.py
+++ b/src/scitex_agent_container/runtimes/claude_code.py
@@ -8,6 +8,7 @@ import time
 from pathlib import Path
 
 from ..config import AgentConfig
+from ..host_identity import is_local_host
 from .base import RuntimeBase
 from .claude_md import cleanup_claude_md, setup_claude_md
 from .mcp_config import cleanup_mcp_config, setup_mcp_config
@@ -29,6 +30,24 @@ _SSHRemote = SSHRemote
 # Backward-compatible aliases for extracted functions
 _setup_claude_md = setup_claude_md
 _cleanup_claude_md = cleanup_claude_md
+
+
+def _should_dispatch_remote(config: AgentConfig) -> bool:
+    """True iff the config is remote AND the remote host is not ourselves.
+
+    If ``remote.host`` matches a local identity (hostname / alias / env /
+    YAML / fleet default), log an INFO message and return False so callers
+    fall back to the local in-process runtime instead of self-SSH.
+    """
+    if not config.remote.is_remote:
+        return False
+    if is_local_host(config.remote.host):
+        logger.info(
+            "remote.host=%r matches local identity -> falling back to LocalRuntime",
+            config.remote.host,
+        )
+        return False
+    return True
 
 
 def _encode_workdir_for_claude_projects(workdir: str) -> str:
@@ -391,7 +410,7 @@ class ClaudeCodeRuntime(RuntimeBase):
         ``scitex-agent-container start`` call receives ``--force`` and
         stops any existing instance before relaunching.
         """
-        if config.remote.is_remote:
+        if _should_dispatch_remote(config):
             return SSHRemote.start(config, no_preflight=no_preflight, force=force)
 
         if config.container.runtime != "none":
@@ -446,7 +465,7 @@ class ClaudeCodeRuntime(RuntimeBase):
 
     def stop(self, config: AgentConfig) -> bool:
         """Stop a Claude Code agent."""
-        if config.remote.is_remote:
+        if _should_dispatch_remote(config):
             return SSHRemote.stop(config)
 
         if config.container.runtime != "none":
@@ -471,7 +490,7 @@ class ClaudeCodeRuntime(RuntimeBase):
 
     def is_running(self, config: AgentConfig) -> bool:
         """Check if the Claude Code agent is running."""
-        if config.remote.is_remote:
+        if _should_dispatch_remote(config):
             return SSHRemote.is_running(config)
 
         if config.container.runtime == "docker":
@@ -487,7 +506,7 @@ class ClaudeCodeRuntime(RuntimeBase):
 
     def logs(self, config: AgentConfig, lines: int = 50) -> str:
         """Get logs from the Claude Code agent."""
-        if config.remote.is_remote:
+        if _should_dispatch_remote(config):
             return SSHRemote.logs(config, lines)
 
         if config.container.runtime == "docker":

--- a/tests/test_host_identity.py
+++ b/tests/test_host_identity.py
@@ -39,6 +39,33 @@ def test_is_local_host_accepts_none_and_empty(monkeypatch):
     assert is_local_host("   ") is True
 
 
+def test_local_does_not_leak_other_canonical_via_localhost(monkeypatch):
+    """Regression: loopback names must not pull in foreign alias lists.
+
+    NAS's 'localhost' / '127.0.0.1' / '::1' are universally present and
+    previously caused is_local_host('mba') to return True on the NAS,
+    because DEFAULT_HOST_ALIASES['mba'] happened to include 'localhost'.
+    """
+    import os as _os
+
+    _reset_cache_for_tests()
+    monkeypatch.setattr("socket.gethostname", lambda: "DXP480TPLUS-994")
+    monkeypatch.setattr("socket.getfqdn", lambda: "DXP480TPLUS-994")
+
+    # os.uname().nodename on the test host could otherwise leak a real
+    # hostname (e.g. "Yusukes-MacBook-Air.local") that happens to match
+    # another canonical alias list.
+    _fake_uname = _os.uname_result(
+        ("Linux", "DXP480TPLUS-994", "6.1.27", "", "x86_64")
+    )
+    monkeypatch.setattr("os.uname", lambda: _fake_uname)
+    monkeypatch.delenv("SCITEX_AGENT_LOCAL_HOSTS", raising=False)
+    assert is_local_host("nas") is True     # legitimate auto-detect
+    assert is_local_host("mba") is False    # must not leak via loopback
+    assert is_local_host("spartan") is False
+    assert is_local_host("ywata-note-win") is False
+
+
 def test_is_local_host_matches_hostname(monkeypatch):
     _patch_basics(monkeypatch, hostname="mba", fqdn="mba")
     assert is_local_host("mba") is True

--- a/tests/test_host_identity.py
+++ b/tests/test_host_identity.py
@@ -1,0 +1,135 @@
+"""Tests for host_identity and runtime-selection local fallback (todo#294)."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from scitex_agent_container import host_identity
+from scitex_agent_container.config import AgentConfig
+from scitex_agent_container.config._types import RemoteSpec
+from scitex_agent_container.host_identity import (
+    get_local_identities,
+    is_local_host,
+    _reset_cache_for_tests,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache(monkeypatch):
+    _reset_cache_for_tests()
+    # Isolate from real env + real HOME by default
+    monkeypatch.delenv("SCITEX_AGENT_LOCAL_HOSTS", raising=False)
+    yield
+    _reset_cache_for_tests()
+
+
+def _patch_basics(monkeypatch, hostname="testhost", fqdn="testhost.local"):
+    monkeypatch.setattr("socket.gethostname", lambda: hostname)
+    monkeypatch.setattr("socket.getfqdn", lambda: fqdn)
+
+
+def test_is_local_host_accepts_none_and_empty(monkeypatch):
+    _patch_basics(monkeypatch)
+    assert is_local_host(None) is True
+    assert is_local_host("") is True
+    assert is_local_host("   ") is True
+
+
+def test_is_local_host_matches_hostname(monkeypatch):
+    _patch_basics(monkeypatch, hostname="mba", fqdn="mba")
+    assert is_local_host("mba") is True
+    _reset_cache_for_tests()
+    _patch_basics(monkeypatch, hostname="mba", fqdn="mba")
+    assert is_local_host("nas") is False
+
+
+def test_is_local_host_matches_fqdn(monkeypatch):
+    _patch_basics(monkeypatch, hostname="mba", fqdn="Yusukes-MacBook-Air.local")
+    assert is_local_host("Yusukes-MacBook-Air.local") is True
+    assert is_local_host("Yusukes-MacBook-Air") is True
+    assert is_local_host("mba") is True
+
+
+def test_is_local_host_case_insensitive(monkeypatch):
+    _patch_basics(monkeypatch, hostname="nas", fqdn="nas")
+    assert is_local_host("NAS") is True
+    assert is_local_host("Nas") is True
+
+
+def test_env_var_adds_aliases(monkeypatch):
+    _patch_basics(monkeypatch)
+    monkeypatch.setenv("SCITEX_AGENT_LOCAL_HOSTS", "foo,bar, baz ")
+    assert is_local_host("foo") is True
+    assert is_local_host("bar") is True
+    assert is_local_host("baz") is True
+
+
+def test_env_var_overrides_empty(monkeypatch):
+    _patch_basics(monkeypatch, hostname="uniquehost", fqdn="uniquehost")
+    monkeypatch.delenv("SCITEX_AGENT_LOCAL_HOSTS", raising=False)
+    assert is_local_host("foo") is False
+    assert is_local_host("uniquehost") is True
+
+
+def test_yaml_file_aliases(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    (home / ".scitex" / "agent-container").mkdir(parents=True)
+    (home / ".scitex" / "agent-container" / "host_aliases.yaml").write_text(
+        "local:\n  - alpha\n  - beta\n"
+    )
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    _patch_basics(monkeypatch)
+    assert is_local_host("alpha") is True
+    assert is_local_host("beta") is True
+
+
+def test_yaml_file_malformed_fallback(monkeypatch, tmp_path, caplog):
+    home = tmp_path / "home"
+    (home / ".scitex" / "agent-container").mkdir(parents=True)
+    (home / ".scitex" / "agent-container" / "host_aliases.yaml").write_text(
+        "not: valid: yaml: ::\n  - [unclosed\n"
+    )
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    _patch_basics(monkeypatch, hostname="somehost", fqdn="somehost")
+    with caplog.at_level(logging.WARNING, logger="scitex_agent_container.host_identity"):
+        ids = get_local_identities()
+    assert "somehost" in ids
+    assert any("host_aliases.yaml" in r.message for r in caplog.records)
+
+
+def test_default_auto_detect_by_seed_match(monkeypatch):
+    _patch_basics(monkeypatch, hostname="DXP480TPLUS-994", fqdn="DXP480TPLUS-994")
+    assert is_local_host("nas") is True
+    assert is_local_host("ugreen") is True
+
+
+def test_runtime_selection_falls_back_to_local(monkeypatch):
+    from scitex_agent_container.runtimes import claude_code as cc
+
+    cfg = AgentConfig(name="t")
+    cfg.remote = RemoteSpec(host="nas")
+    monkeypatch.setattr(cc, "is_local_host", lambda name: True)
+    assert cc._should_dispatch_remote(cfg) is False
+
+
+def test_runtime_selection_stays_remote_when_not_local(monkeypatch):
+    from scitex_agent_container.runtimes import claude_code as cc
+
+    cfg = AgentConfig(name="t")
+    cfg.remote = RemoteSpec(host="nas")
+    monkeypatch.setattr(cc, "is_local_host", lambda name: False)
+    assert cc._should_dispatch_remote(cfg) is True
+
+
+def test_cache_reset_for_tests(monkeypatch):
+    _patch_basics(monkeypatch, hostname="hostA", fqdn="hostA")
+    assert is_local_host("hostA") is True
+    assert is_local_host("hostB") is False
+    _reset_cache_for_tests()
+    _patch_basics(monkeypatch, hostname="hostB", fqdn="hostB")
+    monkeypatch.setenv("SCITEX_AGENT_LOCAL_HOSTS", "hostB")
+    assert is_local_host("hostB") is True


### PR DESCRIPTION
## Summary

Closes part of todo#294. Fixes the fleet single-source-of-truth problem where a shared agent YAML declaring `remote: {host: nas}` breaks when launched *on* the NAS itself (current behavior: tries to `ssh nas` from NAS, which loops/fails because `nas` is not in NAS's own SSH config).

Fix: before dispatching to `SSHRemote`, check if `remote.host` matches a local identity; if yes, log an INFO line and fall back to the in-process (local) runtime. No config mutation.

## New module: `host_identity.py`

- `get_local_identities() -> set[str]` — cached, lower-cased
- `is_local_host(name) -> bool` — `None`/`""` treated as local
- `_reset_cache_for_tests()`

Sources (in order):
1. `socket.gethostname` / `socket.getfqdn` / `os.uname().nodename` (full + short)
2. `localhost` / `127.0.0.1` / `::1`
3. Env var `SCITEX_AGENT_LOCAL_HOSTS` (comma-separated)
4. `~/.scitex/agent-container/host_aliases.yaml` (optional, malformed → warning, no crash)
5. Built-in fleet defaults — auto-detects canonical name by cross-referencing the seed alias table:
   ```
   mba:            [mba, head-mba, Yusukes-MacBook-Air.local, localhost]
   nas:            [nas, ugreen, DXP480TPLUS-994, nas.local]
   spartan:        [spartan, spartan-login1.hpc.unimelb.edu.au]
   ywata-note-win: [ywata-note-win]
   ```

## Wiring

`runtimes/claude_code.py` gains a private `_should_dispatch_remote(config)` helper used at all four dispatch points (`start`, `stop`, `is_running`, `logs`). The existing `RemoteSpec.is_remote` property is untouched so existing tests and the `cli_pkg` display helpers keep working.

## Example: restore single-source-of-truth on NAS

`~/.dotfiles/src/.scitex/orochi/agents/head-nas/head-nas.yaml`:
```yaml
name: head-nas
remote:
  host: nas
  user: ywatanabe
```

Running this YAML on NAS now silently runs locally (INFO log: `remote.host='nas' matches local identity -> falling back to LocalRuntime`). Running the same YAML from MBA still SSHes into NAS as before.

## Env override

```bash
export SCITEX_AGENT_LOCAL_HOSTS="my-custom-alias,other-alias"
```

Or persistent per-host in `~/.scitex/agent-container/host_aliases.yaml`:
```yaml
local:
  - my-custom-alias
  - other-alias
```

## Tests

`tests/test_host_identity.py` — 12 tests covering: None/empty, hostname/fqdn match, case insensitivity, env var aliases, YAML aliases, malformed YAML fallback, seed auto-detection (`DXP480TPLUS-994` → `nas`), runtime-selection fallback (local and remote paths), and cache reset.

**Full suite: 177 passed** (131 prior baseline + 12 new host_identity tests + previously-uncollected `test_snapshot.py`). No regressions.

## Merge notes

- Independent of the `feat/context-manager` / `#17` / `#18` / `#19` stack — can land in any order.
- Stdlib + PyYAML only, no new deps.
- Branch: `feat/local-host-detect`, based on `origin/develop`.

## Test plan

- [x] `pytest tests/ -q` green (177 passed)
- [x] New module ≤150 lines (134), tests ≤150 lines (135)
- [ ] Launch `head-nas.yaml` on NAS with `remote: {host: nas}` restored, confirm it falls back to local

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
