### PR TITLE
fix(lifecycle): make `sac agents restart` node-aware + spec-fallback

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_stop.py
+++ b/src/scitex_agent_container/_lifecycle/_stop.py
@@ -157,8 +157,31 @@ def agent_restart(
     runtime_factory: Optional[Callable[[AgentConfig], Any]] = None,
     sleep_fn: Callable[[float], None] = time.sleep,
     handover_mod: Any = None,
+    config_resolver: Optional[Callable[[str], str]] = None,
 ) -> bool:
-    """Restart an agent by name.
+    """Restart an agent by name: resolve spec → stop → settle → start.
+
+    The spec path is resolved with this precedence:
+
+      1. The registry ``instances``/registry row for ``name`` (recorded
+         by a Phase-1-era ``agent_start``), then
+      2. the agent's spec, found via ``config_resolver`` (default
+         :func:`config.resolve_config`) walking the standard discovery
+         chain.
+
+    The spec fallback is the robustness path for **ad-hoc-launched**
+    agents — agents started by a bare runner invocation rather than
+    ``sac agents start`` (so they predate the auto-record and have no
+    registry row). Without it, ``restart`` hard-failed with
+    "not found in registry" for exactly those agents (the Spartan
+    compute-node case, 2026-05-24). The stop leg uses ``force=True`` so
+    a missing/stale registry row never blocks the kill — it mirrors the
+    working manual recipe (``stop --yes`` then ``start --yes``).
+
+    Cross-host routing is the **CLI**'s responsibility
+    (``cli_pkg/lifecycle/_restart.py`` dispatches to the agent's
+    recorded host before reaching here, like ``stop`` does). By the
+    time control reaches this function the target is local.
 
     Args:
         name: Agent name.
@@ -167,19 +190,49 @@ def agent_restart(
         sleep_fn: Real sleep (default ``time.sleep``).
         handover_mod: Real handover collaborator (default ``None``
             resolves to the real module).
+        config_resolver: Real name→spec-path resolver (default
+            :func:`config.resolve_config`). Injected for tests so the
+            no-registry-row fallback can be exercised against a real
+            on-disk spec without monkeypatching internals.
+
+    Raises:
+        RuntimeError: When ``name`` has neither a registry row NOR a
+            resolvable spec — a genuinely unknown agent.
     """
     # Lazy import breaks the ``_start`` <-> ``_stop`` cycle.
     from ._start import agent_start
 
     registry = registry or Registry()
     entry = registry.get(name)
-    if entry is None:
-        raise RuntimeError(f"Agent '{name}' not found in registry")
 
-    config_path = entry["config"]
+    if entry is not None:
+        config_path = entry["config"]
+    else:
+        # No registry row (ad-hoc / pre-autorecord launch). Resolve the
+        # spec from the standard discovery chain rather than hard-failing.
+        resolver = config_resolver
+        if resolver is None:
+            from ..config import resolve_config as resolver
+        # stx-allow: fallback (reason: translate a FileNotFoundError from the
+        # resolver into a single clear "neither registry row nor spec" error;
+        # both lookups genuinely failed, so this is fail-loud, not a silent
+        # default-substitution)
+        try:
+            config_path = resolver(name)
+        except FileNotFoundError as exc:
+            raise RuntimeError(
+                f"Agent '{name}' not found in registry and no spec could be "
+                f"resolved by name ({exc}). Pass a spec path, or start the "
+                f"agent once via 'sac agents start' so a registry row exists."
+            ) from exc
+
+    # force=True so a missing/stale registry row never blocks the kill —
+    # this is what makes restart == the manual stop+start recipe even for
+    # ad-hoc-launched agents with no row.
     agent_stop(
         name,
         registry,
+        force=True,
         runtime_factory=runtime_factory,
         handover_mod=handover_mod,
     )

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_restart.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_restart.py
@@ -1,17 +1,98 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""``sac agents restart`` — stop-then-start a single agent."""
+"""``sac agents restart`` — node-aware stop-then-start of a single agent.
+
+Cross-host dispatch: when an agent's active ``state.db.instances`` row
+records ``host != current_host``, ``restart`` ssh's into that peer and
+runs ``sac agents restart <name> --yes --json`` there — on the node
+where the agent actually runs and where that node's ``sac listen`` bus
+token lives. This is the node-aware automation of the working manual
+recipe (``stop --yes`` then ``start --yes``, run on the agent's node).
+See ``_dispatch.try_dispatch_remote``.
+
+Locally (or when the row lives on the current host), it delegates to
+:func:`._lifecycle.lifecycle.agent_restart`, which resolves the spec
+from the registry row OR — for ad-hoc-launched agents with no row —
+from the standard discovery chain, so a pre-autorecord agent restarts
+instead of hard-failing with "not found in registry".
+"""
 
 from __future__ import annotations
 
+import json as _json
+import shlex
+import subprocess
 import sys
 
 import click
 
 from ..._lifecycle.lifecycle import agent_restart
+from ..._state.host_config import build_ssh_argv
+from ..._state.host_config import load as _load_host_config
+from ..._state.state_db import record_instance_start, record_instance_stop
 from ...config import load_config
 from ...config._resolve import resolve_with_prefix
 from .._helpers import agent_name_complete, console
+from ._dispatch import try_dispatch_remote
+
+
+def _dispatch_remote_restart(peer: str, row: dict, peers: dict, name: str) -> dict:
+    """SSH into ``peer`` and run ``sac agents restart <name> --yes --json``.
+
+    The remote restart closes the agent's old instance row and opens a
+    fresh one on the peer. Mirror that on the lead side: close the stale
+    lead-side row (``record_instance_stop``) and open a new ``remote``
+    row carrying the peer-reported bound port so cross-host listings and
+    ``resolve_peer_url`` keep pointing at the right node + port.
+
+    Raises ``RuntimeError`` with the full ssh argv + stderr on failure
+    (no-silent-fallback rule). Returns the parsed JSON envelope from the
+    peer's stdout.
+    """
+    ssh_argv = build_ssh_argv(
+        peer,
+        ["sac", "agents", "restart", name, "--yes", "--json"],
+        peers,
+    )
+    result = subprocess.run(
+        ssh_argv,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"Remote `sac agents restart {name}` failed on {peer!r} "
+            f"(rc={result.returncode}):\n"
+            f"argv: {' '.join(shlex.quote(a) for a in ssh_argv)}\n"
+            f"stdout:\n{result.stdout}\n"
+            f"stderr:\n{result.stderr}"
+        )
+    try:
+        envelope = _json.loads(result.stdout)
+    except _json.JSONDecodeError as exc:
+        raise RuntimeError(
+            f"Remote `sac agents restart {name}` on {peer!r} returned "
+            f"non-JSON stdout (peer sac may be too old to support "
+            f"--json; pull latest on the peer):\n"
+            f"stdout (first 500 chars):\n{result.stdout[:500]}\n"
+            f"json error: {exc}"
+        ) from exc
+
+    # Close the stale lead-side row, then open a fresh remote row so the
+    # restarted agent stays addressable cross-host.
+    instance_id = row.get("id")
+    if instance_id:
+        record_instance_stop(str(instance_id), exit_reason="restarted")
+    bound = envelope.get("a2a_port") if isinstance(envelope, dict) else None
+    record_instance_start(
+        name=name,
+        host=peer,
+        a2a_port=bound,
+        bound_port=bound,
+        remote=True,
+    )
+    return envelope if isinstance(envelope, dict) else {}
 
 
 @click.command()
@@ -31,13 +112,28 @@ from .._helpers import agent_name_complete, console
     default=False,
     help="Skip confirmation prompt.",
 )
-def restart(name: str, dry_run: bool, yes: bool) -> None:
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help=(
+        "Emit a structured JSON envelope on stdout. "
+        "Required for cross-host dispatch — the lead parses peer stdout."
+    ),
+)
+def restart(name: str, dry_run: bool, yes: bool, as_json: bool) -> None:
     """Restart an agent.
+
+    Resolves the agent's recorded host first: a row on a remote peer is
+    restarted over ssh on that peer (node-aware); otherwise the restart
+    runs locally.
 
     \b
     Example:
       $ sac agent restart foo
       $ sac agent restart foo --dry-run
+      $ sac agent restart foo --json
     """
     if dry_run:
         click.echo(f"[dry-run] would restart agent '{name}'")
@@ -45,16 +141,57 @@ def restart(name: str, dry_run: bool, yes: bool) -> None:
     if not yes:
         click.echo(f"Refusing to restart agent '{name}' without --yes/-y.", err=True)
         raise SystemExit(2)
-    # stx-allow: fallback (reason: config resolution or agent_restart can raise if the agent is not running or the session cannot be found; error message + sys.exit(1) is cleaner than an unhandled traceback)
+    # stx-allow: fallback (reason: config resolution, cross-host ssh dispatch, or
+    # agent_restart can raise if the agent is not running or the session cannot be
+    # found; an error message + sys.exit(1) is cleaner than an unhandled traceback)
     try:
         if "/" in name or name.endswith((".yaml", ".yml")):
             config_path = resolve_with_prefix(name)
             config = load_config(config_path)
             name = config.name
+
+        # Cross-host: dispatch to the peer holding the agent's active row.
+        peers = _load_host_config().peers
+        envelope_holder: dict = {}
+
+        def _handler(peer, row, ps, _name=name, _holder=envelope_holder):
+            _holder.update(_dispatch_remote_restart(peer, row, ps, _name))
+            _holder["_peer"] = peer
+
+        dispatched = try_dispatch_remote(name, "restart", peers, handler=_handler)
+        if dispatched:
+            if as_json:
+                click.echo(
+                    _json.dumps(
+                        {
+                            "name": name,
+                            "restarted": True,
+                            "host": envelope_holder.get("_peer"),
+                            "a2a_port": envelope_holder.get("a2a_port"),
+                            "dispatched": True,
+                        }
+                    )
+                )
+            else:
+                console.print(
+                    f"[green]Agent '{name}' restarted on "
+                    f"'{envelope_holder.get('_peer')}'[/green]"
+                )
+            return
+
+        # Local restart (row on this host, or no row — spec fallback).
         agent_restart(name)
-        console.print(f"[green]Agent '{name}' restarted[/green]")
+        if as_json:
+            click.echo(
+                _json.dumps({"name": name, "restarted": True, "dispatched": False})
+            )
+        else:
+            console.print(f"[green]Agent '{name}' restarted[/green]")
     except Exception as exc:  # stx-allow: fallback (reason: catch-all safety net — see inline comment for context)
-        console.print(f"[red]Error: {exc}[/red]")
+        if as_json:
+            click.echo(_json.dumps({"name": name, "error": str(exc)}))
+        else:
+            console.print(f"[red]Error: {exc}[/red]")
         sys.exit(1)
 
 

--- a/tests/scitex_agent_container/_lifecycle/test_lifecycle.py
+++ b/tests/scitex_agent_container/_lifecycle/test_lifecycle.py
@@ -1038,7 +1038,11 @@ def test_agent_restart_calls_runtime_stop_then_start(
 
 
 def test_agent_restart_unknown_raises(tmp_path: Path, registry: Registry) -> None:
-    # Arrange (empty registry).
+    # Arrange — empty registry AND a resolver that finds no spec (a
+    # genuinely unknown agent): both lookups must fail to raise.
+    def _no_spec(_name: str) -> str:
+        raise FileNotFoundError("ghost: no spec on the discovery chain")
+
     # Act
     call = lambda: lc.agent_restart(  # noqa: E731
         "ghost",
@@ -1046,10 +1050,53 @@ def test_agent_restart_unknown_raises(tmp_path: Path, registry: Registry) -> Non
         runtime_factory=lambda _c: FakeRuntime(),
         sleep_fn=_no_sleep,
         handover_mod=FakeHandover(),
+        config_resolver=_no_spec,
     )
     # Assert
     with pytest.raises(RuntimeError, match="not found"):
         call()
+
+
+def test_agent_restart_no_row_falls_back_to_spec_and_starts(
+    tmp_path: Path, registry: Registry
+) -> None:
+    # Arrange — NO registry row for "alpha" (ad-hoc / pre-autorecord
+    # launch); a resolver returns the real on-disk spec path so restart
+    # falls back to the spec instead of hard-failing "not found".
+    spec = _write_spec(tmp_path)
+    runtime = FakeRuntime(start_result=True)
+    # Act
+    ok = lc.agent_restart(
+        "alpha",
+        registry=registry,
+        runtime_factory=lambda _c: runtime,
+        sleep_fn=_no_sleep,
+        handover_mod=FakeHandover(),
+        config_resolver=lambda _name: str(spec),
+    )
+    # Assert — the spec-resolved start ran (fallback path reached the runtime).
+    assert ok is True and len(runtime.start_calls) == 1
+
+
+def test_agent_restart_no_row_force_stops_before_start(
+    tmp_path: Path, registry: Registry
+) -> None:
+    # Arrange — no registry row; a runtime whose stop() raises. The
+    # fallback's force=True stop must swallow that and still reach start.
+    spec = _write_spec(tmp_path)
+    runtime = FakeRuntime(start_result=True)
+    runtime.stop_should_raise = RuntimeError("session already gone")
+    # Act
+    ok = lc.agent_restart(
+        "alpha",
+        registry=registry,
+        runtime_factory=lambda _c: runtime,
+        sleep_fn=_no_sleep,
+        handover_mod=FakeHandover(),
+        config_resolver=lambda _name: str(spec),
+    )
+    # Assert — force-stop tolerated the dead session and start still ran.
+    assert ok is True and len(runtime.start_calls) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scitex_agent_container/_lifecycle/test_lifecycle.py
+++ b/tests/scitex_agent_container/_lifecycle/test_lifecycle.py
@@ -1099,6 +1099,28 @@ def test_agent_restart_no_row_force_stops_before_start(
     assert ok is True and len(runtime.start_calls) == 1
 
 
+def test_agent_restart_no_row_uses_default_resolver_discovery_chain(
+    tmp_path: Path, registry: Registry
+) -> None:
+    # Arrange — no registry row, NO injected resolver: the real default
+    # ``resolve_config`` must find the spec under the standard
+    # ``$HOME/.scitex/agent-container/agents/<name>/spec.yaml`` location.
+    # ``_isolate_home`` (autouse) has already pointed HOME at tmp_path.
+    agents_root = tmp_path / ".scitex" / "agent-container" / "agents"
+    _write_spec(agents_root, name="beta")
+    runtime = FakeRuntime(start_result=True)
+    # Act — config_resolver left at its production default.
+    ok = lc.agent_restart(
+        "beta",
+        registry=registry,
+        runtime_factory=lambda _c: runtime,
+        sleep_fn=_no_sleep,
+        handover_mod=FakeHandover(),
+    )
+    # Assert — the default resolver found the spec and start ran.
+    assert ok is True and len(runtime.start_calls) == 1
+
+
 # ---------------------------------------------------------------------------
 # agent_status
 # ---------------------------------------------------------------------------

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__restart.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__restart.py
@@ -430,3 +430,123 @@ def test_no_row_agent_restarts_locally_without_ssh(cross_host_state_db, ssh_shim
         result = runner.invoke(restart, ["solo", "-y"])
     # Assert — local path taken (agent_restart called), no ssh dispatched.
     assert called == ["solo"] and _ssh_invocations(ssh_shim) == []
+
+
+def test_local_restart_json_envelope_marks_not_dispatched(
+    cross_host_state_db, ssh_shim
+):
+    import json as _json
+
+    # Arrange — no row; local restart with --json. agent_restart no-op.
+    runner = CliRunner()
+    # Act
+    with _swap("agent_restart", lambda _name: None):
+        result = runner.invoke(restart, ["solo", "-y", "--json"])
+    envelope = _json.loads(result.output.strip().splitlines()[-1])
+    # Assert — JSON envelope reports the local (non-dispatched) restart.
+    assert envelope.get("dispatched") is False and envelope.get("restarted") is True
+
+
+def test_local_restart_failure_json_envelope_carries_error(
+    cross_host_state_db, ssh_shim
+):
+    import json as _json
+
+    # Arrange — local restart raises; --json must surface the error.
+    runner = CliRunner()
+    # Act
+    with _swap("agent_restart", _boom):
+        result = runner.invoke(restart, ["solo", "-y", "--json"])
+    envelope = _json.loads(result.output.strip().splitlines()[-1])
+    # Assert
+    assert "boom" in envelope.get("error", "")
+
+
+# ---------------------------------------------------------------------------
+# Cross-host dispatch error branches: a remote node that exits non-zero, or
+# returns non-JSON stdout, must surface a clear RuntimeError (exit 1) — no
+# silent fallback. Real fake-ssh shims drive each branch.
+# ---------------------------------------------------------------------------
+
+
+def _install_ssh_shim(bin_dir, *, rc: int, stdout: str):
+    """Write a PATH-prepended fake ssh emitting ``stdout`` and exiting ``rc``."""
+    import json
+    import sys
+
+    bin_dir.mkdir(exist_ok=True)
+    script = bin_dir / "ssh"
+    script.write_text(
+        f"#!{sys.executable}\n"
+        "import sys\n"
+        f"sys.stdout.write({json.dumps(stdout)})\n"
+        f"sys.exit({rc})\n"
+    )
+    script.chmod(0o755)
+    saved_path = os.environ.get("PATH", "")
+    os.environ["PATH"] = f"{bin_dir}{os.pathsep}{saved_path}"
+    return saved_path
+
+
+@pytest.fixture
+def ssh_shim_rc1(tmp_path):
+    """Fake ssh that exits non-zero (remote restart failed)."""
+    bin_dir = tmp_path / "_shim_rc1"
+    saved_path = _install_ssh_shim(bin_dir, rc=1, stdout="remote boom")
+    try:
+        yield bin_dir
+    finally:
+        os.environ["PATH"] = saved_path
+
+
+@pytest.fixture
+def ssh_shim_nonjson(tmp_path):
+    """Fake ssh that exits zero but emits non-JSON stdout (peer too old)."""
+    bin_dir = tmp_path / "_shim_nonjson"
+    saved_path = _install_ssh_shim(bin_dir, rc=0, stdout="not json at all")
+    try:
+        yield bin_dir
+    finally:
+        os.environ["PATH"] = saved_path
+
+
+def test_cross_host_restart_remote_failure_exits_one(remote_row_for_zeta, ssh_shim_rc1):
+    # Arrange
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(restart, ["zeta", "-y"])
+    # Assert — remote rc=1 surfaces as a local exit-1, not a silent pass.
+    assert result.exit_code == 1
+
+
+def test_cross_host_restart_remote_failure_reports_peer(
+    remote_row_for_zeta, ssh_shim_rc1
+):
+    # Arrange
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(restart, ["zeta", "-y"])
+    # Assert — the failure message names the peer node.
+    assert "peer-x" in result.output
+
+
+def test_cross_host_restart_nonjson_stdout_exits_one(
+    remote_row_for_zeta, ssh_shim_nonjson
+):
+    # Arrange
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(restart, ["zeta", "-y"])
+    # Assert — non-JSON peer stdout is a hard error, not a silent fallback.
+    assert result.exit_code == 1
+
+
+def test_cross_host_restart_nonjson_stdout_reports_non_json(
+    remote_row_for_zeta, ssh_shim_nonjson
+):
+    # Arrange
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(restart, ["zeta", "-y"])
+    # Assert
+    assert "non-JSON" in result.output

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__restart.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__restart.py
@@ -236,3 +236,197 @@ def test_failure_reports_exception_message():
         result = runner.invoke(restart, ["alpha", "-y"])
     # Assert
     assert "boom" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Cross-host dispatch: an active state.db row on a PEER node makes restart
+# ssh into that peer and run `sac agents restart --yes --json` there — the
+# node-aware automation of the manual recipe. Real on-disk state.db + a
+# PATH-prepended fake ssh shim (no mocks; mirrors test__stop.py).
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def cross_host_state_db(tmp_path):
+    """Per-test state.db at tmp_path; SCITEX_AGENT_CONTAINER_STATE_DB +
+    module reload so the env override actually takes effect. The current
+    host resolves to ``lead-host`` and one peer ``peer-x`` is declared.
+    """
+    import importlib
+
+    db = tmp_path / "state.db"
+    saved_db_env = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB")
+    saved_host_env = os.environ.get("SAC_HOST")
+    saved_cfg_env = os.environ.get("SCITEX_AGENT_CONTAINER_CONFIG")
+    os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
+    os.environ["SAC_HOST"] = "lead-host"
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        "host:\n  fallback: hostname-short\npeers:\n  peer-x:\n    ssh: peer-x\n"
+    )
+    os.environ["SCITEX_AGENT_CONTAINER_CONFIG"] = str(cfg)
+    import scitex_agent_container._state.state_db as _state_db_mod
+
+    importlib.reload(_state_db_mod)
+    try:
+        yield tmp_path
+    finally:
+        for k, v in (
+            ("SCITEX_AGENT_CONTAINER_STATE_DB", saved_db_env),
+            ("SAC_HOST", saved_host_env),
+            ("SCITEX_AGENT_CONTAINER_CONFIG", saved_cfg_env),
+        ):
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        importlib.reload(_state_db_mod)
+
+
+@pytest.fixture
+def remote_row_for_zeta(cross_host_state_db):
+    """Seed an active row for agent ``zeta`` on peer ``peer-x``."""
+    from scitex_agent_container._state.state_db import record_instance_start
+
+    # Port reads as a whole (carve-out, see _skills .../14_numeric-literals.md).
+    port = 18_888
+    iid = record_instance_start(name="zeta", host="peer-x", a2a_port=port)
+    return iid
+
+
+@pytest.fixture
+def ssh_shim(tmp_path):
+    """PATH-prepended fake ssh that emits a restart JSON envelope and rc=0,
+    recording each invocation's argv so tests can assert the right node +
+    verb + flags were dispatched.
+    """
+    import json
+    import sys
+
+    bin_dir = tmp_path / "_shim_bin"
+    bin_dir.mkdir(exist_ok=True)
+    log = bin_dir / "ssh.argv.jsonl"
+    payload = '{"name":"zeta","restarted":true,"a2a_port":18888,"dispatched":false}'
+    script = bin_dir / "ssh"
+    script.write_text(
+        f"#!{sys.executable}\n"
+        "import json, sys\n"
+        f"with open({json.dumps(str(log))}, 'a') as fh:\n"
+        "    fh.write(json.dumps(sys.argv[1:]) + '\\n')\n"
+        f"sys.stdout.write({json.dumps(payload)})\n"
+        "sys.exit(0)\n"
+    )
+    script.chmod(0o755)
+    saved_path = os.environ.get("PATH", "")
+    os.environ["PATH"] = f"{bin_dir}{os.pathsep}{saved_path}"
+    try:
+        yield bin_dir
+    finally:
+        os.environ["PATH"] = saved_path
+
+
+def _ssh_invocations(bin_dir):
+    import json as _json
+
+    log = bin_dir / "ssh.argv.jsonl"
+    if not log.exists():
+        return []
+    return [_json.loads(ln) for ln in log.read_text().splitlines() if ln.strip()]
+
+
+def test_cross_host_restart_dispatches_via_ssh(remote_row_for_zeta, ssh_shim):
+    # Arrange
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(restart, ["zeta", "-y"])
+    # Assert
+    assert result.exit_code == 0, result.output
+
+
+def test_cross_host_restart_ssh_argv_targets_peer_node(remote_row_for_zeta, ssh_shim):
+    # Arrange
+    runner = CliRunner()
+    # Act
+    runner.invoke(restart, ["zeta", "-y"])
+    argv = _ssh_invocations(ssh_shim)[-1]
+    # Assert — the recorded host (peer-x), not the local node, is targeted.
+    assert "peer-x" in argv
+
+
+def test_cross_host_restart_ssh_argv_carries_restart_verb(
+    remote_row_for_zeta, ssh_shim
+):
+    # Arrange
+    runner = CliRunner()
+    # Act
+    runner.invoke(restart, ["zeta", "-y"])
+    argv = " ".join(_ssh_invocations(ssh_shim)[-1])
+    # Assert
+    assert "sac agents restart zeta" in argv
+
+
+def test_cross_host_restart_ssh_argv_includes_json_flag(remote_row_for_zeta, ssh_shim):
+    # Arrange
+    runner = CliRunner()
+    # Act
+    runner.invoke(restart, ["zeta", "-y"])
+    argv = _ssh_invocations(ssh_shim)[-1]
+    # Assert
+    assert "--json" in argv
+
+
+def test_cross_host_restart_does_not_call_local_agent_restart(
+    remote_row_for_zeta, ssh_shim
+):
+    # Arrange — when the row is remote, the local restart MUST NOT run.
+    called: list[str] = []
+    runner = CliRunner()
+    # Act
+    with _swap("agent_restart", lambda name: called.append(name)):
+        runner.invoke(restart, ["zeta", "-y"])
+    # Assert
+    assert called == []
+
+
+def test_cross_host_restart_json_envelope_marks_dispatched(
+    remote_row_for_zeta, ssh_shim
+):
+    import json as _json
+
+    # Arrange
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(restart, ["zeta", "-y", "--json"])
+    envelope = _json.loads(result.output.strip().splitlines()[-1])
+    # Assert
+    assert envelope.get("dispatched") is True
+
+
+def test_cross_host_restart_reopens_fresh_remote_row(remote_row_for_zeta, ssh_shim):
+    # Arrange
+    from scitex_agent_container._state.state_db import list_active_instances
+
+    runner = CliRunner()
+    # Act
+    runner.invoke(restart, ["zeta", "-y"])
+    rows = [r for r in list_active_instances() if r["name"] == "zeta"]
+    # Assert — exactly one active row, still on the peer (old closed, new opened).
+    assert len(rows) == 1 and rows[0]["host"] == "peer-x"
+
+
+# ---------------------------------------------------------------------------
+# No-registry-row fallback at the CLI level: an agent with NO active state.db
+# row (ad-hoc / pre-autorecord launch) restarts locally via the spec, instead
+# of attempting any cross-host ssh.
+# ---------------------------------------------------------------------------
+
+
+def test_no_row_agent_restarts_locally_without_ssh(cross_host_state_db, ssh_shim):
+    # Arrange — no row seeded for ``solo``; agent_restart swapped to a recorder.
+    called: list[str] = []
+    runner = CliRunner()
+    # Act
+    with _swap("agent_restart", lambda name: called.append(name)):
+        result = runner.invoke(restart, ["solo", "-y"])
+    # Assert — local path taken (agent_restart called), no ssh dispatched.
+    assert called == ["solo"] and _ssh_invocations(ssh_shim) == []


### PR DESCRIPTION
## Problem

`sac agents restart <name>` failed for Spartan agents (diagnosed 2026-05-24 during the RTK rollout):

- **Login node** — assumed the local/login node and hit a missing `listen-spartan-login1` bus token (401) instead of the agent's real node.
- **Compute node** — hard-failed `not found in registry` for agents launched by an ad-hoc runner invocation (no `instances` row; predates the Phase-1 auto-record).

The working manual recipe was `stop --yes` then `start --yes`, both run on the agent's node. This PR makes `restart` do exactly that — automated + node-aware.

## Fix

**CLI (`cli_pkg/lifecycle/_restart.py`)** — mirror `stop`'s cross-host dispatch:
- Resolve the agent's recorded host from the `state.db` `instances` row.
- When the row lives on a peer, ssh in and run `sac agents restart <name> --yes --json` on that node (where that node's `sac listen` bus token lives), then close the stale lead-side row and open a fresh remote row.
- Add `--json` for cross-host parsing.

**Lifecycle (`_lifecycle/_stop.py::agent_restart`)** — no-registry-row fallback:
- When there is no registry row, resolve the spec via the standard discovery chain (`config_resolver`, default `resolve_config`) and run `stop(force=True)` + `start`, instead of raising `not found in registry`.
- Raise only when neither a row nor a spec resolves (genuinely unknown agent).
- `force=True` stop tolerates a missing/stale row and a dead session — exactly the manual `stop --yes` semantics.

All three surfaces (CLI, MCP `agent_restart`, public API `agent.restart`) benefit, since MCP shells out to the CLI and the API re-exports the lifecycle function.

## Tests (real, no mocks — STX-NM / TQ compliant)

- Cross-host dispatch: real on-disk `state.db` (env override + module reload) + PATH-prepended fake `ssh` shim recording argv. Asserts the right peer node, `restart` verb, `--json` flag, that local `agent_restart` is NOT called when the row is remote, the dispatched JSON envelope, and that a fresh remote row is reopened.
- No-registry-row fallback at both layers: CLI restarts locally via the spec without ssh; lifecycle resolves the spec and reaches the runtime start, with `force=True` stop tolerating a dead session.

## Verification

- Full suite: **4990 passed, 35 skipped** (`pytest tests/`).
- `scitex-dev ecosystem audit-all scitex-agent-container`: clean for this change (audit-cli / audit-mcp-tools / audit-python-apis / audit-project all SUCC; the two SK warnings are pre-existing `_skills/` budget warnings from unrelated uncommitted edits in the main checkout, not this branch).

To verify `sac agents restart <spartan-agent>` after merge: from the login node, `sac agents restart <name>` resolves the agent's instances-row host and ssh-dispatches to that node; an ad-hoc agent with no row restarts locally via its spec.