### PR TITLE
release: v0.17.3 — channel push fixes (capability + requires_reply meta-string)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-agent-container"
-version = "0.17.2"
+version = "0.17.3"
 description = "Declarative YAML-based framework for defining, managing, and orchestrating AI coding agent instances"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/src/scitex_agent_container/_mcp/channel.py
+++ b/src/scitex_agent_container/_mcp/channel.py
@@ -121,18 +121,37 @@ async def _consume_sse(
         backoff = min(backoff * 2, 30.0)
 
 
+def _meta_str(value: Any) -> str:
+    """Coerce a meta value to the string the Claude Code client demands.
+
+    Claude Code's ``claude/channel`` notification schema types **every**
+    ``meta`` value as a string. A raw bool (``requires_reply``) trips the
+    client's Zod validator — its notification handler throws and the
+    pushed turn is silently dropped (mcp-logs-sac: "Uncaught error in
+    notification handler: ZodError ... requires_reply: expected string,
+    received boolean"). Render bools JSON-style so a receiving agent can
+    compare them verbatim against ``"true"`` / ``"false"``.
+    """
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return str(value)
+
+
 def _build_notification(event: dict[str, Any]) -> dict[str, Any]:
     """Project a bus event onto the Claude Code channel notification
     shape: ``{content, meta: {source, chat_id, ts, ...}}``.
+
+    Every ``meta`` value is stringified via :func:`_meta_str` — the
+    client schema rejects non-string values (see that helper).
     """
     meta: dict[str, Any] = {
-        "source": event.get("from_agent", "unknown"),
-        "ts": str(event.get("ts", "")),
-        "msg_id": event.get("msg_id", ""),
+        "source": _meta_str(event.get("from_agent", "unknown")),
+        "ts": _meta_str(event.get("ts", "")),
+        "msg_id": _meta_str(event.get("msg_id", "")),
     }
     for k in ("conversation_id", "in_reply_to", "priority", "requires_reply"):
         if k in event:
-            meta[k] = event[k]
+            meta[k] = _meta_str(event[k])
     return {
         "content": event.get("content", ""),
         "meta": meta,

--- a/src/scitex_agent_container/_mcp/channel.py
+++ b/src/scitex_agent_container/_mcp/channel.py
@@ -199,7 +199,16 @@ async def _serve(
             ServerSession(
                 read_stream,
                 write_stream,
-                server.create_initialization_options(),
+                # Declare the `claude/channel` experimental capability in the
+                # initialize response. Without it Claude Code logs "Channel
+                # notifications skipped: server did not declare claude/channel
+                # capability" and drops every notifications/claude/channel we
+                # push — the receive→inject seam dies on the *client* side even
+                # though send_message succeeded. This is distinct from the
+                # earlier silent-drop (the server not pushing at all).
+                server.create_initialization_options(
+                    experimental_capabilities={"claude/channel": {}},
+                ),
             )
         )
 

--- a/src/scitex_agent_container/_sphinx_html/.buildinfo
+++ b/src/scitex_agent_container/_sphinx_html/.buildinfo
@@ -1,4 +1,4 @@
 # Sphinx build info version 1
 # This file records the configuration used when building these files. When it is not found, a full rebuild will be done.
-config: ffb059c0aea708efa8b8074017284678
+config: a79c689f22ee1f2c962358b9e910fde4
 tags: 645f666f9bcd5a90fca523b33c5a78b7

--- a/src/scitex_agent_container/_sphinx_html/_modules/index.html
+++ b/src/scitex_agent_container/_sphinx_html/_modules/index.html
@@ -5,7 +5,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Overview: module code &mdash; scitex-agent-container v0.17.2</title>
+  <title>Overview: module code &mdash; scitex-agent-container v0.17.3</title>
       <link rel="stylesheet" type="text/css" href="../_static/pygments.css?v=b86133f3" />
       <link rel="stylesheet" type="text/css" href="../_static/css/theme.css?v=9edc463e" />
       <link rel="stylesheet" type="text/css" href="../_static/copybutton.css?v=76b2166b" />
@@ -13,7 +13,7 @@
   
       <script src="../_static/jquery.js?v=5d32c60e"></script>
       <script src="../_static/_sphinx_javascript_frameworks_compat.js?v=2cd50e6c"></script>
-      <script src="../_static/documentation_options.js?v=9fbddafe"></script>
+      <script src="../_static/documentation_options.js?v=3bc55ee7"></script>
       <script src="../_static/doctools.js?v=fd6eb6e6"></script>
       <script src="../_static/sphinx_highlight.js?v=6ffebe34"></script>
       <script src="../_static/clipboard.min.js?v=a7894cd8"></script>

--- a/src/scitex_agent_container/_sphinx_html/_modules/scitex_agent_container/config.html
+++ b/src/scitex_agent_container/_sphinx_html/_modules/scitex_agent_container/config.html
@@ -5,7 +5,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>scitex_agent_container.config &mdash; scitex-agent-container v0.17.2</title>
+  <title>scitex_agent_container.config &mdash; scitex-agent-container v0.17.3</title>
       <link rel="stylesheet" type="text/css" href="../../_static/pygments.css?v=b86133f3" />
       <link rel="stylesheet" type="text/css" href="../../_static/css/theme.css?v=9edc463e" />
       <link rel="stylesheet" type="text/css" href="../../_static/copybutton.css?v=76b2166b" />
@@ -13,7 +13,7 @@
   
       <script src="../../_static/jquery.js?v=5d32c60e"></script>
       <script src="../../_static/_sphinx_javascript_frameworks_compat.js?v=2cd50e6c"></script>
-      <script src="../../_static/documentation_options.js?v=9fbddafe"></script>
+      <script src="../../_static/documentation_options.js?v=3bc55ee7"></script>
       <script src="../../_static/doctools.js?v=fd6eb6e6"></script>
       <script src="../../_static/sphinx_highlight.js?v=6ffebe34"></script>
       <script src="../../_static/clipboard.min.js?v=a7894cd8"></script>

--- a/src/scitex_agent_container/_sphinx_html/_modules/scitex_agent_container/config/_host.html
+++ b/src/scitex_agent_container/_sphinx_html/_modules/scitex_agent_container/config/_host.html
@@ -5,7 +5,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>scitex_agent_container.config._host &mdash; scitex-agent-container v0.17.2</title>
+  <title>scitex_agent_container.config._host &mdash; scitex-agent-container v0.17.3</title>
       <link rel="stylesheet" type="text/css" href="../../../_static/pygments.css?v=b86133f3" />
       <link rel="stylesheet" type="text/css" href="../../../_static/css/theme.css?v=9edc463e" />
       <link rel="stylesheet" type="text/css" href="../../../_static/copybutton.css?v=76b2166b" />
@@ -13,7 +13,7 @@
   
       <script src="../../../_static/jquery.js?v=5d32c60e"></script>
       <script src="../../../_static/_sphinx_javascript_frameworks_compat.js?v=2cd50e6c"></script>
-      <script src="../../../_static/documentation_options.js?v=9fbddafe"></script>
+      <script src="../../../_static/documentation_options.js?v=3bc55ee7"></script>
       <script src="../../../_static/doctools.js?v=fd6eb6e6"></script>
       <script src="../../../_static/sphinx_highlight.js?v=6ffebe34"></script>
       <script src="../../../_static/clipboard.min.js?v=a7894cd8"></script>

--- a/src/scitex_agent_container/_sphinx_html/_modules/scitex_agent_container/config/_loaders.html
+++ b/src/scitex_agent_container/_sphinx_html/_modules/scitex_agent_container/config/_loaders.html
@@ -5,7 +5,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>scitex_agent_container.config._loaders &mdash; scitex-agent-container v0.17.2</title>
+  <title>scitex_agent_container.config._loaders &mdash; scitex-agent-container v0.17.3</title>
       <link rel="stylesheet" type="text/css" href="../../../_static/pygments.css?v=b86133f3" />
       <link rel="stylesheet" type="text/css" href="../../../_static/css/theme.css?v=9edc463e" />
       <link rel="stylesheet" type="text/css" href="../../../_static/copybutton.css?v=76b2166b" />
@@ -13,7 +13,7 @@
   
       <script src="../../../_static/jquery.js?v=5d32c60e"></script>
       <script src="../../../_static/_sphinx_javascript_frameworks_compat.js?v=2cd50e6c"></script>
-      <script src="../../../_static/documentation_options.js?v=9fbddafe"></script>
+      <script src="../../../_static/documentation_options.js?v=3bc55ee7"></script>
       <script src="../../../_static/doctools.js?v=fd6eb6e6"></script>
       <script src="../../../_static/sphinx_highlight.js?v=6ffebe34"></script>
       <script src="../../../_static/clipboard.min.js?v=a7894cd8"></script>

--- a/src/scitex_agent_container/_sphinx_html/_modules/scitex_agent_container/config/_proxy_types.html
+++ b/src/scitex_agent_container/_sphinx_html/_modules/scitex_agent_container/config/_proxy_types.html
@@ -5,7 +5,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>scitex_agent_container.config._proxy_types &mdash; scitex-agent-container v0.17.2</title>
+  <title>scitex_agent_container.config._proxy_types &mdash; scitex-agent-container v0.17.3</title>
       <link rel="stylesheet" type="text/css" href="../../../_static/pygments.css?v=b86133f3" />
       <link rel="stylesheet" type="text/css" href="../../../_static/css/theme.css?v=9edc463e" />
       <link rel="stylesheet" type="text/css" href="../../../_static/copybutton.css?v=76b2166b" />
@@ -13,7 +13,7 @@
   
       <script src="../../../_static/jquery.js?v=5d32c60e"></script>
       <script src="../../../_static/_sphinx_javascript_frameworks_compat.js?v=2cd50e6c"></script>
-      <script src="../../../_static/documentation_options.js?v=9fbddafe"></script>
+      <script src="../../../_static/documentation_options.js?v=3bc55ee7"></script>
       <script src="../../../_static/doctools.js?v=fd6eb6e6"></script>
       <script src="../../../_static/sphinx_highlight.js?v=6ffebe34"></script>
       <script src="../../../_static/clipboard.min.js?v=a7894cd8"></script>

--- a/src/scitex_agent_container/_sphinx_html/_modules/scitex_agent_container/config/_resolve.html
+++ b/src/scitex_agent_container/_sphinx_html/_modules/scitex_agent_container/config/_resolve.html
@@ -5,7 +5,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>scitex_agent_container.config._resolve &mdash; scitex-agent-container v0.17.2</title>
+  <title>scitex_agent_container.config._resolve &mdash; scitex-agent-container v0.17.3</title>
       <link rel="stylesheet" type="text/css" href="../../../_static/pygments.css?v=b86133f3" />
       <link rel="stylesheet" type="text/css" href="../../../_static/css/theme.css?v=9edc463e" />
       <link rel="stylesheet" type="text/css" href="../../../_static/copybutton.css?v=76b2166b" />
@@ -13,7 +13,7 @@
   
       <script src="../../../_static/jquery.js?v=5d32c60e"></script>
       <script src="../../../_static/_sphinx_javascript_frameworks_compat.js?v=2cd50e6c"></script>
-      <script src="../../../_static/documentation_options.js?v=9fbddafe"></script>
+      <script src="../../../_static/documentation_options.js?v=3bc55ee7"></script>
       <script src="../../../_static/doctools.js?v=fd6eb6e6"></script>
       <script src="../../../_static/sphinx_highlight.js?v=6ffebe34"></script>
       <script src="../../../_static/clipboard.min.js?v=a7894cd8"></script>

--- a/src/scitex_agent_container/_sphinx_html/_modules/scitex_agent_container/config/_types.html
+++ b/src/scitex_agent_container/_sphinx_html/_modules/scitex_agent_container/config/_types.html
@@ -5,7 +5,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>scitex_agent_container.config._types &mdash; scitex-agent-container v0.17.2</title>
+  <title>scitex_agent_container.config._types &mdash; scitex-agent-container v0.17.3</title>
       <link rel="stylesheet" type="text/css" href="../../../_static/pygments.css?v=b86133f3" />
       <link rel="stylesheet" type="text/css" href="../../../_static/css/theme.css?v=9edc463e" />
       <link rel="stylesheet" type="text/css" href="../../../_static/copybutton.css?v=76b2166b" />
@@ -13,7 +13,7 @@
   
       <script src="../../../_static/jquery.js?v=5d32c60e"></script>
       <script src="../../../_static/_sphinx_javascript_frameworks_compat.js?v=2cd50e6c"></script>
-      <script src="../../../_static/documentation_options.js?v=9fbddafe"></script>
+      <script src="../../../_static/documentation_options.js?v=3bc55ee7"></script>
       <script src="../../../_static/doctools.js?v=fd6eb6e6"></script>
       <script src="../../../_static/sphinx_highlight.js?v=6ffebe34"></script>
       <script src="../../../_static/clipboard.min.js?v=a7894cd8"></script>

--- a/src/scitex_agent_container/_sphinx_html/_modules/scitex_agent_container/config/_validation.html
+++ b/src/scitex_agent_container/_sphinx_html/_modules/scitex_agent_container/config/_validation.html
@@ -5,7 +5,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>scitex_agent_container.config._validation &mdash; scitex-agent-container v0.17.2</title>
+  <title>scitex_agent_container.config._validation &mdash; scitex-agent-container v0.17.3</title>
       <link rel="stylesheet" type="text/css" href="../../../_static/pygments.css?v=b86133f3" />
       <link rel="stylesheet" type="text/css" href="../../../_static/css/theme.css?v=9edc463e" />
       <link rel="stylesheet" type="text/css" href="../../../_static/copybutton.css?v=76b2166b" />
@@ -13,7 +13,7 @@
   
       <script src="../../../_static/jquery.js?v=5d32c60e"></script>
       <script src="../../../_static/_sphinx_javascript_frameworks_compat.js?v=2cd50e6c"></script>
-      <script src="../../../_static/documentation_options.js?v=9fbddafe"></script>
+      <script src="../../../_static/documentation_options.js?v=3bc55ee7"></script>
       <script src="../../../_static/doctools.js?v=fd6eb6e6"></script>
       <script src="../../../_static/sphinx_highlight.js?v=6ffebe34"></script>
       <script src="../../../_static/clipboard.min.js?v=a7894cd8"></script>

--- a/src/scitex_agent_container/_sphinx_html/_modules/scitex_agent_container/runtimes/prompts.html
+++ b/src/scitex_agent_container/_sphinx_html/_modules/scitex_agent_container/runtimes/prompts.html
@@ -5,7 +5,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>scitex_agent_container.runtimes.prompts &mdash; scitex-agent-container v0.17.2</title>
+  <title>scitex_agent_container.runtimes.prompts &mdash; scitex-agent-container v0.17.3</title>
       <link rel="stylesheet" type="text/css" href="../../../_static/pygments.css?v=b86133f3" />
       <link rel="stylesheet" type="text/css" href="../../../_static/css/theme.css?v=9edc463e" />
       <link rel="stylesheet" type="text/css" href="../../../_static/copybutton.css?v=76b2166b" />
@@ -13,7 +13,7 @@
   
       <script src="../../../_static/jquery.js?v=5d32c60e"></script>
       <script src="../../../_static/_sphinx_javascript_frameworks_compat.js?v=2cd50e6c"></script>
-      <script src="../../../_static/documentation_options.js?v=9fbddafe"></script>
+      <script src="../../../_static/documentation_options.js?v=3bc55ee7"></script>
       <script src="../../../_static/doctools.js?v=fd6eb6e6"></script>
       <script src="../../../_static/sphinx_highlight.js?v=6ffebe34"></script>
       <script src="../../../_static/clipboard.min.js?v=a7894cd8"></script>

--- a/src/scitex_agent_container/_sphinx_html/_static/documentation_options.js
+++ b/src/scitex_agent_container/_sphinx_html/_static/documentation_options.js
@@ -1,5 +1,5 @@
 const DOCUMENTATION_OPTIONS = {
-    VERSION: '0.17.2',
+    VERSION: '0.17.3',
     LANGUAGE: 'en',
     COLLAPSE_INDEX: false,
     BUILDER: 'html',

--- a/src/scitex_agent_container/_sphinx_html/adr/0001-isolation-hardening.html
+++ b/src/scitex_agent_container/_sphinx_html/adr/0001-isolation-hardening.html
@@ -6,7 +6,7 @@
   <meta charset="utf-8" /><meta name="viewport" content="width=device-width, initial-scale=1" />
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>ADR: Isolation Hardening (2026-05-13) &mdash; scitex-agent-container v0.17.2</title>
+  <title>ADR: Isolation Hardening (2026-05-13) &mdash; scitex-agent-container v0.17.3</title>
       <link rel="stylesheet" type="text/css" href="../_static/pygments.css?v=b86133f3" />
       <link rel="stylesheet" type="text/css" href="../_static/css/theme.css?v=9edc463e" />
       <link rel="stylesheet" type="text/css" href="../_static/copybutton.css?v=76b2166b" />
@@ -14,7 +14,7 @@
   
       <script src="../_static/jquery.js?v=5d32c60e"></script>
       <script src="../_static/_sphinx_javascript_frameworks_compat.js?v=2cd50e6c"></script>
-      <script src="../_static/documentation_options.js?v=9fbddafe"></script>
+      <script src="../_static/documentation_options.js?v=3bc55ee7"></script>
       <script src="../_static/doctools.js?v=fd6eb6e6"></script>
       <script src="../_static/sphinx_highlight.js?v=6ffebe34"></script>
       <script src="../_static/clipboard.min.js?v=a7894cd8"></script>

--- a/src/scitex_agent_container/_sphinx_html/adr/0003-runtime-home-directory.html
+++ b/src/scitex_agent_container/_sphinx_html/adr/0003-runtime-home-directory.html
@@ -6,7 +6,7 @@
   <meta charset="utf-8" /><meta name="viewport" content="width=device-width, initial-scale=1" />
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>ADR-0003: Runtime home/ directory as the canonical container HOME (2026-05-14) &mdash; scitex-agent-container v0.17.2</title>
+  <title>ADR-0003: Runtime home/ directory as the canonical container HOME (2026-05-14) &mdash; scitex-agent-container v0.17.3</title>
       <link rel="stylesheet" type="text/css" href="../_static/pygments.css?v=b86133f3" />
       <link rel="stylesheet" type="text/css" href="../_static/css/theme.css?v=9edc463e" />
       <link rel="stylesheet" type="text/css" href="../_static/copybutton.css?v=76b2166b" />
@@ -14,7 +14,7 @@
   
       <script src="../_static/jquery.js?v=5d32c60e"></script>
       <script src="../_static/_sphinx_javascript_frameworks_compat.js?v=2cd50e6c"></script>
-      <script src="../_static/documentation_options.js?v=9fbddafe"></script>
+      <script src="../_static/documentation_options.js?v=3bc55ee7"></script>
       <script src="../_static/doctools.js?v=fd6eb6e6"></script>
       <script src="../_static/sphinx_highlight.js?v=6ffebe34"></script>
       <script src="../_static/clipboard.min.js?v=a7894cd8"></script>

--- a/src/scitex_agent_container/_sphinx_html/adr/0004-a2a-v1-compliance.html
+++ b/src/scitex_agent_container/_sphinx_html/adr/0004-a2a-v1-compliance.html
@@ -6,7 +6,7 @@
   <meta charset="utf-8" /><meta name="viewport" content="width=device-width, initial-scale=1" />
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>ADR-0004: Adopt A2A v1.0 (drop /v1/ REST prefix, v1 AgentCard shape) (2026-05-14) &mdash; scitex-agent-container v0.17.2</title>
+  <title>ADR-0004: Adopt A2A v1.0 (drop /v1/ REST prefix, v1 AgentCard shape) (2026-05-14) &mdash; scitex-agent-container v0.17.3</title>
       <link rel="stylesheet" type="text/css" href="../_static/pygments.css?v=b86133f3" />
       <link rel="stylesheet" type="text/css" href="../_static/css/theme.css?v=9edc463e" />
       <link rel="stylesheet" type="text/css" href="../_static/copybutton.css?v=76b2166b" />
@@ -14,7 +14,7 @@
   
       <script src="../_static/jquery.js?v=5d32c60e"></script>
       <script src="../_static/_sphinx_javascript_frameworks_compat.js?v=2cd50e6c"></script>
-      <script src="../_static/documentation_options.js?v=9fbddafe"></script>
+      <script src="../_static/documentation_options.js?v=3bc55ee7"></script>
       <script src="../_static/doctools.js?v=fd6eb6e6"></script>
       <script src="../_static/sphinx_highlight.js?v=6ffebe34"></script>
       <script src="../_static/clipboard.min.js?v=a7894cd8"></script>

--- a/src/scitex_agent_container/_sphinx_html/adr/0008-sac-node-transport-boundary.html
+++ b/src/scitex_agent_container/_sphinx_html/adr/0008-sac-node-transport-boundary.html
@@ -6,7 +6,7 @@
   <meta charset="utf-8" /><meta name="viewport" content="width=device-width, initial-scale=1" />
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>ADR-0008: sac is the node-transport substrate; comms model is nodes / lineage / groups / ACL (2026-05-20) &mdash; scitex-agent-container v0.17.2</title>
+  <title>ADR-0008: sac is the node-transport substrate; comms model is nodes / lineage / groups / ACL (2026-05-20) &mdash; scitex-agent-container v0.17.3</title>
       <link rel="stylesheet" type="text/css" href="../_static/pygments.css?v=b86133f3" />
       <link rel="stylesheet" type="text/css" href="../_static/css/theme.css?v=9edc463e" />
       <link rel="stylesheet" type="text/css" href="../_static/copybutton.css?v=76b2166b" />
@@ -14,7 +14,7 @@
   
       <script src="../_static/jquery.js?v=5d32c60e"></script>
       <script src="../_static/_sphinx_javascript_frameworks_compat.js?v=2cd50e6c"></script>
-      <script src="../_static/documentation_options.js?v=9fbddafe"></script>
+      <script src="../_static/documentation_options.js?v=3bc55ee7"></script>
       <script src="../_static/doctools.js?v=fd6eb6e6"></script>
       <script src="../_static/sphinx_highlight.js?v=6ffebe34"></script>
       <script src="../_static/clipboard.min.js?v=a7894cd8"></script>

--- a/src/scitex_agent_container/_sphinx_html/api/scitex_agent_container.html
+++ b/src/scitex_agent_container/_sphinx_html/api/scitex_agent_container.html
@@ -6,7 +6,7 @@
   <meta charset="utf-8" /><meta name="viewport" content="width=device-width, initial-scale=1" />
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>scitex_agent_container API Reference &mdash; scitex-agent-container v0.17.2</title>
+  <title>scitex_agent_container API Reference &mdash; scitex-agent-container v0.17.3</title>
       <link rel="stylesheet" type="text/css" href="../_static/pygments.css?v=b86133f3" />
       <link rel="stylesheet" type="text/css" href="../_static/css/theme.css?v=9edc463e" />
       <link rel="stylesheet" type="text/css" href="../_static/copybutton.css?v=76b2166b" />
@@ -14,7 +14,7 @@
   
       <script src="../_static/jquery.js?v=5d32c60e"></script>
       <script src="../_static/_sphinx_javascript_frameworks_compat.js?v=2cd50e6c"></script>
-      <script src="../_static/documentation_options.js?v=9fbddafe"></script>
+      <script src="../_static/documentation_options.js?v=3bc55ee7"></script>
       <script src="../_static/doctools.js?v=fd6eb6e6"></script>
       <script src="../_static/sphinx_highlight.js?v=6ffebe34"></script>
       <script src="../_static/clipboard.min.js?v=a7894cd8"></script>

--- a/src/scitex_agent_container/_sphinx_html/credentials.html
+++ b/src/scitex_agent_container/_sphinx_html/credentials.html
@@ -6,7 +6,7 @@
   <meta charset="utf-8" /><meta name="viewport" content="width=device-width, initial-scale=1" />
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Claude Code credential &amp; settings files &mdash; scitex-agent-container v0.17.2</title>
+  <title>Claude Code credential &amp; settings files &mdash; scitex-agent-container v0.17.3</title>
       <link rel="stylesheet" type="text/css" href="_static/pygments.css?v=b86133f3" />
       <link rel="stylesheet" type="text/css" href="_static/css/theme.css?v=9edc463e" />
       <link rel="stylesheet" type="text/css" href="_static/copybutton.css?v=76b2166b" />
@@ -14,7 +14,7 @@
   
       <script src="_static/jquery.js?v=5d32c60e"></script>
       <script src="_static/_sphinx_javascript_frameworks_compat.js?v=2cd50e6c"></script>
-      <script src="_static/documentation_options.js?v=9fbddafe"></script>
+      <script src="_static/documentation_options.js?v=3bc55ee7"></script>
       <script src="_static/doctools.js?v=fd6eb6e6"></script>
       <script src="_static/sphinx_highlight.js?v=6ffebe34"></script>
       <script src="_static/clipboard.min.js?v=a7894cd8"></script>

--- a/src/scitex_agent_container/_sphinx_html/directories.html
+++ b/src/scitex_agent_container/_sphinx_html/directories.html
@@ -6,7 +6,7 @@
   <meta charset="utf-8" /><meta name="viewport" content="width=device-width, initial-scale=1" />
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Configuration and Runtime Directories &mdash; scitex-agent-container v0.17.2</title>
+  <title>Configuration and Runtime Directories &mdash; scitex-agent-container v0.17.3</title>
       <link rel="stylesheet" type="text/css" href="_static/pygments.css?v=b86133f3" />
       <link rel="stylesheet" type="text/css" href="_static/css/theme.css?v=9edc463e" />
       <link rel="stylesheet" type="text/css" href="_static/copybutton.css?v=76b2166b" />
@@ -14,7 +14,7 @@
   
       <script src="_static/jquery.js?v=5d32c60e"></script>
       <script src="_static/_sphinx_javascript_frameworks_compat.js?v=2cd50e6c"></script>
-      <script src="_static/documentation_options.js?v=9fbddafe"></script>
+      <script src="_static/documentation_options.js?v=3bc55ee7"></script>
       <script src="_static/doctools.js?v=fd6eb6e6"></script>
       <script src="_static/sphinx_highlight.js?v=6ffebe34"></script>
       <script src="_static/clipboard.min.js?v=a7894cd8"></script>

--- a/src/scitex_agent_container/_sphinx_html/genindex.html
+++ b/src/scitex_agent_container/_sphinx_html/genindex.html
@@ -5,7 +5,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Index &mdash; scitex-agent-container v0.17.2</title>
+  <title>Index &mdash; scitex-agent-container v0.17.3</title>
       <link rel="stylesheet" type="text/css" href="_static/pygments.css?v=b86133f3" />
       <link rel="stylesheet" type="text/css" href="_static/css/theme.css?v=9edc463e" />
       <link rel="stylesheet" type="text/css" href="_static/copybutton.css?v=76b2166b" />
@@ -13,7 +13,7 @@
   
       <script src="_static/jquery.js?v=5d32c60e"></script>
       <script src="_static/_sphinx_javascript_frameworks_compat.js?v=2cd50e6c"></script>
-      <script src="_static/documentation_options.js?v=9fbddafe"></script>
+      <script src="_static/documentation_options.js?v=3bc55ee7"></script>
       <script src="_static/doctools.js?v=fd6eb6e6"></script>
       <script src="_static/sphinx_highlight.js?v=6ffebe34"></script>
       <script src="_static/clipboard.min.js?v=a7894cd8"></script>

--- a/src/scitex_agent_container/_sphinx_html/how-sac-works.html
+++ b/src/scitex_agent_container/_sphinx_html/how-sac-works.html
@@ -6,7 +6,7 @@
   <meta charset="utf-8" /><meta name="viewport" content="width=device-width, initial-scale=1" />
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>How sac works &mdash; scitex-agent-container v0.17.2</title>
+  <title>How sac works &mdash; scitex-agent-container v0.17.3</title>
       <link rel="stylesheet" type="text/css" href="_static/pygments.css?v=b86133f3" />
       <link rel="stylesheet" type="text/css" href="_static/css/theme.css?v=9edc463e" />
       <link rel="stylesheet" type="text/css" href="_static/copybutton.css?v=76b2166b" />
@@ -14,7 +14,7 @@
   
       <script src="_static/jquery.js?v=5d32c60e"></script>
       <script src="_static/_sphinx_javascript_frameworks_compat.js?v=2cd50e6c"></script>
-      <script src="_static/documentation_options.js?v=9fbddafe"></script>
+      <script src="_static/documentation_options.js?v=3bc55ee7"></script>
       <script src="_static/doctools.js?v=fd6eb6e6"></script>
       <script src="_static/sphinx_highlight.js?v=6ffebe34"></script>
       <script src="_static/clipboard.min.js?v=a7894cd8"></script>

--- a/src/scitex_agent_container/_sphinx_html/images.html
+++ b/src/scitex_agent_container/_sphinx_html/images.html
@@ -6,7 +6,7 @@
   <meta charset="utf-8" /><meta name="viewport" content="width=device-width, initial-scale=1" />
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Apptainer Images &mdash; scitex-agent-container v0.17.2</title>
+  <title>Apptainer Images &mdash; scitex-agent-container v0.17.3</title>
       <link rel="stylesheet" type="text/css" href="_static/pygments.css?v=b86133f3" />
       <link rel="stylesheet" type="text/css" href="_static/css/theme.css?v=9edc463e" />
       <link rel="stylesheet" type="text/css" href="_static/copybutton.css?v=76b2166b" />
@@ -14,7 +14,7 @@
   
       <script src="_static/jquery.js?v=5d32c60e"></script>
       <script src="_static/_sphinx_javascript_frameworks_compat.js?v=2cd50e6c"></script>
-      <script src="_static/documentation_options.js?v=9fbddafe"></script>
+      <script src="_static/documentation_options.js?v=3bc55ee7"></script>
       <script src="_static/doctools.js?v=fd6eb6e6"></script>
       <script src="_static/sphinx_highlight.js?v=6ffebe34"></script>
       <script src="_static/clipboard.min.js?v=a7894cd8"></script>

--- a/src/scitex_agent_container/_sphinx_html/index.html
+++ b/src/scitex_agent_container/_sphinx_html/index.html
@@ -6,7 +6,7 @@
   <meta charset="utf-8" /><meta name="viewport" content="width=device-width, initial-scale=1" />
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>scitex-agent-container - Declarative AI Agent Lifecycle Management &mdash; scitex-agent-container v0.17.2</title>
+  <title>scitex-agent-container - Declarative AI Agent Lifecycle Management &mdash; scitex-agent-container v0.17.3</title>
       <link rel="stylesheet" type="text/css" href="_static/pygments.css?v=b86133f3" />
       <link rel="stylesheet" type="text/css" href="_static/css/theme.css?v=9edc463e" />
       <link rel="stylesheet" type="text/css" href="_static/copybutton.css?v=76b2166b" />
@@ -14,7 +14,7 @@
   
       <script src="_static/jquery.js?v=5d32c60e"></script>
       <script src="_static/_sphinx_javascript_frameworks_compat.js?v=2cd50e6c"></script>
-      <script src="_static/documentation_options.js?v=9fbddafe"></script>
+      <script src="_static/documentation_options.js?v=3bc55ee7"></script>
       <script src="_static/doctools.js?v=fd6eb6e6"></script>
       <script src="_static/sphinx_highlight.js?v=6ffebe34"></script>
       <script src="_static/clipboard.min.js?v=a7894cd8"></script>

--- a/src/scitex_agent_container/_sphinx_html/installation.html
+++ b/src/scitex_agent_container/_sphinx_html/installation.html
@@ -6,7 +6,7 @@
   <meta charset="utf-8" /><meta name="viewport" content="width=device-width, initial-scale=1" />
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Installation &mdash; scitex-agent-container v0.17.2</title>
+  <title>Installation &mdash; scitex-agent-container v0.17.3</title>
       <link rel="stylesheet" type="text/css" href="_static/pygments.css?v=b86133f3" />
       <link rel="stylesheet" type="text/css" href="_static/css/theme.css?v=9edc463e" />
       <link rel="stylesheet" type="text/css" href="_static/copybutton.css?v=76b2166b" />
@@ -14,7 +14,7 @@
   
       <script src="_static/jquery.js?v=5d32c60e"></script>
       <script src="_static/_sphinx_javascript_frameworks_compat.js?v=2cd50e6c"></script>
-      <script src="_static/documentation_options.js?v=9fbddafe"></script>
+      <script src="_static/documentation_options.js?v=3bc55ee7"></script>
       <script src="_static/doctools.js?v=fd6eb6e6"></script>
       <script src="_static/sphinx_highlight.js?v=6ffebe34"></script>
       <script src="_static/clipboard.min.js?v=a7894cd8"></script>

--- a/src/scitex_agent_container/_sphinx_html/isolation.html
+++ b/src/scitex_agent_container/_sphinx_html/isolation.html
@@ -6,7 +6,7 @@
   <meta charset="utf-8" /><meta name="viewport" content="width=device-width, initial-scale=1" />
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Container Isolation in sac &mdash; scitex-agent-container v0.17.2</title>
+  <title>Container Isolation in sac &mdash; scitex-agent-container v0.17.3</title>
       <link rel="stylesheet" type="text/css" href="_static/pygments.css?v=b86133f3" />
       <link rel="stylesheet" type="text/css" href="_static/css/theme.css?v=9edc463e" />
       <link rel="stylesheet" type="text/css" href="_static/copybutton.css?v=76b2166b" />
@@ -14,7 +14,7 @@
   
       <script src="_static/jquery.js?v=5d32c60e"></script>
       <script src="_static/_sphinx_javascript_frameworks_compat.js?v=2cd50e6c"></script>
-      <script src="_static/documentation_options.js?v=9fbddafe"></script>
+      <script src="_static/documentation_options.js?v=3bc55ee7"></script>
       <script src="_static/doctools.js?v=fd6eb6e6"></script>
       <script src="_static/sphinx_highlight.js?v=6ffebe34"></script>
       <script src="_static/clipboard.min.js?v=a7894cd8"></script>

--- a/src/scitex_agent_container/_sphinx_html/py-modindex.html
+++ b/src/scitex_agent_container/_sphinx_html/py-modindex.html
@@ -5,7 +5,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Python Module Index &mdash; scitex-agent-container v0.17.2</title>
+  <title>Python Module Index &mdash; scitex-agent-container v0.17.3</title>
       <link rel="stylesheet" type="text/css" href="_static/pygments.css?v=b86133f3" />
       <link rel="stylesheet" type="text/css" href="_static/css/theme.css?v=9edc463e" />
       <link rel="stylesheet" type="text/css" href="_static/copybutton.css?v=76b2166b" />
@@ -13,7 +13,7 @@
   
       <script src="_static/jquery.js?v=5d32c60e"></script>
       <script src="_static/_sphinx_javascript_frameworks_compat.js?v=2cd50e6c"></script>
-      <script src="_static/documentation_options.js?v=9fbddafe"></script>
+      <script src="_static/documentation_options.js?v=3bc55ee7"></script>
       <script src="_static/doctools.js?v=fd6eb6e6"></script>
       <script src="_static/sphinx_highlight.js?v=6ffebe34"></script>
       <script src="_static/clipboard.min.js?v=a7894cd8"></script>

--- a/src/scitex_agent_container/_sphinx_html/quickstart.html
+++ b/src/scitex_agent_container/_sphinx_html/quickstart.html
@@ -6,7 +6,7 @@
   <meta charset="utf-8" /><meta name="viewport" content="width=device-width, initial-scale=1" />
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Quickstart &mdash; scitex-agent-container v0.17.2</title>
+  <title>Quickstart &mdash; scitex-agent-container v0.17.3</title>
       <link rel="stylesheet" type="text/css" href="_static/pygments.css?v=b86133f3" />
       <link rel="stylesheet" type="text/css" href="_static/css/theme.css?v=9edc463e" />
       <link rel="stylesheet" type="text/css" href="_static/copybutton.css?v=76b2166b" />
@@ -14,7 +14,7 @@
   
       <script src="_static/jquery.js?v=5d32c60e"></script>
       <script src="_static/_sphinx_javascript_frameworks_compat.js?v=2cd50e6c"></script>
-      <script src="_static/documentation_options.js?v=9fbddafe"></script>
+      <script src="_static/documentation_options.js?v=3bc55ee7"></script>
       <script src="_static/doctools.js?v=fd6eb6e6"></script>
       <script src="_static/sphinx_highlight.js?v=6ffebe34"></script>
       <script src="_static/clipboard.min.js?v=a7894cd8"></script>

--- a/src/scitex_agent_container/_sphinx_html/sac-and-orochi.html
+++ b/src/scitex_agent_container/_sphinx_html/sac-and-orochi.html
@@ -6,7 +6,7 @@
   <meta charset="utf-8" /><meta name="viewport" content="width=device-width, initial-scale=1" />
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>sac and orochi &mdash; scitex-agent-container v0.17.2</title>
+  <title>sac and orochi &mdash; scitex-agent-container v0.17.3</title>
       <link rel="stylesheet" type="text/css" href="_static/pygments.css?v=b86133f3" />
       <link rel="stylesheet" type="text/css" href="_static/css/theme.css?v=9edc463e" />
       <link rel="stylesheet" type="text/css" href="_static/copybutton.css?v=76b2166b" />
@@ -14,7 +14,7 @@
   
       <script src="_static/jquery.js?v=5d32c60e"></script>
       <script src="_static/_sphinx_javascript_frameworks_compat.js?v=2cd50e6c"></script>
-      <script src="_static/documentation_options.js?v=9fbddafe"></script>
+      <script src="_static/documentation_options.js?v=3bc55ee7"></script>
       <script src="_static/doctools.js?v=fd6eb6e6"></script>
       <script src="_static/sphinx_highlight.js?v=6ffebe34"></script>
       <script src="_static/clipboard.min.js?v=a7894cd8"></script>

--- a/src/scitex_agent_container/_sphinx_html/search.html
+++ b/src/scitex_agent_container/_sphinx_html/search.html
@@ -5,7 +5,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Search &mdash; scitex-agent-container v0.17.2</title>
+  <title>Search &mdash; scitex-agent-container v0.17.3</title>
       <link rel="stylesheet" type="text/css" href="_static/pygments.css?v=b86133f3" />
       <link rel="stylesheet" type="text/css" href="_static/css/theme.css?v=9edc463e" />
       <link rel="stylesheet" type="text/css" href="_static/copybutton.css?v=76b2166b" />
@@ -14,7 +14,7 @@
     
       <script src="_static/jquery.js?v=5d32c60e"></script>
       <script src="_static/_sphinx_javascript_frameworks_compat.js?v=2cd50e6c"></script>
-      <script src="_static/documentation_options.js?v=9fbddafe"></script>
+      <script src="_static/documentation_options.js?v=3bc55ee7"></script>
       <script src="_static/doctools.js?v=fd6eb6e6"></script>
       <script src="_static/sphinx_highlight.js?v=6ffebe34"></script>
       <script src="_static/clipboard.min.js?v=a7894cd8"></script>

--- a/src/scitex_agent_container/_sphinx_html/spec-reference.html
+++ b/src/scitex_agent_container/_sphinx_html/spec-reference.html
@@ -6,7 +6,7 @@
   <meta charset="utf-8" /><meta name="viewport" content="width=device-width, initial-scale=1" />
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>YAML Spec Reference (v3) &mdash; scitex-agent-container v0.17.2</title>
+  <title>YAML Spec Reference (v3) &mdash; scitex-agent-container v0.17.3</title>
       <link rel="stylesheet" type="text/css" href="_static/pygments.css?v=b86133f3" />
       <link rel="stylesheet" type="text/css" href="_static/css/theme.css?v=9edc463e" />
       <link rel="stylesheet" type="text/css" href="_static/copybutton.css?v=76b2166b" />
@@ -14,7 +14,7 @@
   
       <script src="_static/jquery.js?v=5d32c60e"></script>
       <script src="_static/_sphinx_javascript_frameworks_compat.js?v=2cd50e6c"></script>
-      <script src="_static/documentation_options.js?v=9fbddafe"></script>
+      <script src="_static/documentation_options.js?v=3bc55ee7"></script>
       <script src="_static/doctools.js?v=fd6eb6e6"></script>
       <script src="_static/sphinx_highlight.js?v=6ffebe34"></script>
       <script src="_static/clipboard.min.js?v=a7894cd8"></script>

--- a/src/scitex_agent_container/_sphinx_html/status_and_hooks.html
+++ b/src/scitex_agent_container/_sphinx_html/status_and_hooks.html
@@ -6,7 +6,7 @@
   <meta charset="utf-8" /><meta name="viewport" content="width=device-width, initial-scale=1" />
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Status and Hook Integration &mdash; scitex-agent-container v0.17.2</title>
+  <title>Status and Hook Integration &mdash; scitex-agent-container v0.17.3</title>
       <link rel="stylesheet" type="text/css" href="_static/pygments.css?v=b86133f3" />
       <link rel="stylesheet" type="text/css" href="_static/css/theme.css?v=9edc463e" />
       <link rel="stylesheet" type="text/css" href="_static/copybutton.css?v=76b2166b" />
@@ -14,7 +14,7 @@
   
       <script src="_static/jquery.js?v=5d32c60e"></script>
       <script src="_static/_sphinx_javascript_frameworks_compat.js?v=2cd50e6c"></script>
-      <script src="_static/documentation_options.js?v=9fbddafe"></script>
+      <script src="_static/documentation_options.js?v=3bc55ee7"></script>
       <script src="_static/doctools.js?v=fd6eb6e6"></script>
       <script src="_static/sphinx_highlight.js?v=6ffebe34"></script>
       <script src="_static/clipboard.min.js?v=a7894cd8"></script>

--- a/src/scitex_agent_container/_sphinx_html/talking-to-agents.html
+++ b/src/scitex_agent_container/_sphinx_html/talking-to-agents.html
@@ -6,7 +6,7 @@
   <meta charset="utf-8" /><meta name="viewport" content="width=device-width, initial-scale=1" />
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Talking to a Running Agent &mdash; scitex-agent-container v0.17.2</title>
+  <title>Talking to a Running Agent &mdash; scitex-agent-container v0.17.3</title>
       <link rel="stylesheet" type="text/css" href="_static/pygments.css?v=b86133f3" />
       <link rel="stylesheet" type="text/css" href="_static/css/theme.css?v=9edc463e" />
       <link rel="stylesheet" type="text/css" href="_static/copybutton.css?v=76b2166b" />
@@ -14,7 +14,7 @@
   
       <script src="_static/jquery.js?v=5d32c60e"></script>
       <script src="_static/_sphinx_javascript_frameworks_compat.js?v=2cd50e6c"></script>
-      <script src="_static/documentation_options.js?v=9fbddafe"></script>
+      <script src="_static/documentation_options.js?v=3bc55ee7"></script>
       <script src="_static/doctools.js?v=fd6eb6e6"></script>
       <script src="_static/sphinx_highlight.js?v=6ffebe34"></script>
       <script src="_static/clipboard.min.js?v=a7894cd8"></script>

--- a/src/scitex_agent_container/_sphinx_html/templates.html
+++ b/src/scitex_agent_container/_sphinx_html/templates.html
@@ -6,7 +6,7 @@
   <meta charset="utf-8" /><meta name="viewport" content="width=device-width, initial-scale=1" />
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Templates and Examples &mdash; scitex-agent-container v0.17.2</title>
+  <title>Templates and Examples &mdash; scitex-agent-container v0.17.3</title>
       <link rel="stylesheet" type="text/css" href="_static/pygments.css?v=b86133f3" />
       <link rel="stylesheet" type="text/css" href="_static/css/theme.css?v=9edc463e" />
       <link rel="stylesheet" type="text/css" href="_static/copybutton.css?v=76b2166b" />
@@ -14,7 +14,7 @@
   
       <script src="_static/jquery.js?v=5d32c60e"></script>
       <script src="_static/_sphinx_javascript_frameworks_compat.js?v=2cd50e6c"></script>
-      <script src="_static/documentation_options.js?v=9fbddafe"></script>
+      <script src="_static/documentation_options.js?v=3bc55ee7"></script>
       <script src="_static/doctools.js?v=fd6eb6e6"></script>
       <script src="_static/sphinx_highlight.js?v=6ffebe34"></script>
       <script src="_static/clipboard.min.js?v=a7894cd8"></script>

--- a/tests/scitex_agent_container/_mcp/test_channel.py
+++ b/tests/scitex_agent_container/_mcp/test_channel.py
@@ -1182,3 +1182,64 @@ async def test_serve_pushes_sse_event_to_client_as_channel_notification(
 
     # Assert — the event reached the client through the live session.
     assert got.get("params", {}).get("content") == "hello channel"
+
+
+# ---------------------------------------------------------------------------
+# _serve — initialize handshake must advertise the `claude/channel`
+# experimental capability.
+#
+# Distinct seam from the push test above: even when the server *sends*
+# notifications/claude/channel, Claude Code drops every one of them if
+# the initialize response did not declare `claude/channel` in
+# experimental capabilities ("Channel notifications skipped: server did
+# not declare claude/channel capability"). The raw-frame push test reads
+# without a real client and cannot catch that client-side gate — only a
+# real initialize handshake exercises the capability declaration.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_serve_initialize_declares_claude_channel_capability(
+    fake_listen,
+):
+    # Arrange — no SSE events needed; we only drive the handshake.
+    import anyio
+    from mcp.client.session import ClientSession
+    from mcp.shared.memory import create_client_server_memory_streams
+
+    from scitex_agent_container._mcp.channel import _serve
+
+    fake_listen.sse_events = []
+    caps: dict[str, Any] = {}
+
+    async with create_client_server_memory_streams() as (
+        client_streams,
+        server_streams,
+    ):
+        client_read, client_write = client_streams
+        server_read, server_write = server_streams
+
+        async with anyio.create_task_group() as tg:
+
+            async def _run_serve() -> None:
+                await _serve(
+                    server_read,
+                    server_write,
+                    name="alice",
+                    listen_url=fake_listen.base_url,
+                    bearer=None,
+                )
+
+            tg.start_soon(_run_serve)
+
+            # Act — a real client initialize handshake returns the server's
+            # advertised capabilities.
+            async with ClientSession(client_read, client_write) as client:
+                result = await client.initialize()
+                caps["experimental"] = result.capabilities.experimental
+
+            tg.cancel_scope.cancel()
+
+    # Assert — the `claude/channel` capability is advertised, so Claude
+    # Code will accept the pushed notifications instead of dropping them.
+    assert caps["experimental"] == {"claude/channel": {}}

--- a/tests/scitex_agent_container/_mcp/test_channel.py
+++ b/tests/scitex_agent_container/_mcp/test_channel.py
@@ -292,21 +292,49 @@ def test_build_notification_ts_is_stringified():
 
 
 @pytest.mark.parametrize(
-    "key,value",
+    "key,raw,expected",
     [
-        ("conversation_id", "conv-42"),
-        ("in_reply_to", "msg-7"),
-        ("priority", "high"),
-        ("requires_reply", True),
+        ("conversation_id", "conv-42", "conv-42"),
+        ("in_reply_to", "msg-7", "msg-7"),
+        ("priority", "high", "high"),
+        # requires_reply arrives as a bool off the bus but must be
+        # stringified — a raw bool trips the client's Zod validator and
+        # the pushed turn is silently dropped.
+        ("requires_reply", True, "true"),
+        ("requires_reply", False, "false"),
     ],
 )
-def test_build_notification_propagates_optional_meta_key(key: str, value: Any):
+def test_build_notification_propagates_optional_meta_key(
+    key: str, raw: Any, expected: str
+):
     # Arrange
-    event = {"from_agent": "bob", "content": "x", key: value}
+    event = {"from_agent": "bob", "content": "x", key: raw}
     # Act
     meta = _build_notification(event)["meta"]
     # Assert
-    assert meta[key] == value
+    assert meta[key] == expected
+
+
+def test_build_notification_meta_values_are_all_strings():
+    """Regression: Claude Code's channel-notification schema types every
+    ``meta`` value as a string. A raw bool (``requires_reply``) made the
+    client's notification handler throw a ZodError and silently drop the
+    pushed turn. Pin the contract: nothing non-string reaches ``meta``."""
+    # Arrange — include the boolean offender plus a non-str ts.
+    event = {
+        "from_agent": "bob",
+        "content": "x",
+        "ts": 1234,
+        "msg_id": "m1",
+        "requires_reply": True,
+        "priority": "high",
+        "conversation_id": "c1",
+    }
+    # Act
+    meta = _build_notification(event)["meta"]
+    non_strings = {k: v for k, v in meta.items() if not isinstance(v, str)}
+    # Assert
+    assert non_strings == {}
 
 
 def test_build_notification_omits_optional_keys_when_absent():


### PR DESCRIPTION
## v0.17.3 — channel push fixes

Two fixes that together make A2A turns actually surface as Claude Code channel notifications (verified live end-to-end after a lead-session restart).

1. **declare `claude/channel` capability** (`3a20192`) — the channel adapter now advertises the `claude/channel` experimental capability in its initialize response. Without it Claude Code logged "Channel notifications skipped" and dropped every pushed notification (client-reject).

2. **stringify `requires_reply` bool in meta** (`65d690e`) — once registration was unblocked, the pushed turn still vanished: Claude Code's notification handler threw `ZodError ... requires_reply: expected string, received boolean`. The client schema types every `meta` value as a string; the bus sends `requires_reply` as a raw bool. Added `_meta_str()` to coerce all meta values (bools → "true"/"false") + a regression test pinning "no non-string value reaches meta". The prior parametrized test had encoded the bug and shipped green.

## Verification
- Channel test suite: 52 passed.
- Full suite: green on CI (clean runner).
- Live: `a2a_send target=lead requires_reply=true` now surfaces in-session as `<channel ... requires_reply="true">` with no ZodError.