### PR TITLE
fix(audit): clear PA-306/PA-307/PS-204 from ssh ControlMaster tests

### DIFF
--- a/src/scitex_agent_container/_skills/scitex-agent-container/26_credentials-rotation.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/26_credentials-rotation.md
@@ -1,74 +1,59 @@
 ---
 description: |
-  [TOPIC] scitex-agent-container — SAC OAuth credentials rotation / refresh / recovery for Claude Pro/Max accounts (verified ywata-note-win 2026-05-26).
-  [DETAILS] Three per-account ~/.claude/.credentials-<account>.json as the single source of truth, with .credentials.json + every other reference as mode 0600 symlinks to a canonical; the rw bind at /tmp/sac-claude/.credentials.json that lets the bundled claude refresh access tokens in place (~5 min skew); the per-account COPY in _apptainer_creds.resolve_cred_file that LOSES write-back when spec.claude.account is set (refresher must instead bind the canonical via spec.apptainer.binds + custom CLAUDE_CONFIG_DIR); the preflight (_state/_preflight_creds.check_oauth_token_expiry, 300s skew) that only inspects access-token expiresAt and is skipped under an API-key env, so a direct-bind agent starts then fails LOUD with 401 the first turn if the bound file is dead; per-account refresher agent + 30-min keepalive cron pattern; and the verified headless re-login flow (code-paste via tmux, isolated CLAUDE_CONFIG_DIR, /bin/cp -f promote, sac agents restart --yes).
+  [TOPIC] scitex-agent-container — SAC OAuth credentials rotation / refresh model for Claude Pro/Max accounts.
+  [DETAILS] Per-account `~/.claude/.credentials-<acct>.json` canonicals + mode-0600 symlinks; the `:rw` bind at `/tmp/sac-claude/.credentials.json` that lets the bundled CLI refresh access tokens in place (~5 min skew); the per-account COPY caveat in `_apptainer_creds.resolve_cred_file` that LOSES write-back when `spec.claude.account` is set; the preflight (300s skew, access-token only); per-account refresher agent + 30-min keepalive cron. Re-login flow lives in 27_credentials-relogin.md.
 tags: [scitex-agent-container-credentials-rotation]
 ---
 
-# SAC OAuth credentials: rotation, refresh, and recovery
+# SAC OAuth credentials: model + auto-refresh
 
 > Verified on `ywata-note-win` 2026-05-26.
+> Re-login flow (operator-in-loop, after refresh-token death):
+> [27_credentials-relogin.md](27_credentials-relogin.md).
 
-This skill is the operator runbook for the **Anthropic OAuth credentials**
-SAC binds into every Claude-backed agent. It covers the on-disk model, the
-auth mechanics that make live refresh work, why some configurations
-silently lose write-back, what the preflight does (and does not) catch,
-and the verified headless re-login flow when a refresh token has actually
-died.
+Operator runbook for the **Anthropic OAuth credentials** SAC binds into
+every Claude-backed agent. Covers the on-disk model, the auth mechanics
+that make live refresh work, why some configurations silently lose
+write-back, and what the preflight catches.
 
-It does **not** cover the API-key (`SAC_ANTHROPIC_API_KEY`) path — that
-path is unaffected by everything below because the preflight short-circuits
-on any API-key env (see `_state/_preflight_creds._api_key_env_is_set`).
+Does **not** cover the API-key (`SAC_ANTHROPIC_API_KEY`) path — the
+preflight short-circuits on any API-key env (see
+`_state/_preflight_creds._api_key_env_is_set`).
 
-## 1. Model — three per-account files, one canonical, everything else is a symlink
+## 1. Model — one canonical per account, everything else symlinks
 
-**Single source of truth.** Each Anthropic account has exactly one
-real on-disk credentials file:
+Each Anthropic account has exactly one real file:
 
 ```
-~/.claude/.credentials-<account>.json     # account A: e.g. ywatanabe
-~/.claude/.credentials-<account>.json     # account B: e.g. scitex-ai
-~/.claude/.credentials-<account>.json     # account C: e.g. spartan
+~/.claude/.credentials-<account>.json     # one per account
 ```
 
-Mode is **0600** on the canonical and every symlink. The "active"
-file `~/.claude/.credentials.json` is **always a symlink** to whichever
-canonical the host is currently logged in as; any other reference
-(per-agent state dirs, lead session pointers, etc.) is **also a symlink**
-to the same canonical. There is never a second real copy on disk.
+Mode **0600** on the canonical and every symlink. The active file
+`~/.claude/.credentials.json` is **always a symlink** to whichever
+canonical the host is currently logged in as; per-agent state dirs and
+lead session pointers are **also symlinks** to the same canonical. There
+is never a second real copy on disk.
 
-This rule is enforced by two non-negotiables:
+Non-negotiables:
 
-- **Never copy a credentials file into `to_home/`.** `to_home/` is the
-  git-tracked agent-definition tree (see
-  [25_claude-setup-delivery.md](25_claude-setup-delivery.md)) — committing
-  a token leaks it; and the symlink-resolver dereference-copies, which
-  would land a **snapshot** of the canonical and lose write-back (an
-  in-container refresh would write into the snapshot, not the host
-  canonical, so the host stays dead).
+- **Never copy a credentials file into `to_home/`.** It's git-tracked
+  (see [25_claude-setup-delivery.md](25_claude-setup-delivery.md)) — a
+  commit leaks the token; the symlink-resolver dereferences and lands a
+  snapshot that loses write-back.
 - **Never bake credentials into the SIF image.** The image is shared
-  across accounts and machines; a baked credential is wrong for at least
-  N-1 of them and unrotatable in any of them.
+  across accounts; baked creds are wrong for N-1 and unrotatable in any.
 
-The canonical is the only thing the bundled `claude` CLI is allowed to
-write back to.
+## 2. Auth mechanics — canonical → SDK, stays fresh
 
-## 2. Auth mechanics — how the canonical reaches the SDK and stays fresh
-
-Three pieces in this repo cooperate. Citations are the SSoT.
+Three pieces in this repo cooperate:
 
 ### `provision_anthropic_auth` (`runtimes/_sdk_common.py`)
 
-Precedence (in order):
-
-1. Pop any bare `ANTHROPIC_API_KEY` from env unconditionally
-   (`os.environ.pop("ANTHROPIC_API_KEY", None)`) — a stale dotfiles export
-   must not survive past this point.
+1. Pop any bare `ANTHROPIC_API_KEY` from env unconditionally — a stale
+   dotfiles export must not survive.
 2. Resolve the credentials path via `_cred_file_path()`; if the file
-   exists, **call the preflight** (`check_oauth_token_expiry`) and on
-   success return `"credentials_file"`. **No env mirroring** — Anthropic
-   rejects `sk-ant-oat*` OAuth tokens passed as a bare env, so the SDK
-   must read the file directly.
+   exists, call the preflight and return `"credentials_file"`. **No env
+   mirroring** — Anthropic rejects `sk-ant-oat*` OAuth tokens as bare env.
 3. Else, if `SAC_ANTHROPIC_API_KEY` is set, mirror it into
    `ANTHROPIC_API_KEY` and return `"sac_env"`.
 4. Else, raise `SDKCommonError`.
@@ -80,46 +65,41 @@ CLAUDE_CONFIG_DIR if set → <CLAUDE_CONFIG_DIR>/.credentials.json
 else                     → ~/.claude/.credentials.json
 ```
 
-This is the **same env** the bundled `claude` CLI itself respects, so the
-SDK, the CLI, and the auth helper always resolve to the same file.
+Same env as the bundled `claude` CLI, so SDK + CLI + helper all resolve
+to the same file.
 
 ### Apptainer bind (`runtimes/_apptainer_auth.py::auth_argv`)
 
-For the default (host-live) path, the runtime emits:
+Default (host-live) path:
 
 ```
 --bind <cred_file>:/tmp/sac-claude/.credentials.json:rw
 --env  CLAUDE_CONFIG_DIR=/tmp/sac-claude
 ```
 
-The **`:rw`** is the reason live refresh works: when the bundled
-`claude` inside the container detects the access token nearing expiry
-(~5 min skew) it writes the new token back through the bind to the
-host canonical. Without `:rw` the file would be frozen and the
-container would 401 the moment the token expired.
+The **`:rw`** is why live refresh works: when the bundled `claude`
+inside the container detects a near-expiry access token (~5 min skew),
+it writes the new token back through the bind to the host canonical.
+Without `:rw` the container 401s the moment the token expires.
 
-The target lives under `/tmp/` (not `$HOME`) because the D2 hardened
-preflight requires `$HOME` to be empty; pointing `CLAUDE_CONFIG_DIR`
-at `/tmp/sac-claude` keeps both the SDK and the CLI in sync without
-polluting `$HOME`.
+Target lives under `/tmp/` (not `$HOME`) because D2 hardened preflight
+requires `$HOME` empty; `CLAUDE_CONFIG_DIR=/tmp/sac-claude` keeps SDK and
+CLI in sync without polluting `$HOME`.
 
-### Per-account COPY caveat (`runtimes/_apptainer_creds.py::resolve_cred_file`) — **write-back is lost**
+### Per-account COPY caveat — **write-back is lost**
 
-When `spec.claude.account` is non-empty, `resolve_cred_file`
-**`shutil.copy2`**s the store snapshot into the agent's own state dir
-and returns that path; the caller binds **the copy** `:rw`. So:
+When `spec.claude.account` is non-empty,
+`runtimes/_apptainer_creds.resolve_cred_file` **`shutil.copy2`**s the
+store snapshot into the agent's own state dir and returns that path; the
+caller binds **the copy** `:rw`. So:
 
-- The container's refresh writes into the **agent-local copy**, not the
-  host canonical.
+- The container's refresh writes into the **agent-local copy**.
 - The host canonical never advances.
-- The agent stays alive until the refresh token in its frozen copy
-  itself dies, then 401s with no host-visible recovery.
+- The agent stays alive until the frozen copy's refresh token dies, then
+  401s with no host-visible recovery.
 
 **Implication for a refresher agent:** do **not** use
-`spec.claude.account`. Bind the host canonical directly via an
-explicit `spec.apptainer.binds` entry and a custom `CLAUDE_CONFIG_DIR`,
-so the refresh **writes through** to the canonical the rest of the
-fleet shares:
+`spec.claude.account`. Bind the host canonical directly:
 
 ```yaml
 apptainer:
@@ -130,209 +110,66 @@ env:
 # leave spec.claude.account UNSET
 ```
 
-### Preflight (`_state/_preflight_creds.check_oauth_token_expiry`) — what it does NOT do
+### Preflight (`_state/_preflight_creds.check_oauth_token_expiry`)
 
-`EXPIRY_SKEW_SECONDS = 300`. The preflight reads
-`data["claudeAiOauth"]["expiresAt"]` (ms or s; auto-detected via
-`> 1e12`) and refuses to start if the **access** token is within 300 s
-of expiring or already dead. It is also **skipped entirely** when any
-API-key env is set (`_api_key_env_is_set`).
+`EXPIRY_SKEW_SECONDS = 300`. Reads `data["claudeAiOauth"]["expiresAt"]`
+(ms or s, auto-detected via `> 1e12`) and refuses to start if the
+**access** token is within 300 s of expiring or already dead. Skipped
+entirely when any API-key env is set.
 
 It does **not** inspect the refresh token. It does **not** make a
 network call. So:
 
 > A direct-bind agent **starts** (preflight passes if access still has
 > more than five minutes of life) then fails **LOUD** at the **first
-> turn** with 401 if the bound file is in fact dead (e.g. refresh
-> token expired, account revoked).
+> turn** with 401 if the bound file is in fact dead (refresh token
+> expired, account revoked).
 
-This is the **start-then-fail-loud** mode — the agent's first 401 is
-the first authoritative signal that the canonical needs operator
-recovery.
+The first 401 is the first authoritative signal that the canonical
+needs operator recovery → see
+[27_credentials-relogin.md](27_credentials-relogin.md).
 
-## 3. Auto-refresh — the bundled CLI does it; sac just keeps a session live
+## 3. Auto-refresh — the bundled CLI does it; sac keeps a session live
 
 The bundled `claude` renews the **access** token in place ~5 min before
-expiry **while a session is active**. With the `:rw` bind the new
-token persists to the host canonical; every other agent and refresher
-sharing that canonical sees the fresh token on its next read.
+expiry **while a session is active**. With the `:rw` bind the new token
+persists to the host canonical; every other agent and refresher sharing
+that canonical sees the fresh token on its next read.
 
 So the canonical stays fresh **as long as something is talking to the
-account**. The standard pattern:
+account**. Standard pattern:
 
 - **One per-account refresher agent** on the cheapest model
-  (`claude-haiku-4-5`), direct-bound to the canonical
-  (`/home/<user>/.claude/.credentials-<account>.json`) with a custom
-  `CLAUDE_CONFIG_DIR` — see the YAML snippet above.
+  (`claude-haiku-4-5`), direct-bound to the canonical with a custom
+  `CLAUDE_CONFIG_DIR` (see YAML snippet above).
 - **A 30-minute keepalive cron** that posts an A2A turn to each
   refresher: `sac agents send <refresher> hello`. The turn forces the
   bundled CLI to spin a session, observe the impending expiry, and
   rotate the access token through the bind back to the canonical.
 
-Every other agent on the same account benefits transparently — they
-all bind the same canonical.
+Every other agent on the same account benefits transparently — they all
+bind the same canonical.
 
 ## 4. Expired ≠ unrecoverable — until the refresh token dies
 
-The credentials JSON carries both an `accessToken` (~8 h life) and a
-`refreshToken` (multi-hour to multi-day). The bundled CLI quietly swaps
-an expired access token for a new one **using the refresh token**.
+Credentials JSON carries `accessToken` (~8 h life) and `refreshToken`
+(multi-hour to multi-day). The bundled CLI quietly swaps an expired
+access token for a new one using the refresh token.
 
-What dies in stages:
+Stages of death:
 
 - **Access expired, refresh alive** → CLI rotates silently; no operator
   action.
-- **Access expired, refresh expired** → CLI cannot self-revive; the
-  next session 401s. **Re-login is required.**
-
-Verified: the `scitex-ai` canonical hit an expired refresh; the
-refresher 401'd with no self-revival path. Re-login (§5) cleared it.
-
-## 5. Verified re-login flow — headless, operator-in-loop
-
-The bundled CLI's auth subcommands are:
-
-```
-claude auth login        # OAuth login (code-paste flow)
-claude auth logout
-claude auth status
-```
-
-`login` is **not** a localhost redirect — `redirect_uri` is
-`https://platform.claude.com/oauth/code/callback`, and the resulting
-page shows a **code** of the form `<code>#<state>` for the operator to
-paste back. So:
-
-- The URL alone is not enough — the operator needs a way to **return
-  the code into the CLI's prompt**.
-- A direct-injection path (`tmux send-keys`, or an A2A turn that pipes
-  to the running `claude auth login` process) is required.
-
-### Step-by-step (verified ywata-note-win 2026-05-26)
-
-1. **Back up the live canonical** (always — so the lead/host session is
-   never disturbed by a botched login):
-
-   ```
-   /bin/cp -f ~/.claude/.credentials.json ~/.claude/.credentials.json.bak
-   ```
-
-2. **Run login in an isolated `CLAUDE_CONFIG_DIR` via tmux**, so the
-   host `~/.claude/` is untouched:
-
-   ```
-   tmux new -d -s login-<acct> "
-     CLAUDE_CONFIG_DIR=/tmp/login-<acct> claude auth login
-   "
-   ```
-
-3. **Capture the pane and reassemble the OAuth URL.** The URL **wraps
-   across pane lines** (no inserted spaces). Programmatically join the
-   wrapped lines into a single URL — do **not** rely on a single-line
-   grep.
-
-4. **Surface only the URL** to the operator, with **which account** is
-   being logged in (so the operator picks the right Anthropic account
-   in the browser). Do **not** print token values; do not print the
-   refresh/access fields. Only `expiresAt` and `subscriptionType` are
-   safe to log later.
-
-5. **Operator authorizes** the correct account; `platform.claude.com`
-   shows a code as `<code>#<state>` (single-use, never log it).
-
-6. **Inject the full `<code>#<state>` into the prompt** (it says
-   `Paste code here >`):
-
-   ```
-   tmux send-keys -t login-<acct> "<code>#<state>" Enter
-   ```
-
-   The CLI prints `Login successful` and writes
-   `/tmp/login-<acct>/.credentials.json` (`expiresAt` ~+8 h,
-   `subscriptionType=max`).
-
-7. **Promote to the canonical** (note `/bin/cp` to bypass any aliased
-   `cp` — see §7):
-
-   ```
-   /bin/cp -f /tmp/login-<acct>/.credentials.json \
-             ~/.claude/.credentials-<acct>.json
-   chmod 600 ~/.claude/.credentials-<acct>.json
-   ```
-
-   If `<acct>` is the active account, also re-point the symlink:
-
-   ```
-   ln -sfn ~/.claude/.credentials-<acct>.json ~/.claude/.credentials.json
-   ```
-
-8. **Restart the per-account refresher** (the `--yes` is mandatory —
-   see §7):
-
-   ```
-   sac agents restart cred-refresher-<acct> --yes
-   ```
-
-9. **Verify**:
-
-   ```
-   sac agents send cred-refresher-<acct> hello
-   # expect a plain `ok`-style reply, NOT a 401
-   ```
-
-## 6. 401-recovery layer (design)
-
-Hook the refresher (or the keepalive cron) so that on a 401 it:
-
-1. Spawns `claude auth login` in an isolated `CLAUDE_CONFIG_DIR`.
-2. Captures + reassembles the wrapped URL.
-3. Notifies the operator with `{machine, host, agent, account, URL}` —
-   typically via the Telegram MCP tools (see
-   [23_telegram-integration.md](23_telegram-integration.md)) so the
-   operator can one-click + reply with the code.
-4. Pastes the returned `<code>#<state>` via `tmux send-keys` (or an
-   A2A turn carrying the code) into the running login process.
-5. Promotes the new credentials JSON to the canonical (§5 step 7)
-   and restarts the refresher (§5 step 8).
-6. The whole fleet on that account recovers automatically — they all
-   bind the same canonical.
-
-Because the flow is **code-paste**, URL-click-only is insufficient.
-Plan for a direct-injection return path (tmux send-keys or an A2A
-turn) from day one.
-
-## 7. Gotchas
-
-- **`/bin/cp -f` (not `cp -f`).** A shell `cp` alias/function on the
-  host commonly maps to `cp -i`, which then prompts to overwrite and,
-  in a non-interactive context, silently no-ops. Always promote via
-  the bare binary.
-- **`sac agents restart` needs `--yes`.** Without it the CLI prompts
-  for confirmation and a non-interactive call hangs.
-- **The URL wraps across tmux pane lines.** Reassemble by joining
-  lines (no inserted spaces); a naive `grep '^https://'` only sees
-  the first fragment.
-- **The pasted value is `<code>#<state>`** — the literal `#` and
-  `<state>` are part of the payload, not a comment or shell pipe.
-- **Never print token values.** Log only `expiresAt` and
-  `subscriptionType`. The OAuth code is single-use but still sensitive
-  (it grants account access for the duration of the exchange).
-- **Always log in inside an isolated `CLAUDE_CONFIG_DIR`** and back up
-  the live canonical first. The lead/host session must never be
-  disturbed by a refresh in progress.
+- **Access expired, refresh expired** → CLI cannot self-revive; the next
+  session 401s. **Re-login required** — see
+  [27_credentials-relogin.md](27_credentials-relogin.md).
 
 ## See also
 
+- [27_credentials-relogin.md](27_credentials-relogin.md) — verified
+  re-login flow (tmux code-paste) + 401-recovery design.
 - [25_claude-setup-delivery.md](25_claude-setup-delivery.md) — why
-  `to_home/` is the wrong place for credentials and how
-  `setting_sources=[]` isolates the agent from host `~/.claude`
-  auto-discovery.
-- [40_troubleshooting.md](40_troubleshooting.md) — generic 401 / start
-  failure debugging.
-- Source files cited: `runtimes/_sdk_common.py`
-  (`provision_anthropic_auth`, `_cred_file_path`),
-  `runtimes/_apptainer_auth.py` (`auth_argv` — the `:rw` bind at
-  `/tmp/sac-claude/.credentials.json` + `CLAUDE_CONFIG_DIR`),
-  `runtimes/_apptainer_creds.py` (`resolve_cred_file` — the per-account
-  COPY behavior), `_state/_preflight_creds.py`
-  (`check_oauth_token_expiry`, `EXPIRY_SKEW_SECONDS=300`).
+  `to_home/` is the wrong place for credentials; `setting_sources=[]`.
+- Source files cited: `runtimes/_sdk_common.py`,
+  `runtimes/_apptainer_auth.py`, `runtimes/_apptainer_creds.py`,
+  `_state/_preflight_creds.py`.

--- a/src/scitex_agent_container/_skills/scitex-agent-container/27_credentials-relogin.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/27_credentials-relogin.md
@@ -1,0 +1,142 @@
+---
+description: |
+  [TOPIC] scitex-agent-container — verified re-login flow + 401-recovery design for SAC OAuth credentials.
+  [DETAILS] Headless tmux-based code-paste flow; the auth subcommand surface; isolated `CLAUDE_CONFIG_DIR` so the host canonical is never disturbed; `/bin/cp -f` and `--yes` gotchas; 401-recovery hook design via Telegram for operator-in-loop. Companion to 26_credentials-rotation.md, which covers the on-disk model + auto-refresh mechanics.
+tags: [scitex-agent-container-credentials-relogin]
+---
+
+# SAC OAuth credentials: re-login + 401 recovery
+
+> Companion to [26_credentials-rotation.md](26_credentials-rotation.md).
+> 26_ covers the canonical-symlink model, the `:rw` bind, and the auto-refresh
+> path. This skill covers what to do when **the refresh token has actually
+> died** and the bundled CLI can't self-revive.
+
+## Verified re-login flow — headless, operator-in-loop
+
+Verified on `ywata-note-win` 2026-05-26.
+
+The bundled CLI's auth surface:
+
+```
+claude auth login        # OAuth login (code-paste flow)
+claude auth logout
+claude auth status
+```
+
+`login` is **not** a localhost redirect — `redirect_uri` is
+`https://platform.claude.com/oauth/code/callback`, which shows a **code**
+of the form `<code>#<state>` for the operator to paste back. The URL alone
+is not enough; the operator needs a way to **return the code into the
+CLI's prompt**. A direct-injection path (`tmux send-keys`, or an A2A turn
+piped to the running `claude auth login` process) is required.
+
+### Step-by-step
+
+1. **Back up the live canonical** so the lead/host session is never
+   disturbed by a botched login:
+
+   ```
+   /bin/cp -f ~/.claude/.credentials.json ~/.claude/.credentials.json.bak
+   ```
+
+2. **Run login in an isolated `CLAUDE_CONFIG_DIR` via tmux**, so the
+   host `~/.claude/` is untouched:
+
+   ```
+   tmux new -d -s login-<acct> "
+     CLAUDE_CONFIG_DIR=/tmp/login-<acct> claude auth login
+   "
+   ```
+
+3. **Capture the pane and reassemble the OAuth URL.** The URL **wraps
+   across pane lines** (no inserted spaces). Join the wrapped lines
+   programmatically — do **not** rely on a single-line grep.
+
+4. **Surface only the URL** to the operator with **which account** is
+   being logged in (so the operator picks the right Anthropic account in
+   the browser). Do **not** print token values.
+
+5. **Operator authorizes** the correct account; `platform.claude.com`
+   shows a code as `<code>#<state>` (single-use, never log it).
+
+6. **Inject the full `<code>#<state>` into the prompt**:
+
+   ```
+   tmux send-keys -t login-<acct> "<code>#<state>" Enter
+   ```
+
+   The CLI prints `Login successful` and writes
+   `/tmp/login-<acct>/.credentials.json` (`expiresAt` ~+8 h).
+
+7. **Promote to the canonical** (`/bin/cp` to bypass any aliased `cp`):
+
+   ```
+   /bin/cp -f /tmp/login-<acct>/.credentials.json \
+             ~/.claude/.credentials-<acct>.json
+   chmod 600 ~/.claude/.credentials-<acct>.json
+   ```
+
+   If `<acct>` is the active account, re-point the symlink:
+
+   ```
+   ln -sfn ~/.claude/.credentials-<acct>.json ~/.claude/.credentials.json
+   ```
+
+8. **Restart the per-account refresher** (the `--yes` is mandatory):
+
+   ```
+   sac agents restart cred-refresher-<acct> --yes
+   ```
+
+9. **Verify**:
+
+   ```
+   sac agents send cred-refresher-<acct> hello
+   # expect a plain `ok`-style reply, NOT a 401
+   ```
+
+## 401-recovery layer (design)
+
+Hook the refresher (or the keepalive cron) so that on a 401 it:
+
+1. Spawns `claude auth login` in an isolated `CLAUDE_CONFIG_DIR`.
+2. Captures + reassembles the wrapped URL.
+3. Notifies the operator with `{machine, host, agent, account, URL}` —
+   typically via Telegram MCP tools (see
+   [23_telegram-integration.md](23_telegram-integration.md)) for one-click
+   + reply with the code.
+4. Pastes the returned `<code>#<state>` via `tmux send-keys` (or an A2A
+   turn carrying the code) into the running login process.
+5. Promotes the new credentials JSON to the canonical (step 7 above) and
+   restarts the refresher (step 8 above).
+6. The whole fleet on that account recovers automatically — every agent
+   binds the same canonical.
+
+Because the flow is **code-paste**, URL-click-only is insufficient. Plan
+for a direct-injection return path from day one.
+
+## Gotchas
+
+- **`/bin/cp -f` (not `cp -f`).** A host `cp` alias/function commonly maps
+  to `cp -i`, which prompts in non-interactive contexts and silently
+  no-ops. Always promote via the bare binary.
+- **`sac agents restart` needs `--yes`.** Without it the CLI prompts and a
+  non-interactive call hangs.
+- **The URL wraps across tmux pane lines.** Reassemble by joining lines
+  (no inserted spaces); a naive `grep '^https://'` sees only the first
+  fragment.
+- **The pasted value is `<code>#<state>`** — the literal `#` and
+  `<state>` are part of the payload, not a comment or shell pipe.
+- **Never print token values.** Log only `expiresAt` and
+  `subscriptionType`. The OAuth code is single-use but still sensitive.
+- **Always log in inside an isolated `CLAUDE_CONFIG_DIR`** and back up the
+  live canonical first.
+
+## See also
+
+- [26_credentials-rotation.md](26_credentials-rotation.md) — on-disk
+  model, auto-refresh mechanics, the per-account COPY caveat.
+- [25_claude-setup-delivery.md](25_claude-setup-delivery.md) — why
+  `to_home/` is the wrong place for credentials.
+- [40_troubleshooting.md](40_troubleshooting.md) — generic 401 debugging.

--- a/src/scitex_agent_container/_skills/scitex-agent-container/SKILL.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/SKILL.md
@@ -52,22 +52,23 @@ through `sac agents list`/`tail`/`health`.
 - [05_resource-heartbeat.md](05_resource-heartbeat.md) — Resource heartbeat
 - [06_env-injection-ports.md](06_env-injection-ports.md) — Four env-injection ports + decision tree
 - [07_a2a-protocol.md](07_a2a-protocol.md) — Native A2A protocol (`sac a2a serve`)
-- [07_a2a-protocol-extension-fields.md](07_a2a-protocol-extension-fields.md) — `x-scitex-agent-container.*` AgentCard extension fields + JSON example
-- [08_templates.md](08_templates.md) — Six pattern templates + real-world examples
-- [14_claude-session-state.md](14_claude-session-state.md) — claude-session runner reference: state-dir layout, auth precedence, `sdk_session` status JSON, supervisor
-- [15_claude-session.md](15_claude-session.md) — the claude-session SDK runner (inside the apptainer SIF) + `POST /v1/turn` inbound endpoint; `runtime: apptainer` is the operative runtime
-- [16_claude-session-migration.md](16_claude-session-migration.md) — historical: the claude-code → SDK migration is complete; `runtime` is apptainer-only now
+- [07_a2a-protocol-extension-fields.md](07_a2a-protocol-extension-fields.md) — `x-scitex-agent-container.*` AgentCard extension fields
+- [08_templates.md](08_templates.md) — Six pattern templates + examples
+- [14_claude-session-state.md](14_claude-session-state.md) — state-dir layout, auth precedence, `sdk_session` status, supervisor
+- [15_claude-session.md](15_claude-session.md) — the claude-session SDK runner (inside the apptainer SIF) + `POST /v1/turn` inbound
+- [16_claude-session-migration.md](16_claude-session-migration.md) — historical: claude-code → SDK migration (apptainer-only now)
 - [17_inbound-turn-endpoint.md](17_inbound-turn-endpoint.md) — `POST /v1/turn` wire format + sidecar replacement
-- [18_full-agent-delegation.md](18_full-agent-delegation.md) — Delegate multi-step work to another *full* Claude Code agent (vs Task subagent)
-- [19_full-agent-troubleshooting.md](19_full-agent-troubleshooting.md) — Operational deep-dives for sac peer fleets: stuck-peer recovery, reaper pattern, hard/soft skills, Monitor over polling
+- [18_full-agent-delegation.md](18_full-agent-delegation.md) — Delegate to another *full* Claude Code agent (vs Task subagent)
+- [19_full-agent-troubleshooting.md](19_full-agent-troubleshooting.md) — Deep-dives: stuck-peer recovery, reaper pattern, hard/soft skills
 
 ### Workflows
 - [10_cli.md](10_cli.md) — CLI commands and Python API
 - [11_remote-deploy.md](11_remote-deploy.md) — SSH deployment, src files, venv
 - [12_wsl-connectivity.md](12_wsl-connectivity.md) — WSL connectivity notes
 - [24_image-build.md](24_image-build.md) — apptainer `.sif` build/rebuild, `@develop` pin, rebuild-to-ship runner/channel changes (gotcha)
-- [25_claude-setup-delivery.md](25_claude-setup-delivery.md) — how sac passes Claude setup explicitly into apptainer agents: `to_home`→`$HOME` 1:1 mirror, overlay/`--home` delivery, `--settings` hook load, `setting_sources=[]`
-- [26_credentials-rotation.md](26_credentials-rotation.md) — SAC OAuth credentials rotation/refresh/recovery: per-account canonicals + symlinks, the `:rw` bind that enables live refresh, the per-account COPY caveat that loses write-back, preflight (300s skew, access-token only), and the verified headless re-login flow
+- [25_claude-setup-delivery.md](25_claude-setup-delivery.md) — `to_home`→`$HOME` 1:1 mirror, overlay/`--home`, `--settings` hook load
+- [26_credentials-rotation.md](26_credentials-rotation.md) — OAuth model: per-account symlinks, `:rw` bind, preflight, COPY caveat
+- [27_credentials-relogin.md](27_credentials-relogin.md) — verified re-login flow (tmux code-paste) + 401-recovery design
 
 ### Reference
 - [13_observability.md](13_observability.md) — `sac agents status` JSON contract

--- a/src/scitex_agent_container/_state/host_config.py
+++ b/src/scitex_agent_container/_state/host_config.py
@@ -403,8 +403,10 @@ def _parse_env_preamble(name: str, raw) -> tuple[str, ...]:
 # ssh ControlMaster option rendering lives in its own module so the test
 # file mirror is 1:1 (project rule PS-204). This re-export keeps the
 # existing import surface (`from ..._state.host_config import
-# ssh_control_options`) working unchanged.
-from .ssh_control_options import (  # noqa: E402
+# ssh_control_options`) working unchanged for downstream callers, even
+# though only ``ssh_control_options`` is used by ``build_ssh_argv``
+# below (hence the F401 ignore on the second name).
+from .ssh_control_options import (  # noqa: E402,F401
     ssh_control_options,
     ssh_control_options_str,
 )

--- a/src/scitex_agent_container/_state/host_config.py
+++ b/src/scitex_agent_container/_state/host_config.py
@@ -400,101 +400,14 @@ def _parse_env_preamble(name: str, raw) -> tuple[str, ...]:
     )
 
 
-def ssh_control_options(*, control_dir: str | os.PathLike | None = None) -> list[str]:
-    """Return ssh ControlMaster options for connection multiplexing.
-
-    Without multiplexing, every concurrent sac invocation (parallel
-    ``sac host exec`` calls, dispatch fan-out, drift probes, OAuth
-    preflight, ssh+curl turn delivery) opens its own TCP/SSH session.
-    On hosts that cap concurrent sessions per user (Spartan's
-    ``MaxSessions``, sshd ``MaxStartups``) the surplus connections are
-    dropped and the calling agent sees empty stdout / sporadic failures.
-    Inside an apptainer SIF the default OpenSSH ``ControlPath``
-    (``~/.ssh/sockets``) also lives on a read-only overlay, surfacing as
-    ``control socket dir is read-only`` and silently disabling
-    multiplexing even when the user has it configured in
-    ``~/.ssh/config``.
-
-    Strategy:
-
-      * ``ControlMaster=auto`` — first ssh becomes master; siblings reuse.
-      * ``ControlPersist=60s`` — master lingers 60s after the last client
-        exits so a sub-second burst of sac calls shares one TCP handshake.
-      * ``ControlPath=<dir>/%C`` — ``%C`` is the SHA256 hash of
-        ``(user,host,port)``; collision-free across targets and short
-        enough to stay inside the Unix-domain-socket 108-byte name limit
-        even when ``<dir>`` is long.
-
-    The control_dir is created on call (``mkdir -p`` semantics).
-    Resolution order:
-
-      1. ``control_dir`` argument — explicit pin (tests, callers that
-         already have a writable scratch dir).
-      2. ``$SAC_SSH_CONTROL_DIR`` env override.
-      3. ``${TMPDIR:-/tmp}/.sac-ssh-cm`` via :func:`tempfile.gettempdir`
-         (writable inside apptainer SIFs by default).
-
-    Set ``SAC_SSH_CONTROL_MASTER=0`` (or ``no``/``false``/``off``) to opt
-    out entirely; the function returns ``[]`` so each sac-emitted ssh
-    argv falls back to one-connection-per-invocation. Useful when ssh
-    is itself proxied through a wrapper that breaks ``ControlPath``
-    (rare, but the escape hatch is required).
-
-    Failure mode is fall-through: if the control_dir cannot be created
-    (read-only mount, ENOSPC) the function returns ``[]`` rather than
-    raising. The next sac ssh invocation just omits the ``-o`` flags
-    and behaves exactly like pre-patch. This is intentional — connection
-    multiplexing is an optimization; making it required would break
-    callers that already work on hosts where the optimization can't
-    apply.
-    """
-    opt_out = (os.environ.get("SAC_SSH_CONTROL_MASTER", "") or "").strip().lower()
-    if opt_out in ("0", "no", "false", "off"):
-        return []
-    if control_dir is None:
-        env_dir = os.environ.get("SAC_SSH_CONTROL_DIR")
-        if env_dir:
-            control_dir = env_dir
-        else:
-            # Lazy import — keeps `sac --help` startup cost off
-            # `host_config` import (see _skills/.../21_cli-startup-budget.md).
-            import tempfile
-
-            control_dir = os.path.join(tempfile.gettempdir(), ".sac-ssh-cm")
-    try:
-        Path(control_dir).mkdir(parents=True, exist_ok=True)
-    except OSError:
-        # Read-only mount or ENOSPC — degrade to one-conn-per-call. The
-        # caller's ssh argv ends up byte-identical to pre-patch.
-        return []
-    # %C => hashed (user,host,port); keeps the socket name short and
-    # collision-free across simultaneously-active peers.
-    path = os.path.join(str(control_dir), "%C")
-    return [
-        "-o",
-        "ControlMaster=auto",
-        "-o",
-        "ControlPersist=60s",
-        "-o",
-        f"ControlPath={path}",
-    ]
-
-
-def ssh_control_options_str(*, control_dir: str | os.PathLike | None = None) -> str:
-    """Return :func:`ssh_control_options` flags as a shell-quoted string.
-
-    Convenience for agent prompts and shell wrappers that want to splat
-    the options into a literal ``ssh`` command::
-
-        ssh $(sac host ssh-opts) myhost cmd
-
-    Returns the empty string when multiplexing is opted out so the splat
-    has no effect.
-    """
-    import shlex
-
-    opts = ssh_control_options(control_dir=control_dir)
-    return " ".join(shlex.quote(o) for o in opts)
+# ssh ControlMaster option rendering lives in its own module so the test
+# file mirror is 1:1 (project rule PS-204). This re-export keeps the
+# existing import surface (`from ..._state.host_config import
+# ssh_control_options`) working unchanged.
+from .ssh_control_options import (  # noqa: E402
+    ssh_control_options,
+    ssh_control_options_str,
+)
 
 
 def build_ssh_argv(

--- a/src/scitex_agent_container/_state/ssh_control_options.py
+++ b/src/scitex_agent_container/_state/ssh_control_options.py
@@ -1,0 +1,117 @@
+"""SSH ControlMaster option rendering for sac→peer multiplexing.
+
+Without multiplexing, every concurrent sac invocation (parallel
+``sac host exec`` calls, dispatch fan-out, drift probes, OAuth
+preflight, ssh+curl turn delivery) opens its own TCP/SSH session.
+On hosts that cap concurrent sessions per user (Spartan's
+``MaxSessions``, sshd ``MaxStartups``) the surplus connections are
+dropped and the calling agent sees empty stdout / sporadic failures.
+Inside an apptainer SIF the default OpenSSH ``ControlPath``
+(``~/.ssh/sockets``) also lives on a read-only overlay, surfacing as
+``control socket dir is read-only`` and silently disabling
+multiplexing even when the user has it configured in ``~/.ssh/config``.
+
+This module is the single source of truth for the rendered
+``-o ControlMaster/Persist/Path`` triple. ``_state.host_config``,
+``cli_pkg.priority_cmds``, ``cli_pkg._send_preflight``, and
+``_network.peer`` all import :func:`ssh_control_options` (or its
+shell-quoted twin) and prepend the result to their ssh argv.
+
+The module is intentionally tiny + self-contained so the per-package
+cli-startup budget (`_skills/.../21_cli-startup-budget.md`) isn't
+affected — ``host_config`` re-exports the symbols, but the heavy
+imports (``tempfile``, ``shlex``) are deferred to call time.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+__all__ = ["ssh_control_options", "ssh_control_options_str"]
+
+
+def ssh_control_options(*, control_dir: str | os.PathLike | None = None) -> list[str]:
+    """Return ssh ControlMaster options for connection multiplexing.
+
+    Strategy:
+
+      * ``ControlMaster=auto`` — first ssh becomes master; siblings reuse.
+      * ``ControlPersist=60s`` — master lingers 60s after the last client
+        exits so a sub-second burst of sac calls shares one TCP handshake.
+      * ``ControlPath=<dir>/%C`` — ``%C`` is the SHA256 hash of
+        ``(user,host,port)``; collision-free across targets and short
+        enough to stay inside the Unix-domain-socket 108-byte name limit
+        even when ``<dir>`` is long.
+
+    The control_dir is created on call (``mkdir -p`` semantics).
+    Resolution order:
+
+      1. ``control_dir`` argument — explicit pin (tests, callers that
+         already have a writable scratch dir).
+      2. ``$SAC_SSH_CONTROL_DIR`` env override.
+      3. ``${TMPDIR:-/tmp}/.sac-ssh-cm`` via :func:`tempfile.gettempdir`
+         (writable inside apptainer SIFs by default).
+
+    Set ``SAC_SSH_CONTROL_MASTER=0`` (or ``no``/``false``/``off``) to opt
+    out entirely; the function returns ``[]`` so each sac-emitted ssh
+    argv falls back to one-connection-per-invocation. Useful when ssh
+    is itself proxied through a wrapper that breaks ``ControlPath``
+    (rare, but the escape hatch is required).
+
+    Failure mode is fall-through: if the control_dir cannot be created
+    (read-only mount, ENOSPC) the function returns ``[]`` rather than
+    raising. The next sac ssh invocation just omits the ``-o`` flags
+    and behaves exactly like pre-patch. This is intentional — connection
+    multiplexing is an optimization; making it required would break
+    callers that already work on hosts where the optimization can't
+    apply.
+    """
+    opt_out = (os.environ.get("SAC_SSH_CONTROL_MASTER", "") or "").strip().lower()
+    if opt_out in ("0", "no", "false", "off"):
+        return []
+    if control_dir is None:
+        env_dir = os.environ.get("SAC_SSH_CONTROL_DIR")
+        if env_dir:
+            control_dir = env_dir
+        else:
+            # Lazy import — keeps `sac --help` startup cost off the
+            # `_state` package import (see
+            # `_skills/.../21_cli-startup-budget.md`).
+            import tempfile
+
+            control_dir = os.path.join(tempfile.gettempdir(), ".sac-ssh-cm")
+    try:
+        Path(control_dir).mkdir(parents=True, exist_ok=True)
+    except OSError:
+        # Read-only mount or ENOSPC — degrade to one-conn-per-call. The
+        # caller's ssh argv ends up byte-identical to pre-patch.
+        return []
+    # %C => hashed (user,host,port); keeps the socket name short and
+    # collision-free across simultaneously-active peers.
+    path = os.path.join(str(control_dir), "%C")
+    return [
+        "-o",
+        "ControlMaster=auto",
+        "-o",
+        "ControlPersist=60s",
+        "-o",
+        f"ControlPath={path}",
+    ]
+
+
+def ssh_control_options_str(*, control_dir: str | os.PathLike | None = None) -> str:
+    """Return :func:`ssh_control_options` flags as a shell-quoted string.
+
+    Convenience for agent prompts and shell wrappers that want to splat
+    the options into a literal ``ssh`` command::
+
+        ssh $(sac host ssh-opts) myhost cmd
+
+    Returns the empty string when multiplexing is opted out so the splat
+    has no effect.
+    """
+    import shlex
+
+    opts = ssh_control_options(control_dir=control_dir)
+    return " ".join(shlex.quote(o) for o in opts)

--- a/tests/scitex_agent_container/_state/test_ssh_control_options.py
+++ b/tests/scitex_agent_container/_state/test_ssh_control_options.py
@@ -1,162 +1,346 @@
 """Tests for :mod:`scitex_agent_container._state.host_config` ssh ControlMaster wiring.
 
-Real-function tests — no mocks. The helper is a pure-Python wrapper around
-``os.environ`` + ``Path.mkdir``; we exercise it against a fresh ``tmp_path``
-and assert on argv shape, env-var honouring, opt-out semantics, and the
-fall-through-on-EROFS guarantee.
+Conventions (mirroring test_dispatch_ledger.py / test_state_db_turns_*.py):
 
-Coverage:
+  * One assertion per test (STX-TQ007). Related invariants collapse
+    into ``pytest.parametrize``.
+  * AAA markers (Arrange / Act / Assert).
+  * No mocks / monkeypatch (PA-306). Env mutation goes through the
+    ``env_save_restore`` fixture; subprocess calls run for real against
+    a PATH-installed fake ``ssh`` binary via the ``subprocess_shim``
+    fixture (`tests/scitex_agent_container/_helpers/subprocess_shim.py`).
 
-* :func:`ssh_control_options` — default control_dir, explicit dir arg,
-  ``$SAC_SSH_CONTROL_DIR`` env override, ``SAC_SSH_CONTROL_MASTER=0``
-  opt-out, fall-through to ``[]`` on read-only mount.
-* :func:`ssh_control_options_str` — shell-quoted shape; empty when opted out.
-* :func:`build_ssh_argv` — the master options appear in the rendered argv
-  between the existing ``-o BatchMode/...`` block and any caller
-  ``extra_opts`` so caller overrides still win.
-* Direct-ssh sites — sentinel-driven checks that the inline argvs in
-  ``_network.peer`` / ``cli_pkg.priority_cmds`` / ``cli_pkg._send_preflight``
-  prepend the control-options block.
-* CLI — ``sac host ssh-opts`` round-trip.
+Coverage map:
+
+  * ``ssh_control_options`` — default shape, explicit dir arg,
+    ``$SAC_SSH_CONTROL_DIR`` env override, ``SAC_SSH_CONTROL_MASTER``
+    opt-out matrix, fall-through to ``[]`` on read-only parent.
+  * ``ssh_control_options_str`` — shell-quoted shape; empty when opted out.
+  * ``build_ssh_argv`` — control options appear, opt-out preserves the
+    pre-patch shape, caller ``extra_opts`` wins (last-flag-wins on ssh).
+  * Direct-ssh sites — ``_network.peer._post_turn_via_ssh``,
+    ``cli_pkg.priority_cmds._ssh_start_agent``,
+    ``cli_pkg._send_preflight.default_ssh_runner`` all run real ssh
+    against the PATH shim and we read their argv back.
+  * CLI — ``sac host ssh-opts`` round-trip (CliRunner is in-process, no
+    subprocess.run involved, so the shim isn't needed there).
 """
 
 from __future__ import annotations
 
 import shlex
 import stat
-import sys
+import tempfile
+from pathlib import Path
 
 import pytest
 from click.testing import CliRunner
 
+# Re-import the shared helpers package fixtures (env_save_restore,
+# subprocess_shim) via the conftest at tests/scitex_agent_container/.
+
 
 # ---------------------------------------------------------------------------
-# ssh_control_options — pure function
+# ssh_control_options — pure function, default shape
 # ---------------------------------------------------------------------------
 
 
-def test_ssh_control_options_default_shape_has_three_opt_pairs(tmp_path, monkeypatch):
+def test_ssh_control_options_emits_three_opt_pairs(tmp_path, env_save_restore):
     # Arrange — pin control_dir away from $TMPDIR so the test is hermetic.
-    monkeypatch.delenv("SAC_SSH_CONTROL_MASTER", raising=False)
-    monkeypatch.delenv("SAC_SSH_CONTROL_DIR", raising=False)
+    env_save_restore.delete("SAC_SSH_CONTROL_MASTER")
+    env_save_restore.delete("SAC_SSH_CONTROL_DIR")
     from scitex_agent_container._state.host_config import ssh_control_options
 
     # Act
     opts = ssh_control_options(control_dir=tmp_path / "cm")
 
-    # Assert — exactly three -o pairs, in the documented order.
+    # Assert
     assert opts[0::2] == ["-o", "-o", "-o"]
+
+
+def test_ssh_control_options_first_pair_is_ControlMaster_auto(
+    tmp_path, env_save_restore
+):
+    # Arrange
+    env_save_restore.delete("SAC_SSH_CONTROL_MASTER")
+    env_save_restore.delete("SAC_SSH_CONTROL_DIR")
+    from scitex_agent_container._state.host_config import ssh_control_options
+
+    # Act
+    opts = ssh_control_options(control_dir=tmp_path / "cm")
+
+    # Assert
     assert opts[1] == "ControlMaster=auto"
+
+
+def test_ssh_control_options_second_pair_is_ControlPersist_60s(
+    tmp_path, env_save_restore
+):
+    # Arrange
+    env_save_restore.delete("SAC_SSH_CONTROL_MASTER")
+    env_save_restore.delete("SAC_SSH_CONTROL_DIR")
+    from scitex_agent_container._state.host_config import ssh_control_options
+
+    # Act
+    opts = ssh_control_options(control_dir=tmp_path / "cm")
+
+    # Assert
     assert opts[3] == "ControlPersist=60s"
+
+
+def test_ssh_control_options_third_pair_starts_with_ControlPath(
+    tmp_path, env_save_restore
+):
+    # Arrange
+    env_save_restore.delete("SAC_SSH_CONTROL_MASTER")
+    env_save_restore.delete("SAC_SSH_CONTROL_DIR")
+    from scitex_agent_container._state.host_config import ssh_control_options
+
+    # Act
+    opts = ssh_control_options(control_dir=tmp_path / "cm")
+
+    # Assert
     assert opts[5].startswith("ControlPath=")
 
 
-def test_ssh_control_options_creates_control_dir_on_call(tmp_path, monkeypatch):
+# ---------------------------------------------------------------------------
+# ssh_control_options — control_dir creation + ControlPath shape
+# ---------------------------------------------------------------------------
+
+
+def test_ssh_control_options_creates_missing_control_dir(tmp_path, env_save_restore):
     # Arrange
-    monkeypatch.delenv("SAC_SSH_CONTROL_MASTER", raising=False)
-    monkeypatch.delenv("SAC_SSH_CONTROL_DIR", raising=False)
+    env_save_restore.delete("SAC_SSH_CONTROL_MASTER")
+    env_save_restore.delete("SAC_SSH_CONTROL_DIR")
     target = tmp_path / "freshly-created-cm-dir"
-    assert not target.exists()
+    from scitex_agent_container._state.host_config import ssh_control_options
+
+    # Act
+    ssh_control_options(control_dir=target)
+
+    # Assert
+    assert target.is_dir()
+
+
+def test_ssh_control_options_control_path_points_inside_control_dir(
+    tmp_path, env_save_restore
+):
+    # Arrange
+    env_save_restore.delete("SAC_SSH_CONTROL_MASTER")
+    env_save_restore.delete("SAC_SSH_CONTROL_DIR")
+    target = tmp_path / "cm"
     from scitex_agent_container._state.host_config import ssh_control_options
 
     # Act
     opts = ssh_control_options(control_dir=target)
 
-    # Assert — dir was created, ControlPath points inside it via %C.
-    assert target.is_dir()
-    control_path = next(o for o in opts if o.startswith("ControlPath="))
-    assert control_path == f"ControlPath={target}/%C"
+    # Assert — %C is OpenSSH's hashed (user,host,port) token; keeps the
+    # socket name short + collision-free across simultaneously-active peers.
+    assert f"ControlPath={target}/%C" in opts
 
 
-def test_ssh_control_options_honours_explicit_env_var(tmp_path, monkeypatch):
-    # Arrange — env override beats the $TMPDIR default.
+# ---------------------------------------------------------------------------
+# ssh_control_options — env override + arg precedence
+# ---------------------------------------------------------------------------
+
+
+def test_ssh_control_options_env_var_creates_override_dir(tmp_path, env_save_restore):
+    # Arrange
     override = tmp_path / "env-override-cm"
-    monkeypatch.delenv("SAC_SSH_CONTROL_MASTER", raising=False)
-    monkeypatch.setenv("SAC_SSH_CONTROL_DIR", str(override))
+    env_save_restore.delete("SAC_SSH_CONTROL_MASTER")
+    env_save_restore.set("SAC_SSH_CONTROL_DIR", str(override))
+    from scitex_agent_container._state.host_config import ssh_control_options
+
+    # Act
+    ssh_control_options()
+
+    # Assert
+    assert override.is_dir()
+
+
+def test_ssh_control_options_env_var_appears_in_control_path(
+    tmp_path, env_save_restore
+):
+    # Arrange
+    override = tmp_path / "env-override-cm"
+    env_save_restore.delete("SAC_SSH_CONTROL_MASTER")
+    env_save_restore.set("SAC_SSH_CONTROL_DIR", str(override))
     from scitex_agent_container._state.host_config import ssh_control_options
 
     # Act
     opts = ssh_control_options()
 
     # Assert
-    assert override.is_dir()
     assert f"ControlPath={override}/%C" in opts
 
 
-def test_ssh_control_options_explicit_arg_beats_env_var(tmp_path, monkeypatch):
-    # Arrange — function arg should win over env.
-    monkeypatch.delenv("SAC_SSH_CONTROL_MASTER", raising=False)
-    env_dir = tmp_path / "env"
+def test_ssh_control_options_explicit_arg_creates_arg_dir(tmp_path, env_save_restore):
+    # Arrange — arg should win over env.
+    env_save_restore.delete("SAC_SSH_CONTROL_MASTER")
+    env_save_restore.set("SAC_SSH_CONTROL_DIR", str(tmp_path / "env"))
     arg_dir = tmp_path / "arg"
-    monkeypatch.setenv("SAC_SSH_CONTROL_DIR", str(env_dir))
+    from scitex_agent_container._state.host_config import ssh_control_options
+
+    # Act
+    ssh_control_options(control_dir=arg_dir)
+
+    # Assert
+    assert arg_dir.is_dir()
+
+
+def test_ssh_control_options_explicit_arg_skips_env_dir(tmp_path, env_save_restore):
+    # Arrange
+    env_save_restore.delete("SAC_SSH_CONTROL_MASTER")
+    env_dir = tmp_path / "env"
+    env_save_restore.set("SAC_SSH_CONTROL_DIR", str(env_dir))
+    arg_dir = tmp_path / "arg"
+    from scitex_agent_container._state.host_config import ssh_control_options
+
+    # Act
+    ssh_control_options(control_dir=arg_dir)
+
+    # Assert — env_dir is NOT materialized because the explicit arg won.
+    assert not env_dir.exists()
+
+
+def test_ssh_control_options_explicit_arg_path_appears_in_control_path(
+    tmp_path, env_save_restore
+):
+    # Arrange
+    env_save_restore.delete("SAC_SSH_CONTROL_MASTER")
+    env_save_restore.set("SAC_SSH_CONTROL_DIR", str(tmp_path / "env"))
+    arg_dir = tmp_path / "arg"
     from scitex_agent_container._state.host_config import ssh_control_options
 
     # Act
     opts = ssh_control_options(control_dir=arg_dir)
 
-    # Assert — arg dir is materialized; env dir is not.
-    assert arg_dir.is_dir()
-    assert not env_dir.exists()
-    assert any(o == f"ControlPath={arg_dir}/%C" for o in opts)
+    # Assert
+    assert f"ControlPath={arg_dir}/%C" in opts
+
+
+# ---------------------------------------------------------------------------
+# ssh_control_options — opt-out semantics
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize("opt_out_value", ["0", "no", "false", "off", "NO", "FALSE"])
-def test_ssh_control_options_opt_out_returns_empty(tmp_path, monkeypatch, opt_out_value):
+def test_ssh_control_options_opt_out_returns_empty(
+    tmp_path, env_save_restore, opt_out_value
+):
     # Arrange
-    monkeypatch.setenv("SAC_SSH_CONTROL_MASTER", opt_out_value)
-    monkeypatch.delenv("SAC_SSH_CONTROL_DIR", raising=False)
+    env_save_restore.set("SAC_SSH_CONTROL_MASTER", opt_out_value)
+    env_save_restore.delete("SAC_SSH_CONTROL_DIR")
     from scitex_agent_container._state.host_config import ssh_control_options
 
     # Act
     opts = ssh_control_options(control_dir=tmp_path / "cm-should-not-be-used")
 
-    # Assert — empty list; control_dir argument NOT created (no side effect).
+    # Assert — empty list = ssh argv falls back to pre-patch shape.
     assert opts == []
-    assert not (tmp_path / "cm-should-not-be-used").exists()
 
 
-def test_ssh_control_options_falls_through_when_control_dir_unwritable(
-    tmp_path, monkeypatch
+def test_ssh_control_options_opt_out_does_not_create_control_dir(
+    tmp_path, env_save_restore
 ):
-    # Arrange — make the parent read-only so mkdir(parents=True) fails.
-    readonly_parent = tmp_path / "ro-parent"
-    readonly_parent.mkdir()
-    readonly_parent.chmod(stat.S_IRUSR | stat.S_IXUSR)  # 0o500 — no write.
+    # Arrange — opt-out must short-circuit BEFORE mkdir so we don't leave
+    # scratch dirs behind when the operator has disabled multiplexing.
+    env_save_restore.set("SAC_SSH_CONTROL_MASTER", "0")
+    env_save_restore.delete("SAC_SSH_CONTROL_DIR")
+    target = tmp_path / "should-not-be-created"
+    from scitex_agent_container._state.host_config import ssh_control_options
+
+    # Act
+    ssh_control_options(control_dir=target)
+
+    # Assert
+    assert not target.exists()
+
+
+# ---------------------------------------------------------------------------
+# ssh_control_options — fall-through when control_dir parent is read-only
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def readonly_parent_dir(tmp_path):
+    """tmp_path/ro-parent with mode 0o500 (no write) — auto-restored."""
+    parent = tmp_path / "ro-parent"
+    parent.mkdir()
+    parent.chmod(stat.S_IRUSR | stat.S_IXUSR)
     try:
-        target = readonly_parent / "cm"
-        monkeypatch.delenv("SAC_SSH_CONTROL_MASTER", raising=False)
-        monkeypatch.delenv("SAC_SSH_CONTROL_DIR", raising=False)
-        from scitex_agent_container._state.host_config import ssh_control_options
-
-        # Act
-        opts = ssh_control_options(control_dir=target)
-
-        # Assert — fall-through: empty list, NO exception. ssh argv ends up
-        # byte-identical to the pre-patch shape.
-        assert opts == []
-        assert not target.exists()
+        yield parent
     finally:
-        # Restore for cleanup.
-        readonly_parent.chmod(stat.S_IRWXU)
+        parent.chmod(stat.S_IRWXU)
 
 
-def test_ssh_control_options_default_dir_lives_under_tempdir(monkeypatch):
-    # Arrange — clear overrides; let the function pick its default.
-    monkeypatch.delenv("SAC_SSH_CONTROL_MASTER", raising=False)
-    monkeypatch.delenv("SAC_SSH_CONTROL_DIR", raising=False)
-    import tempfile
+def test_ssh_control_options_falls_through_when_mkdir_fails(
+    readonly_parent_dir, env_save_restore
+):
+    # Arrange — read-only parent makes ``mkdir(parents=True)`` fail.
+    env_save_restore.delete("SAC_SSH_CONTROL_MASTER")
+    env_save_restore.delete("SAC_SSH_CONTROL_DIR")
+    target = readonly_parent_dir / "cm"
+    from scitex_agent_container._state.host_config import ssh_control_options
 
+    # Act
+    opts = ssh_control_options(control_dir=target)
+
+    # Assert — empty list (no exception); ssh argv stays byte-identical
+    # to pre-patch behavior.
+    assert opts == []
+
+
+def test_ssh_control_options_does_not_partially_create_target_on_eros(
+    readonly_parent_dir, env_save_restore
+):
+    # Arrange
+    env_save_restore.delete("SAC_SSH_CONTROL_MASTER")
+    env_save_restore.delete("SAC_SSH_CONTROL_DIR")
+    target = readonly_parent_dir / "cm"
+    from scitex_agent_container._state.host_config import ssh_control_options
+
+    # Act
+    ssh_control_options(control_dir=target)
+
+    # Assert
+    assert not target.exists()
+
+
+# ---------------------------------------------------------------------------
+# ssh_control_options — default (no arg, no env) lives under $TMPDIR
+# ---------------------------------------------------------------------------
+
+
+def test_ssh_control_options_default_dir_starts_with_tempdir(env_save_restore):
+    # Arrange
+    env_save_restore.delete("SAC_SSH_CONTROL_MASTER")
+    env_save_restore.delete("SAC_SSH_CONTROL_DIR")
     from scitex_agent_container._state.host_config import ssh_control_options
 
     # Act
     opts = ssh_control_options()
-
-    # Assert
     control_path = next(o for o in opts if o.startswith("ControlPath="))
     path = control_path.split("=", 1)[1]
-    # The default lives under $TMPDIR (gettempdir) — exact match validates
-    # we honour TMPDIR like apptainer expects.
+
+    # Assert
     assert path.startswith(tempfile.gettempdir())
+
+
+def test_ssh_control_options_default_dir_ends_with_sac_ssh_cm_percent_C(
+    env_save_restore,
+):
+    # Arrange
+    env_save_restore.delete("SAC_SSH_CONTROL_MASTER")
+    env_save_restore.delete("SAC_SSH_CONTROL_DIR")
+    from scitex_agent_container._state.host_config import ssh_control_options
+
+    # Act
+    opts = ssh_control_options()
+    control_path = next(o for o in opts if o.startswith("ControlPath="))
+    path = control_path.split("=", 1)[1]
+
+    # Assert
     assert path.endswith("/.sac-ssh-cm/%C")
 
 
@@ -165,12 +349,12 @@ def test_ssh_control_options_default_dir_lives_under_tempdir(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_ssh_control_options_str_is_shell_quoted_and_round_trips(
-    tmp_path, monkeypatch
+def test_ssh_control_options_str_shlex_split_matches_options_list(
+    tmp_path, env_save_restore
 ):
     # Arrange
-    monkeypatch.delenv("SAC_SSH_CONTROL_MASTER", raising=False)
-    monkeypatch.delenv("SAC_SSH_CONTROL_DIR", raising=False)
+    env_save_restore.delete("SAC_SSH_CONTROL_MASTER")
+    env_save_restore.delete("SAC_SSH_CONTROL_DIR")
     from scitex_agent_container._state.host_config import (
         ssh_control_options,
         ssh_control_options_str,
@@ -180,13 +364,13 @@ def test_ssh_control_options_str_is_shell_quoted_and_round_trips(
     s = ssh_control_options_str(control_dir=tmp_path / "cm")
     expected = ssh_control_options(control_dir=tmp_path / "cm")
 
-    # Assert — shlex.split of the string returns the exact opts list.
+    # Assert — shlex.split of the rendered string returns the exact opts list.
     assert shlex.split(s) == expected
 
 
-def test_ssh_control_options_str_empty_when_opted_out(monkeypatch):
+def test_ssh_control_options_str_is_empty_when_opted_out(env_save_restore):
     # Arrange
-    monkeypatch.setenv("SAC_SSH_CONTROL_MASTER", "0")
+    env_save_restore.set("SAC_SSH_CONTROL_MASTER", "0")
     from scitex_agent_container._state.host_config import ssh_control_options_str
 
     # Act
@@ -197,193 +381,296 @@ def test_ssh_control_options_str_empty_when_opted_out(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# build_ssh_argv — the wired call site
+# build_ssh_argv — central call site wired through ssh_control_options()
 # ---------------------------------------------------------------------------
 
 
-def test_build_ssh_argv_emits_control_master_flags_by_default(tmp_path, monkeypatch):
-    # Arrange
-    monkeypatch.setenv("SAC_SSH_CONTROL_DIR", str(tmp_path / "cm"))
-    monkeypatch.delenv("SAC_SSH_CONTROL_MASTER", raising=False)
-    from scitex_agent_container._state.host_config import PeerSpec, build_ssh_argv
+@pytest.fixture
+def mba_peer():
+    from scitex_agent_container._state.host_config import PeerSpec
 
-    peers = {"mba": PeerSpec(name="mba", ssh="ywatanabe@mba.local")}
+    return {"mba": PeerSpec(name="mba", ssh="ywatanabe@mba.local")}
+
+
+def test_build_ssh_argv_includes_ControlMaster_auto(
+    tmp_path, env_save_restore, mba_peer
+):
+    # Arrange
+    env_save_restore.set("SAC_SSH_CONTROL_DIR", str(tmp_path / "cm"))
+    env_save_restore.delete("SAC_SSH_CONTROL_MASTER")
+    from scitex_agent_container._state.host_config import build_ssh_argv
 
     # Act
-    argv = build_ssh_argv("mba", ["echo", "hi"], peers)
+    argv = build_ssh_argv("mba", ["echo", "hi"], mba_peer)
 
-    # Assert — the three options appear, AFTER the existing -o block and
-    # BEFORE the host arg so caller `extra_opts` precedence still works.
+    # Assert
     assert "ControlMaster=auto" in argv
+
+
+def test_build_ssh_argv_includes_ControlPersist_60s(
+    tmp_path, env_save_restore, mba_peer
+):
+    # Arrange
+    env_save_restore.set("SAC_SSH_CONTROL_DIR", str(tmp_path / "cm"))
+    env_save_restore.delete("SAC_SSH_CONTROL_MASTER")
+    from scitex_agent_container._state.host_config import build_ssh_argv
+
+    # Act
+    argv = build_ssh_argv("mba", ["echo", "hi"], mba_peer)
+
+    # Assert
     assert "ControlPersist=60s" in argv
+
+
+def test_build_ssh_argv_control_path_ends_with_percent_C(
+    tmp_path, env_save_restore, mba_peer
+):
+    # Arrange
+    env_save_restore.set("SAC_SSH_CONTROL_DIR", str(tmp_path / "cm"))
+    env_save_restore.delete("SAC_SSH_CONTROL_MASTER")
+    from scitex_agent_container._state.host_config import build_ssh_argv
+
+    # Act
+    argv = build_ssh_argv("mba", ["echo", "hi"], mba_peer)
     cp = next(a for a in argv if a.startswith("ControlPath="))
+
+    # Assert
     assert cp.endswith("/%C")
 
 
-def test_build_ssh_argv_opted_out_matches_pre_patch_shape(monkeypatch):
-    # Arrange — opt out; the rendered argv should be free of any
-    # Control* option. This guarantees the escape hatch keeps existing
-    # ssh-config-based multiplexing setups working as-is.
-    monkeypatch.setenv("SAC_SSH_CONTROL_MASTER", "0")
-    from scitex_agent_container._state.host_config import PeerSpec, build_ssh_argv
-
-    peers = {"mba": PeerSpec(name="mba", ssh="ywatanabe@mba.local")}
+def test_build_ssh_argv_opt_out_has_no_control_options(env_save_restore, mba_peer):
+    # Arrange — escape hatch keeps existing ssh-config-based multiplexing
+    # setups working as-is; the rendered argv carries no ``Control*``.
+    env_save_restore.set("SAC_SSH_CONTROL_MASTER", "0")
+    from scitex_agent_container._state.host_config import build_ssh_argv
 
     # Act
-    argv = build_ssh_argv("mba", ["echo", "hi"], peers)
+    argv = build_ssh_argv("mba", ["echo", "hi"], mba_peer)
 
     # Assert
     assert not any("Control" in a for a in argv)
 
 
-def test_build_ssh_argv_caller_extra_opts_win_over_defaults(tmp_path, monkeypatch):
-    # Arrange — pass a `ControlPersist=300s` override via extra_opts and
-    # verify it appears AFTER the default 60s so ssh's last-flag-wins
-    # semantics give the caller's value precedence.
-    monkeypatch.setenv("SAC_SSH_CONTROL_DIR", str(tmp_path / "cm"))
-    monkeypatch.delenv("SAC_SSH_CONTROL_MASTER", raising=False)
-    from scitex_agent_container._state.host_config import PeerSpec, build_ssh_argv
-
-    peers = {"mba": PeerSpec(name="mba", ssh="ywatanabe@mba.local")}
+def test_build_ssh_argv_caller_extra_opts_emit_two_ControlPersist_entries(
+    tmp_path, env_save_restore, mba_peer
+):
+    # Arrange — both the package default and the caller override should
+    # appear in the rendered argv (ssh's last-flag-wins decides at parse).
+    env_save_restore.set("SAC_SSH_CONTROL_DIR", str(tmp_path / "cm"))
+    env_save_restore.delete("SAC_SSH_CONTROL_MASTER")
+    from scitex_agent_container._state.host_config import build_ssh_argv
 
     # Act
     argv = build_ssh_argv(
-        "mba", ["echo", "hi"], peers, extra_opts=["-o", "ControlPersist=300s"]
+        "mba",
+        ["echo", "hi"],
+        mba_peer,
+        extra_opts=["-o", "ControlPersist=300s"],
     )
+    persist_positions = [i for i, a in enumerate(argv) if "ControlPersist=" in a]
 
     # Assert
+    assert len(persist_positions) == 2
+
+
+def test_build_ssh_argv_caller_extra_opts_position_after_package_default(
+    tmp_path, env_save_restore, mba_peer
+):
+    # Arrange — caller-supplied value MUST come AFTER the package default so
+    # ssh's last-flag-wins semantics give the caller's value precedence.
+    env_save_restore.set("SAC_SSH_CONTROL_DIR", str(tmp_path / "cm"))
+    env_save_restore.delete("SAC_SSH_CONTROL_MASTER")
+    from scitex_agent_container._state.host_config import build_ssh_argv
+
+    # Act
+    argv = build_ssh_argv(
+        "mba",
+        ["echo", "hi"],
+        mba_peer,
+        extra_opts=["-o", "ControlPersist=300s"],
+    )
     persist_positions = [i for i, a in enumerate(argv) if "ControlPersist=" in a]
-    assert len(persist_positions) == 2, argv
-    # Caller-supplied override appears LATER → wins on ssh re-parse.
     later = max(persist_positions)
+
+    # Assert
     assert argv[later] == "ControlPersist=300s"
 
 
 # ---------------------------------------------------------------------------
-# Direct-ssh sites — _network.peer / cli_pkg.priority_cmds / cli_pkg._send_preflight
+# Direct-ssh sites — verified via PATH-shim, NOT mocked.
+# Each helper invokes real ``subprocess.run(["ssh", ...])``; the shim
+# fixture installs a fake ``ssh`` at the front of $PATH, the real
+# subprocess machinery exec's it, and the fake records its argv to a log.
 # ---------------------------------------------------------------------------
 
 
-def test_priority_cmds_ssh_start_agent_argv_includes_control_options(
-    tmp_path, monkeypatch
-):
-    # Arrange — capture the argv handed to subprocess.run by stubbing the
-    # subprocess module *attribute* the function looks up at call time.
-    # No mock library — just a small recorder class.
-    monkeypatch.setenv("SAC_SSH_CONTROL_DIR", str(tmp_path / "cm"))
-    monkeypatch.delenv("SAC_SSH_CONTROL_MASTER", raising=False)
-    captured: dict = {}
-
-    class _FakeProc:
-        returncode = 0
-
-    def _record(argv, **kwargs):  # noqa: ANN001
-        captured["argv"] = argv
-        return _FakeProc()
-
-    from scitex_agent_container.cli_pkg import priority_cmds
-
-    monkeypatch.setattr(priority_cmds.subprocess, "run", _record)
-
-    # Act
-    rc = priority_cmds._ssh_start_agent("some-host", "agent-x")
-
-    # Assert
-    assert rc is True
-    argv = captured["argv"]
-    assert "ControlMaster=auto" in argv
-    assert "ControlPersist=60s" in argv
-    assert any(
-        isinstance(a, str) and a.startswith("ControlPath=") for a in argv
-    )
-
-
-def test_send_preflight_default_ssh_runner_argv_includes_control_options(
-    tmp_path, monkeypatch
+def test_priority_cmds_ssh_start_agent_argv_includes_ControlMaster_auto(
+    tmp_path, env_save_restore, subprocess_shim
 ):
     # Arrange
-    monkeypatch.setenv("SAC_SSH_CONTROL_DIR", str(tmp_path / "cm"))
-    monkeypatch.delenv("SAC_SSH_CONTROL_MASTER", raising=False)
-    captured: dict = {}
-
-    class _FakeProc:
-        returncode = 0
-        stdout = ""
-        stderr = ""
-
-    def _record(argv, **kwargs):  # noqa: ANN001
-        captured["argv"] = argv
-        return _FakeProc()
-
-    from scitex_agent_container.cli_pkg import _send_preflight
-
-    monkeypatch.setattr(_send_preflight.subprocess, "run", _record)
+    env_save_restore.set("SAC_SSH_CONTROL_DIR", str(tmp_path / "cm"))
+    env_save_restore.delete("SAC_SSH_CONTROL_MASTER")
+    subprocess_shim.install("ssh", exit=0)
+    from scitex_agent_container.cli_pkg.priority_cmds import _ssh_start_agent
 
     # Act
-    _send_preflight.default_ssh_runner("some-host", "/remote/creds.json")
+    _ssh_start_agent("some-host", "agent-x")
+    argv = subprocess_shim.argv_for("ssh")
 
     # Assert
-    argv = captured["argv"]
     assert "ControlMaster=auto" in argv
-    assert any(
-        isinstance(a, str) and a.startswith("ControlPath=") for a in argv
-    )
-    # Sanity — the rest of the argv (peer_host, python3, ...) is still there.
-    assert "some-host" in argv
+
+
+def test_priority_cmds_ssh_start_agent_argv_includes_control_path(
+    tmp_path, env_save_restore, subprocess_shim
+):
+    # Arrange
+    env_save_restore.set("SAC_SSH_CONTROL_DIR", str(tmp_path / "cm"))
+    env_save_restore.delete("SAC_SSH_CONTROL_MASTER")
+    subprocess_shim.install("ssh", exit=0)
+    from scitex_agent_container.cli_pkg.priority_cmds import _ssh_start_agent
+
+    # Act
+    _ssh_start_agent("some-host", "agent-x")
+    argv = subprocess_shim.argv_for("ssh")
+
+    # Assert
+    assert any(isinstance(a, str) and a.startswith("ControlPath=") for a in argv)
+
+
+def test_send_preflight_default_ssh_runner_argv_includes_ControlMaster_auto(
+    tmp_path, env_save_restore, subprocess_shim
+):
+    # Arrange
+    env_save_restore.set("SAC_SSH_CONTROL_DIR", str(tmp_path / "cm"))
+    env_save_restore.delete("SAC_SSH_CONTROL_MASTER")
+    subprocess_shim.install("ssh", exit=0, stdout="")
+    from scitex_agent_container.cli_pkg._send_preflight import default_ssh_runner
+
+    # Act
+    default_ssh_runner("some-host", "/remote/creds.json")
+    argv = subprocess_shim.argv_for("ssh")
+
+    # Assert
+    assert "ControlMaster=auto" in argv
+
+
+def test_send_preflight_default_ssh_runner_argv_includes_control_path(
+    tmp_path, env_save_restore, subprocess_shim
+):
+    # Arrange
+    env_save_restore.set("SAC_SSH_CONTROL_DIR", str(tmp_path / "cm"))
+    env_save_restore.delete("SAC_SSH_CONTROL_MASTER")
+    subprocess_shim.install("ssh", exit=0, stdout="")
+    from scitex_agent_container.cli_pkg._send_preflight import default_ssh_runner
+
+    # Act
+    default_ssh_runner("some-host", "/remote/creds.json")
+    argv = subprocess_shim.argv_for("ssh")
+
+    # Assert
+    assert any(isinstance(a, str) and a.startswith("ControlPath=") for a in argv)
+
+
+def test_send_preflight_default_ssh_runner_argv_includes_peer_host(
+    tmp_path, env_save_restore, subprocess_shim
+):
+    # Arrange — sanity check that the rest of the argv (peer_host,
+    # python3 probe) survives the option prepending.
+    env_save_restore.set("SAC_SSH_CONTROL_DIR", str(tmp_path / "cm"))
+    env_save_restore.delete("SAC_SSH_CONTROL_MASTER")
+    subprocess_shim.install("ssh", exit=0, stdout="")
+    from scitex_agent_container.cli_pkg._send_preflight import default_ssh_runner
+
+    # Act
+    default_ssh_runner("my-peer-host", "/remote/creds.json")
+    argv = subprocess_shim.argv_for("ssh")
+
+    # Assert
+    assert "my-peer-host" in argv
+
+
+def test_send_preflight_default_ssh_runner_argv_invokes_python3_probe(
+    tmp_path, env_save_restore, subprocess_shim
+):
+    # Arrange
+    env_save_restore.set("SAC_SSH_CONTROL_DIR", str(tmp_path / "cm"))
+    env_save_restore.delete("SAC_SSH_CONTROL_MASTER")
+    subprocess_shim.install("ssh", exit=0, stdout="")
+    from scitex_agent_container.cli_pkg._send_preflight import default_ssh_runner
+
+    # Act
+    default_ssh_runner("some-host", "/remote/creds.json")
+    argv = subprocess_shim.argv_for("ssh")
+
+    # Assert
     assert "python3" in argv
 
 
-def test_network_peer_ssh_curl_argv_includes_control_options(tmp_path, monkeypatch):
-    # Arrange — call the inner sender with a fake subprocess.run that
-    # records the argv but returns a successful 200 JSON envelope so the
-    # parser is happy.
-    monkeypatch.setenv("SAC_SSH_CONTROL_DIR", str(tmp_path / "cm"))
-    monkeypatch.delenv("SAC_SSH_CONTROL_MASTER", raising=False)
-    captured: dict = {}
+def test_network_peer_post_turn_via_ssh_argv_includes_ControlMaster_auto(
+    tmp_path, env_save_restore, subprocess_shim
+):
+    # Arrange — fake ssh emits the JSON envelope the parser expects so
+    # ``_post_turn_via_ssh`` reaches its return path; we then inspect argv.
+    env_save_restore.set("SAC_SSH_CONTROL_DIR", str(tmp_path / "cm"))
+    env_save_restore.delete("SAC_SSH_CONTROL_MASTER")
+    subprocess_shim.install("ssh", exit=0, stdout='{"text": "ok"}')
+    from scitex_agent_container._network.peer import _post_turn_via_ssh
 
-    class _FakeProc:
-        returncode = 0
-        stdout = '{"text": "ok"}'
-        stderr = ""
-
-    def _record(argv, **kwargs):  # noqa: ANN001
-        captured["argv"] = argv
-        return _FakeProc()
-
-    from scitex_agent_container._network import peer as peer_mod
-
-    # The function imports subprocess inline; patch the module's
-    # subprocess attribute by injecting it after the inline import runs.
-    # Simplest: monkeypatch sys.modules so the local import resolves to a
-    # tiny shim with our recorder.
-    import subprocess as _real_subprocess
-    import types
-
-    fake_sp = types.SimpleNamespace(
-        run=_record,
-        TimeoutExpired=_real_subprocess.TimeoutExpired,
-        SubprocessError=_real_subprocess.SubprocessError,
+    # Act
+    _post_turn_via_ssh(
+        "ssh://example.invalid:9999/v1/turn",
+        text="hello",
+        exit_after=False,
+        timeout_s=5,
     )
-    monkeypatch.setitem(sys.modules, "subprocess", fake_sp)
+    argv = subprocess_shim.argv_for("ssh")
 
-    try:
-        # Act
-        reply = peer_mod._post_turn_via_ssh(
-            "ssh://example.invalid:9999/v1/turn",
-            text="hello",
-            exit_after=False,
-            timeout_s=5,
-        )
-    finally:
-        monkeypatch.setitem(sys.modules, "subprocess", _real_subprocess)
+    # Assert
+    assert "ControlMaster=auto" in argv
+
+
+def test_network_peer_post_turn_via_ssh_argv_includes_control_path(
+    tmp_path, env_save_restore, subprocess_shim
+):
+    # Arrange
+    env_save_restore.set("SAC_SSH_CONTROL_DIR", str(tmp_path / "cm"))
+    env_save_restore.delete("SAC_SSH_CONTROL_MASTER")
+    subprocess_shim.install("ssh", exit=0, stdout='{"text": "ok"}')
+    from scitex_agent_container._network.peer import _post_turn_via_ssh
+
+    # Act
+    _post_turn_via_ssh(
+        "ssh://example.invalid:9999/v1/turn",
+        text="hello",
+        exit_after=False,
+        timeout_s=5,
+    )
+    argv = subprocess_shim.argv_for("ssh")
+
+    # Assert
+    assert any(isinstance(a, str) and a.startswith("ControlPath=") for a in argv)
+
+
+def test_network_peer_post_turn_via_ssh_returns_parsed_text(
+    tmp_path, env_save_restore, subprocess_shim
+):
+    # Arrange — sanity check the full happy path through the shim.
+    env_save_restore.set("SAC_SSH_CONTROL_DIR", str(tmp_path / "cm"))
+    env_save_restore.delete("SAC_SSH_CONTROL_MASTER")
+    subprocess_shim.install("ssh", exit=0, stdout='{"text": "ok"}')
+    from scitex_agent_container._network.peer import _post_turn_via_ssh
+
+    # Act
+    reply = _post_turn_via_ssh(
+        "ssh://example.invalid:9999/v1/turn",
+        text="hello",
+        exit_after=False,
+        timeout_s=5,
+    )
 
     # Assert
     assert reply == "ok"
-    argv = captured["argv"]
-    assert "ControlMaster=auto" in argv
-    assert any(
-        isinstance(a, str) and a.startswith("ControlPath=") for a in argv
-    )
 
 
 # ---------------------------------------------------------------------------
@@ -391,10 +678,10 @@ def test_network_peer_ssh_curl_argv_includes_control_options(tmp_path, monkeypat
 # ---------------------------------------------------------------------------
 
 
-def test_sac_host_ssh_opts_emits_shell_quoted_options(tmp_path, monkeypatch):
+def test_sac_host_ssh_opts_exit_code_is_zero(tmp_path, env_save_restore):
     # Arrange
-    monkeypatch.setenv("SAC_SSH_CONTROL_DIR", str(tmp_path / "cm"))
-    monkeypatch.delenv("SAC_SSH_CONTROL_MASTER", raising=False)
+    env_save_restore.set("SAC_SSH_CONTROL_DIR", str(tmp_path / "cm"))
+    env_save_restore.delete("SAC_SSH_CONTROL_MASTER")
     from scitex_agent_container.cli_pkg.host_group import host_ssh_opts
 
     # Act
@@ -402,20 +689,73 @@ def test_sac_host_ssh_opts_emits_shell_quoted_options(tmp_path, monkeypatch):
 
     # Assert
     assert result.exit_code == 0
+
+
+def test_sac_host_ssh_opts_output_parses_to_three_opt_pairs(tmp_path, env_save_restore):
+    # Arrange
+    env_save_restore.set("SAC_SSH_CONTROL_DIR", str(tmp_path / "cm"))
+    env_save_restore.delete("SAC_SSH_CONTROL_MASTER")
+    from scitex_agent_container.cli_pkg.host_group import host_ssh_opts
+
+    # Act
+    result = CliRunner().invoke(host_ssh_opts, [])
     parsed = shlex.split(result.output.strip())
+
+    # Assert
     assert parsed[0::2] == ["-o", "-o", "-o"]
+
+
+def test_sac_host_ssh_opts_output_includes_ControlMaster_auto(
+    tmp_path, env_save_restore
+):
+    # Arrange
+    env_save_restore.set("SAC_SSH_CONTROL_DIR", str(tmp_path / "cm"))
+    env_save_restore.delete("SAC_SSH_CONTROL_MASTER")
+    from scitex_agent_container.cli_pkg.host_group import host_ssh_opts
+
+    # Act
+    result = CliRunner().invoke(host_ssh_opts, [])
+    parsed = shlex.split(result.output.strip())
+
+    # Assert
     assert "ControlMaster=auto" in parsed
+
+
+def test_sac_host_ssh_opts_output_includes_ControlPersist_60s(
+    tmp_path, env_save_restore
+):
+    # Arrange
+    env_save_restore.set("SAC_SSH_CONTROL_DIR", str(tmp_path / "cm"))
+    env_save_restore.delete("SAC_SSH_CONTROL_MASTER")
+    from scitex_agent_container.cli_pkg.host_group import host_ssh_opts
+
+    # Act
+    result = CliRunner().invoke(host_ssh_opts, [])
+    parsed = shlex.split(result.output.strip())
+
+    # Assert
     assert "ControlPersist=60s" in parsed
 
 
-def test_sac_host_ssh_opts_prints_empty_line_when_opted_out(monkeypatch):
-    # Arrange
-    monkeypatch.setenv("SAC_SSH_CONTROL_MASTER", "0")
+def test_sac_host_ssh_opts_empty_output_when_opted_out(env_save_restore):
+    # Arrange — empty stdout so `ssh $(sac host ssh-opts) host cmd` is a no-op.
+    env_save_restore.set("SAC_SSH_CONTROL_MASTER", "0")
     from scitex_agent_container.cli_pkg.host_group import host_ssh_opts
 
     # Act
     result = CliRunner().invoke(host_ssh_opts, [])
 
-    # Assert — empty output so `ssh $(sac host ssh-opts) host cmd` works.
-    assert result.exit_code == 0
+    # Assert
     assert result.output.strip() == ""
+
+
+def test_sac_host_ssh_opts_exit_code_zero_when_opted_out(env_save_restore):
+    # Arrange
+    env_save_restore.set("SAC_SSH_CONTROL_MASTER", "0")
+    from scitex_agent_container.cli_pkg.host_group import host_ssh_opts
+
+    # Act
+    result = CliRunner().invoke(host_ssh_opts, [])
+
+    # Assert
+    assert result.exit_code == 0

--- a/tests/scitex_agent_container/_state/test_ssh_control_options.py
+++ b/tests/scitex_agent_container/_state/test_ssh_control_options.py
@@ -31,7 +31,6 @@ from __future__ import annotations
 import shlex
 import stat
 import tempfile
-from pathlib import Path
 
 import pytest
 from click.testing import CliRunner


### PR DESCRIPTION
Fix-forward to clear `tests/develop/test_audit.py::test_audit_all_clean` violations introduced by #218 (ssh ControlMaster fix). Three audit rules were tripping; this PR addresses all three.

## What was failing

```
ERRO: scitex-agent-container: 31 violation(s)
ERRO:   [PA-306 §3 no-mocks]      tests/.../test_ssh_control_options.py — 17× monkeypatch
ERRO:   [PA-307 §3 STX-TQ007]     tests/.../test_ssh_control_options.py — 14× multi-assert
ERRO:   [PA-307 §3 STX-TQ002]     tests/.../test_ssh_control_options.py:352 — missing AAA marker
ERRO:   [PS-204 §2 orphan-test]   tests/.../test_ssh_control_options.py — no matching src file
```

## What changed

1. **PA-306 no-mocks** — `monkeypatch.setenv/delenv/setattr/setitem` removed. Tests now use the project's existing real-subprocess helpers in `tests/scitex_agent_container/_helpers/subprocess_shim.py`:
   - `env_save_restore` — explicit `os.environ` save/restore via fixture.
   - `subprocess_shim` — PATH-installed fake `ssh` script that records its argv to a log. Production code runs **real** `subprocess.run` and `exec`s the shim via the real PATH lookup.
2. **PA-307 STX-TQ007 multi-assert** — 22 multi-assertion tests collapsed into **45 single-assertion tests**; similar-shape checks use `pytest.parametrize`.
3. **PA-307 STX-TQ002 AAA** — added missing `# Act` marker.
4. **PS-204 orphan-test** — extracted `ssh_control_options()` / `ssh_control_options_str()` into a new module `_state/ssh_control_options.py`; `host_config.py` re-exports the symbols so every existing `from ..._state.host_config import ssh_control_options` continues to work unchanged. Test file now has a 1:1 src mirror.

## Test plan

- [x] `pytest tests/scitex_agent_container/_state/test_ssh_control_options.py` → **45 passed**, 6.9s.
- [x] `pytest tests/develop/test_audit.py` audit-python-apis section → `SUCC: no Python API violations`.
- [ ] CI pytest matrix green (this PR).
- [ ] CI audit-project picks up the new src mirror → orphan-test resolved.

## NOT addressed in this PR

These pre-existed on develop and are independent of #218:

- `audit-mcp-tools` internal `TypeError` in `scitex-dev` (`Path(getattr(bridge_pkg, '__file__', None))` — bridge pkg has `__file__=None`). Upstream `scitex-dev` fix needed.
- `SK-301`/`SK-401` skill-budget warnings on `SKILL.md` and `26_credentials-rotation.md`.
- `audit-cli §6a` `SAC_*` env-var prefix policy (8 vars).