### PR TITLE
feat(heartbeat): add elapsed_s + token usage to the SDK-session heartbeat

### DIFF
--- a/src/scitex_agent_container/_runners/_session_state.py
+++ b/src/scitex_agent_container/_runners/_session_state.py
@@ -72,6 +72,40 @@ def read_pid(state_dir: Path) -> int | None:
 
 
 # ---------------------------------------------------------------------------
+# Session start time (for heartbeat elapsed_s)
+# ---------------------------------------------------------------------------
+
+
+def write_started_at(state_dir: Path, started_at: float | None = None) -> float:
+    """Persist the runner's session start time (unix seconds) atomically.
+
+    Written once at runner startup so every heartbeat can report
+    ``elapsed_s`` without the heartbeat loop having to carry the
+    start time in memory (it survives a supervised restart of the
+    conversation task too, since the file outlives it). Returns the
+    value written so the caller can reuse it.
+    """
+    if started_at is None:
+        started_at = time.time()
+    state_dir.mkdir(parents=True, exist_ok=True)
+    tmp = state_dir / "started_at.tmp"
+    tmp.write_text(repr(float(started_at)), encoding="utf-8")
+    tmp.replace(state_dir / "started_at")
+    return float(started_at)
+
+
+def read_started_at(state_dir: Path) -> float | None:
+    """Return the persisted session start time, or None if absent / corrupt."""
+    p = state_dir / "started_at"
+    if not p.is_file():
+        return None
+    try:
+        return float(p.read_text(encoding="utf-8").strip())
+    except (OSError, ValueError):
+        return None
+
+
+# ---------------------------------------------------------------------------
 # Heartbeat
 # ---------------------------------------------------------------------------
 
@@ -114,6 +148,39 @@ def _resolve_db_writer(db_writer):
     return db_writer if db_writer is not None else _DefaultDBWriter()
 
 
+def _heartbeat_usage_fields(state_dir: Path, now: float) -> dict:
+    """Build the elapsed-time + token-usage enrichment for a heartbeat.
+
+    Sourced PROGRAMMATICALLY from the runner's own state dir — no TUI
+    scraping:
+
+      * ``elapsed_s`` from the persisted ``started_at`` (None until the
+        runner has written it, so legacy / pre-start callers stay clean).
+      * ``input_tokens`` / ``output_tokens`` / ``total_tokens`` from the
+        accumulated ``quota.json`` (the same totals ``accumulate_quota``
+        sums from each ``ResultMessage.usage``). ``total_tokens`` adds the
+        cache tokens so it reflects everything billed against the session.
+
+    Returns only the keys it can populate; ``write_heartbeat`` splats
+    them onto the payload so ``elapsed_s`` is absent (not 0) when the
+    start time is unknown.
+    """
+    out: dict = {}
+    started_at = read_started_at(state_dir)
+    if started_at is not None:
+        out["started_at"] = started_at
+        out["elapsed_s"] = round(max(0.0, now - started_at), 3)
+    quota = read_quota(state_dir)
+    input_tokens = int(quota.get("input_tokens", 0) or 0)
+    output_tokens = int(quota.get("output_tokens", 0) or 0)
+    cache_creation = int(quota.get("cache_creation_input_tokens", 0) or 0)
+    cache_read = int(quota.get("cache_read_input_tokens", 0) or 0)
+    out["input_tokens"] = input_tokens
+    out["output_tokens"] = output_tokens
+    out["total_tokens"] = input_tokens + output_tokens + cache_creation + cache_read
+    return out
+
+
 def write_heartbeat(
     state_dir: Path,
     *,
@@ -123,8 +190,16 @@ def write_heartbeat(
     host: str | None = None,
     db_writer=None,
 ) -> None:
-    """Atomically write ``{ts, pid, state}`` to ``heartbeat.json``
+    """Atomically write the heartbeat record to ``heartbeat.json``
     AND append a row to ``state.db.heartbeats`` (diary).
+
+    The record carries ``{ts, pid, state}`` plus, when the runner has
+    recorded a start time, an ``elapsed_s`` (seconds since session
+    start, derived from the persisted ``started_at``) and the running
+    token totals (``input_tokens`` / ``output_tokens`` / ``total_tokens``)
+    accumulated from each ``ResultMessage.usage`` into ``quota.json``.
+    This lets the operator see, per agent, how long it has been running
+    and how many tokens it has used — straight off the fast-path JSON.
 
     The JSON file is kept as a fast-path cache for local readers
     (``sac agent status`` polls it without opening sqlite); the DB
@@ -135,7 +210,9 @@ def write_heartbeat(
     pass these stay JSON-only, no surprise rows.
     """
     state_dir.mkdir(parents=True, exist_ok=True)
-    payload = {"ts": time.time(), "pid": pid, "state": state}
+    now = time.time()
+    payload = {"ts": now, "pid": pid, "state": state}
+    payload.update(_heartbeat_usage_fields(state_dir, now))
     tmp = state_dir / "heartbeat.json.tmp"
     tmp.write_text(json.dumps(payload), encoding="utf-8")
     tmp.replace(state_dir / "heartbeat.json")

--- a/src/scitex_agent_container/_runners/claude_session.py
+++ b/src/scitex_agent_container/_runners/claude_session.py
@@ -58,10 +58,12 @@ from ._session_state import (
     read_pid,
     read_quota,
     read_session_id,
+    read_started_at,
     state_dir_for,
     write_heartbeat,
     write_pid,
     write_session_id,
+    write_started_at,
 )
 from ._session_state import (
     heartbeat_loop as _heartbeat_loop,
@@ -83,11 +85,13 @@ __all__ = [
     "read_pid",
     "read_quota",
     "read_session_id",
+    "read_started_at",
     "run",
     "state_dir_for",
     "write_heartbeat",
     "write_pid",
     "write_session_id",
+    "write_started_at",
 ]
 
 
@@ -235,6 +239,14 @@ async def run(
             signal.signal(sig, lambda s, _f: _on_signal(s))
 
     write_pid(state_dir, pid)
+    # Record the session start time so every heartbeat can report
+    # ``elapsed_s``. Preserve an existing value across a respawn that
+    # resumes the same SDK session (resume_session_id present) — the
+    # elapsed clock should track the conversation, not the process.
+    if resume_session_id and read_started_at(state_dir) is not None:
+        pass
+    else:
+        write_started_at(state_dir)
     write_heartbeat(state_dir, pid=pid, state=STATE_STARTING, name=name, host=host)
 
     hb_task = asyncio.create_task(

--- a/src/scitex_agent_container/_skills/scitex-agent-container/15_claude-session.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/15_claude-session.md
@@ -86,7 +86,8 @@ Per-agent state lives at `<scope>/runtime/<name>/`:
 | File | Contents |
 |---|---|
 | `pid` | Runner's PID (atomic write — tmp + rename). |
-| `heartbeat.json` | `{ts, pid, state}`. State ∈ `starting / idle / working / stopping`. Refreshed every 10 s (`--tick-seconds`). |
+| `heartbeat.json` | `{ts, pid, state}` plus `elapsed_s` (seconds since session start, from `started_at`) and the running token totals `input_tokens / output_tokens / total_tokens` (from `quota.json`). State ∈ `starting / idle / working / stopping`. Refreshed every 10 s (`--tick-seconds`). |
+| `started_at` | Session start time (unix seconds). Written once at startup; preserved across a resumed respawn so `elapsed_s` tracks the conversation, not the process. |
 | `session.jsonl` | One JSON object per turn event: `user / assistant / user_echo / result / error`. The transcript. |
 | `session_id` | Latest SDK session UUID. Auto-resumed by the next `sac agent start`. |
 | `quota.json` | Accumulated per-turn token totals (input / output / cache_creation / cache_read / turns). |
@@ -143,7 +144,11 @@ agents on this runtime:
       "cache_read_input_tokens": 0,
       "turns": 1
     },
-    "heartbeat": {"ts": 1777766006.95, "pid": 3476972, "state": "idle"},
+    "heartbeat": {
+      "ts": 1777766006.95, "pid": 3476972, "state": "idle",
+      "started_at": 1777765800.0, "elapsed_s": 206.95,
+      "input_tokens": 6000, "output_tokens": 1500, "total_tokens": 40503
+    },
     "state_dir": "/path/to/.scitex/agent-container/runtime/<name>"
   }
 }

--- a/tests/scitex_agent_container/_runners/test_claude_session.py
+++ b/tests/scitex_agent_container/_runners/test_claude_session.py
@@ -285,6 +285,103 @@ def test_subsequent_heartbeat_writes_overwrite_state(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# started_at (session start time) + heartbeat enrichment
+# ---------------------------------------------------------------------------
+
+
+def test_write_started_at_returns_value(tmp_path: Path) -> None:
+    # Arrange
+    started_at = 1000.0
+    # Act
+    result = runner.write_started_at(tmp_path, started_at=started_at)
+    # Assert
+    assert result == 1000.0
+
+
+def test_read_started_at_round_trips(tmp_path: Path) -> None:
+    # Arrange
+    runner.write_started_at(tmp_path, started_at=1234.5)
+    # Act
+    result = runner.read_started_at(tmp_path)
+    # Assert
+    assert result == 1234.5
+
+
+def test_read_started_at_none_when_missing(tmp_path: Path) -> None:
+    # Arrange: no started_at file.
+    # Act
+    result = runner.read_started_at(tmp_path)
+    # Assert
+    assert result is None
+
+
+def test_heartbeat_omits_elapsed_when_start_unknown(tmp_path: Path) -> None:
+    # Arrange: no started_at recorded.
+    runner.write_heartbeat(tmp_path, pid=1, state=runner.STATE_IDLE)
+    # Act
+    hb = runner.read_heartbeat(tmp_path)
+    # Assert
+    assert hb is not None and "elapsed_s" not in hb
+
+
+def test_heartbeat_includes_elapsed_s_from_started_at(tmp_path: Path) -> None:
+    # Arrange: session started 5s ago.
+    runner.write_started_at(tmp_path, started_at=time.time() - 5.0)
+    runner.write_heartbeat(tmp_path, pid=1, state=runner.STATE_WORKING)
+    # Act
+    hb = runner.read_heartbeat(tmp_path)
+    # Assert: elapsed reflects the start time (allow a small scheduling slack).
+    assert hb is not None and 5.0 <= hb["elapsed_s"] < 6.0
+
+
+def test_heartbeat_elapsed_s_is_non_negative(tmp_path: Path) -> None:
+    # Arrange: start time set in the future (clock skew) must not go negative.
+    runner.write_started_at(tmp_path, started_at=time.time() + 100.0)
+    runner.write_heartbeat(tmp_path, pid=1, state=runner.STATE_IDLE)
+    # Act
+    hb = runner.read_heartbeat(tmp_path)
+    # Assert
+    assert hb is not None and hb["elapsed_s"] == 0.0
+
+
+def test_heartbeat_total_tokens_zero_without_quota(tmp_path: Path) -> None:
+    # Arrange: no quota.json yet.
+    runner.write_heartbeat(tmp_path, pid=1, state=runner.STATE_IDLE)
+    # Act
+    hb = runner.read_heartbeat(tmp_path)
+    # Assert
+    assert hb is not None and hb["total_tokens"] == 0
+
+
+def test_heartbeat_includes_total_tokens_from_quota(tmp_path: Path) -> None:
+    # Arrange: a ResultMessage usage block accumulated into quota.json.
+    runner.accumulate_quota(
+        tmp_path,
+        {
+            "input_tokens": 100,
+            "output_tokens": 30,
+            "cache_creation_input_tokens": 10,
+            "cache_read_input_tokens": 5,
+        },
+    )
+    runner.write_heartbeat(tmp_path, pid=1, state=runner.STATE_WORKING)
+    # Act
+    hb = runner.read_heartbeat(tmp_path)
+    # Assert: total = input + output + cache_creation + cache_read.
+    assert hb is not None and hb["total_tokens"] == 145
+
+
+def test_heartbeat_carries_input_and_output_tokens(tmp_path: Path) -> None:
+    # Arrange
+    runner.accumulate_quota(tmp_path, {"input_tokens": 7, "output_tokens": 3})
+    runner.write_heartbeat(tmp_path, pid=1, state=runner.STATE_IDLE)
+    # Act
+    hb = runner.read_heartbeat(tmp_path)
+    # Assert
+    assert hb is not None and (hb["input_tokens"], hb["output_tokens"]) == (7, 3)
+
+
+# ---------------------------------------------------------------------------
 # _heartbeat_loop (in-process)
 # ---------------------------------------------------------------------------
 

--- a/tests/scitex_agent_container/_state/test_agent_meta.py
+++ b/tests/scitex_agent_container/_state/test_agent_meta.py
@@ -825,6 +825,36 @@ def test_read_sdk_session_state_surfaces_accumulated_quota_turns(
     assert payload["quota"]["turns"] == 1
 
 
+def test_read_sdk_session_state_heartbeat_carries_elapsed_s(
+    isolated_local_state: Path,
+):
+    # Arrange — record a start time then beat so the heartbeat has elapsed_s.
+    from scitex_agent_container._runners import _session_state as ss
+
+    state_dir = isolated_local_state / "runtime" / "alpha"
+    ss.write_started_at(state_dir)
+    ss.write_heartbeat(state_dir, pid=1, state=ss.STATE_IDLE)
+    # Act
+    payload = tr_mod._read_sdk_session_state("alpha", workdir="/tmp")
+    # Assert
+    assert "elapsed_s" in payload["heartbeat"]
+
+
+def test_read_sdk_session_state_heartbeat_carries_total_tokens(
+    isolated_local_state: Path,
+):
+    # Arrange — accumulate usage then beat so the heartbeat has total_tokens.
+    from scitex_agent_container._runners import _session_state as ss
+
+    state_dir = isolated_local_state / "runtime" / "alpha"
+    ss.accumulate_quota(state_dir, {"input_tokens": 7, "output_tokens": 11})
+    ss.write_heartbeat(state_dir, pid=1, state=ss.STATE_IDLE)
+    # Act
+    payload = tr_mod._read_sdk_session_state("alpha", workdir="/tmp")
+    # Assert
+    assert payload["heartbeat"]["total_tokens"] == 18
+
+
 # ---------------------------------------------------------------------------
 # collect_rich — end-to-end smoke + key fields
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Enrich the agent heartbeat with elapsed time and token usage, read **programmatically** from the SDK `ResultMessage.usage` the session runner already consumes (not from the TUI). Operators can now see, per agent, how long it has been running and how many tokens it has used.

## Fields added (to `heartbeat.json` and surfaced in `agent_status` via `sdk_session.heartbeat`)

- `elapsed_s` — seconds since session start, from a newly persisted `started_at`.
- `started_at` — session start time (unix seconds), written once at runner startup; preserved across a resumed respawn so elapsed tracks the conversation, not the process.
- `input_tokens` / `output_tokens` / `total_tokens` — from the existing accumulated `quota.json` (the same totals `accumulate_quota` sums from each `ResultMessage.usage`). `total_tokens` includes cache tokens. No parallel plumbing.

`ts` / `pid` / `state` kept for compat. `elapsed_s` is **omitted** (not 0) when start time is unknown, so legacy / non-runner callers stay clean. Timestamps follow the `*_at` naming convention.

## Source

- `_runners/_session_state.py`: `write_started_at` / `read_started_at`; `write_heartbeat` now splats `_heartbeat_usage_fields(state_dir, now)`.
- `_runners/claude_session.py`: records `started_at` at startup before the first beat.
- Skill doc `15_claude-session.md` updated to document the new shape.

## Tests (no mocks)

11 new tests: `started_at` round-trip, `elapsed_s` from start time + non-negative clamp, `total/input/output` tokens from a real accumulated quota, omission when start unknown, plus two asserting the status surface (`_read_sdk_session_state`) carries the new fields.

Full suite: 4615 passed; 3 pre-existing failures (`test_audit_all_clean`, `test_claude_session_channels_without_port_raises`, `test_hanging_remote_probe_respects_timeout_budget`) reproduce identically on clean `develop` with none of this PR's code in scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)