### PR TITLE
feat(zoo#12): lead-state-handover sac runtime — hydrate, failback, identity

### DIFF
--- a/src/scitex_agent_container/_handover.py
+++ b/src/scitex_agent_container/_handover.py
@@ -88,7 +88,8 @@ def ensure_instance_uuid(config) -> str:
     has ``SCITEX_AGENT_INSTANCE_UUID`` (e.g. caller set it explicitly),
     leave it alone.
     """
-    env = config.env if isinstance(config.env, dict) else {}
+    env = getattr(config, "env", None)
+    env = env if isinstance(env, dict) else {}
     existing = env.get("SCITEX_AGENT_INSTANCE_UUID", "")
     if existing:
         return str(existing)

--- a/src/scitex_agent_container/_handover.py
+++ b/src/scitex_agent_container/_handover.py
@@ -1,0 +1,236 @@
+"""Lead-state-handover (ZOO#12) — sac runtime helpers.
+
+Reads ZOO#12-specific keys from the agent YAML spec without polluting the
+canonical :class:`AgentConfig` schema:
+
+  - ``cardinality_enforced_at_hub: true``  (FR-C — sent to the hub on WS
+    accept; the hub enforces 4001 on duplicate-name-different-UUID)
+  - ``priority_list: [host_a, host_b, ...]`` (FR-B — order of preferred
+    owner hosts; a healthier higher-priority host triggers failback)
+
+Plus three lifecycle pieces:
+
+  - ``ensure_instance_uuid(config)`` — generates ``uuid4()`` once per
+    agent_start invocation and writes it to ``config.env`` so the
+    runtime's ``_build_env_exports`` propagates it as
+    ``SCITEX_AGENT_INSTANCE_UUID`` (FR-E)
+  - ``hydrate_from_hub(config)``    — pulls the latest snapshot from the
+    hub and writes its payload to ``<workdir>/.scitex/handover/snapshot.json``
+    so the agent's boot-time skill can pick it up (FR-A)
+  - ``start_failback_poller(config)`` — daemon thread that polls
+    ``/api/agents/<name>/owner/`` every 60 s; on a healthier
+    higher-priority host showing up, pushes a snapshot then exits the
+    process so the local lead steps aside (FR-B)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import signal
+import threading
+import uuid
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from . import hub_client
+
+logger = logging.getLogger(__name__)
+
+_FAILBACK_POLL_INTERVAL_S = 60.0
+
+
+# ---------- spec readers --------------------------------------------------
+
+
+def _load_raw_spec(config_path: str) -> dict:
+    """Load the YAML at ``config_path`` and return the inner spec dict.
+
+    The orochi spec format wraps everything under ``spec:``; older specs
+    are flat. Tolerate both.
+    """
+    if not config_path:
+        return {}
+    try:
+        with open(config_path, "r", encoding="utf-8") as fh:
+            raw = yaml.safe_load(fh) or {}
+    except (OSError, yaml.YAMLError) as exc:
+        logger.warning("_handover: cannot read spec %s: %s", config_path, exc)
+        return {}
+    if isinstance(raw, dict) and isinstance(raw.get("spec"), dict):
+        return raw["spec"]
+    return raw if isinstance(raw, dict) else {}
+
+
+def read_cardinality_enforced(config_path: str) -> bool:
+    spec = _load_raw_spec(config_path)
+    return bool(spec.get("cardinality_enforced_at_hub", False))
+
+
+def read_priority_list(config_path: str) -> list[str]:
+    spec = _load_raw_spec(config_path)
+    raw = spec.get("priority_list") or []
+    if not isinstance(raw, list):
+        return []
+    return [str(x) for x in raw if x]
+
+
+# ---------- FR-E identity -------------------------------------------------
+
+
+def ensure_instance_uuid(config) -> str:
+    """Generate a UUID for this start and write it into ``config.env``.
+
+    Idempotent on the AgentConfig instance: if ``config.env`` already
+    has ``SCITEX_AGENT_INSTANCE_UUID`` (e.g. caller set it explicitly),
+    leave it alone.
+    """
+    env = config.env if isinstance(config.env, dict) else {}
+    existing = env.get("SCITEX_AGENT_INSTANCE_UUID", "")
+    if existing:
+        return str(existing)
+    new_uuid = str(uuid.uuid4())
+    env["SCITEX_AGENT_INSTANCE_UUID"] = new_uuid
+    config.env = env
+    return new_uuid
+
+
+# ---------- FR-A snapshot hydrate ----------------------------------------
+
+
+def _handover_dir(config) -> Path:
+    workdir = Path(config.expanded_workdir).expanduser()
+    out = workdir / ".scitex" / "handover"
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def hydrate_from_hub(config) -> bool:
+    """Fetch the latest snapshot from the hub and dump it locally.
+
+    Best-effort: returns False on any error (no token / 404 / network).
+    The snapshot is written atomically as
+    ``<workdir>/.scitex/handover/snapshot.json``; the agent's boot-time
+    skill consumes it (or ignores it on first start).
+    """
+    snap = hub_client.fetch_snapshot(config.name)
+    if not snap or "payload" not in snap:
+        return False
+    out_dir = _handover_dir(config)
+    target = out_dir / "snapshot.json"
+    tmp = target.with_suffix(".json.tmp")
+    try:
+        tmp.write_text(json.dumps(snap, indent=2, default=str), encoding="utf-8")
+        tmp.replace(target)
+        logger.info(
+            "hydrate_from_hub: %s wrote %d bytes from owner=%s",
+            config.name,
+            len(snap.get("payload") or {}),
+            snap.get("owner_host", ""),
+        )
+        return True
+    except OSError as exc:
+        logger.warning("hydrate_from_hub: write failed: %s", exc)
+        return False
+
+
+def push_pre_stop_snapshot(config, payload: dict[str, Any] | None = None) -> bool:
+    """Push a snapshot to the hub right before the agent stops.
+
+    The default payload is a sentinel ``{"reason": "pre_stop"}``; richer
+    state (e.g. transcript tail, memory) is the agent's responsibility
+    via its own pre_stop hook.
+    """
+    body = payload if payload is not None else {"reason": "pre_stop"}
+    owner = os.environ.get("SCITEX_OROCHI_MACHINE", "") or os.environ.get(
+        "SCITEX_AGENT_CONTAINER_HOSTNAME", ""
+    )
+    return hub_client.push_snapshot(config.name, body, owner_host=owner)
+
+
+# ---------- FR-B priority-failback poller --------------------------------
+
+
+_pollers: dict[str, threading.Thread] = {}
+_pollers_lock = threading.Lock()
+
+
+def _self_host() -> str:
+    return os.environ.get("SCITEX_OROCHI_MACHINE", "") or os.environ.get(
+        "SCITEX_AGENT_CONTAINER_HOSTNAME", ""
+    )
+
+
+def _should_step_aside(self_host: str, owner_payload: dict) -> bool:
+    """Return True iff a higher-priority host than us is healthy.
+
+    The hub's ``healthy`` map only flags hosts that have an active
+    online registration; a higher-priority host that's not in healthy
+    is by definition not a contender.
+    """
+    if not self_host:
+        return False
+    priority = owner_payload.get("priority_list") or []
+    healthy = owner_payload.get("healthy") or {}
+    if self_host not in priority:
+        return False
+    self_idx = priority.index(self_host)
+    for i, host in enumerate(priority[:self_idx]):
+        if healthy.get(host):
+            logger.info(
+                "_should_step_aside: higher-priority host %s healthy (idx=%d, self=%s idx=%d)",
+                host,
+                i,
+                self_host,
+                self_idx,
+            )
+            return True
+    return False
+
+
+def _failback_loop(config, stop_event: threading.Event) -> None:
+    while not stop_event.wait(_FAILBACK_POLL_INTERVAL_S):
+        try:
+            owner = hub_client.fetch_owner(config.name)
+            if _should_step_aside(_self_host(), owner):
+                logger.warning(
+                    "failback_poller: stepping aside for higher-priority owner of %s",
+                    config.name,
+                )
+                push_pre_stop_snapshot(config, {"reason": "priority_failback"})
+                # SIGTERM lets the agent's own pre_stop hooks fire via
+                # the runtime's normal shutdown path.
+                os.kill(os.getpid(), signal.SIGTERM)
+                return
+        except Exception:
+            logger.exception("failback_poller: tick failed for %s", config.name)
+
+
+def start_failback_poller(config) -> threading.Event | None:
+    """Spawn a daemon thread that polls /owner/ for this agent.
+
+    No-op (returns ``None``) if no priority_list is configured for this
+    agent — without one there's no defined "higher priority" host.
+    Returns the stop event so callers can shut the poller down (the
+    process exit also kills the daemon thread).
+    """
+    if not read_priority_list(config.config_path):
+        return None
+    name = config.name
+    with _pollers_lock:
+        if name in _pollers and _pollers[name].is_alive():
+            logger.debug("start_failback_poller: %s already running", name)
+            return None
+        stop_event = threading.Event()
+        thread = threading.Thread(
+            target=_failback_loop,
+            args=(config, stop_event),
+            name=f"sac-failback-{name}",
+            daemon=True,
+        )
+        _pollers[name] = thread
+        thread.start()
+    return stop_event

--- a/src/scitex_agent_container/hub_client.py
+++ b/src/scitex_agent_container/hub_client.py
@@ -1,0 +1,130 @@
+"""Stdlib-only HTTP client for the Orochi hub's lead-state-handover API.
+
+Three endpoints (server side: scitex-orochi PR feat/lead-state-handover-server):
+
+  - POST /api/agents/<name>/snapshot/        — upsert payload (FR-A)
+  - GET  /api/agents/<name>/snapshot/latest/ — fetch latest payload (FR-A)
+  - GET  /api/agents/<name>/owner/           — current_host + priority_list +
+                                               healthy{} (FR-B)
+
+Auth: workspace token from ``SCITEX_AGENT_HUB_TOKEN``. Hub base URL from
+``SCITEX_AGENT_HUB_URL`` (defaults to ``https://scitex-orochi.com``).
+
+Stdlib only — no requests/httpx dependency. Same urlopen pattern as
+``scitex_agent_container.hooks._dispatch_http`` so this module is safe
+to import at agent_start without dragging in heavy deps.
+
+All functions are best-effort: network / HTTP errors are logged and
+swallowed, returning ``None`` (or an empty result dict) so the caller
+can decide whether the failure is fatal. Hot path: a hub outage must
+NOT block agent_start / agent_stop.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any
+from urllib import error as urlerror
+from urllib import parse as urlparse
+from urllib import request as urlrequest
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_HUB = "https://scitex-orochi.com"
+_HTTP_TIMEOUT_S = 10.0
+
+
+def _hub_url() -> str:
+    return os.environ.get("SCITEX_AGENT_HUB_URL", _DEFAULT_HUB).rstrip("/")
+
+
+def _hub_token() -> str:
+    return os.environ.get("SCITEX_AGENT_HUB_TOKEN", "").strip()
+
+
+def _request(method: str, path: str, *, body: dict | None = None) -> dict | None:
+    """Issue a hub request. Returns parsed JSON dict or ``None`` on error."""
+    token = _hub_token()
+    if not token:
+        logger.debug("hub_client: SCITEX_AGENT_HUB_TOKEN unset, skipping %s %s", method, path)
+        return None
+
+    url = f"{_hub_url()}{path}"
+    data: bytes | None = None
+    headers = {"Accept": "application/json"}
+    if method == "GET":
+        sep = "&" if "?" in url else "?"
+        url = f"{url}{sep}token={urlparse.quote(token)}"
+    else:
+        payload = dict(body or {})
+        payload["token"] = token
+        data = json.dumps(payload, default=str).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+
+    req = urlrequest.Request(url, data=data, method=method, headers=headers)
+    try:
+        with urlrequest.urlopen(req, timeout=_HTTP_TIMEOUT_S) as resp:
+            raw = resp.read()
+            if not raw:
+                return {}
+            return json.loads(raw)
+    except urlerror.HTTPError as exc:
+        # 404s are expected (no snapshot yet) — caller decides.
+        body_preview = ""
+        try:
+            body_preview = exc.read().decode("utf-8", errors="replace")[:200]
+        except Exception:
+            pass
+        logger.info(
+            "hub_client: %s %s -> %s %s",
+            method,
+            path,
+            exc.code,
+            body_preview,
+        )
+        return None
+    except (urlerror.URLError, OSError, ValueError) as exc:
+        logger.warning("hub_client: %s %s failed: %s", method, path, exc)
+        return None
+
+
+def push_snapshot(
+    agent_name: str,
+    payload: dict[str, Any],
+    *,
+    owner_host: str = "",
+) -> bool:
+    """POST a snapshot for ``agent_name``. Returns True on 200."""
+    body = {"payload": payload, "owner_host": owner_host}
+    out = _request("POST", f"/api/agents/{agent_name}/snapshot/", body=body)
+    if out is None:
+        return False
+    return out.get("status") == "ok"
+
+
+def fetch_snapshot(agent_name: str) -> dict | None:
+    """GET the latest snapshot. Returns the response dict or ``None``.
+
+    Response shape: ``{"agent_name", "owner_host", "payload", "updated_at"}``.
+    Returns ``None`` if the agent has no snapshot yet (404) or on transport
+    error.
+    """
+    return _request("GET", f"/api/agents/{agent_name}/snapshot/latest/")
+
+
+def fetch_owner(agent_name: str) -> dict:
+    """GET the owner endpoint. Always returns a dict (empty on error).
+
+    Response shape: ``{"agent", "current_host", "priority_list", "healthy"}``.
+    """
+    out = _request("GET", f"/api/agents/{agent_name}/owner/")
+    if out is None:
+        return {
+            "agent": agent_name,
+            "current_host": "",
+            "priority_list": [],
+            "healthy": {},
+        }
+    return out

--- a/src/scitex_agent_container/lifecycle.py
+++ b/src/scitex_agent_container/lifecycle.py
@@ -146,6 +146,25 @@ def agent_start(
         "SCITEX_AGENT_CONTAINER_NAME": config.name,
     }
 
+    # ZOO#12 — lead-state-handover plumbing. All three calls are
+    # best-effort: missing token / 404 / network errors must NOT block
+    # agent_start. ``ensure_instance_uuid`` writes
+    # ``SCITEX_AGENT_INSTANCE_UUID`` into ``config.env`` so the runtime's
+    # ``_build_env_exports`` (claude_code.py) propagates it; the runtime
+    # is supposed to read it back when wiring up the orochi WS connect
+    # (FR-E). ``hydrate_from_hub`` is pre-start so the agent's boot-time
+    # skill can pick up the snapshot before claude actually launches.
+    from . import _handover as _h
+
+    _h.ensure_instance_uuid(config)
+    try:
+        _h.hydrate_from_hub(config)
+    except Exception:
+        # Defensive: hub_client already swallows transport errors, but
+        # in case of a serialization bug here, never let agent_start
+        # die because of a snapshot fetch.
+        traceback.print_exc()
+
     # Pre-start hooks
     _run_hooks(config.hooks.get("pre_start", []), extra_env=hook_env)
     _fire_forget_hook(config.name, "pre_start", config.hooks.get("pre_start", []))
@@ -195,6 +214,15 @@ def agent_start(
         )
         thread.start()
 
+    # ZOO#12 FR-B — priority-failback poller. No-op when the spec lacks
+    # a ``priority_list``; otherwise polls the hub every 60 s and steps
+    # aside (snapshot push + SIGTERM) when a higher-priority host is
+    # healthy. Daemon thread, dies with the process.
+    try:
+        _h.start_failback_poller(config)
+    except Exception:
+        traceback.print_exc()
+
     return True
 
 
@@ -235,6 +263,18 @@ def agent_stop(
         "SCITEX_AGENT_CONTAINER_SCREEN_NAME": config.screen_name,
         "SCITEX_AGENT_CONTAINER_NAME": config.name,
     }
+
+    # ZOO#12 FR-A — push a sentinel snapshot to the hub right before
+    # the agent stops, so a future agent_start (here or on a different
+    # host) can hydrate. Best-effort: never block the stop path on a
+    # hub outage. The sentinel is a marker; the agent's own pre_stop
+    # hook is the right place for richer state (transcript, memory).
+    try:
+        from . import _handover as _h
+
+        _h.push_pre_stop_snapshot(config)
+    except Exception:
+        traceback.print_exc()
 
     # Pre-stop hooks
     try:

--- a/tests/test_handover.py
+++ b/tests/test_handover.py
@@ -1,0 +1,155 @@
+"""Tests for ``_handover`` — sac runtime side of ZOO#12.
+
+Covers:
+  - spec-key readers tolerate flat + ``spec:``-wrapped YAML
+  - ``ensure_instance_uuid`` writes ``SCITEX_AGENT_INSTANCE_UUID`` once
+  - ``_should_step_aside`` priority+healthy logic
+  - ``hydrate_from_hub`` writes the snapshot file atomically
+  - ``push_pre_stop_snapshot`` calls hub_client.push_snapshot
+
+The hub HTTP layer is monkeypatched at the ``hub_client`` boundary so
+no real network is touched.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from scitex_agent_container import _handover
+
+
+def _write_spec(path: Path, body: dict) -> Path:
+    import yaml
+
+    path.write_text(yaml.safe_dump(body), encoding="utf-8")
+    return path
+
+
+def test_read_cardinality_enforced_flat_yaml(tmp_path):
+    p = _write_spec(tmp_path / "a.yaml", {"cardinality_enforced_at_hub": True})
+    assert _handover.read_cardinality_enforced(str(p)) is True
+
+
+def test_read_cardinality_enforced_nested_under_spec(tmp_path):
+    p = _write_spec(
+        tmp_path / "b.yaml", {"spec": {"cardinality_enforced_at_hub": True}}
+    )
+    assert _handover.read_cardinality_enforced(str(p)) is True
+
+
+def test_read_priority_list_filters_blanks(tmp_path):
+    p = _write_spec(
+        tmp_path / "c.yaml",
+        {"priority_list": ["spartan", "", None, "mba"]},
+    )
+    assert _handover.read_priority_list(str(p)) == ["spartan", "mba"]
+
+
+def test_read_priority_list_missing_returns_empty(tmp_path):
+    p = _write_spec(tmp_path / "d.yaml", {})
+    assert _handover.read_priority_list(str(p)) == []
+
+
+def test_ensure_instance_uuid_writes_env(tmp_path):
+    cfg = SimpleNamespace(env={}, expanded_workdir=str(tmp_path))
+    out = _handover.ensure_instance_uuid(cfg)
+    # uuid4 string format: 36 chars including 4 hyphens.
+    assert len(out) == 36
+    assert cfg.env["SCITEX_AGENT_INSTANCE_UUID"] == out
+
+
+def test_ensure_instance_uuid_idempotent(tmp_path):
+    cfg = SimpleNamespace(
+        env={"SCITEX_AGENT_INSTANCE_UUID": "preset-id"}, expanded_workdir=str(tmp_path)
+    )
+    out = _handover.ensure_instance_uuid(cfg)
+    assert out == "preset-id"
+    assert cfg.env["SCITEX_AGENT_INSTANCE_UUID"] == "preset-id"
+
+
+def test_should_step_aside_higher_priority_healthy():
+    payload = {
+        "priority_list": ["spartan", "mba", "ywata-note-win"],
+        "healthy": {"spartan": True, "mba": False},
+    }
+    # We're "mba" — spartan is higher and healthy → step aside.
+    assert _handover._should_step_aside("mba", payload) is True
+
+
+def test_should_step_aside_higher_priority_unhealthy():
+    payload = {
+        "priority_list": ["spartan", "mba"],
+        "healthy": {"spartan": False, "mba": True},
+    }
+    # spartan is higher but unhealthy → keep running on mba.
+    assert _handover._should_step_aside("mba", payload) is False
+
+
+def test_should_step_aside_self_top_of_list():
+    payload = {
+        "priority_list": ["spartan", "mba"],
+        "healthy": {"spartan": True, "mba": True},
+    }
+    # spartan is us and the top of priority_list — never step aside.
+    assert _handover._should_step_aside("spartan", payload) is False
+
+
+def test_should_step_aside_self_not_in_list():
+    payload = {
+        "priority_list": ["spartan", "mba"],
+        "healthy": {"spartan": True},
+    }
+    assert _handover._should_step_aside("strange-host", payload) is False
+
+
+def test_hydrate_from_hub_writes_snapshot(tmp_path, monkeypatch):
+    cfg = SimpleNamespace(name="lead", expanded_workdir=str(tmp_path))
+
+    def fake_fetch(name):
+        return {
+            "agent_name": name,
+            "owner_host": "spartan",
+            "payload": {"memory": "alpha"},
+            "updated_at": "2026-04-29T00:00:00Z",
+        }
+
+    monkeypatch.setattr(_handover.hub_client, "fetch_snapshot", fake_fetch)
+    assert _handover.hydrate_from_hub(cfg) is True
+    written = (tmp_path / ".scitex" / "handover" / "snapshot.json").read_text()
+    assert json.loads(written)["payload"] == {"memory": "alpha"}
+
+
+def test_hydrate_from_hub_404_returns_false(tmp_path, monkeypatch):
+    cfg = SimpleNamespace(name="lead", expanded_workdir=str(tmp_path))
+    monkeypatch.setattr(_handover.hub_client, "fetch_snapshot", lambda n: None)
+    assert _handover.hydrate_from_hub(cfg) is False
+    # No file should be written on miss.
+    assert not (tmp_path / ".scitex" / "handover" / "snapshot.json").exists()
+
+
+def test_push_pre_stop_snapshot_calls_hub_client(tmp_path, monkeypatch):
+    seen = {}
+
+    def fake_push(name, payload, owner_host=""):
+        seen["name"] = name
+        seen["payload"] = payload
+        seen["owner_host"] = owner_host
+        return True
+
+    monkeypatch.setattr(_handover.hub_client, "push_snapshot", fake_push)
+    monkeypatch.setenv("SCITEX_OROCHI_MACHINE", "spartan")
+    cfg = SimpleNamespace(name="lead", expanded_workdir=str(tmp_path))
+    assert _handover.push_pre_stop_snapshot(cfg) is True
+    assert seen["name"] == "lead"
+    assert seen["owner_host"] == "spartan"
+    assert seen["payload"]["reason"] == "pre_stop"
+
+
+def test_start_failback_poller_no_priority_list_is_noop(tmp_path):
+    p = _write_spec(tmp_path / "e.yaml", {})
+    cfg = SimpleNamespace(
+        name="freerunner", expanded_workdir=str(tmp_path), config_path=str(p)
+    )
+    assert _handover.start_failback_poller(cfg) is None

--- a/tests/test_hub_client.py
+++ b/tests/test_hub_client.py
@@ -1,0 +1,135 @@
+"""Tests for hub_client (ZOO#12 lead-state-handover).
+
+Verifies the stdlib HTTP wrappers without touching the real hub:
+``urllib.request.urlopen`` is monkeypatched to return canned responses
+or raise ``HTTPError`` / ``URLError`` so the error-swallow paths are
+exercised too. Mirrors the pattern in ``tests/test_hooks.py`` for the
+``hooks._dispatch_http`` HTTP path.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from urllib import error as urlerror
+
+import pytest
+
+from scitex_agent_container import hub_client
+
+
+class _FakeResp:
+    def __init__(self, body: bytes, status: int = 200):
+        self._body = body
+        self.status = status
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def read(self):
+        return self._body
+
+
+@pytest.fixture(autouse=True)
+def _set_token(monkeypatch):
+    monkeypatch.setenv("SCITEX_AGENT_HUB_TOKEN", "wks_test_token")
+    monkeypatch.setenv("SCITEX_AGENT_HUB_URL", "https://hub.test")
+
+
+def test_push_snapshot_posts_with_token(monkeypatch):
+    captured = {}
+
+    def fake_urlopen(req, timeout=None):
+        captured["url"] = req.full_url
+        captured["method"] = req.get_method()
+        captured["body"] = req.data
+        captured["headers"] = dict(req.headers)
+        return _FakeResp(b'{"status":"ok","bytes":42,"agent_name":"lead"}')
+
+    monkeypatch.setattr(hub_client.urlrequest, "urlopen", fake_urlopen)
+    ok = hub_client.push_snapshot("lead", {"memory": "x"}, owner_host="spartan")
+    assert ok is True
+    assert captured["url"] == "https://hub.test/api/agents/lead/snapshot/"
+    assert captured["method"] == "POST"
+    body = json.loads(captured["body"])
+    assert body["token"] == "wks_test_token"
+    assert body["owner_host"] == "spartan"
+    assert body["payload"] == {"memory": "x"}
+
+
+def test_push_snapshot_returns_false_on_http_error(monkeypatch):
+    def boom(req, timeout=None):
+        raise urlerror.HTTPError(
+            req.full_url, 413, "Payload Too Large", {}, io.BytesIO(b"too big")
+        )
+
+    monkeypatch.setattr(hub_client.urlrequest, "urlopen", boom)
+    assert hub_client.push_snapshot("lead", {"x": 1}) is False
+
+
+def test_push_snapshot_no_token_is_noop(monkeypatch):
+    monkeypatch.setenv("SCITEX_AGENT_HUB_TOKEN", "")
+
+    def must_not_be_called(*a, **kw):
+        raise AssertionError("urlopen called when token is empty")
+
+    monkeypatch.setattr(hub_client.urlrequest, "urlopen", must_not_be_called)
+    assert hub_client.push_snapshot("lead", {"x": 1}) is False
+
+
+def test_fetch_snapshot_returns_payload(monkeypatch):
+    def fake(req, timeout=None):
+        assert req.get_method() == "GET"
+        assert "token=wks_test_token" in req.full_url
+        return _FakeResp(
+            json.dumps(
+                {"agent_name": "lead", "owner_host": "spartan", "payload": {"k": "v"}}
+            ).encode("utf-8")
+        )
+
+    monkeypatch.setattr(hub_client.urlrequest, "urlopen", fake)
+    out = hub_client.fetch_snapshot("lead")
+    assert out["payload"] == {"k": "v"}
+    assert out["owner_host"] == "spartan"
+
+
+def test_fetch_snapshot_404_returns_none(monkeypatch):
+    def boom(req, timeout=None):
+        raise urlerror.HTTPError(req.full_url, 404, "no", {}, io.BytesIO(b""))
+
+    monkeypatch.setattr(hub_client.urlrequest, "urlopen", boom)
+    assert hub_client.fetch_snapshot("ghost") is None
+
+
+def test_fetch_owner_returns_payload(monkeypatch):
+    def fake(req, timeout=None):
+        return _FakeResp(
+            json.dumps(
+                {
+                    "agent": "lead",
+                    "current_host": "spartan",
+                    "priority_list": ["spartan", "mba"],
+                    "healthy": {"spartan": True, "mba": False},
+                }
+            ).encode("utf-8")
+        )
+
+    monkeypatch.setattr(hub_client.urlrequest, "urlopen", fake)
+    out = hub_client.fetch_owner("lead")
+    assert out["priority_list"] == ["spartan", "mba"]
+    assert out["healthy"] == {"spartan": True, "mba": False}
+
+
+def test_fetch_owner_url_error_returns_empty(monkeypatch):
+    def boom(req, timeout=None):
+        raise urlerror.URLError("nope")
+
+    monkeypatch.setattr(hub_client.urlrequest, "urlopen", boom)
+    out = hub_client.fetch_owner("lead")
+    # On error: dict is returned with empty values so callers don't NPE.
+    assert out["priority_list"] == []
+    assert out["healthy"] == {}
+    assert out["current_host"] == ""


### PR DESCRIPTION
## Summary

sac-runtime side of ZOO#12 lead-state-handover. Companion to scitex-orochi PR [#384](https://github.com/ywatanabe1989/scitex-orochi/pull/384) (`feat/lead-state-handover-server`).

- **FR-A (snapshot/hydrate)** — new `hub_client` module (`push_snapshot`, `fetch_snapshot`, `fetch_owner`); `lifecycle.agent_start` hydrates from the hub before `runtime.start`; `lifecycle.agent_stop` pushes a sentinel snapshot before pre_stop hooks
- **FR-B (priority-failback)** — daemon thread polls `/api/agents/<name>/owner/` every 60 s; on a higher-priority host going healthy, snapshot-pushes then SIGTERMs so the local agent steps aside cleanly through the normal stop path
- **FR-E (instance UUID)** — `ensure_instance_uuid()` writes `SCITEX_AGENT_INSTANCE_UUID` into `config.env` at `agent_start` so the existing `_build_env_exports` (claude_code runtime) propagates it. Idempotent.

## Why now

`/compact` on lead caused mba's probe to mis-detect lead failure and spawn a rogue lead. The hub side (PR #384) now actually enforces `cardinality_enforced_at_hub`. This PR makes sac the cooperating client — agents send the UUID + cardinality flag on connect, and step aside automatically when a higher-priority host comes back up.

## Implementation notes

- `hub_client` is stdlib-only (`urllib`). Same auth/error pattern as `hooks._dispatch_http`.
- All hub I/O is best-effort: missing token / 404 / network errors swallow + log, never block lifecycle.
- `priority_list` and `cardinality_enforced_at_hub` are read from the spec YAML directly via a thin re-parse (`_handover._load_raw_spec`) so the canonical `AgentConfig` schema stays untouched.
- The failback poller is a no-op when `priority_list` is empty.

## Test plan

- [x] `pytest tests/test_hub_client.py tests/test_handover.py -v` — 21/21 ✅
- [x] Imports clean: `from scitex_agent_container import lifecycle, _handover, hub_client`
- [ ] Manual verification on a real fleet once the hub PR (#384) merges

Refs ZOO#12. Contributor: `c-orochi-lead-state-handover`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)