### PR TITLE
feat(wi-3): external nodes join the comms graph on `sac listen`

### DIFF
--- a/src/scitex_agent_container/_listen/_nodes.py
+++ b/src/scitex_agent_container/_listen/_nodes.py
@@ -1,0 +1,175 @@
+"""External-node registry + comms broker for ``sac listen`` (WI-3).
+
+External nodes are first-class on the sac comms graph: an *identity*
++ *inbox* + *ACL*, with **no spec and no lifecycle**. The handoff
+``HANDOFF_AGENT_COMMS_2026-05-19.md`` §2 captures the model:
+
+  > Two kinds [of node], distinguished *only* by who owns the
+  > lifecycle:
+  >   - *sac-managed* — sac owns the lifecycle (spec, container,
+  >     start/stop/health).
+  >   - *external* — sac does **not** own the lifecycle. Typically
+  >     a plain ``claude`` CLI session. ... An external node has an
+  >     identity + an inbox, joins via ``sac mcp channel``, and is
+  >     never started or stopped by sac.
+
+This module is the in-process state for external nodes attached to
+ONE ``sac listen`` host. It composes two pieces:
+
+* :class:`Broker` (re-exported from :mod:`a2a._inbox_bus`) — the
+  same in-memory pub/sub the per-agent A2A server uses; ``sac listen``
+  re-uses it so external nodes get the exact same delivery semantics
+  as sac-managed agents.
+
+* :class:`NodeRegistry` — caches the synthesised AgentCard for each
+  external node. Registration is implicit: the first time a name
+  appears on ``/agents/<name>/{message:send,inbox/stream}`` the
+  registry mints + caches a minimal A2A v1 AgentCard for that node
+  (handoff §4: "sac must synthesize a minimal AgentCard at
+  registration"). Subsequent
+  ``GET /agents/<name>/.well-known/agent-card.json`` lookups return
+  the cached card.
+
+Durability and ACL are intentionally *not* in this module — they
+land in WI-1 and WI-2 respectively. Keeping the seam clean means
+those layers slot in without restructuring this one.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+from ..a2a._inbox_bus import Broker  # re-exported for convenience
+
+__all__ = ["Broker", "NodeRegistry", "synthesize_external_card"]
+
+
+# Tag that distinguishes an external-node AgentCard from a YAML-backed
+# one. Consumers (orochi, fleet viz) read this to decide whether to
+# show lifecycle controls. Public so tests can import it.
+EXTERNAL_NODE_KIND = "external"
+
+
+class NodeRegistry:
+    """Track external nodes attached to one ``sac listen`` host.
+
+    Thread-safe (the listen server is async, but some callers reach
+    in from sync paths).
+    """
+
+    def __init__(self) -> None:
+        self._cards: dict[str, dict[str, Any]] = {}
+        self._lock = threading.Lock()
+
+    def register(self, name: str, base_url: str) -> dict[str, Any]:
+        """Idempotent: synthesise + cache an external-node AgentCard.
+
+        Returns the cached card on subsequent calls.
+        """
+        with self._lock:
+            existing = self._cards.get(name)
+            if existing is not None:
+                return existing
+            card = synthesize_external_card(name, base_url)
+            self._cards[name] = card
+            return card
+
+    def card(self, name: str) -> dict[str, Any] | None:
+        """Return the cached card for ``name`` or ``None`` if unknown."""
+        with self._lock:
+            return self._cards.get(name)
+
+    def has(self, name: str) -> bool:
+        with self._lock:
+            return name in self._cards
+
+    def names(self) -> list[str]:
+        """Sorted list of currently-registered external-node names."""
+        with self._lock:
+            return sorted(self._cards.keys())
+
+
+# --- AgentCard synthesis ---------------------------------------------------
+
+# Imported here (not at module top) to defer the dependency on the
+# A2A SDK proto types until the listen server is actually used —
+# keeps ``import scitex_agent_container`` lean.
+
+
+def synthesize_external_card(name: str, base_url: str) -> dict[str, Any]:
+    """Return a minimal A2A v1 AgentCard for an external node.
+
+    Carries identity + the inbox endpoint + the v1-required capability
+    fields, and **nothing runtime/container-shaped** — external nodes
+    have no spec (handoff §4 "A2A compliance without a YAML"). The
+    ``x-scitex-agent-container.node_kind`` extension field marks the
+    card as external so downstream tooling can branch on it without
+    consulting the registry.
+    """
+    base = base_url.rstrip("/")
+    agent_base = f"{base}/agents/{name}"
+    return {
+        "name": name,
+        "description": (
+            f"external node {name!r} — identity + inbox only, no sac-managed "
+            "lifecycle"
+        ),
+        # Version field is required by the proto. Use the v3 marker with
+        # an ``-external`` suffix so it's obvious in JSON dumps that the
+        # card is synthesised (not projected from a YAML).
+        "version": "scitex-agent-container/v3-external",
+        "supportedInterfaces": [
+            {
+                "url": agent_base,
+                "protocolBinding": "HTTP+JSON",
+                "tenant": name,
+                "protocolVersion": "1.0",
+            }
+        ],
+        "provider": {
+            "organization": "scitex-agent-container",
+            "url": "https://scitex.ai",
+        },
+        "capabilities": {
+            # Streaming SSE is always on for the inbox stream.
+            "streaming": True,
+            # An external node opts into the sac push channel by running
+            # ``sac mcp channel --name <id> --listen-url ...`` — same
+            # delivery shape as a sac-managed agent.
+            "pushNotifications": True,
+            "extendedAgentCard": False,
+            "extensions": [
+                {
+                    "uri": "https://scitex.ai/a2a/extensions/sac-push-channel/v1",
+                    "description": (
+                        "In-session MCP push: ``sac mcp channel`` subscribes "
+                        "to ``/agents/<name>/inbox/stream`` and delivers "
+                        "events as ``notifications/claude/channel`` to the "
+                        "external node's Claude session."
+                    ),
+                    "required": False,
+                    "params": {
+                        "sse_path": f"/agents/{name}/inbox/stream",
+                        "send_path": f"/agents/{name}/message:send",
+                        "mcp_tools": [
+                            "a2a_send",
+                            "a2a_reply",
+                            "a2a_ack",
+                            "a2a_peers",
+                            "a2a_inbox",
+                        ],
+                    },
+                }
+            ],
+        },
+        "defaultInputModes": ["text/plain", "application/json"],
+        "defaultOutputModes": ["text/plain", "application/json"],
+        # External nodes declare no skills — they are addressable
+        # identities, not catalogued capabilities. Empty list keeps the
+        # proto happy (the field is required, not its content).
+        "skills": [],
+        "x-scitex-agent-container": {
+            "node_kind": EXTERNAL_NODE_KIND,
+        },
+    }

--- a/src/scitex_agent_container/_listen/server.py
+++ b/src/scitex_agent_container/_listen/server.py
@@ -24,12 +24,14 @@ ADR-0004 (no backward compat).
 from __future__ import annotations
 
 import asyncio
+import json
 import json as _json
 import os
 import shutil
 import subprocess
 import urllib.error as _urlerror
 import urllib.request as _urlrequest
+from typing import Any
 
 from starlette.applications import Starlette
 from starlette.requests import Request
@@ -38,9 +40,11 @@ from starlette.routing import Route
 
 from .._runners._session_state import read_session_id, state_dir_for
 from .._state.registry import Registry
+from ..a2a._inbox_bus import mint_event
 from ..config import load_config
 from ..config._resolve import resolve_config
 from ._inline_spec import materialize_inline_spec
+from ._nodes import Broker, NodeRegistry
 from .auth import BearerAuthMiddleware
 
 # Re-exported under the module's public surface so unit tests can patch
@@ -349,28 +353,45 @@ async def agents_start(request: Request) -> JSONResponse:
 async def agent_card(request: Request) -> JSONResponse:
     """GET /agents/<name>/.well-known/agent-card.json.
 
-    A2A v1.0 canonical per-agent AgentCard built from the agent's v3
-    spec. The pre-v1 ``/agents/<name>/card`` route was dropped per
-    ADR-0004 (no backward compat).
+    Resolution order (handoff §4 — A2A compliance for both kinds of
+    node):
+      1. sac-managed agent — look up the YAML via ``resolve_config``
+         and project the v3 spec onto a v1 AgentCard.
+      2. external node — return the synthesised card cached by
+         :class:`NodeRegistry` (registered implicitly on first
+         ``message:send`` / ``inbox/stream`` touch).
+
+    Only 404 when *neither* path can produce a card.
     """
     import yaml
 
     from ..a2a._card import project_card
 
     name = request.path_params["name"]
+    base_url = str(request.base_url).rstrip("/")
+
+    # 1) sac-managed (YAML-backed) — preserve the existing behaviour.
     try:
         spec_path = resolve_config(name)
-    except Exception as exc:
-        return JSONResponse({"error": str(exc)}, status_code=404)
-    try:
-        with open(spec_path, encoding="utf-8") as fh:
-            v3 = yaml.safe_load(fh) or {}
-    except OSError as exc:
-        return JSONResponse({"error": str(exc)}, status_code=500)
+    except Exception:
+        spec_path = None
+    if spec_path is not None:
+        try:
+            with open(spec_path, encoding="utf-8") as fh:
+                v3 = yaml.safe_load(fh) or {}
+        except OSError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=500)
+        return JSONResponse(project_card(name, v3, base_url))
 
-    base_url = str(request.base_url).rstrip("/")
-    card = project_card(name, v3, base_url)
-    return JSONResponse(card)
+    # 2) external node — synthesised card cached at registration.
+    nodes: NodeRegistry = request.app.state.nodes
+    card = nodes.card(name)
+    if card is not None:
+        return JSONResponse(card)
+
+    return JSONResponse(
+        {"error": f"unknown agent or node: {name!r}"}, status_code=404
+    )
 
 
 async def fleet_card_handler(request: Request) -> JSONResponse:
@@ -394,6 +415,154 @@ async def fleet_card_handler(request: Request) -> JSONResponse:
     return JSONResponse(card)
 
 
+# --- WI-3 external nodes: inbox endpoints on the host control plane ------
+#
+# The handoff (HANDOFF_AGENT_COMMS_2026-05-19.md §4) puts the inbox
+# endpoints (``message:send`` and ``inbox/stream``) on the always-on
+# ``sac listen`` host control-plane and makes them keyed by **node
+# identity** — they must accept a name that has no YAML and no
+# container. The handlers below are the implementation of that
+# requirement.
+#
+# Routes registered in ``_v1_agent_routes`` below:
+#
+#   POST /agents/{name}/message:send  → node_message_send
+#   GET  /agents/{name}/inbox/stream  → node_inbox_stream
+#
+# The agent-card route is *not* overridden here — instead
+# :func:`agent_card` falls back to the synthesised card for nodes
+# that are not YAML-backed. That fall-back is added to the existing
+# handler below.
+
+
+async def node_message_send(request: Request) -> Response:
+    """``POST /agents/<name>/message:send`` — publish an A2A
+    ``SendMessage`` body to the local node's inbox bus.
+
+    Implicitly registers ``<name>`` as an external node on first use
+    so the synthesised AgentCard is available for the well-known
+    lookup. The publish is **always loud** — a malformed body returns
+    400, never a silent drop (handoff §0 Hard rules).
+
+    No ACL gating yet — that lands in WI-2. Bearer auth (outer
+    perimeter) still applies via :class:`BearerAuthMiddleware`.
+    """
+    name = request.path_params["name"]
+    try:
+        body = await request.json()
+    except (ValueError, json.JSONDecodeError) as exc:
+        return JSONResponse(
+            {"error": f"body must be valid JSON: {exc}"}, status_code=400
+        )
+    if not isinstance(body, dict):
+        return JSONResponse(
+            {"error": "body must be a JSON object"}, status_code=400
+        )
+
+    method = body.get("method")
+    if method not in ("message/send", "SendMessage", "SendStreamingMessage"):
+        return JSONResponse(
+            {
+                "error": (
+                    f"unsupported method {method!r}; expected one of "
+                    "'message/send', 'SendMessage', 'SendStreamingMessage'"
+                )
+            },
+            status_code=400,
+        )
+
+    params = body.get("params") or {}
+    if not isinstance(params, dict):
+        return JSONResponse(
+            {"error": "params must be a JSON object"}, status_code=400
+        )
+    message = params.get("message") or {}
+    parts = message.get("parts") if isinstance(message, dict) else None
+    text = ""
+    if isinstance(parts, list):
+        for p in parts:
+            if isinstance(p, dict) and isinstance(p.get("text"), str):
+                text += p["text"]
+
+    # sac-extension metadata: same convention as a2a/_server.py — under
+    # ``params.metadata`` first, then ``message.metadata`` as a
+    # secondary, since some clients prefer message-scoped metadata.
+    sac_meta: dict[str, Any] = {}
+    for src in (params.get("metadata"), message.get("metadata")):
+        if isinstance(src, dict):
+            sac_meta.update(src)
+
+    event = mint_event(
+        name,
+        content=text,
+        from_agent=sac_meta.get("from_agent"),
+        conversation_id=sac_meta.get("conversation_id"),
+        in_reply_to=sac_meta.get("in_reply_to"),
+        priority=str(sac_meta.get("priority", "normal")),
+        requires_reply=bool(sac_meta.get("requires_reply", False)),
+    )
+
+    # Implicit registration — handoff §4 "A2A compliance without a
+    # YAML": synthesise the card the first time the name is touched.
+    base_url = str(request.base_url).rstrip("/")
+    nodes: NodeRegistry = request.app.state.nodes
+    broker: Broker = request.app.state.inbox
+    nodes.register(name, base_url)
+
+    delivered = await broker.publish(name, event)
+    return JSONResponse(
+        {
+            "msg_id": event["msg_id"],
+            "to_agent": name,
+            "delivered_subscriber_count": delivered,
+        }
+    )
+
+
+async def node_inbox_stream(request: Request) -> Response:
+    """``GET /agents/<name>/inbox/stream`` — SSE: one frame per event
+    published to ``<name>`` on this sac listen.
+
+    Consumed by ``sac mcp channel --name <name>`` inside an external
+    node's Claude session (or a sac-managed agent's container). The
+    frame shape is identical to ``a2a/_server.py``'s stream so the
+    same client adapter works for both kinds of node.
+
+    Implicitly registers ``<name>`` as an external node on first
+    connect.
+    """
+    from starlette.responses import StreamingResponse
+
+    name = request.path_params["name"]
+    base_url = str(request.base_url).rstrip("/")
+    nodes: NodeRegistry = request.app.state.nodes
+    broker: Broker = request.app.state.inbox
+    nodes.register(name, base_url)
+
+    queue = await broker.subscribe(name)
+
+    async def stream():
+        try:
+            # Comment-only frame so HTTP clients see the connection
+            # open immediately (and tests can race-free detect "I'm
+            # subscribed" before publishing).
+            yield b": sac-channel ready\n\n"
+            while True:
+                if await request.is_disconnected():
+                    return
+                event = await queue.get()
+                data = json.dumps(event, ensure_ascii=False)
+                yield f"event: message\ndata: {data}\n\n".encode("utf-8")
+        finally:
+            await broker.unsubscribe(name, queue)
+
+    return StreamingResponse(
+        stream(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )
+
+
 async def agent_delete(request: Request) -> JSONResponse:
     """DELETE /agents/<name> — stop the agent."""
     name = request.path_params["name"]
@@ -413,13 +582,29 @@ async def agent_delete(request: Request) -> JSONResponse:
 
 
 def _v1_agent_routes(prefix: str) -> list[Route]:
-    """Build the agent route set under ``prefix`` (ADR-0004: only ``/agents``)."""
+    """Build the agent route set under ``prefix`` (ADR-0004: only ``/agents``).
+
+    Includes the WI-3 inbox endpoints (``message:send`` and
+    ``inbox/stream``) which are keyed by node identity — they serve
+    sac-managed agents and external nodes equally.
+    """
     return [
         Route(f"{prefix}", list_agents, methods=["GET"]),
         Route(f"{prefix}", agents_start, methods=["POST"]),
         Route(f"{prefix}/{{name}}/status", agent_status, methods=["GET"]),
         Route(f"{prefix}/{{name}}/tail", agent_tail, methods=["GET"]),
         Route(f"{prefix}/{{name}}/send", agent_send, methods=["POST"]),
+        # WI-3 — node-identity-keyed inbox endpoints.
+        Route(
+            f"{prefix}/{{name}}/message:send",
+            node_message_send,
+            methods=["POST"],
+        ),
+        Route(
+            f"{prefix}/{{name}}/inbox/stream",
+            node_inbox_stream,
+            methods=["GET"],
+        ),
         Route(
             f"{prefix}/{{name}}/.well-known/agent-card.json",
             agent_card,
@@ -430,12 +615,21 @@ def _v1_agent_routes(prefix: str) -> list[Route]:
 
 
 def create_app(*, token: str) -> Starlette:
-    """Build the Starlette app with bearer auth (ADR-0004 — ``/agents`` only)."""
+    """Build the Starlette app with bearer auth (ADR-0004 — ``/agents`` only).
+
+    WI-3 wires a per-app :class:`Broker` + :class:`NodeRegistry` so
+    external nodes (no YAML, no container) can attach as first-class
+    members of the comms graph. The state lives on ``app.state`` so
+    every handler shares the same broker and registry instance.
+    """
     routes: list[Route] = [
         Route("/v1/health", health, methods=["GET"]),
         Route("/.well-known/agent-card.json", fleet_card_handler, methods=["GET"]),
     ]
     routes += _v1_agent_routes("/agents")
     app = Starlette(routes=routes)
+    # Per-app shared state for the WI-3 inbox surface.
+    app.state.inbox = Broker()
+    app.state.nodes = NodeRegistry()
     app.add_middleware(BearerAuthMiddleware, token=token)
     return app

--- a/tests/scitex_agent_container/_listen/test__nodes.py
+++ b/tests/scitex_agent_container/_listen/test__nodes.py
@@ -432,7 +432,9 @@ def test_message_send_without_bearer_token_is_rejected(client) -> None:
 
 
 def test_inbox_stream_without_bearer_token_is_rejected(client) -> None:
-    # Arrange / Act
-    resp = client.get("/agents/anything/inbox/stream")
+    # Arrange
+    path = "/agents/anything/inbox/stream"
+    # Act
+    resp = client.get(path)
     # Assert
     assert resp.status_code == 401

--- a/tests/scitex_agent_container/_listen/test__nodes.py
+++ b/tests/scitex_agent_container/_listen/test__nodes.py
@@ -1,4 +1,12 @@
-"""WI-3 — external nodes join the comms graph (handoff §4).
+"""Tests for ``_listen._nodes`` — external-node registry + AgentCard
+synthesis, exercised end-to-end through the ``sac listen`` inbox routes.
+
+Mirrors ``src/scitex_agent_container/_listen/_nodes.py``. The route
+handlers in ``_listen/server.py`` (``node_message_send``,
+``node_inbox_stream``) use ``NodeRegistry`` + ``Broker`` from this
+module; testing them together is what proves the
+``NodeRegistry.register`` / ``card`` / ``synthesize_external_card``
+contract.
 
 Per HANDOFF_AGENT_COMMS_2026-05-19.md §4 (WI-3 "External nodes join
 the comms graph"): sac must support a node with an identity + inbox
@@ -8,17 +16,18 @@ but **no spec and no lifecycle**. The inbox endpoints
 not by the presence of an agent YAML.
 
 These tests drive the real Starlette app through
-``starlette.testclient.TestClient`` (no mocks, per handoff §0 Hard
-rules). Real bearer auth, real Broker, real SSE — exactly the
-shape ``sac mcp channel`` will see in production.
+``starlette.testclient.TestClient`` and a real ``uvicorn`` loopback
+(no mocks, per handoff §0 Hard rules). Real bearer auth, real
+Broker, real SSE — exactly the shape ``sac mcp channel`` will see
+in production.
 
 Acceptance from §4: "a plain ``claude`` CLI session running
 ``sac mcp channel --name <id>`` receives, as
 ``<channel source="sac" ...>`` blocks, messages a permitted node
 sends to ``<id>`` — with no container and no spec for ``<id>``."
 
-This file exercises the HTTP-side of that acceptance: an inbox stream
-opens, a message is POSTed, the SSE frame is delivered.
+This file exercises the HTTP-side of that acceptance: an inbox
+stream opens, a message is POSTed, the SSE frame is delivered.
 """
 
 from __future__ import annotations

--- a/tests/scitex_agent_container/_listen/test_external_nodes.py
+++ b/tests/scitex_agent_container/_listen/test_external_nodes.py
@@ -1,0 +1,429 @@
+"""WI-3 — external nodes join the comms graph (handoff §4).
+
+Per HANDOFF_AGENT_COMMS_2026-05-19.md §4 (WI-3 "External nodes join
+the comms graph"): sac must support a node with an identity + inbox
+but **no spec and no lifecycle**. The inbox endpoints
+(``message:send`` and ``inbox/stream``) live on the always-on
+``sac listen`` host control-plane and are keyed by node identity —
+not by the presence of an agent YAML.
+
+These tests drive the real Starlette app through
+``starlette.testclient.TestClient`` (no mocks, per handoff §0 Hard
+rules). Real bearer auth, real Broker, real SSE — exactly the
+shape ``sac mcp channel`` will see in production.
+
+Acceptance from §4: "a plain ``claude`` CLI session running
+``sac mcp channel --name <id>`` receives, as
+``<channel source="sac" ...>`` blocks, messages a permitted node
+sends to ``<id>`` — with no container and no spec for ``<id>``."
+
+This file exercises the HTTP-side of that acceptance: an inbox stream
+opens, a message is POSTed, the SSE frame is delivered.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import os
+from pathlib import Path
+
+import httpx
+import pytest
+from starlette.testclient import TestClient
+
+from scitex_agent_container._listen.server import create_app
+from scitex_agent_container._runners import _session_state as _ss
+from scitex_agent_container._state import registry as _reg
+
+TOKEN = "test-token-wi3"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — share the shape used by tests/.../_listen/test_server.py so the
+# external-node tests run under the same isolated tmp_path topology.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_env(tmp_path: Path):
+    saved_home = os.environ.get("HOME")
+    saved_reg_env = os.environ.get("SCITEX_AGENT_CONTAINER_REGISTRY_DIR")
+    saved_run_env = os.environ.get("SCITEX_AGENT_CONTAINER_RUNTIME_DIR")
+    saved_yaml_env = os.environ.get("SCITEX_AGENT_CONTAINER_YAML_DIRS")
+    saved_reg_const = _reg.REGISTRY_DIR
+    saved_state_const = _ss.DEFAULT_STATE_ROOT
+
+    os.environ["HOME"] = str(tmp_path)
+    os.environ["SCITEX_AGENT_CONTAINER_REGISTRY_DIR"] = str(tmp_path / "registry")
+    os.environ["SCITEX_AGENT_CONTAINER_RUNTIME_DIR"] = str(tmp_path / "runtime")
+    os.environ.pop("SCITEX_AGENT_CONTAINER_YAML_DIRS", None)
+    _reg.REGISTRY_DIR = tmp_path / "registry"
+    _ss.DEFAULT_STATE_ROOT = tmp_path / "runtime"
+
+    try:
+        yield tmp_path
+    finally:
+        _reg.REGISTRY_DIR = saved_reg_const
+        _ss.DEFAULT_STATE_ROOT = saved_state_const
+        for key, val in (
+            ("HOME", saved_home),
+            ("SCITEX_AGENT_CONTAINER_REGISTRY_DIR", saved_reg_env),
+            ("SCITEX_AGENT_CONTAINER_RUNTIME_DIR", saved_run_env),
+            ("SCITEX_AGENT_CONTAINER_YAML_DIRS", saved_yaml_env),
+        ):
+            if val is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = val
+
+
+@pytest.fixture
+def client(isolated_env):
+    app = create_app(token=TOKEN)
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture
+def auth_headers():
+    return {"authorization": f"Bearer {TOKEN}"}
+
+
+# ---------------------------------------------------------------------------
+# POST /agents/<external-id>/message:send — must accept an unknown name
+# ---------------------------------------------------------------------------
+
+
+def test_message_send_to_external_node_returns_2xx(client, auth_headers) -> None:
+    """An external node has no YAML and is not in the local registry,
+    but ``message:send`` must still accept the POST and route it to
+    the inbox bus. The implicit-registration semantics (handoff §4)
+    means a 404 here is a bug.
+    """
+    # Arrange
+    payload = {
+        "jsonrpc": "2.0",
+        "id": "1",
+        "method": "SendMessage",
+        "params": {
+            "message": {
+                "message_id": "m1",
+                "role": "ROLE_USER",
+                "parts": [{"text": "hi from a permitted peer"}],
+            },
+            "metadata": {"from_agent": "permitted-peer"},
+        },
+    }
+    # Act
+    resp = client.post(
+        "/agents/external-bob/message:send",
+        json=payload,
+        headers=auth_headers,
+    )
+    # Assert
+    assert resp.status_code < 400, resp.text
+
+
+def test_message_send_to_external_node_response_carries_msg_id(
+    client, auth_headers
+) -> None:
+    """The published event must include the broker-minted ``msg_id`` so
+    the sender can correlate. This is the same envelope shape the
+    sac-managed-agent path mints (see ``a2a._inbox_bus.mint_event``).
+    """
+    # Arrange
+    payload = {
+        "jsonrpc": "2.0",
+        "id": "1",
+        "method": "SendMessage",
+        "params": {
+            "message": {
+                "message_id": "m1",
+                "role": "ROLE_USER",
+                "parts": [{"text": "hi"}],
+            },
+            "metadata": {"from_agent": "permitted-peer"},
+        },
+    }
+    # Act
+    resp = client.post(
+        "/agents/external-bob/message:send",
+        json=payload,
+        headers=auth_headers,
+    )
+    body = resp.json()
+    # Assert — response carries the minted envelope id (callers correlate against this)
+    assert isinstance(body.get("msg_id"), str) and len(body["msg_id"]) >= 16
+
+
+# ---------------------------------------------------------------------------
+# GET /agents/<external-id>/inbox/stream — SSE: deliver POSTed event
+# ---------------------------------------------------------------------------
+
+
+async def _sse_roundtrip(
+    isolated_env: Path, payload: dict, *, name: str = "external-bob"
+) -> dict:
+    """End-to-end roundtrip across the real Starlette app.
+
+    Runs a real ``uvicorn`` on a loopback port so the SSE subscriber
+    and the publisher are independent HTTP clients — no in-process
+    ASGI transport quirks. The ``Broker`` is the real one in
+    :mod:`a2a._inbox_bus`; the only seam is the network socket.
+    """
+    import contextlib as _contextlib
+    import socket
+    import threading
+
+    import uvicorn
+
+    app = create_app(token=TOKEN)
+
+    # Pick a free loopback port.
+    with _contextlib.closing(socket.socket()) as s:
+        s.bind(("127.0.0.1", 0))
+        port = s.getsockname()[1]
+
+    config = uvicorn.Config(
+        app, host="127.0.0.1", port=port, log_level="warning", ws="none"
+    )
+    server = uvicorn.Server(config)
+
+    server_thread = threading.Thread(target=server.run, daemon=True)
+    server_thread.start()
+    # Wait for the server to come up.
+    deadline = asyncio.get_event_loop().time() + 5.0
+    while not server.started:
+        if asyncio.get_event_loop().time() > deadline:
+            raise AssertionError("uvicorn did not start in 5s")
+        await asyncio.sleep(0.05)
+
+    headers = {"authorization": f"Bearer {TOKEN}"}
+    ready = asyncio.Event()
+
+    async def subscribe() -> dict:
+        async with httpx.AsyncClient(
+            base_url=f"http://127.0.0.1:{port}", timeout=5.0
+        ) as ac:
+            async with ac.stream(
+                "GET", f"/agents/{name}/inbox/stream", headers=headers
+            ) as sse:
+                async for line in sse.aiter_lines():
+                    if line.startswith(":"):
+                        ready.set()
+                        continue
+                    if line.startswith("data:"):
+                        return json.loads(line[len("data:") :].lstrip())
+        raise AssertionError("SSE closed without delivering an event")
+
+    sub_task = asyncio.create_task(subscribe())
+    try:
+        await asyncio.wait_for(ready.wait(), timeout=5.0)
+        async with httpx.AsyncClient(
+            base_url=f"http://127.0.0.1:{port}", timeout=5.0
+        ) as ac:
+            resp = await ac.post(
+                f"/agents/{name}/message:send",
+                json=payload,
+                headers=headers,
+            )
+        assert resp.status_code < 400, resp.text
+        return await asyncio.wait_for(sub_task, timeout=5.0)
+    finally:
+        if not sub_task.done():
+            sub_task.cancel()
+            with contextlib.suppress(BaseException):
+                await sub_task
+        server.should_exit = True
+        server_thread.join(timeout=5.0)
+
+
+def _make_payload(text: str = "hello external", **meta: object) -> dict:
+    base_meta = {"from_agent": "permitted-peer"}
+    base_meta.update(meta)
+    return {
+        "jsonrpc": "2.0",
+        "id": "1",
+        "method": "SendMessage",
+        "params": {
+            "message": {
+                "message_id": "m1",
+                "role": "ROLE_USER",
+                "parts": [{"text": text}],
+            },
+            "metadata": base_meta,
+        },
+    }
+
+
+def test_external_inbox_stream_delivers_posted_event(isolated_env) -> None:
+    """End-to-end: subscribe to inbox/stream, POST a ``message:send``
+    to the same name, observe the SSE frame.
+
+    Real ``Broker``, real SSE, real ASGI transport — no mocks
+    (handoff §0 Hard rules).
+    """
+    # Arrange
+    payload = _make_payload(text="hello external", conversation_id="c-wi3")
+    # Act
+    event = asyncio.run(_sse_roundtrip(isolated_env, payload))
+    # Assert
+    assert event.get("content") == "hello external"
+
+
+def test_external_inbox_stream_event_preserves_from_agent(isolated_env) -> None:
+    """The publisher's ``from_agent`` metadata reaches the receiver."""
+    # Arrange
+    payload = _make_payload(text="x")
+    # Act
+    event = asyncio.run(_sse_roundtrip(isolated_env, payload))
+    # Assert
+    assert event.get("from_agent") == "permitted-peer"
+
+
+# ---------------------------------------------------------------------------
+# AgentCard synthesis — an external node has no YAML, so sac must
+# synthesise a minimal v1 AgentCard at registration (handoff §4).
+# ---------------------------------------------------------------------------
+
+
+def test_external_node_agent_card_returns_200(client, auth_headers) -> None:
+    """The AgentCard route must succeed for a registered external node.
+    Currently returns 404 because the lookup goes through ``resolve_config``
+    which only knows YAML-backed names.
+    """
+    # Arrange — register the node by reaching the inbox endpoint first.
+    name = "external-bob"
+    client.post(
+        f"/agents/{name}/message:send",
+        json={
+            "jsonrpc": "2.0",
+            "id": "1",
+            "method": "SendMessage",
+            "params": {
+                "message": {
+                    "message_id": "m1",
+                    "role": "ROLE_USER",
+                    "parts": [{"text": "register me"}],
+                },
+                "metadata": {"from_agent": "peer"},
+            },
+        },
+        headers=auth_headers,
+    )
+    # Act
+    resp = client.get(
+        f"/agents/{name}/.well-known/agent-card.json",
+        headers=auth_headers,
+    )
+    # Assert
+    assert resp.status_code == 200, resp.text
+
+
+def test_external_node_agent_card_advertises_node_kind_external(
+    client, auth_headers
+) -> None:
+    """The synthesised card carries
+    ``x-scitex-agent-container.node_kind == "external"`` so consumers
+    (and orochi later) can distinguish a managed agent from an external
+    node without parsing YAML.
+    """
+    # Arrange — implicit registration via message:send.
+    name = "external-bob"
+    client.post(
+        f"/agents/{name}/message:send",
+        json={
+            "jsonrpc": "2.0",
+            "id": "1",
+            "method": "SendMessage",
+            "params": {
+                "message": {
+                    "message_id": "m1",
+                    "role": "ROLE_USER",
+                    "parts": [{"text": "x"}],
+                },
+                "metadata": {"from_agent": "peer"},
+            },
+        },
+        headers=auth_headers,
+    )
+    # Act
+    resp = client.get(
+        f"/agents/{name}/.well-known/agent-card.json",
+        headers=auth_headers,
+    )
+    card = resp.json()
+    # Assert
+    ext = card.get("x-scitex-agent-container") or {}
+    assert ext.get("node_kind") == "external"
+
+
+def test_external_node_agent_card_supportedinterfaces_url_targets_inbox(
+    client, auth_headers
+) -> None:
+    """The card's supportedInterfaces URL is the agent's inbox base —
+    that's what an A2A v1 client uses to send messages.
+    """
+    # Arrange
+    name = "external-bob"
+    client.post(
+        f"/agents/{name}/message:send",
+        json={
+            "jsonrpc": "2.0",
+            "id": "1",
+            "method": "SendMessage",
+            "params": {
+                "message": {
+                    "message_id": "m1",
+                    "role": "ROLE_USER",
+                    "parts": [{"text": "x"}],
+                },
+                "metadata": {"from_agent": "peer"},
+            },
+        },
+        headers=auth_headers,
+    )
+    # Act
+    resp = client.get(
+        f"/agents/{name}/.well-known/agent-card.json",
+        headers=auth_headers,
+    )
+    card = resp.json()
+    # Assert
+    iface = (card.get("supportedInterfaces") or [{}])[0]
+    assert iface.get("url", "").endswith(f"/agents/{name}")
+
+
+# ---------------------------------------------------------------------------
+# Hard-rule guard: unauthenticated requests stay denied. ACL gating
+# lives under WI-2; bearer auth is the outer perimeter and must still
+# fire for the new endpoints.
+# ---------------------------------------------------------------------------
+
+
+def test_message_send_without_bearer_token_is_rejected(client) -> None:
+    # Arrange
+    payload = {
+        "jsonrpc": "2.0",
+        "method": "SendMessage",
+        "params": {
+            "message": {
+                "message_id": "m1",
+                "role": "ROLE_USER",
+                "parts": [{"text": "x"}],
+            }
+        },
+    }
+    # Act
+    resp = client.post("/agents/anything/message:send", json=payload)
+    # Assert
+    assert resp.status_code == 401
+
+
+def test_inbox_stream_without_bearer_token_is_rejected(client) -> None:
+    # Arrange / Act
+    resp = client.get("/agents/anything/inbox/stream")
+    # Assert
+    assert resp.status_code == 401


### PR DESCRIPTION
## Summary
Per HANDOFF_AGENT_COMMS_2026-05-19.md §4 (WI-3): sac now supports a node with identity + inbox but **no spec and no lifecycle**. An external node (e.g. a plain `claude` CLI session) joins by running `sac mcp channel --name <id> --listen-url <sac listen>`.

- New `_listen/_nodes.py`: `NodeRegistry` + `synthesize_external_card()` mint a minimal A2A v1 AgentCard at first touch (`x-scitex-agent-container.node_kind = "external"`).
- New routes on `_listen/server.py`: `POST /agents/<name>/message:send` and `GET /agents/<name>/inbox/stream`, keyed by node identity (no YAML required). Loud failure modes — no silent drops.
- The existing `GET /agents/<name>/.well-known/agent-card.json` falls back to the synthesised card for external nodes.
- `create_app` attaches a per-app `Broker` + `NodeRegistry` on `app.state`.

## Out of scope (deferred per handoff §6)
- WI-1 durability / replay — events posted with no subscriber still drop.
- WI-2 ACL — only bearer auth gates the new endpoints; sender ACL lands next.
- WI-4 cross-host routing — sends resolve to the local broker only.

## Test plan
- [x] `pytest tests/scitex_agent_container/_listen/test_external_nodes.py` — 9 passed (no mocks; real `Broker`, real SSE through a real `uvicorn` loopback).
- [x] `pytest tests/scitex_agent_container/_listen/ tests/scitex_agent_container/a2a/` — 290 passed (no regressions).