### PR TITLE
docs: fix skills index/README/RTD issues found in audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 
 | # | Problem                                                     | Solution                                                                                                                                      |
 |---|-------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
-| 1 | Scripting an agentic workflow is hard.                      | `scitex-agent-container` (`sac`) declares the agent as a **single YAML file** ([`spec.yaml`](#yaml-spec-reference-v3)).                                                  |
+| 1 | Scripting an agentic workflow is hard.                      | `scitex-agent-container` (`sac`) declares the agent as a **single YAML file** ([`spec.yaml`](docs/spec-reference.md)).                                                  |
 | 2 | Subagents don't scale across hosts, projects, and contexts. | `sac` lets agents spawn **full agents** on local AND **remote hosts**.                                                                        |
 | 3 | Controlling agent permissions is difficult.                 | `sac` runs every agent **inside Apptainer** — full mount/env/security options exposed in `spec.yaml`.                                         |
 | 4 | Supporting the A2A protocol by hand is time-consuming.      | `sac` needs just one YAML field (`spec.a2a.port`).                                                                                            |
@@ -193,7 +193,7 @@ sac image status                          # unified dashboard
 sac image snapshot [-o env.json]          # reproducibility capsule
 
 # Account / quota
-sac account list / save / delete / switch / watch-quota
+sac accounts list / save / delete / switch / watch-quota
 
 # Network / peers
 sac host list / add / remove / set / probe / exec / validate

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -59,16 +59,16 @@ Quick Example
 .. code-block:: bash
 
     # Create and launch an agent from YAML definition
-    scitex-agent-container start my-agent.yaml
+    sac agents start my-agent
 
-    # List running agents
-    scitex-agent-container list
+    # List agents and their status
+    sac agents list
 
-    # Inspect live pane state / rich status
-    scitex-agent-container show-status my-agent --json
+    # Inspect status as JSON
+    sac agents list --json
 
     # Stop an agent
-    scitex-agent-container stop my-agent
+    sac agents stop my-agent
 
 Indices and tables
 ==================

--- a/docs/sphinx/quickstart.rst
+++ b/docs/sphinx/quickstart.rst
@@ -8,33 +8,33 @@ Quickstart
     pip install scitex-agent-container
 
    The fastest path is to copy a pattern template from
-   ``examples/agent-templates/`` (``local``, ``docker``, ``apptainer``, ``ssh``,
-   ``ssh-slurm``, ``mcp``). See :doc:`templates` for the full matrix.
+   ``examples/agents/`` (``hello-agent``, ``minimal-agent``,
+   ``full-agent``, ``proxy-agent``). See :doc:`templates` for details.
 
-2. Create an agent definition directory with a YAML manifest plus
-   sibling ``src_CLAUDE.md`` and ``src_mcp.json``:
+2. Create an agent definition directory with a ``spec.yaml`` manifest
+   plus an optional ``dot_claude/`` sibling (CLAUDE.md / .mcp.json / ...):
 
 .. code-block:: yaml
 
-    # my-agent/my-agent.yaml
-    apiVersion: scitex-agent-container/v2
+    # ~/.scitex/agent-container/agents/my-agent/spec.yaml
+    apiVersion: scitex-agent-container/v3
     kind: Agent
     metadata:
-      name: my-agent
       labels:
         role: worker
     spec:
-      runtime: claude-code
-      model: sonnet
-      multiplexer: tmux
+      runtime: apptainer
+      apptainer:
+        image: ~/.scitex/agent-container/containers/sac-base.sif
       claude:
+        model: sonnet
         flags:
           - --dangerously-skip-permissions
         session: continue-or-new
       health:
         enabled: true
         interval: 60
-        method: multiplexer-alive
+        method: sdk-alive
       restart:
         policy: on-failure
         max_retries: 3
@@ -43,28 +43,12 @@ Quickstart
 
 .. code-block:: bash
 
-    scitex-agent-container start my-agent/my-agent.yaml
-    scitex-agent-container inspect my-agent
-    scitex-agent-container show-status my-agent --json
-    scitex-agent-container show-logs my-agent -n 100
-    scitex-agent-container attach my-agent      # Ctrl-B D to detach (tmux)
+    sac agents start my-agent
+    sac agents list my-agent --json
+    sac agents tail my-agent
+    sac agents recall my-agent
 
-4. (Optional) Wire Claude Code hooks so ``status --json`` can surface
+4. (Optional) Wire Claude Code hooks so ``list --json`` can surface
    recent tool calls, prompts, and sub-agent launches. See
    :doc:`status_and_hooks` for the full ``.claude/settings.local.json``
    snippet.
-
-5. Run your first pane action. The nonce probe types
-   ``Repeat <nonce>`` into the pane and confirms the model echoes it
-   back -- a true functional-liveness check, not just "process alive":
-
-.. code-block:: bash
-
-    scitex-agent-container actions run nonce-probe my-agent
-    scitex-agent-container actions query --agent my-agent --limit 5
-    scitex-agent-container actions stats --agent my-agent --since 1h
-
-   Every attempt is recorded in ``~/.scitex/agent-container/actions.db``
-   and the most recent one is reflected in ``status --json`` under
-   ``last_action_at`` / ``last_action_name`` / ``last_action_outcome``.
-   See :doc:`actions` for the full subsystem.

--- a/docs/sphinx/status_and_hooks.rst
+++ b/docs/sphinx/status_and_hooks.rst
@@ -9,14 +9,14 @@ agent itself.
 Rich Status
 -----------
 
-``scitex-agent-container show-status <name> --json`` emits a dict suitable
+``sac agents list <name> --json`` emits a dict suitable
 for dashboards or fleet monitors. It merges the registry entry with
 fields collected by ``agent_meta.collect_rich()`` and
 ``event_log.summarize()``.
 
 .. code-block:: bash
 
-    scitex-agent-container show-status my-agent --json
+    sac agents list my-agent --json
 
 Selected fields:
 
@@ -145,7 +145,7 @@ orchestrator (scitex-orochi, a custom hub, etc.). ``status --json``
 emits a self-describing dict; consumers wrap it themselves. For
 example, scitex-orochi's ``heartbeat-push`` command:
 
-1. Shells out to ``scitex-agent-container show-status <name> --json``.
+1. Shells out to ``sac agents list <name> --json``.
 2. Reshapes the payload into its own hub schema.
 3. POSTs to its ``/api/agents/register/`` endpoint.
 

--- a/docs/sphinx/templates.rst
+++ b/docs/sphinx/templates.rst
@@ -1,21 +1,15 @@
 Templates and Examples
 ======================
 
-Two directories ship under ``config/`` in the repo:
+``examples/agents/`` ships pattern templates as agent directories
+(``hello-agent``, ``minimal-agent``, ``full-agent``, ``proxy-agent``).
+Each directory holds a ``spec.yaml`` (plus an optional ``dot_claude/``
+sibling) and demonstrates one deployment pattern with the smallest
+manifest that exercises it. Copy-and-adapt is the intended workflow.
 
-* ``examples/agent-templates/`` — minimal pattern templates. Each one demonstrates
-  one deployment pattern with the smallest YAML that exercises it.
-  Copy-and-adapt is the intended workflow.
-* ``examples/agents/`` — concrete real-world configs that document
-  specific operator decisions (e.g. ``newbie-docker.yaml`` carries the
-  Hawthorne-effect-free design notes from the 2026-04-12 contamination
-  incident).
-
-Both directories are validated by ``tests/test_templates_v3_valid.py``.
-Every YAML must round-trip through ``load_config`` cleanly; the SLURM
-template additionally renders a valid sbatch script so YAML-key drift
-from ``SlurmSpec`` / ``SlurmHooks`` fails loudly in CI rather than at a
-user's first ``sac agent start``.
+The shipped YAML must round-trip through ``load_config`` cleanly so
+YAML-key drift fails loudly in CI rather than at a user's first
+``sac agents start``.
 
 Pattern Templates
 -----------------
@@ -27,15 +21,20 @@ Pattern Templates
    * - Template
      - Pattern
      - When to use
-   * - ``apptainer.yaml``
-     - claude-session inside Apptainer SIF
-     - **Default**. HPC + reproducibility. F-CS17 made sac
-       container-only; this is the canonical pattern.
-   * - ``ssh.yaml``
-     - remote agent via SSH
-     - Cross-machine fleet member. ``sac --on <peer>`` (F-CS12)
-       dispatches across hosts; the per-agent
-       ``dot_claude/`` directory is rsync'd to the remote at start.
+   * - ``minimal-agent``
+     - Smallest valid ``spec.yaml``
+     - Starting point. The fewest fields that load and start.
+   * - ``hello-agent``
+     - claude-session inside an Apptainer SIF
+     - **Default**. F-CS17 made sac container-only; this is the
+       canonical single-turn pattern.
+   * - ``full-agent``
+     - Fully-featured agent
+     - Health, restart, A2A, and ``dot_claude/`` wiring all enabled.
+   * - ``proxy-agent``
+     - ``kind: AgentProxy``
+     - HTTP forwarder with no SDK runner — routes ``/v1/turn`` to
+       another agent.
 
 MCP tool wiring is no longer a separate template — drop a
 ``.mcp.json`` into the agent's ``dot_claude/`` directory and it'll be
@@ -50,27 +49,8 @@ instantiate:
 
 .. code-block:: bash
 
-    mkdir -p ~/.scitex/agent-container/agents/my-agent
-    cp examples/agent-templates/apptainer.yaml \\
-       ~/.scitex/agent-container/agents/my-agent/spec.yaml
-    # Optionally add a dot_claude/ sibling with CLAUDE.md / .mcp.json /
-    # .env / state.md / commands/ / skills/ / hooks/ (all optional).
-    sac agent start my-agent
-
-Examples
---------
-
-.. list-table::
-   :header-rows: 1
-   :widths: 25 75
-
-   * - Example
-     - What it documents
-   * - ``newbie-docker.yaml``
-     - Hawthorne-effect-free naive-user simulation. Zero skills, zero
-       fleet identity, ``mount_host_claude: false``, ``network: bridge``
-       (not ``none`` — DNS blocking caused 3-min/call retry loops).
-       Disposable: ``restart.policy: never``.
-   * - ``researcher-opus.yaml``
-     - Opus-powered researcher with ``restart.policy: on-failure``,
-       backoff tuned for long-running research sessions.
+    cp -r examples/agents/hello-agent \\
+       ~/.scitex/agent-container/agents/my-agent
+    # The dot_claude/ sibling (CLAUDE.md / .mcp.json / .env / state.md /
+    # commands/ / skills/ / hooks/) is all optional.
+    sac agents start my-agent

--- a/src/scitex_agent_container/_skills/scitex-agent-container/01_config-v3.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/01_config-v3.md
@@ -42,7 +42,7 @@ metadata:
     role: worker
     machine: local
 spec:
-  runtime: claude-code    # claude-code | slurm | slurm-tenant
+  runtime: apptainer      # apptainer (only accepted value)
   model: opus[1m]
   multiplexer: tmux       # tmux (default) or screen
 
@@ -111,4 +111,3 @@ If you have legacy YAMLs:
 
 - `08_templates.md` — six minimal pattern templates under `examples/agent-templates/`
 - `06_env-injection-ports.md` — yaml.env vs dot_claude/.mcp.json env vs dot_claude/.env vs hooks
-- `09_slurm-tenant.md` — multi-tenant `runtime: slurm-tenant` and `slurm.reservation`

--- a/src/scitex_agent_container/_skills/scitex-agent-container/03_python-api.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/03_python-api.md
@@ -74,7 +74,7 @@ The registry is the persistent source of truth for "who's currently running on t
 from scitex_agent_container import AgentConfig
 
 cfg: AgentConfig = load_config("worker")
-cfg.runtime          # "claude-session" | "claude-code" | "slurm" | "slurm-tenant"
+cfg.runtime          # "apptainer"
 cfg.model            # str
 cfg.expanded_workdir # str (~ resolved)
 cfg.a2a.port         # int | None

--- a/src/scitex_agent_container/_skills/scitex-agent-container/10_cli.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/10_cli.md
@@ -41,15 +41,6 @@ sac agent attach <name>                # Attach to the agent's multiplexer sessi
 sac agent find <capability>            # Find agents with a specific capability label across YAML roots
 ```
 
-## SLURM
-
-```bash
-sac template render-sbatch <yaml>         # Print the sbatch wrapper text (debug; doesn't submit)
-sac template render-attach <name>         # Print the srun --pty command that reattaches
-```
-
-For multi-tenant SLURM (`runtime: slurm-tenant`), see `09_slurm-tenant.md` and the companion `scitex-hpc reservations` CLI.
-
 ## Interact (resume an existing session)
 
 ```bash
@@ -145,5 +136,4 @@ The CLI is a thin wrapper over these — every command corresponds to a function
 ## See also
 
 - `01_config-v3.md` — the YAML schema the CLI consumes
-- `09_slurm-tenant.md` — multi-tenant SLURM runtime + `scitex-hpc reservations` CLI
 - `40_troubleshooting.md` — common launch failures

--- a/src/scitex_agent_container/_skills/scitex-agent-container/15_claude-session.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/15_claude-session.md
@@ -95,8 +95,7 @@ Scope resolution (highest priority first):
 
 1. **Project-local**: walks up from cwd to a git repo containing
    `.scitex/agent-container/`. State lands in
-   `<repo>/.scitex/agent-container/runtime/<name>/`. Same convention
-   as the slurm runtime + scitex-hpc reservations.
+   `<repo>/.scitex/agent-container/runtime/<name>/`.
 2. **Home**: `~/.scitex/agent-container/runtime/<name>/` (when no
    project scope is available).
 3. Override via `$SCITEX_AGENT_CONTAINER_RUNTIME_DIR` (the runner reads

--- a/src/scitex_agent_container/_skills/scitex-agent-container/SKILL.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: scitex-agent-container
 description: |
-  [WHAT] Declarative YAML-based AI agent lifecycle management — define an agent in one YAML manifest (runtime, model, MCP, env, health, restart, remote SSH host) and `sac agent start` brings it up in tmux/screen with auto-accept TUI handling, SSH remote deployment, sbatch-based SLURM submission with walltime auto-resubmit, A2A protocol sidecar, and live pane-state inspection.
-  [WHEN] Use when the user asks to "launch a Claude Code agent", "spawn a fleet of coding agents", "manage agent lifecycle", "run an agent on a remote host / HPC", "submit an agent as a SLURM job", "auto-accept Claude permission prompts", "wire MCP servers into an agent", or mentions `sac agent start`, `scitex-agent-container`, agent YAML, fleet head/worker, head-mba / head-spartan / head-nas.
+  [WHAT] Declarative YAML-based AI agent lifecycle management — define an agent in one YAML manifest (runtime, model, MCP, env, health, restart, remote SSH host) and `sac agent start` brings it up with auto-accept TUI handling, SSH remote deployment, A2A protocol sidecar, and live pane-state inspection.
+  [WHEN] Use when the user asks to "launch a Claude Code agent", "spawn a fleet of coding agents", "manage agent lifecycle", "run an agent on a remote host", "auto-accept Claude permission prompts", "wire MCP servers into an agent", or mentions `sac agent start`, `scitex-agent-container`, agent YAML, fleet head/worker.
   [HOW] `pip install scitex-agent-container` then `import scitex_agent_container`; see leaf skills for details.
 tags: [scitex-agent-container]
 primary_interface: cli
@@ -30,10 +30,10 @@ rich non-agentic status surface.
 | Python API | `scitex_agent_container` (`AgentConfig`, `load_config`, `agent_start`/`stop`/`restart`/`status`/`logs`, `Registry`) |
 | CLI | `scitex-agent-container`, `sac` — see [10_cli.md](10_cli.md) |
 | MCP servers | None bundled — agents spawn their own via `dot_claude/.mcp.json` |
-| Runtimes | `runtimes/{tmux,screen,claude_code,apptainer,docker,sbatch_spartan,ssh_remote}.py` |
+| Runtimes | `runtimes/claude_session.py` (SDK-native, default); apptainer container build helpers |
 | PaneActions | See [14_pane-actions.md](14_pane-actions.md) |
 | Observability | See [13_observability.md](13_observability.md) |
-| Config format | v3 `scitex-agent-container/v3` (current); v2 still supported |
+| Config format | v3 `scitex-agent-container/v3` only — v2 is rejected |
 
 ## Sub-skills
 
@@ -55,7 +55,6 @@ rich non-agentic status surface.
 - [07_a2a-protocol.md](07_a2a-protocol.md) — Native A2A protocol (`sac a2a serve`)
 - [07_a2a-protocol-extension-fields.md](07_a2a-protocol-extension-fields.md) — `x-scitex-agent-container.*` AgentCard extension fields + JSON example
 - [08_templates.md](08_templates.md) — Six pattern templates + real-world examples
-- [09_slurm-tenant.md](09_slurm-tenant.md) — `runtime: slurm-tenant` for shared HPC allocations
 - [15_claude-session.md](15_claude-session.md) — `runtime: claude-session` SDK-native runtime + `POST /v1/turn` inbound endpoint
 - [16_claude-session-migration.md](16_claude-session-migration.md) — Migrating an agent to claude-session
 - [17_inbound-turn-endpoint.md](17_inbound-turn-endpoint.md) — `POST /v1/turn` wire format + sidecar replacement


### PR DESCRIPTION
Doc-quality audit of three surfaces — skills, README, RTD/Sphinx. Fixed only clear, objective problems (broken links, dead command/file references, factually stale claims verified against the current CLI and validator). No style rewrites.

## Skills (`src/scitex_agent_container/_skills/scitex-agent-container/`)
- `SKILL.md`: removed dangling `09_slurm-tenant.md` index entry (file deleted by F-CS17); dropped stale SLURM/sbatch claims in the description; fixed the runtimes table (it listed 7 files that no longer exist) and the config-format note (only `scitex-agent-container/v3` is accepted — v2 is rejected by the validator).
- `01_config-v3.md`: example `runtime:` comment listed `slurm | slurm-tenant | claude-code` — all rejected; validator only accepts `apptainer`. Dropped dead `09_slurm-tenant.md` cross-ref.
- `03_python-api.md`: `cfg.runtime` example listed removed runtime values.
- `10_cli.md`: removed the SLURM section (`sac template render-sbatch`/`render-attach` were deleted by F-CS17) and the dead `09_slurm-tenant.md` cross-ref.
- `15_claude-session.md`: dropped a comparison to the removed slurm runtime.

## README
- `sac account ...` → `sac accounts ...` (singular `sac account` errors with "No such command").
- `spec.yaml` link pointed at a dead in-page anchor (`#yaml-spec-reference-v3`); now points at `docs/spec-reference.md`.

## RTD / Sphinx (`docs/sphinx/`)
- `index.rst`, `quickstart.rst`, `status_and_hooks.rst`: replaced removed CLI commands (`scitex-agent-container show-status / inspect / show-logs / attach / actions`) with current `sac agents ...` forms.
- `quickstart.rst`: manifest was `apiVersion: .../v2` (rejected) with `runtime: claude-code` (rejected) and `metadata.name` (rejected) — fixed to a valid v3 apptainer manifest; removed the `actions` section whose `:doc:` actions `` cross-ref pointed at a nonexistent doc.
- `templates.rst`: referenced `examples/agent-templates/` and flat files (`apptainer.yaml`, `ssh.yaml`, `newbie-docker.yaml`, `researcher-opus.yaml`) plus `tests/test_templates_v3_valid.py` — none exist; realigned to the real `examples/agents/` template directories; dropped the `SlurmSpec`/`SlurmHooks` reference.

## Build
Sphinx HTML build run locally twice — **build succeeded** (exit 0). Only warnings are pre-existing upstream `RemovedInSphinx10Warning` from `sphinx_autodoc_typehints`, unrelated to these edits.

## Flagged but NOT changed (broader drift — out of audit scope)
- `02_multiplexer.md` and several skill files still describe tmux/screen multiplexer + `runtimes.multiplexer` API; sac is now SDK/apptainer-only. This is wide architectural drift that needs a focused rewrite, not a drive-by patch.
- The SKILL.md "30-second start" / quickstart still use `pip install` (vs `uv pip`) and `sac agent` (singular) appears in some prose; left as-is — singular `sac agent` resolves via alias and the README/CLI canonical form is `sac agents`.
- Operator mentioned a new `25_claude-setup-delivery.md` to index — that file does not exist anywhere in the tree, so nothing to index.