### PR TITLE
feat(heartbeat): surface container /tmp fill % (bash-wedge Class B)

### DIFF
--- a/src/scitex_agent_container/_runners/_session_state.py
+++ b/src/scitex_agent_container/_runners/_session_state.py
@@ -17,6 +17,7 @@ import asyncio
 import json
 import logging
 import os
+import shutil
 import time
 from pathlib import Path
 
@@ -192,6 +193,38 @@ def _heartbeat_usage_fields(state_dir: Path, now: float) -> dict:
     return out
 
 
+# /tmp pressure probe path. The session runner executes inside the
+# container, where /tmp is the RAM-backed tmpfs (apptainer --containall
+# default, unbounded by sac). Heavy run_in_background Bash sessions
+# write per-command + task-output files there; once it fills, every
+# shell command that needs a temp file fails with exit 1 + empty stdout
+# — the silent "Class B" bash wedge (2026-05-22 diagnosis §3). Surfacing
+# the fill % on the heartbeat turns that silent failure into an
+# observable one the operator (and `sac agents status`) can see BEFORE
+# the wedge.
+_TMP_PRESSURE_PATH = "/tmp"  # noqa: S108 — container tmpfs, intentional
+
+
+def _tmp_pressure_fields(probe_path: str = _TMP_PRESSURE_PATH) -> dict:
+    """Return ``{tmp_used_pct}`` for the container tmpfs, best-effort.
+
+    ``tmp_used_pct`` is the percentage of ``probe_path`` consumed
+    (``used / total * 100``, rounded to 1 dp). Any failure — the path
+    not existing (running on the host where there is no container
+    ``/tmp`` tmpfs), a permission error, or a zero-total stat — degrades
+    to an EMPTY dict so the heartbeat loop never crashes and the field
+    is simply ABSENT rather than a misleading 0. Absent ≠ 0%: a reader
+    distinguishes "not probed" from "empty tmpfs".
+    """
+    try:
+        usage = shutil.disk_usage(probe_path)
+    except OSError:
+        return {}
+    if usage.total <= 0:
+        return {}
+    return {"tmp_used_pct": round(usage.used / usage.total * 100.0, 1)}
+
+
 def write_heartbeat(
     state_dir: Path,
     *,
@@ -212,6 +245,13 @@ def write_heartbeat(
     This lets the operator see, per agent, how long it has been running
     and how many tokens it has used — straight off the fast-path JSON.
 
+    When the container tmpfs is probeable it also carries
+    ``tmp_used_pct`` — the ``/tmp`` fill percentage — so a filling
+    tmpfs (the silent "Class B" bash-wedge precursor) is observable
+    on every beat BEFORE it wedges the SDK's Bash tool. Absent (not 0)
+    when the probe fails, e.g. on the host where there is no container
+    ``/tmp`` tmpfs.
+
     The JSON file is kept as a fast-path cache for local readers
     (``sac agent status`` polls it without opening sqlite); the DB
     row is the cross-host queryable record.
@@ -224,6 +264,7 @@ def write_heartbeat(
     now = time.time()
     payload = {"ts": now, "pid": pid, "state": state}
     payload.update(_heartbeat_usage_fields(state_dir, now))
+    payload.update(_tmp_pressure_fields())
     tmp = state_dir / "heartbeat.json.tmp"
     tmp.write_text(json.dumps(payload), encoding="utf-8")
     tmp.replace(state_dir / "heartbeat.json")

--- a/src/scitex_agent_container/_skills/scitex-agent-container/13_observability.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/13_observability.md
@@ -40,6 +40,36 @@ This means:
   document in CHANGELOG.
 - Removing a field is a breaking change.
 
+## tmp-pressure field (`sdk_session.heartbeat.tmp_used_pct`)
+
+For `runtime: apptainer` (claude-session) agents the per-beat heartbeat
+carries `tmp_used_pct` — the fill percentage of the container's `/tmp`.
+Surfaces as `sdk_session.heartbeat.tmp_used_pct` in `sac agents status
+--json` (the status surface echoes the heartbeat dict verbatim).
+
+Why it exists: inside the container `/tmp` is the RAM-backed tmpfs
+(apptainer `--containall` default, unbounded by sac). A heavy
+`run_in_background` Bash session writes per-command + task-output files
+there; once it fills, every shell command that needs a temp file fails
+with exit 1 + empty stdout — the silent "Class B" bash wedge (2026-05-22
+diagnosis §3). Watching `tmp_used_pct` climb toward 100 turns that
+silent failure into an observable precursor.
+
+Best-effort: the field is **absent** (not `0`) when the probe fails
+(e.g. read on the host, where there is no container `/tmp` tmpfs). Absent
+≠ 0% — a reader distinguishes "not probed" from "empty tmpfs".
+
+### Deferred: bounding the tmpfs (not in this change)
+
+The companion mitigation — capping `/tmp` so exhaustion surfaces as a
+loud `No space left on device` rather than a silent exit-1 — was
+**deliberately deferred**. It requires threading a
+`--mount type=tmpfs,…,size=…` (or sized `--writable-tmpfs`) into the
+apptainer raw_args, which touches the iso-flags / relaxed-vs-hardened
+launch path and risks regressing the live `--containall` behaviour.
+Instrumentation (this field) is the cheap, non-invasive first half; the
+bounding is tracked separately so it can be reviewed on its own.
+
 ## See also
 
 - README "Rich Status" table — full field list with types and meanings.

--- a/tests/scitex_agent_container/_runners/test_claude_session.py
+++ b/tests/scitex_agent_container/_runners/test_claude_session.py
@@ -353,6 +353,56 @@ def test_heartbeat_total_tokens_zero_without_quota(tmp_path: Path) -> None:
     assert hb is not None and hb["total_tokens"] == 0
 
 
+# ---------------------------------------------------------------------------
+# tmp-pressure heartbeat field (Class B bash-wedge instrumentation).
+# The session runner executes in the container, where /tmp is the
+# RAM-backed tmpfs that a heavy background-Bash session can silently
+# fill — surfacing tmp_used_pct on the heartbeat makes that observable.
+# ---------------------------------------------------------------------------
+
+
+def test_tmp_pressure_fields_reports_used_pct_for_real_path(tmp_path: Path) -> None:
+    # Arrange — probe a real filesystem dir (tmp_path) so disk_usage
+    # returns a genuine reading.
+    from scitex_agent_container._runners._session_state import _tmp_pressure_fields
+
+    # Act
+    fields = _tmp_pressure_fields(str(tmp_path))
+    # Assert
+    assert "tmp_used_pct" in fields
+
+
+def test_tmp_pressure_fields_used_pct_is_a_percentage(tmp_path: Path) -> None:
+    # Arrange
+    from scitex_agent_container._runners._session_state import _tmp_pressure_fields
+
+    # Act
+    pct = _tmp_pressure_fields(str(tmp_path))["tmp_used_pct"]
+    # Assert
+    assert 0.0 <= pct <= 100.0
+
+
+def test_tmp_pressure_fields_missing_path_returns_empty_dict(tmp_path: Path) -> None:
+    # Arrange — a path that does not exist must degrade to {} (absent,
+    # not a misleading 0%), so the heartbeat loop never crashes.
+    from scitex_agent_container._runners._session_state import _tmp_pressure_fields
+
+    missing = tmp_path / "does-not-exist"
+    # Act
+    fields = _tmp_pressure_fields(str(missing))
+    # Assert
+    assert fields == {}
+
+
+def test_heartbeat_includes_tmp_used_pct(tmp_path: Path) -> None:
+    # Arrange — the default /tmp probe yields a reading on any Linux runner.
+    runner.write_heartbeat(tmp_path, pid=1, state=runner.STATE_IDLE)
+    # Act
+    hb = runner.read_heartbeat(tmp_path)
+    # Assert
+    assert hb is not None and "tmp_used_pct" in hb
+
+
 def test_heartbeat_includes_total_tokens_from_quota(tmp_path: Path) -> None:
     # Arrange: a ResultMessage usage block accumulated into quota.json.
     runner.accumulate_quota(


### PR DESCRIPTION
## Problem

Inside the container, `/tmp` is the RAM-backed tmpfs (apptainer `--containall` default, unbounded by sac). A heavy `run_in_background` Bash session writes per-command + task-output files there; once it fills, **every** shell command that needs a temp file fails with exit 1 + empty stdout — the silent "Class B" bash wedge (2026-05-22 diagnosis §3). It is indistinguishable from a healthy session because the heartbeat + `/health` keep answering.

## Fix (instrumentation half)

Add a best-effort `tmp_used_pct` field to the session-runner heartbeat via `shutil.disk_usage("/tmp")`. It flows through `read_heartbeat` → `sac agents status --json` as `sdk_session.heartbeat.tmp_used_pct` (the status surface echoes the heartbeat dict verbatim, see `_state/_meta/transcript.py`), so a filling tmpfs is observable **before** it wedges.

Best-effort: the field is **absent** (not `0`) when the probe fails — e.g. read on the host, where there is no container `/tmp` tmpfs. Absent ≠ 0% lets a reader distinguish "not probed" from "empty tmpfs". The probe never raises, so the heartbeat loop is never crashed.

## Scope note — bounding deferred

Per the task's escape hatch, this ships the **instrumentation only**. The companion mitigation (capping `/tmp` so exhaustion surfaces as a loud `No space left on device` instead of silent exit-1) requires threading a sized `--mount type=tmpfs`/`--writable-tmpfs` into the apptainer raw_args, which touches the iso-flags / relaxed-vs-hardened launch path and risks regressing the live `--containall` behaviour. Deferred and documented in `13_observability.md` so it can be reviewed on its own.

## Verification

- `_tmp_pressure_fields("/tmp")` → `{'tmp_used_pct': 76.1}`; missing path → `{}`; `write_heartbeat` now emits `tmp_used_pct`.
- 4 new TQ-compliant tests (no mocks — real `shutil.disk_usage` against `tmp_path`, a non-existent path, and the default `/tmp` probe).
- Full `_runners` + `_state` suites (1034 tests) green — no regression to the heartbeat-consuming surfaces.
- CI ruff selector (F401,F811) clean.

## Test plan

- [x] `pytest tests/scitex_agent_container/_runners/ tests/scitex_agent_container/_state/` — 1034 passed
- [x] helper + heartbeat integration verified against real `/tmp`