### PR TITLE
feat(runner): observe background-subagent task completions (C2)

### DIFF
--- a/src/scitex_agent_container/_runners/_session_conversation.py
+++ b/src/scitex_agent_container/_runners/_session_conversation.py
@@ -10,28 +10,36 @@ exponential backoff, refresh the resume session_id from disk so the
 next attempt picks up where the last completed turn left off, and
 re-open the client. Init failures (missing SDK, bad options) are
 treated as terminal — no point retrying a config error.
+
+The per-turn driver (:func:`._session_turn._drive_turn`) is a sibling
+module so neither file exceeds the per-file line cap. It is re-exported
+here (along with :func:`._session_turn._safe_repr` and
+:func:`._session_turn._build_completion_push_fn`) so existing imports
+of those names from this module keep resolving.
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
-import os
-import sys
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 from ._session_state import (
-    STATE_IDLE,
-    STATE_WORKING,
-    accumulate_quota,
     append_session_message,
     read_session_id,
     read_session_id_history,
-    record_turn_transition,
     report_sdk_error,
-    write_heartbeat,
-    write_session_id,
+)
+from ._session_tasks import (
+    TaskObservations,
+    log_observability_status,
+    resolve_task_types,
+)
+from ._session_turn import (
+    _build_completion_push_fn,
+    _drive_turn,
+    _safe_repr,
 )
 from ._stderr_capture import (
     StderrCapture,
@@ -40,46 +48,6 @@ from ._stderr_capture import (
 )
 
 logger = logging.getLogger(__name__)
-
-
-def _safe_repr(value: object) -> str:
-    """Bounded repr so a runaway tool-result blob can't bloat session.jsonl."""
-    s = repr(value)
-    return s if len(s) <= 1024 else s[:1024] + "…"  # stx-allow: STX-NL001
-
-
-def _build_completion_push_fn(agent_name: str):
-    """Build the Stop-hook completion ``push_fn``, or ``None`` if not wired.
-
-    The push reuses the agent's own ``sac listen`` (``message:send``) — its
-    base URL + bearer ride in the runner's env (``SAC_LISTEN_BASE_URL`` /
-    ``SAC_LISTEN_BEARER``), injected by the apptainer runtime alongside the
-    channel adapter. When no listen URL is configured (e.g. a bare runner
-    with no host control-plane), there is nowhere to push a report, so we
-    return ``None`` and the Stop hook keeps its append-only behaviour. This
-    is the honest "no channel → no push" case, NOT a silenced failure: a
-    push that has a URL but cannot deliver still fails LOUD inside the hook.
-    """
-    listen_url = os.environ.get("SAC_LISTEN_BASE_URL", "").strip()
-    if not listen_url:
-        return None
-    bearer = os.environ.get("SAC_LISTEN_BEARER") or None
-
-    from ._session_completion import push_completion
-
-    async def _push_fn(
-        report: dict, requester: str, dispatch_id: Optional[str]
-    ) -> None:
-        await push_completion(
-            agent=agent_name,
-            requester=requester,
-            report=report,
-            listen_url=listen_url,
-            bearer=bearer,
-            dispatch_id=dispatch_id,
-        )
-
-    return _push_fn
 
 
 def _drain_failed_inbox(inbox: "asyncio.Queue", exc: BaseException) -> None:
@@ -122,192 +90,6 @@ def _resume_candidate(
     if attempt == 0:
         return read_session_id(state_dir) or fallback
     return None
-
-
-async def _drive_turn(
-    client: Any,
-    env: Any,
-    *,
-    state_dir: Path,
-    pid: int,
-    stop: asyncio.Event,
-    print_stream: bool,
-    sdk_types: dict,
-    name: str | None = None,
-    host: str | None = None,
-    db_writer=None,
-    stderr_capture: Any | None = None,
-    turn_context: Any | None = None,
-    push_fn: Any | None = None,
-) -> None:
-    AssistantMessage = sdk_types["AssistantMessage"]
-    TextBlock = sdk_types["TextBlock"]
-    UserMessage = sdk_types["UserMessage"]
-    ResultMessage = sdk_types["ResultMessage"]
-
-    # Open the turn context BEFORE any work so the Stop hook (which fires
-    # after the SDK drains this turn) can address the requester that
-    # dispatched it. Requester identity rides on the envelope (threaded by
-    # the inbound /v1/turn handler from the POST body — see _session_http).
-    # ``None`` requester == a mission/boot turn with no peer to answer to.
-    if turn_context is not None:
-        turn_context.begin(
-            requester=getattr(env, "from_agent", None),
-            dispatch_id=getattr(env, "dispatch_id", None),
-        )
-
-    write_heartbeat(
-        state_dir,
-        pid=pid,
-        state=STATE_WORKING,
-        name=name,
-        host=host,
-        db_writer=db_writer,
-    )
-    append_session_message(state_dir, {"type": "user", "text": env.text})
-    # Tag a turn_id on the envelope so the diary's four
-    # state-transition rows share an identity. ``record_turn_transition``
-    # is a no-op when name/host/turn_id are unset (legacy callers).
-    turn_id = getattr(env, "turn_id", None)
-    if turn_id and name and host:
-        record_turn_transition(
-            turn_id=turn_id,
-            name=name,
-            host=host,
-            status="delivered",
-            prompt_text=env.text,
-            db_writer=db_writer,
-        )
-        record_turn_transition(
-            turn_id=turn_id,
-            name=name,
-            host=host,
-            status="read",
-            db_writer=db_writer,
-        )
-    chunks: list[str] = []
-    try:
-        await client.query(env.text)
-        async for msg in client.receive_response():
-            if stop.is_set():
-                await client.interrupt()
-                break
-            if isinstance(msg, AssistantMessage):
-                for block in msg.content:
-                    if isinstance(block, TextBlock):
-                        chunks.append(block.text)
-                        append_session_message(
-                            state_dir,
-                            {"type": "assistant", "text": block.text},
-                        )
-                        if print_stream:
-                            sys.stdout.write(block.text)
-                            sys.stdout.flush()
-            elif isinstance(msg, UserMessage):
-                append_session_message(
-                    state_dir,
-                    {"type": "user_echo", "raw": _safe_repr(msg)},
-                )
-            elif isinstance(msg, ResultMessage):
-                sid = getattr(msg, "session_id", None)
-                if sid:
-                    # Fork detection: the SDK can return a NEW session id
-                    # on resume instead of the one we asked it to resume
-                    # (a fork). The latest marker still advances to the
-                    # fork below — we don't change behaviour here — but a
-                    # silent transition would orphan the prior id, so log
-                    # it LOUDLY (warning) to make the fork observable. The
-                    # prior id is preserved in session_id_history (see
-                    # write_session_id).
-                    prev_sid = read_session_id(state_dir)
-                    if prev_sid and prev_sid != sid:
-                        logger.warning(
-                            "session_id changed on resume: %s -> %s "
-                            "(SDK fork?); prior id retained in "
-                            "session_id_history",
-                            prev_sid,
-                            sid,
-                        )
-                    write_session_id(state_dir, sid)
-                    # Tag the envelope so the HTTP sidecar can echo the
-                    # SDK session id back to the caller. Set BEFORE the
-                    # future resolves (in the finally block below) so
-                    # the awaiter sees a consistent (text, session_id).
-                    env.session_id = sid
-                usage = getattr(msg, "usage", None)
-                accumulate_quota(state_dir, usage)
-                append_session_message(
-                    state_dir,
-                    {"type": "result", "session_id": sid, "usage": usage},
-                )
-                # Clean drain: record the HONEST success outcome + reply
-                # summary on the turn context BEFORE the Stop hook fires
-                # (Stop comes after this ResultMessage). The Stop hook reads
-                # this to PUSH the completion report to the requester.
-                if turn_context is not None:
-                    from ._session_completion import STATUS_SUCCESS
-
-                    turn_context.finish(status=STATUS_SUCCESS, summary="".join(chunks))
-                break
-    except BaseException as exc:  # stx-allow: fallback (reason: enrich the failure with the real captured stderr, resolve the awaiter with the real cause, then re-raise for the supervisor)
-        # The SDK turn failed (e.g. a ProcessError from a stale --resume
-        # whose only "stderr" is the placeholder). Fold the stderr the
-        # registered callback captured into the exception so the awaiting
-        # /v1/turn handler returns a 502 carrying the REAL cause instead
-        # of a silent empty-200 (the pre-fix behaviour: the finally below
-        # resolved the future with "".join(chunks)). Then re-raise so
-        # run_conversation's supervisor records + classifies it.
-        if not env.response.done():
-            captured = stderr_capture.text() if stderr_capture is not None else ""
-            enriched = enrich_detail_with_stderr(str(exc), captured)
-            if enriched != str(exc):
-                # Attach the enriched detail without losing the exception
-                # type, so classify_auth_failure / the supervisor still
-                # see the original class.
-                exc.args = (enriched,) + tuple(exc.args[1:])
-            env.response.set_exception(exc)
-        # Record the HONEST failure outcome on the turn context. Stop does
-        # NOT reliably fire when the SDK raises mid-turn, so the finally
-        # below is what emits the requester push in this case (status from
-        # here). Summary carries the failure detail so the requester sees
-        # WHY, not a bare "failure".
-        if turn_context is not None:
-            from ._session_completion import STATUS_FAILURE
-
-            turn_context.finish(status=STATUS_FAILURE, summary=str(exc))
-        raise
-    finally:
-        if not env.response.done():
-            env.response.set_result("".join(chunks))
-        if turn_id and name and host:
-            record_turn_transition(
-                turn_id=turn_id,
-                name=name,
-                host=host,
-                status="responded",
-                response_text="".join(chunks),
-                session_id=getattr(env, "session_id", None),
-                db_writer=db_writer,
-            )
-        # Emit the requester completion push exactly once per turn. On a
-        # clean drain the Stop hook already pushed (pushed=True) → this is a
-        # no-op; on an SDK error (no clean Stop) THIS is the emit point,
-        # carrying the honest FAILURE status set in the except branch. The
-        # ``pushed`` guard inside ``emit_completion_push`` makes the double
-        # call idempotent. A no-requester (mission) turn skips quietly.
-        if turn_context is not None and push_fn is not None and name:
-            from ._session_hooks import emit_completion_push
-
-            await emit_completion_push(turn_context, push_fn, agent_name=name)
-        if not stop.is_set():
-            write_heartbeat(
-                state_dir,
-                pid=pid,
-                state=STATE_IDLE,
-                name=name,
-                host=host,
-                db_writer=db_writer,
-            )
 
 
 async def run_conversation(
@@ -388,6 +170,18 @@ async def run_conversation(
     hooks = build_event_log_hooks(
         name, HookMatcher, turn_context=turn_context, push_fn=push_fn
     )
+
+    # Background-subagent observation (C2): one TaskObservations holder for
+    # the whole conversation (NOT per-turn — completions must survive across
+    # turns so the next turn / autonomous loop can read them). ``task_types``
+    # maps the SDK's task-message classes to their session.jsonl event type;
+    # it is empty when the installed SDK predates background-subagent
+    # observation, in which case ``is_task_message`` never matches and the
+    # receive loop is unchanged. The availability is logged once (LOUD at
+    # WARNING when unavailable) so the gap is never a silent swallow.
+    task_observations = TaskObservations()
+    task_types = resolve_task_types(sdk_module)
+    log_observability_status(task_types, name=name)
 
     # Thread spec.claude.channels + the runner's own a2a_port into the
     # SDK options under the sac-private ``extra`` keys so build_sdk_options
@@ -499,6 +293,8 @@ async def run_conversation(
                         stderr_capture=stderr_capture,
                         turn_context=turn_context,
                         push_fn=push_fn,
+                        task_observations=task_observations,
+                        task_types=task_types,
                     )
                     if env.exit_after:
                         stop.set()
@@ -581,3 +377,17 @@ async def run_conversation(
             except asyncio.TimeoutError:
                 pass
             attempt += 1
+
+
+# Re-export the per-turn driver + its helpers (moved to ._session_turn to
+# keep both modules under the per-file line cap) so existing imports of
+# these names from this module keep resolving (claude_session.py imports
+# _safe_repr + _drain_failed_inbox + run_conversation from here).
+__all__ = [
+    "_build_completion_push_fn",
+    "_drain_failed_inbox",
+    "_drive_turn",
+    "_resume_candidate",
+    "_safe_repr",
+    "run_conversation",
+]

--- a/src/scitex_agent_container/_runners/_session_tasks.py
+++ b/src/scitex_agent_container/_runners/_session_tasks.py
@@ -1,0 +1,195 @@
+"""Observe background-subagent task lifecycle messages (autonomy C2).
+
+The claude-agent-sdk surfaces background subagents (``task_type ==
+"local_agent"``) through three message classes that interleave with the
+normal assistant stream during a turn:
+
+* ``TaskStartedMessage`` — a background subagent began.
+* ``TaskProgressMessage`` — incremental progress.
+* ``TaskNotificationMessage`` — terminal signal carrying
+  ``status`` (``completed`` / ``failed`` / ``stopped``) + ``summary``.
+
+The per-turn receive loop used to drop these on the floor, so a
+background subagent's result reached *nobody* — the whole point of a
+background subagent (fan out work, react to it later) was unusable.
+This module is the C2 fix: it CAPTURES each task message into
+``session.jsonl`` as a structured event and ACCUMULATES it on a
+:class:`TaskObservations` holder so a LATER turn (or the autonomous
+loop — C3, separate item) can read which background subagents
+completed and what they produced.
+
+Honesty / non-breaking contract
+--------------------------------
+The three message classes are a recent SDK addition. :func:`resolve_task_types`
+detects whether the *installed* SDK exposes them via ``hasattr`` and
+returns an empty mapping when it does not — :func:`is_task_message` then
+never matches and the receive loop is unchanged. The runner logs the
+unavailability ONCE at startup so the gap is observable, never silently
+swallowed. This is the honest "SDK too old → no-op + loud log" case, not
+a masked failure.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# The SDK symbol names this module observes, mapped to the
+# ``session.jsonl`` event ``type`` we record them under.
+_TASK_SYMBOL_EVENT = {
+    "TaskStartedMessage": "task_started",
+    "TaskProgressMessage": "task_progress",
+    "TaskNotificationMessage": "task_notification",
+}
+
+
+def resolve_task_types(sdk_module: Any) -> dict[type, str]:
+    """Map the SDK's task-message classes to their event ``type`` string.
+
+    Returns ``{TaskStartedMessage: "task_started", ...}`` for whichever of
+    the three classes the installed SDK actually exposes. An SDK that
+    predates background-subagent observation exposes none of them →
+    returns ``{}`` and the caller no-ops (see module docstring). The gap
+    is logged LOUD at WARNING by :func:`log_observability_status` so it is
+    never a silent swallow.
+    """
+    resolved: dict[type, str] = {}
+    for symbol, event_type in _TASK_SYMBOL_EVENT.items():
+        cls = getattr(sdk_module, symbol, None)
+        if isinstance(cls, type):
+            resolved[cls] = event_type
+    return resolved
+
+
+def log_observability_status(task_types: dict[type, str], *, name: str) -> None:
+    """Log whether background-task observation is available for this run.
+
+    Called once at conversation startup. When ``task_types`` is empty the
+    installed SDK is too old to surface task lifecycle messages, so the
+    runner cannot react to background subagents — that is a real
+    limitation the operator must be able to see, logged at WARNING. When
+    available, logged at INFO so the capability is confirmable in the log.
+    """
+    if task_types:
+        logger.info(
+            "background-task observation enabled for %s (%d message types)",
+            name,
+            len(task_types),
+        )
+    else:
+        logger.warning(
+            "background-task observation UNAVAILABLE for %s: installed "
+            "claude-agent-sdk exposes none of %s — background subagent "
+            "completions will not be captured (SDK too old)",
+            name,
+            ", ".join(_TASK_SYMBOL_EVENT),
+        )
+
+
+def is_task_message(msg: Any, task_types: dict[type, str]) -> bool:
+    """True when ``msg`` is one of the resolved task-lifecycle classes."""
+    return isinstance(msg, tuple(task_types)) if task_types else False
+
+
+def _task_event(msg: Any, event_type: str) -> dict:
+    """Build the structured ``session.jsonl`` record for a task message.
+
+    Pulls the fields common to all three classes (``task_id``,
+    ``session_id``), plus the terminal-signal fields (``status``,
+    ``summary``, ``output_file``) and the descriptive ``description`` when
+    present. ``getattr`` defaults keep this robust across the three shapes
+    (only ``TaskNotificationMessage`` has ``status`` / ``summary`` /
+    ``output_file``; only Started/Progress have ``description``).
+    """
+    record: dict[str, Any] = {
+        "type": event_type,
+        "task_id": getattr(msg, "task_id", None),
+        "session_id": getattr(msg, "session_id", None),
+    }
+    status = getattr(msg, "status", None)
+    if status is not None:
+        record["status"] = status
+    summary = getattr(msg, "summary", None)
+    if summary is not None:
+        record["summary"] = summary
+    output_file = getattr(msg, "output_file", None)
+    if output_file is not None:
+        record["output_file"] = output_file
+    description = getattr(msg, "description", None)
+    if description is not None:
+        record["description"] = description
+    task_type = getattr(msg, "task_type", None)
+    if task_type is not None:
+        record["task_type"] = task_type
+    return record
+
+
+@dataclass
+class TaskObservations:
+    """Per-conversation accumulator of observed background-subagent events.
+
+    Turns are serial, so a single mutable holder is race-free (same model
+    as :class:`._session_hooks.TurnContext`). ``completions`` records the
+    terminal ``task_notification`` signals (the results a later turn /
+    the autonomous loop reacts to — C3 consumes this). ``started`` /
+    ``progress`` are kept for completeness so the full lifecycle is
+    inspectable, but the load-bearing list for "which background subagents
+    finished + what they produced" is ``completions``.
+    """
+
+    completions: list[dict] = field(default_factory=list)
+    started: list[dict] = field(default_factory=list)
+    progress: list[dict] = field(default_factory=list)
+
+    def record(self, event: dict) -> None:
+        """File a task event into the matching lifecycle bucket."""
+        event_type = event.get("type")
+        if event_type == "task_notification":
+            self.completions.append(event)
+        elif event_type == "task_started":
+            self.started.append(event)
+        elif event_type == "task_progress":
+            self.progress.append(event)
+
+    def drain_completions(self) -> list[dict]:
+        """Return the accumulated completions and clear them.
+
+        The autonomous loop (C3) calls this to consume the background
+        subagent results since the last drain exactly once — clearing
+        avoids re-reacting to the same completion on every later turn.
+        """
+        drained = self.completions
+        self.completions = []
+        return drained
+
+
+def handle_task_message(
+    msg: Any,
+    event_type: str,
+    *,
+    observations: TaskObservations,
+    append_fn: Any,
+    state_dir: Any,
+) -> None:
+    """Capture one task-lifecycle message: persist + accumulate.
+
+    Writes the structured record to ``session.jsonl`` via ``append_fn``
+    (the runner injects ``append_session_message``) AND files it on the
+    ``observations`` holder so a later turn can read it. Does NOT break
+    the turn — task messages interleave with the assistant stream.
+    """
+    record = _task_event(msg, event_type)
+    append_fn(state_dir, record)
+    observations.record(record)
+
+
+__all__ = [
+    "TaskObservations",
+    "handle_task_message",
+    "is_task_message",
+    "log_observability_status",
+    "resolve_task_types",
+]

--- a/src/scitex_agent_container/_runners/_session_turn.py
+++ b/src/scitex_agent_container/_runners/_session_turn.py
@@ -1,0 +1,291 @@
+"""The per-turn SDK driver for the claude-session runner.
+
+Split out of :mod:`._session_conversation` so each module stays under
+the project's per-file line cap. :func:`_drive_turn` drains one turn's
+SDK response stream — assistant text, the user echo, the terminal
+``ResultMessage``, and (autonomy C2) the background-subagent
+task-lifecycle messages — persisting each to ``session.jsonl`` and
+firing the requester completion push. The supervisor / inbox loop that
+calls it lives in :mod:`._session_conversation`.
+
+Background-subagent observation (C2)
+------------------------------------
+A background subagent (``task_type == "local_agent"``) interleaves
+``TaskStartedMessage`` / ``TaskProgressMessage`` /
+``TaskNotificationMessage`` into the turn's response stream. The loop
+used to drop them, so a background subagent's result reached *nobody*.
+:func:`_drive_turn` now captures each into ``session.jsonl`` AND files
+it on the conversation-lifetime :class:`._session_tasks.TaskObservations`
+holder so the NEXT turn / the autonomous loop (C3, a separate item) can
+read which background subagents completed and what they produced. Task
+messages do NOT break the turn — only ``ResultMessage`` does.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Any, Optional
+
+from ._session_state import (
+    STATE_IDLE,
+    STATE_WORKING,
+    accumulate_quota,
+    append_session_message,
+    read_session_id,
+    record_turn_transition,
+    write_heartbeat,
+    write_session_id,
+)
+from ._session_tasks import handle_task_message, is_task_message
+from ._stderr_capture import enrich_detail_with_stderr
+
+logger = logging.getLogger(__name__)
+
+
+def _safe_repr(value: object) -> str:
+    """Bounded repr so a runaway tool-result blob can't bloat session.jsonl."""
+    s = repr(value)
+    return s if len(s) <= 1024 else s[:1024] + "…"  # stx-allow: STX-NL001
+
+
+def _build_completion_push_fn(agent_name: str):
+    """Build the Stop-hook completion ``push_fn``, or ``None`` if not wired.
+
+    The push reuses the agent's own ``sac listen`` (``message:send``) — its
+    base URL + bearer ride in the runner's env (``SAC_LISTEN_BASE_URL`` /
+    ``SAC_LISTEN_BEARER``), injected by the apptainer runtime alongside the
+    channel adapter. When no listen URL is configured (e.g. a bare runner
+    with no host control-plane), there is nowhere to push a report, so we
+    return ``None`` and the Stop hook keeps its append-only behaviour. This
+    is the honest "no channel → no push" case, NOT a silenced failure: a
+    push that has a URL but cannot deliver still fails LOUD inside the hook.
+    """
+    listen_url = os.environ.get("SAC_LISTEN_BASE_URL", "").strip()
+    if not listen_url:
+        return None
+    bearer = os.environ.get("SAC_LISTEN_BEARER") or None
+
+    from ._session_completion import push_completion
+
+    async def _push_fn(
+        report: dict, requester: str, dispatch_id: Optional[str]
+    ) -> None:
+        await push_completion(
+            agent=agent_name,
+            requester=requester,
+            report=report,
+            listen_url=listen_url,
+            bearer=bearer,
+            dispatch_id=dispatch_id,
+        )
+
+    return _push_fn
+
+
+async def _drive_turn(
+    client: Any,
+    env: Any,
+    *,
+    state_dir: Path,
+    pid: int,
+    stop: asyncio.Event,
+    print_stream: bool,
+    sdk_types: dict,
+    name: str | None = None,
+    host: str | None = None,
+    db_writer=None,
+    stderr_capture: Any | None = None,
+    turn_context: Any | None = None,
+    push_fn: Any | None = None,
+    task_observations: Any | None = None,
+    task_types: dict | None = None,
+) -> None:
+    AssistantMessage = sdk_types["AssistantMessage"]
+    TextBlock = sdk_types["TextBlock"]
+    UserMessage = sdk_types["UserMessage"]
+    ResultMessage = sdk_types["ResultMessage"]
+    task_types = task_types or {}
+
+    # Open the turn context BEFORE any work so the Stop hook (which fires
+    # after the SDK drains this turn) can address the requester that
+    # dispatched it. Requester identity rides on the envelope (threaded by
+    # the inbound /v1/turn handler from the POST body — see _session_http).
+    # ``None`` requester == a mission/boot turn with no peer to answer to.
+    if turn_context is not None:
+        turn_context.begin(
+            requester=getattr(env, "from_agent", None),
+            dispatch_id=getattr(env, "dispatch_id", None),
+        )
+
+    write_heartbeat(
+        state_dir,
+        pid=pid,
+        state=STATE_WORKING,
+        name=name,
+        host=host,
+        db_writer=db_writer,
+    )
+    append_session_message(state_dir, {"type": "user", "text": env.text})
+    # Tag a turn_id on the envelope so the diary's four
+    # state-transition rows share an identity. ``record_turn_transition``
+    # is a no-op when name/host/turn_id are unset (legacy callers).
+    turn_id = getattr(env, "turn_id", None)
+    if turn_id and name and host:
+        record_turn_transition(
+            turn_id=turn_id,
+            name=name,
+            host=host,
+            status="delivered",
+            prompt_text=env.text,
+            db_writer=db_writer,
+        )
+        record_turn_transition(
+            turn_id=turn_id,
+            name=name,
+            host=host,
+            status="read",
+            db_writer=db_writer,
+        )
+    chunks: list[str] = []
+    try:
+        await client.query(env.text)
+        async for msg in client.receive_response():
+            if stop.is_set():
+                await client.interrupt()
+                break
+            if isinstance(msg, AssistantMessage):
+                for block in msg.content:
+                    if isinstance(block, TextBlock):
+                        chunks.append(block.text)
+                        append_session_message(
+                            state_dir,
+                            {"type": "assistant", "text": block.text},
+                        )
+                        if print_stream:
+                            sys.stdout.write(block.text)
+                            sys.stdout.flush()
+            elif is_task_message(msg, task_types):
+                # C2 — a background subagent's lifecycle signal interleaves
+                # with the assistant stream. Capture it into session.jsonl
+                # AND accumulate it on the conversation-lifetime observations
+                # holder so the NEXT turn / autonomous loop can react to the
+                # completion. Crucially: do NOT break — the turn continues.
+                handle_task_message(
+                    msg,
+                    task_types[type(msg)],
+                    observations=task_observations,
+                    append_fn=append_session_message,
+                    state_dir=state_dir,
+                )
+            elif isinstance(msg, UserMessage):
+                append_session_message(
+                    state_dir,
+                    {"type": "user_echo", "raw": _safe_repr(msg)},
+                )
+            elif isinstance(msg, ResultMessage):
+                sid = getattr(msg, "session_id", None)
+                if sid:
+                    # Fork detection: the SDK can return a NEW session id
+                    # on resume instead of the one we asked it to resume
+                    # (a fork). The latest marker still advances to the
+                    # fork below — we don't change behaviour here — but a
+                    # silent transition would orphan the prior id, so log
+                    # it LOUDLY (warning) to make the fork observable. The
+                    # prior id is preserved in session_id_history (see
+                    # write_session_id).
+                    prev_sid = read_session_id(state_dir)
+                    if prev_sid and prev_sid != sid:
+                        logger.warning(
+                            "session_id changed on resume: %s -> %s "
+                            "(SDK fork?); prior id retained in "
+                            "session_id_history",
+                            prev_sid,
+                            sid,
+                        )
+                    write_session_id(state_dir, sid)
+                    # Tag the envelope so the HTTP sidecar can echo the
+                    # SDK session id back to the caller. Set BEFORE the
+                    # future resolves (in the finally block below) so
+                    # the awaiter sees a consistent (text, session_id).
+                    env.session_id = sid
+                usage = getattr(msg, "usage", None)
+                accumulate_quota(state_dir, usage)
+                append_session_message(
+                    state_dir,
+                    {"type": "result", "session_id": sid, "usage": usage},
+                )
+                # Clean drain: record the HONEST success outcome + reply
+                # summary on the turn context BEFORE the Stop hook fires
+                # (Stop comes after this ResultMessage). The Stop hook reads
+                # this to PUSH the completion report to the requester.
+                if turn_context is not None:
+                    from ._session_completion import STATUS_SUCCESS
+
+                    turn_context.finish(status=STATUS_SUCCESS, summary="".join(chunks))
+                break
+    except BaseException as exc:  # stx-allow: fallback (reason: enrich the failure with the real captured stderr, resolve the awaiter with the real cause, then re-raise for the supervisor)
+        # The SDK turn failed (e.g. a ProcessError from a stale --resume
+        # whose only "stderr" is the placeholder). Fold the stderr the
+        # registered callback captured into the exception so the awaiting
+        # /v1/turn handler returns a 502 carrying the REAL cause instead
+        # of a silent empty-200 (the pre-fix behaviour: the finally below
+        # resolved the future with "".join(chunks)). Then re-raise so
+        # run_conversation's supervisor records + classifies it.
+        if not env.response.done():
+            captured = stderr_capture.text() if stderr_capture is not None else ""
+            enriched = enrich_detail_with_stderr(str(exc), captured)
+            if enriched != str(exc):
+                # Attach the enriched detail without losing the exception
+                # type, so classify_auth_failure / the supervisor still
+                # see the original class.
+                exc.args = (enriched,) + tuple(exc.args[1:])
+            env.response.set_exception(exc)
+        # Record the HONEST failure outcome on the turn context. Stop does
+        # NOT reliably fire when the SDK raises mid-turn, so the finally
+        # below is what emits the requester push in this case (status from
+        # here). Summary carries the failure detail so the requester sees
+        # WHY, not a bare "failure".
+        if turn_context is not None:
+            from ._session_completion import STATUS_FAILURE
+
+            turn_context.finish(status=STATUS_FAILURE, summary=str(exc))
+        raise
+    finally:
+        if not env.response.done():
+            env.response.set_result("".join(chunks))
+        if turn_id and name and host:
+            record_turn_transition(
+                turn_id=turn_id,
+                name=name,
+                host=host,
+                status="responded",
+                response_text="".join(chunks),
+                session_id=getattr(env, "session_id", None),
+                db_writer=db_writer,
+            )
+        # Emit the requester completion push exactly once per turn. On a
+        # clean drain the Stop hook already pushed (pushed=True) → this is a
+        # no-op; on an SDK error (no clean Stop) THIS is the emit point,
+        # carrying the honest FAILURE status set in the except branch. The
+        # ``pushed`` guard inside ``emit_completion_push`` makes the double
+        # call idempotent. A no-requester (mission) turn skips quietly.
+        if turn_context is not None and push_fn is not None and name:
+            from ._session_hooks import emit_completion_push
+
+            await emit_completion_push(turn_context, push_fn, agent_name=name)
+        if not stop.is_set():
+            write_heartbeat(
+                state_dir,
+                pid=pid,
+                state=STATE_IDLE,
+                name=name,
+                host=host,
+                db_writer=db_writer,
+            )
+
+
+__all__ = ["_build_completion_push_fn", "_drive_turn", "_safe_repr"]

--- a/tests/scitex_agent_container/_runners/test__session_conversation.py
+++ b/tests/scitex_agent_container/_runners/test__session_conversation.py
@@ -333,3 +333,146 @@ def test_resume_candidate_attempt0_uses_fallback_before_any_history(
     candidate = _resume_candidate(state_dir, attempt=0, fallback="seed-sid")
     # Assert — preserves the pre-history initial-resume behaviour.
     assert candidate == "seed-sid"
+
+
+# ---------------------------------------------------------------------------
+# C2 — run_conversation observes background-subagent task messages
+# ---------------------------------------------------------------------------
+
+
+def _make_sdk_module_with_task() -> types.ModuleType:
+    """SDK module whose one turn interleaves a TaskNotification + result.
+
+    Exposes ``TaskNotificationMessage`` so ``resolve_task_types`` enables
+    background-subagent observation, then the scripted client yields a
+    completion notification between the assistant text and the result.
+    """
+
+    class _Text:
+        def __init__(self, text: str) -> None:
+            self.text = text
+
+    class _Assistant:
+        def __init__(self, content):
+            self.content = content
+
+    class _User:
+        pass
+
+    class _Result:
+        def __init__(self, sid_, usage):
+            self.session_id = sid_
+            self.usage = usage
+
+    class _TaskNotification:
+        def __init__(self, task_id, status, summary):
+            self.task_id = task_id
+            self.session_id = "s1"
+            self.status = status
+            self.summary = summary
+            self.output_file = "/out"
+
+    class _Client:
+        def __init__(self, *, options):
+            self._messages = [
+                _Assistant([_Text("hi")]),
+                _TaskNotification("bg-1", "completed", "subagent done"),
+                _Result("sid-1", {}),
+            ]
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return None
+
+        async def query(self, prompt):
+            self._prompt = prompt
+
+        async def receive_response(self):
+            for m in self._messages:
+                yield m
+
+        async def interrupt(self):
+            return None
+
+    class _HookMatcher:
+        def __init__(self, *a, **kw):
+            pass
+
+    mod = types.ModuleType("fake_sdk_task")
+    mod.AssistantMessage = _Assistant
+    mod.TextBlock = _Text
+    mod.UserMessage = _User
+    mod.ResultMessage = _Result
+    mod.TaskNotificationMessage = _TaskNotification
+    mod.ClaudeSDKClient = _Client
+    mod.HookMatcher = _HookMatcher
+    return mod
+
+
+def _read_session_jsonl(state_dir: Path) -> list[dict]:
+    import json
+
+    text = (state_dir / "session.jsonl").read_text(encoding="utf-8")
+    return [json.loads(line) for line in text.splitlines() if line.strip()]
+
+
+def _run_conversation_with_task(state_dir: Path) -> None:
+    sdk_mod = _make_sdk_module_with_task()
+
+    async def _run():
+        inbox = await _seed("go")
+        await runner._run_conversation(
+            "alpha",
+            state_dir,
+            pid=1,
+            inbox=inbox,
+            resume_session_id=None,
+            stop=asyncio.Event(),
+            sdk_module=sdk_mod,
+            build_sdk_options_fn=_capturing_build_options({}),
+        )
+
+    asyncio.run(_run())
+
+
+def test_run_conversation_captures_task_completion_to_jsonl(tmp_path: Path) -> None:
+    # Arrange
+    state_dir = tmp_path / "alpha"
+    # Act
+    _run_conversation_with_task(state_dir)
+    # Assert — the background-subagent completion reached the transcript end
+    # to end through the full run_conversation path.
+    notifications = [
+        r for r in _read_session_jsonl(state_dir) if r["type"] == "task_notification"
+    ]
+    assert notifications[0]["summary"] == "subagent done"
+
+
+def test_run_conversation_logs_warning_when_sdk_lacks_task_types(
+    tmp_path: Path, caplog
+) -> None:
+    # Arrange — the default one-turn SDK module exposes NO task classes, so
+    # background-subagent observation is unavailable and must be logged LOUD.
+    state_dir = tmp_path / "beta"
+    sdk_mod = _make_one_turn_sdk_module()
+
+    async def _run():
+        inbox = await _seed("go")
+        await runner._run_conversation(
+            "beta",
+            state_dir,
+            pid=1,
+            inbox=inbox,
+            resume_session_id=None,
+            stop=asyncio.Event(),
+            sdk_module=sdk_mod,
+            build_sdk_options_fn=_capturing_build_options({}),
+        )
+
+    # Act
+    with caplog.at_level(logging.WARNING):
+        asyncio.run(_run())
+    # Assert — the gap is observable, never a silent swallow.
+    assert "background-task observation UNAVAILABLE for beta" in caplog.text

--- a/tests/scitex_agent_container/_runners/test__session_tasks.py
+++ b/tests/scitex_agent_container/_runners/test__session_tasks.py
@@ -1,0 +1,241 @@
+"""Background-subagent task observation (autonomy C2): capture + expose.
+
+``_session_tasks`` resolves the SDK's task-lifecycle classes, captures
+each task message into ``session.jsonl``, and accumulates terminal
+completions on a conversation-lifetime :class:`TaskObservations` holder
+so a later turn can read which background subagents finished + what they
+produced.
+
+No mocks: every fake here is a real dataclass-shaped object or a real
+``types.ModuleType`` carrying real classes — the same hand-rolled-fake
+discipline the sibling conversation tests use. The capture path writes a
+real ``session.jsonl`` under ``tmp_path`` and reads it back.
+"""
+
+from __future__ import annotations
+
+import json
+import types
+from dataclasses import dataclass
+from pathlib import Path
+
+from scitex_agent_container._runners._session_state import append_session_message
+from scitex_agent_container._runners._session_tasks import (
+    TaskObservations,
+    handle_task_message,
+    is_task_message,
+    resolve_task_types,
+)
+
+# ---------------------------------------------------------------------------
+# Real dataclass-shaped fakes for the three SDK task-message classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeTaskStarted:
+    task_id: str
+    session_id: str
+    description: str
+    task_type: str = "local_agent"
+
+
+@dataclass
+class _FakeTaskProgress:
+    task_id: str
+    session_id: str
+    description: str
+
+
+@dataclass
+class _FakeTaskNotification:
+    task_id: str
+    session_id: str
+    status: str
+    summary: str
+    output_file: str
+
+
+def _fake_sdk_with_task_types() -> types.ModuleType:
+    """An SDK module that exposes all three task-message classes."""
+    mod = types.ModuleType("fake_sdk_tasks")
+    mod.TaskStartedMessage = _FakeTaskStarted
+    mod.TaskProgressMessage = _FakeTaskProgress
+    mod.TaskNotificationMessage = _FakeTaskNotification
+    return mod
+
+
+def _read_jsonl(state_dir: Path) -> list[dict]:
+    """Read every record from the state dir's ``session.jsonl``."""
+    text = (state_dir / "session.jsonl").read_text(encoding="utf-8")
+    return [json.loads(line) for line in text.splitlines() if line.strip()]
+
+
+# ---------------------------------------------------------------------------
+# resolve_task_types — maps the SDK classes to their event-type strings
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_task_types_maps_notification_to_event_type() -> None:
+    # Arrange
+    sdk = _fake_sdk_with_task_types()
+    # Act
+    resolved = resolve_task_types(sdk)
+    # Assert
+    assert resolved[_FakeTaskNotification] == "task_notification"
+
+
+def test_resolve_task_types_empty_when_sdk_lacks_classes() -> None:
+    # Arrange — an SDK predating background-subagent observation.
+    sdk = types.ModuleType("fake_sdk_no_tasks")
+    # Act
+    resolved = resolve_task_types(sdk)
+    # Assert
+    assert resolved == {}
+
+
+# ---------------------------------------------------------------------------
+# is_task_message — recognises resolved classes, no-ops on empty mapping
+# ---------------------------------------------------------------------------
+
+
+def test_is_task_message_true_for_resolved_notification() -> None:
+    # Arrange
+    sdk = _fake_sdk_with_task_types()
+    task_types = resolve_task_types(sdk)
+    msg = _FakeTaskNotification("t1", "s1", "completed", "did the thing", "/out")
+    # Act
+    matched = is_task_message(msg, task_types)
+    # Assert
+    assert matched is True
+
+
+def test_is_task_message_false_when_task_types_empty() -> None:
+    # Arrange — no resolved task classes → nothing should ever match.
+    msg = _FakeTaskNotification("t1", "s1", "completed", "x", "/out")
+    # Act
+    matched = is_task_message(msg, {})
+    # Assert
+    assert matched is False
+
+
+# ---------------------------------------------------------------------------
+# TaskObservations — files events into lifecycle buckets, drains completions
+# ---------------------------------------------------------------------------
+
+
+def test_observations_record_files_notification_into_completions() -> None:
+    # Arrange
+    obs = TaskObservations()
+    # Act
+    obs.record({"type": "task_notification", "task_id": "t1", "status": "completed"})
+    # Assert
+    assert obs.completions == [
+        {"type": "task_notification", "task_id": "t1", "status": "completed"}
+    ]
+
+
+def test_observations_record_files_started_into_started_bucket() -> None:
+    # Arrange
+    obs = TaskObservations()
+    # Act
+    obs.record({"type": "task_started", "task_id": "t1"})
+    # Assert
+    assert obs.started == [{"type": "task_started", "task_id": "t1"}]
+
+
+def test_observations_drain_completions_returns_accumulated() -> None:
+    # Arrange
+    obs = TaskObservations()
+    obs.record({"type": "task_notification", "task_id": "t1", "status": "completed"})
+    # Act
+    drained = obs.drain_completions()
+    # Assert
+    assert drained == [
+        {"type": "task_notification", "task_id": "t1", "status": "completed"}
+    ]
+
+
+def test_observations_drain_completions_clears_after_draining() -> None:
+    # Arrange
+    obs = TaskObservations()
+    obs.record({"type": "task_notification", "task_id": "t1", "status": "completed"})
+    obs.drain_completions()
+    # Act
+    second = obs.drain_completions()
+    # Assert — a consumed completion is not re-delivered on the next drain.
+    assert second == []
+
+
+# ---------------------------------------------------------------------------
+# handle_task_message — persists to session.jsonl AND accumulates on the holder
+# ---------------------------------------------------------------------------
+
+
+def test_handle_task_message_persists_notification_to_jsonl(tmp_path: Path) -> None:
+    # Arrange
+    state_dir = tmp_path / "agent"
+    obs = TaskObservations()
+    msg = _FakeTaskNotification("t1", "s1", "completed", "shipped the fix", "/tmp/out")
+    # Act
+    handle_task_message(
+        msg,
+        "task_notification",
+        observations=obs,
+        append_fn=append_session_message,
+        state_dir=state_dir,
+    )
+    # Assert — the structured record reached session.jsonl with the summary.
+    records = _read_jsonl(state_dir)
+    assert records[0]["summary"] == "shipped the fix"
+
+
+def test_handle_task_message_records_status_field_in_jsonl(tmp_path: Path) -> None:
+    # Arrange
+    state_dir = tmp_path / "agent"
+    obs = TaskObservations()
+    msg = _FakeTaskNotification("t1", "s1", "failed", "broke", "/tmp/out")
+    # Act
+    handle_task_message(
+        msg,
+        "task_notification",
+        observations=obs,
+        append_fn=append_session_message,
+        state_dir=state_dir,
+    )
+    # Assert
+    assert _read_jsonl(state_dir)[0]["status"] == "failed"
+
+
+def test_handle_task_message_accumulates_completion_on_holder(tmp_path: Path) -> None:
+    # Arrange
+    state_dir = tmp_path / "agent"
+    obs = TaskObservations()
+    msg = _FakeTaskNotification("t9", "s1", "completed", "done", "/tmp/out")
+    # Act
+    handle_task_message(
+        msg,
+        "task_notification",
+        observations=obs,
+        append_fn=append_session_message,
+        state_dir=state_dir,
+    )
+    # Assert — a later turn can read the completion off the holder.
+    assert obs.completions[0]["task_id"] == "t9"
+
+
+def test_handle_task_message_progress_has_no_status_field(tmp_path: Path) -> None:
+    # Arrange — TaskProgressMessage carries no status; the record omits it.
+    state_dir = tmp_path / "agent"
+    obs = TaskObservations()
+    msg = _FakeTaskProgress("t1", "s1", "halfway")
+    # Act
+    handle_task_message(
+        msg,
+        "task_progress",
+        observations=obs,
+        append_fn=append_session_message,
+        state_dir=state_dir,
+    )
+    # Assert
+    assert "status" not in _read_jsonl(state_dir)[0]

--- a/tests/scitex_agent_container/_runners/test__session_turn.py
+++ b/tests/scitex_agent_container/_runners/test__session_turn.py
@@ -1,0 +1,242 @@
+"""Per-turn driver C2 behaviour: observe background-subagent tasks.
+
+``_drive_turn`` drains one turn's SDK response stream. With autonomy C2
+it must capture interleaved task-lifecycle messages into ``session.jsonl``
+AND onto the injected :class:`TaskObservations` holder, WITHOUT breaking
+the turn — only the terminal ``ResultMessage`` ends it.
+
+No mocks: a real ``types.ModuleType`` carries real fake message classes,
+a real ``asyncio.Future`` backs the envelope, and a real ``session.jsonl``
+under ``tmp_path`` is read back.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import types
+from dataclasses import dataclass
+from pathlib import Path
+
+from scitex_agent_container._runners._session_tasks import (
+    TaskObservations,
+    resolve_task_types,
+)
+from scitex_agent_container._runners._session_turn import _drive_turn
+
+# ---------------------------------------------------------------------------
+# Real fake SDK message classes + a client that yields a scripted stream
+# ---------------------------------------------------------------------------
+
+
+class _Text:
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+
+class _Assistant:
+    def __init__(self, content) -> None:
+        self.content = content
+
+
+class _User:
+    pass
+
+
+class _Result:
+    def __init__(self, sid: str, usage) -> None:
+        self.session_id = sid
+        self.usage = usage
+
+
+@dataclass
+class _TaskNotification:
+    task_id: str
+    session_id: str
+    status: str
+    summary: str
+    output_file: str
+
+
+@dataclass
+class _Envelope:
+    text: str
+    response: asyncio.Future
+    from_agent: str | None = None
+    dispatch_id: str | None = None
+    session_id: str | None = None
+
+
+def _sdk_types() -> dict:
+    return {
+        "AssistantMessage": _Assistant,
+        "TextBlock": _Text,
+        "UserMessage": _User,
+        "ResultMessage": _Result,
+    }
+
+
+def _task_type_map() -> dict:
+    """resolve_task_types over a module exposing only TaskNotificationMessage."""
+    mod = types.ModuleType("fake_sdk_turn")
+    mod.TaskNotificationMessage = _TaskNotification
+    return resolve_task_types(mod)
+
+
+class _ScriptedClient:
+    """Yields a fixed message sequence from ``receive_response``."""
+
+    def __init__(self, messages: list) -> None:
+        self._messages = messages
+
+    async def query(self, prompt: str) -> None:
+        self._prompt = prompt
+
+    async def receive_response(self):
+        for m in self._messages:
+            yield m
+
+    async def interrupt(self) -> None:
+        return None
+
+
+def _run_turn(state_dir: Path, messages: list, obs: TaskObservations) -> None:
+    """Drive one turn against a scripted client; no host/db/push wiring."""
+
+    async def _go() -> None:
+        loop = asyncio.get_running_loop()
+        env = _Envelope(text="go", response=loop.create_future())
+        await _drive_turn(
+            _ScriptedClient(messages),
+            env,
+            state_dir=state_dir,
+            pid=1,
+            stop=asyncio.Event(),
+            print_stream=False,
+            sdk_types=_sdk_types(),
+            task_observations=obs,
+            task_types=_task_type_map(),
+        )
+
+    asyncio.run(_go())
+
+
+def _read_jsonl(state_dir: Path) -> list[dict]:
+    text = (state_dir / "session.jsonl").read_text(encoding="utf-8")
+    return [json.loads(line) for line in text.splitlines() if line.strip()]
+
+
+# ---------------------------------------------------------------------------
+# A turn carrying an interleaved TaskNotification
+# ---------------------------------------------------------------------------
+
+
+def _messages_with_task() -> list:
+    """Assistant text, then a background-subagent completion, then result."""
+    return [
+        _Assistant([_Text("starting")]),
+        _TaskNotification("bg-1", "s1", "completed", "subagent finished", "/out"),
+        _Assistant([_Text("after task")]),
+        _Result("s1", {}),
+    ]
+
+
+def test_drive_turn_captures_task_notification_into_jsonl(tmp_path: Path) -> None:
+    # Arrange
+    state_dir = tmp_path / "agent"
+    obs = TaskObservations()
+    # Act
+    _run_turn(state_dir, _messages_with_task(), obs)
+    # Assert — the background-subagent completion reached the transcript.
+    notifications = [
+        r for r in _read_jsonl(state_dir) if r["type"] == "task_notification"
+    ]
+    assert notifications[0]["summary"] == "subagent finished"
+
+
+def test_drive_turn_accumulates_completion_on_observations(tmp_path: Path) -> None:
+    # Arrange
+    state_dir = tmp_path / "agent"
+    obs = TaskObservations()
+    # Act
+    _run_turn(state_dir, _messages_with_task(), obs)
+    # Assert — a later turn / the autonomous loop can read the completion.
+    assert obs.completions[0]["task_id"] == "bg-1"
+
+
+def test_drive_turn_does_not_break_on_task_message(tmp_path: Path) -> None:
+    # Arrange — assistant text AFTER the task message must still be processed,
+    # proving the task branch did not terminate the turn early.
+    state_dir = tmp_path / "agent"
+    obs = TaskObservations()
+    # Act
+    _run_turn(state_dir, _messages_with_task(), obs)
+    # Assert
+    assistant_texts = [
+        r["text"] for r in _read_jsonl(state_dir) if r["type"] == "assistant"
+    ]
+    assert "after task" in assistant_texts
+
+
+def test_drive_turn_resolves_future_with_full_assistant_text(tmp_path: Path) -> None:
+    # Arrange — the awaiting /v1/turn future gets the concatenated reply,
+    # spanning both assistant chunks across the interleaved task message.
+    state_dir = tmp_path / "agent"
+    obs = TaskObservations()
+    captured: dict = {}
+
+    async def _go() -> None:
+        loop = asyncio.get_running_loop()
+        env = _Envelope(text="go", response=loop.create_future())
+        await _drive_turn(
+            _ScriptedClient(_messages_with_task()),
+            env,
+            state_dir=state_dir,
+            pid=1,
+            stop=asyncio.Event(),
+            print_stream=False,
+            sdk_types=_sdk_types(),
+            task_observations=obs,
+            task_types=_task_type_map(),
+        )
+        captured["reply"] = env.response.result()
+
+    # Act
+    asyncio.run(_go())
+    # Assert
+    assert captured["reply"] == "startingafter task"
+
+
+def test_drive_turn_without_task_types_ignores_task_shaped_message(
+    tmp_path: Path,
+) -> None:
+    # Arrange — an SDK with no task classes resolved: a task-shaped object
+    # falls through unrecognised (here it has no .content, so it is simply
+    # not an assistant/user/result and is skipped) and nothing is captured.
+    state_dir = tmp_path / "agent"
+    obs = TaskObservations()
+
+    async def _go() -> None:
+        loop = asyncio.get_running_loop()
+        env = _Envelope(text="go", response=loop.create_future())
+        await _drive_turn(
+            _ScriptedClient(
+                [
+                    _TaskNotification("bg-1", "s1", "completed", "x", "/out"),
+                    _Result("s1", {}),
+                ]
+            ),
+            env,
+            state_dir=state_dir,
+            pid=1,
+            stop=asyncio.Event(),
+            print_stream=False,
+            sdk_types=_sdk_types(),
+            task_observations=obs,
+            task_types={},  # SDK too old → no task classes
+        )
+
+    # Act
+    asyncio.run(_go())
+    # Assert — graceful no-op: nothing accumulated when observation is off.
+    assert obs.completions == []


### PR DESCRIPTION
## Autonomy roadmap C2 — make a SAC agent able to react to its background subagents finishing

The claude-session per-turn driver handled only `AssistantMessage` /
`UserMessage` / `ResultMessage` and discarded the SDK's background-subagent
lifecycle messages (`TaskStartedMessage` / `TaskProgressMessage` /
`TaskNotificationMessage`, `task_type="local_agent"`). A background
subagent's result therefore reached **nobody** — the whole point of a
background subagent (fan out work, react later) was unusable.

This PR is **C2 only** (capture + expose). NOT C1/C3/C4.

### What changed

- **New `_session_tasks.py`** — `resolve_task_types()` maps the SDK's task
  classes to `session.jsonl` event types (empty mapping when the installed
  SDK predates them → logged LOUD at WARNING once at startup, never a
  silent swallow). `handle_task_message()` persists each task message into
  `session.jsonl` AND files it on a conversation-lifetime
  `TaskObservations` holder. Completions survive **across turns** (NOT the
  per-turn `TurnContext`, which resets each turn) so the next turn / the
  autonomous loop (C3, separate item) can read which background subagents
  completed and what they produced. `drain_completions()` consumes-once.

- **`_drive_turn`** handles task messages in its receive loop **without
  breaking the turn** — only `ResultMessage` ends it.
  **`run_conversation`** builds one `TaskObservations`, resolves task types
  once, logs availability, and threads both through.

- **Line-cap-driven extraction**: `_session_conversation.py` was already
  583 lines (> the 512 cap). Extracted the per-turn driver (`_drive_turn`
  + `_safe_repr` + `_build_completion_push_fn`) into a new `_session_turn.py`
  and re-export them from `_session_conversation.py` so existing imports
  (`claude_session.py`, tests) keep resolving. Pure extraction — no
  behaviour change to the supervisor loop.

### Graceful degradation

If the installed `claude-agent-sdk` lacks the task message classes,
`resolve_task_types()` returns `{}`, `is_task_message()` never matches, the
receive loop is unchanged, and `log_observability_status()` emits a single
WARNING naming the gap. Never silently swallowed.

### Tests (NO MOCKS)

Hand-rolled fake SDK modules / real dataclass-shaped task objects via the
existing `run_conversation(sdk_module=...)` / `_drive_turn(...)` injection
seams:
- `test__session_tasks.py` — resolver, holder buckets, drain-once, capture.
- `test__session_turn.py` — full turn: capture into `session.jsonl` + onto
  the holder, turn does NOT break on a task message, future resolves with
  the full reply spanning the interleaved task message, SDK-too-old no-op.
- `test__session_conversation.py` — end-to-end `run_conversation` capture +
  the unavailable-SDK WARNING.

All STX-NM + STX-TQ (AAA markers, ≥3-word names, one assert each).

### Verification

- Full suite: **4850 passed, 35 skipped, 0 failed**.
- `scitex-dev linter` on changed files: source clean; tests only carry
  pre-existing-style warnings (STX-NL001 port literal in the existing
  channels test, STX-IO006 `json.loads` reader — same pattern as sibling
  `test__session_completion.py`). No STX-NM / STX-TQ violations.
- `scitex-dev ecosystem audit-python-apis` (PA-306 no-mocks): clean.
- `scitex-dev ecosystem audit-project` (PS-204 mirror discipline): clean.
- All three touched source files under the 512-line cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)