### PR TITLE
feat(snapshot): expose pane_tail + recent_actions in agent_meta projection (todo#269/#270)

### DIFF
--- a/src/scitex_agent_container/snapshot.py
+++ b/src/scitex_agent_container/snapshot.py
@@ -31,6 +31,13 @@ from typing import Any, Iterator
 from .context_manager import fetch_agent_meta, get_sensor
 
 # Keys from agent_meta.py we surface in snapshots / status --json.
+# `pane_tail` and `pane_tail_block` carry the last N lines of the agent's
+# tmux pane (todo#269 / todo#270): consumers (mamba-healer-*, the Agents
+# dashboard card #311, fleet_watch.sh diff_one) use them as the cheapest
+# liveness signal and to render a live preview of what the agent is doing.
+# `recent_actions` is an array of {ts, preview} tool-use snippets from the
+# session jsonl, useful for identifying stuck-vs-busy states without a full
+# pane capture.
 _AGENT_META_KEYS = (
     "alive",
     "subagents",
@@ -38,6 +45,9 @@ _AGENT_META_KEYS = (
     "current_tool",
     "last_activity",
     "model",
+    "pane_tail",
+    "pane_tail_block",
+    "recent_actions",
 )
 
 

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -282,6 +282,44 @@ def test_screen_count_positive_when_sessions_listed(monkeypatch):
     assert snap_mod._probe_screen_count() == 2
 
 
+def test_agent_meta_projection_includes_pane_tail_and_recent_actions(monkeypatch):
+    """Snapshot must surface the new last_pane_lines fields (todo#269/#270).
+
+    Consumers (mamba-healer-*, fleet_watch.sh diff_one, the Agents dashboard
+    card #311) rely on `pane_tail` / `pane_tail_block` / `recent_actions` as
+    the cheapest liveness + activity signal. Regression: an earlier projection
+    only exposed alive/subagents/context_pct/current_tool/last_activity/model
+    and silently dropped the pane fields even when agent_meta.py emitted them.
+    """
+    full_meta = {
+        "alive": True,
+        "subagents": 0,
+        "context_pct": 42.0,
+        "current_tool": "Bash",
+        "last_activity": "2026-04-13T08:00:00Z",
+        "model": "claude-opus-4-6",
+        "pane_tail": "❯ ",
+        "pane_tail_block": "✻ Mulling… (12s · ↓ 6 tokens)\n← #agent: ...",
+        "recent_actions": [
+            {"ts": "2026-04-13T07:59:00Z", "preview": "TaskUpdate: ..."},
+            {"ts": "2026-04-13T07:59:30Z", "preview": "Bash: tmux ls"},
+        ],
+        "irrelevant_extra_field": "should be dropped",
+    }
+    projected = snap_mod._project_agent_meta(full_meta)
+    assert projected is not None
+    # New fields must be present.
+    assert projected["pane_tail"] == "❯ "
+    assert "✻ Mulling…" in projected["pane_tail_block"]
+    assert isinstance(projected["recent_actions"], list)
+    assert len(projected["recent_actions"]) == 2
+    # Existing fields preserved.
+    assert projected["context_pct"] == 42.0
+    assert projected["model"] == "claude-opus-4-6"
+    # Whitelist enforcement: extra fields are dropped.
+    assert "irrelevant_extra_field" not in projected
+
+
 def test_probe_mem_darwin_counts_inactive_and_speculative(monkeypatch):
     """Darwin mem must count free + inactive + speculative as available.
 


### PR DESCRIPTION
## Summary

Widens the `_AGENT_META_KEYS` whitelist in `snapshot.py` so the snapshot CLI / `status --json` surfaces three more fields that `agent_meta.py` already collects:

- `pane_tail` — the last cursor line from the live tmux pane
- `pane_tail_block` — the bottom N lines (typically the most recent thinking/output block)
- `recent_actions` — array of `{ts, preview}` tool-use snippets from the session jsonl

Source of truth is unchanged — `agent_meta.py` already emits these. The projection was silently dropping them, which is why the Agents dashboard cards (todo#311) and `mamba-healer-*` probes have to fall back to running their own `tmux capture-pane`.

## Why this is the cheapest liveness signal

The 3-signal escalation gate in `mamba-healer-ywata-note-win` (msg#8392 et al) currently needs SSH probe + claude proc count + Orochi silent-time. With `pane_tail_block` available via `snapshot --json`, healers can collapse two of those into one cache read + a regex match on `Mulling…` / `Working…` / `Press up to edit queued messages` (the busy-vs-idle decision table mamba-skill-manager landed in `agent-health-check.md`). Cheaper, faster, and works without an extra ssh round-trip per probe.

## Test

`test_agent_meta_projection_includes_pane_tail_and_recent_actions` asserts:
- All three new fields land in the projected dict.
- `recent_actions` stays a list.
- Existing fields preserved.
- Whitelist still drops unknown extras (regression guard against accidentally leaking new `agent_meta.py` fields without an audit).

Full test suite: 19 pass (was 18, +1 new).

## Test plan

- [x] Unit test (above)
- [x] `pytest tests/test_snapshot.py` → 19/19 pass
- [ ] Live verify post-merge: `scitex-agent-container snapshot --agent head-mba --json | jq '.agent_meta.pane_tail_block'` returns the live tmux preview
- [ ] fleet_watch.sh consumer side picks up the new fields automatically (Task #2 follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)