### PR TITLE
fix(#396): pre-seed ~/.claude.json projects[] to skip OAuth onboarding

### DIFF
--- a/src/scitex_agent_container/runtimes/claude_code.py
+++ b/src/scitex_agent_container/runtimes/claude_code.py
@@ -15,6 +15,7 @@ from .a2a_sidecar import stop_sidecar as _a2a_stop_sidecar
 from .base import RuntimeBase
 from .claude_md import cleanup_claude_md, setup_claude_md
 from .mcp_config import cleanup_mcp_config, setup_mcp_config
+from .onboarding import ensure_project_onboarding
 from .settings_json import cleanup_settings_json, setup_settings_json
 from .src_files import (  # noqa: F401
     cleanup_src_claude_md,
@@ -561,6 +562,10 @@ class ClaudeCodeRuntime(RuntimeBase):
         cmd = self._build_command(config)
         env_exports = self._build_env_exports(config)
         workdir = config.expanded_workdir
+
+        # Pre-populate ~/.claude.json projects entry so the agent skips
+        # interactive onboarding (theme / login-method / dev-channels prompts).
+        ensure_project_onboarding(workdir)
 
         # v2: deploy src files from definition directory
         # v1: generate from config (legacy)

--- a/src/scitex_agent_container/runtimes/onboarding.py
+++ b/src/scitex_agent_container/runtimes/onboarding.py
@@ -1,0 +1,121 @@
+"""Pre-seed ~/.claude.json projects entry to skip per-workspace onboarding.
+
+When Claude Code launches in a workspace it has never seen before, it shows
+interactive prompts (theme selection, login method, dev-channels approval).
+For fleet agents these prompts block startup and require a human click.
+
+This module pre-populates the ``projects[<workdir>]`` entry in
+``~/.claude.json`` with the minimal fields that signal "onboarding complete",
+so Claude Code skips the ceremony and reaches the working prompt immediately.
+
+Only the safe, non-secret fields are written:
+  - ``hasCompletedProjectOnboarding``: true — suppresses the wizard
+  - ``hasTrustDialogAccepted``: true — suppresses trust prompt
+  - ``allowedTools``, ``mcpContextUris``, etc.: empty — safe defaults
+
+Token / credential fields are never touched by this module.
+
+See: ywatanabe1989/todo#396
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Minimal project entry that satisfies Claude Code's onboarding gate.
+# Fields with dynamic values (lastCost, lastSessionId, etc.) are omitted —
+# Claude Code fills them in after the first real session.
+_ONBOARDING_SEED: dict = {
+    "allowedTools": [],
+    "mcpContextUris": [],
+    "mcpServers": {},
+    "enabledMcpjsonServers": [],
+    "disabledMcpjsonServers": [],
+    "hasTrustDialogAccepted": True,
+    "projectOnboardingSeenCount": 1,
+    "hasClaudeMdExternalIncludesApproved": True,
+    "hasClaudeMdExternalIncludesWarningShown": True,
+    "hasCompletedProjectOnboarding": True,
+    "lastGracefulShutdown": False,
+}
+
+
+def ensure_project_onboarding(
+    workdir: str,
+    home: Path | None = None,
+) -> bool:
+    """Ensure ``~/.claude.json`` has a complete projects entry for ``workdir``.
+
+    If the entry already exists and ``hasCompletedProjectOnboarding`` is True,
+    this is a no-op. Otherwise the seed fields are merged into the entry
+    (existing keys are preserved so we don't clobber live session stats).
+
+    Args:
+        workdir: Absolute path to the agent's working directory.
+        home: Override for the home directory. Defaults to ``Path.home()``.
+
+    Returns:
+        True if the entry was created or updated; False if already complete.
+
+    Never raises — errors are logged and the function returns False so
+    callers can continue without crashing.
+    """
+    home = home or Path.home()
+    claude_json_path = home / ".claude.json"
+
+    # Resolve the workdir to a canonical absolute path
+    workdir_path = Path(workdir).expanduser()
+    if workdir_path.exists():
+        workdir_path = workdir_path.resolve()
+    workdir_key = str(workdir_path)
+
+    try:
+        data: dict = {}
+        if claude_json_path.exists():
+            try:
+                with claude_json_path.open("r", encoding="utf-8") as fh:
+                    data = json.load(fh)
+            except (OSError, json.JSONDecodeError) as exc:
+                logger.warning("cannot read %s: %s", claude_json_path, exc)
+                return False
+
+        projects: dict = data.setdefault("projects", {})
+        entry = projects.get(workdir_key, {})
+
+        if entry.get("hasCompletedProjectOnboarding"):
+            logger.debug("onboarding already seeded for %s", workdir_key)
+            return False
+
+        # Merge seed into existing entry (preserve any live stats already there)
+        for key, value in _ONBOARDING_SEED.items():
+            entry.setdefault(key, value)
+        # Ensure the critical gate fields are set even if entry had them as False
+        entry["hasCompletedProjectOnboarding"] = True
+        entry["hasTrustDialogAccepted"] = True
+        entry["hasClaudeMdExternalIncludesApproved"] = True
+
+        projects[workdir_key] = entry
+
+        # Write atomically: temp file + rename
+        tmp_path = claude_json_path.with_suffix(".json.tmp")
+        try:
+            with tmp_path.open("w", encoding="utf-8") as fh:
+                json.dump(data, fh, indent=2, ensure_ascii=False)
+                fh.write("\n")
+            os.replace(tmp_path, claude_json_path)
+        except OSError as exc:
+            logger.warning("cannot write %s: %s", claude_json_path, exc)
+            tmp_path.unlink(missing_ok=True)
+            return False
+
+        logger.info("onboarding seeded for %s", workdir_key)
+        return True
+
+    except Exception as exc:  # pragma: no cover — defensive
+        logger.warning("ensure_project_onboarding failed for %s: %s", workdir_key, exc)
+        return False


### PR DESCRIPTION
## Summary
- Cherry-pick of ec80b91 (originally in closed PR #32, never merged)
- Add runtimes/onboarding.py with ensure_project_onboarding() that writes the minimal projects[<workdir>] entry before agent launch
- Prevents interactive theme/login-method/dev-channels prompts for new workspaces
- Injected into ClaudeCodeRuntime.start() before existing setup chain

## How it works
Claude Code skips onboarding when hasCompletedProjectOnboarding=true + hasTrustDialogAccepted=true exist in the projects entry. Writes atomically via temp-file rename before every launch. No-op on already-seeded workspaces.

## Test plan
- Import verified OK
- Wire-up in claude_code.py:568 verified

Closes ywatanabe1989/todo#396

Generated with Claude Code