### PR TITLE
chore(audit): declare env_allowlist=["SAC_"] for §6a opt-out

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -190,6 +190,31 @@ Documentation = "https://scitex-agent-container.readthedocs.io"
 # legitimately expose far more MCP tools than Python-API functions").
 mcp_parity_exempt = true
 
+# §6a (audit-cli, env-var prefix) — per-package opt-out for legacy
+# operator-facing `SAC_*` env-var namespace.
+#
+# sac ships 8 operator-facing `SAC_*` env vars
+# (SAC_ANTHROPIC_API_KEY, SAC_LISTEN_BASE_URL, SAC_LISTEN_BEARER,
+# SAC_STATUSLINE_STATE_DIR, SAC_PROBE_LOG_ROOT, SAC_HOST_IDENTITY_PATH,
+# SAC_CHANNEL_AUTO_ACK, SAC_WORKDIR_CLAUDE_WARN_BYTES) with 186
+# in-repo occurrences across 75 files plus undefined downstream
+# operator shell / dotfile / hook / agent-spec / skill breakage.
+# Renaming to `SCITEX_AGENT_CONTAINER_*` would break every running
+# deployment, so the operator-approved real fix is the per-package
+# allowlist mechanism added in scitex-dev PR #69.
+#
+# Entries apply "equal-to-stripped or prefix-match" semantics
+# (identical to the universal allowlist) — `"SAC_"` covers every
+# `SAC_*` var sac uses.
+#
+# Forward-compatible: TOML extra keys are silently ignored by older
+# scitex-dev releases (≤0.12.2 does not read this key), so this
+# line is a no-op until the env_allowlist support ships. Once
+# scitex-dev's next release ships, audit-all on sac will clear §6a
+# automatically — `test_audit_all_clean` stays honestly red on this
+# PR's CI in the interim (no `skip_rules` masking).
+env_allowlist = ["SAC_"]
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/scitex_agent_container"]
 


### PR DESCRIPTION
## Summary

Adds the per-package `[tool.scitex_dev] env_allowlist = ["SAC_"]`
opt-out to sac's `pyproject.toml`. Companion to upstream
**scitex-dev PR #69**
(`feat/audit-cli-env-allowlist`), which adds the audit-cli §6a
mechanism that reads this key.

This is the operator-approved **real fix** for the 8 `SAC_*` env-var
§6a violations — hard rules #1 (fix root cause, no skip_rules
masking) and #2 (red-as-red, never hide a failure). No skip_rules,
no `SCITEX_DEV_SKIP_AUDIT=1`, no `# stx-allow`.

## Why allowlist, not rename

sac ships 8 operator-facing `SAC_*` env vars with **186 in-repo
occurrences across 75 files** plus undefined downstream operator
shell / dotfile / hook / agent-spec / skill breakage. Renaming to
`SCITEX_AGENT_CONTAINER_*` would break every running deployment.

## Forward-compatible

TOML extra keys are silently ignored by older scitex-dev releases
(≤0.12.2). This line is a no-op until scitex-dev's next release
ships env_allowlist support. Once that release lands on PyPI:
sac's existing `scitex-dev>=0.11.7` dev-dep constraint resolves
to the new version on fresh installs, audit-all clears §6a
automatically — no further sac code change required.

## Honest-red until upstream release

`tests/develop/test_audit.py::test_audit_all_clean` **remains red**
on this PR's CI until scitex-dev releases. That is the correct
state. Once scitex-dev publishes the next version:

1. Re-running CI on this PR will pick up the new scitex-dev →
   audit-all clears → `test_audit_all_clean` goes green.
2. develop is then merge-ready for this PR.

## Stacking

This branch is **stacked on `chore/audit-all-clean` (PR #209)**,
which introduces the `[tool.scitex_dev]` block with
`mcp_parity_exempt = true`. Lead merges PR #209 first, then this
PR cleanly auto-merges to add `env_allowlist`.

## Test plan

- [x] Targeted suite: 23/23 pass on `tests/integration/test_templates_v3_valid.py` + `tests/integration/test_cross_package_imports.py` under `TMPDIR=/home/ywatanabe/.cache/pytest-tmp`.
- [ ] CI matrix (py3.11 / py3.12 / py3.13) — expected: `test_audit_all_clean` red on §6a until scitex-dev releases; all other tests green.
- [ ] `ruff`, `import-smoke`, `quality`, `docs/rtd`, `CLAssistant`

## Related

- PR #209 (sac §6 MCP-parity exemption) — parent branch
- scitex-dev PR #69 (`feat/audit-cli-env-allowlist`) — upstream mechanism

🤖 Generated with [Claude Code](https://claude.com/claude-code)