### PR TITLE
fix(apptainer,to_home): inject bus bearer into all specs + overwrite read-only deploy targets

### DIFF
--- a/src/scitex_agent_container/runtimes/_apptainer_build.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_build.py
@@ -1,0 +1,197 @@
+"""SIF-build + overlay-image helpers for the apptainer runtime.
+
+Extracted from :mod:`_apptainer_runtime` (which orchestrates argv
+assembly + lifecycle). These are pure-ish build helpers with no
+dependency on :class:`ApptainerContainerRuntime`:
+
+* :func:`_safe_image_tag` — hash an image reference to a cache filename.
+* :func:`_create_overlay_image` — ``apptainer overlay create``.
+* :func:`_build_sif_from_uri` — ``apptainer build <sif> <uri>``.
+* :func:`_build_sif_from_def` — ``apptainer build <sif> <def>``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import subprocess
+from pathlib import Path
+
+from ..config import AgentConfig
+
+
+def resolve_sif(config: AgentConfig, cache_dir: Path) -> Path | None:
+    """Resolve the local SIF path for ``config`` against ``cache_dir``.
+
+    Pure resolution logic extracted from
+    :meth:`ApptainerContainerRuntime.resolve_sif` (the method owns the
+    apptainer-on-PATH guard + cache-dir creation, then delegates here).
+
+    Resolution order:
+      1. ``spec.apptainer.def_file`` — build from this .def.
+      2. ``spec.image`` is a local ``.sif`` path — use directly.
+      3. ``spec.image`` is a ``--sandbox`` dir — use directly.
+      4. ``spec.image`` starts with ``docker://`` / ``oras://`` — cache + build.
+      5. Bare image name — assume ``docker://``.
+
+    Returns ``None`` on any unrecoverable error (build failed,
+    unparseable image reference).
+    """
+    ap = getattr(config, "apptainer", None)
+    def_file_str = getattr(ap, "def_file", "") if ap is not None else ""
+    if def_file_str:
+        def_file = Path(def_file_str).expanduser().resolve()
+        if not def_file.is_file():
+            return None
+        sif_path = cache_dir / f"{_safe_image_tag(str(def_file))}.sif"
+        if sif_path.is_file():
+            return sif_path
+        return sif_path if _build_sif_from_def(sif_path, def_file) else None
+
+    # v3-realign: prefer spec.apptainer.image; fall back to legacy
+    # AgentConfig.image (kept populated for back-compat) and finally
+    # to the default sac-scitex SIF path.
+    ap_image = getattr(ap, "image", "") if ap is not None else ""
+    image = (ap_image or config.image or "").strip()
+    if not image:
+        return None
+
+    if image.endswith(".sif"):
+        sif_path = Path(image).expanduser().resolve()
+        return sif_path if sif_path.is_file() else None
+
+    # Sandbox image: a directory tree built via `apptainer build
+    # --sandbox`. Used on hosts where /dev/fuse isn't exposed to
+    # user namespaces (Spartan compute nodes etc.) — the rootfs
+    # is a regular directory tree, no squashfuse needed at exec.
+    # Detection: presence of the `.singularity.d/` marker dir.
+    candidate = Path(image).expanduser()
+    if candidate.is_dir() and (candidate / ".singularity.d").is_dir():
+        return candidate.resolve()
+
+    if image.startswith("docker://") or image.startswith("oras://"):
+        sif_path = cache_dir / f"{_safe_image_tag(image)}.sif"
+        if sif_path.is_file():
+            return sif_path
+        return sif_path if _build_sif_from_uri(sif_path, image) else None
+
+    # Bare image name without a scheme — assume docker://.
+    uri = f"docker://{image}"
+    sif_path = cache_dir / f"{_safe_image_tag(uri)}.sif"
+    if sif_path.is_file():
+        return sif_path
+    return sif_path if _build_sif_from_uri(sif_path, uri) else None
+
+
+def _safe_image_tag(reference: str) -> str:
+    """Hash an image reference / def-file path to a filename-safe tag.
+
+    apptainer build emits a single .sif per (image, build-time) tuple;
+    this hash gives us a deterministic filename so subsequent starts
+    skip the rebuild. The full reference is preserved in the .sif
+    metadata; the hash is just the cache key.
+    """
+    digest = hashlib.sha1(reference.encode("utf-8")).hexdigest()[:16]
+    return digest
+
+
+def _create_overlay_image(path: Path, size: str) -> None:
+    """Create an apptainer overlay image at ``path`` with the given size.
+
+    Size string accepts apptainer-style units with **M/MB/G/GB only**:
+    ``"5G"``, ``"500M"``, ``"1024MB"`` etc. K/KB are explicitly
+    rejected — ``apptainer overlay create --size`` takes integer MB so
+    sub-MB granularity is unrepresentable. Parent dir is created if
+    missing. Raises ``ValueError`` for unparseable / unsupported sizes
+    and ``RuntimeError`` if the apptainer call itself fails.
+    """
+    m = re.match(r"^\s*(\d+)\s*([MG]B?)\s*$", size, re.IGNORECASE)
+    if not m:
+        raise ValueError(
+            f"overlay_size {size!r} unparseable; use '5G', '500M', '1024MB' "
+            "etc. (units M/MB/G/GB only — K/KB rejected because apptainer "
+            "overlay create takes integer MB)."
+        )
+    n = int(m.group(1))
+    unit = m.group(2).upper()
+    # apptainer overlay create --size expects integer MB.
+    multipliers = {"M": 1, "MB": 1, "G": 1024, "GB": 1024}
+    if unit not in multipliers:
+        # Defensive: regex already constrains to M/MB/G/GB, but if
+        # someone ever broadens it without updating multipliers we
+        # want a clear error, not a KeyError.
+        raise ValueError(f"overlay_size unit {unit!r} unsupported")
+    mb = int(n * multipliers[unit])
+    if mb < 1:
+        raise ValueError(f"overlay_size {size!r} resolves to <1MB")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    result = subprocess.run(
+        ["apptainer", "overlay", "create", "--size", str(mb), str(path)],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"apptainer overlay create failed (rc={result.returncode}): "
+            f"{result.stderr.strip()}"
+        )
+
+
+def _build_sif_from_uri(sif_path: Path, uri: str) -> bool:
+    """``apptainer build <sif> <uri>`` — pulls + converts an OCI image."""
+    sif_path.parent.mkdir(parents=True, exist_ok=True)
+    result = subprocess.run(["apptainer", "build", str(sif_path), uri])
+    return result.returncode == 0
+
+
+def _build_sif_from_def(sif_path: Path, def_file: Path) -> bool:
+    """``apptainer build <sif> <def_file>`` — builds from a .def script.
+
+    No docker daemon required even if the .def starts with
+    ``Bootstrap: docker`` — apptainer's docker compatibility runs
+    entirely over OCI registry pulls.
+    """
+    sif_path.parent.mkdir(parents=True, exist_ok=True)
+    result = subprocess.run(["apptainer", "build", str(sif_path), str(def_file)])
+    return result.returncode == 0
+
+
+# ---------------------------------------------------------------------------
+# Bus-auth bearer resolution (FIX 1)
+# ---------------------------------------------------------------------------
+
+
+def _listen_token_path() -> Path:
+    """Canonical ``sac listen`` bearer token file for this host.
+
+    Mirrors the resolver the listen server itself uses
+    (:func:`_listen.tokens.default_token_path`,
+    ``~/.scitex/agent-container/tokens/listen-<host>.token``) so the
+    bearer we inject matches the one the bus validates against.
+    """
+    from .._listen.tokens import default_token_path
+
+    return default_token_path()
+
+
+def _read_listen_bearer() -> str | None:
+    """Read the host bus bearer from the token file, or ``None``.
+
+    Never raises — a missing/unreadable token file yields ``None`` so
+    the caller can warn loudly (no silent fallback) and inject only the
+    base URL.
+    """
+    from .._listen.tokens import read_token
+
+    return read_token(_listen_token_path())
+
+
+__all__ = [
+    "resolve_sif",
+    "_listen_token_path",
+    "_read_listen_bearer",
+    "_safe_image_tag",
+    "_create_overlay_image",
+    "_build_sif_from_uri",
+    "_build_sif_from_def",
+]

--- a/src/scitex_agent_container/runtimes/_apptainer_runtime.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_runtime.py
@@ -30,7 +30,7 @@ no-passwd-entry trap with non-1000 UIDs.
 
 from __future__ import annotations
 
-import hashlib
+import logging
 import os
 import shutil
 import signal
@@ -38,7 +38,22 @@ import subprocess
 from pathlib import Path
 
 from ..config import AgentConfig
+
+# Re-exported for back-compat — extracted to _apptainer_build, still
+# imported here so existing `mod._build_sif_* / mod._safe_image_tag`
+# references keep resolving.
+from ._apptainer_build import (  # noqa: F401
+    _build_sif_from_def,
+    _build_sif_from_uri,
+    _create_overlay_image,
+    _listen_token_path,
+    _read_listen_bearer,
+    _safe_image_tag,
+)
+from ._apptainer_build import resolve_sif as _resolve_sif
 from .base import RuntimeBase
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_SIF_NAME = "scitex-agent-container.sif"
 RUNNER_MODULE = "scitex_agent_container._runners.claude_session"
@@ -249,6 +264,33 @@ class ApptainerContainerRuntime(RuntimeBase):
 
         argv += ["--env", f"SAC_LISTEN_BASE_URL={_listen_base_url()}"]
 
+        # Bus auth — the in-container channel adapter (sac MCP) must present
+        # a bearer to reach `sac listen` (it returns 401 without one), or the
+        # inbox subscription never lands and pushed turns report
+        # delivered_subscriber_count=0. Inject the host-generated bearer read
+        # from the token file the listen server itself writes
+        # (~/.scitex/agent-container/tokens/listen-<host>.token via
+        # default_token_path()). This injection is UNCONDITIONAL w.r.t. the
+        # relaxed escape-hatch below — relaxed specs bypass the preflight
+        # wrapper but still need bus auth. The token is read at start time;
+        # it is never written into spec.yaml.
+        #
+        # Missing token file → inject only BASE_URL and log a loud warning
+        # (push will not work). No silent fallback: the adapter surfaces the
+        # resulting auth failure rather than silently degrading.
+        bearer = _read_listen_bearer()
+        if bearer:
+            argv += ["--env", f"SAC_LISTEN_BEARER={bearer}"]
+        else:
+            logger.warning(
+                "SAC_LISTEN_BEARER not injected: bus token file %s is absent. "
+                "The in-container channel adapter cannot authenticate to "
+                "`sac listen` (401), so inbox subscription and pushed turns "
+                "will fail. Start `sac listen` to generate the token, then "
+                "restart this agent.",
+                _listen_token_path(),
+            )
+
         # v3-realign: spec.apptainer.raw_args (§1 escape-hatch invariant) —
         # appended verbatim after all curated args, before the SIF +
         # inner command. Lets operators bolt on flags sac doesn't model
@@ -321,57 +363,15 @@ class ApptainerContainerRuntime(RuntimeBase):
         Returns ``None`` on any unrecoverable error (build failed,
         unparseable image reference) so the caller can short-circuit
         ``start`` with a clear message.
+
+        Thin delegate over :func:`_apptainer_build.resolve_sif` — this
+        method only supplies the per-agent image cache dir.
         """
         if shutil.which("apptainer") is None:
             return None
-
         cache_dir = self._image_cache_dir(config)
         cache_dir.mkdir(parents=True, exist_ok=True)
-
-        ap = getattr(config, "apptainer", None)
-        def_file_str = getattr(ap, "def_file", "") if ap is not None else ""
-        if def_file_str:
-            def_file = Path(def_file_str).expanduser().resolve()
-            if not def_file.is_file():
-                return None
-            sif_path = cache_dir / f"{_safe_image_tag(str(def_file))}.sif"
-            if sif_path.is_file():
-                return sif_path
-            return sif_path if _build_sif_from_def(sif_path, def_file) else None
-
-        # v3-realign: prefer spec.apptainer.image; fall back to legacy
-        # AgentConfig.image (kept populated for back-compat) and finally
-        # to the default sac-scitex SIF path.
-        ap_image = getattr(ap, "image", "") if ap is not None else ""
-        image = (ap_image or config.image or "").strip()
-        if not image:
-            return None
-
-        if image.endswith(".sif"):
-            sif_path = Path(image).expanduser().resolve()
-            return sif_path if sif_path.is_file() else None
-
-        # Sandbox image: a directory tree built via `apptainer build
-        # --sandbox`. Used on hosts where /dev/fuse isn't exposed to
-        # user namespaces (Spartan compute nodes etc.) — the rootfs
-        # is a regular directory tree, no squashfuse needed at exec.
-        # Detection: presence of the `.singularity.d/` marker dir.
-        candidate = Path(image).expanduser()
-        if candidate.is_dir() and (candidate / ".singularity.d").is_dir():
-            return candidate.resolve()
-
-        if image.startswith("docker://") or image.startswith("oras://"):
-            sif_path = cache_dir / f"{_safe_image_tag(image)}.sif"
-            if sif_path.is_file():
-                return sif_path
-            return sif_path if _build_sif_from_uri(sif_path, image) else None
-
-        # Bare image name without a scheme — assume docker://.
-        uri = f"docker://{image}"
-        sif_path = cache_dir / f"{_safe_image_tag(uri)}.sif"
-        if sif_path.is_file():
-            return sif_path
-        return sif_path if _build_sif_from_uri(sif_path, uri) else None
+        return _resolve_sif(config, cache_dir)
 
     # ------------------------------------------------------------------
     # lifecycle
@@ -486,86 +486,6 @@ class ApptainerContainerRuntime(RuntimeBase):
         """Per-host SIF cache. Lives under the per-agent state dir so
         cleanup follows the agent's lifecycle."""
         return self._state_dir(config) / "images"
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _safe_image_tag(reference: str) -> str:
-    """Hash an image reference / def-file path to a filename-safe tag.
-
-    apptainer build emits a single .sif per (image, build-time) tuple;
-    this hash gives us a deterministic filename so subsequent starts
-    skip the rebuild. The full reference is preserved in the .sif
-    metadata; the hash is just the cache key.
-    """
-    digest = hashlib.sha1(reference.encode("utf-8")).hexdigest()[:16]
-    return digest
-
-
-def _create_overlay_image(path: Path, size: str) -> None:
-    """Create an apptainer overlay image at ``path`` with the given size.
-
-    Size string accepts apptainer-style units with **M/MB/G/GB only**:
-    ``"5G"``, ``"500M"``, ``"1024MB"`` etc. K/KB are explicitly
-    rejected — ``apptainer overlay create --size`` takes integer MB so
-    sub-MB granularity is unrepresentable. Parent dir is created if
-    missing. Raises ``ValueError`` for unparseable / unsupported sizes
-    and ``RuntimeError`` if the apptainer call itself fails.
-    """
-    import re
-
-    m = re.match(r"^\s*(\d+)\s*([MG]B?)\s*$", size, re.IGNORECASE)
-    if not m:
-        raise ValueError(
-            f"overlay_size {size!r} unparseable; use '5G', '500M', '1024MB' "
-            "etc. (units M/MB/G/GB only — K/KB rejected because apptainer "
-            "overlay create takes integer MB)."
-        )
-    n = int(m.group(1))
-    unit = m.group(2).upper()
-    # apptainer overlay create --size expects integer MB.
-    multipliers = {"M": 1, "MB": 1, "G": 1024, "GB": 1024}
-    if unit not in multipliers:
-        # Defensive: regex already constrains to M/MB/G/GB, but if
-        # someone ever broadens it without updating multipliers we
-        # want a clear error, not a KeyError.
-        raise ValueError(f"overlay_size unit {unit!r} unsupported")
-    mb = int(n * multipliers[unit])
-    if mb < 1:
-        raise ValueError(f"overlay_size {size!r} resolves to <1MB")
-    path.parent.mkdir(parents=True, exist_ok=True)
-    result = subprocess.run(
-        ["apptainer", "overlay", "create", "--size", str(mb), str(path)],
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode != 0:
-        raise RuntimeError(
-            f"apptainer overlay create failed (rc={result.returncode}): "
-            f"{result.stderr.strip()}"
-        )
-
-
-def _build_sif_from_uri(sif_path: Path, uri: str) -> bool:
-    """``apptainer build <sif> <uri>`` — pulls + converts an OCI image."""
-    sif_path.parent.mkdir(parents=True, exist_ok=True)
-    result = subprocess.run(["apptainer", "build", str(sif_path), uri])
-    return result.returncode == 0
-
-
-def _build_sif_from_def(sif_path: Path, def_file: Path) -> bool:
-    """``apptainer build <sif> <def_file>`` — builds from a .def script.
-
-    No docker daemon required even if the .def starts with
-    ``Bootstrap: docker`` — apptainer's docker compatibility runs
-    entirely over OCI registry pulls.
-    """
-    sif_path.parent.mkdir(parents=True, exist_ok=True)
-    result = subprocess.run(["apptainer", "build", str(sif_path), str(def_file)])
-    return result.returncode == 0
 
 
 __all__ = [

--- a/src/scitex_agent_container/runtimes/_to_home.py
+++ b/src/scitex_agent_container/runtimes/_to_home.py
@@ -68,6 +68,7 @@ from __future__ import annotations
 import logging
 import os
 import shutil
+import stat
 from datetime import datetime
 from pathlib import Path
 
@@ -245,6 +246,28 @@ def _walk_and_apply(
 # --- per-entry deploy helpers ----------------------------------------------
 
 
+def _clear_readonly_dst(dst: Path) -> None:
+    """Make an existing ``dst`` overwritable before a copy/write.
+
+    Hooks deployed under ``to_home/`` are commonly mode 0755/read-only
+    (e.g. ``hook_switch_helper.sh``). ``shutil.copy2`` / ``Path.write_text``
+    over a read-only existing destination raise
+    ``PermissionError: [Errno 13]`` — the deploy from #142 hit exactly
+    this. We add the owner-write bit so the in-place overwrite succeeds.
+
+    No-op when ``dst`` doesn't exist or is already writable. Symlinks are
+    left untouched (the symlink path unlinks them instead). Genuinely
+    unexpected ``OSError`` (e.g. EROFS, EPERM on a foreign-owned file) is
+    re-raised so the deploy still crashes loud rather than masking a real
+    permissions problem.
+    """
+    if dst.is_symlink() or not dst.exists():
+        return
+    mode = dst.stat().st_mode
+    if not mode & stat.S_IWUSR:
+        os.chmod(dst, mode | stat.S_IWUSR)
+
+
 def _copy_symlink(src: Path, dst: Path) -> None:
     """Preserve a symlink verbatim — never resolve the target.
 
@@ -293,6 +316,7 @@ def _deploy_plain_file(
     """Full overwrite. Uses ``shutil.copy2`` for binary-safe perm preserve
     when no interpolation is needed; otherwise writes interpolated text."""
     dst.parent.mkdir(parents=True, exist_ok=True)
+    _clear_readonly_dst(dst)
     if config is None:
         shutil.copy2(src, dst)
     else:
@@ -317,6 +341,7 @@ def _deploy_tight_perm_file(
     """Full overwrite, then chmod 0600 (e.g. ``.env``)."""
     text = _read_and_interpolate(src, config)
     dst.parent.mkdir(parents=True, exist_ok=True)
+    _clear_readonly_dst(dst)
     if not text.endswith("\n"):
         text += "\n"
     dst.write_text(text)
@@ -385,6 +410,7 @@ def _deploy_marker_protected(
         updated = new_content
 
     dst.parent.mkdir(parents=True, exist_ok=True)
+    _clear_readonly_dst(dst)
     dst.write_text(updated)
     logger.info(
         "to_home: marker-protected %s -> %s (user tail preserved: %s)",

--- a/tests/scitex_agent_container/runtimes/test__apptainer_runtime.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_runtime.py
@@ -1823,6 +1823,143 @@ def test_config_listen_host_propagates_to_env(tmp_path: Path, env_save_restore) 
 
 
 # ---------------------------------------------------------------------------
+# Bus-auth bearer injection (FIX 1) — SAC_LISTEN_BEARER must be injected
+# into EVERY apptainer spec (including relaxed:true), read from the host
+# token file the listen server writes. Missing token → BASE_URL only +
+# loud warning, no crash, no bearer.
+# ---------------------------------------------------------------------------
+
+
+def _write_listen_token(home: Path, token: str) -> Path:
+    """Materialize the canonical listen token file under a redirected HOME.
+
+    Resolves the path exactly as production does (``default_token_path``),
+    so the test exercises the real resolver rather than a hard-coded path.
+    """
+    from scitex_agent_container._listen.tokens import default_token_path
+
+    tok_path = default_token_path(home=home)
+    tok_path.parent.mkdir(parents=True, exist_ok=True)
+    tok_path.write_text(token, encoding="utf-8")
+    return tok_path
+
+
+def test_argv_injects_listen_bearer_from_token_file(
+    tmp_path: Path, home_redirect: Path
+) -> None:
+    # Arrange — standard spec with a real token file under HOME.
+    _write_listen_token(home_redirect, "tok-abc123")
+    rt = ApptainerContainerRuntime()
+    cfg = _config(tmp_path / "wd")
+    # Act
+    argv = rt.build_run_argv(
+        cfg, state_dir=tmp_path / "state", sif_path=tmp_path / "x.sif"
+    )
+    # Assert
+    assert _env_pairs(argv).get("SAC_LISTEN_BEARER") == "tok-abc123"
+
+
+def test_argv_still_injects_base_url_alongside_bearer(
+    tmp_path: Path, home_redirect: Path
+) -> None:
+    # Arrange
+    _write_listen_token(home_redirect, "tok-abc123")
+    rt = ApptainerContainerRuntime()
+    cfg = _config(tmp_path / "wd")
+    # Act
+    argv = rt.build_run_argv(
+        cfg, state_dir=tmp_path / "state", sif_path=tmp_path / "x.sif"
+    )
+    # Assert
+    assert _env_pairs(argv).get("SAC_LISTEN_BASE_URL") == "http://127.0.0.1:7878"
+
+
+def test_relaxed_spec_omits_preflight_wrapper(
+    tmp_path: Path, home_redirect: Path
+) -> None:
+    # Arrange — confirm relaxed mode is actually in effect.
+    _write_listen_token(home_redirect, "tok-relaxed-xyz")
+    rt = ApptainerContainerRuntime()
+    cfg = AgentConfig(
+        name="relaxed-agent",
+        runtime="apptainer",
+        workdir=str(tmp_path / "wd"),
+        apptainer=ApptainerSpec(relaxed=True, raw_args=["--userns", "--cleanenv"]),
+    )
+    # Act
+    argv = rt.build_run_argv(
+        cfg, state_dir=tmp_path / "state", sif_path=tmp_path / "x.sif"
+    )
+    # Assert
+    assert "--containall" not in argv
+
+
+def test_relaxed_spec_still_injects_listen_bearer(
+    tmp_path: Path, home_redirect: Path
+) -> None:
+    # Arrange — bus-auth injection must be unconditional w.r.t relaxed.
+    _write_listen_token(home_redirect, "tok-relaxed-xyz")
+    rt = ApptainerContainerRuntime()
+    cfg = AgentConfig(
+        name="relaxed-agent",
+        runtime="apptainer",
+        workdir=str(tmp_path / "wd"),
+        apptainer=ApptainerSpec(relaxed=True, raw_args=["--userns", "--cleanenv"]),
+    )
+    # Act
+    argv = rt.build_run_argv(
+        cfg, state_dir=tmp_path / "state", sif_path=tmp_path / "x.sif"
+    )
+    # Assert
+    assert _env_pairs(argv).get("SAC_LISTEN_BEARER") == "tok-relaxed-xyz"
+
+
+def test_missing_token_omits_bearer(tmp_path: Path, home_redirect: Path) -> None:
+    # Arrange — no token file under HOME.
+    rt = ApptainerContainerRuntime()
+    cfg = _config(tmp_path / "wd")
+    # Act
+    argv = rt.build_run_argv(
+        cfg, state_dir=tmp_path / "state", sif_path=tmp_path / "x.sif"
+    )
+    # Assert
+    assert "SAC_LISTEN_BEARER" not in _env_pairs(argv)
+
+
+def test_missing_token_still_injects_base_url(
+    tmp_path: Path, home_redirect: Path
+) -> None:
+    # Arrange — no token file under HOME.
+    rt = ApptainerContainerRuntime()
+    cfg = _config(tmp_path / "wd")
+    # Act
+    argv = rt.build_run_argv(
+        cfg, state_dir=tmp_path / "state", sif_path=tmp_path / "x.sif"
+    )
+    # Assert
+    assert _env_pairs(argv).get("SAC_LISTEN_BASE_URL") == "http://127.0.0.1:7878"
+
+
+def test_missing_token_logs_loud_warning(
+    tmp_path: Path, home_redirect: Path, caplog
+) -> None:
+    # Arrange — no token file → loud warning, no silent fallback.
+    import logging
+
+    rt = ApptainerContainerRuntime()
+    cfg = _config(tmp_path / "wd")
+    # Act
+    with caplog.at_level(logging.WARNING):
+        rt.build_run_argv(
+            cfg, state_dir=tmp_path / "state", sif_path=tmp_path / "x.sif"
+        )
+    # Assert
+    assert any(
+        "SAC_LISTEN_BEARER not injected" in rec.getMessage() for rec in caplog.records
+    )
+
+
+# ---------------------------------------------------------------------------
 # Hardened isolation defaults (--containall, --cleanenv, --writable-tmpfs)
 # ---------------------------------------------------------------------------
 

--- a/tests/scitex_agent_container/runtimes/test__to_home.py
+++ b/tests/scitex_agent_container/runtimes/test__to_home.py
@@ -654,3 +654,80 @@ class TestMarkerProtectedOverlay:
         # Act
         # Assert
         assert content.count(END_MARKER) == 1
+
+
+# ---------------------------------------------------------------------------
+# Read-only destination overwrite (FIX 2) — hooks are commonly mode 0755 /
+# read-only; deploy must overwrite them in place without PermissionError.
+# ---------------------------------------------------------------------------
+
+
+class TestReadOnlyDestinationOverwrite:
+    def _deploy_over_readonly(
+        self, tmp_path: Path, basename: str, *, mode: int = 0o555
+    ) -> Path:
+        """Materialize a source file over a pre-existing read-only dest.
+
+        Returns the destination path. Uses the no-config
+        ``materialize_to_home`` path so the plain-file ``shutil.copy2``
+        branch is exercised directly.
+        """
+        spec_dir = tmp_path / "spec"
+        (spec_dir / "to_home").mkdir(parents=True)
+        (spec_dir / "to_home" / basename).write_text("new content\n")
+        home = tmp_path / "home"
+        home.mkdir()
+        dst = home / basename
+        dst.write_text("old content\n")
+        os.chmod(dst, mode)
+        materialize_to_home(spec_dir, home)
+        return dst
+
+    def test_plain_file_overwrite_succeeds_over_readonly(self, tmp_path):
+        # Arrange — read-only existing dest (the #142 PermissionError case).
+        # Act
+        dst = self._deploy_over_readonly(tmp_path, "hook_switch_helper.sh")
+        # Assert — no PermissionError raised; content updated.
+        assert dst.read_text() == "new content\n"
+
+    def test_plain_file_content_is_updated(self, tmp_path):
+        # Arrange
+        # Act
+        dst = self._deploy_over_readonly(tmp_path, "hook_switch_helper.sh")
+        # Assert
+        assert "old content" not in dst.read_text()
+
+    def test_marker_protected_overwrite_succeeds_over_readonly(self, tmp_path):
+        # Arrange — CLAUDE.md gets marker-protected merge; a prior deploy
+        # left a valid marker section that is now read-only.
+        spec_dir = tmp_path / "spec"
+        (spec_dir / "to_home").mkdir(parents=True)
+        (spec_dir / "to_home" / "CLAUDE.md").write_text("## doctrine\n")
+        home = tmp_path / "home"
+        home.mkdir()
+        dst = home / "CLAUDE.md"
+        dst.write_text(
+            "<!-- Start of scitex-agent-container generated section (old) -->\n"
+            "## stale\n"
+            f"{END_MARKER}\n"
+        )
+        os.chmod(dst, 0o444)
+        # Act
+        materialize_to_home(spec_dir, home)
+        # Assert — wrapped section refreshed, no PermissionError.
+        assert "doctrine" in dst.read_text()
+
+    def test_tight_perm_file_overwrite_succeeds_over_readonly(self, tmp_path):
+        # Arrange — .env gets chmod 0600; dest starts read-only.
+        spec_dir = tmp_path / "spec"
+        (spec_dir / "to_home").mkdir(parents=True)
+        (spec_dir / "to_home" / ".env").write_text("KEY=new\n")
+        home = tmp_path / "home"
+        home.mkdir()
+        dst = home / ".env"
+        dst.write_text("KEY=old\n")
+        os.chmod(dst, 0o400)
+        # Act
+        materialize_to_home(spec_dir, home)
+        # Assert
+        assert dst.read_text() == "KEY=new\n"


### PR DESCRIPTION
Two host-side fixes (run at \`sac agents start\`; no image rebuild needed).

## FIX 1 — unconditional bus-auth env injection (apptainer runtime)
The in-container channel adapter (sac MCP) must present \`SAC_LISTEN_BEARER\`
to reach \`sac listen\` (returns 401 without it), or the inbox subscription
never lands and pushed turns report \`delivered_subscriber_count: 0\`.

Previously the bearer was **never** injected, and \`SAC_LISTEN_BASE_URL\` was
skipped for \`apptainer.relaxed: true\` specs that use \`raw_args\` (the
relaxed branch bypassed the standard injection path).

Now **both** env vars are injected for **every** apptainer spec (including
relaxed), placed before the \`raw_args\` / inner-command assembly. The bearer
is read at start time from the host token file the listen server itself
writes (\`default_token_path()\` → \`~/.scitex/agent-container/tokens/listen-<host>.token\`),
so it matches the token the bus validates against. Absent token file →
\`BASE_URL\` only + a loud warning (no silent fallback, no crash). The token
is never written into \`spec.yaml\` / git.

\`src/scitex_agent_container/runtimes/_apptainer_runtime.py\` (injection),
\`src/scitex_agent_container/runtimes/_apptainer_build.py\` (\`_listen_token_path\`,
\`_read_listen_bearer\`).

## FIX 2 — to_home deploy overwrites read-only destinations
The baseline-layer deploy (#142) raised \`PermissionError: [Errno 13]\`
overwriting an existing read-only file (hooks are commonly mode 0755 /
read-only, e.g. \`hook_switch_helper.sh\`). The plain-file, tight-perm
(\`.env\`), and marker-protected (\`CLAUDE.md\`/\`state.md\`) paths now clear the
destination's read-only bit before writing. Genuinely unexpected
\`OSError\` still propagates (crash-loud preserved).

\`src/scitex_agent_container/runtimes/_to_home.py\` (\`_clear_readonly_dst\` +
call sites).

## Refactor
\`_apptainer_runtime.py\` was over the line budget; SIF-build / overlay /
bus-auth helpers extracted into \`_apptainer_build.py\`. Public helper names
re-exported for back-compat (existing \`mod._build_sif_* / mod._safe_image_tag\`
references keep resolving).

## Tests (TDD, real tmp_path, no mocks)
- relaxed + standard specs inject \`SAC_LISTEN_BEARER\` + \`SAC_LISTEN_BASE_URL\`
  from a real token file under a redirected \`\$HOME\`;
- absent token → base URL only + warning, no bearer, no crash;
- deploy over a pre-existing **read-only** dst succeeds and updates content
  (plain / \`.env\` / marker-protected).

Full \`tests/.../runtimes/\` suite green (603 passed).