### PR TITLE
fix(skills): correct ACL note in 29 (APIs cited in #242 do not exist)

### DIFF
--- a/src/scitex_agent_container/_skills/scitex-agent-container/29_progress-reporting-to-lead.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/29_progress-reporting-to-lead.md
@@ -83,26 +83,7 @@ If you already pushed a milestone earlier in this turn, you can skip the next St
 
 ## ACL note
 
-The first time a new sac agent sends to `lead`, you may hit:
-
-```
-HTTP 403 (ACL deny): cross-group send: sender '<name>' (group=['<name>']) may not address 'lead' without an explicit ACL grant
-```
-
-Fix (lead-side, one-time per agent):
-
-```python
-from scitex_agent_container.comms.acl import grant_send
-grant_send(sender='<agent-name>', target='lead')
-```
-
-Or via CLI on the host:
-
-```bash
-sac a2a grant --sender <name> --target lead
-```
-
-After grant, send works without further config. Idempotent — re-granting is safe.
+ACL-based send restrictions are not currently enforced in sac (verified 2026-05-28: no `scitex_agent_container.comms.acl` module, no `sac a2a grant` subcommand). If a future sac release adds an enforced ACL and you hit 403, file an issue against scitex-agent-container for the grant-CLI + Python API to be implemented — don't try to work around it manually.
 
 ## Companion Stop-hook reminder
 


### PR DESCRIPTION
## Summary

The ACL note section in `29_progress-reporting-to-lead.md` (just landed in #242) cited two APIs that do not exist in sac.

```
$ python3 -c "from scitex_agent_container.comms.acl import grant_send"
ModuleNotFoundError: No module named 'scitex_agent_container.comms'

$ sac a2a --help
Commands:
  doctor  Probe an agent's A2A AgentCard endpoint and report health.
  serve   Serve A2A endpoints for the given agent YAMLs (foreground).
        (no `grant` subcommand)
```

Both verified on `develop` HEAD (commit `490e697`, the merge of #242 itself) — verification re-run inside the worktree this PR opens from.

## What this PR changes

Replaces the old ACL section (which included a Python snippet referencing `grant_send` and a shell snippet referencing `sac a2a grant --sender <name> --target lead`) with a short paragraph that states the empirical reality:

> ACL-based send restrictions are not currently enforced in sac (verified 2026-05-28: no `scitex_agent_container.comms.acl` module, no `sac a2a grant` subcommand). If a future sac release adds an enforced ACL and you hit 403, file an issue against scitex-agent-container for the grant-CLI + Python API to be implemented — don't try to work around it manually.

## Empirical evidence

During the #242 / dotfiles#94 PR pair earlier today, **four** a2a sends from `handyman` to `lead` all returned `HTTP 200` with `delivered_subscriber_count=1` on the first attempt, with no grant ever issued:

| msg_id | content |
|---|---|
| `2656fbaecc…` | PR_OPENED scitex-agent-container#242 |
| `4ac93b5d17…` | PR_OPENED dotfiles#94 |
| `fab315cc35…` | PR_MERGED dotfiles#94 |
| `9fd6c586e2…` | PR_MERGED scitex-agent-container#242 |

So either ACL is not enforced today, or grants happen implicitly somewhere we haven't documented. Either way, the old text would mislead the next reader.

## Diff stat

`29_progress-reporting-to-lead.md`: -20 / +1 (one paragraph in, two code blocks + scaffolding out). No `SKILL.md` change — no SK-301 byte-budget risk.

## Tests

- [x] `scitex-dev ecosystem audit-skills scitex-agent-container` — `SUCC: no skills violations` (local v0.12.3)
- [ ] CI green on the docs-only path