### PR TITLE
feat: post-merge-pull cron + sac install boot + workspace path convention

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,9 @@ Issues = "https://github.com/ywatanabe1989/scitex-agent-container/issues"
 [tool.hatch.build.targets.wheel]
 packages = ["src/scitex_agent_container"]
 
+[tool.hatch.build.targets.wheel.force-include]
+"src/scitex_agent_container/cron/post-merge-pull.sh" = "scitex_agent_container/cron/post-merge-pull.sh"
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = ["test_*.py"]

--- a/src/scitex_agent_container/cli_pkg/_main.py
+++ b/src/scitex_agent_container/cli_pkg/_main.py
@@ -109,6 +109,10 @@ main.add_command(render_attach)
 # Connectivity probe (todo#457): fleet-facing WSL ↔ hub liveness.
 main.add_command(probe_network)
 
+# Install helpers: host bootstrap + cron installer.
+main.add_command(install_group)
+main.add_command(install_post_merge_cron)
+
 # A2A protocol — generic agent-to-agent surface (no fleet deps).
 from .a2a_cmds import a2a as a2a_group  # noqa: E402
 

--- a/src/scitex_agent_container/cli_pkg/_main.py
+++ b/src/scitex_agent_container/cli_pkg/_main.py
@@ -15,6 +15,7 @@ from .action_cmds import actions_cli
 from .build_cmds import build, check, validate
 from .hook_cmds import hook_event
 from .info_cmds import attach, find, list_python_apis, logs
+from .install_cmds import install_group, install_post_merge_cron
 from .lifecycle_cmds import (
     cleanup,
     restart,

--- a/src/scitex_agent_container/cli_pkg/install_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/install_cmds.py
@@ -1,0 +1,332 @@
+"""Install commands: ``sac install --boot`` and ``sac install-post-merge-cron``.
+
+Deliverables:
+  * ``sac install --boot`` — first-time host bootstrap (venv, dirs, PATH)
+  * ``sac install-post-merge-cron`` — add/remove crontab entry for
+    post-merge-pull.sh
+"""
+
+from __future__ import annotations
+
+import importlib.resources
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import click
+
+from ._helpers import console
+
+# ---------------------------------------------------------------------------
+# Shared constants
+# ---------------------------------------------------------------------------
+
+_SHARED_DIRS = [
+    "~/.scitex/orochi/shared/agents",
+    "~/.scitex/orochi/shared/skills",
+    "~/.scitex/orochi/shared/logs",
+    "~/.scitex/orochi/shared/cron",
+]
+
+_CRON_SCRIPT_NAME = "post-merge-pull.sh"
+_CRON_SCRIPT_DEST = Path("~/.scitex/orochi/shared/cron").expanduser() / _CRON_SCRIPT_NAME
+_CRON_LOG_PATTERN = "~/.scitex/orochi/shared/logs/post-merge-pull.$(hostname -s).cron.log"
+
+_CRON_MARKER = "post-merge-pull"
+
+
+def _cron_line() -> str:
+    return (
+        f"* * * * * {_CRON_SCRIPT_DEST} "
+        f">> {_CRON_LOG_PATTERN} 2>&1"
+    )
+
+
+# ---------------------------------------------------------------------------
+# install group
+# ---------------------------------------------------------------------------
+
+@click.group("install")
+def install_group() -> None:
+    """Bootstrap and install helpers for a new fleet host."""
+
+
+# ---------------------------------------------------------------------------
+# sac install --boot
+# ---------------------------------------------------------------------------
+
+@install_group.command("boot")
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Print what would be done without making any changes.",
+)
+def boot(dry_run: bool) -> None:  # noqa: C901
+    """First-time host bootstrap: venv, PATH, shared dirs, cron script.
+
+    Safe to re-run — every step is idempotent.
+
+    \\b
+    Steps:
+      1. Create ~/.venv-3.11 (python3.11+) if missing.
+      2. pip install -e <this package> into the venv.
+      3. Add ~/.venv-3.11/bin to ~/.bashrc and ~/.zshrc (if they exist).
+      4. Verify tmux is on PATH (prints instructions if missing).
+      5. Create ~/.scitex/orochi/shared/{agents,skills,logs,cron}/.
+      6. Copy bundled post-merge-pull.sh to the cron dir (chmod +x).
+      7. Print "boot OK" and the installed sac version.
+    """
+    tag = "[dim][dry-run][/dim] " if dry_run else ""
+
+    # ------------------------------------------------------------------
+    # Step 1 — venv
+    # ------------------------------------------------------------------
+    venv_dir = Path("~/.venv-3.11").expanduser()
+    if venv_dir.exists():
+        console.print(f"{tag}venv [green]already exists[/green]: {venv_dir}")
+    else:
+        python = _find_python311()
+        if python is None:
+            console.print(
+                "[red]Error:[/red] python3.11+ not found on PATH. "
+                "Install it via your package manager (e.g. apt install python3.11).",
+                err=True,
+            )
+            sys.exit(1)
+        console.print(f"{tag}Creating venv at {venv_dir} with {python}…")
+        if not dry_run:
+            subprocess.run([python, "-m", "venv", str(venv_dir)], check=True)
+
+    # ------------------------------------------------------------------
+    # Step 2 — pip install -e <this package>
+    # ------------------------------------------------------------------
+    sac_src = _find_sac_src()
+    pip = venv_dir / "bin" / "pip"
+    if not dry_run and venv_dir.exists():
+        console.print(f"{tag}Installing sac into venv…")
+        subprocess.run([str(pip), "install", "--quiet", "-e", str(sac_src)], check=True)
+    else:
+        console.print(f"{tag}Would run: {pip} install -e {sac_src}")
+
+    # ------------------------------------------------------------------
+    # Step 3 — PATH injection
+    # ------------------------------------------------------------------
+    bin_dir = str(venv_dir / "bin")
+    path_line = f'\nexport PATH="{bin_dir}:$PATH"  # added by sac install --boot\n'
+    for rc in ["~/.bashrc", "~/.zshrc"]:
+        rc_path = Path(rc).expanduser()
+        if not rc_path.exists():
+            continue
+        content = rc_path.read_text()
+        if bin_dir in content:
+            console.print(f"{tag}PATH already set in {rc_path}")
+        else:
+            console.print(f"{tag}Adding {bin_dir} to {rc_path}…")
+            if not dry_run:
+                rc_path.write_text(content + path_line)
+
+    # ------------------------------------------------------------------
+    # Step 4 — tmux check
+    # ------------------------------------------------------------------
+    if shutil.which("tmux") is None:
+        console.print(
+            "[yellow]WARNING:[/yellow] tmux not found on PATH. "
+            "Install it with your package manager:\n"
+            "  Ubuntu/Debian: sudo apt install tmux\n"
+            "  macOS:         brew install tmux\n"
+            "  RHEL/Rocky:    sudo dnf install tmux"
+        )
+    else:
+        tmux_ver = subprocess.run(
+            ["tmux", "-V"], capture_output=True, text=True
+        ).stdout.strip()
+        console.print(f"{tag}tmux [green]OK[/green]: {tmux_ver}")
+
+    # ------------------------------------------------------------------
+    # Step 5 — shared dirs
+    # ------------------------------------------------------------------
+    for d in _SHARED_DIRS:
+        p = Path(d).expanduser()
+        if p.exists():
+            console.print(f"{tag}dir [green]exists[/green]: {p}")
+        else:
+            console.print(f"{tag}Creating {p}…")
+            if not dry_run:
+                p.mkdir(parents=True, exist_ok=True)
+
+    # ------------------------------------------------------------------
+    # Step 6 — copy cron script
+    # ------------------------------------------------------------------
+    _deploy_cron_script(dry_run=dry_run, tag=tag)
+
+    # ------------------------------------------------------------------
+    # Step 7 — summary
+    # ------------------------------------------------------------------
+    if dry_run:
+        console.print("[dim]dry-run complete — no changes were made.[/dim]")
+    else:
+        try:
+            sac_bin = venv_dir / "bin" / "sac"
+            ver = subprocess.run(
+                [str(sac_bin), "--version"], capture_output=True, text=True
+            ).stdout.strip()
+        except Exception:
+            ver = "(version unavailable)"
+        console.print(f"[green bold]boot OK[/green bold] — {ver}")
+        console.print(
+            "[dim]Re-source your shell or open a new terminal to pick up the PATH change.[/dim]"
+        )
+
+
+def _find_python311() -> str | None:
+    for candidate in ("python3.11", "python3.12", "python3.13", "python3"):
+        path = shutil.which(candidate)
+        if path is None:
+            continue
+        result = subprocess.run(
+            [path, "-c", "import sys; print(sys.version_info >= (3,11))"],
+            capture_output=True,
+            text=True,
+        )
+        if result.stdout.strip() == "True":
+            return path
+    return None
+
+
+def _find_sac_src() -> Path:
+    """Return the root directory of the scitex-agent-container package."""
+    try:
+        import scitex_agent_container as _pkg
+        pkg_path = Path(_pkg.__file__).parent
+        # Walk up to pyproject.toml
+        for parent in [pkg_path, pkg_path.parent, pkg_path.parent.parent]:
+            if (parent / "pyproject.toml").exists():
+                return parent
+    except ImportError:
+        pass
+    return Path(__file__).parent.parent.parent.parent
+
+
+def _deploy_cron_script(dry_run: bool, tag: str) -> None:
+    """Copy bundled post-merge-pull.sh to the shared cron dir."""
+    dest = _CRON_SCRIPT_DEST
+    dest.parent.mkdir(parents=True, exist_ok=True)
+
+    # Locate the bundled script via package resources.
+    try:
+        src = importlib.resources.files("scitex_agent_container.cron").joinpath(
+            _CRON_SCRIPT_NAME
+        )
+        src_path = Path(str(src))
+    except Exception:
+        # Fallback: relative to this file.
+        src_path = Path(__file__).parent.parent / "cron" / _CRON_SCRIPT_NAME
+
+    if not src_path.exists():
+        console.print(
+            f"[red]Error:[/red] bundled {_CRON_SCRIPT_NAME} not found at {src_path}",
+            err=True,
+        )
+        return
+
+    if dest.exists() and dest.read_bytes() == src_path.read_bytes():
+        console.print(f"{tag}cron script [green]up-to-date[/green]: {dest}")
+    else:
+        console.print(f"{tag}Deploying {_CRON_SCRIPT_NAME} → {dest}…")
+        if not dry_run:
+            shutil.copy2(str(src_path), str(dest))
+            dest.chmod(0o755)
+
+
+# ---------------------------------------------------------------------------
+# sac install-post-merge-cron
+# ---------------------------------------------------------------------------
+
+@click.command("install-post-merge-cron")
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Print the crontab line without modifying crontab.",
+)
+@click.option(
+    "--uninstall",
+    is_flag=True,
+    default=False,
+    help="Remove the post-merge-pull cron entry if present.",
+)
+def install_post_merge_cron(dry_run: bool, uninstall: bool) -> None:
+    """Add (or remove) the post-merge-pull crontab entry.
+
+    Idempotent: re-running when the line already exists is a no-op.
+    Requires post-merge-pull.sh to be deployed first
+    (run ``sac install boot`` to do that).
+    """
+    if dry_run and uninstall:
+        click.echo("Error: --dry-run and --uninstall are mutually exclusive.", err=True)
+        sys.exit(2)
+
+    cron_line = _cron_line()
+
+    # Read current crontab.
+    result = subprocess.run(
+        ["crontab", "-l"], capture_output=True, text=True
+    )
+    if result.returncode not in (0, 1):
+        console.print(f"[red]Error reading crontab:[/red] {result.stderr.strip()}")
+        sys.exit(1)
+    current = result.stdout if result.returncode == 0 else ""
+    lines = current.splitlines(keepends=True)
+
+    already_present = any(_CRON_MARKER in line for line in lines)
+
+    if uninstall:
+        if not already_present:
+            console.print("[dim]No post-merge-pull entry in crontab — nothing to remove.[/dim]")
+            return
+        new_lines = [l for l in lines if _CRON_MARKER not in l]
+        _write_crontab(new_lines)
+        console.print("[green]Removed[/green] post-merge-pull from crontab.")
+        return
+
+    if dry_run:
+        console.print("[bold]Would add to crontab:[/bold]")
+        click.echo(cron_line)
+        if already_present:
+            console.print("[dim](line already present — would be a no-op)[/dim]")
+        return
+
+    if already_present:
+        console.print(
+            "[dim]post-merge-pull already in crontab — no-op.[/dim]"
+        )
+        return
+
+    # Ensure cron script is executable.
+    if not _CRON_SCRIPT_DEST.exists():
+        console.print(
+            f"[yellow]WARNING:[/yellow] {_CRON_SCRIPT_DEST} not found. "
+            "Run `sac install boot` first to deploy the script."
+        )
+
+    new_content = current.rstrip("\n") + ("\n" if current else "") + cron_line + "\n"
+    _write_crontab_str(new_content)
+    console.print(f"[green]Added[/green] to crontab:\n  {cron_line}")
+
+
+def _write_crontab(lines: list[str]) -> None:
+    _write_crontab_str("".join(lines))
+
+
+def _write_crontab_str(content: str) -> None:
+    proc = subprocess.run(
+        ["crontab", "-"],
+        input=content,
+        text=True,
+        capture_output=True,
+    )
+    if proc.returncode != 0:
+        console.print(f"[red]Error writing crontab:[/red] {proc.stderr.strip()}")
+        sys.exit(1)

--- a/src/scitex_agent_container/cron/__init__.py
+++ b/src/scitex_agent_container/cron/__init__.py
@@ -1,0 +1,1 @@
+# Bundled cron scripts for fleet hosts.

--- a/src/scitex_agent_container/cron/post-merge-pull.sh
+++ b/src/scitex_agent_container/cron/post-merge-pull.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# post-merge-pull.sh — pull every scitex-* in-tree clone from gitea:develop.
+#
+# Designed to run under cron once a minute on each fleet host.
+# Scope: ~/proj/<repo> only.  ~/forks/ and workspace clones are skipped.
+#
+# Usage:
+#   crontab: * * * * * ~/.scitex/orochi/shared/cron/post-merge-pull.sh \
+#              >> ~/.scitex/orochi/shared/logs/post-merge-pull.$(hostname -s).cron.log 2>&1
+
+set -euo pipefail
+
+HOST="$(hostname -s)"
+LOG_DIR="${HOME}/.scitex/orochi/shared/logs"
+LOG_FILE="${LOG_DIR}/post-merge-pull.${HOST}.log"
+LOCK_FILE="/tmp/post-merge-pull.${HOST}.lock"
+
+mkdir -p "${LOG_DIR}"
+
+_ts() { date '+%Y-%m-%dT%H:%M:%S'; }
+_info() { echo "$(_ts) [INFO] $*" | tee -a "${LOG_FILE}"; }
+_warn() { echo "$(_ts) [WARN] $*" | tee -a "${LOG_FILE}" >&2; }
+
+# Acquire exclusive lock — abort if another run is still active.
+exec 9>"${LOCK_FILE}"
+if ! flock -n 9; then
+    _warn "Another instance is running (${LOCK_FILE}). Exiting."
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Repo list: canonical name → gitea remote URL
+# ---------------------------------------------------------------------------
+declare -A GITEA_URLS=(
+    ["scitex-agent-container"]="git@git.scitex.ai:ywatanabe1989/scitex-agent-container.git"
+    ["scitex-orochi"]="git@git.scitex.ai:ywatanabe1989/scitex-orochi.git"
+    ["scitex-resource"]="git@git.scitex.ai:ywatanabe1989/scitex-resource.git"
+    ["scitex-ssh"]="git@git.scitex.ai:ywatanabe1989/scitex-ssh.git"
+    ["scitex-hpc"]="git@git.scitex.ai:ywatanabe1989/scitex-hpc.git"
+    ["scitex"]="git@git.scitex.ai:ywatanabe1989/scitex.git"
+)
+
+_pull_repo() {
+    local name="$1"
+    local repo_path="${HOME}/proj/${name}"
+
+    [[ -d "${repo_path}" ]] || { _info "SKIP ${name}: not found at ${repo_path}"; return 0; }
+
+    # Skip repos with uncommitted local changes (contributor workspace guard).
+    local dirty
+    dirty="$(git -C "${repo_path}" status --porcelain 2>/dev/null || true)"
+    if [[ -n "${dirty}" ]]; then
+        _warn "SKIP ${name}: has uncommitted changes — not pulling"
+        return 0
+    fi
+
+    # Ensure gitea remote exists (idempotent).
+    local gitea_url="${GITEA_URLS[${name}]}"
+    if ! git -C "${repo_path}" remote get-url gitea &>/dev/null; then
+        git -C "${repo_path}" remote add gitea "${gitea_url}"
+        _info "Added remote 'gitea' → ${gitea_url} for ${name}"
+    fi
+
+    # Fetch + ff-only pull from gitea develop.
+    if ! git -C "${repo_path}" fetch gitea develop 2>>"${LOG_FILE}"; then
+        _warn "FAIL ${name}: fetch gitea develop failed"
+        return 0
+    fi
+
+    local before_sha after_sha
+    before_sha="$(git -C "${repo_path}" rev-parse HEAD)"
+
+    if ! git -C "${repo_path}" pull --ff-only gitea develop 2>>"${LOG_FILE}"; then
+        _warn "FAIL ${name}: pull --ff-only failed (non-fast-forward?)"
+        return 0
+    fi
+
+    after_sha="$(git -C "${repo_path}" rev-parse HEAD)"
+    if [[ "${before_sha}" == "${after_sha}" ]]; then
+        _info "OK ${name}: already at $(echo "${after_sha}" | head -c 12) (no new commits)"
+    else
+        _info "OK ${name}: ${before_sha:0:12} → ${after_sha:0:12}"
+    fi
+}
+
+_info "--- post-merge-pull start (host=${HOST}) ---"
+for repo_name in "${!GITEA_URLS[@]}"; do
+    _pull_repo "${repo_name}"
+done
+_info "--- post-merge-pull done ---"

--- a/tests/test_install_cmds.py
+++ b/tests/test_install_cmds.py
@@ -1,0 +1,293 @@
+"""Tests for install_cmds: sac install boot + sac install-post-merge-cron.
+
+Coverage:
+- boot --dry-run: prints actions, touches nothing
+- boot idempotency: re-run on already-bootstrapped host is a no-op
+- install-post-merge-cron: add, idempotent add, dry-run, uninstall
+- install-post-merge-cron: --dry-run + --uninstall mutually exclusive
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from scitex_agent_container.cli_pkg.install_cmds import (
+    _cron_line,
+    boot,
+    install_post_merge_cron,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+FAKE_CRON_LINE = _cron_line()
+
+
+def _make_crontab_proc(stdout: str = "", returncode: int = 0) -> MagicMock:
+    m = MagicMock()
+    m.returncode = returncode
+    m.stdout = stdout
+    m.stderr = ""
+    return m
+
+
+# ---------------------------------------------------------------------------
+# sac install boot
+# ---------------------------------------------------------------------------
+
+
+class TestBoot:
+    def test_dry_run_touches_nothing(self, tmp_path, monkeypatch):
+        """--dry-run prints plan without creating any files."""
+        monkeypatch.setattr(
+            "scitex_agent_container.cli_pkg.install_cmds._find_python311",
+            lambda: "/usr/bin/python3.11",
+        )
+        monkeypatch.setattr(
+            "scitex_agent_container.cli_pkg.install_cmds._find_sac_src",
+            lambda: tmp_path,
+        )
+        # Patch subprocess so nothing is actually run.
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="tmux 3.3", stderr="")
+            runner = CliRunner()
+            result = runner.invoke(boot, ["--dry-run"])
+
+        assert result.exit_code == 0, result.output
+        assert "dry-run" in result.output
+        # subprocess.run should NOT be called for venv creation in dry-run.
+        venv_calls = [c for c in mock_run.call_args_list if "venv" in str(c)]
+        assert venv_calls == [], "venv should not be created in dry-run"
+
+    def test_venv_already_exists_is_reported(self, tmp_path, monkeypatch):
+        """If ~/.venv-3.11 already exists, boot reports it and skips creation."""
+        fake_venv = tmp_path / ".venv-3.11"
+        fake_venv.mkdir()
+        monkeypatch.setattr(
+            "scitex_agent_container.cli_pkg.install_cmds.Path",
+            lambda p: fake_venv if "venv-3.11" in str(p) else Path(p),
+        )
+        # Avoid actually running anything.
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="tmux 3.3a", stderr="")
+            with patch(
+                "scitex_agent_container.cli_pkg.install_cmds._find_python311",
+                return_value="/usr/bin/python3.11",
+            ):
+                with patch(
+                    "scitex_agent_container.cli_pkg.install_cmds._find_sac_src",
+                    return_value=tmp_path,
+                ):
+                    with patch(
+                        "scitex_agent_container.cli_pkg.install_cmds._deploy_cron_script"
+                    ):
+                        runner = CliRunner()
+                        result = runner.invoke(boot, ["--dry-run"])
+
+        assert result.exit_code == 0
+        # Even in dry-run the venv "already exists" path should be hit.
+        assert "already exists" in result.output or "dry-run" in result.output
+
+
+# ---------------------------------------------------------------------------
+# sac install-post-merge-cron
+# ---------------------------------------------------------------------------
+
+
+class TestInstallPostMergeCron:
+    def _invoke(self, args: list[str], crontab_out: str = "", crontab_rc: int = 0):
+        """Invoke with side_effect: crontab -l returns crontab_rc/out; crontab - succeeds."""
+        runner = CliRunner()
+
+        def _side_effect(cmd, **kwargs):
+            if list(cmd) == ["crontab", "-l"]:
+                return _make_crontab_proc(stdout=crontab_out, returncode=crontab_rc)
+            return _make_crontab_proc(stdout="", returncode=0)
+
+        with patch("subprocess.run", side_effect=_side_effect) as mock_run:
+            result = runner.invoke(install_post_merge_cron, args)
+        return result, mock_run
+
+    def test_add_when_empty_crontab(self):
+        """Adds the cron line when crontab is empty (rc=1 means no crontab)."""
+        result, mock_run = self._invoke([], crontab_out="", crontab_rc=1)
+        assert result.exit_code == 0, result.output
+        # Should call crontab -l then crontab -
+        calls = mock_run.call_args_list
+        assert any(["crontab", "-l"] == list(c.args[0]) for c in calls)
+        write_calls = [c for c in calls if "-" in c.args[0]]
+        assert write_calls, "crontab - should be called to write"
+
+    def test_add_when_existing_crontab(self):
+        """Adds the cron line to a crontab that already has other entries."""
+        existing = "0 * * * * /usr/bin/some-other-job\n"
+        result, mock_run = self._invoke([], crontab_out=existing, crontab_rc=0)
+        assert result.exit_code == 0
+        # The written content should include both old entry and our new line.
+        write_calls = [
+            c for c in mock_run.call_args_list if "crontab" in str(c) and "-" in str(c)
+        ]
+        if write_calls:
+            written = write_calls[-1].kwargs.get("input", "")
+            assert "post-merge-pull" in written
+
+    def test_idempotent_already_present(self):
+        """No-op when cron line is already present."""
+        existing = FAKE_CRON_LINE + "\n"
+        result, mock_run = self._invoke([], crontab_out=existing, crontab_rc=0)
+        assert result.exit_code == 0
+        assert "no-op" in result.output.lower() or "already" in result.output.lower()
+        # crontab - should NOT be called.
+        write_calls = [
+            c
+            for c in mock_run.call_args_list
+            if c.args and list(c.args[0]) == ["crontab", "-"]
+        ]
+        assert write_calls == [], "Should not write crontab when already present"
+
+    def test_dry_run_prints_line(self):
+        """--dry-run prints the cron line without touching crontab."""
+        result, mock_run = self._invoke(["--dry-run"], crontab_out="", crontab_rc=1)
+        assert result.exit_code == 0
+        assert "post-merge-pull" in result.output
+        write_calls = [
+            c
+            for c in mock_run.call_args_list
+            if c.args and list(c.args[0]) == ["crontab", "-"]
+        ]
+        assert write_calls == [], "crontab should not be written in dry-run"
+
+    def test_dry_run_notes_already_present(self):
+        """--dry-run still reports if line is already present."""
+        existing = FAKE_CRON_LINE + "\n"
+        result, mock_run = self._invoke(
+            ["--dry-run"], crontab_out=existing, crontab_rc=0
+        )
+        assert result.exit_code == 0
+        assert "no-op" in result.output.lower() or "already" in result.output.lower()
+
+    def test_uninstall_removes_line(self):
+        """--uninstall removes the cron line if present."""
+        existing = "0 2 * * * /something/else\n" + FAKE_CRON_LINE + "\n"
+        result, mock_run = self._invoke(
+            ["--uninstall"], crontab_out=existing, crontab_rc=0
+        )
+        assert result.exit_code == 0
+        assert "Removed" in result.output
+        write_calls = [
+            c
+            for c in mock_run.call_args_list
+            if c.args and list(c.args[0]) == ["crontab", "-"]
+        ]
+        assert write_calls, "crontab - should be called to remove"
+        written = write_calls[-1].kwargs.get("input", "")
+        assert "post-merge-pull" not in written
+
+    def test_uninstall_noop_when_not_present(self):
+        """--uninstall is a no-op if line not in crontab."""
+        existing = "0 2 * * * /something/else\n"
+        result, mock_run = self._invoke(
+            ["--uninstall"], crontab_out=existing, crontab_rc=0
+        )
+        assert result.exit_code == 0
+        assert "nothing to remove" in result.output.lower()
+        write_calls = [
+            c
+            for c in mock_run.call_args_list
+            if c.args and list(c.args[0]) == ["crontab", "-"]
+        ]
+        assert write_calls == [], "Should not write crontab"
+
+    def test_dry_run_and_uninstall_mutually_exclusive(self):
+        """--dry-run and --uninstall together exit with code 2."""
+        result, _ = self._invoke(["--dry-run", "--uninstall"])
+        assert result.exit_code == 2
+
+
+# ---------------------------------------------------------------------------
+# Integration: bash script smoke test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestPostMergePullScript:
+    """Spin up two fake git repos and verify the script pulls them."""
+
+    def _make_repo(self, path: Path, name: str) -> Path:
+        """Create a bare upstream and a clone with 'gitea' remote."""
+        upstream = path / f"{name}-upstream"
+        clone = path / "proj" / name
+        upstream.mkdir(parents=True)
+        clone.mkdir(parents=True)
+
+        subprocess.run(["git", "init", "--bare", str(upstream)], check=True, capture_output=True)
+        subprocess.run(["git", "init", str(clone)], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "-C", str(clone), "remote", "add", "gitea", str(upstream)],
+            check=True, capture_output=True,
+        )
+        # Initial commit.
+        (clone / "README.md").write_text("hello")
+        subprocess.run(["git", "-C", str(clone), "add", "."], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "-C", str(clone), "commit", "--allow-empty", "-m", "init"],
+            check=True, capture_output=True,
+            env={**__import__("os").environ, "GIT_AUTHOR_NAME": "test", "GIT_AUTHOR_EMAIL": "t@t", "GIT_COMMITTER_NAME": "test", "GIT_COMMITTER_EMAIL": "t@t"},
+        )
+        subprocess.run(
+            ["git", "-C", str(clone), "push", "gitea", "HEAD:develop"],
+            check=True, capture_output=True,
+        )
+        return clone
+
+    def test_script_pulls_clean_repo(self, tmp_path):
+        """Script pulls a clean repo and writes a log entry."""
+        script = Path(__file__).parent.parent / "src" / "scitex_agent_container" / "cron" / "post-merge-pull.sh"
+        assert script.exists(), f"Cron script not found: {script}"
+
+        clone = self._make_repo(tmp_path, "scitex-agent-container")
+        log_dir = tmp_path / ".scitex" / "orochi" / "shared" / "logs"
+        log_dir.mkdir(parents=True)
+
+        env = {
+            **__import__("os").environ,
+            "HOME": str(tmp_path),
+        }
+        result = subprocess.run(
+            ["bash", str(script)],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        # Script exits 0 and log file exists.
+        assert result.returncode == 0, result.stderr
+        log_files = list(log_dir.glob("post-merge-pull.*.log"))
+        assert log_files, "Log file should be created"
+        log_content = log_files[0].read_text()
+        assert "done" in log_content.lower() or "OK" in log_content
+
+    def test_script_skips_dirty_repo(self, tmp_path):
+        """Script skips repos with uncommitted changes and logs WARN."""
+        script = Path(__file__).parent.parent / "src" / "scitex_agent_container" / "cron" / "post-merge-pull.sh"
+        clone = self._make_repo(tmp_path, "scitex-agent-container")
+
+        # Make the clone dirty.
+        (clone / "dirty.txt").write_text("unsaved")
+        subprocess.run(["git", "-C", str(clone), "add", "dirty.txt"], capture_output=True)
+
+        log_dir = tmp_path / ".scitex" / "orochi" / "shared" / "logs"
+        log_dir.mkdir(parents=True)
+
+        env = {**__import__("os").environ, "HOME": str(tmp_path)}
+        result = subprocess.run(["bash", str(script)], capture_output=True, text=True, env=env)
+        assert result.returncode == 0
+        log_files = list(log_dir.glob("post-merge-pull.*.log"))
+        assert log_files
+        log_content = log_files[0].read_text()
+        assert "WARN" in log_content or "SKIP" in log_content


### PR DESCRIPTION
## Summary

- **D1 — cron script** (`src/scitex_agent_container/cron/post-merge-pull.sh`): pulls gitea:develop for 6 scitex-* repos under `~/proj/` with `--ff-only`; flock prevents concurrent runs; skips repos with uncommitted changes; logs INFO/WARN to `~/.scitex/orochi/shared/logs/post-merge-pull.<host>.log`
- **D2 — `sac install boot`**: first-time host bootstrap — venv, pip install -e, PATH injection, tmux check, shared dirs, cron script deploy; idempotent + `--dry-run`
- **D2 — `sac install-post-merge-cron`**: add/remove crontab entry (`* * * * *`); idempotent, `--dry-run`, `--uninstall`
- **D3/D5 — path convention** (dotfiles commit `21c15ee8`): all `~/forks/<name>/` references in 11 agent `src_CLAUDE.md` files replaced with `~/.scitex/orochi/runtime/workspaces/<agent>/<repo>/`
- **D4 — sac source**: no Python source had `~/forks/` paths; verified clean

## Cron line installed by `sac install-post-merge-cron`

```
* * * * * ~/.scitex/orochi/shared/cron/post-merge-pull.sh >> ~/.scitex/orochi/shared/logs/post-merge-pull.$(hostname -s).cron.log 2>&1
```

## `~/proj/<repo>` vs `~/forks/<repo>` distinction

The script explicitly skips any repo that has uncommitted changes (`git status --porcelain`). Since contributor `~/forks/` clones are always in-flight (dirty), they are naturally skipped. The script only targets the 6 canonical `~/proj/<repo>` paths.

## Test plan

- [x] 10 unit tests pass (`pytest tests/test_install_cmds.py -m "not integration"`)
- [x] Integration tests present (`@pytest.mark.integration`) — require real git + bash
- [x] `sac --help` shows `install` group and `install-post-merge-cron` commands
- [ ] Per-host rollout: `sac install boot && sac install-post-merge-cron` on each alive host after merge (delegated to proj-scitex-maintenance via alive heads)

## Commits

- `356e8dd` feat(cron): add post-merge-pull.sh fleet sync script
- `98f683d` feat(cli): add sac install boot + install-post-merge-cron subcommands  
- `db7e8dc` test(install): add unit + integration tests for install commands

Knowledge-file path migration: dotfiles commit `21c15ee8` (chore(agents): migrate clone paths from ~/forks/ to workspace convention)

🤖 Generated with [Claude Code](https://claude.com/claude-code)