### PR TITLE
release: bump to v0.21.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.21.1] — 2026-05-26
+
 ### Added
 - **feat(ssh): connection multiplexing across all sac→peer ssh calls**
   — every sac call that shells out to ssh now prepends

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-agent-container"
-version = "0.21.0"
+version = "0.21.1"
 description = "Declarative YAML-based framework for defining, managing, and orchestrating AI coding agent instances"
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
## Summary
Patch release for ssh ControlMaster connection multiplexing (#218).

- Bumps `pyproject.toml` to `0.21.1`.
- Moves the Unreleased entry under `## [0.21.1] — 2026-05-26` in `CHANGELOG.md`.

## What's in 0.21.1
- ssh ControlMaster/ControlPersist/ControlPath flags prepended on every sac→peer ssh call so concurrent calls share one TCP+SSH master.
- Fixes "control socket dir is read-only" inside apptainer SIFs and silent drops on per-user `MaxSessions`-capped hosts (Spartan).
- New CLI: `sac host ssh-opts` for agent prompts.
- Opt-out via `SAC_SSH_CONTROL_MASTER=0`; control dir override via `$SAC_SSH_CONTROL_DIR`.

## Test plan
- [x] PR #218 merged to develop with 1851 / 1851 tests in touched modules passing.
- [ ] After this PR merges, tag `v0.21.1` and push it.