### PR TITLE
fix(registry): record --on override state + fail-loud unresolvable instance (#192)

### DIFF
--- a/src/scitex_agent_container/_network/_peer_faillloud.py
+++ b/src/scitex_agent_container/_network/_peer_faillloud.py
@@ -1,0 +1,130 @@
+"""Fail-loud helpers for peer-URL resolution (#192).
+
+The pre-#192 resolver had two silent failure modes that produced an
+*unbreakable wrong state*:
+
+1. **Silent-local assumption.** When the YAML's ``spec.host`` was empty
+   (or stale) and a port happened to resolve from this host's local
+   allocator, the resolver returned ``http://127.0.0.1:<port>`` — silently
+   assuming the agent runs locally — even when the cross-host registry
+   held a fresh ``remote=True`` row placing the agent on a DIFFERENT host.
+   This is the clew incident: the lead resolved clew as local when it was
+   actually running on Spartan bm001.
+
+2. **Uninformative "is the agent running?".** When NO port resolved, the
+   error named neither the last-known host nor when the agent was last
+   seen, so the operator had no thread to pull.
+
+These helpers turn both into LOUD, INFORMATIVE failures. The doctrine:
+*never silently assume local when the registry says otherwise; never raise
+an unresolvable error without naming the last-known placement.*
+"""
+
+from __future__ import annotations
+
+from .peer import PeerError
+
+__all__ = [
+    "raise_unresolvable_instance",
+    "detect_contradicting_remote_instance",
+]
+
+
+def _format_last_known(row: dict) -> str:
+    """One-line description of a ``last_known_instance`` row for an error."""
+    host = row.get("host") or "<unknown-host>"
+    started = row.get("started_at") or "<unknown-time>"
+    ended = row.get("ended_at")
+    remote = bool(row.get("remote"))
+    port = row.get("bound_port")
+    if port is None:
+        port = row.get("a2a_port")
+    state = "ended" if ended else "active per registry (ended_at unset)"
+    loc = "remote" if remote else "local"
+    port_str = f"port={port}" if port is not None else "port=<none>"
+    return (
+        f"last known: host={host!r} ({loc}), {port_str}, started_at={started}, {state}"
+    )
+
+
+def raise_unresolvable_instance(agent_name: str, *, port_is_auto: bool) -> None:
+    """Raise an INFORMATIVE :class:`PeerError`; never return.
+
+    Called when no live ``/v1/turn`` endpoint resolves for ``agent_name``.
+    Consults the cross-host registry's last-known row (active OR ended) so
+    the message names the last-known host + timestamp + locality. The
+    resolver REFUSES to silently assume the agent is local — the unbreakable
+    wrong state #192 was about.
+
+    ``port_is_auto`` selects the base sentence (``port: auto`` agent vs a
+    statically-mis-configured one) so the operator sees the right next step.
+    """
+    last = _last_known(agent_name)
+    if last is not None:
+        raise PeerError(
+            f"agent {agent_name!r}: no live instance resolvable in the "
+            f"cross-host registry; {_format_last_known(last)}; current state "
+            f"unknown — refusing to assume local. Restart it "
+            f"(`sac --on <host> agents start {agent_name}`) or check the "
+            f"holding host before sending."
+        )
+    # No registry history at all — keep the original guidance but stay loud
+    # about the locality refusal.
+    if port_is_auto:
+        raise PeerError(
+            f"agent {agent_name!r} has port: auto and no bound port recorded "
+            f"in the cross-host registry, and no prior instance row exists; "
+            f"the agent has never run on a host this lead knows about — "
+            f"start it before sending. Refusing to assume local."
+        )
+    raise PeerError(
+        f"agent {agent_name!r} has no spec.a2a.port and no registry history — "
+        f"add a port to its YAML to enable inbound /v1/turn, then start it."
+    )
+
+
+def detect_contradicting_remote_instance(
+    agent_name: str,
+    *,
+    resolved_local: bool,
+) -> dict | None:
+    """Return a fresh ``remote=True`` row that contradicts a local resolution.
+
+    The resolver only consults ``_lookup_instance_endpoint`` when no port
+    resolved from the YAML / local allocator. That leaves a hole: a STALE
+    local-allocator port can make the resolver land on
+    ``http://127.0.0.1`` while a FRESH ``remote=True`` instances row places
+    the agent on another host. Before returning a local URL, the resolver
+    asks this helper whether such a contradicting remote row exists.
+
+    Returns the contradicting row when ``resolved_local`` is True AND the
+    latest active instance for ``agent_name`` is ``remote=True`` on a host
+    that is not this one. Returns ``None`` when there is no contradiction
+    (no row, the active row is local, or the resolution was already
+    remote). Best-effort registry read — never raises (a registry glitch
+    must not turn a working send into a crash).
+    """
+    if not resolved_local:
+        return None
+    try:
+        from .._state.state_db import list_active_instances
+
+        rows = [r for r in list_active_instances() if r.get("name") == agent_name]
+    except Exception:  # stx-allow: fallback (reason: best-effort contradiction probe — a registry read glitch must not crash a send that would otherwise work)
+        return None
+    if not rows:
+        return None
+    row = rows[0]  # started_at DESC → newest active first
+    if bool(row.get("remote")):
+        return row
+    return None
+
+
+def _last_known(agent_name: str) -> dict | None:
+    """Best-effort fetch of the last-known instance row for ``agent_name``."""
+    try:
+        from .._state.state_db import last_known_instance
+
+        return last_known_instance(agent_name)
+    except Exception:  # stx-allow: fallback (reason: best-effort evidence read for the error message — a registry glitch must not mask the underlying PeerError)
+        return None

--- a/src/scitex_agent_container/_network/_peer_resolve.py
+++ b/src/scitex_agent_container/_network/_peer_resolve.py
@@ -73,18 +73,41 @@ def resolve_peer_url(agent_name: str) -> str:
             if inst_host and not dest_host:
                 dest_host = inst_host
     if a2a_port is None:
-        if _yaml_port_is_auto(yaml_path):
-            raise PeerError(
-                f"agent {agent_name!r} has port: auto and no bound port "
-                "recorded in registry; is the agent running?"
-            )
-        raise PeerError(
-            f"agent {agent_name!r} has no spec.a2a.port — add a port to "
-            "its YAML to enable inbound /v1/turn"
+        # FAIL LOUD (#192): no live endpoint resolved. Don't raise a bare
+        # "is the agent running?" — name the last-known host + timestamp +
+        # locality from the cross-host registry, and explicitly refuse to
+        # assume local.
+        from ._peer_faillloud import raise_unresolvable_instance
+
+        raise_unresolvable_instance(
+            agent_name, port_is_auto=_yaml_port_is_auto(yaml_path)
         )
     if dest_host and not _is_local_host(dest_host):
         # Tunnel via ssh — agent's a2a.host can stay loopback (default).
         return f"ssh://{dest_host}:{a2a_port}/v1/turn"
+    # About to resolve LOCAL (spec.host empty or pointing at this machine).
+    # Before trusting that, check the cross-host registry for a FRESH
+    # remote=True instance row that contradicts the local resolution — the
+    # #192 unbreakable wrong state (a stale local-allocator port made the
+    # resolver land on 127.0.0.1 while the agent was actually running on
+    # another host). If one exists, FAIL LOUD rather than silently send to
+    # the wrong endpoint.
+    from ._peer_faillloud import detect_contradicting_remote_instance
+
+    contradiction = detect_contradicting_remote_instance(
+        agent_name, resolved_local=True
+    )
+    if contradiction is not None:
+        c_host = contradiction.get("host") or "<unknown-host>"
+        c_port = contradiction.get("bound_port") or contradiction.get("a2a_port")
+        raise PeerError(
+            f"agent {agent_name!r}: local resolution yielded "
+            f"http://{a2a_host or '127.0.0.1'}:{a2a_port}, but the cross-host "
+            f"registry holds a live remote=True instance on host {c_host!r} "
+            f"(bound_port={c_port}). Refusing to send to a stale local "
+            f"endpoint. Reach it via the holding host, or stop the stale "
+            f"local row if the remote one is wrong."
+        )
     # Local agent (spec.host empty or pointing at this machine).
     host = a2a_host or "127.0.0.1"
     return f"http://{host}:{a2a_port}/v1/turn"

--- a/src/scitex_agent_container/_state/state_db.py
+++ b/src/scitex_agent_container/_state/state_db.py
@@ -417,6 +417,7 @@ from .state_db_heartbeats import (  # noqa: E402,F401
     update_heartbeat,
 )
 from .state_db_instances import (  # noqa: E402,F401
+    last_known_instance,
     list_active_instances,
     record_instance_start,
     record_instance_stop,

--- a/src/scitex_agent_container/_state/state_db_instances.py
+++ b/src/scitex_agent_container/_state/state_db_instances.py
@@ -153,7 +153,35 @@ def list_active_instances(
         return [dict(r) for r in cur.fetchall()]
 
 
+def last_known_instance(
+    name: str,
+    db_path: Path | None = None,
+) -> dict | None:
+    """Return the most-recent ``instances`` row for ``name``, active OR ended.
+
+    Unlike :func:`list_active_instances` (which filters ``ended_at IS
+    NULL``), this returns the latest row regardless of lifecycle state so a
+    fail-loud resolver can report the LAST KNOWN host + ``started_at`` +
+    whether the row has ``ended_at`` set. ``None`` only when the agent name
+    has never appeared in this host's cross-host registry.
+
+    This is the evidence behind the #192 fail-loud message: when an agent
+    cannot be resolved to a live instance, the resolver must name the last
+    known placement rather than silently assume the agent is local.
+    """
+    from .state_db import open_db
+
+    with open_db(db_path) as conn:
+        cur = conn.execute(
+            "SELECT * FROM instances WHERE name=? ORDER BY started_at DESC LIMIT 1",
+            (name,),
+        )
+        row = cur.fetchone()
+        return dict(row) if row is not None else None
+
+
 __all__ = [
+    "last_known_instance",
     "list_active_instances",
     "record_instance_start",
     "record_instance_stop",

--- a/src/scitex_agent_container/cli_pkg/_on_start_propagate.py
+++ b/src/scitex_agent_container/cli_pkg/_on_start_propagate.py
@@ -1,0 +1,254 @@
+"""Propagate a ``--on <peer> agents start`` into the lead-side registry.
+
+The global ``--on <peer>`` flag (handled in ``_main.cli_entry_point`` ->
+``host_group.dispatch_remote``) runs ``sac <argv>`` verbatim on ``peer``
+over ssh and returns the remote exit code. That is correct for read-only
+verbs (``agents list``, ``host probe``), but for ``agents start`` it left
+a GAP: the started instance was recorded ONLY in the REMOTE peer's local
+``state.db`` and never propagated back to the dispatching (lead) host's
+cross-host ``instances`` table.
+
+The incident this closes (issue #192, 2026-05-24): clew was restarted via
+``sac --on spartan-bm001 agents start`` after a reservation moved it to a
+new node. The new bm001 instance was invisible to the lead — its
+cross-host registry still resolved clew against the OLD lapsed reservation
+node with ``remote=False`` (the silent-local default), an unbreakable
+wrong state.
+
+The fix mirrors the spec-host-driven path in
+``cli_pkg/lifecycle/_dispatch.py::_dispatch_remote_start``: when the ``--on``
+target is an ``agents start``, run it remotely with ``--json
+--no-redispatch`` appended, parse the JSON the remote start emits, and
+write a lead-side ``record_instance_start`` row capturing the ACTUAL
+resolved runtime state — the override host (``--on <peer>``), the bound
+port the remote allocator claimed, ``remote=True``, and the lineage edge.
+
+The registry is thus populated from actually-used data (the override host
+the operator typed), and spec-vs-actual divergence is captured rather than
+silently lost.
+"""
+
+from __future__ import annotations
+
+import json
+
+import click
+
+__all__ = [
+    "is_agents_start_argv",
+    "parse_started_agent_name",
+    "propagate_remote_start",
+]
+
+
+# Verb tokens that name the start command. ``sac agents start`` is the
+# canonical form; the legacy ``agent`` (singular) alias is also accepted
+# so an operator who typed the older spelling still propagates.
+_AGENTS_NOUNS = ("agents", "agent")
+_START_VERB = "start"
+
+# Read-only flags that take a value we must skip when scanning for the
+# positional agent name. Mirrors the value-taking options on the
+# ``agents start`` click command.
+_VALUE_FLAGS = {
+    "--resume",
+    "--session",
+    "--params-file",
+    "--params-out",
+}
+
+
+def is_agents_start_argv(argv: list[str]) -> bool:
+    """Return True iff ``argv`` is an ``agents start`` invocation.
+
+    Matches ``["agents", "start", ...]`` or the legacy singular
+    ``["agent", "start", ...]``. Anything else (``agents list``,
+    ``host probe``, ``db query`` ...) returns False so the caller keeps
+    the verbatim pass-through behaviour for non-start verbs.
+    """
+    return len(argv) >= 2 and argv[0] in _AGENTS_NOUNS and argv[1] == _START_VERB
+
+
+def parse_started_agent_name(argv: list[str]) -> str | None:
+    """Return the first positional agent name in an ``agents start`` argv.
+
+    Skips the ``agents start`` tokens and any leading value-taking flags
+    (``--resume <id>``, ``--session <mode>``, ...) plus their values, and
+    plain flags (``--force``, ``--json``). The first bare token that is
+    not a flag (and not a flag value) is the agent name/path.
+
+    Returns None when no positional is present (e.g. a malformed
+    ``agents start --force`` with no target) — the caller then skips
+    propagation and falls back to the plain pass-through, so a missing
+    name never crashes the dispatch.
+    """
+    rest = argv[2:]  # drop "agents"/"agent" + "start"
+    i = 0
+    while i < len(rest):
+        tok = rest[i]
+        if tok.startswith("--") and "=" in tok:
+            # ``--resume=<id>`` style — consumes no separate value token.
+            i += 1
+            continue
+        if tok in _VALUE_FLAGS:
+            i += 2  # skip the flag AND its value
+            continue
+        if tok.startswith("-"):
+            i += 1  # plain flag (no value)
+            continue
+        return tok  # first bare positional = agent name/path
+    return None
+
+
+def _name_from_target(target: str) -> str:
+    """Derive the agent name from a start TARGET (name or yaml path).
+
+    ``sac agents start`` accepts either a bare name or a yaml path; the
+    instances row is keyed by the agent NAME. A path's name is its parent
+    directory stem (``<name>/<name>.yaml``) or the file stem; a bare name
+    is returned unchanged.
+    """
+    from pathlib import Path
+
+    if "/" not in target and not target.endswith((".yaml", ".yml")):
+        return target
+    p = Path(target)
+    # ``<name>/<name>.yaml`` → parent stem; bare ``<name>.yaml`` → file stem.
+    if p.suffix in (".yaml", ".yml"):
+        return p.parent.name or p.stem
+    return p.name
+
+
+def _spawned_by() -> str:
+    """Launching identity for the lineage edge (Rule B/D).
+
+    A parent AGENT shelling out carries ``SAC_NAME`` in its env; a bare
+    lead / operator dispatch records ``"cli"``.
+    """
+    from .._env import getenv
+
+    return getenv("NAME") or "cli"
+
+
+def propagate_remote_start(
+    peer: str,
+    argv: list[str],
+    *,
+    runner=None,
+    ssh_argv0: str = "sac",
+) -> int:
+    """Run ``sac agents start ...`` on ``peer`` and record a lead-side row.
+
+    Re-invokes the remote ``agents start`` with ``--json --no-redispatch``
+    appended (idempotent — appending again is harmless if already
+    present), parses the JSON the remote start emits, and writes a
+    lead-side ``record_instance_start`` row with the ACTUAL override host
+    (``peer``), the remote-resolved ``bound_port``, ``remote=True``, and
+    the lineage edge.
+
+    The recorded host is the override host the operator typed via
+    ``--on``, captured EXACTLY rather than re-derived from the spec — the
+    crux of the #192 fix.
+
+    Args:
+        peer: The ``--on`` target peer (must already be a known peer; the
+            caller validates membership before calling).
+        argv: The ``agents start ...`` argv (sans ``--on <peer>``).
+        runner: subprocess-style callable seam
+            ``runner(ssh_argv) -> CompletedProcess``. Defaults to a real
+            ssh round-trip via ``build_ssh_argv`` + ``subprocess.run``.
+        ssh_argv0: Remote program name (``sac`` by convention).
+
+    Returns:
+        The remote exit code. On a non-zero remote start, no row is
+        written (there is no live instance to record) and the remote rc
+        is returned so the operator sees the failure.
+
+    Raises:
+        RuntimeError: When the remote start succeeded (rc 0) but its
+            stdout is not parseable JSON — a LOUD failure rather than a
+            silently-unrecorded start, because a started-but-unrecorded
+            agent is exactly the invisible state #192 was about.
+    """
+    name = parse_started_agent_name(argv)
+    if name is None:
+        # No positional target — nothing to record. Fall back to the
+        # plain verbatim pass-through so the remote still runs (and emits
+        # its own usage error if the argv is malformed).
+        from .host_group import dispatch_remote
+
+        return dispatch_remote(peer, argv, ssh_argv0=ssh_argv0)
+
+    # Build the remote argv with --json --no-redispatch so we can parse
+    # the started state and the remote doesn't try to re-dispatch.
+    remote_argv = list(argv)
+    if "--json" not in remote_argv:
+        remote_argv.append("--json")
+    if "--no-redispatch" not in remote_argv:
+        remote_argv.append("--no-redispatch")
+
+    if runner is None:
+        runner = _default_ssh_runner
+    result = runner(peer, [ssh_argv0, *remote_argv])
+    if result.returncode != 0:
+        # Remote start failed — no live instance to record. Surface the
+        # remote rc; the operator sees stdout/stderr from the inherited
+        # streams (real runner) or from the result object.
+        return result.returncode
+
+    stdout = getattr(result, "stdout", None) or ""
+    try:
+        peer_state = json.loads(stdout)
+    except (json.JSONDecodeError, TypeError) as exc:
+        raise RuntimeError(
+            f"`sac --on {peer} agents start {name}` succeeded but returned "
+            f"non-JSON stdout; cannot record the lead-side instances row "
+            f"(the started agent would be invisible to the lead — the "
+            f"exact #192 failure). Re-run with --json to inspect.\n"
+            f"stdout (first 500 chars):\n{stdout[:500]}\n"
+            f"json error: {exc}"
+        ) from exc
+
+    # A skipped / dry-run start has no live instance to record.
+    status = peer_state.get("status")
+    if status not in ("started",):
+        return 0
+
+    agent_name = _name_from_target(name)
+    bound = peer_state.get("a2a_port")
+    from .._state.state_db import record_instance_start
+
+    record_instance_start(
+        name=agent_name,
+        host=peer,
+        a2a_port=bound,
+        bound_port=bound,
+        remote=True,
+        spawned_by=_spawned_by(),
+        workdir=peer_state.get("host_workdir"),
+    )
+    click.echo(
+        f"[--on] {agent_name!r} started on {peer!r} "
+        f"(a2a_port={bound!s}, started_at={peer_state.get('started_at')!s}); "
+        f"recorded lead-side instances row (remote=True, host={peer!r})."
+    )
+    return 0
+
+
+def _default_ssh_runner(peer: str, full_argv: list[str]):
+    """Real ssh round-trip, capturing stdout so the JSON can be parsed.
+
+    Returns a ``subprocess.CompletedProcess`` (text mode). The remote
+    ``sac agents start --json`` writes its report to stdout; stderr is
+    inherited so the operator still sees progress / errors live.
+    """
+    import subprocess
+
+    from .._state.host_config import build_ssh_argv
+    from .._state.host_config import load as _load
+
+    cfg = _load()
+    ssh_argv = build_ssh_argv(peer, full_argv, cfg.peers)
+    return subprocess.run(ssh_argv, capture_output=True, text=True, check=False)
+
+

--- a/src/scitex_agent_container/cli_pkg/host_group.py
+++ b/src/scitex_agent_container/cli_pkg/host_group.py
@@ -200,6 +200,16 @@ def dispatch_remote(peer: str, argv: list[str], ssh_argv0: str = "sac") -> int:
     remote command is always ``sac <argv>`` — orchestrators rely on
     that prefix so peers can be set up to alias ``sac`` to the right
     binary path on hosts where it isn't on $PATH.
+
+    Special case ``agents start``: the verbatim pass-through would record
+    the new instance ONLY in the REMOTE peer's local registry, leaving the
+    dispatching (lead) host's cross-host ``instances`` table unaware of the
+    override-host placement (issue #192 — clew restarted via
+    ``sac --on spartan-bm001 agents start`` was invisible to the lead).
+    For that verb we delegate to :func:`._on_start_propagate.propagate_remote_start`,
+    which runs the remote start with ``--json --no-redispatch`` and writes
+    a lead-side row capturing the ACTUAL override host + bound port +
+    ``remote=True``.
     """
     cfg = load()
     if peer not in cfg.peers:
@@ -209,6 +219,10 @@ def dispatch_remote(peer: str, argv: list[str], ssh_argv0: str = "sac") -> int:
             err=True,
         )
         return 2
+    from ._on_start_propagate import is_agents_start_argv, propagate_remote_start
+
+    if is_agents_start_argv(argv):
+        return propagate_remote_start(peer, argv, ssh_argv0=ssh_argv0)
     ssh_argv = build_ssh_argv(peer, [ssh_argv0, *argv], cfg.peers)
     proc = subprocess.run(ssh_argv)
     return proc.returncode

--- a/tests/scitex_agent_container/_network/test__peer_faillloud.py
+++ b/tests/scitex_agent_container/_network/test__peer_faillloud.py
@@ -1,0 +1,226 @@
+"""Tests for fail-loud peer-URL resolution (#192).
+
+The pre-#192 resolver silently assumed an agent was local when its
+``spec.host`` was empty and a port happened to resolve, even when the
+cross-host registry placed it on a different host. It also raised an
+uninformative "is the agent running?" with no last-known-host evidence.
+
+These tests prove the resolver now:
+  * RAISES an informative ``PeerError`` (naming the last-known host +
+    timestamp) when no live instance resolves — never silently local.
+  * RAISES when a stale local resolution contradicts a fresh
+    ``remote=True`` instances row — refusing to send to the wrong endpoint.
+
+No-mocks: real on-disk isolated state.db rows + real YAML files swapped
+through ``resolve_config``. Conforms to STX-TQ002 (AAA markers), STX-TQ003
+(descriptive names), STX-TQ007 (one assertion per test).
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._network.peer import PeerError, resolve_peer_url
+
+
+@pytest.fixture
+def resolve_yaml_to():
+    """Yield a setter that swaps ``resolve_config`` and restores on teardown."""
+    from scitex_agent_container.config import _resolve
+
+    saved = _resolve.resolve_config
+
+    def _set(yaml_path):
+        _resolve.resolve_config = lambda _name: str(yaml_path)
+
+    try:
+        yield _set
+    finally:
+        _resolve.resolve_config = saved
+
+
+@pytest.fixture
+def isolated_state_db(tmp_path: Path):
+    """Redirect state.db to a tmp path; reload the module so the
+    module-level DEFAULT_DB_PATH picks it up (explicit save/restore)."""
+    db = tmp_path / "state.db"
+    key = "SCITEX_AGENT_CONTAINER_STATE_DB"
+    saved = os.environ.get(key)
+    os.environ[key] = str(db)
+    import scitex_agent_container._state.state_db as mod
+
+    importlib.reload(mod)
+    try:
+        yield db
+    finally:
+        if saved is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = saved
+        importlib.reload(mod)
+
+
+def _write_auto_port_yaml(tmp_path: Path) -> Path:
+    """A v3 YAML with ``a2a.port: auto`` and no ``spec.host`` — clew's shape."""
+    y = tmp_path / "clew" / "clew.yaml"
+    y.parent.mkdir(parents=True)
+    y.write_text(
+        "apiVersion: scitex-agent-container/v3\n"
+        "kind: Agent\n"
+        "spec:\n"
+        "  runtime: apptainer\n"
+        "  a2a: {port: auto}\n"
+    )
+    return y
+
+
+def _write_static_local_yaml(tmp_path: Path) -> Path:
+    """A v3 YAML with a static loopback a2a port and no spec.host."""
+    y = tmp_path / "clew" / "clew.yaml"
+    y.parent.mkdir(parents=True)
+    y.write_text(
+        "apiVersion: scitex-agent-container/v3\n"
+        "kind: Agent\n"
+        "spec:\n"
+        "  runtime: apptainer\n"
+        "  a2a: {port: 18888, host: 127.0.0.1}\n"
+    )
+    return y
+
+
+# ---------------------------------------------------------------------------
+# Unresolvable instance → informative fail-loud (never silent-local)
+# ---------------------------------------------------------------------------
+
+
+class TestUnresolvableInstanceFailsLoud:
+    def test_no_live_instance_with_history_names_last_known_host(
+        self, tmp_path, resolve_yaml_to, isolated_state_db, env_save_restore
+    ) -> None:
+        # Arrange — auto-port YAML, no local allocator claim, and an
+        # ENDED prior instance row recording the last-known host.
+        env_save_restore.set("SAC_HOST", "lead-host")
+        resolve_yaml_to(_write_auto_port_yaml(tmp_path))
+        from scitex_agent_container._state.state_db import (
+            record_instance_start,
+            record_instance_stop,
+        )
+
+        iid = record_instance_start(
+            name="clew", host="spartan-bm043", bound_port=19000, remote=True
+        )
+        record_instance_stop(iid, exit_reason="superseded")
+        # Act
+        ctx = pytest.raises(PeerError, match="spartan-bm043")
+        # Assert — the error names the last-known host.
+        with ctx:
+            resolve_peer_url("clew")
+
+    def test_no_live_instance_refuses_to_assume_local(
+        self, tmp_path, resolve_yaml_to, isolated_state_db, env_save_restore
+    ) -> None:
+        # Arrange — same ended-history shape.
+        env_save_restore.set("SAC_HOST", "lead-host")
+        resolve_yaml_to(_write_auto_port_yaml(tmp_path))
+        from scitex_agent_container._state.state_db import (
+            record_instance_start,
+            record_instance_stop,
+        )
+
+        iid = record_instance_start(
+            name="clew", host="spartan-bm043", bound_port=19000, remote=True
+        )
+        record_instance_stop(iid, exit_reason="superseded")
+        # Act
+        ctx = pytest.raises(PeerError, match="refusing to assume local")
+        # Assert — the message explicitly states the locality refusal.
+        with ctx:
+            resolve_peer_url("clew")
+
+    def test_no_registry_history_at_all_still_raises_loud(
+        self, tmp_path, resolve_yaml_to, isolated_state_db, env_save_restore
+    ) -> None:
+        # Arrange — auto-port YAML, no allocator claim, NO instances row.
+        env_save_restore.set("SAC_HOST", "lead-host")
+        resolve_yaml_to(_write_auto_port_yaml(tmp_path))
+        # Act
+        ctx = pytest.raises(PeerError, match="never run on a host this lead knows")
+        # Assert
+        with ctx:
+            resolve_peer_url("clew")
+
+
+# ---------------------------------------------------------------------------
+# Stale-local-vs-fresh-remote contradiction → fail-loud
+# ---------------------------------------------------------------------------
+
+
+class TestStaleLocalContradictsRemoteFailsLoud:
+    def test_static_local_port_with_fresh_remote_row_raises(
+        self, tmp_path, resolve_yaml_to, isolated_state_db, env_save_restore
+    ) -> None:
+        # Arrange — a STATIC loopback port in the YAML would resolve
+        # local, but the cross-host registry holds a FRESH remote=True
+        # row on another host (the #192 unbreakable wrong state).
+        env_save_restore.set("SAC_HOST", "lead-host")
+        resolve_yaml_to(_write_static_local_yaml(tmp_path))
+        from scitex_agent_container._state.state_db import record_instance_start
+
+        record_instance_start(
+            name="clew", host="spartan-bm001", bound_port=19500, remote=True
+        )
+        # Act
+        ctx = pytest.raises(PeerError, match="stale local endpoint")
+        # Assert — refuses the local URL, naming the holding host.
+        with ctx:
+            resolve_peer_url("clew")
+
+    def test_contradiction_error_names_the_holding_host(
+        self, tmp_path, resolve_yaml_to, isolated_state_db, env_save_restore
+    ) -> None:
+        # Arrange
+        env_save_restore.set("SAC_HOST", "lead-host")
+        resolve_yaml_to(_write_static_local_yaml(tmp_path))
+        from scitex_agent_container._state.state_db import record_instance_start
+
+        record_instance_start(
+            name="clew", host="spartan-bm001", bound_port=19500, remote=True
+        )
+        # Act
+        ctx = pytest.raises(PeerError, match="spartan-bm001")
+        # Assert
+        with ctx:
+            resolve_peer_url("clew")
+
+    def test_static_local_port_without_remote_row_resolves_local(
+        self, tmp_path, resolve_yaml_to, isolated_state_db, env_save_restore
+    ) -> None:
+        # Arrange — a static local port and NO contradicting remote row
+        # must still resolve to the loopback URL (no false-positive raise).
+        env_save_restore.set("SAC_HOST", "lead-host")
+        resolve_yaml_to(_write_static_local_yaml(tmp_path))
+        # Act
+        url = resolve_peer_url("clew")
+        # Assert
+        assert url == "http://127.0.0.1:18888/v1/turn"
+
+    def test_local_row_does_not_contradict_local_resolution(
+        self, tmp_path, resolve_yaml_to, isolated_state_db, env_save_restore
+    ) -> None:
+        # Arrange — a local (remote=False) instances row must NOT trigger
+        # the contradiction guard.
+        env_save_restore.set("SAC_HOST", "lead-host")
+        resolve_yaml_to(_write_static_local_yaml(tmp_path))
+        from scitex_agent_container._state.state_db import record_instance_start
+
+        record_instance_start(
+            name="clew", host="lead-host", bound_port=18888, remote=False
+        )
+        # Act
+        url = resolve_peer_url("clew")
+        # Assert
+        assert url == "http://127.0.0.1:18888/v1/turn"

--- a/tests/scitex_agent_container/_state/test_state_db_instances.py
+++ b/tests/scitex_agent_container/_state/test_state_db_instances.py
@@ -200,3 +200,56 @@ def test_migration_is_idempotent_on_replay(db_path: Path):
     init_schema()
     # Assert — reaching here means the replay did not raise.
     assert db_path.exists()
+
+
+# ---------------------------------------------------------------------------
+# last_known_instance — the fail-loud evidence helper (#192).
+# ---------------------------------------------------------------------------
+
+
+def test_last_known_instance_returns_ended_row_when_no_active(db_path: Path):
+    # Arrange — record then end the only instance for the agent.
+    from scitex_agent_container._state.state_db import (
+        last_known_instance,
+        record_instance_start,
+        record_instance_stop,
+    )
+
+    iid = record_instance_start(name="clew", host="spartan-bm043", remote=True)
+    record_instance_stop(iid, exit_reason="superseded")
+    # Act
+    row = last_known_instance("clew")
+    # Assert — the ended row is still returned (active filter would hide it).
+    assert row["host"] == "spartan-bm043"
+
+
+def test_last_known_instance_returns_none_for_unknown_agent(db_path: Path):
+    # Arrange — a fresh isolated db with no rows for this name.
+    from scitex_agent_container._state.state_db import (
+        last_known_instance,
+        record_instance_start,
+    )
+
+    record_instance_start(name="other", host="lead-host", remote=False)
+    # Act
+    row = last_known_instance("never-seen")
+    # Assert
+    assert row is None
+
+
+def test_last_known_instance_returns_latest_by_started_at(db_path: Path):
+    # Arrange — two rows for one name; the second is newer.
+    import time
+
+    from scitex_agent_container._state.state_db import (
+        last_known_instance,
+        record_instance_start,
+    )
+
+    record_instance_start(name="clew", host="spartan-bm043", remote=True)
+    time.sleep(1.05)  # now_iso() is second-resolution; ensure a later started_at
+    record_instance_start(name="clew", host="spartan-bm001", remote=True)
+    # Act
+    row = last_known_instance("clew")
+    # Assert — the most recent placement wins.
+    assert row["host"] == "spartan-bm001"

--- a/tests/scitex_agent_container/cli_pkg/test__on_start_propagate.py
+++ b/tests/scitex_agent_container/cli_pkg/test__on_start_propagate.py
@@ -1,0 +1,236 @@
+"""Tests for ``--on <peer> agents start`` lead-side registry propagation.
+
+Issue #192: a ``sac --on spartan-bm001 agents start clew`` recorded the
+new instance ONLY in the remote peer's local registry; the dispatching
+(lead) host's cross-host ``instances`` table never learned about it, so
+the lead resolved clew against a STALE node with the silent-local default.
+
+These tests prove ``propagate_remote_start`` records a lead-side
+``instances`` row capturing the ACTUAL override host (``--on <peer>``),
+the remote-resolved bound port, and ``remote=True``.
+
+No-mocks: a real callable seam (``runner``) returns a real
+``CompletedProcess`` carrying the JSON a remote ``agents start --json``
+would emit; the registry write goes to an isolated on-disk state.db.
+Conforms to STX-TQ002 (AAA markers), STX-TQ003 (descriptive names),
+STX-TQ007 (one assertion per test).
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container.cli_pkg._on_start_propagate import (
+    is_agents_start_argv,
+    parse_started_agent_name,
+    propagate_remote_start,
+)
+
+
+@pytest.fixture
+def isolated_state_db(tmp_path: Path):
+    """Redirect state.db to a tmp path; reload the module so the
+    module-level DEFAULT_DB_PATH picks it up (explicit save/restore)."""
+    db = tmp_path / "state.db"
+    key = "SCITEX_AGENT_CONTAINER_STATE_DB"
+    saved = os.environ.get(key)
+    os.environ[key] = str(db)
+    import scitex_agent_container._state.state_db as mod
+
+    importlib.reload(mod)
+    try:
+        yield db
+    finally:
+        if saved is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = saved
+        importlib.reload(mod)
+
+
+def _started_runner(name: str, *, host_workdir: str = "/work", port: int = 19123):
+    """Return a runner seam that emits the JSON a successful remote start prints."""
+    payload = {
+        "name": name,
+        "status": "started",
+        "host": "peer-side-reported",
+        "host_workdir": host_workdir,
+        "container_workdir": "/container",
+        "dry_run": False,
+        "a2a_port": port,
+        "started_at": "2026-05-24T08:00:00Z",
+    }
+
+    def _run(peer, full_argv):
+        return subprocess.CompletedProcess(
+            args=full_argv,
+            returncode=0,
+            stdout=json.dumps(payload),
+            stderr="",
+        )
+
+    return _run
+
+
+# ---------------------------------------------------------------------------
+# argv classification
+# ---------------------------------------------------------------------------
+
+
+class TestArgvClassification:
+    def test_agents_start_argv_is_recognized_as_start(self) -> None:
+        # Arrange
+        argv = ["agents", "start", "clew", "--force"]
+        # Act
+        recognized = is_agents_start_argv(argv)
+        # Assert
+        assert recognized is True
+
+    def test_agents_list_argv_is_not_recognized_as_start(self) -> None:
+        # Arrange
+        argv = ["agents", "list", "--json"]
+        # Act
+        recognized = is_agents_start_argv(argv)
+        # Assert
+        assert recognized is False
+
+    def test_legacy_singular_agent_start_is_recognized(self) -> None:
+        # Arrange
+        argv = ["agent", "start", "clew"]
+        # Act
+        recognized = is_agents_start_argv(argv)
+        # Assert
+        assert recognized is True
+
+    def test_positional_name_parsed_past_value_flag(self) -> None:
+        # Arrange — --session takes a value that must NOT be mistaken
+        # for the agent name.
+        argv = ["agents", "start", "--session", "resume", "clew"]
+        # Act
+        name = parse_started_agent_name(argv)
+        # Assert
+        assert name == "clew"
+
+    def test_positional_name_parsed_past_plain_flag(self) -> None:
+        # Arrange
+        argv = ["agents", "start", "--force", "--json", "neurovista"]
+        # Act
+        name = parse_started_agent_name(argv)
+        # Assert
+        assert name == "neurovista"
+
+    def test_no_positional_returns_none(self) -> None:
+        # Arrange
+        argv = ["agents", "start", "--force"]
+        # Act
+        name = parse_started_agent_name(argv)
+        # Assert
+        assert name is None
+
+
+# ---------------------------------------------------------------------------
+# propagation records the ACTUAL override host
+# ---------------------------------------------------------------------------
+
+
+class TestPropagateRecordsOverrideHost:
+    def test_records_lead_side_row_on_override_host(
+        self, isolated_state_db, capsys
+    ) -> None:
+        # Arrange — a successful remote start on the override host.
+        runner = _started_runner("clew", port=19123)
+        # Act
+        propagate_remote_start(
+            "spartan-bm001", ["agents", "start", "clew"], runner=runner
+        )
+        # Assert — the recorded instances row's host IS the --on override.
+        from scitex_agent_container._state.state_db import list_active_instances
+
+        rows = [r for r in list_active_instances() if r["name"] == "clew"]
+        assert rows[0]["host"] == "spartan-bm001"
+
+    def test_records_row_with_remote_flag_set(self, isolated_state_db) -> None:
+        # Arrange
+        runner = _started_runner("clew", port=19123)
+        # Act
+        propagate_remote_start(
+            "spartan-bm001", ["agents", "start", "clew"], runner=runner
+        )
+        # Assert
+        from scitex_agent_container._state.state_db import list_active_instances
+
+        rows = [r for r in list_active_instances() if r["name"] == "clew"]
+        assert bool(rows[0]["remote"]) is True
+
+    def test_records_remote_resolved_bound_port(self, isolated_state_db) -> None:
+        # Arrange
+        runner = _started_runner("clew", port=19123)
+        # Act
+        propagate_remote_start(
+            "spartan-bm001", ["agents", "start", "clew"], runner=runner
+        )
+        # Assert
+        from scitex_agent_container._state.state_db import list_active_instances
+
+        rows = [r for r in list_active_instances() if r["name"] == "clew"]
+        assert rows[0]["bound_port"] == 19123
+
+    def test_appends_json_and_no_redispatch_to_remote_argv(
+        self, isolated_state_db
+    ) -> None:
+        # Arrange — capture the argv the runner is invoked with.
+        seen: list[list[str]] = []
+
+        def _run(peer, full_argv):
+            seen.append(full_argv)
+            return subprocess.CompletedProcess(
+                args=full_argv,
+                returncode=0,
+                stdout=json.dumps({"name": "clew", "status": "started", "a2a_port": 1}),
+                stderr="",
+            )
+
+        # Act
+        propagate_remote_start(
+            "spartan-bm001", ["agents", "start", "clew"], runner=_run
+        )
+        # Assert — both control flags appended for a parseable, non-recursive remote start.
+        assert {"--json", "--no-redispatch"}.issubset(set(seen[0]))
+
+    def test_non_json_stdout_raises_loud_error(self, isolated_state_db) -> None:
+        # Arrange — remote start succeeded (rc 0) but emitted non-JSON.
+        def _run(peer, full_argv):
+            return subprocess.CompletedProcess(
+                args=full_argv, returncode=0, stdout="not-json", stderr=""
+            )
+
+        # Act
+        ctx = pytest.raises(RuntimeError, match="non-JSON stdout")
+        # Assert
+        with ctx:
+            propagate_remote_start(
+                "spartan-bm001", ["agents", "start", "clew"], runner=_run
+            )
+
+    def test_remote_failure_records_no_row(self, isolated_state_db) -> None:
+        # Arrange — remote start failed (rc 1); no live instance to record.
+        def _run(peer, full_argv):
+            return subprocess.CompletedProcess(
+                args=full_argv, returncode=1, stdout="", stderr="boom"
+            )
+
+        propagate_remote_start(
+            "spartan-bm001", ["agents", "start", "clew"], runner=_run
+        )
+        # Act
+        from scitex_agent_container._state.state_db import list_active_instances
+
+        rows = [r for r in list_active_instances() if r["name"] == "clew"]
+        # Assert — nothing recorded for a failed remote start.
+        assert rows == []


### PR DESCRIPTION
## Why

Consolidates two of the three operator diagnoses from the clew/neurovista ~5h outage (#192). Both honour the fail-loud / no-silent-fallback doctrine.

During recovery the lead-side registry resolved clew as `host=spartan-bm043` (OLD lapsed reservation), `remote=False` (WRONG — clew was remote on Spartan bm001), `started_at=May-17` (stale). The CURRENT bm001 instance (restarted via `sac --on spartan-bm001 agents start`) was NEVER propagated to the lead's cross-host registry. The `remote=False` silent default was the core bug — the lead silently assumed local, an unbreakable wrong state.

## What

**1. Actual-state-record.** `dispatch_remote` (the `--on <peer>` path) ran `sac <argv>` verbatim on the peer for ALL verbs, so an `agents start` recorded the instance only in the *remote* peer's local registry. It now delegates start to `propagate_remote_start`, which runs the remote start with `--json --no-redispatch`, parses the started state, and writes a lead-side `record_instance_start` row capturing the **actual override host** (`--on <peer>`), the remote-resolved `bound_port`, and `remote=True`. A started-but-unrecorded agent (non-JSON stdout) is a **loud** `RuntimeError`.

**2. Fail-loud resolution.** `resolve_peer_url` no longer silently defaults to `http://127.0.0.1` when an agent is unresolvable. It now:
- raises an **informative** `PeerError` naming the last-known host + `started_at` + locality (via new `last_known_instance`), explicitly *refusing to assume local*;
- catches the unbreakable wrong state directly: a stale local-allocator port that would resolve local while the registry holds a **fresh `remote=True` row** on another host fails loud rather than sending to the wrong endpoint.

## Fail-loud messages

- Unresolvable + history: `agent 'clew': no live instance resolvable in the cross-host registry; last known: host='spartan-bm043' (remote), ...; current state unknown — refusing to assume local.`
- Stale-local-vs-fresh-remote: `agent 'clew': local resolution yielded http://127.0.0.1:18888, but the cross-host registry holds a live remote=True instance on host 'spartan-bm001' ... Refusing to send to a stale local endpoint.`

## Tests (no mocks)

Real on-disk isolated state.db + real callable seams / real shim binaries:
- `test__on_start_propagate.py` — override host / remote flag / bound port recorded; `--json --no-redispatch` appended; non-JSON raises; failed remote records nothing.
- `test__peer_faillloud.py` — resolver names last-known host; refuses to assume local; no-history raises; stale-local-vs-fresh-remote contradiction fails loud; genuine local still resolves local.
- `test_state_db_instances.py` — `last_known_instance` returns ended rows / None / latest-by-time.

199 relevant tests pass with `pytest-randomly` enabled.

PR 2 (session-resume informative + selectable, Part B #3) follows separately.