### PR TITLE
feat(runtimes): merge $HOME/.mcp.json into SDK mcp_servers (per-agent MCP delivery)

### DIFF
--- a/src/scitex_agent_container/runtimes/_sdk_channels.py
+++ b/src/scitex_agent_container/runtimes/_sdk_channels.py
@@ -29,6 +29,72 @@ Two separate concerns, gated independently:
 
 from __future__ import annotations
 
+import json as _json
+import os as _os
+from pathlib import Path as _Path
+
+
+def merge_home_mcp_servers(mcp_servers: dict) -> dict:
+    """Merge ``$HOME/.mcp.json`` MCP servers into ``mcp_servers``.
+
+    ``to_home/.mcp.json`` deploys to the container ``$HOME/.mcp.json``
+    (see ``_to_home.py`` / skill 25 — the documented per-agent MCP
+    delivery). But the apptainer SDK runner runs INSIDE the container
+    where ``resolve_agent_workspace`` cannot find the agent's mcp config:
+    the in-container registry lookup fails AND the config's ``workdir``
+    is the HOST path (absent in-container), so it returns ``{}``. The
+    SDK's own project-scope ``.mcp.json`` discovery is also dead because
+    the runner sets ``setting_sources=[]`` (verified: a ``/work/.mcp.json``
+    is NOT loaded under empty setting_sources). So the ONLY reliable way
+    a per-agent MCP (e.g. an agent's own telegrammer bot) reaches the SDK
+    is via ``ClaudeAgentOptions.mcp_servers`` — which this helper
+    populates from the to_home-deployed ``$HOME/.mcp.json``.
+
+    Best-effort: a missing/malformed file yields the input unchanged.
+    ``resolve_agent_workspace`` entries (passed in as ``mcp_servers``)
+    win on key collision — explicit registry config beats the file.
+    ``${VAR}`` refs in entry values resolve from ``os.environ``.
+    """
+    home = _os.environ.get("HOME")
+    if not home:
+        return mcp_servers
+    path = _Path(home) / ".mcp.json"
+    if not path.is_file():
+        return mcp_servers
+    try:
+        raw = _json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, _json.JSONDecodeError):
+        return mcp_servers
+    servers = raw.get("mcpServers", {}) if isinstance(raw, dict) else {}
+    if not isinstance(servers, dict) or not servers:
+        return mcp_servers
+
+    merged = dict(mcp_servers)
+    for name, entry in servers.items():
+        if name in merged or not isinstance(entry, dict):
+            continue  # registry config wins; skip non-dict junk
+        e = _resolve_env_refs_local(dict(entry))
+        e.setdefault("type", "stdio")
+        merged[name] = e
+    return merged
+
+
+def _resolve_env_refs_local(value):
+    """Resolve ``${VAR}`` refs from os.environ, recursively (str/list/dict)."""
+    import re as _re
+
+    if isinstance(value, str):
+        return _re.sub(
+            r"\$\{(\w+)\}",
+            lambda m: _os.environ.get(m.group(1), m.group(0)),
+            value,
+        )
+    if isinstance(value, dict):
+        return {k: _resolve_env_refs_local(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_resolve_env_refs_local(v) for v in value]
+    return value
+
 
 def _dedupe_channels(channels: list[str]) -> list[str]:
     """Return the channel names stripped + deduped, preserving spec order."""

--- a/src/scitex_agent_container/runtimes/_sdk_common.py
+++ b/src/scitex_agent_container/runtimes/_sdk_common.py
@@ -41,7 +41,7 @@ import re as _re
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from ._sdk_channels import apply_channels
+from ._sdk_channels import apply_channels, merge_home_mcp_servers
 
 if TYPE_CHECKING:  # pragma: no cover — typing only
     from claude_agent_sdk import ClaudeAgentOptions
@@ -371,6 +371,11 @@ def build_sdk_options(
 
     provision_anthropic_auth()
     mcp_servers, workdir = resolve_agent_workspace(agent_name)
+    # Merge to_home-deployed $HOME/.mcp.json (the per-agent MCP delivery
+    # path) — resolve_agent_workspace returns {} inside an apptainer
+    # container, and setting_sources=[] kills the SDK's own project-scope
+    # discovery, so this is the only path a per-agent MCP reaches the SDK.
+    mcp_servers = merge_home_mcp_servers(mcp_servers)
 
     # Apptainer/Docker dispatch binds the host workdir at /work inside
     # the container; the config's workdir field carries the HOST path

--- a/tests/scitex_agent_container/runtimes/test__sdk_channels.py
+++ b/tests/scitex_agent_container/runtimes/test__sdk_channels.py
@@ -19,7 +19,61 @@ contract that regressed.
 
 from __future__ import annotations
 
-from scitex_agent_container.runtimes._sdk_channels import apply_channels
+import json
+import os
+
+import pytest
+
+from scitex_agent_container.runtimes._sdk_channels import (
+    apply_channels,
+    merge_home_mcp_servers,
+)
+
+
+@pytest.fixture
+def home_with_mcp(tmp_path):
+    """Point $HOME at a tmp dir and write a real ``.mcp.json`` there.
+
+    Yield-based save/restore of $HOME (PA-306: no monkeypatch). The file
+    is real on disk so ``merge_home_mcp_servers`` exercises its actual
+    read path, not a stubbed one.
+    """
+    saved = os.environ.get("HOME")
+    os.environ["HOME"] = str(tmp_path)
+    (tmp_path / ".mcp.json").write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "claude-code-telegrammer": {
+                        "command": "bash",
+                        "args": ["-c", "exec bun run /tg/telegram-server.ts"],
+                        "env": {"TG_STATE": "/home/agent/.tg-clew"},
+                    }
+                }
+            }
+        )
+    )
+    try:
+        yield tmp_path
+    finally:
+        if saved is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = saved
+
+
+@pytest.fixture
+def home_without_mcp(tmp_path):
+    """Point $HOME at a tmp dir with NO ``.mcp.json``."""
+    saved = os.environ.get("HOME")
+    os.environ["HOME"] = str(tmp_path)
+    try:
+        yield tmp_path
+    finally:
+        if saved is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = saved
 
 
 def _devflag(kwargs: dict) -> str | None:
@@ -138,3 +192,65 @@ class TestNoChannels:
         apply_channels(kwargs, None, None, "lead")
         # Assert
         assert "mcp_servers" not in kwargs
+
+
+class TestMergeHomeMcpServers:
+    """``$HOME/.mcp.json`` is the per-agent MCP delivery path for the SDK.
+
+    The apptainer SDK runner's ``resolve_agent_workspace`` returns ``{}``
+    inside the container, and ``setting_sources=[]`` kills the SDK's own
+    project-scope ``.mcp.json`` discovery — so this merge is the ONLY way
+    a per-agent MCP (e.g. an agent's own telegrammer) reaches the SDK.
+    """
+
+    def test_home_mcp_server_is_merged_in(self, home_with_mcp):
+        # Arrange
+        existing: dict = {}
+        # Act
+        out = merge_home_mcp_servers(existing)
+        # Assert
+        assert "claude-code-telegrammer" in out
+
+    def test_merged_entry_gets_default_stdio_type(self, home_with_mcp):
+        # Arrange
+        existing: dict = {}
+        # Act
+        out = merge_home_mcp_servers(existing)
+        # Assert
+        assert out["claude-code-telegrammer"]["type"] == "stdio"
+
+    def test_registry_entry_wins_on_key_collision(self, home_with_mcp):
+        # Arrange — same key already present from resolve_agent_workspace.
+        existing = {"claude-code-telegrammer": {"command": "registry", "type": "stdio"}}
+        # Act
+        out = merge_home_mcp_servers(existing)
+        # Assert
+        assert out["claude-code-telegrammer"]["command"] == "registry"
+
+    def test_missing_home_mcp_file_is_noop(self, home_without_mcp):
+        # Arrange
+        existing = {"sac": {"command": "sac", "type": "stdio"}}
+        # Act
+        out = merge_home_mcp_servers(existing)
+        # Assert
+        assert out == existing
+
+    def test_env_refs_resolved_from_environ(self, home_with_mcp):
+        # Arrange — write a ${VAR} ref into the home .mcp.json + set the var.
+        (home_with_mcp / ".mcp.json").write_text(
+            json.dumps(
+                {"mcpServers": {"x": {"command": "c", "env": {"K": "${MY_REF}"}}}}
+            )
+        )
+        saved = os.environ.get("MY_REF")
+        os.environ["MY_REF"] = "resolved-value"
+        # Act
+        try:
+            out = merge_home_mcp_servers({})
+        finally:
+            if saved is None:
+                os.environ.pop("MY_REF", None)
+            else:
+                os.environ["MY_REF"] = saved
+        # Assert
+        assert out["x"]["env"]["K"] == "resolved-value"


### PR DESCRIPTION
## What

Per-agent MCP servers delivered via `to_home/.mcp.json` (which lands at the container `$HOME/.mcp.json`) never reached the SDK for **apptainer** agents. `build_sdk_options` now merges them into `ClaudeAgentOptions.mcp_servers`.

## Why (the gap)

For an apptainer `claude-session` agent:
- `resolve_agent_workspace(name)` returns `{}` **inside the container** — the in-container registry lookup fails, and the config's `workdir` is the HOST path (absent in-container), so it reads no `.mcp.json`. (Verified by reproducing the call inside the SIF.)
- The SDK's own project-scope `.mcp.json` discovery is **dead** because the runner sets `setting_sources=[]`. (Verified: a `/work/.mcp.json` is NOT loaded under empty `setting_sources` — `get_mcp_status` omitted it.)

So the **only** reliable way a per-agent MCP reaches the SDK is via `ClaudeAgentOptions.mcp_servers`. This PR makes `build_sdk_options` merge the `$HOME/.mcp.json` (the documented `to_home` MCP delivery path, per skill 25 / `_to_home.py`) into `mcp_servers`.

## Behavior

- Registry config (`resolve_agent_workspace`) **wins** on key collision.
- `${VAR}` refs in entry values resolve from `os.environ`.
- Missing / malformed `$HOME/.mcp.json` → input unchanged (best-effort).
- Entry `type` defaults to `stdio`.

## End-to-end verification (in the rebuilt SIF, sac 0.18.0)

With `mcp_servers` populated by the merge, `claude.get_mcp_status()` lists `claude-code-telegrammer` under `setting_sources=[]` — proving the backing telegrammer MCP spawns. Pairs with PR #181 (`apply_channels` dev-channels generalization): #181 turns on `<channel>` rendering for the channel; this PR actually spawns the MCP that delivers the messages.

## Tests

`merge_home_mcp_servers` helper in `runtimes/_sdk_channels.py` + 5 tests (real `tmp_path` + `.mcp.json`, yield-based `$HOME` save/restore — no mocks): merge, default-type, registry-wins-on-collision, missing-file no-op, `${VAR}` resolution. Full `tests/.../runtimes/` suite: 585 passed.