### PR TITLE
fix(src_files): refresh workspace .mcp.json on every start (todo#453) — develop forward-port

### DIFF
--- a/src/scitex_agent_container/runtimes/src_files.py
+++ b/src/scitex_agent_container/runtimes/src_files.py
@@ -271,10 +271,35 @@ def cleanup_src_claude_md(config: AgentConfig, workdir: str) -> None:
 
 
 def deploy_src_mcp_json(config: AgentConfig, workdir: str) -> None:
-    """Copy src_mcp.json to {workdir}/.mcp.json with interpolation.
+    """Copy ``src_mcp.json`` to ``{workdir}/.mcp.json`` on EVERY invocation.
 
-    Resolves ${metadata.*} and ${ENV_VAR} references.
-    If src_mcp.json does not exist, does nothing.
+    Contract (see todo#453):
+
+    * **Unconditional refresh** — the workspace ``.mcp.json`` is always
+      rewritten from the canonical ``src_mcp.json`` when this function
+      is called. There is NO ``if dest.exists()`` fast-path. This is the
+      invariant that makes canonical config edits (e.g. adding a channel
+      to ``SCITEX_OROCHI_CHANNELS``) propagate on the next agent start
+      rather than lingering as stale workspace state for hours.
+    * **Per-server replace**, not deep-merge — every server entry
+      declared in ``src_mcp.json`` fully overwrites the same-named entry
+      in the workspace copy. This means env keys removed from the
+      canonical source are also removed from the workspace.
+    * **Other servers preserved** — servers present in the workspace
+      ``.mcp.json`` but NOT declared by this agent's ``src_mcp.json``
+      are left untouched (e.g. user-added local tools).
+    * **Idempotent** — calling this repeatedly with an unchanged source
+      produces byte-identical output.
+
+    Interpolation:
+
+    * ``${metadata.name}`` / ``${metadata.labels.*}`` → resolved from
+      the AgentConfig.
+    * ``${ENV_VAR}`` → resolved from ``os.environ`` at write time.
+    * ``~`` prefix in ``args`` entries → expanded to ``$HOME``.
+
+    If ``src_mcp.json`` does not exist next to the agent YAML, does
+    nothing (legacy-v1 / no-MCP agents).
     """
     defdir = _definition_dir(config)
     if defdir is None:
@@ -301,7 +326,8 @@ def deploy_src_mcp_json(config: AgentConfig, workdir: str) -> None:
 
     dest = Path(workdir) / ".mcp.json"
 
-    # Merge with existing .mcp.json if present
+    # Preserve any OTHER servers the workspace has that we don't declare.
+    # Our own servers are always replaced wholesale below.
     existing: dict = {}
     if dest.exists():
         try:
@@ -319,9 +345,33 @@ def deploy_src_mcp_json(config: AgentConfig, workdir: str) -> None:
                 for a in server["args"]
             ]
 
-    # Merge mcpServers
+    # Per-server replace (NOT deep merge): the src entry wholly overrides
+    # any workspace entry with the same key. This guarantees that env
+    # keys removed from src_mcp.json are also removed from the workspace
+    # copy — critical for e.g. retiring a ``SCITEX_OROCHI_CHANNELS``
+    # subscription entry cleanly.
     src_servers = data.get("mcpServers", {})
     existing.setdefault("mcpServers", {}).update(src_servers)
+
+    # Drift diagnostics: log when the workspace was older than src —
+    # the common case of "PR merged N hours ago, agent still stale"
+    # now leaves a breadcrumb in the agent-container log instead of
+    # being a silent no-op.
+    try:
+        if dest.exists():
+            src_mtime = src.stat().st_mtime
+            dest_mtime = dest.stat().st_mtime
+            if src_mtime > dest_mtime:
+                drift_minutes = (src_mtime - dest_mtime) / 60
+                logger.info(
+                    "src_mcp.json for %s is newer than workspace copy by "
+                    "%.1f min — refreshing %s",
+                    config.name,
+                    drift_minutes,
+                    dest,
+                )
+    except OSError:
+        pass
 
     dest.parent.mkdir(parents=True, exist_ok=True)
     dest.write_text(json.dumps(existing, indent=2) + "\n")

--- a/tests/test_src_files.py
+++ b/tests/test_src_files.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+import os
 import re
 import tempfile
 from pathlib import Path
@@ -14,6 +16,7 @@ from scitex_agent_container.runtimes.src_files import (
     _extract_user_tail,
     cleanup_src_claude_md,
     deploy_src_claude_md,
+    deploy_src_mcp_json,
 )
 
 START_MARKER_RE = re.compile(
@@ -194,3 +197,213 @@ class TestCleanupStopStartRoundTrip:
         cleanup_src_claude_md(cfg, str(workdir))
         # Nothing survives the strip, so the file is removed.
         assert not (workdir / "CLAUDE.md").exists()
+
+
+def _make_mcp_config(defdir: Path, servers: dict) -> MagicMock:
+    """Create a mock AgentConfig pointing at a tmp dir with src_mcp.json."""
+    defdir.mkdir(parents=True, exist_ok=True)
+    (defdir / "src_mcp.json").write_text(json.dumps({"mcpServers": servers}))
+    cfg = MagicMock()
+    cfg.name = "test-agent"
+    cfg.labels = {}
+    cfg.config_path = str(defdir / "test-agent.yaml")
+    return cfg
+
+
+class TestDeploySrcMcpJsonRefresh:
+    """Regression tests for todo#453 — workspace .mcp.json must refresh
+    from canonical src_mcp.json on EVERY deploy, not just first launch.
+
+    The 2026-04-15 fleet-lead incident: canonical ``src_mcp.json`` was
+    updated (PR #49 added ``#lead`` and ``#agent`` to the channel
+    subscription), but because the workspace ``.mcp.json`` had been
+    copied on first launch 2 hours prior, the running agent kept
+    reading the stale two-channel subscription. Every agent restart
+    must re-read src_mcp.json and propagate canonical changes.
+    """
+
+    def _server_entry(self, channels: str) -> dict:
+        return {
+            "scitex-orochi": {
+                "type": "stdio",
+                "command": "bun",
+                "args": ["run", "~/proj/scitex-orochi/ts/mcp_channel.ts"],
+                "env": {
+                    "SCITEX_OROCHI_AGENT": "${metadata.name}",
+                    "SCITEX_OROCHI_CHANNELS": channels,
+                },
+            }
+        }
+
+    def test_fresh_deploy_writes_workspace_copy(self, tmp_path):
+        defdir = tmp_path / "def"
+        workdir = str(tmp_path / "workspace")
+        cfg = _make_mcp_config(defdir, self._server_entry("#ywatanabe,#heads"))
+
+        deploy_src_mcp_json(cfg, workdir)
+
+        dest = Path(workdir) / ".mcp.json"
+        assert dest.exists()
+        data = json.loads(dest.read_text())
+        assert data["mcpServers"]["scitex-orochi"]["env"][
+            "SCITEX_OROCHI_CHANNELS"
+        ] == "#ywatanabe,#heads"
+
+    def test_env_change_propagates_on_redeploy(self, tmp_path):
+        """The todo#453 scenario exactly: canonical src_mcp.json gets a
+        new channel added after first launch; the next deploy must
+        overwrite the stale workspace env.
+        """
+        defdir = tmp_path / "def"
+        workdir = str(tmp_path / "workspace")
+        cfg = _make_mcp_config(defdir, self._server_entry("#ywatanabe,#heads"))
+
+        # First launch: workspace gets old subscription
+        deploy_src_mcp_json(cfg, workdir)
+        dest = Path(workdir) / ".mcp.json"
+        assert json.loads(dest.read_text())["mcpServers"]["scitex-orochi"][
+            "env"
+        ]["SCITEX_OROCHI_CHANNELS"] == "#ywatanabe,#heads"
+
+        # Canonical PR lands: new channels appear in src_mcp.json
+        (defdir / "src_mcp.json").write_text(
+            json.dumps(
+                {"mcpServers": self._server_entry(
+                    "#ywatanabe,#heads,#lead,#agent"
+                )}
+            )
+        )
+
+        # Restart: deploy re-runs, workspace MUST reflect canonical
+        deploy_src_mcp_json(cfg, workdir)
+
+        refreshed = json.loads(dest.read_text())
+        assert refreshed["mcpServers"]["scitex-orochi"]["env"][
+            "SCITEX_OROCHI_CHANNELS"
+        ] == "#ywatanabe,#heads,#lead,#agent"
+
+    def test_removed_env_key_is_dropped_on_redeploy(self, tmp_path):
+        """Per-server replace semantics: if src drops an env key, the
+        workspace copy must also drop it. This guards against the
+        inverse stale-state bug (a retired env var lingering).
+        """
+        defdir = tmp_path / "def"
+        workdir = str(tmp_path / "workspace")
+
+        server_with_extra = {
+            "scitex-orochi": {
+                "type": "stdio",
+                "command": "bun",
+                "env": {
+                    "SCITEX_OROCHI_AGENT": "${metadata.name}",
+                    "LEGACY_KEY": "should-be-dropped",
+                },
+            }
+        }
+        (defdir).mkdir(parents=True, exist_ok=True)
+        (defdir / "src_mcp.json").write_text(
+            json.dumps({"mcpServers": server_with_extra})
+        )
+        cfg = MagicMock()
+        cfg.name = "test-agent"
+        cfg.labels = {}
+        cfg.config_path = str(defdir / "test-agent.yaml")
+
+        deploy_src_mcp_json(cfg, workdir)
+        dest = Path(workdir) / ".mcp.json"
+        assert "LEGACY_KEY" in json.loads(dest.read_text())[
+            "mcpServers"
+        ]["scitex-orochi"]["env"]
+
+        # Canonical drops the key
+        server_no_extra = {
+            "scitex-orochi": {
+                "type": "stdio",
+                "command": "bun",
+                "env": {"SCITEX_OROCHI_AGENT": "${metadata.name}"},
+            }
+        }
+        (defdir / "src_mcp.json").write_text(
+            json.dumps({"mcpServers": server_no_extra})
+        )
+
+        deploy_src_mcp_json(cfg, workdir)
+
+        env = json.loads(dest.read_text())["mcpServers"]["scitex-orochi"]["env"]
+        assert "LEGACY_KEY" not in env
+        assert env["SCITEX_OROCHI_AGENT"] == "test-agent"
+
+    def test_other_servers_preserved(self, tmp_path):
+        """Servers present in workspace .mcp.json but NOT declared by this
+        agent's src_mcp.json are preserved (user-added local tools etc.).
+        """
+        defdir = tmp_path / "def"
+        workdir = Path(tmp_path / "workspace")
+        workdir.mkdir(parents=True, exist_ok=True)
+        cfg = _make_mcp_config(defdir, self._server_entry("#a,#b"))
+
+        # Pre-seed workspace with a foreign server
+        (workdir / ".mcp.json").write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "local-tool": {
+                            "type": "stdio",
+                            "command": "my-local-mcp",
+                        }
+                    }
+                }
+            )
+        )
+
+        deploy_src_mcp_json(cfg, str(workdir))
+
+        data = json.loads((workdir / ".mcp.json").read_text())
+        assert "local-tool" in data["mcpServers"]
+        assert "scitex-orochi" in data["mcpServers"]
+
+    def test_unconditional_refresh_even_when_src_older(self, tmp_path):
+        """The invariant is unconditional: we refresh even if the src
+        mtime is older than the workspace copy. This protects against
+        clock-skew or filesystem-copy edge cases where the canonical
+        file's mtime might be artificially earlier than the workspace.
+
+        Without this guarantee, a naive ``if src.mtime > dest.mtime``
+        fast-path would silently skip legitimate updates.
+        """
+        defdir = tmp_path / "def"
+        workdir = str(tmp_path / "workspace")
+        cfg = _make_mcp_config(defdir, self._server_entry("#v2"))
+
+        deploy_src_mcp_json(cfg, workdir)
+        dest = Path(workdir) / ".mcp.json"
+
+        # Rewrite src with new content, but backdate its mtime so it
+        # appears OLDER than the workspace copy.
+        (defdir / "src_mcp.json").write_text(
+            json.dumps({"mcpServers": self._server_entry("#v3")})
+        )
+        ancient = dest.stat().st_mtime - 3600  # 1 hour older
+        os.utime(defdir / "src_mcp.json", (ancient, ancient))
+
+        deploy_src_mcp_json(cfg, workdir)
+
+        env = json.loads(dest.read_text())["mcpServers"]["scitex-orochi"][
+            "env"
+        ]
+        assert env["SCITEX_OROCHI_CHANNELS"] == "#v3"
+
+    def test_idempotent_when_src_unchanged(self, tmp_path):
+        """Repeated deploys with no src change produce byte-identical
+        output."""
+        defdir = tmp_path / "def"
+        workdir = str(tmp_path / "workspace")
+        cfg = _make_mcp_config(defdir, self._server_entry("#stable"))
+
+        deploy_src_mcp_json(cfg, workdir)
+        first = (Path(workdir) / ".mcp.json").read_text()
+
+        deploy_src_mcp_json(cfg, workdir)
+        second = (Path(workdir) / ".mcp.json").read_text()
+
+        assert first == second


### PR DESCRIPTION
## Summary

Forward-port of merged PR #64 (todo#453 fix) from `main` to `develop`.

The original PR #64 was merged into `main` only and never made it into `develop`, leaving the develop line still vulnerable to the class-3 agent-silence failure mode (stale workspace `.mcp.json`). This PR re-applies the same patch on top of the current `develop` HEAD via `git cherry-pick f02f0fa`.

## Why this exists

Per `scitex-orochi` convention, PRs must target `develop`, not `main`. PR #64 violated that and the fix never propagated. Without this forward-port, every release cut from `develop` ships without the todo#453 regression-test guardrails — a future "optimization" could silently re-introduce the first-launch-only copy bug.

## Changes

Identical to PR #64:

- `src/scitex_agent_container/runtimes/src_files.py`:
  - Strengthen `deploy_src_mcp_json` docstring with explicit invariants (unconditional refresh, per-server replace, foreign-server preservation, idempotency).
  - Add mtime-drift diagnostic log when `src.mtime > dest.mtime` so canonical-vs-runtime drift is visible at boot instead of silent.
- `tests/test_src_files.py`: +6 regression tests in new `TestDeploySrcMcpJsonRefresh` class:
  - fresh deploy writes workspace copy
  - env change propagates on redeploy (exact todo#453 scenario)
  - removed env key dropped on redeploy
  - foreign (non-declared) servers preserved
  - unconditional refresh even when src mtime is backdated
  - idempotent when src unchanged

## Test plan

- [x] `PYTHONPATH=src pytest tests/test_src_files.py -v` — 20/20 pass (14 existing + 6 new)
- [x] `PYTHONPATH=src pytest tests/test_src_files.py tests/test_config_v2.py -v` — 48/48 pass
- [ ] Manual verification on fleet-lead (next restart cycle): edit `src_mcp.json` `SCITEX_OROCHI_CHANNELS`, restart, confirm workspace `.mcp.json` reflects change.

## Deferred follow-up

`fleet_sub_snapshot.py` drift-detector integration (issue deliverable #3) is not done in this PR. The script exists only inside `scitex-orochi` worktree directories (e.g. `/home/ywatanabe/proj/scitex-orochi/.claude/worktrees/agent-*/scripts/client/fleet_sub_snapshot.py`) and is NOT a tracked file in either `scitex-orochi` or `scitex-agent-container`. Promoting it to a tracked, periodic fleet-audit timer is a separate todo and out of scope for this code-only fix.

## Cross-refs

- Closes ywatanabe1989/todo#453
- Original (main-only) PR: #64
- head-nas msg#12744 — originating finding
- 2026-04-15 fleet-lead incident — class-3 silence root cause

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>