### PR TITLE
feat(runtimes): inject Claude Code hook-event wiring at agent spawn (scitex-orochi todo#59)

### DIFF
--- a/src/scitex_agent_container/runtimes/settings_json.py
+++ b/src/scitex_agent_container/runtimes/settings_json.py
@@ -36,8 +36,62 @@ _MANAGED_KEYS = frozenset(
         "skipDangerousModePermissionPrompt",
         "enableAllProjectMcpServers",
         "enabledMcpjsonServers",
+        "hooks",
     }
 )
+
+# Hook config pushed into every spawned agent's settings.local.json so
+# PreToolUse / PostToolUse / UserPromptSubmit / Stop events flow into
+# the per-agent event ring-buffer (~/.scitex/agent-container/events/
+# <agent>.jsonl). Consumed by event_log.summarize() which feeds the
+# Orochi dashboard's Last tool / Last MCP / Last action rows. Without
+# this wiring those rows render as dashes (scitex-orochi todo#59).
+_HOOKS_CONFIG = {
+    "PreToolUse": [
+        {
+            "matcher": "",
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": "scitex-agent-container hook-event pretool",
+                }
+            ],
+        }
+    ],
+    "PostToolUse": [
+        {
+            "matcher": "",
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": "scitex-agent-container hook-event posttool",
+                }
+            ],
+        }
+    ],
+    "UserPromptSubmit": [
+        {
+            "matcher": "",
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": "scitex-agent-container hook-event prompt",
+                }
+            ],
+        }
+    ],
+    "Stop": [
+        {
+            "matcher": "",
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": "scitex-agent-container hook-event stop",
+                }
+            ],
+        }
+    ],
+}
 
 
 def _mcp_server_names(config: AgentConfig, workdir: str) -> list[str]:
@@ -63,16 +117,13 @@ def _mcp_server_names(config: AgentConfig, workdir: str) -> list[str]:
 
 def _needs_skip_permissions(config: AgentConfig) -> bool:
     """Check if config uses --dangerously-skip-permissions."""
-    return any(
-        "--dangerously-skip-permissions" in f for f in config.claude.flags
-    )
+    return any("--dangerously-skip-permissions" in f for f in config.claude.flags)
 
 
 def _needs_dev_channels(config: AgentConfig) -> bool:
     """Check if config uses --dangerously-load-development-channels."""
     return any(
-        "--dangerously-load-development-channels" in f
-        for f in config.claude.flags
+        "--dangerously-load-development-channels" in f for f in config.claude.flags
     )
 
 
@@ -92,6 +143,11 @@ def setup_settings_json(config: AgentConfig, workdir: str) -> None:
         server_names = _mcp_server_names(config, workdir)
         if server_names:
             settings["enabledMcpjsonServers"] = server_names
+
+    # Always inject hook wiring — even if skip-permissions / dev-channels
+    # aren't active we still want Last tool / Last MCP / Last action rows
+    # to populate on the dashboard (scitex-orochi todo#59).
+    settings["hooks"] = _HOOKS_CONFIG
 
     if not settings:
         return
@@ -156,9 +212,7 @@ def cleanup_settings_json(config: AgentConfig, workdir: str) -> None:
 
     if not data:
         settings_path.unlink(missing_ok=True)
-        logger.info(
-            "Removed empty .claude/settings.local.json at %s", settings_path
-        )
+        logger.info("Removed empty .claude/settings.local.json at %s", settings_path)
     else:
         settings_path.write_text(json.dumps(data, indent=2) + "\n")
         logger.info(

--- a/tests/test_haiku_integration.py
+++ b/tests/test_haiku_integration.py
@@ -108,7 +108,10 @@ def haiku_agent():
     if _SKIP_REASON:
         pytest.skip(_SKIP_REASON)
 
-    session = f"scitex-haiku-int-{uuid.uuid4().hex[:8]}"
+    # Readable session + workdir prefix so the leaked-fixture signature
+    # on the dashboard is self-explanatory ("scitex-haiku-integration-*"
+    # instead of the cryptic "int" abbreviation).
+    session = f"scitex-haiku-integration-{uuid.uuid4().hex[:8]}"
     # Claude Code's TUI respects ``--dangerously-skip-permissions`` so
     # it doesn't prompt for tool-use consent. ``--model`` pins haiku
     # for cheap, fast replies.
@@ -117,7 +120,7 @@ def haiku_agent():
     # ask the agent to touch the filesystem.
     import tempfile
 
-    workdir = tempfile.mkdtemp(prefix="scitex-haiku-int-")
+    workdir = tempfile.mkdtemp(prefix="scitex-haiku-integration-")
 
     cmd = f"cd {workdir} && claude --model {model} --dangerously-skip-permissions"
     # Start the tmux session running ``bash -lc`` so env is set up.
@@ -151,19 +154,37 @@ def haiku_agent():
         def _send(s: str, *keys: str) -> None:
             TmuxManager.send_keys(s, *keys)
 
-        accepted: set[str] = set()
-        deadline = time.time() + 90.0
+        # Previously a one-shot `accepted: set[str]` set permanently marked
+        # each prompt as done after the first keystroke. In practice the
+        # first send can silently no-op (tmux send-keys races with the TUI
+        # startup before claude-code has grabbed stdin) and the handler
+        # would then be skipped for the rest of the 90s deadline, causing
+        # the fixture to time out with the prompt still visible and leak
+        # the tmux session (msg#13170, scitex-haiku-int-48f9c296 incident).
+        #
+        # Track per-handler "last-fired-at" instead, with a 5s cool-down.
+        # If the prompt is still visible after the cool-down, we fire
+        # again — this recovers from a silently-lost initial keystroke
+        # without spamming the main input (the detector only fires while
+        # the prompt text is literally present in the pane).
+        last_fired: dict[str, float] = {}
+        FIRE_COOLDOWN_S = 5.0
+        deadline = time.time() + 180.0
         ready = False
         while time.time() < deadline:
             content = TmuxManager.capture_content(session) or ""
             if is_ready(content):
                 ready = True
                 break
+            now = time.time()
+            # Build a view of "handlers that fired too recently" so
+            # detect_and_respond skips them on this iteration only.
+            cooling = {k for k, t in last_fired.items() if now - t < FIRE_COOLDOWN_S}
             matched = detect_and_respond(
-                content, accepted, lambda *keys: _send(session, *keys)
+                content, cooling, lambda *keys: _send(session, *keys)
             )
             if matched:
-                accepted.add(matched)
+                last_fired[matched] = time.time()
                 time.sleep(2.0)
                 continue
             time.sleep(1.5)
@@ -171,8 +192,8 @@ def haiku_agent():
         if not ready:
             tail = (TmuxManager.capture_content(session) or "")[-1500:]
             pytest.skip(
-                "haiku agent did not reach ready state in 90s. "
-                f"accepted prompts: {accepted or 'none'}. "
+                "haiku agent did not reach ready state in 180s. "
+                f"fired prompts: {sorted(last_fired) or 'none'}. "
                 f"Last pane:\n{tail}"
             )
 


### PR DESCRIPTION
## Problem
Orochi dashboard shows `Last tool: —`, `Last MCP: —`, `Last action: —` on every agent. Server projects the fields correctly, but `~/.scitex/agent-container/events/<agent>.jsonl` is empty because no Claude Code hooks are wired to `scitex-agent-container hook-event`.

## Fix
`setup_settings_json` now also writes a `"hooks"` block into every spawned agent's `.claude/settings.local.json` with PreToolUse / PostToolUse / UserPromptSubmit / Stop pointing at `scitex-agent-container hook-event <kind>`.

`_MANAGED_KEYS` tracks `"hooks"` so `cleanup_settings_json` removes it on stop. Hook dict is module-level so every spawn path reuses the same config verbatim.

## Test plan
- Spawn a fresh agent → verify `.claude/settings.local.json` contains `hooks.PreToolUse[0].hooks[0].command` equal to `scitex-agent-container hook-event pretool`
- Wait one tool call → verify `~/.scitex/agent-container/events/<agent>.jsonl` gains an entry
- Reload the Orochi Agents tab → Last tool row shows actual tool name + freshness

🤖 Generated with [Claude Code](https://claude.com/claude-code)