### PR TITLE
fix(claude-session): capture the real subprocess stderr on turn failure

### DIFF
--- a/src/scitex_agent_container/_runners/_session_conversation.py
+++ b/src/scitex_agent_container/_runners/_session_conversation.py
@@ -32,6 +32,11 @@ from ._session_state import (
     write_heartbeat,
     write_session_id,
 )
+from ._stderr_capture import (
+    StderrCapture,
+    enrich_detail_with_stderr,
+    write_stderr_log,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -96,6 +101,7 @@ async def _drive_turn(
     name: str | None = None,
     host: str | None = None,
     db_writer=None,
+    stderr_capture: Any | None = None,
 ) -> None:
     AssistantMessage = sdk_types["AssistantMessage"]
     TextBlock = sdk_types["TextBlock"]
@@ -187,6 +193,24 @@ async def _drive_turn(
                     {"type": "result", "session_id": sid, "usage": usage},
                 )
                 break
+    except BaseException as exc:  # stx-allow: fallback (reason: enrich the failure with the real captured stderr, resolve the awaiter with the real cause, then re-raise for the supervisor)
+        # The SDK turn failed (e.g. a ProcessError from a stale --resume
+        # whose only "stderr" is the placeholder). Fold the stderr the
+        # registered callback captured into the exception so the awaiting
+        # /v1/turn handler returns a 502 carrying the REAL cause instead
+        # of a silent empty-200 (the pre-fix behaviour: the finally below
+        # resolved the future with "".join(chunks)). Then re-raise so
+        # run_conversation's supervisor records + classifies it.
+        if not env.response.done():
+            captured = stderr_capture.text() if stderr_capture is not None else ""
+            enriched = enrich_detail_with_stderr(str(exc), captured)
+            if enriched != str(exc):
+                # Attach the enriched detail without losing the exception
+                # type, so classify_auth_failure / the supervisor still
+                # see the original class.
+                exc.args = (enriched,) + tuple(exc.args[1:])
+            env.response.set_exception(exc)
+        raise
     finally:
         if not env.response.done():
             env.response.set_result("".join(chunks))
@@ -317,13 +341,25 @@ async def run_conversation(
                 name,
                 current_sid,
             )
+        # Fresh per-attempt stderr collector. The SDK only PIPES the
+        # claude subprocess's stderr when a ``stderr`` callback is
+        # registered on ``ClaudeAgentOptions``; without it a ProcessError
+        # carries only the useless placeholder "Check stderr output for
+        # details". Register the callback through the ``extra`` seam
+        # (``stderr`` is a real ClaudeAgentOptions field) so the real
+        # failure reason — e.g. "No conversation found for session <id>"
+        # on a stale --resume — reaches both the persisted error record
+        # and the awaiting /v1/turn future.
+        stderr_capture = StderrCapture()
+        attempt_extra = dict(sdk_extra) if sdk_extra else {}
+        attempt_extra["stderr"] = stderr_capture.callback
         try:
             options = build_sdk_options_fn(
                 name,
                 permission_mode="bypassPermissions",
                 resume=current_sid,
                 hooks=hooks,
-                extra=sdk_extra,
+                extra=attempt_extra,
             )
         except SDKCommonError as exc:
             # A missing/expired credentials file fails option-building
@@ -374,6 +410,7 @@ async def run_conversation(
                         name=name,
                         host=host,
                         db_writer=db_writer,
+                        stderr_capture=stderr_capture,
                     )
                     if env.exit_after:
                         stop.set()
@@ -392,7 +429,19 @@ async def run_conversation(
                 classify_auth_failure,
             )
 
-            auth_detail = classify_auth_failure(exc)
+            # Fold the captured subprocess stderr into the failure string
+            # so BOTH auth classification AND the persisted detail see the
+            # real reason — not the SDK's "Check stderr output for details"
+            # placeholder. Also persist the full stream to a dedicated log
+            # so the actionable tail survives even when ``detail`` is
+            # bounded downstream. (When the failure came from _drive_turn,
+            # str(exc) is already enriched; enrich_detail_with_stderr is a
+            # no-op there since the captured text is already a substring.)
+            captured_stderr = stderr_capture.text()
+            enriched = enrich_detail_with_stderr(str(exc), captured_stderr)
+            write_stderr_log(state_dir, captured_stderr)
+
+            auth_detail = classify_auth_failure(enriched)
             if auth_detail is not None:
                 cause = AUTH_FAILURE_CAUSE
                 detail = auth_detail
@@ -402,9 +451,11 @@ async def run_conversation(
                 )
             else:
                 cause = "sdk-crash"
-                detail = str(exc)
+                detail = enriched
                 error_kind = "sdk_runtime"
-                logger.exception("claude-session conversation failed for %s", name)
+                logger.exception(
+                    "claude-session conversation failed for %s: %s", name, detail
+                )
             append_session_message(
                 state_dir,
                 {

--- a/src/scitex_agent_container/_runners/_stderr_capture.py
+++ b/src/scitex_agent_container/_runners/_stderr_capture.py
@@ -1,0 +1,164 @@
+# -*- coding: utf-8 -*-
+"""Capture the claude subprocess's stderr so SDK failures stay legible.
+
+The ``claude-agent-sdk`` only PIPES the subprocess stderr when the caller
+registers a ``stderr`` callback on ``ClaudeAgentOptions``; otherwise the
+stderr fd is inherited and discarded, and a process failure surfaces as
+``ProcessError(stderr="Check stderr output for details")`` — a useless
+placeholder that drops the actual reason (e.g. "No conversation found for
+session <id>" on a stale ``--resume``, or a Python traceback from a hook).
+
+This module gives the conversation runner the two pieces it needs:
+
+* :class:`StderrCapture` — a bounded ring buffer plus a per-line callback
+  to register on ``ClaudeAgentOptions(stderr=...)``.
+* :func:`enrich_detail_with_stderr` — fold the captured text into the
+  exception detail, replacing the SDK placeholder with the real reason.
+
+A best-effort :func:`write_stderr_log` persists the full captured stream
+to a dedicated log so the actionable tail is never lost even when the
+``detail`` written to ``session.jsonl`` is bounded.
+
+Pure stdlib — no SDK import — so it is unit-testable against the stderr
+of a real subprocess without the optional ``claude-agent-sdk`` present.
+"""
+
+from __future__ import annotations
+
+import collections
+from pathlib import Path
+
+__all__ = [
+    "StderrCapture",
+    "enrich_detail_with_stderr",
+    "is_sdk_stderr_placeholder",
+    "write_stderr_log",
+]
+
+# The SDK invokes the callback once per stderr line. A dead-session resume
+# or auth failure emits a handful of lines; cap the ring so a runaway
+# subprocess can't bloat memory while still keeping the tail — where the
+# actual error and any traceback live.
+_MAX_LINES = 400
+
+# Placeholder the SDK substitutes when it did NOT pipe stderr. Any detail
+# containing this carries no real stderr, so we prefer our own buffer.
+_SDK_PLACEHOLDER = "Check stderr output for details"
+
+# Marker the SDK uses to introduce the (placeholder) stderr tail on a
+# ProcessError message: "<message> (exit code: N)\nError output: <stderr>".
+_ERROR_OUTPUT_MARKER = "Error output:"
+
+_STDERR_LOG_NAME = "runner-stderr.log"
+
+
+class StderrCapture:
+    """Bounded collector for the claude subprocess's stderr lines.
+
+    Register :attr:`callback` on ``ClaudeAgentOptions(stderr=...)``; the
+    SDK then pipes the subprocess stderr and feeds each line here. After a
+    failure, read :meth:`text` to recover the real stderr.
+
+    Parameters
+    ----------
+    max_lines : int
+        Keep at most this many most-recent lines (the tail). Older lines
+        are dropped once the ring is full.
+    """
+
+    def __init__(self, max_lines: int = _MAX_LINES) -> None:
+        self._lines: "collections.deque[str]" = collections.deque(maxlen=max_lines)
+
+    def callback(self, line: str) -> None:
+        """SDK per-line stderr hook. Must never raise into the SDK reader.
+
+        The SDK's stderr reader task invokes this synchronously per line;
+        an exception here would be swallowed by the SDK but could still
+        interrupt the line loop, so we guard defensively.
+        """
+        try:
+            stripped = line.rstrip("\n")
+            if stripped:
+                self._lines.append(stripped)
+        except Exception:  # stx-allow: fallback (reason: SDK stderr reader must not crash on a bad line)
+            pass
+
+    def text(self) -> str:
+        """Return the joined captured stderr (most recent ``max_lines``)."""
+        return "\n".join(self._lines)
+
+    def __bool__(self) -> bool:
+        return bool(self._lines)
+
+
+def is_sdk_stderr_placeholder(detail: str | None) -> bool:
+    """Return ``True`` when ``detail`` carries the SDK's stderr placeholder.
+
+    The placeholder means the SDK never piped real stderr, so the caller
+    should substitute its own captured buffer.
+    """
+    return _SDK_PLACEHOLDER in (detail or "")
+
+
+def enrich_detail_with_stderr(detail: str | None, captured: str | None) -> str:
+    """Fold captured stderr into ``detail`` so the real reason is legible.
+
+    Parameters
+    ----------
+    detail : str or None
+        The stringified exception (typically ``str(ProcessError)``).
+    captured : str or None
+        Text accumulated by :class:`StderrCapture`.
+
+    Returns
+    -------
+    str
+        - If ``captured`` is empty → ``detail`` unchanged.
+        - If ``detail`` carries the SDK placeholder → the bogus
+          ``Error output: Check stderr output for details`` tail is
+          replaced with the real captured stderr.
+        - Else if ``captured`` is already a substring of ``detail`` (the
+          SDK surfaced it) → ``detail`` unchanged.
+        - Otherwise → ``detail`` with the captured stderr appended on a
+          labelled line, so nothing the SDK omitted is lost.
+    """
+    captured = (captured or "").strip()
+    detail = detail or ""
+    if not captured:
+        return detail
+    if is_sdk_stderr_placeholder(detail):
+        head, _, _tail = detail.partition(_ERROR_OUTPUT_MARKER)
+        head = head.rstrip()
+        return f"{head}\n{_ERROR_OUTPUT_MARKER} {captured}" if head else captured
+    if captured in detail:
+        return detail
+    return f"{detail}\nCaptured stderr: {captured}"
+
+
+def write_stderr_log(state_dir: Path, captured: str | None) -> Path | None:
+    """Append the full captured stderr to ``runner-stderr.log``.
+
+    Returns
+    -------
+    pathlib.Path or None
+        The log path on success; ``None`` when nothing was captured or
+        the write fails. A logging failure must never mask the original
+        error, so write errors are swallowed (and returned as ``None``).
+    """
+    captured = (captured or "").strip()
+    if not captured:
+        return None
+    state_dir = Path(state_dir)
+    path = state_dir / _STDERR_LOG_NAME
+    try:
+        state_dir.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(captured)
+            if not captured.endswith("\n"):
+                fh.write("\n")
+        return path
+    except Exception:  # stx-allow: fallback (reason: best-effort log; a write failure must not mask the original error)
+        return None
+
+
+# EOF

--- a/tests/scitex_agent_container/_runners/test__session_conversation.py
+++ b/tests/scitex_agent_container/_runners/test__session_conversation.py
@@ -131,12 +131,17 @@ def test_run_conversation_threads_channels_and_port_into_extra(
 
     # Act
     asyncio.run(_run())
-    # Assert — sac-private extra keys present so build_sdk_options
-    # registers the `sac mcp channel` adapter.
-    assert captured["extra"] == {"_channels": ["server:sac"], "_a2a_port": 7878}
+    # Assert — sac-private channel keys present so build_sdk_options
+    # registers the `sac mcp channel` adapter. (An always-on ``stderr``
+    # capture callback is also threaded into extra by the runner; this
+    # test asserts only the channel keys it cares about.)
+    assert {
+        "_channels": captured["extra"]["_channels"],
+        "_a2a_port": captured["extra"]["_a2a_port"],
+    } == {"_channels": ["server:sac"], "_a2a_port": 7878}
 
 
-def test_run_conversation_extra_is_none_without_channels_or_port(
+def test_run_conversation_omits_channel_keys_without_channels_or_port(
     tmp_path: Path,
 ) -> None:
     # Arrange
@@ -158,8 +163,9 @@ def test_run_conversation_extra_is_none_without_channels_or_port(
 
     # Act
     asyncio.run(_run())
-    # Assert — no channels and no a2a_port → no extra payload at all.
-    assert captured["extra"] is None
+    # Assert — no channels and no a2a_port → only the always-on stderr
+    # capture callback is threaded; no sac-private channel keys.
+    assert set(captured["extra"]) == {"stderr"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scitex_agent_container/_runners/test__stderr_capture.py
+++ b/tests/scitex_agent_container/_runners/test__stderr_capture.py
@@ -1,0 +1,187 @@
+"""Unit tests for the runner's stderr-capture helper.
+
+No mocks: the capture path is exercised against the stderr of a REAL
+subprocess. A tiny Python program writes a known multi-line traceback to
+stderr and exits non-zero; we read that stream line-by-line and feed each
+line to ``StderrCapture.callback`` exactly the way the claude-agent-sdk's
+``_handle_stderr`` reader does. We then assert the captured text reaches
+the enriched failure detail. Pure-function behaviour (placeholder
+detection, enrichment, log write) is checked against real strings and a
+real ``tmp_path`` directory.
+
+Style: AAA marker comments, descriptive >=3-word names, one assert each.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+from scitex_agent_container._runners._stderr_capture import (
+    StderrCapture,
+    enrich_detail_with_stderr,
+    is_sdk_stderr_placeholder,
+    write_stderr_log,
+)
+
+# A real program that emits a recognisable traceback on stderr and fails.
+# Mirrors the kind of crash the claude subprocess produces (a stale-resume
+# or a hook traceback) — the actionable reason lives in the stderr tail.
+_FAILING_PROGRAM = (
+    "import sys\n"
+    "print('No conversation found for session abc-123', file=sys.stderr)\n"
+    "raise RuntimeError('boom: the real underlying cause')\n"
+)
+
+# The SDK placeholder substituted onto ProcessError when stderr was NOT
+# piped — the bug this helper exists to defeat.
+_PLACEHOLDER_DETAIL = (
+    "Command failed (exit code: 1)\nError output: Check stderr output for details"
+)
+
+
+def _run_failing_subprocess_capturing_stderr() -> tuple[StderrCapture, int]:
+    """Run the failing program and stream its stderr into a StderrCapture.
+
+    This is the real data path: a child process writes to its stderr fd,
+    the parent reads it line-by-line and invokes the per-line callback —
+    the same contract the SDK's stderr reader honours. Returns the
+    populated capture and the process exit code.
+    """
+    capture = StderrCapture()
+    proc = subprocess.run(
+        [sys.executable, "-c", _FAILING_PROGRAM],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    for line in proc.stderr.splitlines():
+        capture.callback(line)
+    return capture, proc.returncode
+
+
+class TestStderrCaptureFromRealSubprocess:
+    """A real subprocess's stderr survives into the capture buffer."""
+
+    def test_capture_keeps_real_traceback_final_line(self) -> None:
+        # Arrange
+        # (the failing program is fixed; nothing to set up)
+        # Act
+        capture, _rc = _run_failing_subprocess_capturing_stderr()
+        # Assert
+        assert "boom: the real underlying cause" in capture.text()
+
+    def test_capture_keeps_real_stderr_diagnostic_line(self) -> None:
+        # Arrange
+        # (the failing program is fixed; nothing to set up)
+        # Act
+        capture, _rc = _run_failing_subprocess_capturing_stderr()
+        # Assert
+        assert "No conversation found for session abc-123" in capture.text()
+
+    def test_failing_subprocess_exits_nonzero(self) -> None:
+        # Arrange
+        # (the failing program is fixed; nothing to set up)
+        # Act
+        _capture, rc = _run_failing_subprocess_capturing_stderr()
+        # Assert
+        assert rc != 0
+
+
+class TestEnrichDetailReplacesPlaceholderWithRealStderr:
+    """The SDK placeholder is swapped for the captured real stderr."""
+
+    def test_enriched_detail_contains_real_cause(self) -> None:
+        # Arrange
+        capture, _rc = _run_failing_subprocess_capturing_stderr()
+        # Act
+        enriched = enrich_detail_with_stderr(_PLACEHOLDER_DETAIL, capture.text())
+        # Assert
+        assert "boom: the real underlying cause" in enriched
+
+    def test_enriched_detail_drops_the_sdk_placeholder(self) -> None:
+        # Arrange
+        capture, _rc = _run_failing_subprocess_capturing_stderr()
+        # Act
+        enriched = enrich_detail_with_stderr(_PLACEHOLDER_DETAIL, capture.text())
+        # Assert
+        assert "Check stderr output for details" not in enriched
+
+    def test_enriched_detail_keeps_the_exit_code_head(self) -> None:
+        # Arrange
+        capture, _rc = _run_failing_subprocess_capturing_stderr()
+        # Act
+        enriched = enrich_detail_with_stderr(_PLACEHOLDER_DETAIL, capture.text())
+        # Assert
+        assert "Command failed (exit code: 1)" in enriched
+
+
+class TestEnrichDetailWithoutPlaceholder:
+    """Real-stderr-bearing details are augmented, not clobbered."""
+
+    def test_appends_captured_when_detail_lacks_it(self) -> None:
+        # Arrange
+        detail = "RuntimeError: something else entirely"
+        captured = "extra stderr line the sdk omitted"
+        # Act
+        enriched = enrich_detail_with_stderr(detail, captured)
+        # Assert
+        assert enriched == f"{detail}\nCaptured stderr: {captured}"
+
+    def test_returns_detail_unchanged_when_already_present(self) -> None:
+        # Arrange
+        captured = "the only line"
+        detail = f"RuntimeError: wrap\nCaptured stderr: {captured}"
+        # Act
+        enriched = enrich_detail_with_stderr(detail, captured)
+        # Assert
+        assert enriched == detail
+
+    def test_returns_detail_unchanged_when_nothing_captured(self) -> None:
+        # Arrange
+        detail = "RuntimeError: no stderr was captured"
+        # Act
+        enriched = enrich_detail_with_stderr(detail, "")
+        # Assert
+        assert enriched == detail
+
+
+class TestPlaceholderDetection:
+    """The SDK placeholder string is recognised, real stderr is not."""
+
+    def test_detects_the_sdk_placeholder_string(self) -> None:
+        # Arrange
+        detail = _PLACEHOLDER_DETAIL
+        # Act
+        flagged = is_sdk_stderr_placeholder(detail)
+        # Assert
+        assert flagged is True
+
+    def test_real_stderr_is_not_flagged_as_placeholder(self) -> None:
+        # Arrange
+        detail = "real: boom"
+        # Act
+        flagged = is_sdk_stderr_placeholder(detail)
+        # Assert
+        assert flagged is False
+
+
+class TestWriteStderrLogToRealDir:
+    """The captured stderr is persisted to a real on-disk log file."""
+
+    def test_writes_captured_text_to_log_file(self, tmp_path: Path) -> None:
+        # Arrange
+        captured = "No conversation found for session abc-123\nboom: real cause"
+        # Act
+        path = write_stderr_log(tmp_path, captured)
+        # Assert
+        assert path is not None and "boom: real cause" in path.read_text()
+
+    def test_returns_none_when_nothing_to_write(self, tmp_path: Path) -> None:
+        # Arrange
+        empty = "   "
+        # Act
+        path = write_stderr_log(tmp_path, empty)
+        # Assert
+        assert path is None


### PR DESCRIPTION
## Problem

When a `claude-session` turn fails, the runner swallowed the **real**
underlying error and surfaced only a generic message:

- the `/v1/turn` future resolved with an empty-200 (the failure was lost
  in the `finally` that returned `"".join(chunks)`), and
- the supervisor recorded `detail = str(exc)` which, for a `ProcessError`
  whose stderr was never piped, is the useless SDK placeholder
  `"Check stderr output for details"`.

A stale-`--resume` exit-1 (whose real reason is e.g. *"No conversation
found for session <id>"*) was therefore undebuggable from
`session.jsonl` / the error record.

## Fix

New pure, SDK-independent unit `_runners/_stderr_capture.py`:

- `StderrCapture` — bounded ring buffer + a per-line `callback` to
  register on `ClaudeAgentOptions(stderr=...)`.
- `enrich_detail_with_stderr` — fold the captured stderr into the
  exception detail, replacing the SDK placeholder with the real reason.
- `write_stderr_log` — persist the full captured stream to
  `runner-stderr.log` so the actionable tail survives a bounded `detail`.

This unit knows nothing about the SDK (pure stdlib).

Thin glue in `run_conversation` / `_drive_turn`:

- register a fresh `StderrCapture` per attempt via the `extra["stderr"]`
  seam (`stderr` is a real `ClaudeAgentOptions` field),
- on turn failure, resolve the awaiting future with the **enriched real
  cause** so `/v1/turn` returns a 502 carrying the real reason instead of
  a silent empty-200,
- enrich the supervisor's persisted `detail` + db row and feed the
  enriched string to `classify_auth_failure`, so an auth phrase that only
  appears in the captured stderr is still recognised.

## Testing (no mocks, no monkeypatching)

`tests/.../test__stderr_capture.py` exercises the pure unit against a
**real subprocess** — a child writes a known multi-line traceback to its
stderr and exits non-zero; we feed each real stderr line to the callback
(the same contract the SDK's stderr reader honours) and assert the
captured text reaches the enriched detail. No `unittest.mock`, no
`monkeypatch`, no fake SDK module. AAA markers, descriptive names, one
assert per test.

The SDK-coupled glue is kept minimal; the two pre-existing
`extra`-shape assertions in `test__session_conversation.py` are updated
to account for the always-on `stderr` callback.

## Verification

- `tests/scitex_agent_container/_runners/` — 278 passed
- full suite — 4792 passed, 38 skipped, 0 failed
- `scitex-linter` clean on the new files (no STX-NM / STX-TQ)