### PR TITLE
chore(audit): exempt sac from §6 MCP-Python parity via pyproject opt-out

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,53 @@ Repository = "https://github.com/ywatanabe1989/scitex-agent-container.git"
 Issues = "https://github.com/ywatanabe1989/scitex-agent-container/issues"
 Documentation = "https://scitex-agent-container.readthedocs.io"
 
+# scitex-dev audit configuration. Per-package opt-outs sit here per
+# scitex-dev's documented precedent (the same [tool.scitex_dev] block
+# is read by `is_mcp_parity_exempt` in
+# scitex_dev/_cli/audit/_summary/_mcp_parity.py).
+[tool.scitex_dev]
+# §6 (audit-mcp-tools, Python-API ↔ MCP parity) — exempt by design.
+#
+# sac's MCP tool surface mirrors its CLI subcommand surface (which in
+# turn wraps internal handlers); the public Python API
+# (`scitex_agent_container.<noun>.<verb>`) is a thin re-export of the
+# SAME handlers, not a 1:1 parent of the MCP tools. The auditor's
+# name-derivation algorithm (`<noun>_<verb>` flatten) consequently sees
+# 4 "orphan" MCP tools that are real working features with their own
+# canonical names:
+#
+#   * agent_spawn         — in-container spawn → spawn-proxy (ADR-0010).
+#                           MCP-only by design; no CLI/Python counterpart.
+#   * list_python_apis    — introspection helper. CLI path:
+#                           `sac info list-python-apis`. The closest
+#                           Python noun is `sac.mcp.list_tools`, which
+#                           is a different concept (FastMCP server's
+#                           registered tools, not "all Python APIs").
+#   * quota_watch         — account-quota watcher. CLI path:
+#                           `sac account watch-quota`. The matching
+#                           Python noun is `sac.account.watch_quota`
+#                           (flattened: `account_watch_quota`) — the
+#                           MCP tool's word order is intentionally the
+#                           verb-first form that MCP clients read more
+#                           naturally.
+#   * subagent_get_state  — subagent state introspection. CLI path:
+#                           `sac subagent get-state`. There is no
+#                           `sac.subagent` noun submodule today; adding
+#                           one purely to satisfy the auditor's
+#                           name-derivation would be ceremony.
+#
+# Renaming either the MCP tools or adding the missing noun submodule
+# would be a breaking change for MCP clients calling by tool name AND
+# would broaden the Python public API surface beyond what sac actually
+# intends (sac is a CLI/MCP-first tool, not a Python library — the
+# noun-submodule `__all__`s are convenience re-exports for script
+# users, not the canonical command surface).
+#
+# This is the exact shape `mcp_parity_exempt` was designed for; see
+# scitex_dev/_cli/audit/_summary/_mcp_parity.py:9-13 ("Some packages
+# legitimately expose far more MCP tools than Python-API functions").
+mcp_parity_exempt = true
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/scitex_agent_container"]
 


### PR DESCRIPTION
## Summary

Closes the **§6 MCP-Python parity** violation that has been failing
`tests/develop/test_audit.py::test_audit_all_clean` on every recent CI
run. Adds `[tool.scitex_dev] mcp_parity_exempt = true` to
`pyproject.toml` — the documented per-package opt-out for tools whose
MCP surface mirrors CLI/operator concerns rather than top-level Python
APIs.

## Why exempt (not re-export the 4 orphans)

The auditor flags 4 MCP tools without a matching entry in top-level
`scitex_agent_container.__all__`:

| MCP tool | Source | Why orphan |
|---|---|---|
| `agent_spawn` | `_mcp/_tools/_agent.py:111` | MCP-only by design per ADR-0010 (in-container spawn → spawn-proxy); no CLI/Python counterpart. |
| `list_python_apis` | `_mcp/_tools/_info.py:15` + `cli_pkg/info_cmds.py:317` | Closest Python noun is `sac.mcp.list_tools`, but that's a different concept (FastMCP-registered tools, not "all Python APIs"). |
| `quota_watch` | `_mcp/_tools/_account.py:16` + `cli_pkg/account_group.py:420` | Matching Python is `sac.account.watch_quota` (flattened: `account_watch_quota`); MCP word-order is the intentional verb-first form MCP clients read more naturally. |
| `subagent_get_state` | `_mcp/_tools/_subagent.py` + `cli_pkg/subagent_group.py` | No `sac.subagent` noun submodule today; adding one purely to satisfy the auditor's name-derivation would be ceremony. |

Renaming either the MCP tools or adding the missing noun submodule
would be a breaking change for MCP clients calling by tool name AND
would broaden the Python public API surface beyond what sac actually
intends. sac is the exact shape `mcp_parity_exempt` was designed for —
see `scitex_dev/_cli/audit/_summary/_mcp_parity.py:9-13`: *"Some
packages legitimately expose far more MCP tools than Python-API
functions."*

## What this PR does NOT close

The audit-conformance gate has been failing on a TOTAL of 2
develop-shared violation categories (per PR #208's CI run logs):

- **§6 MCP-parity** (this PR): closed here.
- **§6a env-var prefix** (`SAC_*` not in scitex-dev's hardcoded
  allowlist): blocked on scitex-dev releasing per-package
  `[tool.scitex_dev] env_allowlist` support. **NOTE:** on CI's editable
  install shape, `_scan_env_vars` walks zero `.py` files (`pip install
  -e` produces a RECORD with only `.dist-info` files), so §6a does NOT
  actually fire on CI — the failure was always §6 + occasionally a
  PS-140 cross-package-gate drift. §6a is a local-dev-box-only phantom
  for editable installs. Still, sac's `[tool.scitex_dev]` block is
  ready to accept the `env_allowlist = ["SAC_"]` line as soon as the
  scitex-dev PR ships.

## Test plan

- [x] `tests/develop/test_audit.py::test_audit_all_clean` passes
      locally with the worktree venv's `scitex-dev` on `PATH` (worktree
      basename is the only remaining local-only blocker — CI's
      checkout basename is `scitex-agent-container`, no drift)
- [ ] Full pytest matrix on CI (py3.11 / py3.12 / py3.13)
- [ ] `ruff`, `import-smoke`, `quality`, `docs/rtd`, `CLAssistant`

Companion: scitex-dev PR (in progress) adding per-package `[tool.scitex_dev] env_allowlist` support for §6a — once released, sac pyproject will gain `env_allowlist = ["SAC_"]` in the same `[tool.scitex_dev]` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)