### PR TITLE
feat(wi-4): name → host resolver primitive for cross-host routing

### DIFF
--- a/src/scitex_agent_container/_state/state_db_nodes.py
+++ b/src/scitex_agent_container/_state/state_db_nodes.py
@@ -45,9 +45,11 @@ from typing import Any
 
 __all__ = [
     "derive_group",
+    "is_local_node",
     "list_node_tokens",
     "mint_node_token",
     "record_lineage",
+    "resolve_node_host",
     "resolve_node_token",
 ]
 
@@ -195,6 +197,69 @@ def derive_group(
         for r in sibling_rows:
             group.add(str(r["child_name"]))
         return group
+
+
+def resolve_node_host(
+    *,
+    name: str,
+    db_path: Path | None = None,
+) -> dict[str, Any] | None:
+    """Map a node ``name`` to ``{host, a2a_port}`` from the
+    ``instances`` table.
+
+    Returns ``None`` when the name does not match a *live* instance
+    (``ended_at IS NULL``). When several live records exist for the
+    same name (e.g., a restart race), the most recently started one
+    wins — cross-host forwarding cannot pick non-deterministically.
+
+    WI-4: the cross-host forwarder consults this resolver to decide
+    whether ``message:send`` targets a local node (broker publish)
+    or a remote node (HTTP forward to that host's ``sac listen``).
+    """
+    if not name:
+        return None
+    from .state_db import open_db
+
+    with open_db(db_path) as conn:
+        row = conn.execute(
+            """
+            SELECT host, a2a_port
+              FROM instances
+             WHERE name = ? AND ended_at IS NULL
+             ORDER BY started_at DESC, id DESC
+             LIMIT 1
+            """,
+            (name,),
+        ).fetchone()
+    if row is None:
+        return None
+    return {
+        "host": str(row["host"]),
+        "a2a_port": int(row["a2a_port"]) if row["a2a_port"] is not None else None,
+    }
+
+
+def is_local_node(
+    *,
+    name: str,
+    local_host: str,
+    db_path: Path | None = None,
+) -> bool:
+    """Return ``True`` if ``name`` should be served locally, ``False``
+    if the cross-host forwarder should hand it off.
+
+    Local cases:
+
+    * The name resolves to ``local_host`` via ``resolve_node_host``.
+    * The name does NOT resolve to any host (unknown / external node) —
+      defer to the local ``NodeRegistry`` implicit-registration path.
+      Forwarding a never-seen name would synthesise an SSRF target
+      from a self-claimed string; the host-local path is correct.
+    """
+    info = resolve_node_host(name=name, db_path=db_path)
+    if info is None:
+        return True
+    return info["host"] == local_host
 
 
 def list_node_tokens(db_path: Path | None = None) -> list[dict[str, Any]]:

--- a/tests/scitex_agent_container/_state/test_state_db_nodes_resolve.py
+++ b/tests/scitex_agent_container/_state/test_state_db_nodes_resolve.py
@@ -1,0 +1,154 @@
+"""WI-4 — name → host resolver primitive (handoff §4).
+
+Per HANDOFF_AGENT_COMMS_2026-05-19.md §4 (WI-4 "Cross-host routing"):
+
+  Required: A name→host→URL resolver; reuse sac's peer/fleet host
+  registry and the ``peer.py post_turn`` cross-host pattern.
+
+This module exercises the *resolver primitive*. The HTTP forwarding
+layer that uses this primitive is gated on cross-host bearer
+discovery (see QUESTIONS Q4) and lands as a separate change.
+
+No mocks (handoff §0): real SQLite under ``tmp_path``, real
+``record_instance_start`` writes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._state import state_db
+from scitex_agent_container._state.state_db_nodes import (
+    is_local_node,
+    resolve_node_host,
+)
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    # Arrange
+    p = tmp_path / "state.db"
+    state_db.init_schema(p)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# resolve_node_host — name → (host, a2a_port) lookup
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_node_host_returns_none_for_unknown_name(db_path: Path) -> None:
+    # Arrange
+    name = "no-such-node"
+    # Act
+    result = resolve_node_host(name=name, db_path=db_path)
+    # Assert
+    assert result is None
+
+
+def test_resolve_node_host_returns_host_for_recorded_instance(db_path: Path) -> None:
+    """A sac-managed agent recorded via ``record_instance_start`` is
+    resolvable by name."""
+    # Arrange
+    state_db.record_instance_start(
+        name="alice",
+        host="host-a",
+        a2a_port=8801,
+        db_path=db_path,
+    )
+    # Act
+    result = resolve_node_host(name="alice", db_path=db_path)
+    # Assert
+    assert result is not None and result["host"] == "host-a"
+
+
+def test_resolve_node_host_returns_a2a_port_when_set(db_path: Path) -> None:
+    # Arrange
+    state_db.record_instance_start(
+        name="alice",
+        host="host-a",
+        a2a_port=8801,
+        db_path=db_path,
+    )
+    # Act
+    result = resolve_node_host(name="alice", db_path=db_path)
+    # Assert
+    assert result is not None and result["a2a_port"] == 8801
+
+
+def test_resolve_node_host_skips_ended_instances(db_path: Path) -> None:
+    """An ended instance must not satisfy a live-routing lookup."""
+    # Arrange
+    instance_id = state_db.record_instance_start(
+        name="alice",
+        host="host-a",
+        a2a_port=8801,
+        db_path=db_path,
+    )
+    state_db.record_instance_stop(instance_id, db_path=db_path)
+    # Act
+    result = resolve_node_host(name="alice", db_path=db_path)
+    # Assert
+    assert result is None
+
+
+def test_resolve_node_host_returns_latest_when_multiple_live(db_path: Path) -> None:
+    """Two live records for the same name (e.g., a restart race) —
+    return the most recent. Determinism matters: cross-host forward
+    cannot pick non-deterministically.
+    """
+    # Arrange
+    state_db.record_instance_start(
+        name="alice", host="host-a", a2a_port=8801, db_path=db_path
+    )
+    state_db.record_instance_start(
+        name="alice", host="host-b", a2a_port=8802, db_path=db_path
+    )
+    # Act
+    result = resolve_node_host(name="alice", db_path=db_path)
+    # Assert — most-recent wins
+    assert result is not None and result["host"] == "host-b"
+
+
+# ---------------------------------------------------------------------------
+# is_local_node — local-vs-remote decision for the forwarder
+# ---------------------------------------------------------------------------
+
+
+def test_is_local_node_true_when_host_matches_local(db_path: Path) -> None:
+    # Arrange
+    state_db.record_instance_start(
+        name="alice", host="host-a", a2a_port=8801, db_path=db_path
+    )
+    # Act
+    local = is_local_node(name="alice", local_host="host-a", db_path=db_path)
+    # Assert
+    assert local is True
+
+
+def test_is_local_node_false_when_host_differs(db_path: Path) -> None:
+    # Arrange
+    state_db.record_instance_start(
+        name="alice", host="host-a", a2a_port=8801, db_path=db_path
+    )
+    # Act
+    local = is_local_node(name="alice", local_host="host-b", db_path=db_path)
+    # Assert
+    assert local is False
+
+
+def test_is_local_node_true_for_unknown_name(db_path: Path) -> None:
+    """An unknown name (no instance recorded — e.g., an external node
+    we haven't seen before) is treated as local. The local
+    ``NodeRegistry`` handles implicit registration; deferring the
+    decision to the cross-host forwarder for a node sac doesn't know
+    about would just synthesise an SSRF target.
+    """
+    # Arrange
+    # (no instance recorded)
+    # Act
+    local = is_local_node(name="ghost", local_host="host-a", db_path=db_path)
+    # Assert
+    assert local is True


### PR DESCRIPTION
## Summary
Per HANDOFF_AGENT_COMMS_2026-05-19.md §4 (WI-4). Stacks on PR #128 (WI-2). Ships the **resolver primitive** that the cross-host forwarder will sit on; the forwarder itself is gated on a separate decision documented as **Q4 in /work/QUESTIONS.md** (per-host bearer discovery).

- New ``resolve_node_host(name)`` in ``_state/state_db_nodes.py`` — consults ``instances`` table, picks newest live row deterministically (``started_at DESC, id DESC``).
- New ``is_local_node(name, local_host)`` — local-vs-remote decision; treats unknown names as local so external-node implicit registration still works (forwarding a never-seen name would be an SSRF risk).

## Q4 — needs your decision

How does host A know host B's listen bearer for the cross-host forward? Three options described in ``/work/QUESTIONS.md``:

a) Shared fleet bearer (simplest; weakest).
b) Per-host token registry on each host (medium cost; per-host blast radius). Handoff hints at this.
c) Asymmetric crypto + signed JWT (highest cost; cleanest blast radius).

As soon as you pick one I'll add the HTTP forwarding layer that uses these primitives.

## Test plan
- [x] ``pytest tests/.../_state/test_state_db_nodes_resolve.py`` — 8 passed (no mocks; real SQLite + real ``record_instance_start``).
- [x] Local ``scitex-dev ecosystem audit-all`` — audit-python-apis clean.

## Out of scope
- HTTP forwarder layer — gated on Q4 decision.
- Authenticated cross-host trust — same gate.