### PR TITLE
feat(status): show per-agent Anthropic account in list + status

### DIFF
--- a/src/scitex_agent_container/_account/agent_account.py
+++ b/src/scitex_agent_container/_account/agent_account.py
@@ -1,0 +1,169 @@
+"""Resolve which Anthropic account an agent effectively uses.
+
+Fleet-wide account *visibility* (operator request 4581): surface, per
+agent, the identity of the Anthropic account it authenticates as, so the
+operator can see at a glance which agents share one account — and thus
+which agents collide on the same server-side rate limit (429).
+
+Mechanism (mirrors ``runtimes/_sdk_common.py::provision_anthropic_auth``,
+the runtime auth precedence):
+
+1. **Agent env override.** If the agent's effective env carries
+   ``SAC_ANTHROPIC_API_KEY`` (declared in ``spec.apptainer.env`` and
+   promoted by the v3 loader into ``AgentConfig.env``), that is a
+   *distinct* credential source from the host's shared OAuth file. We
+   label it by the key form:
+
+   * ``sk-ant-api*`` → pay-per-token API key →
+     ``apikey:…<last4>`` fingerprint (no identity is recoverable from
+     the key alone, so the last 4 chars are the discriminator).
+   * ``sk-ant-oat*`` → an OAuth bearer handed in via env (rare; used on
+     hosts that deliberately have no credentials.json) → ``sac-env``
+     (a label, not the secret — the token is never surfaced).
+   * any other / unparseable value → ``sac-env``.
+
+2. **Host OAuth (the common case).** No env override → the agent uses
+   the host's ``~/.claude/.credentials.json`` (bind-mounted into every
+   container today; there is no per-agent credential-file override yet
+   — that is part 1 of the multi-account set, deferred). The identity
+   is the ``oauthAccount.emailAddress`` from ``~/.claude.json``. If that
+   email matches a saved account from ``sac accounts``, we prefer the
+   named-account label (``<name> (<email>)``); else just ``<email>``.
+
+3. **Fallbacks (never crash).**
+
+   * credentials.json present but no resolvable email → ``default``.
+   * neither a credentials file nor an env key → ``unknown``.
+
+Design rules
+------------
+* Never raises. A resolution failure maps to ``unknown``/``default``,
+  never an exception that would break ``sac agents list``.
+* Token material is never returned. Only an email, a saved-account
+  name, a key fingerprint (last 4), or a coarse label string.
+* Pure stdlib + the existing ``credentials`` / ``account_store``
+  readers. No new dependency, no network call.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+_SAC_API_KEY_ENV = "SAC_ANTHROPIC_API_KEY"
+
+# Resolution result labels for the non-identity cases.
+_LABEL_UNKNOWN = "unknown"
+_LABEL_DEFAULT = "default"
+_LABEL_SAC_ENV = "sac-env"
+
+
+def _env_key_label(value: str) -> str:
+    """Label for an agent that overrides auth via ``SAC_ANTHROPIC_API_KEY``.
+
+    ``sk-ant-api*`` (pay-per-token) → ``apikey:…<last4>`` so two agents
+    on two distinct API keys read as distinct accounts. Anything else
+    (OAuth bearer or unparseable) → ``sac-env`` — a coarse "this agent
+    brings its own credential" marker. The raw value is never surfaced.
+    """
+    val = value.strip()
+    if val.startswith("sk-ant-api"):
+        last4 = val[-4:] if len(val) >= 4 else val
+        return f"apikey:…{last4}"
+    return _LABEL_SAC_ENV
+
+
+def _cred_file(home: Path) -> Path:
+    """The credentials.json path the SDK would read for the HOST account.
+
+    Mirrors ``_sdk_common._cred_file_path`` *for the resolver's vantage*:
+    we always reason about the host operator's ``~/.claude/`` here, not a
+    container's ``CLAUDE_CONFIG_DIR`` — the list/status command runs on
+    the host and every agent today shares this one file.
+    """
+    return home / ".claude" / ".credentials.json"
+
+
+def _match_saved_account(
+    email: str,
+    home: Path,
+    store_dir: Path | None,
+) -> str | None:
+    """Return the saved-account NAME whose email matches ``email``, or None.
+
+    Best-effort: any failure listing the store maps to ``None`` (we just
+    fall back to showing the bare email). Never raises.
+    """
+    # stx-allow: fallback (reason: account-store read is best-effort enrichment; a missing/corrupt store must degrade to the bare-email label, never break list/status)
+    try:
+        from .._state.account_store import list_accounts
+
+        for acct in list_accounts(store_dir=store_dir, home=home):
+            if acct.get("email_address") == email:
+                name = acct.get("name")
+                if isinstance(name, str) and name:
+                    return name
+    except Exception:  # stx-allow: fallback (reason: catch-all — see inline comment)
+        return None
+    return None
+
+
+def resolve_agent_account_label(
+    env: dict[str, str] | None,
+    home: Path | None = None,
+    store_dir: Path | None = None,
+) -> str:
+    """Resolve a short, human-readable account label for one agent.
+
+    Args:
+        env: The agent's effective env dict (``AgentConfig.env`` — the v3
+            loader promotes ``spec.apptainer.env`` into it). Used to
+            detect a ``SAC_ANTHROPIC_API_KEY`` override. ``None`` / empty
+            means the agent inherits the host's shared auth.
+        home: Override for the user home directory (defaults to
+            ``Path.home()``). The host ``~/.claude.json`` /
+            ``~/.claude/.credentials.json`` under it are the source of
+            truth for the shared-OAuth identity. Used by tests.
+        store_dir: Override for the saved-accounts store directory
+            (defaults to the SciTeX local-state cascade). Used by tests.
+
+    Returns:
+        One of:
+
+        * ``apikey:…<last4>`` — agent brings its own API key.
+        * ``sac-env`` — agent brings its own (non-API-key) env credential.
+        * ``<name> (<email>)`` — host OAuth, matched to a saved account.
+        * ``<email>`` — host OAuth, no matching saved account.
+        * ``default`` — credentials.json present but no email resolvable.
+        * ``unknown`` — no credentials file and no env override.
+
+    Never raises.
+    """
+    _home = Path(home) if home is not None else Path.home()
+
+    # 1. Agent-level env override wins (distinct credential source).
+    env = env or {}
+    override = env.get(_SAC_API_KEY_ENV)
+    if isinstance(override, str) and override.strip():
+        return _env_key_label(override)
+
+    # 2. Host shared OAuth — resolve identity from the credentials file.
+    if not _cred_file(_home).is_file():
+        return _LABEL_UNKNOWN
+
+    # stx-allow: fallback (reason: credentials-metadata read is best-effort identity enrichment; a corrupt/partial ~/.claude.json must degrade to the "default" label, never break list/status)
+    try:
+        from .credentials import read_credentials_metadata
+
+        meta: dict[str, Any] = read_credentials_metadata(home=_home)
+    except Exception:  # stx-allow: fallback (reason: catch-all — see inline comment)
+        return _LABEL_DEFAULT
+
+    email = meta.get("email_address")
+    if not (isinstance(email, str) and email):
+        return _LABEL_DEFAULT
+
+    saved_name = _match_saved_account(email, _home, store_dir)
+    if saved_name:
+        return f"{saved_name} ({email})"
+    return email

--- a/src/scitex_agent_container/_lifecycle/_status.py
+++ b/src/scitex_agent_container/_lifecycle/_status.py
@@ -14,6 +14,29 @@ from ..config import AgentConfig, load_config
 from ._runtime_select import _fallback_workdir, _get_runtime
 
 
+def _resolve_account(config: AgentConfig | None) -> str:
+    """Resolve the agent's effective Anthropic-account label.
+
+    Surfaces which account the agent authenticates as (operator request
+    4581) so the operator can see which agents share one account — and
+    thus one server-side rate limit. Mirrors the runtime auth precedence
+    (agent ``spec.env`` override → host shared OAuth → fallback). See
+    ``_account.agent_account.resolve_agent_account_label``.
+
+    Tolerant: a missing config or any resolver hiccup maps to
+    ``"unknown"`` so status never fails on account lookup.
+    """
+    # stx-allow: fallback (reason: status output must never crash on an
+    # account-resolution hiccup; ``"unknown"`` is the right degraded UX.)
+    try:
+        from .._account.agent_account import resolve_agent_account_label
+
+        env = config.env if config is not None else None
+        return resolve_agent_account_label(env)
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        return "unknown"
+
+
 def _remote_instance_status(name: str) -> dict | None:
     """Build a status dict from the active ``instances`` row for ``name``.
 
@@ -51,6 +74,9 @@ def _remote_instance_status(name: str) -> dict | None:
             "status": "running",
             "model": "unknown",
             "runtime": "unknown",
+            # Cross-host agent: its credentials live on the remote host,
+            # not resolvable from here. Keep the key for shape parity.
+            "account": "unknown",
             "host": row.get("host", "") or "",
             "a2a_port": row.get("a2a_port"),
             "bound_port": bound,
@@ -107,6 +133,10 @@ def agent_status(
         "status": "running" if running else "stopped",
         "model": config.model if config else "unknown",
         "runtime": config.runtime if config else "unknown",
+        # Which Anthropic account this agent authenticates as (operator
+        # request 4581). Agents sharing one label share one server-side
+        # rate limit. Resolved from the agent's effective auth source.
+        "account": _resolve_account(config),
     }
     # ``config.remote`` was deleted in WI-6; spec.host (host pinning)
     # is the v3 equivalent and is recorded in state.db's ``instances``

--- a/src/scitex_agent_container/cli_pkg/_helpers/_agent_list.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers/_agent_list.py
@@ -31,6 +31,30 @@ def _safe_port_for(name: str) -> int | None:
         return None
 
 
+def _safe_account_for(cfg) -> str:
+    """Resolve the agent's effective Anthropic-account label.
+
+    Surfaces which account the agent authenticates as (operator request
+    4581) so the operator can spot agents sharing one account — and thus
+    one server-side rate limit. Resolution mirrors the runtime auth
+    precedence: agent ``spec.env`` override → host shared OAuth identity
+    → ``default``/``unknown`` fallback. See
+    ``_account.agent_account.resolve_agent_account_label`` for the rule.
+
+    Tolerant: a missing config or any resolver hiccup maps to
+    ``"unknown"`` so the list command never crashes on account lookup.
+    """
+    # stx-allow: fallback (reason: list output must never crash on an
+    # account-resolution hiccup; ``"unknown"`` cell is the right UX.)
+    try:
+        from ..._account.agent_account import resolve_agent_account_label
+
+        env = getattr(cfg, "env", None) if cfg is not None else None
+        return resolve_agent_account_label(env)
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        return "unknown"
+
+
 def _probe_local(cfg) -> bool | None:
     """Probe an agent's liveness via ContainerRuntime.
 
@@ -240,6 +264,9 @@ def get_agent_list_data(
             "host": host_label,
             "path": spec_path,
             "a2a_port": a2a_port,
+            # Which Anthropic account this agent authenticates as.
+            # Agents sharing one label share one server-side rate limit.
+            "account": _safe_account_for(cfg),
         }
         if errors:
             row["validation_errors"] = errors
@@ -300,6 +327,7 @@ def get_agent_list_data(
             "host": "local",
             "path": str(spec_path),
             "a2a_port": _safe_port_for(name),
+            "account": _safe_account_for(cfg),
         }
         if errors:
             row["validation_errors"] = errors
@@ -368,10 +396,16 @@ def print_agent_list(
         return
 
     table = Table(title="Agents")
-    table.add_column("Name", style="bold")
+    # ``no_wrap`` keeps the agent name (the primary identifier) intact:
+    # rich shrinks the fold-able Account/Path columns instead of
+    # ellipsising the name when the terminal is narrow.
+    table.add_column("Name", style="bold", no_wrap=True)
     table.add_column("Status")
     table.add_column("YAML")
     table.add_column("Host")
+    # Account labels (e.g. ``<name> (<email>)``) can be long; fold within
+    # the cell rather than stealing width from the name column.
+    table.add_column("Account", overflow="fold")
     table.add_column("Path", overflow="fold")
     table.add_column("Started")
     cmap = {
@@ -392,11 +426,13 @@ def print_agent_list(
             else "[green]✓[/green]"
         )
         started = row["started_at"] if row["started_at"] not in ("-", "?") else "—"
+        account_cell = row.get("account") or "—"
         table.add_row(
             row["name"],
             f"[{col}]{row['status']}[/{col}]",
             yaml_cell,
             host_cell,
+            account_cell,
             row.get("path") or "—",
             started,
         )

--- a/tests/scitex_agent_container/_account/test_agent_account.py
+++ b/tests/scitex_agent_container/_account/test_agent_account.py
@@ -1,0 +1,176 @@
+"""Tests for ``_account.agent_account.resolve_agent_account_label``.
+
+No-mocks: every case writes real ``~/.claude.json`` /
+``~/.claude/.credentials.json`` files and real ``sac accounts`` store
+entries under ``tmp_path`` and resolves against them. No
+``unittest.mock``, no ``monkeypatch``, no ``MagicMock`` — the resolver
+reads bytes on disk, so the tests put bytes on disk.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scitex_agent_container._account.agent_account import (
+    resolve_agent_account_label,
+)
+from scitex_agent_container._state.account_store import save_account
+
+# ---------------------------------------------------------------------------
+# Real credential-file fixtures (helpers write real JSON to tmp_path).
+# ---------------------------------------------------------------------------
+
+
+def _write_credentials(home: Path, *, expires_at: int = 9_999_999_999_000) -> None:
+    """Write a real ``~/.claude/.credentials.json`` under ``home``.
+
+    ``expires_at`` is far in the future by default so any token-expiry
+    check the resolver path triggers treats it as live.
+    """
+    claude_dir = home / ".claude"
+    claude_dir.mkdir(parents=True, exist_ok=True)
+    (claude_dir / ".credentials.json").write_text(
+        json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "sk-ant-SECRET-TOKEN",
+                    "refreshToken": "REFRESH-SECRET",
+                    "expiresAt": expires_at,
+                    "scopes": ["user:inference"],
+                    "subscriptionType": "max",
+                    "rateLimitTier": "default_claude_max_20x",
+                }
+            }
+        )
+    )
+
+
+def _write_claude_json(home: Path, email: str | None) -> None:
+    """Write ``~/.claude.json`` with (or without) an oauth email."""
+    oauth = {"emailAddress": email} if email is not None else {}
+    (home / ".claude.json").write_text(json.dumps({"oauthAccount": oauth}))
+
+
+# ---------------------------------------------------------------------------
+# 1. Env-override branch (agent brings its own credential).
+# ---------------------------------------------------------------------------
+
+
+def test_api_key_env_override_returns_fingerprint_label(tmp_path):
+    # Arrange
+    env = {"SAC_ANTHROPIC_API_KEY": "sk-ant-api03-ABCDEFGHabcd1234"}
+    # Act
+    label = resolve_agent_account_label(env, home=tmp_path)
+    # Assert
+    assert label == "apikey:…1234"
+
+
+def test_oauth_token_env_override_returns_sac_env_label(tmp_path):
+    # Arrange
+    env = {"SAC_ANTHROPIC_API_KEY": "sk-ant-oat01-OPAQUE-BEARER"}
+    # Act
+    label = resolve_agent_account_label(env, home=tmp_path)
+    # Assert
+    assert label == "sac-env"
+
+
+def test_env_override_wins_over_host_credentials(tmp_path):
+    # Arrange — host OAuth file present, but agent overrides via env.
+    _write_credentials(tmp_path)
+    _write_claude_json(tmp_path, "host@example.com")
+    env = {"SAC_ANTHROPIC_API_KEY": "sk-ant-api03-zzzz9999"}
+    # Act
+    label = resolve_agent_account_label(env, home=tmp_path)
+    # Assert
+    assert label == "apikey:…9999"
+
+
+def test_blank_env_override_falls_through_to_host(tmp_path):
+    # Arrange — a whitespace-only override must NOT count as a credential.
+    _write_credentials(tmp_path)
+    _write_claude_json(tmp_path, "host@example.com")
+    env = {"SAC_ANTHROPIC_API_KEY": "   "}
+    # Act
+    label = resolve_agent_account_label(env, home=tmp_path)
+    # Assert
+    assert label == "host@example.com"
+
+
+# ---------------------------------------------------------------------------
+# 2. Host shared-OAuth branch — identity from ~/.claude.json email.
+# ---------------------------------------------------------------------------
+
+
+def test_host_oauth_email_when_no_saved_account_match(tmp_path):
+    # Arrange
+    _write_credentials(tmp_path)
+    _write_claude_json(tmp_path, "solo@example.com")
+    # Act
+    label = resolve_agent_account_label({}, home=tmp_path)
+    # Assert
+    assert label == "solo@example.com"
+
+
+def test_host_oauth_prefers_saved_account_name_on_email_match(tmp_path):
+    # Arrange — a saved account whose email matches the host OAuth email.
+    _write_credentials(tmp_path)
+    _write_claude_json(tmp_path, "ywata@example.com")
+    save_account("primary", {"email_address": "ywata@example.com"}, home=tmp_path)
+    # Act
+    label = resolve_agent_account_label({}, home=tmp_path)
+    # Assert
+    assert label == "primary (ywata@example.com)"
+
+
+def test_host_oauth_ignores_saved_account_with_different_email(tmp_path):
+    # Arrange — saved account exists but its email does not match.
+    _write_credentials(tmp_path)
+    _write_claude_json(tmp_path, "current@example.com")
+    save_account("other", {"email_address": "different@example.com"}, home=tmp_path)
+    # Act
+    label = resolve_agent_account_label({}, home=tmp_path)
+    # Assert
+    assert label == "current@example.com"
+
+
+# ---------------------------------------------------------------------------
+# 3. Fallback branches — never crash.
+# ---------------------------------------------------------------------------
+
+
+def test_no_credentials_file_returns_unknown(tmp_path):
+    # Arrange — empty home: no credentials.json, no env override.
+    # Act
+    label = resolve_agent_account_label({}, home=tmp_path)
+    # Assert
+    assert label == "unknown"
+
+
+def test_credentials_present_but_no_email_returns_default(tmp_path):
+    # Arrange — credentials file present, but oauthAccount has no email.
+    _write_credentials(tmp_path)
+    _write_claude_json(tmp_path, None)
+    # Act
+    label = resolve_agent_account_label({}, home=tmp_path)
+    # Assert
+    assert label == "default"
+
+
+def test_credentials_present_but_no_claude_json_returns_default(tmp_path):
+    # Arrange — credentials file present, ~/.claude.json entirely absent.
+    _write_credentials(tmp_path)
+    # Act
+    label = resolve_agent_account_label({}, home=tmp_path)
+    # Assert
+    assert label == "default"
+
+
+def test_none_env_inherits_host_account(tmp_path):
+    # Arrange — env=None (not just empty) must still resolve host OAuth.
+    _write_credentials(tmp_path)
+    _write_claude_json(tmp_path, "inherited@example.com")
+    # Act
+    label = resolve_agent_account_label(None, home=tmp_path)
+    # Assert
+    assert label == "inherited@example.com"

--- a/tests/scitex_agent_container/_lifecycle/test_lifecycle.py
+++ b/tests/scitex_agent_container/_lifecycle/test_lifecycle.py
@@ -1376,6 +1376,103 @@ def test_agent_status_config_load_failure_reports_unknown_model_and_runtime(
     assert result["model"] == "unknown" and result["runtime"] == "unknown"
 
 
+# ---------------------------------------------------------------------------
+# agent_status — account field (operator request 4581).
+#
+# The autouse ``_isolate_home`` fixture points HOME at tmp_path, so an
+# agent with no env override and no credentials.json there resolves to
+# "unknown"; writing a real credentials.json + ~/.claude.json under HOME
+# exercises the host-OAuth path; a spec.env override exercises the
+# distinct-credential path. All real files, no mocks.
+# ---------------------------------------------------------------------------
+
+
+def test_agent_status_account_unknown_when_no_credentials(
+    tmp_path: Path, registry: Registry
+) -> None:
+    # Arrange — HOME (=tmp_path) has no credentials.json and the spec
+    # carries no SAC_ANTHROPIC_API_KEY override.
+    spec = _write_spec(tmp_path)
+    registry.add("alpha", str(spec), "cld-alpha")
+    # Act
+    result = lc.agent_status(
+        "alpha", registry=registry, runtime_factory=lambda _c: FakeRuntime()
+    )
+    # Assert
+    assert result["account"] == "unknown"
+
+
+def test_agent_status_account_reports_host_oauth_email(
+    tmp_path: Path, registry: Registry
+) -> None:
+    # Arrange — real host OAuth files under HOME (=tmp_path).
+    import json as _json
+
+    claude_dir = tmp_path / ".claude"
+    claude_dir.mkdir(parents=True, exist_ok=True)
+    (claude_dir / ".credentials.json").write_text(
+        _json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "sk-ant-SECRET",
+                    "expiresAt": 9_999_999_999_000,
+                    "subscriptionType": "max",
+                    "rateLimitTier": "default_claude_max_20x",
+                }
+            }
+        )
+    )
+    (tmp_path / ".claude.json").write_text(
+        _json.dumps({"oauthAccount": {"emailAddress": "shared@example.com"}})
+    )
+    spec = _write_spec(tmp_path)
+    registry.add("alpha", str(spec), "cld-alpha")
+    # Act
+    result = lc.agent_status(
+        "alpha", registry=registry, runtime_factory=lambda _c: FakeRuntime()
+    )
+    # Assert
+    assert result["account"] == "shared@example.com"
+
+
+def test_agent_status_account_reports_apikey_fingerprint_on_env_override(
+    tmp_path: Path, registry: Registry
+) -> None:
+    # Arrange — spec.apptainer.env supplies a distinct API key (the v3
+    # loader promotes it into cfg.env). HOME OAuth (if any) must be
+    # ignored in favour of the agent's own credential.
+    spec = _write_spec(
+        tmp_path,
+        extra_spec=(
+            "  apptainer:\n"
+            "    env:\n"
+            "      SAC_ANTHROPIC_API_KEY: sk-ant-api03-AAAABBBB7777\n"
+        ),
+    )
+    registry.add("alpha", str(spec), "cld-alpha")
+    # Act
+    result = lc.agent_status(
+        "alpha", registry=registry, runtime_factory=lambda _c: FakeRuntime()
+    )
+    # Assert
+    assert result["account"] == "apikey:…7777"
+
+
+def test_agent_status_account_unknown_when_config_load_fails(
+    tmp_path: Path, registry: Registry
+) -> None:
+    # Arrange — config path points at a non-existent YAML so load_config
+    # raises; the account resolver must degrade to "unknown" (config is
+    # None), never crash status.
+    registry.add("alpha", str(tmp_path / "alpha" / "spec.yaml"), "cld-alpha")
+    # Act
+    result = lc.agent_status(
+        "alpha", registry=registry, runtime_factory=lambda _c: FakeRuntime()
+    )
+    # Assert
+    assert result["account"] == "unknown"
+
+
 def test_agent_status_omits_remote_host_after_wi6_deletion(
     tmp_path: Path, registry: Registry
 ) -> None:

--- a/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list.py
+++ b/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list.py
@@ -498,3 +498,146 @@ def test_discover_defined_agents_skips_dirs_without_spec_yaml(tmp_path):
         pairs = _al._discover_defined_agents()
     # Assert
     assert "no-spec" not in [n for n, _ in pairs]
+
+
+# ---------------------------------------------------------------------------
+# account column (operator request 4581) — per-agent Anthropic-account
+# label so the operator can spot agents sharing one rate limit.
+#
+# ``_safe_account_for`` is called as a bare module-level name inside
+# ``_agent_list``, so swapping ``_al._safe_account_for`` intercepts both
+# row-builder call sites (registered + defined-on-disk). The swap is a
+# real callable returning a fixed label — not a mock.
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def _swap_account(impl: Callable[[Any], str]) -> Iterator[None]:
+    """Swap ``_al._safe_account_for`` for a real callable returning a label."""
+    saved = _al._safe_account_for
+    _al._safe_account_for = impl  # type: ignore[assignment]
+    try:
+        yield
+    finally:
+        _al._safe_account_for = saved  # type: ignore[assignment]
+
+
+def test_get_data_row_carries_account_field(tmp_path):
+    # Arrange
+    spec = _write_valid_spec(tmp_path / "x")
+    entries = [{"name": "x", "config": str(spec)}]
+    registry = _FakeRegistry(entries)
+    # Act
+    with (
+        _swap_discover(_no_discover),
+        _swap_probe(lambda cfg: True),
+        _swap_account(lambda cfg: "alice@example.com"),
+    ):
+        out = get_agent_list_data(registry)
+    # Assert
+    assert out[0]["account"] == "alice@example.com"
+
+
+def test_get_data_defined_agent_row_carries_account_field(tmp_path):
+    # Arrange — agent on disk only, not in registry.
+    spec = _write_valid_spec(tmp_path / "ondisk")
+    registry = _FakeRegistry([])
+
+    def _discover() -> list[tuple[str, Path]]:
+        return [("ondisk", spec)]
+
+    # Act
+    with _swap_discover(_discover), _swap_account(lambda cfg: "bob@example.com"):
+        out = get_agent_list_data(registry)
+    # Assert
+    row = next(r for r in out if r["name"] == "ondisk")
+    assert row["account"] == "bob@example.com"
+
+
+def test_print_agent_list_renders_account_column_header(capsys, tmp_path):
+    # Arrange
+    spec = _write_valid_spec(tmp_path / "x")
+    registry = _FakeRegistry([{"name": "x", "config": str(spec)}])
+    # Act
+    with (
+        _swap_discover(_no_discover),
+        _swap_probe(lambda cfg: True),
+        _swap_account(lambda cfg: "alice@example.com"),
+    ):
+        print_agent_list(registry)
+    # Assert
+    assert "Account" in capsys.readouterr().out
+
+
+def test_print_agent_list_renders_account_value(capsys, tmp_path):
+    # Arrange — a short label survives the narrow capture-mode terminal
+    # width (a long email gets ellipsised by rich; the JSON test below
+    # covers the full value).
+    spec = _write_valid_spec(tmp_path / "x")
+    registry = _FakeRegistry([{"name": "x", "config": str(spec)}])
+    # Act
+    with (
+        _swap_discover(_no_discover),
+        _swap_probe(lambda cfg: True),
+        _swap_account(lambda cfg: "acct-x"),
+    ):
+        print_agent_list(registry)
+    # Assert
+    assert "acct-x" in capsys.readouterr().out
+
+
+def test_print_agent_list_json_emits_account_in_row(capsys, tmp_path):
+    # Arrange
+    spec = _write_valid_spec(tmp_path / "x")
+    registry = _FakeRegistry([{"name": "x", "config": str(spec)}])
+    # Act
+    with (
+        _swap_discover(_no_discover),
+        _swap_probe(lambda cfg: True),
+        _swap_account(lambda cfg: "alice@example.com"),
+    ):
+        print_agent_list_json(registry)
+    # Assert
+    data = json.loads(capsys.readouterr().out)
+    assert data[0]["account"] == "alice@example.com"
+
+
+def test_safe_account_for_resolves_real_credentials_end_to_end(tmp_path):
+    # Arrange — real credentials + claude.json under a tmp HOME; no env
+    # override on the config, so the real resolver flows through.
+    import json as _json
+
+    from scitex_agent_container.config._types import AgentConfig
+
+    claude_dir = tmp_path / ".claude"
+    claude_dir.mkdir(parents=True)
+    (claude_dir / ".credentials.json").write_text(
+        _json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "sk-ant-SECRET",
+                    "expiresAt": 9_999_999_999_000,
+                    "subscriptionType": "max",
+                    "rateLimitTier": "default_claude_max_20x",
+                }
+            }
+        )
+    )
+    (tmp_path / ".claude.json").write_text(
+        _json.dumps({"oauthAccount": {"emailAddress": "real@example.com"}})
+    )
+    cfg = AgentConfig(name="x")  # no SAC_ANTHROPIC_API_KEY in env
+    # Act
+    with _home_set_to(tmp_path):
+        label = _al._safe_account_for(cfg)
+    # Assert
+    assert label == "real@example.com"
+
+
+def test_safe_account_for_returns_string_on_none_config():
+    # Arrange — None config (registry entry whose YAML failed to load).
+    cfg = None
+    # Act — must not crash; contract is "never raises, returns a string".
+    result = _al._safe_account_for(cfg)
+    # Assert
+    assert isinstance(result, str) and result


### PR DESCRIPTION
## What

Per-agent Anthropic-account **visibility** (operator request 4581).
`sac agents list` gains an **Account** column and `sac agents status`
gains an `account` field (both in `--json` too), showing which account
each agent authenticates as — so the operator can see at a glance which
agents share one account and thus collide on the same server-side rate
limit (429).

This is **part 2 only** of the multi-account orchestration set
(visibility). Part 1 (per-agent account assignment) and part 3 (group
distribution) are intentionally out of scope.

## How the label is resolved

`_account/agent_account.resolve_agent_account_label(env, home, store_dir)`
mirrors the runtime auth precedence in
`runtimes/_sdk_common.provision_anthropic_auth`:

1. **Agent env override** — `SAC_ANTHROPIC_API_KEY` declared in
   `spec.apptainer.env` (the v3 loader promotes it into
   `AgentConfig.env`) is a *distinct* credential source →
   `apikey:…<last4>` for an `sk-ant-api*` key, else `sac-env`.
2. **Host shared OAuth** (today's common case — every container
   bind-mounts the host `~/.claude/.credentials.json`) → the
   `oauthAccount.emailAddress` from `~/.claude.json`, preferring a
   matching saved-account name (`<name> (<email>)`) from the
   `sac accounts` store when one exists, else the bare `<email>`.
3. **Fallbacks** — `default` (creds present, no email) / `unknown`
   (no auth, or config failed to load). Never raises.

Because there is no per-agent credential-file override yet, this
column will correctly show **many agents on the same account today**
(e.g. everything sharing the lead's default `~/.claude` OAuth) — which
is exactly the collision signal the operator wants surfaced.

Token material is never surfaced — only an email, a saved-account
name, or a 4-char key fingerprint.

## Output shape

- `agents list` table: new `Account` column. Name column is now
  `no_wrap` and Account folds, so the agent name (primary identifier)
  is never ellipsised by the extra column on a narrow terminal.
- `agents list --json`: each row (registered + defined-on-disk) carries
  an `account` field.
- `agents status [--json]`: new `account` field. Cross-host instance
  rows carry `account: "unknown"` (creds live on the remote host).

## Tests

Real credential-file fixtures + real `sac accounts` store under
`tmp_path`; no mocks. Covers every resolution branch, the list/status
wiring, JSON parity, and the never-crash fallbacks.

## Test plan

- `pytest tests/scitex_agent_container/_account/test_agent_account.py` — 11 passed
- `pytest tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list.py` — 31 passed
- `pytest tests/scitex_agent_container/_lifecycle/test_lifecycle.py -k account` — 4 passed
- `pytest tests/scitex_agent_container/cli_pkg/test_status_cmds.py` — green (fleet-table name-visibility test fixed via `no_wrap`)
- `scitex-dev linter check-files` clean on all changed files
- CLI startup-budget test still green (lazy imports)