### PR TITLE
feat(runner): push completion report to turn requester via Stop hook

### DIFF
--- a/src/scitex_agent_container/_listen/_agent_exec.py
+++ b/src/scitex_agent_container/_listen/_agent_exec.py
@@ -1,0 +1,328 @@
+"""Agent prompt/key + start routes for ``sac listen`` (extracted from server.py).
+
+Hosts the claude-execution surface — sending a prompt or interrupt key to
+an agent and starting an agent — plus the claude-binary resolver and the
+SSE streaming helper they depend on:
+
+    POST /agents/<name>/send   → :func:`agent_send`
+    POST /agents               → :func:`agents_start`
+
+Split out of :mod:`scitex_agent_container._listen.server` (which grew
+past the per-file line cap). ``server.py`` re-imports the handlers so
+route registration (:func:`_v1_agent_routes`) and the historical
+``from ..._listen.server import agent_send`` import path keep working
+unchanged. No behaviour change — this is a pure extraction of one
+cohesive responsibility (driving the claude binary / starting agents)
+away from the host control-plane wiring that stays in ``server.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json as _json
+import os
+import shutil
+import subprocess
+
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response, StreamingResponse
+
+from .._runners._session_state import read_session_id, state_dir_for
+from ..config import load_config
+from ..config._resolve import resolve_config
+from ._acl import check_spawn, deny_response
+from ._forward import forward_to_live_runner
+from ._inline_spec import materialize_inline_spec
+
+__all__ = [
+    "_find_claude_binary",
+    "agent_send",
+    "agents_start",
+]
+
+
+def _find_claude_binary() -> str:
+    """Same resolver as send_cmds — bundled SDK copy first, then PATH."""
+    bundled = (
+        "/opt/venv-sac/lib/python3.12/site-packages/claude_agent_sdk/_bundled/claude"
+    )
+    if os.path.isfile(bundled) and os.access(bundled, os.X_OK):
+        return bundled
+    found = shutil.which("claude")
+    if not found:
+        raise RuntimeError("claude binary not found")
+    return found
+
+
+async def agent_send(request: Request) -> Response:
+    """POST /agents/<name>/send.
+
+    Body discriminator (per REQUIREMENT_SUMMARY §4.2):
+        {"type":"prompt","prompt":"...","options":{...}}
+        {"type":"key","key":"ESC"}
+
+    Back-compat (this commit only): a body without ``type`` is treated
+    as ``{type: "prompt", ...}`` so existing callers keep working.
+
+    Routing for ``type: prompt``:
+        1. If the agent has ``spec.a2a.port`` set and its inbound HTTP
+           is reachable, forward the turn into the live in-memory
+           runner inbox.
+        2. Otherwise fall back to ``claude --resume <sid> -p`` —
+           short-lived re-launch against the persisted session.jsonl.
+
+    Routing for ``type: key``:
+        SIGINT the live runner pid (best-effort). ESC / C-c / SIGINT
+        accepted; unknown keys → 400. No live runner → 404.
+    """
+    name = request.path_params["name"]
+    try:
+        body = await request.json()
+    except Exception:  # stx-allow: fallback (reason: malformed JSON → 400 with explanation rather than ASGI 500)
+        return JSONResponse({"error": "body must be JSON"}, status_code=400)
+
+    # Default to prompt when ``type`` is absent — back-compat shim
+    # documented in REQUIREMENT_SUMMARY §4.2.
+    type_ = body.get("type", "prompt")
+    if type_ == "key":
+        key = body.get("key")
+        # Supported: ESC / C-c / SIGINT — all map to SIGINT on the
+        # runner pid, which interrupts the current turn without
+        # killing the agent.
+        if key not in ("ESC", "C-c", "SIGINT"):
+            return JSONResponse(
+                {
+                    "error": (
+                        f"unsupported key={key!r}; expected one of "
+                        "'ESC', 'C-c', 'SIGINT'"
+                    )
+                },
+                status_code=400,
+            )
+        import signal as _signal
+
+        sd = state_dir_for(name)
+        pid_file = sd / "pid"
+        if not pid_file.is_file():
+            return JSONResponse(
+                {"error": f"agent {name!r} has no live session"},
+                status_code=404,
+            )
+        try:
+            pid = int(pid_file.read_text().strip())
+            os.kill(pid, _signal.SIGINT)
+        except (OSError, ValueError) as exc:
+            return JSONResponse({"error": str(exc)}, status_code=500)
+        return JSONResponse(
+            {
+                "name": name,
+                "route": "interrupt",
+                "pid": pid,
+                "signal": "SIGINT",
+            }
+        )
+    if type_ != "prompt":
+        return JSONResponse(
+            {"error": f"unknown type {type_!r}; expected 'prompt' or 'key'"},
+            status_code=400,
+        )
+
+    prompt = body.get("prompt")
+    if not isinstance(prompt, str) or not prompt:
+        return JSONResponse(
+            {"error": "missing or empty 'prompt' string"}, status_code=400
+        )
+
+    try:
+        spec_path = resolve_config(name)
+        cfg = load_config(spec_path)
+    except Exception as exc:
+        return JSONResponse({"error": str(exc)}, status_code=404)
+
+    # 1) Try live-runner route first.
+    options = body.get("options") or {}
+    live = await forward_to_live_runner(cfg, name, prompt, options)
+    if live is not None:
+        return live
+
+    # 2) Fall back to short-lived re-launch.
+    sd = state_dir_for(name)
+    sid = read_session_id(sd)
+    if not sid:
+        return JSONResponse(
+            {"error": f"no session_id recorded for {name!r}"}, status_code=409
+        )
+
+    try:
+        claude_bin = _find_claude_binary()
+    except RuntimeError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=500)
+
+    argv = [claude_bin, "--resume", sid, "-p", prompt]
+    if "model" in options:
+        argv += ["--model", str(options["model"])]
+    if "max_turns" in options:
+        argv += ["--max-turns", str(options["max_turns"])]
+
+    workdir = cfg.expanded_workdir or os.getcwd()
+
+    # SSE branch: client opted in via Accept: text/event-stream. Stream
+    # claude's stdout line-by-line as SSE frames.
+    accept = request.headers.get("accept", "")
+    if "text/event-stream" in accept:
+        argv += ["--output-format", "stream-json", "--include-partial-messages"]
+        return StreamingResponse(
+            _stream_claude(argv, workdir, name, sid),
+            media_type="text/event-stream",
+            headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+        )
+
+    # Buffered branch (default): run to completion, return one JSON blob.
+    proc = await asyncio.to_thread(
+        subprocess.run,
+        argv,
+        cwd=workdir,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return JSONResponse(
+        {
+            "name": name,
+            "session_id": sid,
+            "returncode": proc.returncode,
+            "stdout": proc.stdout,
+            "stderr": proc.stderr,
+        }
+    )
+
+
+def _sse_frame(event: str | None, data: str) -> bytes:
+    """Encode one SSE frame. ``event`` is optional; ``data`` is one line."""
+    head = f"event: {event}\n" if event else ""
+    return (head + f"data: {data}\n\n").encode("utf-8")
+
+
+async def _stream_claude(argv: list[str], workdir: str, name: str, sid: str):
+    """Run claude as an async subprocess and yield SSE frames."""
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *argv,
+            cwd=workdir,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+    except FileNotFoundError as exc:
+        yield _sse_frame("error", _json.dumps({"error": str(exc)}))
+        return
+
+    yield _sse_frame("start", _json.dumps({"name": name, "session_id": sid}))
+
+    assert proc.stdout is not None
+    try:
+        while True:
+            line = await proc.stdout.readline()
+            if not line:
+                break
+            yield _sse_frame(None, line.decode("utf-8", "replace").rstrip("\n"))
+        rc = await proc.wait()
+        yield _sse_frame("done", _json.dumps({"returncode": rc}))
+    except (asyncio.CancelledError, GeneratorExit):
+        if proc.returncode is None:
+            proc.terminate()
+            try:
+                await asyncio.wait_for(proc.wait(), timeout=2.0)
+            except asyncio.TimeoutError:
+                proc.kill()
+        raise
+
+
+async def agents_start(request: Request) -> JSONResponse:
+    """POST /agents — start one or more agents.
+
+    Body shapes:
+
+        # Start a pre-registered spec (existing on disk):
+        {"name": "<existing-spec-name>", "caller": "<sender-name>"}
+
+        # Register-and-start an ad-hoc spec in one call:
+        {
+            "name": "<name>",
+            "caller": "<sender-name>",
+            "spec": {"apiVersion": "scitex-agent-container/v3",
+                     "kind": "Agent",
+                     "spec": {...}},
+            "overwrite": false   # optional; default false → 409 on clash
+        }
+
+    WI-2 spawn-permission gate (limited scope per lead 2026-05-20):
+    the optional ``caller`` field carries the spawning node's name
+    (same self-claimed-identity caveat as ``message:send``'s
+    ``metadata.from_agent``). The gate is **root-only** today —
+    a node with no parent in the ``lineage`` table may spawn; a
+    child gets a clear 403. ``caller`` omitted = administrative /
+    human-operator path → allowed.
+
+    On allow, the parent → child edge is recorded in ``lineage``
+    so the new agent inherits the spawner's group.
+    """
+    try:
+        body = await request.json()
+    except (
+        Exception
+    ):  # stx-allow: fallback (reason: malformed JSON → 400 instead of 500)
+        return JSONResponse({"error": "body must be JSON"}, status_code=400)
+    name = body.get("name")
+    if not isinstance(name, str) or not name:
+        return JSONResponse(
+            {"error": "missing or empty 'name' string"}, status_code=400
+        )
+
+    # WI-2 spawn-permission gate.
+    caller = body.get("caller")
+    if caller is not None and not isinstance(caller, str):
+        return JSONResponse(
+            {"error": "'caller' must be a string if present"}, status_code=400
+        )
+    decision, reason = check_spawn(caller=caller)
+    if decision == "deny":
+        return deny_response(reason or "spawn denied")
+
+    inline_spec = body.get("spec")
+    if inline_spec is not None:
+        err = materialize_inline_spec(
+            name, inline_spec, overwrite=bool(body.get("overwrite"))
+        )
+        if err is not None:
+            return err
+
+    # Record lineage on allowed-spawn so the new child inherits the
+    # caller's group. ``caller=None`` → no lineage record (admin /
+    # operator path; the new agent starts as a root).
+    if caller:
+        from .._state.state_db_nodes import record_lineage as _record_lineage
+
+        try:
+            _record_lineage(child=name, parent=caller)
+        except ValueError as exc:
+            # Idempotent same-parent re-record is fine; a re-parent
+            # to a different caller is loudly rejected.
+            return JSONResponse({"error": str(exc)}, status_code=409)
+
+    sac_bin = shutil.which("sac") or "sac"
+    proc = await asyncio.to_thread(
+        subprocess.run,
+        [sac_bin, "agent", "start", name],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return JSONResponse(
+        {
+            "name": name,
+            "returncode": proc.returncode,
+            "stdout": proc.stdout,
+            "stderr": proc.stderr,
+        },
+        status_code=200 if proc.returncode == 0 else 502,
+    )

--- a/src/scitex_agent_container/_listen/_node_channel.py
+++ b/src/scitex_agent_container/_listen/_node_channel.py
@@ -1,0 +1,449 @@
+"""Node inbox-channel routes for ``sac listen`` (extracted from server.py).
+
+Hosts the A2A node-comms surface — the publish + subscribe halves of the
+per-node inbox channel plus the cross-host forwarder they depend on:
+
+    POST /agents/<name>/message:send   → :func:`node_message_send`
+    GET  /agents/<name>/inbox/stream    → :func:`node_inbox_stream`
+
+Split out of :mod:`scitex_agent_container._listen.server` (which grew
+past the per-file line cap). ``server.py`` re-imports the three handlers
+so route registration (:func:`_v1_agent_routes`) and the historical
+``from ..._listen.server import node_message_send`` test import path keep
+working unchanged. No behaviour change — this is a pure extraction of one
+cohesive responsibility (node comms) away from the agent-lifecycle /
+card responsibility that stays in ``server.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response, StreamingResponse
+
+from .._state.state_db_channel import (
+    list_since_id,
+    list_undelivered,
+    mark_delivered,
+    persist_event,
+)
+from ..a2a._inbox_bus import mint_deny_notification, mint_event
+from ._acl import check_send_acl, deny_response
+from ._nodes import Broker, NodeRegistry
+
+__all__ = ["_forward_to_remote", "node_message_send", "node_inbox_stream"]
+
+
+async def _forward_to_remote(
+    request: Request,
+    *,
+    body: dict[str, Any],
+    target_host: str,
+    target_port: int | None,
+    target_name: str,
+) -> Response:
+    """WI-4 cross-host forwarder. Reposts ``body`` to the destination
+    host's ``sac listen`` and proxies the response back.
+
+    **Bearer handling — per-host bearer registry** (Q4 (b)). The
+    destination's host bearer is read from
+    ``peer-tokens/<target_host>.token`` on the forwarding host. The
+    operator populates that registry with ``sac host add-peer <host>
+    <token>`` (one entry per peer). The forwarder uses that bearer
+    on the wire — not its own, not the original caller's. This
+    keeps the **per-host blast radius** the lead asked for: leaking
+    one host's listen bearer compromises only that host.
+
+    Missing ``peer-tokens/<host>.token`` is a **loud failure**: 502
+    with a clear "no peer token for X" message that names the file
+    and the ``sac host add-peer`` fix. Never silently drop a forward
+    (handoff §0 Hard rules).
+
+    **ACL handling**: the body is unchanged, so the destination
+    re-runs ``check_send_acl`` against the same
+    ``metadata.from_agent``. Because the forwarder authenticates
+    with the destination's *host* bearer (administrative caller),
+    ``authenticated_node`` is ``None`` at the destination and the
+    ACL gates on the metadata claim — exactly the cross-host shape
+    the lead documented under Q1's restored design. Cross-group
+    denials fire at the receiving host (handoff §4 acceptance "ACL
+    is enforced at the receiving host").
+    """
+    if not target_port:
+        return JSONResponse(
+            {
+                "error": (
+                    f"cannot forward to {target_name!r} on host "
+                    f"{target_host!r}: missing a2a_port in instances row"
+                )
+            },
+            status_code=502,
+        )
+
+    # ``state_db.resolve_node_host`` returns the *canonical* host
+    # name; we trust that to be reachable (handoff §2 "sac assumes
+    # reachability; orochi establishes it"). For loopback test
+    # scenarios callers set ``a2a_port`` to a 127.0.0.1 port and
+    # the test fixtures match the canonical host name to "host-a"
+    # / "host-b" via SAC_HOST.
+    import httpx as _httpx
+
+    from .peer_tokens import PeerTokenError, read_peer_token
+
+    forward_url = (
+        f"http://{target_host}:{target_port}/agents/{target_name}/message:send"
+    )
+    # In our test loopback both hosts live on 127.0.0.1; the canonical
+    # host name is a label, not a routable address. Rewrite to
+    # 127.0.0.1 when the resolved host is a known-loopback alias so
+    # the test fixtures can drive both legs on one machine. Real
+    # deployments use ssh-alias / tunnel hostnames and route as-is.
+    if target_host in ("host-a", "host-b") or target_host.startswith("host-"):
+        forward_url = (
+            f"http://127.0.0.1:{target_port}/agents/{target_name}/message:send"
+        )
+
+    # WI-4 Q4(b) — per-host bearer registry. Pull the destination's
+    # host bearer; loud 502 if it's missing.
+    try:
+        peer_bearer = read_peer_token(peer_host=target_host)
+    except PeerTokenError as exc:
+        return JSONResponse(
+            {"error": f"cross-host forward refused: {exc}"},
+            status_code=502,
+        )
+
+    forward_headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {peer_bearer}",
+    }
+
+    try:
+        async with _httpx.AsyncClient(timeout=15.0) as ac:
+            resp = await ac.post(forward_url, json=body, headers=forward_headers)
+    except _httpx.HTTPError as exc:
+        # Loud failure (handoff §0): the operator needs to see when
+        # cross-host reachability breaks, not get a silent 200.
+        return JSONResponse(
+            {"error": (f"cross-host forward to {forward_url!r} failed: {exc}")},
+            status_code=502,
+        )
+
+    # Pass through the destination's response, including its 403 / 400
+    # / 200 status. Body is JSON or text — try JSON first.
+    try:
+        return JSONResponse(resp.json(), status_code=resp.status_code)
+    except Exception:  # noqa: BLE001  # stx-allow: fallback (reason: non-JSON destination body is tolerated; surfaced as text)
+        return JSONResponse(
+            {"forwarded_body_text": resp.text}, status_code=resp.status_code
+        )
+
+
+async def node_message_send(request: Request) -> Response:
+    """``POST /agents/<name>/message:send`` — publish an A2A
+    ``SendMessage`` body to the local node's inbox bus.
+
+    Implicitly registers ``<name>`` as an external node on first use
+    so the synthesised AgentCard is available for the well-known
+    lookup. The publish is **always loud** — a malformed body returns
+    400, never a silent drop (handoff §0 Hard rules).
+
+    WI-2 ACL gate: every send is checked by
+    :func:`_acl.check_send_acl` before publish:
+
+    * **Per-node bearer** pins identity — ``metadata.from_agent``
+      must match the resolved name, else 403 "identity spoof"
+      (handoff §4 acceptance).
+    * **Cross-group** is denied by default; intra-group
+      (parent↔child and sibling↔sibling) is allowed.
+    * **Explicit cross-group grants** (``comms_grants`` table) flip
+      a deny to an allow.
+    * **Self-send** is always allowed.
+    * The **host-wide bearer** is the administrative / cross-host
+      forwarding caller; it honours ``metadata.from_agent``
+      verbatim (used by WI-4 forwarders authenticating with the
+      destination's host bearer from ``peer-tokens/`` registry).
+
+    Bearer auth is enforced by :class:`BearerAuthMiddleware` (outer
+    perimeter) and identity resolution by :class:`NodeAuthMiddleware`
+    (sets ``request.state.authenticated_node``).
+    """
+    name = request.path_params["name"]
+    try:
+        body = await request.json()
+    except (ValueError, json.JSONDecodeError) as exc:
+        return JSONResponse(
+            {"error": f"body must be valid JSON: {exc}"}, status_code=400
+        )
+    if not isinstance(body, dict):
+        return JSONResponse({"error": "body must be a JSON object"}, status_code=400)
+
+    method = body.get("method")
+    if method not in ("message/send", "SendMessage", "SendStreamingMessage"):
+        return JSONResponse(
+            {
+                "error": (
+                    f"unsupported method {method!r}; expected one of "
+                    "'message/send', 'SendMessage', 'SendStreamingMessage'"
+                )
+            },
+            status_code=400,
+        )
+
+    # WI-4 cross-host forward. If the target lives on a different
+    # host, forward the body unchanged to that host's sac listen.
+    # The destination re-runs the ACL check against the same
+    # ``metadata.from_agent`` we received, so cross-group denials
+    # fire at the receiving host (handoff §4 acceptance).
+    from .._state.state_db import _resolve_host as _resolve_local_host
+    from .._state.state_db_nodes import is_local_node, resolve_node_host
+
+    # Prefer the per-app ``local_host`` configured at ``create_app``
+    # time; fall back to the env-based resolver for callers that
+    # haven't pinned one. Per-app config matters for in-process
+    # multi-host tests where the env is shared.
+    local_host = getattr(request.app.state, "local_host", None) or _resolve_local_host(
+        None
+    )
+    if not is_local_node(name=name, local_host=local_host):
+        target_info = resolve_node_host(name=name)
+        if target_info is None:
+            return JSONResponse(
+                {
+                    "error": (
+                        f"target {name!r} resolves to a non-local host but no "
+                        "instance row carries its address — cannot forward"
+                    )
+                },
+                status_code=502,
+            )
+        return await _forward_to_remote(
+            request,
+            body=body,
+            target_host=target_info["host"],
+            target_port=target_info["a2a_port"],
+            target_name=name,
+        )
+
+    params = body.get("params") or {}
+    if not isinstance(params, dict):
+        return JSONResponse({"error": "params must be a JSON object"}, status_code=400)
+    message = params.get("message") or {}
+    parts = message.get("parts") if isinstance(message, dict) else None
+    text = ""
+    if isinstance(parts, list):
+        for p in parts:
+            if isinstance(p, dict) and isinstance(p.get("text"), str):
+                text += p["text"]
+
+    # sac-extension metadata: same convention as a2a/_server.py — under
+    # ``params.metadata`` first, then ``message.metadata`` as a
+    # secondary, since some clients prefer message-scoped metadata.
+    sac_meta: dict[str, Any] = {}
+    for src in (params.get("metadata"), message.get("metadata")):
+        if isinstance(src, dict):
+            sac_meta.update(src)
+
+    # WI-2 ACL check. ``authenticated_node`` is set by
+    # :class:`NodeAuthMiddleware` — ``None`` means the host-wide
+    # bearer was presented (administrative caller). With a per-node
+    # bearer, ``metadata.from_agent`` MUST match the resolved name
+    # so identity cannot be spoofed via a metadata field (handoff
+    # §4 acceptance). See :func:`_acl.check_send_acl`.
+    authenticated_node = getattr(request.state, "authenticated_node", None)
+    decision, reason = check_send_acl(
+        authenticated_node=authenticated_node,
+        claimed_from_agent=sac_meta.get("from_agent"),
+        target=name,
+    )
+    if decision == "deny":
+        # Comms item D — fail-loud on the RECEIVER side too. The sender
+        # gets a 403 with the reason; without this notification the
+        # receiver would never learn that someone tried to reach them
+        # and was denied, so they couldn't decide whether to grant. We
+        # publish a ``kind="denied_attempt"`` envelope onto the target's
+        # inbox channel carrying only attempt METADATA — never the
+        # message body, which must not leak to an unauthorized
+        # receiver. Persist + publish mirrors the success path
+        # (handoff §0 durability — a notification with no live
+        # subscriber must not be silently dropped) but the
+        # ``channel_events`` row's ``content`` column stays empty.
+        # The ``missing target`` deny has no inbox to notify, so we
+        # skip publishing in that case (still 403 to the sender).
+        if name:
+            broker: Broker = request.app.state.inbox
+            notif = mint_deny_notification(
+                target=name,
+                from_agent=(authenticated_node or sac_meta.get("from_agent")),
+                reason=reason or "ACL deny",
+            )
+            row_id = persist_event(target=name, event=notif)
+            notif["_row_id"] = row_id
+            await broker.publish(name, notif)
+        return deny_response(reason or "ACL deny")
+
+    event = mint_event(
+        name,
+        content=text,
+        from_agent=sac_meta.get("from_agent"),
+        conversation_id=sac_meta.get("conversation_id"),
+        in_reply_to=sac_meta.get("in_reply_to"),
+        priority=str(sac_meta.get("priority", "normal")),
+        requires_reply=bool(sac_meta.get("requires_reply", False)),
+        ack=bool(sac_meta.get("ack", False)),
+        dispatch_id=sac_meta.get("dispatch_id"),
+    )
+
+    # Implicit registration — handoff §4 "A2A compliance without a
+    # YAML": synthesise the card the first time the name is touched.
+    base_url = str(request.base_url).rstrip("/")
+    nodes: NodeRegistry = request.app.state.nodes
+    broker: Broker = request.app.state.inbox
+    nodes.register(name, base_url)
+
+    # WI-1 finish-work (Q5 — handoff §4 durability acceptance applied
+    # to the ``sac listen`` surface, not just ``a2a/_server.py``).
+    # Persist BEFORE publish so an event POSTed with no subscriber is
+    # not silently dropped (handoff §0 hard rule). The persisted row
+    # id is attached to the envelope as ``_row_id``; the SSE stream
+    # stamps it onto the ``id:`` line so clients can resume with
+    # ``Last-Event-ID``. A denied send (returned earlier with 403)
+    # never reaches this point — denial leaves no ``content`` on
+    # ``channel_events`` and emits no ``kind="message"`` event on the
+    # broker. (Comms item D adds a separate ``kind="denied_attempt"``
+    # envelope on the deny branch above so the receiver still learns
+    # of the attempt; only attempt metadata is published — never the
+    # message body.)
+    row_id = persist_event(target=name, event=event)
+    event["_row_id"] = row_id
+
+    delivered = await broker.publish(name, event)
+    return JSONResponse(
+        {
+            "msg_id": event["msg_id"],
+            "to_agent": name,
+            "delivered_subscriber_count": delivered,
+        }
+    )
+
+
+async def node_inbox_stream(request: Request) -> Response:
+    """``GET /agents/<name>/inbox/stream`` — SSE: one frame per event
+    published to ``<name>`` on this sac listen.
+
+    Consumed by ``sac mcp channel --name <name>`` inside an external
+    node's Claude session (or a sac-managed agent's container). The
+    frame shape is identical to ``a2a/_server.py``'s stream so the
+    same client adapter works for both kinds of node.
+
+    Implicitly registers ``<name>`` as an external node on first
+    connect.
+
+    WI-1 finish-work (Q5 — handoff §4 durability acceptance applied
+    to the ``sac listen`` surface, mirroring ``a2a/_server.py``):
+
+      * On connect, replay missed events from the persistent
+        ``channel_events`` table BEFORE accepting any new live event.
+        Replay source:
+
+          - if the client passed ``Last-Event-ID``, replay every row
+            with ``id > Last-Event-ID``;
+          - otherwise replay every undelivered row (fresh-subscriber
+            case — handoff acceptance "an event POSTed with no
+            subscriber is delivered on connect").
+
+      * Each replay frame stamps the SQLite row id onto the SSE
+        ``id:`` line so the client can echo it back as
+        ``Last-Event-ID`` after a reconnect.
+
+      * After yielding a replay frame the row is marked
+        ``delivered_at`` so a subsequent fresh-subscriber connect
+        does not re-yield it.
+
+      * A malformed ``Last-Event-ID`` header is a loud 400 — a
+        corrupt cursor would silently disable replay if tolerated
+        (handoff §0).
+    """
+    name = request.path_params["name"]
+    base_url = str(request.base_url).rstrip("/")
+    nodes: NodeRegistry = request.app.state.nodes
+    broker: Broker = request.app.state.inbox
+    nodes.register(name, base_url)
+
+    last_event_id_raw = request.headers.get("last-event-id")
+    last_event_id: int | None = None
+    if last_event_id_raw is not None:
+        try:
+            last_event_id = int(last_event_id_raw)
+        except ValueError:
+            return JSONResponse(
+                {
+                    "error": (
+                        "Last-Event-ID header must be an integer; got "
+                        f"{last_event_id_raw!r}"
+                    )
+                },
+                status_code=400,
+            )
+
+    queue = await broker.subscribe(name)
+
+    async def stream():
+        try:
+            # Comment-only frame so HTTP clients see the connection
+            # open immediately (and tests can race-free detect "I'm
+            # subscribed" before publishing).
+            yield b": sac-channel ready\n\n"
+
+            # WI-1 replay: yield every missed durable row first, then
+            # accept live events from the broker.
+            if last_event_id is not None:
+                replay = list_since_id(target=name, since_id=last_event_id)
+            else:
+                replay = list_undelivered(target=name)
+            for entry in replay:
+                if await request.is_disconnected():
+                    return
+                row_id = entry["id"]
+                event = entry["event"]
+                # Strip the internal ``_row_id`` if a previous publish
+                # path stored it inside ``meta_json``; the SSE ``id:``
+                # line is the authoritative cursor.
+                event.pop("_row_id", None)
+                data = json.dumps(event, ensure_ascii=False)
+                yield (f"id: {row_id}\nevent: message\ndata: {data}\n\n").encode(
+                    "utf-8"
+                )
+                mark_delivered([row_id])
+
+            while True:
+                if await request.is_disconnected():
+                    return
+                event = await queue.get()
+                # The publish path stamps the persisted row id onto
+                # the envelope as ``_row_id`` (see
+                # :func:`node_message_send`). We surface it as the SSE
+                # ``id:`` line and mark the row delivered.
+                row_id = event.pop("_row_id", None)
+                data = json.dumps(event, ensure_ascii=False)
+                if row_id is not None:
+                    yield (f"id: {row_id}\nevent: message\ndata: {data}\n\n").encode(
+                        "utf-8"
+                    )
+                    mark_delivered([int(row_id)])
+                else:
+                    # No row id means the event was injected by a
+                    # path that did NOT persist (future lifecycle
+                    # fan-out, ACL-reject notice, …). Deliver it but
+                    # skip the marker.
+                    yield f"event: message\ndata: {data}\n\n".encode("utf-8")
+        finally:
+            await broker.unsubscribe(name, queue)
+
+    return StreamingResponse(
+        stream(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )

--- a/src/scitex_agent_container/_listen/server.py
+++ b/src/scitex_agent_container/_listen/server.py
@@ -23,39 +23,22 @@ ADR-0004 (no backward compat).
 
 from __future__ import annotations
 
-import asyncio
-import json
-import json as _json
 import os
-import shutil
-import subprocess
 import urllib.error as _urlerror
 import urllib.request as _urlrequest
-from typing import Any
 
 from starlette.applications import Starlette
 from starlette.requests import Request
-from starlette.responses import JSONResponse, Response, StreamingResponse
+from starlette.responses import JSONResponse
 from starlette.routing import Route
 
 from .._runners._session_state import read_session_id, state_dir_for
 from .._state.registry import Registry
-from .._state.state_db_channel import (
-    list_since_id,
-    list_undelivered,
-    mark_delivered,
-    persist_event,
-)
-from ..a2a._inbox_bus import mint_deny_notification, mint_event
 from ..config import load_config
 from ..config._resolve import resolve_config
 from ._acl import (
     NodeAuthMiddleware,
-    check_send_acl,
-    check_spawn,
-    deny_response,
 )
-from ._inline_spec import materialize_inline_spec
 from ._nodes import Broker, NodeRegistry
 from .auth import BearerAuthMiddleware
 
@@ -63,19 +46,6 @@ from .auth import BearerAuthMiddleware
 # them as ``scitex_agent_container._listen.server._urlrequest.urlopen``
 # / ``._urlerror.URLError`` without forcing every call site to alias.
 __all__ = ["create_app", "_urlrequest", "_urlerror"]
-
-
-def _find_claude_binary() -> str:
-    """Same resolver as send_cmds — bundled SDK copy first, then PATH."""
-    bundled = (
-        "/opt/venv-sac/lib/python3.12/site-packages/claude_agent_sdk/_bundled/claude"
-    )
-    if os.path.isfile(bundled) and os.access(bundled, os.X_OK):
-        return bundled
-    found = shutil.which("claude")
-    if not found:
-        raise RuntimeError("claude binary not found")
-    return found
 
 
 # --- Handlers --------------------------------------------------------------
@@ -115,286 +85,21 @@ async def agent_status(request: Request) -> JSONResponse:
     )
 
 
-from ._forward import forward_to_live_runner  # noqa: E402
-
-
-async def agent_send(request: Request) -> Response:
-    """POST /agents/<name>/send.
-
-    Body discriminator (per REQUIREMENT_SUMMARY §4.2):
-        {"type":"prompt","prompt":"...","options":{...}}
-        {"type":"key","key":"ESC"}
-
-    Back-compat (this commit only): a body without ``type`` is treated
-    as ``{type: "prompt", ...}`` so existing callers keep working.
-
-    Routing for ``type: prompt``:
-        1. If the agent has ``spec.a2a.port`` set and its inbound HTTP
-           is reachable, forward the turn into the live in-memory
-           runner inbox.
-        2. Otherwise fall back to ``claude --resume <sid> -p`` —
-           short-lived re-launch against the persisted session.jsonl.
-
-    Routing for ``type: key``:
-        SIGINT the live runner pid (best-effort). ESC / C-c / SIGINT
-        accepted; unknown keys → 400. No live runner → 404.
-    """
-    name = request.path_params["name"]
-    try:
-        body = await request.json()
-    except Exception:  # stx-allow: fallback (reason: malformed JSON → 400 with explanation rather than ASGI 500)
-        return JSONResponse({"error": "body must be JSON"}, status_code=400)
-
-    # Default to prompt when ``type`` is absent — back-compat shim
-    # documented in REQUIREMENT_SUMMARY §4.2.
-    type_ = body.get("type", "prompt")
-    if type_ == "key":
-        key = body.get("key")
-        # Supported: ESC / C-c / SIGINT — all map to SIGINT on the
-        # runner pid, which interrupts the current turn without
-        # killing the agent.
-        if key not in ("ESC", "C-c", "SIGINT"):
-            return JSONResponse(
-                {
-                    "error": (
-                        f"unsupported key={key!r}; expected one of "
-                        "'ESC', 'C-c', 'SIGINT'"
-                    )
-                },
-                status_code=400,
-            )
-        import signal as _signal
-
-        sd = state_dir_for(name)
-        pid_file = sd / "pid"
-        if not pid_file.is_file():
-            return JSONResponse(
-                {"error": f"agent {name!r} has no live session"},
-                status_code=404,
-            )
-        try:
-            pid = int(pid_file.read_text().strip())
-            os.kill(pid, _signal.SIGINT)
-        except (OSError, ValueError) as exc:
-            return JSONResponse({"error": str(exc)}, status_code=500)
-        return JSONResponse(
-            {
-                "name": name,
-                "route": "interrupt",
-                "pid": pid,
-                "signal": "SIGINT",
-            }
-        )
-    if type_ != "prompt":
-        return JSONResponse(
-            {"error": f"unknown type {type_!r}; expected 'prompt' or 'key'"},
-            status_code=400,
-        )
-
-    prompt = body.get("prompt")
-    if not isinstance(prompt, str) or not prompt:
-        return JSONResponse(
-            {"error": "missing or empty 'prompt' string"}, status_code=400
-        )
-
-    try:
-        spec_path = resolve_config(name)
-        cfg = load_config(spec_path)
-    except Exception as exc:
-        return JSONResponse({"error": str(exc)}, status_code=404)
-
-    # 1) Try live-runner route first.
-    options = body.get("options") or {}
-    live = await forward_to_live_runner(cfg, name, prompt, options)
-    if live is not None:
-        return live
-
-    # 2) Fall back to short-lived re-launch.
-    sd = state_dir_for(name)
-    sid = read_session_id(sd)
-    if not sid:
-        return JSONResponse(
-            {"error": f"no session_id recorded for {name!r}"}, status_code=409
-        )
-
-    try:
-        claude_bin = _find_claude_binary()
-    except RuntimeError as exc:
-        return JSONResponse({"error": str(exc)}, status_code=500)
-
-    argv = [claude_bin, "--resume", sid, "-p", prompt]
-    if "model" in options:
-        argv += ["--model", str(options["model"])]
-    if "max_turns" in options:
-        argv += ["--max-turns", str(options["max_turns"])]
-
-    workdir = cfg.expanded_workdir or os.getcwd()
-
-    # SSE branch: client opted in via Accept: text/event-stream. Stream
-    # claude's stdout line-by-line as SSE frames.
-    accept = request.headers.get("accept", "")
-    if "text/event-stream" in accept:
-        argv += ["--output-format", "stream-json", "--include-partial-messages"]
-        return StreamingResponse(
-            _stream_claude(argv, workdir, name, sid),
-            media_type="text/event-stream",
-            headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
-        )
-
-    # Buffered branch (default): run to completion, return one JSON blob.
-    proc = await asyncio.to_thread(
-        subprocess.run,
-        argv,
-        cwd=workdir,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    return JSONResponse(
-        {
-            "name": name,
-            "session_id": sid,
-            "returncode": proc.returncode,
-            "stdout": proc.stdout,
-            "stderr": proc.stderr,
-        }
-    )
-
-
-def _sse_frame(event: str | None, data: str) -> bytes:
-    """Encode one SSE frame. ``event`` is optional; ``data`` is one line."""
-    head = f"event: {event}\n" if event else ""
-    return (head + f"data: {data}\n\n").encode("utf-8")
-
-
-async def _stream_claude(argv: list[str], workdir: str, name: str, sid: str):
-    """Run claude as an async subprocess and yield SSE frames."""
-    try:
-        proc = await asyncio.create_subprocess_exec(
-            *argv,
-            cwd=workdir,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-    except FileNotFoundError as exc:
-        yield _sse_frame("error", _json.dumps({"error": str(exc)}))
-        return
-
-    yield _sse_frame("start", _json.dumps({"name": name, "session_id": sid}))
-
-    assert proc.stdout is not None
-    try:
-        while True:
-            line = await proc.stdout.readline()
-            if not line:
-                break
-            yield _sse_frame(None, line.decode("utf-8", "replace").rstrip("\n"))
-        rc = await proc.wait()
-        yield _sse_frame("done", _json.dumps({"returncode": rc}))
-    except (asyncio.CancelledError, GeneratorExit):
-        if proc.returncode is None:
-            proc.terminate()
-            try:
-                await asyncio.wait_for(proc.wait(), timeout=2.0)
-            except asyncio.TimeoutError:
-                proc.kill()
-        raise
-
-
-# --- tail (SSE over session.jsonl) — extracted to ``_tail.py`` -------------
-
+# --- extracted handlers re-imported for routes + back-compat ---------------
+#
+# ``agent_send`` (prompt / interrupt-key) + ``agents_start`` (claude-exec),
+# the ``agent_tail`` SSE-over-session.jsonl handler, and the node inbox
+# channel were all extracted into focused sibling modules (server.py hit the
+# per-file line cap). Re-imported here so route registration
+# (:func:`_v1_agent_routes`) and the historical
+# ``from ..._listen.server import agent_send`` test import path keep working
+# unchanged.
+from ._agent_exec import (  # noqa: E402
+    _find_claude_binary,  # noqa: F401  (re-exported for tests)
+    agent_send,
+    agents_start,
+)
 from ._tail import agent_tail  # noqa: F401, E402  (re-exported for routes)
-
-
-async def agents_start(request: Request) -> JSONResponse:
-    """POST /agents — start one or more agents.
-
-    Body shapes:
-
-        # Start a pre-registered spec (existing on disk):
-        {"name": "<existing-spec-name>", "caller": "<sender-name>"}
-
-        # Register-and-start an ad-hoc spec in one call:
-        {
-            "name": "<name>",
-            "caller": "<sender-name>",
-            "spec": {"apiVersion": "scitex-agent-container/v3",
-                     "kind": "Agent",
-                     "spec": {...}},
-            "overwrite": false   # optional; default false → 409 on clash
-        }
-
-    WI-2 spawn-permission gate (limited scope per lead 2026-05-20):
-    the optional ``caller`` field carries the spawning node's name
-    (same self-claimed-identity caveat as ``message:send``'s
-    ``metadata.from_agent``). The gate is **root-only** today —
-    a node with no parent in the ``lineage`` table may spawn; a
-    child gets a clear 403. ``caller`` omitted = administrative /
-    human-operator path → allowed.
-
-    On allow, the parent → child edge is recorded in ``lineage``
-    so the new agent inherits the spawner's group.
-    """
-    try:
-        body = await request.json()
-    except (
-        Exception
-    ):  # stx-allow: fallback (reason: malformed JSON → 400 instead of 500)
-        return JSONResponse({"error": "body must be JSON"}, status_code=400)
-    name = body.get("name")
-    if not isinstance(name, str) or not name:
-        return JSONResponse(
-            {"error": "missing or empty 'name' string"}, status_code=400
-        )
-
-    # WI-2 spawn-permission gate.
-    caller = body.get("caller")
-    if caller is not None and not isinstance(caller, str):
-        return JSONResponse(
-            {"error": "'caller' must be a string if present"}, status_code=400
-        )
-    decision, reason = check_spawn(caller=caller)
-    if decision == "deny":
-        return deny_response(reason or "spawn denied")
-
-    inline_spec = body.get("spec")
-    if inline_spec is not None:
-        err = materialize_inline_spec(
-            name, inline_spec, overwrite=bool(body.get("overwrite"))
-        )
-        if err is not None:
-            return err
-
-    # Record lineage on allowed-spawn so the new child inherits the
-    # caller's group. ``caller=None`` → no lineage record (admin /
-    # operator path; the new agent starts as a root).
-    if caller:
-        from .._state.state_db_nodes import record_lineage as _record_lineage
-
-        try:
-            _record_lineage(child=name, parent=caller)
-        except ValueError as exc:
-            # Idempotent same-parent re-record is fine; a re-parent
-            # to a different caller is loudly rejected.
-            return JSONResponse({"error": str(exc)}, status_code=409)
-
-    sac_bin = shutil.which("sac") or "sac"
-    proc = await asyncio.to_thread(
-        subprocess.run,
-        [sac_bin, "agent", "start", name],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    return JSONResponse(
-        {
-            "name": name,
-            "returncode": proc.returncode,
-            "stdout": proc.stdout,
-            "stderr": proc.stderr,
-        },
-        status_code=200 if proc.returncode == 0 else 502,
-    )
 
 
 async def agent_card(request: Request) -> JSONResponse:
@@ -436,9 +141,7 @@ async def agent_card(request: Request) -> JSONResponse:
     if card is not None:
         return JSONResponse(card)
 
-    return JSONResponse(
-        {"error": f"unknown agent or node: {name!r}"}, status_code=404
-    )
+    return JSONResponse({"error": f"unknown agent or node: {name!r}"}, status_code=404)
 
 
 async def fleet_card_handler(request: Request) -> JSONResponse:
@@ -468,440 +171,28 @@ async def fleet_card_handler(request: Request) -> JSONResponse:
 # endpoints (``message:send`` and ``inbox/stream``) on the always-on
 # ``sac listen`` host control-plane and makes them keyed by **node
 # identity** — they must accept a name that has no YAML and no
-# container. The handlers below are the implementation of that
-# requirement.
+# container.
 #
 # Routes registered in ``_v1_agent_routes`` below:
 #
 #   POST /agents/{name}/message:send  → node_message_send
 #   GET  /agents/{name}/inbox/stream  → node_inbox_stream
 #
+# The handlers were extracted into ``_node_channel`` (server.py hit the
+# per-file line cap); re-imported here so route registration and the
+# historical ``from ..._listen.server import node_message_send`` import
+# path keep working unchanged. ``_forward_to_remote`` rides along (it is
+# the cross-host leg of ``node_message_send``).
+#
 # The agent-card route is *not* overridden here — instead
 # :func:`agent_card` falls back to the synthesised card for nodes
 # that are not YAML-backed. That fall-back is added to the existing
 # handler below.
-
-
-async def _forward_to_remote(
-    request: Request,
-    *,
-    body: dict[str, Any],
-    target_host: str,
-    target_port: int | None,
-    target_name: str,
-) -> Response:
-    """WI-4 cross-host forwarder. Reposts ``body`` to the destination
-    host's ``sac listen`` and proxies the response back.
-
-    **Bearer handling — per-host bearer registry** (Q4 (b)). The
-    destination's host bearer is read from
-    ``peer-tokens/<target_host>.token`` on the forwarding host. The
-    operator populates that registry with ``sac host add-peer <host>
-    <token>`` (one entry per peer). The forwarder uses that bearer
-    on the wire — not its own, not the original caller's. This
-    keeps the **per-host blast radius** the lead asked for: leaking
-    one host's listen bearer compromises only that host.
-
-    Missing ``peer-tokens/<host>.token`` is a **loud failure**: 502
-    with a clear "no peer token for X" message that names the file
-    and the ``sac host add-peer`` fix. Never silently drop a forward
-    (handoff §0 Hard rules).
-
-    **ACL handling**: the body is unchanged, so the destination
-    re-runs ``check_send_acl`` against the same
-    ``metadata.from_agent``. Because the forwarder authenticates
-    with the destination's *host* bearer (administrative caller),
-    ``authenticated_node`` is ``None`` at the destination and the
-    ACL gates on the metadata claim — exactly the cross-host shape
-    the lead documented under Q1's restored design. Cross-group
-    denials fire at the receiving host (handoff §4 acceptance "ACL
-    is enforced at the receiving host").
-    """
-    if not target_port:
-        return JSONResponse(
-            {
-                "error": (
-                    f"cannot forward to {target_name!r} on host "
-                    f"{target_host!r}: missing a2a_port in instances row"
-                )
-            },
-            status_code=502,
-        )
-
-    # ``state_db.resolve_node_host`` returns the *canonical* host
-    # name; we trust that to be reachable (handoff §2 "sac assumes
-    # reachability; orochi establishes it"). For loopback test
-    # scenarios callers set ``a2a_port`` to a 127.0.0.1 port and
-    # the test fixtures match the canonical host name to "host-a"
-    # / "host-b" via SAC_HOST.
-    import httpx as _httpx
-
-    from .peer_tokens import PeerTokenError, read_peer_token
-
-    forward_url = f"http://{target_host}:{target_port}/agents/{target_name}/message:send"
-    # In our test loopback both hosts live on 127.0.0.1; the canonical
-    # host name is a label, not a routable address. Rewrite to
-    # 127.0.0.1 when the resolved host is a known-loopback alias so
-    # the test fixtures can drive both legs on one machine. Real
-    # deployments use ssh-alias / tunnel hostnames and route as-is.
-    if target_host in ("host-a", "host-b") or target_host.startswith("host-"):
-        forward_url = (
-            f"http://127.0.0.1:{target_port}/agents/{target_name}/message:send"
-        )
-
-    # WI-4 Q4(b) — per-host bearer registry. Pull the destination's
-    # host bearer; loud 502 if it's missing.
-    try:
-        peer_bearer = read_peer_token(peer_host=target_host)
-    except PeerTokenError as exc:
-        return JSONResponse(
-            {"error": f"cross-host forward refused: {exc}"},
-            status_code=502,
-        )
-
-    forward_headers = {
-        "Content-Type": "application/json",
-        "Authorization": f"Bearer {peer_bearer}",
-    }
-
-    try:
-        async with _httpx.AsyncClient(timeout=15.0) as ac:
-            resp = await ac.post(forward_url, json=body, headers=forward_headers)
-    except _httpx.HTTPError as exc:
-        # Loud failure (handoff §0): the operator needs to see when
-        # cross-host reachability breaks, not get a silent 200.
-        return JSONResponse(
-            {
-                "error": (
-                    f"cross-host forward to {forward_url!r} failed: {exc}"
-                )
-            },
-            status_code=502,
-        )
-
-    # Pass through the destination's response, including its 403 / 400
-    # / 200 status. Body is JSON or text — try JSON first.
-    try:
-        return JSONResponse(resp.json(), status_code=resp.status_code)
-    except Exception:  # noqa: BLE001  # stx-allow: fallback (reason: non-JSON destination body is tolerated; surfaced as text)
-        return JSONResponse(
-            {"forwarded_body_text": resp.text}, status_code=resp.status_code
-        )
-
-
-async def node_message_send(request: Request) -> Response:
-    """``POST /agents/<name>/message:send`` — publish an A2A
-    ``SendMessage`` body to the local node's inbox bus.
-
-    Implicitly registers ``<name>`` as an external node on first use
-    so the synthesised AgentCard is available for the well-known
-    lookup. The publish is **always loud** — a malformed body returns
-    400, never a silent drop (handoff §0 Hard rules).
-
-    WI-2 ACL gate: every send is checked by
-    :func:`_acl.check_send_acl` before publish:
-
-    * **Per-node bearer** pins identity — ``metadata.from_agent``
-      must match the resolved name, else 403 "identity spoof"
-      (handoff §4 acceptance).
-    * **Cross-group** is denied by default; intra-group
-      (parent↔child and sibling↔sibling) is allowed.
-    * **Explicit cross-group grants** (``comms_grants`` table) flip
-      a deny to an allow.
-    * **Self-send** is always allowed.
-    * The **host-wide bearer** is the administrative / cross-host
-      forwarding caller; it honours ``metadata.from_agent``
-      verbatim (used by WI-4 forwarders authenticating with the
-      destination's host bearer from ``peer-tokens/`` registry).
-
-    Bearer auth is enforced by :class:`BearerAuthMiddleware` (outer
-    perimeter) and identity resolution by :class:`NodeAuthMiddleware`
-    (sets ``request.state.authenticated_node``).
-    """
-    name = request.path_params["name"]
-    try:
-        body = await request.json()
-    except (ValueError, json.JSONDecodeError) as exc:
-        return JSONResponse(
-            {"error": f"body must be valid JSON: {exc}"}, status_code=400
-        )
-    if not isinstance(body, dict):
-        return JSONResponse(
-            {"error": "body must be a JSON object"}, status_code=400
-        )
-
-    method = body.get("method")
-    if method not in ("message/send", "SendMessage", "SendStreamingMessage"):
-        return JSONResponse(
-            {
-                "error": (
-                    f"unsupported method {method!r}; expected one of "
-                    "'message/send', 'SendMessage', 'SendStreamingMessage'"
-                )
-            },
-            status_code=400,
-        )
-
-    # WI-4 cross-host forward. If the target lives on a different
-    # host, forward the body unchanged to that host's sac listen.
-    # The destination re-runs the ACL check against the same
-    # ``metadata.from_agent`` we received, so cross-group denials
-    # fire at the receiving host (handoff §4 acceptance).
-    from .._state.state_db_nodes import is_local_node, resolve_node_host
-    from .._state.state_db import _resolve_host as _resolve_local_host
-
-    # Prefer the per-app ``local_host`` configured at ``create_app``
-    # time; fall back to the env-based resolver for callers that
-    # haven't pinned one. Per-app config matters for in-process
-    # multi-host tests where the env is shared.
-    local_host = getattr(request.app.state, "local_host", None) or _resolve_local_host(None)
-    if not is_local_node(name=name, local_host=local_host):
-        target_info = resolve_node_host(name=name)
-        if target_info is None:
-            return JSONResponse(
-                {
-                    "error": (
-                        f"target {name!r} resolves to a non-local host but no "
-                        "instance row carries its address — cannot forward"
-                    )
-                },
-                status_code=502,
-            )
-        return await _forward_to_remote(
-            request,
-            body=body,
-            target_host=target_info["host"],
-            target_port=target_info["a2a_port"],
-            target_name=name,
-        )
-
-    params = body.get("params") or {}
-    if not isinstance(params, dict):
-        return JSONResponse(
-            {"error": "params must be a JSON object"}, status_code=400
-        )
-    message = params.get("message") or {}
-    parts = message.get("parts") if isinstance(message, dict) else None
-    text = ""
-    if isinstance(parts, list):
-        for p in parts:
-            if isinstance(p, dict) and isinstance(p.get("text"), str):
-                text += p["text"]
-
-    # sac-extension metadata: same convention as a2a/_server.py — under
-    # ``params.metadata`` first, then ``message.metadata`` as a
-    # secondary, since some clients prefer message-scoped metadata.
-    sac_meta: dict[str, Any] = {}
-    for src in (params.get("metadata"), message.get("metadata")):
-        if isinstance(src, dict):
-            sac_meta.update(src)
-
-    # WI-2 ACL check. ``authenticated_node`` is set by
-    # :class:`NodeAuthMiddleware` — ``None`` means the host-wide
-    # bearer was presented (administrative caller). With a per-node
-    # bearer, ``metadata.from_agent`` MUST match the resolved name
-    # so identity cannot be spoofed via a metadata field (handoff
-    # §4 acceptance). See :func:`_acl.check_send_acl`.
-    authenticated_node = getattr(
-        request.state, "authenticated_node", None
-    )
-    decision, reason = check_send_acl(
-        authenticated_node=authenticated_node,
-        claimed_from_agent=sac_meta.get("from_agent"),
-        target=name,
-    )
-    if decision == "deny":
-        # Comms item D — fail-loud on the RECEIVER side too. The sender
-        # gets a 403 with the reason; without this notification the
-        # receiver would never learn that someone tried to reach them
-        # and was denied, so they couldn't decide whether to grant. We
-        # publish a ``kind="denied_attempt"`` envelope onto the target's
-        # inbox channel carrying only attempt METADATA — never the
-        # message body, which must not leak to an unauthorized
-        # receiver. Persist + publish mirrors the success path
-        # (handoff §0 durability — a notification with no live
-        # subscriber must not be silently dropped) but the
-        # ``channel_events`` row's ``content`` column stays empty.
-        # The ``missing target`` deny has no inbox to notify, so we
-        # skip publishing in that case (still 403 to the sender).
-        if name:
-            broker: Broker = request.app.state.inbox
-            notif = mint_deny_notification(
-                target=name,
-                from_agent=(
-                    authenticated_node or sac_meta.get("from_agent")
-                ),
-                reason=reason or "ACL deny",
-            )
-            row_id = persist_event(target=name, event=notif)
-            notif["_row_id"] = row_id
-            await broker.publish(name, notif)
-        return deny_response(reason or "ACL deny")
-
-    event = mint_event(
-        name,
-        content=text,
-        from_agent=sac_meta.get("from_agent"),
-        conversation_id=sac_meta.get("conversation_id"),
-        in_reply_to=sac_meta.get("in_reply_to"),
-        priority=str(sac_meta.get("priority", "normal")),
-        requires_reply=bool(sac_meta.get("requires_reply", False)),
-        ack=bool(sac_meta.get("ack", False)),
-    )
-
-    # Implicit registration — handoff §4 "A2A compliance without a
-    # YAML": synthesise the card the first time the name is touched.
-    base_url = str(request.base_url).rstrip("/")
-    nodes: NodeRegistry = request.app.state.nodes
-    broker: Broker = request.app.state.inbox
-    nodes.register(name, base_url)
-
-    # WI-1 finish-work (Q5 — handoff §4 durability acceptance applied
-    # to the ``sac listen`` surface, not just ``a2a/_server.py``).
-    # Persist BEFORE publish so an event POSTed with no subscriber is
-    # not silently dropped (handoff §0 hard rule). The persisted row
-    # id is attached to the envelope as ``_row_id``; the SSE stream
-    # stamps it onto the ``id:`` line so clients can resume with
-    # ``Last-Event-ID``. A denied send (returned earlier with 403)
-    # never reaches this point — denial leaves no ``content`` on
-    # ``channel_events`` and emits no ``kind="message"`` event on the
-    # broker. (Comms item D adds a separate ``kind="denied_attempt"``
-    # envelope on the deny branch above so the receiver still learns
-    # of the attempt; only attempt metadata is published — never the
-    # message body.)
-    row_id = persist_event(target=name, event=event)
-    event["_row_id"] = row_id
-
-    delivered = await broker.publish(name, event)
-    return JSONResponse(
-        {
-            "msg_id": event["msg_id"],
-            "to_agent": name,
-            "delivered_subscriber_count": delivered,
-        }
-    )
-
-
-async def node_inbox_stream(request: Request) -> Response:
-    """``GET /agents/<name>/inbox/stream`` — SSE: one frame per event
-    published to ``<name>`` on this sac listen.
-
-    Consumed by ``sac mcp channel --name <name>`` inside an external
-    node's Claude session (or a sac-managed agent's container). The
-    frame shape is identical to ``a2a/_server.py``'s stream so the
-    same client adapter works for both kinds of node.
-
-    Implicitly registers ``<name>`` as an external node on first
-    connect.
-
-    WI-1 finish-work (Q5 — handoff §4 durability acceptance applied
-    to the ``sac listen`` surface, mirroring ``a2a/_server.py``):
-
-      * On connect, replay missed events from the persistent
-        ``channel_events`` table BEFORE accepting any new live event.
-        Replay source:
-
-          - if the client passed ``Last-Event-ID``, replay every row
-            with ``id > Last-Event-ID``;
-          - otherwise replay every undelivered row (fresh-subscriber
-            case — handoff acceptance "an event POSTed with no
-            subscriber is delivered on connect").
-
-      * Each replay frame stamps the SQLite row id onto the SSE
-        ``id:`` line so the client can echo it back as
-        ``Last-Event-ID`` after a reconnect.
-
-      * After yielding a replay frame the row is marked
-        ``delivered_at`` so a subsequent fresh-subscriber connect
-        does not re-yield it.
-
-      * A malformed ``Last-Event-ID`` header is a loud 400 — a
-        corrupt cursor would silently disable replay if tolerated
-        (handoff §0).
-    """
-    from starlette.responses import StreamingResponse
-
-    name = request.path_params["name"]
-    base_url = str(request.base_url).rstrip("/")
-    nodes: NodeRegistry = request.app.state.nodes
-    broker: Broker = request.app.state.inbox
-    nodes.register(name, base_url)
-
-    last_event_id_raw = request.headers.get("last-event-id")
-    last_event_id: int | None = None
-    if last_event_id_raw is not None:
-        try:
-            last_event_id = int(last_event_id_raw)
-        except ValueError:
-            return JSONResponse(
-                {
-                    "error": (
-                        "Last-Event-ID header must be an integer; got "
-                        f"{last_event_id_raw!r}"
-                    )
-                },
-                status_code=400,
-            )
-
-    queue = await broker.subscribe(name)
-
-    async def stream():
-        try:
-            # Comment-only frame so HTTP clients see the connection
-            # open immediately (and tests can race-free detect "I'm
-            # subscribed" before publishing).
-            yield b": sac-channel ready\n\n"
-
-            # WI-1 replay: yield every missed durable row first, then
-            # accept live events from the broker.
-            if last_event_id is not None:
-                replay = list_since_id(target=name, since_id=last_event_id)
-            else:
-                replay = list_undelivered(target=name)
-            for entry in replay:
-                if await request.is_disconnected():
-                    return
-                row_id = entry["id"]
-                event = entry["event"]
-                # Strip the internal ``_row_id`` if a previous publish
-                # path stored it inside ``meta_json``; the SSE ``id:``
-                # line is the authoritative cursor.
-                event.pop("_row_id", None)
-                data = json.dumps(event, ensure_ascii=False)
-                yield (
-                    f"id: {row_id}\nevent: message\ndata: {data}\n\n"
-                ).encode("utf-8")
-                mark_delivered([row_id])
-
-            while True:
-                if await request.is_disconnected():
-                    return
-                event = await queue.get()
-                # The publish path stamps the persisted row id onto
-                # the envelope as ``_row_id`` (see
-                # :func:`node_message_send`). We surface it as the SSE
-                # ``id:`` line and mark the row delivered.
-                row_id = event.pop("_row_id", None)
-                data = json.dumps(event, ensure_ascii=False)
-                if row_id is not None:
-                    yield (
-                        f"id: {row_id}\nevent: message\ndata: {data}\n\n"
-                    ).encode("utf-8")
-                    mark_delivered([int(row_id)])
-                else:
-                    # No row id means the event was injected by a
-                    # path that did NOT persist (future lifecycle
-                    # fan-out, ACL-reject notice, …). Deliver it but
-                    # skip the marker.
-                    yield f"event: message\ndata: {data}\n\n".encode("utf-8")
-        finally:
-            await broker.unsubscribe(name, queue)
-
-    return StreamingResponse(
-        stream(),
-        media_type="text/event-stream",
-        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
-    )
+from ._node_channel import (  # noqa: E402
+    _forward_to_remote,  # noqa: F401  (re-exported for tests)
+    node_inbox_stream,
+    node_message_send,
+)
 
 
 async def agent_delete(request: Request) -> JSONResponse:

--- a/src/scitex_agent_container/_mcp/_channel_wake.py
+++ b/src/scitex_agent_container/_mcp/_channel_wake.py
@@ -73,13 +73,31 @@ async def _wake_turn(
     once rather than buffered until some unrelated next turn. Raises on any
     transport/HTTP failure so the caller can decide whether to surface or
     contain it (WI-2 fail-loud).
+
+    Requester identity rides into the body so the woken turn's
+    ``TurnEnvelope`` carries it through to the Stop hook, which PUSHes a
+    completion report back to whoever asked. ``from_agent`` is the event's
+    sender (the requesting peer — generalizes to ANY peer, the lead is not
+    special-cased); ``dispatch_id`` is the sender-minted ledger id when the
+    sender minted one. Both are tolerated-absent: an event with no sender /
+    no ledger id simply drives a turn the Stop hook cannot address.
     """
     import httpx
 
     headers = {"Content-Type": "application/json"}
     if bearer:
         headers["Authorization"] = f"Bearer {bearer}"
-    payload = {"text": _wake_text(event)}
+    payload: dict[str, Any] = {"text": _wake_text(event)}
+    requester = event.get("from_agent")
+    if isinstance(requester, str) and requester and requester != "unknown":
+        # ``mint_event`` defaults a missing sender to the literal
+        # ``"unknown"`` — that is not an addressable peer, so don't thread
+        # it as a requester (the Stop hook would otherwise try to push to a
+        # node named "unknown").
+        payload["from_agent"] = requester
+    dispatch_id = event.get("dispatch_id")
+    if isinstance(dispatch_id, str) and dispatch_id:
+        payload["dispatch_id"] = dispatch_id
     # The wake POST returns only after the driven turn completes (the runner
     # awaits the SDK reply before responding). Use no client-side deadline —
     # a short client timeout would abort a legitimately long turn; the runner

--- a/src/scitex_agent_container/_network/peer.py
+++ b/src/scitex_agent_container/_network/peer.py
@@ -120,8 +120,15 @@ def post_turn_to_url(
     )
 
     dispatch_id = new_dispatch_id()
+    # The requester identity stamped on both the ledger row AND the wire
+    # body. Defaults to this container's own name so the receiver's Stop
+    # hook can PUSH a completion report back to us — push-feedback, not a
+    # special-cased lead. ``None`` only when neither an explicit value nor
+    # ``SAC_NAME`` is available (a bare ops script), in which case the
+    # receiver has nobody to address and skips the push.
+    requester = from_agent if from_agent is not None else self_agent_name()
     record_dispatch_safe(
-        from_agent=from_agent if from_agent is not None else self_agent_name(),
+        from_agent=requester,
         to_agent=to_agent,
         text=text,
         conversation_id=conversation_id,
@@ -136,6 +143,7 @@ def post_turn_to_url(
                 exit_after=exit_after,
                 timeout_s=timeout_s,
                 dispatch_id=dispatch_id,
+                from_agent=requester,
             )
         except PeerError as exc:
             terminal = (
@@ -146,13 +154,14 @@ def post_turn_to_url(
         update_dispatch_safe(dispatch_id, STATUS_DELIVERED)
         return reply
 
-    body = json.dumps(
-        {
-            "text": text,
-            "exit_after": bool(exit_after),
-            "dispatch_id": dispatch_id,
-        }
-    ).encode("utf-8")
+    turn_body: dict[str, Any] = {
+        "text": text,
+        "exit_after": bool(exit_after),
+        "dispatch_id": dispatch_id,
+    }
+    if requester is not None:
+        turn_body["from_agent"] = requester
+    body = json.dumps(turn_body).encode("utf-8")
     req = urllib.request.Request(
         url,
         data=body,
@@ -374,6 +383,7 @@ def _post_turn_via_ssh(
     exit_after: bool,
     timeout_s: float,
     dispatch_id: str | None = None,
+    from_agent: str | None = None,
 ) -> str:
     """Dispatch a turn via ``ssh <host> curl ...`` and parse the response.
 
@@ -408,6 +418,8 @@ def _post_turn_via_ssh(
     turn_body: dict[str, Any] = {"text": text, "exit_after": bool(exit_after)}
     if dispatch_id is not None:
         turn_body["dispatch_id"] = dispatch_id
+    if from_agent is not None:
+        turn_body["from_agent"] = from_agent
     body = json.dumps(turn_body)
     try:
         proc = subprocess.run(

--- a/src/scitex_agent_container/_runners/_session_completion.py
+++ b/src/scitex_agent_container/_runners/_session_completion.py
@@ -1,0 +1,210 @@
+"""Stop-hook completion push for the claude-session runner.
+
+When a turn finishes, the runner's Stop hook PUSHes a completion report
+back to whoever dispatched the turn — the *requester* threaded onto the
+``TurnEnvelope`` (``from_agent`` + ``dispatch_id``). This realises the
+push-feedback north star: a peer that drove a turn into this agent hears
+about completion without polling, and it generalises to ANY peer — the
+lead is not special-cased.
+
+The push reuses the existing ``sac listen`` ``message:send`` channel
+(the same path ``a2a_send`` uses): POST a JSON-RPC ``SendMessage`` to
+``{SAC_LISTEN_BASE_URL}/agents/<requester>/message:send`` with the
+completion payload as the message text and sac-extension metadata under
+``params.metadata``. That path already publishes to the requester's
+inbox Broker, persists to ``channel_events``, and — crucially — FAILS
+LOUD when ``delivered_subscriber_count == 0`` (no live subscriber). We
+honour that: a push that reaches nobody raises :class:`CompletionPushError`
+so the failure is visible, never a silent drop.
+
+The completion payload the requester receives is the JSON object
+``{agent, dispatch_id, status, summary}``:
+
+* ``agent``       — this agent's own name (who is reporting).
+* ``dispatch_id`` — the sender-minted ledger id that resolves *which
+  task from which agent* (operator's explicit requirement). ``None``
+  when the dispatch was not minted through the ledger.
+* ``status``      — honest turn outcome: ``"success"`` (the turn drained
+  cleanly), ``"failure"`` (the SDK raised), or ``"unknown"`` (no clear
+  signal). NEVER hardcoded — see :func:`build_completion_report`.
+* ``summary``     — a bounded slice of the assistant's reply text so the
+  requester can read the gist without fetching the full transcript.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from typing import Any, Optional
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "CompletionPushError",
+    "STATUS_FAILURE",
+    "STATUS_SUCCESS",
+    "STATUS_UNKNOWN",
+    "build_completion_report",
+    "push_completion",
+]
+
+STATUS_SUCCESS = "success"
+STATUS_FAILURE = "failure"
+STATUS_UNKNOWN = "unknown"
+
+# Cap the summary so a runaway assistant turn cannot bloat the push body
+# (and the requester's inbox row). The full text is always on disk in the
+# agent's session.jsonl; the push is a notification, not the transcript.
+_SUMMARY_CAP = 2000
+
+
+class CompletionPushError(RuntimeError):
+    """A completion push could NOT reach the requester.
+
+    Raised when the ``message:send`` POST fails to deliver: transport
+    error, non-2xx status, or ``delivered_subscriber_count == 0`` (the
+    requester has no live inbox subscriber). Mirrors the send-side
+    :class:`scitex_agent_container._mcp._channel_tools.SendError` contract
+    — fail loud, never a misleading success.
+    """
+
+
+def build_completion_report(
+    *,
+    agent: str,
+    dispatch_id: Optional[str],
+    status: str,
+    summary_text: str,
+) -> dict[str, Any]:
+    """Build the ``{agent, dispatch_id, status, summary}`` completion payload.
+
+    ``status`` is validated against the honest vocabulary — an unknown
+    value is coerced to :data:`STATUS_UNKNOWN` rather than passed through,
+    so a caller bug can never smuggle a fabricated ``"success"``-looking
+    string the requester would trust. ``summary_text`` is bounded to
+    :data:`_SUMMARY_CAP` chars (the full reply lives in session.jsonl).
+    """
+    if status not in (STATUS_SUCCESS, STATUS_FAILURE, STATUS_UNKNOWN):
+        log.warning(
+            "completion report built with non-canonical status %r; coercing to %r",
+            status,
+            STATUS_UNKNOWN,
+        )
+        status = STATUS_UNKNOWN
+    summary = summary_text or ""
+    if len(summary) > _SUMMARY_CAP:
+        summary = summary[:_SUMMARY_CAP] + "…"
+    return {
+        "agent": agent,
+        "dispatch_id": dispatch_id,
+        "status": status,
+        "summary": summary,
+    }
+
+
+def _wrap_completion_send(
+    *,
+    agent: str,
+    report: dict[str, Any],
+    dispatch_id: Optional[str],
+) -> dict[str, Any]:
+    """Wrap the completion report as a JSON-RPC ``SendMessage`` body.
+
+    The report JSON is the message text; sac-extension fields ride under
+    ``params.metadata`` (the A2A v1 convention the ``message:send`` route
+    reads). ``from_agent`` is THIS agent (who is reporting); ``kind`` marks
+    the envelope as a completion so a requester can distinguish it from a
+    normal inbound message; ``dispatch_id`` lets the requester correlate.
+    """
+    metadata: dict[str, Any] = {"from_agent": agent, "kind": "completion"}
+    if dispatch_id:
+        metadata["dispatch_id"] = dispatch_id
+    return {
+        "jsonrpc": "2.0",
+        "id": uuid.uuid4().hex,
+        "method": "SendMessage",
+        "params": {
+            "message": {
+                "message_id": uuid.uuid4().hex,
+                "role": "ROLE_USER",
+                "parts": [{"text": json.dumps(report)}],
+            },
+            "metadata": metadata,
+        },
+    }
+
+
+async def push_completion(
+    *,
+    agent: str,
+    requester: str,
+    report: dict[str, Any],
+    listen_url: str,
+    bearer: Optional[str],
+    dispatch_id: Optional[str] = None,
+) -> dict[str, Any]:
+    """POST the completion ``report`` to ``requester``'s inbox; FAIL LOUD.
+
+    Reuses the ``sac listen`` ``message:send`` channel (same path
+    ``a2a_send`` uses). Raises :class:`CompletionPushError` — never a
+    misleading success — when:
+
+    * the transport raises (requester host down / connection refused),
+    * the HTTP status is non-2xx (delivery / ACL error), or
+    * the publish reports ``delivered_subscriber_count == 0`` — the
+      requester has no live inbox subscriber, so the report woke nobody.
+
+    Returns the parsed ``{status, body}`` dict on success. ``httpx`` is
+    imported lazily so the runner stays importable without the HTTP deps
+    (the colocated channel adapter guards its own deps the same way).
+    """
+    import httpx
+
+    payload = _wrap_completion_send(agent=agent, report=report, dispatch_id=dispatch_id)
+    base = listen_url.rstrip("/")
+    url = f"{base}/agents/{requester}/message:send"
+    headers = {"Content-Type": "application/json"}
+    if bearer:
+        headers["Authorization"] = f"Bearer {bearer}"
+
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.post(url, json=payload, headers=headers)
+    except httpx.HTTPError as exc:
+        log.warning("completion push to %r failed (transport): %s", requester, exc)
+        raise CompletionPushError(
+            f"completion push to {requester!r} failed: unreachable ({exc})"
+        ) from exc
+
+    status_code = resp.status_code
+    try:
+        body: Any = resp.json()
+    except Exception:  # stx-allow: fallback (reason: non-JSON body tolerated; surfaced verbatim in the loud error)
+        body = resp.text
+    if status_code < 200 or status_code >= 300:
+        log.warning(
+            "completion push to %r returned HTTP %s: %s",
+            requester,
+            status_code,
+            body,
+        )
+        raise CompletionPushError(
+            f"completion push to {requester!r} failed: "
+            f"listen returned HTTP {status_code} ({body})"
+        )
+    if isinstance(body, dict):
+        delivered = body.get("delivered_subscriber_count")
+        if isinstance(delivered, int) and delivered == 0:
+            log.warning(
+                "completion push to %r reached no subscriber "
+                "(delivered_subscriber_count=0)",
+                requester,
+            )
+            raise CompletionPushError(
+                f"completion push to {requester!r} reached no live "
+                "subscriber (delivered_subscriber_count=0): the requester "
+                "is not subscribed to its inbox (down, not started, or its "
+                "channel adapter is not connected) — the report woke nobody."
+            )
+    return {"status": status_code, "body": body}

--- a/src/scitex_agent_container/_runners/_session_conversation.py
+++ b/src/scitex_agent_container/_runners/_session_conversation.py
@@ -16,9 +16,10 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 
 from ._session_state import (
     STATE_IDLE,
@@ -44,7 +45,41 @@ logger = logging.getLogger(__name__)
 def _safe_repr(value: object) -> str:
     """Bounded repr so a runaway tool-result blob can't bloat session.jsonl."""
     s = repr(value)
-    return s if len(s) <= 1024 else s[:1024] + "…"
+    return s if len(s) <= 1024 else s[:1024] + "…"  # stx-allow: STX-NL001
+
+
+def _build_completion_push_fn(agent_name: str):
+    """Build the Stop-hook completion ``push_fn``, or ``None`` if not wired.
+
+    The push reuses the agent's own ``sac listen`` (``message:send``) — its
+    base URL + bearer ride in the runner's env (``SAC_LISTEN_BASE_URL`` /
+    ``SAC_LISTEN_BEARER``), injected by the apptainer runtime alongside the
+    channel adapter. When no listen URL is configured (e.g. a bare runner
+    with no host control-plane), there is nowhere to push a report, so we
+    return ``None`` and the Stop hook keeps its append-only behaviour. This
+    is the honest "no channel → no push" case, NOT a silenced failure: a
+    push that has a URL but cannot deliver still fails LOUD inside the hook.
+    """
+    listen_url = os.environ.get("SAC_LISTEN_BASE_URL", "").strip()
+    if not listen_url:
+        return None
+    bearer = os.environ.get("SAC_LISTEN_BEARER") or None
+
+    from ._session_completion import push_completion
+
+    async def _push_fn(
+        report: dict, requester: str, dispatch_id: Optional[str]
+    ) -> None:
+        await push_completion(
+            agent=agent_name,
+            requester=requester,
+            report=report,
+            listen_url=listen_url,
+            bearer=bearer,
+            dispatch_id=dispatch_id,
+        )
+
+    return _push_fn
 
 
 def _drain_failed_inbox(inbox: "asyncio.Queue", exc: BaseException) -> None:
@@ -102,11 +137,24 @@ async def _drive_turn(
     host: str | None = None,
     db_writer=None,
     stderr_capture: Any | None = None,
+    turn_context: Any | None = None,
+    push_fn: Any | None = None,
 ) -> None:
     AssistantMessage = sdk_types["AssistantMessage"]
     TextBlock = sdk_types["TextBlock"]
     UserMessage = sdk_types["UserMessage"]
     ResultMessage = sdk_types["ResultMessage"]
+
+    # Open the turn context BEFORE any work so the Stop hook (which fires
+    # after the SDK drains this turn) can address the requester that
+    # dispatched it. Requester identity rides on the envelope (threaded by
+    # the inbound /v1/turn handler from the POST body — see _session_http).
+    # ``None`` requester == a mission/boot turn with no peer to answer to.
+    if turn_context is not None:
+        turn_context.begin(
+            requester=getattr(env, "from_agent", None),
+            dispatch_id=getattr(env, "dispatch_id", None),
+        )
 
     write_heartbeat(
         state_dir,
@@ -192,6 +240,14 @@ async def _drive_turn(
                     state_dir,
                     {"type": "result", "session_id": sid, "usage": usage},
                 )
+                # Clean drain: record the HONEST success outcome + reply
+                # summary on the turn context BEFORE the Stop hook fires
+                # (Stop comes after this ResultMessage). The Stop hook reads
+                # this to PUSH the completion report to the requester.
+                if turn_context is not None:
+                    from ._session_completion import STATUS_SUCCESS
+
+                    turn_context.finish(status=STATUS_SUCCESS, summary="".join(chunks))
                 break
     except BaseException as exc:  # stx-allow: fallback (reason: enrich the failure with the real captured stderr, resolve the awaiter with the real cause, then re-raise for the supervisor)
         # The SDK turn failed (e.g. a ProcessError from a stale --resume
@@ -210,6 +266,15 @@ async def _drive_turn(
                 # see the original class.
                 exc.args = (enriched,) + tuple(exc.args[1:])
             env.response.set_exception(exc)
+        # Record the HONEST failure outcome on the turn context. Stop does
+        # NOT reliably fire when the SDK raises mid-turn, so the finally
+        # below is what emits the requester push in this case (status from
+        # here). Summary carries the failure detail so the requester sees
+        # WHY, not a bare "failure".
+        if turn_context is not None:
+            from ._session_completion import STATUS_FAILURE
+
+            turn_context.finish(status=STATUS_FAILURE, summary=str(exc))
         raise
     finally:
         if not env.response.done():
@@ -224,6 +289,16 @@ async def _drive_turn(
                 session_id=getattr(env, "session_id", None),
                 db_writer=db_writer,
             )
+        # Emit the requester completion push exactly once per turn. On a
+        # clean drain the Stop hook already pushed (pushed=True) → this is a
+        # no-op; on an SDK error (no clean Stop) THIS is the emit point,
+        # carrying the honest FAILURE status set in the except branch. The
+        # ``pushed`` guard inside ``emit_completion_push`` makes the double
+        # call idempotent. A no-requester (mission) turn skips quietly.
+        if turn_context is not None and push_fn is not None and name:
+            from ._session_hooks import emit_completion_push
+
+            await emit_completion_push(turn_context, push_fn, agent_name=name)
         if not stop.is_set():
             write_heartbeat(
                 state_dir,
@@ -296,12 +371,23 @@ async def run_conversation(
     }
 
     from ..runtimes._sdk_common import SDKCommonError, build_sdk_options
-    from ._session_hooks import build_event_log_hooks
+    from ._session_hooks import TurnContext, build_event_log_hooks
 
     if build_sdk_options_fn is None:
         build_sdk_options_fn = build_sdk_options
 
-    hooks = build_event_log_hooks(name, HookMatcher)
+    # Requester-feedback wiring: one TurnContext shared across the whole
+    # conversation (turns are serial, so a single holder is race-free) plus
+    # a completion push_fn resolved from the runner's listen env. The Stop
+    # hook reads the context to PUSH a completion report back to whoever
+    # dispatched each turn. ``push_fn`` is ``None`` when no host control-
+    # plane is configured (bare runner) — then the Stop hook keeps its
+    # append-only behaviour and ``_drive_turn`` skips the finally emit.
+    turn_context = TurnContext()
+    push_fn = _build_completion_push_fn(name)
+    hooks = build_event_log_hooks(
+        name, HookMatcher, turn_context=turn_context, push_fn=push_fn
+    )
 
     # Thread spec.claude.channels + the runner's own a2a_port into the
     # SDK options under the sac-private ``extra`` keys so build_sdk_options
@@ -411,6 +497,8 @@ async def run_conversation(
                         host=host,
                         db_writer=db_writer,
                         stderr_capture=stderr_capture,
+                        turn_context=turn_context,
+                        push_fn=push_fn,
                     )
                     if env.exit_after:
                         stop.set()

--- a/src/scitex_agent_container/_runners/_session_hooks.py
+++ b/src/scitex_agent_container/_runners/_session_hooks.py
@@ -9,14 +9,144 @@ downstream consumers (``sac agent status``, ``event_log.summarize``,
 fleet dashboards) work unchanged when an agent flips runtimes.
 
 Hook callbacks are *async no-ops on the wire*: they return ``{}`` to
-the SDK and never block. ``append_event`` is itself swallowed-failure,
-so a misbehaving hook cannot kill the agent.
+the SDK and never block its control flow. ``append_event`` is itself
+swallowed-failure, so a misbehaving hook cannot kill the agent.
+
+Stop-hook completion push (requester-feedback)
+----------------------------------------------
+The ``Stop`` hook additionally PUSHes a completion report back to the
+turn's *requester* — the peer that dispatched the turn, threaded onto
+the ``TurnEnvelope`` as ``from_agent`` + ``dispatch_id`` and surfaced to
+the hook via a per-conversation :class:`TurnContext` holder. This is the
+push-feedback north star: a requester hears about completion without
+polling, and it generalises to ANY peer (the lead is not special-cased).
+
+The push is wired through two injected seams so it stays testable
+end-to-end without mocks:
+
+* ``turn_context`` — a mutable holder the conversation task updates at
+  the start/end of each turn (requester, dispatch_id, summary, status).
+  Turns are serial, so one holder is race-free.
+* ``push_fn`` — an async ``(report, requester, dispatch_id) -> None``
+  callable that performs the actual delivery. The runner injects a
+  closure over :func:`_session_completion.push_completion`; tests inject
+  a closure that POSTs to a real local receiver.
+
+A push failure is LOUD (logged at WARNING with the requester named) but
+does NOT crash the agent — the turn already completed; the hook returns
+``{}`` regardless. When the turn had no requester, the push is skipped
+(a mission/boot turn answers to no peer — not an error).
 """
 
 from __future__ import annotations
 
+import logging
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, Awaitable, Callable, Optional
+
+log = logging.getLogger(__name__)
+
+# Async seam: (report, requester, dispatch_id) -> awaitable. The runner
+# binds it to the real completion-push emitter; tests bind it to a real
+# local-receiver-backed closure. No mock surface.
+PushFn = Callable[[dict, str, Optional[str]], Awaitable[None]]
+
+
+@dataclass
+class TurnContext:
+    """Per-conversation holder for the in-flight turn's requester identity.
+
+    The conversation task calls :meth:`begin` when it picks an envelope and
+    :meth:`finish` when the turn drains (or fails). The Stop hook reads the
+    holder to address its completion push. Turns are serial, so a single
+    mutable holder is correct — there is never more than one in-flight turn.
+
+    ``status`` is the honest outcome the conversation records: ``None``
+    before a turn, then one of the ``_session_completion`` status strings.
+    """
+
+    requester: Optional[str] = None
+    dispatch_id: Optional[str] = None
+    summary: str = ""
+    status: Optional[str] = None
+    pushed: bool = field(default=False, repr=False)
+
+    def begin(self, *, requester: Optional[str], dispatch_id: Optional[str]) -> None:
+        """Open a new turn: record its requester + dispatch id, reset outcome.
+
+        Resets ``pushed`` so each turn gets exactly one completion push —
+        the guard the Stop hook and the failure path share so a turn that
+        both errors AND fires Stop cannot double-report.
+        """
+        self.requester = requester
+        self.dispatch_id = dispatch_id
+        self.summary = ""
+        self.status = None
+        self.pushed = False
+
+    def finish(self, *, status: str, summary: str) -> None:
+        """Close the turn with its honest outcome + reply summary."""
+        self.status = status
+        self.summary = summary
+
+
+async def emit_completion_push(
+    turn_context: Optional[TurnContext],
+    push_fn: Optional[PushFn],
+    *,
+    agent_name: str,
+) -> None:
+    """PUSH the current turn's completion report to its requester (once).
+
+    The single shared emit path used by BOTH the Stop hook (clean-turn-end
+    signal) and the conversation's failure branch (the SDK raised before a
+    clean Stop). The ``turn_context.pushed`` guard ensures exactly one push
+    per turn — a turn that errors AND somehow also fires Stop reports once.
+
+    Skips quietly (returns) when:
+
+    * the seams aren't wired (``turn_context`` / ``push_fn`` is ``None``) —
+      a bare runner with no host control-plane has nowhere to push;
+    * the turn had no requester (a mission/boot turn answers to no peer); or
+    * this turn was already pushed.
+
+    Status is taken verbatim from ``turn_context.status`` — set honestly by
+    the conversation (``success`` on clean drain, ``failure`` on SDK error).
+    A ``None`` status (the push fired before the conversation recorded an
+    outcome — should not happen, since Stop comes after the ResultMessage)
+    is reported as ``unknown``, NEVER fabricated as success.
+
+    A delivery failure is LOUD (logged at WARNING, requester named) but
+    never re-raised: the turn already completed, and a flaky receipt must
+    not crash the agent or abort the SDK control flow.
+    """
+    if turn_context is None or push_fn is None:
+        return
+    requester = turn_context.requester
+    if not requester or turn_context.pushed:
+        return
+    turn_context.pushed = True
+
+    from ._session_completion import STATUS_UNKNOWN, build_completion_report
+
+    status = turn_context.status or STATUS_UNKNOWN
+    report = build_completion_report(
+        agent=agent_name,
+        dispatch_id=turn_context.dispatch_id,
+        status=status,
+        summary_text=turn_context.summary,
+    )
+    try:
+        await push_fn(report, requester, turn_context.dispatch_id)
+    except Exception as exc:  # stx-allow: fallback (reason: a failed completion push must be LOUD but must not crash the agent — the turn already completed; logged at WARNING, never re-raised)
+        log.warning(
+            "completion push to requester %r failed (status=%s dispatch_id=%s): %s",
+            requester,
+            status,
+            turn_context.dispatch_id,
+            exc,
+        )
 
 
 def build_event_log_hooks(
@@ -24,6 +154,8 @@ def build_event_log_hooks(
     hook_matcher_cls: Any,
     *,
     event_log_root: Path | None = None,
+    turn_context: TurnContext | None = None,
+    push_fn: PushFn | None = None,
 ) -> dict:
     """Return the ``hooks=`` dict passed to ``ClaudeAgentOptions``.
 
@@ -34,6 +166,14 @@ def build_event_log_hooks(
     ``event_log_root`` (optional) is forwarded to ``append_event(..., root=)``
     so tests can redirect the ring-buffer to a tmp dir without monkey-
     patching the production helper.
+
+    ``turn_context`` + ``push_fn`` (optional, both required together to
+    enable the push) wire the Stop-hook completion push. When supplied, the
+    Stop hook reads the just-finished turn's requester from ``turn_context``
+    and, if a requester is present, calls ``push_fn(report, requester,
+    dispatch_id)``. Absent either seam, the Stop hook keeps its prior
+    behaviour (event-log append only) — so legacy callers and the mission
+    boot path are unaffected.
     """
     from .._state.event_log import append_event
 
@@ -78,6 +218,10 @@ def build_event_log_hooks(
             {"stop_hook_active": bool(payload.get("stop_hook_active"))},
             root=event_log_root,
         )
+        # The Stop hook firing is the clean-turn-end signal. The success
+        # status / reply summary were recorded on ``turn_context`` by the
+        # conversation when it processed the ResultMessage (before Stop).
+        await emit_completion_push(turn_context, push_fn, agent_name=agent_name)
         return {}
 
     return {
@@ -86,3 +230,6 @@ def build_event_log_hooks(
         "UserPromptSubmit": [hook_matcher_cls(hooks=[_on_prompt])],
         "Stop": [hook_matcher_cls(hooks=[_on_stop])],
     }
+
+
+__all__ = ["TurnContext", "build_event_log_hooks", "emit_completion_push"]

--- a/src/scitex_agent_container/_runners/_session_http.py
+++ b/src/scitex_agent_container/_runners/_session_http.py
@@ -11,12 +11,21 @@ Wire format:
 
     POST /v1/turn
     Content-Type: application/json
-    {"text": "your message", "exit_after": false}
+    {"text": "your message", "exit_after": false,
+     "dispatch_id": "<sender dispatch-ledger id, optional>",
+     "from_agent": "<requester node id, optional>"}
 
 The request field is ``text`` — that's the sac sidecar shape. Callers
 sending ``{"prompt": "..."}`` (e.g. some early lead helpers) get a
 ``400`` with ``"missing or empty 'text' field"`` so the schema mismatch
 is loud, not a hang. Use ``text`` end-to-end.
+
+``dispatch_id`` and ``from_agent`` are optional requester-identity
+fields: ``from_agent`` names the peer that dispatched this turn and
+``dispatch_id`` correlates it to the sender's dispatch-ledger row. The
+runner threads both onto the ``TurnEnvelope`` so the Stop hook can PUSH
+a completion report ({agent, dispatch_id, status, summary}) back to the
+requester. Absent for a mission boot turn (no peer to answer to).
 
     200 OK
     {
@@ -247,6 +256,15 @@ async def serve_inbound(
         dispatch_id = body.get("dispatch_id") if isinstance(body, dict) else None
         if not isinstance(dispatch_id, str) or not dispatch_id:
             dispatch_id = None
+        # Requester identity (optional). The peer that dispatched this
+        # turn — threaded onto the envelope so the Stop hook can PUSH a
+        # completion report back to it. Generalizes to ANY peer; the lead
+        # is not special-cased. Tolerated-absent: a mission boot turn or a
+        # legacy caller leaves it None and the Stop hook simply has nobody
+        # to address.
+        from_agent = body.get("from_agent") if isinstance(body, dict) else None
+        if not isinstance(from_agent, str) or not from_agent:
+            from_agent = None
 
         loop = asyncio.get_running_loop()
         env = TurnEnvelope(
@@ -254,6 +272,7 @@ async def serve_inbound(
             response=loop.create_future(),
             exit_after=exit_after,
             dispatch_id=dispatch_id,
+            from_agent=from_agent,
         )
         await inbox.put(env)
         try:

--- a/src/scitex_agent_container/_runners/_session_inbox.py
+++ b/src/scitex_agent_container/_runners/_session_inbox.py
@@ -40,6 +40,16 @@ class TurnEnvelope:
     threads it here so the receiver side can correlate this turn back to
     the originating dispatch row. ``None`` when the dispatch was not
     minted through the ledger (legacy / test-only producers).
+
+    ``from_agent`` is the REQUESTER identity — the peer (any node, not a
+    special-cased lead) that dispatched this turn. The sender stamps it
+    onto the ``/v1/turn`` POST body (``peer.post_turn``) or it rides in
+    via the channel wake path's body; the inbound HTTP handler threads it
+    here so the Stop hook can PUSH a completion report back to whoever
+    asked. ``None`` for a mission boot turn or a legacy caller that does
+    not declare a requester — the Stop hook then has nobody to address
+    and the push is skipped (not an error: a mission turn answers to no
+    peer).
     """
 
     text: str
@@ -48,6 +58,7 @@ class TurnEnvelope:
     session_id: str | None = None
     turn_id: str | None = None
     dispatch_id: str | None = None
+    from_agent: str | None = None
 
 
 @dataclass

--- a/src/scitex_agent_container/a2a/_inbox_bus.py
+++ b/src/scitex_agent_container/a2a/_inbox_bus.py
@@ -106,6 +106,7 @@ def mint_event(
     ack: bool = False,
     extra: dict[str, Any] | None = None,
     kind: str | None = None,
+    dispatch_id: str | None = None,
 ) -> dict[str, Any]:
     """Mint the event shape sac's channel publishes.
 
@@ -118,6 +119,13 @@ def mint_event(
     survive minting so the receiving adapter's auto-ack loop-guard
     can recognise an ack and decline to ack it back — otherwise two
     auto-ack adapters ping-pong forever.
+
+    ``dispatch_id`` is the SENDER-minted dispatch-ledger id (see
+    :mod:`scitex_agent_container._state.dispatch_ledger`). It rides on
+    the event so the channel wake path can thread it onto the woken
+    turn's ``/v1/turn`` body, letting the receiver's Stop hook correlate
+    its completion push back to the originating dispatch row. Omitted
+    when the sender did not mint a ledger id.
     """
     event: dict[str, Any] = {
         "msg_id": uuid.uuid4().hex,
@@ -133,6 +141,8 @@ def mint_event(
         event["conversation_id"] = conversation_id
     if in_reply_to:
         event["in_reply_to"] = in_reply_to
+    if dispatch_id:
+        event["dispatch_id"] = dispatch_id
     if extra:
         event["extra"] = extra
     if kind:

--- a/tests/scitex_agent_container/_listen/test_server.py
+++ b/tests/scitex_agent_container/_listen/test_server.py
@@ -1047,3 +1047,17 @@ def test_message_send_without_ack_metadata_yields_falsey_ack_event(
     event = _roundtrip_local_send(cross_host_env, metadata=metadata)
     # Assert
     assert not event.get("ack")
+
+
+def test_message_send_threads_dispatch_id_into_published_event(
+    cross_host_env,
+) -> None:
+    # Arrange
+    # The sender-minted dispatch_id must ride from metadata onto the
+    # published inbox event so the channel wake path can thread it onto
+    # the woken turn for requester-completion correlation.
+    metadata = {"from_agent": "bob", "dispatch_id": "d-route-99"}
+    # Act
+    event = _roundtrip_local_send(cross_host_env, metadata=metadata)
+    # Assert
+    assert event.get("dispatch_id") == "d-route-99"

--- a/tests/scitex_agent_container/_mcp/test_channel_wake_requester.py
+++ b/tests/scitex_agent_container/_mcp/test_channel_wake_requester.py
@@ -1,0 +1,133 @@
+"""``_wake_turn`` threads requester identity into the woken ``/v1/turn`` body.
+
+NO MOCKS. ``_wake_turn`` POSTs to a REAL in-process HTTP/1.1 receiver
+(``asyncio.start_server``) that captures the JSON body. The test then
+asserts the requester fields (``from_agent`` / ``dispatch_id``) rode
+into the body so the woken turn's envelope carries them to the Stop
+hook. The ``"unknown"`` sentinel that ``mint_event`` stamps for a
+missing sender must NOT be threaded as a requester.
+
+TQ: AAA markers, ≥3-word names, one assertion each.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import socket
+from typing import Any
+
+from scitex_agent_container._mcp._channel_wake import _wake_turn
+
+
+def _free_port() -> int:
+    """Ask the kernel for an unused TCP port."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+class _CapturingHTTP:
+    """Minimal real HTTP/1.1 server that records one POST body and 200s."""
+
+    def __init__(self) -> None:
+        self.bodies: list[dict[str, Any]] = []
+        self._server: asyncio.AbstractServer | None = None
+        self.port = 0
+
+    async def start(self) -> None:
+        self.port = _free_port()
+        self._server = await asyncio.start_server(self._handle, "127.0.0.1", self.port)
+
+    async def stop(self) -> None:
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+
+    async def _handle(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        data = await reader.read(65_536)
+        head, _, body = data.partition(b"\r\n\r\n")
+        # Read any remaining body bytes up to Content-Length.
+        length = 0
+        for line in head.split(b"\r\n"):
+            if line.lower().startswith(b"content-length:"):
+                length = int(line.split(b":", 1)[1].strip())
+        while len(body) < length:
+            more = await reader.read(length - len(body))
+            if not more:
+                break
+            body += more
+        try:
+            self.bodies.append(json.loads(body.decode() or "{}"))
+        except json.JSONDecodeError:
+            self.bodies.append({})
+        resp_body = b'{"text": "ok", "session_id": null, "exit_after": false}'
+        writer.write(
+            b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n"
+            b"Content-Length: " + str(len(resp_body)).encode() + b"\r\n\r\n" + resp_body
+        )
+        await writer.drain()
+        writer.close()
+
+
+async def _wake_and_capture(event: dict[str, Any]) -> dict[str, Any]:
+    """Start the real receiver, run ``_wake_turn``, return the captured body."""
+    srv = _CapturingHTTP()
+    await srv.start()
+    try:
+        await _wake_turn(
+            event, turn_url=f"http://127.0.0.1:{srv.port}/v1/turn", bearer=None
+        )
+    finally:
+        await srv.stop()
+    return srv.bodies[0]
+
+
+class TestWakeThreadsRequester:
+    def test_wake_body_carries_from_agent_of_event_sender(self) -> None:
+        # Arrange
+        event = {"from_agent": "lead", "content": "do it", "msg_id": "m1"}
+        # Act
+        body = asyncio.run(_wake_and_capture(event))
+        # Assert
+        assert body["from_agent"] == "lead"
+
+    def test_wake_body_carries_dispatch_id_when_event_has_one(self) -> None:
+        # Arrange
+        event = {
+            "from_agent": "lead",
+            "content": "do it",
+            "msg_id": "m1",
+            "dispatch_id": "d-42",
+        }
+        # Act
+        body = asyncio.run(_wake_and_capture(event))
+        # Assert
+        assert body["dispatch_id"] == "d-42"
+
+    def test_wake_body_omits_unknown_sentinel_as_requester(self) -> None:
+        # Arrange
+        # mint_event defaults a missing sender to the literal "unknown".
+        event = {"from_agent": "unknown", "content": "do it", "msg_id": "m1"}
+        # Act
+        body = asyncio.run(_wake_and_capture(event))
+        # Assert
+        assert "from_agent" not in body
+
+    def test_wake_body_omits_dispatch_id_when_event_lacks_one(self) -> None:
+        # Arrange
+        event = {"from_agent": "lead", "content": "do it", "msg_id": "m1"}
+        # Act
+        body = asyncio.run(_wake_and_capture(event))
+        # Assert
+        assert "dispatch_id" not in body
+
+    def test_wake_body_always_carries_the_turn_text(self) -> None:
+        # Arrange
+        event = {"from_agent": "lead", "content": "do it", "msg_id": "m1"}
+        # Act
+        body = asyncio.run(_wake_and_capture(event))
+        # Assert
+        assert "do it" in body["text"]

--- a/tests/scitex_agent_container/_network/test_peer_requester_body.py
+++ b/tests/scitex_agent_container/_network/test_peer_requester_body.py
@@ -1,0 +1,86 @@
+"""``post_turn_to_url`` stamps the requester ``from_agent`` into the body.
+
+NO MOCKS. A real ``http.server`` on 127.0.0.1 captures the POSTed
+``/v1/turn`` body; the test asserts the explicit ``from_agent`` rode
+into it so the receiving runner's Stop hook can push a completion report
+back to the requester. Mirrors the real-server pattern already used in
+``test_peer.py``.
+
+TQ: AAA markers, ≥3-word names, one assertion each.
+"""
+
+from __future__ import annotations
+
+import http.server
+import json
+import socket
+import threading
+from typing import Any
+
+from scitex_agent_container._network.peer import post_turn_to_url
+
+
+def _free_port() -> int:
+    """Ask the kernel for an unused TCP port."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _capture_post_body(*, from_agent: str | None) -> dict[str, Any]:
+    """Run ``post_turn_to_url`` against a real receiver; return the captured body."""
+    port = _free_port()
+    captured: list[dict[str, Any]] = []
+
+    class _Handler(http.server.BaseHTTPRequestHandler):
+        def do_POST(self):  # noqa: N802
+            length = int(self.headers.get("Content-Length", "0"))
+            captured.append(json.loads(self.rfile.read(length).decode("utf-8")))
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(
+                json.dumps({"text": "ok", "exit_after": False}).encode("utf-8")
+            )
+
+        def log_message(self, *a, **kw):
+            pass
+
+    server = http.server.HTTPServer(("127.0.0.1", port), _Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        post_turn_to_url(
+            f"http://127.0.0.1:{port}/v1/turn",
+            "hello",
+            timeout_s=5.0,
+            from_agent=from_agent,
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2.0)
+    return captured[0]
+
+
+class TestPeerRequesterBody:
+    def test_explicit_from_agent_rides_into_post_body(self) -> None:
+        # Arrange
+        # Act
+        body = _capture_post_body(from_agent="lead")
+        # Assert
+        assert body["from_agent"] == "lead"
+
+    def test_post_body_always_carries_a_dispatch_id(self) -> None:
+        # Arrange
+        # Act
+        body = _capture_post_body(from_agent="lead")
+        # Assert
+        assert isinstance(body.get("dispatch_id"), str)
+
+    def test_post_body_carries_the_turn_text(self) -> None:
+        # Arrange
+        # Act
+        body = _capture_post_body(from_agent="lead")
+        # Assert
+        assert body["text"] == "hello"

--- a/tests/scitex_agent_container/_runners/test__session_completion.py
+++ b/tests/scitex_agent_container/_runners/test__session_completion.py
@@ -1,0 +1,766 @@
+"""End-to-end tests for the Stop-hook requester-completion push.
+
+NO MOCKS. The completion push is exercised against a REAL local HTTP
+receiver shaped like ``sac listen``'s ``/agents/<name>/message:send``
+route: a Starlette app on a real socket that records the bodies it
+receives and answers with a real ``delivered_subscriber_count``. The
+Stop hook closure built by ``build_event_log_hooks`` is the real one and
+is fired directly; the conversation→push path runs the real
+``run_conversation`` against a hand-rolled fake SDK module passed via the
+injection seam (``sdk_module=``) — a fake collaborator, not a patched
+module attribute.
+
+TQ: every test carries ``# Arrange`` / ``# Act`` / ``# Assert`` markers,
+a ≥3-word descriptive name, and exactly one assertion.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import socket
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Iterator
+
+import pytest
+
+from scitex_agent_container._runners._session_completion import (
+    STATUS_FAILURE,
+    STATUS_SUCCESS,
+    STATUS_UNKNOWN,
+    CompletionPushError,
+    build_completion_report,
+    push_completion,
+)
+from scitex_agent_container._runners._session_hooks import (
+    TurnContext,
+    build_event_log_hooks,
+    emit_completion_push,
+)
+
+# ---------------------------------------------------------------------------
+# Real collaborators — a message:send-shaped receiver on a real socket
+# ---------------------------------------------------------------------------
+
+
+def _free_port() -> int:
+    """Ask the kernel for an unused TCP port."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+async def _wait_bound(port: int) -> None:
+    """Poll until the TCP port accepts connections."""
+    for _ in range(50):
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.2):
+                return
+        except OSError:
+            await asyncio.sleep(0.05)
+    pytest.fail(f"receiver never bound on port {port}")
+
+
+class _Receiver:
+    """Records the message:send bodies it is POSTed; configurable delivered count."""
+
+    def __init__(self, *, delivered: int = 1) -> None:
+        self.delivered = delivered
+        self.received: list[dict[str, Any]] = []
+        self.paths: list[str] = []
+
+
+async def _run_receiver(
+    *,
+    port: int,
+    receiver: _Receiver,
+    client_coro,
+) -> Any:
+    """Spin up the real Starlette receiver, run ``client_coro(port)``, tear down."""
+    import uvicorn
+    from starlette.applications import Starlette
+    from starlette.requests import Request
+    from starlette.responses import JSONResponse
+    from starlette.routing import Route
+
+    async def message_send(request: Request) -> JSONResponse:
+        body = await request.json()
+        receiver.received.append(body)
+        receiver.paths.append(request.url.path)
+        return JSONResponse(
+            {
+                "msg_id": "m-1",
+                "to_agent": request.path_params.get("name", ""),
+                "delivered_subscriber_count": receiver.delivered,
+            }
+        )
+
+    app = Starlette(
+        routes=[Route("/agents/{name}/message:send", message_send, methods=["POST"])]
+    )
+    config = uvicorn.Config(
+        app, host="127.0.0.1", port=port, log_level="warning", ws="none", lifespan="off"
+    )
+    server = uvicorn.Server(config)
+    stop = asyncio.Event()
+
+    async def _serve() -> None:
+        serve_task = asyncio.create_task(server.serve())
+        await stop.wait()
+        server.should_exit = True
+        await asyncio.wait_for(serve_task, timeout=5.0)
+
+    server_task = asyncio.create_task(_serve())
+    try:
+        await _wait_bound(port)
+        return await client_coro(port)
+    finally:
+        stop.set()
+        await asyncio.wait_for(server_task, timeout=5.0)
+
+
+@pytest.fixture
+def listen_env() -> Iterator[None]:
+    """Real save/restore of the listen env the runner's push_fn reads."""
+    saved_base = os.environ.get("SAC_LISTEN_BASE_URL")
+    saved_bearer = os.environ.get("SAC_LISTEN_BEARER")
+    try:
+        yield
+    finally:
+        for key, val in (
+            ("SAC_LISTEN_BASE_URL", saved_base),
+            ("SAC_LISTEN_BEARER", saved_bearer),
+        ):
+            if val is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = val
+
+
+# ---------------------------------------------------------------------------
+# build_completion_report — honest status, bounded summary
+# ---------------------------------------------------------------------------
+
+
+class TestBuildCompletionReport:
+    def test_report_carries_dispatch_id_for_task_correlation(self) -> None:
+        # Arrange
+        did = "dispatch-abc"
+        # Act
+        report = build_completion_report(
+            agent="a", dispatch_id=did, status=STATUS_SUCCESS, summary_text="ok"
+        )
+        # Assert
+        assert report["dispatch_id"] == did
+
+    def test_report_preserves_honest_success_status(self) -> None:
+        # Arrange
+        # Act
+        report = build_completion_report(
+            agent="a", dispatch_id=None, status=STATUS_SUCCESS, summary_text="ok"
+        )
+        # Assert
+        assert report["status"] == STATUS_SUCCESS
+
+    def test_report_preserves_honest_failure_status(self) -> None:
+        # Arrange
+        # Act
+        report = build_completion_report(
+            agent="a", dispatch_id=None, status=STATUS_FAILURE, summary_text="boom"
+        )
+        # Assert
+        assert report["status"] == STATUS_FAILURE
+
+    def test_report_coerces_unknown_status_never_fabricates_success(self) -> None:
+        # Arrange
+        bogus = "totally-made-up"
+        # Act
+        report = build_completion_report(
+            agent="a", dispatch_id=None, status=bogus, summary_text=""
+        )
+        # Assert
+        assert report["status"] == STATUS_UNKNOWN
+
+    def test_report_bounds_runaway_summary_length(self) -> None:
+        # Arrange
+        huge = "x" * 9_000
+        # Act
+        report = build_completion_report(
+            agent="a", dispatch_id=None, status=STATUS_SUCCESS, summary_text=huge
+        )
+        # Assert
+        assert len(report["summary"]) < len(huge)
+
+    def test_report_names_reporting_agent(self) -> None:
+        # Arrange
+        # Act
+        report = build_completion_report(
+            agent="worker-7", dispatch_id=None, status=STATUS_SUCCESS, summary_text=""
+        )
+        # Assert
+        assert report["agent"] == "worker-7"
+
+
+# ---------------------------------------------------------------------------
+# push_completion — real receiver, loud on no-subscriber / transport
+# ---------------------------------------------------------------------------
+
+
+class TestPushCompletion:
+    def test_push_delivers_report_to_requester_inbox(self) -> None:
+        # Arrange
+        port = _free_port()
+        receiver = _Receiver(delivered=1)
+        report = build_completion_report(
+            agent="worker", dispatch_id="d1", status=STATUS_SUCCESS, summary_text="done"
+        )
+
+        async def _client(p: int):
+            await push_completion(
+                agent="worker",
+                requester="lead",
+                report=report,
+                listen_url=f"http://127.0.0.1:{p}",
+                bearer=None,
+                dispatch_id="d1",
+            )
+            return receiver.received
+
+        # Act
+        received = asyncio.run(
+            _run_receiver(port=port, receiver=receiver, client_coro=_client)
+        )
+        # Assert
+        assert len(received) == 1
+
+    def test_push_addresses_the_requester_path(self) -> None:
+        # Arrange
+        port = _free_port()
+        receiver = _Receiver(delivered=1)
+        report = build_completion_report(
+            agent="worker", dispatch_id=None, status=STATUS_SUCCESS, summary_text=""
+        )
+
+        async def _client(p: int):
+            await push_completion(
+                agent="worker",
+                requester="lead",
+                report=report,
+                listen_url=f"http://127.0.0.1:{p}",
+                bearer=None,
+            )
+            return receiver.paths
+
+        # Act
+        paths = asyncio.run(
+            _run_receiver(port=port, receiver=receiver, client_coro=_client)
+        )
+        # Assert
+        assert paths == ["/agents/lead/message:send"]
+
+    def test_push_body_carries_reporting_agent_as_from_agent(self) -> None:
+        # Arrange
+        port = _free_port()
+        receiver = _Receiver(delivered=1)
+        report = build_completion_report(
+            agent="worker", dispatch_id=None, status=STATUS_SUCCESS, summary_text=""
+        )
+
+        async def _client(p: int):
+            await push_completion(
+                agent="worker",
+                requester="lead",
+                report=report,
+                listen_url=f"http://127.0.0.1:{p}",
+                bearer=None,
+            )
+            return receiver.received[0]
+
+        # Act
+        body = asyncio.run(
+            _run_receiver(port=port, receiver=receiver, client_coro=_client)
+        )
+        # Assert
+        assert body["params"]["metadata"]["from_agent"] == "worker"
+
+    def test_push_body_carries_dispatch_id_in_metadata(self) -> None:
+        # Arrange
+        port = _free_port()
+        receiver = _Receiver(delivered=1)
+        report = build_completion_report(
+            agent="worker", dispatch_id="d-77", status=STATUS_SUCCESS, summary_text=""
+        )
+
+        async def _client(p: int):
+            await push_completion(
+                agent="worker",
+                requester="lead",
+                report=report,
+                listen_url=f"http://127.0.0.1:{p}",
+                bearer=None,
+                dispatch_id="d-77",
+            )
+            return receiver.received[0]
+
+        # Act
+        body = asyncio.run(
+            _run_receiver(port=port, receiver=receiver, client_coro=_client)
+        )
+        # Assert
+        assert body["params"]["metadata"]["dispatch_id"] == "d-77"
+
+    def test_push_message_text_is_the_completion_report_json(self) -> None:
+        # Arrange
+        port = _free_port()
+        receiver = _Receiver(delivered=1)
+        report = build_completion_report(
+            agent="worker", dispatch_id="d-9", status=STATUS_SUCCESS, summary_text="hi"
+        )
+
+        async def _client(p: int):
+            await push_completion(
+                agent="worker",
+                requester="lead",
+                report=report,
+                listen_url=f"http://127.0.0.1:{p}",
+                bearer=None,
+                dispatch_id="d-9",
+            )
+            text = receiver.received[0]["params"]["message"]["parts"][0]["text"]
+            return json.loads(text)
+
+        # Act
+        decoded = asyncio.run(
+            _run_receiver(port=port, receiver=receiver, client_coro=_client)
+        )
+        # Assert
+        assert decoded["status"] == STATUS_SUCCESS
+
+    def test_push_raises_loud_when_no_live_subscriber(self) -> None:
+        # Arrange
+        port = _free_port()
+        receiver = _Receiver(delivered=0)  # no subscriber → woke nobody
+        report = build_completion_report(
+            agent="worker", dispatch_id=None, status=STATUS_SUCCESS, summary_text=""
+        )
+
+        async def _client(p: int):
+            await push_completion(
+                agent="worker",
+                requester="lead",
+                report=report,
+                listen_url=f"http://127.0.0.1:{p}",
+                bearer=None,
+            )
+
+        async def _scenario():
+            await _run_receiver(port=port, receiver=receiver, client_coro=_client)
+
+        # Act
+        ctx = pytest.raises(CompletionPushError)
+        # Assert
+        with ctx:
+            asyncio.run(_scenario())
+
+    def test_push_raises_loud_when_requester_unreachable(self) -> None:
+        # Arrange
+        dead_port = _free_port()  # nothing listening here
+        report = build_completion_report(
+            agent="worker", dispatch_id=None, status=STATUS_FAILURE, summary_text="x"
+        )
+
+        async def _scenario():
+            await push_completion(
+                agent="worker",
+                requester="lead",
+                report=report,
+                listen_url=f"http://127.0.0.1:{dead_port}",
+                bearer=None,
+            )
+
+        # Act
+        ctx = pytest.raises(CompletionPushError)
+        # Assert
+        with ctx:
+            asyncio.run(_scenario())
+
+
+# ---------------------------------------------------------------------------
+# Stop hook fires → emits the completion push (the real hook closure)
+# ---------------------------------------------------------------------------
+
+
+class _HookMatcher:
+    """Real stand-in for the SDK HookMatcher — records the callbacks it wraps."""
+
+    def __init__(self, hooks: list) -> None:
+        self.hooks = hooks
+
+
+def _stop_callback(hooks_dict: dict):
+    """Pull the single Stop callback out of the built hooks dict."""
+    return hooks_dict["Stop"][0].hooks[0]
+
+
+class TestStopHookEmitsCompletion:
+    def test_stop_hook_fire_delivers_completion_to_requester(
+        self, tmp_path: Path
+    ) -> None:
+        # Arrange
+        port = _free_port()
+        receiver = _Receiver(delivered=1)
+        ctx = TurnContext()
+        ctx.begin(requester="lead", dispatch_id="d-stop")
+        ctx.finish(status=STATUS_SUCCESS, summary="all good")
+
+        async def _client(p: int):
+            async def _push_fn(report, requester, dispatch_id):
+                await push_completion(
+                    agent="worker",
+                    requester=requester,
+                    report=report,
+                    listen_url=f"http://127.0.0.1:{p}",
+                    bearer=None,
+                    dispatch_id=dispatch_id,
+                )
+
+            hooks = build_event_log_hooks(
+                "worker",
+                _HookMatcher,
+                event_log_root=tmp_path,
+                turn_context=ctx,
+                push_fn=_push_fn,
+            )
+            on_stop = _stop_callback(hooks)
+            await on_stop({"stop_hook_active": False}, None, None)
+            return receiver.received
+
+        # Act
+        received = asyncio.run(
+            _run_receiver(port=port, receiver=receiver, client_coro=_client)
+        )
+        # Assert
+        assert len(received) == 1
+
+    def test_stop_hook_completion_reports_honest_success_status(
+        self, tmp_path: Path
+    ) -> None:
+        # Arrange
+        port = _free_port()
+        receiver = _Receiver(delivered=1)
+        ctx = TurnContext()
+        ctx.begin(requester="lead", dispatch_id="d-stop2")
+        ctx.finish(status=STATUS_SUCCESS, summary="done")
+
+        async def _client(p: int):
+            async def _push_fn(report, requester, dispatch_id):
+                await push_completion(
+                    agent="worker",
+                    requester=requester,
+                    report=report,
+                    listen_url=f"http://127.0.0.1:{p}",
+                    bearer=None,
+                    dispatch_id=dispatch_id,
+                )
+
+            hooks = build_event_log_hooks(
+                "worker",
+                _HookMatcher,
+                event_log_root=tmp_path,
+                turn_context=ctx,
+                push_fn=_push_fn,
+            )
+            await _stop_callback(hooks)({"stop_hook_active": False}, None, None)
+            text = receiver.received[0]["params"]["message"]["parts"][0]["text"]
+            return json.loads(text)
+
+        # Act
+        report = asyncio.run(
+            _run_receiver(port=port, receiver=receiver, client_coro=_client)
+        )
+        # Assert
+        assert report["status"] == STATUS_SUCCESS
+
+    def test_stop_hook_without_requester_pushes_nothing(self, tmp_path: Path) -> None:
+        # Arrange
+        ctx = TurnContext()
+        ctx.begin(requester=None, dispatch_id=None)  # mission/boot turn
+        ctx.finish(status=STATUS_SUCCESS, summary="x")
+        pushed: list = []
+
+        async def _push_fn(report, requester, dispatch_id):
+            pushed.append(report)
+
+        async def _scenario():
+            hooks = build_event_log_hooks(
+                "worker",
+                _HookMatcher,
+                event_log_root=tmp_path,
+                turn_context=ctx,
+                push_fn=_push_fn,
+            )
+            await _stop_callback(hooks)({"stop_hook_active": False}, None, None)
+            return pushed
+
+        # Act
+        observed = asyncio.run(_scenario())
+        # Assert
+        assert observed == []
+
+    def test_stop_hook_failed_push_does_not_raise(self, tmp_path: Path) -> None:
+        # Arrange
+        ctx = TurnContext()
+        ctx.begin(requester="lead", dispatch_id="d")
+        ctx.finish(status=STATUS_SUCCESS, summary="x")
+
+        async def _push_fn(report, requester, dispatch_id):
+            raise CompletionPushError("no subscriber")
+
+        async def _scenario():
+            hooks = build_event_log_hooks(
+                "worker",
+                _HookMatcher,
+                event_log_root=tmp_path,
+                turn_context=ctx,
+                push_fn=_push_fn,
+            )
+            # A loud-but-contained push failure must NOT propagate out of
+            # the Stop hook (the turn already completed).
+            await _stop_callback(hooks)({"stop_hook_active": False}, None, None)
+            return "no-raise"
+
+        # Act
+        observed = asyncio.run(_scenario())
+        # Assert
+        assert observed == "no-raise"
+
+
+# ---------------------------------------------------------------------------
+# emit_completion_push — the once-per-turn guard
+# ---------------------------------------------------------------------------
+
+
+class TestEmitOnceGuard:
+    def test_second_emit_for_same_turn_is_suppressed(self) -> None:
+        # Arrange
+        ctx = TurnContext()
+        ctx.begin(requester="lead", dispatch_id="d")
+        ctx.finish(status=STATUS_SUCCESS, summary="x")
+        calls: list = []
+
+        async def _push_fn(report, requester, dispatch_id):
+            calls.append(report)
+
+        async def _scenario():
+            await emit_completion_push(ctx, _push_fn, agent_name="worker")
+            await emit_completion_push(ctx, _push_fn, agent_name="worker")
+            return calls
+
+        # Act
+        observed = asyncio.run(_scenario())
+        # Assert
+        assert len(observed) == 1
+
+
+# ---------------------------------------------------------------------------
+# Full conversation → requester push (real run_conversation, fake SDK module)
+# ---------------------------------------------------------------------------
+
+
+class _FakeAssistantMsg:
+    def __init__(self, *texts: str) -> None:
+        self.content = [_FakeTextBlock(t) for t in texts]
+
+
+class _FakeTextBlock:
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+
+class _FakeResultMsg:
+    def __init__(self, session_id: str, usage: dict | None = None) -> None:
+        self.session_id = session_id
+        self.usage = usage
+
+
+class _FakeUserMsg:
+    pass
+
+
+class _FakeSDKClient:
+    """Real fake SDK client: one canned assistant turn + a ResultMessage."""
+
+    def __init__(self, options=None) -> None:
+        self.queries: list[str] = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def query(self, text: str) -> None:
+        self.queries.append(text)
+
+    async def interrupt(self) -> None:
+        pass
+
+    async def receive_response(self):
+        for m in (
+            _FakeAssistantMsg("the ", "answer"),
+            _FakeResultMsg("sess-c", {"input_tokens": 1, "output_tokens": 1}),
+        ):
+            yield m
+
+
+def _fake_sdk_module(client: _FakeSDKClient) -> SimpleNamespace:
+    """Hand-rolled fake of the claude_agent_sdk module — passed via injection."""
+    return SimpleNamespace(
+        ClaudeSDKClient=lambda options=None: client,
+        AssistantMessage=_FakeAssistantMsg,
+        TextBlock=_FakeTextBlock,
+        ResultMessage=_FakeResultMsg,
+        UserMessage=_FakeUserMsg,
+        HookMatcher=_HookMatcher,
+    )
+
+
+class TestConversationPushesCompletion:
+    def test_completed_turn_pushes_report_to_requester(
+        self, tmp_path: Path, listen_env
+    ) -> None:
+        # Arrange
+        from scitex_agent_container._runners import _session_conversation as conv
+        from scitex_agent_container._runners._session_inbox import (
+            ShutdownEnvelope,
+            TurnEnvelope,
+            make_inbox,
+        )
+
+        port = _free_port()
+        receiver = _Receiver(delivered=1)
+        os.environ["SAC_LISTEN_BASE_URL"] = f"http://127.0.0.1:{port}"
+        os.environ.pop("SAC_LISTEN_BEARER", None)
+
+        async def _client(p: int):
+            inbox = make_inbox()
+            stop = asyncio.Event()
+            loop = asyncio.get_running_loop()
+            env = TurnEnvelope(
+                text="hi",
+                response=loop.create_future(),
+                from_agent="lead",
+                dispatch_id="d-conv",
+            )
+            await inbox.put(env)
+            await inbox.put(ShutdownEnvelope())
+            await conv.run_conversation(
+                "worker",
+                tmp_path / "worker",
+                pid=4_321,
+                inbox=inbox,
+                resume_session_id=None,
+                stop=stop,
+                sdk_module=_fake_sdk_module(_FakeSDKClient()),
+                build_sdk_options_fn=lambda name, **kw: SimpleNamespace(name=name),
+            )
+            return receiver.received
+
+        # Act
+        received = asyncio.run(
+            _run_receiver(port=port, receiver=receiver, client_coro=_client)
+        )
+        # Assert
+        assert len(received) == 1
+
+    def test_completed_turn_completion_carries_dispatch_id(
+        self, tmp_path: Path, listen_env
+    ) -> None:
+        # Arrange
+        from scitex_agent_container._runners import _session_conversation as conv
+        from scitex_agent_container._runners._session_inbox import (
+            ShutdownEnvelope,
+            TurnEnvelope,
+            make_inbox,
+        )
+
+        port = _free_port()
+        receiver = _Receiver(delivered=1)
+        os.environ["SAC_LISTEN_BASE_URL"] = f"http://127.0.0.1:{port}"
+        os.environ.pop("SAC_LISTEN_BEARER", None)
+
+        async def _client(p: int):
+            inbox = make_inbox()
+            stop = asyncio.Event()
+            loop = asyncio.get_running_loop()
+            env = TurnEnvelope(
+                text="hi",
+                response=loop.create_future(),
+                from_agent="lead",
+                dispatch_id="d-corr",
+            )
+            await inbox.put(env)
+            await inbox.put(ShutdownEnvelope())
+            await conv.run_conversation(
+                "worker",
+                tmp_path / "worker",
+                pid=4_322,
+                inbox=inbox,
+                resume_session_id=None,
+                stop=stop,
+                sdk_module=_fake_sdk_module(_FakeSDKClient()),
+                build_sdk_options_fn=lambda name, **kw: SimpleNamespace(name=name),
+            )
+            return receiver.received[0]
+
+        # Act
+        body = asyncio.run(
+            _run_receiver(port=port, receiver=receiver, client_coro=_client)
+        )
+        # Assert
+        assert body["params"]["metadata"]["dispatch_id"] == "d-corr"
+
+    def test_mission_turn_without_requester_pushes_nothing(
+        self, tmp_path: Path, listen_env
+    ) -> None:
+        # Arrange
+        from scitex_agent_container._runners import _session_conversation as conv
+        from scitex_agent_container._runners._session_inbox import (
+            ShutdownEnvelope,
+            TurnEnvelope,
+            make_inbox,
+        )
+
+        port = _free_port()
+        receiver = _Receiver(delivered=1)
+        os.environ["SAC_LISTEN_BASE_URL"] = f"http://127.0.0.1:{port}"
+        os.environ.pop("SAC_LISTEN_BEARER", None)
+
+        async def _client(p: int):
+            inbox = make_inbox()
+            stop = asyncio.Event()
+            loop = asyncio.get_running_loop()
+            # No from_agent → a mission/boot turn that answers to no peer.
+            env = TurnEnvelope(text="boot", response=loop.create_future())
+            await inbox.put(env)
+            await inbox.put(ShutdownEnvelope())
+            await conv.run_conversation(
+                "worker",
+                tmp_path / "worker",
+                pid=4_323,
+                inbox=inbox,
+                resume_session_id=None,
+                stop=stop,
+                sdk_module=_fake_sdk_module(_FakeSDKClient()),
+                build_sdk_options_fn=lambda name, **kw: SimpleNamespace(name=name),
+            )
+            return receiver.received
+
+        # Act
+        received = asyncio.run(
+            _run_receiver(port=port, receiver=receiver, client_coro=_client)
+        )
+        # Assert
+        assert received == []

--- a/tests/scitex_agent_container/_runners/test__session_http_requester.py
+++ b/tests/scitex_agent_container/_runners/test__session_http_requester.py
@@ -1,0 +1,122 @@
+"""``POST /v1/turn`` threads requester identity onto the TurnEnvelope.
+
+NO MOCKS. A real ``serve_inbound`` HTTP server on a real socket, fed by a
+real asyncio consumer that captures the dequeued envelope so the test can
+assert the requester fields (``from_agent`` / ``dispatch_id``) landed on
+it. Mirrors the no-mock pattern in ``test__session_http.py``.
+
+TQ: AAA markers, ≥3-word names, one assertion each.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import socket
+import urllib.request
+from typing import Any
+
+import pytest
+
+from scitex_agent_container._runners._session_http import serve_inbound
+from scitex_agent_container._runners._session_inbox import (
+    ShutdownEnvelope,
+    TurnEnvelope,
+    make_inbox,
+)
+
+
+def _free_port() -> int:
+    """Ask the kernel for an unused TCP port."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+async def _wait_bound(port: int) -> None:
+    """Poll until the TCP port accepts connections."""
+    for _ in range(50):
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.2):
+                return
+        except OSError:
+            await asyncio.sleep(0.05)
+    pytest.fail(f"server never bound on port {port}")
+
+
+async def _capturing_consumer(inbox: "asyncio.Queue", *, captured: list) -> None:
+    """Real consumer: record each turn envelope, then resolve its future."""
+    while True:
+        env = await inbox.get()
+        if isinstance(env, ShutdownEnvelope):
+            return
+        if isinstance(env, TurnEnvelope) and not env.response.done():
+            captured.append(env)
+            env.response.set_result("ok")
+
+
+def _post(url: str, body: dict) -> None:
+    """POST a JSON body to ``url`` (fire-and-forget; success is implicit)."""
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=5.0) as resp:
+        resp.read()
+
+
+async def _run_and_capture(body: dict) -> TurnEnvelope:
+    """Spin the real sidecar, POST ``body`` to /v1/turn, return the envelope."""
+    port = _free_port()
+    inbox = make_inbox()
+    stop = asyncio.Event()
+    captured: list[Any] = []
+    consumer = asyncio.create_task(_capturing_consumer(inbox, captured=captured))
+    server = asyncio.create_task(
+        serve_inbound(inbox, host="127.0.0.1", port=port, stop=stop)
+    )
+    try:
+        await _wait_bound(port)
+        await asyncio.to_thread(_post, f"http://127.0.0.1:{port}/v1/turn", body)
+    finally:
+        stop.set()
+        await inbox.put(ShutdownEnvelope())
+        await asyncio.wait_for(consumer, timeout=5.0)
+        await asyncio.wait_for(server, timeout=5.0)
+    return captured[0]
+
+
+class TestRequesterThreading:
+    def test_v1_turn_threads_from_agent_onto_envelope(self) -> None:
+        # Arrange
+        body = {"text": "hi", "from_agent": "lead", "dispatch_id": "d-1"}
+        # Act
+        env = asyncio.run(_run_and_capture(body))
+        # Assert
+        assert env.from_agent == "lead"
+
+    def test_v1_turn_threads_dispatch_id_onto_envelope(self) -> None:
+        # Arrange
+        body = {"text": "hi", "from_agent": "lead", "dispatch_id": "d-1"}
+        # Act
+        env = asyncio.run(_run_and_capture(body))
+        # Assert
+        assert env.dispatch_id == "d-1"
+
+    def test_v1_turn_without_from_agent_leaves_envelope_requester_none(self) -> None:
+        # Arrange
+        body = {"text": "boot"}  # mission/boot turn — no requester declared
+        # Act
+        env = asyncio.run(_run_and_capture(body))
+        # Assert
+        assert env.from_agent is None
+
+    def test_v1_turn_blank_from_agent_is_normalised_to_none(self) -> None:
+        # Arrange
+        body = {"text": "hi", "from_agent": ""}
+        # Act
+        env = asyncio.run(_run_and_capture(body))
+        # Assert
+        assert env.from_agent is None

--- a/tests/scitex_agent_container/a2a/test__inbox_bus.py
+++ b/tests/scitex_agent_container/a2a/test__inbox_bus.py
@@ -343,6 +343,30 @@ def test_mint_event_defaults_ack_to_false() -> None:
 
 
 # ---------------------------------------------------------------------------
+# mint_event: ``dispatch_id`` rides on the event so the channel wake path
+# can thread it onto the woken turn for requester-completion correlation.
+# ---------------------------------------------------------------------------
+
+
+def test_mint_event_carries_dispatch_id_when_provided() -> None:
+    # Arrange
+    event = mint_event("alice", content="hi", from_agent="bob", dispatch_id="d-123")
+    # Act
+    dispatch_id = event["dispatch_id"]
+    # Assert
+    assert dispatch_id == "d-123"
+
+
+def test_mint_event_omits_dispatch_id_when_absent() -> None:
+    # Arrange
+    event = mint_event("alice", content="hi", from_agent="bob")
+    # Act
+    present = "dispatch_id" in event
+    # Assert
+    assert present is False
+
+
+# ---------------------------------------------------------------------------
 # mint_deny_notification — receiver-side ACL-deny notice (comms item D).
 # Shape contract: marked ``kind="denied_attempt"``, empty content,
 # from/to/reason carried, no message body leak.


### PR DESCRIPTION
## What

Thread **requester identity** end-to-end so a SAC agent's Stop hook PUSHes a completion report back to **whoever dispatched the turn** — generalised to ANY peer (the lead is not special-cased). Realises the push-feedback north star and aligns with ACL + the agent↔agent mesh.

## Threading (both inbound paths)

- `TurnEnvelope` gains `from_agent`; the inbound `POST /v1/turn` handler reads `from_agent` + the existing `dispatch_id` from the body onto it.
- `peer.post_turn_to_url` stamps the requester `from_agent` into the `/v1/turn` body (HTTP **and** ssh transports), defaulting to `SAC_NAME`.
- `mint_event` carries `dispatch_id`; `node_message_send` threads `metadata.dispatch_id` through, so the channel **wake path** body carries both `from_agent` and `dispatch_id` onto the woken turn.

## Emit

- A per-conversation `TurnContext` holder records each turn's requester + honest outcome; `build_event_log_hooks` gains `turn_context` + `push_fn` seams.
- The **Stop hook** (clean-turn-end) emits the completion push; the conversation `finally`-block emits on the SDK-error path (no clean Stop), guarded **once-per-turn**.
- `push_completion` reuses the existing `sac listen` `message:send` channel and **FAILS LOUD** when `delivered_subscriber_count == 0` / transport fails.
- `status` is **honest** (`success` / `failure` / `unknown` — never hardcoded). `dispatch_id` rides in the `{agent, dispatch_id, status, summary}` payload so the requester can correlate *which task from which agent*.

## Refactor (required, pure)

`_listen/server.py` was already 1006 lines (over the 512 cap on `develop`), so the size hook blocked the 1-line `mint_event` edit. Extracted two cohesive clusters — node inbox-channel routes → `_node_channel.py`, claude-exec routes → `_agent_exec.py`. `server.py` re-imports both; public API + test import paths preserved. No behaviour change (verified by the existing `_listen`/`a2a` suites).

## Tests — NO MOCKS

Real subprocess / HTTP receivers + a hand-rolled fake SDK module via the `run_conversation(sdk_module=...)` injection seam. Cover: the Stop hook actually firing + emitting; the full conversation→push e2e; loud-on-no-subscriber + loud-on-unreachable; honest-status (no fabricated success); `dispatch_id` correlation; and the body threading on every path (`/v1/turn`, peer, wake, `mint_event`, route). STX-NM + STX-TQ compliant.

## Test plan

- Full suite: **4831 passed, 35 skipped** (`pytest tests/`).
- Affected dirs under `pytest-randomly`: **1070 passed** (ordering-bug gate).
- `tests/develop/test_audit.py` (audit-conformance gate): **pass**.
- Linter clean on all changed files; pre-existing `peer.py` F822 (lazy `__getattr__` re-export) untouched.