### PR TITLE
fix(host_identity): derive short-form aliases from DEFAULT_HOST_ALIASES

### DIFF
--- a/src/scitex_agent_container/host_identity.py
+++ b/src/scitex_agent_container/host_identity.py
@@ -113,7 +113,9 @@ def get_local_identities() -> set[str]:
         alias_lower = {a.lower() for a in aliases}
         overlap = (lowered & alias_lower) - _UNIVERSAL_LOOPBACK
         if overlap or canonical.lower() in lowered:
-            names.update(aliases)
+            for a in aliases:
+                names.add(a)
+                names.add(_short(a))
             names.add(canonical)
 
     _CACHE = {n.lower() for n in names if n}


### PR DESCRIPTION
## Summary
- The auto-detect loop added full aliases (e.g. "Yusukes-MacBook-Air.local") but did not derive the short form ("Yusukes-MacBook-Air")
- Causes `test_is_local_host_matches_fqdn` CI failure on non-MBA hosts
- Fix: apply `_short()` to each alias entry in DEFAULT_HOST_ALIASES

## Test plan
- [x] 13/13 tests pass locally (including the previously failing test)
- [ ] CI green on GitHub Actions

Fixes todo#399.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>