### PR TITLE
fix(a2a): channel sidecar subscribes to bus, not a2a_port (delivered_subscriber_count=0)

### DIFF
--- a/src/scitex_agent_container/a2a/_handlers.py
+++ b/src/scitex_agent_container/a2a/_handlers.py
@@ -158,10 +158,11 @@ def handle_claude_session(
     # pass None and the agent uses its own configured persona.
     system = _sac_env("A2A_CLAUDE_SYSTEM", "").strip() or None
     model = _sac_env("A2A_CLAUDE_MODEL")
-    # Forward `spec.claude.channels` + the agent's own A2A port so the
-    # sac MCP sidecar (auto-injected when `server:sac` is in channels)
-    # subscribes to THIS agent's inbox SSE at
-    # ``http://127.0.0.1:<a2a_port>/agents/<name>/inbox/stream``.
+    # Forward `spec.claude.channels` + the agent's own A2A port. The sac
+    # MCP sidecar (auto-injected when `server:sac` is in channels)
+    # subscribes to the inbox SSE on the BUS (`sac listen`, resolved from
+    # SAC_LISTEN_BASE_URL), not the a2a_port. a2a_port is forwarded only so
+    # build_sdk_options has it for the /v1/turn registration path.
     sdk_extra: dict | None = None
     if channels or a2a_port is not None:
         sdk_extra = {}

--- a/src/scitex_agent_container/runtimes/_sdk_common.py
+++ b/src/scitex_agent_container/runtimes/_sdk_common.py
@@ -378,11 +378,14 @@ def build_sdk_options(
     # ClaudeAgentOptions is strict and rejects unknown fields. The
     # ``_*`` prefix marks these as sac-internal (not SDK fields).
     channels: list[str] | None = None
-    a2a_port: int | None = None
     if extra:
         extra = dict(extra)  # shallow copy so we can mutate
         channels = extra.pop("_channels", None)
-        a2a_port = extra.pop("_a2a_port", None)
+        # ``_a2a_port`` is threaded for the /v1/turn registration path; the
+        # channel sidecar below does NOT use it (the inbox SSE lives on the
+        # bus, resolved from SAC_LISTEN_BASE_URL). Pop it only to strip the
+        # sac-private key before merging ``extra`` into ClaudeAgentOptions.
+        extra.pop("_a2a_port", None)
         if extra:
             kwargs.update(extra)
 
@@ -408,28 +411,23 @@ def build_sdk_options(
             extra_args.setdefault("dangerously-load-development-channels", "server:sac")
         mcps = kwargs.setdefault("mcp_servers", {})
         if isinstance(mcps, dict) and "sac" not in mcps:
-            # No silent fallback. The sidecar's --listen-url MUST point
-            # at the actual server hosting /agents/<name>/inbox/stream.
-            # If a2a_port wasn't threaded through, the caller forgot to
-            # pass listen_port to build_app — surface that explicitly
-            # rather than letting the sidecar quietly fall back to env
-            # / 127.0.0.1:7878 and produce "Command failed with no
-            # output" tool errors at runtime.
-            if a2a_port is None:
-                raise SDKCommonError(
-                    "spec.claude.channels=[server:sac] is set but no "
-                    "a2a_port was threaded through to build_sdk_options. "
-                    "The MCP sidecar needs the server's actual listen "
-                    "port for its --listen-url. Pass listen_port to "
-                    "build_app(), or set spec.a2a.port in the yaml."
-                )
+            # The sidecar subscribes to /agents/<name>/inbox/stream, which
+            # is served by the BUS (`sac listen`, default :7878), NOT the
+            # agent's own a2a sidecar port. Omit --listen-url here and let
+            # the adapter's main() resolve the bus from SAC_LISTEN_BASE_URL
+            # (its existing default, injected into the container) — the
+            # same source the CLI default and the adapter both use. Passing
+            # the a2a_port here pointed the SSE GET at a server that 404s on
+            # the inbox route, so the bus saw zero subscribers and
+            # delivered_subscriber_count was always 0.
+            #
+            # a2a_port stays threaded for the /v1/turn registration path; it
+            # is simply irrelevant to inbox subscription.
             sidecar_args = [
                 "mcp",
                 "channel",
                 "--name",
                 agent_name,
-                "--listen-url",
-                f"http://127.0.0.1:{int(a2a_port)}",
             ]
             mcps["sac"] = {
                 "type": "stdio",

--- a/tests/scitex_agent_container/runtimes/test__sdk_common.py
+++ b/tests/scitex_agent_container/runtimes/test__sdk_common.py
@@ -500,3 +500,89 @@ class TestBuildOptions:
         # Assert
         with ctx:
             build_sdk_options("any")
+
+
+# ---------------------------------------------------------------------------
+# build_sdk_options — server:sac channel sidecar registration
+# ---------------------------------------------------------------------------
+
+
+class TestChannelSidecar:
+    """``channels=[server:sac]`` registers the ``sac mcp channel`` adapter.
+
+    Regression guard: the adapter subscribes to ``/agents/<name>/inbox/
+    stream`` which is served by the BUS (``sac listen``, resolved from
+    ``SAC_LISTEN_BASE_URL``), NOT the agent's own a2a sidecar port. An
+    earlier version hardcoded ``--listen-url http://127.0.0.1:{a2a_port}``,
+    pointing the SSE GET at a server that 404s on the inbox route, so the
+    bus saw zero subscribers and ``delivered_subscriber_count`` was always
+    0. These tests pin: the ``sac`` stdio MCP is registered, and its args
+    never carry an a2a_port-derived ``--listen-url``.
+    """
+
+    @pytest.fixture
+    def _sac_channel_opts(self, sdk_env: _Env, tmp_path):
+        # Arrange: cred file present so auth needs no env mutation.
+        cred = tmp_path / ".credentials.json"
+        cred.write_text("{}")
+        sdk_env.setattr_module(_sdk_common, "_CRED_FILE", cred)
+        sdk_env.delenv("ANTHROPIC_API_KEY")
+        _swap_registry(sdk_env, None)
+        # Act: thread the same sac-private extra the runner sends, including
+        # an a2a_port that must NOT leak into the channel sidecar args.
+        opts = build_sdk_options(
+            "lead",
+            extra={"_channels": ["server:sac"], "_a2a_port": 9999},
+        )
+        return opts
+
+    def test_registers_sac_stdio_mcp(self, _sac_channel_opts):
+        # Arrange
+        servers = _sac_channel_opts.mcp_servers  # type: ignore[operator]
+        # Act
+        sac = servers.get("sac")
+        # Assert
+        assert sac is not None and sac["command"] == "sac"
+
+    def test_sidecar_args_subscribe_to_named_agent_inbox(self, _sac_channel_opts):
+        # Arrange
+        sac = _sac_channel_opts.mcp_servers["sac"]  # type: ignore[index]
+        # Act
+        args = sac["args"]
+        # Assert
+        assert args[:4] == ["mcp", "channel", "--name", "lead"]
+
+    def test_sidecar_args_omit_a2a_port_listen_url(self, _sac_channel_opts):
+        # Arrange
+        sac = _sac_channel_opts.mcp_servers["sac"]  # type: ignore[index]
+        # Act — the a2a_port (9999) must never appear in any sidecar arg.
+        args = sac["args"]
+        # Assert: bus URL resolution is delegated to the adapter's main()
+        # via SAC_LISTEN_BASE_URL; no hardcoded a2a-port listen-url here.
+        assert not any("9999" in str(a) for a in args)
+
+    def test_sidecar_listen_url_when_present_is_not_a2a_port(self, _sac_channel_opts):
+        # Arrange
+        sac = _sac_channel_opts.mcp_servers["sac"]  # type: ignore[index]
+        args = sac["args"]
+        # Act: if a --listen-url is emitted at all, it must be the bus, never
+        # the agent's own a2a sidecar port.
+        if "--listen-url" in args:
+            listen_url = args[args.index("--listen-url") + 1]
+        else:
+            listen_url = None
+        # Assert
+        assert listen_url is None or listen_url == os.environ.get("SAC_LISTEN_BASE_URL")
+
+    def test_no_error_when_a2a_port_absent(self, sdk_env: _Env, tmp_path):
+        # Arrange: cred file present; channels set but NO _a2a_port threaded.
+        cred = tmp_path / ".credentials.json"
+        cred.write_text("{}")
+        sdk_env.setattr_module(_sdk_common, "_CRED_FILE", cred)
+        sdk_env.delenv("ANTHROPIC_API_KEY")
+        _swap_registry(sdk_env, None)
+        # Act: a2a_port is irrelevant to inbox subscription, so its absence
+        # must NOT raise — the adapter resolves the bus from env at runtime.
+        opts = build_sdk_options("lead", extra={"_channels": ["server:sac"]})
+        # Assert
+        assert "sac" in opts.mcp_servers  # type: ignore[operator]


### PR DESCRIPTION
## Problem

Pushed A2A turns to agents returned \`delivered_subscriber_count: 0\` — the agent's session never saw the inbound \`<channel>\` tags.

## Root cause

\`runtimes/_sdk_common.py\` auto-registers the \`sac mcp channel\` adapter with \`--listen-url http://127.0.0.1:{a2a_port}\` (the agent's own a2a sidecar port). That sidecar server (\`_runners/_session_http.py\`) does **not** expose \`/agents/<name>/inbox/stream\` — the inbox SSE lives only on the **bus** (\`sac listen\`, \`_listen/server.py\`, port 7878 / \`SAC_LISTEN_BASE_URL\`). The adapter's SSE GET 404'd, it never subscribed, the bus reported 0 subscribers, and delivery reported \`delivered=0\`.

## Fix

- Omit \`--listen-url\` from the sidecar args so the adapter's \`main()\` resolves the bus from \`SAC_LISTEN_BASE_URL\` (its existing default — matching the CLI default in \`cli_pkg/mcp_group.py\` and the adapter in \`_mcp/channel.py\`).
- Drop the now-incorrect \`a2a_port is None\` hard-error block (a2a_port is irrelevant to inbox subscription).
- \`a2a_port\` stays threaded for the \`/v1/turn\` registration path; only its (mis)use for the channel \`--listen-url\` is removed.

## Tests

New \`TestChannelSidecar\` in \`tests/.../runtimes/test__sdk_common.py\` asserts:
- \`channels=[server:sac]\` registers the \`sac\` stdio MCP
- sidecar args are \`[mcp, channel, --name, <agent>]\` and contain no a2a_port-derived \`--listen-url\`
- any emitted \`--listen-url\` equals the bus (\`SAC_LISTEN_BASE_URL\`), never the a2a port
- no error when \`_a2a_port\` is absent

## Post-merge

The base agent image must be rebuilt (\`sac image build base\`) for the fix to reach agents.