### PR TITLE
fix(resume): session-not-found informative + selectable, not silent fresh-start (#192)

### DIFF
--- a/src/scitex_agent_container/_runners/_session_candidates.py
+++ b/src/scitex_agent_container/_runners/_session_candidates.py
@@ -1,0 +1,198 @@
+"""List resumable Claude Code conversations for an agent (#192, Part B #3).
+
+When a ``--resume <uuid>`` target is gone ("No conversation found with
+session ID: <uuid>") the recovery must be INFORMATIVE and SELECTABLE, not
+a silent fresh start (operator design 4488):
+
+  * Informative — list the conversations actually available for the agent
+    (``$HOME/.claude/projects/<encoded-cwd>/*.jsonl``) with their
+    timestamps and a first-message snippet, so the operator can see what
+    is resumable.
+  * Selectable — surface that candidate list so a ``--resume <chosen>``
+    (or the explicit fresh-start last resort) is an informed choice.
+
+The SDK (claude-agent-sdk / Claude Code) writes one ``<session-uuid>.jsonl``
+per conversation under ``$HOME/.claude/projects/<encoded-resolved-cwd>/``,
+where the dir name is the resolved working directory with ``/`` and ``.``
+mapped to ``-`` (triple+ dashes collapsed to ``--``). This module reads
+that store and returns structured candidates — no SDK import, pure stdlib,
+unit-testable against a tmp ``$HOME``.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+__all__ = [
+    "SessionCandidate",
+    "encode_claude_project",
+    "list_session_candidates",
+    "format_candidates",
+]
+
+
+@dataclass(frozen=True)
+class SessionCandidate:
+    """One resumable conversation discovered in the SDK projects store.
+
+    ``session_id`` is the ``.jsonl`` stem (the uuid a ``--resume`` takes).
+    ``mtime`` is the file's last-modified unix time (newest = most recently
+    active). ``first_message`` is a short snippet of the first user prompt
+    (empty when the transcript has no parseable user turn).
+    """
+
+    session_id: str
+    mtime: float
+    first_message: str
+
+    @property
+    def mtime_iso(self) -> str:
+        """ISO-8601 UTC timestamp of last activity (for human display)."""
+        return datetime.fromtimestamp(self.mtime, tz=timezone.utc).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+
+
+def encode_claude_project(workdir: str) -> str:
+    """Replicate Claude Code's cwd → ``projects/`` dir-name encoding.
+
+    ``/`` and ``.`` both become ``-``; triple-or-more dashes (from hidden
+    dirs like ``/.foo``) collapse back to ``--``. Mirrors
+    ``_state._meta.transcript._encode_claude_project`` — duplicated here
+    (one line of regex) so the runner-side candidate lister has no import
+    dependency on the heavier ``agent_meta`` module.
+    """
+    encoded = workdir.replace("/", "-").replace(".", "-")
+    return re.sub(r"-{3,}", "--", encoded)
+
+
+def _project_dir(workdir: str, home: Path | None = None) -> Path:
+    """Return the SDK projects dir for ``workdir`` under ``home``.
+
+    Follows symlinks (Claude Code encodes the *resolved* cwd). ``home``
+    defaults to ``Path.home()`` so the in-container runner finds its own
+    store; tests pass a tmp home.
+    """
+    base = home or Path.home()
+    try:
+        resolved = str(Path(workdir).expanduser().resolve())
+    except OSError:
+        resolved = workdir
+    return base / ".claude" / "projects" / encode_claude_project(resolved)
+
+
+def _first_user_message(jsonl_path: Path, *, max_chars: int = 120) -> str:
+    """Return a short snippet of the first user turn in a transcript.
+
+    Best-effort: scans the ``.jsonl`` for the first record whose role /
+    type marks a user message and pulls its text. Any IO / parse failure
+    yields an empty string (the candidate is still listed by id + mtime).
+    """
+    try:
+        with jsonl_path.open(encoding="utf-8", errors="replace") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                text = _extract_user_text(rec)
+                if text:
+                    snippet = " ".join(text.split())
+                    return snippet[:max_chars]
+    except OSError:
+        return ""
+    return ""
+
+
+def _extract_user_text(rec: dict) -> str:
+    """Pull user-prompt text out of one transcript record, else ''.
+
+    Handles the common Claude Code transcript shapes: a top-level
+    ``{"type": "user", "message": {"content": ...}}`` and the simpler
+    ``{"role": "user", "content": ...}``. ``content`` may be a plain
+    string or a list of ``{"type": "text", "text": ...}`` blocks.
+    """
+    if not isinstance(rec, dict):
+        return ""
+    is_user = rec.get("type") == "user" or rec.get("role") == "user"
+    if not is_user:
+        return ""
+    message = rec.get("message")
+    content = (
+        message.get("content") if isinstance(message, dict) else rec.get("content")
+    )
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "text":
+                parts.append(str(block.get("text", "")))
+            elif isinstance(block, str):
+                parts.append(block)
+        return " ".join(parts)
+    return ""
+
+
+def list_session_candidates(
+    workdir: str,
+    *,
+    home: Path | None = None,
+    limit: int = 10,
+) -> list[SessionCandidate]:
+    """Return resumable conversations for ``workdir``, newest first.
+
+    Reads ``$HOME/.claude/projects/<encoded-workdir>/*.jsonl`` and returns
+    up to ``limit`` :class:`SessionCandidate` rows sorted by mtime
+    descending (most recently active first). Empty list when the projects
+    dir is absent or holds no transcripts — the caller then knows there is
+    genuinely nothing to resume.
+    """
+    proj = _project_dir(workdir, home=home)
+    if not proj.is_dir():
+        return []
+    try:
+        jsonls = sorted(
+            proj.glob("*.jsonl"),
+            key=lambda p: p.stat().st_mtime,
+            reverse=True,
+        )
+    except OSError:
+        return []
+    out: list[SessionCandidate] = []
+    for p in jsonls[:limit]:
+        try:
+            mtime = p.stat().st_mtime
+        except OSError:
+            continue
+        out.append(
+            SessionCandidate(
+                session_id=p.stem,
+                mtime=mtime,
+                first_message=_first_user_message(p),
+            )
+        )
+    return out
+
+
+def format_candidates(candidates: list[SessionCandidate]) -> str:
+    """Render candidates as a human-readable, copy-pasteable list.
+
+    Each line: ``  <session_id>  (<iso-mtime>)  <first-message snippet>``.
+    Returns a sentinel line when there are no candidates so the caller's
+    message is never an empty block.
+    """
+    if not candidates:
+        return "  (no resumable conversations found in the projects store)"
+    lines = [
+        f"  {c.session_id}  ({c.mtime_iso})  {c.first_message}".rstrip()
+        for c in candidates
+    ]
+    return "\n".join(lines)

--- a/src/scitex_agent_container/_runners/_session_conversation.py
+++ b/src/scitex_agent_container/_runners/_session_conversation.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 from pathlib import Path
 from typing import Any
 
@@ -366,11 +367,33 @@ async def run_conversation(
                     or extract_dead_session_id(enriched)
                     or read_session_id(state_dir)
                 )
+                # INFORMATIVE (#192, Part B #3): before the last-resort fresh
+                # start, enumerate the conversations that ARE resumable for
+                # this agent and surface them — both to the log (LOUD) and to
+                # session.jsonl, so the operator can `sac agents send --resume
+                # <chosen>` / restart with a chosen id rather than only ever
+                # getting the silent fresh start. The fresh start below is the
+                # documented LAST RESORT for the autonomous runner (it cannot
+                # prompt interactively); the operator-facing CLI path
+                # (`agents start --resume <uuid>`) is where the choice is made
+                # synchronously (see cli_pkg/lifecycle/_resume_preflight.py).
+                from ._session_candidates import (
+                    format_candidates,
+                    list_session_candidates,
+                )
+
+                candidates = list_session_candidates(os.getcwd())
+                candidate_listing = format_candidates(candidates)
                 logger.warning(
-                    "claude-session DEAD SESSION for %s: resume id %s is gone; "
-                    "discarding it from session_id + history and starting FRESH",
+                    "claude-session DEAD SESSION for %s: resume id %s is gone. "
+                    "Resumable conversations for this agent:\n%s\n"
+                    "Last resort: starting a FRESH session (resume=None). To "
+                    "resume a specific one instead, restart with "
+                    "`sac agents start %s --resume <session-id>`.",
                     name,
                     dead_id,
+                    candidate_listing,
+                    name,
                 )
                 if dead_id:
                     discard_dead_session(state_dir, dead_id)
@@ -397,6 +420,14 @@ async def run_conversation(
                         "type": "supervisor",
                         "event": "dead-session-fresh-start",
                         "discarded_session_id": dead_id,
+                        "resumable_candidates": [
+                            {
+                                "session_id": c.session_id,
+                                "mtime_iso": c.mtime_iso,
+                                "first_message": c.first_message,
+                            }
+                            for c in candidates
+                        ],
                     },
                 )
                 dead_session_recoveries += 1

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_resume_preflight.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_resume_preflight.py
@@ -1,0 +1,142 @@
+"""Operator-facing ``--resume <uuid>`` preflight (#192, Part B #3).
+
+When the operator EXPLICITLY asks ``sac agents start <name> --resume
+<uuid>`` and that uuid does not exist in the agent's Claude Code projects
+store, the recovery must be INFORMATIVE and SELECTABLE — never a silent
+fresh start (operator design 4488):
+
+  * fail loud BEFORE launching the runner,
+  * list the conversations that ARE resumable for this agent (with
+    timestamps + first-message snippets), and
+  * point the operator at ``--resume <chosen>`` (an informed choice) or
+    the EXPLICIT last-resort fresh start (``--session new-session``).
+
+This is the synchronous, human-in-the-loop half of Part B #3. The
+autonomous runner (which cannot prompt) keeps the documented last-resort
+fresh start, but now surfaces the same candidate list loudly via
+``session.jsonl`` (see ``_runners/_session_conversation.py``).
+
+The conversations live inside the agent's container ``$HOME``: for a
+local apptainer agent that is ``runtime/<name>/home/.claude/projects/
+<encode(container_workdir)>/``. This module resolves that store and lists
+the candidates. When the store can't be located (e.g. a remote agent
+whose conversations live on another host), the preflight degrades to a
+LOUD warning rather than a hard block — the runner-side candidate
+surfacing then becomes the operator's window.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+
+from ...config import AgentConfig
+
+__all__ = ["ResumePreflightError", "preflight_resume_id"]
+
+
+class ResumePreflightError(click.ClickException):
+    """Raised when an explicit ``--resume <uuid>`` names an unknown session.
+
+    A ``click.ClickException`` so the CLI prints the (informative) message
+    and exits non-zero without a traceback — the operator sees the
+    candidate list and the next-step hint, then re-runs with a chosen id.
+    """
+
+
+def _container_home(config: AgentConfig) -> Path | None:
+    """Return the host-side path that backs the container ``$HOME``.
+
+    For a local apptainer agent sac binds ``runtime/<name>/home/`` →
+    ``/home/agent`` (ADR-0003 D6), so the conversations land under
+    ``runtime/<name>/home/.claude/projects/``. Returns None when the
+    runtime root / name can't be resolved (the caller then degrades to a
+    loud warning rather than a hard block).
+    """
+    import os
+
+    root = Path(
+        os.environ.get(
+            "SCITEX_AGENT_CONTAINER_RUNTIME_DIR",
+            str(Path.home() / ".scitex" / "agent-container" / "runtime"),
+        )
+    )
+    home = root / config.name / "home"
+    return home if home.is_dir() else None
+
+
+def preflight_resume_id(
+    config: AgentConfig,
+    resume_id: str,
+    *,
+    is_remote: bool = False,
+) -> None:
+    """Validate an explicit ``--resume`` id; fail loud + informative on miss.
+
+    Looks up the agent's resumable conversations in its container projects
+    store. If ``resume_id`` matches one, returns silently (the resume is a
+    valid choice). If it does not match:
+
+      * with discoverable candidates → raise :class:`ResumePreflightError`
+        listing them + the ``--resume <chosen>`` / explicit-fresh-start
+        next steps;
+      * with NO candidates → raise naming that nothing is resumable
+        (start fresh with ``--session new-session``).
+
+    When the store can't be located (remote agent, or the container home
+    hasn't been materialised yet) the check degrades to a LOUD stderr
+    warning and returns — it does not hard-block, because the id may be
+    valid on the remote side and the runner will surface candidates via
+    ``sac agents tail``.
+
+    ``is_remote`` lets the caller skip the local-store assertion for
+    cross-host agents (their conversations are not on this host).
+    """
+    from ..._runners._session_candidates import (
+        format_candidates,
+        list_session_candidates,
+    )
+
+    if is_remote:
+        click.echo(
+            f"[--resume] agent {config.name!r} is remote; the resume id "
+            f"{resume_id!r} cannot be verified locally. If it is stale the "
+            f"runner will surface the resumable conversations via "
+            f"`sac agents tail {config.name}`.",
+            err=True,
+        )
+        return
+
+    home = _container_home(config)
+    if home is None:
+        click.echo(
+            f"[--resume] could not locate the conversation store for "
+            f"{config.name!r} (container home not materialised yet); the "
+            f"resume id {resume_id!r} cannot be verified before launch. "
+            f"If it is stale the runner will surface candidates via "
+            f"`sac agents tail {config.name}`.",
+            err=True,
+        )
+        return
+
+    workdir = config.apptainer.container_workdir
+    candidates = list_session_candidates(workdir, home=home)
+    if any(c.session_id == resume_id for c in candidates):
+        return  # valid choice — proceed to launch.
+
+    listing = format_candidates(candidates)
+    if candidates:
+        raise ResumePreflightError(
+            f"agent {config.name!r}: requested --resume {resume_id} but no "
+            f"conversation with that id exists in the projects store.\n"
+            f"Resumable conversations:\n{listing}\n"
+            f"Re-run with `--resume <one-of-the-above>` to resume a specific "
+            f"one, or `--session new-session` to start fresh explicitly."
+        )
+    raise ResumePreflightError(
+        f"agent {config.name!r}: requested --resume {resume_id} but the "
+        f"projects store holds no resumable conversations at all.\n{listing}\n"
+        f"Start fresh explicitly with `--session new-session` (drop "
+        f"--resume)."
+    )

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_start_single.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_start_single.py
@@ -24,6 +24,7 @@ from ...config._resolve import resolve_with_prefix
 from .._helpers import console, system_msg
 from ._common import _multiplex_foreground_tails, _singleton_skip_reason
 from ._dispatch import try_dispatch
+from ._resume_preflight import ResumePreflightError
 
 
 def run_single_targets(
@@ -52,7 +53,6 @@ def run_single_targets(
 
     def _emit_json(payload: dict) -> None:
         click.echo(_json.dumps(payload, ensure_ascii=False))
-
 
     if single_targets:
         preflight_runner()
@@ -133,6 +133,27 @@ def run_single_targets(
                     if resume_id:
                         msg += f", resume_id = {resume_id}"
                     system_msg(msg, style="dim")
+            # Operator-facing --resume preflight (#192, Part B #3): when the
+            # operator explicitly names a resume id, validate it against the
+            # agent's projects store BEFORE launch. On a miss it fails loud
+            # + informative (lists resumable conversations) so the choice is
+            # explicit — never a silent fresh start. Skipped on --no-preflight
+            # and dry-run.
+            if resume_id and not no_preflight and not dry_run:
+                from ._resume_preflight import preflight_resume_id
+
+                try:
+                    current_host = resolve_hostname()
+                except RuntimeError:  # stx-allow: fallback (reason: hostname resolution failure — treat as local for the preflight)
+                    current_host = ""
+                spec_host = config.hosts_spec.host
+                target_host = (
+                    (spec_host[0] if spec_host else None)
+                    if isinstance(spec_host, list)
+                    else (spec_host or None)
+                )
+                is_remote = bool(target_host) and target_host != current_host
+                preflight_resume_id(config, resume_id, is_remote=is_remote)
             agent_start(
                 config_path,
                 no_preflight=no_preflight,
@@ -186,6 +207,23 @@ def run_single_targets(
                     console.print(
                         f"[yellow]auto_accept: false — manual TUI acceptance required on {host}[/yellow]"
                     )
+        except ResumePreflightError as exc:
+            # Informative, operator-facing --resume miss (#192, Part B #3).
+            # The message body IS the candidate listing + next-step hint;
+            # print it cleanly without a traceback (it is not a crash, it
+            # is a refusal to silently fresh-start).
+            any_error = True
+            if as_json:
+                _emit_json(
+                    {
+                        "name": raw_target,
+                        "status": "resume-not-found",
+                        "error": str(exc),
+                        "dry_run": dry_run,
+                    }
+                )
+            else:
+                console.print(f"[red]{exc}[/red]")
         except Exception as exc:
             any_error = True
             if as_json:

--- a/tests/scitex_agent_container/_runners/test__session_candidates.py
+++ b/tests/scitex_agent_container/_runners/test__session_candidates.py
@@ -1,0 +1,150 @@
+"""Tests for resumable-conversation listing (#192, Part B #3).
+
+When a ``--resume`` target is gone, recovery must be INFORMATIVE +
+SELECTABLE: list the conversations actually available for the agent so a
+``--resume <chosen>`` is an informed choice rather than a silent fresh
+start. These tests prove ``list_session_candidates`` reads the SDK's
+``$HOME/.claude/projects/<encoded-cwd>/*.jsonl`` store and returns
+structured candidates newest-first with a first-message snippet.
+
+No-mocks: real on-disk ``.jsonl`` transcripts under a tmp ``$HOME``.
+Conforms to STX-TQ002 (AAA markers), STX-TQ003 (descriptive names),
+STX-TQ007 (one assertion per test).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+
+from scitex_agent_container._runners._session_candidates import (
+    encode_claude_project,
+    format_candidates,
+    list_session_candidates,
+)
+
+
+def _write_transcript(
+    home: Path,
+    workdir: str,
+    session_id: str,
+    *,
+    first_user_text: str = "do the thing",
+) -> Path:
+    """Create a fake SDK transcript .jsonl under the encoded projects dir."""
+    proj = home / ".claude" / "projects" / encode_claude_project(workdir)
+    proj.mkdir(parents=True, exist_ok=True)
+    p = proj / f"{session_id}.jsonl"
+    lines = [
+        json.dumps({"type": "user", "message": {"content": first_user_text}}),
+        json.dumps({"type": "assistant", "message": {"content": "ok"}}),
+    ]
+    p.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# encoding parity with Claude Code
+# ---------------------------------------------------------------------------
+
+
+class TestEncodeClaudeProject:
+    def test_slashes_and_dots_become_dashes(self) -> None:
+        # Arrange
+        workdir = "/home/agent/work"
+        # Act
+        encoded = encode_claude_project(workdir)
+        # Assert
+        assert encoded == "-home-agent-work"
+
+    def test_hidden_dir_triple_dash_collapses_to_double(self) -> None:
+        # Arrange — ``/.scitex`` produces ``---scitex`` then collapses.
+        workdir = "/home/agent/.scitex"
+        # Act
+        encoded = encode_claude_project(workdir)
+        # Assert
+        assert encoded == "-home-agent--scitex"
+
+
+# ---------------------------------------------------------------------------
+# list_session_candidates
+# ---------------------------------------------------------------------------
+
+
+class TestListSessionCandidates:
+    def test_lists_session_id_from_jsonl_stem(self, tmp_path: Path) -> None:
+        # Arrange
+        home = tmp_path / "home"
+        _write_transcript(home, "/work", "uuid-aaa")
+        # Act
+        candidates = list_session_candidates("/work", home=home)
+        # Assert
+        assert candidates[0].session_id == "uuid-aaa"
+
+    def test_includes_first_user_message_snippet(self, tmp_path: Path) -> None:
+        # Arrange
+        home = tmp_path / "home"
+        _write_transcript(home, "/work", "uuid-aaa", first_user_text="resume me please")
+        # Act
+        candidates = list_session_candidates("/work", home=home)
+        # Assert
+        assert candidates[0].first_message == "resume me please"
+
+    def test_orders_candidates_newest_first(self, tmp_path: Path) -> None:
+        # Arrange — two transcripts; bump the second's mtime to be newer.
+        home = tmp_path / "home"
+        _write_transcript(home, "/work", "uuid-old")
+        newer = _write_transcript(home, "/work", "uuid-new")
+        now = time.time()
+        os.utime(newer, (now, now + 100))
+        # Act
+        candidates = list_session_candidates("/work", home=home)
+        # Assert — newest (uuid-new) is first.
+        assert candidates[0].session_id == "uuid-new"
+
+    def test_missing_projects_dir_returns_empty_list(self, tmp_path: Path) -> None:
+        # Arrange — a home with no projects dir for this workdir.
+        home = tmp_path / "home"
+        home.mkdir()
+        # Act
+        candidates = list_session_candidates("/work", home=home)
+        # Assert
+        assert candidates == []
+
+    def test_limit_caps_returned_candidate_count(self, tmp_path: Path) -> None:
+        # Arrange — three transcripts, limit to one.
+        home = tmp_path / "home"
+        for i, sid in enumerate(("uuid-a", "uuid-b", "uuid-c")):
+            p = _write_transcript(home, "/work", sid)
+            os.utime(p, (time.time(), time.time() + i))
+        # Act
+        candidates = list_session_candidates("/work", home=home, limit=1)
+        # Assert
+        assert len(candidates) == 1
+
+
+# ---------------------------------------------------------------------------
+# format_candidates
+# ---------------------------------------------------------------------------
+
+
+class TestFormatCandidates:
+    def test_empty_list_renders_sentinel_line(self) -> None:
+        # Arrange
+        candidates: list = []
+        # Act
+        rendered = format_candidates(candidates)
+        # Assert
+        assert "no resumable conversations" in rendered
+
+    def test_renders_session_id_in_listing(self, tmp_path: Path) -> None:
+        # Arrange
+        home = tmp_path / "home"
+        _write_transcript(home, "/work", "uuid-zzz", first_user_text="hi")
+        candidates = list_session_candidates("/work", home=home)
+        # Act
+        rendered = format_candidates(candidates)
+        # Assert
+        assert "uuid-zzz" in rendered

--- a/tests/scitex_agent_container/_runners/test__session_conversation.py
+++ b/tests/scitex_agent_container/_runners/test__session_conversation.py
@@ -666,3 +666,57 @@ def test_valid_session_is_still_resumed_not_reset(tmp_path: Path) -> None:
     # Assert — the valid id was the one resume target the client saw; no
     # dead-session reset fired (the only open used the valid id).
     assert recorder.opens == ["valid-uuid"]
+
+
+# ---------------------------------------------------------------------------
+# Dead-session recovery surfaces the resumable candidate list (#192 #3) —
+# the autonomous runner's fresh start is the last resort, but it must be
+# INFORMATIVE: the supervisor event carries the conversations that ARE
+# resumable so the operator can choose one instead.
+# ---------------------------------------------------------------------------
+
+
+def _seed_cwd_conversation(home: Path, session_id: str) -> None:
+    """Write a transcript under the SDK projects dir for the current cwd."""
+    import json
+    import os
+
+    from scitex_agent_container._runners._session_candidates import (
+        encode_claude_project,
+    )
+
+    proj = home / ".claude" / "projects" / encode_claude_project(os.getcwd())
+    proj.mkdir(parents=True, exist_ok=True)
+    (proj / f"{session_id}.jsonl").write_text(
+        json.dumps({"type": "user", "message": {"content": "earlier work"}}) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _dead_session_fresh_start_event(state_dir: Path) -> dict:
+    events = [
+        r
+        for r in _read_session_jsonl(state_dir)
+        if r.get("type") == "supervisor"
+        and r.get("event") == "dead-session-fresh-start"
+    ]
+    return events[0]
+
+
+def test_dead_session_fresh_start_event_lists_resumable_candidates(
+    tmp_path: Path, env_save_restore
+) -> None:
+    # Arrange — point HOME at a tmp dir holding a resumable transcript for
+    # the runner's cwd, then trigger the dead-session recovery.
+    home = tmp_path / "home"
+    env_save_restore.set("HOME", str(home))
+    _seed_cwd_conversation(home, "resumable-uuid")
+    state_dir = tmp_path / "alpha"
+    sid.write_session_id(state_dir, "dead-uuid")
+    recorder = _DeadSessionRecorder("dead-uuid")
+    # Act
+    _run_dead_session_recovery(state_dir, recorder)
+    # Assert — the fresh-start event surfaces the resumable conversation so
+    # the operator can resume it explicitly instead of accepting the reset.
+    event = _dead_session_fresh_start_event(state_dir)
+    assert event["resumable_candidates"][0]["session_id"] == "resumable-uuid"

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__resume_preflight.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__resume_preflight.py
@@ -1,0 +1,150 @@
+"""Tests for the operator-facing ``--resume`` preflight (#192, Part B #3).
+
+When the operator explicitly asks ``--resume <uuid>`` and the id is gone,
+the preflight must FAIL LOUD + INFORMATIVE (list resumable conversations)
+rather than silently fresh-start. These tests prove the raise + its
+candidate-listing body, and that a valid id passes silently.
+
+No-mocks: real on-disk projects store under a tmp runtime dir + a real
+``AgentConfig``. Conforms to STX-TQ002 (AAA markers), STX-TQ003
+(descriptive names), STX-TQ007 (one assertion per test).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._runners._session_candidates import (
+    encode_claude_project,
+)
+from scitex_agent_container.cli_pkg.lifecycle._resume_preflight import (
+    ResumePreflightError,
+    preflight_resume_id,
+)
+
+
+@pytest.fixture
+def runtime_root(tmp_path: Path, env_save_restore):
+    """Isolate the runtime root so the container-home lookup is tmp-scoped."""
+    root = tmp_path / "runtime"
+    root.mkdir()
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_RUNTIME_DIR", str(root))
+    return root
+
+
+class _FakeApptainer:
+    def __init__(self, container_workdir: str) -> None:
+        self.container_workdir = container_workdir
+
+
+class _FakeHostsSpec:
+    def __init__(self, host=None) -> None:
+        self.host = host
+
+
+class _FakeConfig:
+    """Minimal AgentConfig stand-in carrying only what the preflight reads.
+
+    Not a mock — a real production-shaped value object with the two
+    attributes ``preflight_resume_id`` touches (``name`` and
+    ``apptainer.container_workdir``).
+    """
+
+    def __init__(self, name: str, container_workdir: str) -> None:
+        self.name = name
+        self.apptainer = _FakeApptainer(container_workdir)
+        self.hosts_spec = _FakeHostsSpec()
+
+
+def _seed_conversation(
+    runtime_root: Path,
+    name: str,
+    container_workdir: str,
+    session_id: str,
+) -> Path:
+    """Write a real transcript under runtime/<name>/home/.claude/projects/."""
+    home = runtime_root / name / "home"
+    proj = home / ".claude" / "projects" / encode_claude_project(container_workdir)
+    proj.mkdir(parents=True, exist_ok=True)
+    p = proj / f"{session_id}.jsonl"
+    p.write_text(
+        json.dumps({"type": "user", "message": {"content": "prior work"}}) + "\n",
+        encoding="utf-8",
+    )
+    return p
+
+
+class TestPreflightResumeId:
+    def test_valid_resume_id_passes_silently(self, runtime_root: Path) -> None:
+        # Arrange — a transcript whose id the operator asks to resume.
+        cfg = _FakeConfig("clew", "/home/agent/work")
+        _seed_conversation(runtime_root, "clew", "/home/agent/work", "uuid-live")
+        # Act — returns None (no raise) for a valid id.
+        result = preflight_resume_id(cfg, "uuid-live")
+        # Assert
+        assert result is None
+
+    def test_unknown_resume_id_raises_preflight_error(self, runtime_root: Path) -> None:
+        # Arrange — store holds a DIFFERENT id than requested.
+        cfg = _FakeConfig("clew", "/home/agent/work")
+        _seed_conversation(runtime_root, "clew", "/home/agent/work", "uuid-live")
+        # Act
+        ctx = pytest.raises(ResumePreflightError)
+        # Assert
+        with ctx:
+            preflight_resume_id(cfg, "uuid-gone")
+
+    def test_error_lists_the_resumable_candidate(self, runtime_root: Path) -> None:
+        # Arrange
+        cfg = _FakeConfig("clew", "/home/agent/work")
+        _seed_conversation(runtime_root, "clew", "/home/agent/work", "uuid-live")
+        # Act
+        ctx = pytest.raises(ResumePreflightError, match="uuid-live")
+        # Assert — the informative body names the resumable conversation.
+        with ctx:
+            preflight_resume_id(cfg, "uuid-gone")
+
+    def test_error_names_explicit_fresh_start_next_step(
+        self, runtime_root: Path
+    ) -> None:
+        # Arrange
+        cfg = _FakeConfig("clew", "/home/agent/work")
+        _seed_conversation(runtime_root, "clew", "/home/agent/work", "uuid-live")
+        # Act
+        ctx = pytest.raises(ResumePreflightError, match="new-session")
+        # Assert — points at the EXPLICIT last-resort fresh start.
+        with ctx:
+            preflight_resume_id(cfg, "uuid-gone")
+
+    def test_no_candidates_at_all_still_raises_loud(self, runtime_root: Path) -> None:
+        # Arrange — container home exists but holds no transcripts.
+        cfg = _FakeConfig("clew", "/home/agent/work")
+        (runtime_root / "clew" / "home").mkdir(parents=True)
+        # Act
+        ctx = pytest.raises(ResumePreflightError, match="no resumable conversations")
+        # Assert
+        with ctx:
+            preflight_resume_id(cfg, "uuid-gone")
+
+    def test_remote_agent_warns_and_returns_without_raising(
+        self, runtime_root: Path, capsys
+    ) -> None:
+        # Arrange — a remote agent's store is not on this host.
+        cfg = _FakeConfig("clew", "/home/agent/work")
+        # Act — is_remote short-circuits to a loud warning, no raise.
+        result = preflight_resume_id(cfg, "uuid-gone", is_remote=True)
+        # Assert
+        assert result is None
+
+    def test_unmaterialised_home_warns_and_returns_without_raising(
+        self, runtime_root: Path
+    ) -> None:
+        # Arrange — no runtime/<name>/home dir yet (first-ever start).
+        cfg = _FakeConfig("clew", "/home/agent/work")
+        # Act — degrades to a loud warning rather than a hard block.
+        result = preflight_resume_id(cfg, "uuid-gone")
+        # Assert
+        assert result is None


### PR DESCRIPTION
## Why

Part B #3 of the #192 consolidation (operator design 4488). When a `--resume <uuid>` target is gone (`No conversation found with session ID`), recovery must be **informative** and **selectable** — never a silent fresh start. #191's self-heal is repurposed as the EXPLICIT last resort, not the silent default.

The ~08:00 trigger of the clew/neurovista outage was OAuth-token expiry (confirmed by clew); on recovery the operator wants to *choose* which conversation to resume, not have the agent blindly fresh-start.

## What

New `_session_candidates.list_session_candidates(workdir)` reads the SDK store (`$HOME/.claude/projects/<encoded-cwd>/*.jsonl`) and returns structured `(session_id, mtime, first_message)` rows, newest-first.

**1. Operator-facing CLI (synchronous, human-in-the-loop).** New `_resume_preflight` runs before launch when the operator explicitly passes `--resume <uuid>`. On an unknown id it **fails loud** with the resumable-conversation listing + next steps:
- `--resume <one-of-the-above>` for an informed choice;
- `--session new-session` for the explicit fresh start.

A valid id passes silently. Remote / not-yet-materialised stores degrade to a loud warning (the id may be valid remote-side; the runner surfaces candidates via `sac agents tail`). Raised as a `ClickException` so the listing prints with no traceback.

**2. Autonomous runner (cannot prompt).** The dead-session path keeps the documented last-resort fresh start but now surfaces the **same candidate list loudly**: the supervisor logs the resumable conversations, and the `session.jsonl` `dead-session-fresh-start` event carries a `resumable_candidates` array — so the operator can resume a specific one (restart with `--resume <chosen>`) instead of only ever getting the reset.

## Example

```
agent 'clew': requested --resume uuid-gone but no conversation with that id exists.
Resumable conversations:
  uuid-live  (2026-05-24T07:55:00Z)  prior work on neurovista sweep
Re-run with `--resume <one-of-the-above>` to resume a specific one, or
`--session new-session` to start fresh explicitly.
```

## Tests (no mocks)

Real on-disk `.jsonl` transcripts + the existing fake-SDK shim:
- `test__session_candidates.py` — reads store, snippets first user turn, newest-first ordering, limit, empty-on-missing-dir, encoding parity.
- `test__resume_preflight.py` — valid id passes; unknown id raises listing candidates; raises naming the explicit fresh-start step; raises with no candidates; remote / unmaterialised store warn-and-return.
- `test__session_conversation.py` — the dead-session fresh-start event carries `resumable_candidates`.

560 runners + lifecycle tests pass with `pytest-randomly` enabled (existing #191 dead-session tests still green — the self-heal is preserved, repurposed not reverted).

Builds on PR #193 (registry fail-loud + actual-state-record). Independent — both target develop.