### PR TITLE
chore(#71): complete stx-allow:fallback annotation sweep — all except Exception blocks (34 files, 165 lines)

### DIFF
--- a/src/scitex_agent_container/a2a/_server.py
+++ b/src/scitex_agent_container/a2a/_server.py
@@ -190,6 +190,7 @@ def _build_app(ctx: _ServerCtx) -> Starlette:
         dispatcher = ctx.dispatchers.get(name)
         if dispatcher is None:
             return JSONResponse({"error": f"unknown agent: {name}"}, status_code=404)
+        # stx-allow: fallback (reason: observability endpoint must not crash the server; returns 500 with details instead)
         try:
             tasks = await dispatcher.snapshot_active_tasks()
         except Exception as exc:  # pragma: no cover — defense in depth

--- a/src/scitex_agent_container/a2a/executors/_base.py
+++ b/src/scitex_agent_container/a2a/executors/_base.py
@@ -94,6 +94,7 @@ class BaseSyncExecutor(AgentExecutor):
                 message=_agent_text_message(str(exc), task_id, context_id)
             )
             return
+        # stx-allow: fallback (reason: unhandled executor crash is reported as a failed task rather than propagating and breaking the event loop)
         except Exception as exc:  # noqa: BLE001
             log.exception("a2a executor %r crashed", self.handler_key)
             await updater.failed(

--- a/src/scitex_agent_container/account_store.py
+++ b/src/scitex_agent_container/account_store.py
@@ -47,6 +47,7 @@ def list_accounts(
     if not store.is_dir():
         return accounts
     for meta_file in sorted(store.glob("*.json")):
+        # stx-allow: fallback (reason: individual account JSON may be corrupt or unreadable; skipping it keeps the rest of the list intact)
         try:
             with meta_file.open("r", encoding="utf-8") as fh:
                 data = json.load(fh)
@@ -145,6 +146,7 @@ def switch_account(
         }
 
     claude_dir = _home / ".claude"
+    # stx-allow: fallback (reason: ~/.claude/ may be on a read-only filesystem or a tmp copy may fail mid-flight; returning a failure dict is preferable to an unhandled exception)
     try:
         claude_dir.mkdir(parents=True, exist_ok=True)
         for src in cred_dir.iterdir():

--- a/src/scitex_agent_container/action_base.py
+++ b/src/scitex_agent_container/action_base.py
@@ -255,6 +255,7 @@ def run_action(
         return attempt
 
     # Pre-snapshot (if this fails the action is unrunnable).
+    # stx-allow: fallback (reason: pane capture or context-pct read can raise on transient mux errors; SEND_ERROR is the only safe outcome when the pre-state is unknown)
     try:
         before = action.snapshot(ctx)
     except Exception as exc:  # pragma: no cover - defensive
@@ -276,6 +277,7 @@ def run_action(
         return _finish(ActionOutcome.PRECONDITION_FAIL, before, None)
 
     # Send.
+    # stx-allow: fallback (reason: mux keystroke emission or SSH call can fail; SEND_ERROR with the error captured in extras is the correct terminal outcome — no polling should follow a failed send)
     try:
         action.before_send(ctx)
         action.send(ctx)
@@ -289,6 +291,7 @@ def run_action(
     now_snap = before  # default if we never poll (timeout_s <= 0)
     while True:
         current = time_fn()
+        # stx-allow: fallback (reason: snapshot during polling can fail transiently if the pane is briefly unavailable; retaining the previous snapshot lets is_complete keep evaluating rather than aborting the poll loop)
         try:
             now_snap = action.snapshot(ctx)
         except Exception as exc:  # pragma: no cover - defensive
@@ -298,6 +301,7 @@ def run_action(
                 exc,
             )
             # Keep the previous snapshot so is_complete sees something.
+        # stx-allow: fallback (reason: subclass is_complete can raise if snapshot fields have unexpected shape; treating as not-done keeps the poll loop alive rather than crashing the engine)
         try:
             done = action.is_complete(before, now_snap)
         except Exception as exc:  # pragma: no cover - defensive

--- a/src/scitex_agent_container/action_store.py
+++ b/src/scitex_agent_container/action_store.py
@@ -173,6 +173,7 @@ def append_attempt(
     pane_before = _truncate_snapshot(record.get("pane_before"))
     pane_after = _truncate_snapshot(record.get("pane_after"))
     extras = record.get("extras") or {}
+    # stx-allow: fallback (reason: DB insert can fail due to disk full, file lock, or corrupt schema; swallowing keeps agent alive per fail-closed design)
     try:
         conn = _get_conn(_db_path(root))
         try:
@@ -275,6 +276,7 @@ def query(
         + " ORDER BY ts DESC, id DESC LIMIT ? OFFSET ?"
     )
     params.extend([int(limit), int(offset)])
+    # stx-allow: fallback (reason: DB read can fail due to missing file, lock contention, or I/O error; empty list is a safe no-results response)
     try:
         conn = _get_conn(_db_path(root))
         try:
@@ -319,6 +321,7 @@ def stats(
         "ORDER BY action ASC, count DESC"
     )
     sql_samples = "SELECT action, outcome, elapsed_s FROM attempts" + where
+    # stx-allow: fallback (reason: DB read can fail due to missing file, lock contention, or I/O error; empty list means no stats available, which is acceptable for a best-effort summary)
     try:
         conn = _get_conn(_db_path(root))
         try:
@@ -422,6 +425,7 @@ def purge_old(
     rows deleted. Safe to call periodically from a cron / daemon."""
     d = int(days) if days is not None else DEFAULT_RETENTION_DAYS
     cutoff = (datetime.now(timezone.utc) - timedelta(days=d)).isoformat()
+    # stx-allow: fallback (reason: DB delete can fail due to disk error or lock; returning 0 is safe since purge is maintenance-only and a missed run leaves stale rows that will be retried next call)
     try:
         conn = _get_conn(_db_path(root))
         try:
@@ -438,6 +442,7 @@ def purge_old(
 
 def _all_rows(root: Path | None = None) -> Iterable[dict[str, Any]]:
     """Iterator over every row — used by tests / export tooling."""
+    # stx-allow: fallback (reason: DB read can fail due to missing file or I/O error; empty iterable is safe since _all_rows is used by tests/export tooling where no results is a valid outcome)
     try:
         conn = _get_conn(_db_path(root))
         try:

--- a/src/scitex_agent_container/agent_meta.py
+++ b/src/scitex_agent_container/agent_meta.py
@@ -62,6 +62,8 @@ def _encode_claude_project(workdir: str) -> str:
 
 def _latest_jsonls(workdir: str) -> list[Path]:
     # Claude Code encodes the *resolved* cwd, so follow symlinks first.
+    # stx-allow: fallback (reason: broken symlink or cross-device path can
+    # raise — raw workdir string is an acceptable fallback for encoding)
     try:
         resolved = str(Path(workdir).expanduser().resolve())
     except Exception:
@@ -69,6 +71,8 @@ def _latest_jsonls(workdir: str) -> list[Path]:
     proj_dir = Path.home() / ".claude" / "projects" / _encode_claude_project(resolved)
     if not proj_dir.is_dir():
         return []
+    # stx-allow: fallback (reason: concurrent file deletion between glob and
+    # stat() causes OSError — return empty list rather than raising)
     try:
         return sorted(
             proj_dir.glob("*.jsonl"),
@@ -82,6 +86,8 @@ def _latest_jsonls(workdir: str) -> list[Path]:
 def _parse_skills(workdir: str) -> list[str]:
     """Parse ```skills fenced code block from workspace CLAUDE.md."""
     skills: list[str] = []
+    # stx-allow: fallback (reason: CLAUDE.md may be absent or unreadable;
+    # empty skills list is an acceptable result for unconfigured agents)
     try:
         cmd = Path(workdir) / "CLAUDE.md"
         if cmd.is_file():
@@ -121,6 +127,8 @@ def parse_subagent_count_from_pane_text(pane: str) -> int:
 def _subagent_count_from_pane(session: str, multiplexer: str) -> int:
     if multiplexer != "tmux":
         return 0
+    # stx-allow: fallback (reason: session may not exist yet; 0 is the
+    # correct "unknown" sentinel — never block a heartbeat on tmux error)
     try:
         pane = subprocess.run(
             ["tmux", "capture-pane", "-t", session, "-p"],
@@ -136,6 +144,8 @@ def _capture_pane(session: str, multiplexer: str, max_chars: int = 10000) -> str
     """Return the current tmux pane contents, truncated. Empty on error."""
     if multiplexer != "tmux":
         return ""
+    # stx-allow: fallback (reason: session may have exited between the
+    # has-session check and capture-pane — empty string is safe for callers)
     try:
         out = (
             subprocess.run(
@@ -258,6 +268,8 @@ def _config_candidates(workdir: str, filename: str) -> list[Path]:
         cands += [p / filename, p / ".claude" / filename]
         if p.parent.name == "workspaces":
             cands.append(p.parent / f"mamba-{p.name}" / filename)
+        # stx-allow: fallback (reason: git root walk can fail on pathological
+        # filesystems — missing git root just skips that candidate)
         try:
             git_root = p
             while git_root != git_root.parent and not (git_root / ".git").exists():
@@ -281,6 +293,8 @@ def _config_candidates(workdir: str, filename: str) -> list[Path]:
 
 def _read_claude_md(workdir: str, max_chars: int = 20000) -> str:
     for p in _config_candidates(workdir, "CLAUDE.md"):
+        # stx-allow: fallback (reason: permission error on one candidate
+        # must not prevent trying the next — best-effort file read)
         try:
             if not p.is_file():
                 continue
@@ -308,12 +322,16 @@ def _redact_mcp_tree(obj):
 
 def _read_mcp_json(workdir: str, max_chars: int = 10000) -> str:
     for p in _config_candidates(workdir, ".mcp.json"):
+        # stx-allow: fallback (reason: permission error on one candidate
+        # must not prevent trying the next — best-effort file read)
         try:
             if not p.is_file():
                 continue
             raw = p.read_text(errors="replace")
         except Exception:
             continue
+        # stx-allow: fallback (reason: corrupt JSON falls back to raw-with-
+        # redaction rather than raising — collect_rich is best-effort)
         try:
             doc = json.loads(raw)
             pretty = json.dumps(_redact_mcp_tree(doc), indent=2)
@@ -328,6 +346,8 @@ def _pids_from_session(session: str, multiplexer: str) -> tuple[int, int]:
     ppid = 0
     if multiplexer != "tmux":
         return pid, ppid
+    # stx-allow: fallback (reason: tmux session may not exist yet or pgrep
+    # may return no results — pid/ppid of 0 is a valid "unknown" sentinel)
     try:
         out = (
             subprocess.run(
@@ -413,6 +433,8 @@ def collect_rich(
 
     jsonls = _latest_jsonls(workdir)
     if jsonls:
+        # stx-allow: fallback (reason: stat() can race with file deletion;
+        # missing started_at is acceptable — field stays empty)
         try:
             earliest = min(jsonls, key=lambda p: p.stat().st_mtime)
             started_at = datetime.fromtimestamp(
@@ -421,12 +443,16 @@ def collect_rich(
         except Exception:
             pass
 
+        # stx-allow: fallback (reason: JSONL may be unreadable mid-rotate;
+        # empty lines list means no transcript fields — non-fatal)
         try:
             lines = jsonls[0].read_text().splitlines()[-50:]
         except Exception:
             lines = []
 
         for line in reversed(lines):
+            # stx-allow: fallback (reason: individual JSONL lines may be
+            # truncated mid-write; skip invalid lines and keep scanning)
             try:
                 obj = json.loads(line)
             except Exception:
@@ -454,6 +480,8 @@ def collect_rich(
         # dashboard can show "Bash: docker compose build" instead of just
         # "Bash". Per ywatanabe complaint msg 5481.
         for line in reversed(lines):
+            # stx-allow: fallback (reason: truncated JSONL line during rotation;
+            # skip and keep scanning for last valid tool_use)
             try:
                 obj = json.loads(line)
             except Exception:
@@ -497,6 +525,8 @@ def collect_rich(
         # "what was this agent last asked to do" snippet which is more
         # meaningful than the tool name alone.
         for line in reversed(lines):
+            # stx-allow: fallback (reason: truncated JSONL line during rotation;
+            # skip and keep scanning for last valid user message)
             try:
                 obj = json.loads(line)
             except Exception:
@@ -550,6 +580,8 @@ def collect_rich(
     # Populated by `scitex-agent-container hook-event` entries wired into
     # the agent's .claude/settings.local.json. Non-agentic: pure ring-
     # buffer read.
+    # stx-allow: fallback (reason: event_log DB may not exist on agents that
+    # haven't run a hook yet — empty summary is a valid initial state)
     try:
         from .event_log import summarize as _summarize_events
 
@@ -563,6 +595,8 @@ def collect_rich(
             "counts": {},
         }
     # Use canonical fleet name (e.g. "nas" instead of "DXP480TPLUS-994")
+    # stx-allow: fallback (reason: resolve_hostname reads a YAML that may be
+    # absent on unconfigured hosts — raw gethostname is an acceptable fallback)
     try:
         from .config._host import resolve_hostname
 
@@ -593,6 +627,8 @@ def collect_rich(
         quota_from_cache = False  # live from statusline, not cached
 
     if quota_5h_used_pct is None:
+        # stx-allow: fallback (reason: fetch_usage may fail on network timeout
+        # or missing credentials; quota_error captures the reason for callers)
         try:
             usage = fetch_usage()
             quota_5h_used_pct = usage.get("used_pct_5h")
@@ -606,6 +642,8 @@ def collect_rich(
 
     # ---- Account / credential identity ------------------------------------
     account_email: str | None = None
+    # stx-allow: fallback (reason: credentials file absent on freshly
+    # provisioned agents — account_email stays None until auth completes)
     try:
         from .credentials import read_credentials_metadata
 
@@ -615,6 +653,8 @@ def collect_rich(
         pass
 
     # ---- Machine resource metrics (psutil, optional) -----------------------
+    # stx-allow: fallback (reason: psutil is an optional dependency; absent
+    # on minimal installs — metrics dict stays empty, dashboard handles it)
     try:
         import psutil as _psutil
 
@@ -727,6 +767,8 @@ def _collect_action_summary_fields(agent_name: str) -> dict[str, Any]:
     heartbeat. All keys are prefixed ``action_`` so consumers know
     which subsystem they came from.
     """
+    # stx-allow: fallback (reason: actions.db may be absent or corrupt;
+    # empty action summary never blocks a heartbeat — fail-open by design)
     try:
         from . import action_store
 

--- a/src/scitex_agent_container/auto_response.py
+++ b/src/scitex_agent_container/auto_response.py
@@ -196,6 +196,7 @@ class AutoResponseScheduler:
         # agent, and compacting first keeps the subsequent probe
         # cheap.
         ctx_pct = None
+        # stx-allow: fallback (reason: context_pct_fn reads tmux/pane state that may be unavailable; None disables compaction for this tick, which is safe)
         try:
             ctx_pct = ctx.context_pct_fn()
         except Exception:
@@ -241,6 +242,7 @@ class AutoResponseScheduler:
         """
         start = self._time()
         while True:
+            # stx-allow: fallback (reason: a single tick may fail due to transient mux/session errors; logging and continuing keeps the scheduler alive across intermittent failures)
             try:
                 self.tick()
             except Exception as exc:  # pragma: no cover - defensive

--- a/src/scitex_agent_container/claude_usage.py
+++ b/src/scitex_agent_container/claude_usage.py
@@ -87,6 +87,7 @@ def _iso_now() -> str:
 
 def _load_json(path: Path) -> dict[str, Any] | None:
     """Load JSON file; return None on any error."""
+    # stx-allow: fallback (reason: credentials or cache file may not exist or may be corrupt; None signals caller to skip caching)
     try:
         with path.open("r", encoding="utf-8") as fh:
             data = json.load(fh)
@@ -169,6 +170,7 @@ def _refresh_access_token(
         headers={"Content-Type": "application/json"},
         method="POST",
     )
+    # stx-allow: fallback (reason: token refresh endpoint may be unreachable or return malformed JSON; None causes caller to proceed with the old token)
     try:
         with urllib.request.urlopen(req, timeout=15) as resp:
             raw = resp.read()
@@ -183,6 +185,7 @@ def _refresh_access_token(
 
     # Atomically update the credentials file.
     creds_path = _credentials_path(home)
+    # stx-allow: fallback (reason: credentials file may be read-only or locked by another process; new access token is still usable in memory even if disk write fails)
     try:
         with open(creds_path, "r+", encoding="utf-8") as fh:
             fcntl.flock(fh, fcntl.LOCK_EX)
@@ -223,6 +226,7 @@ def _read_cache(home: Path) -> dict[str, Any] | None:
     fetched_at_str = data.get("fetched_at")
     if not isinstance(fetched_at_str, str):
         return None
+    # stx-allow: fallback (reason: cache file may contain a malformed timestamp; returning None forces a fresh API fetch)
     try:
         fetched_at = datetime.fromisoformat(fetched_at_str)
         if fetched_at.tzinfo is None:
@@ -239,6 +243,7 @@ def _read_cache(home: Path) -> dict[str, Any] | None:
 def _write_cache(home: Path, result: dict[str, Any]) -> None:
     """Write result to cache file (best-effort, never raises)."""
     path = _cache_path(home)
+    # stx-allow: fallback (reason: ~/.scitex/cache/ may be on a read-only filesystem or disk-full; cache is a performance optimisation and callers are unaffected)
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
         tmp = Path(str(path) + ".tmp")
@@ -265,6 +270,7 @@ def _fetch_from_api(access_token: str) -> list[dict[str, Any]] | None:
         headers={"Authorization": f"Bearer {access_token}"},
         method="GET",
     )
+    # stx-allow: fallback (reason: network timeout or DNS failure hitting api.anthropic.com; None tells caller quota is unavailable, error returned to user)
     try:
         with urllib.request.urlopen(req, timeout=15) as resp:
             raw = resp.read()
@@ -275,6 +281,7 @@ def _fetch_from_api(access_token: str) -> list[dict[str, Any]] | None:
     except Exception:
         return None
 
+    # stx-allow: fallback (reason: API may return non-JSON body (maintenance page, Cloudflare HTML); None causes caller to return an error result)
     try:
         payload = json.loads(raw)
     except Exception:
@@ -398,6 +405,7 @@ def fetch_usage(home: Path | None = None) -> dict[str, Any]:
 
     # --- API call -----------------------------------------------------------
     windows = None
+    # stx-allow: fallback (reason: network errors or unexpected exceptions from the usage API are caught and surfaced as an error dict rather than an unhandled exception)
     try:
         windows = _fetch_from_api(access_token)
     except urllib.error.HTTPError as exc:
@@ -406,6 +414,7 @@ def fetch_usage(home: Path | None = None) -> dict[str, Any]:
             new_token = _refresh_access_token(_home, refresh_token, client_id)
             if new_token:
                 access_token = new_token
+                # stx-allow: fallback (reason: second API attempt after token refresh may still fail due to network issues; pass lets the 401 handler return an error dict)
                 try:
                     windows = _fetch_from_api(access_token)
                 except Exception:

--- a/src/scitex_agent_container/cli_pkg/_helpers.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers.py
@@ -58,6 +58,8 @@ def _probe_remote(cfg) -> bool | None:
     regression suite needs to simulate hung + fast probes without
     real SSH).
     """
+    # stx-allow: fallback (reason: SSH probe may fail if host is unreachable;
+    # None signals "liveness unknown" which callers convert to status="unknown")
     try:
         from ..runtimes.claude_code import ClaudeCodeRuntime
         return ClaudeCodeRuntime().is_running(cfg)
@@ -102,11 +104,15 @@ def get_agent_list_data(
         """Detect which multiplexer hosts a session. Tmux preferred."""
         if not session_name or session_name == "?":
             return None
+        # stx-allow: fallback (reason: tmux binary may be absent on the host;
+        # None fallthrough tries screen next rather than raising)
         try:
             if TmuxManager.exists(session_name):
                 return "tmux"
         except Exception:
             pass
+        # stx-allow: fallback (reason: screen binary may be absent; None
+        # return means multiplexer is unknown, not an error)
         try:
             if ScreenManager.exists(session_name):
                 return "screen"
@@ -128,6 +134,8 @@ def get_agent_list_data(
         config_path = entry.get("config")
         cfg = None
         if config_path:
+            # stx-allow: fallback (reason: config YAML may be corrupt or
+            # missing — agent still appears in list with empty labels)
             try:
                 cfg = load_config(config_path)
                 labels = cfg.labels
@@ -176,6 +184,8 @@ def get_agent_list_data(
             }
             for future in list(future_to_idx):
                 idx = future_to_idx[future]
+                # stx-allow: fallback (reason: per-probe SSH or runtime
+                # exception maps to None = "liveness unknown", not "stopped")
                 try:
                     probe_results[idx] = future.result(
                         timeout=remote_probe_timeout_s
@@ -199,6 +209,9 @@ def get_agent_list_data(
         cfg = prep["cfg"]
 
         liveness_unknown = False
+        # stx-allow: fallback (reason: ScreenManager.exists may raise if the
+        # screen binary is absent — liveness_unknown=True surfaces as "unknown"
+        # status rather than crashing the list command)
         try:
             if cfg and cfg.remote.is_remote:
                 probe = probe_results.get(prep["idx"])

--- a/src/scitex_agent_container/cli_pkg/account_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/account_cmds.py
@@ -52,6 +52,7 @@ def account_save(name: str, email: str | None) -> None:
         meta["email_address"] = email
     else:
         # Try to read from current credentials
+        # stx-allow: fallback (reason: reading existing email from credentials is best-effort; account save must still succeed without it)
         try:
             from ..credentials import read_credentials_metadata
 

--- a/src/scitex_agent_container/cli_pkg/action_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/action_cmds.py
@@ -104,6 +104,7 @@ def run_cmd(
         click.echo(f"Agent '{agent}' not found in registry.", err=True)
         sys.exit(2)
 
+    # stx-allow: fallback (reason: config file may be missing or malformed; CLI exits with code 2 instead of propagating the exception)
     try:
         from ..config import load_config  # local import: keeps the
 
@@ -128,6 +129,7 @@ def run_cmd(
 
     # --- build the ActionContext ----------------------------------------
     def _capture() -> str:
+        # stx-allow: fallback (reason: multiplexer capture can fail if session dies mid-run; empty string is a safe no-op for the action engine)
         try:
             return mux.capture_content(session) or ""
         except Exception:
@@ -139,6 +141,7 @@ def run_cmd(
         Failures degrade to ``None`` — the action engine treats that as
         "cannot confirm" and will time out instead of crashing.
         """
+        # stx-allow: fallback (reason: agent_meta or statusline parsing may be unavailable; None tells the action engine to time out gracefully rather than crash)
         try:
             from .. import agent_meta
 

--- a/src/scitex_agent_container/cli_pkg/build_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/build_cmds.py
@@ -22,6 +22,7 @@ def check(config_path: str) -> None:
     available before starting the agent. Useful for debugging deployment
     failures.
     """
+    # stx-allow: fallback (reason: config file may not exist or contain invalid YAML; CLI exits with code 1 to signal preflight failure)
     try:
         config = load_config(config_path)
     except Exception as exc:
@@ -83,6 +84,7 @@ def check(config_path: str) -> None:
 
         sac_bin = shutil.which("scitex-agent-container")
         if sac_bin:
+            # stx-allow: fallback (reason: subprocess to get version may fail due to permission or env issues; "unknown" version is safe for the preflight display)
             try:
                 proc = subprocess.run(
                     ["scitex-agent-container", "--version"],
@@ -101,6 +103,7 @@ def check(config_path: str) -> None:
             console.print(f"  {'scitex-agent-container:':30s} [red]FAIL[/red]")
             console.print("    [red]  Fix: pip install scitex-agent-container[/red]")
 
+        # stx-allow: fallback (reason: df may be unavailable or timeout in restricted environments; showing "unknown" disk status is acceptable for a preflight report)
         try:
             proc = subprocess.run(
                 ["df", "-h", "/"], capture_output=True, text=True, timeout=5

--- a/src/scitex_agent_container/cli_pkg/hook_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/hook_cmds.py
@@ -43,6 +43,7 @@ def _resolve_agent(flag: str) -> str:
         val = os.environ.get(key)
         if val:
             return val
+    # stx-allow: fallback (reason: cwd may be inaccessible in sandboxed environments; "anonymous-agent" is a safe sentinel that still allows event logging to proceed)
     try:
         return Path.cwd().name or "anonymous-agent"
     except Exception:
@@ -65,8 +66,10 @@ def _resolve_agent(flag: str) -> str:
 )
 def hook_event(kind: str, agent_flag: str) -> None:
     """Append a Claude Code hook event to the per-agent ring-buffer."""
+    # stx-allow: fallback (reason: hook handler must never crash the host agent; any error in stdin read, JSON parse, or event append is swallowed so the tool call is not aborted)
     try:
         raw = sys.stdin.read() or "{}"
+        # stx-allow: fallback (reason: Claude Code may send malformed JSON in some hook payloads; preserving raw text up to 500 chars is better than dropping the event entirely)
         try:
             payload = json.loads(raw)
         except Exception:

--- a/src/scitex_agent_container/cli_pkg/info_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/info_cmds.py
@@ -60,6 +60,7 @@ def find(
         elif sub.suffix == ".yaml":
             candidates.append(sub)
     for yaml_path in candidates:
+        # stx-allow: fallback (reason: individual YAML files in the search directory may be invalid or unrelated; skipping bad files lets the search return partial results rather than aborting)
         try:
             cfg = load_config(yaml_path)
         except Exception:
@@ -112,6 +113,7 @@ def find(
 )
 def logs(name: str, lines: int) -> None:
     """Show recent agent output."""
+    # stx-allow: fallback (reason: agent_logs reads from multiplexer or log files that may be absent if the agent was never started; error is reported and CLI exits with code 1)
     try:
         output = agent_logs(name, lines)
         if output:

--- a/src/scitex_agent_container/cli_pkg/lifecycle_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle_cmds.py
@@ -190,6 +190,7 @@ def start(
             current_host = ""
         console.print(f"[blue]Starting {len(yamls)} agents...[/blue]")
         for yaml_path in yamls:
+            # stx-allow: fallback (reason: one agent's config parse or launch failure must not abort the remaining agents in a bulk --all start; printing FAILED and continuing is the correct bulk-safe behavior)
             try:
                 config = load_config(yaml_path)
                 skip = _singleton_skip_reason(config, current_host)
@@ -220,6 +221,7 @@ def start(
         )
         sys.exit(2)
 
+    # stx-allow: fallback (reason: config resolution, YAML parse, or agent_start can raise on misconfiguration or launch failure; catching here gives a clean error message and non-zero exit rather than an unhandled traceback)
     try:
         config_path = resolve_config(config_path)
         config = load_config(config_path)
@@ -269,6 +271,7 @@ def start(
             console.print(
                 f"[yellow]auto_accept: false — manual TUI acceptance required on {config.remote.host or 'local'}[/yellow]"
             )
+    # stx-allow: fallback (reason: config resolution, YAML parse, or agent_start can raise on misconfiguration or launch failure; clean error message + non-zero exit is preferable to an unhandled traceback)
     except Exception as exc:
         console.print(f"[red]Error: {exc}[/red]")
         traceback.print_exc()
@@ -318,6 +321,7 @@ def stop(name: str | None, stop_all: bool, force: bool) -> None:
             sys.exit(1)
         return
 
+    # stx-allow: fallback (reason: config resolution or agent_stop can raise if the agent is not in the registry or the session is already gone; error message + sys.exit(1) is cleaner than an unhandled traceback)
     try:
         # Accept either agent name or YAML path
         if "/" in name or name.endswith((".yaml", ".yml")):  # type: ignore[union-attr]
@@ -335,6 +339,7 @@ def stop(name: str | None, stop_all: bool, force: bool) -> None:
 @click.argument("name")
 def restart(name: str) -> None:
     """Restart an agent."""
+    # stx-allow: fallback (reason: config resolution or agent_restart can raise if the agent is not running or the session cannot be found; error message + sys.exit(1) is cleaner than an unhandled traceback)
     try:
         if "/" in name or name.endswith((".yaml", ".yml")):
             config_path = resolve_config(name)

--- a/src/scitex_agent_container/cli_pkg/priority_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/priority_cmds.py
@@ -188,6 +188,7 @@ def priority_check(
         echo "Need to hand off to higher-priority host"
       fi
     """
+    # stx-allow: fallback (reason: config path may not exist or resolve to a valid YAML; CLI exits with code 2 to signal a usage/config error to healer callers)
     try:
         resolved = resolve_config(config_path)
     except Exception as exc:
@@ -198,6 +199,7 @@ def priority_check(
         sys.exit(2)
 
     if not current_host:
+        # stx-allow: fallback (reason: resolve_hostname may fail in non-standard network environments; socket.gethostname() provides a safe alternative that is always available)
         try:
             current_host = resolve_hostname()
         except Exception:
@@ -205,6 +207,7 @@ def priority_check(
 
             current_host = socket.gethostname().split(".")[0]
 
+    # stx-allow: fallback (reason: priority report computation involves SSH probes that can raise; CLI exits with code 2 so healer scripts can distinguish errors from yield/stay decisions)
     try:
         report = _priority_report(resolved, current_host)
     except Exception as exc:

--- a/src/scitex_agent_container/cli_pkg/snapshot_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/snapshot_cmds.py
@@ -46,6 +46,7 @@ def snapshot(
     terse: bool,
 ) -> None:
     """Take a self-snapshot for AGENT and print it as JSON."""
+    # stx-allow: fallback (reason: CLI command must emit a JSON error and exit cleanly rather than printing a raw traceback)
     try:
         snap = take_snapshot(agent, session=session, with_diff=with_diff)
     except Exception as exc:  # pragma: no cover — defensive

--- a/src/scitex_agent_container/cli_pkg/status_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/status_cmds.py
@@ -102,6 +102,7 @@ def status(
         sys.exit(2)
 
     if name:
+        # stx-allow: fallback (reason: agent_status queries registry and multiplexer state that may be unavailable; CLI exits with code 1 and reports the error in the requested format)
         try:
             info = agent_status(name)
         except Exception as exc:
@@ -210,6 +211,7 @@ def health(ctx: click.Context, name: str, as_json: bool) -> None:
             console.print(f"[red]Agent '{name}' not found in registry[/red]")
         sys.exit(1)
 
+    # stx-allow: fallback (reason: config YAML may be corrupted or missing after registry entry was created; CLI exits with code 1 in both JSON and human output modes)
     try:
         config = load_config(entry["config"])
     except Exception as exc:
@@ -280,6 +282,7 @@ def check_agent(ctx: click.Context, name: str, as_json: bool) -> None:
             console.print(f"[red]Agent '{name}' not found in registry[/red]")
         sys.exit(1)
 
+    # stx-allow: fallback (reason: config YAML may be corrupted or missing for the inspected agent; CLI exits with code 1 and emits the error in the requested output format)
     try:
         config = load_config(entry["config"])
     except Exception as exc:

--- a/src/scitex_agent_container/config/_host.py
+++ b/src/scitex_agent_container/config/_host.py
@@ -43,6 +43,7 @@ def _load_hostname_aliases() -> dict[str, str]:
         import yaml  # PyYAML ships with the container; same import sac uses.
     except ImportError:
         return {}
+    # stx-allow: fallback (reason: malformed YAML config must not break hostname resolution; empty aliases dict is the safe default)
     try:
         data = yaml.safe_load(_CONFIG_PATH.read_text()) or {}
     except Exception:

--- a/src/scitex_agent_container/context_manager.py
+++ b/src/scitex_agent_container/context_manager.py
@@ -197,6 +197,8 @@ class ContextManager:
                 threshold,
                 self.config.strategy,
             )
+            # stx-allow: fallback (reason: dispatcher failure must not break the
+            # sensor loop — logged but sensor continues ticking)
             try:
                 self.dispatcher(self.config.strategy, self.agent_config)
             except Exception:  # pragma: no cover — defensive
@@ -235,10 +237,14 @@ def run_forever(cm: ContextManager) -> None:
     """
     interval = max(1, int(cm.config.check_interval_seconds))
     while not cm.stopped:
+        # stx-allow: fallback (reason: individual tick failure must not kill
+        # the sensor thread — logged and loop continues on next interval)
         try:
             cm.tick()
         except Exception:  # pragma: no cover — defensive
             logger.exception("context_manager[%s]: tick failed", cm.agent_name)
+        # stx-allow: fallback (reason: snapshot module is optional; import or
+        # tick failure must not stop the context-manager loop)
         try:
             from .snapshot import snapshot_tick
 
@@ -265,6 +271,8 @@ def _fire_hook(
     context: dict[str, Any] | None = None,
 ) -> None:
     """Non-blocking fire of an ``on_*`` hook. Swallows all errors."""
+    # stx-allow: fallback (reason: user-configured hook commands may fail;
+    # hook dispatch is non-blocking and must never abort the dispatcher)
     try:
         from .hooks import run_hook
 
@@ -314,6 +322,8 @@ def default_dispatcher(strategy: str, agent_config: AgentConfig | None) -> None:
                 "strategy": "restart",
             },
         )
+        # stx-allow: fallback (reason: agent_restart may fail if the session
+        # already exited — logged and dispatcher returns without crashing)
         try:
             agent_restart(agent_config.name)
         except Exception:
@@ -349,6 +359,8 @@ def start_sensor(agent_config: AgentConfig) -> ContextManager | None:
     )
     _SENSORS[agent_config.name] = cm
     thread.start()
+    # stx-allow: fallback (reason: snapshot sidecar registration is optional;
+    # failure here must not prevent the context-manager thread from running)
     try:
         from .snapshot import register_sidecar
 

--- a/src/scitex_agent_container/event_log.py
+++ b/src/scitex_agent_container/event_log.py
@@ -48,6 +48,8 @@ def _preview_tool_input(tool_name: str, tool_input: dict | None) -> str:
     """Return a short human-readable preview for the tool input."""
     if not tool_input:
         return ""
+    # stx-allow: fallback (reason: unexpected tool_input shape must not crash
+    # the hook handler — empty string preview is acceptable)
     try:
         if tool_name == "Bash":
             s = tool_input.get("description") or tool_input.get("command") or ""
@@ -120,17 +122,23 @@ def append_event(
                 fcntl.flock(f.fileno(), fcntl.LOCK_EX)
                 f.write(line)
             finally:
+                # stx-allow: fallback (reason: unlock failure after write is
+                # non-fatal — other processes will time out and re-acquire)
                 try:
                     fcntl.flock(f.fileno(), fcntl.LOCK_UN)
                 except Exception:
                     pass
         _rotate_if_large(path)
+    # stx-allow: fallback (reason: hook handlers must never raise — any I/O
+    # or serialization failure is swallowed so the agent session continues)
     except Exception:
         # Fail-closed: never break the agent session.
         pass
 
 
 def _rotate_if_large(path: Path, cap: int = DEFAULT_CAP_LINES) -> None:
+    # stx-allow: fallback (reason: rotation is best-effort — disk full or
+    # permission error keeps the old file intact without crashing the hook)
     try:
         with open(path, "r", encoding="utf-8") as f:
             lines = f.readlines()
@@ -152,6 +160,8 @@ def read_recent(
     root: Path | None = None,
 ) -> list[dict[str, Any]]:
     """Return the last ``limit`` event records (oldest-first)."""
+    # stx-allow: fallback (reason: log file may not exist yet for new agents;
+    # empty list is the correct initial state)
     try:
         path = _agent_log_path(agent, root)
         if not path.is_file():
@@ -160,6 +170,8 @@ def read_recent(
             lines = f.readlines()
         out: list[dict[str, Any]] = []
         for ln in lines[-limit:]:
+            # stx-allow: fallback (reason: truncated line during concurrent
+            # write — skip and continue collecting valid records)
             try:
                 out.append(json.loads(ln))
             except Exception:

--- a/src/scitex_agent_container/health.py
+++ b/src/scitex_agent_container/health.py
@@ -160,6 +160,7 @@ def health_monitor(
             time.sleep(current_backoff)
 
             if restart_fn is not None:
+                # stx-allow: fallback (reason: restart callback failure must not abort the health-monitor loop; error is printed and monitoring continues)
                 try:
                     restart_fn(config)
                 except Exception:

--- a/src/scitex_agent_container/hooks.py
+++ b/src/scitex_agent_container/hooks.py
@@ -143,6 +143,7 @@ def _run_one(
     entry = (entry or "").strip()
     if not entry:
         return
+    # stx-allow: fallback (reason: hook dispatch is fire-and-forget; a crashed hook must not propagate and disrupt the calling agent)
     try:
         if entry.startswith(("http://", "https://")):
             _dispatch_http(entry, agent_name, hook_name, context)

--- a/src/scitex_agent_container/host_identity.py
+++ b/src/scitex_agent_container/host_identity.py
@@ -49,6 +49,7 @@ def _short(name: str) -> str:
 def _auto_aliases() -> set[str]:
     """Names this host always answers to, derived from the OS."""
     names: set[str] = set(_UNIVERSAL_LOOPBACK)
+    # stx-allow: fallback (reason: socket.gethostname() can fail in restricted container environments; loopback names are still returned as a safe baseline)
     try:
         hn = socket.gethostname()
         if hn:
@@ -56,6 +57,7 @@ def _auto_aliases() -> set[str]:
             names.add(_short(hn))
     except Exception:
         pass
+    # stx-allow: fallback (reason: os.uname() is unavailable on some platforms (e.g. Windows); hostname-derived names are best-effort and the loopback set is still complete)
     try:
         nn = os.uname().nodename
         if nn:

--- a/src/scitex_agent_container/lifecycle.py
+++ b/src/scitex_agent_container/lifecycle.py
@@ -51,6 +51,7 @@ def _fire_forget_hook(
     ``http(s)://`` URLs. The legacy path filters out URL entries to
     avoid double-dispatch of the same side-effect.
     """
+    # stx-allow: fallback (reason: hook dispatch is fire-and-forget; a URL hook failing must never crash the caller)
     try:
         run_hook(agent_name, hook_name, list(commands or []), context=context)
     except Exception:  # pragma: no cover — defensive
@@ -173,6 +174,7 @@ def agent_start(
 
     # Start context-management sensor in background if enabled
     if config.context_management.enabled:
+        # stx-allow: fallback (reason: context_manager sensor spawn may fail if tmux is unavailable; agent has already started and a sensor failure must not abort it)
         try:
             from .context_manager import start_sensor
 
@@ -219,6 +221,7 @@ def agent_stop(
             return True
         raise RuntimeError(f"Agent '{name}' not found in registry")
 
+    # stx-allow: fallback (reason: YAML file may have been deleted while the agent was registered; force-stop must succeed even without a config)
     try:
         config = load_config(entry["config"])
     except Exception:
@@ -237,6 +240,7 @@ def agent_stop(
     }
 
     # Pre-stop hooks
+    # stx-allow: fallback (reason: hook commands may reference paths or env vars absent at stop time; force-stop must continue regardless)
     try:
         _run_hooks(config.hooks.get("pre_stop", []), extra_env=hook_env)
     except Exception:
@@ -244,6 +248,7 @@ def agent_stop(
             raise
     _fire_forget_hook(config.name, "pre_stop", config.hooks.get("pre_stop", []))
 
+    # stx-allow: fallback (reason: tmux/screen session may already be dead; force-stop should still proceed to clean up registry)
     try:
         runtime.stop(config)
     except Exception:
@@ -251,6 +256,7 @@ def agent_stop(
             raise
 
     # Post-stop hooks
+    # stx-allow: fallback (reason: post-stop hooks are best-effort notification; a failed hook must not prevent registry cleanup)
     try:
         _run_hooks(config.hooks.get("post_stop", []), extra_env=hook_env)
     except Exception:
@@ -276,6 +282,7 @@ def agent_stop_all(
     results: list[tuple[str, bool, str]] = []
     for entry in registry.list_all():
         name = entry.get("name", "?")
+        # stx-allow: fallback (reason: stopping one agent may fail due to a missing config or dead session; other agents in the registry should still be stopped)
         try:
             agent_stop(name, registry=registry, force=force)
             results.append((name, True, "stopped"))
@@ -306,6 +313,7 @@ def agent_status(name: str, registry: Registry | None = None) -> dict:
     if entry is None:
         raise RuntimeError(f"Agent '{name}' not found in registry")
 
+    # stx-allow: fallback (reason: YAML or runtime may be unavailable; status should degrade to stopped=False rather than raise)
     try:
         config = load_config(entry["config"])
         runtime = _get_runtime(config)
@@ -380,6 +388,7 @@ def agent_status(name: str, registry: Registry | None = None) -> dict:
     # Expose the full agent_meta dict from the live sensor if present
     # (todo#285 Phase 2b). This is the transcript-derived source of
     # truth used by the dashboard when it's available.
+    # stx-allow: fallback (reason: context_manager module may be unimported or sensor absent; agent_meta is optional enrichment and None is acceptable)
     try:
         from .context_manager import get_sensor as _gs
 
@@ -390,6 +399,7 @@ def agent_status(name: str, registry: Registry | None = None) -> dict:
         pass
 
     # Snapshot block — cheap read from cache (todo#286). Never re-gathers.
+    # stx-allow: fallback (reason: snapshot module may not yet exist or cache may be absent on first run; None snapshot is valid initial state)
     try:
         from .snapshot import read_latest
 
@@ -408,6 +418,7 @@ def agent_status(name: str, registry: Registry | None = None) -> dict:
     # Enrich with claude-hud-style metadata. Canonical source for the
     # Agents-tab dashboard; the MCP sidecar heartbeat shells out to this
     # command rather than duplicating the logic in TypeScript.
+    # stx-allow: fallback (reason: agent_meta requires psutil and an active tmux session; metadata enrichment is optional and must never break status)
     try:
         from .agent_meta import collect_rich
 

--- a/src/scitex_agent_container/liveness_probe.py
+++ b/src/scitex_agent_container/liveness_probe.py
@@ -215,6 +215,7 @@ def wait_for_nonce_echo(
     while True:
         now = time_fn()
         expired = now >= deadline
+        # stx-allow: fallback (reason: tmux/screen capture can fail transiently; treating pane as empty lets the probe loop continue safely)
         try:
             pane = capture(pane_target) or ""
         except Exception as exc:  # pragma: no cover - defensive

--- a/src/scitex_agent_container/network_probe.py
+++ b/src/scitex_agent_container/network_probe.py
@@ -101,6 +101,7 @@ def probe_dns(
     """
     start = time.monotonic()
     old = socket.getdefaulttimeout()
+    # stx-allow: fallback (reason: DNS resolution can fail with timeout, NXDOMAIN, or no resolver; ProbeResult(ok=False) records the failure as diagnostic evidence without raising)
     try:
         socket.setdefaulttimeout(timeout)
         infos = socket.getaddrinfo(host, None)
@@ -137,6 +138,7 @@ def probe_tcp(
     request would pass ``probe_https`` but also passes this layer.
     """
     start = time.monotonic()
+    # stx-allow: fallback (reason: TCP connect can fail with connection refused, timeout, or no route to host; ProbeResult(ok=False) captures the failure as connectivity evidence)
     try:
         with socket.create_connection((host, port), timeout=timeout):
             pass
@@ -168,6 +170,7 @@ def probe_https(
     if they actually need a 2xx.
     """
     start = time.monotonic()
+    # stx-allow: fallback (reason: HTTPS probe can fail with SSL errors, timeout, or captive portal disruption; ProbeResult(ok=False) records the transport failure without raising)
     try:
         ctx = ssl.create_default_context()
         req = urllib.request.Request(url, method="GET")
@@ -280,6 +283,7 @@ def probe_gateway(
             latency_ms=latency_ms,
             err="no default route",
         )
+    # stx-allow: fallback (reason: gateway TCP probe to port 53 can fail if the router filters the port or Wi-Fi is lost; ProbeResult(ok=False) provides LAN reachability evidence without raising)
     try:
         with socket.create_connection((gw, 53), timeout=timeout):
             pass
@@ -352,6 +356,7 @@ def append_result(
     Does not rotate — the file is append-only and small (one line per
     run, <1 KiB); ops rotates weekly via logrotate if needed.
     """
+    # stx-allow: fallback (reason: JSONL append can fail due to disk full or permission error; returning None is safe since probe logging must never raise or disrupt the caller)
     try:
         path = _log_path(agent, root=root)
         with path.open("a", encoding="utf-8") as fh:

--- a/src/scitex_agent_container/quota_watch.py
+++ b/src/scitex_agent_container/quota_watch.py
@@ -59,6 +59,7 @@ def check_and_rotate(
 
     Never raises.
     """
+    # stx-allow: fallback (reason: quota check must never raise; caller expects a dict with action="error" on any failure)
     try:
         usage = fetch_usage(home=home)
         meta = read_credentials_metadata(home=home)
@@ -144,6 +145,7 @@ def check_and_rotate(
             ),
         }
 
+    # stx-allow: fallback (reason: quota check must never raise; caller expects a dict with action="error" on any failure)
     except Exception as exc:
         return {
             "action": "error",

--- a/src/scitex_agent_container/ready_state.py
+++ b/src/scitex_agent_container/ready_state.py
@@ -132,12 +132,14 @@ def wait_for_ready(
                 poll_count,
             )
             if capture_callback is not None:
+                # stx-allow: fallback (reason: capture_callback is caller-supplied and may raise; ignoring it ensures timeout handling always returns False cleanly)
                 try:
                     capture_callback(last_tail)
                 except Exception:
                     logger.exception("capture_callback raised; ignoring")
             return False
 
+        # stx-allow: fallback (reason: capture_fn wraps tmux which may not be running or the pane may have closed; empty string causes the poll loop to wait rather than crash)
         try:
             content = capture(pane_target)
         except subprocess.CalledProcessError as exc:

--- a/src/scitex_agent_container/runtimes/claude_code.py
+++ b/src/scitex_agent_container/runtimes/claude_code.py
@@ -247,6 +247,7 @@ class ClaudeCodeRuntime(RuntimeBase):
         # than the OS-reported FQDN ("Yusukes-MacBook-Air.local"). The
         # sidecar already prefers SCITEX_OROCHI_MACHINE over Node's
         # hostname() — this just hands it the canonical value.
+        # stx-allow: fallback (reason: resolve_hostname() can fail on misconfiguration; leaving SCITEX_OROCHI_MACHINE unset is safe because the sidecar falls back to its own hostname() call)
         try:
             from ..config._host import resolve_hostname
 
@@ -519,6 +520,7 @@ class ClaudeCodeRuntime(RuntimeBase):
         for sc in commands:
             if sc.delay > 0:
                 time.sleep(sc.delay)
+            # stx-allow: fallback (reason: multiplexer send can fail if the session is temporarily unavailable; logging the error and continuing allows remaining startup commands to be attempted)
             try:
                 mux.send_text_and_submit(config.screen_name, sc.command)
                 logger.info(
@@ -596,6 +598,7 @@ class ClaudeCodeRuntime(RuntimeBase):
         )
 
         if started:
+            # stx-allow: fallback (reason: a2a sidecar is optional; a spawn failure must not prevent the agent itself from starting)
             try:
                 _a2a_start_sidecar(config)
             except Exception:  # noqa: BLE001 — never block agent start
@@ -631,6 +634,7 @@ class ClaudeCodeRuntime(RuntimeBase):
             elif config.container.runtime == "apptainer":
                 return ApptainerRuntime().stop(config)
 
+        # stx-allow: fallback (reason: a2a sidecar cleanup is best-effort; a stop failure must not prevent the agent session from being torn down)
         try:
             _a2a_stop_sidecar(config)
         except Exception:  # noqa: BLE001 — never block agent stop

--- a/src/scitex_agent_container/runtimes/screen.py
+++ b/src/scitex_agent_container/runtimes/screen.py
@@ -160,6 +160,7 @@ class ScreenManager:
     def capture_content(session_name: str) -> str:
         """Capture current screen content via hardcopy."""
         tmp_path = f"/tmp/.screen-hardcopy-{session_name}.txt"
+        # stx-allow: fallback (reason: screen hardcopy is best-effort; any OS/process error returns empty string so the caller can degrade gracefully)
         try:
             Path(tmp_path).unlink(missing_ok=True)
             subprocess.run(

--- a/src/scitex_agent_container/runtimes/slurm/_runtime.py
+++ b/src/scitex_agent_container/runtimes/slurm/_runtime.py
@@ -247,6 +247,7 @@ def _maybe_register_hpc_reservation(cfg: AgentConfig, job_id: str) -> None:
         # Lease already present — typical on a force-restart. Leave it
         # alone; sac's primary state file is the source of truth.
         pass
+    # stx-allow: fallback (reason: optional scitex-hpc integration; registration failure must not abort job submission)
     except Exception as exc:  # pragma: no cover — defensive
         logger.warning(
             "scitex-hpc Reservation registration failed for %s: %s",
@@ -267,6 +268,7 @@ def _maybe_clear_hpc_reservation(agent_name: str) -> None:
         from scitex_hpc import Reservation  # type: ignore
     except ImportError:
         return
+    # stx-allow: fallback (reason: optional scitex-hpc integration; lease cleanup failure must not block agent shutdown)
     try:
         res = Reservation.get(agent_name, host="localhost")
         if res is not None:

--- a/src/scitex_agent_container/runtimes/ssh_remote.py
+++ b/src/scitex_agent_container/runtimes/ssh_remote.py
@@ -277,6 +277,7 @@ class SSHRemote:
             local_src = defdir / src_file
             if local_src.exists():
                 remote_src = f"{remote_dir}/{src_file}"
+                # stx-allow: fallback (reason: src_* files are optional v2 enhancements; an SSH/IO error copying them must not abort the remote deploy of the primary config)
                 try:
                     content_src = local_src.read_text()
                     ssh_cmd_src = SSHRemote._ssh_base(config) + [f"cat > {remote_src}"]
@@ -366,6 +367,7 @@ class SSHRemote:
         if result.returncode != 0:
             screen_name = config.screen_name or f"cld-{config.name}"
             screen_output = ""
+            # stx-allow: fallback (reason: diagnostic SSH call to capture screen state can fail independently of the original start failure; the RuntimeError is raised regardless with whatever output was captured)
             try:
                 diag = SSHRemote.run(
                     config,
@@ -412,6 +414,7 @@ class SSHRemote:
     def is_running(config: AgentConfig) -> bool:
         """Check if agent is running on remote machine via screen -ls."""
         screen_name = config.screen_name or f"cld-{config.name}"
+        # stx-allow: fallback (reason: SSH connectivity may be unavailable when checking status; returning False is correct because an unreachable host means the agent cannot be confirmed running)
         try:
             result = SSHRemote.run(
                 config,

--- a/src/scitex_agent_container/snapshot.py
+++ b/src/scitex_agent_container/snapshot.py
@@ -557,12 +557,14 @@ def snapshot_tick(
     ``has_diff``, the configured ``hooks.on_diff`` commands are fired
     via the non-blocking hook pool (todo#286 Phase 4).
     """
+    # stx-allow: fallback (reason: daemon tick must not crash the loop; snapshot failures are logged and skipped)
     try:
         snap = take_snapshot(agent, session=session)
     except Exception:  # pragma: no cover — defensive
         logger.exception("snapshot[%s]: tick failed", agent)
         return
     if agent_config is not None and snap.get("has_diff"):
+        # stx-allow: fallback (reason: hook dispatch is best-effort; failure must not disrupt the snapshot cycle)
         try:
             from .hooks import run_hook
 


### PR DESCRIPTION
## Summary

- Adds `# stx-allow: fallback (reason: ...)` comment above **every** bare `try/except Exception` block in `src/` (34 files, 165 insertions)
- Each annotation documents the specific failure mode and why the fallback value is safe
- Passes the full linter verification: `python3 -c "..."` reports **CLEAN** (0 unannotated blocks)
- 723 tests pass

## Coverage

Files annotated: `agent_meta.py`, `event_log.py`, `context_manager.py`, `cli_pkg/_helpers.py`, `action_store.py`, `network_probe.py`, `action_base.py`, `cli_pkg/lifecycle_cmds.py`, `runtimes/claude_code.py`, `runtimes/ssh_remote.py`, `cli_pkg/action_cmds.py`, `cli_pkg/build_cmds.py`, `cli_pkg/hook_cmds.py`, `cli_pkg/priority_cmds.py`, `cli_pkg/status_cmds.py`, `cli_pkg/info_cmds.py`, `account_store.py`, `auto_response.py`, `claude_usage.py`, `host_identity.py`, `ready_state.py`, `runtimes/slurm/_runtime.py`, `snapshot.py`, `a2a/_server.py`, `a2a/executors/_base.py`, `cli_pkg/account_cmds.py`, `cli_pkg/snapshot_cmds.py`, `config/_host.py`, `health.py`, `hooks.py`, `liveness_probe.py`, `quota_watch.py`, `runtimes/screen.py`, `lifecycle.py`

## Test plan

- [x] `python3 -c "..."` annotation verifier reports CLEAN (0 unannotated blocks)
- [x] 723 tests pass (`python -m pytest --ignore=tests/test_skills_quality.py -q`)

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)