### PR TITLE
fix(listen): propagate ack marker through mint_event so auto-ack loop-guard works

### DIFF
--- a/src/scitex_agent_container/_listen/server.py
+++ b/src/scitex_agent_container/_listen/server.py
@@ -715,6 +715,7 @@ async def node_message_send(request: Request) -> Response:
         in_reply_to=sac_meta.get("in_reply_to"),
         priority=str(sac_meta.get("priority", "normal")),
         requires_reply=bool(sac_meta.get("requires_reply", False)),
+        ack=bool(sac_meta.get("ack", False)),
     )
 
     # Implicit registration — handoff §4 "A2A compliance without a

--- a/src/scitex_agent_container/a2a/_inbox_bus.py
+++ b/src/scitex_agent_container/a2a/_inbox_bus.py
@@ -103,6 +103,7 @@ def mint_event(
     in_reply_to: str | None = None,
     priority: str = "normal",
     requires_reply: bool = False,
+    ack: bool = False,
     extra: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Mint the event shape sac's channel publishes.
@@ -110,6 +111,12 @@ def mint_event(
     Sender side fills ``content`` + optional metadata; sac listen
     enriches with ``msg_id`` and ``ts`` so receivers can ack/reply
     against stable identifiers.
+
+    ``ack`` marks the event as itself a read-receipt (the same flag
+    the ``a2a_ack`` tool stamps under ``metadata.ack``). It must
+    survive minting so the receiving adapter's auto-ack loop-guard
+    can recognise an ack and decline to ack it back — otherwise two
+    auto-ack adapters ping-pong forever.
     """
     event: dict[str, Any] = {
         "msg_id": uuid.uuid4().hex,
@@ -119,6 +126,7 @@ def mint_event(
         "content": content,
         "priority": priority,
         "requires_reply": requires_reply,
+        "ack": ack,
     }
     if conversation_id:
         event["conversation_id"] = conversation_id

--- a/tests/scitex_agent_container/_listen/test_server.py
+++ b/tests/scitex_agent_container/_listen/test_server.py
@@ -711,9 +711,7 @@ def test_cross_host_send_forwards_to_target_host(cross_host_env) -> None:
     # Arrange
     db = cross_host_env["db"]
     # Register the target as a live instance on host-a.
-    state_db.record_instance_start(
-        name="alice", host="host-a", a2a_port=0, db_path=db
-    )
+    state_db.record_instance_start(name="alice", host="host-a", a2a_port=0, db_path=db)
     # Permitted-peer is registered as a child of root, so is alice;
     # they share a group and ACL allows the send.
     record_lineage(child="permitted-peer", parent="root", db_path=db)
@@ -768,9 +766,7 @@ def test_cross_host_send_forwards_to_target_host(cross_host_env) -> None:
                             json=_send_payload(
                                 "hi from b", from_agent="permitted-peer"
                             ),
-                            headers={
-                                "authorization": f"Bearer {SHARED_TOKEN}"
-                            },
+                            headers={"authorization": f"Bearer {SHARED_TOKEN}"},
                         )
                 if resp.status_code >= 400:
                     raise RuntimeError(
@@ -797,9 +793,7 @@ def test_cross_host_forward_preserves_from_agent_metadata(cross_host_env) -> Non
     """
     # Arrange
     db = cross_host_env["db"]
-    state_db.record_instance_start(
-        name="alice", host="host-a", a2a_port=0, db_path=db
-    )
+    state_db.record_instance_start(name="alice", host="host-a", a2a_port=0, db_path=db)
     record_lineage(child="permitted-peer", parent="root", db_path=db)
     record_lineage(child="alice", parent="root", db_path=db)
     host_a_port = _free_port()
@@ -841,12 +835,8 @@ def test_cross_host_forward_preserves_from_agent_metadata(cross_host_env) -> Non
                     async with httpx.AsyncClient(timeout=5.0) as ac:
                         await ac.post(
                             f"http://127.0.0.1:{host_b_port}/agents/alice/message:send",
-                            json=_send_payload(
-                                "x", from_agent="permitted-peer"
-                            ),
-                            headers={
-                                "authorization": f"Bearer {SHARED_TOKEN}"
-                            },
+                            json=_send_payload("x", from_agent="permitted-peer"),
+                            headers={"authorization": f"Bearer {SHARED_TOKEN}"},
                         )
                 await asyncio.wait_for(sub, timeout=5.0)
             finally:
@@ -955,3 +945,105 @@ def test_cross_host_forward_502_body_carries_add_peer_fix(
     err = r.json().get("error", "")
     # Assert
     assert "sac host add-peer" in err
+
+
+# ---------------------------------------------------------------------------
+# Auto-ack loop-guard propagation (#140 follow-up): the ``ack`` marker a
+# sender stamps under ``params.metadata.ack`` must survive minting so the
+# receiving adapter's ``_should_auto_ack`` sees it and declines to ack an
+# ack — otherwise two auto-ack adapters ping-pong forever. Real uvicorn +
+# SSE round-trip on one host (handoff §0 — no mocks).
+# ---------------------------------------------------------------------------
+
+
+def _send_payload_with_meta(text: str, *, metadata: dict) -> dict:
+    return {
+        "jsonrpc": "2.0",
+        "id": "1",
+        "method": "SendMessage",
+        "params": {
+            "message": {
+                "message_id": "m1",
+                "role": "ROLE_USER",
+                "parts": [{"text": text}],
+            },
+            "metadata": metadata,
+        },
+    }
+
+
+def _roundtrip_local_send(cross_host_env, *, metadata: dict) -> dict:
+    """POST a ``message:send`` to a single local host and return the
+    event the SSE inbox subscriber receives. ``alice`` has no instance
+    row so the target resolves local (no cross-host forward); sender
+    ``bob`` and target ``alice`` are siblings under ``root`` so the
+    intra-group ACL allows the send.
+    """
+    db = cross_host_env["db"]
+    record_lineage(child="bob", parent="root", db_path=db)
+    record_lineage(child="alice", parent="root", db_path=db)
+    port = _free_port()
+    app = create_app(token=SHARED_TOKEN, local_host="host-a")
+
+    async def driver() -> dict:
+        with _run_loopback(app, port):
+            ready = asyncio.Event()
+            captured: dict = {}
+
+            async def consume():
+                async with httpx.AsyncClient(timeout=5.0) as ac:
+                    async with ac.stream(
+                        "GET",
+                        f"http://127.0.0.1:{port}/agents/alice/inbox/stream",
+                        headers={"authorization": f"Bearer {SHARED_TOKEN}"},
+                    ) as sse:
+                        async for line in sse.aiter_lines():
+                            if line.startswith(":"):
+                                ready.set()
+                                continue
+                            if line.startswith("data:"):
+                                captured["event"] = json.loads(
+                                    line[len("data:") :].lstrip()
+                                )
+                                return
+
+            sub = asyncio.create_task(consume())
+            try:
+                await asyncio.wait_for(ready.wait(), timeout=5.0)
+                async with httpx.AsyncClient(timeout=5.0) as ac:
+                    await ac.post(
+                        f"http://127.0.0.1:{port}/agents/alice/message:send",
+                        json=_send_payload_with_meta("ping", metadata=metadata),
+                        headers={"authorization": f"Bearer {SHARED_TOKEN}"},
+                    )
+                await asyncio.wait_for(sub, timeout=5.0)
+            finally:
+                if not sub.done():
+                    sub.cancel()
+                    with contextlib.suppress(BaseException):
+                        await sub
+            return captured.get("event", {})
+
+    return asyncio.run(driver())
+
+
+def test_message_send_with_ack_metadata_yields_ack_true_event(
+    cross_host_env,
+) -> None:
+    # Arrange
+    metadata = {"from_agent": "bob", "ack": True}
+    # Act
+    event = _roundtrip_local_send(cross_host_env, metadata=metadata)
+    # Assert
+    assert event.get("ack") is True
+
+
+def test_message_send_without_ack_metadata_yields_falsey_ack_event(
+    cross_host_env,
+) -> None:
+    # Arrange
+    metadata = {"from_agent": "bob"}
+    # Act
+    event = _roundtrip_local_send(cross_host_env, metadata=metadata)
+    # Assert
+    assert not event.get("ack")

--- a/tests/scitex_agent_container/a2a/test__inbox_bus.py
+++ b/tests/scitex_agent_container/a2a/test__inbox_bus.py
@@ -313,3 +313,26 @@ def test_mint_event_attaches_extra_metadata_when_provided() -> None:
     extra = event.get("extra")
     # Assert
     assert extra == {"trace_id": "abc"}
+
+
+# ---------------------------------------------------------------------------
+# mint_event: ``ack`` survives minting so the auto-ack loop-guard works
+# ---------------------------------------------------------------------------
+
+
+def test_mint_event_carries_ack_flag_when_true() -> None:
+    # Arrange
+    event = mint_event("alice", content="read", from_agent="bob", ack=True)
+    # Act
+    ack = event["ack"]
+    # Assert
+    assert ack is True
+
+
+def test_mint_event_defaults_ack_to_false() -> None:
+    # Arrange
+    event = mint_event("alice", content="hi", from_agent="bob")
+    # Act
+    ack = event["ack"]
+    # Assert
+    assert ack is False


### PR DESCRIPTION
## Problem

PR #140 (feat/channel-auto-ack) added an infra-automatic `a2a_ack` read-receipt in the channel adapter, with a loop-guard `_should_auto_ack` that skips events carrying a truthy `ack` flag. The guard does NOT work end-to-end: the listen server STRIPS the `ack` field when minting the bus event, so a received auto-ack arrives at the other adapter without `event["ack"]`. The guard can't see it, and two auto-ack adapters would ping-pong infinitely.

## Root cause

`_listen/server.py::node_message_send` builds the outbound bus event via `a2a/_inbox_bus.py::mint_event`, which minted a fixed field set that excluded `ack`. The incoming `message:send` payload carries the `ack: true` marker under `params.metadata` (sac_meta), but it was never forwarded.

## Fix (additive, minimal)

- `mint_event(...)` gains `ack: bool = False` and includes `"ack": ack` in the event dict. Default False; existing callers unaffected; no other field/shape change.
- `node_message_send` reads `ack` from incoming sac metadata (`sac_meta.get("ack", False)`) and passes it to `mint_event(..., ack=...)`.

Result: an event minted from an ack-flagged message carries `event["ack"] == True`, so the receiving adapter's `_should_auto_ack` (merged in #140) correctly skips it → no ping-pong.

## Tests (no mocks — real SQLite + uvicorn + SSE)

- `test__inbox_bus.py`: `mint_event` carries `ack=True` when set / defaults `False`.
- `test_server.py` propagation: a `message:send` with `metadata.ack=true` yields a bus event with `ack=True`; without it, `ack` is falsey.

Full a2a + _listen + _mcp suite: 539 passed, 0 failures.

## Note

`_listen/server.py` is already over the per-file line budget on develop (880 lines, pre-existing). Per task scope this change is strictly additive (one line in `node_message_send`); no size-driven refactor was performed.

Depends on #140 for the consuming `_should_auto_ack` behavior. After both merge, the agent image must be rebuilt for auto-ack to take effect live.
