### PR TITLE
fix(tests): bypass send preflight in CI

### DIFF
--- a/tests/scitex_agent_container/_state/test_fleet_template.py
+++ b/tests/scitex_agent_container/_state/test_fleet_template.py
@@ -250,8 +250,40 @@ def test_read_csv_rows_preserves_value_whitespace_verbatim(
 
 
 @pytest.fixture
-def cli_dry_run_result(tmp_path: Path):
-    """Invoke ``sac agent start --params-file --dry-run`` once."""
+def cli_dry_run_result(tmp_path: Path, env_save_restore):
+    """Invoke ``sac agent start --params-file --dry-run`` once.
+
+    The ``start`` command's preflight reads ``$HOME/.claude/.credentials.json``
+    on the actual-dispatch path; ``--dry-run`` still ends up exercising
+    that branch via the per-target loop, so we pin ``$HOME`` at the
+    test's ``tmp_path`` and install a fresh OAuth credentials file there
+    so CI runners (which have no such file) don't short-circuit before
+    the materialisation step we care about.
+    """
+    import json
+    import time
+
+    env_save_restore.set("HOME", str(tmp_path))
+    env_save_restore.delete("ANTHROPIC_API_KEY")
+    env_save_restore.delete("SAC_ANTHROPIC_API_KEY")
+    claude_dir = tmp_path / ".claude"
+    claude_dir.mkdir(parents=True, exist_ok=True)
+    expires_at_ms = int((time.time() + 3600) * 1000)
+    (claude_dir / ".credentials.json").write_text(
+        json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "sk-ant-oat-fake",
+                    "refreshToken": "sk-ant-ort-fake",
+                    "expiresAt": expires_at_ms,
+                    "scopes": ["user:inference"],
+                    "subscriptionType": "max",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
     template = tmp_path / "template.yaml"
     csv_file = tmp_path / "fleet.csv"
     _write(

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__start.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__start.py
@@ -25,11 +25,46 @@ smoke tests.
 
 from __future__ import annotations
 
+import json
+import time
 from pathlib import Path
 
 from click.testing import CliRunner
 
 from scitex_agent_container.cli_pkg.lifecycle._start import start
+
+
+def _install_fresh_creds(home: Path) -> Path:
+    """Write a non-expired OAuth credentials file under ``$home/.claude/``.
+
+    The start command's preflight (``_state._preflight_creds.check_oauth_token_expiry``)
+    reads ``$HOME/.claude/.credentials.json`` whenever an actual dispatch
+    is about to fire — CI runners don't have one, so the preflight
+    short-circuits with ``FileNotFoundError`` before the test's
+    singleton-skip / multiplex / dispatch branch ever executes. Tests
+    that pin ``$HOME`` to ``tmp_path`` and call this helper get a
+    deterministic fresh-token preflight on any host.
+    """
+    claude_dir = home / ".claude"
+    claude_dir.mkdir(parents=True, exist_ok=True)
+    creds = claude_dir / ".credentials.json"
+    expires_at_ms = int((time.time() + 3600) * 1000)
+    creds.write_text(
+        json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "sk-ant-oat-fake",
+                    "refreshToken": "sk-ant-ort-fake",
+                    "expiresAt": expires_at_ms,
+                    "scopes": ["user:inference"],
+                    "subscriptionType": "max",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    return creds
+
 
 # ---------------------------------------------------------------------------
 # Argument-level validation — no collaborator is invoked; click parses,
@@ -221,6 +256,8 @@ class TestSingletonHostSkip:
     def test_single_target_singleton_skip_exits_clean(self, tmp_path, env_save_restore):
         # Arrange
         env_save_restore.set("SCITEX_AGENT_CONTAINER_HOSTNAME", "this-host")
+        env_save_restore.set("HOME", str(tmp_path))
+        _install_fresh_creds(tmp_path)
         yaml_path = _write_singleton_yaml(tmp_path, "mini", "nowhere-host")
         runner = CliRunner()
         # Act
@@ -233,6 +270,8 @@ class TestSingletonHostSkip:
     ):
         # Arrange
         env_save_restore.set("SCITEX_AGENT_CONTAINER_HOSTNAME", "this-host")
+        env_save_restore.set("HOME", str(tmp_path))
+        _install_fresh_creds(tmp_path)
         yaml_path = _write_singleton_yaml(tmp_path, "mini", "nowhere-host")
         runner = CliRunner()
         # Act
@@ -245,6 +284,8 @@ class TestSingletonHostSkip:
     ):
         # Arrange
         env_save_restore.set("SCITEX_AGENT_CONTAINER_HOSTNAME", "this-host")
+        env_save_restore.set("HOME", str(tmp_path))
+        _install_fresh_creds(tmp_path)
         yaml_path = _write_singleton_yaml(tmp_path, "mini", "nowhere-host")
         runner = CliRunner()
         # Act
@@ -257,6 +298,8 @@ class TestSingletonHostSkip:
     ):
         # Arrange
         env_save_restore.set("SCITEX_AGENT_CONTAINER_HOSTNAME", "this-host")
+        env_save_restore.set("HOME", str(tmp_path))
+        _install_fresh_creds(tmp_path)
         agents_dir = tmp_path / "agents"
         _write_singleton_yaml(agents_dir, "aa", "nowhere-host")
         _write_singleton_yaml(agents_dir, "bb", "nowhere-host")
@@ -269,6 +312,8 @@ class TestSingletonHostSkip:
     def test_bulk_directory_singleton_skip_exits_zero(self, tmp_path, env_save_restore):
         # Arrange
         env_save_restore.set("SCITEX_AGENT_CONTAINER_HOSTNAME", "this-host")
+        env_save_restore.set("HOME", str(tmp_path))
+        _install_fresh_creds(tmp_path)
         agents_dir = tmp_path / "agents"
         _write_singleton_yaml(agents_dir, "aa", "nowhere-host")
         _write_singleton_yaml(agents_dir, "bb", "nowhere-host")
@@ -290,6 +335,8 @@ class TestResumeAndForeground:
         # Arrange — --resume without --session must default session_mode to
         # "resume" rather than rejecting the invocation.
         env_save_restore.set("SCITEX_AGENT_CONTAINER_HOSTNAME", "this-host")
+        env_save_restore.set("HOME", str(tmp_path))
+        _install_fresh_creds(tmp_path)
         yaml_path = _write_singleton_yaml(tmp_path, "mini", "nowhere-host")
         runner = CliRunner()
         # Act
@@ -302,6 +349,8 @@ class TestResumeAndForeground:
     ):
         # Arrange
         env_save_restore.set("SCITEX_AGENT_CONTAINER_HOSTNAME", "this-host")
+        env_save_restore.set("HOME", str(tmp_path))
+        _install_fresh_creds(tmp_path)
         yaml_path = _write_singleton_yaml(tmp_path, "mini", "nowhere-host")
         runner = CliRunner()
         # Act
@@ -319,6 +368,8 @@ class TestResumeAndForeground:
         # multiplex call; we just exercise the branch where foreground gets
         # demoted from True -> False.
         env_save_restore.set("SCITEX_AGENT_CONTAINER_HOSTNAME", "this-host")
+        env_save_restore.set("HOME", str(tmp_path))
+        _install_fresh_creds(tmp_path)
         y1 = _write_singleton_yaml(tmp_path, "mini1", "nowhere-host")
         y2 = _write_singleton_yaml(tmp_path, "mini2", "nowhere-host")
         runner = CliRunner()
@@ -332,6 +383,8 @@ class TestResumeAndForeground:
     ):
         # Arrange
         env_save_restore.set("SCITEX_AGENT_CONTAINER_HOSTNAME", "this-host")
+        env_save_restore.set("HOME", str(tmp_path))
+        _install_fresh_creds(tmp_path)
         agents_dir = tmp_path / "agents"
         _write_singleton_yaml(agents_dir, "aa", "nowhere-host")
         _write_singleton_yaml(agents_dir, "bb", "nowhere-host")
@@ -381,6 +434,7 @@ class TestDispatchBranch:
         # local spec dir exists under ``~/.scitex/agent-container/agents/``.
         env_save_restore.set("SCITEX_AGENT_CONTAINER_HOSTNAME", "this-host")
         env_save_restore.set("HOME", str(tmp_path))
+        _install_fresh_creds(tmp_path)
         cfg = _write_peer_config(tmp_path, "remote-host")
         env_save_restore.set("SCITEX_AGENT_CONTAINER_CONFIG", str(cfg))
         yaml_path = _write_singleton_yaml(tmp_path, "mini", "remote-host")
@@ -397,6 +451,7 @@ class TestDispatchBranch:
         # know the routing branch handed off the resolved peer.
         env_save_restore.set("SCITEX_AGENT_CONTAINER_HOSTNAME", "this-host")
         env_save_restore.set("HOME", str(tmp_path))
+        _install_fresh_creds(tmp_path)
         cfg = _write_peer_config(tmp_path, "remote-host")
         env_save_restore.set("SCITEX_AGENT_CONTAINER_CONFIG", str(cfg))
         yaml_path = _write_singleton_yaml(tmp_path, "mini", "remote-host")
@@ -414,6 +469,7 @@ class TestDispatchBranch:
         # branch.
         env_save_restore.set("SCITEX_AGENT_CONTAINER_HOSTNAME", "this-host")
         env_save_restore.set("HOME", str(tmp_path))
+        _install_fresh_creds(tmp_path)
         cfg = _write_peer_config(tmp_path, "remote-host")
         env_save_restore.set("SCITEX_AGENT_CONTAINER_CONFIG", str(cfg))
         yaml_path = _write_singleton_yaml(tmp_path, "mini", "remote-host")
@@ -465,6 +521,8 @@ class TestDispatchBranch:
         # routing branch falls through, and singleton-skip emits the
         # ``Skipping 'mini'`` line.
         env_save_restore.set("SCITEX_AGENT_CONTAINER_HOSTNAME", "this-host")
+        env_save_restore.set("HOME", str(tmp_path))
+        _install_fresh_creds(tmp_path)
         cfg = _write_peer_config(tmp_path, "remote-host")
         env_save_restore.set("SCITEX_AGENT_CONTAINER_CONFIG", str(cfg))
         yaml_path = _write_singleton_yaml(tmp_path, "mini", "unknown-host")

--- a/tests/scitex_agent_container/cli_pkg/test__send.py
+++ b/tests/scitex_agent_container/cli_pkg/test__send.py
@@ -21,8 +21,11 @@ carries Arrange / Act / Assert markers.
 from __future__ import annotations
 
 import importlib
+import json
 import os
+import time
 from contextlib import contextmanager
+from pathlib import Path
 from typing import Iterator
 
 import pytest
@@ -44,6 +47,50 @@ def _swap_post_turn(fn) -> Iterator[None]:
         yield
     finally:
         _send_mod._post_turn = saved  # type: ignore[assignment]
+
+
+# ---------------------------------------------------------------------------
+# Fresh OAuth credentials fixture
+#
+# PR #114 wired ``preflight_send_creds`` into ``send_to_agent`` so a stale
+# ``~/.claude/.credentials.json`` short-circuits dispatch with
+# ``status="creds-expired"`` BEFORE the test's mocked ``_post_turn`` ever
+# runs. CI runners don't have the operator's credentials file at all,
+# which fires the same short-circuit (``FileNotFoundError`` → mapped to
+# ``creds-expired``).
+#
+# The production helper accepts ``lead_creds_path=`` as an explicit
+# injection seam (see ``_send.send_to_agent`` docstring) — tests that
+# need to exercise the post-preflight code path pass an explicit tmp
+# creds file so the preflight passes deterministically on any host.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fresh_lead_creds_path(tmp_path) -> Path:
+    """Return a path to a fresh, non-expired OAuth credentials JSON.
+
+    Matches the shape ``_state._preflight_creds.check_oauth_token_expiry``
+    reads: ``{"claudeAiOauth": {"expiresAt": <unix-millis>, ...}}`` with
+    expiry one hour in the future (well beyond the 5-minute skew window).
+    """
+    creds = tmp_path / ".credentials.json"
+    expires_at_ms = int((time.time() + 3600) * 1000)
+    creds.write_text(
+        json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "sk-ant-oat-fake",
+                    "refreshToken": "sk-ant-ort-fake",
+                    "expiresAt": expires_at_ms,
+                    "scopes": ["user:inference"],
+                    "subscriptionType": "max",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    return creds
 
 
 # ---------------------------------------------------------------------------
@@ -94,7 +141,7 @@ def _seed_remote(name: str, peer: str, a2a_port: int) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_agent_send_returns_dict_with_status_field(state_db_env):
+def test_agent_send_returns_dict_with_status_field(state_db_env, fresh_lead_creds_path):
     # Arrange
     _seed_local("alpha", a2a_port=12345)
 
@@ -103,12 +150,14 @@ def test_agent_send_returns_dict_with_status_field(state_db_env):
 
     # Act
     with _swap_post_turn(fake_post):
-        result = send_to_agent("alpha", "hi")
+        result = send_to_agent("alpha", "hi", lead_creds_path=fresh_lead_creds_path)
     # Assert
     assert "status" in result
 
 
-def test_agent_send_status_ok_on_successful_response(state_db_env):
+def test_agent_send_status_ok_on_successful_response(
+    state_db_env, fresh_lead_creds_path
+):
     # Arrange
     _seed_local("alpha", a2a_port=12345)
 
@@ -117,12 +166,14 @@ def test_agent_send_status_ok_on_successful_response(state_db_env):
 
     # Act
     with _swap_post_turn(fake_post):
-        result = send_to_agent("alpha", "hi")
+        result = send_to_agent("alpha", "hi", lead_creds_path=fresh_lead_creds_path)
     # Assert
     assert result["status"] == "ok"
 
 
-def test_agent_send_returns_response_text_field_on_success(state_db_env):
+def test_agent_send_returns_response_text_field_on_success(
+    state_db_env, fresh_lead_creds_path
+):
     # Arrange
     _seed_local("alpha", a2a_port=12345)
 
@@ -131,7 +182,7 @@ def test_agent_send_returns_response_text_field_on_success(state_db_env):
 
     # Act
     with _swap_post_turn(fake_post):
-        result = send_to_agent("alpha", "hi")
+        result = send_to_agent("alpha", "hi", lead_creds_path=fresh_lead_creds_path)
     # Assert
     assert result["response_text"] == "the reply"
 
@@ -162,7 +213,7 @@ def test_agent_send_error_message_when_agent_not_running(state_db_env):
 # ---------------------------------------------------------------------------
 
 
-def test_agent_send_status_timeout_on_slow_sidecar(state_db_env):
+def test_agent_send_status_timeout_on_slow_sidecar(state_db_env, fresh_lead_creds_path):
     # Arrange
     _seed_local("alpha", a2a_port=12345)
     from scitex_agent_container._network.peer import PeerError
@@ -172,12 +223,16 @@ def test_agent_send_status_timeout_on_slow_sidecar(state_db_env):
 
     # Act
     with _swap_post_turn(fake_post):
-        result = send_to_agent("alpha", "hi", timeout_seconds=2)
+        result = send_to_agent(
+            "alpha", "hi", timeout_seconds=2, lead_creds_path=fresh_lead_creds_path
+        )
     # Assert
     assert result["status"] == "timeout"
 
 
-def test_agent_send_timeout_error_message_quotes_timeout_value(state_db_env):
+def test_agent_send_timeout_error_message_quotes_timeout_value(
+    state_db_env, fresh_lead_creds_path
+):
     # Arrange
     _seed_local("alpha", a2a_port=12345)
     from scitex_agent_container._network.peer import PeerError
@@ -187,7 +242,9 @@ def test_agent_send_timeout_error_message_quotes_timeout_value(state_db_env):
 
     # Act
     with _swap_post_turn(fake_post):
-        result = send_to_agent("alpha", "hi", timeout_seconds=2)
+        result = send_to_agent(
+            "alpha", "hi", timeout_seconds=2, lead_creds_path=fresh_lead_creds_path
+        )
     # Assert
     assert "2s" in result["error"]
 
@@ -228,7 +285,7 @@ def test_agent_send_neither_prompt_nor_key_raises_value_error(state_db_env):
 # ---------------------------------------------------------------------------
 
 
-def test_agent_send_cross_host_routes_through_ssh(state_db_env):
+def test_agent_send_cross_host_routes_through_ssh(state_db_env, fresh_lead_creds_path):
     # Arrange
     _seed_remote("beta", peer="peer-x", a2a_port=18888)
     captured: dict = {}
@@ -237,14 +294,27 @@ def test_agent_send_cross_host_routes_through_ssh(state_db_env):
         captured["url"] = url
         return ("ok", {})
 
+    # Cross-host preflight also ssh-probes the peer; inject a stub
+    # runner that returns rc=0 so the preflight passes without invoking
+    # real ssh. (Lead-local probe is satisfied by ``fresh_lead_creds_path``.)
+    import subprocess
+
+    def fake_ssh_runner(peer_host, remote_creds_path):
+        return subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+
     # Act
     with _swap_post_turn(fake_post):
-        send_to_agent("beta", "hi")
+        send_to_agent(
+            "beta",
+            "hi",
+            lead_creds_path=fresh_lead_creds_path,
+            ssh_runner=fake_ssh_runner,
+        )
     # Assert
     assert captured["url"] == "ssh://peer-x:18888/v1/turn"
 
 
-def test_agent_send_local_host_uses_loopback_url(state_db_env):
+def test_agent_send_local_host_uses_loopback_url(state_db_env, fresh_lead_creds_path):
     # Arrange
     _seed_local("alpha", a2a_port=12345)
     captured: dict = {}
@@ -255,7 +325,7 @@ def test_agent_send_local_host_uses_loopback_url(state_db_env):
 
     # Act
     with _swap_post_turn(fake_post):
-        send_to_agent("alpha", "hi")
+        send_to_agent("alpha", "hi", lead_creds_path=fresh_lead_creds_path)
     # Assert
     assert captured["url"] == "http://127.0.0.1:12345/v1/turn"
 
@@ -265,7 +335,9 @@ def test_agent_send_local_host_uses_loopback_url(state_db_env):
 # ---------------------------------------------------------------------------
 
 
-def test_agent_send_includes_response_metadata_on_success(state_db_env):
+def test_agent_send_includes_response_metadata_on_success(
+    state_db_env, fresh_lead_creds_path
+):
     # Arrange
     _seed_local("alpha", a2a_port=12345)
 
@@ -274,7 +346,7 @@ def test_agent_send_includes_response_metadata_on_success(state_db_env):
 
     # Act
     with _swap_post_turn(fake_post):
-        result = send_to_agent("alpha", "hi")
+        result = send_to_agent("alpha", "hi", lead_creds_path=fresh_lead_creds_path)
     # Assert
     assert result["response_metadata"]["name"] == "alpha"
 
@@ -290,7 +362,9 @@ def test_agent_send_error_when_row_has_no_a2a_port(state_db_env):
     assert result["status"] == "error"
 
 
-def test_agent_send_error_when_sidecar_returns_non_200(state_db_env):
+def test_agent_send_error_when_sidecar_returns_non_200(
+    state_db_env, fresh_lead_creds_path
+):
     # Arrange
     _seed_local("alpha", a2a_port=12345)
     from scitex_agent_container._network.peer import PeerError
@@ -300,6 +374,8 @@ def test_agent_send_error_when_sidecar_returns_non_200(state_db_env):
 
     # Act
     with _swap_post_turn(fake_post):
-        result = send_to_agent("alpha", "hi", timeout_seconds=2)
+        result = send_to_agent(
+            "alpha", "hi", timeout_seconds=2, lead_creds_path=fresh_lead_creds_path
+        )
     # Assert
     assert result["status"] == "error"

--- a/tests/smoke/test_sac_cli_smoke.py
+++ b/tests/smoke/test_sac_cli_smoke.py
@@ -14,13 +14,44 @@ assert, ≥3-word test names, ``pytest.mark.smoke``.
 
 from __future__ import annotations
 
+import json
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 import pytest
 
 pytestmark = pytest.mark.smoke
+
+
+def _install_fresh_creds(home: Path) -> Path:
+    """Write a non-expired OAuth credentials file under ``$home/.claude/``.
+
+    The ``agents start`` preflight reads ``$HOME/.claude/.credentials.json``;
+    CI runners don't have one, so the smoke subprocess exits 1 before the
+    --dry-run path ever runs. Mirrors the same helper in
+    ``tests/scitex_agent_container/cli_pkg/lifecycle/test__start.py``.
+    """
+    claude_dir = home / ".claude"
+    claude_dir.mkdir(parents=True, exist_ok=True)
+    creds = claude_dir / ".credentials.json"
+    expires_at_ms = int((time.time() + 3600) * 1000)
+    creds.write_text(
+        json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "sk-ant-oat-fake",
+                    "refreshToken": "sk-ant-ort-fake",
+                    "expiresAt": expires_at_ms,
+                    "scopes": ["user:inference"],
+                    "subscriptionType": "max",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    return creds
 
 
 # ---------------------------------------------------------------------------
@@ -126,6 +157,7 @@ def test_sac_agents_start_dry_run_against_real_spec_yaml(tmp_path, env_save_rest
     home = tmp_path / "home"
     home.mkdir()
     env_save_restore.set("HOME", str(home))
+    _install_fresh_creds(home)
     spec = tmp_path / "smoke-agent" / "spec.yaml"
     spec.parent.mkdir()
     spec.write_text(_MINIMAL_V3_SPEC)


### PR DESCRIPTION
## Root cause

PR #114 (merged to develop, commit 7dcefc2) added a preflight OAuth-creds
check via ``preflight_send_creds(...)`` inside ``send_to_agent`` at
``src/scitex_agent_container/cli_pkg/_send.py:149``. The same OAuth check
also fires inside ``cli_pkg.lifecycle._start`` via
``_state._preflight_creds.check_oauth_token_expiry`` whenever an actual
dispatch is about to fire.

Both helpers default to ``~/.claude/.credentials.json``. CI runners have
no such file, so the preflight short-circuits and returns
``{"status": "creds-expired", ...}`` (for ``send_to_agent``) or exits 1
(for the ``start`` command) BEFORE the test's swapped collaborator ever
runs. This makes ~20 tests across three files fail with assertions like
``assert 'creds-expired' == 'ok'``.

## Fix

Use the existing ``lead_creds_path=`` injection seam that ``_send.py``
already documents (``_send.py:86-90``) and the ``HOME`` env override
already exercised by ``test__start_preflight.py``. Both surfaces are
production-supported test seams; no production code changes.

* **``test__send.py``** - added a ``fresh_lead_creds_path`` fixture
  that builds a non-expired OAuth credentials JSON (1h in the future,
  matching the shape ``check_oauth_token_expiry`` reads) and threaded
  it through every ``send_to_agent`` call that exercises the
  post-preflight code path. Cross-host test also injects a stub
  ``ssh_runner`` so the peer probe returns rc=0 without invoking real
  ssh.
* **``lifecycle/test__start.py``** - added an ``_install_fresh_creds
  (home)`` helper mirroring the existing ``_install_expired_creds`` in
  ``test__start_preflight.py``. Each failing test now pins ``$HOME`` at
  its ``tmp_path`` and writes a fresh creds file under it.
* **``_state/test_fleet_template.py``** - added the same ``HOME`` +
  fresh-creds setup to the ``cli_dry_run_result`` fixture.

Constraints honoured: no production code changes; no mock library use;
no ``monkeypatch`` (PA-306 / STX-NM002) - all env mutations go through
the established ``env_save_restore`` save/restore fixture from
``tests/scitex_agent_container/_helpers/subprocess_shim.py``.

## Verification

Locally reproduced CI conditions via ``env -i HOME=/tmp/fake-ci-home``
and verified the diagnosis (8 tests in ``test__send.py``, 13 in
``test__start.py``, 1 in ``test_fleet_template.py`` failed before the
fix; all 64 pass after).

## Test plan

- [x] ``test__send.py`` - 14 tests pass under CI-scrubbed env
- [x] ``lifecycle/test__start.py`` - 30 tests pass under CI-scrubbed env
- [x] ``_state/test_fleet_template.py`` - 20 tests pass under CI-scrubbed env
- [x] Adjacent ``test__start_preflight.py`` still green (6/6) - no regression
- [ ] CI green on this branch

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>