### PR TITLE
docs: refresh CLI surface + relocate coverage data out of repo root

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,16 +193,31 @@ sac image status                          # unified dashboard
 sac image snapshot [-o env.json]          # reproducibility capsule
 
 # Account / quota
-sac accounts list / save / delete / switch / watch-quota
+sac accounts list / save / delete / switch        # stored-credential rotation
+sac accounts status                       # one-shot quota snapshot (5h%, 7d%, tier)
+sac accounts sync-live / watch-live       # auto-snapshot live cred on `claude /login`
+sac accounts watch-quota                  # auto-rotate when quota threshold hit
 
 # Network / peers
 sac host list / add / remove / set / probe / exec / validate
-sac peer post-turn AGENT TEXT             # A2A outbound
+sac host ssh-opts                         # print sac's ssh ControlMaster flags (shell-quoted)
+sac host add-peer / list-peers / remove-peer      # cross-host listen-bearer registry
+sac host probe-hub                        # WSL → fleet-hub layered connectivity probe
+sac peer post-turn AGENT TEXT             # A2A outbound (loopback or cross-host)
 sac a2a serve <yamls...>                  # A2A inbound for non-SDK runtimes
 
+# Fleet (peer-aware multi-agent orchestration)
+sac fleet launch  PEER <name>...          # rsync specs to PEER, start each remotely
+sac fleet notify  done|blocker|status --summary "..."   # agent→lead push (ADR-0013)
+
+# Diagnostics / introspection
+sac doctor [--fleet]                      # diagnose agent-spec source drift
+sac subagent get-state                    # Claude Code Agent-tool subagent state
+
 # Misc
+sac installation boot                     # first-time host bootstrap (venv, PATH, cron)
 sac event ingest                          # Claude Code hook event ingestor
-sac db   query / show / clean / migrate   # state.db inspection
+sac db   query / show / clean / export / import / migrate   # state.db inspection
 sac registry reconcile                    # singleton placement reconcile across fleet
 sac --help-recursive                      # full subcommand tree
 ```

--- a/docs/spec-reference.md
+++ b/docs/spec-reference.md
@@ -162,6 +162,8 @@ when `spec.a2a.port` is set) and `GET /agents/<name>/card`
 | Field                       | Type                                  | Description                                                       |
 |-----------------------------|---------------------------------------|-------------------------------------------------------------------|
 | `model`                     | `haiku` \| `sonnet` \| `opus` \| ...  | Claude model                                                      |
+| `account`                   | string                                | Pin this agent to a stored OAuth account (`sac accounts` store-name). Mutually exclusive with `provider`. |
+| `provider`                  | `{ base_url, auth_token_env }`        | Point the SDK session at any Anthropic-compatible endpoint (e.g. DeepSeek). `base_url` is the endpoint; `auth_token_env` is the NAME of the host env var holding the key (never the key). Mutually exclusive with `account`; relaxes the `claude-*` model-alias check. See ADR-0011. |
 | `session`                   | `continue` \| `new-session` \| `resume`| Session strategy (default `continue` — safe fallback). Legacy aliases `continue-or-new`, `new` accepted |
 | `resume_id`                 | string                                | Explicit session UUID for `session: resume`                       |
 | `continue_max_age_minutes`  | int                                   | Only resume if session.jsonl is newer than N minutes              |

--- a/docs/sphinx/spec-reference.md
+++ b/docs/sphinx/spec-reference.md
@@ -162,6 +162,8 @@ when `spec.a2a.port` is set) and `GET /agents/<name>/card`
 | Field                       | Type                                  | Description                                                       |
 |-----------------------------|---------------------------------------|-------------------------------------------------------------------|
 | `model`                     | `haiku` \| `sonnet` \| `opus` \| ...  | Claude model                                                      |
+| `account`                   | string                                | Pin this agent to a stored OAuth account (`sac accounts` store-name). Mutually exclusive with `provider`. |
+| `provider`                  | `{ base_url, auth_token_env }`        | Point the SDK session at any Anthropic-compatible endpoint (e.g. DeepSeek). `base_url` is the endpoint; `auth_token_env` is the NAME of the host env var holding the key (never the key). Mutually exclusive with `account`; relaxes the `claude-*` model-alias check. See ADR-0011. |
 | `session`                   | `continue` \| `new-session` \| `resume`| Session strategy (default `continue` — safe fallback). Legacy aliases `continue-or-new`, `new` accepted |
 | `resume_id`                 | string                                | Explicit session UUID for `session: resume`                       |
 | `continue_max_age_minutes`  | int                                   | Only resume if session.jsonl is newer than N minutes              |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ slurm = [
     "scitex-hpc>=0.6.2",
 ]
 dev = [
-    "scitex-dev>=0.11.7",
+    "scitex-dev>=0.14.0",  # tests/results/ accepted as a known tests subdir (PS-302)
     # PS210: tests import scitex_hpc unguarded, so [dev] must include it
     # (otherwise `pip install -e .[dev]` can't run the full suite).
     "scitex-hpc>=0.6.2",

--- a/src/scitex_agent_container/_skills/scitex-agent-container/04_cli-reference.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/04_cli-reference.md
@@ -80,16 +80,27 @@ sac image switch X
 | Command | Purpose |
 |---|---|
 | `sac host list / add / remove / set / probe / exec / validate` | Local hostname + peer machine routing (ssh round-trip / exec on PEER). |
+| `sac host add-peer / list-peers / remove-peer` | Cross-host `sac listen` bearer registry (who may push into this host). |
+| `sac host ssh-opts` | Print sac's ssh ControlMaster flags shell-quoted — use as `ssh $(sac host ssh-opts) host cmd`. |
+| `sac host probe-hub` | WSL → fleet-hub layered connectivity probe (DNS, gateway, TCP, HTTPS). |
 | `sac peer post-turn AGENT TEXT` | Outbound A2A — POST a turn to another agent's `/v1/turn`. |
 | `sac peer resolve-url AGENT` | Print the URL `peer post-turn` would target. |
 | `sac a2a serve <yamls...>` | A2A inbound HTTP server (sidecar mode for non-SDK runtimes). For `runtime: apptainer` agents the runner hosts `POST /v1/turn` itself. |
-| `sac host probe-hub` | WSL → fleet-hub layered connectivity probe (DNS, gateway, TCP, HTTPS). |
+| `sac a2a doctor AGENT` | Probe an agent's A2A AgentCard endpoint and report health. |
+
+## Fleet (`sac fleet`)
+
+| Command | Purpose |
+|---|---|
+| `sac fleet launch PEER <name>...` | Rsync each agent's spec to PEER and run `sac agents start <name>` there. |
+| `sac fleet notify done\|blocker\|status --summary "..."` | Agent→lead push channel (ADR-0013 Phase 1) — POST a typed event to the lead's `sac listen` inbox. `--detail`, `--conversation-id`, `--dry-run`, `--json`. |
 
 ## State database / registry / events
 
 | Command | Purpose |
 |---|---|
 | `sac db query / show / clean / migrate / tick` | Inspect and maintain the sac state database (`state.db`). `db clean` replaces the legacy `registry clean`. |
+| `sac db export / import` | Dump state.db rows as a JSON delta / ingest a dump (cross-host registry sync). |
 | `sac registry reconcile` | Reconcile singleton agent placement across the fleet. |
 | `sac event ingest` | Append a Claude Code hook event to the per-agent ring buffer. |
 
@@ -105,6 +116,8 @@ sac image switch X
 
 | Command | Purpose |
 |---|---|
+| `sac doctor [--fleet]` | Diagnose agent-spec source drift (locally, or `--fleet` across peers). |
+| `sac subagent get-state` | Pure state data for every matching Claude Code Agent-tool subagent (Type 2). |
 | `sac mcp list-tools` | Local MCP introspection (no MCP server bundled — sac agents spawn their own via `to_home/.mcp.json`). |
 | `sac skills list / get` | Bundled agent-facing skills. |
 | `sac list-python-apis` | Enumerate the public Python API. |

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,10 +20,14 @@ from pathlib import Path
 
 _PROJECT_ROOT = Path(__file__).resolve().parent.parent
 
-# Pin coverage's data file at the repo root and point process_startup
-# at our pyproject so child interpreters configure themselves correctly.
+# Pin coverage's data file under tests/results/coverage/ (keeps the repo
+# root clean) and point process_startup at our pyproject so child
+# interpreters configure themselves correctly. COVERAGE_FILE is absolute
+# so every child writes here regardless of its working directory.
+_COVERAGE_DIR = _PROJECT_ROOT / "tests" / "results" / "coverage"
+_COVERAGE_DIR.mkdir(parents=True, exist_ok=True)
 os.environ["COVERAGE_PROCESS_START"] = str(_PROJECT_ROOT / "pyproject.toml")
-os.environ["COVERAGE_FILE"] = str(_PROJECT_ROOT / ".coverage")
+os.environ["COVERAGE_FILE"] = str(_COVERAGE_DIR / ".coverage")
 
 
 def _ensure_subprocess_coverage_shim() -> None:


### PR DESCRIPTION
Two related housekeeping changes.

## 1. Docs refresh (`docs:` commit)
README + skills CLI reference had drifted from the current command surface. Brought them current:
- `fleet` group (`launch` / `notify` — the ADR-0013 agent→lead push)
- `host ssh-opts`, peer-bearer commands (`add-peer`/`list-peers`/`remove-peer`), `probe-hub`
- `accounts status` / `sync-live` / `watch-live`
- `doctor`, `subagent get-state`, `db export`/`import`
- `spec.claude.account` (OAuth pin) and `spec.claude.provider` (DeepSeek/Anthropic-compatible backend, ADR-0011) documented in `spec-reference` (top-level + sphinx copy)

Sphinx build verified locally.

## 2. Coverage data relocation (`test:` commit)
Parallel + subprocess coverage was dropping `.coverage.<host>.<pid>.*` files into the repo **root** (~15 stray files). `conftest.py` now pins `COVERAGE_FILE` under `tests/results/coverage/` (absolute path, so child processes write there regardless of CWD). Root stays clean.

Depends on **scitex-dev >= 0.14.0** (already on PyPI), which makes `tests/results/` a recognized `tests/` subdir (PS-302). Pin bumped accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)