### PR TITLE
fix(claude_code): repair --continue, add --resume override and 'sac recall'

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_main.py
+++ b/src/scitex_agent_container/cli_pkg/_main.py
@@ -17,6 +17,7 @@ from .hook_cmds import hook_event
 from .info_cmds import attach, find, list_python_apis, logs
 from .lifecycle_cmds import cleanup, restart, start, stop
 from .probe_cmds import probe_network
+from .recall_cmds import recall
 from .render_cmds import render_attach, render_sbatch
 from .snapshot_cmds import snapshot
 from .status_cmds import check_agent, health, list_agents, status
@@ -80,6 +81,10 @@ main.add_command(quota_watch)
 
 # Claude Code hook event ingestor
 main.add_command(hook_event)
+
+# Recall: read back a previous session's jsonl (post-crash recovery,
+# context inspection without --continue).
+main.add_command(recall)
 
 # Action subsystem: run PaneActions, query attempts, aggregate stats.
 main.add_command(actions_cli)

--- a/src/scitex_agent_container/cli_pkg/lifecycle_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle_cmds.py
@@ -134,10 +134,48 @@ def _discover_all_agents() -> list[str]:
     default=False,
     help="If already running or stale, stop first then start fresh.",
 )
+@click.option(
+    "--resume",
+    "resume_id",
+    type=str,
+    default=None,
+    help="Resume a specific Claude Code session by ID (e.g. the UUID of the "
+    "*.jsonl under ~/.claude/projects/<encoded>/). Implies --session resume "
+    "and overrides the YAML's claude.session / claude.resume_id.",
+)
+@click.option(
+    "--session",
+    "session_mode",
+    type=click.Choice(
+        ["continue-or-new", "continue", "new", "resume"], case_sensitive=False
+    ),
+    default=None,
+    help="Override the YAML's claude.session for this start invocation.",
+)
 def start(
-    config_path: str | None, start_all: bool, no_preflight: bool, force: bool
+    config_path: str | None,
+    start_all: bool,
+    no_preflight: bool,
+    force: bool,
+    resume_id: str | None,
+    session_mode: str | None,
 ) -> None:
     """Start an agent from a YAML definition, or --all to start every agent."""
+    if (resume_id or session_mode) and start_all:
+        click.echo(
+            "Error: --resume / --session cannot be combined with --all "
+            "(they would apply the same value to every agent).",
+            err=True,
+        )
+        sys.exit(2)
+    if resume_id and session_mode and session_mode != "resume":
+        click.echo(
+            f"Error: --resume requires --session resume, got --session {session_mode}.",
+            err=True,
+        )
+        sys.exit(2)
+    if resume_id and session_mode is None:
+        session_mode = "resume"
     if start_all:
         yamls = _discover_all_agents()
         if not yamls:
@@ -204,7 +242,19 @@ def start(
             console.print("[dim]Preflight checks skipped (--no-preflight)[/dim]")
         if force:
             console.print("[dim]Force mode: stopping any existing instance first[/dim]")
-        agent_start(config_path, no_preflight=no_preflight, force=force)
+        if session_mode:
+            console.print(
+                f"[dim]Session override: claude.session = {session_mode}"
+                + (f", resume_id = {resume_id}" if resume_id else "")
+                + "[/dim]"
+            )
+        agent_start(
+            config_path,
+            no_preflight=no_preflight,
+            force=force,
+            session_override=session_mode,
+            resume_id_override=resume_id,
+        )
         console.print(
             f"[green]Agent '{config.name}' started successfully [{location}][/green]"
         )

--- a/src/scitex_agent_container/cli_pkg/recall_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/recall_cmds.py
@@ -1,0 +1,183 @@
+"""``sac recall <jsonl>`` — summarize / read back a Claude Code session jsonl.
+
+Used after a host crash to reconstruct what the dead agent was doing
+without paying the cost of a full ``--continue`` resume.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import click
+
+from ..recall import (
+    collect_stats,
+    filter_entries,
+    format_entry,
+    format_stats,
+    iter_entries,
+    parse_duration,
+)
+
+
+def _resolve_jsonl(arg: str) -> Path:
+    """Accept a path, a session id, or '<agent-name>:<session-id>'."""
+    p = Path(arg).expanduser()
+    if p.exists():
+        return p
+    # Bare session id: search ~/.claude/projects/*/<id>.jsonl
+    candidates = list(Path.home().glob(f".claude/projects/*/{arg}.jsonl"))
+    if len(candidates) == 1:
+        return candidates[0]
+    if len(candidates) > 1:
+        raise click.ClickException(
+            f"Ambiguous session id {arg!r} matches {len(candidates)} files"
+        )
+    raise click.ClickException(f"jsonl not found: {arg}")
+
+
+@click.command()
+@click.argument("jsonl", type=str)
+@click.option(
+    "--stats",
+    "stats_only",
+    is_flag=True,
+    default=False,
+    help="Print stats summary only (no per-message body).",
+)
+@click.option(
+    "--last",
+    "last",
+    type=str,
+    default=None,
+    help="Limit to the final window of the transcript "
+    "(e.g. '8h', '30m', '1.5d'). Anchored on the transcript's last "
+    "timestamp, not wallclock now.",
+)
+@click.option(
+    "--since",
+    "since",
+    type=str,
+    default=None,
+    help="ISO-8601 timestamp; show entries strictly after this.",
+)
+@click.option(
+    "--until",
+    "until",
+    type=str,
+    default=None,
+    help="ISO-8601 timestamp; show entries strictly before this.",
+)
+@click.option(
+    "--role",
+    "role",
+    type=click.Choice(["user", "assistant", "system", "all"]),
+    default=None,
+    help="Filter by message role. 'all' includes infra types too.",
+)
+@click.option(
+    "--contains",
+    "contains",
+    type=str,
+    default=None,
+    help="Case-insensitive substring filter on message text.",
+)
+@click.option(
+    "--limit",
+    "limit",
+    type=int,
+    default=None,
+    help="Cap to the last N matching entries (after filtering).",
+)
+@click.option(
+    "--include-thinking",
+    is_flag=True,
+    default=False,
+    help="Include [thinking] parts (off by default — usually noise).",
+)
+@click.option(
+    "--no-tool-results",
+    "no_tool_results",
+    is_flag=True,
+    default=False,
+    help="Drop synthetic 'user' records that are really tool_result "
+    "callbacks. Useful when --role user should mean 'human prompts only'.",
+)
+@click.option(
+    "--body-limit",
+    "body_limit",
+    type=int,
+    default=600,
+    help="Truncate each printed message body to this many chars (0 = no limit).",
+)
+def recall(
+    jsonl: str,
+    stats_only: bool,
+    last: str | None,
+    since: str | None,
+    until: str | None,
+    role: str | None,
+    contains: str | None,
+    limit: int | None,
+    include_thinking: bool,
+    no_tool_results: bool,
+    body_limit: int,
+) -> None:
+    """Summarize a Claude Code session jsonl.
+
+    JSONL can be a full path or a bare session id (auto-resolved against
+    ``~/.claude/projects/*/``).
+    """
+    path = _resolve_jsonl(jsonl)
+    stats = collect_stats(path)
+    click.echo("# stats")
+    click.echo(format_stats(stats))
+    if stats_only:
+        return
+
+    last_td = parse_duration(last) if last else None
+    since_dt = _parse_iso(since) if since else None
+    until_dt = _parse_iso(until) if until else None
+
+    # Anchor "last" on the transcript's last timestamp, not wallclock now.
+    reference_now = stats.last_ts if last_td else None
+
+    entries = list(
+        filter_entries(
+            iter_entries(path),
+            last=last_td,
+            since=since_dt,
+            until=until_dt,
+            role=role,
+            contains=contains,
+            include_thinking=include_thinking,
+            include_tool_results=not no_tool_results,
+            reference_now=reference_now,
+        )
+    )
+
+    if limit is not None and limit > 0 and len(entries) > limit:
+        entries = entries[-limit:]
+
+    click.echo(f"\n# entries ({len(entries)})")
+    bl = body_limit if body_limit and body_limit > 0 else None
+    for e in entries:
+        click.echo("")
+        click.echo(format_entry(e, body_limit=bl))
+
+
+def _parse_iso(s: str) -> datetime:
+    raw = s.strip()
+    if raw.endswith("Z"):
+        raw = raw[:-1] + "+00:00"
+    try:
+        dt = datetime.fromisoformat(raw)
+    except ValueError as exc:
+        raise click.ClickException(f"invalid ISO timestamp: {s!r} ({exc})")
+    return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(recall.main(standalone_mode=True))

--- a/src/scitex_agent_container/lifecycle.py
+++ b/src/scitex_agent_container/lifecycle.py
@@ -98,6 +98,8 @@ def agent_start(
     registry: Registry | None = None,
     no_preflight: bool = False,
     force: bool = False,
+    session_override: str | None = None,
+    resume_id_override: str | None = None,
 ) -> bool:
     """Start an agent from a YAML config file.
 
@@ -108,12 +110,21 @@ def agent_start(
         force: If True and the agent is already running, stop it first
             and then start fresh. Also tolerates stale registry entries
             and ghost screens (via force-stop).
+        session_override: If set, override config.claude.session for this
+            start invocation (one of continue-or-new | continue | new | resume).
+        resume_id_override: If set, override config.claude.resume_id. Pass
+            with session_override="resume" to launch ``claude --resume <id>``
+            without editing the YAML.
 
     Returns True on success, False on failure.
     """
     config_path = resolve_config(config_path)
     registry = registry or Registry()
     config = load_config(config_path)
+    if session_override:
+        config.claude.session = session_override
+    if resume_id_override is not None:
+        config.claude.resume_id = resume_id_override
     runtime = _get_runtime(config)
 
     # Already running?

--- a/src/scitex_agent_container/recall.py
+++ b/src/scitex_agent_container/recall.py
@@ -1,0 +1,310 @@
+"""Recall context from a Claude Code session jsonl.
+
+Used by ``sac recall <jsonl>`` to summarize a previous session — typically
+the dead transcript left behind after a host crash — so a fresh agent
+can re-read the salient state without paying the cost of a full
+``--continue``.
+
+Three things the CLI should support:
+
+1. Path-in: any ``~/.claude/projects/<encoded>/<uuid>.jsonl``.
+2. Stats: rough message/tool/time histogram so the user sees the shape
+   before reading line-by-line.
+3. Filtering: time window (``--last 8h``), role, substring match. Time
+   filtering is the core use case — "what was I doing in the last
+   8 hours of the dead session" is the reason this exists.
+
+Kept dependency-free (stdlib only) so it loads even when the broader
+sac runtime can't import (cf. the a2a / scitex_config gaps that block
+the rest of the CLI).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections import Counter
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Iterable, Iterator
+
+
+# Records we treat as "conversational" rather than infrastructure noise.
+# attachment / queue-operation / permission-mode / file-history-snapshot
+# bloat the transcript without carrying user-facing intent.
+ROLE_TYPES = ("user", "assistant", "system")
+
+
+@dataclass
+class Entry:
+    """A flattened jsonl line with the bits we actually print."""
+
+    ts: datetime | None
+    type: str  # user | assistant | system | ... (raw jsonl 'type')
+    role: str  # user | assistant | system | other
+    text: str = ""  # joined text parts
+    tool_uses: list[tuple[str, dict]] = field(default_factory=list)  # (name, input)
+    is_tool_result: bool = False  # True if this 'user' record is actually a tool_result
+    raw: dict = field(default_factory=dict)
+
+
+@dataclass
+class Stats:
+    total_lines: int = 0
+    parse_errors: int = 0
+    by_type: Counter = field(default_factory=Counter)
+    tool_uses: Counter = field(default_factory=Counter)
+    first_ts: datetime | None = None
+    last_ts: datetime | None = None
+    session_id: str = ""
+    cwd: str = ""
+    version: str = ""
+
+    @property
+    def duration(self) -> timedelta | None:
+        if self.first_ts and self.last_ts:
+            return self.last_ts - self.first_ts
+        return None
+
+
+_DURATION_RE = re.compile(r"^(\d+(?:\.\d+)?)\s*([smhdw])$", re.IGNORECASE)
+
+
+def parse_duration(spec: str) -> timedelta:
+    """Parse '8h', '30m', '1.5d', '2w', '45s' into a timedelta.
+
+    Raises ValueError on unrecognised input. Whitespace is tolerated.
+    """
+    s = (spec or "").strip()
+    m = _DURATION_RE.match(s)
+    if not m:
+        raise ValueError(f"unrecognised duration: {spec!r}")
+    value = float(m.group(1))
+    unit = m.group(2).lower()
+    factor = {"s": 1, "m": 60, "h": 3600, "d": 86400, "w": 604800}[unit]
+    return timedelta(seconds=value * factor)
+
+
+def _parse_ts(raw: str | None) -> datetime | None:
+    if not raw:
+        return None
+    try:
+        # Claude Code timestamps are ISO-8601 with a trailing 'Z'.
+        if raw.endswith("Z"):
+            raw = raw[:-1] + "+00:00"
+        dt = datetime.fromisoformat(raw)
+        return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+    except ValueError:
+        return None
+
+
+def _extract_text(content) -> tuple[str, list[tuple[str, dict]], bool]:
+    """Pull joined text + tool_use pairs out of a message.content blob.
+
+    Returns (joined_text, tool_uses, is_tool_result). The third element
+    is True iff every part in the content list is a tool_result — the
+    common shape for synthetic 'user' records that are really tool
+    feedback, not human prompts.
+    """
+    if content is None:
+        return "", [], False
+    if isinstance(content, str):
+        return content, [], False
+    if not isinstance(content, list):
+        return "", [], False
+    texts: list[str] = []
+    tools: list[tuple[str, dict]] = []
+    saw_non_tool_result = False
+    saw_tool_result = False
+    for part in content:
+        if not isinstance(part, dict):
+            saw_non_tool_result = True
+            continue
+        ptype = part.get("type")
+        if ptype == "text":
+            saw_non_tool_result = True
+            t = part.get("text") or ""
+            if t:
+                texts.append(t)
+        elif ptype == "thinking":
+            saw_non_tool_result = True
+            t = part.get("thinking") or part.get("text") or ""
+            if t:
+                texts.append(f"[thinking] {t}")
+        elif ptype == "tool_use":
+            saw_non_tool_result = True
+            tools.append((part.get("name") or "?", part.get("input") or {}))
+        elif ptype == "tool_result":
+            saw_tool_result = True
+            t = part.get("content") or ""
+            if isinstance(t, list):
+                t = "\n".join(
+                    (p.get("text") or "")
+                    for p in t
+                    if isinstance(p, dict)
+                )
+            if isinstance(t, str) and t:
+                texts.append(f"[tool_result] {t}")
+        else:
+            saw_non_tool_result = True
+    is_tool_result = saw_tool_result and not saw_non_tool_result
+    return "\n".join(texts), tools, is_tool_result
+
+
+def iter_entries(jsonl_path: Path | str) -> Iterator[Entry]:
+    """Stream Entry records from a jsonl file. Skips infra-only lines."""
+    path = Path(jsonl_path).expanduser()
+    with path.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                d = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            rtype = d.get("type", "")
+            ts = _parse_ts(d.get("timestamp"))
+            msg = d.get("message") if isinstance(d.get("message"), dict) else {}
+            role = msg.get("role") or rtype
+            text, tools, is_tool_result = _extract_text(msg.get("content"))
+            yield Entry(
+                ts=ts,
+                type=rtype,
+                role=role or "",
+                text=text,
+                tool_uses=tools,
+                is_tool_result=is_tool_result,
+                raw=d,
+            )
+
+
+def collect_stats(jsonl_path: Path | str) -> Stats:
+    """Single pass over the jsonl producing a histogram + time range."""
+    s = Stats()
+    path = Path(jsonl_path).expanduser()
+    with path.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            s.total_lines += 1
+            try:
+                d = json.loads(line)
+            except json.JSONDecodeError:
+                s.parse_errors += 1
+                continue
+            s.by_type[d.get("type", "?")] += 1
+            ts = _parse_ts(d.get("timestamp"))
+            if ts:
+                if s.first_ts is None or ts < s.first_ts:
+                    s.first_ts = ts
+                if s.last_ts is None or ts > s.last_ts:
+                    s.last_ts = ts
+            if d.get("type") == "assistant":
+                msg = d.get("message") or {}
+                for part in msg.get("content") or []:
+                    if isinstance(part, dict) and part.get("type") == "tool_use":
+                        s.tool_uses[part.get("name") or "?"] += 1
+            if not s.session_id:
+                s.session_id = d.get("sessionId") or ""
+            if not s.cwd:
+                s.cwd = d.get("cwd") or ""
+            if not s.version:
+                s.version = d.get("version") or ""
+    return s
+
+
+def filter_entries(
+    entries: Iterable[Entry],
+    *,
+    last: timedelta | None = None,
+    since: datetime | None = None,
+    until: datetime | None = None,
+    role: str | None = None,
+    contains: str | None = None,
+    include_thinking: bool = False,
+    include_tool_results: bool = True,
+    skip_empty: bool = True,
+    reference_now: datetime | None = None,
+) -> Iterator[Entry]:
+    """Apply CLI-style filters lazily.
+
+    ``last`` is interpreted relative to ``reference_now`` (default: the
+    last entry in the stream — but the caller usually passes the
+    transcript's last_ts so 'last 8h' is "the final 8h of the
+    transcript", not 'the last 8h before wallclock now'. The dead
+    transcript may be days old).
+    """
+    items = list(entries) if reference_now is None else None
+    if items is not None:
+        # Need two passes only if last is specified and reference_now wasn't given.
+        if last is not None and reference_now is None:
+            ref_candidates = [e.ts for e in items if e.ts is not None]
+            reference_now = max(ref_candidates) if ref_candidates else None
+        source: Iterable[Entry] = items
+    else:
+        source = entries
+
+    contains_lc = contains.lower() if contains else None
+
+    for e in source:
+        if role and (e.role or "") != role and role != "all":
+            continue
+        if not include_tool_results and e.is_tool_result:
+            continue
+        if not include_thinking and e.text.startswith("[thinking] "):
+            continue
+        if skip_empty and not e.text and not e.tool_uses:
+            continue
+        if last is not None and reference_now is not None and e.ts is not None:
+            if (reference_now - e.ts) > last:
+                continue
+        if since is not None and (e.ts is None or e.ts < since):
+            continue
+        if until is not None and (e.ts is None or e.ts > until):
+            continue
+        if contains_lc and contains_lc not in e.text.lower():
+            continue
+        yield e
+
+
+def format_stats(s: Stats) -> str:
+    """Compact human-readable stats block."""
+    lines = []
+    lines.append(f"session_id : {s.session_id or '-'}")
+    lines.append(f"cwd        : {s.cwd or '-'}")
+    lines.append(f"version    : {s.version or '-'}")
+    lines.append(f"lines      : {s.total_lines} (parse-errors: {s.parse_errors})")
+    if s.first_ts and s.last_ts:
+        lines.append(f"time range : {s.first_ts.isoformat()} → {s.last_ts.isoformat()}")
+        dur = s.duration
+        if dur:
+            total_min = dur.total_seconds() / 60
+            lines.append(f"duration   : {total_min:.1f} min")
+    if s.by_type:
+        lines.append("by_type    :")
+        for t, n in s.by_type.most_common():
+            lines.append(f"  {t}: {n}")
+    if s.tool_uses:
+        lines.append("tool_uses  :")
+        for t, n in s.tool_uses.most_common():
+            lines.append(f"  {t}: {n}")
+    return "\n".join(lines)
+
+
+def format_entry(e: Entry, *, body_limit: int | None = 600) -> str:
+    """Single-message markdown-ish block."""
+    ts = e.ts.isoformat() if e.ts else "-"
+    head = f"## [{ts}] {e.role or e.type}"
+    body = e.text or ""
+    if body_limit is not None and len(body) > body_limit:
+        body = body[:body_limit].rstrip() + f" … (+{len(e.text) - body_limit} chars)"
+    parts = [head]
+    if body:
+        parts.append(body)
+    if e.tool_uses:
+        tu_lines = [f"  - {name}({', '.join(sorted((inp or {}).keys()))})" for name, inp in e.tool_uses]
+        parts.append("tool_use:\n" + "\n".join(tu_lines))
+    return "\n".join(parts)

--- a/src/scitex_agent_container/runtimes/claude_code.py
+++ b/src/scitex_agent_container/runtimes/claude_code.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 import threading
 import time
 from pathlib import Path
@@ -59,16 +60,18 @@ def _encode_workdir_for_claude_projects(workdir: str) -> str:
 
     Claude Code stores per-project session history under
     ``~/.claude/projects/<encoded>/`` where ``<encoded>`` is the absolute
-    workdir with every ``/`` replaced by ``-`` (the leading slash becomes a
-    leading ``-``; dot-prefixed path segments like ``.dotfiles`` produce a
-    double-dash, which is expected).
+    workdir with both ``/`` and ``.`` replaced by ``-``. Dot-prefixed path
+    segments like ``/.dotfiles`` therefore produce a double-dash
+    (``/`` + ``.`` → ``-`` + ``-``); runs of three or more dashes are
+    collapsed back to ``--`` to match Claude Code's own normalization.
     """
     abs_path = str(
         Path(workdir).expanduser().resolve()
         if Path(workdir).expanduser().exists()
         else Path(workdir).expanduser()
     )
-    return abs_path.replace("/", "-")
+    encoded = abs_path.replace("/", "-").replace(".", "-")
+    return re.sub(r"-{3,}", "--", encoded)
 
 
 def _session_resumable(
@@ -175,7 +178,11 @@ class ClaudeCodeRuntime(RuntimeBase):
                     config.expanded_workdir,
                 )
             else:
-                logger.info(
+                # Warning rather than info: continue-or-new is best-effort, so
+                # we still launch fresh, but a missed resume often points to
+                # an encoding/path bug (the ~/.claude/projects/<encoded>/ dir
+                # didn't match) and silent info hides that.
+                logger.warning(
                     "session=continue-or-new: no resumable session for %s, launching fresh",
                     config.expanded_workdir,
                 )

--- a/tests/test_recall.py
+++ b/tests/test_recall.py
@@ -1,0 +1,261 @@
+"""Tests for ``sac recall`` and the ``recall`` module.
+
+Focus areas:
+    - jsonl parsing and Entry extraction
+    - duration string parsing ('8h', '30m', '1.5d', ...)
+    - filter combinations (last, since, role, contains)
+    - stats collection
+    - ``--last`` anchored on transcript last_ts (not wallclock now)
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container.recall import (
+    Entry,
+    collect_stats,
+    filter_entries,
+    iter_entries,
+    parse_duration,
+)
+
+
+# ---------------------------------------------------------------------------
+# parse_duration
+# ---------------------------------------------------------------------------
+
+
+class TestParseDuration:
+    @pytest.mark.parametrize(
+        "spec, seconds",
+        [
+            ("30s", 30),
+            ("5m", 300),
+            ("8h", 8 * 3600),
+            ("1d", 86400),
+            ("2w", 2 * 604800),
+            ("1.5h", 1.5 * 3600),
+            ("  10m  ", 600),  # whitespace ok
+            ("8H", 8 * 3600),  # case-insensitive
+        ],
+    )
+    def test_basic(self, spec, seconds):
+        assert parse_duration(spec).total_seconds() == seconds
+
+    @pytest.mark.parametrize("bad", ["", "8", "8x", "abc", "8h30m", "-3h"])
+    def test_invalid_raises(self, bad):
+        with pytest.raises(ValueError):
+            parse_duration(bad)
+
+
+# ---------------------------------------------------------------------------
+# Sample jsonl writer
+# ---------------------------------------------------------------------------
+
+
+def _write_jsonl(path: Path, lines: list[dict]) -> None:
+    path.write_text("\n".join(json.dumps(rec) for rec in lines) + "\n")
+
+
+def _user(ts: str, text: str) -> dict:
+    return {
+        "type": "user",
+        "timestamp": ts,
+        "message": {"role": "user", "content": text},
+        "sessionId": "sess-1",
+        "cwd": "/fake/wd",
+        "version": "0.0.0-test",
+    }
+
+
+def _assistant(ts: str, text: str = "", tools: list[tuple[str, dict]] | None = None) -> dict:
+    content: list[dict] = []
+    if text:
+        content.append({"type": "text", "text": text})
+    for name, inp in tools or []:
+        content.append({"type": "tool_use", "name": name, "input": inp})
+    return {
+        "type": "assistant",
+        "timestamp": ts,
+        "message": {"role": "assistant", "content": content},
+        "sessionId": "sess-1",
+    }
+
+
+# ---------------------------------------------------------------------------
+# iter_entries
+# ---------------------------------------------------------------------------
+
+
+class TestIterEntries:
+    def test_strips_infra_and_keeps_role_messages(self, tmp_path):
+        path = tmp_path / "s.jsonl"
+        _write_jsonl(
+            path,
+            [
+                _user("2026-04-28T01:00:00Z", "first user"),
+                {"type": "attachment", "timestamp": "2026-04-28T01:00:01Z"},
+                _assistant("2026-04-28T01:00:02Z", "first reply"),
+                {"type": "queue-operation", "timestamp": "2026-04-28T01:00:03Z"},
+                _user("2026-04-28T01:00:04Z", "second user"),
+            ],
+        )
+        entries = list(iter_entries(path))
+        # All 5 records yielded; role-based filtering happens in filter_entries.
+        assert len(entries) == 5
+        roles_with_text = [(e.role, e.text) for e in entries if e.text]
+        assert roles_with_text == [
+            ("user", "first user"),
+            ("assistant", "first reply"),
+            ("user", "second user"),
+        ]
+
+    def test_extracts_tool_uses(self, tmp_path):
+        path = tmp_path / "s.jsonl"
+        _write_jsonl(
+            path,
+            [
+                _assistant(
+                    "2026-04-28T01:00:00Z",
+                    "running test",
+                    tools=[("Bash", {"command": "ls"}), ("Read", {"file_path": "/a"})],
+                ),
+            ],
+        )
+        entries = list(iter_entries(path))
+        assert len(entries) == 1
+        e = entries[0]
+        assert e.text == "running test"
+        assert [name for name, _ in e.tool_uses] == ["Bash", "Read"]
+
+    def test_skips_unparseable_lines(self, tmp_path):
+        path = tmp_path / "s.jsonl"
+        path.write_text("\n".join([
+            "{not json",
+            json.dumps(_user("2026-04-28T01:00:00Z", "hi")),
+            "",
+        ]) + "\n")
+        entries = list(iter_entries(path))
+        # The bad line is dropped; the good one and the empty separator (skipped) → 1 entry.
+        assert len(entries) == 1
+        assert entries[0].role == "user"
+
+
+# ---------------------------------------------------------------------------
+# collect_stats
+# ---------------------------------------------------------------------------
+
+
+class TestCollectStats:
+    def test_basic(self, tmp_path):
+        path = tmp_path / "s.jsonl"
+        _write_jsonl(
+            path,
+            [
+                _user("2026-04-28T01:00:00Z", "u1"),
+                _assistant("2026-04-28T01:01:00Z", "a1", tools=[("Bash", {})]),
+                _assistant("2026-04-28T01:02:00Z", "", tools=[("Bash", {}), ("Read", {})]),
+                {"type": "attachment", "timestamp": "2026-04-28T01:03:00Z"},
+            ],
+        )
+        s = collect_stats(path)
+        assert s.total_lines == 4
+        assert s.parse_errors == 0
+        assert s.by_type["user"] == 1
+        assert s.by_type["assistant"] == 2
+        assert s.by_type["attachment"] == 1
+        assert s.tool_uses["Bash"] == 2
+        assert s.tool_uses["Read"] == 1
+        assert s.first_ts == datetime(2026, 4, 28, 1, 0, tzinfo=timezone.utc)
+        assert s.last_ts == datetime(2026, 4, 28, 1, 3, tzinfo=timezone.utc)
+        assert s.duration == timedelta(minutes=3)
+        assert s.session_id == "sess-1"
+        assert s.cwd == "/fake/wd"
+
+
+# ---------------------------------------------------------------------------
+# filter_entries
+# ---------------------------------------------------------------------------
+
+
+def _entry(ts_iso: str, role: str, text: str = "") -> Entry:
+    dt = datetime.fromisoformat(ts_iso.replace("Z", "+00:00"))
+    return Entry(ts=dt, type=role, role=role, text=text)
+
+
+class TestFilterEntries:
+    def test_role_filter(self):
+        entries = [
+            _entry("2026-04-28T01:00:00Z", "user", "u1"),
+            _entry("2026-04-28T01:01:00Z", "assistant", "a1"),
+            _entry("2026-04-28T01:02:00Z", "user", "u2"),
+        ]
+        kept = list(filter_entries(entries, role="user"))
+        assert [e.text for e in kept] == ["u1", "u2"]
+
+    def test_contains_filter_case_insensitive(self):
+        entries = [
+            _entry("2026-04-28T01:00:00Z", "user", "Hello world"),
+            _entry("2026-04-28T01:01:00Z", "user", "goodbye"),
+        ]
+        kept = list(filter_entries(entries, contains="HELLO"))
+        assert [e.text for e in kept] == ["Hello world"]
+
+    def test_last_anchored_on_reference_now_not_wallclock(self):
+        # Transcript span: 10:00 to 10:30 on a day far in the past.
+        entries = [
+            _entry("2020-01-01T10:00:00Z", "user", "old"),
+            _entry("2020-01-01T10:15:00Z", "user", "mid"),
+            _entry("2020-01-01T10:29:30Z", "user", "near-end"),
+            _entry("2020-01-01T10:30:00Z", "user", "end"),
+        ]
+        last_15m = parse_duration("15m")
+        # Anchored on the transcript's last_ts (10:30) → keeps mid, near-end, end.
+        kept = list(
+            filter_entries(
+                entries,
+                last=last_15m,
+                reference_now=datetime(2020, 1, 1, 10, 30, tzinfo=timezone.utc),
+            )
+        )
+        assert [e.text for e in kept] == ["mid", "near-end", "end"]
+
+    def test_since_until(self):
+        entries = [
+            _entry("2026-04-28T01:00:00Z", "user", "early"),
+            _entry("2026-04-28T01:30:00Z", "user", "middle"),
+            _entry("2026-04-28T02:00:00Z", "user", "late"),
+        ]
+        kept = list(
+            filter_entries(
+                entries,
+                since=datetime(2026, 4, 28, 1, 15, tzinfo=timezone.utc),
+                until=datetime(2026, 4, 28, 1, 45, tzinfo=timezone.utc),
+            )
+        )
+        assert [e.text for e in kept] == ["middle"]
+
+    def test_skip_empty_default(self):
+        entries = [
+            _entry("2026-04-28T01:00:00Z", "assistant", ""),  # no text, no tools
+            _entry("2026-04-28T01:01:00Z", "user", "hi"),
+        ]
+        kept = list(filter_entries(entries))
+        assert [e.text for e in kept] == ["hi"]
+
+    def test_no_tool_results_drops_synthetic_user_records(self):
+        # Mimics the jsonl shape where 'user' messages are really
+        # tool_result callbacks. With --no-tool-results those should be
+        # filtered out so --role user means 'human prompts only'.
+        human = _entry("2026-04-28T01:00:00Z", "user", "real prompt")
+        synthetic = _entry(
+            "2026-04-28T01:01:00Z", "user", "[tool_result] sent"
+        )
+        synthetic.is_tool_result = True
+        kept = list(filter_entries([human, synthetic], include_tool_results=False))
+        assert [e.text for e in kept] == ["real prompt"]

--- a/tests/test_session_resume.py
+++ b/tests/test_session_resume.py
@@ -184,6 +184,7 @@ class TestAgentStartOverrides:
 
     def test_session_override_mutates_config(self, tmp_path):
         from scitex_agent_container import lifecycle
+        from scitex_agent_container.registry import Registry
 
         yaml = tmp_path / "agent.yaml"
         yaml.write_text(
@@ -195,13 +196,25 @@ class TestAgentStartOverrides:
             "  claude:\n    session: continue-or-new\n"
         )
         captured: dict = {}
+
+        class _StubRegistry:
+            def exists(self_inner, name):
+                return False
+
+            def add(self_inner, **kwargs):
+                # Don't write to ~/.scitex/agent-container/registry/.
+                pass
+
         with patch.object(
-            lifecycle, "_get_runtime", return_value=self._stub_runtime_capture(captured)
+            lifecycle,
+            "_get_runtime",
+            return_value=self._stub_runtime_capture(captured),
         ), patch.object(lifecycle, "_run_hooks"), patch.object(
             lifecycle, "_fire_forget_hook"
-        ):
+        ), patch.object(Registry, "__new__", lambda cls, *a, **kw: _StubRegistry()):
             lifecycle.agent_start(
                 str(yaml),
+                registry=_StubRegistry(),  # type: ignore[arg-type]
                 session_override="resume",
                 resume_id_override="abc-xyz",
             )

--- a/tests/test_session_resume.py
+++ b/tests/test_session_resume.py
@@ -146,6 +146,68 @@ class TestBuildCommand:
             cmd = ClaudeCodeRuntime()._build_command(cfg)
         assert "--continue" not in cmd
 
+    def test_resume_mode_with_id_emits_resume_flag(self):
+        cfg = AgentConfig(
+            name="test-agent",
+            workdir="/fake/workdir",
+            claude=ClaudeSpec(session="resume", resume_id="abc-123"),
+        )
+        cmd = ClaudeCodeRuntime()._build_command(cfg)
+        assert "--resume 'abc-123'" in cmd
+        assert "--continue" not in cmd
+
+
+# ---------------------------------------------------------------------------
+# agent_start CLI overrides (--resume / --session)
+# ---------------------------------------------------------------------------
+
+
+class TestAgentStartOverrides:
+    """``agent_start(session_override=..., resume_id_override=...)`` mutates
+    the loaded config before the runtime sees it, so callers can do
+    ``sac start lead.yaml --resume <id>`` without editing the YAML.
+    """
+
+    def _stub_runtime_capture(self, captured: dict):
+        """Build a fake runtime whose .start() records the config it sees."""
+
+        class _StubRuntime:
+            def is_running(self_inner, config):
+                return False
+
+            def start(self_inner, config, **kwargs):
+                captured["session"] = config.claude.session
+                captured["resume_id"] = config.claude.resume_id
+                return True
+
+        return _StubRuntime()
+
+    def test_session_override_mutates_config(self, tmp_path):
+        from scitex_agent_container import lifecycle
+
+        yaml = tmp_path / "agent.yaml"
+        yaml.write_text(
+            "apiVersion: scitex-agent-container/v3\n"
+            "kind: Agent\n"
+            "metadata:\n  labels: {role: test}\n"
+            "spec:\n"
+            "  runtime: claude-code\n"
+            "  claude:\n    session: continue-or-new\n"
+        )
+        captured: dict = {}
+        with patch.object(
+            lifecycle, "_get_runtime", return_value=self._stub_runtime_capture(captured)
+        ), patch.object(lifecycle, "_run_hooks"), patch.object(
+            lifecycle, "_fire_forget_hook"
+        ):
+            lifecycle.agent_start(
+                str(yaml),
+                session_override="resume",
+                resume_id_override="abc-xyz",
+            )
+        assert captured["session"] == "resume"
+        assert captured["resume_id"] == "abc-xyz"
+
 
 # ---------------------------------------------------------------------------
 # parse_claude

--- a/tests/test_session_resume.py
+++ b/tests/test_session_resume.py
@@ -41,10 +41,31 @@ class TestEncodeWorkdir:
         )
 
     def test_dot_prefix_segment_produces_double_dash(self):
-        # Matches observed Claude Code behavior, e.g. ``.dotfiles`` -> ``--dotfiles``.
+        # Claude Code replaces both ``/`` and ``.`` with ``-``, so
+        # ``/.dotfiles`` becomes ``--dotfiles``.
         assert (
             _encode_workdir_for_claude_projects("/Users/ywatanabe/.dotfiles")
-            == "-Users-ywatanabe-.dotfiles"
+            == "-Users-ywatanabe--dotfiles"
+        )
+
+    def test_scitex_workspace_path_matches_disk(self):
+        # Regression: the lead/proj/contributor workspaces under
+        # ~/.scitex/agent-container/workspaces/<name>/ must encode to the
+        # exact dirname Claude Code uses on disk, otherwise --continue is
+        # silently dropped on every restart.
+        assert (
+            _encode_workdir_for_claude_projects(
+                "/home/ywatanabe/.scitex/agent-container/workspaces/lead"
+            )
+            == "-home-ywatanabe--scitex-agent-container-workspaces-lead"
+        )
+
+    def test_triple_or_more_dashes_collapse_to_double(self):
+        # ``/..foo`` would naively expand to ``---foo`` (slash + two dots);
+        # Claude Code collapses runs of 3+ dashes back to ``--``.
+        assert (
+            _encode_workdir_for_claude_projects("/Users/ywatanabe/..foo")
+            == "-Users-ywatanabe--foo"
         )
 
 


### PR DESCRIPTION
## Summary

Three changes that landed together while recovering from a host crash that left every fleet agent unable to ``--continue`` its previous session:

- **fix**: `_encode_workdir_for_claude_projects()` now replaces `.` (in addition to `/`) and collapses runs of 3+ dashes back to `--`, matching Claude Code's actual on-disk encoding. Any workspace under a dot-prefixed path (`~/.scitex/...`, `~/.dotfiles/...`) was hashing to a non-existent dir, so `_session_resumable()` returned `False` for the whole fleet and `continue-or-new` silently degraded to `new` on every restart. Also bumps the "no resumable session" log from `info` to `warning` so the next encoding mismatch isn't silent.
- **feat**: `sac start --resume <id>` and `--session <mode>` CLI overrides — let an operator point an agent at a specific dead jsonl (e.g. `--resume 43c52f3b-...`) without editing the YAML.
- **feat**: `sac recall <jsonl>` — read back a previous session's transcript with a histogram + filter set (`--last 8h` anchored on the transcript's last ts, `--role user --no-tool-results`, `--contains`, `--limit`, etc.). Stdlib-only so it loads even when the rest of the CLI can't import.

## Tests

All 43 unit tests pass (24 new for recall, 19 for session-resume incl. 2 regression tests asserting the lead workspace path encodes to the exact dirname Claude Code uses on disk).

## Test plan

- [x] `pytest tests/test_session_resume.py tests/test_recall.py -v` → 43/43 pass
- [x] `_encode_workdir_for_claude_projects('/home/ywatanabe/.scitex/agent-container/workspaces/lead')` matches the on-disk dir
- [x] `sac recall <jsonl> --stats` against the dead lead's 02:50 transcript prints session_id / cwd / time-range / by_type histogram / tool_uses
- [x] `sac recall <jsonl> --last 1h --role user --no-tool-results --limit 5` recovers the last 5 real human prompts only (no tool_result noise)
- [ ] `sac start <yaml>` with the fix in place actually emits `--continue` for a workspace under `~/.scitex/...` (manual smoke; verifying after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)