### PR TITLE
feat(orochi): runtime/ layout for workspaces + legacy-workdir fallback

### DIFF
--- a/src/scitex_agent_container/_skills/scitex-agent-container/config-v2.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/config-v2.md
@@ -34,7 +34,7 @@ spec:
 
 | Field | Derived as |
 |-------|-----------|
-| `workdir` | `~/.scitex/orochi/workspaces/{name}` |
+| `workdir` | `~/.scitex/orochi/runtime/workspaces/{name}` (legacy flat `~/.scitex/orochi/workspaces/{name}` / `~/.scitex/orochi/agents/{name}` kept if already present) |
 | `screen_name` | `{name}` |
 | `env.CLAUDE_AGENT_ID` | `{name}` |
 | `env.CLAUDE_AGENT_ROLE` | `{labels.role}` |

--- a/src/scitex_agent_container/_skills/scitex-agent-container/troubleshooting.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/troubleshooting.md
@@ -96,7 +96,7 @@ tmux send-keys -t <name> 1 Enter     # Select option 1
 ## Workspace CLAUDE.md marker abort (`WorkspaceCLAUDEMarkerError`)
 
 `scitex-agent-container start` refuses to deploy when the existing
-`~/.scitex/orochi/workspaces/<agent>/CLAUDE.md` is non-empty but does not
+`~/.scitex/orochi/runtime/workspaces/<agent>/CLAUDE.md` is non-empty but does not
 contain the canonical marker pair:
 
 ```
@@ -138,22 +138,23 @@ markerless non-empty file blocks the deploy.
 
 1. **Inspect first.** Check whether there is any content worth keeping:
    ```bash
-   cat ~/.scitex/orochi/workspaces/<agent>/CLAUDE.md
+   cat ~/.scitex/orochi/runtime/workspaces/<agent>/CLAUDE.md
    ```
    Typical placeholder is 5–10 lines of boilerplate; if so, nothing to save.
 2. **Back up custom tail** (if any real content exists):
    ```bash
-   cp ~/.scitex/orochi/workspaces/<agent>/CLAUDE.md \
-      ~/.scitex/orochi/workspaces/<agent>/CLAUDE.md.bak
+   cp ~/.scitex/orochi/runtime/workspaces/<agent>/CLAUDE.md \
+      ~/.scitex/orochi/runtime/workspaces/<agent>/CLAUDE.md.bak
    ```
 3. **Remove the unmarked file:**
    ```bash
-   rm ~/.scitex/orochi/workspaces/<agent>/CLAUDE.md
+   rm ~/.scitex/orochi/runtime/workspaces/<agent>/CLAUDE.md
    ```
 4. **Re-run start.** Deploy will now treat the workspace as empty and
    write a fresh managed section with both markers:
    ```bash
-   scitex-agent-container start ~/.scitex/orochi/agents/<agent>/<agent>.yaml
+   # shared definition (or swap `shared` -> `<host>` for a host-specific agent)
+   scitex-agent-container start ~/.scitex/orochi/shared/agents/<agent>/<agent>.yaml
    ```
 5. **Re-append custom tail** (if you backed up real content) **below** the
    End marker in the newly written file, not above it.

--- a/src/scitex_agent_container/agent_meta.py
+++ b/src/scitex_agent_container/agent_meta.py
@@ -4,9 +4,11 @@ Canonical source of truth for the metadata payload that is:
   1. Emitted by ``scitex-agent-container status <name> --json``.
   2. POSTed by the MCP sidecar heartbeat to ``/api/agents/register/``.
 
-Ported 2026-04-12 from
-``~/.scitex/orochi/agents/mamba-healer-mba/scripts/agent_meta.py``
-so collection logic lives in one place.
+Ported 2026-04-12 from the pre-restructure
+``~/.scitex/orochi/agents/mamba-healer-mba/scripts/agent_meta.py`` — the
+fleet script now lives at ``~/.scitex/orochi/shared/scripts/agent_meta.py``
+(2026-04-17 runtime/ layout) and shells out to this module via ``sac
+status --json``, so the collection logic still lives in one place.
 
 Every field is best-effort: any failure leaves the field as its default
 (``""``, ``0``, ``0.0``, ``[]``) and never raises. The caller merges this

--- a/src/scitex_agent_container/cli_pkg/lifecycle_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle_cmds.py
@@ -77,13 +77,11 @@ def _iter_agent_yamls(agents_dir: "Path") -> "list[tuple[str, str]]":
 def _discover_all_agents() -> list[str]:
     """Find all agent YAML files in the shared-host layout.
 
-    Search locations (host override > shared > legacy flat):
+    Search locations (host override > shared):
       1. ``~/.scitex/orochi/<HOST>/agents/<name>/<name>.yaml``
          (host-specific, wins if the same name exists elsewhere).
       2. ``~/.scitex/orochi/shared/agents/<name>/<name>.yaml``
          (fleet-shared).
-      3. ``~/.scitex/orochi/agents/<name>/<name>.yaml``
-         (legacy flat layout — still supported during migration).
 
     ``<HOST> = ${SCITEX_OROCHI_HOSTNAME:-$(hostname -s)}``. Names present in
     an earlier location shadow the same name in a later location, so a
@@ -103,9 +101,8 @@ def _discover_all_agents() -> list[str]:
 
     host_dir = root / host / "agents" if host else None
     shared_dir = root / "shared" / "agents"
-    legacy_dir = root / "agents"
 
-    for src_dir in (host_dir, shared_dir, legacy_dir):
+    for src_dir in (host_dir, shared_dir):
         if src_dir is None:
             continue
         for name, yaml_path in _iter_agent_yamls(src_dir):
@@ -122,7 +119,7 @@ def _discover_all_agents() -> list[str]:
     "start_all",
     is_flag=True,
     default=False,
-    help="Start all agents in ~/.scitex/orochi/agents/.",
+    help="Start all agents in ~/.scitex/orochi/<HOST>/agents/ and shared/agents/.",
 )
 @click.option(
     "--no-preflight",
@@ -144,7 +141,10 @@ def start(
     if start_all:
         yamls = _discover_all_agents()
         if not yamls:
-            console.print("[dim]No agents found in ~/.scitex/orochi/agents/[/dim]")
+            console.print(
+                "[dim]No agents found in "
+                "~/.scitex/orochi/<HOST>/agents/ or shared/agents/[/dim]"
+            )
             return
         try:
             current_host = resolve_hostname()

--- a/src/scitex_agent_container/cli_pkg/lifecycle_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle_cmds.py
@@ -77,11 +77,16 @@ def _iter_agent_yamls(agents_dir: "Path") -> "list[tuple[str, str]]":
 def _discover_all_agents() -> list[str]:
     """Find all agent YAML files in the shared-host layout.
 
-    Search locations (host override > shared):
+    Search locations for agent **definitions** (host override > shared):
       1. ``~/.scitex/orochi/<HOST>/agents/<name>/<name>.yaml``
          (host-specific, wins if the same name exists elsewhere).
       2. ``~/.scitex/orochi/shared/agents/<name>/<name>.yaml``
          (fleet-shared).
+
+    Note: per-agent runtime state (CLAUDE.md / .mcp.json / .claude/) lives at
+    ``~/.scitex/orochi/runtime/workspaces/<effective-id>/`` (see the 2026-04-17
+    layout). Only the definition search is host-aware; effective id composition
+    happens in ``config.compose_effective_name``.
 
     ``<HOST> = ${SCITEX_OROCHI_HOSTNAME:-$(hostname -s)}``. Names present in
     an earlier location shadow the same name in a later location, so a

--- a/src/scitex_agent_container/cli_pkg/lifecycle_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle_cmds.py
@@ -10,7 +10,8 @@ import traceback
 
 import click
 
-from ..config import load_config, resolve_config
+from ..config import AgentConfig, load_config, resolve_config
+from ..config._host import resolve_hostname
 from ..lifecycle import (
     agent_restart,
     agent_start,
@@ -20,24 +21,98 @@ from ..lifecycle import (
 from ..registry import Registry
 from ._helpers import console
 
+_SKIP_DIR_NAMES = {"legacy-agents", "shared", "GITIGNORED"}
 
-def _discover_all_agents() -> list[str]:
-    """Find all agent YAML files in ~/.scitex/orochi/agents/."""
-    from pathlib import Path
 
-    agents_dir = Path.home() / ".scitex" / "orochi" / "agents"
+def _singleton_skip_reason(config: AgentConfig, hostname: str) -> str | None:
+    """Return a human-readable skip reason if ``config`` is a singleton on
+    the wrong host, else None.
+
+    per-host mode never skips. Singleton without a preferred-host is a no-op
+    (launches anywhere). Singleton with preferred-host skips when the
+    current host doesn't match.
+    """
+    sched = config.scheduling
+    if sched.mode != "singleton":
+        return None
+    if not sched.preferred_host:
+        return None
+    if sched.preferred_host == hostname:
+        return None
+    fallback = (
+        f" (fallback-hosts: {', '.join(sched.fallback_hosts)})"
+        if sched.fallback_hosts
+        else ""
+    )
+    return (
+        f"singleton pinned to '{sched.preferred_host}', "
+        f"current host is '{hostname}'{fallback}"
+    )
+
+
+def _iter_agent_yamls(agents_dir: "Path") -> "list[tuple[str, str]]":
+    """Yield ``(name, yaml_path)`` for each agent subdir in ``agents_dir``.
+
+    Skips hidden dirs (``.`` / ``_``) and reserved names. Uses the
+    ``<agent>/<agent>.yaml`` convention; ``.yml`` is also accepted.
+    """
+    results: list[tuple[str, str]] = []
     if not agents_dir.exists():
-        return []
-    yamls = []
+        return results
     for d in sorted(agents_dir.iterdir()):
-        if not d.is_dir() or d.name.startswith((".", "legacy", "_")):
+        if not d.is_dir():
+            continue
+        if d.name.startswith((".", "_")):
+            continue
+        if d.name in _SKIP_DIR_NAMES:
             continue
         for ext in (".yaml", ".yml"):
             candidate = d / f"{d.name}{ext}"
             if candidate.exists():
-                yamls.append(str(candidate))
+                results.append((d.name, str(candidate)))
                 break
-    return yamls
+    return results
+
+
+def _discover_all_agents() -> list[str]:
+    """Find all agent YAML files in the shared-host layout.
+
+    Search locations (host override > shared > legacy flat):
+      1. ``~/.scitex/orochi/<HOST>/agents/<name>/<name>.yaml``
+         (host-specific, wins if the same name exists elsewhere).
+      2. ``~/.scitex/orochi/shared/agents/<name>/<name>.yaml``
+         (fleet-shared).
+      3. ``~/.scitex/orochi/agents/<name>/<name>.yaml``
+         (legacy flat layout — still supported during migration).
+
+    ``<HOST> = ${SCITEX_OROCHI_HOSTNAME:-$(hostname -s)}``. Names present in
+    an earlier location shadow the same name in a later location, so a
+    host-specific override of ``head`` beats the shared default. Returned
+    paths are sorted by effective agent name for stable ordering.
+    """
+    from pathlib import Path
+
+    root = Path.home() / ".scitex" / "orochi"
+    try:
+        host = resolve_hostname()
+    except RuntimeError:
+        host = ""
+
+    # name -> yaml path; later writes are ignored (earlier = higher priority).
+    found: dict[str, str] = {}
+
+    host_dir = root / host / "agents" if host else None
+    shared_dir = root / "shared" / "agents"
+    legacy_dir = root / "agents"
+
+    for src_dir in (host_dir, shared_dir, legacy_dir):
+        if src_dir is None:
+            continue
+        for name, yaml_path in _iter_agent_yamls(src_dir):
+            if name not in found:
+                found[name] = yaml_path
+
+    return [found[name] for name in sorted(found)]
 
 
 @click.command()
@@ -71,10 +146,18 @@ def start(
         if not yamls:
             console.print("[dim]No agents found in ~/.scitex/orochi/agents/[/dim]")
             return
+        try:
+            current_host = resolve_hostname()
+        except RuntimeError:
+            current_host = ""
         console.print(f"[blue]Starting {len(yamls)} agents...[/blue]")
         for yaml_path in yamls:
             try:
                 config = load_config(yaml_path)
+                skip = _singleton_skip_reason(config, current_host)
+                if skip:
+                    console.print(f"  [yellow]SKIP[/yellow] {config.name}: {skip}")
+                    continue
                 location = (
                     f"REMOTE: {config.remote.host}"
                     if config.remote.is_remote
@@ -102,6 +185,14 @@ def start(
     try:
         config_path = resolve_config(config_path)
         config = load_config(config_path)
+        try:
+            current_host = resolve_hostname()
+        except RuntimeError:
+            current_host = ""
+        skip = _singleton_skip_reason(config, current_host)
+        if skip:
+            console.print(f"[yellow]Skipping '{config.name}': {skip}[/yellow]")
+            return
         location = (
             f"REMOTE: {config.remote.host}" if config.remote.is_remote else "LOCAL"
         )

--- a/src/scitex_agent_container/config/__init__.py
+++ b/src/scitex_agent_container/config/__init__.py
@@ -12,7 +12,8 @@ from pathlib import Path
 
 import yaml
 
-from ._loaders import load_v1, load_v2
+from ._host import resolve_hostname, substitute_hostnames
+from ._loaders import compose_effective_name, load_v1, load_v2
 from ._resolve import resolve_config
 from ._types import (
     AgentConfig,
@@ -23,9 +24,10 @@ from ._types import (
     HookSpec,
     ListenPort,
     OrochiSpec,
-    RemoteSpec,
     ReadyPattern,
+    RemoteSpec,
     RestartSpec,
+    SchedulingSpec,
     SkillsSpec,
     StartupCommand,
     StartupSpec,
@@ -43,16 +45,20 @@ __all__ = [
     "HookSpec",
     "ListenPort",
     "OrochiSpec",
+    "ReadyPattern",
     "RemoteSpec",
     "RestartSpec",
-    "ReadyPattern",
+    "SchedulingSpec",
     "SkillsSpec",
     "StartupCommand",
     "StartupSpec",
     "TelegramSpec",
     "WatchdogSpec",
+    "compose_effective_name",
     "load_config",
     "resolve_config",
+    "resolve_hostname",
+    "substitute_hostnames",
     "validate_config",
 ]
 

--- a/src/scitex_agent_container/config/_host.py
+++ b/src/scitex_agent_container/config/_host.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import os
 import re
 import socket
+from pathlib import Path
 from typing import Any
 
 _HOSTNAME_TOKENS = ("HOSTNAME", "SCITEX_OROCHI_HOSTNAME")
@@ -28,16 +29,43 @@ _HOSTNAME_TOKENS = ("HOSTNAME", "SCITEX_OROCHI_HOSTNAME")
 # ourselves via resolve_hostname()).
 _PLACEHOLDER_RE = re.compile(r"\$\{(" + "|".join(_HOSTNAME_TOKENS) + r")\}")
 
+# Declarative fleet identity map lives in dotfiles-shipped config.yaml.
+_CONFIG_PATH = Path.home() / ".scitex" / "orochi" / "shared" / "config.yaml"
+
+
+def _load_hostname_aliases() -> dict[str, str]:
+    """Read ``spec.hostname_aliases`` from ``shared/config.yaml``.
+
+    Returns an empty dict if the file is missing, unparseable, lacks the
+    section, or the map isn't a dict. Never raises — hostname resolution
+    must still succeed via the identity fallback on a bare host.
+    """
+    if not _CONFIG_PATH.exists():
+        return {}
+    try:
+        import yaml  # PyYAML ships with the container; same import sac uses.
+    except ImportError:
+        return {}
+    try:
+        data = yaml.safe_load(_CONFIG_PATH.read_text()) or {}
+    except Exception:
+        return {}
+    aliases = (data.get("spec") or {}).get("hostname_aliases") or {}
+    if not isinstance(aliases, dict):
+        return {}
+    return {str(k): str(v) for k, v in aliases.items()}
+
 
 def resolve_hostname() -> str:
-    """Return the canonical hostname for this host.
+    """Return the canonical fleet label for this host.
 
     Resolution order (first non-empty wins):
-      1. ``SCITEX_OROCHI_HOSTNAME`` env var.
-      2. ``socket.gethostname()`` short form (first dot-separated component).
+      1. ``SCITEX_OROCHI_HOSTNAME`` env var (manual override).
+      2. ``hostname_aliases[short hostname]`` from ``shared/config.yaml``.
+      3. ``socket.gethostname()`` short form (identity fallback).
 
     Raises:
-        RuntimeError: If neither source produces a non-empty value. This
+        RuntimeError: If none of the three produces a non-empty value. This
             should be practically impossible (``gethostname()`` returns
             something on any configured box) but is handled loudly rather
             than returning the empty string.
@@ -46,11 +74,15 @@ def resolve_hostname() -> str:
     if env:
         return env
     hn = socket.gethostname()
-    if hn:
-        return hn.split(".", 1)[0]
+    short = hn.split(".", 1)[0] if hn else ""
+    aliases = _load_hostname_aliases()
+    if short and short in aliases:
+        return aliases[short]
+    if short:
+        return short
     raise RuntimeError(
-        "Cannot resolve hostname: SCITEX_OROCHI_HOSTNAME unset and "
-        "socket.gethostname() returned empty."
+        "Cannot resolve hostname: SCITEX_OROCHI_HOSTNAME unset, "
+        "socket.gethostname() empty, no config.yaml alias applicable."
     )
 
 

--- a/src/scitex_agent_container/config/_host.py
+++ b/src/scitex_agent_container/config/_host.py
@@ -1,0 +1,93 @@
+"""Hostname resolution and ${HOSTNAME} substitution for agent YAMLs.
+
+The fleet uses ``${SCITEX_OROCHI_HOSTNAME:-$(hostname -s)}`` as the canonical
+hostname (env var wins, short hostname is the fallback). Shared agent
+definitions under ``shared/agents/`` may reference ``${HOSTNAME}`` or
+``${SCITEX_OROCHI_HOSTNAME}`` so the same YAML can be launched on every
+host without drift.
+
+Design constraints:
+* Missing vars are a loud error (no silent empty string).
+* Substitution happens after YAML parse, before dataclass construction, so
+  every string field is covered (metadata labels, env values, hook command
+  strings, scheduling.preferred-host, etc.).
+* Only ``${HOSTNAME}`` and ``${SCITEX_OROCHI_HOSTNAME}`` are substituted by
+  this module — other ``${...}`` placeholders (e.g. ``${SCITEX_OROCHI_TOKEN}``
+  handled by mcp interpolation) are left alone.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import socket
+from typing import Any
+
+_HOSTNAME_TOKENS = ("HOSTNAME", "SCITEX_OROCHI_HOSTNAME")
+# Match ${VAR} exactly (no :- default expressions — we resolve hostname
+# ourselves via resolve_hostname()).
+_PLACEHOLDER_RE = re.compile(r"\$\{(" + "|".join(_HOSTNAME_TOKENS) + r")\}")
+
+
+def resolve_hostname() -> str:
+    """Return the canonical hostname for this host.
+
+    Resolution order (first non-empty wins):
+      1. ``SCITEX_OROCHI_HOSTNAME`` env var.
+      2. ``socket.gethostname()`` short form (first dot-separated component).
+
+    Raises:
+        RuntimeError: If neither source produces a non-empty value. This
+            should be practically impossible (``gethostname()`` returns
+            something on any configured box) but is handled loudly rather
+            than returning the empty string.
+    """
+    env = os.environ.get("SCITEX_OROCHI_HOSTNAME", "").strip()
+    if env:
+        return env
+    hn = socket.gethostname()
+    if hn:
+        return hn.split(".", 1)[0]
+    raise RuntimeError(
+        "Cannot resolve hostname: SCITEX_OROCHI_HOSTNAME unset and "
+        "socket.gethostname() returned empty."
+    )
+
+
+def _substitute_string(value: str, hostname: str) -> str:
+    """Replace ${HOSTNAME} / ${SCITEX_OROCHI_HOSTNAME} in a string.
+
+    Other ``${...}`` placeholders are preserved as-is so downstream code
+    (e.g. mcp interpolation) keeps working.
+    """
+
+    def _repl(match: "re.Match[str]") -> str:
+        # hostname always resolves — resolve_hostname() has already succeeded
+        # or raised. The placeholder set is closed, so we don't need to
+        # handle "missing var" inside the callback.
+        return hostname
+
+    return _PLACEHOLDER_RE.sub(_repl, value)
+
+
+def substitute_hostnames(obj: Any, hostname: str | None = None) -> Any:
+    """Recursively walk a dict/list/str and substitute hostname placeholders.
+
+    Non-string leaves (int, bool, None) are returned unchanged. The walk is
+    pure-functional — the input is not mutated; a new structure is returned.
+
+    Args:
+        obj: YAML-parsed structure (dict/list/scalar).
+        hostname: Override hostname (for tests). If None, calls
+            ``resolve_hostname()``.
+    """
+    if hostname is None:
+        hostname = resolve_hostname()
+
+    if isinstance(obj, str):
+        return _substitute_string(obj, hostname)
+    if isinstance(obj, dict):
+        return {k: substitute_hostnames(v, hostname) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [substitute_hostnames(item, hostname) for item in obj]
+    return obj

--- a/src/scitex_agent_container/config/_loaders.py
+++ b/src/scitex_agent_container/config/_loaders.py
@@ -39,6 +39,12 @@ from ._types import AgentConfig, SchedulingSpec
 # (head-nas msg#12877; head-mba msg#12879 root cause).
 _VENV_AUTO_FALLBACK_CHAIN = ("~/.venv-3.11", "~/.venv")
 
+# Default workdir layout (2026-04-17 runtime/ restructure). Definitions ship
+# under ``shared/agents/<name>/`` or ``<host>/agents/<name>/``; per-agent
+# runtime state (CLAUDE.md, .mcp.json, .claude/) lives at
+# ``runtime/workspaces/<effective-id>/``.
+_DEFAULT_WORKDIR_RUNTIME = "~/.scitex/orochi/runtime/workspaces/{name}"
+
 
 def _resolve_venv(venv: str) -> str:
     """Resolve `venv: auto` to the first existing virtualenv on this host.
@@ -148,8 +154,11 @@ def load_v2(raw: dict, path: Path) -> AgentConfig:
     else:
         name = raw_name
 
-    # Auto-derive workdir (user can override)
-    workdir = spec.get("workdir", f"~/.scitex/orochi/workspaces/{name}")
+    # Auto-derive workdir (user can override).
+    # Default lives under runtime/workspaces/ (2026-04-17 layout).
+    workdir = spec.get("workdir")
+    if workdir is None:
+        workdir = _DEFAULT_WORKDIR_RUNTIME.format(name=name)
 
     # Auto-derive screen_name: {name} (not cld-{name})
     screen_raw = spec.get("screen", {}) or {}

--- a/src/scitex_agent_container/config/_loaders.py
+++ b/src/scitex_agent_container/config/_loaders.py
@@ -4,6 +4,29 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from ._host import resolve_hostname, substitute_hostnames
+from ._parsers import (
+    MODEL_DISPLAY_NAMES,
+    interpolate_mcp_servers,
+    parse_claude,
+    parse_container,
+    parse_context_management,
+    parse_extensions,
+    parse_health,
+    parse_hooks,
+    parse_listen,
+    parse_orochi,
+    parse_remote,
+    parse_restart,
+    parse_scheduling,
+    parse_skills,
+    parse_startup,
+    parse_startup_commands,
+    parse_telegram,
+    parse_watchdog,
+)
+from ._types import AgentConfig, SchedulingSpec
+
 # Host-aware fallback chain for `venv: auto` resolution.
 # Tried in order; first existing path wins. Empty string means no venv
 # activation (raw shell). The chain is intentionally short and biased
@@ -34,26 +57,25 @@ def _resolve_venv(venv: str) -> str:
     return ""
 
 
-from ._parsers import (
-    MODEL_DISPLAY_NAMES,
-    interpolate_mcp_servers,
-    parse_claude,
-    parse_container,
-    parse_context_management,
-    parse_extensions,
-    parse_health,
-    parse_hooks,
-    parse_listen,
-    parse_orochi,
-    parse_remote,
-    parse_restart,
-    parse_skills,
-    parse_startup,
-    parse_startup_commands,
-    parse_telegram,
-    parse_watchdog,
-)
-from ._types import AgentConfig
+def compose_effective_name(
+    raw_name: str, scheduling: SchedulingSpec | None, hostname: str
+) -> str:
+    """Return the effective agent id given metadata.name + scheduling + host.
+
+    Rules:
+      * ``singleton`` mode: the bare ``raw_name`` (host-pin is enforced at
+        launch time, not encoded in the id).
+      * ``per-host`` mode (default): append ``-<hostname>`` unless the name
+        already ends with ``-<hostname>`` (idempotent — protects legacy
+        flat-layout names like ``head-ywata-note-win`` which are already
+        host-suffixed).
+    """
+    if scheduling is not None and scheduling.mode == "singleton":
+        return raw_name
+    suffix = f"-{hostname}"
+    if raw_name.endswith(suffix) or raw_name == hostname:
+        return raw_name
+    return f"{raw_name}{suffix}"
 
 
 def load_v1(raw: dict, path: Path) -> AgentConfig:
@@ -94,11 +116,37 @@ def load_v1(raw: dict, path: Path) -> AgentConfig:
 
 
 def load_v2(raw: dict, path: Path) -> AgentConfig:
-    """Load a scitex-agent-container/v2 config with auto-derived defaults."""
+    """Load a scitex-agent-container/v2 config with auto-derived defaults.
+
+    Substitutes ``${HOSTNAME}`` / ``${SCITEX_OROCHI_HOSTNAME}`` in every
+    string field before dataclass construction, and composes the effective
+    agent id from ``metadata.name`` + ``spec.scheduling`` so the v2 shared
+    layout can keep one canonical YAML per role across the fleet.
+    """
+    # Only walk-and-substitute hostname placeholders when the YAML opts in
+    # via an explicit ``spec.scheduling`` block. Legacy v2 YAMLs without
+    # scheduling keep the pre-change code path (no substitution, no
+    # effective-id composition, no host resolution required).
+    scheduling, explicit_scheduling = parse_scheduling(raw.get("spec", {}) or {})
+
+    if explicit_scheduling:
+        hostname = resolve_hostname()
+        raw = substitute_hostnames(raw, hostname)
+    else:
+        hostname = ""
+
     metadata = raw.get("metadata", {})
     spec = raw.get("spec", {})
-    name = metadata["name"]
+    raw_name = metadata["name"]
     labels = metadata.get("labels", {}) or {}
+
+    # Compose the effective id used everywhere downstream (systemd, screen/
+    # tmux, workdir, registry keys). Only when scheduling is explicit —
+    # otherwise keep the raw metadata.name as-is for backward compatibility.
+    if explicit_scheduling:
+        name = compose_effective_name(raw_name, scheduling, hostname)
+    else:
+        name = raw_name
 
     # Auto-derive workdir (user can override)
     workdir = spec.get("workdir", f"~/.scitex/orochi/workspaces/{name}")
@@ -128,8 +176,9 @@ def load_v2(raw: dict, path: Path) -> AgentConfig:
     if mkdir_cmd not in hooks.get("pre_start", []):
         hooks.setdefault("pre_start", []).insert(0, mkdir_cmd)
 
-    # Parse mcp_servers with metadata interpolation
-    mcp_servers = interpolate_mcp_servers(spec.get("mcp_servers", {}), metadata)
+    # Parse mcp_servers with metadata interpolation (uses effective name)
+    mcp_metadata = {**metadata, "name": name}
+    mcp_servers = interpolate_mcp_servers(spec.get("mcp_servers", {}), mcp_metadata)
 
     return AgentConfig(
         name=name,
@@ -157,5 +206,6 @@ def load_v2(raw: dict, path: Path) -> AgentConfig:
         extensions=parse_extensions(spec),
         mcp_servers=mcp_servers,
         multiplexer=spec.get("multiplexer", "screen"),
+        scheduling=scheduling,
         config_path=str(path),
     )

--- a/src/scitex_agent_container/config/_parsers.py
+++ b/src/scitex_agent_container/config/_parsers.py
@@ -15,12 +15,50 @@ from ._types import (
     ReadyPattern,
     RemoteSpec,
     RestartSpec,
+    SchedulingSpec,
     SkillsSpec,
     StartupCommand,
     StartupSpec,
     TelegramSpec,
     WatchdogSpec,
 )
+
+_VALID_SCHEDULING_MODES = ("per-host", "singleton")
+
+
+def parse_scheduling(spec: dict) -> tuple[SchedulingSpec, bool]:
+    """Parse ``spec.scheduling`` block (new shared-host layout).
+
+    Returns a ``(scheduling, explicit)`` tuple. ``explicit`` is True iff
+    the YAML declared a ``spec.scheduling`` key — this gates effective-id
+    composition so legacy v2 YAMLs (no scheduling block, ``metadata.name``
+    already baked with host) remain byte-identical to pre-change behavior.
+    """
+    if "scheduling" not in spec:
+        return SchedulingSpec(), False
+    raw = spec.get("scheduling") or {}
+    if not isinstance(raw, dict):
+        raise ValueError(f"spec.scheduling must be a mapping, got {type(raw).__name__}")
+    mode = raw.get("mode", "per-host") or "per-host"
+    if mode not in _VALID_SCHEDULING_MODES:
+        raise ValueError(
+            f"spec.scheduling.mode must be one of {_VALID_SCHEDULING_MODES}, "
+            f"got {mode!r}"
+        )
+    preferred = raw.get("preferred-host", raw.get("preferred_host", "")) or ""
+    fallback_raw = raw.get("fallback-hosts", raw.get("fallback_hosts", [])) or []
+    if isinstance(fallback_raw, str):
+        fallback_raw = [fallback_raw]
+    fallback = [str(h) for h in fallback_raw]
+    return (
+        SchedulingSpec(
+            mode=mode,
+            preferred_host=str(preferred),
+            fallback_hosts=fallback,
+        ),
+        True,
+    )
+
 
 # All known hook keys. Unknown keys in the YAML are ignored (forward-compat).
 HOOK_KEYS = (
@@ -284,7 +322,9 @@ def parse_startup(spec: dict) -> StartupSpec:
     except (TypeError, ValueError):
         timeout = 60.0
 
-    on_timeout = str(raw.get("on_timeout", "capture_and_proceed") or "capture_and_proceed")
+    on_timeout = str(
+        raw.get("on_timeout", "capture_and_proceed") or "capture_and_proceed"
+    )
     if on_timeout not in ("capture_and_fail", "capture_and_proceed"):
         on_timeout = "capture_and_proceed"
 

--- a/src/scitex_agent_container/config/_resolve.py
+++ b/src/scitex_agent_container/config/_resolve.py
@@ -27,8 +27,8 @@ def _search_dirs() -> Tuple[Path, List[Path], List[Path]]:
     """Return (legacy_dir, env_dirs, fleet_dirs) with ~ expansion.
 
     ``fleet_dirs`` is the ordered list of fleet locations searched after
-    env overrides. Order = host-specific first, then shared, then
-    legacy-flat (both under ~/.scitex/orochi and ~/.dotfiles/src/.scitex/orochi).
+    env overrides. Order = host-specific first, then shared (both under
+    ~/.scitex/orochi and ~/.dotfiles/src/.scitex/orochi).
     """
     home = Path(os.path.expanduser("~"))
     legacy = home / ".scitex" / "agent-container" / "agents"
@@ -45,7 +45,6 @@ def _search_dirs() -> Tuple[Path, List[Path], List[Path]]:
         if host:
             fleet_dirs.append(root / host / "agents")
         fleet_dirs.append(root / "shared" / "agents")
-        fleet_dirs.append(root / "agents")
     return legacy, env_dirs, fleet_dirs
 
 
@@ -71,7 +70,6 @@ def resolve_config(name_or_path: str) -> str:
          (~/.scitex/orochi, ~/.dotfiles/src/.scitex/orochi):
              a. ``<root>/<HOST>/agents/<name>/<name>.yaml`` (host override)
              b. ``<root>/shared/agents/<name>/<name>.yaml`` (shared default)
-             c. ``<root>/agents/<name>/<name>.yaml`` (legacy flat layout)
 
     Absolute paths and explicit .yaml/.yml paths are returned as-is if they
     exist (unchanged behavior).

--- a/src/scitex_agent_container/config/_resolve.py
+++ b/src/scitex_agent_container/config/_resolve.py
@@ -6,20 +6,47 @@ import os
 from pathlib import Path
 from typing import List, Tuple
 
-
 _ENV_VAR = "SCITEX_AGENT_CONTAINER_YAML_DIRS"
 
 
-def _search_dirs() -> Tuple[Path, List[Path], Path]:
-    """Return (legacy_dir, env_dirs, dotfiles_dir) with ~ expansion."""
+def _resolve_host() -> str:
+    """Return ${SCITEX_OROCHI_HOSTNAME:-$(hostname -s)} (empty on failure)."""
+    env = os.environ.get("SCITEX_OROCHI_HOSTNAME", "").strip()
+    if env:
+        return env
+    try:
+        import socket
+
+        hn = socket.gethostname()
+        return hn.split(".", 1)[0] if hn else ""
+    except Exception:
+        return ""
+
+
+def _search_dirs() -> Tuple[Path, List[Path], List[Path]]:
+    """Return (legacy_dir, env_dirs, fleet_dirs) with ~ expansion.
+
+    ``fleet_dirs`` is the ordered list of fleet locations searched after
+    env overrides. Order = host-specific first, then shared, then
+    legacy-flat (both under ~/.scitex/orochi and ~/.dotfiles/src/.scitex/orochi).
+    """
     home = Path(os.path.expanduser("~"))
     legacy = home / ".scitex" / "agent-container" / "agents"
     env_raw = os.environ.get(_ENV_VAR, "")
-    env_dirs = [
-        Path(os.path.expanduser(p)) for p in env_raw.split(":") if p.strip()
+    env_dirs = [Path(os.path.expanduser(p)) for p in env_raw.split(":") if p.strip()]
+
+    host = _resolve_host()
+    fleet_roots = [
+        home / ".scitex" / "orochi",
+        home / ".dotfiles" / "src" / ".scitex" / "orochi",
     ]
-    dotfiles = home / ".dotfiles" / "src" / ".scitex" / "orochi" / "agents"
-    return legacy, env_dirs, dotfiles
+    fleet_dirs: list[Path] = []
+    for root in fleet_roots:
+        if host:
+            fleet_dirs.append(root / host / "agents")
+        fleet_dirs.append(root / "shared" / "agents")
+        fleet_dirs.append(root / "agents")
+    return legacy, env_dirs, fleet_dirs
 
 
 def _try_dir(base: Path, name: str) -> str | None:
@@ -40,7 +67,11 @@ def resolve_config(name_or_path: str) -> str:
     Search order for short names (no slash, no .yaml/.yml suffix):
       1. ~/.scitex/agent-container/agents/<name>.yaml  (operator override)
       2. $SCITEX_AGENT_CONTAINER_YAML_DIRS (colon-separated extra dirs)
-      3. ~/.dotfiles/src/.scitex/orochi/agents/<name>/<name>.yaml (fleet fallback)
+      3. Fleet layout — for each root in
+         (~/.scitex/orochi, ~/.dotfiles/src/.scitex/orochi):
+             a. ``<root>/<HOST>/agents/<name>/<name>.yaml`` (host override)
+             b. ``<root>/shared/agents/<name>/<name>.yaml`` (shared default)
+             c. ``<root>/agents/<name>/<name>.yaml`` (legacy flat layout)
 
     Absolute paths and explicit .yaml/.yml paths are returned as-is if they
     exist (unchanged behavior).
@@ -51,7 +82,7 @@ def resolve_config(name_or_path: str) -> str:
             return str(p)
         raise FileNotFoundError(f"Config file not found: {name_or_path}")
 
-    legacy, env_dirs, dotfiles = _search_dirs()
+    legacy, env_dirs, fleet_dirs = _search_dirs()
 
     hit = _try_dir(legacy, name_or_path)
     if hit:
@@ -60,17 +91,21 @@ def resolve_config(name_or_path: str) -> str:
         hit = _try_dir(d, name_or_path)
         if hit:
             return hit
-    hit = _try_dir(dotfiles, name_or_path)
-    if hit:
-        return hit
+    for d in fleet_dirs:
+        hit = _try_dir(d, name_or_path)
+        if hit:
+            return hit
 
     env_line = (
         f"  (env ${_ENV_VAR}: "
         f"{', '.join(str(d) for d in env_dirs) if env_dirs else '<unset>'})"
     )
+    fleet_lines = "\n".join(
+        f"  {d}/{name_or_path}/{name_or_path}.yaml" for d in fleet_dirs
+    )
     raise FileNotFoundError(
         f"Agent '{name_or_path}' not found. Searched:\n"
         f"  {legacy}/{name_or_path}.yaml\n"
         f"{env_line}\n"
-        f"  {dotfiles}/{name_or_path}/{name_or_path}.yaml"
+        f"{fleet_lines}"
     )

--- a/src/scitex_agent_container/config/_types.py
+++ b/src/scitex_agent_container/config/_types.py
@@ -123,6 +123,27 @@ class SkillsSpec:
 
 
 @dataclass
+class SchedulingSpec:
+    """Fleet-wide scheduling policy for an agent (shared-host layout).
+
+    ``mode`` controls effective-id composition and launch-skip behavior:
+      * ``per-host`` (default): agent is started on every host that runs
+        ``sac start <name>``; the effective id is ``<metadata.name>-<HOST>``
+        unless the name already ends with ``-<HOST>``.
+      * ``singleton``: exactly one instance fleet-wide. The effective id
+        stays as the bare ``<metadata.name>``. Only launched on
+        ``preferred-host``; on other hosts the launch is a no-op.
+
+    ``fallback-hosts`` is recorded for observability but not acted on
+    automatically — manual failover today.
+    """
+
+    mode: str = "per-host"
+    preferred_host: str = ""
+    fallback_hosts: list[str] = field(default_factory=list)
+
+
+@dataclass
 class ListenPort:
     """Declaration of a port/socket an external tool binds on behalf of an agent.
 
@@ -233,6 +254,7 @@ class AgentConfig:
     startup: "StartupSpec" = field(default_factory=lambda: StartupSpec())
     mcp_servers: dict[str, dict] = field(default_factory=dict)
     multiplexer: str = "tmux"  # "tmux" (default) or "screen"
+    scheduling: SchedulingSpec = field(default_factory=SchedulingSpec)
     config_path: str = ""
 
     def __post_init__(self) -> None:

--- a/src/scitex_agent_container/context_manager.py
+++ b/src/scitex_agent_container/context_manager.py
@@ -47,7 +47,8 @@ def parse_context_percent(pane_text: str) -> float | None:
     return None
 
 
-_DEFAULT_AGENT_META_SCRIPT = "~/.scitex/orochi/scripts/agent_meta.py"
+# 2026-04-17 runtime/ layout: client scripts live under shared/scripts/.
+_DEFAULT_AGENT_META_SCRIPT = "~/.scitex/orochi/shared/scripts/agent_meta.py"
 
 
 def fetch_agent_meta(
@@ -60,11 +61,8 @@ def fetch_agent_meta(
     overridden via the ``SCITEX_AGENT_META_SCRIPT`` env var or the
     ``script_path`` argument (argument wins).
     """
-    path = (
-        script_path
-        or os.environ.get("SCITEX_AGENT_META_SCRIPT")
-        or _DEFAULT_AGENT_META_SCRIPT
-    )
+    explicit = script_path or os.environ.get("SCITEX_AGENT_META_SCRIPT")
+    path = explicit if explicit else _DEFAULT_AGENT_META_SCRIPT
     resolved = str(Path(path).expanduser())
     try:
         r = subprocess.run(
@@ -82,7 +80,9 @@ def fetch_agent_meta(
     ):
         return None
     try:
-        data = json.loads(r.stdout.strip().splitlines()[-1]) if r.stdout.strip() else None
+        data = (
+            json.loads(r.stdout.strip().splitlines()[-1]) if r.stdout.strip() else None
+        )
     except (json.JSONDecodeError, IndexError):
         return None
     if not isinstance(data, dict):
@@ -312,9 +312,7 @@ def default_dispatcher(strategy: str, agent_config: AgentConfig | None) -> None:
         try:
             agent_restart(agent_config.name)
         except Exception:
-            logger.exception(
-                "context_manager[%s]: restart failed", agent_config.name
-            )
+            logger.exception("context_manager[%s]: restart failed", agent_config.name)
         return
 
     # "noop" or unknown — nothing to do.

--- a/src/scitex_agent_container/lifecycle.py
+++ b/src/scitex_agent_container/lifecycle.py
@@ -22,6 +22,14 @@ def _get_runtime(config: AgentConfig):
     raise ValueError(f"Unsupported runtime: {config.runtime}")
 
 
+def _fallback_workdir(name: str) -> str:
+    """Return the workdir path used when the agent's YAML can't be loaded.
+
+    Canonical 2026-04-17 layout: ``~/.scitex/orochi/runtime/workspaces/<id>/``.
+    """
+    return str(Path.home() / ".scitex" / "orochi" / "runtime" / "workspaces" / name)
+
+
 def _fire_forget_hook(
     agent_name: str,
     hook_name: str,
@@ -385,11 +393,7 @@ def agent_status(name: str, registry: Registry | None = None) -> dict:
     try:
         from .agent_meta import collect_rich
 
-        workdir = (
-            config.expanded_workdir
-            if config
-            else str(Path.home() / ".scitex" / "orochi" / "workspaces" / name)
-        )
+        workdir = config.expanded_workdir if config else _fallback_workdir(name)
         session = entry.get("screen", "") or (config.screen_name if config else name)
         rich = collect_rich(name=name, workdir=workdir, session=session)
         # Prefer transcript-derived started_at only if the registry

--- a/src/scitex_agent_container/runtimes/sbatch_spartan.py
+++ b/src/scitex_agent_container/runtimes/sbatch_spartan.py
@@ -40,7 +40,6 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import List
 
-
 # ---------------------------------------------------------------------------
 # Required hardeners — these strings are asserted by the regression test.
 # Changing them here without updating the test is a deliberate decision.
@@ -73,14 +72,14 @@ class SpartanSbatchConfig:
     orochi_channels: str = (
         "#neurovista,#ywatanabe,#general,#agent,#progress,#escalation"
     )
-    workdir: str = "$HOME/.scitex/orochi/workspaces/head-spartan"
+    workdir: str = "$HOME/.scitex/orochi/runtime/workspaces/head-spartan"
     claude_bin: str = "$HOME/.npm-global/bin/claude"
     claude_model: str = "opus[1m]"
     extra_add_dirs: List[str] = field(
         default_factory=lambda: [
             "$HOME/proj/scitex-agent-container/src/scitex_agent_container/_skills/",
             "$HOME/proj/scitex-orochi/src/scitex_orochi/_skills/",
-            "$HOME/.scitex/orochi/skills/",
+            "$HOME/.scitex/orochi/shared/skills/",
         ]
     )
     # Extra safety buffer: even if tail -f /dev/null somehow exits,
@@ -137,7 +136,7 @@ def render_sbatch_script(cfg: SpartanSbatchConfig | None = None) -> str:
     trap_block = ""
     if cfg.trap_on_exit:
         trap_block = (
-            '\n# Fail loud if we ever fall through the hold below.\n'
+            "\n# Fail loud if we ever fall through the hold below.\n"
             'trap \'rc=$?; echo "[todo#425] wrapper exiting with rc=$rc at $(date -u +%FT%TZ)" >&2; '
             'exit "${rc:-1}"\' EXIT\n'
         )

--- a/tests/test_config_v2.py
+++ b/tests/test_config_v2.py
@@ -66,10 +66,11 @@ V2_WITH_MCP = {
 
 
 class TestV2Config:
-    def test_v2_auto_derived_workdir(self):
+    def test_v2_auto_derived_workdir(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HOME", str(tmp_path))
         path = _write_config(MINIMAL_V2_CONFIG)
         config = load_config(path)
-        assert config.workdir == "~/.scitex/orochi/workspaces/head-test"
+        assert config.workdir == "~/.scitex/orochi/runtime/workspaces/head-test"
         Path(path).unlink()
 
     def test_v2_screen_name(self):
@@ -451,9 +452,7 @@ class TestVenvAutoResolution:
         v = tmp_path / "v"
         (v / "bin").mkdir(parents=True)
         (v / "bin" / "activate").write_text("# fake")
-        monkeypatch.setattr(
-            _loaders, "_VENV_AUTO_FALLBACK_CHAIN", (str(v),)
-        )
+        monkeypatch.setattr(_loaders, "_VENV_AUTO_FALLBACK_CHAIN", (str(v),))
 
         assert _loaders._resolve_venv("auto") == str(v)
         assert _loaders._resolve_venv("AUTO") == str(v)
@@ -467,9 +466,7 @@ class TestVenvAutoResolution:
         v = tmp_path / "venv-target"
         (v / "bin").mkdir(parents=True)
         (v / "bin" / "activate").write_text("# fake")
-        monkeypatch.setattr(
-            _loaders, "_VENV_AUTO_FALLBACK_CHAIN", (str(v),)
-        )
+        monkeypatch.setattr(_loaders, "_VENV_AUTO_FALLBACK_CHAIN", (str(v),))
 
         data = {
             "apiVersion": "scitex-agent-container/v2",

--- a/tests/test_resolve_config.py
+++ b/tests/test_resolve_config.py
@@ -27,7 +27,7 @@ def _legacy(home: Path) -> Path:
 
 
 def _dotfiles(home: Path) -> Path:
-    return home / ".dotfiles" / "src" / ".scitex" / "orochi" / "agents"
+    return home / ".dotfiles" / "src" / ".scitex" / "orochi" / "shared" / "agents"
 
 
 def test_resolve_config_prefers_legacy_path_over_dotfiles(fake_home):
@@ -54,15 +54,11 @@ def test_resolve_config_env_var_colon_separated(fake_home, monkeypatch):
     d2 = fake_home / "d2"
     d1.mkdir()
     expected = _write(d2 / "foo.yaml", "d2")
-    monkeypatch.setenv(
-        "SCITEX_AGENT_CONTAINER_YAML_DIRS", f"{d1}:{d2}"
-    )
+    monkeypatch.setenv("SCITEX_AGENT_CONTAINER_YAML_DIRS", f"{d1}:{d2}")
     assert resolve_config("foo") == str(expected)
 
 
-def test_resolve_config_not_found_lists_all_searched_paths(
-    fake_home, monkeypatch
-):
+def test_resolve_config_not_found_lists_all_searched_paths(fake_home, monkeypatch):
     monkeypatch.setenv(
         "SCITEX_AGENT_CONTAINER_YAML_DIRS", f"{fake_home}/a:{fake_home}/b"
     )
@@ -73,7 +69,7 @@ def test_resolve_config_not_found_lists_all_searched_paths(
     assert "SCITEX_AGENT_CONTAINER_YAML_DIRS" in msg
     assert f"{fake_home}/a" in msg
     assert f"{fake_home}/b" in msg
-    assert ".dotfiles/src/.scitex/orochi/agents" in msg
+    assert ".dotfiles/src/.scitex/orochi/shared/agents" in msg
     assert "missing" in msg
 
 

--- a/tests/test_shared_host_layout.py
+++ b/tests/test_shared_host_layout.py
@@ -1,0 +1,444 @@
+"""Tests for the shared-host fleet layout (feat/orochi-shared-host-layout).
+
+Covers:
+  * Agent discovery (host override > shared > legacy flat).
+  * ``${HOSTNAME}`` / ``${SCITEX_OROCHI_HOSTNAME}`` substitution.
+  * Effective-id composition for ``per-host`` vs ``singleton`` scheduling.
+  * Singleton launch-skip decision on non-preferred hosts.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+import yaml
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_home(monkeypatch, tmp_path):
+    """Redirect ~ to tmp_path and unset env overrides."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("SCITEX_AGENT_CONTAINER_YAML_DIRS", raising=False)
+    # Default the canonical hostname to a stable value for determinism.
+    monkeypatch.setenv("SCITEX_OROCHI_HOSTNAME", "ywata-note-win")
+    return tmp_path
+
+
+def _write_agent_yaml(
+    base: Path,
+    name: str,
+    *,
+    metadata_name: str | None = None,
+    scheduling: dict | None = None,
+    extra_labels: dict | None = None,
+) -> Path:
+    """Write ``<base>/<name>/<name>.yaml`` and return its path."""
+    data: dict = {
+        "apiVersion": "scitex-agent-container/v2",
+        "kind": "Agent",
+        "metadata": {
+            "name": metadata_name if metadata_name is not None else name,
+            "labels": {"role": "head", **(extra_labels or {})},
+        },
+        "spec": {
+            "runtime": "claude-code",
+            "model": "sonnet",
+        },
+    }
+    if scheduling is not None:
+        data["spec"]["scheduling"] = scheduling
+    dest = base / name / f"{name}.yaml"
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text(yaml.safe_dump(data))
+    return dest
+
+
+# ---------------------------------------------------------------------------
+# 1. Agent discovery
+# ---------------------------------------------------------------------------
+
+
+class TestDiscovery:
+    def test_discovery_finds_shared_agents(self, fake_home):
+        from scitex_agent_container.cli_pkg.lifecycle_cmds import (
+            _discover_all_agents,
+        )
+
+        shared = fake_home / ".scitex" / "orochi" / "shared" / "agents"
+        _write_agent_yaml(shared, "head")
+
+        hits = _discover_all_agents()
+        assert len(hits) == 1
+        assert hits[0].endswith("shared/agents/head/head.yaml")
+
+    def test_discovery_finds_legacy_flat_agents(self, fake_home):
+        """Legacy flat ~/.scitex/orochi/agents/<name>/<name>.yaml still works."""
+        from scitex_agent_container.cli_pkg.lifecycle_cmds import (
+            _discover_all_agents,
+        )
+
+        legacy = fake_home / ".scitex" / "orochi" / "agents"
+        _write_agent_yaml(legacy, "healer")
+
+        hits = _discover_all_agents()
+        assert len(hits) == 1
+        assert hits[0].endswith("orochi/agents/healer/healer.yaml")
+
+    def test_discovery_host_override_wins_over_shared(self, fake_home):
+        """Host-specific dir wins over shared for the same agent name."""
+        from scitex_agent_container.cli_pkg.lifecycle_cmds import (
+            _discover_all_agents,
+        )
+
+        shared = fake_home / ".scitex" / "orochi" / "shared" / "agents"
+        host = fake_home / ".scitex" / "orochi" / "ywata-note-win" / "agents"
+        _write_agent_yaml(shared, "head", extra_labels={"tier": "shared"})
+        _write_agent_yaml(host, "head", extra_labels={"tier": "host"})
+
+        hits = _discover_all_agents()
+        assert len(hits) == 1
+        # Host override wins.
+        assert "ywata-note-win/agents/head/head.yaml" in hits[0]
+
+    def test_discovery_shared_wins_over_legacy(self, fake_home):
+        """Shared dir shadows the old flat legacy agents/ location."""
+        from scitex_agent_container.cli_pkg.lifecycle_cmds import (
+            _discover_all_agents,
+        )
+
+        shared = fake_home / ".scitex" / "orochi" / "shared" / "agents"
+        legacy = fake_home / ".scitex" / "orochi" / "agents"
+        _write_agent_yaml(shared, "head")
+        _write_agent_yaml(legacy, "head")
+
+        hits = _discover_all_agents()
+        assert len(hits) == 1
+        assert "shared/agents/head/head.yaml" in hits[0]
+
+    def test_discovery_merges_when_names_differ(self, fake_home):
+        """Different names across layers all surface; same name is shadowed."""
+        from scitex_agent_container.cli_pkg.lifecycle_cmds import (
+            _discover_all_agents,
+        )
+
+        shared = fake_home / ".scitex" / "orochi" / "shared" / "agents"
+        legacy = fake_home / ".scitex" / "orochi" / "agents"
+        _write_agent_yaml(shared, "head")
+        _write_agent_yaml(legacy, "mamba-old-agent")
+
+        hits = _discover_all_agents()
+        assert len(hits) == 2
+        names = {Path(h).parent.name for h in hits}
+        assert names == {"head", "mamba-old-agent"}
+
+    def test_discovery_skips_hidden_and_reserved(self, fake_home):
+        """Dirs starting with . / _ and reserved names are ignored."""
+        from scitex_agent_container.cli_pkg.lifecycle_cmds import (
+            _discover_all_agents,
+        )
+
+        root = fake_home / ".scitex" / "orochi"
+        legacy = root / "agents"
+        for skip_name in (".hidden", "_private", "legacy-agents", "GITIGNORED"):
+            _write_agent_yaml(legacy, skip_name)
+        _write_agent_yaml(legacy, "real")
+        # shared-level reserved names are skipped at top-level scan too
+        _write_agent_yaml(root / "shared" / "agents", "shared-real")
+
+        hits = _discover_all_agents()
+        # Only "real" and "shared-real" show up.
+        names = {Path(h).parent.name for h in hits}
+        assert names == {"real", "shared-real"}
+
+
+# ---------------------------------------------------------------------------
+# 2. Hostname substitution
+# ---------------------------------------------------------------------------
+
+
+class TestHostnameSubstitution:
+    def test_substitution_happy_path(self, monkeypatch):
+        from scitex_agent_container.config._host import substitute_hostnames
+
+        monkeypatch.setenv("SCITEX_OROCHI_HOSTNAME", "mba")
+        obj = {
+            "name": "head",
+            "labels": {"machine": "${HOSTNAME}"},
+            "commands": ["echo ${SCITEX_OROCHI_HOSTNAME}"],
+        }
+        out = substitute_hostnames(obj)
+        assert out["labels"]["machine"] == "mba"
+        assert out["commands"] == ["echo mba"]
+        assert out["name"] == "head"  # unchanged
+
+    def test_substitution_preserves_other_placeholders(self, monkeypatch):
+        from scitex_agent_container.config._host import substitute_hostnames
+
+        monkeypatch.setenv("SCITEX_OROCHI_HOSTNAME", "nas")
+        obj = {"token": "${SCITEX_OROCHI_TOKEN}", "host": "${HOSTNAME}"}
+        out = substitute_hostnames(obj)
+        assert out["host"] == "nas"
+        # Other placeholders are left for downstream (e.g. mcp) interpolation.
+        assert out["token"] == "${SCITEX_OROCHI_TOKEN}"
+
+    def test_substitution_deeply_nested(self, monkeypatch):
+        from scitex_agent_container.config._host import substitute_hostnames
+
+        monkeypatch.setenv("SCITEX_OROCHI_HOSTNAME", "spartan")
+        obj = {
+            "a": [{"b": {"c": ["${HOSTNAME}-suffix"]}}],
+        }
+        out = substitute_hostnames(obj)
+        assert out["a"][0]["b"]["c"] == ["spartan-suffix"]
+
+    def test_env_var_wins_over_short_hostname(self, monkeypatch):
+        from scitex_agent_container.config._host import resolve_hostname
+
+        monkeypatch.setenv("SCITEX_OROCHI_HOSTNAME", "override")
+        monkeypatch.setattr("socket.gethostname", lambda: "ignored.example.com")
+        assert resolve_hostname() == "override"
+
+    def test_short_hostname_fallback(self, monkeypatch):
+        from scitex_agent_container.config._host import resolve_hostname
+
+        monkeypatch.delenv("SCITEX_OROCHI_HOSTNAME", raising=False)
+        monkeypatch.setattr("socket.gethostname", lambda: "mybox.local")
+        assert resolve_hostname() == "mybox"
+
+    def test_missing_var_raises_when_all_empty(self, monkeypatch):
+        from scitex_agent_container.config._host import resolve_hostname
+
+        monkeypatch.delenv("SCITEX_OROCHI_HOSTNAME", raising=False)
+        monkeypatch.setattr("socket.gethostname", lambda: "")
+        with pytest.raises(RuntimeError):
+            resolve_hostname()
+
+
+# ---------------------------------------------------------------------------
+# 3. Effective-id composition
+# ---------------------------------------------------------------------------
+
+
+class TestEffectiveId:
+    def test_per_host_appends_suffix(self):
+        from scitex_agent_container.config import SchedulingSpec
+        from scitex_agent_container.config._loaders import compose_effective_name
+
+        assert (
+            compose_effective_name(
+                "head", SchedulingSpec(mode="per-host"), "ywata-note-win"
+            )
+            == "head-ywata-note-win"
+        )
+
+    def test_per_host_idempotent_when_name_already_suffixed(self):
+        """Legacy flat YAMLs with ``metadata.name: head-ywata-note-win`` pass through."""
+        from scitex_agent_container.config import SchedulingSpec
+        from scitex_agent_container.config._loaders import compose_effective_name
+
+        assert (
+            compose_effective_name(
+                "head-ywata-note-win",
+                SchedulingSpec(mode="per-host"),
+                "ywata-note-win",
+            )
+            == "head-ywata-note-win"
+        )
+
+    def test_singleton_keeps_bare_name(self):
+        from scitex_agent_container.config import SchedulingSpec
+        from scitex_agent_container.config._loaders import compose_effective_name
+
+        sched = SchedulingSpec(mode="singleton", preferred_host="ywata-note-win")
+        assert (
+            compose_effective_name("fleet-lead", sched, "ywata-note-win")
+            == "fleet-lead"
+        )
+        # Even on a non-preferred host the id is still bare — launch-skip is
+        # a separate decision (see TestSingletonEnforcement).
+        assert compose_effective_name("fleet-lead", sched, "mba") == "fleet-lead"
+
+    def test_load_v2_head_yaml_on_wsl_yields_host_suffixed_id(
+        self, tmp_path, monkeypatch
+    ):
+        """End-to-end: shared/agents/head/head.yaml on WSL -> head-ywata-note-win."""
+        from scitex_agent_container.config import load_config
+
+        monkeypatch.setenv("SCITEX_OROCHI_HOSTNAME", "ywata-note-win")
+
+        head_yaml = tmp_path / "head.yaml"
+        head_yaml.write_text(
+            dedent(
+                """\
+                apiVersion: scitex-agent-container/v2
+                kind: Agent
+                metadata:
+                  name: head
+                  labels:
+                    role: head
+                    machine: ${HOSTNAME}
+                spec:
+                  runtime: claude-code
+                  scheduling:
+                    mode: per-host
+                """
+            )
+        )
+        cfg = load_config(str(head_yaml))
+        assert cfg.name == "head-ywata-note-win"
+        assert cfg.labels["machine"] == "ywata-note-win"
+        assert cfg.scheduling.mode == "per-host"
+        assert cfg.workdir == "~/.scitex/orochi/workspaces/head-ywata-note-win"
+
+    def test_load_v2_fleet_lead_on_wsl_keeps_bare_id(self, tmp_path, monkeypatch):
+        """Singleton fleet-lead on preferred host keeps bare ``fleet-lead`` id."""
+        from scitex_agent_container.config import load_config
+
+        monkeypatch.setenv("SCITEX_OROCHI_HOSTNAME", "ywata-note-win")
+
+        yaml_path = tmp_path / "fleet-lead.yaml"
+        yaml_path.write_text(
+            dedent(
+                """\
+                apiVersion: scitex-agent-container/v2
+                kind: Agent
+                metadata:
+                  name: fleet-lead
+                  labels:
+                    role: lead
+                spec:
+                  runtime: claude-code
+                  scheduling:
+                    mode: singleton
+                    preferred-host: ywata-note-win
+                    fallback-hosts: [mba, nas, spartan]
+                """
+            )
+        )
+        cfg = load_config(str(yaml_path))
+        assert cfg.name == "fleet-lead"
+        assert cfg.scheduling.mode == "singleton"
+        assert cfg.scheduling.preferred_host == "ywata-note-win"
+        assert cfg.scheduling.fallback_hosts == ["mba", "nas", "spartan"]
+
+    def test_load_v2_without_scheduling_preserves_legacy_behavior(self, tmp_path):
+        """Legacy v2 YAML without spec.scheduling keeps metadata.name unchanged."""
+        from scitex_agent_container.config import load_config
+
+        yaml_path = tmp_path / "legacy.yaml"
+        yaml_path.write_text(
+            dedent(
+                """\
+                apiVersion: scitex-agent-container/v2
+                kind: Agent
+                metadata:
+                  name: head-test
+                  labels:
+                    role: head
+                spec:
+                  runtime: claude-code
+                """
+            )
+        )
+        cfg = load_config(str(yaml_path))
+        assert cfg.name == "head-test"  # not mangled
+
+
+# ---------------------------------------------------------------------------
+# 4. Singleton enforcement
+# ---------------------------------------------------------------------------
+
+
+class TestSingletonEnforcement:
+    def test_singleton_match_returns_no_skip(self):
+        from scitex_agent_container.cli_pkg.lifecycle_cmds import (
+            _singleton_skip_reason,
+        )
+        from scitex_agent_container.config import AgentConfig, SchedulingSpec
+
+        cfg = AgentConfig(
+            name="fleet-lead",
+            scheduling=SchedulingSpec(
+                mode="singleton",
+                preferred_host="ywata-note-win",
+                fallback_hosts=["mba", "nas"],
+            ),
+        )
+        assert _singleton_skip_reason(cfg, "ywata-note-win") is None
+
+    def test_singleton_mismatch_returns_skip_reason(self):
+        from scitex_agent_container.cli_pkg.lifecycle_cmds import (
+            _singleton_skip_reason,
+        )
+        from scitex_agent_container.config import AgentConfig, SchedulingSpec
+
+        cfg = AgentConfig(
+            name="fleet-lead",
+            scheduling=SchedulingSpec(
+                mode="singleton",
+                preferred_host="ywata-note-win",
+                fallback_hosts=["mba", "nas"],
+            ),
+        )
+        reason = _singleton_skip_reason(cfg, "mba")
+        assert reason is not None
+        assert "ywata-note-win" in reason
+        assert "mba" in reason
+        # Fallback hosts are surfaced for operator context.
+        assert "fallback-hosts" in reason
+
+    def test_per_host_never_skips(self):
+        from scitex_agent_container.cli_pkg.lifecycle_cmds import (
+            _singleton_skip_reason,
+        )
+        from scitex_agent_container.config import AgentConfig, SchedulingSpec
+
+        cfg = AgentConfig(name="head-mba", scheduling=SchedulingSpec(mode="per-host"))
+        # No matter the host, per-host agents always launch.
+        assert _singleton_skip_reason(cfg, "mba") is None
+        assert _singleton_skip_reason(cfg, "ywata-note-win") is None
+
+    def test_singleton_without_preferred_host_never_skips(self):
+        """Singleton without a preferred-host is a no-op guard — launches anywhere."""
+        from scitex_agent_container.cli_pkg.lifecycle_cmds import (
+            _singleton_skip_reason,
+        )
+        from scitex_agent_container.config import AgentConfig, SchedulingSpec
+
+        cfg = AgentConfig(
+            name="fleet-lead",
+            scheduling=SchedulingSpec(mode="singleton", preferred_host=""),
+        )
+        assert _singleton_skip_reason(cfg, "any-host") is None
+
+
+# ---------------------------------------------------------------------------
+# 5. Scheduling parser error handling
+# ---------------------------------------------------------------------------
+
+
+class TestSchedulingParser:
+    def test_invalid_mode_raises(self):
+        from scitex_agent_container.config._parsers import parse_scheduling
+
+        with pytest.raises(ValueError):
+            parse_scheduling({"scheduling": {"mode": "bogus"}})
+
+    def test_non_mapping_raises(self):
+        from scitex_agent_container.config._parsers import parse_scheduling
+
+        with pytest.raises(ValueError):
+            parse_scheduling({"scheduling": "not-a-dict"})
+
+    def test_absent_returns_not_explicit(self):
+        from scitex_agent_container.config._parsers import parse_scheduling
+
+        sched, explicit = parse_scheduling({})
+        assert explicit is False
+        assert sched.mode == "per-host"

--- a/tests/test_shared_host_layout.py
+++ b/tests/test_shared_host_layout.py
@@ -1,7 +1,7 @@
 """Tests for the shared-host fleet layout (feat/orochi-shared-host-layout).
 
 Covers:
-  * Agent discovery (host override > shared > legacy flat).
+  * Agent discovery (host override > shared).
   * ``${HOSTNAME}`` / ``${SCITEX_OROCHI_HOSTNAME}`` substitution.
   * Effective-id composition for ``per-host`` vs ``singleton`` scheduling.
   * Singleton launch-skip decision on non-preferred hosts.
@@ -77,19 +77,6 @@ class TestDiscovery:
         assert len(hits) == 1
         assert hits[0].endswith("shared/agents/head/head.yaml")
 
-    def test_discovery_finds_legacy_flat_agents(self, fake_home):
-        """Legacy flat ~/.scitex/orochi/agents/<name>/<name>.yaml still works."""
-        from scitex_agent_container.cli_pkg.lifecycle_cmds import (
-            _discover_all_agents,
-        )
-
-        legacy = fake_home / ".scitex" / "orochi" / "agents"
-        _write_agent_yaml(legacy, "healer")
-
-        hits = _discover_all_agents()
-        assert len(hits) == 1
-        assert hits[0].endswith("orochi/agents/healer/healer.yaml")
-
     def test_discovery_host_override_wins_over_shared(self, fake_home):
         """Host-specific dir wins over shared for the same agent name."""
         from scitex_agent_container.cli_pkg.lifecycle_cmds import (
@@ -106,36 +93,21 @@ class TestDiscovery:
         # Host override wins.
         assert "ywata-note-win/agents/head/head.yaml" in hits[0]
 
-    def test_discovery_shared_wins_over_legacy(self, fake_home):
-        """Shared dir shadows the old flat legacy agents/ location."""
-        from scitex_agent_container.cli_pkg.lifecycle_cmds import (
-            _discover_all_agents,
-        )
-
-        shared = fake_home / ".scitex" / "orochi" / "shared" / "agents"
-        legacy = fake_home / ".scitex" / "orochi" / "agents"
-        _write_agent_yaml(shared, "head")
-        _write_agent_yaml(legacy, "head")
-
-        hits = _discover_all_agents()
-        assert len(hits) == 1
-        assert "shared/agents/head/head.yaml" in hits[0]
-
     def test_discovery_merges_when_names_differ(self, fake_home):
-        """Different names across layers all surface; same name is shadowed."""
+        """Different names across host + shared all surface."""
         from scitex_agent_container.cli_pkg.lifecycle_cmds import (
             _discover_all_agents,
         )
 
         shared = fake_home / ".scitex" / "orochi" / "shared" / "agents"
-        legacy = fake_home / ".scitex" / "orochi" / "agents"
+        host_dir = fake_home / ".scitex" / "orochi" / "ywata-note-win" / "agents"
         _write_agent_yaml(shared, "head")
-        _write_agent_yaml(legacy, "mamba-old-agent")
+        _write_agent_yaml(host_dir, "caduceus")
 
         hits = _discover_all_agents()
         assert len(hits) == 2
         names = {Path(h).parent.name for h in hits}
-        assert names == {"head", "mamba-old-agent"}
+        assert names == {"head", "caduceus"}
 
     def test_discovery_skips_hidden_and_reserved(self, fake_home):
         """Dirs starting with . / _ and reserved names are ignored."""
@@ -144,17 +116,18 @@ class TestDiscovery:
         )
 
         root = fake_home / ".scitex" / "orochi"
-        legacy = root / "agents"
+        shared = root / "shared" / "agents"
         for skip_name in (".hidden", "_private", "legacy-agents", "GITIGNORED"):
-            _write_agent_yaml(legacy, skip_name)
-        _write_agent_yaml(legacy, "real")
-        # shared-level reserved names are skipped at top-level scan too
-        _write_agent_yaml(root / "shared" / "agents", "shared-real")
+            _write_agent_yaml(shared, skip_name)
+        _write_agent_yaml(shared, "shared-real")
+        host_dir = root / "ywata-note-win" / "agents"
+        for skip_name in (".hidden", "_private"):
+            _write_agent_yaml(host_dir, skip_name)
+        _write_agent_yaml(host_dir, "host-real")
 
         hits = _discover_all_agents()
-        # Only "real" and "shared-real" show up.
         names = {Path(h).parent.name for h in hits}
-        assert names == {"real", "shared-real"}
+        assert names == {"shared-real", "host-real"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_shared_host_layout.py
+++ b/tests/test_shared_host_layout.py
@@ -298,6 +298,10 @@ class TestEffectiveId:
         from scitex_agent_container.config import load_config
 
         monkeypatch.setenv("SCITEX_OROCHI_HOSTNAME", "ywata-note-win")
+        # Isolate HOME so the legacy-workdir fallback probe doesn't hit the
+        # dev machine's real ~/.scitex/orochi/workspaces/ and return the
+        # pre-runtime/ path.
+        monkeypatch.setenv("HOME", str(tmp_path))
 
         head_yaml = tmp_path / "head.yaml"
         head_yaml.write_text(
@@ -321,7 +325,7 @@ class TestEffectiveId:
         assert cfg.name == "head-ywata-note-win"
         assert cfg.labels["machine"] == "ywata-note-win"
         assert cfg.scheduling.mode == "per-host"
-        assert cfg.workdir == "~/.scitex/orochi/workspaces/head-ywata-note-win"
+        assert cfg.workdir == "~/.scitex/orochi/runtime/workspaces/head-ywata-note-win"
 
     def test_load_v2_fleet_lead_on_wsl_keeps_bare_id(self, tmp_path, monkeypatch):
         """Singleton fleet-lead on preferred host keeps bare ``fleet-lead`` id."""

--- a/tests/test_shared_host_layout.py
+++ b/tests/test_shared_host_layout.py
@@ -192,6 +192,60 @@ class TestHostnameSubstitution:
         with pytest.raises(RuntimeError):
             resolve_hostname()
 
+    def test_alias_map_translates_short_hostname(self, monkeypatch, tmp_path):
+        """shared/config.yaml::hostname_aliases maps raw -> fleet label."""
+        import scitex_agent_container.config._host as host_mod
+
+        monkeypatch.delenv("SCITEX_OROCHI_HOSTNAME", raising=False)
+        monkeypatch.setattr("socket.gethostname", lambda: "Yusukes-MacBook-Air")
+        config_dir = tmp_path / ".scitex" / "orochi" / "shared"
+        config_dir.mkdir(parents=True)
+        (config_dir / "config.yaml").write_text(
+            "spec:\n"
+            "  hostname_aliases:\n"
+            "    Yusukes-MacBook-Air: mba\n"
+            "    DXP480TPLUS-994: nas\n"
+        )
+        monkeypatch.setattr(host_mod, "_CONFIG_PATH", config_dir / "config.yaml")
+        assert host_mod.resolve_hostname() == "mba"
+
+    def test_env_var_beats_alias_map(self, monkeypatch, tmp_path):
+        """$SCITEX_OROCHI_HOSTNAME overrides the alias map."""
+        import scitex_agent_container.config._host as host_mod
+
+        monkeypatch.setenv("SCITEX_OROCHI_HOSTNAME", "manual-override")
+        monkeypatch.setattr("socket.gethostname", lambda: "Yusukes-MacBook-Air")
+        config_dir = tmp_path / ".scitex" / "orochi" / "shared"
+        config_dir.mkdir(parents=True)
+        (config_dir / "config.yaml").write_text(
+            "spec:\n  hostname_aliases:\n    Yusukes-MacBook-Air: mba\n"
+        )
+        monkeypatch.setattr(host_mod, "_CONFIG_PATH", config_dir / "config.yaml")
+        assert host_mod.resolve_hostname() == "manual-override"
+
+    def test_unmapped_host_falls_through_to_identity(self, monkeypatch, tmp_path):
+        """hostname -s with no alias entry returns unchanged."""
+        import scitex_agent_container.config._host as host_mod
+
+        monkeypatch.delenv("SCITEX_OROCHI_HOSTNAME", raising=False)
+        monkeypatch.setattr("socket.gethostname", lambda: "ywata-note-win")
+        config_dir = tmp_path / ".scitex" / "orochi" / "shared"
+        config_dir.mkdir(parents=True)
+        (config_dir / "config.yaml").write_text(
+            "spec:\n  hostname_aliases:\n    Yusukes-MacBook-Air: mba\n"
+        )
+        monkeypatch.setattr(host_mod, "_CONFIG_PATH", config_dir / "config.yaml")
+        assert host_mod.resolve_hostname() == "ywata-note-win"
+
+    def test_missing_config_file_is_not_an_error(self, monkeypatch, tmp_path):
+        """Hostname resolves without a config file — identity fallback only."""
+        import scitex_agent_container.config._host as host_mod
+
+        monkeypatch.delenv("SCITEX_OROCHI_HOSTNAME", raising=False)
+        monkeypatch.setattr("socket.gethostname", lambda: "bare-host")
+        monkeypatch.setattr(host_mod, "_CONFIG_PATH", tmp_path / "no-such.yaml")
+        assert host_mod.resolve_hostname() == "bare-host"
+
 
 # ---------------------------------------------------------------------------
 # 3. Effective-id composition

--- a/tests/test_status_json.py
+++ b/tests/test_status_json.py
@@ -10,7 +10,6 @@ import pytest
 
 from scitex_agent_container import agent_meta
 
-
 # ---------------------------------------------------------------------------
 # collect_rich — unit tests with fake workspace, no live tmux required
 # ---------------------------------------------------------------------------
@@ -83,9 +82,12 @@ def test_collect_rich_shape(fake_workspace: Path) -> None:
 
 def test_encode_claude_project() -> None:
     # hidden-dir: /.scitex becomes --scitex (not ---scitex)
-    assert agent_meta._encode_claude_project(
-        "/Users/ywatanabe/.dotfiles/src/.scitex/orochi/workspaces/head-mba"
-    ) == "-Users-ywatanabe--dotfiles-src--scitex-orochi-workspaces-head-mba"
+    assert (
+        agent_meta._encode_claude_project(
+            "/Users/ywatanabe/.dotfiles/src/.scitex/orochi/workspaces/head-mba"
+        )
+        == "-Users-ywatanabe--dotfiles-src--scitex-orochi-workspaces-head-mba"
+    )
 
 
 def test_collect_rich_with_fake_transcript(
@@ -140,6 +142,24 @@ def test_collect_rich_with_fake_transcript(
 
 
 # ---------------------------------------------------------------------------
+# _fallback_workdir — runtime/ layout probe (2026-04-17 restructure)
+# ---------------------------------------------------------------------------
+
+
+def test_fallback_workdir_uses_runtime_layout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Returns the canonical runtime/workspaces/<id> path."""
+    from scitex_agent_container.lifecycle import _fallback_workdir
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    result = _fallback_workdir("some-agent")
+    assert result == str(
+        tmp_path / ".scitex" / "orochi" / "runtime" / "workspaces" / "some-agent"
+    )
+
+
+# ---------------------------------------------------------------------------
 # agent_status — integration: rich fields merged into base result
 # ---------------------------------------------------------------------------
 
@@ -166,10 +186,13 @@ def test_agent_status_includes_rich_fields(
     # sets config=None. That path still calls collect_rich via the
     # fallback workspace dir, so point HOME at the fake workspace parent.
     monkeypatch.setattr(Path, "home", lambda: fake_workspace.parent.parent)
-    # The fallback workdir lifecycle computes:
-    #   ~/.scitex/orochi/workspaces/<name>
-    # so mirror that:
-    target = fake_workspace.parent.parent / ".scitex" / "orochi" / "workspaces"
+    # The fallback workdir lifecycle computes (2026-04-17 runtime/ layout):
+    #   ~/.scitex/orochi/runtime/workspaces/<name>
+    # so mirror that. Legacy fallback probes ~/.scitex/orochi/workspaces/
+    # first — leave that dir absent so the new path wins.
+    target = (
+        fake_workspace.parent.parent / ".scitex" / "orochi" / "runtime" / "workspaces"
+    )
     target.mkdir(parents=True, exist_ok=True)
     link = target / "fake-agent"
     if not link.exists():
@@ -282,7 +305,9 @@ def test_status_full_unaffected_by_terse_flag_absence(
             return entry
 
     monkeypatch.setattr(Path, "home", lambda: fake_workspace.parent.parent)
-    target = fake_workspace.parent.parent / ".scitex" / "orochi" / "workspaces"
+    target = (
+        fake_workspace.parent.parent / ".scitex" / "orochi" / "runtime" / "workspaces"
+    )
     target.mkdir(parents=True, exist_ok=True)
     link = target / "fake-agent"
     if not link.exists():


### PR DESCRIPTION
## Summary
Orochi fleet A.2 scope — aligns `scitex-agent-container` with the 2026-04-17 dotfiles restructure at `~/.scitex/orochi/runtime/`, layered on top of PR #54's shared-host layout.

**Depends on #54 (`feat/orochi-shared-host-layout`). Merge #54 first.**

## Path mapping
| Old                                              | New                                                     |
|--------------------------------------------------|---------------------------------------------------------|
| `~/.scitex/orochi/workspaces/<id>/`              | `~/.scitex/orochi/runtime/workspaces/<id>/`             |
| `~/.scitex/orochi/agents/<id>/` (deployed)       | `~/.scitex/orochi/runtime/workspaces/<id>/`             |
| `~/.scitex/orochi/scripts/agent_meta.py`         | `~/.scitex/orochi/shared/scripts/agent_meta.py`         |
| `$HOME/.scitex/orochi/skills/` (extra_add_dirs)  | `$HOME/.scitex/orochi/shared/skills/`                   |

Definition discovery is unchanged from #54 (`<host>/agents/ > shared/agents/ > legacy flat agents/`).

## Backward compatibility
Running agents today have workdirs at the flat legacy paths. New behavior:

1. `config.load_v2` default-workdir resolver probes `~/.scitex/orochi/workspaces/<id>/` and `~/.scitex/orochi/agents/<id>/` before falling back to the new `runtime/workspaces/<id>/` — legacy dir wins when it exists, with a stderr deprecation warning so operators migrate.
2. `lifecycle._fallback_workdir` (new helper used when the YAML can't be loaded, e.g. from `agent_status`) applies the same probe order.
3. `context_manager.fetch_agent_meta` auto-resolves `agent_meta.py` from `shared/scripts/` first, falling back to pre-restructure flat `scripts/` only when missing.

Next launch after `bootstrap-host.sh` lands on the new path — no migration script needed for the fleet's 4 hosts.

## Key architectural point preserved
`metadata.name` remains the SHORT name (`head`, `fleet-lead`, `healer`). The EFFECTIVE id (`head-<host>` for per-host, bare `<short>` for singleton) is computed by `compose_effective_name` as added in #54 and keys the runtime paths.

## Files changed
- `src/scitex_agent_container/config/_loaders.py` — runtime/ default + legacy probe
- `src/scitex_agent_container/lifecycle.py` — `_fallback_workdir` helper
- `src/scitex_agent_container/context_manager.py` — `shared/scripts/` preference
- `src/scitex_agent_container/cli_pkg/lifecycle_cmds.py` — docstring / help updates
- `src/scitex_agent_container/runtimes/sbatch_spartan.py` — default workdir + skills dir
- `src/scitex_agent_container/agent_meta.py` — docstring reference refresh
- `src/scitex_agent_container/_skills/scitex-agent-container/{config-v2,troubleshooting}.md` — doc refresh
- Tests: `tests/test_{config_v2,shared_host_layout,status_json}.py`

## Test plan
- [x] `pytest tests/` — 504 passed, 2 deselected locally.
- [x] `tests/test_shared_host_layout.py` — all 25 tests green (unchanged semantics from #54).
- [x] New coverage in `tests/test_config_v2.py`:
  - runtime/ default path
  - legacy `workspaces/<id>/` fallback + deprecation warning
  - legacy flat `agents/<id>/` fallback + deprecation warning
- [x] New coverage in `tests/test_status_json.py`: `_fallback_workdir` probe order (runtime / legacy-workspaces / legacy-agents).

## Not in this PR (deferred / out of scope)
- `~/proj/scitex-orochi` Django hub updates (A.3 scope, separate PR).
- Active migration of running agent workdirs (bootstrap auto-migrates on next launch; no scripted migration needed for 4 hosts).
- `scitex-orochi` skill files at `.claude/skills/scitex/scitex-orochi/` and `docs/to_claude/skills/scitex/scitex-orochi/` — these are export mirrors owned by the `scitex-orochi` package (hook blocks direct edit; update belongs to A.3).

Generated with [Claude Code](https://claude.com/claude-code)