### PR TITLE
feat(runtime): mirror to_home into relaxed apptainer $HOME + explicit --settings load

### DIFF
--- a/src/scitex_agent_container/_skills/scitex-agent-container/25_claude-setup-delivery.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/25_claude-setup-delivery.md
@@ -46,6 +46,27 @@ materialized copy is wrong:
 Both are acceptable mechanisms, but `to_home` is the first choice; reach for a
 `ro`-bind only for secrets or shared-live trees.
 
+### Placement default vs override precedence (two different axes)
+
+Two principles that sound similar but govern different things — they coexist:
+
+- **Placement default (`to_home`-first):** where you *put* a setup. Default to
+  `to_home`.
+- **Override precedence (when the same key is declared in several layers, which
+  wins):**
+
+  ```
+  direct command arguments  >  spec.yaml fields  >  to_home/<files>
+  ```
+
+  `to_home` is the **base** (declared defaults); `spec.yaml` fields override it;
+  explicit command arguments / `raw_args` are the final override. This mirrors
+  Claude's own settings precedence (user < project < flag). So: declare the
+  baseline in `to_home`, and use `spec`/args only as escape hatches to override
+  a specific value without editing the `to_home` base. (Implementing this
+  cleanly requires the runtime to merge the layers and resolve overrides —
+  today `spec.raw_args` and `to_home` are still separate surfaces.)
+
 ## The `to_home` 1:1 mirror (general, not just `.claude`)
 
 `<spec_dir>/to_home/` mirrors the container `$HOME` **1:1**. Every path under

--- a/src/scitex_agent_container/_skills/scitex-agent-container/25_claude-setup-delivery.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/25_claude-setup-delivery.md
@@ -7,11 +7,22 @@ tags: [scitex-agent-container-claude-setup-delivery]
 
 # Claude setup delivery into apptainer agents
 
-SAC runs each agent's Claude session **inside** an apptainer container. The
-guiding principle is the `claude --bare` philosophy: SAC never auto-discovers
-the host operator's `~/.claude`. Every piece of Claude setup — settings,
-hooks, MCP config, credentials, CLAUDE.md, `.bashrc`, `.env` — is passed
-**explicitly** so a run is reproducible on any host (machine-independence).
+## Core doctrine — the definition files are the single source of truth
+
+**To understand or reproduce an agent you should only ever need to read its
+definition: the `spec.yaml` plus its `to_home/`. Never the host machine.**
+Nothing about an agent is implicit or inherited from whatever box it happens
+to run on. This is *why* everything below exists — it is not a set of
+mechanisms first, it is this principle, enforced by mechanisms.
+
+SAC runs each agent's Claude session **inside** an apptainer container and
+never auto-discovers the host operator's `~/.claude` (the `claude --bare`
+philosophy). Every piece of Claude setup — settings, hooks, MCP config,
+credentials, CLAUDE.md, `.bashrc`, `.env` — is passed **explicitly**, declared
+in the agent's definition, so a run is identically reproducible on any host
+(machine-independence). If you find yourself reaching for host state to make
+an agent behave, that is the bug: put it in the definition (`to_home`/`spec`)
+and pass it explicitly.
 
 ## The `to_home` 1:1 mirror (general, not just `.claude`)
 

--- a/src/scitex_agent_container/_skills/scitex-agent-container/25_claude-setup-delivery.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/25_claude-setup-delivery.md
@@ -24,91 +24,48 @@ in the agent's definition, so a run is identically reproducible on any host
 an agent behave, that is the bug: put it in the definition (`to_home`/`spec`)
 and pass it explicitly.
 
-## `to_home`-first: the default placement, with a `ro`-bind exception
+## `to_home`-first: the default, with a `ro`-bind exception
 
 **Default everything to `to_home`.** The whole agent `$HOME` — `.env`,
-`.mcp.json`, `CLAUDE.md`, `.claude/hooks`, instructions, `.bashrc` — should be
-declared as `to_home` files and materialized into the container. `spec.yaml`
-should shrink toward *container wiring only* (image, overlay, runtime flags);
-the agent's *contents* live in `to_home`.
+`.mcp.json`, `CLAUDE.md`, `.claude/hooks`, instructions, `.bashrc` — is declared
+as `to_home` files; `spec.yaml` shrinks toward container wiring only. (Migration
+target: today's `raw_args: --env GIT_AUTHOR_*` → `to_home/.env`;
+`startup_prompts` → `to_home/CLAUDE.md`.) Why this beats stuffing config into
+`raw_args`: ordinary files (easy to handle), add a file to add a capability
+(easy to grow), self-contained (host-isolated), and **isomorphic to a normal
+`$HOME`** — standard tools and mental models apply with no special knowledge.
 
-Why `to_home`-first beats stuffing config into `raw_args`/`startup_prompts`:
+The **only** exception is read-only `bind`s, for two cases where a copy is wrong:
 
-1. **Easier to handle** — ordinary files, edited with ordinary tools.
-2. **Easier to grow** — add a capability by adding a file, no spec schema churn.
-3. **Host-isolated** — the tree is self-contained; nothing leaks in from the host.
-4. **Isomorphic to a normal `$HOME`** — it *is* just a home dir (`.bashrc`,
-   `.env`, `.ssh`, `.claude`), so standard conventions, tools, and mental
-   models apply directly. No special knowledge is needed to read, reason about,
-   or reproduce an agent. (Migration target: today's
-`raw_args: --env GIT_AUTHOR_*` move to `to_home/.env`; `startup_prompts` move
-to `to_home/CLAUDE.md`.)
+- **Host secrets** (`.ssh`, `.config/gh`, `.claude/.credentials.json`) — a copy
+  would commit secrets into the git-tracked `to_home`; a `ro`-bind keeps them out.
+- **Large shared, always-current trees** (`~/.claude/skills`) — a copy would
+  duplicate and go stale.
 
-The **only** exception is read-only `bind`s, used for two narrow cases where a
-materialized copy is wrong:
+### Placement vs precedence (two different axes)
 
-- **Host secrets** — `.ssh`, `.config/gh`, `.claude/.credentials.json`. A copy
-  would land secrets in the git-tracked `to_home` source; a `ro`-bind keeps
-  them out of git and always current.
-- **Large shared, always-current trees** — `~/.claude/skills`. A copy would
-  duplicate and go stale; a `ro`-bind shares the live host copy.
-
-Both are acceptable mechanisms, but `to_home` is the first choice; reach for a
-`ro`-bind only for secrets or shared-live trees.
-
-### Placement default vs override precedence (two different axes)
-
-Two principles that sound similar but govern different things — they coexist:
-
-- **Placement default (`to_home`-first):** where you *put* a setup. Default to
-  `to_home`.
-- **Override precedence (when the same key is declared in several layers, which
-  wins):**
-
-  ```
-  direct command arguments  >  spec.yaml fields  >  to_home/<files>
-  ```
-
-  `to_home` is the **base** (declared defaults); `spec.yaml` fields override it;
-  explicit command arguments / `raw_args` are the final override. This mirrors
-  Claude's own settings precedence (user < project < flag). So: declare the
-  baseline in `to_home`, and use `spec`/args only as escape hatches to override
-  a specific value without editing the `to_home` base. (Implementing this
-  cleanly requires the runtime to merge the layers and resolve overrides —
-  today `spec.raw_args` and `to_home` are still separate surfaces.)
+- **Placement (`to_home`-first):** *where* you put a setup. Default `to_home`.
+- **Precedence (which layer wins on conflict):**
+  `direct command args > spec.yaml fields > to_home/<files>`. `to_home` is the
+  base; `spec`/args are escape-hatch overrides (mirrors Claude's
+  `user < project < flag`). Clean layering still needs the runtime to merge +
+  resolve — today `spec.raw_args` and `to_home` are separate surfaces.
 
 ### Scope / non-goals
 
-SAC guarantees exactly this model: per-agent `to_home` + the `_base` shared
-baseline, with `ro`-binds for secrets and shared skills. That is the line.
-
-Bolder convenience patterns are *possible* through the raw escape hatches
-(`spec.apptainer.binds` / `raw_args`) but are explicitly **out of scope** — SAC
-neither designs for nor supports them, and they are the operator's own risk:
-
-- pooling a single **shared `to_home`** across many agents, or
-- binding the **host `$HOME` directly** into the container.
-
-Keeping these out of scope is deliberate — it avoids over-engineering and keeps
-the reproducibility guarantee crisp.
+SAC guarantees this model only: per-agent `to_home` + the `_base` baseline, with
+`ro`-binds for secrets/skills. Bolder patterns — a pooled **shared `to_home`**, or
+binding the **host `$HOME`** directly — are possible via raw escape hatches but
+are explicitly **out of scope** (operator's own risk). Keeps the guarantee crisp.
 
 ### The `ro`-bind reproducibility trade-off
 
-A `ro`-bind trades strict reproducibility for currency/sharing — worth being
-honest about:
-
-- **Secrets** (`.ssh`, `.config/gh`, `.credentials.json`): correctly *outside*
-  the reproducible artifact. You reproduce the *structure*; secret values are
-  injected at run time, never committed. This is standard and not a gap.
-- **Skills**: a real trade-off. The live `ro`-bind is always-current and shared
-  but **not pinned** — if the host's `~/.claude/skills` changes, the agent
-  changes, so the run is not byte-reproducible. For *strict* reproducibility you
-  would "chain everything": pin the skills to a version and materialize that
-  pinned snapshot into `to_home` (bringing it into the definition chain).
-
-So there are two postures: **default = `ro`-bind** (current, shared) and
-**strict-reproducible = pin skills into `to_home`**. Pick per agent; the default
-is currency.
+- **Secrets**: correctly *outside* the reproducible artifact — you reproduce the
+  structure; values are injected at run time. Not a gap.
+- **Skills**: a real trade-off. The live `ro`-bind is current but **not pinned**,
+  so a run isn't byte-reproducible. For *strict* reproducibility, pin skills to a
+  version and materialize that into `to_home` ("chain everything"). Default =
+  currency (`ro`-bind); strict = pinned `to_home`.
 
 ## The `to_home` 1:1 mirror (general, not just `.claude`)
 
@@ -226,13 +183,3 @@ at a missing file). The hook `command`s inside `settings.local.json` use
 `$HOME/.claude/hooks/...`, so they resolve in-container regardless of what
 `$HOME` is — both the workspace-home bind and the overlay upper home put the
 hook scripts at exactly that path.
-
-## Summary
-
-1. `to_home/` = a general 1:1 `$HOME` mirror.
-2. Hardened mode: delivered via the workspace-home bind. Relaxed
-   `--home`/`--overlay` mode: delivered into `<overlay>/upper/<home>/` so the
-   tree is part of the container filesystem and the skills bind layers on top.
-3. `setting_sources=[]` (machine-independence) + explicit `--settings`,
-   `--mcp-config`, and the auth-layer credentials bind. No host `~/.claude`
-   auto-discovery, ever.

--- a/src/scitex_agent_container/_skills/scitex-agent-container/25_claude-setup-delivery.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/25_claude-setup-delivery.md
@@ -1,0 +1,141 @@
+---
+description: |
+  [TOPIC] scitex-agent-container — how sac passes Claude setup explicitly into apptainer agents for reproducibility
+  [DETAILS] The to_home → container $HOME 1:1 mirror (general, not just .claude), overlay/--home delivery for relaxed specs, explicit --settings hook load, setting_sources=[] for machine-independence (no host ~/.claude auto-discovery), and the credentials/MCP/hooks loading model (credentials via auth layer, MCP via --mcp-config, hooks via --settings).
+tags: [scitex-agent-container-claude-setup-delivery]
+---
+
+# Claude setup delivery into apptainer agents
+
+SAC runs each agent's Claude session **inside** an apptainer container. The
+guiding principle is the `claude --bare` philosophy: SAC never auto-discovers
+the host operator's `~/.claude`. Every piece of Claude setup — settings,
+hooks, MCP config, credentials, CLAUDE.md, `.bashrc`, `.env` — is passed
+**explicitly** so a run is reproducible on any host (machine-independence).
+
+## The `to_home` 1:1 mirror (general, not just `.claude`)
+
+`<spec_dir>/to_home/` mirrors the container `$HOME` **1:1**. Every path under
+`to_home/` lands at the same relative path under the container `$HOME`:
+
+```
+agents/<name>/to_home/
+  .bashrc            → $HOME/.bashrc
+  .env               → $HOME/.env            (chmod 0600)
+  .mcp.json          → $HOME/.mcp.json
+  CLAUDE.md          → $HOME/CLAUDE.md        (marker-protected)
+  .claude/
+    CLAUDE.md        → $HOME/.claude/CLAUDE.md (marker-protected)
+    settings.local.json
+    hooks/
+    skills/          (usually a separate read-only bind, see below)
+```
+
+A shared baseline (`<agents_dir>/_base/to_home/`, or `$SAC_TO_HOME_BASELINE`)
+is applied first; the per-agent `to_home/` overlays on top (per-agent wins).
+See `runtimes/_to_home.py` and ADR-0006 for the per-entry semantics. **This
+is general** — `to_home` is not a `.claude` delivery mechanism, it is a `$HOME`
+delivery mechanism.
+
+## Two delivery paths into the container `$HOME`
+
+Where the materialized tree must physically land depends on how the container
+gets its `$HOME`.
+
+### Hardened mode — workspace-home bind
+
+By default the apptainer runtime binds the host workspace home at the
+container `$HOME`:
+
+```
+--bind <runtime/<name>/home/>:/home/agent
+```
+
+`deploy_to_home(config, <workspace_home>)` materializes the tree into
+`runtime/<name>/home/`, and the bind makes it visible at `/home/agent`. Done.
+
+### Relaxed mode — overlay upper home
+
+Relaxed specs (`apptainer.relaxed: true`) opt out of the hardened auto-flags
+and declare their own `raw_args`, typically:
+
+```yaml
+raw_args:
+  - --containall
+  - --home
+  - /home/agent
+  - --overlay
+  - .../containers/overlays/<name>/      # a DIRECTORY overlay
+```
+
+Under this combo the operator-declared `--home /home/agent` is satisfied by
+the **overlay's upper layer**, not by the earlier workspace-home bind — so the
+workspace-home delivery is shadowed and the `to_home` tree never reaches the
+container `$HOME`.
+
+Fix (`runtimes/_to_home_overlay.py`): before launch, `deploy_to_home_overlay`
+materializes the **same** tree into the overlay's upper home —
+
+```
+<overlay>/upper/<container_home>/      e.g. <overlay>/upper/home/agent/
+```
+
+— so the whole tree is part of the container filesystem. The container `$HOME`
+is resolved from the spec's `--home` (defaulting to `/home/agent`), **never**
+from the host operator's environment. This applies only to **directory**
+overlays; `.img` loopback overlays are a no-op (they can't host an upper layer
+writable from the host), and such specs don't use the `--home`-override
+pattern anyway.
+
+### Why the skills bind is not shadowed
+
+Specs commonly bind skills read-only on top of `$HOME`:
+
+```yaml
+binds:
+  - /home/ywatanabe/.claude/skills:/home/agent/.claude/skills:ro
+```
+
+Writing `.claude/` (settings, hooks) into the overlay upper home is safe:
+apptainer bind mounts always win at their **exact** mount point, so the
+`/home/agent/.claude/skills` bind layers cleanly on top of the overlay's
+`.claude/` without being shadowed. This is precisely why overlay-write (not
+per-entry binds) is the chosen mechanism — a single `.claude` bind would
+shadow the skills sub-mount.
+
+## Loading model — credentials, MCP, hooks
+
+The SDK runner is started with `setting_sources=[]` (see
+`runtimes/_sdk_common.py::build_sdk_options`). This is **intentional and must
+not change**: the default would load the host's `~/.claude` state files
+(`state.json`, `projects/`, `settings.json`) and treat "no state" as
+not-logged-in even when credentials are mounted. Empty `setting_sources` means
+the explicitly-passed setup is the entire context — no host auto-discovery.
+
+Each surface is therefore loaded explicitly:
+
+| Surface       | Mechanism                                                              |
+|---------------|------------------------------------------------------------------------|
+| Credentials   | The auth layer (`provision_anthropic_auth`): `~/.claude/.credentials.json` is bind-mounted at `/tmp/sac-claude/`, `CLAUDE_CONFIG_DIR` points the SDK there; or `SAC_ANTHROPIC_API_KEY` bridged into `ANTHROPIC_API_KEY`. A bare host `ANTHROPIC_API_KEY` is never honoured. |
+| MCP servers   | `--mcp-config` — parsed from the workspace `.mcp.json` (materialized by sac from `spec.mcp_servers`) into `ClaudeAgentOptions.mcp_servers`. The `sac` channel sidecar is auto-registered for `channels: [server:sac]`. |
+| Hooks/settings| `--settings <path>` — `ClaudeAgentOptions.settings` is set to the in-container `$HOME/.claude/settings.local.json`. This is the SDK's "flag settings" layer, the highest-priority user-controlled layer, loaded **independently** of `setting_sources`. Without it, `setting_sources=[]` would never load the delivered settings. |
+
+### `--settings` and hook paths
+
+`build_sdk_options` resolves the settings path from the in-container `$HOME`
+(`$HOME/.claude/settings.local.json`) and sets `ClaudeAgentOptions.settings`
+only when the file is present (so a spec without one doesn't aim `--settings`
+at a missing file). The hook `command`s inside `settings.local.json` use
+`$HOME/.claude/hooks/...`, so they resolve in-container regardless of what
+`$HOME` is — both the workspace-home bind and the overlay upper home put the
+hook scripts at exactly that path.
+
+## Summary
+
+1. `to_home/` = a general 1:1 `$HOME` mirror.
+2. Hardened mode: delivered via the workspace-home bind. Relaxed
+   `--home`/`--overlay` mode: delivered into `<overlay>/upper/<home>/` so the
+   tree is part of the container filesystem and the skills bind layers on top.
+3. `setting_sources=[]` (machine-independence) + explicit `--settings`,
+   `--mcp-config`, and the auth-layer credentials bind. No host `~/.claude`
+   auto-discovery, ever.

--- a/src/scitex_agent_container/_skills/scitex-agent-container/25_claude-setup-delivery.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/25_claude-setup-delivery.md
@@ -77,6 +77,39 @@ Two principles that sound similar but govern different things — they coexist:
   cleanly requires the runtime to merge the layers and resolve overrides —
   today `spec.raw_args` and `to_home` are still separate surfaces.)
 
+### Scope / non-goals
+
+SAC guarantees exactly this model: per-agent `to_home` + the `_base` shared
+baseline, with `ro`-binds for secrets and shared skills. That is the line.
+
+Bolder convenience patterns are *possible* through the raw escape hatches
+(`spec.apptainer.binds` / `raw_args`) but are explicitly **out of scope** — SAC
+neither designs for nor supports them, and they are the operator's own risk:
+
+- pooling a single **shared `to_home`** across many agents, or
+- binding the **host `$HOME` directly** into the container.
+
+Keeping these out of scope is deliberate — it avoids over-engineering and keeps
+the reproducibility guarantee crisp.
+
+### The `ro`-bind reproducibility trade-off
+
+A `ro`-bind trades strict reproducibility for currency/sharing — worth being
+honest about:
+
+- **Secrets** (`.ssh`, `.config/gh`, `.credentials.json`): correctly *outside*
+  the reproducible artifact. You reproduce the *structure*; secret values are
+  injected at run time, never committed. This is standard and not a gap.
+- **Skills**: a real trade-off. The live `ro`-bind is always-current and shared
+  but **not pinned** — if the host's `~/.claude/skills` changes, the agent
+  changes, so the run is not byte-reproducible. For *strict* reproducibility you
+  would "chain everything": pin the skills to a version and materialize that
+  pinned snapshot into `to_home` (bringing it into the definition chain).
+
+So there are two postures: **default = `ro`-bind** (current, shared) and
+**strict-reproducible = pin skills into `to_home`**. Pick per agent; the default
+is currency.
+
 ## The `to_home` 1:1 mirror (general, not just `.claude`)
 
 `<spec_dir>/to_home/` mirrors the container `$HOME` **1:1**. Every path under

--- a/src/scitex_agent_container/_skills/scitex-agent-container/25_claude-setup-delivery.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/25_claude-setup-delivery.md
@@ -30,7 +30,17 @@ and pass it explicitly.
 `.mcp.json`, `CLAUDE.md`, `.claude/hooks`, instructions, `.bashrc` — should be
 declared as `to_home` files and materialized into the container. `spec.yaml`
 should shrink toward *container wiring only* (image, overlay, runtime flags);
-the agent's *contents* live in `to_home`. (Migration target: today's
+the agent's *contents* live in `to_home`.
+
+Why `to_home`-first beats stuffing config into `raw_args`/`startup_prompts`:
+
+1. **Easier to handle** — ordinary files, edited with ordinary tools.
+2. **Easier to grow** — add a capability by adding a file, no spec schema churn.
+3. **Host-isolated** — the tree is self-contained; nothing leaks in from the host.
+4. **Isomorphic to a normal `$HOME`** — it *is* just a home dir (`.bashrc`,
+   `.env`, `.ssh`, `.claude`), so standard conventions, tools, and mental
+   models apply directly. No special knowledge is needed to read, reason about,
+   or reproduce an agent. (Migration target: today's
 `raw_args: --env GIT_AUTHOR_*` move to `to_home/.env`; `startup_prompts` move
 to `to_home/CLAUDE.md`.)
 

--- a/src/scitex_agent_container/_skills/scitex-agent-container/25_claude-setup-delivery.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/25_claude-setup-delivery.md
@@ -24,6 +24,28 @@ in the agent's definition, so a run is identically reproducible on any host
 an agent behave, that is the bug: put it in the definition (`to_home`/`spec`)
 and pass it explicitly.
 
+## `to_home`-first: the default placement, with a `ro`-bind exception
+
+**Default everything to `to_home`.** The whole agent `$HOME` — `.env`,
+`.mcp.json`, `CLAUDE.md`, `.claude/hooks`, instructions, `.bashrc` — should be
+declared as `to_home` files and materialized into the container. `spec.yaml`
+should shrink toward *container wiring only* (image, overlay, runtime flags);
+the agent's *contents* live in `to_home`. (Migration target: today's
+`raw_args: --env GIT_AUTHOR_*` move to `to_home/.env`; `startup_prompts` move
+to `to_home/CLAUDE.md`.)
+
+The **only** exception is read-only `bind`s, used for two narrow cases where a
+materialized copy is wrong:
+
+- **Host secrets** — `.ssh`, `.config/gh`, `.claude/.credentials.json`. A copy
+  would land secrets in the git-tracked `to_home` source; a `ro`-bind keeps
+  them out of git and always current.
+- **Large shared, always-current trees** — `~/.claude/skills`. A copy would
+  duplicate and go stale; a `ro`-bind shares the live host copy.
+
+Both are acceptable mechanisms, but `to_home` is the first choice; reach for a
+`ro`-bind only for secrets or shared-live trees.
+
 ## The `to_home` 1:1 mirror (general, not just `.claude`)
 
 `<spec_dir>/to_home/` mirrors the container `$HOME` **1:1**. Every path under

--- a/src/scitex_agent_container/_skills/scitex-agent-container/SKILL.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/SKILL.md
@@ -67,6 +67,7 @@ rich non-agentic status surface.
 - [11_remote-deploy.md](11_remote-deploy.md) — SSH deployment, src files, venv
 - [12_wsl-connectivity.md](12_wsl-connectivity.md) — WSL connectivity notes
 - [24_image-build.md](24_image-build.md) — apptainer `.sif` build/rebuild, `@develop` pin, rebuild-to-ship runner/channel changes (gotcha)
+- [25_claude-setup-delivery.md](25_claude-setup-delivery.md) — how sac passes Claude setup explicitly into apptainer agents: `to_home`→`$HOME` 1:1 mirror, overlay/`--home` delivery, `--settings` hook load, `setting_sources=[]`
 
 ### Reference
 - [13_observability.md](13_observability.md) — `sac agent status` JSON contract

--- a/src/scitex_agent_container/runtimes/_sdk_common.py
+++ b/src/scitex_agent_container/runtimes/_sdk_common.py
@@ -93,6 +93,30 @@ def _cred_file_path() -> Path:
 
 _CRED_FILE = _cred_file_path()
 
+
+def _container_settings_path() -> str | None:
+    """Resolve the in-container ``settings.local.json`` path, or ``None``.
+
+    sac mirrors the agent's ``to_home`` tree (including
+    ``.claude/settings.local.json``) into the container ``$HOME`` — both via
+    the workspace-home bind (hardened mode) and via the overlay upper home
+    (relaxed ``--home``/``--overlay`` specs). The runner executes INSIDE the
+    container, so ``$HOME`` already points at ``/home/agent`` (or whatever
+    ``--home`` the spec set). We resolve the settings file against that
+    ``$HOME`` and return its path only when the file is present — so a spec
+    without a ``settings.local.json`` doesn't aim ``--settings`` at a missing
+    file.
+
+    The hook ``command``s inside that settings file use ``$HOME/.claude/...``,
+    so they resolve in-container regardless of what ``$HOME`` resolves to.
+    """
+    home = os.environ.get("HOME")
+    if not home:
+        return None
+    candidate = Path(home) / ".claude" / "settings.local.json"
+    return str(candidate) if candidate.is_file() else None
+
+
 # ---------------------------------------------------------------------------
 # Why we never honour a pre-set ANTHROPIC_API_KEY
 # ---------------------------------------------------------------------------
@@ -374,6 +398,22 @@ def build_sdk_options(
     # this way either, which is the right default for container-as-
     # boundary anyway.)
     kwargs.setdefault("setting_sources", [])
+    # Load hooks/settings explicitly via the SDK ``settings`` field
+    # (emits ``--settings <path>``). This is the "flag settings" layer —
+    # the highest-priority user-controlled layer — and loads INDEPENDENTLY
+    # of ``setting_sources``, which stays ``[]`` for machine-independence
+    # (no host ``~/.claude`` auto-discovery). sac delivers the agent's
+    # ``settings.local.json`` into the container ``$HOME/.claude/`` via the
+    # ``to_home`` mirror; without ``--settings`` the SDK would never load it
+    # (empty ``setting_sources`` skips the $HOME settings layer entirely).
+    #
+    # We resolve the path from the in-container ``$HOME`` (where the runner
+    # actually executes) and only set it when the file is present, so a
+    # spec without a settings.local.json doesn't point ``--settings`` at a
+    # missing file.
+    settings_path = _container_settings_path()
+    if settings_path is not None and "settings" not in kwargs:
+        kwargs["settings"] = settings_path
     # Pop sac-private keys from ``extra`` BEFORE merging into kwargs —
     # ClaudeAgentOptions is strict and rejects unknown fields. The
     # ``_*`` prefix marks these as sac-internal (not SDK fields).

--- a/src/scitex_agent_container/runtimes/_to_home_overlay.py
+++ b/src/scitex_agent_container/runtimes/_to_home_overlay.py
@@ -1,0 +1,159 @@
+"""Deliver the ``to_home`` tree into a relaxed apptainer overlay ``$HOME``.
+
+Companion to :mod:`_to_home`. The default apptainer path binds the host
+workspace home (``runtime/<name>/home/``) at the container ``$HOME`` via
+``--bind <workspace_home>:/home/agent``, so :func:`_to_home.deploy_to_home`
+writing into the workspace home is enough — the bind makes the tree visible.
+
+Relaxed specs (``apptainer.relaxed: true``) opt out of sac's hardened flags
+and instead declare their own ``raw_args`` — typically
+``--containall --home /home/agent --overlay <dir>``. Under that combo the
+operator-declared ``--home /home/agent`` sets a container HOME that is
+satisfied by the overlay's upper layer, NOT by the earlier workspace-home
+bind. The result: the materialized ``to_home`` tree never reaches the
+container ``$HOME`` — hooks/settings/.bashrc/etc. silently absent.
+
+Fix: materialize the SAME tree (1:1, all files — not just ``.claude``) into
+the overlay's upper directory at ``<overlay>/upper/<container_home>/`` BEFORE
+launch, so the whole tree is part of the container filesystem. The separate
+read-only skills bind (``/home/agent/.claude/skills``) then layers cleanly ON
+TOP at exec time — apptainer bind mounts always win at their exact mount
+point, so writing ``.claude/`` (settings, hooks) into the overlay does NOT
+shadow the skills sub-mount.
+
+Only directory-form overlays support an upper layer. ``.img`` overlays are
+loopback ext3 images we cannot write into from the host without mounting
+them, so this delivery is a no-op for them (the caller falls back to the
+workspace-home bind, which an ``.img`` overlay does not shadow because such
+specs are not the relaxed ``--home``-override pattern).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from ..config import AgentConfig
+from ._to_home import deploy_to_home
+
+logger = logging.getLogger(__name__)
+
+# Apptainer directory overlays keep the writable layer under ``upper/``
+# (sibling ``work/`` is scratch). See ``apptainer overlay create`` docs.
+_OVERLAY_UPPER_DIRNAME = "upper"
+
+# Canonical container HOME — matches the D5 preflight invariant and the
+# hardened-mode ``--home /home/agent`` default. Used when the spec's raw_args
+# do not declare an explicit ``--home``.
+DEFAULT_CONTAINER_HOME = "/home/agent"
+
+
+def resolve_container_home(config: AgentConfig) -> str:
+    """Resolve the in-container ``$HOME`` for ``config``.
+
+    Reads ``--home <path>`` from ``spec.apptainer.raw_args`` (operator's
+    explicit override under relaxed mode). Falls back to
+    :data:`DEFAULT_CONTAINER_HOME` — the canonical operator-independent HOME
+    that hardened mode auto-prepends.
+
+    Always returns an absolute POSIX path string; never reads the host
+    operator's environment (machine-independence).
+    """
+    ap = getattr(config, "apptainer", None)
+    raw = list(getattr(ap, "raw_args", None) or []) if ap is not None else []
+    for i, arg in enumerate(raw):
+        if arg == "--home" and i + 1 < len(raw):
+            val = str(raw[i + 1]).strip()
+            if val:
+                return val
+    return DEFAULT_CONTAINER_HOME
+
+
+def _resolve_overlay_dir(config: AgentConfig) -> Path | None:
+    """Resolve the apptainer overlay path to an absolute directory, or None.
+
+    Sources, in order:
+      1. ``spec.apptainer.overlay`` (the modeled field), or
+      2. ``--overlay <path>`` in ``spec.apptainer.raw_args`` (the escape
+         hatch the relaxed pattern uses).
+
+    Relative paths resolve against ``spec.workdir`` (matching
+    :meth:`ApptainerContainerRuntime.build_run_argv`). Returns ``None`` when
+    no overlay is declared, or when the declared overlay path exists but is
+    not a directory (e.g. an ``.img`` loopback image we cannot write into
+    from the host).
+    """
+    ap = getattr(config, "apptainer", None)
+    if ap is None:
+        return None
+    raw_overlay = (getattr(ap, "overlay", "") or "").strip()
+    if not raw_overlay:
+        raw = list(getattr(ap, "raw_args", None) or [])
+        for i, arg in enumerate(raw):
+            if arg == "--overlay" and i + 1 < len(raw):
+                raw_overlay = str(raw[i + 1]).strip()
+                break
+    if not raw_overlay:
+        return None
+    p = Path(raw_overlay).expanduser()
+    if not p.is_absolute():
+        workdir = getattr(config, "workdir", "") or ""
+        if not workdir:
+            return None
+        p = Path(workdir).expanduser() / p
+    # Directory-form overlay only. An existing path must be a dir; a
+    # not-yet-created path is treated as a dir (apptainer creates the
+    # upper/ tree on first launch — we pre-create it here).
+    if p.exists() and not p.is_dir():
+        return None
+    return p
+
+
+def resolve_overlay_upper_home(config: AgentConfig) -> Path | None:
+    """Resolve ``<overlay>/upper/<container_home>/`` for relaxed+overlay specs.
+
+    Returns the host-side directory where the ``to_home`` tree must be
+    materialized so it appears at the container ``$HOME``. Returns ``None``
+    when the spec is not the relaxed-directory-overlay pattern (no overlay,
+    or an ``.img`` overlay) — the caller then relies on the workspace-home
+    bind instead.
+
+    The container home (from :func:`resolve_container_home`) is an absolute
+    path like ``/home/agent``; its leading slash is stripped so it joins
+    under ``<overlay>/upper/``.
+    """
+    overlay_dir = _resolve_overlay_dir(config)
+    if overlay_dir is None:
+        return None
+    container_home = resolve_container_home(config).lstrip("/")
+    if not container_home:
+        return None
+    return overlay_dir / _OVERLAY_UPPER_DIRNAME / container_home
+
+
+def deploy_to_home_overlay(config: AgentConfig) -> Path | None:
+    """Materialize the ``to_home`` tree into the overlay upper home.
+
+    Resolves the destination via :func:`resolve_overlay_upper_home` and, when
+    applicable, runs the same two-pass overlay materialization
+    :func:`_to_home.deploy_to_home` performs (baseline first, per-agent on
+    top, 1:1 for every file — not just ``.claude``).
+
+    Returns the destination directory it wrote into, or ``None`` when the
+    spec is not a relaxed-directory-overlay spec (no-op).
+    """
+    dest = resolve_overlay_upper_home(config)
+    if dest is None:
+        return None
+    dest.mkdir(parents=True, exist_ok=True)
+    deploy_to_home(config, str(dest))
+    logger.info("to_home: mirrored into overlay upper home %s", dest)
+    return dest
+
+
+__all__ = [
+    "DEFAULT_CONTAINER_HOME",
+    "deploy_to_home_overlay",
+    "resolve_container_home",
+    "resolve_overlay_upper_home",
+]

--- a/src/scitex_agent_container/runtimes/claude_session.py
+++ b/src/scitex_agent_container/runtimes/claude_session.py
@@ -218,6 +218,14 @@ class ClaudeSessionRuntime(RuntimeBase):
         Path(home_dir).mkdir(parents=True, exist_ok=True)
         setup_claude_md(config, home_dir)
         _materialize_home_layouts(config, home_dir)
+        # Relaxed apptainer specs declare their own ``--home``/``--overlay``
+        # in raw_args; under that combo the workspace-home bind above is
+        # shadowed and the to_home tree never reaches the container $HOME.
+        # Mirror the same tree into the overlay's upper home so it lands as
+        # part of the container filesystem (no-op for non-overlay specs).
+        from ._to_home_overlay import deploy_to_home_overlay
+
+        deploy_to_home_overlay(config)
 
     def _cleanup_workspace(self, config: AgentConfig) -> None:
         """Remove the agent-container CLAUDE.md section on stop."""

--- a/tests/scitex_agent_container/runtimes/test__sdk_common.py
+++ b/tests/scitex_agent_container/runtimes/test__sdk_common.py
@@ -503,6 +503,65 @@ class TestBuildOptions:
 
 
 # ---------------------------------------------------------------------------
+# build_sdk_options — explicit --settings load (hooks/settings)
+#
+# setting_sources stays [] (machine-independence: no host ~/.claude
+# auto-discovery). The agent's settings.local.json is delivered into the
+# container $HOME/.claude/ via the to_home mirror; build_sdk_options must
+# point the SDK ``settings`` field (=> --settings, the highest-priority
+# flag-settings layer) at it so hooks load independently of setting_sources.
+# ---------------------------------------------------------------------------
+
+
+class TestSettingsFlag:
+    @pytest.fixture
+    def _opts_with_settings(self, sdk_env: _Env, tmp_path):
+        # Arrange — auth via cred file (no env mutation), and a container
+        # $HOME holding the delivered settings.local.json.
+        cred = tmp_path / ".credentials.json"
+        cred.write_text("{}")
+        sdk_env.setattr_module(_sdk_common, "_CRED_FILE", cred)
+        sdk_env.delenv("ANTHROPIC_API_KEY")
+        home = tmp_path / "home" / "agent"
+        (home / ".claude").mkdir(parents=True)
+        (home / ".claude" / "settings.local.json").write_text('{"hooks": {}}\n')
+        sdk_env.setenv("HOME", str(home))
+        _swap_registry(sdk_env, None)
+        # Act
+        opts = build_sdk_options("alpha")
+        return opts, home
+
+    def test_settings_points_at_container_home_settings(self, _opts_with_settings):
+        # Arrange
+        opts, home = _opts_with_settings
+        # Act
+        # Assert — the in-container path, derived from $HOME.
+        assert opts.settings == str(home / ".claude" / "settings.local.json")
+
+    def test_setting_sources_stays_empty(self, _opts_with_settings):
+        # Arrange — machine-independence invariant must NOT change.
+        opts, _ = _opts_with_settings
+        # Act
+        # Assert
+        assert opts.setting_sources == []
+
+    def test_no_settings_when_file_absent(self, sdk_env: _Env, tmp_path):
+        # Arrange — $HOME without a settings.local.json → no --settings.
+        cred = tmp_path / ".credentials.json"
+        cred.write_text("{}")
+        sdk_env.setattr_module(_sdk_common, "_CRED_FILE", cred)
+        sdk_env.delenv("ANTHROPIC_API_KEY")
+        empty_home = tmp_path / "empty_home"
+        empty_home.mkdir()
+        sdk_env.setenv("HOME", str(empty_home))
+        _swap_registry(sdk_env, None)
+        # Act
+        opts = build_sdk_options("alpha")
+        # Assert
+        assert opts.settings is None
+
+
+# ---------------------------------------------------------------------------
 # build_sdk_options — server:sac channel sidecar registration
 # ---------------------------------------------------------------------------
 

--- a/tests/scitex_agent_container/runtimes/test__to_home_overlay.py
+++ b/tests/scitex_agent_container/runtimes/test__to_home_overlay.py
@@ -1,0 +1,233 @@
+"""Tests for relaxed-overlay ``to_home`` delivery (:mod:`_to_home_overlay`).
+
+Relaxed apptainer specs declare ``--containall --home /home/agent
+--overlay <dir>`` in raw_args; under that combo the workspace-home bind is
+shadowed and the ``to_home`` tree must be mirrored into the overlay's upper
+home (``<overlay>/upper/<container_home>/``) so it reaches the container
+``$HOME``.
+
+PA-306 no-mocks: real ``AgentConfig`` + ``ApptainerSpec`` instances against
+``tmp_path`` real directories. No monkeypatching — the resolvers are pure.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container.config import AgentConfig
+from scitex_agent_container.config._types import ApptainerSpec
+from scitex_agent_container.runtimes._to_home_overlay import (
+    DEFAULT_CONTAINER_HOME,
+    deploy_to_home_overlay,
+    resolve_container_home,
+    resolve_overlay_upper_home,
+)
+
+# ---------------------------------------------------------------------------
+# Builders
+# ---------------------------------------------------------------------------
+
+
+def _relaxed_cfg(
+    tmp_path: Path,
+    *,
+    overlay_dir: Path | None = None,
+    container_home: str = "/home/agent",
+    seed_to_home: bool = True,
+) -> AgentConfig:
+    """Build a relaxed apptainer ``AgentConfig`` whose raw_args declare
+    ``--home <container_home> --overlay <overlay_dir>``, with a populated
+    ``to_home/`` next to spec.yaml.
+    """
+    agent_dir = tmp_path / "agent_def"
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    if seed_to_home:
+        th = agent_dir / "to_home"
+        (th / ".claude").mkdir(parents=True, exist_ok=True)
+        (th / ".claude" / "settings.local.json").write_text('{"hooks": {}}\n')
+        (th / ".bashrc").write_text("export FROM_TO_HOME=1\n")
+    if overlay_dir is None:
+        overlay_dir = tmp_path / "overlay"
+    raw_args = [
+        "--containall",
+        "--home",
+        container_home,
+        "--overlay",
+        str(overlay_dir),
+    ]
+    cfg = AgentConfig(name="relaxed-agent", runtime="apptainer", workdir=str(tmp_path))
+    cfg.config_path = str(agent_dir / "spec.yaml")
+    cfg.to_home = ""
+    cfg.apptainer = ApptainerSpec(relaxed=True, raw_args=raw_args)
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# resolve_container_home
+# ---------------------------------------------------------------------------
+
+
+class TestResolveContainerHome:
+    def test_reads_home_from_raw_args(self, tmp_path):
+        # Arrange
+        cfg = _relaxed_cfg(tmp_path, container_home="/home/agent")
+        # Act
+        # Assert
+        assert resolve_container_home(cfg) == "/home/agent"
+
+    def test_honours_non_default_home_override(self, tmp_path):
+        # Arrange
+        cfg = _relaxed_cfg(tmp_path, container_home="/home/custom")
+        # Act
+        # Assert
+        assert resolve_container_home(cfg) == "/home/custom"
+
+    def test_defaults_when_no_home_in_raw_args(self, tmp_path):
+        # Arrange — apptainer spec with no --home flag.
+        cfg = AgentConfig(name="a", runtime="apptainer", workdir=str(tmp_path))
+        cfg.apptainer = ApptainerSpec(raw_args=["--containall"])
+        # Act
+        # Assert
+        assert resolve_container_home(cfg) == DEFAULT_CONTAINER_HOME
+
+
+# ---------------------------------------------------------------------------
+# resolve_overlay_upper_home
+# ---------------------------------------------------------------------------
+
+
+class TestResolveOverlayUpperHome:
+    def test_joins_overlay_upper_and_container_home(self, tmp_path):
+        # Arrange
+        overlay = tmp_path / "ov"
+        cfg = _relaxed_cfg(tmp_path, overlay_dir=overlay, container_home="/home/agent")
+        # Act
+        dest = resolve_overlay_upper_home(cfg)
+        # Assert
+        assert dest == overlay / "upper" / "home" / "agent"
+
+    def test_reads_overlay_from_modeled_field(self, tmp_path):
+        # Arrange — overlay declared via the modeled spec.apptainer.overlay
+        # field rather than raw_args.
+        overlay = tmp_path / "ov2"
+        overlay.mkdir()
+        cfg = AgentConfig(name="a", runtime="apptainer", workdir=str(tmp_path))
+        cfg.apptainer = ApptainerSpec(
+            relaxed=True, overlay=str(overlay), raw_args=["--home", "/home/agent"]
+        )
+        # Act
+        dest = resolve_overlay_upper_home(cfg)
+        # Assert
+        assert dest == overlay / "upper" / "home" / "agent"
+
+    def test_returns_none_without_overlay(self, tmp_path):
+        # Arrange — no overlay declared anywhere.
+        cfg = AgentConfig(name="a", runtime="apptainer", workdir=str(tmp_path))
+        cfg.apptainer = ApptainerSpec(raw_args=["--home", "/home/agent"])
+        # Act
+        # Assert
+        assert resolve_overlay_upper_home(cfg) is None
+
+    def test_returns_none_for_img_overlay_file(self, tmp_path):
+        # Arrange — an .img loopback overlay (a file) cannot host an upper/.
+        img = tmp_path / "overlay.img"
+        img.write_bytes(b"\x00")
+        cfg = AgentConfig(name="a", runtime="apptainer", workdir=str(tmp_path))
+        cfg.apptainer = ApptainerSpec(
+            relaxed=True, raw_args=["--home", "/home/agent", "--overlay", str(img)]
+        )
+        # Act
+        # Assert
+        assert resolve_overlay_upper_home(cfg) is None
+
+    def test_relative_overlay_resolves_against_workdir(self, tmp_path):
+        # Arrange — relative --overlay path resolves against spec.workdir.
+        cfg = AgentConfig(name="a", runtime="apptainer", workdir=str(tmp_path))
+        cfg.apptainer = ApptainerSpec(
+            relaxed=True, raw_args=["--home", "/home/agent", "--overlay", "ov_rel"]
+        )
+        # Act
+        dest = resolve_overlay_upper_home(cfg)
+        # Assert
+        assert dest == tmp_path / "ov_rel" / "upper" / "home" / "agent"
+
+
+# ---------------------------------------------------------------------------
+# deploy_to_home_overlay — real file placement
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def deployed_overlay(tmp_path: Path) -> tuple[Path, Path]:
+    """Run a real overlay deploy once; return ``(overlay_dir, dest)``."""
+    overlay = tmp_path / "ov"
+    cfg = _relaxed_cfg(tmp_path, overlay_dir=overlay, container_home="/home/agent")
+    dest = deploy_to_home_overlay(cfg)
+    assert dest is not None
+    return overlay, dest
+
+
+class TestDeployToHomeOverlay:
+    def test_destination_is_overlay_upper_home(self, deployed_overlay):
+        # Arrange
+        overlay, dest = deployed_overlay
+        # Act
+        # Assert
+        assert dest == overlay / "upper" / "home" / "agent"
+
+    def test_non_claude_file_lands_one_to_one(self, deployed_overlay):
+        # Arrange — delivery is GENERAL: .bashrc, not just .claude.
+        _, dest = deployed_overlay
+        # Act
+        # Assert
+        assert (dest / ".bashrc").read_text() == "export FROM_TO_HOME=1\n"
+
+    def test_settings_file_lands_under_claude(self, deployed_overlay):
+        # Arrange
+        _, dest = deployed_overlay
+        # Act
+        # Assert
+        assert (dest / ".claude" / "settings.local.json").is_file()
+
+    def test_settings_relpath_matches_in_container_path(self, deployed_overlay):
+        # Arrange — relative path under upper must match the in-container
+        # /home/agent/.claude/settings.local.json the SDK loads via --settings.
+        overlay, dest = deployed_overlay
+        # Act
+        rel = (dest / ".claude" / "settings.local.json").relative_to(overlay / "upper")
+        # Assert
+        assert str(rel) == "home/agent/.claude/settings.local.json"
+
+    def test_creates_upper_home_dir_when_overlay_absent(self, tmp_path):
+        # Arrange — overlay dir doesn't exist yet (apptainer creates upper/
+        # on first launch; we pre-create it for the host-side write).
+        overlay = tmp_path / "fresh_overlay"
+        cfg = _relaxed_cfg(tmp_path, overlay_dir=overlay)
+        # Act
+        dest = deploy_to_home_overlay(cfg)
+        # Assert
+        assert dest.is_dir()
+
+    def test_writes_files_when_overlay_absent(self, tmp_path):
+        # Arrange
+        overlay = tmp_path / "fresh_overlay2"
+        cfg = _relaxed_cfg(tmp_path, overlay_dir=overlay)
+        # Act
+        dest = deploy_to_home_overlay(cfg)
+        # Assert
+        assert (dest / ".bashrc").is_file()
+
+    def test_noop_returns_none_for_non_overlay_spec(self, tmp_path):
+        # Arrange — relaxed spec but no overlay → workspace-home bind handles
+        # delivery; overlay path is a no-op.
+        cfg = AgentConfig(name="a", runtime="apptainer", workdir=str(tmp_path))
+        agent_dir = tmp_path / "agent_def"
+        (agent_dir / "to_home").mkdir(parents=True)
+        (agent_dir / "to_home" / ".bashrc").write_text("x\n")
+        cfg.config_path = str(agent_dir / "spec.yaml")
+        cfg.apptainer = ApptainerSpec(relaxed=True, raw_args=["--home", "/home/agent"])
+        # Act
+        # Assert
+        assert deploy_to_home_overlay(cfg) is None


### PR DESCRIPTION
## Problem

The relaxed apptainer agent pattern (`relaxed: true` + `--containall --home /home/agent --overlay <dir>` in `raw_args`) does not run its enforcement hooks. Two root causes:

1. Delivery gap: `deploy_to_home` materializes `to_home` into the runtime workspace home (`runtime/<name>/home/`), bound at `/home/agent`. But the operator-declared `--home /home/agent` is satisfied by the overlay's upper layer, shadowing that bind, so the tree never reaches the container `$HOME`.
2. Load gap: the runner sets `setting_sources=[]` (intentional, for machine-independence), so even a present `settings.local.json` would not load.

## Changes (one PR)

### 1. General overlay delivery (`runtimes/_to_home_overlay.py`)
Before launch, mirror the **entire** `to_home` tree (1:1, all files — not just `.claude`) into the overlay's upper home `<overlay>/upper/<container_home>/`, resolved from the spec's `--home` (default `/home/agent`). The tree becomes part of the container filesystem; the read-only skills bind (`/home/agent/.claude/skills`) layers cleanly on top (apptainer binds win at their exact mount point), so it is **not** shadowed. Directory overlays only; `.img` loopback overlays are a no-op (host can't write their upper layer). Wired into `ClaudeSessionRuntime._setup_workspace`.

Overlay-write was chosen over per-entry binds precisely because a single `.claude` bind would shadow the skills sub-mount.

### 2. Explicit `--settings` load (`runtimes/_sdk_common.build_sdk_options`)
Set `ClaudeAgentOptions.settings` to the in-container `$HOME/.claude/settings.local.json` (resolved from `$HOME` at runtime, only when present). This is the SDK "flag settings" layer — highest-priority, loaded **independently** of `setting_sources`. `setting_sources=[]` is unchanged (no host `~/.claude` auto-discovery). Hook commands inside the settings file use `$HOME/.claude/hooks/...`, so they resolve in-container.

### 3. Documentation
New skill page `_skills/scitex-agent-container/25_claude-setup-delivery.md`: the explicit Claude-setup delivery model — `to_home`→`$HOME` 1:1 mirror, overlay/`--home` delivery, `--settings` hook load, `setting_sources=[]`, and the credentials (auth layer) / MCP (`--mcp-config`) / hooks (`--settings`) loading model.

## Tests (TDD, no mocks, real fixtures)
- `tests/.../runtimes/test__to_home_overlay.py` — real `AgentConfig`/`ApptainerSpec` + real tmp dirs: container-home resolution, overlay-upper-home resolution (`.img` no-op, relative paths, modeled vs raw_args overlay), and overlay file placement (general tree, settings relpath matches the in-container path).
- `tests/.../runtimes/test__sdk_common.py::TestSettingsFlag` — `build_sdk_options` emits `settings=` pointing at the in-container path, and `setting_sources` stays `[]`; no `settings` when the file is absent.

50 new/affected tests pass. Full suite: 4647 passed, 38 skipped. The 2 remaining failures are pre-existing on `develop` and unrelated to this change (verified by running them on the clean main checkout): `test_audit.py` (FastMCP `list_tools` tooling-version drift) and `test_claude_session_channels_without_port_raises` (host-environment artifact — real credentials present, so the test reaches a real `query()` subprocess instead of the expected `SDKCommonError`).
