### PR TITLE
feat(registry): auto-record bound port + lineage in start codepath (Phase 1, Rule B)

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_instances.py
+++ b/src/scitex_agent_container/_lifecycle/_instances.py
@@ -25,6 +25,21 @@ from typing import Any
 from ..config import AgentConfig
 
 
+def _spawned_by() -> str:
+    """Return the launching identity for the lineage edge (Rule B/D).
+
+    When a PARENT agent shells out ``sac agents start <child>``, its
+    container env carries ``SAC_NAME`` (the parent's own name), so the
+    child's row records ``spawned_by=<parent>``. A bare CLI / lead /
+    operator launch has no ``SAC_NAME`` and records ``"cli"``. Richer
+    attribution (operator vs lead vs a specific human) is a documented
+    follow-on phase; the schema column is ready for it now.
+    """
+    from .._env import getenv
+
+    return getenv("NAME") or "cli"
+
+
 def _state_dir_for(config: AgentConfig, runtime: Any):
     """Per-agent runtime state dir, via the runtime's own resolver.
 
@@ -68,10 +83,20 @@ def record_local_instance(config: AgentConfig, runtime: Any) -> str | None:
     workdir = getattr(config, "expanded_workdir", None) or getattr(
         config, "workdir", None
     )
+    # Rule B (sac-agent-spawn design): recording the lineage + bound
+    # port is an intrinsic side-effect of the start codepath, never a
+    # caller responsibility. ``spawned_by`` is the launching identity:
+    # the parent agent's SAC_NAME when a parent shelled out, else "cli"
+    # for a bare lead/operator launch. ``remote=False`` — this helper is
+    # only reached on the host where the agent actually runs; the
+    # cross-host dispatcher records the remote=True lead-side row.
     instance_id = record_instance_start(
         name=config.name,
         host=host,
         a2a_port=a2a_port,
+        bound_port=a2a_port,
+        remote=False,
+        spawned_by=_spawned_by(),
         workdir=str(workdir) if workdir else None,
     )
 

--- a/src/scitex_agent_container/_lifecycle/_status.py
+++ b/src/scitex_agent_container/_lifecycle/_status.py
@@ -14,6 +14,53 @@ from ..config import AgentConfig, load_config
 from ._runtime_select import _fallback_workdir, _get_runtime
 
 
+def _remote_instance_status(name: str) -> dict | None:
+    """Build a status dict from the active ``instances`` row for ``name``.
+
+    Used when the LOCAL file registry has no entry — the case for a
+    cross-host-dispatched agent, whose row was written into the
+    ``instances`` table by the dispatcher (``remote=1`` + peer ``host``
+    + peer-resolved ``bound_port``). Returns ``None`` when no active row
+    exists (caller raises the normal "not found" error), or on any
+    lookup failure.
+
+    The shape mirrors the canonical ``agent_status`` keys callers
+    expect, surfacing the family-tree fields (``host``, ``a2a_port`` /
+    ``bound_port``, ``remote``, ``spawned_by``) so a remote agent
+    resolves rather than erroring.
+    """
+    try:
+        from .._state.state_db import list_active_instances
+
+        rows = [r for r in list_active_instances() if r.get("name") == name]
+        if not rows:
+            return None
+        # list_active_instances orders started_at DESC → newest first.
+        row = rows[0]
+        bound = row.get("bound_port")
+        if bound is None:
+            bound = row.get("a2a_port")
+        return {
+            "name": name,
+            "config": "",
+            "screen": row.get("screen", "") or "",
+            "started_at": row.get("started_at", "") or "",
+            # The instances row says the agent is active (ended_at IS
+            # NULL); reaching the remote runtime to confirm is the
+            # cross-host dispatcher's job, not this read-side resolver.
+            "status": "running",
+            "model": "unknown",
+            "runtime": "unknown",
+            "host": row.get("host", "") or "",
+            "a2a_port": row.get("a2a_port"),
+            "bound_port": bound,
+            "remote": bool(row.get("remote")),
+            "spawned_by": row.get("spawned_by"),
+        }
+    except Exception:  # stx-allow: fallback (reason: best-effort cross-host status — caller raises the normal "not found" error when None)
+        return None
+
+
 def agent_status(
     name: str,
     registry: Registry | None = None,
@@ -30,6 +77,15 @@ def agent_status(
     registry = registry or Registry()
     entry = registry.get(name)
     if entry is None:
+        # Cross-host fallback (sac-agent-spawn design, Rule B/F): a
+        # remote-dispatched agent has no LOCAL file-registry entry — its
+        # row lives in the ``instances`` table written by the cross-host
+        # dispatcher. Resolve status from there so ``sac agents status
+        # <remote>`` reports host + bound_port + remote + spawned_by
+        # instead of raising "not found in registry".
+        remote_status = _remote_instance_status(name)
+        if remote_status is not None:
+            return remote_status
         raise RuntimeError(f"Agent '{name}' not found in registry")
 
     runtime_factory = runtime_factory or _get_runtime

--- a/src/scitex_agent_container/_network/_peer_resolve.py
+++ b/src/scitex_agent_container/_network/_peer_resolve.py
@@ -1,0 +1,234 @@
+"""Agent-name → ``/v1/turn`` URL resolution for the peer client.
+
+Extracted from :mod:`peer` (which would otherwise exceed the 512-line
+per-file cap after the cross-host ``_lookup_instance_endpoint``
+read-back landed). Mirrors the existing ``_peer_timeout`` /
+``_peer_dispatch`` extractions: the transport machinery
+(``post_turn`` / ``post_turn_to_url``) stays in :mod:`peer`; this module
+owns the "where does this agent listen?" resolution.
+
+:class:`PeerError` is imported from :mod:`peer` — the same direction
+``_peer_timeout`` already imports it, so there is no cycle (nothing in
+:mod:`peer` imports this module at its own load time; the re-export at
+the bottom of :mod:`peer` runs after ``PeerError`` is defined).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .peer import PeerError
+
+
+def resolve_peer_url(agent_name: str) -> str:
+    """Resolve the ``/v1/turn`` URL for a named agent.
+
+    Looks up the agent's YAML via the standard discovery chain
+    (project-local → ``~/.scitex/agent-container/agents/`` → env →
+    fleet dirs), reads ``spec.a2a.{host,port}`` and ``spec.host``,
+    and returns the URL the caller should POST to.
+
+    When the YAML pins ``spec.a2a.port: auto`` the actual bound port
+    isn't in the YAML — it lives in ``state.db``'s ``a2a_ports`` table
+    where the port allocator persists the claim at agent_start.  We
+    consult that table by ``agent_name`` to discover the real port.
+    See foundation-polish bug 1.
+
+    For **cross-host** agents (``spec.host`` is set to a non-local peer
+    name) the returned URL is a synthetic ``ssh://<host>:<port>/v1/turn``
+    form that :func:`peer.post_turn_to_url` recognises and dispatches via
+    ``ssh <host> curl http://127.0.0.1:<port>/...``. This way the agent
+    can keep ``spec.a2a.host: 127.0.0.1`` (more secure) and remote
+    callers still reach it through the ssh control plane — no LAN
+    exposure required, no DNS resolution needed for ssh aliases.
+
+    The same ``spec.host`` field is consulted by ``sac start`` for
+    dispatch, so post-turn cannot disagree about where the agent
+    lives. The legacy ``spec.remote`` block was deleted in WI-6
+    (handoff §6, 2026-05-20).
+    """
+    from ..config._resolve import resolve_config
+
+    try:
+        yaml_path = resolve_config(agent_name)
+    except FileNotFoundError as exc:
+        raise PeerError(str(exc)) from exc
+
+    a2a_host, a2a_port, dest_host = _read_yaml_endpoints(yaml_path)
+    if a2a_port is None:
+        a2a_port = _lookup_bound_port(agent_name)
+    if a2a_port is None:
+        # Cross-host fallback (sac-agent-spawn design, Rule B/F): the
+        # local port allocator only holds claims for agents that ran on
+        # THIS host. A remote-dispatched agent's bound port + host live
+        # in the ``instances`` table (written by the cross-host
+        # dispatcher's ``record_instance_start`` with ``remote=True``).
+        # Consult it so post-turn resolves a remote agent instead of
+        # raising "port: auto and no bound port recorded" — the exact
+        # gap that left the lead unable to reach clew on Spartan
+        # (2026-05-23).
+        inst_port, inst_host = _lookup_instance_endpoint(agent_name)
+        if inst_port is not None:
+            a2a_port = inst_port
+            if inst_host and not dest_host:
+                dest_host = inst_host
+    if a2a_port is None:
+        if _yaml_port_is_auto(yaml_path):
+            raise PeerError(
+                f"agent {agent_name!r} has port: auto and no bound port "
+                "recorded in registry; is the agent running?"
+            )
+        raise PeerError(
+            f"agent {agent_name!r} has no spec.a2a.port — add a port to "
+            "its YAML to enable inbound /v1/turn"
+        )
+    if dest_host and not _is_local_host(dest_host):
+        # Tunnel via ssh — agent's a2a.host can stay loopback (default).
+        return f"ssh://{dest_host}:{a2a_port}/v1/turn"
+    # Local agent (spec.host empty or pointing at this machine).
+    host = a2a_host or "127.0.0.1"
+    return f"http://{host}:{a2a_port}/v1/turn"
+
+
+def _is_local_host(dest_host: str) -> bool:
+    """Return True iff ``dest_host`` names the current machine.
+
+    Consults host_config's canonical hostname so an agent pinned to
+    its own host is reached via http://127.0.0.1, not via ssh-to-self.
+    Any resolution failure raises — we do not silently treat unknown
+    hosts as local (would mask config drift).
+    """
+    from .._state.host_config import load as load_host_config
+
+    cfg = load_host_config()
+    canonical = cfg.canonical_host()
+    return dest_host == canonical or dest_host in cfg.host.aliases
+
+
+def _lookup_bound_port(agent_name: str) -> int | None:
+    """Return the port the allocator persisted for ``agent_name``, else None.
+
+    The YAML may say ``spec.a2a.port: auto`` (or omit ``port`` entirely)
+    when the spec author wants the runtime to pick a free port. The
+    actual port is recorded in the ``a2a_ports`` table in ``state.db``
+    by :func:`_state.port_allocator.claim_port` at agent_start. The
+    peer client consults the same table so it can talk to an
+    auto-port agent without having to re-parse + reproduce the
+    allocator's logic.
+
+    Failure modes (registry missing, schema not yet created, sqlite
+    locked) degrade to ``None`` so the caller raises the same "no
+    port recorded" PeerError it would for a static-port misconfig.
+    """
+    try:
+        from .._state.port_allocator import get_port
+
+        return get_port(agent_name)
+    except Exception:  # stx-allow: fallback (reason: best-effort lookup — caller raises a clear PeerError when None)
+        return None
+
+
+def _lookup_instance_endpoint(agent_name: str) -> tuple[int | None, str | None]:
+    """Return ``(bound_port, host)`` from the active ``instances`` row.
+
+    The cross-host dispatcher records a lead-side ``instances`` row with
+    ``remote=True``, the peer ``host``, and the peer-resolved
+    ``bound_port`` (``record_instance_start`` in
+    ``cli_pkg/lifecycle/_dispatch.py``). When the local port allocator
+    has no claim for ``agent_name`` — always the case for an agent that
+    ran on a DIFFERENT host — this is where the bound port + host live.
+
+    Prefers the ``bound_port`` column, falling back to legacy
+    ``a2a_port`` for rows written before the family-tree columns
+    existed. Returns ``(None, None)`` when no active row exists or any
+    lookup fails (caller raises the same clear PeerError it would for a
+    missing port).
+    """
+    try:
+        from .._state.state_db import list_active_instances
+
+        rows = [r for r in list_active_instances() if r.get("name") == agent_name]
+        if not rows:
+            return (None, None)
+        # list_active_instances orders started_at DESC → newest first.
+        row = rows[0]
+        port = row.get("bound_port")
+        if port is None:
+            port = row.get("a2a_port")
+        host = row.get("host") or None
+        return (int(port) if port is not None else None, host)
+    except Exception:  # stx-allow: fallback (reason: best-effort cross-host lookup — caller raises a clear PeerError when None)
+        return (None, None)
+
+
+def _yaml_port_is_auto(yaml_path: str) -> bool:
+    """Return True iff ``spec.a2a.port`` is the literal string ``"auto"``.
+
+    Used to decide which PeerError to raise when no bound port is
+    available: an auto-port spec with no registry entry means "agent
+    isn't running", while a missing port means "the spec is incomplete".
+    Best-effort — any IO / parse failure returns False.
+    """
+    try:
+        from pathlib import Path
+
+        import yaml as _yaml
+
+        raw = _yaml.safe_load(Path(yaml_path).read_text(encoding="utf-8")) or {}
+    except Exception:  # stx-allow: fallback (reason: best-effort detection; falls through to generic no-port error)
+        return False
+    spec = (raw.get("spec") or {}) if isinstance(raw, dict) else {}
+    a2a = spec.get("a2a") or {}
+    port = a2a.get("port") if isinstance(a2a, dict) else None
+    return isinstance(port, str) and port.strip().lower() == "auto"
+
+
+def _read_yaml_endpoints(yaml_path: str) -> tuple[str | None, int | None, str | None]:
+    """Return ``(a2a_host, a2a_port, dest_host)`` from a v3 YAML file.
+
+    ``dest_host`` is the agent's destination peer name (the value of
+    ``spec.host``). It is the same lookup key used by cross-host
+    dispatch, so peer routing and start dispatch agree on a single
+    field. SSH alias resolution happens at the SSH layer
+    (``~/.ssh/config``), not here.
+
+    Best-effort: any IO / parse failure produces ``(None, None, None)``.
+    """
+    try:
+        from pathlib import Path
+
+        import yaml as _yaml
+
+        v3 = _yaml.safe_load(Path(yaml_path).read_text(encoding="utf-8")) or {}
+    except Exception:  # stx-allow: fallback (reason: malformed YAML degrades to "no endpoints" — caller raises a clear PeerError)
+        return (None, None, None)
+    spec = (v3.get("spec") or {}) if isinstance(v3, dict) else {}
+    a2a: dict[str, Any] = spec.get("a2a") or {}
+    a2a_port = a2a.get("port")
+    if not isinstance(a2a_port, int) or a2a_port <= 0:
+        a2a_port = None
+    a2a_host = a2a.get("host")
+    if not isinstance(a2a_host, str) or not a2a_host.strip():
+        a2a_host = None
+    # spec.host (HostsSpec) is the single source of truth for the
+    # destination peer. Can be empty (local), a string (one host),
+    # or a list (priority chain — last entry wins for routing).
+    raw_host = spec.get("host")
+    dest_host: str | None = None
+    if isinstance(raw_host, str) and raw_host.strip():
+        dest_host = raw_host.strip()
+    elif isinstance(raw_host, list) and raw_host:
+        last = raw_host[-1]
+        if isinstance(last, str) and last.strip():
+            dest_host = last.strip()
+    return (a2a_host, a2a_port, dest_host)
+
+
+__all__ = [
+    "resolve_peer_url",
+    "_is_local_host",
+    "_lookup_bound_port",
+    "_lookup_instance_endpoint",
+    "_yaml_port_is_auto",
+    "_read_yaml_endpoints",
+]

--- a/src/scitex_agent_container/_network/peer.py
+++ b/src/scitex_agent_container/_network/peer.py
@@ -204,121 +204,6 @@ def post_turn_to_url(
     return str(payload["text"])
 
 
-def resolve_peer_url(agent_name: str) -> str:
-    """Resolve the ``/v1/turn`` URL for a named agent.
-
-    Looks up the agent's YAML via the standard discovery chain
-    (project-local → ``~/.scitex/agent-container/agents/`` → env →
-    fleet dirs), reads ``spec.a2a.{host,port}`` and ``spec.host``,
-    and returns the URL the caller should POST to.
-
-    When the YAML pins ``spec.a2a.port: auto`` the actual bound port
-    isn't in the YAML — it lives in ``state.db``'s ``a2a_ports`` table
-    where the port allocator persists the claim at agent_start.  We
-    consult that table by ``agent_name`` to discover the real port.
-    See foundation-polish bug 1.
-
-    For **cross-host** agents (``spec.host`` is set to a non-local peer
-    name) the returned URL is a synthetic ``ssh://<host>:<port>/v1/turn``
-    form that :func:`post_turn_to_url` recognises and dispatches via
-    ``ssh <host> curl http://127.0.0.1:<port>/...``. This way the agent
-    can keep ``spec.a2a.host: 127.0.0.1`` (more secure) and remote
-    callers still reach it through the ssh control plane — no LAN
-    exposure required, no DNS resolution needed for ssh aliases.
-
-    The same ``spec.host`` field is consulted by ``sac start`` for
-    dispatch, so post-turn cannot disagree about where the agent
-    lives. The legacy ``spec.remote`` block was deleted in WI-6
-    (handoff §6, 2026-05-20).
-    """
-    from ..config._resolve import resolve_config
-
-    try:
-        yaml_path = resolve_config(agent_name)
-    except FileNotFoundError as exc:
-        raise PeerError(str(exc)) from exc
-
-    a2a_host, a2a_port, dest_host = _read_yaml_endpoints(yaml_path)
-    if a2a_port is None:
-        a2a_port = _lookup_bound_port(agent_name)
-    if a2a_port is None:
-        if _yaml_port_is_auto(yaml_path):
-            raise PeerError(
-                f"agent {agent_name!r} has port: auto and no bound port "
-                "recorded in registry; is the agent running?"
-            )
-        raise PeerError(
-            f"agent {agent_name!r} has no spec.a2a.port — add a port to "
-            "its YAML to enable inbound /v1/turn"
-        )
-    if dest_host and not _is_local_host(dest_host):
-        # Tunnel via ssh — agent's a2a.host can stay loopback (default).
-        return f"ssh://{dest_host}:{a2a_port}/v1/turn"
-    # Local agent (spec.host empty or pointing at this machine).
-    host = a2a_host or "127.0.0.1"
-    return f"http://{host}:{a2a_port}/v1/turn"
-
-
-def _is_local_host(dest_host: str) -> bool:
-    """Return True iff ``dest_host`` names the current machine.
-
-    Consults host_config's canonical hostname so an agent pinned to
-    its own host is reached via http://127.0.0.1, not via ssh-to-self.
-    Any resolution failure raises — we do not silently treat unknown
-    hosts as local (would mask config drift).
-    """
-    from .._state.host_config import load as load_host_config
-
-    cfg = load_host_config()
-    canonical = cfg.canonical_host()
-    return dest_host == canonical or dest_host in cfg.host.aliases
-
-
-def _lookup_bound_port(agent_name: str) -> int | None:
-    """Return the port the allocator persisted for ``agent_name``, else None.
-
-    The YAML may say ``spec.a2a.port: auto`` (or omit ``port`` entirely)
-    when the spec author wants the runtime to pick a free port. The
-    actual port is recorded in the ``a2a_ports`` table in ``state.db``
-    by :func:`_state.port_allocator.claim_port` at agent_start. The
-    peer client consults the same table so it can talk to an
-    auto-port agent without having to re-parse + reproduce the
-    allocator's logic.
-
-    Failure modes (registry missing, schema not yet created, sqlite
-    locked) degrade to ``None`` so the caller raises the same "no
-    port recorded" PeerError it would for a static-port misconfig.
-    """
-    try:
-        from .._state.port_allocator import get_port
-
-        return get_port(agent_name)
-    except Exception:  # stx-allow: fallback (reason: best-effort lookup — caller raises a clear PeerError when None)
-        return None
-
-
-def _yaml_port_is_auto(yaml_path: str) -> bool:
-    """Return True iff ``spec.a2a.port`` is the literal string ``"auto"``.
-
-    Used to decide which PeerError to raise when no bound port is
-    available: an auto-port spec with no registry entry means "agent
-    isn't running", while a missing port means "the spec is incomplete".
-    Best-effort — any IO / parse failure returns False.
-    """
-    try:
-        from pathlib import Path
-
-        import yaml as _yaml
-
-        raw = _yaml.safe_load(Path(yaml_path).read_text(encoding="utf-8")) or {}
-    except Exception:  # stx-allow: fallback (reason: best-effort detection; falls through to generic no-port error)
-        return False
-    spec = (raw.get("spec") or {}) if isinstance(raw, dict) else {}
-    a2a = spec.get("a2a") or {}
-    port = a2a.get("port") if isinstance(a2a, dict) else None
-    return isinstance(port, str) and port.strip().lower() == "auto"
-
-
 def post_turn(
     agent_name: str,
     text: str,
@@ -462,42 +347,19 @@ def _post_turn_via_ssh(
     return str(payload["text"])
 
 
-def _read_yaml_endpoints(yaml_path: str) -> tuple[str | None, int | None, str | None]:
-    """Return ``(a2a_host, a2a_port, dest_host)`` from a v3 YAML file.
-
-    ``dest_host`` is the agent's destination peer name (the value of
-    ``spec.host``). It is the same lookup key used by cross-host
-    dispatch, so peer routing and start dispatch agree on a single
-    field. SSH alias resolution happens at the SSH layer
-    (``~/.ssh/config``), not here.
-
-    Best-effort: any IO / parse failure produces ``(None, None, None)``.
-    """
-    try:
-        from pathlib import Path
-
-        import yaml as _yaml
-
-        v3 = _yaml.safe_load(Path(yaml_path).read_text(encoding="utf-8")) or {}
-    except Exception:  # stx-allow: fallback (reason: malformed YAML degrades to "no endpoints" — caller raises a clear PeerError)
-        return (None, None, None)
-    spec = (v3.get("spec") or {}) if isinstance(v3, dict) else {}
-    a2a: dict[str, Any] = spec.get("a2a") or {}
-    a2a_port = a2a.get("port")
-    if not isinstance(a2a_port, int) or a2a_port <= 0:
-        a2a_port = None
-    a2a_host = a2a.get("host")
-    if not isinstance(a2a_host, str) or not a2a_host.strip():
-        a2a_host = None
-    # spec.host (HostsSpec) is the single source of truth for the
-    # destination peer. Can be empty (local), a string (one host),
-    # or a list (priority chain — last entry wins for routing).
-    raw_host = spec.get("host")
-    dest_host: str | None = None
-    if isinstance(raw_host, str) and raw_host.strip():
-        dest_host = raw_host.strip()
-    elif isinstance(raw_host, list) and raw_host:
-        last = raw_host[-1]
-        if isinstance(last, str) and last.strip():
-            dest_host = last.strip()
-    return (a2a_host, a2a_port, dest_host)
+# Agent-name → URL resolution moved to ``_peer_resolve`` under the
+# per-file line cap; re-exported here so ``from ...peer import
+# resolve_peer_url`` (and the helper imports the tests rely on) keep
+# working. ``post_turn`` above calls ``resolve_peer_url`` at call time,
+# so the name only needs to be in module globals by then — this
+# bottom-of-module import satisfies that without an import cycle
+# (``_peer_resolve`` imports ``PeerError`` from here, which is defined
+# above before this line runs).
+from ._peer_resolve import (  # noqa: E402,F401
+    _is_local_host,
+    _lookup_bound_port,
+    _lookup_instance_endpoint,
+    _read_yaml_endpoints,
+    _yaml_port_is_auto,
+    resolve_peer_url,
+)

--- a/src/scitex_agent_container/_state/state_db.py
+++ b/src/scitex_agent_container/_state/state_db.py
@@ -34,7 +34,6 @@ module so ``from ...state_db import X`` imports keep working:
 
 from __future__ import annotations
 
-import json
 import os
 import sqlite3
 import uuid
@@ -43,9 +42,15 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Iterator
 
-from .state_db_hostname import resolve_host as _resolve_host
+# Re-exported for the 7 modules that ``from ...state_db import
+# _resolve_host`` (claude_session, _node_channel, state_db_export,
+# state_db_gc, _send, send_cmds, _dispatch). The ``instances`` CRUD
+# that used it directly moved to state_db_instances; keep the
+# re-export here so those import sites keep resolving.
+from .state_db_hostname import resolve_host as _resolve_host  # noqa: F401
 from .state_db_migrations import (
     migrate_instance_heartbeats_add_seq,
+    migrate_instances_add_family_tree_cols,
     migrate_legacy_heartbeats,
 )
 
@@ -90,7 +95,16 @@ CREATE TABLE IF NOT EXISTS instances (
     exit_reason         TEXT,
     iter_count          INTEGER DEFAULT 0,
     input_tokens        INTEGER DEFAULT 0,
-    output_tokens       INTEGER DEFAULT 0
+    output_tokens       INTEGER DEFAULT 0,
+    -- Family-tree / cross-host columns (sac-agent-spawn design, Rule
+    -- B/D). ``bound_port`` mirrors ``a2a_port`` for new readers (both
+    -- written together so legacy ``a2a_port`` callers keep working);
+    -- ``remote`` is 1 for a cross-host-dispatched agent; ``spawned_by``
+    -- is the launching identity ("cli"/parent-agent-name) — the lineage
+    -- edge the spawn DAG is reconstructed from.
+    bound_port          INTEGER,
+    remote              INTEGER DEFAULT 0,
+    spawned_by          TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_instances_active
@@ -336,6 +350,10 @@ def init_schema(db_path: Path | None = None) -> Path:
         migrate_legacy_heartbeats(conn)
         migrate_instance_heartbeats_add_seq(conn)
         conn.executescript(_SCHEMA_REGISTRY)
+        # ``executescript`` above creates ``instances`` fresh on a new
+        # DB (with the family-tree columns) but is a no-op on an
+        # existing one; the migration ADD COLUMNs them onto a pre-cols DB.
+        migrate_instances_add_family_tree_cols(conn)
         conn.executescript(_SCHEMA_ATTEMPTS)
         conn.executescript(_SCHEMA_DIARY)
         conn.commit()
@@ -367,103 +385,10 @@ def table_counts(db_path: Path | None = None) -> dict[str, int]:
     return counts
 
 
-def record_instance_start(
-    name: str,
-    *,
-    pid: int | None = None,
-    ppid: int | None = None,
-    screen: str | None = None,
-    workdir: str | None = None,
-    a2a_port: int | None = None,
-    scope: str = "global",
-    host: str | None = None,
-    definition_id: str | None = None,
-    db_path: Path | None = None,
-) -> str:
-    """Insert an ``instances`` row for a freshly-started agent.
-
-    Returns the new ``instance_id`` (uuid7). Also appends a
-    ``kind='start'`` row to ``events``.
-    """
-    instance_id = new_uuid7()
-    started_at = now_iso()
-    canonical_host = _resolve_host(host)
-    with open_db(db_path) as conn:
-        conn.execute(
-            """
-            INSERT INTO instances (
-                id, definition_id, name, host, scope,
-                pid, ppid, screen, workdir, a2a_port, started_at
-            )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                instance_id,
-                definition_id,
-                name,
-                canonical_host,
-                scope,
-                pid,
-                ppid,
-                screen,
-                workdir,
-                a2a_port,
-                started_at,
-            ),
-        )
-        conn.execute(
-            "INSERT INTO events (ts, instance_id, kind, actor) VALUES (?, ?, 'start', 'sac')",
-            (started_at, instance_id),
-        )
-    return instance_id
-
-
-def record_instance_stop(
-    instance_id: str,
-    *,
-    exit_reason: str = "stopped",
-    db_path: Path | None = None,
-) -> bool:
-    """Mark an instance as ended. Returns True iff a row was updated.
-
-    Idempotent: stopping an already-stopped row is a no-op.
-    """
-    ended_at = now_iso()
-    with open_db(db_path) as conn:
-        cur = conn.execute(
-            "UPDATE instances SET ended_at=?, exit_reason=? "
-            "WHERE id=? AND ended_at IS NULL",
-            (ended_at, exit_reason, instance_id),
-        )
-        if cur.rowcount == 0:
-            return False
-        conn.execute(
-            "INSERT INTO events (ts, instance_id, kind, actor, payload_json) "
-            "VALUES (?, ?, 'stop', 'sac', ?)",
-            (ended_at, instance_id, json.dumps({"exit_reason": exit_reason})),
-        )
-    return True
-
-
-def list_active_instances(
-    host: str | None = None,
-    db_path: Path | None = None,
-) -> list[dict]:
-    """Return every ``ended_at IS NULL`` row, optionally host-filtered."""
-    with open_db(db_path) as conn:
-        if host is None:
-            cur = conn.execute(
-                "SELECT * FROM instances WHERE ended_at IS NULL "
-                "ORDER BY started_at DESC"
-            )
-        else:
-            cur = conn.execute(
-                "SELECT * FROM instances WHERE ended_at IS NULL AND host=? "
-                "ORDER BY started_at DESC",
-                (host,),
-            )
-        return [dict(r) for r in cur.fetchall()]
-
+# ``instances`` lifecycle CRUD (record_instance_start / _stop /
+# list_active_instances) moved to :mod:`state_db_instances` under the
+# per-file line cap; re-exported below so callers keep importing them
+# from :mod:`state_db`.
 
 # Re-export the helpers that used to live in this file but moved
 # into sibling modules under the per-file line cap. Existing callers
@@ -490,6 +415,11 @@ from .state_db_gc import (  # noqa: E402,F401
 from .state_db_heartbeats import (  # noqa: E402,F401
     latest_instance_heartbeat,
     update_heartbeat,
+)
+from .state_db_instances import (  # noqa: E402,F401
+    list_active_instances,
+    record_instance_start,
+    record_instance_stop,
 )
 
 

--- a/src/scitex_agent_container/_state/state_db_instances.py
+++ b/src/scitex_agent_container/_state/state_db_instances.py
@@ -1,0 +1,160 @@
+"""``instances`` lifecycle CRUD for state.db.
+
+Extracted from :mod:`state_db` (which would otherwise exceed the
+512-line per-file cap after the sac-agent-spawn family-tree columns
+landed). DDL for the ``instances`` table still lives in
+:mod:`state_db`; this module owns the row WRITE/READ helpers and is
+re-exported from :mod:`state_db` so ``from ...state_db import
+record_instance_start`` keeps working for every existing caller.
+
+Family-tree columns (sac-agent-spawn design, Rule B/D):
+
+  * ``bound_port`` — the ACTUAL bound a2a port. Written together with
+    the legacy ``a2a_port`` so new readers can prefer ``bound_port``
+    while legacy ``a2a_port`` callers keep working unchanged.
+  * ``remote`` — ``1`` when the row was written for an agent that
+    landed on a DIFFERENT host (cross-host dispatch); ``0`` for a
+    local start.
+  * ``spawned_by`` — the launching identity (parent agent name, or
+    ``"cli"`` when launched from the bare CLI / lead). The lineage
+    edge the family-tree DAG is reconstructed from.
+
+Following the sibling-module convention (``state_db_diary``,
+``state_db_heartbeats``), :func:`state_db.open_db` and the id/clock
+helpers are imported lazily inside each function so :mod:`state_db`
+can re-export from here without a circular import at module load.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from .state_db_hostname import resolve_host as _resolve_host
+
+
+def record_instance_start(
+    name: str,
+    *,
+    pid: int | None = None,
+    ppid: int | None = None,
+    screen: str | None = None,
+    workdir: str | None = None,
+    a2a_port: int | None = None,
+    scope: str = "global",
+    host: str | None = None,
+    definition_id: str | None = None,
+    bound_port: int | None = None,
+    remote: bool = False,
+    spawned_by: str | None = None,
+    db_path: Path | None = None,
+) -> str:
+    """Insert an ``instances`` row for a freshly-started agent.
+
+    Returns the new ``instance_id`` (uuid7). Also appends a
+    ``kind='start'`` row to ``events``.
+
+    The family-tree columns make every start — local OR cross-host
+    dispatch — record its bound port, host, lineage and locality as an
+    intrinsic side-effect (sac-agent-spawn design, Rule B). When
+    ``bound_port`` is not given it defaults to ``a2a_port`` so a caller
+    that only knows the resolved port still populates both columns.
+    """
+    from .state_db import new_uuid7, now_iso, open_db
+
+    instance_id = new_uuid7()
+    started_at = now_iso()
+    canonical_host = _resolve_host(host)
+    if bound_port is None:
+        bound_port = a2a_port
+    with open_db(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO instances (
+                id, definition_id, name, host, scope,
+                pid, ppid, screen, workdir, a2a_port, started_at,
+                bound_port, remote, spawned_by
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                instance_id,
+                definition_id,
+                name,
+                canonical_host,
+                scope,
+                pid,
+                ppid,
+                screen,
+                workdir,
+                a2a_port,
+                started_at,
+                bound_port,
+                1 if remote else 0,
+                spawned_by,
+            ),
+        )
+        conn.execute(
+            "INSERT INTO events (ts, instance_id, kind, actor) "
+            "VALUES (?, ?, 'start', 'sac')",
+            (started_at, instance_id),
+        )
+    return instance_id
+
+
+def record_instance_stop(
+    instance_id: str,
+    *,
+    exit_reason: str = "stopped",
+    db_path: Path | None = None,
+) -> bool:
+    """Mark an instance as ended. Returns True iff a row was updated.
+
+    Idempotent: stopping an already-stopped row is a no-op.
+    """
+    from .state_db import now_iso, open_db
+
+    ended_at = now_iso()
+    with open_db(db_path) as conn:
+        cur = conn.execute(
+            "UPDATE instances SET ended_at=?, exit_reason=? "
+            "WHERE id=? AND ended_at IS NULL",
+            (ended_at, exit_reason, instance_id),
+        )
+        if cur.rowcount == 0:
+            return False
+        conn.execute(
+            "INSERT INTO events (ts, instance_id, kind, actor, payload_json) "
+            "VALUES (?, ?, 'stop', 'sac', ?)",
+            (ended_at, instance_id, json.dumps({"exit_reason": exit_reason})),
+        )
+    return True
+
+
+def list_active_instances(
+    host: str | None = None,
+    db_path: Path | None = None,
+) -> list[dict]:
+    """Return every ``ended_at IS NULL`` row, optionally host-filtered."""
+    from .state_db import open_db
+
+    with open_db(db_path) as conn:
+        if host is None:
+            cur = conn.execute(
+                "SELECT * FROM instances WHERE ended_at IS NULL "
+                "ORDER BY started_at DESC"
+            )
+        else:
+            cur = conn.execute(
+                "SELECT * FROM instances WHERE ended_at IS NULL AND host=? "
+                "ORDER BY started_at DESC",
+                (host,),
+            )
+        return [dict(r) for r in cur.fetchall()]
+
+
+__all__ = [
+    "list_active_instances",
+    "record_instance_start",
+    "record_instance_stop",
+]

--- a/src/scitex_agent_container/_state/state_db_migrations.py
+++ b/src/scitex_agent_container/_state/state_db_migrations.py
@@ -12,6 +12,9 @@ every :func:`state_db.init_schema`.
     ``instance_heartbeats`` to add the monotonic ``seq`` PK that makes
     "latest heartbeat" deterministic (see the table DDL in
     :mod:`state_db` and :mod:`state_db_heartbeats`).
+  * :func:`migrate_instances_add_family_tree_cols` — ADD COLUMN the
+    sac-agent-spawn family-tree columns (``bound_port``, ``remote``,
+    ``spawned_by``) onto a pre-existing ``instances`` table.
 """
 
 from __future__ import annotations
@@ -99,3 +102,38 @@ def migrate_instance_heartbeats_add_seq(conn: sqlite3.Connection) -> None:
         ALTER TABLE instance_heartbeats__new RENAME TO instance_heartbeats;
         """
     )
+
+
+def migrate_instances_add_family_tree_cols(conn: sqlite3.Connection) -> None:
+    """ADD the sac-agent-spawn family-tree columns to ``instances``.
+
+    New columns (see :mod:`state_db` DDL + :mod:`state_db_instances`):
+
+      * ``bound_port`` INTEGER — the actual bound a2a port.
+      * ``remote``     INTEGER DEFAULT 0 — 1 for a cross-host agent.
+      * ``spawned_by`` TEXT — launching identity (lineage edge).
+
+    A fresh DB gets these from the ``CREATE TABLE`` DDL; this migration
+    is for an EXISTING ``instances`` table created before the columns
+    existed. ``ALTER TABLE ... ADD COLUMN`` is cheap and SQLite-native.
+
+    Detection: ``instances`` exists AND is missing one of the three
+    columns. Per-column guarded so a partially-migrated DB completes.
+    Idempotent: a no-op once all three columns are present (or the
+    table is absent).
+    """
+    existing = {
+        r[0]
+        for r in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+    }
+    if "instances" not in existing:
+        return
+    cols = {r[1] for r in conn.execute("PRAGMA table_info(instances)").fetchall()}
+    if "bound_port" not in cols:
+        conn.execute("ALTER TABLE instances ADD COLUMN bound_port INTEGER")
+    if "remote" not in cols:
+        conn.execute("ALTER TABLE instances ADD COLUMN remote INTEGER DEFAULT 0")
+    if "spawned_by" not in cols:
+        conn.execute("ALTER TABLE instances ADD COLUMN spawned_by TEXT")

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_dispatch.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_dispatch.py
@@ -38,6 +38,19 @@ if TYPE_CHECKING:
     from ..._state.host_config import PeerSpec
 
 
+def _spawned_by() -> str:
+    """Launching identity for the lineage edge (Rule B/D).
+
+    The host that runs ``sac agents start`` and dispatches cross-host is
+    the spawn parent. A parent AGENT shelling out carries ``SAC_NAME``
+    in its env (recorded as ``spawned_by=<parent>``); a bare lead /
+    operator dispatch has none and records ``"cli"``.
+    """
+    from ..._env import getenv
+
+    return getenv("NAME") or "cli"
+
+
 def _is_first_launch_line(line: str) -> bool:
     """Return True when an rsync ``--itemize-changes`` row is a pure-new
     entry (head contains only ``+`` markers, no ``*`` deletion flag).
@@ -234,11 +247,24 @@ def _dispatch_remote_start(
     # Lead-side instances row — mirrors the canonical
     # record_instance_start API used elsewhere. host=peer so cross-host
     # listings see the remote agent; a2a_port comes from the peer's
-    # --json output (None when sidecar is disabled).
+    # --json output (None when sidecar is disabled). This is the BOUND
+    # port the peer's allocator resolved — the crux of the remote-port
+    # gap fix: the peer's ``--json`` ``a2a_port`` field carries the
+    # concrete int the peer's port allocator claimed (auto -> int
+    # happens BEFORE the runtime builds argv, see
+    # ``_lifecycle/_a2a_port.py``). Recorded as both ``a2a_port`` (legacy
+    # readers) and ``bound_port`` (new readers). ``remote=True`` marks
+    # the cross-host locality so ``resolve_peer_url`` / ``agent_status``
+    # know to reach the agent on ``peer``. ``spawned_by`` is the
+    # launching identity (Rule B/D lineage edge).
+    bound = peer_state.get("a2a_port")
     record_instance_start(
         name=name,
         host=peer,
-        a2a_port=peer_state.get("a2a_port"),
+        a2a_port=bound,
+        bound_port=bound,
+        remote=True,
+        spawned_by=_spawned_by(),
     )
     click.echo(
         f"[dispatch] {name!r} started on {peer!r} "

--- a/tests/scitex_agent_container/_lifecycle/test__instances.py
+++ b/tests/scitex_agent_container/_lifecycle/test__instances.py
@@ -97,6 +97,79 @@ def test_record_local_instance_persists_resolved_a2a_port(db_path, tmp_path) -> 
     assert row["a2a_port"] == 7901
 
 
+def test_record_local_instance_mirrors_bound_port(db_path, tmp_path) -> None:
+    # Arrange — local row's bound_port mirrors the allocator-claimed port.
+    from scitex_agent_container._lifecycle._instances import record_local_instance
+    from scitex_agent_container._state.state_db import list_active_instances
+
+    cfg = AgentConfig(name="rec-bp", runtime="apptainer")
+    _claim_port("rec-bp", 7902)
+    # Act
+    record_local_instance(cfg, _RuntimeStub(tmp_path))
+    # Assert
+    row = [r for r in list_active_instances() if r["name"] == "rec-bp"][0]
+    assert row["bound_port"] == 7902
+
+
+def test_record_local_instance_marks_remote_false(db_path, tmp_path) -> None:
+    # Arrange — a local start records remote=0 (it ran on THIS host).
+    from scitex_agent_container._lifecycle._instances import record_local_instance
+    from scitex_agent_container._state.state_db import list_active_instances
+
+    cfg = AgentConfig(name="rec-loc", runtime="apptainer")
+    # Act
+    record_local_instance(cfg, _RuntimeStub(tmp_path))
+    # Assert
+    row = [r for r in list_active_instances() if r["name"] == "rec-loc"][0]
+    assert row["remote"] == 0
+
+
+def test_record_local_instance_records_cli_spawned_by_without_sac_name(
+    db_path, tmp_path
+) -> None:
+    # Arrange — no SAC_NAME in env → launcher is the bare CLI/lead.
+    saved = os.environ.pop("SAC_NAME", None)
+    saved_long = os.environ.pop("SCITEX_AGENT_CONTAINER_NAME", None)
+    from scitex_agent_container._lifecycle._instances import record_local_instance
+    from scitex_agent_container._state.state_db import list_active_instances
+
+    cfg = AgentConfig(name="rec-cli", runtime="apptainer")
+    try:
+        # Act
+        record_local_instance(cfg, _RuntimeStub(tmp_path))
+    finally:
+        if saved is not None:
+            os.environ["SAC_NAME"] = saved
+        if saved_long is not None:
+            os.environ["SCITEX_AGENT_CONTAINER_NAME"] = saved_long
+    # Assert
+    row = [r for r in list_active_instances() if r["name"] == "rec-cli"][0]
+    assert row["spawned_by"] == "cli"
+
+
+def test_record_local_instance_records_parent_spawned_by_from_sac_name(
+    db_path, tmp_path
+) -> None:
+    # Arrange — a parent agent shelled out; SAC_NAME carries its name.
+    saved = os.environ.get("SAC_NAME")
+    os.environ["SAC_NAME"] = "parent-bot"
+    from scitex_agent_container._lifecycle._instances import record_local_instance
+    from scitex_agent_container._state.state_db import list_active_instances
+
+    cfg = AgentConfig(name="rec-child", runtime="apptainer")
+    try:
+        # Act
+        record_local_instance(cfg, _RuntimeStub(tmp_path))
+    finally:
+        if saved is None:
+            os.environ.pop("SAC_NAME", None)
+        else:
+            os.environ["SAC_NAME"] = saved
+    # Assert
+    row = [r for r in list_active_instances() if r["name"] == "rec-child"][0]
+    assert row["spawned_by"] == "parent-bot"
+
+
 def test_record_local_instance_writes_instance_id_marker(db_path, tmp_path) -> None:
     # Arrange
     from scitex_agent_container._lifecycle._instances import record_local_instance

--- a/tests/scitex_agent_container/_lifecycle/test_lifecycle.py
+++ b/tests/scitex_agent_container/_lifecycle/test_lifecycle.py
@@ -1057,8 +1057,12 @@ def test_agent_restart_unknown_raises(tmp_path: Path, registry: Registry) -> Non
 # ---------------------------------------------------------------------------
 
 
-def test_agent_status_unknown_raises(tmp_path: Path, registry: Registry) -> None:
-    # Arrange (empty registry).
+def test_agent_status_unknown_raises(
+    tmp_path: Path, registry: Registry, isolated_state_db: Path
+) -> None:
+    # Arrange — empty file registry AND an isolated empty state.db, so
+    # neither the local registry nor the cross-host instances fallback
+    # has a row for "ghost".
     # Act
     call = lambda: lc.agent_status(  # noqa: E731
         "ghost", registry=registry, runtime_factory=lambda _c: FakeRuntime()
@@ -1066,6 +1070,69 @@ def test_agent_status_unknown_raises(tmp_path: Path, registry: Registry) -> None
     # Assert
     with pytest.raises(RuntimeError, match="not found"):
         call()
+
+
+def test_agent_status_resolves_remote_agent_from_instances_row(
+    tmp_path: Path, registry: Registry, isolated_state_db: Path
+) -> None:
+    # Arrange — a remote-dispatched agent has NO local file-registry
+    # entry; its row lives only in the instances table (remote=1, peer
+    # host, peer-resolved bound_port). Status must resolve it instead of
+    # raising "not found".
+    from scitex_agent_container._state.state_db import record_instance_start
+
+    record_instance_start(
+        name="clew", host="spartan", bound_port=19123, remote=True, spawned_by="lead"
+    )
+    # Act
+    result = lc.agent_status("clew", registry=registry)
+    # Assert
+    assert result["host"] == "spartan"
+
+
+def test_agent_status_remote_row_reports_bound_port(
+    tmp_path: Path, registry: Registry, isolated_state_db: Path
+) -> None:
+    # Arrange
+    from scitex_agent_container._state.state_db import record_instance_start
+
+    record_instance_start(
+        name="clew", host="spartan", bound_port=19123, remote=True, spawned_by="lead"
+    )
+    # Act
+    result = lc.agent_status("clew", registry=registry)
+    # Assert
+    assert result["bound_port"] == 19123
+
+
+def test_agent_status_remote_row_marks_remote_true(
+    tmp_path: Path, registry: Registry, isolated_state_db: Path
+) -> None:
+    # Arrange
+    from scitex_agent_container._state.state_db import record_instance_start
+
+    record_instance_start(
+        name="clew", host="spartan", bound_port=19123, remote=True, spawned_by="lead"
+    )
+    # Act
+    result = lc.agent_status("clew", registry=registry)
+    # Assert
+    assert result["remote"] is True
+
+
+def test_agent_status_remote_row_reports_spawned_by(
+    tmp_path: Path, registry: Registry, isolated_state_db: Path
+) -> None:
+    # Arrange
+    from scitex_agent_container._state.state_db import record_instance_start
+
+    record_instance_start(
+        name="clew", host="spartan", bound_port=19123, remote=True, spawned_by="lead"
+    )
+    # Act
+    result = lc.agent_status("clew", registry=registry)
+    # Assert
+    assert result["spawned_by"] == "lead"
 
 
 def test_agent_status_running_reports_status_running(

--- a/tests/scitex_agent_container/_network/test_peer.py
+++ b/tests/scitex_agent_container/_network/test_peer.py
@@ -177,6 +177,132 @@ class TestResolvePeerUrl:
 
 
 # ---------------------------------------------------------------------------
+# 4b — resolve_peer_url cross-host fallback via the instances table.
+#
+# The remote-registry gap fix (sac-agent-spawn design, Rule B/F): an
+# agent dispatched to another host claims its auto-port in THAT host's
+# allocator, so the lead's local allocator has no claim. The cross-host
+# dispatcher records the bound port + peer host in the lead's
+# ``instances`` table; resolve_peer_url falls back to it so post-turn
+# resolves a remote agent instead of raising "no bound port recorded".
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_state_db(tmp_path: Path):
+    """Redirect state.db to a tmp path; reload the module so the
+    module-level DEFAULT_DB_PATH picks it up (explicit save/restore)."""
+    import importlib
+    import os
+
+    db = tmp_path / "state.db"
+    key = "SCITEX_AGENT_CONTAINER_STATE_DB"
+    saved = os.environ.get(key)
+    os.environ[key] = str(db)
+    import scitex_agent_container._state.state_db as mod
+
+    importlib.reload(mod)
+    try:
+        yield db
+    finally:
+        if saved is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = saved
+        importlib.reload(mod)
+
+
+def _write_auto_port_yaml(tmp_path: Path) -> Path:
+    """A v3 YAML with ``a2a.port: auto`` and no ``spec.host`` — the
+    exact shape clew had (no static port, no local host pin)."""
+    y = tmp_path / "clew" / "clew.yaml"
+    y.parent.mkdir(parents=True)
+    y.write_text(
+        "apiVersion: scitex-agent-container/v3\n"
+        "kind: Agent\n"
+        "spec:\n"
+        "  runtime: apptainer\n"
+        "  a2a: {port: auto}\n"
+    )
+    return y
+
+
+class TestResolvePeerUrlCrossHostFallback:
+    def test_remote_instances_row_resolves_to_ssh_url(
+        self, tmp_path: Path, resolve_yaml_to, isolated_state_db, env_save_restore
+    ) -> None:
+        # Arrange — auto-port YAML (no static port, no local allocator
+        # claim) + a remote instances row recording the peer-resolved
+        # bound port and host.
+        env_save_restore.set("SAC_HOST", "lead-host")
+        resolve_yaml_to(_write_auto_port_yaml(tmp_path))
+        from scitex_agent_container._state.state_db import record_instance_start
+
+        record_instance_start(
+            name="clew", host="spartan", bound_port=19123, remote=True
+        )
+        # Act
+        url = resolve_peer_url("clew")
+        # Assert — resolved to the recorded peer host + bound port.
+        assert url == "ssh://spartan:19123/v1/turn"
+
+    def test_remote_instances_row_without_local_claim_does_not_raise(
+        self, tmp_path: Path, resolve_yaml_to, isolated_state_db, env_save_restore
+    ) -> None:
+        # Arrange — same shape; the pre-fix behaviour was a PeerError
+        # ("port: auto and no bound port recorded").
+        env_save_restore.set("SAC_HOST", "lead-host")
+        resolve_yaml_to(_write_auto_port_yaml(tmp_path))
+        from scitex_agent_container._state.state_db import record_instance_start
+
+        record_instance_start(
+            name="clew", host="spartan", bound_port=19123, remote=True
+        )
+        raised: list[BaseException] = []
+        # Act
+        try:
+            resolve_peer_url("clew")
+        except PeerError as exc:
+            raised.append(exc)
+        # Assert
+        assert raised == []
+
+    def test_legacy_row_without_bound_port_falls_back_to_a2a_port(
+        self, tmp_path: Path, resolve_yaml_to, isolated_state_db, env_save_restore
+    ) -> None:
+        # Arrange — a row written before the family-tree columns existed
+        # carries the port only in ``a2a_port``; the fallback must still
+        # resolve it.
+        env_save_restore.set("SAC_HOST", "lead-host")
+        resolve_yaml_to(_write_auto_port_yaml(tmp_path))
+        from scitex_agent_container._state.state_db import record_instance_start
+
+        record_instance_start(
+            name="clew", host="spartan", a2a_port=19200, bound_port=None
+        )
+        # Act
+        url = resolve_peer_url("clew")
+        # Assert
+        assert url == "ssh://spartan:19200/v1/turn"
+
+    def test_no_instances_row_still_raises_auto_port_error(
+        self, tmp_path: Path, resolve_yaml_to, isolated_state_db, env_save_restore
+    ) -> None:
+        # Arrange — auto-port YAML, NO instances row, NO local claim:
+        # the honest "is the agent running?" error must still fire.
+        env_save_restore.set("SAC_HOST", "lead-host")
+        resolve_yaml_to(_write_auto_port_yaml(tmp_path))
+        from scitex_agent_container._state.state_db import init_schema
+
+        init_schema()
+        # Act
+        action = lambda: resolve_peer_url("clew")
+        # Assert
+        with pytest.raises(PeerError, match="no bound port recorded"):
+            action()
+
+
+# ---------------------------------------------------------------------------
 # 5-7 — post_turn_to_url
 # ---------------------------------------------------------------------------
 

--- a/tests/scitex_agent_container/_state/test_state_db_instances.py
+++ b/tests/scitex_agent_container/_state/test_state_db_instances.py
@@ -1,0 +1,202 @@
+"""Tests for ``state_db_instances`` family-tree columns (Rule B/D).
+
+The sac-agent-spawn design adds ``bound_port`` / ``remote`` /
+``spawned_by`` to the ``instances`` table so every start — local or
+cross-host dispatch — records its bound port, locality and lineage as
+an intrinsic side-effect. These tests use a real on-disk SQLite
+state.db (isolated per test via the ``SCITEX_AGENT_CONTAINER_STATE_DB``
+env override) — no mocks. Each test carries AAA markers and a single
+assertion.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def db_path(tmp_path: Path):
+    """Isolated state.db location, exported via env (explicit save/restore)."""
+    p = tmp_path / "state.db"
+    key = "SCITEX_AGENT_CONTAINER_STATE_DB"
+    saved = os.environ.get(key)
+    os.environ[key] = str(p)
+    import scitex_agent_container._state.state_db as mod
+
+    importlib.reload(mod)
+    try:
+        yield p
+    finally:
+        if saved is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = saved
+        importlib.reload(mod)
+
+
+def _active_row(name: str) -> dict:
+    from scitex_agent_container._state.state_db import list_active_instances
+
+    return [r for r in list_active_instances() if r["name"] == name][0]
+
+
+# ---------------------------------------------------------------------------
+# Schema — fresh DB carries the family-tree columns.
+# ---------------------------------------------------------------------------
+
+
+def test_fresh_instances_table_has_bound_port_column(db_path: Path):
+    # Arrange
+    from scitex_agent_container._state.state_db import init_schema
+
+    # Act
+    init_schema()
+    # Assert
+    with sqlite3.connect(db_path) as conn:
+        cols = {r[1] for r in conn.execute("PRAGMA table_info(instances)")}
+    assert "bound_port" in cols
+
+
+def test_fresh_instances_table_has_remote_column(db_path: Path):
+    # Arrange
+    from scitex_agent_container._state.state_db import init_schema
+
+    # Act
+    init_schema()
+    # Assert
+    with sqlite3.connect(db_path) as conn:
+        cols = {r[1] for r in conn.execute("PRAGMA table_info(instances)")}
+    assert "remote" in cols
+
+
+def test_fresh_instances_table_has_spawned_by_column(db_path: Path):
+    # Arrange
+    from scitex_agent_container._state.state_db import init_schema
+
+    # Act
+    init_schema()
+    # Assert
+    with sqlite3.connect(db_path) as conn:
+        cols = {r[1] for r in conn.execute("PRAGMA table_info(instances)")}
+    assert "spawned_by" in cols
+
+
+# ---------------------------------------------------------------------------
+# record_instance_start — writes the new columns.
+# ---------------------------------------------------------------------------
+
+
+def test_record_instance_start_persists_remote_flag(db_path: Path):
+    # Arrange
+    from scitex_agent_container._state.state_db import record_instance_start
+
+    # Act
+    record_instance_start(name="rem-1", host="peer-x", a2a_port=19001, remote=True)
+    # Assert
+    assert _active_row("rem-1")["remote"] == 1
+
+
+def test_record_instance_start_persists_spawned_by(db_path: Path):
+    # Arrange
+    from scitex_agent_container._state.state_db import record_instance_start
+
+    # Act
+    record_instance_start(name="sb-1", host="peer-x", spawned_by="parent-agent")
+    # Assert
+    assert _active_row("sb-1")["spawned_by"] == "parent-agent"
+
+
+def test_record_instance_start_defaults_bound_port_to_a2a_port(db_path: Path):
+    # Arrange — caller passes only the resolved a2a_port (no explicit
+    # bound_port); the helper must mirror it into bound_port.
+    from scitex_agent_container._state.state_db import record_instance_start
+
+    # Act
+    record_instance_start(name="bp-1", host="peer-x", a2a_port=19042)
+    # Assert
+    assert _active_row("bp-1")["bound_port"] == 19042
+
+
+def test_record_instance_start_keeps_explicit_bound_port(db_path: Path):
+    # Arrange — an explicit bound_port wins over the a2a_port default.
+    from scitex_agent_container._state.state_db import record_instance_start
+
+    # Act
+    record_instance_start(name="bp-2", host="peer-x", a2a_port=None, bound_port=19077)
+    # Assert
+    assert _active_row("bp-2")["bound_port"] == 19077
+
+
+def test_record_instance_start_defaults_remote_to_zero(db_path: Path):
+    # Arrange — a local start omits remote; column defaults to 0.
+    from scitex_agent_container._state.state_db import record_instance_start
+
+    # Act
+    record_instance_start(name="loc-1", host="this-host", a2a_port=19003)
+    # Assert
+    assert _active_row("loc-1")["remote"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Migration — an instances table created before the columns gets them.
+# ---------------------------------------------------------------------------
+
+
+def _create_pre_family_tree_instances(db: Path) -> None:
+    """Build an ``instances`` table WITHOUT the family-tree columns."""
+    with sqlite3.connect(db) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE instances (
+                id TEXT PRIMARY KEY, definition_id TEXT, name TEXT NOT NULL,
+                host TEXT NOT NULL, scope TEXT NOT NULL, pid INTEGER,
+                ppid INTEGER, screen TEXT, workdir TEXT, a2a_port INTEGER,
+                started_at TEXT NOT NULL, last_heartbeat_at TEXT,
+                ended_at TEXT, exit_reason TEXT, iter_count INTEGER DEFAULT 0,
+                input_tokens INTEGER DEFAULT 0, output_tokens INTEGER DEFAULT 0
+            );
+            INSERT INTO instances (id, name, host, scope, started_at, a2a_port)
+            VALUES ('old1', 'legacy', 'h', 'global', '2026-01-01T00:00:00Z', 18888);
+            """
+        )
+        conn.commit()
+
+
+def test_migration_adds_bound_port_to_pre_existing_table(db_path: Path):
+    # Arrange — a DB whose instances table predates the columns.
+    _create_pre_family_tree_instances(db_path)
+    from scitex_agent_container._state.state_db import init_schema
+
+    # Act — init_schema runs the idempotent ADD COLUMN migration.
+    init_schema()
+    # Assert
+    with sqlite3.connect(db_path) as conn:
+        cols = {r[1] for r in conn.execute("PRAGMA table_info(instances)")}
+    assert "bound_port" in cols
+
+
+def test_migration_preserves_legacy_row_on_pre_existing_table(db_path: Path):
+    # Arrange
+    _create_pre_family_tree_instances(db_path)
+    from scitex_agent_container._state.state_db import init_schema
+
+    # Act
+    init_schema()
+    # Assert — the legacy row survives the ADD COLUMN migration.
+    assert _active_row("legacy")["a2a_port"] == 18888
+
+
+def test_migration_is_idempotent_on_replay(db_path: Path):
+    # Arrange — a fresh DB already has the columns from the DDL.
+    from scitex_agent_container._state.state_db import init_schema
+
+    init_schema()
+    # Act — a second init_schema must not raise (ADD COLUMN guarded).
+    init_schema()
+    # Assert — reaching here means the replay did not raise.
+    assert db_path.exists()

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__dispatch.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__dispatch.py
@@ -426,6 +426,51 @@ class TestDispatchSshSuccessPath:
         # Assert
         assert "a2a_port=47213" in scen.captured_stdout
 
+    def test_dispatch_ssh_success_marks_row_remote(
+        self, spec_dir, shim_bin, state_db, fake_home, env_save_restore, capsys
+    ):
+        # Arrange — a cross-host dispatch must record remote=1 so
+        # resolve_peer_url / agent_status know to reach the agent on the
+        # peer (sac-agent-spawn design, Rule B/F).
+        _write_peer_config(fake_home, env_save_restore)
+        # Act
+        _act_dispatch(shim_bin, capsys, rsync_kwargs=_RK_OK, ssh_kwargs=_SK_OK)
+        # Assert
+        from scitex_agent_container._state.state_db import list_active_instances
+
+        rows = [r for r in list_active_instances() if r["name"] == "alpha"]
+        assert rows[0]["remote"] == 1
+
+    def test_dispatch_ssh_success_records_bound_port_from_peer_json(
+        self, spec_dir, shim_bin, state_db, fake_home, env_save_restore, capsys
+    ):
+        # Arrange — the bound port captured back from the peer's --json
+        # output is the concrete int the peer's allocator resolved (the
+        # crux of the remote-port gap fix).
+        _write_peer_config(fake_home, env_save_restore)
+        # Act
+        _act_dispatch(shim_bin, capsys, rsync_kwargs=_RK_OK, ssh_kwargs=_SK_OK)
+        # Assert
+        from scitex_agent_container._state.state_db import list_active_instances
+
+        rows = [r for r in list_active_instances() if r["name"] == "alpha"]
+        assert rows[0]["bound_port"] == 47213
+
+    def test_dispatch_ssh_success_records_cli_spawned_by(
+        self, spec_dir, shim_bin, state_db, fake_home, env_save_restore, capsys
+    ):
+        # Arrange — a bare lead dispatch (no SAC_NAME) records the
+        # lineage edge as "cli".
+        env_save_restore.set("SAC_NAME", "")
+        _write_peer_config(fake_home, env_save_restore)
+        # Act
+        _act_dispatch(shim_bin, capsys, rsync_kwargs=_RK_OK, ssh_kwargs=_SK_OK)
+        # Assert
+        from scitex_agent_container._state.state_db import list_active_instances
+
+        rows = [r for r in list_active_instances() if r["name"] == "alpha"]
+        assert rows[0]["spawned_by"] == "cli"
+
     def test_dispatch_ssh_success_propagates_a2a_port_none_when_spec_omits_it(
         self, spec_dir, shim_bin, state_db, fake_home, env_save_restore, capsys
     ):


### PR DESCRIPTION
## Phase 1 of the operator-locked SAC agent-spawn family-tree design (Rule B)

Spec: `~/.scitex/todo/docs/sac-agent-spawn-design.md`. This is the keystone that fixes the remote-registry gap — remote-dispatched agents (`sac --on <host> agents start`) wrote no resolvable cross-host state, so `sac agents status <remote>` / `sac peer post-turn <remote>` failed with "port: auto, no bound port recorded".

### What this implements (Rule B — automatic recording, never caller responsibility)

**Schema** (`state.db` `instances` table) — three new columns + idempotent migration:
- `bound_port` — the ACTUAL bound a2a port (mirrors `a2a_port` for new readers; both written together so legacy `a2a_port` callers keep working).
- `remote` — `1` when the agent landed on a different host (cross-host dispatch).
- `spawned_by` — launching identity (parent agent `SAC_NAME`, or `"cli"`); the lineage edge the family-tree DAG (Rule D) is reconstructed from.
- `migrate_instances_add_family_tree_cols` ADDs the columns onto a pre-existing table; runs from `init_schema`.

**Recording** is now intrinsic to both start paths:
- Local (`record_local_instance`): `remote=False`, `bound_port`=resolved allocator port, `spawned_by`.
- Remote (`_dispatch_remote_start`): `remote=True`, `bound_port`=the peer's `--json` `a2a_port`, `spawned_by`.

**The crux — how the bound port is captured on the remote path:** the existing remote handoff already invokes `sac agents start <name> --no-redispatch --json` over ssh. That `--json` payload's `a2a_port` field is the **concrete int the peer's port allocator resolved** (`auto` → int happens in `_lifecycle/_a2a_port.py` *before* the runtime builds argv). The lead reads `peer_state["a2a_port"]` and records it as `bound_port`. No new reporting mechanism was needed; the gap was purely on the **read** side.

**Read-side resolution** (the gap fixed):
- `resolve_peer_url` falls back to the active `instances` row's `bound_port` + `host` when the local allocator has no claim (always the case for a cross-host agent) → returns `ssh://<host>:<port>/v1/turn`.
- `agent_status` resolves a remote agent (no local file-registry entry) from the `instances` row, reporting `host`/`bound_port`/`remote`/`spawned_by`.

### Refactor (per-file 512-line cap)
- `state_db_instances.py` ← instances CRUD extracted from `state_db.py` (re-exported).
- `_peer_resolve.py` ← agent→URL resolver group extracted from `peer.py` (re-exported).

### Tests
Real on-disk sqlite (`tmp_path`) + real start/dispatch codepaths + PATH-prepended shell shims — **no mocks** (STX-NM clean), TQ-compliant (descriptive names, AAA markers, one assert). They assert the real recording (remote flag, concrete bound_port from peer JSON, spawned_by) and the read-back (`resolve_peer_url` / `agent_status` resolve a remote row; a missing row still raises the honest "is the agent running?" error). Migration tested on a pre-family-tree table.

Full suite: 4979 passed (the one failing `tests/develop/test_audit.py` is a **pre-existing** over-budget skill-export drift in two uncommitted `_skills/*.md` files unrelated to this PR — confirmed clean once those are at HEAD; not in this diff).

### Follow-on phases (schema fields ready, populated more richly later)
DAG viz (D), server-managed ACL + child⊆parent (E/G), the 3 spawn mechanisms (#1/#2/#3), cross-host server-mediated spawn (F).