### PR TITLE
feat(prompts): runtime prompt handlers to prevent stuck agents

### DIFF
--- a/src/scitex_agent_container/runtimes/prompts.py
+++ b/src/scitex_agent_container/runtimes/prompts.py
@@ -86,6 +86,50 @@ def _detect_skip_permissions_yn(content: str) -> bool:
     )
 
 
+def _detect_mcp_json_edit(content: str) -> bool:
+    """Permission prompt when Claude tries to edit .mcp.json (runtime).
+
+    Matches "1. Yes" / "1. Proceed" / "1. Allow" + ".mcp.json" + "Enter to confirm".
+    """
+    return (
+        ".mcp.json" in content
+        and "Enter to confirm" in content
+        and ("1. Yes" in content or "1. Proceed" in content or "1. Allow" in content)
+    )
+
+
+def _detect_press_enter_continue(content: str) -> bool:
+    """Generic 'Press Enter to continue' runtime pause (context-window warning, etc).
+
+    Uses a strict last-5-lines window to avoid scrollback false positives
+    (per pane-state-patterns.md: classify against last 5 visible lines only).
+    Excluded: active tool calls and numbered radio selectors.
+    """
+    lines = [l for l in content.splitlines() if l.strip()]
+    last = "\n".join(lines[-5:]) if lines else ""
+    has_enter_cue = (
+        "Press Enter to continue" in last
+        or "press Enter" in last
+        or "Hit Enter" in last
+    )
+    is_active = "Working\u2026" in last or "Ruminating\u2026" in last
+    has_radio = "Enter to confirm" in last or "1. " in last
+    return has_enter_cue and not is_active and not has_radio
+
+
+def _detect_file_trust(content: str) -> bool:
+    """'Do you trust the files in this folder?' prompt (first-run or new cwd).
+
+    May appear when --dangerously-skip-permissions was not propagated to a subshell.
+    """
+    return (
+        "trust" in content.lower()
+        and "folder" in content.lower()
+        and ("y/n" in content.lower() or "yes" in content.lower())
+        and "Enter to confirm" not in content
+    )
+
+
 def _detect_done(content: str) -> bool:
     """Check if claude is at the main input prompt (all TUI prompts done).
 
@@ -117,10 +161,28 @@ PROMPT_HANDLERS: list[PromptHandler] = [
         priority=3,
     ),
     PromptHandler(
+        name="mcp-json-edit",
+        detect=_detect_mcp_json_edit,
+        keys=["1", "Enter"],  # "1. Yes, proceed" — .mcp.json edit dialog
+        priority=4,
+    ),
+    PromptHandler(
         name="skip-permissions-yn",
         detect=_detect_skip_permissions_yn,
         keys=["y", "Enter"],  # Legacy y/n text prompt
         priority=5,
+    ),
+    PromptHandler(
+        name="press-enter-continue",
+        detect=_detect_press_enter_continue,
+        keys=["Enter"],  # Dismiss informational banners / context-window warnings
+        priority=6,
+    ),
+    PromptHandler(
+        name="file-trust",
+        detect=_detect_file_trust,
+        keys=["y", "Enter"],  # "Do you trust the files in this folder?"
+        priority=7,
     ),
 ]
 

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,0 +1,121 @@
+"""Tests for prompts.py — TUI prompt detection handlers."""
+import pytest
+from scitex_agent_container.runtimes.prompts import (
+    PROMPT_HANDLERS,
+    _detect_bypass_permissions,
+    _detect_dev_channels,
+    _detect_file_trust,
+    _detect_mcp_json_edit,
+    _detect_press_enter_continue,
+    _detect_skip_permissions_yn,
+    _detect_thinking_effort,
+    detect_and_respond,
+)
+
+
+# ── Startup handlers ──────────────────────────────────────────────────────────
+
+def test_bypass_permissions_match():
+    content = "Bypass Permissions\n2. Yes, I accept\nEnter to confirm"
+    assert _detect_bypass_permissions(content) is True
+
+
+def test_bypass_permissions_no_match():
+    assert _detect_bypass_permissions("Normal chat text") is False
+
+
+def test_dev_channels_match():
+    content = "1. I am using this for local development\n2. Exit\nEnter to confirm"
+    assert _detect_dev_channels(content) is True
+
+
+def test_thinking_effort_match():
+    content = "1. * Medium (recommended)\nthinking effort\nEnter to confirm"
+    assert _detect_thinking_effort(content) is True
+
+
+def test_skip_permissions_yn_match():
+    content = "skip-permissions y/n"
+    assert _detect_skip_permissions_yn(content) is True
+
+
+# ── Runtime handlers ──────────────────────────────────────────────────────────
+
+def test_mcp_json_edit_match():
+    content = ".mcp.json\n1. Yes, proceed\nEnter to confirm"
+    assert _detect_mcp_json_edit(content) is True
+
+
+def test_mcp_json_edit_no_match_without_confirm():
+    content = ".mcp.json updated successfully"
+    assert _detect_mcp_json_edit(content) is False
+
+
+def test_press_enter_continue_match():
+    content = "Context window approaching limit.\nPress Enter to continue"
+    assert _detect_press_enter_continue(content) is True
+
+
+def test_press_enter_continue_no_match_active():
+    content = "Working\u2026 Press Enter to continue"
+    assert _detect_press_enter_continue(content) is False
+
+
+def test_press_enter_continue_no_match_radio():
+    content = "1. Option A\n2. Option B\nEnter to confirm\nPress Enter to continue"
+    assert _detect_press_enter_continue(content) is False
+
+
+def test_press_enter_continue_only_checks_tail():
+    # Old scrollback + current idle prompt should NOT trigger
+    # (strict last-5-lines window: the last visible line is the shell prompt)
+    old = "Press Enter to continue\n" * 50
+    current = old + "Some output\nMore output\nAnd more\nAnd even more\n\u276f "
+    assert _detect_press_enter_continue(current) is False
+
+
+def test_file_trust_match():
+    content = "Do you trust the files in this folder? yes/no"
+    assert _detect_file_trust(content) is True
+
+
+def test_file_trust_no_match_no_folder():
+    assert _detect_file_trust("Do you trust this?") is False
+
+
+# ── Registry ─────────────────────────────────────────────────────────────────
+
+def test_all_handlers_present():
+    names = {h.name for h in PROMPT_HANDLERS}
+    expected = {
+        "bypass-permissions",
+        "dev-channels",
+        "thinking-effort",
+        "mcp-json-edit",
+        "skip-permissions-yn",
+        "press-enter-continue",
+        "file-trust",
+    }
+    assert expected <= names
+
+
+def test_handlers_sorted_by_priority():
+    priorities = [h.priority for h in PROMPT_HANDLERS]
+    assert priorities == sorted(priorities)
+
+
+def test_detect_and_respond_calls_send_keys():
+    sent = []
+    content = "Bypass Permissions\n2. Yes, I accept\nEnter to confirm"
+    result = detect_and_respond(content, set(), lambda k: sent.append(k))
+    assert result == "bypass-permissions"
+    assert "2" in sent
+    assert "Enter" in sent
+
+
+def test_detect_and_respond_skips_accepted():
+    sent = []
+    content = "Bypass Permissions\n2. Yes, I accept\nEnter to confirm"
+    result = detect_and_respond(content, {"bypass-permissions"}, lambda k: sent.append(k))
+    assert result is None
+    assert sent == []


### PR DESCRIPTION
Adds 3 new PromptHandler entries for runtime prompts not covered by startup auto-accept. Root cause of fleet-stuck incident (ywatanabe msg#10839). Adds tests/test_prompts.py 17/17 pass.