### PR TITLE
fix(mcp): account tools call renamed accounts subcommands

### DIFF
--- a/src/scitex_agent_container/_mcp/_tools/_account.py
+++ b/src/scitex_agent_container/_mcp/_tools/_account.py
@@ -1,4 +1,4 @@
-"""``sac account / sac quota`` tools (F-CS15) — Python API + MCP wrappers."""
+"""``sac accounts`` tools (F-CS15) — Python API + MCP wrappers."""
 
 from __future__ import annotations
 
@@ -9,17 +9,19 @@ from ._helpers import invoke_cli_text
 
 def account_show() -> dict[str, Any]:
     """Show the current Anthropic account binding (Pro/Max OAuth
-    vs API key, balance hints if available). Mirrors ``sac account``."""
-    return invoke_cli_text(["account"])
+    vs API key, quota snapshot, email + tier). Mirrors
+    ``sac accounts status``."""
+    return invoke_cli_text(["accounts", "status"])
 
 
 def quota_watch(name: str | None = None) -> dict[str, Any]:
-    """Watch per-agent token quota. Mirrors ``sac quota watch``.
+    """Watch per-agent token quota and auto-rotate on threshold.
+    Mirrors ``sac accounts watch-quota``.
 
-    ``quota watch`` is interactive in the CLI; running through
+    ``watch-quota`` is interactive in the CLI; running through
     ``CliRunner`` returns the first poll's snapshot then exits.
     """
-    argv = ["quota", "watch"]
+    argv = ["accounts", "watch-quota"]
     if name:
         argv.append(name)
     return invoke_cli_text(argv)


### PR DESCRIPTION
The MCP `account_show` / `quota_watch` tools invoked CLI subcommands that were renamed and no longer exist, so both tools failed at runtime:
- `["account"]` → `["accounts", "status"]`
- `["quota", "watch"]` → `["accounts", "watch-quota"]`

Salvaged from #216 (whose skills edits are superseded by #230). 2 MCP account tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)