### PR TITLE
feat(agent_meta): plan label + rotation tracking + plugins/MCPs audit

### DIFF
--- a/src/scitex_agent_container/agent_meta.py
+++ b/src/scitex_agent_container/agent_meta.py
@@ -230,6 +230,59 @@ def _read_mcp_json(workdir: str, max_chars: int = 10000) -> str:
         return ""
 
 
+def _parse_mcp_servers(workdir: str) -> list[dict[str, Any]]:
+    """Return a structured summary of MCP servers configured for this agent.
+
+    Parses ``<workdir>/.mcp.json`` into a flat list of
+    ``{name, transport, url_host, command}`` entries so the dashboard
+    can render a setup-audit table alongside installed plugins. URL
+    hosts (not full URLs) and commands (not args) are surfaced because
+    that is enough to verify the server is pointing at the right
+    endpoint without exposing query-string secrets.
+
+    Returns [] if the file is missing or malformed — callers never get
+    ``None``.
+    """
+    try:
+        p = Path(workdir) / ".mcp.json"
+        if not p.is_file():
+            return []
+        doc = json.loads(p.read_text(errors="replace"))
+    except Exception:
+        return []
+    if not isinstance(doc, dict):
+        return []
+    servers = doc.get("mcpServers")
+    if not isinstance(servers, dict):
+        return []
+    out: list[dict[str, Any]] = []
+    for sname, sconf in servers.items():
+        if not isinstance(sconf, dict):
+            continue
+        transport = sconf.get("type") or sconf.get("transport")
+        url_host: str | None = None
+        url_val = sconf.get("url")
+        if isinstance(url_val, str):
+            try:
+                from urllib.parse import urlparse
+
+                url_host = urlparse(url_val).hostname or None
+            except Exception:
+                url_host = None
+        command = sconf.get("command")
+        if not isinstance(command, str):
+            command = None
+        out.append(
+            {
+                "name": sname,
+                "transport": transport if isinstance(transport, str) else None,
+                "url_host": url_host,
+                "command": command,
+            }
+        )
+    return out
+
+
 def _pids_from_session(session: str, multiplexer: str) -> tuple[int, int]:
     pid = 0
     ppid = 0
@@ -423,6 +476,7 @@ def collect_rich(
     # ---- workspace file snapshots -----------------------------------
     claude_md = _read_claude_md(workdir)
     mcp_json = _read_mcp_json(workdir)
+    mcp_servers = _parse_mcp_servers(workdir)
 
     # ---- hook-captured tool / prompt log ----------------------------
     # Populated by `scitex-agent-container hook-event` entries wired into
@@ -476,14 +530,82 @@ def collect_rich(
         quota_error = f"fetch_usage raised: {exc}"
 
     # ---- Account / credential identity ------------------------------------
+    # Pull the full non-secret credentials view so downstream consumers
+    # can render plan, plugins, statusline command, and auth-rotation
+    # state without re-scanning ~/.claude/. The dashboard previously
+    # showed billing_type ("stripe_subscription") as the plan, which is
+    # wrong — the real plan comes from rateLimitTier in credentials.json
+    # and is normalized to plan_label here.
     account_email: str | None = None
+    account_plan_label: str | None = None
+    account_subscription_type: str | None = None
+    account_rate_limit_tier: str | None = None
+    account_organization_name: str | None = None
+    account_uuid: str | None = None
+    oauth_expires_at: int | None = None
+    installed_plugins: list = []
+    status_line_command: str | None = None
     try:
         from .credentials import read_credentials_metadata
 
         _cred = read_credentials_metadata()
         account_email = _cred.get("email_address")
+        account_plan_label = _cred.get("plan_label")
+        account_subscription_type = _cred.get("subscription_type")
+        account_rate_limit_tier = _cred.get("rate_limit_tier")
+        account_organization_name = _cred.get("organization_name")
+        account_uuid = _cred.get("account_uuid")
+        _expires = _cred.get("oauth_expires_at")
+        if isinstance(_expires, int):
+            oauth_expires_at = _expires
+        _plugins = _cred.get("installed_plugins")
+        if isinstance(_plugins, list):
+            installed_plugins = _plugins
+        _slc = _cred.get("status_line_command")
+        if isinstance(_slc, str):
+            status_line_command = _slc
     except Exception:
         pass
+
+    # ---- Auth-rotation tracking -------------------------------------------
+    # When Claude Code rotates the OAuth token the expiresAt timestamp
+    # jumps. We append one NDJSON line per observed change, keyed on the
+    # email so the dashboard can show "this email has rotated N times,
+    # last at T". The log is local-only (not pushed as a bulk field)
+    # because the hub should dedupe rotations on its side from the
+    # per-heartbeat oauth_expires_at field.
+    if account_email and isinstance(oauth_expires_at, int):
+        try:
+            rot_dir = Path.home() / ".scitex" / "agent-container" / "auth-rotations"
+            rot_dir.mkdir(parents=True, exist_ok=True)
+            rot_file = rot_dir / f"{account_email}.ndjson"
+            last_expires: int | None = None
+            if rot_file.is_file():
+                try:
+                    for line in reversed(rot_file.read_text().splitlines()):
+                        line = line.strip()
+                        if not line:
+                            continue
+                        obj = json.loads(line)
+                        if isinstance(obj, dict) and isinstance(
+                            obj.get("oauth_expires_at"), int
+                        ):
+                            last_expires = obj["oauth_expires_at"]
+                            break
+                except Exception:
+                    last_expires = None
+            if last_expires != oauth_expires_at:
+                entry = {
+                    "ts": datetime.now(tz=timezone.utc).isoformat(),
+                    "email": account_email,
+                    "account_uuid": account_uuid,
+                    "oauth_expires_at": oauth_expires_at,
+                    "plan_label": account_plan_label,
+                }
+                with rot_file.open("a", encoding="utf-8") as fh:
+                    fh.write(json.dumps(entry) + "\n")
+        except Exception:
+            pass
 
     # ---- Machine resource metrics (psutil, optional) -----------------------
     try:
@@ -540,7 +662,27 @@ def collect_rich(
         "quota_from_cache": quota_from_cache,
         "quota_error": quota_error,
         # ---- Account identity (which Claude account this agent is using) ----
+        # `account_email` stays as the stable id consumers group on.
+        # `account_plan_label` is the human-readable plan ("Max 20x" etc.)
+        # derived from rateLimitTier — dashboards should prefer this over
+        # billing_type, which only reports payment method.
+        # `oauth_expires_at` is the unix-ms token expiry; a change across
+        # heartbeats indicates the OAuth token was rotated.
         "account_email": account_email,
+        "account_plan_label": account_plan_label,
+        "account_subscription_type": account_subscription_type,
+        "account_rate_limit_tier": account_rate_limit_tier,
+        "account_organization_name": account_organization_name,
+        "account_uuid": account_uuid,
+        "oauth_expires_at": oauth_expires_at,
+        # ---- Claude Code setup audit (for web-UI setup check) ---------------
+        # `installed_plugins` lists what is installed via /plugin install.
+        # `status_line_command` exposes whatever claude-hud / custom
+        # statusline the user wired up — the hub uses it as a "setup-ok"
+        # signal (is claude-hud wired in? is the sac-statusline wrapper
+        # in place?).
+        "installed_plugins": installed_plugins,
+        "status_line_command": status_line_command,
         # ---- Machine resource metrics (for hub /api/resources/) -------------
         # NOTE: metrics are host-level, not agent-level. When multiple agents
         # run on the same host they all report identical values; the hub is
@@ -555,9 +697,11 @@ def collect_rich(
         # ---- Workspace file snapshots --------------------------------------
         # Full CLAUDE.md (truncated) so downstream consumers do not need
         # per-host filesystem access. .mcp.json has token-style keys
-        # redacted.
+        # redacted. mcp_servers is the structured view for setup audit
+        # (name + transport + host/command, nothing sensitive).
         "claude_md": claude_md,
         "mcp_json": mcp_json,
+        "mcp_servers": mcp_servers,
         # ---- Claude Code hook-captured events ------------------------------
         # Structured view of the last N events the agent fired through
         # .claude/settings.local.json hooks. Surfaces full tool inputs

--- a/src/scitex_agent_container/credentials.py
+++ b/src/scitex_agent_container/credentials.py
@@ -8,9 +8,10 @@ Design rules:
 1. **Whitelist only.** This module never blacklists. Only the fields
    explicitly listed below are copied out of the source files.
 2. **Token material is forbidden.** The file ``~/.claude/.credentials.json``
-   contains OAuth tokens. Only the two non-secret strings
-   ``subscriptionType`` and ``rateLimitTier`` are ever read from it.
-   No other field is parsed.
+   contains OAuth tokens. Only three non-secret fields are ever read
+   from it: ``subscriptionType``, ``rateLimitTier``, and ``expiresAt``
+   (a unix-ms integer deadline, used to detect token rotations).
+   ``accessToken``, ``refreshToken``, and ``scopes`` are never parsed.
 3. **Post-extraction guard.** After extraction, the result dict is
    scanned for any key or stringified value containing a secret-looking
    substring. A match raises ``RuntimeError``.
@@ -48,11 +49,32 @@ _TOP_LEVEL_FIELDS = {
     "hasCompletedOnboarding": "has_completed_onboarding",
 }
 
-# Only these two fields are read from ~/.claude/.credentials.json.
-# Nothing else from that file is ever touched.
+# Fields read from ~/.claude/.credentials.json.
+# Whitelist only. accessToken/refreshToken/scopes are NEVER read.
+# ``expiresAt`` is a unix-ms integer (token rotation deadline); it is
+# not a secret and is required for the auth-rotation tracker
+# (`oauth_expires_at` changes → token has rotated → emit one NDJSON
+# line keyed on email so the dashboard can show "rotated N times").
 _CREDENTIALS_SAFE_FIELDS = {
     "subscriptionType": "subscription_type",
     "rateLimitTier": "rate_limit_tier",
+    "expiresAt": "oauth_expires_at",
+}
+
+# Human-friendly label derived from rateLimitTier (fallback to
+# subscriptionType). Dashboard should prefer ``plan_label``; raw
+# values stay exposed so future tiers surface as ``plan_label=None``
+# rather than silently being bucketed wrong.
+_PLAN_LABELS = {
+    "default_claude_max_20x": "Max 20x",
+    "default_claude_max_5x": "Max 5x",
+    "default_claude_pro": "Pro",
+    "default_claude_free": "Free",
+}
+_SUBSCRIPTION_FALLBACK_LABELS = {
+    "max": "Max",
+    "pro": "Pro",
+    "free": "Free",
 }
 
 # Fields read from ~/.claude/settings.json
@@ -60,6 +82,13 @@ _SETTINGS_FIELDS = {
     "statusLine": "status_line_command",
     "enabledPlugins": "enabled_plugins",
 }
+
+# Derived (not read directly from any file). Always present in the
+# output dict so callers have a stable schema.
+_DERIVED_FIELDS = (
+    "plan_label",
+    "installed_plugins",
+)
 
 # Substrings that MUST NOT appear in any returned key or stringified value.
 _FORBIDDEN_SUBSTRINGS = (
@@ -80,7 +109,61 @@ def _all_safe_keys() -> list[str]:
     keys.extend(_TOP_LEVEL_FIELDS.values())
     keys.extend(_CREDENTIALS_SAFE_FIELDS.values())
     keys.extend(_SETTINGS_FIELDS.values())
+    keys.extend(_DERIVED_FIELDS)
     return keys
+
+
+def _derive_plan_label(
+    rate_limit_tier: str | None,
+    subscription_type: str | None,
+) -> str | None:
+    """Map raw tier/subscription strings to a human plan label.
+
+    Returns ``None`` if neither input yields a known tier — the
+    dashboard should surface the raw values as a fallback so unknown
+    plans don't get silently bucketed under "Free".
+    """
+    if rate_limit_tier and rate_limit_tier in _PLAN_LABELS:
+        return _PLAN_LABELS[rate_limit_tier]
+    if subscription_type and subscription_type in _SUBSCRIPTION_FALLBACK_LABELS:
+        return _SUBSCRIPTION_FALLBACK_LABELS[subscription_type]
+    return None
+
+
+def _read_installed_plugins(home: Path) -> list[dict[str, Any]]:
+    """Return a flat list of installed Claude Code plugins.
+
+    Parses ``~/.claude/plugins/installed_plugins.json`` which Claude
+    Code writes when plugins are installed via ``/plugin install``.
+    One entry per (plugin, scope) tuple — the same plugin can appear
+    twice (user-scope + local-scope). Empty list if the file does not
+    exist or is malformed.
+    """
+    path = home / ".claude" / "plugins" / "installed_plugins.json"
+    data = _load_json(path)
+    if data is None:
+        return []
+    plugins_raw = data.get("plugins")
+    if not isinstance(plugins_raw, dict):
+        return []
+    out: list[dict[str, Any]] = []
+    for pname, entries in plugins_raw.items():
+        if not isinstance(entries, list):
+            continue
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            out.append(
+                {
+                    "name": pname,
+                    "version": entry.get("version"),
+                    "scope": entry.get("scope"),
+                    "installed_at": entry.get("installedAt"),
+                    "last_updated": entry.get("lastUpdated"),
+                    "project_path": entry.get("projectPath"),
+                }
+            )
+    return out
 
 
 def _load_json(path: Path) -> dict[str, Any] | None:
@@ -112,8 +195,7 @@ def _check_no_secrets(result: dict[str, Any]) -> None:
         for needle in _FORBIDDEN_SUBSTRINGS:
             if needle in val_l:
                 raise RuntimeError(
-                    f"credentials extractor leaked forbidden value "
-                    f"under key {key!r}"
+                    f"credentials extractor leaked forbidden value under key {key!r}"
                 )
 
 
@@ -187,6 +269,21 @@ def read_credentials_metadata(home: Path | None = None) -> dict[str, Any]:
         enabled = settings_json.get("enabledPlugins")
         if isinstance(enabled, (list, dict)):
             result["enabled_plugins"] = enabled
+
+    # --- Derived fields ----------------------------------------------------
+    result["plan_label"] = _derive_plan_label(
+        rate_limit_tier=(
+            result["rate_limit_tier"]
+            if isinstance(result["rate_limit_tier"], str)
+            else None
+        ),
+        subscription_type=(
+            result["subscription_type"]
+            if isinstance(result["subscription_type"], str)
+            else None
+        ),
+    )
+    result["installed_plugins"] = _read_installed_plugins(home)
 
     # Post-extraction guard: must not contain any secret-looking material.
     _check_no_secrets(result)

--- a/tests/test_agent_meta_setup_audit.py
+++ b/tests/test_agent_meta_setup_audit.py
@@ -1,0 +1,286 @@
+"""Tests for the setup-audit and auth-rotation fields on the
+``collect_rich`` payload.
+
+These tests cover the three concerns raised alongside the claude-hud
+statusline discussion (2026-04-17):
+
+1. The plan label must come from ``rateLimitTier`` (credentials.json),
+   not from ``billingType`` (claude.json). The latter only reports
+   payment method (``stripe_subscription`` vs ``free``) and is not a
+   plan identifier.
+2. The auth-rotation log must append one line per observed
+   ``expiresAt`` change, keyed on email, and must NOT duplicate when
+   the same ``expiresAt`` is seen twice in a row.
+3. The ``mcp_servers`` and ``installed_plugins`` lists must be
+   structured (not raw JSON blobs) so the dashboard can render a
+   setup-audit table.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container.agent_meta import _parse_mcp_servers
+
+# ---------------------------------------------------------------------------
+# 1. MCP-server parser
+# ---------------------------------------------------------------------------
+
+
+def _write_mcp(workdir: Path, body: dict) -> None:
+    workdir.mkdir(parents=True, exist_ok=True)
+    (workdir / ".mcp.json").write_text(json.dumps(body))
+
+
+def test_parse_mcp_stdio_server(tmp_path: Path) -> None:
+    _write_mcp(
+        tmp_path,
+        {
+            "mcpServers": {
+                "scitex-orochi": {
+                    "type": "stdio",
+                    "command": "bun",
+                    "args": ["/path/to/mcp/server.ts"],
+                }
+            }
+        },
+    )
+    out = _parse_mcp_servers(str(tmp_path))
+    assert len(out) == 1
+    e = out[0]
+    assert e["name"] == "scitex-orochi"
+    assert e["transport"] == "stdio"
+    assert e["command"] == "bun"
+    assert e["url_host"] is None
+
+
+def test_parse_mcp_http_server_extracts_host(tmp_path: Path) -> None:
+    _write_mcp(
+        tmp_path,
+        {
+            "mcpServers": {
+                "remote-hub": {
+                    "type": "http",
+                    "url": "https://scitex-orochi.com/mcp/sse?token=secret",
+                }
+            }
+        },
+    )
+    out = _parse_mcp_servers(str(tmp_path))
+    assert len(out) == 1
+    assert out[0]["url_host"] == "scitex-orochi.com"
+    # Regression: we extract host only, never the full URL (no secret
+    # in query string).
+    for v in out[0].values():
+        assert v is None or "secret" not in str(v)
+
+
+def test_parse_mcp_missing_file_returns_empty(tmp_path: Path) -> None:
+    assert _parse_mcp_servers(str(tmp_path)) == []
+
+
+def test_parse_mcp_malformed_json_returns_empty(tmp_path: Path) -> None:
+    (tmp_path / ".mcp.json").write_text("not json")
+    assert _parse_mcp_servers(str(tmp_path)) == []
+
+
+def test_parse_mcp_no_mcp_servers_key(tmp_path: Path) -> None:
+    _write_mcp(tmp_path, {"some_other_field": 1})
+    assert _parse_mcp_servers(str(tmp_path)) == []
+
+
+def test_parse_mcp_multi_servers(tmp_path: Path) -> None:
+    _write_mcp(
+        tmp_path,
+        {
+            "mcpServers": {
+                "a": {"type": "stdio", "command": "bun"},
+                "b": {"type": "http", "url": "https://example.com/mcp"},
+            }
+        },
+    )
+    out = _parse_mcp_servers(str(tmp_path))
+    names = sorted(e["name"] for e in out)
+    assert names == ["a", "b"]
+
+
+# ---------------------------------------------------------------------------
+# 2. Auth-rotation NDJSON log
+# ---------------------------------------------------------------------------
+
+
+def _setup_fake_home(tmp_path: Path, expires_at: int) -> Path:
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".claude.json").write_text(
+        json.dumps(
+            {
+                "oauthAccount": {
+                    "emailAddress": "rotator@example.com",
+                    "accountUuid": "uuid-XYZ",
+                    "billingType": "stripe_subscription",
+                    "organizationName": "Test",
+                }
+            }
+        )
+    )
+    claude_dir = home / ".claude"
+    claude_dir.mkdir()
+    (claude_dir / ".credentials.json").write_text(
+        json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "sk-ant-DO-NOT-LEAK",
+                    "refreshToken": "REFRESH",
+                    "expiresAt": expires_at,
+                    "subscriptionType": "max",
+                    "rateLimitTier": "default_claude_max_20x",
+                }
+            }
+        )
+    )
+    return home
+
+
+def test_rotation_log_writes_one_line_per_change(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Same expires_at twice -> one line. Different expires_at -> two lines."""
+    home = _setup_fake_home(tmp_path, expires_at=1_000_000_000_000)
+    monkeypatch.setattr(Path, "home", lambda: home)
+
+    # Use an empty workspace so the transcript-JSONL path is a no-op
+    # and we are really only testing the rotation-log branch.
+    workdir = tmp_path / "workspace"
+    workdir.mkdir()
+
+    from scitex_agent_container.agent_meta import collect_rich
+
+    collect_rich(name="agent-x", workdir=str(workdir), session="agent-x")
+    collect_rich(name="agent-x", workdir=str(workdir), session="agent-x")
+
+    rot_file = (
+        home
+        / ".scitex"
+        / "agent-container"
+        / "auth-rotations"
+        / "rotator@example.com.ndjson"
+    )
+    assert rot_file.is_file()
+    lines = [l for l in rot_file.read_text().splitlines() if l.strip()]
+    assert len(lines) == 1, f"expected idempotent single entry, got {lines}"
+
+    # Now rotate the token and collect again.
+    (home / ".claude" / ".credentials.json").write_text(
+        json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "sk-ant-NEW",
+                    "refreshToken": "REFRESH",
+                    "expiresAt": 2_000_000_000_000,
+                    "subscriptionType": "max",
+                    "rateLimitTier": "default_claude_max_20x",
+                }
+            }
+        )
+    )
+    collect_rich(name="agent-x", workdir=str(workdir), session="agent-x")
+
+    lines = [l for l in rot_file.read_text().splitlines() if l.strip()]
+    assert len(lines) == 2
+    new_entry = json.loads(lines[-1])
+    assert new_entry["oauth_expires_at"] == 2_000_000_000_000
+    assert new_entry["email"] == "rotator@example.com"
+    assert new_entry["plan_label"] == "Max 20x"
+    # No token material in the NDJSON.
+    blob = rot_file.read_text().lower()
+    assert "sk-ant" not in blob
+
+
+def test_rotation_log_skipped_without_email(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No oauthAccount.emailAddress -> no rotation log is written."""
+    home = tmp_path / "home"
+    (home / ".claude").mkdir(parents=True)
+    # Credentials present but .claude.json has no oauthAccount.
+    (home / ".claude.json").write_text(json.dumps({}))
+    (home / ".claude" / ".credentials.json").write_text(
+        json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "sk-ant-x",
+                    "expiresAt": 1,
+                    "subscriptionType": "max",
+                    "rateLimitTier": "default_claude_max_20x",
+                }
+            }
+        )
+    )
+    monkeypatch.setattr(Path, "home", lambda: home)
+
+    workdir = tmp_path / "workspace"
+    workdir.mkdir()
+
+    from scitex_agent_container.agent_meta import collect_rich
+
+    collect_rich(name="agent-y", workdir=str(workdir), session="agent-y")
+
+    # The rotations directory should not have been created.
+    rot_dir = home / ".scitex" / "agent-container" / "auth-rotations"
+    assert not rot_dir.exists()
+
+
+# ---------------------------------------------------------------------------
+# 3. Payload shape: plan label + plugins + mcp_servers
+# ---------------------------------------------------------------------------
+
+
+def test_collect_rich_exposes_plan_and_plugins(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home = _setup_fake_home(tmp_path, expires_at=1234)
+    # Add plugins file.
+    plugins_dir = home / ".claude" / "plugins"
+    plugins_dir.mkdir()
+    (plugins_dir / "installed_plugins.json").write_text(
+        json.dumps(
+            {
+                "plugins": {
+                    "claude-hud@claude-hud": [{"scope": "user", "version": "0.0.10"}]
+                }
+            }
+        )
+    )
+    monkeypatch.setattr(Path, "home", lambda: home)
+
+    workdir = tmp_path / "workspace"
+    _write_mcp(
+        workdir,
+        {"mcpServers": {"scitex-orochi": {"type": "stdio", "command": "bun"}}},
+    )
+
+    from scitex_agent_container.agent_meta import collect_rich
+
+    payload = collect_rich(name="agent-z", workdir=str(workdir), session="agent-z")
+
+    assert payload["account_email"] == "rotator@example.com"
+    assert payload["account_plan_label"] == "Max 20x"
+    assert payload["account_subscription_type"] == "max"
+    assert payload["account_rate_limit_tier"] == "default_claude_max_20x"
+    assert payload["oauth_expires_at"] == 1234
+    assert (
+        payload["installed_plugins"]
+        and payload["installed_plugins"][0]["name"] == "claude-hud@claude-hud"
+    )
+    assert payload["mcp_servers"] == [
+        {
+            "name": "scitex-orochi",
+            "transport": "stdio",
+            "url_host": None,
+            "command": "bun",
+        }
+    ]

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -12,6 +12,7 @@ import pytest
 from scitex_agent_container.credentials import (
     _FORBIDDEN_SUBSTRINGS,
     _all_safe_keys,
+    _derive_plan_label,
     read_credentials_metadata,
 )
 
@@ -158,10 +159,14 @@ def test_missing_files_tolerated(tmp_path: Path) -> None:
     # tmp_path is completely empty — no claude files at all.
     result = read_credentials_metadata(home=tmp_path)
     assert isinstance(result, dict)
-    # Every safe key present, all None.
+    # Every safe key present; scalars None, installed_plugins defaults
+    # to [] so consumers can always iterate without a None check.
     for key in _all_safe_keys():
         assert key in result
-        assert result[key] is None
+        if key == "installed_plugins":
+            assert result[key] == []
+        else:
+            assert result[key] is None
 
 
 # ---------------------------------------------------------------------------
@@ -247,3 +252,173 @@ def test_status_json_contains_claude_account(
     blob = result.stdout.lower()
     for needle in ("sk-ant", "accesstoken", "refreshtoken", "claudeaioauth"):
         assert needle not in blob
+
+
+# ---------------------------------------------------------------------------
+# 6. Plan-label derivation
+# ---------------------------------------------------------------------------
+
+
+def test_plan_label_from_rate_limit_tier(tmp_path: Path) -> None:
+    _write_credentials_json(
+        tmp_path,
+        {
+            "claudeAiOauth": {
+                "accessToken": "sk-ant-fake",
+                "subscriptionType": "max",
+                "rateLimitTier": "default_claude_max_20x",
+                "expiresAt": 1776451091741,
+            }
+        },
+    )
+    result = read_credentials_metadata(home=tmp_path)
+    assert result["plan_label"] == "Max 20x"
+    assert result["oauth_expires_at"] == 1776451091741
+
+
+def test_plan_label_falls_back_to_subscription_type(tmp_path: Path) -> None:
+    _write_credentials_json(
+        tmp_path,
+        {
+            "claudeAiOauth": {
+                "accessToken": "sk-ant-fake",
+                "subscriptionType": "pro",
+                "rateLimitTier": "unseen_future_tier",
+                "expiresAt": 1,
+            }
+        },
+    )
+    result = read_credentials_metadata(home=tmp_path)
+    # rate_limit_tier is not in _PLAN_LABELS -> fall through to subscription.
+    assert result["plan_label"] == "Pro"
+
+
+def test_plan_label_unknown_plan_returns_none(tmp_path: Path) -> None:
+    _write_credentials_json(
+        tmp_path,
+        {
+            "claudeAiOauth": {
+                "subscriptionType": "enterprise_super_mega",
+                "rateLimitTier": "default_claude_enterprise_mega",
+            }
+        },
+    )
+    result = read_credentials_metadata(home=tmp_path)
+    assert result["plan_label"] is None
+    # Raw fields still exposed so the dashboard can show the unknown tier.
+    assert result["rate_limit_tier"] == "default_claude_enterprise_mega"
+    assert result["subscription_type"] == "enterprise_super_mega"
+
+
+def test_derive_plan_label_pure_function() -> None:
+    assert _derive_plan_label("default_claude_max_20x", None) == "Max 20x"
+    assert _derive_plan_label("default_claude_max_5x", "max") == "Max 5x"
+    assert _derive_plan_label(None, "max") == "Max"
+    assert _derive_plan_label(None, None) is None
+    assert _derive_plan_label("unknown", "unknown") is None
+
+
+# ---------------------------------------------------------------------------
+# 7. Installed plugins listing
+# ---------------------------------------------------------------------------
+
+
+def test_installed_plugins_parsed(tmp_path: Path) -> None:
+    plugins_dir = tmp_path / ".claude" / "plugins"
+    plugins_dir.mkdir(parents=True)
+    (plugins_dir / "installed_plugins.json").write_text(
+        json.dumps(
+            {
+                "version": 2,
+                "plugins": {
+                    "claude-hud@claude-hud": [
+                        {
+                            "scope": "user",
+                            "version": "0.0.10",
+                            "installedAt": "2026-03-18T00:00:26.724Z",
+                            "lastUpdated": "2026-04-10T08:25:12.944Z",
+                            "installPath": "/path/to/plugin",
+                        }
+                    ],
+                    "telegram@claude-plugins-official": [
+                        {
+                            "scope": "local",
+                            "version": "0.0.4",
+                            "installedAt": "2026-04-10T08:25:12.944Z",
+                            "projectPath": "/home/u/proj/foo",
+                        }
+                    ],
+                },
+            }
+        )
+    )
+    result = read_credentials_metadata(home=tmp_path)
+    plugins = result["installed_plugins"]
+    assert isinstance(plugins, list)
+    names = sorted(p["name"] for p in plugins)
+    assert names == [
+        "claude-hud@claude-hud",
+        "telegram@claude-plugins-official",
+    ]
+    hud = next(p for p in plugins if p["name"] == "claude-hud@claude-hud")
+    assert hud["version"] == "0.0.10"
+    assert hud["scope"] == "user"
+    assert hud["installed_at"] == "2026-03-18T00:00:26.724Z"
+
+
+def test_installed_plugins_multi_scope_same_plugin(tmp_path: Path) -> None:
+    # One plugin, two scopes (user + local) -> two entries.
+    plugins_dir = tmp_path / ".claude" / "plugins"
+    plugins_dir.mkdir(parents=True)
+    (plugins_dir / "installed_plugins.json").write_text(
+        json.dumps(
+            {
+                "plugins": {
+                    "pyright-lsp@claude-plugins-official": [
+                        {"scope": "local", "version": "1.0.0"},
+                        {"scope": "user", "version": "1.0.0"},
+                    ]
+                }
+            }
+        )
+    )
+    result = read_credentials_metadata(home=tmp_path)
+    plugins = result["installed_plugins"]
+    assert len(plugins) == 2
+    scopes = sorted(p["scope"] for p in plugins)
+    assert scopes == ["local", "user"]
+
+
+def test_installed_plugins_malformed_json(tmp_path: Path) -> None:
+    plugins_dir = tmp_path / ".claude" / "plugins"
+    plugins_dir.mkdir(parents=True)
+    (plugins_dir / "installed_plugins.json").write_text("not json {")
+    result = read_credentials_metadata(home=tmp_path)
+    assert result["installed_plugins"] == []
+
+
+# ---------------------------------------------------------------------------
+# 8. expires_at does NOT trip the secret guard
+# ---------------------------------------------------------------------------
+
+
+def test_expires_at_passes_secret_guard(tmp_path: Path) -> None:
+    """Regression: oauth_expires_at is an integer and must not be
+    classified as a secret despite living next to accessToken."""
+    _write_credentials_json(
+        tmp_path,
+        {
+            "claudeAiOauth": {
+                "accessToken": "sk-ant-SECRET",
+                "refreshToken": "REFRESH",
+                "expiresAt": 1776451091741,
+                "subscriptionType": "max",
+                "rateLimitTier": "default_claude_max_20x",
+            }
+        },
+    )
+    result = read_credentials_metadata(home=tmp_path)
+    assert result["oauth_expires_at"] == 1776451091741
+    # And the secret guard still would have caught a leaked token.
+    blob = json.dumps(result).lower()
+    assert "sk-ant" not in blob


### PR DESCRIPTION
## Summary

- **Fix wrong plan report.** Dashboard showed \`billing_type=stripe_subscription\` as the plan; real plan comes from \`claudeAiOauth.rateLimitTier\`. Expose \`account_plan_label\` ('Max 20x') derived from it.
- **Add auth-rotation tracking.** Whitelist non-secret \`expiresAt\` (unix-ms); when it changes across heartbeats, append one NDJSON line per rotation keyed on email at \`~/.scitex/agent-container/auth-rotations/<email>.ndjson\`. Idempotent.
- **Setup audit for web UI.** Parse \`~/.claude/plugins/installed_plugins.json\` into \`installed_plugins\` list and workspace \`.mcp.json\` into structured \`mcp_servers\` (name, transport, url_host, command). Hub can now show a setup-audit table across the fleet.

Prep work for #52 (claude-hud statusline-JSON capture). Today's audit showed claude-hud is only installed locally on WSL, not fleet-wide — so the setup-audit payload is shipping first so the dashboard can see which hosts need claude-hud installed.

## Test plan

- [x] 491 tests pass locally (full suite)
- [x] Smoke-tested on real \`~/.claude.json\` / \`.credentials.json\`: plan label 'Max 20x', plugins list, rotation log entry written
- [x] Idempotency verified: second call with same \`expiresAt\` — no duplicate NDJSON line
- [ ] Verify payload on a host with no plugins / no credentials (mba/spartan/nas)

## Security notes

- \`expiresAt\` is a unix-ms integer; not a secret. Existing whitelist-only extractor + \`_check_no_secrets\` guard still block access/refresh tokens.
- \`mcp_servers\` surfaces URL host only, not full URLs, so query-string tokens in MCP configs are never exposed.
- New regression test \`test_expires_at_passes_secret_guard\` ensures the guard is not tripped by the new field.

Closes part of #52.

🤖 Generated with [Claude Code](https://claude.com/claude-code)