### PR TITLE
fix(claude-session): log session_id forks + append-only history with resume fallback

### DIFF
--- a/src/scitex_agent_container/_runners/_session_conversation.py
+++ b/src/scitex_agent_container/_runners/_session_conversation.py
@@ -26,6 +26,7 @@ from ._session_state import (
     accumulate_quota,
     append_session_message,
     read_session_id,
+    read_session_id_history,
     record_turn_transition,
     report_sdk_error,
     write_heartbeat,
@@ -52,6 +53,35 @@ def _drain_failed_inbox(inbox: "asyncio.Queue", exc: BaseException) -> None:
             break
         if isinstance(env, TurnEnvelope) and not env.response.done():
             env.response.set_exception(exc)
+
+
+def _resume_candidate(
+    state_dir: Path,
+    *,
+    attempt: int,
+    fallback: str | None,
+) -> str | None:
+    """Pick the resume session_id for supervisor restart ``attempt``.
+
+    Walks the append-only ``session_id_history`` from latest to oldest:
+    ``attempt`` 0 → latest, 1 → next-older, etc. This lets a supervised
+    restart retry a prior still-on-disk id when the latest one was
+    forked or aged out and its resume is rejected.
+
+    - ``attempt`` within the history range → that id (latest-first).
+    - ``attempt == 0`` with no history yet → ``read_session_id`` if
+      present else ``fallback`` (preserves the pre-history behaviour for
+      the very first start, before any turn has recorded an id).
+    - ``attempt`` beyond the history → ``None`` (history exhausted →
+      fresh start, resume disabled).
+    """
+    history = read_session_id_history(state_dir)
+    candidates = list(reversed(history))  # latest-first
+    if attempt < len(candidates):
+        return candidates[attempt]
+    if attempt == 0:
+        return read_session_id(state_dir) or fallback
+    return None
 
 
 async def _drive_turn(
@@ -127,6 +157,23 @@ async def _drive_turn(
             elif isinstance(msg, ResultMessage):
                 sid = getattr(msg, "session_id", None)
                 if sid:
+                    # Fork detection: the SDK can return a NEW session id
+                    # on resume instead of the one we asked it to resume
+                    # (a fork). The latest marker still advances to the
+                    # fork below — we don't change behaviour here — but a
+                    # silent transition would orphan the prior id, so log
+                    # it LOUDLY (warning) to make the fork observable. The
+                    # prior id is preserved in session_id_history (see
+                    # write_session_id).
+                    prev_sid = read_session_id(state_dir)
+                    if prev_sid and prev_sid != sid:
+                        logger.warning(
+                            "session_id changed on resume: %s -> %s "
+                            "(SDK fork?); prior id retained in "
+                            "session_id_history",
+                            prev_sid,
+                            sid,
+                        )
                     write_session_id(state_dir, sid)
                     # Tag the envelope so the HTTP sidecar can echo the
                     # SDK session id back to the caller. Set BEFORE the
@@ -250,9 +297,26 @@ async def run_conversation(
     attempt = 0
     last_exc: BaseException | None = None
     while True:
-        # Re-read session_id each iteration so a supervised restart resumes
-        # against the most recent completed turn rather than the initial sid.
-        current_sid = read_session_id(state_dir) or resume_session_id
+        # Resume target, with history fallback. On the first attempt this
+        # is the latest completed-turn id (== read_session_id, since
+        # write_session_id appends to the history). On each supervised
+        # restart we step to a progressively OLDER id from the
+        # append-only history before giving up on resume — so if the
+        # latest id was forked/aged-out and its resume is rejected, a
+        # prior still-on-disk id gets a chance rather than the runner
+        # losing the whole conversation. Once the history is exhausted we
+        # fall through to a fresh start (resume=None).
+        current_sid = _resume_candidate(
+            state_dir, attempt=attempt, fallback=resume_session_id
+        )
+        if attempt > 0:
+            logger.warning(
+                "claude-session resume retry %d for %s: trying session_id %s "
+                "(walking session_id_history)",
+                attempt,
+                name,
+                current_sid,
+            )
         try:
             options = build_sdk_options_fn(
                 name,

--- a/src/scitex_agent_container/_runners/_session_id.py
+++ b/src/scitex_agent_container/_runners/_session_id.py
@@ -1,0 +1,125 @@
+"""Session-id resume marker + append-only history.
+
+Extracted from ``_runners/_session_state.py`` (which re-exports this
+surface for back-compat) to keep that module under the 512-line cap and
+to give the session-id concern one focused home.
+
+Two on-disk artifacts under ``<state_dir>/``:
+
+- ``session_id``         — the single, overwritten *latest* resume marker.
+- ``session_id_history`` — append-only, one distinct id per line.
+
+The SDK may **fork** the session id on a resume (return a new id instead
+of the one we asked it to resume). The latest marker advances to the
+fork, but the prior id's transcript is still on disk; the history keeps
+that orphaned id auditable and resumable. See ``_session_conversation``
+for the fork-detection log and the resume fallback that walks the
+history when the latest id is rejected.
+
+Atomic writes use the tmp + ``Path.replace`` pattern so a concurrent
+reader (``sac agent status``) never sees a half-formed file. The history
+is append-only, so a plain append is already crash-consistent at line
+granularity.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _session_id_history_path(state_dir: Path) -> Path:
+    return state_dir / "session_id_history"
+
+
+def append_session_id_history(state_dir: Path, session_id: str) -> bool:
+    """Append ``session_id`` to the append-only history when it is distinct.
+
+    The history (``<state_dir>/session_id_history``, one id per line) lets
+    an orphaned-but-on-disk session id stay auditable and resumable even
+    after the SDK forks the resume marker on a resume (see
+    :func:`write_session_id`). Appends only when ``session_id`` differs
+    from the most recent recorded id, so re-writing the same id every
+    turn does not bloat the file.
+
+    Returns True if a new line was appended, False if it was a duplicate
+    of the current tail (or the id was empty).
+    """
+    if not session_id:
+        return False
+    history = read_session_id_history(state_dir)
+    if history and history[-1] == session_id:
+        return False
+    state_dir.mkdir(parents=True, exist_ok=True)
+    with _session_id_history_path(state_dir).open("a", encoding="utf-8") as fh:
+        fh.write(session_id + "\n")
+    return True
+
+
+def read_session_id_history(state_dir: Path) -> list[str]:
+    """Return every distinct session id recorded, oldest first.
+
+    Empty list when no history exists. The last element is the most
+    recently recorded id (which should match :func:`read_session_id`).
+    """
+    p = _session_id_history_path(state_dir)
+    if not p.is_file():
+        return []
+    try:
+        return [
+            line.strip()
+            for line in p.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+    except OSError:
+        return []
+
+
+def write_session_id(state_dir: Path, session_id: str) -> None:
+    """Persist the SDK session id so a respawn can resume.
+
+    Also appends the id to the append-only ``session_id_history`` when it
+    is distinct from the last recorded one, so a forked/orphaned id is
+    never lost: the latest marker is overwritten, but the history is
+    additive.
+    """
+    state_dir.mkdir(parents=True, exist_ok=True)
+    tmp = state_dir / "session_id.tmp"
+    tmp.write_text(session_id, encoding="utf-8")
+    tmp.replace(state_dir / "session_id")
+    append_session_id_history(state_dir, session_id)
+
+
+def read_session_id(state_dir: Path) -> str | None:
+    """Return the persisted session id, or None if absent."""
+    p = state_dir / "session_id"
+    if not p.is_file():
+        return None
+    try:
+        return p.read_text(encoding="utf-8").strip() or None
+    except OSError:
+        return None
+
+
+def clear_session_id(state_dir: Path) -> bool:
+    """Remove the persisted ``session_id`` resume marker.
+
+    Used by ``agent_start(force=True)`` so a stale session id left over
+    from a previous run can't make the SDK try to resume a conversation
+    the server has already aged out (symptom: ``ProcessError: Command
+    failed with exit code 1`` ~90s into the first turn).
+
+    Returns True if a file was removed, False if there was nothing to
+    remove. Never raises FileNotFoundError; never silently swallows
+    other ``OSError``s (callers want a loud failure if e.g. the runtime
+    dir is unreadable due to permissions).
+
+    Note: this clears only the *latest* marker, not the append-only
+    ``session_id_history`` — the history is intentionally durable so a
+    forced fresh start can still audit which ids preceded it.
+    """
+    p = state_dir / "session_id"
+    try:
+        p.unlink()
+        return True
+    except FileNotFoundError:
+        return False

--- a/src/scitex_agent_container/_runners/_session_state.py
+++ b/src/scitex_agent_container/_runners/_session_state.py
@@ -20,6 +20,17 @@ import os
 import time
 from pathlib import Path
 
+# Session-id resume marker + append-only history live in a focused
+# module to keep this file under the 512-line cap. Re-exported here
+# (explicit ``as`` aliases mark the intentional re-export) so the
+# existing importers of ``_session_state.{write,read,clear}_session_id``
+# keep working unchanged.
+from ._session_id import append_session_id_history as append_session_id_history
+from ._session_id import clear_session_id as clear_session_id
+from ._session_id import read_session_id as read_session_id
+from ._session_id import read_session_id_history as read_session_id_history
+from ._session_id import write_session_id as write_session_id
+
 DEFAULT_STATE_ROOT = Path(
     os.environ.get(
         "SCITEX_AGENT_CONTAINER_RUNTIME_DIR",
@@ -378,48 +389,15 @@ def accumulate_quota(state_dir: Path, usage: dict | None) -> dict:
 
 
 # ---------------------------------------------------------------------------
-# Session id (resume marker)
+# Session id (resume marker) + append-only history
+#
+# Implementation extracted to ``_session_id.py`` (focused module, keeps
+# this file under the 512-line cap) and imported at the top of this
+# module. The names ``write_session_id`` / ``read_session_id`` /
+# ``clear_session_id`` (plus the new ``append_session_id_history`` /
+# ``read_session_id_history``) therefore resolve as
+# ``_session_state.<name>`` unchanged for every existing caller.
 # ---------------------------------------------------------------------------
-
-
-def write_session_id(state_dir: Path, session_id: str) -> None:
-    """Persist the SDK session id so a respawn can resume."""
-    state_dir.mkdir(parents=True, exist_ok=True)
-    tmp = state_dir / "session_id.tmp"
-    tmp.write_text(session_id, encoding="utf-8")
-    tmp.replace(state_dir / "session_id")
-
-
-def read_session_id(state_dir: Path) -> str | None:
-    """Return the persisted session id, or None if absent."""
-    p = state_dir / "session_id"
-    if not p.is_file():
-        return None
-    try:
-        return p.read_text(encoding="utf-8").strip() or None
-    except OSError:
-        return None
-
-
-def clear_session_id(state_dir: Path) -> bool:
-    """Remove the persisted ``session_id`` resume marker.
-
-    Used by ``agent_start(force=True)`` so a stale session id left over
-    from a previous run can't make the SDK try to resume a conversation
-    the server has already aged out (symptom: ``ProcessError: Command
-    failed with exit code 1`` ~90s into the first turn).
-
-    Returns True if a file was removed, False if there was nothing to
-    remove. Never raises FileNotFoundError; never silently swallows
-    other ``OSError``s (callers want a loud failure if e.g. the runtime
-    dir is unreadable due to permissions).
-    """
-    p = state_dir / "session_id"
-    try:
-        p.unlink()
-        return True
-    except FileNotFoundError:
-        return False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scitex_agent_container/_runners/test__session_conversation.py
+++ b/tests/scitex_agent_container/_runners/test__session_conversation.py
@@ -1,21 +1,35 @@
-"""``run_conversation`` packs channels + a2a_port into build_sdk_options.
+"""``run_conversation`` behaviour: channels/a2a_port threading, plus
+session-id fork-detection logging and the resume history fallback.
 
-The conversation half of the sac-node-comms fix: when ``channels`` /
-``a2a_port`` are threaded in, they must arrive in the ``extra`` kwarg of
-``build_sdk_options`` under the sac-private ``_channels`` / ``_a2a_port``
-keys so the ``sac mcp channel`` adapter is auto-registered (see
-``runtimes/_sdk_common.py``). Real injected SDK module + build-options
-seam — no mocks.
+The channels half: when ``channels`` / ``a2a_port`` are threaded in,
+they must arrive in the ``extra`` kwarg of ``build_sdk_options`` under
+the sac-private ``_channels`` / ``_a2a_port`` keys so the
+``sac mcp channel`` adapter is auto-registered (see
+``runtimes/_sdk_common.py``).
+
+The session-id half: a real turn whose ``ResultMessage`` returns a
+session id DIFFERENT from the stored one must (i) log the transition at
+warning level (fork observability) and (ii) accumulate both ids in the
+append-only ``session_id_history`` while the latest marker advances to
+the fork. ``_resume_candidate`` walks that history latest-first so a
+supervised restart can fall back to a prior still-on-disk id.
+
+Real injected SDK module + real state dir under ``tmp_path`` — no mocks.
 """
 
 from __future__ import annotations
 
 import asyncio
+import logging
 import types
 from pathlib import Path
 from typing import Any
 
 import scitex_agent_container._runners.claude_session as runner
+from scitex_agent_container._runners import _session_id as sid
+from scitex_agent_container._runners._session_conversation import (
+    _resume_candidate,
+)
 from scitex_agent_container._runners._session_inbox import (
     ShutdownEnvelope,
     TurnEnvelope,
@@ -146,3 +160,170 @@ def test_run_conversation_extra_is_none_without_channels_or_port(
     asyncio.run(_run())
     # Assert — no channels and no a2a_port → no extra payload at all.
     assert captured["extra"] is None
+
+
+# ---------------------------------------------------------------------------
+# Session-id fork detection + history (a real turn returning a NEW id)
+# ---------------------------------------------------------------------------
+
+
+def _make_sdk_module_returning(result_sid: str) -> types.ModuleType:
+    """SDK module whose one turn yields a result with ``result_sid``."""
+
+    class _Text:
+        def __init__(self, text: str) -> None:
+            self.text = text
+
+    class _Assistant:
+        def __init__(self, content):
+            self.content = content
+
+    class _User:
+        pass
+
+    class _Result:
+        def __init__(self, sid_, usage):
+            self.session_id = sid_
+            self.usage = usage
+
+    class _Client:
+        def __init__(self, *, options):
+            self._messages = [
+                _Assistant([_Text("hi")]),
+                _Result(result_sid, {}),
+            ]
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return None
+
+        async def query(self, prompt):
+            self._prompt = prompt
+
+        async def receive_response(self):
+            for m in self._messages:
+                yield m
+
+        async def interrupt(self):
+            return None
+
+    class _HookMatcher:
+        def __init__(self, *a, **kw):
+            pass
+
+    mod = types.ModuleType("fake_sdk")
+    mod.AssistantMessage = _Assistant
+    mod.TextBlock = _Text
+    mod.UserMessage = _User
+    mod.ResultMessage = _Result
+    mod.ClaudeSDKClient = _Client
+    mod.HookMatcher = _HookMatcher
+    return mod
+
+
+def _run_one_forked_turn(state_dir: Path) -> None:
+    """Pre-seed an old id, then run a real turn whose result forks to a new id."""
+    sid.write_session_id(state_dir, "id-old")
+    sdk_mod = _make_sdk_module_returning("id-new")
+
+    async def _run():
+        inbox = await _seed("go")
+        await runner._run_conversation(
+            "alpha",
+            state_dir,
+            pid=1,
+            inbox=inbox,
+            resume_session_id=None,
+            stop=asyncio.Event(),
+            sdk_module=sdk_mod,
+            build_sdk_options_fn=_capturing_build_options({}),
+        )
+
+    asyncio.run(_run())
+
+
+def test_turn_logs_fork_when_result_session_id_differs(tmp_path: Path, caplog) -> None:
+    # Arrange
+    state_dir = tmp_path / "alpha"
+    # Act
+    with caplog.at_level(logging.WARNING):
+        _run_one_forked_turn(state_dir)
+    # Assert — the silent fork is now observable in the logs.
+    assert "session_id changed on resume: id-old -> id-new" in caplog.text
+
+
+def test_turn_history_accumulates_both_old_and_new_id(tmp_path: Path) -> None:
+    # Arrange
+    state_dir = tmp_path / "alpha"
+    # Act
+    _run_one_forked_turn(state_dir)
+    # Assert — both ids retained, oldest first.
+    assert sid.read_session_id_history(state_dir) == ["id-old", "id-new"]
+
+
+def test_turn_latest_marker_advances_to_new_id(tmp_path: Path) -> None:
+    # Arrange
+    state_dir = tmp_path / "alpha"
+    # Act
+    _run_one_forked_turn(state_dir)
+    # Assert — the resume marker is the forked (latest) id.
+    assert sid.read_session_id(state_dir) == "id-new"
+
+
+def test_turn_history_retains_prior_id_after_fork(tmp_path: Path) -> None:
+    # Arrange
+    state_dir = tmp_path / "alpha"
+    # Act
+    _run_one_forked_turn(state_dir)
+    # Assert — the orphaned prior id stays auditable / resumable.
+    assert "id-old" in sid.read_session_id_history(state_dir)
+
+
+# ---------------------------------------------------------------------------
+# Resume fallback — _resume_candidate walks history latest-first
+# ---------------------------------------------------------------------------
+
+
+def test_resume_candidate_attempt0_is_latest_id(tmp_path: Path) -> None:
+    # Arrange
+    state_dir = tmp_path / "alpha"
+    sid.write_session_id(state_dir, "id-A")
+    sid.write_session_id(state_dir, "id-B")
+    # Act
+    candidate = _resume_candidate(state_dir, attempt=0, fallback=None)
+    # Assert
+    assert candidate == "id-B"
+
+
+def test_resume_candidate_attempt1_falls_back_to_prior_id(tmp_path: Path) -> None:
+    # Arrange
+    state_dir = tmp_path / "alpha"
+    sid.write_session_id(state_dir, "id-A")
+    sid.write_session_id(state_dir, "id-B")
+    # Act — latest (id-B) was rejected; the supervisor steps to the prior.
+    candidate = _resume_candidate(state_dir, attempt=1, fallback=None)
+    # Assert
+    assert candidate == "id-A"
+
+
+def test_resume_candidate_returns_none_when_history_exhausted(tmp_path: Path) -> None:
+    # Arrange
+    state_dir = tmp_path / "alpha"
+    sid.write_session_id(state_dir, "id-A")
+    # Act — only one id; attempt 1 has nothing older → fresh start.
+    candidate = _resume_candidate(state_dir, attempt=1, fallback=None)
+    # Assert
+    assert candidate is None
+
+
+def test_resume_candidate_attempt0_uses_fallback_before_any_history(
+    tmp_path: Path,
+) -> None:
+    # Arrange — first-ever start: no history file yet.
+    state_dir = tmp_path / "alpha"
+    # Act
+    candidate = _resume_candidate(state_dir, attempt=0, fallback="seed-sid")
+    # Assert — preserves the pre-history initial-resume behaviour.
+    assert candidate == "seed-sid"

--- a/tests/scitex_agent_container/_runners/test__session_id.py
+++ b/tests/scitex_agent_container/_runners/test__session_id.py
@@ -1,0 +1,145 @@
+"""Tests for the session-id resume marker + append-only history.
+
+No mocks: every test exercises the real ``_session_id`` helpers against a
+real state directory under ``tmp_path``. AAA structure, one assertion
+per test, descriptive names.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scitex_agent_container._runners import _session_id as sid
+
+
+def test_write_session_id_then_read_returns_same_value(tmp_path: Path) -> None:
+    # Arrange
+    state_dir = tmp_path / "alpha"
+    # Act
+    sid.write_session_id(state_dir, "id-A")
+    # Assert
+    assert sid.read_session_id(state_dir) == "id-A"
+
+
+def test_read_session_id_returns_none_when_marker_absent(tmp_path: Path) -> None:
+    # Arrange
+    state_dir = tmp_path / "alpha"
+    # Act
+    result = sid.read_session_id(state_dir)
+    # Assert
+    assert result is None
+
+
+def test_read_session_id_history_empty_when_no_history_file(tmp_path: Path) -> None:
+    # Arrange
+    state_dir = tmp_path / "alpha"
+    # Act
+    history = sid.read_session_id_history(state_dir)
+    # Assert
+    assert history == []
+
+
+def test_write_session_id_appends_to_history(tmp_path: Path) -> None:
+    # Arrange
+    state_dir = tmp_path / "alpha"
+    # Act
+    sid.write_session_id(state_dir, "id-A")
+    # Assert
+    assert sid.read_session_id_history(state_dir) == ["id-A"]
+
+
+def test_history_accumulates_distinct_ids_oldest_first(tmp_path: Path) -> None:
+    # Arrange
+    state_dir = tmp_path / "alpha"
+    # Act
+    sid.write_session_id(state_dir, "id-A")
+    sid.write_session_id(state_dir, "id-B")
+    # Assert
+    assert sid.read_session_id_history(state_dir) == ["id-A", "id-B"]
+
+
+def test_history_does_not_duplicate_repeated_latest_id(tmp_path: Path) -> None:
+    # Arrange
+    state_dir = tmp_path / "alpha"
+    sid.write_session_id(state_dir, "id-A")
+    # Act — re-writing the same id every turn must not bloat the history.
+    sid.write_session_id(state_dir, "id-A")
+    # Assert
+    assert sid.read_session_id_history(state_dir) == ["id-A"]
+
+
+def test_history_retains_prior_id_after_fork(tmp_path: Path) -> None:
+    # Arrange — id-A recorded, then the SDK "forks" to id-B.
+    state_dir = tmp_path / "alpha"
+    sid.write_session_id(state_dir, "id-A")
+    # Act
+    sid.write_session_id(state_dir, "id-B")
+    # Assert — the orphaned prior id is still auditable in the history.
+    assert "id-A" in sid.read_session_id_history(state_dir)
+
+
+def test_latest_marker_advances_to_forked_id(tmp_path: Path) -> None:
+    # Arrange
+    state_dir = tmp_path / "alpha"
+    sid.write_session_id(state_dir, "id-A")
+    # Act
+    sid.write_session_id(state_dir, "id-B")
+    # Assert — the single overwritten marker tracks the latest (fork).
+    assert sid.read_session_id(state_dir) == "id-B"
+
+
+def test_append_session_id_history_returns_true_on_new_id(tmp_path: Path) -> None:
+    # Arrange
+    state_dir = tmp_path / "alpha"
+    # Act
+    appended = sid.append_session_id_history(state_dir, "id-A")
+    # Assert
+    assert appended is True
+
+
+def test_append_session_id_history_returns_false_on_duplicate(tmp_path: Path) -> None:
+    # Arrange
+    state_dir = tmp_path / "alpha"
+    sid.append_session_id_history(state_dir, "id-A")
+    # Act
+    appended = sid.append_session_id_history(state_dir, "id-A")
+    # Assert
+    assert appended is False
+
+
+def test_append_session_id_history_ignores_empty_id(tmp_path: Path) -> None:
+    # Arrange
+    state_dir = tmp_path / "alpha"
+    # Act
+    sid.append_session_id_history(state_dir, "")
+    # Assert
+    assert sid.read_session_id_history(state_dir) == []
+
+
+def test_clear_session_id_removes_latest_marker(tmp_path: Path) -> None:
+    # Arrange
+    state_dir = tmp_path / "alpha"
+    sid.write_session_id(state_dir, "id-A")
+    # Act
+    sid.clear_session_id(state_dir)
+    # Assert
+    assert sid.read_session_id(state_dir) is None
+
+
+def test_clear_session_id_preserves_history(tmp_path: Path) -> None:
+    # Arrange — clearing the resume marker must not wipe the audit trail.
+    state_dir = tmp_path / "alpha"
+    sid.write_session_id(state_dir, "id-A")
+    # Act
+    sid.clear_session_id(state_dir)
+    # Assert
+    assert sid.read_session_id_history(state_dir) == ["id-A"]
+
+
+def test_clear_session_id_returns_false_when_nothing_to_remove(tmp_path: Path) -> None:
+    # Arrange
+    state_dir = tmp_path / "alpha"
+    # Act
+    removed = sid.clear_session_id(state_dir)
+    # Assert
+    assert removed is False


### PR DESCRIPTION
## Problem

The claude-session runner stored only the **latest** `session_id` in a single overwritten file and, after each (possibly resumed) turn, **unconditionally overwrote** it with `ResultMessage.session_id` — with no check whether the SDK returned the same id or a **forked** one. If the SDK forks the session id on resume, SAC silently advanced its marker to the fork and the original id became unreachable (its jsonl still on disk, but no longer pointed at).

Evidence: `_runners/_session_conversation.py` (mint + unconditional overwrite), `_runners/_session_state.py` (single-file `write_session_id`/`clear`).

## What this PR does

**1a — fork-detection log.** In `_drive_turn`, before overwriting, compare the incoming `ResultMessage.session_id` to the stored id. On a (non-empty) change, log a `warning`: `session_id changed on resume: <old> -> <new> (SDK fork?)`. Behaviour is unchanged — the new id is still written — but a silent fork is now **observable**.

**1b — session_id history + resume fallback.**
- `write_session_id` now appends every **distinct** id to an append-only `<state_dir>/session_id_history` (one id per line), so orphaned-but-on-disk ids stay auditable and resumable.
- The supervisor restart loop walks the history **latest-first** (`_resume_candidate`): attempt 0 = latest, attempt N = next-older, falling through to a fresh start once exhausted. Attempt 0 preserves the pre-history behaviour exactly, so this engages only when the operator opts into supervised restarts (`max_restarts > 0`).
- `clear_session_id` intentionally leaves the history intact.

The session-id surface is extracted into a focused `_session_id.py` (re-exported by `_session_state.py` via explicit `as` aliases) to stay under the per-file line cap; all existing `_session_state.{write,read,clear}_session_id` importers are unaffected.

## Tests (no mocks)

Real state dir under `tmp_path`; a real turn whose `ResultMessage` returns a **different** id asserts:
1. the fork is logged (via `caplog`),
2. the history accumulates **both** ids (oldest-first),
3. the latest marker is the fork while the history retains the prior id.

Plus unit tests for the history helpers (`append`/`read`/dedup/empty-id/clear-preserves-history) and `_resume_candidate`'s latest-first walk (attempt0/attempt1/exhausted/fallback).

STX-TQ compliant (AAA, descriptive names, one assert each). Full `_runners` + `_state` + `_listen` + `cli_pkg` suites green (2025 passed, 0 failures).

## Rebase note
Changes are localized to distinct regions of `_session_conversation.py` (top-of-module helper, the result-handling block, the loop preamble) so a later item-B branch touching the same file rebases cleanly.