### PR TITLE
feat(spawn): in-container HTTP client + MCP `agent_spawn` for host-side spawn-proxy

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_spawn_client.py
+++ b/src/scitex_agent_container/_lifecycle/_spawn_client.py
@@ -1,0 +1,308 @@
+"""In-container HTTP client for the host-side spawn-proxy endpoint.
+
+Lets an agent running INSIDE an apptainer container ask the host's
+``sac listen`` to spawn a child agent on the bare host. This is the
+canonical (ADR-0010 mechanism #3) spawn path — the only sanctioned
+agent-driven spawn, because the listen-server gate
+(:func:`_listen._acl.check_spawn`) and the lineage recorder
+(:func:`_state.state_db_nodes.record_lineage`) run on every accepted
+request. Apptainer-in-apptainer is avoided structurally: the child is
+booted on the bare host, never nested.
+
+Transport contract
+------------------
+
+Endpoint: ``POST {SAC_LISTEN_BASE_URL}/agents``
+(canonical control-plane route, see :mod:`_listen.server`).
+
+Auth: ``Authorization: Bearer {SAC_LISTEN_BEARER}`` — both injected
+into the container by :mod:`runtimes._apptainer_listen_env` alongside
+the channel-adapter env. Missing ``SAC_LISTEN_BASE_URL`` raises
+:class:`SpawnRequestError` (fail loud — there is no useful default).
+
+Body:
+
+    {"name": "<child>",
+     "caller": "<spawning-agent>",        # auto-resolved from SAC_NAME
+     "spec": {...},                       # optional inline spec
+     "overwrite": false}                  # optional, default false
+
+The server's ``agents_start`` handler runs ``check_spawn(caller=...)``
+BEFORE any runtime work. On allow it records the ``caller → child``
+lineage edge and shells ``sac agent start <name>`` on the bare host.
+On deny it returns 403 with an ACL reason; we surface that verbatim
+as :class:`SpawnRequestError` (status=403) so the caller fails LOUD
+rather than swallowing the deny.
+
+Stdlib-only on purpose
+----------------------
+
+Mirrors :mod:`_network.hub_client`: ``urllib.request`` (no ``httpx``)
++ injected ``opener`` callable for tests. Containers may not have the
+heavier HTTP stack loaded at MCP-tool invocation time, and a spawn
+request is a single one-shot POST — no streaming, no async.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Callable
+from urllib import error as urlerror
+from urllib import request as urlrequest
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["SpawnRequestError", "request_spawn"]
+
+_DEFAULT_TIMEOUT_S = 30.0
+
+
+class SpawnRequestError(RuntimeError):
+    """Raised when the host-side spawn POST cannot be completed.
+
+    Carries the structured failure information so the caller (CLI / MCP
+    tool / log line) can show *why* the spawn failed without re-parsing
+    a free-text message:
+
+    * ``status`` — HTTP status code returned by the listen server
+      (``None`` for transport errors before any HTTP exchange happened
+      or for missing-env failures).
+    * ``body`` — parsed response dict, or the raw text fallback if the
+      body was not JSON, or ``None`` when no body was received.
+
+    The fail-loud invariants this class encodes (ADR-0010 + handoff §0):
+
+    * A 403 ACL deny is an ERROR for the caller — never silently
+      swallowed. The reason from the server is forwarded verbatim in
+      ``body``.
+    * A transport error (host listen unreachable, refused, timed out)
+      is an ERROR — never converted to "ok with empty result".
+    * A missing ``SAC_LISTEN_BASE_URL`` is an ERROR — the container is
+      misconfigured (the apptainer runtime forgot to inject it), and
+      pretending the spawn succeeded would leave the lineage row
+      unwritten on the host.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status: int | None = None,
+        body: Any = None,
+    ) -> None:
+        super().__init__(message)
+        self.status = status
+        self.body = body
+
+
+def _resolve_base_url(explicit: str | None) -> str:
+    """Return the listen-server base URL or raise loudly.
+
+    Resolution order: explicit argument → ``SAC_LISTEN_BASE_URL``
+    (via :func:`_env.getenv` so the long-form alias also works).
+    Trailing slash is stripped so callers can safely concatenate
+    ``/agents``.
+    """
+    if explicit:
+        return explicit.rstrip("/")
+    from .._env import getenv
+
+    raw = getenv("LISTEN_BASE_URL", "") or ""
+    raw = raw.strip()
+    if not raw:
+        raise SpawnRequestError(
+            "spawn request requires SAC_LISTEN_BASE_URL (the host-stable "
+            "`sac listen` URL injected into the container by the apptainer "
+            "runtime). Got empty/unset."
+        )
+    return raw.rstrip("/")
+
+
+def _resolve_bearer(explicit: str | None) -> str | None:
+    """Return the listen-server bearer token, or ``None`` if unset.
+
+    Unlike ``SAC_LISTEN_BASE_URL``, an absent bearer is NOT fatal here:
+    the listen server may have been started with bearer auth disabled,
+    in which case the request still goes through. The server enforces
+    its own auth contract; we just forward whatever credential the
+    runtime injected.
+    """
+    if explicit is not None:
+        return explicit or None
+    from .._env import getenv
+
+    raw = getenv("LISTEN_BEARER", "") or ""
+    return raw.strip() or None
+
+
+def _resolve_caller(explicit: str | None) -> str | None:
+    """Return the spawning agent's identity, or ``None`` for the admin path.
+
+    Reuses the same resolution rule as the in-process
+    :func:`_lifecycle._spawn_gate.resolve_spawn_caller`: read ``SAC_NAME``
+    from the parent container's env. An empty string is normalised to
+    ``None`` (admin / human-operator launch — always allowed by the
+    server's current root-only ``check_spawn`` policy).
+    """
+    if explicit is not None:
+        return explicit or None
+    from ._spawn_gate import resolve_spawn_caller
+
+    return resolve_spawn_caller()
+
+
+def _parse_body(raw: bytes) -> Any:
+    """Return JSON-parsed body or raw text fallback."""
+    if not raw:
+        return None
+    try:
+        return json.loads(raw)
+    except ValueError:
+        # stx-allow: fallback (reason: non-JSON body surfaced verbatim
+        # to the caller via SpawnRequestError.body — never silently
+        # dropped or converted into a fake success).
+        return raw.decode("utf-8", errors="replace")
+
+
+def request_spawn(
+    child_name: str,
+    *,
+    caller: str | None = None,
+    spec: dict | None = None,
+    overwrite: bool = False,
+    base_url: str | None = None,
+    bearer: str | None = None,
+    timeout_s: float = _DEFAULT_TIMEOUT_S,
+    opener: Callable | None = None,
+) -> dict:
+    """POST a spawn request to the host listen server; FAIL LOUD on error.
+
+    Parameters
+    ----------
+    child_name
+        The agent to start (must already be registered on the host, OR
+        passed inline via ``spec``).
+    caller
+        The spawning agent's identity for the listen-server's
+        ``check_spawn`` gate + lineage edge. Defaults to ``SAC_NAME``
+        from the container env via :func:`_resolve_caller`.
+    spec
+        Optional inline spec dict (``{apiVersion, kind, spec}``) — the
+        server materialises it under
+        ``~/.scitex/agent-container/agents/<name>/spec.yaml`` and then
+        starts it. Use for ephemeral / per-turn children.
+    overwrite
+        Forwarded as the ``overwrite`` body field; only meaningful with
+        ``spec``. Defaults to ``False`` (409 on clash).
+    base_url
+        Override ``SAC_LISTEN_BASE_URL``. Tests pass an in-process
+        listen-server URL; production passes ``None``.
+    bearer
+        Override ``SAC_LISTEN_BEARER``. Tests pass either an explicit
+        value or ``""`` to force the unauthenticated branch.
+    timeout_s
+        Per-request HTTP timeout (seconds). Defaults to 30 — long enough
+        for the server's ``sac agent start`` subprocess to return.
+    opener
+        Optional ``urllib.request.urlopen``-shaped callable. Default
+        ``urlrequest.urlopen``; tests inject a fake opener that returns
+        a ``urllib.response``-shaped object (no monkeypatching).
+
+    Returns
+    -------
+    dict
+        The server's parsed JSON body on 2xx — the ``agents_start``
+        handler returns ``{name, returncode, stdout, stderr}``. The
+        caller can branch on ``returncode``; ``returncode != 0`` means
+        the gate passed but the bare-host ``sac agent start`` itself
+        failed (e.g. a spec validation error on the host).
+
+    Raises
+    ------
+    SpawnRequestError
+        On missing base URL, transport failure, non-2xx HTTP status
+        (including 403 ACL deny), or malformed-but-otherwise-OK body
+        the server itself would reject.
+    """
+    if not isinstance(child_name, str) or not child_name:
+        raise SpawnRequestError("child_name must be a non-empty string")
+
+    base = _resolve_base_url(base_url)
+    tok = _resolve_bearer(bearer)
+    resolved_caller = _resolve_caller(caller)
+
+    body: dict[str, Any] = {"name": child_name}
+    if resolved_caller:
+        body["caller"] = resolved_caller
+    if spec is not None:
+        body["spec"] = spec
+        body["overwrite"] = bool(overwrite)
+
+    payload = json.dumps(body).encode("utf-8")
+    url = f"{base}/agents"
+    headers = {"Content-Type": "application/json", "Accept": "application/json"}
+    if tok:
+        headers["Authorization"] = f"Bearer {tok}"
+
+    req = urlrequest.Request(url, data=payload, method="POST", headers=headers)
+    opener_fn = opener if opener is not None else urlrequest.urlopen
+
+    try:
+        with opener_fn(req, timeout=timeout_s) as resp:
+            raw = resp.read()
+            status = int(getattr(resp, "status", 200))
+    except urlerror.HTTPError as exc:
+        # Non-2xx — read the body if any so the caller sees the
+        # server's reason verbatim (ACL deny carries it).
+        raw_body = b""
+        try:
+            raw_body = exc.read() or b""
+        except Exception:  # stx-allow: defensive — body read on a half-closed HTTPError stream may itself fail; we already have status + URL.  # noqa: BLE001
+            pass
+        parsed = _parse_body(raw_body)
+        logger.warning(
+            "spawn_client: POST %s returned HTTP %s body=%r",
+            url,
+            exc.code,
+            parsed,
+        )
+        raise SpawnRequestError(
+            f"spawn of {child_name!r} rejected: listen returned HTTP "
+            f"{exc.code} ({parsed!r})",
+            status=exc.code,
+            body=parsed,
+        ) from exc
+    except (urlerror.URLError, OSError, ValueError) as exc:
+        logger.warning("spawn_client: POST %s transport error: %s", url, exc)
+        raise SpawnRequestError(
+            f"spawn of {child_name!r} failed: cannot reach listen at "
+            f"{base!r} ({exc})"
+        ) from exc
+
+    parsed = _parse_body(raw)
+    if status < 200 or status >= 300:
+        # Some opener implementations don't raise HTTPError for non-2xx
+        # — guard explicitly so a misbehaving server can't masquerade
+        # as success.
+        logger.warning(
+            "spawn_client: POST %s returned HTTP %s body=%r",
+            url,
+            status,
+            parsed,
+        )
+        raise SpawnRequestError(
+            f"spawn of {child_name!r} rejected: listen returned HTTP "
+            f"{status} ({parsed!r})",
+            status=status,
+            body=parsed,
+        )
+
+    if not isinstance(parsed, dict):
+        raise SpawnRequestError(
+            f"spawn of {child_name!r} succeeded transport-wise but the "
+            f"listen response was not a JSON object: {parsed!r}",
+            status=status,
+            body=parsed,
+        )
+    return parsed

--- a/src/scitex_agent_container/_mcp/_tools/_agent.py
+++ b/src/scitex_agent_container/_mcp/_tools/_agent.py
@@ -92,11 +92,82 @@ def agent_start(name: str, foreground: bool = False) -> dict[str, Any]:
     that need to share a Registry instance, use
     :func:`scitex_agent_container._lifecycle.lifecycle.agent_start`
     directly.
+
+    .. note::
+       Runs the CLI **inside the current container**. Inside an
+       apptainer-isolated agent that means apptainer-in-apptainer
+       (blocked on most HPCs) or a bare-runner fallback. Use
+       :func:`agent_spawn` instead to ask the bare HOST to start the
+       child via the sac-listen control plane — that path goes through
+       the server-side ACL gate and records the parent→child lineage
+       edge automatically (ADR-0010 mechanism #3).
     """
     argv = ["agents", "start", name]
     if foreground:
         argv.append("--foreground")
     return invoke_cli_text(argv)
+
+
+def agent_spawn(
+    name: str,
+    spec: dict | None = None,
+    overwrite: bool = False,
+    caller: str | None = None,
+) -> dict[str, Any]:
+    """Ask the HOST sac-listen to spawn ``name`` on the bare host.
+
+    This is the ADR-0010 mechanism-#3 spawn path — the only sanctioned
+    agent-driven spawn surface. Every accepted request runs through
+    the server-side ``check_spawn`` ACL gate and is recorded in the
+    ``lineage`` table BEFORE any runtime work happens. The child is
+    booted on the bare host (no apptainer-in-apptainer).
+
+    Compared to :func:`agent_start` (which shells ``sac agents start``
+    in the CURRENT container), ``agent_spawn`` POSTs to the host's
+    ``/agents`` endpoint via :mod:`_lifecycle._spawn_client`. The
+    container needs ``SAC_LISTEN_BASE_URL`` (+ optional
+    ``SAC_LISTEN_BEARER``) injected by the apptainer runtime; both
+    are standard on sac-managed agents.
+
+    Args:
+        name: The child agent to start (must be registered on the
+            host OR provided inline via ``spec``).
+        spec: Optional inline spec dict ``{apiVersion, kind, spec}``.
+            When provided, the server materialises it under
+            ``~/.scitex/agent-container/agents/<name>/spec.yaml`` and
+            then starts it. Use for ephemeral / per-turn children.
+        overwrite: Only meaningful with ``spec`` — overwrite an
+            existing on-disk spec instead of returning 409.
+        caller: Override the auto-resolved caller identity. Defaults
+            to ``SAC_NAME`` from the container env (resolved inside
+            :mod:`_lifecycle._spawn_client`), which is what the
+            server-side ``check_spawn`` gate keys off.
+
+    Returns:
+        On success: ``{"status": "ok", "result": {...server body...}}``
+        where the inner body is the agents_start response
+        ``{name, returncode, stdout, stderr}``. The MCP host can branch
+        on ``result.returncode``.
+
+        On failure (transport / 4xx-5xx / missing env): ``{"status":
+        "error", "reason": "...", "http_status": <int|null>,
+        "body": <server body or null>}`` — fail loud, never silently
+        swallowed (ADR-0010 / handoff §0).
+    """
+    from ..._lifecycle._spawn_client import SpawnRequestError, request_spawn
+
+    try:
+        result = request_spawn(
+            name, caller=caller, spec=spec, overwrite=overwrite
+        )
+    except SpawnRequestError as exc:
+        return {
+            "status": "error",
+            "reason": str(exc),
+            "http_status": exc.status,
+            "body": exc.body,
+        }
+    return {"status": "ok", "result": result}
 
 
 def agent_stop(name: str) -> dict[str, Any]:
@@ -175,6 +246,7 @@ def register_agent_tools(mcp) -> None:
         agent_check,
         agent_recall,
         agent_start,
+        agent_spawn,
         agent_stop,
         agent_restart,
         agent_send,
@@ -191,6 +263,7 @@ __all__ = [
     "agent_check",
     "agent_recall",
     "agent_start",
+    "agent_spawn",
     "agent_stop",
     "agent_restart",
     "agent_send",

--- a/tests/scitex_agent_container/_lifecycle/test__spawn_client.py
+++ b/tests/scitex_agent_container/_lifecycle/test__spawn_client.py
@@ -1,0 +1,400 @@
+"""Tests for the in-container spawn-proxy HTTP client (ADR-0010 mech #3).
+
+No-mocks pattern: the production module exposes an injectable
+``opener`` callable that defaults to ``urllib.request.urlopen``. Tests
+pass a hand-rolled opener that returns a ``urllib.response``-shaped
+object (a real file-like body + ``status``). This mirrors the
+established :mod:`scitex_agent_container._network.hub_client` test
+style — no ``monkeypatch.setattr`` on the production internals.
+
+Each test: AAA markers (TQ002), one assertion (TQ007), 3+-word name.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+from typing import Iterator
+from urllib import error as urlerror
+
+import pytest
+
+from scitex_agent_container._lifecycle._spawn_client import (
+    SpawnRequestError,
+    request_spawn,
+)
+
+# ---------------------------------------------------------------------------
+# Fake response + opener factories (real objects, urllib protocol)
+# ---------------------------------------------------------------------------
+
+
+class _FakeResp:
+    """A real callable response object matching the urllib contract.
+
+    ``__enter__`` / ``__exit__`` make it usable as the context manager
+    that ``urlrequest.urlopen(...)`` returns; ``read()`` yields the
+    bytes body; ``status`` carries the HTTP code the production
+    explicit-status guard reads.
+    """
+
+    def __init__(self, body: bytes, status: int = 200) -> None:
+        self._body = body
+        self.status = status
+
+    def __enter__(self) -> "_FakeResp":
+        return self
+
+    def __exit__(self, *args: object) -> bool:
+        return False
+
+    def read(self) -> bytes:
+        return self._body
+
+
+def _opener_returning(body: bytes, status: int = 200):
+    """Build (opener, captured) — the opener records each call."""
+    captured: dict = {}
+
+    def opener(req, timeout=None):
+        captured["url"] = req.full_url
+        captured["method"] = req.get_method()
+        captured["body"] = req.data
+        captured["headers"] = {k.lower(): v for k, v in dict(req.headers).items()}
+        captured["timeout"] = timeout
+        return _FakeResp(body, status)
+
+    return opener, captured
+
+
+def _opener_raising(exc: Exception):
+    def opener(req, timeout=None):
+        raise exc
+
+    return opener
+
+
+# ---------------------------------------------------------------------------
+# Env fixtures (real save/restore — both SAC_ and SCITEX_AGENT_CONTAINER_)
+# ---------------------------------------------------------------------------
+
+
+_LISTEN_KEYS = (
+    "SAC_LISTEN_BASE_URL",
+    "SCITEX_AGENT_CONTAINER_LISTEN_BASE_URL",
+    "SAC_LISTEN_BEARER",
+    "SCITEX_AGENT_CONTAINER_LISTEN_BEARER",
+    "SAC_NAME",
+    "SCITEX_AGENT_CONTAINER_NAME",
+)
+
+
+@pytest.fixture
+def listen_env() -> Iterator[callable]:
+    """Yield a setter; clears + restores both prefixes for every key.
+
+    Tests call ``set("LISTEN_BASE_URL", "http://h:9100")`` etc. — the
+    SAC_ short form is written so :func:`_env.getenv` resolves it.
+    """
+    saved = {k: os.environ.get(k) for k in _LISTEN_KEYS}
+    # Always start from a clean slate so a stray export in the operator's
+    # shell can't make a "must fail" test silently pass.
+    for k in _LISTEN_KEYS:
+        os.environ.pop(k, None)
+
+    def _set(suffix: str, value: str | None) -> None:
+        long_form = f"SCITEX_AGENT_CONTAINER_{suffix}"
+        short_form = f"SAC_{suffix}"
+        if value is None:
+            os.environ.pop(long_form, None)
+            os.environ.pop(short_form, None)
+        else:
+            os.environ.pop(long_form, None)
+            os.environ[short_form] = value
+
+    try:
+        yield _set
+    finally:
+        for k in _LISTEN_KEYS:
+            os.environ.pop(k, None)
+        for k, prev in saved.items():
+            if prev is not None:
+                os.environ[k] = prev
+
+
+# ---------------------------------------------------------------------------
+# Missing base URL — fail loud
+# ---------------------------------------------------------------------------
+
+
+def test_missing_base_url_raises_spawn_request_error(listen_env) -> None:
+    # Arrange — listen_env yields with both base-url envs cleared.
+    captured_message = ""
+    # Act
+    try:
+        request_spawn("child", opener=lambda req, timeout=None: None)
+    except SpawnRequestError as exc:
+        captured_message = str(exc)
+    # Assert — the error message must name the missing env var so the
+    # operator knows which container var the apptainer runtime missed.
+    assert "SAC_LISTEN_BASE_URL" in captured_message
+
+
+def test_empty_child_name_raises_spawn_request_error(listen_env) -> None:
+    # Arrange — even with a base URL set, empty child name must fail.
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    raised = False
+    # Act
+    try:
+        request_spawn("", opener=lambda req, timeout=None: None)
+    except SpawnRequestError:
+        raised = True
+    # Assert
+    assert raised is True
+
+
+# ---------------------------------------------------------------------------
+# Happy path — POST shape
+# ---------------------------------------------------------------------------
+
+
+def test_post_targets_agents_route_on_base_url(listen_env) -> None:
+    # Arrange
+    listen_env("LISTEN_BASE_URL", "http://host:9100/")  # trailing slash stripped
+    opener, captured = _opener_returning(b'{"name":"c","returncode":0}')
+    # Act
+    request_spawn("c", opener=opener)
+    # Assert
+    assert captured["url"] == "http://host:9100/agents"
+
+
+def test_post_uses_http_post_method(listen_env) -> None:
+    # Arrange
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    opener, captured = _opener_returning(b'{"name":"c","returncode":0}')
+    # Act
+    request_spawn("c", opener=opener)
+    # Assert
+    assert captured["method"] == "POST"
+
+
+def test_post_body_includes_child_name(listen_env) -> None:
+    # Arrange
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    opener, captured = _opener_returning(b'{"name":"c","returncode":0}')
+    # Act
+    request_spawn("c", opener=opener)
+    # Assert
+    assert json.loads(captured["body"])["name"] == "c"
+
+
+def test_post_body_defaults_caller_from_sac_name_env(listen_env) -> None:
+    # Arrange — SAC_NAME present → resolved as caller automatically.
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    listen_env("NAME", "parent-bot")
+    opener, captured = _opener_returning(b'{"name":"c","returncode":0}')
+    # Act
+    request_spawn("c", opener=opener)
+    # Assert
+    assert json.loads(captured["body"])["caller"] == "parent-bot"
+
+
+def test_post_body_omits_caller_for_admin_path(listen_env) -> None:
+    # Arrange — no SAC_NAME → admin path; the field is omitted entirely
+    # so the server-side ``check_spawn(caller=None)`` admin branch runs.
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    opener, captured = _opener_returning(b'{"name":"c","returncode":0}')
+    # Act
+    request_spawn("c", opener=opener)
+    # Assert
+    assert "caller" not in json.loads(captured["body"])
+
+
+def test_explicit_caller_arg_overrides_sac_name_env(listen_env) -> None:
+    # Arrange — env says "env-parent" but the explicit caller wins.
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    listen_env("NAME", "env-parent")
+    opener, captured = _opener_returning(b'{"name":"c","returncode":0}')
+    # Act
+    request_spawn("c", caller="arg-parent", opener=opener)
+    # Assert
+    assert json.loads(captured["body"])["caller"] == "arg-parent"
+
+
+def test_inline_spec_is_forwarded_with_overwrite_flag(listen_env) -> None:
+    # Arrange — inline-spec path (server materialises under ~/.scitex/...).
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    spec = {"apiVersion": "scitex-agent-container/v3", "kind": "Agent", "spec": {}}
+    opener, captured = _opener_returning(b'{"name":"c","returncode":0}')
+    # Act
+    request_spawn("c", spec=spec, overwrite=True, opener=opener)
+    # Assert
+    body = json.loads(captured["body"])
+    assert body["spec"] == spec and body["overwrite"] is True
+
+
+def test_bearer_token_attached_as_authorization_header(listen_env) -> None:
+    # Arrange
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    listen_env("LISTEN_BEARER", "tok-abc")
+    opener, captured = _opener_returning(b'{"name":"c","returncode":0}')
+    # Act
+    request_spawn("c", opener=opener)
+    # Assert
+    assert captured["headers"].get("authorization") == "Bearer tok-abc"
+
+
+def test_no_authorization_header_when_bearer_unset(listen_env) -> None:
+    # Arrange — no bearer in env, none passed explicitly.
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    opener, captured = _opener_returning(b'{"name":"c","returncode":0}')
+    # Act
+    request_spawn("c", opener=opener)
+    # Assert
+    assert "authorization" not in captured["headers"]
+
+
+def test_content_type_header_is_application_json(listen_env) -> None:
+    # Arrange
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    opener, captured = _opener_returning(b'{"name":"c","returncode":0}')
+    # Act
+    request_spawn("c", opener=opener)
+    # Assert
+    assert captured["headers"].get("content-type") == "application/json"
+
+
+# ---------------------------------------------------------------------------
+# Success — returns parsed dict
+# ---------------------------------------------------------------------------
+
+
+def test_success_returns_parsed_response_dict(listen_env) -> None:
+    # Arrange — server's agents_start returns the {name, returncode, ...} dict.
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    body = json.dumps(
+        {"name": "c", "returncode": 0, "stdout": "ok", "stderr": ""}
+    ).encode()
+    opener, _ = _opener_returning(body)
+    # Act
+    out = request_spawn("c", opener=opener)
+    # Assert
+    assert out["returncode"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Failure modes — fail loud, never swallowed
+# ---------------------------------------------------------------------------
+
+
+def test_acl_403_deny_raises_with_reason_in_body(listen_env) -> None:
+    # Arrange — server returns the ACL deny payload from deny_response().
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    deny_body = json.dumps(
+        {"error": "ACL deny", "reason": "spawn denied: caller is a child"}
+    ).encode()
+    opener = _opener_raising(
+        urlerror.HTTPError(
+            "http://host:9100/agents", 403, "Forbidden", {}, io.BytesIO(deny_body)
+        )
+    )
+    captured_status = None
+    # Act
+    try:
+        request_spawn("c", opener=opener)
+    except SpawnRequestError as exc:
+        captured_status = exc.status
+    # Assert
+    assert captured_status == 403
+
+
+def test_acl_403_deny_preserves_server_reason_in_body_attr(listen_env) -> None:
+    # Arrange
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    deny_body = json.dumps(
+        {"error": "ACL deny", "reason": "spawn denied: caller is a child"}
+    ).encode()
+    opener = _opener_raising(
+        urlerror.HTTPError(
+            "http://host:9100/agents", 403, "Forbidden", {}, io.BytesIO(deny_body)
+        )
+    )
+    # Act
+    try:
+        request_spawn("c", opener=opener)
+    except SpawnRequestError as exc:
+        captured_body = exc.body
+    # Assert — the server's reason survives verbatim for caller logs.
+    assert captured_body == {
+        "error": "ACL deny",
+        "reason": "spawn denied: caller is a child",
+    }
+
+
+def test_server_500_raises_spawn_request_error(listen_env) -> None:
+    # Arrange — a 500 must propagate as a fail-loud error, not return None.
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    opener = _opener_raising(
+        urlerror.HTTPError(
+            "http://host:9100/agents", 500, "boom", {}, io.BytesIO(b"")
+        )
+    )
+    captured_status = None
+    # Act
+    try:
+        request_spawn("c", opener=opener)
+    except SpawnRequestError as exc:
+        captured_status = exc.status
+    # Assert
+    assert captured_status == 500
+
+
+def test_transport_error_raises_spawn_request_error(listen_env) -> None:
+    # Arrange — listen unreachable (connection refused etc.).
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    opener = _opener_raising(urlerror.URLError("connection refused"))
+    captured_status: object = "UNSET"
+    # Act
+    try:
+        request_spawn("c", opener=opener)
+    except SpawnRequestError as exc:
+        captured_status = exc.status
+    # Assert — no HTTP exchange happened, so status stays None.
+    assert captured_status is None
+
+
+def test_non_dict_2xx_body_raises_spawn_request_error(listen_env) -> None:
+    # Arrange — server returns a JSON array instead of an object; must
+    # fail loud rather than silently corrupt the caller's downstream use.
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    opener, _ = _opener_returning(b'[1,2,3]', status=200)
+    raised = False
+    # Act
+    try:
+        request_spawn("c", opener=opener)
+    except SpawnRequestError:
+        raised = True
+    # Assert
+    assert raised is True
+
+
+def test_explicit_bearer_arg_overrides_env(listen_env) -> None:
+    # Arrange — env has tok-env but the arg passes tok-arg.
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    listen_env("LISTEN_BEARER", "tok-env")
+    opener, captured = _opener_returning(b'{"name":"c","returncode":0}')
+    # Act
+    request_spawn("c", bearer="tok-arg", opener=opener)
+    # Assert
+    assert captured["headers"].get("authorization") == "Bearer tok-arg"
+
+
+def test_explicit_base_url_arg_overrides_env(listen_env) -> None:
+    # Arrange
+    listen_env("LISTEN_BASE_URL", "http://env-host:9100")
+    opener, captured = _opener_returning(b'{"name":"c","returncode":0}')
+    # Act
+    request_spawn("c", base_url="http://arg-host:9100", opener=opener)
+    # Assert
+    assert captured["url"] == "http://arg-host:9100/agents"

--- a/tests/scitex_agent_container/_mcp/_tools/test__agent_spawn.py
+++ b/tests/scitex_agent_container/_mcp/_tools/test__agent_spawn.py
@@ -1,0 +1,214 @@
+"""Tests for the MCP ``agent_spawn`` tool wrapper.
+
+The wrapper delegates to
+:func:`scitex_agent_container._lifecycle._spawn_client.request_spawn`
+and re-shapes the result/error into a status-tagged dict suitable for
+an MCP host. We verify both the registration shim and the wrap/error
+shaping.
+
+PA-306 / STX-NM002: no ``unittest.mock``, no ``monkeypatch``. The
+``request_spawn`` collaborator is swapped on the ``_spawn_client``
+module namespace via a real save/restore context manager — mirrors
+the ``test__agent_send.py`` pattern.
+
+STX-TQ002 / TQ007: AAA markers per test, one fact per test.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Iterator
+
+import scitex_agent_container._lifecycle._spawn_client as _spawn_mod
+from scitex_agent_container._lifecycle._spawn_client import SpawnRequestError
+from scitex_agent_container._mcp._tools import register_all_tools
+from scitex_agent_container._mcp._tools._agent import (
+    agent_spawn,
+    register_agent_tools,
+)
+
+
+@contextmanager
+def _swap_request_spawn(*, raises: Exception | None = None, returns: dict | None = None) -> Iterator[list]:
+    """Swap ``_spawn_client.request_spawn`` with a recording fake.
+
+    Yields the capture list. ``raises`` simulates a SpawnRequestError;
+    ``returns`` provides the success payload. Exactly one must be
+    given.
+    """
+    captured: list = []
+
+    def fake(*args, **kwargs):
+        captured.append({"args": args, "kwargs": kwargs})
+        if raises is not None:
+            raise raises
+        return returns if returns is not None else {"name": args[0], "returncode": 0}
+
+    saved = _spawn_mod.request_spawn
+    _spawn_mod.request_spawn = fake  # type: ignore[assignment]
+    try:
+        yield captured
+    finally:
+        _spawn_mod.request_spawn = saved  # type: ignore[assignment]
+
+
+class _FakeMCP:
+    """Records every fn registered via ``@mcp.tool()``."""
+
+    def __init__(self) -> None:
+        self.registered: list = []
+
+    def tool(self, *args, **kw):
+        def decorator(fn):
+            self.registered.append(fn)
+            return fn
+
+        return decorator
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+def test_agent_spawn_registered_in_mcp_tool_list():
+    # Arrange
+    mcp = _FakeMCP()
+    # Act
+    register_all_tools(mcp)
+    # Assert
+    assert "agent_spawn" in {fn.__name__ for fn in mcp.registered}
+
+
+def test_register_agent_tools_includes_agent_spawn():
+    # Arrange
+    mcp = _FakeMCP()
+    # Act
+    register_agent_tools(mcp)
+    # Assert
+    assert "agent_spawn" in {fn.__name__ for fn in mcp.registered}
+
+
+# ---------------------------------------------------------------------------
+# Happy path — wraps result with status=ok
+# ---------------------------------------------------------------------------
+
+
+def test_agent_spawn_returns_status_ok_on_success():
+    # Arrange
+    with _swap_request_spawn(returns={"name": "c", "returncode": 0}):
+        # Act
+        out = agent_spawn("c")
+    # Assert
+    assert out["status"] == "ok"
+
+
+def test_agent_spawn_wraps_server_body_under_result_key():
+    # Arrange
+    body = {"name": "c", "returncode": 0, "stdout": "ok", "stderr": ""}
+    with _swap_request_spawn(returns=body):
+        # Act
+        out = agent_spawn("c")
+    # Assert
+    assert out["result"] == body
+
+
+def test_agent_spawn_forwards_name_to_request_spawn():
+    # Arrange
+    with _swap_request_spawn() as captured:
+        # Act
+        agent_spawn("alpha")
+    # Assert
+    assert captured[-1]["args"][0] == "alpha"
+
+
+def test_agent_spawn_forwards_inline_spec_kwarg():
+    # Arrange
+    spec = {"apiVersion": "scitex-agent-container/v3", "kind": "Agent", "spec": {}}
+    with _swap_request_spawn() as captured:
+        # Act
+        agent_spawn("alpha", spec=spec)
+    # Assert
+    assert captured[-1]["kwargs"]["spec"] == spec
+
+
+def test_agent_spawn_forwards_overwrite_kwarg():
+    # Arrange
+    with _swap_request_spawn() as captured:
+        # Act
+        agent_spawn("alpha", spec={"a": 1}, overwrite=True)
+    # Assert
+    assert captured[-1]["kwargs"]["overwrite"] is True
+
+
+def test_agent_spawn_forwards_explicit_caller_kwarg():
+    # Arrange
+    with _swap_request_spawn() as captured:
+        # Act
+        agent_spawn("alpha", caller="parent-bot")
+    # Assert
+    assert captured[-1]["kwargs"]["caller"] == "parent-bot"
+
+
+# ---------------------------------------------------------------------------
+# Error paths — fail loud, structured
+# ---------------------------------------------------------------------------
+
+
+def test_agent_spawn_returns_status_error_on_spawn_request_error():
+    # Arrange — a deny from the server-side ACL gate.
+    err = SpawnRequestError(
+        "spawn of 'c' rejected: listen returned HTTP 403",
+        status=403,
+        body={"error": "ACL deny", "reason": "child caller"},
+    )
+    with _swap_request_spawn(raises=err):
+        # Act
+        out = agent_spawn("c")
+    # Assert
+    assert out["status"] == "error"
+
+
+def test_agent_spawn_error_includes_http_status_code():
+    # Arrange
+    err = SpawnRequestError("nope", status=403, body={"reason": "x"})
+    with _swap_request_spawn(raises=err):
+        # Act
+        out = agent_spawn("c")
+    # Assert
+    assert out["http_status"] == 403
+
+
+def test_agent_spawn_error_includes_server_body_verbatim():
+    # Arrange
+    err_body = {"error": "ACL deny", "reason": "child caller may not spawn"}
+    err = SpawnRequestError("denied", status=403, body=err_body)
+    with _swap_request_spawn(raises=err):
+        # Act
+        out = agent_spawn("c")
+    # Assert — server's reason survives so the MCP host can render it.
+    assert out["body"] == err_body
+
+
+def test_agent_spawn_transport_error_returns_null_http_status():
+    # Arrange — transport-layer failure (listen unreachable).
+    err = SpawnRequestError(
+        "spawn of 'c' failed: cannot reach listen at 'http://h:9100'",
+        status=None,
+        body=None,
+    )
+    with _swap_request_spawn(raises=err):
+        # Act
+        out = agent_spawn("c")
+    # Assert
+    assert out["http_status"] is None
+
+
+def test_agent_spawn_error_includes_reason_message():
+    # Arrange
+    err = SpawnRequestError("very specific failure text", status=500, body=None)
+    with _swap_request_spawn(raises=err):
+        # Act
+        out = agent_spawn("c")
+    # Assert
+    assert out["reason"] == "very specific failure text"


### PR DESCRIPTION
## Summary

ADR-0010 mechanism #3, step 4 — the in-container spawn-proxy client. Lets an agent **inside** an apptainer container ask the bare-host `sac listen` to spawn a child, without apptainer-in-apptainer and without a separate daemon. The host endpoint, ACL gate, and lineage recorder already exist (PRs #189, #197); this PR adds:

- `request_spawn(...)` — stdlib-only urllib POST to `{SAC_LISTEN_BASE_URL}/agents`, bearer from `SAC_LISTEN_BEARER`, caller from `SAC_NAME`. All three injected by the apptainer runtime.
- `SpawnRequestError(status, body)` — fail-loud on missing env, transport failure, 4xx/5xx (incl. 403 ACL deny — server reason forwarded verbatim), or 2xx non-dict body. No silent fallbacks.
- MCP `agent_spawn` tool — wraps the client; returns `{status: ok, result: {...}}` or `{status: error, reason, http_status, body}` so the MCP host can render the deny reason intact.

**Unblocks clew's "sac from sac" workflow today** without waiting for the full `spec.acl` schema + `child ⊆ parent` clamp work (ADR-0010 Phase 3 steps 2–3). The existing root-only `check_spawn` policy already permits a root agent like clew to spawn capsule children, and the clamp will slot into the same `enforce_spawn_gate` chokepoint when it lands.

## Why standalone (not blocked on `spec.acl`)

- `POST /agents` already calls `check_spawn` (root-only binary policy) + `record_lineage` (PR #189). clew is a root → it will be allowed.
- The future `child ⊆ parent` clamp will be installed inside `enforce_spawn_gate`, the existing single chokepoint, so this PR's transport surface needs no rework when that lands.

## Test plan

PA-306 no-mocks, STX-TQ002 AAA + STX-TQ007 one-assertion-per-test throughout.

- **`tests/_lifecycle/test__spawn_client.py` (20 tests)** — POST shape (URL/method/body keys), caller resolution (env default / explicit override / admin-path omission), inline-spec forwarding, bearer header presence/absence, 200 → parsed dict, 403/500/transport → `SpawnRequestError` with status preserved, 2xx non-dict → fail loud, explicit `base_url`/`bearer` arg overrides env. Uses the established `_network.hub_client` opener-injection pattern.
- **`tests/_mcp/_tools/test__agent_spawn.py` (13 tests)** — registration (both `register_agent_tools` and `register_all_tools`), kwarg forwarding (name, spec, overwrite, caller), success/error envelope shaping, transport-error null-http_status path.

## Verification

- 33 new tests pass.
- `_lifecycle/` + `_listen/` + `_mcp/` regression suites: 685 passed.
- Full project suite: 4943 passed. The 21 remaining failures (`_drift`, `_helpers/completion`, `cli_pkg/hook_cmds`, `test_statusline`, `runtimes/_sdk_common`, `a2a/_handlers`, `audit-mcp-tools` internal TypeError) are pre-existing on develop and unrelated to this PR — verified by running the same failures against `develop` head with no PYTHONPATH override.
- ruff clean on all four files.
- audit-python-apis / audit-skills / audit-project all clean.

## Follow-ups (separate PRs)

- ADR-0010 Phase 3 Step 2: `spec.acl` schema + parser.
- ADR-0010 Phase 3 Step 3: `child ⊆ parent` clamp inside `enforce_spawn_gate` + lead-bypass rule.
- `sac acl grant/revoke/list` operator CLI.
- `sac fleet tree` DAG visualisation (schema fields already there).