### PR TITLE
feat(runtimes): generalize dev-channels gate to any spec.claude.channels entry

### DIFF
--- a/src/scitex_agent_container/runtimes/_sdk_channels.py
+++ b/src/scitex_agent_container/runtimes/_sdk_channels.py
@@ -1,0 +1,91 @@
+"""``spec.claude.channels`` → claude dev-channels flag + sac MCP sidecar.
+
+Extracted from ``_sdk_common.build_sdk_options`` so the channel wiring has
+one focused home (and its own test surface).
+
+claude renders ``<channel ...>`` tags — the ONLY way a channel notification
+ADVANCES a turn in an SDK session — solely when the bundled ``claude`` binary
+is started with ``--dangerously-load-development-channels`` listing the
+channel set. ``apply_channels`` sets that flag and, for ``server:sac``,
+auto-registers sac's own bus-adapter MCP.
+
+Two separate concerns, gated independently:
+
+  (a) dev-channels flag — fire for ANY ``spec.claude.channels`` entry, value
+      = comma-joined set of every requested channel. This is what lets a
+      per-agent channel work, e.g. an agent running its OWN telegrammer bot
+      via ``server:claude-code-telegrammer`` (whose backing stdio MCP the
+      spec author supplies through ``to_home/.mcp.json``). The gate was
+      previously hard-coded to ``server:sac`` only, so any foreign channel
+      survived all the way down the runner argv but was DROPPED here —
+      claude never turned on rendering and the notifications were silently
+      ignored (the "store fills, no turn appears" silent-failure class).
+
+  (b) ``sac mcp channel`` MCP auto-registration — ``server:sac`` ONLY. That
+      sidecar is sac's own bus adapter; it must never be auto-wired for a
+      foreign channel. Backing MCPs for non-sac channels come from the
+      spec's ``to_home/.mcp.json`` (already merged into ``mcp_servers``).
+"""
+
+from __future__ import annotations
+
+
+def _dedupe_channels(channels: list[str]) -> list[str]:
+    """Return the channel names stripped + deduped, preserving spec order."""
+    seen: set[str] = set()
+    out: list[str] = []
+    for raw in channels:
+        name = raw.strip()
+        if name and name not in seen:
+            seen.add(name)
+            out.append(name)
+    return out
+
+
+def apply_channels(
+    kwargs: dict,
+    channels: list[str] | None,
+    a2a_port: int | None,
+    agent_name: str,
+) -> None:
+    """Wire ``spec.claude.channels`` into the ``ClaudeAgentOptions`` kwargs.
+
+    Mutates ``kwargs`` in place:
+
+      * sets ``extra_args["dangerously-load-development-channels"]`` to the
+        comma-joined channel set when ANY channel is requested (concern (a));
+      * registers the ``sac mcp channel`` stdio MCP under ``mcp_servers["sac"]``
+        when ``server:sac`` is among the channels (concern (b)).
+
+    No-op when ``channels`` is empty/None.
+    """
+    if not channels:
+        return
+
+    chset = _dedupe_channels(channels)
+    if chset:
+        extra_args = kwargs.setdefault("extra_args", {})
+        if isinstance(extra_args, dict):
+            extra_args.setdefault(
+                "dangerously-load-development-channels", ",".join(chset)
+            )
+
+    if any(c.strip() == "server:sac" for c in channels):
+        mcps = kwargs.setdefault("mcp_servers", {})
+        if isinstance(mcps, dict) and "sac" not in mcps:
+            # Sidecar subscribes to the BUS inbox (`sac listen`), resolved
+            # from SAC_LISTEN_BASE_URL — NOT the a2a port. a2a_port is the
+            # WAKE path (WI-1): passed as --turn-url so a received bus event
+            # POSTs to the agent's own loopback /v1/turn to wake an idle
+            # session (push ≡ Telegram).
+            sidecar_args = ["mcp", "channel", "--name", agent_name]
+            if a2a_port is not None:
+                sidecar_args += [
+                    "--turn-url",
+                    f"http://127.0.0.1:{int(a2a_port)}/v1/turn",
+                ]
+            mcps["sac"] = {
+                "type": "stdio",
+                "command": "sac",
+                "args": sidecar_args,
+            }

--- a/src/scitex_agent_container/runtimes/_sdk_common.py
+++ b/src/scitex_agent_container/runtimes/_sdk_common.py
@@ -41,6 +41,8 @@ import re as _re
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from ._sdk_channels import apply_channels
+
 if TYPE_CHECKING:  # pragma: no cover — typing only
     from claude_agent_sdk import ClaudeAgentOptions
 
@@ -452,60 +454,10 @@ def build_sdk_options(
         if extra:
             kwargs.update(extra)
 
-    # spec.claude.channels → claude CLI --channels passthrough.
-    # The SDK runs the bundled claude binary as a subprocess; channels
-    # are CLI-only (research preview, MCP `notifications/claude/channel`
-    # delivery). We forward each entry as a separate ``--channels`` arg
-    # via the SDK's ``extra_args`` escape hatch when available.
-    if channels and any(c.strip() == "server:sac" for c in channels):
-        # Register `sac mcp channel` as a stdio MCP server. claude
-        # exposes its tools (a2a_send/reply/ack/peers/inbox) under the
-        # `mcp__sac__*` namespace AND delivers its push events through
-        # the standard MCP `notifications/claude/channel` method —
-        # provided claude was started with
-        # `--dangerously-load-development-channels`, which is what
-        # turns rendering of those `<channel ...>` tags on in the
-        # session. The `--channels server:sac` flag (without the
-        # dangerously- prefix) caused claude to treat the MCP server
-        # as channel-only and dropped the tool surface; we do NOT set
-        # that one. Net effect: tools + push delivery both work.
-        extra_args = kwargs.setdefault("extra_args", {})
-        if isinstance(extra_args, dict):
-            extra_args.setdefault("dangerously-load-development-channels", "server:sac")
-        mcps = kwargs.setdefault("mcp_servers", {})
-        if isinstance(mcps, dict) and "sac" not in mcps:
-            # The sidecar subscribes to /agents/<name>/inbox/stream, which
-            # is served by the BUS (`sac listen`, default :7878), NOT the
-            # agent's own a2a sidecar port. Omit --listen-url here and let
-            # the adapter's main() resolve the bus from SAC_LISTEN_BASE_URL
-            # (its existing default, injected into the container) — the
-            # same source the CLI default and the adapter both use. Passing
-            # the a2a_port here pointed the SSE GET at a server that 404s on
-            # the inbox route, so the bus saw zero subscribers and
-            # delivered_subscriber_count was always 0.
-            #
-            # a2a_port is irrelevant to inbox SUBSCRIPTION but IS the wake
-            # path (WI-1): pass it as ``--turn-url`` so the adapter can POST
-            # received bus events to the agent's OWN ``/v1/turn`` and WAKE an
-            # idle session. The bind host is loopback (the sidecar and the
-            # runner share the container netns); host LAN exposure of the turn
-            # endpoint does not change the in-container wake target.
-            sidecar_args = [
-                "mcp",
-                "channel",
-                "--name",
-                agent_name,
-            ]
-            if a2a_port is not None:
-                sidecar_args += [
-                    "--turn-url",
-                    f"http://127.0.0.1:{int(a2a_port)}/v1/turn",
-                ]
-            mcps["sac"] = {
-                "type": "stdio",
-                "command": "sac",
-                "args": sidecar_args,
-            }
+    # spec.claude.channels → dev-channels flag + sac MCP sidecar.
+    # See ``_sdk_channels.apply_channels`` for the two gated concerns
+    # (any-channel dev-flag vs server:sac-only sidecar registration).
+    apply_channels(kwargs, channels, a2a_port, agent_name)
 
     # Enable subagents. The Agent (Task) tool is only OFFERED to the model
     # when it appears in ``allowed_tools`` (Anthropic "Subagents in the SDK"

--- a/tests/scitex_agent_container/runtimes/test__sdk_channels.py
+++ b/tests/scitex_agent_container/runtimes/test__sdk_channels.py
@@ -1,0 +1,140 @@
+"""Tests for ``runtimes/_sdk_channels.apply_channels``.
+
+``apply_channels`` is pure: it mutates a plain ``kwargs`` dict in place.
+No auth, registry, or env fixtures needed — the tests pass real dicts and
+assert on the mutation.
+
+The load-bearing behaviour this guards (the Task A generalization): the
+``--dangerously-load-development-channels`` flag fires for ANY
+``spec.claude.channels`` entry, not just ``server:sac``. Before the fix a
+foreign channel (e.g. ``server:claude-code-telegrammer`` for an agent's own
+telegrammer bot) survived the runner argv but was DROPPED at the gate, so
+claude never rendered its ``<channel>`` tags and the notifications were
+silently ignored.
+
+TQ: each test is Arrange / Act / Assert with a single assertion; multi-fact
+scenarios are split into sibling tests so the failing line names the
+contract that regressed.
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container.runtimes._sdk_channels import apply_channels
+
+
+def _devflag(kwargs: dict) -> str | None:
+    """Return the dev-channels flag value, or None if unset."""
+    return kwargs.get("extra_args", {}).get("dangerously-load-development-channels")
+
+
+class TestForeignChannelTurnsOnDevChannels:
+    """A non-sac channel must enable dev-channels (the regression guard)."""
+
+    def test_telegrammer_channel_sets_dev_flag(self):
+        # Arrange
+        kwargs: dict = {}
+        # Act
+        apply_channels(kwargs, ["server:claude-code-telegrammer"], None, "clew")
+        # Assert
+        assert _devflag(kwargs) == "server:claude-code-telegrammer"
+
+    def test_telegrammer_channel_does_not_register_sac_mcp(self):
+        # Arrange
+        kwargs: dict = {}
+        # Act
+        apply_channels(kwargs, ["server:claude-code-telegrammer"], None, "clew")
+        # Assert: sac sidecar is server:sac-only — must NOT auto-wire here.
+        assert "sac" not in kwargs.get("mcp_servers", {})
+
+
+class TestSacChannelStillWorks:
+    """``server:sac`` keeps both the dev flag and the sidecar registration."""
+
+    def test_sac_channel_sets_dev_flag(self):
+        # Arrange
+        kwargs: dict = {}
+        # Act
+        apply_channels(kwargs, ["server:sac"], 9999, "lead")
+        # Assert
+        assert _devflag(kwargs) == "server:sac"
+
+    def test_sac_channel_registers_sac_mcp(self):
+        # Arrange
+        kwargs: dict = {}
+        # Act
+        apply_channels(kwargs, ["server:sac"], 9999, "lead")
+        # Assert
+        assert kwargs["mcp_servers"]["sac"]["command"] == "sac"
+
+    def test_sac_sidecar_carries_turn_url_for_wake(self):
+        # Arrange
+        kwargs: dict = {}
+        # Act
+        apply_channels(kwargs, ["server:sac"], 9999, "lead")
+        # Assert
+        args = kwargs["mcp_servers"]["sac"]["args"]
+        assert args[args.index("--turn-url") + 1] == "http://127.0.0.1:9999/v1/turn"
+
+    def test_sac_sidecar_omits_turn_url_when_no_a2a_port(self):
+        # Arrange
+        kwargs: dict = {}
+        # Act
+        apply_channels(kwargs, ["server:sac"], None, "lead")
+        # Assert
+        assert "--turn-url" not in kwargs["mcp_servers"]["sac"]["args"]
+
+
+class TestBothChannelsCoexist:
+    """An agent can request both its own channel AND the sac bus channel."""
+
+    def test_dev_flag_lists_both_channels_comma_joined(self):
+        # Arrange
+        kwargs: dict = {}
+        # Act
+        apply_channels(
+            kwargs, ["server:sac", "server:claude-code-telegrammer"], None, "clew"
+        )
+        # Assert: claude needs the full set to render both channels' tags.
+        assert _devflag(kwargs) == "server:sac,server:claude-code-telegrammer"
+
+    def test_sac_mcp_registered_when_sac_present_among_many(self):
+        # Arrange
+        kwargs: dict = {}
+        # Act
+        apply_channels(
+            kwargs, ["server:claude-code-telegrammer", "server:sac"], None, "clew"
+        )
+        # Assert
+        assert "sac" in kwargs["mcp_servers"]
+
+
+class TestDedupeAndNormalization:
+    """Whitespace + duplicate channel entries are normalized."""
+
+    def test_duplicate_channels_collapse_in_dev_flag(self):
+        # Arrange
+        kwargs: dict = {}
+        # Act
+        apply_channels(kwargs, ["server:sac", " server:sac "], None, "lead")
+        # Assert
+        assert _devflag(kwargs) == "server:sac"
+
+
+class TestNoChannels:
+    """No channels → no dev flag, no sidecar (the common case)."""
+
+    def test_empty_list_leaves_dev_flag_unset(self):
+        # Arrange
+        kwargs: dict = {}
+        # Act
+        apply_channels(kwargs, [], None, "lead")
+        # Assert
+        assert _devflag(kwargs) is None
+
+    def test_none_leaves_mcp_servers_untouched(self):
+        # Arrange
+        kwargs: dict = {}
+        # Act
+        apply_channels(kwargs, None, None, "lead")
+        # Assert
+        assert "mcp_servers" not in kwargs


### PR DESCRIPTION
## What

`build_sdk_options` hard-coded `server:sac` as the only channel that got `--dangerously-load-development-channels`. Any other `spec.claude.channels` entry survived the runner argv but was **dropped at the gate** — claude never rendered its `<channel>` tags, so those notifications were silently ignored (the "store fills, no turn appears" silent-failure class).

## Change

- **dev-channels flag** now fires for ANY channel; value = comma-joined set of every requested channel (so claude renders each channel's tags).
- **`sac mcp channel` sidecar auto-registration** stays gated on `server:sac` only — sac's own bus adapter is never auto-wired for a foreign channel. Backing MCPs for non-sac channels come from the spec's `to_home/.mcp.json`.
- Extracted the channel wiring into a focused `runtimes/_sdk_channels.apply_channels` helper (the inline block tipped `_sdk_common.py` past the 512-line budget). Public API of `_sdk_common` unchanged.

## Why

Unblocks **per-agent Telegram bots**: an agent supplies its own telegrammer MCP via `to_home/.mcp.json` and adds `server:claude-code-telegrammer` to `spec.claude.channels`; inbound Telegram messages then advance its SDK turns via the same `notifications/claude/channel` path the lead uses for `server:sac`. Both channels coexist.

## Tests

- New `tests/.../runtimes/test__sdk_channels.py` (11 tests): foreign-channel dev-flag, sac-only sidecar gating, both-coexist comma-join, dedupe, no-channel no-op.
- Existing `test__sdk_common.py::TestChannelSidecar` (server:sac) still green.
- Full `tests/.../runtimes/` suite: 580 passed.

No mocks; AAA + one-assert-per-test.