### PR TITLE
ci(test): install fd so the scitex-dev audit-project gate can run

### DIFF
--- a/.github/workflows/pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml
+++ b/.github/workflows/pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml
@@ -26,6 +26,14 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install fd (Rust) for the scitex-dev audit gate
+        # `scitex-dev ecosystem audit-project` (run by the mandatory
+        # tests/develop/test_audit.py gate) walks src/ via the Rust `fd`
+        # tool and HARD-CRASHES with FdNotFoundError when it is absent —
+        # ubuntu-latest does not ship it. Debian/Ubuntu installs the
+        # binary as `fdfind`, which the auditor's fd_binary() accepts as
+        # a fallback name, so no symlink is needed.
+        run: sudo apt-get update -qq && sudo apt-get install -y fd-find
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
## Why

`tests/develop/test_audit.py::test_audit_all_clean` runs `scitex-dev ecosystem audit-project`, whose mirror-check (`_check_mirror` → `build_orphan_hinter` → `fd_find_files`) walks `src/` via the Rust `fd` tool and **hard-crashes** with `FdNotFoundError` when `fd` is absent. `ubuntu-latest` does not ship `fd`/`fdfind`, so the audit gate fails on a missing-tool crash — not a real violation.

Verified: `audit-project` reports `SUCC: no project-structure violations` locally once `fd` is on PATH; the crash reproduces identically on any branch when `fd` is removed from PATH (it is environmental, not code-specific). This surfaced when #195 merged — develop's `tests` workflow is currently red on this crash.

## What

Add one step to the pytest-matrix workflow that installs `fd-find` (Debian binary name `fdfind`, which the auditor's `fd_binary()` accepts as a fallback name — no symlink needed) before the suite runs.

Unblocks the mandatory audit gate for every PR that touches `src/`.