### PR TITLE
feat(send): state-aware diagnosis on agent_send timeout/error

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_send.py
+++ b/src/scitex_agent_container/cli_pkg/_send.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from ._send_diagnosis import diagnose_send_failure
 from ._send_preflight import SshRunner, preflight_send_creds
 
 __all__ = ["send_to_agent"]
@@ -102,12 +103,23 @@ def send_to_agent(
     from .._network.peer import PeerError
     from .._state.state_db import _resolve_host, list_active_instances
 
+    current_host = _resolve_host(None)
     rows = list_active_instances()
     matching = [r for r in rows if r.get("name") == name]
     if not matching:
-        return {"status": "error", "error": f"agent {name!r} not running"}
+        return {
+            "status": "error",
+            "error": f"agent {name!r} not running",
+            "diagnosis": diagnose_send_failure(
+                name,
+                a2a_port=None,
+                peer_host=current_host,
+                current_host=current_host,
+            ),
+        }
     row = matching[0]
     a2a_port = row.get("a2a_port")
+    peer_host = str(row.get("host") or "")
     if not isinstance(a2a_port, int) or a2a_port <= 0:
         return {
             "status": "error",
@@ -115,9 +127,13 @@ def send_to_agent(
                 f"agent {name!r} has no a2a_port recorded "
                 f"(a2a_port={a2a_port!r}); cannot reach /v1/turn"
             ),
+            "diagnosis": diagnose_send_failure(
+                name,
+                a2a_port=a2a_port if isinstance(a2a_port, int) else None,
+                peer_host=peer_host or current_host,
+                current_host=current_host,
+            ),
         }
-    peer_host = str(row.get("host") or "")
-    current_host = _resolve_host(None)
     if peer_host and peer_host != current_host:
         url = f"ssh://{peer_host}:{a2a_port}/v1/turn"
     else:
@@ -164,9 +180,24 @@ def send_to_agent(
         # ssh+curl timeouts as "ssh+curl timeout to ...". Sniff either
         # shape so the MCP tool can surface status="timeout" sharply
         # rather than burying the timeout inside a generic "error".
+        #
+        # Both surfaces carry a state-aware ``diagnosis`` gathered at the
+        # moment of failure so the caller can tell "still booting" /
+        # "alive & busy" / "dead" / "port unreachable" apart instead of
+        # getting an opaque "no response".
+        diagnosis = diagnose_send_failure(
+            name,
+            a2a_port=a2a_port,
+            peer_host=peer_host,
+            current_host=current_host,
+        )
         if "timeout" in msg.lower():
-            return {"status": "timeout", "error": f"no response in {timeout_seconds}s"}
-        return {"status": "error", "error": msg}
+            return {
+                "status": "timeout",
+                "error": f"no response in {timeout_seconds}s",
+                "diagnosis": diagnosis,
+            }
+        return {"status": "error", "error": msg, "diagnosis": diagnosis}
 
     metadata: dict[str, Any] = {
         "name": name,

--- a/src/scitex_agent_container/cli_pkg/_send_diagnosis.py
+++ b/src/scitex_agent_container/cli_pkg/_send_diagnosis.py
@@ -1,0 +1,290 @@
+"""State-aware diagnosis for ``send_to_agent`` timeout / error returns.
+
+When a turn POST to an agent's A2A sidecar fails (timeout, refused,
+non-200), the bare ``{"status": "timeout", "error": "no response in
+60s"}`` cannot tell the caller *why*: is the agent still booting, alive
+and busy, alive and idle (turn never consumed), dead, or simply
+unreachable on its port?
+
+This module gathers the state that distinguishes those cases AT THE
+MOMENT OF FAILURE and folds it into a single ``diagnosis`` dict that the
+caller attaches to the failure payload. It reuses the same state sources
+that power ``sac agents list`` / ``agent_status``:
+
+  * registry / instances row liveness — :func:`list_active_instances`
+  * heartbeat state + age            — :func:`latest_heartbeats_per_name`
+    (the ``heartbeats`` diary table: ``name, host, pid, state, ts``)
+  * local pid liveness               — ``os.kill(pid, 0)`` (same probe
+    the state.db GC sweep uses)
+
+No silent fallbacks: when a field can't be gathered the value is an
+explicit ``"unreadable: <reason>"`` / ``"unknown"`` string rather than a
+quiet default, so the caller can always tell "we don't know" apart from
+"we know it's fine".
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import time
+from datetime import datetime, timezone
+from typing import Any
+
+__all__ = ["diagnose_send_failure", "HEARTBEAT_STALE_SECONDS"]
+
+# A heartbeat older than this is treated as "stale" — the agent is
+# likely dead or hung rather than merely busy. Matches the ~120s the
+# operator guidance calls out (the GC sweep's 300s default is a coarser,
+# slower reaper; for live send feedback we want a tighter window).
+HEARTBEAT_STALE_SECONDS = 120.0
+
+
+def _heartbeat_age_seconds(hb_ts: Any, now: float) -> float | None:
+    """Seconds between ``hb_ts`` (REAL unix-seconds) and ``now``.
+
+    The ``heartbeats`` table stores ``ts`` as REAL unix-seconds. Returns
+    ``None`` only when the value is genuinely unparseable so the caller
+    surfaces ``"unreadable"`` rather than a fabricated age.
+    """
+    if hb_ts is None:
+        return None
+    try:
+        return round(now - float(hb_ts), 1)
+    except (TypeError, ValueError):
+        return None
+
+
+def _pid_alive(pid: Any) -> bool | None:
+    """True/False if ``pid`` is/ isn't alive locally; None if unknowable.
+
+    Uses ``os.kill(pid, 0)`` — the same liveness probe the state.db GC
+    sweep uses. Returns ``None`` when there is no pid to probe (so the
+    caller does not mistake "no pid recorded" for "process dead").
+    """
+    if not isinstance(pid, int) or pid <= 0:
+        return None
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Process exists but is owned by another uid — alive from our POV.
+        return True
+    except OSError:
+        return False
+
+
+def _port_reachable(
+    port: int, *, host: str = "127.0.0.1", timeout: float = 1.0
+) -> bool:
+    """True iff a TCP connect to ``host:port`` succeeds within ``timeout``.
+
+    Distinguishes "sidecar listening" from "connection refused / not
+    booted". Only meaningful for a local (loopback) port; cross-host
+    callers pass ``reachable_checked=False`` instead.
+    """
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+def diagnose_send_failure(
+    name: str,
+    *,
+    a2a_port: int | None,
+    peer_host: str,
+    current_host: str,
+    now: float | None = None,
+) -> dict[str, Any]:
+    """Gather state-of-the-agent at the moment a send failed.
+
+    Returns a ``diagnosis`` dict the caller folds into the ``timeout`` /
+    ``error`` payload. Every field is explicit — an un-gatherable value
+    becomes ``"unreadable: <reason>"`` / ``"unknown"`` / ``None``, never
+    a silent healthy-looking default.
+
+    Fields
+    ------
+    registry_status: ``"running"`` (an active instances row exists) or
+        ``"stopped"`` (none) or ``"unreadable: <reason>"``.
+    pid / pid_alive: recorded pid and whether it is alive locally
+        (``True`` / ``False`` / ``None`` when unknowable, e.g. cross-host
+        or no pid recorded).
+    heartbeat_state: the latest heartbeat ``state``
+        (idle/working/starting/...) or ``None`` when no heartbeat row, or
+        ``"unreadable: <reason>"``.
+    heartbeat_age_seconds: age of the latest heartbeat in seconds, or
+        ``None``.
+    last_activity: the instance's ``last_heartbeat_at`` ISO string (or
+        the diary heartbeat ts as ISO) — best available "last seen".
+    a2a_port / port_reachable: the resolved port and whether a local TCP
+        connect succeeded. ``port_reachable`` is ``None`` for cross-host
+        rows (we don't probe a remote port from here).
+    boot_complete: ``True`` when a heartbeat is present and fresh; ``False``
+        when stale/absent; ``None`` when unknowable.
+    likely_causes: plain-language interpretation of the above.
+
+    Parameters
+    ----------
+    name: agent name.
+    a2a_port: resolved port the send targeted (may be ``None``).
+    peer_host: ``row["host"]`` — the host the turn was POSTed to.
+    current_host: lead-side resolved host.
+    now: wall-clock override for deterministic tests.
+    """
+    now = time.time() if now is None else now
+    is_local = (not peer_host) or peer_host == current_host
+
+    diagnosis: dict[str, Any] = {
+        "agent": name,
+        "host": peer_host or current_host,
+        "is_local": is_local,
+        "a2a_port": a2a_port,
+    }
+
+    # ---- registry / instances row + pid ---------------------------------
+    row: dict[str, Any] | None = None
+    try:
+        from .._state.state_db import list_active_instances
+
+        rows = list_active_instances()
+        matching = [r for r in rows if r.get("name") == name]
+        row = matching[0] if matching else None
+        diagnosis["registry_status"] = "running" if row is not None else "stopped"
+    except Exception as exc:  # noqa: BLE001 — report loudly, never fake "stopped"
+        diagnosis["registry_status"] = f"unreadable: {type(exc).__name__}: {exc}"
+
+    pid = row.get("pid") if row else None
+    diagnosis["pid"] = pid
+    if is_local:
+        diagnosis["pid_alive"] = _pid_alive(pid)
+    else:
+        # Cross-host: no local liveness signal. State it, don't guess.
+        diagnosis["pid_alive"] = None
+
+    # last_activity: prefer the instances row's last_heartbeat_at.
+    diagnosis["last_activity"] = (row or {}).get("last_heartbeat_at")
+
+    # ---- heartbeat state + age (diary `heartbeats` table) ----------------
+    hb_state: Any = None
+    hb_age: float | None = None
+    try:
+        from .._state.state_db import latest_heartbeats_per_name
+
+        beats = {b.get("name"): b for b in latest_heartbeats_per_name()}
+        beat = beats.get(name)
+        if beat is None:
+            hb_state = None
+            diagnosis["heartbeat_state"] = None
+            diagnosis["heartbeat_age_seconds"] = None
+        else:
+            hb_state = beat.get("state")
+            hb_age = _heartbeat_age_seconds(beat.get("ts"), now)
+            diagnosis["heartbeat_state"] = hb_state
+            if hb_age is None:
+                diagnosis["heartbeat_age_seconds"] = (
+                    f"unreadable: bad ts {beat.get('ts')!r}"
+                )
+            else:
+                diagnosis["heartbeat_age_seconds"] = hb_age
+            # Fall back to the diary ts for last_activity when the
+            # instances row had none.
+            if not diagnosis.get("last_activity") and beat.get("ts") is not None:
+                try:
+                    diagnosis["last_activity"] = (
+                        datetime.fromtimestamp(float(beat["ts"]), tz=timezone.utc)
+                        .isoformat()
+                        .replace("+00:00", "Z")
+                    )
+                except (TypeError, ValueError):
+                    pass
+    except Exception as exc:  # noqa: BLE001 — report loudly, never fake idle
+        diagnosis["heartbeat_state"] = f"unreadable: {type(exc).__name__}: {exc}"
+        diagnosis["heartbeat_age_seconds"] = None
+
+    hb_fresh = hb_age is not None and hb_age <= HEARTBEAT_STALE_SECONDS
+
+    # ---- boot completion -------------------------------------------------
+    # Boot looks complete when a heartbeat exists and is fresh.
+    if isinstance(diagnosis.get("heartbeat_state"), str) and diagnosis[
+        "heartbeat_state"
+    ].startswith("unreadable"):
+        diagnosis["boot_complete"] = None
+    elif hb_state is None:
+        diagnosis["boot_complete"] = False
+    else:
+        diagnosis["boot_complete"] = bool(hb_fresh)
+
+    # ---- port reachability ----------------------------------------------
+    if not isinstance(a2a_port, int) or a2a_port <= 0:
+        diagnosis["port_reachable"] = None
+    elif not is_local:
+        # Don't probe a remote port from the lead; we can't interpret it.
+        diagnosis["port_reachable"] = None
+    else:
+        diagnosis["port_reachable"] = _port_reachable(a2a_port)
+
+    diagnosis["likely_causes"] = _interpret(diagnosis, hb_state, hb_age, hb_fresh)
+    return diagnosis
+
+
+def _interpret(
+    d: dict[str, Any], hb_state: Any, hb_age: float | None, hb_fresh: bool
+) -> str:
+    """Turn the gathered fields into plain-language guidance."""
+    port_reachable = d.get("port_reachable")
+    pid_alive = d.get("pid_alive")
+    registry = d.get("registry_status")
+
+    # Hard "not running" cases first.
+    if registry == "stopped":
+        return (
+            "agent is not in the active registry (no live instance row); "
+            "it is stopped — start it before sending"
+        )
+    if pid_alive is False:
+        return (
+            "recorded agent pid is not alive; the process crashed or was "
+            "killed — restart it"
+        )
+    if d.get("a2a_port") in (None, 0) or (
+        isinstance(d.get("a2a_port"), int) and d["a2a_port"] <= 0
+    ):
+        return "no a2a_port recorded for the agent; it has not bound a sidecar"
+    if port_reachable is False:
+        return (
+            f"agent sidecar is not listening on port {d.get('a2a_port')}; "
+            "it is not booted or the sidecar crashed"
+        )
+
+    # Heartbeat-based interpretation.
+    if isinstance(hb_state, str) and hb_state in ("working", "busy"):
+        return (
+            "agent is alive and actively working; the turn is likely still "
+            "in progress — raise timeout_seconds or poll status"
+        )
+    if hb_age is not None and not hb_fresh:
+        return (
+            f"heartbeat is stale ({hb_age}s old, > {int(HEARTBEAT_STALE_SECONDS)}s); "
+            "the agent appears dead or hung — restart it"
+        )
+    if hb_state is None:
+        return (
+            "no heartbeat recorded yet; the agent may still be finishing boot "
+            "(sidecar reachable but session not ready) — retry shortly"
+        )
+    if hb_fresh and hb_state in ("idle", "starting"):
+        return (
+            "agent is alive but did not consume the turn (heartbeat fresh, "
+            f"state={hb_state!r}); it may still be finishing boot, or the turn "
+            "was not enqueued — retry shortly"
+        )
+    # Fresh heartbeat, some other state — alive but unexpected.
+    return (
+        f"agent heartbeat is fresh (state={hb_state!r}) but it did not reply; "
+        "retry shortly or poll status"
+    )

--- a/src/scitex_agent_container/cli_pkg/_send_diagnosis.py
+++ b/src/scitex_agent_container/cli_pkg/_send_diagnosis.py
@@ -210,9 +210,8 @@ def diagnose_send_failure(
 
     # ---- boot completion -------------------------------------------------
     # Boot looks complete when a heartbeat exists and is fresh.
-    if isinstance(diagnosis.get("heartbeat_state"), str) and diagnosis[
-        "heartbeat_state"
-    ].startswith("unreadable"):
+    hb_state_str = diagnosis.get("heartbeat_state")
+    if isinstance(hb_state_str, str) and hb_state_str.startswith("unreadable"):
         diagnosis["boot_complete"] = None
     elif hb_state is None:
         diagnosis["boot_complete"] = False

--- a/tests/scitex_agent_container/cli_pkg/test__send.py
+++ b/tests/scitex_agent_container/cli_pkg/test__send.py
@@ -379,3 +379,245 @@ def test_agent_send_error_when_sidecar_returns_non_200(
         )
     # Assert
     assert result["status"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# State-aware failure diagnosis (PS-NN: send_to_agent attaches a
+# ``diagnosis`` to the timeout / error returns so the caller can tell
+# "still booting" / "alive & busy" / "dead" / "port unreachable" apart).
+#
+# Real state: the ``heartbeats`` diary table + ``instances`` row + a real
+# local TCP listener are used — no mocks. ``record_heartbeat`` writes a
+# real row; a throwaway socket binds a real port.
+# ---------------------------------------------------------------------------
+
+
+def _record_heartbeat(name: str, state: str, *, pid=None, ts=None) -> None:
+    """Append one real ``heartbeats`` row for ``name`` (no mocks)."""
+    from scitex_agent_container._state.state_db import record_heartbeat
+
+    record_heartbeat(name=name, host="lead-host", pid=pid, state=state, ts=ts)
+
+
+def _seed_local_with_pid(name: str, a2a_port: int, pid: int) -> None:
+    """Record an active local instance row carrying a specific pid."""
+    from scitex_agent_container._state.state_db import record_instance_start
+
+    record_instance_start(name=name, host="lead-host", pid=pid, a2a_port=a2a_port)
+
+
+@contextmanager
+def _real_listener() -> Iterator[int]:
+    """Bind a real TCP listener on a free loopback port; yield the port.
+
+    Used so the diagnosis sees ``port_reachable=True`` and the heartbeat
+    dimension (not the port) is the deciding factor for ``likely_causes``.
+    """
+    import socket as _socket
+
+    srv = _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM)
+    srv.bind(("127.0.0.1", 0))
+    srv.listen(1)
+    try:
+        yield srv.getsockname()[1]
+    finally:
+        srv.close()
+
+
+def test_agent_send_timeout_includes_diagnosis(state_db_env, fresh_lead_creds_path):
+    # Arrange
+    _seed_local("alpha", a2a_port=12345)
+    from scitex_agent_container._network.peer import PeerError
+
+    def fake_post(url, text, *, timeout_s):
+        raise PeerError(f"peer timeout at {url} after {timeout_s:.0f}s")
+
+    # Act
+    with _swap_post_turn(fake_post):
+        result = send_to_agent(
+            "alpha", "hi", timeout_seconds=2, lead_creds_path=fresh_lead_creds_path
+        )
+    # Assert
+    assert "diagnosis" in result
+
+
+def test_agent_send_error_includes_diagnosis(state_db_env, fresh_lead_creds_path):
+    # Arrange
+    _seed_local("alpha", a2a_port=12345)
+    from scitex_agent_container._network.peer import PeerError
+
+    def fake_post(url, text, *, timeout_s):
+        raise PeerError("peer returned HTTP 500: internal error")
+
+    # Act
+    with _swap_post_turn(fake_post):
+        result = send_to_agent(
+            "alpha", "hi", timeout_seconds=2, lead_creds_path=fresh_lead_creds_path
+        )
+    # Assert
+    assert "diagnosis" in result
+
+
+def test_agent_send_diagnosis_reports_registry_running(
+    state_db_env, fresh_lead_creds_path
+):
+    # Arrange
+    _seed_local("alpha", a2a_port=12345)
+    from scitex_agent_container._network.peer import PeerError
+
+    def fake_post(url, text, *, timeout_s):
+        raise PeerError("peer timeout at <url> after 2s")
+
+    # Act
+    with _swap_post_turn(fake_post):
+        result = send_to_agent(
+            "alpha", "hi", timeout_seconds=2, lead_creds_path=fresh_lead_creds_path
+        )
+    # Assert
+    assert result["diagnosis"]["registry_status"] == "running"
+
+
+def test_agent_send_not_running_diagnosis_reports_stopped(state_db_env):
+    # Arrange — no rows seeded
+    # Act
+    result = send_to_agent("ghost", "hi")
+    # Assert
+    assert result["diagnosis"]["registry_status"] == "stopped"
+
+
+def test_agent_send_diagnosis_reports_busy_heartbeat_state(
+    state_db_env, fresh_lead_creds_path
+):
+    # Arrange
+    _seed_local("alpha", a2a_port=12345)
+    _record_heartbeat("alpha", "working", ts=time.time())
+    from scitex_agent_container._network.peer import PeerError
+
+    def fake_post(url, text, *, timeout_s):
+        raise PeerError("peer timeout at <url> after 2s")
+
+    # Act
+    with _swap_post_turn(fake_post):
+        result = send_to_agent(
+            "alpha", "hi", timeout_seconds=2, lead_creds_path=fresh_lead_creds_path
+        )
+    # Assert
+    assert result["diagnosis"]["heartbeat_state"] == "working"
+
+
+def test_agent_send_diagnosis_busy_likely_cause_says_in_progress(
+    state_db_env, fresh_lead_creds_path
+):
+    # Arrange — real listener so the port is reachable and the heartbeat
+    # state (working) is what drives likely_causes.
+    from scitex_agent_container._network.peer import PeerError
+
+    def fake_post(url, text, *, timeout_s):
+        raise PeerError("peer timeout at <url> after 2s")
+
+    with _real_listener() as port:
+        _seed_local("alpha", a2a_port=port)
+        _record_heartbeat("alpha", "working", ts=time.time())
+        # Act
+        with _swap_post_turn(fake_post):
+            result = send_to_agent(
+                "alpha", "hi", timeout_seconds=2, lead_creds_path=fresh_lead_creds_path
+            )
+    # Assert
+    assert "still" in result["diagnosis"]["likely_causes"].lower()
+
+
+def test_agent_send_diagnosis_stale_heartbeat_likely_cause_says_dead(
+    state_db_env, fresh_lead_creds_path
+):
+    # Arrange — real listener (port reachable) but heartbeat far older
+    # than the staleness window, so "stale/dead" is the deciding factor.
+    from scitex_agent_container._network.peer import PeerError
+
+    def fake_post(url, text, *, timeout_s):
+        raise PeerError("peer timeout at <url> after 2s")
+
+    with _real_listener() as port:
+        _seed_local("alpha", a2a_port=port)
+        _record_heartbeat("alpha", "idle", ts=time.time() - 600)
+        # Act
+        with _swap_post_turn(fake_post):
+            result = send_to_agent(
+                "alpha", "hi", timeout_seconds=2, lead_creds_path=fresh_lead_creds_path
+            )
+    # Assert
+    assert "dead or hung" in result["diagnosis"]["likely_causes"]
+
+
+def test_agent_send_diagnosis_dead_pid_reports_pid_not_alive(
+    state_db_env, fresh_lead_creds_path
+):
+    # Arrange — a pid that is essentially guaranteed not to exist.
+    dead_pid = 2_147_483_646
+    _seed_local_with_pid("alpha", a2a_port=12345, pid=dead_pid)
+    from scitex_agent_container._network.peer import PeerError
+
+    def fake_post(url, text, *, timeout_s):
+        raise PeerError("peer timeout at <url> after 2s")
+
+    # Act
+    with _swap_post_turn(fake_post):
+        result = send_to_agent(
+            "alpha", "hi", timeout_seconds=2, lead_creds_path=fresh_lead_creds_path
+        )
+    # Assert
+    assert result["diagnosis"]["pid_alive"] is False
+
+
+def test_agent_send_diagnosis_port_unreachable_when_nothing_listening(
+    state_db_env, fresh_lead_creds_path
+):
+    # Arrange — a2a_port that no process is listening on. We grab a free
+    # port from the OS and immediately release it so the connect refuses.
+    import socket as _socket
+
+    s = _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    free_port = s.getsockname()[1]
+    s.close()
+    _seed_local("alpha", a2a_port=free_port)
+    from scitex_agent_container._network.peer import PeerError
+
+    def fake_post(url, text, *, timeout_s):
+        raise PeerError("peer timeout at <url> after 2s")
+
+    # Act
+    with _swap_post_turn(fake_post):
+        result = send_to_agent(
+            "alpha", "hi", timeout_seconds=2, lead_creds_path=fresh_lead_creds_path
+        )
+    # Assert
+    assert result["diagnosis"]["port_reachable"] is False
+
+
+def test_agent_send_diagnosis_port_reachable_when_listener_bound(
+    state_db_env, fresh_lead_creds_path
+):
+    # Arrange — bind a real listener so the diagnosis sees a live port.
+    import socket as _socket
+
+    srv = _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM)
+    srv.bind(("127.0.0.1", 0))
+    srv.listen(1)
+    bound_port = srv.getsockname()[1]
+    _seed_local("alpha", a2a_port=bound_port)
+    from scitex_agent_container._network.peer import PeerError
+
+    def fake_post(url, text, *, timeout_s):
+        raise PeerError("peer timeout at <url> after 2s")
+
+    # Act
+    try:
+        with _swap_post_turn(fake_post):
+            result = send_to_agent(
+                "alpha", "hi", timeout_seconds=2, lead_creds_path=fresh_lead_creds_path
+            )
+    finally:
+        srv.close()
+    # Assert
+    assert result["diagnosis"]["port_reachable"] is True

--- a/tests/scitex_agent_container/cli_pkg/test__send.py
+++ b/tests/scitex_agent_container/cli_pkg/test__send.py
@@ -256,11 +256,10 @@ def test_agent_send_timeout_error_message_quotes_timeout_value(
 
 def test_agent_send_prompt_and_key_mutually_exclusive(state_db_env):
     # Arrange
-    args = dict(prompt="hi", key="ESC")
     # Act
     raised: Exception | None = None
     try:
-        send_to_agent("alpha", **args)
+        send_to_agent("alpha", prompt="hi", key="ESC")
     except ValueError as exc:
         raised = exc
     # Assert


### PR DESCRIPTION
## Problem
`agent_send` / `send_to_agent` timeouts returned only `{"status":"timeout","error":"no response in 60s"}` — uninformative. The caller cannot tell apart: agent booting, alive & busy, alive & idle (turn never consumed), process dead, or sidecar port unreachable.

## Change
`send_to_agent` now attaches a structured `diagnosis` to **both** the `timeout` and `error` return paths (and the early `not running` / `no a2a_port` errors). Gathered **at the moment of failure**:

- `registry_status` (running/stopped) + `pid` + `pid_alive` (`os.kill(pid,0)` probe, local host)
- `heartbeat_state` (idle/working/...) + `heartbeat_age_seconds`
- `a2a_port` + `port_reachable` (local TCP connect; `None` cross-host)
- `boot_complete` (heartbeat present & fresh)
- `last_activity`
- `likely_causes` — plain-language interpretation, e.g. "alive and actively working; raise timeout_seconds", "appears dead or hung; restart it", "sidecar not listening on <port>".

Un-gatherable fields surface an explicit `"unreadable: <reason>"`, never a silent healthy-looking default (no-fallback rule).

## Reuse
Reuses the state sources behind `sac agents list` / `agent_status`:
- `list_active_instances` (registry/instances row)
- `latest_heartbeats_per_name` (the `heartbeats` diary table: name/host/pid/state/ts)
- the same `os.kill(pid, 0)` liveness probe the state.db GC sweep uses

Assembly lives in one function: `diagnose_send_failure` in `cli_pkg/_send_diagnosis.py`. The MCP `agent_send` tool returns the dict verbatim, so the diagnosis flows straight through.

## Tests
TDD, no mocks — real temp `state.db`, real `record_heartbeat` rows, real bound/unbound TCP sockets. 11 new tests in `tests/scitex_agent_container/cli_pkg/test__send.py` (24 total in file, all green).

Full suite: 3886 passed, 3 skipped. 2 unrelated failures (`test_claude_session_channels_without_port_raises`, `test_hanging_remote_probe_respects_timeout_budget`) reproduce identically on the clean `develop` baseline — pre-existing, not caused by this change.