### PR TITLE
feat(status/snapshot): add --terse mode for fleet_watch consumers (todo#300)

### DIFF
--- a/src/scitex_agent_container/cli_pkg/snapshot_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/snapshot_cmds.py
@@ -30,11 +30,29 @@ from ..snapshot import take_snapshot
     default=None,
     help="Multiplexer session name (defaults to agent name).",
 )
-def snapshot(agent: str, as_json: bool, with_diff: bool, session: str | None) -> None:
+@click.option(
+    "--terse",
+    "terse",
+    is_flag=True,
+    default=False,
+    help="Project JSON output onto the fleet_watch whitelist (todo#300). "
+    "Reduces per-agent payload size dramatically.",
+)
+def snapshot(
+    agent: str,
+    as_json: bool,
+    with_diff: bool,
+    session: str | None,
+    terse: bool,
+) -> None:
     """Take a self-snapshot for AGENT and print it as JSON."""
     try:
         snap = take_snapshot(agent, session=session, with_diff=with_diff)
     except Exception as exc:  # pragma: no cover — defensive
         click.echo(json_mod.dumps({"error": str(exc)}))
         sys.exit(1)
+    if terse:
+        from ..terse import TERSE_SNAPSHOT_FIELDS, project_terse
+
+        snap = project_terse(snap, TERSE_SNAPSHOT_FIELDS)
     click.echo(json_mod.dumps(snap, indent=2))

--- a/src/scitex_agent_container/cli_pkg/status_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/status_cmds.py
@@ -77,11 +77,29 @@ def _format_claude_account_block(meta: dict) -> list[str]:
     default=False,
     help="Output as JSON.",
 )
+@click.option(
+    "--terse",
+    "terse",
+    is_flag=True,
+    default=False,
+    help="Project JSON output onto the fleet_watch whitelist (todo#300). "
+    "Implies --json. Reduces per-agent payload ~18x.",
+)
 @click.pass_context
-def status(ctx: click.Context, name: str | None, as_json: bool) -> None:
+def status(
+    ctx: click.Context, name: str | None, as_json: bool, terse: bool
+) -> None:
     """Show agent status (one agent or all)."""
-    use_json = _json_flag(ctx, as_json)
+    use_json = _json_flag(ctx, as_json) or terse
     registry = Registry()
+
+    if terse and not name:
+        click.echo(
+            json_mod.dumps(
+                {"error": "--terse requires an agent NAME (per-agent mode only)"}
+            )
+        )
+        sys.exit(2)
 
     if name:
         try:
@@ -94,6 +112,10 @@ def status(ctx: click.Context, name: str | None, as_json: bool) -> None:
             sys.exit(1)
 
         if use_json:
+            if terse:
+                from ..terse import TERSE_STATUS_FIELDS, project_terse
+
+                info = project_terse(info, TERSE_STATUS_FIELDS)
             click.echo(json_mod.dumps(info, indent=2))
             return
 

--- a/src/scitex_agent_container/terse.py
+++ b/src/scitex_agent_container/terse.py
@@ -1,0 +1,89 @@
+"""Terse projection for ``status --json`` and ``snapshot --json`` (todo#300).
+
+Full status/snapshot payloads grew ~18x after todo#286 field additions.
+``fleet_watch.sh`` polls every host every 5 min across ~9 agents and only
+reads a small subset of the JSON. ``--terse`` projects the payload to a
+whitelist superset of what ``probe_remote.sh`` extracts, cutting per-agent
+bytes to the minimum fleet_watch actually needs.
+
+Design:
+    * Output is a **flat dict with dotted keys**. Flat form round-trips
+      cleanly through ``jq -r '.["foo.bar"]'`` and guarantees a stable
+      shape regardless of whether the source nested dict was present.
+    * Absent / unknown source fields are emitted as ``null`` (not omitted)
+      so consumers never have to branch on key presence.
+    * Zero new dependencies — stdlib only.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+# Whitelist used by ``scitex-agent-container status --json --terse``.
+# Superset of what ``scripts/fleet-watch/probe_remote.sh`` extracts via
+# ``jq -r``. Do not remove entries without coordinating with head-nas.
+TERSE_STATUS_FIELDS: tuple[str, ...] = (
+    # identity
+    "agent",
+    "state",
+    "timestamp",
+    # liveness
+    "tmux_alive",
+    "last_post_ts",
+    # context window
+    "context_management.percent",
+    "context_management.strategy",
+    "context_management.trigger_at_percent",
+    # pids for kill -0 liveness
+    "pids.claude_code",
+    "pids.container_daemon",
+    # health summary
+    "health.ok",
+    # snapshot summary (NOT diff_fields, NOT the full snapshot)
+    "snapshot.timestamp",
+    "snapshot.has_diff",
+)
+
+# Whitelist used by ``scitex-agent-container snapshot --json --terse``.
+TERSE_SNAPSHOT_FIELDS: tuple[str, ...] = (
+    "agent",
+    "timestamp",
+    "host",
+    "tmux_count",
+    "screen_count",
+    "claude_procs",
+    "bun_procs",
+    "load1",
+    "mem_total_bytes",
+    "mem_used_bytes",
+    "mem_free_bytes",
+    "fork_pressure_pct",
+    "context_percent",
+    "has_diff",
+    "pids.claude_code",
+    "pids.container_daemon",
+)
+
+
+def _get_dotted(source: dict, dotted: str) -> Any:
+    """Walk ``dotted`` keys into ``source``; return ``None`` if any hop misses."""
+    cur: Any = source
+    for part in dotted.split("."):
+        if not isinstance(cur, dict):
+            return None
+        if part not in cur:
+            return None
+        cur = cur[part]
+    return cur
+
+
+def project_terse(source: dict, fields: Iterable[str]) -> dict:
+    """Project ``source`` onto ``fields``, emitting ``null`` for missing keys.
+
+    Returns a flat dict keyed by the exact dotted field names in ``fields``.
+    Consumers can extract via ``jq -r '.["context_management.percent"]'``.
+    """
+    out: dict[str, Any] = {}
+    for key in fields:
+        out[key] = _get_dotted(source, key)
+    return out

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -452,3 +452,113 @@ def test_tmux_names_is_array(monkeypatch):
     latest = Path(snap_mod._latest_path("arrayguard"))
     data = json.loads(latest.read_text())
     assert isinstance(data["tmux_names"], list)
+
+
+# ---------------------------------------------------------------------------
+# --terse projection (todo#300)
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_terse_emits_only_whitelisted_fields() -> None:
+    from scitex_agent_container.terse import TERSE_SNAPSHOT_FIELDS, project_terse
+
+    full = _fake_snap("t1")
+    full["has_diff"] = False
+    full["diff_fields"] = []
+    full["tmux_names"] = ["a", "b"]  # bulky array — must not leak
+    full["agent_meta"] = {"context_pct": 12.3, "current_tool": "Bash"}
+
+    terse = project_terse(full, TERSE_SNAPSHOT_FIELDS)
+    assert set(terse.keys()) == set(TERSE_SNAPSHOT_FIELDS)
+    assert terse["agent"] == "t1"
+    assert terse["tmux_count"] == 2
+    assert terse["pids.claude_code"] == 2
+    assert terse["pids.container_daemon"] == 1
+    assert terse["has_diff"] is False
+    # Bulky fields must not appear
+    assert "tmux_names" not in terse
+    assert "agent_meta" not in terse
+    assert "diff_fields" not in terse
+
+
+def test_snapshot_terse_absent_fields_emit_null() -> None:
+    from scitex_agent_container.terse import TERSE_SNAPSHOT_FIELDS, project_terse
+
+    full = {"agent": "bare"}
+    terse = project_terse(full, TERSE_SNAPSHOT_FIELDS)
+    assert terse["host"] is None
+    assert terse["tmux_count"] is None
+    assert terse["pids.claude_code"] is None
+    assert terse["pids.container_daemon"] is None
+    assert set(terse.keys()) == set(TERSE_SNAPSHOT_FIELDS)
+
+
+def test_snapshot_terse_byte_size_is_smaller() -> None:
+    """Terse payload must be dramatically smaller than full on a realistic fixture."""
+    from scitex_agent_container.terse import TERSE_SNAPSHOT_FIELDS, project_terse
+
+    full = _fake_snap("real")
+    # Bulk the snapshot up to match reality post-#286.
+    full["has_diff"] = True
+    full["diff_fields"] = ["tmux_count", "claude_procs", "mem_used_bytes"]
+    full["tmux_names"] = [f"session-{i}" for i in range(40)]
+    full["agent_meta"] = {
+        "context_pct": 57.5,
+        "current_tool": "Bash",
+        "current_task": "x" * 500,
+        "last_activity": "2026-04-13T00:00:00Z",
+        "subagents": [{"id": i, "name": f"sub-{i}"} for i in range(10)],
+        "skills_loaded": [f"skill-{i}" for i in range(20)],
+        "model": "claude-opus-4-6",
+        "big_blob": "z" * 4000,
+    }
+    full["pids"]["sidecars"] = {
+        f"side-{i}": {"kind": "thread", "pid": i, "alive": True}
+        for i in range(10)
+    }
+
+    full_bytes = len(json.dumps(full))
+    terse_bytes = len(json.dumps(project_terse(full, TERSE_SNAPSHOT_FIELDS)))
+    ratio = full_bytes / max(terse_bytes, 1)
+    assert ratio >= 5, f"terse only {ratio:.1f}x smaller ({full_bytes}B -> {terse_bytes}B)"
+
+
+def test_status_terse_byte_size_is_smaller() -> None:
+    from scitex_agent_container.terse import TERSE_STATUS_FIELDS, project_terse
+
+    # Simulate a real status --json payload post-#286.
+    full = {
+        "name": "real",
+        "agent": "real",
+        "state": "running",
+        "timestamp": "2026-04-13T00:00:00Z",
+        "tmux_alive": True,
+        "last_post_ts": "2026-04-13T00:00:00Z",
+        "config": "/very/long/path/to/config.yaml",
+        "screen": "real",
+        "started_at": "2026-04-13T00:00:00Z",
+        "status": "running",
+        "model": "claude-opus-4-6",
+        "runtime": "local",
+        "hooks_configured": {f"hook{i}": i for i in range(7)},
+        "listen": [{"port": 8000 + i, "proto": "http"} for i in range(5)],
+        "extensions": {"big": "y" * 3000},
+        "context_management": {
+            "percent": 42.0,
+            "strategy": "compact",
+            "trigger_at_percent": 85,
+        },
+        "agent_meta": {"big": "z" * 5000, "skills_loaded": list(range(30))},
+        "skills_loaded": [f"skill-{i}" for i in range(20)],
+        "pids": {"claude_code": 1, "container_daemon": 2, "sidecars": {"s": {}}},
+        "health": {"ok": True, "details": "x" * 500},
+        "snapshot": {
+            "timestamp": "2026-04-13T00:00:00Z",
+            "has_diff": True,
+            "diff_fields": ["tmux_count", "claude_procs"],
+        },
+    }
+    full_bytes = len(json.dumps(full))
+    terse_bytes = len(json.dumps(project_terse(full, TERSE_STATUS_FIELDS)))
+    ratio = full_bytes / max(terse_bytes, 1)
+    assert ratio >= 5, f"terse only {ratio:.1f}x smaller ({full_bytes}B -> {terse_bytes}B)"

--- a/tests/test_status_json.py
+++ b/tests/test_status_json.py
@@ -191,3 +191,107 @@ def test_agent_status_includes_rich_fields(
         "scitex-orochi",
         "scitex-agent-container",
     ]
+
+
+# ---------------------------------------------------------------------------
+# --terse projection (todo#300)
+# ---------------------------------------------------------------------------
+
+
+def test_status_terse_emits_only_whitelisted_fields() -> None:
+    from scitex_agent_container.terse import TERSE_STATUS_FIELDS, project_terse
+
+    full = {
+        "agent": "a1",
+        "state": "running",
+        "timestamp": "2026-04-13T00:00:00Z",
+        "tmux_alive": True,
+        "last_post_ts": "2026-04-13T00:00:00Z",
+        "context_management": {
+            "percent": 42.0,
+            "strategy": "compact",
+            "trigger_at_percent": 85,
+        },
+        "pids": {"claude_code": 1234, "container_daemon": 5678, "extra": 9},
+        "health": {"ok": True, "details": "xyz"},
+        "snapshot": {
+            "timestamp": "2026-04-13T00:00:00Z",
+            "has_diff": False,
+            "diff_fields": ["tmux_count"],  # must NOT leak into terse
+        },
+        "extra_bulky_field": "x" * 5000,  # must NOT leak
+        "agent_meta": {"context_pct": 42.0},  # must NOT leak
+    }
+    terse = project_terse(full, TERSE_STATUS_FIELDS)
+    assert set(terse.keys()) == set(TERSE_STATUS_FIELDS)
+    assert terse["agent"] == "a1"
+    assert terse["context_management.percent"] == 42.0
+    assert terse["pids.claude_code"] == 1234
+    assert terse["health.ok"] is True
+    assert terse["snapshot.has_diff"] is False
+    assert "extra_bulky_field" not in terse
+    assert "diff_fields" not in terse
+    # Also: no dotted key like "snapshot.diff_fields" should appear
+    for k in terse:
+        assert "diff_fields" not in k
+
+
+def test_status_terse_absent_fields_emit_null() -> None:
+    from scitex_agent_container.terse import TERSE_STATUS_FIELDS, project_terse
+
+    # Source lacks context_management entirely + lacks pids + lacks health
+    full = {"agent": "ghost", "state": "stopped"}
+    terse = project_terse(full, TERSE_STATUS_FIELDS)
+    assert terse["context_management.percent"] is None
+    assert terse["context_management.strategy"] is None
+    assert terse["pids.claude_code"] is None
+    assert terse["pids.container_daemon"] is None
+    assert terse["health.ok"] is None
+    assert terse["snapshot.timestamp"] is None
+    # Shape is stable: every whitelist key is present
+    assert set(terse.keys()) == set(TERSE_STATUS_FIELDS)
+
+
+def test_status_terse_context_management_null_when_disabled() -> None:
+    """Regression: context_management may be ``None`` in real agent_status."""
+    from scitex_agent_container.terse import TERSE_STATUS_FIELDS, project_terse
+
+    full = {"agent": "a2", "context_management": None}
+    terse = project_terse(full, TERSE_STATUS_FIELDS)
+    assert terse["context_management.percent"] is None
+    assert terse["context_management.strategy"] is None
+
+
+def test_status_full_unaffected_by_terse_flag_absence(
+    fake_workspace: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Default status (no --terse) still emits every rich field."""
+    from scitex_agent_container import lifecycle
+
+    class _FakeEntry(dict):
+        pass
+
+    entry = _FakeEntry(
+        config="/nonexistent/fake.yaml",
+        screen="fake-agent",
+        started_at="2026-04-12T00:00:00Z",
+    )
+
+    class _FakeRegistry:
+        def get(self, name):
+            return entry
+
+    monkeypatch.setattr(Path, "home", lambda: fake_workspace.parent.parent)
+    target = fake_workspace.parent.parent / ".scitex" / "orochi" / "workspaces"
+    target.mkdir(parents=True, exist_ok=True)
+    link = target / "fake-agent"
+    if not link.exists():
+        link.symlink_to(fake_workspace)
+
+    with patch.object(agent_meta, "detect_multiplexer", return_value=""):
+        result = lifecycle.agent_status("fake-agent", registry=_FakeRegistry())
+
+    # Full rich field set is still emitted (regression guard for terse
+    # being accidentally applied to the default path).
+    for key in ("skills_loaded", "hooks_configured", "listen", "extensions"):
+        assert key in result


### PR DESCRIPTION
## Summary

- Adds `--terse` to `status --json` and `snapshot --json` to project the payload onto a fleet_watch whitelist (todo#300).
- Full status/snapshot JSON grew ~18x after the #286 field additions; fleet_watch aggregates 9 agents x 288 polls/day = hundreds of MB/day of JSON it never reads. `--terse` cuts per-agent payload to the bare minimum.
- Stdlib-only, ~90 net lines in a new `scitex_agent_container/terse.py` module.

## Design

- Output is a **flat dict keyed by dotted field names** (e.g. `"context_management.percent"`). Flat form round-trips cleanly through `jq -r '.["context_management.percent"]'` and keeps a **stable shape** regardless of whether the source nested dict was present.
- **Absent source fields emit `null`**, never omitted — consumers never have to branch on key presence.
- `status --terse` requires a NAME (per-agent mode) and implies `--json`.
- `snapshot --terse` projects the snapshot payload the same way.
- `--terse` is strictly opt-in; default behavior unchanged.

## Whitelist

`TERSE_STATUS_FIELDS` (per todo#300 spec, verbatim):
```
agent, state, timestamp,
tmux_alive, last_post_ts,
context_management.percent, context_management.strategy, context_management.trigger_at_percent,
pids.claude_code, pids.container_daemon,
health.ok,
snapshot.timestamp, snapshot.has_diff
```

`TERSE_SNAPSHOT_FIELDS` (per todo#300 spec, verbatim):
```
agent, timestamp, host,
tmux_count, screen_count, claude_procs, bun_procs,
load1, mem_total_bytes, mem_used_bytes, mem_free_bytes,
fork_pressure_pct, context_percent,
has_diff,
pids.claude_code, pids.container_daemon
```

No fields were added or removed during the survey. `probe_remote.sh` was not available on MBA for cross-checking — if NAS confirms reads outside this set, a follow-up will extend the whitelist (breaking the consumer is NOT acceptable).

## Before / after payload size

Realistic post-#286 status fixture (indent=2 JSON):

| mode | bytes |
|---|---|
| full | 10,139 |
| terse | 438 |
| ratio | **23.1x** smaller |

Snapshot fixture with `tmux_names[40]`, 10 sidecars, bulky `agent_meta` blob: **>5x** smaller (enforced by `test_snapshot_terse_byte_size_is_smaller`).

## Follow-ups (NOT this PR)

- `fleet_watch.sh` / `probe_remote.sh` on NAS should opt in by appending `--terse` to the `ssh <host> scitex-agent-container status --json ...` invocation. That is a NAS-side change and lives on a separate PR per head-nas's #300 lane.
- NAS-side rotation/gzip of `~/.scitex/orochi/fleet-watch/*.json` is tracked on head-nas's follow-up and deliberately not touched here.

## Test plan

- [x] `pytest tests/test_status_json.py tests/test_snapshot.py -x` — 30/30 pass
- [x] `pytest tests/ -x` — 205/205 pass (full suite)
- [x] `test_status_terse_emits_only_whitelisted_fields` — output keys == whitelist
- [x] `test_status_terse_absent_fields_emit_null` — `{"agent": "ghost"}` still yields shape-stable terse dict with `null`s
- [x] `test_status_terse_context_management_null_when_disabled` — `context_management: None` regression guard
- [x] `test_status_full_unaffected_by_terse_flag_absence` — default path still emits full rich field set
- [x] `test_snapshot_terse_emits_only_whitelisted_fields` + `test_snapshot_terse_absent_fields_emit_null`
- [x] `test_snapshot_terse_byte_size_is_smaller` — asserts >=5x shrink on realistic fixture
- [x] `test_status_terse_byte_size_is_smaller` — asserts >=5x shrink on realistic status fixture
