### PR TITLE
feat(network-probe): WSL -> hub connectivity probe (todo#457)

### DIFF
--- a/src/scitex_agent_container/_skills/scitex-agent-container/wsl-connectivity.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/wsl-connectivity.md
@@ -1,0 +1,166 @@
+# WSL ↔ Fleet-Hub Connectivity (todo#457)
+
+## Problem
+
+`ywata-note-win` (Windows 11 + WSL2) periodically drops WSL-side
+internet connectivity. The fleet sees this as "SSH dead" (banner-
+exchange timeout, then connection-refused), which is indistinguish-
+able from "host asleep" unless the WSL side leaves a local trail.
+
+## What the evidence shows (from this host)
+
+One-shot diagnostics on 2026-04-21:
+
+- `/sbin/ip addr` → `eth0` has `192.168.11.28/24`, a LAN IP (NOT
+  the WSL NAT `172.x.x.x` range). This proves
+  **`networkingMode=mirrored` is already active** — the
+  `.wslconfig` at `/mnt/c/Users/wyusu/.wslconfig` contains
+  `[wsl2] networkingMode=mirrored`.
+- `/sbin/ip route` → default via `192.168.11.1` (the home router)
+  on `eth0`. No separate WSL-bridge hop.
+- `/etc/resolv.conf` → `nameserver 8.8.8.8 / 8.8.4.4` (Google DNS,
+  static). `/etc/wsl.conf` has `generateResolvConf = false`, so
+  DNS is not rewritten on boot.
+- `ping scitex-orochi.com` → 25 ms RTT, 0% loss. Right now the
+  pipe is healthy.
+- `cloudflared` → installed at `~/.local/bin/cloudflared`, **not a
+  systemd service and not currently running**. The cloudflared
+  tunnel failures described in todo#457 are on the **NAS side**
+  dialling *into* a WSL-hosted bastion; they are not owned by this
+  host's head agent.
+
+## What this means for the hypotheses in todo#457
+
+| # | Hypothesis | Status |
+|---|---|---|
+| 1 | WSL2 NAT bridge instability | **Eliminated.** Mirrored mode removes the NAT bridge. |
+| 2 | Hyper-V vswitch desync on NIC change | **Partly eliminated.** Mirrored mode uses the host's NIC directly. |
+| 3 | cloudflared tunnel uplink expiry | **N/A for this host.** No cloudflared service runs here. Belongs to head-nas. |
+| 4 | Windows NIC power-save | **Still live.** Mirrored mode means WSL's eth0 IS the Windows NIC — if Windows powers it down, WSL loses connectivity immediately. |
+| 5 | Wi-Fi roam / DHCP lease | **Amplified by mirrored mode.** Lease expiry on the host re-IPs WSL's `eth0` directly; any TCP connection across the transition breaks. |
+
+## Mitigations that require ywatanabe-side Windows action
+
+These cannot be done from inside WSL. They are the actual root-
+cause fixes; everything below the line is WSL-side visibility.
+
+1. **Disable Windows NIC power-save.** In PowerShell (admin):
+   ```powershell
+   Get-NetAdapter | Where-Object {$_.Status -eq "Up"} |
+     Set-NetAdapterPowerManagement -AllowComputerToTurnOffDevice Disabled
+   ```
+   One-shot, survives reboots.
+2. **Consider static DHCP reservation** on the router for this
+   host. With mirrored mode, every DHCP re-negotiation hits WSL.
+   A static reservation eliminates lease-expiry churn.
+3. **For Wi-Fi specifically,** consider preferring the 5 GHz SSID
+   over the 2.4 GHz one (disable "connect to this network
+   automatically" on the weaker of the two) — roaming between
+   them retriggers the network-change event that mirrored mode
+   propagates into WSL.
+4. **Leave `networkingMode=mirrored` as-is.** The alternative
+   (NAT bridge) is the *previous* failure mode the fleet was
+   hitting before this setting was applied.
+
+## Mitigations available on the WSL side (what this PR ships)
+
+Since the fleet-facing symptom is "SSH dead, cause unknown", the
+WSL-side contribution is **unambiguous evidence** that the outage
+is connectivity, not a crashed Claude process. Use the probe
+command shipped in this package.
+
+### One-shot manual probe
+
+```bash
+scitex-agent-container probe-network --agent head-$(hostname)
+```
+
+Output (when healthy):
+
+```json
+{
+  "ts": "2026-04-21T09:30:00+00:00",
+  "ok": true,
+  "probes": [
+    {"name": "dns", "ok": true, "latency_ms": 4.1, "extra": {"addrs": ["104.19.xx.xx", "172.67.xx.xx"]}},
+    {"name": "gateway", "ok": true, "latency_ms": 1.3, "extra": {"gateway": "192.168.11.1"}},
+    {"name": "tcp", "ok": true, "latency_ms": 13.2},
+    {"name": "https", "ok": true, "latency_ms": 45.0, "extra": {"status": 200}}
+  ]
+}
+```
+
+When the WSL side is broken, the first probe to fail tells you the
+layer that actually broke:
+
+| First failure | Diagnosis |
+|---|---|
+| `dns` | resolver unreachable — `/etc/resolv.conf` nameserver (8.8.8.8) is blocked or Wi-Fi is actually down |
+| `gateway` (but `dns` ok) | rare — DNS is cached / UDP-only while LAN routing died |
+| `gateway` AND `dns` | Wi-Fi roam or NIC power-save just kicked in |
+| `tcp` (but `dns` + `gateway` ok) | hub unreachable: firewall / Cloudflare regional |
+| `https` only | TLS handshake or captive-portal interposing |
+
+The probe writes one JSONL line per run to
+`~/.scitex/agent-container/logs/network/<agent>.jsonl`. This is
+the ring the fleet correlates against its own SSH-dead timestamps.
+
+### Cron-style continuous probe
+
+To leave a timeline the fleet can grep after the next incident,
+run the probe every minute from WSL's user systemd / cron:
+
+```cron
+* * * * * /home/ywatanabe/.venv/bin/scitex-agent-container probe-network \
+            --agent head-ywata-note-win --quiet >/dev/null 2>&1
+```
+
+Or via tmux/screen one-liner for a single session:
+
+```bash
+while true; do
+  scitex-agent-container probe-network --agent head-ywata-note-win --quiet
+  sleep 60
+done &
+```
+
+### Exit-code behaviour for systemd/monit integration
+
+Pass `--exit-nonzero-on-fail` if you want a wrapper script to alert
+on sustained failure:
+
+```bash
+scitex-agent-container probe-network --agent head-ywata-note-win \
+    --quiet --exit-nonzero-on-fail \
+    || notify-send "WSL→hub down"
+```
+
+## Correlating with fleet-side SSH-dead events
+
+When the fleet reports `ssh ywata-note-win` timing out, the fleet
+cannot tell whether:
+
+- the laptop lid is closed (Windows asleep),
+- the laptop is awake but WSL lost Wi-Fi,
+- the laptop is awake and WSL has internet but the SSH service
+  restarted,
+- or Claude Code TUI crashed while the rest of the host is fine.
+
+A minute-granular probe log on WSL disambiguates all four:
+
+- Absent log lines in the window → **Windows host was asleep**
+  (WSL was not running). Fix: disable lid-close / power settings.
+- Present lines but `ok=false` → **WSL lost external connectivity**.
+  Fix: apply one of the Windows-side mitigations above.
+- Present lines and `ok=true` → **WSL was fine**, so the SSH-dead
+  signal is a false positive. Fix: investigate the fleet's SSH
+  probe, not this host.
+
+## See also
+
+- `liveness_probe.py` — TUI-responsiveness probe (different scope:
+  "is Claude still echoing text inside tmux?"). Complements this
+  module: network-probe ensures WSL can REACH the hub; liveness-
+  probe ensures Claude can respond once reached.
+- `infra-host-connectivity`, `infra-network-routing` skills in
+  `~/.scitex/orochi/shared/skills/` — fleet-level tunnel setup.

--- a/src/scitex_agent_container/_skills/scitex-agent-container/wsl-connectivity.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/wsl-connectivity.md
@@ -7,6 +7,14 @@ internet connectivity. The fleet sees this as "SSH dead" (banner-
 exchange timeout, then connection-refused), which is indistinguish-
 able from "host asleep" unless the WSL side leaves a local trail.
 
+## Baseline
+
+**Wired LAN + mirrored mode** (as of 2026-04-21, ywatanabe
+msg#15405). The host has been moved off Wi-Fi onto a stable wired
+Ethernet link; SSID-roam and 2.4 vs 5 GHz hand-off are no longer
+in scope. Remaining live failure modes are NIC-level power-save
+and DHCP lease churn.
+
 ## What the evidence shows (from this host)
 
 One-shot diagnostics on 2026-04-21:
@@ -15,7 +23,9 @@ One-shot diagnostics on 2026-04-21:
   the WSL NAT `172.x.x.x` range). This proves
   **`networkingMode=mirrored` is already active** — the
   `.wslconfig` at `/mnt/c/Users/wyusu/.wslconfig` contains
-  `[wsl2] networkingMode=mirrored`.
+  `[wsl2] networkingMode=mirrored`. Under mirrored mode WSL's
+  `eth0` reflects whichever Windows NIC is carrying traffic —
+  currently the wired Ethernet adapter.
 - `/sbin/ip route` → default via `192.168.11.1` (the home router)
   on `eth0`. No separate WSL-bridge hop.
 - `/etc/resolv.conf` → `nameserver 8.8.8.8 / 8.8.4.4` (Google DNS,
@@ -34,31 +44,30 @@ One-shot diagnostics on 2026-04-21:
 | # | Hypothesis | Status |
 |---|---|---|
 | 1 | WSL2 NAT bridge instability | **Eliminated.** Mirrored mode removes the NAT bridge. |
-| 2 | Hyper-V vswitch desync on NIC change | **Partly eliminated.** Mirrored mode uses the host's NIC directly. |
+| 2 | Hyper-V vswitch desync on NIC change | **Partly eliminated.** Mirrored mode uses the host's NIC directly; wired LAN means no Wi-Fi-driven NIC swaps. |
 | 3 | cloudflared tunnel uplink expiry | **N/A for this host.** No cloudflared service runs here. Belongs to head-nas. |
-| 4 | Windows NIC power-save | **Still live.** Mirrored mode means WSL's eth0 IS the Windows NIC — if Windows powers it down, WSL loses connectivity immediately. |
-| 5 | Wi-Fi roam / DHCP lease | **Amplified by mirrored mode.** Lease expiry on the host re-IPs WSL's `eth0` directly; any TCP connection across the transition breaks. |
+| 4 | Windows NIC power-save | **Still live.** Applies equally to the wired Ethernet adapter — if Windows powers it down (selective-suspend / "allow the computer to turn off this device to save power"), WSL loses connectivity immediately. |
+| 5 | DHCP lease churn | **Still live, reduced scope.** With the host on a single wired link (no Wi-Fi roam), only lease-renewal on the Ethernet adapter remains. A static reservation removes this entirely. |
 
 ## Mitigations that require ywatanabe-side Windows action
 
 These cannot be done from inside WSL. They are the actual root-
 cause fixes; everything below the line is WSL-side visibility.
 
-1. **Disable Windows NIC power-save.** In PowerShell (admin):
+1. **Disable Windows NIC power-save on the wired Ethernet adapter.**
+   In PowerShell (admin):
    ```powershell
    Get-NetAdapter | Where-Object {$_.Status -eq "Up"} |
      Set-NetAdapterPowerManagement -AllowComputerToTurnOffDevice Disabled
    ```
-   One-shot, survives reboots.
-2. **Consider static DHCP reservation** on the router for this
-   host. With mirrored mode, every DHCP re-negotiation hits WSL.
-   A static reservation eliminates lease-expiry churn.
-3. **For Wi-Fi specifically,** consider preferring the 5 GHz SSID
-   over the 2.4 GHz one (disable "connect to this network
-   automatically" on the weaker of the two) — roaming between
-   them retriggers the network-change event that mirrored mode
-   propagates into WSL.
-4. **Leave `networkingMode=mirrored` as-is.** The alternative
+   One-shot, survives reboots. Targets all "Up" adapters, which on
+   a wired-only host is just the Ethernet NIC.
+2. **Static DHCP reservation on the router for this host's wired
+   MAC.** With mirrored mode, every DHCP renegotiation on the
+   Ethernet adapter re-IPs WSL's `eth0` directly and breaks any
+   TCP session crossing the transition. A static reservation
+   eliminates lease-expiry churn.
+3. **Leave `networkingMode=mirrored` as-is.** The alternative
    (NAT bridge) is the *previous* failure mode the fleet was
    hitting before this setting was applied.
 
@@ -95,9 +104,9 @@ layer that actually broke:
 
 | First failure | Diagnosis |
 |---|---|
-| `dns` | resolver unreachable — `/etc/resolv.conf` nameserver (8.8.8.8) is blocked or Wi-Fi is actually down |
+| `dns` | resolver unreachable — `/etc/resolv.conf` nameserver (8.8.8.8) is blocked or the wired link is actually down |
 | `gateway` (but `dns` ok) | rare — DNS is cached / UDP-only while LAN routing died |
-| `gateway` AND `dns` | Wi-Fi roam or NIC power-save just kicked in |
+| `gateway` AND `dns` | Ethernet NIC power-save just kicked in, or DHCP lease renegotiation re-IP'd eth0 |
 | `tcp` (but `dns` + `gateway` ok) | hub unreachable: firewall / Cloudflare regional |
 | `https` only | TLS handshake or captive-portal interposing |
 
@@ -141,7 +150,8 @@ When the fleet reports `ssh ywata-note-win` timing out, the fleet
 cannot tell whether:
 
 - the laptop lid is closed (Windows asleep),
-- the laptop is awake but WSL lost Wi-Fi,
+- the laptop is awake but WSL lost its wired link (NIC power-save
+  or DHCP renegotiation),
 - the laptop is awake and WSL has internet but the SSH service
   restarted,
 - or Claude Code TUI crashed while the rest of the host is fine.

--- a/src/scitex_agent_container/cli_pkg/_main.py
+++ b/src/scitex_agent_container/cli_pkg/_main.py
@@ -16,6 +16,7 @@ from .build_cmds import build, check, validate
 from .hook_cmds import hook_event
 from .info_cmds import attach, find, list_python_apis, logs
 from .lifecycle_cmds import cleanup, restart, start, stop
+from .probe_cmds import probe_network
 from .render_cmds import render_attach, render_sbatch
 from .snapshot_cmds import snapshot
 from .status_cmds import check_agent, health, list_agents, status
@@ -86,6 +87,9 @@ main.add_command(actions_cli)
 # Render ports: emit sbatch/attach text for external consumers.
 main.add_command(render_sbatch)
 main.add_command(render_attach)
+
+# Connectivity probe (todo#457): fleet-facing WSL ↔ hub liveness.
+main.add_command(probe_network)
 
 
 if __name__ == "__main__":

--- a/src/scitex_agent_container/cli_pkg/probe_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/probe_cmds.py
@@ -1,0 +1,98 @@
+"""Probe commands: probe-network.
+
+Filed under ``todo#457`` — fleet-side cannot tell "WSL host sleeping"
+from "WSL lost internet", so we capture that from inside WSL.
+"""
+
+from __future__ import annotations
+
+import json as json_mod
+import os
+import sys
+
+import click
+
+from ..network_probe import DEFAULT_HUB_HOST, DEFAULT_HUB_PORT, DEFAULT_HUB_URL, run_and_log
+
+
+@click.command("probe-network")
+@click.option(
+    "--agent",
+    "-a",
+    default=None,
+    help="Agent name for the JSONL log filename. "
+    "Defaults to $SCITEX_OROCHI_AGENT or 'anonymous-agent'.",
+)
+@click.option(
+    "--hub-host",
+    default=DEFAULT_HUB_HOST,
+    help=f"Hub hostname to probe. Default: {DEFAULT_HUB_HOST}",
+)
+@click.option(
+    "--hub-port",
+    default=DEFAULT_HUB_PORT,
+    type=int,
+    help=f"Hub TCP port. Default: {DEFAULT_HUB_PORT}",
+)
+@click.option(
+    "--hub-url",
+    default=DEFAULT_HUB_URL,
+    help=f"Hub URL for the HTTPS probe. Default: {DEFAULT_HUB_URL}",
+)
+@click.option(
+    "--timeout",
+    default=3.0,
+    type=float,
+    help="Per-probe timeout in seconds. Default: 3.0",
+)
+@click.option(
+    "--quiet",
+    "-q",
+    is_flag=True,
+    default=False,
+    help="Suppress stdout — log to JSONL only. Useful from cron.",
+)
+@click.option(
+    "--exit-nonzero-on-fail",
+    is_flag=True,
+    default=False,
+    help="Exit with status 1 if any probe fails. Lets cron/systemd "
+    "alert on sustained failure.",
+)
+def probe_network(
+    agent: str | None,
+    hub_host: str,
+    hub_port: int,
+    hub_url: str,
+    timeout: float,
+    quiet: bool,
+    exit_nonzero_on_fail: bool,
+) -> None:
+    """Probe WSL → fleet-hub connectivity (todo#457).
+
+    Runs four probes (DNS → default gateway → TCP → HTTPS) and writes
+    the result as one JSONL line under
+    ``~/.scitex/agent-container/logs/network/<agent>.jsonl``.
+
+    The output is designed to be correlated with fleet-side SSH-dead
+    logs: when the fleet's SSH probe to this host fails, we have a
+    timestamp-aligned ``probes`` record from inside WSL proving which
+    layer actually broke (DNS vs LAN vs hub-reach vs TLS).
+    """
+    effective_agent = (
+        agent
+        or os.environ.get("SCITEX_OROCHI_AGENT")
+        or os.environ.get("CLAUDE_AGENT_ID")
+        or "anonymous-agent"
+    )
+    summary = run_and_log(
+        effective_agent,
+        hub_host=hub_host,
+        hub_port=hub_port,
+        hub_url=hub_url,
+        timeout=timeout,
+    )
+    if not quiet:
+        click.echo(json_mod.dumps(summary, indent=2))
+    if exit_nonzero_on_fail and not summary["ok"]:
+        sys.exit(1)

--- a/src/scitex_agent_container/network_probe.py
+++ b/src/scitex_agent_container/network_probe.py
@@ -1,0 +1,382 @@
+"""WSL ↔ fleet-hub connectivity probe.
+
+Filed under ``todo#457`` (bug(infra/wsl): ywata-note-win loses WSL
+internet connectivity periodically). When the WSL side drops
+connectivity to the Orochi hub, the fleet's external view becomes
+``Connection timed out during banner exchange`` — the WSL agents
+look dead from outside but the Windows host itself is usually fine.
+
+This module does not *fix* the root cause (that requires Windows-side
+action on the NIC power-save / Wi-Fi roam / ``.wslconfig`` settings).
+What it does add is **local, unambiguous evidence** that can be
+correlated with fleet-side outages:
+
+1. Is DNS working from inside WSL? (``gethostbyname`` on hub host).
+2. Is IPv4 / IPv6 route to the hub open? (``socket.create_connection``
+   to port 443 with a short timeout — no HTTPS handshake).
+3. Does a TLS handshake + HTTP GET to the hub complete? (full round
+   trip via ``urllib.request`` — catches captive portals / stale
+   TLS resumes).
+4. Is the default gateway reachable? (LAN-side check — if this fails
+   but (1)-(3) pass we learn Wi-Fi roam happened but routing survived).
+
+Each probe records ``(ok, latency_ms, err)`` into a JSONL ring at
+``~/.scitex/agent-container/logs/network/<agent>.jsonl`` so the next
+incident leaves a timeline the fleet can diff against SSH-dead logs
+from other hosts.
+
+Design rules
+------------
+- **Non-agentic.** Pure functions + one writer. No LLM calls.
+- **Stdlib only.** ``socket``, ``ssl``, ``urllib.request``, ``json``,
+  ``pathlib``. No ``requests``, no ``psutil``, no DNS libs — the whole
+  point is to work when higher-level networking is breaking.
+- **Fail-closed but never raise.** Any probe that fails returns a
+  ``ProbeResult`` with ``ok=False`` and an ``err`` string. The writer
+  swallows disk exceptions so a probe call never breaks a caller.
+- **Short timeouts.** Default 3s per probe so a full run takes <15s
+  even when every layer is hanging.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import socket
+import ssl
+import time
+import urllib.error
+import urllib.request
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+DEFAULT_HUB_HOST = "scitex-orochi.com"
+DEFAULT_HUB_PORT = 443
+DEFAULT_HUB_URL = f"https://{DEFAULT_HUB_HOST}/"
+DEFAULT_TIMEOUT_S = 3.0
+
+DEFAULT_LOG_ROOT = (
+    Path(os.environ.get("XDG_DATA_HOME") or Path.home() / ".scitex")
+    / "agent-container"
+    / "logs"
+    / "network"
+)
+
+
+@dataclass
+class ProbeResult:
+    """Outcome of one probe layer.
+
+    ``name`` identifies the layer ("dns", "tcp", "https", "gateway").
+    ``ok`` is the binary success flag. ``latency_ms`` is wall-clock
+    round-trip time, **not** RTT of a specific packet — it includes
+    any retries the kernel did internally.
+    """
+
+    name: str
+    ok: bool
+    latency_ms: float
+    err: str = ""
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def probe_dns(
+    host: str = DEFAULT_HUB_HOST,
+    *,
+    timeout: float = DEFAULT_TIMEOUT_S,
+) -> ProbeResult:
+    """Resolve ``host`` to an IP address.
+
+    ``socket.getaddrinfo`` honours ``/etc/resolv.conf`` ordering and
+    returns AF_INET + AF_INET6 entries, so we see IPv4 and IPv6 both.
+    We apply ``timeout`` indirectly by using a global ``setdefaulttimeout``
+    around the call — there is no per-call resolver timeout in stdlib.
+    """
+    start = time.monotonic()
+    old = socket.getdefaulttimeout()
+    try:
+        socket.setdefaulttimeout(timeout)
+        infos = socket.getaddrinfo(host, None)
+        addrs = sorted({sockaddr[0] for (_f, _t, _p, _c, sockaddr) in infos})
+        latency_ms = (time.monotonic() - start) * 1000.0
+        return ProbeResult(
+            name="dns",
+            ok=True,
+            latency_ms=latency_ms,
+            extra={"addrs": addrs},
+        )
+    except Exception as exc:  # pragma: no cover - exercised via fake
+        latency_ms = (time.monotonic() - start) * 1000.0
+        return ProbeResult(
+            name="dns",
+            ok=False,
+            latency_ms=latency_ms,
+            err=f"{type(exc).__name__}: {exc}",
+        )
+    finally:
+        socket.setdefaulttimeout(old)
+
+
+def probe_tcp(
+    host: str = DEFAULT_HUB_HOST,
+    port: int = DEFAULT_HUB_PORT,
+    *,
+    timeout: float = DEFAULT_TIMEOUT_S,
+) -> ProbeResult:
+    """Open a TCP connection to ``host:port``; close immediately.
+
+    Does NOT speak TLS — we want to isolate "routing/firewall reachable"
+    from "TLS/HTTP works". A captive portal returning a 200 OK to any
+    request would pass ``probe_https`` but also passes this layer.
+    """
+    start = time.monotonic()
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            pass
+        latency_ms = (time.monotonic() - start) * 1000.0
+        return ProbeResult(name="tcp", ok=True, latency_ms=latency_ms)
+    except Exception as exc:
+        latency_ms = (time.monotonic() - start) * 1000.0
+        return ProbeResult(
+            name="tcp",
+            ok=False,
+            latency_ms=latency_ms,
+            err=f"{type(exc).__name__}: {exc}",
+        )
+
+
+def probe_https(
+    url: str = DEFAULT_HUB_URL,
+    *,
+    timeout: float = DEFAULT_TIMEOUT_S,
+    expected_status_prefix: str = "",
+) -> ProbeResult:
+    """GET ``url`` and record status + latency.
+
+    Any 2xx/3xx/4xx counts as "the tunnel is up" because even a 404
+    means packets are flowing end-to-end and TLS completed. Only 5xx
+    from the hub or transport errors mark a failure.
+
+    ``expected_status_prefix`` lets callers tighten (e.g. ``"2"``)
+    if they actually need a 2xx.
+    """
+    start = time.monotonic()
+    try:
+        ctx = ssl.create_default_context()
+        req = urllib.request.Request(url, method="GET")
+        with urllib.request.urlopen(req, timeout=timeout, context=ctx) as resp:
+            status = resp.status
+            latency_ms = (time.monotonic() - start) * 1000.0
+            ok = status < 500 and (
+                not expected_status_prefix
+                or str(status).startswith(expected_status_prefix)
+            )
+            return ProbeResult(
+                name="https",
+                ok=ok,
+                latency_ms=latency_ms,
+                err="" if ok else f"status={status}",
+                extra={"status": status},
+            )
+    except urllib.error.HTTPError as exc:
+        # Cloudflare / hub returning 4xx is still "transport ok".
+        latency_ms = (time.monotonic() - start) * 1000.0
+        status = exc.code
+        ok = status < 500 and (
+            not expected_status_prefix
+            or str(status).startswith(expected_status_prefix)
+        )
+        return ProbeResult(
+            name="https",
+            ok=ok,
+            latency_ms=latency_ms,
+            err="" if ok else f"status={status}",
+            extra={"status": status},
+        )
+    except Exception as exc:
+        latency_ms = (time.monotonic() - start) * 1000.0
+        return ProbeResult(
+            name="https",
+            ok=False,
+            latency_ms=latency_ms,
+            err=f"{type(exc).__name__}: {exc}",
+        )
+
+
+_ROUTE_RE = re.compile(r"^default\s+via\s+(\S+)\s+dev\s+\S+", re.M)
+
+
+def _parse_default_gateway(ip_route_output: str) -> str | None:
+    """Extract the IPv4 default gateway from ``ip route`` output.
+
+    Returns ``None`` if no default route is present (which is itself
+    a strong diagnostic signal).
+    """
+    m = _ROUTE_RE.search(ip_route_output or "")
+    return m.group(1) if m else None
+
+
+def _read_ip_route() -> str:
+    """Read ``/proc/net/route`` and format it like ``ip route`` default.
+
+    We deliberately do not shell out to ``/sbin/ip`` because some WSL
+    distros drop the binary or require sudo. Reading the proc file
+    always works.
+    """
+    path = Path("/proc/net/route")
+    if not path.exists():
+        return ""
+    try:
+        lines = path.read_text().splitlines()
+    except OSError:
+        return ""
+    # /proc/net/route columns: Iface Destination Gateway Flags RefCnt Use Metric Mask ...
+    # A default route has Destination == "00000000".
+    for line in lines[1:]:
+        parts = line.split()
+        if len(parts) < 3:
+            continue
+        dest_hex, gw_hex = parts[1], parts[2]
+        if dest_hex != "00000000":
+            continue
+        # gw_hex is little-endian IPv4 bytes.
+        try:
+            gw_int = int(gw_hex, 16)
+        except ValueError:
+            continue
+        octets = [(gw_int >> (8 * i)) & 0xFF for i in range(4)]
+        gw = ".".join(str(o) for o in octets)
+        return f"default via {gw} dev {parts[0]}\n"
+    return ""
+
+
+def probe_gateway(
+    *,
+    timeout: float = DEFAULT_TIMEOUT_S,
+    ip_route_reader=_read_ip_route,
+) -> ProbeResult:
+    """Try a TCP SYN to the default gateway on port 53 (DNS).
+
+    Port 53 is used because most home routers / captive gateways
+    listen there. This is a best-effort LAN-reachability check — if
+    the gateway silently drops port 53 we still mark ok=False, which
+    is a false negative the caller should interpret loosely.
+    """
+    start = time.monotonic()
+    route_output = ip_route_reader() if callable(ip_route_reader) else str(ip_route_reader or "")
+    gw = _parse_default_gateway(route_output)
+    if not gw:
+        latency_ms = (time.monotonic() - start) * 1000.0
+        return ProbeResult(
+            name="gateway",
+            ok=False,
+            latency_ms=latency_ms,
+            err="no default route",
+        )
+    try:
+        with socket.create_connection((gw, 53), timeout=timeout):
+            pass
+        latency_ms = (time.monotonic() - start) * 1000.0
+        return ProbeResult(
+            name="gateway",
+            ok=True,
+            latency_ms=latency_ms,
+            extra={"gateway": gw},
+        )
+    except Exception as exc:
+        latency_ms = (time.monotonic() - start) * 1000.0
+        return ProbeResult(
+            name="gateway",
+            ok=False,
+            latency_ms=latency_ms,
+            err=f"{type(exc).__name__}: {exc}",
+            extra={"gateway": gw},
+        )
+
+
+def run_all_probes(
+    *,
+    hub_host: str = DEFAULT_HUB_HOST,
+    hub_port: int = DEFAULT_HUB_PORT,
+    hub_url: str = DEFAULT_HUB_URL,
+    timeout: float = DEFAULT_TIMEOUT_S,
+) -> list[ProbeResult]:
+    """Run the four probes in the order dns → gateway → tcp → https.
+
+    DNS first because hub_host is a name; if DNS fails TCP/HTTPS will
+    also fail with a confusing error. Gateway second so we can tell
+    "lost Wi-Fi" from "lost DNS only". TCP before HTTPS so a TLS
+    failure is distinguishable from a routing failure.
+    """
+    return [
+        probe_dns(hub_host, timeout=timeout),
+        probe_gateway(timeout=timeout),
+        probe_tcp(hub_host, hub_port, timeout=timeout),
+        probe_https(hub_url, timeout=timeout),
+    ]
+
+
+def summarise(results: Iterable[ProbeResult]) -> dict[str, Any]:
+    """Collapse N probe results into a single JSON-friendly dict."""
+    results = list(results)
+    return {
+        "ts": _now_iso(),
+        "ok": all(r.ok for r in results),
+        "probes": [asdict(r) for r in results],
+    }
+
+
+def _log_path(agent: str, root: Path | None = None) -> Path:
+    base = Path(root) if root else DEFAULT_LOG_ROOT
+    base.mkdir(parents=True, exist_ok=True)
+    safe = re.sub(r"[^a-zA-Z0-9_.\-]", "-", agent or "anonymous-agent")
+    return base / f"{safe}.jsonl"
+
+
+def append_result(
+    agent: str,
+    summary: dict[str, Any],
+    *,
+    root: Path | None = None,
+) -> Path | None:
+    """Append one summary dict to the per-agent JSONL ring.
+
+    Returns the path written to, or ``None`` if the write failed.
+    Does not rotate — the file is append-only and small (one line per
+    run, <1 KiB); ops rotates weekly via logrotate if needed.
+    """
+    try:
+        path = _log_path(agent, root=root)
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(summary, separators=(",", ":")) + "\n")
+        return path
+    except Exception:
+        return None
+
+
+def run_and_log(
+    agent: str,
+    *,
+    hub_host: str = DEFAULT_HUB_HOST,
+    hub_port: int = DEFAULT_HUB_PORT,
+    hub_url: str = DEFAULT_HUB_URL,
+    timeout: float = DEFAULT_TIMEOUT_S,
+    root: Path | None = None,
+) -> dict[str, Any]:
+    """One-shot convenience: run all probes, log, return the summary."""
+    results = run_all_probes(
+        hub_host=hub_host,
+        hub_port=hub_port,
+        hub_url=hub_url,
+        timeout=timeout,
+    )
+    summary = summarise(results)
+    append_result(agent, summary, root=root)
+    return summary

--- a/tests/test_network_probe.py
+++ b/tests/test_network_probe.py
@@ -1,0 +1,283 @@
+"""Tests for the WSL↔hub connectivity probe (todo#457).
+
+All tests run offline by injecting fake behaviour into the module's
+socket / urllib surface. Real network probes are exercised by
+``tests/integration`` (not included here — this suite must stay green
+on any CI host, including ones with no outbound egress).
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container import network_probe as np
+
+
+# ── probe_dns ────────────────────────────────────────────────────────────────
+
+
+class TestProbeDNS:
+    def test_ok_returns_sorted_addrs(self, monkeypatch):
+        def fake_getaddrinfo(host, port, *a, **kw):
+            return [
+                (socket.AF_INET, 1, 6, "", ("1.2.3.4", 0)),
+                (socket.AF_INET6, 1, 6, "", ("::1", 0, 0, 0)),
+                (socket.AF_INET, 1, 6, "", ("1.2.3.4", 0)),  # dedup
+            ]
+
+        monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+        r = np.probe_dns("example.test")
+        assert r.ok is True
+        assert r.name == "dns"
+        assert r.extra["addrs"] == ["1.2.3.4", "::1"]
+        assert r.latency_ms >= 0.0
+
+    def test_failure_records_error(self, monkeypatch):
+        def boom(*a, **kw):
+            raise socket.gaierror("Name or service not known")
+
+        monkeypatch.setattr(socket, "getaddrinfo", boom)
+        r = np.probe_dns("example.test")
+        assert r.ok is False
+        assert "gaierror" in r.err
+
+
+# ── probe_tcp ────────────────────────────────────────────────────────────────
+
+
+class TestProbeTCP:
+    def test_ok_closes_connection(self, monkeypatch):
+        class FakeSock:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                pass
+
+        def fake_create_connection(addr, timeout):
+            assert addr == ("hub.test", 443)
+            return FakeSock()
+
+        monkeypatch.setattr(socket, "create_connection", fake_create_connection)
+        r = np.probe_tcp("hub.test", 443)
+        assert r.ok is True
+        assert r.name == "tcp"
+
+    def test_failure_records_error(self, monkeypatch):
+        def boom(*a, **kw):
+            raise TimeoutError("timed out")
+
+        monkeypatch.setattr(socket, "create_connection", boom)
+        r = np.probe_tcp("hub.test", 443, timeout=0.1)
+        assert r.ok is False
+        assert "TimeoutError" in r.err
+
+
+# ── probe_https ──────────────────────────────────────────────────────────────
+
+
+class TestProbeHTTPS:
+    def test_2xx_ok(self, monkeypatch):
+        class FakeResp:
+            status = 200
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                pass
+
+        monkeypatch.setattr(
+            np.urllib.request,
+            "urlopen",
+            lambda *a, **kw: FakeResp(),
+        )
+        r = np.probe_https("https://hub.test/")
+        assert r.ok is True
+        assert r.extra["status"] == 200
+
+    def test_404_counts_as_transport_ok(self, monkeypatch):
+        """A 404 still proves TLS + HTTP handshake completed."""
+
+        class FakeResp:
+            status = 404
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                pass
+
+        monkeypatch.setattr(
+            np.urllib.request,
+            "urlopen",
+            lambda *a, **kw: FakeResp(),
+        )
+        r = np.probe_https("https://hub.test/")
+        assert r.ok is True  # <500 is still transport ok
+        assert r.extra["status"] == 404
+
+    def test_expected_status_prefix_tightens(self, monkeypatch):
+        class FakeResp:
+            status = 404
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                pass
+
+        monkeypatch.setattr(
+            np.urllib.request,
+            "urlopen",
+            lambda *a, **kw: FakeResp(),
+        )
+        r = np.probe_https("https://hub.test/", expected_status_prefix="2")
+        assert r.ok is False
+        assert "status=404" in r.err
+
+    def test_connection_refused_fails(self, monkeypatch):
+        def boom(*a, **kw):
+            raise ConnectionRefusedError("refused")
+
+        monkeypatch.setattr(np.urllib.request, "urlopen", boom)
+        r = np.probe_https("https://hub.test/")
+        assert r.ok is False
+        assert "ConnectionRefusedError" in r.err
+
+
+# ── default-gateway parsing ──────────────────────────────────────────────────
+
+
+class TestParseDefaultGateway:
+    def test_extracts_ipv4_gateway(self):
+        text = (
+            "default via 192.168.11.1 dev eth0 proto kernel metric 25\n"
+            "172.17.0.0/16 dev docker0 proto kernel scope link\n"
+        )
+        assert np._parse_default_gateway(text) == "192.168.11.1"
+
+    def test_returns_none_when_no_default(self):
+        assert np._parse_default_gateway("172.17.0.0/16 dev docker0\n") is None
+
+    def test_empty_input(self):
+        assert np._parse_default_gateway("") is None
+
+
+class TestProbeGateway:
+    def test_no_default_route_is_fail(self, monkeypatch):
+        r = np.probe_gateway(ip_route_reader=lambda: "")
+        assert r.ok is False
+        assert "no default route" in r.err
+
+    def test_reachable_gateway_ok(self, monkeypatch):
+        class FakeSock:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                pass
+
+        monkeypatch.setattr(
+            socket,
+            "create_connection",
+            lambda addr, timeout: FakeSock(),
+        )
+        r = np.probe_gateway(
+            ip_route_reader=lambda: "default via 10.0.0.1 dev eth0\n"
+        )
+        assert r.ok is True
+        assert r.extra["gateway"] == "10.0.0.1"
+
+    def test_unreachable_gateway_fail(self, monkeypatch):
+        def boom(addr, timeout):
+            raise TimeoutError("timed out")
+
+        monkeypatch.setattr(socket, "create_connection", boom)
+        r = np.probe_gateway(
+            ip_route_reader=lambda: "default via 10.0.0.1 dev eth0\n",
+            timeout=0.1,
+        )
+        assert r.ok is False
+        assert "TimeoutError" in r.err
+        assert r.extra["gateway"] == "10.0.0.1"
+
+
+# ── run_all_probes / summarise ───────────────────────────────────────────────
+
+
+class TestRunAll:
+    def test_order_is_dns_gateway_tcp_https(self, monkeypatch):
+        calls: list[str] = []
+
+        def log(name):
+            def _inner(*a, **kw):
+                calls.append(name)
+                return np.ProbeResult(name=name, ok=True, latency_ms=1.0)
+
+            return _inner
+
+        monkeypatch.setattr(np, "probe_dns", log("dns"))
+        monkeypatch.setattr(np, "probe_gateway", log("gateway"))
+        monkeypatch.setattr(np, "probe_tcp", log("tcp"))
+        monkeypatch.setattr(np, "probe_https", log("https"))
+
+        np.run_all_probes()
+        assert calls == ["dns", "gateway", "tcp", "https"]
+
+    def test_summarise_all_ok(self):
+        results = [
+            np.ProbeResult(name="dns", ok=True, latency_ms=1.0),
+            np.ProbeResult(name="https", ok=True, latency_ms=2.0),
+        ]
+        s = np.summarise(results)
+        assert s["ok"] is True
+        assert len(s["probes"]) == 2
+        assert s["probes"][0]["name"] == "dns"
+
+    def test_summarise_any_fail(self):
+        results = [
+            np.ProbeResult(name="dns", ok=True, latency_ms=1.0),
+            np.ProbeResult(name="https", ok=False, latency_ms=2.0, err="refused"),
+        ]
+        s = np.summarise(results)
+        assert s["ok"] is False
+
+
+# ── append_result / run_and_log ──────────────────────────────────────────────
+
+
+class TestLogging:
+    def test_append_result_writes_jsonl(self, tmp_path: Path):
+        summary = {"ts": "2026-04-21T00:00:00+00:00", "ok": True, "probes": []}
+        path = np.append_result("head-ywata-note-win", summary, root=tmp_path)
+        assert path is not None
+        text = path.read_text()
+        assert json.loads(text.strip()) == summary
+
+    def test_append_result_appends_multiple(self, tmp_path: Path):
+        np.append_result("a", {"i": 1}, root=tmp_path)
+        np.append_result("a", {"i": 2}, root=tmp_path)
+        lines = (tmp_path / "a.jsonl").read_text().splitlines()
+        assert [json.loads(l) for l in lines] == [{"i": 1}, {"i": 2}]
+
+    def test_append_result_sanitises_agent_name(self, tmp_path: Path):
+        path = np.append_result("weird/name with spaces", {}, root=tmp_path)
+        assert path is not None
+        assert "/" not in path.name
+        assert " " not in path.name
+
+    def test_run_and_log_end_to_end(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setattr(
+            np,
+            "run_all_probes",
+            lambda **kw: [np.ProbeResult(name="dns", ok=True, latency_ms=1.0)],
+        )
+        summary = np.run_and_log("head-ywata-note-win", root=tmp_path)
+        assert summary["ok"] is True
+        path = tmp_path / "head-ywata-note-win.jsonl"
+        assert path.exists()

--- a/tests/test_probe_cmds.py
+++ b/tests/test_probe_cmds.py
@@ -1,0 +1,84 @@
+"""Tests for the ``probe-network`` CLI command (todo#457)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from scitex_agent_container import network_probe as np
+from scitex_agent_container.cli import main
+
+
+def _fake_all_ok(**_kwargs):
+    return [
+        np.ProbeResult(name="dns", ok=True, latency_ms=1.0),
+        np.ProbeResult(name="gateway", ok=True, latency_ms=1.0),
+        np.ProbeResult(name="tcp", ok=True, latency_ms=1.0),
+        np.ProbeResult(name="https", ok=True, latency_ms=1.0),
+    ]
+
+
+def _fake_dns_fail(**_kwargs):
+    return [
+        np.ProbeResult(name="dns", ok=False, latency_ms=1.0, err="gaierror"),
+        np.ProbeResult(name="gateway", ok=True, latency_ms=1.0),
+        np.ProbeResult(name="tcp", ok=False, latency_ms=1.0, err="gaierror"),
+        np.ProbeResult(name="https", ok=False, latency_ms=1.0, err="gaierror"),
+    ]
+
+
+class TestProbeNetworkCLI:
+    def test_all_ok_returns_zero(self, monkeypatch, tmp_path: Path):
+        monkeypatch.setattr(np, "run_all_probes", _fake_all_ok)
+        monkeypatch.setattr(np, "DEFAULT_LOG_ROOT", tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["probe-network", "--agent", "test-agent", "--quiet"],
+        )
+        assert result.exit_code == 0, result.output
+        path = tmp_path / "test-agent.jsonl"
+        assert path.exists()
+        payload = json.loads(path.read_text().strip())
+        assert payload["ok"] is True
+        assert len(payload["probes"]) == 4
+
+    def test_non_quiet_prints_json(self, monkeypatch, tmp_path: Path):
+        monkeypatch.setattr(np, "run_all_probes", _fake_all_ok)
+        monkeypatch.setattr(np, "DEFAULT_LOG_ROOT", tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(main, ["probe-network", "--agent", "a"])
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["ok"] is True
+
+    def test_exit_nonzero_on_fail(self, monkeypatch, tmp_path: Path):
+        monkeypatch.setattr(np, "run_all_probes", _fake_dns_fail)
+        monkeypatch.setattr(np, "DEFAULT_LOG_ROOT", tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "probe-network",
+                "--agent",
+                "a",
+                "--quiet",
+                "--exit-nonzero-on-fail",
+            ],
+        )
+        assert result.exit_code == 1
+        path = tmp_path / "a.jsonl"
+        assert path.exists()
+        payload = json.loads(path.read_text().strip())
+        assert payload["ok"] is False
+
+    def test_env_fallback_for_agent(self, monkeypatch, tmp_path: Path):
+        monkeypatch.setattr(np, "run_all_probes", _fake_all_ok)
+        monkeypatch.setattr(np, "DEFAULT_LOG_ROOT", tmp_path)
+        monkeypatch.setenv("SCITEX_OROCHI_AGENT", "head-ywata-note-win")
+        runner = CliRunner()
+        result = runner.invoke(main, ["probe-network", "--quiet"])
+        assert result.exit_code == 0
+        assert (tmp_path / "head-ywata-note-win.jsonl").exists()


### PR DESCRIPTION
## Summary

- Adds ``scitex_agent_container.network_probe`` (stdlib-only DNS /
  gateway / TCP / HTTPS reachability probe) and a
  ``scitex-agent-container probe-network`` CLI for todo#457.
- Probes write a JSONL timeline to
  ``~/.scitex/agent-container/logs/network/<agent>.jsonl`` so the
  fleet can correlate WSL-side evidence with external SSH-dead reports.
- Ships a skill doc (``_skills/.../wsl-connectivity.md``) documenting
  the Windows-side mitigations that only ywatanabe can apply and the
  on-host evidence that ruled out hypothesis classes 1-3 on
  ywata-note-win.

## Baseline (updated 2026-04-21)

**Wired LAN + mirrored mode.** Per ywatanabe msg#15405 the Windows
host has been switched off Wi-Fi onto a stable wired Ethernet link.
SSID-roam / 2.4 vs 5 GHz concerns are no longer in scope; remaining
live failure modes are Ethernet NIC power-save and DHCP lease churn
on the wired adapter. The ``network_probe`` code is IP-address-
agnostic and requires no change for this transition.

## Findings from live host (ywata-note-win, 2026-04-21)

- ``/sbin/ip addr`` -> ``eth0 192.168.11.28/24`` (LAN IP, not WSL NAT),
  and ``/mnt/c/Users/wyusu/.wslconfig`` contains
  ``networkingMode=mirrored``. **Classes 1 (NAT bridge) and 2 (vswitch
  desync) are eliminated.**
- ``cloudflared`` is installed at ``~/.local/bin/cloudflared`` but is
  not running and not registered as a systemd unit. **Class 3 is
  N/A for this host** -- the tunnel outage in the issue is NAS-side.
- ``ping scitex-orochi.com`` -> 25ms RTT, 0% loss. Currently healthy.
- Under mirrored mode + wired LAN, Windows-side NIC power-save
  (class 4) and DHCP lease renegotiation on the Ethernet adapter
  (reduced-scope class 5) remain the leading hypotheses.

## Scope

This PR **does not** fix the root cause; the root cause is Windows-
side NIC power management / DHCP behaviour on the wired adapter,
which only ywatanabe can adjust on the machine. What this PR does:

- Provides unambiguous **WSL-side evidence** for future incidents so
  the fleet stops guessing between "Windows asleep", "WSL lost net",
  and "Claude TUI frozen".
- Gives ywatanabe an exact recipe (in the skill doc) for the Windows-
  side steps, plus a copy-pasteable cron line to start collecting
  baseline data immediately.

## Test plan

- [x] Unit tests for all four probe layers with monkeypatched
      ``socket`` / ``urllib`` (``tests/test_network_probe.py``, 21 cases).
- [x] CLI tests for ``probe-network`` success/failure/quiet/env paths
      (``tests/test_probe_cmds.py``, 4 cases).
- [x] Full pre-existing ``tests/test_cli.py`` still passes (25 cases).
- [x] Live smoke run on ywata-note-win:
      ``scitex-agent-container probe-network --agent smoke-test``
      returns ``ok: true`` with all four layers green.

## Remaining Windows-side actions (blocked on ywatanabe)

1. Disable Windows NIC power-save on the wired Ethernet adapter
   (``Set-NetAdapterPowerManagement ... Disabled``).
2. Static DHCP reservation for the Windows host's wired MAC on the
   home router.

(Wi-Fi SSID preference review is no longer applicable now that the
host is on wired LAN.)

Details in
``src/scitex_agent_container/_skills/scitex-agent-container/wsl-connectivity.md``.

Filed per todo#457 (ywatanabe1989/todo).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
