### PR TITLE
feat(provider): vendor-agnostic Anthropic-SDK backend override (DeepSeek)

### DIFF
--- a/docs/adr/0011-deepseek-provider-env-config-resolution.md
+++ b/docs/adr/0011-deepseek-provider-env-config-resolution.md
@@ -1,0 +1,172 @@
+# ADR-0011 — DeepSeek / multi-provider auth-token location + resolution via scitex-config
+
+## Status
+
+Accepted (lands with PR #208 — `feat/deepseek-provider-override`).
+
+## Context
+
+sac agents need to run on Anthropic-SDK-compatible alternate providers
+(DeepSeek first, gateway/self-hosted shapes later) for bulk fleet work
+where Anthropic Max-plan quota / OAuth token refresh would otherwise be
+the bottleneck. The provider override requires:
+
+1. **One canonical on-disk home for the auth token** — operators must not
+   have to set the same secret in multiple places, and sac must not
+   surprise them with cwd-relative or hidden-dotfile lookups.
+2. **A documented precedence cascade** — so a temporary `export` in the
+   launch shell predictably overrides the on-disk value, and silent
+   fallback to Anthropic on a missing key is impossible.
+3. **Consistency with the SciTeX ecosystem** — packages across the
+   ecosystem already use scitex-config's `direct → config → env → default`
+   cascade; sac should follow the same convention, not invent a fourth
+   one.
+
+Earlier iterations of PR #208 hand-rolled a `to_home/.env` parser inside
+`_apptainer_provider.py`. The operator's correction (msg 5325): "resolve
+the provider auth token THROUGH scitex-config so precedence is consistent
+with the ecosystem" — replace the hand-rolled parser with the canonical
+ecosystem primitive.
+
+## Decision
+
+1. **Key location.** The DeepSeek API key (and any future provider key
+   declared via `spec.claude.provider.auth_token_env`) lives in the agent's
+   `to_home/.env`, which `runtimes/_to_home.py` materializes into the
+   container's `$HOME/.env` at start (env-injection port 3 — the
+   `to_home → $HOME` mirror; see ADR-0006 / ADR-0009). The host-side
+   equivalent for the launch shell is `$HOME/.env` on the host running
+   `sac agents start`.
+
+2. **Resolution via scitex-config (public API).** `_apptainer_provider.py`
+   resolves the token through the scitex-config public surface — no
+   bespoke parser:
+
+   ```python
+   from pathlib import Path
+   from scitex_config import PriorityConfig, load_dotenv
+
+   load_dotenv(dotenv_path=str(Path.home() / ".env"))
+   resolver = PriorityConfig(auto_uppercase=False)
+   api_key = resolver.resolve(key=auth_token_env, default="")
+   ```
+
+   - `load_dotenv(dotenv_path=...)` merges the named file into
+     `os.environ` **without overriding any already-set var**. The path
+     is pinned to `$HOME/.env` on purpose: the library's default search
+     order also reads `cwd/.env` first, which would be a surprise for
+     an operator running `sac agents start` from an unrelated project
+     dir.
+   - `PriorityConfig(auto_uppercase=False).resolve(key=…)` reads from
+     `os.environ` and applies the standard SciTeX cascade. We pass
+     `auto_uppercase=False` because `auth_token_env` is already the
+     literal env-var name declared by the spec.
+   - `PriorityConfig` auto-masks `API_KEY` / `TOKEN` / `SECRET` style
+     keys in its resolution log — sac never logs the key value.
+
+3. **Precedence cascade (canonical).** From highest priority to lowest:
+
+   1. **direct shell export** — `export DEEPSEEK_API_KEY=...` in the
+      shell that runs `sac agents start`. Wins over everything.
+   2. **`$HOME/.env`** — the operator's standard SciTeX dotenv location,
+      loaded via `scitex_config.load_dotenv`.
+   3. **default** — empty string, which trips the fail-loud branch.
+
+   Note: scitex-config's full cascade signature is `direct → config →
+   env → default`. In sac's call site `config` (YAML) is intentionally
+   not used — API-key secrets do not belong in YAML — so the live
+   layers reduce to `env (process env, populated by load_dotenv) →
+   default`. The `direct` slot is reserved for a future caller-supplied
+   override (e.g. a literal `auth_token` in the spec).
+
+4. **Fail-loud, never silent.** If the cascade yields an empty string,
+   `_apptainer_provider.provider_env_flags()` raises `ProviderEnvError`
+   with a message that names BOTH sources the operator can set. There
+   is no silent fallback to Anthropic — a missing key on a
+   provider-active agent must crash the start, not 401 every turn with
+   a fresh-looking heartbeat.
+
+5. **Spec surface.** `spec.claude.provider: { base_url, auth_token_env }`
+   declares the provider; `spec.claude.model` accepts the provider's
+   own model name (e.g. `deepseek-v4-pro`, lowercase) once the
+   provider block is present (the claude-* model alias check is
+   relaxed under a provider override). `spec.claude.account` and
+   `spec.claude.provider` remain mutually exclusive — an API-key
+   backend uses no Anthropic OAuth.
+
+## Consequences
+
+### Positive
+
+- **Single source of truth.** The operator sets the key once in
+  `$HOME/.env` (or `to_home/.env` for in-container parity); sac switches
+  every agent that names the right `auth_token_env`.
+- **Ecosystem-consistent precedence.** scitex-config owns the cascade.
+  No more re-implementation drift across packages — anyone reading
+  another scitex package's code knows what to expect here.
+- **Sensitive masking comes for free.** `PriorityConfig` recognises
+  `*API*`, `*KEY*`, `*TOKEN*`, `*SECRET*`, etc., and masks the value in
+  its resolution log without any sac-side bookkeeping.
+- **Smaller surface to maintain.** Removed the hand-rolled
+  `_parse_dotenv` / `_to_home_env` helpers from
+  `_apptainer_provider.py` (−145 lines / +94 lines net delta in
+  PR #208's third commit `6ddd2c9`).
+
+### Negative / things to watch
+
+- **Process-wide `os.environ` mutation.** `load_dotenv()` writes to
+  the live process env (only keys not already set). For a sac process
+  running multiple agents with DIFFERENT provider keys, all those keys
+  must coexist in `$HOME/.env` with distinct env-var names (e.g.
+  `DEEPSEEK_API_KEY_PROD`, `DEEPSEEK_API_KEY_DEV`). Per-agent secret
+  isolation via separate `to_home/.env` files no longer applies to
+  host-side provider resolution.
+- **Secret hygiene is the operator's job.** The key is a real secret
+  in a 0600 file. A leaked `$HOME/.env` is a leaked key — must be
+  rotated. sac does not encrypt at rest.
+- **scitex-config is now in `[project] dependencies`.** It was
+  effectively a runtime dependency through `_ecosystem.local_state`
+  already, but the public `PriorityConfig` + `load_dotenv` surface is
+  used directly now. `pyproject.toml` declares `scitex-config>=0.3.0`
+  (the release that split public from ecosystem-internal and exposed
+  both surfaces).
+
+## Alternatives considered
+
+- **Hand-rolled `to_home/.env` parser inside `_apptainer_provider.py`**
+  — was implemented in commit `33505eb` (the interim commit on PR #208),
+  then superseded by the scitex-config refactor in `6ddd2c9` on operator
+  guidance. Rejected because (a) two parsers reading two `.env` files
+  for the same purpose is churn, (b) precedence rules would drift from
+  the ecosystem standard, (c) sensitive-key masking would have to be
+  re-implemented.
+
+- **Bare `os.environ.get(auth_token_env)`** with no `.env` loading —
+  the original v1 of `provider_env_flags()`. Rejected because it
+  forces every operator to manage shell exports / dotfile sourcing
+  manually, with no canonical on-disk home.
+
+- **YAML config (`~/.scitex/sac.yaml` with provider keys)** via
+  `scitex_config.ScitexConfig` — declined. Secrets in YAML files are
+  a worse default than secrets in `chmod 0600 .env`. The `config`
+  layer in scitex-config is left intentionally unused for this lookup.
+
+- **Per-package mini-resolver** that re-exports the cascade as a sac
+  helper — declined. Adds sac-specific API surface for no gain over
+  calling scitex-config directly.
+
+## Related work
+
+- ADR-0006 — `to_home` materialization layout (the in-container side
+  of the `.env` story).
+- ADR-0009 — Claude setup delivery: `to_home` first.
+- PR #208 — `feat/deepseek-provider-override` — implements this ADR.
+
+## Sequencing notes
+
+- WI-A (audit-failure fix, 1b) is in flight on its own branch and will
+  land before #208's CI can go fully green.
+- This ADR ships in PR #208 itself, not a standalone PR — the
+  decisions described here ARE PR #208's decisions; they should land
+  together so that a future reader hitting `git log` finds the rationale
+  next to the implementation.

--- a/examples/agents/deepseek-agent/spec.yaml
+++ b/examples/agents/deepseek-agent/spec.yaml
@@ -1,0 +1,43 @@
+# deepseek — sac v3 agent running on DeepSeek instead of Anthropic.
+#
+# spec.claude.provider points the SDK session at an Anthropic-SDK-
+# compatible backend (DeepSeek here) using a never-expiring, login-free
+# API key. Ideal for bulk fleet work where Max-plan quota / OAuth token
+# refresh would otherwise be the bottleneck.
+#
+# How it works at start (see runtimes/_apptainer_provider.py):
+#   * ANTHROPIC_BASE_URL  ← provider.base_url
+#   * SAC_ANTHROPIC_API_KEY ← the HOST value of $DEEPSEEK_API_KEY
+#       (sac bridges it to ANTHROPIC_API_KEY for the SDK)
+#   * CLAUDE_CONFIG_DIR   ← a clean per-agent dir (conflict-breaker so
+#       the OAuth credentials bind cannot win); the OAuth bind is skipped.
+#
+# Prerequisite: export the API key on the host BEFORE `sac agents start`:
+#   source ~/.dotfiles/.../api_keys/10_llm_deepseek.src   # exports DEEPSEEK_API_KEY
+# sac reads $DEEPSEEK_API_KEY's value at start and never logs it. If the
+# env var is unset, start fails loud (no silent fallback to Anthropic).
+#
+# Mutually exclusive with spec.claude.account (an API-key backend needs
+# no Anthropic OAuth) — declaring both is a config error.
+
+apiVersion: scitex-agent-container/v3
+kind: Agent
+
+spec:
+  runtime: apptainer
+
+  apptainer:
+    image: ~/.scitex/agent-container/containers/sac-scitex.sif
+
+  claude:
+    # The provider's own model id — accepted because provider is set
+    # (the claude-* alias check is relaxed under a provider override).
+    model: deepseek-chat
+    flags:
+      - --dangerously-skip-permissions
+    provider:
+      base_url: https://api.deepseek.com/anthropic
+      # NAME of the host env var holding the key — NOT the key value.
+      auth_token_env: DEEPSEEK_API_KEY
+
+# EOF

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,17 @@ dependencies = [
     # bookkeeping).
     "ruamel.yaml>=0.18",
     "rich>=13.0",
+    # Two distinct uses:
+    #   1. `scitex_config._ecosystem.local_state` — canonical local-state
+    #      directory helper (project-scope override + auto runtime/ seed
+    #      creation) per scitex-python skill
+    #      01_arch_06_local-state-directories.md.
+    #   2. Public `PriorityConfig` + `load_dotenv` surface — used by
+    #      `runtimes/_apptainer_provider.py` to resolve the provider
+    #      auth token via the SciTeX-ecosystem `direct → config → env
+    #      → default` cascade (see ADR-0011).
+    # v0.3.0 was the release that split public from ecosystem-internal
+    # and exposed both surfaces — that is our hard minimum.
     "scitex-config>=0.3.0",
     "scitex-container>=0.1.0",
     "scitex-logging>=0.1.5",
@@ -57,10 +68,6 @@ dependencies = [
     # validate_proto_required_fields still references — pin until upstream
     # adopts the descriptor pool API. See CI failure 2026-04-27.
     "protobuf<6",
-    # Canonical local-state directory helper (project-scope override +
-    # auto runtime/ seed creation). Per scitex-python skill
-    # 01_arch_06_local-state-directories.md.
-    "scitex-config>=0.3.0",
 ]
 
 [project.optional-dependencies]

--- a/src/scitex_agent_container/config/__init__.py
+++ b/src/scitex_agent_container/config/__init__.py
@@ -18,6 +18,7 @@ import yaml
 
 from ._host import resolve_hostname, substitute_hostnames
 from ._loaders import compose_effective_name, load_v3
+from ._provider_types import ProviderSpec
 from ._proxy_types import ProxySpec
 from ._resolve import resolve_config
 from ._types import (
@@ -46,6 +47,7 @@ __all__ = [
     "HookSpec",
     "HostsSpec",
     "ListenPort",
+    "ProviderSpec",
     "ProxySpec",
     "RestartSpec",
     "SchedulingSpec",

--- a/src/scitex_agent_container/config/_parsers/_claude.py
+++ b/src/scitex_agent_container/config/_parsers/_claude.py
@@ -2,7 +2,24 @@
 
 from __future__ import annotations
 
+from .._provider_types import ProviderSpec
 from .._types import ClaudeSpec
+
+
+def _parse_provider(raw: dict) -> ProviderSpec | None:
+    """Parse ``spec.claude.provider`` into a ``ProviderSpec`` or ``None``.
+
+    Absent / explicit-null block → ``None`` (default Anthropic backend).
+    Non-empty fields are surfaced verbatim; the validator enforces that
+    ``base_url`` + ``auth_token_env`` are non-empty when the block exists.
+    """
+    block = raw.get("provider")
+    if not isinstance(block, dict):
+        return None
+    return ProviderSpec(
+        base_url=str(block.get("base_url", "") or ""),
+        auth_token_env=str(block.get("auth_token_env", "") or ""),
+    )
 
 
 def parse_claude(spec: dict) -> ClaudeSpec:
@@ -39,5 +56,6 @@ def parse_claude(spec: dict) -> ClaudeSpec:
         resume_id=str(raw.get("resume_id", "") or ""),
         auto_accept=raw.get("auto_accept", True),
         account=str(raw.get("account", "") or ""),
+        provider=_parse_provider(raw),
         raw_options=dict(raw_options),
     )

--- a/src/scitex_agent_container/config/_provider_types.py
+++ b/src/scitex_agent_container/config/_provider_types.py
@@ -1,0 +1,53 @@
+"""ProviderSpec dataclass for ``spec.claude.provider`` (backend override).
+
+Lives in its own module to keep ``_types.py`` under the project's
+512-line cap (mirrors ``_proxy_types.py``). Re-exported from
+:mod:`scitex_agent_container.config` alongside the rest of the spec
+dataclasses.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class ProviderSpec:
+    """Vendor-agnostic backend override for the Claude SDK session.
+
+    When set under ``spec.claude.provider``, the agent's SDK session
+    talks to an Anthropic-SDK-compatible backend OTHER than Anthropic
+    (DeepSeek, a self-hosted gateway, etc.) using a never-expiring,
+    login-free API key instead of Anthropic OAuth. Lets bulk fleet
+    work run on a cheap backend without burning Max-plan quota.
+
+    The runtime injects three env vars into the container at start
+    (see ``runtimes/_apptainer_provider.py``):
+
+    * ``ANTHROPIC_BASE_URL`` ← :attr:`base_url`
+    * ``SAC_ANTHROPIC_API_KEY`` ← the host value of ``$<auth_token_env>``
+      (bridged to ``ANTHROPIC_API_KEY`` for the SDK by sac's existing
+      auth handoff). Fails loud at start if the env var is unset.
+    * ``CLAUDE_CONFIG_DIR`` ← a clean per-agent dir — the conflict-breaker
+      so the OAuth ``.credentials.json`` bind cannot win (apptainer
+      ``--env`` is last-wins).
+
+    The model id is the provider's own (e.g. ``deepseek-chat``); the
+    claude-* regex in :mod:`config._validation` is relaxed whenever a
+    provider is declared.
+
+    Mutually exclusive with :attr:`ClaudeSpec.account` (OAuth pin) — an
+    API-key backend needs no OAuth, so declaring both is a config error
+    the runtime rejects loudly.
+    """
+
+    base_url: str = ""
+    """Anthropic-compatible base URL, e.g.
+    ``https://api.deepseek.com/anthropic``. Required when the provider
+    block is present."""
+
+    auth_token_env: str = ""
+    """NAME of the host env var holding the API key (e.g.
+    ``DEEPSEEK_API_KEY``) — NOT the key value. The operator sources the
+    secret file; sac reads the env var's value at start and never logs
+    it. Required when the provider block is present."""

--- a/src/scitex_agent_container/config/_types.py
+++ b/src/scitex_agent_container/config/_types.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict
 
+from ._provider_types import ProviderSpec
+
 
 @dataclass
 class ContainerSpec:
@@ -61,6 +63,12 @@ class ClaudeSpec:
     # move a pinned agent (that is the point of pinning), and changing
     # this field requires ``sac agent restart`` to re-copy the snapshot.
     account: str = ""
+    # Vendor-agnostic backend override (see :class:`ProviderSpec`).
+    # When set, the SDK session runs against an Anthropic-SDK-compatible
+    # backend (DeepSeek, a gateway, ...) on an API key instead of
+    # Anthropic OAuth. ``None`` = default Anthropic backend. Mutually
+    # exclusive with ``account`` (an API-key backend needs no OAuth).
+    provider: ProviderSpec | None = None
 
 
 @dataclass

--- a/src/scitex_agent_container/config/_validation.py
+++ b/src/scitex_agent_container/config/_validation.py
@@ -128,6 +128,32 @@ _V3_REMOVED_FIELDS: dict[str, str] = {
 }
 
 
+def _validate_provider(provider_block: object) -> list[str]:
+    """Validate ``spec.claude.provider`` (vendor backend override).
+
+    Absent / non-dict → no errors (provider feature unused). When the
+    block is a dict, both ``base_url`` and ``auth_token_env`` must be
+    non-empty strings — an incomplete override would silently fall back
+    to Anthropic at runtime, which we refuse to allow.
+    """
+    if not isinstance(provider_block, dict):
+        return []
+    errors: list[str] = []
+    for field_name in ("base_url", "auth_token_env"):
+        val = provider_block.get(field_name)
+        if val is None or val == "":
+            errors.append(
+                f"spec.claude.provider.{field_name} is required and must be "
+                "non-empty when spec.claude.provider is declared."
+            )
+        elif not isinstance(val, str):
+            errors.append(
+                f"spec.claude.provider.{field_name} must be a string, got "
+                f"{type(val).__name__}"
+            )
+    return errors
+
+
 def validate_raw(raw: dict, path: str) -> list[str]:
     """Validate raw YAML dict. Returns list of error strings (empty means valid)."""
     errors: list[str] = []
@@ -238,13 +264,23 @@ def validate_raw(raw: dict, path: str) -> list[str]:
         # validate time. Empty / missing is allowed — runtime falls back
         # to its default.
         claude_block = spec.get("claude", {}) or {}
-        model = claude_block.get("model") if isinstance(claude_block, dict) else None
+        if not isinstance(claude_block, dict):
+            claude_block = {}
+        # spec.claude.provider — vendor-agnostic backend override
+        # (ProviderSpec). When present, the SDK session runs against an
+        # Anthropic-SDK-compatible backend on an API key, so the model id
+        # is the provider's own (e.g. 'deepseek-chat') and the claude-*
+        # regex below is skipped. Absent → behaviour unchanged.
+        provider_block = claude_block.get("provider")
+        has_provider = isinstance(provider_block, dict)
+        errors.extend(_validate_provider(provider_block))
+        model = claude_block.get("model")
         if model is not None:
             if not isinstance(model, str):
                 errors.append(
                     f"spec.claude.model must be a string, got {type(model).__name__}"
                 )
-            elif model and not _VALID_MODEL_RE.match(model):
+            elif model and not has_provider and not _VALID_MODEL_RE.match(model):
                 errors.append(
                     f"spec.claude.model '{model}' is not an accepted alias. "
                     "Use a bare alias ('opus', 'sonnet', 'haiku', 'inherit', "
@@ -254,8 +290,20 @@ def validate_raw(raw: dict, path: str) -> list[str]:
                     "'claude-opus-4-7[1m]', 'claude-haiku-4-5-20251001'). "
                     "Abbreviated forms like 'claude-opus[1m]' are rejected "
                     "by the SDK without raising — every turn returns 0 "
-                    "tokens."
+                    "tokens. (When spec.claude.provider is set, the model "
+                    "field accepts the provider's own model id instead.)"
                 )
+
+        # spec.claude.provider + spec.claude.account are mutually
+        # exclusive — an API-key backend needs no OAuth. Declaring both
+        # is a config error (the runtime would otherwise have to guess
+        # which auth path wins). Reject loudly at validate time.
+        if has_provider and (claude_block.get("account") or ""):
+            errors.append(
+                "spec.claude.provider and spec.claude.account are mutually "
+                "exclusive — a provider backend uses an API key, not "
+                "Anthropic OAuth. Set exactly one."
+            )
 
         # container.runtime
         container = spec.get("container", {}) or {}

--- a/src/scitex_agent_container/runtimes/_apptainer_auth.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_auth.py
@@ -1,0 +1,99 @@
+"""Anthropic-auth argv emission for the apptainer runtime.
+
+Extracted from ``_apptainer_runtime.py`` (512-line cap) — mirrors the
+existing helper-module split (``_apptainer_creds``, ``_apptainer_build``,
+``_apptainer_listen_env``, ``_apptainer_iso_flags``, ``_apptainer_provider``).
+
+:func:`auth_argv` renders the ``--env`` / ``--bind`` flags that wire the
+in-container Claude SDK to its backend. It branches on whether a
+vendor-agnostic provider override is active:
+
+* ``spec.claude.provider`` set → run against an Anthropic-SDK-compatible
+  backend (DeepSeek, gateway, ...) on an API key. Emits the provider
+  env flags (``ANTHROPIC_BASE_URL`` + ``SAC_ANTHROPIC_API_KEY`` + a clean
+  ``CLAUDE_CONFIG_DIR``) and SKIPS the OAuth credentials bind entirely —
+  an API-key backend needs no OAuth. See ``_apptainer_provider``.
+
+* no provider → existing Anthropic OAuth path: forward host
+  ``ANTHROPIC_API_KEY`` / ``SAC_ANTHROPIC_API_KEY`` (pay-per-token env),
+  then bind the resolved ``.credentials.json`` at ``/tmp/sac-claude``
+  and point the SDK at it via ``CLAUDE_CONFIG_DIR``.
+
+This helper only CALLS ``_apptainer_creds.resolve_cred_file`` (public
+API) — it does not own per-account credential resolution.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from ..config import AgentConfig
+from ._apptainer_provider import provider_active, provider_env_flags
+
+
+def auth_argv(config: AgentConfig, state_dir: Path) -> list[str]:
+    """Render the Anthropic-auth ``--env`` / ``--bind`` flags for ``config``.
+
+    See the module docstring for the provider-vs-OAuth branch. Raises
+    :class:`_apptainer_provider.ProviderEnvError` (fail-loud) when a
+    provider override is declared but its key env var is unset or it
+    collides with ``spec.claude.account``.
+    """
+    if provider_active(config):
+        # Provider backend: API key, no OAuth. The provider helper owns
+        # ANTHROPIC_BASE_URL + SAC_ANTHROPIC_API_KEY + a clean
+        # CLAUDE_CONFIG_DIR (the last-wins conflict-breaker). The OAuth
+        # creds bind is intentionally NOT emitted.
+        return provider_env_flags(config)
+
+    argv: list[str] = []
+
+    # Forward Anthropic auth (mirrors container.py). Order matters:
+    # see runtimes/_sdk_common.py:provision_anthropic_auth — when
+    # `~/.claude/.credentials.json` exists (Pro/Max OAuth flow), the
+    # SDK reads the file directly and a bare `ANTHROPIC_API_KEY`
+    # env shadows it (Anthropic rejects sk-ant-oat* OAuth tokens as
+    # bare env). So we only pass *pay-per-token* env values; the
+    # credentials.json is bind-mounted below.
+    for auth_env in ("ANTHROPIC_API_KEY", "SAC_ANTHROPIC_API_KEY"):
+        val = os.environ.get(auth_env)
+        if val:
+            argv += ["--env", f"{auth_env}={val}"]
+
+    # Mount operator's Pro/Max credentials when present.
+    # Target lives under /tmp/ (writable tmpfs / overlay) rather
+    # than $HOME — the D2 preflight requires $HOME to be empty, and
+    # binding under $HOME would scaffold a host-mirroring directory.
+    # CLAUDE_CONFIG_DIR points the SDK at this dir so it finds the
+    # credentials file without needing $HOME pollution.
+    #
+    # Mounted RW (no ``:ro``) so the in-container Claude CLI can
+    # refresh the OAuth ``accessToken`` in place when the host's
+    # token expires (~1h cadence). Without RW the bind-mounted file
+    # is frozen and every container 401s after token-expiry, forcing
+    # a manual scp-from-lead dance to re-seed peers. The CLI's
+    # refresh code-path itself is responsible for any concurrency
+    # locking — the bind is just a file passthrough.
+    # Per-agent OAuth account pinning (spec.claude.account). When set,
+    # we COPY that saved account's .credentials.json into the agent's
+    # own state dir (frozen boot-copy) and bind THAT — so two agents
+    # pinned to two accounts never share one mount, and a host /login
+    # never moves a pinned agent. Changing the assigned account needs
+    # a `sac agent restart` to re-copy. ``account=""`` → host live
+    # file (unchanged behaviour). Bind stays RW so the in-container
+    # CLI can refresh the OAuth token on the agent's private copy.
+    from ._apptainer_creds import resolve_cred_file
+
+    cred_file = resolve_cred_file(config, state_dir)
+    if cred_file is not None and cred_file.is_file():
+        argv += [
+            "--bind",
+            f"{cred_file}:/tmp/sac-claude/.credentials.json:rw",
+            "--env",
+            "CLAUDE_CONFIG_DIR=/tmp/sac-claude",
+        ]
+    return argv
+
+
+__all__ = ["auth_argv"]

--- a/src/scitex_agent_container/runtimes/_apptainer_provider.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_provider.py
@@ -23,24 +23,45 @@ OAuth ``.credentials.json`` bind entirely when a provider is active —
 an API-key backend needs no OAuth. :func:`provider_active` is the
 single predicate that gates both the env injection and the bind skip.
 
-Key-resolution order (first non-empty wins):
+Key-resolution via scitex-config
+--------------------------------
 
-  1. ``os.environ[<auth_token_env>]`` — the host process env of the
-     shell that ran ``sac agents start``.
-  2. ``<spec_dir>/to_home/.env`` — overlaid on top of the shared
-     baseline ``to_home/.env`` (per-agent wins on conflict). Operators
-     commonly drop provider keys here rather than exporting them in
-     the launch shell; the file ships into the container as
-     ``$HOME/.env`` via ``runtimes/_to_home.py`` anyway, so the same
-     file is the single source of truth for both host-side resolution
-     and in-container ``.env``.
+The provider API key is resolved through the SciTeX-ecosystem standard
+``direct → config → env → default`` cascade exposed by
+``scitex_config``:
+
+  1. ``scitex_config.load_dotenv(dotenv_path=$HOME/.env)`` merges the
+     host-level ``$HOME/.env`` into ``os.environ`` **without overriding
+     any already-set var** — an explicit ``export DEEPSEEK_API_KEY=...``
+     in the launch shell still wins. Path is pinned to ``$HOME/.env``
+     on purpose: the default ``load_dotenv`` order also checks
+     ``cwd/.env`` first, which would be a surprise for an operator
+     running ``sac agents start`` from an unrelated project dir.
+  2. ``scitex_config.PriorityConfig(auto_uppercase=False).resolve(
+     key=auth_token_env, default="")`` then reads the value from
+     ``os.environ`` (the only layer populated for this resolver —
+     no YAML config_dict by design; secrets do not belong in YAML).
+     ``auto_uppercase=False`` because ``auth_token_env`` is already
+     the literal env-var name declared in ``spec.claude.provider``.
+     ``PriorityConfig`` auto-masks ``API_KEY`` / ``TOKEN`` / ``SECRET``
+     style keys in its resolution log, so the value is never logged.
+
+Where the key lives, in operator-facing terms:
+
+  * ``export DEEPSEEK_API_KEY=sk-...`` in the launch shell, OR
+  * ``DEEPSEEK_API_KEY=sk-...`` as a line in ``$HOME/.env`` (chmod 0600).
+
+The in-container ``$HOME/.env`` materialized by ``runtimes/_to_home.py``
+from each agent's ``to_home/.env`` is a SEPARATE flow (it equips the
+agent INSIDE the container with a ``.env``) and is not consulted for
+host-side provider env resolution.
 
 Fail-loud (never silent fallback):
 
-* ``auth_token_env`` names an env var that is unset/empty in BOTH
-  sources → :class:`ProviderEnvError`. A silent fallback would route
-  the agent to Anthropic on no key (every turn 401s) with a
-  fresh-looking heartbeat.
+* ``auth_token_env`` resolves to empty after the scitex-config cascade
+  → :class:`ProviderEnvError`. A silent fallback would route the agent
+  to Anthropic on no key (every turn 401s) with a fresh-looking
+  heartbeat.
 * ``spec.claude.provider`` AND ``spec.claude.account`` both set →
   :class:`ProviderEnvError`. The two auth paths are mutually exclusive;
   the validator already rejects this at load time, but the runtime
@@ -49,8 +70,9 @@ Fail-loud (never silent fallback):
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
+
+from scitex_config import PriorityConfig, load_dotenv
 
 from ..config import AgentConfig
 
@@ -63,65 +85,6 @@ def _provider_spec(config: AgentConfig):
     """Return ``config.claude.provider`` or ``None`` (defensive getattr)."""
     claude = getattr(config, "claude", None)
     return getattr(claude, "provider", None) if claude is not None else None
-
-
-def _parse_dotenv(path: Path) -> dict[str, str]:
-    """Parse a ``KEY=VALUE`` ``.env`` file into a dict.
-
-    Lenient by design — comments, blanks and an optional ``export``
-    prefix are tolerated; matching surrounding quotes are stripped.
-    Lines without ``=`` are ignored. Missing/unreadable file → ``{}``
-    (the caller treats that as "no key here" and falls through to the
-    fail-loud raise).
-    """
-    out: dict[str, str] = {}
-    if not path.is_file():
-        return out
-    try:
-        text = path.read_text()
-    except OSError:  # stx-allow: fallback (reason: unreadable .env → no key)
-        return out
-    for raw in text.splitlines():
-        line = raw.strip()
-        if not line or line.startswith("#"):
-            continue
-        if line.startswith("export "):
-            line = line[len("export ") :].lstrip()
-        if "=" not in line:
-            continue
-        key, _, val = line.partition("=")
-        key = key.strip()
-        val = val.strip()
-        if len(val) >= 2 and val[0] == val[-1] and val[0] in ("'", '"'):
-            val = val[1:-1]
-        if key:
-            out[key] = val
-    return out
-
-
-def _to_home_env(config: AgentConfig) -> dict[str, str]:
-    """Merge baseline + per-agent ``to_home/.env`` into a dict.
-
-    Mirrors the materialization overlay in :mod:`_to_home`: the shared
-    baseline is loaded first, then the per-agent file on top, so a
-    per-agent ``.env`` wins on key conflict. ``{}`` when neither file
-    is present or when ``config.config_path`` is unset (hand-built
-    AgentConfig with no spec on disk).
-    """
-    # Local import to avoid a cycle at module load (``_to_home`` may
-    # import other runtime helpers in the future).
-    from ._to_home import resolve_baseline_to_home_dir, resolve_to_home_dir
-
-    merged: dict[str, str] = {}
-    cfg_path = getattr(config, "config_path", "") or ""
-    spec_dir = Path(cfg_path).parent if cfg_path else None
-    baseline = resolve_baseline_to_home_dir(spec_dir)
-    if baseline is not None:
-        merged.update(_parse_dotenv(baseline / ".env"))
-    per_agent = resolve_to_home_dir(config)
-    if per_agent is not None:
-        merged.update(_parse_dotenv(per_agent / ".env"))
-    return merged
 
 
 def provider_active(config: AgentConfig) -> bool:
@@ -142,10 +105,11 @@ def provider_env_flags(config: AgentConfig) -> list[str]:
     :class:`ProviderEnvError` (fail-loud) when:
 
     * the agent also pins ``spec.claude.account`` (mutually exclusive), or
-    * ``provider.auth_token_env`` names an unset/empty host env var.
+    * ``provider.auth_token_env`` resolves to empty after the
+      scitex-config cascade (see module docstring).
 
     The API key VALUE is read here and embedded in the argv but never
-    logged by sac.
+    logged by sac (``PriorityConfig`` masks it in its resolution log).
     """
     if not provider_active(config):
         return []
@@ -169,20 +133,23 @@ def provider_env_flags(config: AgentConfig) -> list[str]:
             "holding the key (e.g. DEEPSEEK_API_KEY)."
         )
 
-    # Resolution order: host process env first, then the agent's
-    # to_home/.env (baseline + per-agent overlay). The to_home/.env
-    # path is the operator-friendly default — same file that ships
-    # into the container as $HOME/.env at start.
-    api_key = os.environ.get(auth_token_env, "")
-    if not api_key:
-        api_key = _to_home_env(config).get(auth_token_env, "")
+    # SciTeX-ecosystem precedence: shell-export > $HOME/.env > default.
+    # load_dotenv() is no-op-safe — already-set process env always wins,
+    # so calling it on every provider-env resolution is cheap and
+    # idempotent. Path is pinned to $HOME/.env to avoid the cwd-first
+    # surprise of the default load_dotenv() search order.
+    load_dotenv(dotenv_path=str(Path.home() / ".env"))
+    resolver = PriorityConfig(auto_uppercase=False)
+    api_key = resolver.resolve(key=auth_token_env, default="")
     if not api_key:
         raise ProviderEnvError(
-            f"spec.claude.provider.auth_token_env='{auth_token_env}' names a "
-            "secret that sac could not resolve. Set it in EITHER the host "
-            f"env of `sac agents start` (export {auth_token_env}=...) OR "
-            f"the agent's to_home/.env (line `{auth_token_env}=...`). "
-            "sac reads the value at start and never logs it."
+            f"spec.claude.provider.auth_token_env='{auth_token_env}' could "
+            "not be resolved through scitex-config (direct → config → env "
+            "→ default cascade). Set the key by EITHER exporting "
+            f"{auth_token_env} in the shell that runs `sac agents start` "
+            f"OR adding the line `{auth_token_env}=...` to $HOME/.env "
+            "(chmod 0600). sac reads the value at start and never logs "
+            "it; PriorityConfig auto-masks it in the resolution log."
         )
 
     # Per-agent clean config dir — the conflict-breaker. Distinct from the

--- a/src/scitex_agent_container/runtimes/_apptainer_provider.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_provider.py
@@ -23,11 +23,24 @@ OAuth ``.credentials.json`` bind entirely when a provider is active —
 an API-key backend needs no OAuth. :func:`provider_active` is the
 single predicate that gates both the env injection and the bind skip.
 
+Key-resolution order (first non-empty wins):
+
+  1. ``os.environ[<auth_token_env>]`` — the host process env of the
+     shell that ran ``sac agents start``.
+  2. ``<spec_dir>/to_home/.env`` — overlaid on top of the shared
+     baseline ``to_home/.env`` (per-agent wins on conflict). Operators
+     commonly drop provider keys here rather than exporting them in
+     the launch shell; the file ships into the container as
+     ``$HOME/.env`` via ``runtimes/_to_home.py`` anyway, so the same
+     file is the single source of truth for both host-side resolution
+     and in-container ``.env``.
+
 Fail-loud (never silent fallback):
 
-* ``auth_token_env`` names an env var that is unset/empty on the host →
-  :class:`ProviderEnvError`. A silent fallback would route the agent to
-  Anthropic on no key (every turn 401s) with a fresh-looking heartbeat.
+* ``auth_token_env`` names an env var that is unset/empty in BOTH
+  sources → :class:`ProviderEnvError`. A silent fallback would route
+  the agent to Anthropic on no key (every turn 401s) with a
+  fresh-looking heartbeat.
 * ``spec.claude.provider`` AND ``spec.claude.account`` both set →
   :class:`ProviderEnvError`. The two auth paths are mutually exclusive;
   the validator already rejects this at load time, but the runtime
@@ -37,6 +50,7 @@ Fail-loud (never silent fallback):
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 from ..config import AgentConfig
 
@@ -49,6 +63,65 @@ def _provider_spec(config: AgentConfig):
     """Return ``config.claude.provider`` or ``None`` (defensive getattr)."""
     claude = getattr(config, "claude", None)
     return getattr(claude, "provider", None) if claude is not None else None
+
+
+def _parse_dotenv(path: Path) -> dict[str, str]:
+    """Parse a ``KEY=VALUE`` ``.env`` file into a dict.
+
+    Lenient by design — comments, blanks and an optional ``export``
+    prefix are tolerated; matching surrounding quotes are stripped.
+    Lines without ``=`` are ignored. Missing/unreadable file → ``{}``
+    (the caller treats that as "no key here" and falls through to the
+    fail-loud raise).
+    """
+    out: dict[str, str] = {}
+    if not path.is_file():
+        return out
+    try:
+        text = path.read_text()
+    except OSError:  # stx-allow: fallback (reason: unreadable .env → no key)
+        return out
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[len("export ") :].lstrip()
+        if "=" not in line:
+            continue
+        key, _, val = line.partition("=")
+        key = key.strip()
+        val = val.strip()
+        if len(val) >= 2 and val[0] == val[-1] and val[0] in ("'", '"'):
+            val = val[1:-1]
+        if key:
+            out[key] = val
+    return out
+
+
+def _to_home_env(config: AgentConfig) -> dict[str, str]:
+    """Merge baseline + per-agent ``to_home/.env`` into a dict.
+
+    Mirrors the materialization overlay in :mod:`_to_home`: the shared
+    baseline is loaded first, then the per-agent file on top, so a
+    per-agent ``.env`` wins on key conflict. ``{}`` when neither file
+    is present or when ``config.config_path`` is unset (hand-built
+    AgentConfig with no spec on disk).
+    """
+    # Local import to avoid a cycle at module load (``_to_home`` may
+    # import other runtime helpers in the future).
+    from ._to_home import resolve_baseline_to_home_dir, resolve_to_home_dir
+
+    merged: dict[str, str] = {}
+    cfg_path = getattr(config, "config_path", "") or ""
+    spec_dir = Path(cfg_path).parent if cfg_path else None
+    baseline = resolve_baseline_to_home_dir(spec_dir)
+    if baseline is not None:
+        merged.update(_parse_dotenv(baseline / ".env"))
+    per_agent = resolve_to_home_dir(config)
+    if per_agent is not None:
+        merged.update(_parse_dotenv(per_agent / ".env"))
+    return merged
 
 
 def provider_active(config: AgentConfig) -> bool:
@@ -96,13 +169,20 @@ def provider_env_flags(config: AgentConfig) -> list[str]:
             "holding the key (e.g. DEEPSEEK_API_KEY)."
         )
 
+    # Resolution order: host process env first, then the agent's
+    # to_home/.env (baseline + per-agent overlay). The to_home/.env
+    # path is the operator-friendly default — same file that ships
+    # into the container as $HOME/.env at start.
     api_key = os.environ.get(auth_token_env, "")
+    if not api_key:
+        api_key = _to_home_env(config).get(auth_token_env, "")
     if not api_key:
         raise ProviderEnvError(
             f"spec.claude.provider.auth_token_env='{auth_token_env}' names a "
-            "host env var that is unset or empty. Source the secret file "
-            f"that exports {auth_token_env} before starting this agent "
-            "(sac reads its value at start and never logs it)."
+            "secret that sac could not resolve. Set it in EITHER the host "
+            f"env of `sac agents start` (export {auth_token_env}=...) OR "
+            f"the agent's to_home/.env (line `{auth_token_env}=...`). "
+            "sac reads the value at start and never logs it."
         )
 
     # Per-agent clean config dir — the conflict-breaker. Distinct from the

--- a/src/scitex_agent_container/runtimes/_apptainer_provider.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_provider.py
@@ -1,0 +1,121 @@
+"""Vendor-agnostic backend-override env injection for the apptainer runtime.
+
+Extracted from ``_apptainer_runtime.py`` (512-line cap) — mirrors the
+existing helper-module split (``_apptainer_creds``, ``_apptainer_build``,
+``_apptainer_listen_env``, ``_apptainer_iso_flags``).
+
+When ``spec.claude.provider`` is set, the agent's SDK session runs
+against an Anthropic-SDK-compatible backend (DeepSeek, a self-hosted
+gateway, ...) on a never-expiring API key instead of Anthropic OAuth.
+The proven recipe (validated end-to-end with A/B network proof) is to
+inject three env vars into the container at start:
+
+* ``ANTHROPIC_BASE_URL``   ← ``provider.base_url``
+* ``SAC_ANTHROPIC_API_KEY`` ← the HOST value of ``$<provider.auth_token_env>``
+  (sac's existing handoff bridges it to ``ANTHROPIC_API_KEY`` for the SDK).
+* ``CLAUDE_CONFIG_DIR``    ← a clean per-agent dir. CRITICAL conflict-breaker:
+  apptainer ``--env`` is last-wins, so without forcing a fresh config dir
+  the OAuth ``.credentials.json`` bind (mounted at ``/tmp/sac-claude``)
+  would win and the SDK would talk to Anthropic, not the provider.
+
+The caller (``_apptainer_runtime.build_run_argv``) must ALSO skip the
+OAuth ``.credentials.json`` bind entirely when a provider is active —
+an API-key backend needs no OAuth. :func:`provider_active` is the
+single predicate that gates both the env injection and the bind skip.
+
+Fail-loud (never silent fallback):
+
+* ``auth_token_env`` names an env var that is unset/empty on the host →
+  :class:`ProviderEnvError`. A silent fallback would route the agent to
+  Anthropic on no key (every turn 401s) with a fresh-looking heartbeat.
+* ``spec.claude.provider`` AND ``spec.claude.account`` both set →
+  :class:`ProviderEnvError`. The two auth paths are mutually exclusive;
+  the validator already rejects this at load time, but the runtime
+  guards again so a hand-built ``AgentConfig`` can't sneak past.
+"""
+
+from __future__ import annotations
+
+import os
+
+from ..config import AgentConfig
+
+
+class ProviderEnvError(RuntimeError):
+    """Raised at start when a provider override cannot be satisfied."""
+
+
+def _provider_spec(config: AgentConfig):
+    """Return ``config.claude.provider`` or ``None`` (defensive getattr)."""
+    claude = getattr(config, "claude", None)
+    return getattr(claude, "provider", None) if claude is not None else None
+
+
+def provider_active(config: AgentConfig) -> bool:
+    """True when ``spec.claude.provider`` declares a usable backend override.
+
+    A provider with an empty ``base_url`` is treated as inactive — the
+    validator rejects that shape at load time, so this only guards
+    hand-built configs and keeps the predicate honest.
+    """
+    provider = _provider_spec(config)
+    return bool(provider is not None and getattr(provider, "base_url", ""))
+
+
+def provider_env_flags(config: AgentConfig) -> list[str]:
+    """Render the ``--env`` flags for an active provider override.
+
+    Returns ``[]`` when no provider is active. Raises
+    :class:`ProviderEnvError` (fail-loud) when:
+
+    * the agent also pins ``spec.claude.account`` (mutually exclusive), or
+    * ``provider.auth_token_env`` names an unset/empty host env var.
+
+    The API key VALUE is read here and embedded in the argv but never
+    logged by sac.
+    """
+    if not provider_active(config):
+        return []
+
+    provider = _provider_spec(config)
+    claude = getattr(config, "claude", None)
+    account = (getattr(claude, "account", "") or "") if claude is not None else ""
+    if account:
+        raise ProviderEnvError(
+            "spec.claude.provider and spec.claude.account are mutually "
+            "exclusive — a provider backend uses an API key, not Anthropic "
+            f"OAuth (got account={account!r}). Set exactly one."
+        )
+
+    base_url = getattr(provider, "base_url", "")
+    auth_token_env = getattr(provider, "auth_token_env", "")
+    if not auth_token_env:
+        raise ProviderEnvError(
+            "spec.claude.provider.auth_token_env is empty; cannot resolve "
+            "the backend API key. Set it to the NAME of the host env var "
+            "holding the key (e.g. DEEPSEEK_API_KEY)."
+        )
+
+    api_key = os.environ.get(auth_token_env, "")
+    if not api_key:
+        raise ProviderEnvError(
+            f"spec.claude.provider.auth_token_env='{auth_token_env}' names a "
+            "host env var that is unset or empty. Source the secret file "
+            f"that exports {auth_token_env} before starting this agent "
+            "(sac reads its value at start and never logs it)."
+        )
+
+    # Per-agent clean config dir — the conflict-breaker. Distinct from the
+    # OAuth path's /tmp/sac-claude so a stale OAuth bind can never win.
+    config_dir = f"/tmp/sac-{config.name}-provider-cfg"
+    return [
+        "--env",
+        f"ANTHROPIC_BASE_URL={base_url}",
+        "--env",
+        f"SAC_ANTHROPIC_API_KEY={api_key}",
+        "--env",
+        f"CLAUDE_CONFIG_DIR={config_dir}",
+    ]
+
+
+__all__ = ["ProviderEnvError", "provider_active", "provider_env_flags"]

--- a/src/scitex_agent_container/runtimes/_apptainer_runtime.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_runtime.py
@@ -212,50 +212,16 @@ class ApptainerContainerRuntime(RuntimeBase):
                         )
                 argv += ["--overlay", str(overlay_p)]
 
-        # Forward Anthropic auth (mirrors container.py). Order matters:
-        # see runtimes/_sdk_common.py:provision_anthropic_auth — when
-        # `~/.claude/.credentials.json` exists (Pro/Max OAuth flow), the
-        # SDK reads the file directly and a bare `ANTHROPIC_API_KEY`
-        # env shadows it (Anthropic rejects sk-ant-oat* OAuth tokens as
-        # bare env). So we only pass *pay-per-token* env values; the
-        # credentials.json is bind-mounted below.
-        for auth_env in ("ANTHROPIC_API_KEY", "SAC_ANTHROPIC_API_KEY"):
-            val = os.environ.get(auth_env)
-            if val:
-                argv += ["--env", f"{auth_env}={val}"]
+        # Anthropic-auth argv — emits the backend wiring (env + creds
+        # bind). Branches internally on whether spec.claude.provider is
+        # active: provider → API-key backend (ANTHROPIC_BASE_URL +
+        # SAC_ANTHROPIC_API_KEY + clean CLAUDE_CONFIG_DIR, OAuth bind
+        # skipped); otherwise → the OAuth path (forward host auth env +
+        # bind the resolved .credentials.json). Extracted to
+        # _apptainer_auth so this runtime file stays under the line cap.
+        from ._apptainer_auth import auth_argv
 
-        # Mount operator's Pro/Max credentials when present.
-        # Target lives under /tmp/ (writable tmpfs / overlay) rather
-        # than $HOME — the D2 preflight requires $HOME to be empty, and
-        # binding under $HOME would scaffold a host-mirroring directory.
-        # CLAUDE_CONFIG_DIR points the SDK at this dir so it finds the
-        # credentials file without needing $HOME pollution.
-        #
-        # Mounted RW (no ``:ro``) so the in-container Claude CLI can
-        # refresh the OAuth ``accessToken`` in place when the host's
-        # token expires (~1h cadence). Without RW the bind-mounted file
-        # is frozen and every container 401s after token-expiry, forcing
-        # a manual scp-from-lead dance to re-seed peers. The CLI's
-        # refresh code-path itself is responsible for any concurrency
-        # locking — the bind is just a file passthrough.
-        # Per-agent OAuth account pinning (spec.claude.account). When set,
-        # we COPY that saved account's .credentials.json into the agent's
-        # own state dir (frozen boot-copy) and bind THAT — so two agents
-        # pinned to two accounts never share one mount, and a host /login
-        # never moves a pinned agent. Changing the assigned account needs
-        # a `sac agent restart` to re-copy. ``account=""`` → host live
-        # file (unchanged behaviour). Bind stays RW so the in-container
-        # CLI can refresh the OAuth token on the agent's private copy.
-        from ._apptainer_creds import resolve_cred_file
-
-        cred_file = resolve_cred_file(config, state_dir)
-        if cred_file is not None and cred_file.is_file():
-            argv += [
-                "--bind",
-                f"{cred_file}:/tmp/sac-claude/.credentials.json:rw",
-                "--env",
-                "CLAUDE_CONFIG_DIR=/tmp/sac-claude",
-            ]
+        argv += auth_argv(config, state_dir)
 
         for key, val in (config.env or {}).items():
             argv += ["--env", f"{key}={val}"]

--- a/tests/integration/test_cross_package_imports.py
+++ b/tests/integration/test_cross_package_imports.py
@@ -20,6 +20,7 @@ import pytest
 
 # ===== AUTO-GENERATED: cross-package imports =====
 CROSS_PACKAGE_IMPORTS = [
+    "scitex_config",
     "scitex_config._ecosystem",
     "scitex_container",
     "scitex_dev",

--- a/tests/scitex_agent_container/config/_parsers/test__claude.py
+++ b/tests/scitex_agent_container/config/_parsers/test__claude.py
@@ -199,3 +199,59 @@ def test_account_none_coerced_to_empty_string():
     result = parse_claude(spec)
     # Assert
     assert result.account == ""
+
+
+# ---------------------------------------------------------------------------
+# spec.claude.provider — vendor-agnostic backend override
+# ---------------------------------------------------------------------------
+
+
+def test_missing_provider_block_yields_none_provider():
+    # Arrange — no provider key means the default Anthropic backend.
+    spec = {"claude": {"model": "opus"}}
+    # Act
+    result = parse_claude(spec)
+    # Assert
+    assert result.provider is None
+
+
+def test_provider_block_parses_base_url_field():
+    # Arrange
+    spec = {
+        "claude": {
+            "provider": {
+                "base_url": "https://api.deepseek.com/anthropic",
+                "auth_token_env": "DEEPSEEK_API_KEY",
+            }
+        }
+    }
+    # Act
+    result = parse_claude(spec)
+    # Assert
+    assert result.provider.base_url == "https://api.deepseek.com/anthropic"
+
+
+def test_provider_block_parses_auth_token_env_field():
+    # Arrange
+    spec = {
+        "claude": {
+            "provider": {
+                "base_url": "https://api.deepseek.com/anthropic",
+                "auth_token_env": "DEEPSEEK_API_KEY",
+            }
+        }
+    }
+    # Act
+    result = parse_claude(spec)
+    # Assert
+    assert result.provider.auth_token_env == "DEEPSEEK_API_KEY"
+
+
+def test_provider_non_dict_value_yields_none_provider():
+    # Arrange — a malformed (non-mapping) provider collapses to None so
+    # the validator surfaces the shape error, not the parser.
+    spec = {"claude": {"provider": "garbage"}}
+    # Act
+    result = parse_claude(spec)
+    # Assert
+    assert result.provider is None

--- a/tests/scitex_agent_container/config/test__validation_provider.py
+++ b/tests/scitex_agent_container/config/test__validation_provider.py
@@ -1,0 +1,157 @@
+"""Tests for ``spec.claude.provider`` validation (backend override).
+
+The provider override lets an agent run its SDK session against an
+Anthropic-SDK-compatible backend (DeepSeek, gateway, ...) on an API key
+instead of Anthropic OAuth. Validation rules:
+
+* When provider is present, both ``base_url`` and ``auth_token_env`` are
+  required (non-empty strings); an incomplete override would silently
+  fall back to Anthropic at runtime.
+* When provider is present, the claude-* model regex is relaxed so the
+  provider's own model id (e.g. ``deepseek-chat``) validates cleanly.
+* When provider is ABSENT, model validation is unchanged — a non-claude
+  model id is still rejected.
+* ``provider`` and ``account`` are mutually exclusive.
+
+Each test pins one observable fact (TQ007) with AAA markers (TQ002) and
+a descriptive name (TQ003).
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container.config._validation import validate_raw
+
+_BASE = {
+    "apiVersion": "scitex-agent-container/v3",
+    "kind": "Agent",
+    "spec": {"runtime": "apptainer"},
+}
+
+_PROVIDER = {
+    "base_url": "https://api.deepseek.com/anthropic",
+    "auth_token_env": "DEEPSEEK_API_KEY",
+}
+
+
+def _claude_spec(claude: dict) -> dict:
+    return {**_BASE, "spec": {**_BASE["spec"], "claude": claude}}
+
+
+# ---------------------------------------------------------------------------
+# Model-regex relaxation
+# ---------------------------------------------------------------------------
+
+
+def test_deepseek_model_accepted_when_provider_present():
+    # Arrange
+    raw = _claude_spec({"model": "deepseek-chat", "provider": _PROVIDER})
+    # Act
+    errors = validate_raw(raw, path="<test>")
+    # Assert
+    assert [e for e in errors if "spec.claude.model" in e] == []
+
+
+def test_deepseek_model_rejected_when_provider_absent():
+    # Arrange
+    raw = _claude_spec({"model": "deepseek-chat"})
+    # Act
+    errors = validate_raw(raw, path="<test>")
+    # Assert
+    assert [e for e in errors if "spec.claude.model" in e]
+
+
+# ---------------------------------------------------------------------------
+# Required-field enforcement
+# ---------------------------------------------------------------------------
+
+
+def test_provider_missing_base_url_is_rejected():
+    # Arrange
+    raw = _claude_spec(
+        {"model": "deepseek-chat", "provider": {"auth_token_env": "DEEPSEEK_API_KEY"}}
+    )
+    # Act
+    errors = validate_raw(raw, path="<test>")
+    # Assert
+    assert [e for e in errors if "spec.claude.provider.base_url" in e]
+
+
+def test_provider_missing_auth_token_env_is_rejected():
+    # Arrange
+    raw = _claude_spec(
+        {
+            "model": "deepseek-chat",
+            "provider": {"base_url": "https://api.deepseek.com/anthropic"},
+        }
+    )
+    # Act
+    errors = validate_raw(raw, path="<test>")
+    # Assert
+    assert [e for e in errors if "spec.claude.provider.auth_token_env" in e]
+
+
+def test_provider_empty_base_url_is_rejected():
+    # Arrange
+    raw = _claude_spec(
+        {
+            "model": "deepseek-chat",
+            "provider": {"base_url": "", "auth_token_env": "DEEPSEEK_API_KEY"},
+        }
+    )
+    # Act
+    errors = validate_raw(raw, path="<test>")
+    # Assert
+    assert [e for e in errors if "spec.claude.provider.base_url" in e]
+
+
+def test_provider_non_string_base_url_is_rejected():
+    # Arrange
+    raw = _claude_spec(
+        {
+            "model": "deepseek-chat",
+            "provider": {"base_url": 123, "auth_token_env": "DEEPSEEK_API_KEY"},
+        }
+    )
+    # Act
+    errors = validate_raw(raw, path="<test>")
+    # Assert
+    assert [e for e in errors if "spec.claude.provider.base_url must be a string" in e]
+
+
+# ---------------------------------------------------------------------------
+# Mutual exclusion with spec.claude.account
+# ---------------------------------------------------------------------------
+
+
+def test_provider_and_account_together_are_rejected():
+    # Arrange
+    raw = _claude_spec(
+        {"model": "deepseek-chat", "account": "work", "provider": _PROVIDER}
+    )
+    # Act
+    errors = validate_raw(raw, path="<test>")
+    # Assert
+    assert [e for e in errors if "mutually exclusive" in e]
+
+
+# ---------------------------------------------------------------------------
+# No-provider path is unchanged
+# ---------------------------------------------------------------------------
+
+
+def test_complete_provider_block_validates_clean():
+    # Arrange
+    raw = _claude_spec({"model": "deepseek-chat", "provider": _PROVIDER})
+    # Act
+    errors = validate_raw(raw, path="<test>")
+    # Assert
+    assert errors == []
+
+
+def test_account_only_without_provider_validates_clean():
+    # Arrange — account without provider stays the OAuth-pin happy path.
+    raw = _claude_spec({"model": "opus", "account": "work"})
+    # Act
+    errors = validate_raw(raw, path="<test>")
+    # Assert
+    assert errors == []

--- a/tests/scitex_agent_container/runtimes/test__apptainer_auth.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_auth.py
@@ -1,0 +1,153 @@
+"""Tests for ``runtimes._apptainer_auth.auth_argv`` (backend wiring).
+
+``auth_argv`` branches on whether ``spec.claude.provider`` is active:
+
+* provider active → API-key backend env (``ANTHROPIC_BASE_URL`` +
+  ``SAC_ANTHROPIC_API_KEY`` + a per-agent ``CLAUDE_CONFIG_DIR``), and
+  the OAuth ``.credentials.json`` bind is SKIPPED entirely.
+* provider absent → the OAuth path: forward host auth env + bind the
+  resolved ``.credentials.json`` at ``/tmp/sac-claude``.
+
+Real seams only (no mocks): ``$HOME`` and ``$DEEPSEEK_API_KEY`` are
+driven through ``env_save_restore``; a real ``.credentials.json`` file
+is written under the redirected home so the OAuth branch has something
+to bind.
+
+Each test pins one observable fact (TQ007) with AAA markers (TQ002)
+and a descriptive name (TQ003).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container.config import AgentConfig, ClaudeSpec, ProviderSpec
+from scitex_agent_container.runtimes._apptainer_auth import auth_argv
+
+
+@pytest.fixture
+def home_redirect(tmp_path: Path, env_save_restore) -> Path:
+    """Redirect ``$HOME`` so credential resolution stays in the sandbox.
+
+    ``Path.home()`` reads ``$HOME`` on POSIX — no patching needed.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    env_save_restore.set("HOME", str(home))
+    return home
+
+
+def _write_host_creds(home: Path) -> Path:
+    creds = home / ".claude" / ".credentials.json"
+    creds.parent.mkdir(parents=True, exist_ok=True)
+    creds.write_text("{}")
+    return creds
+
+
+def _provider_config(workdir: Path, **claude_kw) -> AgentConfig:
+    claude = ClaudeSpec(
+        model="deepseek-chat",
+        provider=ProviderSpec(
+            base_url="https://api.deepseek.com/anthropic",
+            auth_token_env="DEEPSEEK_API_KEY",
+        ),
+        **claude_kw,
+    )
+    return AgentConfig(
+        name="ds", runtime="apptainer", workdir=str(workdir), claude=claude
+    )
+
+
+def _oauth_config(workdir: Path) -> AgentConfig:
+    return AgentConfig(
+        name="oauth-agent",
+        runtime="apptainer",
+        workdir=str(workdir),
+        claude=ClaudeSpec(model="opus"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Provider active → API-key backend, OAuth bind skipped
+# ---------------------------------------------------------------------------
+
+
+def test_provider_argv_injects_base_url(
+    tmp_path: Path, home_redirect: Path, env_save_restore
+):
+    # Arrange — a host creds file exists; the provider path must ignore it.
+    _write_host_creds(home_redirect)
+    env_save_restore.set("DEEPSEEK_API_KEY", "sk-deepseek-secret")
+    cfg = _provider_config(tmp_path / "wd")
+    # Act
+    argv = auth_argv(cfg, state_dir=tmp_path / "state")
+    # Assert
+    assert "ANTHROPIC_BASE_URL=https://api.deepseek.com/anthropic" in argv
+
+
+def test_provider_argv_skips_oauth_credentials_bind(
+    tmp_path: Path, home_redirect: Path, env_save_restore
+):
+    # Arrange — even with a real host creds file present, the OAuth bind
+    # must NOT appear when a provider override is active.
+    _write_host_creds(home_redirect)
+    env_save_restore.set("DEEPSEEK_API_KEY", "sk-deepseek-secret")
+    cfg = _provider_config(tmp_path / "wd")
+    # Act
+    argv = auth_argv(cfg, state_dir=tmp_path / "state")
+    # Assert
+    assert not any("/tmp/sac-claude/.credentials.json" in a for a in argv)
+
+
+def test_provider_argv_omits_oauth_config_dir(
+    tmp_path: Path, home_redirect: Path, env_save_restore
+):
+    # Arrange — the OAuth CLAUDE_CONFIG_DIR=/tmp/sac-claude must give way
+    # to the per-agent provider config dir (the last-wins conflict-breaker).
+    _write_host_creds(home_redirect)
+    env_save_restore.set("DEEPSEEK_API_KEY", "sk-deepseek-secret")
+    cfg = _provider_config(tmp_path / "wd")
+    # Act
+    argv = auth_argv(cfg, state_dir=tmp_path / "state")
+    # Assert
+    assert "CLAUDE_CONFIG_DIR=/tmp/sac-claude" not in argv
+
+
+# ---------------------------------------------------------------------------
+# Provider absent → OAuth path unchanged
+# ---------------------------------------------------------------------------
+
+
+def test_oauth_argv_binds_credentials_when_present(tmp_path: Path, home_redirect: Path):
+    # Arrange — no provider, real host creds file → OAuth bind emitted.
+    creds = _write_host_creds(home_redirect)
+    cfg = _oauth_config(tmp_path / "wd")
+    # Act
+    argv = auth_argv(cfg, state_dir=tmp_path / "state")
+    # Assert
+    assert any(
+        a.startswith(str(creds)) and "/tmp/sac-claude/.credentials.json:rw" in a
+        for a in argv
+    )
+
+
+def test_oauth_argv_sets_oauth_config_dir(tmp_path: Path, home_redirect: Path):
+    # Arrange
+    _write_host_creds(home_redirect)
+    cfg = _oauth_config(tmp_path / "wd")
+    # Act
+    argv = auth_argv(cfg, state_dir=tmp_path / "state")
+    # Assert
+    assert "CLAUDE_CONFIG_DIR=/tmp/sac-claude" in argv
+
+
+def test_oauth_argv_omits_provider_base_url(tmp_path: Path, home_redirect: Path):
+    # Arrange — no provider means no ANTHROPIC_BASE_URL injection.
+    _write_host_creds(home_redirect)
+    cfg = _oauth_config(tmp_path / "wd")
+    # Act
+    argv = auth_argv(cfg, state_dir=tmp_path / "state")
+    # Assert
+    assert not any(a.startswith("ANTHROPIC_BASE_URL=") for a in argv)

--- a/tests/scitex_agent_container/runtimes/test__apptainer_provider.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_provider.py
@@ -166,62 +166,61 @@ def test_provider_with_account_raises_provider_env_error(env_save_restore):
 
 
 # ---------------------------------------------------------------------------
-# to_home/.env fallback — operator-friendly key location
+# scitex-config cascade — $HOME/.env feeds the env layer
 # ---------------------------------------------------------------------------
+#
+# The runtime delegates auth-token resolution to scitex_config:
+#   load_dotenv(dotenv_path=$HOME/.env) merges $HOME/.env into os.environ
+#   WITHOUT overriding already-set vars, then PriorityConfig.resolve()
+#   reads the value from os.environ. The tests below pin $HOME to a
+#   tmp_path so the real ~/.env is never touched.
 
 
-def _spec_with_to_home_env(tmp_path, dotenv_body: str):
-    """Write a minimal spec dir with a ``to_home/.env`` file under tmp."""
-    spec_dir = tmp_path / "agent"
-    (spec_dir / "to_home").mkdir(parents=True)
-    (spec_dir / "to_home" / ".env").write_text(dotenv_body)
-    spec_yaml = spec_dir / "spec.yaml"
-    spec_yaml.write_text("# placeholder — config_path only, never loaded\n")
-    return spec_yaml
+def _write_home_dotenv(home: "Path", body: str) -> None:
+    """Write ``$HOME/.env`` under the test's tmp home."""
+    (home / ".env").write_text(body)
 
 
-def test_auth_token_resolved_from_to_home_env_when_host_env_unset(
+def test_auth_token_resolved_from_home_dotenv_via_scitex_config(
     env_save_restore, tmp_path
 ):
-    # Arrange — host env intentionally empty; the operator dropped the
-    # key in to_home/.env, which is the same file that ships into
-    # $HOME/.env inside the container.
+    # Arrange — pin HOME to tmp, drop the key in $HOME/.env only.
+    # Host env intentionally lacks DEEPSEEK_API_KEY so the value MUST
+    # come from the .env via scitex_config.load_dotenv.
+    env_save_restore.set("HOME", str(tmp_path))
     env_save_restore.delete("DEEPSEEK_API_KEY")
-    env_save_restore.delete("SAC_TO_HOME_BASELINE")
-    spec_yaml = _spec_with_to_home_env(tmp_path, "DEEPSEEK_API_KEY=sk-from-to-home\n")
+    _write_home_dotenv(tmp_path, "DEEPSEEK_API_KEY=sk-from-home-dotenv\n")
     cfg = _provider_config()
-    cfg.config_path = str(spec_yaml)
     # Act
     env = _env_dict(provider_env_flags(cfg))
-    # Assert — key bridged from to_home/.env into SAC_ANTHROPIC_API_KEY.
-    assert env["SAC_ANTHROPIC_API_KEY"] == "sk-from-to-home"
+    # Assert — key bridged from $HOME/.env into SAC_ANTHROPIC_API_KEY
+    # through the scitex-config cascade.
+    assert env["SAC_ANTHROPIC_API_KEY"] == "sk-from-home-dotenv"
 
 
-def test_host_env_wins_over_to_home_env_when_both_set(env_save_restore, tmp_path):
-    # Arrange — both sources populated with DIFFERENT values; the host
-    # process env is the higher-priority source per the resolution
-    # order documented in the module.
-    env_save_restore.set("DEEPSEEK_API_KEY", "sk-from-host")
-    env_save_restore.delete("SAC_TO_HOME_BASELINE")
-    spec_yaml = _spec_with_to_home_env(tmp_path, "DEEPSEEK_API_KEY=sk-from-to-home\n")
+def test_shell_export_wins_over_home_dotenv(env_save_restore, tmp_path):
+    # Arrange — both layers populated with DIFFERENT values. The shell
+    # export should win because scitex_config.load_dotenv never
+    # overrides an already-set process env var.
+    env_save_restore.set("HOME", str(tmp_path))
+    env_save_restore.set("DEEPSEEK_API_KEY", "sk-from-shell-export")
+    _write_home_dotenv(tmp_path, "DEEPSEEK_API_KEY=sk-from-home-dotenv\n")
     cfg = _provider_config()
-    cfg.config_path = str(spec_yaml)
     # Act
     env = _env_dict(provider_env_flags(cfg))
     # Assert
-    assert env["SAC_ANTHROPIC_API_KEY"] == "sk-from-host"
+    assert env["SAC_ANTHROPIC_API_KEY"] == "sk-from-shell-export"
 
 
-def test_unset_in_both_sources_still_raises_provider_env_error(
+def test_unset_in_both_layers_still_raises_provider_env_error(
     env_save_restore, tmp_path
 ):
-    # Arrange — host env empty, to_home/.env exists but does NOT set the
-    # named key. Fail-loud must survive the new fallback path.
+    # Arrange — host env empty, $HOME/.env exists but does NOT set the
+    # named key. Fail-loud must survive the scitex-config cascade.
+    env_save_restore.set("HOME", str(tmp_path))
     env_save_restore.delete("DEEPSEEK_API_KEY")
-    env_save_restore.delete("SAC_TO_HOME_BASELINE")
-    spec_yaml = _spec_with_to_home_env(tmp_path, "OTHER_KEY=irrelevant\n")
+    _write_home_dotenv(tmp_path, "OTHER_KEY=irrelevant\n")
     cfg = _provider_config()
-    cfg.config_path = str(spec_yaml)
     # Act
     ctx = pytest.raises(ProviderEnvError)
     # Assert
@@ -229,19 +228,19 @@ def test_unset_in_both_sources_still_raises_provider_env_error(
         provider_env_flags(cfg)
 
 
-def test_to_home_env_supports_quoted_and_export_prefixed_lines(
+def test_home_dotenv_supports_quoted_and_export_prefixed_lines(
     env_save_restore, tmp_path
 ):
     # Arrange — common .env shapes operators copy from dotfiles: an
     # ``export FOO="bar"`` style line with surrounding double quotes.
+    # scitex_config.load_dotenv strips both forms.
+    env_save_restore.set("HOME", str(tmp_path))
     env_save_restore.delete("DEEPSEEK_API_KEY")
-    env_save_restore.delete("SAC_TO_HOME_BASELINE")
-    spec_yaml = _spec_with_to_home_env(
+    _write_home_dotenv(
         tmp_path,
         '# comment line\nexport DEEPSEEK_API_KEY="sk-quoted-export"\n',
     )
     cfg = _provider_config()
-    cfg.config_path = str(spec_yaml)
     # Act
     env = _env_dict(provider_env_flags(cfg))
     # Assert — quotes stripped, ``export`` prefix tolerated.

--- a/tests/scitex_agent_container/runtimes/test__apptainer_provider.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_provider.py
@@ -1,0 +1,165 @@
+"""Tests for ``runtimes._apptainer_provider`` (backend override env).
+
+The provider helper renders the three ``--env`` flags that point an
+agent's SDK session at an Anthropic-SDK-compatible backend on an API
+key (DeepSeek, gateway, ...). It fails loud rather than fall back to
+Anthropic when the override cannot be satisfied.
+
+Real seams only (no mocks): ``$DEEPSEEK_API_KEY`` is set / cleared via
+the ``env_save_restore`` fixture; configs are real ``AgentConfig``
+dataclasses.
+
+Each test pins one observable fact (TQ007) with AAA markers (TQ002)
+and a descriptive name (TQ003).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scitex_agent_container.config import AgentConfig, ClaudeSpec, ProviderSpec
+from scitex_agent_container.runtimes._apptainer_provider import (
+    ProviderEnvError,
+    provider_active,
+    provider_env_flags,
+)
+
+
+def _provider_config(name: str = "ds", **claude_kw) -> AgentConfig:
+    claude = ClaudeSpec(
+        model="deepseek-chat",
+        provider=ProviderSpec(
+            base_url="https://api.deepseek.com/anthropic",
+            auth_token_env="DEEPSEEK_API_KEY",
+        ),
+        **claude_kw,
+    )
+    return AgentConfig(
+        name=name, runtime="apptainer", workdir="/tmp/ds-wd", claude=claude
+    )
+
+
+def _env_dict(flags: list[str]) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for i, a in enumerate(flags):
+        if a == "--env" and i + 1 < len(flags) and "=" in flags[i + 1]:
+            k, _, v = flags[i + 1].partition("=")
+            out[k] = v
+    return out
+
+
+# ---------------------------------------------------------------------------
+# provider_active predicate
+# ---------------------------------------------------------------------------
+
+
+def test_provider_active_true_for_config_with_base_url():
+    # Arrange
+    cfg = _provider_config()
+    # Act
+    active = provider_active(cfg)
+    # Assert
+    assert active is True
+
+
+def test_provider_active_false_for_config_without_provider():
+    # Arrange
+    cfg = AgentConfig(
+        name="plain", runtime="apptainer", workdir="/tmp/x", claude=ClaudeSpec()
+    )
+    # Act
+    active = provider_active(cfg)
+    # Assert
+    assert active is False
+
+
+# ---------------------------------------------------------------------------
+# Env injection — happy path
+# ---------------------------------------------------------------------------
+
+
+def test_flags_inject_anthropic_base_url(env_save_restore):
+    # Arrange
+    env_save_restore.set("DEEPSEEK_API_KEY", "sk-deepseek-secret")
+    cfg = _provider_config()
+    # Act
+    env = _env_dict(provider_env_flags(cfg))
+    # Assert
+    assert env["ANTHROPIC_BASE_URL"] == "https://api.deepseek.com/anthropic"
+
+
+def test_flags_bridge_host_key_to_sac_anthropic_api_key(env_save_restore):
+    # Arrange
+    env_save_restore.set("DEEPSEEK_API_KEY", "sk-deepseek-secret")
+    cfg = _provider_config()
+    # Act
+    env = _env_dict(provider_env_flags(cfg))
+    # Assert
+    assert env["SAC_ANTHROPIC_API_KEY"] == "sk-deepseek-secret"
+
+
+def test_flags_set_per_agent_clean_config_dir(env_save_restore):
+    # Arrange — the conflict-breaker dir is namespaced by agent name.
+    env_save_restore.set("DEEPSEEK_API_KEY", "sk-deepseek-secret")
+    cfg = _provider_config(name="bulk7")
+    # Act
+    env = _env_dict(provider_env_flags(cfg))
+    # Assert
+    assert env["CLAUDE_CONFIG_DIR"] == "/tmp/sac-bulk7-provider-cfg"
+
+
+# ---------------------------------------------------------------------------
+# Inactive path
+# ---------------------------------------------------------------------------
+
+
+def test_flags_empty_when_no_provider():
+    # Arrange
+    cfg = AgentConfig(
+        name="plain", runtime="apptainer", workdir="/tmp/x", claude=ClaudeSpec()
+    )
+    # Act
+    flags = provider_env_flags(cfg)
+    # Assert
+    assert flags == []
+
+
+# ---------------------------------------------------------------------------
+# Fail-loud paths
+# ---------------------------------------------------------------------------
+
+
+def test_unset_auth_token_env_raises_provider_env_error(env_save_restore):
+    # Arrange — the named host env var is absent; no silent Anthropic fallback.
+    env_save_restore.delete("DEEPSEEK_API_KEY")
+    cfg = _provider_config()
+    # Act
+    ctx = pytest.raises(ProviderEnvError)
+    # Assert
+    with ctx:
+        provider_env_flags(cfg)
+
+
+def test_unset_auth_token_env_error_names_the_env_var(env_save_restore):
+    # Arrange
+    env_save_restore.delete("DEEPSEEK_API_KEY")
+    cfg = _provider_config()
+    message = ""
+    # Act
+    try:
+        provider_env_flags(cfg)
+    except ProviderEnvError as exc:
+        message = str(exc)
+    # Assert
+    assert "DEEPSEEK_API_KEY" in message
+
+
+def test_provider_with_account_raises_provider_env_error(env_save_restore):
+    # Arrange — provider + account is the mutually-exclusive collision.
+    env_save_restore.set("DEEPSEEK_API_KEY", "sk-deepseek-secret")
+    cfg = _provider_config(account="work")
+    # Act
+    ctx = pytest.raises(ProviderEnvError)
+    # Assert
+    with ctx:
+        provider_env_flags(cfg)

--- a/tests/scitex_agent_container/runtimes/test__apptainer_provider.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_provider.py
@@ -163,3 +163,86 @@ def test_provider_with_account_raises_provider_env_error(env_save_restore):
     # Assert
     with ctx:
         provider_env_flags(cfg)
+
+
+# ---------------------------------------------------------------------------
+# to_home/.env fallback — operator-friendly key location
+# ---------------------------------------------------------------------------
+
+
+def _spec_with_to_home_env(tmp_path, dotenv_body: str):
+    """Write a minimal spec dir with a ``to_home/.env`` file under tmp."""
+    spec_dir = tmp_path / "agent"
+    (spec_dir / "to_home").mkdir(parents=True)
+    (spec_dir / "to_home" / ".env").write_text(dotenv_body)
+    spec_yaml = spec_dir / "spec.yaml"
+    spec_yaml.write_text("# placeholder — config_path only, never loaded\n")
+    return spec_yaml
+
+
+def test_auth_token_resolved_from_to_home_env_when_host_env_unset(
+    env_save_restore, tmp_path
+):
+    # Arrange — host env intentionally empty; the operator dropped the
+    # key in to_home/.env, which is the same file that ships into
+    # $HOME/.env inside the container.
+    env_save_restore.delete("DEEPSEEK_API_KEY")
+    env_save_restore.delete("SAC_TO_HOME_BASELINE")
+    spec_yaml = _spec_with_to_home_env(tmp_path, "DEEPSEEK_API_KEY=sk-from-to-home\n")
+    cfg = _provider_config()
+    cfg.config_path = str(spec_yaml)
+    # Act
+    env = _env_dict(provider_env_flags(cfg))
+    # Assert — key bridged from to_home/.env into SAC_ANTHROPIC_API_KEY.
+    assert env["SAC_ANTHROPIC_API_KEY"] == "sk-from-to-home"
+
+
+def test_host_env_wins_over_to_home_env_when_both_set(env_save_restore, tmp_path):
+    # Arrange — both sources populated with DIFFERENT values; the host
+    # process env is the higher-priority source per the resolution
+    # order documented in the module.
+    env_save_restore.set("DEEPSEEK_API_KEY", "sk-from-host")
+    env_save_restore.delete("SAC_TO_HOME_BASELINE")
+    spec_yaml = _spec_with_to_home_env(tmp_path, "DEEPSEEK_API_KEY=sk-from-to-home\n")
+    cfg = _provider_config()
+    cfg.config_path = str(spec_yaml)
+    # Act
+    env = _env_dict(provider_env_flags(cfg))
+    # Assert
+    assert env["SAC_ANTHROPIC_API_KEY"] == "sk-from-host"
+
+
+def test_unset_in_both_sources_still_raises_provider_env_error(
+    env_save_restore, tmp_path
+):
+    # Arrange — host env empty, to_home/.env exists but does NOT set the
+    # named key. Fail-loud must survive the new fallback path.
+    env_save_restore.delete("DEEPSEEK_API_KEY")
+    env_save_restore.delete("SAC_TO_HOME_BASELINE")
+    spec_yaml = _spec_with_to_home_env(tmp_path, "OTHER_KEY=irrelevant\n")
+    cfg = _provider_config()
+    cfg.config_path = str(spec_yaml)
+    # Act
+    ctx = pytest.raises(ProviderEnvError)
+    # Assert
+    with ctx:
+        provider_env_flags(cfg)
+
+
+def test_to_home_env_supports_quoted_and_export_prefixed_lines(
+    env_save_restore, tmp_path
+):
+    # Arrange — common .env shapes operators copy from dotfiles: an
+    # ``export FOO="bar"`` style line with surrounding double quotes.
+    env_save_restore.delete("DEEPSEEK_API_KEY")
+    env_save_restore.delete("SAC_TO_HOME_BASELINE")
+    spec_yaml = _spec_with_to_home_env(
+        tmp_path,
+        '# comment line\nexport DEEPSEEK_API_KEY="sk-quoted-export"\n',
+    )
+    cfg = _provider_config()
+    cfg.config_path = str(spec_yaml)
+    # Act
+    env = _env_dict(provider_env_flags(cfg))
+    # Assert — quotes stripped, ``export`` prefix tolerated.
+    assert env["SAC_ANTHROPIC_API_KEY"] == "sk-quoted-export"


### PR DESCRIPTION
## What

Add an optional, vendor-agnostic **provider override** so a sac agent's
Claude-SDK session can run against any Anthropic-SDK-compatible backend
(DeepSeek first) on a never-expiring, login-free API key instead of
Anthropic OAuth.

New spec field:

```yaml
spec:
  claude:
    model: deepseek-chat            # provider's own model id
    provider:
      base_url: https://api.deepseek.com/anthropic
      auth_token_env: DEEPSEEK_API_KEY   # NAME of host env var, not the key
```

## Why

Bulk fleet work shouldn't burn Max-plan quota or fight OAuth token
refresh. A provider override points the SDK at a cheap backend with a
static API key. Validated end-to-end by an earlier spike (A/B network
proof): the recipe is to inject `ANTHROPIC_BASE_URL`, bridge the host
key to `SAC_ANTHROPIC_API_KEY`, and force a clean `CLAUDE_CONFIG_DIR`
so the OAuth credentials bind cannot win (apptainer `--env` is
last-wins).

## Deliverables

1. **Spec field** `spec.claude.provider` (`base_url`, `auth_token_env`).
   - `config/_provider_types.py` — new `ProviderSpec` dataclass (own
     module, mirrors `_proxy_types.py`, keeps `_types.py` under the
     512-line cap).
   - `config/_types.py` — `ClaudeSpec.provider: ProviderSpec | None`.
   - `config/_parsers/_claude.py` — parses the block (absent/non-dict → None).
   - `config/__init__.py` — exports `ProviderSpec`.
2. **Validation** (`config/_validation.py`): when provider present →
   require `base_url` + `auth_token_env` non-empty AND skip the claude-*
   `_VALID_MODEL_RE` (so `deepseek-chat` passes). When absent → unchanged
   (claude-* still enforced). Provider + `account` rejected as mutually
   exclusive.
3. **Runtime env injection** — apptainer:
   - `runtimes/_apptainer_provider.py` — new helper: `provider_active()`
     + `provider_env_flags()`. Emits the 3 env vars; fails loud
     (`ProviderEnvError`) when `auth_token_env` names an unset host var
     or when provider+account collide. Never logs the key value.
   - `runtimes/_apptainer_auth.py` — new helper extracted from
     `_apptainer_runtime.py` (line-cap-driven, genuine extraction).
     Branches: provider → API-key env, **OAuth creds bind skipped
     entirely**; else → existing OAuth path (only *calls*
     `_apptainer_creds.resolve_cred_file`, does not modify it).
   - `runtimes/_apptainer_runtime.py` — inline auth/creds block replaced
     by one `auth_argv(config, state_dir)` call (file shrinks 503→469).
4. **Tests** (real, no mocks; TQ-compliant):
   - parser: provider parses / non-dict → None.
   - validation: deepseek-chat accepted WITH provider, rejected WITHOUT;
     required-field + non-string + mutual-exclusion rejections.
   - provider helper: 3 env vars emitted; fail-loud on unset key and on
     provider+account; inactive when absent.
   - auth helper: OAuth bind skipped + base_url injected when provider
     set; OAuth path unchanged when absent.
5. **Example spec** `examples/agents/deepseek-agent/spec.yaml` (references
   `DEEPSEEK_API_KEY` by name; auto-validated by
   `tests/integration/test_templates_v3_valid.py`).

## Test plan

- Full suite green via `uv`-created venv (editable worktree install).
- 69 targeted tests (parser + validation + both runtime helpers +
  template loader) pass.

## Sibling-worktree overlap warning (for the lead sequencing the merge)

A concurrent subagent is building credential-auto-sync in another
worktree of this repo, touching `_account/`, `cli_pkg/account_group.py`,
and `runtimes/_apptainer_creds.py`. **This PR does NOT modify any of
those** — `_apptainer_auth.py` only *calls* the public
`resolve_cred_file`. A merge-time rebase is expected and should be
clean; the only shared touchpoint is the public `resolve_cred_file`
signature.
