### PR TITLE
fix(state): make instance_heartbeats "latest" deterministic (kill flaky merge test)

### DIFF
--- a/src/scitex_agent_container/_state/state_db.py
+++ b/src/scitex_agent_container/_state/state_db.py
@@ -17,23 +17,19 @@ The single-file layout makes backup/sync trivial (one ``cp``) and
 keeps the existing ``actions.db`` table (``attempts``) co-located so
 queries can join across action history and instance lifecycle.
 
-NOTE: The original F-CS11 ``heartbeats`` table (instance-tied time
-series) is renamed to ``instance_heartbeats`` on first open so the
-diary-style ``heartbeats`` (per-agent state ping, no instance_id
-required) can own the canonical name. The rename happens in
-``init_schema`` when an old layout is detected and is idempotent.
+NOTE: The original F-CS11 ``heartbeats`` table is renamed to
+``instance_heartbeats`` on first open (idempotent migration in
+``init_schema``) so the diary-style ``heartbeats`` can own the name.
 
-Large helper groups live in sibling modules:
+Large helper groups live in sibling modules, all re-exported from THIS
+module so ``from ...state_db import X`` imports keep working:
 
-  * :mod:`state_db_export` — export_state / import_state /
-    import_legacy_registry.
+  * :mod:`state_db_export` — export_state / import_state / import_legacy_registry.
   * :mod:`state_db_gc` — gc_dead_instances / _proc_btime.
-  * :mod:`state_db_diary` — record_turn / record_error /
-    record_heartbeat / latest_heartbeats_per_name.
-
-All three are re-exported from THIS module so existing
-``from scitex_agent_container._state.state_db import X`` imports
-keep working.
+  * :mod:`state_db_diary` — record_turn / record_error / record_heartbeat /
+    latest_heartbeats_per_name.
+  * :mod:`state_db_heartbeats` — update_heartbeat / latest_instance_heartbeat.
+  * :mod:`state_db_migrations` — idempotent schema migrations.
 """
 
 from __future__ import annotations
@@ -47,7 +43,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Iterator
 
-from .._env import getenv as _sac_env
+from .state_db_hostname import resolve_host as _resolve_host
+from .state_db_migrations import (
+    migrate_instance_heartbeats_add_seq,
+    migrate_legacy_heartbeats,
+)
 
 DEFAULT_DB_PATH = Path(
     os.environ.get(
@@ -99,14 +99,20 @@ CREATE INDEX IF NOT EXISTS idx_instances_active
 CREATE INDEX IF NOT EXISTS idx_instances_host
     ON instances(host);
 
+-- ``seq`` (AUTOINCREMENT) gives a total insertion order so "latest
+-- heartbeat" is MAX(seq) — deterministic regardless of ``ts``
+-- (second-resolution) ties. ``UNIQUE(instance_id, ts)`` keeps the
+-- same-second collapse via the ON CONFLICT upsert in update_heartbeat.
+-- See state_db_heartbeats / state_db_migrations for the full rationale.
 CREATE TABLE IF NOT EXISTS instance_heartbeats (
+    seq             INTEGER PRIMARY KEY AUTOINCREMENT,
     instance_id     TEXT NOT NULL REFERENCES instances(id),
     ts              TEXT NOT NULL,
     iter            INTEGER,
     input_tokens    INTEGER,
     output_tokens   INTEGER,
     pane_state      TEXT,
-    PRIMARY KEY (instance_id, ts)
+    UNIQUE (instance_id, ts)
 );
 
 CREATE TABLE IF NOT EXISTS events (
@@ -320,36 +326,6 @@ def _connect(
     return conn
 
 
-def _migrate_legacy_heartbeats(conn: sqlite3.Connection) -> None:
-    """Rename the legacy F-CS11 ``heartbeats`` table → ``instance_heartbeats``.
-
-    Detection: legacy schema has an ``instance_id`` column (NOT NULL,
-    REFERENCES instances). The diary schema has no such column. We
-    only rename when:
-
-      * a table called ``heartbeats`` exists, AND
-      * that table has an ``instance_id`` column, AND
-      * ``instance_heartbeats`` does NOT already exist.
-
-    Idempotent: re-running on an already-migrated DB is a no-op.
-    """
-    existing = {
-        r[0]
-        for r in conn.execute(
-            "SELECT name FROM sqlite_master WHERE type='table'"
-        ).fetchall()
-    }
-    if "heartbeats" not in existing:
-        return
-    if "instance_heartbeats" in existing:
-        return
-    cols = {r[1] for r in conn.execute("PRAGMA table_info(heartbeats)").fetchall()}
-    if "instance_id" not in cols:
-        # Already the diary schema (no rename needed).
-        return
-    conn.execute("ALTER TABLE heartbeats RENAME TO instance_heartbeats")
-
-
 def init_schema(db_path: Path | None = None) -> Path:
     """Create state.db with all tables if missing. Idempotent.
 
@@ -357,7 +333,8 @@ def init_schema(db_path: Path | None = None) -> Path:
     """
     path = Path(db_path) if db_path else DEFAULT_DB_PATH
     with _connect(path) as conn:
-        _migrate_legacy_heartbeats(conn)
+        migrate_legacy_heartbeats(conn)
+        migrate_instance_heartbeats_add_seq(conn)
         conn.executescript(_SCHEMA_REGISTRY)
         conn.executescript(_SCHEMA_ATTEMPTS)
         conn.executescript(_SCHEMA_DIARY)
@@ -388,30 +365,6 @@ def table_counts(db_path: Path | None = None) -> dict[str, int]:
             row = conn.execute(f"SELECT count(*) AS n FROM {table}").fetchone()
             counts[table] = int(row["n"])
     return counts
-
-
-def _resolve_host(host: str | None) -> str:
-    """Canonical hostname for state.db writes.
-
-    Resolution chain (F-CS12):
-        1. ``host`` arg (explicit override)
-        2. ``$SAC_HOST`` env var
-        3. ``host.canonical`` from config.yaml
-        4. ``host.aliases[$(hostname -s)]`` from config.yaml
-        5. ``$(hostname -s)`` (or fqdn when fallback=hostname-fqdn)
-    """
-    if host:
-        return host
-    from . import host_config
-
-    # stx-allow: fallback (reason: a malformed config.yaml must not block
-    # state.db writes — degrade to hostname-only resolution.)
-    try:
-        return host_config.load().canonical_host()
-    except Exception:  # stx-allow: fallback (reason: see inline comment)
-        import socket
-
-        return _sac_env("HOST") or socket.gethostname().split(".")[0]
 
 
 def record_instance_start(
@@ -492,49 +445,6 @@ def record_instance_stop(
     return True
 
 
-def update_heartbeat(
-    instance_id: str,
-    *,
-    iter: int | None = None,
-    input_tokens: int | None = None,
-    output_tokens: int | None = None,
-    pane_state: str | None = None,
-    db_path: Path | None = None,
-) -> None:
-    """Append an instance-heartbeat row + bump the rolling cache.
-
-    The duplicated state on ``instances`` lets ``sac agent status``
-    answer 'is this agent still doing work?' without a JOIN.
-    """
-    ts = now_iso()
-    with open_db(db_path) as conn:
-        conn.execute(
-            """
-            INSERT INTO instance_heartbeats (
-                instance_id, ts, iter, input_tokens, output_tokens, pane_state
-            )
-            VALUES (?, ?, ?, ?, ?, ?)
-            ON CONFLICT(instance_id, ts) DO UPDATE SET
-                iter          = COALESCE(excluded.iter, instance_heartbeats.iter),
-                input_tokens  = COALESCE(excluded.input_tokens, instance_heartbeats.input_tokens),
-                output_tokens = COALESCE(excluded.output_tokens, instance_heartbeats.output_tokens),
-                pane_state    = COALESCE(excluded.pane_state, instance_heartbeats.pane_state)
-            """,
-            (instance_id, ts, iter, input_tokens, output_tokens, pane_state),
-        )
-        conn.execute(
-            """
-            UPDATE instances
-               SET last_heartbeat_at = ?,
-                   iter_count    = COALESCE(?, iter_count),
-                   input_tokens  = COALESCE(?, input_tokens),
-                   output_tokens = COALESCE(?, output_tokens)
-             WHERE id = ?
-            """,
-            (ts, iter, input_tokens, output_tokens, instance_id),
-        )
-
-
 def list_active_instances(
     host: str | None = None,
     db_path: Path | None = None,
@@ -570,12 +480,16 @@ from .state_db_export import (  # noqa: E402,F401
     import_legacy_registry,
     import_state,
 )
-from .state_db_export import (
+from .state_db_export import (  # noqa: E402
     _table_filter_clauses as _table_filter_clauses_impl,
 )
 from .state_db_gc import (  # noqa: E402,F401
     _proc_btime,
     gc_dead_instances,
+)
+from .state_db_heartbeats import (  # noqa: E402,F401
+    latest_instance_heartbeat,
+    update_heartbeat,
 )
 
 

--- a/src/scitex_agent_container/_state/state_db_heartbeats.py
+++ b/src/scitex_agent_container/_state/state_db_heartbeats.py
@@ -1,0 +1,113 @@
+"""Instance-heartbeat write + read helpers for state.db.
+
+Extracted from :mod:`state_db` so that module stays under the per-file
+line cap. The DDL for ``instance_heartbeats`` lives in :mod:`state_db`
+(``_SCHEMA_REGISTRY``); this module owns the WRITE path
+(:func:`update_heartbeat`) and the canonical "latest row" READ
+(:func:`latest_instance_heartbeat`).
+
+Determinism note (the reason this code is careful about ``seq``):
+``instance_heartbeats`` is keyed by a monotonic
+``seq INTEGER PRIMARY KEY AUTOINCREMENT``, NOT by the second-resolution
+``ts``. Two heartbeats in the same wall-clock second collapse into one
+row via the ``ON CONFLICT(instance_id, ts)`` upsert; two beats that
+straddle a second boundary produce two rows. Either way, "the latest
+heartbeat" is unambiguously ``MAX(seq)`` — never an arbitrary tie on
+``ts``. Selecting the latest row by ``ts`` (or with no ORDER BY) is the
+non-determinism this design eliminates.
+
+``open_db`` is imported lazily inside each function to avoid a circular
+import: :mod:`state_db` re-exports :func:`update_heartbeat` from here.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Callable
+
+
+def update_heartbeat(
+    instance_id: str,
+    *,
+    iter: int | None = None,
+    input_tokens: int | None = None,
+    output_tokens: int | None = None,
+    pane_state: str | None = None,
+    db_path: Path | None = None,
+    now_fn: Callable[[], str] | None = None,
+) -> None:
+    """Append an instance-heartbeat row + bump the rolling cache.
+
+    The duplicated state on ``instances`` lets ``sac agent status``
+    answer 'is this agent still doing work?' without a JOIN. Same-second
+    beats merge into one ``instance_heartbeats`` row (last-non-NULL
+    wins per column); the ``seq`` PK keeps "latest" deterministic when
+    beats straddle a second.
+
+    ``now_fn`` is an injection seam (defaults to :func:`state_db.now_iso`)
+    so callers — including tests — can pin the heartbeat ``ts`` to a real
+    deterministic value instead of the wall clock. Passing a fixed value
+    forces same-second collapse; passing distinct values forces the
+    straddle-a-second path.
+    """
+    from .state_db import now_iso, open_db
+
+    ts = (now_fn or now_iso)()
+    with open_db(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO instance_heartbeats (
+                instance_id, ts, iter, input_tokens, output_tokens, pane_state
+            )
+            VALUES (?, ?, ?, ?, ?, ?)
+            ON CONFLICT(instance_id, ts) DO UPDATE SET
+                iter          = COALESCE(excluded.iter, instance_heartbeats.iter),
+                input_tokens  = COALESCE(excluded.input_tokens, instance_heartbeats.input_tokens),
+                output_tokens = COALESCE(excluded.output_tokens, instance_heartbeats.output_tokens),
+                pane_state    = COALESCE(excluded.pane_state, instance_heartbeats.pane_state)
+            """,
+            (instance_id, ts, iter, input_tokens, output_tokens, pane_state),
+        )
+        conn.execute(
+            """
+            UPDATE instances
+               SET last_heartbeat_at = ?,
+                   iter_count    = COALESCE(?, iter_count),
+                   input_tokens  = COALESCE(?, input_tokens),
+                   output_tokens = COALESCE(?, output_tokens)
+             WHERE id = ?
+            """,
+            (ts, iter, input_tokens, output_tokens, instance_id),
+        )
+
+
+def latest_instance_heartbeat(
+    instance_id: str,
+    *,
+    conn: sqlite3.Connection | None = None,
+    db_path: Path | None = None,
+) -> dict | None:
+    """Return the latest ``instance_heartbeats`` row, or ``None``.
+
+    "Latest" is ``MAX(seq)`` — the monotonic insertion order — so the
+    answer is deterministic regardless of how close in wall-clock time
+    the beats arrived. Pass an open ``conn`` to read within an existing
+    transaction; otherwise a short-lived connection is opened.
+    """
+
+    def _query(c: sqlite3.Connection) -> dict | None:
+        row = c.execute(
+            "SELECT * FROM instance_heartbeats "
+            "WHERE instance_id=? ORDER BY seq DESC LIMIT 1",
+            (instance_id,),
+        ).fetchone()
+        return dict(row) if row is not None else None
+
+    if conn is not None:
+        return _query(conn)
+
+    from .state_db import open_db
+
+    with open_db(db_path) as c:
+        return _query(c)

--- a/src/scitex_agent_container/_state/state_db_hostname.py
+++ b/src/scitex_agent_container/_state/state_db_hostname.py
@@ -1,0 +1,36 @@
+"""Canonical-hostname resolution for state.db writes (F-CS12).
+
+Extracted from :mod:`state_db` so that module stays under the per-file
+line cap. :func:`resolve_host` answers "what host string do I stamp on
+this instances row?" and degrades gracefully to a bare hostname when
+config.yaml is missing or malformed (a config error must never block a
+state.db write).
+"""
+
+from __future__ import annotations
+
+from .._env import getenv as _sac_env
+
+
+def resolve_host(host: str | None) -> str:
+    """Canonical hostname for state.db writes.
+
+    Resolution chain (F-CS12):
+        1. ``host`` arg (explicit override)
+        2. ``$SAC_HOST`` env var
+        3. ``host.canonical`` from config.yaml
+        4. ``host.aliases[$(hostname -s)]`` from config.yaml
+        5. ``$(hostname -s)`` (or fqdn when fallback=hostname-fqdn)
+    """
+    if host:
+        return host
+    from . import host_config
+
+    # stx-allow: fallback (reason: a malformed config.yaml must not block
+    # state.db writes — degrade to hostname-only resolution.)
+    try:
+        return host_config.load().canonical_host()
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        import socket
+
+        return _sac_env("HOST") or socket.gethostname().split(".")[0]

--- a/src/scitex_agent_container/_state/state_db_migrations.py
+++ b/src/scitex_agent_container/_state/state_db_migrations.py
@@ -1,0 +1,101 @@
+"""Idempotent schema migrations for state.db.
+
+Extracted from :mod:`state_db` so that module stays under the per-file
+line cap. Each function takes an open :class:`sqlite3.Connection` and is
+a no-op when its migration has already run, so they are safe to call on
+every :func:`state_db.init_schema`.
+
+  * :func:`migrate_legacy_heartbeats` — rename the original F-CS11
+    instance-tied ``heartbeats`` table to ``instance_heartbeats`` so the
+    diary-style ``heartbeats`` can own the canonical name.
+  * :func:`migrate_instance_heartbeats_add_seq` — rebuild
+    ``instance_heartbeats`` to add the monotonic ``seq`` PK that makes
+    "latest heartbeat" deterministic (see the table DDL in
+    :mod:`state_db` and :mod:`state_db_heartbeats`).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+
+def migrate_legacy_heartbeats(conn: sqlite3.Connection) -> None:
+    """Rename the legacy F-CS11 ``heartbeats`` table → ``instance_heartbeats``.
+
+    Detection: legacy schema has an ``instance_id`` column (NOT NULL,
+    REFERENCES instances). The diary schema has no such column. We
+    only rename when:
+
+      * a table called ``heartbeats`` exists, AND
+      * that table has an ``instance_id`` column, AND
+      * ``instance_heartbeats`` does NOT already exist.
+
+    Idempotent: re-running on an already-migrated DB is a no-op.
+    """
+    existing = {
+        r[0]
+        for r in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+    }
+    if "heartbeats" not in existing:
+        return
+    if "instance_heartbeats" in existing:
+        return
+    cols = {r[1] for r in conn.execute("PRAGMA table_info(heartbeats)").fetchall()}
+    if "instance_id" not in cols:
+        # Already the diary schema (no rename needed).
+        return
+    conn.execute("ALTER TABLE heartbeats RENAME TO instance_heartbeats")
+
+
+def migrate_instance_heartbeats_add_seq(conn: sqlite3.Connection) -> None:
+    """Rebuild ``instance_heartbeats`` to add the monotonic ``seq`` PK.
+
+    The pre-``seq`` table had ``PRIMARY KEY (instance_id, ts)`` with a
+    second-resolution ``ts``, so "latest heartbeat" was non-deterministic
+    whenever two beats straddled a second boundary. The new shape adds
+    ``seq INTEGER PRIMARY KEY AUTOINCREMENT`` (total insertion order) and
+    demotes ``(instance_id, ts)`` to ``UNIQUE`` (still collapses
+    same-second beats). SQLite cannot ALTER-add an AUTOINCREMENT PK, so
+    we rebuild: create the new table, copy rows ordered by the old
+    ``rowid`` (preserves arrival order → ``seq`` is monotonic in arrival),
+    drop the old, rename.
+
+    Detection: ``instance_heartbeats`` exists AND lacks a ``seq`` column.
+    Idempotent: a no-op once ``seq`` is present (or the table is absent).
+    """
+    existing = {
+        r[0]
+        for r in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+    }
+    if "instance_heartbeats" not in existing:
+        return
+    cols = {
+        r[1] for r in conn.execute("PRAGMA table_info(instance_heartbeats)").fetchall()
+    }
+    if "seq" in cols:
+        return
+    conn.executescript(
+        """
+        CREATE TABLE instance_heartbeats__new (
+            seq             INTEGER PRIMARY KEY AUTOINCREMENT,
+            instance_id     TEXT NOT NULL REFERENCES instances(id),
+            ts              TEXT NOT NULL,
+            iter            INTEGER,
+            input_tokens    INTEGER,
+            output_tokens   INTEGER,
+            pane_state      TEXT,
+            UNIQUE (instance_id, ts)
+        );
+        INSERT INTO instance_heartbeats__new
+            (instance_id, ts, iter, input_tokens, output_tokens, pane_state)
+        SELECT instance_id, ts, iter, input_tokens, output_tokens, pane_state
+        FROM instance_heartbeats
+        ORDER BY rowid;
+        DROP TABLE instance_heartbeats;
+        ALTER TABLE instance_heartbeats__new RENAME TO instance_heartbeats;
+        """
+    )

--- a/tests/scitex_agent_container/_state/test_state_db.py
+++ b/tests/scitex_agent_container/_state/test_state_db.py
@@ -479,7 +479,8 @@ def test_record_instance_stop_returns_false_on_second_call_for_idempotency(
 def test_update_heartbeat_collapses_two_same_second_beats_into_one_row(
     db_path: Path,
 ):
-    # Arrange
+    # Arrange — pin both beats to one ``ts`` via the now_fn seam so the
+    # same-second collapse is deterministic (not a wall-clock coincidence).
     from scitex_agent_container._state.state_db import (
         open_db,
         record_instance_start,
@@ -487,9 +488,14 @@ def test_update_heartbeat_collapses_two_same_second_beats_into_one_row(
     )
 
     iid = record_instance_start("x", host="h")
-    # Act — two beats in the same wall-clock second.
-    update_heartbeat(iid, iter=1, input_tokens=10, output_tokens=20)
-    update_heartbeat(iid, iter=2, input_tokens=30, output_tokens=40)
+    fixed_ts = "2026-05-22T00:00:00Z"
+    # Act
+    update_heartbeat(
+        iid, iter=1, input_tokens=10, output_tokens=20, now_fn=lambda: fixed_ts
+    )
+    update_heartbeat(
+        iid, iter=2, input_tokens=30, output_tokens=40, now_fn=lambda: fixed_ts
+    )
     with open_db() as conn:
         n = conn.execute(
             "SELECT count(*) AS n FROM instance_heartbeats WHERE instance_id=?",
@@ -499,14 +505,10 @@ def test_update_heartbeat_collapses_two_same_second_beats_into_one_row(
     assert n == 1
 
 
-@pytest.mark.parametrize(
-    "column, expected",
-    [("iter", 2), ("input_tokens", 30), ("output_tokens", 40)],
-)
-def test_update_heartbeat_merged_row_advances_to_latest_value(
-    db_path: Path, column: str, expected: int
+def test_update_heartbeat_keeps_two_rows_when_beats_straddle_a_second(
+    db_path: Path,
 ):
-    # Arrange
+    # Arrange — distinct ``ts`` (clock ticked between beats) → no merge.
     from scitex_agent_container._state.state_db import (
         open_db,
         record_instance_start,
@@ -514,16 +516,57 @@ def test_update_heartbeat_merged_row_advances_to_latest_value(
     )
 
     iid = record_instance_start("x", host="h")
-    update_heartbeat(iid, iter=1, input_tokens=10, output_tokens=20)
-    update_heartbeat(iid, iter=2, input_tokens=30, output_tokens=40)
     # Act
+    update_heartbeat(iid, iter=1, now_fn=lambda: "2026-05-22T00:00:00Z")
+    update_heartbeat(iid, iter=2, now_fn=lambda: "2026-05-22T00:00:01Z")
     with open_db() as conn:
-        hb_row = dict(
-            conn.execute(
-                "SELECT * FROM instance_heartbeats WHERE instance_id=?",
-                (iid,),
-            ).fetchone()
-        )
+        n = conn.execute(
+            "SELECT count(*) AS n FROM instance_heartbeats WHERE instance_id=?",
+            (iid,),
+        ).fetchone()["n"]
+    # Assert — two rows; "latest" stays unambiguous via the seq PK.
+    assert n == 2
+
+
+@pytest.mark.parametrize(
+    "column, expected",
+    [("iter", 2), ("input_tokens", 30), ("output_tokens", 40)],
+)
+@pytest.mark.parametrize(
+    "second_ts",
+    ["2026-05-22T00:00:00Z", "2026-05-22T00:00:01Z"],
+    ids=["same-second", "straddle-second"],
+)
+def test_update_heartbeat_latest_row_holds_latest_value(
+    db_path: Path, column: str, expected: int, second_ts: str
+):
+    # Arrange — exercise BOTH the merge path (same ts) and the straddle
+    # path (clock ticked); "latest" must resolve to the iter=2 beat in
+    # either case. ``ts`` is pinned via now_fn so the test is
+    # deterministic instead of racing the wall clock.
+    from scitex_agent_container._state.state_db import (
+        latest_instance_heartbeat,
+        record_instance_start,
+        update_heartbeat,
+    )
+
+    iid = record_instance_start("x", host="h")
+    update_heartbeat(
+        iid,
+        iter=1,
+        input_tokens=10,
+        output_tokens=20,
+        now_fn=lambda: "2026-05-22T00:00:00Z",
+    )
+    update_heartbeat(
+        iid,
+        iter=2,
+        input_tokens=30,
+        output_tokens=40,
+        now_fn=lambda: second_ts,
+    )
+    # Act — latest is MAX(seq), not an arbitrary fetchone().
+    hb_row = latest_instance_heartbeat(iid)
     # Assert
     assert hb_row[column] == expected
 


### PR DESCRIPTION
## Problem

Intermittent (py3.12, some runs) failure:

```
tests/.../test_state_db.py::test_update_heartbeat_merged_row_advances_to_latest_value[iter-2]
→ assert 1 == 2
```

A real non-determinism bug, not noise.

## Root cause

`instance_heartbeats` PRIMARY KEY was `(instance_id, ts)` where `ts = now_iso()` is **second-resolution**. Two `update_heartbeat` calls were assumed to collapse into one row via `ON CONFLICT(instance_id, ts)`, with the merged row holding the latest values. When the wall clock ticks a second **between** the two calls, they get distinct `ts` → **two rows**, no merge, and the test's `SELECT * … fetchone()` (no `ORDER BY`) returns the arbitrary (stale, iter=1) first row → `assert 1 == 2`.

Same latent non-determinism affects every "latest heartbeat" reader (the CLI's `ts DESC` ties on second-resolution too).

Reproduced deterministically by forcing the two beats into different seconds → 2 rows, `fetchone()` returns iter=1.

## Fix (deterministic, root-level)

- **`seq INTEGER PRIMARY KEY AUTOINCREMENT`** on `instance_heartbeats` — total insertion order independent of `ts`. "Latest" is now `MAX(seq)`, unambiguous whether beats merged (same second) or straddled (two rows).
- `(instance_id, ts)` demoted to `UNIQUE` — same-second collapse still works via the `ON CONFLICT` upsert.
- New `latest_instance_heartbeat()` selects via `ORDER BY seq DESC LIMIT 1`.
- Idempotent migration rebuilds pre-`seq` DBs (`INSERT … ORDER BY rowid` preserves arrival order → monotonic `seq`).
- `update_heartbeat(..., now_fn=)` injection seam so tests pin `ts` to a real deterministic value (no mocks).

## Tests (real SQLite, AAA, one assert, no mocks)

- `collapse_two_same_second_beats_into_one_row` — pins both beats to one `ts`.
- **new** `keeps_two_rows_when_beats_straddle_a_second`.
- `latest_row_holds_latest_value` — parametrized over **same-second AND straddle-second**; asserts `iter=2` via `MAX(seq)` in both.

20/20 green with **and** without `pytest-randomly`. Migration verified end-to-end on a pre-`seq` DB.

## Refactor (line cap)

`state_db.py` was already over the 512-line cap on develop. The heartbeat write path, schema migrations, and hostname resolution are extracted into focused sibling modules (`state_db_heartbeats` / `state_db_migrations` / `state_db_hostname`), re-exported from `state_db` so existing imports keep working. `state_db.py` → 503 lines.

## Verification

- `_state` suite: 677 passed, 3 skipped.
- Full suite: 2649 passed, 38 skipped. The single failure (`a2a/test__handlers.py::test_claude_session_channels_without_port_raises`) is **pre-existing on develop** (unrelated `a2a` handler regex assertion) — confirmed failing on the clean base, another agent is already deselecting it.

## Test plan

- [x] target test 20× green, both randomly modes
- [x] migration: old DB → adds `seq`, preserves order, idempotent
- [x] full `_state` suite green
- [x] ruff clean on all touched files