### PR TITLE
feat(to_home): mirror to_home/ into agent $HOME; deprecate dot_claude/

### DIFF
--- a/docs/adr/0006-to-home-spec-materialization.md
+++ b/docs/adr/0006-to-home-spec-materialization.md
@@ -1,0 +1,148 @@
+# ADR-0006: `to_home/` spec-dir materialization
+
+**Status:** Accepted (2026-05-17).
+**Supersedes:** the `dot_claude/` convention introduced by F-DC1 (kept
+alive one release as the deprecated fallback).
+**Source:** `scitex-lead` FUTURE doc
+`~/proj/scitex-lead/GITIGNORED/FUTURE/sac-to_home-refactor.md`.
+
+## Context
+
+The `dot_claude/` materialization (ADR-0003 sibling logic, codified in
+`runtimes/_dot_claude.py`) mixes two unrelated purposes in one
+directory:
+
+- Four well-known leaf files (`CLAUDE.md`, `.mcp.json`, `.env`,
+  `state.md`) land at the workspace root.
+- Everything else under `dot_claude/` is mirrored into
+  `<workdir>/.claude/<rel>`.
+
+That fragmentation surfaced four concrete pain points during the
+2026-05-17 SIF migration session (full log in lead's FUTURE doc; see
+ADR-0005 for the SIF context):
+
+1. **File-bind auto-create breaks.** sac's apptainer bind pre-create
+   only handles directory targets. A spec wanting `.gitconfig` at
+   `/home/agent/.gitconfig` had to either pre-touch a placeholder
+   file (workaround) or accept the "source is file, dest is dir"
+   apptainer error.
+2. **Workdir == `$HOME`** caused `git status` to report
+   `.claude/` materialization changes as untracked on every restart,
+   polluting every diff.
+3. **`state.md` semantic collision** with the `GITIGNORED/` pattern
+   used elsewhere in the lead's working tree.
+4. **Secrets were threaded through ad-hoc `spec.apptainer.binds`** with
+   file-vs-directory quirks instead of being a first-class
+   per-agent layout concern.
+
+## Decision
+
+Introduce `to_home/` as the canonical spec-dir layout for
+agent-`$HOME` materialization. The rule becomes explicit:
+
+> **Everything under `<spec_dir>/to_home/` is mirrored 1:1 into the
+> agent's container `$HOME` (`= runtime/<name>/home/` on the host) on
+> every start.**
+
+No leaf-vs-mirror branching. The path you see under `to_home/` is the
+path the agent sees relative to `$HOME`.
+
+### Per-entry semantics (encoded in `runtimes/_to_home.py`)
+
+| Entry type | Action |
+|---|---|
+| `CLAUDE.md`, `state.md` | Marker-protected merge — source wrapped in Start/End markers; user content past the End marker preserved; malformed existing markers hard-abort (`WorkspaceCLAUDEMarkerError`). |
+| `.env` | Full overwrite, then `chmod 0600`. |
+| Other regular file | Full overwrite (`shutil.copy2`, then `${metadata.*}` / `${ENV}` interpolation when text-decodable). |
+| Directory | Recursed; structure preserved. |
+| Symlink | Preserved verbatim. Target string passes through unchanged whether relative or absolute. |
+
+### Spec schema change
+
+- New field `AgentConfig.to_home: str = "./to_home"` (default
+  auto-discovers `to_home/` next to `spec.yaml`).
+- Loader parses the YAML key `spec.to_home` with the same default.
+- Validator accepts `to_home` as a known top-level spec key.
+
+### Workdir / `$HOME` separation
+
+Container layout after migration:
+
+- `/home/agent/` = mirror of `to_home/`.
+- `/work` = bind-mounted source repo (canonical workdir).
+- `/home/agent/proj/<pkg>/` = symlink to `/work` for shell muscle
+  memory (`cd ~/proj/<pkg>` still works).
+
+The symlink is created by a per-spec `startup_command`:
+
+```yaml
+startup_commands:
+  - command: mkdir -p $HOME/proj && ln -sfn /work $HOME/proj/<pkg>  # our convention
+```
+
+This is the **convenience-as-affordance** pattern from the lead's
+FUTURE doc: the abstract path (`/work`) is canonical and
+host-layout-free; the friendly path (`~/proj/<pkg>`) is a zero-coupling
+symlink that preserves muscle memory and existing prompts.
+
+### Deprecation policy
+
+- A spec MUST NOT carry **both** `to_home/` and `dot_claude/` next to
+  `spec.yaml`. The agent-start path raises a `RuntimeError` if both
+  exist. No silent merging — that's the data-loss pattern we're
+  explicitly avoiding.
+- A spec with **only** `dot_claude/` continues to work for one release,
+  emitting a `DeprecationWarning` at start.
+- `runtimes/_dot_claude.py` is **not deleted** in this change. It will
+  be removed in a follow-up after the in-tree specs are migrated.
+
+## Consequences
+
+**Positive:**
+
+- File binds for `.gitconfig`, `.ssh`, `.config/gh`, etc. go away —
+  they live as files / dirs under `to_home/` and materialize at the
+  correct path automatically.
+- Workdir (`/work`) and `$HOME` (`runtime/<name>/home/`) are
+  cleanly separated; restart-time materialization no longer leaks
+  into the source-tree `git status`.
+- Per-agent secrets live in `to_home/secrets/` (with a per-dir
+  `.gitignore` of `*` + `!.gitkeep` to keep contents out of the
+  dotfiles repo) — first-class instead of bind-threaded.
+- The marker-protection contract for `CLAUDE.md` / `state.md` is
+  **identical** to `dot_claude/` (shared helpers from
+  `_dot_claude.py`). No regression in the safety guarantee.
+
+**Negative:**
+
+- One-release window where two layouts coexist in the runtime path.
+  Mitigated by the both-present hard-fail and the
+  DeprecationWarning on legacy-only.
+- Existing specs need a one-time migration commit. Six in-tree
+  specs (`proj-scitex-*` and `proj-paper-scitex-clew`) are migrated
+  in the companion dotfiles PR.
+
+## Implementation notes
+
+- Marker-protection helpers (`_validate_marker_invariants`,
+  `_extract_user_tail`, `END_MARKER`, `WorkspaceCLAUDEMarkerError`)
+  are imported from `_dot_claude` so both modules share one source
+  of truth on the merge contract.
+- `materialize_to_home(spec_dir, workspace_home)` is the
+  config-free low-level entrypoint (used by tests and any future
+  caller that doesn't have a full `AgentConfig`).
+- `deploy_to_home(config, workspace_home)` is the
+  config-aware variant (used by the agent-start path) and runs
+  `${metadata.*}` / `${ENV}` interpolation over text files.
+
+## Related work
+
+- `runtimes/_dot_claude.py` — deprecated predecessor (kept for one
+  release).
+- ADR-0003 — runtime home directory layout (`runtime/<name>/home/`
+  bind target).
+- ADR-0005 — SIF-mode migration (the immediate trigger for this
+  refactor; documents the file-bind pain in detail).
+- Lead memory `feedback_scitex_state_tracking_policy.md` — the
+  "track everything except `runtime/`" rule pairs cleanly with the
+  separated `to_home/` layout.

--- a/src/scitex_agent_container/config/_loaders.py
+++ b/src/scitex_agent_container/config/_loaders.py
@@ -296,4 +296,8 @@ def load_v3(raw: dict, path: Path) -> AgentConfig:
         kind=kind,
         proxy=proxy_spec,
         dot_claude=str(spec.get("dot_claude", "")),
+        # ADR-0006: default to ``./to_home`` when the key is absent so a
+        # ``to_home/`` dir next to spec.yaml auto-discovers. An empty
+        # string in YAML keeps the same default behaviour.
+        to_home=str(spec.get("to_home", "./to_home") or "./to_home"),
     )

--- a/src/scitex_agent_container/config/_types.py
+++ b/src/scitex_agent_container/config/_types.py
@@ -459,7 +459,22 @@ class AgentConfig:
     # the agent's workdir at start (replaces the legacy ``src_*`` siblings).
     # Empty = auto-discover ``./dot_claude`` next to spec.yaml; otherwise an
     # absolute path or a path relative to spec.yaml's directory.
+    #
+    # DEPRECATED — superseded by ``spec.to_home`` (see ADR-0006). Specs
+    # carrying a ``dot_claude/`` dir emit a DeprecationWarning on agent
+    # start; the path is retained for one release while existing specs
+    # migrate. A spec MUST NOT carry both layouts at once — the runtime
+    # raises if both ``dot_claude/`` and ``to_home/`` exist next to
+    # ``spec.yaml`` (no silent merge).
     dot_claude: str = ""
+    # ADR-0006: spec.to_home — directory whose contents are mirrored
+    # into the agent's container ``$HOME`` (= ``runtime/<name>/home/``
+    # on the host) on every start. Replaces the leaf-vs-mirror
+    # fragmentation of ``dot_claude/``: every path under ``to_home/``
+    # lands at the same relative path inside ``$HOME``.
+    # Default: ``./to_home`` next to ``spec.yaml`` (auto-discovered
+    # when this field is empty).
+    to_home: str = "./to_home"
 
     def __post_init__(self) -> None:
         if not self.screen_name:

--- a/src/scitex_agent_container/config/_validation.py
+++ b/src/scitex_agent_container/config/_validation.py
@@ -89,7 +89,8 @@ _KNOWN_SPEC_KEYS = frozenset(
         "autonomous",  # F-CS3 — drive-until-done block
         "apptainer",  # F-CS18 — apptainer-specific build extension
         "user",  # container user: "host" | "uid:gid" | "" (image default)
-        "dot_claude",  # F-DC1 — directory merged into workspace/.claude/
+        "dot_claude",  # F-DC1 — directory merged into workspace/.claude/ (DEPRECATED — see to_home)
+        "to_home",  # ADR-0006 — directory mirrored into container $HOME
         # v3 removed (rejected explicitly below with relocation hints):
         # image (→ spec.apptainer.image), mounts (→ spec.apptainer.binds),
         # env (→ spec.apptainer.env), model (→ spec.claude.model),

--- a/src/scitex_agent_container/runtimes/_to_home.py
+++ b/src/scitex_agent_container/runtimes/_to_home.py
@@ -1,0 +1,345 @@
+"""Materialize ``<spec_dir>/to_home/`` into the agent's workspace ``$HOME``.
+
+Successor to :mod:`_dot_claude` (see ADR-0006). The new layout makes
+the rule explicit:
+
+    agents/<name>/
+    ├── spec.yaml          (spec.to_home: ./to_home — default)
+    └── to_home/           contents mirror $HOME 1:1
+        ├── .claude/
+        │   ├── CLAUDE.md          → $HOME/.claude/CLAUDE.md     (marker-protected)
+        │   ├── settings.local.json
+        │   ├── hooks/
+        │   └── skills/
+        ├── .mcp.json              → $HOME/.mcp.json             (full overwrite)
+        ├── .env                   → $HOME/.env                  (overwrite, chmod 0600)
+        ├── state.md               → $HOME/state.md              (marker-protected)
+        └── secrets/               → $HOME/secrets/              (mirror, perms preserved)
+
+Inside the container ``$HOME`` is bind-mounted from
+``runtime/<name>/home/`` on the host — i.e. ``workspace_home`` in this
+module's API.
+
+Semantics per entry (see :func:`materialize_to_home`):
+
+  - **CLAUDE.md** / **state.md** — marker-protected merge. Source is
+    wrapped between Start/End markers; any user tail after the End
+    marker is preserved. Malformed existing markers hard-abort the
+    deploy (re-raised as :class:`WorkspaceCLAUDEMarkerError` from
+    :mod:`_dot_claude`).
+  - **.env** — full overwrite; chmod 0600 after write.
+  - **Other regular files** — full overwrite (``shutil.copy2``).
+  - **Directories** — recursed; structure preserved.
+  - **Symlinks** — preserved as symlinks (target not resolved). Both
+    absolute and relative targets pass through verbatim.
+
+No fragmented "leaf-vs-mirror" distinction — every path under
+``to_home/`` lands at the same relative path under ``workspace_home``.
+
+Missing ``to_home/`` dir → silent no-op (specs without one just don't
+get materialization).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+from datetime import datetime
+from pathlib import Path
+
+from ..config import AgentConfig
+from ._dot_claude import (
+    END_MARKER,
+    WorkspaceCLAUDEMarkerError,
+    _extract_user_tail,
+    _interpolate_env,
+    _interpolate_metadata,
+    _validate_marker_invariants,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Files that get marker-protected merge semantics (vs. full overwrite).
+# Same protection as the legacy dot_claude/CLAUDE.md path — never silent
+# data loss on a hand-edited file.
+_MARKER_PROTECTED_BASENAMES = frozenset({"CLAUDE.md", "state.md"})
+
+# Files that get chmod 0600 after copy. ``.env`` only by default; the
+# rest preserve source perms via ``shutil.copy2``.
+_TIGHT_PERM_BASENAMES = frozenset({".env"})
+
+
+# --- public API ------------------------------------------------------------
+
+
+def resolve_to_home_dir(config: AgentConfig) -> Path | None:
+    """Resolve ``spec.to_home`` to an absolute directory.
+
+    Resolution mirrors :func:`_dot_claude.resolve_dot_claude_dir`:
+      1. Absolute path: use as-is.
+      2. Relative path: resolve against the directory containing
+         ``spec.yaml``.
+      3. Empty: auto-discover ``./to_home`` next to ``spec.yaml``.
+
+    Returns ``None`` if no directory can be resolved (legacy specs
+    without a to_home/ dir simply skip materialization).
+    """
+    spec_dir = _spec_dir(config)
+    raw = (getattr(config, "to_home", "") or "").strip()
+    if not raw:
+        if spec_dir is not None and (spec_dir / "to_home").is_dir():
+            return spec_dir / "to_home"
+        return None
+    p = Path(raw).expanduser()
+    if not p.is_absolute():
+        if spec_dir is None:
+            return None
+        p = spec_dir / p
+    return p if p.is_dir() else None
+
+
+def materialize_to_home(spec_dir: Path, workspace_home: Path) -> None:
+    """Mirror ``<spec_dir>/to_home/`` into ``<workspace_home>/``.
+
+    Walks the tree and applies the per-entry semantics described in the
+    module docstring. Idempotent — safe to call on every agent start.
+
+    No-op when ``<spec_dir>/to_home/`` does not exist.
+    """
+    root = spec_dir / "to_home"
+    if not root.is_dir():
+        return
+    workspace_home.mkdir(parents=True, exist_ok=True)
+    _walk_and_apply(root, root, workspace_home, config=None)
+
+
+def deploy_to_home(config: AgentConfig, workspace_home: str) -> None:
+    """``AgentConfig``-driven entrypoint, parallel to
+    :func:`_dot_claude.deploy_dot_claude`.
+
+    Resolves the to_home/ directory via :func:`resolve_to_home_dir`
+    (honours ``spec.to_home`` overrides) and applies metadata-aware
+    interpolation (${metadata.name}, ${metadata.labels.*}, ${ENV_VAR})
+    to text files. No-op when the directory cannot be resolved.
+    """
+    root = resolve_to_home_dir(config)
+    if root is None:
+        return
+    dest = Path(workspace_home)
+    dest.mkdir(parents=True, exist_ok=True)
+    _walk_and_apply(root, root, dest, config=config)
+
+
+# --- traversal -------------------------------------------------------------
+
+
+def _walk_and_apply(
+    src_root: Path,
+    src_dir: Path,
+    dst_dir: Path,
+    *,
+    config: AgentConfig | None,
+) -> None:
+    """Recursively replicate ``src_dir`` under ``dst_dir``.
+
+    ``src_root`` is the original ``to_home/`` root, retained so log
+    messages can report a path relative to the spec. ``config`` is
+    optional: when present, text-file interpolation (``${metadata.*}``
+    and ``${ENV_VAR}``) runs over CLAUDE.md / state.md / .env / .mcp.json.
+    """
+    for child in sorted(src_dir.iterdir()):
+        rel = child.relative_to(src_root)
+        dst = dst_dir / child.name
+
+        # Symlinks first — must not follow into ``is_dir()`` / ``is_file()``
+        # decisions, because is_dir(follow=True) would route a symlink to
+        # a directory through the mirror branch.
+        if child.is_symlink():
+            _copy_symlink(child, dst)
+            continue
+
+        if child.is_dir():
+            dst.mkdir(parents=True, exist_ok=True)
+            _walk_and_apply(src_root, child, dst, config=config)
+            continue
+
+        # Regular file.
+        if child.name in _MARKER_PROTECTED_BASENAMES:
+            _deploy_marker_protected(child, dst, config=config, rel=rel)
+        elif child.name in _TIGHT_PERM_BASENAMES:
+            _deploy_tight_perm_file(child, dst, config=config, rel=rel)
+        else:
+            _deploy_plain_file(child, dst, config=config, rel=rel)
+
+
+# --- per-entry deploy helpers ----------------------------------------------
+
+
+def _copy_symlink(src: Path, dst: Path) -> None:
+    """Preserve a symlink verbatim — never resolve the target.
+
+    If ``dst`` exists (as link, file, or dir) it's removed first so the
+    new symlink can be written in place. Relative and absolute targets
+    both pass through unchanged.
+    """
+    target = os.readlink(src)
+    if dst.is_symlink() or dst.exists():
+        if dst.is_dir() and not dst.is_symlink():
+            shutil.rmtree(dst)
+        else:
+            try:
+                dst.unlink()
+            except OSError as exc:  # stx-allow: fallback (reason: filesystem race)
+                logger.warning("Failed to unlink %s: %s", dst, exc)
+                return
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    os.symlink(target, dst)
+    logger.info("to_home: symlink %s -> %s", dst, target)
+
+
+def _read_and_interpolate(src: Path, config: AgentConfig | None) -> str:
+    """Read ``src`` as text and apply metadata/env interpolation.
+
+    Interpolation runs only when an ``AgentConfig`` is supplied (i.e. the
+    public ``deploy_to_home`` entrypoint). The lower-level
+    ``materialize_to_home(spec_dir, workspace_home)`` signature copies
+    text verbatim — useful for unit tests and any caller that doesn't
+    have a full AgentConfig in hand.
+    """
+    text = src.read_text()
+    if config is not None and text.strip():
+        text = _interpolate_metadata(text, config)
+        text = _interpolate_env(text)
+    return text
+
+
+def _deploy_plain_file(
+    src: Path,
+    dst: Path,
+    *,
+    config: AgentConfig | None,
+    rel: Path,
+) -> None:
+    """Full overwrite. Uses ``shutil.copy2`` for binary-safe perm preserve
+    when no interpolation is needed; otherwise writes interpolated text."""
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    if config is None:
+        shutil.copy2(src, dst)
+    else:
+        # Best-effort interpolation: binary files raise UnicodeDecodeError
+        # on read_text; fall back to byte copy in that case.
+        try:
+            text = _read_and_interpolate(src, config)
+            dst.write_text(text)
+            shutil.copystat(src, dst)
+        except UnicodeDecodeError:
+            shutil.copy2(src, dst)
+    logger.info("to_home: deployed %s -> %s", rel, dst)
+
+
+def _deploy_tight_perm_file(
+    src: Path,
+    dst: Path,
+    *,
+    config: AgentConfig | None,
+    rel: Path,
+) -> None:
+    """Full overwrite, then chmod 0600 (e.g. ``.env``)."""
+    text = _read_and_interpolate(src, config)
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    if not text.endswith("\n"):
+        text += "\n"
+    dst.write_text(text)
+    try:
+        os.chmod(dst, 0o600)
+    except OSError as exc:  # stx-allow: fallback (reason: filesystem op failure)
+        logger.warning("Failed to chmod 0600 on %s: %s", dst, exc)
+    logger.info("to_home: deployed (0600) %s -> %s", rel, dst)
+
+
+def _deploy_marker_protected(
+    src: Path,
+    dst: Path,
+    *,
+    config: AgentConfig | None,
+    rel: Path,
+) -> None:
+    """Marker-protected merge for CLAUDE.md / state.md.
+
+    Mirrors :func:`_dot_claude._deploy_claude_md` invariants:
+      - Source wrapped in Start/End markers.
+      - Existing user content past the End marker is preserved.
+      - Malformed existing markers (count != 1 or order swapped)
+        hard-abort with :class:`WorkspaceCLAUDEMarkerError`.
+    """
+    section_content = src.read_text().strip()
+    if not section_content:
+        return
+
+    if config is not None:
+        section_content = _interpolate_metadata(section_content, config)
+
+    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    start_tag = (
+        f"<!-- Start of scitex-agent-container generated section ({timestamp}) -->"
+    )
+
+    # Strip any embedded sac markers from the source so we don't end up
+    # with nested Start/End pairs after wrapping (same defensive scrub
+    # _dot_claude applies to CLAUDE.md).
+    import re
+
+    section_body = re.sub(
+        r"<!--.*?scitex-agent-container.*?-->\n?",
+        "",
+        section_content,
+    ).strip()
+
+    new_content = f"{start_tag}\n{section_body}\n{END_MARKER}\n"
+
+    existing_text = dst.read_text() if dst.exists() else ""
+    if existing_text.strip():
+        _validate_marker_invariants(existing_text, str(dst))
+
+    user_tail = _extract_user_tail(dst)
+
+    if END_MARKER not in new_content:
+        # Shouldn't happen — we just wrote END_MARKER — but mirror the
+        # _dot_claude safety net so the contract is identical.
+        updated = new_content
+    elif user_tail:
+        updated = new_content.rstrip("\n") + user_tail
+        if not updated.endswith("\n"):
+            updated += "\n"
+    else:
+        updated = new_content
+
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    dst.write_text(updated)
+    logger.info(
+        "to_home: marker-protected %s -> %s (user tail preserved: %s)",
+        rel,
+        dst,
+        "yes" if user_tail else "no",
+    )
+
+
+# --- internal helpers ------------------------------------------------------
+
+
+def _spec_dir(config: AgentConfig) -> Path | None:
+    if not getattr(config, "config_path", ""):
+        return None
+    return Path(config.config_path).parent
+
+
+# Re-export so callers can ``from _to_home import WorkspaceCLAUDEMarkerError``
+# without also importing _dot_claude.
+__all__ = [
+    "WorkspaceCLAUDEMarkerError",
+    "deploy_to_home",
+    "materialize_to_home",
+    "resolve_to_home_dir",
+]

--- a/src/scitex_agent_container/runtimes/claude_session.py
+++ b/src/scitex_agent_container/runtimes/claude_session.py
@@ -20,14 +20,67 @@ and cross-host work goes through ``sac --on <peer>`` (F-CS12).
 from __future__ import annotations
 
 import sys
+import warnings
 from pathlib import Path
 
 from ..config import AgentConfig
 from ._dot_claude import cleanup_dot_claude, deploy_dot_claude
+from ._to_home import deploy_to_home, resolve_to_home_dir
 from .base import RuntimeBase
 from .claude_md import cleanup_claude_md, setup_claude_md
 
 __all__ = ["ClaudeSessionRuntime"]
+
+
+def _spec_dir_for(config: AgentConfig) -> Path | None:
+    cp = getattr(config, "config_path", "")
+    if not cp:
+        return None
+    return Path(cp).parent
+
+
+def _materialize_home_layouts(config: AgentConfig, home_dir: str) -> None:
+    """Run the to_home / dot_claude materialization pair.
+
+    ADR-0006 transition: ``to_home/`` is the new layout; ``dot_claude/``
+    is deprecated and kept alive for one release. A spec MUST NOT
+    carry both — surfacing the ambiguity loudly avoids the
+    silent-merge data-loss pattern.
+
+    Order:
+      1. If a ``to_home/`` dir is present: deploy it.
+      2. If a ``dot_claude/`` dir is present and ``to_home/`` is NOT:
+         deploy dot_claude (legacy path) and emit a DeprecationWarning.
+      3. If both are present: raise — operator must pick one.
+    """
+    spec_dir = _spec_dir_for(config)
+    to_home_dir = resolve_to_home_dir(config)
+    legacy_dir = None
+    if spec_dir is not None and (spec_dir / "dot_claude").is_dir():
+        legacy_dir = spec_dir / "dot_claude"
+
+    if to_home_dir is not None and legacy_dir is not None:
+        raise RuntimeError(
+            f"Spec {getattr(config, 'config_path', '<unknown>')!r} carries "
+            f"BOTH 'to_home/' and 'dot_claude/' next to spec.yaml. "
+            "Pick one — refusing to silently merge two materialization "
+            "layouts (data-loss risk). dot_claude/ is deprecated; "
+            "see ADR-0006 for the migration guide."
+        )
+
+    if to_home_dir is not None:
+        deploy_to_home(config, home_dir)
+        return
+
+    if legacy_dir is not None:
+        warnings.warn(
+            "dot_claude/ is deprecated; switch to to_home/ "
+            "(see ADR-0006). The legacy path will be removed in a "
+            "future release.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        deploy_dot_claude(config, home_dir)
 
 
 # F-CS8 — silent SDK failure on heavy workdir/.claude/ trees.
@@ -153,7 +206,7 @@ class ClaudeSessionRuntime(RuntimeBase):
         home_dir = str(self._state_dir(config) / "home")
         Path(home_dir).mkdir(parents=True, exist_ok=True)
         setup_claude_md(config, home_dir)
-        deploy_dot_claude(config, home_dir)
+        _materialize_home_layouts(config, home_dir)
 
     def _cleanup_workspace(self, config: AgentConfig) -> None:
         """Remove the agent-container CLAUDE.md section on stop."""

--- a/tests/scitex_agent_container/runtimes/test__to_home.py
+++ b/tests/scitex_agent_container/runtimes/test__to_home.py
@@ -1,0 +1,434 @@
+"""Tests for the to_home/ materialization pipeline (ADR-0006).
+
+The new layout replaces the leaf-vs-mirror fragmentation of
+``dot_claude/``: every path under ``to_home/`` lands at the same
+relative path inside ``$HOME``. Marker-protection semantics for
+``CLAUDE.md`` / ``state.md`` carry over identically from
+:mod:`_dot_claude` — never silent data loss on a hand-edited file.
+
+PA-306 no-mocks: real ``AgentConfig`` instances against ``tmp_path``.
+Env-driven tests use the project-wide ``env_save_restore`` fixture
+(POSIX-honest equivalent of ``monkeypatch.setenv`` /
+``monkeypatch.delenv``).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import stat
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container.config._types import AgentConfig
+from scitex_agent_container.runtimes._dot_claude import END_MARKER
+from scitex_agent_container.runtimes._to_home import (
+    WorkspaceCLAUDEMarkerError,
+    deploy_to_home,
+    materialize_to_home,
+    resolve_to_home_dir,
+)
+
+START_MARKER_RE = re.compile(
+    r"<!-- Start of scitex-agent-container generated section.*?-->"
+)
+
+
+# ---------------------------------------------------------------------------
+# Real-AgentConfig builders.
+# ---------------------------------------------------------------------------
+
+
+def _build_cfg(
+    tmp_path: Path,
+    *,
+    to_home: str = "",
+    labels: dict | None = None,
+) -> tuple[AgentConfig, Path]:
+    """Build a real ``AgentConfig`` pointing at a ``to_home/`` next to
+    ``spec.yaml`` inside ``tmp_path``. Returns (config, to_home_root).
+    """
+    agent_dir = tmp_path / "agent_def"
+    to_home_dir = agent_dir / "to_home"
+    to_home_dir.mkdir(parents=True, exist_ok=True)
+    cfg = AgentConfig(name="test-agent")
+    cfg.config_path = str(agent_dir / "spec.yaml")
+    cfg.to_home = to_home
+    if labels:
+        cfg.labels = dict(labels)
+    return cfg, to_home_dir
+
+
+# ---------------------------------------------------------------------------
+# resolve_to_home_dir — discovery semantics
+# ---------------------------------------------------------------------------
+
+
+class TestResolveToHomeDir:
+    def test_auto_discovers_sibling_to_home_dir(self, tmp_path):
+        # Arrange
+        cfg, root = _build_cfg(tmp_path)
+        # Act
+        resolved = resolve_to_home_dir(cfg)
+        # Assert
+        assert resolved == root
+
+    def test_returns_none_when_no_dir_present(self, tmp_path):
+        # Arrange — config_path points at a dir without to_home/
+        cfg = AgentConfig(name="ghost")
+        cfg.config_path = str(tmp_path / "ghost" / "spec.yaml")
+        cfg.to_home = ""
+        # Act
+        resolved = resolve_to_home_dir(cfg)
+        # Assert
+        assert resolved is None
+
+    def test_honours_explicit_absolute_path_override(self, tmp_path):
+        # Arrange
+        elsewhere = tmp_path / "elsewhere" / "custom_home"
+        elsewhere.mkdir(parents=True)
+        cfg, _ = _build_cfg(tmp_path, to_home=str(elsewhere))
+        # Act
+        resolved = resolve_to_home_dir(cfg)
+        # Assert
+        assert resolved == elsewhere
+
+    def test_honours_explicit_relative_path_override(self, tmp_path):
+        # Arrange — relative path resolves against spec.yaml's dir.
+        cfg, _ = _build_cfg(tmp_path, to_home="./to_home")
+        # Act
+        resolved = resolve_to_home_dir(cfg)
+        # Assert — same as auto-discovery here.
+        assert resolved == tmp_path / "agent_def" / "to_home"
+
+
+# ---------------------------------------------------------------------------
+# materialize_to_home — the low-level (no-config) signature.
+# ---------------------------------------------------------------------------
+
+
+class TestMaterializeToHomeBasics:
+    def test_missing_to_home_dir_is_noop(self, tmp_path):
+        # Arrange — spec_dir with no to_home/ subdir.
+        spec_dir = tmp_path / "spec"
+        spec_dir.mkdir()
+        home = tmp_path / "home"
+        # Act
+        materialize_to_home(spec_dir, home)
+        # Assert
+        assert (not home.exists()) or (not any(home.iterdir()))
+
+    def test_plain_file_is_copied_into_home(self, tmp_path):
+        # Arrange
+        spec_dir = tmp_path / "spec"
+        (spec_dir / "to_home").mkdir(parents=True)
+        (spec_dir / "to_home" / ".bashrc").write_text("export FOO=1\n")
+        home = tmp_path / "home"
+        # Act
+        materialize_to_home(spec_dir, home)
+        # Assert
+        assert (home / ".bashrc").read_text() == "export FOO=1\n"
+
+    def test_directory_structure_is_mirrored(self, tmp_path):
+        # Arrange
+        spec_dir = tmp_path / "spec"
+        nested = spec_dir / "to_home" / ".config" / "gh"
+        nested.mkdir(parents=True)
+        (nested / "hosts.yml").write_text("github.com:\n  user: ywatanabe\n")
+        home = tmp_path / "home"
+        # Act
+        materialize_to_home(spec_dir, home)
+        # Assert
+        assert (home / ".config" / "gh" / "hosts.yml").exists()
+
+    def test_nested_directory_content_preserved(self, tmp_path):
+        # Arrange
+        spec_dir = tmp_path / "spec"
+        nested = spec_dir / "to_home" / "secrets"
+        nested.mkdir(parents=True)
+        (nested / "bot_token").write_text("abcd1234\n")
+        home = tmp_path / "home"
+        # Act
+        materialize_to_home(spec_dir, home)
+        # Assert
+        assert (home / "secrets" / "bot_token").read_text() == "abcd1234\n"
+
+    def test_empty_to_home_dir_creates_workspace_home(self, tmp_path):
+        # Arrange — empty to_home/.
+        spec_dir = tmp_path / "spec"
+        (spec_dir / "to_home").mkdir(parents=True)
+        home = tmp_path / "home"
+        # Act
+        materialize_to_home(spec_dir, home)
+        # Assert
+        assert home.is_dir()
+
+
+# ---------------------------------------------------------------------------
+# Symlink preservation
+# ---------------------------------------------------------------------------
+
+
+class TestSymlinkPreservation:
+    def test_relative_symlink_lands_as_symlink_in_home(self, tmp_path):
+        # Arrange
+        spec_dir = tmp_path / "spec"
+        (spec_dir / "to_home").mkdir(parents=True)
+        (spec_dir / "to_home" / "real.txt").write_text("payload\n")
+        os.symlink("real.txt", spec_dir / "to_home" / "link.txt")
+        home = tmp_path / "home"
+        # Act
+        materialize_to_home(spec_dir, home)
+        # Assert
+        assert (home / "link.txt").is_symlink()
+
+    def test_relative_symlink_target_string_unchanged(self, tmp_path):
+        # Arrange
+        spec_dir = tmp_path / "spec"
+        (spec_dir / "to_home").mkdir(parents=True)
+        (spec_dir / "to_home" / "real.txt").write_text("payload\n")
+        os.symlink("real.txt", spec_dir / "to_home" / "link.txt")
+        home = tmp_path / "home"
+        # Act
+        materialize_to_home(spec_dir, home)
+        # Assert
+        assert os.readlink(home / "link.txt") == "real.txt"
+
+    def test_absolute_symlink_target_string_unchanged(self, tmp_path):
+        # Arrange — target outside to_home/ on the host, absolute.
+        external = tmp_path / "external_target"
+        external.write_text("external\n")
+        spec_dir = tmp_path / "spec"
+        (spec_dir / "to_home").mkdir(parents=True)
+        os.symlink(str(external), spec_dir / "to_home" / "abs_link")
+        home = tmp_path / "home"
+        # Act
+        materialize_to_home(spec_dir, home)
+        # Assert
+        assert os.readlink(home / "abs_link") == str(external)
+
+    def test_broken_symlink_lands_as_symlink_in_home(self, tmp_path):
+        # Arrange — link target doesn't exist; we still preserve the link.
+        spec_dir = tmp_path / "spec"
+        (spec_dir / "to_home").mkdir(parents=True)
+        os.symlink("nonexistent.txt", spec_dir / "to_home" / "dead_link")
+        home = tmp_path / "home"
+        # Act
+        materialize_to_home(spec_dir, home)
+        # Assert
+        assert (home / "dead_link").is_symlink()
+
+    def test_broken_symlink_target_string_unchanged(self, tmp_path):
+        # Arrange
+        spec_dir = tmp_path / "spec"
+        (spec_dir / "to_home").mkdir(parents=True)
+        os.symlink("nonexistent.txt", spec_dir / "to_home" / "dead_link")
+        home = tmp_path / "home"
+        # Act
+        materialize_to_home(spec_dir, home)
+        # Assert
+        assert os.readlink(home / "dead_link") == "nonexistent.txt"
+
+
+# ---------------------------------------------------------------------------
+# .env tight-perm semantics
+# ---------------------------------------------------------------------------
+
+
+class TestEnvFileChmod:
+    def test_env_file_lands_in_home(self, tmp_path):
+        # Arrange
+        spec_dir = tmp_path / "spec"
+        (spec_dir / "to_home").mkdir(parents=True)
+        (spec_dir / "to_home" / ".env").write_text("SECRET=xyz\n")
+        home = tmp_path / "home"
+        # Act
+        materialize_to_home(spec_dir, home)
+        # Assert
+        assert (home / ".env").exists()
+
+    def test_env_file_chmod_is_owner_read_write_only(self, tmp_path):
+        # Arrange
+        spec_dir = tmp_path / "spec"
+        (spec_dir / "to_home").mkdir(parents=True)
+        (spec_dir / "to_home" / ".env").write_text("SECRET=xyz\n")
+        home = tmp_path / "home"
+        # Act
+        materialize_to_home(spec_dir, home)
+        # Assert — only owner read+write (0600).
+        mode = stat.S_IMODE((home / ".env").stat().st_mode)
+        assert mode == 0o600
+
+
+# ---------------------------------------------------------------------------
+# Marker-protected merge: CLAUDE.md
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fresh_claude_md_under_home(tmp_path: Path) -> Path:
+    """Materialize a single CLAUDE.md under to_home/.claude/ and return
+    the resulting destination path. One-shot setup → many single-assert
+    tests.
+    """
+    spec_dir = tmp_path / "spec"
+    (spec_dir / "to_home" / ".claude").mkdir(parents=True)
+    (spec_dir / "to_home" / ".claude" / "CLAUDE.md").write_text(
+        "## Doctrine\nBe helpful.\n"
+    )
+    home = tmp_path / "home"
+    materialize_to_home(spec_dir, home)
+    return home / ".claude" / "CLAUDE.md"
+
+
+class TestMarkerProtectedClaudeMd:
+    def test_fresh_deploy_emits_start_marker(self, fresh_claude_md_under_home):
+        # Arrange
+        content = fresh_claude_md_under_home.read_text()
+        # Act
+        match = START_MARKER_RE.search(content)
+        # Assert
+        assert match is not None
+
+    def test_fresh_deploy_emits_end_marker(self, fresh_claude_md_under_home):
+        # Arrange
+        content = fresh_claude_md_under_home.read_text()
+        # Act
+        # Assert
+        assert END_MARKER in content
+
+    def test_fresh_deploy_includes_source_body(self, fresh_claude_md_under_home):
+        # Arrange
+        content = fresh_claude_md_under_home.read_text()
+        # Act
+        # Assert
+        assert "Be helpful." in content
+
+    def test_redeploy_preserves_user_tail_past_end_marker(self, tmp_path):
+        # Arrange
+        spec_dir = tmp_path / "spec"
+        (spec_dir / "to_home" / ".claude").mkdir(parents=True)
+        (spec_dir / "to_home" / ".claude" / "CLAUDE.md").write_text(
+            "## Doctrine\nBe helpful.\n"
+        )
+        home = tmp_path / "home"
+        materialize_to_home(spec_dir, home)
+        dst = home / ".claude" / "CLAUDE.md"
+        dst.write_text(dst.read_text() + "\n### My notes\nremember me\n")
+        # Act — redeploy.
+        materialize_to_home(spec_dir, home)
+        # Assert
+        assert "remember me" in dst.read_text()
+
+    def test_malformed_existing_markers_hard_abort(self, tmp_path):
+        # Arrange
+        spec_dir = tmp_path / "spec"
+        (spec_dir / "to_home" / ".claude").mkdir(parents=True)
+        (spec_dir / "to_home" / ".claude" / "CLAUDE.md").write_text(
+            "## Doctrine\nBe helpful.\n"
+        )
+        home = tmp_path / "home"
+        (home / ".claude").mkdir(parents=True)
+        # Two Start markers — invariant violation.
+        bad = (
+            "<!-- Start of scitex-agent-container generated section (ts1) -->\n"
+            f"{END_MARKER}\n"
+            "<!-- Start of scitex-agent-container generated section (ts2) -->\n"
+            f"{END_MARKER}\n"
+        )
+        (home / ".claude" / "CLAUDE.md").write_text(bad)
+        # Act
+        # Assert
+        with pytest.raises(WorkspaceCLAUDEMarkerError, match="expected exactly 1"):
+            materialize_to_home(spec_dir, home)
+
+
+@pytest.fixture
+def deployed_state_md(tmp_path: Path) -> Path:
+    """Materialize a single state.md under to_home/ and return the path."""
+    spec_dir = tmp_path / "spec"
+    (spec_dir / "to_home").mkdir(parents=True)
+    (spec_dir / "to_home" / "state.md").write_text("initial state\n")
+    home = tmp_path / "home"
+    materialize_to_home(spec_dir, home)
+    return home / "state.md"
+
+
+class TestMarkerProtectedStateMd:
+    def test_state_md_emits_start_marker(self, deployed_state_md):
+        # Arrange
+        content = deployed_state_md.read_text()
+        # Act
+        match = START_MARKER_RE.search(content)
+        # Assert
+        assert match is not None
+
+    def test_state_md_emits_end_marker(self, deployed_state_md):
+        # Arrange
+        content = deployed_state_md.read_text()
+        # Act
+        # Assert
+        assert END_MARKER in content
+
+
+# ---------------------------------------------------------------------------
+# deploy_to_home — AgentConfig-driven entrypoint.
+# ---------------------------------------------------------------------------
+
+
+class TestDeployToHomeFromConfig:
+    def test_metadata_name_is_interpolated_in_claude_md(self, tmp_path):
+        # Arrange
+        cfg, root = _build_cfg(tmp_path)
+        (root / ".claude").mkdir()
+        (root / ".claude" / "CLAUDE.md").write_text("Agent name: ${metadata.name}\n")
+        home = tmp_path / "home"
+        # Act
+        deploy_to_home(cfg, str(home))
+        # Assert
+        assert "Agent name: test-agent" in (home / ".claude" / "CLAUDE.md").read_text()
+
+    def test_metadata_label_is_interpolated_in_claude_md(self, tmp_path):
+        # Arrange
+        cfg, root = _build_cfg(tmp_path, labels={"role": "dev"})
+        (root / ".claude").mkdir()
+        (root / ".claude" / "CLAUDE.md").write_text("Role: ${metadata.labels.role}\n")
+        home = tmp_path / "home"
+        # Act
+        deploy_to_home(cfg, str(home))
+        # Assert
+        assert "Role: dev" in (home / ".claude" / "CLAUDE.md").read_text()
+
+    def test_env_var_is_interpolated_when_present(self, tmp_path, env_save_restore):
+        # Arrange
+        env_save_restore.set("MY_TEST_HOST", "spartan-gpgpu180")
+        cfg, root = _build_cfg(tmp_path)
+        (root / ".bashrc").write_text("export HOST=${MY_TEST_HOST}\n")
+        home = tmp_path / "home"
+        # Act
+        deploy_to_home(cfg, str(home))
+        # Assert
+        assert "export HOST=spartan-gpgpu180" in (home / ".bashrc").read_text()
+
+    def test_missing_to_home_is_noop_via_deploy_entrypoint(self, tmp_path):
+        # Arrange — config_path points at a dir without to_home/.
+        cfg = AgentConfig(name="ghost")
+        cfg.config_path = str(tmp_path / "ghost" / "spec.yaml")
+        cfg.to_home = ""
+        home = tmp_path / "home"
+        # Act
+        deploy_to_home(cfg, str(home))
+        # Assert
+        assert (not home.exists()) or (not any(home.iterdir()))
+
+    def test_binary_file_falls_back_to_byte_copy(self, tmp_path):
+        # Arrange — embed a binary blob; interpolation must not error.
+        cfg, root = _build_cfg(tmp_path)
+        payload = bytes(range(256))
+        (root / "blob.bin").write_bytes(payload)
+        home = tmp_path / "home"
+        # Act
+        deploy_to_home(cfg, str(home))
+        # Assert
+        assert (home / "blob.bin").read_bytes() == payload


### PR DESCRIPTION
## Summary

- New `runtimes/_to_home.py` mirrors `<spec_dir>/to_home/` into the agent's container `$HOME` (= `runtime/<name>/home/` on the host) on every start. Replaces the leaf-vs-mirror split of `dot_claude/` — every path under `to_home/` lands at the same relative path inside `$HOME`.
- Per-entry semantics: marker-protected merge for `CLAUDE.md` / `state.md`; `chmod 0600` on `.env`; verbatim symlink preservation; recursive directory mirroring; full overwrite for other regular files. Marker primitives reused from `_dot_claude` so the safety contract is one source of truth.
- `dot_claude/` is deprecated, not deleted — kept alive for one release. Agent-start emits a `DeprecationWarning` on legacy-only specs and raises `RuntimeError` if a spec carries both layouts at once (no silent merge — data-loss risk).
- New spec field `AgentConfig.to_home: str = "./to_home"` (parser + validator updated).
- ADR-0006 documents the rationale and per-entry contract (cites lead's FUTURE doc `sac-to_home-refactor.md`).

## Test plan

- [x] New `tests/scitex_agent_container/runtimes/test__to_home.py` — 28 tests covering happy path (file copy), marker-protected merge, symlink preservation (relative / absolute / broken), `.env` chmod, directory recursion, missing-`to_home/` no-op, env interpolation.
- [x] Existing dot_claude tests (87) remain green.
- [x] Existing claude_session / config tests (379) remain green.
- [x] Pre-push lint gate clean (`ruff check --select F401,F811` on src/ + tests/).
- [x] YAML parsing smoke-tested both with explicit `spec.to_home: ./my_home` and with the default.

Reproduce locally:
```
pytest /full/path/to/scitex-agent-container/tests/scitex_agent_container/runtimes/test__to_home.py
```

## Notes

- Companion dotfiles PR migrates the 6 existing `proj-*` agent specs from `dot_claude/CLAUDE.md` to `to_home/CLAUDE.md` and adds the canonical `mkdir -p \$HOME/proj && ln -sfn /work \$HOME/proj/<pkg>` startup command — opened separately against the dotfiles repo.
- Pre-existing CI failures on `develop` (run 25986076140 / 25989028325) are unrelated to this change — they're the missing-OAuth-credentials issue in CI runners. Flagged for visibility, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)