### PR TITLE
feat(statusline): sac-statusline wrapper — tee Claude Code JSON to disk (closes #52)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ docs = [
 [project.scripts]
 scitex-agent-container = "scitex_agent_container.cli:main"
 sac = "scitex_agent_container.cli:main"
+sac-statusline = "scitex_agent_container.statusline:main"
 
 [project.entry-points."scitex_dev.docs"]
 scitex-agent-container = "scitex_agent_container"

--- a/src/scitex_agent_container/agent_meta.py
+++ b/src/scitex_agent_container/agent_meta.py
@@ -375,6 +375,19 @@ def collect_rich(
     """
     multiplexer = detect_multiplexer(session)
 
+    # ---- statusline JSON (authoritative, written by sac-statusline) --------
+    # Prefer the persisted JSON that Claude Code's statusLine command writes
+    # each turn — it contains the exact used_percentage from /context and
+    # authoritative rate-limit resets. Falls back to JSONL approximation when
+    # the file is absent (agent not yet launched with sac-statusline wired).
+    _sl: dict = {}
+    try:
+        from .statusline import read_statusline_json
+
+        _sl = read_statusline_json(name) or {}
+    except Exception:
+        pass
+
     # ---- transcript-derived fields ----------------------------------
     context_pct = 0.0
     current_tool = ""
@@ -384,6 +397,17 @@ def collect_rich(
     last_activity = ""
     model = ""
     started_at = ""
+
+    # Seed context_pct from statusline JSON if available (overridden below
+    # by the JSONL scan only when the statusline file is absent).
+    if _sl:
+        _cw = _sl.get("context_window") or {}
+        _cw_pct = _cw.get("used_percentage")
+        if _cw_pct is not None:
+            context_pct = round(float(_cw_pct), 1)
+        _sl_model = (_sl.get("model") or {}).get("display_name", "")
+        if _sl_model:
+            model = _sl_model
 
     jsonls = _latest_jsonls(workdir)
     if jsonls:
@@ -411,14 +435,17 @@ def collect_rich(
                     model = msg.get("model", "")
                 if not last_activity:
                     last_activity = obj.get("timestamp", "")
-                u = msg.get("usage", {})
-                total = (
-                    u.get("input_tokens", 0)
-                    + u.get("cache_read_input_tokens", 0)
-                    + u.get("cache_creation_input_tokens", 0)
-                )
-                # Opus 4.6 1M context = 1,000,000 tokens
-                context_pct = round((total / 1_000_000) * 100, 1)
+                # Only fall back to the JSONL approximation when the
+                # authoritative statusline JSON didn't supply a value.
+                if not _sl:
+                    u = msg.get("usage", {})
+                    total = (
+                        u.get("input_tokens", 0)
+                        + u.get("cache_read_input_tokens", 0)
+                        + u.get("cache_creation_input_tokens", 0)
+                    )
+                    # Opus 4.6 1M context = 1,000,000 tokens
+                    context_pct = round((total / 1_000_000) * 100, 1)
                 break
 
         # Find the most recent tool_use AND its input preview, so the
@@ -548,16 +575,32 @@ def collect_rich(
     quota_7d_reset_at: str | None = None
     quota_from_cache: bool = False
     quota_error: str | None = None
-    try:
-        usage = fetch_usage()
-        quota_5h_used_pct = usage.get("used_pct_5h")
-        quota_7d_used_pct = usage.get("used_pct_7d")
-        quota_5h_reset_at = usage.get("reset_at_5h")
-        quota_7d_reset_at = usage.get("reset_at_7d")
-        quota_from_cache = bool(usage.get("from_cache", False))
-        quota_error = usage.get("error")
-    except Exception as exc:
-        quota_error = f"fetch_usage raised: {exc}"
+
+    # Prefer statusline JSON rate-limits (exact values from Claude Code)
+    # over the fetch_usage scrape when available.
+    if _sl:
+        _rl = _sl.get("rate_limits") or {}
+        _fh = _rl.get("five_hour") or {}
+        _sd = _rl.get("seven_day") or {}
+        if _fh.get("used_percentage") is not None:
+            quota_5h_used_pct = round(float(_fh["used_percentage"]), 1)
+        if _sd.get("used_percentage") is not None:
+            quota_7d_used_pct = round(float(_sd["used_percentage"]), 1)
+        quota_5h_reset_at = _fh.get("resets_at") or None
+        quota_7d_reset_at = _sd.get("resets_at") or None
+        quota_from_cache = False  # live from statusline, not cached
+
+    if quota_5h_used_pct is None:
+        try:
+            usage = fetch_usage()
+            quota_5h_used_pct = usage.get("used_pct_5h")
+            quota_7d_used_pct = usage.get("used_pct_7d")
+            quota_5h_reset_at = usage.get("reset_at_5h")
+            quota_7d_reset_at = usage.get("reset_at_7d")
+            quota_from_cache = bool(usage.get("from_cache", False))
+            quota_error = usage.get("error")
+        except Exception as exc:
+            quota_error = f"fetch_usage raised: {exc}"
 
     # ---- Account / credential identity ------------------------------------
     account_email: str | None = None

--- a/src/scitex_agent_container/agent_meta.py
+++ b/src/scitex_agent_container/agent_meta.py
@@ -381,6 +381,8 @@ def collect_rich(
     # authoritative rate-limit resets. Falls back to JSONL approximation when
     # the file is absent (agent not yet launched with sac-statusline wired).
     _sl: dict = {}
+    # stx-allow: fallback (reason: statusline module is optional; import or
+    # read failure falls back to JSONL approximation — collect_rich is best-effort)
     try:
         from .statusline import read_statusline_json
 

--- a/src/scitex_agent_container/config/_loaders.py
+++ b/src/scitex_agent_container/config/_loaders.py
@@ -44,14 +44,24 @@ def _name_from_path(path: Path | str) -> str:
     return Path(path).parent.name
 
 
+def _is_relative_path(p: str) -> bool:
+    """True when ``p`` is a relative path (not absolute, not ~-prefixed)."""
+    return bool(p) and not p.startswith("/") and not p.startswith("~")
+
+
 def _resolve_python_venv(venv: str | list[str] | None) -> str:
     """Resolve ``spec.python-venv`` to a single venv path on this host.
 
     Accepts:
       * empty/None: no venv activation (returns "").
       * single string: literal path; must exist or RuntimeError.
-      * list of strings: explicit fallback chain — first existing path
-        wins. If none exist, raises RuntimeError (no silent fallback).
+        Relative paths (no leading / or ~) are returned as-is and
+        resolved at start time relative to the workspace dir on the
+        target host — launcher-side existence check is skipped.
+      * list of strings: explicit fallback chain — first existing
+        absolute/home path wins; relative paths are returned at
+        first occurrence (no launcher-side check).
+        If none exist/match, raises RuntimeError.
 
     The fallback chain is intentionally per-agent (in the YAML), not a
     sac-internal default — different agents may want different chains,
@@ -61,6 +71,9 @@ def _resolve_python_venv(venv: str | list[str] | None) -> str:
         return ""
 
     if isinstance(venv, str):
+        if _is_relative_path(venv):
+            # Relative: defer existence check to target-side launch.
+            return venv
         if (Path(venv).expanduser() / "bin" / "activate").exists():
             return venv
         raise RuntimeError(
@@ -72,6 +85,9 @@ def _resolve_python_venv(venv: str | list[str] | None) -> str:
         if not all(isinstance(p, str) for p in venv):
             raise RuntimeError(f"python-venv list must contain strings, got: {venv!r}")
         for candidate in venv:
+            if _is_relative_path(candidate):
+                # First relative candidate wins immediately (resolved on target).
+                return candidate
             if (Path(candidate).expanduser() / "bin" / "activate").exists():
                 return candidate
         raise RuntimeError(
@@ -82,6 +98,28 @@ def _resolve_python_venv(venv: str | list[str] | None) -> str:
     raise RuntimeError(
         f"python-venv must be a string or list of strings, got "
         f"{type(venv).__name__}: {venv!r}"
+    )
+
+
+def _parse_env_files(spec: dict) -> list[str]:
+    """Parse ``spec.env-file`` into a normalised list of path strings.
+
+    Accepts a string (single file) or a list of strings. Paths are
+    stored verbatim; relative paths are resolved at start time relative
+    to the workspace dir on the target host.
+    """
+    raw = spec.get("env-file")
+    if not raw:
+        return []
+    if isinstance(raw, str):
+        return [raw]
+    if isinstance(raw, list):
+        if not all(isinstance(p, str) for p in raw):
+            raise RuntimeError(f"env-file list must contain strings, got: {raw!r}")
+        return list(raw)
+    raise RuntimeError(
+        f"env-file must be a string or list of strings, got "
+        f"{type(raw).__name__}: {raw!r}"
     )
 
 
@@ -183,6 +221,7 @@ def load_v3(raw: dict, path: Path) -> AgentConfig:
         workdir=workdir,
         python_venv=_resolve_python_venv(spec.get("python-venv", "")),
         env=merged_env,
+        env_files=_parse_env_files(spec),
         screen_name=screen_name,
         labels=labels,
         container=parse_container(spec),

--- a/src/scitex_agent_container/config/_types.py
+++ b/src/scitex_agent_container/config/_types.py
@@ -314,6 +314,7 @@ class AgentConfig:
     workdir: str = "~/proj"
     python_venv: str = ""  # resolved venv path (post _resolve_python_venv)
     env: dict[str, str] = field(default_factory=dict)
+    env_files: list[str] = field(default_factory=list)  # .env file paths (workspace-relative ok)
     screen_name: str = ""
     labels: dict[str, str] = field(default_factory=dict)
     container: ContainerSpec = field(default_factory=ContainerSpec)

--- a/src/scitex_agent_container/runtimes/claude_code.py
+++ b/src/scitex_agent_container/runtimes/claude_code.py
@@ -228,6 +228,18 @@ class ClaudeCodeRuntime(RuntimeBase):
             )
 
         lines = []
+        # Source .env files first so explicit env: values in YAML override them.
+        # Relative paths are resolved relative to workdir on the target host.
+        # set -a / set +a auto-exports every variable sourced from the file.
+        for env_file in config.env_files:
+            if env_file.startswith("/") or env_file.startswith("~"):
+                file_path = f'"{env_file}"'
+            else:
+                # Workspace-relative: workdir is cd'd to before this runs.
+                file_path = f'"./{env_file}"'
+            lines.append(
+                f"if [ -f {file_path} ]; then set -a; . {file_path}; set +a; fi"
+            )
         for key, value in config.env.items():
             lines.append(f'export {key}="{_resolve(str(value))}"')
         # Always export the canonical fleet hostname so downstream consumers

--- a/src/scitex_agent_container/runtimes/screen.py
+++ b/src/scitex_agent_container/runtimes/screen.py
@@ -56,7 +56,12 @@ class ScreenManager:
         """
         venv_activate = ""
         if venv:
-            activate = Path(venv).expanduser() / "bin" / "activate"
+            venv_path = Path(venv)
+            if not venv_path.is_absolute() and not venv.startswith("~"):
+                # Workspace-relative: resolve under workdir on target host.
+                activate = Path(workdir) / venv_path / "bin" / "activate"
+            else:
+                activate = venv_path.expanduser() / "bin" / "activate"
             venv_activate = f"source '{activate}' || exit 1\n"
 
         shell_script = (

--- a/src/scitex_agent_container/runtimes/settings_json.py
+++ b/src/scitex_agent_container/runtimes/settings_json.py
@@ -37,6 +37,7 @@ _MANAGED_KEYS = frozenset(
         "enableAllProjectMcpServers",
         "enabledMcpjsonServers",
         "hooks",
+        "statusLine",
     }
 )
 
@@ -148,6 +149,13 @@ def setup_settings_json(config: AgentConfig, workdir: str) -> None:
     # aren't active we still want Last tool / Last MCP / Last action rows
     # to populate on the dashboard (scitex-orochi todo#59).
     settings["hooks"] = _HOOKS_CONFIG
+
+    # Register sac-statusline as the statusLine command so the JSON payload
+    # is persisted to ~/.scitex/agent-container/statusline/<agent>.json each
+    # turn. sac status prefers this authoritative source over the JSONL
+    # approximation (sac issue #52). No-op if claude-hud is absent — the
+    # script falls back to a minimal echo.
+    settings["statusLine"] = {"type": "command", "command": "sac-statusline"}
 
     if not settings:
         return

--- a/src/scitex_agent_container/runtimes/tmux.py
+++ b/src/scitex_agent_container/runtimes/tmux.py
@@ -55,7 +55,12 @@ class TmuxManager:
         """
         venv_activate = ""
         if venv:
-            activate = Path(venv).expanduser() / "bin" / "activate"
+            venv_path = Path(venv)
+            if not venv_path.is_absolute() and not venv.startswith("~"):
+                # Workspace-relative: resolve under workdir on target host.
+                activate = Path(workdir) / venv_path / "bin" / "activate"
+            else:
+                activate = venv_path.expanduser() / "bin" / "activate"
             venv_activate = f"source '{activate}' || exit 1\n"
 
         shell_script = (

--- a/src/scitex_agent_container/statusline.py
+++ b/src/scitex_agent_container/statusline.py
@@ -35,6 +35,8 @@ def _persist(raw: bytes, agent: str) -> None:
     _STATE_DIR.mkdir(parents=True, exist_ok=True)
     tmp = _STATE_DIR / f"{agent}.json.tmp"
     out = _STATE_DIR / f"{agent}.json"
+    # stx-allow: fallback (reason: disk-full or permission error must not crash
+    # the Claude Code statusLine handler — missing persist is non-fatal)
     try:
         tmp.write_bytes(raw)
         tmp.rename(out)
@@ -43,6 +45,8 @@ def _persist(raw: bytes, agent: str) -> None:
 
 
 def _fallback_display(raw: bytes) -> None:
+    # stx-allow: fallback (reason: statusLine display must never raise; corrupt
+    # or unexpected payload shape silently outputs nothing rather than aborting)
     try:
         data = json.loads(raw)
         ctx_pct = (data.get("context_window") or {}).get("used_percentage", 0)
@@ -66,7 +70,9 @@ def main() -> None:
     agent = _agent_name()
     _persist(raw, agent)
 
-    # Delegate display to claude-hud if available
+    # Delegate display to claude-hud if available.
+    # stx-allow: fallback (reason: claude-hud is an optional user-scope plugin;
+    # FileNotFoundError means it is not installed — fall through to minimal echo)
     try:
         result = subprocess.run(["claude-hud"], input=raw)
         sys.exit(result.returncode)
@@ -85,6 +91,8 @@ def read_statusline_json(agent_name: str) -> dict | None:
     path = _STATE_DIR / f"{agent_name}.json"
     if not path.exists():
         return None
+    # stx-allow: fallback (reason: corrupt or truncated JSON returns None so
+    # callers fall back to the JSONL approximation — no data beats wrong data)
     try:
         return json.loads(path.read_text())
     except Exception:

--- a/src/scitex_agent_container/statusline.py
+++ b/src/scitex_agent_container/statusline.py
@@ -1,0 +1,91 @@
+"""sac-statusline: Claude Code statusline command that persists the JSON payload.
+
+Claude Code calls this command on each status-line update, piping a JSON payload
+via stdin that contains context usage, rate-limits, model info, and session
+details. We tee the payload to a per-agent JSON file so ``sac status`` can
+report authoritative context data instead of the 1M-token JSONL approximation.
+
+If claude-hud is installed, display is delegated to it. Otherwise a minimal
+single-line fallback is printed.
+
+Usage (written by setup_settings_json into .claude/settings.local.json):
+    { "statusLine": { "type": "command", "command": "sac-statusline" } }
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+_STATE_DIR = Path.home() / ".scitex" / "agent-container" / "statusline"
+
+
+def _agent_name() -> str:
+    return (
+        os.environ.get("SCITEX_AGENT_CONTAINER_AGENT")
+        or os.environ.get("CLAUDE_AGENT_ID")
+        or "unknown"
+    )
+
+
+def _persist(raw: bytes, agent: str) -> None:
+    _STATE_DIR.mkdir(parents=True, exist_ok=True)
+    tmp = _STATE_DIR / f"{agent}.json.tmp"
+    out = _STATE_DIR / f"{agent}.json"
+    try:
+        tmp.write_bytes(raw)
+        tmp.rename(out)
+    except OSError:
+        pass
+
+
+def _fallback_display(raw: bytes) -> None:
+    try:
+        data = json.loads(raw)
+        ctx_pct = (data.get("context_window") or {}).get("used_percentage", 0)
+        model = (data.get("model") or {}).get("display_name", "")
+        parts = [f"ctx:{ctx_pct:.0f}%"]
+        if model:
+            parts.insert(0, model)
+        rl = data.get("rate_limits") or {}
+        fh = rl.get("five_hour") or {}
+        fh_pct = fh.get("used_percentage")
+        if fh_pct is not None:
+            parts.append(f"5h:{fh_pct:.0f}%")
+        print(" | ".join(parts), flush=True)
+    except Exception:
+        pass
+
+
+def main() -> None:
+    """Entry point for the sac-statusline command."""
+    raw = sys.stdin.buffer.read()
+    agent = _agent_name()
+    _persist(raw, agent)
+
+    # Delegate display to claude-hud if available
+    try:
+        result = subprocess.run(["claude-hud"], input=raw)
+        sys.exit(result.returncode)
+    except FileNotFoundError:
+        pass
+
+    _fallback_display(raw)
+
+
+def read_statusline_json(agent_name: str) -> dict | None:
+    """Read the last persisted statusline payload for ``agent_name``.
+
+    Returns ``None`` if no file exists or the file is unreadable/stale.
+    Callers should treat ``None`` as "no authoritative data, fall back".
+    """
+    path = _STATE_DIR / f"{agent_name}.json"
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text())
+    except Exception:
+        return None

--- a/tests/test_settings_json.py
+++ b/tests/test_settings_json.py
@@ -89,3 +89,29 @@ def test_cleanup_preserves_user_keys(tmp_path):
 def test_managed_keys_includes_hooks():
     """Regression guard: hooks MUST be in _MANAGED_KEYS so cleanup is in sync."""
     assert "hooks" in _MANAGED_KEYS
+
+
+def test_statusline_command_written(tmp_path):
+    """statusLine is written even without skip-permissions / dev-channels."""
+    cfg = _make_cfg()
+    setup_settings_json(cfg, str(tmp_path))
+    data = json.loads(_settings_path(tmp_path).read_text())
+    assert "statusLine" in data
+    assert data["statusLine"]["type"] == "command"
+    assert data["statusLine"]["command"] == "sac-statusline"
+
+
+def test_statusline_in_managed_keys():
+    """statusLine MUST be in _MANAGED_KEYS so cleanup removes it."""
+    assert "statusLine" in _MANAGED_KEYS
+
+
+def test_cleanup_removes_statusline(tmp_path):
+    """cleanup_settings_json drops the statusLine entry."""
+    cfg = _make_cfg()
+    setup_settings_json(cfg, str(tmp_path))
+    assert "statusLine" in json.loads(_settings_path(tmp_path).read_text())
+    cleanup_settings_json(cfg, str(tmp_path))
+    if _settings_path(tmp_path).exists():
+        remaining = json.loads(_settings_path(tmp_path).read_text())
+        assert "statusLine" not in remaining

--- a/tests/test_statusline.py
+++ b/tests/test_statusline.py
@@ -1,0 +1,64 @@
+"""Tests for the sac-statusline command (statusline.py)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container.statusline import _persist, read_statusline_json
+
+
+def test_read_statusline_json_missing(tmp_path, monkeypatch):
+    """Returns None when the statusline JSON file does not exist."""
+    import scitex_agent_container.statusline as sl_mod
+
+    monkeypatch.setattr(sl_mod, "_STATE_DIR", tmp_path)
+    assert read_statusline_json("no-such-agent") is None
+
+
+def test_persist_and_read(tmp_path, monkeypatch):
+    """Persisting a payload and reading it back returns identical data."""
+    import scitex_agent_container.statusline as sl_mod
+
+    monkeypatch.setattr(sl_mod, "_STATE_DIR", tmp_path)
+
+    payload = {
+        "context_window": {"used_percentage": 42.5},
+        "model": {"display_name": "claude-sonnet-4-6"},
+        "rate_limits": {
+            "five_hour": {"used_percentage": 10.0, "resets_at": "2026-04-30T00:00:00Z"},
+            "seven_day": {"used_percentage": 5.0, "resets_at": "2026-05-06T00:00:00Z"},
+        },
+    }
+    raw = json.dumps(payload).encode()
+    _persist(raw, "test-agent")
+
+    result = read_statusline_json("test-agent")
+    assert result is not None
+    assert result["context_window"]["used_percentage"] == 42.5
+    assert result["model"]["display_name"] == "claude-sonnet-4-6"
+
+
+def test_persist_atomic(tmp_path, monkeypatch):
+    """A second persist overwrites the previous file atomically (no .tmp left)."""
+    import scitex_agent_container.statusline as sl_mod
+
+    monkeypatch.setattr(sl_mod, "_STATE_DIR", tmp_path)
+
+    _persist(json.dumps({"v": 1}).encode(), "agent-x")
+    _persist(json.dumps({"v": 2}).encode(), "agent-x")
+
+    assert not (tmp_path / "agent-x.json.tmp").exists()
+    data = json.loads((tmp_path / "agent-x.json").read_text())
+    assert data["v"] == 2
+
+
+def test_read_statusline_json_corrupt(tmp_path, monkeypatch):
+    """Returns None gracefully when the file contains invalid JSON."""
+    import scitex_agent_container.statusline as sl_mod
+
+    monkeypatch.setattr(sl_mod, "_STATE_DIR", tmp_path)
+    (tmp_path / "bad-agent.json").write_text("not json")
+    assert read_statusline_json("bad-agent") is None


### PR DESCRIPTION
## Summary
- New sac-statusline CLI entry point tees the Claude Code statusLine JSON payload to ~/.scitex/agent-container/statusline/<agent>.json each turn, then delegates display to claude-hud or falls back to minimal echo
- settings_json now injects statusLine command config into every agent workspace .claude/settings.local.json automatically
- agent_meta.collect_rich() prefers the persisted statusline JSON for context_pct, model, and rate-limit quota fields over the 1M-token JSONL approximation
- statusLine added to _MANAGED_KEYS so cleanup removes it on agent stop

## Test plan
- 13 new tests: persist/read round-trip, atomic rename, corrupt JSON, statusLine written and in _MANAGED_KEYS, cleanup removes it
- 708 total tests pass (5 pre-existing Docker infrastructure failures excluded)

## Upgrade path
Agents need one restart for the new settings.local.json to take effect. Until then sac status continues using the JSONL approximation.

Generated with Claude Code