### PR TITLE
feat(creds): pick healthy stored account at agent-start (CREDS-PHASE1)

### DIFF
--- a/src/scitex_agent_container/_creds/__init__.py
+++ b/src/scitex_agent_container/_creds/__init__.py
@@ -1,0 +1,32 @@
+"""Per-agent credential selection helpers.
+
+The package owns the *picker* layer above the existing
+:mod:`scitex_agent_container._account` store. Where ``_account``
+manages stored snapshots (save / sync-live / freshness), ``_creds``
+answers the agent-start question:
+
+    Given ``spec.claude.account`` (or no preference), WHICH stored
+    account should this agent actually run on right now?
+
+Phase 1 (this module): pick a non-expired snapshot — see
+:func:`._pick_healthy.pick_healthy_account`. Cap-state probing is
+not cheaply detectable from disk, so a non-expired snapshot reads
+as healthy; 5h/7d cap-induced 429s are still surfaced from claude
+in-turn — the picker only avoids *known-stale* auth at boot.
+"""
+
+from __future__ import annotations
+
+from ._pick_healthy import (
+    AccountHealth,
+    NoHealthyAccountError,
+    account_health,
+    pick_healthy_account,
+)
+
+__all__ = [
+    "AccountHealth",
+    "NoHealthyAccountError",
+    "account_health",
+    "pick_healthy_account",
+]

--- a/src/scitex_agent_container/_creds/_pick_healthy.py
+++ b/src/scitex_agent_container/_creds/_pick_healthy.py
@@ -1,0 +1,266 @@
+"""Pick a healthy stored account at agent-start.
+
+CREDS-PHASE1: an agent pins ``spec.claude.account`` to one of the
+operator's saved accounts. When that account's stored credential
+snapshot is EXPIRED or ABSENT, today the start fails (see
+:class:`scitex_agent_container.runtimes._apptainer_creds.PinnedAccountError`)
+and the operator has to manually ``claude /login`` + ``sac accounts
+sync-live`` before the agent can run again — even when a *different*
+saved account has a perfectly fresh credential.
+
+This picker is the boot-time first pass that rotates around that
+manual step: keep the pinned account when it's healthy; otherwise
+hand the start a different account whose snapshot IS healthy; raise
+loudly when NOTHING is healthy (the genuine "all three accounts
+capped/expired" case the operator must fix).
+
+Scope (Phase 1, deliberately small)
+-----------------------------------
+* Health is *snapshot freshness*: a non-expired ``claudeAiOauth.
+  expiresAt`` (the same field :mod:`_account.creds_sync` already
+  reads) → ``VALID``. EXPIRED / ABSENT → unhealthy.
+* No 5h/7d cap probe — that requires a live Claude API call, is
+  not "cheaply detectable", and would itself burn one of the three
+  accounts' quota. Cap-induced 429s still surface from claude
+  in-turn; the picker only avoids *known-stale* auth at boot.
+* Read-only: this module NEVER writes a snapshot. The existing
+  per-agent writable boot-copy in
+  :func:`runtimes._apptainer_creds.resolve_cred_file` and its
+  in-container ~1h token refresh are untouched.
+* Pure stdlib; no network call.
+
+Fail-loud contract
+------------------
+``pick_healthy_account`` raises :class:`NoHealthyAccountError` when
+nothing is healthy. The message names every candidate's state so the
+operator immediately sees which accounts to refresh. No silent
+fallback to a stale snapshot — running a pinned agent on a known-
+expired token is exactly what the previous fail-loud guard was added
+to prevent.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from .._account.creds_sync import _read_oauth_expiry_seconds
+from .._state.account_store import _store_path
+
+# Health states for one account's snapshot. Mirrors
+# :class:`_account.creds_sync.Freshness` but anchored on a *name* so the
+# picker can return a structured "why I rotated" record to its caller.
+_VALID = "VALID"
+_EXPIRED = "EXPIRED"
+_ABSENT = "ABSENT"
+
+
+class NoHealthyAccountError(RuntimeError):
+    """Raised when no stored account currently has a usable snapshot.
+
+    The message names every probed account and its state so the
+    operator sees the full picture in one error line — they should
+    ``claude /login`` to one of them and ``sac accounts sync-live``,
+    then restart the agent. Surfaced through ``sac agents start``.
+    """
+
+
+@dataclass(frozen=True)
+class AccountHealth:
+    """Health of one stored account's credential snapshot.
+
+    Attributes
+    ----------
+    name
+        The stored-account name (a slug — see
+        :func:`_account.creds_sync.slugify_email`).
+    state
+        ``"VALID"`` (non-expired snapshot present), ``"EXPIRED"`` (a
+        snapshot exists but its ``expiresAt`` is in the past), or
+        ``"ABSENT"`` (no snapshot file on disk, or unparseable).
+    hours_remaining
+        Signed hours to expiry (positive = remaining, negative =
+        past) for VALID/EXPIRED; ``None`` for ABSENT.
+    """
+
+    name: str
+    state: str
+    hours_remaining: float | None
+
+    @property
+    def is_healthy(self) -> bool:
+        return self.state == _VALID
+
+
+def account_health(
+    name: str,
+    *,
+    store_dir: Path | None = None,
+    home: Path | None = None,
+    now: float | None = None,
+) -> AccountHealth:
+    """Return the health of one stored account's snapshot.
+
+    Never raises. A missing / unparseable snapshot reads as
+    :class:`AccountHealth` ``state="ABSENT"``.
+
+    This is functionally equivalent to
+    :func:`_account.creds_sync.account_freshness`, re-exposed under a
+    name-anchored shape so :func:`pick_healthy_account` can build the
+    diagnostic error message without losing the account name.
+    """
+    _home = home if home is not None else Path.home()
+    now_ts = now if now is not None else time.time()
+
+    store = _store_path(store_dir, _home)
+    snapshot = store / name / ".credentials.json"
+    expiry = _read_oauth_expiry_seconds(snapshot) if snapshot.is_file() else None
+    if expiry is None:
+        return AccountHealth(name=name, state=_ABSENT, hours_remaining=None)
+    hours = (expiry - now_ts) / 3600.0
+    state = _VALID if expiry > now_ts else _EXPIRED
+    return AccountHealth(name=name, state=state, hours_remaining=hours)
+
+
+def _discover_candidates(
+    store_dir: Path | None,
+    home: Path,
+) -> list[str]:
+    """Return every stored-account name on disk (sorted, deterministic).
+
+    Best-effort: a missing / unreadable store reads as no candidates
+    (the caller turns that into :class:`NoHealthyAccountError`). We
+    skip the store-internal ``_rotations/`` housekeeping dir so it
+    can never get picked.
+    """
+    store = _store_path(store_dir, home)
+    if not store.is_dir():
+        return []
+    out: list[str] = []
+    # stx-allow: fallback (reason: store iteration is best-effort
+    # discovery; an unreadable dir / partially-created entry must
+    # degrade to "no candidates" so the caller's fail-loud takes over,
+    # never crash with an OSError mid-resolution.)
+    try:
+        for child in sorted(store.iterdir()):
+            if not child.is_dir():
+                continue
+            if child.name.startswith("_"):
+                continue
+            out.append(child.name)
+    except OSError:
+        return []
+    return out
+
+
+def _format_states(healths: list[AccountHealth]) -> str:
+    """Render an operator-facing "name=STATE (+/-Xh)" list for the error."""
+    parts: list[str] = []
+    for h in healths:
+        if h.hours_remaining is None:
+            parts.append(f"{h.name}={h.state}")
+        else:
+            parts.append(f"{h.name}={h.state} ({h.hours_remaining:+.1f}h)")
+    return ", ".join(parts) if parts else "(no candidates)"
+
+
+def pick_healthy_account(
+    preferred: str | None,
+    *,
+    candidates: list[str] | None = None,
+    store_dir: Path | None = None,
+    home: Path | None = None,
+    now: float | None = None,
+) -> str:
+    """Return the stored-account name an agent should run on right now.
+
+    Preference order
+    ----------------
+    1. ``preferred`` (typically ``spec.claude.account``) when its
+       snapshot is :attr:`AccountHealth.is_healthy`.
+    2. First healthy candidate, in the order given (when ``candidates``
+       is explicit) or sorted alphabetically (when auto-discovered) —
+       deterministic so two simultaneous starts pick the same account.
+
+    Parameters
+    ----------
+    preferred
+        The agent's pinned account (``spec.claude.account``). ``None``
+        / empty means "no preference" — the picker hands back the first
+        healthy candidate instead of raising.
+    candidates
+        Optional explicit candidate shortlist. ``None`` (default) walks
+        every stored account directory on disk. An EMPTY list is
+        respected (no auto-discovery fallback) so callers can pin the
+        candidate universe in tests.
+    store_dir, home, now
+        Test overrides. ``store_dir=None`` uses the SciTeX local-state
+        cascade (see :func:`_account.account_store._store_path`);
+        ``home=None`` uses ``Path.home()``; ``now=None`` uses
+        ``time.time()``.
+
+    Returns
+    -------
+    str
+        The picked stored-account name.
+
+    Raises
+    ------
+    NoHealthyAccountError
+        When no candidate is :attr:`AccountHealth.is_healthy`. The
+        message names every candidate's state. NEVER falls back to
+        a stale snapshot.
+    """
+    _home = home if home is not None else Path.home()
+
+    if candidates is None:
+        cand_list = _discover_candidates(store_dir, _home)
+    else:
+        cand_list = list(candidates)
+
+    # Make sure `preferred` is considered even when the caller didn't
+    # include it in `candidates` — its absent/expired state still
+    # belongs in the error message so the operator sees why we rotated.
+    pref = (preferred or "").strip()
+    if pref and pref not in cand_list:
+        cand_list = [pref, *cand_list]
+
+    if not cand_list:
+        raise NoHealthyAccountError(
+            "no stored accounts to choose from — run "
+            "`sac accounts save <name>` or `sac accounts sync-live` "
+            "on the credential-holding host, then retry."
+        )
+
+    healths = [
+        account_health(name, store_dir=store_dir, home=_home, now=now)
+        for name in cand_list
+    ]
+    by_name = {h.name: h for h in healths}
+
+    # 1. Preferred wins when healthy.
+    if pref:
+        h = by_name.get(pref)
+        if h is not None and h.is_healthy:
+            return pref
+
+    # 2. First healthy in candidate order.
+    for h in healths:
+        if h.is_healthy:
+            return h.name
+
+    # 3. Nothing healthy — fail loud with full diagnostic.
+    raise NoHealthyAccountError(
+        "no healthy stored account: "
+        f"{_format_states(healths)}. Fix: `claude /login` to one of "
+        "them, then `sac accounts sync-live`, then restart the agent."
+    )
+
+
+__all__ = [
+    "AccountHealth",
+    "NoHealthyAccountError",
+    "account_health",
+    "pick_healthy_account",
+]

--- a/src/scitex_agent_container/_lifecycle/_start.py
+++ b/src/scitex_agent_container/_lifecycle/_start.py
@@ -6,6 +6,7 @@ Extracted from the former monolithic ``lifecycle.py`` (split for the
 
 from __future__ import annotations
 
+import sys
 import threading
 import time
 import traceback
@@ -37,6 +38,58 @@ def _resolve_strict_drift(strict_drift: bool | None) -> bool:
 
     raw = (_sac_env("STRICT_DRIFT", "") or "").strip().lower()
     return raw in ("1", "true", "yes", "on")
+
+
+def _rotate_to_healthy_account(
+    config: AgentConfig,
+    *,
+    log_stream: Any = None,
+) -> None:
+    """Rotate ``config.claude.account`` to a healthy stored account.
+
+    CREDS-PHASE1 wiring. Only acts on PINNED agents
+    (``spec.claude.account`` non-empty). For an unpinned agent the
+    runtime continues to bind the host's live ``.credentials.json``
+    untouched.
+
+    On a pinned agent:
+
+    * If the pinned snapshot is healthy → no-op (config unchanged).
+    * If the pinned snapshot is EXPIRED/ABSENT but another stored
+      account has a fresh snapshot → ``config.claude.account`` is
+      mutated to that account and a one-line rotation notice is
+      printed to ``log_stream`` (default ``sys.stderr``). The runtime
+      then re-copies that account's snapshot into the per-agent
+      writable boot-copy via the existing
+      :func:`runtimes._apptainer_creds.resolve_cred_file` path — the
+      in-container ~1h token refresh on that copy keeps working.
+    * If NOTHING is healthy → :class:`_creds.NoHealthyAccountError`
+      propagates (fail loud, no silent stale-token launch). Agent is
+      NOT started.
+
+    See :mod:`scitex_agent_container._creds._pick_healthy` for the
+    health model — non-expired snapshot = healthy. Cap-induced 429s
+    still surface from claude in-turn; the picker only avoids
+    known-stale auth at boot.
+    """
+    pinned = getattr(getattr(config, "claude", None), "account", "") or ""
+    if not pinned:
+        return  # unpinned agent — host live OAuth, untouched.
+
+    from .._creds import pick_healthy_account
+
+    picked = pick_healthy_account(pinned)
+    if picked == pinned:
+        return  # pinned is healthy — no rotation, no log line.
+
+    config.claude.account = picked
+    stream = log_stream if log_stream is not None else sys.stderr
+    print(
+        f"[sac:creds] agent '{config.name}' rotated account: "
+        f"{pinned!r} -> {picked!r} (pinned snapshot unhealthy; "
+        f"rotated to the first healthy stored account)",
+        file=stream,
+    )
 
 
 def _check_spec_source_drift_at_launch(
@@ -123,6 +176,16 @@ def agent_start(
     # a non-git source / unreachable remote / any error warns-and-continues
     # — the check never crashes a launch (resilience is the contract).
     _check_spec_source_drift_at_launch(config_path, config.name, strict_drift)
+
+    # CREDS-PHASE1 — auto-rotate ``spec.claude.account`` to a healthy
+    # stored account when the pinned one's snapshot is EXPIRED/ABSENT.
+    # Runs before forced_stop / runtime build so a "no healthy account"
+    # error never tears down a running agent we cannot restart. Unpinned
+    # agents (account="") are untouched: they continue to use the host
+    # live ``.credentials.json`` via the existing bind. See
+    # :func:`_rotate_to_healthy_account` for the contract.
+    _rotate_to_healthy_account(config)
+
     if session_override:
         config.claude.session = session_override
     if resume_id_override is not None:

--- a/tests/scitex_agent_container/_creds/test__pick_healthy.py
+++ b/tests/scitex_agent_container/_creds/test__pick_healthy.py
@@ -1,0 +1,284 @@
+"""Tests for ``_creds._pick_healthy`` (CREDS-PHASE1 picker).
+
+No mocks (PA-306): every test drives the real picker against real
+JSON snapshots under a tmp store. AAA markers (TQ002), descriptive
+names (TQ003), one assertion per test (TQ007).
+
+The ``_isolate_home`` fixture forces ``$HOME`` inside ``tmp_path`` so a
+``_store_path`` regression can never write to the operator's real
+``~/.scitex/agent-container/accounts/``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._creds._pick_healthy import (
+    AccountHealth,
+    NoHealthyAccountError,
+    account_health,
+    pick_healthy_account,
+)
+
+
+@pytest.fixture
+def _isolate_home(tmp_path: Path):
+    """Force ``Path.home()`` inside ``tmp_path`` for the test's duration.
+
+    PA-306: no monkeypatch — ``Path.home()`` reads ``$HOME`` on Unix,
+    so an explicit ``os.environ`` save/restore is the real equivalent.
+    """
+    saved = os.environ.get("HOME")
+    os.environ["HOME"] = str(tmp_path)
+    try:
+        yield tmp_path
+    finally:
+        if saved is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = saved
+
+
+def _store_root(home: Path) -> Path:
+    return home / ".scitex" / "agent-container" / "accounts"
+
+
+def _write_snapshot(home: Path, name: str, expires_at_ms: int) -> Path:
+    """Write a real per-account credential snapshot under the store."""
+    path = _store_root(home) / name / ".credentials.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"claudeAiOauth": {"expiresAt": expires_at_ms}}))
+    return path
+
+
+def _future_ms(seconds: float = 3600.0) -> int:
+    return int((time.time() + seconds) * 1_000)
+
+
+def _past_ms(seconds: float = 3600.0) -> int:
+    return int((time.time() - seconds) * 1_000)
+
+
+# ---------------------------------------------------------------------------
+# account_health — building block (per-account state)
+# ---------------------------------------------------------------------------
+
+
+def test_account_health_returns_valid_for_unexpired_snapshot(
+    _isolate_home: Path,
+) -> None:
+    # Arrange
+    home = _isolate_home
+    _write_snapshot(home, "wyusuuke-gmail-com", _future_ms(7200))
+    # Act
+    h = account_health("wyusuuke-gmail-com", home=home)
+    # Assert
+    assert h.state == "VALID"
+
+
+def test_account_health_returns_expired_for_past_expiry(_isolate_home: Path) -> None:
+    # Arrange
+    home = _isolate_home
+    _write_snapshot(home, "wyusuuke-gmail-com", _past_ms(60))
+    # Act
+    h = account_health("wyusuuke-gmail-com", home=home)
+    # Assert
+    assert h.state == "EXPIRED"
+
+
+def test_account_health_returns_absent_when_snapshot_missing(
+    _isolate_home: Path,
+) -> None:
+    # Arrange
+    home = _isolate_home
+    # (no snapshot written)
+    # Act
+    h = account_health("ywata1989-gmail-com", home=home)
+    # Assert
+    assert h.state == "ABSENT"
+
+
+# ---------------------------------------------------------------------------
+# pick_healthy_account — preferred wins when healthy
+# ---------------------------------------------------------------------------
+
+
+def test_pick_returns_preferred_when_preferred_is_healthy(_isolate_home: Path) -> None:
+    # Arrange
+    home = _isolate_home
+    _write_snapshot(home, "ywatanabe-scitex-ai", _future_ms())
+    _write_snapshot(home, "wyusuuke-gmail-com", _future_ms())
+    # Act
+    picked = pick_healthy_account(
+        "ywatanabe-scitex-ai",
+        candidates=["ywatanabe-scitex-ai", "wyusuuke-gmail-com"],
+        home=home,
+    )
+    # Assert
+    assert picked == "ywatanabe-scitex-ai"
+
+
+# ---------------------------------------------------------------------------
+# pick_healthy_account — rotation when preferred is unhealthy
+# ---------------------------------------------------------------------------
+
+
+def test_pick_rotates_to_healthy_when_preferred_is_expired(
+    _isolate_home: Path,
+) -> None:
+    # Arrange
+    home = _isolate_home
+    _write_snapshot(home, "ywatanabe-scitex-ai", _past_ms(60))
+    _write_snapshot(home, "wyusuuke-gmail-com", _future_ms())
+    # Act
+    picked = pick_healthy_account(
+        "ywatanabe-scitex-ai",
+        candidates=["ywatanabe-scitex-ai", "wyusuuke-gmail-com"],
+        home=home,
+    )
+    # Assert
+    assert picked == "wyusuuke-gmail-com"
+
+
+def test_pick_rotates_when_preferred_snapshot_absent(_isolate_home: Path) -> None:
+    # Arrange
+    home = _isolate_home
+    _write_snapshot(home, "wyusuuke-gmail-com", _future_ms())
+    # ywatanabe-scitex-ai snapshot deliberately missing
+    # Act
+    picked = pick_healthy_account(
+        "ywatanabe-scitex-ai",
+        candidates=["ywatanabe-scitex-ai", "wyusuuke-gmail-com"],
+        home=home,
+    )
+    # Assert
+    assert picked == "wyusuuke-gmail-com"
+
+
+def test_pick_falls_back_to_first_healthy_in_alphabetic_order(
+    _isolate_home: Path,
+) -> None:
+    # Arrange — preferred missing; two healthy candidates, ensure
+    # deterministic pick (alphabetic).
+    home = _isolate_home
+    _write_snapshot(home, "wyusuuke-gmail-com", _future_ms())
+    _write_snapshot(home, "ywata1989-gmail-com", _future_ms())
+    # Act
+    picked = pick_healthy_account(
+        "ywatanabe-scitex-ai",
+        candidates=["ywatanabe-scitex-ai", "wyusuuke-gmail-com", "ywata1989-gmail-com"],
+        home=home,
+    )
+    # Assert
+    assert picked == "wyusuuke-gmail-com"
+
+
+# ---------------------------------------------------------------------------
+# pick_healthy_account — preferred=None / "": still picks a healthy one
+# ---------------------------------------------------------------------------
+
+
+def test_pick_with_none_preferred_returns_first_healthy(_isolate_home: Path) -> None:
+    # Arrange
+    home = _isolate_home
+    _write_snapshot(home, "ywata1989-gmail-com", _future_ms())
+    # Act
+    picked = pick_healthy_account(
+        None,
+        candidates=["ywatanabe-scitex-ai", "ywata1989-gmail-com"],
+        home=home,
+    )
+    # Assert
+    assert picked == "ywata1989-gmail-com"
+
+
+# ---------------------------------------------------------------------------
+# pick_healthy_account — fail-loud when nothing is healthy
+# ---------------------------------------------------------------------------
+
+
+def test_pick_raises_when_every_candidate_is_expired(_isolate_home: Path) -> None:
+    # Arrange — all three accounts expired (the "all capped" worst case).
+    home = _isolate_home
+    _write_snapshot(home, "ywatanabe-scitex-ai", _past_ms(120))
+    _write_snapshot(home, "wyusuuke-gmail-com", _past_ms(120))
+    _write_snapshot(home, "ywata1989-gmail-com", _past_ms(120))
+    # Act
+    ctx = pytest.raises(NoHealthyAccountError)
+    # Assert
+    with ctx:
+        pick_healthy_account(
+            "ywatanabe-scitex-ai",
+            candidates=[
+                "ywatanabe-scitex-ai",
+                "wyusuuke-gmail-com",
+                "ywata1989-gmail-com",
+            ],
+            home=home,
+        )
+
+
+def test_pick_raises_when_candidate_list_is_empty(_isolate_home: Path) -> None:
+    # Arrange
+    home = _isolate_home
+    # Act
+    ctx = pytest.raises(NoHealthyAccountError)
+    # Assert
+    with ctx:
+        pick_healthy_account("ywatanabe-scitex-ai", candidates=[], home=home)
+
+
+def test_pick_error_message_names_every_candidate_state(_isolate_home: Path) -> None:
+    # Arrange
+    home = _isolate_home
+    _write_snapshot(home, "ywatanabe-scitex-ai", _past_ms(60))
+    _write_snapshot(home, "wyusuuke-gmail-com", _past_ms(60))
+    # Act — the message must let the operator see which accounts are
+    # stale so they know which to `claude /login`.
+    ctx = pytest.raises(NoHealthyAccountError, match=r"ywatanabe-scitex-ai")
+    # Assert
+    with ctx:
+        pick_healthy_account(
+            "ywatanabe-scitex-ai",
+            candidates=["ywatanabe-scitex-ai", "wyusuuke-gmail-com"],
+            home=home,
+        )
+
+
+# ---------------------------------------------------------------------------
+# pick_healthy_account — default candidate discovery (no explicit list)
+# ---------------------------------------------------------------------------
+
+
+def test_pick_discovers_candidates_from_store_when_unspecified(
+    _isolate_home: Path,
+) -> None:
+    # Arrange — only one valid snapshot on disk; picker must auto-discover it.
+    home = _isolate_home
+    _write_snapshot(home, "ywata1989-gmail-com", _future_ms())
+    # Act
+    picked = pick_healthy_account("ywatanabe-scitex-ai", home=home)
+    # Assert
+    assert picked == "ywata1989-gmail-com"
+
+
+# ---------------------------------------------------------------------------
+# AccountHealth dataclass surface (used by callers that want to log)
+# ---------------------------------------------------------------------------
+
+
+def test_account_health_dataclass_carries_name_state_and_hours(
+    _isolate_home: Path,
+) -> None:
+    # Arrange
+    home = _isolate_home
+    _write_snapshot(home, "wyusuuke-gmail-com", _future_ms(3600))
+    # Act
+    h = account_health("wyusuuke-gmail-com", home=home)
+    # Assert
+    assert isinstance(h, AccountHealth) and h.name == "wyusuuke-gmail-com"

--- a/tests/scitex_agent_container/_lifecycle/test__start_creds_rotate.py
+++ b/tests/scitex_agent_container/_lifecycle/test__start_creds_rotate.py
@@ -1,0 +1,186 @@
+"""Tests for the CREDS-PHASE1 account picker wired into ``agent_start``.
+
+PA-306: no mocks. Real config dataclasses, real store snapshots,
+real :func:`_rotate_to_healthy_account` mutation against an isolated
+``$HOME``. AAA markers (TQ002), descriptive names, one assertion each.
+
+The picker wiring lives in :mod:`scitex_agent_container._lifecycle.
+_start`; this file exercises the helper directly because the full
+``agent_start`` flow already has dedicated coverage in
+``test_lifecycle.py`` / ``test__start_drift.py`` — the new behaviour
+is "rotate ``config.claude.account`` to a healthy stored account, or
+fail loud" and that's what we pin here.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import time
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from scitex_agent_container._creds import NoHealthyAccountError
+from scitex_agent_container._lifecycle._start import _rotate_to_healthy_account
+from scitex_agent_container.config import AgentConfig
+
+
+@pytest.fixture
+def _isolate_home(tmp_path: Path) -> Iterator[Path]:
+    saved = os.environ.get("HOME")
+    os.environ["HOME"] = str(tmp_path)
+    try:
+        yield tmp_path
+    finally:
+        if saved is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = saved
+
+
+def _write_snapshot(home: Path, name: str, expires_at_ms: int) -> None:
+    path = (
+        home / ".scitex" / "agent-container" / "accounts" / name / ".credentials.json"
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"claudeAiOauth": {"expiresAt": expires_at_ms}}))
+
+
+def _future_ms(seconds: float = 7200.0) -> int:
+    return int((time.time() + seconds) * 1_000)
+
+
+def _past_ms(seconds: float = 600.0) -> int:
+    return int((time.time() - seconds) * 1_000)
+
+
+def _make_config(name: str, account: str) -> AgentConfig:
+    cfg = AgentConfig(name=name)
+    cfg.claude.account = account
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# Unpinned agent — picker is a no-op.
+# ---------------------------------------------------------------------------
+
+
+def test_unpinned_agent_leaves_account_unchanged(_isolate_home: Path) -> None:
+    # Arrange — no stored accounts, no pin: must NOT touch host live OAuth.
+    cfg = _make_config("alpha", account="")
+    log = io.StringIO()
+    # Act
+    _rotate_to_healthy_account(cfg, log_stream=log)
+    # Assert
+    assert cfg.claude.account == ""
+
+
+def test_unpinned_agent_does_not_print_rotation_line(_isolate_home: Path) -> None:
+    # Arrange
+    cfg = _make_config("alpha", account="")
+    log = io.StringIO()
+    # Act
+    _rotate_to_healthy_account(cfg, log_stream=log)
+    # Assert — quiet path; no log noise for the common unpinned case.
+    assert log.getvalue() == ""
+
+
+# ---------------------------------------------------------------------------
+# Pinned + healthy — picker is a no-op.
+# ---------------------------------------------------------------------------
+
+
+def test_pinned_healthy_agent_keeps_pinned_account(_isolate_home: Path) -> None:
+    # Arrange
+    home = _isolate_home
+    _write_snapshot(home, "ywatanabe-scitex-ai", _future_ms())
+    cfg = _make_config("alpha", account="ywatanabe-scitex-ai")
+    log = io.StringIO()
+    # Act
+    _rotate_to_healthy_account(cfg, log_stream=log)
+    # Assert
+    assert cfg.claude.account == "ywatanabe-scitex-ai"
+
+
+def test_pinned_healthy_agent_emits_no_rotation_line(_isolate_home: Path) -> None:
+    # Arrange
+    home = _isolate_home
+    _write_snapshot(home, "ywatanabe-scitex-ai", _future_ms())
+    cfg = _make_config("alpha", account="ywatanabe-scitex-ai")
+    log = io.StringIO()
+    # Act
+    _rotate_to_healthy_account(cfg, log_stream=log)
+    # Assert — quiet when no rotation happened.
+    assert log.getvalue() == ""
+
+
+# ---------------------------------------------------------------------------
+# Pinned + unhealthy + a healthy alternative — rotate.
+# ---------------------------------------------------------------------------
+
+
+def test_pinned_expired_agent_rotates_to_healthy_account(_isolate_home: Path) -> None:
+    # Arrange — pinned is EXPIRED, sibling is fresh.
+    home = _isolate_home
+    _write_snapshot(home, "ywatanabe-scitex-ai", _past_ms(60))
+    _write_snapshot(home, "wyusuuke-gmail-com", _future_ms())
+    cfg = _make_config("alpha", account="ywatanabe-scitex-ai")
+    log = io.StringIO()
+    # Act
+    _rotate_to_healthy_account(cfg, log_stream=log)
+    # Assert
+    assert cfg.claude.account == "wyusuuke-gmail-com"
+
+
+def test_pinned_rotation_emits_a_one_line_notice_to_log_stream(
+    _isolate_home: Path,
+) -> None:
+    # Arrange
+    home = _isolate_home
+    _write_snapshot(home, "ywatanabe-scitex-ai", _past_ms(60))
+    _write_snapshot(home, "wyusuuke-gmail-com", _future_ms())
+    cfg = _make_config("alpha", account="ywatanabe-scitex-ai")
+    log = io.StringIO()
+    # Act
+    _rotate_to_healthy_account(cfg, log_stream=log)
+    # Assert — the operator must see WHICH agent and HOW the account moved.
+    msg = log.getvalue()
+    assert (
+        "alpha" in msg
+        and "ywatanabe-scitex-ai" in msg
+        and "wyusuuke-gmail-com" in msg
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pinned + nothing healthy — fail loud.
+# ---------------------------------------------------------------------------
+
+
+def test_pinned_all_expired_raises_no_healthy_account_error(
+    _isolate_home: Path,
+) -> None:
+    # Arrange — every stored snapshot expired.
+    home = _isolate_home
+    _write_snapshot(home, "ywatanabe-scitex-ai", _past_ms(60))
+    _write_snapshot(home, "wyusuuke-gmail-com", _past_ms(60))
+    _write_snapshot(home, "ywata1989-gmail-com", _past_ms(60))
+    cfg = _make_config("alpha", account="ywatanabe-scitex-ai")
+    # Act
+    ctx = pytest.raises(NoHealthyAccountError)
+    # Assert
+    with ctx:
+        _rotate_to_healthy_account(cfg)
+
+
+def test_pinned_agent_with_absent_store_raises(_isolate_home: Path) -> None:
+    # Arrange — store dir doesn't exist at all and the pin can't resolve.
+    cfg = _make_config("alpha", account="ywatanabe-scitex-ai")
+    # Act — must NOT silently fall through to "use pinned anyway".
+    ctx = pytest.raises(NoHealthyAccountError)
+    # Assert
+    with ctx:
+        _rotate_to_healthy_account(cfg)


### PR DESCRIPTION
## Summary
- New `_creds` package + `pick_healthy_account(preferred, candidates=…)` — returns the pinned account when its snapshot is non-expired, else the first healthy candidate (deterministic), else raises `NoHealthyAccountError`.
- `_lifecycle._start.agent_start` calls a small wiring helper `_rotate_to_healthy_account(config)` before stop / runtime build; mutates `config.claude.account` and prints a one-line `[sac:creds] agent X rotated account: A -> B` notice when rotation happens. Unpinned agents (host live OAuth) are untouched.

## Problem
When `spec.claude.account` points at a saved account whose snapshot expired, an agent today refuses to start until the operator runs `claude /login` + `sac accounts sync-live` on that exact account — even when a different saved account has a perfectly fresh credential. This change is the boot-time first pass that rotates around the manual step.

## Design notes
- **No 5h/7d cap probe.** Cap state requires a live Claude API call (not cheap; would itself burn quota on each of the three accounts on every boot). Cap-induced 429s still surface from claude in-turn; the picker only avoids *known-stale* auth at boot.
- **Read-only.** The picker writes no credential files. The existing per-agent writable boot-copy + RW bind in `runtimes._apptainer_creds.resolve_cred_file` is unchanged, so the in-container ~1h token refresh keeps working untouched. (No diff against `_apptainer_creds.py` or `_apptainer_auth.py` in this PR.)
- **Fail loud.** No silent fallback to a stale snapshot. `NoHealthyAccountError` names every candidate's state so the operator immediately sees which to refresh. The pinned fail-loud guard in `resolve_cred_file` is preserved as the second line of defence.
- **Wins both `start` and `restart`.** `agent_restart` funnels through `agent_start`, so the wiring covers both.

## Tests
No mocks (PA-306) — real JSON snapshots under a tmp `$HOME`. AAA markers, descriptive names, one assertion per test.

- 13 picker tests (`tests/scitex_agent_container/_creds/test__pick_healthy.py`): healthy / expired / absent / rotation-order / all-capped → raises / empty-candidates → raises / preferred-not-in-candidates / default candidate discovery.
- 8 agent_start wiring tests (`tests/scitex_agent_container/_lifecycle/test__start_creds_rotate.py`): unpinned no-op + no log line, pinned-healthy no-op + no log line, pinned-expired rotation + one-line log, all-expired raises, absent-store raises.

## Test plan
- [x] `pytest tests/scitex_agent_container/_creds/` — 13 passed
- [x] `pytest tests/scitex_agent_container/_lifecycle/` — 223 passed (8 new + 215 pre-existing)
- [x] Full suite: 5056 passed, 7 pre-existing failures on develop (statusline x4, a2a/_handlers x1, runtimes/_sdk_common x1, develop/test_audit x1) — all reproducible against `origin/develop` without this branch.
- [x] `audit-python-apis` clean for `scitex-agent-container` (TQ002 markers split per audit lint).

## NOT merging
This PR introduces a change in the agent auth path (high blast radius). Lead must review and merge — do not auto-merge.