### PR TITLE
feat(config): workspace-relative python-venv and env-file in agent YAML

### DIFF
--- a/src/scitex_agent_container/config/_loaders.py
+++ b/src/scitex_agent_container/config/_loaders.py
@@ -44,14 +44,24 @@ def _name_from_path(path: Path | str) -> str:
     return Path(path).parent.name
 
 
+def _is_relative_path(p: str) -> bool:
+    """True when ``p`` is a relative path (not absolute, not ~-prefixed)."""
+    return bool(p) and not p.startswith("/") and not p.startswith("~")
+
+
 def _resolve_python_venv(venv: str | list[str] | None) -> str:
     """Resolve ``spec.python-venv`` to a single venv path on this host.
 
     Accepts:
       * empty/None: no venv activation (returns "").
       * single string: literal path; must exist or RuntimeError.
-      * list of strings: explicit fallback chain — first existing path
-        wins. If none exist, raises RuntimeError (no silent fallback).
+        Relative paths (no leading / or ~) are returned as-is and
+        resolved at start time relative to the workspace dir on the
+        target host — launcher-side existence check is skipped.
+      * list of strings: explicit fallback chain — first existing
+        absolute/home path wins; relative paths are returned at
+        first occurrence (no launcher-side check).
+        If none exist/match, raises RuntimeError.
 
     The fallback chain is intentionally per-agent (in the YAML), not a
     sac-internal default — different agents may want different chains,
@@ -61,6 +71,9 @@ def _resolve_python_venv(venv: str | list[str] | None) -> str:
         return ""
 
     if isinstance(venv, str):
+        if _is_relative_path(venv):
+            # Relative: defer existence check to target-side launch.
+            return venv
         if (Path(venv).expanduser() / "bin" / "activate").exists():
             return venv
         raise RuntimeError(
@@ -72,6 +85,9 @@ def _resolve_python_venv(venv: str | list[str] | None) -> str:
         if not all(isinstance(p, str) for p in venv):
             raise RuntimeError(f"python-venv list must contain strings, got: {venv!r}")
         for candidate in venv:
+            if _is_relative_path(candidate):
+                # First relative candidate wins immediately (resolved on target).
+                return candidate
             if (Path(candidate).expanduser() / "bin" / "activate").exists():
                 return candidate
         raise RuntimeError(
@@ -82,6 +98,28 @@ def _resolve_python_venv(venv: str | list[str] | None) -> str:
     raise RuntimeError(
         f"python-venv must be a string or list of strings, got "
         f"{type(venv).__name__}: {venv!r}"
+    )
+
+
+def _parse_env_files(spec: dict) -> list[str]:
+    """Parse ``spec.env-file`` into a normalised list of path strings.
+
+    Accepts a string (single file) or a list of strings. Paths are
+    stored verbatim; relative paths are resolved at start time relative
+    to the workspace dir on the target host.
+    """
+    raw = spec.get("env-file")
+    if not raw:
+        return []
+    if isinstance(raw, str):
+        return [raw]
+    if isinstance(raw, list):
+        if not all(isinstance(p, str) for p in raw):
+            raise RuntimeError(f"env-file list must contain strings, got: {raw!r}")
+        return list(raw)
+    raise RuntimeError(
+        f"env-file must be a string or list of strings, got "
+        f"{type(raw).__name__}: {raw!r}"
     )
 
 
@@ -183,6 +221,7 @@ def load_v3(raw: dict, path: Path) -> AgentConfig:
         workdir=workdir,
         python_venv=_resolve_python_venv(spec.get("python-venv", "")),
         env=merged_env,
+        env_files=_parse_env_files(spec),
         screen_name=screen_name,
         labels=labels,
         container=parse_container(spec),

--- a/src/scitex_agent_container/config/_types.py
+++ b/src/scitex_agent_container/config/_types.py
@@ -314,6 +314,7 @@ class AgentConfig:
     workdir: str = "~/proj"
     python_venv: str = ""  # resolved venv path (post _resolve_python_venv)
     env: dict[str, str] = field(default_factory=dict)
+    env_files: list[str] = field(default_factory=list)  # .env file paths (workspace-relative ok)
     screen_name: str = ""
     labels: dict[str, str] = field(default_factory=dict)
     container: ContainerSpec = field(default_factory=ContainerSpec)

--- a/src/scitex_agent_container/runtimes/claude_code.py
+++ b/src/scitex_agent_container/runtimes/claude_code.py
@@ -228,6 +228,18 @@ class ClaudeCodeRuntime(RuntimeBase):
             )
 
         lines = []
+        # Source .env files first so explicit env: values in YAML override them.
+        # Relative paths are resolved relative to workdir on the target host.
+        # set -a / set +a auto-exports every variable sourced from the file.
+        for env_file in config.env_files:
+            if env_file.startswith("/") or env_file.startswith("~"):
+                file_path = f'"{env_file}"'
+            else:
+                # Workspace-relative: workdir is cd'd to before this runs.
+                file_path = f'"./{env_file}"'
+            lines.append(
+                f"if [ -f {file_path} ]; then set -a; . {file_path}; set +a; fi"
+            )
         for key, value in config.env.items():
             lines.append(f'export {key}="{_resolve(str(value))}"')
         # Always export the canonical fleet hostname so downstream consumers

--- a/src/scitex_agent_container/runtimes/screen.py
+++ b/src/scitex_agent_container/runtimes/screen.py
@@ -56,7 +56,12 @@ class ScreenManager:
         """
         venv_activate = ""
         if venv:
-            activate = Path(venv).expanduser() / "bin" / "activate"
+            venv_path = Path(venv)
+            if not venv_path.is_absolute() and not venv.startswith("~"):
+                # Workspace-relative: resolve under workdir on target host.
+                activate = Path(workdir) / venv_path / "bin" / "activate"
+            else:
+                activate = venv_path.expanduser() / "bin" / "activate"
             venv_activate = f"source '{activate}' || exit 1\n"
 
         shell_script = (

--- a/src/scitex_agent_container/runtimes/tmux.py
+++ b/src/scitex_agent_container/runtimes/tmux.py
@@ -55,7 +55,12 @@ class TmuxManager:
         """
         venv_activate = ""
         if venv:
-            activate = Path(venv).expanduser() / "bin" / "activate"
+            venv_path = Path(venv)
+            if not venv_path.is_absolute() and not venv.startswith("~"):
+                # Workspace-relative: resolve under workdir on target host.
+                activate = Path(workdir) / venv_path / "bin" / "activate"
+            else:
+                activate = venv_path.expanduser() / "bin" / "activate"
             venv_activate = f"source '{activate}' || exit 1\n"
 
         shell_script = (


### PR DESCRIPTION
## Summary
- `python-venv: .venv` now works — relative paths are deferred to the target host at start time (no launcher-side check)
- New `env-file: .env` field loads dotenv files from the workspace before explicit `env:` values (later wins)
- Both accept a single path or a list with the same semantics as the existing `python-venv` fallback chain

## YAML example
```yaml
spec:
  python-venv:
    - .venv         # workspace-local (first hit wins, no launcher check)
    - ~/.venv       # host-home fallback
    - ~/.venv-3.11  # last resort
  env-file:
    - .env
    - .env.local
```

Closes ywatanabe1989/scitex-orochi#260

## Test plan
- [ ] Agent with `python-venv: .venv` starts and activates `<workdir>/.venv`
- [ ] Agent with `env-file: .env` loads variables from `<workdir>/.env`
- [ ] Explicit `env:` values override `.env` file values
- [ ] Missing `.env` file is silently skipped (not an error)
- [ ] Absolute/`~`-prefixed paths still work as before
- [ ] 606 tests pass ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)