### PR TITLE
feat(account): credential auto-sync substrate (sync-live / watch-live)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- **feat(account): credential auto-sync substrate (`sac accounts
+  sync-live` / `watch-live`)** — keep the per-account store fresh the
+  moment the operator runs `claude /login`, with zero manual `sac
+  accounts save`. `sync-live` reads the live `~/.claude/.credentials.json`
+  + the active email from `~/.claude.json`, derives the store-name
+  (email slugified, e.g. `ywatanabe@scitex.ai` → `ywatanabe-scitex-ai`),
+  and atomically snapshots the live cred in when the matching store is
+  absent / older / expired (idempotent no-op otherwise). `watch-live`
+  is the always-on daemon: watches the live credential (inotify via
+  `inotifywait` when available, else a poll loop) and runs the engine on
+  every change, logging each sync to stderr or
+  `~/.scitex/agent-container/runtime/logs/creds-watch.log`. New
+  `_account/creds_sync.py` (engine) + `_account/creds_watch.py`
+  (watcher).
+- **feat(account): `sac accounts list` credential-freshness column** —
+  every stored account now shows `VALID (+Xh)` / `EXPIRED (-Xh)` /
+  `ABSENT` read OFFLINE from the snapshot's `expiresAt`, so rotted
+  stores are visible at a glance. The `--json` output gains `freshness`
+  and `freshness_hours` fields. New `_account/creds_sync.account_freshness`.
+
+### Fixed
+- **fix(account): pinned-account credential resolution now fails loud**
+  — when `spec.claude.account` names a store that is ABSENT or its
+  credential is EXPIRED, `sac agents start` now aborts with
+  `PinnedAccountError` carrying the exact remedy (`claude /login` to
+  that account + `sac accounts sync-live`). Previously it silently fell
+  back to the host live file (a *different* account) or launched with a
+  stale token — handing the agent the wrong identity. A pinned agent
+  must never silently fall back. (`runtimes/_apptainer_creds.py`)
+
 ## [0.20.0] — 2026-05-24
 
 ### Added

--- a/src/scitex_agent_container/_account/creds_sync.py
+++ b/src/scitex_agent_container/_account/creds_sync.py
@@ -1,0 +1,305 @@
+"""Credential auto-sync engine: mirror the live Claude OAuth into the store.
+
+The moment the operator runs ``claude /login`` to an account, the live
+``~/.claude/.credentials.json`` is replaced with that account's fresh
+OAuth bundle. Nothing re-saves it into the sac per-account store
+(``~/.scitex/agent-container/accounts/<slug>/.credentials.json``), so
+stores rot — the operator must remember a manual ``sac accounts save``.
+
+This module is the one-shot engine behind ``sac accounts sync-live``:
+it reads the live credential + the active account's email, and — when
+the live cred is VALID and newer/fresher than the matching store —
+atomically snapshots it into that store. It is idempotent: a store
+that already matches or is newer than the live cred is a no-op.
+
+Fail-loud contract (no silent fallbacks): an EXPIRED or ABSENT live
+credential is a hard error (:class:`LiveCredInvalidError`), never a
+silent save of a stale token.
+
+Pure stdlib. No network call. The store-name is the account email
+slugified (``wyusuuke@gmail.com`` → ``wyusuuke-gmail-com``), matching
+the layout the rest of sac already uses on disk.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+
+class LiveCredInvalidError(RuntimeError):
+    """Raised when the live credential is absent, malformed, or expired.
+
+    The message names the live path and tells the operator how to fix
+    it (``claude /login``). Surfaced as a non-zero CLI exit so the
+    operator never mistakes a stale token for a successful sync.
+    """
+
+
+@dataclass(frozen=True)
+class SyncResult:
+    """Outcome of one :func:`sync_live` run.
+
+    Attributes
+    ----------
+    action
+        One of ``"saved"`` (store written), ``"up-to-date"`` (store
+        already matched/newer — no write).
+    store_name
+        Slugified store directory name the live cred maps to.
+    email
+        Active-account email read from ``~/.claude.json``.
+    live_expires_at
+        Live credential expiry, unix seconds.
+    store_expires_at
+        Prior store expiry (unix seconds), or ``None`` when the store
+        was absent / unreadable before this run.
+    """
+
+    action: str
+    store_name: str
+    email: str
+    live_expires_at: float
+    store_expires_at: float | None
+
+
+def slugify_email(email: str) -> str:
+    """Map an account email to its on-disk store-name.
+
+    ``@`` and ``.`` collapse to ``-`` and the result is lower-cased,
+    matching the existing layout (``wyusuuke@gmail.com`` →
+    ``wyusuuke-gmail-com``, ``ywatanabe@scitex.ai`` →
+    ``ywatanabe-scitex-ai``).
+    """
+    return email.strip().lower().replace("@", "-").replace(".", "-")
+
+
+def _read_oauth_expiry_seconds(path: Path) -> float | None:
+    """Return the OAuth ``expiresAt`` of ``path`` in unix seconds, or None.
+
+    ``None`` when the file is missing, unparseable, or lacks a numeric
+    ``claudeAiOauth.expiresAt``. claude-code writes ``expiresAt`` as a
+    unix-MILLISECOND integer; any value above ``1e12`` is treated as
+    milliseconds and divided by 1000 (matching ``_preflight_creds``).
+    Never raises.
+    """
+    # stx-allow: fallback (reason: store-snapshot freshness probe is
+    # best-effort; a missing/corrupt snapshot must read as "no expiry"
+    # (None) so callers treat it as stale/absent, never crash the sync.)
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    oauth = data.get("claudeAiOauth")
+    if not isinstance(oauth, dict):
+        return None
+    raw = oauth.get("expiresAt")
+    if not isinstance(raw, (int, float)) or isinstance(raw, bool):
+        return None
+    val = float(raw)
+    return val / 1000.0 if val > 1e12 else val
+
+
+def _read_active_email(home: Path) -> str | None:
+    """Return the active-account email from ``~/.claude.json``, or None.
+
+    Reads ``oauthAccount.emailAddress``. ``None`` when the file is
+    missing, unparseable, or lacks the field. Never raises.
+    """
+    # stx-allow: fallback (reason: ~/.claude.json may be absent or
+    # mid-rewrite by claude-code; a missing email maps to None so the
+    # caller raises a clear "cannot determine account" error rather than
+    # crashing on a transient read.)
+    try:
+        data = json.loads((home / ".claude.json").read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    oauth = data.get("oauthAccount")
+    if not isinstance(oauth, dict):
+        return None
+    email = oauth.get("emailAddress")
+    if isinstance(email, str) and email.strip():
+        return email.strip()
+    return None
+
+
+def _atomic_copy(src: Path, dst: Path) -> None:
+    """Copy ``src`` to ``dst`` atomically (tmp + rename, preserves mode)."""
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dst.with_suffix(dst.suffix + ".tmp")
+    shutil.copy2(src, tmp)
+    tmp.replace(dst)
+
+
+def sync_live(
+    home: Path | None = None,
+    store_dir: Path | None = None,
+    *,
+    now: float | None = None,
+) -> SyncResult:
+    """Mirror the live credential into its matching store when warranted.
+
+    Reads the live ``~/.claude/.credentials.json`` and the active email
+    from ``~/.claude.json``. The live cred must be VALID (``expiresAt``
+    strictly in the future) — otherwise :class:`LiveCredInvalidError`.
+    Derives the store-name from the email; if the store is ABSENT, OR
+    its snapshot is OLDER (earlier ``expiresAt``) than the live cred,
+    OR the store snapshot is itself expired, the live cred is
+    atomically snapshotted in and the account metadata refreshed.
+
+    Idempotent: when the store snapshot already has an ``expiresAt`` >=
+    the live cred's, returns ``action="up-to-date"`` without writing.
+
+    Parameters
+    ----------
+    home
+        Override for the user home (tests pass ``tmp_path``). Defaults
+        to ``Path.home()``.
+    store_dir
+        Override for the accounts store root. Defaults to the
+        ``account_store`` cascade.
+    now
+        Override for the wall clock (unix seconds). Defaults to
+        ``time.time()``.
+
+    Returns
+    -------
+    SyncResult
+        Describing what happened (``saved`` / ``up-to-date``).
+
+    Raises
+    ------
+    LiveCredInvalidError
+        When the live credential is absent, malformed, expired, or the
+        active email cannot be determined. The message tells the
+        operator to ``claude /login``.
+    """
+    _home = home or Path.home()
+    now_ts = now if now is not None else time.time()
+
+    live_path = _home / ".claude" / ".credentials.json"
+    if not live_path.is_file():
+        raise LiveCredInvalidError(
+            f"live credential not found at {live_path!s}. "
+            "Run `claude /login` to create it."
+        )
+
+    live_expiry = _read_oauth_expiry_seconds(live_path)
+    if live_expiry is None:
+        raise LiveCredInvalidError(
+            f"live credential at {live_path!s} is missing a numeric "
+            "`claudeAiOauth.expiresAt`. Run `claude /login` to regenerate it."
+        )
+    if live_expiry <= now_ts:
+        ago = int(now_ts - live_expiry)
+        raise LiveCredInvalidError(
+            f"live credential at {live_path!s} expired {ago} seconds ago; "
+            "refusing to sync a stale token. Run `claude /login` to refresh."
+        )
+
+    email = _read_active_email(_home)
+    if email is None:
+        raise LiveCredInvalidError(
+            f"cannot determine the active account email from "
+            f"{(_home / '.claude.json')!s} (missing "
+            "`oauthAccount.emailAddress`). Run `claude /login`."
+        )
+
+    store_name = slugify_email(email)
+
+    from .._state.account_store import _store_path, save_account
+
+    store = _store_path(store_dir, _home)
+    snapshot = store / store_name / ".credentials.json"
+    store_expiry = _read_oauth_expiry_seconds(snapshot) if snapshot.is_file() else None
+
+    # Idempotent: store already matches or is fresher than live → no-op.
+    if store_expiry is not None and store_expiry >= live_expiry:
+        return SyncResult(
+            action="up-to-date",
+            store_name=store_name,
+            email=email,
+            live_expires_at=live_expiry,
+            store_expires_at=store_expiry,
+        )
+
+    _atomic_copy(live_path, snapshot)
+    # Refresh the safe metadata (email label) so `account list` resolves
+    # the email even for a store created purely by auto-sync.
+    save_account(store_name, {"email_address": email}, store_dir=store_dir, home=_home)
+
+    return SyncResult(
+        action="saved",
+        store_name=store_name,
+        email=email,
+        live_expires_at=live_expiry,
+        store_expires_at=store_expiry,
+    )
+
+
+@dataclass(frozen=True)
+class Freshness:
+    """Freshness of a single stored account's credential snapshot.
+
+    Attributes
+    ----------
+    state
+        ``"VALID"``, ``"EXPIRED"``, or ``"ABSENT"``.
+    hours
+        Signed hours to expiry (positive = remaining, negative = past)
+        for VALID/EXPIRED; ``None`` for ABSENT.
+    """
+
+    state: str
+    hours: float | None
+
+    def label(self) -> str:
+        """Render the column cell: ``VALID (+5.7h)`` / ``EXPIRED (-138.6h)`` / ``ABSENT``."""
+        if self.state == "ABSENT" or self.hours is None:
+            return "ABSENT"
+        return f"{self.state} ({self.hours:+.1f}h)"
+
+
+def account_freshness(
+    name: str,
+    store_dir: Path | None = None,
+    home: Path | None = None,
+    *,
+    now: float | None = None,
+) -> Freshness:
+    """Return the credential freshness of stored account ``name``.
+
+    Reads ``<store>/<name>/.credentials.json`` and compares its
+    ``expiresAt`` to ``now``. Never raises — an absent/corrupt snapshot
+    reads as :class:`Freshness` ``ABSENT``.
+    """
+    _home = home or Path.home()
+    now_ts = now if now is not None else time.time()
+
+    from .._state.account_store import _store_path
+
+    store = _store_path(store_dir, _home)
+    snapshot = store / name / ".credentials.json"
+    expiry = _read_oauth_expiry_seconds(snapshot) if snapshot.is_file() else None
+    if expiry is None:
+        return Freshness(state="ABSENT", hours=None)
+    hours = (expiry - now_ts) / 3600.0
+    state = "VALID" if expiry > now_ts else "EXPIRED"
+    return Freshness(state=state, hours=hours)
+
+
+__all__ = [
+    "Freshness",
+    "LiveCredInvalidError",
+    "SyncResult",
+    "account_freshness",
+    "slugify_email",
+    "sync_live",
+]

--- a/src/scitex_agent_container/_account/creds_watch.py
+++ b/src/scitex_agent_container/_account/creds_watch.py
@@ -1,0 +1,235 @@
+"""Watch the live Claude credential and auto-sync on every change.
+
+This is the "moment I log in → auto-saved" mechanism behind
+``sac accounts watch-live``. It watches ``~/.claude/.credentials.json``
+and runs the :func:`creds_sync.sync_live` engine whenever the file
+changes (a ``claude /login`` rewrite, or claude-code's ~1h OAuth
+refresh).
+
+Two watch backends, picked at runtime:
+
+* **inotify** via the ``inotifywait`` binary when it is on ``$PATH`` —
+  event-driven, zero idle CPU.
+* **poll** fallback otherwise — stat the file's ``mtime``/``size`` on a
+  short interval.
+
+Both call the same engine, so behaviour is identical; only the
+wake-up mechanism differs. Each sync attempt is logged (stderr by
+default, or a log file under
+``~/.scitex/agent-container/runtime/logs/``). A
+:class:`creds_sync.LiveCredInvalidError` during a sync is logged and
+the watcher keeps running — a transient expired/mid-rewrite state must
+not kill the long-lived daemon.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable, TextIO
+
+from .creds_sync import LiveCredInvalidError, sync_live
+
+# Poll cadence for the fallback loop. Short enough that a /login is
+# mirrored within a couple seconds; long enough to be near-zero CPU.
+DEFAULT_POLL_INTERVAL_S = 2.0
+
+
+def default_log_path(home: Path | None = None) -> Path:
+    """Return the canonical watch-live log file path.
+
+    ``~/.scitex/agent-container/runtime/logs/creds-watch.log`` — the
+    runtime/logs dir is the documented home for daemon logs.
+    """
+    _home = home or Path.home()
+    return (
+        _home / ".scitex" / "agent-container" / "runtime" / "logs" / "creds-watch.log"
+    )
+
+
+def _emit(stream: TextIO, message: str) -> None:
+    """Write one timestamped line to ``stream`` and flush."""
+    ts = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    stream.write(f"{ts} {message}\n")
+    stream.flush()
+
+
+def run_sync_once(
+    log: TextIO,
+    home: Path | None = None,
+    store_dir: Path | None = None,
+    *,
+    now: float | None = None,
+) -> None:
+    """Run one :func:`sync_live` and log the outcome to ``log``.
+
+    A :class:`LiveCredInvalidError` is logged (not raised) so the
+    surrounding watch loop survives a transient invalid/expired live
+    cred. Any other exception is logged and re-raised — a programming
+    bug should not be silently swallowed.
+    """
+    try:
+        result = sync_live(home=home, store_dir=store_dir, now=now)
+    except LiveCredInvalidError as exc:
+        _emit(log, f"live-cred-invalid: {exc}")
+        return
+    if result.action == "saved":
+        _emit(
+            log,
+            f"saved {result.store_name} (email={result.email}, "
+            f"expires_at={result.live_expires_at:.0f})",
+        )
+    else:
+        _emit(log, f"up-to-date {result.store_name} (email={result.email})")
+
+
+def _signature(path: Path) -> tuple[float, int] | None:
+    """Return ``(mtime, size)`` of ``path``, or ``None`` if absent."""
+    try:
+        st = path.stat()
+    except OSError:  # stx-allow: fallback (reason: file may not exist yet — None signals "no live cred", caller treats it as unchanged-absent)
+        return None
+    return (st.st_mtime, st.st_size)
+
+
+def watch_poll(
+    log: TextIO,
+    home: Path | None = None,
+    store_dir: Path | None = None,
+    *,
+    interval: float = DEFAULT_POLL_INTERVAL_S,
+    iterations: int | None = None,
+    sleep_fn: Callable[[float], None] = time.sleep,
+) -> None:
+    """Poll the live credential and sync on every change.
+
+    Runs an initial sync, then watches the file signature
+    (``mtime``+``size``) every ``interval`` seconds, syncing whenever it
+    changes. ``iterations`` caps the number of poll cycles (``None`` =
+    forever); the cap makes the loop smoke-testable against a tmp file.
+    ``sleep_fn`` is injected so a test can drive the loop without real
+    sleeps.
+    """
+    _home = home or Path.home()
+    live = _home / ".claude" / ".credentials.json"
+
+    _emit(log, f"watch-live poll started (interval={interval}s, path={live})")
+    run_sync_once(log, home=home, store_dir=store_dir)
+    last = _signature(live)
+
+    count = 0
+    while iterations is None or count < iterations:
+        sleep_fn(interval)
+        count += 1
+        sig = _signature(live)
+        if sig != last:
+            _emit(log, "change detected")
+            run_sync_once(log, home=home, store_dir=store_dir)
+            last = sig
+
+
+def _inotify_available() -> bool:
+    """True when the ``inotifywait`` binary is on ``$PATH``."""
+    return shutil.which("inotifywait") is not None
+
+
+def watch_inotify(
+    log: TextIO,
+    home: Path | None = None,
+    store_dir: Path | None = None,
+) -> None:
+    """Watch the live credential via ``inotifywait`` and sync on changes.
+
+    Blocks on ``inotifywait -m`` and runs the engine on every
+    close-write / move-in event against the credential file. Requires
+    ``inotifywait`` on ``$PATH`` (caller checks via
+    :func:`_inotify_available`). The credential parent dir is watched
+    (not the file directly) so atomic-rename writes — claude-code's
+    ``tmp`` + rename — still fire an event.
+    """
+    _home = home or Path.home()
+    live = _home / ".claude" / ".credentials.json"
+    watch_dir = live.parent
+
+    _emit(log, f"watch-live inotify started (path={live})")
+    run_sync_once(log, home=home, store_dir=store_dir)
+
+    proc = subprocess.Popen(
+        [
+            "inotifywait",
+            "-m",
+            "-e",
+            "close_write",
+            "-e",
+            "moved_to",
+            "-e",
+            "create",
+            "--format",
+            "%f",
+            str(watch_dir),
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+    try:
+        assert proc.stdout is not None
+        for line in proc.stdout:
+            if line.strip() == live.name:
+                _emit(log, "change detected")
+                run_sync_once(log, home=home, store_dir=store_dir)
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:  # stx-allow: fallback (reason: best-effort shutdown of the watcher subprocess; escalate to kill so the daemon exit never hangs)
+            proc.kill()
+
+
+def run_watch(
+    home: Path | None = None,
+    store_dir: Path | None = None,
+    *,
+    log_path: Path | None = None,
+    interval: float = DEFAULT_POLL_INTERVAL_S,
+    prefer_inotify: bool = True,
+) -> None:
+    """Start the watch-live daemon, choosing inotify or poll automatically.
+
+    Opens the log sink (``log_path`` file, or stderr when ``None``),
+    then dispatches to :func:`watch_inotify` when ``inotifywait`` is
+    available and ``prefer_inotify`` is set, else :func:`watch_poll`.
+    Blocks until the process is signalled.
+    """
+    if log_path is not None:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log: TextIO = log_path.open("a", encoding="utf-8")
+        close_log = True
+    else:
+        log = sys.stderr
+        close_log = False
+
+    try:
+        if prefer_inotify and _inotify_available():
+            watch_inotify(log, home=home, store_dir=store_dir)
+        else:
+            if prefer_inotify:
+                _emit(log, "inotifywait not found; falling back to poll")
+            watch_poll(log, home=home, store_dir=store_dir, interval=interval)
+    finally:
+        if close_log:
+            log.close()
+
+
+__all__ = [
+    "DEFAULT_POLL_INTERVAL_S",
+    "default_log_path",
+    "run_sync_once",
+    "run_watch",
+    "watch_inotify",
+    "watch_poll",
+]

--- a/src/scitex_agent_container/_skills/scitex-agent-container/04_cli-reference.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/04_cli-reference.md
@@ -66,8 +66,10 @@ sac image switch X
 
 | Command | Purpose |
 |---|---|
-| `sac accounts list` | Stored Claude Code accounts + the active credentials block. |
+| `sac accounts list` | Stored Claude Code accounts + active block; per-store freshness column (`VALID (+Xh)` / `EXPIRED (-Xh)` / `ABSENT`). |
 | `sac accounts save <name>` | Snapshot current credentials under `<name>` for later rotation. |
+| `sac accounts sync-live` | Snapshot the live credential into its matching store (store-name = email slugified). Idempotent; fails loud on an expired/absent live cred (never saves a stale token). |
+| `sac accounts watch-live` | Daemon: watch `~/.claude/.credentials.json` (inotify or poll) and auto-run `sync-live` on every change — "the moment I log in → auto-saved". |
 | `sac accounts switch <name>` | Switch active credentials to a stored account. |
 | `sac accounts delete <name>` | Remove a stored account. |
 | `sac accounts status` | One-shot quota snapshot (5h%, 7d%, account email + tier). |

--- a/src/scitex_agent_container/_skills/scitex-agent-container/10_cli.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/10_cli.md
@@ -87,8 +87,10 @@ sac host probe-hub               # Probe WSL → fleet-hub connectivity (DNS, ga
 ## Operational tools
 
 ```bash
-sac accounts list                     # Stored Claude Code accounts + the active one
+sac accounts list                     # Stored accounts + active one + freshness column
 sac accounts save <name>              # Snapshot current credentials for rotation
+sac accounts sync-live                # Mirror the live credential into its matching store (idempotent; fails loud on stale/absent)
+sac accounts watch-live               # Daemon: auto-sync the moment `claude /login` rewrites the live credential
 sac accounts switch <name>            # Switch active credentials
 sac accounts watch-quota              # Monitor quota and auto-rotate credentials
 sac db clean                          # Sweep dead instances from state.db

--- a/src/scitex_agent_container/cli_pkg/_account_sync_live.py
+++ b/src/scitex_agent_container/cli_pkg/_account_sync_live.py
@@ -1,0 +1,149 @@
+"""``sac accounts sync-live`` and ``watch-live`` click commands.
+
+Extracted from ``account_group.py`` to keep that file under the
+per-file line cap. The credential auto-sync substrate (engine in
+``_account.creds_sync``, watcher in ``_account.creds_watch``) is a
+cohesive concern; its two CLI faces live here and are attached onto the
+``account`` group via :func:`register_sync_live_commands`.
+"""
+
+from __future__ import annotations
+
+import click
+
+
+@click.command("sync-live")
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Emit a JSON object describing what happened.",
+)
+def account_sync_live(as_json: bool) -> None:
+    """Snapshot the live credential into its matching account store.
+
+    Reads the live ``~/.claude/.credentials.json`` + the active email
+    from ``~/.claude.json``, derives the store-name (email slugified),
+    and snapshots the live cred in when the store is absent / older /
+    expired. Idempotent — a no-op when the store already matches.
+
+    Fails loud (non-zero exit) when the live credential is absent,
+    malformed, or expired — never saves a stale token.
+
+    \b
+    Examples:
+      $ sac accounts sync-live
+      $ sac accounts sync-live --json
+    """
+    import json as _json
+
+    from .._account.creds_sync import LiveCredInvalidError, sync_live
+
+    try:
+        result = sync_live()
+    except LiveCredInvalidError as exc:
+        if as_json:
+            click.echo(
+                _json.dumps(
+                    {"action": "live-cred-invalid", "error": str(exc)},
+                    ensure_ascii=False,
+                )
+            )
+        else:
+            click.echo(f"Error: {exc}", err=True)
+        raise SystemExit(1)
+
+    if as_json:
+        click.echo(
+            _json.dumps(
+                {
+                    "action": result.action,
+                    "store_name": result.store_name,
+                    "email": result.email,
+                    "live_expires_at": result.live_expires_at,
+                    "store_expires_at": result.store_expires_at,
+                },
+                ensure_ascii=False,
+            )
+        )
+        return
+    if result.action == "saved":
+        click.echo(
+            f"Saved live credential into store '{result.store_name}' "
+            f"(email={result.email})."
+        )
+    else:
+        click.echo(
+            f"Store '{result.store_name}' already up-to-date (email={result.email})."
+        )
+
+
+@click.command("watch-live")
+@click.option(
+    "--interval",
+    default=None,
+    type=float,
+    show_default=False,
+    help=(
+        "Poll interval in seconds for the fallback loop "
+        "(default: 2.0; ignored when inotifywait is available)."
+    ),
+)
+@click.option(
+    "--poll",
+    "force_poll",
+    is_flag=True,
+    default=False,
+    help="Force the poll loop even when inotifywait is on PATH.",
+)
+@click.option(
+    "--log-file",
+    default=None,
+    help=(
+        "Log sync attempts to this file (default: stderr). "
+        "Canonical: ~/.scitex/agent-container/runtime/logs/creds-watch.log."
+    ),
+)
+def account_watch_live(
+    interval: float | None,
+    force_poll: bool,
+    log_file: str | None,
+) -> None:
+    """Watch the live credential and auto-sync on every change.
+
+    The "moment I log in -> auto-saved" daemon. Watches
+    ``~/.claude/.credentials.json`` (inotify when ``inotifywait`` is
+    available, else a poll loop) and runs ``sync-live`` on every change.
+    Safe to run as a long-lived background process; a transient
+    expired/mid-rewrite live cred is logged and the watcher keeps going.
+
+    \b
+    Examples:
+      $ sac accounts watch-live
+      $ sac accounts watch-live --poll --interval 1
+      $ sac accounts watch-live --log-file ~/.scitex/agent-container/runtime/logs/creds-watch.log
+    """
+    from pathlib import Path
+
+    from .._account.creds_watch import DEFAULT_POLL_INTERVAL_S, run_watch
+
+    log_path = Path(log_file).expanduser() if log_file else None
+    run_watch(
+        log_path=log_path,
+        interval=interval if interval is not None else DEFAULT_POLL_INTERVAL_S,
+        prefer_inotify=not force_poll,
+    )
+
+
+def register_sync_live_commands(group: click.Group) -> None:
+    """Attach ``sync-live`` and ``watch-live`` onto the ``account`` group."""
+    group.add_command(account_sync_live)
+    group.add_command(account_watch_live)
+
+
+__all__ = [
+    "account_sync_live",
+    "account_watch_live",
+    "register_sync_live_commands",
+]

--- a/src/scitex_agent_container/cli_pkg/account_group.py
+++ b/src/scitex_agent_container/cli_pkg/account_group.py
@@ -18,6 +18,14 @@ def account() -> None:
     """Manage stored Claude Code accounts for credential rotation."""
 
 
+# Credential auto-sync substrate (sync-live / watch-live) lives in its
+# own module to keep this file under the per-file line cap; attach its
+# commands onto the group at import time.
+from ._account_sync_live import register_sync_live_commands
+
+register_sync_live_commands(account)
+
+
 @account.command("save")
 @click.argument("name")
 @click.option(
@@ -114,6 +122,7 @@ def account_list(as_json: bool) -> None:
     import json as _json
 
     from .._account.credentials import read_credentials_metadata
+    from .._account.creds_sync import account_freshness
     from .._state.account_store import (
         list_accounts,
         read_account_plan,
@@ -130,12 +139,16 @@ def account_list(as_json: bool) -> None:
             active = read_credentials_metadata()
         except (OSError, _json.JSONDecodeError):
             active = {}
-        # Enrich each stored account with OFFLINE plan/tier and any
+        # Enrich each stored account with OFFLINE plan/tier, credential
+        # FRESHNESS (VALID/EXPIRED/ABSENT + signed hours), and any
         # CACHE-ONLY usage snapshot (None when no cache exists yet).
         stored = []
         for acct in accounts:
             entry = dict(acct)
             entry.update(read_account_plan(acct["name"]))
+            fresh = account_freshness(acct["name"])
+            entry["freshness"] = fresh.state
+            entry["freshness_hours"] = fresh.hours
             entry["usage"] = read_account_usage_cache(acct["name"])
             stored.append(entry)
         click.echo(
@@ -170,6 +183,11 @@ def account_list(as_json: bool) -> None:
         plan = read_account_plan(name)
         plan_label = plan.get("plan_label") or "?"
         tier = plan.get("rate_limit_tier") or "?"
+        # OFFLINE credential freshness from the snapshot's expiresAt —
+        # VALID (+Xh) / EXPIRED (-Xh) / ABSENT. The signal that tells the
+        # operator at a glance which stores have rotted and need a
+        # `sac accounts sync-live` (or a `claude /login`).
+        fresh = account_freshness(name).label()
         # CACHE-ONLY usage (5h/7d). "—" when no cache exists; nothing
         # writes the per-account cache yet (see read_account_usage_cache).
         usage = read_account_usage_cache(name)
@@ -180,7 +198,8 @@ def account_list(as_json: bool) -> None:
             as_of = usage.get("as_of") or usage.get("timestamp") or "?"
             usage_str = f"5h={pct5}% 7d={pct7}% (as of {as_of})"
         click.echo(
-            f"  {name:20s}  {email:28s}  {plan_label} [{tier}]  usage: {usage_str}"
+            f"  {name:20s}  {email:28s}  {plan_label} [{tier}]  "
+            f"{fresh:18s}  usage: {usage_str}"
         )
 
 

--- a/src/scitex_agent_container/runtimes/_apptainer_creds.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_creds.py
@@ -19,53 +19,91 @@ can refresh the OAuth ``accessToken`` (~1h cadence) on the agent's
 private copy. Changing ``spec.claude.account`` only takes effect on the
 next ``sac agent restart`` (the copy happens at start).
 
-Fail-soft: any resolution / copy hiccup degrades to the host live file
-(with a best-effort warning) so a stale spec never wedges a start.
+Fail-loud (no silent fallbacks): when ``spec.claude.account`` is set
+but the pinned store is ABSENT or EXPIRED, the start aborts with
+:class:`PinnedAccountError` carrying the exact remedy. A pinned agent
+must NEVER silently fall back to the host live file (a different
+account) or run with a stale token — that would defeat the whole point
+of account pinning and hand the agent the wrong identity.
 """
 
 from __future__ import annotations
 
 import shutil
+import time
 from pathlib import Path
 
 from ..config import AgentConfig
 
 
-def resolve_cred_file(config: AgentConfig, state_dir: Path) -> Path | None:
+class PinnedAccountError(RuntimeError):
+    """Raised when ``spec.claude.account`` points at an absent/expired store.
+
+    The message names the store path and the two remedies:
+    ``claude /login`` to that account (then ``sac accounts sync-live``),
+    or ``sac accounts save <name>`` on the credential-holding host.
+    Surfaced at ``sac agents start`` so a pinned agent never launches
+    with the wrong account or a dead token.
+    """
+
+
+def resolve_cred_file(
+    config: AgentConfig,
+    state_dir: Path,
+    *,
+    now: float | None = None,
+) -> Path | None:
     """Return the host-side ``.credentials.json`` to bind for ``config``.
 
-    Returns ``None`` only when the chosen file does not exist (caller
-    skips the bind). See module docstring for the full decision table.
+    With no ``spec.claude.account`` set, returns the host live file
+    (``None`` only when it does not exist — caller skips the bind).
+
+    With ``spec.claude.account`` set, returns a frozen boot-copy of that
+    store's snapshot. Raises :class:`PinnedAccountError` when the store
+    is absent or its credential is already expired — NEVER falls back to
+    the host live file for a pinned agent. See module docstring.
     """
     host_cred = Path.home() / ".claude" / ".credentials.json"
     acct = getattr(getattr(config, "claude", None), "account", "") or ""
     if not acct:
         return host_cred
 
-    # stx-allow: fallback (reason: account-snapshot copy is the pinning
-    # mechanism; any resolution/copy hiccup degrades to the host live
-    # file so a start is never wedged — the warning surfaces the gap.)
-    try:
-        from .._state.account_store import _store_path
+    from .._account.creds_sync import _read_oauth_expiry_seconds
+    from .._state.account_store import _store_path
 
-        store = _store_path(None, Path.home())
-        snapshot = store / acct / ".credentials.json"
-        if not snapshot.is_file():
-            import warnings
+    store = _store_path(None, Path.home())
+    snapshot = store / acct / ".credentials.json"
+    if not snapshot.is_file():
+        raise PinnedAccountError(
+            f"spec.claude.account='{acct}' has no credential snapshot at "
+            f"{snapshot}. Refusing to fall back to a different account. "
+            f"Fix: run `claude /login` to that account then "
+            f"`sac accounts sync-live`, or `sac accounts save {acct}` on "
+            "the credential-holding host, then restart this agent."
+        )
 
-            warnings.warn(
-                f"spec.claude.account='{acct}' has no snapshot at "
-                f"{snapshot}; falling back to host "
-                "~/.claude/.credentials.json. Create it with "
-                f"`sac account save {acct}` on the credential-holding "
-                "host, then restart this agent.",
-                stacklevel=2,
-            )
-            return host_cred
+    now_ts = now if now is not None else time.time()
+    expiry = _read_oauth_expiry_seconds(snapshot)
+    if expiry is None:
+        raise PinnedAccountError(
+            f"spec.claude.account='{acct}' snapshot at {snapshot} is "
+            "missing a numeric `claudeAiOauth.expiresAt`. Refusing to "
+            f"launch with an unverifiable token. Fix: `claude /login` to "
+            f"that account then `sac accounts sync-live`."
+        )
+    if expiry <= now_ts:
+        ago = int(now_ts - expiry)
+        raise PinnedAccountError(
+            f"spec.claude.account='{acct}' snapshot at {snapshot} expired "
+            f"{ago} seconds ago. Refusing to launch a pinned agent with a "
+            f"stale token. Fix: `claude /login` to that account then "
+            f"`sac accounts sync-live`, and restart this agent."
+        )
 
-        dest = Path(state_dir).expanduser() / "claude" / ".credentials.json"
-        dest.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(snapshot, dest)
-        return dest
-    except Exception:  # stx-allow: fallback (reason: see inline comment)
-        return host_cred
+    dest = Path(state_dir).expanduser() / "claude" / ".credentials.json"
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(snapshot, dest)
+    return dest
+
+
+__all__ = ["PinnedAccountError", "resolve_cred_file"]

--- a/tests/scitex_agent_container/_account/test_creds_sync.py
+++ b/tests/scitex_agent_container/_account/test_creds_sync.py
@@ -1,0 +1,347 @@
+"""Tests for the credential auto-sync engine (``_account.creds_sync``).
+
+No mocks (PA-306): every test drives the real engine against a tmp
+home/store built from real JSON files. AAA markers (TQ002), descriptive
+names (TQ003), one assertion each (TQ007).
+
+The ``_isolate_home`` fixture forces ``$HOME`` inside ``tmp_path`` so a
+``_store_path`` regression can never write to the operator's real
+``~/.scitex/agent-container/accounts/``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._account.creds_sync import (
+    Freshness,
+    LiveCredInvalidError,
+    account_freshness,
+    slugify_email,
+    sync_live,
+)
+
+
+@pytest.fixture
+def _isolate_home(tmp_path: Path):
+    """Force Path.home() inside tmp_path for the test's duration.
+
+    PA-306: no monkeypatch — Path.home() reads $HOME on Unix, so an
+    explicit os.environ save/restore is the real equivalent.
+    """
+    saved = os.environ.get("HOME")
+    os.environ["HOME"] = str(tmp_path)
+    try:
+        yield tmp_path
+    finally:
+        if saved is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = saved
+
+
+def _write_live(home: Path, email: str, expires_at_ms: int) -> None:
+    """Write a real live credential + ~/.claude.json under ``home``."""
+    claude = home / ".claude"
+    claude.mkdir(parents=True, exist_ok=True)
+    (claude / ".credentials.json").write_text(
+        json.dumps({"claudeAiOauth": {"expiresAt": expires_at_ms}})
+    )
+    (home / ".claude.json").write_text(
+        json.dumps({"oauthAccount": {"emailAddress": email}})
+    )
+
+
+def _store_snapshot_path(home: Path, slug: str) -> Path:
+    """Return the on-disk store credential path for a slug under ``home``."""
+    return (
+        home / ".scitex" / "agent-container" / "accounts" / slug / ".credentials.json"
+    )
+
+
+# ---------------------------------------------------------------------------
+# slugify_email
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("email", "slug"),
+    [
+        ("wyusuuke@gmail.com", "wyusuuke-gmail-com"),
+        ("ywatanabe@scitex.ai", "ywatanabe-scitex-ai"),
+        ("Mixed.Case@Example.COM", "mixed-case-example-com"),
+    ],
+)
+def test_slugify_email_replaces_at_and_dot_with_hyphen(email: str, slug: str) -> None:
+    # Arrange
+    source = email
+    # Act
+    result = slugify_email(source)
+    # Assert
+    assert result == slug
+
+
+# ---------------------------------------------------------------------------
+# sync_live — happy path (store absent -> saved)
+# ---------------------------------------------------------------------------
+
+
+def test_sync_live_saves_when_store_absent(_isolate_home: Path) -> None:
+    # Arrange
+    home = _isolate_home
+    future_ms = int((time.time() + 3_600) * 1_000)
+    _write_live(home, "wyusuuke@gmail.com", future_ms)
+    # Act
+    result = sync_live(home=home)
+    # Assert
+    assert result.action == "saved"
+
+
+def test_sync_live_writes_store_snapshot_bytes_matching_live(
+    _isolate_home: Path,
+) -> None:
+    # Arrange
+    home = _isolate_home
+    future_ms = int((time.time() + 3_600) * 1_000)
+    _write_live(home, "wyusuuke@gmail.com", future_ms)
+    # Act
+    sync_live(home=home)
+    # Assert
+    snap = _store_snapshot_path(home, "wyusuuke-gmail-com")
+    assert json.loads(snap.read_text())["claudeAiOauth"]["expiresAt"] == future_ms
+
+
+def test_sync_live_derives_store_name_from_active_email(
+    _isolate_home: Path,
+) -> None:
+    # Arrange
+    home = _isolate_home
+    future_ms = int((time.time() + 3_600) * 1_000)
+    _write_live(home, "ywatanabe@scitex.ai", future_ms)
+    # Act
+    result = sync_live(home=home)
+    # Assert
+    assert result.store_name == "ywatanabe-scitex-ai"
+
+
+def test_sync_live_writes_account_metadata_email(_isolate_home: Path) -> None:
+    # Arrange
+    home = _isolate_home
+    future_ms = int((time.time() + 3_600) * 1_000)
+    _write_live(home, "wyusuuke@gmail.com", future_ms)
+    # Act
+    sync_live(home=home)
+    # Assert
+    meta = (
+        home
+        / ".scitex"
+        / "agent-container"
+        / "accounts"
+        / "wyusuuke-gmail-com"
+        / "account.json"
+    )
+    assert json.loads(meta.read_text())["email_address"] == "wyusuuke@gmail.com"
+
+
+# ---------------------------------------------------------------------------
+# sync_live — idempotence
+# ---------------------------------------------------------------------------
+
+
+def test_sync_live_is_up_to_date_when_store_matches_live(
+    _isolate_home: Path,
+) -> None:
+    # Arrange — first sync writes the store, second should be a no-op.
+    home = _isolate_home
+    future_ms = int((time.time() + 3_600) * 1_000)
+    _write_live(home, "wyusuuke@gmail.com", future_ms)
+    sync_live(home=home)
+    # Act
+    result = sync_live(home=home)
+    # Assert
+    assert result.action == "up-to-date"
+
+
+def test_sync_live_overwrites_store_older_than_live(_isolate_home: Path) -> None:
+    # Arrange — a stale store snapshot with an earlier expiry than live.
+    home = _isolate_home
+    older_ms = int((time.time() + 100) * 1_000)
+    newer_ms = int((time.time() + 10_000) * 1_000)
+    snap = _store_snapshot_path(home, "wyusuuke-gmail-com")
+    snap.parent.mkdir(parents=True, exist_ok=True)
+    snap.write_text(json.dumps({"claudeAiOauth": {"expiresAt": older_ms}}))
+    _write_live(home, "wyusuuke@gmail.com", newer_ms)
+    # Act
+    result = sync_live(home=home)
+    # Assert
+    assert result.action == "saved"
+
+
+def test_sync_live_overwrites_store_that_is_expired(_isolate_home: Path) -> None:
+    # Arrange — store expired in the past; live is valid.
+    home = _isolate_home
+    expired_ms = int((time.time() - 10_000) * 1_000)
+    future_ms = int((time.time() + 3_600) * 1_000)
+    snap = _store_snapshot_path(home, "wyusuuke-gmail-com")
+    snap.parent.mkdir(parents=True, exist_ok=True)
+    snap.write_text(json.dumps({"claudeAiOauth": {"expiresAt": expired_ms}}))
+    _write_live(home, "wyusuuke@gmail.com", future_ms)
+    # Act
+    result = sync_live(home=home)
+    # Assert
+    assert result.action == "saved"
+
+
+# ---------------------------------------------------------------------------
+# sync_live — fail-loud on invalid live cred
+# ---------------------------------------------------------------------------
+
+
+def test_sync_live_raises_when_live_cred_absent(_isolate_home: Path) -> None:
+    # Arrange — no ~/.claude/.credentials.json at all.
+    home = _isolate_home
+    (home / ".claude.json").write_text(
+        json.dumps({"oauthAccount": {"emailAddress": "x@y.com"}})
+    )
+    # Act
+    ctx = pytest.raises(LiveCredInvalidError)
+    # Assert
+    with ctx:
+        sync_live(home=home)
+
+
+def test_sync_live_raises_when_live_cred_expired(_isolate_home: Path) -> None:
+    # Arrange — live cred expired in the past; must NOT save a stale token.
+    home = _isolate_home
+    expired_ms = int((time.time() - 10_000) * 1_000)
+    _write_live(home, "wyusuuke@gmail.com", expired_ms)
+    # Act
+    ctx = pytest.raises(LiveCredInvalidError)
+    # Assert
+    with ctx:
+        sync_live(home=home)
+
+
+def test_sync_live_does_not_write_store_when_live_expired(
+    _isolate_home: Path,
+) -> None:
+    # Arrange
+    home = _isolate_home
+    expired_ms = int((time.time() - 10_000) * 1_000)
+    _write_live(home, "wyusuuke@gmail.com", expired_ms)
+    # Act
+    try:
+        sync_live(home=home)
+    except LiveCredInvalidError:
+        pass
+    # Assert — no snapshot was written for a stale live cred.
+    assert not _store_snapshot_path(home, "wyusuuke-gmail-com").exists()
+
+
+def test_sync_live_raises_when_email_missing(_isolate_home: Path) -> None:
+    # Arrange — valid live cred but no ~/.claude.json email.
+    home = _isolate_home
+    future_ms = int((time.time() + 3_600) * 1_000)
+    claude = home / ".claude"
+    claude.mkdir(parents=True, exist_ok=True)
+    (claude / ".credentials.json").write_text(
+        json.dumps({"claudeAiOauth": {"expiresAt": future_ms}})
+    )
+    # Act
+    ctx = pytest.raises(LiveCredInvalidError)
+    # Assert
+    with ctx:
+        sync_live(home=home)
+
+
+# ---------------------------------------------------------------------------
+# account_freshness
+# ---------------------------------------------------------------------------
+
+
+def test_account_freshness_absent_when_no_snapshot(_isolate_home: Path) -> None:
+    # Arrange — store dir has no snapshot for this account.
+    home = _isolate_home
+    # Act
+    fresh = account_freshness("ghost", home=home)
+    # Assert
+    assert fresh.state == "ABSENT"
+
+
+def test_account_freshness_valid_for_future_expiry(_isolate_home: Path) -> None:
+    # Arrange
+    home = _isolate_home
+    now = 1_700_000_000.0
+    snap = _store_snapshot_path(home, "wyusuuke-gmail-com")
+    snap.parent.mkdir(parents=True, exist_ok=True)
+    snap.write_text(
+        json.dumps({"claudeAiOauth": {"expiresAt": int((now + 3_600) * 1_000)}})
+    )
+    # Act
+    fresh = account_freshness("wyusuuke-gmail-com", home=home, now=now)
+    # Assert
+    assert fresh.state == "VALID"
+
+
+def test_account_freshness_expired_for_past_expiry(_isolate_home: Path) -> None:
+    # Arrange
+    home = _isolate_home
+    now = 1_700_000_000.0
+    snap = _store_snapshot_path(home, "wyusuuke-gmail-com")
+    snap.parent.mkdir(parents=True, exist_ok=True)
+    snap.write_text(
+        json.dumps({"claudeAiOauth": {"expiresAt": int((now - 3_600) * 1_000)}})
+    )
+    # Act
+    fresh = account_freshness("wyusuuke-gmail-com", home=home, now=now)
+    # Assert
+    assert fresh.state == "EXPIRED"
+
+
+def test_account_freshness_hours_signed_positive_when_valid(
+    _isolate_home: Path,
+) -> None:
+    # Arrange — exactly 2h of life remaining.
+    home = _isolate_home
+    now = 1_700_000_000.0
+    snap = _store_snapshot_path(home, "acct")
+    snap.parent.mkdir(parents=True, exist_ok=True)
+    snap.write_text(
+        json.dumps({"claudeAiOauth": {"expiresAt": int((now + 7_200) * 1_000)}})
+    )
+    # Act
+    fresh = account_freshness("acct", home=home, now=now)
+    # Assert
+    assert fresh.hours == pytest.approx(2.0)
+
+
+def test_freshness_label_renders_valid_with_signed_hours() -> None:
+    # Arrange
+    fresh = Freshness(state="VALID", hours=5.7)
+    # Act
+    label = fresh.label()
+    # Assert
+    assert label == "VALID (+5.7h)"
+
+
+def test_freshness_label_renders_expired_with_negative_hours() -> None:
+    # Arrange
+    fresh = Freshness(state="EXPIRED", hours=-138.6)
+    # Act
+    label = fresh.label()
+    # Assert
+    assert label == "EXPIRED (-138.6h)"
+
+
+def test_freshness_label_renders_absent_without_hours() -> None:
+    # Arrange
+    fresh = Freshness(state="ABSENT", hours=None)
+    # Act
+    label = fresh.label()
+    # Assert
+    assert label == "ABSENT"

--- a/tests/scitex_agent_container/_account/test_creds_watch.py
+++ b/tests/scitex_agent_container/_account/test_creds_watch.py
@@ -1,0 +1,188 @@
+"""Tests for the credential auto-sync watcher (``_account.creds_watch``).
+
+No mocks (PA-306): the watcher's engine-call path and poll fallback are
+driven against a real tmp home + a real ``io.StringIO`` log sink and a
+hand-rolled fake ``sleep_fn``. The inotify backend itself is not
+exercised here (it needs the ``inotifywait`` binary); the poll loop
+shares the same engine call so it covers the sync behaviour.
+
+AAA markers (TQ002), descriptive names (TQ003), one assertion each
+(TQ007).
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._account.creds_watch import (
+    default_log_path,
+    run_sync_once,
+    watch_poll,
+)
+
+
+@pytest.fixture
+def _isolate_home(tmp_path: Path):
+    """Force Path.home() inside tmp_path. PA-306: env save/restore."""
+    saved = os.environ.get("HOME")
+    os.environ["HOME"] = str(tmp_path)
+    try:
+        yield tmp_path
+    finally:
+        if saved is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = saved
+
+
+def _write_live(home: Path, email: str, expires_at_ms: int) -> None:
+    claude = home / ".claude"
+    claude.mkdir(parents=True, exist_ok=True)
+    (claude / ".credentials.json").write_text(
+        json.dumps({"claudeAiOauth": {"expiresAt": expires_at_ms}})
+    )
+    (home / ".claude.json").write_text(
+        json.dumps({"oauthAccount": {"emailAddress": email}})
+    )
+
+
+def _store_snapshot_path(home: Path, slug: str) -> Path:
+    return (
+        home / ".scitex" / "agent-container" / "accounts" / slug / ".credentials.json"
+    )
+
+
+# ---------------------------------------------------------------------------
+# default_log_path
+# ---------------------------------------------------------------------------
+
+
+def test_default_log_path_under_runtime_logs(_isolate_home: Path) -> None:
+    # Arrange
+    home = _isolate_home
+    # Act
+    path = default_log_path(home=home)
+    # Assert
+    assert path == (
+        home / ".scitex" / "agent-container" / "runtime" / "logs" / "creds-watch.log"
+    )
+
+
+# ---------------------------------------------------------------------------
+# run_sync_once — engine-call path
+# ---------------------------------------------------------------------------
+
+
+def test_run_sync_once_saves_store_for_valid_live(_isolate_home: Path) -> None:
+    # Arrange
+    home = _isolate_home
+    _write_live(home, "wyusuuke@gmail.com", int((time.time() + 3_600) * 1_000))
+    log = io.StringIO()
+    # Act
+    run_sync_once(log, home=home)
+    # Assert
+    assert _store_snapshot_path(home, "wyusuuke-gmail-com").exists()
+
+
+def test_run_sync_once_logs_saved_action(_isolate_home: Path) -> None:
+    # Arrange
+    home = _isolate_home
+    _write_live(home, "wyusuuke@gmail.com", int((time.time() + 3_600) * 1_000))
+    log = io.StringIO()
+    # Act
+    run_sync_once(log, home=home)
+    # Assert
+    assert "saved wyusuuke-gmail-com" in log.getvalue()
+
+
+def test_run_sync_once_logs_invalid_without_raising(_isolate_home: Path) -> None:
+    # Arrange — expired live cred: the watcher must log, not crash.
+    home = _isolate_home
+    _write_live(home, "wyusuuke@gmail.com", int((time.time() - 10_000) * 1_000))
+    log = io.StringIO()
+    # Act
+    run_sync_once(log, home=home)
+    # Assert
+    assert "live-cred-invalid" in log.getvalue()
+
+
+def test_run_sync_once_does_not_save_for_expired_live(_isolate_home: Path) -> None:
+    # Arrange
+    home = _isolate_home
+    _write_live(home, "wyusuuke@gmail.com", int((time.time() - 10_000) * 1_000))
+    log = io.StringIO()
+    # Act
+    run_sync_once(log, home=home)
+    # Assert
+    assert not _store_snapshot_path(home, "wyusuuke-gmail-com").exists()
+
+
+# ---------------------------------------------------------------------------
+# watch_poll — poll fallback against a tmp file
+# ---------------------------------------------------------------------------
+
+
+def test_watch_poll_initial_sync_writes_store(_isolate_home: Path) -> None:
+    # Arrange — valid live cred; zero poll iterations means only the
+    # initial sync runs.
+    home = _isolate_home
+    _write_live(home, "wyusuuke@gmail.com", int((time.time() + 3_600) * 1_000))
+    log = io.StringIO()
+    # Act
+    watch_poll(log, home=home, iterations=0, sleep_fn=lambda _s: None)
+    # Assert
+    assert _store_snapshot_path(home, "wyusuuke-gmail-com").exists()
+
+
+def test_watch_poll_resyncs_after_live_cred_change(_isolate_home: Path) -> None:
+    # Arrange — start with cred A, then a sleep_fn that rewrites the live
+    # cred to a fresher expiry on the first poll cycle so the loop must
+    # detect the change and re-sync.
+    home = _isolate_home
+    first_ms = int((time.time() + 3_600) * 1_000)
+    second_ms = int((time.time() + 9_999) * 1_000)
+    _write_live(home, "wyusuuke@gmail.com", first_ms)
+    log = io.StringIO()
+
+    def _mutate_on_first_poll(_seconds: float) -> None:
+        _write_live(home, "wyusuuke@gmail.com", second_ms)
+
+    # Act
+    watch_poll(home=home, log=log, iterations=1, sleep_fn=_mutate_on_first_poll)
+    # Assert — the store now holds the SECOND (fresher) expiry.
+    snap = _store_snapshot_path(home, "wyusuuke-gmail-com")
+    assert json.loads(snap.read_text())["claudeAiOauth"]["expiresAt"] == second_ms
+
+
+def test_watch_poll_logs_change_detected_on_mutation(_isolate_home: Path) -> None:
+    # Arrange
+    home = _isolate_home
+    _write_live(home, "wyusuuke@gmail.com", int((time.time() + 3_600) * 1_000))
+    log = io.StringIO()
+
+    def _mutate(_seconds: float) -> None:
+        _write_live(home, "wyusuuke@gmail.com", int((time.time() + 9_999) * 1_000))
+
+    # Act
+    watch_poll(home=home, log=log, iterations=1, sleep_fn=_mutate)
+    # Assert
+    assert "change detected" in log.getvalue()
+
+
+def test_watch_poll_no_change_does_not_log_change_detected(
+    _isolate_home: Path,
+) -> None:
+    # Arrange — sleep_fn leaves the file untouched, so no change fires.
+    home = _isolate_home
+    _write_live(home, "wyusuuke@gmail.com", int((time.time() + 3_600) * 1_000))
+    log = io.StringIO()
+    # Act
+    watch_poll(home=home, log=log, iterations=2, sleep_fn=lambda _s: None)
+    # Assert
+    assert "change detected" not in log.getvalue()

--- a/tests/scitex_agent_container/cli_pkg/test_account_group_sync_live.py
+++ b/tests/scitex_agent_container/cli_pkg/test_account_group_sync_live.py
@@ -1,0 +1,192 @@
+"""Tests for ``sac accounts sync-live`` + the ``list`` freshness column.
+
+PA-306 no-mocks: every test drives the real click commands via
+``CliRunner`` against a real tmp ``$HOME``. ``Path.home()`` reads
+``$HOME`` on POSIX, so the autouse ``sandbox_home`` redirect lands the
+whole account-store cascade inside the test tmpdir.
+
+AAA markers (TQ002), descriptive names (TQ003), one assertion each
+(TQ007).
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from scitex_agent_container._state.account_store import save_account
+from scitex_agent_container.cli_pkg.account_group import account
+
+
+@pytest.fixture(autouse=True)
+def sandbox_home(tmp_path, env_save_restore):
+    """Redirect ``$HOME`` so ``Path.home()`` resolves inside ``tmp_path``."""
+    home = tmp_path / "home"
+    home.mkdir()
+    env_save_restore.set("HOME", str(home))
+    return home
+
+
+def _write_live(home: Path, email: str, expires_at_ms: int) -> None:
+    claude = home / ".claude"
+    claude.mkdir(parents=True, exist_ok=True)
+    (claude / ".credentials.json").write_text(
+        json.dumps({"claudeAiOauth": {"expiresAt": expires_at_ms}})
+    )
+    (home / ".claude.json").write_text(
+        json.dumps({"oauthAccount": {"emailAddress": email}})
+    )
+
+
+def _snapshot_with_expiry(home: Path, name: str, expires_at_ms: int) -> None:
+    """Save a store snapshot carrying an explicit OAuth expiry."""
+    save_account(name, {"email_address": f"{name}@x"}, home=home)
+    (
+        home / ".scitex" / "agent-container" / "accounts" / name / ".credentials.json"
+    ).write_text(json.dumps({"claudeAiOauth": {"expiresAt": expires_at_ms}}))
+
+
+# ---------------------------------------------------------------------------
+# sync-live — happy path
+# ---------------------------------------------------------------------------
+
+
+def test_sync_live_exits_zero_for_valid_live(sandbox_home):
+    # Arrange
+    _write_live(sandbox_home, "wyusuuke@gmail.com", int((time.time() + 3_600) * 1_000))
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(account, ["sync-live"])
+    # Assert
+    assert result.exit_code == 0, result.output
+
+
+def test_sync_live_reports_saved_store_name(sandbox_home):
+    # Arrange
+    _write_live(sandbox_home, "wyusuuke@gmail.com", int((time.time() + 3_600) * 1_000))
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(account, ["sync-live"])
+    # Assert
+    assert "wyusuuke-gmail-com" in result.output
+
+
+def test_sync_live_json_action_saved(sandbox_home):
+    # Arrange
+    _write_live(sandbox_home, "ywatanabe@scitex.ai", int((time.time() + 3_600) * 1_000))
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(account, ["sync-live", "--json"])
+    payload = json.loads(result.output)
+    # Assert
+    assert payload["action"] == "saved"
+
+
+def test_sync_live_idempotent_reports_up_to_date(sandbox_home):
+    # Arrange — sync once, then sync again over the unchanged live cred.
+    _write_live(sandbox_home, "wyusuuke@gmail.com", int((time.time() + 3_600) * 1_000))
+    runner = CliRunner()
+    runner.invoke(account, ["sync-live"])
+    # Act
+    result = runner.invoke(account, ["sync-live", "--json"])
+    payload = json.loads(result.output)
+    # Assert
+    assert payload["action"] == "up-to-date"
+
+
+# ---------------------------------------------------------------------------
+# sync-live — fail loud
+# ---------------------------------------------------------------------------
+
+
+def test_sync_live_exits_nonzero_when_live_expired(sandbox_home):
+    # Arrange — expired live cred must NOT be saved.
+    _write_live(sandbox_home, "wyusuuke@gmail.com", int((time.time() - 10_000) * 1_000))
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(account, ["sync-live"])
+    # Assert
+    assert result.exit_code == 1
+
+
+def test_sync_live_exits_nonzero_when_live_absent(sandbox_home):
+    # Arrange — only ~/.claude.json email, no credentials file.
+    (sandbox_home / ".claude.json").write_text(
+        json.dumps({"oauthAccount": {"emailAddress": "x@y.com"}})
+    )
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(account, ["sync-live"])
+    # Assert
+    assert result.exit_code == 1
+
+
+def test_sync_live_error_message_points_at_login(sandbox_home):
+    # Arrange
+    _write_live(sandbox_home, "wyusuuke@gmail.com", int((time.time() - 10_000) * 1_000))
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(account, ["sync-live"])
+    # Assert
+    assert "claude /login" in result.output
+
+
+# ---------------------------------------------------------------------------
+# list — freshness column
+# ---------------------------------------------------------------------------
+
+
+def test_list_human_shows_valid_for_future_snapshot(sandbox_home):
+    # Arrange
+    _snapshot_with_expiry(sandbox_home, "work", int((time.time() + 3_600) * 1_000))
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(account, ["list"])
+    # Assert
+    assert "VALID" in result.output
+
+
+def test_list_human_shows_expired_for_past_snapshot(sandbox_home):
+    # Arrange
+    _snapshot_with_expiry(sandbox_home, "stale", int((time.time() - 3_600) * 1_000))
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(account, ["list"])
+    # Assert
+    assert "EXPIRED" in result.output
+
+
+def test_list_human_shows_absent_when_snapshot_has_no_expiry(sandbox_home):
+    # Arrange — metadata only, no .credentials.json with an expiry.
+    save_account("bare", {"email_address": "bare@x"}, home=sandbox_home)
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(account, ["list"])
+    # Assert
+    assert "ABSENT" in result.output
+
+
+def test_list_json_includes_freshness_state(sandbox_home):
+    # Arrange
+    _snapshot_with_expiry(sandbox_home, "work", int((time.time() + 3_600) * 1_000))
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(account, ["list", "--json"])
+    payload = json.loads(result.output)
+    # Assert
+    assert payload["stored"][0]["freshness"] == "VALID"
+
+
+def test_list_json_includes_freshness_hours(sandbox_home):
+    # Arrange
+    _snapshot_with_expiry(sandbox_home, "work", int((time.time() + 3_600) * 1_000))
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(account, ["list", "--json"])
+    payload = json.loads(result.output)
+    # Assert
+    assert payload["stored"][0]["freshness_hours"] is not None

--- a/tests/scitex_agent_container/runtimes/test__apptainer_runtime.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_runtime.py
@@ -22,6 +22,7 @@ import os
 import shlex
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -35,6 +36,7 @@ from scitex_agent_container.config._types import (
     ContainerSpec,
 )
 from scitex_agent_container.runtimes import _apptainer_runtime as mod
+from scitex_agent_container.runtimes._apptainer_creds import PinnedAccountError
 from scitex_agent_container.runtimes._apptainer_inner_argv import (
     RUNNER_MODULE_AGENT,
     RUNNER_MODULE_PROXY,
@@ -1122,14 +1124,20 @@ def test_argv_startup_prompts_populates_mission(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _save_snapshot(home: Path, name: str, body: str = '{"snap": true}') -> Path:
+def _save_snapshot(home: Path, name: str, body: str | None = None) -> Path:
     """Write a real saved-account snapshot under the home's account store
     and return its ``.credentials.json`` path.
 
     Mirrors the on-disk layout
     ``~/.scitex/agent-container/accounts/<name>/.credentials.json`` that
-    ``sac account save`` produces.
+    ``sac account save`` produces. The default body carries a VALID
+    (far-future) ``claudeAiOauth.expiresAt`` so the fail-loud pin
+    resolver (``_apptainer_creds.resolve_cred_file``) accepts it; tests
+    that need a stale/odd snapshot pass an explicit ``body``.
     """
+    if body is None:
+        far_future_ms = int((time.time() + 86_400) * 1_000)
+        body = '{"claudeAiOauth": {"expiresAt": %d}}' % far_future_ms
     acct_dir = home / ".scitex" / "agent-container" / "accounts" / name
     acct_dir.mkdir(parents=True, exist_ok=True)
     snap = acct_dir / ".credentials.json"
@@ -1160,8 +1168,14 @@ def test_argv_pins_account_binds_state_dir_copy_not_host_file(
 def test_argv_pins_account_copies_snapshot_bytes_into_state_dir(
     tmp_path: Path, home_redirect: Path
 ) -> None:
-    # Arrange — snapshot has distinctive bytes the copy must reproduce.
-    _save_snapshot(home_redirect, "beta", body='{"pinned": "beta-bytes"}')
+    # Arrange — snapshot has distinctive bytes (plus a VALID future
+    # expiresAt so the fail-loud resolver accepts it) the copy must
+    # reproduce verbatim.
+    far_future_ms = int((time.time() + 86_400) * 1_000)
+    body = '{"pinned": "beta-bytes", "claudeAiOauth": {"expiresAt": %d}}' % (
+        far_future_ms
+    )
+    _save_snapshot(home_redirect, "beta", body=body)
     state_dir = tmp_path / "state"
     state_dir.mkdir()
     rt = ApptainerContainerRuntime()
@@ -1170,7 +1184,7 @@ def test_argv_pins_account_copies_snapshot_bytes_into_state_dir(
     rt.build_run_argv(cfg, state_dir=state_dir, sif_path=tmp_path / "x.sif")
     copied = state_dir / "claude" / ".credentials.json"
     # Assert — frozen boot-copy landed with the snapshot's contents.
-    assert copied.read_text() == '{"pinned": "beta-bytes"}'
+    assert copied.read_text() == body
 
 
 def test_argv_no_account_binds_host_live_file(
@@ -1189,20 +1203,42 @@ def test_argv_no_account_binds_host_live_file(
     assert creds_arg.startswith(str(host_creds))
 
 
-def test_argv_pinned_account_missing_snapshot_falls_back_to_host(
+def test_argv_pinned_account_missing_snapshot_raises_pinned_account_error(
     tmp_path: Path, home_redirect: Path
 ) -> None:
     # Arrange — pin names an account with NO snapshot; host file exists.
+    # A pinned agent must NEVER silently fall back to the host live file
+    # (a different account); it must hard-error with the remedy hint.
     host_creds = home_redirect / ".claude" / ".credentials.json"
     host_creds.parent.mkdir(parents=True, exist_ok=True)
     host_creds.write_text("{}")
     rt = ApptainerContainerRuntime()
     cfg = _config(tmp_path, claude=ClaudeSpec(account="ghost"))
-    # Act — fail-soft fallback (warns; never wedges the start).
-    argv = rt.build_run_argv(cfg, state_dir=tmp_path, sif_path=tmp_path / "x.sif")
-    creds_arg = next(a for a in argv if "/tmp/sac-claude/.credentials.json" in a)
+    # Act
+    ctx = pytest.raises(PinnedAccountError)
+    # Assert — fail loud, never bind the host file.
+    with ctx:
+        rt.build_run_argv(cfg, state_dir=tmp_path, sif_path=tmp_path / "x.sif")
+
+
+def test_argv_pinned_account_expired_snapshot_raises_pinned_account_error(
+    tmp_path: Path, home_redirect: Path
+) -> None:
+    # Arrange — snapshot exists but its OAuth token already expired; a
+    # pinned agent must refuse to launch with a stale token.
+    past_ms = int((time.time() - 86_400) * 1_000)
+    _save_snapshot(
+        home_redirect,
+        "stale",
+        body='{"claudeAiOauth": {"expiresAt": %d}}' % past_ms,
+    )
+    rt = ApptainerContainerRuntime()
+    cfg = _config(tmp_path, claude=ClaudeSpec(account="stale"))
+    # Act
+    ctx = pytest.raises(PinnedAccountError)
     # Assert
-    assert creds_arg.startswith(str(host_creds))
+    with ctx:
+        rt.build_run_argv(cfg, state_dir=tmp_path, sif_path=tmp_path / "x.sif")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What & why

Keep the sac per-account store fresh **the moment** the operator runs
`claude /login` to an account — zero manual `sac accounts save`. Today
stores rot: nothing re-saves them when the live credential refreshes or
the active account changes. (Found 2 of 3 real stores ~5.8 days expired
while the live cred was fresh.)

## The five deliverables

1. **`sac accounts sync-live`** — one-shot engine. Reads the live
   `~/.claude/.credentials.json` + active email from `~/.claude.json`,
   derives the store-name (email slugified, e.g. `ywatanabe@scitex.ai` →
   `ywatanabe-scitex-ai`), and atomically snapshots the live cred into
   the matching store when it is **absent / older / expired**.
   Idempotent (no-op when the store already matches/newer). **Fails
   loud** (non-zero exit, `LiveCredInvalidError`) on an expired/absent
   live cred — never saves a stale token. New `_account/creds_sync.py`.
2. **`sac accounts watch-live`** — daemon. Watches the live credential
   (inotify via `inotifywait` when available, else a poll loop) and runs
   the engine on every change. Logs each sync to stderr or
   `~/.scitex/agent-container/runtime/logs/creds-watch.log`. A transient
   invalid/expired live cred is logged, not fatal — safe as a long-lived
   background process. New `_account/creds_watch.py`.
3. **`sac accounts list` freshness column** — every stored account shows
   `VALID (+Xh)` / `EXPIRED (-Xh)` / `ABSENT`, read OFFLINE from the
   snapshot's `expiresAt`. `--json` gains `freshness` + `freshness_hours`.
   (The existing usage column is kept — freshness is a new column.)
4. **Fail-loud at agent start** — `runtimes/_apptainer_creds.resolve_cred_file`
   previously **silently fell back** to the host live file (a *different*
   account) when a pinned `spec.claude.account` store was absent, and on
   any copy error — and never checked store expiry. Now it raises
   `PinnedAccountError` with the exact remedy when the store is ABSENT
   or EXPIRED. A pinned agent never launches with the wrong identity or
   a stale token.
5. **Tests** for 1, 3, 4 (and the watcher engine-call + poll-fallback
   path for 2) — real collaborators / tmp dirs, no mocks; AAA markers,
   one assertion each, descriptive names.

## Test plan

- New: `tests/.../_account/test_creds_sync.py` (21), `test_creds_watch.py`
  (9), `cli_pkg/test_account_group_sync_live.py` (12).
- Updated: `runtimes/test__apptainer_runtime.py` — the old
  silent-fallback test became two fail-loud assertions (absent + expired
  snapshot); the snapshot helper now embeds a valid future `expiresAt`.
- Full suite: **5158 passed**, 2 pre-existing failures unrelated to this
  change (`test_state_db::...since_cutoff` cross-file DB-state ordering
  leak; `test_cli::...hanging_remote_probe...timeout_budget` a timing
  flake whose own assertion message cites `todo#254`). Both **pass in
  isolation** and neither touches files in this diff. A clean-`develop`
  full-suite baseline run confirms they pre-exist.
- Live smoke: `sync-live` saves + is idempotent + reports up-to-date;
  fail-loud exits 1 with `claude /login` remedy on an expired live cred;
  `watch-live --poll` runs the daemon, syncs, and logs to the canonical
  log file.