### PR TITLE
feat(status): extend --terse whitelist with subagent_count + quota + activity fields (todo#300 follow-up)

### DIFF
--- a/src/scitex_agent_container/terse.py
+++ b/src/scitex_agent_container/terse.py
@@ -22,6 +22,18 @@ from typing import Any, Iterable
 # Whitelist used by ``scitex-agent-container status --json --terse``.
 # Superset of what ``scripts/fleet-watch/probe_remote.sh`` extracts via
 # ``jq -r``. Do not remove entries without coordinating with head-nas.
+#
+# The list below is split into two tranches:
+#
+#   1. The original 13 fields (todo#300) — the fleet_watch.sh
+#      probe_remote.sh whitelist.
+#   2. The todo#300 follow-up extension — high-value heartbeat fields
+#      promoted from ``collect_rich`` so the MCP sidecar's heartbeat
+#      path (PR #66 pivot) can carry them without pulling the ~28 KB
+#      full payload. PII / bulky fields are deliberately excluded
+#      (``pane_text``, ``claude_md``, ``mcp_json``, ``last_user_msg``,
+#      ``stuck_prompt_text``, ``recent_prompts``, ``current_tool_input``,
+#      ``recent_tools``) — those remain available in full mode only.
 TERSE_STATUS_FIELDS: tuple[str, ...] = (
     # identity
     "agent",
@@ -42,6 +54,37 @@ TERSE_STATUS_FIELDS: tuple[str, ...] = (
     # snapshot summary (NOT diff_fields, NOT the full snapshot)
     "snapshot.timestamp",
     "snapshot.has_diff",
+    # --- todo#300 follow-up: heartbeat-grade activity/quota fields ----
+    # subagent load (both the canonical name and the legacy alias so
+    # consumers of either spelling keep working)
+    "subagent_count",
+    "subagents",
+    # context-window usage derived from the transcript (complements the
+    # config-side ``context_management.percent`` above)
+    "context_pct",
+    # Anthropic quota usage + reset timestamps
+    "quota_5h_used_pct",
+    "quota_7d_used_pct",
+    "quota_5h_reset_at",
+    "quota_7d_reset_at",
+    # classified pane state + last recorded PaneAction
+    "pane_state",
+    "last_action_at",
+    "last_action_name",
+    "last_action_outcome",
+    # hook-captured tool liveness (LLM-level heartbeat)
+    "last_tool_at",
+    "last_tool_name",
+    # high-level "what is this agent doing" + tool name only
+    # (``current_tool_input`` is intentionally excluded — may carry
+    # prompt / path fragments that count as PII)
+    "current_task",
+    "current_tool",
+    # identity / machine affinity
+    "account_email",
+    "skills_loaded",
+    "hostname_canonical",
+    "machine",
 )
 
 # Whitelist used by ``scitex-agent-container snapshot --json --terse``.

--- a/tests/test_status_json.py
+++ b/tests/test_status_json.py
@@ -373,6 +373,168 @@ def test_terse_status_is_heartbeat_safe() -> None:
     assert len(json.dumps(terse)) < 4096
 
 
+def test_status_terse_whitelist_includes_extended_fields() -> None:
+    """todo#300 follow-up: whitelist extends beyond the original 13 fields.
+
+    The heartbeat path (PR #66 pivot) depends on these names being
+    present in the terse projection.
+    """
+    from scitex_agent_container.terse import TERSE_STATUS_FIELDS
+
+    # Original 13 (unchanged; kept as a regression guard)
+    original_13 = {
+        "agent",
+        "state",
+        "timestamp",
+        "tmux_alive",
+        "last_post_ts",
+        "context_management.percent",
+        "context_management.strategy",
+        "context_management.trigger_at_percent",
+        "pids.claude_code",
+        "pids.container_daemon",
+        "health.ok",
+        "snapshot.timestamp",
+        "snapshot.has_diff",
+    }
+    assert original_13.issubset(set(TERSE_STATUS_FIELDS))
+
+    # Extended tranche — high-value heartbeat fields
+    extended = {
+        "subagent_count",
+        "subagents",
+        "context_pct",
+        "quota_5h_used_pct",
+        "quota_7d_used_pct",
+        "quota_5h_reset_at",
+        "quota_7d_reset_at",
+        "pane_state",
+        "last_action_at",
+        "last_action_name",
+        "last_action_outcome",
+        "last_tool_at",
+        "last_tool_name",
+        "current_task",
+        "current_tool",
+        "account_email",
+        "skills_loaded",
+        "hostname_canonical",
+        "machine",
+    }
+    assert extended.issubset(set(TERSE_STATUS_FIELDS)), (
+        f"missing extended fields: {extended - set(TERSE_STATUS_FIELDS)}"
+    )
+
+
+def test_status_terse_excludes_pii_and_bulky_fields() -> None:
+    """PII / heavy fields must stay full-mode-only (todo#300 follow-up).
+
+    These fields may carry prompt fragments, full CLAUDE.md contents, or
+    raw pane scrollback — they are deliberately excluded from the
+    heartbeat-bound terse projection.
+    """
+    from scitex_agent_container.terse import TERSE_STATUS_FIELDS, project_terse
+
+    pii_blacklist = {
+        "pane_text",
+        "claude_md",
+        "mcp_json",
+        "last_user_msg",
+        "stuck_prompt_text",
+        "recent_prompts",
+        "current_tool_input",
+        "recent_tools",
+    }
+    # Not in the whitelist tuple itself
+    assert pii_blacklist.isdisjoint(set(TERSE_STATUS_FIELDS))
+
+    # And not in the projected output either, even when present in source
+    full = {name: f"SENSITIVE_{name}" * 200 for name in pii_blacklist}
+    full["agent"] = "x"
+    terse = project_terse(full, TERSE_STATUS_FIELDS)
+    for name in pii_blacklist:
+        assert name not in terse
+        # Also ensure no residue leaked into any value
+        for v in terse.values():
+            if isinstance(v, str):
+                assert "SENSITIVE_" not in v
+
+
+def test_status_terse_payload_size_under_threshold() -> None:
+    """Terse payload stays under 4 KB on a representative full snapshot.
+
+    Lead's target was ~1-2 KB / ~32 fields. The 4 KB ceiling gives
+    headroom for long ISO timestamps + skills lists without allowing
+    the projection to silently bloat toward the 28 KB full size.
+    """
+    import json as _json
+
+    from scitex_agent_container.terse import TERSE_STATUS_FIELDS, project_terse
+
+    full = {
+        # Original 13 sources
+        "agent": "head-mba",
+        "state": "running",
+        "timestamp": "2026-04-20T12:34:56Z",
+        "tmux_alive": True,
+        "last_post_ts": "2026-04-20T12:34:00Z",
+        "context_management": {
+            "percent": 42.5,
+            "strategy": "compact",
+            "trigger_at_percent": 85,
+        },
+        "pids": {"claude_code": 12345, "container_daemon": 67890},
+        "health": {"ok": True, "details": "everything nominal"},
+        "snapshot": {
+            "timestamp": "2026-04-20T12:30:00Z",
+            "has_diff": False,
+            "diff_fields": [],
+        },
+        # Extended tranche sources
+        "subagent_count": 2,
+        "subagents": 2,
+        "context_pct": 42.5,
+        "quota_5h_used_pct": 37.5,
+        "quota_7d_used_pct": 61.2,
+        "quota_5h_reset_at": "2026-04-20T17:00:00Z",
+        "quota_7d_reset_at": "2026-04-27T00:00:00Z",
+        "pane_state": "running",
+        "last_action_at": "2026-04-20T12:30:00Z",
+        "last_action_name": "nonce-probe",
+        "last_action_outcome": "alive",
+        "last_tool_at": "2026-04-20T12:34:00Z",
+        "last_tool_name": "Bash",
+        "current_task": "Bash: git status",
+        "current_tool": "Bash",
+        "account_email": "ywata1989@gmail.com",
+        "skills_loaded": [
+            "orochi-agent-startup-protocol",
+            "orochi-fleet-communication-discipline",
+            "orochi-fleet-members",
+            "orochi-user-communication",
+            "orochi-fleet-resurrection-protocol",
+        ],
+        "hostname_canonical": "mba.hpc.unimelb.edu.au",
+        "machine": "mba",
+        # Bulky / PII — must be dropped by the projection
+        "pane_text": "x" * 10000,
+        "claude_md": "y" * 20000,
+        "mcp_json": "z" * 5000,
+        "last_user_msg": "q" * 200,
+        "stuck_prompt_text": "s" * 200,
+        "recent_prompts": ["p" * 500] * 10,
+        "current_tool_input": "c" * 120,
+        "recent_tools": [{"tool": "Bash", "input": "x" * 300}] * 20,
+    }
+    projected = project_terse(full, TERSE_STATUS_FIELDS)
+    size = len(_json.dumps(projected))
+    assert size < 4096, f"terse payload too large: {size}B"
+    # And the expected shape: ~32 fields (31 after we merged two
+    # subagent spellings — keep both, so exactly 32)
+    assert len(TERSE_STATUS_FIELDS) == 32
+    assert set(projected.keys()) == set(TERSE_STATUS_FIELDS)
+
+
 def test_status_full_unaffected_by_terse_flag_absence(
     fake_workspace: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- Extends `TERSE_STATUS_FIELDS` from **13 -> 32** fields so the MCP sidecar heartbeat path (PR #66 pivot) carries high-value status fields without pulling the ~28 KB full payload.
- New fields: `subagent_count`, `subagents` (legacy alias), `context_pct`, `quota_{5h,7d}_{used_pct,reset_at}`, `pane_state`, `last_action_{at,name,outcome}`, `last_tool_{at,name}`, `current_task`, `current_tool`, `account_email`, `skills_loaded`, `hostname_canonical`, `machine`.
- All new names already exist as top-level keys returned by `agent_meta.collect_rich`, so they round-trip cleanly through `project_terse`. No collection-side changes.
- PII / bulky fields (`pane_text`, `claude_md`, `mcp_json`, `last_user_msg`, `stuck_prompt_text`, `recent_prompts`, `current_tool_input`, `recent_tools`) are deliberately EXCLUDED and remain available in full mode only.

## Size on a representative snapshot
- ~1.2 KB / 32 fields -- inside the lead's ~1-2 KB target.
- Test ceiling asserts < 4 KB with a bloated source dict.

## Test plan
- [x] `pytest tests/` -- **593 passed**, 2 deselected.
- [x] `test_status_terse_whitelist_includes_extended_fields` -- whitelist contains the extended tranche AND preserves the original 13.
- [x] `test_status_terse_excludes_pii_and_bulky_fields` -- PII blacklist names absent from both the tuple and the projected output.
- [x] `test_status_terse_payload_size_under_threshold` -- payload < 4 KB on a realistic fixture (full source ~40 KB including the blacklisted bulk fields).

## Files touched
- `src/scitex_agent_container/terse.py` -- whitelist tuple extended.
- `tests/test_status_json.py` -- three new tests.

Follow-up to todo#300 (original terse projection). No behavioural change outside `--terse` mode.
