### PR TITLE
docs(wi-5): rewrite sac/orochi boundary + ADR-0008 + fix stale channel docstring

### DIFF
--- a/docs/adr/0008-sac-node-transport-boundary.md
+++ b/docs/adr/0008-sac-node-transport-boundary.md
@@ -1,0 +1,187 @@
+# ADR-0008: sac is the node-transport substrate; comms model is nodes / lineage / groups / ACL (2026-05-20)
+
+**Status:** Accepted.
+**Supersedes:** the implicit "sac = one host; orochi = across hosts"
+framing in [`docs/sac-and-orochi.md`](../sac-and-orochi.md) (pre-2026-05-20
+revision).
+**Related:** [`ADR-0004`](0004-a2a-v1-compliance.md) (A2A v1 compliance —
+§D12 defines the push primitive this ADR builds on).
+**Handoff:** `GITIGNORED/HANDOFF_AGENT_COMMS_2026-05-19.md`.
+
+## Problem
+
+Two boundaries had drifted out of alignment with reality:
+
+1. **The "one host vs many hosts" split between sac and orochi was
+   wrong.** sac already places and drives agents on remote hosts via
+   `spec.host` (and SSH hops in `spec.remote.hops`); the moment it does
+   so, it must also carry their messages — there is no "off-host" sac
+   could hand the messaging off to without orochi installed. Yet the
+   doc said "sac = one host, orochi = across hosts."
+
+2. **sac had no model for non-sac-managed nodes on its comms graph.**
+   A plain `claude` CLI session — the official CLI is stable and good
+   for terminal/human interaction — could not address or be addressed by
+   a sac-managed agent without sac inheriting its lifecycle. That made
+   "lead = plain `claude` CLI, workers = sac-managed agents" impossible
+   to express, even though the operator regularly runs exactly that
+   topology.
+
+The remediation is a single ADR because the two are intertwined: the
+non-sac-managed-node concept *only* makes sense once sac is the
+transport substrate (not the lifecycle manager that happens to also
+forward messages).
+
+## Decision
+
+### D1. sac is the node-transport substrate
+
+sac carries messages **any node ↔ any node**, on **any host** (same
+host, LAN, SSH-alias, tunnel), **ACL-gated**, self-sufficient with zero
+orochi installed.
+
+Orochi is the human/product layer: web chatops UI, dashboard, topology
+viz, presence, channels/DMs/threads as features, *and* the connectivity
+mesh (cloudflared / autossh) that **establishes** host reachability.
+Orochi is a *consumer* of sac transport, not the transport.
+
+sac assumes reachability. Orochi establishes it.
+
+### D2. Two kinds of node, distinguished only by who owns the lifecycle
+
+A **node** is an *identity* + an *inbox* + an *ACL*. Two kinds:
+
+* **sac-managed** — sac owns the lifecycle (spec, container,
+  start/stop/health). Lifecycle entry point: `sac agent start`.
+* **external** — sac does **not** own the lifecycle. Typically a plain
+  `claude` CLI session. Joins the comms graph by running
+  `sac mcp channel --name <id> --listen-url <sac listen>`. No
+  container. No spec. sac never starts or stops an external node.
+
+Both kinds are equal on the comms graph. The orchestration layer may
+assign a role ("lead", "worker", "coordinator") to a node — sac sees
+only "a node".
+
+### D3. Lineage and groups
+
+sac records who called `sac agents start`: the caller is the **parent**,
+the spawned agent its **child**. A parent together with its direct
+children is one **group**. The group is the unit of default ACL.
+
+### D4. ACL — permissioned messaging
+
+* Intra-group sends are allowed by default (parent↔child *and*
+  sibling↔sibling, bidirectional).
+* Cross-group sends require an **explicit ACL grant**
+  (`spec.comms.allow` for sac-managed nodes; a policy store for
+  external nodes).
+* The graph is permissioned — never implicitly all-to-all. An ungated
+  channel is a prompt-injection vector
+  ([Claude Code channels reference](https://code.claude.com/docs/en/channels-reference)).
+
+### D5. Depth limit is a POLICY, not a structural ceiling
+
+We currently forbid a child from spawning children, so the *live*
+hierarchy is two levels. The model, schema, lineage and group logic
+remain **N-level capable** — recursion is the natural shape; nothing
+hard-codes "2" or assumes fixed depth. The cap is a lift-able policy
+rule. Lifting it later is a policy change only — zero
+structural / schema / data-structure change.
+
+### D6. A2A compliance for both kinds of node
+
+Every node, sac-managed or external, is addressable via A2A; a node's
+identity *is* its A2A AgentCard.
+
+* sac-managed: the card is projected from `spec.yaml` by
+  `a2a/_card.py::project_card`.
+* External: the card is **synthesised at registration** by
+  `_listen/_nodes.py::synthesize_external_card` — identity + inbox
+  endpoint + the v1-required capability fields, marked
+  `"x-scitex-agent-container.node_kind": "external"`. Registration is
+  implicit: the first `message:send` / `inbox/stream` touch on a name
+  mints + caches the card.
+
+### D7. Durability of the channel bus
+
+Every channel event is persisted to `state.db.channel_events` before
+fan-out. The SSE handler replays missed events on connect
+(`Last-Event-ID` cursor) and stamps each frame with `id: <row_id>`,
+marking the row delivered as it ships. An event POSTed while no
+subscriber is connected is delivered on the next connect; a
+kill + reconnect replays exactly the missed events; nothing is dropped
+silently.
+
+Schema: `(id, target, source, kind, content, meta_json, ts, delivered_at)`.
+
+### D8. Endpoint location for the inbox surface
+
+The inbox endpoints (`message:send` and `inbox/stream`) live on the
+always-on `sac listen` host control-plane (`_listen/server.py`),
+**keyed by node identity** — they accept a name that has no YAML and
+no container. The per-agent `a2a/_server.py` is a separate surface
+for sac-managed-agent SDK plumbing.
+
+### D9. The transport is Claude Code's official channels feature
+
+No new channel protocol. The MCP server emits
+`notifications/claude/channel`; Claude Code renders it as a
+`<channel source="..." ...>` block in the running session. This is
+the same protocol orochi's `server:orochi-push` uses — sac just adds
+the `server:sac` flavour pointing at the local listen.
+
+## What this rules out
+
+* No UI, dashboard, or topology viz in sac — orochi's.
+* No orochi awareness in sac. The boundary stays one-way (orochi → sac).
+* No new channel protocol — use Claude Code channels as-is.
+* No "lead" / "head" / "worker" / role concept in sac — only nodes,
+  lineage, groups, ACL.
+* No sac lifecycle management of external nodes — sac never starts or
+  stops any external node.
+* No per-agent role/address config beyond `spec.comms` ACL.
+
+## What this opens up (deliberately, but not built yet)
+
+The model is shaped to accept **transport adapters** in a phase-2:
+
+* A **human adapter** (a human is a node too — reachable via Telegram /
+  phone / email; replies in that app). Backed by
+  `claude-code-telegrammer` + `scitex-notification` today; phase 2
+  registers them behind the same `node = identity + inbox + ACL` model.
+* A possible HTTP webhook adapter or the orochi UI as an adapter.
+
+The phase-1 work (WI-1..6 from the handoff) builds exactly one adapter:
+the Claude-session adapter (`sac mcp channel`, MCP
+`notifications/claude/channel`). The model is deliberately
+adapter-shaped so a second adapter can be added later without touching
+the core. The only phase-2 obligation on phase-1 is: keep the adapter
+seam clean — the node model, ACL and routing must not assume the
+Claude-session adapter is the only transport.
+
+## Implementation sources of truth
+
+* Node-identity inbox endpoints + external-node registry —
+  `src/scitex_agent_container/_listen/_nodes.py`,
+  `src/scitex_agent_container/_listen/server.py`.
+* Channel-event durability + replay —
+  `src/scitex_agent_container/_state/state_db_channel.py`,
+  `channel_events` table schema in
+  `src/scitex_agent_container/_state/state_db.py`.
+* SSE replay handler — `a2a/_server.py::get_inbox_stream` (and the
+  symmetric handler in `_listen/server.py::node_inbox_stream`).
+* Card projection (sac-managed) — `a2a/_card.py::project_card`.
+* Card synthesis (external) — `_listen/_nodes.py::synthesize_external_card`.
+
+## References
+
+* `docs/sac-and-orochi.md` — narrative version of this ADR for the
+  package docs.
+* `GITIGNORED/HANDOFF_AGENT_COMMS_2026-05-19.md` — the handoff that
+  motivated this work; superseded once WI-1..6 land.
+* [Claude Code channels reference](https://code.claude.com/docs/en/channels-reference)
+  — protocol + the "gate inbound messages" guidance that directly
+  informs D4.
+* `docs/design/telegram-fold.md` — the consumer flow
+  (telegram → Broker → SSE → `sac mcp channel` → session) that
+  prefigured this model.

--- a/docs/sac-and-orochi.md
+++ b/docs/sac-and-orochi.md
@@ -1,9 +1,91 @@
 # sac and orochi
 
-`scitex-agent-container` (`sac`) and [`scitex-orochi`](https://github.com/ywatanabe1989/scitex-orochi)
-are two separate packages with a **one-way dependency**: orochi reads from sac; sac never imports orochi.
+`scitex-agent-container` (`sac`) and
+[`scitex-orochi`](https://github.com/ywatanabe1989/scitex-orochi) are two
+separate packages with a **one-way dependency**: orochi reads from sac; sac
+never imports orochi.
 
-## Architecture
+This doc supersedes the older "sac = one host; orochi = across hosts"
+framing — sac already places and drives agents on remote hosts via SSH
+hops, so it must also carry their messages. The corrected boundary is
+captured below and tracked under
+[`docs/adr/0008-sac-node-transport-boundary.md`](adr/0008-sac-node-transport-boundary.md).
+
+## The comms model — what sac knows
+
+sac sees a single thing on its comms graph: **nodes**. A node is an
+*identity* + an *inbox* + an *ACL*. There are two kinds, distinguished
+*only* by who owns the lifecycle:
+
+| Kind          | Lifecycle owner                                       | Example                                                                       |
+|---------------|-------------------------------------------------------|-------------------------------------------------------------------------------|
+| sac-managed   | sac (spec, container, start/stop/health)              | An agent declared in a `spec.yaml`, launched by `sac agent start`.            |
+| **external**  | NOT sac — the operator, a separate tool, a human      | A plain `claude` CLI session, joining via `sac mcp channel --name <id>`.      |
+
+Both kinds are equal on the comms graph. Whatever *role* the orchestration
+layer assigns a node — "lead", "head", "worker", "coordinator" — is
+irrelevant to sac; sac sees only "a node".
+
+### Lineage — parent / children
+
+sac records who called `sac agents start`: the caller is the **parent**,
+the spawned agent its **child**. A parent may have many children; every
+node is a parent or a child (the root is a parent with no parent of its
+own).
+
+### Group — the unit of default ACL
+
+A parent together with its direct children is one **group**. The group is
+the unit of intra-group default ACL: within a group every node may
+message every other, **bidirectionally** (parent↔child *and*
+sibling↔sibling).
+
+### Depth limit — a POLICY, not a structural limit
+
+We currently forbid a child from spawning children, so the *live*
+hierarchy is two levels (root + its direct children). **This is a
+policy constraint we choose to enforce, not an architectural ceiling.**
+The model, schema, lineage and group logic remain **N-level capable** —
+recursion is the natural shape; nothing hard-codes "2" or assumes a
+fixed depth. The cap is a *lift-able policy* (a rule that denies a
+non-root spawn). Lifting it later is a policy change only — zero
+structural / schema / data-structure change.
+
+### ACL — permissioned messaging
+
+- Intra-group is allowed by default (bidirectional).
+- Cross-group requires an **explicit ACL grant** (per-node config:
+  `spec.comms.allow` for sac-managed; a policy store for external nodes).
+- The graph is permissioned — never implicitly all-to-all. An ungated
+  channel is a prompt-injection vector
+  ([Claude Code channels reference](https://code.claude.com/docs/en/channels-reference)).
+
+### A2A compliance
+
+Every node, sac-managed or external, is addressable via the A2A protocol;
+a node's identity *is* its A2A AgentCard.
+
+- sac-managed nodes derive their AgentCard from `spec.yaml` (see
+  [`a2a/_card.py::project_card`](../src/scitex_agent_container/a2a/_card.py)).
+- External nodes have no YAML, so sac **synthesises a minimal AgentCard
+  at registration** when `sac mcp channel --name <id>` connects: identity
+  + inbox endpoint + the required A2A capability fields, and *nothing*
+  runtime/container-shaped. The synthesised card is the external node's
+  whole definition (see
+  [`_listen/_nodes.py::synthesize_external_card`](../src/scitex_agent_container/_listen/_nodes.py)).
+  The card carries `"x-scitex-agent-container.node_kind": "external"` so
+  downstream tooling can distinguish the kinds.
+
+### What sac knows vs doesn't
+
+| sac knows                                | sac does NOT know                       |
+|------------------------------------------|-----------------------------------------|
+| Nodes (sac-managed + external)           | Roles ("lead", "head", "worker", …)     |
+| Lineage (parent / children)              | Topology visualisations                 |
+| Groups (parent + direct children)        | Connectivity mesh (cloudflared, autossh) |
+| ACL grants                               | Human chatops UI                        |
+
+## The corrected boundary
 
 ```
             ┌────────────────────┐                       ┌──────────────────────┐
@@ -14,51 +96,66 @@ are two separate packages with a **one-way dependency**: orochi reads from sac; 
                       ▼                                             │
         ┌──────────────────────────────────┐                        │
         │   scitex-orochi                  │                        │
-        │   WebSocket hub · dashboard      │                        │
-        │   MCP channels · presence · A2A  │                        │
-        │   peer registry · cross-host     │                        │
+        │   web chatops UI · dashboard     │                        │
+        │   topology / presence            │                        │
+        │   channels · DMs · threads       │                        │
+        │   connectivity mesh              │                        │
+        │   (cloudflared / autossh)        │                        │
         └─────────────────┬────────────────┘                        │
-                          │  reads status                           │
+                          │  CONSUMES sac transport                 │
                           │  (one-way dep: orochi → sac)            │
                           ▼                                         │
         ┌──────────────────────────────────┐                        │
         │   scitex-agent-container (sac)   │                        │
-        │   lifecycle · health · restart   │                        │
-        │   apptainer runtime · per host   │                        │
-        │   (zero knowledge of orochi)     │                        │
+        │   NODE TRANSPORT SUBSTRATE       │                        │
+        │     any-node ↔ any-node          │                        │
+        │     any host (same / LAN /       │                        │
+        │     SSH-alias / tunnel)          │                        │
+        │     ACL-gated                    │                        │
+        │   Lifecycle for sac-managed      │                        │
+        │   nodes only (apptainer)         │                        │
+        │   Zero knowledge of orochi       │                        │
         └─────────────────┬────────────────┘                        │
-                          │  starts / supervises                    │
+                          │  starts / supervises (sac-managed)      │
                           ▼                                         │
         ┌──────────────────────────────────┐                        │
-        │   Claude agents (one per host)   │ ── heartbeat-push ──▶ orochi
-        │   session.jsonl · SDK            │ ── alerts ─────────────┘
+        │   Claude agents + external nodes │ ── heartbeat-push ──▶ orochi
+        │   (sac-managed)   (external)     │ ── alerts ─────────────┘
         └──────────────────────────────────┘
 ```
 
-## Responsibility split
+### Responsibility split
 
-| Concern                                                   | Owner                                      |
-|-----------------------------------------------------------|--------------------------------------------|
-| Agent process (SDK + session.jsonl)                       | **sac**                                    |
-| Per-host control plane (start/stop/send/tail/list)        | **sac**                                    |
-| Container runtime (apptainer)                             | **sac**                                    |
-| Per-agent local inbox (`POST /agents/<name>/turn`) | **sac**                                    |
-| In-session push (MCP channel server `server:sac`)         | **sac** — connects to local `sac listen` SSE stream and pushes `notifications/claude/channel` into the running session |
-| Cross-host message routing                                | **orochi**                                 |
-| Human chatops UI (Slack-like web interface)               | **orochi**                                 |
-| SSH mesh / tunnel layer (cloudflared + autossh)           | **orochi**                                 |
-| Peer registry                                             | **orochi** (`~/.scitex/orochi/peers.yaml`) |
+| Concern                                                                   | Owner       |
+|---------------------------------------------------------------------------|-------------|
+| Agent process (SDK + session.jsonl)                                       | **sac**     |
+| Per-host control plane (start/stop/send/tail/list)                        | **sac**     |
+| Container runtime (apptainer)                                             | **sac**     |
+| **Node transport (any-to-any, any host, ACL-gated)**                      | **sac**     |
+| **Channel-event durability + replay** (`channel_events` in state.db)      | **sac**     |
+| **External-node inbox** (no YAML, identity + inbox only)                  | **sac**     |
+| In-session push (MCP channel server `server:sac`)                         | **sac**     |
+| Human chatops UI (Slack-like web interface)                               | **orochi**  |
+| Topology / presence / dashboard                                           | **orochi**  |
+| Channels / DMs / threads as features                                      | **orochi**  |
+| Connectivity mesh (cloudflared + autossh) — *establishes* host reachability | **orochi**  |
 
-**Rule: sac owns containers + sessions + the local channel primitive on one host; orochi owns messages + people + transport across hosts.** `server:orochi-push` remains orochi's own MCP channel (for orochi-mediated cross-host topics + chat); `server:sac` is sac's local primitive that any peer reaches by POSTing to the host's `sac listen` — whether the network in between is orochi-mediated, an operator's SSH tunnel, or nothing at all (same host).
+**Rule:** sac is the node-transport substrate. Orochi is the human/product
+layer that *consumes* sac transport. The connectivity mesh that
+establishes reachability lives in orochi; sac assumes reachability.
 
 ## How orochi consumes sac
 
-orochi reads `~/.scitex/agent-container/runtime/<name>/heartbeat.json` and
-`session.jsonl` from each host it manages. It never calls `sac` CLI commands
-directly — the contract is the on-disk state files.
+orochi reads sac's state files
+(`~/.scitex/agent-container/runtime/<name>/heartbeat.json`,
+`session.jsonl`, `state.db`) from each host it manages. It also calls
+sac's HTTP endpoints (`/agents/<name>/{message:send,inbox/stream}`) like
+any other A2A v1 client. It never calls `sac` CLI commands directly —
+the contract is the on-disk state files plus the published HTTP
+endpoints.
 
-Agents push heartbeats and alerts to orochi via the `server:orochi-push` MCP
-channel, configured in `spec.claude.channels`:
+Agents push heartbeats and alerts to orochi via the `server:orochi-push`
+MCP channel, configured in `spec.claude.channels`:
 
 ```yaml
 spec:
@@ -67,11 +164,31 @@ spec:
       - server:orochi-push
 ```
 
+The `server:sac` channel is sac's own primitive — agents enable it the
+same way:
+
+```yaml
+spec:
+  claude:
+    channels:
+      - server:sac
+```
+
+When `server:sac` is in `channels`, `sac agent start` auto-spawns
+`sac mcp channel --name <agent>` as a stdio MCP subprocess of the agent's
+Claude session; it subscribes to the host-local
+`/agents/<name>/inbox/stream` SSE and pushes
+`notifications/claude/channel` so the agent sees
+`<channel source="sac" ...>` tags in real time. External nodes opt in by
+running the same command from their own Claude session — no container,
+no spec.
+
 ## Standalone use
 
-sac works fully without orochi. If you don't need cross-host chatops, just
-omit `server:orochi-push` from `spec.claude.channels` and skip the orochi
-install entirely.
+sac works fully without orochi. If you don't need cross-host chatops,
+just omit `server:orochi-push` from `spec.claude.channels` and skip the
+orochi install entirely. The sac comms graph still works: nodes message
+each other, the channel bus is durable, and the ACL still gates.
 
 ## Live instance
 

--- a/docs/sac-and-orochi.md
+++ b/docs/sac-and-orochi.md
@@ -60,25 +60,50 @@ structural / schema / data-structure change.
   channel is a prompt-injection vector
   ([Claude Code channels reference](https://code.claude.com/docs/en/channels-reference)).
 
-> ⚠️ **Identity caveat — ACL is policy-shaped today** (handoff
-> 2026-05-20 limited-scope decision).
->
-> The shipped ACL gates on the **self-claimed
-> `metadata.from_agent`** field; cryptographic per-node identity
-> is **deferred** to a separate follow-on handoff. The design for
-> the cryptographic-identity work is filed in scitex-lead at
-> `GITIGNORED/FUTURE/sac-per-node-authenticated-acl.md` — not in
-> this repo. Every cross-group grant row in `comms_grants`
-> carries the audit note
-> `"trusts metadata.from_agent until per-node creds land"` so the
-> follow-on work has the audit trail it needs to scope what each
-> grant must be re-validated against.
->
-> Until that lands, the ACL is a policy gate — a misbehaving node
-> can claim a different identity by writing a different
-> `from_agent`. The handoff acceptance "identity cannot be
-> spoofed via a metadata field" will be met by the follow-on, not
-> by the limited-scope WI-2.
+### Authenticated identity (handoff §4 acceptance)
+
+Identity is **bearer-authenticated**, not self-claimed:
+
+- Every node (sac-managed or external) gets a per-node bearer
+  minted at registration (`node_tokens` table). The listen
+  server's `NodeAuthMiddleware` resolves the `Authorization:
+  Bearer <token>` header to a node name on `request.state`.
+- `check_send_acl` requires `params.metadata.from_agent` to
+  **match** the resolved name; mismatch → `403 identity spoof`
+  with the resolved-name vs claimed-name in the body. This meets
+  the handoff §4 acceptance "identity cannot be spoofed via a
+  metadata field".
+- The **host-wide bearer** is the *administrative caller* — it
+  honours `metadata.from_agent` verbatim (used by cross-host
+  forwarders, see below).
+
+### Cross-host forwarding — per-host bearer registry
+
+When `message:send` targets a node on a different host, the local
+`sac listen` forwards to that host's `sac listen`. The destination
+host has its own listen bearer; the forwarder authenticates
+**with the destination's bearer**, pulled from a small registry:
+
+```
+~/.scitex/agent-container/peer-tokens/
+    host-a.token      # 0600 — host A's listen bearer, used to
+                      # auth at host A from this host.
+    head-spartan.token
+    ...
+```
+
+Operators populate the registry with `sac host add-peer <host>
+<token>`; `sac host list-peers` shows the registered hosts (token
+values are never printed). A missing entry is a **loud 502** with
+the file path and the `add-peer` fix in the error body — never a
+silent drop (handoff §0 Hard rules).
+
+This gives a **per-host blast radius**: leaking host A's listen
+bearer compromises only host A, not the whole fleet. The
+ACL is re-evaluated at the receiving host on the same
+`metadata.from_agent`, so cross-group denials fire at the
+destination per handoff §4 ("ACL is enforced at the receiving
+host").
 
 ### A2A compliance
 

--- a/docs/sac-and-orochi.md
+++ b/docs/sac-and-orochi.md
@@ -65,13 +65,14 @@ structural / schema / data-structure change.
 >
 > The shipped ACL gates on the **self-claimed
 > `metadata.from_agent`** field; cryptographic per-node identity
-> is **deferred** to a separate follow-on handoff (related to the
-> existing
-> [`sac-accounts-per-agent-credentials-and-rotation`](https://github.com/ywatanabe1989/scitex-agent-container/blob/develop/docs/design/sac-accounts-per-agent-credentials-and-rotation.md)
-> FUTURE doc). Every cross-group grant row in `comms_grants`
+> is **deferred** to a separate follow-on handoff. The design for
+> the cryptographic-identity work is filed in scitex-lead at
+> `GITIGNORED/FUTURE/sac-per-node-authenticated-acl.md` — not in
+> this repo. Every cross-group grant row in `comms_grants`
 > carries the audit note
 > `"trusts metadata.from_agent until per-node creds land"` so the
-> follow-on work has the audit trail it needs.
+> follow-on work has the audit trail it needs to scope what each
+> grant must be re-validated against.
 >
 > Until that lands, the ACL is a policy gate — a misbehaving node
 > can claim a different identity by writing a different

--- a/docs/sac-and-orochi.md
+++ b/docs/sac-and-orochi.md
@@ -60,6 +60,25 @@ structural / schema / data-structure change.
   channel is a prompt-injection vector
   ([Claude Code channels reference](https://code.claude.com/docs/en/channels-reference)).
 
+> ⚠️ **Identity caveat — ACL is policy-shaped today** (handoff
+> 2026-05-20 limited-scope decision).
+>
+> The shipped ACL gates on the **self-claimed
+> `metadata.from_agent`** field; cryptographic per-node identity
+> is **deferred** to a separate follow-on handoff (related to the
+> existing
+> [`sac-accounts-per-agent-credentials-and-rotation`](https://github.com/ywatanabe1989/scitex-agent-container/blob/develop/docs/design/sac-accounts-per-agent-credentials-and-rotation.md)
+> FUTURE doc). Every cross-group grant row in `comms_grants`
+> carries the audit note
+> `"trusts metadata.from_agent until per-node creds land"` so the
+> follow-on work has the audit trail it needs.
+>
+> Until that lands, the ACL is a policy gate — a misbehaving node
+> can claim a different identity by writing a different
+> `from_agent`. The handoff acceptance "identity cannot be
+> spoofed via a metadata field" will be met by the follow-on, not
+> by the limited-scope WI-2.
+
 ### A2A compliance
 
 Every node, sac-managed or external, is addressable via the A2A protocol;

--- a/docs/sphinx/adr/0001-isolation-hardening.md
+++ b/docs/sphinx/adr/0001-isolation-hardening.md
@@ -1,0 +1,340 @@
+---
+orphan: true
+---
+
+# ADR: Isolation Hardening (2026-05-13)
+
+**Status:** Accepted.
+**Context:** Agent symlink incident in `scitex-stats-auditor` proof of
+concept; sac's positioning vs. Clew reproducibility verification.
+
+## Problem
+
+On 2026-05-13 the first per-package auditor (`scitex-stats-auditor`)
+ran under Apptainer with `sac-base.sif + overlay` and reported:
+"the project venv targets `/opt/python3.12/bin/python3.12`, which is
+missing on this host; I repaired it by symlinking it to
+`/usr/bin/python3.12`." The agent's mental model was that it had
+patched the host. Investigation showed the symlink only landed in the
+container's overlay — the host was untouched. But two systemic gaps
+were exposed:
+
+1. **The agent thought it had host write access.** Apptainer's
+   defaults make the container/host boundary porous enough that an
+   agent can't distinguish "I patched the container's view of /opt"
+   from "I patched the host."
+2. **Operator-side prompts can't enforce isolation.** The prompt told
+   the agent to be read-only; the agent ignored it. Prompt-level
+   guardrails are not a security mechanism.
+
+The deeper issue: sac's stated positioning is reproducible-by-default,
+but its actual default behavior inherited Apptainer's HPC-convenience
+defaults (auto-bind `$HOME`, `/tmp`, `/proc`, `/sys`, `/dev`; inherit
+all env vars; share host namespaces). Convenience-first defaults are
+upside-down for an agent runtime where the container is supposed to
+be the security boundary.
+
+## Decisions
+
+### D1. Hardened isolation by default; `relaxed: true` to opt out.
+
+`spec.apptainer.relaxed: false` is the default. sac auto-prepends
+`--containall` (filesystem isolation), `--cleanenv` (environment
+isolation), and `--writable-tmpfs` (when no overlay is declared) to
+the apptainer argv.
+
+`relaxed: true` is an explicit opt-out for HPC-style convenience use
+cases. Agents started with `relaxed: true` are **outside the Clew
+verification chain** — their runs cannot be attested as reproducible.
+
+**Rationale.** sac's differentiation against LangGraph / CrewAI /
+AutoGen is "spec.yaml declares isolation; mechanism enforces it;
+external verifier can attest it." Default-strict supports that
+thesis directly. HPC users can opt in to the legacy behavior with
+one line, and they pay the cost of falling out of the verification
+chain (which they typically don't need anyway).
+
+### D2. Universal preflight via `$HOME`-visibility check, not per-path enumeration.
+
+The preflight that sac auto-injects before user `startup_commands` is:
+
+```bash
+test "$(id -u)" != "0" || (echo 'ERROR: running as root' && exit 1)
+test ! -d "$HOME" || (echo 'ERROR: host $HOME visible — isolation breach' && exit 1)
+```
+
+**Rationale.** Per-path enumeration (`test ! -e $HOME/.gitconfig`,
+`test ! -e $HOME/.ssh`, …) has unbounded false-negative risk: every
+new credential store added in the next decade (`.kube/config`,
+`.docker/config.json`, `.netrc`, `.npmrc`, `.pypirc`, `.gnupg/`,
+`~/.config/anthropic/`, `~/.bash_history` with embedded secrets, …)
+requires a new line. The `$HOME`-visibility check covers all of them
+at once.
+
+Under `--containall`, `$HOME` is NOT auto-bound — it should be
+invisible inside the container. If the check fails, either `--containall`
+isn't in effect or an operator-declared bind brought it in. Either way,
+the agent shouldn't start.
+
+**Operator opt-out** for paths that legitimately need to be visible:
+
+```yaml
+spec:
+  apptainer:
+    preflight_allow:
+      - "$HOME/.gitconfig"   # acknowledged: agent needs read-only gitconfig
+```
+
+The opt-out is declared per-path, not as a blanket "disable preflight."
+
+### D3. AgentCard exposes structured isolation block, not a flat enum.
+
+Instead of `isolation_level: hardened | relaxed | custom`:
+
+```json
+"x-scitex-agent-container": {
+  "isolation": {
+    "level": "hardened",
+    "containall": true,
+    "cleanenv": true,
+    "writable_tmpfs": false,
+    "preflight_passed": ["uid-nonzero", "no-host-home"],
+    "preflight_allowed": [],
+    "binds_count": 3,
+    "binds_writable_count": 0
+  }
+}
+```
+
+`level: hardened` is the human shorthand for "all booleans true +
+`preflight_allowed: []`". External verifiers (Clew, orochi attestation)
+read the structured booleans to attest specific properties.
+
+**Rationale.** A flat `custom` label hides what's custom about it.
+A run with `preflight_allow: [$HOME/.ssh]` and a run with
+`preflight_allow: [$HOME/.aws]` are both `custom` under the enum but
+have very different security profiles. Clew's verification chain wants
+to attest specific properties: "did this run set containall? did it
+allow any preflight bypasses?" The structured block answers those
+directly.
+
+## Considered and rejected
+
+### Rejected: prompt-level isolation guarantees.
+
+"Tell the agent in the prompt to be read-only." The PoC proved this
+fails — the agent acknowledged the rule and then violated it. Prompts
+are not a security mechanism. Mechanism-level enforcement is
+non-negotiable for the Clew thesis.
+
+### Rejected: `test -w <path>` permission-based preflight.
+
+`test ! -w /opt` would fail inside any container with a writable
+overlay shadowing `/opt`, even when no host damage is possible. The
+intent (catch leaks) and the test (catch any write capability) don't
+align under apptainer's overlay model. Existence-based checks on
+identity files (`$HOME` visibility) avoid this entirely.
+
+### Rejected: enumerated per-path preflight (`.gitconfig`, `.ssh`, `.aws`, ...).
+
+Forever incomplete; every new credential cache added by tooling
+elsewhere requires a sac patch. The `$HOME`-visibility check covers
+the same surface in one assertion.
+
+### Rejected: `isolation_level: hardened | relaxed | custom` flat enum.
+
+Loses verifier resolution. Two `custom` runs with very different
+preflight_allow sets become indistinguishable on the card.
+
+## Implementation
+
+| Layer | Where | Status |
+|---|---|---|
+| `apptainer.relaxed: false` default | `config/_types.py::ApptainerSpec` | ✅ shipped earlier today |
+| `--containall` auto-prepended | `runtimes/_apptainer_runtime.py` | ✅ shipped |
+| `--cleanenv` auto-prepended | same | ✅ shipped (D1) |
+| `--writable-tmpfs` when no overlay | same | ✅ shipped (D1) |
+| Universal preflight injection | runtime wraps inner cmd with `bash -c "<preflight>\nexec <inner>"` | ✅ shipped (D2) |
+| `spec.apptainer.preflight_allow` field | `config/_types.py::ApptainerSpec` | ⏳ deferred (out of D1–D4 scope) |
+| AgentCard structured `isolation` block | `a2a/_card.py::project_card` | ✅ shipped (D3) |
+| `sac agents check` D4 bind-target warning | `cli_pkg/build_cmds.py::check` | ✅ shipped (D4) |
+| Regression tests | `tests/.../test__apptainer_runtime.py` + `tests/.../a2a/test__card.py` + `tests/.../cli_pkg/test_build_cmds.py` + `tests/.../runtimes/test__apptainer_isolation.py` + `tests/.../runtimes/test__apptainer_preflight.py` | ✅ shipped |
+
+## Consequences
+
+**Positive.**
+- sac becomes the only A2A-compatible agent runtime that mechanically
+  enforces isolation by default. Clear differentiation from LangGraph
+  / CrewAI / AutoGen (no isolation concept) and from Docker (isolation
+  exists but not declared / not attestable).
+- Clew can build verification chains that attest specific isolation
+  properties without sac-internal introspection.
+- The `scitex-stats-auditor` symlink-confusion class of incidents
+  becomes impossible: the agent can't "fix" the host because the host
+  isn't reachable.
+
+**Negative / tradeoffs.**
+- Existing agents that worked under the old defaults will fail-fast
+  if they implicitly relied on `$HOME` auto-bind. Operators must
+  either declare the bind explicitly OR opt in to `relaxed: true`.
+- The `--cleanenv` default removes `$PATH` inheritance; sac has to
+  inject the container's expected `$PATH` itself.
+- HPC-style "just run my command inside the container with my home
+  visible" is now a two-step (write `relaxed: true`); intentional.
+
+## Addendum: D2 refinement (2026-05-13 evening)
+
+Initial D2 design proposed `test ! -d "$HOME"` as a universal
+invariant. Pre-implementation verification against the
+scitex-stats-auditor spec.yaml exposed an Apptainer-specific edge
+case: **Apptainer creates the entire directory path of every bind
+target as scaffolding**, so a bind like
+`/home/$USER/proj/scitex-stats:/home/$USER/proj/scitex-stats:ro`
+causes `/home/$USER` (== `$HOME`) to exist as a directory inside the
+container — even under `--containall`, with no credential files
+visible. The D2 check would false-fire on every agent that mirrors
+host paths into the container.
+
+Two solutions were considered:
+
+- **Bind-aware preflight** (sac generates the preflight at runtime,
+  knowing what binds it's about to create, and the preflight checks
+  `$HOME` contents are a subset of the declared bind scaffolding).
+  Rejected: dynamic preflight is harder to integrate into Clew's
+  verification chain — verifier has to attest the *generator*, not
+  just the executed script.
+- **Container-canonical paths** (bind targets MUST use container-
+  side conventional roots — `/srv/`, `/work/`, `/opt/`, `/data/` —
+  never host-mirroring paths). Accepted.
+
+### D4. Bind targets MUST be container-canonical paths.
+
+Bind targets that mirror host paths (`/home/`, `/Users/`, `/root/`,
+absolute Windows-style paths) are deprecated. Bind targets MUST live
+under conventional container roots: `/srv/`, `/work/`, `/opt/`,
+`/data/`.
+
+Spec.yaml convention:
+
+```yaml
+spec:
+  apptainer:
+    binds:
+      - $HOME/proj/scitex-stats:/srv/sources/scitex-stats:ro
+      - $HOME/proj/scitex-dev:/srv/sources/scitex-dev:ro
+```
+
+Inside the container nothing under `/home/$USER` appears, so:
+
+1. The D2 preflight (`test ! -d "$HOME"`) stays static and universal.
+2. spec.yaml is **operator-agnostic** — the same spec runs cleanly
+   for any user.
+3. Verification chain receives a static preflight script with a
+   stable sha256; no meta-verification required.
+
+**Rationale, beyond the technical fix.** Container-canonical paths
+match Docker / OCI best practice and break the "works on my
+machine" failure mode (every agent that hardcodes
+`/home/ywatanabe/proj/...` is operator-bound). The shared-path
+convention was an HPC convenience artifact; Clew's reproducibility
+context inverts it.
+
+**sac-side enforcement (planned).** `sac agents check <name>` will
+emit a warning when a bind target starts with `/home/`, `/Users/`, or
+`/root/`. Future strict mode (`sac.audit.strict_binds: true`) makes
+it an error.
+
+**Convenience.** The runtime sets `$SAC_WORKDIR=/srv/sources` inside
+the container (when any bind targets land there), so `startup_prompts`
+and operator scripts can use `cd $SAC_WORKDIR/<pkg>` without
+hardcoding paths.
+
+### Order of execution
+
+1. ADR addendum (this section) — done.
+2. scitex-stats-auditor spec.yaml — bind targets translated to
+   `/srv/sources/...`; startup_prompts updated to reference the
+   container paths.
+3. Implementation: D1 + D2 (static check) + D3 + D4 (CLI validator).
+4. Restart scitex-stats-auditor against hardened sac; verify the
+   static preflight passes end-to-end.
+5. Preserve session.jsonl + preflight result for Clew supplementary.
+
+## Addendum: D5 — canonical container HOME (2026-05-14)
+
+Live verification of the hardened auditor exposed two issues with D2
+as originally specified:
+
+1. **Empty-`$HOME` false-fires.** Apptainer scaffolds `$HOME` from the
+   inherited passwd entry regardless of bind targets (even under
+   `--containall`), so `$HOME` is always a directory. The D2 check was
+   relaxed to "`$HOME` is *empty*" — workable, but it forces bind
+   targets out of `$HOME`, breaking operator-intuitive paths.
+2. **`/srv/`-style targets force script rewrites.** Anything that
+   references `~/proj/X` or `$HOME/proj/X` inside the container
+   breaks.
+
+### D5. Canonical container HOME = `/home/agent`.
+
+sac auto-injects `--home /home/agent` (skipped only under
+`apptainer.relaxed: true` or when the operator declared `--home`).
+Inside the container:
+
+- `$HOME == /home/agent`, operator-independent.
+- Bind targets use the canonical HOME: `~/proj/X:/home/agent/proj/X`.
+- The operator's actual host home is never scaffolded inside the
+  container.
+- `sac-base.sif` is rebuilt so UID-1000's passwd entry reads `agent`
+  (not `ubuntu`); `whoami` matches `$HOME`.
+
+### D5 preflight (replaces D2's empty-`$HOME` check).
+
+```bash
+# uid != 0, OR /proc/self/uid_map confirms userns-fakeroot.
+if [ "$(id -u)" = "0" ]; then
+  awk '$1==0 && $2!=0 {found=1} END {exit !found}' /proc/self/uid_map \
+    || exit 11   # real root, refuse
+fi
+test "$HOME" = "/home/agent" || exit 12  # canonical HOME
+```
+
+Two static lines, attestable by sha256. The "no host leak" property
+falls out of `--containall` + canonical `--home` + declared `binds:`.
+
+### Rationale.
+
+- **D4 stays** but is no longer the only path. Bind destinations may
+  live under `/home/agent/...` (intuitive) OR `/srv/`, `/work/`,
+  `/opt/`, `/data/` (container-canonical). Both pass D5.
+- **fakeroot opt-in (`apptainer.fakeroot: true`)** integrates: inside
+  the container `id -u == 0`, but `/proc/self/uid_map` proves
+  userns-mapping; the preflight accepts this without weakening the
+  no-real-root guarantee.
+
+### Implementation (D5).
+
+| Layer | Where | Status |
+|---|---|---|
+| `apptainer.fakeroot: bool` | `config/_types.py::ApptainerSpec` | ✅ |
+| Auto-prepend `--home /home/agent` | `runtimes/_apptainer_iso_flags.py` | ✅ |
+| Auto-append `--fakeroot` when opted in | same | ✅ |
+| Preflight rewrite (uid-map + canonical-HOME) | `runtimes/_apptainer_preflight.py` | ✅ |
+| sac-base.sif: ubuntu → agent | `containers/apptainer-base.def` | ✅ recipe; SIF rebuild pending |
+| Bind destination validation | `config/_parsers/_apptainer.py` | ✅ |
+| Doc updates + AgentCard JSON example | `docs/isolation.md` | ✅ |
+
+### Network isolation addendum (2026-05-14).
+
+Peer review pushed on `--network=bridge`, surfaced the A2A +
+MCP-over-loopback interop constraint, and converged on: stay with
+host netns for the Clew arXiv window; plan a `--network=bridge` +
+bridge-IF bind + `sac-host` `/etc/hosts` injection migration that
+preserves MCP URL stability. See `docs/isolation.md` §4.
+
+## References
+
+- [`docs/isolation.md`](../isolation.md) — the 10-category leak catalog this ADR's decisions close.
+- [`docs/spec-reference.md`](../spec-reference.md) — `spec.apptainer.relaxed`, `spec.apptainer.fakeroot`.
+- The 2026-05-13 scitex-stats-auditor incident — session.jsonl at
+  `~/.scitex/agent-container/runtime/scitex-stats-auditor/` for the
+  full trace.

--- a/docs/sphinx/adr/0003-runtime-home-directory.md
+++ b/docs/sphinx/adr/0003-runtime-home-directory.md
@@ -1,0 +1,204 @@
+---
+orphan: true
+---
+
+# ADR-0003: Runtime `home/` directory as the canonical container HOME (2026-05-14)
+
+**Status:** Accepted.
+**Supersedes:** Implicit layout from `runtime/agents/<name>/` + `runtime/workspaces/<name>/` (both unused after this ADR).
+**Related:** [`0001-isolation-hardening.md`](0001-isolation-hardening.md) — D5 introduced `--home /home/agent` but didn't relocate the host-side directory the container HOME points at.
+
+## Problem
+
+After D5 (`docs/adr/0001-isolation-hardening.md`), sac auto-injects
+`--home /home/agent` so `$HOME` is operator-independent inside the
+container. But `_dot_claude.py::deploy_dot_claude(config, workdir)`
+still materialises `dot_claude/*` into `<host-workdir>/.claude/`,
+and the host workdir is bind-mounted at **`/work`** — not at
+`/home/agent`.
+
+Consequence:
+
+- `/work/.claude/CLAUDE.md` is found by Claude's auto-walk-from-cwd
+  (still works for CLAUDE.md).
+- `/home/agent/.claude/skills/`, `/home/agent/.claude/.mcp.json`,
+  `/home/agent/.claude/hooks/`, `/home/agent/.claude/commands/` — empty.
+  Claude SDK's `$HOME/.claude/`-rooted discovery never sees the
+  operator's `dot_claude/` contents.
+
+The runtime layout also carries vestigial empty directories
+(`runtime/agents/<name>/`, `runtime/workspaces/<name>/`) from earlier
+designs that were never wired through, which makes the "where does
+sac actually put things?" question ambiguous.
+
+## Decision
+
+### D6. Per-agent runtime directory = the container's `$HOME` source.
+
+For each agent, sac maintains:
+
+```
+~/.scitex/agent-container/runtime/<name>/
+├── home/                  ← bind-mounted at /home/agent (canonical $HOME)
+│   ├── .claude/           ← dot_claude materialised here
+│   │   ├── CLAUDE.md
+│   │   ├── .mcp.json
+│   │   ├── skills/
+│   │   ├── hooks/
+│   │   └── commands/
+│   └── (anything the agent writes to $HOME — proj/, .cache/, ...)
+├── overlay.img            ← per-agent writable layer (was: runtime/overlays/<name>.img)
+├── pid
+├── apptainer_pid
+├── heartbeat.json
+├── session_id
+├── session.jsonl
+├── quota.json
+└── stdout.log
+```
+
+The bind:
+
+```
+~/.scitex/agent-container/runtime/<name>/home  →  /home/agent  (rw)
+```
+
+So inside the container:
+
+- `$HOME == /home/agent` (D5 invariant).
+- `$HOME/.claude/skills/` resolves to the materialised tree —
+  Claude SDK's discovery works without further config.
+- Anything the agent writes under `$HOME` persists on the host at
+  `runtime/<name>/home/`, browsable from the operator side without
+  entering the container.
+
+### D7. `dot_claude` materialises into `runtime/<name>/home/.claude/`.
+
+`_dot_claude.py::deploy_dot_claude` is rewritten to:
+
+1. Resolve `runtime/<name>/home/.claude/` as the target.
+2. Materialise `dot_claude/CLAUDE.md → home/CLAUDE.md`,
+   `dot_claude/.mcp.json → home/.mcp.json`, `dot_claude/.env →
+   home/.env`, `dot_claude/state.md → home/state.md`.
+3. Mirror `dot_claude/{commands,skills,hooks,agents,settings,...}/`
+   → `home/.claude/<same>/`.
+
+The workdir `/work` (which still mounts the operator's host workdir)
+no longer receives a `.claude/` materialisation — it stays a pure
+project-content mount.
+
+### D8. Overlay path consolidation.
+
+`apptainer.overlay` default resolves to `runtime/<name>/overlay.img`
+(previously `runtime/overlays/<name>.img`). Per-agent state lives
+under `runtime/<name>/` exclusively; the old `runtime/overlays/`
+location is left in place for backward compatibility but new agents
+write to the new location.
+
+### D9. Vestigial directories deprecated.
+
+`runtime/agents/<name>/` and `runtime/workspaces/<name>/` are no
+longer used by sac. They remain in the filesystem for now (no
+destructive cleanup); a future `sac runtime cleanup` command can
+remove them.
+
+## Migration
+
+- **Existing agents** — on next `sac agents start`:
+  - `runtime/<name>/home/` is auto-created if missing.
+  - `dot_claude` re-materialises into the new location.
+  - Existing `runtime/<name>/{pid,session.jsonl,…}` files keep their
+    current location (this ADR doesn't move them).
+  - Existing `runtime/overlays/<name>.img` continues to work if
+    `apptainer.overlay` points at it explicitly; new agents get
+    `runtime/<name>/overlay.img` by default.
+- **No data loss** — the refactor adds a directory; doesn't delete
+  or move existing data.
+
+## Rationale
+
+### Why name the directory `home/`, not `workspace/`?
+
+The semantic name (`home/`) directly matches what it becomes inside
+the container (`/home/agent`). Operators reading
+`runtime/scitex-stats-auditor/home/.claude/skills/` instantly know
+"this is what the agent sees as `~/.claude/skills/` inside the
+container." `workspace/` requires a glossary lookup.
+
+The bind line is self-documenting:
+
+```
+runtime/<name>/home  →  /home/agent
+       (host home)      (container home)
+```
+
+This matches Kubernetes' philosophy of naming things by their
+container-side semantic (`volumeMounts.mountPath`), not the host-side
+implementation detail.
+
+### Why `home/` *inside* `runtime/<name>/`, not as a sibling?
+
+Per-agent state should be browsable as one directory tree. Operators
+running `du -sh runtime/<name>/` should see the total footprint of
+that agent (overlay + home + logs + session). Splitting across
+parallel trees (`runtime/<name>/`, `runtime/overlays/<name>.img`,
+`runtime/workspaces/<name>/`) makes the "what does this agent use?"
+question harder than it needs to be.
+
+### Why not symlink `/home/agent → /work`?
+
+- Symlinks inside containers interact poorly with apptainer's bind
+  scaffolding (the same class of bugs as the original D4 motivation).
+- Two distinct mounts (one at `/work`, one at `/home/agent`) makes
+  the semantic separation visible: `/work` = project source code
+  (often read-only), `/home/agent` = agent's own state + skills.
+
+### Relationship to "strict vs relaxed" deployment modes
+
+This ADR is layout-only. The strict-vs-relaxed mode distinction
+(Clew reproducibility runs vs everyday development) layers on top:
+
+- **strict**: `runtime/<name>/home` bound `:ro`, project sources
+  `:ro`, no shared skills bind. Promises the verification chain
+  that `$HOME` was immutable during the run.
+- **relaxed**: `runtime/<name>/home` bound `:rw`, project sources
+  potentially `:rw`, host-side `~/.claude/skills/` optionally bound
+  in for cross-agent skill sharing.
+
+A separate ADR (0004) will formalise the mode field. This ADR just
+gives both modes a sensible directory to bind.
+
+## Implementation
+
+| Layer | Where | Status |
+|---|---|---|
+| Auto-create `runtime/<name>/home/` on start | `_apptainer_runtime.py::start` | ⏳ this PR |
+| Auto-prepend bind `home:/home/agent:rw` | `_apptainer_runtime.py::build_run_argv` | ⏳ this PR |
+| Materialise `dot_claude/` into `runtime/<name>/home/.claude/` | `_dot_claude.py::deploy_dot_claude` | ⏳ this PR |
+| Default `apptainer.overlay` → `runtime/<name>/overlay.img` | `_apptainer_runtime.py` resolution | ⏳ this PR |
+| ADR + `docs/isolation.md` cross-ref | docs | ✅ this commit |
+
+## Consequences
+
+**Positive.**
+- Claude SDK's `$HOME/.claude/`-rooted discovery (skills, hooks,
+  `.mcp.json`) works without operator intervention.
+- Per-agent state lives in one tree (`runtime/<name>/`) — backup,
+  cleanup, and inspection commands stay simple.
+- Operator-side debugging: `ls runtime/<name>/home/` shows what the
+  agent sees as its `$HOME` — no container shell needed.
+- Layout name aligns with container-side semantic — fewer
+  glossary jumps in docs.
+
+**Negative / tradeoffs.**
+- One extra bind in every container's argv. Negligible startup cost.
+- `dot_claude/` materialised twice during the transition window:
+  once into `runtime/<name>/home/.claude/` (new) and old
+  `<workdir>/.claude/` may still exist on disk from prior runs.
+  Cleanup deferred; not a correctness issue.
+
+## References
+
+- [`0001-isolation-hardening.md`](0001-isolation-hardening.md) — D5 introduced `--home /home/agent`.
+- [`../isolation.md`](../isolation.md) — to be updated with the new layout description.
+- [`../spec-reference.md`](../spec-reference.md) — `spec.dot_claude` materialisation target.

--- a/docs/sphinx/adr/0004-a2a-v1-compliance.md
+++ b/docs/sphinx/adr/0004-a2a-v1-compliance.md
@@ -1,0 +1,251 @@
+---
+orphan: true
+---
+
+# ADR-0004: Adopt A2A v1.0 (drop `/v1/` REST prefix, v1 AgentCard shape) (2026-05-14)
+
+**Status:** Accepted.
+**Supersedes:** Earlier `/v1/sac/...` REST surface + v0.3-shaped AgentCard.
+**Related:** [`0001`](0001-isolation-hardening.md), [`0003`](0003-runtime-home-directory.md).
+
+## Problem
+
+A2A reached v1.0 stable (Linux Foundation, April 2026) and the REST
+binding now **prohibits** any path that starts with `/v1/`. sac's
+existing routes — `/agents/<name>`, `/agents/<name>/`,
+`/agents/<name>/inbox/stream`, `/agents/<name>/_active`,
+plus the fleet root `/.well-known/agent.json` (v1 renamed the
+well-known file to `agent-card.json`) — fail A2A v1.0 compliance.
+
+The AgentCard projection (`_card.py`) carries v0.x shapes too: top-level
+`url` + `preferredTransport`, `defaultInputModes` /`defaultOutputModes`
+spellings that A2A v1 may have reshuffled into a per-interface block,
+and no `supportedInterfaces[]` array.
+
+Backward compatibility is **not** maintained — sac has no external
+consumers yet, and the simpler the v1 surface, the better the Clew
+arXiv positioning ("sac is A2A v1.0 compliant", not "sac speaks a
+custom dialect plus v1.0 in parallel").
+
+## Decision
+
+### D10. Route prefix `/agents/` → `/agents/`.
+
+All sac REST routes drop the `/v1/` prefix:
+
+| Old | New |
+|---|---|
+| `GET /.well-known/agent.json` | `GET /.well-known/agent-card.json` |
+| `GET /agents/` | `GET /agents/` |
+| `GET /agents/<name>/.well-known/agent.json` | `GET /agents/<name>/.well-known/agent-card.json` |
+| `POST /agents/<name>` | `POST /agents/<name>/message:send` (A2A v1 REST binding) |
+| `GET /agents/<name>/inbox/stream` | `GET /agents/<name>/inbox/stream` (sac extension) |
+| `GET /agents/<name>/_active` | `GET /agents/<name>/_active` (sac extension) |
+
+The `/agents/<name>/` prefix is sac's multi-agent extension above the
+A2A REST binding (the spec defines single-agent paths; sac fans
+several agents from one listen process).
+
+## sac extension namespace
+
+A2A v1.0 reserves the AgentCard top level for spec-defined fields and
+funnels vendor data into a namespaced extension block. **sac uses
+exactly one namespace key: `x-scitex-agent-container`.** Every
+sac-specific datum (role, scheduling, runtime, isolation, fleet
+listings, proxy metadata) lives under that key. This contract is what
+makes sac-served cards forward-compatible with vendor-neutral A2A
+clients — a strict v1 validator (e.g. proto `ParseDict(AgentCard)`)
+ignores the `x-*` namespace; sac-aware clients walk into it.
+
+**Implementation source of truth:**
+- `src/scitex_agent_container/a2a/_card.py::project_card` — per-agent
+  card.
+- `src/scitex_agent_container/a2a/_card.py::fleet_card` — fleet-level
+  card.
+- `src/scitex_agent_container/a2a/_card.py::validate_card_v1` — strips
+  `x-*` before proto validation, so the namespace is honoured by the
+  schema gate.
+- `src/scitex_agent_container/_runners/a2a_proxy.py::splice_card` —
+  AgentProxy runner overlay (kind / upstream / trust).
+
+**Rules (hard).**
+
+1. sac-specific data MUST live under `x-scitex-agent-container.*`.
+   Never at the top level of the card. Never under a different
+   namespace (e.g. `x-orochi`, `x-sac`, `vendor` — all forbidden).
+2. `x-orochi` is owned by the orochi fleet hub, not by sac. A
+   standalone `sac a2a serve` agent intentionally carries no
+   `x-orochi` block.
+3. `validate_card_v1` strips the `x-scitex-agent-container` key (and
+   any other `x-*` key) before proto validation. New fields therefore
+   only need to be valid JSON; they don't need a proto schema. This is
+   the explicit forward-compat lever.
+
+### Per-agent card fields (`project_card`)
+
+Every per-agent card served at
+`GET /agents/<name>/.well-known/agent-card.json` carries:
+
+| Field | Source | Description |
+|---|---|---|
+| `x-scitex-agent-container.role_class` | `metadata.labels.role` | Operator-declared role taxonomy (e.g. `worker-telegrammer`, `head`). Mirrors `skills[0].name`. |
+| `x-scitex-agent-container.cardinality` | `metadata.labels.cardinality` | `singleton` / `multi-instance` hint for fleet schedulers. |
+| `x-scitex-agent-container.scheduling` | derived from `spec.host` / `spec.hosts` | `{mode: "singleton", priority: [...]}` or `{mode: "multi-instance", hosts: [...]}`. The fleet hub reads this to place the agent. |
+| `x-scitex-agent-container.runtime` | `spec.runtime` | Runtime kind (`claude-code`, `agent-proxy`, etc.). |
+| `x-scitex-agent-container.model` | `spec.claude.model` (v3) ∨ `spec.model` (v2 back-compat) | LLM model identifier. |
+| `x-scitex-agent-container.multiplexer` | `spec.multiplexer` | tmux / zellij / none — operational tool selection. |
+| `x-scitex-agent-container.required_skills` | `metadata.labels.skills` (CSV) ∪ legacy `spec.skills.required` | Skill IDs the agent loads at boot. Also merged into `skills[0].tags`. |
+| `x-scitex-agent-container.isolation` | derived from `spec.apptainer.*` | Structured D3 isolation block — see below. |
+
+The `isolation` block (see ADR-0001) carries:
+
+| Sub-field | Type | Description |
+|---|---|---|
+| `level` | enum | `hardened` (default) / `relaxed` (escape hatch) / `custom` (any preflight allow-list). |
+| `containall` | bool | `--containall` flag is/will be passed to apptainer. |
+| `cleanenv` | bool | `--cleanenv` flag is/will be passed to apptainer. |
+| `writable_tmpfs` | bool | `--writable-tmpfs` will be passed (auto-added when not relaxed and no overlay). |
+| `preflight_passed` | list[str] | Preflight checks that ran and succeeded (`uid-nonzero`, `no-host-home`). |
+| `preflight_allowed` | list[str] | Preflight checks the operator explicitly bypassed. |
+| `binds_count` | int | Total apptainer `--bind` entries. |
+| `binds_writable_count` | int | Number of binds NOT carrying `:ro`. |
+
+External attestation surfaces (Clew, orochi) read these booleans to
+prove isolation properties without re-parsing the YAML.
+
+### Per-agent `capabilities.extensions[]` entries
+
+Distinct from the `x-scitex-agent-container.*` namespace, the A2A v1
+spec-defined `capabilities.extensions[]` array advertises sac
+extensions by URI:
+
+| URI | Emitted when | Purpose |
+|---|---|---|
+| `https://scitex.ai/a2a/extensions/sac-push-channel/v1` | `spec.claude.channels` contains `server:sac` | Advertises the in-session MCP push: `sac mcp channel` SSE-subscribes to `/agents/<name>/inbox/stream` and forwards events as `notifications/claude/channel` to the agent's Claude session. `params.sse_path` + `params.mcp_tools` enumerate the wire details. |
+
+### Fleet card fields (`fleet_card`)
+
+The fleet card at `GET /.well-known/agent-card.json` carries:
+
+| Field | Type | Description |
+|---|---|---|
+| `x-scitex-agent-container.agents` | list[object] | Member directory. Each entry has `name` + `supportedInterfaces[]` (v1 shape — no top-level `url`). Spec-aware clients walk this array to fetch each member's `/agents/<name>/.well-known/agent-card.json`. |
+
+The fleet card also advertises `capabilities.extensions[]`:
+
+| URI | Purpose |
+|---|---|
+| `https://scitex.ai/a2a/extensions/sac-fleet/v1` | Declares the multi-agent directory shape. `params.members_path` and `params.member_card_path` tell vendor-neutral clients how to walk the fleet. |
+
+### AgentProxy overlay (`splice_card`)
+
+When a `kind: AgentProxy` agent serves its card, three additional
+fields appear under `x-scitex-agent-container`:
+
+| Field | Source | Description |
+|---|---|---|
+| `x-scitex-agent-container.kind` | runner constant | `"AgentProxy"` — distinguishes a proxy from a native sac runtime. |
+| `x-scitex-agent-container.upstream` | `--upstream` CLI arg | Upstream A2A URL the proxy forwards to. |
+| `x-scitex-agent-container.trust` | `--trust` CLI arg | Trust tier (`trusted` / `untrusted`). |
+| `x-scitex-agent-container.upstream_card_fetch_error` | runtime | Present only when boot-time fetch of the upstream card failed; surfaces the error so operators see why upstream skills aren't propagating. |
+
+See `src/scitex_agent_container/_runners/a2a_proxy.py::splice_card`.
+
+### Cross-references
+
+- Skill doc: [`07_a2a-protocol.md`](https://github.com/ywatanabe1989/scitex-agent-container/blob/develop/src/scitex_agent_container/_skills/scitex-agent-container/07_a2a-protocol.md)
+  mirrors this enumeration for operators reading skill docs.
+- Per-agent projection: `a2a/_card.py:project_card`
+- Fleet projection: `a2a/_card.py:fleet_card`
+- v1 schema gate: `a2a/_card.py:validate_card_v1`
+- AgentProxy overlay: `_runners/a2a_proxy.py:splice_card`
+
+## Decision (continued)
+
+### D11. AgentCard publishes A2A v1.0 fields only.
+
+Verified against the lf/a2a/v1 proto (`~/proj/A2A`), not the auditor's
+summary — the auditor had two wrong field names:
+
+- Top-level `url` is **removed**. The v1 proto has no top-level `url`;
+  binding URLs live under `supportedInterfaces[]` only.
+- `supportedInterfaces[]` is REQUIRED. Each interface has:
+  - `url` (HTTPS in prod)
+  - `protocolBinding`: `"JSONRPC"` | `"GRPC"` | `"HTTP+JSON"` (the
+    canonical strings — **not** `"REST"` as the auditor suggested).
+  - `tenant` (sac uses the agent name as tenant)
+  - `protocolVersion`: `"1.0"`
+- `capabilities` carries `streaming`, `pushNotifications`,
+  `extensions[]`, `extendedAgentCard` — no `stateTransitionHistory`
+  (v0.x field, gone in v1).
+- No top-level `authentication.schemes` (v0.x). v1 uses
+  `securitySchemes` (map) + `securityRequirements[]`. Current sac
+  cards advertise no auth, so we simply omit both fields rather
+  than emit empty placeholders.
+- `kind` discriminator: not present in current sac card, so no action.
+- Enums (where sac surfaces any) follow SCREAMING_SNAKE_CASE per
+  A2A v1.0.
+
+### D12. The `notifications/claude/channel` push primitive stays sac's, not A2A.
+
+A2A v1.0 has `tasks/pushNotificationConfig/*` for *task-level*
+push, which is orthogonal to Claude Code's in-session channel. The
+sac MCP push channel (ADR's commit 1–4 from today) is a Claude Code
+construct, not an A2A construct — keep it where it lives, in
+`server:sac` MCP, not on the A2A wire.
+
+### D13. No backward compatibility.
+
+Old `/v1/sac/...` paths are deleted. Tests that hit them are
+updated. The change is internal to sac (no external API consumers
+yet); any operator scripts that hardcoded the old paths must update
+to the new ones.
+
+## Implementation
+
+| Layer | Where | Status |
+|---|---|---|
+| Route refactor (delete /v1/sac/, add /agents/) | `a2a/_server.py` | ⏳ this PR |
+| AgentCard shape update (supportedInterfaces, drop top-level url, streaming=true) | `a2a/_card.py` | ⏳ this PR |
+| Card consumer updates (sac mcp channel SSE URL, sidecar references) | `_mcp/channel.py`, `runtimes/_apptainer_runtime.py`, `_runners/...` | ⏳ this PR |
+| Tests updated to new paths + shape | `tests/.../a2a/*`, `tests/.../runtimes/*` | ⏳ this PR |
+| docs (`isolation.md`, `sac-and-orochi.md`, `spec-reference.md`) | docs | ⏳ this PR |
+| A2A TCK as CI gate | `.github/workflows/a2a-tck.yml` | ⏳ follow-up |
+| JWS-signed AgentCard | `a2a/_card.py` + new dep | ⏳ follow-up (ADR-0005) |
+
+## Rationale
+
+- **Future-proof against v1.1+**: standard paths + `supportedInterfaces[]`
+  is the v1.0 shape; minor versions extend, don't break.
+- **TCK passable**: the A2A Technology Compatibility Kit
+  (`a2aproject/a2a-tck`) runs against the standard REST binding.
+  Once routes match, `--category mandatory` becomes a CI gate.
+- **Inspector friendly**: `ghcr.io/a2aproject/a2a-inspector`
+  expects the standard surface; refactoring lets us point it at
+  sac's localhost and get a real diff vs zero diff (= compliant).
+- **Clew positioning**: "sac is A2A v1.0 compliant" is a one-line
+  claim in the Methods section. The earlier alternative ("sac
+  speaks A2A-like REST") was honest but weaker.
+
+## Consequences
+
+**Positive.**
+- One step closer to upstream-mergeable example for the A2A community.
+- All A2A v1.0 framework consumers (Google ADK, LangGraph, CrewAI,
+  LlamaIndex, Microsoft Agent Framework) can speak to sac agents
+  natively over the standard REST binding.
+- TCK gate possible; passes prove sac compliance mechanically.
+
+**Negative.**
+- One-shot refactor across `_server.py`, `_card.py`,
+  `_mcp/channel.py`, sidecar bind logic, and all tests. No
+  parallel-path softening; the merge is the migration.
+- Any operator who curl-tested the old `/v1/sac/...` paths needs to
+  re-learn the new ones. Mitigation: docs updated in the same PR.
+
+## References
+
+- A2A v1.0 spec: <https://a2a-protocol.org/latest/specification/>
+- A2A Inspector: <https://github.com/a2aproject/a2a-inspector>
+- A2A TCK: <https://github.com/a2aproject/a2a-tck>
+- Peer discussion that motivated this ADR — `2026-05-14` transcript.

--- a/docs/sphinx/adr/0008-sac-node-transport-boundary.md
+++ b/docs/sphinx/adr/0008-sac-node-transport-boundary.md
@@ -1,0 +1,191 @@
+---
+orphan: true
+---
+
+# ADR-0008: sac is the node-transport substrate; comms model is nodes / lineage / groups / ACL (2026-05-20)
+
+**Status:** Accepted.
+**Supersedes:** the implicit "sac = one host; orochi = across hosts"
+framing in [`docs/sac-and-orochi.md`](../sac-and-orochi.md) (pre-2026-05-20
+revision).
+**Related:** [`ADR-0004`](0004-a2a-v1-compliance.md) (A2A v1 compliance —
+§D12 defines the push primitive this ADR builds on).
+**Handoff:** `GITIGNORED/HANDOFF_AGENT_COMMS_2026-05-19.md`.
+
+## Problem
+
+Two boundaries had drifted out of alignment with reality:
+
+1. **The "one host vs many hosts" split between sac and orochi was
+   wrong.** sac already places and drives agents on remote hosts via
+   `spec.host` (and SSH hops in `spec.remote.hops`); the moment it does
+   so, it must also carry their messages — there is no "off-host" sac
+   could hand the messaging off to without orochi installed. Yet the
+   doc said "sac = one host, orochi = across hosts."
+
+2. **sac had no model for non-sac-managed nodes on its comms graph.**
+   A plain `claude` CLI session — the official CLI is stable and good
+   for terminal/human interaction — could not address or be addressed by
+   a sac-managed agent without sac inheriting its lifecycle. That made
+   "lead = plain `claude` CLI, workers = sac-managed agents" impossible
+   to express, even though the operator regularly runs exactly that
+   topology.
+
+The remediation is a single ADR because the two are intertwined: the
+non-sac-managed-node concept *only* makes sense once sac is the
+transport substrate (not the lifecycle manager that happens to also
+forward messages).
+
+## Decision
+
+### D1. sac is the node-transport substrate
+
+sac carries messages **any node ↔ any node**, on **any host** (same
+host, LAN, SSH-alias, tunnel), **ACL-gated**, self-sufficient with zero
+orochi installed.
+
+Orochi is the human/product layer: web chatops UI, dashboard, topology
+viz, presence, channels/DMs/threads as features, *and* the connectivity
+mesh (cloudflared / autossh) that **establishes** host reachability.
+Orochi is a *consumer* of sac transport, not the transport.
+
+sac assumes reachability. Orochi establishes it.
+
+### D2. Two kinds of node, distinguished only by who owns the lifecycle
+
+A **node** is an *identity* + an *inbox* + an *ACL*. Two kinds:
+
+* **sac-managed** — sac owns the lifecycle (spec, container,
+  start/stop/health). Lifecycle entry point: `sac agent start`.
+* **external** — sac does **not** own the lifecycle. Typically a plain
+  `claude` CLI session. Joins the comms graph by running
+  `sac mcp channel --name <id> --listen-url <sac listen>`. No
+  container. No spec. sac never starts or stops an external node.
+
+Both kinds are equal on the comms graph. The orchestration layer may
+assign a role ("lead", "worker", "coordinator") to a node — sac sees
+only "a node".
+
+### D3. Lineage and groups
+
+sac records who called `sac agents start`: the caller is the **parent**,
+the spawned agent its **child**. A parent together with its direct
+children is one **group**. The group is the unit of default ACL.
+
+### D4. ACL — permissioned messaging
+
+* Intra-group sends are allowed by default (parent↔child *and*
+  sibling↔sibling, bidirectional).
+* Cross-group sends require an **explicit ACL grant**
+  (`spec.comms.allow` for sac-managed nodes; a policy store for
+  external nodes).
+* The graph is permissioned — never implicitly all-to-all. An ungated
+  channel is a prompt-injection vector
+  ([Claude Code channels reference](https://code.claude.com/docs/en/channels-reference)).
+
+### D5. Depth limit is a POLICY, not a structural ceiling
+
+We currently forbid a child from spawning children, so the *live*
+hierarchy is two levels. The model, schema, lineage and group logic
+remain **N-level capable** — recursion is the natural shape; nothing
+hard-codes "2" or assumes fixed depth. The cap is a lift-able policy
+rule. Lifting it later is a policy change only — zero
+structural / schema / data-structure change.
+
+### D6. A2A compliance for both kinds of node
+
+Every node, sac-managed or external, is addressable via A2A; a node's
+identity *is* its A2A AgentCard.
+
+* sac-managed: the card is projected from `spec.yaml` by
+  `a2a/_card.py::project_card`.
+* External: the card is **synthesised at registration** by
+  `_listen/_nodes.py::synthesize_external_card` — identity + inbox
+  endpoint + the v1-required capability fields, marked
+  `"x-scitex-agent-container.node_kind": "external"`. Registration is
+  implicit: the first `message:send` / `inbox/stream` touch on a name
+  mints + caches the card.
+
+### D7. Durability of the channel bus
+
+Every channel event is persisted to `state.db.channel_events` before
+fan-out. The SSE handler replays missed events on connect
+(`Last-Event-ID` cursor) and stamps each frame with `id: <row_id>`,
+marking the row delivered as it ships. An event POSTed while no
+subscriber is connected is delivered on the next connect; a
+kill + reconnect replays exactly the missed events; nothing is dropped
+silently.
+
+Schema: `(id, target, source, kind, content, meta_json, ts, delivered_at)`.
+
+### D8. Endpoint location for the inbox surface
+
+The inbox endpoints (`message:send` and `inbox/stream`) live on the
+always-on `sac listen` host control-plane (`_listen/server.py`),
+**keyed by node identity** — they accept a name that has no YAML and
+no container. The per-agent `a2a/_server.py` is a separate surface
+for sac-managed-agent SDK plumbing.
+
+### D9. The transport is Claude Code's official channels feature
+
+No new channel protocol. The MCP server emits
+`notifications/claude/channel`; Claude Code renders it as a
+`<channel source="..." ...>` block in the running session. This is
+the same protocol orochi's `server:orochi-push` uses — sac just adds
+the `server:sac` flavour pointing at the local listen.
+
+## What this rules out
+
+* No UI, dashboard, or topology viz in sac — orochi's.
+* No orochi awareness in sac. The boundary stays one-way (orochi → sac).
+* No new channel protocol — use Claude Code channels as-is.
+* No "lead" / "head" / "worker" / role concept in sac — only nodes,
+  lineage, groups, ACL.
+* No sac lifecycle management of external nodes — sac never starts or
+  stops any external node.
+* No per-agent role/address config beyond `spec.comms` ACL.
+
+## What this opens up (deliberately, but not built yet)
+
+The model is shaped to accept **transport adapters** in a phase-2:
+
+* A **human adapter** (a human is a node too — reachable via Telegram /
+  phone / email; replies in that app). Backed by
+  `claude-code-telegrammer` + `scitex-notification` today; phase 2
+  registers them behind the same `node = identity + inbox + ACL` model.
+* A possible HTTP webhook adapter or the orochi UI as an adapter.
+
+The phase-1 work (WI-1..6 from the handoff) builds exactly one adapter:
+the Claude-session adapter (`sac mcp channel`, MCP
+`notifications/claude/channel`). The model is deliberately
+adapter-shaped so a second adapter can be added later without touching
+the core. The only phase-2 obligation on phase-1 is: keep the adapter
+seam clean — the node model, ACL and routing must not assume the
+Claude-session adapter is the only transport.
+
+## Implementation sources of truth
+
+* Node-identity inbox endpoints + external-node registry —
+  `src/scitex_agent_container/_listen/_nodes.py`,
+  `src/scitex_agent_container/_listen/server.py`.
+* Channel-event durability + replay —
+  `src/scitex_agent_container/_state/state_db_channel.py`,
+  `channel_events` table schema in
+  `src/scitex_agent_container/_state/state_db.py`.
+* SSE replay handler — `a2a/_server.py::get_inbox_stream` (and the
+  symmetric handler in `_listen/server.py::node_inbox_stream`).
+* Card projection (sac-managed) — `a2a/_card.py::project_card`.
+* Card synthesis (external) — `_listen/_nodes.py::synthesize_external_card`.
+
+## References
+
+* `docs/sac-and-orochi.md` — narrative version of this ADR for the
+  package docs.
+* `GITIGNORED/HANDOFF_AGENT_COMMS_2026-05-19.md` — the handoff that
+  motivated this work; superseded once WI-1..6 land.
+* [Claude Code channels reference](https://code.claude.com/docs/en/channels-reference)
+  — protocol + the "gate inbound messages" guidance that directly
+  informs D4.
+* `docs/design/telegram-fold.md` — the consumer flow
+  (telegram → Broker → SSE → `sac mcp channel` → session) that
+  prefigured this model.

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -130,6 +130,10 @@ myst_enable_extensions = [
     "substitution",
     "tasklist",
 ]
+# Auto-generate anchors for headings up to h3 so cross-document
+# fragment links (e.g. ``[X](spec-reference.md#kind-agentproxy)``)
+# resolve without explicit ``(target)=`` labels in the source.
+myst_heading_anchors = 3
 
 # -- Options for intersphinx extension ---------------------------------------
 

--- a/docs/sphinx/credentials.md
+++ b/docs/sphinx/credentials.md
@@ -1,1 +1,124 @@
-../credentials.md
+# Claude Code credential & settings files
+
+This document describes the on-disk files Claude Code manages for a user
+and which fields `scitex-agent-container` is allowed to read and surface.
+
+## Files
+
+### `~/.claude.json`
+
+The main per-user settings JSON managed by Claude Code itself. Top-level
+keys relevant to agent orchestration:
+
+- `oauthAccount` (subdict): `accountUuid`, `emailAddress`, `organizationUuid`,
+  `organizationName`, `billingType`, `accountCreatedAt`,
+  `subscriptionCreatedAt`, `hasExtraUsageEnabled`, `displayName`,
+  `organizationRole`.
+- `hasAvailableSubscription` (bool)
+- `cachedExtraUsageDisabledReason` (str, e.g. `"out_of_credits"`)
+- `overageCreditGrantCache` (obj)
+- `numStartups` (int)
+- `installMethod` (str)
+- `claudeCodeFirstTokenDate` (str)
+- `firstStartTime` (str)
+- `hasCompletedOnboarding` (bool)
+- `passesEligibilityCache` (obj)
+- `changelogLastFetched` (str)
+- `lastReleaseNotesSeen` (str)
+- `skillUsage` (obj)
+
+Any other keys (model caches, feature flags, editor state, MCP server
+definitions, per-project history) are considered opaque and MUST NOT be
+surfaced by our tooling.
+
+### `~/.claude/.credentials.json`
+
+OAuth tokens for Claude.ai. Contains (inside a `claudeAiOauth` subdict):
+`accessToken`, `refreshToken`, `expiresAt`, `scopes`, `subscriptionType`,
+`rateLimitTier`.
+
+**RULE: this file MUST NEVER be read or emitted by scitex-agent-container
+tooling except for the non-secret strings `subscriptionType` and
+`rateLimitTier`.** The extractor must not load, log, cache, or transmit
+any other field from this file. Tokens are the highest-sensitivity
+material on the host.
+
+### `~/.claude/settings.json`
+
+Per-user Claude Code settings. Common keys: `permissions`, `statusLine`
+(command used to render the bottom bar, often claude-hud),
+`enabledPlugins`. Contains no secrets but may reveal which plugins /
+skills are enabled.
+
+## Fleet hosts
+
+Each fleet host runs exactly one Claude Code OAuth identity shared by
+all tmux-managed agents on that host:
+
+| Host              | Domain role            | Credential home |
+|-------------------|------------------------|-----------------|
+| MBA               | scitex-orochi.com hub  | `~/.claude/`    |
+| NAS               | scitex.ai              | `~/.claude/`    |
+| spartan           | GPU worker             | `~/.claude/`    |
+| ywata-note-win    | Windows/WSL            | `~/.claude/`    |
+
+All tmux panes on a host inherit the same `~/.claude.json` +
+`~/.credentials.json`, so any head-agent view of "Claude account" is
+per-host, not per-agent.
+
+## What NOT to emit
+
+The extraction layer MUST strip any field whose key or stringified value
+contains any of these substrings (case-insensitive):
+
+- `accessToken`
+- `refreshToken`
+- `sk-ant-`
+- `Bearer ` (with trailing space)
+- `secret`
+- `apiKey`
+- `claudeAiOauth`
+
+A post-extraction guard asserts the returned dict contains none of the
+above in either keys or values, and raises if violated.
+
+## Safe metadata fields (whitelist)
+
+`read_credentials_metadata()` returns a flat dict with exactly these
+keys. Fields unavailable on disk are returned as `None`.
+
+From `~/.claude.json` `oauthAccount`:
+
+- `account_uuid`
+- `email_address`
+- `organization_uuid`
+- `organization_name`
+- `billing_type`
+- `account_created_at`
+- `subscription_created_at`
+- `has_extra_usage_enabled`
+- `display_name`
+- `organization_role`
+
+From `~/.claude.json` top level:
+
+- `has_available_subscription`
+- `cached_extra_usage_disabled_reason`
+- `num_startups`
+- `install_method`
+- `claude_code_first_token_date`
+- `first_start_time`
+- `has_completed_onboarding`
+
+From `~/.claude/.credentials.json` `claudeAiOauth` (only these two):
+
+- `subscription_type`
+- `rate_limit_tier`
+
+From `~/.claude/settings.json`:
+
+- `status_line_command`
+- `enabled_plugins`
+
+Any addition to this list requires updating both this doc and the
+whitelist in `src/scitex_agent_container/credentials.py`.

--- a/docs/sphinx/directories.md
+++ b/docs/sphinx/directories.md
@@ -1,1 +1,62 @@
-../directories.md
+# Configuration and Runtime Directories
+
+## Layout
+
+Configuration is separated into user-scope and project-scope. Project-scope (`.scitex/agent-container/` at the git root) takes priority when present.
+
+```
+~/.scitex/agent-container/ or <project>/.scitex/agent-container/
+├── config.yaml                ← host identity, host.aliases, peers (F-CS12),
+│                                listen.{host,port}, a2a.port_range
+├── agents/<name>/             ← per-agent declarations (you write these)
+│   ├── spec.yaml              ← v3 Agent definition (the SSoT)
+│   └── dot_claude/            ← optional: materialized into <workdir> at start
+│       ├── CLAUDE.md           (→ <workdir>/CLAUDE.md, marker-protected)
+│       ├── .mcp.json           (→ <workdir>/.mcp.json, per-server merge)
+│       ├── .env                (→ <workdir>/.env, mode 0600)
+│       ├── state.md            (→ <workdir>/state.md, full overwrite)
+│       ├── commands/           (→ <workdir>/.claude/commands/)
+│       ├── skills/             (→ <workdir>/.claude/skills/)
+│       └── hooks/              (→ <workdir>/.claude/hooks/)
+├── accounts/                  ← saved Claude Code accounts (sac account save)
+│   ├── <name>/
+│   │   ├── account.json        (safe metadata; no tokens)
+│   │   └── .credentials.json   (copied into ~/.claude/ on `sac account use`)
+│   └── _rotations/
+│       └── <email>.ndjson      (OAuth-rotation log, one append per observed rotation)
+├── tokens/
+│   └── listen-<host>.token    ← `sac listen` bearer tokens (0600)
+├── containers/                ← built Apptainer images
+│   ├── sac-base.sif    -> sac-base/sac-base.sif        (top-level symlink)
+│   ├── sac-scitex.sif  -> sac-scitex/sac-scitex.sif    (top-level symlink)
+│   ├── sac-{base,scitex}/                              (dir-per-image)
+│   │   ├── sac-{base,scitex}.sif                       (the image; gitignored)
+│   │   ├── sac-{base,scitex}.def                       (recipe snapshot)
+│   │   ├── sac-{base,scitex}.build-YYYY-MMDD-HHMMSS.log (full build log; gitignored)
+│   │   └── .def-hash                                   (skip-rebuild cache)
+│   └── {dpkg,node,requirements}-lock.txt               (auto-freeze lock files)
+└── runtime/                   ← regenerable per-host state; gitignored
+    ├── <agent-name>/           per-agent runner state
+    │   ├── pid                  (runner PID)
+    │   ├── heartbeat.json       ({ts, pid, state}; refreshed every tick)
+    │   ├── session_id           (persisted SDK session id, resume marker)
+    │   ├── session.jsonl        (one JSON object per turn event)
+    │   └── quota.json           (accumulated per-turn token totals)
+    ├── events/                  Claude Code hook event ring-buffer
+    │   └── <agent>.jsonl
+    └── cache/                   snapshot cache for the dashboard / `sac agents diff`
+        └── <agent>.{latest,prev,diff}.json
+```
+
+## Configuration cascade
+
+Settings are resolved in this order (first wins):
+
+1. **CLI flag** — `sac agents start hello --workdir /tmp/x`
+2. **Env var** — `SAC_<X>` or the long `SCITEX_AGENT_CONTAINER_<X>` form
+   (setting both with different values raises `SacEnvConflict`). Copy
+   [`.env.example`](https://github.com/ywatanabe1989/scitex-agent-container/blob/develop/.env.example) to `.env` and uncomment what you need.
+3. **Project config** — `<proj>/.scitex/agent-container/config.yaml`,
+   when you're inside a git repo that ships one.
+4. **User config** — `~/.scitex/agent-container/config.yaml`
+   (relocatable via `$SCITEX_DIR`).

--- a/docs/sphinx/how-sac-works.md
+++ b/docs/sphinx/how-sac-works.md
@@ -1,1 +1,99 @@
-../how-sac-works.md
+# How sac works
+
+`scitex-agent-container` (`sac`) materializes a `spec.yaml` into a long-lived,
+externally addressable Claude agent.
+
+## Launch flow
+
+```
+  spec.yaml   ─┐
+  dot_claude/ ─┴─→ sac agents start ──→ apptainer instance
+                                          │
+                                          ▼
+                              long-lived Claude SDK session
+                              │
+                              ├── <workdir>  (= spec.workdir, mounted rw)
+                              │     CLAUDE.md / .mcp.json / .env / state.md     ← from dot_claude/
+                              │     .claude/{commands,skills,hooks,...}         ← mirrored
+                              │
+                              ├── spec.mounts[]  ← explicit host-path allowlist (ro/rw)
+                              │
+                              ├── state-dir  (host: ~/.scitex/agent-container/runtime/<name>/)
+                              │     pid, heartbeat.json,
+                              │     session.jsonl, session_id, quota.json
+                              │
+                              ├─→ POST /v1/turn                 (per-agent A2A inbound)
+                              │       ▲
+                              │       │  live-runner route
+                              │       │
+  sac listen :7878 ───────────┼───────┘
+  bearer-auth /v1/sac/{                 \
+    health, agents,                      ─→ claude --resume <sid> -p
+    agents/<n>/{status,send,card},                          (re-launch fallback when
+    ...                                                      no live runner)
+  }
+                                                            ▲
+  sac channel send TO MSG ─────────────────────────────────┤
+  sac peer  post-turn  AGENT TEXT  ────────────────────────┘
+```
+
+## What each piece does
+
+### `spec.yaml` (SSoT)
+
+The single file that fully defines an agent. The agent name is the name of its
+parent directory — no name field in the YAML. See [spec-reference.md](spec-reference.md).
+
+### `dot_claude/` (optional)
+
+A directory next to `spec.yaml`. At start, `sac` copies its contents into the
+agent's `<workdir>`:
+
+| Source                    | Destination                     | Merge rule             |
+|---------------------------|---------------------------------|------------------------|
+| `CLAUDE.md`               | `<workdir>/CLAUDE.md`           | marker-protected append |
+| `.mcp.json`               | `<workdir>/.mcp.json`           | per-server merge       |
+| `.env`                    | `<workdir>/.env`                | mode 0600, overwrite   |
+| `state.md`                | `<workdir>/state.md`            | full overwrite         |
+| `commands/`, `skills/`, `hooks/` | `<workdir>/.claude/*/`   | recursive copy         |
+
+### Apptainer instance
+
+`sac agents start` calls `apptainer exec` with:
+- the SIF at `spec.apptainer.image`
+- `<workdir>` bound rw at `/work`
+- any extra binds from `spec.apptainer.binds[]`
+- env vars from `spec.apptainer.env`
+- optional GPU passthrough (`--nv` / `--rocm`)
+
+### Claude SDK session
+
+Inside the container, `sac` launches `claude` (Claude Code CLI) as a long-lived
+SDK session. Session state persists in the host-side state dir so it survives
+container restarts. `spec.claude.session` controls whether to start fresh
+(`new-session`), continue the last session (`continue`), or resume a specific
+one (`resume <sid>`).
+
+### A2A inbound (`spec.a2a.port`)
+
+When `spec.a2a.port` is set, `sac` binds `POST /v1/turn` on that localhost port
+for this agent. Any process on the host can send a prompt without knowing the
+tmux pane — including other agents via `sac peer post-turn`.
+
+### `sac listen` (control plane)
+
+A per-host REST API (bearer-auth, loopback-only) that exposes fleet-wide
+operations: health checks, agent status, send, agent-card, and more.
+`sac channel send` routes through it for local agent-to-agent messaging.
+
+## Restart / health
+
+The runner supervisor checks `spec.health` probes and applies `spec.restart`
+policy (never / on-failure / always) with exponential backoff.
+Heartbeat state is written to `runtime/<name>/heartbeat.json` every tick.
+
+## See also
+
+- [spec-reference.md](spec-reference.md) — full field reference
+- [directories.md](directories.md) — directory tree + config cascade
+- [images.md](images.md) — Apptainer image management

--- a/docs/sphinx/images.md
+++ b/docs/sphinx/images.md
@@ -1,1 +1,60 @@
-../images.md
+# Apptainer Images
+
+## Builtin layers
+
+Two `.def` recipes, layered:
+
+| Tag       | What's inside                                                                                               | When                                   |
+|-----------|-------------------------------------------------------------------------------------------------------------|----------------------------------------|
+| `:base`   | Ubuntu 24.04 + dev tools (git, gh, rust CLIs, mermaid, prettier, eslint, jsonlint, uv, pipx, tree, node 20) | **Default** when `spec.image` is unset |
+| `:scitex` | `FROM :base` + ffmpeg + portaudio + `scitex[all]` + claude-agent-sdk + sac itself                           | Optional heavier layer                 |
+
+Recipes ship in the pip wheel — no need to clone the repo to run `sac image build`.
+Built artifacts live under `~/.scitex/agent-container/containers/`, never in git.
+
+```
+<site-packages>/scitex_agent_container/containers/
+  apptainer-{base,scitex}.def    ← canonical SSoT
+```
+
+## Build
+
+```bash
+sac image build           # :base SIF (default; OS + dev tools, ~15-25 min)
+sac image build scitex    # :scitex SIF (FROM :base + scitex[all], ~10-20 min)
+sac image build --sandbox # writable sandbox dir instead of frozen SIF
+```
+
+## Sandbox / freeze workflow
+
+Sandbox once, refresh when you want, freeze when stable:
+
+```bash
+sac image build scitex --sandbox        # one-time: writable sandbox
+sac image update sandbox/               # any time: pip install --upgrade scitex[all]
+sac image freeze sandbox/ scitex-2.28.15.sif   # bake to immutable SIF
+sac image switch 2.28.15               # atomic flip (previous remembered)
+sac image rollback                     # restore previous version
+sac image snapshot -o env.json         # full reproducibility capsule
+```
+
+The build / sandbox / version / rollback verbs all delegate to
+[`scitex-container`](https://github.com/ywatanabe1989/scitex-container).
+
+## Pinning a custom image
+
+Set `spec.apptainer.image` in your `spec.yaml`:
+
+```yaml
+spec:
+  apptainer:
+    image: ~/.scitex/agent-container/containers/sac-base/sac-base.sif
+```
+
+Or use a relative path (resolved relative to `spec.yaml`):
+
+```yaml
+spec:
+  apptainer:
+    image: ./my-custom.sif
+```

--- a/docs/sphinx/isolation.md
+++ b/docs/sphinx/isolation.md
@@ -1,1 +1,369 @@
-../isolation.md
+# Container Isolation in sac
+
+> **TL;DR.** Apptainer's defaults prioritize HPC convenience: it
+> auto-binds `$HOME`, `/tmp`, `/proc`, `/sys`, `/dev`; inherits every
+> environment variable; shares the host's network, PID, and IPC
+> namespaces; and uses the host's UID/GID. For agent workloads —
+> where the container is meant to be a security boundary — these
+> defaults are upside-down. This document enumerates every leak path
+> and the sac-side default flip that closes it.
+
+This is also the reference for the **Clew** reproducibility experiments:
+"same SIF + same spec.yaml" can only be a real claim when isolation
+is declared, mechanically enforced, and externally verifiable. sac's
+position: isolation level is a first-class spec.yaml field, sac
+chooses **hardened by default**, and the AgentCard publishes the
+agreed level so peers can audit it.
+
+---
+
+## Apptainer's default leak paths (10 categories)
+
+### 1. Auto-bound filesystem paths
+
+`apptainer exec` without options auto-binds:
+
+| Path | What leaks | Impact |
+|---|---|---|
+| `$HOME` | dotfiles, `.ssh/`, `.gitconfig`, `.bash_history`, `.cache/`, app config | agent can read host identity AND mutate it |
+| `/tmp` | other processes' temp files, locks, sockets | cross-container contamination, host-state writes |
+| `/var/tmp` | persistent temp files | state persists across runs |
+| `/proc` | every host PID's metadata | host process introspection |
+| `/sys` | kernel settings, devices | host hardware fingerprint |
+| `/dev` | device nodes (`/dev/null`, GPU, etc.) | device access |
+| `$PWD` | the cwd at `apptainer exec` time | accidental scope creep |
+
+**Fix:** `--containall` (cuts all of the above in one flag), or
+`--contain --no-home` for finer control.
+
+### 2. Environment variable inheritance
+
+Apptainer forwards essentially every host env var into the container:
+
+| Variable | What leaks |
+|---|---|
+| `$PATH` | host bin paths (`/usr/local/cuda/bin`, etc.) — references that don't exist inside |
+| `$HOME` | host home path — tools that expect a specific `$HOME` get confused |
+| `$USER`, `$LOGNAME` | host username |
+| `$SSH_AUTH_SOCK` | host ssh-agent socket — agent inherits ssh-agent identity |
+| `$DISPLAY`, `$WAYLAND_DISPLAY` | host X / Wayland session |
+| `$DBUS_SESSION_BUS_ADDRESS` | host D-Bus access |
+| `$AWS_*`, `$GCP_*`, `$ANTHROPIC_API_KEY`, … | every cloud / API credential |
+| `$XDG_RUNTIME_DIR` | host runtime dir (`/run/user/$UID`) |
+| `$LANG`, `$LC_*` | locale (host vs container OS mismatch) |
+
+**Fix:** `--cleanenv` wipes everything; pass only what's needed via
+`--env KEY=VAL`.
+
+### 3. User / permission inheritance
+
+| Item | Default | What leaks |
+|---|---|---|
+| UID / GID | host user inherited as-is | files created in container land on host with host UID |
+| supplementary groups | host's full group list | host's group permissions effective inside |
+| `/etc/passwd`, `/etc/group` | host's partially visible | host user table partially exposed |
+| `/etc/resolv.conf` | host's used as-is | host DNS config |
+| `/etc/hosts` | host's used as-is | host hostname map |
+
+**Fix:** `--fakeroot` for UID 0 mapping (with caveats — needs user
+namespaces in the kernel), or `--no-mount /etc/passwd,/etc/group`.
+
+### 4. Network transparency
+
+Default: the container **shares the host's network namespace**.
+
+| Leak | What's possible |
+|---|---|
+| host loopback (127.0.0.1) | container reaches `127.0.0.1:7878` (sac listen) directly |
+| host Unix sockets | `/var/run/docker.sock`, `/run/postgresql/...`, etc. |
+| host `/etc/resolv.conf` | host DNS resolver |
+| every host-bound port | every service the host exposes is reachable |
+| host interfaces | `eth0`, `wlan0` directly addressable |
+
+**This is the deepest one for sac.** A container running an agent
+should NOT be able to bypass sac listen's bearer auth by talking to
+its loopback directly. With shared netns it can.
+
+**Fix:** `--net --network=none` (full isolation; agent loses Claude
+API access) OR `--net --network=bridge` (independent netns + explicit
+egress allowlist for `api.anthropic.com`). Bridge + allowlist is the
+realistic answer; pure isolation kills the agent.
+
+**Realistic trade-off (current sac default).** sac currently uses the
+host netns — agents reach `sac listen` on `127.0.0.1` (A2A) and any
+MCP server on host loopback (orochi push channels, etc.) over the same
+path. Naive `--network=bridge` would isolate host services but break
+both A2A and MCP-over-loopback. The realistic path forward is
+`--network=bridge` + binding `sac listen` on the bridge interface +
+injecting an `sac-host` hostname into `/etc/hosts` so MCP URLs stay
+transport-stable (e.g. `http://sac-host:7878`) — none of which is
+shipped yet. We accept the host-loopback exposure today as a known
+limitation; see roadmap row below.
+
+### 5. Process / IPC / UTS namespaces
+
+| Item | Default | Impact |
+|---|---|---|
+| PID namespace | shared | `ps aux` sees host PIDs; `kill` can target host processes (subject to UID checks) |
+| IPC namespace | shared | host SysV IPC + shared memory accessible |
+| UTS namespace | shared | `hostname` returns host's name |
+| cgroup | inherited | resource limits hit host-wide, not container-wide |
+
+**Fix:** `--pid`, `--ipc`, `--uts` — note these are NOT included in
+`--containall` and must be specified separately.
+
+### 6. SIF build-time leaks (Apptainer-specific)
+
+The SIF itself can carry host-derived metadata baked at build time:
+
+| Source | Example leak |
+|---|---|
+| `.def` `%files` | absolute host paths copied verbatim into the layer |
+| build host's `/etc/passwd` | snapshotted into the SIF |
+| env-var-passed credentials | accidentally baked into a layer |
+| absolute symlinks | targets pointing at the BUILD host |
+
+**Implication for Clew:** "same SIF hash = same environment" is only
+true if the SIF was built without host-specific data leaking in.
+
+**Fix:**
+- Build SIFs with `--fix-perms --force` (normalizes host metadata)
+- Use ARG (build-time variables) in `.def`, never hardcoded paths
+- Build on a clean / CI host, not a developer laptop
+
+### 7. Overlay state persistence
+
+`overlay.img` is a writable layer that persists across container
+restarts. It's a feature (hot-start cache for pip installs) AND a
+leak vector (previous-run state contaminates the next run):
+
+| Persists across runs | Risk |
+|---|---|
+| `/tmp` writes | accumulating garbage; race conditions if two runs overlap |
+| `~/.cache/pip`, build artifacts | unintended reproducibility break (same SIF, different overlay → different result) |
+| Claude session state | prior conversation leaks into next start |
+| accidentally shared overlay | horizontal contamination between agents |
+
+**Fix:**
+- Clew experiments: ephemeral overlay (create on start, destroy on stop)
+- Persistent overlay: include the overlay hash in the verification chain
+- One agent ↔ one overlay; never share
+
+**Declarative auto-create (sac).** sac drives overlay provisioning
+from the spec so new peers don't require a manual
+`apptainer overlay create` setup step:
+
+```yaml
+spec:
+  apptainer:
+    overlay: proj-<peer>.overlay.img   # path (workdir-relative ok)
+    overlay_size: "5G"                  # units: M/MB/G/GB only
+    overlay_create_if_missing: true     # default; set false to gate off
+```
+
+Semantics:
+- `overlay_size` set + overlay path missing + `overlay_create_if_missing`
+  true (default) → sac runs
+  `apptainer overlay create --size <MB> <path>` before launch.
+- `overlay_size` set but `overlay_create_if_missing: false` → sac raises
+  `FileNotFoundError` (operator must pre-create).
+- `overlay_size` empty + overlay missing → sac raises
+  `FileNotFoundError` early with a helpful message instead of letting
+  apptainer fail cryptically at exec time.
+- K/KB units are explicitly rejected — apptainer's
+  `overlay create --size` takes integer MB.
+
+### 8. `--writable` vs `--writable-tmpfs` confusion
+
+- `--writable` — modifies the SIF itself. Destroys SIF immutability.
+  Used by accident → SIF hash changes → "same SIF" claim broken.
+- `--writable-tmpfs` — tmpfs (in RAM); writes are ephemeral. Safe.
+  Cannot combine with `--overlay <image>`; pick one.
+- `--overlay` — writable image file; persists. Safe for reproducibility
+  if the overlay hash is recorded.
+
+**Fix for Clew:** never `--writable`. Use `--overlay` (recorded) or
+`--writable-tmpfs` (ephemeral). For sac per-agent auditors we use
+`--overlay` so pip's editable installs persist for hot-start; tmpfs
+is given up because the overlay catches `/tmp` writes anyway.
+
+### 9. Indirect leakage via bind-mounts
+
+The most subtle category — the container respects `:ro` on the bind
+itself, but the bound content can chain to host state:
+
+| Path | How it leaks |
+|---|---|
+| `~/.ssh` bound | ssh out to other hosts → mutate them OR receive callback → mutate this host |
+| `~/proj/foo/.venv/bin/python` symlinks to `/opt/...` | container follows the symlink, lands on container's `/opt` (overlay) OR host `/opt` depending on bind |
+| `.git/config` with `[url "..."]` directives | `git clone` reaches unexpected remotes |
+| Python `.pth` editable-install files | `sys.path` lands on bound dirs containing more symlinks |
+| Symlinks inside a bind-mount pointing OUT of the mount | container follows out of the mount to wherever the symlink points |
+
+**This is what bit the scitex-stats-auditor PoC.** A symlink inside
+the bound `~/proj/scitex-stats/.venv/bin/python` pointed at
+`/opt/python3.12/bin/python3.12` — the container resolved it to its
+OWN `/opt`, decided the path was missing, "fixed" it inside the
+overlay. The agent's mental model thought it had patched the host.
+
+**Fix:**
+- Don't bind `~/.ssh` unless the agent provably needs it (most don't)
+- Don't bind venvs at all if you only need source — bind `src/` only
+- Preflight: assert known host-only paths are NOT visible inside (see §sac defaults below)
+
+### 10. Apptainer version differences
+
+Behavior varies across versions:
+
+| Version | Difference |
+|---|---|
+| `< 1.0` (legacy Singularity) | `--containall` slightly different scope |
+| `1.0 – 1.2` | `/dev` bind looser |
+| `1.3+` | some isolation tightened by default |
+| any | `--fakeroot` requires user namespaces (host kernel config) |
+
+**Implication for Clew:** "same SIF + same spec.yaml" can produce
+different results across Apptainer versions. Record `apptainer
+--version` in the experiment metadata.
+
+---
+
+## sac's hardened defaults
+
+For agent workloads, sac's recommended `apptainer.raw_args` (and
+where it's safe to make these defaults) closes most leak paths:
+
+```yaml
+spec:
+  apptainer:
+    raw_args:
+      - "--containall"        # §1: filesystem isolation
+      - "--cleanenv"          # §2: environment isolation
+      # Network (§4): pick one based on workload —
+      #   --net --network=none  → no egress (most secure; agent can't reach Claude API)
+      #   --net --network=bridge  → bridged + allowlist (realistic for Claude agents)
+      # PID / IPC / UTS (§5): not in --containall; add if you need them.
+      #   "--pid", "--ipc", "--uts"
+```
+
+### Canonical container HOME — `/home/agent` (D5)
+
+Apptainer's default behavior sets `$HOME` inside the container from
+the host operator's passwd entry (e.g. `/home/ywatanabe`). Even under
+`--containall` the directory is scaffolded as a side-effect, so any
+bind whose target descends `/home/<operator>/` populates `$HOME` and
+makes spec.yaml operator-specific.
+
+sac auto-injects `--home /home/agent` (skipped only when
+`apptainer.relaxed: true`). Inside the container:
+
+- `$HOME == /home/agent`, regardless of the operator's host username.
+- Bind targets use the canonical HOME: `~/proj/foo:/home/agent/proj/foo:ro`.
+- The host operator's home (`/home/ywatanabe`, `/home/alice`, …) is
+  never created inside the container.
+- spec.yaml is operator-agnostic — the same file runs identically on
+  any operator's host.
+
+**Per-agent binds** declare exactly what's allowed; nothing else
+visible:
+
+```yaml
+    binds:
+      # Source side: ~ expands to operator's host home (sac expands it
+      # before passing to apptainer). Target side: canonical
+      # /home/agent/... — operator-independent.
+      - ~/proj/<one-package>:/home/agent/proj/<one-package>:ro
+      # NEVER bind ~/.ssh, ~/.gitconfig, ~/.claude unless the agent
+      # provably needs them — reduces blast radius of indirect leaks (§9).
+```
+
+**Preflight checks** are sac-injected as a `bash -c` wrapper around
+the inner command; they run BEFORE any operator `startup_commands`:
+
+```bash
+# D5 preflight (auto-injected; not in spec.yaml)
+test "$(id -u)" != "0" || exit 11           # not root (or userns-fakeroot — see below)
+test "$HOME" = "/home/agent" || exit 12      # canonical HOME — drift = misconfigured
+```
+
+**Interaction with `apptainer.fakeroot: true`.** Under fakeroot the
+in-container `id -u` returns 0, which would normally trip the first
+check. sac detects fakeroot at preflight time via `/proc/self/uid_map`:
+when the map is a single-line `0 <host_uid> 1` with `host_uid != 0`,
+the agent is running as userns-fakeroot (root inside, operator on
+host) — the root-check is treated as passed. A bare `id -u == 0`
+without that map (somehow escaped to real root) still fails fast.
+
+Two static lines, attestable by hash. The "no host leak" property
+falls out of `--containall` (no auto-mounts) + canonical HOME (no
+operator-specific `$HOME` scaffolding) + the declared `binds:` list
+(reviewable on the AgentCard). Any leak hard-stops the agent with an
+explicit error.
+
+---
+
+## Roadmap for sac's isolation surface
+
+| Item | Status |
+|---|---|
+| `apptainer.raw_args` field (operator-declared) | ✅ shipped |
+| Per-agent preflight in `startup_commands` | ✅ pattern documented (this doc) |
+| Default `--containall` in apptainer argv if operator doesn't override | ✅ shipped (auto-prepended when `apptainer.relaxed: false`) |
+| `apptainer.relaxed: true` opt-out to disable hardened defaults | ✅ shipped (`spec.apptainer.relaxed`) |
+| Default `--cleanenv` + `--writable-tmpfs` auto-prepend (D1) | ✅ shipped |
+| sac-injected static preflight (D2; refined to D5 invariants) | ✅ shipped |
+| AgentCard structured `isolation` block (D3) | ✅ shipped |
+| `sac agents check` warns on host-mirroring bind targets (D4) | ✅ shipped |
+| Canonical container `$HOME=/home/agent` auto-injected via `--home` (D5) | ✅ shipped |
+| `apptainer.fakeroot: true` opt-in (userns root inside container) | ✅ shipped |
+| Network: shared host netns for MCP/A2A interop (known limitation) | ⏳ planned migration to `--network=bridge` + bridge-IF bind + `sac-host` hostname injection — keeps MCP URLs transport-stable while closing host-loopback exposure |
+| `sac image overlay {init,reset,prune}` for ephemeral-overlay workflows | ⏳ planned |
+
+The AgentCard field is the differentiator: external verifiers (orochi,
+Clew) can attest "this agent ran at isolation level X" by reading the
+card alone, no SIF introspection required. The shape published at
+`/.well-known/agent-card.json` (D3 + D5):
+
+```json
+"x-scitex-agent-container": {
+  "isolation": {
+    "level": "hardened",
+    "containall": true,
+    "cleanenv": true,
+    "writable_tmpfs": false,
+    "home_canonical": "/home/agent",
+    "fakeroot": false,
+    "preflight_passed": ["uid-nonzero", "home-canonical"],
+    "preflight_allowed": [],
+    "binds_count": 3,
+    "binds_writable_count": 0
+  }
+}
+```
+
+`level: hardened` is the human shorthand for "all booleans align with
+sac defaults + `preflight_allowed: []`". A run with any opt-out
+(`relaxed: true`, `fakeroot: true`, an entry in `preflight_allowed`)
+publishes `level: custom` plus the explicit booleans, so the verifier
+sees exactly what changed instead of a flat "non-standard" label.
+
+## One-line summary for papers / READMEs
+
+> Apptainer's default behavior prioritizes HPC convenience: it
+> auto-binds the user's home, `/tmp`, `/proc`, `/sys`, and `/dev`;
+> inherits all environment variables; shares the host's network, PID,
+> and IPC namespaces; and uses the host's UID/GID. For
+> reproducibility, all of these defaults must be inverted. sac uses
+> `--containall` (filesystem isolation), `--cleanenv` (environment
+> isolation), `--home /home/agent` (canonical operator-independent
+> HOME), `--net --network=none` or controlled bridge (network
+> isolation), and explicit `--bind` declarations for every host path
+> that must be visible. A sac-injected two-line preflight verifies
+> `id -u != 0` and `$HOME == /home/agent` at boot and fails hard on
+> any breach.
+
+## See also
+
+- [`spec-reference.md`](spec-reference.md) — `spec.apptainer.raw_args` field
+- [`talking-to-agents.md`](talking-to-agents.md) — A2A surface (where isolation level should be advertised)
+- [`how-sac-works.md`](how-sac-works.md) — overall architecture

--- a/docs/sphinx/sac-and-orochi.md
+++ b/docs/sphinx/sac-and-orochi.md
@@ -1,1 +1,215 @@
-../sac-and-orochi.md
+# sac and orochi
+
+`scitex-agent-container` (`sac`) and
+[`scitex-orochi`](https://github.com/ywatanabe1989/scitex-orochi) are two
+separate packages with a **one-way dependency**: orochi reads from sac; sac
+never imports orochi.
+
+This doc supersedes the older "sac = one host; orochi = across hosts"
+framing — sac already places and drives agents on remote hosts via SSH
+hops, so it must also carry their messages. The corrected boundary is
+captured below and tracked under
+[`docs/adr/0008-sac-node-transport-boundary.md`](adr/0008-sac-node-transport-boundary.md).
+
+## The comms model — what sac knows
+
+sac sees a single thing on its comms graph: **nodes**. A node is an
+*identity* + an *inbox* + an *ACL*. There are two kinds, distinguished
+*only* by who owns the lifecycle:
+
+| Kind          | Lifecycle owner                                       | Example                                                                       |
+|---------------|-------------------------------------------------------|-------------------------------------------------------------------------------|
+| sac-managed   | sac (spec, container, start/stop/health)              | An agent declared in a `spec.yaml`, launched by `sac agent start`.            |
+| **external**  | NOT sac — the operator, a separate tool, a human      | A plain `claude` CLI session, joining via `sac mcp channel --name <id>`.      |
+
+Both kinds are equal on the comms graph. Whatever *role* the orchestration
+layer assigns a node — "lead", "head", "worker", "coordinator" — is
+irrelevant to sac; sac sees only "a node".
+
+### Lineage — parent / children
+
+sac records who called `sac agents start`: the caller is the **parent**,
+the spawned agent its **child**. A parent may have many children; every
+node is a parent or a child (the root is a parent with no parent of its
+own).
+
+### Group — the unit of default ACL
+
+A parent together with its direct children is one **group**. The group is
+the unit of intra-group default ACL: within a group every node may
+message every other, **bidirectionally** (parent↔child *and*
+sibling↔sibling).
+
+### Depth limit — a POLICY, not a structural limit
+
+We currently forbid a child from spawning children, so the *live*
+hierarchy is two levels (root + its direct children). **This is a
+policy constraint we choose to enforce, not an architectural ceiling.**
+The model, schema, lineage and group logic remain **N-level capable** —
+recursion is the natural shape; nothing hard-codes "2" or assumes a
+fixed depth. The cap is a *lift-able policy* (a rule that denies a
+non-root spawn). Lifting it later is a policy change only — zero
+structural / schema / data-structure change.
+
+### ACL — permissioned messaging
+
+- Intra-group is allowed by default (bidirectional).
+- Cross-group requires an **explicit ACL grant** (per-node config:
+  `spec.comms.allow` for sac-managed; a policy store for external nodes).
+- The graph is permissioned — never implicitly all-to-all. An ungated
+  channel is a prompt-injection vector
+  ([Claude Code channels reference](https://code.claude.com/docs/en/channels-reference)).
+
+> ⚠️ **Identity caveat — ACL is policy-shaped today** (handoff
+> 2026-05-20 limited-scope decision).
+>
+> The shipped ACL gates on the **self-claimed
+> `metadata.from_agent`** field; cryptographic per-node identity
+> is **deferred** to a separate follow-on handoff. The design for
+> the cryptographic-identity work is filed in scitex-lead at
+> `GITIGNORED/FUTURE/sac-per-node-authenticated-acl.md` — not in
+> this repo. Every cross-group grant row in `comms_grants`
+> carries the audit note
+> `"trusts metadata.from_agent until per-node creds land"` so the
+> follow-on work has the audit trail it needs to scope what each
+> grant must be re-validated against.
+>
+> Until that lands, the ACL is a policy gate — a misbehaving node
+> can claim a different identity by writing a different
+> `from_agent`. The handoff acceptance "identity cannot be
+> spoofed via a metadata field" will be met by the follow-on, not
+> by the limited-scope WI-2.
+
+### A2A compliance
+
+Every node, sac-managed or external, is addressable via the A2A protocol;
+a node's identity *is* its A2A AgentCard.
+
+- sac-managed nodes derive their AgentCard from `spec.yaml` (see
+  [`a2a/_card.py::project_card`](https://github.com/ywatanabe1989/scitex-agent-container/blob/develop/src/scitex_agent_container/a2a/_card.py)).
+- External nodes have no YAML, so sac **synthesises a minimal AgentCard
+  at registration** when `sac mcp channel --name <id>` connects: identity
+  + inbox endpoint + the required A2A capability fields, and *nothing*
+  runtime/container-shaped. The synthesised card is the external node's
+  whole definition (see
+  [`_listen/_nodes.py::synthesize_external_card`](https://github.com/ywatanabe1989/scitex-agent-container/blob/develop/src/scitex_agent_container/_listen/_nodes.py)).
+  The card carries `"x-scitex-agent-container.node_kind": "external"` so
+  downstream tooling can distinguish the kinds.
+
+### What sac knows vs doesn't
+
+| sac knows                                | sac does NOT know                       |
+|------------------------------------------|-----------------------------------------|
+| Nodes (sac-managed + external)           | Roles ("lead", "head", "worker", …)     |
+| Lineage (parent / children)              | Topology visualisations                 |
+| Groups (parent + direct children)        | Connectivity mesh (cloudflared, autossh) |
+| ACL grants                               | Human chatops UI                        |
+
+## The corrected boundary
+
+```
+            ┌────────────────────┐                       ┌──────────────────────┐
+            │   Human operator   │  chat · DM · channel  │ claude-code-         │
+            │   (web UI / CLI)   │ ◄───── alerts ─────── │ telegrammer          │
+            └─────────┬──────────┘                       │ Telegram MCP + TUI   │
+                      │                                  └──────────▲───────────┘
+                      ▼                                             │
+        ┌──────────────────────────────────┐                        │
+        │   scitex-orochi                  │                        │
+        │   web chatops UI · dashboard     │                        │
+        │   topology / presence            │                        │
+        │   channels · DMs · threads       │                        │
+        │   connectivity mesh              │                        │
+        │   (cloudflared / autossh)        │                        │
+        └─────────────────┬────────────────┘                        │
+                          │  CONSUMES sac transport                 │
+                          │  (one-way dep: orochi → sac)            │
+                          ▼                                         │
+        ┌──────────────────────────────────┐                        │
+        │   scitex-agent-container (sac)   │                        │
+        │   NODE TRANSPORT SUBSTRATE       │                        │
+        │     any-node ↔ any-node          │                        │
+        │     any host (same / LAN /       │                        │
+        │     SSH-alias / tunnel)          │                        │
+        │     ACL-gated                    │                        │
+        │   Lifecycle for sac-managed      │                        │
+        │   nodes only (apptainer)         │                        │
+        │   Zero knowledge of orochi       │                        │
+        └─────────────────┬────────────────┘                        │
+                          │  starts / supervises (sac-managed)      │
+                          ▼                                         │
+        ┌──────────────────────────────────┐                        │
+        │   Claude agents + external nodes │ ── heartbeat-push ──▶ orochi
+        │   (sac-managed)   (external)     │ ── alerts ─────────────┘
+        └──────────────────────────────────┘
+```
+
+### Responsibility split
+
+| Concern                                                                   | Owner       |
+|---------------------------------------------------------------------------|-------------|
+| Agent process (SDK + session.jsonl)                                       | **sac**     |
+| Per-host control plane (start/stop/send/tail/list)                        | **sac**     |
+| Container runtime (apptainer)                                             | **sac**     |
+| **Node transport (any-to-any, any host, ACL-gated)**                      | **sac**     |
+| **Channel-event durability + replay** (`channel_events` in state.db)      | **sac**     |
+| **External-node inbox** (no YAML, identity + inbox only)                  | **sac**     |
+| In-session push (MCP channel server `server:sac`)                         | **sac**     |
+| Human chatops UI (Slack-like web interface)                               | **orochi**  |
+| Topology / presence / dashboard                                           | **orochi**  |
+| Channels / DMs / threads as features                                      | **orochi**  |
+| Connectivity mesh (cloudflared + autossh) — *establishes* host reachability | **orochi**  |
+
+**Rule:** sac is the node-transport substrate. Orochi is the human/product
+layer that *consumes* sac transport. The connectivity mesh that
+establishes reachability lives in orochi; sac assumes reachability.
+
+## How orochi consumes sac
+
+orochi reads sac's state files
+(`~/.scitex/agent-container/runtime/<name>/heartbeat.json`,
+`session.jsonl`, `state.db`) from each host it manages. It also calls
+sac's HTTP endpoints (`/agents/<name>/{message:send,inbox/stream}`) like
+any other A2A v1 client. It never calls `sac` CLI commands directly —
+the contract is the on-disk state files plus the published HTTP
+endpoints.
+
+Agents push heartbeats and alerts to orochi via the `server:orochi-push`
+MCP channel, configured in `spec.claude.channels`:
+
+```yaml
+spec:
+  claude:
+    channels:
+      - server:orochi-push
+```
+
+The `server:sac` channel is sac's own primitive — agents enable it the
+same way:
+
+```yaml
+spec:
+  claude:
+    channels:
+      - server:sac
+```
+
+When `server:sac` is in `channels`, `sac agent start` auto-spawns
+`sac mcp channel --name <agent>` as a stdio MCP subprocess of the agent's
+Claude session; it subscribes to the host-local
+`/agents/<name>/inbox/stream` SSE and pushes
+`notifications/claude/channel` so the agent sees
+`<channel source="sac" ...>` tags in real time. External nodes opt in by
+running the same command from their own Claude session — no container,
+no spec.
+
+## Standalone use
+
+sac works fully without orochi. If you don't need cross-host chatops,
+just omit `server:orochi-push` from `spec.claude.channels` and skip the
+orochi install entirely. The sac comms graph still works: nodes message
+each other, the channel bus is durable, and the ACL still gates.
+
+## Live instance
+
+[https://scitex-orochi.com](https://scitex-orochi.com)

--- a/docs/sphinx/sac-and-orochi.md
+++ b/docs/sphinx/sac-and-orochi.md
@@ -60,25 +60,50 @@ structural / schema / data-structure change.
   channel is a prompt-injection vector
   ([Claude Code channels reference](https://code.claude.com/docs/en/channels-reference)).
 
-> ⚠️ **Identity caveat — ACL is policy-shaped today** (handoff
-> 2026-05-20 limited-scope decision).
->
-> The shipped ACL gates on the **self-claimed
-> `metadata.from_agent`** field; cryptographic per-node identity
-> is **deferred** to a separate follow-on handoff. The design for
-> the cryptographic-identity work is filed in scitex-lead at
-> `GITIGNORED/FUTURE/sac-per-node-authenticated-acl.md` — not in
-> this repo. Every cross-group grant row in `comms_grants`
-> carries the audit note
-> `"trusts metadata.from_agent until per-node creds land"` so the
-> follow-on work has the audit trail it needs to scope what each
-> grant must be re-validated against.
->
-> Until that lands, the ACL is a policy gate — a misbehaving node
-> can claim a different identity by writing a different
-> `from_agent`. The handoff acceptance "identity cannot be
-> spoofed via a metadata field" will be met by the follow-on, not
-> by the limited-scope WI-2.
+### Authenticated identity (handoff §4 acceptance)
+
+Identity is **bearer-authenticated**, not self-claimed:
+
+- Every node (sac-managed or external) gets a per-node bearer
+  minted at registration (`node_tokens` table). The listen
+  server's `NodeAuthMiddleware` resolves the `Authorization:
+  Bearer <token>` header to a node name on `request.state`.
+- `check_send_acl` requires `params.metadata.from_agent` to
+  **match** the resolved name; mismatch → `403 identity spoof`
+  with the resolved-name vs claimed-name in the body. This meets
+  the handoff §4 acceptance "identity cannot be spoofed via a
+  metadata field".
+- The **host-wide bearer** is the *administrative caller* — it
+  honours `metadata.from_agent` verbatim (used by cross-host
+  forwarders, see below).
+
+### Cross-host forwarding — per-host bearer registry
+
+When `message:send` targets a node on a different host, the local
+`sac listen` forwards to that host's `sac listen`. The destination
+host has its own listen bearer; the forwarder authenticates
+**with the destination's bearer**, pulled from a small registry:
+
+```
+~/.scitex/agent-container/peer-tokens/
+    host-a.token      # 0600 — host A's listen bearer, used to
+                      # auth at host A from this host.
+    head-spartan.token
+    ...
+```
+
+Operators populate the registry with `sac host add-peer <host>
+<token>`; `sac host list-peers` shows the registered hosts (token
+values are never printed). A missing entry is a **loud 502** with
+the file path and the `add-peer` fix in the error body — never a
+silent drop (handoff §0 Hard rules).
+
+This gives a **per-host blast radius**: leaking host A's listen
+bearer compromises only host A, not the whole fleet. The
+ACL is re-evaluated at the receiving host on the same
+`metadata.from_agent`, so cross-group denials fire at the
+destination per handoff §4 ("ACL is enforced at the receiving
+host").
 
 ### A2A compliance
 

--- a/docs/sphinx/spec-reference.md
+++ b/docs/sphinx/spec-reference.md
@@ -1,1 +1,319 @@
-../spec-reference.md
+# YAML Spec Reference (v3)
+
+Container + session knobs nest under the engine that interprets them
+(`spec.apptainer.*`, `spec.claude.*`). Cross-cutting knobs (workdir,
+a2a, health, restart, autonomous, listen, skills, telegram, hooks)
+stay at the top level. Every curated block has a `raw_*` escape hatch
+— the full underlying surface is always reachable.
+
+The agent name is the parent directory of `spec.yaml` (dir-as-SSoT —
+no `metadata.name` field).
+
+## Quick links
+
+- Annotated full example: [`examples/agents/full-agent/spec.yaml`](https://github.com/ywatanabe1989/scitex-agent-container/blob/develop/examples/agents/full-agent/spec.yaml) — every supported field with inline comments
+- Minimal example: [`examples/agents/minimal-agent/spec.yaml`](https://github.com/ywatanabe1989/scitex-agent-container/blob/develop/examples/agents/minimal-agent/spec.yaml)
+- Quickstart with `startup_prompts`: [`examples/agents/hello-agent/spec.yaml`](https://github.com/ywatanabe1989/scitex-agent-container/blob/develop/examples/agents/hello-agent/spec.yaml)
+
+## Top-level shape
+
+```yaml
+apiVersion: scitex-agent-container/v3    # REQUIRED — v1/v2 raise loud validation errors
+kind: Agent                              # REQUIRED — Agent | AgentProxy
+                                         # (AgentProxy → HTTP forwarder, no SDK;
+                                         #  see spec.proxy + examples/agents/proxy-agent)
+
+metadata:
+  labels:                                # drives `sac fleet` filters AND the AgentCard
+    role: ecosystem-auditor
+    team: lab-a
+    description: ...                     # → AgentCard.description
+    function: audit, git status, ...     # → AgentCard.skills[0].description
+    capabilities: audit,health-check     # CSV → AgentCard.skills[0].tags
+    cardinality: singleton               # → AgentCard.x-scitex-agent-container.cardinality
+
+spec:
+  runtime: apptainer                     # optional; only `apptainer` accepted; empty defaults to `apptainer` (since 2026-05-13)
+  workdir: ~/proj                        # mounted rw at /work
+  dot_claude: ./dot_claude               # merged into <workdir>/.claude/ at start (no auto-discover; default "")
+  python-venv: auto                      # string or list — fallback chain
+  env-file: .env                         # string or list of dotenv paths   (VERIFY: validator currently rejects — must be added to _KNOWN_SPEC_KEYS)
+  multiplexer: tmux                      # tmux | screen                    (VERIFY: validator currently rejects — must be added to _KNOWN_SPEC_KEYS)
+
+  apptainer:    { ... }
+  claude:       { ... }
+  mcp_servers:  { ... }
+  health:       { ... }
+  restart:      { ... }
+  autonomous:   { ... }
+  a2a:          { host: 127.0.0.1, port: auto }    # port: auto | <int> | null (disable)
+  proxy:        { upstream: https://peer/, trust: untrusted }   # kind: AgentProxy only
+  listen:                                # LIST of side-port DECLARATIONS (no binding):
+    - { port: 9000, proto: tcp, name: api, owner: app }
+    - { proto: unix, path: /tmp/x.sock, name: ipc }
+  # NOTE: the host-level `sac listen` server port lives in
+  # ~/.scitex/agent-container/config.yaml (listen.port, default 7878),
+  # NOT in agent spec.yaml.
+  startup:                               # (optional) ready-pattern gating block (todo#291)
+    commands: [...]                      # shadows top-level startup_commands when set
+    ready_patterns: [...]                # regex strings (or { regex: "..." } dicts)
+    ready_idle_ticks: 3
+    ready_poll_interval_seconds: 0.5
+    ready_timeout_seconds: 60
+    on_timeout: capture_and_proceed      # capture_and_proceed | capture_and_fail
+  context_management:                    # context auto-management (compact/restart/noop)
+    trigger_at_percent: 70
+    strategy: noop                       # compact | restart | noop
+    warn_before_n_checks: 0
+    check_interval_seconds: 300
+  telegram:     { bot_token_env: ..., allowed_users: [...], auto_connect: true, greeting: ... }
+  hooks:        { pre_start: [...], post_start: [...], pre_stop: [...], post_stop: [...] }
+  extensions:   { ... }                  # opaque per-deployment dict
+
+  startup_commands:                      # SHELL before claude starts (list of {delay, command} dicts)
+    - { delay: 0, command: "echo hi" }
+  startup_prompts:  [...]                # TEXT fed to claude as first user msg
+  session: continue                      # top-level shortcut overriding spec.claude.session
+
+  host:  gpu-box                         # mutually exclusive: singleton on one peer
+  hosts: [laptop, gpu-box, nas]          # OR multi-instance, one per peer
+```
+
+## Field reference
+
+### `metadata.labels` → AgentCard fields
+
+> **Note on naming — two "skills" concepts.** A2A's AgentCard has a
+> standard top-level `skills[]` array used to *advertise* capabilities
+> to peers (id / name / description / tags / examples). Anthropic's
+> Claude Code separately uses "skills" for *prompt-fragment* markdown
+> files under `<HOME>/.claude/skills/<name>/` that the SDK loads into
+> the agent's own context. Both share the English word but live at
+> orthogonal layers:
+>
+> | Layer | Drives | Effect |
+> |---|---|---|
+> | `metadata.labels.skills` (CSV) | A2A `skills[0].tags` + `x-scitex-agent-container.required_skills` | Advertises capabilities on the card; **no behaviour change inside the agent** |
+> | `spec.dot_claude/skills/<name>/SKILL.md` (files) | Materialised at `runtime/<name>/home/.claude/skills/` (ADR-0003) and surfaced via `spec.skills.required[]` `@`-imports in the auto-generated CLAUDE.md | Loaded into the agent's prompt by the Claude SDK |
+>
+> Also note A2A's separate top-level `capabilities` field is for
+> *transport* properties (`streaming`, `pushNotifications`, etc.) —
+> not a synonym for "what the agent can do". The "can do" surface is
+> always `skills[]`.
+
+The AgentCard at `GET /.well-known/agent-card.json` (per-agent sidecar
+when `spec.a2a.port` is set) and `GET /agents/<name>/card`
+(host-level `sac listen`) is built **entirely** from spec.yaml:
+
+| AgentCard field                       | spec.yaml source                                 |
+|---------------------------------------|--------------------------------------------------|
+| `name`                                | parent directory of `spec.yaml`                  |
+| `description`                         | `metadata.labels.description` (else auto)        |
+| `version`                             | `apiVersion`                                     |
+| `url`                                 | `<base>/agents/<name>`                        |
+| `provider.organization`               | `metadata.labels.team`                           |
+| `skills[0].id` / `name`               | `metadata.labels.role`                           |
+| `skills[0].description`               | `metadata.labels.function`                       |
+| `skills[0].tags`                      | `metadata.labels.capabilities` ∪ `metadata.labels.skills` (both CSV) |
+| `x-scitex-agent-container.role_class` | `metadata.labels.role`                           |
+| `x-scitex-agent-container.cardinality`| `metadata.labels.cardinality`                    |
+| `x-scitex-agent-container.scheduling` | derived from `spec.host` / `spec.hosts`          |
+| `x-scitex-agent-container.runtime`    | `spec.runtime`                                   |
+| `x-scitex-agent-container.model`      | `spec.claude.model` (v3) / `spec.model` (v2 back-compat) |
+| `x-scitex-agent-container.required_skills` | `metadata.labels.skills` (CSV) ∪ legacy `spec.skills.required` |
+| `x-scitex-agent-container.multiplexer`| `spec.multiplexer`                               |
+
+### `spec` — top-level
+
+| Field                | Type                       | Description                                                              |
+|----------------------|----------------------------|--------------------------------------------------------------------------|
+| `runtime`            | `apptainer` (optional)     | Empty/unset defaults to `apptainer`; any other value is rejected. docker/podman were dropped 2026-05-13 |
+| `workdir`            | path                       | Mounted rw at `/work` (default: `~/.scitex/agent-container/runtime/agents/<name>/`) |
+| `dot_claude`         | path                       | Materialized into `<workdir>/.claude/`. Default is empty string — no auto-discovery of a sibling directory; operators must set the path explicitly if they want a `dot_claude/` merged in. |
+| `python-venv`        | string \| list             | Pre-activated for startup_commands; `auto` probes `~/.venv-3.11`, `~/.venv` |
+| `env-file`           | string \| list             | dotenv paths sourced at start. **(VERIFY: parsed by the loader but currently rejected by `_validation._KNOWN_SPEC_KEYS` — known parser/validator drift.)** |
+| `user`               | `""` \| `"host"` \| `"<uid>:<gid>"` | Container user override; empty = image default. |
+| `multiplexer`        | `tmux` \| `screen`         | Long-lived session host (default `tmux`). **(VERIFY: parsed by the loader but currently rejected by `_validation._KNOWN_SPEC_KEYS` — known parser/validator drift.)** |
+| `host` / `hosts`     | string / list of strings   | Singleton on one peer / multi-instance one-per-peer (mutually exclusive). `hosts: "all"` = every fleet host. |
+| `session`            | string                     | Top-level shortcut overriding `spec.claude.session`; legacy aliases accepted (`continue-or-new`, `new`). |
+| `screen.name`        | string                     | Legacy metadata (agent display name in `sac fleet`). Default = agent name. Does NOT drive a multiplexer. |
+| `startup_commands[]` | list of `{delay, command}` | Run **before** Claude starts. Each item is a dict with optional `delay` (int seconds, default 0) and required `command` (string); bare strings are not accepted. |
+| `startup_prompts[]`  | list of strings            | Fed to Claude as first user message(s)                                   |
+
+### `spec.apptainer` — engine knobs
+
+| Field         | Type                          | Description                                                |
+|---------------|-------------------------------|------------------------------------------------------------|
+| `image`       | path to `.sif`                | `sac-scitex.sif` (full stack) or `sac-base.sif` (minimal). Optional; empty falls back to the sac default SIF at dispatch. |
+| `overlay`     | path                          | Writable rw layer above the SIF                            |
+| `overlay_size` | size string (e.g. `"5G"`, `"500M"`) | When set together with `overlay`, sac auto-creates the overlay image at that path with the given size if it doesn't exist (declarative — no manual `apptainer overlay create` step). Units: M/MB/G/GB only (K/KB rejected). Empty = no auto-create (missing overlay raises a clear FileNotFoundError at launch). |
+| `overlay_create_if_missing` | bool (default `true`) | Gate for the auto-create behaviour above. When `false` AND the overlay is missing, sac raises FileNotFoundError without attempting creation (operator must pre-create with `apptainer overlay create`). |
+| `binds[]`     | `host:container[:ro\|rw]` (or legacy `{src,dst,mode}` dict) | Bind mounts. Source side supports `~` / `$VAR` (sac expands before calling apptainer). Destination MUST be absolute (apptainer rejects relative / `~` / `$VAR`); conventional roots are `/home/agent/...` (D5 canonical HOME), `/srv/`, `/work/`, `/opt/`, `/data/`. The legacy `{src, dst, mode}` dict form is still accepted by the parser and normalized to the string form. |
+| `env`         | key-value dict                | Env vars exported into the container                       |
+| `container_workdir` | path (default `/work`)  | Working directory inside the container.                    |
+| `nv` / `rocm` | bool                          | Forward host NVIDIA / AMD ROCm libs. (DESIGN — mutual exclusion not currently enforced by the parser.) |
+| `raw_args[]`  | list of strings               | **Escape hatch** — appended verbatim to `apptainer exec`   |
+| `post` / `environment` / `def_file` | string / KV dict / path | Apptainer `%post` shell snippet, `%environment` KV map, and override `.def` path for `apptainer build`. Empty / missing → no build extension. |
+| `relaxed`     | bool (default `false`)        | **(DESIGN — not yet implemented in the parser.)** Intent: opt OUT of hardened-by-default isolation. When `false` (default), sac auto-prepends `--containall` / `--cleanenv` / `--writable-tmpfs` / `--home /home/agent`. Set `true` to disable; see [`docs/isolation.md`](isolation.md) + [`docs/adr/0001-isolation-hardening.md`](adr/0001-isolation-hardening.md). TODO: wire into `ApptainerSpec`. |
+| `fakeroot`    | bool (default `false`)        | **(DESIGN — not yet implemented in the parser.)** Intent: apptainer `--fakeroot` — uid 0 inside via user-namespace remap; host uid unchanged. D5 preflight detects userns-fakeroot via `/proc/self/uid_map` and accepts uid 0 only when remapped. TODO: wire into `ApptainerSpec`. |
+
+### `spec.claude` — SDK knobs
+
+| Field                       | Type                                  | Description                                                       |
+|-----------------------------|---------------------------------------|-------------------------------------------------------------------|
+| `model`                     | `haiku` \| `sonnet` \| `opus` \| ...  | Claude model                                                      |
+| `session`                   | `continue` \| `new-session` \| `resume`| Session strategy (default `continue` — safe fallback). Legacy aliases `continue-or-new`, `new` accepted |
+| `resume_id`                 | string                                | Explicit session UUID for `session: resume`                       |
+| `continue_max_age_minutes`  | int                                   | Only resume if session.jsonl is newer than N minutes              |
+| `flags[]`                   | list of strings                       | Extra flags appended to `claude` invocation                       |
+| `channels[]`                | `server:<name>` / `plugin:<id>@<v>`   | MCP push channels (passed as `claude --channels`)                 |
+| `auto_accept`               | bool (default `True`)                 | Auto-confirm permission prompts in the TUI                        |
+| `raw_options`               | dict                                  | **Escape hatch** — splatted into `ClaudeAgentOptions(**raw_options)` |
+
+### `spec.health` / `spec.restart` / `spec.watchdog` / `spec.autonomous`
+
+| Field                       | Description                                                                              |
+|-----------------------------|------------------------------------------------------------------------------------------|
+| `health.enabled`            | bool — enable periodic liveness probe                                                    |
+| `health.interval`           | seconds between probes                                                                   |
+| `health.timeout`            | per-probe timeout                                                                        |
+| `health.method`             | `sdk-alive` (only value accepted by the validator). NOTE: the parser default is the legacy string `multiplexer-alive`; with the validator pin in place, any explicit value other than `sdk-alive` is rejected at load time. |
+| `autonomous.idle_kick_after_s` | int seconds — nudge cadence when no tool activity (default 120)                       |
+| `restart.policy`            | `never` \| `on-failure` \| `always`                                                      |
+| `restart.max_retries`       | int                                                                                      |
+| `restart.backoff.initial`   | seconds before first retry                                                               |
+| `restart.backoff.max`       | cap on backoff                                                                           |
+| `restart.backoff.multiplier`| exponential factor                                                                       |
+| `watchdog.enabled`          | parsed for back-compat; lifecycle managed via hooks                                      |
+| `autonomous.enabled`        | drive turns until `drive_until` token or `max_turns`                                     |
+| `autonomous.drive_until`    | string token Claude prints when done (default `DONE`)                                    |
+| `autonomous.max_turns`      | int                                                                                      |
+| `autonomous.kick_text`      | nudge sent when Claude pauses                                                            |
+
+### `spec.a2a` / `spec.listen` — network endpoints
+
+| Field        | Description                                                                          |
+|--------------|--------------------------------------------------------------------------------------|
+| `a2a.host`   | Bind interface for the per-agent A2A sidecar (default `127.0.0.1`).                  |
+| `a2a.port`   | `auto` (default) — sac claims a free port from `~/.scitex/agent-container/config.yaml`'s `a2a.port_range` (default 19000-19999), persists in `state.db`, surfaces via `sac agents list`. Set an explicit int (e.g. `7901`) to pin for a stable external URL. Set `null` to disable the sidecar entirely. **Most operators never touch this** — auto is the right default. |
+| `listen[]`   | LIST of side-port DECLARATIONS (NOT a single port override). Each item: `{port, proto, path, name, owner}`. `proto`: `tcp` (default) / `udp` / `unix`. Entries that fail validation (`tcp`/`udp` needs `port>0`; `unix` needs `path`) are silently dropped. **The container does NOT bind these — declarations only**, surfaced on the AgentCard for peers. The host-level `sac listen` server port (default 7878) is configured in `~/.scitex/agent-container/config.yaml` under `listen.port`, NOT here. |
+
+The per-agent sidecar binds the **same URL shape** as `sac listen`
+(`/agents/<name>/{turn,send,card}`, `/v1/a2a/agents/<name>/...`,
+`/.well-known/agent-card.json`, `/health`), so the same client code
+works against either transport. Per-agent ports are an internal IPC
+mechanism between `sac listen` and the runner (different processes);
+clients reach every agent through the **one stable host port** at
+`sac listen` (default `:7878`).
+
+The AgentCard's `url` field advertises the **sac listen** URL
+(`http://127.0.0.1:7878/agents/<name>`) regardless of which
+endpoint served the card, so external A2A clients caching the card
+get a URL that survives per-agent port churn.
+
+### `~/.scitex/agent-container/config.yaml`
+
+Host-wide sac configuration. All keys optional; defaults shown.
+
+```yaml
+listen:
+  host: 127.0.0.1        # bind interface for sac listen (loopback only)
+  port: 7878             # host control-plane port
+
+a2a:
+  port_range: [19000, 19999]   # range the auto-allocator picks from
+```
+
+### Skills
+
+`spec.skills` was **removed in v3** — skills now live under
+`dot_claude/skills/` (a sibling directory next to `spec.yaml`,
+materialized into the workspace at start).
+
+For AgentCard publication, declare the skill IDs via
+`metadata.labels.skills` as a CSV (e.g. `skills: "scitex-dev, gh-cli, git"`).
+The list ends up in the card's `skills[0].tags` (unioned with
+`metadata.labels.capabilities`) and `x-scitex-agent-container.required_skills`.
+
+### `spec.mcp_servers`
+
+A dict-of-dicts merged into `<workdir>/.mcp.json` at start. Mirrors
+the `.mcp.json` shape directly. Use this OR drop a `.mcp.json` into
+`dot_claude/` — both are merged.
+
+### `spec.telegram` / `spec.hooks` / `spec.extensions`
+
+| Field                  | Description                                                                |
+|------------------------|----------------------------------------------------------------------------|
+| `telegram.bot_token_env`| Env var name holding the bot token (default `SCITEX_AGENT_CONTAINER_TELEGRAM_BOT_TOKEN`) |
+| `telegram.allowed_users`| List of Telegram user IDs (strings) allowed to talk to this bridge        |
+| `telegram.auto_connect`| bool (default `true`) — auto-attach the bridge at agent start              |
+| `telegram.greeting`    | Optional greeting string posted on connect                                 |
+| `hooks.pre_start[]`    | Shell commands before `apptainer exec` (a `mkdir -p <workdir>/.claude` is auto-prepended) |
+| `hooks.post_start[]`   | Shell commands after the runner reports ready                              |
+| `hooks.pre_stop[]`     | Shell commands before SIGTERM                                              |
+| `hooks.post_stop[]`    | Shell commands after the runner exits                                      |
+| `extensions`           | Opaque dict — read by downstream tooling (priority, owner, etc.)           |
+
+## Lifetime / session selection
+
+Default = long-lived + safe-fallback session continue. The `sac
+agents start` CLI overrides at start time:
+
+```bash
+sac agents start <name> --one-shot                 # exits after first startup_prompt
+sac agents start <name> --session continue         # default (try continue, fall back to fresh)
+sac agents start <name> --session new-session      # force fresh
+sac agents start <name> --resume <sid>             # implies --session resume
+```
+
+CLI flags ALWAYS override the YAML — one-direction precedence so a
+per-invocation tweak doesn't mutate the persistent default.
+
+## `kind: AgentProxy` — HTTP forwarder agents
+
+A proxy agent forwards `POST /v1/turn` to an **external A2A
+endpoint** instead of running a Claude SDK conversation in-process.
+There is no SDK in the container; the runner is a thin Starlette
+forwarder (image: `sac-proxy.sif`, lighter than `sac-scitex.sif` —
+no Python ML stack).
+
+Authoring contract:
+
+- `kind: AgentProxy` (instead of `kind: Agent`).
+- `spec.proxy` is **REQUIRED**.
+- `spec.claude`, `spec.startup_prompts`, `spec.startup_commands` are
+  rejected at validation time (no SDK to configure / prompt).
+- `spec.a2a.port` works the same — that's the port operators POST to.
+
+### `spec.proxy` reference
+
+| Field           | Type              | Default       | Notes                                                                                  |
+|-----------------|-------------------|---------------|----------------------------------------------------------------------------------------|
+| `upstream`      | string (REQUIRED) | —             | Full URL to the upstream A2A endpoint (must start with `http://` or `https://`).        |
+| `trust`         | enum              | `untrusted`   | `untrusted` / `local-mesh` / `trusted`. Advisory — surfaced on our AgentCard.           |
+| `redact`        | list[str]         | `[]`          | Substring tokens; any inbound `text` containing one is refused HTTP 400 before forward. |
+| `timeout_s`     | float > 0         | `30.0`        | Per-turn upstream HTTP timeout. Longer forwards return HTTP 504 to the caller.          |
+
+### Security notes
+
+- Proxy is HTTP-only — no mTLS in the MVP (the `trusted` level is
+  reserved for future work).
+- Default trust is `untrusted`; operators must opt in to anything
+  more permissive.
+- Egress lockdown is application-layer: a 3xx redirect from upstream
+  to a *different* host is rejected with HTTP 502. The MVP does
+  not enforce an apptainer `--net` policy.
+- Runs in `sac-proxy.sif` — see `containers/sac-proxy.def`.
+
+See [`examples/agents/proxy-agent/spec.yaml`](https://github.com/ywatanabe1989/scitex-agent-container/blob/develop/examples/agents/proxy-agent/spec.yaml)
+for a complete minimal example.
+
+## Examples
+
+Copy from [`examples/agents/`](https://github.com/ywatanabe1989/scitex-agent-container/tree/develop/examples/agents):
+
+- [`full-agent/`](https://github.com/ywatanabe1989/scitex-agent-container/tree/develop/examples/agents/full-agent) — annotated spec exercising every supported field (plus `dot_claude/` layout)
+- [`minimal-agent/`](https://github.com/ywatanabe1989/scitex-agent-container/tree/develop/examples/agents/minimal-agent) — bare minimum, no `dot_claude`
+- [`hello-agent/`](https://github.com/ywatanabe1989/scitex-agent-container/tree/develop/examples/agents/hello-agent) — quickstart with `startup_prompts`
+- [`proxy-agent/`](https://github.com/ywatanabe1989/scitex-agent-container/tree/develop/examples/agents/proxy-agent) — `kind: AgentProxy` forwarder example

--- a/docs/sphinx/talking-to-agents.md
+++ b/docs/sphinx/talking-to-agents.md
@@ -1,1 +1,253 @@
-../talking-to-agents.md
+<!-- ---
+!-- Timestamp: 2026-05-13 19:55:42
+!-- Author: ywatanabe
+!-- File: /home/ywatanabe/proj/scitex-agent-container/docs/talking-to-agents.md
+!-- --- -->
+
+# Talking to a Running Agent
+
+A `sac` agent is a long-lived process: once started, it stays alive
+and accepts new turns. Three transports reach into that process,
+ordered from external-friendliest to most internal:
+
+| Transport                                                                    | When to use                                                               | Auth            |
+|------------------------------------------------------------------------------|---------------------------------------------------------------------------|-----------------|
+| **A2A sidecar** — `POST /agents/<name>/turn` on the agent's own port  | External tools, browsers, curl, peer agents, A2A-spec consumers           | none (loopback) |
+| **CLI** — `sac agents send` / `tail`                                         | Scripted flows on the same host (the one running the agent)               | none            |
+| **`sac listen`** — `POST /agents/<name>/send` on the host port (7878) | Trusted orchestrators (e.g. orochi), cross-host via the existing SSH mesh | bearer token    |
+
+All three end up dropping a `TurnEnvelope` on the runner's shared
+inbox, so the SDK conversation is identical regardless of which door
+the prompt came through.
+
+---
+
+## 1. A2A sidecar — `POST /agents/<name>/turn`
+
+Enable it by leaving `spec.a2a.port` at its default (`auto`) — sac
+claims a free port from `~/.scitex/agent-container/config.yaml`'s
+`a2a.port_range` (default `[19000, 19999]`) at start time and persists
+it in `state.db`. Operators see the assigned port via `sac agents list`.
+Most agents need no `a2a` block at all:
+
+```yaml
+spec:
+  # a2a:
+  #   port: auto         # the default; sac picks + persists
+  #   port: 7901         # pin only when you need a stable external URL
+  #   port: null         # disable the sidecar entirely
+```
+
+**Per-agent ports are an internal IPC detail.** External clients reach
+every agent through the **one stable host port** at `sac listen`
+(default `127.0.0.1:7878`). The AgentCard's `url` field advertises
+that stable URL — so the URL survives restarts even when the
+per-agent port churns.
+
+The per-agent sidecar then exposes the **same URL shape** as the
+host-level `sac listen`, so the same client URL works whether it
+routes through the host control plane or POSTs directly to the
+agent's port. Per the sac/orochi contract, two symmetric namespaces
+serve identical handlers:
+
+| Method | Path                                          | Purpose                                              |
+|--------|-----------------------------------------------|------------------------------------------------------|
+| POST   | `/agents/<name>/turn`                  | **Canonical.** Drop a prompt onto the SDK session    |
+| POST   | `/agents/<name>/send`                  | Alias of `/turn` (matches `sac listen`'s verb)       |
+| GET    | `/agents/<name>/card`                  | This agent's AgentCard                               |
+| POST   | `/v1/a2a/agents/<name>/turn`                  | A2A-protocol-compat mirror of `/turn`                |
+| POST   | `/v1/a2a/agents/<name>/send`                  | A2A-protocol-compat mirror of `/send`                |
+| GET    | `/v1/a2a/agents/<name>/card`                  | A2A-protocol-compat mirror of `/card`                |
+| POST   | `/v1/turn`                                    | Bare shortcut (port already pins the agent)          |
+| GET    | `/.well-known/agent-card.json`                | A2A discovery card (built from this agent's `spec.yaml`) |
+| GET    | `/.well-known/agent.json`                     | Alias of `agent-card.json` (some clients try this)   |
+| GET    | `/health`                                     | `{status: "ok"}` liveness probe                      |
+
+The `{name}` segment is informational — port routing has already pinned
+the request to one agent, so a name mismatch returns `404 {"error":
+"this port serves agent 'X', not 'Y'"}` as a sanity check.
+
+### Send a turn
+
+```bash
+curl -s --max-time 120 -X POST \
+  http://127.0.0.1:7901/agents/ecosystem-auditor/turn \
+  -H 'Content-Type: application/json' \
+  -d '{"text": "Which scitex packages currently have audit-all violations?"}'
+```
+
+Or, since the port already identifies the agent, the bare shortcut:
+
+```bash
+curl -s --max-time 120 -X POST http://127.0.0.1:7901/v1/turn \
+  -H 'Content-Type: application/json' \
+  -d '{"text": "Same question, via the shortcut."}'
+```
+
+Response shape (either path):
+
+```json
+{ "reply": "scitex-stats has 2 PS-204 violations; rest are green.",
+  "exit_after": false }
+```
+
+The runner stays attached after — subsequent POSTs reach the **same**
+SDK session (the conversation accumulates).
+
+### Discover the agent
+
+The AgentCard at `/.well-known/agent-card.json` is auto-generated from
+the agent's `spec.yaml` (see [`spec-reference.md`](spec-reference.md)
+for the field-to-card mapping). Browsers and A2A-spec discovery clients
+read it directly:
+
+```bash
+curl -s http://127.0.0.1:7901/.well-known/agent-card.json | python3 -m json.tool
+```
+
+The card's `url` field advertises `<base>/agents/<name>` —
+exactly the path the sidecar serves — so a client following the
+advertised URL hits a working endpoint.
+
+### One-shot vs follow-up
+
+The HTTP body accepts an `"exit_after"` flag:
+
+```json
+{ "text": "Reply DONE and exit.", "exit_after": true }
+```
+
+When `true`, the runner shuts down after this turn. Default is `false`
+(stay alive for more turns).
+
+---
+
+## 2. CLI — `sac agents send` / `sac agents tail`
+
+The same-host, no-network path:
+
+```bash
+# Send a turn — output is just the ack; the reply lands on session.jsonl
+sac agents send ecosystem-auditor "Which packages have uncommitted changes?"
+
+# Read the latest assistant turns
+sac agents tail ecosystem-auditor -n 5
+
+# Or stream as structured JSON (one envelope per line)
+sac agents tail ecosystem-auditor -n 5 --json
+```
+
+This is the right transport for shell scripts driving an agent
+locally — no port, no JSON, no token.
+
+---
+
+## 3. `sac listen` — host-level HTTP control plane
+
+`sac listen` boots a host-wide bearer-auth HTTP server (default port
+`7878`, loopback only). Cross-host orchestrators reach it through the
+existing SSH mesh; same-host orchestrators speak to it directly.
+
+```bash
+# Start the listen server (one per host; sac respects existing instance)
+sac listen &
+
+TOKEN=$(cat ~/.scitex/agent-container/tokens/listen-$(hostname).token)
+
+# Send a turn through the control plane
+curl -s -X POST http://127.0.0.1:7878/agents/ecosystem-auditor/send \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"type":"prompt","prompt":"Same question, via sac listen."}'
+```
+
+The full host-level surface (mirrored at `/v1/a2a/...` for A2A-spec
+consumers):
+
+| Method | Path                                         | Purpose                                |
+|--------|----------------------------------------------|----------------------------------------|
+| GET    | `/v1/sac/health`                             | `{ok, version, host}`                  |
+| GET    | `/agents`                             | List all agents on this host           |
+| GET    | `/agents/<name>/status`               | Full agent state                       |
+| GET    | `/agents/<name>/tail?since=...&follow=...` | SSE stream of `session.jsonl`     |
+| POST   | `/agents/<name>/send`                 | Send prompt or interrupt key           |
+| GET    | `/agents/<name>/card`                 | AgentCard for this agent               |
+| POST   | `/agents`                             | Create + start from an inline spec     |
+| DELETE | `/agents/<name>`                      | Stop the agent                         |
+
+`send` accepts both turn types:
+
+```text
+// prompt turn
+{ "type": "prompt", "prompt": "Your question here", "options": { ... } }
+
+// key / interrupt
+{ "type": "key", "key": "ESC" }
+```
+
+---
+
+## Cross-host: `sac --on <peer>`
+
+`sac --on <peer> agents send ...` dispatches the call across hosts via
+the peer registry's SSH mesh. The remote `sac` does the local send;
+output streams back. Same prompt-text contract.
+
+```bash
+sac --on gpu-box agents send researcher "Resume training and tail the logs."
+```
+
+---
+
+## Forwarding to external A2A (`kind: AgentProxy`)
+
+Sometimes the agent on the other end isn't a sac agent — it's a
+peer A2A endpoint hosted somewhere else (a hosted service, a peer
+fleet, a contracted vendor). Wrapping it in a `kind: AgentProxy`
+agent lets the rest of sac (`sac agents send`, `sac listen`, the
+AgentCard discovery surface) treat it the same as a local SDK agent.
+
+The proxy agent has no Claude SDK; it just forwards `POST /v1/turn`
+to its configured `spec.proxy.upstream` and re-projects the
+upstream AgentCard at its own `/.well-known/agent-card.json` so
+peers see one consistent skill list.
+
+```yaml
+apiVersion: scitex-agent-container/v3
+kind: AgentProxy
+
+spec:
+  runtime: apptainer
+  apptainer: { image: ~/.scitex/agent-container/containers/sac-proxy.sif }
+  proxy:
+    upstream: https://peer.example.com
+    trust: local-mesh
+    redact: [ANTHROPIC_API_KEY, sk-]
+    timeout_s: 30.0
+  a2a: { port: 7905 }
+```
+
+See [`spec-reference.md` § `kind: AgentProxy`](spec-reference.md#kind-agentproxy--http-forwarder-agents)
+and [`examples/agents/proxy-agent/`](https://github.com/ywatanabe1989/scitex-agent-container/tree/develop/examples/agents/proxy-agent)
+for the full reference.
+
+## Picking a transport
+
+- **A2A-spec client / browser / curl** → POST to the URL the AgentCard advertises (`<base>/agents/<name>/turn`). Loopback only; no auth.
+- **Shell script on the same host** → `sac agents send` + `tail`. No port, no JSON, no token.
+- **Another agent, on the same host** → A2A sidecar; agents have `httpx` in the SIF. Use the canonical URL or the `/v1/turn` shortcut — both work.
+- **Orchestrator (orochi, custom)** → `sac listen` (port 7878) with the bearer token; same `/agents/<name>/...` path shape, cross-host via the existing SSH mesh.
+- **External A2A peer (hosted service, vendor)** → wrap as a [`kind: AgentProxy`](spec-reference.md#kind-agentproxy--http-forwarder-agents) agent so the rest of sac treats it the same.
+
+Pick the most external transport that meets your needs — every layer
+above the inbox is a thin wrapper, so there's no functional difference
+once the turn lands. The URL shape is identical on both the per-agent
+sidecar and `sac listen`, so the same client code works against either.
+
+## See also
+
+- [`spec-reference.md`](spec-reference.md) — the YAML knobs (`spec.a2a.port`, `spec.listen.port`)
+- [`how-sac-works.md`](how-sac-works.md) — the architecture diagram showing where each transport hooks in
+- [`sac-and-orochi.md`](sac-and-orochi.md) — how orochi consumes `sac listen` across hosts
+
+<!-- EOF -->

--- a/src/scitex_agent_container/_mcp/channel.py
+++ b/src/scitex_agent_container/_mcp/channel.py
@@ -1,15 +1,16 @@
-"""sac MCP **channel** server (commit 2/4 of the A2A push slice).
+"""sac MCP **channel** server — the receive-side Claude-session adapter.
 
 Run as a stdio MCP subprocess of Claude Code:
 
-    sac mcp channel --name <agent> [--listen-url http://127.0.0.1:7878]
+    sac mcp channel --name <node-id> [--listen-url http://127.0.0.1:7878]
 
 Behaviour:
 
 1. Speaks the standard MCP handshake over stdio (so `claude
    --dangerously-load-development-channels server:sac` is happy).
 2. After initialise, opens an HTTP SSE connection to the local
-   `sac listen` at ``/agents/<name>/inbox/stream`` (ADR-0004).
+   `sac listen` at ``/agents/<node-id>/inbox/stream`` (ADR-0004,
+   ADR-0008).
 3. For every event the bus pushes, emits a JSON-RPC notification:
 
        method: notifications/claude/channel
@@ -18,11 +19,18 @@ Behaviour:
    so Claude renders ``<channel source="..." chat_id="..." ...>`` in
    the running session (see Claude Code channels reference).
 
-This module has **no tools** — pure receive-side adapter. The tools
-(`a2a_send`, `a2a_reply`, …) land in commit 3 on the existing sac MCP
-server. Splitting them keeps each surface single-purpose: the channel
-is a stdio process Claude spawns at session start; the tools server
-lives in the agent's MCP config.
+This module hosts the receive-side adapter **and** the send-side
+``a2a_*`` MCP tools (``a2a_send``, ``a2a_reply``, ``a2a_ack``,
+``a2a_peers``, ``a2a_inbox``). They live together because they
+share the per-process inbox ring buffer (``_recent``) that
+``a2a_reply`` / ``a2a_ack`` consult to look up the original sender
+of a msg_id.
+
+Per ADR-0008 (sac node-transport boundary), a *node* — sac-managed
+or external — joins the comms graph by running this command. An
+external node (e.g. a plain ``claude`` CLI session) has no
+container and no spec; its AgentCard is synthesised by
+``_listen/_nodes.py::synthesize_external_card`` at first connect.
 """
 
 from __future__ import annotations

--- a/src/scitex_agent_container/config/_host.py
+++ b/src/scitex_agent_container/config/_host.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import re
 import socket
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from scitex_config._ecosystem import local_state as _local_state
 


### PR DESCRIPTION
## Summary
Per HANDOFF_AGENT_COMMS_2026-05-19.md §4 (WI-5): docs cleanup to match the corrected boundary.

- ``docs/sac-and-orochi.md`` rewritten to the §2 model & boundary: sac is the node-transport substrate (any node ↔ any node, any host, ACL-gated); orochi is the human/product layer that consumes sac transport. Comms model (nodes / lineage / groups / ACL) is the centrepiece, with the two kinds of node (sac-managed + external) explained side by side.
- New ``docs/adr/0008-sac-node-transport-boundary.md`` captures D1–D9 (transport substrate; two node kinds; lineage + groups; ACL; depth-is-policy; A2A compliance for both kinds; channel-bus durability; endpoint location; Claude Code channels protocol). Cross-references ADR-0004.
- Fixed the stale ``_mcp/channel.py`` module docstring ("no tools", "commit 3" — both wrong: the a2a_* tools live on that module today).

Pure docs/docstring — no code change. ``import scitex_agent_container._mcp.channel`` still imports cleanly.

## Test plan
- [x] Smoke import: ``python -c "import scitex_agent_container._mcp.channel"`` — ok.
- [ ] CI runs full suite — no behaviour changed, expected green.