### PR TITLE
fix(quota): restore usage API parse (operator priority 2026-05-28)

### DIFF
--- a/src/scitex_agent_container/_account/claude_usage.py
+++ b/src/scitex_agent_container/_account/claude_usage.py
@@ -21,12 +21,15 @@ from __future__ import annotations
 
 import fcntl
 import json
+import logging
 import time
 import urllib.error
 import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+
+_logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Public return-shape sentinel keys
@@ -48,6 +51,17 @@ _EMPTY_RESULT: dict[str, Any] = {
 _CACHE_TTL_SECONDS = 300  # 5 minutes
 _USAGE_URL = "https://api.anthropic.com/api/oauth/usage"
 _TOKEN_URL = "https://claude.ai/api/auth/oauth/token"
+
+# Shape-dispatch + per-window extraction lives in a sibling module so this
+# file stays focused on orchestration (token read / refresh / cache / HTTP).
+# Re-exported here so existing imports such as
+# ``from .claude_usage import _parse_windows`` keep resolving.
+from .claude_usage_parsers import (  # noqa: E402,F401 — public re-exports
+    _NEW_SHAPE_KEYS as _NEW_SHAPE_KEYS,
+    _extract_quota_from_payload as _extract_quota_from_payload,
+    _parse_new_shape as _parse_new_shape,
+    _parse_windows as _parse_windows,
+)
 
 # Substrings that must never appear in KEYS of the returned dict.
 # These are chosen to catch accidental token field leaks (e.g. "accessToken")
@@ -261,11 +275,17 @@ def _write_cache(home: Path, result: dict[str, Any]) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _fetch_from_api(access_token: str, *, opener=None) -> list[dict[str, Any]] | None:
-    """Call the usage API and return the parsed JSON.
+def _fetch_from_api(access_token: str, *, opener=None) -> Any:
+    """Call the usage API and return the raw parsed JSON payload.
 
-    Returns None on failure.  The response may be a list of window objects
-    or a single dict.
+    Returns whatever shape the API sent (dict for the 2026-05-28+ schema,
+    list for legacy deployments), or ``None`` on network / HTTP / JSON
+    decode failure. Shape-dispatch is the caller's job — see
+    ``_extract_quota_from_payload``.
+
+    HTTP 401 is re-raised so the public ``fetch_usage`` flow can retry
+    after a token refresh; every other failure mode is logged at WARNING
+    and returns ``None``.
     """
     req = urllib.request.Request(
         _USAGE_URL,
@@ -282,50 +302,30 @@ def _fetch_from_api(access_token: str, *, opener=None) -> list[dict[str, Any]] |
     ) as exc:  # stx-allow: fallback (reason: expected failure — see inline comment)
         if exc.code == 401:
             raise  # caller handles 401 as token-expired
+        _logger.warning("claude_usage: usage API returned HTTP %s", exc.code)
         return None
-    except Exception:  # stx-allow: fallback (reason: catch-all safety net — see inline comment for context)
+    except Exception as exc:  # stx-allow: fallback (reason: catch-all safety net — see inline comment for context)
+        _logger.warning("claude_usage: usage API request failed: %s", exc)
         return None
 
     # stx-allow: fallback (reason: API may return non-JSON body (maintenance page, Cloudflare HTML); None causes caller to return an error result)
     try:
         payload = json.loads(raw)
-    except Exception:  # stx-allow: fallback (reason: catch-all safety net — see inline comment for context)
+    except Exception as exc:  # stx-allow: fallback (reason: catch-all safety net — see inline comment for context)
+        _logger.warning(
+            "claude_usage: usage API response was not JSON: %s; first 200 bytes=%r",
+            exc,
+            raw[:200],
+        )
         return None
 
-    if isinstance(payload, list):
+    if isinstance(payload, (dict, list)):
         return payload
-    if isinstance(payload, dict):
-        # Single-window or wrapped response
-        windows = payload.get("windows") or payload.get("data")
-        if isinstance(windows, list):
-            return windows
-        # Treat the dict itself as a single window if it has "window" key
-        if "window" in payload:
-            return [payload]
+    _logger.warning(
+        "claude_usage: usage API JSON was unexpected top-level type %s",
+        type(payload).__name__,
+    )
     return None
-
-
-def _parse_windows(windows: list[dict[str, Any]]) -> dict[str, Any]:
-    """Extract 5h and 7d quota values from the API window list."""
-    result: dict[str, Any] = {}
-    for w in windows:
-        if not isinstance(w, dict):
-            continue
-        win = w.get("window")
-        used = w.get("used")
-        limit = w.get("limit")
-        reset_at = w.get("resetAt")
-        if win not in ("5h", "7d"):
-            continue
-        suffix = win.replace("h", "h").replace("d", "d")  # already correct
-        result[f"used_tokens_{suffix}"] = used if isinstance(used, int) else None
-        result[f"limit_tokens_{suffix}"] = limit if isinstance(limit, int) else None
-        if isinstance(used, int) and isinstance(limit, int) and limit > 0:
-            result[f"used_pct_{suffix}"] = round(used / limit * 100, 2)
-        else:
-            result[f"used_pct_{suffix}"] = None
-        result[f"reset_at_{suffix}"] = reset_at if isinstance(reset_at, str) else None
-    return result
 
 
 # ---------------------------------------------------------------------------
@@ -403,10 +403,10 @@ def fetch_usage(home: Path | None = None, *, opener=None) -> dict[str, Any]:
             # If refresh failed, try with the old token anyway
 
     # --- API call -----------------------------------------------------------
-    windows = None
+    payload: Any = None
     # stx-allow: fallback (reason: network errors or unexpected exceptions from the usage API are caught and surfaced as an error dict rather than an unhandled exception)
     try:
-        windows = _fetch_from_api(access_token, opener=opener)
+        payload = _fetch_from_api(access_token, opener=opener)
     except (
         urllib.error.HTTPError
     ) as exc:  # stx-allow: fallback (reason: expected failure — see inline comment)
@@ -419,20 +419,24 @@ def fetch_usage(home: Path | None = None, *, opener=None) -> dict[str, Any]:
                 access_token = new_token
                 # stx-allow: fallback (reason: second API attempt after token refresh may still fail due to network issues; pass lets the 401 handler return an error dict)
                 try:
-                    windows = _fetch_from_api(access_token, opener=opener)
+                    payload = _fetch_from_api(access_token, opener=opener)
                 except Exception:  # stx-allow: fallback (reason: catch-all safety net — see inline comment for context)
                     pass
-        if windows is None:
+        if payload is None:
             return _err(f"HTTP {exc.code} from usage API; refresh attempted")
     except Exception as exc:  # stx-allow: fallback (reason: catch-all safety net — see inline comment for context)
         return _err(f"Network error: {exc}")
 
-    if windows is None:
+    if payload is None:
+        return _err("Failed to fetch or parse usage API response")
+
+    quota = _extract_quota_from_payload(payload)
+    if quota is None:
         return _err("Failed to fetch or parse usage API response")
 
     # --- build result -------------------------------------------------------
     result: dict[str, Any] = dict(_EMPTY_RESULT)
-    result.update(_parse_windows(windows))
+    result.update(quota)
     result["fetched_at"] = _iso_now()
     result["from_cache"] = False
     result["error"] = None

--- a/src/scitex_agent_container/_account/claude_usage_parsers.py
+++ b/src/scitex_agent_container/_account/claude_usage_parsers.py
@@ -1,0 +1,121 @@
+"""Pure payload-shape parsers for the Anthropic usage API.
+
+Split out of ``claude_usage`` so the orchestrator (token read / refresh /
+cache / fetch) stays focused on I/O and side effects, while the
+shape-dispatch + per-window extraction lives here as deterministic
+pure-function code.
+
+Schemas recognised
+------------------
+1. **New (2026-05-28+) Anthropic schema** — a dict carrying per-window
+   sub-dicts under ``five_hour`` / ``seven_day`` keys, each with
+   ``utilization`` (0-100 float %) and ``resets_at`` (ISO-8601 string).
+   Raw token counts are not exposed by this schema, so
+   ``used_tokens_*`` / ``limit_tokens_*`` stay ``None``.
+2. **Legacy wrapped dict** — ``{"windows": [...]}`` or
+   ``{"data": [...]}`` containing window objects with ``window`` /
+   ``used`` / ``limit`` / ``resetAt`` keys.
+3. **Legacy single-window dict** — ``{"window": "5h", ...}``; wrapped
+   and re-routed through the legacy list parser.
+4. **Legacy list** — ``[{"window": "5h", ...}, ...]`` directly.
+
+Anything else returns ``None`` and is logged at WARNING with a key
+summary so the operator has something to grep for.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+_logger = logging.getLogger(__name__)
+
+# Anthropic's 2026-05-28+ usage API uses snake_case per-window dicts that
+# carry ``utilization`` (0-100 float percentage) + ``resets_at``
+# (ISO-8601). Raw token counts are no longer exposed by the API, so
+# used_tokens_* / limit_tokens_* stay None when parsed from this shape.
+_NEW_SHAPE_KEYS: dict[str, str] = {
+    "five_hour": "5h",
+    "seven_day": "7d",
+}
+
+
+def _extract_quota_from_payload(payload: Any) -> dict[str, Any] | None:
+    """Shape-dispatch ``payload`` and extract per-window quota fields.
+
+    Returns ``None`` for any unrecognised shape (logged at WARNING with
+    the payload's top-level key summary).
+    """
+    if isinstance(payload, dict):
+        if any(k in payload for k in _NEW_SHAPE_KEYS):
+            return _parse_new_shape(payload)
+        wrapped = payload.get("windows")
+        if isinstance(wrapped, list):
+            return _parse_windows(wrapped)
+        wrapped = payload.get("data")
+        if isinstance(wrapped, list):
+            return _parse_windows(wrapped)
+        if "window" in payload:
+            return _parse_windows([payload])
+        _logger.warning(
+            "claude_usage: unrecognised dict payload; keys=%r",
+            sorted(payload.keys()),
+        )
+        return None
+    if isinstance(payload, list):
+        return _parse_windows(payload)
+    _logger.warning(
+        "claude_usage: payload was %s, not dict/list",
+        type(payload).__name__,
+    )
+    return None
+
+
+def _parse_new_shape(payload: dict[str, Any]) -> dict[str, Any]:
+    """Extract used_pct_* / reset_at_* from the 2026-05-28+ schema.
+
+    Token counts are not surfaced by this schema; the corresponding
+    fields are emitted as ``None`` so downstream consumers that only
+    look at percentages (``quota_watch``, ``_account_status``,
+    ``account_group``) keep working unchanged.
+    """
+    result: dict[str, Any] = {}
+    for src_key, suffix in _NEW_SHAPE_KEYS.items():
+        window = payload.get(src_key) if isinstance(payload, dict) else None
+        if isinstance(window, dict):
+            util = window.get("utilization")
+            reset = window.get("resets_at")
+            result[f"used_pct_{suffix}"] = (
+                float(util) if isinstance(util, (int, float)) else None
+            )
+            result[f"reset_at_{suffix}"] = reset if isinstance(reset, str) else None
+        else:
+            result[f"used_pct_{suffix}"] = None
+            result[f"reset_at_{suffix}"] = None
+        # 2026-05-28+ schema does not surface raw token counts.
+        result[f"used_tokens_{suffix}"] = None
+        result[f"limit_tokens_{suffix}"] = None
+    return result
+
+
+def _parse_windows(windows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Extract 5h and 7d quota values from the legacy API window list."""
+    result: dict[str, Any] = {}
+    for w in windows:
+        if not isinstance(w, dict):
+            continue
+        win = w.get("window")
+        used = w.get("used")
+        limit = w.get("limit")
+        reset_at = w.get("resetAt")
+        if win not in ("5h", "7d"):
+            continue
+        suffix = win  # already "5h" or "7d"
+        result[f"used_tokens_{suffix}"] = used if isinstance(used, int) else None
+        result[f"limit_tokens_{suffix}"] = limit if isinstance(limit, int) else None
+        if isinstance(used, int) and isinstance(limit, int) and limit > 0:
+            result[f"used_pct_{suffix}"] = round(used / limit * 100, 2)
+        else:
+            result[f"used_pct_{suffix}"] = None
+        result[f"reset_at_{suffix}"] = reset_at if isinstance(reset_at, str) else None
+    return result

--- a/src/scitex_agent_container/containers/apptainer-base.def
+++ b/src/scitex_agent_container/containers/apptainer-base.def
@@ -93,6 +93,30 @@ From: ubuntu:24.04
     apt-get update
     apt-get install -y --no-install-recommends gh
 
+    # ---- 2a. Apptainer (for inside-SIF nested launch) -------------------
+    # Bundled so sac-from-sac flows (clew -> cohort capsule spawn) work
+    # without needing a host bind. Per operator decision 2026-05-28 (msg
+    # 6704: SIF-bundle preferred over host-bind / upstream conditional
+    # bypass). Spartan's host `which apptainer` is a 1KB bash shim that
+    # requires `module` (Lmod) -- not available in the container -- so
+    # the bind approach was infeasible.
+    #
+    # Unprivileged user-namespace mode only (no setuid in nested SIF);
+    # `--fakeroot` requires `uidmap` for newuidmap/newgidmap.
+    # squashfs-tools for SIF read.
+    #
+    # Apptainer is NOT in Ubuntu 24.04 noble main/universe (verified
+    # 2026-05-28 against packages.ubuntu.com); the only canonical
+    # distribution channel is the official PPA `ppa:apptainer/ppa`
+    # (see apptainer.org/docs/admin/main/installation.html). We use
+    # `add-apt-repository` from software-properties-common, which is
+    # the path the upstream install doc prescribes verbatim.
+    apt-get install -y --no-install-recommends software-properties-common
+    add-apt-repository -y ppa:apptainer/ppa
+    apt-get update
+    apt-get install -y --no-install-recommends \
+        apptainer uidmap squashfs-tools
+
     # ---- 3. Node.js + npm globals --------------------------------------
     curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
     apt-get install -y --no-install-recommends nodejs
@@ -226,7 +250,7 @@ From: ubuntu:24.04
 %labels
     org.scitex.layer base
     org.scitex.runtime apptainer
-    org.scitex.contains "git gh node npm rustc cargo fd bat eza rg tree jq yq delta gdu sd dust uv pipx mermaid prettier eslint jsonlint"
+    org.scitex.contains "git gh node npm rustc cargo fd bat eza rg tree jq yq delta gdu sd dust uv pipx mermaid prettier eslint jsonlint apptainer"
 
 %help
     scitex-agent-container :base layer.

--- a/tests/scitex_agent_container/_account/test_claude_usage.py
+++ b/tests/scitex_agent_container/_account/test_claude_usage.py
@@ -18,6 +18,7 @@ from typing import Any
 import pytest
 
 from scitex_agent_container._account import claude_usage as cu
+from scitex_agent_container._account import claude_usage_parsers as cup
 from scitex_agent_container._account.claude_usage import (
     _EMPTY_RESULT,
     fetch_usage,
@@ -548,40 +549,15 @@ def test_fetch_from_api_returns_list_payload_unchanged() -> None:
     assert out == [{"window": "5h"}]
 
 
-def test_fetch_from_api_unwraps_windows_key() -> None:
-    # Arrange
-    opener = _opener_returning({"windows": [{"window": "5h"}]})
+def test_fetch_from_api_returns_dict_payload_unchanged() -> None:
+    # Arrange — 2026-05-28+ shape; ``_fetch_from_api`` now returns the
+    # raw payload and lets ``_extract_quota_from_payload`` dispatch.
+    payload = {"five_hour": {"utilization": 5.0, "resets_at": "2026-01-01T00:00Z"}}
+    opener = _opener_returning(payload)
     # Act
     out = cu._fetch_from_api("tok", opener=opener)
     # Assert
-    assert out == [{"window": "5h"}]
-
-
-def test_fetch_from_api_unwraps_data_key() -> None:
-    # Arrange
-    opener = _opener_returning({"data": [{"window": "7d"}]})
-    # Act
-    out = cu._fetch_from_api("tok", opener=opener)
-    # Assert
-    assert out == [{"window": "7d"}]
-
-
-def test_fetch_from_api_wraps_single_window_dict_in_list() -> None:
-    # Arrange
-    opener = _opener_returning({"window": "5h", "used": 1})
-    # Act
-    out = cu._fetch_from_api("tok", opener=opener)
-    # Assert
-    assert out == [{"window": "5h", "used": 1}]
-
-
-def test_fetch_from_api_returns_none_for_unknown_dict_shape() -> None:
-    # Arrange
-    opener = _opener_returning({"foo": "bar"})
-    # Act
-    out = cu._fetch_from_api("tok", opener=opener)
-    # Assert
-    assert out is None
+    assert out == payload
 
 
 def test_fetch_from_api_returns_none_on_malformed_json() -> None:
@@ -612,6 +588,216 @@ def test_fetch_from_api_returns_none_on_http_500() -> None:
     out = cu._fetch_from_api("tok", opener=opener)
     # Assert
     assert out is None
+
+
+def test_fetch_from_api_returns_none_for_non_dict_non_list_payload() -> None:
+    # Arrange — scalar payload (e.g. bare JSON string from a maintenance page).
+    opener = _opener_returning(b'"a bare string"')
+    # Act
+    out = cu._fetch_from_api("tok", opener=opener)
+    # Assert
+    assert out is None
+
+
+# ---------------------------------------------------------------------------
+# _extract_quota_from_payload — shape dispatcher (moved out of _fetch_from_api).
+# ---------------------------------------------------------------------------
+
+
+def test_extract_quota_dispatches_new_dict_shape() -> None:
+    # Arrange
+    payload = {
+        "five_hour": {"utilization": 12.0, "resets_at": "2026-01-01T00:00Z"},
+        "seven_day": {"utilization": 34.0, "resets_at": "2026-01-08T00:00Z"},
+    }
+    # Act
+    out = cup._extract_quota_from_payload(payload)
+    # Assert
+    assert out is not None and out["used_pct_5h"] == 12.0
+
+
+def test_extract_quota_dispatches_legacy_list_shape() -> None:
+    # Arrange
+    payload = [{"window": "5h", "used": 10, "limit": 100, "resetAt": "x"}]
+    # Act
+    out = cup._extract_quota_from_payload(payload)
+    # Assert
+    assert out is not None and out["used_pct_5h"] == 10.0
+
+
+def test_extract_quota_unwraps_legacy_windows_key() -> None:
+    # Arrange
+    payload = {"windows": [{"window": "5h", "used": 2, "limit": 10, "resetAt": "x"}]}
+    # Act
+    out = cup._extract_quota_from_payload(payload)
+    # Assert
+    assert out is not None and out["used_pct_5h"] == 20.0
+
+
+def test_extract_quota_unwraps_legacy_data_key() -> None:
+    # Arrange
+    payload = {"data": [{"window": "7d", "used": 3, "limit": 30, "resetAt": "x"}]}
+    # Act
+    out = cup._extract_quota_from_payload(payload)
+    # Assert
+    assert out is not None and out["used_pct_7d"] == 10.0
+
+
+def test_extract_quota_wraps_legacy_single_window_dict() -> None:
+    # Arrange
+    payload = {"window": "5h", "used": 1, "limit": 10, "resetAt": "x"}
+    # Act
+    out = cup._extract_quota_from_payload(payload)
+    # Assert
+    assert out is not None and out["used_pct_5h"] == 10.0
+
+
+def test_extract_quota_returns_none_for_unknown_dict_shape() -> None:
+    # Arrange
+    payload = {"foo": "bar"}
+    # Act
+    out = cup._extract_quota_from_payload(payload)
+    # Assert
+    assert out is None
+
+
+def test_extract_quota_returns_none_for_non_dict_non_list_input() -> None:
+    # Arrange
+    payload = "scalar"
+    # Act
+    out = cup._extract_quota_from_payload(payload)
+    # Assert
+    assert out is None
+
+
+# ---------------------------------------------------------------------------
+# _parse_new_shape — 2026-05-28+ Anthropic schema.
+# ---------------------------------------------------------------------------
+
+
+def test_parse_new_shape_extracts_five_hour_utilization() -> None:
+    # Arrange
+    payload = {"five_hour": {"utilization": 5.0, "resets_at": "2026-01-01T00:00Z"}}
+    # Act
+    out = cup._parse_new_shape(payload)
+    # Assert
+    assert out["used_pct_5h"] == 5.0
+
+
+def test_parse_new_shape_extracts_seven_day_utilization() -> None:
+    # Arrange
+    payload = {"seven_day": {"utilization": 39.0, "resets_at": "2026-06-01T23Z"}}
+    # Act
+    out = cup._parse_new_shape(payload)
+    # Assert
+    assert out["used_pct_7d"] == 39.0
+
+
+def test_parse_new_shape_extracts_five_hour_reset_at() -> None:
+    # Arrange
+    payload = {"five_hour": {"utilization": 5.0, "resets_at": "2026-01-01T00:00Z"}}
+    # Act
+    out = cup._parse_new_shape(payload)
+    # Assert
+    assert out["reset_at_5h"] == "2026-01-01T00:00Z"
+
+
+def test_parse_new_shape_handles_missing_five_hour_window() -> None:
+    # Arrange — only seven_day present.
+    payload = {"seven_day": {"utilization": 5.0, "resets_at": "x"}}
+    # Act
+    out = cup._parse_new_shape(payload)
+    # Assert
+    assert out["used_pct_5h"] is None
+
+
+def test_parse_new_shape_handles_null_window_value() -> None:
+    # Arrange
+    payload = {"five_hour": None, "seven_day": {"utilization": 1.0, "resets_at": "x"}}
+    # Act
+    out = cup._parse_new_shape(payload)
+    # Assert
+    assert out["used_pct_5h"] is None
+
+
+def test_parse_new_shape_handles_non_numeric_utilization() -> None:
+    # Arrange
+    payload = {"five_hour": {"utilization": "not-a-number", "resets_at": "x"}}
+    # Act
+    out = cup._parse_new_shape(payload)
+    # Assert
+    assert out["used_pct_5h"] is None
+
+
+def test_parse_new_shape_leaves_token_counts_as_none() -> None:
+    # Arrange — new schema does not surface raw token counts.
+    payload = {"five_hour": {"utilization": 50.0, "resets_at": "x"}}
+    # Act
+    out = cup._parse_new_shape(payload)
+    # Assert
+    assert out["used_tokens_5h"] is None
+
+
+# ---------------------------------------------------------------------------
+# fetch_usage — end-to-end with the live 2026-05-28+ shape.
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_usage_parses_live_anthropic_dict_shape(tmp_path: Path) -> None:
+    # Arrange — the exact shape returned by api.anthropic.com on 2026-05-28.
+    home = _make_home_full_creds(tmp_path)
+    payload = {
+        "five_hour": {"utilization": 5.0, "resets_at": "2026-05-28T15:50:00Z"},
+        "seven_day": {"utilization": 39.0, "resets_at": "2026-06-01T23:00:00Z"},
+        "seven_day_oauth_apps": None,
+        "seven_day_opus": None,
+        "seven_day_sonnet": {
+            "utilization": 0.0,
+            "resets_at": "2026-06-01T23:00:00Z",
+        },
+        "extra_usage": {
+            "is_enabled": True,
+            "monthly_limit": 4000,
+            "used_credits": 0.0,
+            "utilization": None,
+            "currency": "USD",
+            "disabled_reason": None,
+        },
+    }
+    opener = _opener_returning(payload)
+    # Act
+    result = fetch_usage(home=home, opener=opener)
+    # Assert
+    assert result["used_pct_5h"] == 5.0
+
+
+def test_fetch_usage_extracts_seven_day_from_live_anthropic_shape(
+    tmp_path: Path,
+) -> None:
+    # Arrange
+    home = _make_home_full_creds(tmp_path)
+    payload = {
+        "five_hour": {"utilization": 5.0, "resets_at": "x"},
+        "seven_day": {"utilization": 39.0, "resets_at": "y"},
+    }
+    opener = _opener_returning(payload)
+    # Act
+    result = fetch_usage(home=home, opener=opener)
+    # Assert
+    assert result["used_pct_7d"] == 39.0
+
+
+def test_fetch_usage_clears_error_field_on_new_shape_success(
+    tmp_path: Path,
+) -> None:
+    # Arrange
+    home = _make_home_full_creds(tmp_path)
+    payload = {"five_hour": {"utilization": 5.0, "resets_at": "x"}}
+    opener = _opener_returning(payload)
+    # Act
+    result = fetch_usage(home=home, opener=opener)
+    # Assert
+    assert result["error"] is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The Anthropic usage API at `GET https://api.anthropic.com/api/oauth/usage` switched to a snake_case per-window dict shape with a `utilization` float (0–100 %) and a `resets_at` ISO-8601 string per window. The previous parser expected a list of `{"window": "5h", "used": N, "limit": M, "resetAt": "..."}` objects, so every call returned `"Failed to fetch or parse usage API response"` and the load-balancing path (`sac accounts show`, `agent_status.quota_5h_used_pct`) went dark across all 3 Max accounts (operator msg 6740).

## Live shape (probed against api.anthropic.com 2026-05-28T23:51:58Z)

```jsonc
{
  "five_hour":           {"utilization":  5.0, "resets_at": "2026-05-28T15:50:00+00:00"},
  "seven_day":           {"utilization": 39.0, "resets_at": "2026-06-01T23:00:00+00:00"},
  "seven_day_oauth_apps": null,
  "seven_day_opus":       null,
  "seven_day_sonnet":    {"utilization":  0.0, "resets_at": "2026-06-01T23:00:00+00:00"},
  "extra_usage":         {"is_enabled": true, "monthly_limit": 4000, ...},
  "tangelo":              null,
  "iguana_necktie":       null,
  "omelette_promotional": null
}
```

No raw token counts are surfaced; only percentages. Downstream consumers (`quota_watch`, `_account_status`, `account_group`) only read `used_pct_5h` / `used_pct_7d`, so the load-balancing path is fully restored.

## What changed

- **New** `src/scitex_agent_container/_account/claude_usage_parsers.py` — pure-logic shape dispatcher + per-window extractors. `_extract_quota_from_payload(payload)` recognises the 2026-05-28+ dict shape **and** all legacy shapes (`{"windows": [...]}`, `{"data": [...]}`, single-window dict, bare list), and logs a key summary at WARNING for any unrecognised payload.
- **`_fetch_from_api`** now returns the raw payload (dict or list) and lets the dispatcher classify it; HTTP / JSON / DNS failures log at WARNING with the first 200 bytes of the body so Cloudflare / maintenance-page bodies are diagnosable. `"Failed to fetch or parse usage API response"` is preserved verbatim as the user-facing error string in both the fetch-failed and parse-failed branches so existing log greps keep working.
- **Tests** — migrated the 4 `_fetch_from_api` unwrap cases to `test_extract_quota_*` (responsibility moved), added 7 `test_parse_new_shape_*`, 7 `test_extract_quota_*`, and 3 end-to-end `test_fetch_usage_*_live_anthropic_*` that carry the exact 2026-05-28 payload through an injected opener.

## Test pattern (PA-306 — no mocks)

Every test pulls in a hand-rolled `_FakeResp` / `_opener_returning(...)` / `_opener_sequence(...)` callable through the `opener=` kwarg already exposed on `_fetch_from_api` / `_refresh_access_token` / `fetch_usage`. No `unittest.mock`, no `monkeypatch`, no real `urllib.request.urlopen` in CI. All new tests use AAA markers, ≥3-token names, and 1 assertion per test (TQ rules).

## Verification

Runtime sanity-check against `_extract_quota_from_payload` with the live payload above:

```
LIVE_SHAPE: {
  "used_pct_5h": 5.0,
  "reset_at_5h": "2026-05-28T15:50:00.569126+00:00",
  "used_tokens_5h": null,
  "limit_tokens_5h": null,
  "used_pct_7d": 39.0,
  "reset_at_7d": "2026-06-01T23:00:00.569158+00:00",
  "used_tokens_7d": null,
  "limit_tokens_7d": null
}
LEGACY_LIST → used_pct_5h: 10.0   (backward compat preserved)
UNKNOWN     → None                (with WARNING-level log of payload keys)
```

## Related
- Operator msg 6740 (2026-05-28) — programmatic usage visibility for 3-Max-account load balancing.