### PR TITLE
docs(skills): correct stale claude-session SIF-less framing

### DIFF
--- a/src/scitex_agent_container/_skills/scitex-agent-container/01_installation.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/01_installation.md
@@ -75,30 +75,27 @@ A bare host `ANTHROPIC_API_KEY` is **never honoured**: if
 silently switch you to pay-per-token billing or shadow a working OAuth
 credentials file. Set neither and you get a clear `SDKCommonError`.
 
-## Per-host hook (optional but recommended for remote/HPC)
+## Remote / HPC agents
 
-When running agents on remote hosts via ssh, sac sources `~/.scitex/agent-container/hosts/$(hostname).sh` on the remote before launching the runner. Keeps per-host quirks (Lmod, env unsets, custom PATH, container wrappers) out of the package and in your private dotfiles.
+sac is apptainer-only: the runner always launches via `apptainer exec`
+inside the SIF — there is no host-side bare-Python launch path. The old
+per-host `~/.scitex/agent-container/hosts/$(hostname).sh` + `SAC_RUNNER_PREFIX`
+hook (a host-side `python -m ... claude_session` wrapper) was removed with
+the bare-metal/SSH-dispatch ripout (WI-6, 2026-05-20). The
+`_runners/_remote_launch` module that generated it still exists but is
+dead code (no live importers).
 
-Example for Spartan HPC compute nodes:
+Cross-host placement now goes through:
 
-```bash
-# ~/.scitex/agent-container/hosts/spartan-bm198.hpc.unimelb.edu.au.sh
-module load GCCcore/11.3.0 OpenSSL/1.1
-unset SAC_ANTHROPIC_API_KEY
-# Optional: re-exec the runner inside an existing SLURM allocation
-if [ -z "$SLURM_JOB_ID" ]; then
-    JOBID=$(squeue --me -h -n head-spartan -o "%i" | head -1)
-    [ -n "$JOBID" ] && export SAC_RUNNER_PREFIX="srun --jobid=$JOBID --overlap"
-fi
-```
+- **`spec.host`** — pin an agent to a host (or a priority list). See
+  [11_remote-deploy.md](11_remote-deploy.md).
+- **`sac --on <peer>`** (F-CS12) — dispatch a `sac` command on a peer
+  defined in `config.yaml`'s `peers:` block.
 
-`SAC_RUNNER_PREFIX` is honored by the launch script; common values:
-
-```bash
-export SAC_RUNNER_PREFIX="srun --jobid=$JOBID --overlap"          # SLURM tenancy
-export SAC_RUNNER_PREFIX="apptainer exec --bind ... my-sac.sif"   # SIF-pinned version
-export SAC_RUNNER_PREFIX="conda run -n agent-env"                  # conda env
-```
+HPC-specific environment (Lmod modules, SLURM tenancy, etc.) belongs in
+the apptainer image / overlay or the agent's `to_home/` (see
+[25_claude-setup-delivery.md](25_claude-setup-delivery.md)), not in a
+host-side launch hook.
 
 ## Verify
 

--- a/src/scitex_agent_container/_skills/scitex-agent-container/06_http-api.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/06_http-api.md
@@ -49,7 +49,7 @@ Response body fields:
 
 ## Remote agents — ssh-as-transport
 
-For agents declared with `spec.remote.host`, the runner stays on `127.0.0.1` (loopback only — no LAN exposure). Peers reach it through ssh:
+For agents pinned to another host via `spec.host`, the runner stays on `127.0.0.1` (loopback only — no LAN exposure). Peers reach it through ssh:
 
 ```python
 from scitex_agent_container.peer import post_turn
@@ -71,6 +71,6 @@ This works for ssh aliases that aren't DNS-resolvable from the caller (e.g., `mb
 ## See also
 
 - [10_cli.md](10_cli.md) — `sac listen` + `sac agents send` + `sac peer post-turn`
-- [17_inbound-turn-endpoint.md](17_inbound-turn-endpoint.md) — full reference: detailed wire examples, comparison vs legacy A2A sidecar, implementation files, `SAC_RUNNER_PREFIX` hook for SLURM / apptainer wrappers
+- [17_inbound-turn-endpoint.md](17_inbound-turn-endpoint.md) — full reference: detailed wire examples, comparison vs legacy A2A sidecar, implementation files, cross-host (`spec.host` / `sac --on`)
 - [03_python-api.md](03_python-api.md) — `peer.post_turn()` + `peer.PeerError`
-- [07_a2a-protocol.md](07_a2a-protocol.md) — JSON-RPC `message/send` surface (legacy `runtime: claude-code` only)
+- [07_a2a-protocol.md](07_a2a-protocol.md) — JSON-RPC `message/send` surface (sidecar path for non-SDK runtimes)

--- a/src/scitex_agent_container/_skills/scitex-agent-container/07_a2a-protocol.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/07_a2a-protocol.md
@@ -40,7 +40,7 @@ kind: Agent
 metadata:
   name: my-agent
 spec:
-  runtime: claude-code
+  runtime: apptainer
   a2a:
     port: 8888
     handler: echo          # echo (default) | claude_cli | exec

--- a/src/scitex_agent_container/_skills/scitex-agent-container/14_claude-session-state.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/14_claude-session-state.md
@@ -1,0 +1,132 @@
+---
+description: |
+  [TOPIC] claude-session runner — state layout, auth, status JSON, supervisor
+  [DETAILS] Operational reference for the in-container claude-session SDK runner (see 15_claude-session.md for the overview). Covers the per-agent state dir (`pid`/`heartbeat.json`/`session.jsonl`/`session_id`/`quota.json`), scope resolution, the cost-critical auth precedence (`~/.claude/.credentials.json` OAuth vs `SAC_ANTHROPIC_API_KEY`), the `sdk_session` status-JSON block, the in-repo smoke test, the auto-restart supervisor, and the no-interactive-session constraint.
+tags: [scitex-agent-container-claude-session-state, claude-session, sdk]
+---
+
+# claude-session runner — state, auth, status, supervisor
+
+Operational reference for the in-container `claude-session` SDK runner.
+For the runtime overview, the canonical apptainer YAML, and operating
+modes, see [15_claude-session.md](15_claude-session.md).
+
+## State layout
+
+Per-agent state lives at `<scope>/runtime/<name>/`:
+
+| File | Contents |
+|---|---|
+| `pid` | Runner's PID (atomic write — tmp + rename). |
+| `heartbeat.json` | `{ts, pid, state}` plus `elapsed_s` (seconds since session start, from `started_at`) and the running token totals `input_tokens / output_tokens / total_tokens` (from `quota.json`). State ∈ `starting / idle / working / stopping`. Refreshed every 10 s (`--tick-seconds`). |
+| `started_at` | Session start time (unix seconds). Written once at startup; preserved across a resumed respawn so `elapsed_s` tracks the conversation, not the process. |
+| `session.jsonl` | One JSON object per turn event: `user / assistant / user_echo / result / error`. The transcript. |
+| `session_id` | Latest SDK session UUID. Auto-resumed by the next `sac agents start`. |
+| `quota.json` | Accumulated per-turn token totals (input / output / cache_creation / cache_read / turns). |
+
+Scope resolution (highest priority first):
+
+1. **Project-local**: walks up from cwd to a git repo containing
+   `.scitex/agent-container/`. State lands in
+   `<repo>/.scitex/agent-container/runtime/<name>/`.
+2. **Home**: `~/.scitex/agent-container/runtime/<name>/` (when no
+   project scope is available).
+3. Override via `$SCITEX_AGENT_CONTAINER_RUNTIME_DIR` (the runner reads
+   this verbatim — useful for ad-hoc tests).
+
+Symmetric: agent definitions follow the same resolution order
+(`<scope>/agents/<name>/<name>.yaml` first, then
+`~/.scitex/agent-container/agents/`, then env, then fleet dirs).
+
+## Auth (cost-critical)
+
+The SDK's authentication path, by precedence
+(`runtimes/_sdk_common.py::provision_anthropic_auth`):
+
+1. `~/.claude/.credentials.json` exists → SDK reads OAuth token
+   automatically (Pro/Max plan, **flat-rate**). The default on every
+   workstation that has run `claude /login`.
+2. `SAC_ANTHROPIC_API_KEY` (sac-namespaced handoff for headless
+   contexts — CI, SLURM, cron). When set it is mirrored into
+   `ANTHROPIC_API_KEY` for the SDK (an `sk-ant-api*` value is
+   **pay-per-token**, explicit opt-in only).
+
+A bare host `ANTHROPIC_API_KEY` is **never honoured**: the first thing
+`provision_anthropic_auth` does is overwrite it from
+`SAC_ANTHROPIC_API_KEY`, or *pop* it from the env when
+`SAC_ANTHROPIC_API_KEY` is unset — so a stale dotfiles export can't be
+picked up by the SDK auto-reader, shadow a working OAuth credentials
+file, or silently switch you to API-key billing. Set neither input and
+you get a clear `SDKCommonError`.
+
+## Status JSON addition
+
+`sac agents status <name> --json` carries an `sdk_session` field for
+agents on this runtime:
+
+```json
+{
+  "runtime": "apptainer",
+  "sdk_session": {
+    "session_id": "6ef8248f-1ccd-4877-934d-908e15333b52",
+    "quota": {
+      "input_tokens": 6,
+      "output_tokens": 14,
+      "cache_creation_input_tokens": 33003,
+      "cache_read_input_tokens": 0,
+      "turns": 1
+    },
+    "heartbeat": {
+      "ts": 1777766006.95, "pid": 3476972, "state": "idle",
+      "started_at": 1777765800.0, "elapsed_s": 206.95,
+      "input_tokens": 6000, "output_tokens": 1500, "total_tokens": 40503
+    },
+    "state_dir": "/path/to/.scitex/agent-container/runtime/<name>"
+  }
+}
+```
+
+`sdk_session` is populated for `kind: Agent` (SDK runner) and `null` for
+`kind: AgentProxy` (the HTTP forwarder, which has no SDK) — never absent
+— so dashboards can switch on its presence without parsing further.
+
+## In-repo smoke test
+
+`<repo>/.scitex/agent-container/agents/sdk-test/sdk-test.yaml` is a
+checked-in fixture that the project-local discovery picks up
+automatically when `sac` is invoked from inside the repo:
+
+```bash
+cd ~/proj/scitex-agent-container
+sac agents start sdk-test --foreground
+# expected: sdk-runtime-ok
+```
+
+The `sdk-runtime-smoke` GitHub workflow runs this exact command on every
+push to develop / main (and daily) so an upstream SDK breakage surfaces
+immediately rather than during the next manual fleet operation.
+
+## Supervisor — auto-restart on SDK crash
+
+`--max-restarts N` (default `0` = terminate on first failure) + `--restart-backoff-s S` (default `1.0`, doubles per attempt) let the runner reopen `ClaudeSDKClient` after a mid-session exception. On each retry it re-reads `session_id` from the state dir so the new client resumes the latest completed turn; the inbox is preserved across restarts. Each restart writes `{type: error, kind: sdk_runtime, attempt: N}` + `{type: supervisor, event: restarting, in_s: <delay>}` to `session.jsonl`. After `max_restarts` attempts the inbox is drained with the last exception and the runner exits. Init failures (missing SDK, bad options) stay terminal.
+
+## Constraints
+
+- **No human-typed interactive session.** There is no tmux pane to type
+  `/clear`, `/compact`, or paste into. The SDK runner takes one mission
+  prompt at start; subsequent turns arrive via A2A (`POST /v1/turn`,
+  `sac peer post-turn`, or another inbound channel).
+
+## Related skills
+
+- [15_claude-session.md](15_claude-session.md) — the runtime overview,
+  canonical apptainer YAML, and operating modes (this leaf is its
+  state/auth/status reference half).
+- [24_image-build.md](24_image-build.md) — building/rebuilding the
+  `sac-base.sif` the runner executes inside.
+- [25_claude-setup-delivery.md](25_claude-setup-delivery.md) — how
+  `to_home/`, settings, MCP, and credentials reach the in-container `$HOME`.
+- [03_auto-accept.md](03_auto-accept.md) — the auto-accept handler set is
+  vestigial for the SDK runner (it has no TUI prompts).
+- [13_observability.md](13_observability.md) — the broader status JSON
+  contract; this leaf describes the SDK-specific addition.

--- a/src/scitex_agent_container/_skills/scitex-agent-container/15_claude-session.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/15_claude-session.md
@@ -122,114 +122,19 @@ so resume id + quota are preserved. See
 format, semantics, ssh-as-transport for remote agents, and the
 `SAC_RUNNER_PREFIX` hook.
 
-## State layout
+## State, auth, status, supervisor
 
-Per-agent state lives at `<scope>/runtime/<name>/`:
-
-| File | Contents |
-|---|---|
-| `pid` | Runner's PID (atomic write — tmp + rename). |
-| `heartbeat.json` | `{ts, pid, state}` plus `elapsed_s` (seconds since session start, from `started_at`) and the running token totals `input_tokens / output_tokens / total_tokens` (from `quota.json`). State ∈ `starting / idle / working / stopping`. Refreshed every 10 s (`--tick-seconds`). |
-| `started_at` | Session start time (unix seconds). Written once at startup; preserved across a resumed respawn so `elapsed_s` tracks the conversation, not the process. |
-| `session.jsonl` | One JSON object per turn event: `user / assistant / user_echo / result / error`. The transcript. |
-| `session_id` | Latest SDK session UUID. Auto-resumed by the next `sac agents start`. |
-| `quota.json` | Accumulated per-turn token totals (input / output / cache_creation / cache_read / turns). |
-
-Scope resolution (highest priority first):
-
-1. **Project-local**: walks up from cwd to a git repo containing
-   `.scitex/agent-container/`. State lands in
-   `<repo>/.scitex/agent-container/runtime/<name>/`.
-2. **Home**: `~/.scitex/agent-container/runtime/<name>/` (when no
-   project scope is available).
-3. Override via `$SCITEX_AGENT_CONTAINER_RUNTIME_DIR` (the runner reads
-   this verbatim — useful for ad-hoc tests).
-
-Symmetric: agent definitions follow the same resolution order
-(`<scope>/agents/<name>/<name>.yaml` first, then
-`~/.scitex/agent-container/agents/`, then env, then fleet dirs).
-
-## Auth (cost-critical)
-
-The SDK's authentication path, by precedence
-(`runtimes/_sdk_common.py::provision_anthropic_auth`):
-
-1. `~/.claude/.credentials.json` exists → SDK reads OAuth token
-   automatically (Pro/Max plan, **flat-rate**). The default on every
-   workstation that has run `claude /login`.
-2. `SAC_ANTHROPIC_API_KEY` (sac-namespaced handoff for headless
-   contexts — CI, SLURM, cron). When set it is mirrored into
-   `ANTHROPIC_API_KEY` for the SDK (an `sk-ant-api*` value is
-   **pay-per-token**, explicit opt-in only).
-
-A bare host `ANTHROPIC_API_KEY` is **never honoured**: the first thing
-`provision_anthropic_auth` does is overwrite it from
-`SAC_ANTHROPIC_API_KEY`, or *pop* it from the env when
-`SAC_ANTHROPIC_API_KEY` is unset — so a stale dotfiles export can't be
-picked up by the SDK auto-reader, shadow a working OAuth credentials
-file, or silently switch you to API-key billing. Set neither input and
-you get a clear `SDKCommonError`.
-
-## Status JSON addition
-
-`sac agents status <name> --json` carries an `sdk_session` field for
-agents on this runtime:
-
-```json
-{
-  "runtime": "apptainer",
-  "sdk_session": {
-    "session_id": "6ef8248f-1ccd-4877-934d-908e15333b52",
-    "quota": {
-      "input_tokens": 6,
-      "output_tokens": 14,
-      "cache_creation_input_tokens": 33003,
-      "cache_read_input_tokens": 0,
-      "turns": 1
-    },
-    "heartbeat": {
-      "ts": 1777766006.95, "pid": 3476972, "state": "idle",
-      "started_at": 1777765800.0, "elapsed_s": 206.95,
-      "input_tokens": 6000, "output_tokens": 1500, "total_tokens": 40503
-    },
-    "state_dir": "/path/to/.scitex/agent-container/runtime/<name>"
-  }
-}
-```
-
-`sdk_session` is populated for `kind: Agent` (SDK runner) and `null` for
-`kind: AgentProxy` (the HTTP forwarder, which has no SDK) — never absent
-— so dashboards can switch on its presence without parsing further.
-
-## In-repo smoke test
-
-`<repo>/.scitex/agent-container/agents/sdk-test/sdk-test.yaml` is a
-checked-in fixture that the project-local discovery picks up
-automatically when `sac` is invoked from inside the repo:
-
-```bash
-cd ~/proj/scitex-agent-container
-sac agents start sdk-test --foreground
-# expected: sdk-runtime-ok
-```
-
-The `sdk-runtime-smoke` GitHub workflow runs this exact command on every
-push to develop / main (and daily) so an upstream SDK breakage surfaces
-immediately rather than during the next manual fleet operation.
-
-## Supervisor — auto-restart on SDK crash
-
-`--max-restarts N` (default `0` = terminate on first failure) + `--restart-backoff-s S` (default `1.0`, doubles per attempt) let the runner reopen `ClaudeSDKClient` after a mid-session exception. On each retry it re-reads `session_id` from the state dir so the new client resumes the latest completed turn; the inbox is preserved across restarts. Each restart writes `{type: error, kind: sdk_runtime, attempt: N}` + `{type: supervisor, event: restarting, in_s: <delay>}` to `session.jsonl`. After `max_restarts` attempts the inbox is drained with the last exception and the runner exits. Init failures (missing SDK, bad options) stay terminal.
-
-## Constraints
-
-- **No human-typed interactive session.** There is no tmux pane to type
-  `/clear`, `/compact`, or paste into. The SDK runner takes one mission
-  prompt at start; subsequent turns arrive via A2A (`POST /v1/turn`,
-  `sac peer post-turn`, or another inbound channel).
+The operational reference — per-agent state-dir layout
+(`pid`/`heartbeat.json`/`session.jsonl`/`session_id`/`quota.json`),
+scope resolution, the cost-critical auth precedence, the `sdk_session`
+status-JSON block, the in-repo smoke test, the auto-restart supervisor,
+and the no-interactive-session constraint — lives in the sibling leaf
+[14_claude-session-state.md](14_claude-session-state.md).
 
 ## Related skills
 
+- [14_claude-session-state.md](14_claude-session-state.md) — state
+  layout, auth, status JSON, supervisor (this overview's reference half).
 - [24_image-build.md](24_image-build.md) — building/rebuilding the
   `sac-base.sif` the runner executes inside.
 - [25_claude-setup-delivery.md](25_claude-setup-delivery.md) — how
@@ -237,4 +142,4 @@ immediately rather than during the next manual fleet operation.
 - [03_auto-accept.md](03_auto-accept.md) — the auto-accept handler set is
   vestigial for the SDK runner (it has no TUI prompts).
 - [13_observability.md](13_observability.md) — the broader status JSON
-  contract; this leaf describes the SDK-specific addition.
+  contract; the state leaf describes the SDK-specific addition.

--- a/src/scitex_agent_container/_skills/scitex-agent-container/15_claude-session.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/15_claude-session.md
@@ -1,53 +1,96 @@
 ---
 description: |
-  [TOPIC] `runtime: claude-session`
-  [DETAILS] SDK-native agent runtime — drives claude-agent-sdk directly instead of running the claude CLI inside tmux. No TUI prompts, no auto-accept, no pane-state classifier. Project-local agent + state discovery so test fixtur....
+  [TOPIC] The claude-session SDK runner (inside apptainer)
+  [DETAILS] sac runs claude-agent-sdk via the claude_session runner INSIDE an apptainer SIF (sac-base.sif + relaxed directory overlay + uv-editable /opt/venv-agent). `runtime: apptainer` is the only operative runtime value; `claude-session` is the name of the in-container runner module, NOT a runtime you select. Covers state layout, auth, turn endpoint, status JSON.
 tags: [scitex-agent-container-claude-session, claude-session, sdk]
 ---
 
-# `runtime: claude-session`
+# The claude-session SDK runner (inside apptainer)
 
-The SDK-native counterpart to the legacy `claude-code` runtime. Where
-`claude-code` spawns the `claude` CLI inside tmux/screen and screen-scrapes
-the TUI, `claude-session` drives `claude-agent-sdk` from a Python runner —
-no terminal multiplexer, no auto-accept handlers, no permission prompts.
+`claude-session` is the **name of the in-container SDK runner module**
+(`scitex_agent_container._runners.claude_session`), driven by
+`claude-agent-sdk`. It is **not** a runtime you select in YAML.
 
-Same lifecycle CLI surface (`sac agents start`, `sac agents stop`, `sac agents status`,
-`sac agents tail`); flip a single YAML key.
+sac is **apptainer-only** (since 2026-05-13 — docker/podman ripped out).
+`runtime: apptainer` is the only value the validator accepts
+(`config/_validation.py` rejects everything else). When `sac agents start`
+runs an agent, `ClaudeSessionRuntime` delegates to
+`ApptainerContainerRuntime`, which `apptainer exec`s the runner **inside
+the SIF** — "The host side never spawns a Python subprocess; every
+`start` goes through `apptainer exec`" (`runtimes/claude_session.py`).
 
-## Why use it
+The canonical container shape (see [24_image-build.md](24_image-build.md)
+and [25_claude-setup-delivery.md](25_claude-setup-delivery.md)):
 
-| Concern | `claude-code` | `claude-session` |
-|---|---|---|
-| Process | `claude` binary in tmux | Python runner (no multiplexer) |
-| TUI prompts | auto-accept via `tmux send-keys` | `permission_mode='bypassPermissions'` |
-| Hooks | shell out to `sac record-hook-event` | Python async callbacks |
-| Resume | `claude --resume <uuid>` | `ClaudeAgentOptions(resume=...)` (auto-loaded from `state_dir/session_id`) |
-| Quota | poll `claude usage` daemon | accumulated from per-turn `usage` blocks in the SDK message stream |
-| Auth | env / `~/.claude/.credentials.json` | env / `~/.claude/.credentials.json` (same — flat-rate OAuth by default) |
-| Human attach | `tmux attach` | `--foreground` / `sac agents tail` |
+- **SIF**: `sac-base.sif` (OS + dev tools + uv + node). There is no
+  separate `sac-scitex.sif`.
+- **Overlay**: a relaxed directory overlay (`--overlay <dir>/`, NOT an
+  `.img`) holds the writable upper layer that persists across restarts.
+- **Code**: a uv-editable venv at `/opt/venv-agent`, bootstrapped once via
+  `uv pip install -e ".[all]"` from the repo mounted at `/work`, persisted
+  in the overlay. The package code the agent runs comes from this editable
+  venv, not from a pre-baked SIF layer.
 
-## Minimal YAML
+The SDK runner does not use a terminal multiplexer (no tmux/screen, no
+pane scraping, no auto-accept) — but it still runs **inside the
+container**, not as a bare host process. The `spec.multiplexer` field is
+vestigial for agents (see [02_multiplexer.md](02_multiplexer.md)).
+
+Same lifecycle CLI surface across every agent (`sac agents start`,
+`sac agents stop`, `sac agents status`, `sac agents tail`).
+
+## What the SDK runner gives you
+
+| Concern | Behaviour |
+|---|---|
+| Process | `claude_session` runner inside `apptainer exec` (no multiplexer) |
+| TUI prompts | none — `permission_mode='bypassPermissions'` (no auto-accept needed) |
+| Hooks | Python async callbacks (`_runners/_session_hooks.py`) |
+| Resume | `ClaudeAgentOptions(resume=...)` auto-loaded from `state_dir/session_id` |
+| Quota | accumulated from per-turn `usage` blocks in the SDK message stream |
+| Auth | `~/.claude/.credentials.json` OAuth (flat-rate) or `SAC_ANTHROPIC_API_KEY` — see below |
+| Human attach | `--foreground` / `sac agents tail` |
+
+## Minimal YAML (canonical apptainer pattern)
 
 ```yaml
 apiVersion: scitex-agent-container/v3
 kind: Agent
 
 metadata:
-  labels: { pattern: claude-session }
+  labels: { project: my-project }
 
 spec:
-  runtime: claude-session
-  model: claude-haiku-4-5
-  workdir: /tmp/my-agent
+  runtime: apptainer
+  workdir: /home/me/proj/my-project
+
+  apptainer:
+    image: /home/me/.scitex/agent-container/containers/sac-base.sif
+    relaxed: true
+    raw_args:
+      - --userns
+      - --containall
+      - --home
+      - /home/agent
+      - --overlay
+      - /home/me/.scitex/agent-container/containers/overlays/my-agent/
+
+  claude:
+    model: claude-haiku-4-5
 
   startup_commands:
-    - command: "Reply with the string 'hello' and nothing else."
+    # Idempotent venv bootstrap — only builds if missing (overlay persists it
+    # across restarts), so boots don't re-run a full install every time.
+    - command: '[ -x /opt/venv-agent/bin/python ] || { cd /work && uv venv /opt/venv-agent --python python3 && uv pip install --python /opt/venv-agent/bin/python -e ".[all]"; }'
+
+  startup_prompts:
+    - "Reply with the string 'hello' and nothing else."
 ```
 
-The first non-empty `startup_commands[*].command` is the SDK mission
-(seed prompt). `delay` is ignored — the SDK takes a one-shot prompt,
-not a timed sequence.
+`startup_commands` are SHELL commands run inside the container **before**
+the SDK starts (e.g. the `/opt/venv-agent` bootstrap above).
+`startup_prompts` carry the claude mission text. `delay` is ignored — the
+SDK takes a one-shot prompt, not a timed sequence.
 
 ## Operating modes
 
@@ -134,7 +177,7 @@ agents on this runtime:
 
 ```json
 {
-  "runtime": "claude-session",
+  "runtime": "apptainer",
   "sdk_session": {
     "session_id": "6ef8248f-1ccd-4877-934d-908e15333b52",
     "quota": {
@@ -154,9 +197,9 @@ agents on this runtime:
 }
 ```
 
-`sdk_session` is `null` for non-SDK agents (claude-code etc.) — never
-absent — so dashboards can switch on its presence without checking
-`runtime`.
+`sdk_session` is populated for `kind: Agent` (SDK runner) and `null` for
+`kind: AgentProxy` (the HTTP forwarder, which has no SDK) — never absent
+— so dashboards can switch on its presence without parsing further.
 
 ## In-repo smoke test
 
@@ -178,18 +221,20 @@ immediately rather than during the next manual fleet operation.
 
 `--max-restarts N` (default `0` = terminate on first failure) + `--restart-backoff-s S` (default `1.0`, doubles per attempt) let the runner reopen `ClaudeSDKClient` after a mid-session exception. On each retry it re-reads `session_id` from the state dir so the new client resumes the latest completed turn; the inbox is preserved across restarts. Each restart writes `{type: error, kind: sdk_runtime, attempt: N}` + `{type: supervisor, event: restarting, in_s: <delay>}` to `session.jsonl`. After `max_restarts` attempts the inbox is drained with the last exception and the runner exits. Init failures (missing SDK, bad options) stay terminal.
 
-## When NOT to use it
+## Constraints
 
-- **Human-typed interactive sessions.** The CLI runtime's tmux session
-  lets you type `/clear`, `/compact`, paste, etc. The SDK runtime takes
-  one prompt at start time; future turns require A2A or a different
-  inbound channel.
-- **Existing fleet agents under heavy load.** Migrate one at a time,
-  watch for a release cycle before flipping the next.
+- **No human-typed interactive session.** There is no tmux pane to type
+  `/clear`, `/compact`, or paste into. The SDK runner takes one mission
+  prompt at start; subsequent turns arrive via A2A (`POST /v1/turn`,
+  `sac peer post-turn`, or another inbound channel).
 
 ## Related skills
 
-- [03_auto-accept.md](03_auto-accept.md) — only relevant under the CLI
-  runtime; the SDK runtime makes auto-accept obsolete.
+- [24_image-build.md](24_image-build.md) — building/rebuilding the
+  `sac-base.sif` the runner executes inside.
+- [25_claude-setup-delivery.md](25_claude-setup-delivery.md) — how
+  `to_home/`, settings, MCP, and credentials reach the in-container `$HOME`.
+- [03_auto-accept.md](03_auto-accept.md) — the auto-accept handler set is
+  vestigial for the SDK runner (it has no TUI prompts).
 - [13_observability.md](13_observability.md) — the broader status JSON
   contract; this leaf describes the SDK-specific addition.

--- a/src/scitex_agent_container/_skills/scitex-agent-container/16_claude-session-migration.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/16_claude-session-migration.md
@@ -1,187 +1,69 @@
 ---
 description: |
-  [TOPIC] Migrating an existing agent to `runtime: claude-session`
-  [DETAILS] Step-by-step recipe for migrating an existing claude-code agent (CLI runtime, tmux) to claude-session (SDK runtime, no tmux). Includes a parity-check phase, a controlled cutover with the original kept alongside as fal....
+  [TOPIC] claude-session migration — historical (complete)
+  [DETAILS] The CLI/TUI (`claude-code`) → SDK (`claude-session`) migration is DONE and the host-side runtime choice no longer exists. sac is apptainer-only: `runtime: apptainer` is the sole accepted value and the SDK runner runs inside the SIF. There is no `runtime: claude-code` to migrate FROM and no YAML key to flip. This leaf is retained only to explain why old specs that set `runtime: claude-session`/`claude-code` are rejected.
 tags: [scitex-agent-container-claude-session-migration, claude-session, migration, fleet]
 ---
 
-# Migrating an existing agent to `runtime: claude-session`
+# claude-session migration — historical (complete)
 
-Single YAML key edit, but the safe flow has four phases: parity-check
-→ side-by-side → cutover → soak. See
-[15_claude-session.md](15_claude-session.md) for the runtime itself.
+The migration this leaf used to describe — flipping
+`runtime: claude-code` → `runtime: claude-session` per agent — is **done
+and the runtime-choice no longer exists**. Do not look for a YAML key to
+flip.
 
-## When NOT to migrate
+## Current reality (verify in `config/_validation.py`)
 
-- Agent depends on **interactive** typing into tmux (`/clear`,
-  `/compact`, paste). SDK takes one mission prompt at start.
-- MCP servers started by hand inside tmux (not in `spec.mcp_servers`).
-  The SDK only wires what's in the YAML.
-- Heavy load, can't tolerate a 10-second cutover gap.
+- sac is **apptainer-only** since 2026-05-13. `config/_validation.py`
+  accepts only `runtime: apptainer` (empty/unset defaults to apptainer);
+  any other value — including `claude-code` and `claude-session` — is a
+  hard validation error.
+- The SDK runner (`scitex_agent_container._runners.claude_session`) is
+  **not a runtime you select**. It is the in-container runner module that
+  `ApptainerContainerRuntime` `apptainer exec`s inside the SIF for every
+  `kind: Agent`. See [15_claude-session.md](15_claude-session.md).
+- The legacy `claude-code` CLI/TUI runtime (the `claude` binary inside
+  tmux/screen with auto-accept + pane scraping) and the host-side
+  bare-Python runner were **removed**:
+  - docker/podman ripout — 2026-05-13 (`runtimes/__init__.py`,
+    `runtimes/claude_session.py`).
+  - bare-metal subprocess + SSH-dispatch (`spec.remote`) ripout — WI-6,
+    2026-05-20 (`config/_types.py`: `RemoteSpec` deleted; validator
+    rejects `spec.remote`).
 
-## Phase 1 — parity check (no production touch)
+## If you hit `spec.runtime must be 'apptainer'`
 
-Prove the SDK can produce something sensible before flipping anything.
+An old spec set `runtime: claude-code` or `runtime: claude-session`.
+Update it to the canonical apptainer shape (full template in
+[15_claude-session.md](15_claude-session.md)):
 
-1. Copy the existing YAML to a sandbox name and switch the runtime:
-
-   ```bash
-   AGENT=head-ywata-note-win
-   SANDBOX=${AGENT}-sdk
-   cp ~/.scitex/agent-container/agents/$AGENT/$AGENT.yaml /tmp/$SANDBOX.yaml
-   sed -i "s/runtime: claude-code/runtime: claude-session/" /tmp/$SANDBOX.yaml
-   sed -i "s/^metadata:/metadata:\n  labels:\n    sandbox-of: $AGENT/" /tmp/$SANDBOX.yaml
-   # Make sure the workdir doesn't collide with the live agent.
-   sed -i "s|workdir:.*|workdir: /tmp/$SANDBOX-workspace|" /tmp/$SANDBOX.yaml
-   ```
-
-2. Run **one SDK turn** in foreground and inspect the response:
-
-   ```bash
-   sac agents start /tmp/$SANDBOX.yaml --foreground
-   ```
-
-   Pass criteria:
-   - The runner prints assistant text to stdout (not just an `[error]`
-     line).
-   - The closing `[result]` reports a non-zero `output_tokens` and a
-     `session_id`.
-   - If the original agent uses MCP, ask the SDK turn to invoke one
-     of those tools — the assistant should call it (visible in
-     `~/.scitex/agent-container/runtime/$SANDBOX/session.jsonl` as
-     a `pretool` event in `event_log`).
-
-3. If parity fails, capture the transcript and abort:
-
-   ```bash
-   cat ~/.scitex/agent-container/runtime/$SANDBOX/session.jsonl
-   sac agents stop $SANDBOX  # if daemon-mode left anything around
-   ```
-
-   Common causes: missing MCP server in YAML, tool the agent expects
-   isn't actually available without the tmux session env, or the
-   mission relies on bash heredoc state the SDK doesn't have.
-
-## Phase 2 — side-by-side soak (8–24 h)
-
-Goal: run the SDK version *alongside* the live one and compare.
-
-1. Don't replace the live YAML. Drop the sandbox YAML into the
-   discovery path under a `-sdk` suffix:
-
-   ```bash
-   mkdir -p ~/.scitex/agent-container/agents/$SANDBOX
-   cp /tmp/$SANDBOX.yaml ~/.scitex/agent-container/agents/$SANDBOX/$SANDBOX.yaml
-   sac agents start $SANDBOX
-   ```
-
-2. Compare quota + event_log between the two over the same wall-clock
-   window (`sac agents status $AGENT --json` legacy vs `--json | jq
-   .sdk_session.quota` SDK; `sac agents status ... | jq .event_log` for
-   hook-firing rate). A 10× divergence in either direction is a red
-   flag — stop the sandbox and investigate before cutover.
-
-## Phase 3 — controlled cutover
-
-Goal: flip the live YAML, keep the legacy one stoppable as fallback.
-
-1. Snapshot the live agent's session id so you can resume into the
-   SDK side:
-
-   ```bash
-   LIVE_SID=$(sac agents status $AGENT --json | jq -r .session_id)
-   echo "live session id: $LIVE_SID"
-   ```
-
-   (For `claude-session` agents the SDK runner already persists the
-   id to `state_dir/session_id` and the next `sac agents start` auto-resumes
-   — but we don't have that for the legacy CLI runtime. The session
-   carries over via Claude Code's own
-   `~/.claude/projects/<encoded>/<uuid>.jsonl` file, which the SDK
-   resume= path also reads.)
-
-2. Stop the live agent, edit its YAML in place, start it back up:
-
-   ```bash
-   sac agents stop $AGENT
-   YAML=~/.scitex/agent-container/agents/$AGENT/$AGENT.yaml
-   cp $YAML $YAML.bak
-   sed -i "s/runtime: claude-code/runtime: claude-session/" $YAML
-   # Drop the multiplexer line — claude-session has no terminal:
-   sed -i "/^[[:space:]]*multiplexer:/d" $YAML
-   # The existing spec.a2a.port (e.g. 19108 on handyman-sonnet) is
-   # automatically reused by the runner's in-process /v1/turn endpoint.
-   # No sidecar needed.
-   # If you captured a session id and want to seed it (otherwise
-   # sac auto-discovers from state_dir/session_id on the next run):
-   if [ -n "$LIVE_SID" ]; then
-       mkdir -p ~/.scitex/agent-container/runtime/$AGENT
-       echo "$LIVE_SID" > ~/.scitex/agent-container/runtime/$AGENT/session_id
-   fi
-   sac agents start $AGENT
-   ```
-
-3. Verify the runtime swap landed and the agent answered the mission:
-
-   ```bash
-   sac agents status $AGENT --json | jq '.runtime, .sdk_session.heartbeat.state'
-   sac agents tail $AGENT
-   ```
-
-4. Stop the parallel sandbox now that the live agent is on SDK:
-
-   ```bash
-   sac agents stop $SANDBOX
-   rm -rf ~/.scitex/agent-container/agents/$SANDBOX
-   ```
-
-## Phase 4 — soak window (one release cycle)
-
-Don't drop the legacy backup yet. Keep `~/.scitex/agent-container/agents/$AGENT/$AGENT.yaml.bak`
-in place for at least one minor-version cycle. Watch:
-
-- `sac agents status $AGENT --json` heartbeat state stays in
-  `idle / working` (not stuck in `starting` or `stopping`).
-- `event_log.summarize($AGENT)` still produces sensible counts.
-- Quota burn rate (`sdk_session.quota.turns`) tracks workload
-  reasonably — not 10x the pre-migration rate.
-
-## Rollback
-
-```bash
-sac agents stop $AGENT
-mv ~/.scitex/agent-container/agents/$AGENT/$AGENT.yaml.bak \
-   ~/.scitex/agent-container/agents/$AGENT/$AGENT.yaml
-sac agents start $AGENT
-sac agents status $AGENT --json | jq .runtime  # back to claude-code
+```yaml
+spec:
+  runtime: apptainer
+  apptainer:
+    image: /home/me/.scitex/agent-container/containers/sac-base.sif
+    relaxed: true
+    raw_args: [--userns, --containall, --home, /home/agent,
+               --overlay, /home/me/.scitex/agent-container/containers/overlays/<name>/]
+  claude:
+    model: claude-opus-4-7[1m]
+  startup_commands:
+    - command: '[ -x /opt/venv-agent/bin/python ] || { cd /work && uv venv /opt/venv-agent --python python3 && uv pip install --python /opt/venv-agent/bin/python -e ".[all]"; }'
 ```
 
-The SDK runtime never deletes the legacy CLI's
-`~/.claude/projects/<encoded>/*.jsonl` files, so resume continuity
-across rollback works the other way too.
+Drop any `multiplexer:` line (vestigial — [02_multiplexer.md](02_multiplexer.md))
+and any `spec.remote:` block (deleted — use `spec.host` / `sac --on <peer>`
+for cross-host placement).
 
-## Order of fleet rollout
+## Cross-host placement (replaces the old per-agent rollout)
 
-Per-agent — no flag day. Migrate in escalating-blast-radius order;
-soak each one for at least one release cycle before the next.
-**Pre-flight (2026-05-03):** SDK runtime smoke-tested end-to-end on
-WSL + mba (macOS arm64) + nas (Linux x86_64) + spartan-bm198 (RHEL9
-HPC compute). All passed; auth via `~/.claude/.credentials.json`
-OAuth on every host.
+The old "migrate fleet agents one at a time, flip the runtime key" flow is
+obsolete. Cross-host work now goes through `spec.host` pinning and
+`sac --on <peer>` dispatch (F-CS12), not a runtime swap. See
+[11_remote-deploy.md](11_remote-deploy.md).
 
-1. `handyman-haiku` / `handyman-sonnet` (local pool members; lowest blast radius)
-2. `head-ywata-note-win` (local head; SSH fallback)
-3. `telegrammer-ywata-note-win` (single inbound channel; reuses existing `a2a.port`)
-4. `head-mba` / `head-nas` (remote, one at a time)
-5. `head-spartan` (SLURM-tenant; most moving parts — last; remember `module load OpenSSL/1.1` + unset stale `SAC_ANTHROPIC_API_KEY` on compute nodes)
+## Related skills
 
-## Audit checklist (run before declaring "migrated")
-
-- `.runtime == "claude-session"` and `sdk_session.heartbeat.state` in
-  `{idle, working}`
-- `sdk_session.quota.turns` increments over a 1 h window
-- `event_log.summarize($AGENT).hook_event_counts` shows
-  `pretool / posttool / prompt / stop` (Python hooks bridged)
-- `sac agents tail $AGENT` renders recent assistant turns
-- `$AGENT.yaml.bak` still in place for rollback
-- `restart`, `health`, `a2a`, `orochi` blocks carried over verbatim
+- [15_claude-session.md](15_claude-session.md) — the SDK runner inside apptainer.
+- [24_image-build.md](24_image-build.md) — building the `sac-base.sif`.
+- [01_config-v3.md](01_config-v3.md) — v3 config format.

--- a/src/scitex_agent_container/_skills/scitex-agent-container/17_inbound-turn-endpoint.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/17_inbound-turn-endpoint.md
@@ -1,31 +1,44 @@
 ---
 description: |
   [TOPIC] Inbound-turn HTTP endpoint (`POST /v1/turn`)
-  [DETAILS] Reference for the in-runner HTTP inbound-turn endpoint served by the claude-session runtime when ``spec.a2a.port`` is declared. Wire format, semantics, curl examples, and how it differs from the legacy A2A sidecar..
+  [DETAILS] Reference for the in-runner HTTP inbound-turn endpoint served by the in-container claude-session SDK runner when ``spec.a2a.port`` is declared. Wire format, semantics, curl examples, and how it differs from the legacy A2A sidecar. Runs inside the apptainer SIF — `runtime: apptainer` is the operative runtime.
 tags: [scitex-agent-container-inbound-turn-endpoint, claude-session, a2a, inbound]
 ---
 
 # Inbound-turn HTTP endpoint (`POST /v1/turn`)
 
-Long-living `runtime: claude-session` agents accept new turns over HTTP. The endpoint is **colocated with the SDK conversation** (no sidecar process) so each turn lands on the same persistent `ClaudeSDKClient` — the resume id, accumulated quota, and tool history are preserved across turns.
+Long-living agents accept new turns over HTTP. The endpoint is
+**colocated with the SDK conversation** (no separate sidecar process) so
+each turn lands on the same persistent `ClaudeSDKClient` — the resume id,
+accumulated quota, and tool history are preserved across turns.
 
-Lives in `_runners/_session_http.py`; spawned by `_runners/claude_session.py::run` when the runner argv has `--a2a-port N` (the runtime adapter sets that from `spec.a2a.port`).
+The endpoint lives in `_runners/_session_http.py`, spawned by the SDK
+runner (`_runners/claude_session.py::run`) when its argv carries
+`--a2a-port N`. The runner — and therefore this HTTP server — runs
+**inside the apptainer container** (`apptainer exec`); the runtime adapter
+sets `--a2a-port` from `spec.a2a.port`. See
+[15_claude-session.md](15_claude-session.md) for the container shape.
 
 ## YAML
 
+`runtime: apptainer` is the only accepted runtime (sac is apptainer-only;
+the SDK runner is invoked inside the SIF). Enable the endpoint with
+`spec.a2a.port`:
+
 ```yaml
 spec:
-  runtime: claude-session
+  runtime: apptainer
+  apptainer:
+    image: /home/me/.scitex/agent-container/containers/sac-base.sif
+    relaxed: true
   a2a:
-    port: 18888         # required to enable the endpoint
+    port: 18888         # int, or "auto" (default) — set to enable inbound HTTP
     host: 127.0.0.1     # default; set to 0.0.0.0 for LAN exposure
 ```
 
-Existing `claude-code` agents that already have an `a2a.port` (e.g.
-handyman-sonnet at 19108) keep the same port — when you flip
-`runtime: claude-code` → `claude-session`, the runner's HTTP server
-binds the same port the sidecar used to. Telegram bridge / orochi
-clients keep working unchanged.
+`port: auto` (the default) lets sac allocate; clients then reach the agent
+through `sac listen` (one host port, name-in-path) rather than the
+per-agent port directly. Pin an int to bind a fixed port.
 
 ## Wire format
 
@@ -55,11 +68,16 @@ curl -s http://127.0.0.1:18888/health
 
 ## How it differs from the legacy A2A sidecar
 
-| Aspect | Legacy sidecar (`runtime: claude-code`) | In-runner (`runtime: claude-session`) |
+The in-runner endpoint replaced the standalone A2A sidecar that the old
+CLI/TUI runtime used. For SDK agents (`kind: Agent`) the runner hosts
+`/v1/turn` itself; the `sac a2a serve` sidecar path is retained only for
+non-SDK runtimes (see [07_a2a-protocol.md](07_a2a-protocol.md)).
+
+| Aspect | Legacy `sac a2a serve` sidecar | In-runner (current) |
 |---|---|---|
-| Process | Separate `sac a2a serve` process | Asyncio task inside the runner |
+| Process | Separate `sac a2a serve` process | Asyncio task inside the SDK runner (in-container) |
 | Per-request transport | New `query()` per request — fresh conversation each time | `client.query()` on the persistent SDK client — turns share context |
-| Wire | A2A JSON-RPC `message/send` | Plain `{text, exit_after}` (PR4 will add JSON-RPC compat) |
+| Wire | A2A JSON-RPC `message/send` | Plain `{text, exit_after}` |
 | Concurrency | Each request spawns its own SDK call | Serial drain — turns queue |
 | Resume | None (each request is stateless) | Full — session_id persists across runs |
 
@@ -74,50 +92,39 @@ The runner's argv `--a2a-port`/`--a2a-host` is set automatically by `runtimes/cl
 - `src/scitex_agent_container/_runners/claude_session.py::_run_conversation` — drains the inbox into the persistent `ClaudeSDKClient`
 - `tests/scitex_agent_container/_runners/test__session_http.py` — round-trip + 400 + health smoke tests
 
-## Remote launch via `_remote_launch.render_remote_launch`
+## Cross-host placement
 
-For running the SDK runner on a remote host, sac provides a generic bash-script generator that sources a per-host hook before exec. The package stays generic; per-host quirks (Spartan module loads, NAS PATH overrides, etc.) live in private `~/.scitex/agent-container/hosts/$(hostname).sh` on the remote.
+The old host-side bare-Python launch (a `render_remote_launch` bash-script
+generator + `SAC_RUNNER_PREFIX` wrapper, exec'd over ssh) was **removed**
+with the bare-metal/SSH-dispatch ripout (WI-6, 2026-05-20). The runner
+only ever launches via `apptainer exec` now; there is no host-side
+`python -m ... claude_session` path.
+
+> Note: `_runners/_remote_launch.render_remote_launch` still exists as a
+> module with a unit test, but it is **not wired into any live launch
+> path** (no importers in `src/` outside its own test). Treat it as dead
+> code, not as the way agents start on remote hosts.
+
+Cross-host work goes through two mechanisms:
+
+- **`spec.host`** — pin an agent to a host (or a priority list). See
+  [11_remote-deploy.md](11_remote-deploy.md).
+- **`sac --on <peer>`** (F-CS12) — dispatch a `sac` command on a peer
+  defined in `config.yaml`'s `peers:` block.
+
+### Reaching a remote agent's `/v1/turn` — ssh-as-transport
+
+The runner binds `/v1/turn` on `127.0.0.1` inside its container — never on
+a LAN interface. A peer reaches a remote agent through ssh, resolved
+automatically by the peer helper:
 
 ```python
-from scitex_agent_container._runners._remote_launch import render_remote_launch
-
-script = render_remote_launch(
-    runner_argv=["python", "-m", "scitex_agent_container._runners.claude_session",
-                 "--name", "my-agent", "--a2a-port", "18888"],
-    agent_name="my-agent",
-    state_root="/tmp/runtime",
-    detach=True,  # setsid + nohup; emits the runner PID on stdout
-)
-# Pipe over ssh:
-#   ssh -o BatchMode=yes <host> 'bash -l -s' <<< "$script"
-# The login shell ensures Lmod / pyenv / venv-PATH from .bashrc is loaded
-# *before* the per-host hook runs.
+from scitex_agent_container.peer import post_turn
+reply = post_turn("head-mba", "your message")
+# resolves to ssh://mba:18888/v1/turn → ssh + curl on the remote loopback
 ```
 
-The script:
-
-1. (if `state_root` given) `export SCITEX_AGENT_CONTAINER_RUNTIME_DIR=...`
-2. Source `~/.scitex/agent-container/hosts/$(hostname).sh` if it exists (silent skip otherwise)
-3. exec the runner (foreground) or `setsid nohup ... &` (detached) with output redirected to `runner.log`
-
-**Always invoke remote with `bash -l -s` (login shell)** so the user's `.bashrc` loads (Lmod, venv PATH, etc.) before the hook runs. Tested 2026-05-03 on `spartan-bm198`: hook does `module load GCCcore/11.3.0 OpenSSL/1.1; unset SAC_ANTHROPIC_API_KEY` → SDK runner round-trips a turn against the OAuth in `~/.claude/.credentials.json`.
-
-### `SAC_RUNNER_PREFIX` — generic launcher hook
-
-The launch script honors `${SAC_RUNNER_PREFIX:-}` immediately before the runner argv. Per-host hooks can set this to wrap the runner with **anything**:
-
-```bash
-# ~/.scitex/agent-container/hosts/spartan-bm198.hpc.unimelb.edu.au.sh
-# Spartan: re-exec the runner inside an existing SLURM allocation
-module load GCCcore/11.3.0 OpenSSL/1.1 slurm/default
-unset SAC_ANTHROPIC_API_KEY
-if [ -z "$SLURM_JOB_ID" ]; then
-    JOBID=$(squeue --me -h -n head-spartan -o "%i" | head -1)
-    [ -n "$JOBID" ] && export SAC_RUNNER_PREFIX="srun --jobid=$JOBID --overlap"
-fi
-
-# OR: for an apptainer-pinned runner version (any host)
-# export SAC_RUNNER_PREFIX="apptainer exec --bind $HOME/proj:$HOME/proj \"$HOME/scitex-images/sac-0.13.sif\""
-```
-
-This keeps SLURM, apptainer, container-runtime, conda-env-activation, etc. as **user-side concerns** — sac stays generic. The package ships a single env-var honor; users compose their own dispatch. Live-verified 2026-05-03 against `spartan-bm198`: same `sac agents start` command works on plain ssh hosts and Spartan compute nodes simultaneously.
+This works for ssh aliases that aren't DNS-resolvable from the caller
+(e.g. `mba`, `head-spartan`) and survives NAT, while keeping the endpoint
+loopback-only. See [06_http-api.md](06_http-api.md) and
+[07_a2a-protocol.md](07_a2a-protocol.md).

--- a/src/scitex_agent_container/_skills/scitex-agent-container/18_full-agent-delegation.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/18_full-agent-delegation.md
@@ -46,7 +46,7 @@ metadata:
   labels: { project: <my-project>, purpose: <one-line> }
 
 spec:
-  runtime: claude-session         # SDK-native, no tmux pane scraping
+  runtime: apptainer              # the only accepted runtime (sac is apptainer-only)
   model: sonnet                   # alias for the latest Sonnet (4.6+)
   workdir: /absolute/path/to/repo
   # WARNING (F-CS8): NEVER point workdir at an umbrella directory
@@ -126,29 +126,20 @@ sac agents stop <name>
 sac agents restart <name>
 ```
 
-## Why `runtime: claude-session` (default)
+## How the agent runs — `runtime: apptainer`
 
-| Runtime | Drives | How |
-|---|---|---|
-| `claude-session` (default) | `claude-agent-sdk` Python library | direct, no multiplexer, structured tool events |
-| `claude-cli-tui` (formerly `claude-code`) | the `claude` CLI binary | tmux/screen pane, send-keys + screen-scrape (TUI mode) |
+sac is **apptainer-only** (since 2026-05-13). `runtime: apptainer` is the
+only accepted value (`config/_validation.py` rejects everything else) —
+there is no runtime to choose between. The agent runs the
+`claude-agent-sdk` runner (`scitex_agent_container._runners.claude_session`)
+**inside** an apptainer SIF (`sac-base.sif` + relaxed directory overlay +
+uv-editable `/opt/venv-agent`), invoked via `apptainer exec`. No terminal
+multiplexer, no auto-accept, no pane scraping — but still in-container,
+not a bare host process. The legacy CLI/TUI (`claude-code`) and host-side
+bare-Python runtimes were removed.
 
-`claude-session` is the default — lower latency, no auto-accept hacks,
-no pane scraping, programmatic tool events. Most new agents should use
-it.
-
-`claude-cli-tui` is **intentionally retained** as a stability fallback
-while `claude-session` matures: when the SDK runtime is unavailable,
-broken, or feature-incomplete on a given host, `claude-cli-tui` provides
-a known-good path through the same Anthropic CLI a human would run
-interactively. The orthogonal `spec.multiplexer: tmux|screen` field
-chooses *which* multiplexer to use under it.
-
-The name `claude-code` (legacy alias) will continue to be accepted but
-new agents should write `claude-cli-tui` to make the implementation
-mechanism explicit.
-
-See [15_claude-session.md](15_claude-session.md) for the runtime details.
+See [15_claude-session.md](15_claude-session.md) for the runner and
+container shape, and [24_image-build.md](24_image-build.md) for the SIF.
 
 ## Model selection — `sonnet` vs `opus`
 

--- a/src/scitex_agent_container/_skills/scitex-agent-container/19_full-agent-troubleshooting.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/19_full-agent-troubleshooting.md
@@ -60,13 +60,10 @@ push channel.
 | **hard** | `spec.skills.required: [foo]` | `@<absolute-path>` line so the SDK inlines content at session start | invariants the agent must apply (procedure, validity gate, security rule) |
 | **soft** | `spec.skills.available: [foo]` | name + path under `## Available Skills` (no `@-import`) | references / examples / optional patterns |
 
-Caveat (resolved 2026-05-05): `runtime: claude-session` previously
-ignored both modes. F-CS1 (commit `2483f6f` on
-`feat/f-cs1-claude-session-skills`) extends `claude-session` to honour
-both uniformly via the existing `setup_claude_md` /
-`build_skills_lines` helpers. Until merged to develop, include the
-absolute path to any required skill in the mission text as a safety
-net.
+Both modes are honoured by the SDK runner uniformly (F-CS1, via
+`setup_claude_md` / `build_skills_lines`). The skills are materialised
+into the agent's in-container `$HOME/.claude/` so the SDK auto-discovers
+them at session start (see [25_claude-setup-delivery.md](25_claude-setup-delivery.md)).
 
 ## Reaper pattern (when delegating multiple agents)
 

--- a/src/scitex_agent_container/_skills/scitex-agent-container/SKILL.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: scitex-agent-container
 description: |
-  [WHAT] Declarative YAML-based AI agent lifecycle management — define an agent in one `spec.yaml` (apptainer image, model, MCP, mounts/env, health, restart, A2A port, remote host) and `sac agents start` brings it up as a long-lived Claude SDK session inside Apptainer, with A2A inbound (`POST /v1/turn`), SSH remote deployment, and JSON status introspection.
-  [WHEN] Use when the user asks to "launch a Claude Code agent", "spawn a fleet of coding agents", "manage agent lifecycle", "run an agent on a remote host", "wire MCP servers into an agent", "talk to a running agent over A2A", or mentions `sac agents start`, `scitex-agent-container`, `spec.yaml`, fleet head/worker.
-  [HOW] `pip install scitex-agent-container` then `sac agents start <name>` (CLI) or `import scitex_agent_container`; see leaf skills for details.
+  [WHAT] Declarative YAML AI-agent lifecycle — define an agent in one `spec.yaml` (apptainer image, model, MCP, mounts/env, health, restart, A2A port, remote host); `sac agents start` runs it as a long-lived Claude SDK session inside Apptainer, with A2A inbound (`POST /v1/turn`), SSH remote deploy, and JSON status.
+  [WHEN] Launching/managing a Claude Code agent or fleet, running an agent on a remote host, wiring MCP into an agent, talking to one over A2A, or any mention of `sac agents start`, `scitex-agent-container`, `spec.yaml`, fleet head/worker.
+  [HOW] `pip install scitex-agent-container` then `sac agents start <name>` (CLI) or `import scitex_agent_container`.
 tags: [scitex-agent-container]
 primary_interface: cli
 interfaces:
@@ -18,17 +18,16 @@ interfaces:
 
 > **Interfaces:** Python ⭐⭐ · CLI ⭐⭐⭐ (primary) · MCP ⭐ · Skills ⭐⭐ · Hook — · HTTP —
 
-Declarative lifecycle management for AI coding agents (Claude Code).
-Define an agent in `spec.yaml`, launch it as a long-lived Claude SDK
-session inside Apptainer — locally or on a remote host via SSH — and
-observe it through a rich non-agentic status surface (`sac agents
-list`/`tail`/`health`).
+Declarative lifecycle management for AI coding agents (Claude Code):
+define an agent in `spec.yaml`, launch it as a long-lived Claude SDK
+session inside Apptainer (local or remote via SSH), and observe it
+through `sac agents list`/`tail`/`health`.
 
 ## What the package ships
 
 | Surface | Location |
 |---|---|
-| Python API | `scitex_agent_container` (`AgentConfig`, `load_config`, `validate_config`, `Registry`, + namespaced submodules `agent.start`/`stop`/`status`/`logs`, `db.*`, `host.*`, `peer.*`) |
+| Python API | `scitex_agent_container` (`AgentConfig`, `load_config`, `validate_config`, `Registry`; submodules `agent.*`, `db.*`, `host.*`, `peer.*`) |
 | CLI | `scitex-agent-container`, `sac` — see [10_cli.md](10_cli.md) |
 | MCP servers | None bundled — agents spawn their own via `to_home/.mcp.json` |
 | Runtimes | `runtimes/claude_session.py` (SDK-native, default); apptainer container build helpers |
@@ -55,6 +54,7 @@ list`/`tail`/`health`).
 - [07_a2a-protocol.md](07_a2a-protocol.md) — Native A2A protocol (`sac a2a serve`)
 - [07_a2a-protocol-extension-fields.md](07_a2a-protocol-extension-fields.md) — `x-scitex-agent-container.*` AgentCard extension fields + JSON example
 - [08_templates.md](08_templates.md) — Six pattern templates + real-world examples
+- [14_claude-session-state.md](14_claude-session-state.md) — claude-session runner reference: state-dir layout, auth precedence, `sdk_session` status JSON, supervisor
 - [15_claude-session.md](15_claude-session.md) — the claude-session SDK runner (inside the apptainer SIF) + `POST /v1/turn` inbound endpoint; `runtime: apptainer` is the operative runtime
 - [16_claude-session-migration.md](16_claude-session-migration.md) — historical: the claude-code → SDK migration is complete; `runtime` is apptainer-only now
 - [17_inbound-turn-endpoint.md](17_inbound-turn-endpoint.md) — `POST /v1/turn` wire format + sidecar replacement

--- a/src/scitex_agent_container/_skills/scitex-agent-container/SKILL.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/SKILL.md
@@ -55,8 +55,8 @@ list`/`tail`/`health`).
 - [07_a2a-protocol.md](07_a2a-protocol.md) — Native A2A protocol (`sac a2a serve`)
 - [07_a2a-protocol-extension-fields.md](07_a2a-protocol-extension-fields.md) — `x-scitex-agent-container.*` AgentCard extension fields + JSON example
 - [08_templates.md](08_templates.md) — Six pattern templates + real-world examples
-- [15_claude-session.md](15_claude-session.md) — `runtime: claude-session` SDK-native runtime + `POST /v1/turn` inbound endpoint
-- [16_claude-session-migration.md](16_claude-session-migration.md) — Migrating an agent to claude-session
+- [15_claude-session.md](15_claude-session.md) — the claude-session SDK runner (inside the apptainer SIF) + `POST /v1/turn` inbound endpoint; `runtime: apptainer` is the operative runtime
+- [16_claude-session-migration.md](16_claude-session-migration.md) — historical: the claude-code → SDK migration is complete; `runtime` is apptainer-only now
 - [17_inbound-turn-endpoint.md](17_inbound-turn-endpoint.md) — `POST /v1/turn` wire format + sidecar replacement
 - [18_full-agent-delegation.md](18_full-agent-delegation.md) — Delegate multi-step work to another *full* Claude Code agent (vs Task subagent)
 - [19_full-agent-troubleshooting.md](19_full-agent-troubleshooting.md) — Operational deep-dives for sac peer fleets: stuck-peer recovery, reaper pattern, hard/soft skills, Monitor over polling


### PR DESCRIPTION
## The stale-doc bug

Several skill leaves under `src/scitex_agent_container/_skills/scitex-agent-container/` described `runtime: claude-session` as a **distinct, SIF-less, bare-Python runtime** — a live choice against `runtime: claude-code`, implying agents run as a bare host process *without* an apptainer container. That is stale.

## Ground truth (verified in code — the source of truth)

- **`config/_validation.py`** rejects every `spec.runtime` value except `apptainer`: *"spec.runtime must be 'apptainer' (got '...'). Sac is apptainer-only since 2026-05-13."* Neither `claude-code` nor `claude-session` is a valid runtime value.
- **`runtimes/claude_session.py`** — the adapter is a thin shim: *"The host side never spawns a Python subprocess; every `start` goes through `apptainer exec`."* `ClaudeSessionRuntime` delegates to `ApptainerContainerRuntime`. `claude-session` is the **name of the in-container runner module** (`_runners/claude_session.py`), not a runtime.
- **`config/_types.py`** — `runtime` defaults to `apptainer`; `RemoteSpec`/`spec.remote` deleted (WI-6, 2026-05-20).
- **Canonical spec** (`agents/proj-scitex-agent-container/spec.yaml`): `runtime: apptainer`, `apptainer.image: sac-base.sif`, `relaxed: true`, directory overlay, startup `uv pip install -e ".[all]"` into `/opt/venv-agent`. There is no separate `sac-scitex.sif`; code comes from the editable venv in the overlay.
- `_runners/_remote_launch.py` (+ `SAC_RUNNER_PREFIX`) is **dead code** — exists with a unit test but has zero live importers in `src/`.

## Corrected

| File | Was wrong | Now |
|---|---|---|
| `15_claude-session.md` | "SDK-native runtime, no container, flip a YAML key" | in-container SDK runner; `runtime: apptainer` operative; SIF + overlay + uv venv; status JSON `runtime: apptainer` |
| `16_claude-session-migration.md` | step-by-step `claude-code` → `claude-session` flip | historical note: migration complete, neither is a valid runtime, how to fix rejected specs |
| `17_inbound-turn-endpoint.md` | `runtime: claude-session` YAML; dead `_remote_launch`/`SAC_RUNNER_PREFIX` host-launch section | `runtime: apptainer`; in-container endpoint; cross-host via `spec.host` / `sac --on` + ssh-as-transport |
| `18_full-agent-delegation.md` | `claude-session`-vs-`claude-cli-tui` runtime choice | single `runtime: apptainer` reality |
| `06_http-api.md` | `spec.remote.host` (deleted) | `spec.host` |
| `07_a2a-protocol.md` | `runtime: claude-code` in YAML | `runtime: apptainer` |
| `19_full-agent-troubleshooting.md` | resolved `runtime: claude-session` skill caveat | dropped |
| `01_installation.md` | dead per-host-hook / `SAC_RUNNER_PREFIX` launch | `spec.host` / `sac --on` cross-host story |
| `SKILL.md` | index descriptions | reconciled |

Useful SDK/turn-endpoint mechanics preserved — only the SIF/runtime framing fixed.

## Verification

`scitex-dev ecosystem audit-skills scitex-agent-container` clean before and after.

## Deferred (noted in GITIGNORED/QUESTIONS.md, separate work item)

Adjacent stale leaves not in scope here: `22_host-passthrough.md` (`runtime: docker` + pre-v3 `spec.image`/`spec.mounts`) and `spec.remote.host` refs in `02/03/04/11`. Recommend a follow-up "realign host-passthrough + remote-deploy leaves to v3" PR.