### PR TITLE
feat(event_log): open_agent_calls detection for stuck-subagent alerting (orochi#133)

### DIFF
--- a/src/scitex_agent_container/agent_meta.py
+++ b/src/scitex_agent_container/agent_meta.py
@@ -530,6 +530,7 @@ def collect_rich(
             "recent_tools": [],
             "recent_prompts": [],
             "agent_calls": [],
+            "open_agent_calls": [],
             "background_tasks": [],
             "counts": {},
         }
@@ -655,6 +656,18 @@ def collect_rich(
         "recent_tools": _event_summary.get("recent_tools") or [],
         "recent_prompts": _event_summary.get("recent_prompts") or [],
         "agent_calls": _event_summary.get("agent_calls") or [],
+        "open_agent_calls": _event_summary.get("open_agent_calls") or [],
+        # Scalar summaries for terse projection and healer thresholding.
+        # open_agent_calls_count > 0 means there are Agent pretool events
+        # with no matching posttool — possible stuck subagent.
+        # oldest_open_agent_age_s gives the age of the oldest such call.
+        # Cross-check with subagent_count before alerting (ring-buffer
+        # rotation can produce false positives).
+        "open_agent_calls_count": len(_event_summary.get("open_agent_calls") or []),
+        "oldest_open_agent_age_s": max(
+            (c.get("age_seconds") or 0 for c in (_event_summary.get("open_agent_calls") or [])),
+            default=None,
+        ) or None,
         "background_tasks": _event_summary.get("background_tasks") or [],
         "tool_counts": _event_summary.get("counts") or {},
         # Functional-heartbeat shortcuts — top-level so consumers don't

--- a/src/scitex_agent_container/event_log.py
+++ b/src/scitex_agent_container/event_log.py
@@ -169,6 +169,63 @@ def read_recent(
         return []
 
 
+def _compute_open_agent_calls(
+    recent_tools: list[dict[str, Any]],
+    now: datetime | None = None,
+) -> list[dict[str, Any]]:
+    """Return Agent pretool events with no matching posttool (LIFO matching).
+
+    Walks ``recent_tools`` in chronological order, maintaining a stack of
+    open Agent pretool events. Each Agent posttool pops the most-recent
+    unmatched pretool (LIFO — subagents can be nested). Entries still on
+    the stack at the end have no posttool in the observed window.
+
+    Each returned record adds ``age_seconds`` (wall-clock seconds since
+    ``ts``) so callers can threshold on stuck duration without re-parsing
+    ISO timestamps.
+
+    Caveats
+    -------
+    - The event log is a ring-buffer. A pretool that fired before the
+      window started would look "open" even if it already completed.
+      Consumers should cross-check ``subagent_count`` from the pane text
+      before declaring an open call "stuck".
+    - Nested Agent calls are matched LIFO, which is the correct order
+      when the outer agent waits for the inner one to complete.
+    """
+    if now is None:
+        now = datetime.now(timezone.utc)
+    stack: list[dict[str, Any]] = []
+    for ev in recent_tools:
+        tool = ev.get("tool", "")
+        if tool != "Agent":
+            continue
+        if ev.get("kind") == "pretool":
+            stack.append(ev)
+        elif ev.get("kind") == "posttool" and stack:
+            stack.pop()
+
+    result: list[dict[str, Any]] = []
+    for ev in stack:
+        ts_str = ev.get("ts", "")
+        age: float | None = None
+        try:
+            started = datetime.fromisoformat(ts_str)
+            if started.tzinfo is None:
+                started = started.replace(tzinfo=timezone.utc)
+            age = (now - started).total_seconds()
+        except Exception:
+            pass
+        result.append(
+            {
+                "ts": ts_str,
+                "input_preview": ev.get("input_preview", ""),
+                "age_seconds": age,
+            }
+        )
+    return result
+
+
 def summarize(
     agent: str,
     limit: int = 50,
@@ -183,6 +240,10 @@ def summarize(
           "recent_tools":       [{ts, tool, input_preview, ...}, ...] last ``limit``
           "recent_prompts":     [{ts, prompt_preview}, ...]            last 5
           "agent_calls":        [{ts, input_preview}, ...]             last 20 Agent invocations
+          "open_agent_calls":   [{ts, input_preview, age_seconds}, ...]
+                                  Agent pretool events with no matching posttool in the
+                                  observation window. Non-empty = subagent(s) may be stuck.
+                                  Cross-check with ``subagent_count`` before alerting.
           "background_tasks":   [{ts, input_preview}, ...]             unresolved Bash run_in_background starts
           "counts":             {tool_name: count_in_window}
           "last_tool_at":       ISO ts of newest tool (pretool kind) — "functional" heartbeat
@@ -251,6 +312,7 @@ def summarize(
         "recent_tools": recent_tools[-limit:],
         "recent_prompts": recent_prompts[-5:],
         "agent_calls": agent_calls[-20:],
+        "open_agent_calls": _compute_open_agent_calls(recent_tools),
         "background_tasks": background_tasks[-20:],
         "counts": counts,
         "last_tool_at": last_tool_at,

--- a/src/scitex_agent_container/terse.py
+++ b/src/scitex_agent_container/terse.py
@@ -75,6 +75,11 @@ TERSE_STATUS_FIELDS: tuple[str, ...] = (
     # hook-captured tool liveness (LLM-level heartbeat)
     "last_tool_at",
     "last_tool_name",
+    # stuck-subagent detection (orochi#133): Agent pretool events with
+    # no matching posttool in the ring-buffer window. Non-zero count +
+    # non-zero subagent_count is the healer's trigger threshold.
+    "open_agent_calls_count",
+    "oldest_open_agent_age_s",
     # high-level "what is this agent doing" + tool name only
     # (``current_tool_input`` is intentionally excluded — may carry
     # prompt / path fragments that count as PII)

--- a/tests/test_event_log.py
+++ b/tests/test_event_log.py
@@ -229,6 +229,7 @@ class TestSummarize:
             "recent_tools": [],
             "recent_prompts": [],
             "agent_calls": [],
+            "open_agent_calls": [],
             "background_tasks": [],
             "counts": {},
             "last_tool_at": "",
@@ -314,3 +315,62 @@ class TestSummarize:
         # Both pretool and posttool appear in recent_tools
         assert len(out["recent_tools"]) == 2
         assert [t["kind"] for t in out["recent_tools"]] == ["pretool", "posttool"]
+
+
+class TestOpenAgentCalls:
+    """_compute_open_agent_calls LIFO matching detects stuck Agent calls."""
+
+    def test_matched_pretool_posttool_not_open(self, tmp_root: Path):
+        """Completed Agent call (pretool + posttool) does not appear in open."""
+        for kind, resp in [("pretool", None), ("posttool", {"content": "done"})]:
+            payload: dict = {"tool_name": "Agent", "tool_input": {"description": "task"}}
+            if resp:
+                payload["tool_response"] = resp
+            append_event("ag-m", kind, payload, root=tmp_root)
+        out = summarize("ag-m", root=tmp_root)
+        assert out["open_agent_calls"] == []
+
+    def test_unmatched_pretool_appears_open(self, tmp_root: Path):
+        """Agent pretool with no posttool is in open_agent_calls."""
+        append_event(
+            "ag-u",
+            "pretool",
+            {"tool_name": "Agent", "tool_input": {"description": "long task"}},
+            root=tmp_root,
+        )
+        out = summarize("ag-u", root=tmp_root)
+        assert len(out["open_agent_calls"]) == 1
+        assert out["open_agent_calls"][0]["input_preview"] == "long task"
+        # age_seconds should be a small non-negative float
+        assert out["open_agent_calls"][0]["age_seconds"] is not None
+        assert out["open_agent_calls"][0]["age_seconds"] >= 0
+
+    def test_nested_agents_lifo_matching(self, tmp_root: Path):
+        """Two Agent pretools + one posttool leaves one open (LIFO)."""
+        for desc in ["outer", "inner"]:
+            append_event(
+                "ag-n",
+                "pretool",
+                {"tool_name": "Agent", "tool_input": {"description": desc}},
+                root=tmp_root,
+            )
+        # inner completes first
+        append_event(
+            "ag-n",
+            "posttool",
+            {"tool_name": "Agent", "tool_response": {"content": "inner done"}},
+            root=tmp_root,
+        )
+        out = summarize("ag-n", root=tmp_root)
+        assert len(out["open_agent_calls"]) == 1
+        # "outer" was pushed first; "inner" pretool was popped by the posttool
+        assert out["open_agent_calls"][0]["input_preview"] == "outer"
+
+    def test_no_agent_calls_empty_open(self, tmp_root: Path):
+        """No Agent events → empty open_agent_calls."""
+        append_event(
+            "ag-e", "pretool", {"tool_name": "Read", "tool_input": {"file_path": "/x"}},
+            root=tmp_root,
+        )
+        out = summarize("ag-e", root=tmp_root)
+        assert out["open_agent_calls"] == []

--- a/tests/test_status_json.py
+++ b/tests/test_status_json.py
@@ -529,9 +529,9 @@ def test_status_terse_payload_size_under_threshold() -> None:
     projected = project_terse(full, TERSE_STATUS_FIELDS)
     size = len(_json.dumps(projected))
     assert size < 4096, f"terse payload too large: {size}B"
-    # And the expected shape: ~32 fields (31 after we merged two
-    # subagent spellings — keep both, so exactly 32)
-    assert len(TERSE_STATUS_FIELDS) == 32
+    # And the expected shape: 34 fields (added open_agent_calls_count +
+    # oldest_open_agent_age_s for orochi#133 stuck-subagent detection)
+    assert len(TERSE_STATUS_FIELDS) == 34
     assert set(projected.keys()) == set(TERSE_STATUS_FIELDS)
 
 


### PR DESCRIPTION
## Summary

Adds stuck-subagent detection to `event_log.summarize()` as part of the orochi#133 fleet observability epic.

- **`_compute_open_agent_calls()`**: walks pretool/posttool stream in chronological order; maintains a LIFO stack of open `Agent` invocations; entries still on the stack at the end have no matching posttool → agent may be stuck with an in-flight subagent
- **`open_agent_calls`**: new key in `summarize()` — list of `{ts, input_preview, age_seconds}` entries
- **`open_agent_calls_count` / `oldest_open_agent_age_s`**: scalar summaries in `collect_rich()` for easy threshold checks
- **Terse projection**: both scalar fields added to `TERSE_STATUS_FIELDS` so healers can consume without pulling the ~28KB full payload

## Healer usage pattern

```python
if open_agent_calls_count > 0 and subagent_count > 0 and oldest_open_agent_age_s > 600:
    # likely stuck — raise advisory to head
```

## Caveat

Ring-buffer rotation can produce false positives (a pretool before the window start looks "open" with no posttool). Always cross-check `subagent_count` from the pane before alerting.

## Test plan

- [x] `pytest tests/` — 606 passed, 2 deselected
- [x] 4 new tests: matched call → not open, unmatched → open with age, nested LIFO, no Agent calls → empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)