### PR TITLE
fix(ci): rename PERSONAL_ACCESS_TOKEN to SAC_PERSONAL_ACCESS_TOKEN

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -20,7 +20,7 @@ jobs:
         uses: contributor-assistant/github-action@v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.SAC_PERSONAL_ACCESS_TOKEN }}
         with:
           path-to-signatures: "signatures/cla.json"
           path-to-document: "https://github.com/ywatanabe1989/scitex-agent-container/blob/main/CLA.md"


### PR DESCRIPTION
PS-168 (narrowed 2026-05-18) flags the cla.yml's secrets.PERSONAL_ACCESS_TOKEN — rename to SAC_PERSONAL_ACCESS_TOKEN using the accepted SAC_ alias. env-var the action sees stays unchanged. After merge, populate the new secret in repo Settings before the CLA workflow's next run.