### PR TITLE
feat(peer): interpret peer's honest 504 timeout for the calling agent

### DIFF
--- a/src/scitex_agent_container/_network/_peer_timeout.py
+++ b/src/scitex_agent_container/_network/_peer_timeout.py
@@ -1,0 +1,196 @@
+"""Sender-side interpretation of the peer's honest 504 timeout body.
+
+When agent A drives a turn into agent B via :func:`peer.post_turn` /
+:func:`peer.post_turn_to_url` (and the ``sac peer post-turn`` CLI) and
+B's turn exceeds the bounded HTTP wait, B's ``/v1/turn`` returns HTTP
+504 with an *honest* body (PR #169,
+``_runners/_session_http.py::_build_timeout_body``):
+
+    {
+      "status": "timeout_wait_elapsed",
+      "detail": "<neutral one-liner>",
+      "possibilities": [...],
+      "timeout_s": <float>,
+      "session_id": <str|None>,
+      "heartbeat": {<phase/state, ts, elapsed_s, ...>} | null,
+      "error": "<legacy '<N>s timeout' alias>"
+    }
+
+This module turns that body into a clear, neutral *interpretation* for
+the calling agent — so the sender surfaces "the turn may still be
+running" rather than the raw JSON.
+
+A 504-still-running is NOT an exception-worthy failure, so the
+interpretation is carried by :class:`PeerTimeoutPending` — a
+:class:`PeerError` subclass that signals *in-progress*, not *failed*.
+See its docstring for the return-vs-raise rationale.
+
+The base :class:`PeerError` lives in :mod:`peer` (the canonical home of
+the transport-error type); this module imports it. ``peer`` imports the
+helpers here lazily inside its 504 branch, so there is no import cycle.
+"""
+
+from __future__ import annotations
+
+from .peer import PeerError
+
+__all__ = ["PeerTimeoutPending", "interpret_timeout_body", "TIMEOUT_STATUS"]
+
+# Discriminator the runner stamps into the honest 504 body. Its presence
+# is how the sender knows a 504 carries the structured "wait elapsed,
+# turn may still be running" state rather than a genuine gateway failure.
+TIMEOUT_STATUS = "timeout_wait_elapsed"
+
+
+class PeerTimeoutPending(PeerError):
+    """The bounded HTTP wait elapsed — the turn may STILL be running.
+
+    Raised (instead of a plain :class:`PeerError`) when the peer returns
+    HTTP 504 because its bounded ``/v1/turn`` wait elapsed. A 504 here is
+    NOT a failure: the runner never cancels the SDK call, so the turn is
+    usually still queued / draining and its result will land in the
+    peer's session. This is therefore an *in-progress* signal, not an
+    error.
+
+    Why an exception subclass rather than a normal return value: the
+    ``post_turn*`` contract is ``-> str`` where the string is the agent's
+    *reply*. A timeout-pending is fundamentally not a reply, so returning
+    it as the reply string would let an unaware caller mistake "still
+    running" for the actual answer. Making it a ``PeerError`` *subclass*
+    keeps existing ``except PeerError`` callers working unchanged, while
+    callers that care can ``except PeerTimeoutPending`` first and treat
+    it as in-progress (e.g. the CLI exits 0, not 2). See this PR's
+    description for the return-vs-raise design fork.
+
+    Attributes
+    ----------
+    interpretation : str
+        Human-readable, neutral interpretation built for the calling
+        agent (also ``str(exc)``).
+    status : str | None
+        The peer's ``status`` field (``"timeout_wait_elapsed"`` for an
+        honest-shape body; ``None`` for an older peer that returned a 504
+        without the honest body).
+    timeout_s : float | None
+        The peer's reported bounded-wait duration, when available.
+    session_id : str | None
+        The peer's session id, when the body carried one.
+    heartbeat : dict | None
+        The peer's verbatim heartbeat record, or ``None`` when the peer
+        could not read live state.
+    possibilities : list[str]
+        The peer's neutral list of what the timeout might mean.
+    raw_body : dict | None
+        The full parsed JSON body, for callers that want everything.
+    """
+
+    def __init__(
+        self,
+        interpretation: str,
+        *,
+        status: str | None = None,
+        timeout_s: float | None = None,
+        session_id: str | None = None,
+        heartbeat: dict | None = None,
+        possibilities: list[str] | None = None,
+        raw_body: dict | None = None,
+    ) -> None:
+        super().__init__(interpretation)
+        self.interpretation = interpretation
+        self.status = status
+        self.timeout_s = timeout_s
+        self.session_id = session_id
+        self.heartbeat = heartbeat
+        self.possibilities = possibilities or []
+        self.raw_body = raw_body
+
+
+def interpret_timeout_body(
+    body: dict | None, *, fallback_label: str
+) -> PeerTimeoutPending:
+    """Build a :class:`PeerTimeoutPending` from a 504 response body.
+
+    ``body`` is the parsed JSON of the peer's 504 response, or ``None``
+    when the body was empty / unparseable. Robust to an OLDER peer that
+    returns a 504 *without* the honest shape (no ``status`` /
+    ``heartbeat`` / ``possibilities``): every field is read with
+    ``.get`` and a sensible generic interpretation is produced instead
+    of crashing on a missing key.
+
+    ``fallback_label`` names the peer (URL or ``host:port``) for the
+    generic message when the honest shape is absent.
+    """
+    body = body if isinstance(body, dict) else None
+
+    timeout_s = body.get("timeout_s") if body else None
+    session_id = body.get("session_id") if body else None
+    heartbeat = body.get("heartbeat") if body else None
+    if not isinstance(heartbeat, dict):
+        heartbeat = None
+    possibilities = body.get("possibilities") if body else None
+    if not isinstance(possibilities, list):
+        possibilities = []
+    status = body.get("status") if body else None
+
+    # Lead line: timeout is NOT necessarily a failure.
+    if isinstance(timeout_s, (int, float)):
+        lead = (
+            f"Timeout after {float(timeout_s):.0f}s — this is NOT necessarily "
+            "a failure. The turn may still be running on the peer."
+        )
+    else:
+        lead = (
+            "Timeout — this is NOT necessarily a failure. The turn may still "
+            f"be running on {fallback_label}."
+        )
+
+    # Heartbeat line: report verbatim state, or say it's unavailable.
+    hb_line = _format_heartbeat_line(heartbeat)
+
+    # Possibilities line: join the peer's neutral list when present.
+    if possibilities:
+        poss_line = "Possibilities: " + "; ".join(str(p) for p in possibilities) + "."
+    else:
+        poss_line = (
+            "Possibilities: turn still draining in the SDK; live state "
+            "unavailable (older peer returned no structured timeout body)."
+        )
+
+    # Push-promise framing (PR #169 / dispatch-ledger direction).
+    push_line = (
+        "The result will land in the peer's session; an update will be "
+        "pushed when there is news."
+    )
+
+    interpretation = "\n".join([lead, hb_line, poss_line, push_line])
+    return PeerTimeoutPending(
+        interpretation,
+        status=status if isinstance(status, str) else None,
+        timeout_s=float(timeout_s) if isinstance(timeout_s, (int, float)) else None,
+        session_id=session_id if isinstance(session_id, str) else None,
+        heartbeat=heartbeat,
+        possibilities=[str(p) for p in possibilities],
+        raw_body=body,
+    )
+
+
+def _format_heartbeat_line(heartbeat: dict | None) -> str:
+    """Render the one-line heartbeat summary for the interpretation.
+
+    Reads the runner's heartbeat record (``state`` = phase, plus
+    optional ``ts`` / ``elapsed_s`` activity fields) with ``.get`` so a
+    differently-shaped or absent record degrades to a clear
+    "unavailable" line rather than crashing.
+    """
+    if not isinstance(heartbeat, dict):
+        return "Peer heartbeat: unavailable."
+    phase = heartbeat.get("state")
+    elapsed = heartbeat.get("elapsed_s")
+    ts = heartbeat.get("ts") or heartbeat.get("heartbeat_at")
+    parts: list[str] = []
+    parts.append(f"phase {phase!r}" if phase is not None else "phase unknown")
+    if ts is not None:
+        parts.append(f"last beat {ts}")
+    if isinstance(elapsed, (int, float)):
+        parts.append(f"elapsed {float(elapsed):.0f}s")
+    return "Peer heartbeat: " + ", ".join(parts) + "."

--- a/src/scitex_agent_container/_network/peer.py
+++ b/src/scitex_agent_container/_network/peer.py
@@ -46,11 +46,32 @@ import urllib.error
 import urllib.request
 from typing import Any
 
-__all__ = ["post_turn", "post_turn_to_url", "resolve_peer_url", "PeerError"]
+__all__ = [
+    "post_turn",
+    "post_turn_to_url",
+    "resolve_peer_url",
+    "PeerError",
+    "PeerTimeoutPending",
+]
 
 
 class PeerError(RuntimeError):
     """Raised when the peer call cannot be completed (resolution + transport)."""
+
+
+def __getattr__(name: str):
+    """Lazily re-export :class:`PeerTimeoutPending` from ``_peer_timeout``.
+
+    Kept lazy so ``_peer_timeout`` can import ``PeerError`` from this
+    module at its own import time without a cycle: nothing here imports
+    ``_peer_timeout`` at module load; the symbol resolves on first
+    attribute access (``from ..peer import PeerTimeoutPending``).
+    """
+    if name == "PeerTimeoutPending":
+        from ._peer_timeout import PeerTimeoutPending
+
+        return PeerTimeoutPending
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def post_turn_to_url(
@@ -89,6 +110,13 @@ def post_turn_to_url(
             Exception
         ):  # stx-allow: fallback (reason: defensive — body read may fail)
             err_body = ""
+        if exc.code == 504:
+            # A 504 means the peer's bounded HTTP wait elapsed — the turn
+            # is usually still running. Interpret the honest body (PR #169)
+            # for the caller instead of surfacing raw JSON; an older peer
+            # that returns 504 without the honest shape degrades to a
+            # generic "may still be running" message.
+            raise _interpret_504(err_body, fallback_label=url) from exc
         raise PeerError(
             f"peer returned HTTP {exc.code}: {err_body or exc.reason}"
         ) from exc
@@ -238,6 +266,29 @@ def post_turn(
 # ---------------------------------------------------------------------------
 
 
+def _interpret_504(err_body: str, *, fallback_label: str) -> PeerError:
+    """Return a ``PeerTimeoutPending`` interpreting a 504 response body.
+
+    Parses ``err_body`` as JSON and delegates to
+    :func:`_peer_timeout.interpret_timeout_body`. An empty or
+    unparseable body still yields a generic "timeout, may still be
+    running" interpretation — never a crash, never a raw-JSON leak.
+
+    The return type is annotated ``PeerError`` (the base) so the call
+    sites' ``raise ... from exc`` reads cleanly; the concrete object is
+    always a :class:`PeerTimeoutPending`.
+    """
+    from ._peer_timeout import interpret_timeout_body
+
+    body: dict | None
+    try:
+        parsed = json.loads(err_body) if err_body else None
+        body = parsed if isinstance(parsed, dict) else None
+    except json.JSONDecodeError:
+        body = None
+    return interpret_timeout_body(body, fallback_label=fallback_label)
+
+
 def _post_turn_via_ssh(
     url: str,
     text: str,
@@ -304,6 +355,14 @@ def _post_turn_via_ssh(
         raise PeerError(
             f"ssh+curl to {host}:{port} returned non-JSON: {(proc.stdout or '')[:300]}"
         ) from exc
+    # Over ssh the remote curl (no --fail) returns rc=0 even on a 504, so
+    # the HTTP status is invisible — the honest body's status field is the
+    # reliable discriminator. When present, interpret it as in-progress.
+    if isinstance(payload, dict):
+        from ._peer_timeout import TIMEOUT_STATUS
+
+        if payload.get("status") == TIMEOUT_STATUS:
+            raise _interpret_504(json.dumps(payload), fallback_label=f"{host}:{port}")
     if not isinstance(payload, dict) or "text" not in payload:
         raise PeerError(f"peer returned malformed body: {payload!r}")
     return str(payload["text"])

--- a/src/scitex_agent_container/cli_pkg/peer_group.py
+++ b/src/scitex_agent_container/cli_pkg/peer_group.py
@@ -69,12 +69,25 @@ def peer_post_turn(
         sac peer post-turn head-mba "..." --exit-after
         sac peer post-turn worker "ping" --json | jq -r .text
     """
-    from scitex_agent_container._network.peer import PeerError, post_turn
+    from scitex_agent_container._network.peer import (
+        PeerError,
+        PeerTimeoutPending,
+        post_turn,
+    )
 
     try:
         text_out = post_turn(
             agent_name, text, exit_after=exit_after, timeout_s=timeout_s
         )
+    except PeerTimeoutPending as pending:
+        # A 504-wait-elapsed is NOT a failure — the turn is likely still
+        # running on the peer. Surface the neutral interpretation and
+        # exit 0 so callers don't treat in-progress as an error.
+        if as_json:
+            click.echo(json.dumps(pending.raw_body or {"status": pending.status}))
+        else:
+            click.echo(pending.interpretation)
+        sys.exit(0)
     except PeerError as exc:
         click.echo(f"peer error: {exc}", err=True)
         sys.exit(2)

--- a/tests/scitex_agent_container/_network/test__peer_timeout.py
+++ b/tests/scitex_agent_container/_network/test__peer_timeout.py
@@ -1,0 +1,252 @@
+"""Sender-side interpretation of the peer's honest 504 timeout body.
+
+Tests:
+  1. ``interpret_timeout_body`` builds a neutral PeerTimeoutPending from
+     the honest shape (status / heartbeat / possibilities present).
+  2. ``interpret_timeout_body`` degrades to a generic message when the
+     body is empty / missing the honest shape (older peer).
+  3. ``interpret_timeout_body`` does not crash when heartbeat is None.
+  4. ``post_turn_to_url`` raises PeerTimeoutPending (NOT plain PeerError)
+     against a REAL local server returning 504 + honest body.
+  5. ``post_turn_to_url`` raises PeerTimeoutPending against a REAL local
+     504 WITHOUT the honest body (generic interpretation).
+  6. A genuine non-504 transport failure still raises plain PeerError
+     (the in-progress path is 504-only).
+  7. PeerTimeoutPending IS a PeerError subclass (back-compat catch).
+  8. ``sac peer post-turn`` exits 0 and prints the interpretation when
+     the peer returns a 504 honest body (in-progress, not failure).
+
+HARD RULE — NO MOCKS: every transport test runs against a real
+``http.server`` on 127.0.0.1; the connection-failure test points at an
+unrouteable loopback port. STX-TQ: AAA markers, descriptive names, one
+assertion per test.
+"""
+
+from __future__ import annotations
+
+import http.server
+import json
+import socket
+import threading
+
+import pytest
+
+from scitex_agent_container._network._peer_timeout import (
+    PeerTimeoutPending,
+    interpret_timeout_body,
+)
+from scitex_agent_container._network.peer import PeerError, post_turn_to_url
+
+_HONEST_BODY = {
+    "status": "timeout_wait_elapsed",
+    "detail": "The bounded HTTP wait of 120s elapsed; the turn may still be running.",
+    "possibilities": ["turn still draining", "agent in a long tool call"],
+    "timeout_s": 120.0,
+    "session_id": "sid-abc",
+    "heartbeat": {"state": "working", "ts": 1700000000.0, "elapsed_s": 215.0},
+    "error": "turn exceeded 120s timeout",
+}
+
+
+def _start_504_server(body: bytes):
+    """Spin up a daemon http.server on 127.0.0.1 that returns 504 + ``body``.
+
+    Returns ``(server, thread, port)``. Caller is responsible for
+    ``server.shutdown()`` + ``thread.join()``.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        port = s.getsockname()[1]
+
+    class _Handler(http.server.BaseHTTPRequestHandler):
+        def do_POST(self):  # noqa: N802
+            length = int(self.headers.get("Content-Length", "0"))
+            self.rfile.read(length)
+            self.send_response(504)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *a, **kw):  # silence test output
+            pass
+
+    server = http.server.HTTPServer(("127.0.0.1", port), _Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, thread, port
+
+
+# ---------------------------------------------------------------------------
+# 1-3 — interpret_timeout_body unit behaviour (no transport)
+# ---------------------------------------------------------------------------
+
+
+class TestInterpretTimeoutBody:
+    def test_honest_body_interpretation_states_not_a_failure(self) -> None:
+        # Arrange
+        body = dict(_HONEST_BODY)
+        # Act
+        exc = interpret_timeout_body(body, fallback_label="http://x/v1/turn")
+        # Assert
+        assert "NOT necessarily" in exc.interpretation
+
+    def test_honest_body_preserves_session_id_field(self) -> None:
+        # Arrange
+        body = dict(_HONEST_BODY)
+        # Act
+        exc = interpret_timeout_body(body, fallback_label="http://x/v1/turn")
+        # Assert
+        assert exc.session_id == "sid-abc"
+
+    def test_honest_body_renders_heartbeat_phase(self) -> None:
+        # Arrange
+        body = dict(_HONEST_BODY)
+        # Act
+        exc = interpret_timeout_body(body, fallback_label="http://x/v1/turn")
+        # Assert
+        assert "phase 'working'" in exc.interpretation
+
+    def test_honest_body_joins_possibilities_list(self) -> None:
+        # Arrange
+        body = dict(_HONEST_BODY)
+        # Act
+        exc = interpret_timeout_body(body, fallback_label="http://x/v1/turn")
+        # Assert
+        assert "agent in a long tool call" in exc.interpretation
+
+    def test_empty_body_produces_generic_may_still_be_running_message(self) -> None:
+        # Arrange — older peer: no structured body at all.
+        body = None
+        # Act
+        exc = interpret_timeout_body(body, fallback_label="mba:18888")
+        # Assert
+        assert "may still be running on mba:18888" in exc.interpretation
+
+    def test_empty_body_status_field_is_none(self) -> None:
+        # Arrange
+        body = None
+        # Act
+        exc = interpret_timeout_body(body, fallback_label="mba:18888")
+        # Assert
+        assert exc.status is None
+
+    def test_heartbeat_none_renders_unavailable_without_crashing(self) -> None:
+        # Arrange — honest shape but the peer could not read live state.
+        body = {
+            "status": "timeout_wait_elapsed",
+            "timeout_s": 60.0,
+            "heartbeat": None,
+            "possibilities": [],
+        }
+        # Act
+        exc = interpret_timeout_body(body, fallback_label="p")
+        # Assert
+        assert "Peer heartbeat: unavailable." in exc.interpretation
+
+    def test_pending_is_peer_error_subclass_for_backcompat_catch(self) -> None:
+        # Arrange
+        body = dict(_HONEST_BODY)
+        # Act
+        exc = interpret_timeout_body(body, fallback_label="x")
+        # Assert
+        assert isinstance(exc, PeerError)
+
+
+# ---------------------------------------------------------------------------
+# 4-6 — post_turn_to_url against a REAL local server (no mocks)
+# ---------------------------------------------------------------------------
+
+
+class TestPostTurnTimeoutOverHttp:
+    def test_504_honest_body_raises_peer_timeout_pending(self) -> None:
+        # Arrange
+        server, thread, port = _start_504_server(
+            json.dumps(_HONEST_BODY).encode("utf-8")
+        )
+        raised: list[BaseException] = []
+        try:
+            # Act
+            try:
+                post_turn_to_url(
+                    f"http://127.0.0.1:{port}/v1/turn", "hi", timeout_s=5.0
+                )
+            except PeerTimeoutPending as exc:
+                raised.append(exc)
+            # Assert
+            assert raised and isinstance(raised[0], PeerTimeoutPending)
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=2.0)
+
+    def test_504_honest_body_interpretation_not_raw_json(self) -> None:
+        # Arrange
+        server, thread, port = _start_504_server(
+            json.dumps(_HONEST_BODY).encode("utf-8")
+        )
+        raised: list[PeerTimeoutPending] = []
+        try:
+            # Act
+            try:
+                post_turn_to_url(
+                    f"http://127.0.0.1:{port}/v1/turn", "hi", timeout_s=5.0
+                )
+            except PeerTimeoutPending as exc:
+                raised.append(exc)
+            # Assert — friendly text, not the raw JSON envelope.
+            assert raised and "NOT necessarily" in raised[0].interpretation
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=2.0)
+
+    def test_504_honest_body_carries_structured_timeout_s(self) -> None:
+        # Arrange
+        server, thread, port = _start_504_server(
+            json.dumps(_HONEST_BODY).encode("utf-8")
+        )
+        raised: list[PeerTimeoutPending] = []
+        try:
+            # Act
+            try:
+                post_turn_to_url(
+                    f"http://127.0.0.1:{port}/v1/turn", "hi", timeout_s=5.0
+                )
+            except PeerTimeoutPending as exc:
+                raised.append(exc)
+            # Assert
+            assert raised and raised[0].timeout_s == 120.0
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=2.0)
+
+    def test_504_without_honest_body_raises_generic_pending(self) -> None:
+        # Arrange — older peer: 504 with a non-JSON / non-honest body.
+        server, thread, port = _start_504_server(b"Gateway Timeout")
+        raised: list[BaseException] = []
+        try:
+            # Act
+            try:
+                post_turn_to_url(
+                    f"http://127.0.0.1:{port}/v1/turn", "hi", timeout_s=5.0
+                )
+            except PeerTimeoutPending as exc:
+                raised.append(exc)
+            # Assert
+            assert raised and "may still be running" in raised[0].interpretation
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=2.0)
+
+    def test_connection_failure_raises_plain_peer_error_not_pending(self) -> None:
+        # Arrange — port 1 on loopback is unrouteable → URLError.
+        raised: list[BaseException] = []
+        # Act
+        try:
+            post_turn_to_url("http://127.0.0.1:1/v1/turn", "x", timeout_s=1.0)
+        except PeerError as exc:
+            raised.append(exc)
+        # Assert — a genuine transport failure is NOT in-progress.
+        assert raised and not isinstance(raised[0], PeerTimeoutPending)

--- a/tests/scitex_agent_container/_network/test__peer_timeout.py
+++ b/tests/scitex_agent_container/_network/test__peer_timeout.py
@@ -29,8 +29,6 @@ import json
 import socket
 import threading
 
-import pytest
-
 from scitex_agent_container._network._peer_timeout import (
     PeerTimeoutPending,
     interpret_timeout_body,

--- a/tests/scitex_agent_container/cli_pkg/test_peer_group.py
+++ b/tests/scitex_agent_container/cli_pkg/test_peer_group.py
@@ -20,6 +20,7 @@ from typing import Callable, Iterator
 from click.testing import CliRunner
 
 import scitex_agent_container._network.peer as peer_mod
+from scitex_agent_container._network._peer_timeout import PeerTimeoutPending
 from scitex_agent_container._network.peer import PeerError
 from scitex_agent_container.cli_pkg.peer_group import peer_group
 
@@ -188,6 +189,62 @@ def test_post_turn_peer_error_message_surfaces_in_output() -> None:
     result = invoke()
     # Assert
     assert "boom" in result.output
+
+
+# ---------------------------------------------------------------------------
+# `sac peer post-turn` — PeerTimeoutPending (504 in-progress) surface
+# ---------------------------------------------------------------------------
+
+
+def _pending_exc() -> PeerTimeoutPending:
+    """Build a real PeerTimeoutPending an in-progress 504 would raise."""
+    return PeerTimeoutPending(
+        "Timeout after 120s — this is NOT necessarily a failure. ...",
+        status="timeout_wait_elapsed",
+        timeout_s=120.0,
+        session_id="sid-abc",
+        heartbeat={"state": "working"},
+        possibilities=["turn still draining"],
+        raw_body={"status": "timeout_wait_elapsed", "timeout_s": 120.0},
+    )
+
+
+def _invoke_post_turn_timeout(extra_args: list[str] | None = None):
+    def fake_post_turn(*_a, **_kw) -> str:
+        raise _pending_exc()
+
+    runner = CliRunner()
+    args = ["post-turn", "alpha", "hi"] + (extra_args or [])
+    with _swap("post_turn", fake_post_turn):
+        result = runner.invoke(peer_group, args)
+    return result
+
+
+def test_post_turn_timeout_pending_exits_zero_not_failure() -> None:
+    # Arrange
+    invoke = _invoke_post_turn_timeout
+    # Act
+    result = invoke()
+    # Assert — in-progress is not an error; exit 0 (not 2).
+    assert result.exit_code == 0
+
+
+def test_post_turn_timeout_pending_prints_interpretation() -> None:
+    # Arrange
+    invoke = _invoke_post_turn_timeout
+    # Act
+    result = invoke()
+    # Assert
+    assert "NOT necessarily a failure" in result.output
+
+
+def test_post_turn_timeout_pending_json_emits_structured_body() -> None:
+    # Arrange
+    invoke = _invoke_post_turn_timeout
+    # Act
+    result = invoke(["--json"])
+    # Assert
+    assert json.loads(result.output)["status"] == "timeout_wait_elapsed"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

When agent A drives a turn into agent B via `peer.post_turn` /
`post_turn_to_url` (and the `sac peer post-turn` CLI), and B's turn
exceeds the bounded HTTP wait, B's `/v1/turn` now returns HTTP 504 with
the **honest body** from #169 (`status=timeout_wait_elapsed` + `heartbeat`
+ `possibilities` + `timeout_s` + `session_id`).

Today the **sender** surfaces the raw `peer error: peer returned HTTP 504: {json}` — unhelpful. This PR makes the sender **interpret** it for the calling agent.

## Behaviour

A 504 carrying the honest body now produces a neutral, forward-looking interpretation, e.g.:

```
Timeout after 120s — this is NOT necessarily a failure. The turn may still be running on the peer.
Peer heartbeat: phase 'working', last beat 1700000000.0, elapsed 215s.
Possibilities: turn still draining; agent in a long tool call.
The result will land in the peer's session; an update will be pushed when there is news.
```

(The last line is the push-promise framing per #169 / dispatch-ledger direction.)

## Scope of the interpretation

- **Only** the 504-honest-body case gets the friendly interpretation.
- **Genuine transport failures** (connection refused, DNS, non-504 HTTP) keep raising plain `PeerError` unchanged.
- **Older peer** that returns 504 *without* the honest shape: every field read with `.get`, degrades to a generic "timeout, may still be running" message — never crashes on a missing key.
- **ssh transport**: remote `curl` (no `--fail`) hides the HTTP 504 code, so the honest body's `status` field is the discriminator there.

## Design fork — return-vs-raise (REPORT-WITH-OPTIONS)

A 504-still-running is **not** a normal reply and **not** a hard failure. Three options:

| Option | Mechanism | Trade-off |
|---|---|---|
| **A. return interpreted string** | keep `-> str`, return the message as the "reply" | zero contract change, but an unaware caller can mistake "still running" for the actual answer (the `-> str` contract means "this string is the agent's reply") |
| **B. return a structured object** | `-> str \| PeerTimeout` | distinguishable, but ripples the type contract to every caller |
| **C. distinct exception subclass** (chosen) | `PeerTimeoutPending(PeerError)` | preserves `-> str` (never returns a fake reply); `except PeerError` callers keep working; callers who care `except PeerTimeoutPending` first and treat it as in-progress |

**Chose C.** It satisfies "distinguishable + in-progress not failed" without coercing "still running" into the reply string. The CLI catches `PeerTimeoutPending` before `PeerError`, prints the interpretation, and **exits 0** (in-progress, not a failure). `PeerTimeoutPending` carries the structured fields (`status` / `timeout_s` / `session_id` / `heartbeat` / `possibilities` / `raw_body`) for programmatic callers and `--json`.

## Tests (NO MOCKS)

`tests/.../_network/test__peer_timeout.py` + additions to `test_peer_group.py`:
- real local `http.server` returning **504 + honest body** → asserts `PeerTimeoutPending`, interpreted message (not raw json), structured `timeout_s`
- real local **504 *without* honest body** → generic "may still be running" message
- real **connection failure** → still plain `PeerError`, NOT `PeerTimeoutPending`
- `interpret_timeout_body` unit cases incl. `heartbeat: None` robustness
- CLI: `sac peer post-turn` against a 504-pending exits **0**, prints interpretation, `--json` emits structured body

STX-TQ throughout (AAA markers, descriptive names, one assertion).

## Refactor note

Interpretation logic extracted to a focused sibling module
`_network/_peer_timeout.py` to keep `peer.py` under the 512-line budget.
Public import surface unchanged — `PeerError`, `PeerTimeoutPending`,
`post_turn`, `post_turn_to_url`, `resolve_peer_url` all importable from
`scitex_agent_container._network.peer` (the new symbol is lazily
re-exported via module `__getattr__` to avoid an import cycle).

## Verification

- `tests/scitex_agent_container/{_runners,_network,cli_pkg}/`: **1251 passed**, 0 failures
- `tests/develop/` audit gate: **passed**
- pre-commit + pre-push (ruff) green