### PR TITLE
test(src_files): regression test for stale workspace .mcp.json on restart (todo#453)

### DIFF
--- a/tests/test_config_v2.py
+++ b/tests/test_config_v2.py
@@ -307,6 +307,65 @@ class TestSrcFiles:
             assert server["env"]["AGENT"] == "my-agent"
             assert server["env"]["TOKEN"] == "secret123"
 
+    def test_deploy_src_mcp_json_refreshes_on_restart(self):
+        """Regression: re-deploy after canonical src_mcp.json changes (todo#453).
+
+        Simulate the fleet-lead incident: agent launched with old channel list,
+        canonical src_mcp.json updated (PR merged), agent restarted.
+        Workspace .mcp.json must reflect the new canonical on restart.
+        """
+        from scitex_agent_container.runtimes.src_files import deploy_src_mcp_json
+
+        with (
+            tempfile.TemporaryDirectory() as defdir,
+            tempfile.TemporaryDirectory() as workdir,
+        ):
+            src = Path(defdir) / "src_mcp.json"
+            # First launch — old channel list
+            src.write_text(
+                json.dumps(
+                    {
+                        "mcpServers": {
+                            "scitex-orochi": {
+                                "type": "stdio",
+                                "env": {"SCITEX_OROCHI_CHANNELS": "#ywatanabe,#heads"},
+                            }
+                        }
+                    }
+                )
+            )
+            config = AgentConfig(
+                name="fleet-lead",
+                config_path=str(Path(defdir) / "agent.yaml"),
+            )
+            deploy_src_mcp_json(config, workdir)
+
+            dest = Path(workdir) / ".mcp.json"
+            data = json.loads(dest.read_text())
+            assert data["mcpServers"]["scitex-orochi"]["env"]["SCITEX_OROCHI_CHANNELS"] == "#ywatanabe,#heads"
+
+            # PR merged — canonical updated with extra channels
+            src.write_text(
+                json.dumps(
+                    {
+                        "mcpServers": {
+                            "scitex-orochi": {
+                                "type": "stdio",
+                                "env": {"SCITEX_OROCHI_CHANNELS": "#ywatanabe,#heads,#lead,#agent"},
+                            }
+                        }
+                    }
+                )
+            )
+            # Simulate restart (re-deploy)
+            deploy_src_mcp_json(config, workdir)
+
+            data = json.loads(dest.read_text())
+            assert (
+                data["mcpServers"]["scitex-orochi"]["env"]["SCITEX_OROCHI_CHANNELS"]
+                == "#ywatanabe,#heads,#lead,#agent"
+            ), "workspace .mcp.json must reflect updated canonical after restart"
+
     def test_cleanup_src_claude_md(self):
         from scitex_agent_container.runtimes.src_files import (
             cleanup_src_claude_md,


### PR DESCRIPTION
## Summary
- Adds test_deploy_src_mcp_json_refreshes_on_restart to TestSrcFiles
- Simulates the fleet-lead incident: agent launched with old SCITEX_OROCHI_CHANNELS, canonical src_mcp.json updated (PR merged), agent restarted
- Confirms workspace .mcp.json reflects the updated canonical after restart

## Root cause (already fixed)
deploy_src_mcp_json() in src_files.py was already called on every start() and uses dict.update() to merge canonical server entries over existing ones. The bug in the original incident was that fleet-lead was running when the PR merged and had not been restarted. After restart it picks up the correct channels.

## Test plan
- [x] test_deploy_src_mcp_json_refreshes_on_restart PASS (5/5 mcp tests pass)

Closes ywatanabe1989/todo#453

Generated with Claude Code