### PR TITLE
feat(drift): spec-source git-drift detection (launch-time + sac doctor --fleet)

### DIFF
--- a/src/scitex_agent_container/_drift/__init__.py
+++ b/src/scitex_agent_container/_drift/__init__.py
@@ -1,0 +1,39 @@
+"""Agent-spec source drift detection (sac-drift).
+
+Two surfaces:
+
+* :mod:`._local` — launch-time check that the LOCAL host's agent-spec
+  source git repo is current with its remote. Wired into
+  ``sac agents start`` so a stale (or unpushed) spec source produces a
+  loud warning before the agent boots. Fast (cached ``git fetch``) and
+  resilient (never crashes a launch).
+* :mod:`._fleet` — on-demand ``sac doctor --fleet`` that ssh-checks the
+  same drift on every configured peer host and renders a per-host table.
+
+The shared drift model lives in :mod:`._status`.
+"""
+
+from __future__ import annotations
+
+from ._fleet import HostDrift, check_fleet_drift, check_peer_drift
+from ._local import (
+    SpecSourceDriftError,
+    check_spec_source_drift,
+    drift_warning_lines,
+    spec_source_repo,
+    warn_if_spec_source_drifted,
+)
+from ._status import DriftState, DriftStatus
+
+__all__ = [
+    "DriftState",
+    "DriftStatus",
+    "HostDrift",
+    "SpecSourceDriftError",
+    "check_fleet_drift",
+    "check_peer_drift",
+    "check_spec_source_drift",
+    "drift_warning_lines",
+    "spec_source_repo",
+    "warn_if_spec_source_drifted",
+]

--- a/src/scitex_agent_container/_drift/_fleet.py
+++ b/src/scitex_agent_container/_drift/_fleet.py
@@ -1,0 +1,238 @@
+"""Fleet-wide spec-source drift check for ``sac doctor --fleet``.
+
+For each configured peer host (from ``config.yaml``'s ``peers:`` block)
+this ssh-runs the SAME git-drift comparison the launch-time local check
+does, against the peer's own agent-spec source repo, and collects a
+:class:`DriftStatus` per host. The CLI layer renders a per-host table.
+
+The remote check is a single self-contained POSIX-sh snippet (no
+dependency on the peer's sac version): it resolves the agents dir,
+asks git for the toplevel + upstream, and prints a one-line
+``DRIFT <state> <ahead> <behind> <upstream>`` marker the local side
+parses back into a :class:`DriftStatus`. Unreachable / non-git / no-
+upstream peers degrade to UNREACHABLE / NOT_A_REPO — never an exception.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+
+from .._state.host_config import PeerSpec, build_ssh_argv
+from ._status import DriftState, DriftStatus
+
+# Remote agents-dir path. On fleet hosts this symlinks into the dotfiles
+# checkout; ``git -C`` follows it to the real repo. ``$HOME`` is expanded
+# by the remote shell. Honour SCITEX_DIR for relocated user-state roots.
+_REMOTE_AGENTS_REL = ".scitex/agent-container/agents"
+
+# Marker the remote snippet prints; parsed back on the local side.
+_MARKER = "SAC_DRIFT"
+
+# POSIX-sh that runs on the peer. Resolves the agents dir, finds the git
+# toplevel, compares HEAD against @{upstream} after a fetch, and prints
+# exactly one ``SAC_DRIFT <state> <ahead> <behind> <upstream>`` line.
+# Every failure path prints a marker line too (never silent) so the
+# local parser always has something to read.
+_REMOTE_SNIPPET = r"""
+set -u
+base="${SCITEX_DIR:-$HOME/.scitex}"
+dir="$base/agent-container/agents"
+if [ ! -e "$dir" ]; then dir="$HOME/.scitex/agent-container/agents"; fi
+if ! command -v git >/dev/null 2>&1; then
+  echo "SAC_DRIFT not-a-repo 0 0 - (git unavailable)"; exit 0
+fi
+top=$(git -C "$dir" rev-parse --show-toplevel 2>/dev/null)
+if [ -z "$top" ]; then
+  echo "SAC_DRIFT not-a-repo 0 0 - (spec source not in a git repo)"; exit 0
+fi
+up=$(git -C "$top" rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null)
+if [ -z "$up" ]; then
+  echo "SAC_DRIFT unreachable 0 0 - (no upstream configured)"; exit 0
+fi
+if ! git -C "$top" fetch --quiet 2>/dev/null; then
+  echo "SAC_DRIFT unreachable 0 0 $up (fetch failed)"; exit 0
+fi
+ahead=$(git -C "$top" rev-list --count "$up..HEAD" 2>/dev/null)
+behind=$(git -C "$top" rev-list --count "HEAD..$up" 2>/dev/null)
+if [ -z "$ahead" ] || [ -z "$behind" ]; then
+  echo "SAC_DRIFT unreachable 0 0 $up (compare failed)"; exit 0
+fi
+if [ "$ahead" -gt 0 ] && [ "$behind" -gt 0 ]; then st=diverged
+elif [ "$behind" -gt 0 ]; then st=behind
+elif [ "$ahead" -gt 0 ]; then st=ahead
+else st=current; fi
+echo "SAC_DRIFT $st $ahead $behind $up"
+"""
+
+
+@dataclass(frozen=True)
+class HostDrift:
+    """One peer's drift verdict for the fleet table."""
+
+    host: str
+    status: DriftStatus
+
+    def to_dict(self) -> dict:
+        d = {"host": self.host}
+        d.update(self.status.to_dict())
+        return d
+
+
+def _parse_marker(line: str) -> DriftStatus:
+    """Parse a ``SAC_DRIFT <state> <ahead> <behind> <upstream> [detail]`` line.
+
+    Anything unparseable degrades to UNREACHABLE with the raw line as
+    detail — the local side never raises on remote output.
+    """
+    parts = line.strip().split(None, 5)
+    if len(parts) < 5 or parts[0] != _MARKER:
+        return DriftStatus(
+            state=DriftState.UNREACHABLE,
+            detail=f"unparseable remote output: {line.strip()[:120]!r}",
+        )
+    _marker, state_raw, ahead_raw, behind_raw, upstream = parts[:5]
+    detail = parts[5].strip("() ") if len(parts) == 6 else ""
+    try:
+        ahead = int(ahead_raw)
+        behind = int(behind_raw)
+    except (
+        ValueError
+    ):  # stx-allow: fallback (reason: malformed remote counts → treat as unknown drift)
+        return DriftStatus(
+            state=DriftState.UNREACHABLE,
+            detail=f"non-numeric remote counts: {line.strip()[:120]!r}",
+        )
+    try:
+        state = DriftState(state_raw)
+    except ValueError:  # stx-allow: fallback (reason: unknown state token from a future/older peer → unknown drift)
+        return DriftStatus(
+            state=DriftState.UNREACHABLE,
+            detail=f"unknown remote state {state_raw!r}",
+        )
+    upstream_clean = "" if upstream == "-" else upstream
+    return DriftStatus(
+        state=state,
+        ahead=ahead,
+        behind=behind,
+        upstream=upstream_clean,
+        detail=detail,
+    )
+
+
+def _extract_marker_line(stdout: str) -> str | None:
+    """Return the last ``SAC_DRIFT`` line in ``stdout`` (or None).
+
+    The peer's login shell may emit motd / rc noise before our marker;
+    scan for the marker line specifically rather than trusting the
+    whole stdout to be just our echo.
+    """
+    found = None
+    for ln in stdout.splitlines():
+        if ln.strip().startswith(_MARKER + " "):
+            found = ln
+    return found
+
+
+def check_peer_drift(
+    peer_name: str,
+    peers: dict[str, PeerSpec],
+    *,
+    timeout: int = 30,
+    runner=subprocess.run,
+) -> HostDrift:
+    """ssh ``peer_name`` and run the remote drift snippet; never raises.
+
+    Args:
+        peer_name: peer key from config.yaml's ``peers:`` block.
+        peers: the parsed peers map (for ssh argv + ProxyJump chain).
+        timeout: ssh wall-clock cap; a hung peer maps to UNREACHABLE.
+        runner: injectable ``subprocess.run``-shaped callable (real;
+            tests pass a real callable so no mocks are used).
+
+    Returns:
+        A :class:`HostDrift`. Unreachable / non-git / no-upstream peers
+        all degrade gracefully — the fleet check never crashes on one
+        bad host.
+    """
+    try:
+        ssh_argv = build_ssh_argv(
+            peer_name,
+            ["sh", "-c", _REMOTE_SNIPPET],
+            peers,
+            extra_opts=["-o", f"ConnectTimeout={min(timeout, 15)}"],
+        )
+    except KeyError:
+        return HostDrift(
+            host=peer_name,
+            status=DriftStatus(
+                state=DriftState.UNREACHABLE,
+                detail="peer not defined in config.yaml",
+            ),
+        )
+    try:
+        proc = runner(
+            ssh_argv,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return HostDrift(
+            host=peer_name,
+            status=DriftStatus(
+                state=DriftState.UNREACHABLE, detail=f"ssh timed out after {timeout}s"
+            ),
+        )
+    except (
+        FileNotFoundError,
+        OSError,
+        subprocess.SubprocessError,
+    ) as exc:  # stx-allow: fallback (reason: ssh missing / spawn error → unreachable, never crash the fleet check)
+        return HostDrift(
+            host=peer_name,
+            status=DriftStatus(
+                state=DriftState.UNREACHABLE,
+                detail=f"ssh failed: {type(exc).__name__}",
+            ),
+        )
+    marker = _extract_marker_line(proc.stdout or "")
+    if marker is None:
+        stderr_tail = (proc.stderr or "").strip().splitlines()[-1:] or [""]
+        return HostDrift(
+            host=peer_name,
+            status=DriftStatus(
+                state=DriftState.UNREACHABLE,
+                detail=(
+                    f"no drift marker in remote output (exit {proc.returncode}): "
+                    f"{stderr_tail[0][:120]}"
+                ),
+            ),
+        )
+    return HostDrift(host=peer_name, status=_parse_marker(marker))
+
+
+def check_fleet_drift(
+    peers: dict[str, PeerSpec],
+    *,
+    timeout: int = 30,
+    runner=subprocess.run,
+) -> list[HostDrift]:
+    """Check every peer's spec-source drift; return one row per peer.
+
+    Serial ssh round-trips (fleets are small; parallelism is a future
+    optimization, not a correctness concern). Order matches the sorted
+    peer names for a stable table.
+    """
+    rows: list[HostDrift] = []
+    for name in sorted(peers):
+        rows.append(check_peer_drift(name, peers, timeout=timeout, runner=runner))
+    return rows
+
+
+__all__ = [
+    "HostDrift",
+    "check_fleet_drift",
+    "check_peer_drift",
+]

--- a/src/scitex_agent_container/_drift/_local.py
+++ b/src/scitex_agent_container/_drift/_local.py
@@ -1,0 +1,400 @@
+"""Launch-time LOCAL spec-source drift check.
+
+When ``sac agents start`` (or any lifecycle path that loads a spec)
+runs, the agent's spec.yaml may have come from a git-tracked source
+directory — on these hosts ``~/.scitex/agent-container/agents`` is a
+symlink into ``~/.dotfiles/src/.scitex/...``. If that source repo is
+stale (behind its remote) or has unpushed local commits (ahead /
+diverged), the agent might run an old spec or have a spec that never
+propagates to other hosts.
+
+This module compares the spec source's git working tree against its
+upstream tracking branch and returns a :class:`DriftStatus`.
+
+Design constraints (per the work item):
+
+* **FAST** — a single ``git fetch`` per repo, cached for
+  ``_FETCH_TTL_S`` seconds so repeated launches don't pay the network
+  cost. The rev-list compare itself is local + instant.
+* **RESILIENT** — never raises. A missing git binary, a
+  non-repo source dir, an unreachable remote, or any subprocess error
+  degrades to ``NOT_A_REPO`` / ``UNREACHABLE`` and the launch proceeds.
+* **DEFAULT = warn loud, NOT block** — hosts like spartan legitimately
+  carry local commits; a hard block would break every start there.
+  ``--strict-drift`` / ``SAC_STRICT_DRIFT=1`` escalate to a hard block.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+from ._status import DriftState, DriftStatus
+
+# How long a successful ``git fetch`` for a given repo stays "fresh".
+# Repeated ``sac agents start`` within this window skip the network
+# round-trip and reuse the cached fetch. Keeps the hot path cheap.
+_FETCH_TTL_S = 60
+
+# Per-git-subprocess wall-clock cap. ``git fetch`` against an
+# unreachable remote must not hang a launch; we bound it and treat a
+# timeout as UNREACHABLE.
+_GIT_TIMEOUT_S = 15
+
+
+def _run_git(repo: Path, *args: str, timeout: int = _GIT_TIMEOUT_S):
+    """Run ``git -C <repo> <args>``; return the CompletedProcess.
+
+    Real subprocess (no mocks). Tests install a ``git`` shim on PATH or
+    operate on a real ``git init`` repo. Never raises — a missing git
+    binary or a timeout is surfaced via the return value.
+    """
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def spec_source_repo(spec_path: str | Path) -> Path | None:
+    """Return the git working-tree root that contains ``spec_path``.
+
+    Resolves the path first (so a symlinked
+    ``~/.scitex/agent-container/agents`` is followed into the real
+    ``~/.dotfiles/...`` checkout) and asks git for the toplevel. Returns
+    ``None`` when the path is not inside a git working tree or git is
+    unavailable.
+    """
+    p = Path(spec_path)
+    # Resolve through symlinks so ``git -C`` sees the real checkout, not
+    # the symlink-into-dotfiles. ``strict=False`` tolerates a path that
+    # doesn't fully exist yet (defensive — caller passes a real file).
+    try:
+        resolved = p.resolve()
+    except OSError:  # stx-allow: fallback (reason: a broken symlink in the spec path must degrade to "no repo", never crash the launch)
+        return None
+    start = resolved if resolved.is_dir() else resolved.parent
+    try:
+        proc = _run_git(start, "rev-parse", "--show-toplevel", timeout=5)
+    except (
+        FileNotFoundError,
+        OSError,
+        subprocess.SubprocessError,
+    ):  # stx-allow: fallback (reason: git missing / unusable → no repo, warn-and-continue)
+        return None
+    if proc.returncode != 0:
+        return None
+    top = proc.stdout.strip()
+    return Path(top) if top else None
+
+
+def _upstream_ref(repo: Path) -> str | None:
+    """Return the upstream tracking ref of the current branch, or None.
+
+    e.g. ``origin/develop``. ``None`` when no upstream is configured —
+    a detached HEAD or a branch with no ``@{upstream}`` — in which case
+    drift is undefined and we report UNREACHABLE.
+    """
+    try:
+        proc = _run_git(
+            repo,
+            "rev-parse",
+            "--abbrev-ref",
+            "--symbolic-full-name",
+            "@{upstream}",
+            timeout=5,
+        )
+    except (
+        FileNotFoundError,
+        OSError,
+        subprocess.SubprocessError,
+    ):  # stx-allow: fallback (reason: git unusable → treat as no upstream, warn-and-continue)
+        return None
+    if proc.returncode != 0:
+        return None
+    ref = proc.stdout.strip()
+    return ref or None
+
+
+def _fetch_cache_path() -> Path:
+    """Host-stable cache file for last-fetch timestamps per repo.
+
+    Uses the user-scope runtime dir (NOT project-scope) so the cache is
+    one-per-host regardless of which project directory the launch was
+    invoked from.
+    """
+    # Import lazily so a missing scitex_config (optional dep elsewhere)
+    # never breaks module import; sac depends on it but be defensive.
+    from scitex_config._ecosystem import local_state
+
+    return local_state.user_path("agent-container", "runtime", "drift-fetch.json")
+
+
+def _load_fetch_cache(cache_path: Path) -> dict:
+    """Read the per-repo last-fetch timestamp map; {} on any problem."""
+    if not cache_path.exists():
+        return {}
+    try:
+        data = json.loads(cache_path.read_text())
+    except (
+        OSError,
+        ValueError,
+    ):  # stx-allow: fallback (reason: a corrupt cache must not break drift detection; treat as empty)
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _save_fetch_cache(cache_path: Path, data: dict) -> None:
+    """Persist the last-fetch timestamp map; swallow write errors."""
+    try:
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache_path.write_text(json.dumps(data, indent=2))
+    except OSError:  # stx-allow: fallback (reason: read-only home / disk-full must not break a launch — the only cost is re-fetching next time)
+        pass
+
+
+def _maybe_fetch(repo: Path, *, now: float, ttl: int) -> bool:
+    """Run ``git fetch`` for ``repo`` unless fetched within ``ttl`` seconds.
+
+    Returns True when the remote is reachable (a fresh-cached fetch
+    counts as reachable). Returns False when a fetch was attempted and
+    failed (unreachable remote / timeout) — the caller maps that to
+    UNREACHABLE. The cache is keyed on the resolved repo path.
+    """
+    cache_path = _fetch_cache_path()
+    cache = _load_fetch_cache(cache_path)
+    key = str(repo)
+    last = cache.get(key)
+    if isinstance(last, (int, float)) and (now - last) < ttl:
+        return True  # fetched recently — assume still reachable
+    try:
+        proc = _run_git(repo, "fetch", "--quiet")
+    except subprocess.TimeoutExpired:
+        return False
+    except (
+        FileNotFoundError,
+        OSError,
+        subprocess.SubprocessError,
+    ):  # stx-allow: fallback (reason: git missing / unusable → unreachable, warn-and-continue)
+        return False
+    if proc.returncode != 0:
+        return False
+    cache[key] = now
+    _save_fetch_cache(cache_path, cache)
+    return True
+
+
+def _count_rev_list(repo: Path, range_spec: str) -> int | None:
+    """Return ``git rev-list --count <range_spec>`` as an int, or None."""
+    try:
+        proc = _run_git(repo, "rev-list", "--count", range_spec, timeout=5)
+    except (
+        FileNotFoundError,
+        OSError,
+        subprocess.SubprocessError,
+    ):  # stx-allow: fallback (reason: git unusable → cannot count, caller maps to UNREACHABLE)
+        return None
+    if proc.returncode != 0:
+        return None
+    out = proc.stdout.strip()
+    try:
+        return int(out)
+    except ValueError:  # stx-allow: fallback (reason: non-numeric git output is malformed; treat as uncountable)
+        return None
+
+
+def check_spec_source_drift(
+    spec_path: str | Path,
+    *,
+    do_fetch: bool = True,
+    ttl: int = _FETCH_TTL_S,
+    now_fn=time.time,
+) -> DriftStatus:
+    """Compute the drift of the git repo that contains ``spec_path``.
+
+    Args:
+        spec_path: Path to the agent spec.yaml (or its directory).
+        do_fetch: When True (default) refresh the remote via a cached
+            ``git fetch`` before comparing. Set False to compare against
+            whatever the local repo already knows (used by the fleet
+            check, which does its own remote refresh).
+        ttl: Seconds a successful fetch stays fresh before re-fetching.
+        now_fn: Injectable clock (real ``time.time``); tests pass a
+            real callable returning a fixed value to exercise the TTL
+            without sleeping.
+
+    Returns:
+        A :class:`DriftStatus`. NEVER raises — every failure mode maps
+        to NOT_A_REPO or UNREACHABLE so a launch is never crashed.
+    """
+    repo = spec_source_repo(spec_path)
+    if repo is None:
+        return DriftStatus(
+            state=DriftState.NOT_A_REPO,
+            detail="spec source is not inside a git working tree",
+        )
+    upstream = _upstream_ref(repo)
+    if upstream is None:
+        return DriftStatus(
+            state=DriftState.UNREACHABLE,
+            repo=str(repo),
+            detail="no upstream tracking branch configured",
+        )
+    if do_fetch and not _maybe_fetch(repo, now=now_fn(), ttl=ttl):
+        return DriftStatus(
+            state=DriftState.UNREACHABLE,
+            repo=str(repo),
+            upstream=upstream,
+            detail="git fetch failed (offline / auth / timeout)",
+        )
+    behind = _count_rev_list(repo, f"HEAD..{upstream}")
+    ahead = _count_rev_list(repo, f"{upstream}..HEAD")
+    if behind is None or ahead is None:
+        return DriftStatus(
+            state=DriftState.UNREACHABLE,
+            repo=str(repo),
+            upstream=upstream,
+            detail="could not compare HEAD with upstream",
+        )
+    if behind and ahead:
+        state = DriftState.DIVERGED
+    elif behind:
+        state = DriftState.BEHIND
+    elif ahead:
+        state = DriftState.AHEAD
+    else:
+        state = DriftState.CURRENT
+    return DriftStatus(
+        state=state,
+        behind=behind,
+        ahead=ahead,
+        repo=str(repo),
+        upstream=upstream,
+    )
+
+
+def drift_warning_lines(status: DriftStatus, *, agent: str | None = None) -> list[str]:
+    """Build the loud stderr warning lines for a drifted spec source.
+
+    Returns an empty list when ``status`` is CURRENT (nothing to warn).
+    NOT_A_REPO / UNREACHABLE produce a single soft note (drift unknown).
+    BEHIND / AHEAD / DIVERGED produce a prominent banner that names the
+    drift and the exact fix command.
+    """
+    if status.state is DriftState.CURRENT:
+        return []
+
+    who = f" for agent '{agent}'" if agent else ""
+    if status.state in (DriftState.NOT_A_REPO, DriftState.UNREACHABLE):
+        return [
+            f"sac-drift: spec source{who} could not be drift-checked "
+            f"({status.summary()}). Continuing.",
+        ]
+
+    repo = status.repo or "<spec-source-repo>"
+    if status.state is DriftState.BEHIND:
+        fix = f"git -C {repo} pull --ff-only"
+        why = (
+            f"the spec source is {status.behind} commit(s) BEHIND "
+            f"{status.upstream} — you may be launching a STALE spec."
+        )
+    elif status.state is DriftState.AHEAD:
+        fix = f"git -C {repo} push"
+        why = (
+            f"the spec source has {status.ahead} unpushed local commit(s) "
+            f"(AHEAD of {status.upstream}) — this spec will NOT propagate "
+            "to other hosts until pushed."
+        )
+    else:  # DIVERGED
+        fix = f"git -C {repo} pull --ff-only   # then resolve, then  git -C {repo} push"
+        why = (
+            f"the spec source has DIVERGED from {status.upstream} "
+            f"({status.ahead} ahead / {status.behind} behind) — it is both "
+            "stale AND unpushed."
+        )
+    bar = "!" * 72
+    return [
+        bar,
+        f"sac-drift WARNING{who}:",
+        f"  {why}",
+        f"  repo:     {repo}",
+        f"  fix:      {fix}",
+        bar,
+    ]
+
+
+def warn_if_spec_source_drifted(
+    spec_path: str | Path,
+    *,
+    agent: str | None = None,
+    strict: bool = False,
+    do_fetch: bool = True,
+    stream=None,
+) -> DriftStatus:
+    """Check + emit the launch-time drift warning to ``stream``.
+
+    Always returns the computed :class:`DriftStatus`. When ``strict`` is
+    True AND the source is genuinely drifted (BEHIND / AHEAD / DIVERGED),
+    raises :class:`SpecSourceDriftError` so the caller can hard-block the
+    launch. NOT_A_REPO / UNREACHABLE never block, even under strict —
+    drift is *unknown* there, not present.
+
+    ``stream`` defaults to ``None`` and is resolved to ``sys.stderr`` at
+    CALL time (not import time) so a test's ``capsys`` / a runtime
+    stderr redirect is honoured. Pass an explicit stream to override.
+
+    NEVER raises for any reason other than the deliberate strict-mode
+    block: the drift computation itself is fully guarded.
+    """
+    if stream is None:
+        stream = sys.stderr
+    # stx-allow: fallback (reason: the drift check is a best-effort guard;
+    # an unforeseen bug in it must NEVER crash a launch — degrade to a
+    # silent "unknown" status and let the agent start)
+    try:
+        status = check_spec_source_drift(spec_path, do_fetch=do_fetch)
+    except (
+        Exception
+    ) as exc:  # stx-allow: fallback (reason: see above — resilience is the contract)
+        status = DriftStatus(
+            state=DriftState.UNREACHABLE,
+            detail=f"drift check raised {type(exc).__name__}: {exc}",
+        )
+    lines = drift_warning_lines(status, agent=agent)
+    for line in lines:
+        print(line, file=stream, flush=True)
+    if strict and status.is_drifted:
+        raise SpecSourceDriftError(status, agent=agent)
+    return status
+
+
+class SpecSourceDriftError(RuntimeError):
+    """Raised under ``--strict-drift`` when the spec source is drifted.
+
+    Carries the offending :class:`DriftStatus` so the CLI layer can set
+    a clear non-zero exit. Only fires for BEHIND / AHEAD / DIVERGED —
+    NOT_A_REPO / UNREACHABLE never escalate.
+    """
+
+    def __init__(self, status: DriftStatus, *, agent: str | None = None):
+        self.status = status
+        self.agent = agent
+        who = f" for agent '{agent}'" if agent else ""
+        super().__init__(
+            f"strict-drift: spec source{who} is drifted ({status.summary()}); "
+            "refusing to launch. Resolve the drift or drop --strict-drift."
+        )
+
+
+__all__ = [
+    "SpecSourceDriftError",
+    "check_spec_source_drift",
+    "drift_warning_lines",
+    "spec_source_repo",
+    "warn_if_spec_source_drifted",
+]

--- a/src/scitex_agent_container/_drift/_status.py
+++ b/src/scitex_agent_container/_drift/_status.py
@@ -1,0 +1,102 @@
+"""Shared drift-status model for sac-drift.
+
+A :class:`DriftStatus` is the result of comparing a local git repo
+against its upstream tracking branch. Both the launch-time local check
+(:mod:`._local`) and the fleet ssh check (:mod:`._fleet`) speak this
+vocabulary so the table renderer and the warning formatter stay shared.
+"""
+
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass
+
+
+class DriftState(enum.Enum):
+    """The drift verdict for one spec-source git repo.
+
+    * ``CURRENT`` — local HEAD == upstream; nothing to do.
+    * ``BEHIND`` — upstream has commits the local repo lacks. The
+      running spec may be stale (an old version of the YAML).
+    * ``AHEAD`` — local has unpushed commits. The spec WON'T propagate
+      to other hosts until pushed.
+    * ``DIVERGED`` — both ahead AND behind. The most dangerous case:
+      stale *and* unpushed.
+    * ``NOT_A_REPO`` — the spec source isn't inside a git working tree
+      (or git is unavailable). Drift is undefined; warn-and-continue.
+    * ``UNREACHABLE`` — the remote could not be contacted (offline,
+      auth, no upstream configured). Drift is unknown; warn-and-continue.
+    """
+
+    CURRENT = "current"
+    BEHIND = "behind"
+    AHEAD = "ahead"
+    DIVERGED = "diverged"
+    NOT_A_REPO = "not-a-repo"
+    UNREACHABLE = "unreachable"
+
+
+@dataclass(frozen=True)
+class DriftStatus:
+    """Outcome of a drift check against one repo's upstream.
+
+    Attributes:
+        state: The :class:`DriftState` verdict.
+        behind: Commits upstream has that local lacks (0 unless BEHIND/DIVERGED).
+        ahead: Local commits not on upstream (0 unless AHEAD/DIVERGED).
+        repo: The git working-tree root that was checked (``""`` when NOT_A_REPO).
+        upstream: The upstream ref compared against (e.g. ``origin/develop``).
+        detail: Human-readable note for NOT_A_REPO / UNREACHABLE causes.
+    """
+
+    state: DriftState
+    behind: int = 0
+    ahead: int = 0
+    repo: str = ""
+    upstream: str = ""
+    detail: str = ""
+
+    @property
+    def is_drifted(self) -> bool:
+        """True when the repo is behind, ahead, or diverged.
+
+        NOT_A_REPO / UNREACHABLE are NOT drift — drift is *unknown*
+        there, not present. Callers that want "anything non-current"
+        should test ``state != DriftState.CURRENT`` instead.
+        """
+        return self.state in (
+            DriftState.BEHIND,
+            DriftState.AHEAD,
+            DriftState.DIVERGED,
+        )
+
+    def summary(self) -> str:
+        """One-line human summary of the drift verdict."""
+        if self.state is DriftState.CURRENT:
+            return "current"
+        if self.state is DriftState.BEHIND:
+            return f"{self.behind} behind {self.upstream}"
+        if self.state is DriftState.AHEAD:
+            return f"{self.ahead} ahead of {self.upstream} (unpushed)"
+        if self.state is DriftState.DIVERGED:
+            return (
+                f"diverged: {self.ahead} ahead / {self.behind} behind {self.upstream}"
+            )
+        if self.state is DriftState.NOT_A_REPO:
+            return f"not a git repo{(' — ' + self.detail) if self.detail else ''}"
+        return f"unreachable{(' — ' + self.detail) if self.detail else ''}"
+
+    def to_dict(self) -> dict:
+        """JSON-friendly projection (for ``--json`` surfaces)."""
+        return {
+            "state": self.state.value,
+            "behind": self.behind,
+            "ahead": self.ahead,
+            "repo": self.repo,
+            "upstream": self.upstream,
+            "detail": self.detail,
+            "summary": self.summary(),
+        }
+
+
+__all__ = ["DriftState", "DriftStatus"]

--- a/src/scitex_agent_container/_lifecycle/_start.py
+++ b/src/scitex_agent_container/_lifecycle/_start.py
@@ -23,6 +23,45 @@ from ._session_reset import _clear_persisted_session_id
 from .health import health_monitor
 
 
+def _resolve_strict_drift(strict_drift: bool | None) -> bool:
+    """Resolve effective strict-drift mode (arg wins, else env).
+
+    ``strict_drift=True/False`` from ``--strict-drift`` takes priority.
+    ``None`` falls back to ``SAC_STRICT_DRIFT`` (``1``/``true``/``yes``
+    → strict). Read through the sac env helper so either prefix works.
+    """
+    if strict_drift is not None:
+        return strict_drift
+    from .._env import getenv as _sac_env
+
+    raw = (_sac_env("STRICT_DRIFT", "") or "").strip().lower()
+    return raw in ("1", "true", "yes", "on")
+
+
+def _check_spec_source_drift_at_launch(
+    config_path: str, agent_name: str, strict_drift: bool | None
+) -> None:
+    """Run the launch-time drift check; warn loud (or block if strict).
+
+    Fully guarded: the underlying check never raises except the
+    deliberate strict-mode :class:`SpecSourceDriftError`. We let that
+    propagate (the CLI / caller turns it into a non-zero exit); any
+    other unexpected failure here is swallowed so a launch is never
+    crashed by the drift guard.
+    """
+    from .._drift import SpecSourceDriftError, warn_if_spec_source_drifted
+
+    strict = _resolve_strict_drift(strict_drift)
+    try:
+        warn_if_spec_source_drifted(config_path, agent=agent_name, strict=strict)
+    except SpecSourceDriftError:
+        # Deliberate strict-mode block — propagate so the caller exits
+        # non-zero. This is the ONE thing this guard is allowed to raise.
+        raise
+    except Exception:  # stx-allow: fallback (reason: the drift guard must NEVER crash a launch; any unexpected error degrades to "no check ran" and the agent proceeds)
+        traceback.print_exc()
+
+
 def agent_start(
     config_path: str,
     registry: Registry | None = None,
@@ -34,6 +73,7 @@ def agent_start(
     no_preflight: bool = False,
     foreground: bool = False,
     one_shot: bool = False,
+    strict_drift: bool | None = None,
     runtime_factory: Optional[Callable[[AgentConfig], Any]] = None,
     sleep_fn: Callable[[float], None] = time.sleep,
     thread_factory: Callable[..., Any] = threading.Thread,
@@ -52,6 +92,10 @@ def agent_start(
         foreground: Run the runtime in the foreground.
         one_shot: Run the startup prompts once and exit; requires
             ``spec.startup_prompts`` to be non-empty.
+        strict_drift: Escalate a drifted spec-source git repo from a
+            loud warning to a hard block (raise before launch). ``None``
+            (default) reads ``SAC_STRICT_DRIFT`` / ``--strict-drift`` is
+            not set; ``True`` forces strict, ``False`` forces lenient.
         runtime_factory: Injectable real callable that builds an SDK
             runtime from an :class:`AgentConfig`. Default is the real
             :func:`_get_runtime`.
@@ -67,6 +111,17 @@ def agent_start(
     config_path = resolve_config(config_path)
     registry = registry or Registry()
     config = load_config(config_path)
+
+    # Launch-time LOCAL spec-source drift check. Verifies the git repo
+    # backing this spec.yaml (on these hosts ``~/.scitex/agent-container/
+    # agents`` symlinks into ``~/.dotfiles``) is current with its remote.
+    # Stale (BEHIND) → may run an old spec; unpushed (AHEAD/DIVERGED) →
+    # won't propagate. Default = LOUD WARNING, never a block (hosts like
+    # spartan legitimately carry local commits). ``--strict-drift`` /
+    # ``SAC_STRICT_DRIFT=1`` escalate to a hard block. Always best-effort:
+    # a non-git source / unreachable remote / any error warns-and-continues
+    # — the check never crashes a launch (resilience is the contract).
+    _check_spec_source_drift_at_launch(config_path, config.name, strict_drift)
     if session_override:
         config.claude.session = session_override
     if resume_id_override is not None:

--- a/src/scitex_agent_container/cli_pkg/_main.py
+++ b/src/scitex_agent_container/cli_pkg/_main.py
@@ -46,6 +46,7 @@ COMMAND_CATEGORIES = [
     ),
     ("Registry & Events", ["db", "registry", "event"]),
     ("Build & Install", ["image", "installation"]),
+    ("Diagnostics", ["doctor"]),
     ("Introspection", ["mcp", "list-python-apis", "skills"]),
     ("Developer", ["dev"]),
 ]
@@ -78,6 +79,7 @@ class _MainGroup(LazyGroup):
         "peer": f"{_PKG}.peer_group:peer_group",
         "fleet": f"{_PKG}.fleet_group:fleet_group",
         "listen": f"{_PKG}.listen_cmds:listen",
+        "doctor": f"{_PKG}.doctor_cmds:doctor",
         # Top-level standalone
         "list-python-apis": f"{_PKG}.info_cmds:list_python_apis",
         "installation": f"{_PKG}.installation_group:install_group",
@@ -247,6 +249,7 @@ class _MainGroup(LazyGroup):
         "list-python-apis": "List all public Python APIs of scitex-agent-container.",
         "installation": "Bootstrap and install helpers for a new fleet host.",
         "fleet": "Peer-aware multi-agent orchestration across hosts.",
+        "doctor": "Diagnose agent-spec source drift (local, or --fleet across hosts).",
         "listen": "Boot the sac listen HTTP/JSON control-plane server.",
         "install-shell-completion": "Wire up `<TAB>` completion in the user's shell rc.",
         "print-shell-completion": "Print the shell-completion eval line (no install).",

--- a/src/scitex_agent_container/cli_pkg/doctor_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/doctor_cmds.py
@@ -1,0 +1,151 @@
+"""``sac doctor`` — drift + health diagnostics.
+
+Today the doctor surfaces spec-source git drift:
+
+* ``sac doctor`` — check THIS host's agent-spec source repo against its
+  remote (the same comparison the launch-time guard runs) and print the
+  verdict.
+* ``sac doctor --fleet`` — ssh every configured peer and render a
+  per-host drift table (current / N-behind / M-ahead / diverged /
+  unreachable / not-a-repo).
+
+``--strict`` makes a drifted result a non-zero exit (CI gate). Both
+surfaces are resilient: an unreachable peer is reported, never crashed.
+"""
+
+from __future__ import annotations
+
+import json
+
+import click
+
+from .._drift import DriftState, check_spec_source_drift
+from .._drift._fleet import HostDrift, check_fleet_drift
+from ._helpers import _json_flag, console
+
+CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
+
+# Rich style per drift state for the human table.
+_STATE_STYLE = {
+    DriftState.CURRENT: "green",
+    DriftState.BEHIND: "yellow",
+    DriftState.AHEAD: "yellow",
+    DriftState.DIVERGED: "red",
+    DriftState.NOT_A_REPO: "dim",
+    DriftState.UNREACHABLE: "dim",
+}
+
+
+def _local_agents_spec_dir() -> str:
+    """Path used as the local drift probe target (the agents dir).
+
+    ``check_spec_source_drift`` resolves it to the git toplevel, so
+    pointing at the agents dir is enough — no need for a concrete
+    spec.yaml. On fleet hosts this symlinks into the dotfiles checkout.
+    """
+    from pathlib import Path
+
+    return str(Path("~/.scitex/agent-container/agents").expanduser())
+
+
+def _render_local(ctx: click.Context, as_json: bool, strict: bool) -> int:
+    """Run + render the local spec-source drift check. Returns exit code."""
+    status = check_spec_source_drift(_local_agents_spec_dir())
+    if _json_flag(ctx, as_json):
+        click.echo(json.dumps({"local": status.to_dict()}, indent=2))
+    else:
+        style = _STATE_STYLE.get(status.state, "white")
+        console.print(
+            f"[bold]local spec-source[/bold]  [{style}]{status.summary()}[/{style}]"
+        )
+        if status.repo:
+            console.print(f"  repo  {status.repo}")
+    if strict and status.is_drifted:
+        return 1
+    return 0
+
+
+def _render_fleet(ctx: click.Context, as_json: bool, strict: bool, timeout: int) -> int:
+    """ssh every peer, render the drift table. Returns exit code."""
+    from .._state.host_config import load as _load_host_config
+
+    cfg = _load_host_config()
+    peers = cfg.peers
+    rows: list[HostDrift] = check_fleet_drift(peers, timeout=timeout)
+    if _json_flag(ctx, as_json):
+        click.echo(
+            json.dumps(
+                {
+                    "config_path": str(cfg.source_path) if cfg.source_path else None,
+                    "peers": [r.to_dict() for r in rows],
+                },
+                indent=2,
+            )
+        )
+    elif not rows:
+        console.print(
+            "[dim](no peers configured — nothing to drift-check. "
+            "Add peers with `sac host add <name> --ssh ...`.)[/dim]"
+        )
+    else:
+        console.print("[bold]fleet spec-source drift[/bold]")
+        width = max((len(r.host) for r in rows), default=4)
+        for r in rows:
+            style = _STATE_STYLE.get(r.status.state, "white")
+            line = f"  {r.host:<{width}}  [{style}]{r.status.summary()}[/{style}]"
+            console.print(line)
+    drifted = [r for r in rows if r.status.is_drifted]
+    if strict and drifted:
+        return 1
+    return 0
+
+
+@click.command("doctor", context_settings=CONTEXT_SETTINGS)
+@click.option(
+    "--fleet",
+    "fleet",
+    is_flag=True,
+    default=False,
+    help="ssh every configured peer and report each host's spec-source drift.",
+)
+@click.option(
+    "--strict",
+    "strict",
+    is_flag=True,
+    default=False,
+    help="Exit non-zero when any checked source is drifted (CI gate).",
+)
+@click.option(
+    "--timeout",
+    type=int,
+    default=30,
+    show_default=True,
+    help="Per-peer ssh timeout (seconds) for the --fleet check.",
+)
+@click.option("--json", "as_json", is_flag=True, default=False, help="Output as JSON.")
+@click.pass_context
+def doctor(
+    ctx: click.Context,
+    fleet: bool,
+    strict: bool,
+    timeout: int,
+    as_json: bool,
+) -> None:
+    """Diagnose agent-spec source drift (local, or --fleet across hosts).
+
+    \b
+    Examples:
+      $ sac doctor                 # this host's spec source vs its remote
+      $ sac doctor --fleet         # per-host drift table for every peer
+      $ sac doctor --fleet --json
+      $ sac doctor --fleet --strict   # exit 1 if any host drifted
+    """
+    if fleet:
+        code = _render_fleet(ctx, as_json, strict, timeout)
+    else:
+        code = _render_local(ctx, as_json, strict)
+    if code:
+        raise SystemExit(code)
+
+
+__all__ = ["doctor"]

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_start.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_start.py
@@ -10,22 +10,12 @@ template fan-out, and the multi-target foreground multiplexer.
 from __future__ import annotations
 
 import sys
-import traceback
 from pathlib import Path
 
 import click
 
-from ..._lifecycle.lifecycle import agent_start
-from ...config import load_config
-from ...config._host import resolve_hostname
-from ...config._resolve import resolve_with_prefix
-from .._helpers import agent_name_complete, console, system_msg
-from ._common import (
-    _iter_agent_yamls,
-    _multiplex_foreground_tails,
-    _singleton_skip_reason,
-)
-from ._dispatch import try_dispatch
+from .._helpers import agent_name_complete, console
+from ._common import _iter_agent_yamls
 
 
 @click.command()
@@ -151,6 +141,14 @@ from ._dispatch import try_dispatch
     help="Replace existing materialised yamls under --params-out.",
 )
 @click.option(
+    "--strict-drift",
+    "strict_drift",
+    is_flag=True,
+    default=False,
+    help="Hard-block (non-zero exit) on a drifted spec-source git repo "
+    "instead of warn-and-launch. Equivalent to SAC_STRICT_DRIFT=1.",
+)
+@click.option(
     "--no-redispatch",
     "no_redispatch",
     is_flag=True,
@@ -175,6 +173,7 @@ def start(
     params_file: Path | None,
     params_out: Path | None,
     params_overwrite: bool,
+    strict_drift: bool,
     no_redispatch: bool,
 ) -> None:
     """Start one or more agents from YAML definitions.
@@ -320,184 +319,25 @@ def start(
         if not single_targets:
             return
 
-    # Per-target single-start loop.
-    if single_targets:
-        _run_preflight_once()
-    any_error = False
-    for target_idx, raw_target in enumerate(single_targets):
-        if target_idx > 0 and not as_json:
-            console.print()  # blank line between agents
+    # Per-target single-start loop. Body lives in ``_start_single`` to
+    # keep this click entry under the per-file line cap.
+    from ._start_single import run_single_targets
 
-        # stx-allow: fallback (reason: config resolution, YAML parse, or agent_start can raise on misconfiguration or launch failure; catching here gives a clean error message and continues to the next target)
-        try:
-            config_path = resolve_with_prefix(raw_target)
-            config = load_config(config_path)
-            try:
-                current_host = resolve_hostname()
-            except (
-                RuntimeError
-            ):  # stx-allow: fallback (reason: runtime state error — handled gracefully)
-                current_host = ""
-            # Cross-host dispatch branch (step 2 of 6 — routing only; the
-            # actual rsync / ssh / drift-check / registry-row work lands
-            # in steps 3-6). Skipped entirely when --no-redispatch is
-            # passed (peer-side invocation uses this to prevent
-            # recursion). Source of ``target_host`` is still
-            # ``spec.host`` per the architectural decision — the
-            # ``--on <host>`` CLI arg arrives in a later step.
-            if not no_redispatch:
-                from ..._state.host_config import load as _load_host_config
-
-                peers = _load_host_config().peers
-                if try_dispatch(
-                    config,
-                    current_host,
-                    peers,
-                    dry_run=dry_run,
-                    force=force,
-                ):
-                    continue
-            skip = _singleton_skip_reason(config, current_host)
-            if skip:
-                if as_json:
-                    _emit_json(
-                        {
-                            "name": config.name,
-                            "status": "skipped",
-                            "reason": skip,
-                            "dry_run": dry_run,
-                        }
-                    )
-                else:
-                    console.print(f"[yellow]Skipping '{config.name}': {skip}[/yellow]")
-                continue
-            # Location reads as `host@<host-workdir>:<container-workdir>`
-            # so the operator sees:
-            #   * which host the agent runs on
-            #   * the host-side dir that gets bind-mounted into the
-            #     container (= spec.workdir)
-            #   * the path the agent sees inside the container
-            # The container side is always /work — fixed by sac
-            # (`--bind <workdir>:/work` in _apptainer_runtime).
-            # ``config.remote`` deleted in WI-6; v3 uses ``spec.host``
-            # for cross-host placement, exposed via ``resolve_hostname``.
-            host = resolve_hostname() or "local"
-            host_workdir = config.expanded_workdir
-            container_workdir = config.apptainer.container_workdir
-            location = f"{host}@{host_workdir}:{container_workdir}"
-            # `--foreground --json` was emitting the JSON summary on the
-            # same line as the runner's tail-of-stdout (Claude's reply
-            # has no trailing newline). Redirect the JSON to stderr in
-            # that combo + lead with a `\n` so interactive ttys (stderr
-            # and stdout glued together) still get visual separation.
-            json_stream_err = as_json and foreground and not dry_run
-
-            def _emit(obj):
-                line = _json.dumps(obj, ensure_ascii=False)
-                if json_stream_err:
-                    line = "\n" + line
-                click.echo(line, err=json_stream_err)
-
-            if not as_json:
-                verb_now = "dry-run" if dry_run else "starting"
-                system_msg(
-                    f"[dim]{verb_now}[/dim] [bold]{config.name}[/bold] "
-                    f"[dim]→ {location}[/dim]"
-                )
-                if no_preflight:
-                    system_msg("preflight skipped (--no-preflight)", style="dim")
-                if force:
-                    system_msg(
-                        "force mode — stopping any existing instance first",
-                        style="dim",
-                    )
-                if session_mode:
-                    msg = f"session override: claude.session = {session_mode}"
-                    if resume_id:
-                        msg += f", resume_id = {resume_id}"
-                    system_msg(msg, style="dim")
-            agent_start(
-                config_path,
-                no_preflight=no_preflight,
-                force=force,
-                dry_run=dry_run,
-                session_override=session_mode,
-                resume_id_override=resume_id,
-                foreground=foreground,
-                one_shot=one_shot,
-            )
-            if as_json:
-                # a2a_port: read the RESOLVED claim from port_allocator
-                # (populated by resolve_a2a_port inside agent_start).
-                # The local config here is a separate AgentConfig from
-                # the one agent_start mutated, so its a2a.port is still
-                # the raw spec value ("auto" / int / None). Lead's
-                # cross-host dispatcher writes this directly into
-                # instances.a2a_port — must be the resolved int.
-                from ..._state.port_allocator import get_port as _get_port
-                from ..._state.state_db import now_iso as _now_iso
-
-                _raw_port = getattr(getattr(config, "a2a", None), "port", None)
-                _resolved_port: int | None = (
-                    None if (dry_run or _raw_port is None) else _get_port(config.name)
-                )
-                _emit(
-                    {
-                        "name": config.name,
-                        "status": "dry_run_ok" if dry_run else "started",
-                        "host": host,
-                        "host_workdir": host_workdir,
-                        "container_workdir": container_workdir,
-                        "dry_run": dry_run,
-                        "a2a_port": _resolved_port,
-                        "started_at": None if dry_run else _now_iso(),
-                    }
-                )
-            else:
-                if foreground and not dry_run:
-                    # Agent stdout often lacks a trailing newline; break
-                    # the join before our success summary lands.
-                    click.echo("")
-                verb = "dry-run prepared the workspace for" if dry_run else "started"
-                tail = "" if dry_run else f" [dim]({location})[/dim]"
-                system_msg(f"[bold]{config.name}[/bold] {verb}{tail}", style="green")
-                if (
-                    not dry_run
-                    and not config.claude.auto_accept
-                    and any(
-                        df in f
-                        for f in config.claude.flags
-                        for df in (
-                            "--dangerously-skip-permissions",
-                            "--dangerously-load-development-channels",
-                        )
-                    )
-                ):
-                    # ``config.remote`` deleted in WI-6; ``host`` was
-                    # resolved above from ``resolve_hostname`` (v3
-                    # ``spec.host``) so reuse it.
-                    console.print(
-                        f"[yellow]auto_accept: false — manual TUI acceptance required on {host}[/yellow]"
-                    )
-        except Exception as exc:
-            any_error = True
-            if as_json:
-                _emit_json(
-                    {
-                        "name": raw_target,
-                        "status": "error",
-                        "error": str(exc),
-                        "dry_run": dry_run,
-                    }
-                )
-            else:
-                console.print(f"[red]Error ({raw_target}): {exc}[/red]")
-                traceback.print_exc()
-    if any_error:
-        sys.exit(1)
-
-    if multi_foreground and not dry_run:
-        _multiplex_foreground_tails(single_targets)
+    run_single_targets(
+        single_targets,
+        no_preflight=no_preflight,
+        force=force,
+        resume_id=resume_id,
+        session_mode=session_mode,
+        dry_run=dry_run,
+        as_json=as_json,
+        foreground=foreground,
+        one_shot=one_shot,
+        strict_drift=strict_drift,
+        no_redispatch=no_redispatch,
+        multi_foreground=multi_foreground,
+        preflight_runner=_run_preflight_once,
+    )
 
 
 __all__ = ["start"]

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_start_single.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_start_single.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Per-target single-start loop for ``sac agents start``.
+
+Extracted from ``_start.py`` (which would otherwise exceed the 512-line
+per-file cap) — the click entry point stays a thin orchestrator and
+delegates the per-target loop here. Mirrors the existing sibling
+``_start_bulk.py::run_bulk_path``.
+"""
+
+from __future__ import annotations
+
+import json as _json
+import sys
+import traceback
+from typing import Callable
+
+import click
+
+from ..._lifecycle.lifecycle import agent_start
+from ...config import load_config
+from ...config._host import resolve_hostname
+from ...config._resolve import resolve_with_prefix
+from .._helpers import console, system_msg
+from ._common import _multiplex_foreground_tails, _singleton_skip_reason
+from ._dispatch import try_dispatch
+
+
+def run_single_targets(
+    single_targets: list[str],
+    *,
+    no_preflight: bool,
+    force: bool,
+    resume_id: str | None,
+    session_mode: str | None,
+    dry_run: bool,
+    as_json: bool,
+    foreground: bool,
+    one_shot: bool,
+    strict_drift: bool,
+    no_redispatch: bool,
+    multi_foreground: bool,
+    preflight_runner: Callable[[], None],
+) -> None:
+    """Start each name/path in ``single_targets`` (directory bulk handled upstream).
+
+    Exits non-zero (``sys.exit(1)``) when any target fails. Honours the
+    cross-host dispatch branch, the singleton-skip guard, the JSON
+    report shape, and the launch-time ``strict_drift`` escalation —
+    behaviour is byte-identical to the inline loop it replaced.
+    """
+
+    def _emit_json(payload: dict) -> None:
+        click.echo(_json.dumps(payload, ensure_ascii=False))
+
+
+    if single_targets:
+        preflight_runner()
+    any_error = False
+    for target_idx, raw_target in enumerate(single_targets):
+        if target_idx > 0 and not as_json:
+            console.print()  # blank line between agents
+
+        # stx-allow: fallback (reason: config resolution, YAML parse, or agent_start can raise on misconfiguration or launch failure; catching here gives a clean error message and continues to the next target)
+        try:
+            config_path = resolve_with_prefix(raw_target)
+            config = load_config(config_path)
+            try:
+                current_host = resolve_hostname()
+            except (
+                RuntimeError
+            ):  # stx-allow: fallback (reason: runtime state error — handled gracefully)
+                current_host = ""
+            # Cross-host dispatch branch (routing only). Skipped when
+            # --no-redispatch is passed (peer-side invocation uses this
+            # to prevent recursion).
+            if not no_redispatch:
+                from ..._state.host_config import load as _load_host_config
+
+                peers = _load_host_config().peers
+                if try_dispatch(
+                    config,
+                    current_host,
+                    peers,
+                    dry_run=dry_run,
+                    force=force,
+                ):
+                    continue
+            skip = _singleton_skip_reason(config, current_host)
+            if skip:
+                if as_json:
+                    _emit_json(
+                        {
+                            "name": config.name,
+                            "status": "skipped",
+                            "reason": skip,
+                            "dry_run": dry_run,
+                        }
+                    )
+                else:
+                    console.print(f"[yellow]Skipping '{config.name}': {skip}[/yellow]")
+                continue
+            # Location reads as `host@<host-workdir>:<container-workdir>`.
+            host = resolve_hostname() or "local"
+            host_workdir = config.expanded_workdir
+            container_workdir = config.apptainer.container_workdir
+            location = f"{host}@{host_workdir}:{container_workdir}"
+            # `--foreground --json` redirect: keep the JSON summary off
+            # the runner's trailing-newline-less stdout line.
+            json_stream_err = as_json and foreground and not dry_run
+
+            def _emit(obj, _err=json_stream_err):
+                line = _json.dumps(obj, ensure_ascii=False)
+                if _err:
+                    line = "\n" + line
+                click.echo(line, err=_err)
+
+            if not as_json:
+                verb_now = "dry-run" if dry_run else "starting"
+                system_msg(
+                    f"[dim]{verb_now}[/dim] [bold]{config.name}[/bold] "
+                    f"[dim]→ {location}[/dim]"
+                )
+                if no_preflight:
+                    system_msg("preflight skipped (--no-preflight)", style="dim")
+                if force:
+                    system_msg(
+                        "force mode — stopping any existing instance first",
+                        style="dim",
+                    )
+                if session_mode:
+                    msg = f"session override: claude.session = {session_mode}"
+                    if resume_id:
+                        msg += f", resume_id = {resume_id}"
+                    system_msg(msg, style="dim")
+            agent_start(
+                config_path,
+                no_preflight=no_preflight,
+                force=force,
+                dry_run=dry_run,
+                session_override=session_mode,
+                resume_id_override=resume_id,
+                foreground=foreground,
+                one_shot=one_shot,
+                strict_drift=strict_drift,
+            )
+            if as_json:
+                from ..._state.port_allocator import get_port as _get_port
+                from ..._state.state_db import now_iso as _now_iso
+
+                _raw_port = getattr(getattr(config, "a2a", None), "port", None)
+                _resolved_port: int | None = (
+                    None if (dry_run or _raw_port is None) else _get_port(config.name)
+                )
+                _emit(
+                    {
+                        "name": config.name,
+                        "status": "dry_run_ok" if dry_run else "started",
+                        "host": host,
+                        "host_workdir": host_workdir,
+                        "container_workdir": container_workdir,
+                        "dry_run": dry_run,
+                        "a2a_port": _resolved_port,
+                        "started_at": None if dry_run else _now_iso(),
+                    }
+                )
+            else:
+                if foreground and not dry_run:
+                    # Agent stdout often lacks a trailing newline.
+                    click.echo("")
+                verb = "dry-run prepared the workspace for" if dry_run else "started"
+                tail = "" if dry_run else f" [dim]({location})[/dim]"
+                system_msg(f"[bold]{config.name}[/bold] {verb}{tail}", style="green")
+                if (
+                    not dry_run
+                    and not config.claude.auto_accept
+                    and any(
+                        df in f
+                        for f in config.claude.flags
+                        for df in (
+                            "--dangerously-skip-permissions",
+                            "--dangerously-load-development-channels",
+                        )
+                    )
+                ):
+                    console.print(
+                        f"[yellow]auto_accept: false — manual TUI acceptance required on {host}[/yellow]"
+                    )
+        except Exception as exc:
+            any_error = True
+            if as_json:
+                _emit_json(
+                    {
+                        "name": raw_target,
+                        "status": "error",
+                        "error": str(exc),
+                        "dry_run": dry_run,
+                    }
+                )
+            else:
+                console.print(f"[red]Error ({raw_target}): {exc}[/red]")
+                traceback.print_exc()
+    if any_error:
+        sys.exit(1)
+
+    if multi_foreground and not dry_run:
+        _multiplex_foreground_tails(single_targets)
+
+
+__all__ = ["run_single_targets"]

--- a/tests/scitex_agent_container/_drift/__init__.py
+++ b/tests/scitex_agent_container/_drift/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the _drift package (sac-drift detection)."""

--- a/tests/scitex_agent_container/_drift/test__fleet.py
+++ b/tests/scitex_agent_container/_drift/test__fleet.py
@@ -1,0 +1,180 @@
+"""Tests for the fleet-wide spec-source drift check.
+
+PA-306: no mocks. The ssh round-trip is exercised through the real
+``subprocess.run`` against a PATH-installed ``ssh`` shim (the shared
+``subprocess_shim`` fixture) that prints a canned ``SAC_DRIFT`` marker
+— the same shape a real peer's snippet emits. Resilience paths use a
+real injected ``runner`` callable (no patching).
+
+Each test: AAA markers (TQ002), one assertion (TQ007), 3+-word name
+(TQ003).
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+from scitex_agent_container._drift import DriftState, check_peer_drift
+from scitex_agent_container._drift._fleet import check_fleet_drift
+from scitex_agent_container._state.host_config import PeerSpec
+
+
+def _peers(*names: str) -> dict[str, PeerSpec]:
+    return {n: PeerSpec(name=n, ssh=f"user@{n}") for n in names}
+
+
+# ---------------------------------------------------------------------------
+# check_peer_drift via the real ssh shim
+# ---------------------------------------------------------------------------
+
+
+def test_current_marker_parses_to_current(subprocess_shim):
+    # Arrange
+    subprocess_shim.install("ssh", stdout="SAC_DRIFT current 0 0 origin/develop\n")
+    # Act
+    row = check_peer_drift("mba", _peers("mba"))
+    # Assert
+    assert row.status.state is DriftState.CURRENT
+
+
+def test_behind_marker_parses_behind_count(subprocess_shim):
+    # Arrange
+    subprocess_shim.install("ssh", stdout="SAC_DRIFT behind 0 4 origin/develop\n")
+    # Act
+    row = check_peer_drift("nas", _peers("nas"))
+    # Assert
+    assert row.status.behind == 4
+
+
+def test_diverged_marker_parses_both_counts(subprocess_shim):
+    # Arrange
+    subprocess_shim.install("ssh", stdout="SAC_DRIFT diverged 2 5 origin/develop\n")
+    # Act
+    row = check_peer_drift("spartan", _peers("spartan"))
+    # Assert
+    assert (row.status.ahead, row.status.behind) == (2, 5)
+
+
+def test_marker_after_motd_noise_is_still_parsed(subprocess_shim):
+    # Arrange — login shells print motd before our marker line.
+    subprocess_shim.install(
+        "ssh",
+        stdout="Welcome to spartan\nLast login: ...\nSAC_DRIFT ahead 1 0 origin/develop\n",
+    )
+    # Act
+    row = check_peer_drift("spartan", _peers("spartan"))
+    # Assert
+    assert row.status.state is DriftState.AHEAD
+
+
+def test_not_a_repo_marker_carries_detail(subprocess_shim):
+    # Arrange
+    subprocess_shim.install(
+        "ssh", stdout="SAC_DRIFT not-a-repo 0 0 - (spec source not in a git repo)\n"
+    )
+    # Act
+    row = check_peer_drift("mba", _peers("mba"))
+    # Assert
+    assert row.status.state is DriftState.NOT_A_REPO
+
+
+def test_missing_marker_maps_to_unreachable(subprocess_shim):
+    # Arrange — ssh succeeds but prints nothing recognizable.
+    subprocess_shim.install("ssh", stdout="garbage output, no marker\n")
+    # Act
+    row = check_peer_drift("mba", _peers("mba"))
+    # Assert
+    assert row.status.state is DriftState.UNREACHABLE
+
+
+def test_ssh_nonzero_exit_without_marker_is_unreachable(subprocess_shim):
+    # Arrange — connection refused: nonzero exit, stderr only.
+    subprocess_shim.install("ssh", exit=255, stderr="ssh: connect: refused\n")
+    # Act
+    row = check_peer_drift("nas", _peers("nas"))
+    # Assert
+    assert row.status.state is DriftState.UNREACHABLE
+
+
+def test_undefined_peer_maps_to_unreachable():
+    # Arrange — 'ghost' not in the peers map.
+    # Act
+    row = check_peer_drift("ghost", _peers("mba"))
+    # Assert
+    assert row.status.state is DriftState.UNREACHABLE
+
+
+def test_peer_drift_records_host_name(subprocess_shim):
+    # Arrange
+    subprocess_shim.install("ssh", stdout="SAC_DRIFT current 0 0 origin/develop\n")
+    # Act
+    row = check_peer_drift("mba", _peers("mba"))
+    # Assert
+    assert row.host == "mba"
+
+
+# ---------------------------------------------------------------------------
+# resilience via an injected real runner (no mocks)
+# ---------------------------------------------------------------------------
+
+
+def test_ssh_timeout_maps_to_unreachable():
+    # Arrange — a real callable that raises TimeoutExpired like ssh would.
+    def timing_out_runner(*_a, **_kw):
+        raise subprocess.TimeoutExpired(cmd="ssh", timeout=5)
+
+    # Act
+    row = check_peer_drift("nas", _peers("nas"), runner=timing_out_runner)
+    # Assert
+    assert row.status.state is DriftState.UNREACHABLE
+
+
+def test_one_bad_host_does_not_crash_the_fleet_sweep():
+    # Arrange — runner raises for 'nas', returns a marker for 'mba'.
+    def selective_runner(argv, *_a, **_kw):
+        if any("nas" in tok for tok in argv):
+            raise OSError("spawn failed")
+        return subprocess.CompletedProcess(
+            argv, 0, stdout="SAC_DRIFT current 0 0 origin/develop\n", stderr=""
+        )
+
+    peers = _peers("mba", "nas")
+    # Act
+    rows = check_fleet_drift(peers, runner=selective_runner)
+    # Assert — both hosts reported; the bad one degrades, no exception.
+    assert {r.host: r.status.state for r in rows} == {
+        "mba": DriftState.CURRENT,
+        "nas": DriftState.UNREACHABLE,
+    }
+
+
+def test_fleet_rows_are_sorted_by_host_name():
+    # Arrange
+    def ok_runner(argv, *_a, **_kw):
+        return subprocess.CompletedProcess(
+            argv, 0, stdout="SAC_DRIFT current 0 0 origin/develop\n", stderr=""
+        )
+
+    peers = _peers("zeta", "alpha", "mid")
+    # Act
+    rows = check_fleet_drift(peers, runner=ok_runner)
+    # Assert
+    assert [r.host for r in rows] == ["alpha", "mid", "zeta"]
+
+
+def test_empty_peers_map_yields_no_rows():
+    # Arrange
+    # Act
+    rows = check_fleet_drift({})
+    # Assert
+    assert rows == []
+
+
+def test_remote_snippet_is_passed_through_ssh(subprocess_shim):
+    # Arrange
+    subprocess_shim.install("ssh", stdout="SAC_DRIFT current 0 0 origin/develop\n")
+    # Act
+    check_peer_drift("mba", _peers("mba"))
+    argv = subprocess_shim.argv_for("ssh")
+    # Assert — the remote command runs the drift snippet via sh -c.
+    assert "SAC_DRIFT" in " ".join(argv)

--- a/tests/scitex_agent_container/_drift/test__local.py
+++ b/tests/scitex_agent_container/_drift/test__local.py
@@ -1,0 +1,338 @@
+"""Tests for the launch-time LOCAL spec-source drift check.
+
+PA-306: no mocks. Every test runs against a REAL git repo built with
+``git init`` in ``tmp_path`` — a bare remote plus working clones — so
+the drift comparison exercises real ``git fetch`` / ``git rev-list``.
+The fetch cache is redirected to ``tmp_path`` via SCITEX_DIR so tests
+never touch the user's real ~/.scitex.
+
+Each test: AAA markers (TQ002), one assertion (TQ007), 3+-word name
+(TQ003).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._drift import (
+    DriftState,
+    SpecSourceDriftError,
+    check_spec_source_drift,
+    drift_warning_lines,
+    spec_source_repo,
+    warn_if_spec_source_drifted,
+)
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.fixture
+def isolated_scitex_dir(tmp_path: Path, env_save_restore):
+    """Redirect the fetch-cache root to tmp_path via SCITEX_DIR.
+
+    Keeps the per-repo last-fetch cache out of the user's real
+    ~/.scitex during the test run.
+    """
+    cache_root = tmp_path / "scitex-home"
+    cache_root.mkdir()
+    env_save_restore.set("SCITEX_DIR", str(cache_root))
+    return cache_root
+
+
+@pytest.fixture
+def spec_repo(tmp_path: Path):
+    """A real git working clone tracking a bare remote on ``develop``.
+
+    Returns ``(spec_path, work, remote)``. ``spec_path`` is a spec.yaml
+    committed + pushed so the working clone starts CURRENT.
+    """
+    remote = tmp_path / "remote.git"
+    subprocess.run(
+        ["git", "init", "--bare", str(remote)], check=True, capture_output=True
+    )
+    work = tmp_path / "work"
+    subprocess.run(
+        ["git", "clone", str(remote), str(work)], check=True, capture_output=True
+    )
+    _git(work, "config", "user.email", "t@example.com")
+    _git(work, "config", "user.name", "Test")
+    _git(work, "checkout", "-b", "develop")
+    agents = work / ".scitex" / "agent-container" / "agents" / "foo"
+    agents.mkdir(parents=True)
+    spec = agents / "spec.yaml"
+    spec.write_text("apiVersion: scitex-agent-container/v3\n")
+    _git(work, "add", "-A")
+    _git(work, "commit", "-m", "init")
+    _git(work, "push", "-u", "origin", "develop")
+    return spec, work, remote
+
+
+def _advance_remote(remote: Path, base_work: Path, tmp_path: Path) -> None:
+    """Push a new commit to ``remote`` from a second clone (makes base BEHIND)."""
+    other = tmp_path / "other"
+    subprocess.run(
+        ["git", "clone", str(remote), str(other)], check=True, capture_output=True
+    )
+    _git(other, "config", "user.email", "t@example.com")
+    _git(other, "config", "user.name", "Test")
+    _git(other, "checkout", "develop")
+    (other / "new.txt").write_text("remote work")
+    _git(other, "add", "-A")
+    _git(other, "commit", "-m", "remote work")
+    _git(other, "push")
+
+
+# ---------------------------------------------------------------------------
+# spec_source_repo
+# ---------------------------------------------------------------------------
+
+
+def test_spec_source_repo_finds_git_toplevel(spec_repo):
+    # Arrange
+    spec, work, _remote = spec_repo
+    # Act
+    repo = spec_source_repo(spec)
+    # Assert
+    assert repo == work.resolve()
+
+
+def test_spec_source_repo_returns_none_outside_git(tmp_path: Path):
+    # Arrange
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    (plain / "spec.yaml").write_text("x")
+    # Act
+    repo = spec_source_repo(plain / "spec.yaml")
+    # Assert
+    assert repo is None
+
+
+# ---------------------------------------------------------------------------
+# check_spec_source_drift — state classification
+# ---------------------------------------------------------------------------
+
+
+def test_clean_clone_reports_current(spec_repo, isolated_scitex_dir):
+    # Arrange
+    spec, _work, _remote = spec_repo
+    # Act
+    status = check_spec_source_drift(spec, ttl=0)
+    # Assert
+    assert status.state is DriftState.CURRENT
+
+
+def test_remote_ahead_reports_behind(spec_repo, isolated_scitex_dir, tmp_path):
+    # Arrange
+    spec, work, remote = spec_repo
+    _advance_remote(remote, work, tmp_path)
+    # Act
+    status = check_spec_source_drift(spec, ttl=0)
+    # Assert
+    assert status.state is DriftState.BEHIND
+
+
+def test_unpushed_local_commit_reports_ahead(spec_repo, isolated_scitex_dir):
+    # Arrange
+    spec, work, _remote = spec_repo
+    (work / "local.txt").write_text("local work")
+    _git(work, "add", "-A")
+    _git(work, "commit", "-m", "local work")
+    # Act
+    status = check_spec_source_drift(spec, ttl=0)
+    # Assert
+    assert status.state is DriftState.AHEAD
+
+
+def test_both_ahead_and_behind_reports_diverged(
+    spec_repo, isolated_scitex_dir, tmp_path
+):
+    # Arrange
+    spec, work, remote = spec_repo
+    _advance_remote(remote, work, tmp_path)
+    (work / "local.txt").write_text("local work")
+    _git(work, "add", "-A")
+    _git(work, "commit", "-m", "local work")
+    # Act
+    status = check_spec_source_drift(spec, ttl=0)
+    # Assert
+    assert status.state is DriftState.DIVERGED
+
+
+def test_behind_count_matches_remote_commits(spec_repo, isolated_scitex_dir, tmp_path):
+    # Arrange
+    spec, work, remote = spec_repo
+    _advance_remote(remote, work, tmp_path)
+    # Act
+    status = check_spec_source_drift(spec, ttl=0)
+    # Assert
+    assert status.behind == 1
+
+
+def test_non_git_source_reports_not_a_repo(tmp_path, isolated_scitex_dir):
+    # Arrange
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    (plain / "spec.yaml").write_text("x")
+    # Act
+    status = check_spec_source_drift(plain / "spec.yaml")
+    # Assert
+    assert status.state is DriftState.NOT_A_REPO
+
+
+def test_branch_without_upstream_reports_unreachable(tmp_path, isolated_scitex_dir):
+    # Arrange — a repo with a commit but no remote/upstream configured.
+    repo = tmp_path / "lonely"
+    subprocess.run(["git", "init", str(repo)], check=True, capture_output=True)
+    _git(repo, "config", "user.email", "t@example.com")
+    _git(repo, "config", "user.name", "Test")
+    spec = repo / "spec.yaml"
+    spec.write_text("x")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "only commit")
+    # Act
+    status = check_spec_source_drift(spec)
+    # Assert
+    assert status.state is DriftState.UNREACHABLE
+
+
+# ---------------------------------------------------------------------------
+# fetch caching (TTL)
+# ---------------------------------------------------------------------------
+
+
+def test_recent_fetch_is_cached_within_ttl(spec_repo, isolated_scitex_dir, tmp_path):
+    # Arrange — first check fetches at t=1000 (writes cache); remote then
+    # advances; second check at t=1030 with ttl=60 must reuse the cache
+    # and therefore still see CURRENT (no re-fetch).
+    spec, work, remote = spec_repo
+    check_spec_source_drift(spec, ttl=60, now_fn=lambda: 1000.0)
+    _advance_remote(remote, work, tmp_path)
+    # Act
+    status = check_spec_source_drift(spec, ttl=60, now_fn=lambda: 1030.0)
+    # Assert
+    assert status.state is DriftState.CURRENT
+
+
+def test_expired_fetch_cache_refetches_and_sees_drift(
+    spec_repo, isolated_scitex_dir, tmp_path
+):
+    # Arrange — first fetch at t=1000; remote advances; second check at
+    # t=2000 (ttl=60 expired) must re-fetch and see BEHIND.
+    spec, work, remote = spec_repo
+    check_spec_source_drift(spec, ttl=60, now_fn=lambda: 1000.0)
+    _advance_remote(remote, work, tmp_path)
+    # Act
+    status = check_spec_source_drift(spec, ttl=60, now_fn=lambda: 2000.0)
+    # Assert
+    assert status.state is DriftState.BEHIND
+
+
+# ---------------------------------------------------------------------------
+# drift_warning_lines
+# ---------------------------------------------------------------------------
+
+
+def test_current_status_produces_no_warning(spec_repo, isolated_scitex_dir):
+    # Arrange
+    spec, _work, _remote = spec_repo
+    status = check_spec_source_drift(spec, ttl=0)
+    # Act
+    lines = drift_warning_lines(status)
+    # Assert
+    assert lines == []
+
+
+def test_behind_warning_names_the_pull_fix(spec_repo, isolated_scitex_dir, tmp_path):
+    # Arrange
+    spec, work, remote = spec_repo
+    _advance_remote(remote, work, tmp_path)
+    status = check_spec_source_drift(spec, ttl=0)
+    # Act
+    text = "\n".join(drift_warning_lines(status))
+    # Assert
+    assert "pull --ff-only" in text
+
+
+def test_ahead_warning_names_the_push_fix(spec_repo, isolated_scitex_dir):
+    # Arrange
+    spec, work, _remote = spec_repo
+    (work / "local.txt").write_text("local")
+    _git(work, "add", "-A")
+    _git(work, "commit", "-m", "local")
+    status = check_spec_source_drift(spec, ttl=0)
+    # Act
+    text = "\n".join(drift_warning_lines(status))
+    # Assert
+    assert "push" in text
+
+
+# ---------------------------------------------------------------------------
+# warn_if_spec_source_drifted — default warn vs strict block
+# ---------------------------------------------------------------------------
+
+
+def test_default_warn_does_not_raise_on_drift(
+    spec_repo, isolated_scitex_dir, tmp_path, capsys
+):
+    # Arrange
+    spec, work, remote = spec_repo
+    _advance_remote(remote, work, tmp_path)
+    # Act
+    status = warn_if_spec_source_drifted(spec, agent="foo", strict=False)
+    # Assert — returns the drifted status, never raises (default = warn)
+    assert status.state is DriftState.BEHIND
+
+
+def test_default_warn_emits_loud_stderr_banner(
+    spec_repo, isolated_scitex_dir, tmp_path, capsys
+):
+    # Arrange
+    spec, work, remote = spec_repo
+    _advance_remote(remote, work, tmp_path)
+    # Act
+    warn_if_spec_source_drifted(spec, agent="foo", strict=False)
+    # Assert
+    assert "sac-drift WARNING" in capsys.readouterr().err
+
+
+def test_strict_mode_raises_on_drift(spec_repo, isolated_scitex_dir, tmp_path):
+    # Arrange
+    spec, work, remote = spec_repo
+    _advance_remote(remote, work, tmp_path)
+    # Act
+    ctx = pytest.raises(SpecSourceDriftError)
+    # Assert
+    with ctx:
+        warn_if_spec_source_drifted(spec, agent="foo", strict=True)
+
+
+def test_strict_mode_does_not_raise_on_not_a_repo(tmp_path, isolated_scitex_dir):
+    # Arrange — strict only blocks genuine drift, not unknown drift.
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    (plain / "spec.yaml").write_text("x")
+    # Act
+    status = warn_if_spec_source_drifted(
+        plain / "spec.yaml", strict=True, do_fetch=False
+    )
+    # Assert
+    assert status.state is DriftState.NOT_A_REPO
+
+
+def test_strict_mode_does_not_raise_when_current(spec_repo, isolated_scitex_dir):
+    # Arrange
+    spec, _work, _remote = spec_repo
+    # Act
+    status = warn_if_spec_source_drifted(spec, strict=True)
+    # Assert
+    assert status.state is DriftState.CURRENT

--- a/tests/scitex_agent_container/_drift/test__status.py
+++ b/tests/scitex_agent_container/_drift/test__status.py
@@ -1,0 +1,102 @@
+"""Tests for the DriftStatus model.
+
+PA-306: no mocks. Pure dataclass behaviour — real instances, real
+assertions. Each test: AAA markers (TQ002), one assertion (TQ007),
+3+-word descriptive name (TQ003).
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container._drift import DriftState, DriftStatus
+
+
+def test_current_status_reports_not_drifted():
+    # Arrange
+    status = DriftStatus(state=DriftState.CURRENT)
+    # Act
+    drifted = status.is_drifted
+    # Assert
+    assert drifted is False
+
+
+def test_behind_status_reports_drifted():
+    # Arrange
+    status = DriftStatus(state=DriftState.BEHIND, behind=3, upstream="origin/develop")
+    # Act
+    drifted = status.is_drifted
+    # Assert
+    assert drifted is True
+
+
+def test_diverged_status_reports_drifted():
+    # Arrange
+    status = DriftStatus(state=DriftState.DIVERGED, behind=2, ahead=1)
+    # Act
+    drifted = status.is_drifted
+    # Assert
+    assert drifted is True
+
+
+def test_not_a_repo_status_is_not_treated_as_drift():
+    # Arrange
+    status = DriftStatus(state=DriftState.NOT_A_REPO)
+    # Act
+    drifted = status.is_drifted
+    # Assert
+    assert drifted is False
+
+
+def test_unreachable_status_is_not_treated_as_drift():
+    # Arrange
+    status = DriftStatus(state=DriftState.UNREACHABLE, detail="offline")
+    # Act
+    drifted = status.is_drifted
+    # Assert
+    assert drifted is False
+
+
+def test_behind_summary_names_commit_count():
+    # Arrange
+    status = DriftStatus(state=DriftState.BEHIND, behind=3, upstream="origin/develop")
+    # Act
+    summary = status.summary()
+    # Assert
+    assert summary == "3 behind origin/develop"
+
+
+def test_ahead_summary_marks_unpushed():
+    # Arrange
+    status = DriftStatus(state=DriftState.AHEAD, ahead=2, upstream="origin/develop")
+    # Act
+    summary = status.summary()
+    # Assert
+    assert "unpushed" in summary
+
+
+def test_diverged_summary_reports_both_directions():
+    # Arrange
+    status = DriftStatus(
+        state=DriftState.DIVERGED, ahead=2, behind=5, upstream="origin/develop"
+    )
+    # Act
+    summary = status.summary()
+    # Assert
+    assert "2 ahead / 5 behind" in summary
+
+
+def test_to_dict_carries_state_value_string():
+    # Arrange
+    status = DriftStatus(state=DriftState.BEHIND, behind=1, upstream="origin/develop")
+    # Act
+    payload = status.to_dict()
+    # Assert
+    assert payload["state"] == "behind"
+
+
+def test_to_dict_includes_human_summary_field():
+    # Arrange
+    status = DriftStatus(state=DriftState.CURRENT)
+    # Act
+    payload = status.to_dict()
+    # Assert
+    assert payload["summary"] == "current"

--- a/tests/scitex_agent_container/_lifecycle/test__start_drift.py
+++ b/tests/scitex_agent_container/_lifecycle/test__start_drift.py
@@ -1,0 +1,241 @@
+"""Tests for the launch-time drift guard wired into ``agent_start``.
+
+PA-306: no mocks. The spec lives inside a REAL git repo (``git init``
+in tmp_path); a real hand-rolled fake runtime/handover capture whether
+``start`` was reached. HOME + SCITEX_DIR are redirected into tmp_path so
+the drift fetch-cache and Path.home() never touch the developer's home.
+
+Covers:
+  * default (lenient) → drifted source warns but the runtime still starts.
+  * --strict-drift → drifted source raises SpecSourceDriftError BEFORE
+    the runtime is touched.
+  * env SAC_STRICT_DRIFT honoured by ``_resolve_strict_drift`` (arg wins).
+  * a clean (current) source launches normally under strict.
+
+Each test: AAA markers (TQ002), one assertion (TQ007), 3+-word name.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from typing import Any, Iterator
+
+import pytest
+
+from scitex_agent_container._drift import SpecSourceDriftError
+from scitex_agent_container._lifecycle._start import _resolve_strict_drift, agent_start
+from scitex_agent_container._state.registry import Registry
+from scitex_agent_container.config import AgentConfig
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", "-C", str(repo), *args], check=True, capture_output=True, text=True
+    )
+
+
+class _FakeRuntime:
+    """Real runtime surface; records whether start() was reached."""
+
+    def __init__(self) -> None:
+        self.started: list[AgentConfig] = []
+
+    def is_running(self, config: AgentConfig) -> bool:
+        return False
+
+    def start(self, config: AgentConfig, **kwargs: Any) -> bool:
+        self.started.append(config)
+        return True
+
+    def stop(self, config: AgentConfig) -> None:  # pragma: no cover - unused here
+        pass
+
+
+class _FakeHandover:
+    """Real handover surface; no-op for the four module callables."""
+
+    def ensure_instance_uuid(self, config: AgentConfig) -> str:
+        return "uuid"
+
+    def hydrate_from_hub(self, config: AgentConfig) -> bool:
+        return True
+
+    def start_failback_poller(self, config: AgentConfig) -> None:
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _isolate_home(tmp_path: Path) -> Iterator[None]:
+    home = tmp_path / "home"
+    home.mkdir()
+    prev_home = os.environ.get("HOME")
+    prev_dir = os.environ.get("SCITEX_DIR")
+    os.environ["HOME"] = str(home)
+    os.environ["SCITEX_DIR"] = str(home / ".scitex")
+    try:
+        yield
+    finally:
+        for key, prev in (("HOME", prev_home), ("SCITEX_DIR", prev_dir)):
+            if prev is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = prev
+
+
+def _make_spec_repo(tmp_path: Path, *, drifted: bool) -> Path:
+    """Create a real git clone holding the agent spec; optionally BEHIND.
+
+    Returns the spec.yaml path. The spec is health-disabled and uses the
+    apptainer runtime; the injected fake runtime handles the launch.
+    """
+    remote = tmp_path / "remote.git"
+    subprocess.run(
+        ["git", "init", "--bare", str(remote)], check=True, capture_output=True
+    )
+    work = tmp_path / "specsrc"
+    subprocess.run(
+        ["git", "clone", str(remote), str(work)], check=True, capture_output=True
+    )
+    _git(work, "config", "user.email", "t@example.com")
+    _git(work, "config", "user.name", "Test")
+    _git(work, "checkout", "-b", "develop")
+    agent_dir = work / "agents" / "alpha"
+    agent_dir.mkdir(parents=True)
+    spec = agent_dir / "spec.yaml"
+    spec.write_text(
+        "apiVersion: scitex-agent-container/v3\n"
+        "kind: Agent\n"
+        "spec:\n"
+        "  runtime: apptainer\n"
+        f"  workdir: {tmp_path / 'work'}\n"
+        "  claude:\n"
+        "    model: sonnet\n"
+        "  health:\n"
+        "    enabled: false\n"
+    )
+    _git(work, "add", "-A")
+    _git(work, "commit", "-m", "init")
+    _git(work, "push", "-u", "origin", "develop")
+    if drifted:
+        other = tmp_path / "other"
+        subprocess.run(
+            ["git", "clone", str(remote), str(other)], check=True, capture_output=True
+        )
+        _git(other, "config", "user.email", "t@example.com")
+        _git(other, "config", "user.name", "Test")
+        _git(other, "checkout", "develop")
+        (other / "x.txt").write_text("remote")
+        _git(other, "add", "-A")
+        _git(other, "commit", "-m", "remote work")
+        _git(other, "push")
+    return spec
+
+
+def _start(spec: Path, registry: Registry, runtime: _FakeRuntime, **kw):
+    return agent_start(
+        str(spec),
+        registry=registry,
+        runtime_factory=lambda _c: runtime,
+        handover_mod=_FakeHandover(),
+        sleep_fn=lambda _s: None,
+        **kw,
+    )
+
+
+@pytest.fixture
+def registry(tmp_path: Path) -> Registry:
+    return Registry(registry_dir=tmp_path / "reg")
+
+
+# ---------------------------------------------------------------------------
+# default lenient vs strict block
+# ---------------------------------------------------------------------------
+
+
+def test_drifted_source_still_starts_by_default(tmp_path, registry, capsys):
+    # Arrange
+    spec = _make_spec_repo(tmp_path, drifted=True)
+    runtime = _FakeRuntime()
+    # Act
+    _start(spec, registry, runtime)
+    # Assert — lenient default: the runtime is reached despite drift.
+    assert len(runtime.started) == 1
+
+
+def test_drifted_source_emits_loud_warning_by_default(tmp_path, registry, capsys):
+    # Arrange
+    spec = _make_spec_repo(tmp_path, drifted=True)
+    runtime = _FakeRuntime()
+    # Act
+    _start(spec, registry, runtime)
+    # Assert
+    assert "sac-drift WARNING" in capsys.readouterr().err
+
+
+def test_strict_drift_blocks_before_runtime_start(tmp_path, registry):
+    # Arrange
+    spec = _make_spec_repo(tmp_path, drifted=True)
+    runtime = _FakeRuntime()
+    # Act
+    ctx = pytest.raises(SpecSourceDriftError)
+    # Assert
+    with ctx:
+        _start(spec, registry, runtime, strict_drift=True)
+
+
+def test_strict_drift_does_not_reach_runtime(tmp_path, registry):
+    # Arrange
+    spec = _make_spec_repo(tmp_path, drifted=True)
+    runtime = _FakeRuntime()
+    # Act
+    try:
+        _start(spec, registry, runtime, strict_drift=True)
+    except SpecSourceDriftError:
+        pass
+    # Assert — start() never ran.
+    assert runtime.started == []
+
+
+def test_clean_source_starts_even_under_strict(tmp_path, registry):
+    # Arrange
+    spec = _make_spec_repo(tmp_path, drifted=False)
+    runtime = _FakeRuntime()
+    # Act
+    _start(spec, registry, runtime, strict_drift=True)
+    # Assert
+    assert len(runtime.started) == 1
+
+
+# ---------------------------------------------------------------------------
+# _resolve_strict_drift — arg-wins / env-fallback
+# ---------------------------------------------------------------------------
+
+
+def test_explicit_true_arg_wins_over_env(env_save_restore):
+    # Arrange
+    env_save_restore.set("SAC_STRICT_DRIFT", "0")
+    # Act
+    resolved = _resolve_strict_drift(True)
+    # Assert
+    assert resolved is True
+
+
+def test_env_truthy_enables_strict_when_arg_none(env_save_restore):
+    # Arrange
+    env_save_restore.set("SAC_STRICT_DRIFT", "1")
+    # Act
+    resolved = _resolve_strict_drift(None)
+    # Assert
+    assert resolved is True
+
+
+def test_env_unset_defaults_to_lenient(env_save_restore):
+    # Arrange
+    env_save_restore.delete("SAC_STRICT_DRIFT")
+    env_save_restore.delete("SCITEX_AGENT_CONTAINER_STRICT_DRIFT")
+    # Act
+    resolved = _resolve_strict_drift(None)
+    # Assert
+    assert resolved is False

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__start.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__start.py
@@ -637,11 +637,16 @@ def _run_start_no_redispatch_json(
 
     from scitex_agent_container.cli_pkg.lifecycle import _start as start_mod
 
+    # ``agent_start`` is invoked inside the per-target loop, which lives
+    # in the ``_start_single`` sibling (split out of ``_start`` to keep
+    # the click entry under the line cap). Swap it there.
+    from scitex_agent_container.cli_pkg.lifecycle import _start_single as single_mod
+
     def _fake_agent_start(*args: Any, **kwargs: Any) -> bool:
         return True
 
     runner = CliRunner()
-    with _swap_attr(start_mod, "agent_start", _fake_agent_start):
+    with _swap_attr(single_mod, "agent_start", _fake_agent_start):
         result = runner.invoke(
             start_mod.start,
             [str(yaml_path), "--no-redispatch", "--json"],
@@ -714,3 +719,12 @@ class TestStartNoRedispatchJsonA2aPort:
         finally:
             importlib.reload(_sdb)
             importlib.reload(_pa)
+
+
+def test_start_command_exposes_strict_drift_flag():
+    # Arrange
+    flag_names = {opt for p in start.params for opt in p.opts}
+    # Act
+    has_flag = "--strict-drift" in flag_names
+    # Assert
+    assert has_flag is True

--- a/tests/scitex_agent_container/cli_pkg/test_doctor_cmds.py
+++ b/tests/scitex_agent_container/cli_pkg/test_doctor_cmds.py
@@ -1,0 +1,182 @@
+"""CLI tests for ``sac doctor`` (drift diagnostics).
+
+PA-306: no mocks. ``CliRunner`` drives the real click command; the
+fleet ssh round-trip uses the shared ``subprocess_shim`` (a real fake
+binary on PATH) and a real tmp_path config.yaml surfaced via the
+SCITEX_AGENT_CONTAINER_CONFIG env override.
+
+Each test: AAA markers (TQ002), one assertion (TQ007), 3+-word name
+(TQ003).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from scitex_agent_container.cli_pkg.doctor_cmds import doctor
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", "-C", str(repo), *args], check=True, capture_output=True, text=True
+    )
+
+
+@pytest.fixture
+def cfg_with_peer(tmp_path: Path, env_save_restore) -> Path:
+    """Real config.yaml (one peer) surfaced via the env override."""
+    p = tmp_path / "config.yaml"
+    p.write_text("peers:\n  mba: { ssh: user@mba }\n")
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_CONFIG", str(p))
+    return p
+
+
+@pytest.fixture
+def empty_cfg(tmp_path: Path, env_save_restore) -> Path:
+    """Real config.yaml with no peers."""
+    p = tmp_path / "config.yaml"
+    p.write_text("peers: {}\n")
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_CONFIG", str(p))
+    return p
+
+
+# ---------------------------------------------------------------------------
+# sac doctor --fleet
+# ---------------------------------------------------------------------------
+
+
+def test_fleet_table_renders_peer_drift(subprocess_shim, cfg_with_peer):
+    # Arrange
+    subprocess_shim.install("ssh", stdout="SAC_DRIFT behind 0 3 origin/develop\n")
+    # Act
+    result = CliRunner().invoke(doctor, ["--fleet"])
+    # Assert
+    assert "3 behind origin/develop" in result.output
+
+
+def test_fleet_json_lists_each_peer(subprocess_shim, cfg_with_peer):
+    # Arrange
+    subprocess_shim.install("ssh", stdout="SAC_DRIFT current 0 0 origin/develop\n")
+    # Act
+    result = CliRunner().invoke(doctor, ["--fleet", "--json"])
+    payload = json.loads(result.output)
+    # Assert
+    assert payload["peers"][0]["host"] == "mba"
+
+
+def test_fleet_empty_config_notes_no_peers(empty_cfg):
+    # Arrange
+    # Act
+    result = CliRunner().invoke(doctor, ["--fleet"])
+    # Assert
+    assert "no peers configured" in result.output
+
+
+def test_fleet_strict_exits_nonzero_on_drift(subprocess_shim, cfg_with_peer):
+    # Arrange
+    subprocess_shim.install("ssh", stdout="SAC_DRIFT diverged 2 5 origin/develop\n")
+    # Act
+    result = CliRunner().invoke(doctor, ["--fleet", "--strict"])
+    # Assert
+    assert result.exit_code == 1
+
+
+def test_fleet_strict_exits_zero_when_all_current(subprocess_shim, cfg_with_peer):
+    # Arrange
+    subprocess_shim.install("ssh", stdout="SAC_DRIFT current 0 0 origin/develop\n")
+    # Act
+    result = CliRunner().invoke(doctor, ["--fleet", "--strict"])
+    # Assert
+    assert result.exit_code == 0
+
+
+def test_fleet_unreachable_peer_does_not_crash(subprocess_shim, cfg_with_peer):
+    # Arrange — ssh refused: nonzero exit, no marker.
+    subprocess_shim.install("ssh", exit=255, stderr="connect: refused\n")
+    # Act
+    result = CliRunner().invoke(doctor, ["--fleet"])
+    # Assert — reported, not crashed.
+    assert result.exit_code == 0 and "unreachable" in result.output
+
+
+# ---------------------------------------------------------------------------
+# sac doctor (local)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def local_drifted_source(tmp_path: Path, env_save_restore):
+    """Point the local probe at a real BEHIND git repo via SCITEX_DIR.
+
+    ``_local_agents_spec_dir()`` resolves ``~/.scitex/agent-container/
+    agents`` — relocating ``$SCITEX_DIR`` (which expands ``~``-> via
+    HOME isn't enough), so we instead set HOME to a tmp dir whose
+    ``.scitex/agent-container/agents`` is the working clone.
+    """
+    home = tmp_path / "home"
+    agents_parent = home / ".scitex" / "agent-container"
+    agents_parent.mkdir(parents=True)
+
+    remote = tmp_path / "remote.git"
+    subprocess.run(
+        ["git", "init", "--bare", str(remote)], check=True, capture_output=True
+    )
+    work = agents_parent / "agents"
+    subprocess.run(
+        ["git", "clone", str(remote), str(work)], check=True, capture_output=True
+    )
+    _git(work, "config", "user.email", "t@example.com")
+    _git(work, "config", "user.name", "Test")
+    _git(work, "checkout", "-b", "develop")
+    (work / "foo").mkdir()
+    (work / "foo" / "spec.yaml").write_text("x")
+    _git(work, "add", "-A")
+    _git(work, "commit", "-m", "init")
+    _git(work, "push", "-u", "origin", "develop")
+    # Make the local clone BEHIND by pushing from a second clone.
+    other = tmp_path / "other"
+    subprocess.run(
+        ["git", "clone", str(remote), str(other)], check=True, capture_output=True
+    )
+    _git(other, "config", "user.email", "t@example.com")
+    _git(other, "config", "user.name", "Test")
+    _git(other, "checkout", "develop")
+    (other / "new.txt").write_text("remote")
+    _git(other, "add", "-A")
+    _git(other, "commit", "-m", "remote work")
+    _git(other, "push")
+
+    env_save_restore.set("HOME", str(home))
+    # Bust any cross-test fetch cache by relocating the cache root too.
+    env_save_restore.set("SCITEX_DIR", str(home / ".scitex"))
+    return work
+
+
+def test_local_check_reports_drift_summary(local_drifted_source):
+    # Arrange
+    # Act
+    result = CliRunner().invoke(doctor, [])
+    # Assert
+    assert "behind origin/develop" in result.output
+
+
+def test_local_strict_exits_nonzero_on_drift(local_drifted_source):
+    # Arrange
+    # Act
+    result = CliRunner().invoke(doctor, ["--strict"])
+    # Assert
+    assert result.exit_code == 1
+
+
+def test_local_json_carries_state_field(local_drifted_source):
+    # Arrange
+    # Act
+    result = CliRunner().invoke(doctor, ["--json"])
+    payload = json.loads(result.output)
+    # Assert
+    assert payload["local"]["state"] == "behind"


### PR DESCRIPTION
## What

Two-part spec-source git-drift detection (operator-approved; tracked as `sac-drift` under sac-hardening).

### Part 1 — launch-time LOCAL drift check
`sac agents start` (and any lifecycle path reading a spec, via `agent_start`) now checks that the local host's agent-spec source git repo is current with its remote. On these hosts `~/.scitex/agent-container/agents` symlinks into `~/.dotfiles`; `git rev-parse --show-toplevel` follows the symlink to the real checkout.

- **BEHIND** → may launch a stale spec. **AHEAD/DIVERGED** → spec won't propagate.
- **Default = LOUD stderr warning, NOT a block** — hosts like spartan legitimately carry local commits, so a hard block would break every start there. `--strict-drift` flag + `SAC_STRICT_DRIFT=1` env escalate to a hard block (non-zero exit, runtime never reached).
- **FAST**: one cached `git fetch` per repo (60 s TTL) + instant local `rev-list` compare. **RESILIENT**: non-git source / unreachable remote / missing git / any error → warn-and-continue. The guard never crashes a launch.

### Part 2 — `sac doctor --fleet`
New top-level `doctor` command.
- `sac doctor` — this host's spec source vs its remote.
- `sac doctor --fleet` — ssh every configured peer (`config.yaml` `peers:`), run the same git-drift snippet remotely, render a per-host table (current / N-behind / M-ahead / diverged / unreachable / not-a-repo). `--strict` → non-zero exit if any host drifted. `--json` for machines. An unreachable host is reported, never crashes the sweep.

## Refactor
Extracted the per-target single-start loop from `cli_pkg/lifecycle/_start.py` into a sibling `_start_single.py` to keep the click entry under the 512-line cap (the `--strict-drift` option pushed it over). Public `start` command + imports unchanged.

## Tests (no mocks — STX-NM)
Real `git init` repos for the local logic, a real PATH-installed `ssh` shim for the fleet ssh round-trip, real injected `runner` callables for resilience paths.

- `_drift/test__status.py` — DriftStatus model
- `_drift/test__local.py` — state classification, fetch-cache TTL, warning render, strict raise, resilience
- `_drift/test__fleet.py` — marker parse, motd-noise tolerance, unreachable/timeout resilience, sweep ordering
- `_lifecycle/test__start_drift.py` — launch-guard wiring (lenient vs strict, env fallback, runtime-not-reached)
- `cli_pkg/test_doctor_cmds.py` — doctor local + `--fleet` CLI surface

## Verification
- Full suite green: **4954 passed, 35 skipped**.
- `ruff check` clean on new files; `scitex-dev ecosystem audit-project` clean.
- Verified live against real env: `sac doctor` correctly flagged `~/.dotfiles` as 1-ahead; `sac doctor --fleet` reached real peers (spartan diverged 2/27, mba/nas not-a-repo, glob peer unreachable) without crashing.