### PR TITLE
feat(channels): wake idle session on server:claude-code-telegrammer push

### DIFF
--- a/src/scitex_agent_container/runtimes/_sdk_channels.py
+++ b/src/scitex_agent_container/runtimes/_sdk_channels.py
@@ -155,3 +155,61 @@ def apply_channels(
                 "command": "sac",
                 "args": sidecar_args,
             }
+
+    _wire_telegrammer_wake(kwargs, channels, a2a_port)
+
+
+# Channel name for the standalone claude-code-telegrammer MCP a per-agent
+# bot rides on (its backing MCP comes from the agent's to_home/.mcp.json,
+# keyed ``claude-code-telegrammer``).
+_TELEGRAMMER_CHANNEL = "server:claude-code-telegrammer"
+_TELEGRAMMER_MCP_KEY = "claude-code-telegrammer"
+# Env var the telegrammer poller reads to enable wake-on-push (POST inbound
+# to the agent's own /v1/turn). See claude-code-telegrammer ts/lib/wake.ts.
+_TELEGRAMMER_TURN_URL_ENV = "CLAUDE_CODE_TELEGRAMMER_TURN_URL"
+
+
+def _wire_telegrammer_wake(
+    kwargs: dict,
+    channels: list[str],
+    a2a_port: int | None,
+) -> None:
+    """Concern (c): wake-on-push for the ``server:claude-code-telegrammer``
+    channel — symmetric with the ``server:sac`` ``--turn-url`` above.
+
+    The telegrammer MCP (an agent's OWN Telegram bot, backed by the spec's
+    ``to_home/.mcp.json``) only emits ``notifications/claude/channel``. That
+    renders ``<channel>`` for an ACTIVE turn but does NOT advance an IDLE
+    SDK-runner session — the same limitation the ``sac mcp channel``
+    ``--turn-url`` removes for ``server:sac``. Inbound messages then pile up
+    unread (the "store fills, no turn appears" silent-failure class).
+
+    Fix: inject ``CLAUDE_CODE_TELEGRAMMER_TURN_URL`` into the telegrammer MCP
+    entry's env, pointing at the agent's own loopback ``/v1/turn``. The
+    telegrammer poller (ts/lib/wake.ts) then POSTs each inbound message there
+    and the runner drives a turn at once (push ≡ the lead's Telegram channel).
+
+    Gated: only when the channel set requests the telegrammer channel, the
+    merged ``mcp_servers`` actually carries the backing entry, and the runner
+    has an ``a2a_port`` (so a ``/v1/turn`` endpoint exists). No-op otherwise —
+    e.g. an interactive CLI with no a2a port keeps the notification-only path.
+    Never overrides an explicit operator-set TURN_URL in the spec.
+    """
+    if not any(c.strip() == _TELEGRAMMER_CHANNEL for c in channels):
+        return
+    if a2a_port is None:
+        return
+    mcps = kwargs.get("mcp_servers")
+    if not isinstance(mcps, dict):
+        return
+    entry = mcps.get(_TELEGRAMMER_MCP_KEY)
+    if not isinstance(entry, dict):
+        return
+    env = entry.setdefault("env", {})
+    if not isinstance(env, dict):
+        return
+    # Operator-set value wins (explicit > inferred).
+    env.setdefault(
+        _TELEGRAMMER_TURN_URL_ENV,
+        f"http://127.0.0.1:{int(a2a_port)}/v1/turn",
+    )

--- a/tests/scitex_agent_container/runtimes/test__sdk_channels.py
+++ b/tests/scitex_agent_container/runtimes/test__sdk_channels.py
@@ -101,6 +101,74 @@ class TestForeignChannelTurnsOnDevChannels:
         assert "sac" not in kwargs.get("mcp_servers", {})
 
 
+class TestTelegrammerWakeWiring:
+    """Concern (c): inject CLAUDE_CODE_TELEGRAMMER_TURN_URL so the agent's own
+    telegrammer bot WAKES an idle SDK session (symmetric with server:sac)."""
+
+    def _kwargs_with_telegrammer_mcp(self) -> dict:
+        return {
+            "mcp_servers": {
+                "claude-code-telegrammer": {
+                    "type": "stdio",
+                    "command": "bash",
+                    "args": ["-c", "exec bun run telegram-server.ts"],
+                    "env": {"CLAUDE_CODE_TELEGRAMMER_TELEGRAM_AGENT_ID": "clew"},
+                }
+            }
+        }
+
+    def test_turn_url_injected_into_telegrammer_env(self):
+        # Arrange
+        kwargs = self._kwargs_with_telegrammer_mcp()
+        # Act
+        apply_channels(kwargs, ["server:claude-code-telegrammer"], 19007, "clew")
+        # Assert
+        env = kwargs["mcp_servers"]["claude-code-telegrammer"]["env"]
+        assert env["CLAUDE_CODE_TELEGRAMMER_TURN_URL"] == (
+            "http://127.0.0.1:19007/v1/turn"
+        )
+
+    def test_no_turn_url_when_a2a_port_missing(self):
+        # Arrange
+        kwargs = self._kwargs_with_telegrammer_mcp()
+        # Act
+        apply_channels(kwargs, ["server:claude-code-telegrammer"], None, "clew")
+        # Assert
+        env = kwargs["mcp_servers"]["claude-code-telegrammer"]["env"]
+        assert "CLAUDE_CODE_TELEGRAMMER_TURN_URL" not in env
+
+    def test_operator_set_turn_url_is_preserved(self):
+        # Arrange
+        kwargs = self._kwargs_with_telegrammer_mcp()
+        kwargs["mcp_servers"]["claude-code-telegrammer"]["env"][
+            "CLAUDE_CODE_TELEGRAMMER_TURN_URL"
+        ] = "http://operator.example/v1/turn"
+        # Act
+        apply_channels(kwargs, ["server:claude-code-telegrammer"], 19007, "clew")
+        # Assert
+        env = kwargs["mcp_servers"]["claude-code-telegrammer"]["env"]
+        assert env["CLAUDE_CODE_TELEGRAMMER_TURN_URL"] == (
+            "http://operator.example/v1/turn"
+        )
+
+    def test_no_injection_without_telegrammer_channel(self):
+        # Arrange
+        kwargs = self._kwargs_with_telegrammer_mcp()
+        # Act — channel not requested, only the MCP entry present
+        apply_channels(kwargs, ["server:sac"], 19007, "clew")
+        # Assert
+        env = kwargs["mcp_servers"]["claude-code-telegrammer"]["env"]
+        assert "CLAUDE_CODE_TELEGRAMMER_TURN_URL" not in env
+
+    def test_no_crash_when_telegrammer_mcp_absent(self):
+        # Arrange — channel requested but no backing MCP entry merged
+        kwargs: dict = {"mcp_servers": {}}
+        # Act
+        apply_channels(kwargs, ["server:claude-code-telegrammer"], 19007, "clew")
+        # Assert
+        assert "claude-code-telegrammer" not in kwargs["mcp_servers"]
+
+
 class TestSacChannelStillWorks:
     """``server:sac`` keeps both the dev flag and the sidecar registration."""
 


### PR DESCRIPTION
## Problem (proj-paper-scitex-clew bot — end-to-end debug, post-#183)

After PR #183 fixed the overlay-home tmpfs shadow, the clew agent's own
Telegram bot still gets NO reply. Verified against the live container +
runtime source:

- `.mcp.json` IS visible in `/home/agent` (the #183 bind wins despite the
  "destination already in mount point list" warning — `/proc/mounts` shows
  both the tmpfs and the overlay-upper ext4, last-mount-shadows).
- The telegrammer bun MCP IS loaded by the SDK (`--mcp-config` carries it)
  and IS polling — `messages.db` has 4 inbound rows.
- BUT all 4 rows have `read_at`/`replied_at` = NULL, and `session.jsonl`
  shows zero turns driven from a Telegram message. **Inbound → turn is the
  gap.**

Root cause: the telegrammer's only inbound path is
`notifications/claude/channel`, which renders `<channel>` for an ACTIVE
turn but does NOT advance an IDLE SDK-runner session. The runner
(`_session_conversation.py`) is strictly inbox-driven — turns arrive only
via `/v1/turn`. `server:sac` solves this with the `sac mcp channel`
`--turn-url` wake (`_mcp/_channel_wake.py::_wake_turn`); the foreign
telegrammer channel had **no equivalent wake**, so notifications die on an
idle session.

## Fix (sac side — the wiring half)

`apply_channels` now injects `CLAUDE_CODE_TELEGRAMMER_TURN_URL` into the
merged telegrammer MCP entry's env (the agent's own loopback `/v1/turn`)
when the channel set requests `server:claude-code-telegrammer`, the merged
`mcp_servers` carries the backing entry, and the runner has an `a2a_port`.
Symmetric with the existing `server:sac` sidecar `--turn-url` block.
Operator-set `TURN_URL` wins (`setdefault`). No-op otherwise.

The receiving half (the telegrammer poller actually POSTing to that URL) is
**claude-code-telegrammer PR #16** — both must land for the bot to reply.

## Test plan

- `_sdk_channels` tests: 21 pass (+5: inject / no-a2a-port / operator-override
  / wrong-channel / absent-entry).
- Full `tests/.../runtimes/` suite: 593 pass.

## Why two PRs

The wake mechanism is fundamentally cross-repo: the poller (telegrammer) is
the only process that sees the inbound message and must POST it; sac's job
is to hand it the right `/v1/turn`. PR #16 (telegrammer) adds the POST;
this PR hands it the URL. Neither alone makes the bot reply.

Not auto-merged — for lead review.