### PR TITLE
ci: pin haiku-integration checkout to develop

### DIFF
--- a/.github/workflows/haiku-integration.yml
+++ b/.github/workflows/haiku-integration.yml
@@ -49,6 +49,14 @@ jobs:
           echo "secret present (len=${#SCITEX_AGENT_CONTAINER_CI_ANTHROPIC_API_KEY})"
 
       - uses: actions/checkout@v4
+        with:
+          # Features (tests + source for PaneAction / nonce-probe /
+          # file-trust-radio) land on develop first; main only at
+          # release-merge time. The workflow file itself must live on
+          # the default branch for workflow_dispatch + schedule to
+          # register, but the code under test is pinned to develop so
+          # CI reflects the active feature line.
+          ref: develop
 
       - name: Install system deps (tmux)
         run: |


### PR DESCRIPTION
## Summary
- Pin `actions/checkout@v4` in `haiku-integration.yml` to `ref: develop`.
- Unblocks nightly CI without waiting for a develop→main release merge.

## Why
Workflow files must live on the default branch (main) for `workflow_dispatch` + `schedule` to register. But the *tests + source* they need (PaneAction, nonce_probe, file-trust-radio handler) only exist on develop until the next release merge. Pinning checkout to develop decouples CI cadence from release cadence.

## Test plan
- [ ] Merge
- [ ] `gh workflow run haiku-integration.yml` picks up develop's tests
- [ ] Run passes 2/2 integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)