### PR TITLE
feat(wi-1): durability + replay on the sac listen surface (finish-work)

### DIFF
--- a/src/scitex_agent_container/_listen/server.py
+++ b/src/scitex_agent_container/_listen/server.py
@@ -40,6 +40,12 @@ from starlette.routing import Route
 
 from .._runners._session_state import read_session_id, state_dir_for
 from .._state.registry import Registry
+from .._state.state_db_channel import (
+    list_since_id,
+    list_undelivered,
+    mark_delivered,
+    persist_event,
+)
 from ..a2a._inbox_bus import mint_event
 from ..config import load_config
 from ..config._resolve import resolve_config
@@ -725,6 +731,19 @@ async def node_message_send(request: Request) -> Response:
     broker: Broker = request.app.state.inbox
     nodes.register(name, base_url)
 
+    # WI-1 finish-work (Q5 — handoff §4 durability acceptance applied
+    # to the ``sac listen`` surface, not just ``a2a/_server.py``).
+    # Persist BEFORE publish so an event POSTed with no subscriber is
+    # not silently dropped (handoff §0 hard rule). The persisted row
+    # id is attached to the envelope as ``_row_id``; the SSE stream
+    # stamps it onto the ``id:`` line so clients can resume with
+    # ``Last-Event-ID``. A denied send (returned earlier with 403)
+    # never reaches this point — denial leaves zero side-effects on
+    # ``channel_events`` and on the broker (handoff §0: "denial is
+    # the policy working").
+    row_id = persist_event(target=name, event=event)
+    event["_row_id"] = row_id
+
     delivered = await broker.publish(name, event)
     return JSONResponse(
         {
@@ -746,6 +765,31 @@ async def node_inbox_stream(request: Request) -> Response:
 
     Implicitly registers ``<name>`` as an external node on first
     connect.
+
+    WI-1 finish-work (Q5 — handoff §4 durability acceptance applied
+    to the ``sac listen`` surface, mirroring ``a2a/_server.py``):
+
+      * On connect, replay missed events from the persistent
+        ``channel_events`` table BEFORE accepting any new live event.
+        Replay source:
+
+          - if the client passed ``Last-Event-ID``, replay every row
+            with ``id > Last-Event-ID``;
+          - otherwise replay every undelivered row (fresh-subscriber
+            case — handoff acceptance "an event POSTed with no
+            subscriber is delivered on connect").
+
+      * Each replay frame stamps the SQLite row id onto the SSE
+        ``id:`` line so the client can echo it back as
+        ``Last-Event-ID`` after a reconnect.
+
+      * After yielding a replay frame the row is marked
+        ``delivered_at`` so a subsequent fresh-subscriber connect
+        does not re-yield it.
+
+      * A malformed ``Last-Event-ID`` header is a loud 400 — a
+        corrupt cursor would silently disable replay if tolerated
+        (handoff §0).
     """
     from starlette.responses import StreamingResponse
 
@@ -755,6 +799,22 @@ async def node_inbox_stream(request: Request) -> Response:
     broker: Broker = request.app.state.inbox
     nodes.register(name, base_url)
 
+    last_event_id_raw = request.headers.get("last-event-id")
+    last_event_id: int | None = None
+    if last_event_id_raw is not None:
+        try:
+            last_event_id = int(last_event_id_raw)
+        except ValueError:
+            return JSONResponse(
+                {
+                    "error": (
+                        "Last-Event-ID header must be an integer; got "
+                        f"{last_event_id_raw!r}"
+                    )
+                },
+                status_code=400,
+            )
+
     queue = await broker.subscribe(name)
 
     async def stream():
@@ -763,12 +823,49 @@ async def node_inbox_stream(request: Request) -> Response:
             # open immediately (and tests can race-free detect "I'm
             # subscribed" before publishing).
             yield b": sac-channel ready\n\n"
+
+            # WI-1 replay: yield every missed durable row first, then
+            # accept live events from the broker.
+            if last_event_id is not None:
+                replay = list_since_id(target=name, since_id=last_event_id)
+            else:
+                replay = list_undelivered(target=name)
+            for entry in replay:
+                if await request.is_disconnected():
+                    return
+                row_id = entry["id"]
+                event = entry["event"]
+                # Strip the internal ``_row_id`` if a previous publish
+                # path stored it inside ``meta_json``; the SSE ``id:``
+                # line is the authoritative cursor.
+                event.pop("_row_id", None)
+                data = json.dumps(event, ensure_ascii=False)
+                yield (
+                    f"id: {row_id}\nevent: message\ndata: {data}\n\n"
+                ).encode("utf-8")
+                mark_delivered([row_id])
+
             while True:
                 if await request.is_disconnected():
                     return
                 event = await queue.get()
+                # The publish path stamps the persisted row id onto
+                # the envelope as ``_row_id`` (see
+                # :func:`node_message_send`). We surface it as the SSE
+                # ``id:`` line and mark the row delivered.
+                row_id = event.pop("_row_id", None)
                 data = json.dumps(event, ensure_ascii=False)
-                yield f"event: message\ndata: {data}\n\n".encode("utf-8")
+                if row_id is not None:
+                    yield (
+                        f"id: {row_id}\nevent: message\ndata: {data}\n\n"
+                    ).encode("utf-8")
+                    mark_delivered([int(row_id)])
+                else:
+                    # No row id means the event was injected by a
+                    # path that did NOT persist (future lifecycle
+                    # fan-out, ACL-reject notice, …). Deliver it but
+                    # skip the marker.
+                    yield f"event: message\ndata: {data}\n\n".encode("utf-8")
         finally:
             await broker.unsubscribe(name, queue)
 

--- a/tests/smoke/test_node_comms_e2e_http.py
+++ b/tests/smoke/test_node_comms_e2e_http.py
@@ -30,18 +30,18 @@ Six AAA-marked cases — one behaviour each (TQ):
 Substrate split
 ===============
 
-Today the substrate has two SSE-publish surfaces with non-overlapping
-feature sets:
-
-* ``sac listen`` (``_listen/server.py``) carries bearer auth + WI-2
-  ACL but does **not** persist or honour ``Last-Event-ID``.
-* ``a2a/_server.py`` (the sac-managed agent sidecar) carries WI-1
-  persistence + replay but has neither bearer auth nor the WI-2 ACL
-  gate.
-
-So cases (a)–(e) drive ``sac listen`` (the only ACL surface) and case
-(f) drives ``a2a/_server.py`` (the only replay surface). Unifying the
-two surfaces is an open follow-on WI.
+Historically the substrate had two SSE-publish surfaces with
+non-overlapping feature sets — ``sac listen`` carried bearer-auth +
+WI-2 ACL but no persistence, while ``a2a/_server.py`` carried
+WI-1 persistence + replay but no auth/ACL. The follow-on WI-1 finish-
+work has now unified them: ``_listen/server.py``'s
+``node_message_send`` persists every accepted publish to
+``channel_events`` and ``node_inbox_stream`` replays missed events on
+connect (honouring ``Last-Event-ID``). Cases (a)–(e) still drive
+``sac listen`` for the ACL semantics; case (f) drives the
+``a2a/_server.py`` surface for replay; new cases (g)–(i) drive WI-1
+durability through ``sac listen`` so the same acceptance criteria
+hold there.
 """
 
 from __future__ import annotations
@@ -468,4 +468,223 @@ def test_replay_on_reconnect_uses_last_event_id_to_resume_cursor(comms_env):
     # Assert — exactly e3 surfaces after the cursor.
     assert third_event.get("content") == "e3", (
         f"expected only e3 after Last-Event-ID={cursor_id}; got {third_event!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Case (g) — WI-1 finish-work: an event POSTed to ``sac listen`` with no
+# subscriber is delivered on the NEXT subscribe (fresh-replay path —
+# undelivered rows in ``channel_events``).
+#
+# This is the WI-1 acceptance "an event POSTed with no subscriber is
+# delivered on connect" applied to the ``_listen/server.py`` surface
+# (the WI-3 external-node substrate). Until the durability wiring landed
+# there, this publish was silently dropped — the exact failure mode the
+# handoff §0 hard rules forbid.
+# ---------------------------------------------------------------------------
+
+
+def test_listen_publish_with_no_subscriber_is_replayed_on_next_connect(comms_env):
+    """Publish first, subscribe second — the event must arrive.
+
+    Sequence:
+      1. POST alpha → beta with **no SSE subscriber attached** (the
+         ``Broker.publish`` fan-out returns ``delivered=0``).
+      2. Open beta's inbox stream — the WI-1 fresh-replay path yields
+         the missed event from ``channel_events`` (``delivered_at IS
+         NULL``).
+
+    Acceptance (handoff §4): "an event POSTed with no subscriber is
+    delivered on connect; … nothing is ever dropped silently."
+    """
+    # Arrange — siblings under one parent so default ACL allows the send.
+    db = comms_env["db"]
+    tokens = _set_up_two_groups(db)
+    app = create_app(token=tokens["host"], local_host="smoke-local")
+    port = _free_port()
+
+    async def driver() -> dict:
+        # Pre-subscriber publish.
+        async with httpx.AsyncClient(timeout=5.0) as ac:
+            resp = await ac.post(
+                f"http://127.0.0.1:{port}/agents/beta/message:send",
+                json=_send_payload("delayed delivery", from_agent="alpha"),
+                headers=_bearer(tokens["alpha"]),
+            )
+        if resp.status_code != 200:
+            raise RuntimeError(
+                f"precondition publish failed: {resp.status_code}: {resp.text!r}"
+            )
+
+        # Now subscribe — the WI-1 fresh-replay yields the missed event.
+        ready = asyncio.Event()
+        captured: dict = {}
+
+        async def consume() -> None:
+            captured["event"] = await _await_subscribed_and_read_one(
+                f"http://127.0.0.1:{port}/agents/beta/inbox/stream",
+                headers=_bearer(tokens["beta"]),
+                ready=ready,
+            )
+
+        sub = asyncio.create_task(consume())
+        try:
+            await asyncio.wait_for(sub, timeout=5.0)
+        finally:
+            if not sub.done():
+                sub.cancel()
+                with contextlib.suppress(BaseException):
+                    await sub
+        return captured.get("event", {})
+
+    # Act
+    with _run_loopback(app, port):
+        event = asyncio.run(driver())
+    # Assert
+    assert event.get("content") == "delayed delivery", (
+        f"WI-1 fresh-replay on _listen surface did not surface the missed "
+        f"pre-subscriber publish; got {event!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Case (h) — WI-1 finish-work: kill + reconnect with ``Last-Event-ID``
+# resumes the stream at the next undelivered row on the ``sac listen``
+# surface. Mirrors case (f) but against ``_listen/server.py`` rather
+# than ``a2a/_server.py``.
+# ---------------------------------------------------------------------------
+
+
+def test_listen_replay_on_reconnect_uses_last_event_id_to_resume_cursor(comms_env):
+    """Three publishes; subscribe, disconnect after #2, publish #3,
+    re-subscribe with ``Last-Event-ID = id(#2)`` → only #3 arrives.
+    """
+    # Arrange
+    db = comms_env["db"]
+    tokens = _set_up_two_groups(db)
+    app = create_app(token=tokens["host"], local_host="smoke-local")
+    port = _free_port()
+    url_send = f"http://127.0.0.1:{port}/agents/beta/message:send"
+    url_stream = f"http://127.0.0.1:{port}/agents/beta/inbox/stream"
+
+    async def consume_n(
+        url: str,
+        n: int,
+        *,
+        last_event_id: str | None = None,
+    ) -> list[tuple[str | None, dict]]:
+        seen: list[tuple[str | None, dict]] = []
+        cur_id: str | None = None
+        headers = dict(_bearer(tokens["beta"]))
+        if last_event_id is not None:
+            headers["Last-Event-ID"] = last_event_id
+        async with httpx.AsyncClient(timeout=5.0) as ac:
+            async with ac.stream("GET", url, headers=headers) as sse:
+                async for line in sse.aiter_lines():
+                    if line.startswith("id:"):
+                        cur_id = line[len("id:") :].strip()
+                        continue
+                    if line.startswith("data:"):
+                        seen.append(
+                            (
+                                cur_id,
+                                json.loads(line[len("data:") :].lstrip()),
+                            )
+                        )
+                        if len(seen) == n:
+                            return seen
+        raise AssertionError(
+            f"SSE {url!r} closed before {n} events (saw {len(seen)})"
+        )
+
+    async def driver() -> tuple[list[tuple[str | None, dict]], dict]:
+        # Two pre-subscriber publishes.
+        async with httpx.AsyncClient(timeout=5.0) as ac:
+            for i in (1, 2):
+                r = await ac.post(
+                    url_send,
+                    json=_send_payload(f"e{i}", from_agent="alpha"),
+                    headers=_bearer(tokens["alpha"]),
+                )
+                if r.status_code != 200:
+                    raise RuntimeError(
+                        f"precondition publish e{i} failed {r.status_code}: {r.text!r}"
+                    )
+        # First subscribe — replays e1 + e2; capture their SSE ids.
+        first_two = await consume_n(url_stream, 2)
+        # Third publish post-disconnect.
+        async with httpx.AsyncClient(timeout=5.0) as ac:
+            r3 = await ac.post(
+                url_send,
+                json=_send_payload("e3", from_agent="alpha"),
+                headers=_bearer(tokens["alpha"]),
+            )
+        if r3.status_code != 200:
+            raise RuntimeError(
+                f"precondition publish e3 failed {r3.status_code}: {r3.text!r}"
+            )
+        cursor = first_two[-1][0]
+        if cursor is None:
+            raise RuntimeError(
+                f"precondition: SSE id missing on replay frame: {first_two!r}"
+            )
+        # Reconnect with Last-Event-ID → expect ONLY e3.
+        post_cursor = await consume_n(url_stream, 1, last_event_id=cursor)
+        return first_two, post_cursor[0][1]
+
+    # Act
+    with _run_loopback(app, port):
+        first_two, third = asyncio.run(driver())
+
+    # Assert — replay frames carry e1/e2 contents in id order; the
+    # cursor resume yields only e3.
+    contents = [evt.get("content") for _id, evt in first_two]
+    assert contents == ["e1", "e2"], f"replay order wrong: {contents!r}"
+    assert third.get("content") == "e3", (
+        f"expected only e3 after Last-Event-ID; got {third!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Case (i) — WI-1 finish-work: a DENIED publish must NOT persist to
+# ``channel_events``. Denial is the policy working (handoff §0): it
+# returns 403 to the sender and leaves zero side-effects on the bus or
+# the durable store — otherwise a malicious / mis-permissioned sender
+# could pollute the recipient's inbox by triggering the persist path.
+# ---------------------------------------------------------------------------
+
+
+def test_listen_denied_send_does_not_persist_to_channel_events(comms_env):
+    """403'd cross-group send leaves ``channel_events`` empty for the target."""
+    # Arrange
+    import sqlite3
+
+    db = comms_env["db"]
+    tokens = _set_up_two_groups(db)
+    app = create_app(token=tokens["host"], local_host="smoke-local")
+    port = _free_port()
+
+    # Act — alpha (group A) attempts gamma (group B); no grant exists.
+    with _run_loopback(app, port):
+        with httpx.Client(timeout=5.0) as c:
+            resp = c.post(
+                f"http://127.0.0.1:{port}/agents/gamma/message:send",
+                json=_send_payload("forbidden", from_agent="alpha"),
+                headers=_bearer(tokens["alpha"]),
+            )
+    if resp.status_code != 403:
+        raise RuntimeError(
+            f"precondition: expected 403, got {resp.status_code}: {resp.text!r}"
+        )
+
+    # Assert — no channel_events row materialised for the denied target.
+    with sqlite3.connect(db) as conn:
+        cur = conn.execute(
+            "SELECT COUNT(*) FROM channel_events WHERE target = ?",
+            ("gamma",),
+        )
+        n = int(cur.fetchone()[0])
+    assert n == 0, (
+        f"denied send must not persist; channel_events has {n} row(s) "
+        "for target=gamma"
     )

--- a/tests/smoke/test_node_comms_e2e_http.py
+++ b/tests/smoke/test_node_comms_e2e_http.py
@@ -14,7 +14,7 @@ same ``sac listen`` — lives in ``test_node_comms_e2e_mcp.py``. Shared
 bring-up helpers live in ``_node_comms.py``; shared fixtures
 (``comms_env`` / ``disk_tmp``) live in ``conftest.py``.
 
-Six AAA-marked cases — one behaviour each (TQ):
+AAA-marked cases — one behaviour each (TQ):
 
 * (a) Same-group send (alpha → beta, both children of parent_a).
 * (b) Cross-group deny (alpha groupA → gamma groupB) — 403 + reason.
@@ -26,6 +26,14 @@ Six AAA-marked cases — one behaviour each (TQ):
   gamma, zeta); every sibling→sibling pair allowed by default.
 * (f) Replay-on-reconnect — emit with no subscriber, reconnect,
   receive via ``Last-Event-ID``.
+* (g) Fresh-replay on the ``sac listen`` surface — a single
+  pre-subscriber publish surfaces on first connect.
+* (h.1) Listen-surface replay order — two pre-subscriber publishes
+  arrive in id order on first connect.
+* (h.2) Listen-surface cursor resume — ``Last-Event-ID`` =
+  id(previous) yields only the post-cursor publish.
+* (i) Listen-surface denied send leaves ``channel_events`` empty —
+  denial is the policy working (handoff §0).
 
 Substrate split
 ===============
@@ -552,30 +560,39 @@ def test_listen_publish_with_no_subscriber_is_replayed_on_next_connect(comms_env
 # resumes the stream at the next undelivered row on the ``sac listen``
 # surface. Mirrors case (f) but against ``_listen/server.py`` rather
 # than ``a2a/_server.py``.
+#
+# Split into two TQ007-clean tests, one behaviour each:
+#
+#   (h.1) ``test_listen_replay_on_reconnect_replays_pre_subscribe_events_in_id_order``
+#         — pre-subscriber publishes are replayed in insertion (id)
+#         order on first connect. Validates the *replay* half of the
+#         durability contract.
+#
+#   (h.2) ``test_listen_replay_on_reconnect_resumes_only_post_cursor_event_with_last_event_id``
+#         — after disconnect + a fresh publish, reconnecting with
+#         ``Last-Event-ID`` = the previously-seen id yields **only**
+#         the post-cursor event. Validates the *cursor resume* half.
 # ---------------------------------------------------------------------------
 
 
-def test_listen_replay_on_reconnect_uses_last_event_id_to_resume_cursor(comms_env):
-    """Three publishes; subscribe, disconnect after #2, publish #3,
-    re-subscribe with ``Last-Event-ID = id(#2)`` → only #3 arrives.
-    """
-    # Arrange
-    db = comms_env["db"]
-    tokens = _set_up_two_groups(db)
-    app = create_app(token=tokens["host"], local_host="smoke-local")
-    port = _free_port()
-    url_send = f"http://127.0.0.1:{port}/agents/beta/message:send"
-    url_stream = f"http://127.0.0.1:{port}/agents/beta/inbox/stream"
+def _consume_sse_n(
+    url: str,
+    n: int,
+    *,
+    bearer: dict[str, str],
+    last_event_id: str | None = None,
+) -> "asyncio.coroutines.Coroutine[None, None, list[tuple[str | None, dict]]]":
+    """Open an SSE stream and return the first ``n`` ``data:`` events
+    paired with the most recent ``id:`` line that preceded each.
 
-    async def consume_n(
-        url: str,
-        n: int,
-        *,
-        last_event_id: str | None = None,
-    ) -> list[tuple[str | None, dict]]:
+    Lifted to a module helper so cases (h.1) and (h.2) share one
+    implementation without coupling their assertions.
+    """
+
+    async def _run() -> list[tuple[str | None, dict]]:
         seen: list[tuple[str | None, dict]] = []
         cur_id: str | None = None
-        headers = dict(_bearer(tokens["beta"]))
+        headers = dict(bearer)
         if last_event_id is not None:
             headers["Last-Event-ID"] = last_event_id
         async with httpx.AsyncClient(timeout=5.0) as ac:
@@ -597,7 +614,24 @@ def test_listen_replay_on_reconnect_uses_last_event_id_to_resume_cursor(comms_en
             f"SSE {url!r} closed before {n} events (saw {len(seen)})"
         )
 
-    async def driver() -> tuple[list[tuple[str | None, dict]], dict]:
+    return _run()
+
+
+def test_listen_replay_on_reconnect_replays_pre_subscribe_events_in_id_order(comms_env):
+    """Two pre-subscriber publishes are replayed in id order on first connect.
+
+    Isolates the *replay-order* half of case (h). The cursor-resume
+    half lives in the sister test below.
+    """
+    # Arrange
+    db = comms_env["db"]
+    tokens = _set_up_two_groups(db)
+    app = create_app(token=tokens["host"], local_host="smoke-local")
+    port = _free_port()
+    url_send = f"http://127.0.0.1:{port}/agents/beta/message:send"
+    url_stream = f"http://127.0.0.1:{port}/agents/beta/inbox/stream"
+
+    async def driver() -> list[str]:
         # Two pre-subscriber publishes.
         async with httpx.AsyncClient(timeout=5.0) as ac:
             for i in (1, 2):
@@ -610,8 +644,59 @@ def test_listen_replay_on_reconnect_uses_last_event_id_to_resume_cursor(comms_en
                     raise RuntimeError(
                         f"precondition publish e{i} failed {r.status_code}: {r.text!r}"
                     )
-        # First subscribe — replays e1 + e2; capture their SSE ids.
-        first_two = await consume_n(url_stream, 2)
+        # First subscribe — replays e1 + e2; surface their contents in
+        # arrival order so the assertion can compare on order alone.
+        frames = await _consume_sse_n(
+            url_stream, 2, bearer=_bearer(tokens["beta"])
+        )
+        return [evt.get("content") for _id, evt in frames]
+
+    # Act
+    with _run_loopback(app, port):
+        contents = asyncio.run(driver())
+    # Assert
+    assert contents == ["e1", "e2"], f"replay order wrong: {contents!r}"
+
+
+def test_listen_replay_on_reconnect_resumes_only_post_cursor_event_with_last_event_id(
+    comms_env,
+):
+    """Three publishes; subscribe + disconnect after #2, publish #3,
+    re-subscribe with ``Last-Event-ID = id(#2)`` → only #3 arrives.
+    """
+    # Arrange
+    db = comms_env["db"]
+    tokens = _set_up_two_groups(db)
+    app = create_app(token=tokens["host"], local_host="smoke-local")
+    port = _free_port()
+    url_send = f"http://127.0.0.1:{port}/agents/beta/message:send"
+    url_stream = f"http://127.0.0.1:{port}/agents/beta/inbox/stream"
+
+    async def driver() -> dict:
+        # Two pre-subscriber publishes.
+        async with httpx.AsyncClient(timeout=5.0) as ac:
+            for i in (1, 2):
+                r = await ac.post(
+                    url_send,
+                    json=_send_payload(f"e{i}", from_agent="alpha"),
+                    headers=_bearer(tokens["alpha"]),
+                )
+                if r.status_code != 200:
+                    raise RuntimeError(
+                        f"precondition publish e{i} failed {r.status_code}: {r.text!r}"
+                    )
+        # First subscribe — replays e1 + e2; capture the trailing id as
+        # the resume cursor. The *order* of these frames is covered as
+        # primary behaviour by the sister test above, so a wrong order
+        # here is a precondition failure, not the assertion under test.
+        first_two = await _consume_sse_n(
+            url_stream, 2, bearer=_bearer(tokens["beta"])
+        )
+        first_contents = [evt.get("content") for _id, evt in first_two]
+        if first_contents != ["e1", "e2"]:
+            raise RuntimeError(
+                f"precondition: replay order wrong: {first_contents!r}"
+            )
         # Third publish post-disconnect.
         async with httpx.AsyncClient(timeout=5.0) as ac:
             r3 = await ac.post(
@@ -629,17 +714,18 @@ def test_listen_replay_on_reconnect_uses_last_event_id_to_resume_cursor(comms_en
                 f"precondition: SSE id missing on replay frame: {first_two!r}"
             )
         # Reconnect with Last-Event-ID → expect ONLY e3.
-        post_cursor = await consume_n(url_stream, 1, last_event_id=cursor)
-        return first_two, post_cursor[0][1]
+        post_cursor = await _consume_sse_n(
+            url_stream,
+            1,
+            bearer=_bearer(tokens["beta"]),
+            last_event_id=cursor,
+        )
+        return post_cursor[0][1]
 
     # Act
     with _run_loopback(app, port):
-        first_two, third = asyncio.run(driver())
-
-    # Assert — replay frames carry e1/e2 contents in id order; the
-    # cursor resume yields only e3.
-    contents = [evt.get("content") for _id, evt in first_two]
-    assert contents == ["e1", "e2"], f"replay order wrong: {contents!r}"
+        third = asyncio.run(driver())
+    # Assert
     assert third.get("content") == "e3", (
         f"expected only e3 after Last-Event-ID; got {third!r}"
     )


### PR DESCRIPTION
## Summary

WI-1 originally landed durability + ``Last-Event-ID`` replay on the
``a2a/_server.py`` agent-sidecar surface (PR #126). The ``sac listen``
control-plane (``_listen/server.py``) — the external-node surface
added by WI-3 (PR #125) — still dropped pre-subscribe publishes
silently, violating the WI-1 acceptance "nothing is ever dropped
silently" on that surface. This PR finishes the WI-1 acceptance on
both publish surfaces.

- ``node_message_send`` persists every accepted publish to
  ``channel_events`` BEFORE fan-out and stamps the row id onto the
  envelope as ``_row_id`` so the stream handler surfaces it as the
  SSE ``id:`` cursor.
- ``node_inbox_stream`` honours ``Last-Event-ID`` (replay rows with
  ``id > cursor``) and, fresh-subscriber, replays every undelivered
  row. A malformed ``Last-Event-ID`` is a loud 400.
- A denied publish (cross-group, no ACL grant) returns 403 BEFORE
  the persist path — ``channel_events`` stays empty for the denied
  target. Denial is the policy working.

## Test plan

- [x] ``tests/smoke/test_node_comms_e2e_http.py`` — all 10 cases pass,
      including three new TDD cases (g/h/i) for the listen surface
      (real Broker, real SQLite, real SSE).
- [x] Full ``tests/smoke/`` (31 cases) passes.
- [x] No new audit-cli / project-structure violations.