### PR TITLE
fix(cli/list): use detected multiplexer for is_running (tmux agents always stopped)

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_helpers.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers.py
@@ -198,6 +198,10 @@ def get_agent_list_data(
         remote_host = prep["remote_host"]
         cfg = prep["cfg"]
 
+        multiplexer: str | None = None
+        if not (cfg and cfg.remote.is_remote):
+            multiplexer = _detect_multiplexer(screen_name)
+
         liveness_unknown = False
         try:
             if cfg and cfg.remote.is_remote:
@@ -208,14 +212,15 @@ def get_agent_list_data(
                 else:
                     is_running = bool(probe)
             else:
-                is_running = ScreenManager.exists(screen_name)
+                # _detect_multiplexer returned non-None iff either the tmux
+                # OR screen backend sees this session live — use it as the
+                # authoritative liveness signal. Previously this path
+                # hardcoded ScreenManager.exists(), which always returned
+                # False for tmux agents and reported them as stopped.
+                is_running = multiplexer is not None
         except Exception:
             is_running = False
             liveness_unknown = True
-
-        multiplexer: str | None = None
-        if not (cfg and cfg.remote.is_remote):
-            multiplexer = _detect_multiplexer(screen_name)
 
         status_val: str
         if liveness_unknown:


### PR DESCRIPTION
## Summary

`sac list --json` was reporting `status=stopped` for every tmux-backed agent because `_helpers.get_agent_list_data` hardcoded `ScreenManager.exists(screen_name)` as its liveness check. That call runs `screen -ls <name>`, which never sees a tmux session, so any agent whose multiplexer is `tmux` came back `False` regardless of actual state.

`_detect_multiplexer()` already tries `TmuxManager.exists()` then `ScreenManager.exists()` and returns the backend name (or `None`). Reordered the block so `multiplexer` is detected first, then derived `is_running = multiplexer is not None`.

## Repro (on any host running tmux-backed agents)

```bash
sac list --json | python3 -c 'import sys,json;[print(a["name"], a["status"]) for a in json.loads(sys.stdin.read())]'
```

Before: every agent reports `stopped`.
After: live tmux agents report `running`; only genuinely dead ones report `stopped`.

`sac inspect <name> --json` was (and is) accurate, so the bug only surfaced via bulk listing.

## Why now

Surfaced during healer-mba fleet audit on 2026-04-22 (lead DM msg#17294). Healer routines that relied on `sac list` for stuck-agent detection were getting false-positive `stopped` on every tmux agent, masking real health state. Fixing this removes a false-negative from fleet-resurrection layer 2.

## Test plan

- [x] `pytest tests/` — 602 passed, 2 deselected (full suite unchanged)
- [x] Smoke on mba: `sac list --json` now reports `running` for all 19 live tmux agents; previously reported all `stopped`
- [x] `sac inspect <name> --json` still reports the same `alive: true / state: ...` fields

## Non-goals / Future work

- No regression test added (one-line behavioural change, existing unit tests cover the listing path but don't mock the multiplexer backends). Happy to add one if reviewer prefers.
- Does not change the multiplexer detection order or the remote-probe path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
