### PR TITLE
feat(slurm-tenant): forward spec.env so the compute claude finds ANTHROPIC_API_KEY

### DIFF
--- a/src/scitex_agent_container/runtimes/slurm_tenant.py
+++ b/src/scitex_agent_container/runtimes/slurm_tenant.py
@@ -148,6 +148,36 @@ class SlurmTenantRuntime(RuntimeBase):
             parts.append("--continue")
         return shlex.join(parts)
 
+    def _build_env_prefix(self, config: AgentConfig) -> str:
+        """Render ``KEY=value KEY2=value2 ...`` for the tmux launch line.
+
+        Each spec ``env:`` entry is forwarded to the compute-side claude
+        via inline assignment in the bash command (``FOO=bar
+        BAZ=qux exec claude ...``). Values support:
+
+        * ``~``-prefix → expanded to ``$HOME`` literal so the compute
+          shell does the expansion at exec time.
+        * ``${VAR}`` → kept as a shell ref so the compute shell
+          resolves it from its own env (lets agents inherit values
+          like ``$ANTHROPIC_API_KEY2`` that are set in the user's
+          login profile but not in the spec).
+
+        Returns an empty string when ``config.env`` is empty.
+        """
+        if not config.env:
+            return ""
+        pairs: list[str] = []
+        for k, v in config.env.items():
+            if not isinstance(v, str):
+                v = str(v)
+            if v.startswith("~"):
+                v = "$HOME" + v[1:]
+            # Quote the value so bash treats it as a single token, but
+            # leave ${VAR} refs unexpanded by the local quoting layer
+            # (they still get expanded by the remote bash).
+            pairs.append(f"{k}={shlex.quote(v)}")
+        return " ".join(pairs)
+
     def _setup_workspace(self, config: AgentConfig) -> str:
         """Provision the agent's workspace dir on disk and return its path.
 
@@ -210,12 +240,19 @@ class SlurmTenantRuntime(RuntimeBase):
         workdir = self._setup_workspace(config)
 
         claude_cmd = self._build_claude_command(config)
-        # tmux launches ``cd <workdir> && exec <claude>`` so the agent's
-        # cwd is its workspace dir (where .mcp.json, CLAUDE.md, and
-        # ~/.claude/projects/<encoded>/ live), not the user's $HOME.
-        # Without ``cd`` claude treats $HOME as the project root and the
-        # workspace's MCP servers / CLAUDE.md never get loaded.
-        cwd_cmd = f"cd {shlex.quote(workdir)} && exec {claude_cmd}"
+        env_prefix = self._build_env_prefix(config)
+        # tmux launches ``[cd <workdir> &&] [<env>] exec <claude>`` so the
+        # agent's cwd is its workspace dir (.mcp.json, CLAUDE.md,
+        # ~/.claude/projects/<encoded>/ all relative to it) and any
+        # spec-declared env vars (e.g. ANTHROPIC_API_KEY redirects,
+        # SCITEX_OROCHI_AGENT) reach the compute-side claude even if
+        # the user's login shell on the compute node doesn't set them.
+        if env_prefix:
+            cwd_cmd = (
+                f"cd {shlex.quote(workdir)} && {env_prefix} exec {claude_cmd}"
+            )
+        else:
+            cwd_cmd = f"cd {shlex.quote(workdir)} && exec {claude_cmd}"
         # tmux new -d (detached) -s <session> '<command>'
         # The double-shell-quote is intentional: outer wrapper for srun, inner
         # for tmux's command argument.

--- a/tests/test_slurm_tenant_runtime.py
+++ b/tests/test_slurm_tenant_runtime.py
@@ -440,3 +440,69 @@ class TestStartProvisionsWorkspace:
         assert "cd " in new_session_call
         assert cfg.expanded_workdir in new_session_call
         assert "exec claude" in new_session_call
+
+
+class TestEnvPrefix:
+    """``_build_env_prefix`` translates ``spec.env`` into inline
+    ``KEY=value KEY2=value2 ...`` assignments before ``exec claude``,
+    so spec-declared vars (ANTHROPIC_API_KEY redirects, agent name,
+    workspace token) reach the compute-side process even when the
+    compute node's login shell doesn't set them.
+    """
+
+    def test_empty_env_returns_empty_string(self):
+        cfg = _cfg()
+        cfg.env = {}
+        assert SlurmTenantRuntime()._build_env_prefix(cfg) == ""
+
+    def test_basic_env_pairs_quoted(self):
+        cfg = _cfg()
+        cfg.env = {"FOO": "bar", "BAZ": "with space"}
+        prefix = SlurmTenantRuntime()._build_env_prefix(cfg)
+        assert "FOO=bar" in prefix
+        # shlex.quote turns 'with space' into 'with space' single-quoted.
+        assert "BAZ='with space'" in prefix
+
+    def test_tilde_expanded_to_HOME_for_compute_shell(self):
+        cfg = _cfg()
+        cfg.env = {"FOO_PATH": "~/secrets/foo"}
+        prefix = SlurmTenantRuntime()._build_env_prefix(cfg)
+        # Local shlex.quote quotes the entire string with $HOME literal,
+        # so the compute-side bash will expand $HOME at exec time.
+        assert "FOO_PATH='$HOME/secrets/foo'" in prefix
+
+    def test_dollar_var_kept_for_compute_expansion(self):
+        cfg = _cfg()
+        cfg.env = {"ANTHROPIC_API_KEY": "${ANTHROPIC_API_KEY2}"}
+        prefix = SlurmTenantRuntime()._build_env_prefix(cfg)
+        assert "ANTHROPIC_API_KEY='${ANTHROPIC_API_KEY2}'" in prefix
+
+    def test_env_prefix_lands_in_tmux_command(
+        self, fake_scitex_hpc, monkeypatch
+    ):
+        from scitex_agent_container.runtimes import slurm_tenant as st_mod
+
+        for name in (
+            "setup_mcp_config",
+            "setup_settings_json",
+            "setup_claude_md",
+            "deploy_src_claude_md",
+            "deploy_src_mcp_json",
+            "deploy_src_env",
+        ):
+            monkeypatch.setattr(st_mod, name, lambda *a, **kw: None)
+        monkeypatch.setattr(st_mod, "_has_src_files", lambda cfg: False)
+
+        fake_scitex_hpc.exec.side_effect = [_proc(stdout="NONE"), _proc()]
+        cfg = _cfg()
+        cfg.env = {"ANTHROPIC_API_KEY": "${ANTHROPIC_API_KEY2}"}
+        SlurmTenantRuntime().start(cfg)
+
+        new_session_call = fake_scitex_hpc.exec.call_args_list[1].args[0]
+        # ANTHROPIC_API_KEY assignment must appear between the cd and
+        # the exec, so the env reaches the claude process.
+        assert "ANTHROPIC_API_KEY=" in new_session_call
+        cd_idx = new_session_call.find("cd ")
+        env_idx = new_session_call.find("ANTHROPIC_API_KEY=")
+        exec_idx = new_session_call.find("exec claude")
+        assert cd_idx < env_idx < exec_idx


### PR DESCRIPTION
## Summary

Stacks on top of #90. Adds env-forwarding to ``SlurmTenantRuntime`` so a spec ``env:`` block reaches the compute-side ``claude`` as inline ``KEY=value KEY2=value2 ...`` assignments before ``exec claude``.

Why this matters: Spartan compute nodes have ``ANTHROPIC_API_KEY2``, ``..._3``, ``SCITEX_*_ANTHROPIC_API_KEY``, etc. set in the user's login profile but **no bare ``ANTHROPIC_API_KEY``**. A fresh ``claude`` boot inside the fleet-pool reservation therefore 401s on its first API call (verified during today's smoke test of ``c-scitex-orochi-fr4-agents-tab-detail``). Without an env channel, the runtime can't redirect those values; operators' only fallback was to touch every compute node's profile.

With this change, the fix is one line in the spec:

```yaml
spec:
  env:
    ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY2}"
```

The ``${...}`` ref is shlex.quoted but kept literally so the compute-side bash expands it at exec time.

Behaviour:
- ``~``-prefix → expanded to ``$HOME`` literal (compute shell expands at exec).
- ``${VAR}`` refs → kept as shell refs, quoted whole, expanded by compute bash.
- Plain values → shlex.quoted as one token.

## Tests

- ``test_empty_env_returns_empty_string``
- ``test_basic_env_pairs_quoted`` — including a value with internal whitespace.
- ``test_tilde_expanded_to_HOME_for_compute_shell``
- ``test_dollar_var_kept_for_compute_expansion`` — the production case.
- ``test_env_prefix_lands_in_tmux_command`` — asserts the prefix sits between ``cd <workdir>`` and ``exec claude``.

31/31 tests in ``tests/test_slurm_tenant_runtime.py`` pass.

## Test plan

- [x] ``pytest tests/test_slurm_tenant_runtime.py`` → 31/31 pass.
- [ ] After #90 + this merge, set ``env: ANTHROPIC_API_KEY: \"\${ANTHROPIC_API_KEY2}\"`` on a Spartan tenant agent and confirm the fresh claude boot reaches the hub instead of 401-ing. (Manual smoke after merge.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)