### PR TITLE
refactor(ci): rename cla secret to CLA_PERSONAL_ACCESS_TOKEN

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -20,7 +20,7 @@ jobs:
         uses: contributor-assistant/github-action@v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.SAC_PERSONAL_ACCESS_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_PERSONAL_ACCESS_TOKEN }}
         with:
           path-to-signatures: "signatures/cla.json"
           path-to-document: "https://github.com/ywatanabe1989/scitex-agent-container/blob/main/CLA.md"


### PR DESCRIPTION
Renames the contributor-assistant PAT from SAC_PERSONAL_ACCESS_TOKEN to CLA_PERSONAL_ACCESS_TOKEN, matching the per-action convention shared across repos that opt into the CLA gate. scitex-dev added the same exception in scitex-dev#37; the auditor accepts the bare CLA_PERSONAL_ACCESS_TOKEN name via EXCEPTION_SECRETS. After merge, populate the new secret in repo Settings.