### PR TITLE
feat(spawn): ACL-gate every spawn path + unify lineage in core agent_start

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_spawn_gate.py
+++ b/src/scitex_agent_container/_lifecycle/_spawn_gate.py
@@ -1,0 +1,131 @@
+"""Spawn-permission gate + lineage recording — wired into core
+``agent_start`` so EVERY spawn path enforces the same ACL (ADR-0010
+Rule B / Phase 2: ``起動経路 = 記録経路 = ACL経路`` collapsed to one path).
+
+Before this gate lived in core ``agent_start``, only the
+``sac listen`` ``POST /agents`` handler ran :func:`check_spawn` +
+:func:`record_lineage`. The MCP ``agent_start`` tool (clew's spawn
+surface) and the plain ``sac agents start`` CLI both bypass that
+handler — they shell straight through to core ``agent_start`` — so an
+agent-from-agent spawn was NOT ACL-gated and the ``lineage`` table was
+split-brained: only the server path wrote it, while ``instances.spawned_by``
+(a descriptive string) was written on every local start.
+
+This module unifies the two. The core start codepath now:
+
+  1. resolves the *caller* identity from the parent agent's
+     ``SAC_NAME`` container env (``None`` / empty → admin / human-operator
+     / lead path — always allowed);
+  2. runs :func:`check_spawn` — root-only spawn under current policy;
+     a denied spawn raises :class:`SpawnDeniedError` BEFORE the runtime
+     is touched;
+  3. on allow with a non-empty caller, records the ``caller → child``
+     edge in the ``lineage`` table (idempotent; same-parent re-record is
+     a no-op).
+
+The same ``SAC_NAME`` already drives ``_instances._spawned_by()`` (the
+``instances.spawned_by`` string), so after this gate the lineage table
+and the spawned_by string are written from the same identity on the
+same codepath — the split-brain is resolved.
+
+Scope (ADR-0010 staged plan): this is **Phase 2 / Step 1 only** —
+make ALL spawn paths go through ``check_spawn`` + write the lineage
+row. The ``spec.acl`` schema (Step 2) and ``child ⊆ parent`` clamp
+(Step 3) are separate follow-up PRs; ``check_spawn``'s current binary
+root/child policy is kept verbatim.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+__all__ = ["SpawnDeniedError", "enforce_spawn_gate", "resolve_spawn_caller"]
+
+
+class SpawnDeniedError(RuntimeError):
+    """Raised when an agent-from-agent spawn is rejected by the ACL.
+
+    Current policy (``spawn_allowed``): only a *root* node (no parent
+    in ``lineage``) may spawn. A child caller gets this error, carrying
+    the explicit allow/deny reason for the operator log + caller.
+    """
+
+
+def resolve_spawn_caller() -> str | None:
+    """Return the spawning agent's identity, or ``None`` for admin paths.
+
+    When a PARENT agent shells out ``sac agents start <child>`` from
+    inside its container, its env carries ``SAC_NAME`` (the parent's own
+    name). A bare CLI / lead / human-operator launch has no ``SAC_NAME``
+    — that is the administrative path and is always allowed to spawn.
+
+    Reads through the sac env helper so either prefix
+    (``SAC_NAME`` / ``SCITEX_AGENT_CONTAINER_NAME``) is honoured. An
+    empty string is normalised to ``None`` (admin).
+    """
+    from .._env import getenv
+
+    caller = getenv("NAME")
+    return caller or None
+
+
+def enforce_spawn_gate(
+    child_name: str,
+    *,
+    caller: str | None = None,
+    db_path: Path | None = None,
+) -> str | None:
+    """Gate a spawn of ``child_name`` and record its lineage edge.
+
+    This is the single chokepoint every spawn path funnels through (via
+    core ``agent_start``). It performs both halves of the unified spawn
+    contract:
+
+    * **ACL gate** — :func:`check_spawn` against the resolved caller.
+      On deny, raises :class:`SpawnDeniedError` (the caller / CLI turns
+      it into a non-zero exit) BEFORE any runtime work happens.
+    * **Lineage record** — on allow with a non-empty caller, the
+      ``caller → child_name`` edge is written to the ``lineage`` table
+      via :func:`record_lineage` (idempotent on the same parent; a
+      re-parent to a different caller raises ``ValueError`` upstream —
+      surfaced as a :class:`SpawnDeniedError`).
+
+    Args:
+        child_name: The agent being started.
+        caller: The spawning identity. ``None`` (default) resolves from
+            the parent's ``SAC_NAME`` env via :func:`resolve_spawn_caller`.
+            An explicit ``caller`` (e.g. the server handler's request
+            ``caller`` field) overrides the env.
+        db_path: Optional isolated state.db (tests). ``None`` → default.
+
+    Returns the resolved caller (``None`` for the admin path), so a
+    diagnostic / log line can attribute the spawn.
+
+    Raises:
+        SpawnDeniedError: when the spawn is not permitted by current
+            policy, or when the lineage edge conflicts with an existing
+            different parent.
+    """
+    from .._listen._acl import check_spawn
+    from .._state.state_db_nodes import record_lineage
+
+    if caller is None:
+        caller = resolve_spawn_caller()
+
+    decision, reason = check_spawn(caller=caller, db_path=db_path)
+    if decision == "deny":
+        raise SpawnDeniedError(reason or f"spawn of {child_name!r} denied")
+
+    # ``caller=None`` is the admin / operator / lead path — the new agent
+    # starts as a root, so NO lineage edge is recorded (recording one
+    # would make every operator-launched agent a child of "").
+    if caller:
+        try:
+            record_lineage(child=child_name, parent=caller, db_path=db_path)
+        except ValueError as exc:
+            # A child that switches parents is exactly the identity drift
+            # the ACL is meant to prevent — reject loudly, never silently
+            # re-parent.
+            raise SpawnDeniedError(str(exc)) from exc
+
+    return caller

--- a/src/scitex_agent_container/_lifecycle/_start.py
+++ b/src/scitex_agent_container/_lifecycle/_start.py
@@ -20,6 +20,7 @@ from ._hook_runner import _fire_forget_hook, _run_hooks
 from ._instances import record_local_instance as _record_local_instance
 from ._runtime_select import _get_runtime
 from ._session_reset import _clear_persisted_session_id
+from ._spawn_gate import enforce_spawn_gate
 from .health import health_monitor
 
 
@@ -131,6 +132,28 @@ def agent_start(
             f"--one-shot requires spec.startup_prompts (or legacy "
             f"startup_commands) on agent '{config.name}'; nothing to run."
         )
+
+    # Spawn-permission gate + lineage record (ADR-0010 Rule B / Phase 2:
+    # "起動経路 = 記録経路 = ACL経路" collapsed to one path). EVERY spawn
+    # path funnels through core ``agent_start`` — the MCP ``agent_start``
+    # tool and the plain ``sac agents start`` CLI both reach here, not
+    # just the ``sac listen`` ``POST /agents`` handler. Enforcing the
+    # gate here (rather than only in the server handler) means an
+    # agent-from-agent spawn is ACL-gated WITHOUT requiring a running
+    # ``sac listen`` daemon — clew on Spartan can spawn capsule children
+    # with no extra process. The caller identity is the parent agent's
+    # ``SAC_NAME`` env (``None`` → admin / operator / lead → always
+    # allowed). On allow with a real caller, the ``caller → child`` edge
+    # is written to the ``lineage`` table — the same identity that
+    # ``record_local_instance`` records as ``instances.spawned_by``, so
+    # the two are no longer split-brained. A denied spawn raises
+    # ``SpawnDeniedError`` HERE, before the runtime is built or touched.
+    # The server handler still passes its request ``caller`` verbatim and
+    # records lineage itself; its subprocess inherits no ``SAC_NAME`` on
+    # the bare host, so this gate sees ``caller=None`` (admin) and does
+    # not double-record — and ``record_lineage`` is idempotent regardless.
+    enforce_spawn_gate(config.name)
+
     # Resolve spec.a2a.port BEFORE the runtime builds argv. ``"auto"``
     # gets a fresh allocator claim; an explicit int is recorded so
     # ``sac listen`` can find the port via state.db without re-parsing

--- a/tests/scitex_agent_container/_lifecycle/test__spawn_gate.py
+++ b/tests/scitex_agent_container/_lifecycle/test__spawn_gate.py
@@ -1,0 +1,201 @@
+"""Spawn-permission gate + lineage record — the unified spawn chokepoint
+wired into core ``agent_start`` (ADR-0010 Rule B / Phase 2).
+
+PA-306: NO mocks. Every test runs ``enforce_spawn_gate`` against a REAL
+on-disk SQLite state.db (isolated per test) and the REAL ``check_spawn``
+/ ``record_lineage`` collaborators. The caller identity is set via a
+real yield-based env override (no monkeypatch).
+
+Each test: AAA markers (TQ002), one assertion (TQ007), 3+-word name.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from scitex_agent_container._lifecycle._spawn_gate import (
+    SpawnDeniedError,
+    enforce_spawn_gate,
+    resolve_spawn_caller,
+)
+from scitex_agent_container._state import state_db
+from scitex_agent_container._state.state_db_nodes import (
+    derive_group,
+    record_lineage,
+)
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Iterator[Path]:
+    """Isolated state.db; env + DEFAULT_DB_PATH overridden then restored.
+
+    The gate's internal calls use ``db_path=None`` (→ DEFAULT_DB_PATH),
+    so re-binding the module constant is what isolates them. No mocks —
+    a real sqlite file under tmp_path.
+    """
+    db = tmp_path / "state.db"
+    saved_env = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB")
+    saved_default = state_db.DEFAULT_DB_PATH
+    os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
+    state_db.DEFAULT_DB_PATH = db
+    state_db.init_schema(db)
+    try:
+        yield db
+    finally:
+        state_db.DEFAULT_DB_PATH = saved_default
+        if saved_env is None:
+            os.environ.pop("SCITEX_AGENT_CONTAINER_STATE_DB", None)
+        else:
+            os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = saved_env
+
+
+@pytest.fixture
+def sac_name() -> Iterator[callable]:
+    """Yield a setter for SAC_NAME (the parent caller identity).
+
+    Real env mutation with full save/restore of BOTH prefixes, so a
+    spawn under a parent agent's identity can be exercised without mocks.
+    """
+    keys = ("SAC_NAME", "SCITEX_AGENT_CONTAINER_NAME")
+    saved = {k: os.environ.get(k) for k in keys}
+
+    def _set(value: str | None) -> None:
+        for k in keys:
+            if value is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = value
+
+    try:
+        yield _set
+    finally:
+        for k, prev in saved.items():
+            if prev is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = prev
+
+
+# ---------------------------------------------------------------------------
+# resolve_spawn_caller — SAC_NAME → caller, empty → admin (None)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_caller_returns_sac_name_when_set(sac_name) -> None:
+    # Arrange
+    sac_name("parent-bot")
+    # Act
+    caller = resolve_spawn_caller()
+    # Assert
+    assert caller == "parent-bot"
+
+
+def test_resolve_caller_returns_none_without_sac_name(sac_name) -> None:
+    # Arrange — no SAC_NAME → admin / lead / operator path.
+    sac_name(None)
+    # Act
+    caller = resolve_spawn_caller()
+    # Assert
+    assert caller is None
+
+
+# ---------------------------------------------------------------------------
+# enforce_spawn_gate — admin / root allow paths
+# ---------------------------------------------------------------------------
+
+
+def test_gate_allows_admin_caller_when_sac_name_unset(db_path, sac_name) -> None:
+    # Arrange — no SAC_NAME → admin path → always allowed.
+    sac_name(None)
+    # Act
+    caller = enforce_spawn_gate("child-a")
+    # Assert
+    assert caller is None
+
+
+def test_gate_allows_root_caller_to_spawn(db_path, sac_name) -> None:
+    # Arrange — "root" has no parent in lineage → root → allowed.
+    sac_name("root")
+    # Act
+    caller = enforce_spawn_gate("child-b")
+    # Assert
+    assert caller == "root"
+
+
+# ---------------------------------------------------------------------------
+# enforce_spawn_gate — lineage recording on allow
+# ---------------------------------------------------------------------------
+
+
+def test_gate_records_lineage_edge_for_root_caller(db_path, sac_name) -> None:
+    # Arrange — a root caller spawning a child writes the lineage edge.
+    sac_name("root")
+    # Act
+    enforce_spawn_gate("child-c")
+    # Assert — the child's group now contains its parent (proves the edge).
+    assert "root" in derive_group(name="child-c")
+
+
+def test_gate_does_not_record_lineage_for_admin_caller(db_path, sac_name) -> None:
+    # Arrange — admin spawn (no SAC_NAME) must leave the child unattached.
+    sac_name(None)
+    # Act
+    enforce_spawn_gate("child-d")
+    # Assert — a fresh unattached node's group is just itself (singleton).
+    assert derive_group(name="child-d") == {"child-d"}
+
+
+def test_gate_lineage_record_is_idempotent_on_same_parent(db_path, sac_name) -> None:
+    # Arrange — root spawns the same child twice (e.g. a --force restart).
+    sac_name("root")
+    enforce_spawn_gate("child-e")
+    # Act — second spawn under the same parent must not raise.
+    enforce_spawn_gate("child-e")
+    # Assert — still exactly one parent edge.
+    assert "root" in derive_group(name="child-e")
+
+
+# ---------------------------------------------------------------------------
+# enforce_spawn_gate — deny paths
+# ---------------------------------------------------------------------------
+
+
+def test_gate_denies_child_caller_under_root_only_policy(db_path, sac_name) -> None:
+    # Arrange — "worker-a" is a child of "root" → not a root → may not spawn.
+    record_lineage(child="worker-a", parent="root", db_path=db_path)
+    sac_name("worker-a")
+    # Act
+    ctx = pytest.raises(SpawnDeniedError)
+    # Assert
+    with ctx:
+        enforce_spawn_gate("grandchild")
+
+
+def test_gate_denies_reparent_to_different_caller(db_path, sac_name) -> None:
+    # Arrange — child-f already parented to "root-1"; re-spawn under a
+    # different root must be rejected (identity drift the ACL prevents).
+    record_lineage(child="child-f", parent="root-1", db_path=db_path)
+    sac_name("root-2")
+    # Act
+    ctx = pytest.raises(SpawnDeniedError)
+    # Assert
+    with ctx:
+        enforce_spawn_gate("child-f")
+
+
+# ---------------------------------------------------------------------------
+# explicit caller arg overrides the SAC_NAME env
+# ---------------------------------------------------------------------------
+
+
+def test_explicit_caller_arg_overrides_sac_name_env(db_path, sac_name) -> None:
+    # Arrange — env says "env-parent" but the explicit arg wins.
+    sac_name("env-parent")
+    # Act
+    enforce_spawn_gate("child-g", caller="arg-parent")
+    # Assert — the recorded edge is from the explicit arg, not the env.
+    assert "arg-parent" in derive_group(name="child-g")

--- a/tests/scitex_agent_container/_lifecycle/test__start_spawn_acl.py
+++ b/tests/scitex_agent_container/_lifecycle/test__start_spawn_acl.py
@@ -1,0 +1,266 @@
+"""Spawn ACL is enforced on the CORE start path AND the MCP tool path
+(ADR-0010 Rule B / Phase 2 — 起動経路 = 記録経路 = ACL経路).
+
+The acceptance for "sac from sac" Step 1: an agent-from-agent spawn,
+whether driven through the MCP ``agent_start`` tool (clew's surface) or
+the plain CLI, now (a) passes through ``check_spawn`` and (b) writes a
+``lineage`` table row — not just the ``instances.spawned_by`` string.
+
+PA-306: NO mocks. The two surfaces are exercised for real:
+
+  * **core path** — :func:`agent_start` is driven with ``dry_run=True``
+    and a real hand-rolled ``_FakeRuntime`` collaborator (the runtime is
+    NOT a mock; it records whether ``start`` was reached, exactly as the
+    existing drift-guard tests do). ``dry_run`` returns right after the
+    gate, so the gate's lineage write is exercised without launching a
+    container. The lineage row is then read back from a REAL on-disk
+    state.db.
+  * **MCP-tool path** — the real ``agent_start`` MCP tool function is
+    called; it drives the real Click CLI (``invoke_cli_text``) through to
+    core ``agent_start``. A child-caller spawn is rejected by the gate
+    BEFORE any runtime work, proving the MCP surface is ACL-gated.
+
+Each test: AAA markers (TQ002), one assertion (TQ007), 3+-word name.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Iterator
+
+import pytest
+
+from scitex_agent_container._lifecycle._start import agent_start
+from scitex_agent_container._state import state_db
+from scitex_agent_container._state.registry import Registry
+from scitex_agent_container._state.state_db_nodes import derive_group, record_lineage
+from scitex_agent_container.config import AgentConfig
+
+# ---------------------------------------------------------------------------
+# Real (non-mock) collaborators + isolation fixtures
+# ---------------------------------------------------------------------------
+
+
+class _FakeRuntime:
+    """Honest runtime surface; records whether start() was reached.
+
+    Not a mock — a hand-rolled fake exposing only the methods core
+    ``agent_start`` calls (``is_running`` / ``start``). ``start`` honours
+    the ``dry_run`` kwarg so the dry-run early-return path works.
+    """
+
+    def __init__(self) -> None:
+        self.started: list[AgentConfig] = []
+
+    def is_running(self, config: AgentConfig) -> bool:
+        return False
+
+    def start(self, config: AgentConfig, **kwargs: Any) -> bool:
+        self.started.append(config)
+        return True
+
+
+class _FakeHandover:
+    """Honest handover surface; no-op for the module callables core start
+    invokes. Not a mock."""
+
+    def ensure_instance_uuid(self, config: AgentConfig) -> str:
+        return "uuid"
+
+    def hydrate_from_hub(self, config: AgentConfig) -> bool:
+        return True
+
+    def start_failback_poller(self, config: AgentConfig) -> None:
+        pass
+
+
+@pytest.fixture
+def isolated_state(tmp_path: Path) -> Iterator[Path]:
+    """Isolated state.db + runtime dir + HOME, all under tmp_path.
+
+    No mocks — real sqlite, real dirs; env + module constants saved and
+    restored on teardown.
+    """
+    db = tmp_path / "state.db"
+    runtime_dir = tmp_path / "runtime"
+    home = tmp_path / "home"
+    home.mkdir()
+    keys = {
+        "SCITEX_AGENT_CONTAINER_STATE_DB": str(db),
+        "SCITEX_AGENT_CONTAINER_RUNTIME_DIR": str(runtime_dir),
+        "HOME": str(home),
+        "SCITEX_DIR": str(home / ".scitex"),
+    }
+    saved = {k: os.environ.get(k) for k in keys}
+    saved_default = state_db.DEFAULT_DB_PATH
+    os.environ.update(keys)
+    state_db.DEFAULT_DB_PATH = db
+    state_db.init_schema(db)
+    try:
+        yield db
+    finally:
+        state_db.DEFAULT_DB_PATH = saved_default
+        for k, prev in saved.items():
+            if prev is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = prev
+
+
+@pytest.fixture
+def sac_name() -> Iterator[Any]:
+    """Yield a setter for the caller identity (SAC_NAME, both prefixes)."""
+    keys = ("SAC_NAME", "SCITEX_AGENT_CONTAINER_NAME")
+    saved = {k: os.environ.get(k) for k in keys}
+
+    def _set(value: str | None) -> None:
+        for k in keys:
+            if value is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = value
+
+    try:
+        yield _set
+    finally:
+        for k, prev in saved.items():
+            if prev is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = prev
+
+
+def _write_spec(yaml_root: Path, name: str) -> Path:
+    """Write a minimal, real v3 spec under the dir-as-SSoT layout."""
+    agent_dir = yaml_root / name
+    agent_dir.mkdir(parents=True)
+    spec = agent_dir / "spec.yaml"
+    spec.write_text(
+        "apiVersion: scitex-agent-container/v3\n"
+        "kind: Agent\n"
+        "spec:\n"
+        "  runtime: apptainer\n"
+        f"  workdir: {yaml_root / (name + '-work')}\n"
+        "  claude:\n"
+        "    model: sonnet\n"
+        "  health:\n"
+        "    enabled: false\n"
+    )
+    return spec
+
+
+# ---------------------------------------------------------------------------
+# (b) Core spawn path writes a lineage row (not just spawned_by string)
+# ---------------------------------------------------------------------------
+
+
+def test_core_start_writes_lineage_row_for_parent_caller(
+    isolated_state, sac_name, tmp_path
+) -> None:
+    # Arrange — a root parent agent spawns a child via core agent_start.
+    sac_name("parent-root")
+    spec = _write_spec(tmp_path / "yaml", "capsule-child")
+    registry = Registry(registry_dir=tmp_path / "reg")
+    # Act — dry_run returns right after the gate; no container launched.
+    agent_start(
+        str(spec),
+        registry=registry,
+        dry_run=True,
+        runtime_factory=lambda _c: _FakeRuntime(),
+        handover_mod=_FakeHandover(),
+        sleep_fn=lambda _s: None,
+    )
+    # Assert — the lineage edge is in state.db (child's group has parent).
+    assert "parent-root" in derive_group(name="capsule-child")
+
+
+def test_admin_start_records_no_lineage_edge(
+    isolated_state, sac_name, tmp_path
+) -> None:
+    # Arrange — no SAC_NAME → admin / operator / lead launch.
+    sac_name(None)
+    spec = _write_spec(tmp_path / "yaml", "admin-agent")
+    registry = Registry(registry_dir=tmp_path / "reg")
+    # Act
+    agent_start(
+        str(spec),
+        registry=registry,
+        dry_run=True,
+        runtime_factory=lambda _c: _FakeRuntime(),
+        handover_mod=_FakeHandover(),
+        sleep_fn=lambda _s: None,
+    )
+    # Assert — admin-launched agent starts unattached (singleton group).
+    assert derive_group(name="admin-agent") == {"admin-agent"}
+
+
+# ---------------------------------------------------------------------------
+# (a) MCP-tool path passes through check_spawn (deny gated before runtime)
+# ---------------------------------------------------------------------------
+
+
+def test_mcp_tool_spawn_is_denied_for_child_caller(
+    isolated_state, sac_name, tmp_path
+) -> None:
+    # Arrange — the MCP tool runs through the real CLI; a child caller
+    # ("worker-a", parented to "root") must be rejected by check_spawn.
+    record_lineage(child="worker-a", parent="root", db_path=isolated_state)
+    sac_name("worker-a")
+    yaml_root = tmp_path / "yaml"
+    _write_spec(yaml_root, "denied-child")
+    saved_yaml = os.environ.get("SCITEX_AGENT_CONTAINER_YAML_DIRS")
+    saved_key = os.environ.get("SAC_ANTHROPIC_API_KEY")
+    # SAC_ANTHROPIC_API_KEY satisfies the OAuth preflight so the ONLY
+    # thing that can deny is the spawn gate (not a missing-creds exit).
+    os.environ["SCITEX_AGENT_CONTAINER_YAML_DIRS"] = str(yaml_root)
+    os.environ["SAC_ANTHROPIC_API_KEY"] = "sk-ant-api-test-dummy"
+    from scitex_agent_container._mcp._tools._agent import agent_start as mcp_start
+
+    try:
+        # Act — drive the real MCP tool → real Click CLI → core start.
+        result = mcp_start("denied-child")
+    finally:
+        for k, prev in (
+            ("SCITEX_AGENT_CONTAINER_YAML_DIRS", saved_yaml),
+            ("SAC_ANTHROPIC_API_KEY", saved_key),
+        ):
+            if prev is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = prev
+    # Assert — the CLI exited non-zero because the gate denied the spawn.
+    assert result["exit_code"] != 0
+
+
+def test_mcp_tool_spawn_deny_does_not_launch_child(
+    isolated_state, sac_name, tmp_path
+) -> None:
+    # Arrange — same denied child; assert no live instance row was created
+    # (the gate fired BEFORE any runtime/instance bookkeeping).
+    record_lineage(child="worker-b", parent="root", db_path=isolated_state)
+    sac_name("worker-b")
+    yaml_root = tmp_path / "yaml"
+    _write_spec(yaml_root, "never-launched")
+    saved_yaml = os.environ.get("SCITEX_AGENT_CONTAINER_YAML_DIRS")
+    saved_key = os.environ.get("SAC_ANTHROPIC_API_KEY")
+    os.environ["SCITEX_AGENT_CONTAINER_YAML_DIRS"] = str(yaml_root)
+    os.environ["SAC_ANTHROPIC_API_KEY"] = "sk-ant-api-test-dummy"
+    from scitex_agent_container._mcp._tools._agent import agent_start as mcp_start
+    from scitex_agent_container._state.state_db import list_active_instances
+
+    try:
+        # Act
+        mcp_start("never-launched")
+        active = [r["name"] for r in list_active_instances()]
+    finally:
+        for k, prev in (
+            ("SCITEX_AGENT_CONTAINER_YAML_DIRS", saved_yaml),
+            ("SAC_ANTHROPIC_API_KEY", saved_key),
+        ):
+            if prev is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = prev
+    # Assert — the denied child never reached instance bookkeeping.
+    assert "never-launched" not in active


### PR DESCRIPTION
## Summary

"sac from sac" **Step 1** (ADR-0010 Rule B / Phase 2): make agent-from-agent spawn genuinely ACL-gated on **all** paths and unify lineage onto one codepath — `起動経路 = 記録経路 = ACL経路`.

### Problem (before)
Only the `sac listen` `POST /agents` handler ran `check_spawn` + `record_lineage`. The MCP `agent_start` tool (clew's spawn surface) and the plain `sac agents start` CLI both shell straight through to core `agent_start`, bypassing the gate. Lineage was **split-brain**: only the server path wrote the `lineage` table (which drives ACL via `derive_group`/`spawn_allowed`), while `instances.spawned_by` (a descriptive string) was written on every local start.

### Mechanism chosen: (i) gate in the core/shared spawn path
Preferred over (ii) routing the MCP tool through `sac listen POST /agents`. Justification:
- ADR-0010 Rule B already mandates core `agent_start` as the single convergence point every spawn path flows through. Gating there extends recording → gating + lineage with no new daemon dependency.
- The MCP `agent_start` tool shells `sac agents start <name>` → core `agent_start`, so gating in core automatically covers the MCP path.
- (ii) would add a fragile `sac listen` dependency that clew on Spartan does not have running — clew must spawn capsule children with no separate daemon.

### What changed
- **New** `_lifecycle/_spawn_gate.py` — `enforce_spawn_gate(child)` resolves the caller from the parent's `SAC_NAME` env (None/empty → admin/operator/lead → always allowed), runs `check_spawn` (raises `SpawnDeniedError` on deny, **before** any runtime work), and records the `caller → child` edge in the `lineage` table on allow (idempotent).
- **Wired** into core `agent_start` (`_lifecycle/_start.py`) just before the runtime is built — so the MCP tool, the CLI, and the server path all funnel through it.
- The same `SAC_NAME` drives both `_instances._spawned_by` (the `instances.spawned_by` string) and the new gate (the `lineage` row), so the two are written from one identity on one codepath — **split-brain resolved**.
- The server handler still passes its request `caller` verbatim and records lineage itself; its bare-host subprocess inherits no `SAC_NAME`, so the core gate sees `caller=None` (admin) and does not double-record (`record_lineage` is idempotent regardless).

### Scope
Step 1 **only**. No `spec.acl` schema (Step 2), no `child ⊆ parent` clamp (Step 3) — separate follow-up PRs. `check_spawn`'s binary root/child policy is kept verbatim.

## Tests (no mocks, real state.db)
- `test__spawn_gate.py` (10 tests) — unit on `enforce_spawn_gate` against the real `check_spawn` / `record_lineage` collaborators and a real on-disk sqlite state.db; deny, allow, admin-no-record, idempotency, re-parent rejection, explicit-caller-override.
- `test__start_spawn_acl.py` (4 tests) — integration:
  - **(a) passes through check_spawn**: a child-caller spawn via the **real MCP `agent_start` tool → real Click CLI → core `agent_start`** is denied with a non-zero exit, and never reaches instance bookkeeping.
  - **(b) writes a lineage row**: core `agent_start` (the convergence point the MCP tool wraps) writes the `lineage` edge for a parent caller — verified by reading the row back from a real state.db.

All AAA markers, 3+-word names, one assertion per test. Verified manually that the MCP deny output is the spawn gate's reason (`spawn denied: caller 'worker-a' is a child of 'root'`), not the OAuth preflight.

## Test plan
- New suites: 14 passed.
- Regression sweep: `_lifecycle/` + `_listen/` (incl. `test__acl.py`, `test_server.py`) 400 passed with randomization enabled; `_mcp/` + `cli_pkg/` + `_state/` 1897 passed.
- ruff clean; PostToolUse NM/TQ lint clean.

## Step 2/3 dependencies discovered
- Step 2 (`spec.acl` schema) and Step 3 (`child ⊆ parent` clamp) build directly on this gate — `enforce_spawn_gate` is the single chokepoint where the clamp will live. `spawn_allowed`'s "lift-able policy" comment documents the single-callsite edit point.
- Note: the server `agents_start` handler and core `agent_start` now both record lineage on their respective paths; Step 3 should consolidate the *clamp* into `enforce_spawn_gate` so the server path inherits it for free.