### PR TITLE
feat(to_home): shared baseline layer overlaid by per-agent to_home

### DIFF
--- a/src/scitex_agent_container/runtimes/_to_home.py
+++ b/src/scitex_agent_container/runtimes/_to_home.py
@@ -38,6 +38,29 @@ No fragmented "leaf-vs-mirror" distinction — every path under
 
 Missing ``to_home/`` dir → silent no-op (specs without one just don't
 get materialization).
+
+Baseline layer (shared/common to_home)
+--------------------------------------
+Common hooks/settings shared by every agent live in ONE place instead
+of being copied into every agent's ``to_home/``. Materialization is a
+two-pass overlay:
+
+  1. Apply the COMMON baseline ``to_home/`` first.
+  2. Apply the per-agent ``<spec_dir>/to_home/`` ON TOP.
+
+Per-agent files therefore win on conflict (overlay semantics) — they
+re-run the same per-entry deploy helpers over whatever the baseline
+laid down (full overwrite, marker-protected re-wrap, symlink replace).
+
+Baseline location (see :func:`resolve_baseline_to_home_dir`):
+
+  - ``$SAC_TO_HOME_BASELINE`` — explicit override (absolute dir), or
+  - ``<agents_dir>/_base/to_home/`` — a sibling ``_base`` dir under the
+    agents root (agents live at ``<agents_dir>/<name>/``, so the agents
+    root is the spec dir's parent).
+
+Absent baseline dir → behaves exactly as before (no baseline = current
+behavior; fully backward compatible).
 """
 
 from __future__ import annotations
@@ -70,6 +93,15 @@ _MARKER_PROTECTED_BASENAMES = frozenset({"CLAUDE.md", "state.md"})
 # rest preserve source perms via ``shutil.copy2``.
 _TIGHT_PERM_BASENAMES = frozenset({".env"})
 
+# Env var: explicit override for the shared/common baseline to_home dir.
+# Absolute path. When unset we fall back to ``<agents_dir>/_base/to_home``.
+_BASELINE_ENV_VAR = "SAC_TO_HOME_BASELINE"
+
+# Name of the sibling dir (under the agents root) that holds the common
+# baseline. Agents live at ``<agents_dir>/<name>/``, so the agents root
+# is the spec dir's parent and the baseline is ``<parent>/_base/to_home``.
+_BASELINE_DIR_NAME = "_base"
+
 
 # --- public API ------------------------------------------------------------
 
@@ -100,36 +132,72 @@ def resolve_to_home_dir(config: AgentConfig) -> Path | None:
     return p if p.is_dir() else None
 
 
+def resolve_baseline_to_home_dir(spec_dir: Path | None) -> Path | None:
+    """Resolve the shared/common baseline ``to_home/`` directory.
+
+    Resolution order:
+      1. ``$SAC_TO_HOME_BASELINE`` (absolute dir) — explicit override.
+      2. ``<agents_dir>/_base/to_home`` — a sibling ``_base`` dir under
+         the agents root. Agents live at ``<agents_dir>/<name>/``, so the
+         agents root is ``spec_dir.parent``.
+
+    Returns ``None`` when no baseline dir can be resolved (no baseline =
+    current behavior; fully backward compatible).
+    """
+    override = (os.environ.get(_BASELINE_ENV_VAR, "") or "").strip()
+    if override:
+        p = Path(override).expanduser()
+        return p if p.is_dir() else None
+    if spec_dir is None:
+        return None
+    p = spec_dir.parent / _BASELINE_DIR_NAME / "to_home"
+    return p if p.is_dir() else None
+
+
 def materialize_to_home(spec_dir: Path, workspace_home: Path) -> None:
     """Mirror ``<spec_dir>/to_home/`` into ``<workspace_home>/``.
 
-    Walks the tree and applies the per-entry semantics described in the
-    module docstring. Idempotent — safe to call on every agent start.
+    Two-pass overlay: the shared/common baseline ``to_home/`` is applied
+    first, then ``<spec_dir>/to_home/`` is applied on top — so per-agent
+    files win on conflict. Walks each tree and applies the per-entry
+    semantics described in the module docstring. Idempotent — safe to
+    call on every agent start.
 
-    No-op when ``<spec_dir>/to_home/`` does not exist.
+    No-op when neither the baseline nor ``<spec_dir>/to_home/`` exists.
     """
+    baseline = resolve_baseline_to_home_dir(spec_dir)
     root = spec_dir / "to_home"
-    if not root.is_dir():
+    if baseline is None and not root.is_dir():
         return
     workspace_home.mkdir(parents=True, exist_ok=True)
-    _walk_and_apply(root, root, workspace_home, config=None)
+    if baseline is not None:
+        _walk_and_apply(baseline, baseline, workspace_home, config=None)
+    if root.is_dir():
+        _walk_and_apply(root, root, workspace_home, config=None)
 
 
 def deploy_to_home(config: AgentConfig, workspace_home: str) -> None:
     """``AgentConfig``-driven entrypoint, parallel to
     :func:`_dot_claude.deploy_dot_claude`.
 
-    Resolves the to_home/ directory via :func:`resolve_to_home_dir`
-    (honours ``spec.to_home`` overrides) and applies metadata-aware
-    interpolation (${metadata.name}, ${metadata.labels.*}, ${ENV_VAR})
-    to text files. No-op when the directory cannot be resolved.
+    Two-pass overlay: the shared/common baseline ``to_home/`` is applied
+    first, then the per-agent ``to_home/`` is applied on top — so
+    per-agent files win on conflict. Resolves the per-agent directory via
+    :func:`resolve_to_home_dir` (honours ``spec.to_home`` overrides) and
+    the baseline via :func:`resolve_baseline_to_home_dir`, then applies
+    metadata-aware interpolation (${metadata.name}, ${metadata.labels.*},
+    ${ENV_VAR}) to text files. No-op when neither directory resolves.
     """
     root = resolve_to_home_dir(config)
-    if root is None:
+    baseline = resolve_baseline_to_home_dir(_spec_dir(config))
+    if root is None and baseline is None:
         return
     dest = Path(workspace_home)
     dest.mkdir(parents=True, exist_ok=True)
-    _walk_and_apply(root, root, dest, config=config)
+    if baseline is not None:
+        _walk_and_apply(baseline, baseline, dest, config=config)
+    if root is not None:
+        _walk_and_apply(root, root, dest, config=config)
 
 
 # --- traversal -------------------------------------------------------------
@@ -341,5 +409,6 @@ __all__ = [
     "WorkspaceCLAUDEMarkerError",
     "deploy_to_home",
     "materialize_to_home",
+    "resolve_baseline_to_home_dir",
     "resolve_to_home_dir",
 ]

--- a/src/scitex_agent_container/runtimes/claude_session.py
+++ b/src/scitex_agent_container/runtimes/claude_session.py
@@ -26,7 +26,11 @@ from pathlib import Path
 
 from ..config import AgentConfig
 from ._dot_claude import cleanup_dot_claude, deploy_dot_claude
-from ._to_home import deploy_to_home, resolve_to_home_dir
+from ._to_home import (
+    deploy_to_home,
+    resolve_baseline_to_home_dir,
+    resolve_to_home_dir,
+)
 from .base import RuntimeBase
 from .claude_md import cleanup_claude_md, setup_claude_md
 
@@ -49,13 +53,16 @@ def _materialize_home_layouts(config: AgentConfig, home_dir: str) -> None:
     silent-merge data-loss pattern.
 
     Order:
-      1. If a ``to_home/`` dir is present: deploy it.
+      1. If a ``to_home/`` dir (per-agent or shared baseline) is present:
+         deploy it. ``deploy_to_home`` overlays the per-agent ``to_home/``
+         on top of the common baseline, so per-agent files win.
       2. If a ``dot_claude/`` dir is present and ``to_home/`` is NOT:
          deploy dot_claude (legacy path) and emit a DeprecationWarning.
       3. If both are present: raise — operator must pick one.
     """
     spec_dir = _spec_dir_for(config)
     to_home_dir = resolve_to_home_dir(config)
+    baseline_dir = resolve_baseline_to_home_dir(spec_dir)
     legacy_dir = None
     if spec_dir is not None and (spec_dir / "dot_claude").is_dir():
         legacy_dir = spec_dir / "dot_claude"
@@ -69,7 +76,10 @@ def _materialize_home_layouts(config: AgentConfig, home_dir: str) -> None:
             "see ADR-0006 for the migration guide."
         )
 
-    if to_home_dir is not None:
+    # The baseline alone is enough to take the to_home path, but only when
+    # the spec is NOT a legacy dot_claude spec — otherwise a global baseline
+    # would silently shadow the legacy deploy.
+    if to_home_dir is not None or (baseline_dir is not None and legacy_dir is None):
         deploy_to_home(config, home_dir)
         return
 

--- a/tests/scitex_agent_container/runtimes/test__to_home.py
+++ b/tests/scitex_agent_container/runtimes/test__to_home.py
@@ -27,6 +27,7 @@ from scitex_agent_container.runtimes._to_home import (
     WorkspaceCLAUDEMarkerError,
     deploy_to_home,
     materialize_to_home,
+    resolve_baseline_to_home_dir,
     resolve_to_home_dir,
 )
 
@@ -432,3 +433,224 @@ class TestDeployToHomeFromConfig:
         deploy_to_home(cfg, str(home))
         # Assert
         assert (home / "blob.bin").read_bytes() == payload
+
+
+# ---------------------------------------------------------------------------
+# Baseline layer — shared/common to_home overlaid by per-agent to_home.
+#
+# Layout under tmp_path:
+#   agents/<name>/spec.yaml   ← spec dir
+#   agents/<name>/to_home/    ← per-agent layer (overlay, wins on conflict)
+#   agents/_base/to_home/     ← shared baseline (applied first)
+# ---------------------------------------------------------------------------
+
+
+def _build_layered(tmp_path: Path) -> tuple[Path, Path, Path]:
+    """Build the agents-root layout used by baseline tests.
+
+    Returns ``(spec_dir, per_agent_to_home, baseline_to_home)`` — all
+    real directories rooted at ``tmp_path/agents``.
+    """
+    agents_root = tmp_path / "agents"
+    spec_dir = agents_root / "test-agent"
+    per_agent = spec_dir / "to_home"
+    baseline = agents_root / "_base" / "to_home"
+    per_agent.mkdir(parents=True, exist_ok=True)
+    baseline.mkdir(parents=True, exist_ok=True)
+    return spec_dir, per_agent, baseline
+
+
+class TestResolveBaselineToHomeDir:
+    def test_resolves_sibling_base_dir_under_agents_root(self, tmp_path):
+        # Arrange
+        spec_dir, _, baseline = _build_layered(tmp_path)
+        # Act
+        resolved = resolve_baseline_to_home_dir(spec_dir)
+        # Assert
+        assert resolved == baseline
+
+    def test_returns_none_when_no_base_dir_present(self, tmp_path):
+        # Arrange — spec dir without a sibling _base/to_home.
+        spec_dir = tmp_path / "agents" / "lonely-agent"
+        spec_dir.mkdir(parents=True)
+        # Act
+        resolved = resolve_baseline_to_home_dir(spec_dir)
+        # Assert
+        assert resolved is None
+
+    def test_returns_none_when_spec_dir_is_none(self):
+        # Arrange — no spec dir, no env override.
+        # Act
+        resolved = resolve_baseline_to_home_dir(None)
+        # Assert
+        assert resolved is None
+
+    def test_env_override_takes_precedence(self, tmp_path, env_save_restore):
+        # Arrange — an explicit baseline elsewhere wins over the sibling.
+        spec_dir, _, sibling = _build_layered(tmp_path)
+        custom = tmp_path / "custom_baseline" / "to_home"
+        custom.mkdir(parents=True)
+        env_save_restore.set("SAC_TO_HOME_BASELINE", str(custom))
+        # Act
+        resolved = resolve_baseline_to_home_dir(spec_dir)
+        # Assert
+        assert resolved == custom
+
+    def test_env_override_pointing_at_missing_dir_returns_none(
+        self, tmp_path, env_save_restore
+    ):
+        # Arrange — override path that does not exist.
+        spec_dir, _, _ = _build_layered(tmp_path)
+        env_save_restore.set("SAC_TO_HOME_BASELINE", str(tmp_path / "does_not_exist"))
+        # Act
+        resolved = resolve_baseline_to_home_dir(spec_dir)
+        # Assert
+        assert resolved is None
+
+
+class TestMaterializeBaselineOverlay:
+    def test_baseline_only_file_lands_in_home(self, tmp_path):
+        # Arrange — baseline provides a shared file the agent does not.
+        spec_dir, _, baseline = _build_layered(tmp_path)
+        (baseline / ".bashrc").write_text("export BASE=1\n")
+        home = tmp_path / "home"
+        # Act
+        materialize_to_home(spec_dir, home)
+        # Assert
+        assert (home / ".bashrc").read_text() == "export BASE=1\n"
+
+    def test_per_agent_file_overrides_baseline_file_of_same_name(self, tmp_path):
+        # Arrange — same relative path in both layers; per-agent must win.
+        spec_dir, per_agent, baseline = _build_layered(tmp_path)
+        (baseline / "shared.txt").write_text("from baseline\n")
+        (per_agent / "shared.txt").write_text("from agent\n")
+        home = tmp_path / "home"
+        # Act
+        materialize_to_home(spec_dir, home)
+        # Assert
+        assert (home / "shared.txt").read_text() == "from agent\n"
+
+    def test_distinct_baseline_file_lands_alongside_per_agent(self, tmp_path):
+        # Arrange — distinct files in each layer.
+        spec_dir, per_agent, baseline = _build_layered(tmp_path)
+        (baseline / "base_only.txt").write_text("base\n")
+        (per_agent / "agent_only.txt").write_text("agent\n")
+        home = tmp_path / "home"
+        # Act
+        materialize_to_home(spec_dir, home)
+        # Assert
+        assert (home / "base_only.txt").read_text() == "base\n"
+
+    def test_distinct_per_agent_file_lands_alongside_baseline(self, tmp_path):
+        # Arrange — distinct files in each layer.
+        spec_dir, per_agent, baseline = _build_layered(tmp_path)
+        (baseline / "base_only.txt").write_text("base\n")
+        (per_agent / "agent_only.txt").write_text("agent\n")
+        home = tmp_path / "home"
+        # Act
+        materialize_to_home(spec_dir, home)
+        # Assert
+        assert (home / "agent_only.txt").read_text() == "agent\n"
+
+    def test_absent_baseline_is_unchanged_current_behavior(self, tmp_path):
+        # Arrange — no _base/ sibling at all; only a per-agent to_home.
+        # (Matches the historical single-layer layout.)
+        spec_dir = tmp_path / "spec"
+        (spec_dir / "to_home").mkdir(parents=True)
+        (spec_dir / "to_home" / ".bashrc").write_text("export FOO=1\n")
+        home = tmp_path / "home"
+        # Act
+        materialize_to_home(spec_dir, home)
+        # Assert — identical to the legacy single-layer test.
+        assert (home / ".bashrc").read_text() == "export FOO=1\n"
+
+    def test_baseline_only_with_no_per_agent_to_home(self, tmp_path):
+        # Arrange — baseline exists but the agent has NO to_home/ of its own.
+        agents_root = tmp_path / "agents"
+        spec_dir = agents_root / "test-agent"
+        spec_dir.mkdir(parents=True)
+        baseline = agents_root / "_base" / "to_home"
+        baseline.mkdir(parents=True)
+        (baseline / "common.txt").write_text("shared\n")
+        home = tmp_path / "home"
+        # Act
+        materialize_to_home(spec_dir, home)
+        # Assert
+        assert (home / "common.txt").read_text() == "shared\n"
+
+
+class TestDeployBaselineFromConfig:
+    def test_baseline_lands_via_config_entrypoint(self, tmp_path):
+        # Arrange — config_path under an agents root with a _base sibling.
+        agents_root = tmp_path / "agents"
+        spec_dir = agents_root / "test-agent"
+        (spec_dir / "to_home").mkdir(parents=True)
+        baseline = agents_root / "_base" / "to_home"
+        baseline.mkdir(parents=True)
+        (baseline / ".bashrc").write_text("export BASE=1\n")
+        cfg = AgentConfig(name="test-agent")
+        cfg.config_path = str(spec_dir / "spec.yaml")
+        cfg.to_home = ""
+        home = tmp_path / "home"
+        # Act
+        deploy_to_home(cfg, str(home))
+        # Assert
+        assert (home / ".bashrc").read_text() == "export BASE=1\n"
+
+    def test_per_agent_overrides_baseline_via_config_entrypoint(self, tmp_path):
+        # Arrange
+        agents_root = tmp_path / "agents"
+        spec_dir = agents_root / "test-agent"
+        per_agent = spec_dir / "to_home"
+        per_agent.mkdir(parents=True)
+        baseline = agents_root / "_base" / "to_home"
+        baseline.mkdir(parents=True)
+        (baseline / "shared.txt").write_text("from baseline\n")
+        (per_agent / "shared.txt").write_text("from agent\n")
+        cfg = AgentConfig(name="test-agent")
+        cfg.config_path = str(spec_dir / "spec.yaml")
+        cfg.to_home = ""
+        home = tmp_path / "home"
+        # Act
+        deploy_to_home(cfg, str(home))
+        # Assert
+        assert (home / "shared.txt").read_text() == "from agent\n"
+
+
+@pytest.fixture
+def overlaid_claude_md(tmp_path: Path) -> Path:
+    """Materialize a marker-protected CLAUDE.md from BOTH layers and return
+    the destination. Per-agent must win the overlay. One-shot setup feeds
+    several single-assert tests.
+    """
+    spec_dir, per_agent, baseline = _build_layered(tmp_path)
+    (baseline / ".claude").mkdir()
+    (baseline / ".claude" / "CLAUDE.md").write_text("## Base doctrine\n")
+    (per_agent / ".claude").mkdir()
+    (per_agent / ".claude" / "CLAUDE.md").write_text("## Agent doctrine\n")
+    home = tmp_path / "home"
+    materialize_to_home(spec_dir, home)
+    return home / ".claude" / "CLAUDE.md"
+
+
+class TestMarkerProtectedOverlay:
+    def test_per_agent_body_wins(self, overlaid_claude_md):
+        # Arrange
+        content = overlaid_claude_md.read_text()
+        # Act
+        # Assert
+        assert "Agent doctrine" in content
+
+    def test_baseline_body_is_overwritten(self, overlaid_claude_md):
+        # Arrange
+        content = overlaid_claude_md.read_text()
+        # Act
+        # Assert
+        assert "Base doctrine" not in content
+
+    def test_result_has_single_marker_section(self, overlaid_claude_md):
+        # Arrange
+        content = overlaid_claude_md.read_text()
+        # Act
+        # Assert
+        assert content.count(END_MARKER) == 1


### PR DESCRIPTION
## What

Adds a shared/common **baseline** `to_home/` layer so common hooks/settings can live in ONE place instead of being copied into every agent's `to_home/`. This is the **mechanism only** — no hooks are populated.

## How

Materialization becomes a two-pass overlay in `runtimes/_to_home.py`:
1. Apply the common baseline `to_home/` first.
2. Apply the per-agent `<spec_dir>/to_home/` on top — **per-agent files win** on conflict.

Both passes reuse the existing per-entry deploy helpers unchanged, so all current semantics are preserved:
- marker-protected merge for `CLAUDE.md` / `state.md` (per-agent re-wraps a single section)
- `.env` chmod 0600
- symlink preservation (target string verbatim)
- plain-file full overwrite

### Baseline location (`resolve_baseline_to_home_dir`)
1. `$SAC_TO_HOME_BASELINE` — explicit absolute-dir override, else
2. `<agents_dir>/_base/to_home/` — a sibling `_base` dir under the agents root (agents live at `<agents_dir>/<name>/`, so the root is the spec dir's parent).

**Absent baseline => behaves exactly as today (fully backward compatible).**

### Call site
`claude_session.py::_materialize_home_layouts` now lets the baseline alone trigger the `to_home` path, but only when the spec is **not** a legacy `dot_claude` spec — so a global baseline never silently shadows a legacy deploy. The both-present (`to_home` + `dot_claude`) guard is unchanged.

## Tests

Real-dir `tmp_path` coverage (no mocks), per PS-204/205 (`test__to_home.py`):
- baseline-only file lands in `$HOME`
- per-agent file overrides same-named baseline file (overlay)
- distinct files from both layers both land
- absent baseline = unchanged single-layer behavior
- baseline-only with no per-agent `to_home/`
- marker-protected `CLAUDE.md` overlay: per-agent body wins, single marker section
- `SAC_TO_HOME_BASELINE` env override precedence + missing-dir => None
- config-entrypoint (`deploy_to_home`) baseline + override paths

Full `tests/.../runtimes/` suite: **587 passed** (44 in `test__to_home.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)