### PR TITLE
fix(registry): cleanup_stale dual-probe tmux+screen (fixes todo#455, todo#454)

### DIFF
--- a/src/scitex_agent_container/registry.py
+++ b/src/scitex_agent_container/registry.py
@@ -76,26 +76,44 @@ class Registry:
         return self._path(name).exists()
 
     def cleanup_stale(self) -> int:
-        """Remove entries whose screen sessions no longer exist. Returns count removed."""
+        """Remove entries whose multiplexer sessions no longer exist.
+
+        Probes tmux first (tmux has-session), then screen (-ls).  An entry is
+        removed only when the session is absent from *both* multiplexers.  This
+        makes cleanup safe on mixed fleets where agents may run under either
+        tmux or GNU screen.
+
+        Returns count removed.
+        """
         import subprocess
 
         if not self.dir.exists():
             return 0
+
+        def _tmux_alive(session: str) -> bool:
+            r = subprocess.run(
+                ["tmux", "has-session", "-t", session],
+                capture_output=True,
+            )
+            return r.returncode == 0
+
+        def _screen_alive(session: str) -> bool:
+            r = subprocess.run(
+                ["screen", "-ls", session],
+                capture_output=True,
+                text=True,
+            )
+            return session in r.stdout
 
         cleaned = 0
         for path in list(self.dir.glob("*.json")):
             try:
                 with open(path) as f:
                     data = json.load(f)
-                screen_name = data.get("screen", "")
-                if not screen_name:
+                session_name = data.get("screen", "")
+                if not session_name:
                     continue
-                result = subprocess.run(
-                    ["screen", "-ls", screen_name],
-                    capture_output=True,
-                    text=True,
-                )
-                if screen_name not in result.stdout:
+                if not _tmux_alive(session_name) and not _screen_alive(session_name):
                     path.unlink()
                     cleaned += 1
             except (json.JSONDecodeError, OSError):

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -70,3 +70,48 @@ class TestRegistry:
         registry.add("test", "/config.yaml", "cld-test")
         assert reg_dir.exists()
         assert registry.exists("test")
+
+    def test_cleanup_stale_keeps_tmux_sessions(self, registry, monkeypatch):
+        """cleanup_stale must NOT remove entries for live tmux sessions.
+
+        Regression test for the MBA false-alarm incident (2026-04-15): agents
+        ran under tmux but cleanup_stale probed screen -ls only, causing the
+        entire registry to be wiped and scitex-agent-container list to return [].
+        """
+        import subprocess
+
+        registry.add("alive-tmux-agent", "/config.yaml", "cld-alive")
+
+        # Simulate: tmux reports session alive, screen reports nothing
+        def fake_run(cmd, **kwargs):
+            result = subprocess.CompletedProcess(cmd, returncode=0)
+            result.stdout = ""
+            if cmd[0] == "tmux":
+                result.returncode = 0  # tmux has-session succeeds
+            else:
+                result.returncode = 1  # screen -ls finds nothing
+                result.stdout = ""
+            return result
+
+        monkeypatch.setattr("subprocess.run", fake_run)
+
+        cleaned = registry.cleanup_stale()
+        assert cleaned == 0, "Must not remove entry when tmux session is alive"
+        assert registry.exists("alive-tmux-agent")
+
+    def test_cleanup_stale_removes_dead_sessions(self, registry, monkeypatch):
+        """cleanup_stale removes entries absent from both tmux and screen."""
+        import subprocess
+
+        registry.add("dead-agent", "/config.yaml", "cld-dead")
+
+        def fake_run(cmd, **kwargs):
+            result = subprocess.CompletedProcess(cmd, returncode=1)
+            result.stdout = ""
+            return result
+
+        monkeypatch.setattr("subprocess.run", fake_run)
+
+        cleaned = registry.cleanup_stale()
+        assert cleaned == 1
+        assert not registry.exists("dead-agent")


### PR DESCRIPTION
## Summary

- Registry.cleanup_stale() probed only screen -ls, wiping all registry entries on MBA where agents run under tmux — causing scitex-agent-container list to return [] and triggering the 2026-04-15T22:05Z false-alarm ('MBA fleet fully down')
- Fix: probe tmux has-session -t <name> first; fall back to screen -ls. Entry removed only when absent from both multiplexers
- No schema changes, fully backward-compatible

## Test plan

- [x] test_cleanup_stale_keeps_tmux_sessions — asserts entries NOT removed when tmux session alive (regression for MBA false-alarm)
- [x] test_cleanup_stale_removes_dead_sessions — asserts entries ARE removed when both tmux and screen report dead
- [x] All 11 existing registry tests pass

## Fixes
- todo#455 (registry wipes MBA fleet)
- todo#454 (healer false-positive root cause #2)

Generated with Claude Code