### PR TITLE
docs(skills): document spec.claude fields (account + provider)

### DIFF
--- a/src/scitex_agent_container/_skills/scitex-agent-container/01_config-v3.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/01_config-v3.md
@@ -66,6 +66,21 @@ spec:
     max_retries: 3
 ```
 
+### `spec.claude` fields
+
+| Field | Type | Purpose |
+|---|---|---|
+| `model` | alias or full ID | `opus` / `sonnet` (default) / `haiku` (+ `[1m]` for 1M context), or a full ID like `claude-opus-4-7`. May also sit at `spec.model` (top level). Abbreviated IDs missing version digits (`claude-opus[1m]`) are rejected at validate-time. |
+| `session` | enum | `continue-or-new` (default) \| `continue` \| `new` \| `resume` |
+| `resume_id` | string | Explicit session UUID for `session: resume` |
+| `continue_max_age_minutes` | int | Only resume if `session.jsonl` is newer than N minutes |
+| `flags[]` | list | Extra flags appended to the `claude` invocation |
+| `channels[]` | list | MCP push channels (`server:<name>` / `plugin:<id>@<v>`) |
+| `auto_accept` | bool (default `true`) | Auto-confirm TUI permission prompts |
+| `account` | string | Pin this agent to a stored OAuth account (`sac accounts` store-name). Credentials are **boot-copied** into the agent state dir, not live-bound. Mutually exclusive with `provider`. See [26_credentials-rotation.md](26_credentials-rotation.md). |
+| `provider` | `{ base_url, auth_token_env }` | Point the SDK at any Anthropic-compatible backend (e.g. DeepSeek). `base_url` is the endpoint; `auth_token_env` is the **name** of the host env var holding the key (never the key value). Mutually exclusive with `account`; relaxes the `claude-*` model-alias check. See ADR-0011. |
+| `raw_options` | dict | Escape hatch — splatted into `ClaudeAgentOptions(**raw_options)` |
+
 ## Auto-derived fields
 
 The v3 loader fills in defaults from the agent name (parent-directory stem):


### PR DESCRIPTION
Closes the skills-freshness gap found while auditing `_skills/scitex-agent-container/` against current code.

`01_config-v3.md` documented only `flags` and `session`. Adds a full `spec.claude` reference table including the two fields that shipped in v0.21 but were undocumented in any skill leaf:
- **`account`** — boot-copied OAuth account pin (`sac accounts` store-name)
- **`provider`** — `{ base_url, auth_token_env }` for DeepSeek / Anthropic-compatible backends (ADR-0011)

plus `model`, `resume_id`, `continue_max_age_minutes`, `channels`, `auto_accept`, `raw_options`.

The CLI-reference skills (`04_cli-reference.md`, `10_cli.md`) and `20_env-vars.md` were checked and are already current. `audit-skills` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)