### PR TITLE
fix(snapshot): Darwin mem probe must include inactive + speculative pages (todo#310)

### DIFF
--- a/src/scitex_agent_container/snapshot.py
+++ b/src/scitex_agent_container/snapshot.py
@@ -285,7 +285,16 @@ def _probe_mem_darwin() -> tuple[int | None, int | None, int | None]:
         m = re.match(r"(.+?):\s+(\d+)", ln)
         if m:
             pages[m.group(1).strip()] = int(m.group(2))
-    free_pages = pages.get("Pages free", 0) + pages.get("Pages speculative", 0)
+    # Darwin gotcha: "Pages free" alone is always tiny (~100MB) because
+    # macOS aggressively uses inactive + speculative pages as cache and
+    # reclaims them on demand. Counting only "free" produces false-positive
+    # mem-CRITICAL alerts (msg#8603 / todo#310). The true "available"
+    # memory is Pages free + Pages inactive + Pages speculative.
+    free_pages = (
+        pages.get("Pages free", 0)
+        + pages.get("Pages inactive", 0)
+        + pages.get("Pages speculative", 0)
+    )
     free_bytes = free_pages * page_size
     used_bytes = (total - free_bytes) if total is not None else None
     return total, used_bytes, free_bytes

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -282,6 +282,53 @@ def test_screen_count_positive_when_sessions_listed(monkeypatch):
     assert snap_mod._probe_screen_count() == 2
 
 
+def test_probe_mem_darwin_counts_inactive_and_speculative(monkeypatch):
+    """Darwin mem must count free + inactive + speculative as available.
+
+    Regression for msg#8603 / todo#310: the previous implementation only
+    summed free + speculative, which fired false-positive mem-CRITICAL
+    alerts on MBA where ~6GB lived in inactive+speculative cache while
+    free was a typical ~100MB.
+    """
+    monkeypatch.setattr(snap_mod.platform, "system", lambda: "Darwin")
+
+    page_size = 4096
+    # 16 GB total, only 25600 pages (100 MB) "free", 1.5M pages (6 GB)
+    # inactive, 50k pages (200 MB) speculative — typical macOS at idle.
+    free_pgs = 25_600
+    inactive_pgs = 1_572_864
+    speculative_pgs = 51_200
+    total_bytes = 16 * 1024 ** 3
+    expected_free_bytes = (free_pgs + inactive_pgs + speculative_pgs) * page_size
+
+    vm_stat_output = (
+        "Mach Virtual Memory Statistics: (page size of 4096 bytes)\n"
+        f"Pages free:                              {free_pgs}.\n"
+        f"Pages active:                            500000.\n"
+        f"Pages inactive:                          {inactive_pgs}.\n"
+        f"Pages speculative:                       {speculative_pgs}.\n"
+        f"Pages wired down:                        200000.\n"
+    )
+
+    def fake_run(cmd, *a, **kw):
+        if cmd[:2] == ["/usr/sbin/sysctl", "-n"] and cmd[2] == "hw.memsize":
+            return _FakeCompleted(stdout=f"{total_bytes}\n", returncode=0)
+        if cmd[0] == "vm_stat":
+            return _FakeCompleted(stdout=vm_stat_output, returncode=0)
+        return _FakeCompleted(stdout="", returncode=0)
+
+    monkeypatch.setattr(snap_mod.subprocess, "run", fake_run)
+
+    total, used, free = snap_mod._probe_mem_darwin()
+    assert total == total_bytes
+    assert free == expected_free_bytes
+    # Used must reflect the realistic (~9.7 GB) figure, not the broken
+    # ~15.9 GB that the old "free + speculative only" math produced.
+    assert used == total_bytes - expected_free_bytes
+    # Sanity: free should be measured in GBs, not MBs.
+    assert free > 1024 ** 3, f"free={free} suggests inactive pages were dropped"
+
+
 def test_claude_pid_does_not_match_container_python(monkeypatch):
     """pgrep -x claude must not match the container python wrapper."""
     captured = {}


### PR DESCRIPTION
## Summary

Third probe false positive of the session was a mem-CRITICAL alert on MBA. Root cause: `_probe_mem_darwin` was only summing `Pages free + Pages speculative` and treating that as "available". On macOS the kernel parks reclaimable cache in `Pages inactive`, so the "free" figure is always tiny (~100 MB) even when there's many GB of reclaimable memory. The math then claimed MBA was at ~99% memory used.

Fix: add `Pages inactive` to the sum. This matches the formula `memory_pressure` uses internally (`free + inactive + speculative`).

## Test plan

- [x] New test `test_probe_mem_darwin_counts_inactive_and_speculative` feeds a realistic vm_stat (16 GB total, 100 MB free, 6 GB inactive, 200 MB speculative) and asserts `free > 1 GB` — catches the regression class.
- [x] Full `pytest tests/test_snapshot.py` → 18/18 pass (was 17/17, +1 new test).
- [x] Linux branch unchanged (`MemAvailable` already accounts for reclaimables).

## Context

Pattern note: this is the third Darwin-vs-Linux semantics false positive this session:
1. `tmux ls` socket env mismatch (msg#8308) — fixed in healer probe with `bash -lc`
2. `nas` SSH alias routing to stale LAN IP (msg#8377) — fixed in WSL ssh config
3. **(this PR)** mem metric assuming Linux semantics on Darwin

mamba-skill-manager landed a `connectivity-probe.md` "Cross-OS semantics — Darwin is not Linux" section to make the pattern visible. This PR closes the implementation half for the mem case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)