### PR TITLE
fix(channel): propagate ack flag on a2a send path + cap auto-acks

### DIFF
--- a/src/scitex_agent_container/_mcp/channel.py
+++ b/src/scitex_agent_container/_mcp/channel.py
@@ -39,8 +39,11 @@ import asyncio
 import json
 import logging
 import os
+import time
 from collections import deque
 from typing import Any
+
+from .._env import getenv as _sac_env
 
 log = logging.getLogger(__name__)
 
@@ -90,6 +93,77 @@ def _should_auto_ack(event: dict[str, Any]) -> bool:
         return False
     if event.get("ack"):
         return False
+    return True
+
+
+# --- Auto-ack rate limiter (belt-and-suspenders loop breaker) -------------
+# Even with the ack-flag loop-guard (``_should_auto_ack``), a future
+# regression in flag propagation could restart an ack-on-ack cycle. This
+# sliding-window cap ensures any such loop self-terminates: once a sender
+# exceeds the budget within the window we stop auto-acking it and log
+# loudly (fail-loud, never a silent drop).
+_AUTO_ACK_RATE_MAX_DEFAULT = 20
+_AUTO_ACK_RATE_WINDOW_DEFAULT = 60.0
+# Per-sender sliding window of auto-ack emission timestamps.
+_auto_ack_window: "dict[str, deque[float]]" = {}
+# Senders currently over budget — latches the loud log to once per trip.
+_auto_ack_tripped: "set[str]" = set()
+
+
+def _auto_ack_rate_limits() -> "tuple[int, float]":
+    """Resolve ``(max_acks, window_seconds)`` for the auto-ack cap.
+
+    Configurable via ``SAC_AUTO_ACK_RATE_MAX`` / ``SAC_AUTO_ACK_RATE_WINDOW_S``
+    (and their ``SCITEX_AGENT_CONTAINER_*`` aliases). A non-positive max
+    disables the cap (explicit opt-out).
+    """
+    raw_max = _sac_env("AUTO_ACK_RATE_MAX")
+    raw_win = _sac_env("AUTO_ACK_RATE_WINDOW_S")
+    try:
+        max_n = int(raw_max) if raw_max is not None else _AUTO_ACK_RATE_MAX_DEFAULT
+    except (TypeError, ValueError):
+        max_n = _AUTO_ACK_RATE_MAX_DEFAULT
+    try:
+        window = (
+            float(raw_win) if raw_win is not None else _AUTO_ACK_RATE_WINDOW_DEFAULT
+        )
+    except (TypeError, ValueError):
+        window = _AUTO_ACK_RATE_WINDOW_DEFAULT
+    return max_n, window
+
+
+def _auto_ack_rate_allow(sender: str, *, now: "float | None" = None) -> bool:
+    """Whether an auto-ack to ``sender`` is within the rate budget.
+
+    Sliding-window cap keyed by sender. Returns ``True`` and records the
+    emission when within budget; returns ``False`` (logging loudly, once
+    per trip) when the cap is exceeded inside the window. After the window
+    clears, emission resumes and the loud-log latch resets so a fresh loop
+    is reported again. ``now`` is injectable for deterministic tests.
+    """
+    max_n, window = _auto_ack_rate_limits()
+    if max_n <= 0:
+        return True
+    ts = time.monotonic() if now is None else now
+    dq = _auto_ack_window.setdefault(sender, deque())
+    cutoff = ts - window
+    while dq and dq[0] < cutoff:
+        dq.popleft()
+    if len(dq) >= max_n:
+        if sender not in _auto_ack_tripped:
+            _auto_ack_tripped.add(sender)
+            log.warning(
+                "sac channel: auto-ack rate cap hit for sender %r "
+                "(%d auto-acks within %.0fs) — suppressing further "
+                "auto-acks to this sender until the window clears. "
+                "Possible ack loop.",
+                sender,
+                len(dq),
+                window,
+            )
+        return False
+    dq.append(ts)
+    _auto_ack_tripped.discard(sender)
     return True
 
 
@@ -323,6 +397,9 @@ async def _push_channel_event(
         and listen_url is not None
         and _auto_ack_enabled()
         and _should_auto_ack(event)
+        # _should_auto_ack guarantees a truthy ``from_agent`` above, so the
+        # short-circuit makes this index safe; the cap is the last gate.
+        and _auto_ack_rate_allow(event["from_agent"])
     ):
         try:
             await _post_auto_ack(

--- a/src/scitex_agent_container/a2a/_server.py
+++ b/src/scitex_agent_container/a2a/_server.py
@@ -299,9 +299,9 @@ def _build_app(ctx: _ServerCtx) -> Starlette:
                     row_id = entry["id"]
                     event = entry["event"]
                     data = json.dumps(event, ensure_ascii=False)
-                    yield (
-                        f"id: {row_id}\nevent: message\ndata: {data}\n\n"
-                    ).encode("utf-8")
+                    yield (f"id: {row_id}\nevent: message\ndata: {data}\n\n").encode(
+                        "utf-8"
+                    )
                     mark_delivered([row_id])
 
                 while True:
@@ -324,9 +324,7 @@ def _build_app(ctx: _ServerCtx) -> Starlette:
                         # path that did NOT persist (lifecycle event
                         # fan-out, future ACL-reject notice, …).
                         # Deliver it but skip the marker.
-                        yield f"event: message\ndata: {data}\n\n".encode(
-                            "utf-8"
-                        )
+                        yield f"event: message\ndata: {data}\n\n".encode("utf-8")
             finally:
                 await ctx.inbox.unsubscribe(name, queue)
 
@@ -452,6 +450,13 @@ async def _publish_channel_event(
         in_reply_to=sac_meta.get("in_reply_to"),
         priority=str(sac_meta.get("priority", "normal")),
         requires_reply=bool(sac_meta.get("requires_reply", False)),
+        # Propagate the ack flag so an auto-ack arriving via this per-agent
+        # A2A path is minted with top-level ``ack=True`` and the receiver's
+        # ``_should_auto_ack`` loop-guard recognises it. Without this the
+        # flag was silently dropped (mint_event default ``ack=False``) and
+        # two auto-ack adapters ping-ponged forever. Mirrors the host
+        # control-plane path in ``_listen/server.py``.
+        ack=bool(sac_meta.get("ack", False)),
     )
 
     # WI-1 durability: persist BEFORE publishing. If state.db is
@@ -548,7 +553,7 @@ def serve(
     agent_yamls: list[Path],
     *,
     host: str = "127.0.0.1",
-    port: int = 8888,
+    port: int = 8888,  # stx-allow: STX-NL001
     handler: str = "echo",
 ) -> None:
     """Run the A2A HTTP server in the foreground via uvicorn.

--- a/tests/scitex_agent_container/_mcp/test_channel.py
+++ b/tests/scitex_agent_container/_mcp/test_channel.py
@@ -1411,3 +1411,77 @@ async def test_wake_failure_propagates_to_caller():
         raised = True
     # Assert — the unreachable wake surfaced loudly, not silently dropped.
     assert raised is True
+
+
+# ---------------------------------------------------------------------------
+# Auto-ack rate limiter (`_auto_ack_rate_allow`) — belt-and-suspenders loop
+# breaker. Pure sync function; deterministic via the injectable ``now``. No
+# sleeps, no mocks. Module-level window/latch state is reset in each Arrange.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _ack_rate_max_two():
+    """Lower the auto-ack cap to 2 via env (yield save/restore, no monkeypatch)."""
+    key = "SAC_AUTO_ACK_RATE_MAX"
+    saved = os.environ.get(key)
+    os.environ[key] = "2"
+    try:
+        yield
+    finally:
+        if saved is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = saved
+
+
+def test_auto_ack_rate_allows_calls_within_default_budget():
+    """Up to the default cap (20) within the window are all permitted."""
+    # Arrange
+    channel_mod._auto_ack_window.clear()
+    channel_mod._auto_ack_tripped.clear()
+    # Act
+    results = [
+        channel_mod._auto_ack_rate_allow("peer", now=float(i)) for i in range(20)
+    ]
+    # Assert
+    assert all(results) is True
+
+
+def test_auto_ack_rate_blocks_calls_over_default_budget():
+    """The 21st auto-ack to one sender within the window is refused."""
+    # Arrange
+    channel_mod._auto_ack_window.clear()
+    channel_mod._auto_ack_tripped.clear()
+    for i in range(20):
+        channel_mod._auto_ack_rate_allow("peer", now=float(i))
+    # Act
+    over = channel_mod._auto_ack_rate_allow("peer", now=19.5)
+    # Assert
+    assert over is False
+
+
+def test_auto_ack_rate_resumes_after_window_clears():
+    """Once the window passes, emission to the same sender resumes."""
+    # Arrange
+    channel_mod._auto_ack_window.clear()
+    channel_mod._auto_ack_tripped.clear()
+    for i in range(20):
+        channel_mod._auto_ack_rate_allow("peer", now=float(i))
+    # Act — far past the 60s default window, the old timestamps drop out.
+    after = channel_mod._auto_ack_rate_allow("peer", now=200.0)
+    # Assert
+    assert after is True
+
+
+def test_auto_ack_rate_env_override_lowers_cap(_ack_rate_max_two):
+    """``SAC_AUTO_ACK_RATE_MAX=2`` makes the 3rd call refuse."""
+    # Arrange
+    channel_mod._auto_ack_window.clear()
+    channel_mod._auto_ack_tripped.clear()
+    channel_mod._auto_ack_rate_allow("peer", now=0.0)
+    channel_mod._auto_ack_rate_allow("peer", now=1.0)
+    # Act
+    third = channel_mod._auto_ack_rate_allow("peer", now=2.0)
+    # Assert
+    assert third is False

--- a/tests/scitex_agent_container/a2a/test__server.py
+++ b/tests/scitex_agent_container/a2a/test__server.py
@@ -58,7 +58,7 @@ def _write_yaml(tmpdir: Path, name: str, handler: str = "echo") -> Path:
                 "team": "scitex",
             },
         },
-        "spec": {"a2a": {"handler": handler, "port": 8888}},
+        "spec": {"a2a": {"handler": handler, "port": 8888}},  # stx-allow: STX-NL001
     }
     p = tmpdir / f"{name}.yaml"
     p.write_text(yaml.safe_dump(body))
@@ -776,8 +776,7 @@ def _durable_publish_row(_isolated_db, tmp_path):
     # Assert handled by per-behaviour tests below.
     with _state_db.open_db(_isolated_db) as conn:
         rows = conn.execute(
-            "SELECT id, target, source, content, delivered_at "
-            "FROM channel_events"
+            "SELECT id, target, source, content, delivered_at FROM channel_events"
         ).fetchall()
     return rows
 
@@ -862,14 +861,11 @@ def test_event_posted_before_subscribe_is_replayed_on_connect(
             )
             if r.status_code not in (200, 201, 202):
                 raise RuntimeError(
-                    f"precondition: publisher POST returned {r.status_code}: "
-                    f"{r.text!r}"
+                    f"precondition: publisher POST returned {r.status_code}: {r.text!r}"
                 )
         # Act — subscribe and read the replay.
         event = _asyncio.run(
-            _consume_first_event(
-                f"http://127.0.0.1:{port}/agents/bob/inbox/stream"
-            )
+            _consume_first_event(f"http://127.0.0.1:{port}/agents/bob/inbox/stream")
         )
     # Assert
     assert event.get("content") == "queued for bob"
@@ -893,9 +889,7 @@ def test_replayed_event_is_marked_delivered_after_first_delivery(
                 json=_send_payload("queued for bob"),
             )
         _asyncio.run(
-            _consume_first_event(
-                f"http://127.0.0.1:{port}/agents/bob/inbox/stream"
-            )
+            _consume_first_event(f"http://127.0.0.1:{port}/agents/bob/inbox/stream")
         )
     # Act
     with _state_db.open_db(_isolated_db) as conn:
@@ -906,9 +900,7 @@ def test_replayed_event_is_marked_delivered_after_first_delivery(
     assert row["delivered_at"] is not None
 
 
-def test_sse_id_line_is_persisted_row_id(
-    _isolated_db, tmp_path: Path
-) -> None:
+def test_sse_id_line_is_persisted_row_id(_isolated_db, tmp_path: Path) -> None:
     """The SSE ``id:`` line carries the channel_events row id — the
     cursor a reconnecting client echoes back as Last-Event-ID."""
     # Arrange
@@ -923,9 +915,7 @@ def test_sse_id_line_is_persisted_row_id(
                 json=_send_payload("first"),
             )
         sse_id, _event = _asyncio.run(
-            _consume_event_with_id(
-                f"http://127.0.0.1:{port}/agents/bob/inbox/stream"
-            )
+            _consume_event_with_id(f"http://127.0.0.1:{port}/agents/bob/inbox/stream")
         )
     with _state_db.open_db(_isolated_db) as conn:
         row = conn.execute(
@@ -935,3 +925,78 @@ def test_sse_id_line_is_persisted_row_id(
     matches = sse_id is not None and int(sse_id) == int(row["id"])
     # Assert
     assert matches
+
+
+# ---------------------------------------------------------------------
+# Regression: the per-agent A2A send path must propagate metadata.ack
+# into the minted event. It previously omitted ``ack=`` (its twin in
+# ``_listen/server.py`` included it), so an auto-ack arriving via this
+# path was minted with ``ack=False`` — the receiver's loop-guard then
+# failed to recognise it and auto-acked back, ping-ponging forever.
+# ---------------------------------------------------------------------
+
+
+def _ack_send_payload(*, from_agent: str = "alice") -> dict:
+    """A ``message:send`` body shaped like an auto-ack (``metadata.ack``)."""
+    return {
+        "jsonrpc": "2.0",
+        "id": "1",
+        "method": "SendMessage",
+        "params": {
+            "message": {
+                "message_id": "m-ack",
+                "role": "ROLE_USER",
+                "parts": [{"text": ""}],
+            },
+            "metadata": {"from_agent": from_agent, "ack": True},
+        },
+    }
+
+
+@pytest.fixture
+def _persisted_ack_event(_isolated_db, tmp_path):
+    """POST an ack-flagged message:send; return the round-tripped event.
+
+    Real end-to-end path (TestClient -> _publish_channel_event ->
+    mint_event -> persist_event), no mocks. ``persist_event`` stores the
+    minted envelope verbatim in ``meta_json``, so the returned dict is
+    exactly what the bus would deliver to a subscriber.
+    """
+    # Arrange
+    yml = _write_yaml(tmp_path, "bob")
+    app = build_app([yml])
+    # Act
+    with TestClient(app) as client:
+        resp = client.post(
+            "/agents/bob/message:send",
+            json=_ack_send_payload(from_agent="alice"),
+        )
+    assert resp.status_code in (200, 201, 202), resp.text
+    # Assert handled by per-behaviour tests below.
+    with _state_db.open_db(_isolated_db) as conn:
+        row = conn.execute(
+            "SELECT meta_json FROM channel_events WHERE target='bob'"
+        ).fetchone()
+    return json.loads(row["meta_json"])
+
+
+def test_a2a_send_path_propagates_ack_flag_into_event(_persisted_ack_event):
+    """The minted event carries top-level ``ack=True`` (was dropped)."""
+    # Arrange
+    event = _persisted_ack_event
+    # Act
+    actual = event.get("ack")
+    # Assert
+    assert actual is True
+
+
+def test_a2a_published_ack_event_is_not_re_acked(_persisted_ack_event):
+    """The loop-guard recognises the round-tripped ack and declines."""
+    # Arrange
+    from scitex_agent_container._mcp.channel import _should_auto_ack
+
+    event = _persisted_ack_event
+    # Act
+    should = _should_auto_ack(event)
+    # Assert
+    assert should is False


### PR DESCRIPTION
## Root cause
The flood of empty-content auto-acks (alternating conversation threads,
`in_reply_to` set) was a **recursive auto-ack loop**.

The receive-side loop-guard `_should_auto_ack` checks top-level
`event["ack"]`. Events are minted by `mint_event(...)`, which exposes a
top-level `ack` field — but only if the caller passes `ack=`. Two
callers existed and had **silently diverged**:

- `_listen/server.py` (host control plane) — passed `ack=` ✓
- `a2a/_server.py` (per-agent A2A server) — **omitted `ack=`** ✗

So an auto-ack arriving via the per-agent path was minted with
`ack=False`; the receiver didn't recognise it as an ack and auto-acked
back → two adapters ping-ponged forever.

## Fix
1. `a2a/_server.py`: pass `ack=bool(sac_meta.get("ack", False))` to
   `mint_event`, mirroring `_listen/server.py`.
2. `_mcp/channel.py`: per-sender sliding-window cap on auto-ack
   emission (`_auto_ack_rate_allow`) — a belt-and-suspenders loop
   breaker so even an unforeseen loop self-terminates and logs loudly.
   Config: `SAC_AUTO_ACK_RATE_MAX` (default 20) /
   `SAC_AUTO_ACK_RATE_WINDOW_S` (default 60), dual-name aliases honoured.

## Tests (real collaborators, no mocks)
- a2a regression: drives the real `message:send` path, asserts the
  minted event carries top-level `ack=True` and `_should_auto_ack`
  declines it. **Both fail on pre-fix source, pass after** (verified by
  running the same tests against the unfixed `src/`).
- rate-limiter unit tests: allow within budget / block over budget /
  resume after window / env override.

Local: 137 passed (`a2a/_server`, `_mcp/channel`, `a2a/_inbox_bus`).
