### PR TITLE
feat(network_probe): probe_cloudflared — bastion tunnel liveness (orochi#133)

### DIFF
--- a/src/scitex_agent_container/network_probe.py
+++ b/src/scitex_agent_container/network_probe.py
@@ -301,6 +301,61 @@ def probe_gateway(
         )
 
 
+def probe_cloudflared() -> ProbeResult:
+    """Detect a running cloudflared tunnel daemon on this host.
+
+    Scans the process list for ``cloudflared tunnel run`` (the long-lived
+    bastion daemon). Does not probe the tunnel's remote endpoint — just
+    confirms the local process is alive. If the process is present the
+    tunnel is *likely* healthy (cloudflared auto-reconnects); absence
+    means the bastion path is definitely down.
+
+    Reports the PID of the first matching process in ``extra``.
+    Uses only stdlib ``subprocess`` so it works without psutil.
+    """
+    t0 = time.monotonic()
+    # stx-allow: fallback (reason: pgrep may be absent on some OS (Windows/
+    # minimal containers); any unexpected pgrep output is a graceful miss)
+    try:
+        import subprocess as _sp
+
+        result = _sp.run(
+            ["pgrep", "-f", "cloudflared tunnel run"],
+            capture_output=True,
+            text=True,
+        )
+        latency_ms = round((time.monotonic() - t0) * 1000, 2)
+        if result.returncode == 0:
+            pids = [p.strip() for p in result.stdout.splitlines() if p.strip()]
+            pid = int(pids[0]) if pids else 0
+            return ProbeResult(
+                name="cloudflared",
+                ok=True,
+                latency_ms=latency_ms,
+                extra={"pid": pid},
+            )
+        return ProbeResult(
+            name="cloudflared",
+            ok=False,
+            latency_ms=latency_ms,
+            err="cloudflared tunnel run process not found",
+        )
+    except FileNotFoundError:
+        return ProbeResult(
+            name="cloudflared",
+            ok=False,
+            latency_ms=round((time.monotonic() - t0) * 1000, 2),
+            err="pgrep not available on this host",
+        )
+    except Exception as exc:
+        return ProbeResult(
+            name="cloudflared",
+            ok=False,
+            latency_ms=round((time.monotonic() - t0) * 1000, 2),
+            err=str(exc),
+        )
+
+
 def run_all_probes(
     *,
     hub_host: str = DEFAULT_HUB_HOST,
@@ -308,18 +363,20 @@ def run_all_probes(
     hub_url: str = DEFAULT_HUB_URL,
     timeout: float = DEFAULT_TIMEOUT_S,
 ) -> list[ProbeResult]:
-    """Run the four probes in the order dns → gateway → tcp → https.
+    """Run probes in the order dns → gateway → tcp → https → cloudflared.
 
     DNS first because hub_host is a name; if DNS fails TCP/HTTPS will
     also fail with a confusing error. Gateway second so we can tell
     "lost Wi-Fi" from "lost DNS only". TCP before HTTPS so a TLS
-    failure is distinguishable from a routing failure.
+    failure is distinguishable from a routing failure. Cloudflared last
+    (process check — independent of the network probes).
     """
     return [
         probe_dns(hub_host, timeout=timeout),
         probe_gateway(timeout=timeout),
         probe_tcp(hub_host, hub_port, timeout=timeout),
         probe_https(hub_url, timeout=timeout),
+        probe_cloudflared(),
     ]
 
 

--- a/tests/test_network_probe.py
+++ b/tests/test_network_probe.py
@@ -207,11 +207,52 @@ class TestProbeGateway:
         assert r.extra["gateway"] == "10.0.0.1"
 
 
+# ── probe_cloudflared ───────────────────────────────────────────────────────
+
+
+class TestProbeCloudflared:
+    def test_process_found_returns_ok(self, monkeypatch):
+        import subprocess
+        from unittest.mock import MagicMock
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "12345\n"
+        monkeypatch.setattr(subprocess, "run", lambda *a, **kw: mock_result)
+        r = np.probe_cloudflared()
+        assert r.ok is True
+        assert r.name == "cloudflared"
+        assert r.extra.get("pid") == 12345
+
+    def test_process_not_found_returns_failure(self, monkeypatch):
+        import subprocess
+        from unittest.mock import MagicMock
+
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stdout = ""
+        monkeypatch.setattr(subprocess, "run", lambda *a, **kw: mock_result)
+        r = np.probe_cloudflared()
+        assert r.ok is False
+        assert "not found" in r.err
+
+    def test_pgrep_missing_returns_failure(self, monkeypatch):
+        import subprocess
+
+        def raise_fnf(*a, **kw):
+            raise FileNotFoundError("pgrep")
+
+        monkeypatch.setattr(subprocess, "run", raise_fnf)
+        r = np.probe_cloudflared()
+        assert r.ok is False
+        assert "pgrep" in r.err
+
+
 # ── run_all_probes / summarise ───────────────────────────────────────────────
 
 
 class TestRunAll:
-    def test_order_is_dns_gateway_tcp_https(self, monkeypatch):
+    def test_order_is_dns_gateway_tcp_https_cloudflared(self, monkeypatch):
         calls: list[str] = []
 
         def log(name):
@@ -225,9 +266,10 @@ class TestRunAll:
         monkeypatch.setattr(np, "probe_gateway", log("gateway"))
         monkeypatch.setattr(np, "probe_tcp", log("tcp"))
         monkeypatch.setattr(np, "probe_https", log("https"))
+        monkeypatch.setattr(np, "probe_cloudflared", log("cloudflared"))
 
         np.run_all_probes()
-        assert calls == ["dns", "gateway", "tcp", "https"]
+        assert calls == ["dns", "gateway", "tcp", "https", "cloudflared"]
 
     def test_summarise_all_ok(self):
         results = [


### PR DESCRIPTION
## Summary

Adds cloudflared tunnel process detection to the existing connectivity probe suite (orochi#133 network-layer health sub-item).

- **`probe_cloudflared()`**: `pgrep -f "cloudflared tunnel run"` check; reports `ok=True + extra.pid` when the bastion daemon is alive, `ok=False + err` when absent or `pgrep` unavailable
- **`run_all_probes()`**: now returns 5 probes — `dns → gateway → tcp → https → cloudflared`
- `stx-allow: fallback` annotation on the try/except (pgrep absent on Windows/containers is expected)

## Why cloudflared specifically

`cloudflared tunnel run` is the long-lived bastion daemon that gives the fleet SSH access to MBA. Process alive = tunnel likely healthy (cloudflared auto-reconnects on drop). Process absent = external fleet access to this host is definitely broken. This is the only local, zero-config signal that the external access path works.

## Test plan

- [x] `pytest tests/` — 605 passed, 2 deselected
- [x] 3 new tests: process found → ok+pid, process absent → failure, pgrep missing → graceful failure
- [x] Smoke: `probe_cloudflared()` on MBA returns `ok=True, pid=61719` (live cloudflared daemon)

🤖 Generated with [Claude Code](https://claude.com/claude-code)