### PR TITLE
docs(skills): refresh SKILL.md + CLI/auto-accept/README against live code

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,8 @@
 <p align="center"><b>Declarative YAML-based AI agent lifecycle management</b></p>
 
 <p align="center">
-  <a href="https://badge.fury.io/py/scitex-agent-container"><img src="https://badge.fury.io/py/scitex-agent-container.svg" alt="PyPI version"></a>
-  <a href="https://scitex-agent-container.readthedocs.io/"><img src="https://readthedocs.org/projects/scitex-agent-container/badge/?version=latest" alt="Documentation"></a>
-  <a href="https://github.com/ywatanabe1989/scitex-agent-container/actions/workflows/ci.yml"><img src="https://github.com/ywatanabe1989/scitex-agent-container/actions/workflows/ci.yml/badge.svg" alt="Tests"></a>
+  <a href="https://pypi.org/project/scitex-agent-container/"><img src="https://badge.fury.io/py/scitex-agent-container.svg" alt="PyPI version"></a>
+  <a href="https://github.com/ywatanabe1989/scitex-agent-container/actions/workflows/test.yml"><img src="https://github.com/ywatanabe1989/scitex-agent-container/actions/workflows/test.yml/badge.svg" alt="Tests"></a>
   <a href="https://www.gnu.org/licenses/agpl-3.0"><img src="https://img.shields.io/badge/License-AGPL--3.0-blue.svg" alt="License: AGPL-3.0"></a>
 </p>
 

--- a/docs/sphinx/api/scitex_agent_container.rst
+++ b/docs/sphinx/api/scitex_agent_container.rst
@@ -1,0 +1,89 @@
+scitex_agent_container API Reference
+====================================
+
+Top-level package surface re-exported from :mod:`scitex_agent_container`.
+Use ``scitex-agent-container list-python-apis`` for the authoritative
+runtime enumeration.
+
+.. automodule:: scitex_agent_container
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Config
+------
+
+.. automodule:: scitex_agent_container.config
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Lifecycle
+---------
+
+.. automodule:: scitex_agent_container.lifecycle
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Registry
+--------
+
+.. automodule:: scitex_agent_container.registry
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Observability
+-------------
+
+.. automodule:: scitex_agent_container.agent_meta
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: scitex_agent_container.event_log
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: scitex_agent_container.snapshot
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Pane Actions
+------------
+
+.. automodule:: scitex_agent_container.action_base
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: scitex_agent_container.action_store
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: scitex_agent_container.actions.nonce_probe
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: scitex_agent_container.actions.compact
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Runtimes / Multiplexer
+----------------------
+
+.. automodule:: scitex_agent_container.runtimes.multiplexer
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: scitex_agent_container.runtimes.prompts
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/src/scitex_agent_container/_skills/scitex-agent-container/SKILL.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/SKILL.md
@@ -1,19 +1,63 @@
 ---
 name: scitex-agent-container
-description: Declarative YAML-based AI agent lifecycle management with tmux/screen, SSH remote deployment, modular auto-accept, and live state inspection.
+description: Declarative YAML-based AI agent lifecycle management with tmux/screen, SSH remote deployment, modular auto-accept, live pane inspection, Claude Code hook ingestion, and a typed PaneAction engine.
 ---
 
 # scitex-agent-container
 
-Declarative agent deployment. Define agents in YAML, launch them in tmux/screen sessions locally or on remote hosts via SSH.
+Declarative lifecycle management for AI coding agents (Claude Code,
+Cursor, Aider). Define an agent in YAML, launch it in a
+tmux (default) or screen session locally or on a remote host via SSH,
+and observe it through a rich non-agentic status surface.
+
+## What the package ships
+
+| Surface | Location |
+|---|---|
+| Python API | `scitex_agent_container` (`AgentConfig`, `load_config`, `validate_config`, `agent_start`, `agent_stop`, `agent_restart`, `agent_status`, `agent_logs`, `Registry`) |
+| CLI entry points | `scitex-agent-container`, `sac` (see [cli.md](cli.md)) |
+| MCP servers | None bundled — agents spawn their own via `src_mcp.json` |
+| Runtimes | `runtimes/tmux.py`, `runtimes/screen.py`, `runtimes/claude_code.py`, `runtimes/apptainer.py`, `runtimes/docker.py`, `runtimes/sbatch_spartan.py`, `runtimes/ssh_remote.py` |
+| PaneActions | `actions/nonce_probe.py`, `actions/compact.py` (typed, logged via `action_store` to `~/.scitex/agent-container/actions.db`) |
+| Observability | `agent_meta.collect_rich()`, `event_log`, `snapshot`, `hooks.hook_event`, `liveness_probe`, `quota_watch` |
+| Config format | v2 `scitex-agent-container/v2` (auto-derived fields); legacy v1 `cld-agent/v1` still supported |
 
 ## Quick Reference
 
-| File | Topic |
+| Topic | File |
 |------|-------|
-| [config-v2.md](config-v2.md) | v2 config format, auto-derived fields, src files |
-| [multiplexer.md](multiplexer.md) | tmux vs screen, capture-pane, send-keys |
-| [auto-accept.md](auto-accept.md) | Modular prompt handlers, extending, diagnostics |
-| [remote-deploy.md](remote-deploy.md) | SSH deployment, src file copying, venv |
-| [cli.md](cli.md) | CLI commands and Python API |
-| [troubleshooting.md](troubleshooting.md) | Common issues and debugging |
+| v2 config format, auto-derived fields, `src_*` deployment | [config-v2.md](config-v2.md) |
+| tmux vs screen, `capture_content`, `send_keys`, `send_text_and_submit` | [multiplexer.md](multiplexer.md) |
+| Modular TUI prompt handlers, extending, diagnostics | [auto-accept.md](auto-accept.md) |
+| SSH deployment, `src_*` copying, preflight, venv | [remote-deploy.md](remote-deploy.md) |
+| Full CLI + Python API reference | [cli.md](cli.md) |
+| Common launch failures and recovery | [troubleshooting.md](troubleshooting.md) |
+| Resource heartbeat / cache contract (cross-package) | [resource-heartbeat.md](resource-heartbeat.md), [resource-management.md](resource-management.md) |
+
+## 30-second start
+
+```bash
+pip install scitex-agent-container
+scitex-agent-container start my-agent.yaml
+scitex-agent-container status my-agent --json | jq .pane_state
+scitex-agent-container attach my-agent           # Ctrl-B D to detach
+```
+
+## Observability contract
+
+`status <name> --json` merges the registry entry with `agent_meta.collect_rich()`
+and `event_log.summarize()`. Downstream orchestrators (e.g. scitex-orochi)
+consume that JSON — no direct coupling. Every field is best-effort; failures
+leave the default (`""`, `0`, `[]`) rather than raising. See the README's
+"Rich Status" table for the full field list.
+
+## PaneActions
+
+Typed, logged vocabulary for pane-mediated operations. Each action subclasses
+`PaneAction` and implements `snapshot` / `precheck` / `send` / `is_complete`.
+`run_action` classifies every attempt (`success`, `precondition_fail`,
+`send_error`, `completion_timeout`, `skipped_by_policy`) and writes the row to
+the host-wide SQLite store at `~/.scitex/agent-container/actions.db`.
+Built-ins: `NonceProbeAction` (functional liveness) and `CompactAction`
+(context-window compaction with drop-verification). See
+`scitex-agent-container actions --help`.

--- a/src/scitex_agent_container/_skills/scitex-agent-container/auto-accept.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/auto-accept.md
@@ -9,12 +9,22 @@ Claude Code shows confirmation prompts for dangerous flags. The auto-accept syst
 
 ## Built-in Handlers
 
-| Name | Detects | Sends |
-|------|---------|-------|
-| bypass-permissions | "2. Yes, I accept" + "Bypass Permissions" | `2`, `Enter` |
-| dev-channels | "1. I am using this for local development" | `1`, `Enter` |
-| thinking-effort | "Medium" + "thinking" | `1`, `Enter` |
-| skip-permissions-yn | "skip-permissions" or "Trust" (legacy y/n) | `y`, `Enter` |
+Ordered by priority (lowest number runs first). See
+`src/scitex_agent_container/runtimes/prompts.py::PROMPT_HANDLERS` for
+the canonical list.
+
+| Priority | Name | Detects | Sends |
+|---:|------|---------|-------|
+| 1 | bypass-permissions   | "2. Yes, I accept" + "Bypass Permissions"         | `2`, `Enter` |
+| 2 | dev-channels         | "1. I am using this for local development"        | `1`, `Enter` |
+| 3 | thinking-effort      | "1. Medium (recommended)" + "thinking"            | `1`, `Enter` |
+| 4 | mcp-json-edit        | "1. Yes, proceed" in the `.mcp.json` edit dialog  | `1`, `Enter` |
+| 5 | skip-permissions-yn  | Legacy y/n skip-permissions / trust prompt        | `y`, `Enter` |
+| 6 | press-enter-continue | Informational banner / context-window warning     | `Enter` |
+| 7 | file-trust           | "Do you trust the files in this folder?" (y/n)    | `y`, `Enter` |
+| 8 | file-trust-radio     | "1. Yes, I trust this folder" (radio variant)     | `1`, `Enter` |
+| 9 | theme-selection      | "1. Auto (match terminal)" on first run           | `1`, `Enter` |
+| 10 | login-method        | "2. Anthropic Console account · API usage billing"| `2`, `Enter` |
 
 ## Design
 

--- a/src/scitex_agent_container/_skills/scitex-agent-container/cli.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/cli.md
@@ -1,44 +1,142 @@
 ---
 name: agent-container-cli
-description: CLI commands and Python API for scitex-agent-container.
+description: CLI commands and Python API for scitex-agent-container (generated against the live Click tree).
 ---
 
-# CLI Commands
+# CLI
+
+Two entry points are installed: `scitex-agent-container` and its
+alias `sac`. Any subcommand accepts `--json` at the top level to emit
+structured JSON.
 
 ```bash
-# Lifecycle (accepts name or YAML path)
-scitex-agent-container start <config.yaml>
-scitex-agent-container stop <name|yaml>
-scitex-agent-container restart <name|yaml>
-
-# Inspection
-scitex-agent-container inspect <name> [--json]   # Live pane state detection
-scitex-agent-container status [name] [--json]
-scitex-agent-container list [--json] [--capability X] [--machine Y]
-scitex-agent-container logs <name> [-n LINES]
-scitex-agent-container health <name> [--json]
-scitex-agent-container attach <name>
-
-# Configuration
-scitex-agent-container validate <config.yaml>
-scitex-agent-container check <config.yaml>
-
-# Maintenance
-scitex-agent-container cleanup
+scitex-agent-container [--json] <command> [ARGS]
+scitex-agent-container --help-recursive     # Full command tree
+scitex-agent-container --version
 ```
+
+## Lifecycle
+
+```bash
+scitex-agent-container start <config.yaml|--all>
+scitex-agent-container stop <name|yaml|--all>
+scitex-agent-container restart <name|yaml>
+scitex-agent-container cleanup              # Drop stale registry entries
+```
+
+## Inspection
+
+```bash
+scitex-agent-container status [name] [--json]      # Rich non-agentic snapshot
+scitex-agent-container inspect <name> [--json]     # Live pane-state classifier
+scitex-agent-container list [--json] [--capability X] [--machine Y]
+scitex-agent-container health <name> [--json]
+scitex-agent-container logs <name> [-n LINES]
+scitex-agent-container attach <name>               # Interactive; Ctrl-B D detaches (tmux)
+scitex-agent-container snapshot <name>             # Self-snapshot JSON
+scitex-agent-container find --capability <label>   # Find agents by capability label
+scitex-agent-container list-python-apis            # Enumerate public Python APIs
+```
+
+## Validation / preflight
+
+```bash
+scitex-agent-container validate <config.yaml>
+scitex-agent-container check <name|yaml>           # Preflight (local and remote)
+scitex-agent-container build                       # Build container base image
+```
+
+## Claude Code hook ingestor
+
+```bash
+scitex-agent-container hook-event <pretool|posttool|prompt|stop|other>
+```
+
+Invoked from Claude Code hooks (`PreToolUse`, `PostToolUse`,
+`UserPromptSubmit`, `Stop`). Appends a compact JSON record to the
+per-agent ring buffer at
+`$XDG_DATA_HOME/.scitex/agent-container/events/<agent>.jsonl` (500-line
+cap). `status --json` reads the buffer to populate `recent_tools`,
+`recent_prompts`, `agent_calls`, `background_tasks`, `tool_counts`,
+`last_tool_at/name`, and `last_mcp_tool_at/name`.
+
+Agent name resolution: `--agent <name>` > `SCITEX_OROCHI_AGENT` env
+var > `CLAUDE_AGENT_ID` env var > basename of CWD. All errors are
+swallowed so a broken log cannot block a tool call.
+
+## Pane actions (typed, logged)
+
+```bash
+scitex-agent-container actions run nonce-probe <agent> [--json]
+scitex-agent-container actions run compact <agent> \
+    [--min-drop-pct 20] [--timeout 60] [--json]
+scitex-agent-container actions query [--agent X] [--action Y] \
+    [--since 2h] [--limit 20]
+scitex-agent-container actions stats [--agent X] [--since 7d]
+scitex-agent-container actions purge [--days 30]
+```
+
+Attempts are persisted to `~/.scitex/agent-container/actions.db`
+(SQLite). Latest attempt is folded into `status --json` as
+`last_action_at`, `last_action_name`, `last_action_outcome`,
+`last_action_elapsed_s`, plus `action_counts` and
+`p95_elapsed_s_by_action` rollups.
+
+## Account / quota management
+
+```bash
+scitex-agent-container account save <name>
+scitex-agent-container account list
+scitex-agent-container account switch <name>
+scitex-agent-container account delete <name>
+
+scitex-agent-container quota-watch                 # Auto-rotate on quota hit
+```
+
+## Environment knobs
+
+| Env var | Default | Meaning |
+|---|---|---|
+| `SCITEX_AGENT_KEY_DELAY_S` | `0.1` | Delay between individual keys in `send_keys` |
+| `SCITEX_AGENT_SUBMIT_SETTLE_S` | `0.3` | Settle window after text, before `Enter` |
+| `SCITEX_AGENT_ACTION_RETENTION_DAYS` | `30` | Default horizon for `actions purge` |
+| `SCITEX_OROCHI_AGENT` | — | Agent name used by `hook-event` when `--agent` is absent |
+| `CLAUDE_AGENT_ID` | — | Fallback agent name for `hook-event` |
+| `XDG_DATA_HOME` | `~/.local/share` | Base path for the event ring buffer |
 
 # Python API
 
 ```python
 from scitex_agent_container import (
+    __version__,
     AgentConfig, load_config, validate_config,
-    agent_start, agent_stop, agent_restart, agent_status,
+    agent_start, agent_stop, agent_restart, agent_status, agent_logs,
+    Registry,
 )
+
+# Multiplexer abstraction (tmux or screen).
 from scitex_agent_container.runtimes.multiplexer import get_multiplexer
-from scitex_agent_container.runtimes.prompts import PROMPT_HANDLERS, register_prompt
+from scitex_agent_container.runtimes.prompts import (
+    PROMPT_HANDLERS, PromptHandler, register_prompt,
+)
+
+# Rich observability surfaces used by `status --json`.
+from scitex_agent_container.agent_meta import collect_rich
+from scitex_agent_container.event_log import summarize as summarize_events
+from scitex_agent_container.snapshot import take_snapshot, gather_snapshot, read_latest
+
+# Typed pane actions.
+from scitex_agent_container.action_base import PaneAction, run_action, ActionOutcome
+from scitex_agent_container.actions.nonce_probe import NonceProbeAction
+from scitex_agent_container.actions.compact import CompactAction
+from scitex_agent_container.action_store import append_attempt, query, stats, summarize
 
 config = load_config("agent.yaml")
 mux = get_multiplexer(config)
 content = mux.capture_content("name")
 mux.send_keys("name", "2", "Enter")
 ```
+
+Use `scitex-agent-container list-python-apis` to enumerate the public
+surface programmatically — the authoritative list is generated from
+the package, not the docs.


### PR DESCRIPTION
## Summary
- **SKILL.md** rewritten to describe the actual public surface: Python API (AgentConfig, load_config, agent_start/stop/restart/status/logs, Registry), CLI entry points (scitex-agent-container + sac), runtimes, pane actions, and observability modules. No MCP servers are bundled -- claim removed.
- **cli.md** regenerated against the live Click tree. Adds sections for actions run|query|stats|purge, account, quota-watch, hook-event, snapshot, build, list-python-apis, find. Python API block corrected (collect_rich, gather_snapshot, take_snapshot, action_base, action_store).
- **auto-accept.md** now lists all 10 built-in handlers in priority order (was: 4 stale entries). Mirrors runtimes/prompts.py::PROMPT_HANDLERS.
- **README.md**: dropped the broken readthedocs badge (no RTD project exists), retargeted the CI badge from nonexistent ci.yml at the real test.yml workflow, and pointed the PyPI badge at the project page.
- **sphinx**: added docs/sphinx/api/scitex_agent_container.rst so index.rst's toctree reference resolves -- the API reference section now actually renders.

## Verification
- pytest -x --tb=short: **474 passed, 2 deselected, 0 failed**
- python -m build: wheel + sdist both include scitex_agent_container/_skills/scitex-agent-container/*.md (verified via unzip -l / tar -tzf)
- sphinx-build -b html docs/sphinx docs/sphinx/_build/html: exit 0, index.html emitted
- GitHub About: topics updated on the repo to include scitex-ecosystem (was missing); scitex and claude-code already present.

## Test plan
- [x] pytest green
- [x] wheel packages _skills/**
- [x] sphinx build exits 0
- [x] About topics include scitex, scitex-ecosystem, claude-code
- [ ] Fleet-lead review + merge
