### PR TITLE
release: bump to v0.21.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,47 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.21.3] — 2026-05-28
+
+### Added
+- **feat(comms): stage 1 — symmetric federated `comms_nodes`** (ADR-0014,
+  #234). New `comms_nodes` table (globally-unique `name` → `(host, a2a_port)`
+  routing tuple) added to `KNOWN_TABLES` so `sac db export/import` carries
+  it. `resolve_node_host` falls through to `comms_nodes` after the
+  `instances` lookup, so a node living on another host's listen (e.g.
+  `lead` on `ywata-note-win`) resolves correctly from a peer host.
+  Symmetric ssh-pull anti-entropy via new `sac registry sync
+  [--from PEER | --to PEER | --all] [--dry-run]` reusing the existing
+  `sac db export/import` primitive over the operator's `peers:` ssh
+  trust. Listen-startup hook registers the host's operator identity
+  (from `LeadConfig`) into local `comms_nodes`; agent-lifecycle hook
+  writes/tombstones the agent's row alongside the `instances` row.
+  Conflict policy: name globally unique, fail-loud (`CommsNodeConflictError`)
+  on `(host, a2a_port)` mismatch between sources. Adds `sac db export
+  --tables TABLE[,TABLE...]` filter.
+- **feat(comms): stage 2 — cross-host push via ssh-transport selector +
+  ACL e2e** (ADR-0015, #236). `_node_channel._forward_to_remote` now
+  selects per-host: ssh-curl when `target_host` is a member of
+  `host_config.peers` (including `spartan-*` glob), HTTP otherwise.
+  Generalized `_network._ssh_curl._post_via_ssh_curl(host, port, path,
+  body, bearer, timeout_s)` helper shared by `/v1/turn` and
+  `/agents/<name>/message:send` — same argv shape, ControlMaster reuse,
+  body via ssh-stdin into `curl -d @-`. Receiver-side ACL already
+  correct (admin-bearer path → `metadata.from_agent` honoured →
+  `has_grant` checked against the **receiver's** local `comms_grants`).
+  Closes the structural WAN gap that blocked Spartan-agent → lead push.
+  No-mocks ssh-shim fixture (`tests/.../_helpers/ssh_http_shim.py`)
+  installs a real `ssh` binary on `$PATH` that performs an in-process
+  `httpx.post` against the destination loopback listen — substitutes
+  the ssh tunnel without mocking subprocess. Stage 2 added 17 NM+TQ-
+  compliant tests (5 happy-path e2e + 12 error-path); codecov on the
+  diff landed at 87.50%.
+
+### Fixed
+- **docs(changelog): drop orphan `>>>>>>> origin/develop` merge marker**
+  that survived a prior develop→main resolution and rendered as raw
+  conflict text inside the v0.21.1 entry.
+
 ## [0.21.2] — 2026-05-28
 
 ### Added
@@ -74,7 +115,6 @@ versioning follows [SemVer](https://semver.org/).
   "SSH connection multiplexing". Failure mode is fall-through: if the
   control dir can't be created (read-only mount, ENOSPC) the helper
   returns `[]` and ssh argv stays byte-identical to pre-patch.
->>>>>>> origin/develop
 
 ## [0.21.0] — 2026-05-25
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-agent-container"
-version = "0.21.2"
+version = "0.21.3"
 description = "Declarative YAML-based framework for defining, managing, and orchestrating AI coding agent instances"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/src/scitex_agent_container/containers/apptainer-base.def
+++ b/src/scitex_agent_container/containers/apptainer-base.def
@@ -143,7 +143,7 @@ From: ubuntu:24.04
         https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-musl.tgz \
         | tar xz -C /opt/cargo/bin/
     chmod +x /opt/cargo/bin/cargo-binstall
-    cargo binstall --no-confirm --force sd dust
+    cargo binstall --no-confirm --force sd du-dust
     rm -rf /opt/cargo/registry /opt/cargo/git
 
     # ---- 4a. yq — pulled as a static binary from mikefarah/yq --------
@@ -199,7 +199,7 @@ From: ubuntu:24.04
     export PATH=/root/.local/bin:/usr/local/bin:$PATH
     uv pip install --python /opt/venv-sac/bin/python \
         "claude-agent-sdk==0.1.72" \
-        "git+https://github.com/ywatanabe1989/scitex-agent-container.git@develop"
+        "git+https://github.com/ywatanabe1989/scitex-agent-container.git@main"
 
     # Surface the SDK's bundled claude CLI on PATH so humans can
     # `apptainer shell` and run `claude` interactively, and so that

--- a/src/scitex_agent_container/containers/apptainer-proxy.def
+++ b/src/scitex_agent_container/containers/apptainer-proxy.def
@@ -62,7 +62,7 @@ From: ubuntu:24.04
     # fails with ModuleNotFoundError. Pin to develop until proxy lands
     # in a release.
     python3 -m pip install --no-cache-dir --break-system-packages \
-        "git+https://github.com/ywatanabe1989/scitex-agent-container.git@develop"
+        "git+https://github.com/ywatanabe1989/scitex-agent-container.git@main"
 
     # Convenience symlink — same rationale as apptainer-base.def: many
     # tools hard-code `python` rather than `python3`.

--- a/src/scitex_agent_container/containers/apptainer-scitex.def
+++ b/src/scitex_agent_container/containers/apptainer-scitex.def
@@ -57,7 +57,7 @@ From: ./sac-base.sif
             pytest pytest-cov \
             claude-agent-sdk \
             "scitex[all]" \
-            "git+https://github.com/ywatanabe1989/scitex-agent-container.git@develop"
+            "git+https://github.com/ywatanabe1989/scitex-agent-container.git@main"
     else
         /opt/venv-sac/bin/pip install --no-cache-dir --upgrade \
             pip setuptools wheel
@@ -67,9 +67,9 @@ From: ./sac-base.sif
             pytest pytest-cov \
             claude-agent-sdk \
             "scitex[all]" \
-            "git+https://github.com/ywatanabe1989/scitex-agent-container.git@develop"
+            "git+https://github.com/ywatanabe1989/scitex-agent-container.git@main"
     fi
-    # Pin a specific sac release by editing the @develop above to @v0.14.0
+    # Pin a specific sac release by editing the @main above to @v0.14.0
     # (or whatever tag), then ``sac image build scitex -y`` again.
 
 %environment


### PR DESCRIPTION
## Summary

PATCH release v0.21.3 — cross-host A2A comms (stage 1 + stage 2 of the converged plan).

- **#234** (ADR-0014) — stage 1: symmetric federated `comms_nodes` table. `resolve_node_host` falls through to it after `instances`; new `sac registry sync [--from PEER | --to PEER | --all]` reuses the existing `sac db export/import` primitive over ssh-pull anti-entropy; listen-startup + agent-lifecycle hooks register/tombstone rows; fail-loud `CommsNodeConflictError` on `(host, port)` mismatch between sources; `sac db export --tables TABLE[,TABLE...]` filter added.
- **#236** (ADR-0015) — stage 2: cross-host push via ssh-transport selector keyed on `host_config.peers` membership. Generalized `_post_via_ssh_curl(host, port, path, body, bearer, timeout_s)` helper shared with `/v1/turn`. Receiver-side ACL grants honored end-to-end via no-mocks ssh-shim tests (17 NM+TQ-compliant tests, codecov diff 87.50%). Closes the structural WAN gap blocking Spartan-agent → lead push.

### Drive-by

- `CHANGELOG.md`: dropped orphan `>>>>>>> origin/develop` merge marker that survived a prior resolution inside the v0.21.1 entry. Surfaced under v0.21.3 `### Fixed`.

## What's in this commit

- `pyproject.toml`: `0.21.2 → 0.21.3`
- `CHANGELOG.md`: v0.21.3 entry (Added: stages 1+2; Fixed: orphan marker)
- `__version__` in `src/scitex_agent_container/__init__.py` is dynamic (read from installed metadata, or pyproject.toml fallback) — no hardcoded bump needed there.

## Post-merge

Tag `v0.21.3` retagged onto the merge commit (not the prep commit), then pushed. On-tag workflow `pypi-publish-and-github-release-on-tag.yml` auto-publishes PyPI + GH Release.

## CI

Standard gates apply: pytest matrix py3.{11,12,13}, ruff, scitex-dev-quality-audit (NM+TQ), codecov/patch, import-smoke, sphinx, RTD, CLA.