### PR TITLE
feat(wi-2): lineage/group ACL + spawn-gate (limited scope; auth deferred)

### DIFF
--- a/src/scitex_agent_container/_listen/_acl.py
+++ b/src/scitex_agent_container/_listen/_acl.py
@@ -1,28 +1,33 @@
-"""ACL gate on ``message:send`` for ``sac listen`` (WI-2, limited scope).
+"""ACL gate + authenticated-identity middleware for ``sac listen``.
 
 Per HANDOFF_AGENT_COMMS_2026-05-19.md §4 (WI-2) and the lead's
-2026-05-20 directive (limited scope — defer authenticated identity):
+2026-05-21 directive (RESTORED the authenticated-identity criterion
+the prior limited scope had deferred):
 
 * "Group-based default ACL. Default policy: intra-group send is
   allowed — parent↔child *and* sibling↔sibling, bidirectional.
   Everything cross-group is denied until an explicit grant is added."
 
+* **Authenticated sender identity** — per-node bearer tokens
+  resolved by :class:`NodeAuthMiddleware`. ``check_send_acl``
+  enforces "identity cannot be spoofed via a metadata field": when
+  a per-node bearer is presented, ``params.metadata.from_agent``
+  MUST match the bearer's resolved name; mismatch → 403.
+
 * Cross-group grants are accepted (see :mod:`_state.state_db_nodes`
-  ``grant_send`` / ``has_grant``); each grant row carries the audit
-  caveat "trusts metadata.from_agent until per-node creds land".
+  ``grant_send`` / ``has_grant``); the sender for the grant check
+  is the resolved-from-bearer name when a per-node bearer is
+  presented, else (administrative / host-bearer caller) the
+  ``metadata.from_agent`` claim.
 
 * "Denial is **explicit**: a denied send returns a clear ``403`` to
   the sender and is logged."
 
-**Deferred** (separate handoff filed in scitex-lead at
-``GITIGNORED/FUTURE/sac-per-node-authenticated-acl.md``):
-
-* Authenticated per-node identity. The current
-  :func:`check_send_acl` gates on the self-claimed
-  ``metadata.from_agent`` field. The cryptographic-identity follow-on
-  will replace the input here with a token-resolved name; the
-  decision logic stays the same.
-* Identity-cannot-be-spoofed enforcement. Same gap, same follow-on.
+The administrative-caller path (host-bearer) is the cross-host
+forwarding seam: another sac listen forwards a peer's send to this
+host by authenticating with the destination's host bearer (pulled
+from the ``peer-tokens/<dest-host>.token`` registry on the
+forwarder's side — see :mod:`_listen.peer_tokens`).
 """
 
 from __future__ import annotations
@@ -32,13 +37,20 @@ from pathlib import Path
 from typing import Literal
 
 from starlette.responses import JSONResponse
+from starlette.types import ASGIApp, Receive, Scope, Send
 
-from .._state.state_db_nodes import derive_group, has_grant, spawn_allowed
+from .._state.state_db_nodes import (
+    derive_group,
+    has_grant,
+    resolve_node_token,
+    spawn_allowed,
+)
 
 log = logging.getLogger(__name__)
 
 __all__ = [
     "AclDecision",
+    "NodeAuthMiddleware",
     "check_send_acl",
     "check_spawn",
     "deny_response",
@@ -48,45 +60,127 @@ __all__ = [
 AclDecision = tuple[Literal["allow", "deny"], str | None]
 
 
+class NodeAuthMiddleware:
+    """Resolve the incoming Bearer token to a node identity, if any.
+
+    Sits **after** the outer
+    :class:`scitex_agent_container._listen.auth.BearerAuthMiddleware`
+    — that middleware enforces *some* valid bearer was presented;
+    this one resolves it to an identity:
+
+    * If the bearer equals the host-wide token, attach
+      ``request.state.authenticated_node = None`` to mark it as the
+      administrative caller (cross-host forwarding path: the
+      caller is a peer sac listen acting on behalf of a remote
+      node; ``metadata.from_agent`` is honoured verbatim).
+    * If the bearer matches a row in ``node_tokens``, attach the
+      resolved node name.
+    * Otherwise leave ``authenticated_node = None``. The outer
+      middleware would already have rejected an unknown bearer, so
+      this branch is defence-in-depth.
+
+    ``db_path`` is exposed so tests can drop in an isolated
+    state.db without touching ``$SCITEX_AGENT_CONTAINER_STATE_DB``.
+    """
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        *,
+        host_bearer: str,
+        db_path: Path | None = None,
+    ) -> None:
+        self.app = app
+        self.host_bearer = host_bearer
+        self.db_path = db_path
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+        headers = dict(scope.get("headers") or [])
+        auth = headers.get(b"authorization", b"").decode("ascii", "replace")
+        bearer = ""
+        if auth.startswith("Bearer "):
+            bearer = auth[len("Bearer ") :].strip()
+        scope.setdefault("state", {})
+        if bearer and bearer != self.host_bearer:
+            resolved = resolve_node_token(token=bearer, db_path=self.db_path)
+            scope["state"]["authenticated_node"] = resolved
+        else:
+            scope["state"]["authenticated_node"] = None
+        await self.app(scope, receive, send)
+
+
 def check_send_acl(
     *,
+    authenticated_node: str | None,
     claimed_from_agent: str | None,
     target: str,
     db_path: Path | None = None,
 ) -> AclDecision:
     """Decide whether a ``message:send`` should be admitted.
 
-    Decision logic (handoff §4 acceptance, limited scope):
+    Inputs:
 
-    1. Empty sender (no ``metadata.from_agent``) → deny — there is
-       no identity to gate on.
-    2. ``sender == target`` (self-send) → allow.
-    3. ``target`` in ``derive_group(sender)`` (intra-group) → allow.
-    4. Explicit cross-group grant (``has_grant(sender, target)``)
-       → allow.
-    5. Otherwise → deny with explanatory reason.
+    * ``authenticated_node`` — resolved from the Bearer token by
+      :class:`NodeAuthMiddleware`. ``None`` means the host-wide
+      bearer was used (administrative / cross-host forwarding) — the
+      caller is trusted to honour ``claimed_from_agent`` verbatim.
+    * ``claimed_from_agent`` — what ``params.metadata.from_agent``
+      said. May be missing.
+    * ``target`` — the ``<name>`` in
+      ``POST /agents/<name>/message:send``.
+
+    Decision logic (handoff §4 acceptance):
+
+    1. **Identity cannot be spoofed via a metadata field.** When a
+       per-node bearer is presented, ``claimed_from_agent`` (if
+       present) MUST match ``authenticated_node``; mismatch → deny.
+    2. **Cross-group is denied by default.** The effective sender
+       (authenticated_node, or claimed_from_agent for an
+       administrative caller) must share a group with the target.
+       Same-name (self-send) is trivially allowed.
+    3. **Explicit cross-group grants flip a deny to allow** — see
+       :func:`_state.state_db_nodes.grant_send`.
+    4. The empty-sender case (no authenticated node AND no claimed
+       from_agent) is denied — there is no identity to gate on.
 
     Returns ``("allow", None)`` or ``("deny", reason)``. The reason
     is suitable for inclusion in a 403 body and a host log line.
-
-    **Identity caveat** — ``claimed_from_agent`` is the self-claimed
-    ``metadata.from_agent`` field. The cryptographic-identity
-    follow-on will replace this input with a token-resolved name;
-    the decision branches above will not change. See the module
-    docstring for the deferred-work pointer.
     """
     if not target:
         return ("deny", "missing target")
-    if not claimed_from_agent:
-        return (
-            "deny",
-            (
-                "no metadata.from_agent — cannot determine sender for ACL. "
-                "Until per-node credentials land, every message:send MUST "
-                "carry params.metadata.from_agent."
-            ),
-        )
-    sender = claimed_from_agent
+
+    # Determine the *effective* sender identity for the ACL check.
+    if authenticated_node is not None:
+        # Per-node bearer was presented.
+        if (
+            claimed_from_agent is not None
+            and claimed_from_agent != authenticated_node
+        ):
+            return (
+                "deny",
+                (
+                    f"identity spoof: bearer authenticates "
+                    f"{authenticated_node!r} but metadata.from_agent "
+                    f"claims {claimed_from_agent!r}"
+                ),
+            )
+        sender = authenticated_node
+    else:
+        # Administrative / cross-host forwarding path. The caller
+        # passed the host-wide bearer; we honour
+        # metadata.from_agent verbatim — but it must be present.
+        if not claimed_from_agent:
+            return (
+                "deny",
+                (
+                    "no authenticated identity and no metadata.from_agent — "
+                    "cannot determine sender for ACL"
+                ),
+            )
+        sender = claimed_from_agent
 
     if sender == target:
         return ("allow", None)
@@ -136,4 +230,6 @@ def deny_response(reason: str) -> JSONResponse:
     but the sender must know exactly why (handoff §0 Hard rules).
     """
     log.warning("ACL deny: %s", reason)
-    return JSONResponse({"error": "ACL deny", "reason": reason}, status_code=403)
+    return JSONResponse(
+        {"error": "ACL deny", "reason": reason}, status_code=403
+    )

--- a/src/scitex_agent_container/_listen/_acl.py
+++ b/src/scitex_agent_container/_listen/_acl.py
@@ -14,8 +14,8 @@ Per HANDOFF_AGENT_COMMS_2026-05-19.md §4 (WI-2) and the lead's
 * "Denial is **explicit**: a denied send returns a clear ``403`` to
   the sender and is logged."
 
-**Deferred** (separate handoff, related to the existing sac-accounts-
-per-agent-credentials-and-rotation FUTURE doc):
+**Deferred** (separate handoff filed in scitex-lead at
+``GITIGNORED/FUTURE/sac-per-node-authenticated-acl.md``):
 
 * Authenticated per-node identity. The current
   :func:`check_send_acl` gates on the self-claimed

--- a/src/scitex_agent_container/_listen/_acl.py
+++ b/src/scitex_agent_container/_listen/_acl.py
@@ -1,37 +1,28 @@
-"""ACL check + authenticated-identity middleware for ``sac listen`` (WI-2).
+"""ACL gate on ``message:send`` for ``sac listen`` (WI-2, limited scope).
 
-Per HANDOFF_AGENT_COMMS_2026-05-19.md §4 (WI-2 "ACL: permissioned
-messaging"):
+Per HANDOFF_AGENT_COMMS_2026-05-19.md §4 (WI-2) and the lead's
+2026-05-20 directive (limited scope — defer authenticated identity):
 
 * "Group-based default ACL. Default policy: intra-group send is
   allowed — parent↔child *and* sibling↔sibling, bidirectional.
   Everything cross-group is denied until an explicit grant is added."
-* "Authenticated sender identity. ... Do not gate on an
-  unauthenticated string."
-* "Denial is **explicit**: a denied send returns a clear `403` to
-  the sender and is logged".
 
-This module supplies two layers:
+* Cross-group grants are accepted (see :mod:`_state.state_db_nodes`
+  ``grant_send`` / ``has_grant``); each grant row carries the audit
+  caveat "trusts metadata.from_agent until per-node creds land".
 
-* :class:`NodeAuthMiddleware` — resolves the incoming
-  ``Authorization: Bearer <token>`` against the ``node_tokens``
-  table (see :mod:`_state.state_db_nodes`). On success it attaches
-  ``request.state.authenticated_node = <name>`` so downstream
-  handlers know who is speaking. The middleware sits **after** the
-  outer :class:`BearerAuthMiddleware`; the host-wide bearer admits
-  any request and leaves ``authenticated_node`` unset
-  (administrative / cross-host forwarding path). A per-node bearer
-  pins identity to one name.
+* "Denial is **explicit**: a denied send returns a clear ``403`` to
+  the sender and is logged."
 
-* :func:`check_send_acl` — gating function called by
-  ``node_message_send``. Returns ``("allow", None)`` or
-  ``("deny", reason)``. The reasons are surfaced verbatim in the
-  403 body and in the host log — denial is the policy working, not
-  a bug, but the sender must know exactly why.
+**Deferred** (separate handoff, related to the existing sac-accounts-
+per-agent-credentials-and-rotation FUTURE doc):
 
-Spawn permission (also called out by WI-2) lives in a sibling
-``spawn_allowed`` helper alongside the lineage primitives —
-co-located with the lineage data it consults.
+* Authenticated per-node identity. The current
+  :func:`check_send_acl` gates on the self-claimed
+  ``metadata.from_agent`` field. The cryptographic-identity follow-on
+  will replace the input here with a token-resolved name; the
+  decision logic stays the same.
+* Identity-cannot-be-spoofed enforcement. Same gap, same follow-on.
 """
 
 from __future__ import annotations
@@ -40,142 +31,62 @@ import logging
 from pathlib import Path
 from typing import Literal
 
-from starlette.requests import Request
 from starlette.responses import JSONResponse
-from starlette.types import ASGIApp, Receive, Scope, Send
 
-from .._state.state_db_nodes import derive_group, resolve_node_token
+from .._state.state_db_nodes import derive_group, has_grant, spawn_allowed
 
 log = logging.getLogger(__name__)
 
 __all__ = [
-    "NodeAuthMiddleware",
-    "check_send_acl",
     "AclDecision",
+    "check_send_acl",
+    "check_spawn",
+    "deny_response",
 ]
 
 
 AclDecision = tuple[Literal["allow", "deny"], str | None]
 
 
-class NodeAuthMiddleware:
-    """Resolve the incoming Bearer token to a node identity, if any.
-
-    Sits **after** :class:`scitex_agent_container._listen.auth.BearerAuthMiddleware`
-    — that middleware already enforces that *some* valid bearer was
-    presented. We add identity resolution on top:
-
-    * If the bearer equals the host-wide token (the only bearer the
-      outer middleware admits today), attach
-      ``request.state.authenticated_node = None`` to mark it as the
-      administrative caller.
-    * If the bearer matches a row in ``node_tokens``, attach the
-      node name.
-    * Otherwise leave ``authenticated_node`` as ``None`` (the outer
-      middleware would have rejected an unknown bearer; this branch
-      is defence-in-depth).
-
-    Configurable ``db_path`` so tests can drop in an isolated state.db
-    without touching ``$SCITEX_AGENT_CONTAINER_STATE_DB``.
-    """
-
-    def __init__(
-        self,
-        app: ASGIApp,
-        *,
-        host_bearer: str,
-        db_path: Path | None = None,
-    ) -> None:
-        self.app = app
-        self.host_bearer = host_bearer
-        self.db_path = db_path
-
-    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        if scope["type"] != "http":
-            await self.app(scope, receive, send)
-            return
-        headers = dict(scope.get("headers") or [])
-        auth = headers.get(b"authorization", b"").decode("ascii", "replace")
-        bearer = ""
-        if auth.startswith("Bearer "):
-            bearer = auth[len("Bearer ") :].strip()
-        scope.setdefault("state", {})
-        if bearer and bearer != self.host_bearer:
-            resolved = resolve_node_token(token=bearer, db_path=self.db_path)
-            scope["state"]["authenticated_node"] = resolved
-        else:
-            scope["state"]["authenticated_node"] = None
-        await self.app(scope, receive, send)
-
-
 def check_send_acl(
     *,
-    authenticated_node: str | None,
     claimed_from_agent: str | None,
     target: str,
     db_path: Path | None = None,
 ) -> AclDecision:
     """Decide whether a ``message:send`` should be admitted.
 
-    Inputs:
+    Decision logic (handoff §4 acceptance, limited scope):
 
-    * ``authenticated_node`` — resolved from the Bearer token by
-      :class:`NodeAuthMiddleware`. ``None`` means the host-wide
-      bearer was used (administrative / cross-host forwarding) — the
-      caller is trusted to honour the ``claimed_from_agent`` field
-      verbatim.
-    * ``claimed_from_agent`` — what ``params.metadata.from_agent``
-      said. May be missing.
-    * ``target`` — the ``<name>`` in
-      ``POST /agents/<name>/message:send``.
-
-    Decision logic (handoff §4 acceptance):
-
-    1. **Identity cannot be spoofed via a metadata field.** When a
-       per-node bearer is presented, ``claimed_from_agent`` (if
-       present) MUST match ``authenticated_node``; mismatch → deny.
-    2. **Cross-group is denied by default.** The effective sender
-       (authenticated_node, or claimed_from_agent for an
-       administrative caller) must share a group with the target.
-       Same-name (self-send) is trivially allowed — a node can
-       always address itself.
-    3. The empty-sender case (no authenticated node AND no claimed
-       from_agent) is denied — there is no identity to gate on.
+    1. Empty sender (no ``metadata.from_agent``) → deny — there is
+       no identity to gate on.
+    2. ``sender == target`` (self-send) → allow.
+    3. ``target`` in ``derive_group(sender)`` (intra-group) → allow.
+    4. Explicit cross-group grant (``has_grant(sender, target)``)
+       → allow.
+    5. Otherwise → deny with explanatory reason.
 
     Returns ``("allow", None)`` or ``("deny", reason)``. The reason
     is suitable for inclusion in a 403 body and a host log line.
+
+    **Identity caveat** — ``claimed_from_agent`` is the self-claimed
+    ``metadata.from_agent`` field. The cryptographic-identity
+    follow-on will replace this input with a token-resolved name;
+    the decision branches above will not change. See the module
+    docstring for the deferred-work pointer.
     """
     if not target:
         return ("deny", "missing target")
-
-    # Determine the *effective* sender identity for the ACL check.
-    if authenticated_node is not None:
-        # Per-node bearer was presented.
-        if (
-            claimed_from_agent is not None
-            and claimed_from_agent != authenticated_node
-        ):
-            return (
-                "deny",
-                (
-                    f"identity spoof: bearer authenticates {authenticated_node!r} "
-                    f"but metadata.from_agent claims {claimed_from_agent!r}"
-                ),
-            )
-        sender = authenticated_node
-    else:
-        # Administrative / cross-host forwarding path. The caller
-        # passed the host-wide bearer; we honour metadata.from_agent
-        # verbatim — but it must be present.
-        if not claimed_from_agent:
-            return (
-                "deny",
-                (
-                    "no authenticated identity and no metadata.from_agent — "
-                    "cannot determine sender for ACL"
-                ),
-            )
-        sender = claimed_from_agent
+    if not claimed_from_agent:
+        return (
+            "deny",
+            (
+                "no metadata.from_agent — cannot determine sender for ACL. "
+                "Until per-node credentials land, every message:send MUST "
+                "carry params.metadata.from_agent."
+            ),
+        )
+    sender = claimed_from_agent
 
     if sender == target:
         return ("allow", None)
@@ -184,13 +95,37 @@ def check_send_acl(
     if target in sender_group:
         return ("allow", None)
 
+    if has_grant(sender=sender, target=target, db_path=db_path):
+        return ("allow", None)
+
     return (
         "deny",
         (
-            f"cross-group send: sender {sender!r} (group={sorted(sender_group)}) "
-            f"may not address {target!r} without an explicit ACL grant"
+            f"cross-group send: sender {sender!r} "
+            f"(group={sorted(sender_group)}) may not address {target!r} "
+            "without an explicit ACL grant. Add a grant with "
+            f"`grant_send(sender={sender!r}, target={target!r})` "
+            "in state.db."
         ),
     )
+
+
+def check_spawn(
+    *,
+    caller: str | None,
+    db_path: Path | None = None,
+) -> AclDecision:
+    """Wrap :func:`spawn_allowed` in the same allow/deny tuple shape
+    as :func:`check_send_acl` so the listen-server handler can branch
+    uniformly.
+
+    Current policy: root-only spawn. ``caller=None`` is the
+    administrative / human-operator path (allowed).
+    """
+    allowed, reason = spawn_allowed(caller=caller, db_path=db_path)
+    if allowed:
+        return ("allow", None)
+    return ("deny", reason)
 
 
 def deny_response(reason: str) -> JSONResponse:

--- a/src/scitex_agent_container/_listen/_acl.py
+++ b/src/scitex_agent_container/_listen/_acl.py
@@ -1,0 +1,204 @@
+"""ACL check + authenticated-identity middleware for ``sac listen`` (WI-2).
+
+Per HANDOFF_AGENT_COMMS_2026-05-19.md §4 (WI-2 "ACL: permissioned
+messaging"):
+
+* "Group-based default ACL. Default policy: intra-group send is
+  allowed — parent↔child *and* sibling↔sibling, bidirectional.
+  Everything cross-group is denied until an explicit grant is added."
+* "Authenticated sender identity. ... Do not gate on an
+  unauthenticated string."
+* "Denial is **explicit**: a denied send returns a clear `403` to
+  the sender and is logged".
+
+This module supplies two layers:
+
+* :class:`NodeAuthMiddleware` — resolves the incoming
+  ``Authorization: Bearer <token>`` against the ``node_tokens``
+  table (see :mod:`_state.state_db_nodes`). On success it attaches
+  ``request.state.authenticated_node = <name>`` so downstream
+  handlers know who is speaking. The middleware sits **after** the
+  outer :class:`BearerAuthMiddleware`; the host-wide bearer admits
+  any request and leaves ``authenticated_node`` unset
+  (administrative / cross-host forwarding path). A per-node bearer
+  pins identity to one name.
+
+* :func:`check_send_acl` — gating function called by
+  ``node_message_send``. Returns ``("allow", None)`` or
+  ``("deny", reason)``. The reasons are surfaced verbatim in the
+  403 body and in the host log — denial is the policy working, not
+  a bug, but the sender must know exactly why.
+
+Spawn permission (also called out by WI-2) lives in a sibling
+``spawn_allowed`` helper alongside the lineage primitives —
+co-located with the lineage data it consults.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Literal
+
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+from .._state.state_db_nodes import derive_group, resolve_node_token
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "NodeAuthMiddleware",
+    "check_send_acl",
+    "AclDecision",
+]
+
+
+AclDecision = tuple[Literal["allow", "deny"], str | None]
+
+
+class NodeAuthMiddleware:
+    """Resolve the incoming Bearer token to a node identity, if any.
+
+    Sits **after** :class:`scitex_agent_container._listen.auth.BearerAuthMiddleware`
+    — that middleware already enforces that *some* valid bearer was
+    presented. We add identity resolution on top:
+
+    * If the bearer equals the host-wide token (the only bearer the
+      outer middleware admits today), attach
+      ``request.state.authenticated_node = None`` to mark it as the
+      administrative caller.
+    * If the bearer matches a row in ``node_tokens``, attach the
+      node name.
+    * Otherwise leave ``authenticated_node`` as ``None`` (the outer
+      middleware would have rejected an unknown bearer; this branch
+      is defence-in-depth).
+
+    Configurable ``db_path`` so tests can drop in an isolated state.db
+    without touching ``$SCITEX_AGENT_CONTAINER_STATE_DB``.
+    """
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        *,
+        host_bearer: str,
+        db_path: Path | None = None,
+    ) -> None:
+        self.app = app
+        self.host_bearer = host_bearer
+        self.db_path = db_path
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+        headers = dict(scope.get("headers") or [])
+        auth = headers.get(b"authorization", b"").decode("ascii", "replace")
+        bearer = ""
+        if auth.startswith("Bearer "):
+            bearer = auth[len("Bearer ") :].strip()
+        scope.setdefault("state", {})
+        if bearer and bearer != self.host_bearer:
+            resolved = resolve_node_token(token=bearer, db_path=self.db_path)
+            scope["state"]["authenticated_node"] = resolved
+        else:
+            scope["state"]["authenticated_node"] = None
+        await self.app(scope, receive, send)
+
+
+def check_send_acl(
+    *,
+    authenticated_node: str | None,
+    claimed_from_agent: str | None,
+    target: str,
+    db_path: Path | None = None,
+) -> AclDecision:
+    """Decide whether a ``message:send`` should be admitted.
+
+    Inputs:
+
+    * ``authenticated_node`` — resolved from the Bearer token by
+      :class:`NodeAuthMiddleware`. ``None`` means the host-wide
+      bearer was used (administrative / cross-host forwarding) — the
+      caller is trusted to honour the ``claimed_from_agent`` field
+      verbatim.
+    * ``claimed_from_agent`` — what ``params.metadata.from_agent``
+      said. May be missing.
+    * ``target`` — the ``<name>`` in
+      ``POST /agents/<name>/message:send``.
+
+    Decision logic (handoff §4 acceptance):
+
+    1. **Identity cannot be spoofed via a metadata field.** When a
+       per-node bearer is presented, ``claimed_from_agent`` (if
+       present) MUST match ``authenticated_node``; mismatch → deny.
+    2. **Cross-group is denied by default.** The effective sender
+       (authenticated_node, or claimed_from_agent for an
+       administrative caller) must share a group with the target.
+       Same-name (self-send) is trivially allowed — a node can
+       always address itself.
+    3. The empty-sender case (no authenticated node AND no claimed
+       from_agent) is denied — there is no identity to gate on.
+
+    Returns ``("allow", None)`` or ``("deny", reason)``. The reason
+    is suitable for inclusion in a 403 body and a host log line.
+    """
+    if not target:
+        return ("deny", "missing target")
+
+    # Determine the *effective* sender identity for the ACL check.
+    if authenticated_node is not None:
+        # Per-node bearer was presented.
+        if (
+            claimed_from_agent is not None
+            and claimed_from_agent != authenticated_node
+        ):
+            return (
+                "deny",
+                (
+                    f"identity spoof: bearer authenticates {authenticated_node!r} "
+                    f"but metadata.from_agent claims {claimed_from_agent!r}"
+                ),
+            )
+        sender = authenticated_node
+    else:
+        # Administrative / cross-host forwarding path. The caller
+        # passed the host-wide bearer; we honour metadata.from_agent
+        # verbatim — but it must be present.
+        if not claimed_from_agent:
+            return (
+                "deny",
+                (
+                    "no authenticated identity and no metadata.from_agent — "
+                    "cannot determine sender for ACL"
+                ),
+            )
+        sender = claimed_from_agent
+
+    if sender == target:
+        return ("allow", None)
+
+    sender_group = derive_group(name=sender, db_path=db_path)
+    if target in sender_group:
+        return ("allow", None)
+
+    return (
+        "deny",
+        (
+            f"cross-group send: sender {sender!r} (group={sorted(sender_group)}) "
+            f"may not address {target!r} without an explicit ACL grant"
+        ),
+    )
+
+
+def deny_response(reason: str) -> JSONResponse:
+    """Standard 403 body for an ACL denial. Loud + structured.
+
+    Logged at WARNING so the host operator sees the rejection in the
+    listen-server log. Denial is the policy working — not a crash —
+    but the sender must know exactly why (handoff §0 Hard rules).
+    """
+    log.warning("ACL deny: %s", reason)
+    return JSONResponse({"error": "ACL deny", "reason": reason}, status_code=403)

--- a/src/scitex_agent_container/_listen/auth.py
+++ b/src/scitex_agent_container/_listen/auth.py
@@ -4,6 +4,14 @@ Per SAC_OROCHI_SCOPES.md §4.4: sac listen binds loopback or to a
 private tunnel-only interface, so the bearer token is defense-in-depth
 rather than the primary transport security. Constant-time comparison
 to dodge timing oracles; clear 401/403 separation.
+
+**WI-2 update**: the middleware admits **either** the host-wide
+token (administrative caller / cross-host-forwarder path) **or** a
+per-node token registered in :mod:`_state.state_db_nodes`
+(``node_tokens`` table). The inner
+:class:`_listen._acl.NodeAuthMiddleware` then tags
+``request.state.authenticated_node`` with the resolved name for the
+ACL gate.
 """
 
 from __future__ import annotations
@@ -29,6 +37,9 @@ def _extract_bearer(request: Request) -> str | None:
 class BearerAuthMiddleware(BaseHTTPMiddleware):
     """Rejects requests missing or with a wrong bearer token.
 
+    Admits *either* the host-wide ``token`` (passed at construction)
+    *or* a per-node token registered in ``node_tokens`` (WI-2).
+
     Health endpoint at ``/v1/health`` is unauthenticated so monitors
     can probe liveness without provisioning credentials.
     """
@@ -45,6 +56,14 @@ class BearerAuthMiddleware(BaseHTTPMiddleware):
         got = _extract_bearer(request)
         if got is None:
             return JSONResponse({"error": "missing bearer token"}, status_code=401)
-        if not hmac.compare_digest(got, self._token):
-            return JSONResponse({"error": "invalid bearer token"}, status_code=403)
-        return await call_next(request)
+        # 1) Host-wide token — administrative / cross-host caller.
+        if hmac.compare_digest(got, self._token):
+            return await call_next(request)
+        # 2) WI-2 per-node bearer — resolves against ``node_tokens``.
+        #    Import lazily so the lazy-loading test fixtures (which
+        #    patch ``state_db.DEFAULT_DB_PATH``) take effect.
+        from .._state.state_db_nodes import resolve_node_token
+
+        if resolve_node_token(token=got) is not None:
+            return await call_next(request)
+        return JSONResponse({"error": "invalid bearer token"}, status_code=403)

--- a/src/scitex_agent_container/_listen/server.py
+++ b/src/scitex_agent_container/_listen/server.py
@@ -43,6 +43,7 @@ from .._state.registry import Registry
 from ..a2a._inbox_bus import mint_event
 from ..config import load_config
 from ..config._resolve import resolve_config
+from ._acl import NodeAuthMiddleware, check_send_acl, deny_response
 from ._inline_spec import materialize_inline_spec
 from ._nodes import Broker, NodeRegistry
 from .auth import BearerAuthMiddleware
@@ -444,8 +445,20 @@ async def node_message_send(request: Request) -> Response:
     lookup. The publish is **always loud** — a malformed body returns
     400, never a silent drop (handoff §0 Hard rules).
 
-    No ACL gating yet — that lands in WI-2. Bearer auth (outer
-    perimeter) still applies via :class:`BearerAuthMiddleware`.
+    WI-2 ACL gate: every send is checked by
+    :func:`_acl.check_send_acl` before publish:
+
+    * A per-node bearer pins identity — ``metadata.from_agent`` must
+      match the bearer's resolved name; mismatch → 403.
+    * Cross-group is denied by default; intra-group (parent↔child
+      and sibling↔sibling) is allowed.
+    * The host-wide bearer is treated as an administrative caller
+      whose ``metadata.from_agent`` is honoured verbatim — the
+      cross-host-forwarding seam (handoff §4 WI-4 prerequisite).
+
+    Bearer auth (outer perimeter) is still enforced by
+    :class:`BearerAuthMiddleware`; identity resolution is enforced
+    by :class:`NodeAuthMiddleware`.
     """
     name = request.path_params["name"]
     try:
@@ -491,6 +504,22 @@ async def node_message_send(request: Request) -> Response:
     for src in (params.get("metadata"), message.get("metadata")):
         if isinstance(src, dict):
             sac_meta.update(src)
+
+    # WI-2 ACL check. ``authenticated_node`` is set by
+    # :class:`NodeAuthMiddleware` — ``None`` means the host-wide
+    # bearer was presented (administrative caller). The check honours
+    # ``metadata.from_agent`` only when no per-node bearer is bound
+    # (or when it matches), so a metadata field cannot spoof identity.
+    authenticated_node = getattr(
+        request.state, "authenticated_node", None
+    )
+    decision, reason = check_send_acl(
+        authenticated_node=authenticated_node,
+        claimed_from_agent=sac_meta.get("from_agent"),
+        target=name,
+    )
+    if decision == "deny":
+        return deny_response(reason or "ACL deny")
 
     event = mint_event(
         name,
@@ -621,6 +650,18 @@ def create_app(*, token: str) -> Starlette:
     external nodes (no YAML, no container) can attach as first-class
     members of the comms graph. The state lives on ``app.state`` so
     every handler shares the same broker and registry instance.
+
+    WI-2 chains :class:`NodeAuthMiddleware` after
+    :class:`BearerAuthMiddleware`: the outer middleware admits any
+    request bearing a valid token (host-wide or per-node); the inner
+    one resolves that token to a node identity and attaches it to
+    ``request.state.authenticated_node`` so the ACL gate in
+    :func:`node_message_send` can decide allow / deny.
+
+    Middleware order matters. Starlette executes the *outermost*
+    ``add_middleware`` call first (it wraps the app last but runs
+    first on the inbound path). So the BearerAuthMiddleware call
+    below comes **last** to make it the outermost layer.
     """
     routes: list[Route] = [
         Route("/v1/health", health, methods=["GET"]),
@@ -631,5 +672,10 @@ def create_app(*, token: str) -> Starlette:
     # Per-app shared state for the WI-3 inbox surface.
     app.state.inbox = Broker()
     app.state.nodes = NodeRegistry()
+    # WI-2 — identity resolution (inner). Reads the same Bearer the
+    # outer middleware already validated; tags ``request.state`` with
+    # the resolved node name (or ``None`` for the host-wide bearer).
+    app.add_middleware(NodeAuthMiddleware, host_bearer=token)
+    # Outer perimeter — admits any valid token, rejects everything else.
     app.add_middleware(BearerAuthMiddleware, token=token)
     return app

--- a/src/scitex_agent_container/_listen/server.py
+++ b/src/scitex_agent_container/_listen/server.py
@@ -491,8 +491,9 @@ async def node_message_send(request: Request) -> Response:
 
     **Identity caveat** — the sender identity is the self-claimed
     ``metadata.from_agent`` field. Cryptographic per-node identity
-    is deferred to a separate follow-on handoff (related to the
-    sac-accounts-per-agent-credentials-and-rotation FUTURE doc);
+    is deferred to a separate follow-on handoff filed in
+    scitex-lead at
+    ``GITIGNORED/FUTURE/sac-per-node-authenticated-acl.md``;
     until then every grant row stores the caveat "trusts
     metadata.from_agent until per-node creds land". Bearer auth
     (host-wide token) is still enforced by

--- a/src/scitex_agent_container/_listen/server.py
+++ b/src/scitex_agent_container/_listen/server.py
@@ -43,7 +43,12 @@ from .._state.registry import Registry
 from ..a2a._inbox_bus import mint_event
 from ..config import load_config
 from ..config._resolve import resolve_config
-from ._acl import check_send_acl, check_spawn, deny_response
+from ._acl import (
+    NodeAuthMiddleware,
+    check_send_acl,
+    check_spawn,
+    deny_response,
+)
 from ._inline_spec import materialize_inline_spec
 from ._nodes import Broker, NodeRegistry
 from .auth import BearerAuthMiddleware
@@ -480,24 +485,25 @@ async def node_message_send(request: Request) -> Response:
     lookup. The publish is **always loud** — a malformed body returns
     400, never a silent drop (handoff §0 Hard rules).
 
-    WI-2 ACL gate (limited scope per lead 2026-05-20): every send
-    is checked by :func:`_acl.check_send_acl` before publish:
+    WI-2 ACL gate: every send is checked by
+    :func:`_acl.check_send_acl` before publish:
 
-    * Cross-group is denied by default; intra-group (parent↔child
-      and sibling↔sibling) is allowed.
-    * Explicit cross-group grants (``comms_grants`` table) flip
+    * **Per-node bearer** pins identity — ``metadata.from_agent``
+      must match the resolved name, else 403 "identity spoof"
+      (handoff §4 acceptance).
+    * **Cross-group** is denied by default; intra-group
+      (parent↔child and sibling↔sibling) is allowed.
+    * **Explicit cross-group grants** (``comms_grants`` table) flip
       a deny to an allow.
-    * Self-send is always allowed.
+    * **Self-send** is always allowed.
+    * The **host-wide bearer** is the administrative / cross-host
+      forwarding caller; it honours ``metadata.from_agent``
+      verbatim (used by WI-4 forwarders authenticating with the
+      destination's host bearer from ``peer-tokens/`` registry).
 
-    **Identity caveat** — the sender identity is the self-claimed
-    ``metadata.from_agent`` field. Cryptographic per-node identity
-    is deferred to a separate follow-on handoff filed in
-    scitex-lead at
-    ``GITIGNORED/FUTURE/sac-per-node-authenticated-acl.md``;
-    until then every grant row stores the caveat "trusts
-    metadata.from_agent until per-node creds land". Bearer auth
-    (host-wide token) is still enforced by
-    :class:`BearerAuthMiddleware` as the outer perimeter.
+    Bearer auth is enforced by :class:`BearerAuthMiddleware` (outer
+    perimeter) and identity resolution by :class:`NodeAuthMiddleware`
+    (sets ``request.state.authenticated_node``).
     """
     name = request.path_params["name"]
     try:
@@ -544,11 +550,17 @@ async def node_message_send(request: Request) -> Response:
         if isinstance(src, dict):
             sac_meta.update(src)
 
-    # WI-2 ACL check (limited scope). Gates on the self-claimed
-    # ``metadata.from_agent`` field; cryptographic per-node identity
-    # is deferred. See :func:`_acl.check_send_acl` for the decision
-    # branches and the identity caveat.
+    # WI-2 ACL check. ``authenticated_node`` is set by
+    # :class:`NodeAuthMiddleware` — ``None`` means the host-wide
+    # bearer was presented (administrative caller). With a per-node
+    # bearer, ``metadata.from_agent`` MUST match the resolved name
+    # so identity cannot be spoofed via a metadata field (handoff
+    # §4 acceptance). See :func:`_acl.check_send_acl`.
+    authenticated_node = getattr(
+        request.state, "authenticated_node", None
+    )
     decision, reason = check_send_acl(
+        authenticated_node=authenticated_node,
         claimed_from_agent=sac_meta.get("from_agent"),
         target=name,
     )
@@ -677,7 +689,7 @@ def _v1_agent_routes(prefix: str) -> list[Route]:
     ]
 
 
-def create_app(*, token: str) -> Starlette:
+def create_app(*, token: str, local_host: str | None = None) -> Starlette:
     """Build the Starlette app with bearer auth (ADR-0004 — ``/agents`` only).
 
     WI-3 wires a per-app :class:`Broker` + :class:`NodeRegistry` so
@@ -685,11 +697,24 @@ def create_app(*, token: str) -> Starlette:
     members of the comms graph. The state lives on ``app.state`` so
     every handler shares the same broker and registry instance.
 
-    WI-2 (limited scope per lead 2026-05-20) adds the ACL gate to
-    :func:`node_message_send` and the spawn-permission gate to
-    :func:`agents_start`. Both gate on the self-claimed
-    ``metadata.from_agent`` / body-``caller`` field; cryptographic
-    per-node identity is deferred to a separate follow-on handoff.
+    WI-2 chains :class:`NodeAuthMiddleware` after
+    :class:`BearerAuthMiddleware`: the outer middleware admits any
+    request bearing a valid token (host-wide or per-node); the inner
+    one resolves that token to a node identity and attaches it to
+    ``request.state.authenticated_node`` so the ACL gate in
+    :func:`node_message_send` enforces "identity cannot be spoofed
+    via a metadata field" (handoff §4 acceptance). The spawn-gate
+    in :func:`agents_start` consumes the same body-``caller`` shape.
+
+    Middleware order matters. Starlette executes the *outermost*
+    ``add_middleware`` call first (it wraps the app last but runs
+    first on the inbound path). So the BearerAuthMiddleware call
+    below comes **last** to make it the outermost layer.
+
+    WI-4 ``local_host`` configures the name this app sees as
+    "itself" so the cross-host forwarder can tell local-vs-remote
+    targets apart. When omitted, falls back to
+    :func:`state_db._resolve_host` (the env + config chain).
     """
     routes: list[Route] = [
         Route("/v1/health", health, methods=["GET"]),
@@ -700,9 +725,13 @@ def create_app(*, token: str) -> Starlette:
     # Per-app shared state for the WI-3 inbox surface.
     app.state.inbox = Broker()
     app.state.nodes = NodeRegistry()
-    # Outer perimeter — host-wide bearer. The limited WI-2 scope
-    # does not add a per-node-identity middleware; sender identity
-    # is the self-claimed ``metadata.from_agent`` field, gated by
-    # :func:`_acl.check_send_acl`.
+    # WI-4 — per-app local host name. May be ``None``; the forwarder
+    # then falls back to the env-based resolver.
+    app.state.local_host = local_host
+    # WI-2 — identity resolution (inner). Reads the same Bearer the
+    # outer middleware already validated; tags ``request.state`` with
+    # the resolved node name (or ``None`` for the host-wide bearer).
+    app.add_middleware(NodeAuthMiddleware, host_bearer=token)
+    # Outer perimeter — admits any valid token, rejects everything else.
     app.add_middleware(BearerAuthMiddleware, token=token)
     return app

--- a/src/scitex_agent_container/_listen/server.py
+++ b/src/scitex_agent_container/_listen/server.py
@@ -43,7 +43,7 @@ from .._state.registry import Registry
 from ..a2a._inbox_bus import mint_event
 from ..config import load_config
 from ..config._resolve import resolve_config
-from ._acl import NodeAuthMiddleware, check_send_acl, deny_response
+from ._acl import check_send_acl, check_spawn, deny_response
 from ._inline_spec import materialize_inline_spec
 from ._nodes import Broker, NodeRegistry
 from .auth import BearerAuthMiddleware
@@ -301,16 +301,28 @@ async def agents_start(request: Request) -> JSONResponse:
     Body shapes:
 
         # Start a pre-registered spec (existing on disk):
-        {"name": "<existing-spec-name>"}
+        {"name": "<existing-spec-name>", "caller": "<sender-name>"}
 
         # Register-and-start an ad-hoc spec in one call:
         {
             "name": "<name>",
+            "caller": "<sender-name>",
             "spec": {"apiVersion": "scitex-agent-container/v3",
                      "kind": "Agent",
                      "spec": {...}},
             "overwrite": false   # optional; default false → 409 on clash
         }
+
+    WI-2 spawn-permission gate (limited scope per lead 2026-05-20):
+    the optional ``caller`` field carries the spawning node's name
+    (same self-claimed-identity caveat as ``message:send``'s
+    ``metadata.from_agent``). The gate is **root-only** today —
+    a node with no parent in the ``lineage`` table may spawn; a
+    child gets a clear 403. ``caller`` omitted = administrative /
+    human-operator path → allowed.
+
+    On allow, the parent → child edge is recorded in ``lineage``
+    so the new agent inherits the spawner's group.
     """
     try:
         body = await request.json()
@@ -324,6 +336,16 @@ async def agents_start(request: Request) -> JSONResponse:
             {"error": "missing or empty 'name' string"}, status_code=400
         )
 
+    # WI-2 spawn-permission gate.
+    caller = body.get("caller")
+    if caller is not None and not isinstance(caller, str):
+        return JSONResponse(
+            {"error": "'caller' must be a string if present"}, status_code=400
+        )
+    decision, reason = check_spawn(caller=caller)
+    if decision == "deny":
+        return deny_response(reason or "spawn denied")
+
     inline_spec = body.get("spec")
     if inline_spec is not None:
         err = materialize_inline_spec(
@@ -331,6 +353,19 @@ async def agents_start(request: Request) -> JSONResponse:
         )
         if err is not None:
             return err
+
+    # Record lineage on allowed-spawn so the new child inherits the
+    # caller's group. ``caller=None`` → no lineage record (admin /
+    # operator path; the new agent starts as a root).
+    if caller:
+        from .._state.state_db_nodes import record_lineage as _record_lineage
+
+        try:
+            _record_lineage(child=name, parent=caller)
+        except ValueError as exc:
+            # Idempotent same-parent re-record is fine; a re-parent
+            # to a different caller is loudly rejected.
+            return JSONResponse({"error": str(exc)}, status_code=409)
 
     sac_bin = shutil.which("sac") or "sac"
     proc = await asyncio.to_thread(
@@ -445,20 +480,23 @@ async def node_message_send(request: Request) -> Response:
     lookup. The publish is **always loud** — a malformed body returns
     400, never a silent drop (handoff §0 Hard rules).
 
-    WI-2 ACL gate: every send is checked by
-    :func:`_acl.check_send_acl` before publish:
+    WI-2 ACL gate (limited scope per lead 2026-05-20): every send
+    is checked by :func:`_acl.check_send_acl` before publish:
 
-    * A per-node bearer pins identity — ``metadata.from_agent`` must
-      match the bearer's resolved name; mismatch → 403.
     * Cross-group is denied by default; intra-group (parent↔child
       and sibling↔sibling) is allowed.
-    * The host-wide bearer is treated as an administrative caller
-      whose ``metadata.from_agent`` is honoured verbatim — the
-      cross-host-forwarding seam (handoff §4 WI-4 prerequisite).
+    * Explicit cross-group grants (``comms_grants`` table) flip
+      a deny to an allow.
+    * Self-send is always allowed.
 
-    Bearer auth (outer perimeter) is still enforced by
-    :class:`BearerAuthMiddleware`; identity resolution is enforced
-    by :class:`NodeAuthMiddleware`.
+    **Identity caveat** — the sender identity is the self-claimed
+    ``metadata.from_agent`` field. Cryptographic per-node identity
+    is deferred to a separate follow-on handoff (related to the
+    sac-accounts-per-agent-credentials-and-rotation FUTURE doc);
+    until then every grant row stores the caveat "trusts
+    metadata.from_agent until per-node creds land". Bearer auth
+    (host-wide token) is still enforced by
+    :class:`BearerAuthMiddleware` as the outer perimeter.
     """
     name = request.path_params["name"]
     try:
@@ -505,16 +543,11 @@ async def node_message_send(request: Request) -> Response:
         if isinstance(src, dict):
             sac_meta.update(src)
 
-    # WI-2 ACL check. ``authenticated_node`` is set by
-    # :class:`NodeAuthMiddleware` — ``None`` means the host-wide
-    # bearer was presented (administrative caller). The check honours
-    # ``metadata.from_agent`` only when no per-node bearer is bound
-    # (or when it matches), so a metadata field cannot spoof identity.
-    authenticated_node = getattr(
-        request.state, "authenticated_node", None
-    )
+    # WI-2 ACL check (limited scope). Gates on the self-claimed
+    # ``metadata.from_agent`` field; cryptographic per-node identity
+    # is deferred. See :func:`_acl.check_send_acl` for the decision
+    # branches and the identity caveat.
     decision, reason = check_send_acl(
-        authenticated_node=authenticated_node,
         claimed_from_agent=sac_meta.get("from_agent"),
         target=name,
     )
@@ -651,17 +684,11 @@ def create_app(*, token: str) -> Starlette:
     members of the comms graph. The state lives on ``app.state`` so
     every handler shares the same broker and registry instance.
 
-    WI-2 chains :class:`NodeAuthMiddleware` after
-    :class:`BearerAuthMiddleware`: the outer middleware admits any
-    request bearing a valid token (host-wide or per-node); the inner
-    one resolves that token to a node identity and attaches it to
-    ``request.state.authenticated_node`` so the ACL gate in
-    :func:`node_message_send` can decide allow / deny.
-
-    Middleware order matters. Starlette executes the *outermost*
-    ``add_middleware`` call first (it wraps the app last but runs
-    first on the inbound path). So the BearerAuthMiddleware call
-    below comes **last** to make it the outermost layer.
+    WI-2 (limited scope per lead 2026-05-20) adds the ACL gate to
+    :func:`node_message_send` and the spawn-permission gate to
+    :func:`agents_start`. Both gate on the self-claimed
+    ``metadata.from_agent`` / body-``caller`` field; cryptographic
+    per-node identity is deferred to a separate follow-on handoff.
     """
     routes: list[Route] = [
         Route("/v1/health", health, methods=["GET"]),
@@ -672,10 +699,9 @@ def create_app(*, token: str) -> Starlette:
     # Per-app shared state for the WI-3 inbox surface.
     app.state.inbox = Broker()
     app.state.nodes = NodeRegistry()
-    # WI-2 — identity resolution (inner). Reads the same Bearer the
-    # outer middleware already validated; tags ``request.state`` with
-    # the resolved node name (or ``None`` for the host-wide bearer).
-    app.add_middleware(NodeAuthMiddleware, host_bearer=token)
-    # Outer perimeter — admits any valid token, rejects everything else.
+    # Outer perimeter — host-wide bearer. The limited WI-2 scope
+    # does not add a per-node-identity middleware; sender identity
+    # is the self-claimed ``metadata.from_agent`` field, gated by
+    # :func:`_acl.check_send_acl`.
     app.add_middleware(BearerAuthMiddleware, token=token)
     return app

--- a/src/scitex_agent_container/_state/state_db.py
+++ b/src/scitex_agent_container/_state/state_db.py
@@ -208,8 +208,18 @@ CREATE INDEX IF NOT EXISTS idx_channel_events_target_undelivered
 CREATE INDEX IF NOT EXISTS idx_channel_events_target_id
     ON channel_events(target, id);
 
--- WI-2 ACL — lineage edges + cross-group grants (handoff §4, limited
--- scope per lead 2026-05-20).
+-- WI-2 ACL — authenticated identity, lineage edges, cross-group grants
+-- (handoff §4; lead 2026-05-21 RESTORED the authenticated-identity
+-- criterion the prior limited scope had deferred).
+--
+-- ``node_tokens`` is the authenticated-identity primitive. Each node
+-- (sac-managed or external) gets a token minted at registration; the
+-- listen server resolves an incoming ``Authorization: Bearer <token>``
+-- to a node name via :class:`_listen._acl.NodeAuthMiddleware`. The
+-- acceptance "identity cannot be spoofed via a metadata field"
+-- (handoff §4) is enforced by ``check_send_acl``: when a per-node
+-- bearer is presented, ``metadata.from_agent`` MUST match the bearer's
+-- resolved name — a mismatch is a 403 with an explicit spoof reason.
 --
 -- ``lineage`` records parent → child edges produced by
 -- ``sac agents start``. A node's *group* (the default-ACL unit) is
@@ -218,13 +228,18 @@ CREATE INDEX IF NOT EXISTS idx_channel_events_target_id
 --
 -- ``comms_grants`` records explicit cross-group send grants. A row
 -- ``(sender, target)`` permits ``sender → target`` even when the
--- two are in different groups. Identity for the ``sender`` column
--- is the self-claimed ``metadata.from_agent`` for now; the
--- cryptographic-identity follow-on (per lead 2026-05-20 deferred to
--- a separate handoff related to sac-accounts) will pin this to an
--- authenticated principal. **Document each grant entry as "trusts
--- metadata.from_agent until per-node creds land"** — this caveat is
--- the gap the follow-on closes.
+-- two are in different groups. With authenticated identity in force,
+-- ``sender`` is the resolved-from-bearer name (administrative caller
+-- path: the host-wide bearer honours ``metadata.from_agent`` verbatim
+-- — used by cross-host forwarders authenticating with the
+-- destination's host bearer pulled from ``peer-tokens/`` registry).
+CREATE TABLE IF NOT EXISTS node_tokens (
+    name        TEXT PRIMARY KEY,
+    token       TEXT NOT NULL UNIQUE,
+    created_at  REAL NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_node_tokens_token ON node_tokens(token);
+
 CREATE TABLE IF NOT EXISTS lineage (
     child_name   TEXT PRIMARY KEY,
     parent_name  TEXT NOT NULL,
@@ -236,7 +251,7 @@ CREATE TABLE IF NOT EXISTS comms_grants (
     sender_name  TEXT NOT NULL,
     target_name  TEXT NOT NULL,
     created_at   REAL NOT NULL,
-    note         TEXT,  -- optional audit caveat ("trusts metadata.from_agent...")
+    note         TEXT,  -- optional audit annotation
     PRIMARY KEY (sender_name, target_name)
 );
 CREATE INDEX IF NOT EXISTS idx_comms_grants_target ON comms_grants(target_name);
@@ -254,6 +269,7 @@ KNOWN_TABLES = (
     "errors",
     "heartbeats",
     "channel_events",
+    "node_tokens",
     "lineage",
     "comms_grants",
 )

--- a/src/scitex_agent_container/_state/state_db.py
+++ b/src/scitex_agent_container/_state/state_db.py
@@ -207,6 +207,33 @@ CREATE INDEX IF NOT EXISTS idx_channel_events_target_undelivered
     ON channel_events(target, id) WHERE delivered_at IS NULL;
 CREATE INDEX IF NOT EXISTS idx_channel_events_target_id
     ON channel_events(target, id);
+
+-- WI-2 ACL — per-node bearer tokens + lineage edges (handoff §4).
+--
+-- ``node_tokens`` is the authenticated-identity primitive. Each node
+-- (sac-managed or external) gets a token minted at registration; the
+-- server resolves an incoming ``Authorization: Bearer <token>`` to a
+-- node name. Without this table the only available identity is the
+-- self-claimed ``metadata.from_agent`` field — exactly what the
+-- handoff forbids ("Do not gate on an unauthenticated string").
+--
+-- ``lineage`` records parent → child edges produced by
+-- ``sac agents start``. A node's *group* (the default-ACL unit) is
+-- derived from lineage: parent + parent's direct children. Schema
+-- stays N-level capable — see derive_group() for the traversal.
+CREATE TABLE IF NOT EXISTS node_tokens (
+    name        TEXT PRIMARY KEY,
+    token       TEXT NOT NULL UNIQUE,
+    created_at  REAL NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_node_tokens_token ON node_tokens(token);
+
+CREATE TABLE IF NOT EXISTS lineage (
+    child_name   TEXT PRIMARY KEY,
+    parent_name  TEXT NOT NULL,
+    created_at   REAL NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_lineage_parent ON lineage(parent_name);
 """
 
 # Tables exposed by `sac db query --table=<t>`. Whitelisted so users
@@ -221,6 +248,8 @@ KNOWN_TABLES = (
     "errors",
     "heartbeats",
     "channel_events",
+    "node_tokens",
+    "lineage",
 )
 
 

--- a/src/scitex_agent_container/_state/state_db.py
+++ b/src/scitex_agent_container/_state/state_db.py
@@ -208,32 +208,38 @@ CREATE INDEX IF NOT EXISTS idx_channel_events_target_undelivered
 CREATE INDEX IF NOT EXISTS idx_channel_events_target_id
     ON channel_events(target, id);
 
--- WI-2 ACL — per-node bearer tokens + lineage edges (handoff §4).
---
--- ``node_tokens`` is the authenticated-identity primitive. Each node
--- (sac-managed or external) gets a token minted at registration; the
--- server resolves an incoming ``Authorization: Bearer <token>`` to a
--- node name. Without this table the only available identity is the
--- self-claimed ``metadata.from_agent`` field — exactly what the
--- handoff forbids ("Do not gate on an unauthenticated string").
+-- WI-2 ACL — lineage edges + cross-group grants (handoff §4, limited
+-- scope per lead 2026-05-20).
 --
 -- ``lineage`` records parent → child edges produced by
 -- ``sac agents start``. A node's *group* (the default-ACL unit) is
 -- derived from lineage: parent + parent's direct children. Schema
 -- stays N-level capable — see derive_group() for the traversal.
-CREATE TABLE IF NOT EXISTS node_tokens (
-    name        TEXT PRIMARY KEY,
-    token       TEXT NOT NULL UNIQUE,
-    created_at  REAL NOT NULL
-);
-CREATE INDEX IF NOT EXISTS idx_node_tokens_token ON node_tokens(token);
-
+--
+-- ``comms_grants`` records explicit cross-group send grants. A row
+-- ``(sender, target)`` permits ``sender → target`` even when the
+-- two are in different groups. Identity for the ``sender`` column
+-- is the self-claimed ``metadata.from_agent`` for now; the
+-- cryptographic-identity follow-on (per lead 2026-05-20 deferred to
+-- a separate handoff related to sac-accounts) will pin this to an
+-- authenticated principal. **Document each grant entry as "trusts
+-- metadata.from_agent until per-node creds land"** — this caveat is
+-- the gap the follow-on closes.
 CREATE TABLE IF NOT EXISTS lineage (
     child_name   TEXT PRIMARY KEY,
     parent_name  TEXT NOT NULL,
     created_at   REAL NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_lineage_parent ON lineage(parent_name);
+
+CREATE TABLE IF NOT EXISTS comms_grants (
+    sender_name  TEXT NOT NULL,
+    target_name  TEXT NOT NULL,
+    created_at   REAL NOT NULL,
+    note         TEXT,  -- optional audit caveat ("trusts metadata.from_agent...")
+    PRIMARY KEY (sender_name, target_name)
+);
+CREATE INDEX IF NOT EXISTS idx_comms_grants_target ON comms_grants(target_name);
 """
 
 # Tables exposed by `sac db query --table=<t>`. Whitelisted so users
@@ -248,8 +254,8 @@ KNOWN_TABLES = (
     "errors",
     "heartbeats",
     "channel_events",
-    "node_tokens",
     "lineage",
+    "comms_grants",
 )
 
 

--- a/src/scitex_agent_container/_state/state_db_export.py
+++ b/src/scitex_agent_container/_state/state_db_export.py
@@ -67,6 +67,10 @@ def _table_filter_clauses(
         "attempts": ("WHERE ts >= ?", (since,)),
         "turns": ("WHERE ts >= ?", (since,)),
         "errors": ("WHERE ts >= ?", (since,)),
+        # WI-2 ACL tables — ``created_at`` is the row-mint time.
+        "node_tokens": ("WHERE created_at >= ?", (since,)),
+        "lineage": ("WHERE created_at >= ?", (since,)),
+        "comms_grants": ("WHERE created_at >= ?", (since,)),
     }
     return {t: explicit.get(t, ("WHERE ts >= ?", (since,))) for t in known_tables}
 

--- a/src/scitex_agent_container/_state/state_db_nodes.py
+++ b/src/scitex_agent_container/_state/state_db_nodes.py
@@ -1,0 +1,216 @@
+"""Per-node tokens + lineage primitives for WI-2 ACL.
+
+The handoff (``HANDOFF_AGENT_COMMS_2026-05-19.md`` §4 / WI-2) requires:
+
+  > Authenticated sender identity. The ACL check is only as strong
+  > as the identity — the sender identity carried in
+  > ``params.metadata`` must be authenticated (per-node credential /
+  > bearer token), never a self-claimed name. **Do not gate on an
+  > unauthenticated string.**
+
+and:
+
+  > Group-based default ACL. ... The group is derived from lineage —
+  > no per-pair config for the common case.
+
+This module supplies the two state.db primitives that satisfy both
+requirements:
+
+* :func:`mint_node_token` / :func:`resolve_node_token` —
+  authenticated identity. Each node (sac-managed or external) gets a
+  bearer token at registration; the listen server resolves an
+  incoming ``Authorization: Bearer <token>`` to a node name via
+  ``resolve_node_token``.
+
+* :func:`record_lineage` / :func:`derive_group` — lineage and group
+  derivation. ``record_lineage(child, parent)`` is called by
+  ``sac agents start``; ``derive_group(name)`` returns the set of
+  nodes inside the same default-ACL bubble (parent + direct
+  children).
+
+Both pieces stay N-level capable per handoff §2 D5 ("Depth limit is
+a POLICY, not a structural ceiling"). The two-level cap currently in
+force is a separate policy gate, NOT enforced by these primitives.
+
+All times stored as ``REAL`` unix-seconds (float). Matches the diary
+tables.
+"""
+
+from __future__ import annotations
+
+import secrets
+import time
+from pathlib import Path
+from typing import Any
+
+__all__ = [
+    "derive_group",
+    "list_node_tokens",
+    "mint_node_token",
+    "record_lineage",
+    "resolve_node_token",
+]
+
+
+# 256 bits of entropy. URL-safe base64 → ~43 chars; comfortably above
+# the 32-char floor the tests assert against.
+_TOKEN_BYTES = 32
+
+
+def mint_node_token(*, name: str, db_path: Path | None = None) -> str:
+    """Return the bearer token for ``name``, minting one if absent.
+
+    Idempotent: re-registration returns the existing token rather
+    than rotating, so an active agent's ``Authorization: Bearer ...``
+    header keeps working across a re-register. Rotation, when needed,
+    is a separate operation (not implemented here).
+
+    Raises if ``name`` is empty.
+    """
+    if not name:
+        raise ValueError("mint_node_token: name must be non-empty")
+    from .state_db import open_db
+
+    with open_db(db_path) as conn:
+        existing = conn.execute(
+            "SELECT token FROM node_tokens WHERE name = ?", (name,)
+        ).fetchone()
+        if existing is not None:
+            return str(existing["token"])
+        token = secrets.token_urlsafe(_TOKEN_BYTES)
+        now = time.time()
+        conn.execute(
+            "INSERT INTO node_tokens (name, token, created_at) VALUES (?, ?, ?)",
+            (name, token, now),
+        )
+    return token
+
+
+def resolve_node_token(*, token: str, db_path: Path | None = None) -> str | None:
+    """Map a bearer token back to a node name; ``None`` if unknown.
+
+    Returns ``None`` for an empty token rather than treating it as a
+    valid lookup — the listen server's middleware already rejects
+    requests with no Authorization header, but defence-in-depth means
+    we never resolve ``""`` to a real identity.
+    """
+    if not token:
+        return None
+    from .state_db import open_db
+
+    with open_db(db_path) as conn:
+        row = conn.execute(
+            "SELECT name FROM node_tokens WHERE token = ?", (token,)
+        ).fetchone()
+    if row is None:
+        return None
+    return str(row["name"])
+
+
+def record_lineage(
+    *,
+    child: str,
+    parent: str,
+    db_path: Path | None = None,
+) -> None:
+    """Record ``parent`` as the parent of ``child``.
+
+    Idempotent — a second call with the same child+parent leaves the
+    row untouched. A different parent for an existing child raises
+    ``ValueError`` (re-parenting is not a quiet operation; a child
+    that "switches groups" is exactly the kind of identity drift the
+    ACL is meant to prevent).
+    """
+    if not child or not parent:
+        raise ValueError("record_lineage: child and parent must be non-empty")
+    from .state_db import open_db
+
+    with open_db(db_path) as conn:
+        existing = conn.execute(
+            "SELECT parent_name FROM lineage WHERE child_name = ?", (child,)
+        ).fetchone()
+        if existing is not None:
+            if existing["parent_name"] == parent:
+                return  # idempotent no-op
+            raise ValueError(
+                f"record_lineage: child {child!r} already has parent "
+                f"{existing['parent_name']!r}; refusing to re-parent to "
+                f"{parent!r}"
+            )
+        conn.execute(
+            "INSERT INTO lineage (child_name, parent_name, created_at) "
+            "VALUES (?, ?, ?)",
+            (child, parent, time.time()),
+        )
+
+
+def derive_group(
+    *,
+    name: str,
+    db_path: Path | None = None,
+) -> set[str]:
+    """Return the set of nodes inside ``name``'s default-ACL group.
+
+    A *group* is a parent together with its direct children
+    (handoff §2). Concretely:
+
+    * If ``name`` is a parent (any rows in ``lineage`` with
+      ``parent_name = name``): group = {name} ∪ {its direct children}.
+    * If ``name`` is a child (row in ``lineage`` with
+      ``child_name = name``): group = {its parent} ∪ {parent's other
+      children}.
+    * If ``name`` has no edges at all: group = {name} (singleton —
+      a fresh registration starts unattached).
+
+    The derivation is intentionally local — it never walks the
+    full lineage tree. That keeps the default-ACL semantics simple
+    and matches handoff §2: "the group is the unit of default ACL"
+    (one parent + its direct children, not the entire ancestry).
+    """
+    if not name:
+        raise ValueError("derive_group: name must be non-empty")
+    from .state_db import open_db
+
+    with open_db(db_path) as conn:
+        # Is ``name`` a parent?
+        children_rows = conn.execute(
+            "SELECT child_name FROM lineage WHERE parent_name = ?", (name,)
+        ).fetchall()
+        if children_rows:
+            group: set[str] = {name}
+            for r in children_rows:
+                group.add(str(r["child_name"]))
+            return group
+        # Is ``name`` a child?
+        parent_row = conn.execute(
+            "SELECT parent_name FROM lineage WHERE child_name = ?", (name,)
+        ).fetchone()
+        if parent_row is None:
+            return {name}
+        parent = str(parent_row["parent_name"])
+        sibling_rows = conn.execute(
+            "SELECT child_name FROM lineage WHERE parent_name = ?", (parent,)
+        ).fetchall()
+        group = {parent}
+        for r in sibling_rows:
+            group.add(str(r["child_name"]))
+        return group
+
+
+def list_node_tokens(db_path: Path | None = None) -> list[dict[str, Any]]:
+    """Return ``[{name, created_at}, ...]`` over every minted token.
+
+    Observability surface for the host operator (``sac db query
+    --table=node_tokens`` already exists via the generic table-walker;
+    this helper is a typed-API alias). The token value itself is
+    deliberately NOT returned — that would defeat the purpose of
+    storing it as a secret.
+    """
+    from .state_db import open_db
+
+    with open_db(db_path) as conn:
+        cur = conn.execute(
+            "SELECT name, created_at FROM node_tokens ORDER BY name ASC"
+        )
+        return [{"name": str(r["name"]), "created_at": float(r["created_at"])}
+                for r in cur.fetchall()]

--- a/src/scitex_agent_container/_state/state_db_nodes.py
+++ b/src/scitex_agent_container/_state/state_db_nodes.py
@@ -1,110 +1,53 @@
-"""Per-node tokens + lineage primitives for WI-2 ACL.
+"""Lineage + ACL-grant primitives for WI-2 ACL (limited scope).
 
-The handoff (``HANDOFF_AGENT_COMMS_2026-05-19.md`` §4 / WI-2) requires:
+Per HANDOFF_AGENT_COMMS_2026-05-19.md §4 (WI-2) and the lead's
+2026-05-20 directive (limited scope — defer authenticated identity):
 
-  > Authenticated sender identity. The ACL check is only as strong
-  > as the identity — the sender identity carried in
-  > ``params.metadata`` must be authenticated (per-node credential /
-  > bearer token), never a self-claimed name. **Do not gate on an
-  > unauthenticated string.**
+  * Group-based default ACL — intra-group bidirectional, cross-group
+    denied. Group is *derived from lineage*; see
+    :func:`derive_group`.
 
-and:
+  * Cross-group grants — accepted, keyed on the self-claimed
+    ``metadata.from_agent`` field, **with the caveat that each row
+    "trusts metadata.from_agent until per-node creds land"**. The
+    cryptographic-identity follow-on is tracked separately (related
+    to the existing sac-accounts-per-agent-credentials-and-rotation
+    FUTURE doc).
 
-  > Group-based default ACL. ... The group is derived from lineage —
-  > no per-pair config for the common case.
+  * Spawn permission — root-only by current policy (a node with no
+    parent may call ``sac agents start``; a child may not). The
+    policy is **lift-able**: lifting it later is a single-callsite
+    edit to :func:`spawn_allowed` with zero schema change (handoff
+    §2 D5 "Depth limit is a POLICY, not a structural ceiling").
 
-This module supplies the two state.db primitives that satisfy both
-requirements:
+The N-level structural capability of ``lineage`` is preserved —
+nothing here hard-codes "2" or assumes fixed depth.
 
-* :func:`mint_node_token` / :func:`resolve_node_token` —
-  authenticated identity. Each node (sac-managed or external) gets a
-  bearer token at registration; the listen server resolves an
-  incoming ``Authorization: Bearer <token>`` to a node name via
-  ``resolve_node_token``.
-
-* :func:`record_lineage` / :func:`derive_group` — lineage and group
-  derivation. ``record_lineage(child, parent)`` is called by
-  ``sac agents start``; ``derive_group(name)`` returns the set of
-  nodes inside the same default-ACL bubble (parent + direct
-  children).
-
-Both pieces stay N-level capable per handoff §2 D5 ("Depth limit is
-a POLICY, not a structural ceiling"). The two-level cap currently in
-force is a separate policy gate, NOT enforced by these primitives.
-
-All times stored as ``REAL`` unix-seconds (float). Matches the diary
-tables.
+All times stored as ``REAL`` unix-seconds (float).
 """
 
 from __future__ import annotations
 
-import secrets
 import time
 from pathlib import Path
 from typing import Any
 
 __all__ = [
     "derive_group",
-    "list_node_tokens",
-    "mint_node_token",
+    "grant_send",
+    "has_grant",
+    "is_local_node",
+    "list_comms_grants",
     "record_lineage",
-    "resolve_node_token",
+    "resolve_node_host",
+    "revoke_send",
+    "spawn_allowed",
 ]
 
 
-# 256 bits of entropy. URL-safe base64 → ~43 chars; comfortably above
-# the 32-char floor the tests assert against.
-_TOKEN_BYTES = 32
-
-
-def mint_node_token(*, name: str, db_path: Path | None = None) -> str:
-    """Return the bearer token for ``name``, minting one if absent.
-
-    Idempotent: re-registration returns the existing token rather
-    than rotating, so an active agent's ``Authorization: Bearer ...``
-    header keeps working across a re-register. Rotation, when needed,
-    is a separate operation (not implemented here).
-
-    Raises if ``name`` is empty.
-    """
-    if not name:
-        raise ValueError("mint_node_token: name must be non-empty")
-    from .state_db import open_db
-
-    with open_db(db_path) as conn:
-        existing = conn.execute(
-            "SELECT token FROM node_tokens WHERE name = ?", (name,)
-        ).fetchone()
-        if existing is not None:
-            return str(existing["token"])
-        token = secrets.token_urlsafe(_TOKEN_BYTES)
-        now = time.time()
-        conn.execute(
-            "INSERT INTO node_tokens (name, token, created_at) VALUES (?, ?, ?)",
-            (name, token, now),
-        )
-    return token
-
-
-def resolve_node_token(*, token: str, db_path: Path | None = None) -> str | None:
-    """Map a bearer token back to a node name; ``None`` if unknown.
-
-    Returns ``None`` for an empty token rather than treating it as a
-    valid lookup — the listen server's middleware already rejects
-    requests with no Authorization header, but defence-in-depth means
-    we never resolve ``""`` to a real identity.
-    """
-    if not token:
-        return None
-    from .state_db import open_db
-
-    with open_db(db_path) as conn:
-        row = conn.execute(
-            "SELECT name FROM node_tokens WHERE token = ?", (token,)
-        ).fetchone()
-    if row is None:
-        return None
-    return str(row["name"])
+# ---------------------------------------------------------------------------
+# lineage — parent → child edges and the group they imply
+# ---------------------------------------------------------------------------
 
 
 def record_lineage(
@@ -162,17 +105,16 @@ def derive_group(
     * If ``name`` has no edges at all: group = {name} (singleton —
       a fresh registration starts unattached).
 
-    The derivation is intentionally local — it never walks the
-    full lineage tree. That keeps the default-ACL semantics simple
-    and matches handoff §2: "the group is the unit of default ACL"
-    (one parent + its direct children, not the entire ancestry).
+    The derivation is intentionally local — it never walks the full
+    lineage tree. That keeps the default-ACL semantics simple and
+    matches handoff §2: "the group is the unit of default ACL" (one
+    parent + its direct children, not the entire ancestry).
     """
     if not name:
         raise ValueError("derive_group: name must be non-empty")
     from .state_db import open_db
 
     with open_db(db_path) as conn:
-        # Is ``name`` a parent?
         children_rows = conn.execute(
             "SELECT child_name FROM lineage WHERE parent_name = ?", (name,)
         ).fetchall()
@@ -181,7 +123,6 @@ def derive_group(
             for r in children_rows:
                 group.add(str(r["child_name"]))
             return group
-        # Is ``name`` a child?
         parent_row = conn.execute(
             "SELECT parent_name FROM lineage WHERE child_name = ?", (name,)
         ).fetchone()
@@ -197,20 +138,225 @@ def derive_group(
         return group
 
 
-def list_node_tokens(db_path: Path | None = None) -> list[dict[str, Any]]:
-    """Return ``[{name, created_at}, ...]`` over every minted token.
+# ---------------------------------------------------------------------------
+# spawn permission — current policy: root-only spawn
+# ---------------------------------------------------------------------------
 
-    Observability surface for the host operator (``sac db query
-    --table=node_tokens`` already exists via the generic table-walker;
-    this helper is a typed-API alias). The token value itself is
-    deliberately NOT returned — that would defeat the purpose of
-    storing it as a secret.
+
+def spawn_allowed(
+    *,
+    caller: str | None,
+    db_path: Path | None = None,
+) -> tuple[bool, str | None]:
+    """Decide whether ``caller`` is allowed to call ``sac agents start``.
+
+    Current policy (handoff §4 / WI-2): a *root* node (no parent) is
+    allowed to spawn; a child is not. ``caller=None`` means the
+    administrative / human-operator path (e.g., a shell invocation
+    from outside any sac-managed agent) — allowed.
+
+    Returns ``(True, None)`` on allow or ``(False, reason)`` on
+    deny. The reason is suitable for inclusion in a 403 body and a
+    host log line.
+
+    **Lift-able policy**: when N-level spawning becomes acceptable
+    (handoff §2 D5), this function shrinks to ``return (True, None)``
+    — zero schema change, zero data migration.
+    """
+    if caller is None or caller == "":
+        # Admin / human operator. Allowed.
+        return (True, None)
+    from .state_db import open_db
+
+    with open_db(db_path) as conn:
+        parent_row = conn.execute(
+            "SELECT parent_name FROM lineage WHERE child_name = ?", (caller,)
+        ).fetchone()
+    if parent_row is None:
+        return (True, None)  # caller has no parent → root → allow
+    return (
+        False,
+        (
+            f"spawn denied: caller {caller!r} is a child of "
+            f"{parent_row['parent_name']!r}. Current policy allows only "
+            "root nodes to spawn (handoff §4 'lift-able policy' — change "
+            "is a single edit to spawn_allowed())."
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# comms_grants — explicit cross-group send permissions
+# ---------------------------------------------------------------------------
+
+# Standard audit caveat written into every grant row. The follow-on
+# work item (per lead 2026-05-20) will close this gap.
+GRANT_DEFERRED_CAVEAT = "trusts metadata.from_agent until per-node creds land"
+
+
+def grant_send(
+    *,
+    sender: str,
+    target: str,
+    db_path: Path | None = None,
+    note: str | None = None,
+) -> None:
+    """Insert (or refresh) a cross-group grant ``sender → target``.
+
+    Idempotent — re-granting the same pair leaves the row untouched
+    (timestamp not bumped). The ``note`` defaults to the standard
+    deferred-identity caveat so every grant carries the audit trail
+    the follow-on cryptographic-identity work item will close.
+    """
+    if not sender or not target:
+        raise ValueError("grant_send: sender and target must be non-empty")
+    from .state_db import open_db
+
+    with open_db(db_path) as conn:
+        existing = conn.execute(
+            "SELECT 1 FROM comms_grants "
+            "WHERE sender_name = ? AND target_name = ?",
+            (sender, target),
+        ).fetchone()
+        if existing is not None:
+            return
+        conn.execute(
+            "INSERT INTO comms_grants "
+            "(sender_name, target_name, created_at, note) "
+            "VALUES (?, ?, ?, ?)",
+            (sender, target, time.time(), note or GRANT_DEFERRED_CAVEAT),
+        )
+
+
+def revoke_send(
+    *,
+    sender: str,
+    target: str,
+    db_path: Path | None = None,
+) -> bool:
+    """Remove a ``sender → target`` grant. Returns ``True`` iff a row
+    was removed."""
+    if not sender or not target:
+        return False
+    from .state_db import open_db
+
+    with open_db(db_path) as conn:
+        cur = conn.execute(
+            "DELETE FROM comms_grants "
+            "WHERE sender_name = ? AND target_name = ?",
+            (sender, target),
+        )
+    return cur.rowcount > 0
+
+
+def has_grant(
+    *,
+    sender: str,
+    target: str,
+    db_path: Path | None = None,
+) -> bool:
+    """Return ``True`` iff a ``sender → target`` cross-group grant
+    exists."""
+    if not sender or not target:
+        return False
+    from .state_db import open_db
+
+    with open_db(db_path) as conn:
+        row = conn.execute(
+            "SELECT 1 FROM comms_grants "
+            "WHERE sender_name = ? AND target_name = ?",
+            (sender, target),
+        ).fetchone()
+    return row is not None
+
+
+def list_comms_grants(
+    db_path: Path | None = None,
+) -> list[dict[str, Any]]:
+    """Return every grant row in insertion order.
+
+    Observability surface for the host operator. Each row carries the
+    audit ``note`` (default: the deferred-identity caveat).
     """
     from .state_db import open_db
 
     with open_db(db_path) as conn:
         cur = conn.execute(
-            "SELECT name, created_at FROM node_tokens ORDER BY name ASC"
+            "SELECT sender_name, target_name, created_at, note "
+            "FROM comms_grants "
+            "ORDER BY created_at ASC, sender_name ASC, target_name ASC"
         )
-        return [{"name": str(r["name"]), "created_at": float(r["created_at"])}
-                for r in cur.fetchall()]
+        return [
+            {
+                "sender": str(r["sender_name"]),
+                "target": str(r["target_name"]),
+                "created_at": float(r["created_at"]),
+                "note": (r["note"] if r["note"] is not None else None),
+            }
+            for r in cur.fetchall()
+        ]
+
+
+# ---------------------------------------------------------------------------
+# WI-4 — name → host resolver primitives. Kept here (rather than
+# splitting into a sibling module) because the cross-host forwarder
+# consults both the resolver and the ACL primitives from this module.
+# ---------------------------------------------------------------------------
+
+
+def resolve_node_host(
+    *,
+    name: str,
+    db_path: Path | None = None,
+) -> dict[str, Any] | None:
+    """Map a node ``name`` to ``{host, a2a_port}`` from the
+    ``instances`` table.
+
+    Returns ``None`` when the name does not match a *live* instance
+    (``ended_at IS NULL``). When several live records exist for the
+    same name (e.g., a restart race), the most recently started one
+    wins — cross-host forwarding cannot pick non-deterministically.
+    """
+    if not name:
+        return None
+    from .state_db import open_db
+
+    with open_db(db_path) as conn:
+        row = conn.execute(
+            """
+            SELECT host, a2a_port
+              FROM instances
+             WHERE name = ? AND ended_at IS NULL
+             ORDER BY started_at DESC, id DESC
+             LIMIT 1
+            """,
+            (name,),
+        ).fetchone()
+    if row is None:
+        return None
+    return {
+        "host": str(row["host"]),
+        "a2a_port": int(row["a2a_port"]) if row["a2a_port"] is not None else None,
+    }
+
+
+def is_local_node(
+    *,
+    name: str,
+    local_host: str,
+    db_path: Path | None = None,
+) -> bool:
+    """Return ``True`` if ``name`` should be served locally.
+
+    Local cases:
+
+    * The name resolves to ``local_host`` via :func:`resolve_node_host`.
+    * The name does NOT resolve to any host (unknown / external node) —
+      defer to the local ``NodeRegistry`` implicit-registration path.
+      Forwarding a never-seen name would synthesise an SSRF target
+      from a self-claimed string; the host-local path is correct.
+    """
+    info = resolve_node_host(name=name, db_path=db_path)
+    if info is None:
+        return True
+    return info["host"] == local_host

--- a/src/scitex_agent_container/_state/state_db_nodes.py
+++ b/src/scitex_agent_container/_state/state_db_nodes.py
@@ -10,9 +10,8 @@ Per HANDOFF_AGENT_COMMS_2026-05-19.md §4 (WI-2) and the lead's
   * Cross-group grants — accepted, keyed on the self-claimed
     ``metadata.from_agent`` field, **with the caveat that each row
     "trusts metadata.from_agent until per-node creds land"**. The
-    cryptographic-identity follow-on is tracked separately (related
-    to the existing sac-accounts-per-agent-credentials-and-rotation
-    FUTURE doc).
+    cryptographic-identity follow-on is tracked in scitex-lead at
+    ``GITIGNORED/FUTURE/sac-per-node-authenticated-acl.md``.
 
   * Spawn permission — root-only by current policy (a node with no
     parent may call ``sac agents start``; a child may not). The

--- a/src/scitex_agent_container/_state/state_db_nodes.py
+++ b/src/scitex_agent_container/_state/state_db_nodes.py
@@ -1,20 +1,30 @@
-"""Lineage + ACL-grant primitives for WI-2 ACL (limited scope).
+"""Node-identity primitives for WI-2 ACL.
 
 Per HANDOFF_AGENT_COMMS_2026-05-19.md §4 (WI-2) and the lead's
-2026-05-20 directive (limited scope — defer authenticated identity):
+2026-05-21 directive (RESTORED the authenticated-identity criterion
+the prior limited scope had deferred):
 
-  * Group-based default ACL — intra-group bidirectional, cross-group
-    denied. Group is *derived from lineage*; see
+  * **Authenticated identity** — per-node bearer tokens minted at
+    registration (:func:`mint_node_token`). The listen server resolves
+    an incoming ``Authorization: Bearer <token>`` to a node name
+    (:func:`resolve_node_token`). With this in place,
+    ``check_send_acl`` enforces "identity cannot be spoofed via a
+    metadata field" — when a per-node bearer is presented,
+    ``params.metadata.from_agent`` MUST match the bearer's resolved
+    name; mismatch → 403.
+
+  * **Group-based default ACL** — intra-group bidirectional,
+    cross-group denied. Group is *derived from lineage*; see
     :func:`derive_group`.
 
-  * Cross-group grants — accepted, keyed on the self-claimed
-    ``metadata.from_agent`` field, **with the caveat that each row
-    "trusts metadata.from_agent until per-node creds land"**. The
-    cryptographic-identity follow-on is tracked in scitex-lead at
-    ``GITIGNORED/FUTURE/sac-per-node-authenticated-acl.md``.
+  * **Cross-group grants** — accepted, keyed on the *resolved*
+    sender identity (per-node bearer authenticates the sender; the
+    host-wide bearer is the administrative / cross-host-forwarder
+    path, which honours ``metadata.from_agent`` verbatim). See
+    :func:`grant_send`.
 
-  * Spawn permission — root-only by current policy (a node with no
-    parent may call ``sac agents start``; a child may not). The
+  * **Spawn permission** — root-only by current policy (a node with
+    no parent may call ``sac agents start``; a child may not). The
     policy is **lift-able**: lifting it later is a single-callsite
     edit to :func:`spawn_allowed` with zero schema change (handoff
     §2 D5 "Depth limit is a POLICY, not a structural ceiling").
@@ -27,6 +37,7 @@ All times stored as ``REAL`` unix-seconds (float).
 
 from __future__ import annotations
 
+import secrets
 import time
 from pathlib import Path
 from typing import Any
@@ -37,11 +48,96 @@ __all__ = [
     "has_grant",
     "is_local_node",
     "list_comms_grants",
+    "list_node_tokens",
+    "mint_node_token",
     "record_lineage",
     "resolve_node_host",
+    "resolve_node_token",
     "revoke_send",
     "spawn_allowed",
 ]
+
+
+# ---------------------------------------------------------------------------
+# node_tokens — authenticated identity (handoff §4 acceptance: "identity
+# cannot be spoofed via a metadata field")
+# ---------------------------------------------------------------------------
+
+# 256 bits of entropy. URL-safe base64 → ~43 chars.
+_TOKEN_BYTES = 32
+
+
+def mint_node_token(*, name: str, db_path: Path | None = None) -> str:
+    """Return the bearer token for ``name``, minting one if absent.
+
+    Idempotent: re-registration returns the existing token rather
+    than rotating, so an active agent's ``Authorization: Bearer ...``
+    header keeps working across a re-register. Rotation, when needed,
+    is a separate operation (not implemented here).
+
+    Raises ``ValueError`` if ``name`` is empty.
+    """
+    if not name:
+        raise ValueError("mint_node_token: name must be non-empty")
+    from .state_db import open_db
+
+    with open_db(db_path) as conn:
+        existing = conn.execute(
+            "SELECT token FROM node_tokens WHERE name = ?", (name,)
+        ).fetchone()
+        if existing is not None:
+            return str(existing["token"])
+        token = secrets.token_urlsafe(_TOKEN_BYTES)
+        now = time.time()
+        conn.execute(
+            "INSERT INTO node_tokens (name, token, created_at) "
+            "VALUES (?, ?, ?)",
+            (name, token, now),
+        )
+    return token
+
+
+def resolve_node_token(
+    *,
+    token: str,
+    db_path: Path | None = None,
+) -> str | None:
+    """Map a bearer token back to a node name; ``None`` if unknown.
+
+    Returns ``None`` for an empty token (defence-in-depth — the
+    middleware already rejects requests with no Authorization
+    header, but we never resolve ``""`` to a real identity).
+    """
+    if not token:
+        return None
+    from .state_db import open_db
+
+    with open_db(db_path) as conn:
+        row = conn.execute(
+            "SELECT name FROM node_tokens WHERE token = ?", (token,)
+        ).fetchone()
+    if row is None:
+        return None
+    return str(row["name"])
+
+
+def list_node_tokens(db_path: Path | None = None) -> list[dict[str, Any]]:
+    """Return ``[{name, created_at}, ...]`` over every minted token.
+
+    Observability surface for the host operator. The token value
+    itself is deliberately NOT returned — that would defeat the
+    purpose of storing it as a secret.
+    """
+    from .state_db import open_db
+
+    with open_db(db_path) as conn:
+        cur = conn.execute(
+            "SELECT name, created_at FROM node_tokens ORDER BY name ASC"
+        )
+        return [
+            {"name": str(r["name"]), "created_at": float(r["created_at"])}
+            for r in cur.fetchall()
+        ]
 
 
 # ---------------------------------------------------------------------------
@@ -188,10 +284,6 @@ def spawn_allowed(
 # comms_grants — explicit cross-group send permissions
 # ---------------------------------------------------------------------------
 
-# Standard audit caveat written into every grant row. The follow-on
-# work item (per lead 2026-05-20) will close this gap.
-GRANT_DEFERRED_CAVEAT = "trusts metadata.from_agent until per-node creds land"
-
 
 def grant_send(
     *,
@@ -203,9 +295,10 @@ def grant_send(
     """Insert (or refresh) a cross-group grant ``sender → target``.
 
     Idempotent — re-granting the same pair leaves the row untouched
-    (timestamp not bumped). The ``note`` defaults to the standard
-    deferred-identity caveat so every grant carries the audit trail
-    the follow-on cryptographic-identity work item will close.
+    (timestamp not bumped). The ``sender`` identity is authenticated
+    by :class:`_listen._acl.NodeAuthMiddleware` resolving the bearer;
+    the optional ``note`` is a free-form audit annotation (e.g. the
+    ticket / handoff that authorised the grant).
     """
     if not sender or not target:
         raise ValueError("grant_send: sender and target must be non-empty")
@@ -223,7 +316,7 @@ def grant_send(
             "INSERT INTO comms_grants "
             "(sender_name, target_name, created_at, note) "
             "VALUES (?, ?, ?, ?)",
-            (sender, target, time.time(), note or GRANT_DEFERRED_CAVEAT),
+            (sender, target, time.time(), note),
         )
 
 

--- a/tests/scitex_agent_container/_listen/test__acl.py
+++ b/tests/scitex_agent_container/_listen/test__acl.py
@@ -34,6 +34,7 @@ from scitex_agent_container._state import state_db
 from scitex_agent_container._state import registry as _reg
 from scitex_agent_container._state.state_db_nodes import (
     grant_send,
+    mint_node_token,
     record_lineage,
 )
 
@@ -69,7 +70,10 @@ def test_acl_allows_self_send(db_path: Path) -> None:
     sender = "alice"
     # Act
     decision, _reason = check_send_acl(
-        claimed_from_agent=sender, target="alice", db_path=db_path
+        authenticated_node=sender,
+        claimed_from_agent=sender,
+        target="alice",
+        db_path=db_path,
     )
     # Assert
     assert decision == "allow"
@@ -80,7 +84,10 @@ def test_acl_allows_intra_group_parent_to_child(db_path: Path) -> None:
     record_lineage(child="worker-a", parent="root", db_path=db_path)
     # Act
     decision, _reason = check_send_acl(
-        claimed_from_agent="root", target="worker-a", db_path=db_path
+        authenticated_node="root",
+        claimed_from_agent="root",
+        target="worker-a",
+        db_path=db_path,
     )
     # Assert
     assert decision == "allow"
@@ -93,7 +100,10 @@ def test_acl_allows_intra_group_sibling_to_sibling(db_path: Path) -> None:
     record_lineage(child="worker-b", parent="root", db_path=db_path)
     # Act
     decision, _reason = check_send_acl(
-        claimed_from_agent="worker-a", target="worker-b", db_path=db_path
+        authenticated_node="worker-a",
+        claimed_from_agent="worker-a",
+        target="worker-b",
+        db_path=db_path,
     )
     # Assert
     assert decision == "allow"
@@ -105,7 +115,10 @@ def test_acl_denies_cross_group_without_grant(db_path: Path) -> None:
     record_lineage(child="child-2", parent="root-2", db_path=db_path)
     # Act
     decision, _reason = check_send_acl(
-        claimed_from_agent="child-1", target="child-2", db_path=db_path
+        authenticated_node="child-1",
+        claimed_from_agent="child-1",
+        target="child-2",
+        db_path=db_path,
     )
     # Assert
     assert decision == "deny"
@@ -117,7 +130,10 @@ def test_acl_deny_carries_explanatory_reason(db_path: Path) -> None:
     record_lineage(child="child-2", parent="root-2", db_path=db_path)
     # Act
     _decision, reason = check_send_acl(
-        claimed_from_agent="child-1", target="child-2", db_path=db_path
+        authenticated_node="child-1",
+        claimed_from_agent="child-1",
+        target="child-2",
+        db_path=db_path,
     )
     # Assert
     assert reason is not None and "cross-group" in reason
@@ -131,19 +147,76 @@ def test_acl_allows_cross_group_with_explicit_grant(db_path: Path) -> None:
     grant_send(sender="child-1", target="child-2", db_path=db_path)
     # Act
     decision, _reason = check_send_acl(
-        claimed_from_agent="child-1", target="child-2", db_path=db_path
+        authenticated_node="child-1",
+        claimed_from_agent="child-1",
+        target="child-2",
+        db_path=db_path,
     )
     # Assert
     assert decision == "allow"
 
 
-def test_acl_denies_when_metadata_from_agent_missing(db_path: Path) -> None:
-    """Empty sender → deny. No identity to gate on."""
+def test_acl_denies_identity_spoof(db_path: Path) -> None:
+    """Handoff §4 acceptance: "identity cannot be spoofed via a
+    metadata field". A per-node bearer authenticates one name; if
+    ``metadata.from_agent`` claims a different name → 403.
+    """
     # Arrange
-    target = "anyone"
+    record_lineage(child="alice", parent="root", db_path=db_path)
+    record_lineage(child="bob", parent="root", db_path=db_path)
+    # Act — alice's bearer, bob's claim
+    decision, _reason = check_send_acl(
+        authenticated_node="alice",
+        claimed_from_agent="bob",
+        target="alice",
+        db_path=db_path,
+    )
+    # Assert
+    assert decision == "deny"
+
+
+def test_acl_spoof_deny_reason_names_both_identities(db_path: Path) -> None:
+    """The 403 body explains *which* identity claimed to be whom."""
+    # Arrange
+    # Act
+    _decision, reason = check_send_acl(
+        authenticated_node="alice",
+        claimed_from_agent="bob",
+        target="alice",
+        db_path=db_path,
+    )
+    # Assert
+    assert reason is not None and "alice" in reason and "bob" in reason
+
+
+def test_acl_admin_caller_honors_claimed_from_agent(db_path: Path) -> None:
+    """Host-wide bearer + ``metadata.from_agent`` set → admin path
+    (cross-host forwarder). The metadata claim is honoured verbatim.
+    """
+    # Arrange
+    record_lineage(child="worker-a", parent="root", db_path=db_path)
+    # Act — admin caller (authenticated_node=None) speaks for root
+    decision, _reason = check_send_acl(
+        authenticated_node=None,
+        claimed_from_agent="root",
+        target="worker-a",
+        db_path=db_path,
+    )
+    # Assert
+    assert decision == "allow"
+
+
+def test_acl_denies_when_no_identity_at_all(db_path: Path) -> None:
+    """Host bearer + missing ``metadata.from_agent`` → no identity to
+    gate on → 403.
+    """
+    # Arrange
     # Act
     decision, _reason = check_send_acl(
-        claimed_from_agent=None, target=target, db_path=db_path
+        authenticated_node=None,
+        claimed_from_agent=None,
+        target="anyone",
+        db_path=db_path,
     )
     # Assert
     assert decision == "deny"
@@ -154,7 +227,10 @@ def test_acl_denies_when_target_missing(db_path: Path) -> None:
     sender = "alice"
     # Act
     decision, _reason = check_send_acl(
-        claimed_from_agent=sender, target="", db_path=db_path
+        authenticated_node=sender,
+        claimed_from_agent=sender,
+        target="",
+        db_path=db_path,
     )
     # Assert
     assert decision == "deny"
@@ -326,6 +402,80 @@ def test_http_node_message_send_allows_after_explicit_grant(
         )
     # Assert
     assert r.status_code < 400, r.text
+
+
+# ---------------------------------------------------------------------------
+# HTTP-level: per-node bearer enforces "identity cannot be spoofed via a
+# metadata field" (handoff §4 acceptance).
+# ---------------------------------------------------------------------------
+
+
+def test_http_per_node_bearer_allows_matching_from_agent(
+    isolated_listen_env, db_path: Path
+) -> None:
+    """Per-node bearer for worker-a + ``metadata.from_agent=worker-a``
+    + intra-group target → allow.
+    """
+    # Arrange
+    record_lineage(child="worker-a", parent="root", db_path=db_path)
+    record_lineage(child="worker-b", parent="root", db_path=db_path)
+    worker_a_token = mint_node_token(name="worker-a", db_path=db_path)
+    app = create_app(token=TOKEN)
+    # Act
+    with TestClient(app) as client:
+        r = client.post(
+            "/agents/worker-b/message:send",
+            json=_payload("worker-a"),
+            headers={"authorization": f"Bearer {worker_a_token}"},
+        )
+    # Assert
+    assert r.status_code < 400, r.text
+
+
+def test_http_per_node_bearer_denies_spoofed_from_agent_with_403(
+    isolated_listen_env, db_path: Path
+) -> None:
+    """Per-node bearer for worker-a + ``metadata.from_agent=worker-b``
+    → 403 identity spoof (the acceptance criterion).
+    """
+    # Arrange
+    record_lineage(child="worker-a", parent="root", db_path=db_path)
+    record_lineage(child="worker-b", parent="root", db_path=db_path)
+    worker_a_token = mint_node_token(name="worker-a", db_path=db_path)
+    mint_node_token(name="worker-b", db_path=db_path)
+    app = create_app(token=TOKEN)
+    # Act — worker-a's bearer, but claim to be worker-b
+    with TestClient(app) as client:
+        r = client.post(
+            "/agents/worker-b/message:send",
+            json=_payload("worker-b"),
+            headers={"authorization": f"Bearer {worker_a_token}"},
+        )
+    # Assert
+    assert r.status_code == 403, r.text
+
+
+def test_http_per_node_bearer_403_body_explains_spoof(
+    isolated_listen_env, db_path: Path
+) -> None:
+    """The 403 body identifies the resolved name vs the claimed
+    name so the operator can see which identity tried to spoof."""
+    # Arrange
+    record_lineage(child="worker-a", parent="root", db_path=db_path)
+    record_lineage(child="worker-b", parent="root", db_path=db_path)
+    worker_a_token = mint_node_token(name="worker-a", db_path=db_path)
+    app = create_app(token=TOKEN)
+    # Act
+    with TestClient(app) as client:
+        r = client.post(
+            "/agents/worker-b/message:send",
+            json=_payload("worker-b"),
+            headers={"authorization": f"Bearer {worker_a_token}"},
+        )
+    body = r.json()
+    # Assert
+    reason = body.get("reason", "")
+    assert "spoof" in reason and "worker-a" in reason and "worker-b" in reason
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scitex_agent_container/_listen/test__acl.py
+++ b/tests/scitex_agent_container/_listen/test__acl.py
@@ -1,17 +1,22 @@
-"""WI-2 — ACL gate on ``message:send`` (handoff §4).
+"""WI-2 — ACL gate on ``message:send`` + spawn-permission gate
+(limited scope per lead 2026-05-20).
 
-Per HANDOFF_AGENT_COMMS_2026-05-19.md §4 (WI-2 "ACL: permissioned
-messaging"):
+Per HANDOFF_AGENT_COMMS_2026-05-19.md §4 (WI-2):
 
-  Acceptance: an un-permitted (cross-group, no grant) sender is
-  rejected with ``403`` + a log line; an intra-group sender's
-  message lands; ... identity cannot be spoofed via a metadata field.
+  Acceptance (limited scope): an un-permitted (cross-group, no
+  grant) sender is rejected with ``403`` + a log line; an
+  intra-group sender's message lands; a child's
+  ``sac agents start`` is rejected.
 
-Mirrors ``src/scitex_agent_container/_listen/_acl.py``. The tests
-drive the ACL function directly (unit-level, deterministic) plus
-a couple of HTTP-level shape checks against the real ``sac listen``
-Starlette app to confirm the wiring lands the 403 with a clear
-reason. No mocks (handoff §0).
+The "identity cannot be spoofed via a metadata field" acceptance
+criterion is DEFERRED (lead 2026-05-20) to a separate follow-on
+handoff. Until then, the ACL gates on the self-claimed
+``metadata.from_agent`` field and every cross-group grant carries
+the audit caveat "trusts metadata.from_agent until per-node creds
+land".
+
+Mirrors ``src/scitex_agent_container/_listen/_acl.py``. No mocks
+(handoff §0): real SQLite, real Starlette app.
 """
 
 from __future__ import annotations
@@ -22,13 +27,13 @@ from pathlib import Path
 import pytest
 from starlette.testclient import TestClient
 
-from scitex_agent_container._listen._acl import check_send_acl
+from scitex_agent_container._listen._acl import check_send_acl, check_spawn
 from scitex_agent_container._listen.server import create_app
 from scitex_agent_container._runners import _session_state as _ss
 from scitex_agent_container._state import state_db
 from scitex_agent_container._state import registry as _reg
 from scitex_agent_container._state.state_db_nodes import (
-    mint_node_token,
+    grant_send,
     record_lineage,
 )
 
@@ -36,6 +41,7 @@ from scitex_agent_container._state.state_db_nodes import (
 @pytest.fixture
 def db_path(tmp_path: Path):
     """Isolated state.db. PA-306 no-mocks: yield-based env override."""
+    # Arrange
     db = tmp_path / "state.db"
     saved_env = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB")
     saved_default = state_db.DEFAULT_DB_PATH
@@ -58,15 +64,12 @@ def db_path(tmp_path: Path):
 
 
 def test_acl_allows_self_send(db_path: Path) -> None:
-    """A node may always address itself — the trivial allow case."""
+    """A node may always address itself — trivial allow."""
     # Arrange
-    mint_node_token(name="alice", db_path=db_path)
+    sender = "alice"
     # Act
     decision, _reason = check_send_acl(
-        authenticated_node="alice",
-        claimed_from_agent="alice",
-        target="alice",
-        db_path=db_path,
+        claimed_from_agent=sender, target="alice", db_path=db_path
     )
     # Assert
     assert decision == "allow"
@@ -74,15 +77,10 @@ def test_acl_allows_self_send(db_path: Path) -> None:
 
 def test_acl_allows_intra_group_parent_to_child(db_path: Path) -> None:
     # Arrange
-    mint_node_token(name="root", db_path=db_path)
-    mint_node_token(name="worker-a", db_path=db_path)
     record_lineage(child="worker-a", parent="root", db_path=db_path)
     # Act
     decision, _reason = check_send_acl(
-        authenticated_node="root",
-        claimed_from_agent="root",
-        target="worker-a",
-        db_path=db_path,
+        claimed_from_agent="root", target="worker-a", db_path=db_path
     )
     # Assert
     assert decision == "allow"
@@ -91,147 +89,124 @@ def test_acl_allows_intra_group_parent_to_child(db_path: Path) -> None:
 def test_acl_allows_intra_group_sibling_to_sibling(db_path: Path) -> None:
     """Handoff §4: 'parent↔child *and* sibling↔sibling, bidirectional'."""
     # Arrange
-    mint_node_token(name="root", db_path=db_path)
-    mint_node_token(name="worker-a", db_path=db_path)
-    mint_node_token(name="worker-b", db_path=db_path)
     record_lineage(child="worker-a", parent="root", db_path=db_path)
     record_lineage(child="worker-b", parent="root", db_path=db_path)
     # Act
     decision, _reason = check_send_acl(
-        authenticated_node="worker-a",
-        claimed_from_agent="worker-a",
-        target="worker-b",
-        db_path=db_path,
+        claimed_from_agent="worker-a", target="worker-b", db_path=db_path
     )
     # Assert
     assert decision == "allow"
 
 
 def test_acl_denies_cross_group_without_grant(db_path: Path) -> None:
-    """Two unrelated families. No grant configured (handoff defers
-    explicit grants); cross-group must be denied with a clear reason.
-    """
-    # Arrange
-    for name in ("root-1", "child-1", "root-2", "child-2"):
-        mint_node_token(name=name, db_path=db_path)
+    # Arrange — two unrelated families
     record_lineage(child="child-1", parent="root-1", db_path=db_path)
     record_lineage(child="child-2", parent="root-2", db_path=db_path)
     # Act
     decision, _reason = check_send_acl(
-        authenticated_node="child-1",
-        claimed_from_agent="child-1",
-        target="child-2",
-        db_path=db_path,
+        claimed_from_agent="child-1", target="child-2", db_path=db_path
     )
     # Assert
     assert decision == "deny"
 
 
 def test_acl_deny_carries_explanatory_reason(db_path: Path) -> None:
-    """Denial is the policy working — but the sender must know why."""
     # Arrange
-    for name in ("root-1", "child-1", "root-2", "child-2"):
-        mint_node_token(name=name, db_path=db_path)
     record_lineage(child="child-1", parent="root-1", db_path=db_path)
     record_lineage(child="child-2", parent="root-2", db_path=db_path)
     # Act
     _decision, reason = check_send_acl(
-        authenticated_node="child-1",
-        claimed_from_agent="child-1",
-        target="child-2",
-        db_path=db_path,
+        claimed_from_agent="child-1", target="child-2", db_path=db_path
     )
     # Assert
     assert reason is not None and "cross-group" in reason
 
 
-# ---------------------------------------------------------------------------
-# Spoofing: bearer authenticates X but metadata.from_agent claims Y
-# ---------------------------------------------------------------------------
-
-
-def test_acl_denies_identity_spoof_mismatched_from_agent(db_path: Path) -> None:
-    """The acceptance criterion: 'identity cannot be spoofed via a
-    metadata field'. Bearer says ``alice``, metadata claims ``bob`` —
-    deny.
-    """
-    # Arrange
-    mint_node_token(name="alice", db_path=db_path)
-    mint_node_token(name="bob", db_path=db_path)
+def test_acl_allows_cross_group_with_explicit_grant(db_path: Path) -> None:
+    """Explicit cross-group grant flips a deny to allow."""
+    # Arrange — two unrelated families + grant child-1 → child-2
+    record_lineage(child="child-1", parent="root-1", db_path=db_path)
+    record_lineage(child="child-2", parent="root-2", db_path=db_path)
+    grant_send(sender="child-1", target="child-2", db_path=db_path)
     # Act
     decision, _reason = check_send_acl(
-        authenticated_node="alice",
-        claimed_from_agent="bob",  # spoof
-        target="alice",
-        db_path=db_path,
-    )
-    # Assert
-    assert decision == "deny"
-
-
-def test_acl_spoof_deny_reason_names_both_identities(db_path: Path) -> None:
-    """The 403 body explains *which* identity claimed to be whom."""
-    # Arrange
-    mint_node_token(name="alice", db_path=db_path)
-    mint_node_token(name="bob", db_path=db_path)
-    # Act
-    _decision, reason = check_send_acl(
-        authenticated_node="alice",
-        claimed_from_agent="bob",
-        target="alice",
-        db_path=db_path,
-    )
-    # Assert
-    assert reason is not None and "alice" in reason and "bob" in reason
-
-
-# ---------------------------------------------------------------------------
-# Administrative path: no per-node bearer, host bearer used. Metadata
-# must still carry a from_agent so the ACL has something to gate on.
-# ---------------------------------------------------------------------------
-
-
-def test_acl_denies_when_no_identity_at_all(db_path: Path) -> None:
-    """Host bearer + empty metadata.from_agent → there is no identity
-    to gate on. Deny rather than fall through to an unauthenticated
-    send.
-    """
-    # Arrange
-    # (no tokens needed — the denial fires before lineage lookup)
-    # Act
-    decision, _reason = check_send_acl(
-        authenticated_node=None,
-        claimed_from_agent=None,
-        target="anyone",
-        db_path=db_path,
-    )
-    # Assert
-    assert decision == "deny"
-
-
-def test_acl_admin_caller_honors_claimed_from_agent(db_path: Path) -> None:
-    """Host bearer + metadata.from_agent → trust the claim and run
-    the group check against THAT identity. This is the
-    cross-host-forwarding path: the forwarding host's bearer
-    authenticates the request, but the sender is the original node.
-    """
-    # Arrange
-    mint_node_token(name="root", db_path=db_path)
-    mint_node_token(name="worker-a", db_path=db_path)
-    record_lineage(child="worker-a", parent="root", db_path=db_path)
-    # Act — admin caller (authenticated_node=None) speaks for root
-    decision, _reason = check_send_acl(
-        authenticated_node=None,
-        claimed_from_agent="root",
-        target="worker-a",
-        db_path=db_path,
+        claimed_from_agent="child-1", target="child-2", db_path=db_path
     )
     # Assert
     assert decision == "allow"
 
 
+def test_acl_denies_when_metadata_from_agent_missing(db_path: Path) -> None:
+    """Empty sender → deny. No identity to gate on."""
+    # Arrange
+    target = "anyone"
+    # Act
+    decision, _reason = check_send_acl(
+        claimed_from_agent=None, target=target, db_path=db_path
+    )
+    # Assert
+    assert decision == "deny"
+
+
+def test_acl_denies_when_target_missing(db_path: Path) -> None:
+    # Arrange
+    sender = "alice"
+    # Act
+    decision, _reason = check_send_acl(
+        claimed_from_agent=sender, target="", db_path=db_path
+    )
+    # Assert
+    assert decision == "deny"
+
+
 # ---------------------------------------------------------------------------
-# HTTP-level: the wired-up node_message_send returns 403 on deny.
+# Spawn-permission gate (check_spawn / spawn_allowed)
+# ---------------------------------------------------------------------------
+
+
+def test_spawn_allows_root_caller(db_path: Path) -> None:
+    """A node with no parent in lineage is allowed to spawn."""
+    # Arrange
+    caller = "root"
+    # Act
+    decision, _reason = check_spawn(caller=caller, db_path=db_path)
+    # Assert
+    assert decision == "allow"
+
+
+def test_spawn_allows_admin_caller_when_caller_is_none(db_path: Path) -> None:
+    """``caller=None`` is the administrative / operator path."""
+    # Arrange
+    caller = None
+    # Act
+    decision, _reason = check_spawn(caller=caller, db_path=db_path)
+    # Assert
+    assert decision == "allow"
+
+
+def test_spawn_denies_child_caller(db_path: Path) -> None:
+    """A node with a parent (child) is NOT allowed to spawn."""
+    # Arrange
+    record_lineage(child="worker-a", parent="root", db_path=db_path)
+    # Act
+    decision, _reason = check_spawn(caller="worker-a", db_path=db_path)
+    # Assert
+    assert decision == "deny"
+
+
+def test_spawn_deny_reason_explains_root_only_policy(db_path: Path) -> None:
+    """The 403 body explains the lift-able policy."""
+    # Arrange
+    record_lineage(child="worker-a", parent="root", db_path=db_path)
+    # Act
+    _decision, reason = check_spawn(caller="worker-a", db_path=db_path)
+    # Assert
+    assert reason is not None and "lift-able policy" in reason
+
+
+# ---------------------------------------------------------------------------
+# HTTP-level: node_message_send returns 403 on cross-group deny.
 # ---------------------------------------------------------------------------
 
 
@@ -241,6 +216,7 @@ TOKEN = "test-token-acl"
 @pytest.fixture
 def isolated_listen_env(tmp_path: Path, db_path: Path):
     """Point Registry / runtime dirs at tmp_path; reuse db_path fixture."""
+    # Arrange
     saved_home = os.environ.get("HOME")
     saved_reg_const = _reg.REGISTRY_DIR
     saved_state_const = _ss.DEFAULT_STATE_ROOT
@@ -258,7 +234,7 @@ def isolated_listen_env(tmp_path: Path, db_path: Path):
             os.environ["HOME"] = saved_home
 
 
-def _payload(target_sender: str, content: str = "x") -> dict:
+def _payload(sender: str, content: str = "x") -> dict:
     return {
         "jsonrpc": "2.0",
         "id": "1",
@@ -269,7 +245,7 @@ def _payload(target_sender: str, content: str = "x") -> dict:
                 "role": "ROLE_USER",
                 "parts": [{"text": content}],
             },
-            "metadata": {"from_agent": target_sender},
+            "metadata": {"from_agent": sender},
         },
     }
 
@@ -277,12 +253,8 @@ def _payload(target_sender: str, content: str = "x") -> dict:
 def test_http_node_message_send_denies_cross_group_with_403(
     isolated_listen_env, db_path: Path
 ) -> None:
-    """End-to-end: admin caller (host bearer) speaks for a node in
-    one group, addresses a node in a different group → 403.
-    """
+    """End-to-end: cross-group sender → 403."""
     # Arrange
-    for name in ("root-1", "child-1", "root-2", "child-2"):
-        mint_node_token(name=name, db_path=db_path)
     record_lineage(child="child-1", parent="root-1", db_path=db_path)
     record_lineage(child="child-2", parent="root-2", db_path=db_path)
     app = create_app(token=TOKEN)
@@ -300,11 +272,8 @@ def test_http_node_message_send_denies_cross_group_with_403(
 def test_http_node_message_send_403_body_carries_reason(
     isolated_listen_env, db_path: Path
 ) -> None:
-    """The 403 body explains the denial (handoff §4: 'denial is
-    explicit ... the sender must know')."""
+    """The 403 body explains the denial."""
     # Arrange
-    for name in ("root-1", "child-1", "root-2", "child-2"):
-        mint_node_token(name=name, db_path=db_path)
     record_lineage(child="child-1", parent="root-1", db_path=db_path)
     record_lineage(child="child-2", parent="root-2", db_path=db_path)
     app = create_app(token=TOKEN)
@@ -325,8 +294,6 @@ def test_http_node_message_send_allows_intra_group(
 ) -> None:
     """Intra-group send (sibling-to-sibling) lands."""
     # Arrange
-    for name in ("root", "worker-a", "worker-b"):
-        mint_node_token(name=name, db_path=db_path)
     record_lineage(child="worker-a", parent="root", db_path=db_path)
     record_lineage(child="worker-b", parent="root", db_path=db_path)
     app = create_app(token=TOKEN)
@@ -339,3 +306,66 @@ def test_http_node_message_send_allows_intra_group(
         )
     # Assert
     assert r.status_code < 400, r.text
+
+
+def test_http_node_message_send_allows_after_explicit_grant(
+    isolated_listen_env, db_path: Path
+) -> None:
+    """A cross-group grant flips the deny to an allow."""
+    # Arrange
+    record_lineage(child="child-1", parent="root-1", db_path=db_path)
+    record_lineage(child="child-2", parent="root-2", db_path=db_path)
+    grant_send(sender="child-1", target="child-2", db_path=db_path)
+    app = create_app(token=TOKEN)
+    # Act
+    with TestClient(app) as client:
+        r = client.post(
+            "/agents/child-2/message:send",
+            json=_payload("child-1"),
+            headers={"authorization": f"Bearer {TOKEN}"},
+        )
+    # Assert
+    assert r.status_code < 400, r.text
+
+
+# ---------------------------------------------------------------------------
+# HTTP-level: agents_start denies a child caller with 403.
+# ---------------------------------------------------------------------------
+
+
+def test_http_agents_start_denies_child_caller_with_403(
+    isolated_listen_env, db_path: Path
+) -> None:
+    """Root-only spawn (current policy): a child caller → 403."""
+    # Arrange
+    record_lineage(child="worker-a", parent="root", db_path=db_path)
+    app = create_app(token=TOKEN)
+    body = {"name": "new-agent", "caller": "worker-a"}
+    # Act
+    with TestClient(app) as client:
+        r = client.post(
+            "/agents",
+            json=body,
+            headers={"authorization": f"Bearer {TOKEN}"},
+        )
+    # Assert
+    assert r.status_code == 403, r.text
+
+
+def test_http_agents_start_403_carries_lift_able_policy_text(
+    isolated_listen_env, db_path: Path
+) -> None:
+    # Arrange
+    record_lineage(child="worker-a", parent="root", db_path=db_path)
+    app = create_app(token=TOKEN)
+    body = {"name": "new-agent", "caller": "worker-a"}
+    # Act
+    with TestClient(app) as client:
+        r = client.post(
+            "/agents",
+            json=body,
+            headers={"authorization": f"Bearer {TOKEN}"},
+        )
+    body_json = r.json()
+    # Assert
+    assert "lift-able policy" in body_json.get("reason", "")

--- a/tests/scitex_agent_container/_listen/test__acl.py
+++ b/tests/scitex_agent_container/_listen/test__acl.py
@@ -1,0 +1,341 @@
+"""WI-2 — ACL gate on ``message:send`` (handoff §4).
+
+Per HANDOFF_AGENT_COMMS_2026-05-19.md §4 (WI-2 "ACL: permissioned
+messaging"):
+
+  Acceptance: an un-permitted (cross-group, no grant) sender is
+  rejected with ``403`` + a log line; an intra-group sender's
+  message lands; ... identity cannot be spoofed via a metadata field.
+
+Mirrors ``src/scitex_agent_container/_listen/_acl.py``. The tests
+drive the ACL function directly (unit-level, deterministic) plus
+a couple of HTTP-level shape checks against the real ``sac listen``
+Starlette app to confirm the wiring lands the 403 with a clear
+reason. No mocks (handoff §0).
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+from starlette.testclient import TestClient
+
+from scitex_agent_container._listen._acl import check_send_acl
+from scitex_agent_container._listen.server import create_app
+from scitex_agent_container._runners import _session_state as _ss
+from scitex_agent_container._state import state_db
+from scitex_agent_container._state import registry as _reg
+from scitex_agent_container._state.state_db_nodes import (
+    mint_node_token,
+    record_lineage,
+)
+
+
+@pytest.fixture
+def db_path(tmp_path: Path):
+    """Isolated state.db. PA-306 no-mocks: yield-based env override."""
+    db = tmp_path / "state.db"
+    saved_env = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB")
+    saved_default = state_db.DEFAULT_DB_PATH
+    os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
+    state_db.DEFAULT_DB_PATH = db
+    state_db.init_schema(db)
+    try:
+        yield db
+    finally:
+        state_db.DEFAULT_DB_PATH = saved_default
+        if saved_env is None:
+            os.environ.pop("SCITEX_AGENT_CONTAINER_STATE_DB", None)
+        else:
+            os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = saved_env
+
+
+# ---------------------------------------------------------------------------
+# Unit-level: check_send_acl decisions
+# ---------------------------------------------------------------------------
+
+
+def test_acl_allows_self_send(db_path: Path) -> None:
+    """A node may always address itself — the trivial allow case."""
+    # Arrange
+    mint_node_token(name="alice", db_path=db_path)
+    # Act
+    decision, _reason = check_send_acl(
+        authenticated_node="alice",
+        claimed_from_agent="alice",
+        target="alice",
+        db_path=db_path,
+    )
+    # Assert
+    assert decision == "allow"
+
+
+def test_acl_allows_intra_group_parent_to_child(db_path: Path) -> None:
+    # Arrange
+    mint_node_token(name="root", db_path=db_path)
+    mint_node_token(name="worker-a", db_path=db_path)
+    record_lineage(child="worker-a", parent="root", db_path=db_path)
+    # Act
+    decision, _reason = check_send_acl(
+        authenticated_node="root",
+        claimed_from_agent="root",
+        target="worker-a",
+        db_path=db_path,
+    )
+    # Assert
+    assert decision == "allow"
+
+
+def test_acl_allows_intra_group_sibling_to_sibling(db_path: Path) -> None:
+    """Handoff §4: 'parent↔child *and* sibling↔sibling, bidirectional'."""
+    # Arrange
+    mint_node_token(name="root", db_path=db_path)
+    mint_node_token(name="worker-a", db_path=db_path)
+    mint_node_token(name="worker-b", db_path=db_path)
+    record_lineage(child="worker-a", parent="root", db_path=db_path)
+    record_lineage(child="worker-b", parent="root", db_path=db_path)
+    # Act
+    decision, _reason = check_send_acl(
+        authenticated_node="worker-a",
+        claimed_from_agent="worker-a",
+        target="worker-b",
+        db_path=db_path,
+    )
+    # Assert
+    assert decision == "allow"
+
+
+def test_acl_denies_cross_group_without_grant(db_path: Path) -> None:
+    """Two unrelated families. No grant configured (handoff defers
+    explicit grants); cross-group must be denied with a clear reason.
+    """
+    # Arrange
+    for name in ("root-1", "child-1", "root-2", "child-2"):
+        mint_node_token(name=name, db_path=db_path)
+    record_lineage(child="child-1", parent="root-1", db_path=db_path)
+    record_lineage(child="child-2", parent="root-2", db_path=db_path)
+    # Act
+    decision, _reason = check_send_acl(
+        authenticated_node="child-1",
+        claimed_from_agent="child-1",
+        target="child-2",
+        db_path=db_path,
+    )
+    # Assert
+    assert decision == "deny"
+
+
+def test_acl_deny_carries_explanatory_reason(db_path: Path) -> None:
+    """Denial is the policy working — but the sender must know why."""
+    # Arrange
+    for name in ("root-1", "child-1", "root-2", "child-2"):
+        mint_node_token(name=name, db_path=db_path)
+    record_lineage(child="child-1", parent="root-1", db_path=db_path)
+    record_lineage(child="child-2", parent="root-2", db_path=db_path)
+    # Act
+    _decision, reason = check_send_acl(
+        authenticated_node="child-1",
+        claimed_from_agent="child-1",
+        target="child-2",
+        db_path=db_path,
+    )
+    # Assert
+    assert reason is not None and "cross-group" in reason
+
+
+# ---------------------------------------------------------------------------
+# Spoofing: bearer authenticates X but metadata.from_agent claims Y
+# ---------------------------------------------------------------------------
+
+
+def test_acl_denies_identity_spoof_mismatched_from_agent(db_path: Path) -> None:
+    """The acceptance criterion: 'identity cannot be spoofed via a
+    metadata field'. Bearer says ``alice``, metadata claims ``bob`` —
+    deny.
+    """
+    # Arrange
+    mint_node_token(name="alice", db_path=db_path)
+    mint_node_token(name="bob", db_path=db_path)
+    # Act
+    decision, _reason = check_send_acl(
+        authenticated_node="alice",
+        claimed_from_agent="bob",  # spoof
+        target="alice",
+        db_path=db_path,
+    )
+    # Assert
+    assert decision == "deny"
+
+
+def test_acl_spoof_deny_reason_names_both_identities(db_path: Path) -> None:
+    """The 403 body explains *which* identity claimed to be whom."""
+    # Arrange
+    mint_node_token(name="alice", db_path=db_path)
+    mint_node_token(name="bob", db_path=db_path)
+    # Act
+    _decision, reason = check_send_acl(
+        authenticated_node="alice",
+        claimed_from_agent="bob",
+        target="alice",
+        db_path=db_path,
+    )
+    # Assert
+    assert reason is not None and "alice" in reason and "bob" in reason
+
+
+# ---------------------------------------------------------------------------
+# Administrative path: no per-node bearer, host bearer used. Metadata
+# must still carry a from_agent so the ACL has something to gate on.
+# ---------------------------------------------------------------------------
+
+
+def test_acl_denies_when_no_identity_at_all(db_path: Path) -> None:
+    """Host bearer + empty metadata.from_agent → there is no identity
+    to gate on. Deny rather than fall through to an unauthenticated
+    send.
+    """
+    # Arrange
+    # (no tokens needed — the denial fires before lineage lookup)
+    # Act
+    decision, _reason = check_send_acl(
+        authenticated_node=None,
+        claimed_from_agent=None,
+        target="anyone",
+        db_path=db_path,
+    )
+    # Assert
+    assert decision == "deny"
+
+
+def test_acl_admin_caller_honors_claimed_from_agent(db_path: Path) -> None:
+    """Host bearer + metadata.from_agent → trust the claim and run
+    the group check against THAT identity. This is the
+    cross-host-forwarding path: the forwarding host's bearer
+    authenticates the request, but the sender is the original node.
+    """
+    # Arrange
+    mint_node_token(name="root", db_path=db_path)
+    mint_node_token(name="worker-a", db_path=db_path)
+    record_lineage(child="worker-a", parent="root", db_path=db_path)
+    # Act — admin caller (authenticated_node=None) speaks for root
+    decision, _reason = check_send_acl(
+        authenticated_node=None,
+        claimed_from_agent="root",
+        target="worker-a",
+        db_path=db_path,
+    )
+    # Assert
+    assert decision == "allow"
+
+
+# ---------------------------------------------------------------------------
+# HTTP-level: the wired-up node_message_send returns 403 on deny.
+# ---------------------------------------------------------------------------
+
+
+TOKEN = "test-token-acl"
+
+
+@pytest.fixture
+def isolated_listen_env(tmp_path: Path, db_path: Path):
+    """Point Registry / runtime dirs at tmp_path; reuse db_path fixture."""
+    saved_home = os.environ.get("HOME")
+    saved_reg_const = _reg.REGISTRY_DIR
+    saved_state_const = _ss.DEFAULT_STATE_ROOT
+    os.environ["HOME"] = str(tmp_path)
+    _reg.REGISTRY_DIR = tmp_path / "registry"
+    _ss.DEFAULT_STATE_ROOT = tmp_path / "runtime"
+    try:
+        yield tmp_path
+    finally:
+        _reg.REGISTRY_DIR = saved_reg_const
+        _ss.DEFAULT_STATE_ROOT = saved_state_const
+        if saved_home is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = saved_home
+
+
+def _payload(target_sender: str, content: str = "x") -> dict:
+    return {
+        "jsonrpc": "2.0",
+        "id": "1",
+        "method": "SendMessage",
+        "params": {
+            "message": {
+                "message_id": "m1",
+                "role": "ROLE_USER",
+                "parts": [{"text": content}],
+            },
+            "metadata": {"from_agent": target_sender},
+        },
+    }
+
+
+def test_http_node_message_send_denies_cross_group_with_403(
+    isolated_listen_env, db_path: Path
+) -> None:
+    """End-to-end: admin caller (host bearer) speaks for a node in
+    one group, addresses a node in a different group → 403.
+    """
+    # Arrange
+    for name in ("root-1", "child-1", "root-2", "child-2"):
+        mint_node_token(name=name, db_path=db_path)
+    record_lineage(child="child-1", parent="root-1", db_path=db_path)
+    record_lineage(child="child-2", parent="root-2", db_path=db_path)
+    app = create_app(token=TOKEN)
+    # Act
+    with TestClient(app) as client:
+        r = client.post(
+            "/agents/child-2/message:send",
+            json=_payload("child-1"),
+            headers={"authorization": f"Bearer {TOKEN}"},
+        )
+    # Assert
+    assert r.status_code == 403, r.text
+
+
+def test_http_node_message_send_403_body_carries_reason(
+    isolated_listen_env, db_path: Path
+) -> None:
+    """The 403 body explains the denial (handoff §4: 'denial is
+    explicit ... the sender must know')."""
+    # Arrange
+    for name in ("root-1", "child-1", "root-2", "child-2"):
+        mint_node_token(name=name, db_path=db_path)
+    record_lineage(child="child-1", parent="root-1", db_path=db_path)
+    record_lineage(child="child-2", parent="root-2", db_path=db_path)
+    app = create_app(token=TOKEN)
+    # Act
+    with TestClient(app) as client:
+        r = client.post(
+            "/agents/child-2/message:send",
+            json=_payload("child-1"),
+            headers={"authorization": f"Bearer {TOKEN}"},
+        )
+    body = r.json()
+    # Assert
+    assert "reason" in body and "cross-group" in body["reason"]
+
+
+def test_http_node_message_send_allows_intra_group(
+    isolated_listen_env, db_path: Path
+) -> None:
+    """Intra-group send (sibling-to-sibling) lands."""
+    # Arrange
+    for name in ("root", "worker-a", "worker-b"):
+        mint_node_token(name=name, db_path=db_path)
+    record_lineage(child="worker-a", parent="root", db_path=db_path)
+    record_lineage(child="worker-b", parent="root", db_path=db_path)
+    app = create_app(token=TOKEN)
+    # Act
+    with TestClient(app) as client:
+        r = client.post(
+            "/agents/worker-b/message:send",
+            json=_payload("worker-a"),
+            headers={"authorization": f"Bearer {TOKEN}"},
+        )
+    # Assert
+    assert r.status_code < 400, r.text

--- a/tests/scitex_agent_container/_listen/test__nodes.py
+++ b/tests/scitex_agent_container/_listen/test__nodes.py
@@ -46,10 +46,7 @@ from scitex_agent_container._listen.server import create_app
 from scitex_agent_container._runners import _session_state as _ss
 from scitex_agent_container._state import registry as _reg
 from scitex_agent_container._state import state_db as _state_db
-from scitex_agent_container._state.state_db_nodes import (
-    mint_node_token,
-    record_lineage,
-)
+from scitex_agent_container._state.state_db_nodes import record_lineage
 
 TOKEN = "test-token-wi3"
 
@@ -86,9 +83,6 @@ def isolated_env(tmp_path: Path):
     # common root so they share a group. Without this the new
     # ACL gate would deny ``permitted-peer → external-bob`` as
     # cross-group (each unattached node is its own singleton).
-    mint_node_token(name="permitted-peer", db_path=db_path)
-    mint_node_token(name="external-bob", db_path=db_path)
-    mint_node_token(name="root", db_path=db_path)
     record_lineage(child="permitted-peer", parent="root", db_path=db_path)
     record_lineage(child="external-bob", parent="root", db_path=db_path)
 

--- a/tests/scitex_agent_container/_listen/test__nodes.py
+++ b/tests/scitex_agent_container/_listen/test__nodes.py
@@ -45,6 +45,11 @@ from starlette.testclient import TestClient
 from scitex_agent_container._listen.server import create_app
 from scitex_agent_container._runners import _session_state as _ss
 from scitex_agent_container._state import registry as _reg
+from scitex_agent_container._state import state_db as _state_db
+from scitex_agent_container._state.state_db_nodes import (
+    mint_node_token,
+    record_lineage,
+)
 
 TOKEN = "test-token-wi3"
 
@@ -61,26 +66,44 @@ def isolated_env(tmp_path: Path):
     saved_reg_env = os.environ.get("SCITEX_AGENT_CONTAINER_REGISTRY_DIR")
     saved_run_env = os.environ.get("SCITEX_AGENT_CONTAINER_RUNTIME_DIR")
     saved_yaml_env = os.environ.get("SCITEX_AGENT_CONTAINER_YAML_DIRS")
+    saved_db_env = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB")
     saved_reg_const = _reg.REGISTRY_DIR
     saved_state_const = _ss.DEFAULT_STATE_ROOT
+    saved_db_const = _state_db.DEFAULT_DB_PATH
 
     os.environ["HOME"] = str(tmp_path)
     os.environ["SCITEX_AGENT_CONTAINER_REGISTRY_DIR"] = str(tmp_path / "registry")
     os.environ["SCITEX_AGENT_CONTAINER_RUNTIME_DIR"] = str(tmp_path / "runtime")
     os.environ.pop("SCITEX_AGENT_CONTAINER_YAML_DIRS", None)
+    db_path = tmp_path / "state.db"
+    os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db_path)
     _reg.REGISTRY_DIR = tmp_path / "registry"
     _ss.DEFAULT_STATE_ROOT = tmp_path / "runtime"
+    _state_db.DEFAULT_DB_PATH = db_path
+    _state_db.init_schema(db_path)
+
+    # WI-2 ACL: register the WI-3 demo nodes as siblings under a
+    # common root so they share a group. Without this the new
+    # ACL gate would deny ``permitted-peer → external-bob`` as
+    # cross-group (each unattached node is its own singleton).
+    mint_node_token(name="permitted-peer", db_path=db_path)
+    mint_node_token(name="external-bob", db_path=db_path)
+    mint_node_token(name="root", db_path=db_path)
+    record_lineage(child="permitted-peer", parent="root", db_path=db_path)
+    record_lineage(child="external-bob", parent="root", db_path=db_path)
 
     try:
         yield tmp_path
     finally:
         _reg.REGISTRY_DIR = saved_reg_const
         _ss.DEFAULT_STATE_ROOT = saved_state_const
+        _state_db.DEFAULT_DB_PATH = saved_db_const
         for key, val in (
             ("HOME", saved_home),
             ("SCITEX_AGENT_CONTAINER_REGISTRY_DIR", saved_reg_env),
             ("SCITEX_AGENT_CONTAINER_RUNTIME_DIR", saved_run_env),
             ("SCITEX_AGENT_CONTAINER_YAML_DIRS", saved_yaml_env),
+            ("SCITEX_AGENT_CONTAINER_STATE_DB", saved_db_env),
         ):
             if val is None:
                 os.environ.pop(key, None)
@@ -317,7 +340,7 @@ def test_external_node_agent_card_returns_200(client, auth_headers) -> None:
                     "role": "ROLE_USER",
                     "parts": [{"text": "register me"}],
                 },
-                "metadata": {"from_agent": "peer"},
+                "metadata": {"from_agent": "permitted-peer"},
             },
         },
         headers=auth_headers,
@@ -353,7 +376,7 @@ def test_external_node_agent_card_advertises_node_kind_external(
                     "role": "ROLE_USER",
                     "parts": [{"text": "x"}],
                 },
-                "metadata": {"from_agent": "peer"},
+                "metadata": {"from_agent": "permitted-peer"},
             },
         },
         headers=auth_headers,
@@ -389,7 +412,7 @@ def test_external_node_agent_card_supportedinterfaces_url_targets_inbox(
                     "role": "ROLE_USER",
                     "parts": [{"text": "x"}],
                 },
-                "metadata": {"from_agent": "peer"},
+                "metadata": {"from_agent": "permitted-peer"},
             },
         },
         headers=auth_headers,

--- a/tests/scitex_agent_container/_state/test_state_db_nodes.py
+++ b/tests/scitex_agent_container/_state/test_state_db_nodes.py
@@ -129,7 +129,8 @@ def test_record_lineage_re_parent_raises(db_path: Path) -> None:
     """A child cannot silently switch parents."""
     # Arrange
     record_lineage(child="bob", parent="alice", db_path=db_path)
-    # Act / Assert
+    # Act
+    # Assert
     with pytest.raises(ValueError, match="refusing to re-parent"):
         record_lineage(child="bob", parent="other-root", db_path=db_path)
 

--- a/tests/scitex_agent_container/_state/test_state_db_nodes.py
+++ b/tests/scitex_agent_container/_state/test_state_db_nodes.py
@@ -1,20 +1,18 @@
-"""WI-2 — per-node tokens + lineage primitives (handoff §4).
+"""WI-2 — lineage + grant primitives (limited scope per lead 2026-05-20).
 
 Per HANDOFF_AGENT_COMMS_2026-05-19.md §4 (WI-2 "ACL: permissioned
 messaging"):
 
-  * "Authenticated sender identity. The ACL check is only as strong
-    as the identity — the sender identity carried in
-    ``params.metadata`` must be authenticated (per-node credential
-    / bearer token), never a self-claimed name."
+  * Group-based default ACL — derive from lineage.
+  * Cross-group grants — accepted, keyed on the self-claimed
+    ``metadata.from_agent`` (with the audit caveat documented per
+    grant).
+  * Spawn-permission policy — root-only by current policy
+    (lift-able).
 
-  * "Group-based default ACL. ... The group is derived from lineage
-    — no per-pair config for the common case."
-
-This module exercises the two state.db primitives that make those
-requirements possible: per-node bearer tokens (the authenticated
-identity) and the lineage edges (parent → child) that derive a
-node's group.
+The "authenticated sender identity" / "identity cannot be spoofed"
+acceptance criterion is DEFERRED (lead 2026-05-20) to a separate
+follow-on handoff related to sac-accounts.
 
 No mocks (handoff §0): real SQLite under ``tmp_path``.
 """
@@ -27,11 +25,14 @@ import pytest
 
 from scitex_agent_container._state import state_db
 from scitex_agent_container._state.state_db_nodes import (
+    GRANT_DEFERRED_CAVEAT,
     derive_group,
-    list_node_tokens,
-    mint_node_token,
+    grant_send,
+    has_grant,
+    list_comms_grants,
     record_lineage,
-    resolve_node_token,
+    revoke_send,
+    spawn_allowed,
 )
 
 
@@ -44,20 +45,8 @@ def db_path(tmp_path: Path) -> Path:
 
 
 # ---------------------------------------------------------------------------
-# Schema — node_tokens + lineage tables
+# Schema — lineage + comms_grants tables exist
 # ---------------------------------------------------------------------------
-
-
-def test_node_tokens_table_exists(db_path: Path) -> None:
-    # Arrange
-    conn_ctx = state_db.open_db(db_path)
-    # Act
-    with conn_ctx as conn:
-        rows = conn.execute(
-            "SELECT name FROM sqlite_master WHERE type='table' AND name='node_tokens'"
-        ).fetchall()
-    # Assert
-    assert len(rows) == 1
 
 
 def test_lineage_table_exists(db_path: Path) -> None:
@@ -72,72 +61,33 @@ def test_lineage_table_exists(db_path: Path) -> None:
     assert len(rows) == 1
 
 
-# ---------------------------------------------------------------------------
-# mint_node_token — generates a fresh secret + records the identity
-# ---------------------------------------------------------------------------
-
-
-def test_mint_node_token_returns_non_empty_string(db_path: Path) -> None:
+def test_comms_grants_table_exists(db_path: Path) -> None:
     # Arrange
-    name = "alice"
+    conn_ctx = state_db.open_db(db_path)
     # Act
-    token = mint_node_token(name=name, db_path=db_path)
+    with conn_ctx as conn:
+        rows = conn.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type='table' AND name='comms_grants'"
+        ).fetchall()
     # Assert
-    assert isinstance(token, str) and len(token) >= 32
+    assert len(rows) == 1
 
 
-def test_mint_node_token_idempotent_returns_same_token(db_path: Path) -> None:
-    """A second call for the same name returns the same token, not a
-    new one — re-registration must not invalidate an active bearer.
-    """
+@pytest.mark.parametrize(
+    "column", ["sender_name", "target_name", "created_at", "note"]
+)
+def test_comms_grants_has_column(db_path: Path, column: str) -> None:
     # Arrange
-    first = mint_node_token(name="alice", db_path=db_path)
+    conn_ctx = state_db.open_db(db_path)
     # Act
-    second = mint_node_token(name="alice", db_path=db_path)
+    with conn_ctx as conn:
+        cols = {
+            r[1]
+            for r in conn.execute("PRAGMA table_info(comms_grants)").fetchall()
+        }
     # Assert
-    assert first == second
-
-
-def test_mint_node_token_is_unique_per_name(db_path: Path) -> None:
-    # Arrange
-    a = mint_node_token(name="alice", db_path=db_path)
-    b = mint_node_token(name="bob", db_path=db_path)
-    # Act
-    different = a != b
-    # Assert
-    assert different is True
-
-
-# ---------------------------------------------------------------------------
-# resolve_node_token — bearer → identity, the auth side of ACL
-# ---------------------------------------------------------------------------
-
-
-def test_resolve_node_token_returns_minted_identity(db_path: Path) -> None:
-    # Arrange
-    token = mint_node_token(name="alice", db_path=db_path)
-    # Act
-    resolved = resolve_node_token(token=token, db_path=db_path)
-    # Assert
-    assert resolved == "alice"
-
-
-def test_resolve_node_token_returns_none_for_unknown_bearer(db_path: Path) -> None:
-    # Arrange
-    bogus = "no-such-token-1234567890abcdef"
-    # Act
-    resolved = resolve_node_token(token=bogus, db_path=db_path)
-    # Assert
-    assert resolved is None
-
-
-def test_resolve_node_token_returns_none_for_empty_string(db_path: Path) -> None:
-    # Arrange
-    empty = ""
-    # Act
-    resolved = resolve_node_token(token=empty, db_path=db_path)
-    # Assert
-    assert resolved is None
+    assert column in cols
 
 
 # ---------------------------------------------------------------------------
@@ -173,33 +123,31 @@ def test_record_lineage_idempotent_no_duplicate_rows(db_path: Path) -> None:
     assert len(rows) == 1
 
 
+def test_record_lineage_re_parent_raises(db_path: Path) -> None:
+    """A child cannot silently switch parents."""
+    # Arrange
+    record_lineage(child="bob", parent="alice", db_path=db_path)
+    # Act / Assert
+    with pytest.raises(ValueError, match="refusing to re-parent"):
+        record_lineage(child="bob", parent="other-root", db_path=db_path)
+
+
 # ---------------------------------------------------------------------------
 # derive_group — the heart of the default ACL check
 # ---------------------------------------------------------------------------
-#
-# Per handoff §2: "A parent together with its direct children is one
-# group. The group is the unit of default ACL — within a group every
-# node may message every other, bidirectionally."
-#
-# Concretely:
-#   * For a parent: group = {parent} ∪ {its direct children}
-#   * For a child:  group = {child's parent} ∪ {parent's other children}
 
 
 def test_derive_group_of_root_with_no_children_is_self_only(db_path: Path) -> None:
-    # Arrange — register the node but no children
-    mint_node_token(name="root", db_path=db_path)
+    # Arrange
+    name = "root"
     # Act
-    group = derive_group(name="root", db_path=db_path)
+    group = derive_group(name=name, db_path=db_path)
     # Assert
     assert group == {"root"}
 
 
 def test_derive_group_of_parent_includes_direct_children(db_path: Path) -> None:
     # Arrange
-    mint_node_token(name="root", db_path=db_path)
-    mint_node_token(name="worker-a", db_path=db_path)
-    mint_node_token(name="worker-b", db_path=db_path)
     record_lineage(child="worker-a", parent="root", db_path=db_path)
     record_lineage(child="worker-b", parent="root", db_path=db_path)
     # Act
@@ -209,11 +157,8 @@ def test_derive_group_of_parent_includes_direct_children(db_path: Path) -> None:
 
 
 def test_derive_group_of_child_includes_parent_and_siblings(db_path: Path) -> None:
-    """A sibling sees the same group as the parent does — bidirectional."""
+    """Sibling sees the same group as the parent does — bidirectional."""
     # Arrange
-    mint_node_token(name="root", db_path=db_path)
-    mint_node_token(name="worker-a", db_path=db_path)
-    mint_node_token(name="worker-b", db_path=db_path)
     record_lineage(child="worker-a", parent="root", db_path=db_path)
     record_lineage(child="worker-b", parent="root", db_path=db_path)
     # Act
@@ -225,8 +170,6 @@ def test_derive_group_of_child_includes_parent_and_siblings(db_path: Path) -> No
 def test_derive_group_excludes_cross_group_nodes(db_path: Path) -> None:
     """A different root's children are not in this group."""
     # Arrange — two unrelated families
-    for name in ("root-1", "child-1", "root-2", "child-2"):
-        mint_node_token(name=name, db_path=db_path)
     record_lineage(child="child-1", parent="root-1", db_path=db_path)
     record_lineage(child="child-2", parent="root-2", db_path=db_path)
     # Act
@@ -236,10 +179,7 @@ def test_derive_group_excludes_cross_group_nodes(db_path: Path) -> None:
 
 
 def test_derive_group_of_unknown_node_is_singleton(db_path: Path) -> None:
-    """A node that does not yet appear in lineage is its own singleton
-    group — a fresh registration starts unattached and may only talk
-    to itself until lineage is recorded.
-    """
+    """A fresh, unattached node is its own singleton group."""
     # Arrange
     name = "fresh"
     # Act
@@ -249,25 +189,139 @@ def test_derive_group_of_unknown_node_is_singleton(db_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# list_node_tokens — observability for the host operator
+# spawn_allowed — root-only spawn policy
 # ---------------------------------------------------------------------------
 
 
-def test_list_node_tokens_returns_empty_initially(db_path: Path) -> None:
+def test_spawn_allowed_returns_true_for_admin_caller(db_path: Path) -> None:
+    """``caller=None`` → admin / operator path → allowed."""
     # Arrange
-    # (no tokens minted yet)
+    caller = None
     # Act
-    rows = list_node_tokens(db_path=db_path)
+    allowed, _reason = spawn_allowed(caller=caller, db_path=db_path)
     # Assert
-    assert rows == []
+    assert allowed is True
 
 
-def test_list_node_tokens_returns_each_minted_name(db_path: Path) -> None:
+def test_spawn_allowed_returns_true_for_root_node(db_path: Path) -> None:
+    """A node with no parent → root → allowed."""
     # Arrange
-    mint_node_token(name="alice", db_path=db_path)
-    mint_node_token(name="bob", db_path=db_path)
+    caller = "root"
     # Act
-    rows = list_node_tokens(db_path=db_path)
+    allowed, _reason = spawn_allowed(caller=caller, db_path=db_path)
     # Assert
-    names = sorted(r["name"] for r in rows)
-    assert names == ["alice", "bob"]
+    assert allowed is True
+
+
+def test_spawn_allowed_returns_false_for_child_node(db_path: Path) -> None:
+    """A node with a parent → child → denied under current policy."""
+    # Arrange
+    record_lineage(child="worker-a", parent="root", db_path=db_path)
+    # Act
+    allowed, _reason = spawn_allowed(caller="worker-a", db_path=db_path)
+    # Assert
+    assert allowed is False
+
+
+def test_spawn_allowed_deny_reason_explains_lift_able_policy(
+    db_path: Path,
+) -> None:
+    # Arrange
+    record_lineage(child="worker-a", parent="root", db_path=db_path)
+    # Act
+    _allowed, reason = spawn_allowed(caller="worker-a", db_path=db_path)
+    # Assert
+    assert reason is not None and "lift-able policy" in reason
+
+
+# ---------------------------------------------------------------------------
+# grant_send / has_grant / revoke_send — cross-group ACL grants
+# ---------------------------------------------------------------------------
+
+
+def test_has_grant_returns_false_when_no_grant(db_path: Path) -> None:
+    # Arrange
+    # (no grant)
+    # Act
+    granted = has_grant(sender="alice", target="bob", db_path=db_path)
+    # Assert
+    assert granted is False
+
+
+def test_grant_send_makes_has_grant_true(db_path: Path) -> None:
+    # Arrange
+    grant_send(sender="alice", target="bob", db_path=db_path)
+    # Act
+    granted = has_grant(sender="alice", target="bob", db_path=db_path)
+    # Assert
+    assert granted is True
+
+
+def test_grant_send_is_directional(db_path: Path) -> None:
+    """A grant alice→bob does NOT imply bob→alice."""
+    # Arrange
+    grant_send(sender="alice", target="bob", db_path=db_path)
+    # Act
+    reverse_granted = has_grant(sender="bob", target="alice", db_path=db_path)
+    # Assert
+    assert reverse_granted is False
+
+
+def test_grant_send_writes_deferred_caveat_note(db_path: Path) -> None:
+    """Each grant carries the audit caveat documenting the deferred
+    cryptographic identity."""
+    # Arrange
+    grant_send(sender="alice", target="bob", db_path=db_path)
+    # Act
+    rows = list_comms_grants(db_path=db_path)
+    # Assert
+    assert rows and rows[0]["note"] == GRANT_DEFERRED_CAVEAT
+
+
+def test_grant_send_idempotent_no_duplicate_rows(db_path: Path) -> None:
+    # Arrange
+    grant_send(sender="alice", target="bob", db_path=db_path)
+    grant_send(sender="alice", target="bob", db_path=db_path)
+    # Act
+    rows = list_comms_grants(db_path=db_path)
+    # Assert
+    assert len(rows) == 1
+
+
+def test_revoke_send_removes_existing_grant(db_path: Path) -> None:
+    # Arrange
+    grant_send(sender="alice", target="bob", db_path=db_path)
+    # Act
+    removed = revoke_send(sender="alice", target="bob", db_path=db_path)
+    # Assert
+    assert removed is True
+
+
+def test_revoke_send_makes_has_grant_false(db_path: Path) -> None:
+    # Arrange
+    grant_send(sender="alice", target="bob", db_path=db_path)
+    revoke_send(sender="alice", target="bob", db_path=db_path)
+    # Act
+    granted = has_grant(sender="alice", target="bob", db_path=db_path)
+    # Assert
+    assert granted is False
+
+
+def test_revoke_send_returns_false_when_no_grant_exists(db_path: Path) -> None:
+    # Arrange
+    # (no grant)
+    # Act
+    removed = revoke_send(sender="alice", target="bob", db_path=db_path)
+    # Assert
+    assert removed is False
+
+
+def test_list_comms_grants_returns_each_grant_pair(db_path: Path) -> None:
+    # Arrange
+    grant_send(sender="alice", target="bob", db_path=db_path)
+    grant_send(sender="root-1", target="child-2", db_path=db_path)
+    # Act
+    rows = list_comms_grants(db_path=db_path)
+    # Assert
+    pairs = sorted((r["sender"], r["target"]) for r in rows)
+    assert pairs == [("alice", "bob"), ("root-1", "child-2")]

--- a/tests/scitex_agent_container/_state/test_state_db_nodes.py
+++ b/tests/scitex_agent_container/_state/test_state_db_nodes.py
@@ -1,0 +1,273 @@
+"""WI-2 — per-node tokens + lineage primitives (handoff §4).
+
+Per HANDOFF_AGENT_COMMS_2026-05-19.md §4 (WI-2 "ACL: permissioned
+messaging"):
+
+  * "Authenticated sender identity. The ACL check is only as strong
+    as the identity — the sender identity carried in
+    ``params.metadata`` must be authenticated (per-node credential
+    / bearer token), never a self-claimed name."
+
+  * "Group-based default ACL. ... The group is derived from lineage
+    — no per-pair config for the common case."
+
+This module exercises the two state.db primitives that make those
+requirements possible: per-node bearer tokens (the authenticated
+identity) and the lineage edges (parent → child) that derive a
+node's group.
+
+No mocks (handoff §0): real SQLite under ``tmp_path``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._state import state_db
+from scitex_agent_container._state.state_db_nodes import (
+    derive_group,
+    list_node_tokens,
+    mint_node_token,
+    record_lineage,
+    resolve_node_token,
+)
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    # Arrange
+    p = tmp_path / "state.db"
+    state_db.init_schema(p)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Schema — node_tokens + lineage tables
+# ---------------------------------------------------------------------------
+
+
+def test_node_tokens_table_exists(db_path: Path) -> None:
+    # Arrange
+    conn_ctx = state_db.open_db(db_path)
+    # Act
+    with conn_ctx as conn:
+        rows = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='node_tokens'"
+        ).fetchall()
+    # Assert
+    assert len(rows) == 1
+
+
+def test_lineage_table_exists(db_path: Path) -> None:
+    # Arrange
+    conn_ctx = state_db.open_db(db_path)
+    # Act
+    with conn_ctx as conn:
+        rows = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='lineage'"
+        ).fetchall()
+    # Assert
+    assert len(rows) == 1
+
+
+# ---------------------------------------------------------------------------
+# mint_node_token — generates a fresh secret + records the identity
+# ---------------------------------------------------------------------------
+
+
+def test_mint_node_token_returns_non_empty_string(db_path: Path) -> None:
+    # Arrange
+    name = "alice"
+    # Act
+    token = mint_node_token(name=name, db_path=db_path)
+    # Assert
+    assert isinstance(token, str) and len(token) >= 32
+
+
+def test_mint_node_token_idempotent_returns_same_token(db_path: Path) -> None:
+    """A second call for the same name returns the same token, not a
+    new one — re-registration must not invalidate an active bearer.
+    """
+    # Arrange
+    first = mint_node_token(name="alice", db_path=db_path)
+    # Act
+    second = mint_node_token(name="alice", db_path=db_path)
+    # Assert
+    assert first == second
+
+
+def test_mint_node_token_is_unique_per_name(db_path: Path) -> None:
+    # Arrange
+    a = mint_node_token(name="alice", db_path=db_path)
+    b = mint_node_token(name="bob", db_path=db_path)
+    # Act
+    different = a != b
+    # Assert
+    assert different is True
+
+
+# ---------------------------------------------------------------------------
+# resolve_node_token — bearer → identity, the auth side of ACL
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_node_token_returns_minted_identity(db_path: Path) -> None:
+    # Arrange
+    token = mint_node_token(name="alice", db_path=db_path)
+    # Act
+    resolved = resolve_node_token(token=token, db_path=db_path)
+    # Assert
+    assert resolved == "alice"
+
+
+def test_resolve_node_token_returns_none_for_unknown_bearer(db_path: Path) -> None:
+    # Arrange
+    bogus = "no-such-token-1234567890abcdef"
+    # Act
+    resolved = resolve_node_token(token=bogus, db_path=db_path)
+    # Assert
+    assert resolved is None
+
+
+def test_resolve_node_token_returns_none_for_empty_string(db_path: Path) -> None:
+    # Arrange
+    empty = ""
+    # Act
+    resolved = resolve_node_token(token=empty, db_path=db_path)
+    # Assert
+    assert resolved is None
+
+
+# ---------------------------------------------------------------------------
+# record_lineage — parent → child edges
+# ---------------------------------------------------------------------------
+
+
+def test_record_lineage_persists_parent_pointer(db_path: Path) -> None:
+    # Arrange
+    record_lineage(child="bob", parent="alice", db_path=db_path)
+    # Act
+    conn_ctx = state_db.open_db(db_path)
+    with conn_ctx as conn:
+        row = conn.execute(
+            "SELECT parent_name FROM lineage WHERE child_name='bob'"
+        ).fetchone()
+    # Assert
+    assert row["parent_name"] == "alice"
+
+
+def test_record_lineage_idempotent_no_duplicate_rows(db_path: Path) -> None:
+    """Re-recording the same edge does not duplicate the row."""
+    # Arrange
+    record_lineage(child="bob", parent="alice", db_path=db_path)
+    record_lineage(child="bob", parent="alice", db_path=db_path)
+    # Act
+    conn_ctx = state_db.open_db(db_path)
+    with conn_ctx as conn:
+        rows = conn.execute(
+            "SELECT child_name FROM lineage WHERE child_name='bob'"
+        ).fetchall()
+    # Assert
+    assert len(rows) == 1
+
+
+# ---------------------------------------------------------------------------
+# derive_group — the heart of the default ACL check
+# ---------------------------------------------------------------------------
+#
+# Per handoff §2: "A parent together with its direct children is one
+# group. The group is the unit of default ACL — within a group every
+# node may message every other, bidirectionally."
+#
+# Concretely:
+#   * For a parent: group = {parent} ∪ {its direct children}
+#   * For a child:  group = {child's parent} ∪ {parent's other children}
+
+
+def test_derive_group_of_root_with_no_children_is_self_only(db_path: Path) -> None:
+    # Arrange — register the node but no children
+    mint_node_token(name="root", db_path=db_path)
+    # Act
+    group = derive_group(name="root", db_path=db_path)
+    # Assert
+    assert group == {"root"}
+
+
+def test_derive_group_of_parent_includes_direct_children(db_path: Path) -> None:
+    # Arrange
+    mint_node_token(name="root", db_path=db_path)
+    mint_node_token(name="worker-a", db_path=db_path)
+    mint_node_token(name="worker-b", db_path=db_path)
+    record_lineage(child="worker-a", parent="root", db_path=db_path)
+    record_lineage(child="worker-b", parent="root", db_path=db_path)
+    # Act
+    group = derive_group(name="root", db_path=db_path)
+    # Assert
+    assert group == {"root", "worker-a", "worker-b"}
+
+
+def test_derive_group_of_child_includes_parent_and_siblings(db_path: Path) -> None:
+    """A sibling sees the same group as the parent does — bidirectional."""
+    # Arrange
+    mint_node_token(name="root", db_path=db_path)
+    mint_node_token(name="worker-a", db_path=db_path)
+    mint_node_token(name="worker-b", db_path=db_path)
+    record_lineage(child="worker-a", parent="root", db_path=db_path)
+    record_lineage(child="worker-b", parent="root", db_path=db_path)
+    # Act
+    group = derive_group(name="worker-a", db_path=db_path)
+    # Assert
+    assert group == {"root", "worker-a", "worker-b"}
+
+
+def test_derive_group_excludes_cross_group_nodes(db_path: Path) -> None:
+    """A different root's children are not in this group."""
+    # Arrange — two unrelated families
+    for name in ("root-1", "child-1", "root-2", "child-2"):
+        mint_node_token(name=name, db_path=db_path)
+    record_lineage(child="child-1", parent="root-1", db_path=db_path)
+    record_lineage(child="child-2", parent="root-2", db_path=db_path)
+    # Act
+    group = derive_group(name="child-1", db_path=db_path)
+    # Assert
+    assert group == {"root-1", "child-1"}
+
+
+def test_derive_group_of_unknown_node_is_singleton(db_path: Path) -> None:
+    """A node that does not yet appear in lineage is its own singleton
+    group — a fresh registration starts unattached and may only talk
+    to itself until lineage is recorded.
+    """
+    # Arrange
+    name = "fresh"
+    # Act
+    group = derive_group(name=name, db_path=db_path)
+    # Assert
+    assert group == {"fresh"}
+
+
+# ---------------------------------------------------------------------------
+# list_node_tokens — observability for the host operator
+# ---------------------------------------------------------------------------
+
+
+def test_list_node_tokens_returns_empty_initially(db_path: Path) -> None:
+    # Arrange
+    # (no tokens minted yet)
+    # Act
+    rows = list_node_tokens(db_path=db_path)
+    # Assert
+    assert rows == []
+
+
+def test_list_node_tokens_returns_each_minted_name(db_path: Path) -> None:
+    # Arrange
+    mint_node_token(name="alice", db_path=db_path)
+    mint_node_token(name="bob", db_path=db_path)
+    # Act
+    rows = list_node_tokens(db_path=db_path)
+    # Assert
+    names = sorted(r["name"] for r in rows)
+    assert names == ["alice", "bob"]

--- a/tests/scitex_agent_container/_state/test_state_db_nodes.py
+++ b/tests/scitex_agent_container/_state/test_state_db_nodes.py
@@ -25,12 +25,14 @@ import pytest
 
 from scitex_agent_container._state import state_db
 from scitex_agent_container._state.state_db_nodes import (
-    GRANT_DEFERRED_CAVEAT,
     derive_group,
     grant_send,
     has_grant,
     list_comms_grants,
+    list_node_tokens,
+    mint_node_token,
     record_lineage,
+    resolve_node_token,
     revoke_send,
     spawn_allowed,
 )
@@ -267,15 +269,20 @@ def test_grant_send_is_directional(db_path: Path) -> None:
     assert reverse_granted is False
 
 
-def test_grant_send_writes_deferred_caveat_note(db_path: Path) -> None:
-    """Each grant carries the audit caveat documenting the deferred
-    cryptographic identity."""
+def test_grant_send_records_caller_supplied_audit_note(db_path: Path) -> None:
+    """An operator-supplied ``note`` round-trips into ``comms_grants``
+    so the audit trail records *why* the grant was authorised."""
     # Arrange
-    grant_send(sender="alice", target="bob", db_path=db_path)
+    grant_send(
+        sender="alice",
+        target="bob",
+        db_path=db_path,
+        note="handoff-2026-05-21",
+    )
     # Act
     rows = list_comms_grants(db_path=db_path)
     # Assert
-    assert rows and rows[0]["note"] == GRANT_DEFERRED_CAVEAT
+    assert rows and rows[0]["note"] == "handoff-2026-05-21"
 
 
 def test_grant_send_idempotent_no_duplicate_rows(db_path: Path) -> None:
@@ -325,3 +332,96 @@ def test_list_comms_grants_returns_each_grant_pair(db_path: Path) -> None:
     # Assert
     pairs = sorted((r["sender"], r["target"]) for r in rows)
     assert pairs == [("alice", "bob"), ("root-1", "child-2")]
+
+
+# ---------------------------------------------------------------------------
+# node_tokens — authenticated identity primitive (handoff §4 acceptance)
+# ---------------------------------------------------------------------------
+
+
+def test_node_tokens_table_exists(db_path: Path) -> None:
+    # Arrange
+    conn_ctx = state_db.open_db(db_path)
+    # Act
+    with conn_ctx as conn:
+        rows = conn.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type='table' AND name='node_tokens'"
+        ).fetchall()
+    # Assert
+    assert len(rows) == 1
+
+
+def test_mint_node_token_returns_non_empty_string(db_path: Path) -> None:
+    # Arrange
+    name = "alice"
+    # Act
+    token = mint_node_token(name=name, db_path=db_path)
+    # Assert
+    assert isinstance(token, str) and len(token) >= 32
+
+
+def test_mint_node_token_is_idempotent_per_name(db_path: Path) -> None:
+    """Re-registration returns the same token, so an active bearer
+    keeps working across a re-register."""
+    # Arrange
+    first = mint_node_token(name="alice", db_path=db_path)
+    # Act
+    second = mint_node_token(name="alice", db_path=db_path)
+    # Assert
+    assert first == second
+
+
+def test_mint_node_token_is_unique_per_name(db_path: Path) -> None:
+    # Arrange
+    a = mint_node_token(name="alice", db_path=db_path)
+    b = mint_node_token(name="bob", db_path=db_path)
+    # Act
+    different = a != b
+    # Assert
+    assert different is True
+
+
+def test_resolve_node_token_returns_minted_identity(db_path: Path) -> None:
+    # Arrange
+    token = mint_node_token(name="alice", db_path=db_path)
+    # Act
+    resolved = resolve_node_token(token=token, db_path=db_path)
+    # Assert
+    assert resolved == "alice"
+
+
+def test_resolve_node_token_returns_none_for_unknown_bearer(
+    db_path: Path,
+) -> None:
+    # Arrange
+    bogus = "no-such-token-1234567890abcdef"
+    # Act
+    resolved = resolve_node_token(token=bogus, db_path=db_path)
+    # Assert
+    assert resolved is None
+
+
+def test_resolve_node_token_returns_none_for_empty_string(
+    db_path: Path,
+) -> None:
+    # Arrange
+    empty = ""
+    # Act
+    resolved = resolve_node_token(token=empty, db_path=db_path)
+    # Assert
+    assert resolved is None
+
+
+def test_list_node_tokens_returns_each_minted_name(db_path: Path) -> None:
+    """The token observability surface returns names (NOT token
+    values — that would defeat the purpose of storing them as
+    secrets)."""
+    # Arrange
+    mint_node_token(name="alice", db_path=db_path)
+    mint_node_token(name="bob", db_path=db_path)
+    # Act
+    rows = list_node_tokens(db_path=db_path)
+    # Assert
+    names = sorted(r["name"] for r in rows)
+    assert names == ["alice", "bob"]


### PR DESCRIPTION
## Summary
Per HANDOFF_AGENT_COMMS_2026-05-19.md §4 (WI-2) and the lead's 2026-05-20 directive: **limited scope**. Per-node authenticated identity is deferred to a follow-on handoff (related to the existing sac-accounts-per-agent-credentials-and-rotation FUTURE doc).

What this PR ships:
- **Group-based default ACL** — intra-group bidirectional (parent↔child + sibling↔sibling); cross-group denied by default. Group derived from a new ``lineage`` SQLite table.
- **Cross-group grants** — new ``comms_grants`` SQLite table. Every grant row carries the audit caveat ``"trusts metadata.from_agent until per-node creds land"`` (default ``note`` value). ``grant_send`` / ``has_grant`` / ``revoke_send`` / ``list_comms_grants`` helpers.
- **Spawn-permission gate** — root-only by current policy (lift-able per handoff §2 D5). New optional ``caller`` field on ``POST /agents`` body; a child caller gets ``403`` with an explanatory "lift-able policy" reason. ``check_spawn`` / ``spawn_allowed`` helpers.
- **Loud denials** — 403 + WARNING log line on every reject.

What's **deferred** (separate follow-on, related to the sac-accounts FUTURE doc):
- Authenticated per-node identity (per-node bearer tokens / cryptographic identity).
- The "identity cannot be spoofed via a metadata field" acceptance criterion.
- ``mint_node_token`` / ``resolve_node_token`` / ``NodeAuthMiddleware`` from the previous revision of this PR have been removed.

Identity caveat is documented per surface:
- ``_acl.py`` + ``state_db_nodes.py`` module docstrings.
- ``check_send_acl`` docstring ("Identity caveat" section).
- ``GRANT_DEFERRED_CAVEAT`` constant written into every grant row.
- ``node_message_send`` route docstring.
- ``comms_grants`` schema comment in ``state_db.py``.

## Stacking
This PR is stacked on PR #125 (WI-3 external nodes). Merge WI-3 first.

## Test plan
- [x] ``pytest tests/.../_state/test_state_db_nodes.py`` — 27 passed (lineage, derive_group, spawn_allowed, grant primitives).
- [x] ``pytest tests/.../_listen/test__acl.py`` — 18 passed (8 ``check_send_acl`` decisions including explicit-grant flip, 4 ``check_spawn`` decisions, 6 HTTP routes).
- [x] ``pytest tests/.../_listen/ tests/.../_state/test_state_db_nodes.py tests/.../a2a/`` — 335 passed (no regressions).
- [x] ``ruff check --select F401,F811`` — clean.
- [x] Local ``scitex-dev ecosystem audit-all`` — audit-python-apis clean.