### PR TITLE
release: v0.17.0 (version bump)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-agent-container"
-version = "0.16.0"
+version = "0.17.0"
 description = "Declarative YAML-based framework for defining, managing, and orchestrating AI coding agent instances"
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
## Summary

Version bump 0.16.0 → 0.17.0 on develop. Required because v0.16.0 was already tagged at the pre-#118 main HEAD on 2026-05-15.

Once this lands on develop, opens a follow-up develop→main PR to actually release 0.17.0; tag-push triggers PyPI auto-publish via `pypi-publish-and-github-release-on-tag.yml`.

## Test plan

- [x] User accepted 0.17.0 minor over 0.16.1 patch (Telegram Q2 → "B")
- [ ] CI green