### PR TITLE
chore(code-quality): annotate try/except blocks with stx-allow: fallback (closes #71)

### DIFF
--- a/src/scitex_agent_container/__init__.py
+++ b/src/scitex_agent_container/__init__.py
@@ -17,6 +17,7 @@ Modules:
 from importlib.metadata import PackageNotFoundError as _PackageNotFoundError
 from importlib.metadata import version as _version
 
+# stx-allow: fallback (reason: package may not be installed in editable/dev environments)
 try:
     __version__ = _version("scitex-agent-container")
 except _PackageNotFoundError:

--- a/src/scitex_agent_container/_skills/scitex-agent-container/scitex-smoke-test.py
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/scitex-smoke-test.py
@@ -46,6 +46,7 @@ PACKAGES = [
 
 
 def test_import(module):
+    # stx-allow: fallback (reason: optional dependency not always installed)
     try:
         importlib.import_module(module)
         return True, ""
@@ -59,6 +60,7 @@ def test_cli(entry, timeout=15):
     path = shutil.which(entry)
     if not path:
         return None, "cli not found"
+    # stx-allow: fallback (reason: subprocess may not be available or CLI may fail to run)
     try:
         r = subprocess.run([path, "--help"], capture_output=True,
                            text=True, timeout=timeout)

--- a/src/scitex_agent_container/account_store.py
+++ b/src/scitex_agent_container/account_store.py
@@ -47,6 +47,7 @@ def list_accounts(
     if not store.is_dir():
         return accounts
     for meta_file in sorted(store.glob("*.json")):
+        # stx-allow: fallback (reason: individual account metadata file may be corrupt or unreadable)
         try:
             with meta_file.open("r", encoding="utf-8") as fh:
                 data = json.load(fh)
@@ -145,6 +146,7 @@ def switch_account(
         }
 
     claude_dir = _home / ".claude"
+    # stx-allow: fallback (reason: credential file copy may fail on permission or I/O error)
     try:
         claude_dir.mkdir(parents=True, exist_ok=True)
         for src in cred_dir.iterdir():

--- a/src/scitex_agent_container/action_base.py
+++ b/src/scitex_agent_container/action_base.py
@@ -255,6 +255,7 @@ def run_action(
         return attempt
 
     # Pre-snapshot (if this fails the action is unrunnable).
+    # stx-allow: fallback (reason: pane snapshot may fail if session is not yet available)
     try:
         before = action.snapshot(ctx)
     except Exception as exc:  # pragma: no cover - defensive
@@ -276,6 +277,7 @@ def run_action(
         return _finish(ActionOutcome.PRECONDITION_FAIL, before, None)
 
     # Send.
+    # stx-allow: fallback (reason: send to multiplexer may fail if session closed unexpectedly)
     try:
         action.before_send(ctx)
         action.send(ctx)
@@ -289,6 +291,7 @@ def run_action(
     now_snap = before  # default if we never poll (timeout_s <= 0)
     while True:
         current = time_fn()
+        # stx-allow: fallback (reason: pane snapshot during polling may fail transiently)
         try:
             now_snap = action.snapshot(ctx)
         except Exception as exc:  # pragma: no cover - defensive
@@ -298,6 +301,7 @@ def run_action(
                 exc,
             )
             # Keep the previous snapshot so is_complete sees something.
+        # stx-allow: fallback (reason: completion check may raise on unexpected pane state)
         try:
             done = action.is_complete(before, now_snap)
         except Exception as exc:  # pragma: no cover - defensive

--- a/src/scitex_agent_container/action_store.py
+++ b/src/scitex_agent_container/action_store.py
@@ -80,6 +80,7 @@ def _safe_float(value: Any) -> float | None:
     """Coerce to float, returning None for None / unparseable."""
     if value is None:
         return None
+    # stx-allow: fallback (reason: value may be a non-numeric type from DB row)
     try:
         return float(value)
     except (TypeError, ValueError):
@@ -133,6 +134,7 @@ def _truncate_snapshot(
             **({"truncated": True} if len(snap) > max_chars else {}),
         }
     # Arbitrary serializable object — dump once then truncate.
+    # stx-allow: fallback (reason: arbitrary snapshot object may not be JSON-serializable)
     try:
         dumped = json.dumps(snap, default=str)
     except (TypeError, ValueError):
@@ -161,6 +163,7 @@ def append_attempt(
     * ``pane_before`` / ``pane_after`` — snapshot dicts / strings.
     * ``extras`` — action-specific fields (dict).
     """
+    # stx-allow: fallback (reason: record may have missing or wrong-type required keys)
     try:
         agent = str(record["agent"])
         action = str(record["action"])
@@ -173,8 +176,10 @@ def append_attempt(
     pane_before = _truncate_snapshot(record.get("pane_before"))
     pane_after = _truncate_snapshot(record.get("pane_after"))
     extras = record.get("extras") or {}
+    # stx-allow: fallback (reason: SQLite insert may fail on disk full or corrupt database)
     try:
         conn = _get_conn(_db_path(root))
+        # stx-allow: fallback (reason: SQLite execute may fail; connection must be closed in finally)
         try:
             conn.execute(
                 "INSERT INTO attempts "
@@ -203,6 +208,7 @@ def _row_to_dict(row: sqlite3.Row) -> dict[str, Any]:
         raw = out.get(key)
         if raw is None:
             continue
+        # stx-allow: fallback (reason: JSON column may be corrupt; rest of row remains usable)
         try:
             out[key] = json.loads(raw)
         except (TypeError, ValueError):
@@ -275,8 +281,10 @@ def query(
         + " ORDER BY ts DESC, id DESC LIMIT ? OFFSET ?"
     )
     params.extend([int(limit), int(offset)])
+    # stx-allow: fallback (reason: SQLite query may fail on missing or corrupt database)
     try:
         conn = _get_conn(_db_path(root))
+        # stx-allow: fallback (reason: SQLite execute may fail; connection must be closed in finally)
         try:
             rows = conn.execute(sql, tuple(params)).fetchall()
         finally:
@@ -319,8 +327,10 @@ def stats(
         "ORDER BY action ASC, count DESC"
     )
     sql_samples = "SELECT action, outcome, elapsed_s FROM attempts" + where
+    # stx-allow: fallback (reason: SQLite stats query may fail on missing or corrupt database)
     try:
         conn = _get_conn(_db_path(root))
+        # stx-allow: fallback (reason: SQLite execute may fail; connection must be closed in finally)
         try:
             groups = conn.execute(sql_counts, tuple(params)).fetchall()
             samples = conn.execute(sql_samples, tuple(params)).fetchall()
@@ -392,6 +402,7 @@ def summarize(
     for r in rows:
         key = f"{r['action']}:{r['outcome']}"
         counts[key] = counts.get(key, 0) + 1
+        # stx-allow: fallback (reason: elapsed_s may be NULL or non-numeric in corrupt rows)
         try:
             samples_by_action.setdefault(r["action"], []).append(float(r["elapsed_s"]))
         except (TypeError, ValueError):
@@ -422,8 +433,10 @@ def purge_old(
     rows deleted. Safe to call periodically from a cron / daemon."""
     d = int(days) if days is not None else DEFAULT_RETENTION_DAYS
     cutoff = (datetime.now(timezone.utc) - timedelta(days=d)).isoformat()
+    # stx-allow: fallback (reason: SQLite purge may fail on disk full or corrupt database)
     try:
         conn = _get_conn(_db_path(root))
+        # stx-allow: fallback (reason: SQLite execute may fail; connection must be closed in finally)
         try:
             cur = conn.execute("DELETE FROM attempts WHERE ts < ?", (cutoff,))
             deleted = cur.rowcount
@@ -438,8 +451,10 @@ def purge_old(
 
 def _all_rows(root: Path | None = None) -> Iterable[dict[str, Any]]:
     """Iterator over every row — used by tests / export tooling."""
+    # stx-allow: fallback (reason: SQLite read may fail on missing or corrupt database)
     try:
         conn = _get_conn(_db_path(root))
+        # stx-allow: fallback (reason: SQLite execute may fail; connection must be closed in finally)
         try:
             rows = conn.execute(
                 "SELECT id, ts, agent, action, outcome, elapsed_s, "

--- a/src/scitex_agent_container/actions/compact.py
+++ b/src/scitex_agent_container/actions/compact.py
@@ -125,6 +125,7 @@ def _coerce_float(value: Any) -> Optional[float]:
     depending on the Claude Code build, so be forgiving."""
     if value is None:
         return None
+    # stx-allow: fallback (reason: statusline parser may emit non-numeric or None values)
     try:
         return float(value)
     except (TypeError, ValueError):

--- a/src/scitex_agent_container/agent_meta.py
+++ b/src/scitex_agent_container/agent_meta.py
@@ -26,6 +26,7 @@ from .claude_usage import fetch_usage
 
 def detect_multiplexer(session: str) -> str:
     """Return 'tmux', 'screen', or '' if neither reports the session."""
+    # stx-allow: fallback (reason: tmux may not be installed on this host)
     try:
         if (
             subprocess.run(
@@ -37,6 +38,7 @@ def detect_multiplexer(session: str) -> str:
             return "tmux"
     except FileNotFoundError:
         pass
+    # stx-allow: fallback (reason: screen may not be installed on this host)
     try:
         r = subprocess.run(
             ["screen", "-ls", session],
@@ -62,6 +64,7 @@ def _encode_claude_project(workdir: str) -> str:
 
 def _latest_jsonls(workdir: str) -> list[Path]:
     # Claude Code encodes the *resolved* cwd, so follow symlinks first.
+    # stx-allow: fallback (reason: workdir path may be invalid or inaccessible)
     try:
         resolved = str(Path(workdir).expanduser().resolve())
     except Exception:
@@ -69,6 +72,7 @@ def _latest_jsonls(workdir: str) -> list[Path]:
     proj_dir = Path.home() / ".claude" / "projects" / _encode_claude_project(resolved)
     if not proj_dir.is_dir():
         return []
+    # stx-allow: fallback (reason: filesystem glob or stat may fail on permission issues)
     try:
         return sorted(
             proj_dir.glob("*.jsonl"),
@@ -82,6 +86,7 @@ def _latest_jsonls(workdir: str) -> list[Path]:
 def _parse_skills(workdir: str) -> list[str]:
     """Parse ```skills fenced code block from workspace CLAUDE.md."""
     skills: list[str] = []
+    # stx-allow: fallback (reason: CLAUDE.md may be missing or unreadable)
     try:
         cmd = Path(workdir) / "CLAUDE.md"
         if cmd.is_file():
@@ -99,6 +104,7 @@ def _parse_skills(workdir: str) -> list[str]:
 def _subagent_count_from_pane(session: str, multiplexer: str) -> int:
     if multiplexer != "tmux":
         return 0
+    # stx-allow: fallback (reason: subprocess may not be available or tmux session may not exist)
     try:
         pane = subprocess.run(
             ["tmux", "capture-pane", "-t", session, "-p"],
@@ -115,6 +121,7 @@ def _capture_pane(session: str, multiplexer: str, max_chars: int = 10000) -> str
     """Return the current tmux pane contents, truncated. Empty on error."""
     if multiplexer != "tmux":
         return ""
+    # stx-allow: fallback (reason: subprocess may not be available or tmux session may not exist)
     try:
         out = (
             subprocess.run(
@@ -237,6 +244,7 @@ def _config_candidates(workdir: str, filename: str) -> list[Path]:
         cands += [p / filename, p / ".claude" / filename]
         if p.parent.name == "workspaces":
             cands.append(p.parent / f"mamba-{p.name}" / filename)
+        # stx-allow: fallback (reason: filesystem traversal may fail on permission errors)
         try:
             git_root = p
             while git_root != git_root.parent and not (git_root / ".git").exists():
@@ -260,6 +268,7 @@ def _config_candidates(workdir: str, filename: str) -> list[Path]:
 
 def _read_claude_md(workdir: str, max_chars: int = 20000) -> str:
     for p in _config_candidates(workdir, "CLAUDE.md"):
+        # stx-allow: fallback (reason: CLAUDE.md candidate may be missing or unreadable)
         try:
             if not p.is_file():
                 continue
@@ -287,12 +296,14 @@ def _redact_mcp_tree(obj):
 
 def _read_mcp_json(workdir: str, max_chars: int = 10000) -> str:
     for p in _config_candidates(workdir, ".mcp.json"):
+        # stx-allow: fallback (reason: .mcp.json candidate may be missing or unreadable)
         try:
             if not p.is_file():
                 continue
             raw = p.read_text(errors="replace")
         except Exception:
             continue
+        # stx-allow: fallback (reason: .mcp.json may contain invalid JSON)
         try:
             doc = json.loads(raw)
             pretty = json.dumps(_redact_mcp_tree(doc), indent=2)
@@ -307,6 +318,7 @@ def _pids_from_session(session: str, multiplexer: str) -> tuple[int, int]:
     ppid = 0
     if multiplexer != "tmux":
         return pid, ppid
+    # stx-allow: fallback (reason: subprocess may not be available or tmux session may not exist)
     try:
         out = (
             subprocess.run(
@@ -366,6 +378,7 @@ def collect_rich(
 
     jsonls = _latest_jsonls(workdir)
     if jsonls:
+        # stx-allow: fallback (reason: stat may fail if file was removed between glob and stat())
         try:
             earliest = min(jsonls, key=lambda p: p.stat().st_mtime)
             started_at = datetime.fromtimestamp(
@@ -374,12 +387,14 @@ def collect_rich(
         except Exception:
             pass
 
+        # stx-allow: fallback (reason: jsonl file may be deleted or unreadable between glob and read)
         try:
             lines = jsonls[0].read_text().splitlines()[-50:]
         except Exception:
             lines = []
 
         for line in reversed(lines):
+            # stx-allow: fallback (reason: jsonl line may be incomplete or malformed)
             try:
                 obj = json.loads(line)
             except Exception:
@@ -404,6 +419,7 @@ def collect_rich(
         # dashboard can show "Bash: docker compose build" instead of just
         # "Bash". Per ywatanabe complaint msg 5481.
         for line in reversed(lines):
+            # stx-allow: fallback (reason: jsonl line may be incomplete or malformed)
             try:
                 obj = json.loads(line)
             except Exception:
@@ -447,6 +463,7 @@ def collect_rich(
         # "what was this agent last asked to do" snippet which is more
         # meaningful than the tool name alone.
         for line in reversed(lines):
+            # stx-allow: fallback (reason: jsonl line may be incomplete or malformed)
             try:
                 obj = json.loads(line)
             except Exception:
@@ -500,6 +517,7 @@ def collect_rich(
     # Populated by `scitex-agent-container hook-event` entries wired into
     # the agent's .claude/settings.local.json. Non-agentic: pure ring-
     # buffer read.
+    # stx-allow: fallback (reason: event_log may be unavailable or missing log file)
     try:
         from .event_log import summarize as _summarize_events
 
@@ -513,6 +531,7 @@ def collect_rich(
             "counts": {},
         }
     # Use canonical fleet name (e.g. "nas" instead of "DXP480TPLUS-994")
+    # stx-allow: fallback (reason: hostname resolution may fail on unconfigured hosts)
     try:
         from .config._host import resolve_hostname
 
@@ -527,6 +546,7 @@ def collect_rich(
     quota_7d_reset_at: str | None = None
     quota_from_cache: bool = False
     quota_error: str | None = None
+    # stx-allow: fallback (reason: usage API may be unavailable or credentials missing)
     try:
         usage = fetch_usage()
         quota_5h_used_pct = usage.get("used_pct_5h")
@@ -540,6 +560,7 @@ def collect_rich(
 
     # ---- Account / credential identity ------------------------------------
     account_email: str | None = None
+    # stx-allow: fallback (reason: credentials file may be missing or unreadable)
     try:
         from .credentials import read_credentials_metadata
 
@@ -549,6 +570,7 @@ def collect_rich(
         pass
 
     # ---- Machine resource metrics (psutil, optional) -----------------------
+    # stx-allow: fallback (reason: optional dependency not always installed)
     try:
         import psutil as _psutil
 
@@ -661,6 +683,7 @@ def _collect_action_summary_fields(agent_name: str) -> dict[str, Any]:
     heartbeat. All keys are prefixed ``action_`` so consumers know
     which subsystem they came from.
     """
+    # stx-allow: fallback (reason: action database may be corrupt or missing)
     try:
         from . import action_store
 

--- a/src/scitex_agent_container/auto_response.py
+++ b/src/scitex_agent_container/auto_response.py
@@ -196,6 +196,7 @@ class AutoResponseScheduler:
         # agent, and compacting first keeps the subsequent probe
         # cheap.
         ctx_pct = None
+        # stx-allow: fallback (reason: context percentage probe may fail if sensor is unavailable)
         try:
             ctx_pct = ctx.context_pct_fn()
         except Exception:
@@ -241,6 +242,7 @@ class AutoResponseScheduler:
         """
         start = self._time()
         while True:
+            # stx-allow: fallback (reason: tick may raise unexpectedly; run loop must continue)
             try:
                 self.tick()
             except Exception as exc:  # pragma: no cover - defensive

--- a/src/scitex_agent_container/claude_usage.py
+++ b/src/scitex_agent_container/claude_usage.py
@@ -87,6 +87,7 @@ def _iso_now() -> str:
 
 def _load_json(path: Path) -> dict[str, Any] | None:
     """Load JSON file; return None on any error."""
+    # stx-allow: fallback (reason: filesystem read may fail on missing or corrupt JSON file)
     try:
         with path.open("r", encoding="utf-8") as fh:
             data = json.load(fh)
@@ -169,6 +170,7 @@ def _refresh_access_token(
         headers={"Content-Type": "application/json"},
         method="POST",
     )
+    # stx-allow: fallback (reason: token refresh HTTP request may fail due to network or auth error)
     try:
         with urllib.request.urlopen(req, timeout=15) as resp:
             raw = resp.read()
@@ -183,9 +185,11 @@ def _refresh_access_token(
 
     # Atomically update the credentials file.
     creds_path = _credentials_path(home)
+    # stx-allow: fallback (reason: credentials file update may fail; token is still usable in memory)
     try:
         with open(creds_path, "r+", encoding="utf-8") as fh:
             fcntl.flock(fh, fcntl.LOCK_EX)
+            # stx-allow: fallback (reason: credentials JSON may be corrupt or file write may fail)
             try:
                 data = json.load(fh)
                 if not isinstance(data, dict):
@@ -223,6 +227,7 @@ def _read_cache(home: Path) -> dict[str, Any] | None:
     fetched_at_str = data.get("fetched_at")
     if not isinstance(fetched_at_str, str):
         return None
+    # stx-allow: fallback (reason: cached timestamp may be malformed or from an older format)
     try:
         fetched_at = datetime.fromisoformat(fetched_at_str)
         if fetched_at.tzinfo is None:
@@ -239,6 +244,7 @@ def _read_cache(home: Path) -> dict[str, Any] | None:
 def _write_cache(home: Path, result: dict[str, Any]) -> None:
     """Write result to cache file (best-effort, never raises)."""
     path = _cache_path(home)
+    # stx-allow: fallback (reason: cache write may fail on disk full or permission error)
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
         tmp = Path(str(path) + ".tmp")
@@ -265,6 +271,7 @@ def _fetch_from_api(access_token: str) -> list[dict[str, Any]] | None:
         headers={"Authorization": f"Bearer {access_token}"},
         method="GET",
     )
+    # stx-allow: fallback (reason: usage API request may fail due to network or auth error)
     try:
         with urllib.request.urlopen(req, timeout=15) as resp:
             raw = resp.read()
@@ -275,6 +282,7 @@ def _fetch_from_api(access_token: str) -> list[dict[str, Any]] | None:
     except Exception:
         return None
 
+    # stx-allow: fallback (reason: response body may not be valid JSON)
     try:
         payload = json.loads(raw)
     except Exception:
@@ -398,6 +406,7 @@ def fetch_usage(home: Path | None = None) -> dict[str, Any]:
 
     # --- API call -----------------------------------------------------------
     windows = None
+    # stx-allow: fallback (reason: API call may fail with HTTP error or network issue)
     try:
         windows = _fetch_from_api(access_token)
     except urllib.error.HTTPError as exc:
@@ -406,6 +415,7 @@ def fetch_usage(home: Path | None = None) -> dict[str, Any]:
             new_token = _refresh_access_token(_home, refresh_token, client_id)
             if new_token:
                 access_token = new_token
+                # stx-allow: fallback (reason: retry after token refresh may also fail)
                 try:
                     windows = _fetch_from_api(access_token)
                 except Exception:
@@ -426,6 +436,7 @@ def fetch_usage(home: Path | None = None) -> dict[str, Any]:
     result["error"] = None
 
     # Security guard — must run before cache write
+    # stx-allow: fallback (reason: security check raises on token leak; return error instead of crashing)
     try:
         _check_no_token_leak(result)
     except RuntimeError as exc:

--- a/src/scitex_agent_container/cli_pkg/_helpers.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers.py
@@ -58,6 +58,7 @@ def _probe_remote(cfg) -> bool | None:
     regression suite needs to simulate hung + fast probes without
     real SSH).
     """
+    # stx-allow: fallback (reason: remote liveness probe may fail on network or SSH error)
     try:
         from ..runtimes.claude_code import ClaudeCodeRuntime
         return ClaudeCodeRuntime().is_running(cfg)
@@ -102,11 +103,13 @@ def get_agent_list_data(
         """Detect which multiplexer hosts a session. Tmux preferred."""
         if not session_name or session_name == "?":
             return None
+        # stx-allow: fallback (reason: tmux may not be installed or session may not exist)
         try:
             if TmuxManager.exists(session_name):
                 return "tmux"
         except Exception:
             pass
+        # stx-allow: fallback (reason: screen may not be installed or session may not exist)
         try:
             if ScreenManager.exists(session_name):
                 return "screen"
@@ -128,6 +131,7 @@ def get_agent_list_data(
         config_path = entry.get("config")
         cfg = None
         if config_path:
+            # stx-allow: fallback (reason: config file may be invalid or missing for stale entries)
             try:
                 cfg = load_config(config_path)
                 labels = cfg.labels
@@ -169,6 +173,7 @@ def get_agent_list_data(
     probe_results: dict[int, bool | None] = {}
     if remote_probes:
         pool = ThreadPoolExecutor(max_workers=max_parallel_probes)
+        # stx-allow: fallback (reason: remote probe futures may timeout or raise; pool must be shut down)
         try:
             future_to_idx = {
                 pool.submit(_probe_remote, cfg): idx
@@ -176,6 +181,7 @@ def get_agent_list_data(
             }
             for future in list(future_to_idx):
                 idx = future_to_idx[future]
+                # stx-allow: fallback (reason: individual probe future may timeout or raise)
                 try:
                     probe_results[idx] = future.result(
                         timeout=remote_probe_timeout_s
@@ -199,6 +205,7 @@ def get_agent_list_data(
         cfg = prep["cfg"]
 
         liveness_unknown = False
+        # stx-allow: fallback (reason: liveness check may fail for stopped or unreachable agents)
         try:
             if cfg and cfg.remote.is_remote:
                 probe = probe_results.get(prep["idx"])

--- a/src/scitex_agent_container/cli_pkg/account_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/account_cmds.py
@@ -52,6 +52,7 @@ def account_save(name: str, email: str | None) -> None:
         meta["email_address"] = email
     else:
         # Try to read from current credentials
+        # stx-allow: fallback (reason: credentials file may be missing or unreadable)
         try:
             from ..credentials import read_credentials_metadata
 

--- a/src/scitex_agent_container/cli_pkg/action_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/action_cmds.py
@@ -104,6 +104,7 @@ def run_cmd(
         click.echo(f"Agent '{agent}' not found in registry.", err=True)
         sys.exit(2)
 
+    # stx-allow: fallback (reason: config load may fail for stale or invalid config files)
     try:
         from ..config import load_config  # local import: keeps the
 
@@ -128,6 +129,7 @@ def run_cmd(
 
     # --- build the ActionContext ----------------------------------------
     def _capture() -> str:
+        # stx-allow: fallback (reason: pane capture may fail if multiplexer is unavailable)
         try:
             return mux.capture_content(session) or ""
         except Exception:
@@ -139,6 +141,7 @@ def run_cmd(
         Failures degrade to ``None`` — the action engine treats that as
         "cannot confirm" and will time out instead of crashing.
         """
+        # stx-allow: fallback (reason: agent_meta collection may fail; degrade to None gracefully)
         try:
             from .. import agent_meta
 

--- a/src/scitex_agent_container/cli_pkg/build_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/build_cmds.py
@@ -22,6 +22,7 @@ def check(config_path: str) -> None:
     available before starting the agent. Useful for debugging deployment
     failures.
     """
+    # stx-allow: fallback (reason: config load may fail with user-visible error for invalid YAML)
     try:
         config = load_config(config_path)
     except Exception as exc:
@@ -63,6 +64,7 @@ def check(config_path: str) -> None:
             console.print("    [red]GNU screen not found[/red]")
             console.print("    [red]  Fix: sudo apt install screen[/red]")
 
+        # stx-allow: fallback (reason: python3 binary may not be on PATH in some environments)
         try:
             proc = subprocess.run(
                 ["python3", "--version"],
@@ -83,6 +85,7 @@ def check(config_path: str) -> None:
 
         sac_bin = shutil.which("scitex-agent-container")
         if sac_bin:
+            # stx-allow: fallback (reason: version check subprocess may fail)
             try:
                 proc = subprocess.run(
                     ["scitex-agent-container", "--version"],
@@ -101,6 +104,7 @@ def check(config_path: str) -> None:
             console.print(f"  {'scitex-agent-container:':30s} [red]FAIL[/red]")
             console.print("    [red]  Fix: pip install scitex-agent-container[/red]")
 
+        # stx-allow: fallback (reason: df command may not be available on all systems)
         try:
             proc = subprocess.run(
                 ["df", "-h", "/"], capture_output=True, text=True, timeout=5

--- a/src/scitex_agent_container/cli_pkg/hook_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/hook_cmds.py
@@ -43,6 +43,7 @@ def _resolve_agent(flag: str) -> str:
         val = os.environ.get(key)
         if val:
             return val
+    # stx-allow: fallback (reason: cwd may be unavailable in certain process contexts)
     try:
         return Path.cwd().name or "anonymous-agent"
     except Exception:
@@ -65,8 +66,10 @@ def _resolve_agent(flag: str) -> str:
 )
 def hook_event(kind: str, agent_flag: str) -> None:
     """Append a Claude Code hook event to the per-agent ring-buffer."""
+    # stx-allow: fallback (reason: hook events must never break the agent session on any error)
     try:
         raw = sys.stdin.read() or "{}"
+        # stx-allow: fallback (reason: stdin may not be valid JSON; preserve raw content)
         try:
             payload = json.loads(raw)
         except Exception:

--- a/src/scitex_agent_container/cli_pkg/info_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/info_cmds.py
@@ -60,6 +60,7 @@ def find(
         elif sub.suffix == ".yaml":
             candidates.append(sub)
     for yaml_path in candidates:
+        # stx-allow: fallback (reason: individual config file may be invalid; skip and continue)
         try:
             cfg = load_config(yaml_path)
         except Exception:
@@ -112,6 +113,7 @@ def find(
 )
 def logs(name: str, lines: int) -> None:
     """Show recent agent output."""
+    # stx-allow: fallback (reason: log read may fail if agent session or log file is missing)
     try:
         output = agent_logs(name, lines)
         if output:
@@ -200,6 +202,7 @@ def list_python_apis(
                 if obj is None:
                     break
             if obj and callable(obj):
+                # stx-allow: fallback (reason: inspect.signature may fail on built-in or C functions)
                 try:
                     sig = str(inspect.signature(obj))
                 except (ValueError, TypeError):

--- a/src/scitex_agent_container/cli_pkg/lifecycle_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle_cmds.py
@@ -143,12 +143,14 @@ def start(
                 "~/.scitex/agent-container/agents/ or $SCITEX_AGENT_CONTAINER_YAML_DIRS[/dim]"
             )
             return
+        # stx-allow: fallback (reason: hostname resolution may fail on unconfigured hosts)
         try:
             current_host = resolve_hostname()
         except RuntimeError:
             current_host = ""
         console.print(f"[blue]Starting {len(yamls)} agents...[/blue]")
         for yaml_path in yamls:
+            # stx-allow: fallback (reason: individual agent config may be invalid; skip and continue)
             try:
                 config = load_config(yaml_path)
                 skip = _singleton_skip_reason(config, current_host)
@@ -179,9 +181,11 @@ def start(
         )
         sys.exit(2)
 
+    # stx-allow: fallback (reason: config load or agent start may fail with user-visible error)
     try:
         config_path = resolve_config(config_path)
         config = load_config(config_path)
+        # stx-allow: fallback (reason: hostname resolution may fail on unconfigured hosts)
         try:
             current_host = resolve_hostname()
         except RuntimeError:
@@ -265,6 +269,7 @@ def stop(name: str | None, stop_all: bool, force: bool) -> None:
             sys.exit(1)
         return
 
+    # stx-allow: fallback (reason: agent stop may fail with user-visible error)
     try:
         # Accept either agent name or YAML path
         if "/" in name or name.endswith((".yaml", ".yml")):  # type: ignore[union-attr]
@@ -282,6 +287,7 @@ def stop(name: str | None, stop_all: bool, force: bool) -> None:
 @click.argument("name")
 def restart(name: str) -> None:
     """Restart an agent."""
+    # stx-allow: fallback (reason: agent restart may fail with user-visible error)
     try:
         if "/" in name or name.endswith((".yaml", ".yml")):
             config_path = resolve_config(name)

--- a/src/scitex_agent_container/cli_pkg/snapshot_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/snapshot_cmds.py
@@ -46,6 +46,7 @@ def snapshot(
     terse: bool,
 ) -> None:
     """Take a self-snapshot for AGENT and print it as JSON."""
+    # stx-allow: fallback (reason: snapshot gathering may fail on probe or I/O error)
     try:
         snap = take_snapshot(agent, session=session, with_diff=with_diff)
     except Exception as exc:  # pragma: no cover — defensive

--- a/src/scitex_agent_container/cli_pkg/status_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/status_cmds.py
@@ -102,6 +102,7 @@ def status(
         sys.exit(2)
 
     if name:
+        # stx-allow: fallback (reason: agent status collection may fail with user-visible error)
         try:
             info = agent_status(name)
         except Exception as exc:
@@ -128,6 +129,7 @@ def status(
             table.add_row(key, str(value), style=style)
         console.print(table)
     else:
+        # stx-allow: fallback (reason: credentials file may be missing or unreadable)
         try:
             claude_account = read_credentials_metadata()
         except (OSError, json_mod.JSONDecodeError):
@@ -210,6 +212,7 @@ def health(ctx: click.Context, name: str, as_json: bool) -> None:
             console.print(f"[red]Agent '{name}' not found in registry[/red]")
         sys.exit(1)
 
+    # stx-allow: fallback (reason: config load may fail for stale or removed config files)
     try:
         config = load_config(entry["config"])
     except Exception as exc:
@@ -280,6 +283,7 @@ def check_agent(ctx: click.Context, name: str, as_json: bool) -> None:
             console.print(f"[red]Agent '{name}' not found in registry[/red]")
         sys.exit(1)
 
+    # stx-allow: fallback (reason: config load may fail for stale or removed config files)
     try:
         config = load_config(entry["config"])
     except Exception as exc:

--- a/src/scitex_agent_container/config/_host.py
+++ b/src/scitex_agent_container/config/_host.py
@@ -39,10 +39,12 @@ def _load_hostname_aliases() -> dict[str, str]:
     """
     if not _CONFIG_PATH.exists():
         return {}
+    # stx-allow: fallback (reason: optional dependency not always installed)
     try:
         import yaml  # PyYAML ships with the container; same import sac uses.
     except ImportError:
         return {}
+    # stx-allow: fallback (reason: config file may contain invalid YAML or be unreadable)
     try:
         data = yaml.safe_load(_CONFIG_PATH.read_text()) or {}
     except Exception:

--- a/src/scitex_agent_container/config/_parsers.py
+++ b/src/scitex_agent_container/config/_parsers.py
@@ -91,6 +91,7 @@ def parse_claude(spec: dict) -> ClaudeSpec:
         session = raw.get("session", "continue-or-new")
     continue_max_age = raw.get("continue_max_age_minutes")
     if continue_max_age is not None:
+        # stx-allow: fallback (reason: continue_max_age_minutes value may be wrong type in YAML)
         try:
             continue_max_age = int(continue_max_age)
         except (TypeError, ValueError):
@@ -202,6 +203,7 @@ def parse_skills(spec: dict) -> SkillsSpec:
 
 def parse_context_management(spec: dict) -> ContextManagementConfig:
     raw = spec.get("context_management", {}) or {}
+    # stx-allow: fallback (reason: config value may be wrong type or missing)
     try:
         trigger = float(raw.get("trigger_at_percent", 70.0))
     except (TypeError, ValueError):
@@ -209,10 +211,12 @@ def parse_context_management(spec: dict) -> ContextManagementConfig:
     strategy = str(raw.get("strategy", "noop") or "noop")
     if strategy not in ("compact", "restart", "noop"):
         strategy = "noop"
+    # stx-allow: fallback (reason: config value may be wrong type or missing)
     try:
         warn_n = int(raw.get("warn_before_n_checks", 0))
     except (TypeError, ValueError):
         warn_n = 0
+    # stx-allow: fallback (reason: config value may be wrong type or missing)
     try:
         interval = int(raw.get("check_interval_seconds", 300))
     except (TypeError, ValueError):
@@ -261,6 +265,7 @@ def parse_listen(spec: dict) -> list[ListenPort]:
         if not isinstance(item, dict):
             continue
         proto = str(item.get("proto", "tcp") or "tcp")
+        # stx-allow: fallback (reason: listen port value may be wrong type or missing)
         try:
             port = int(item.get("port", 0) or 0)
         except (TypeError, ValueError):
@@ -307,6 +312,7 @@ def _parse_command_list(raw: Any) -> list[StartupCommand]:
             if item:
                 out.append(StartupCommand(delay=0, command=item))
         elif isinstance(item, dict) and item.get("command"):
+            # stx-allow: fallback (reason: delay value may be wrong type in YAML)
             try:
                 delay = int(item.get("delay", 0))
             except (TypeError, ValueError):
@@ -336,14 +342,17 @@ def parse_startup(spec: dict) -> StartupSpec:
         elif isinstance(item, dict) and item.get("regex"):
             patterns.append(ReadyPattern(regex=str(item["regex"])))
 
+    # stx-allow: fallback (reason: startup spec value may be wrong type or missing)
     try:
         idle_ticks = max(1, int(raw.get("ready_idle_ticks", 3)))
     except (TypeError, ValueError):
         idle_ticks = 3
+    # stx-allow: fallback (reason: startup spec value may be wrong type or missing)
     try:
         poll_interval = max(0.05, float(raw.get("ready_poll_interval_seconds", 0.5)))
     except (TypeError, ValueError):
         poll_interval = 0.5
+    # stx-allow: fallback (reason: startup spec value may be wrong type or missing)
     try:
         timeout = max(1.0, float(raw.get("ready_timeout_seconds", 60.0)))
     except (TypeError, ValueError):

--- a/src/scitex_agent_container/config/_validation.py
+++ b/src/scitex_agent_container/config/_validation.py
@@ -142,6 +142,7 @@ def validate_raw(raw: dict, path: str) -> list[str]:
 def validate_config(path: str | Path) -> list[str]:
     """Validate a config file and return list of errors (empty = valid)."""
     path = Path(path).resolve()
+    # stx-allow: fallback (reason: config file may be missing, unreadable, or contain invalid YAML)
     try:
         with open(path) as f:
             raw = yaml.safe_load(f)

--- a/src/scitex_agent_container/context_manager.py
+++ b/src/scitex_agent_container/context_manager.py
@@ -38,6 +38,7 @@ def parse_context_percent(pane_text: str) -> float | None:
         return None
     for line in reversed(pane_text.splitlines()):
         for match in _PERCENT_RE.finditer(line):
+            # stx-allow: fallback (reason: regex match group may not be convertible to float)
             try:
                 value = float(match.group(1))
             except ValueError:
@@ -69,6 +70,7 @@ def fetch_agent_meta(
     if not explicit:
         return None
     resolved = str(Path(explicit).expanduser())
+    # stx-allow: fallback (reason: subprocess may not be available or script may fail)
     try:
         r = subprocess.run(
             [resolved, agent_name],
@@ -84,6 +86,7 @@ def fetch_agent_meta(
         OSError,
     ):
         return None
+    # stx-allow: fallback (reason: stdout may be empty or contain non-JSON content)
     try:
         data = (
             json.loads(r.stdout.strip().splitlines()[-1]) if r.stdout.strip() else None
@@ -197,6 +200,7 @@ class ContextManager:
                 threshold,
                 self.config.strategy,
             )
+            # stx-allow: fallback (reason: dispatcher may raise; must not crash the sensor loop)
             try:
                 self.dispatcher(self.config.strategy, self.agent_config)
             except Exception:  # pragma: no cover — defensive
@@ -235,10 +239,12 @@ def run_forever(cm: ContextManager) -> None:
     """
     interval = max(1, int(cm.config.check_interval_seconds))
     while not cm.stopped:
+        # stx-allow: fallback (reason: context manager tick may raise unexpectedly; loop must continue)
         try:
             cm.tick()
         except Exception:  # pragma: no cover — defensive
             logger.exception("context_manager[%s]: tick failed", cm.agent_name)
+        # stx-allow: fallback (reason: snapshot piggyback tick may fail; must not block context loop)
         try:
             from .snapshot import snapshot_tick
 
@@ -265,6 +271,7 @@ def _fire_hook(
     context: dict[str, Any] | None = None,
 ) -> None:
     """Non-blocking fire of an ``on_*`` hook. Swallows all errors."""
+    # stx-allow: fallback (reason: hook dispatch may raise unexpectedly; must not block context manager)
     try:
         from .hooks import run_hook
 
@@ -314,6 +321,7 @@ def default_dispatcher(strategy: str, agent_config: AgentConfig | None) -> None:
                 "strategy": "restart",
             },
         )
+        # stx-allow: fallback (reason: agent restart may fail due to runtime or registry error)
         try:
             agent_restart(agent_config.name)
         except Exception:
@@ -349,6 +357,7 @@ def start_sensor(agent_config: AgentConfig) -> ContextManager | None:
     )
     _SENSORS[agent_config.name] = cm
     thread.start()
+    # stx-allow: fallback (reason: sidecar registration is optional; failure must not block agent start)
     try:
         from .snapshot import register_sidecar
 

--- a/src/scitex_agent_container/credentials.py
+++ b/src/scitex_agent_container/credentials.py
@@ -85,6 +85,7 @@ def _all_safe_keys() -> list[str]:
 
 def _load_json(path: Path) -> dict[str, Any] | None:
     """Load a JSON file; return ``None`` if missing or unparseable."""
+    # stx-allow: fallback (reason: filesystem read may fail on missing or corrupt file)
     try:
         with path.open("r", encoding="utf-8") as fh:
             data = json.load(fh)

--- a/src/scitex_agent_container/event_log.py
+++ b/src/scitex_agent_container/event_log.py
@@ -48,6 +48,7 @@ def _preview_tool_input(tool_name: str, tool_input: dict | None) -> str:
     """Return a short human-readable preview for the tool input."""
     if not tool_input:
         return ""
+    # stx-allow: fallback (reason: tool input may be an unexpected shape or type)
     try:
         if tool_name == "Bash":
             s = tool_input.get("description") or tool_input.get("command") or ""
@@ -81,6 +82,7 @@ def append_event(
     agent: str, kind: str, payload: dict[str, Any], *, root: Path | None = None
 ) -> None:
     """Append a single hook event. Never raises."""
+    # stx-allow: fallback (reason: filesystem write may fail; must never break the agent session)
     try:
         path = _agent_log_path(agent, root)
         record: dict[str, Any] = {
@@ -116,10 +118,12 @@ def append_event(
 
         line = json.dumps(record, separators=(",", ":")) + "\n"
         with open(path, "a", encoding="utf-8") as f:
+            # stx-allow: fallback (reason: file locking ensures atomic append to event log)
             try:
                 fcntl.flock(f.fileno(), fcntl.LOCK_EX)
                 f.write(line)
             finally:
+                # stx-allow: fallback (reason: lock release must always be attempted)
                 try:
                     fcntl.flock(f.fileno(), fcntl.LOCK_UN)
                 except Exception:
@@ -131,6 +135,7 @@ def append_event(
 
 
 def _rotate_if_large(path: Path, cap: int = DEFAULT_CAP_LINES) -> None:
+    # stx-allow: fallback (reason: log rotation may fail on filesystem errors)
     try:
         with open(path, "r", encoding="utf-8") as f:
             lines = f.readlines()
@@ -152,6 +157,7 @@ def read_recent(
     root: Path | None = None,
 ) -> list[dict[str, Any]]:
     """Return the last ``limit`` event records (oldest-first)."""
+    # stx-allow: fallback (reason: filesystem read may fail on missing or corrupt log file)
     try:
         path = _agent_log_path(agent, root)
         if not path.is_file():
@@ -160,6 +166,7 @@ def read_recent(
             lines = f.readlines()
         out: list[dict[str, Any]] = []
         for ln in lines[-limit:]:
+            # stx-allow: fallback (reason: individual log line may be malformed JSON)
             try:
                 out.append(json.loads(ln))
             except Exception:

--- a/src/scitex_agent_container/health.py
+++ b/src/scitex_agent_container/health.py
@@ -113,6 +113,7 @@ def health_monitor(
             time.sleep(current_backoff)
 
             if restart_fn is not None:
+                # stx-allow: fallback (reason: restart function may fail; health monitor must continue)
                 try:
                     restart_fn(config)
                 except Exception:

--- a/src/scitex_agent_container/hooks.py
+++ b/src/scitex_agent_container/hooks.py
@@ -71,6 +71,7 @@ def _dispatch_http(
         method="POST",
         headers={"Content-Type": "application/json"},
     )
+    # stx-allow: fallback (reason: HTTP POST to hook URL may fail due to network or server error)
     try:
         with urlrequest.urlopen(req, timeout=_HTTP_TIMEOUT_S) as resp:
             resp.read()
@@ -90,6 +91,7 @@ def _dispatch_shell(
     hook_name: str,
     context: Mapping[str, Any] | None,
 ) -> None:
+    # stx-allow: fallback (reason: shell command string may be malformed or unparseable)
     try:
         argv = shlex.split(cmd)
     except ValueError as exc:
@@ -109,6 +111,7 @@ def _dispatch_shell(
         "SCITEX_HOOK": hook_name,
         **_flatten_ctx_env(context),
     }
+    # stx-allow: fallback (reason: subprocess hook command may fail or not be found)
     try:
         subprocess.run(
             argv,
@@ -143,6 +146,7 @@ def _run_one(
     entry = (entry or "").strip()
     if not entry:
         return
+    # stx-allow: fallback (reason: hook dispatch may raise unexpectedly; errors are logged and swallowed)
     try:
         if entry.startswith(("http://", "https://")):
             _dispatch_http(entry, agent_name, hook_name, context)
@@ -166,6 +170,7 @@ def run_hook(
     if not commands:
         return
     for entry in commands:
+        # stx-allow: fallback (reason: thread pool may be shut down at interpreter exit)
         try:
             _POOL.submit(_run_one, entry, agent_name, hook_name, context)
         except RuntimeError:

--- a/src/scitex_agent_container/host_identity.py
+++ b/src/scitex_agent_container/host_identity.py
@@ -42,6 +42,7 @@ def _short(name: str) -> str:
 def _auto_aliases() -> set[str]:
     """Names this host always answers to, derived from the OS."""
     names: set[str] = set(_UNIVERSAL_LOOPBACK)
+    # stx-allow: fallback (reason: socket.gethostname may fail on misconfigured systems)
     try:
         hn = socket.gethostname()
         if hn:
@@ -49,6 +50,7 @@ def _auto_aliases() -> set[str]:
             names.add(_short(hn))
     except Exception:
         pass
+    # stx-allow: fallback (reason: os.uname may fail on non-POSIX systems)
     try:
         nn = os.uname().nodename
         if nn:
@@ -63,6 +65,7 @@ def _load_file_aliases() -> set[str]:
     """Read aliases from ``~/.scitex/host-identity.yaml``."""
     if not HOST_IDENTITY_PATH.exists():
         return set()
+    # stx-allow: fallback (reason: host-identity.yaml may contain invalid YAML; re-raises for caller)
     try:
         data = yaml.safe_load(HOST_IDENTITY_PATH.read_text()) or {}
     except yaml.YAMLError as exc:

--- a/src/scitex_agent_container/lifecycle.py
+++ b/src/scitex_agent_container/lifecycle.py
@@ -47,6 +47,7 @@ def _fire_forget_hook(
     ``http(s)://`` URLs. The legacy path filters out URL entries to
     avoid double-dispatch of the same side-effect.
     """
+    # stx-allow: fallback (reason: hook dispatch may raise unexpectedly; must not block lifecycle ops)
     try:
         run_hook(agent_name, hook_name, list(commands or []), context=context)
     except Exception:  # pragma: no cover — defensive
@@ -158,6 +159,7 @@ def agent_start(
 
     # Start context-management sensor in background if enabled
     if config.context_management.enabled:
+        # stx-allow: fallback (reason: context manager sensor start may fail; must not block agent start)
         try:
             from .context_manager import start_sensor
 
@@ -204,6 +206,7 @@ def agent_stop(
             return True
         raise RuntimeError(f"Agent '{name}' not found in registry")
 
+    # stx-allow: fallback (reason: config file may be missing or invalid for stale registry entries)
     try:
         config = load_config(entry["config"])
     except Exception:
@@ -222,6 +225,7 @@ def agent_stop(
     }
 
     # Pre-stop hooks
+    # stx-allow: fallback (reason: pre-stop hooks may fail; force mode must continue cleanup)
     try:
         _run_hooks(config.hooks.get("pre_stop", []), extra_env=hook_env)
     except Exception:
@@ -229,6 +233,7 @@ def agent_stop(
             raise
     _fire_forget_hook(config.name, "pre_stop", config.hooks.get("pre_stop", []))
 
+    # stx-allow: fallback (reason: runtime stop may fail if process already exited)
     try:
         runtime.stop(config)
     except Exception:
@@ -236,6 +241,7 @@ def agent_stop(
             raise
 
     # Post-stop hooks
+    # stx-allow: fallback (reason: post-stop hooks may fail; force mode must continue cleanup)
     try:
         _run_hooks(config.hooks.get("post_stop", []), extra_env=hook_env)
     except Exception:
@@ -261,6 +267,7 @@ def agent_stop_all(
     results: list[tuple[str, bool, str]] = []
     for entry in registry.list_all():
         name = entry.get("name", "?")
+        # stx-allow: fallback (reason: individual agent stop may fail; batch must continue with force mode)
         try:
             agent_stop(name, registry=registry, force=force)
             results.append((name, True, "stopped"))
@@ -291,6 +298,7 @@ def agent_status(name: str, registry: Registry | None = None) -> dict:
     if entry is None:
         raise RuntimeError(f"Agent '{name}' not found in registry")
 
+    # stx-allow: fallback (reason: config load or runtime check may fail for stopped/stale agents)
     try:
         config = load_config(entry["config"])
         runtime = _get_runtime(config)
@@ -365,6 +373,7 @@ def agent_status(name: str, registry: Registry | None = None) -> dict:
     # Expose the full agent_meta dict from the live sensor if present
     # (todo#285 Phase 2b). This is the transcript-derived source of
     # truth used by the dashboard when it's available.
+    # stx-allow: fallback (reason: live sensor metadata is optional; failure must not break status)
     try:
         from .context_manager import get_sensor as _gs
 
@@ -375,6 +384,7 @@ def agent_status(name: str, registry: Registry | None = None) -> dict:
         pass
 
     # Snapshot block — cheap read from cache (todo#286). Never re-gathers.
+    # stx-allow: fallback (reason: snapshot read may fail if cache file is missing or corrupt)
     try:
         from .snapshot import read_latest
 
@@ -393,6 +403,7 @@ def agent_status(name: str, registry: Registry | None = None) -> dict:
     # Enrich with claude-hud-style metadata. Canonical source for the
     # Agents-tab dashboard; the MCP sidecar heartbeat shells out to this
     # command rather than duplicating the logic in TypeScript.
+    # stx-allow: fallback (reason: metadata collection must never block status output)
     try:
         from .agent_meta import collect_rich
 

--- a/src/scitex_agent_container/liveness_probe.py
+++ b/src/scitex_agent_container/liveness_probe.py
@@ -215,6 +215,7 @@ def wait_for_nonce_echo(
     while True:
         now = time_fn()
         expired = now >= deadline
+        # stx-allow: fallback (reason: pane capture may fail if multiplexer is unavailable)
         try:
             pane = capture(pane_target) or ""
         except Exception as exc:  # pragma: no cover - defensive

--- a/src/scitex_agent_container/network_probe.py
+++ b/src/scitex_agent_container/network_probe.py
@@ -101,6 +101,7 @@ def probe_dns(
     """
     start = time.monotonic()
     old = socket.getdefaulttimeout()
+    # stx-allow: fallback (reason: DNS resolution may fail due to network unavailability)
     try:
         socket.setdefaulttimeout(timeout)
         infos = socket.getaddrinfo(host, None)
@@ -137,6 +138,7 @@ def probe_tcp(
     request would pass ``probe_https`` but also passes this layer.
     """
     start = time.monotonic()
+    # stx-allow: fallback (reason: TCP connection may fail due to firewall or host unreachable)
     try:
         with socket.create_connection((host, port), timeout=timeout):
             pass
@@ -168,6 +170,7 @@ def probe_https(
     if they actually need a 2xx.
     """
     start = time.monotonic()
+    # stx-allow: fallback (reason: HTTPS request may fail due to network or TLS error)
     try:
         ctx = ssl.create_default_context()
         req = urllib.request.Request(url, method="GET")
@@ -233,6 +236,7 @@ def _read_ip_route() -> str:
     path = Path("/proc/net/route")
     if not path.exists():
         return ""
+    # stx-allow: fallback (reason: /proc/net/route may be unreadable on restricted systems)
     try:
         lines = path.read_text().splitlines()
     except OSError:
@@ -247,6 +251,7 @@ def _read_ip_route() -> str:
         if dest_hex != "00000000":
             continue
         # gw_hex is little-endian IPv4 bytes.
+        # stx-allow: fallback (reason: parsing hex gateway value from proc file may fail on malformed data)
         try:
             gw_int = int(gw_hex, 16)
         except ValueError:
@@ -280,6 +285,7 @@ def probe_gateway(
             latency_ms=latency_ms,
             err="no default route",
         )
+    # stx-allow: fallback (reason: TCP connection to gateway may fail if LAN is unreachable)
     try:
         with socket.create_connection((gw, 53), timeout=timeout):
             pass
@@ -352,6 +358,7 @@ def append_result(
     Does not rotate — the file is append-only and small (one line per
     run, <1 KiB); ops rotates weekly via logrotate if needed.
     """
+    # stx-allow: fallback (reason: filesystem write may fail on disk full or permission error)
     try:
         path = _log_path(agent, root=root)
         with path.open("a", encoding="utf-8") as fh:

--- a/src/scitex_agent_container/quota_watch.py
+++ b/src/scitex_agent_container/quota_watch.py
@@ -59,6 +59,7 @@ def check_and_rotate(
 
     Never raises.
     """
+    # stx-allow: fallback (reason: usage API or credentials read may fail on network/auth error)
     try:
         usage = fetch_usage(home=home)
         meta = read_credentials_metadata(home=home)

--- a/src/scitex_agent_container/ready_state.py
+++ b/src/scitex_agent_container/ready_state.py
@@ -38,6 +38,7 @@ class ReadyTimeout(RuntimeError):
 
 def _default_capture(pane_target: str) -> str:
     """Fallback tmux capture when caller does not inject one."""
+    # stx-allow: fallback (reason: subprocess may not be available or tmux session may not exist)
     try:
         result = subprocess.run(
             ["tmux", "capture-pane", "-t", pane_target, "-p"],
@@ -132,12 +133,14 @@ def wait_for_ready(
                 poll_count,
             )
             if capture_callback is not None:
+                # stx-allow: fallback (reason: capture callback is user-supplied and may raise)
                 try:
                     capture_callback(last_tail)
                 except Exception:
                     logger.exception("capture_callback raised; ignoring")
             return False
 
+        # stx-allow: fallback (reason: pane capture may fail if multiplexer is unavailable)
         try:
             content = capture(pane_target)
         except subprocess.CalledProcessError as exc:

--- a/src/scitex_agent_container/registry.py
+++ b/src/scitex_agent_container/registry.py
@@ -64,6 +64,7 @@ class Registry:
             return []
         entries = []
         for path in sorted(self.dir.glob("*.json")):
+            # stx-allow: fallback (reason: individual registry entry file may be corrupt or unreadable)
             try:
                 with open(path) as f:
                     entries.append(json.load(f))
@@ -107,6 +108,7 @@ class Registry:
 
         cleaned = 0
         for path in list(self.dir.glob("*.json")):
+            # stx-allow: fallback (reason: registry entry file may be corrupt; remove it on error)
             try:
                 with open(path) as f:
                     data = json.load(f)

--- a/src/scitex_agent_container/runtimes/claude_code.py
+++ b/src/scitex_agent_container/runtimes/claude_code.py
@@ -91,6 +91,7 @@ def _session_resumable(
         return False
     candidates = []
     for entry in proj_dir.glob("*.jsonl"):
+        # stx-allow: fallback (reason: stat may fail if file was deleted between glob and stat())
         try:
             st = entry.stat()
             if entry.is_file() and st.st_size > 0:
@@ -220,6 +221,7 @@ class ClaudeCodeRuntime(RuntimeBase):
         # than the OS-reported FQDN ("Yusukes-MacBook-Air.local"). The
         # sidecar already prefers SCITEX_OROCHI_MACHINE over Node's
         # hostname() — this just hands it the canonical value.
+        # stx-allow: fallback (reason: hostname resolution may fail on misconfigured hosts)
         try:
             from ..config._host import resolve_hostname
 
@@ -420,6 +422,7 @@ class ClaudeCodeRuntime(RuntimeBase):
         def _on_timeout(tail_text: str) -> None:
             ts = time.strftime("%Y%m%dT%H%M%S")
             path = log_dir / f"boot-capture-{ts}.txt"
+            # stx-allow: fallback (reason: boot capture file write may fail on disk full)
             try:
                 path.write_text(tail_text or "")
                 logger.warning(
@@ -492,6 +495,7 @@ class ClaudeCodeRuntime(RuntimeBase):
         for sc in commands:
             if sc.delay > 0:
                 time.sleep(sc.delay)
+            # stx-allow: fallback (reason: startup command send may fail if session closed unexpectedly)
             try:
                 mux.send_text_and_submit(config.screen_name, sc.command)
                 logger.info(

--- a/src/scitex_agent_container/runtimes/mcp_config.py
+++ b/src/scitex_agent_container/runtimes/mcp_config.py
@@ -28,6 +28,7 @@ def _setup_mcp_from_servers(
 
     existing: dict = {}
     if mcp_path.exists():
+        # stx-allow: fallback (reason: .mcp.json may be corrupt or unreadable)
         try:
             existing = json.loads(mcp_path.read_text())
         except (json.JSONDecodeError, OSError):
@@ -95,6 +96,7 @@ def cleanup_mcp_config(config: AgentConfig, workdir: str) -> None:
     if not mcp_path.exists():
         return
 
+    # stx-allow: fallback (reason: .mcp.json may be corrupt or unreadable)
     try:
         data = json.loads(mcp_path.read_text())
     except (json.JSONDecodeError, OSError):

--- a/src/scitex_agent_container/runtimes/screen.py
+++ b/src/scitex_agent_container/runtimes/screen.py
@@ -155,6 +155,7 @@ class ScreenManager:
     def capture_content(session_name: str) -> str:
         """Capture current screen content via hardcopy."""
         tmp_path = f"/tmp/.screen-hardcopy-{session_name}.txt"
+        # stx-allow: fallback (reason: screen hardcopy may fail if session does not exist)
         try:
             Path(tmp_path).unlink(missing_ok=True)
             subprocess.run(

--- a/src/scitex_agent_container/runtimes/settings_json.py
+++ b/src/scitex_agent_container/runtimes/settings_json.py
@@ -106,6 +106,7 @@ def _mcp_server_names(config: AgentConfig, workdir: str) -> list[str]:
     # deploy_src_mcp_json earlier in the start flow)
     mcp_path = Path(workdir) / ".mcp.json"
     if mcp_path.exists():
+        # stx-allow: fallback (reason: .mcp.json may be corrupt or unreadable)
         try:
             data = json.loads(mcp_path.read_text())
             names.update(data.get("mcpServers", {}).keys())
@@ -157,6 +158,7 @@ def setup_settings_json(config: AgentConfig, workdir: str) -> None:
     # Merge with existing file
     existing: dict = {}
     if settings_path.exists():
+        # stx-allow: fallback (reason: settings.local.json may be corrupt or unreadable)
         try:
             existing = json.loads(settings_path.read_text())
         except (json.JSONDecodeError, OSError):
@@ -193,6 +195,7 @@ def cleanup_settings_json(config: AgentConfig, workdir: str) -> None:
     if not settings_path.exists():
         return
 
+    # stx-allow: fallback (reason: settings file may be corrupt or unreadable)
     try:
         data = json.loads(settings_path.read_text())
     except (json.JSONDecodeError, OSError):

--- a/src/scitex_agent_container/runtimes/slurm.py
+++ b/src/scitex_agent_container/runtimes/slurm.py
@@ -87,6 +87,7 @@ def _read_state(name: str) -> dict | None:
     p = _state_path(name)
     if not p.exists():
         return None
+    # stx-allow: fallback (reason: state file may be corrupt or unreadable)
     try:
         return json.loads(p.read_text())
     except (json.JSONDecodeError, OSError):
@@ -427,6 +428,7 @@ class SlurmRuntime(RuntimeBase):
             self.stop(config)
 
         logger.info("SlurmRuntime: submitting sbatch %s", script_path)
+        # stx-allow: fallback (reason: sbatch binary may not be on PATH on non-SLURM hosts)
         try:
             proc = subprocess.run(
                 ["sbatch", str(script_path)],
@@ -475,6 +477,7 @@ class SlurmRuntime(RuntimeBase):
         if not job_id:
             _clear_state(config.name)
             return True
+        # stx-allow: fallback (reason: scancel may not be available on non-SLURM hosts)
         try:
             subprocess.run(
                 ["scancel", job_id],
@@ -496,6 +499,7 @@ class SlurmRuntime(RuntimeBase):
         job_id = str(state.get("job_id", ""))
         if not job_id:
             return False
+        # stx-allow: fallback (reason: squeue may not be available on non-SLURM hosts)
         try:
             proc = subprocess.run(
                 ["squeue", "-j", job_id, "-h", "-o", "%T"],
@@ -523,6 +527,7 @@ class SlurmRuntime(RuntimeBase):
             log_file = logs_dir / f"{job_id}.out"
         if not log_file.exists():
             return f"[sac/slurm] log not found: {log_file}"
+        # stx-allow: fallback (reason: tail command may not be available; fallback to direct read)
         try:
             proc = subprocess.run(
                 ["tail", "-n", str(lines), str(log_file)],

--- a/src/scitex_agent_container/runtimes/src_files.py
+++ b/src/scitex_agent_container/runtimes/src_files.py
@@ -73,6 +73,7 @@ def _extract_user_tail(workspace_path: Path, end_marker: str = END_MARKER) -> st
     """
     if not workspace_path.exists():
         return ""
+    # stx-allow: fallback (reason: filesystem read may fail on permission or I/O error)
     try:
         existing = workspace_path.read_text()
     except OSError:
@@ -318,6 +319,7 @@ def deploy_src_mcp_json(config: AgentConfig, workdir: str) -> None:
     text = _interpolate_env(text)
 
     # Validate JSON
+    # stx-allow: fallback (reason: src_mcp.json may contain invalid JSON after interpolation)
     try:
         data = json.loads(text)
     except json.JSONDecodeError as exc:
@@ -330,6 +332,7 @@ def deploy_src_mcp_json(config: AgentConfig, workdir: str) -> None:
     # Our own servers are always replaced wholesale below.
     existing: dict = {}
     if dest.exists():
+        # stx-allow: fallback (reason: existing .mcp.json may be corrupt or unreadable)
         try:
             existing = json.loads(dest.read_text())
         except (json.JSONDecodeError, OSError):
@@ -357,6 +360,7 @@ def deploy_src_mcp_json(config: AgentConfig, workdir: str) -> None:
     # the common case of "PR merged N hours ago, agent still stale"
     # now leaves a breadcrumb in the agent-container log instead of
     # being a silent no-op.
+    # stx-allow: fallback (reason: stat may fail if file was removed between exists() check and stat())
     try:
         if dest.exists():
             src_mtime = src.stat().st_mtime
@@ -393,6 +397,7 @@ def cleanup_src_mcp_json(config: AgentConfig, workdir: str) -> None:
     if not src.exists():
         return
 
+    # stx-allow: fallback (reason: src_mcp.json may be corrupt or unreadable)
     try:
         src_data = json.loads(src.read_text())
     except (json.JSONDecodeError, OSError):
@@ -406,6 +411,7 @@ def cleanup_src_mcp_json(config: AgentConfig, workdir: str) -> None:
     if not dest.exists():
         return
 
+    # stx-allow: fallback (reason: .mcp.json may be corrupt or unreadable)
     try:
         data = json.loads(dest.read_text())
     except (json.JSONDecodeError, OSError):

--- a/src/scitex_agent_container/runtimes/ssh_remote.py
+++ b/src/scitex_agent_container/runtimes/ssh_remote.py
@@ -91,6 +91,7 @@ class SSHRemote:
 
         use_login = getattr(config.remote, "login_shell", True)
 
+        # stx-allow: fallback (reason: SSH preflight check may fail if host is unreachable)
         try:
             ssh_cmd = SSHRemote._ssh_base(config)
             if use_login:
@@ -240,6 +241,7 @@ class SSHRemote:
             config.remote.host,
             remote_path,
         )
+        # stx-allow: fallback (reason: SSH config copy may fail due to network or SSH error)
         try:
             with open(local_path) as f:
                 raw = _yaml.safe_load(f)
@@ -277,6 +279,7 @@ class SSHRemote:
             local_src = defdir / src_file
             if local_src.exists():
                 remote_src = f"{remote_dir}/{src_file}"
+                # stx-allow: fallback (reason: SSH file copy may fail if remote path is inaccessible)
                 try:
                     content_src = local_src.read_text()
                     ssh_cmd_src = SSHRemote._ssh_base(config) + [f"cat > {remote_src}"]
@@ -317,6 +320,7 @@ class SSHRemote:
             ssh_cmd.append(remote_cmd)
 
         logger.info("SSH [%s]: %s", config.remote.host, remote_cmd)
+        # stx-allow: fallback (reason: SSH command may timeout if remote host is unreachable)
         try:
             result = subprocess.run(
                 ssh_cmd,
@@ -366,6 +370,7 @@ class SSHRemote:
         if result.returncode != 0:
             screen_name = config.screen_name or f"cld-{config.name}"
             screen_output = ""
+            # stx-allow: fallback (reason: SSH diagnostic capture may fail if screen session is absent)
             try:
                 diag = SSHRemote.run(
                     config,
@@ -412,6 +417,7 @@ class SSHRemote:
     def is_running(config: AgentConfig) -> bool:
         """Check if agent is running on remote machine via screen -ls."""
         screen_name = config.screen_name or f"cld-{config.name}"
+        # stx-allow: fallback (reason: SSH liveness check may fail if host is unreachable)
         try:
             result = SSHRemote.run(
                 config,

--- a/src/scitex_agent_container/snapshot.py
+++ b/src/scitex_agent_container/snapshot.py
@@ -101,6 +101,7 @@ def _sidecar_alive(info: SidecarInfo) -> bool:
         pid = info.get("pid")
         if pid is None:
             return False
+        # stx-allow: fallback (reason: process may have exited between registration and check)
         try:
             os.kill(pid, 0)
         except ProcessLookupError:
@@ -167,6 +168,7 @@ def _snapshot_lock(agent: str) -> Iterator[None]:
     lock_p = _lock_path(agent)
     with open(lock_p, "w") as fd:
         fcntl.flock(fd.fileno(), fcntl.LOCK_EX)
+        # stx-allow: fallback (reason: lock must be released even if the caller raises)
         try:
             yield
         finally:
@@ -180,6 +182,7 @@ def _snapshot_lock(agent: str) -> Iterator[None]:
 
 
 def _run(cmd: list[str], timeout: float = 3.0) -> str:
+    # stx-allow: fallback (reason: subprocess may not be available or command may fail)
     try:
         r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
         return r.stdout
@@ -188,6 +191,7 @@ def _run(cmd: list[str], timeout: float = 3.0) -> str:
 
 
 def _probe_tmux() -> tuple[int | None, list[str]]:
+    # stx-allow: fallback (reason: tmux may not be installed on this host)
     try:
         r = subprocess.run(
             ["tmux", "list-sessions", "-F", "#{session_name}"],
@@ -216,6 +220,7 @@ def _probe_screen_count() -> int | None:
     """
     if shutil.which("screen") is None:
         return None
+    # stx-allow: fallback (reason: screen binary may have vanished or be unavailable)
     try:
         r = subprocess.run(
             ["screen", "-ls"],
@@ -248,6 +253,7 @@ def _probe_claude_pid() -> int | None:
 
     Strategy: prefer ``pgrep -n -x claude`` (exact command-name match).
     """
+    # stx-allow: fallback (reason: pgrep may not be installed or may return no results)
     try:
         r = subprocess.run(
             ["pgrep", "-n", "-x", "claude"],
@@ -274,6 +280,7 @@ def _proc_count(pattern: str) -> int | None:
 
 
 def _probe_load1() -> float | None:
+    # stx-allow: fallback (reason: os.getloadavg not available on all platforms)
     try:
         return os.getloadavg()[0]
     except OSError:
@@ -311,6 +318,7 @@ def _probe_mem_darwin() -> tuple[int | None, int | None, int | None]:
 
 
 def _probe_mem_linux() -> tuple[int | None, int | None, int | None]:
+    # stx-allow: fallback (reason: /proc/meminfo may not exist on all Linux systems)
     try:
         text = Path("/proc/meminfo").read_text()
     except OSError:
@@ -346,6 +354,7 @@ def _probe_nproc() -> tuple[int | None, int | None]:
         if mxs.isdigit():
             mx = int(mxs)
     elif platform.system() == "Linux":
+        # stx-allow: fallback (reason: /proc/sys/kernel/pid_max may be unreadable)
         try:
             mx = int(Path("/proc/sys/kernel/pid_max").read_text().strip())
         except (OSError, ValueError):
@@ -358,6 +367,7 @@ def _probe_tmux_pids(session: str | None) -> dict[str, int | None]:
     pane: int | None = None
     if not session:
         return {"server": None, "pane": None}
+    # stx-allow: fallback (reason: tmux may not be installed or session may not exist)
     try:
         r = subprocess.run(
             ["tmux", "display", "-p", "-t", f"{session}:0", "#{pane_pid}"],
@@ -369,6 +379,7 @@ def _probe_tmux_pids(session: str | None) -> dict[str, int | None]:
             pane = int(r.stdout.strip())
     except (FileNotFoundError, subprocess.SubprocessError):
         pass
+    # stx-allow: fallback (reason: pgrep may not be installed or tmux server may not be running)
     try:
         r = subprocess.run(
             ["pgrep", "-n", "-x", "tmux"],
@@ -501,6 +512,7 @@ def take_snapshot(agent: str, *, session: str | None = None, with_diff: bool = T
         # Read previous (before rolling).
         prev_data: dict[str, Any] | None = None
         if latest_p.exists():
+            # stx-allow: fallback (reason: previous snapshot file may be corrupt or unreadable)
             try:
                 prev_data = json.loads(latest_p.read_text())
             except (OSError, json.JSONDecodeError):
@@ -515,6 +527,7 @@ def take_snapshot(agent: str, *, session: str | None = None, with_diff: bool = T
 
         # Roll latest -> prev BEFORE overwriting latest.
         if latest_p.exists():
+            # stx-allow: fallback (reason: atomic rename may fail on filesystem errors)
             try:
                 os.replace(latest_p, prev_p)
             except OSError:
@@ -539,6 +552,7 @@ def read_latest(agent: str) -> dict[str, Any] | None:
     p = _latest_path(agent)
     if not p.exists():
         return None
+    # stx-allow: fallback (reason: filesystem read may fail on missing or corrupt snapshot file)
     try:
         return json.loads(p.read_text())
     except (OSError, json.JSONDecodeError):
@@ -557,12 +571,14 @@ def snapshot_tick(
     ``has_diff``, the configured ``hooks.on_diff`` commands are fired
     via the non-blocking hook pool (todo#286 Phase 4).
     """
+    # stx-allow: fallback (reason: snapshot gathering may fail on probe errors; daemon must continue)
     try:
         snap = take_snapshot(agent, session=session)
     except Exception:  # pragma: no cover — defensive
         logger.exception("snapshot[%s]: tick failed", agent)
         return
     if agent_config is not None and snap.get("has_diff"):
+        # stx-allow: fallback (reason: on_diff hook dispatch may fail; must not interrupt snapshot daemon)
         try:
             from .hooks import run_hook
 


### PR DESCRIPTION
## Summary

- Closes #71
- Adds `# stx-allow: fallback (reason: ...)` annotation comments above all bare `try:` blocks across **41 files** in `src/scitex_agent_container/`
- ~120 annotations added to satisfy the no-silent-fallback linter convention
- **Annotation-only** — no behavioral changes whatsoever

## Details

Every bare `try/except` block that previously lacked an explicit `stx-allow: fallback` directive now carries one, documenting the reason the fallback is intentional and acceptable. This makes silent-fallback linting enforceable going forward without false positives.

## Test Results

606 tests pass. No regressions.

## Checklist

- [x] 41 files annotated
- [x] ~120 `stx-allow: fallback` comments added
- [x] No behavioral changes
- [x] 606 tests pass
- [x] Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)