### PR TITLE
fix(apptainer): fail loud when server:sac channel has no resolvable bus bearer

### DIFF
--- a/src/scitex_agent_container/runtimes/_apptainer_listen_env.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_listen_env.py
@@ -1,0 +1,83 @@
+"""Bus-listen env injection for the apptainer runtime.
+
+Pulled out of ``_apptainer_runtime.py`` so the listen-env logic lives in
+one place and the runtime file stays under sac's 512-line cap. Mirrors
+the ``_apptainer_iso_flags.compute_iso_prepend`` extraction pattern.
+
+The in-container ``sac mcp channel`` adapter (registered when
+``spec.claude.channels`` contains ``server:sac``) resolves the bus from
+two env vars at start:
+
+* ``SAC_LISTEN_BASE_URL`` — the host-stable ``sac listen`` URL the
+  adapter subscribes its inbox SSE against, and the per-agent sidecar
+  advertises in its agent card so peers survive per-restart port churn.
+* ``SAC_LISTEN_BEARER`` — the bearer the adapter must present or
+  ``sac listen`` returns 401, the subscription never lands, and every
+  lead ``a2a_send`` push reports ``delivered_subscriber_count=0``.
+
+This module returns the ``--env`` flags ``build_run_argv`` should append.
+The injection is UNCONDITIONAL w.r.t. the relaxed escape-hatch: relaxed
+specs (``--containall`` + explicit ``raw_args``) bypass the preflight
+wrapper but still need bus auth, otherwise their adapter can never
+subscribe.
+
+Fail-loud contract: when ``server:sac`` is registered but the bearer
+cannot be resolved, this raises ``RuntimeError`` rather than launching an
+agent whose adapter can never authenticate (the silent wake-on-push
+failure this guard exists to prevent). When ``server:sac`` is absent a
+missing token is harmless (nothing subscribes) — we inject only the base
+URL and log a loud warning.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def listen_env_flags(config) -> list[str]:
+    """Return the ``--env SAC_LISTEN_*`` flags for ``apptainer exec``.
+
+    Pure except for reading the host token file and config; raises
+    ``RuntimeError`` when a ``server:sac`` spec has no resolvable bearer.
+    """
+    # Local imports keep these resolvable even if a formatter strips
+    # module-level unused imports during a refactor, and avoid a circular
+    # import with the runtime module that calls this helper.
+    from .._listen._config import listen_base_url
+    from ._apptainer_build import _listen_token_path, _read_listen_bearer
+
+    flags: list[str] = ["--env", f"SAC_LISTEN_BASE_URL={listen_base_url()}"]
+
+    claude_spec = getattr(config, "claude", None)
+    channels = list(getattr(claude_spec, "channels", None) or [])
+    wants_bus = any(str(c).strip() == "server:sac" for c in channels)
+
+    bearer = _read_listen_bearer()
+    if bearer:
+        flags += ["--env", f"SAC_LISTEN_BEARER={bearer}"]
+    elif wants_bus:
+        raise RuntimeError(
+            "spec.claude.channels includes 'server:sac' but the bus bearer "
+            f"token file {_listen_token_path()} is absent or empty, so the "
+            "in-container channel adapter could never authenticate to "
+            "`sac listen` (401). Subscriptions would never land and every "
+            "pushed turn would report delivered_subscriber_count=0 — "
+            "refusing to launch an agent whose adapter can never subscribe. "
+            "Start `sac listen` to generate the token, then restart this "
+            "agent."
+        )
+    else:
+        logger.warning(
+            "SAC_LISTEN_BEARER not injected: bus token file %s is absent. "
+            "The in-container channel adapter cannot authenticate to "
+            "`sac listen` (401), so inbox subscription and pushed turns "
+            "will fail. Start `sac listen` to generate the token, then "
+            "restart this agent.",
+            _listen_token_path(),
+        )
+    return flags
+
+
+__all__ = ["listen_env_flags"]

--- a/src/scitex_agent_container/runtimes/_apptainer_runtime.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_runtime.py
@@ -30,7 +30,6 @@ no-passwd-entry trap with non-1000 UIDs.
 
 from __future__ import annotations
 
-import logging
 import os
 import shutil
 import signal
@@ -52,8 +51,6 @@ from ._apptainer_build import (  # noqa: F401
 )
 from ._apptainer_build import resolve_sif as _resolve_sif
 from .base import RuntimeBase
-
-logger = logging.getLogger(__name__)
 
 DEFAULT_SIF_NAME = "scitex-agent-container.sif"
 RUNNER_MODULE = "scitex_agent_container._runners.claude_session"
@@ -253,43 +250,18 @@ class ApptainerContainerRuntime(RuntimeBase):
         for key, val in (config.env or {}).items():
             argv += ["--env", f"{key}={val}"]
 
-        # Layer-5 of auto-port-allocation: forward the host-stable
-        # ``sac listen`` base URL so the per-agent sidecar's
-        # ``/.well-known/agent-card.json`` can advertise an ``url``
-        # field that survives restarts. Without this, the card's url
-        # would be built from the runner's own port (auto-allocated
-        # and therefore churning every restart), and any peer that
-        # cached the previous card would dangle on its next call.
-        from .._listen._config import listen_base_url as _listen_base_url
+        # Layer-5 of auto-port-allocation + bus auth — forward the
+        # host-stable ``sac listen`` base URL and the host-generated bearer
+        # so the in-container ``sac mcp channel`` adapter can reach AND
+        # authenticate to the bus. Extracted to ``_apptainer_listen_env`` so
+        # the runtime file stays under the line cap; the helper fails loud
+        # when ``server:sac`` is registered but the bearer is unresolvable
+        # (see its docstring). UNCONDITIONAL w.r.t. the relaxed escape-hatch
+        # below: relaxed specs bypass the preflight wrapper but still need
+        # bus auth, else their adapter can never subscribe.
+        from ._apptainer_listen_env import listen_env_flags
 
-        argv += ["--env", f"SAC_LISTEN_BASE_URL={_listen_base_url()}"]
-
-        # Bus auth — the in-container channel adapter (sac MCP) must present
-        # a bearer to reach `sac listen` (it returns 401 without one), or the
-        # inbox subscription never lands and pushed turns report
-        # delivered_subscriber_count=0. Inject the host-generated bearer read
-        # from the token file the listen server itself writes
-        # (~/.scitex/agent-container/tokens/listen-<host>.token via
-        # default_token_path()). This injection is UNCONDITIONAL w.r.t. the
-        # relaxed escape-hatch below — relaxed specs bypass the preflight
-        # wrapper but still need bus auth. The token is read at start time;
-        # it is never written into spec.yaml.
-        #
-        # Missing token file → inject only BASE_URL and log a loud warning
-        # (push will not work). No silent fallback: the adapter surfaces the
-        # resulting auth failure rather than silently degrading.
-        bearer = _read_listen_bearer()
-        if bearer:
-            argv += ["--env", f"SAC_LISTEN_BEARER={bearer}"]
-        else:
-            logger.warning(
-                "SAC_LISTEN_BEARER not injected: bus token file %s is absent. "
-                "The in-container channel adapter cannot authenticate to "
-                "`sac listen` (401), so inbox subscription and pushed turns "
-                "will fail. Start `sac listen` to generate the token, then "
-                "restart this agent.",
-                _listen_token_path(),
-            )
+        argv += listen_env_flags(config)
 
         # v3-realign: spec.apptainer.raw_args (§1 escape-hatch invariant) —
         # appended verbatim after all curated args, before the SIF +

--- a/tests/scitex_agent_container/runtimes/test__apptainer_runtime.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_runtime.py
@@ -31,6 +31,7 @@ from scitex_agent_container.config._types import (
     A2ASpec,
     ApptainerSpec,
     AutonomousSpec,
+    ClaudeSpec,
     ContainerSpec,
 )
 from scitex_agent_container.runtimes import _apptainer_runtime as mod
@@ -1957,6 +1958,86 @@ def test_missing_token_logs_loud_warning(
     assert any(
         "SAC_LISTEN_BEARER not injected" in rec.getMessage() for rec in caplog.records
     )
+
+
+# ---------------------------------------------------------------------------
+# Fail-loud: server:sac channel + unresolvable bearer
+# ---------------------------------------------------------------------------
+# When the channel adapter is actually registered (spec.claude.channels has
+# server:sac) but the bus bearer can't be resolved, the runtime must REFUSE
+# to launch rather than start an agent whose adapter can never subscribe
+# (delivered_subscriber_count would always be 0). This is the live blocker.
+
+
+def _relaxed_bus_cfg(workdir: Path) -> AgentConfig:
+    """Production proj-scitex-agent-container shape: relaxed + explicit
+    raw_args carrying NO SAC_LISTEN_*, plus channels=[server:sac]."""
+    return AgentConfig(
+        name="relaxed-bus-agent",
+        runtime="apptainer",
+        workdir=str(workdir),
+        apptainer=ApptainerSpec(relaxed=True, raw_args=["--userns", "--containall"]),
+        claude=ClaudeSpec(channels=["server:sac"]),
+    )
+
+
+def test_relaxed_with_server_sac_channel_injects_bearer(
+    tmp_path: Path, home_redirect: Path
+) -> None:
+    # Arrange
+    _write_listen_token(home_redirect, "tok-relaxed-bus")
+    rt = ApptainerContainerRuntime()
+    cfg = _relaxed_bus_cfg(tmp_path / "wd")
+    # Act
+    argv = rt.build_run_argv(
+        cfg, state_dir=tmp_path / "state", sif_path=tmp_path / "x.sif"
+    )
+    # Assert
+    assert _env_pairs(argv).get("SAC_LISTEN_BEARER") == "tok-relaxed-bus"
+
+
+def test_relaxed_with_server_sac_channel_injects_base_url(
+    tmp_path: Path, home_redirect: Path
+) -> None:
+    # Arrange
+    _write_listen_token(home_redirect, "tok-relaxed-bus")
+    rt = ApptainerContainerRuntime()
+    cfg = _relaxed_bus_cfg(tmp_path / "wd")
+    # Act
+    argv = rt.build_run_argv(
+        cfg, state_dir=tmp_path / "state", sif_path=tmp_path / "x.sif"
+    )
+    # Assert
+    assert _env_pairs(argv).get("SAC_LISTEN_BASE_URL") == "http://127.0.0.1:7878"
+
+
+def test_server_sac_channel_missing_token_fails_loud(
+    tmp_path: Path, home_redirect: Path
+) -> None:
+    # Arrange
+    rt = ApptainerContainerRuntime()
+    cfg = _relaxed_bus_cfg(tmp_path / "wd")
+    # Act
+    # Assert — refuse to launch (no silent degradation).
+    with pytest.raises(RuntimeError, match="server:sac"):
+        rt.build_run_argv(
+            cfg, state_dir=tmp_path / "state", sif_path=tmp_path / "x.sif"
+        )
+
+
+def test_no_channel_missing_token_does_not_raise(
+    tmp_path: Path, home_redirect: Path
+) -> None:
+    # Arrange — no server:sac channel → a missing token is harmless because
+    # nothing subscribes; the runtime warns but must NOT raise.
+    rt = ApptainerContainerRuntime()
+    cfg = _config(tmp_path / "wd")
+    # Act
+    argv = rt.build_run_argv(
+        cfg, state_dir=tmp_path / "state", sif_path=tmp_path / "x.sif"
+    )
+    # Assert
+    assert "SAC_LISTEN_BEARER" not in _env_pairs(argv)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem (live blocker)

A relaxed apptainer agent's `sac mcp channel` adapter never authenticates
to the bus, so lead→agent pushes reach 0 subscribers and wake-on-push
can't fire. The in-container adapter resolves the bus from
`SAC_LISTEN_BASE_URL` + `SAC_LISTEN_BEARER`; without a valid bearer
`sac listen` returns 401, the inbox subscription never lands, and every
`a2a_send` reports `delivered_subscriber_count=0`.

## Fix

The runtime already injected `SAC_LISTEN_*` unconditionally w.r.t. the
relaxed escape-hatch, but a missing bearer only **warned** and launched
anyway — silently producing an agent whose adapter can never subscribe.

- When `spec.claude.channels` includes `server:sac` **and** the bearer
  cannot be resolved (token file absent/empty), the runtime now **fails
  loud** (`RuntimeError`) instead of launching a broken agent.
- When `server:sac` is **absent**, a missing token stays harmless
  (warn-only — nothing subscribes), preserving the non-channel path.
- Injection stays unconditional for relaxed + `raw_args` specs.

## Where / how

- New focused helper `runtimes/_apptainer_listen_env.py::listen_env_flags`
  (extracted from `build_run_argv`, mirrors `_apptainer_iso_flags`), which
  keeps `_apptainer_runtime.py` under the 512-line cap.
- Reuses existing resolvers — no hardcoding:
  - base URL: `_listen._config.listen_base_url` (same source the lead /
    non-relaxed agents use).
  - bearer: `_listen.tokens.default_token_path` + `read_token`
    (`~/.scitex/agent-container/tokens/listen-<host>.token`).

## Tests (no mocks)

- relaxed + `channels:[server:sac]` → both `SAC_LISTEN_BASE_URL` and
  `SAC_LISTEN_BEARER` in launch env (bearer from a tmp token file).
- `server:sac` + missing token → `RuntimeError` (fail loud).
- no channel + missing token → no raise, base URL still injected.
- existing non-relaxed bearer/base-url injection unchanged (regression).

Full suite: 4422 passed. The 2 residual failures are pre-existing on
develop and unrelated: `test_state_db` cutoff is a timing flake (passes in
isolation), and `test_audit_all_clean` fails on a stale PS-140
cross-package-imports gate + a `FastMCP.list_tools` AttributeError in the
diverged editable scitex-dev — both reproduce on clean develop.
