### PR TITLE
fix(runner): self-heal dead-session resume instead of crash-looping

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_session_reset.py
+++ b/src/scitex_agent_container/_lifecycle/_session_reset.py
@@ -9,27 +9,15 @@ from __future__ import annotations
 from pathlib import Path
 
 
-def _clear_persisted_session_id(name: str) -> None:
-    """Wipe ``<runtime-root>/<name>/session_id`` if present.
+def _runtime_state_dir(name: str) -> Path:
+    """Resolve ``<runtime-root>/<name>`` from the env every call.
 
-    Called from :func:`agent_start` on the ``--force`` path so a stale
-    SDK resume marker can't ambush the next launch (see the module-level
-    explanation at the call site).
-
-    The runtime root is re-read from ``SCITEX_AGENT_CONTAINER_RUNTIME_DIR``
-    every invocation rather than reused from the module-level constant
-    captured at import time, so tests (and callers that flip the env
-    var per-process) see the fresh value without monkeypatching.
-
-    Loud-by-design: prints a ``[force]`` notice when a file was actually
-    removed. Missing file is a no-op (first-ever start). Any other OS
-    error is allowed to propagate — the operator wants to know about a
-    busted runtime dir, not have it silently swallowed.
+    Re-reads ``SCITEX_AGENT_CONTAINER_RUNTIME_DIR`` each invocation rather
+    than capturing a module-level constant at import time, so tests (and
+    callers that flip the env var per-process) see the fresh value without
+    monkeypatching.
     """
     import os
-    import sys
-
-    from .._runners._session_state import clear_session_id
 
     runtime_root = Path(
         os.environ.get(
@@ -37,11 +25,46 @@ def _clear_persisted_session_id(name: str) -> None:
             str(Path.home() / ".scitex" / "agent-container" / "runtime"),
         )
     )
-    state_dir = runtime_root / name
-    removed = clear_session_id(state_dir)
-    if removed:
+    return runtime_root / name
+
+
+def _clear_persisted_session_id(name: str) -> None:
+    """Wipe BOTH the ``session_id`` marker AND ``session_id_history`` on ``--force``.
+
+    Called from :func:`agent_start` on the ``--force`` path so a stale SDK
+    resume marker can't ambush the next launch (see the module-level
+    explanation at the call site).
+
+    Clearing only ``session_id`` was insufficient: the runner's resume
+    fallback walks the append-only ``session_id_history`` (see
+    ``_session_conversation._resume_candidate``), so a dead uuid left in
+    the history was RE-RESUMED on the next start and RE-CRASHED — the
+    crash-loop that made ``sac agents restart`` unable to recover a dead
+    session (clew/neurovista, 2026-05-24). A ``--force`` start means "clean
+    slate", so the history is cleared too (backed up to
+    ``session_id_history.dead-<ts>`` first by ``clear_session_history``).
+
+    Loud-by-design: prints a ``[force]`` notice for each artifact actually
+    removed. Missing files are a no-op (first-ever start). Any other OS
+    error is allowed to propagate — the operator wants to know about a
+    busted runtime dir, not have it silently swallowed.
+    """
+    import sys
+
+    from .._runners._session_state import clear_session_history, clear_session_id
+
+    state_dir = _runtime_state_dir(name)
+    removed_marker = clear_session_id(state_dir)
+    removed_history = clear_session_history(state_dir)
+    if removed_marker:
         print(
             f"[force] cleared persisted session_id for {name!r} "
             f"({state_dir / 'session_id'})",
+            file=sys.stderr,
+        )
+    if removed_history:
+        print(
+            f"[force] cleared session_id_history for {name!r} "
+            f"(backed up to {state_dir}/session_id_history.dead-*)",
             file=sys.stderr,
         )

--- a/src/scitex_agent_container/_lifecycle/_stop.py
+++ b/src/scitex_agent_container/_lifecycle/_stop.py
@@ -237,6 +237,20 @@ def agent_restart(
         handover_mod=handover_mod,
     )
     sleep_fn(2)
+    # Clear BOTH the persisted session_id AND session_id_history before the
+    # restart. A plain ``agent_restart`` previously called ``agent_start``
+    # WITHOUT force=True (so no session reset ran at all), and the
+    # ``--force`` path itself only cleared ``session_id`` — leaving a dead
+    # uuid in the append-only history that the runner's resume fallback
+    # RE-RESUMED and RE-CRASHED. That is why ``sac agents restart`` could
+    # not recover a DEAD session (clew/neurovista, 2026-05-24): the manual
+    # recovery had to clear both and back them up. Doing it here makes a
+    # plain restart self-recovering regardless of the start path's force
+    # flag. ``_clear_persisted_session_id`` backs both up to
+    # ``session_id_history.dead-<ts>`` and is a no-op on a clean state dir.
+    from ._session_reset import _clear_persisted_session_id
+
+    _clear_persisted_session_id(name)
     return agent_start(
         config_path,
         registry,

--- a/src/scitex_agent_container/_runners/_dead_session.py
+++ b/src/scitex_agent_container/_runners/_dead_session.py
@@ -1,0 +1,97 @@
+"""Classify an SDK conversation failure that is a *dead session resume*.
+
+When a long-lived ``claude-session`` runner tries to ``--resume`` a
+session id the Claude server has already aged out (server-side TTL is
+finite) or that never existed, the ``claude-agent-sdk`` does not surface
+a typed exception. It bubbles up as a generic ``ProcessError`` /
+``RuntimeError`` whose message contains "No conversation found with
+session ID: <uuid>" (the real reason, captured from the claude
+subprocess's stderr).
+
+Left unclassified, that failure lands in the conversation supervisor's
+catch-all (``cause="sdk-crash"``) and the supervisor *retries the same
+dead id* by walking ``session_id_history`` — which on a genuinely dead
+session contains only that dead id (and possibly its equally-dead
+forks). The supervisor then exhausts ``max_restarts`` and the
+conversation loop (with its Telegram poller) DIES while the heartbeat
+thread survives — the agent looks alive but is mute. This is the
+production crash-loop that left clew/neurovista silent for ~5h
+(2026-05-24).
+
+This module turns that into self-healing: :func:`is_dead_session_resume`
+recognises the signature so the supervisor can discard the dead id from
+both the latest marker and the history (see
+:func:`._session_id.discard_dead_session`) and immediately start a FRESH
+session (``resume=None``) — preserving resume for genuinely-valid
+sessions and only resetting on a confirmed-dead one.
+
+:func:`extract_dead_session_id` recovers the specific uuid named in the
+error so only that id is purged (a newer valid id is left intact).
+
+Pure stdlib, no SDK import — unit-testable against plain strings.
+"""
+
+from __future__ import annotations
+
+import re
+
+__all__ = [
+    "DEAD_SESSION_CAUSE",
+    "extract_dead_session_id",
+    "is_dead_session_resume",
+]
+
+# Short ``cause`` identifier written to ``state.db.errors``. Distinct
+# from the generic ``sdk-crash`` so the operator can see at a glance
+# that the runner self-healed from a stale resume marker rather than
+# hit a transient network/SDK fault.
+DEAD_SESSION_CAUSE = "dead-session"
+
+# Lower-cased substrings that mark a failure as a dead/expired resume
+# target. Matched against the stringified, stderr-enriched exception.
+# Kept narrow so an unrelated tool-result blob that merely mentions a
+# session id doesn't get misclassified — every needle is a phrase the
+# SDK / claude subprocess emits when the --resume target is gone.
+_DEAD_SESSION_SIGNATURES = (
+    "no conversation found with session id",
+    "no conversation found for session",
+    "no conversation found with session",
+    "session not found",
+    "no such session",
+)
+
+# Captures the uuid named in "No conversation found with session ID:
+# <uuid>". Tolerant of the exact preposition / punctuation around the id.
+_SESSION_ID_RE = re.compile(
+    r"session\s*id[:\s]+([0-9a-fA-F][0-9a-fA-F-]{7,})",
+    re.IGNORECASE,
+)
+
+
+def is_dead_session_resume(error: object) -> bool:
+    """Return True if ``error`` is a dead/expired ``--resume`` rejection.
+
+    Parameters
+    ----------
+    error
+        The exception (or any object) raised by the SDK conversation,
+        already enriched with the captured subprocess stderr. Stringified
+        and scanned case-insensitively for the "no conversation found"
+        signatures in :data:`_DEAD_SESSION_SIGNATURES`.
+    """
+    haystack = str(error).lower()
+    return any(sig in haystack for sig in _DEAD_SESSION_SIGNATURES)
+
+
+def extract_dead_session_id(error: object) -> str | None:
+    """Return the dead session uuid named in ``error``, or None.
+
+    Used so the supervisor purges *only* the confirmed-dead id from the
+    history rather than wiping every recorded id. Returns None when the
+    error doesn't name a parseable id (the caller then falls back to
+    discarding whatever the latest resume marker was).
+    """
+    match = _SESSION_ID_RE.search(str(error))
+    if match is None:
+        return None
+    return match.group(1)

--- a/src/scitex_agent_container/_runners/_session_conversation.py
+++ b/src/scitex_agent_container/_runners/_session_conversation.py
@@ -199,6 +199,14 @@ async def run_conversation(
             sdk_extra["_a2a_port"] = int(a2a_port)
 
     attempt = 0
+    # Dead-session recoveries are NOT charged to ``max_restarts``: a stale
+    # resume marker is a recoverable, self-healing condition (discard the
+    # dead id → fresh start), not a crash budget. Bound it separately so a
+    # pathological loop (discard somehow fails to purge the id) still
+    # terminates instead of spinning forever. One per distinct dead id is
+    # the realistic ceiling — the latest + every forked id in the history.
+    dead_session_recoveries = 0
+    _MAX_DEAD_SESSION_RECOVERIES = 5
     last_exc: BaseException | None = None
     while True:
         # Resume target, with history fallback. On the first attempt this
@@ -324,6 +332,81 @@ async def run_conversation(
             captured_stderr = stderr_capture.text()
             enriched = enrich_detail_with_stderr(str(exc), captured_stderr)
             write_stderr_log(state_dir, captured_stderr)
+
+            # Dead-session resume — the SDK rejected our --resume target
+            # ("No conversation found with session ID: <uuid>"). This is
+            # SELF-HEALING, not a crash: walking session_id_history toward
+            # the same (or equally-dead forked) id just re-crashes until
+            # max_restarts is exhausted and the conversation loop dies mute
+            # (the clew/neurovista 5h outage, 2026-05-24). Instead, purge
+            # the dead id from BOTH the latest marker and the history, then
+            # retry as a FRESH session (resume=None) — independent of the
+            # max_restarts budget. Bounded by _MAX_DEAD_SESSION_RECOVERIES.
+            from ._dead_session import (
+                DEAD_SESSION_CAUSE,
+                extract_dead_session_id,
+                is_dead_session_resume,
+            )
+            from ._session_id import (
+                discard_dead_session,
+                read_session_id,
+            )
+
+            if (
+                is_dead_session_resume(enriched)
+                and not stop.is_set()
+                and dead_session_recoveries < _MAX_DEAD_SESSION_RECOVERIES
+            ):
+                # ``current_sid`` is the ground truth — it IS the resume
+                # target the SDK just rejected. Prefer it; fall back to the
+                # id parsed out of the error string, then to the on-disk
+                # marker, so we always have a concrete id to purge.
+                dead_id = (
+                    current_sid
+                    or extract_dead_session_id(enriched)
+                    or read_session_id(state_dir)
+                )
+                logger.warning(
+                    "claude-session DEAD SESSION for %s: resume id %s is gone; "
+                    "discarding it from session_id + history and starting FRESH",
+                    name,
+                    dead_id,
+                )
+                if dead_id:
+                    discard_dead_session(state_dir, dead_id)
+                append_session_message(
+                    state_dir,
+                    {
+                        "type": "error",
+                        "kind": "dead_session",
+                        "detail": enriched,
+                        "attempt": attempt,
+                    },
+                )
+                if host:
+                    report_sdk_error(
+                        name=name,
+                        host=host,
+                        cause=DEAD_SESSION_CAUSE,
+                        detail=enriched,
+                        db_writer=db_writer,
+                    )
+                append_session_message(
+                    state_dir,
+                    {
+                        "type": "supervisor",
+                        "event": "dead-session-fresh-start",
+                        "discarded_session_id": dead_id,
+                    },
+                )
+                dead_session_recoveries += 1
+                # Reset the resume-attempt walk to 0: with the dead id now
+                # purged from the history, _resume_candidate(attempt=0)
+                # returns None (no history left) and the next loop opens a
+                # genuinely fresh session.
+                attempt = 0
+                resume_session_id = None
+                continue
 
             auth_detail = classify_auth_failure(enriched)
             if auth_detail is not None:

--- a/src/scitex_agent_container/_runners/_session_id.py
+++ b/src/scitex_agent_container/_runners/_session_id.py
@@ -123,3 +123,105 @@ def clear_session_id(state_dir: Path) -> bool:
         return True
     except FileNotFoundError:
         return False
+
+
+def discard_dead_session(state_dir: Path, dead_id: str) -> bool:
+    """Purge a *known-dead* session id from BOTH the latest marker and history.
+
+    Unlike :func:`clear_session_id` (which clears only the latest marker
+    and deliberately keeps the append-only history for audit), this is
+    the recovery path for an id the SDK has confirmed is gone (resume
+    rejected with "No conversation found with session ID"). Leaving a
+    dead id in ``session_id_history`` makes a plain restart (and the
+    supervisor's history-walking resume fallback in
+    :mod:`._session_conversation`) RE-RESUME the dead uuid and
+    RE-CRASH — the production crash-loop that left clew/neurovista mute
+    for ~5h (2026-05-24).
+
+    The whole history is first copied to ``session_id_history.dead-<ts>``
+    so the audit trail is preserved, then:
+
+    - the latest ``session_id`` marker is removed iff it equals
+      ``dead_id`` (a newer valid id is left untouched), and
+    - every line equal to ``dead_id`` is stripped from
+      ``session_id_history`` (the file is removed when nothing valid
+      remains).
+
+    Returns True if anything was changed (marker cleared or a history
+    line removed), False if ``dead_id`` was empty or appeared nowhere.
+
+    Loud-by-design: the caller logs the discard. Never silently swallows
+    an OSError other than the missing-file no-op (a busted runtime dir
+    must surface).
+    """
+    if not dead_id:
+        return False
+
+    changed = False
+
+    # Drop the latest marker only when it IS the dead id — a restart that
+    # already wrote a fresher valid id must not be clobbered.
+    if read_session_id(state_dir) == dead_id:
+        changed = clear_session_id(state_dir) or changed
+
+    history = read_session_id_history(state_dir)
+    if dead_id not in history:
+        return changed
+
+    # Back up the full history before rewriting, so the dead id stays
+    # auditable off to the side rather than vanishing.
+    import time
+
+    backup = state_dir / f"session_id_history.dead-{int(time.time())}"
+    history_path = _session_id_history_path(state_dir)
+    try:
+        backup.write_text("\n".join(history) + "\n", encoding="utf-8")
+    except OSError:
+        # A failed backup must not block the recovery — the dead id MUST
+        # be purged so the agent can self-heal. Losing the side-file
+        # audit copy is the lesser evil; the discard itself is logged.
+        pass
+
+    survivors = [sid for sid in history if sid != dead_id]
+    if survivors:
+        tmp = state_dir / "session_id_history.tmp"
+        tmp.write_text("\n".join(survivors) + "\n", encoding="utf-8")
+        tmp.replace(history_path)
+    else:
+        try:
+            history_path.unlink()
+        except FileNotFoundError:
+            pass
+    return True
+
+
+def clear_session_history(state_dir: Path) -> bool:
+    """Clear the entire ``session_id_history`` (backed up first).
+
+    The force-start / restart recovery path: a ``--force`` start means
+    "I want a clean slate", so the resume fallback must not walk a
+    history that may contain a dead id (the bug that made
+    ``sac agents restart`` unable to recover a dead session — PR #190
+    cleared only ``session_id``, leaving the dead uuid in history to be
+    re-resumed). The whole history is copied to
+    ``session_id_history.dead-<ts>`` before removal so nothing is lost.
+
+    Returns True if a history file was removed, False if there was none.
+    """
+    history_path = _session_id_history_path(state_dir)
+    if not history_path.is_file():
+        return False
+    history = read_session_id_history(state_dir)
+    if history:
+        import time
+
+        backup = state_dir / f"session_id_history.dead-{int(time.time())}"
+        try:
+            backup.write_text("\n".join(history) + "\n", encoding="utf-8")
+        except OSError:
+            pass
+    try:
+        history_path.unlink()
+        return True
+    except FileNotFoundError:
+        return False

--- a/src/scitex_agent_container/_runners/_session_state.py
+++ b/src/scitex_agent_container/_runners/_session_state.py
@@ -27,7 +27,9 @@ from pathlib import Path
 # existing importers of ``_session_state.{write,read,clear}_session_id``
 # keep working unchanged.
 from ._session_id import append_session_id_history as append_session_id_history
+from ._session_id import clear_session_history as clear_session_history
 from ._session_id import clear_session_id as clear_session_id
+from ._session_id import discard_dead_session as discard_dead_session
 from ._session_id import read_session_id as read_session_id
 from ._session_id import read_session_id_history as read_session_id_history
 from ._session_id import write_session_id as write_session_id

--- a/tests/scitex_agent_container/_lifecycle/test_lifecycle.py
+++ b/tests/scitex_agent_container/_lifecycle/test_lifecycle.py
@@ -1037,6 +1037,109 @@ def test_agent_restart_calls_runtime_stop_then_start(
     assert ok is True and len(runtime.stop_calls) == 1 and len(runtime.start_calls) == 1
 
 
+def test_agent_restart_clears_dead_session_marker(
+    tmp_path: Path, registry: Registry
+) -> None:
+    # Arrange — a runtime state dir holding a DEAD resume marker + history
+    # (the production shape after a session aged out). PR #190's restart
+    # left the dead uuid in the history to be re-resumed and re-crashed;
+    # a plain restart must now clear it.
+    spec = _write_spec(tmp_path)
+    registry.add("alpha", str(spec), "cld-alpha")
+    runtime_root = tmp_path / "rt"
+    prev = os.environ.get("SCITEX_AGENT_CONTAINER_RUNTIME_DIR")
+    os.environ["SCITEX_AGENT_CONTAINER_RUNTIME_DIR"] = str(runtime_root)
+    try:
+        from scitex_agent_container._runners import _session_id as sid
+
+        state_dir = runtime_root / "alpha"
+        sid.write_session_id(state_dir, "dead-uuid")
+        # Act
+        lc.agent_restart(
+            "alpha",
+            registry=registry,
+            runtime_factory=lambda _c: FakeRuntime(start_result=True),
+            sleep_fn=_no_sleep,
+            handover_mod=FakeHandover(),
+        )
+        # Assert — the dead resume marker is gone so the restart is fresh.
+        result = sid.read_session_id(state_dir)
+    finally:
+        if prev is None:
+            os.environ.pop("SCITEX_AGENT_CONTAINER_RUNTIME_DIR", None)
+        else:
+            os.environ["SCITEX_AGENT_CONTAINER_RUNTIME_DIR"] = prev
+    assert result is None
+
+
+def test_agent_restart_clears_dead_session_history(
+    tmp_path: Path, registry: Registry
+) -> None:
+    # Arrange — the dead uuid lives in the append-only history that the
+    # runner's resume fallback would otherwise walk and re-resume.
+    spec = _write_spec(tmp_path)
+    registry.add("alpha", str(spec), "cld-alpha")
+    runtime_root = tmp_path / "rt"
+    prev = os.environ.get("SCITEX_AGENT_CONTAINER_RUNTIME_DIR")
+    os.environ["SCITEX_AGENT_CONTAINER_RUNTIME_DIR"] = str(runtime_root)
+    try:
+        from scitex_agent_container._runners import _session_id as sid
+
+        state_dir = runtime_root / "alpha"
+        sid.write_session_id(state_dir, "dead-uuid")
+        sid.write_session_id(state_dir, "dead-fork")
+        # Act
+        lc.agent_restart(
+            "alpha",
+            registry=registry,
+            runtime_factory=lambda _c: FakeRuntime(start_result=True),
+            sleep_fn=_no_sleep,
+            handover_mod=FakeHandover(),
+        )
+        # Assert — the whole history is cleared so no dead uuid can be
+        # re-resumed on the next start (the crash-loop is closed).
+        history = sid.read_session_id_history(state_dir)
+    finally:
+        if prev is None:
+            os.environ.pop("SCITEX_AGENT_CONTAINER_RUNTIME_DIR", None)
+        else:
+            os.environ["SCITEX_AGENT_CONTAINER_RUNTIME_DIR"] = prev
+    assert history == []
+
+
+def test_agent_restart_backs_up_dead_session_history(
+    tmp_path: Path, registry: Registry
+) -> None:
+    # Arrange — clearing the dead history must preserve it as an audit
+    # side-file, not silently destroy it.
+    spec = _write_spec(tmp_path)
+    registry.add("alpha", str(spec), "cld-alpha")
+    runtime_root = tmp_path / "rt"
+    prev = os.environ.get("SCITEX_AGENT_CONTAINER_RUNTIME_DIR")
+    os.environ["SCITEX_AGENT_CONTAINER_RUNTIME_DIR"] = str(runtime_root)
+    try:
+        from scitex_agent_container._runners import _session_id as sid
+
+        state_dir = runtime_root / "alpha"
+        sid.write_session_id(state_dir, "dead-uuid")
+        # Act
+        lc.agent_restart(
+            "alpha",
+            registry=registry,
+            runtime_factory=lambda _c: FakeRuntime(start_result=True),
+            sleep_fn=_no_sleep,
+            handover_mod=FakeHandover(),
+        )
+        # Assert
+        backups = list(state_dir.glob("session_id_history.dead-*"))
+    finally:
+        if prev is None:
+            os.environ.pop("SCITEX_AGENT_CONTAINER_RUNTIME_DIR", None)
+        else:
+            os.environ["SCITEX_AGENT_CONTAINER_RUNTIME_DIR"] = prev
+    assert len(backups) == 1
+
+
 def test_agent_restart_unknown_raises(tmp_path: Path, registry: Registry) -> None:
     # Arrange — empty registry AND a resolver that finds no spec (a
     # genuinely unknown agent): both lookups must fail to raise.

--- a/tests/scitex_agent_container/_runners/test__dead_session.py
+++ b/tests/scitex_agent_container/_runners/test__dead_session.py
@@ -1,0 +1,64 @@
+"""Tests for the dead-session resume-failure classifier.
+
+No mocks: every test exercises the real ``_dead_session`` helpers against
+plain strings / exceptions. AAA structure, one assertion per test,
+descriptive names.
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container._runners import _dead_session as ds
+
+
+def test_is_dead_session_resume_matches_canonical_sdk_phrase() -> None:
+    # Arrange
+    msg = "Error: No conversation found with session ID: abc-123"
+    # Act
+    matched = ds.is_dead_session_resume(msg)
+    # Assert
+    assert matched is True
+
+
+def test_is_dead_session_resume_is_case_insensitive() -> None:
+    # Arrange
+    msg = "NO CONVERSATION FOUND WITH SESSION ID: ABC-123"
+    # Act
+    matched = ds.is_dead_session_resume(msg)
+    # Assert
+    assert matched is True
+
+
+def test_is_dead_session_resume_rejects_auth_failure_text() -> None:
+    # Arrange — a 401 must NOT be misclassified as a dead session.
+    msg = "API error: 401 Unauthorized"
+    # Act
+    matched = ds.is_dead_session_resume(msg)
+    # Assert
+    assert matched is False
+
+
+def test_is_dead_session_resume_rejects_generic_network_crash() -> None:
+    # Arrange
+    msg = "Connection reset by peer"
+    # Act
+    matched = ds.is_dead_session_resume(msg)
+    # Assert
+    assert matched is False
+
+
+def test_extract_dead_session_id_recovers_uuid_from_message() -> None:
+    # Arrange
+    msg = "No conversation found with session ID: 6ef8248f-1ccd-4877-934d-908e15333b52"
+    # Act
+    extracted = ds.extract_dead_session_id(msg)
+    # Assert
+    assert extracted == "6ef8248f-1ccd-4877-934d-908e15333b52"
+
+
+def test_extract_dead_session_id_returns_none_when_no_id_present() -> None:
+    # Arrange — dead-session phrasing without a parseable uuid.
+    msg = "No conversation found for session"
+    # Act
+    extracted = ds.extract_dead_session_id(msg)
+    # Assert
+    assert extracted is None

--- a/tests/scitex_agent_container/_runners/test__session_conversation.py
+++ b/tests/scitex_agent_container/_runners/test__session_conversation.py
@@ -476,3 +476,193 @@ def test_run_conversation_logs_warning_when_sdk_lacks_task_types(
         asyncio.run(_run())
     # Assert — the gap is observable, never a silent swallow.
     assert "background-task observation UNAVAILABLE for beta" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Dead-session self-heal — a stale --resume target must NOT crash-loop
+# ---------------------------------------------------------------------------
+
+
+class _DeadSessionRecorder:
+    """Records each client open with the resume id it was asked to use."""
+
+    def __init__(self, dead_id: str) -> None:
+        self.dead_id = dead_id
+        self.opens: list[str | None] = []
+
+
+def _make_dead_session_sdk_module(recorder: _DeadSessionRecorder) -> types.ModuleType:
+    """SDK module that rejects a resume of ``recorder.dead_id``, else succeeds.
+
+    The injected ``build_sdk_options_fn`` (below) carries the ``resume``
+    value onto the returned options object so the scripted client can
+    branch on it — exactly what the real claude subprocess does (it fails
+    "No conversation found with session ID: <uuid>" only when --resume
+    targets a gone session, and starts fresh when --resume is absent).
+    """
+
+    class _Text:
+        def __init__(self, text: str) -> None:
+            self.text = text
+
+    class _Assistant:
+        def __init__(self, content):
+            self.content = content
+
+    class _User:
+        pass
+
+    class _Result:
+        def __init__(self, sid_, usage):
+            self.session_id = sid_
+            self.usage = usage
+
+    class _Client:
+        def __init__(self, *, options):
+            resume = getattr(options, "resume", None)
+            recorder.opens.append(resume)
+            self._resume = resume
+
+        async def __aenter__(self):
+            # A resume of the dead id is rejected at open time, just like
+            # the real SDK's stale --resume ProcessError.
+            if self._resume == recorder.dead_id:
+                raise RuntimeError(
+                    f"Error: No conversation found with session ID: {recorder.dead_id}"
+                )
+            return self
+
+        async def __aexit__(self, *a):
+            return None
+
+        async def query(self, prompt):
+            self._prompt = prompt
+
+        async def receive_response(self):
+            # Fresh session: the agent answers normally with a NEW id.
+            yield _Assistant([_Text("recovered")])
+            yield _Result("fresh-sid", {})
+
+        async def interrupt(self):
+            return None
+
+    class _HookMatcher:
+        def __init__(self, *a, **kw):
+            pass
+
+    mod = types.ModuleType("fake_sdk_dead")
+    mod.AssistantMessage = _Assistant
+    mod.TextBlock = _Text
+    mod.UserMessage = _User
+    mod.ResultMessage = _Result
+    mod.ClaudeSDKClient = _Client
+    mod.HookMatcher = _HookMatcher
+    return mod
+
+
+def _resume_threading_build_options(name: str, **kw) -> object:
+    """Build-options stub that surfaces the ``resume`` kwarg on the options.
+
+    The scripted dead-session client reads ``options.resume`` to decide
+    whether to reject (stale resume) or start fresh — so the resume value
+    the supervisor chose per attempt must be observable on the object.
+    """
+    opts = types.SimpleNamespace()
+    opts.resume = kw.get("resume")
+    return opts
+
+
+def _run_dead_session_recovery(state_dir: Path, recorder: _DeadSessionRecorder) -> None:
+    sdk_mod = _make_dead_session_sdk_module(recorder)
+
+    async def _run():
+        inbox = await _seed("go")
+        # max_restarts=0 — the PRODUCTION default. Dead-session recovery
+        # must NOT depend on a restart budget.
+        await runner._run_conversation(
+            "alpha",
+            state_dir,
+            pid=1,
+            inbox=inbox,
+            resume_session_id=None,
+            stop=asyncio.Event(),
+            sdk_module=sdk_mod,
+            build_sdk_options_fn=_resume_threading_build_options,
+            max_restarts=0,
+        )
+
+    asyncio.run(_run())
+
+
+def test_dead_session_resume_recovers_with_fresh_start(tmp_path: Path) -> None:
+    # Arrange — both the latest marker AND the history hold the SAME dead
+    # uuid (the production shape: the only recorded id is the dead one).
+    state_dir = tmp_path / "alpha"
+    sid.write_session_id(state_dir, "dead-uuid")
+    recorder = _DeadSessionRecorder("dead-uuid")
+    # Act
+    _run_dead_session_recovery(state_dir, recorder)
+    # Assert — the runner opened a FRESH session (resume=None) after the
+    # dead-id rejection rather than dying; the recovered turn wrote a new id.
+    assert sid.read_session_id(state_dir) == "fresh-sid"
+
+
+def test_dead_session_resume_does_not_re_resume_dead_uuid(tmp_path: Path) -> None:
+    # Arrange — latest marker AND history both contain only the dead uuid.
+    state_dir = tmp_path / "alpha"
+    sid.write_session_id(state_dir, "dead-uuid")
+    recorder = _DeadSessionRecorder("dead-uuid")
+    # Act
+    _run_dead_session_recovery(state_dir, recorder)
+    # Assert — exactly ONE open used the dead uuid; the recovery opened a
+    # fresh session (resume=None) instead of re-resuming the dead id (the
+    # crash-loop). No second dead-uuid open.
+    assert recorder.opens.count("dead-uuid") == 1
+
+
+def test_dead_session_purges_dead_id_from_history(tmp_path: Path) -> None:
+    # Arrange — the dead uuid sits in the append-only history that the
+    # supervisor's resume fallback would otherwise walk and re-resume.
+    state_dir = tmp_path / "alpha"
+    sid.write_session_id(state_dir, "dead-uuid")
+    recorder = _DeadSessionRecorder("dead-uuid")
+    # Act
+    _run_dead_session_recovery(state_dir, recorder)
+    # Assert — the dead uuid is gone from the history so a later restart
+    # cannot re-resume it either.
+    assert "dead-uuid" not in sid.read_session_id_history(state_dir)
+
+
+def _make_valid_resume_sdk_module(recorder: _DeadSessionRecorder) -> types.ModuleType:
+    """SDK module that ACCEPTS the resume id (happy path — valid session)."""
+    return _make_dead_session_sdk_module(recorder)
+
+
+def test_valid_session_is_still_resumed_not_reset(tmp_path: Path) -> None:
+    # Arrange — the stored id is VALID (the recorder's dead_id is something
+    # else), so the client accepts the resume and the supervisor must NOT
+    # reset it. This guards the happy path against an over-eager reset.
+    state_dir = tmp_path / "alpha"
+    sid.write_session_id(state_dir, "valid-uuid")
+    recorder = _DeadSessionRecorder("a-different-dead-id")
+    sdk_mod = _make_valid_resume_sdk_module(recorder)
+
+    async def _run():
+        inbox = await _seed("go")
+        await runner._run_conversation(
+            "alpha",
+            state_dir,
+            pid=1,
+            inbox=inbox,
+            resume_session_id=None,
+            stop=asyncio.Event(),
+            sdk_module=sdk_mod,
+            build_sdk_options_fn=_resume_threading_build_options,
+            max_restarts=0,
+        )
+
+    # Act
+    asyncio.run(_run())
+    # Assert — the valid id was the one resume target the client saw; no
+    # dead-session reset fired (the only open used the valid id).
+    assert recorder.opens == ["valid-uuid"]

--- a/tests/scitex_agent_container/_runners/test__session_id_discard.py
+++ b/tests/scitex_agent_container/_runners/test__session_id_discard.py
@@ -1,0 +1,125 @@
+"""Tests for dead-session discard + full-history clear helpers.
+
+These are the recovery primitives that fix the ``sac agents restart``
+dead-session crash-loop: PR #190's reset cleared only ``session_id``,
+leaving a dead uuid in ``session_id_history`` to be re-resumed. The
+helpers here clear BOTH (with a backup) so a restart gets a clean slate.
+
+No mocks: real ``_session_id`` helpers against a real state dir under
+``tmp_path``. AAA structure, one assertion per test, descriptive names.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scitex_agent_container._runners import _session_id as sid
+
+
+def test_discard_dead_session_removes_dead_id_from_history(tmp_path: Path) -> None:
+    # Arrange — a single dead id is the only thing in the history.
+    state_dir = tmp_path / "alpha"
+    sid.write_session_id(state_dir, "dead-1")
+    # Act
+    sid.discard_dead_session(state_dir, "dead-1")
+    # Assert — the dead id no longer survives in the history.
+    assert "dead-1" not in sid.read_session_id_history(state_dir)
+
+
+def test_discard_dead_session_clears_latest_marker_when_it_is_the_dead_id(
+    tmp_path: Path,
+) -> None:
+    # Arrange
+    state_dir = tmp_path / "alpha"
+    sid.write_session_id(state_dir, "dead-1")
+    # Act
+    sid.discard_dead_session(state_dir, "dead-1")
+    # Assert — the resume marker is gone so the next start is fresh.
+    assert sid.read_session_id(state_dir) is None
+
+
+def test_discard_dead_session_preserves_a_newer_valid_marker(tmp_path: Path) -> None:
+    # Arrange — the latest marker advanced to a NEW valid id; only the
+    # older dead id should be purged, the valid marker left intact.
+    state_dir = tmp_path / "alpha"
+    sid.write_session_id(state_dir, "dead-old")
+    sid.write_session_id(state_dir, "valid-new")
+    # Act
+    sid.discard_dead_session(state_dir, "dead-old")
+    # Assert
+    assert sid.read_session_id(state_dir) == "valid-new"
+
+
+def test_discard_dead_session_strips_only_the_dead_id_from_history(
+    tmp_path: Path,
+) -> None:
+    # Arrange
+    state_dir = tmp_path / "alpha"
+    sid.write_session_id(state_dir, "dead-old")
+    sid.write_session_id(state_dir, "valid-new")
+    # Act
+    sid.discard_dead_session(state_dir, "dead-old")
+    # Assert — the surviving valid id remains, the dead one is gone.
+    assert sid.read_session_id_history(state_dir) == ["valid-new"]
+
+
+def test_discard_dead_session_backs_up_history_before_rewrite(tmp_path: Path) -> None:
+    # Arrange
+    state_dir = tmp_path / "alpha"
+    sid.write_session_id(state_dir, "dead-1")
+    # Act
+    sid.discard_dead_session(state_dir, "dead-1")
+    # Assert — the audit trail survives in a dead-* side file.
+    backups = list(state_dir.glob("session_id_history.dead-*"))
+    assert len(backups) == 1
+
+
+def test_discard_dead_session_returns_false_for_unknown_id(tmp_path: Path) -> None:
+    # Arrange — the id to discard never appears anywhere.
+    state_dir = tmp_path / "alpha"
+    sid.write_session_id(state_dir, "live-1")
+    # Act
+    changed = sid.discard_dead_session(state_dir, "ghost")
+    # Assert
+    assert changed is False
+
+
+def test_discard_dead_session_returns_false_for_empty_id(tmp_path: Path) -> None:
+    # Arrange
+    state_dir = tmp_path / "alpha"
+    sid.write_session_id(state_dir, "live-1")
+    # Act
+    changed = sid.discard_dead_session(state_dir, "")
+    # Assert
+    assert changed is False
+
+
+def test_clear_session_history_removes_the_history_file(tmp_path: Path) -> None:
+    # Arrange
+    state_dir = tmp_path / "alpha"
+    sid.write_session_id(state_dir, "id-A")
+    sid.write_session_id(state_dir, "id-B")
+    # Act
+    sid.clear_session_history(state_dir)
+    # Assert
+    assert sid.read_session_id_history(state_dir) == []
+
+
+def test_clear_session_history_backs_up_before_removal(tmp_path: Path) -> None:
+    # Arrange
+    state_dir = tmp_path / "alpha"
+    sid.write_session_id(state_dir, "id-A")
+    # Act
+    sid.clear_session_history(state_dir)
+    # Assert — the cleared ids are preserved in a dead-* side file.
+    backups = list(state_dir.glob("session_id_history.dead-*"))
+    assert len(backups) == 1
+
+
+def test_clear_session_history_returns_false_when_no_history(tmp_path: Path) -> None:
+    # Arrange — no history file exists.
+    state_dir = tmp_path / "alpha"
+    # Act
+    removed = sid.clear_session_history(state_dir)
+    # Assert
+    assert removed is False


### PR DESCRIPTION
## The bug (confirmed in production, 2026-05-24)

clew + neurovista went silent for ~5h. The SDK conversation loop was in a
**dead-session-resume crash-loop**: the runner kept `--resume`-ing a stale
session uuid, the SDK returned `No conversation found with session ID: <uuid>`,
the supervisor walked `session_id_history` toward the same (or equally-dead
forked) ids, exhausted `restart.max_retries`, and the conversation loop (with
its Telegram poller) **died** — only the heartbeat thread survived, so the
agent looked alive but was mute.

PR #190's `sac agents restart` (and `agent_start(force=True)`) cleared only
`session_id`, **not** `session_id_history` — so a plain restart re-resumed the
dead uuid from history and re-crashed. Manual recovery had to clear both and
back them up.

## The fix (both #1 and #2 land)

**#1 — Resilient resume (root cause).** New `_dead_session` classifier detects
the `No conversation found` signature. The supervisor purges the dead id from
BOTH the latest marker and the history (new `discard_dead_session`, backed up
to `session_id_history.dead-<ts>`) and retries as a **FRESH** session
(`resume=None`) — independent of the `max_restarts` budget, bounded by a
separate recovery counter. A genuinely-valid session is still resumed (no
over-eager reset). This makes even a non-restarted agent self-heal, closing the
crash-loop at the source.

**#2 — Restart clears both.** `agent_restart` now clears `session_id` AND the
history before the start; `_clear_persisted_session_id` (the `--force` path)
clears both too. `clear_session_id` keeps its history-preserving audit
semantics for the callers that depend on it (a new `clear_session_history`
clears the history with a backup).

Builds on PR #190 — node-aware dispatch / no-row fallback untouched.

## Tests (no mocks — NM + TQ)

Real on-disk state files + a real fake SDK shim that raises
`No conversation found` only when `--resume` targets the dead uuid:

- `test_dead_session_resume_recovers_with_fresh_start` — dead-id resume → fresh
  session id (`max_restarts=0`, the production default).
- `test_dead_session_resume_does_not_re_resume_dead_uuid` — exactly **one** open
  used the dead uuid; no re-resume, no crash-loop.
- `test_dead_session_purges_dead_id_from_history` — dead id gone from history.
- `test_valid_session_is_still_resumed_not_reset` — happy path preserved.
- `agent_restart` clears the dead marker + history and backs them up.
- `discard_dead_session` / `clear_session_history` unit coverage.

Proof: with the recovery branch disabled, the dead-session tests FAIL (the
dead-uuid resume raises and the runner dies); with it, they pass.

Targeted suites green: **523 passed** across `_runners/` + `_lifecycle/`.