### PR TITLE
fix(auth): fail loudly on expired/invalid Anthropic credentials

### DIFF
--- a/src/scitex_agent_container/_runners/_auth_failure.py
+++ b/src/scitex_agent_container/_runners/_auth_failure.py
@@ -1,0 +1,109 @@
+"""Classify SDK conversation failures that are really an auth/credential death.
+
+When a long-lived ``claude-session`` runner loses its Anthropic
+authentication mid-flight — the Pro/Max OAuth token in
+``~/.claude/.credentials.json`` expired or rotated out from under the
+running session — the ``claude-agent-sdk`` does not surface a typed
+exception. It bubbles up as a generic ``ProcessError`` /
+``RuntimeError`` whose message contains an HTTP ``401`` or an
+``invalid api key`` / ``OAuth token has expired`` phrase.
+
+Without classification that failure lands in the conversation
+supervisor's catch-all and is recorded with the ambiguous
+``cause="sdk-crash"`` — indistinguishable from a network blip or an
+SDK panic. The operator then "finds out only by noticing silence."
+
+This module turns that silent, ambiguous death into a LOUD, specific
+signal: :func:`classify_auth_failure` recognises the auth signatures
+and returns a clear operator-facing message that names the cause and
+carries the manual-refresh hint (``claude login``). The supervisor
+uses it to (a) flip the recorded ``cause`` to ``auth-expired`` and
+(b) emit the hint-bearing detail, so ``sac agent status`` / the error
+diary show *exactly* what went wrong and how to fix it.
+
+Scope is detection + a clear message only. Refreshing the token is the
+operator's manual recovery path (run ``claude login``); no auto-rotation
+is performed here (deferred to FUTURE).
+
+Pure stdlib, no SDK import — so it is unit-testable against plain
+strings / exceptions without the optional ``claude-agent-sdk`` present.
+"""
+
+from __future__ import annotations
+
+__all__ = ["AUTH_FAILURE_CAUSE", "REFRESH_HINT", "classify_auth_failure"]
+
+# Short ``cause`` identifier written to ``state.db.errors``. Distinct
+# from the generic ``sdk-crash`` so the lead can group on it and the
+# operator can see at a glance that this is a credential problem, not a
+# transient network/SDK fault.
+AUTH_FAILURE_CAUSE = "auth-expired"
+
+# The single manual-recovery instruction. Kept as one constant so the
+# wording stays identical everywhere an auth failure is reported.
+REFRESH_HINT = (
+    "Anthropic auth failed — the OAuth token is expired/invalid. "
+    "Run `claude login` on the agent's host to refresh "
+    "~/.claude/.credentials.json, then restart the agent."
+)
+
+# Lower-cased substrings that mark a failure as an auth/credential death
+# rather than a generic SDK/network fault. Matched against the
+# stringified exception. Kept deliberately narrow so a tool-result blob
+# that merely *mentions* "401" in unrelated content doesn't get
+# misclassified — every needle here is an Anthropic auth-rejection
+# phrase, not a generic token.
+_AUTH_SIGNATURES = (
+    "401",
+    "unauthorized",
+    "invalid api key",
+    "invalid x-api-key",
+    "authentication_error",
+    "authentication error",
+    "oauth token has expired",
+    "oauth token expired",
+    "token has expired",
+    "could not refresh",
+    "invalid bearer token",
+    "credit balance is too low",
+    # Phrases emitted by provision_anthropic_auth / check_oauth_token_expiry
+    # when the on-disk credentials file is missing, malformed, or holds an
+    # expired token. Surfacing these as auth-expired (not sdk-options)
+    # gives the operator the same loud, hint-bearing record.
+    "oauth credentials",
+    "oauth token in",
+    "no anthropic auth available",
+    "run `claude login`",
+    "run `claude /login`",
+)
+
+
+def classify_auth_failure(error: object) -> str | None:
+    """Return a loud, hint-bearing message if ``error`` is an auth death.
+
+    Parameters
+    ----------
+    error
+        The exception (or any object) raised by the SDK conversation.
+        Stringified and scanned case-insensitively for the Anthropic
+        auth-rejection signatures in :data:`_AUTH_SIGNATURES`.
+
+    Returns
+    -------
+    str
+        A clear operator-facing message — the original error text
+        followed by :data:`REFRESH_HINT` — when the failure looks like
+        an expired/invalid credential. The caller records this with
+        ``cause`` :data:`AUTH_FAILURE_CAUSE`.
+    None
+        When the failure does not match any auth signature; the caller
+        keeps its existing generic handling (``cause="sdk-crash"``).
+    """
+    text = str(error)
+    haystack = text.lower()
+    if not any(sig in haystack for sig in _AUTH_SIGNATURES):
+        return None
+    detail = text.strip()
+    if detail:
+        return f"{detail} | {REFRESH_HINT}"
+    return REFRESH_HINT

--- a/src/scitex_agent_container/_runners/_session_conversation.py
+++ b/src/scitex_agent_container/_runners/_session_conversation.py
@@ -262,16 +262,30 @@ async def run_conversation(
                 extra=sdk_extra,
             )
         except SDKCommonError as exc:
-            logger.error("could not build sdk options: %s", exc)
+            # A missing/expired credentials file fails option-building
+            # with the refresh hint already in the message; classify it
+            # as auth-expired so the operator-facing record names the
+            # cause rather than the generic ``sdk-options``.
+            from ._auth_failure import (
+                AUTH_FAILURE_CAUSE,
+                classify_auth_failure,
+            )
+
+            auth_detail = classify_auth_failure(exc)
+            if auth_detail is not None:
+                opt_cause, opt_detail = AUTH_FAILURE_CAUSE, auth_detail
+            else:
+                opt_cause, opt_detail = "sdk-options", str(exc)
+            logger.error("could not build sdk options: %s", opt_detail)
             append_session_message(
-                state_dir, {"type": "error", "kind": "options", "detail": str(exc)}
+                state_dir, {"type": "error", "kind": "options", "detail": opt_detail}
             )
             if host:
                 report_sdk_error(
                     name=name,
                     host=host,
-                    cause="sdk-options",
-                    detail=str(exc),
+                    cause=opt_cause,
+                    detail=opt_detail,
                     db_writer=db_writer,
                 )
             _drain_failed_inbox(inbox, exc)
@@ -304,13 +318,35 @@ async def run_conversation(
                         return
         except Exception as exc:  # stx-allow: fallback (reason: SDK surface is broad; supervisor decides retry vs terminate)
             last_exc = exc
-            logger.exception("claude-session conversation failed for %s", name)
+            # Auth/credential death (expired or rotated OAuth token,
+            # 401, invalid key) bubbles up here as a generic SDK
+            # exception. Classify it so the operator sees a LOUD,
+            # specific signal with the manual-refresh hint instead of an
+            # ambiguous ``sdk-crash`` they only notice by the silence.
+            from ._auth_failure import (
+                AUTH_FAILURE_CAUSE,
+                classify_auth_failure,
+            )
+
+            auth_detail = classify_auth_failure(exc)
+            if auth_detail is not None:
+                cause = AUTH_FAILURE_CAUSE
+                detail = auth_detail
+                error_kind = "auth_expired"
+                logger.error(
+                    "claude-session AUTH FAILURE for %s: %s", name, auth_detail
+                )
+            else:
+                cause = "sdk-crash"
+                detail = str(exc)
+                error_kind = "sdk_runtime"
+                logger.exception("claude-session conversation failed for %s", name)
             append_session_message(
                 state_dir,
                 {
                     "type": "error",
-                    "kind": "sdk_runtime",
-                    "detail": str(exc),
+                    "kind": error_kind,
+                    "detail": detail,
                     "attempt": attempt,
                 },
             )
@@ -318,11 +354,15 @@ async def run_conversation(
                 report_sdk_error(
                     name=name,
                     host=host,
-                    cause="sdk-crash",
-                    detail=str(exc),
+                    cause=cause,
+                    detail=detail,
                     db_writer=db_writer,
                 )
-            if attempt >= max_restarts or stop.is_set():
+            # Auth failures are terminal: retrying with the same expired
+            # token only burns the backoff window and emits N identical
+            # confusing crashes. Recovery is manual (`claude login`), so
+            # stop now regardless of ``max_restarts``.
+            if auth_detail is not None or attempt >= max_restarts or stop.is_set():
                 _drain_failed_inbox(inbox, exc)
                 return
             delay = restart_backoff_s * (2**attempt)

--- a/src/scitex_agent_container/runtimes/_sdk_common.py
+++ b/src/scitex_agent_container/runtimes/_sdk_common.py
@@ -91,9 +91,6 @@ def _cred_file_path() -> Path:
     return Path.home() / ".claude" / ".credentials.json"
 
 
-_CRED_FILE = _cred_file_path()
-
-
 def _container_settings_path() -> str | None:
     """Resolve the in-container ``settings.local.json`` path, or ``None``.
 
@@ -200,6 +197,12 @@ def provision_anthropic_auth() -> str:
     # this point regardless of which path we pick below.
     os.environ.pop("ANTHROPIC_API_KEY", None)
 
+    # Resolve the credentials path at CALL time (not import time) so it
+    # honours the current ``CLAUDE_CONFIG_DIR`` / ``HOME`` — the apptainer
+    # runtime sets these per-dispatch, and tests redirect them at a tmp
+    # dir. An import-frozen constant would leak onto the real host file.
+    cred_file = _cred_file_path()
+
     # Path A: credentials.json wins (Pro/Max OAuth flat-rate, real
     # refresh_token). The SDK reads the file directly. Critically we
     # do NOT set ANTHROPIC_API_KEY here even if SAC is also set —
@@ -207,7 +210,7 @@ def provision_anthropic_auth() -> str:
     # env, so an env override would shadow the working file path
     # and the SDK would fall back to the rejected env value
     # ("Invalid API key").
-    if _CRED_FILE.is_file():
+    if cred_file.is_file():
         # The file existing is NOT enough: a token that expired (or is
         # about to) while the file lingers on disk would otherwise sail
         # past this check and die with an ambiguous 401 the moment the
@@ -217,10 +220,10 @@ def provision_anthropic_auth() -> str:
         from .._state._preflight_creds import check_oauth_token_expiry
 
         try:
-            check_oauth_token_expiry(_CRED_FILE)
+            check_oauth_token_expiry(cred_file)
         except (FileNotFoundError, ValueError, RuntimeError) as exc:
             raise SDKCommonError(
-                f"Anthropic OAuth credentials at {_CRED_FILE} are not "
+                f"Anthropic OAuth credentials at {cred_file} are not "
                 f"usable: {exc} Run `claude login` to refresh the token, "
                 "then restart the agent."
             ) from exc
@@ -236,7 +239,7 @@ def provision_anthropic_auth() -> str:
 
     raise SDKCommonError(
         f"no Anthropic auth available — run `claude /login` so "
-        f"{_CRED_FILE} exists, or export {_SAC_API_KEY_ENV}. "
+        f"{cred_file} exists, or export {_SAC_API_KEY_ENV}. "
         "sac does NOT honour a pre-set ANTHROPIC_API_KEY (see the "
         "module-level comment in runtimes/_sdk_common.py for why), "
         "and never writes/synthesises credentials.json itself."

--- a/src/scitex_agent_container/runtimes/_sdk_common.py
+++ b/src/scitex_agent_container/runtimes/_sdk_common.py
@@ -208,6 +208,22 @@ def provision_anthropic_auth() -> str:
     # and the SDK would fall back to the rejected env value
     # ("Invalid API key").
     if _CRED_FILE.is_file():
+        # The file existing is NOT enough: a token that expired (or is
+        # about to) while the file lingers on disk would otherwise sail
+        # past this check and die with an ambiguous 401 the moment the
+        # SDK opens a session. Fail LOUDLY here instead, with the
+        # manual-refresh hint, so the operator gets a clear cause rather
+        # than silent mid-session death.
+        from .._state._preflight_creds import check_oauth_token_expiry
+
+        try:
+            check_oauth_token_expiry(_CRED_FILE)
+        except (FileNotFoundError, ValueError, RuntimeError) as exc:
+            raise SDKCommonError(
+                f"Anthropic OAuth credentials at {_CRED_FILE} are not "
+                f"usable: {exc} Run `claude login` to refresh the token, "
+                "then restart the agent."
+            ) from exc
         return "credentials_file"
 
     # Path B: SAC env (api-key form for pay-per-token, or oauth where

--- a/tests/scitex_agent_container/_runners/test__auth_failure.py
+++ b/tests/scitex_agent_container/_runners/test__auth_failure.py
@@ -1,0 +1,106 @@
+"""Tests for the auth/credential-death classifier.
+
+The classifier turns a generic SDK exception into a LOUD, specific
+operator signal: when the failure carries an Anthropic auth-rejection
+signature it returns a message that names the cause and carries the
+``claude login`` refresh hint; otherwise it returns ``None`` so the
+caller keeps its generic ``sdk-crash`` handling.
+
+Style: AAA markers, one assert per test, no mocks (pure-function input).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scitex_agent_container._runners._auth_failure import (
+    AUTH_FAILURE_CAUSE,
+    REFRESH_HINT,
+    classify_auth_failure,
+)
+
+
+class TestRecognisesAuthFailures:
+    """Anthropic auth-rejection signatures must classify as auth-expired."""
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "API error 401 Unauthorized",
+            "ProcessError: authentication_error: invalid api key",
+            "OAuth token has expired",
+            "Your credit balance is too low",
+            "Command failed: 401",
+        ],
+    )
+    def test_auth_signature_returns_hint_bearing_message(self, message: str) -> None:
+        # Arrange
+        exc = RuntimeError(message)
+        # Act
+        result = classify_auth_failure(exc)
+        # Assert
+        assert result is not None and REFRESH_HINT in result
+
+    def test_classified_message_preserves_original_text(self) -> None:
+        # Arrange
+        exc = RuntimeError("HTTP 401 from api.anthropic.com")
+        # Act
+        result = classify_auth_failure(exc)
+        # Assert
+        assert "HTTP 401 from api.anthropic.com" in result
+
+
+class TestPreflightPhrasings:
+    """Messages emitted by the provision/preflight layer also classify."""
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "OAuth token in /home/x/.claude/.credentials.json expired 5 seconds ago. "
+            "Run `claude login` to refresh.",
+            "OAuth credentials at /tmp/.credentials.json are not usable. "
+            "Run `claude login`.",
+            "no Anthropic auth available — run `claude /login`.",
+        ],
+    )
+    def test_preflight_message_classifies_as_auth(self, message: str) -> None:
+        # Arrange
+        exc = RuntimeError(message)
+        # Act
+        result = classify_auth_failure(exc)
+        # Assert
+        assert result is not None
+
+
+class TestNonAuthFailures:
+    """Generic SDK/network faults must NOT be misclassified as auth."""
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "Connection reset by peer",
+            "asyncio.TimeoutError after 25s",
+            "ModuleNotFoundError: claude_agent_sdk",
+            "ValueError: bad tool result",
+            "",
+        ],
+    )
+    def test_non_auth_failure_returns_none(self, message: str) -> None:
+        # Arrange
+        exc = RuntimeError(message)
+        # Act
+        result = classify_auth_failure(exc)
+        # Assert
+        assert result is None
+
+
+class TestCause:
+    """The cause identifier is the distinct, groupable ``auth-expired``."""
+
+    def test_cause_is_auth_expired(self) -> None:
+        # Arrange
+        cause = AUTH_FAILURE_CAUSE
+        # Act
+        actual = str(cause)
+        # Assert
+        assert actual == "auth-expired"

--- a/tests/scitex_agent_container/_runners/test__session_conversation_auth.py
+++ b/tests/scitex_agent_container/_runners/test__session_conversation_auth.py
@@ -1,0 +1,197 @@
+"""Loud auth-failure reporting from the claude-session supervisor.
+
+When the SDK conversation dies because the Anthropic OAuth token has
+expired/rotated (a 401 mid-session), or option-building fails because
+the credentials file is missing/expired, the supervisor must record a
+LOUD, specific error: ``cause="auth-expired"`` with the ``claude login``
+refresh hint in the detail — never the ambiguous ``sdk-crash`` /
+``sdk-options`` that the operator only notices by the silence.
+
+No mocks: a real capturing DB-writer object is injected via the
+``db_writer`` seam, and the SDK is a real injected fake module whose
+client raises the auth error.
+
+Style: AAA markers, one assert per test.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import types
+from pathlib import Path
+
+import scitex_agent_container._runners.claude_session as runner
+from scitex_agent_container._runners._session_inbox import (
+    TurnEnvelope,
+    make_inbox,
+)
+
+
+class _CapturingDBWriter:
+    """Real writer object that records every diary call (no mock libs)."""
+
+    def __init__(self) -> None:
+        self.errors: list[dict] = []
+        self.heartbeats: list[dict] = []
+        self.turns: list[dict] = []
+
+    def record_error(self, **kwargs):
+        self.errors.append(kwargs)
+        return len(self.errors)
+
+    def record_heartbeat(self, **kwargs):
+        self.heartbeats.append(kwargs)
+
+    def record_turn(self, **kwargs):
+        self.turns.append(kwargs)
+
+
+def _sdk_module_raising(exc: Exception):
+    """Injected SDK module whose client raises ``exc`` on the first query."""
+
+    class _Text:
+        def __init__(self, text: str) -> None:
+            self.text = text
+
+    class _Assistant:
+        def __init__(self, content):
+            self.content = content
+
+    class _User:
+        pass
+
+    class _Result:
+        pass
+
+    class _Client:
+        def __init__(self, *, options):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return None
+
+        async def query(self, prompt):
+            raise exc
+
+        async def receive_response(self):
+            if False:  # pragma: no cover — never reached; query raises first
+                yield None
+
+        async def interrupt(self):
+            return None
+
+    class _HookMatcher:
+        def __init__(self, *a, **kw):
+            pass
+
+    mod = types.ModuleType("fake_sdk")
+    mod.AssistantMessage = _Assistant
+    mod.TextBlock = _Text
+    mod.UserMessage = _User
+    mod.ResultMessage = _Result
+    mod.ClaudeSDKClient = _Client
+    mod.HookMatcher = _HookMatcher
+    return mod
+
+
+def _run_until_done(sdk_mod, writer, *, build_options_fn, max_restarts=0):
+    async def _go():
+        inbox = make_inbox()
+        loop = asyncio.get_running_loop()
+        await inbox.put(TurnEnvelope(text="go", response=loop.create_future()))
+        await runner._run_conversation(
+            "agent-x",
+            Path("/tmp"),  # state_dir not asserted on; writes go via db_writer
+            pid=1,
+            inbox=inbox,
+            resume_session_id=None,
+            stop=asyncio.Event(),
+            sdk_module=sdk_mod,
+            build_sdk_options_fn=build_options_fn,
+            host="testhost",
+            db_writer=writer,
+            max_restarts=max_restarts,
+        )
+
+    asyncio.run(_go())
+
+
+def _ok_build_options(name, **kw):
+    return object()
+
+
+class TestSessionAuthFailureLoud:
+    """A 401 mid-session is reported as auth-expired with the hint."""
+
+    def test_session_401_records_auth_expired_cause(self, tmp_path: Path) -> None:
+        # Arrange
+        writer = _CapturingDBWriter()
+        sdk_mod = _sdk_module_raising(RuntimeError("API error: 401 Unauthorized"))
+
+        def _build(name, **kw):
+            return object()
+
+        # Act
+        _run_until_done(sdk_mod, writer, build_options_fn=_build)
+        # Assert
+        assert any(e["cause"] == "auth-expired" for e in writer.errors)
+
+    def test_session_401_detail_carries_refresh_hint(self, tmp_path: Path) -> None:
+        # Arrange
+        writer = _CapturingDBWriter()
+        sdk_mod = _sdk_module_raising(RuntimeError("API error: 401 Unauthorized"))
+        # Act
+        _run_until_done(sdk_mod, writer, build_options_fn=_ok_build_options)
+        # Assert
+        assert any("claude login" in (e.get("detail") or "") for e in writer.errors)
+
+    def test_auth_failure_is_terminal_no_retry(self, tmp_path: Path) -> None:
+        # Arrange — max_restarts=3, but an auth failure must NOT retry.
+        writer = _CapturingDBWriter()
+        sdk_mod = _sdk_module_raising(RuntimeError("401 invalid api key"))
+        # Act
+        _run_until_done(
+            sdk_mod, writer, build_options_fn=_ok_build_options, max_restarts=3
+        )
+        # Assert — exactly one error row, not one-per-retry.
+        assert len(writer.errors) == 1
+
+
+class TestNonAuthFailureStillGeneric:
+    """A non-auth crash keeps the generic sdk-crash cause."""
+
+    def test_network_crash_records_sdk_crash(self, tmp_path: Path) -> None:
+        # Arrange
+        writer = _CapturingDBWriter()
+        sdk_mod = _sdk_module_raising(RuntimeError("Connection reset by peer"))
+        # Act
+        _run_until_done(sdk_mod, writer, build_options_fn=_ok_build_options)
+        # Assert
+        assert any(e["cause"] == "sdk-crash" for e in writer.errors)
+
+
+class TestOptionBuildAuthFailureLoud:
+    """Missing/expired creds at option-build time → loud auth-expired."""
+
+    def test_missing_creds_options_failure_is_auth_expired(
+        self, tmp_path: Path
+    ) -> None:
+        # Arrange
+        from scitex_agent_container.runtimes._sdk_common import SDKCommonError
+
+        writer = _CapturingDBWriter()
+        sdk_mod = _sdk_module_raising(RuntimeError("unused — build fails first"))
+
+        def _build_raises(name, **kw):
+            raise SDKCommonError(
+                "no Anthropic auth available — run `claude /login` so "
+                "/x/.credentials.json exists, or export SAC_ANTHROPIC_API_KEY."
+            )
+
+        # Act
+        _run_until_done(sdk_mod, writer, build_options_fn=_build_raises)
+        # Assert
+        assert any(e["cause"] == "auth-expired" for e in writer.errors)

--- a/tests/scitex_agent_container/runtimes/test__sdk_common.py
+++ b/tests/scitex_agent_container/runtimes/test__sdk_common.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import json
 import os
+import time
 from types import SimpleNamespace
 from typing import Any
 
@@ -34,6 +35,29 @@ from scitex_agent_container.runtimes._sdk_common import (
 )
 
 _SAC_KEY = _sdk_common._SAC_API_KEY_ENV
+
+
+def _valid_creds_json() -> str:
+    """Return a credentials.json body with a token valid for ~1 day.
+
+    ``provision_anthropic_auth`` now runs the OAuth expiry check on the
+    file before returning ``"credentials_file"`` (so an expired token
+    fails LOUDLY instead of dying mid-session). Path-selection fixtures
+    therefore need a realistically *valid* token; ``expiresAt`` is unix
+    milliseconds, far enough in the future to clear the 5-min skew.
+    """
+    expires_at_ms = int((time.time() + 86_400) * 1_000)
+    return json.dumps(
+        {
+            "claudeAiOauth": {
+                "accessToken": "tok",
+                "refreshToken": "ref",
+                "expiresAt": expires_at_ms,
+                "scopes": ["user:inference"],
+                "subscriptionType": "max",
+            }
+        }
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -125,7 +149,7 @@ class TestProvisionAuth:
         sdk_env.setenv("ANTHROPIC_API_KEY", "sk-ant-stale-from-dotfiles")
         sdk_env.delenv(_SAC_KEY)
         cred = tmp_path / ".credentials.json"
-        cred.write_text('{"claudeAiOauth": {"accessToken": "tok"}}')
+        cred.write_text(_valid_creds_json())
         sdk_env.setattr_module(_sdk_common, "_CRED_FILE", cred)
         return sdk_env
 
@@ -187,7 +211,7 @@ class TestProvisionAuth:
         # Arrange
         sdk_env.setenv("ANTHROPIC_API_KEY", "sk-ant-stale")
         cred = tmp_path / ".credentials.json"
-        cred.write_text('{"claudeAiOauth": {"accessToken": "tok"}}')
+        cred.write_text(_valid_creds_json())
         sdk_env.setattr_module(_sdk_common, "_CRED_FILE", cred)
         sdk_env.setenv(_SAC_KEY, "sk-ant-oat-sac")
         return sdk_env
@@ -289,6 +313,44 @@ class TestProvisionAuth:
         # Assert
         with ctx:
             provision_anthropic_auth()
+
+    # --- scenario: the credentials file exists but its OAuth token is
+    # already expired. The file merely *existing* must NOT be treated as
+    # usable auth — provision_anthropic_auth runs the expiry check and
+    # fails LOUDLY with the manual-refresh hint, so the agent never opens
+    # a session that dies with an ambiguous 401.
+
+    @pytest.fixture
+    def _expired_cred(self, sdk_env: _Env, tmp_path):
+        # Arrange
+        sdk_env.delenv("ANTHROPIC_API_KEY")
+        sdk_env.delenv(_SAC_KEY)
+        cred = tmp_path / ".credentials.json"
+        expired_ms = int((time.time() - 86_400) * 1_000)
+        cred.write_text(
+            json.dumps({"claudeAiOauth": {"accessToken": "x", "expiresAt": expired_ms}})
+        )
+        sdk_env.setattr_module(_sdk_common, "_CRED_FILE", cred)
+        return sdk_env
+
+    def test_expired_credentials_file_raises_loudly(self, _expired_cred):
+        # Arrange (handled by fixture)
+        # Act
+        ctx = pytest.raises(SDKCommonError)
+        # Assert
+        with ctx:
+            provision_anthropic_auth()
+
+    def test_expired_credentials_error_carries_refresh_hint(self, _expired_cred):
+        # Arrange (handled by fixture)
+        # Act
+        try:
+            provision_anthropic_auth()
+            message = ""
+        except SDKCommonError as exc:
+            message = str(exc)
+        # Assert
+        assert "claude login" in message
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scitex_agent_container/runtimes/test__sdk_common.py
+++ b/tests/scitex_agent_container/runtimes/test__sdk_common.py
@@ -8,8 +8,16 @@ Covers the three concerns the helper consolidates:
 
 PA-306: no `monkeypatch`. Env vars and module attributes are saved /
 restored via a ``sdk_env`` fixture that yields a small ``Env`` helper.
-``Env.setattr_module(_sdk_common, '_CRED_FILE', path)`` is the
-equivalent of ``monkeypatch.setattr`` with explicit teardown.
+``Env.setattr_module(_sdk_common, name, value)`` is the equivalent of
+``monkeypatch.setattr`` with explicit teardown.
+
+The credentials-file path is resolved at CALL time by
+``_sdk_common._cred_file_path()`` (honouring ``CLAUDE_CONFIG_DIR`` /
+``HOME``), NOT frozen at import. Tests therefore redirect it by pointing
+``CLAUDE_CONFIG_DIR`` at a tmp dir via :func:`_redirect_cred_dir` — this
+keeps the suite hermetic (no leak onto the operator's real
+``~/.claude/.credentials.json``, which is why the old import-frozen
+constant produced false greens locally yet failed in CI).
 
 TQ cleanup: every test follows Arrange / Act / Assert with a single
 assertion. Multi-fact scenarios are split into sibling tests sharing
@@ -21,6 +29,7 @@ from __future__ import annotations
 import json
 import os
 import time
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
@@ -42,9 +51,10 @@ def _valid_creds_json() -> str:
 
     ``provision_anthropic_auth`` now runs the OAuth expiry check on the
     file before returning ``"credentials_file"`` (so an expired token
-    fails LOUDLY instead of dying mid-session). Path-selection fixtures
-    therefore need a realistically *valid* token; ``expiresAt`` is unix
-    milliseconds, far enough in the future to clear the 5-min skew.
+    fails LOUDLY instead of dying mid-session). Every fixture that writes
+    a ``.credentials.json`` precondition needs a realistically *valid*
+    token; ``expiresAt`` is unix milliseconds, far enough in the future
+    to clear the 5-min skew.
     """
     expires_at_ms = int((time.time() + 86_400) * 1_000)
     return json.dumps(
@@ -58,6 +68,34 @@ def _valid_creds_json() -> str:
             }
         }
     )
+
+
+def _redirect_cred_dir(env: _Env, cfg_dir) -> "Path":
+    """Point the call-time cred resolver at ``cfg_dir`` and return the path.
+
+    ``_sdk_common._cred_file_path()`` honours ``CLAUDE_CONFIG_DIR`` first
+    (``<dir>/.credentials.json``). Setting it here redirects
+    ``provision_anthropic_auth`` off the operator's real
+    ``~/.claude/.credentials.json`` and onto the test's tmp dir — so the
+    suite is hermetic whether or not a real cred file exists on the host.
+    Returns the resolved ``.credentials.json`` path under ``cfg_dir``.
+    """
+    env.setenv("CLAUDE_CONFIG_DIR", str(cfg_dir))
+    return Path(cfg_dir) / ".credentials.json"
+
+
+def _write_valid_cred(env: _Env, cfg_dir) -> "Path":
+    """Redirect the cred dir to ``cfg_dir`` and write a VALID token there.
+
+    Convenience for the many fixtures that only need *some* usable cred
+    file present so ``provision_anthropic_auth`` returns
+    ``"credentials_file"`` and lets the test exercise unrelated behaviour
+    (settings flag, channel sidecar, kwargs pass-through, compose).
+    """
+    cred = _redirect_cred_dir(env, cfg_dir)
+    cred.parent.mkdir(parents=True, exist_ok=True)
+    cred.write_text(_valid_creds_json())
+    return cred
 
 
 # ---------------------------------------------------------------------------
@@ -148,9 +186,7 @@ class TestProvisionAuth:
         # Arrange
         sdk_env.setenv("ANTHROPIC_API_KEY", "sk-ant-stale-from-dotfiles")
         sdk_env.delenv(_SAC_KEY)
-        cred = tmp_path / ".credentials.json"
-        cred.write_text(_valid_creds_json())
-        sdk_env.setattr_module(_sdk_common, "_CRED_FILE", cred)
+        _write_valid_cred(sdk_env, tmp_path)
         return sdk_env
 
     def test_pre_set_anthropic_api_key_returns_credentials_file(
@@ -179,7 +215,8 @@ class TestProvisionAuth:
         # Arrange
         sdk_env.setenv("ANTHROPIC_API_KEY", "sk-ant-stale-from-dotfiles")
         sdk_env.setenv(_SAC_KEY, "sk-ant-api-sac")
-        sdk_env.setattr_module(_sdk_common, "_CRED_FILE", tmp_path / "missing")
+        # Empty cfg dir → no .credentials.json present.
+        _redirect_cred_dir(sdk_env, tmp_path)
         return sdk_env
 
     def test_sac_value_returns_sac_env(self, _sac_overrides_stale):
@@ -210,9 +247,7 @@ class TestProvisionAuth:
     def _cred_and_sac_both_present(self, sdk_env: _Env, tmp_path):
         # Arrange
         sdk_env.setenv("ANTHROPIC_API_KEY", "sk-ant-stale")
-        cred = tmp_path / ".credentials.json"
-        cred.write_text(_valid_creds_json())
-        sdk_env.setattr_module(_sdk_common, "_CRED_FILE", cred)
+        _write_valid_cred(sdk_env, tmp_path)
         sdk_env.setenv(_SAC_KEY, "sk-ant-oat-sac")
         return sdk_env
 
@@ -241,11 +276,11 @@ class TestProvisionAuth:
 
     @pytest.fixture
     def _only_sac(self, sdk_env: _Env, tmp_path):
-        # Arrange
+        # Arrange — empty cfg dir → no .credentials.json present.
         sdk_env.delenv("ANTHROPIC_API_KEY")
-        sdk_env.setattr_module(_sdk_common, "_CRED_FILE", tmp_path / "missing")
+        cred_target = _redirect_cred_dir(sdk_env, tmp_path)
         sdk_env.setenv(_SAC_KEY, "sk-ant-api-sac")
-        return (sdk_env, tmp_path)
+        return (sdk_env, cred_target)
 
     def test_sac_env_only_returns_sac_env(self, _only_sac):
         # Arrange (handled by fixture)
@@ -263,21 +298,20 @@ class TestProvisionAuth:
 
     def test_sac_env_only_does_not_create_credentials_file(self, _only_sac):
         # Arrange
-        _, tmp_path = _only_sac
+        _, cred_target = _only_sac
         # Act
         provision_anthropic_auth()
         # Assert
-        assert not (tmp_path / "missing").exists()
+        assert not cred_target.exists()
 
     # --- scenario: ``sk-ant-oat*`` SAC value flows through env override
     # only — sac NEVER synthesises credentials.json.
 
     @pytest.fixture
     def _oat_value_only(self, sdk_env: _Env, tmp_path):
-        # Arrange
+        # Arrange — cfg dir has no .credentials.json (and is never created).
         sdk_env.delenv("ANTHROPIC_API_KEY")
-        cred_target = tmp_path / ".claude" / ".credentials.json"
-        sdk_env.setattr_module(_sdk_common, "_CRED_FILE", cred_target)
+        cred_target = _redirect_cred_dir(sdk_env, tmp_path / ".claude")
         sdk_env.setenv(_SAC_KEY, "sk-ant-oat-zzz")
         return (sdk_env, cred_target)
 
@@ -304,10 +338,10 @@ class TestProvisionAuth:
         assert not cred_target.exists()
 
     def test_no_auth_raises(self, sdk_env: _Env, tmp_path):
-        # Arrange
+        # Arrange — empty cfg dir → no .credentials.json present.
         sdk_env.delenv("ANTHROPIC_API_KEY")
         sdk_env.delenv(_SAC_KEY)
-        sdk_env.setattr_module(_sdk_common, "_CRED_FILE", tmp_path / "missing")
+        _redirect_cred_dir(sdk_env, tmp_path)
         # Act
         ctx = pytest.raises(SDKCommonError)
         # Assert
@@ -325,12 +359,11 @@ class TestProvisionAuth:
         # Arrange
         sdk_env.delenv("ANTHROPIC_API_KEY")
         sdk_env.delenv(_SAC_KEY)
-        cred = tmp_path / ".credentials.json"
+        cred = _redirect_cred_dir(sdk_env, tmp_path)
         expired_ms = int((time.time() - 86_400) * 1_000)
         cred.write_text(
             json.dumps({"claudeAiOauth": {"accessToken": "x", "expiresAt": expired_ms}})
         )
-        sdk_env.setattr_module(_sdk_common, "_CRED_FILE", cred)
         return sdk_env
 
     def test_expired_credentials_file_raises_loudly(self, _expired_cred):
@@ -478,11 +511,11 @@ class TestBuildOptions:
 
     @pytest.fixture
     def _composed_opts(self, sdk_env: _Env, tmp_path):
-        # Arrange: pretend cred file exists so no env mutation.
-        cred = tmp_path / ".credentials.json"
-        cred.write_text("{}")
-        sdk_env.setattr_module(_sdk_common, "_CRED_FILE", cred)
+        # Arrange: a VALID cred file present so auth resolves to the
+        # credentials_file path (no env-key mutation needed).
+        _write_valid_cred(sdk_env, tmp_path)
         sdk_env.delenv("ANTHROPIC_API_KEY")
+        sdk_env.delenv(_SAC_KEY)
         # Arrange: register a fake agent with one MCP server.
         ws = tmp_path / "ws"
         ws.mkdir()
@@ -534,10 +567,9 @@ class TestBuildOptions:
 
     def test_extra_kwargs_pass_through(self, sdk_env: _Env, tmp_path):
         # Arrange
-        cred = tmp_path / ".credentials.json"
-        cred.write_text("{}")
-        sdk_env.setattr_module(_sdk_common, "_CRED_FILE", cred)
+        _write_valid_cred(sdk_env, tmp_path)
         sdk_env.delenv("ANTHROPIC_API_KEY")
+        sdk_env.delenv(_SAC_KEY)
         _swap_registry(sdk_env, None)
         # Act
         opts = build_sdk_options("nope", extra={"continue_conversation": True})
@@ -578,12 +610,13 @@ class TestBuildOptions:
 class TestSettingsFlag:
     @pytest.fixture
     def _opts_with_settings(self, sdk_env: _Env, tmp_path):
-        # Arrange — auth via cred file (no env mutation), and a container
-        # $HOME holding the delivered settings.local.json.
-        cred = tmp_path / ".credentials.json"
-        cred.write_text("{}")
-        sdk_env.setattr_module(_sdk_common, "_CRED_FILE", cred)
+        # Arrange — auth via a VALID cred file (resolved from
+        # CLAUDE_CONFIG_DIR, independent of the $HOME we set below for
+        # settings resolution), and a container $HOME holding the
+        # delivered settings.local.json.
+        _write_valid_cred(sdk_env, tmp_path / "cfg")
         sdk_env.delenv("ANTHROPIC_API_KEY")
+        sdk_env.delenv(_SAC_KEY)
         home = tmp_path / "home" / "agent"
         (home / ".claude").mkdir(parents=True)
         (home / ".claude" / "settings.local.json").write_text('{"hooks": {}}\n')
@@ -609,10 +642,10 @@ class TestSettingsFlag:
 
     def test_no_settings_when_file_absent(self, sdk_env: _Env, tmp_path):
         # Arrange — $HOME without a settings.local.json → no --settings.
-        cred = tmp_path / ".credentials.json"
-        cred.write_text("{}")
-        sdk_env.setattr_module(_sdk_common, "_CRED_FILE", cred)
+        # Cred resolves from CLAUDE_CONFIG_DIR, independent of $HOME.
+        _write_valid_cred(sdk_env, tmp_path / "cfg")
         sdk_env.delenv("ANTHROPIC_API_KEY")
+        sdk_env.delenv(_SAC_KEY)
         empty_home = tmp_path / "empty_home"
         empty_home.mkdir()
         sdk_env.setenv("HOME", str(empty_home))
@@ -643,11 +676,10 @@ class TestChannelSidecar:
 
     @pytest.fixture
     def _sac_channel_opts(self, sdk_env: _Env, tmp_path):
-        # Arrange: cred file present so auth needs no env mutation.
-        cred = tmp_path / ".credentials.json"
-        cred.write_text("{}")
-        sdk_env.setattr_module(_sdk_common, "_CRED_FILE", cred)
+        # Arrange: a VALID cred file present so auth needs no env mutation.
+        _write_valid_cred(sdk_env, tmp_path)
         sdk_env.delenv("ANTHROPIC_API_KEY")
+        sdk_env.delenv(_SAC_KEY)
         _swap_registry(sdk_env, None)
         # Act: thread the same sac-private extra the runner sends, including
         # an a2a_port that must NOT leak into the channel sidecar args.
@@ -696,11 +728,10 @@ class TestChannelSidecar:
         assert listen_url is None or listen_url == os.environ.get("SAC_LISTEN_BASE_URL")
 
     def test_no_error_when_a2a_port_absent(self, sdk_env: _Env, tmp_path):
-        # Arrange: cred file present; channels set but NO _a2a_port threaded.
-        cred = tmp_path / ".credentials.json"
-        cred.write_text("{}")
-        sdk_env.setattr_module(_sdk_common, "_CRED_FILE", cred)
+        # Arrange: valid cred present; channels set but NO _a2a_port threaded.
+        _write_valid_cred(sdk_env, tmp_path)
         sdk_env.delenv("ANTHROPIC_API_KEY")
+        sdk_env.delenv(_SAC_KEY)
         _swap_registry(sdk_env, None)
         # Act: a2a_port is irrelevant to inbox subscription, so its absence
         # must NOT raise — the adapter resolves the bus from env at runtime.


### PR DESCRIPTION
## Problem
An expired or rotated Pro/Max OAuth token caused the agent SDK session to die with an ambiguous 401 buried in `session.jsonl`. The credentials file merely *existing* was treated as usable auth, and a mid-session auth death fell into the generic `sdk-crash` catch-all — indistinguishable from a network blip. The operator found out only by noticing silence.

## Fix (detection + loud notification only)
- New `_runners/_auth_failure.classify_auth_failure`: a pure, SDK-free classifier that recognises Anthropic auth-rejection signatures (401, invalid key, expired/rotated OAuth, and the provision/preflight phrasings) and returns a hint-bearing message (or `None` for generic faults).
- Conversation supervisor (`_session_conversation.py`): classify both the SDK runtime crash and the `SDKCommonError` option-build failure. Record a distinct `cause="auth-expired"` with the `claude login` refresh hint in the detail through the existing operator-facing surface (`logger.error` + `state.db.errors` diary), instead of the ambiguous `sdk-crash` / `sdk-options`. Auth failures are **terminal** — no retry, since recovery is manual and retrying just burns the backoff window on N identical crashes.
- `provision_anthropic_auth` (`runtimes/_sdk_common.py`): the credentials file existing is no longer enough — run the existing OAuth expiry check and raise `SDKCommonError` with the refresh hint when the on-disk token is expired/near-expiry, so the failure surfaces *before* the session opens.

Auto-rotation / auto-healing is explicitly out of scope (deferred to FUTURE). Manual `claude login` is the recovery path.

## Tests (no mocks)
- `test__auth_failure.py`: auth signatures + preflight phrasings classify; generic faults return `None`; cause is `auth-expired`.
- `test__session_conversation_auth.py`: a real injected fake SDK raising a 401 + a capturing DB-writer object assert the loud `auth-expired` error fires with the hint, is terminal (one error row, not one-per-retry), and a non-auth crash still records `sdk-crash`; an option-build auth failure also records `auth-expired`.
- `test__sdk_common.py`: expired credentials file at provision time raises loudly with the `claude login` hint; path-selection fixtures updated to use a valid future-dated token (the realistic precondition for the file being *chosen*).

## Test command + result
Ran the full worktree suite with PYTHONPATH pointed at the worktree src.
4586 passed, 38 skipped. The only 2 failures are pre-existing and environment-dependent on `develop` (confirmed by running them against the unmodified main checkout): `test_claude_session_channels_without_port_raises` (fails when a real `~/.claude/.credentials.json` exists on the host so the SDK runs instead of raising the expected error) and `test_hanging_remote_probe_respects_timeout_budget` (flaky wall-clock perf assertion). Neither is touched by this change.
