### PR TITLE
feat(config): search dotfiles agent dir for short-name YAML lookup (todo#295)

### DIFF
--- a/src/scitex_agent_container/config/_resolve.py
+++ b/src/scitex_agent_container/config/_resolve.py
@@ -2,27 +2,75 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
+from typing import List, Tuple
+
+
+_ENV_VAR = "SCITEX_AGENT_CONTAINER_YAML_DIRS"
+
+
+def _search_dirs() -> Tuple[Path, List[Path], Path]:
+    """Return (legacy_dir, env_dirs, dotfiles_dir) with ~ expansion."""
+    home = Path(os.path.expanduser("~"))
+    legacy = home / ".scitex" / "agent-container" / "agents"
+    env_raw = os.environ.get(_ENV_VAR, "")
+    env_dirs = [
+        Path(os.path.expanduser(p)) for p in env_raw.split(":") if p.strip()
+    ]
+    dotfiles = home / ".dotfiles" / "src" / ".scitex" / "orochi" / "agents"
+    return legacy, env_dirs, dotfiles
+
+
+def _try_dir(base: Path, name: str) -> str | None:
+    """Try <base>/<name>.yaml|yml and <base>/<name>/<name>.yaml|yml."""
+    for ext in (".yaml", ".yml"):
+        cand = base / f"{name}{ext}"
+        if cand.exists():
+            return str(cand)
+        cand = base / name / f"{name}{ext}"
+        if cand.exists():
+            return str(cand)
+    return None
 
 
 def resolve_config(name_or_path: str) -> str:
-    """Resolve agent name or path to a config file path."""
+    """Resolve agent name or path to a config file path.
+
+    Search order for short names (no slash, no .yaml/.yml suffix):
+      1. ~/.scitex/agent-container/agents/<name>.yaml  (operator override)
+      2. $SCITEX_AGENT_CONTAINER_YAML_DIRS (colon-separated extra dirs)
+      3. ~/.dotfiles/src/.scitex/orochi/agents/<name>/<name>.yaml (fleet fallback)
+
+    Absolute paths and explicit .yaml/.yml paths are returned as-is if they
+    exist (unchanged behavior).
+    """
     p = Path(name_or_path)
     if "/" in name_or_path or name_or_path.endswith((".yaml", ".yml")):
         if p.exists():
             return str(p)
         raise FileNotFoundError(f"Config file not found: {name_or_path}")
-    user_dir = Path.home() / ".scitex" / "agent-container" / "agents"
-    for ext in (".yaml", ".yml"):
-        candidate = user_dir / f"{name_or_path}{ext}"
-        if candidate.exists():
-            return str(candidate)
-        # Subdirectory convention: agents/<name>/<name>.yaml
-        candidate = user_dir / name_or_path / f"{name_or_path}{ext}"
-        if candidate.exists():
-            return str(candidate)
+
+    legacy, env_dirs, dotfiles = _search_dirs()
+
+    hit = _try_dir(legacy, name_or_path)
+    if hit:
+        return hit
+    for d in env_dirs:
+        hit = _try_dir(d, name_or_path)
+        if hit:
+            return hit
+    hit = _try_dir(dotfiles, name_or_path)
+    if hit:
+        return hit
+
+    env_line = (
+        f"  (env ${_ENV_VAR}: "
+        f"{', '.join(str(d) for d in env_dirs) if env_dirs else '<unset>'})"
+    )
     raise FileNotFoundError(
-        f"Agent '{name_or_path}' not found in ~/.scitex/agent-container/agents/\n"
-        f"  Create: cp templates/... "
-        f"~/.scitex/agent-container/agents/{name_or_path}.yaml"
+        f"Agent '{name_or_path}' not found. Searched:\n"
+        f"  {legacy}/{name_or_path}.yaml\n"
+        f"{env_line}\n"
+        f"  {dotfiles}/{name_or_path}/{name_or_path}.yaml"
     )

--- a/tests/test_resolve_config.py
+++ b/tests/test_resolve_config.py
@@ -1,0 +1,87 @@
+"""Tests for resolve_config search order (todo#295)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container.config import resolve_config
+
+
+def _write(p: Path, name: str = "x") -> Path:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(f"metadata:\n  name: {name}\n")
+    return p
+
+
+@pytest.fixture
+def fake_home(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("SCITEX_AGENT_CONTAINER_YAML_DIRS", raising=False)
+    return tmp_path
+
+
+def _legacy(home: Path) -> Path:
+    return home / ".scitex" / "agent-container" / "agents"
+
+
+def _dotfiles(home: Path) -> Path:
+    return home / ".dotfiles" / "src" / ".scitex" / "orochi" / "agents"
+
+
+def test_resolve_config_prefers_legacy_path_over_dotfiles(fake_home):
+    legacy = _write(_legacy(fake_home) / "foo.yaml", "legacy")
+    _write(_dotfiles(fake_home) / "foo" / "foo.yaml", "dotfiles")
+    assert resolve_config("foo") == str(legacy)
+
+
+def test_resolve_config_falls_back_to_dotfiles(fake_home):
+    expected = _write(_dotfiles(fake_home) / "foo" / "foo.yaml", "dotfiles")
+    assert resolve_config("foo") == str(expected)
+
+
+def test_resolve_config_env_var_takes_middle_priority(fake_home, monkeypatch):
+    envdir = fake_home / "envdir"
+    envhit = _write(envdir / "foo.yaml", "env")
+    _write(_dotfiles(fake_home) / "foo" / "foo.yaml", "dotfiles")
+    monkeypatch.setenv("SCITEX_AGENT_CONTAINER_YAML_DIRS", str(envdir))
+    assert resolve_config("foo") == str(envhit)
+
+
+def test_resolve_config_env_var_colon_separated(fake_home, monkeypatch):
+    d1 = fake_home / "d1"
+    d2 = fake_home / "d2"
+    d1.mkdir()
+    expected = _write(d2 / "foo.yaml", "d2")
+    monkeypatch.setenv(
+        "SCITEX_AGENT_CONTAINER_YAML_DIRS", f"{d1}:{d2}"
+    )
+    assert resolve_config("foo") == str(expected)
+
+
+def test_resolve_config_not_found_lists_all_searched_paths(
+    fake_home, monkeypatch
+):
+    monkeypatch.setenv(
+        "SCITEX_AGENT_CONTAINER_YAML_DIRS", f"{fake_home}/a:{fake_home}/b"
+    )
+    with pytest.raises(FileNotFoundError) as excinfo:
+        resolve_config("missing")
+    msg = str(excinfo.value)
+    assert ".scitex/agent-container/agents" in msg
+    assert "SCITEX_AGENT_CONTAINER_YAML_DIRS" in msg
+    assert f"{fake_home}/a" in msg
+    assert f"{fake_home}/b" in msg
+    assert ".dotfiles/src/.scitex/orochi/agents" in msg
+    assert "missing" in msg
+
+
+def test_resolve_config_absolute_path_unchanged(fake_home, tmp_path):
+    abs_yaml = _write(tmp_path / "elsewhere" / "my.yaml", "abs")
+    assert resolve_config(str(abs_yaml)) == str(abs_yaml)
+
+
+def test_resolve_config_absolute_path_missing_raises(fake_home, tmp_path):
+    with pytest.raises(FileNotFoundError):
+        resolve_config(str(tmp_path / "nope" / "x.yaml"))


### PR DESCRIPTION
## Summary

`scitex-agent-container start <name>` required a per-host symlink farm at `~/.scitex/agent-container/agents/` because `resolve_config()` only searched that one directory. This PR expands the short-name lookup to also search the dotfiles-managed fleet YAML directory, plus an optional env var for extra dirs — so fleet hosts work out of the box with no manual symlinks.

Fixes todo#295.

## Search order (new)

For short names (no slash, no `.yaml` suffix), `resolve_config(name)` now tries in order:

1. `~/.scitex/agent-container/agents/<name>.yaml` — operator override (existing, highest priority)
2. `$SCITEX_AGENT_CONTAINER_YAML_DIRS` — colon-separated extra dirs (new, middle priority)
3. `~/.dotfiles/src/.scitex/orochi/agents/<name>/<name>.yaml` — fleet fallback (new, lowest priority)

Absolute paths and explicit `*.yaml` paths are returned verbatim (unchanged).

## Diagnostic message

Before:
```
FileNotFoundError: Agent 'foo' not found in ~/.scitex/agent-container/agents/
```

After:
```
Agent 'foo' not found. Searched:
  /home/u/.scitex/agent-container/agents/foo.yaml
  (env $SCITEX_AGENT_CONTAINER_YAML_DIRS: /tmp/a, /tmp/b)
  /home/u/.dotfiles/src/.scitex/orochi/agents/foo/foo.yaml
```

## Test plan

- [x] 7 new tests in `tests/test_resolve_config.py` covering each priority level, colon-separated env var, absolute-path regression, and error message contents.
- [x] Full suite: **200 passed** (`pytest tests/`).
- [x] Stdlib only, no new deps.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
