### PR TITLE
fix(send): route LOCAL agent sends through loopback /v1/turn

### DIFF
--- a/src/scitex_agent_container/cli_pkg/send_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/send_cmds.py
@@ -95,6 +95,60 @@ def _try_dispatch_remote_send(name: str, prompt: str) -> bool:
     return True
 
 
+def _try_dispatch_local_send(name: str, prompt: str) -> bool:
+    """POST a turn to a LOCAL agent via its loopback /v1/turn endpoint.
+
+    Symmetric to :func:`_try_dispatch_remote_send`: when ``name`` has an
+    active ``state.db.instances`` row on the *current* host with a bound
+    ``a2a_port``, build ``http://127.0.0.1:<port>/v1/turn`` and POST one
+    turn so the running SDK runner re-uses its in-process Claude session.
+
+    This is the fix for the local mis-target diagnosed 2026-05-22: an
+    apptainer agent's SDK session lives inside the container's
+    ``~/.claude/projects/`` store, NOT on the host, so a host-side
+    ``claude --resume <sid>`` cannot see it and exits 1 with "No
+    conversation found". The HTTP path reaches the live in-container
+    session instead.
+
+    Returns:
+        * ``True`` when the dispatch happened (reply printed to stdout).
+        * ``False`` when there is no active local row, or the row exists
+          but records no ``a2a_port`` (a non-A2A runtime) — the caller
+          then falls through to the ``claude --resume`` host shellout,
+          which only makes sense for a non-containerized host-side agent.
+
+    Raises:
+        click.ClickException: When the underlying HTTP call fails. We
+            wrap the PeerError so the user sees the same error shape they
+            get from ``sac peer post-turn``.
+    """
+    from .._network.peer import PeerError, post_turn_to_url
+    from .._state.state_db import _resolve_host, list_active_instances
+
+    current_host = _resolve_host(None)
+    rows = list_active_instances()
+    matching = [
+        r
+        for r in rows
+        if r.get("name") == name and str(r.get("host") or "") == current_host
+    ]
+    if not matching:
+        return False
+    a2a_port = matching[0].get("a2a_port")
+    if not isinstance(a2a_port, int) or a2a_port <= 0:
+        # No bound A2A port: this is a non-A2A runtime. Let the caller
+        # fall through to the host-side claude --resume path.
+        return False
+    url = f"http://127.0.0.1:{a2a_port}/v1/turn"
+    click.echo(f"# send {name}: POST {url}", err=True)
+    try:
+        reply = post_turn_to_url(url, prompt)
+    except PeerError as exc:
+        raise click.ClickException(f"local send failed: {exc}") from exc
+    click.echo(reply)
+    return True
+
+
 def _find_claude_binary() -> str:
     """Locate the ``claude`` CLI binary, preferring the SDK's bundled
     copy under ``/opt/venv-sac/...`` (when running inside the sac
@@ -198,6 +252,17 @@ def send(
     # the running runner re-uses its in-process Claude session, not via
     # a separate `claude --resume` shellout that would race the runner.
     if _try_dispatch_remote_send(name, prompt):
+        return
+
+    # Local A2A: when the agent is running on THIS host with a bound
+    # a2a_port, POST one turn to its loopback /v1/turn so the live
+    # in-container SDK session handles it. A host-side `claude --resume`
+    # cannot see a containerized agent's session (it lives inside the
+    # container's ~/.claude/projects/ store), so the HTTP path is the
+    # only correct local delivery for an apptainer runtime. Falls
+    # through to claude --resume only when no a2a_port is recorded
+    # (non-A2A, host-side runtime).
+    if _try_dispatch_local_send(name, prompt):
         return
 
     spec_path = resolve_config(name)

--- a/tests/scitex_agent_container/cli_pkg/test_send_cmds.py
+++ b/tests/scitex_agent_container/cli_pkg/test_send_cmds.py
@@ -575,3 +575,125 @@ def test_remote_send_prints_reply_from_peer(remote_send_env):
         _peer_mod.post_turn_to_url = saved  # type: ignore[assignment]
     # Assert
     assert "REMOTE-REPLY" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Local send: active state.db row on THIS host with a bound a2a_port →
+# http://127.0.0.1:port/v1/turn POST (NOT host-side claude --resume).
+# The fix for the 2026-05-22 apptainer mis-target diagnosis.
+# ---------------------------------------------------------------------------
+
+
+# Loopback A2A port for the local-send fixtures. A port reads as a
+# whole identifier, so it stays bare (NL001 carve-out); the suppression
+# keeps the file lint-clean since the rule still flags 4+ digit ints.
+_LOCAL_PORT = 19005  # stx-allow: STX-NL001
+
+
+@contextmanager
+def _swap_peer_post_turn_to_url(fn: Callable) -> Iterator[None]:
+    import scitex_agent_container._network.peer as _peer_mod
+
+    saved = _peer_mod.post_turn_to_url
+    _peer_mod.post_turn_to_url = fn  # type: ignore[assignment]
+    try:
+        yield
+    finally:
+        _peer_mod.post_turn_to_url = saved  # type: ignore[assignment]
+
+
+def test_local_send_with_a2a_port_dispatches_to_loopback_v1turn(remote_send_env):
+    # Arrange — seed a LOCAL row (host == current SAC_HOST) with a port.
+    from scitex_agent_container._state.state_db import record_instance_start
+
+    record_instance_start(name="local-a", host="lead-host", a2a_port=_LOCAL_PORT)
+    captured: dict = {}
+
+    def fake_post(url, text, *, exit_after=False, timeout_s=600.0):
+        captured["url"] = url
+        return "LOCAL-REPLY"
+
+    # Act
+    with _swap_peer_post_turn_to_url(fake_post):
+        CliRunner().invoke(send, ["local-a", "hi"])
+    # Assert
+    assert captured.get("url") == "http://127.0.0.1:19005/v1/turn"
+
+
+def test_local_send_forwards_the_prompt_text(remote_send_env):
+    # Arrange
+    from scitex_agent_container._state.state_db import record_instance_start
+
+    record_instance_start(name="local-a", host="lead-host", a2a_port=_LOCAL_PORT)
+    captured: dict = {}
+
+    def fake_post(url, text, *, exit_after=False, timeout_s=600.0):
+        captured["text"] = text
+        return "LOCAL-REPLY"
+
+    # Act
+    with _swap_peer_post_turn_to_url(fake_post):
+        CliRunner().invoke(send, ["local-a", "do the thing"])
+    # Assert
+    assert captured.get("text") == "do the thing"
+
+
+def test_local_send_prints_reply_from_loopback(remote_send_env):
+    # Arrange
+    from scitex_agent_container._state.state_db import record_instance_start
+
+    record_instance_start(name="local-a", host="lead-host", a2a_port=_LOCAL_PORT)
+    # Act
+    with _swap_peer_post_turn_to_url(lambda *a, **kw: "LOCAL-REPLY"):
+        result = CliRunner().invoke(send, ["local-a", "hi"])
+    # Assert
+    assert "LOCAL-REPLY" in result.output
+
+
+def test_local_send_exits_zero_on_loopback_reply(remote_send_env):
+    # Arrange
+    from scitex_agent_container._state.state_db import record_instance_start
+
+    record_instance_start(name="local-a", host="lead-host", a2a_port=_LOCAL_PORT)
+    # Act
+    with _swap_peer_post_turn_to_url(lambda *a, **kw: "LOCAL-REPLY"):
+        result = CliRunner().invoke(send, ["local-a", "hi"])
+    # Assert
+    assert result.exit_code == 0
+
+
+def test_local_send_without_a2a_port_falls_through_to_resume(remote_send_env):
+    # Arrange — a LOCAL row WITHOUT a bound port must NOT take the HTTP
+    # path; it falls through to the host-side claude --resume shellout.
+    from scitex_agent_container._state.state_db import record_instance_start
+
+    record_instance_start(name="local-b", host="lead-host", a2a_port=None)
+    posted: dict = {}
+
+    def fake_post(url, text, *, exit_after=False, timeout_s=600.0):
+        posted["url"] = url
+        return "SHOULD-NOT-HAPPEN"
+
+    # Act — no session_id seeded, so resume errors; we only assert the
+    # HTTP path was NOT taken (no post_turn_to_url call captured).
+    with _swap_peer_post_turn_to_url(fake_post):
+        CliRunner().invoke(send, ["local-b", "hi"])
+    # Assert
+    assert "url" not in posted
+
+
+def test_local_send_failure_wraps_peer_error(remote_send_env):
+    # Arrange
+    from scitex_agent_container._network.peer import PeerError
+    from scitex_agent_container._state.state_db import record_instance_start
+
+    record_instance_start(name="local-a", host="lead-host", a2a_port=_LOCAL_PORT)
+
+    def fake_post(url, text, *, exit_after=False, timeout_s=600.0):
+        raise PeerError("connection refused")
+
+    # Act
+    with _swap_peer_post_turn_to_url(fake_post):
+        result = CliRunner().invoke(send, ["local-a", "hi"])
+    # Assert
+    assert "local send failed" in result.output

--- a/tests/scitex_agent_container/cli_pkg/test_send_cmds.py
+++ b/tests/scitex_agent_container/cli_pkg/test_send_cmds.py
@@ -76,6 +76,37 @@ spec:
     return yaml_root
 
 
+@contextmanager
+def _empty_state_db(tmp_path: Path) -> Iterator[None]:
+    """Point ``state.db`` at a fresh empty file for the duration.
+
+    The local-send branch in ``send`` consults
+    ``state_db.list_active_instances()`` to decide whether an agent is
+    running locally with a bound a2a_port. Without isolation a row left
+    by an earlier test in the shared default db (CI runs the whole
+    suite) makes ``alpha`` look "running" and the send POSTs to a dead
+    loopback port instead of falling through to ``claude --resume``.
+    Redirecting to an empty db (and reloading the import-time
+    ``DEFAULT_DB_PATH``) keeps these resume-path tests deterministic.
+    """
+    import importlib
+
+    import scitex_agent_container._state.state_db as _state_db_mod
+
+    key = "SCITEX_AGENT_CONTAINER_STATE_DB"
+    saved = os.environ.get(key)
+    os.environ[key] = str(tmp_path / "isolated-state.db")
+    importlib.reload(_state_db_mod)
+    try:
+        yield
+    finally:
+        if saved is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = saved
+        importlib.reload(_state_db_mod)
+
+
 @pytest.fixture
 def isolated_env(tmp_path):
     """PA-306: env + send_mod.state_dir_for save/restore in one fixture.
@@ -83,7 +114,9 @@ def isolated_env(tmp_path):
     Also pins ``resolve_config`` to the seeded yaml root so a pre-existing
     ``~/.scitex/agent-container/agents/<name>/spec.yaml`` on the dev box
     cannot shadow the per-test fixture (resolver search order puts the
-    home install root before ``$SCITEX_AGENT_CONTAINER_YAML_DIRS``).
+    home install root before ``$SCITEX_AGENT_CONTAINER_YAML_DIRS``), and
+    isolates ``state.db`` so the local-send branch sees no stray active
+    row for the seeded agent.
     """
     yaml_root = _seed_agent(tmp_path, "alpha", "abc-123-def")
     key = "SCITEX_AGENT_CONTAINER_YAML_DIRS"
@@ -97,15 +130,16 @@ def isolated_env(tmp_path):
     send_mod.resolve_config = (  # type: ignore[assignment]
         lambda name: str(yaml_root / name / "spec.yaml")
     )
-    try:
-        yield tmp_path
-    finally:
-        send_mod.resolve_config = saved_resolve  # type: ignore[assignment]
-        send_mod.state_dir_for = saved_state  # type: ignore[assignment]
-        if saved_env is None:
-            os.environ.pop(key, None)
-        else:
-            os.environ[key] = saved_env
+    with _empty_state_db(tmp_path):
+        try:
+            yield tmp_path
+        finally:
+            send_mod.resolve_config = saved_resolve  # type: ignore[assignment]
+            send_mod.state_dir_for = saved_state  # type: ignore[assignment]
+            if saved_env is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = saved_env
 
 
 # ---------------------------------------------------------------------------
@@ -256,15 +290,16 @@ def isolated_env_without_session_id(tmp_path):
         lambda name: str(yaml_root / name / "spec.yaml")
     )
     (tmp_path / "state" / "alpha" / "session_id").unlink()
-    try:
-        yield tmp_path
-    finally:
-        send_mod.resolve_config = saved_resolve  # type: ignore[assignment]
-        send_mod.state_dir_for = saved_state  # type: ignore[assignment]
-        if saved_env is None:
-            os.environ.pop(key, None)
-        else:
-            os.environ[key] = saved_env
+    with _empty_state_db(tmp_path):
+        try:
+            yield tmp_path
+        finally:
+            send_mod.resolve_config = saved_resolve  # type: ignore[assignment]
+            send_mod.state_dir_for = saved_state  # type: ignore[assignment]
+            if saved_env is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = saved_env
 
 
 def _invoke_send_without_session_id():


### PR DESCRIPTION
## Problem

`sac agents send <name>` for a LOCAL apptainer agent mis-targeted a host-side `claude --resume <sid>`. The in-container SDK session lives in the container's `~/.claude/projects/` store, not on the host, so resume exits 1 with `No conversation found with session ID …`. (Diagnosed 2026-05-22, `GITIGNORED/DIAGNOSIS/lead-inbound-and-bash-wedge-2026-05-22.md` §2c.)

The cross-host branch (`_try_dispatch_remote_send`) already POSTs to `ssh://<peer>:<port>/v1/turn` correctly; only the local path was broken.

## Fix

Add `_try_dispatch_local_send`, symmetric to the remote helper: when the agent has an active `state.db.instances` row on the current host with a bound `a2a_port`, POST one turn to `http://127.0.0.1:<port>/v1/turn` so the running runner re-uses its live SDK session. Falls through to `claude --resume` only when no `a2a_port` is recorded (non-A2A host-side runtime).

## Verification

- Live-verified against the running `proj-scitex-agent-container` (a2a_port 19005): the helper resolved the loopback URL and returned a context-aware reply from the persistent session.
- 6 new TQ-compliant tests (no mocks — real `state.db` rows + `post_turn_to_url` namespace swap), exercising URL resolution, prompt forwarding, reply echo, exit code, no-port fall-through, and `PeerError` wrapping. Full `test_send_cmds.py` (38 tests) green.
- CI ruff selector (F401,F811) clean on changed files.

## Test plan

- [x] `pytest tests/scitex_agent_container/cli_pkg/test_send_cmds.py` — green
- [x] live `sac agents send` against proj-scitex-agent-container returns a real reply