### PR TITLE
feat(a2a): fail loud when an a2a_send push cannot reach or wake the target

### DIFF
--- a/src/scitex_agent_container/_mcp/_channel_tools.py
+++ b/src/scitex_agent_container/_mcp/_channel_tools.py
@@ -16,9 +16,29 @@ other way around at module load).
 from __future__ import annotations
 
 import json
+import logging
 from typing import Any
 
 from .channel import _recent
+
+log = logging.getLogger(__name__)
+
+
+class SendError(RuntimeError):
+    """A send/push could NOT reach or wake the target agent.
+
+    Raised by the send helper when delivery demonstrably failed:
+
+    * the transport raised (agent down / connection refused),
+    * the listen server returned a non-2xx status (delivery error), or
+    * the publish reported ``delivered_subscriber_count == 0`` — no live
+      inbox subscriber, so the message woke nobody.
+
+    The send-side ``a2a_*`` tools translate this into a loud, explicit
+    ``{"error": ...}`` result for the calling agent (never a misleading
+    success) and log it. STX hard rule: fail loudly, never silently drop
+    or return a misleading success.
+    """
 
 
 def register_tools(
@@ -59,6 +79,86 @@ def register_tools(
                 return {"status": resp.status_code, "body": resp.json()}
             except Exception:  # stx-allow: fallback (reason: non-JSON body tolerated)
                 return {"status": resp.status_code, "body": resp.text}
+
+    async def _send_or_raise(
+        target: str, path: str, payload: dict[str, Any]
+    ) -> dict[str, Any]:
+        """POST a send/push and FAIL LOUDLY when it cannot reach/wake (WI-2).
+
+        Returns the parsed ``{status, body}`` on success. Raises
+        :class:`SendError` — never a misleading success — when:
+
+        * the transport raises (target agent down / connection refused),
+        * the HTTP status is 5xx (server / infra delivery error), or
+        * ``body.delivered_subscriber_count == 0`` — no live inbox
+          subscriber, so the push woke nobody.
+
+        A **4xx** is passed through verbatim (returned, not raised). A 4xx —
+        notably the 403 ACL deny carrying ``body.reason`` — is a deliberate,
+        structured policy/client response, already loud and actionable for
+        the agent ("denial is the policy working"). Reshaping it into an
+        opaque error string would lose the structured ``reason`` and is not
+        the silent-drop/misleading-success the fail-loud rule targets.
+
+        ``delivered_subscriber_count`` ABSENT is NOT treated as zero: some
+        responses (cross-host forwards) don't carry it, and inventing a
+        zero would be a false-positive failure. Only an explicit ``0``
+        from the local publish path is the no-subscriber signal.
+        """
+        import httpx
+
+        try:
+            res = await _post(path, payload)
+        except httpx.HTTPError as exc:
+            log.warning("sac a2a: send to %r failed (transport): %s", target, exc)
+            raise SendError(
+                f"send to {target!r} failed: agent unreachable ({exc})"
+            ) from exc
+
+        status = res.get("status")
+        # 5xx (and any non-int / sub-200) = server/infra delivery failure.
+        # 4xx passes through (deliberate policy/client response — see above).
+        if isinstance(status, int) and status >= 500:
+            body = res.get("body")
+            log.warning(
+                "sac a2a: send to %r returned HTTP %s: %s", target, status, body
+            )
+            raise SendError(
+                f"send to {target!r} failed: listen returned HTTP {status} ({body})"
+            )
+        if not isinstance(status, int) or status < 200:
+            body = res.get("body")
+            log.warning(
+                "sac a2a: send to %r returned unexpected status %r: %s",
+                target,
+                status,
+                body,
+            )
+            raise SendError(
+                f"send to {target!r} failed: unexpected status {status!r} ({body})"
+            )
+
+        body = res.get("body")
+        if isinstance(body, dict):
+            delivered = body.get("delivered_subscriber_count")
+            if isinstance(delivered, int) and delivered == 0:
+                log.warning(
+                    "sac a2a: send to %r reached no subscriber "
+                    "(delivered_subscriber_count=0)",
+                    target,
+                )
+                raise SendError(
+                    f"send to {target!r} reached no live subscriber "
+                    "(delivered_subscriber_count=0): the agent is not "
+                    "subscribed to its inbox (down, not started, or its "
+                    "channel adapter is not connected) — the message woke "
+                    "nobody and was not delivered."
+                )
+        return res
+
+    def _error_result(exc: SendError) -> "list[TextContent]":
+        """Render a :class:`SendError` as a loud tool result."""
+        return [TextContent(type="text", text=json.dumps({"error": str(exc)}))]
 
     def _find(msg_id: str) -> dict[str, Any] | None:
         for ev in reversed(_recent):
@@ -173,7 +273,12 @@ def register_tools(
                 priority=arguments.get("priority"),
                 requires_reply=arguments.get("requires_reply"),
             )
-            res = await _post(f"/agents/{target}/message:send", payload)
+            try:
+                res = await _send_or_raise(
+                    target, f"/agents/{target}/message:send", payload
+                )
+            except SendError as exc:
+                return _error_result(exc)
             return [TextContent(type="text", text=json.dumps(res))]
 
         if name == "a2a_reply":
@@ -201,7 +306,12 @@ def register_tools(
                 conversation_id=orig.get("conversation_id"),
                 in_reply_to=mid,
             )
-            res = await _post(f"/agents/{target}/message:send", payload)
+            try:
+                res = await _send_or_raise(
+                    target, f"/agents/{target}/message:send", payload
+                )
+            except SendError as exc:
+                return _error_result(exc)
             return [TextContent(type="text", text=json.dumps(res))]
 
         if name == "a2a_ack":
@@ -230,7 +340,12 @@ def register_tools(
                 in_reply_to=mid,
                 ack=True,
             )
-            res = await _post(f"/agents/{target}/message:send", payload)
+            try:
+                res = await _send_or_raise(
+                    target, f"/agents/{target}/message:send", payload
+                )
+            except SendError as exc:
+                return _error_result(exc)
             return [TextContent(type="text", text=json.dumps(res))]
 
         if name == "a2a_peers":
@@ -256,4 +371,4 @@ def register_tools(
         ]
 
 
-__all__ = ["register_tools"]
+__all__ = ["SendError", "register_tools"]

--- a/tests/scitex_agent_container/_mcp/test__channel_tools.py
+++ b/tests/scitex_agent_container/_mcp/test__channel_tools.py
@@ -45,6 +45,14 @@ class _FakeListenServer:
         self._server: asyncio.base_events.Server | None = None
         self.host: str = "127.0.0.1"
         self.port: int = 0
+        # Response the fake returns for a successful ``message:send`` POST.
+        # Default mirrors the historical fake (200 + ``{"ok": True}``). WI-2
+        # tests override this to model a real publish reply carrying
+        # ``delivered_subscriber_count``.
+        self.send_response: dict[str, Any] = {"ok": True}
+        # When set, ``message:send`` returns this HTTP status with a tiny
+        # body instead of a 200 JSON envelope (models a delivery error).
+        self.send_status: int = 200
 
     async def start(self) -> None:
         self._server = await asyncio.start_server(self._handle, host=self.host, port=0)
@@ -95,7 +103,12 @@ class _FakeListenServer:
                 except json.JSONDecodeError:
                     payload = {}
                 self.posts.append((path, payload))
-                await self._serve_json(writer, {"ok": True})
+                if self.send_status != 200:
+                    await self._serve_status(
+                        writer, self.send_status, b"delivery error"
+                    )
+                else:
+                    await self._serve_json(writer, self.send_response)
             else:
                 await self._serve_status(writer, 404, b"not found")
         finally:
@@ -502,3 +515,141 @@ async def test_register_tools_forwards_bearer_token_on_post(fake_listen):
     await rec.call_tool_fn("a2a_send", {"target": "bob", "content": "hi"})
     # Assert
     assert fake_listen.last_auth == "Bearer s3cret"
+
+
+# ---------------------------------------------------------------------------
+# WI-2 fail-loud — a send/push that cannot reach or wake the target must
+# surface a loud, explicit error to the caller, never a misleading success.
+#
+# Three failure modes from the work-item: no inbox subscriber
+# (delivered_subscriber_count == 0), agent stopped (connection refused),
+# delivery error (non-2xx). Real loopback servers, no mocks.
+# ---------------------------------------------------------------------------
+
+
+def _err(out: "list[TextContent]") -> str | None:
+    """Pull the ``error`` field out of a tool result, or None."""
+    body = json.loads(out[0].text)
+    return body.get("error") if isinstance(body, dict) else None
+
+
+@pytest.mark.asyncio
+async def test_a2a_send_no_subscriber_returns_loud_error(
+    registered_tools: _ToolRecorder, fake_listen
+):
+    """delivered_subscriber_count == 0 → the push woke nobody → loud error,
+    not a misleading success body."""
+    # Arrange — model a publish reply with zero subscribers.
+    fake_listen.send_response = {
+        "msg_id": "m1",
+        "to_agent": "bob",
+        "delivered_subscriber_count": 0,
+    }
+    call_fn = registered_tools.call_tool_fn
+    # Act
+    out = await call_fn("a2a_send", {"target": "bob", "content": "hi"})
+    # Assert
+    assert "no live subscriber" in (_err(out) or "")
+
+
+@pytest.mark.asyncio
+async def test_a2a_send_with_subscriber_returns_success(
+    registered_tools: _ToolRecorder, fake_listen
+):
+    """A delivered_subscriber_count >= 1 is a real delivery — success, no
+    error (guards against the fail-loud check over-firing)."""
+    # Arrange
+    fake_listen.send_response = {
+        "msg_id": "m1",
+        "to_agent": "bob",
+        "delivered_subscriber_count": 1,
+    }
+    call_fn = registered_tools.call_tool_fn
+    # Act
+    out = await call_fn("a2a_send", {"target": "bob", "content": "hi"})
+    # Assert
+    assert _err(out) is None
+
+
+@pytest.mark.asyncio
+async def test_a2a_send_delivery_error_status_returns_loud_error(
+    registered_tools: _ToolRecorder, fake_listen
+):
+    """A non-2xx from the listen server (e.g. 502 forward failure) is a
+    delivery error — surface it loudly, not as a success body."""
+    # Arrange
+    fake_listen.send_status = 502
+    call_fn = registered_tools.call_tool_fn
+    # Act
+    out = await call_fn("a2a_send", {"target": "bob", "content": "hi"})
+    # Assert
+    assert "HTTP 502" in (_err(out) or "")
+
+
+@pytest.mark.asyncio
+async def test_a2a_send_agent_stopped_connection_refused_returns_loud_error():
+    """Target agent down / listen unreachable (refused connection) → loud
+    'agent unreachable' error rather than a hang or silent success."""
+    # Arrange — register tools pointing at a closed loopback port.
+    import socket
+
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    refused_port = s.getsockname()[1]
+    s.close()
+    rec = _ToolRecorder()
+    register_tools(
+        rec,
+        agent_name="alice",
+        listen_url=f"http://127.0.0.1:{refused_port}",
+        bearer=None,
+    )
+    # Act
+    out = await rec.call_tool_fn("a2a_send", {"target": "bob", "content": "hi"})
+    # Assert
+    assert "unreachable" in (_err(out) or "")
+
+
+@pytest.mark.asyncio
+async def test_a2a_send_absent_delivered_count_is_not_treated_as_failure(
+    registered_tools: _ToolRecorder, fake_listen
+):
+    """A 200 reply WITHOUT delivered_subscriber_count (e.g. a cross-host
+    forward) must NOT be flagged as a no-subscriber failure — inventing a
+    zero would be a false positive."""
+    # Arrange — default fake response is ``{"ok": True}`` (no count field).
+    call_fn = registered_tools.call_tool_fn
+    # Act
+    out = await call_fn("a2a_send", {"target": "bob", "content": "hi"})
+    # Assert
+    assert _err(out) is None
+
+
+@pytest.mark.asyncio
+async def test_a2a_reply_no_subscriber_returns_loud_error(
+    registered_tools: _ToolRecorder, fake_listen
+):
+    """The reply path shares the fail-loud send helper."""
+    # Arrange — seed a known inbound message to reply to, then zero subs.
+    _recent.append({"msg_id": "orig1", "from_agent": "bob", "conversation_id": "c1"})
+    fake_listen.send_response = {"delivered_subscriber_count": 0}
+    call_fn = registered_tools.call_tool_fn
+    # Act
+    out = await call_fn("a2a_reply", {"in_reply_to": "orig1", "content": "hey"})
+    # Assert
+    assert "no live subscriber" in (_err(out) or "")
+
+
+@pytest.mark.asyncio
+async def test_a2a_ack_no_subscriber_returns_loud_error(
+    registered_tools: _ToolRecorder, fake_listen
+):
+    """The explicit ack tool also fails loud when it reaches no subscriber."""
+    # Arrange
+    _recent.append({"msg_id": "orig2", "from_agent": "bob", "conversation_id": "c2"})
+    fake_listen.send_response = {"delivered_subscriber_count": 0}
+    call_fn = registered_tools.call_tool_fn
+    # Act
+    out = await call_fn("a2a_ack", {"msg_id": "orig2"})
+    # Assert
+    assert "no live subscriber" in (_err(out) or "")


### PR DESCRIPTION
Fail-loud half of the wake-on-push work (wake landed in #155). Cherry-picked clean onto develop — supersedes #156 (which carried the now-merged wake commits after the squash-merge of #155).

`_channel_tools._send_or_raise` + `SendError` make a2a_send/a2a_reply/a2a_ack fail LOUDLY instead of returning a misleading success when a push reaches nobody:
- transport error (target down / connection refused)
- HTTP 5xx (server/infra delivery error)
- delivered_subscriber_count == 0 (no live inbox subscriber)

Design: 4xx (403 ACL deny) passes through verbatim (carries structured reason; denial is the policy working). Absent delivered_subscriber_count is NOT treated as zero (cross-host forwards omit it — avoids false-positive). Tests use real loopback servers, no mocks.