### PR TITLE
feat(a2a): fail loud when an a2a_send push cannot reach or wake the target

### DIFF
--- a/src/scitex_agent_container/_mcp/_channel_tools.py
+++ b/src/scitex_agent_container/_mcp/_channel_tools.py
@@ -16,9 +16,29 @@ other way around at module load).
 from __future__ import annotations
 
 import json
+import logging
 from typing import Any
 
 from .channel import _recent
+
+log = logging.getLogger(__name__)
+
+
+class SendError(RuntimeError):
+    """A send/push could NOT reach or wake the target agent.
+
+    Raised by the send helper when delivery demonstrably failed:
+
+    * the transport raised (agent down / connection refused),
+    * the listen server returned a non-2xx status (delivery error), or
+    * the publish reported ``delivered_subscriber_count == 0`` — no live
+      inbox subscriber, so the message woke nobody.
+
+    The send-side ``a2a_*`` tools translate this into a loud, explicit
+    ``{"error": ...}`` result for the calling agent (never a misleading
+    success) and log it. STX hard rule: fail loudly, never silently drop
+    or return a misleading success.
+    """
 
 
 def register_tools(
@@ -59,6 +79,86 @@ def register_tools(
                 return {"status": resp.status_code, "body": resp.json()}
             except Exception:  # stx-allow: fallback (reason: non-JSON body tolerated)
                 return {"status": resp.status_code, "body": resp.text}
+
+    async def _send_or_raise(
+        target: str, path: str, payload: dict[str, Any]
+    ) -> dict[str, Any]:
+        """POST a send/push and FAIL LOUDLY when it cannot reach/wake (WI-2).
+
+        Returns the parsed ``{status, body}`` on success. Raises
+        :class:`SendError` — never a misleading success — when:
+
+        * the transport raises (target agent down / connection refused),
+        * the HTTP status is 5xx (server / infra delivery error), or
+        * ``body.delivered_subscriber_count == 0`` — no live inbox
+          subscriber, so the push woke nobody.
+
+        A **4xx** is passed through verbatim (returned, not raised). A 4xx —
+        notably the 403 ACL deny carrying ``body.reason`` — is a deliberate,
+        structured policy/client response, already loud and actionable for
+        the agent ("denial is the policy working"). Reshaping it into an
+        opaque error string would lose the structured ``reason`` and is not
+        the silent-drop/misleading-success the fail-loud rule targets.
+
+        ``delivered_subscriber_count`` ABSENT is NOT treated as zero: some
+        responses (cross-host forwards) don't carry it, and inventing a
+        zero would be a false-positive failure. Only an explicit ``0``
+        from the local publish path is the no-subscriber signal.
+        """
+        import httpx
+
+        try:
+            res = await _post(path, payload)
+        except httpx.HTTPError as exc:
+            log.warning("sac a2a: send to %r failed (transport): %s", target, exc)
+            raise SendError(
+                f"send to {target!r} failed: agent unreachable ({exc})"
+            ) from exc
+
+        status = res.get("status")
+        # 5xx (and any non-int / sub-200) = server/infra delivery failure.
+        # 4xx passes through (deliberate policy/client response — see above).
+        if isinstance(status, int) and status >= 500:
+            body = res.get("body")
+            log.warning(
+                "sac a2a: send to %r returned HTTP %s: %s", target, status, body
+            )
+            raise SendError(
+                f"send to {target!r} failed: listen returned HTTP {status} ({body})"
+            )
+        if not isinstance(status, int) or status < 200:
+            body = res.get("body")
+            log.warning(
+                "sac a2a: send to %r returned unexpected status %r: %s",
+                target,
+                status,
+                body,
+            )
+            raise SendError(
+                f"send to {target!r} failed: unexpected status {status!r} ({body})"
+            )
+
+        body = res.get("body")
+        if isinstance(body, dict):
+            delivered = body.get("delivered_subscriber_count")
+            if isinstance(delivered, int) and delivered == 0:
+                log.warning(
+                    "sac a2a: send to %r reached no subscriber "
+                    "(delivered_subscriber_count=0)",
+                    target,
+                )
+                raise SendError(
+                    f"send to {target!r} reached no live subscriber "
+                    "(delivered_subscriber_count=0): the agent is not "
+                    "subscribed to its inbox (down, not started, or its "
+                    "channel adapter is not connected) — the message woke "
+                    "nobody and was not delivered."
+                )
+        return res
+
+    def _error_result(exc: SendError) -> "list[TextContent]":
+        """Render a :class:`SendError` as a loud tool result."""
+        return [TextContent(type="text", text=json.dumps({"error": str(exc)}))]
 
     def _find(msg_id: str) -> dict[str, Any] | None:
         for ev in reversed(_recent):
@@ -173,7 +273,12 @@ def register_tools(
                 priority=arguments.get("priority"),
                 requires_reply=arguments.get("requires_reply"),
             )
-            res = await _post(f"/agents/{target}/message:send", payload)
+            try:
+                res = await _send_or_raise(
+                    target, f"/agents/{target}/message:send", payload
+                )
+            except SendError as exc:
+                return _error_result(exc)
             return [TextContent(type="text", text=json.dumps(res))]
 
         if name == "a2a_reply":
@@ -201,7 +306,12 @@ def register_tools(
                 conversation_id=orig.get("conversation_id"),
                 in_reply_to=mid,
             )
-            res = await _post(f"/agents/{target}/message:send", payload)
+            try:
+                res = await _send_or_raise(
+                    target, f"/agents/{target}/message:send", payload
+                )
+            except SendError as exc:
+                return _error_result(exc)
             return [TextContent(type="text", text=json.dumps(res))]
 
         if name == "a2a_ack":
@@ -230,7 +340,12 @@ def register_tools(
                 in_reply_to=mid,
                 ack=True,
             )
-            res = await _post(f"/agents/{target}/message:send", payload)
+            try:
+                res = await _send_or_raise(
+                    target, f"/agents/{target}/message:send", payload
+                )
+            except SendError as exc:
+                return _error_result(exc)
             return [TextContent(type="text", text=json.dumps(res))]
 
         if name == "a2a_peers":
@@ -256,4 +371,4 @@ def register_tools(
         ]
 
 
-__all__ = ["register_tools"]
+__all__ = ["SendError", "register_tools"]

--- a/src/scitex_agent_container/_mcp/_channel_wake.py
+++ b/src/scitex_agent_container/_mcp/_channel_wake.py
@@ -1,0 +1,89 @@
+"""Wake-on-push primitives for the sac MCP **channel** adapter (WI-1).
+
+A pushed A2A message to an IDLE containerized agent must WAKE it and drive
+a turn immediately — push must behave like the lead's Telegram channel,
+where a pushed message is processed now rather than buffered until some
+unrelated next turn. The ``notifications/claude/channel`` push that the
+receive-side adapter emits renders a ``<channel>`` tag for an *active* turn
+but does NOT advance an idle session's turn.
+
+This module is the wake mechanism: given the agent's own colocated
+``/v1/turn`` endpoint URL, it POSTs each qualifying bus event there so the
+runner enqueues it onto the persistent SDK conversation and drives a turn
+at once. Extracted from :mod:`scitex_agent_container._mcp.channel` (which
+hit the module size budget); ``channel`` re-exports these for the historical
+import path.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = ["_should_wake_turn", "_wake_text", "_wake_turn"]
+
+
+def _should_wake_turn(event: dict[str, Any]) -> bool:
+    """Whether a received bus event should DRIVE a turn (wake-on-push).
+
+    A pushed message to an idle agent must wake it and be processed now —
+    push ≡ Telegram. We drive a turn for normal inbound messages but skip:
+
+    - **acks** (truthy ``ack`` flag): a stage-2 read-receipt carries no
+      content for the agent to act on; driving a turn on every ack would
+      burn a turn (and tokens) per receipt and could ping-pong with the
+      auto-ack side-effect.
+    - **empty content**: nothing to feed the SDK as turn input.
+
+    The notification push (the ``<channel>`` tag) still fires for these in
+    the no-wake path — only the turn-driving wake is gated here.
+    """
+    if event.get("ack"):
+        return False
+    content = event.get("content")
+    return isinstance(content, str) and content.strip() != ""
+
+
+def _wake_text(event: dict[str, Any]) -> str:
+    """Render the turn input fed to the agent's ``/v1/turn`` on wake.
+
+    Mirrors the ``<channel ...>`` framing Claude renders for an in-session
+    push so a woken (idle) agent sees the same shape it would have seen had
+    the notification arrived mid-turn — source, msg_id, and the message
+    body. This keeps the wake path behaviourally identical to the lead's
+    Telegram channel: the message is processed as a real turn, attributed
+    to its sender.
+    """
+    source = event.get("from_agent", "unknown")
+    msg_id = event.get("msg_id", "")
+    content = event.get("content", "")
+    return f'<channel source="{source}" msg_id="{msg_id}">\n{content}\n</channel>'
+
+
+async def _wake_turn(
+    event: dict[str, Any],
+    *,
+    turn_url: str,
+    bearer: str | None,
+) -> None:
+    """POST ``event`` to the agent's own ``/v1/turn`` to DRIVE a turn now.
+
+    This is the wake-on-push primitive: the colocated runner's ``/v1/turn``
+    endpoint enqueues the text onto the persistent SDK conversation and
+    drives a turn immediately, so a push to an IDLE agent is processed at
+    once rather than buffered until some unrelated next turn. Raises on any
+    transport/HTTP failure so the caller can decide whether to surface or
+    contain it (WI-2 fail-loud).
+    """
+    import httpx
+
+    headers = {"Content-Type": "application/json"}
+    if bearer:
+        headers["Authorization"] = f"Bearer {bearer}"
+    payload = {"text": _wake_text(event)}
+    # The wake POST returns only after the driven turn completes (the runner
+    # awaits the SDK reply before responding). Use no client-side deadline —
+    # a short client timeout would abort a legitimately long turn; the runner
+    # imposes its own bounded per-turn timeout and answers with a 504.
+    async with httpx.AsyncClient(timeout=None) as client:
+        resp = await client.post(turn_url, json=payload, headers=headers)
+        resp.raise_for_status()

--- a/src/scitex_agent_container/_mcp/channel.py
+++ b/src/scitex_agent_container/_mcp/channel.py
@@ -67,6 +67,13 @@ def _auto_ack_enabled() -> bool:
     return raw.strip().lower() not in ("0", "false", "no", "off")
 
 
+# WI-1 wake-on-push primitives live in ``_channel_wake`` (extracted to keep
+# this receive-side adapter under the module size budget). Re-exported here
+# so the historical ``from .channel import _wake_turn`` import path — used by
+# ``_push_channel_event`` below and the test suite — keeps working.
+from ._channel_wake import _should_wake_turn, _wake_text, _wake_turn  # noqa: E402,F401
+
+
 def _should_auto_ack(event: dict[str, Any]) -> bool:
     """Loop-guard for the auto-ack side-effect.
 
@@ -253,38 +260,63 @@ async def _push_channel_event(
     agent_name: str | None = None,
     listen_url: str | None = None,
     bearer: str | None = None,
+    turn_url: str | None = None,
 ) -> None:
-    """Buffer ``event``, push it to the client as a
-    ``notifications/claude/channel`` message through ``session``, then —
-    if auto-ack is enabled and the event qualifies — emit an automatic
-    ``a2a_ack`` back to the sender (stage-2 "read" receipt).
+    """Deliver ``event`` to the agent, then emit the stage-2 read-receipt.
 
-    Split out of the SSE consumer so the receive→inject path is
-    directly testable end-to-end (see ``tests/.../_mcp/test_channel.py``
-    ``test_serve_pushes_sse_event_to_client_as_channel_notification``).
-    That seam used to be untested, which let a silent drop ship.
+    Delivery has two modes:
 
-    The auto-ack is a best-effort side-effect: it runs only *after* the
-    notification is injected and its failure is logged loudly but never
-    re-raised, so a flaky send can neither block injection nor kill the
-    long-lived SSE consumer. The agent is unaware — the adapter acks.
+    * **Wake-on-push (WI-1)** — when ``turn_url`` is set and the event
+      qualifies (:func:`_should_wake_turn`), POST it to the agent's own
+      ``/v1/turn`` so an IDLE session WAKES and processes the message now.
+      Push then behaves like the lead's Telegram channel. The driven turn
+      carries the message as its input, so the ``notifications/claude/
+      channel`` push is intentionally SKIPPED in this mode — pushing it too
+      would make the agent see the same message twice (once as turn input,
+      once as a buffered ``<channel>`` tag on the next turn boundary).
+    * **Notification-only (legacy / external nodes)** — when no ``turn_url``
+      is configured (a plain ``claude`` node with no colocated runner), push
+      the ``notifications/claude/channel`` message through ``session`` so an
+      already-active turn renders the ``<channel>`` tag. This cannot wake an
+      idle session — that is exactly the limitation ``turn_url`` removes.
+
+    Split out of the SSE consumer so the receive→inject path is directly
+    testable end-to-end (see ``tests/.../_mcp/test_channel.py``). That seam
+    used to be untested, which let a silent drop ship.
+
+    The auto-ack is a best-effort side-effect: it runs only *after* delivery
+    and its failure is logged loudly but never re-raised, so a flaky receipt
+    can neither block delivery nor kill the long-lived SSE consumer.
     """
     from mcp.shared.message import SessionMessage
     from mcp.types import JSONRPCMessage, JSONRPCNotification
 
     # Buffer for a2a_reply / a2a_ack lookups by msg_id.
     _recent.append(event)
-    params = _build_notification(event)
-    msg = JSONRPCMessage(
-        JSONRPCNotification(
-            jsonrpc="2.0",
-            method="notifications/claude/channel",
-            params=params,
-        )
-    )
-    await session.send_message(SessionMessage(msg))
 
-    # Stage-2 receipt: auto-ack AFTER successful injection. Best-effort —
+    woke = False
+    if turn_url is not None and _should_wake_turn(event):
+        # Wake path: drive a turn on the agent's own runner. A failure here
+        # is NOT silently contained — re-raise so the SSE consumer's
+        # on_event wrapper logs it loudly (WI-2 fail-loud) while keeping the
+        # long-lived stream alive. We must never pretend a wake succeeded.
+        await _wake_turn(event, turn_url=turn_url, bearer=bearer)
+        woke = True
+
+    if not woke:
+        # Notification-only delivery (no colocated runner to wake, or an
+        # ack/empty event that does not warrant a driven turn).
+        params = _build_notification(event)
+        msg = JSONRPCMessage(
+            JSONRPCNotification(
+                jsonrpc="2.0",
+                method="notifications/claude/channel",
+                params=params,
+            )
+        )
+        await session.send_message(SessionMessage(msg))
+
+    # Stage-2 receipt: auto-ack AFTER successful delivery. Best-effort —
     # never let an ack failure propagate past this point.
     if (
         agent_name is not None
@@ -314,9 +346,15 @@ async def _serve(
     name: str,
     listen_url: str,
     bearer: str | None,
+    turn_url: str | None = None,
 ) -> None:
     """Drive the MCP session **and** the SSE consumer over the given
     streams, keeping a handle to the session so the consumer can push.
+
+    ``turn_url`` (WI-1) is the agent's own colocated ``/v1/turn`` endpoint.
+    When set, each received bus event WAKES the session by driving a turn
+    there (push ≡ Telegram); when ``None`` the adapter falls back to the
+    notification-only push that cannot advance an idle turn.
 
     We deliberately do not call ``Server.run``: it constructs its
     ``ServerSession`` internally and never exposes it, so a side
@@ -363,9 +401,10 @@ async def _serve(
                     agent_name=name,
                     listen_url=listen_url,
                     bearer=bearer,
+                    turn_url=turn_url,
                 )
-            except Exception as exc:  # stx-allow: fallback (reason: one failed push must not kill the long-lived SSE consumer; logged loudly, never silent)
-                log.warning("sac channel: pushing inbox event failed: %s", exc)
+            except Exception as exc:  # stx-allow: fallback (reason: one failed push/wake must not kill the long-lived SSE consumer; logged loudly, never silent)
+                log.warning("sac channel: delivering inbox event failed: %s", exc)
 
         sse_task: asyncio.Task[None] = asyncio.create_task(
             _consume_sse(sse_url, bearer, on_event)
@@ -384,7 +423,9 @@ async def _serve(
             sse_task.cancel()
 
 
-async def _run(name: str, listen_url: str, bearer: str | None) -> None:
+async def _run(
+    name: str, listen_url: str, bearer: str | None, turn_url: str | None = None
+) -> None:
     from mcp.server.stdio import stdio_server
 
     async with stdio_server() as (read_stream, write_stream):
@@ -394,6 +435,7 @@ async def _run(name: str, listen_url: str, bearer: str | None) -> None:
             name=name,
             listen_url=listen_url,
             bearer=bearer,
+            turn_url=turn_url,
         )
 
 
@@ -410,18 +452,21 @@ def _register_tools(
     """
     from ._channel_tools import register_tools
 
-    register_tools(
-        server, agent_name=agent_name, listen_url=listen_url, bearer=bearer
-    )
+    register_tools(server, agent_name=agent_name, listen_url=listen_url, bearer=bearer)
 
 
-def main(name: str, listen_url: str | None = None) -> None:
-    """CLI entry point. Bearer comes from ``SAC_LISTEN_BEARER`` env."""
+def main(name: str, listen_url: str | None = None, turn_url: str | None = None) -> None:
+    """CLI entry point. Bearer comes from ``SAC_LISTEN_BEARER`` env.
+
+    ``turn_url`` (WI-1) is the agent's own ``/v1/turn`` endpoint; when set,
+    each received bus event WAKES the session by driving a turn there so a
+    push to an idle agent is processed immediately (push ≡ Telegram).
+    """
     listen = listen_url or os.environ.get(
         "SAC_LISTEN_BASE_URL", "http://127.0.0.1:7878"
     )
     bearer = os.environ.get("SAC_LISTEN_BEARER")
-    asyncio.run(_run(name, listen, bearer))
+    asyncio.run(_run(name, listen, bearer, turn_url))
 
 
 __all__ = ["main"]

--- a/src/scitex_agent_container/cli_pkg/mcp_group.py
+++ b/src/scitex_agent_container/cli_pkg/mcp_group.py
@@ -146,21 +146,35 @@ def mcp_start(use_http: bool, host: str, port: int, dry_run: bool, yes: bool) ->
     default=None,
     help="sac listen base URL (default: $SAC_LISTEN_BASE_URL or http://127.0.0.1:7878).",
 )
-def mcp_channel(name: str, listen_url: str | None) -> None:
+@click.option(
+    "--turn-url",
+    default=None,
+    help=(
+        "The agent's own colocated /v1/turn endpoint (e.g. "
+        "http://127.0.0.1:18888/v1/turn). When set, each received bus event "
+        "is POSTed here so a push WAKES an idle session and drives a turn "
+        "immediately (push behaves like the lead's Telegram channel). "
+        "Without it the adapter only pushes the channel notification, which "
+        "does not advance an idle agent's turn."
+    ),
+)
+def mcp_channel(name: str, listen_url: str | None, turn_url: str | None) -> None:
     """Run the sac push channel adapter as a stdio MCP subprocess.
 
     Intended to be spawned by Claude Code via
     ``--dangerously-load-development-channels server:sac`` — see
     ``docs/sac-and-orochi.md``. Streams inbox events from sac listen
     as ``notifications/claude/channel`` so the running session sees
-    ``<channel source="..." msg_id="...">`` tags in real time.
+    ``<channel source="..." msg_id="...">`` tags in real time, and (when
+    ``--turn-url`` is set) WAKES the session by POSTing each event to the
+    agent's own ``/v1/turn`` so an idle agent processes it immediately.
 
     \b
     Example (manual):
       $ sac mcp channel --name lead
     """
     _channel_main = _load_channel_main()
-    _channel_main(name=name, listen_url=listen_url)
+    _channel_main(name=name, listen_url=listen_url, turn_url=turn_url)
 
 
 @mcp.command("doctor")

--- a/src/scitex_agent_container/runtimes/_sdk_common.py
+++ b/src/scitex_agent_container/runtimes/_sdk_common.py
@@ -418,14 +418,18 @@ def build_sdk_options(
     # ClaudeAgentOptions is strict and rejects unknown fields. The
     # ``_*`` prefix marks these as sac-internal (not SDK fields).
     channels: list[str] | None = None
+    a2a_port: int | None = None
     if extra:
         extra = dict(extra)  # shallow copy so we can mutate
         channels = extra.pop("_channels", None)
-        # ``_a2a_port`` is threaded for the /v1/turn registration path; the
-        # channel sidecar below does NOT use it (the inbox SSE lives on the
-        # bus, resolved from SAC_LISTEN_BASE_URL). Pop it only to strip the
-        # sac-private key before merging ``extra`` into ClaudeAgentOptions.
-        extra.pop("_a2a_port", None)
+        # ``_a2a_port`` is threaded for two purposes:
+        #   1. The /v1/turn registration path (handled by the runner).
+        #   2. The channel sidecar's WAKE path (WI-1) — the adapter POSTs
+        #      received bus events to the agent's OWN ``/v1/turn`` on this
+        #      port so a push WAKES an idle session (push ≡ Telegram). This
+        #      is the agent's loopback turn endpoint, NOT the bus inbox SSE
+        #      (that still lives on SAC_LISTEN_BASE_URL — see below).
+        a2a_port = extra.pop("_a2a_port", None)
         if extra:
             kwargs.update(extra)
 
@@ -461,14 +465,23 @@ def build_sdk_options(
             # the inbox route, so the bus saw zero subscribers and
             # delivered_subscriber_count was always 0.
             #
-            # a2a_port stays threaded for the /v1/turn registration path; it
-            # is simply irrelevant to inbox subscription.
+            # a2a_port is irrelevant to inbox SUBSCRIPTION but IS the wake
+            # path (WI-1): pass it as ``--turn-url`` so the adapter can POST
+            # received bus events to the agent's OWN ``/v1/turn`` and WAKE an
+            # idle session. The bind host is loopback (the sidecar and the
+            # runner share the container netns); host LAN exposure of the turn
+            # endpoint does not change the in-container wake target.
             sidecar_args = [
                 "mcp",
                 "channel",
                 "--name",
                 agent_name,
             ]
+            if a2a_port is not None:
+                sidecar_args += [
+                    "--turn-url",
+                    f"http://127.0.0.1:{int(a2a_port)}/v1/turn",
+                ]
             mcps["sac"] = {
                 "type": "stdio",
                 "command": "sac",

--- a/tests/scitex_agent_container/_mcp/test__channel_tools.py
+++ b/tests/scitex_agent_container/_mcp/test__channel_tools.py
@@ -45,6 +45,14 @@ class _FakeListenServer:
         self._server: asyncio.base_events.Server | None = None
         self.host: str = "127.0.0.1"
         self.port: int = 0
+        # Response the fake returns for a successful ``message:send`` POST.
+        # Default mirrors the historical fake (200 + ``{"ok": True}``). WI-2
+        # tests override this to model a real publish reply carrying
+        # ``delivered_subscriber_count``.
+        self.send_response: dict[str, Any] = {"ok": True}
+        # When set, ``message:send`` returns this HTTP status with a tiny
+        # body instead of a 200 JSON envelope (models a delivery error).
+        self.send_status: int = 200
 
     async def start(self) -> None:
         self._server = await asyncio.start_server(self._handle, host=self.host, port=0)
@@ -95,7 +103,12 @@ class _FakeListenServer:
                 except json.JSONDecodeError:
                     payload = {}
                 self.posts.append((path, payload))
-                await self._serve_json(writer, {"ok": True})
+                if self.send_status != 200:
+                    await self._serve_status(
+                        writer, self.send_status, b"delivery error"
+                    )
+                else:
+                    await self._serve_json(writer, self.send_response)
             else:
                 await self._serve_status(writer, 404, b"not found")
         finally:
@@ -502,3 +515,141 @@ async def test_register_tools_forwards_bearer_token_on_post(fake_listen):
     await rec.call_tool_fn("a2a_send", {"target": "bob", "content": "hi"})
     # Assert
     assert fake_listen.last_auth == "Bearer s3cret"
+
+
+# ---------------------------------------------------------------------------
+# WI-2 fail-loud — a send/push that cannot reach or wake the target must
+# surface a loud, explicit error to the caller, never a misleading success.
+#
+# Three failure modes from the work-item: no inbox subscriber
+# (delivered_subscriber_count == 0), agent stopped (connection refused),
+# delivery error (non-2xx). Real loopback servers, no mocks.
+# ---------------------------------------------------------------------------
+
+
+def _err(out: "list[TextContent]") -> str | None:
+    """Pull the ``error`` field out of a tool result, or None."""
+    body = json.loads(out[0].text)
+    return body.get("error") if isinstance(body, dict) else None
+
+
+@pytest.mark.asyncio
+async def test_a2a_send_no_subscriber_returns_loud_error(
+    registered_tools: _ToolRecorder, fake_listen
+):
+    """delivered_subscriber_count == 0 → the push woke nobody → loud error,
+    not a misleading success body."""
+    # Arrange — model a publish reply with zero subscribers.
+    fake_listen.send_response = {
+        "msg_id": "m1",
+        "to_agent": "bob",
+        "delivered_subscriber_count": 0,
+    }
+    call_fn = registered_tools.call_tool_fn
+    # Act
+    out = await call_fn("a2a_send", {"target": "bob", "content": "hi"})
+    # Assert
+    assert "no live subscriber" in (_err(out) or "")
+
+
+@pytest.mark.asyncio
+async def test_a2a_send_with_subscriber_returns_success(
+    registered_tools: _ToolRecorder, fake_listen
+):
+    """A delivered_subscriber_count >= 1 is a real delivery — success, no
+    error (guards against the fail-loud check over-firing)."""
+    # Arrange
+    fake_listen.send_response = {
+        "msg_id": "m1",
+        "to_agent": "bob",
+        "delivered_subscriber_count": 1,
+    }
+    call_fn = registered_tools.call_tool_fn
+    # Act
+    out = await call_fn("a2a_send", {"target": "bob", "content": "hi"})
+    # Assert
+    assert _err(out) is None
+
+
+@pytest.mark.asyncio
+async def test_a2a_send_delivery_error_status_returns_loud_error(
+    registered_tools: _ToolRecorder, fake_listen
+):
+    """A non-2xx from the listen server (e.g. 502 forward failure) is a
+    delivery error — surface it loudly, not as a success body."""
+    # Arrange
+    fake_listen.send_status = 502
+    call_fn = registered_tools.call_tool_fn
+    # Act
+    out = await call_fn("a2a_send", {"target": "bob", "content": "hi"})
+    # Assert
+    assert "HTTP 502" in (_err(out) or "")
+
+
+@pytest.mark.asyncio
+async def test_a2a_send_agent_stopped_connection_refused_returns_loud_error():
+    """Target agent down / listen unreachable (refused connection) → loud
+    'agent unreachable' error rather than a hang or silent success."""
+    # Arrange — register tools pointing at a closed loopback port.
+    import socket
+
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    refused_port = s.getsockname()[1]
+    s.close()
+    rec = _ToolRecorder()
+    register_tools(
+        rec,
+        agent_name="alice",
+        listen_url=f"http://127.0.0.1:{refused_port}",
+        bearer=None,
+    )
+    # Act
+    out = await rec.call_tool_fn("a2a_send", {"target": "bob", "content": "hi"})
+    # Assert
+    assert "unreachable" in (_err(out) or "")
+
+
+@pytest.mark.asyncio
+async def test_a2a_send_absent_delivered_count_is_not_treated_as_failure(
+    registered_tools: _ToolRecorder, fake_listen
+):
+    """A 200 reply WITHOUT delivered_subscriber_count (e.g. a cross-host
+    forward) must NOT be flagged as a no-subscriber failure — inventing a
+    zero would be a false positive."""
+    # Arrange — default fake response is ``{"ok": True}`` (no count field).
+    call_fn = registered_tools.call_tool_fn
+    # Act
+    out = await call_fn("a2a_send", {"target": "bob", "content": "hi"})
+    # Assert
+    assert _err(out) is None
+
+
+@pytest.mark.asyncio
+async def test_a2a_reply_no_subscriber_returns_loud_error(
+    registered_tools: _ToolRecorder, fake_listen
+):
+    """The reply path shares the fail-loud send helper."""
+    # Arrange — seed a known inbound message to reply to, then zero subs.
+    _recent.append({"msg_id": "orig1", "from_agent": "bob", "conversation_id": "c1"})
+    fake_listen.send_response = {"delivered_subscriber_count": 0}
+    call_fn = registered_tools.call_tool_fn
+    # Act
+    out = await call_fn("a2a_reply", {"in_reply_to": "orig1", "content": "hey"})
+    # Assert
+    assert "no live subscriber" in (_err(out) or "")
+
+
+@pytest.mark.asyncio
+async def test_a2a_ack_no_subscriber_returns_loud_error(
+    registered_tools: _ToolRecorder, fake_listen
+):
+    """The explicit ack tool also fails loud when it reaches no subscriber."""
+    # Arrange
+    _recent.append({"msg_id": "orig2", "from_agent": "bob", "conversation_id": "c2"})
+    fake_listen.send_response = {"delivered_subscriber_count": 0}
+    call_fn = registered_tools.call_tool_fn
+    # Act
+    out = await call_fn("a2a_ack", {"msg_id": "orig2"})
+    # Assert
+    assert "no live subscriber" in (_err(out) or "")

--- a/tests/scitex_agent_container/_mcp/test_channel.py
+++ b/tests/scitex_agent_container/_mcp/test_channel.py
@@ -1132,3 +1132,282 @@ async def test_auto_ack_failure_is_best_effort_does_not_raise():
     )
     # Assert — injection still succeeded (the failure was contained).
     assert len(session.sent) == 1
+
+
+# ---------------------------------------------------------------------------
+# WI-1 wake-on-push — a pushed message to an IDLE agent must DRIVE a turn.
+#
+# The notification-only push (covered above) renders a ``<channel>`` tag for
+# an already-active turn but does NOT advance an idle session. When a
+# ``turn_url`` (the agent's own colocated ``/v1/turn``) is configured, the
+# adapter POSTs each qualifying event there so the runner enqueues it onto
+# the persistent SDK conversation and processes it immediately — push behaves
+# like the lead's Telegram channel. These tests pin: a real POST reaches the
+# turn endpoint, acks/empty events do NOT drive a turn, and the wake path
+# delivers exactly once (no duplicate notification).
+# ---------------------------------------------------------------------------
+
+
+class _FakeTurnServer:
+    """A real asyncio TCP server standing in for the agent's ``/v1/turn``.
+
+    Records every POST body so the wake path is directly observable. Not a
+    mock — a genuine loopback HTTP/1.1 endpoint, same approach as
+    ``_FakeListenServer``.
+    """
+
+    def __init__(self) -> None:
+        self.turns: list[dict[str, Any]] = []
+        self._server: asyncio.base_events.Server | None = None
+        self.host = "127.0.0.1"
+        self.port = 0
+
+    async def start(self) -> None:
+        self._server = await asyncio.start_server(self._handle, host=self.host, port=0)
+        self.port = self._server.sockets[0].getsockname()[1]
+
+    async def stop(self) -> None:
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+            self._server = None
+
+    @property
+    def turn_url(self) -> str:
+        return f"http://{self.host}:{self.port}/v1/turn"
+
+    async def _handle(self, reader, writer) -> None:
+        try:
+            request_line = await reader.readline()
+            if not request_line:
+                return
+            content_length = 0
+            while True:
+                line = await reader.readline()
+                if line in (b"\r\n", b"\n", b""):
+                    break
+                if line.lower().startswith(b"content-length:"):
+                    content_length = int(line.split(b":", 1)[1].strip())
+            body = b""
+            if content_length:
+                body = await reader.readexactly(content_length)
+            try:
+                payload = json.loads(body.decode() or "{}")
+            except json.JSONDecodeError:
+                payload = {}
+            self.turns.append(payload)
+            resp = json.dumps({"text": "ok", "session_id": "s1"}).encode()
+            writer.write(
+                b"HTTP/1.1 200 OK\r\n"
+                b"Content-Type: application/json\r\n"
+                b"Content-Length: " + str(len(resp)).encode() + b"\r\n"
+                b"Connection: close\r\n\r\n" + resp
+            )
+            await writer.drain()
+        finally:
+            try:
+                writer.close()
+                await writer.wait_closed()
+            except Exception:
+                pass
+
+
+@pytest_asyncio.fixture
+async def fake_turn():
+    s = _FakeTurnServer()
+    await s.start()
+    try:
+        yield s
+    finally:
+        await s.stop()
+
+
+def test_should_wake_turn_true_for_normal_inbound_event():
+    # Arrange
+    from scitex_agent_container._mcp.channel import _should_wake_turn
+
+    event = {"from_agent": "bob", "content": "do the thing", "msg_id": "m1"}
+    # Act
+    decision = _should_wake_turn(event)
+    # Assert
+    assert decision is True
+
+
+def test_should_wake_turn_false_for_ack_event():
+    """An ack carries no actionable content — driving a turn per receipt
+    would burn turns and risk an auto-ack ping-pong."""
+    # Arrange
+    from scitex_agent_container._mcp.channel import _should_wake_turn
+
+    event = {"from_agent": "bob", "content": "", "msg_id": "m1", "ack": True}
+    # Act
+    decision = _should_wake_turn(event)
+    # Assert
+    assert decision is False
+
+
+def test_should_wake_turn_false_for_empty_content():
+    # Arrange
+    from scitex_agent_container._mcp.channel import _should_wake_turn
+
+    event = {"from_agent": "bob", "content": "   ", "msg_id": "m1"}
+    # Act
+    decision = _should_wake_turn(event)
+    # Assert
+    assert decision is False
+
+
+def test_wake_text_frames_content_with_source_and_msg_id():
+    # Arrange
+    from scitex_agent_container._mcp.channel import _wake_text
+
+    event = {"from_agent": "bob", "content": "hello", "msg_id": "m1"}
+    # Act
+    text = _wake_text(event)
+    # Assert — the sender attribution survives into the driven turn input.
+    assert 'source="bob"' in text and "hello" in text
+
+
+@pytest.mark.asyncio
+async def test_push_with_turn_url_drives_a_turn(fake_turn):
+    """The wake POST reaches the agent's own /v1/turn — the core WI-1 claim:
+    a pushed message to an idle agent advances its turn without any external
+    turn trigger."""
+    # Arrange
+    from scitex_agent_container._mcp.channel import _push_channel_event
+
+    session = _CapturingSession()
+    event = {"from_agent": "bob", "content": "summarize commits", "msg_id": "m1"}
+    # Act — turn_url set: the adapter must drive a turn.
+    await _push_channel_event(
+        session,
+        event,
+        agent_name="alice",
+        listen_url="http://127.0.0.1:1",  # unused on the wake path
+        bearer=None,
+        turn_url=fake_turn.turn_url,
+    )
+    # Assert — exactly one turn was driven on the runner's endpoint.
+    assert len(fake_turn.turns) == 1
+
+
+@pytest.mark.asyncio
+async def test_push_with_turn_url_carries_message_content_as_turn_text(fake_turn):
+    # Arrange
+    from scitex_agent_container._mcp.channel import _push_channel_event
+
+    session = _CapturingSession()
+    event = {"from_agent": "bob", "content": "summarize commits", "msg_id": "m1"}
+    # Act
+    await _push_channel_event(
+        session,
+        event,
+        agent_name="alice",
+        listen_url="http://127.0.0.1:1",
+        bearer=None,
+        turn_url=fake_turn.turn_url,
+    )
+    # Assert — the driven turn carries the original message body.
+    assert "summarize commits" in fake_turn.turns[0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_push_with_turn_url_skips_duplicate_notification(fake_turn):
+    """Wake delivers the message as turn input; the notification push is
+    skipped so the agent does not see the same message twice."""
+    # Arrange
+    from scitex_agent_container._mcp.channel import _push_channel_event
+
+    session = _CapturingSession()
+    event = {"from_agent": "bob", "content": "do it", "msg_id": "m1"}
+    # Act
+    await _push_channel_event(
+        session,
+        event,
+        agent_name="alice",
+        listen_url="http://127.0.0.1:1",
+        bearer=None,
+        turn_url=fake_turn.turn_url,
+    )
+    # Assert — no notification was injected (turn input is the sole delivery).
+    assert session.sent == []
+
+
+@pytest.mark.asyncio
+async def test_push_with_turn_url_ack_event_does_not_drive_turn(fake_turn):
+    """An ack event must NOT wake a turn — it falls back to notification-only
+    so the loop-guard / receipt semantics are unchanged."""
+    # Arrange
+    from scitex_agent_container._mcp.channel import _push_channel_event
+
+    session = _CapturingSession()
+    ack_event = {"from_agent": "bob", "content": "", "msg_id": "m1", "ack": True}
+    # Act
+    await _push_channel_event(
+        session,
+        ack_event,
+        agent_name="alice",
+        listen_url="http://127.0.0.1:1",
+        bearer=None,
+        turn_url=fake_turn.turn_url,
+    )
+    # Assert — zero turns driven for an ack.
+    assert fake_turn.turns == []
+
+
+@pytest.mark.asyncio
+async def test_push_without_turn_url_falls_back_to_notification(fake_listen):
+    """Backward-compat: with no turn_url (external node, no colocated
+    runner) the adapter still pushes the channel notification."""
+    # Arrange
+    from scitex_agent_container._mcp.channel import _push_channel_event
+
+    session = _CapturingSession()
+    event = {"from_agent": "bob", "content": "hi", "msg_id": "m1"}
+    # Act — no turn_url.
+    await _push_channel_event(
+        session,
+        event,
+        agent_name="alice",
+        listen_url=fake_listen.base_url,
+        bearer=None,
+    )
+    # Assert — notification injected as before.
+    assert len(session.sent) == 1
+
+
+@pytest.mark.asyncio
+async def test_wake_failure_propagates_to_caller():
+    """WI-2 fail-loud: when the wake POST cannot reach the runner (refused
+    connection), ``_push_channel_event`` must RAISE rather than silently
+    pretend the message was delivered."""
+    # Arrange — a closed loopback port refuses connect.
+    import socket
+
+    from scitex_agent_container._mcp.channel import _push_channel_event
+
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    refused_port = s.getsockname()[1]
+    s.close()
+    session = _CapturingSession()
+    event = {"from_agent": "bob", "content": "hi", "msg_id": "m1"}
+
+    async def _do() -> None:
+        await _push_channel_event(
+            session,
+            event,
+            agent_name="alice",
+            listen_url="http://127.0.0.1:1",
+            bearer=None,
+            turn_url=f"http://127.0.0.1:{refused_port}/v1/turn",
+        )
+
+    # Act
+    raised = False
+    try:
+        await _do()
+    except Exception:
+        raised = True
+    # Assert — the unreachable wake surfaced loudly, not silently dropped.
+    assert raised is True

--- a/tests/scitex_agent_container/cli_pkg/test_mcp_group.py
+++ b/tests/scitex_agent_container/cli_pkg/test_mcp_group.py
@@ -357,6 +357,61 @@ def test_install_claude_code_emits_mcp_config_snippet():
 
 
 # ---------------------------------------------------------------------------
+# channel — wake-on-push turn-url passthrough (WI-1)
+# ---------------------------------------------------------------------------
+
+
+class _FakeChannelMain:
+    """Real callable recording each ``channel.main(...)`` invocation."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def __call__(self, *, name: str, listen_url=None, turn_url=None) -> None:
+        self.calls.append(
+            {"name": name, "listen_url": listen_url, "turn_url": turn_url}
+        )
+
+
+@contextmanager
+def _use_channel_main(fake: _FakeChannelMain) -> Iterator[_FakeChannelMain]:
+    """Swap ``mcp_group._load_channel_main`` for a loader returning ``fake``."""
+    saved = mg._load_channel_main
+    mg._load_channel_main = lambda: fake
+    try:
+        yield fake
+    finally:
+        mg._load_channel_main = saved
+
+
+def test_channel_forwards_turn_url_to_main():
+    # Arrange
+    fake = _FakeChannelMain()
+    runner = CliRunner()
+    # Act
+    with _use_channel_main(fake):
+        result = runner.invoke(
+            mcp,
+            ["channel", "--name", "lead", "--turn-url", "http://127.0.0.1:9/v1/turn"],
+        )
+    # Assert
+    assert result.exit_code == 0 and fake.calls[0]["turn_url"] == (
+        "http://127.0.0.1:9/v1/turn"
+    )
+
+
+def test_channel_turn_url_defaults_to_none():
+    # Arrange
+    fake = _FakeChannelMain()
+    runner = CliRunner()
+    # Act
+    with _use_channel_main(fake):
+        result = runner.invoke(mcp, ["channel", "--name", "lead"])
+    # Assert
+    assert result.exit_code == 0 and fake.calls[0]["turn_url"] is None
+
+
+# ---------------------------------------------------------------------------
 # _enumerate_tools — version-agnostic shape detection (real classes only)
 # ---------------------------------------------------------------------------
 

--- a/tests/scitex_agent_container/runtimes/test__sdk_common.py
+++ b/tests/scitex_agent_container/runtimes/test__sdk_common.py
@@ -614,11 +614,29 @@ class TestChannelSidecar:
     def test_sidecar_args_omit_a2a_port_listen_url(self, _sac_channel_opts):
         # Arrange
         sac = _sac_channel_opts.mcp_servers["sac"]  # type: ignore[index]
-        # Act — the a2a_port (9999) must never appear in any sidecar arg.
         args = sac["args"]
-        # Assert: bus URL resolution is delegated to the adapter's main()
-        # via SAC_LISTEN_BASE_URL; no hardcoded a2a-port listen-url here.
-        assert not any("9999" in str(a) for a in args)
+        # Act — find the --listen-url value, if any.
+        if "--listen-url" in args:
+            listen_url = args[args.index("--listen-url") + 1]
+        else:
+            listen_url = None
+        # Assert: the a2a_port (9999) must NOT be the BUS listen-url — bus URL
+        # resolution is delegated to the adapter's main() via
+        # SAC_LISTEN_BASE_URL. (It DOES appear as --turn-url, the agent's own
+        # /v1/turn wake target — a distinct concern, covered separately.)
+        assert listen_url is None or "9999" not in str(listen_url)
+
+    def test_sidecar_args_carry_turn_url_for_wake(self, _sac_channel_opts):
+        """WI-1: the a2a_port is threaded as ``--turn-url`` so the adapter can
+        POST received bus events to the agent's own /v1/turn and WAKE an idle
+        session (push ≡ Telegram)."""
+        # Arrange
+        sac = _sac_channel_opts.mcp_servers["sac"]  # type: ignore[index]
+        args = sac["args"]
+        # Act
+        turn_url = args[args.index("--turn-url") + 1] if "--turn-url" in args else None
+        # Assert — points at the agent's own loopback /v1/turn on the a2a_port.
+        assert turn_url == "http://127.0.0.1:9999/v1/turn"
 
     def test_sidecar_listen_url_when_present_is_not_a2a_port(self, _sac_channel_opts):
         # Arrange


### PR DESCRIPTION
## WI-2 — fail loud when a push can't reach/wake (stacked on #155)

> **Stacked**: this PR targets `feat/wake-on-push` (PR #155). Review/merge #155 first; this diff is WI-2 only.

### Problem
The send-side `a2a_*` tools returned the listen reply verbatim. A push that woke nobody (`delivered_subscriber_count == 0`), a target that was down (connection refused), or a server-side delivery error (5xx) surfaced as a misleading "success" body the calling agent could silently ignore — the message was effectively dropped with no loud signal.

### Fix
`_channel_tools._send_or_raise` + `SendError` make the send path fail LOUDLY. `a2a_send` / `a2a_reply` / `a2a_ack` translate a `SendError` into an explicit `{"error": ...}` tool result (never a misleading success) and log a warning. Fails loud on:

- **transport error** — target agent down / listen unreachable (connection refused),
- **HTTP 5xx** — server / infra delivery error,
- **`delivered_subscriber_count == 0`** — no live inbox subscriber, so the push reached nobody (agent not started, or its channel adapter not connected).

### Design decisions
- **4xx is passed through verbatim, not raised.** The 403 ACL deny carries a structured `body.reason` and is a deliberate, already-loud policy response ("denial is the policy working"). Opaquing it into an error string would lose the `reason` and isn't the silent-drop/misleading-success the rule targets. (This preserves the existing `test_node_comms_e2e_mcp` ACL-deny / identity-spoof contracts.)
- **Absent `delivered_subscriber_count` is NOT treated as zero.** Some replies (cross-host forwards) omit the field; inventing a zero would be a false-positive failure (STX no-false-positives). Only an explicit `0` from the local publish path is the no-subscriber signal.

### Tests (real loopback servers, no mocks)
- no-subscriber (`delivered_subscriber_count == 0`) → loud error
- agent stopped (connection refused) → loud "unreachable" error
- 5xx delivery error → loud error
- delivered>=1 → success; absent count → success (guards against over-firing)
- `a2a_reply` / `a2a_ack` share the fail-loud helper

Full suite green except 3 confirmed pre-existing/environmental failures (verified identical on `develop`: a SDK-dependent handler test, a timing-budget test, and a non-deterministic FastMCP `audit-mcp-tools` probe). None touch the modified code.