### PR TITLE
gitignore: cover writable sandboxes + nested SIFs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,15 @@ __pycache__/
 dist/
 build/
 .eggs/
+
+# Apptainer images + writable rootfs sandboxes (large, regenerable;
+# byte storage lives under ~/.scitex/<pkg>/containers/ → punim2354 on
+# Spartan per SIF-CONSOLIDATION).
 *.sif
+**/*.sif
+*.sandbox/
+**/*.sandbox/
+
 .pytest_cache/
 GITIGNORED/
 .env


### PR DESCRIPTION
## Summary
- Add explicit `.gitignore` patterns for Apptainer writable sandboxes (`*.sandbox/`, `**/*.sandbox/`) and nested SIFs (`**/*.sif`) so a stray sandbox under `tests/` or `containers/` can't sneak into `git add -A`.
- Group existing `*.sif` line under the same Apptainer header with rationale: canonical byte storage now lives at `~/.scitex/<pkg>/containers/<flavor>/<flavor>.sif`, which on Spartan symlinks to `/data/gpfs/projects/punim2354/...` (byte-rich punim, inode-tight — fine for few large blobs).

Part of SIF-CONSOLIDATION (consolidate to canonical `~/.scitex/<pkg-short>/containers/` on both lead host + Spartan; retire `~/scitex-images/`).

## Test plan
- [x] `.gitignore` diff applies cleanly on top of develop.
- [x] `git check-ignore -v test.sandbox/foo` matches the new rule (verified locally — `*.sandbox/` line).
- [x] `git check-ignore -v sub/dir/x.sif` matches `**/*.sif`.
- [x] No existing tracked file becomes ignored (only new patterns added).