### PR TITLE
feat(channel): infra-automatic stage-2 "read" receipt (auto-ack)

### DIFF
--- a/src/scitex_agent_container/_mcp/_channel_tools.py
+++ b/src/scitex_agent_container/_mcp/_channel_tools.py
@@ -1,0 +1,259 @@
+"""sac MCP **channel** send-side ``a2a_*`` tool surface.
+
+Extracted from :mod:`scitex_agent_container._mcp.channel` (which grew past
+the module size budget). Hosts the send-side tools the agent calls
+explicitly — ``a2a_send``, ``a2a_reply``, ``a2a_ack``, ``a2a_peers``,
+``a2a_inbox`` — while the receive-side adapter (SSE consumer, session
+push, the automatic ``a2a_ack`` side-effect) stays in ``channel``.
+
+The two halves share the per-process inbox ring buffer ``_recent``,
+which lives in ``channel`` (the receive side fills it; these tools read
+it). Importing it from ``channel`` keeps a single source of truth and
+avoids a circular import (``channel`` imports *this* module, not the
+other way around at module load).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from .channel import _recent
+
+
+def register_tools(
+    server, *, agent_name: str, listen_url: str, bearer: str | None
+) -> None:
+    """Wire the a2a_* tools onto the channel server.
+
+    All tools speak HTTP to local `sac listen`; receivers' inbox state
+    (for reply/ack lookups) lives in the shared ``_recent`` ring.
+    Tools-as-contract: each tool sets `from_agent`, `ts`, `msg_id`,
+    `conversation_id` correctly so the calling agent can't get it wrong.
+    """
+    import uuid as _uuid
+
+    from mcp.types import TextContent, Tool
+
+    base = listen_url.rstrip("/")
+    headers = {"Content-Type": "application/json"}
+    if bearer:
+        headers["Authorization"] = f"Bearer {bearer}"
+
+    async def _post(path: str, payload: dict[str, Any]) -> dict[str, Any]:
+        import httpx
+
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.post(f"{base}{path}", json=payload, headers=headers)
+            try:
+                return {"status": resp.status_code, "body": resp.json()}
+            except Exception:  # stx-allow: fallback (reason: non-JSON body tolerated)
+                return {"status": resp.status_code, "body": resp.text}
+
+    async def _get(path: str) -> dict[str, Any]:
+        import httpx
+
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(f"{base}{path}", headers=headers)
+            try:
+                return {"status": resp.status_code, "body": resp.json()}
+            except Exception:  # stx-allow: fallback (reason: non-JSON body tolerated)
+                return {"status": resp.status_code, "body": resp.text}
+
+    def _find(msg_id: str) -> dict[str, Any] | None:
+        for ev in reversed(_recent):
+            if ev.get("msg_id") == msg_id:
+                return ev
+        return None
+
+    def _wrap_message_send(content: str, **extra: Any) -> dict[str, Any]:
+        # sac-extension fields (from_agent, conversation_id, ...) live
+        # under ``params.metadata`` per A2A v1 — the SDK's strict proto
+        # validator rejects unknown top-level params fields, so we
+        # CANNOT splat them at the params root.
+        metadata: dict[str, Any] = {"from_agent": agent_name}
+        metadata.update({k: v for k, v in extra.items() if v is not None})
+        params: dict[str, Any] = {
+            "message": {
+                "message_id": _uuid.uuid4().hex,
+                "role": "ROLE_USER",
+                "parts": [{"text": content}],
+            },
+            "metadata": metadata,
+        }
+        return {
+            "jsonrpc": "2.0",
+            "id": _uuid.uuid4().hex,
+            # v1 gRPC-style method name; sac's `_publish_channel_event`
+            # accepts both `SendMessage` and legacy `message/send`.
+            "method": "SendMessage",
+            "params": params,
+        }
+
+    @server.list_tools()
+    async def _list_tools() -> list[Tool]:
+        return [
+            Tool(
+                name="a2a_send",
+                description=(
+                    "Send a message to another agent on this sac listen. "
+                    "Sets from_agent automatically; mints conversation_id "
+                    "when omitted."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "required": ["target", "content"],
+                    "properties": {
+                        "target": {"type": "string"},
+                        "content": {"type": "string"},
+                        "conversation_id": {"type": "string"},
+                        "priority": {
+                            "type": "string",
+                            "enum": ["low", "normal", "high"],
+                        },
+                        "requires_reply": {"type": "boolean"},
+                    },
+                },
+            ),
+            Tool(
+                name="a2a_reply",
+                description=(
+                    "Reply to a received message. Looks up the original "
+                    "sender by msg_id; carries the same conversation_id."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "required": ["in_reply_to", "content"],
+                    "properties": {
+                        "in_reply_to": {"type": "string"},
+                        "content": {"type": "string"},
+                    },
+                },
+            ),
+            Tool(
+                name="a2a_ack",
+                description=(
+                    "Acknowledge a received message without content. "
+                    "Cheap 'got it' to a sender that set requires_reply=true."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "required": ["msg_id"],
+                    "properties": {"msg_id": {"type": "string"}},
+                },
+            ),
+            Tool(
+                name="a2a_peers",
+                description="List reachable agents on this sac listen.",
+                inputSchema={"type": "object", "properties": {}},
+            ),
+            Tool(
+                name="a2a_inbox",
+                description=(
+                    "Return up to `limit` most recent received messages "
+                    "from this agent's inbox buffer (default 20)."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "limit": {"type": "integer", "minimum": 1, "maximum": 200},
+                    },
+                },
+            ),
+        ]
+
+    @server.call_tool()
+    async def _call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
+        if name == "a2a_send":
+            target = arguments["target"]
+            content = arguments["content"]
+            payload = _wrap_message_send(
+                content,
+                conversation_id=arguments.get("conversation_id") or _uuid.uuid4().hex,
+                priority=arguments.get("priority"),
+                requires_reply=arguments.get("requires_reply"),
+            )
+            res = await _post(f"/agents/{target}/message:send", payload)
+            return [TextContent(type="text", text=json.dumps(res))]
+
+        if name == "a2a_reply":
+            mid = arguments["in_reply_to"]
+            orig = _find(mid)
+            if orig is None:
+                return [
+                    TextContent(
+                        type="text",
+                        text=json.dumps(
+                            {"error": f"unknown msg_id {mid} (inbox window)"}
+                        ),
+                    )
+                ]
+            target = orig.get("from_agent", "")
+            if not target:
+                return [
+                    TextContent(
+                        type="text",
+                        text=json.dumps({"error": "original sender unknown"}),
+                    )
+                ]
+            payload = _wrap_message_send(
+                arguments["content"],
+                conversation_id=orig.get("conversation_id"),
+                in_reply_to=mid,
+            )
+            res = await _post(f"/agents/{target}/message:send", payload)
+            return [TextContent(type="text", text=json.dumps(res))]
+
+        if name == "a2a_ack":
+            mid = arguments["msg_id"]
+            orig = _find(mid)
+            if orig is None:
+                return [
+                    TextContent(
+                        type="text",
+                        text=json.dumps(
+                            {"error": f"unknown msg_id {mid} (inbox window)"}
+                        ),
+                    )
+                ]
+            target = orig.get("from_agent", "")
+            if not target:
+                return [
+                    TextContent(
+                        type="text",
+                        text=json.dumps({"error": "original sender unknown"}),
+                    )
+                ]
+            payload = _wrap_message_send(
+                "",
+                conversation_id=orig.get("conversation_id"),
+                in_reply_to=mid,
+                ack=True,
+            )
+            res = await _post(f"/agents/{target}/message:send", payload)
+            return [TextContent(type="text", text=json.dumps(res))]
+
+        if name == "a2a_peers":
+            # No trailing slash: sac listen registers `/agents` and a GET to
+            # `/agents/` 307-redirects, which httpx does not follow by default
+            # (a2a_peers then returns a bare 307 with empty body).
+            res = await _get("/agents")
+            return [TextContent(type="text", text=json.dumps(res))]
+
+        if name == "a2a_inbox":
+            limit = int(arguments.get("limit") or 20)
+            items = list(_recent)[-limit:]
+            return [
+                TextContent(
+                    type="text", text=json.dumps({"count": len(items), "items": items})
+                )
+            ]
+
+        return [
+            TextContent(
+                type="text", text=json.dumps({"error": f"unknown tool: {name}"})
+            )
+        ]
+
+
+__all__ = ["register_tools"]

--- a/src/scitex_agent_container/_mcp/channel.py
+++ b/src/scitex_agent_container/_mcp/channel.py
@@ -51,6 +51,41 @@ _INBOX_CAP = 200
 _recent: "deque[dict[str, Any]]" = deque(maxlen=_INBOX_CAP)
 
 
+def _auto_ack_enabled() -> bool:
+    """Whether the receive-side adapter emits an automatic ``a2a_ack`` the
+    moment it injects a received bus event into the session.
+
+    Two-stage receipt, infra-automatic: the receiving agent calls nothing —
+    the channel adapter does. Stage 1 ("delivered") is the send response's
+    ``delivered_subscriber_count``; stage 2 ("read") is this auto-ack,
+    emitted on injection. Default ON; set ``SAC_CHANNEL_AUTO_ACK`` to one of
+    ``0/false/no/off`` (case-insensitive) to disable.
+    """
+    raw = os.environ.get("SAC_CHANNEL_AUTO_ACK")
+    if raw is None:
+        return True
+    return raw.strip().lower() not in ("0", "false", "no", "off")
+
+
+def _should_auto_ack(event: dict[str, Any]) -> bool:
+    """Loop-guard for the auto-ack side-effect.
+
+    An auto-ack is itself a message that lands in the sender's inbox and is
+    injected by *their* adapter — which would auto-ack back, ad infinitum.
+    Break the cycle:
+
+    - never auto-ack an event that is itself an ack (truthy ``ack`` flag —
+      the same metadata flag the ``a2a_ack`` tool stamps), and
+    - never auto-ack an event with no identifiable original sender
+      (``from_agent`` missing/empty): there is nowhere to send the receipt.
+    """
+    if not event.get("from_agent"):
+        return False
+    if event.get("ack"):
+        return False
+    return True
+
+
 async def _consume_sse(
     url: str,
     bearer: str | None,
@@ -158,14 +193,81 @@ def _build_notification(event: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-async def _push_channel_event(session: Any, event: dict[str, Any]) -> None:
-    """Buffer ``event`` and push it to the client as a
-    ``notifications/claude/channel`` message through ``session``.
+async def _post_auto_ack(
+    event: dict[str, Any],
+    *,
+    agent_name: str,
+    listen_url: str,
+    bearer: str | None,
+) -> None:
+    """POST an automatic ``a2a_ack`` back to the sender of ``event``.
+
+    Reuses the exact ``/agents/<sender>/message:send`` path and metadata
+    shape the ``a2a_ack`` tool uses (``ack=True``, ``in_reply_to`` the
+    original ``msg_id``, same ``conversation_id``). ``ack=True`` is the
+    loop-guard marker: the sender's adapter sees it and won't ack back.
+
+    Caller guarantees ``event`` passed :func:`_should_auto_ack` (so
+    ``from_agent`` is present and the event is not itself an ack).
+    """
+    import uuid as _uuid
+
+    import httpx
+
+    target = event["from_agent"]
+    metadata: dict[str, Any] = {"from_agent": agent_name, "ack": True}
+    msg_id = event.get("msg_id")
+    if msg_id:
+        metadata["in_reply_to"] = msg_id
+    conversation_id = event.get("conversation_id")
+    if conversation_id:
+        metadata["conversation_id"] = conversation_id
+    payload = {
+        "jsonrpc": "2.0",
+        "id": _uuid.uuid4().hex,
+        "method": "SendMessage",
+        "params": {
+            "message": {
+                "message_id": _uuid.uuid4().hex,
+                "role": "ROLE_USER",
+                "parts": [{"text": ""}],
+            },
+            "metadata": metadata,
+        },
+    }
+    base = listen_url.rstrip("/")
+    headers = {"Content-Type": "application/json"}
+    if bearer:
+        headers["Authorization"] = f"Bearer {bearer}"
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        resp = await client.post(
+            f"{base}/agents/{target}/message:send", json=payload, headers=headers
+        )
+        resp.raise_for_status()
+
+
+async def _push_channel_event(
+    session: Any,
+    event: dict[str, Any],
+    *,
+    agent_name: str | None = None,
+    listen_url: str | None = None,
+    bearer: str | None = None,
+) -> None:
+    """Buffer ``event``, push it to the client as a
+    ``notifications/claude/channel`` message through ``session``, then —
+    if auto-ack is enabled and the event qualifies — emit an automatic
+    ``a2a_ack`` back to the sender (stage-2 "read" receipt).
 
     Split out of the SSE consumer so the receive→inject path is
     directly testable end-to-end (see ``tests/.../_mcp/test_channel.py``
     ``test_serve_pushes_sse_event_to_client_as_channel_notification``).
     That seam used to be untested, which let a silent drop ship.
+
+    The auto-ack is a best-effort side-effect: it runs only *after* the
+    notification is injected and its failure is logged loudly but never
+    re-raised, so a flaky send can neither block injection nor kill the
+    long-lived SSE consumer. The agent is unaware — the adapter acks.
     """
     from mcp.shared.message import SessionMessage
     from mcp.types import JSONRPCMessage, JSONRPCNotification
@@ -181,6 +283,28 @@ async def _push_channel_event(session: Any, event: dict[str, Any]) -> None:
         )
     )
     await session.send_message(SessionMessage(msg))
+
+    # Stage-2 receipt: auto-ack AFTER successful injection. Best-effort —
+    # never let an ack failure propagate past this point.
+    if (
+        agent_name is not None
+        and listen_url is not None
+        and _auto_ack_enabled()
+        and _should_auto_ack(event)
+    ):
+        try:
+            await _post_auto_ack(
+                event,
+                agent_name=agent_name,
+                listen_url=listen_url,
+                bearer=bearer,
+            )
+        except Exception as exc:  # stx-allow: fallback (reason: best-effort auto-ack; a failed receipt must not block injection or kill the SSE consumer — logged loudly, never silent)
+            log.warning(
+                "sac channel: auto-ack to %r failed: %s",
+                event.get("from_agent"),
+                exc,
+            )
 
 
 async def _serve(
@@ -233,7 +357,13 @@ async def _serve(
 
         async def on_event(event: dict[str, Any]) -> None:
             try:
-                await _push_channel_event(session, event)
+                await _push_channel_event(
+                    session,
+                    event,
+                    agent_name=name,
+                    listen_url=listen_url,
+                    bearer=bearer,
+                )
             except Exception as exc:  # stx-allow: fallback (reason: one failed push must not kill the long-lived SSE consumer; logged loudly, never silent)
                 log.warning("sac channel: pushing inbox event failed: %s", exc)
 
@@ -270,236 +400,19 @@ async def _run(name: str, listen_url: str, bearer: str | None) -> None:
 def _register_tools(
     server, *, agent_name: str, listen_url: str, bearer: str | None
 ) -> None:
-    """Wire the a2a_* tools onto the channel server.
+    """Wire the send-side ``a2a_*`` tools onto the channel server.
 
-    All tools speak HTTP to local `sac listen`; receivers' inbox state
-    (for reply/ack lookups) lives in the module-level ``_recent`` ring.
-    Tools-as-contract: each tool sets `from_agent`, `ts`, `msg_id`,
-    `conversation_id` correctly so the calling agent can't get it wrong.
+    Thin re-export of :func:`scitex_agent_container._mcp._channel_tools.register_tools`.
+    The tool surface was extracted to its own module to keep this
+    receive-side adapter under the module size budget; this wrapper
+    preserves the historical import path (callers and tests import
+    ``_register_tools`` from ``channel``).
     """
-    import uuid as _uuid
+    from ._channel_tools import register_tools
 
-    from mcp.types import TextContent, Tool
-
-    base = listen_url.rstrip("/")
-    headers = {"Content-Type": "application/json"}
-    if bearer:
-        headers["Authorization"] = f"Bearer {bearer}"
-
-    async def _post(path: str, payload: dict[str, Any]) -> dict[str, Any]:
-        import httpx
-
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.post(f"{base}{path}", json=payload, headers=headers)
-            try:
-                return {"status": resp.status_code, "body": resp.json()}
-            except Exception:  # stx-allow: fallback (reason: non-JSON body tolerated)
-                return {"status": resp.status_code, "body": resp.text}
-
-    async def _get(path: str) -> dict[str, Any]:
-        import httpx
-
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.get(f"{base}{path}", headers=headers)
-            try:
-                return {"status": resp.status_code, "body": resp.json()}
-            except Exception:  # stx-allow: fallback (reason: non-JSON body tolerated)
-                return {"status": resp.status_code, "body": resp.text}
-
-    def _find(msg_id: str) -> dict[str, Any] | None:
-        for ev in reversed(_recent):
-            if ev.get("msg_id") == msg_id:
-                return ev
-        return None
-
-    def _wrap_message_send(content: str, **extra: Any) -> dict[str, Any]:
-        # sac-extension fields (from_agent, conversation_id, ...) live
-        # under ``params.metadata`` per A2A v1 — the SDK's strict proto
-        # validator rejects unknown top-level params fields, so we
-        # CANNOT splat them at the params root.
-        metadata: dict[str, Any] = {"from_agent": agent_name}
-        metadata.update({k: v for k, v in extra.items() if v is not None})
-        params: dict[str, Any] = {
-            "message": {
-                "message_id": _uuid.uuid4().hex,
-                "role": "ROLE_USER",
-                "parts": [{"text": content}],
-            },
-            "metadata": metadata,
-        }
-        return {
-            "jsonrpc": "2.0",
-            "id": _uuid.uuid4().hex,
-            # v1 gRPC-style method name; sac's `_publish_channel_event`
-            # accepts both `SendMessage` and legacy `message/send`.
-            "method": "SendMessage",
-            "params": params,
-        }
-
-    @server.list_tools()
-    async def _list_tools() -> list[Tool]:
-        return [
-            Tool(
-                name="a2a_send",
-                description=(
-                    "Send a message to another agent on this sac listen. "
-                    "Sets from_agent automatically; mints conversation_id "
-                    "when omitted."
-                ),
-                inputSchema={
-                    "type": "object",
-                    "required": ["target", "content"],
-                    "properties": {
-                        "target": {"type": "string"},
-                        "content": {"type": "string"},
-                        "conversation_id": {"type": "string"},
-                        "priority": {
-                            "type": "string",
-                            "enum": ["low", "normal", "high"],
-                        },
-                        "requires_reply": {"type": "boolean"},
-                    },
-                },
-            ),
-            Tool(
-                name="a2a_reply",
-                description=(
-                    "Reply to a received message. Looks up the original "
-                    "sender by msg_id; carries the same conversation_id."
-                ),
-                inputSchema={
-                    "type": "object",
-                    "required": ["in_reply_to", "content"],
-                    "properties": {
-                        "in_reply_to": {"type": "string"},
-                        "content": {"type": "string"},
-                    },
-                },
-            ),
-            Tool(
-                name="a2a_ack",
-                description=(
-                    "Acknowledge a received message without content. "
-                    "Cheap 'got it' to a sender that set requires_reply=true."
-                ),
-                inputSchema={
-                    "type": "object",
-                    "required": ["msg_id"],
-                    "properties": {"msg_id": {"type": "string"}},
-                },
-            ),
-            Tool(
-                name="a2a_peers",
-                description="List reachable agents on this sac listen.",
-                inputSchema={"type": "object", "properties": {}},
-            ),
-            Tool(
-                name="a2a_inbox",
-                description=(
-                    "Return up to `limit` most recent received messages "
-                    "from this agent's inbox buffer (default 20)."
-                ),
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "limit": {"type": "integer", "minimum": 1, "maximum": 200},
-                    },
-                },
-            ),
-        ]
-
-    @server.call_tool()
-    async def _call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
-        if name == "a2a_send":
-            target = arguments["target"]
-            content = arguments["content"]
-            payload = _wrap_message_send(
-                content,
-                conversation_id=arguments.get("conversation_id") or _uuid.uuid4().hex,
-                priority=arguments.get("priority"),
-                requires_reply=arguments.get("requires_reply"),
-            )
-            res = await _post(f"/agents/{target}/message:send", payload)
-            return [TextContent(type="text", text=json.dumps(res))]
-
-        if name == "a2a_reply":
-            mid = arguments["in_reply_to"]
-            orig = _find(mid)
-            if orig is None:
-                return [
-                    TextContent(
-                        type="text",
-                        text=json.dumps(
-                            {"error": f"unknown msg_id {mid} (inbox window)"}
-                        ),
-                    )
-                ]
-            target = orig.get("from_agent", "")
-            if not target:
-                return [
-                    TextContent(
-                        type="text",
-                        text=json.dumps({"error": "original sender unknown"}),
-                    )
-                ]
-            payload = _wrap_message_send(
-                arguments["content"],
-                conversation_id=orig.get("conversation_id"),
-                in_reply_to=mid,
-            )
-            res = await _post(f"/agents/{target}/message:send", payload)
-            return [TextContent(type="text", text=json.dumps(res))]
-
-        if name == "a2a_ack":
-            mid = arguments["msg_id"]
-            orig = _find(mid)
-            if orig is None:
-                return [
-                    TextContent(
-                        type="text",
-                        text=json.dumps(
-                            {"error": f"unknown msg_id {mid} (inbox window)"}
-                        ),
-                    )
-                ]
-            target = orig.get("from_agent", "")
-            if not target:
-                return [
-                    TextContent(
-                        type="text",
-                        text=json.dumps({"error": "original sender unknown"}),
-                    )
-                ]
-            payload = _wrap_message_send(
-                "",
-                conversation_id=orig.get("conversation_id"),
-                in_reply_to=mid,
-                ack=True,
-            )
-            res = await _post(f"/agents/{target}/message:send", payload)
-            return [TextContent(type="text", text=json.dumps(res))]
-
-        if name == "a2a_peers":
-            # No trailing slash: sac listen registers `/agents` and a GET to
-            # `/agents/` 307-redirects, which httpx does not follow by default
-            # (a2a_peers then returns a bare 307 with empty body).
-            res = await _get("/agents")
-            return [TextContent(type="text", text=json.dumps(res))]
-
-        if name == "a2a_inbox":
-            limit = int(arguments.get("limit") or 20)
-            items = list(_recent)[-limit:]
-            return [
-                TextContent(
-                    type="text", text=json.dumps({"count": len(items), "items": items})
-                )
-            ]
-
-        return [
-            TextContent(
-                type="text", text=json.dumps({"error": f"unknown tool: {name}"})
-            )
-        ]
+    register_tools(
+        server, agent_name=agent_name, listen_url=listen_url, bearer=bearer
+    )
 
 
 def main(name: str, listen_url: str | None = None) -> None:

--- a/tests/scitex_agent_container/_mcp/test__channel_tools.py
+++ b/tests/scitex_agent_container/_mcp/test__channel_tools.py
@@ -1,0 +1,504 @@
+"""Tests for the sac MCP channel **send-side** ``a2a_*`` tool surface
+(``_mcp._channel_tools``).
+
+This module hosts the tools the agent calls explicitly — ``a2a_send``,
+``a2a_reply``, ``a2a_ack``, ``a2a_peers``, ``a2a_inbox`` — extracted from
+``_mcp.channel`` (which kept the receive-side adapter). The receive-side
+push + auto-ack path is covered by ``test_channel.py``.
+
+Per the "no cut corners" principle these tests use **real** asyncio +
+real ``httpx`` + a real ``asyncio.start_server``-backed HTTP/1.1 server
+on loopback. No mocks, no monkeypatch — the only test double is an
+explicit ``_ToolRecorder`` mirroring the MCP ``@server.list_tools()`` /
+``@server.call_tool()`` registration contract (a real collaborator).
+
+AAA markers, one-assert per test (TQ002, TQ007).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import pytest
+import pytest_asyncio
+
+mcp_types = pytest.importorskip("mcp.types")  # gates entire module on `mcp`
+from mcp.types import TextContent, Tool  # noqa: E402
+
+from scitex_agent_container._mcp._channel_tools import register_tools  # noqa: E402
+from scitex_agent_container._mcp.channel import _recent  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Real in-process HTTP/1.1 + JSON server (no aiohttp dependency).
+# ---------------------------------------------------------------------------
+
+
+class _FakeListenServer:
+    """A real asyncio TCP server speaking minimal HTTP/1.1 for tests."""
+
+    def __init__(self) -> None:
+        self.posts: list[tuple[str, dict[str, Any]]] = []
+        self.peers_payload: dict[str, Any] = {"agents": []}
+        self.last_auth: str | None = None
+        self._server: asyncio.base_events.Server | None = None
+        self.host: str = "127.0.0.1"
+        self.port: int = 0
+
+    async def start(self) -> None:
+        self._server = await asyncio.start_server(self._handle, host=self.host, port=0)
+        self.port = self._server.sockets[0].getsockname()[1]
+
+    async def stop(self) -> None:
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+            self._server = None
+
+    @property
+    def base_url(self) -> str:
+        return f"http://{self.host}:{self.port}"
+
+    async def _handle(
+        self,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        try:
+            request_line = await reader.readline()
+            if not request_line:
+                return
+            try:
+                method, path, _ = request_line.decode().rstrip("\r\n").split(" ")
+            except ValueError:
+                return
+            content_length = 0
+            while True:
+                line = await reader.readline()
+                if line in (b"\r\n", b"\n", b""):
+                    break
+                low = line.lower()
+                if low.startswith(b"content-length:"):
+                    content_length = int(line.split(b":", 1)[1].strip())
+                elif low.startswith(b"authorization:"):
+                    self.last_auth = line.split(b":", 1)[1].decode().strip()
+            body = b""
+            if content_length:
+                body = await reader.readexactly(content_length)
+
+            if method == "GET" and path.rstrip("/") == "/agents":
+                await self._serve_json(writer, self.peers_payload)
+            elif method == "POST" and "/message:send" in path:
+                try:
+                    payload = json.loads(body.decode() or "{}")
+                except json.JSONDecodeError:
+                    payload = {}
+                self.posts.append((path, payload))
+                await self._serve_json(writer, {"ok": True})
+            else:
+                await self._serve_status(writer, 404, b"not found")
+        finally:
+            try:
+                writer.close()
+                await writer.wait_closed()
+            except Exception:
+                pass
+
+    async def _serve_json(
+        self, writer: asyncio.StreamWriter, payload: dict[str, Any]
+    ) -> None:
+        body = json.dumps(payload).encode()
+        writer.write(
+            b"HTTP/1.1 200 OK\r\n"
+            b"Content-Type: application/json\r\n"
+            b"Content-Length: " + str(len(body)).encode() + b"\r\n"
+            b"Connection: close\r\n"
+            b"\r\n" + body
+        )
+        await writer.drain()
+
+    async def _serve_status(
+        self, writer: asyncio.StreamWriter, code: int, body: bytes
+    ) -> None:
+        writer.write(
+            f"HTTP/1.1 {code} X\r\n"
+            f"Content-Length: {len(body)}\r\n"
+            f"Connection: close\r\n\r\n".encode()
+            + body
+        )
+        await writer.drain()
+
+
+@pytest_asyncio.fixture
+async def fake_listen():
+    server = _FakeListenServer()
+    await server.start()
+    try:
+        yield server
+    finally:
+        await server.stop()
+
+
+class _ToolRecorder:
+    """Captures ``@server.list_tools()`` and ``@server.call_tool()``
+    decorations onto a structural stand-in.
+
+    Mirrors the MCP server contract closely enough that ``register_tools``
+    runs unchanged, and the captured callables can be invoked directly.
+    Not a mock — just attribute storage.
+    """
+
+    def __init__(self) -> None:
+        self.list_tools_fn = None
+        self.call_tool_fn = None
+
+    def list_tools(self):
+        def _decorate(fn):
+            self.list_tools_fn = fn
+            return fn
+
+        return _decorate
+
+    def call_tool(self):
+        def _decorate(fn):
+            self.call_tool_fn = fn
+            return fn
+
+        return _decorate
+
+
+@pytest.fixture
+def registered_tools(fake_listen):
+    """Register tools against a fresh recorder, pointing at the fake."""
+    rec = _ToolRecorder()
+    register_tools(
+        rec,
+        agent_name="alice",
+        listen_url=fake_listen.base_url,
+        bearer=None,
+    )
+    return rec
+
+
+@pytest.fixture(autouse=True)
+def _clear_recent_ring():
+    """Each test sees an empty inbox ring buffer."""
+    _recent.clear()
+    yield
+    _recent.clear()
+
+
+# ---------------------------------------------------------------------------
+# list_tools surface
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_tools_returns_five_tools(registered_tools: _ToolRecorder):
+    # Arrange
+    list_fn = registered_tools.list_tools_fn
+    # Act
+    tools = await list_fn()
+    # Assert
+    assert len(tools) == 5
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "expected_name",
+    ["a2a_send", "a2a_reply", "a2a_ack", "a2a_peers", "a2a_inbox"],
+)
+async def test_list_tools_includes_expected_tool(
+    registered_tools: _ToolRecorder, expected_name: str
+):
+    # Arrange
+    list_fn = registered_tools.list_tools_fn
+    # Act
+    names = {t.name for t in await list_fn()}
+    # Assert
+    assert expected_name in names
+
+
+@pytest.mark.asyncio
+async def test_list_tools_every_entry_is_a_tool_instance(
+    registered_tools: _ToolRecorder,
+):
+    # Arrange
+    list_fn = registered_tools.list_tools_fn
+    # Act
+    tools = await list_fn()
+    bad = [t for t in tools if not isinstance(t, Tool)]
+    # Assert
+    assert bad == []
+
+
+# ---------------------------------------------------------------------------
+# call_tool dispatch (real HTTP to fake_listen)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_call_tool_unknown_name_returns_error_payload(
+    registered_tools: _ToolRecorder,
+):
+    # Arrange
+    call_fn = registered_tools.call_tool_fn
+    # Act
+    out = await call_fn("not_a_tool", {})
+    body = json.loads(out[0].text)
+    # Assert
+    assert "error" in body
+
+
+@pytest.mark.asyncio
+async def test_call_tool_a2a_send_posts_to_target_path(
+    registered_tools: _ToolRecorder, fake_listen
+):
+    # Arrange
+    call_fn = registered_tools.call_tool_fn
+    # Act
+    await call_fn("a2a_send", {"target": "bob", "content": "hello"})
+    paths = [p for p, _ in fake_listen.posts]
+    # Assert
+    assert "/agents/bob/message:send" in paths
+
+
+@pytest.mark.asyncio
+async def test_call_tool_a2a_send_sets_from_agent_in_metadata(
+    registered_tools: _ToolRecorder, fake_listen
+):
+    # Arrange
+    call_fn = registered_tools.call_tool_fn
+    # Act
+    await call_fn("a2a_send", {"target": "bob", "content": "hi"})
+    _, payload = fake_listen.posts[-1]
+    # Assert
+    assert payload["params"]["metadata"]["from_agent"] == "alice"
+
+
+@pytest.mark.asyncio
+async def test_call_tool_a2a_send_uses_send_message_method(
+    registered_tools: _ToolRecorder, fake_listen
+):
+    # Arrange
+    call_fn = registered_tools.call_tool_fn
+    # Act
+    await call_fn("a2a_send", {"target": "bob", "content": "hi"})
+    _, payload = fake_listen.posts[-1]
+    # Assert
+    assert payload["method"] == "SendMessage"
+
+
+@pytest.mark.asyncio
+async def test_call_tool_a2a_send_returns_status_field(
+    registered_tools: _ToolRecorder,
+):
+    # Arrange
+    call_fn = registered_tools.call_tool_fn
+    # Act
+    out = await call_fn("a2a_send", {"target": "bob", "content": "hi"})
+    body = json.loads(out[0].text)
+    # Assert
+    assert body["status"] == 200
+
+
+@pytest.mark.asyncio
+async def test_call_tool_a2a_reply_unknown_msg_id_returns_error(
+    registered_tools: _ToolRecorder,
+):
+    # Arrange
+    call_fn = registered_tools.call_tool_fn
+    # Act
+    out = await call_fn("a2a_reply", {"in_reply_to": "ghost", "content": "x"})
+    body = json.loads(out[0].text)
+    # Assert
+    assert "error" in body
+
+
+@pytest.mark.asyncio
+async def test_call_tool_a2a_reply_routes_to_original_sender(
+    registered_tools: _ToolRecorder, fake_listen
+):
+    # Arrange — seed the ring buffer with a received event.
+    _recent.append({"msg_id": "m1", "from_agent": "carol", "conversation_id": "c1"})
+    call_fn = registered_tools.call_tool_fn
+    # Act
+    await call_fn("a2a_reply", {"in_reply_to": "m1", "content": "thanks"})
+    paths = [p for p, _ in fake_listen.posts]
+    # Assert
+    assert "/agents/carol/message:send" in paths
+
+
+@pytest.mark.asyncio
+async def test_call_tool_a2a_reply_carries_conversation_id(
+    registered_tools: _ToolRecorder, fake_listen
+):
+    # Arrange
+    _recent.append({"msg_id": "m1", "from_agent": "carol", "conversation_id": "c-orig"})
+    call_fn = registered_tools.call_tool_fn
+    # Act
+    await call_fn("a2a_reply", {"in_reply_to": "m1", "content": "y"})
+    _, payload = fake_listen.posts[-1]
+    # Assert
+    assert payload["params"]["metadata"]["conversation_id"] == "c-orig"
+
+
+@pytest.mark.asyncio
+async def test_call_tool_a2a_reply_sets_in_reply_to_metadata(
+    registered_tools: _ToolRecorder, fake_listen
+):
+    # Arrange
+    _recent.append({"msg_id": "m1", "from_agent": "carol", "conversation_id": "c-orig"})
+    call_fn = registered_tools.call_tool_fn
+    # Act
+    await call_fn("a2a_reply", {"in_reply_to": "m1", "content": "y"})
+    _, payload = fake_listen.posts[-1]
+    # Assert
+    assert payload["params"]["metadata"]["in_reply_to"] == "m1"
+
+
+@pytest.mark.asyncio
+async def test_call_tool_a2a_reply_unknown_sender_returns_error(
+    registered_tools: _ToolRecorder,
+):
+    # Arrange — event with no from_agent.
+    _recent.append({"msg_id": "m9", "conversation_id": "c"})
+    call_fn = registered_tools.call_tool_fn
+    # Act
+    out = await call_fn("a2a_reply", {"in_reply_to": "m9", "content": "x"})
+    body = json.loads(out[0].text)
+    # Assert
+    assert "error" in body
+
+
+@pytest.mark.asyncio
+async def test_call_tool_a2a_ack_unknown_msg_id_returns_error(
+    registered_tools: _ToolRecorder,
+):
+    # Arrange
+    call_fn = registered_tools.call_tool_fn
+    # Act
+    out = await call_fn("a2a_ack", {"msg_id": "nope"})
+    body = json.loads(out[0].text)
+    # Assert
+    assert "error" in body
+
+
+@pytest.mark.asyncio
+async def test_call_tool_a2a_ack_unknown_sender_returns_error(
+    registered_tools: _ToolRecorder,
+):
+    # Arrange — event present but no from_agent
+    _recent.append({"msg_id": "m11"})
+    call_fn = registered_tools.call_tool_fn
+    # Act
+    out = await call_fn("a2a_ack", {"msg_id": "m11"})
+    body = json.loads(out[0].text)
+    # Assert
+    assert "error" in body
+
+
+@pytest.mark.asyncio
+async def test_call_tool_a2a_ack_posts_ack_metadata(
+    registered_tools: _ToolRecorder, fake_listen
+):
+    # Arrange
+    _recent.append({"msg_id": "m1", "from_agent": "carol", "conversation_id": "c1"})
+    call_fn = registered_tools.call_tool_fn
+    # Act
+    await call_fn("a2a_ack", {"msg_id": "m1"})
+    _, payload = fake_listen.posts[-1]
+    # Assert
+    assert payload["params"]["metadata"]["ack"] is True
+
+
+@pytest.mark.asyncio
+async def test_call_tool_a2a_peers_returns_status(
+    registered_tools: _ToolRecorder, fake_listen
+):
+    # Arrange
+    fake_listen.peers_payload = {"agents": ["alice", "bob"]}
+    call_fn = registered_tools.call_tool_fn
+    # Act
+    out = await call_fn("a2a_peers", {})
+    body = json.loads(out[0].text)
+    # Assert
+    assert body["status"] == 200
+
+
+@pytest.mark.asyncio
+async def test_call_tool_a2a_peers_returns_peers_body(
+    registered_tools: _ToolRecorder, fake_listen
+):
+    # Arrange
+    fake_listen.peers_payload = {"agents": ["alice", "bob"]}
+    call_fn = registered_tools.call_tool_fn
+    # Act
+    out = await call_fn("a2a_peers", {})
+    body = json.loads(out[0].text)
+    # Assert
+    assert body["body"] == {"agents": ["alice", "bob"]}
+
+
+@pytest.mark.asyncio
+async def test_call_tool_a2a_inbox_returns_count(
+    registered_tools: _ToolRecorder,
+):
+    # Arrange
+    _recent.extend(
+        [
+            {"msg_id": "a", "from_agent": "x"},
+            {"msg_id": "b", "from_agent": "x"},
+            {"msg_id": "c", "from_agent": "x"},
+        ]
+    )
+    call_fn = registered_tools.call_tool_fn
+    # Act
+    out = await call_fn("a2a_inbox", {"limit": 10})
+    body = json.loads(out[0].text)
+    # Assert
+    assert body["count"] == 3
+
+
+@pytest.mark.asyncio
+async def test_call_tool_a2a_inbox_respects_limit(
+    registered_tools: _ToolRecorder,
+):
+    # Arrange
+    for i in range(20):
+        _recent.append({"msg_id": str(i), "from_agent": "x"})
+    call_fn = registered_tools.call_tool_fn
+    # Act
+    out = await call_fn("a2a_inbox", {"limit": 5})
+    body = json.loads(out[0].text)
+    # Assert
+    assert body["count"] == 5
+
+
+@pytest.mark.asyncio
+async def test_call_tool_returns_text_content_instance(
+    registered_tools: _ToolRecorder,
+):
+    # Arrange
+    call_fn = registered_tools.call_tool_fn
+    # Act
+    out = await call_fn("a2a_inbox", {})
+    # Assert
+    assert isinstance(out[0], TextContent)
+
+
+@pytest.mark.asyncio
+async def test_register_tools_forwards_bearer_token_on_post(fake_listen):
+    # Arrange
+    rec = _ToolRecorder()
+    register_tools(
+        rec,
+        agent_name="alice",
+        listen_url=fake_listen.base_url,
+        bearer="s3cret",
+    )
+    # Act
+    await rec.call_tool_fn("a2a_send", {"target": "bob", "content": "hi"})
+    # Assert
+    assert fake_listen.last_auth == "Bearer s3cret"

--- a/tests/scitex_agent_container/_mcp/test_channel.py
+++ b/tests/scitex_agent_container/_mcp/test_channel.py
@@ -5,16 +5,17 @@ The channel server is a stdio MCP subprocess that:
 1. Opens an HTTP/SSE connection to ``sac listen`` at
    ``/agents/<name>/inbox/stream`` and converts every event into an
    MCP ``notifications/claude/channel`` JSON-RPC notification.
-2. Registers the ``a2a_*`` tool surface (``a2a_send``, ``a2a_reply``,
-   ``a2a_ack``, ``a2a_peers``, ``a2a_inbox``), which speak HTTP to the
-   same ``sac listen`` HTTP base.
+2. On injecting a received event, emits an automatic ``a2a_ack`` back
+   to the sender (stage-2 "read" receipt) — infra-automatic, the agent
+   is unaware. The loop-guard skips events that are themselves acks.
+
+The send-side ``a2a_*`` tool surface lives in ``_channel_tools`` and is
+covered by ``test__channel_tools.py``; only the wrapper delegation is
+asserted here.
 
 Per the "no cut corners" principle these tests use **real** asyncio +
 real ``httpx`` + a real ``asyncio.start_server``-backed HTTP/1.1 server
-on loopback that speaks SSE and JSON. No mocks, no monkeypatch — the
-only test double is an explicit ``_ToolRecorder`` mirroring the MCP
-``@server.list_tools()`` / ``@server.call_tool()`` registration
-contract (a real collaborator, not a mock).
+on loopback that speaks SSE and JSON. No mocks, no monkeypatch.
 
 AAA markers, one-assert per test (TQ002, TQ007).
 """
@@ -22,14 +23,16 @@ AAA markers, one-assert per test (TQ002, TQ007).
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
+import os
 from typing import Any
 
 import pytest
 import pytest_asyncio
 
 mcp_types = pytest.importorskip("mcp.types")  # gates entire module on `mcp`
-from mcp.types import TextContent, Tool  # noqa: E402
+from mcp.types import Tool  # noqa: E402
 
 from scitex_agent_container._mcp import channel as channel_mod  # noqa: E402
 from scitex_agent_container._mcp.channel import (  # noqa: E402
@@ -175,53 +178,6 @@ async def fake_listen():
         yield server
     finally:
         await server.stop()
-
-
-class _ToolRecorder:
-    """Captures ``@server.list_tools()`` and ``@server.call_tool()``
-    decorations onto a structural stand-in.
-
-    Mirrors the MCP server contract closely enough that
-    ``_register_tools`` runs unchanged, and the captured callables can
-    be invoked directly. Not a mock — no auto-spec, no call tracking
-    magic; just attribute storage.
-    """
-
-    def __init__(self) -> None:
-        self.list_tools_fn = None
-        self.call_tool_fn = None
-
-    def list_tools(self):
-        def _decorate(fn):
-            self.list_tools_fn = fn
-            return fn
-
-        return _decorate
-
-    def call_tool(self):
-        def _decorate(fn):
-            self.call_tool_fn = fn
-            return fn
-
-        return _decorate
-
-
-@pytest.fixture
-def tool_recorder() -> _ToolRecorder:
-    rec = _ToolRecorder()
-    return rec
-
-
-@pytest.fixture
-def registered_tools(tool_recorder: _ToolRecorder, fake_listen):
-    """Register tools against the recorder, pointing at the fake server."""
-    _register_tools(
-        tool_recorder,
-        agent_name="alice",
-        listen_url=fake_listen.base_url,
-        bearer=None,
-    )
-    return tool_recorder
 
 
 @pytest.fixture(autouse=True)
@@ -433,373 +389,49 @@ async def test_consume_sse_dispatches_multiple_events_in_order(fake_listen):
 
 
 # ---------------------------------------------------------------------------
-# _register_tools — list_tools surface
+# _register_tools — thin re-export wrapper delegation
+#
+# The a2a_* tool surface lives in ``_channel_tools`` (see
+# ``test__channel_tools.py`` for its full coverage). ``channel`` keeps a
+# ``_register_tools`` wrapper preserving the historical import path; this
+# test pins that the wrapper actually wires the tools onto the server.
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_list_tools_returns_five_tools(registered_tools: _ToolRecorder):
-    # Arrange
-    list_fn = registered_tools.list_tools_fn
-    # Act
-    tools = await list_fn()
-    # Assert
-    assert len(tools) == 5
+async def test_register_tools_wrapper_delegates_to_channel_tools(fake_listen):
+    # Arrange — a structural recorder for the MCP decoration contract.
+    class _Rec:
+        def __init__(self):
+            self.list_tools_fn = None
 
+        def list_tools(self):
+            def _d(fn):
+                self.list_tools_fn = fn
+                return fn
 
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "expected_name",
-    ["a2a_send", "a2a_reply", "a2a_ack", "a2a_peers", "a2a_inbox"],
-)
-async def test_list_tools_includes_expected_tool(
-    registered_tools: _ToolRecorder, expected_name: str
-):
-    # Arrange
-    list_fn = registered_tools.list_tools_fn
-    # Act
-    names = {t.name for t in await list_fn()}
-    # Assert
-    assert expected_name in names
+            return _d
 
+        def call_tool(self):
+            def _d(fn):
+                return fn
 
-@pytest.mark.asyncio
-async def test_list_tools_every_entry_is_a_tool_instance(
-    registered_tools: _ToolRecorder,
-):
-    # Arrange
-    list_fn = registered_tools.list_tools_fn
-    # Act
-    tools = await list_fn()
-    bad = [t for t in tools if not isinstance(t, Tool)]
-    # Assert
-    assert bad == []
+            return _d
 
-
-# ---------------------------------------------------------------------------
-# _register_tools — call_tool dispatch (real HTTP to fake_listen)
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_call_tool_unknown_name_returns_error_payload(
-    registered_tools: _ToolRecorder,
-):
-    # Arrange
-    call_fn = registered_tools.call_tool_fn
-    # Act
-    out = await call_fn("not_a_tool", {})
-    body = json.loads(out[0].text)
-    # Assert
-    assert "error" in body
-
-
-@pytest.mark.asyncio
-async def test_call_tool_a2a_send_posts_to_target_path(
-    registered_tools: _ToolRecorder, fake_listen
-):
-    # Arrange
-    call_fn = registered_tools.call_tool_fn
-    # Act
-    await call_fn("a2a_send", {"target": "bob", "content": "hello"})
-    paths = [p for p, _ in fake_listen.posts]
-    # Assert
-    assert "/agents/bob/message:send" in paths
-
-
-@pytest.mark.asyncio
-async def test_call_tool_a2a_send_sets_from_agent_in_metadata(
-    registered_tools: _ToolRecorder, fake_listen
-):
-    # Arrange
-    call_fn = registered_tools.call_tool_fn
-    # Act
-    await call_fn("a2a_send", {"target": "bob", "content": "hi"})
-    _, payload = fake_listen.posts[-1]
-    # Assert
-    assert payload["params"]["metadata"]["from_agent"] == "alice"
-
-
-@pytest.mark.asyncio
-async def test_call_tool_a2a_send_uses_send_message_method(
-    registered_tools: _ToolRecorder, fake_listen
-):
-    # Arrange
-    call_fn = registered_tools.call_tool_fn
-    # Act
-    await call_fn("a2a_send", {"target": "bob", "content": "hi"})
-    _, payload = fake_listen.posts[-1]
-    # Assert
-    assert payload["method"] == "SendMessage"
-
-
-@pytest.mark.asyncio
-async def test_call_tool_a2a_send_returns_status_field(
-    registered_tools: _ToolRecorder,
-):
-    # Arrange
-    call_fn = registered_tools.call_tool_fn
-    # Act
-    out = await call_fn("a2a_send", {"target": "bob", "content": "hi"})
-    body = json.loads(out[0].text)
-    # Assert
-    assert body["status"] == 200
-
-
-@pytest.mark.asyncio
-async def test_call_tool_a2a_reply_unknown_msg_id_returns_error(
-    registered_tools: _ToolRecorder,
-):
-    # Arrange
-    call_fn = registered_tools.call_tool_fn
-    # Act
-    out = await call_fn("a2a_reply", {"in_reply_to": "ghost", "content": "x"})
-    body = json.loads(out[0].text)
-    # Assert
-    assert "error" in body
-
-
-@pytest.mark.asyncio
-async def test_call_tool_a2a_reply_routes_to_original_sender(
-    registered_tools: _ToolRecorder, fake_listen
-):
-    # Arrange — seed the ring buffer with a received event.
-    _recent.append({"msg_id": "m1", "from_agent": "carol", "conversation_id": "c1"})
-    call_fn = registered_tools.call_tool_fn
-    # Act
-    await call_fn("a2a_reply", {"in_reply_to": "m1", "content": "thanks"})
-    paths = [p for p, _ in fake_listen.posts]
-    # Assert
-    assert "/agents/carol/message:send" in paths
-
-
-@pytest.mark.asyncio
-async def test_call_tool_a2a_reply_carries_conversation_id(
-    registered_tools: _ToolRecorder, fake_listen
-):
-    # Arrange
-    _recent.append({"msg_id": "m1", "from_agent": "carol", "conversation_id": "c-orig"})
-    call_fn = registered_tools.call_tool_fn
-    # Act
-    await call_fn("a2a_reply", {"in_reply_to": "m1", "content": "y"})
-    _, payload = fake_listen.posts[-1]
-    # Assert
-    assert payload["params"]["metadata"]["conversation_id"] == "c-orig"
-
-
-@pytest.mark.asyncio
-async def test_call_tool_a2a_reply_sets_in_reply_to_metadata(
-    registered_tools: _ToolRecorder, fake_listen
-):
-    # Arrange
-    _recent.append({"msg_id": "m1", "from_agent": "carol", "conversation_id": "c-orig"})
-    call_fn = registered_tools.call_tool_fn
-    # Act
-    await call_fn("a2a_reply", {"in_reply_to": "m1", "content": "y"})
-    _, payload = fake_listen.posts[-1]
-    # Assert
-    assert payload["params"]["metadata"]["in_reply_to"] == "m1"
-
-
-@pytest.mark.asyncio
-async def test_call_tool_a2a_reply_unknown_sender_returns_error(
-    registered_tools: _ToolRecorder,
-):
-    # Arrange — event with no from_agent.
-    _recent.append({"msg_id": "m9", "conversation_id": "c"})
-    call_fn = registered_tools.call_tool_fn
-    # Act
-    out = await call_fn("a2a_reply", {"in_reply_to": "m9", "content": "x"})
-    body = json.loads(out[0].text)
-    # Assert
-    assert "error" in body
-
-
-@pytest.mark.asyncio
-async def test_call_tool_a2a_ack_unknown_msg_id_returns_error(
-    registered_tools: _ToolRecorder,
-):
-    # Arrange
-    call_fn = registered_tools.call_tool_fn
-    # Act
-    out = await call_fn("a2a_ack", {"msg_id": "nope"})
-    body = json.loads(out[0].text)
-    # Assert
-    assert "error" in body
-
-
-@pytest.mark.asyncio
-async def test_call_tool_a2a_ack_unknown_sender_returns_error(
-    registered_tools: _ToolRecorder,
-):
-    # Arrange — event present but no from_agent
-    _recent.append({"msg_id": "m11"})
-    call_fn = registered_tools.call_tool_fn
-    # Act
-    out = await call_fn("a2a_ack", {"msg_id": "m11"})
-    body = json.loads(out[0].text)
-    # Assert
-    assert "error" in body
-
-
-@pytest.mark.asyncio
-async def test_call_tool_a2a_ack_posts_ack_metadata(
-    registered_tools: _ToolRecorder, fake_listen
-):
-    # Arrange
-    _recent.append({"msg_id": "m1", "from_agent": "carol", "conversation_id": "c1"})
-    call_fn = registered_tools.call_tool_fn
-    # Act
-    await call_fn("a2a_ack", {"msg_id": "m1"})
-    _, payload = fake_listen.posts[-1]
-    # Assert
-    assert payload["params"]["metadata"]["ack"] is True
-
-
-@pytest.mark.asyncio
-async def test_call_tool_a2a_peers_returns_status(
-    registered_tools: _ToolRecorder, fake_listen
-):
-    # Arrange
-    fake_listen.peers_payload = {"agents": ["alice", "bob"]}
-    call_fn = registered_tools.call_tool_fn
-    # Act
-    out = await call_fn("a2a_peers", {})
-    body = json.loads(out[0].text)
-    # Assert
-    assert body["status"] == 200
-
-
-@pytest.mark.asyncio
-async def test_call_tool_a2a_peers_returns_peers_body(
-    registered_tools: _ToolRecorder, fake_listen
-):
-    # Arrange
-    fake_listen.peers_payload = {"agents": ["alice", "bob"]}
-    call_fn = registered_tools.call_tool_fn
-    # Act
-    out = await call_fn("a2a_peers", {})
-    body = json.loads(out[0].text)
-    # Assert
-    assert body["body"] == {"agents": ["alice", "bob"]}
-
-
-@pytest.mark.asyncio
-async def test_call_tool_a2a_inbox_returns_count(
-    registered_tools: _ToolRecorder,
-):
-    # Arrange
-    _recent.extend(
-        [
-            {"msg_id": "a", "from_agent": "x"},
-            {"msg_id": "b", "from_agent": "x"},
-            {"msg_id": "c", "from_agent": "x"},
-        ]
-    )
-    call_fn = registered_tools.call_tool_fn
-    # Act
-    out = await call_fn("a2a_inbox", {"limit": 10})
-    body = json.loads(out[0].text)
-    # Assert
-    assert body["count"] == 3
-
-
-@pytest.mark.asyncio
-async def test_call_tool_a2a_inbox_respects_limit(
-    registered_tools: _ToolRecorder,
-):
-    # Arrange
-    for i in range(20):
-        _recent.append({"msg_id": str(i), "from_agent": "x"})
-    call_fn = registered_tools.call_tool_fn
-    # Act
-    out = await call_fn("a2a_inbox", {"limit": 5})
-    body = json.loads(out[0].text)
-    # Assert
-    assert body["count"] == 5
-
-
-@pytest.mark.asyncio
-async def test_call_tool_returns_text_content_instance(
-    registered_tools: _ToolRecorder,
-):
-    # Arrange
-    call_fn = registered_tools.call_tool_fn
-    # Act
-    out = await call_fn("a2a_inbox", {})
-    # Assert
-    assert isinstance(out[0], TextContent)
-
-
-# ---------------------------------------------------------------------------
-# bearer plumbing — Authorization header on POST
-# ---------------------------------------------------------------------------
-
-
-class _BearerEchoServer(_FakeListenServer):
-    """Records the Authorization header seen on POST requests."""
-
-    def __init__(self) -> None:
-        super().__init__()
-        self.last_auth: str | None = None
-
-    async def _handle(self, reader, writer):  # type: ignore[override]
-        try:
-            request_line = await reader.readline()
-            if not request_line:
-                return
-            try:
-                method, path, _ = request_line.decode().rstrip("\r\n").split(" ")
-            except ValueError:
-                return
-            content_length = 0
-            while True:
-                line = await reader.readline()
-                if line in (b"\r\n", b"\n", b""):
-                    break
-                low = line.lower()
-                if low.startswith(b"content-length:"):
-                    content_length = int(line.split(b":", 1)[1].strip())
-                elif low.startswith(b"authorization:"):
-                    self.last_auth = line.split(b":", 1)[1].decode().strip()
-            if content_length:
-                await reader.readexactly(content_length)
-            if method == "POST":
-                await self._serve_json(writer, {"ok": True})
-            else:
-                await self._serve_status(writer, 404, b"x")
-        finally:
-            try:
-                writer.close()
-                await writer.wait_closed()
-            except Exception:
-                pass
-
-
-@pytest_asyncio.fixture
-async def bearer_server():
-    s = _BearerEchoServer()
-    await s.start()
-    try:
-        yield s
-    finally:
-        await s.stop()
-
-
-@pytest.mark.asyncio
-async def test_register_tools_forwards_bearer_token_on_post(bearer_server):
-    # Arrange
-    rec = _ToolRecorder()
+    rec = _Rec()
+    # Act — the wrapper must register the tool surface on the recorder.
     _register_tools(
-        rec,
-        agent_name="alice",
-        listen_url=bearer_server.base_url,
-        bearer="s3cret",
+        rec, agent_name="alice", listen_url=fake_listen.base_url, bearer=None
     )
-    # Act
-    await rec.call_tool_fn("a2a_send", {"target": "bob", "content": "hi"})
-    # Assert
-    assert bearer_server.last_auth == "Bearer s3cret"
+    tools = await rec.list_tools_fn()
+    # Assert — wiring reached _channel_tools.register_tools.
+    assert {t.name for t in tools if isinstance(t, Tool)} == {
+        "a2a_send",
+        "a2a_reply",
+        "a2a_ack",
+        "a2a_peers",
+        "a2a_inbox",
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -1028,73 +660,6 @@ async def test_consume_sse_skips_malformed_json_frames(
 # ---------------------------------------------------------------------------
 
 
-class _PlainTextServer(_FakeListenServer):
-    """Returns a non-JSON ``text/plain`` body for both POST and GET."""
-
-    async def _handle(self, reader, writer):  # type: ignore[override]
-        try:
-            request_line = await reader.readline()
-            if not request_line:
-                return
-            try:
-                method, _path, _ = request_line.decode().rstrip("\r\n").split(" ")
-            except ValueError:
-                return
-            content_length = 0
-            while True:
-                line = await reader.readline()
-                if line in (b"\r\n", b"\n", b""):
-                    break
-                if line.lower().startswith(b"content-length:"):
-                    content_length = int(line.split(b":", 1)[1].strip())
-            if content_length:
-                await reader.readexactly(content_length)
-            body = b"plain-text-body"
-            writer.write(
-                b"HTTP/1.1 200 OK\r\n"
-                b"Content-Type: text/plain\r\n"
-                b"Content-Length: " + str(len(body)).encode() + b"\r\n"
-                b"Connection: close\r\n\r\n" + body
-            )
-            await writer.drain()
-            del method
-        finally:
-            try:
-                writer.close()
-                await writer.wait_closed()
-            except Exception:
-                pass
-
-
-@pytest_asyncio.fixture
-async def plain_text_server():
-    s = _PlainTextServer()
-    await s.start()
-    try:
-        yield s
-    finally:
-        await s.stop()
-
-
-@pytest.mark.asyncio
-async def test_call_tool_a2a_send_handles_non_json_response_body(
-    plain_text_server: _PlainTextServer,
-):
-    # Arrange
-    rec = _ToolRecorder()
-    _register_tools(
-        rec,
-        agent_name="alice",
-        listen_url=plain_text_server.base_url,
-        bearer=None,
-    )
-    # Act
-    out = await rec.call_tool_fn("a2a_send", {"target": "bob", "content": "x"})
-    body = json.loads(out[0].text)
-    # Assert
-    assert body["body"] == "plain-text-body"
-
-
 @pytest.mark.asyncio
 async def test_consume_sse_retries_after_connection_error():
     """Bind a loopback socket then immediately close to force refused
@@ -1123,25 +688,6 @@ async def test_consume_sse_retries_after_connection_error():
         pass
     # Assert — the consumer survived the connection error and kept looping.
     assert is_alive
-
-
-@pytest.mark.asyncio
-async def test_call_tool_a2a_peers_handles_non_json_response_body(
-    plain_text_server: _PlainTextServer,
-):
-    # Arrange
-    rec = _ToolRecorder()
-    _register_tools(
-        rec,
-        agent_name="alice",
-        listen_url=plain_text_server.base_url,
-        bearer=None,
-    )
-    # Act
-    out = await rec.call_tool_fn("a2a_peers", {})
-    body = json.loads(out[0].text)
-    # Assert
-    assert body["body"] == "plain-text-body"
 
 
 # ---------------------------------------------------------------------------
@@ -1271,3 +817,318 @@ async def test_serve_initialize_declares_claude_channel_capability(
     # Assert — the `claude/channel` capability is advertised, so Claude
     # Code will accept the pushed notifications instead of dropping them.
     assert caps["experimental"] == {"claude/channel": {}}
+
+
+# ---------------------------------------------------------------------------
+# Auto-ack — infra-automatic stage-2 "read" receipt.
+#
+# When the receive-side adapter injects an inbound event into the
+# session, it automatically POSTs an ``a2a_ack`` back to the original
+# sender — the receiving agent calls nothing. These tests pin the
+# enable gate, the loop-guard (acks are never re-acked; no ping-pong),
+# the best-effort failure mode, and the end-to-end POST through a real
+# fake listen server.
+# ---------------------------------------------------------------------------
+
+
+class _CapturingSession:
+    """Real collaborator standing in for an MCP ServerSession.
+
+    Records every ``send_message`` so the injection half of
+    ``_push_channel_event`` is observable. Not a mock — plain capture,
+    no auto-spec or call assertions.
+    """
+
+    def __init__(self) -> None:
+        self.sent: list[Any] = []
+
+    async def send_message(self, msg: Any) -> None:
+        self.sent.append(msg)
+
+
+@contextlib.contextmanager
+def _env(name: str, value: str | None):
+    """Set (or unset) a real ``os.environ`` entry and restore on exit.
+
+    Used in place of the ecosystem-forbidden ``monkeypatch`` fixture
+    (STX-NM002): production reads the genuine ``os.environ``, and we put
+    a real value there, then put the prior state back.
+    """
+    sentinel = object()
+    prior: Any = os.environ.get(name, sentinel)
+    if value is None:
+        os.environ.pop(name, None)
+    else:
+        os.environ[name] = value
+    try:
+        yield
+    finally:
+        if prior is sentinel:
+            os.environ.pop(name, None)
+        else:
+            os.environ[name] = prior
+
+
+def test_auto_ack_enabled_default_on_when_env_unset():
+    # Arrange
+    from scitex_agent_container._mcp.channel import _auto_ack_enabled
+
+    # Act — with the env var genuinely absent.
+    with _env("SAC_CHANNEL_AUTO_ACK", None):
+        enabled = _auto_ack_enabled()
+    # Assert
+    assert enabled is True
+
+
+@pytest.mark.parametrize("raw", ["0", "false", "FALSE", "no", "off", " Off "])
+def test_auto_ack_disabled_by_falsey_env(raw):
+    # Arrange
+    from scitex_agent_container._mcp.channel import _auto_ack_enabled
+
+    # Act
+    with _env("SAC_CHANNEL_AUTO_ACK", raw):
+        enabled = _auto_ack_enabled()
+    # Assert
+    assert enabled is False
+
+
+def test_should_auto_ack_true_for_normal_inbound_event():
+    # Arrange
+    from scitex_agent_container._mcp.channel import _should_auto_ack
+
+    event = {"from_agent": "bob", "content": "hi", "msg_id": "m1"}
+    # Act
+    decision = _should_auto_ack(event)
+    # Assert
+    assert decision is True
+
+
+def test_should_auto_ack_false_for_event_that_is_itself_an_ack():
+    """Loop-guard: an auto-ack is itself a message; re-acking it would
+    ping-pong forever. An event carrying ``ack`` truthy must be skipped."""
+    # Arrange
+    from scitex_agent_container._mcp.channel import _should_auto_ack
+
+    event = {"from_agent": "bob", "content": "", "msg_id": "m1", "ack": True}
+    # Act
+    decision = _should_auto_ack(event)
+    # Assert
+    assert decision is False
+
+
+def test_should_auto_ack_false_when_sender_missing():
+    # Arrange — no from_agent: nowhere to send the receipt.
+    from scitex_agent_container._mcp.channel import _should_auto_ack
+
+    event = {"content": "x", "msg_id": "m1"}
+    # Act
+    decision = _should_auto_ack(event)
+    # Assert
+    assert decision is False
+
+
+@pytest.mark.asyncio
+async def test_push_channel_event_still_injects_notification(fake_listen):
+    """Existing push behavior is preserved: the notification reaches the
+    session regardless of the auto-ack side-effect."""
+    # Arrange
+    from scitex_agent_container._mcp.channel import _push_channel_event
+
+    session = _CapturingSession()
+    event = {"from_agent": "bob", "content": "hi", "msg_id": "m1"}
+    # Act
+    await _push_channel_event(
+        session,
+        event,
+        agent_name="alice",
+        listen_url=fake_listen.base_url,
+        bearer=None,
+    )
+    # Assert — the channel notification was sent through the session.
+    assert len(session.sent) == 1
+
+
+@pytest.mark.asyncio
+async def test_push_channel_event_auto_acks_to_sender_path(fake_listen):
+    # Arrange
+    from scitex_agent_container._mcp.channel import _push_channel_event
+
+    session = _CapturingSession()
+    event = {"from_agent": "bob", "content": "hi", "msg_id": "m1"}
+    # Act
+    await _push_channel_event(
+        session,
+        event,
+        agent_name="alice",
+        listen_url=fake_listen.base_url,
+        bearer=None,
+    )
+    paths = [p for p, _ in fake_listen.posts]
+    # Assert — the receipt went back to the original sender's send path.
+    assert "/agents/bob/message:send" in paths
+
+
+@pytest.mark.asyncio
+async def test_push_channel_event_auto_ack_carries_ack_marker(fake_listen):
+    """The auto-ack must stamp ``ack=True`` — that flag IS the loop-guard
+    marker the receiving adapter checks before re-acking."""
+    # Arrange
+    from scitex_agent_container._mcp.channel import _push_channel_event
+
+    session = _CapturingSession()
+    event = {"from_agent": "bob", "content": "hi", "msg_id": "m1"}
+    # Act
+    await _push_channel_event(
+        session,
+        event,
+        agent_name="alice",
+        listen_url=fake_listen.base_url,
+        bearer=None,
+    )
+    _, payload = fake_listen.posts[-1]
+    # Assert
+    assert payload["params"]["metadata"]["ack"] is True
+
+
+@pytest.mark.asyncio
+async def test_push_channel_event_auto_ack_references_original_msg_id(fake_listen):
+    # Arrange
+    from scitex_agent_container._mcp.channel import _push_channel_event
+
+    session = _CapturingSession()
+    event = {"from_agent": "bob", "content": "hi", "msg_id": "m1"}
+    # Act
+    await _push_channel_event(
+        session,
+        event,
+        agent_name="alice",
+        listen_url=fake_listen.base_url,
+        bearer=None,
+    )
+    _, payload = fake_listen.posts[-1]
+    # Assert
+    assert payload["params"]["metadata"]["in_reply_to"] == "m1"
+
+
+@pytest.mark.asyncio
+async def test_push_channel_event_does_not_auto_ack_an_ack(fake_listen):
+    """Loop-guard end-to-end: injecting an inbound event that is itself
+    an ack must NOT generate another ack POST."""
+    # Arrange
+    from scitex_agent_container._mcp.channel import _push_channel_event
+
+    session = _CapturingSession()
+    ack_event = {"from_agent": "bob", "content": "", "msg_id": "m1", "ack": True}
+    # Act
+    await _push_channel_event(
+        session,
+        ack_event,
+        agent_name="alice",
+        listen_url=fake_listen.base_url,
+        bearer=None,
+    )
+    # Assert — zero POSTs: an ack does not beget an ack.
+    assert fake_listen.posts == []
+
+
+@pytest.mark.asyncio
+async def test_two_adapters_do_not_ping_pong_to_a_fixed_point(fake_listen):
+    """Drive the full bounce: adapter A injects B's message → auto-acks B;
+    then feed A's ack into adapter B's inject path. B must NOT ack back, so
+    the exchange terminates after exactly one ack rather than diverging."""
+    # Arrange
+    from scitex_agent_container._mcp.channel import _push_channel_event
+
+    session_a = _CapturingSession()
+    session_b = _CapturingSession()
+    inbound_to_a = {"from_agent": "bob", "content": "hi", "msg_id": "m1"}
+    # Act — A receives B's message and auto-acks (1 POST expected).
+    await _push_channel_event(
+        session_a,
+        inbound_to_a,
+        agent_name="alice",
+        listen_url=fake_listen.base_url,
+        bearer=None,
+    )
+    _, ack_payload = fake_listen.posts[-1]
+    # Reconstruct the bus event B's adapter would see from A's ack POST.
+    ack_meta = ack_payload["params"]["metadata"]
+    inbound_to_b = {
+        "from_agent": ack_meta["from_agent"],
+        "content": "",
+        "msg_id": "m2",
+        "ack": ack_meta.get("ack"),
+    }
+    # B injects A's ack — the loop-guard must stop here.
+    await _push_channel_event(
+        session_b,
+        inbound_to_b,
+        agent_name="bob",
+        listen_url=fake_listen.base_url,
+        bearer=None,
+    )
+    # Assert — exactly one ack total; B did not bounce another back.
+    assert len(fake_listen.posts) == 1
+
+
+@pytest.mark.asyncio
+async def test_auto_ack_disabled_via_env_emits_no_post(fake_listen):
+    # Arrange
+    from scitex_agent_container._mcp.channel import _push_channel_event
+
+    session = _CapturingSession()
+    event = {"from_agent": "bob", "content": "hi", "msg_id": "m1"}
+    # Act
+    with _env("SAC_CHANNEL_AUTO_ACK", "0"):
+        await _push_channel_event(
+            session,
+            event,
+            agent_name="alice",
+            listen_url=fake_listen.base_url,
+            bearer=None,
+        )
+    # Assert — injection happened, but no auto-ack POST.
+    assert fake_listen.posts == []
+
+
+@pytest.mark.asyncio
+async def test_push_channel_event_skips_auto_ack_without_send_config(fake_listen):
+    """Backward-compat: called without agent_name/listen_url (the old
+    2-arg signature path) injects but cannot auto-ack — no POST, no crash."""
+    # Arrange
+    from scitex_agent_container._mcp.channel import _push_channel_event
+
+    session = _CapturingSession()
+    event = {"from_agent": "bob", "content": "hi", "msg_id": "m1"}
+    # Act
+    await _push_channel_event(session, event)
+    # Assert
+    assert fake_listen.posts == []
+
+
+@pytest.mark.asyncio
+async def test_auto_ack_failure_is_best_effort_does_not_raise():
+    """A failed auto-ack POST must be swallowed-with-a-loud-log, never
+    re-raised: it can neither block injection nor kill the SSE consumer.
+    Point the adapter at a refused port to force the failure."""
+    # Arrange — a closed loopback port (bind then close) refuses connect.
+    import socket
+
+    from scitex_agent_container._mcp.channel import _push_channel_event
+
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    refused_port = s.getsockname()[1]
+    s.close()
+    session = _CapturingSession()
+    event = {"from_agent": "bob", "content": "hi", "msg_id": "m1"}
+    # Act — must complete without raising despite the ack POST failing.
+    await _push_channel_event(
+        session,
+        event,
+        agent_name="alice",
+        listen_url=f"http://127.0.0.1:{refused_port}",
+        bearer=None,
+    )
+    # Assert — injection still succeeded (the failure was contained).
+    assert len(session.sent) == 1


### PR DESCRIPTION
## What

The receive-side channel adapter (`_mcp/channel.py`) now emits an automatic
`a2a_ack` back to the sender the moment it injects a received bus event into
the Claude session. Two-stage receipt, infra-automatic and agent-unaware:

- stage 1 "delivered" — unchanged: the send response's `delivered_subscriber_count`.
- stage 2 "read" — NEW: this auto-ack, emitted on injection. The receiving
  agent calls nothing; the adapter does it.

## How (file:line)

- `src/scitex_agent_container/_mcp/channel.py`
  - `_auto_ack_enabled()` — env gate `SAC_CHANNEL_AUTO_ACK` (default ON; `0/false/no/off` disables).
  - `_should_auto_ack(event)` — loop-guard: skip events that are themselves
    acks (`ack` flag) or have no `from_agent`.
  - `_post_auto_ack(event, ...)` — POSTs `ack=True` to `event["from_agent"]`
    via the same `/agents/<sender>/message:send` path `a2a_ack` uses.
  - `_push_channel_event(session, event, *, agent_name, listen_url, bearer)` —
    after the existing notification injection (UNCHANGED), best-effort auto-ack;
    a failed ack is logged loudly and never re-raised (can neither block
    injection nor kill the SSE consumer). `_serve.on_event` passes the config.
  - `_register_tools` is now a thin re-export of the extracted module (below).
- `src/scitex_agent_container/_mcp/_channel_tools.py` — NEW: the send-side
  `a2a_*` tool surface, extracted to keep `channel.py` under the size budget.

## Tests (real asyncio + httpx + in-repo fake listen server; no mocks)

- `tests/.../_mcp/test_channel.py` — auto-ack gate, loop-guard incl. a
  **two-adapter no-ping-pong** proof, best-effort failure containment, env
  disable, backward-compat (no send-config = no ack), wrapper delegation.
- `tests/.../_mcp/test__channel_tools.py` — migrated tool-surface tests
  (PS-204/205 mirror for the new private module).
- `_mcp` suite: 70 passed locally.

## ⚠️ BLOCKER — do NOT merge until resolved (operator decision)

The loop-guard is provably correct at the unit level, but it does NOT yet
guard end-to-end in production: the listen server drops the `ack` marker.
`_listen/server.py::node_message_send` -> `a2a/_inbox_bus.py::mint_event`
mint a fixed field set that excludes `ack`, so a received auto-ack arrives
WITHOUT `event["ack"]`. With auto-ack ON on both sides, two adapters would
ping-pong infinitely.

Closing it needs a one-field passthrough:
- `mint_event(..., ack: bool = False)` -> set `event["ack"] = True` when truthy.
- `node_message_send`: `ack=bool(sac_meta.get("ack", False))`.

I deliberately did NOT make that change: the brief says STOP and report if the
listen server / notification shape must change, and `server.py` is also over
the module-size budget (would force a comms-core refactor). Requesting the
operator's go-ahead to add the 2-line passthrough (+ a propagation test) before
this leaves draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
