### PR TITLE
feat(agent_send): non-blocking dispatch by default (wait flag for sync)

### DIFF
--- a/src/scitex_agent_container/_mcp/_tools/_agent.py
+++ b/src/scitex_agent_container/_mcp/_tools/_agent.py
@@ -116,22 +116,37 @@ def agent_send(
     key: str | None = None,
     model: str | None = None,
     max_turns: int | None = None,
+    wait: bool = False,
 ) -> dict[str, Any]:
-    """Send one prompt (or control key) to ``name``'s live session via /v1/turn.
+    """Dispatch one prompt (or control key) to ``name``'s live session.
+
+    NON-BLOCKING by default. An MCP tool call cannot be backgrounded by
+    the caller, so a synchronous send would hang the lead's whole turn
+    until the target agent finishes processing. By default this tool
+    therefore validates that the agent is reachable and returns PROMPTLY
+    with ``status="dispatched"`` plus a backgroundable ``track_command``
+    — the equivalent ``sac agents send ...`` CLI the caller runs in a
+    background shell to deliver the prompt and stream the reply. Pass
+    ``wait=True`` to block inline and get the reply in ``response_text``.
 
     Library-grade dispatch to the agent's A2A sidecar. Unlike the
     other ``agent_*`` tools this does NOT go through the CLI runner
     surface — it calls
     :func:`scitex_agent_container.cli_pkg._send.send_to_agent` directly
-    so the structured ``{status, response_text, response_metadata}``
-    payload survives MCP transport intact (the CLI prints the reply as
-    free text, which would lose the metadata).
+    so the structured payload survives MCP transport intact (the CLI
+    prints the reply as free text, which would lose the metadata).
 
     Returns the helper's dict verbatim. ``status`` is one of:
 
-      * ``"ok"`` — reply received; ``response_text`` populated
-      * ``"error"`` — agent not running / no a2a_port / HTTP failure
-      * ``"timeout"`` — no response in ``timeout_seconds``
+      * ``"dispatched"`` — (default, ``wait=False``) reachability
+        validated; ``track_command`` carries the backgroundable
+        ``sac agents send ...`` CLI to deliver + await the reply
+      * ``"ok"`` — (``wait=True``) reply received; ``response_text``
+        populated
+      * ``"error"`` — agent not running / no a2a_port / sidecar
+        unreachable / HTTP failure
+      * ``"creds-expired"`` — lead/peer OAuth token expired
+      * ``"timeout"`` — (``wait=True``) no response in ``timeout_seconds``
 
     ``prompt`` and ``key`` are mutually exclusive; passing both raises
     ``ValueError`` (surfaced to the MCP host as a tool-input error).
@@ -145,6 +160,7 @@ def agent_send(
         timeout_seconds=timeout_seconds,
         model=model,
         max_turns=max_turns,
+        wait=wait,
     )
 
 

--- a/src/scitex_agent_container/cli_pkg/_send.py
+++ b/src/scitex_agent_container/cli_pkg/_send.py
@@ -25,12 +25,31 @@ the peer probe path is testable without an actual ssh subprocess.
 
 from __future__ import annotations
 
+import shlex
 from typing import Any
 
 from ._send_diagnosis import diagnose_send_failure
 from ._send_preflight import SshRunner, preflight_send_creds
 
-__all__ = ["send_to_agent"]
+__all__ = ["send_to_agent", "build_track_command"]
+
+
+def build_track_command(name: str, prompt: str) -> str:
+    """Return the backgroundable ``sac`` CLI that delivers + awaits a reply.
+
+    The non-blocking dispatch path validates reachability and hands the
+    caller this command instead of POSTing the turn itself. Running it in
+    a backgrounded shell delivers the prompt to the agent's live session
+    and streams the reply — so the lead's MCP turn never blocks on the
+    agent's processing, yet the reply is still trackable.
+
+    The ``sac agents send`` codepath is the SAME library helper this
+    module backs (it routes prompt-style sends through /v1/turn for the
+    running session), so the backgrounded command and the in-process
+    ``wait=True`` path are behaviourally identical — there is no second,
+    drifting delivery implementation.
+    """
+    return f"sac agents send {shlex.quote(name)} {shlex.quote(prompt)}"
 
 
 def _post_turn(url: str, text: str, *, timeout_s: float) -> tuple[str, dict[str, Any]]:
@@ -62,24 +81,53 @@ def send_to_agent(
     timeout_seconds: int = 120,
     model: str | None = None,
     max_turns: int | None = None,
+    wait: bool = False,
     ssh_runner: SshRunner | None = None,
     lead_creds_path: Any = None,
 ) -> dict[str, Any]:
-    """Send a turn to ``name``'s live A2A sidecar; return a structured dict.
+    """Dispatch a turn to ``name``'s live A2A sidecar; return a structured dict.
+
+    Two modes, selected by ``wait``:
+
+    * ``wait=False`` (DEFAULT, non-blocking) — validate that the agent is
+      reachable (running, has a bound a2a_port, fresh creds, sidecar
+      port accepting connections), then return PROMPTLY with
+      ``status="dispatched"`` WITHOUT blocking on the agent's turn. The
+      payload carries a ``track_command`` — a backgroundable ``sac
+      agents send ...`` CLI the caller runs in a background shell to
+      actually deliver the prompt and stream the reply. This is the path
+      the MCP ``agent_send`` tool uses so the lead's turn never hangs on
+      the agent's processing. Validation still fails LOUD: an agent that
+      cannot possibly receive the turn (not running, no a2a_port, expired
+      creds, sidecar port unreachable, recorded pid dead) returns the
+      same ``error`` / ``creds-expired`` payload as the blocking path —
+      never a misleading "dispatched".
+
+    * ``wait=True`` (legacy synchronous) — POST the turn and BLOCK until
+      the agent finishes the turn, then return its reply. Use only when
+      the caller genuinely needs the response inline.
 
     Returns:
+        ``{"status": "dispatched", "agent": str, "host": str, "url": str,
+        "a2a_port": int, "track_command": str, "track_command_argv":
+        [str, ...], "delivered_subscriber_count": 1}`` in the default
+        non-blocking mode once reachability is validated;
         ``{"status": "ok", "response_text": str, "response_metadata":
-        {...}}`` on success;
+        {...}}`` on a successful blocking (``wait=True``) reply;
         ``{"status": "error", "error": "..."}`` when the agent isn't
-        running, the row has no a2a_port, transport fails, or the
-        sidecar returns non-200;
+        running, the row has no a2a_port, the sidecar is unreachable,
+        transport fails, or the sidecar returns non-200;
         ``{"status": "creds-expired", "error": "...", "agent": str}``
         when the lead's OAuth token (or the peer's, via ssh probe) is
         expired / near-expiry. Refuses to dispatch.
-        ``{"status": "timeout", "error": "no response in <N>s"}`` when
-        the sidecar doesn't reply within ``timeout_seconds``.
+        ``{"status": "timeout", "error": "no response in <N>s"}`` when a
+        blocking send's sidecar doesn't reply within ``timeout_seconds``.
 
     Args:
+        wait: When ``True`` block on the agent's turn and return the
+            reply inline (legacy behavior). When ``False`` (default)
+            validate reachability and return a ``dispatched`` payload
+            with a backgroundable ``track_command``.
         ssh_runner: Optional injection seam for the peer-side OAuth
             probe. Defaults to :func:`_send_preflight.default_ssh_runner`
             (real ssh). Tests pass a fake that returns a
@@ -172,6 +220,21 @@ def send_to_agent(
     if preflight_result is not None:
         return preflight_result
 
+    if not wait:
+        # Non-blocking dispatch (default). Do NOT POST the blocking turn
+        # — that would hang the caller until the agent finishes. Instead
+        # validate that the agent can actually receive the turn and hand
+        # back a backgroundable CLI that delivers + tracks the reply.
+        return _dispatch_nonblocking(
+            name,
+            prompt or "",
+            a2a_port=a2a_port,
+            peer_host=peer_host,
+            current_host=current_host,
+            url=url,
+            metadata_extras=metadata_extras,
+        )
+
     try:
         reply, body = _post_turn(url, text, timeout_s=float(timeout_seconds))
     except PeerError as exc:
@@ -213,3 +276,91 @@ def send_to_agent(
         "response_text": reply,
         "response_metadata": metadata,
     }
+
+
+def _dispatch_nonblocking(
+    name: str,
+    prompt: str,
+    *,
+    a2a_port: int,
+    peer_host: str,
+    current_host: str,
+    url: str,
+    metadata_extras: dict[str, Any],
+) -> dict[str, Any]:
+    """Validate reachability, then return a non-blocking dispatch payload.
+
+    Reachability is gathered via :func:`diagnose_send_failure`, which
+    runs the SAME state probes (registry row, pid liveness, local sidecar
+    TCP connect) the blocking path attaches on failure. We translate
+    *demonstrable* unreachability into a LOUD ``status="error"`` — never a
+    misleading "dispatched":
+
+      * recorded pid is not alive       -> the process is dead
+      * local sidecar port refuses TCP  -> the sidecar isn't listening
+
+    A cross-host agent (``peer_host != current_host``) cannot be locally
+    port-probed; we don't invent a verdict — the diagnosis records
+    ``port_reachable=None`` and we proceed to ``dispatched`` (the
+    backgrounded ``track_command`` is what ultimately surfaces a
+    cross-host transport failure, loudly, when the caller runs it).
+
+    On success the payload carries ``track_command`` — the backgroundable
+    ``sac agents send`` CLI that delivers the prompt and streams the
+    reply — so the caller fires-and-tracks instead of blocking inline.
+    ``delivered_subscriber_count`` is ``1`` (the validated live sidecar)
+    so callers sharing the channel-send contract can branch uniformly.
+    """
+    diagnosis = diagnose_send_failure(
+        name,
+        a2a_port=a2a_port,
+        peer_host=peer_host,
+        current_host=current_host,
+    )
+
+    # Fail loud on demonstrable unreachability (local probes only — a
+    # cross-host port we cannot probe stays None and is NOT treated as
+    # unreachable, which would be a false-positive failure).
+    if diagnosis.get("pid_alive") is False:
+        return {
+            "status": "error",
+            "error": (
+                f"agent {name!r} recorded pid is not alive; the process "
+                "crashed or was killed — cannot dispatch"
+            ),
+            "diagnosis": diagnosis,
+        }
+    if diagnosis.get("port_reachable") is False:
+        return {
+            "status": "error",
+            "error": (
+                f"agent {name!r} sidecar is not listening on port {a2a_port}; "
+                "it is not booted or the sidecar crashed — cannot dispatch"
+            ),
+            "diagnosis": diagnosis,
+        }
+
+    track_command = build_track_command(name, prompt)
+    payload: dict[str, Any] = {
+        "status": "dispatched",
+        "agent": name,
+        "host": peer_host or current_host,
+        "url": url,
+        "a2a_port": a2a_port,
+        # The validated live sidecar is the single subscriber for this
+        # turn; mirrors the channel-send `delivered_subscriber_count`
+        # contract so callers can branch uniformly.
+        "delivered_subscriber_count": 1,
+        # Backgroundable CLI: run this in a background shell to deliver
+        # the prompt + stream the reply without blocking this turn.
+        "track_command": track_command,
+        "track_command_argv": ["sac", "agents", "send", name, prompt],
+        "note": (
+            "non-blocking dispatch: the prompt was NOT yet delivered. Run "
+            "`track_command` in a backgrounded shell to deliver it and "
+            "stream the reply, or call agent_send(..., wait=True) to block "
+            "inline."
+        ),
+    }
+    payload.update(metadata_extras)
+    return payload

--- a/tests/scitex_agent_container/_mcp/_tools/test__agent_send.py
+++ b/tests/scitex_agent_container/_mcp/_tools/test__agent_send.py
@@ -142,6 +142,26 @@ def test_agent_send_forwards_max_turns_kwarg():
     assert last["kwargs"]["max_turns"] == 3
 
 
+def test_agent_send_defaults_wait_to_false_nonblocking():
+    # Arrange
+    with _swap_send_to_agent() as captured:
+        # Act
+        agent_send("alpha", prompt="hi")
+        last = captured[-1]
+    # Assert — default dispatch is non-blocking.
+    assert last["kwargs"]["wait"] is False
+
+
+def test_agent_send_forwards_explicit_wait_kwarg():
+    # Arrange
+    with _swap_send_to_agent() as captured:
+        # Act
+        agent_send("alpha", prompt="hi", wait=True)
+        last = captured[-1]
+    # Assert
+    assert last["kwargs"]["wait"] is True
+
+
 def test_agent_send_returns_send_to_agent_payload_verbatim():
     # Arrange
     with _swap_send_to_agent():

--- a/tests/scitex_agent_container/cli_pkg/test__send.py
+++ b/tests/scitex_agent_container/cli_pkg/test__send.py
@@ -150,7 +150,9 @@ def test_agent_send_returns_dict_with_status_field(state_db_env, fresh_lead_cred
 
     # Act
     with _swap_post_turn(fake_post):
-        result = send_to_agent("alpha", "hi", lead_creds_path=fresh_lead_creds_path)
+        result = send_to_agent(
+            "alpha", "hi", wait=True, lead_creds_path=fresh_lead_creds_path
+        )
     # Assert
     assert "status" in result
 
@@ -166,7 +168,9 @@ def test_agent_send_status_ok_on_successful_response(
 
     # Act
     with _swap_post_turn(fake_post):
-        result = send_to_agent("alpha", "hi", lead_creds_path=fresh_lead_creds_path)
+        result = send_to_agent(
+            "alpha", "hi", wait=True, lead_creds_path=fresh_lead_creds_path
+        )
     # Assert
     assert result["status"] == "ok"
 
@@ -182,7 +186,9 @@ def test_agent_send_returns_response_text_field_on_success(
 
     # Act
     with _swap_post_turn(fake_post):
-        result = send_to_agent("alpha", "hi", lead_creds_path=fresh_lead_creds_path)
+        result = send_to_agent(
+            "alpha", "hi", wait=True, lead_creds_path=fresh_lead_creds_path
+        )
     # Assert
     assert result["response_text"] == "the reply"
 
@@ -224,7 +230,11 @@ def test_agent_send_status_timeout_on_slow_sidecar(state_db_env, fresh_lead_cred
     # Act
     with _swap_post_turn(fake_post):
         result = send_to_agent(
-            "alpha", "hi", timeout_seconds=2, lead_creds_path=fresh_lead_creds_path
+            "alpha",
+            "hi",
+            timeout_seconds=2,
+            wait=True,
+            lead_creds_path=fresh_lead_creds_path,
         )
     # Assert
     assert result["status"] == "timeout"
@@ -243,7 +253,11 @@ def test_agent_send_timeout_error_message_quotes_timeout_value(
     # Act
     with _swap_post_turn(fake_post):
         result = send_to_agent(
-            "alpha", "hi", timeout_seconds=2, lead_creds_path=fresh_lead_creds_path
+            "alpha",
+            "hi",
+            timeout_seconds=2,
+            wait=True,
+            lead_creds_path=fresh_lead_creds_path,
         )
     # Assert
     assert "2s" in result["error"]
@@ -306,6 +320,7 @@ def test_agent_send_cross_host_routes_through_ssh(state_db_env, fresh_lead_creds
         send_to_agent(
             "beta",
             "hi",
+            wait=True,
             lead_creds_path=fresh_lead_creds_path,
             ssh_runner=fake_ssh_runner,
         )
@@ -324,7 +339,7 @@ def test_agent_send_local_host_uses_loopback_url(state_db_env, fresh_lead_creds_
 
     # Act
     with _swap_post_turn(fake_post):
-        send_to_agent("alpha", "hi", lead_creds_path=fresh_lead_creds_path)
+        send_to_agent("alpha", "hi", wait=True, lead_creds_path=fresh_lead_creds_path)
     # Assert
     assert captured["url"] == "http://127.0.0.1:12345/v1/turn"
 
@@ -345,7 +360,9 @@ def test_agent_send_includes_response_metadata_on_success(
 
     # Act
     with _swap_post_turn(fake_post):
-        result = send_to_agent("alpha", "hi", lead_creds_path=fresh_lead_creds_path)
+        result = send_to_agent(
+            "alpha", "hi", wait=True, lead_creds_path=fresh_lead_creds_path
+        )
     # Assert
     assert result["response_metadata"]["name"] == "alpha"
 
@@ -374,7 +391,11 @@ def test_agent_send_error_when_sidecar_returns_non_200(
     # Act
     with _swap_post_turn(fake_post):
         result = send_to_agent(
-            "alpha", "hi", timeout_seconds=2, lead_creds_path=fresh_lead_creds_path
+            "alpha",
+            "hi",
+            timeout_seconds=2,
+            wait=True,
+            lead_creds_path=fresh_lead_creds_path,
         )
     # Assert
     assert result["status"] == "error"
@@ -434,7 +455,11 @@ def test_agent_send_timeout_includes_diagnosis(state_db_env, fresh_lead_creds_pa
     # Act
     with _swap_post_turn(fake_post):
         result = send_to_agent(
-            "alpha", "hi", timeout_seconds=2, lead_creds_path=fresh_lead_creds_path
+            "alpha",
+            "hi",
+            timeout_seconds=2,
+            wait=True,
+            lead_creds_path=fresh_lead_creds_path,
         )
     # Assert
     assert "diagnosis" in result
@@ -451,7 +476,11 @@ def test_agent_send_error_includes_diagnosis(state_db_env, fresh_lead_creds_path
     # Act
     with _swap_post_turn(fake_post):
         result = send_to_agent(
-            "alpha", "hi", timeout_seconds=2, lead_creds_path=fresh_lead_creds_path
+            "alpha",
+            "hi",
+            timeout_seconds=2,
+            wait=True,
+            lead_creds_path=fresh_lead_creds_path,
         )
     # Assert
     assert "diagnosis" in result
@@ -470,7 +499,11 @@ def test_agent_send_diagnosis_reports_registry_running(
     # Act
     with _swap_post_turn(fake_post):
         result = send_to_agent(
-            "alpha", "hi", timeout_seconds=2, lead_creds_path=fresh_lead_creds_path
+            "alpha",
+            "hi",
+            timeout_seconds=2,
+            wait=True,
+            lead_creds_path=fresh_lead_creds_path,
         )
     # Assert
     assert result["diagnosis"]["registry_status"] == "running"
@@ -498,7 +531,11 @@ def test_agent_send_diagnosis_reports_busy_heartbeat_state(
     # Act
     with _swap_post_turn(fake_post):
         result = send_to_agent(
-            "alpha", "hi", timeout_seconds=2, lead_creds_path=fresh_lead_creds_path
+            "alpha",
+            "hi",
+            timeout_seconds=2,
+            wait=True,
+            lead_creds_path=fresh_lead_creds_path,
         )
     # Assert
     assert result["diagnosis"]["heartbeat_state"] == "working"
@@ -520,7 +557,11 @@ def test_agent_send_diagnosis_busy_likely_cause_says_in_progress(
         # Act
         with _swap_post_turn(fake_post):
             result = send_to_agent(
-                "alpha", "hi", timeout_seconds=2, lead_creds_path=fresh_lead_creds_path
+                "alpha",
+                "hi",
+                timeout_seconds=2,
+                wait=True,
+                lead_creds_path=fresh_lead_creds_path,
             )
     # Assert
     assert "still" in result["diagnosis"]["likely_causes"].lower()
@@ -542,7 +583,11 @@ def test_agent_send_diagnosis_stale_heartbeat_likely_cause_says_dead(
         # Act
         with _swap_post_turn(fake_post):
             result = send_to_agent(
-                "alpha", "hi", timeout_seconds=2, lead_creds_path=fresh_lead_creds_path
+                "alpha",
+                "hi",
+                timeout_seconds=2,
+                wait=True,
+                lead_creds_path=fresh_lead_creds_path,
             )
     # Assert
     assert "dead or hung" in result["diagnosis"]["likely_causes"]
@@ -562,7 +607,11 @@ def test_agent_send_diagnosis_dead_pid_reports_pid_not_alive(
     # Act
     with _swap_post_turn(fake_post):
         result = send_to_agent(
-            "alpha", "hi", timeout_seconds=2, lead_creds_path=fresh_lead_creds_path
+            "alpha",
+            "hi",
+            timeout_seconds=2,
+            wait=True,
+            lead_creds_path=fresh_lead_creds_path,
         )
     # Assert
     assert result["diagnosis"]["pid_alive"] is False
@@ -588,7 +637,11 @@ def test_agent_send_diagnosis_port_unreachable_when_nothing_listening(
     # Act
     with _swap_post_turn(fake_post):
         result = send_to_agent(
-            "alpha", "hi", timeout_seconds=2, lead_creds_path=fresh_lead_creds_path
+            "alpha",
+            "hi",
+            timeout_seconds=2,
+            wait=True,
+            lead_creds_path=fresh_lead_creds_path,
         )
     # Assert
     assert result["diagnosis"]["port_reachable"] is False
@@ -614,9 +667,167 @@ def test_agent_send_diagnosis_port_reachable_when_listener_bound(
     try:
         with _swap_post_turn(fake_post):
             result = send_to_agent(
-                "alpha", "hi", timeout_seconds=2, lead_creds_path=fresh_lead_creds_path
+                "alpha",
+                "hi",
+                timeout_seconds=2,
+                wait=True,
+                lead_creds_path=fresh_lead_creds_path,
             )
     finally:
         srv.close()
     # Assert
     assert result["diagnosis"]["port_reachable"] is True
+
+
+# ---------------------------------------------------------------------------
+# Non-blocking dispatch (default wait=False)
+#
+# The default path validates reachability and returns PROMPTLY with
+# status="dispatched" + a backgroundable track_command, WITHOUT POSTing
+# the blocking turn. A swapped ``_post_turn`` that records every call is
+# used to PROVE the blocking POST never fires in non-blocking mode (it
+# would hang the caller). Reachability uses a REAL bound listener so the
+# diagnosis sees port_reachable=True — no mocks.
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def _exploding_post_turn() -> Iterator[list]:
+    """Swap ``_post_turn`` with a recorder that FAILS if ever called.
+
+    Yields the call-log list. The non-blocking path must never invoke
+    the blocking POST; calling this stand-in raises so a regression that
+    re-introduces the blocking call surfaces loudly in the test.
+    """
+    calls: list = []
+
+    def recorder(url, text, *, timeout_s):
+        calls.append(url)
+        raise AssertionError("blocking _post_turn must NOT run in non-blocking mode")
+
+    with _swap_post_turn(recorder):
+        yield calls
+
+
+def test_agent_send_nonblocking_returns_dispatched_status(
+    state_db_env, fresh_lead_creds_path
+):
+    # Arrange — real bound listener so the sidecar port is reachable.
+    with _real_listener() as port:
+        _seed_local("alpha", a2a_port=port)
+        # Act
+        with _exploding_post_turn():
+            result = send_to_agent("alpha", "hi", lead_creds_path=fresh_lead_creds_path)
+    # Assert
+    assert result["status"] == "dispatched"
+
+
+def test_agent_send_nonblocking_does_not_fire_blocking_post(
+    state_db_env, fresh_lead_creds_path
+):
+    # Arrange
+    with _real_listener() as port:
+        _seed_local("alpha", a2a_port=port)
+        # Act
+        with _exploding_post_turn() as calls:
+            send_to_agent("alpha", "hi", lead_creds_path=fresh_lead_creds_path)
+    # Assert — the blocking POST recorder was never reached.
+    assert calls == []
+
+
+def test_agent_send_nonblocking_payload_carries_track_command(
+    state_db_env, fresh_lead_creds_path
+):
+    # Arrange
+    with _real_listener() as port:
+        _seed_local("alpha", a2a_port=port)
+        # Act
+        with _exploding_post_turn():
+            result = send_to_agent(
+                "alpha", "now bump the threshold", lead_creds_path=fresh_lead_creds_path
+            )
+    # Assert
+    assert result["track_command"] == "sac agents send alpha 'now bump the threshold'"
+
+
+def test_agent_send_nonblocking_track_command_argv_is_a_list(
+    state_db_env, fresh_lead_creds_path
+):
+    # Arrange
+    with _real_listener() as port:
+        _seed_local("alpha", a2a_port=port)
+        # Act
+        with _exploding_post_turn():
+            result = send_to_agent("alpha", "hi", lead_creds_path=fresh_lead_creds_path)
+    # Assert
+    assert result["track_command_argv"] == ["sac", "agents", "send", "alpha", "hi"]
+
+
+def test_agent_send_nonblocking_reports_delivered_subscriber_count(
+    state_db_env, fresh_lead_creds_path
+):
+    # Arrange
+    with _real_listener() as port:
+        _seed_local("alpha", a2a_port=port)
+        # Act
+        with _exploding_post_turn():
+            result = send_to_agent("alpha", "hi", lead_creds_path=fresh_lead_creds_path)
+    # Assert
+    assert result["delivered_subscriber_count"] == 1
+
+
+def test_agent_send_nonblocking_fails_loud_when_port_unreachable(
+    state_db_env, fresh_lead_creds_path
+):
+    # Arrange — grab then release a port so nothing is listening on it.
+    import socket as _socket
+
+    s = _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    dead_port = s.getsockname()[1]
+    s.close()
+    _seed_local("alpha", a2a_port=dead_port)
+    # Act
+    with _exploding_post_turn():
+        result = send_to_agent("alpha", "hi", lead_creds_path=fresh_lead_creds_path)
+    # Assert — demonstrable unreachability is a loud error, not "dispatched".
+    assert result["status"] == "error"
+
+
+def test_agent_send_nonblocking_port_unreachable_error_carries_diagnosis(
+    state_db_env, fresh_lead_creds_path
+):
+    # Arrange
+    import socket as _socket
+
+    s = _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    dead_port = s.getsockname()[1]
+    s.close()
+    _seed_local("alpha", a2a_port=dead_port)
+    # Act
+    with _exploding_post_turn():
+        result = send_to_agent("alpha", "hi", lead_creds_path=fresh_lead_creds_path)
+    # Assert
+    assert result["diagnosis"]["port_reachable"] is False
+
+
+def test_agent_send_nonblocking_fails_loud_when_dead_pid(
+    state_db_env, fresh_lead_creds_path
+):
+    # Arrange — a recorded pid that is essentially guaranteed not to exist.
+    dead_pid = 2_147_483_646
+    _seed_local_with_pid("alpha", a2a_port=12345, pid=dead_pid)
+    # Act
+    with _exploding_post_turn():
+        result = send_to_agent("alpha", "hi", lead_creds_path=fresh_lead_creds_path)
+    # Assert
+    assert result["status"] == "error"
+
+
+def test_agent_send_nonblocking_not_running_still_errors(state_db_env):
+    # Arrange — no rows seeded (mode-independent failure, before dispatch).
+    # Act
+    result = send_to_agent("ghost", "hi")
+    # Assert
+    assert result["status"] == "error"


### PR DESCRIPTION
## Problem
The MCP `agent_send` tool POSTed to the agent's `/v1/turn` synchronously and **blocked the caller's whole turn** until the agent finished processing. An MCP tool call cannot be backgrounded by the caller, so this hung the lead.

## Change
`agent_send` / `send_to_agent` are **non-blocking by default**.

### New return contract (default, `wait=False`)
`send_to_agent` validates reachability (registry row, pid liveness, local sidecar TCP connect, creds preflight) and returns PROMPTLY:

```
{
  "status": "dispatched",
  "agent": "<name>",
  "host": "<host>",
  "url": "http://127.0.0.1:<port>/v1/turn",
  "a2a_port": <int>,
  "delivered_subscriber_count": 1,
  "track_command": "sac agents send <name> '<prompt>'",
  "track_command_argv": ["sac", "agents", "send", "<name>", "<prompt>"],
  "note": "non-blocking dispatch: ... run track_command in a backgrounded shell ..."
}
```

The caller runs `track_command` in a **backgrounded shell** to actually deliver the prompt and stream the reply — the lead's turn never blocks on the agent's processing. `sac agents send` is the same library codepath, so the backgrounded delivery and the inline `wait=True` path are behaviourally identical (no second drifting implementation).

### Wait flag (opt-in synchronous)
`wait=True` preserves the **legacy** synchronous POST/await path: blocks and returns `{"status": "ok", "response_text": ..., "response_metadata": {...}}`.

### Fail-loud preserved
An agent that demonstrably cannot receive the turn returns the same loud `error` / `creds-expired` payload (with `diagnosis`) as before — **never a misleading "dispatched"**:
- not running / no a2a_port / expired creds (lead or peer)
- local sidecar port refuses TCP connect
- recorded pid not alive

Cross-host agents (no local port probe possible) proceed to `dispatched`; the backgrounded `track_command` surfaces any transport failure loudly when run.

## Tests (no mocks)
- default returns `status="dispatched"` with `track_command` / `track_command_argv` / `delivered_subscriber_count`, and the blocking POST is proven NOT to fire (recorder raises if called)
- `wait=True` still awaits and returns `response_text`
- non-blocking dispatch fails loud (`status="error"` + `diagnosis`) when the sidecar port is unreachable or the pid is dead
- MCP wrapper defaults `wait=False` and forwards an explicit `wait=True`
- existing blocking-path tests updated intentionally to pass `wait=True`

`tests/.../cli_pkg/test__send.py` + `tests/.../_mcp/_tools/test__agent_send.py`: **43 passed**.

Full suite: 4615 passed; the 3 failures (`test_audit_all_clean`, `test_claude_session_channels_without_port_raises`, `test_hanging_remote_probe_respects_timeout_budget`) are pre-existing/environmental — they reproduce identically on clean `develop` and are unrelated to this change (FastMCP/scitex-dev tooling drift, missing local `.claude` creds, timing-flaky timeout assertion).