### PR TITLE
feat(runtime): enable subagents in claude_session runner

### DIFF
--- a/src/scitex_agent_container/runtimes/_sdk_common.py
+++ b/src/scitex_agent_container/runtimes/_sdk_common.py
@@ -507,4 +507,17 @@ def build_sdk_options(
                 "args": sidecar_args,
             }
 
+    # Enable subagents. The Agent (Task) tool is only OFFERED to the model
+    # when it appears in ``allowed_tools`` (Anthropic "Subagents in the SDK"
+    # guide — the built-in general-purpose subagent is invokable once "Agent"
+    # is listed). The runner uses permission_mode=bypassPermissions, where
+    # listing a tool only AUTO-APPROVES it and unlisted tools (Bash/Read/
+    # Edit/…) stay available — so appending "Agent" enables subagent
+    # delegation WITHOUT narrowing the toolset. Merge so any spec-provided
+    # allowed_tools list is preserved.
+    _allowed = list(kwargs.get("allowed_tools") or [])
+    if "Agent" not in _allowed:
+        _allowed.append("Agent")
+    kwargs["allowed_tools"] = _allowed
+
     return ClaudeAgentOptions(**kwargs)

--- a/tests/scitex_agent_container/runtimes/test__sdk_common.py
+++ b/tests/scitex_agent_container/runtimes/test__sdk_common.py
@@ -557,6 +557,53 @@ class TestBuildOptions:
         # Assert
         assert cwd == str(ws)
 
+    def test_compose_enables_agent_tool_for_subagents(self, _composed_opts):
+        # Arrange
+        opts, _ = _composed_opts
+        # Act
+        allowed = list(opts.allowed_tools or [])
+        # Assert
+        assert "Agent" in allowed
+
+    @pytest.fixture
+    def _opts_preset_tools(self, sdk_env: _Env, tmp_path):
+        # Arrange: same auth + workspace setup as _composed_opts, but the
+        # caller pre-sets allowed_tools via ``extra`` to prove the merge
+        # preserves the caller's list AND appends "Agent".
+        _write_valid_cred(sdk_env, tmp_path)
+        sdk_env.delenv("ANTHROPIC_API_KEY")
+        sdk_env.delenv(_SAC_KEY)
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        (ws / ".mcp.json").write_text(
+            json.dumps({"mcpServers": {"stx": {"command": "scitex"}}})
+        )
+        _swap_registry(sdk_env, {"config": "cfg.yaml"})
+        _swap_load_config(sdk_env, str(ws))
+        # Act
+        opts = build_sdk_options(
+            "alpha",
+            permission_mode="bypassPermissions",
+            extra={"allowed_tools": ["Read", "Bash"]},
+        )
+        return list(opts.allowed_tools or [])
+
+    def test_compose_preserves_caller_allowed_tools(self, _opts_preset_tools):
+        # Arrange
+        allowed = _opts_preset_tools
+        # Act
+        preserved = "Read" in allowed and "Bash" in allowed
+        # Assert
+        assert preserved is True
+
+    def test_compose_appends_agent_to_caller_allowed_tools(self, _opts_preset_tools):
+        # Arrange
+        allowed = _opts_preset_tools
+        # Act
+        has_agent = "Agent" in allowed
+        # Assert
+        assert has_agent is True
+
     def test_compose_attaches_mcp_servers(self, _composed_opts):
         # Arrange
         opts, _ = _composed_opts


### PR DESCRIPTION
## Why
SAC agents on the `claude_session` runtime could not use subagents — they
ran as a single linear session. Root cause: `build_sdk_options`
(`runtimes/_sdk_common.py`) never set `allowed_tools` (SDK default `[]`),
so the **Agent** (Task) tool was not offered to the model. Per Anthropic's
"Subagents in the SDK" guide, the Agent tool must be in `allowed_tools`
(the built-in `general-purpose` subagent is invokable once it is listed).

## Change
Append `"Agent"` to `allowed_tools`, merge-preserving any caller-provided
list. The runner uses `permission_mode=bypassPermissions`, where listing a
tool only auto-approves it and unlisted tools (Bash/Read/Edit/…) remain
available — so this enables subagent delegation **without narrowing** the
toolset.

## Tests (real, no mocks)
- `"Agent"` present in the default compose.
- A caller-provided `allowed_tools` is preserved AND `"Agent"` appended.
- The two Agent assertions **fail on pre-change source, pass after**
  (verified by running the new tests against the unfixed `src/`).
- 41 passed in `test__sdk_common.py`.

## Scope / follow-ups
- Custom subagent definitions (`agents=` from spec) are a follow-up; this
  ships the built-in general-purpose capability — the fastest unlock.
- Live verification (an agent actually spawning a subagent) requires an
  image rebuild + restart, since the runner is baked into the container
  image.
