### PR TITLE
fix(src_files): refresh workspace .mcp.json on every start (todo#453)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-agent-container"
-version = "0.8.0"
+version = "0.8.1"
 description = "Declarative YAML-based framework for defining, managing, and orchestrating AI coding agent instances"
 readme = "README.md"
 license = "AGPL-3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-agent-container"
-version = "0.7.2"
+version = "0.8.0"
 description = "Declarative YAML-based framework for defining, managing, and orchestrating AI coding agent instances"
 readme = "README.md"
 license = "AGPL-3.0"

--- a/src/scitex_agent_container/_skills/scitex-agent-container/wsl-connectivity.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/wsl-connectivity.md
@@ -1,0 +1,166 @@
+# WSL ↔ Fleet-Hub Connectivity (todo#457)
+
+## Problem
+
+`ywata-note-win` (Windows 11 + WSL2) periodically drops WSL-side
+internet connectivity. The fleet sees this as "SSH dead" (banner-
+exchange timeout, then connection-refused), which is indistinguish-
+able from "host asleep" unless the WSL side leaves a local trail.
+
+## What the evidence shows (from this host)
+
+One-shot diagnostics on 2026-04-21:
+
+- `/sbin/ip addr` → `eth0` has `192.168.11.28/24`, a LAN IP (NOT
+  the WSL NAT `172.x.x.x` range). This proves
+  **`networkingMode=mirrored` is already active** — the
+  `.wslconfig` at `/mnt/c/Users/wyusu/.wslconfig` contains
+  `[wsl2] networkingMode=mirrored`.
+- `/sbin/ip route` → default via `192.168.11.1` (the home router)
+  on `eth0`. No separate WSL-bridge hop.
+- `/etc/resolv.conf` → `nameserver 8.8.8.8 / 8.8.4.4` (Google DNS,
+  static). `/etc/wsl.conf` has `generateResolvConf = false`, so
+  DNS is not rewritten on boot.
+- `ping scitex-orochi.com` → 25 ms RTT, 0% loss. Right now the
+  pipe is healthy.
+- `cloudflared` → installed at `~/.local/bin/cloudflared`, **not a
+  systemd service and not currently running**. The cloudflared
+  tunnel failures described in todo#457 are on the **NAS side**
+  dialling *into* a WSL-hosted bastion; they are not owned by this
+  host's head agent.
+
+## What this means for the hypotheses in todo#457
+
+| # | Hypothesis | Status |
+|---|---|---|
+| 1 | WSL2 NAT bridge instability | **Eliminated.** Mirrored mode removes the NAT bridge. |
+| 2 | Hyper-V vswitch desync on NIC change | **Partly eliminated.** Mirrored mode uses the host's NIC directly. |
+| 3 | cloudflared tunnel uplink expiry | **N/A for this host.** No cloudflared service runs here. Belongs to head-nas. |
+| 4 | Windows NIC power-save | **Still live.** Mirrored mode means WSL's eth0 IS the Windows NIC — if Windows powers it down, WSL loses connectivity immediately. |
+| 5 | Wi-Fi roam / DHCP lease | **Amplified by mirrored mode.** Lease expiry on the host re-IPs WSL's `eth0` directly; any TCP connection across the transition breaks. |
+
+## Mitigations that require ywatanabe-side Windows action
+
+These cannot be done from inside WSL. They are the actual root-
+cause fixes; everything below the line is WSL-side visibility.
+
+1. **Disable Windows NIC power-save.** In PowerShell (admin):
+   ```powershell
+   Get-NetAdapter | Where-Object {$_.Status -eq "Up"} |
+     Set-NetAdapterPowerManagement -AllowComputerToTurnOffDevice Disabled
+   ```
+   One-shot, survives reboots.
+2. **Consider static DHCP reservation** on the router for this
+   host. With mirrored mode, every DHCP re-negotiation hits WSL.
+   A static reservation eliminates lease-expiry churn.
+3. **For Wi-Fi specifically,** consider preferring the 5 GHz SSID
+   over the 2.4 GHz one (disable "connect to this network
+   automatically" on the weaker of the two) — roaming between
+   them retriggers the network-change event that mirrored mode
+   propagates into WSL.
+4. **Leave `networkingMode=mirrored` as-is.** The alternative
+   (NAT bridge) is the *previous* failure mode the fleet was
+   hitting before this setting was applied.
+
+## Mitigations available on the WSL side (what this PR ships)
+
+Since the fleet-facing symptom is "SSH dead, cause unknown", the
+WSL-side contribution is **unambiguous evidence** that the outage
+is connectivity, not a crashed Claude process. Use the probe
+command shipped in this package.
+
+### One-shot manual probe
+
+```bash
+scitex-agent-container probe-network --agent head-$(hostname)
+```
+
+Output (when healthy):
+
+```json
+{
+  "ts": "2026-04-21T09:30:00+00:00",
+  "ok": true,
+  "probes": [
+    {"name": "dns", "ok": true, "latency_ms": 4.1, "extra": {"addrs": ["104.19.xx.xx", "172.67.xx.xx"]}},
+    {"name": "gateway", "ok": true, "latency_ms": 1.3, "extra": {"gateway": "192.168.11.1"}},
+    {"name": "tcp", "ok": true, "latency_ms": 13.2},
+    {"name": "https", "ok": true, "latency_ms": 45.0, "extra": {"status": 200}}
+  ]
+}
+```
+
+When the WSL side is broken, the first probe to fail tells you the
+layer that actually broke:
+
+| First failure | Diagnosis |
+|---|---|
+| `dns` | resolver unreachable — `/etc/resolv.conf` nameserver (8.8.8.8) is blocked or Wi-Fi is actually down |
+| `gateway` (but `dns` ok) | rare — DNS is cached / UDP-only while LAN routing died |
+| `gateway` AND `dns` | Wi-Fi roam or NIC power-save just kicked in |
+| `tcp` (but `dns` + `gateway` ok) | hub unreachable: firewall / Cloudflare regional |
+| `https` only | TLS handshake or captive-portal interposing |
+
+The probe writes one JSONL line per run to
+`~/.scitex/agent-container/logs/network/<agent>.jsonl`. This is
+the ring the fleet correlates against its own SSH-dead timestamps.
+
+### Cron-style continuous probe
+
+To leave a timeline the fleet can grep after the next incident,
+run the probe every minute from WSL's user systemd / cron:
+
+```cron
+* * * * * /home/ywatanabe/.venv/bin/scitex-agent-container probe-network \
+            --agent head-ywata-note-win --quiet >/dev/null 2>&1
+```
+
+Or via tmux/screen one-liner for a single session:
+
+```bash
+while true; do
+  scitex-agent-container probe-network --agent head-ywata-note-win --quiet
+  sleep 60
+done &
+```
+
+### Exit-code behaviour for systemd/monit integration
+
+Pass `--exit-nonzero-on-fail` if you want a wrapper script to alert
+on sustained failure:
+
+```bash
+scitex-agent-container probe-network --agent head-ywata-note-win \
+    --quiet --exit-nonzero-on-fail \
+    || notify-send "WSL→hub down"
+```
+
+## Correlating with fleet-side SSH-dead events
+
+When the fleet reports `ssh ywata-note-win` timing out, the fleet
+cannot tell whether:
+
+- the laptop lid is closed (Windows asleep),
+- the laptop is awake but WSL lost Wi-Fi,
+- the laptop is awake and WSL has internet but the SSH service
+  restarted,
+- or Claude Code TUI crashed while the rest of the host is fine.
+
+A minute-granular probe log on WSL disambiguates all four:
+
+- Absent log lines in the window → **Windows host was asleep**
+  (WSL was not running). Fix: disable lid-close / power settings.
+- Present lines but `ok=false` → **WSL lost external connectivity**.
+  Fix: apply one of the Windows-side mitigations above.
+- Present lines and `ok=true` → **WSL was fine**, so the SSH-dead
+  signal is a false positive. Fix: investigate the fleet's SSH
+  probe, not this host.
+
+## See also
+
+- `liveness_probe.py` — TUI-responsiveness probe (different scope:
+  "is Claude still echoing text inside tmux?"). Complements this
+  module: network-probe ensures WSL can REACH the hub; liveness-
+  probe ensures Claude can respond once reached.
+- `infra-host-connectivity`, `infra-network-routing` skills in
+  `~/.scitex/orochi/shared/skills/` — fleet-level tunnel setup.

--- a/src/scitex_agent_container/_skills/scitex-agent-container/wsl-connectivity.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/wsl-connectivity.md
@@ -7,6 +7,14 @@ internet connectivity. The fleet sees this as "SSH dead" (banner-
 exchange timeout, then connection-refused), which is indistinguish-
 able from "host asleep" unless the WSL side leaves a local trail.
 
+## Baseline
+
+**Wired LAN + mirrored mode** (as of 2026-04-21, ywatanabe
+msg#15405). The host has been moved off Wi-Fi onto a stable wired
+Ethernet link; SSID-roam and 2.4 vs 5 GHz hand-off are no longer
+in scope. Remaining live failure modes are NIC-level power-save
+and DHCP lease churn.
+
 ## What the evidence shows (from this host)
 
 One-shot diagnostics on 2026-04-21:
@@ -15,7 +23,9 @@ One-shot diagnostics on 2026-04-21:
   the WSL NAT `172.x.x.x` range). This proves
   **`networkingMode=mirrored` is already active** — the
   `.wslconfig` at `/mnt/c/Users/wyusu/.wslconfig` contains
-  `[wsl2] networkingMode=mirrored`.
+  `[wsl2] networkingMode=mirrored`. Under mirrored mode WSL's
+  `eth0` reflects whichever Windows NIC is carrying traffic —
+  currently the wired Ethernet adapter.
 - `/sbin/ip route` → default via `192.168.11.1` (the home router)
   on `eth0`. No separate WSL-bridge hop.
 - `/etc/resolv.conf` → `nameserver 8.8.8.8 / 8.8.4.4` (Google DNS,
@@ -34,31 +44,30 @@ One-shot diagnostics on 2026-04-21:
 | # | Hypothesis | Status |
 |---|---|---|
 | 1 | WSL2 NAT bridge instability | **Eliminated.** Mirrored mode removes the NAT bridge. |
-| 2 | Hyper-V vswitch desync on NIC change | **Partly eliminated.** Mirrored mode uses the host's NIC directly. |
+| 2 | Hyper-V vswitch desync on NIC change | **Partly eliminated.** Mirrored mode uses the host's NIC directly; wired LAN means no Wi-Fi-driven NIC swaps. |
 | 3 | cloudflared tunnel uplink expiry | **N/A for this host.** No cloudflared service runs here. Belongs to head-nas. |
-| 4 | Windows NIC power-save | **Still live.** Mirrored mode means WSL's eth0 IS the Windows NIC — if Windows powers it down, WSL loses connectivity immediately. |
-| 5 | Wi-Fi roam / DHCP lease | **Amplified by mirrored mode.** Lease expiry on the host re-IPs WSL's `eth0` directly; any TCP connection across the transition breaks. |
+| 4 | Windows NIC power-save | **Still live.** Applies equally to the wired Ethernet adapter — if Windows powers it down (selective-suspend / "allow the computer to turn off this device to save power"), WSL loses connectivity immediately. |
+| 5 | DHCP lease churn | **Still live, reduced scope.** With the host on a single wired link (no Wi-Fi roam), only lease-renewal on the Ethernet adapter remains. A static reservation removes this entirely. |
 
 ## Mitigations that require ywatanabe-side Windows action
 
 These cannot be done from inside WSL. They are the actual root-
 cause fixes; everything below the line is WSL-side visibility.
 
-1. **Disable Windows NIC power-save.** In PowerShell (admin):
+1. **Disable Windows NIC power-save on the wired Ethernet adapter.**
+   In PowerShell (admin):
    ```powershell
    Get-NetAdapter | Where-Object {$_.Status -eq "Up"} |
      Set-NetAdapterPowerManagement -AllowComputerToTurnOffDevice Disabled
    ```
-   One-shot, survives reboots.
-2. **Consider static DHCP reservation** on the router for this
-   host. With mirrored mode, every DHCP re-negotiation hits WSL.
-   A static reservation eliminates lease-expiry churn.
-3. **For Wi-Fi specifically,** consider preferring the 5 GHz SSID
-   over the 2.4 GHz one (disable "connect to this network
-   automatically" on the weaker of the two) — roaming between
-   them retriggers the network-change event that mirrored mode
-   propagates into WSL.
-4. **Leave `networkingMode=mirrored` as-is.** The alternative
+   One-shot, survives reboots. Targets all "Up" adapters, which on
+   a wired-only host is just the Ethernet NIC.
+2. **Static DHCP reservation on the router for this host's wired
+   MAC.** With mirrored mode, every DHCP renegotiation on the
+   Ethernet adapter re-IPs WSL's `eth0` directly and breaks any
+   TCP session crossing the transition. A static reservation
+   eliminates lease-expiry churn.
+3. **Leave `networkingMode=mirrored` as-is.** The alternative
    (NAT bridge) is the *previous* failure mode the fleet was
    hitting before this setting was applied.
 
@@ -95,9 +104,9 @@ layer that actually broke:
 
 | First failure | Diagnosis |
 |---|---|
-| `dns` | resolver unreachable — `/etc/resolv.conf` nameserver (8.8.8.8) is blocked or Wi-Fi is actually down |
+| `dns` | resolver unreachable — `/etc/resolv.conf` nameserver (8.8.8.8) is blocked or the wired link is actually down |
 | `gateway` (but `dns` ok) | rare — DNS is cached / UDP-only while LAN routing died |
-| `gateway` AND `dns` | Wi-Fi roam or NIC power-save just kicked in |
+| `gateway` AND `dns` | Ethernet NIC power-save just kicked in, or DHCP lease renegotiation re-IP'd eth0 |
 | `tcp` (but `dns` + `gateway` ok) | hub unreachable: firewall / Cloudflare regional |
 | `https` only | TLS handshake or captive-portal interposing |
 
@@ -141,7 +150,8 @@ When the fleet reports `ssh ywata-note-win` timing out, the fleet
 cannot tell whether:
 
 - the laptop lid is closed (Windows asleep),
-- the laptop is awake but WSL lost Wi-Fi,
+- the laptop is awake but WSL lost its wired link (NIC power-save
+  or DHCP renegotiation),
 - the laptop is awake and WSL has internet but the SSH service
   restarted,
 - or Claude Code TUI crashed while the rest of the host is fine.

--- a/src/scitex_agent_container/agent_meta.py
+++ b/src/scitex_agent_container/agent_meta.py
@@ -180,29 +180,39 @@ def _classify_pane_state(pane_text: str) -> tuple[str, str]:
         "authentication_error",  # raw API error type
     )
     if any(m in lower for m in _auth_markers):
-        return "auth_error", tail.strip().splitlines()[-1][:200]
+        # Return the line that actually contains the auth marker so the
+        # snippet is operationally useful (a human reading the dashboard
+        # sees "/login" / "401" rather than the trailing bare prompt).
+        snippet = ""
+        for ln in reversed(tail.strip().splitlines()):
+            if any(m in ln.lower() for m in _auth_markers):
+                snippet = ln.strip()[:200]
+                break
+        if not snippet:
+            snippet = tail.strip().splitlines()[-1][:200]
+        return "auth_error", snippet
     if "limit reached" in lower or "resets in" in lower:
         return "limit_reached", ""
     if re.search(r"\(y/n\)|\[y/n\]|\(yes/no\)|\[yes/no\]", lower):
         return "y_n_prompt", tail.strip().splitlines()[-1][:200]
-    # compose_pending: presence of a non-empty ❯ prompt with user text below
-    if re.search(r"❯\s+\S", tail):
+    # compose_pending: ❯ followed by non-whitespace on the SAME line.
+    # Use `[^\s\n]` (non-newline, non-whitespace) to avoid matching the
+    # decorative dashed separator that lives a line below the empty
+    # prompt — earlier `❯\s+\S` greedily crossed the newline and lit
+    # compose_pending for every freshly-booted agent.
+    if re.search(r"❯[ \t]+\S", tail):
         return "compose_pending_unsent", ""
-    # Initial-waiting: freshly booted agent at the bare prompt with no
-    # context used yet. Distinguishing this from "running" / "idle" gives
-    # the dashboard a discrete "alive but never worked" signal so a
-    # never-replied agent doesn't masquerade as healthy idle. Cheap
-    # markers: 0% context bar AND empty ❯ prompt AND the channel-listen
-    # banner from a fresh boot. Any one of the latter two is too loose;
-    # require all three so a long-running idle doesn't wrongly classify.
-    has_zero_ctx = "context ░░░░░░░░░░ 0%" in lower or "context: 0%" in lower
-    has_empty_prompt = bool(re.search(r"❯\s*\n", tail) or re.search(r"❯\s*$", tail))
-    has_listen_banner = "listening for channel messages" in lower
-    if has_zero_ctx and has_empty_prompt and has_listen_banner:
-        return "waiting", ""
     if "❯" in tail or ">" in tail:
         return "running", ""
     return "unknown", ""
+
+    # Note: "waiting" (freshly booted, never received work) is intentionally
+    # NOT detected here. The earlier draft relied on the claude-hud
+    # statusline `Context ░░░░░░░░░░ 0%` marker, but claude-hud is an
+    # external tool not present in every install. The dashboard derives
+    # "waiting" instead from the hub-side `last_tool_at` field — an agent
+    # that is connected but has never recorded a tool call is waiting,
+    # regardless of what its pane statusline looks like.
 
 
 def _config_candidates(workdir: str, filename: str) -> list[Path]:

--- a/src/scitex_agent_container/agent_meta.py
+++ b/src/scitex_agent_container/agent_meta.py
@@ -169,7 +169,17 @@ def _classify_pane_state(pane_text: str) -> tuple[str, str]:
         return "unknown", ""
     tail = pane_text[-2000:]
     lower = tail.lower()
-    if "invalid api key" in lower or "please re-run /login" in lower:
+    # auth_error patterns — Claude Code surfaces a few wordings depending on
+    # which auth path failed. Keep the list literal-string so adding new
+    # variants is obvious; lower-case match because the source casing varies.
+    _auth_markers = (
+        "invalid api key",
+        "invalid authentication credentials",  # Anthropic API 401 body
+        "please re-run /login",
+        "please run /login",  # Claude Code 2.1.x wording
+        "authentication_error",  # raw API error type
+    )
+    if any(m in lower for m in _auth_markers):
         return "auth_error", tail.strip().splitlines()[-1][:200]
     if "limit reached" in lower or "resets in" in lower:
         return "limit_reached", ""
@@ -178,6 +188,18 @@ def _classify_pane_state(pane_text: str) -> tuple[str, str]:
     # compose_pending: presence of a non-empty ❯ prompt with user text below
     if re.search(r"❯\s+\S", tail):
         return "compose_pending_unsent", ""
+    # Initial-waiting: freshly booted agent at the bare prompt with no
+    # context used yet. Distinguishing this from "running" / "idle" gives
+    # the dashboard a discrete "alive but never worked" signal so a
+    # never-replied agent doesn't masquerade as healthy idle. Cheap
+    # markers: 0% context bar AND empty ❯ prompt AND the channel-listen
+    # banner from a fresh boot. Any one of the latter two is too loose;
+    # require all three so a long-running idle doesn't wrongly classify.
+    has_zero_ctx = "context ░░░░░░░░░░ 0%" in lower or "context: 0%" in lower
+    has_empty_prompt = bool(re.search(r"❯\s*\n", tail) or re.search(r"❯\s*$", tail))
+    has_listen_banner = "listening for channel messages" in lower
+    if has_zero_ctx and has_empty_prompt and has_listen_banner:
+        return "waiting", ""
     if "❯" in tail or ">" in tail:
         return "running", ""
     return "unknown", ""

--- a/src/scitex_agent_container/cli_pkg/_main.py
+++ b/src/scitex_agent_container/cli_pkg/_main.py
@@ -16,6 +16,7 @@ from .build_cmds import build, check, validate
 from .hook_cmds import hook_event
 from .info_cmds import attach, find, list_python_apis, logs
 from .lifecycle_cmds import cleanup, restart, start, stop
+from .probe_cmds import probe_network
 from .render_cmds import render_attach, render_sbatch
 from .snapshot_cmds import snapshot
 from .status_cmds import check_agent, health, list_agents, status
@@ -86,6 +87,9 @@ main.add_command(actions_cli)
 # Render ports: emit sbatch/attach text for external consumers.
 main.add_command(render_sbatch)
 main.add_command(render_attach)
+
+# Connectivity probe (todo#457): fleet-facing WSL ↔ hub liveness.
+main.add_command(probe_network)
 
 
 if __name__ == "__main__":

--- a/src/scitex_agent_container/cli_pkg/probe_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/probe_cmds.py
@@ -1,0 +1,98 @@
+"""Probe commands: probe-network.
+
+Filed under ``todo#457`` — fleet-side cannot tell "WSL host sleeping"
+from "WSL lost internet", so we capture that from inside WSL.
+"""
+
+from __future__ import annotations
+
+import json as json_mod
+import os
+import sys
+
+import click
+
+from ..network_probe import DEFAULT_HUB_HOST, DEFAULT_HUB_PORT, DEFAULT_HUB_URL, run_and_log
+
+
+@click.command("probe-network")
+@click.option(
+    "--agent",
+    "-a",
+    default=None,
+    help="Agent name for the JSONL log filename. "
+    "Defaults to $SCITEX_OROCHI_AGENT or 'anonymous-agent'.",
+)
+@click.option(
+    "--hub-host",
+    default=DEFAULT_HUB_HOST,
+    help=f"Hub hostname to probe. Default: {DEFAULT_HUB_HOST}",
+)
+@click.option(
+    "--hub-port",
+    default=DEFAULT_HUB_PORT,
+    type=int,
+    help=f"Hub TCP port. Default: {DEFAULT_HUB_PORT}",
+)
+@click.option(
+    "--hub-url",
+    default=DEFAULT_HUB_URL,
+    help=f"Hub URL for the HTTPS probe. Default: {DEFAULT_HUB_URL}",
+)
+@click.option(
+    "--timeout",
+    default=3.0,
+    type=float,
+    help="Per-probe timeout in seconds. Default: 3.0",
+)
+@click.option(
+    "--quiet",
+    "-q",
+    is_flag=True,
+    default=False,
+    help="Suppress stdout — log to JSONL only. Useful from cron.",
+)
+@click.option(
+    "--exit-nonzero-on-fail",
+    is_flag=True,
+    default=False,
+    help="Exit with status 1 if any probe fails. Lets cron/systemd "
+    "alert on sustained failure.",
+)
+def probe_network(
+    agent: str | None,
+    hub_host: str,
+    hub_port: int,
+    hub_url: str,
+    timeout: float,
+    quiet: bool,
+    exit_nonzero_on_fail: bool,
+) -> None:
+    """Probe WSL → fleet-hub connectivity (todo#457).
+
+    Runs four probes (DNS → default gateway → TCP → HTTPS) and writes
+    the result as one JSONL line under
+    ``~/.scitex/agent-container/logs/network/<agent>.jsonl``.
+
+    The output is designed to be correlated with fleet-side SSH-dead
+    logs: when the fleet's SSH probe to this host fails, we have a
+    timestamp-aligned ``probes`` record from inside WSL proving which
+    layer actually broke (DNS vs LAN vs hub-reach vs TLS).
+    """
+    effective_agent = (
+        agent
+        or os.environ.get("SCITEX_OROCHI_AGENT")
+        or os.environ.get("CLAUDE_AGENT_ID")
+        or "anonymous-agent"
+    )
+    summary = run_and_log(
+        effective_agent,
+        hub_host=hub_host,
+        hub_port=hub_port,
+        hub_url=hub_url,
+        timeout=timeout,
+    )
+    if not quiet:
+        click.echo(json_mod.dumps(summary, indent=2))
+    if exit_nonzero_on_fail and not summary["ok"]:
+        sys.exit(1)

--- a/src/scitex_agent_container/network_probe.py
+++ b/src/scitex_agent_container/network_probe.py
@@ -1,0 +1,382 @@
+"""WSL ↔ fleet-hub connectivity probe.
+
+Filed under ``todo#457`` (bug(infra/wsl): ywata-note-win loses WSL
+internet connectivity periodically). When the WSL side drops
+connectivity to the Orochi hub, the fleet's external view becomes
+``Connection timed out during banner exchange`` — the WSL agents
+look dead from outside but the Windows host itself is usually fine.
+
+This module does not *fix* the root cause (that requires Windows-side
+action on the NIC power-save / Wi-Fi roam / ``.wslconfig`` settings).
+What it does add is **local, unambiguous evidence** that can be
+correlated with fleet-side outages:
+
+1. Is DNS working from inside WSL? (``gethostbyname`` on hub host).
+2. Is IPv4 / IPv6 route to the hub open? (``socket.create_connection``
+   to port 443 with a short timeout — no HTTPS handshake).
+3. Does a TLS handshake + HTTP GET to the hub complete? (full round
+   trip via ``urllib.request`` — catches captive portals / stale
+   TLS resumes).
+4. Is the default gateway reachable? (LAN-side check — if this fails
+   but (1)-(3) pass we learn Wi-Fi roam happened but routing survived).
+
+Each probe records ``(ok, latency_ms, err)`` into a JSONL ring at
+``~/.scitex/agent-container/logs/network/<agent>.jsonl`` so the next
+incident leaves a timeline the fleet can diff against SSH-dead logs
+from other hosts.
+
+Design rules
+------------
+- **Non-agentic.** Pure functions + one writer. No LLM calls.
+- **Stdlib only.** ``socket``, ``ssl``, ``urllib.request``, ``json``,
+  ``pathlib``. No ``requests``, no ``psutil``, no DNS libs — the whole
+  point is to work when higher-level networking is breaking.
+- **Fail-closed but never raise.** Any probe that fails returns a
+  ``ProbeResult`` with ``ok=False`` and an ``err`` string. The writer
+  swallows disk exceptions so a probe call never breaks a caller.
+- **Short timeouts.** Default 3s per probe so a full run takes <15s
+  even when every layer is hanging.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import socket
+import ssl
+import time
+import urllib.error
+import urllib.request
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+DEFAULT_HUB_HOST = "scitex-orochi.com"
+DEFAULT_HUB_PORT = 443
+DEFAULT_HUB_URL = f"https://{DEFAULT_HUB_HOST}/"
+DEFAULT_TIMEOUT_S = 3.0
+
+DEFAULT_LOG_ROOT = (
+    Path(os.environ.get("XDG_DATA_HOME") or Path.home() / ".scitex")
+    / "agent-container"
+    / "logs"
+    / "network"
+)
+
+
+@dataclass
+class ProbeResult:
+    """Outcome of one probe layer.
+
+    ``name`` identifies the layer ("dns", "tcp", "https", "gateway").
+    ``ok`` is the binary success flag. ``latency_ms`` is wall-clock
+    round-trip time, **not** RTT of a specific packet — it includes
+    any retries the kernel did internally.
+    """
+
+    name: str
+    ok: bool
+    latency_ms: float
+    err: str = ""
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def probe_dns(
+    host: str = DEFAULT_HUB_HOST,
+    *,
+    timeout: float = DEFAULT_TIMEOUT_S,
+) -> ProbeResult:
+    """Resolve ``host`` to an IP address.
+
+    ``socket.getaddrinfo`` honours ``/etc/resolv.conf`` ordering and
+    returns AF_INET + AF_INET6 entries, so we see IPv4 and IPv6 both.
+    We apply ``timeout`` indirectly by using a global ``setdefaulttimeout``
+    around the call — there is no per-call resolver timeout in stdlib.
+    """
+    start = time.monotonic()
+    old = socket.getdefaulttimeout()
+    try:
+        socket.setdefaulttimeout(timeout)
+        infos = socket.getaddrinfo(host, None)
+        addrs = sorted({sockaddr[0] for (_f, _t, _p, _c, sockaddr) in infos})
+        latency_ms = (time.monotonic() - start) * 1000.0
+        return ProbeResult(
+            name="dns",
+            ok=True,
+            latency_ms=latency_ms,
+            extra={"addrs": addrs},
+        )
+    except Exception as exc:  # pragma: no cover - exercised via fake
+        latency_ms = (time.monotonic() - start) * 1000.0
+        return ProbeResult(
+            name="dns",
+            ok=False,
+            latency_ms=latency_ms,
+            err=f"{type(exc).__name__}: {exc}",
+        )
+    finally:
+        socket.setdefaulttimeout(old)
+
+
+def probe_tcp(
+    host: str = DEFAULT_HUB_HOST,
+    port: int = DEFAULT_HUB_PORT,
+    *,
+    timeout: float = DEFAULT_TIMEOUT_S,
+) -> ProbeResult:
+    """Open a TCP connection to ``host:port``; close immediately.
+
+    Does NOT speak TLS — we want to isolate "routing/firewall reachable"
+    from "TLS/HTTP works". A captive portal returning a 200 OK to any
+    request would pass ``probe_https`` but also passes this layer.
+    """
+    start = time.monotonic()
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            pass
+        latency_ms = (time.monotonic() - start) * 1000.0
+        return ProbeResult(name="tcp", ok=True, latency_ms=latency_ms)
+    except Exception as exc:
+        latency_ms = (time.monotonic() - start) * 1000.0
+        return ProbeResult(
+            name="tcp",
+            ok=False,
+            latency_ms=latency_ms,
+            err=f"{type(exc).__name__}: {exc}",
+        )
+
+
+def probe_https(
+    url: str = DEFAULT_HUB_URL,
+    *,
+    timeout: float = DEFAULT_TIMEOUT_S,
+    expected_status_prefix: str = "",
+) -> ProbeResult:
+    """GET ``url`` and record status + latency.
+
+    Any 2xx/3xx/4xx counts as "the tunnel is up" because even a 404
+    means packets are flowing end-to-end and TLS completed. Only 5xx
+    from the hub or transport errors mark a failure.
+
+    ``expected_status_prefix`` lets callers tighten (e.g. ``"2"``)
+    if they actually need a 2xx.
+    """
+    start = time.monotonic()
+    try:
+        ctx = ssl.create_default_context()
+        req = urllib.request.Request(url, method="GET")
+        with urllib.request.urlopen(req, timeout=timeout, context=ctx) as resp:
+            status = resp.status
+            latency_ms = (time.monotonic() - start) * 1000.0
+            ok = status < 500 and (
+                not expected_status_prefix
+                or str(status).startswith(expected_status_prefix)
+            )
+            return ProbeResult(
+                name="https",
+                ok=ok,
+                latency_ms=latency_ms,
+                err="" if ok else f"status={status}",
+                extra={"status": status},
+            )
+    except urllib.error.HTTPError as exc:
+        # Cloudflare / hub returning 4xx is still "transport ok".
+        latency_ms = (time.monotonic() - start) * 1000.0
+        status = exc.code
+        ok = status < 500 and (
+            not expected_status_prefix
+            or str(status).startswith(expected_status_prefix)
+        )
+        return ProbeResult(
+            name="https",
+            ok=ok,
+            latency_ms=latency_ms,
+            err="" if ok else f"status={status}",
+            extra={"status": status},
+        )
+    except Exception as exc:
+        latency_ms = (time.monotonic() - start) * 1000.0
+        return ProbeResult(
+            name="https",
+            ok=False,
+            latency_ms=latency_ms,
+            err=f"{type(exc).__name__}: {exc}",
+        )
+
+
+_ROUTE_RE = re.compile(r"^default\s+via\s+(\S+)\s+dev\s+\S+", re.M)
+
+
+def _parse_default_gateway(ip_route_output: str) -> str | None:
+    """Extract the IPv4 default gateway from ``ip route`` output.
+
+    Returns ``None`` if no default route is present (which is itself
+    a strong diagnostic signal).
+    """
+    m = _ROUTE_RE.search(ip_route_output or "")
+    return m.group(1) if m else None
+
+
+def _read_ip_route() -> str:
+    """Read ``/proc/net/route`` and format it like ``ip route`` default.
+
+    We deliberately do not shell out to ``/sbin/ip`` because some WSL
+    distros drop the binary or require sudo. Reading the proc file
+    always works.
+    """
+    path = Path("/proc/net/route")
+    if not path.exists():
+        return ""
+    try:
+        lines = path.read_text().splitlines()
+    except OSError:
+        return ""
+    # /proc/net/route columns: Iface Destination Gateway Flags RefCnt Use Metric Mask ...
+    # A default route has Destination == "00000000".
+    for line in lines[1:]:
+        parts = line.split()
+        if len(parts) < 3:
+            continue
+        dest_hex, gw_hex = parts[1], parts[2]
+        if dest_hex != "00000000":
+            continue
+        # gw_hex is little-endian IPv4 bytes.
+        try:
+            gw_int = int(gw_hex, 16)
+        except ValueError:
+            continue
+        octets = [(gw_int >> (8 * i)) & 0xFF for i in range(4)]
+        gw = ".".join(str(o) for o in octets)
+        return f"default via {gw} dev {parts[0]}\n"
+    return ""
+
+
+def probe_gateway(
+    *,
+    timeout: float = DEFAULT_TIMEOUT_S,
+    ip_route_reader=_read_ip_route,
+) -> ProbeResult:
+    """Try a TCP SYN to the default gateway on port 53 (DNS).
+
+    Port 53 is used because most home routers / captive gateways
+    listen there. This is a best-effort LAN-reachability check — if
+    the gateway silently drops port 53 we still mark ok=False, which
+    is a false negative the caller should interpret loosely.
+    """
+    start = time.monotonic()
+    route_output = ip_route_reader() if callable(ip_route_reader) else str(ip_route_reader or "")
+    gw = _parse_default_gateway(route_output)
+    if not gw:
+        latency_ms = (time.monotonic() - start) * 1000.0
+        return ProbeResult(
+            name="gateway",
+            ok=False,
+            latency_ms=latency_ms,
+            err="no default route",
+        )
+    try:
+        with socket.create_connection((gw, 53), timeout=timeout):
+            pass
+        latency_ms = (time.monotonic() - start) * 1000.0
+        return ProbeResult(
+            name="gateway",
+            ok=True,
+            latency_ms=latency_ms,
+            extra={"gateway": gw},
+        )
+    except Exception as exc:
+        latency_ms = (time.monotonic() - start) * 1000.0
+        return ProbeResult(
+            name="gateway",
+            ok=False,
+            latency_ms=latency_ms,
+            err=f"{type(exc).__name__}: {exc}",
+            extra={"gateway": gw},
+        )
+
+
+def run_all_probes(
+    *,
+    hub_host: str = DEFAULT_HUB_HOST,
+    hub_port: int = DEFAULT_HUB_PORT,
+    hub_url: str = DEFAULT_HUB_URL,
+    timeout: float = DEFAULT_TIMEOUT_S,
+) -> list[ProbeResult]:
+    """Run the four probes in the order dns → gateway → tcp → https.
+
+    DNS first because hub_host is a name; if DNS fails TCP/HTTPS will
+    also fail with a confusing error. Gateway second so we can tell
+    "lost Wi-Fi" from "lost DNS only". TCP before HTTPS so a TLS
+    failure is distinguishable from a routing failure.
+    """
+    return [
+        probe_dns(hub_host, timeout=timeout),
+        probe_gateway(timeout=timeout),
+        probe_tcp(hub_host, hub_port, timeout=timeout),
+        probe_https(hub_url, timeout=timeout),
+    ]
+
+
+def summarise(results: Iterable[ProbeResult]) -> dict[str, Any]:
+    """Collapse N probe results into a single JSON-friendly dict."""
+    results = list(results)
+    return {
+        "ts": _now_iso(),
+        "ok": all(r.ok for r in results),
+        "probes": [asdict(r) for r in results],
+    }
+
+
+def _log_path(agent: str, root: Path | None = None) -> Path:
+    base = Path(root) if root else DEFAULT_LOG_ROOT
+    base.mkdir(parents=True, exist_ok=True)
+    safe = re.sub(r"[^a-zA-Z0-9_.\-]", "-", agent or "anonymous-agent")
+    return base / f"{safe}.jsonl"
+
+
+def append_result(
+    agent: str,
+    summary: dict[str, Any],
+    *,
+    root: Path | None = None,
+) -> Path | None:
+    """Append one summary dict to the per-agent JSONL ring.
+
+    Returns the path written to, or ``None`` if the write failed.
+    Does not rotate — the file is append-only and small (one line per
+    run, <1 KiB); ops rotates weekly via logrotate if needed.
+    """
+    try:
+        path = _log_path(agent, root=root)
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(summary, separators=(",", ":")) + "\n")
+        return path
+    except Exception:
+        return None
+
+
+def run_and_log(
+    agent: str,
+    *,
+    hub_host: str = DEFAULT_HUB_HOST,
+    hub_port: int = DEFAULT_HUB_PORT,
+    hub_url: str = DEFAULT_HUB_URL,
+    timeout: float = DEFAULT_TIMEOUT_S,
+    root: Path | None = None,
+) -> dict[str, Any]:
+    """One-shot convenience: run all probes, log, return the summary."""
+    results = run_all_probes(
+        hub_host=hub_host,
+        hub_port=hub_port,
+        hub_url=hub_url,
+        timeout=timeout,
+    )
+    summary = summarise(results)
+    append_result(agent, summary, root=root)
+    return summary

--- a/src/scitex_agent_container/runtimes/claude_code.py
+++ b/src/scitex_agent_container/runtimes/claude_code.py
@@ -215,6 +215,23 @@ class ClaudeCodeRuntime(RuntimeBase):
         lines = []
         for key, value in config.env.items():
             lines.append(f'export {key}="{_resolve(str(value))}"')
+        # Always export the canonical fleet hostname so downstream consumers
+        # (orochi MCP sidecar, telegram, etc.) register with "mba" rather
+        # than the OS-reported FQDN ("Yusukes-MacBook-Air.local"). The
+        # sidecar already prefers SCITEX_OROCHI_MACHINE over Node's
+        # hostname() — this just hands it the canonical value.
+        try:
+            from ..config._host import resolve_hostname
+
+            _canonical = resolve_hostname()
+            if _canonical:
+                lines.append(f'export SCITEX_OROCHI_MACHINE="{_canonical}"')
+                lines.append(f'export SCITEX_AGENT_CONTAINER_HOSTNAME="{_canonical}"')
+        except Exception:
+            # resolve_hostname falls through to socket.gethostname() short
+            # form on misconfig; if even that raises, leave the env unset
+            # and let the sidecar fall back to its own hostname() call.
+            pass
         # Cross-package env vars (e.g., orochi-side channel/auth config)
         # are caller's concern: declare them in the agent YAML's env
         # block and they are exported above with the rest of config.env.

--- a/src/scitex_agent_container/runtimes/src_files.py
+++ b/src/scitex_agent_container/runtimes/src_files.py
@@ -271,10 +271,35 @@ def cleanup_src_claude_md(config: AgentConfig, workdir: str) -> None:
 
 
 def deploy_src_mcp_json(config: AgentConfig, workdir: str) -> None:
-    """Copy src_mcp.json to {workdir}/.mcp.json with interpolation.
+    """Copy ``src_mcp.json`` to ``{workdir}/.mcp.json`` on EVERY invocation.
 
-    Resolves ${metadata.*} and ${ENV_VAR} references.
-    If src_mcp.json does not exist, does nothing.
+    Contract (see todo#453):
+
+    * **Unconditional refresh** — the workspace ``.mcp.json`` is always
+      rewritten from the canonical ``src_mcp.json`` when this function
+      is called. There is NO ``if dest.exists()`` fast-path. This is the
+      invariant that makes canonical config edits (e.g. adding a channel
+      to ``SCITEX_OROCHI_CHANNELS``) propagate on the next agent start
+      rather than lingering as stale workspace state for hours.
+    * **Per-server replace**, not deep-merge — every server entry
+      declared in ``src_mcp.json`` fully overwrites the same-named entry
+      in the workspace copy. This means env keys removed from the
+      canonical source are also removed from the workspace.
+    * **Other servers preserved** — servers present in the workspace
+      ``.mcp.json`` but NOT declared by this agent's ``src_mcp.json``
+      are left untouched (e.g. user-added local tools).
+    * **Idempotent** — calling this repeatedly with an unchanged source
+      produces byte-identical output.
+
+    Interpolation:
+
+    * ``${metadata.name}`` / ``${metadata.labels.*}`` → resolved from
+      the AgentConfig.
+    * ``${ENV_VAR}`` → resolved from ``os.environ`` at write time.
+    * ``~`` prefix in ``args`` entries → expanded to ``$HOME``.
+
+    If ``src_mcp.json`` does not exist next to the agent YAML, does
+    nothing (legacy-v1 / no-MCP agents).
     """
     defdir = _definition_dir(config)
     if defdir is None:
@@ -301,7 +326,8 @@ def deploy_src_mcp_json(config: AgentConfig, workdir: str) -> None:
 
     dest = Path(workdir) / ".mcp.json"
 
-    # Merge with existing .mcp.json if present
+    # Preserve any OTHER servers the workspace has that we don't declare.
+    # Our own servers are always replaced wholesale below.
     existing: dict = {}
     if dest.exists():
         try:
@@ -319,9 +345,33 @@ def deploy_src_mcp_json(config: AgentConfig, workdir: str) -> None:
                 for a in server["args"]
             ]
 
-    # Merge mcpServers
+    # Per-server replace (NOT deep merge): the src entry wholly overrides
+    # any workspace entry with the same key. This guarantees that env
+    # keys removed from src_mcp.json are also removed from the workspace
+    # copy — critical for e.g. retiring a ``SCITEX_OROCHI_CHANNELS``
+    # subscription entry cleanly.
     src_servers = data.get("mcpServers", {})
     existing.setdefault("mcpServers", {}).update(src_servers)
+
+    # Drift diagnostics: log when the workspace was older than src —
+    # the common case of "PR merged N hours ago, agent still stale"
+    # now leaves a breadcrumb in the agent-container log instead of
+    # being a silent no-op.
+    try:
+        if dest.exists():
+            src_mtime = src.stat().st_mtime
+            dest_mtime = dest.stat().st_mtime
+            if src_mtime > dest_mtime:
+                drift_minutes = (src_mtime - dest_mtime) / 60
+                logger.info(
+                    "src_mcp.json for %s is newer than workspace copy by "
+                    "%.1f min — refreshing %s",
+                    config.name,
+                    drift_minutes,
+                    dest,
+                )
+    except OSError:
+        pass
 
     dest.parent.mkdir(parents=True, exist_ok=True)
     dest.write_text(json.dumps(existing, indent=2) + "\n")

--- a/tests/test_network_probe.py
+++ b/tests/test_network_probe.py
@@ -1,0 +1,283 @@
+"""Tests for the WSL↔hub connectivity probe (todo#457).
+
+All tests run offline by injecting fake behaviour into the module's
+socket / urllib surface. Real network probes are exercised by
+``tests/integration`` (not included here — this suite must stay green
+on any CI host, including ones with no outbound egress).
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container import network_probe as np
+
+
+# ── probe_dns ────────────────────────────────────────────────────────────────
+
+
+class TestProbeDNS:
+    def test_ok_returns_sorted_addrs(self, monkeypatch):
+        def fake_getaddrinfo(host, port, *a, **kw):
+            return [
+                (socket.AF_INET, 1, 6, "", ("1.2.3.4", 0)),
+                (socket.AF_INET6, 1, 6, "", ("::1", 0, 0, 0)),
+                (socket.AF_INET, 1, 6, "", ("1.2.3.4", 0)),  # dedup
+            ]
+
+        monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+        r = np.probe_dns("example.test")
+        assert r.ok is True
+        assert r.name == "dns"
+        assert r.extra["addrs"] == ["1.2.3.4", "::1"]
+        assert r.latency_ms >= 0.0
+
+    def test_failure_records_error(self, monkeypatch):
+        def boom(*a, **kw):
+            raise socket.gaierror("Name or service not known")
+
+        monkeypatch.setattr(socket, "getaddrinfo", boom)
+        r = np.probe_dns("example.test")
+        assert r.ok is False
+        assert "gaierror" in r.err
+
+
+# ── probe_tcp ────────────────────────────────────────────────────────────────
+
+
+class TestProbeTCP:
+    def test_ok_closes_connection(self, monkeypatch):
+        class FakeSock:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                pass
+
+        def fake_create_connection(addr, timeout):
+            assert addr == ("hub.test", 443)
+            return FakeSock()
+
+        monkeypatch.setattr(socket, "create_connection", fake_create_connection)
+        r = np.probe_tcp("hub.test", 443)
+        assert r.ok is True
+        assert r.name == "tcp"
+
+    def test_failure_records_error(self, monkeypatch):
+        def boom(*a, **kw):
+            raise TimeoutError("timed out")
+
+        monkeypatch.setattr(socket, "create_connection", boom)
+        r = np.probe_tcp("hub.test", 443, timeout=0.1)
+        assert r.ok is False
+        assert "TimeoutError" in r.err
+
+
+# ── probe_https ──────────────────────────────────────────────────────────────
+
+
+class TestProbeHTTPS:
+    def test_2xx_ok(self, monkeypatch):
+        class FakeResp:
+            status = 200
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                pass
+
+        monkeypatch.setattr(
+            np.urllib.request,
+            "urlopen",
+            lambda *a, **kw: FakeResp(),
+        )
+        r = np.probe_https("https://hub.test/")
+        assert r.ok is True
+        assert r.extra["status"] == 200
+
+    def test_404_counts_as_transport_ok(self, monkeypatch):
+        """A 404 still proves TLS + HTTP handshake completed."""
+
+        class FakeResp:
+            status = 404
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                pass
+
+        monkeypatch.setattr(
+            np.urllib.request,
+            "urlopen",
+            lambda *a, **kw: FakeResp(),
+        )
+        r = np.probe_https("https://hub.test/")
+        assert r.ok is True  # <500 is still transport ok
+        assert r.extra["status"] == 404
+
+    def test_expected_status_prefix_tightens(self, monkeypatch):
+        class FakeResp:
+            status = 404
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                pass
+
+        monkeypatch.setattr(
+            np.urllib.request,
+            "urlopen",
+            lambda *a, **kw: FakeResp(),
+        )
+        r = np.probe_https("https://hub.test/", expected_status_prefix="2")
+        assert r.ok is False
+        assert "status=404" in r.err
+
+    def test_connection_refused_fails(self, monkeypatch):
+        def boom(*a, **kw):
+            raise ConnectionRefusedError("refused")
+
+        monkeypatch.setattr(np.urllib.request, "urlopen", boom)
+        r = np.probe_https("https://hub.test/")
+        assert r.ok is False
+        assert "ConnectionRefusedError" in r.err
+
+
+# ── default-gateway parsing ──────────────────────────────────────────────────
+
+
+class TestParseDefaultGateway:
+    def test_extracts_ipv4_gateway(self):
+        text = (
+            "default via 192.168.11.1 dev eth0 proto kernel metric 25\n"
+            "172.17.0.0/16 dev docker0 proto kernel scope link\n"
+        )
+        assert np._parse_default_gateway(text) == "192.168.11.1"
+
+    def test_returns_none_when_no_default(self):
+        assert np._parse_default_gateway("172.17.0.0/16 dev docker0\n") is None
+
+    def test_empty_input(self):
+        assert np._parse_default_gateway("") is None
+
+
+class TestProbeGateway:
+    def test_no_default_route_is_fail(self, monkeypatch):
+        r = np.probe_gateway(ip_route_reader=lambda: "")
+        assert r.ok is False
+        assert "no default route" in r.err
+
+    def test_reachable_gateway_ok(self, monkeypatch):
+        class FakeSock:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                pass
+
+        monkeypatch.setattr(
+            socket,
+            "create_connection",
+            lambda addr, timeout: FakeSock(),
+        )
+        r = np.probe_gateway(
+            ip_route_reader=lambda: "default via 10.0.0.1 dev eth0\n"
+        )
+        assert r.ok is True
+        assert r.extra["gateway"] == "10.0.0.1"
+
+    def test_unreachable_gateway_fail(self, monkeypatch):
+        def boom(addr, timeout):
+            raise TimeoutError("timed out")
+
+        monkeypatch.setattr(socket, "create_connection", boom)
+        r = np.probe_gateway(
+            ip_route_reader=lambda: "default via 10.0.0.1 dev eth0\n",
+            timeout=0.1,
+        )
+        assert r.ok is False
+        assert "TimeoutError" in r.err
+        assert r.extra["gateway"] == "10.0.0.1"
+
+
+# ── run_all_probes / summarise ───────────────────────────────────────────────
+
+
+class TestRunAll:
+    def test_order_is_dns_gateway_tcp_https(self, monkeypatch):
+        calls: list[str] = []
+
+        def log(name):
+            def _inner(*a, **kw):
+                calls.append(name)
+                return np.ProbeResult(name=name, ok=True, latency_ms=1.0)
+
+            return _inner
+
+        monkeypatch.setattr(np, "probe_dns", log("dns"))
+        monkeypatch.setattr(np, "probe_gateway", log("gateway"))
+        monkeypatch.setattr(np, "probe_tcp", log("tcp"))
+        monkeypatch.setattr(np, "probe_https", log("https"))
+
+        np.run_all_probes()
+        assert calls == ["dns", "gateway", "tcp", "https"]
+
+    def test_summarise_all_ok(self):
+        results = [
+            np.ProbeResult(name="dns", ok=True, latency_ms=1.0),
+            np.ProbeResult(name="https", ok=True, latency_ms=2.0),
+        ]
+        s = np.summarise(results)
+        assert s["ok"] is True
+        assert len(s["probes"]) == 2
+        assert s["probes"][0]["name"] == "dns"
+
+    def test_summarise_any_fail(self):
+        results = [
+            np.ProbeResult(name="dns", ok=True, latency_ms=1.0),
+            np.ProbeResult(name="https", ok=False, latency_ms=2.0, err="refused"),
+        ]
+        s = np.summarise(results)
+        assert s["ok"] is False
+
+
+# ── append_result / run_and_log ──────────────────────────────────────────────
+
+
+class TestLogging:
+    def test_append_result_writes_jsonl(self, tmp_path: Path):
+        summary = {"ts": "2026-04-21T00:00:00+00:00", "ok": True, "probes": []}
+        path = np.append_result("head-ywata-note-win", summary, root=tmp_path)
+        assert path is not None
+        text = path.read_text()
+        assert json.loads(text.strip()) == summary
+
+    def test_append_result_appends_multiple(self, tmp_path: Path):
+        np.append_result("a", {"i": 1}, root=tmp_path)
+        np.append_result("a", {"i": 2}, root=tmp_path)
+        lines = (tmp_path / "a.jsonl").read_text().splitlines()
+        assert [json.loads(l) for l in lines] == [{"i": 1}, {"i": 2}]
+
+    def test_append_result_sanitises_agent_name(self, tmp_path: Path):
+        path = np.append_result("weird/name with spaces", {}, root=tmp_path)
+        assert path is not None
+        assert "/" not in path.name
+        assert " " not in path.name
+
+    def test_run_and_log_end_to_end(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setattr(
+            np,
+            "run_all_probes",
+            lambda **kw: [np.ProbeResult(name="dns", ok=True, latency_ms=1.0)],
+        )
+        summary = np.run_and_log("head-ywata-note-win", root=tmp_path)
+        assert summary["ok"] is True
+        path = tmp_path / "head-ywata-note-win.jsonl"
+        assert path.exists()

--- a/tests/test_pane_state_classifier.py
+++ b/tests/test_pane_state_classifier.py
@@ -1,0 +1,136 @@
+"""Regression tests for ``_classify_pane_state``.
+
+The classifier reads tmux pane tail and returns a string state label.
+We only assert on signals that come from **Claude Code itself** —
+banners, error messages, prompt glyphs — not from optional statusline
+tools like claude-hud (https://github.com/jarrodwatts/claude-hud) which
+wouldn't be present in every install.
+
+For state that needs claude-hud-style context-pct / tool-history info,
+detection lives in the dashboard's `_computeStateLocal` (app.js) using
+hub-side hook event fields (`last_tool_at`), not pane text. That is
+the "use logic, not pattern matching" rule.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scitex_agent_container.agent_meta import _classify_pane_state
+
+
+# ----------------------------------------------------------------------
+# auth_error: every known wording from real Claude Code 2.x panes
+# ----------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "marker_line",
+    [
+        "Please run /login",  # Claude Code 2.1.x current wording
+        "Please re-run /login",  # earlier Claude Code wording
+        "API Error: 401 ... Invalid authentication credentials",
+        '{"type":"authentication_error","message":"..."}',
+        "Invalid API key · Please check",  # legacy
+    ],
+)
+def test_auth_error_marker_variants(marker_line):
+    """Each known auth-failure phrase, embedded in a minimal otherwise-
+    legal pane, must trigger ``auth_error``. Pin every variant we see
+    in the wild — when Claude Code rewords its error surface, add the
+    new wording to this list, not by relaxing the matcher.
+    """
+    pane = f"some preamble\n  ⎿  {marker_line}\n❯\n"
+    state, _ = _classify_pane_state(pane)
+    assert state == "auth_error", f"{marker_line!r} → {state!r}"
+
+
+def test_auth_error_real_capture_head_mba_2026_04_20():
+    """Verbatim transcript line from head-mba pane on 2026-04-20 after
+    the user DM'd 'hello' and Claude Code returned 401. Captured live;
+    do not rewrite. If this test breaks, capture the new wording from
+    a real failing agent and add it as a new fixture-line — do NOT
+    weaken the classifier to make this pass.
+    """
+    pane = (
+        "  Listening for channel messages from: server:scitex-orochi\n"
+        "  ← scitex-orochi · ywatanabe: hello\n"
+        '  ⎿  Please run /login · API Error: 401 {"type":"error",'
+        '"error":{"type":"authentication_error","message":'
+        '"Invalid authentication credentials"},'
+        '"request_id":"req_011CaE4U43Uo4X166mwtZtNf"}\n'
+        "❯\n"
+    )
+    state, snippet = _classify_pane_state(pane)
+    assert state == "auth_error", f"got {state!r}"
+    # Snippet should hand the operator the actionable signal.
+    assert any(
+        m in snippet for m in ("/login", "401", "authentication_error", "credentials")
+    ), f"unhelpful snippet: {snippet!r}"
+
+
+# ----------------------------------------------------------------------
+# y/n prompt — defense-in-depth wording matrix
+# ----------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "yn_phrasing",
+    [
+        "Continue? (y/n)",
+        "Proceed? [Y/n]",
+        "Confirm? (yes/no)",
+        "OK? [yes/no]",
+    ],
+)
+def test_y_n_prompt_variants(yn_phrasing):
+    pane = f"work output here\n{yn_phrasing}\n"
+    state, _ = _classify_pane_state(pane)
+    assert state == "y_n_prompt", f"{yn_phrasing!r} → {state!r}"
+
+
+# ----------------------------------------------------------------------
+# compose_pending vs decorative separator
+# ----------------------------------------------------------------------
+def test_compose_pending_does_not_match_separator_line():
+    """Earlier ``❯\\s+\\S`` regex matched the decorative dashed
+    separator below the empty prompt and lit ``compose_pending`` for
+    every fresh agent. Tightened to require non-whitespace on the
+    SAME line as ❯. This test pins the fix.
+    """
+    pane = "──────────────\n❯ \n──────────────\n  some statusline content\n"
+    state, _ = _classify_pane_state(pane)
+    assert state != "compose_pending_unsent", f"got {state!r}"
+
+
+def test_compose_pending_fires_for_actual_user_text():
+    """Defense-in-depth: when the user IS typing, classifier must
+    still flag compose_pending."""
+    pane = "❯ hello world\n"
+    state, _ = _classify_pane_state(pane)
+    assert state == "compose_pending_unsent", f"got {state!r}"
+
+
+# ----------------------------------------------------------------------
+# limit_reached
+# ----------------------------------------------------------------------
+def test_limit_reached_marker():
+    pane = "  Limit reached, resets in 3h 47m\n❯\n"
+    state, _ = _classify_pane_state(pane)
+    assert state == "limit_reached"
+
+
+# ----------------------------------------------------------------------
+# empty / unknown
+# ----------------------------------------------------------------------
+def test_empty_pane_unknown():
+    state, _ = _classify_pane_state("")
+    assert state == "unknown"
+
+
+def test_running_when_only_prompt_visible():
+    """A bare ❯ prompt with nothing else legible classifies as running.
+    The dashboard upgrades / downgrades from there using hub-side
+    hook event ages — pane classifier does not try to distinguish
+    'just booted' from 'idle after work' (that lives in app.js
+    _computeStateLocal where last_tool_at is available).
+    """
+    pane = "──────────────\n❯ \n"
+    state, _ = _classify_pane_state(pane)
+    assert state == "running"

--- a/tests/test_probe_cmds.py
+++ b/tests/test_probe_cmds.py
@@ -1,0 +1,84 @@
+"""Tests for the ``probe-network`` CLI command (todo#457)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from scitex_agent_container import network_probe as np
+from scitex_agent_container.cli import main
+
+
+def _fake_all_ok(**_kwargs):
+    return [
+        np.ProbeResult(name="dns", ok=True, latency_ms=1.0),
+        np.ProbeResult(name="gateway", ok=True, latency_ms=1.0),
+        np.ProbeResult(name="tcp", ok=True, latency_ms=1.0),
+        np.ProbeResult(name="https", ok=True, latency_ms=1.0),
+    ]
+
+
+def _fake_dns_fail(**_kwargs):
+    return [
+        np.ProbeResult(name="dns", ok=False, latency_ms=1.0, err="gaierror"),
+        np.ProbeResult(name="gateway", ok=True, latency_ms=1.0),
+        np.ProbeResult(name="tcp", ok=False, latency_ms=1.0, err="gaierror"),
+        np.ProbeResult(name="https", ok=False, latency_ms=1.0, err="gaierror"),
+    ]
+
+
+class TestProbeNetworkCLI:
+    def test_all_ok_returns_zero(self, monkeypatch, tmp_path: Path):
+        monkeypatch.setattr(np, "run_all_probes", _fake_all_ok)
+        monkeypatch.setattr(np, "DEFAULT_LOG_ROOT", tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["probe-network", "--agent", "test-agent", "--quiet"],
+        )
+        assert result.exit_code == 0, result.output
+        path = tmp_path / "test-agent.jsonl"
+        assert path.exists()
+        payload = json.loads(path.read_text().strip())
+        assert payload["ok"] is True
+        assert len(payload["probes"]) == 4
+
+    def test_non_quiet_prints_json(self, monkeypatch, tmp_path: Path):
+        monkeypatch.setattr(np, "run_all_probes", _fake_all_ok)
+        monkeypatch.setattr(np, "DEFAULT_LOG_ROOT", tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(main, ["probe-network", "--agent", "a"])
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["ok"] is True
+
+    def test_exit_nonzero_on_fail(self, monkeypatch, tmp_path: Path):
+        monkeypatch.setattr(np, "run_all_probes", _fake_dns_fail)
+        monkeypatch.setattr(np, "DEFAULT_LOG_ROOT", tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "probe-network",
+                "--agent",
+                "a",
+                "--quiet",
+                "--exit-nonzero-on-fail",
+            ],
+        )
+        assert result.exit_code == 1
+        path = tmp_path / "a.jsonl"
+        assert path.exists()
+        payload = json.loads(path.read_text().strip())
+        assert payload["ok"] is False
+
+    def test_env_fallback_for_agent(self, monkeypatch, tmp_path: Path):
+        monkeypatch.setattr(np, "run_all_probes", _fake_all_ok)
+        monkeypatch.setattr(np, "DEFAULT_LOG_ROOT", tmp_path)
+        monkeypatch.setenv("SCITEX_OROCHI_AGENT", "head-ywata-note-win")
+        runner = CliRunner()
+        result = runner.invoke(main, ["probe-network", "--quiet"])
+        assert result.exit_code == 0
+        assert (tmp_path / "head-ywata-note-win.jsonl").exists()

--- a/tests/test_src_files.py
+++ b/tests/test_src_files.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+import os
 import re
 import tempfile
 from pathlib import Path
@@ -14,6 +16,7 @@ from scitex_agent_container.runtimes.src_files import (
     _extract_user_tail,
     cleanup_src_claude_md,
     deploy_src_claude_md,
+    deploy_src_mcp_json,
 )
 
 START_MARKER_RE = re.compile(
@@ -194,3 +197,213 @@ class TestCleanupStopStartRoundTrip:
         cleanup_src_claude_md(cfg, str(workdir))
         # Nothing survives the strip, so the file is removed.
         assert not (workdir / "CLAUDE.md").exists()
+
+
+def _make_mcp_config(defdir: Path, servers: dict) -> MagicMock:
+    """Create a mock AgentConfig pointing at a tmp dir with src_mcp.json."""
+    defdir.mkdir(parents=True, exist_ok=True)
+    (defdir / "src_mcp.json").write_text(json.dumps({"mcpServers": servers}))
+    cfg = MagicMock()
+    cfg.name = "test-agent"
+    cfg.labels = {}
+    cfg.config_path = str(defdir / "test-agent.yaml")
+    return cfg
+
+
+class TestDeploySrcMcpJsonRefresh:
+    """Regression tests for todo#453 — workspace .mcp.json must refresh
+    from canonical src_mcp.json on EVERY deploy, not just first launch.
+
+    The 2026-04-15 fleet-lead incident: canonical ``src_mcp.json`` was
+    updated (PR #49 added ``#lead`` and ``#agent`` to the channel
+    subscription), but because the workspace ``.mcp.json`` had been
+    copied on first launch 2 hours prior, the running agent kept
+    reading the stale two-channel subscription. Every agent restart
+    must re-read src_mcp.json and propagate canonical changes.
+    """
+
+    def _server_entry(self, channels: str) -> dict:
+        return {
+            "scitex-orochi": {
+                "type": "stdio",
+                "command": "bun",
+                "args": ["run", "~/proj/scitex-orochi/ts/mcp_channel.ts"],
+                "env": {
+                    "SCITEX_OROCHI_AGENT": "${metadata.name}",
+                    "SCITEX_OROCHI_CHANNELS": channels,
+                },
+            }
+        }
+
+    def test_fresh_deploy_writes_workspace_copy(self, tmp_path):
+        defdir = tmp_path / "def"
+        workdir = str(tmp_path / "workspace")
+        cfg = _make_mcp_config(defdir, self._server_entry("#ywatanabe,#heads"))
+
+        deploy_src_mcp_json(cfg, workdir)
+
+        dest = Path(workdir) / ".mcp.json"
+        assert dest.exists()
+        data = json.loads(dest.read_text())
+        assert data["mcpServers"]["scitex-orochi"]["env"][
+            "SCITEX_OROCHI_CHANNELS"
+        ] == "#ywatanabe,#heads"
+
+    def test_env_change_propagates_on_redeploy(self, tmp_path):
+        """The todo#453 scenario exactly: canonical src_mcp.json gets a
+        new channel added after first launch; the next deploy must
+        overwrite the stale workspace env.
+        """
+        defdir = tmp_path / "def"
+        workdir = str(tmp_path / "workspace")
+        cfg = _make_mcp_config(defdir, self._server_entry("#ywatanabe,#heads"))
+
+        # First launch: workspace gets old subscription
+        deploy_src_mcp_json(cfg, workdir)
+        dest = Path(workdir) / ".mcp.json"
+        assert json.loads(dest.read_text())["mcpServers"]["scitex-orochi"][
+            "env"
+        ]["SCITEX_OROCHI_CHANNELS"] == "#ywatanabe,#heads"
+
+        # Canonical PR lands: new channels appear in src_mcp.json
+        (defdir / "src_mcp.json").write_text(
+            json.dumps(
+                {"mcpServers": self._server_entry(
+                    "#ywatanabe,#heads,#lead,#agent"
+                )}
+            )
+        )
+
+        # Restart: deploy re-runs, workspace MUST reflect canonical
+        deploy_src_mcp_json(cfg, workdir)
+
+        refreshed = json.loads(dest.read_text())
+        assert refreshed["mcpServers"]["scitex-orochi"]["env"][
+            "SCITEX_OROCHI_CHANNELS"
+        ] == "#ywatanabe,#heads,#lead,#agent"
+
+    def test_removed_env_key_is_dropped_on_redeploy(self, tmp_path):
+        """Per-server replace semantics: if src drops an env key, the
+        workspace copy must also drop it. This guards against the
+        inverse stale-state bug (a retired env var lingering).
+        """
+        defdir = tmp_path / "def"
+        workdir = str(tmp_path / "workspace")
+
+        server_with_extra = {
+            "scitex-orochi": {
+                "type": "stdio",
+                "command": "bun",
+                "env": {
+                    "SCITEX_OROCHI_AGENT": "${metadata.name}",
+                    "LEGACY_KEY": "should-be-dropped",
+                },
+            }
+        }
+        (defdir).mkdir(parents=True, exist_ok=True)
+        (defdir / "src_mcp.json").write_text(
+            json.dumps({"mcpServers": server_with_extra})
+        )
+        cfg = MagicMock()
+        cfg.name = "test-agent"
+        cfg.labels = {}
+        cfg.config_path = str(defdir / "test-agent.yaml")
+
+        deploy_src_mcp_json(cfg, workdir)
+        dest = Path(workdir) / ".mcp.json"
+        assert "LEGACY_KEY" in json.loads(dest.read_text())[
+            "mcpServers"
+        ]["scitex-orochi"]["env"]
+
+        # Canonical drops the key
+        server_no_extra = {
+            "scitex-orochi": {
+                "type": "stdio",
+                "command": "bun",
+                "env": {"SCITEX_OROCHI_AGENT": "${metadata.name}"},
+            }
+        }
+        (defdir / "src_mcp.json").write_text(
+            json.dumps({"mcpServers": server_no_extra})
+        )
+
+        deploy_src_mcp_json(cfg, workdir)
+
+        env = json.loads(dest.read_text())["mcpServers"]["scitex-orochi"]["env"]
+        assert "LEGACY_KEY" not in env
+        assert env["SCITEX_OROCHI_AGENT"] == "test-agent"
+
+    def test_other_servers_preserved(self, tmp_path):
+        """Servers present in workspace .mcp.json but NOT declared by this
+        agent's src_mcp.json are preserved (user-added local tools etc.).
+        """
+        defdir = tmp_path / "def"
+        workdir = Path(tmp_path / "workspace")
+        workdir.mkdir(parents=True, exist_ok=True)
+        cfg = _make_mcp_config(defdir, self._server_entry("#a,#b"))
+
+        # Pre-seed workspace with a foreign server
+        (workdir / ".mcp.json").write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "local-tool": {
+                            "type": "stdio",
+                            "command": "my-local-mcp",
+                        }
+                    }
+                }
+            )
+        )
+
+        deploy_src_mcp_json(cfg, str(workdir))
+
+        data = json.loads((workdir / ".mcp.json").read_text())
+        assert "local-tool" in data["mcpServers"]
+        assert "scitex-orochi" in data["mcpServers"]
+
+    def test_unconditional_refresh_even_when_src_older(self, tmp_path):
+        """The invariant is unconditional: we refresh even if the src
+        mtime is older than the workspace copy. This protects against
+        clock-skew or filesystem-copy edge cases where the canonical
+        file's mtime might be artificially earlier than the workspace.
+
+        Without this guarantee, a naive ``if src.mtime > dest.mtime``
+        fast-path would silently skip legitimate updates.
+        """
+        defdir = tmp_path / "def"
+        workdir = str(tmp_path / "workspace")
+        cfg = _make_mcp_config(defdir, self._server_entry("#v2"))
+
+        deploy_src_mcp_json(cfg, workdir)
+        dest = Path(workdir) / ".mcp.json"
+
+        # Rewrite src with new content, but backdate its mtime so it
+        # appears OLDER than the workspace copy.
+        (defdir / "src_mcp.json").write_text(
+            json.dumps({"mcpServers": self._server_entry("#v3")})
+        )
+        ancient = dest.stat().st_mtime - 3600  # 1 hour older
+        os.utime(defdir / "src_mcp.json", (ancient, ancient))
+
+        deploy_src_mcp_json(cfg, workdir)
+
+        env = json.loads(dest.read_text())["mcpServers"]["scitex-orochi"][
+            "env"
+        ]
+        assert env["SCITEX_OROCHI_CHANNELS"] == "#v3"
+
+    def test_idempotent_when_src_unchanged(self, tmp_path):
+        """Repeated deploys with no src change produce byte-identical
+        output."""
+        defdir = tmp_path / "def"
+        workdir = str(tmp_path / "workspace")
+        cfg = _make_mcp_config(defdir, self._server_entry("#stable"))
+
+        deploy_src_mcp_json(cfg, workdir)
+        first = (Path(workdir) / ".mcp.json").read_text()
+
+        deploy_src_mcp_json(cfg, workdir)
+        second = (Path(workdir) / ".mcp.json").read_text()
+
+        assert first == second


### PR DESCRIPTION
## Summary

- Tighten `deploy_src_mcp_json` contract so workspace/`.mcp.json` always reflects the canonical `src_mcp.json` after any agent (re)start — no first-launch-only fast path, no mtime gate.
- Per-server entries are replaced wholesale (keys removed from src are dropped from the workspace); unrelated foreign servers are preserved.
- Add an info log when `src.mtime > dest.mtime` so canonical-vs-runtime drift is visible at boot instead of silent.

## Why

Roots out the **class-3 agent-silence failure mode** from the 2026-04-15 fleet-lead incident (todo#453): canonical `src_mcp.json` added `#lead` / `#agent` to `SCITEX_OROCHI_CHANNELS`, but the running agent kept reading the stale two-channel workspace copy for ~2 hours.

The issue's Option A ("unconditional copy on every start") is adopted — the code already did this *de facto*, but now the contract is:
1. Documented explicitly in the docstring,
2. Covered by regression tests,
3. Immune to a future "if dest.exists(): return" optimization regression.

## Changes

- `src/scitex_agent_container/runtimes/src_files.py`: strengthen docstring with explicit invariants (unconditional refresh, per-server replace, foreign-server preservation, idempotency); add mtime-drift diagnostic log.
- `tests/test_src_files.py`: +6 regression tests in new `TestDeploySrcMcpJsonRefresh` class:
  - fresh deploy writes workspace copy
  - env change propagates on redeploy (exact todo#453 scenario)
  - removed env key dropped on redeploy
  - foreign (non-declared) servers preserved
  - unconditional refresh even when src mtime is backdated
  - idempotent when src unchanged

## Test plan

- [x] `pytest tests/test_src_files.py` — 20/20 pass
- [x] `pytest tests/test_src_files.py tests/test_config_v2.py` — 48/48 pass
- [ ] Manual verification on fleet-lead (next restart cycle): edit `src_mcp.json` `SCITEX_OROCHI_CHANNELS`, restart, confirm workspace `.mcp.json` reflects change

## Cross-refs

- todo#453 — bug report (ywatanabe1989/todo)
- head-nas msg#12744 — originating finding
- PR #49 (dotfiles) — the canonical change that exposed the bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)