### PR TITLE
test(host): harden host probe --json assertions against opaque failures

### DIFF
--- a/tests/scitex_agent_container/_state/test_host_config.py
+++ b/tests/scitex_agent_container/_state/test_host_config.py
@@ -29,6 +29,38 @@ from scitex_agent_container._state.host_config import (
 )
 
 
+def _parse_probe_json(result, *, expect_exit: int = 0) -> dict:
+    """Resiliently parse a ``host probe --json`` invocation.
+
+    Guards both failure surfaces so a flaky run produces an actionable
+    diagnostic instead of an opaque ``JSONDecodeError`` or a bare
+    ``AssertionError`` with no context:
+
+    1. The CLI exit code matches ``expect_exit`` (probe payload is only
+       trustworthy when the command ran to completion).
+    2. ``result.output`` parses as a JSON object.
+
+    Returns the parsed payload so callers assert on a structured field
+    (``payload["remote_canonical"]``) rather than on exact / ordered
+    output text.
+    """
+    assert result.exit_code == expect_exit, (
+        f"host probe exit_code={result.exit_code} (expected {expect_exit}); "
+        f"exception={result.exception!r}; output={result.output!r}"
+    )
+    try:
+        payload = json.loads(result.output)
+    except ValueError as exc:  # JSONDecodeError subclasses ValueError
+        raise AssertionError(
+            f"host probe --json did not emit parseable JSON: {exc}; "
+            f"raw output={result.output!r}"
+        ) from exc
+    assert isinstance(payload, dict), (
+        f"host probe --json payload is not an object: {payload!r}"
+    )
+    return payload
+
+
 @pytest.fixture
 def cfg_path(tmp_path: Path, env_save_restore) -> Path:
     """Real config.yaml at tmp_path, surfaced via the env override."""
@@ -439,7 +471,7 @@ def test_host_probe_reports_reachable_with_remote_canonical(
     # Act
     result = CliRunner().invoke(host_probe, ["mba", "--json"])
     # Assert
-    assert json.loads(result.output)["reachable"] is True
+    assert _parse_probe_json(result)["reachable"] is True
 
 
 def test_host_probe_surfaces_parsed_remote_canonical(cfg_path: Path, subprocess_shim):
@@ -456,7 +488,7 @@ def test_host_probe_surfaces_parsed_remote_canonical(cfg_path: Path, subprocess_
     # Act
     result = CliRunner().invoke(host_probe, ["mba", "--json"])
     # Assert
-    assert json.loads(result.output)["remote_canonical"] == "mba"
+    assert _parse_probe_json(result)["remote_canonical"] == "mba"
 
 
 def test_host_probe_reports_unreachable_on_nonzero_exit(
@@ -474,7 +506,7 @@ def test_host_probe_reports_unreachable_on_nonzero_exit(
     # Act
     result = CliRunner().invoke(host_probe, ["mba", "--json"])
     # Assert
-    assert json.loads(result.output)["reachable"] is False
+    assert _parse_probe_json(result, expect_exit=1)["reachable"] is False
 
 
 def test_host_probe_surfaces_ssh_exit_code(cfg_path: Path, subprocess_shim):
@@ -486,7 +518,7 @@ def test_host_probe_surfaces_ssh_exit_code(cfg_path: Path, subprocess_shim):
     # Act
     result = CliRunner().invoke(host_probe, ["mba", "--json"])
     # Assert
-    assert json.loads(result.output)["exit_code"] == 255
+    assert _parse_probe_json(result, expect_exit=1)["exit_code"] == 255
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

The four `host probe --json` tests in `tests/scitex_agent_container/_state/test_host_config.py` (including `test_host_probe_surfaces_parsed_remote_canonical`) parsed `result.output` directly with `json.loads(...)` and indexed a nested key.

That pattern is brittle: any output corruption — empty output, a stderr warning mixed into stdout, or a non-zero exit before the JSON payload is emitted — surfaced as an opaque `JSONDecodeError` or a silently mis-parsed payload, with no diagnostic pointing at the actual cause.

## How

Added a local `_parse_probe_json(result, expect_exit=...)` helper that:

1. Asserts the CLI exit code first (probe payload is only trustworthy when the command ran to completion — exit 0 reachable, exit 1 unreachable), with `result.exception` + raw output in the message.
2. Parses the JSON defensively, raising `AssertionError` with the raw output embedded when it isn't parseable.
3. Asserts the payload is an object.

Then returns it so each test asserts on a **structured field** (`payload["remote_canonical"]`) rather than on exact / ordered output text.

## Scope

Test-only robustness change — **no production behaviour touched**. The named test was already passing deterministically in local reproduction (no `pytest-randomly` in the dep set; order is definition-order); this PR removes its latent fragility so a future flake produces an actionable message instead of an opaque parse error.

## Verification

- `test_host_probe_surfaces_parsed_remote_canonical` x5 + the full `test_host_config.py` (39 tests) under `-n auto`: green.
- Full suite: `4950 passed, 38 skipped` (deselecting the pre-existing, unrelated timing-flaky `TestListJsonTimeoutBudget::test_hanging_remote_probe_respects_timeout_budget`, which `assert elapsed < 3.0` against a 1s timeout and flakes under parallel CPU contention — out of scope here as fixing it touches production timing logic).
- `ruff check` + `scitex-dev linter check-files`: clean.