### PR TITLE
feat(session): enable supervisor resume-recovery by default

### DIFF
--- a/src/scitex_agent_container/runtimes/_apptainer_inner_argv.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_inner_argv.py
@@ -21,6 +21,23 @@ RUNNER_MODULE_PROXY = "scitex_agent_container._runners.a2a_proxy"
 
 _TINI_PREFIX = ["/usr/bin/tini", "-s", "--", "python3", "-m"]
 
+# Unconditional supervisor-restart floor for ``kind: Agent`` runners.
+# The session runner auto-resumes the persisted session_id; when that
+# conversation no longer exists in the container's ~/.claude/projects/
+# store (overlay redeployed on restart, or aged out after long idle),
+# ``claude --resume <dead-id>`` exits 1 and EVERY turn crashes — a
+# false-healthy "zombie" (heartbeat + /health keep answering). The
+# runner's history-walk recovery (_resume_candidate steps to older ids,
+# then falls back to a fresh session) plus the supervisor loop only run
+# when ``--max-restarts > 0``; the CLI default is 0, so the recovery is
+# dead code for the common ``restart.policy: never`` agent. We pass a
+# floor of restarts so the recovery path is always live — re-resuming a
+# provably-dead id can never succeed, and the history-walk is the only
+# escape. An explicit on-failure/always policy with a higher
+# ``max_retries`` raises the cap above this floor. Auth failures stay
+# terminal regardless (the supervisor short-circuits them).
+_SUPERVISOR_RESTART_FLOOR = 3
+
 
 def _format_shell_steps(cmds: list) -> list[str]:
     # list[StartupCommand] -> shell statement list. `set -e` so any
@@ -70,6 +87,41 @@ def build_inner_argv(config: "AgentConfig", *, one_shot: bool = False) -> list[s
     return ["/bin/bash", "-lc", inline]
 
 
+def _resolve_max_restarts(config: "AgentConfig") -> int:
+    """Supervisor restart cap for the session runner.
+
+    Always at least :data:`_SUPERVISOR_RESTART_FLOOR` so the runner's
+    resume-recovery (history-walk + fresh-session fallback) is live even
+    for ``restart.policy: never`` agents. An explicit ``on-failure`` /
+    ``always`` policy whose ``max_retries`` exceeds the floor raises the
+    cap; ``never`` never lowers it below the floor (the floor is about
+    *resume recovery*, not the operator's crash-restart policy — a dead
+    session id can only be escaped by re-opening the client).
+    """
+    restart = getattr(config, "restart", None)
+    policy = str(getattr(restart, "policy", "never") or "never")
+    if policy in ("on-failure", "always"):
+        max_retries = int(getattr(restart, "max_retries", 0) or 0)
+        return max(max_retries, _SUPERVISOR_RESTART_FLOOR)
+    return _SUPERVISOR_RESTART_FLOOR
+
+
+def _resolve_restart_backoff_s(config: "AgentConfig") -> float:
+    """Initial supervisor backoff seconds (doubles each retry).
+
+    Uses ``restart.backoff_initial`` when an explicit on-failure/always
+    policy sets one; otherwise the runner CLI default (1.0s) keeps the
+    floor-driven resume recovery fast.
+    """
+    restart = getattr(config, "restart", None)
+    policy = str(getattr(restart, "policy", "never") or "never")
+    if policy in ("on-failure", "always"):
+        backoff = getattr(restart, "backoff_initial", None)
+        if isinstance(backoff, (int, float)) and backoff > 0:
+            return float(backoff)
+    return 1.0
+
+
 def _agent_runner_argv(config: "AgentConfig", *, one_shot: bool) -> list[str]:
     """Argv tail for ``kind: Agent`` (claude_session)."""
     runner_argv: list[str] = [
@@ -77,6 +129,14 @@ def _agent_runner_argv(config: "AgentConfig", *, one_shot: bool) -> list[str]:
         config.name,
         "--state-root",
         "/state",
+        # Keep the supervisor / resume-recovery path live (see
+        # _SUPERVISOR_RESTART_FLOOR). The runner CLI defaults to 0
+        # (no restart), which silently disables recovery for every
+        # restart.policy: never agent.
+        "--max-restarts",
+        str(_resolve_max_restarts(config)),
+        "--restart-backoff-s",
+        str(_resolve_restart_backoff_s(config)),
     ]
     # startup_prompts -> claude SDK mission via --mission. NO fallback
     # from startup_commands; that field is shell-exec only (see

--- a/tests/scitex_agent_container/runtimes/test__apptainer_inner_argv.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_inner_argv.py
@@ -8,10 +8,18 @@ the legacy --mission fallback. See commit message
 from __future__ import annotations
 
 from scitex_agent_container.config import AgentConfig
-from scitex_agent_container.config._types import A2ASpec, ClaudeSpec, StartupCommand
+from scitex_agent_container.config._types import (
+    A2ASpec,
+    ClaudeSpec,
+    RestartSpec,
+    StartupCommand,
+)
 from scitex_agent_container.runtimes._apptainer_inner_argv import (
+    _SUPERVISOR_RESTART_FLOOR,
     _agent_runner_argv,
     _format_shell_steps,
+    _resolve_max_restarts,
+    _resolve_restart_backoff_s,
     build_inner_argv,
 )
 
@@ -229,3 +237,100 @@ def test_agent_runner_argv_skips_blank_channel_entries():
     argv = _agent_runner_argv(cfg, one_shot=False)
     # Assert
     assert "--channels" not in argv
+
+
+# ---------------------------------------------------------------------------
+# _agent_runner_argv: supervisor restart cap (resume-recovery enablement).
+# The runner CLI defaults --max-restarts to 0, which disables the
+# history-walk resume recovery for every restart.policy: never agent.
+# The adapter must pass a >0 floor so the recovery path is always live.
+# ---------------------------------------------------------------------------
+
+
+def test_agent_runner_argv_emits_max_restarts_flag():
+    # Arrange
+    cfg = _mk_cfg()
+    # Act
+    argv = _agent_runner_argv(cfg, one_shot=False)
+    # Assert
+    assert "--max-restarts" in argv
+
+
+def test_agent_runner_argv_default_max_restarts_is_above_zero():
+    # Arrange
+    cfg = _mk_cfg()
+    # Act
+    argv = _agent_runner_argv(cfg, one_shot=False)
+    # Assert
+    assert int(argv[argv.index("--max-restarts") + 1]) > 0
+
+
+def test_agent_runner_argv_emits_restart_backoff_flag():
+    # Arrange
+    cfg = _mk_cfg()
+    # Act
+    argv = _agent_runner_argv(cfg, one_shot=False)
+    # Assert
+    assert "--restart-backoff-s" in argv
+
+
+def test_resolve_max_restarts_never_policy_uses_floor():
+    # Arrange — restart.policy: never (the live-agent case) must still
+    # get the floor so resume recovery is live.
+    cfg = _mk_cfg(restart=RestartSpec(policy="never"))
+    # Act
+    resolved = _resolve_max_restarts(cfg)
+    # Assert
+    assert resolved == _SUPERVISOR_RESTART_FLOOR
+
+
+def test_resolve_max_restarts_on_failure_above_floor_raises_cap():
+    # Arrange — an explicit on-failure policy with a higher retry count
+    # raises the cap above the floor.
+    cfg = _mk_cfg(
+        restart=RestartSpec(
+            policy="on-failure", max_retries=_SUPERVISOR_RESTART_FLOOR + 5
+        )
+    )
+    # Act
+    resolved = _resolve_max_restarts(cfg)
+    # Assert
+    assert resolved == _SUPERVISOR_RESTART_FLOOR + 5
+
+
+def test_resolve_max_restarts_on_failure_below_floor_keeps_floor():
+    # Arrange — a small max_retries must not lower the resume-recovery floor.
+    cfg = _mk_cfg(restart=RestartSpec(policy="on-failure", max_retries=1))
+    # Act
+    resolved = _resolve_max_restarts(cfg)
+    # Assert
+    assert resolved == _SUPERVISOR_RESTART_FLOOR
+
+
+def test_resolve_max_restarts_always_policy_uses_max_retries():
+    # Arrange
+    cfg = _mk_cfg(
+        restart=RestartSpec(policy="always", max_retries=_SUPERVISOR_RESTART_FLOOR + 2)
+    )
+    # Act
+    resolved = _resolve_max_restarts(cfg)
+    # Assert
+    assert resolved == _SUPERVISOR_RESTART_FLOOR + 2
+
+
+def test_resolve_restart_backoff_never_policy_uses_runner_default():
+    # Arrange
+    cfg = _mk_cfg(restart=RestartSpec(policy="never", backoff_initial=99))
+    # Act
+    resolved = _resolve_restart_backoff_s(cfg)
+    # Assert
+    assert resolved == 1.0
+
+
+def test_resolve_restart_backoff_on_failure_uses_spec_backoff():
+    # Arrange
+    cfg = _mk_cfg(restart=RestartSpec(policy="on-failure", backoff_initial=7))
+    # Act
+    resolved = _resolve_restart_backoff_s(cfg)
+    # Assert
+    assert resolved == 7.0


### PR DESCRIPTION
## Problem

The session runner auto-resumes the persisted `session_id`. When that conversation no longer exists in the container's `~/.claude/projects/` store (overlay redeployed on restart, or aged out after long idle), `claude --resume <dead-id>` exits 1 and **every** turn crashes — a false-healthy "zombie" (heartbeat + `/health` keep answering). Diagnosed 2026-05-22, §3 Class A.

The runner already ships the escape — `_resume_candidate` walks back through older session ids then falls back to a fresh session, under a supervisor loop. But **both are gated on `--max-restarts > 0`**, and the apptainer adapter never passed the flag. The runner CLI default is `0`, so the recovery is dead code for every `restart.policy: never` agent (the common case, including the live agent).

## Fix

Thread `--max-restarts` (and `--restart-backoff-s`) into `_agent_runner_argv`, derived from `spec.restart` with an **unconditional floor of 3**. The floor is about *resume recovery*, not the operator's crash-restart policy: re-resuming a provably-dead id can never succeed, so the history-walk must always be reachable. An explicit `on-failure`/`always` policy whose `max_retries` exceeds the floor raises the cap. Auth failures stay terminal (the supervisor short-circuits them, line 364 of `_session_conversation.py`).

## Verification

- Live-checked against the running `proj-scitex-agent-container` spec (`restart.policy: never`): now resolves to `--max-restarts 3`, activating the supervisor + history-walk path.
- 9 new TQ-compliant tests (no mocks — real `AgentConfig` + `RestartSpec`), covering flag presence, the `>0` default, the never-policy floor, cap-raising for on-failure/always, below-floor clamping, and backoff resolution.
- Full runtimes suite (569 tests) green — no argv-shape regression.
- CI ruff selector (F401,F811) clean.

## Test plan

- [x] `pytest tests/scitex_agent_container/runtimes/` — 569 passed
- [x] live spec resolves to `--max-restarts 3`