### PR TITLE
fix(apptainer): bind overlay upper-home over --home tmpfs (per-agent MCP/to_home delivery)

### DIFF
--- a/src/scitex_agent_container/runtimes/_apptainer_runtime.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_runtime.py
@@ -272,6 +272,32 @@ class ApptainerContainerRuntime(RuntimeBase):
             for arg in getattr(ap_for_raw, "raw_args", None) or []:
                 argv.append(str(arg))
 
+        # Relaxed + directory-overlay + explicit ``--home`` shadows the
+        # to_home tree. ``deploy_to_home_overlay`` materialises the tree
+        # into ``<overlay>/upper/<container_home>/``, but a raw-arg
+        # ``--home /home/agent`` makes apptainer mount a FRESH tmpfs at
+        # that path (verified via `mount`: ``tmpfs on /home/agent``),
+        # which shadows the overlay's upper-home — so $HOME/.mcp.json,
+        # $HOME/CLAUDE.md, $HOME/.claude/ are all silently absent in the
+        # container. The SDK runner's ``merge_home_mcp_servers`` then
+        # reads an empty ``$HOME/.mcp.json`` and a per-agent MCP (e.g. an
+        # agent's own telegrammer bot) never reaches the SDK.
+        #
+        # Fix: bind the materialised upper-home OVER the container HOME,
+        # appended AFTER raw_args so it wins over the ``--home`` tmpfs
+        # (apptainer applies user binds after home setup). No-op for
+        # non-relaxed / non-directory-overlay specs (resolver returns
+        # None) and when the upper-home wasn't materialised.
+        from ._to_home_overlay import (
+            resolve_container_home,
+            resolve_overlay_upper_home,
+        )
+
+        upper_home = resolve_overlay_upper_home(config)
+        if upper_home is not None and upper_home.is_dir():
+            container_home = resolve_container_home(config)
+            argv += ["--bind", f"{upper_home}:{container_home}"]
+
         argv.append(str(sif_path))
 
         # Inner command (tini-supervised runner). Dispatched on

--- a/tests/scitex_agent_container/runtimes/test__apptainer_runtime.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_runtime.py
@@ -265,6 +265,85 @@ def test_argv_does_not_emit_user_flag(tmp_path: Path) -> None:
     assert "--user" not in argv
 
 
+def test_argv_binds_overlay_upper_home_over_home_tmpfs(tmp_path: Path) -> None:
+    # Arrange — relaxed + directory-overlay + explicit --home. The
+    # raw-arg --home /home/agent mounts a fresh tmpfs that would shadow
+    # the to_home tree materialised into <overlay>/upper/home/agent. The
+    # runtime must bind that upper-home over the container HOME so
+    # $HOME/.mcp.json (per-agent MCP delivery) survives the tmpfs.
+    rt = ApptainerContainerRuntime()
+    overlay_dir = tmp_path / "overlay"
+    upper_home = overlay_dir / "upper" / "home" / "agent"
+    upper_home.mkdir(parents=True, exist_ok=True)  # simulate deploy_to_home_overlay
+    cfg = _config(tmp_path / "wd")
+    cfg.apptainer = ApptainerSpec(
+        relaxed=True,
+        raw_args=[
+            "--containall",
+            "--home",
+            "/home/agent",
+            "--overlay",
+            str(overlay_dir),
+        ],
+    )
+    # Act
+    argv = rt.build_run_argv(
+        cfg, state_dir=tmp_path / "state", sif_path=tmp_path / "x.sif"
+    )
+    # Assert — the upper-home bind exists, targeting the container HOME.
+    bind_idxs = [i for i, a in enumerate(argv) if a == "--bind"]
+    binds = [argv[i + 1] for i in bind_idxs]
+    assert f"{upper_home}:/home/agent" in binds
+
+
+def test_argv_overlay_home_bind_appended_after_home_raw_arg(tmp_path: Path) -> None:
+    # Arrange — order matters: the bind must come AFTER the raw-arg
+    # --home so apptainer applies it over the home tmpfs (verified via
+    # `mount`: a late --bind wins over the --home tmpfs).
+    rt = ApptainerContainerRuntime()
+    overlay_dir = tmp_path / "overlay"
+    upper_home = overlay_dir / "upper" / "home" / "agent"
+    upper_home.mkdir(parents=True, exist_ok=True)
+    cfg = _config(tmp_path / "wd")
+    cfg.apptainer = ApptainerSpec(
+        relaxed=True,
+        raw_args=[
+            "--containall",
+            "--home",
+            "/home/agent",
+            "--overlay",
+            str(overlay_dir),
+        ],
+    )
+    # Act
+    argv = rt.build_run_argv(
+        cfg, state_dir=tmp_path / "state", sif_path=tmp_path / "x.sif"
+    )
+    # Assert
+    home_idx = argv.index("--home")
+    upper_bind = f"{upper_home}:/home/agent"
+    bind_value_idx = argv.index(upper_bind)
+    assert bind_value_idx > home_idx
+
+
+def test_argv_no_overlay_home_bind_without_overlay(tmp_path: Path) -> None:
+    # Arrange — a relaxed spec WITHOUT an overlay must not get the
+    # upper-home bind (resolver returns None → no-op).
+    rt = ApptainerContainerRuntime()
+    cfg = _config(tmp_path / "wd")
+    cfg.apptainer = ApptainerSpec(
+        relaxed=True, raw_args=["--containall", "--home", "/home/agent"]
+    )
+    # Act
+    argv = rt.build_run_argv(
+        cfg, state_dir=tmp_path / "state", sif_path=tmp_path / "x.sif"
+    )
+    # Assert — no bind whose target is /home/agent originating from an overlay upper.
+    bind_idxs = [i for i, a in enumerate(argv) if a == "--bind"]
+    binds = [argv[i + 1] for i in bind_idxs]
+    assert not any("/overlay/upper/home/agent:/home/agent" in b for b in binds)
+
+
 def test_argv_runs_runner_module_via_tini(tmp_path: Path) -> None:
     # Arrange — use startup_prompts (claude mission). startup_commands
     # now wraps the inner argv in bash -lc, so the runner is no longer


### PR DESCRIPTION
## Problem

Relaxed apptainer specs (`apptainer.relaxed: true`) declare
`--containall --home /home/agent --overlay <dir>` in `raw_args`.
`deploy_to_home_overlay` materialises the `to_home` tree into
`<overlay>/upper/<container_home>/`, expecting it to surface at the
container `$HOME`.

It does not. The raw-arg `--home /home/agent` makes apptainer mount a
**fresh tmpfs** at that path (verified via `mount` inside a live
container: `tmpfs on /home/agent type tmpfs ...`), which **shadows** the
overlay's upper-home. Result: `$HOME/.mcp.json`, `$HOME/CLAUDE.md`,
`$HOME/.claude/` are all silently absent in the container.

Downstream impact: the SDK runner's `merge_home_mcp_servers` (#182) reads
an empty `$HOME/.mcp.json`, so a per-agent MCP declared via
`to_home/.mcp.json` (e.g. an agent's own `claude-code-telegrammer` bot)
never reaches `ClaudeAgentOptions.mcp_servers`. The bot never starts,
never polls Telegram, never replies. This is the
`proj-paper-scitex-clew` @ProjPaperSciTeXClewBot symptom.

## Root cause evidence

Inside the running clew container (current code):
```
$ ls /home/agent/.mcp.json          → No such file or directory
$ python3 -c "merge_home_mcp_servers({})" → {}
$ mount | grep agent                → tmpfs on /home/agent ...
```
The overlay upper-home `<overlay>/upper/home/agent/.mcp.json` exists on
the host but is shadowed by the `--home` tmpfs.

## Fix

In `ApptainerContainerRuntime.build_run_argv`, after appending
`raw_args`, bind the materialised upper-home **over** the container HOME:
`--bind <overlay>/upper/<container_home>:<container_home>`. Appended after
`raw_args` so it wins over the `--home` tmpfs (apptainer applies user
binds after home setup). No-op for non-relaxed / non-directory-overlay
specs (resolver returns `None`) and when the upper-home wasn't
materialised.

## Verification (end-to-end, in the real clew container)

With the fix's bind added:
```
$ merge_home_mcp_servers({})  → {'claude-code-telegrammer': {...}}
telegrammer wired: True
```
Without it: `{}`. The standalone telegrammer MCP itself was confirmed
healthy (bun + node_modules + token all present; `polling as
@ProjPaperSciTeXClewBot` succeeds) — the ONLY gap was the shadowed
`$HOME/.mcp.json`.

## Tests

3 new regression tests in `test__apptainer_runtime.py`:
- bind exists targeting the container HOME
- bind is appended *after* the `--home` raw-arg (order matters)
- no bind when the spec has no overlay

Full `tests/.../runtimes/` suite: 588 passed.

## Scope note

This affects **every** relaxed + directory-overlay spec, not just clew —
all `to_home` content (CLAUDE.md, .claude/hooks, .claude/skills, .mcp.json)
has been silently shadowed for these specs. (Credentials still work
because they use the separate `CLAUDE_CONFIG_DIR` bind, not `$HOME`.)
