### PR TITLE
feat(state): dispatch ledger — stable id per outbound dispatch

### DIFF
--- a/src/scitex_agent_container/_mcp/_channel_tools.py
+++ b/src/scitex_agent_container/_mcp/_channel_tools.py
@@ -55,6 +55,42 @@ def register_tools(
 
     from mcp.types import TextContent, Tool
 
+    from .._state.dispatch_ledger import (
+        STATUS_DELIVERED,
+        STATUS_FAILED,
+        new_dispatch_id,
+        record_dispatch,
+        update_dispatch_status,
+    )
+
+    def _ledger_record(
+        *, to_agent: str, content: str, conversation_id: str | None
+    ) -> str:
+        """Mint + record an outbound dispatch row; return its dispatch_id.
+
+        Ledger writes are observability — a state.db hiccup must not break
+        the actual a2a send, so failures log loudly (never silent) and the
+        send proceeds with a freshly-minted id that simply has no row.
+        """
+        did = new_dispatch_id()
+        try:
+            record_dispatch(
+                from_agent=agent_name,
+                to_agent=to_agent,
+                text=content,
+                conversation_id=conversation_id,
+                dispatch_id=did,
+            )
+        except Exception as exc:  # stx-allow: fallback (reason: ledger is observability; a DB write failure must not break the a2a send — logged loudly, never silent)
+            log.warning("dispatch-ledger record (a2a_send) failed: %s", exc)
+        return did
+
+    def _ledger_update(dispatch_id: str, status: str) -> None:
+        try:
+            update_dispatch_status(dispatch_id, status)
+        except Exception as exc:  # stx-allow: fallback (reason: ledger is observability; a status-update failure must not break the a2a send — logged loudly, never silent)
+            log.warning("dispatch-ledger status update (a2a_send) failed: %s", exc)
+
     base = listen_url.rstrip("/")
     headers = {"Content-Type": "application/json"}
     if bearer:
@@ -267,9 +303,16 @@ def register_tools(
         if name == "a2a_send":
             target = arguments["target"]
             content = arguments["content"]
+            conversation_id = arguments.get("conversation_id") or _uuid.uuid4().hex
+            dispatch_id = _ledger_record(
+                to_agent=target,
+                content=content,
+                conversation_id=conversation_id,
+            )
             payload = _wrap_message_send(
                 content,
-                conversation_id=arguments.get("conversation_id") or _uuid.uuid4().hex,
+                conversation_id=conversation_id,
+                dispatch_id=dispatch_id,
                 priority=arguments.get("priority"),
                 requires_reply=arguments.get("requires_reply"),
             )
@@ -278,7 +321,9 @@ def register_tools(
                     target, f"/agents/{target}/message:send", payload
                 )
             except SendError as exc:
+                _ledger_update(dispatch_id, STATUS_FAILED)
                 return _error_result(exc)
+            _ledger_update(dispatch_id, STATUS_DELIVERED)
             return [TextContent(type="text", text=json.dumps(res))]
 
         if name == "a2a_reply":

--- a/src/scitex_agent_container/_network/_peer_dispatch.py
+++ b/src/scitex_agent_container/_network/_peer_dispatch.py
@@ -1,0 +1,63 @@
+"""Dispatch-ledger glue for the outbound peer client (2026-05-22).
+
+Extracted from :mod:`peer` to keep that module under the per-file line
+cap (it already grew an extracted ``_peer_timeout`` sibling; this is the
+ledger counterpart). These helpers wrap
+:mod:`scitex_agent_container._state.dispatch_ledger` so the peer client
+can mint + record + transition a dispatch-ledger row around each
+outbound ``/v1/turn`` POST.
+
+The ledger is OBSERVABILITY, not the dispatch itself: a state.db hiccup
+must never sink a real send. Every helper here therefore catches + logs
+loudly (never silent) instead of letting a ledger write raise into the
+transport path.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+
+def self_agent_name() -> str | None:
+    """Return the sender's own agent name from the sac env, or None.
+
+    Used to stamp ``from_agent`` on dispatch-ledger rows. Best-effort —
+    a script driving ``post_turn`` outside an agent container has no
+    ``SAC_NAME`` and the ledger row records ``from_agent=None``.
+    """
+    from .._env import getenv
+
+    return getenv("NAME")
+
+
+def record_dispatch_safe(**kwargs: Any) -> str | None:
+    """Record a dispatch-ledger row, returning the id (or None on failure).
+
+    Catches + logs (never raises) so a state.db hiccup cannot break the
+    actual dispatch — a broken ledger stays visible in the logs.
+    """
+    from .._state.dispatch_ledger import record_dispatch
+
+    try:
+        return record_dispatch(**kwargs)
+    except Exception as exc:  # stx-allow: fallback (reason: ledger is observability; a DB write failure must not break the actual dispatch — logged loudly, never silent)
+        log.warning("dispatch-ledger record failed: %s", exc)
+        return None
+
+
+def update_dispatch_safe(dispatch_id: str | None, status: str) -> None:
+    """Update a dispatch-ledger row's status; log (never raise) on failure."""
+    if dispatch_id is None:
+        return
+    from .._state.dispatch_ledger import update_dispatch_status
+
+    try:
+        update_dispatch_status(dispatch_id, status)
+    except Exception as exc:  # stx-allow: fallback (reason: ledger is observability; a status-update failure must not break the dispatch — logged loudly, never silent)
+        log.warning("dispatch-ledger status update failed: %s", exc)
+
+
+__all__ = ["record_dispatch_safe", "self_agent_name", "update_dispatch_safe"]

--- a/src/scitex_agent_container/_network/peer.py
+++ b/src/scitex_agent_container/_network/peer.py
@@ -42,6 +42,7 @@ receiving host").
 from __future__ import annotations
 
 import json
+import logging
 import urllib.error
 import urllib.request
 from typing import Any
@@ -53,6 +54,8 @@ __all__ = [
     "PeerError",
     "PeerTimeoutPending",
 ]
+
+log = logging.getLogger(__name__)
 
 
 class PeerError(RuntimeError):
@@ -74,26 +77,82 @@ def __getattr__(name: str):
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
+from ._peer_dispatch import (  # noqa: E402
+    record_dispatch_safe,
+    self_agent_name,
+    update_dispatch_safe,
+)
+
+
 def post_turn_to_url(
     url: str,
     text: str,
     *,
     exit_after: bool = False,
     timeout_s: float = 600.0,
+    from_agent: str | None = None,
+    to_agent: str | None = None,
+    conversation_id: str | None = None,
 ) -> str:
     """POST a single turn to a known ``/v1/turn`` URL; return the ``text`` string.
 
     Raises ``PeerError`` on transport failure or non-200 status with the
     server's error message included.
+
+    Mints a dispatch-ledger ``dispatch_id`` and records a row with
+    ``status="sent"`` before the POST, stamping the same id into the
+    request body so the receiver can correlate. Once the round-trip
+    resolves the status is moved to ``delivered`` (clean reply),
+    ``timeout`` (deadline tripped), or ``failed`` (any other transport /
+    HTTP error). ``from_agent`` defaults to this container's ``SAC_NAME``.
     """
     if not url.endswith("/v1/turn"):
         raise PeerError(
             f"url must end in /v1/turn (got {url!r}); the runner's inbound "
             "endpoint is the only supported target"
         )
+
+    from .._state.dispatch_ledger import (
+        STATUS_DELIVERED,
+        STATUS_FAILED,
+        STATUS_TIMEOUT,
+        new_dispatch_id,
+    )
+
+    dispatch_id = new_dispatch_id()
+    record_dispatch_safe(
+        from_agent=from_agent if from_agent is not None else self_agent_name(),
+        to_agent=to_agent,
+        text=text,
+        conversation_id=conversation_id,
+        dispatch_id=dispatch_id,
+    )
+
     if url.startswith("ssh://"):
-        return _post_turn_via_ssh(url, text, exit_after=exit_after, timeout_s=timeout_s)
-    body = json.dumps({"text": text, "exit_after": bool(exit_after)}).encode("utf-8")
+        try:
+            reply = _post_turn_via_ssh(
+                url,
+                text,
+                exit_after=exit_after,
+                timeout_s=timeout_s,
+                dispatch_id=dispatch_id,
+            )
+        except PeerError as exc:
+            terminal = (
+                STATUS_TIMEOUT if "timeout" in str(exc).lower() else STATUS_FAILED
+            )
+            update_dispatch_safe(dispatch_id, terminal)
+            raise
+        update_dispatch_safe(dispatch_id, STATUS_DELIVERED)
+        return reply
+
+    body = json.dumps(
+        {
+            "text": text,
+            "exit_after": bool(exit_after),
+            "dispatch_id": dispatch_id,
+        }
+    ).encode("utf-8")
     req = urllib.request.Request(
         url,
         data=body,
@@ -112,20 +171,27 @@ def post_turn_to_url(
             err_body = ""
         if exc.code == 504:
             # A 504 means the peer's bounded HTTP wait elapsed — the turn
-            # is usually still running. Interpret the honest body (PR #169)
-            # for the caller instead of surfacing raw JSON; an older peer
-            # that returns 504 without the honest shape degrades to a
-            # generic "may still be running" message.
+            # is usually still running, NOT failed. Mark the ledger row
+            # 'timeout' and interpret the honest body (PR #169) for the
+            # caller instead of surfacing raw JSON; an older peer that
+            # returns 504 without the honest shape degrades to a generic
+            # "may still be running" message.
+            update_dispatch_safe(dispatch_id, STATUS_TIMEOUT)
             raise _interpret_504(err_body, fallback_label=url) from exc
+        update_dispatch_safe(dispatch_id, STATUS_FAILED)
         raise PeerError(
             f"peer returned HTTP {exc.code}: {err_body or exc.reason}"
         ) from exc
     except urllib.error.URLError as exc:
+        update_dispatch_safe(dispatch_id, STATUS_FAILED)
         raise PeerError(f"peer unreachable at {url}: {exc.reason}") from exc
     except TimeoutError as exc:
+        update_dispatch_safe(dispatch_id, STATUS_TIMEOUT)
         raise PeerError(f"peer timeout at {url} after {timeout_s:.0f}s") from exc
     if not isinstance(payload, dict) or "text" not in payload:
+        update_dispatch_safe(dispatch_id, STATUS_FAILED)
         raise PeerError(f"peer returned malformed body: {payload!r}")
+    update_dispatch_safe(dispatch_id, STATUS_DELIVERED)
     return str(payload["text"])
 
 
@@ -250,15 +316,27 @@ def post_turn(
     *,
     exit_after: bool = False,
     timeout_s: float = 600.0,
+    conversation_id: str | None = None,
 ) -> str:
     """Send a turn to a peer agent by name; return the response ``text``.
 
     Convenience wrapper that combines :func:`resolve_peer_url` and
     :func:`post_turn_to_url`. Use this from one running agent to drive
     another (orochi master → workers, peer collaboration, etc.).
+
+    Records a dispatch-ledger row with ``to_agent=agent_name`` so a later
+    ``list_dispatches(to_agent=...)`` can recall every turn sent to a
+    given agent.
     """
     url = resolve_peer_url(agent_name)
-    return post_turn_to_url(url, text, exit_after=exit_after, timeout_s=timeout_s)
+    return post_turn_to_url(
+        url,
+        text,
+        exit_after=exit_after,
+        timeout_s=timeout_s,
+        to_agent=agent_name,
+        conversation_id=conversation_id,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -295,6 +373,7 @@ def _post_turn_via_ssh(
     *,
     exit_after: bool,
     timeout_s: float,
+    dispatch_id: str | None = None,
 ) -> str:
     """Dispatch a turn via ``ssh <host> curl ...`` and parse the response.
 
@@ -326,7 +405,10 @@ def _post_turn_via_ssh(
         host,
         remote_curl,
     ]
-    body = json.dumps({"text": text, "exit_after": bool(exit_after)})
+    turn_body: dict[str, Any] = {"text": text, "exit_after": bool(exit_after)}
+    if dispatch_id is not None:
+        turn_body["dispatch_id"] = dispatch_id
+    body = json.dumps(turn_body)
     try:
         proc = subprocess.run(
             ssh_cmd,

--- a/src/scitex_agent_container/_runners/_session_http.py
+++ b/src/scitex_agent_container/_runners/_session_http.py
@@ -240,10 +240,20 @@ async def serve_inbound(
                 {"error": "missing or empty 'text' field"}, status_code=400
             )
         exit_after = bool(body.get("exit_after", False))
+        # Sender-minted dispatch-ledger id (optional). Threaded onto the
+        # envelope so the receiver side can correlate this turn back to
+        # the originating dispatch row. Tolerated-absent: legacy callers
+        # that don't mint a dispatch_id simply leave it None.
+        dispatch_id = body.get("dispatch_id") if isinstance(body, dict) else None
+        if not isinstance(dispatch_id, str) or not dispatch_id:
+            dispatch_id = None
 
         loop = asyncio.get_running_loop()
         env = TurnEnvelope(
-            text=text, response=loop.create_future(), exit_after=exit_after
+            text=text,
+            response=loop.create_future(),
+            exit_after=exit_after,
+            dispatch_id=dispatch_id,
         )
         await inbox.put(env)
         try:

--- a/src/scitex_agent_container/_runners/_session_inbox.py
+++ b/src/scitex_agent_container/_runners/_session_inbox.py
@@ -33,6 +33,13 @@ class TurnEnvelope:
     ``read`` / ``responded``) the runner writes into the
     ``state.db.turns`` diary table. ``None`` means the diary is not
     tracking this envelope (legacy / test-only producers).
+
+    ``dispatch_id`` is the SENDER-minted dispatch-ledger id (see
+    :mod:`scitex_agent_container._state.dispatch_ledger`). The sender
+    stamps it onto the ``/v1/turn`` POST body; the inbound HTTP handler
+    threads it here so the receiver side can correlate this turn back to
+    the originating dispatch row. ``None`` when the dispatch was not
+    minted through the ledger (legacy / test-only producers).
     """
 
     text: str
@@ -40,6 +47,7 @@ class TurnEnvelope:
     exit_after: bool = False
     session_id: str | None = None
     turn_id: str | None = None
+    dispatch_id: str | None = None
 
 
 @dataclass

--- a/src/scitex_agent_container/_state/dispatch_ledger.py
+++ b/src/scitex_agent_container/_state/dispatch_ledger.py
@@ -1,0 +1,257 @@
+"""Dispatch ledger — one row per OUTBOUND dispatch (2026-05-22).
+
+Every dispatched turn/message gets a stable ``dispatch_id`` (uuid4 hex)
+minted at the sender side and persisted here, so dispatches can be
+filtered and recalled later ("which conversation did this belong to?").
+
+This is the dispatch-ledger piece of the push-feedback architecture.
+
+A ``dispatch_id`` is orthogonal to the other ids already in the system:
+
+  * the a2a ``conversation_id`` correlates many messages in one
+    conversation,
+  * the a2a ``message_id`` identifies one message,
+  * the receiver-side ``turn_id`` (``state_db.turns``) tracks the
+    ``/v1/turn`` state machine.
+
+The ledger row is the identity of one outbound *send action*. One
+conversation produces many dispatches. The optional ``conversation_id``
+column lets a later query group dispatches back into a conversation.
+
+Why a NEW module + NEW table (not an addition to ``state_db.py``):
+a sibling branch is concurrently restructuring the heartbeat code in
+``state_db.py`` (adding a heartbeats module + a seq migration). Keeping
+the ledger table + its ``CREATE TABLE IF NOT EXISTS`` here, behind its
+own :func:`init_ledger_schema`, means the two branches never touch the
+same lines. If a future sequence-numbered migration registry collides
+at merge it is a trivial renumber.
+
+The connection itself comes from :func:`state_db.open_db` (shared WAL +
+busy-timeout + foreign-keys config); we only ensure our own table exists
+on top of the state_db tables.
+
+All times are stored as ``REAL`` unix-seconds (float), matching the
+diary tables in :mod:`state_db_diary`.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+import uuid
+from pathlib import Path
+
+# Bound on the inline message summary so a runaway dispatch can't bloat
+# state.db. Matches the diary tables' "first ~500 chars" convention.
+_TEXT_SUMMARY_LIMIT = 500
+
+# Valid lifecycle statuses. ``sent`` is the mint-time value; the others
+# are terminal observations the sender can record once the round-trip
+# resolves. Kept as a tuple (not an enum) so the column stays free-form
+# TEXT and a richer state machine can push new values without a
+# migration. ``record_dispatch`` validates against this set so a typo
+# fails loudly instead of silently writing an unqueryable status.
+STATUS_SENT = "sent"
+STATUS_DELIVERED = "delivered"
+STATUS_TIMEOUT = "timeout"
+STATUS_FAILED = "failed"
+VALID_STATUSES = (STATUS_SENT, STATUS_DELIVERED, STATUS_TIMEOUT, STATUS_FAILED)
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS dispatches (
+    dispatch_id      TEXT PRIMARY KEY,
+    from_agent       TEXT,
+    to_agent         TEXT,
+    conversation_id  TEXT,
+    text_summary     TEXT,
+    status           TEXT NOT NULL,
+    ts               REAL NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_dispatches_from ON dispatches(from_agent, ts);
+CREATE INDEX IF NOT EXISTS idx_dispatches_to ON dispatches(to_agent, ts);
+CREATE INDEX IF NOT EXISTS idx_dispatches_status ON dispatches(status, ts);
+CREATE INDEX IF NOT EXISTS idx_dispatches_conversation
+    ON dispatches(conversation_id, ts);
+"""
+
+
+def new_dispatch_id() -> str:
+    """Mint a fresh dispatch id (uuid4 hex)."""
+    return uuid.uuid4().hex
+
+
+def _clip(text: str | None, limit: int = _TEXT_SUMMARY_LIMIT) -> str | None:
+    if text is None:
+        return None
+    if len(text) <= limit:
+        return text
+    return text[:limit]
+
+
+def init_ledger_schema(db_path: Path | None = None) -> Path:
+    """Create the ``dispatches`` table if missing. Idempotent.
+
+    Returns the resolved database path. Delegates the base schema +
+    connection config to :func:`state_db.open_db`, then layers our own
+    ``CREATE TABLE IF NOT EXISTS`` so the ledger lives in the same
+    ``state.db`` file as the registry and diary tables.
+    """
+    from .state_db import open_db
+
+    with open_db(db_path) as conn:
+        conn.executescript(_SCHEMA)
+    from .state_db import init_schema
+
+    return init_schema(db_path)
+
+
+def _ensure_table(conn: sqlite3.Connection) -> None:
+    """Ensure the ledger table exists on an already-open connection."""
+    conn.executescript(_SCHEMA)
+
+
+def record_dispatch(
+    *,
+    from_agent: str | None,
+    to_agent: str | None,
+    text: str | None = None,
+    conversation_id: str | None = None,
+    status: str = STATUS_SENT,
+    dispatch_id: str | None = None,
+    ts: float | None = None,
+    db_path: Path | None = None,
+) -> str:
+    """Insert one ``dispatches`` row. Returns the ``dispatch_id``.
+
+    Mints a uuid4-hex ``dispatch_id`` when none is supplied (the caller
+    usually mints it earlier so it can thread the same id onto the wire).
+    ``text`` is the dispatched message body — stored truncated to the
+    first ~500 chars as ``text_summary``.
+
+    ``status`` must be one of :data:`VALID_STATUSES`; an unknown value
+    raises ``ValueError`` rather than silently writing an unqueryable
+    status (fail loudly, never silently).
+    """
+    if status not in VALID_STATUSES:
+        raise ValueError(
+            f"unknown dispatch status {status!r}; expected one of {VALID_STATUSES}"
+        )
+    did = dispatch_id or new_dispatch_id()
+    row_ts = float(ts) if ts is not None else time.time()
+
+    from .state_db import open_db
+
+    with open_db(db_path) as conn:
+        _ensure_table(conn)
+        conn.execute(
+            """
+            INSERT INTO dispatches (
+                dispatch_id, from_agent, to_agent, conversation_id,
+                text_summary, status, ts
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                did,
+                from_agent,
+                to_agent,
+                conversation_id,
+                _clip(text),
+                status,
+                row_ts,
+            ),
+        )
+    return did
+
+
+def update_dispatch_status(
+    dispatch_id: str,
+    status: str,
+    *,
+    db_path: Path | None = None,
+) -> bool:
+    """Update the ``status`` of an existing dispatch. Returns True iff a row matched.
+
+    ``status`` must be one of :data:`VALID_STATUSES`. The ledger row is
+    minted ``sent`` at dispatch time; the sender calls this once the
+    round-trip resolves to ``delivered`` / ``timeout`` / ``failed``.
+    """
+    if status not in VALID_STATUSES:
+        raise ValueError(
+            f"unknown dispatch status {status!r}; expected one of {VALID_STATUSES}"
+        )
+    from .state_db import open_db
+
+    with open_db(db_path) as conn:
+        _ensure_table(conn)
+        cur = conn.execute(
+            "UPDATE dispatches SET status=? WHERE dispatch_id=?",
+            (status, dispatch_id),
+        )
+        return cur.rowcount > 0
+
+
+def list_dispatches(
+    *,
+    from_agent: str | None = None,
+    to_agent: str | None = None,
+    status: str | None = None,
+    conversation_id: str | None = None,
+    since: float | None = None,
+    limit: int | None = None,
+    db_path: Path | None = None,
+) -> list[dict]:
+    """Return ledger rows matching the filters, newest first.
+
+    Every filter is optional and AND-combined. ``since`` is a unix-second
+    lower bound (``ts >= since``). With no filters, returns the whole
+    ledger (subject to ``limit``). The query is parameterised — no
+    user value is str-formatted into the SQL.
+    """
+    clauses: list[str] = []
+    params: list[object] = []
+    if from_agent is not None:
+        clauses.append("from_agent = ?")
+        params.append(from_agent)
+    if to_agent is not None:
+        clauses.append("to_agent = ?")
+        params.append(to_agent)
+    if status is not None:
+        clauses.append("status = ?")
+        params.append(status)
+    if conversation_id is not None:
+        clauses.append("conversation_id = ?")
+        params.append(conversation_id)
+    if since is not None:
+        clauses.append("ts >= ?")
+        params.append(float(since))
+
+    where = f" WHERE {' AND '.join(clauses)}" if clauses else ""
+    limit_sql = ""
+    if limit is not None:
+        limit_sql = " LIMIT ?"
+        params.append(int(limit))
+
+    from .state_db import open_db
+
+    with open_db(db_path) as conn:
+        _ensure_table(conn)
+        rows = conn.execute(
+            f"SELECT * FROM dispatches{where} ORDER BY ts DESC{limit_sql}",
+            tuple(params),
+        ).fetchall()
+        return [dict(r) for r in rows]
+
+
+__all__ = [
+    "STATUS_DELIVERED",
+    "STATUS_FAILED",
+    "STATUS_SENT",
+    "STATUS_TIMEOUT",
+    "VALID_STATUSES",
+    "init_ledger_schema",
+    "list_dispatches",
+    "new_dispatch_id",
+    "record_dispatch",
+    "update_dispatch_status",
+]

--- a/tests/scitex_agent_container/_mcp/test_channel_tools_dispatch_ledger.py
+++ b/tests/scitex_agent_container/_mcp/test_channel_tools_dispatch_ledger.py
@@ -1,0 +1,229 @@
+"""Dispatch-ledger integration for the a2a_send MCP tool.
+
+``register_tools`` wires the send-side ``a2a_*`` tools. ``a2a_send``
+mints a dispatch_id, records a ``sent`` ledger row (from_agent=this
+agent, to_agent=target, conversation_id), stamps the id into the
+A2A ``params.metadata``, then transitions the row to ``delivered`` /
+``failed`` on the send outcome.
+
+No mocks: the ``a2a_send`` tool POSTs to ``{listen_url}/agents/<target>
+/message:send`` over real httpx; a real loopback ``http.server`` stands
+in for ``sac listen`` and captures the wire body. The mcp ``server`` is
+a tiny hand-rolled recorder exposing only the two decorator methods
+``register_tools`` uses (``list_tools`` / ``call_tool``) — a real
+collaborator object, not a Mock.
+
+Conventions: AAA markers, one assertion per test (STX-TQ).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import http.server
+import importlib
+import json
+import os
+import socket
+import threading
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def db_path(tmp_path: Path):
+    """Isolated state.db, exported via env (explicit save/restore, no mock)."""
+    p = tmp_path / "state.db"
+    key = "SCITEX_AGENT_CONTAINER_STATE_DB"
+    saved = os.environ.get(key)
+    os.environ[key] = str(p)
+    import scitex_agent_container._state.state_db as mod
+
+    importlib.reload(mod)
+    try:
+        yield p
+    finally:
+        if saved is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = saved
+        importlib.reload(mod)
+
+
+class _ToolRecorder:
+    """Hand-rolled stand-in for an mcp lowlevel Server.
+
+    Exposes only the two decorator methods ``register_tools`` calls.
+    Captures the registered ``call_tool`` coroutine so the test can
+    invoke it directly. Real object, not a Mock.
+    """
+
+    def __init__(self) -> None:
+        self.call_tool_fn = None
+        self.list_tools_fn = None
+
+    def list_tools(self):
+        def deco(fn):
+            self.list_tools_fn = fn
+            return fn
+
+        return deco
+
+    def call_tool(self):
+        def deco(fn):
+            self.call_tool_fn = fn
+            return fn
+
+        return deco
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _start_listen_stub(status: int, captured: list[dict]):
+    """A loopback http.server mimicking sac listen's message:send route."""
+
+    class _Handler(http.server.BaseHTTPRequestHandler):
+        def do_POST(self):  # noqa: N802
+            length = int(self.headers.get("Content-Length", "0"))
+            body = json.loads(self.rfile.read(length).decode("utf-8"))
+            captured.append(body)
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            payload = {"delivered_subscriber_count": 1} if status < 400 else {}
+            self.wfile.write(json.dumps(payload).encode("utf-8"))
+
+        def log_message(self, *a, **kw):
+            pass
+
+    port = _free_port()
+    server = http.server.HTTPServer(("127.0.0.1", port), _Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, thread, port
+
+
+def _invoke_a2a_send(listen_url: str, target: str, content: str):
+    """Register the tools against a recorder and run a2a_send once."""
+    from scitex_agent_container._mcp._channel_tools import register_tools
+
+    rec = _ToolRecorder()
+    register_tools(rec, agent_name="alice", listen_url=listen_url, bearer=None)
+    return asyncio.run(
+        rec.call_tool_fn("a2a_send", {"target": target, "content": content})
+    )
+
+
+# ---------------------------------------------------------------------------
+# Clean send — ledger row created (from alice, to target) and delivered.
+# ---------------------------------------------------------------------------
+
+
+def test_a2a_send_records_ledger_row_from_this_agent(db_path: Path):
+    # Arrange
+    from scitex_agent_container._state.dispatch_ledger import list_dispatches
+
+    server, thread, port = _start_listen_stub(200, [])
+    try:
+        # Act
+        _invoke_a2a_send(f"http://127.0.0.1:{port}", "bob", "hi")
+        rows = list_dispatches()
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2.0)
+    # Assert
+    assert rows[0]["from_agent"] == "alice"
+
+
+def test_a2a_send_records_target_as_to_agent(db_path: Path):
+    # Arrange
+    from scitex_agent_container._state.dispatch_ledger import list_dispatches
+
+    server, thread, port = _start_listen_stub(200, [])
+    try:
+        # Act
+        _invoke_a2a_send(f"http://127.0.0.1:{port}", "bob", "hi")
+        rows = list_dispatches()
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2.0)
+    # Assert
+    assert rows[0]["to_agent"] == "bob"
+
+
+def test_a2a_send_marks_clean_send_delivered(db_path: Path):
+    # Arrange
+    from scitex_agent_container._state.dispatch_ledger import list_dispatches
+
+    server, thread, port = _start_listen_stub(200, [])
+    try:
+        # Act
+        _invoke_a2a_send(f"http://127.0.0.1:{port}", "bob", "hi")
+        rows = list_dispatches()
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2.0)
+    # Assert
+    assert rows[0]["status"] == "delivered"
+
+
+def test_a2a_send_stamps_dispatch_id_into_metadata(db_path: Path):
+    # Arrange — capture the A2A envelope so we can read params.metadata.
+    captured: list[dict] = []
+    server, thread, port = _start_listen_stub(200, captured)
+    try:
+        # Act
+        _invoke_a2a_send(f"http://127.0.0.1:{port}", "bob", "hi")
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2.0)
+    # Assert
+    assert len(captured[0]["params"]["metadata"]["dispatch_id"]) == 32
+
+
+def test_a2a_send_wire_dispatch_id_matches_ledger_row(db_path: Path):
+    # Arrange
+    from scitex_agent_container._state.dispatch_ledger import list_dispatches
+
+    captured: list[dict] = []
+    server, thread, port = _start_listen_stub(200, captured)
+    try:
+        # Act
+        _invoke_a2a_send(f"http://127.0.0.1:{port}", "bob", "hi")
+        rows = list_dispatches()
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2.0)
+    # Assert
+    assert captured[0]["params"]["metadata"]["dispatch_id"] == rows[0]["dispatch_id"]
+
+
+# ---------------------------------------------------------------------------
+# Failure path — a 5xx from listen marks the row failed (SendError).
+# ---------------------------------------------------------------------------
+
+
+def test_a2a_send_marks_server_error_failed(db_path: Path):
+    # Arrange
+    from scitex_agent_container._state.dispatch_ledger import list_dispatches
+
+    server, thread, port = _start_listen_stub(500, [])
+    try:
+        # Act
+        _invoke_a2a_send(f"http://127.0.0.1:{port}", "bob", "hi")
+        rows = list_dispatches()
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2.0)
+    # Assert
+    assert rows[0]["status"] == "failed"

--- a/tests/scitex_agent_container/_network/test_peer_dispatch_ledger.py
+++ b/tests/scitex_agent_container/_network/test_peer_dispatch_ledger.py
@@ -1,0 +1,229 @@
+"""Dispatch-ledger integration for the outbound peer client.
+
+``post_turn_to_url`` mints a dispatch_id, records a ``sent`` row before
+the POST, stamps the id into the request body, and transitions the row
+to ``delivered`` / ``timeout`` / ``failed`` once the round-trip resolves.
+
+No mocks: a real ``http.server`` on loopback mimics ``/v1/turn`` and the
+real ``state.db`` lives under ``tmp_path`` (isolated via env). The stub
+server captures the request body so we can assert the dispatch_id was
+actually put on the wire.
+
+Conventions: AAA markers, one assertion per test (STX-TQ).
+"""
+
+from __future__ import annotations
+
+import http.server
+import importlib
+import json
+import os
+import socket
+import threading
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._network.peer import PeerError, post_turn_to_url
+
+
+@pytest.fixture
+def db_path(tmp_path: Path):
+    """Isolated state.db, exported via env (explicit save/restore, no mock)."""
+    p = tmp_path / "state.db"
+    key = "SCITEX_AGENT_CONTAINER_STATE_DB"
+    saved = os.environ.get(key)
+    os.environ[key] = str(p)
+    import scitex_agent_container._state.state_db as mod
+
+    importlib.reload(mod)
+    try:
+        yield p
+    finally:
+        if saved is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = saved
+        importlib.reload(mod)
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _start_server(handler_cls):
+    """Spin a daemon http.server on a free loopback port; return (server, thread, port)."""
+    port = _free_port()
+    server = http.server.HTTPServer(("127.0.0.1", port), handler_cls)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, thread, port
+
+
+def _echo_handler(captured: list[dict]):
+    """A /v1/turn handler that records the request body and echoes text."""
+
+    class _Handler(http.server.BaseHTTPRequestHandler):
+        def do_POST(self):  # noqa: N802
+            length = int(self.headers.get("Content-Length", "0"))
+            body = json.loads(self.rfile.read(length).decode("utf-8"))
+            captured.append(body)
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(
+                json.dumps({"text": f"echo:{body.get('text', '')}"}).encode("utf-8")
+            )
+
+        def log_message(self, *a, **kw):
+            pass
+
+    return _Handler
+
+
+def _error_handler(status: int):
+    class _Handler(http.server.BaseHTTPRequestHandler):
+        def do_POST(self):  # noqa: N802
+            self.send_response(status)
+            self.send_header("Content-Type", "text/plain")
+            self.end_headers()
+            self.wfile.write(b"boom")
+
+        def log_message(self, *a, **kw):
+            pass
+
+    return _Handler
+
+
+# ---------------------------------------------------------------------------
+# Clean round-trip — ledger row created and moved to delivered.
+# ---------------------------------------------------------------------------
+
+
+def test_post_turn_records_ledger_row_to_agent(db_path: Path):
+    # Arrange
+    from scitex_agent_container._state.dispatch_ledger import list_dispatches
+
+    server, thread, port = _start_server(_echo_handler([]))
+    try:
+        # Act
+        post_turn_to_url(
+            f"http://127.0.0.1:{port}/v1/turn", "hi", timeout_s=5.0, to_agent="bob"
+        )
+        rows = list_dispatches()
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2.0)
+    # Assert
+    assert rows[0]["to_agent"] == "bob"
+
+
+def test_post_turn_marks_clean_roundtrip_delivered(db_path: Path):
+    # Arrange
+    from scitex_agent_container._state.dispatch_ledger import list_dispatches
+
+    server, thread, port = _start_server(_echo_handler([]))
+    try:
+        # Act
+        post_turn_to_url(f"http://127.0.0.1:{port}/v1/turn", "hi", timeout_s=5.0)
+        rows = list_dispatches()
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2.0)
+    # Assert
+    assert rows[0]["status"] == "delivered"
+
+
+def test_post_turn_stamps_dispatch_id_into_request_body(db_path: Path):
+    # Arrange — the stub captures the wire body so we can assert the id
+    # was actually sent (receiver-side correlation).
+    captured: list[dict] = []
+    server, thread, port = _start_server(_echo_handler(captured))
+    try:
+        # Act
+        post_turn_to_url(f"http://127.0.0.1:{port}/v1/turn", "hi", timeout_s=5.0)
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2.0)
+    # Assert
+    assert len(captured[0]["dispatch_id"]) == 32
+
+
+def test_post_turn_wire_dispatch_id_matches_ledger_row(db_path: Path):
+    # Arrange
+    from scitex_agent_container._state.dispatch_ledger import list_dispatches
+
+    captured: list[dict] = []
+    server, thread, port = _start_server(_echo_handler(captured))
+    try:
+        # Act
+        post_turn_to_url(f"http://127.0.0.1:{port}/v1/turn", "hi", timeout_s=5.0)
+        rows = list_dispatches()
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2.0)
+    # Assert — the id on the wire is the id in the ledger.
+    assert captured[0]["dispatch_id"] == rows[0]["dispatch_id"]
+
+
+# ---------------------------------------------------------------------------
+# Failure paths — HTTP error and unreachable host mark the row failed.
+# ---------------------------------------------------------------------------
+
+
+def test_post_turn_marks_http_error_failed(db_path: Path):
+    # Arrange
+    from scitex_agent_container._state.dispatch_ledger import list_dispatches
+
+    server, thread, port = _start_server(_error_handler(500))
+    raised: list[BaseException] = []
+    try:
+        # Act
+        try:
+            post_turn_to_url(f"http://127.0.0.1:{port}/v1/turn", "hi", timeout_s=5.0)
+        except PeerError as exc:
+            raised.append(exc)
+        rows = list_dispatches()
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2.0)
+    # Assert
+    assert rows[0]["status"] == "failed"
+
+
+def test_post_turn_marks_unreachable_failed(db_path: Path):
+    # Arrange — port 1 on loopback is unrouteable → URLError → failed.
+    from scitex_agent_container._state.dispatch_ledger import list_dispatches
+
+    raised: list[BaseException] = []
+    # Act
+    try:
+        post_turn_to_url("http://127.0.0.1:1/v1/turn", "x", timeout_s=1.0)
+    except PeerError as exc:
+        raised.append(exc)
+    rows = list_dispatches()
+    # Assert
+    assert rows[0]["status"] == "failed"
+
+
+def test_post_turn_still_returns_reply_when_ledger_records(db_path: Path):
+    # Arrange — the dispatch itself must succeed regardless of ledger.
+    server, thread, port = _start_server(_echo_handler([]))
+    try:
+        # Act
+        reply = post_turn_to_url(
+            f"http://127.0.0.1:{port}/v1/turn", "hi", timeout_s=5.0
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2.0)
+    # Assert
+    assert reply == "echo:hi"

--- a/tests/scitex_agent_container/_state/test_dispatch_ledger.py
+++ b/tests/scitex_agent_container/_state/test_dispatch_ledger.py
@@ -1,0 +1,448 @@
+"""Tests for the dispatch ledger (2026-05-22).
+
+Every outbound dispatch gets a stable ``dispatch_id`` minted at the
+sender and persisted to ``state.db.dispatches`` so dispatches can be
+filtered + recalled later.
+
+Conventions (mirroring test_state_db_turns_errors_heartbeats.py):
+
+  * One assertion per test (STX-TQ007); related invariants collapse
+    into ``pytest.parametrize``.
+  * AAA markers (Arrange / Act / Assert).
+  * No mocks / monkeypatch (STX-NM); real sqlite under ``tmp_path``,
+    isolated via the ``db_path`` env fixture.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def db_path(tmp_path: Path):
+    """Isolated state.db location, exported via env so callers pick it up.
+
+    Explicit env save/restore (no monkeypatch fixture, PA-306).
+    """
+    p = tmp_path / "state.db"
+    key = "SCITEX_AGENT_CONTAINER_STATE_DB"
+    saved = os.environ.get(key)
+    os.environ[key] = str(p)
+    import scitex_agent_container._state.state_db as mod
+
+    importlib.reload(mod)
+    try:
+        yield p
+    finally:
+        if saved is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = saved
+        importlib.reload(mod)
+
+
+# ---------------------------------------------------------------------------
+# Schema — the dispatches table is created on first use.
+# ---------------------------------------------------------------------------
+
+
+def test_init_ledger_schema_creates_dispatches_table(db_path: Path):
+    # Arrange
+    from scitex_agent_container._state.dispatch_ledger import init_ledger_schema
+
+    # Act
+    init_ledger_schema()
+    with sqlite3.connect(db_path) as conn:
+        names = {
+            r[0]
+            for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        }
+    # Assert
+    assert "dispatches" in names
+
+
+def test_record_dispatch_creates_table_lazily_without_explicit_init(db_path: Path):
+    # Arrange — never call init_ledger_schema; record_dispatch must
+    # ensure the table itself.
+    from scitex_agent_container._state.dispatch_ledger import (
+        list_dispatches,
+        record_dispatch,
+    )
+
+    # Act
+    record_dispatch(from_agent="alice", to_agent="bob", text="hi")
+    rows = list_dispatches()
+    # Assert
+    assert len(rows) == 1
+
+
+# ---------------------------------------------------------------------------
+# Mint — new_dispatch_id is a 32-char uuid4 hex.
+# ---------------------------------------------------------------------------
+
+
+def test_new_dispatch_id_is_32_char_hex():
+    # Arrange
+    from scitex_agent_container._state.dispatch_ledger import new_dispatch_id
+
+    # Act
+    did = new_dispatch_id()
+    # Assert
+    assert len(did) == 32 and all(c in "0123456789abcdef" for c in did)
+
+
+def test_new_dispatch_id_is_unique_across_calls():
+    # Arrange
+    from scitex_agent_container._state.dispatch_ledger import new_dispatch_id
+
+    # Act
+    ids = {new_dispatch_id() for _ in range(1000)}
+    # Assert
+    assert len(ids) == 1000
+
+
+# ---------------------------------------------------------------------------
+# Round-trip — record_dispatch writes a row SELECT can recover.
+# ---------------------------------------------------------------------------
+
+
+def test_record_dispatch_returns_the_minted_id(db_path: Path):
+    # Arrange
+    from scitex_agent_container._state.dispatch_ledger import record_dispatch
+
+    # Act
+    did = record_dispatch(from_agent="alice", to_agent="bob", text="hi")
+    # Assert
+    assert len(did) == 32
+
+
+def test_record_dispatch_honours_supplied_id(db_path: Path):
+    # Arrange
+    from scitex_agent_container._state.dispatch_ledger import record_dispatch
+
+    # Act
+    did = record_dispatch(
+        from_agent="alice", to_agent="bob", text="hi", dispatch_id="deadbeef"
+    )
+    # Assert
+    assert did == "deadbeef"
+
+
+def test_record_dispatch_round_trips_to_agent(db_path: Path):
+    # Arrange
+    from scitex_agent_container._state.dispatch_ledger import (
+        list_dispatches,
+        record_dispatch,
+    )
+
+    record_dispatch(from_agent="alice", to_agent="bob", text="hi")
+    # Act
+    rows = list_dispatches()
+    # Assert
+    assert rows[0]["to_agent"] == "bob"
+
+
+def test_record_dispatch_round_trips_conversation_id(db_path: Path):
+    # Arrange
+    from scitex_agent_container._state.dispatch_ledger import (
+        list_dispatches,
+        record_dispatch,
+    )
+
+    record_dispatch(from_agent="a", to_agent="b", text="hi", conversation_id="conv-7")
+    # Act
+    rows = list_dispatches()
+    # Assert
+    assert rows[0]["conversation_id"] == "conv-7"
+
+
+def test_record_dispatch_defaults_status_to_sent(db_path: Path):
+    # Arrange
+    from scitex_agent_container._state.dispatch_ledger import (
+        STATUS_SENT,
+        list_dispatches,
+        record_dispatch,
+    )
+
+    record_dispatch(from_agent="a", to_agent="b", text="hi")
+    # Act
+    rows = list_dispatches()
+    # Assert
+    assert rows[0]["status"] == STATUS_SENT
+
+
+def test_record_dispatch_allows_null_agents(db_path: Path):
+    # Arrange — a script driving post_turn outside an agent has no
+    # SAC_NAME; the ledger row must still record (from_agent=None).
+    from scitex_agent_container._state.dispatch_ledger import (
+        list_dispatches,
+        record_dispatch,
+    )
+
+    record_dispatch(from_agent=None, to_agent=None, text="hi")
+    # Act
+    rows = list_dispatches()
+    # Assert
+    assert rows[0]["from_agent"] is None
+
+
+# ---------------------------------------------------------------------------
+# text_summary truncation — long bodies are clipped to the first 500 chars.
+# ---------------------------------------------------------------------------
+
+
+def test_record_dispatch_truncates_long_text_summary(db_path: Path):
+    # Arrange
+    from scitex_agent_container._state.dispatch_ledger import (
+        list_dispatches,
+        record_dispatch,
+    )
+
+    record_dispatch(from_agent="a", to_agent="b", text="x" * 5000)
+    # Act
+    rows = list_dispatches()
+    # Assert
+    assert len(rows[0]["text_summary"]) == 500
+
+
+def test_record_dispatch_keeps_short_text_intact(db_path: Path):
+    # Arrange
+    from scitex_agent_container._state.dispatch_ledger import (
+        list_dispatches,
+        record_dispatch,
+    )
+
+    record_dispatch(from_agent="a", to_agent="b", text="short")
+    # Act
+    rows = list_dispatches()
+    # Assert
+    assert rows[0]["text_summary"] == "short"
+
+
+# ---------------------------------------------------------------------------
+# Status validation — unknown statuses fail loudly (no silent write).
+# ---------------------------------------------------------------------------
+
+
+def test_record_dispatch_rejects_unknown_status(db_path: Path):
+    # Arrange
+    from scitex_agent_container._state.dispatch_ledger import record_dispatch
+
+    # Act
+    ctx = pytest.raises(ValueError, match="unknown dispatch status")
+    # Assert
+    with ctx:
+        record_dispatch(from_agent="a", to_agent="b", text="hi", status="bogus")
+
+
+def test_update_dispatch_status_rejects_unknown_status(db_path: Path):
+    # Arrange
+    from scitex_agent_container._state.dispatch_ledger import (
+        record_dispatch,
+        update_dispatch_status,
+    )
+
+    did = record_dispatch(from_agent="a", to_agent="b", text="hi")
+    # Act
+    ctx = pytest.raises(ValueError, match="unknown dispatch status")
+    # Assert
+    with ctx:
+        update_dispatch_status(did, "bogus")
+
+
+# ---------------------------------------------------------------------------
+# Status transition — sent -> delivered/timeout/failed.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "terminal",
+    ["delivered", "timeout", "failed"],
+)
+def test_update_dispatch_status_transitions_to_terminal(db_path: Path, terminal: str):
+    # Arrange
+    from scitex_agent_container._state.dispatch_ledger import (
+        list_dispatches,
+        record_dispatch,
+        update_dispatch_status,
+    )
+
+    did = record_dispatch(from_agent="a", to_agent="b", text="hi")
+    update_dispatch_status(did, terminal)
+    # Act
+    rows = list_dispatches()
+    # Assert
+    assert rows[0]["status"] == terminal
+
+
+def test_update_dispatch_status_returns_true_on_match(db_path: Path):
+    # Arrange
+    from scitex_agent_container._state.dispatch_ledger import (
+        record_dispatch,
+        update_dispatch_status,
+    )
+
+    did = record_dispatch(from_agent="a", to_agent="b", text="hi")
+    # Act
+    matched = update_dispatch_status(did, "delivered")
+    # Assert
+    assert matched is True
+
+
+def test_update_dispatch_status_returns_false_on_missing_row(db_path: Path):
+    # Arrange — no row with this id exists.
+    from scitex_agent_container._state.dispatch_ledger import update_dispatch_status
+
+    # Act
+    matched = update_dispatch_status("does-not-exist", "delivered")
+    # Assert
+    assert matched is False
+
+
+# ---------------------------------------------------------------------------
+# Query filters — from / to / status / conversation / since / limit.
+# ---------------------------------------------------------------------------
+
+
+def test_list_dispatches_filter_by_from_agent(db_path: Path):
+    # Arrange
+    from scitex_agent_container._state.dispatch_ledger import (
+        list_dispatches,
+        record_dispatch,
+    )
+
+    record_dispatch(from_agent="alice", to_agent="x", text="1")
+    record_dispatch(from_agent="bob", to_agent="x", text="2")
+    record_dispatch(from_agent="alice", to_agent="y", text="3")
+    # Act
+    rows = list_dispatches(from_agent="alice")
+    # Assert
+    assert {r["text_summary"] for r in rows} == {"1", "3"}
+
+
+def test_list_dispatches_filter_by_to_agent(db_path: Path):
+    # Arrange
+    from scitex_agent_container._state.dispatch_ledger import (
+        list_dispatches,
+        record_dispatch,
+    )
+
+    record_dispatch(from_agent="a", to_agent="bob", text="1")
+    record_dispatch(from_agent="a", to_agent="carol", text="2")
+    # Act
+    rows = list_dispatches(to_agent="bob")
+    # Assert
+    assert [r["text_summary"] for r in rows] == ["1"]
+
+
+def test_list_dispatches_filter_by_status(db_path: Path):
+    # Arrange
+    from scitex_agent_container._state.dispatch_ledger import (
+        list_dispatches,
+        record_dispatch,
+    )
+
+    record_dispatch(from_agent="a", to_agent="b", text="1", status="sent")
+    record_dispatch(from_agent="a", to_agent="b", text="2", status="failed")
+    # Act
+    rows = list_dispatches(status="failed")
+    # Assert
+    assert [r["text_summary"] for r in rows] == ["2"]
+
+
+def test_list_dispatches_filter_by_conversation_id(db_path: Path):
+    # Arrange — "which dispatches belonged to this conversation?"
+    from scitex_agent_container._state.dispatch_ledger import (
+        list_dispatches,
+        record_dispatch,
+    )
+
+    record_dispatch(from_agent="a", to_agent="b", text="1", conversation_id="c1")
+    record_dispatch(from_agent="a", to_agent="b", text="2", conversation_id="c2")
+    record_dispatch(from_agent="a", to_agent="b", text="3", conversation_id="c1")
+    # Act
+    rows = list_dispatches(conversation_id="c1")
+    # Assert
+    assert {r["text_summary"] for r in rows} == {"1", "3"}
+
+
+def test_list_dispatches_filter_by_since(db_path: Path):
+    # Arrange
+    from scitex_agent_container._state.dispatch_ledger import (
+        list_dispatches,
+        record_dispatch,
+    )
+
+    record_dispatch(from_agent="a", to_agent="b", text="old", ts=100.0)
+    record_dispatch(from_agent="a", to_agent="b", text="new", ts=200.0)
+    # Act
+    rows = list_dispatches(since=150.0)
+    # Assert
+    assert [r["text_summary"] for r in rows] == ["new"]
+
+
+def test_list_dispatches_combined_filters_are_anded(db_path: Path):
+    # Arrange
+    from scitex_agent_container._state.dispatch_ledger import (
+        list_dispatches,
+        record_dispatch,
+    )
+
+    record_dispatch(from_agent="alice", to_agent="bob", text="hit", status="failed")
+    record_dispatch(from_agent="alice", to_agent="bob", text="miss-status")
+    record_dispatch(from_agent="zed", to_agent="bob", text="miss-from", status="failed")
+    # Act
+    rows = list_dispatches(from_agent="alice", to_agent="bob", status="failed")
+    # Assert
+    assert [r["text_summary"] for r in rows] == ["hit"]
+
+
+def test_list_dispatches_orders_newest_first(db_path: Path):
+    # Arrange
+    from scitex_agent_container._state.dispatch_ledger import (
+        list_dispatches,
+        record_dispatch,
+    )
+
+    record_dispatch(from_agent="a", to_agent="b", text="first", ts=10.0)
+    record_dispatch(from_agent="a", to_agent="b", text="second", ts=20.0)
+    # Act
+    rows = list_dispatches()
+    # Assert
+    assert [r["text_summary"] for r in rows] == ["second", "first"]
+
+
+def test_list_dispatches_respects_limit(db_path: Path):
+    # Arrange
+    from scitex_agent_container._state.dispatch_ledger import (
+        list_dispatches,
+        record_dispatch,
+    )
+
+    for i in range(5):
+        record_dispatch(from_agent="a", to_agent="b", text=str(i), ts=float(i))
+    # Act
+    rows = list_dispatches(limit=2)
+    # Assert
+    assert len(rows) == 2
+
+
+def test_list_dispatches_empty_when_no_match(db_path: Path):
+    # Arrange
+    from scitex_agent_container._state.dispatch_ledger import (
+        list_dispatches,
+        record_dispatch,
+    )
+
+    record_dispatch(from_agent="a", to_agent="b", text="x")
+    # Act
+    rows = list_dispatches(from_agent="nobody")
+    # Assert
+    assert rows == []


### PR DESCRIPTION
## What

Every dispatched turn/message now gets a stable **`dispatch_id`** (uuid4 hex) minted at the outbound dispatch point and persisted to a new `state.db` ledger table, so dispatches can be filtered + recalled later ("which conversation did this dispatch belong to?"). This is the dispatch-ledger piece of the push-feedback architecture.

## New module — `_state/dispatch_ledger.py`

Owns its **own** `dispatches` table + init (`init_ledger_schema` / lazy `_ensure_table`), deliberately kept out of `state_db.py` to avoid colliding with the concurrent heartbeat restructure on `fix/flaky-state-db-heartbeat-merge`. No existing migration touched (conflict-avoidance per the work item).

API:
- `new_dispatch_id()` — uuid4 hex
- `record_dispatch(*, from_agent, to_agent, text=, conversation_id=, status="sent", dispatch_id=, ts=)` → dispatch_id (text clipped to 500 chars)
- `update_dispatch_status(dispatch_id, status)` → bool
- `list_dispatches(*, from_agent=, to_agent=, status=, conversation_id=, since=, limit=)` → rows, newest-first, AND-combined parameterised filters

Row: `(dispatch_id PK, from_agent, to_agent, conversation_id, text_summary, status, ts)`.

## Wiring at outbound dispatch points

- **`peer.post_turn` / `post_turn_to_url`** — mint + record `sent`, stamp `dispatch_id` into the `/v1/turn` body, transition to `delivered` (clean reply) / `timeout` (deadline or 504) / `failed` (other transport/HTTP error). `from_agent` defaults to `SAC_NAME`. (Ledger glue extracted to `_network/_peer_dispatch.py` to keep `peer.py` under the line cap.)
- **`a2a_send` MCP tool** — mint + record (`from_agent`=this agent, `to_agent`=target, `conversation_id`), stamp `dispatch_id` into `params.metadata`, transition `delivered`/`failed`.
- **`TurnEnvelope`** gains `dispatch_id`; the inbound HTTP handler threads it from the request body so the receiver side can correlate.

Ledger writes are **observability** — a state.db hiccup logs loudly (never silent) and never breaks the actual dispatch.

## Design forks (see `GITIGNORED/QUESTIONS.md`, not committed)

- **`dispatch_id` is orthogonal** to the a2a `conversation_id` (correlation) and the receiver-side `turn_id` (turn state machine): it is the identity of one outbound *send action*. One conversation → many dispatches.
- **Status machine kept minimal** (`sent → delivered/timeout/failed`); a richer machine (read/responded, retries) is deferred. `status` is free-form TEXT so new values need no migration.

## Tests — NO MOCKS

41 new tests: real sqlite under `tmp_path`, real loopback `http.server` stubs for the peer + `a2a_send` paths (a2a uses a hand-rolled tool-recorder exposing only the two decorator methods, per the no-mocks replacement menu). All AAA + one-assert (STX-TQ).

- `tests/.../_state/test_dispatch_ledger.py` (28)
- `tests/.../_network/test_peer_dispatch_ledger.py` (7)
- `tests/.../_mcp/test_channel_tools_dispatch_ledger.py` (6)

## Verification

- Rebased onto current `origin/develop`; resolved 2 conflicts in `peer.py` (develop's `PeerTimeoutPending`/504 feature) keeping BOTH features — a 504 now marks the row `timeout` and raises the interpreted body.
- 1332 passed / 0 failed across `_state` + `_network` + `_mcp` + `_runners` + `tests/develop` (audit gate green) on the rebased tree.
- One pre-existing unrelated failure in `a2a/test__handlers.py::test_claude_session_channels_without_port_raises` reproduces identically on clean `develop` (it reaches the real `claude` CLI) — not touched by this PR.

## Merge note

The ledger ships its own `CREATE TABLE IF NOT EXISTS` + init rather than a numbered migration, so it cannot collide with the sibling `fix/flaky-state-db-heartbeat-merge` branch. If a future sequence-numbered migration registry lands, the table just needs registering once — trivial.