### PR TITLE
docs(readme): add Models section

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,18 @@ sac agents delete hello-agent-1 hello-agent-2 -y
 
 [`examples/`](examples/) walks through the runtime in 15 lessons (image build, sandbox/update/freeze, versioning, run/send/tail, logs/exec, stop/remove, binds, env+user, writing your first spec.yaml, to_home/, A2A endpoint, health+restart, multi-host, debugging). Run them read-only with `bash examples/00_run_all.sh`, or `--apply` to execute the mutating ones.
 
+### Models
+
+Pick the model per agent under `spec.claude.model`:
+
+| Alias    | Model (current)             | Use for                         |
+|----------|-----------------------------|---------------------------------|
+| `opus`   | Claude Opus 4.7             | Hardest reasoning; slowest      |
+| `sonnet` | Claude Sonnet 4.6 *(default)* | Balanced capability and speed |
+| `haiku`  | Claude Haiku 4.5            | Fast, cheap, light tasks        |
+
+Aliases auto-track the latest version of each family; append `[1m]` for the 1M-token context window (`opus[1m]`, `sonnet[1m]`). Pin an exact build with a full ID like `claude-opus-4-7` or `claude-haiku-4-5-20251001`. To target a non-Anthropic, Anthropic-compatible backend (e.g. DeepSeek), use `spec.claude.provider` instead. **[Full model reference →](docs/spec-reference.md)**
+
 ## How it works
 
 `scitex-agent-container` (`sac`) materializes a `spec.yaml` into a long-lived, externally addressable Claude agent:

--- a/docs/adr/0012-orchestration-tool-develops-locally.md
+++ b/docs/adr/0012-orchestration-tool-develops-locally.md
@@ -1,0 +1,46 @@
+# ADR-0012: Orchestration tooling develops locally; library packages on Spartan
+
+## Status
+Accepted (2026-05-27)
+
+## Context
+The `proj-scitex-*` development agents run on Spartan (a SLURM compute
+reservation, e.g. bm001) so heavy work — pytest matrices, builds — runs
+on compute rather than the lead laptop.
+
+`scitex-agent-container` (sac) is different in kind: it is the tool that
+**launches and drives** those agents (`sac agents start`, `sac host exec`,
+the A2A `/v1/turn` surface). Developing and testing sac therefore means
+launching agents and interacting with them. Doing that from inside a
+Spartan apptainer container would mean an agent launching agents **inside
+its own container** — nested containers, which are fragile and hit the
+sandbox bind/permission limits that already constrain in-container agents.
+
+The operator raised a consistency concern: if every other `proj-scitex-*`
+agent lives on Spartan, why is this one local? Inconsistency is a cost
+(it changes where one edits, and must be justified).
+
+## Decision
+sac (the fleet-orchestration tool) is developed on the **local lead host**
+(the machine the fleet originates from). All other library / compute
+packages (`scitex-io`, `scitex-gen`, `scitex-stats`, ...) are developed on
+**Spartan**.
+
+Rule: **orchestration tooling → local lead host; library / compute
+packages → Spartan.**
+
+## Consequences
+- sac development can launch and drive real agents to test itself without
+  container nesting.
+- The sync workflow is **unchanged**: GitHub `develop` remains the only
+  sync substrate (local edits push to `develop`; Spartan pulls). Only the
+  *edit location* differs, not the sync model — so consistency of workflow
+  is preserved.
+- This is one **principled** exception to "all `proj-*` agents on Spartan,"
+  justified by the orchestration-at-origin requirement, not an ad-hoc
+  placement. A second tool that orchestrates the fleet would follow the
+  same rule.
+
+## Notes
+Surfaced 2026-05-26/27 while diagnosing a Spartan home-quota wedge; the
+operator asked for this decision to be recorded rather than left implicit.


### PR DESCRIPTION
Adds a **Models** subsection to the top-level README (Getting Started area), so model selection is visible without digging into the spec reference.

- Alias table: `opus` → Opus 4.7, `sonnet` → Sonnet 4.6 (**default**), `haiku` → Haiku 4.5
- `[1m]` 1M-context suffix, full versioned IDs, and the `spec.claude.provider` override for non-Anthropic backends
- Links to the full model reference in `docs/spec-reference.md`

Mirrors the Available models section added to the spec reference in #227.

🤖 Generated with [Claude Code](https://claude.com/claude-code)