### PR TITLE
chore(lint): fix ruff F401 in test_ssh_control_options

### DIFF
--- a/tests/scitex_agent_container/_state/test_ssh_control_options.py
+++ b/tests/scitex_agent_container/_state/test_ssh_control_options.py
@@ -22,11 +22,9 @@ Coverage:
 
 from __future__ import annotations
 
-import os
 import shlex
 import stat
 import sys
-from pathlib import Path
 
 import pytest
 from click.testing import CliRunner


### PR DESCRIPTION
Drops the unused `os` / `pathlib.Path` imports flagged by ruff in the
test file that landed via #218. Lint check failed on the v0.21.1
release PR (#219) — this clears it.

## Test plan
- [x] `ruff check --select F401,F811 --extend-per-file-ignores '**/__init__.py:F401' src/ tests/` → All checks passed.
- [x] 22/22 `test_ssh_control_options.py` tests still pass.