### PR TITLE
feat(base): bundle apptainer for sac-from-sac nested launch (operator-greenlit 2026-05-28)

### DIFF
--- a/src/scitex_agent_container/containers/apptainer-base.def
+++ b/src/scitex_agent_container/containers/apptainer-base.def
@@ -93,6 +93,30 @@ From: ubuntu:24.04
     apt-get update
     apt-get install -y --no-install-recommends gh
 
+    # ---- 2a. Apptainer (for inside-SIF nested launch) -------------------
+    # Bundled so sac-from-sac flows (clew -> cohort capsule spawn) work
+    # without needing a host bind. Per operator decision 2026-05-28 (msg
+    # 6704: SIF-bundle preferred over host-bind / upstream conditional
+    # bypass). Spartan's host `which apptainer` is a 1KB bash shim that
+    # requires `module` (Lmod) -- not available in the container -- so
+    # the bind approach was infeasible.
+    #
+    # Unprivileged user-namespace mode only (no setuid in nested SIF);
+    # `--fakeroot` requires `uidmap` for newuidmap/newgidmap.
+    # squashfs-tools for SIF read.
+    #
+    # Apptainer is NOT in Ubuntu 24.04 noble main/universe (verified
+    # 2026-05-28 against packages.ubuntu.com); the only canonical
+    # distribution channel is the official PPA `ppa:apptainer/ppa`
+    # (see apptainer.org/docs/admin/main/installation.html). We use
+    # `add-apt-repository` from software-properties-common, which is
+    # the path the upstream install doc prescribes verbatim.
+    apt-get install -y --no-install-recommends software-properties-common
+    add-apt-repository -y ppa:apptainer/ppa
+    apt-get update
+    apt-get install -y --no-install-recommends \
+        apptainer uidmap squashfs-tools
+
     # ---- 3. Node.js + npm globals --------------------------------------
     curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
     apt-get install -y --no-install-recommends nodejs
@@ -226,7 +250,7 @@ From: ubuntu:24.04
 %labels
     org.scitex.layer base
     org.scitex.runtime apptainer
-    org.scitex.contains "git gh node npm rustc cargo fd bat eza rg tree jq yq delta gdu sd dust uv pipx mermaid prettier eslint jsonlint"
+    org.scitex.contains "git gh node npm rustc cargo fd bat eza rg tree jq yq delta gdu sd dust uv pipx mermaid prettier eslint jsonlint apptainer"
 
 %help
     scitex-agent-container :base layer.


### PR DESCRIPTION
## Summary

Patches `src/scitex_agent_container/containers/apptainer-base.def` to bundle `apptainer` (+ `uidmap`, `squashfs-tools`) into the `:base` SIF so the sac-from-sac flow (clew agent inside SIF spawning cohort capsules) can call `apptainer` directly from within the container, without needing a host-bind.

A new `## 2a. Apptainer (for inside-SIF nested launch)` section is inserted right after `## 2. GitHub CLI`, mirroring the GitHub CLI section's pattern (apt-get based, idempotent, non-interactive).

The `org.scitex.contains` label also gains `apptainer` for discoverability.

## Operator decision

Greenlit 2026-05-28 (Telegram msg 6700 / 6704). The SIF-bundle path was chosen over two alternatives:

1. **Host-bind** — *infeasible*. Spartan's `which apptainer` resolves to a 1KB bash shim that requires `module` (Lmod), and Lmod is not available inside the container.
2. **Upstream conditional preflight bypass** — *deferred*. More invasive than the bundle, no clear win.

## Why the PPA

`apptainer` is **not** in Ubuntu 24.04 noble main/universe (verified 2026-05-28 against `packages.ubuntu.com/search?keywords=apptainer&suite=noble` — only golang library dev packages surfaced). The canonical distribution channel per [apptainer.org/docs/admin/main/installation.html](https://apptainer.org/docs/admin/main/installation.html) is `ppa:apptainer/ppa`. The PR uses the documented `add-apt-repository -y ppa:apptainer/ppa` path from `software-properties-common`.

`uidmap` and `squashfs-tools` are in noble **main** — no PPA needed for those.

## Runtime mode

Unprivileged user-namespace mode only (no `apptainer-suid` in the SIF). `--fakeroot` works via `uidmap`'s `newuidmap`/`newgidmap`. `squashfs-tools` is required for SIF read.

## Test plan

- [ ] CI green on the def build
- [ ] SIF rebuild on next image build cycle (out of scope here)
- [ ] Smoke test: `apptainer exec scitex-agent-container-base.sif apptainer --version` returns a version string (post-rebuild, follow-up)