### PR TITLE
docs(skills): trim SKILL.md to restore SK-301 budget headroom

### DIFF
--- a/src/scitex_agent_container/_skills/scitex-agent-container/SKILL.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: scitex-agent-container
 description: |
-  [WHAT] Declarative YAML AI-agent lifecycle — define an agent in one `spec.yaml` (apptainer image, model, MCP, mounts/env, health, restart, A2A port, remote host); `sac agents start` runs it as a long-lived Claude SDK session inside Apptainer, with A2A inbound (`POST /v1/turn`), SSH remote deploy, and JSON status.
-  [WHEN] Launching/managing a Claude Code agent or fleet, running an agent on a remote host, wiring MCP into an agent, talking to one over A2A, or any mention of `sac agents start`, `scitex-agent-container`, `spec.yaml`, fleet head/worker.
-  [HOW] `pip install scitex-agent-container` then `sac agents start <name>` (CLI) or `import scitex_agent_container`.
+  [WHAT] Declarative YAML AI-agent lifecycle — define an agent in one `spec.yaml` (apptainer image, model, MCP, mounts/env, health, restart, A2A port, remote host); `sac agents start` runs it as a long-lived Claude SDK session inside Apptainer, with A2A inbound (`POST /v1/turn`), SSH remote deploy, JSON status.
+  [WHEN] Launching/managing a Claude Code agent or fleet, running one on a remote host, wiring MCP, talking over A2A, or any mention of `sac agents start`, `scitex-agent-container`, `spec.yaml`, fleet head/worker.
+  [HOW] `pip install scitex-agent-container`, then `sac agents start <name>` or `import scitex_agent_container`.
 tags: [scitex-agent-container]
 primary_interface: cli
 interfaces:
@@ -20,19 +20,18 @@ interfaces:
 
 Declarative lifecycle management for AI coding agents (Claude Code):
 define an agent in `spec.yaml`, launch it as a long-lived Claude SDK
-session inside Apptainer (local or remote via SSH), and observe it
-through `sac agents list`/`tail`/`health`.
+session inside Apptainer (local or remote via SSH), observe via
+`sac agents list`/`tail`/`health`.
 
 ## What the package ships
 
 | Surface | Location |
 |---|---|
-| Python API | `scitex_agent_container` (`AgentConfig`, `load_config`, `validate_config`, `Registry`; submodules `agent.*`, `db.*`, `host.*`, `peer.*`) |
+| Python API | `scitex_agent_container` (`AgentConfig`, `load_config`, `validate_config`, `Registry`; `agent.*`/`db.*`/`host.*`/`peer.*`) |
 | CLI | `scitex-agent-container`, `sac` — see [10_cli.md](10_cli.md) |
 | MCP servers | None bundled — agents spawn their own via `to_home/.mcp.json` |
-| Runtimes | `runtimes/claude_session.py` (SDK-native, default); apptainer container build helpers |
-| Observability | See [13_observability.md](13_observability.md) |
-| Config format | v3 `scitex-agent-container/v3` only — v2 is rejected |
+| Runtimes | `runtimes/claude_session.py` (SDK-native, default) + apptainer build helpers |
+| Config format | v3 `scitex-agent-container/v3` only — v2 rejected |
 
 ## Sub-skills
 
@@ -41,31 +40,31 @@ through `sac agents list`/`tail`/`health`.
 - [02_quick-start.md](02_quick-start.md) — first agent in 30 seconds
 - [03_python-api.md](03_python-api.md) — programmatic surface (`agent.start`, `peer.post_turn`, ...)
 - [04_cli-reference.md](04_cli-reference.md) — every `sac` subcommand
-- [05_mcp-tools.md](05_mcp-tools.md) — `sac mcp` server, tool inventory, install snippet (F-CS15)
-- [06_http-api.md](06_http-api.md) — `POST /v1/turn` wire format (set `spec.a2a.port` to enable)
+- [05_mcp-tools.md](05_mcp-tools.md) — `sac mcp` server, tool inventory, install snippet
+- [06_http-api.md](06_http-api.md) — `POST /v1/turn` wire format (`spec.a2a.port` enables)
 
 ### Core
 - [01_config-v3.md](01_config-v3.md) — v3 config format (current); v2+`metadata.name` rejected
-- [02_multiplexer.md](02_multiplexer.md) — vestigial for agents (SDK runtime, no tmux); lead-only tmux wrap
-- [03_auto-accept.md](03_auto-accept.md) — Modular prompt handlers
-- [04_resource-management.md](04_resource-management.md) — Resource management
-- [05_resource-heartbeat.md](05_resource-heartbeat.md) — Resource heartbeat
-- [06_env-injection-ports.md](06_env-injection-ports.md) — Four env-injection ports + decision tree
-- [07_a2a-protocol.md](07_a2a-protocol.md) — Native A2A protocol (`sac a2a serve`)
-- [07_a2a-protocol-extension-fields.md](07_a2a-protocol-extension-fields.md) — `x-scitex-agent-container.*` AgentCard extension fields
-- [08_templates.md](08_templates.md) — Six pattern templates + examples
+- [02_multiplexer.md](02_multiplexer.md) — vestigial for agents (SDK runtime); lead-only tmux wrap
+- [03_auto-accept.md](03_auto-accept.md) — modular prompt handlers
+- [04_resource-management.md](04_resource-management.md) — resource management
+- [05_resource-heartbeat.md](05_resource-heartbeat.md) — resource heartbeat
+- [06_env-injection-ports.md](06_env-injection-ports.md) — four env-injection ports + decision tree
+- [07_a2a-protocol.md](07_a2a-protocol.md) — native A2A protocol (`sac a2a serve`)
+- [07_a2a-protocol-extension-fields.md](07_a2a-protocol-extension-fields.md) — `x-scitex-agent-container.*` AgentCard fields
+- [08_templates.md](08_templates.md) — six pattern templates + examples
 - [14_claude-session-state.md](14_claude-session-state.md) — state-dir layout, auth precedence, `sdk_session` status, supervisor
-- [15_claude-session.md](15_claude-session.md) — the claude-session SDK runner (inside the apptainer SIF) + `POST /v1/turn` inbound
-- [16_claude-session-migration.md](16_claude-session-migration.md) — historical: claude-code → SDK migration (apptainer-only now)
+- [15_claude-session.md](15_claude-session.md) — claude-session SDK runner (inside the SIF) + `POST /v1/turn` inbound
+- [16_claude-session-migration.md](16_claude-session-migration.md) — historical: claude-code → SDK migration
 - [17_inbound-turn-endpoint.md](17_inbound-turn-endpoint.md) — `POST /v1/turn` wire format + sidecar replacement
-- [18_full-agent-delegation.md](18_full-agent-delegation.md) — Delegate to another *full* Claude Code agent (vs Task subagent)
-- [19_full-agent-troubleshooting.md](19_full-agent-troubleshooting.md) — Deep-dives: stuck-peer recovery, reaper pattern, hard/soft skills
+- [18_full-agent-delegation.md](18_full-agent-delegation.md) — delegate to another *full* agent (vs Task subagent)
+- [19_full-agent-troubleshooting.md](19_full-agent-troubleshooting.md) — stuck-peer recovery, reaper pattern, hard/soft skills
 
 ### Workflows
 - [10_cli.md](10_cli.md) — CLI commands and Python API
 - [11_remote-deploy.md](11_remote-deploy.md) — SSH deployment, src files, venv
 - [12_wsl-connectivity.md](12_wsl-connectivity.md) — WSL connectivity notes
-- [24_image-build.md](24_image-build.md) — apptainer `.sif` build/rebuild, `@develop` pin, rebuild-to-ship runner/channel changes (gotcha)
+- [24_image-build.md](24_image-build.md) — apptainer `.sif` build/rebuild, `@develop` pin, rebuild-to-ship gotcha
 - [25_claude-setup-delivery.md](25_claude-setup-delivery.md) — `to_home`→`$HOME` 1:1 mirror, overlay/`--home`, `--settings` hook load
 - [26_credentials-rotation.md](26_credentials-rotation.md) — OAuth model: per-account symlinks, `:rw` bind, preflight, COPY caveat
 - [27_credentials-relogin.md](27_credentials-relogin.md) — verified re-login flow (tmux code-paste) + 401-recovery design
@@ -80,8 +79,8 @@ through `sac agents list`/`tail`/`health`.
 
 - [20_env-vars.md](20_env-vars.md) — `SCITEX_*` env vars read at runtime
 - [21_cli-startup-budget.md](21_cli-startup-budget.md) — keep `sac --help` < 500 ms via LazyGroup
-- [22_host-passthrough.md](22_host-passthrough.md) — `spec.mounts` + `spec.user` + `spec.env` for SDK agents that need host filesystem / git / gh
-- [23_telegram-integration.md](23_telegram-integration.md) — Telegram fold (Phase 2+3): `_telegram/` bridge, six `telegram_*` MCP tools, channel-push inbound, lead-only auth gate, per-bot-token flock singleton
+- [22_host-passthrough.md](22_host-passthrough.md) — `spec.mounts`/`spec.user`/`spec.env` for agents needing host fs / git / gh
+- [23_telegram-integration.md](23_telegram-integration.md) — Telegram fold: `_telegram/` bridge, `telegram_*` MCP tools, channel-push inbound, lead-only auth, per-token singleton
 
 ## 30-second start
 
@@ -90,7 +89,7 @@ pip install scitex-agent-container
 # Each agent lives in its own dir; the dir name is the agent name.
 mkdir -p ~/.scitex/agent-container/agents/my-agent
 $EDITOR ~/.scitex/agent-container/agents/my-agent/spec.yaml   # see 01_config-v3.md
-sac agents start my-agent                       # daemon by default; --foreground streams stdio
-sac agents list my-agent --json                 # single-agent status view
-sac agents tail my-agent                         # render session.jsonl transcript
+sac agents start my-agent          # daemon by default; --foreground streams stdio
+sac agents list my-agent --json    # status view
+sac agents tail my-agent           # render session.jsonl transcript
 ```


### PR DESCRIPTION
SKILL.md was 6080B vs the 6144B budget (64B spare), so any PR adding a sub-skill index line tripped `SK-301` and failed the audit gate. Trimmed verbose descriptions (every entry kept) to 5721B (~420B headroom) to unblock #186/#214/#206.

🤖 Generated with [Claude Code](https://claude.com/claude-code)