### PR TITLE
release: bump to v0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.21.0] — 2026-05-25
+
+### Added
+- **feat(provider): vendor-agnostic Anthropic-SDK backend override (PR #208)** —
+  `spec.claude.provider` with `base_url` + `auth_token_env` points a sac
+  agent's Claude-SDK session at any Anthropic-SDK-compatible endpoint
+  (DeepSeek first). Host-side `runtimes/_apptainer_provider.py` emits
+  `ANTHROPIC_BASE_URL` + `SAC_ANTHROPIC_API_KEY` + `CLAUDE_CONFIG_DIR`
+  at start; auth resolution via `scitex_config` cascade
+  (shell-export > `$HOME/.env` > default → fail-loud
+  `ProviderEnvError`). `claude-*` model alias check is relaxed under a
+  provider override; `provider` + `spec.claude.account` are mutually
+  exclusive. New: `config/_provider_types.ProviderSpec`,
+  `runtimes/_apptainer_provider.py`, `runtimes/_apptainer_auth.py`,
+  ADR-0011, `examples/agents/deepseek-agent/spec.yaml`. 73 targeted
+  tests; full pytest matrix green.
+- **chore(audit): exempt sac from §6 MCP-Python parity (PR #209)** —
+  adds `[tool.scitex_dev] mcp_parity_exempt = true` to pyproject for
+  the audit-cli §6 check. sac's MCP tools mirror CLI subcommands, not
+  top-level Python APIs (4 orphan tools: `agent_spawn`,
+  `list_python_apis`, `quota_watch`, `subagent_get_state`). Closes the
+  only develop-shared audit-conformance violation;
+  `tests/develop/test_audit.py::test_audit_all_clean` now green on
+  develop.
+
 ### Added
 - **feat(account): credential auto-sync substrate (`sac accounts
   sync-live` / `watch-live`)** — keep the per-account store fresh the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-agent-container"
-version = "0.20.0"
+version = "0.21.0"
 description = "Declarative YAML-based framework for defining, managing, and orchestrating AI coding agent instances"
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
## Summary

Bumps `pyproject.toml` version 0.20.0 → 0.21.0 and rolls the
CHANGELOG `[Unreleased]` entries into `[0.21.0] — 2026-05-25`.

### Highlights of v0.21.0

- **#208 — vendor-agnostic Anthropic-SDK backend override** (`spec.claude.provider`). DeepSeek-first. Host-side env-flag emit via `runtimes/_apptainer_provider.py`; scitex-config cascade for auth resolution per ADR-0011; fail-loud on missing key.
- **#209 — sac audit-conformance §6 MCP-parity exemption** via `[tool.scitex_dev] mcp_parity_exempt = true`. Closes the only develop-shared audit failure.

## Sequencing

Pre-release CI baseline: develop tip pre-bump (`a668845` / `05e1e3b`) — pytest-matrix py3.11/3.12/3.13, ruff, quality, docs, import-smoke, CLAssistant all SUCCESS.

Post-merge: develop → main PR, then tag `v0.21.0` on main → triggers `pypi-publish-and-github-release-on-tag.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)