### PR TITLE
fix(claude-code): auto-add workdir to --add-dir

### DIFF
--- a/src/scitex_agent_container/runtimes/claude_code.py
+++ b/src/scitex_agent_container/runtimes/claude_code.py
@@ -138,6 +138,10 @@ class ClaudeCodeRuntime(RuntimeBase):
         for flag in config.claude.flags:
             parts.append(flag)
 
+        workdir = config.expanded_workdir
+        if not any(workdir in f for f in config.claude.flags):
+            parts.append(f"--add-dir '{workdir}'")
+
         mode = config.claude.session
         max_age = config.claude.continue_max_age_minutes
         if mode == "continue":


### PR DESCRIPTION
Root cause fix for Write permission prompts that stall agents (msg#10845, dispatch msg#10855). ClaudeCodeRuntime now appends `--add-dir <workdir>` automatically so cwd is trusted, eliminating 'Do you want to create FILE?' prompts that --dangerously-skip-permissions does not bypass.

Smoke-tested: appended when missing, no-op when user already supplied --add-dir for workdir.