### PR TITLE
docs: add ADR-0009 (to_home-first) + fix ANTHROPIC_API_KEY/[sdk]/multiplexer/containers docs

### DIFF
--- a/docs/adr/0009-claude-setup-delivery-to-home-first.md
+++ b/docs/adr/0009-claude-setup-delivery-to-home-first.md
@@ -1,0 +1,144 @@
+# ADR-0009: Claude setup delivery — `to_home`-first, definition-as-source-of-truth
+
+**Status:** Accepted (2026-05-21).
+**Extends:** ADR-0006 (`to_home/` spec-dir materialization) — that ADR
+established the 1:1 `to_home/` → container `$HOME` mirror; this one
+records the *delivery + load* model that makes a containerized Claude
+agent reproducible from its definition alone.
+**Tutorial:** skill `_skills/scitex-agent-container/25_claude-setup-delivery.md`
+(the how-to; this ADR is the decision record).
+
+## Context
+
+SAC runs each agent's Claude session **inside** an apptainer container.
+The SDK runtime (`runtimes/claude_session.py`, backed by
+`runtimes/_sdk_common.py`) does not — and must not — auto-discover the
+host operator's `~/.claude`. Without an explicit policy, agents would
+silently inherit settings, credentials, MCP config, and CLAUDE.md from
+whatever host they happen to run on, so a run would not be reproducible
+and "works on my box" would be the norm.
+
+ADR-0006 gave us the `to_home/` mirror but did not pin down (a) what
+should live in `to_home` versus `spec.yaml`, (b) how conflicting layers
+resolve, or (c) how the materialized tree is actually loaded by the SDK
+inside the container.
+
+## Decision
+
+### Definition files are the single source of truth
+
+An agent is **fully described by its `spec.yaml` plus its `to_home/`** —
+never by the host machine. To understand or reproduce an agent you read
+its definition, nothing else. If you reach for host state to make an
+agent behave, that is the bug: put it in the definition and pass it
+explicitly.
+
+### `to_home`-first
+
+Default **all** `$HOME` content into `to_home/` — `.env`, `.mcp.json`,
+`CLAUDE.md`, `.claude/hooks`, `.bashrc`, etc. `to_home/` mirrors the
+container `$HOME` 1:1 (it is a `$HOME` delivery mechanism, **not** a
+`.claude`-only one). `spec.yaml` shrinks toward container-wiring-only.
+
+Rationale: ordinary files are easy to handle, adding a file adds a
+capability (easy to grow), the agent is self-contained (host-isolated),
+and the layout is **isomorphic to a normal `$HOME`** — standard tools
+and mental models apply with no special knowledge.
+
+### Exception: read-only bind for secrets and large shared trees
+
+The **only** exception to `to_home`-first is a read-only (`ro`) `bind`,
+for two cases where copying is wrong:
+
+- **Host secrets** (`.ssh`, `.config/gh`, `.claude/.credentials.json`)
+  — a copy would commit secrets into the git-tracked `to_home`.
+- **Large shared, always-current trees** (`~/.claude/skills`) — a copy
+  would duplicate the tree and go stale.
+
+The `ro`-bind carries a reproducibility trade-off. Secrets are
+correctly *outside* the reproducible artifact (structure is reproduced,
+values injected at run time — not a gap). Skills are a real trade-off:
+the live bind is **current but not pinned**, so a run is not
+byte-reproducible. Default = currency (`ro`-bind); strict reproducibility
+= pin the skills version and materialize it into `to_home`.
+
+### Override precedence
+
+When the same setting is declared in more than one layer, the winner is:
+
+```
+direct command args  >  spec.yaml fields  >  to_home/<files>
+```
+
+`to_home` is the base; `spec` fields and direct args are escape-hatch
+overrides. This mirrors Claude's own `user < project < flag` layering.
+(Placement and precedence are distinct axes: `to_home`-first is *where*
+you put a setting; precedence is *which layer wins* on conflict.)
+
+### Delivery into the container `$HOME`
+
+Where the materialized tree must physically land depends on how the
+container gets its `$HOME`:
+
+- **Hardened mode** — the runtime binds the host workspace home at the
+  container `$HOME` (`--bind runtime/<name>/home/:/home/agent`);
+  `deploy_to_home` materializes the tree there.
+- **Relaxed mode** (`--home`/`--overlay` specs) — the operator-declared
+  `--home` is satisfied by the overlay's upper layer, which shadows the
+  workspace-home bind. `runtimes/_to_home_overlay.py::deploy_to_home_overlay`
+  therefore materializes the **same** tree into the overlay upper home
+  (`<overlay>/upper/<container_home>/`) so it reaches `$HOME`. This
+  applies only to directory overlays; `.img` loopback overlays are a
+  no-op.
+
+### Load model
+
+The SDK runner is built with `setting_sources=[]`
+(`runtimes/_sdk_common.py::build_sdk_options`). This is **intentional
+and must not change**: the default would load the host's `~/.claude`
+state files and treat "no state" as not-logged-in even when credentials
+are mounted. Empty sources mean the explicitly-delivered setup is the
+entire context — no host auto-discovery (machine-independence).
+
+Each surface is then loaded explicitly:
+
+- **Settings/hooks** — `ClaudeAgentOptions.settings` → `--settings`
+  pointed at the in-container `$HOME/.claude/settings.local.json`. This
+  is the SDK's "flag settings" layer (highest-priority user-controlled
+  layer), loaded **independently** of `setting_sources`; without it the
+  empty `setting_sources` would never load the delivered settings.
+- **MCP** — `--mcp-config`, parsed from the workspace `.mcp.json` that
+  sac materializes from `spec.mcp_servers`.
+- **Credentials** — the auth layer
+  (`provision_anthropic_auth`): `~/.claude/.credentials.json` (Pro/Max
+  OAuth, flat-rate) takes precedence, else `SAC_ANTHROPIC_API_KEY`
+  mirrored into `ANTHROPIC_API_KEY`. A bare host `ANTHROPIC_API_KEY` is
+  never honoured (it is popped when `SAC_ANTHROPIC_API_KEY` is unset).
+
+## Consequences
+
+**Positive:**
+
+- An agent is reproducible from its definition on any host; "works on my
+  box" is structurally prevented.
+- Config grows by adding ordinary files under `to_home/`; no special
+  per-surface plumbing.
+- The same delivered tree reaches `$HOME` under both hardened and
+  relaxed/overlay specs, via one materialization contract.
+
+**Negative:**
+
+- The skills `ro`-bind is current-but-not-pinned, so a default run is
+  not byte-reproducible (mitigated by the strict-mode pin option).
+- `spec.raw_args` and `to_home` remain separate runtime surfaces today;
+  full precedence merging (args > spec > to_home) still relies on the
+  runtime resolving them rather than a single merged layer.
+
+## Related work
+
+- ADR-0006 — `to_home/` spec-dir materialization (the 1:1 mirror this
+  ADR builds on).
+- ADR-0003 — runtime home directory layout (`runtime/<name>/home/`).
+- ADR-0001 — isolation hardening (the `--bare`/`setting_sources=[]`
+  posture).
+- Skill `25_claude-setup-delivery.md` — the operator/maintainer tutorial.

--- a/src/scitex_agent_container/_skills/scitex-agent-container/01_installation.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/01_installation.md
@@ -10,12 +10,16 @@ tags: [scitex-agent-container-installation]
 ## pip install
 
 ```bash
-pip install scitex-agent-container          # core CLI + apptainer runtime
-pip install 'scitex-agent-container[sdk]'   # adds claude-agent-sdk + starlette/uvicorn for the inbound HTTP endpoint
-pip install 'scitex-agent-container[all]'   # everything
+pip install scitex-agent-container          # core CLI + apptainer runtime + claude-agent-sdk
+pip install 'scitex-agent-container[all]'   # everything (mcp + telegram + slurm + dev + docs)
 ```
 
-The CLI ships as both `scitex-agent-container` and the short alias `sac`.
+`claude-agent-sdk` and `uvicorn` (the inbound `/v1/turn` HTTP endpoint)
+are **core** dependencies — they ship in the base install, not behind an
+extra. The declared extras are `[mcp]`, `[telegram]`, `[slurm]`, `[dev]`,
+`[docs]`, and the `[all]` aggregate (see `pyproject.toml`). There is no
+`[sdk]` extra. The CLI ships as both `scitex-agent-container` and the
+short alias `sac`.
 
 ## What ships in the wheel
 
@@ -28,27 +32,48 @@ images without cloning the repo:
   apptainer-scitex.def     # FROM :base + scitex[all] + sac
 ```
 
-Built artifacts (SIFs, sandboxes) land under user state, never in the wheel:
+Built artifacts (SIFs, sandboxes) land under user state, never in the
+wheel. `sac image build` delegates to `scitex-container`, which owns the
+dir-per-layer layout (`cli_pkg/image_group.py`):
 
 ```
 ~/.scitex/agent-container/containers/
-  sac-base/sac-base.sif        + symlink at containers/sac-base.sif
-  sac-scitex/sac-scitex.sif    + symlink at containers/sac-scitex.sif
-  sac-*/*.sandbox/             (optional sandbox builds)
+  sac-base.sif        -> sac-base/sac-base.sif          (symlink)
+  sac-base/
+    sac-base.sif
+    sac-base.def                         # recipe snapshot at build time
+    .def-hash                            # def fingerprint; skips rebuild when unchanged
+    sac-base.build-YYYY-MMDD-HHMMSS.log  # full build log, one per build
+  sac-scitex.sif      -> sac-scitex/sac-scitex.sif      (symlink)
+  sac-scitex/
+    sac-scitex.{sif,def}, .def-hash, sac-scitex.build-*.log
+  overlays/<agent-name>/                 # per-agent directory overlays (upper/, work/)
+  dpkg-lock.txt  node-lock.txt  requirements-lock.txt   # build reproducibility locks
+  sac-*/*.sandbox/                       # optional writable sandbox builds (only when built)
 ```
+
+The `.sif` symlinks at the `containers/` root are the stable paths specs
+reference; the dir-per-layer keeps each build's `.def` snapshot, hash,
+and logs alongside the image. `overlays/<agent-name>/upper/` is the
+relaxed-mode writable upper layer (see ADR-0009); `work/` is its
+apptainer overlay workdir.
 
 Build with `sac image build base -y && sac image build scitex -y`. See
 [`02_quick-start.md`](02_quick-start.md) for the full first-agent flow.
 
 ## Auth (cost-critical)
 
-The SDK runtime reads Anthropic auth in this precedence (see `runtimes/_sdk_common.py`):
+The SDK runtime reads Anthropic auth in this precedence (see
+`runtimes/_sdk_common.py::provision_anthropic_auth`):
 
-1. `ANTHROPIC_API_KEY` env (used verbatim if set — operator opt-in)
-2. `~/.claude/.credentials.json` Pro/Max OAuth (default — flat-rate, no per-token billing)
-3. `SAC_ANTHROPIC_API_KEY` env (sac-namespaced handoff; works for OAuth `sk-ant-oat*` *and* API-key `sk-ant-api*` forms — the runner detects by prefix and either bridges to `ANTHROPIC_API_KEY` or synthesises the credentials file)
+1. `~/.claude/.credentials.json` Pro/Max OAuth (default — flat-rate, no per-token billing). Run `claude /login` once to populate it.
+2. `SAC_ANTHROPIC_API_KEY` env (sac-namespaced handoff for headless contexts — CI, SLURM, cron — mirrored into `ANTHROPIC_API_KEY` for the SDK).
 
-Run `claude /login` once to populate the credentials file. Set neither and you get a clear `SDKCommonError` rather than silent fall-through to API-key billing.
+A bare host `ANTHROPIC_API_KEY` is **never honoured**: if
+`SAC_ANTHROPIC_API_KEY` is unset, `provision_anthropic_auth` *pops*
+`ANTHROPIC_API_KEY` from the env so a stale dotfiles export can't
+silently switch you to pay-per-token billing or shadow a working OAuth
+credentials file. Set neither and you get a clear `SDKCommonError`.
 
 ## Per-host hook (optional but recommended for remote/HPC)
 

--- a/src/scitex_agent_container/_skills/scitex-agent-container/02_multiplexer.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/02_multiplexer.md
@@ -1,38 +1,37 @@
 ---
 description: |
-  [TOPIC] Multiplexer
-  [DETAILS] tmux vs screen multiplexer support, capture-pane, send-keys..
+  [TOPIC] Multiplexer (vestigial for agents)
+  [DETAILS] SAC agents run via the apptainer SDK runtime (runtimes/claude_session.py) — NOT inside a terminal multiplexer. The tmux wrap is the lead session's launcher concern, outside this package. The spec.multiplexer key is a vestigial config field with no live consumer.
 tags: [scitex-agent-container-multiplexer]
 ---
 
 # Multiplexer
 
-Set in YAML: `spec.multiplexer: tmux` (default) or `screen`
+**A terminal multiplexer is not part of the SAC agent execution path.**
+SAC agents run via the apptainer SDK runtime
+(`runtimes/claude_session.py`), which drives `claude-agent-sdk` from a
+Python runner — no tmux, no screen, no pane scraping, no `send-keys`
+auto-accept. See [15_claude-session.md](15_claude-session.md).
 
-## Comparison
+There is no `runtimes/multiplexer.py` module and nothing in the runtime
+imports a `get_multiplexer` / `TmuxManager` / `ScreenManager` API; that
+surface was removed when the SDK runtime replaced the legacy tmux-wrapped
+CLI runtime. The `spec.multiplexer` YAML key still parses (default
+`tmux`, in `config/_types.py`) but is **vestigial** — no agent code path
+consumes it, so setting it has no effect on how an agent runs.
 
-| Feature | tmux | screen |
-|---------|------|--------|
-| `capture-pane` | Works on macOS | Fails on macOS (hardcopy) |
-| Auto-accept | Reliable | Unreliable on macOS |
-| Socket dir | Consistent | Varies (SSH vs local) |
-| Default | Yes (since v0.7) | Legacy |
+## Where tmux *is* used
 
-## Usage
+tmux is used only to wrap the **lead** Claude session — for session
+continuity (`--continue`) and remote (iPhone) attach. That wrapping lives
+in the lead's launcher (`scripts/deployment/claude.sh`, which wraps the
+session in a named tmux session `lead`), **outside** this package. It is
+an operator convenience for one interactive human-facing session, not an
+agent execution mechanism, and SAC does not manage it.
 
-```python
-from scitex_agent_container.runtimes.multiplexer import get_multiplexer
+## Attaching to a running agent
 
-mux = get_multiplexer(config)          # TmuxManager or ScreenManager
-mux.exists("session-name")             # Check session exists
-mux.capture_content("session-name")    # Read pane content
-mux.send_keys("session-name", "2", "Enter")  # Send keystrokes
-mux.start(name, command, workdir)      # Launch session
-mux.stop("session-name")              # Kill session
-mux.attach("session-name")            # Interactive attach
-```
+Use the SDK runtime's own surfaces instead of `tmux attach`:
 
-## Detach shortcuts
-
-- tmux: `Ctrl-B D`
-- screen: `Ctrl-A D`
+- `sac agent logs <name>` — rendered transcript from `session.jsonl`.
+- `sac agent start <name> --foreground` — stream a turn to your terminal.

--- a/src/scitex_agent_container/_skills/scitex-agent-container/15_claude-session.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/15_claude-session.md
@@ -107,21 +107,24 @@ Symmetric: agent definitions follow the same resolution order
 
 ## Auth (cost-critical)
 
-The SDK's authentication path, by precedence:
+The SDK's authentication path, by precedence
+(`runtimes/_sdk_common.py::provision_anthropic_auth`):
 
-1. `ANTHROPIC_API_KEY` already set → used verbatim.
-2. `~/.claude/.credentials.json` exists → SDK reads OAuth token
+1. `~/.claude/.credentials.json` exists → SDK reads OAuth token
    automatically (Pro/Max plan, **flat-rate**). The default on every
    workstation that has run `claude /login`.
-3. `SAC_ANTHROPIC_API_KEY` (sac-namespaced handoff for headless
-   contexts — CI, SLURM, cron). Auto-routes by prefix:
-   * `sk-ant-oat*` → OAuth credentials file is synthesised so the SDK
-     uses the flat-rate OAuth path.
-   * `sk-ant-api*` → bridged into `ANTHROPIC_API_KEY` (**pay-per-token**;
-     explicit opt-in only).
+2. `SAC_ANTHROPIC_API_KEY` (sac-namespaced handoff for headless
+   contexts — CI, SLURM, cron). When set it is mirrored into
+   `ANTHROPIC_API_KEY` for the SDK (an `sk-ant-api*` value is
+   **pay-per-token**, explicit opt-in only).
 
-Set neither and you get a clear `SDKCommonError` rather than a silent
-fall-through to API-key billing.
+A bare host `ANTHROPIC_API_KEY` is **never honoured**: the first thing
+`provision_anthropic_auth` does is overwrite it from
+`SAC_ANTHROPIC_API_KEY`, or *pop* it from the env when
+`SAC_ANTHROPIC_API_KEY` is unset — so a stale dotfiles export can't be
+picked up by the SDK auto-reader, shadow a working OAuth credentials
+file, or silently switch you to API-key billing. Set neither input and
+you get a clear `SDKCommonError`.
 
 ## Status JSON addition
 

--- a/src/scitex_agent_container/_skills/scitex-agent-container/SKILL.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/SKILL.md
@@ -47,7 +47,7 @@ rich non-agentic status surface.
 
 ### Core
 - [01_config-v3.md](01_config-v3.md) — v3 config format (current); v2+`metadata.name` rejected
-- [02_multiplexer.md](02_multiplexer.md) — tmux vs screen
+- [02_multiplexer.md](02_multiplexer.md) — vestigial for agents (SDK runtime, no tmux); lead-only tmux wrap
 - [03_auto-accept.md](03_auto-accept.md) — Modular prompt handlers
 - [04_resource-management.md](04_resource-management.md) — Resource management
 - [05_resource-heartbeat.md](05_resource-heartbeat.md) — Resource heartbeat


### PR DESCRIPTION
Five doc deliverables in one PR (docs-only; no src code touched except `_skills/` markdown).

## 1. ADR-0009 (new)
`docs/adr/0009-claude-setup-delivery-to-home-first.md` — records the definition-as-single-source-of-truth + to_home-first delivery/load decision (extends ADR-0006). Concise decision record; the tutorial lives in skill 25.

## 2. ANTHROPIC_API_KEY factual fix
`01_installation.md` and `15_claude-session.md` claimed a bare host `ANTHROPIC_API_KEY` is used verbatim. Verified against `runtimes/_sdk_common.py::provision_anthropic_auth`: it is **never honoured** — popped from env when `SAC_ANTHROPIC_API_KEY` is unset. Precedence corrected to (1) credentials.json OAuth, (2) `SAC_ANTHROPIC_API_KEY`.

## 3. `[sdk]` extra fix
No `[sdk]` extra exists in `pyproject.toml` (extras: mcp/telegram/slurm/dev/docs/all). `claude-agent-sdk` + `uvicorn` are **core** deps. Install block rewritten to base + `[all]`.

## 4. Multiplexer rewrite
`02_multiplexer.md` — verified no `runtimes/multiplexer.py` and no `get_multiplexer` consumer exists; `spec.multiplexer` is a vestigial config field. Agents run via the apptainer SDK runtime; tmux wraps only the **lead** session via the launcher outside this package. Rewritten + SKILL.md index updated.

## 5. containers/ layout
`01_installation.md` — documented the real `~/.scitex/agent-container/containers/` structure (dir-per-layer, `.def-hash`, build logs, `overlays/<agent>/`, lock files), verified live and against `cli_pkg/image_group.py`.

## Verification
- `scitex-dev ecosystem audit-skills scitex-agent-container` → no violations (no SK-401).
- ADRs + `_skills/` markdown are not in any Sphinx toctree, so no RTD rebuild needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)