### PR TITLE
fix(config): auto-inject SCITEX_OROCHI_AGENT (identity leak)

### DIFF
--- a/src/scitex_agent_container/config/_loaders.py
+++ b/src/scitex_agent_container/config/_loaders.py
@@ -149,12 +149,16 @@ def load_v3(raw: dict, path: Path) -> AgentConfig:
     screen_name = screen_raw.get("name", name)
 
     # Auto-derive env: user values override auto-derived.
-    # Only sac's own namespace is injected. External consumers (orochi etc.)
-    # declare their own env vars explicitly in agent YAML's ``spec.env`` if
-    # they want them set.
+    # sac owns identity injection — ``SCITEX_OROCHI_AGENT`` is stamped here
+    # so the orochi startup-protocol identity check is authoritative against
+    # the agent YAML, not whatever value leaked from the parent shell (see
+    # scitex-orochi fleet DM 2026-04-22, ywatanabe-approved). Other orochi
+    # config (tokens, model labels, channels) remains the caller's concern
+    # and is declared explicitly in agent YAML's ``spec.env``.
     auto_env: dict[str, str] = {
         "CLAUDE_AGENT_ID": name,
         "SCITEX_AGENT_CONTAINER_AGENT": name,
+        "SCITEX_OROCHI_AGENT": name,
     }
     if labels.get("role"):
         auto_env["CLAUDE_AGENT_ROLE"] = labels["role"]

--- a/tests/test_config_v2.py
+++ b/tests/test_config_v2.py
@@ -104,8 +104,12 @@ class TestV2Config:
         assert config.env["CLAUDE_AGENT_ROLE"] == "head"
         assert config.env["SCITEX_AGENT_CONTAINER_AGENT"] == "head-test"
         assert config.env["SCITEX_AGENT_CONTAINER_MODEL"] == "Claude Opus (1M)"
-        # sac MUST NOT auto-inject external-consumer (orochi etc.) env vars.
-        assert "SCITEX_OROCHI_AGENT" not in config.env
+        # sac owns identity injection — SCITEX_OROCHI_AGENT must be stamped
+        # so the orochi startup-protocol identity check is authoritative
+        # and parent-shell leaks cannot bleed through (see fleet DM
+        # 2026-04-22, ywatanabe-approved). Other orochi config (model,
+        # tokens) remains the caller's concern.
+        assert config.env["SCITEX_OROCHI_AGENT"] == "head-test"
         assert "SCITEX_OROCHI_MODEL" not in config.env
         Path(path).unlink()
 


### PR DESCRIPTION
## Summary

- Auto-inject `SCITEX_OROCHI_AGENT={name}` in sac config auto_env alongside existing `CLAUDE_AGENT_ID` / `SCITEX_AGENT_CONTAINER_AGENT`.
- Prevents parent-shell env leaks from overriding agent identity at launch.
- Narrow carveout: **only** `SCITEX_OROCHI_AGENT` is crossing the sac↔orochi namespace boundary, because identity is sac's concern (sac launches the agent). Other orochi config (`SCITEX_OROCHI_MODEL`, tokens, channels) still lives in agent YAML `spec.env`.

## Why

Reported in fleet DM 2026-04-22 01:57 UTC by `lead` (ywatanabe-approved):

> 現 lead プロセスで `SCITEX_OROCHI_AGENT=Yusukes-MacBook-Air-claude` (親シェル由来の旧値) が残存。`agent-startup-protocol` の `SCITEX_OROCHI_AGENT == "lead"` 厳格チェックに違反 (本来 crash すべきケース、hub 側は受理してるので今は実害なし)。

Root cause: `_loaders.py:155` auto_env set `CLAUDE_AGENT_ID` + `SCITEX_AGENT_CONTAINER_AGENT` but **not** `SCITEX_OROCHI_AGENT` — documented behavior at `_skills/scitex-agent-container/config-v2.md:41` disagreed with the code. This PR aligns code with documented behavior for the identity var only.

The startup-protocol identity check is meant to crash-visibly on mismatch. Today the check passes on a leaked value; with this PR it will have the correct value stamped by sac and the check becomes meaningful.

## What does NOT change

- `SCITEX_OROCHI_MODEL` still **not** auto-injected (caller's concern).
- `SCITEX_OROCHI_TOKEN`, channels, webhook secret etc. still **not** auto-injected.
- User-supplied `spec.env.SCITEX_OROCHI_AGENT` still wins (merge order unchanged: `{**auto_env, **user_env}`).

## Test plan

- [x] `pytest tests/test_config_v2.py tests/test_config.py` — 54/54 pass
- [x] Full suite: `pytest tests/` — 606/606 pass
- [ ] After merge: restart lead on mba, verify `echo $SCITEX_OROCHI_AGENT` inside the screen shows `lead` and startup-protocol identity check passes on the stamped value.

## Related

- Fleet DM msg#17454 (lead → head-mba)
- Fleet #heads msg#17460 (ywatanabe — "agent names are weird"). This PR fixes the env-leak component. The separate hostname-suffix rendering (`@Yusukes-MacBook-Air` vs `@mba`) visible in the attached screenshot is a distinct bug — will investigate as a follow-up.
