### PR TITLE
fix(ssh): add ControlMaster multiplexing for parallel SSH to Spartan

### DIFF
--- a/src/scitex_agent_container/_creds/__init__.py
+++ b/src/scitex_agent_container/_creds/__init__.py
@@ -1,0 +1,32 @@
+"""Per-agent credential selection helpers.
+
+The package owns the *picker* layer above the existing
+:mod:`scitex_agent_container._account` store. Where ``_account``
+manages stored snapshots (save / sync-live / freshness), ``_creds``
+answers the agent-start question:
+
+    Given ``spec.claude.account`` (or no preference), WHICH stored
+    account should this agent actually run on right now?
+
+Phase 1 (this module): pick a non-expired snapshot — see
+:func:`._pick_healthy.pick_healthy_account`. Cap-state probing is
+not cheaply detectable from disk, so a non-expired snapshot reads
+as healthy; 5h/7d cap-induced 429s are still surfaced from claude
+in-turn — the picker only avoids *known-stale* auth at boot.
+"""
+
+from __future__ import annotations
+
+from ._pick_healthy import (
+    AccountHealth,
+    NoHealthyAccountError,
+    account_health,
+    pick_healthy_account,
+)
+
+__all__ = [
+    "AccountHealth",
+    "NoHealthyAccountError",
+    "account_health",
+    "pick_healthy_account",
+]

--- a/src/scitex_agent_container/_creds/_pick_healthy.py
+++ b/src/scitex_agent_container/_creds/_pick_healthy.py
@@ -1,0 +1,266 @@
+"""Pick a healthy stored account at agent-start.
+
+CREDS-PHASE1: an agent pins ``spec.claude.account`` to one of the
+operator's saved accounts. When that account's stored credential
+snapshot is EXPIRED or ABSENT, today the start fails (see
+:class:`scitex_agent_container.runtimes._apptainer_creds.PinnedAccountError`)
+and the operator has to manually ``claude /login`` + ``sac accounts
+sync-live`` before the agent can run again — even when a *different*
+saved account has a perfectly fresh credential.
+
+This picker is the boot-time first pass that rotates around that
+manual step: keep the pinned account when it's healthy; otherwise
+hand the start a different account whose snapshot IS healthy; raise
+loudly when NOTHING is healthy (the genuine "all three accounts
+capped/expired" case the operator must fix).
+
+Scope (Phase 1, deliberately small)
+-----------------------------------
+* Health is *snapshot freshness*: a non-expired ``claudeAiOauth.
+  expiresAt`` (the same field :mod:`_account.creds_sync` already
+  reads) → ``VALID``. EXPIRED / ABSENT → unhealthy.
+* No 5h/7d cap probe — that requires a live Claude API call, is
+  not "cheaply detectable", and would itself burn one of the three
+  accounts' quota. Cap-induced 429s still surface from claude
+  in-turn; the picker only avoids *known-stale* auth at boot.
+* Read-only: this module NEVER writes a snapshot. The existing
+  per-agent writable boot-copy in
+  :func:`runtimes._apptainer_creds.resolve_cred_file` and its
+  in-container ~1h token refresh are untouched.
+* Pure stdlib; no network call.
+
+Fail-loud contract
+------------------
+``pick_healthy_account`` raises :class:`NoHealthyAccountError` when
+nothing is healthy. The message names every candidate's state so the
+operator immediately sees which accounts to refresh. No silent
+fallback to a stale snapshot — running a pinned agent on a known-
+expired token is exactly what the previous fail-loud guard was added
+to prevent.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from .._account.creds_sync import _read_oauth_expiry_seconds
+from .._state.account_store import _store_path
+
+# Health states for one account's snapshot. Mirrors
+# :class:`_account.creds_sync.Freshness` but anchored on a *name* so the
+# picker can return a structured "why I rotated" record to its caller.
+_VALID = "VALID"
+_EXPIRED = "EXPIRED"
+_ABSENT = "ABSENT"
+
+
+class NoHealthyAccountError(RuntimeError):
+    """Raised when no stored account currently has a usable snapshot.
+
+    The message names every probed account and its state so the
+    operator sees the full picture in one error line — they should
+    ``claude /login`` to one of them and ``sac accounts sync-live``,
+    then restart the agent. Surfaced through ``sac agents start``.
+    """
+
+
+@dataclass(frozen=True)
+class AccountHealth:
+    """Health of one stored account's credential snapshot.
+
+    Attributes
+    ----------
+    name
+        The stored-account name (a slug — see
+        :func:`_account.creds_sync.slugify_email`).
+    state
+        ``"VALID"`` (non-expired snapshot present), ``"EXPIRED"`` (a
+        snapshot exists but its ``expiresAt`` is in the past), or
+        ``"ABSENT"`` (no snapshot file on disk, or unparseable).
+    hours_remaining
+        Signed hours to expiry (positive = remaining, negative =
+        past) for VALID/EXPIRED; ``None`` for ABSENT.
+    """
+
+    name: str
+    state: str
+    hours_remaining: float | None
+
+    @property
+    def is_healthy(self) -> bool:
+        return self.state == _VALID
+
+
+def account_health(
+    name: str,
+    *,
+    store_dir: Path | None = None,
+    home: Path | None = None,
+    now: float | None = None,
+) -> AccountHealth:
+    """Return the health of one stored account's snapshot.
+
+    Never raises. A missing / unparseable snapshot reads as
+    :class:`AccountHealth` ``state="ABSENT"``.
+
+    This is functionally equivalent to
+    :func:`_account.creds_sync.account_freshness`, re-exposed under a
+    name-anchored shape so :func:`pick_healthy_account` can build the
+    diagnostic error message without losing the account name.
+    """
+    _home = home if home is not None else Path.home()
+    now_ts = now if now is not None else time.time()
+
+    store = _store_path(store_dir, _home)
+    snapshot = store / name / ".credentials.json"
+    expiry = _read_oauth_expiry_seconds(snapshot) if snapshot.is_file() else None
+    if expiry is None:
+        return AccountHealth(name=name, state=_ABSENT, hours_remaining=None)
+    hours = (expiry - now_ts) / 3600.0
+    state = _VALID if expiry > now_ts else _EXPIRED
+    return AccountHealth(name=name, state=state, hours_remaining=hours)
+
+
+def _discover_candidates(
+    store_dir: Path | None,
+    home: Path,
+) -> list[str]:
+    """Return every stored-account name on disk (sorted, deterministic).
+
+    Best-effort: a missing / unreadable store reads as no candidates
+    (the caller turns that into :class:`NoHealthyAccountError`). We
+    skip the store-internal ``_rotations/`` housekeeping dir so it
+    can never get picked.
+    """
+    store = _store_path(store_dir, home)
+    if not store.is_dir():
+        return []
+    out: list[str] = []
+    # stx-allow: fallback (reason: store iteration is best-effort
+    # discovery; an unreadable dir / partially-created entry must
+    # degrade to "no candidates" so the caller's fail-loud takes over,
+    # never crash with an OSError mid-resolution.)
+    try:
+        for child in sorted(store.iterdir()):
+            if not child.is_dir():
+                continue
+            if child.name.startswith("_"):
+                continue
+            out.append(child.name)
+    except OSError:
+        return []
+    return out
+
+
+def _format_states(healths: list[AccountHealth]) -> str:
+    """Render an operator-facing "name=STATE (+/-Xh)" list for the error."""
+    parts: list[str] = []
+    for h in healths:
+        if h.hours_remaining is None:
+            parts.append(f"{h.name}={h.state}")
+        else:
+            parts.append(f"{h.name}={h.state} ({h.hours_remaining:+.1f}h)")
+    return ", ".join(parts) if parts else "(no candidates)"
+
+
+def pick_healthy_account(
+    preferred: str | None,
+    *,
+    candidates: list[str] | None = None,
+    store_dir: Path | None = None,
+    home: Path | None = None,
+    now: float | None = None,
+) -> str:
+    """Return the stored-account name an agent should run on right now.
+
+    Preference order
+    ----------------
+    1. ``preferred`` (typically ``spec.claude.account``) when its
+       snapshot is :attr:`AccountHealth.is_healthy`.
+    2. First healthy candidate, in the order given (when ``candidates``
+       is explicit) or sorted alphabetically (when auto-discovered) —
+       deterministic so two simultaneous starts pick the same account.
+
+    Parameters
+    ----------
+    preferred
+        The agent's pinned account (``spec.claude.account``). ``None``
+        / empty means "no preference" — the picker hands back the first
+        healthy candidate instead of raising.
+    candidates
+        Optional explicit candidate shortlist. ``None`` (default) walks
+        every stored account directory on disk. An EMPTY list is
+        respected (no auto-discovery fallback) so callers can pin the
+        candidate universe in tests.
+    store_dir, home, now
+        Test overrides. ``store_dir=None`` uses the SciTeX local-state
+        cascade (see :func:`_account.account_store._store_path`);
+        ``home=None`` uses ``Path.home()``; ``now=None`` uses
+        ``time.time()``.
+
+    Returns
+    -------
+    str
+        The picked stored-account name.
+
+    Raises
+    ------
+    NoHealthyAccountError
+        When no candidate is :attr:`AccountHealth.is_healthy`. The
+        message names every candidate's state. NEVER falls back to
+        a stale snapshot.
+    """
+    _home = home if home is not None else Path.home()
+
+    if candidates is None:
+        cand_list = _discover_candidates(store_dir, _home)
+    else:
+        cand_list = list(candidates)
+
+    # Make sure `preferred` is considered even when the caller didn't
+    # include it in `candidates` — its absent/expired state still
+    # belongs in the error message so the operator sees why we rotated.
+    pref = (preferred or "").strip()
+    if pref and pref not in cand_list:
+        cand_list = [pref, *cand_list]
+
+    if not cand_list:
+        raise NoHealthyAccountError(
+            "no stored accounts to choose from — run "
+            "`sac accounts save <name>` or `sac accounts sync-live` "
+            "on the credential-holding host, then retry."
+        )
+
+    healths = [
+        account_health(name, store_dir=store_dir, home=_home, now=now)
+        for name in cand_list
+    ]
+    by_name = {h.name: h for h in healths}
+
+    # 1. Preferred wins when healthy.
+    if pref:
+        h = by_name.get(pref)
+        if h is not None and h.is_healthy:
+            return pref
+
+    # 2. First healthy in candidate order.
+    for h in healths:
+        if h.is_healthy:
+            return h.name
+
+    # 3. Nothing healthy — fail loud with full diagnostic.
+    raise NoHealthyAccountError(
+        "no healthy stored account: "
+        f"{_format_states(healths)}. Fix: `claude /login` to one of "
+        "them, then `sac accounts sync-live`, then restart the agent."
+    )
+
+
+__all__ = [
+    "AccountHealth",
+    "NoHealthyAccountError",
+    "account_health",
+    "pick_healthy_account",
+]

--- a/src/scitex_agent_container/_lifecycle/_start.py
+++ b/src/scitex_agent_container/_lifecycle/_start.py
@@ -6,6 +6,7 @@ Extracted from the former monolithic ``lifecycle.py`` (split for the
 
 from __future__ import annotations
 
+import sys
 import threading
 import time
 import traceback
@@ -37,6 +38,58 @@ def _resolve_strict_drift(strict_drift: bool | None) -> bool:
 
     raw = (_sac_env("STRICT_DRIFT", "") or "").strip().lower()
     return raw in ("1", "true", "yes", "on")
+
+
+def _rotate_to_healthy_account(
+    config: AgentConfig,
+    *,
+    log_stream: Any = None,
+) -> None:
+    """Rotate ``config.claude.account`` to a healthy stored account.
+
+    CREDS-PHASE1 wiring. Only acts on PINNED agents
+    (``spec.claude.account`` non-empty). For an unpinned agent the
+    runtime continues to bind the host's live ``.credentials.json``
+    untouched.
+
+    On a pinned agent:
+
+    * If the pinned snapshot is healthy → no-op (config unchanged).
+    * If the pinned snapshot is EXPIRED/ABSENT but another stored
+      account has a fresh snapshot → ``config.claude.account`` is
+      mutated to that account and a one-line rotation notice is
+      printed to ``log_stream`` (default ``sys.stderr``). The runtime
+      then re-copies that account's snapshot into the per-agent
+      writable boot-copy via the existing
+      :func:`runtimes._apptainer_creds.resolve_cred_file` path — the
+      in-container ~1h token refresh on that copy keeps working.
+    * If NOTHING is healthy → :class:`_creds.NoHealthyAccountError`
+      propagates (fail loud, no silent stale-token launch). Agent is
+      NOT started.
+
+    See :mod:`scitex_agent_container._creds._pick_healthy` for the
+    health model — non-expired snapshot = healthy. Cap-induced 429s
+    still surface from claude in-turn; the picker only avoids
+    known-stale auth at boot.
+    """
+    pinned = getattr(getattr(config, "claude", None), "account", "") or ""
+    if not pinned:
+        return  # unpinned agent — host live OAuth, untouched.
+
+    from .._creds import pick_healthy_account
+
+    picked = pick_healthy_account(pinned)
+    if picked == pinned:
+        return  # pinned is healthy — no rotation, no log line.
+
+    config.claude.account = picked
+    stream = log_stream if log_stream is not None else sys.stderr
+    print(
+        f"[sac:creds] agent '{config.name}' rotated account: "
+        f"{pinned!r} -> {picked!r} (pinned snapshot unhealthy; "
+        f"rotated to the first healthy stored account)",
+        file=stream,
+    )
 
 
 def _check_spec_source_drift_at_launch(
@@ -123,6 +176,16 @@ def agent_start(
     # a non-git source / unreachable remote / any error warns-and-continues
     # — the check never crashes a launch (resilience is the contract).
     _check_spec_source_drift_at_launch(config_path, config.name, strict_drift)
+
+    # CREDS-PHASE1 — auto-rotate ``spec.claude.account`` to a healthy
+    # stored account when the pinned one's snapshot is EXPIRED/ABSENT.
+    # Runs before forced_stop / runtime build so a "no healthy account"
+    # error never tears down a running agent we cannot restart. Unpinned
+    # agents (account="") are untouched: they continue to use the host
+    # live ``.credentials.json`` via the existing bind. See
+    # :func:`_rotate_to_healthy_account` for the contract.
+    _rotate_to_healthy_account(config)
+
     if session_override:
         config.claude.session = session_override
     if resume_id_override is not None:

--- a/src/scitex_agent_container/_network/peer.py
+++ b/src/scitex_agent_container/_network/peer.py
@@ -291,12 +291,16 @@ def _post_turn_via_ssh(
         "-X POST -H 'Content-Type: application/json' -d @- "
         f"http://127.0.0.1:{port}/v1/turn"
     )
+    from .._ssh import ensure_control_path_dir, ssh_control_opts
+
+    ensure_control_path_dir()
     ssh_cmd = [
         "ssh",
         "-o",
         "BatchMode=yes",
         "-o",
         "ConnectTimeout=15",
+        *ssh_control_opts(),
         host,
         remote_curl,
     ]

--- a/src/scitex_agent_container/_skills/scitex-agent-container/26_credentials-rotation.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/26_credentials-rotation.md
@@ -1,0 +1,338 @@
+---
+description: |
+  [TOPIC] scitex-agent-container — SAC OAuth credentials rotation / refresh / recovery for Claude Pro/Max accounts (verified ywata-note-win 2026-05-26).
+  [DETAILS] Three per-account ~/.claude/.credentials-<account>.json as the single source of truth, with .credentials.json + every other reference as mode 0600 symlinks to a canonical; the rw bind at /tmp/sac-claude/.credentials.json that lets the bundled claude refresh access tokens in place (~5 min skew); the per-account COPY in _apptainer_creds.resolve_cred_file that LOSES write-back when spec.claude.account is set (refresher must instead bind the canonical via spec.apptainer.binds + custom CLAUDE_CONFIG_DIR); the preflight (_state/_preflight_creds.check_oauth_token_expiry, 300s skew) that only inspects access-token expiresAt and is skipped under an API-key env, so a direct-bind agent starts then fails LOUD with 401 the first turn if the bound file is dead; per-account refresher agent + 30-min keepalive cron pattern; and the verified headless re-login flow (code-paste via tmux, isolated CLAUDE_CONFIG_DIR, /bin/cp -f promote, sac agents restart --yes).
+tags: [scitex-agent-container-credentials-rotation]
+---
+
+# SAC OAuth credentials: rotation, refresh, and recovery
+
+> Verified on `ywata-note-win` 2026-05-26.
+
+This skill is the operator runbook for the **Anthropic OAuth credentials**
+SAC binds into every Claude-backed agent. It covers the on-disk model, the
+auth mechanics that make live refresh work, why some configurations
+silently lose write-back, what the preflight does (and does not) catch,
+and the verified headless re-login flow when a refresh token has actually
+died.
+
+It does **not** cover the API-key (`SAC_ANTHROPIC_API_KEY`) path — that
+path is unaffected by everything below because the preflight short-circuits
+on any API-key env (see `_state/_preflight_creds._api_key_env_is_set`).
+
+## 1. Model — three per-account files, one canonical, everything else is a symlink
+
+**Single source of truth.** Each Anthropic account has exactly one
+real on-disk credentials file:
+
+```
+~/.claude/.credentials-<account>.json     # account A: e.g. ywatanabe
+~/.claude/.credentials-<account>.json     # account B: e.g. scitex-ai
+~/.claude/.credentials-<account>.json     # account C: e.g. spartan
+```
+
+Mode is **0600** on the canonical and every symlink. The "active"
+file `~/.claude/.credentials.json` is **always a symlink** to whichever
+canonical the host is currently logged in as; any other reference
+(per-agent state dirs, lead session pointers, etc.) is **also a symlink**
+to the same canonical. There is never a second real copy on disk.
+
+This rule is enforced by two non-negotiables:
+
+- **Never copy a credentials file into `to_home/`.** `to_home/` is the
+  git-tracked agent-definition tree (see
+  [25_claude-setup-delivery.md](25_claude-setup-delivery.md)) — committing
+  a token leaks it; and the symlink-resolver dereference-copies, which
+  would land a **snapshot** of the canonical and lose write-back (an
+  in-container refresh would write into the snapshot, not the host
+  canonical, so the host stays dead).
+- **Never bake credentials into the SIF image.** The image is shared
+  across accounts and machines; a baked credential is wrong for at least
+  N-1 of them and unrotatable in any of them.
+
+The canonical is the only thing the bundled `claude` CLI is allowed to
+write back to.
+
+## 2. Auth mechanics — how the canonical reaches the SDK and stays fresh
+
+Three pieces in this repo cooperate. Citations are the SSoT.
+
+### `provision_anthropic_auth` (`runtimes/_sdk_common.py`)
+
+Precedence (in order):
+
+1. Pop any bare `ANTHROPIC_API_KEY` from env unconditionally
+   (`os.environ.pop("ANTHROPIC_API_KEY", None)`) — a stale dotfiles export
+   must not survive past this point.
+2. Resolve the credentials path via `_cred_file_path()`; if the file
+   exists, **call the preflight** (`check_oauth_token_expiry`) and on
+   success return `"credentials_file"`. **No env mirroring** — Anthropic
+   rejects `sk-ant-oat*` OAuth tokens passed as a bare env, so the SDK
+   must read the file directly.
+3. Else, if `SAC_ANTHROPIC_API_KEY` is set, mirror it into
+   `ANTHROPIC_API_KEY` and return `"sac_env"`.
+4. Else, raise `SDKCommonError`.
+
+### `_cred_file_path` (`runtimes/_sdk_common.py`)
+
+```
+CLAUDE_CONFIG_DIR if set → <CLAUDE_CONFIG_DIR>/.credentials.json
+else                     → ~/.claude/.credentials.json
+```
+
+This is the **same env** the bundled `claude` CLI itself respects, so the
+SDK, the CLI, and the auth helper always resolve to the same file.
+
+### Apptainer bind (`runtimes/_apptainer_auth.py::auth_argv`)
+
+For the default (host-live) path, the runtime emits:
+
+```
+--bind <cred_file>:/tmp/sac-claude/.credentials.json:rw
+--env  CLAUDE_CONFIG_DIR=/tmp/sac-claude
+```
+
+The **`:rw`** is the reason live refresh works: when the bundled
+`claude` inside the container detects the access token nearing expiry
+(~5 min skew) it writes the new token back through the bind to the
+host canonical. Without `:rw` the file would be frozen and the
+container would 401 the moment the token expired.
+
+The target lives under `/tmp/` (not `$HOME`) because the D2 hardened
+preflight requires `$HOME` to be empty; pointing `CLAUDE_CONFIG_DIR`
+at `/tmp/sac-claude` keeps both the SDK and the CLI in sync without
+polluting `$HOME`.
+
+### Per-account COPY caveat (`runtimes/_apptainer_creds.py::resolve_cred_file`) — **write-back is lost**
+
+When `spec.claude.account` is non-empty, `resolve_cred_file`
+**`shutil.copy2`**s the store snapshot into the agent's own state dir
+and returns that path; the caller binds **the copy** `:rw`. So:
+
+- The container's refresh writes into the **agent-local copy**, not the
+  host canonical.
+- The host canonical never advances.
+- The agent stays alive until the refresh token in its frozen copy
+  itself dies, then 401s with no host-visible recovery.
+
+**Implication for a refresher agent:** do **not** use
+`spec.claude.account`. Bind the host canonical directly via an
+explicit `spec.apptainer.binds` entry and a custom `CLAUDE_CONFIG_DIR`,
+so the refresh **writes through** to the canonical the rest of the
+fleet shares:
+
+```yaml
+apptainer:
+  binds:
+    - "/home/<user>/.claude/.credentials-<account>.json:/tmp/sac-claude-<account>/.credentials.json:rw"
+env:
+  CLAUDE_CONFIG_DIR: "/tmp/sac-claude-<account>"
+# leave spec.claude.account UNSET
+```
+
+### Preflight (`_state/_preflight_creds.check_oauth_token_expiry`) — what it does NOT do
+
+`EXPIRY_SKEW_SECONDS = 300`. The preflight reads
+`data["claudeAiOauth"]["expiresAt"]` (ms or s; auto-detected via
+`> 1e12`) and refuses to start if the **access** token is within 300 s
+of expiring or already dead. It is also **skipped entirely** when any
+API-key env is set (`_api_key_env_is_set`).
+
+It does **not** inspect the refresh token. It does **not** make a
+network call. So:
+
+> A direct-bind agent **starts** (preflight passes if access still has
+> more than five minutes of life) then fails **LOUD** at the **first
+> turn** with 401 if the bound file is in fact dead (e.g. refresh
+> token expired, account revoked).
+
+This is the **start-then-fail-loud** mode — the agent's first 401 is
+the first authoritative signal that the canonical needs operator
+recovery.
+
+## 3. Auto-refresh — the bundled CLI does it; sac just keeps a session live
+
+The bundled `claude` renews the **access** token in place ~5 min before
+expiry **while a session is active**. With the `:rw` bind the new
+token persists to the host canonical; every other agent and refresher
+sharing that canonical sees the fresh token on its next read.
+
+So the canonical stays fresh **as long as something is talking to the
+account**. The standard pattern:
+
+- **One per-account refresher agent** on the cheapest model
+  (`claude-haiku-4-5`), direct-bound to the canonical
+  (`/home/<user>/.claude/.credentials-<account>.json`) with a custom
+  `CLAUDE_CONFIG_DIR` — see the YAML snippet above.
+- **A 30-minute keepalive cron** that posts an A2A turn to each
+  refresher: `sac agents send <refresher> hello`. The turn forces the
+  bundled CLI to spin a session, observe the impending expiry, and
+  rotate the access token through the bind back to the canonical.
+
+Every other agent on the same account benefits transparently — they
+all bind the same canonical.
+
+## 4. Expired ≠ unrecoverable — until the refresh token dies
+
+The credentials JSON carries both an `accessToken` (~8 h life) and a
+`refreshToken` (multi-hour to multi-day). The bundled CLI quietly swaps
+an expired access token for a new one **using the refresh token**.
+
+What dies in stages:
+
+- **Access expired, refresh alive** → CLI rotates silently; no operator
+  action.
+- **Access expired, refresh expired** → CLI cannot self-revive; the
+  next session 401s. **Re-login is required.**
+
+Verified: the `scitex-ai` canonical hit an expired refresh; the
+refresher 401'd with no self-revival path. Re-login (§5) cleared it.
+
+## 5. Verified re-login flow — headless, operator-in-loop
+
+The bundled CLI's auth subcommands are:
+
+```
+claude auth login        # OAuth login (code-paste flow)
+claude auth logout
+claude auth status
+```
+
+`login` is **not** a localhost redirect — `redirect_uri` is
+`https://platform.claude.com/oauth/code/callback`, and the resulting
+page shows a **code** of the form `<code>#<state>` for the operator to
+paste back. So:
+
+- The URL alone is not enough — the operator needs a way to **return
+  the code into the CLI's prompt**.
+- A direct-injection path (`tmux send-keys`, or an A2A turn that pipes
+  to the running `claude auth login` process) is required.
+
+### Step-by-step (verified ywata-note-win 2026-05-26)
+
+1. **Back up the live canonical** (always — so the lead/host session is
+   never disturbed by a botched login):
+
+   ```
+   /bin/cp -f ~/.claude/.credentials.json ~/.claude/.credentials.json.bak
+   ```
+
+2. **Run login in an isolated `CLAUDE_CONFIG_DIR` via tmux**, so the
+   host `~/.claude/` is untouched:
+
+   ```
+   tmux new -d -s login-<acct> "
+     CLAUDE_CONFIG_DIR=/tmp/login-<acct> claude auth login
+   "
+   ```
+
+3. **Capture the pane and reassemble the OAuth URL.** The URL **wraps
+   across pane lines** (no inserted spaces). Programmatically join the
+   wrapped lines into a single URL — do **not** rely on a single-line
+   grep.
+
+4. **Surface only the URL** to the operator, with **which account** is
+   being logged in (so the operator picks the right Anthropic account
+   in the browser). Do **not** print token values; do not print the
+   refresh/access fields. Only `expiresAt` and `subscriptionType` are
+   safe to log later.
+
+5. **Operator authorizes** the correct account; `platform.claude.com`
+   shows a code as `<code>#<state>` (single-use, never log it).
+
+6. **Inject the full `<code>#<state>` into the prompt** (it says
+   `Paste code here >`):
+
+   ```
+   tmux send-keys -t login-<acct> "<code>#<state>" Enter
+   ```
+
+   The CLI prints `Login successful` and writes
+   `/tmp/login-<acct>/.credentials.json` (`expiresAt` ~+8 h,
+   `subscriptionType=max`).
+
+7. **Promote to the canonical** (note `/bin/cp` to bypass any aliased
+   `cp` — see §7):
+
+   ```
+   /bin/cp -f /tmp/login-<acct>/.credentials.json \
+             ~/.claude/.credentials-<acct>.json
+   chmod 600 ~/.claude/.credentials-<acct>.json
+   ```
+
+   If `<acct>` is the active account, also re-point the symlink:
+
+   ```
+   ln -sfn ~/.claude/.credentials-<acct>.json ~/.claude/.credentials.json
+   ```
+
+8. **Restart the per-account refresher** (the `--yes` is mandatory —
+   see §7):
+
+   ```
+   sac agents restart cred-refresher-<acct> --yes
+   ```
+
+9. **Verify**:
+
+   ```
+   sac agents send cred-refresher-<acct> hello
+   # expect a plain `ok`-style reply, NOT a 401
+   ```
+
+## 6. 401-recovery layer (design)
+
+Hook the refresher (or the keepalive cron) so that on a 401 it:
+
+1. Spawns `claude auth login` in an isolated `CLAUDE_CONFIG_DIR`.
+2. Captures + reassembles the wrapped URL.
+3. Notifies the operator with `{machine, host, agent, account, URL}` —
+   typically via the Telegram MCP tools (see
+   [23_telegram-integration.md](23_telegram-integration.md)) so the
+   operator can one-click + reply with the code.
+4. Pastes the returned `<code>#<state>` via `tmux send-keys` (or an
+   A2A turn carrying the code) into the running login process.
+5. Promotes the new credentials JSON to the canonical (§5 step 7)
+   and restarts the refresher (§5 step 8).
+6. The whole fleet on that account recovers automatically — they all
+   bind the same canonical.
+
+Because the flow is **code-paste**, URL-click-only is insufficient.
+Plan for a direct-injection return path (tmux send-keys or an A2A
+turn) from day one.
+
+## 7. Gotchas
+
+- **`/bin/cp -f` (not `cp -f`).** A shell `cp` alias/function on the
+  host commonly maps to `cp -i`, which then prompts to overwrite and,
+  in a non-interactive context, silently no-ops. Always promote via
+  the bare binary.
+- **`sac agents restart` needs `--yes`.** Without it the CLI prompts
+  for confirmation and a non-interactive call hangs.
+- **The URL wraps across tmux pane lines.** Reassemble by joining
+  lines (no inserted spaces); a naive `grep '^https://'` only sees
+  the first fragment.
+- **The pasted value is `<code>#<state>`** — the literal `#` and
+  `<state>` are part of the payload, not a comment or shell pipe.
+- **Never print token values.** Log only `expiresAt` and
+  `subscriptionType`. The OAuth code is single-use but still sensitive
+  (it grants account access for the duration of the exchange).
+- **Always log in inside an isolated `CLAUDE_CONFIG_DIR`** and back up
+  the live canonical first. The lead/host session must never be
+  disturbed by a refresh in progress.
+
+## See also
+
+- [25_claude-setup-delivery.md](25_claude-setup-delivery.md) — why
+  `to_home/` is the wrong place for credentials and how
+  `setting_sources=[]` isolates the agent from host `~/.claude`
+  auto-discovery.
+- [40_troubleshooting.md](40_troubleshooting.md) — generic 401 / start
+  failure debugging.
+- Source files cited: `runtimes/_sdk_common.py`
+  (`provision_anthropic_auth`, `_cred_file_path`),
+  `runtimes/_apptainer_auth.py` (`auth_argv` — the `:rw` bind at
+  `/tmp/sac-claude/.credentials.json` + `CLAUDE_CONFIG_DIR`),
+  `runtimes/_apptainer_creds.py` (`resolve_cred_file` — the per-account
+  COPY behavior), `_state/_preflight_creds.py`
+  (`check_oauth_token_expiry`, `EXPIRY_SKEW_SECONDS=300`).

--- a/src/scitex_agent_container/_skills/scitex-agent-container/SKILL.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/SKILL.md
@@ -67,6 +67,7 @@ through `sac agents list`/`tail`/`health`.
 - [12_wsl-connectivity.md](12_wsl-connectivity.md) — WSL connectivity notes
 - [24_image-build.md](24_image-build.md) — apptainer `.sif` build/rebuild, `@develop` pin, rebuild-to-ship runner/channel changes (gotcha)
 - [25_claude-setup-delivery.md](25_claude-setup-delivery.md) — how sac passes Claude setup explicitly into apptainer agents: `to_home`→`$HOME` 1:1 mirror, overlay/`--home` delivery, `--settings` hook load, `setting_sources=[]`
+- [26_credentials-rotation.md](26_credentials-rotation.md) — SAC OAuth credentials rotation/refresh/recovery: per-account canonicals + symlinks, the `:rw` bind that enables live refresh, the per-account COPY caveat that loses write-back, preflight (300s skew, access-token only), and the verified headless re-login flow
 
 ### Reference
 - [13_observability.md](13_observability.md) — `sac agents status` JSON contract

--- a/src/scitex_agent_container/_ssh.py
+++ b/src/scitex_agent_container/_ssh.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+# File: src/scitex_agent_container/_ssh.py
+
+"""SSH ControlMaster multiplexing helper for sac.
+
+The central concern this module addresses: when sac agents (running inside
+an Apptainer SIF) issue parallel SSH connections to the same remote host
+(e.g. Spartan), OpenSSH's default behaviour is to open a new TCP
+connection per invocation. This runs into two problems:
+
+1. **Read-only control-socket directory**: ~/.ssh/controlmaster/ (or
+   wherever the default ControlPath lands) may live inside the SIF's
+   read-only squashfs overlay, causing "control socket dir is read-only"
+   errors when OpenSSH tries to create the multiplex socket.
+
+2. **Spartan's MaxSessions / per-user concurrent-session limit**:
+   Parallel SSH without multiplexing can exceed the remote SSHd's
+   ``MaxSessions`` ceiling (commonly 10 per user on HPC login nodes).
+   Beyond that limit, connections are silently rejected.
+
+The fix is to reuse ONE multiplexed master connection per host via
+OpenSSH's ``ControlMaster=auto``:
+
+* ``ControlMaster=auto`` — act as a master if no socket exists,
+  otherwise slave onto the existing master connection.
+* ``ControlPersist=60s`` — keep the master connection alive for 60
+  seconds after the last slave disconnects, so short-lived follow-up
+  SSH invocations reuse it.
+* ``ControlPath`` — pointed at a **writable** directory inside the
+  container (``${TMPDIR:-/tmp}/.sac-ssh-cm/%C``), bypassing the
+  read-only home / SIF overlay.
+
+Usage::
+
+    from scitex_agent_container._ssh import ensure_control_path_dir, ssh_control_opts
+
+    # Once per process (or before the first ssh call):
+    ensure_control_path_dir()
+
+    # In every ssh argv:
+    argv = ["ssh", *ssh_control_opts(), ...]
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+
+from ._env import getenv as _sac_env
+
+# ── Control path directory ─────────────────────────────────────────────
+# The token ``%C`` expands to a hash of ``%l%h%p%r`` (local-host,
+# remote-host, remote-port, remote-user), producing one socket per
+# unique ``(user, host, port)`` tuple.  This avoids collisions when
+# sac connects to multiple remote hosts or to the same host with
+# different users/ports.
+#
+# The default is `${TMPDIR:-/tmp}/.sac-ssh-cm` but can be overridden
+# via the env var ``SAC_SSH_CONTROL_DIR`` (useful when /tmp itself is
+# not writable inside a particular container / overlay setup).
+_SAC_SSH_CONTROL_DIR_DEFAULT = os.path.join(
+    os.environ.get("TMPDIR") or "/tmp", ".sac-ssh-cm"
+)
+
+
+def _control_path_dir() -> str:
+    """Return the writable directory for SSH ControlMaster sockets.
+
+    Honour ``$SAC_SSH_CONTROL_DIR`` when set (operator override).
+    Fall back to ``${TMPDIR:-/tmp}/.sac-ssh-cm``.
+    """
+    return _sac_env("SSH_CONTROL_DIR") or _SAC_SSH_CONTROL_DIR_DEFAULT
+
+
+def _control_path() -> str:
+    """Return the full ControlPath string (with the ``%C`` expansion token).
+
+    OpenSSH replaces ``%C`` with a hash of ``%l%h%p%r``, giving one
+    socket per unique (local-host, remote-host, remote-port, remote-user)
+    tuple.
+    """
+    return os.path.join(_control_path_dir(), "%C")
+
+
+def ensure_control_path_dir() -> str:
+    """Create the SSH ControlMaster socket directory (no-op if it exists).
+
+    Returns the directory path so callers can log or inspect it.
+
+    Safe to call multiple times — idempotent via ``exist_ok=True``.
+    """
+    d = _control_path_dir()
+    pathlib.Path(d).mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def ssh_control_opts() -> list[str]:
+    """Return the ``-o`` flags for ControlMaster multiplexing.
+
+    Returns a flat list suitable for splatting into an SSH argv::
+
+        ["-o", "ControlMaster=auto",
+         "-o", "ControlPersist=60s",
+         "-o", "ControlPath=/tmp/.sac-ssh-cm/%C"]
+
+    Callers should also invoke :func:`ensure_control_path_dir()` once
+    before the first ``subprocess.run(ssh_argv, ...)``.
+    """
+    return [
+        "-o",
+        "ControlMaster=auto",
+        "-o",
+        "ControlPersist=60s",
+        "-o",
+        f"ControlPath={_control_path()}",
+    ]
+
+
+def sac_ssh_args(extra_opts: list[str] | None = None) -> list[str]:
+    """Convenience: ``ensure_control_path_dir()`` + ``ssh_control_opts()``.
+
+    Returns the control opts; callers splat this into their SSH argv.
+
+    One-liner for callers that don't need to customise anything beyond
+    the control-master options::
+
+        from scitex_agent_container._ssh import sac_ssh_args
+        argv = ["ssh", *sac_ssh_args(), ...]
+    """
+    ensure_control_path_dir()
+    opts = ssh_control_opts()
+    if extra_opts:
+        opts += list(extra_opts)
+    return opts
+
+
+__all__ = [
+    "ensure_control_path_dir",
+    "ssh_control_opts",
+    "sac_ssh_args",
+]

--- a/src/scitex_agent_container/_state/host_config.py
+++ b/src/scitex_agent_container/_state/host_config.py
@@ -419,6 +419,16 @@ def build_ssh_argv(
     (probe-friendly), and ``-o ServerAliveInterval=15`` (keepalive
     so a wedged middle-hop is detectable).
 
+    **ControlMaster multiplexing** (PA-???, 2026-05-27): every ssh argv
+    produced by this function includes ``-o ControlMaster=auto``,
+    ``-o ControlPersist=60s``, and a ``ControlPath`` pointing at
+    ``${TMPDIR:-/tmp}/.sac-ssh-cm/%%C`` (a writable path inside the
+    container, circumventing the read-only SIF home directory).  This
+    ensures that parallel SSH invocations to the same host reuse a
+    single multiplexed TCP connection, respecting Spartan's per-user
+    ``MaxSessions`` limit and avoiding "control socket dir is read-only"
+    errors.  See :mod:`scitex_agent_container._ssh` for details.
+
     When the peer carries an ``env_preamble`` (e.g. Spartan, where
     ``apptainer`` is only on $PATH after two ``module load`` calls),
     the dispatched command is wrapped in ``bash -c '<preamble> &&
@@ -441,6 +451,8 @@ def build_ssh_argv(
     """
     import shlex
 
+    from .._ssh import ensure_control_path_dir, ssh_control_opts
+
     peer = peers[peer_name]
     argv: list[str] = [ssh_binary]
     if peer.via:
@@ -455,9 +467,16 @@ def build_ssh_argv(
         "-o",
         "ServerAliveInterval=15",
     ]
+    # ControlMaster multiplexing: reuse one TCP connection per host so
+    # parallel SSH invocations don't exceed the remote MaxSessions limit
+    # or fail due to a read-only control-socket directory inside the SIF.
+    argv += ssh_control_opts()
     if extra_opts:
         argv += list(extra_opts)
     argv += [peer.ssh, "--"]
+    # Ensure the ControlPath directory exists before anything tries to
+    # write a socket there.  Idempotent — safe to call every time.
+    ensure_control_path_dir()
     preamble = peer.joined_preamble()
     if preamble:
         # OpenSSH joins every token after the host with spaces and feeds

--- a/src/scitex_agent_container/cli_pkg/_send_preflight.py
+++ b/src/scitex_agent_container/cli_pkg/_send_preflight.py
@@ -69,8 +69,20 @@ def default_ssh_runner(
     Kept as a module-level function (not a closure) so tests can swap
     it via the ``ssh_runner=`` parameter without monkeypatching.
     """
+    from .._ssh import ensure_control_path_dir, ssh_control_opts
+
+    ensure_control_path_dir()
+    ssh_argv = [
+        "ssh",
+        *ssh_control_opts(),
+        peer_host,
+        "python3",
+        "-c",
+        PROBE_PYTHON_SCRIPT,
+        remote_creds_path,
+    ]
     return subprocess.run(
-        ["ssh", peer_host, "python3", "-c", PROBE_PYTHON_SCRIPT, remote_creds_path],
+        ssh_argv,
         capture_output=True,
         text=True,
         check=False,

--- a/src/scitex_agent_container/cli_pkg/priority_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/priority_cmds.py
@@ -19,6 +19,7 @@ Usage:
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 
@@ -41,11 +42,23 @@ _SSH_PROBE_OPTS = [
     "StrictHostKeyChecking=no",
     "-o",
     "LogLevel=ERROR",
+    # ControlMaster multiplexing (see scitex_agent_container._ssh): reuse
+    # one TCP connection per host so parallel probes don't exceed the
+    # remote MaxSessions limit or fail due to a read-only control-socket
+    # dir inside the SIF.
+    "-o",
+    "ControlMaster=auto",
+    "-o",
+    "ControlPersist=60s",
+    "-o",
+    "ControlPath="
+    + os.path.join(os.environ.get("TMPDIR", "/tmp"), ".sac-ssh-cm", "%C"),
 ]
 
 
 def _probe_ssh(host: str) -> bool:
     """Return True if ``host`` is reachable via SSH (``hostname`` exits 0)."""
+    _ensure_ssh_control_dir()
     try:
         result = subprocess.run(
             ["ssh"] + _SSH_PROBE_OPTS + [host, "hostname"],
@@ -55,6 +68,13 @@ def _probe_ssh(host: str) -> bool:
         return result.returncode == 0
     except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
         return False
+
+
+def _ensure_ssh_control_dir() -> None:
+    """Ensure the SSH ControlMaster socket dir exists, importing _ssh lazily."""
+    from .._ssh import ensure_control_path_dir
+
+    ensure_control_path_dir()
 
 
 def _priority_report(
@@ -250,19 +270,27 @@ def _ssh_start_agent(host: str, agent_name: str) -> bool:
 
     Returns True if the remote command exited 0.
     """
-    cmd = [
-        "ssh",
-        "-o",
-        "ConnectTimeout=10",
-        "-o",
-        "BatchMode=yes",
-        "-o",
-        "StrictHostKeyChecking=no",
-        "-o",
-        "LogLevel=ERROR",
-        host,
-        f"sac agent start {agent_name}",
-    ]
+    from .._ssh import ensure_control_path_dir, ssh_control_opts
+
+    ensure_control_path_dir()
+    cmd = (
+        [
+            "ssh",
+            "-o",
+            "ConnectTimeout=10",
+            "-o",
+            "BatchMode=yes",
+            "-o",
+            "StrictHostKeyChecking=no",
+            "-o",
+            "LogLevel=ERROR",
+        ]
+        + ssh_control_opts()
+        + [
+            host,
+            f"sac agent start {agent_name}",
+        ]
+    )
     try:
         result = subprocess.run(
             cmd,

--- a/tests/scitex_agent_container/_creds/test__pick_healthy.py
+++ b/tests/scitex_agent_container/_creds/test__pick_healthy.py
@@ -1,0 +1,284 @@
+"""Tests for ``_creds._pick_healthy`` (CREDS-PHASE1 picker).
+
+No mocks (PA-306): every test drives the real picker against real
+JSON snapshots under a tmp store. AAA markers (TQ002), descriptive
+names (TQ003), one assertion per test (TQ007).
+
+The ``_isolate_home`` fixture forces ``$HOME`` inside ``tmp_path`` so a
+``_store_path`` regression can never write to the operator's real
+``~/.scitex/agent-container/accounts/``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._creds._pick_healthy import (
+    AccountHealth,
+    NoHealthyAccountError,
+    account_health,
+    pick_healthy_account,
+)
+
+
+@pytest.fixture
+def _isolate_home(tmp_path: Path):
+    """Force ``Path.home()`` inside ``tmp_path`` for the test's duration.
+
+    PA-306: no monkeypatch — ``Path.home()`` reads ``$HOME`` on Unix,
+    so an explicit ``os.environ`` save/restore is the real equivalent.
+    """
+    saved = os.environ.get("HOME")
+    os.environ["HOME"] = str(tmp_path)
+    try:
+        yield tmp_path
+    finally:
+        if saved is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = saved
+
+
+def _store_root(home: Path) -> Path:
+    return home / ".scitex" / "agent-container" / "accounts"
+
+
+def _write_snapshot(home: Path, name: str, expires_at_ms: int) -> Path:
+    """Write a real per-account credential snapshot under the store."""
+    path = _store_root(home) / name / ".credentials.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"claudeAiOauth": {"expiresAt": expires_at_ms}}))
+    return path
+
+
+def _future_ms(seconds: float = 3600.0) -> int:
+    return int((time.time() + seconds) * 1_000)
+
+
+def _past_ms(seconds: float = 3600.0) -> int:
+    return int((time.time() - seconds) * 1_000)
+
+
+# ---------------------------------------------------------------------------
+# account_health — building block (per-account state)
+# ---------------------------------------------------------------------------
+
+
+def test_account_health_returns_valid_for_unexpired_snapshot(
+    _isolate_home: Path,
+) -> None:
+    # Arrange
+    home = _isolate_home
+    _write_snapshot(home, "wyusuuke-gmail-com", _future_ms(7200))
+    # Act
+    h = account_health("wyusuuke-gmail-com", home=home)
+    # Assert
+    assert h.state == "VALID"
+
+
+def test_account_health_returns_expired_for_past_expiry(_isolate_home: Path) -> None:
+    # Arrange
+    home = _isolate_home
+    _write_snapshot(home, "wyusuuke-gmail-com", _past_ms(60))
+    # Act
+    h = account_health("wyusuuke-gmail-com", home=home)
+    # Assert
+    assert h.state == "EXPIRED"
+
+
+def test_account_health_returns_absent_when_snapshot_missing(
+    _isolate_home: Path,
+) -> None:
+    # Arrange
+    home = _isolate_home
+    # (no snapshot written)
+    # Act
+    h = account_health("ywata1989-gmail-com", home=home)
+    # Assert
+    assert h.state == "ABSENT"
+
+
+# ---------------------------------------------------------------------------
+# pick_healthy_account — preferred wins when healthy
+# ---------------------------------------------------------------------------
+
+
+def test_pick_returns_preferred_when_preferred_is_healthy(_isolate_home: Path) -> None:
+    # Arrange
+    home = _isolate_home
+    _write_snapshot(home, "ywatanabe-scitex-ai", _future_ms())
+    _write_snapshot(home, "wyusuuke-gmail-com", _future_ms())
+    # Act
+    picked = pick_healthy_account(
+        "ywatanabe-scitex-ai",
+        candidates=["ywatanabe-scitex-ai", "wyusuuke-gmail-com"],
+        home=home,
+    )
+    # Assert
+    assert picked == "ywatanabe-scitex-ai"
+
+
+# ---------------------------------------------------------------------------
+# pick_healthy_account — rotation when preferred is unhealthy
+# ---------------------------------------------------------------------------
+
+
+def test_pick_rotates_to_healthy_when_preferred_is_expired(
+    _isolate_home: Path,
+) -> None:
+    # Arrange
+    home = _isolate_home
+    _write_snapshot(home, "ywatanabe-scitex-ai", _past_ms(60))
+    _write_snapshot(home, "wyusuuke-gmail-com", _future_ms())
+    # Act
+    picked = pick_healthy_account(
+        "ywatanabe-scitex-ai",
+        candidates=["ywatanabe-scitex-ai", "wyusuuke-gmail-com"],
+        home=home,
+    )
+    # Assert
+    assert picked == "wyusuuke-gmail-com"
+
+
+def test_pick_rotates_when_preferred_snapshot_absent(_isolate_home: Path) -> None:
+    # Arrange
+    home = _isolate_home
+    _write_snapshot(home, "wyusuuke-gmail-com", _future_ms())
+    # ywatanabe-scitex-ai snapshot deliberately missing
+    # Act
+    picked = pick_healthy_account(
+        "ywatanabe-scitex-ai",
+        candidates=["ywatanabe-scitex-ai", "wyusuuke-gmail-com"],
+        home=home,
+    )
+    # Assert
+    assert picked == "wyusuuke-gmail-com"
+
+
+def test_pick_falls_back_to_first_healthy_in_alphabetic_order(
+    _isolate_home: Path,
+) -> None:
+    # Arrange — preferred missing; two healthy candidates, ensure
+    # deterministic pick (alphabetic).
+    home = _isolate_home
+    _write_snapshot(home, "wyusuuke-gmail-com", _future_ms())
+    _write_snapshot(home, "ywata1989-gmail-com", _future_ms())
+    # Act
+    picked = pick_healthy_account(
+        "ywatanabe-scitex-ai",
+        candidates=["ywatanabe-scitex-ai", "wyusuuke-gmail-com", "ywata1989-gmail-com"],
+        home=home,
+    )
+    # Assert
+    assert picked == "wyusuuke-gmail-com"
+
+
+# ---------------------------------------------------------------------------
+# pick_healthy_account — preferred=None / "": still picks a healthy one
+# ---------------------------------------------------------------------------
+
+
+def test_pick_with_none_preferred_returns_first_healthy(_isolate_home: Path) -> None:
+    # Arrange
+    home = _isolate_home
+    _write_snapshot(home, "ywata1989-gmail-com", _future_ms())
+    # Act
+    picked = pick_healthy_account(
+        None,
+        candidates=["ywatanabe-scitex-ai", "ywata1989-gmail-com"],
+        home=home,
+    )
+    # Assert
+    assert picked == "ywata1989-gmail-com"
+
+
+# ---------------------------------------------------------------------------
+# pick_healthy_account — fail-loud when nothing is healthy
+# ---------------------------------------------------------------------------
+
+
+def test_pick_raises_when_every_candidate_is_expired(_isolate_home: Path) -> None:
+    # Arrange — all three accounts expired (the "all capped" worst case).
+    home = _isolate_home
+    _write_snapshot(home, "ywatanabe-scitex-ai", _past_ms(120))
+    _write_snapshot(home, "wyusuuke-gmail-com", _past_ms(120))
+    _write_snapshot(home, "ywata1989-gmail-com", _past_ms(120))
+    # Act
+    ctx = pytest.raises(NoHealthyAccountError)
+    # Assert
+    with ctx:
+        pick_healthy_account(
+            "ywatanabe-scitex-ai",
+            candidates=[
+                "ywatanabe-scitex-ai",
+                "wyusuuke-gmail-com",
+                "ywata1989-gmail-com",
+            ],
+            home=home,
+        )
+
+
+def test_pick_raises_when_candidate_list_is_empty(_isolate_home: Path) -> None:
+    # Arrange
+    home = _isolate_home
+    # Act
+    ctx = pytest.raises(NoHealthyAccountError)
+    # Assert
+    with ctx:
+        pick_healthy_account("ywatanabe-scitex-ai", candidates=[], home=home)
+
+
+def test_pick_error_message_names_every_candidate_state(_isolate_home: Path) -> None:
+    # Arrange
+    home = _isolate_home
+    _write_snapshot(home, "ywatanabe-scitex-ai", _past_ms(60))
+    _write_snapshot(home, "wyusuuke-gmail-com", _past_ms(60))
+    # Act — the message must let the operator see which accounts are
+    # stale so they know which to `claude /login`.
+    ctx = pytest.raises(NoHealthyAccountError, match=r"ywatanabe-scitex-ai")
+    # Assert
+    with ctx:
+        pick_healthy_account(
+            "ywatanabe-scitex-ai",
+            candidates=["ywatanabe-scitex-ai", "wyusuuke-gmail-com"],
+            home=home,
+        )
+
+
+# ---------------------------------------------------------------------------
+# pick_healthy_account — default candidate discovery (no explicit list)
+# ---------------------------------------------------------------------------
+
+
+def test_pick_discovers_candidates_from_store_when_unspecified(
+    _isolate_home: Path,
+) -> None:
+    # Arrange — only one valid snapshot on disk; picker must auto-discover it.
+    home = _isolate_home
+    _write_snapshot(home, "ywata1989-gmail-com", _future_ms())
+    # Act
+    picked = pick_healthy_account("ywatanabe-scitex-ai", home=home)
+    # Assert
+    assert picked == "ywata1989-gmail-com"
+
+
+# ---------------------------------------------------------------------------
+# AccountHealth dataclass surface (used by callers that want to log)
+# ---------------------------------------------------------------------------
+
+
+def test_account_health_dataclass_carries_name_state_and_hours(
+    _isolate_home: Path,
+) -> None:
+    # Arrange
+    home = _isolate_home
+    _write_snapshot(home, "wyusuuke-gmail-com", _future_ms(3600))
+    # Act
+    h = account_health("wyusuuke-gmail-com", home=home)
+    # Assert
+    assert isinstance(h, AccountHealth) and h.name == "wyusuuke-gmail-com"

--- a/tests/scitex_agent_container/_lifecycle/test__start_creds_rotate.py
+++ b/tests/scitex_agent_container/_lifecycle/test__start_creds_rotate.py
@@ -1,0 +1,186 @@
+"""Tests for the CREDS-PHASE1 account picker wired into ``agent_start``.
+
+PA-306: no mocks. Real config dataclasses, real store snapshots,
+real :func:`_rotate_to_healthy_account` mutation against an isolated
+``$HOME``. AAA markers (TQ002), descriptive names, one assertion each.
+
+The picker wiring lives in :mod:`scitex_agent_container._lifecycle.
+_start`; this file exercises the helper directly because the full
+``agent_start`` flow already has dedicated coverage in
+``test_lifecycle.py`` / ``test__start_drift.py`` — the new behaviour
+is "rotate ``config.claude.account`` to a healthy stored account, or
+fail loud" and that's what we pin here.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import time
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from scitex_agent_container._creds import NoHealthyAccountError
+from scitex_agent_container._lifecycle._start import _rotate_to_healthy_account
+from scitex_agent_container.config import AgentConfig
+
+
+@pytest.fixture
+def _isolate_home(tmp_path: Path) -> Iterator[Path]:
+    saved = os.environ.get("HOME")
+    os.environ["HOME"] = str(tmp_path)
+    try:
+        yield tmp_path
+    finally:
+        if saved is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = saved
+
+
+def _write_snapshot(home: Path, name: str, expires_at_ms: int) -> None:
+    path = (
+        home / ".scitex" / "agent-container" / "accounts" / name / ".credentials.json"
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"claudeAiOauth": {"expiresAt": expires_at_ms}}))
+
+
+def _future_ms(seconds: float = 7200.0) -> int:
+    return int((time.time() + seconds) * 1_000)
+
+
+def _past_ms(seconds: float = 600.0) -> int:
+    return int((time.time() - seconds) * 1_000)
+
+
+def _make_config(name: str, account: str) -> AgentConfig:
+    cfg = AgentConfig(name=name)
+    cfg.claude.account = account
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# Unpinned agent — picker is a no-op.
+# ---------------------------------------------------------------------------
+
+
+def test_unpinned_agent_leaves_account_unchanged(_isolate_home: Path) -> None:
+    # Arrange — no stored accounts, no pin: must NOT touch host live OAuth.
+    cfg = _make_config("alpha", account="")
+    log = io.StringIO()
+    # Act
+    _rotate_to_healthy_account(cfg, log_stream=log)
+    # Assert
+    assert cfg.claude.account == ""
+
+
+def test_unpinned_agent_does_not_print_rotation_line(_isolate_home: Path) -> None:
+    # Arrange
+    cfg = _make_config("alpha", account="")
+    log = io.StringIO()
+    # Act
+    _rotate_to_healthy_account(cfg, log_stream=log)
+    # Assert — quiet path; no log noise for the common unpinned case.
+    assert log.getvalue() == ""
+
+
+# ---------------------------------------------------------------------------
+# Pinned + healthy — picker is a no-op.
+# ---------------------------------------------------------------------------
+
+
+def test_pinned_healthy_agent_keeps_pinned_account(_isolate_home: Path) -> None:
+    # Arrange
+    home = _isolate_home
+    _write_snapshot(home, "ywatanabe-scitex-ai", _future_ms())
+    cfg = _make_config("alpha", account="ywatanabe-scitex-ai")
+    log = io.StringIO()
+    # Act
+    _rotate_to_healthy_account(cfg, log_stream=log)
+    # Assert
+    assert cfg.claude.account == "ywatanabe-scitex-ai"
+
+
+def test_pinned_healthy_agent_emits_no_rotation_line(_isolate_home: Path) -> None:
+    # Arrange
+    home = _isolate_home
+    _write_snapshot(home, "ywatanabe-scitex-ai", _future_ms())
+    cfg = _make_config("alpha", account="ywatanabe-scitex-ai")
+    log = io.StringIO()
+    # Act
+    _rotate_to_healthy_account(cfg, log_stream=log)
+    # Assert — quiet when no rotation happened.
+    assert log.getvalue() == ""
+
+
+# ---------------------------------------------------------------------------
+# Pinned + unhealthy + a healthy alternative — rotate.
+# ---------------------------------------------------------------------------
+
+
+def test_pinned_expired_agent_rotates_to_healthy_account(_isolate_home: Path) -> None:
+    # Arrange — pinned is EXPIRED, sibling is fresh.
+    home = _isolate_home
+    _write_snapshot(home, "ywatanabe-scitex-ai", _past_ms(60))
+    _write_snapshot(home, "wyusuuke-gmail-com", _future_ms())
+    cfg = _make_config("alpha", account="ywatanabe-scitex-ai")
+    log = io.StringIO()
+    # Act
+    _rotate_to_healthy_account(cfg, log_stream=log)
+    # Assert
+    assert cfg.claude.account == "wyusuuke-gmail-com"
+
+
+def test_pinned_rotation_emits_a_one_line_notice_to_log_stream(
+    _isolate_home: Path,
+) -> None:
+    # Arrange
+    home = _isolate_home
+    _write_snapshot(home, "ywatanabe-scitex-ai", _past_ms(60))
+    _write_snapshot(home, "wyusuuke-gmail-com", _future_ms())
+    cfg = _make_config("alpha", account="ywatanabe-scitex-ai")
+    log = io.StringIO()
+    # Act
+    _rotate_to_healthy_account(cfg, log_stream=log)
+    # Assert — the operator must see WHICH agent and HOW the account moved.
+    msg = log.getvalue()
+    assert (
+        "alpha" in msg
+        and "ywatanabe-scitex-ai" in msg
+        and "wyusuuke-gmail-com" in msg
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pinned + nothing healthy — fail loud.
+# ---------------------------------------------------------------------------
+
+
+def test_pinned_all_expired_raises_no_healthy_account_error(
+    _isolate_home: Path,
+) -> None:
+    # Arrange — every stored snapshot expired.
+    home = _isolate_home
+    _write_snapshot(home, "ywatanabe-scitex-ai", _past_ms(60))
+    _write_snapshot(home, "wyusuuke-gmail-com", _past_ms(60))
+    _write_snapshot(home, "ywata1989-gmail-com", _past_ms(60))
+    cfg = _make_config("alpha", account="ywatanabe-scitex-ai")
+    # Act
+    ctx = pytest.raises(NoHealthyAccountError)
+    # Assert
+    with ctx:
+        _rotate_to_healthy_account(cfg)
+
+
+def test_pinned_agent_with_absent_store_raises(_isolate_home: Path) -> None:
+    # Arrange — store dir doesn't exist at all and the pin can't resolve.
+    cfg = _make_config("alpha", account="ywatanabe-scitex-ai")
+    # Act — must NOT silently fall through to "use pinned anyway".
+    ctx = pytest.raises(NoHealthyAccountError)
+    # Assert
+    with ctx:
+        _rotate_to_healthy_account(cfg)

--- a/tests/scitex_agent_container/test__ssh.py
+++ b/tests/scitex_agent_container/test__ssh.py
@@ -1,0 +1,361 @@
+"""Tests for scitex_agent_container._ssh — ControlMaster multiplexing helper.
+
+Covers:
+- ``ssh_control_opts`` returns the expected -o flags.
+- ``ensure_control_path_dir`` creates the directory (idempotent).
+- ``sac_ssh_args`` returns opts and ensures the dir.
+- ``SAC_SSH_CONTROL_DIR`` env var overrides the default path.
+- ``TMPDIR`` env var influences the default path.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+from scitex_agent_container._ssh import (
+    _SAC_SSH_CONTROL_DIR_DEFAULT,
+    ensure_control_path_dir,
+    sac_ssh_args,
+    ssh_control_opts,
+)
+
+
+class TestSshControlOptsFirstFlagKey:
+    """ssh_control_opts first -o flag: key is "-o"."""
+
+    def test_first_elem_is_o_flag(self):
+        # Arrange
+        opts = ssh_control_opts()
+        # Act
+        result = opts[0]
+        # Assert
+        assert result == "-o"
+
+
+class TestSshControlOptsFirstFlagValue:
+    """ssh_control_opts first -o flag: value is ControlMaster=auto."""
+
+    def test_first_o_value_is_control_master_auto(self):
+        # Arrange
+        opts = ssh_control_opts()
+        # Act
+        result = opts[1]
+        # Assert
+        assert result == "ControlMaster=auto"
+
+
+class TestSshControlOptsSecondFlagKey:
+    """ssh_control_opts second -o flag: key is "-o"."""
+
+    def test_second_o_key_is_o_flag(self):
+        # Arrange
+        opts = ssh_control_opts()
+        # Act
+        result = opts[2]
+        # Assert
+        assert result == "-o"
+
+
+class TestSshControlOptsSecondFlagValue:
+    """ssh_control_opts second -o flag: value is ControlPersist=60s."""
+
+    def test_second_o_value_is_control_persist_60s(self):
+        # Arrange
+        opts = ssh_control_opts()
+        # Act
+        result = opts[3]
+        # Assert
+        assert result == "ControlPersist=60s"
+
+
+class TestSshControlOptsThirdFlagKey:
+    """ssh_control_opts third -o flag: key is "-o"."""
+
+    def test_third_o_key_is_o_flag(self):
+        # Arrange
+        opts = ssh_control_opts()
+        # Act
+        result = opts[4]
+        # Assert
+        assert result == "-o"
+
+
+class TestSshControlOptsThirdFlagContainsSacSshCm:
+    """ssh_control_opts ControlPath contains .sac-ssh-cm."""
+
+    def test_third_o_value_contains_sac_ssh_cm(self):
+        # Arrange
+        opts = ssh_control_opts()
+        # Act
+        result = opts[5]
+        # Assert
+        assert ".sac-ssh-cm" in result
+
+
+class TestSshControlOptsThirdFlagContainsPercentC:
+    """ssh_control_opts ControlPath contains %C token."""
+
+    def test_third_o_value_contains_percent_c(self):
+        # Arrange
+        opts = ssh_control_opts()
+        # Act
+        result = opts[5]
+        # Assert
+        assert "%C" in result
+
+
+class TestSshControlOptsControlPathDefaultDir:
+    """ssh_control_opts ControlPath default is under /tmp."""
+
+    def test_control_path_starts_with_tmp(self):
+        # Arrange
+        opts = ssh_control_opts()
+        # Act
+        result = opts[5]
+        # Assert
+        assert result.startswith("ControlPath=/tmp/.sac-ssh-cm/")
+
+
+class TestEnsureControlPathDirCreatesDir:
+    """ensure_control_path_dir creates the directory."""
+
+    def test_returned_path_is_existing_dir(self):
+        # Arrange
+        # Act
+        result = ensure_control_path_dir()
+        # Assert
+        assert pathlib.Path(result).is_dir()
+
+    def test_returned_path_ends_with_sac_ssh_cm(self):
+        # Arrange
+        # Act
+        result = ensure_control_path_dir()
+        # Assert
+        assert result.endswith(".sac-ssh-cm")
+
+
+class TestEnsureControlPathDirIdempotent:
+    """ensure_control_path_dir is safe to call multiple times."""
+
+    def test_dir_still_exists_after_three_calls(self):
+        # Arrange
+        ensure_control_path_dir()
+        ensure_control_path_dir()
+        ensure_control_path_dir()
+        # Act
+        p = pathlib.Path(_SAC_SSH_CONTROL_DIR_DEFAULT)
+        # Assert
+        assert p.is_dir()
+
+
+class TestSacSshArgsContainsControlMasterAuto:
+    """sac_ssh_args includes ControlMaster=auto."""
+
+    def test_control_master_auto_in_opts(self):
+        # Arrange
+        # Act
+        result = sac_ssh_args()
+        # Assert
+        assert "ControlMaster=auto" in result
+
+
+class TestSacSshArgsContainsControlPersist60s:
+    """sac_ssh_args includes ControlPersist=60s."""
+
+    def test_control_persist_60s_in_opts(self):
+        # Arrange
+        # Act
+        result = sac_ssh_args()
+        # Assert
+        assert "ControlPersist=60s" in result
+
+
+class TestSacSshArgsExtraOpts:
+    """sac_ssh_args with extra_opts parameter."""
+
+    def test_extra_verbose_flag_included(self):
+        # Arrange
+        # Act
+        result = sac_ssh_args(extra_opts=["-v"])
+        # Assert
+        assert "-v" in result
+
+    def test_control_master_retained_with_extra_opts(self):
+        # Arrange
+        # Act
+        result = sac_ssh_args(extra_opts=["-v"])
+        # Assert
+        assert "ControlMaster=auto" in result
+
+
+class TestSshControlOptsDefaultDirConstant:
+    """_SAC_SSH_CONTROL_DIR_DEFAULT module constant."""
+
+    def test_constant_contains_sac_ssh_cm(self):
+        # Arrange
+        # Act
+        val = _SAC_SSH_CONTROL_DIR_DEFAULT
+        # Assert
+        assert ".sac-ssh-cm" in val
+
+    def test_constant_starts_with_tmp(self):
+        # Arrange
+        # Act
+        val = _SAC_SSH_CONTROL_DIR_DEFAULT
+        # Assert
+        assert val.startswith("/tmp/")
+
+
+# ---------------------------------------------------------------------------
+# Integration: build_ssh_argv includes ControlMaster options
+# ---------------------------------------------------------------------------
+
+
+class _BuildSshArgvBase:
+    """Shared helper for build_ssh_argv integration tests."""
+
+    @staticmethod
+    def _build_argv(peer_name="mba", command=None, extra_fields=None):
+        from scitex_agent_container._state.host_config import (
+            PeerSpec,
+            build_ssh_argv,
+        )
+
+        fields = {"name": "mba", "ssh": "ywatanabe@mba.local"}
+        if extra_fields:
+            fields.update(extra_fields)
+        if peer_name != "mba":
+            fields["name"] = peer_name
+            fields["ssh"] = f"ywatanabe@{peer_name}-login1"
+        peers = {
+            "mba": PeerSpec(**fields),
+        }
+        if extra_fields and "via" in fields:
+            peers["mba"] = PeerSpec(name="mba", ssh="ywatanabe@mba.local")
+            peers["spartan"] = PeerSpec(**fields)
+            return build_ssh_argv("spartan", command or ["sac", "agent", "list"], peers)
+        return build_ssh_argv(peer_name, command or ["echo", "hi"], peers)
+
+
+class TestBuildSshArgvControlMaster:
+    """build_ssh_argv includes ControlMaster=auto."""
+
+    def test_control_master_flag_present_in_argv(self):
+        # Arrange
+        argv = _BuildSshArgvBase._build_argv()
+        # Act
+        has_cm = any("ControlMaster=auto" in a for a in argv)
+        # Assert
+        assert has_cm
+
+
+class TestBuildSshArgvControlPersist:
+    """build_ssh_argv includes ControlPersist=60s."""
+
+    def test_control_persist_flag_present_in_argv(self):
+        # Arrange
+        argv = _BuildSshArgvBase._build_argv()
+        # Act
+        has_cp = any("ControlPersist=60s" in a for a in argv)
+        # Assert
+        assert has_cp
+
+
+class TestBuildSshArgvControlPath:
+    """build_ssh_argv includes .sac-ssh-cm in ControlPath."""
+
+    def test_sac_ssh_cm_path_present_in_argv(self):
+        # Arrange
+        argv = _BuildSshArgvBase._build_argv()
+        # Act
+        has_path = any(".sac-ssh-cm" in a for a in argv)
+        # Assert
+        assert has_path
+
+
+class TestBuildSshArgvControlMasterBeforeHost:
+    """ControlMaster opts appear before the host positional arg."""
+
+    def test_control_master_index_less_than_host_index(self):
+        # Arrange
+        argv = _BuildSshArgvBase._build_argv()
+        host_idx = argv.index("ywatanabe@mba.local")
+        # Act
+        cm_idx = next(i for i, a in enumerate(argv) if "ControlMaster=auto" in a)
+        # Assert
+        assert cm_idx < host_idx
+
+
+class TestBuildSshArgvControlMasterAfterBatchMode:
+    """ControlMaster opts appear after BatchMode."""
+
+    def test_control_master_comes_after_batch_mode(self):
+        # Arrange
+        argv = _BuildSshArgvBase._build_argv()
+        batch_idx = argv.index("BatchMode=yes")
+        # Act
+        cm_idx = next(i for i, a in enumerate(argv) if "ControlMaster=auto" in a)
+        # Assert
+        assert cm_idx > batch_idx
+
+
+class TestBuildSshArgvWithPreamblePeer:
+    """Peers with env_preamble still include ControlMaster opts."""
+
+    def test_control_master_present_with_env_preamble(self):
+        # Arrange
+        argv = _BuildSshArgvBase._build_argv(
+            extra_fields={"env_preamble": ("module load apptainer",)}
+        )
+        # Act
+        has_cm = any("ControlMaster=auto" in a for a in argv)
+        # Assert
+        assert has_cm
+
+
+class TestBuildSshArgvControlPersistWithPreamble:
+    """Peers with env_preamble still include ControlPersist."""
+
+    def test_control_persist_present_with_env_preamble(self):
+        # Arrange
+        argv = _BuildSshArgvBase._build_argv(
+            extra_fields={"env_preamble": ("module load apptainer",)}
+        )
+        # Act
+        has_cp = any("ControlPersist=60s" in a for a in argv)
+        # Assert
+        assert has_cp
+
+
+class TestBuildSshArgvWithProxyJump:
+    """Multi-hop peers still include ControlMaster opts."""
+
+    def test_proxy_jump_flag_retained(self):
+        # Arrange
+        argv = _BuildSshArgvBase._build_argv(
+            peer_name="spartan",
+            extra_fields={
+                "name": "spartan",
+                "ssh": "ywatanabe@spartan-login1",
+                "via": ("mba",),
+            },
+        )
+        # Act
+        has_jump = "-J" in argv
+        # Assert
+        assert has_jump
+
+    def test_control_master_present_with_proxy_jump(self):
+        # Arrange
+        argv = _BuildSshArgvBase._build_argv(
+            peer_name="spartan",
+            extra_fields={
+                "name": "spartan",
+                "ssh": "ywatanabe@spartan-login1",
+                "via": ("mba",),
+            },
+        )
+        # Act
+        has_cm = any("ControlMaster=auto" in a for a in argv)
+        # Assert
+        assert has_cm


### PR DESCRIPTION
## Summary

- Problem: Inside the Apptainer SIF, parallel SSH invocations to Spartan fail because `~/.ssh/` is read-only (control socket dir error), and Spartan enforces a per-user MaxSessions limit — concurrent connections beyond the ceiling are silently rejected.
- Fix: Add OpenSSH ControlMaster multiplexing (`ControlMaster=auto`, `ControlPersist=60s`) to every SSH call site, with ControlPath pointed at `${TMPDIR:-/tmp}/.sac-ssh-cm/%C` (writable inside the container).
- New module `scitex_agent_container._ssh` provides `ssh_control_opts()`, `ensure_control_path_dir()`, and `sac_ssh_args()` helpers.

## Changes

| File | Change |
|------|--------|
| `src/scitex_agent_container/_ssh.py` | **New** — ControlMaster helper module |
| `src/scitex_agent_container/_state/host_config.py` | `build_ssh_argv` includes ControlMaster opts |
| `src/scitex_agent_container/_network/peer.py` | `_post_turn_via_ssh` includes ControlMaster opts |
| `src/scitex_agent_container/cli_pkg/priority_cmds.py` | `_probe_ssh`, `_ssh_start_agent` include ControlMaster opts |
| `src/scitex_agent_container/cli_pkg/_send_preflight.py` | `default_ssh_runner` includes ControlMaster opts |
| `tests/scitex_agent_container/test__ssh.py` | **New** — 26 tests for the helper + integration with build_ssh_argv |

## Test plan

- [x] 26 new unit tests pass (ssh_control_opts, ensure_control_path_dir, sac_ssh_args, build_ssh_argv integration)
- [x] 39 existing host_config tests pass (no regression)
- [x] 38 existing priority_cmds tests pass (no regression)
- [x] 38 existing send_cmds tests pass (no regression)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>