### PR TITLE
feat(ssh): multiplex sac→peer ssh via ControlMaster (fix Spartan parallel-ssh failure)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- **feat(ssh): connection multiplexing across all sac→peer ssh calls**
+  — every sac call that shells out to ssh now prepends
+  `-o ControlMaster=auto -o ControlPersist=60s -o ControlPath=<dir>/%C`
+  so concurrent calls against the same peer share one TCP+SSH master.
+  Fixes (a) "control socket dir is read-only" inside apptainer SIFs
+  where the default `~/.ssh/sockets` ControlPath lands on the overlay,
+  and (b) silent drops when fanning out across hosts that cap
+  per-user concurrent sessions (Spartan `MaxSessions`,
+  sshd `MaxStartups`). The ControlPath dir defaults to
+  `${TMPDIR:-/tmp}/.sac-ssh-cm` (writable inside apptainer); override
+  with `$SAC_SSH_CONTROL_DIR`; opt out entirely with
+  `SAC_SSH_CONTROL_MASTER=0`. New helpers
+  `scitex_agent_container._state.host_config.ssh_control_options()`
+  and `ssh_control_options_str()`, applied centrally in `build_ssh_argv`
+  and at three direct-ssh call sites (`_network.peer._post_turn_via_ssh`,
+  `cli_pkg.priority_cmds._ssh_start_agent`,
+  `cli_pkg._send_preflight.default_ssh_runner`). New CLI
+  `sac host ssh-opts` prints the flags shell-quoted for use in agent
+  prompts as `ssh $(sac host ssh-opts) host cmd`. See
+  `_skills/scitex-agent-container/11_remote-deploy.md` §
+  "SSH connection multiplexing". Failure mode is fall-through: if the
+  control dir can't be created (read-only mount, ENOSPC) the helper
+  returns `[]` and ssh argv stays byte-identical to pre-patch.
+
 ## [0.21.0] — 2026-05-25
 
 ### Added

--- a/src/scitex_agent_container/_network/peer.py
+++ b/src/scitex_agent_container/_network/peer.py
@@ -291,12 +291,19 @@ def _post_turn_via_ssh(
         "-X POST -H 'Content-Type: application/json' -d @- "
         f"http://127.0.0.1:{port}/v1/turn"
     )
+    # Connection multiplexing — concurrent v1/turn deliveries to the
+    # same peer share one ssh master, avoiding sshd MaxSessions caps and
+    # the per-call TCP handshake. See
+    # :func:`scitex_agent_container._state.host_config.ssh_control_options`.
+    from .._state.host_config import ssh_control_options
+
     ssh_cmd = [
         "ssh",
         "-o",
         "BatchMode=yes",
         "-o",
         "ConnectTimeout=15",
+        *ssh_control_options(),
         host,
         remote_curl,
     ]

--- a/src/scitex_agent_container/_skills/scitex-agent-container/11_remote-deploy.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/11_remote-deploy.md
@@ -42,3 +42,49 @@ scitex-agent-container start --no-preflight ...      # Skip SSH checks
 - `tmux` (or `screen`) installed
 - `claude` CLI installed
 - SSH key-based auth configured
+
+## SSH connection multiplexing (ControlMaster)
+
+Every sac call that shells out to ssh — `sac host exec`, `sac host probe`,
+dispatch fan-out, drift probes, OAuth send-preflight, ssh+curl turn
+delivery — automatically prepends `-o ControlMaster=auto -o
+ControlPersist=60s -o ControlPath=<dir>/%C`. Concurrent calls against the
+same peer share one TCP+SSH master, which:
+
+- respects per-user `MaxSessions` caps on HPC heads (Spartan: typically
+  10) and `sshd_config` `MaxStartups`,
+- avoids the per-call TCP/cipher handshake when sac fans out across
+  several hosts in parallel, and
+- sidesteps the apptainer `control socket dir is read-only` failure
+  caused by the default `~/.ssh/sockets` ControlPath landing on the SIF
+  overlay.
+
+ControlPath resolution order: explicit caller arg → `$SAC_SSH_CONTROL_DIR`
+env → `${TMPDIR:-/tmp}/.sac-ssh-cm`. The dir is `mkdir -p`'d on first
+use; if the parent is read-only the function falls through to `[]` and
+sac's argv is byte-identical to the pre-patch shape (degrade, don't
+crash).
+
+### Opt out
+
+```
+export SAC_SSH_CONTROL_MASTER=0   # or 'no' / 'false' / 'off'
+```
+
+Useful when ssh is itself proxied through a wrapper that breaks
+ControlPath (rare).
+
+### Helper for agent prompts
+
+Agent prompts that shell out to ssh themselves shouldn't re-derive the
+flags. Use:
+
+```
+ssh   $(sac host ssh-opts) myhost cmd
+rsync -e "ssh $(sac host ssh-opts)" src/ myhost:dst/
+```
+
+`sac host ssh-opts` prints the flags shell-quoted; empty when the opt-out
+env is set so the splat is a no-op either way. The Python helper is
+`scitex_agent_container._state.host_config.ssh_control_options()` for
+in-process callers.

--- a/src/scitex_agent_container/_state/host_config.py
+++ b/src/scitex_agent_container/_state/host_config.py
@@ -400,6 +400,103 @@ def _parse_env_preamble(name: str, raw) -> tuple[str, ...]:
     )
 
 
+def ssh_control_options(*, control_dir: str | os.PathLike | None = None) -> list[str]:
+    """Return ssh ControlMaster options for connection multiplexing.
+
+    Without multiplexing, every concurrent sac invocation (parallel
+    ``sac host exec`` calls, dispatch fan-out, drift probes, OAuth
+    preflight, ssh+curl turn delivery) opens its own TCP/SSH session.
+    On hosts that cap concurrent sessions per user (Spartan's
+    ``MaxSessions``, sshd ``MaxStartups``) the surplus connections are
+    dropped and the calling agent sees empty stdout / sporadic failures.
+    Inside an apptainer SIF the default OpenSSH ``ControlPath``
+    (``~/.ssh/sockets``) also lives on a read-only overlay, surfacing as
+    ``control socket dir is read-only`` and silently disabling
+    multiplexing even when the user has it configured in
+    ``~/.ssh/config``.
+
+    Strategy:
+
+      * ``ControlMaster=auto`` — first ssh becomes master; siblings reuse.
+      * ``ControlPersist=60s`` — master lingers 60s after the last client
+        exits so a sub-second burst of sac calls shares one TCP handshake.
+      * ``ControlPath=<dir>/%C`` — ``%C`` is the SHA256 hash of
+        ``(user,host,port)``; collision-free across targets and short
+        enough to stay inside the Unix-domain-socket 108-byte name limit
+        even when ``<dir>`` is long.
+
+    The control_dir is created on call (``mkdir -p`` semantics).
+    Resolution order:
+
+      1. ``control_dir`` argument — explicit pin (tests, callers that
+         already have a writable scratch dir).
+      2. ``$SAC_SSH_CONTROL_DIR`` env override.
+      3. ``${TMPDIR:-/tmp}/.sac-ssh-cm`` via :func:`tempfile.gettempdir`
+         (writable inside apptainer SIFs by default).
+
+    Set ``SAC_SSH_CONTROL_MASTER=0`` (or ``no``/``false``/``off``) to opt
+    out entirely; the function returns ``[]`` so each sac-emitted ssh
+    argv falls back to one-connection-per-invocation. Useful when ssh
+    is itself proxied through a wrapper that breaks ``ControlPath``
+    (rare, but the escape hatch is required).
+
+    Failure mode is fall-through: if the control_dir cannot be created
+    (read-only mount, ENOSPC) the function returns ``[]`` rather than
+    raising. The next sac ssh invocation just omits the ``-o`` flags
+    and behaves exactly like pre-patch. This is intentional — connection
+    multiplexing is an optimization; making it required would break
+    callers that already work on hosts where the optimization can't
+    apply.
+    """
+    opt_out = (os.environ.get("SAC_SSH_CONTROL_MASTER", "") or "").strip().lower()
+    if opt_out in ("0", "no", "false", "off"):
+        return []
+    if control_dir is None:
+        env_dir = os.environ.get("SAC_SSH_CONTROL_DIR")
+        if env_dir:
+            control_dir = env_dir
+        else:
+            # Lazy import — keeps `sac --help` startup cost off
+            # `host_config` import (see _skills/.../21_cli-startup-budget.md).
+            import tempfile
+
+            control_dir = os.path.join(tempfile.gettempdir(), ".sac-ssh-cm")
+    try:
+        Path(control_dir).mkdir(parents=True, exist_ok=True)
+    except OSError:
+        # Read-only mount or ENOSPC — degrade to one-conn-per-call. The
+        # caller's ssh argv ends up byte-identical to pre-patch.
+        return []
+    # %C => hashed (user,host,port); keeps the socket name short and
+    # collision-free across simultaneously-active peers.
+    path = os.path.join(str(control_dir), "%C")
+    return [
+        "-o",
+        "ControlMaster=auto",
+        "-o",
+        "ControlPersist=60s",
+        "-o",
+        f"ControlPath={path}",
+    ]
+
+
+def ssh_control_options_str(*, control_dir: str | os.PathLike | None = None) -> str:
+    """Return :func:`ssh_control_options` flags as a shell-quoted string.
+
+    Convenience for agent prompts and shell wrappers that want to splat
+    the options into a literal ``ssh`` command::
+
+        ssh $(sac host ssh-opts) myhost cmd
+
+    Returns the empty string when multiplexing is opted out so the splat
+    has no effect.
+    """
+    import shlex
+
+    opts = ssh_control_options(control_dir=control_dir)
+    return " ".join(shlex.quote(o) for o in opts)
+
+
 def build_ssh_argv(
     peer_name: str,
     command: list[str],
@@ -455,6 +552,10 @@ def build_ssh_argv(
         "-o",
         "ServerAliveInterval=15",
     ]
+    # Connection multiplexing — must come before extra_opts so caller
+    # overrides win. See :func:`ssh_control_options` for the rationale
+    # (Spartan MaxSessions cap + apptainer overlay ControlPath issue).
+    argv += ssh_control_options()
     if extra_opts:
         argv += list(extra_opts)
     argv += [peer.ssh, "--"]

--- a/src/scitex_agent_container/cli_pkg/_send_preflight.py
+++ b/src/scitex_agent_container/cli_pkg/_send_preflight.py
@@ -68,9 +68,24 @@ def default_ssh_runner(
 
     Kept as a module-level function (not a closure) so tests can swap
     it via the ``ssh_runner=`` parameter without monkeypatching.
+
+    The probe shares the package-wide ssh ControlMaster pool (see
+    :func:`scitex_agent_container._state.host_config.ssh_control_options`)
+    so a `sac send` storm against the same peer doesn't pay N TCP
+    handshakes nor blow through Spartan's MaxSessions cap.
     """
+    from .._state.host_config import ssh_control_options
+
     return subprocess.run(
-        ["ssh", peer_host, "python3", "-c", PROBE_PYTHON_SCRIPT, remote_creds_path],
+        [
+            "ssh",
+            *ssh_control_options(),
+            peer_host,
+            "python3",
+            "-c",
+            PROBE_PYTHON_SCRIPT,
+            remote_creds_path,
+        ],
         capture_output=True,
         text=True,
         check=False,

--- a/src/scitex_agent_container/cli_pkg/host_group.py
+++ b/src/scitex_agent_container/cli_pkg/host_group.py
@@ -21,6 +21,7 @@ from .._state.host_config import (
     build_ssh_argv,
     host_interfaces,
     load,
+    ssh_control_options_str,
 )
 from ._helpers import _json_flag, console
 
@@ -336,6 +337,27 @@ def host_probe(ctx: click.Context, peer: str, timeout: int, as_json: bool) -> No
             console.print(f"[dim]{proc.stderr.strip()[:200]}[/dim]")
     if not reachable:
         raise SystemExit(1)
+
+
+@host_group.command("ssh-opts")
+def host_ssh_opts() -> None:
+    """Print sac's ssh ControlMaster options as a shell-quoted string.
+
+    Splat this into an ad-hoc ssh / scp / rsync command so multi-host
+    automation reuses sac's existing multiplexed master per peer
+    instead of opening a fresh connection per call. The output is
+    shell-safe — just pass it through ``$(...)``::
+
+        ssh $(sac host ssh-opts) myhost cmd
+        rsync -e "ssh $(sac host ssh-opts)" src/ myhost:dst/
+        parallel ssh $(sac host ssh-opts) myhost ::: cmd1 cmd2 cmd3
+
+    Prints an empty line when multiplexing is opted out
+    (``SAC_SSH_CONTROL_MASTER=0``) so the splat is a no-op. The
+    underlying flags are documented under
+    :func:`scitex_agent_container._state.host_config.ssh_control_options`.
+    """
+    click.echo(ssh_control_options_str())
 
 
 # WSL → fleet-hub layered probe (folded from ``sac network probe``).

--- a/src/scitex_agent_container/cli_pkg/priority_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/priority_cmds.py
@@ -250,6 +250,10 @@ def _ssh_start_agent(host: str, agent_name: str) -> bool:
 
     Returns True if the remote command exited 0.
     """
+    # Singleton-reconcile fans out across many hosts in parallel; share
+    # one ssh master per peer so MaxSessions / MaxStartups stay happy.
+    from .._state.host_config import ssh_control_options
+
     cmd = [
         "ssh",
         "-o",
@@ -260,6 +264,7 @@ def _ssh_start_agent(host: str, agent_name: str) -> bool:
         "StrictHostKeyChecking=no",
         "-o",
         "LogLevel=ERROR",
+        *ssh_control_options(),
         host,
         f"sac agent start {agent_name}",
     ]

--- a/tests/scitex_agent_container/_state/test_ssh_control_options.py
+++ b/tests/scitex_agent_container/_state/test_ssh_control_options.py
@@ -1,0 +1,423 @@
+"""Tests for :mod:`scitex_agent_container._state.host_config` ssh ControlMaster wiring.
+
+Real-function tests — no mocks. The helper is a pure-Python wrapper around
+``os.environ`` + ``Path.mkdir``; we exercise it against a fresh ``tmp_path``
+and assert on argv shape, env-var honouring, opt-out semantics, and the
+fall-through-on-EROFS guarantee.
+
+Coverage:
+
+* :func:`ssh_control_options` — default control_dir, explicit dir arg,
+  ``$SAC_SSH_CONTROL_DIR`` env override, ``SAC_SSH_CONTROL_MASTER=0``
+  opt-out, fall-through to ``[]`` on read-only mount.
+* :func:`ssh_control_options_str` — shell-quoted shape; empty when opted out.
+* :func:`build_ssh_argv` — the master options appear in the rendered argv
+  between the existing ``-o BatchMode/...`` block and any caller
+  ``extra_opts`` so caller overrides still win.
+* Direct-ssh sites — sentinel-driven checks that the inline argvs in
+  ``_network.peer`` / ``cli_pkg.priority_cmds`` / ``cli_pkg._send_preflight``
+  prepend the control-options block.
+* CLI — ``sac host ssh-opts`` round-trip.
+"""
+
+from __future__ import annotations
+
+import os
+import shlex
+import stat
+import sys
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+
+# ---------------------------------------------------------------------------
+# ssh_control_options — pure function
+# ---------------------------------------------------------------------------
+
+
+def test_ssh_control_options_default_shape_has_three_opt_pairs(tmp_path, monkeypatch):
+    # Arrange — pin control_dir away from $TMPDIR so the test is hermetic.
+    monkeypatch.delenv("SAC_SSH_CONTROL_MASTER", raising=False)
+    monkeypatch.delenv("SAC_SSH_CONTROL_DIR", raising=False)
+    from scitex_agent_container._state.host_config import ssh_control_options
+
+    # Act
+    opts = ssh_control_options(control_dir=tmp_path / "cm")
+
+    # Assert — exactly three -o pairs, in the documented order.
+    assert opts[0::2] == ["-o", "-o", "-o"]
+    assert opts[1] == "ControlMaster=auto"
+    assert opts[3] == "ControlPersist=60s"
+    assert opts[5].startswith("ControlPath=")
+
+
+def test_ssh_control_options_creates_control_dir_on_call(tmp_path, monkeypatch):
+    # Arrange
+    monkeypatch.delenv("SAC_SSH_CONTROL_MASTER", raising=False)
+    monkeypatch.delenv("SAC_SSH_CONTROL_DIR", raising=False)
+    target = tmp_path / "freshly-created-cm-dir"
+    assert not target.exists()
+    from scitex_agent_container._state.host_config import ssh_control_options
+
+    # Act
+    opts = ssh_control_options(control_dir=target)
+
+    # Assert — dir was created, ControlPath points inside it via %C.
+    assert target.is_dir()
+    control_path = next(o for o in opts if o.startswith("ControlPath="))
+    assert control_path == f"ControlPath={target}/%C"
+
+
+def test_ssh_control_options_honours_explicit_env_var(tmp_path, monkeypatch):
+    # Arrange — env override beats the $TMPDIR default.
+    override = tmp_path / "env-override-cm"
+    monkeypatch.delenv("SAC_SSH_CONTROL_MASTER", raising=False)
+    monkeypatch.setenv("SAC_SSH_CONTROL_DIR", str(override))
+    from scitex_agent_container._state.host_config import ssh_control_options
+
+    # Act
+    opts = ssh_control_options()
+
+    # Assert
+    assert override.is_dir()
+    assert f"ControlPath={override}/%C" in opts
+
+
+def test_ssh_control_options_explicit_arg_beats_env_var(tmp_path, monkeypatch):
+    # Arrange — function arg should win over env.
+    monkeypatch.delenv("SAC_SSH_CONTROL_MASTER", raising=False)
+    env_dir = tmp_path / "env"
+    arg_dir = tmp_path / "arg"
+    monkeypatch.setenv("SAC_SSH_CONTROL_DIR", str(env_dir))
+    from scitex_agent_container._state.host_config import ssh_control_options
+
+    # Act
+    opts = ssh_control_options(control_dir=arg_dir)
+
+    # Assert — arg dir is materialized; env dir is not.
+    assert arg_dir.is_dir()
+    assert not env_dir.exists()
+    assert any(o == f"ControlPath={arg_dir}/%C" for o in opts)
+
+
+@pytest.mark.parametrize("opt_out_value", ["0", "no", "false", "off", "NO", "FALSE"])
+def test_ssh_control_options_opt_out_returns_empty(tmp_path, monkeypatch, opt_out_value):
+    # Arrange
+    monkeypatch.setenv("SAC_SSH_CONTROL_MASTER", opt_out_value)
+    monkeypatch.delenv("SAC_SSH_CONTROL_DIR", raising=False)
+    from scitex_agent_container._state.host_config import ssh_control_options
+
+    # Act
+    opts = ssh_control_options(control_dir=tmp_path / "cm-should-not-be-used")
+
+    # Assert — empty list; control_dir argument NOT created (no side effect).
+    assert opts == []
+    assert not (tmp_path / "cm-should-not-be-used").exists()
+
+
+def test_ssh_control_options_falls_through_when_control_dir_unwritable(
+    tmp_path, monkeypatch
+):
+    # Arrange — make the parent read-only so mkdir(parents=True) fails.
+    readonly_parent = tmp_path / "ro-parent"
+    readonly_parent.mkdir()
+    readonly_parent.chmod(stat.S_IRUSR | stat.S_IXUSR)  # 0o500 — no write.
+    try:
+        target = readonly_parent / "cm"
+        monkeypatch.delenv("SAC_SSH_CONTROL_MASTER", raising=False)
+        monkeypatch.delenv("SAC_SSH_CONTROL_DIR", raising=False)
+        from scitex_agent_container._state.host_config import ssh_control_options
+
+        # Act
+        opts = ssh_control_options(control_dir=target)
+
+        # Assert — fall-through: empty list, NO exception. ssh argv ends up
+        # byte-identical to the pre-patch shape.
+        assert opts == []
+        assert not target.exists()
+    finally:
+        # Restore for cleanup.
+        readonly_parent.chmod(stat.S_IRWXU)
+
+
+def test_ssh_control_options_default_dir_lives_under_tempdir(monkeypatch):
+    # Arrange — clear overrides; let the function pick its default.
+    monkeypatch.delenv("SAC_SSH_CONTROL_MASTER", raising=False)
+    monkeypatch.delenv("SAC_SSH_CONTROL_DIR", raising=False)
+    import tempfile
+
+    from scitex_agent_container._state.host_config import ssh_control_options
+
+    # Act
+    opts = ssh_control_options()
+
+    # Assert
+    control_path = next(o for o in opts if o.startswith("ControlPath="))
+    path = control_path.split("=", 1)[1]
+    # The default lives under $TMPDIR (gettempdir) — exact match validates
+    # we honour TMPDIR like apptainer expects.
+    assert path.startswith(tempfile.gettempdir())
+    assert path.endswith("/.sac-ssh-cm/%C")
+
+
+# ---------------------------------------------------------------------------
+# ssh_control_options_str — shell-quoted convenience
+# ---------------------------------------------------------------------------
+
+
+def test_ssh_control_options_str_is_shell_quoted_and_round_trips(
+    tmp_path, monkeypatch
+):
+    # Arrange
+    monkeypatch.delenv("SAC_SSH_CONTROL_MASTER", raising=False)
+    monkeypatch.delenv("SAC_SSH_CONTROL_DIR", raising=False)
+    from scitex_agent_container._state.host_config import (
+        ssh_control_options,
+        ssh_control_options_str,
+    )
+
+    # Act
+    s = ssh_control_options_str(control_dir=tmp_path / "cm")
+    expected = ssh_control_options(control_dir=tmp_path / "cm")
+
+    # Assert — shlex.split of the string returns the exact opts list.
+    assert shlex.split(s) == expected
+
+
+def test_ssh_control_options_str_empty_when_opted_out(monkeypatch):
+    # Arrange
+    monkeypatch.setenv("SAC_SSH_CONTROL_MASTER", "0")
+    from scitex_agent_container._state.host_config import ssh_control_options_str
+
+    # Act
+    s = ssh_control_options_str()
+
+    # Assert — empty string so `ssh $(sac host ssh-opts) host cmd` is safe.
+    assert s == ""
+
+
+# ---------------------------------------------------------------------------
+# build_ssh_argv — the wired call site
+# ---------------------------------------------------------------------------
+
+
+def test_build_ssh_argv_emits_control_master_flags_by_default(tmp_path, monkeypatch):
+    # Arrange
+    monkeypatch.setenv("SAC_SSH_CONTROL_DIR", str(tmp_path / "cm"))
+    monkeypatch.delenv("SAC_SSH_CONTROL_MASTER", raising=False)
+    from scitex_agent_container._state.host_config import PeerSpec, build_ssh_argv
+
+    peers = {"mba": PeerSpec(name="mba", ssh="ywatanabe@mba.local")}
+
+    # Act
+    argv = build_ssh_argv("mba", ["echo", "hi"], peers)
+
+    # Assert — the three options appear, AFTER the existing -o block and
+    # BEFORE the host arg so caller `extra_opts` precedence still works.
+    assert "ControlMaster=auto" in argv
+    assert "ControlPersist=60s" in argv
+    cp = next(a for a in argv if a.startswith("ControlPath="))
+    assert cp.endswith("/%C")
+
+
+def test_build_ssh_argv_opted_out_matches_pre_patch_shape(monkeypatch):
+    # Arrange — opt out; the rendered argv should be free of any
+    # Control* option. This guarantees the escape hatch keeps existing
+    # ssh-config-based multiplexing setups working as-is.
+    monkeypatch.setenv("SAC_SSH_CONTROL_MASTER", "0")
+    from scitex_agent_container._state.host_config import PeerSpec, build_ssh_argv
+
+    peers = {"mba": PeerSpec(name="mba", ssh="ywatanabe@mba.local")}
+
+    # Act
+    argv = build_ssh_argv("mba", ["echo", "hi"], peers)
+
+    # Assert
+    assert not any("Control" in a for a in argv)
+
+
+def test_build_ssh_argv_caller_extra_opts_win_over_defaults(tmp_path, monkeypatch):
+    # Arrange — pass a `ControlPersist=300s` override via extra_opts and
+    # verify it appears AFTER the default 60s so ssh's last-flag-wins
+    # semantics give the caller's value precedence.
+    monkeypatch.setenv("SAC_SSH_CONTROL_DIR", str(tmp_path / "cm"))
+    monkeypatch.delenv("SAC_SSH_CONTROL_MASTER", raising=False)
+    from scitex_agent_container._state.host_config import PeerSpec, build_ssh_argv
+
+    peers = {"mba": PeerSpec(name="mba", ssh="ywatanabe@mba.local")}
+
+    # Act
+    argv = build_ssh_argv(
+        "mba", ["echo", "hi"], peers, extra_opts=["-o", "ControlPersist=300s"]
+    )
+
+    # Assert
+    persist_positions = [i for i, a in enumerate(argv) if "ControlPersist=" in a]
+    assert len(persist_positions) == 2, argv
+    # Caller-supplied override appears LATER → wins on ssh re-parse.
+    later = max(persist_positions)
+    assert argv[later] == "ControlPersist=300s"
+
+
+# ---------------------------------------------------------------------------
+# Direct-ssh sites — _network.peer / cli_pkg.priority_cmds / cli_pkg._send_preflight
+# ---------------------------------------------------------------------------
+
+
+def test_priority_cmds_ssh_start_agent_argv_includes_control_options(
+    tmp_path, monkeypatch
+):
+    # Arrange — capture the argv handed to subprocess.run by stubbing the
+    # subprocess module *attribute* the function looks up at call time.
+    # No mock library — just a small recorder class.
+    monkeypatch.setenv("SAC_SSH_CONTROL_DIR", str(tmp_path / "cm"))
+    monkeypatch.delenv("SAC_SSH_CONTROL_MASTER", raising=False)
+    captured: dict = {}
+
+    class _FakeProc:
+        returncode = 0
+
+    def _record(argv, **kwargs):  # noqa: ANN001
+        captured["argv"] = argv
+        return _FakeProc()
+
+    from scitex_agent_container.cli_pkg import priority_cmds
+
+    monkeypatch.setattr(priority_cmds.subprocess, "run", _record)
+
+    # Act
+    rc = priority_cmds._ssh_start_agent("some-host", "agent-x")
+
+    # Assert
+    assert rc is True
+    argv = captured["argv"]
+    assert "ControlMaster=auto" in argv
+    assert "ControlPersist=60s" in argv
+    assert any(
+        isinstance(a, str) and a.startswith("ControlPath=") for a in argv
+    )
+
+
+def test_send_preflight_default_ssh_runner_argv_includes_control_options(
+    tmp_path, monkeypatch
+):
+    # Arrange
+    monkeypatch.setenv("SAC_SSH_CONTROL_DIR", str(tmp_path / "cm"))
+    monkeypatch.delenv("SAC_SSH_CONTROL_MASTER", raising=False)
+    captured: dict = {}
+
+    class _FakeProc:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    def _record(argv, **kwargs):  # noqa: ANN001
+        captured["argv"] = argv
+        return _FakeProc()
+
+    from scitex_agent_container.cli_pkg import _send_preflight
+
+    monkeypatch.setattr(_send_preflight.subprocess, "run", _record)
+
+    # Act
+    _send_preflight.default_ssh_runner("some-host", "/remote/creds.json")
+
+    # Assert
+    argv = captured["argv"]
+    assert "ControlMaster=auto" in argv
+    assert any(
+        isinstance(a, str) and a.startswith("ControlPath=") for a in argv
+    )
+    # Sanity — the rest of the argv (peer_host, python3, ...) is still there.
+    assert "some-host" in argv
+    assert "python3" in argv
+
+
+def test_network_peer_ssh_curl_argv_includes_control_options(tmp_path, monkeypatch):
+    # Arrange — call the inner sender with a fake subprocess.run that
+    # records the argv but returns a successful 200 JSON envelope so the
+    # parser is happy.
+    monkeypatch.setenv("SAC_SSH_CONTROL_DIR", str(tmp_path / "cm"))
+    monkeypatch.delenv("SAC_SSH_CONTROL_MASTER", raising=False)
+    captured: dict = {}
+
+    class _FakeProc:
+        returncode = 0
+        stdout = '{"text": "ok"}'
+        stderr = ""
+
+    def _record(argv, **kwargs):  # noqa: ANN001
+        captured["argv"] = argv
+        return _FakeProc()
+
+    from scitex_agent_container._network import peer as peer_mod
+
+    # The function imports subprocess inline; patch the module's
+    # subprocess attribute by injecting it after the inline import runs.
+    # Simplest: monkeypatch sys.modules so the local import resolves to a
+    # tiny shim with our recorder.
+    import subprocess as _real_subprocess
+    import types
+
+    fake_sp = types.SimpleNamespace(
+        run=_record,
+        TimeoutExpired=_real_subprocess.TimeoutExpired,
+        SubprocessError=_real_subprocess.SubprocessError,
+    )
+    monkeypatch.setitem(sys.modules, "subprocess", fake_sp)
+
+    try:
+        # Act
+        reply = peer_mod._post_turn_via_ssh(
+            "ssh://example.invalid:9999/v1/turn",
+            text="hello",
+            exit_after=False,
+            timeout_s=5,
+        )
+    finally:
+        monkeypatch.setitem(sys.modules, "subprocess", _real_subprocess)
+
+    # Assert
+    assert reply == "ok"
+    argv = captured["argv"]
+    assert "ControlMaster=auto" in argv
+    assert any(
+        isinstance(a, str) and a.startswith("ControlPath=") for a in argv
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI — sac host ssh-opts
+# ---------------------------------------------------------------------------
+
+
+def test_sac_host_ssh_opts_emits_shell_quoted_options(tmp_path, monkeypatch):
+    # Arrange
+    monkeypatch.setenv("SAC_SSH_CONTROL_DIR", str(tmp_path / "cm"))
+    monkeypatch.delenv("SAC_SSH_CONTROL_MASTER", raising=False)
+    from scitex_agent_container.cli_pkg.host_group import host_ssh_opts
+
+    # Act
+    result = CliRunner().invoke(host_ssh_opts, [])
+
+    # Assert
+    assert result.exit_code == 0
+    parsed = shlex.split(result.output.strip())
+    assert parsed[0::2] == ["-o", "-o", "-o"]
+    assert "ControlMaster=auto" in parsed
+    assert "ControlPersist=60s" in parsed
+
+
+def test_sac_host_ssh_opts_prints_empty_line_when_opted_out(monkeypatch):
+    # Arrange
+    monkeypatch.setenv("SAC_SSH_CONTROL_MASTER", "0")
+    from scitex_agent_container.cli_pkg.host_group import host_ssh_opts
+
+    # Act
+    result = CliRunner().invoke(host_ssh_opts, [])
+
+    # Assert — empty output so `ssh $(sac host ssh-opts) host cmd` works.
+    assert result.exit_code == 0
+    assert result.output.strip() == ""


### PR DESCRIPTION
## Summary
- Every sac call that shells out to ssh now prepends `-o ControlMaster=auto -o ControlPersist=60s -o ControlPath=<dir>/%C` so concurrent calls against the same peer share one TCP+SSH master.
- Fixes parallel-ssh-from-SIF failures observed against Spartan today: "control socket dir is read-only" (default `~/.ssh/sockets` lands on the apptainer overlay) AND surplus connections dropped silently by sshd's per-user `MaxSessions` / `MaxStartups`.
- New `sac host ssh-opts` CLI so agent prompts can splat the flags into ad-hoc ssh/rsync without re-deriving them.

## Mechanism
- `_state.host_config.ssh_control_options()` + `ssh_control_options_str()` — pure helpers; `mkdir -p` the control dir; fall through to `[]` on read-only / ENOSPC so argv stays byte-identical to pre-patch.
- Resolution: explicit arg → `$SAC_SSH_CONTROL_DIR` → `${TMPDIR:-/tmp}/.sac-ssh-cm`.
- Opt-out: `SAC_SSH_CONTROL_MASTER=0|no|false|off`.
- Applied centrally in `build_ssh_argv` (covers `sac host exec/probe`, `sac --on`, fleet/drift/dispatch/lifecycle) and at three direct-ssh sites that don't route through it:
  - `_network.peer._post_turn_via_ssh` (ssh+curl /v1/turn)
  - `cli_pkg.priority_cmds._ssh_start_agent` (singleton-reconcile fan-out)
  - `cli_pkg._send_preflight.default_ssh_runner` (OAuth probe)
- All new imports (`shlex`, `tempfile`) kept lazy inside the helpers so `sac --help` startup budget is unaffected.

## Test plan
- [x] 22 new real-function tests (no mocks for option-builder) — see `tests/scitex_agent_container/_state/test_ssh_control_options.py`. Covers default shape, env override precedence, opt-out, EROFS fall-through, `build_ssh_argv` wiring, all three direct-ssh sites, and the new CLI command.
- [x] Local: `pytest tests/scitex_agent_container/_state tests/scitex_agent_container/_network tests/scitex_agent_container/cli_pkg` → **1851 passed, 3 skipped**.
- [x] Full local suite — 5076 passed; 9 pre-existing failures verified to fail identically on develop (statusline IO, audit conformance, state_db filter, a2a port handler, sdk_common cwd, cli-startup-budget flake — all unrelated to ssh).
- [ ] CI green.
- [ ] Tag + patch release after merge.

## Docs
- `_skills/scitex-agent-container/11_remote-deploy.md` § "SSH connection multiplexing" — operator-facing rationale + opt-out + agent-prompt helper.
- `CHANGELOG.md` Unreleased.