### PR TITLE
feat(account): per-agent OAuth account assignment (spec.claude.account)

### DIFF
--- a/.scitex/agent-container/agents/sdk-test/spec.yaml
+++ b/.scitex/agent-container/agents/sdk-test/spec.yaml
@@ -33,11 +33,14 @@ metadata:
     in-repo: "true"
 
 spec:
-  runtime: docker
-  image: scitex-agent-container:sdk-persistent
-  dockerfile: ./containers/Dockerfile
-  model: claude-haiku-4-5
+  runtime: apptainer
   workdir: /tmp/sac-sdk-test-workspace
+
+  apptainer:
+    image: scitex-agent-container:sdk-persistent
+
+  claude:
+    model: claude-haiku-4-5
 
   startup_commands:
     - command: "Reply with exactly the string 'sdk-runtime-ok' and nothing else."

--- a/src/scitex_agent_container/_account/agent_account.py
+++ b/src/scitex_agent_container/_account/agent_account.py
@@ -108,10 +108,41 @@ def _match_saved_account(
     return None
 
 
+def _assigned_account_label(
+    assigned_account: str,
+    home: Path,
+    store_dir: Path | None,
+) -> str:
+    """Label for an agent pinned to a saved account via
+    ``spec.claude.account``.
+
+    Looks up the saved account's ``email_address`` from the store and
+    returns ``<name> (<email>)`` when found, else bare ``<name>``.
+    Never raises — a missing/corrupt store degrades to the bare name.
+    """
+    # stx-allow: fallback (reason: store read is best-effort enrichment;
+    # a missing/corrupt store must degrade to the bare assigned name,
+    # never break list/status.)
+    try:
+        from .._state.account_store import list_accounts
+
+        for acct in list_accounts(store_dir=store_dir, home=home):
+            if acct.get("name") == assigned_account:
+                email = acct.get("email_address")
+                if isinstance(email, str) and email:
+                    return f"{assigned_account} ({email})"
+                break
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        return assigned_account
+    return assigned_account
+
+
 def resolve_agent_account_label(
     env: dict[str, str] | None,
     home: Path | None = None,
     store_dir: Path | None = None,
+    *,
+    assigned_account: str | None = None,
 ) -> str:
     """Resolve a short, human-readable account label for one agent.
 
@@ -126,13 +157,22 @@ def resolve_agent_account_label(
             truth for the shared-OAuth identity. Used by tests.
         store_dir: Override for the saved-accounts store directory
             (defaults to the SciTeX local-state cascade). Used by tests.
+        assigned_account: The agent's ``spec.claude.account`` (saved
+            account name it is pinned to). When set it is the definitive
+            account for this agent — the runtime copies that snapshot in
+            at start (see ``_apptainer_creds.resolve_cred_file``), so it
+            wins over the host shared-OAuth identity regardless of the
+            host's current ``/login``. ``None`` / empty → fall through to
+            the env-override / host-OAuth resolution.
 
     Returns:
         One of:
 
+        * ``<name> (<email>)`` — pinned to a saved account (assigned), or
+          host OAuth matched to a saved account.
+        * ``<name>`` — pinned to a saved account with no email recorded.
         * ``apikey:…<last4>`` — agent brings its own API key.
         * ``sac-env`` — agent brings its own (non-API-key) env credential.
-        * ``<name> (<email>)`` — host OAuth, matched to a saved account.
         * ``<email>`` — host OAuth, no matching saved account.
         * ``default`` — credentials.json present but no email resolvable.
         * ``unknown`` — no credentials file and no env override.
@@ -141,7 +181,12 @@ def resolve_agent_account_label(
     """
     _home = Path(home) if home is not None else Path.home()
 
-    # 1. Agent-level env override wins (distinct credential source).
+    # 0. Pinned account wins — this agent runs on a frozen copy of the
+    #    named snapshot, independent of the host's current /login.
+    if assigned_account:
+        return _assigned_account_label(assigned_account, _home, store_dir)
+
+    # 1. Agent-level env override (distinct credential source).
     env = env or {}
     override = env.get(_SAC_API_KEY_ENV)
     if isinstance(override, str) and override.strip():

--- a/src/scitex_agent_container/_lifecycle/_status.py
+++ b/src/scitex_agent_container/_lifecycle/_status.py
@@ -32,7 +32,12 @@ def _resolve_account(config: AgentConfig | None) -> str:
         from .._account.agent_account import resolve_agent_account_label
 
         env = config.env if config is not None else None
-        return resolve_agent_account_label(env)
+        assigned = (
+            getattr(getattr(config, "claude", None), "account", "") or None
+            if config is not None
+            else None
+        )
+        return resolve_agent_account_label(env, assigned_account=assigned)
     except Exception:  # stx-allow: fallback (reason: see inline comment)
         return "unknown"
 

--- a/src/scitex_agent_container/_state/account_store.py
+++ b/src/scitex_agent_container/_state/account_store.py
@@ -118,6 +118,101 @@ def list_accounts(
     return accounts
 
 
+def read_account_plan(
+    name: str,
+    store_dir: Path | None = None,
+    home: Path | None = None,
+) -> dict[str, Any]:
+    """Read the OFFLINE plan/tier of a saved account from its snapshot.
+
+    Opens ``<acct>/.credentials.json`` and pulls ONLY the two non-secret
+    fields ``subscriptionType`` and ``rateLimitTier`` (whitelist — tokens
+    are never touched), then derives a human ``plan_label`` (Pro / Max 5x
+    / Max 20x / Free) via the same mapping ``read_credentials_metadata``
+    uses. No network call — this is free and works for ALL stored
+    accounts, not just the active one.
+
+    Returns a dict with keys ``subscription_type``, ``rate_limit_tier``,
+    ``plan_label`` (any may be ``None``). Never raises — a
+    missing/corrupt snapshot yields all-``None``.
+    """
+    _home = home or Path.home()
+    store = _store_path(store_dir, _home)
+    snapshot = store / name / ".credentials.json"
+    out: dict[str, Any] = {
+        "subscription_type": None,
+        "rate_limit_tier": None,
+        "plan_label": None,
+    }
+    # stx-allow: fallback (reason: snapshot read is best-effort offline
+    # enrichment for `account list`; a missing/corrupt snapshot must
+    # degrade to all-None, never break the listing.)
+    try:
+        with snapshot.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        return out
+    if not isinstance(data, dict):
+        return out
+    oauth = data.get("claudeAiOauth")
+    if not isinstance(oauth, dict):
+        return out
+    sub = oauth.get("subscriptionType")
+    tier = oauth.get("rateLimitTier")
+    if isinstance(sub, str):
+        out["subscription_type"] = sub
+    if isinstance(tier, str):
+        out["rate_limit_tier"] = tier
+    # Derive label via the canonical credentials mapping.
+    # stx-allow: fallback (reason: label derivation is cosmetic; raw
+    # tier/subscription stay exposed even if the import/derive hiccups.)
+    try:
+        from .._account.credentials import _derive_plan_label
+
+        out["plan_label"] = _derive_plan_label(
+            out["rate_limit_tier"], out["subscription_type"]
+        )
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        out["plan_label"] = None
+    return out
+
+
+def read_account_usage_cache(
+    name: str,
+    store_dir: Path | None = None,
+    home: Path | None = None,
+) -> dict[str, Any] | None:
+    """Read a CACHED per-account usage snapshot, if one exists.
+
+    5h/7d usage (``used_pct_5h`` / ``used_pct_7d``) is NOT in the
+    credential snapshot and needs a per-account network call with a
+    credential swap to fetch — too expensive to do synchronously inside
+    ``account list``. This reader is CACHE-ONLY: it returns the contents
+    of ``<acct>/usage.json`` (with an ``as_of`` timestamp) when present,
+    else ``None`` so the caller can render ``"—"``.
+
+    NOTE: nothing writes ``<acct>/usage.json`` yet. ``sac account
+    watch-quota`` is the natural place to persist a per-account usage
+    snapshot per rotation — wiring that writer is intentionally out of
+    scope for the per-agent-account feature (it needs the credential-swap
+    fetch loop). This reader exists so the display path is ready the day
+    that writer lands. Never raises.
+    """
+    _home = home or Path.home()
+    store = _store_path(store_dir, _home)
+    usage_file = store / name / "usage.json"
+    # stx-allow: fallback (reason: cache-only read; missing/corrupt cache
+    # must yield None so `account list` shows "—", never break the list.)
+    try:
+        with usage_file.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        return None
+    if not isinstance(data, dict):
+        return None
+    return data
+
+
 def save_account(
     name: str,
     metadata: dict[str, Any],

--- a/src/scitex_agent_container/cli_pkg/_helpers/_agent_list.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers/_agent_list.py
@@ -50,7 +50,12 @@ def _safe_account_for(cfg) -> str:
         from ..._account.agent_account import resolve_agent_account_label
 
         env = getattr(cfg, "env", None) if cfg is not None else None
-        return resolve_agent_account_label(env)
+        assigned = (
+            getattr(getattr(cfg, "claude", None), "account", "") or None
+            if cfg is not None
+            else None
+        )
+        return resolve_agent_account_label(env, assigned_account=assigned)
     except Exception:  # stx-allow: fallback (reason: see inline comment)
         return "unknown"
 

--- a/src/scitex_agent_container/cli_pkg/account_group.py
+++ b/src/scitex_agent_container/cli_pkg/account_group.py
@@ -114,7 +114,11 @@ def account_list(as_json: bool) -> None:
     import json as _json
 
     from .._account.credentials import read_credentials_metadata
-    from .._state.account_store import list_accounts
+    from .._state.account_store import (
+        list_accounts,
+        read_account_plan,
+        read_account_usage_cache,
+    )
     from ._helpers import console
     from .status_cmds import _format_claude_account_block
 
@@ -126,9 +130,17 @@ def account_list(as_json: bool) -> None:
             active = read_credentials_metadata()
         except (OSError, _json.JSONDecodeError):
             active = {}
+        # Enrich each stored account with OFFLINE plan/tier and any
+        # CACHE-ONLY usage snapshot (None when no cache exists yet).
+        stored = []
+        for acct in accounts:
+            entry = dict(acct)
+            entry.update(read_account_plan(acct["name"]))
+            entry["usage"] = read_account_usage_cache(acct["name"])
+            stored.append(entry)
         click.echo(
             _json.dumps(
-                {"active": active, "stored": accounts}, ensure_ascii=False, indent=2
+                {"active": active, "stored": stored}, ensure_ascii=False, indent=2
             )
         )
         return
@@ -152,8 +164,24 @@ def account_list(as_json: bool) -> None:
         return
     click.echo("Stored accounts:")
     for acct in accounts:
+        name = acct["name"]
         email = acct.get("email_address") or "(no email)"
-        click.echo(f"  {acct['name']:20s}  {email}")
+        # OFFLINE plan/tier from the snapshot — free, no network.
+        plan = read_account_plan(name)
+        plan_label = plan.get("plan_label") or "?"
+        tier = plan.get("rate_limit_tier") or "?"
+        # CACHE-ONLY usage (5h/7d). "—" when no cache exists; nothing
+        # writes the per-account cache yet (see read_account_usage_cache).
+        usage = read_account_usage_cache(name)
+        usage_str = "—"
+        if usage:
+            pct5 = usage.get("used_pct_5h")
+            pct7 = usage.get("used_pct_7d")
+            as_of = usage.get("as_of") or usage.get("timestamp") or "?"
+            usage_str = f"5h={pct5}% 7d={pct7}% (as of {as_of})"
+        click.echo(
+            f"  {name:20s}  {email:28s}  {plan_label} [{tier}]  usage: {usage_str}"
+        )
 
 
 @account.command("delete")

--- a/src/scitex_agent_container/config/__init__.py
+++ b/src/scitex_agent_container/config/__init__.py
@@ -78,4 +78,40 @@ def load_config(path: str | Path) -> AgentConfig:
             + "\n".join(f"  - {e}" for e in errors)
         )
 
-    return load_v3(raw, path)
+    config = load_v3(raw, path)
+    _warn_if_assigned_account_missing(config)
+    return config
+
+
+def _warn_if_assigned_account_missing(config: AgentConfig) -> None:
+    """Soft-WARN (never fail) when ``spec.claude.account`` names an
+    account whose snapshot dir is absent at load time.
+
+    Accounts may be created later or live on another host, so a missing
+    snapshot is not a hard error — but surfacing it at load time catches
+    typos before the agent silently falls back to the host live file at
+    start. Best-effort: any resolution hiccup is swallowed.
+    """
+    acct = getattr(getattr(config, "claude", None), "account", "") or ""
+    if not acct:
+        return
+    # stx-allow: fallback (reason: store-path resolution is best-effort
+    # advisory only; a hiccup must never break config loading.)
+    try:
+        import warnings
+
+        from .._state.account_store import _store_path
+
+        store = _store_path(None, Path.home())
+        if not (store / acct).is_dir():
+            warnings.warn(
+                f"spec.claude.account='{acct}' has no saved-account "
+                f"snapshot at {store / acct}; the agent will fall back "
+                "to the host live ~/.claude/.credentials.json at start. "
+                "Create it with `sac account save {acct}` (on the host "
+                "that holds those credentials), or ignore if the account "
+                "is provisioned on the target host.",
+                stacklevel=2,
+            )
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        pass

--- a/src/scitex_agent_container/config/_parsers/_claude.py
+++ b/src/scitex_agent_container/config/_parsers/_claude.py
@@ -38,5 +38,6 @@ def parse_claude(spec: dict) -> ClaudeSpec:
         continue_max_age_minutes=continue_max_age,
         resume_id=str(raw.get("resume_id", "") or ""),
         auto_accept=raw.get("auto_accept", True),
+        account=str(raw.get("account", "") or ""),
         raw_options=dict(raw_options),
     )

--- a/src/scitex_agent_container/config/_types.py
+++ b/src/scitex_agent_container/config/_types.py
@@ -47,6 +47,20 @@ class ClaudeSpec:
     # Explicit session ID to pass to --resume. Only used when session="resume".
     resume_id: str = ""
     auto_accept: bool = True
+    # Saved-account name (from ``sac account list``) whose credential
+    # snapshot this agent runs on. ``""`` = the host's live
+    # ``~/.claude/.credentials.json`` (current default).
+    #
+    # When set, the runtime COPIES that account's ``.credentials.json``
+    # into the agent's own state dir at start (frozen boot-copy, not a
+    # live bind), so two agents pinned to two accounts never fight one
+    # mount. The copy is bound RW so in-container ~1h token refresh keeps
+    # working on the agent's private copy.
+    #
+    # Takes effect on next start/restart — a host ``/login`` does NOT
+    # move a pinned agent (that is the point of pinning), and changing
+    # this field requires ``sac agent restart`` to re-copy the snapshot.
+    account: str = ""
 
 
 @dataclass

--- a/src/scitex_agent_container/runtimes/_apptainer_creds.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_creds.py
@@ -1,0 +1,71 @@
+"""Per-agent OAuth credential resolution for the apptainer runtime.
+
+Extracted from ``_apptainer_runtime.py`` (512-line cap) — mirrors the
+existing helper-module split (``_apptainer_build``,
+``_apptainer_listen_env``, ``_apptainer_iso_flags``).
+
+The single public entry point :func:`resolve_cred_file` decides WHICH
+host-side ``.credentials.json`` gets bound into an agent container:
+
+* ``spec.claude.account`` empty → the host's live
+  ``~/.claude/.credentials.json`` (shared OAuth — current default).
+* ``spec.claude.account`` set → a FROZEN BOOT-COPY of that saved
+  account's snapshot, copied into the agent's own state dir so two
+  agents pinned to two accounts never fight one mount, and a host
+  ``/login`` never moves a pinned agent.
+
+The copy is bound ``:rw`` by the caller so the in-container Claude CLI
+can refresh the OAuth ``accessToken`` (~1h cadence) on the agent's
+private copy. Changing ``spec.claude.account`` only takes effect on the
+next ``sac agent restart`` (the copy happens at start).
+
+Fail-soft: any resolution / copy hiccup degrades to the host live file
+(with a best-effort warning) so a stale spec never wedges a start.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+from ..config import AgentConfig
+
+
+def resolve_cred_file(config: AgentConfig, state_dir: Path) -> Path | None:
+    """Return the host-side ``.credentials.json`` to bind for ``config``.
+
+    Returns ``None`` only when the chosen file does not exist (caller
+    skips the bind). See module docstring for the full decision table.
+    """
+    host_cred = Path.home() / ".claude" / ".credentials.json"
+    acct = getattr(getattr(config, "claude", None), "account", "") or ""
+    if not acct:
+        return host_cred
+
+    # stx-allow: fallback (reason: account-snapshot copy is the pinning
+    # mechanism; any resolution/copy hiccup degrades to the host live
+    # file so a start is never wedged — the warning surfaces the gap.)
+    try:
+        from .._state.account_store import _store_path
+
+        store = _store_path(None, Path.home())
+        snapshot = store / acct / ".credentials.json"
+        if not snapshot.is_file():
+            import warnings
+
+            warnings.warn(
+                f"spec.claude.account='{acct}' has no snapshot at "
+                f"{snapshot}; falling back to host "
+                "~/.claude/.credentials.json. Create it with "
+                f"`sac account save {acct}` on the credential-holding "
+                "host, then restart this agent.",
+                stacklevel=2,
+            )
+            return host_cred
+
+        dest = Path(state_dir).expanduser() / "claude" / ".credentials.json"
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(snapshot, dest)
+        return dest
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        return host_cred

--- a/src/scitex_agent_container/runtimes/_apptainer_runtime.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_runtime.py
@@ -238,8 +238,18 @@ class ApptainerContainerRuntime(RuntimeBase):
         # a manual scp-from-lead dance to re-seed peers. The CLI's
         # refresh code-path itself is responsible for any concurrency
         # locking — the bind is just a file passthrough.
-        cred_file = Path.home() / ".claude" / ".credentials.json"
-        if cred_file.is_file():
+        # Per-agent OAuth account pinning (spec.claude.account). When set,
+        # we COPY that saved account's .credentials.json into the agent's
+        # own state dir (frozen boot-copy) and bind THAT — so two agents
+        # pinned to two accounts never share one mount, and a host /login
+        # never moves a pinned agent. Changing the assigned account needs
+        # a `sac agent restart` to re-copy. ``account=""`` → host live
+        # file (unchanged behaviour). Bind stays RW so the in-container
+        # CLI can refresh the OAuth token on the agent's private copy.
+        from ._apptainer_creds import resolve_cred_file
+
+        cred_file = resolve_cred_file(config, state_dir)
+        if cred_file is not None and cred_file.is_file():
             argv += [
                 "--bind",
                 f"{cred_file}:/tmp/sac-claude/.credentials.json:rw",

--- a/tests/scitex_agent_container/_account/test_agent_account.py
+++ b/tests/scitex_agent_container/_account/test_agent_account.py
@@ -174,3 +174,68 @@ def test_none_env_inherits_host_account(tmp_path):
     label = resolve_agent_account_label(None, home=tmp_path)
     # Assert
     assert label == "inherited@example.com"
+
+
+# ---------------------------------------------------------------------------
+# 4. Pinned-account branch — spec.claude.account wins over host OAuth.
+# ---------------------------------------------------------------------------
+
+
+def test_assigned_account_returns_name_and_email(tmp_path):
+    # Arrange — agent pinned to a saved account; resolver pulls its email.
+    save_account("alpha", {"email_address": "alpha@example.com"}, home=tmp_path)
+    # Act
+    label = resolve_agent_account_label({}, home=tmp_path, assigned_account="alpha")
+    # Assert
+    assert label == "alpha (alpha@example.com)"
+
+
+def test_assigned_account_overrides_host_oauth_identity(tmp_path):
+    # Arrange — host /login is a DIFFERENT account; the pin must win
+    # because the runtime copies the pinned snapshot in at start.
+    _write_credentials(tmp_path)
+    _write_claude_json(tmp_path, "host@example.com")
+    save_account("beta", {"email_address": "beta@example.com"}, home=tmp_path)
+    # Act
+    label = resolve_agent_account_label({}, home=tmp_path, assigned_account="beta")
+    # Assert
+    assert label == "beta (beta@example.com)"
+
+
+def test_assigned_account_with_no_saved_email_returns_bare_name(tmp_path):
+    # Arrange — saved account exists but has no recorded email.
+    save_account("gamma", {}, home=tmp_path)
+    # Act
+    label = resolve_agent_account_label({}, home=tmp_path, assigned_account="gamma")
+    # Assert
+    assert label == "gamma"
+
+
+def test_assigned_account_missing_snapshot_returns_bare_name(tmp_path):
+    # Arrange — no saved account dir at all; resolver degrades to the
+    # bare assigned name rather than crashing or falling to host OAuth.
+    # Act
+    label = resolve_agent_account_label({}, home=tmp_path, assigned_account="ghost")
+    # Assert
+    assert label == "ghost"
+
+
+def test_assigned_account_wins_over_env_override(tmp_path):
+    # Arrange — both a pin AND an env key are present; the pin (frozen
+    # snapshot copied in at start) is the definitive account.
+    save_account("delta", {"email_address": "delta@example.com"}, home=tmp_path)
+    env = {"SAC_ANTHROPIC_API_KEY": "sk-ant-api03-zzzz9999"}
+    # Act
+    label = resolve_agent_account_label(env, home=tmp_path, assigned_account="delta")
+    # Assert
+    assert label == "delta (delta@example.com)"
+
+
+def test_empty_assigned_account_falls_through_to_host(tmp_path):
+    # Arrange — assigned_account="" must NOT short-circuit; host OAuth wins.
+    _write_credentials(tmp_path)
+    _write_claude_json(tmp_path, "host@example.com")
+    # Act
+    label = resolve_agent_account_label({}, home=tmp_path, assigned_account="")
+    # Assert
+    assert label == "host@example.com"

--- a/tests/scitex_agent_container/_state/test_account_store_plan_usage.py
+++ b/tests/scitex_agent_container/_state/test_account_store_plan_usage.py
@@ -1,0 +1,145 @@
+"""Tests for ``account_store.read_account_plan`` /
+``read_account_usage_cache`` — the OFFLINE plan/tier reader and the
+CACHE-ONLY usage reader that enrich ``sac account list``.
+
+No-mocks: every case writes real ``<acct>/.credentials.json`` /
+``<acct>/usage.json`` snapshots under ``tmp_path`` and reads them back.
+The autouse ``_isolate_home`` fixture pins ``$HOME`` to ``tmp_path`` so
+the store-path cascade resolves under the sandbox.
+
+TQ: module docstring (TQ001); AAA markers (TQ002); descriptive names
+(TQ003); one assert per test (TQ007).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._state.account_store import (
+    read_account_plan,
+    read_account_usage_cache,
+    save_account,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_home(tmp_path: Path):
+    """Pin ``$HOME`` to ``tmp_path`` (PA-306: env save/restore, no mock)."""
+    saved = os.environ.get("HOME")
+    os.environ["HOME"] = str(tmp_path)
+    try:
+        yield
+    finally:
+        if saved is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = saved
+
+
+def _store_dir(home: Path) -> Path:
+    return home / ".scitex" / "agent-container" / "accounts"
+
+
+def _write_snapshot_creds(
+    home: Path, name: str, *, subscription: str, tier: str
+) -> None:
+    """Write a real saved-account ``.credentials.json`` with the two
+    non-secret fields the plan reader whitelists."""
+    save_account(name, {"email_address": f"{name}@x"}, home=home)
+    acct_dir = _store_dir(home) / name
+    (acct_dir / ".credentials.json").write_text(
+        json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "sk-ant-SECRET",
+                    "subscriptionType": subscription,
+                    "rateLimitTier": tier,
+                }
+            }
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# read_account_plan — offline plan/tier from the snapshot
+# ---------------------------------------------------------------------------
+
+
+def test_read_account_plan_derives_max_20x_label(tmp_path: Path) -> None:
+    # Arrange
+    _write_snapshot_creds(
+        tmp_path, "alpha", subscription="max", tier="default_claude_max_20x"
+    )
+    # Act
+    plan = read_account_plan("alpha", home=tmp_path)
+    # Assert
+    assert plan["plan_label"] == "Max 20x"
+
+
+def test_read_account_plan_surfaces_raw_rate_limit_tier(tmp_path: Path) -> None:
+    # Arrange
+    _write_snapshot_creds(
+        tmp_path, "beta", subscription="pro", tier="default_claude_pro"
+    )
+    # Act
+    plan = read_account_plan("beta", home=tmp_path)
+    # Assert
+    assert plan["rate_limit_tier"] == "default_claude_pro"
+
+
+def test_read_account_plan_missing_snapshot_returns_all_none(
+    tmp_path: Path,
+) -> None:
+    # Arrange — account metadata saved but no .credentials.json snapshot.
+    save_account("gamma", {"email_address": "g@x"}, home=tmp_path)
+    # Act
+    plan = read_account_plan("gamma", home=tmp_path)
+    # Assert
+    assert plan == {
+        "subscription_type": None,
+        "rate_limit_tier": None,
+        "plan_label": None,
+    }
+
+
+def test_read_account_plan_unknown_tier_yields_none_label(tmp_path: Path) -> None:
+    # Arrange — a tier string the mapping doesn't know must NOT be
+    # silently bucketed; plan_label stays None, raw value preserved.
+    _write_snapshot_creds(
+        tmp_path, "delta", subscription="enterprise", tier="future_tier_x"
+    )
+    # Act
+    plan = read_account_plan("delta", home=tmp_path)
+    # Assert
+    assert plan["plan_label"] is None
+
+
+# ---------------------------------------------------------------------------
+# read_account_usage_cache — cache-only (None when absent)
+# ---------------------------------------------------------------------------
+
+
+def test_read_account_usage_cache_absent_returns_none(tmp_path: Path) -> None:
+    # Arrange — no usage.json written for this account.
+    save_account("epsilon", {"email_address": "e@x"}, home=tmp_path)
+    # Act
+    usage = read_account_usage_cache("epsilon", home=tmp_path)
+    # Assert
+    assert usage is None
+
+
+def test_read_account_usage_cache_returns_cached_snapshot(tmp_path: Path) -> None:
+    # Arrange — a real per-account usage.json cache exists.
+    save_account("zeta", {"email_address": "z@x"}, home=tmp_path)
+    usage_file = _store_dir(tmp_path) / "zeta" / "usage.json"
+    usage_file.write_text(
+        json.dumps({"used_pct_5h": 42, "used_pct_7d": 7, "as_of": "2026-05-24"})
+    )
+    # Act
+    usage = read_account_usage_cache("zeta", home=tmp_path)
+    # Assert
+    assert usage == {"used_pct_5h": 42, "used_pct_7d": 7, "as_of": "2026-05-24"}

--- a/tests/scitex_agent_container/cli_pkg/test_account_group.py
+++ b/tests/scitex_agent_container/cli_pkg/test_account_group.py
@@ -706,3 +706,79 @@ def test_watch_quota_once_echoes_survival_banner_when_single_account_over_thresh
     result = runner.invoke(account, ["watch-quota", "--once"])
     # Assert
     assert "[SURVIVAL]" in result.output
+
+
+# ---------------------------------------------------------------------------
+# account list — offline plan/tier + cache-only usage enrichment
+# ---------------------------------------------------------------------------
+
+
+def _store_dir(home: Path) -> Path:
+    return home / ".scitex" / "agent-container" / "accounts"
+
+
+def _write_plan_snapshot(home: Path, name: str, *, subscription: str, tier: str):
+    """Write a real account snapshot .credentials.json with the two
+    non-secret plan fields."""
+    save_account(name, {"email_address": f"{name}@x"}, home=home)
+    (_store_dir(home) / name / ".credentials.json").write_text(
+        json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "sk-ant-SECRET",
+                    "subscriptionType": subscription,
+                    "rateLimitTier": tier,
+                }
+            }
+        )
+    )
+
+
+def test_account_list_human_shows_offline_plan_label(sandbox_home):
+    # Arrange
+    _write_plan_snapshot(
+        sandbox_home, "work", subscription="max", tier="default_claude_max_20x"
+    )
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(account, ["list"])
+    # Assert
+    assert "Max 20x" in result.output
+
+
+def test_account_list_human_shows_usage_dash_when_no_cache(sandbox_home):
+    # Arrange — snapshot present, but no per-account usage.json cache.
+    _write_plan_snapshot(
+        sandbox_home, "work", subscription="pro", tier="default_claude_pro"
+    )
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(account, ["list"])
+    # Assert — cache-only usage renders the em-dash placeholder.
+    assert "usage: —" in result.output
+
+
+def test_account_list_json_includes_plan_label(sandbox_home):
+    # Arrange
+    _write_plan_snapshot(
+        sandbox_home, "work", subscription="max", tier="default_claude_max_5x"
+    )
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(account, ["list", "--json"])
+    payload = json.loads(result.output)
+    # Assert
+    assert payload["stored"][0]["plan_label"] == "Max 5x"
+
+
+def test_account_list_json_usage_is_none_when_no_cache(sandbox_home):
+    # Arrange
+    _write_plan_snapshot(
+        sandbox_home, "work", subscription="pro", tier="default_claude_pro"
+    )
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(account, ["list", "--json"])
+    payload = json.loads(result.output)
+    # Assert
+    assert payload["stored"][0]["usage"] is None

--- a/tests/scitex_agent_container/config/_parsers/test__claude.py
+++ b/tests/scitex_agent_container/config/_parsers/test__claude.py
@@ -40,6 +40,7 @@ from scitex_agent_container.config._parsers._claude import parse_claude
         ("continue_max_age_minutes", None),
         ("resume_id", ""),
         ("auto_accept", True),
+        ("account", ""),
         ("raw_options", {}),
     ],
 )
@@ -175,3 +176,26 @@ def test_nested_field_is_surfaced_verbatim(attr, expected):
     result = parse_claude(spec)
     # Assert
     assert getattr(result, attr) == expected
+
+
+# ---------------------------------------------------------------------------
+# spec.claude.account — per-agent OAuth account pin
+# ---------------------------------------------------------------------------
+
+
+def test_account_parsed_from_nested_block():
+    # Arrange
+    spec = {"claude": {"account": "work"}}
+    # Act
+    result = parse_claude(spec)
+    # Assert
+    assert result.account == "work"
+
+
+def test_account_none_coerced_to_empty_string():
+    # Arrange — an explicit null must collapse to the host-live-file default.
+    spec = {"claude": {"account": None}}
+    # Act
+    result = parse_claude(spec)
+    # Assert
+    assert result.account == ""

--- a/tests/scitex_agent_container/config/test__loaders.py
+++ b/tests/scitex_agent_container/config/test__loaders.py
@@ -430,3 +430,51 @@ def test_load_config_v3_multi_host_appends_hostname(tmp_path: Path) -> None:
         _loaders_mod.resolve_hostname = _saved_resolve
     # Assert
     assert cfg.name == "worker-mba"
+
+
+# ---------------------------------------------------------------------------
+# spec.claude.account soft-WARN (missing snapshot warns, never fails)
+# ---------------------------------------------------------------------------
+
+
+def _v3_yaml(tmp_path: Path, name: str, spec_extra: dict) -> Path:
+    spec = {"runtime": "apptainer", "workdir": str(tmp_path / "wd")}
+    spec.update(spec_extra)
+    body = {
+        "apiVersion": "scitex-agent-container/v3",
+        "kind": "Agent",
+        "metadata": {"labels": {"role": "head"}},
+        "spec": spec,
+    }
+    p = tmp_path / name / "spec.yaml"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(yaml.safe_dump(body))
+    return p
+
+
+def test_load_config_warns_when_pinned_account_snapshot_absent(tmp_path: Path):
+    # Arrange — pin an account with no saved snapshot anywhere.
+    p = _v3_yaml(tmp_path, "pinned", {"claude": {"account": "ghost"}})
+    # Act
+    ctx = pytest.warns(UserWarning, match="ghost")
+    # Assert
+    with ctx:
+        load_config(p)
+
+
+def test_load_config_pinned_account_still_loads_despite_missing_snapshot(
+    tmp_path: Path,
+):
+    # Arrange — the soft-WARN must NOT escalate to a load failure. The
+    # warning itself is asserted by the sibling test; here we suppress
+    # it (catch_warnings, not pytest.warns) so the single assertion is
+    # purely "the config loaded with the pin intact".
+    import warnings
+
+    p = _v3_yaml(tmp_path, "pinned", {"claude": {"account": "ghost"}})
+    # Act
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        cfg = load_config(p)
+    # Assert
+    assert cfg.claude.account == "ghost"

--- a/tests/scitex_agent_container/runtimes/test__apptainer_runtime.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_runtime.py
@@ -1118,6 +1118,94 @@ def test_argv_startup_prompts_populates_mission(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Per-agent OAuth account pin (spec.claude.account) — frozen boot-copy
+# ---------------------------------------------------------------------------
+
+
+def _save_snapshot(home: Path, name: str, body: str = '{"snap": true}') -> Path:
+    """Write a real saved-account snapshot under the home's account store
+    and return its ``.credentials.json`` path.
+
+    Mirrors the on-disk layout
+    ``~/.scitex/agent-container/accounts/<name>/.credentials.json`` that
+    ``sac account save`` produces.
+    """
+    acct_dir = home / ".scitex" / "agent-container" / "accounts" / name
+    acct_dir.mkdir(parents=True, exist_ok=True)
+    snap = acct_dir / ".credentials.json"
+    snap.write_text(body)
+    return snap
+
+
+def test_argv_pins_account_binds_state_dir_copy_not_host_file(
+    tmp_path: Path, home_redirect: Path
+) -> None:
+    # Arrange — host live file AND a saved snapshot both exist; the pin
+    # must bind the state-dir copy, never the host file.
+    host_creds = home_redirect / ".claude" / ".credentials.json"
+    host_creds.parent.mkdir(parents=True, exist_ok=True)
+    host_creds.write_text('{"host": true}')
+    _save_snapshot(home_redirect, "alpha")
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    rt = ApptainerContainerRuntime()
+    cfg = _config(tmp_path, claude=ClaudeSpec(account="alpha"))
+    # Act
+    argv = rt.build_run_argv(cfg, state_dir=state_dir, sif_path=tmp_path / "x.sif")
+    creds_arg = next(a for a in argv if "/tmp/sac-claude/.credentials.json" in a)
+    # Assert — the bound host-side path is the per-agent copy, not host.
+    assert creds_arg.startswith(str(state_dir / "claude" / ".credentials.json"))
+
+
+def test_argv_pins_account_copies_snapshot_bytes_into_state_dir(
+    tmp_path: Path, home_redirect: Path
+) -> None:
+    # Arrange — snapshot has distinctive bytes the copy must reproduce.
+    _save_snapshot(home_redirect, "beta", body='{"pinned": "beta-bytes"}')
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    rt = ApptainerContainerRuntime()
+    cfg = _config(tmp_path, claude=ClaudeSpec(account="beta"))
+    # Act
+    rt.build_run_argv(cfg, state_dir=state_dir, sif_path=tmp_path / "x.sif")
+    copied = state_dir / "claude" / ".credentials.json"
+    # Assert — frozen boot-copy landed with the snapshot's contents.
+    assert copied.read_text() == '{"pinned": "beta-bytes"}'
+
+
+def test_argv_no_account_binds_host_live_file(
+    tmp_path: Path, home_redirect: Path
+) -> None:
+    # Arrange — account="" (default) keeps the legacy host-file bind.
+    host_creds = home_redirect / ".claude" / ".credentials.json"
+    host_creds.parent.mkdir(parents=True, exist_ok=True)
+    host_creds.write_text("{}")
+    rt = ApptainerContainerRuntime()
+    cfg = _config(tmp_path, claude=ClaudeSpec(account=""))
+    # Act
+    argv = rt.build_run_argv(cfg, state_dir=tmp_path, sif_path=tmp_path / "x.sif")
+    creds_arg = next(a for a in argv if "/tmp/sac-claude/.credentials.json" in a)
+    # Assert
+    assert creds_arg.startswith(str(host_creds))
+
+
+def test_argv_pinned_account_missing_snapshot_falls_back_to_host(
+    tmp_path: Path, home_redirect: Path
+) -> None:
+    # Arrange — pin names an account with NO snapshot; host file exists.
+    host_creds = home_redirect / ".claude" / ".credentials.json"
+    host_creds.parent.mkdir(parents=True, exist_ok=True)
+    host_creds.write_text("{}")
+    rt = ApptainerContainerRuntime()
+    cfg = _config(tmp_path, claude=ClaudeSpec(account="ghost"))
+    # Act — fail-soft fallback (warns; never wedges the start).
+    argv = rt.build_run_argv(cfg, state_dir=tmp_path, sif_path=tmp_path / "x.sif")
+    creds_arg = next(a for a in argv if "/tmp/sac-claude/.credentials.json" in a)
+    # Assert
+    assert creds_arg.startswith(str(host_creds))
+
+
+# ---------------------------------------------------------------------------
 # Lifecycle — start / stop / is_running / logs (real subprocesses)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

Adds `spec.claude.account` — pins an agent to a specific saved Anthropic
OAuth account (from `sac account list`). This is the multi-account
load-balance enabler: agents pinned to distinct accounts no longer
collide on one server-side rate limit (429).

## Mechanism — frozen boot-copy (not a live bind)

When `spec.claude.account` is set, the apptainer runtime **copies** that
account's `.credentials.json` snapshot into the agent's own state dir
(`<state_dir>/claude/.credentials.json`) at start and binds the copy
`:rw`. So:

- Two agents on two accounts never fight one shared mount.
- A host `/login` does **not** move a pinned agent (that's the point).
- The `:rw` copy keeps in-container ~1h token refresh working.
- `account=""` (default) → host live `~/.claude/.credentials.json`, unchanged.

**Changing the assignment requires `sac agent restart`** (the copy
happens at start). A missing snapshot is fail-soft: warns and falls
back to the host file rather than wedging the start.

## Parts

1. **Field + parse**: `ClaudeSpec.account` (`config/_types.py`,
   `_parsers/_claude.py`) + a load-time soft-WARN (`config/__init__.py`)
   when the named snapshot is absent — never fails the load.
2. **Frozen copy**: `runtimes/_apptainer_creds.resolve_cred_file`
   (extracted into its own module to keep `_apptainer_runtime.py` under
   the 512-line cap, mirroring the existing `_apptainer_build` /
   `_apptainer_listen_env` split).
3. **Accurate display**: `resolve_agent_account_label(..., assigned_account=)`
   — a pinned agent shows `<name> (<email>)` regardless of the host's
   current `/login`. Threaded through `agent list` + `agent status`.
4. **`account list` enrichment**: OFFLINE plan/tier (Pro / Max 5x /
   Max 20x, read from each snapshot's whitelisted `subscriptionType` /
   `rateLimitTier`) for all stored accounts; CACHE-ONLY usage (`—`
   until a per-account `usage.json` cache exists — no synchronous
   network call in `list`). New readers `read_account_plan` /
   `read_account_usage_cache` in `_state/account_store.py`.
5. **sdk-test fix**: migrate the bundled spec off removed v3 top-level
   fields (`runtime: docker→apptainer`; `image`/`model` under their
   engine blocks; dropped `dockerfile`).

## Tests (real fixtures, no mocks)

- Resolver `assigned_account` branch (pin wins over host OAuth + env key;
  bare-name fallback when no email / no snapshot).
- Frozen-copy staging: bound path is the per-agent copy, snapshot bytes
  land in the state dir, `account=""` binds host file, missing snapshot
  falls back to host.
- `read_account_plan` / `read_account_usage_cache` (offline plan label,
  raw tier, all-None on missing snapshot, cache-only usage).
- `account list` enrichment (human + `--json`).
- Loader soft-WARN (warns on missing snapshot; still loads).
- Parser default + explicit-account.

307 targeted tests pass; zero lint errors on all changed files.

## Test plan
- [x] `pytest tests/scitex_agent_container/{_account,config,_state,cli_pkg,runtimes}` — green
- [x] `scitex-dev linter check-files` — zero errors on every changed file
- [x] sdk-test spec validates + loads under v3