### PR TITLE
feat(provider): registry-based string identifier (spec.claude.provider: mimo)

### DIFF
--- a/docs/adr/0011-deepseek-provider-env-config-resolution.md
+++ b/docs/adr/0011-deepseek-provider-env-config-resolution.md
@@ -4,6 +4,12 @@
 
 Accepted (lands with PR #208 — `feat/deepseek-provider-override`).
 
+**Extended 2026-05-28** (operator directive Telegram msg 6783, this PR):
+`spec.claude.provider` accepts a registered **string identifier**
+(`provider: mimo`, `provider: deepseek`) in addition to the existing
+`{base_url, auth_token_env}` dict shape — see "Extension: registry
+form" below. The dict shape is preserved unchanged for back-compat.
+
 ## Context
 
 sac agents need to run on Anthropic-SDK-compatible alternate providers
@@ -170,3 +176,75 @@ ecosystem primitive.
   decisions described here ARE PR #208's decisions; they should land
   together so that a future reader hitting `git log` finds the rationale
   next to the implementation.
+
+## Extension: registry form (2026-05-28)
+
+Operator directive (Telegram msg 6783): the dict shape leaks the
+abstraction. The canonical operator action is "I want this agent on
+mimo / deepseek / anthropic"; sac should know the rest. Spelling out
+`base_url` and `auth_token_env` for every spec also creates a duplication
+trap — when `spec.claude.model` doesn't auto-inject as `ANTHROPIC_MODEL`,
+operators silently end up with the SDK's default model id winning over
+their spec (the lead-learnings/05 pitfall).
+
+### Decision
+
+1. **New `config/_provider_registry.py`** holds a flat `PROVIDERS` dict:
+   `{name → {base_url, auth_token_env}}`. Initial entries: `anthropic`
+   (sentinel: `base_url=None` means "no override"), `deepseek`, `mimo`,
+   `xiaomi` (alias of `mimo`). Adding a new backend is one line: append
+   an entry to `PROVIDERS`. The registry is the single source of
+   backend metadata.
+
+2. **Parser** (`config/_parsers/_claude.py::_parse_provider`) accepts
+   either a string (registry lookup; unknown → `None`, surfaced by the
+   validator) or a dict (existing shape, unchanged). The
+   `anthropic`-style "no override" entry parses to `None` — equivalent
+   to omitting the provider field.
+
+3. **Validator** (`config/_provider_validation.py::validate_provider`)
+   handles both shapes. Unknown string names produce a loud error
+   listing the registered providers via `list_providers()`, so the
+   operator sees the exact set they can pick from without reading
+   source. Extracted into its own module (sibling of
+   `_provider_registry.py` and `_provider_types.py`) to keep
+   `_validation.py` under the project's 512-line cap.
+
+4. **Runtime** (`runtimes/_apptainer_provider.py::provider_env_flags`)
+   gains `ANTHROPIC_MODEL` auto-injection from `spec.claude.model`
+   whenever a provider is active (string or dict shape — applies
+   uniformly). Closes the lead-learnings/05 duplication pitfall.
+
+### Back-compat
+
+The dict shape continues to load and validate as before. Existing
+specs need no changes. The string shape is purely additive.
+
+### Mutual exclusion with `account`
+
+Unchanged: a registered string name with `base_url != None` is "active"
+and trips the same mutual-exclusion-with-account check as the dict
+shape. The `anthropic` sentinel (or any future entry with `base_url=None`)
+is NOT active — it parses to no override, leaving the OAuth flow intact.
+
+### Adding a new provider
+
+```python
+# config/_provider_registry.py
+PROVIDERS = {
+    ...,
+    "my-gateway": {
+        "base_url": "https://my-gateway.example.com/anthropic",
+        "auth_token_env": "MY_GATEWAY_API_KEY",
+    },
+}
+```
+
+Then `provider: my-gateway` in any spec resolves to the same env-injection
+shape the dict form would have produced. No further code changes needed.
+
+### Related ADRs
+
+- ADR-0016 — Provider × Account axes for sac agent dispatch (just
+  merged; this ADR-0011 extension is the "provider" axis collapsed
+  from `{dict}` to `name`).

--- a/src/scitex_agent_container/_skills/scitex-agent-container/01_config-v3.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/01_config-v3.md
@@ -78,7 +78,7 @@ spec:
 | `channels[]` | list | MCP push channels (`server:<name>` / `plugin:<id>@<v>`) |
 | `auto_accept` | bool (default `true`) | Auto-confirm TUI permission prompts |
 | `account` | string | Pin this agent to a stored OAuth account (`sac accounts` store-name). Credentials are **boot-copied** into the agent state dir, not live-bound. Mutually exclusive with `provider`. See [26_credentials-rotation.md](26_credentials-rotation.md). |
-| `provider` | `{ base_url, auth_token_env }` | Point the SDK at any Anthropic-compatible backend (e.g. DeepSeek). `base_url` is the endpoint; `auth_token_env` is the **name** of the host env var holding the key (never the key value). Mutually exclusive with `account`; relaxes the `claude-*` model-alias check. See ADR-0011. |
+| `provider` | string OR `{ base_url, auth_token_env }` | Point the SDK at any Anthropic-compatible backend. **Canonical (ADR-0011 extension, 2026-05-28):** registered name string, e.g. `provider: mimo` / `provider: deepseek`. sac resolves the base URL + auth env var name from the registry at `config/_provider_registry.py`. **Legacy dict shape** still accepted for back-compat: `base_url` endpoint + `auth_token_env` NAME of the host env var holding the key (never the key value). Mutually exclusive with `account`; relaxes the `claude-*` model-alias check. Auto-injects `ANTHROPIC_MODEL` from `spec.claude.model` (fixes the pitfall where the SDK's default model id silently won). Adding a new provider = add one entry `{base_url, auth_token_env}` to `PROVIDERS` in `_provider_registry.py`. See ADR-0011. |
 | `raw_options` | dict | Escape hatch — splatted into `ClaudeAgentOptions(**raw_options)` |
 
 ## Auto-derived fields

--- a/src/scitex_agent_container/config/_parsers/_claude.py
+++ b/src/scitex_agent_container/config/_parsers/_claude.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from .._provider_registry import resolve_provider
 from .._provider_types import ProviderSpec
 from .._types import ClaudeSpec
 
@@ -9,11 +10,35 @@ from .._types import ClaudeSpec
 def _parse_provider(raw: dict) -> ProviderSpec | None:
     """Parse ``spec.claude.provider`` into a ``ProviderSpec`` or ``None``.
 
-    Absent / explicit-null block → ``None`` (default Anthropic backend).
-    Non-empty fields are surfaced verbatim; the validator enforces that
-    ``base_url`` + ``auth_token_env`` are non-empty when the block exists.
+    Accepts two shapes (back-compat — see ADR-0011 extension):
+
+    * **string** (new shape, operator directive 2026-05-28 msg 6783):
+      a registered provider name, e.g. ``provider: mimo``. Resolved
+      against :mod:`config._provider_registry` to recover the backend
+      metadata. An ``"anthropic"`` string-form (or any registered name
+      whose registry entry has ``base_url=None``) parses to ``None`` —
+      it means "default Anthropic backend, no override".
+    * **dict** (existing shape): ``{base_url, auth_token_env}``.
+      Forwarded verbatim to :class:`ProviderSpec`; the validator
+      enforces both fields are non-empty.
+    * anything else (absent, explicit-null, list, ...) → ``None``.
+
+    Unknown string names are silently surfaced as ``None`` here so
+    the validator (which runs against the raw block) is the single
+    source of the "unknown provider" diagnostic — keeps the error
+    message + the known-providers list in one place.
     """
     block = raw.get("provider")
+    if isinstance(block, str):
+        entry = resolve_provider(block)
+        if entry is None:
+            return None
+        base_url = entry.get("base_url") or ""
+        auth_token_env = entry.get("auth_token_env") or ""
+        if not base_url and not auth_token_env:
+            # Registered "no override" sentinel (e.g. "anthropic").
+            return None
+        return ProviderSpec(base_url=base_url, auth_token_env=auth_token_env)
     if not isinstance(block, dict):
         return None
     return ProviderSpec(

--- a/src/scitex_agent_container/config/_provider_registry.py
+++ b/src/scitex_agent_container/config/_provider_registry.py
@@ -1,0 +1,80 @@
+"""Provider registry — string-identifier → backend metadata.
+
+Operator directive 2026-05-28 (Telegram msg 6783): simplify
+``spec.claude.provider`` from a ``{base_url, auth_token_env}`` dict to
+a bare string identifier (``provider: mimo``). sac resolves the
+backend metadata (Anthropic-compatible base URL + the NAME of the host
+env var holding the API key) internally from this registry.
+
+The dict shape stays accepted for back-compat (see
+``_parsers._claude._parse_provider`` and ``_validation._validate_provider``);
+existing agent specs that declare ``provider: {base_url, auth_token_env}``
+continue to load and run identically. Operators migrating to the new
+shape just replace the dict with the registered name.
+
+Adding a new backend: add one entry to :data:`PROVIDERS`. Each entry is
+``{base_url, auth_token_env}`` — the same two fields the dict shape
+exposes — so a string-form spec is byte-equivalent to a dict-form spec
+that copy-pasted the registry entry verbatim.
+
+The ``"anthropic"`` entry is intentional: it lets an operator write
+``provider: anthropic`` to spell out "use the default Anthropic OAuth
+backend" explicitly without having to omit the field. The runtime
+treats an entry with ``base_url=None`` as "no backend override", same
+as no provider at all.
+
+Aliases (e.g. ``"xiaomi"`` → same metadata as ``"mimo"``) are
+intentional duplicates rather than indirection: the registry stays a
+flat read so no caller has to chase aliases.
+"""
+
+from __future__ import annotations
+
+PROVIDERS: dict[str, dict[str, str | None]] = {
+    "anthropic": {
+        "base_url": None,
+        "auth_token_env": None,
+    },
+    "deepseek": {
+        "base_url": "https://api.deepseek.com/anthropic",
+        "auth_token_env": "DEEPSEEK_API_KEY",
+    },
+    "mimo": {
+        "base_url": "https://token-plan-sgp.xiaomimimo.com/anthropic",
+        "auth_token_env": "XIAOMI_API_KEY",
+    },
+    "xiaomi": {
+        "base_url": "https://token-plan-sgp.xiaomimimo.com/anthropic",
+        "auth_token_env": "XIAOMI_API_KEY",
+    },
+}
+
+
+def resolve_provider(name: str) -> dict[str, str | None] | None:
+    """Return ``{base_url, auth_token_env}`` for a registered provider.
+
+    Returns ``None`` when ``name`` is not in :data:`PROVIDERS`. Callers
+    that need a fail-loud surface (e.g. the spec validator) should
+    detect ``None`` and emit a clear error naming the known providers
+    via :func:`list_providers`.
+
+    The returned dict is a copy — callers may mutate it without
+    disturbing the registry.
+    """
+    entry = PROVIDERS.get(name)
+    if entry is None:
+        return None
+    return dict(entry)
+
+
+def list_providers() -> list[str]:
+    """Return the registered provider names, sorted, for diagnostics.
+
+    Used by the spec validator's "unknown provider" error message so
+    the operator sees the exact set they can pick from without having
+    to read the module source.
+    """
+    return sorted(PROVIDERS)
+
+
+__all__ = ["PROVIDERS", "resolve_provider", "list_providers"]

--- a/src/scitex_agent_container/config/_provider_validation.py
+++ b/src/scitex_agent_container/config/_provider_validation.py
@@ -1,0 +1,88 @@
+"""Validation for ``spec.claude.provider`` — string form + dict form.
+
+Extracted from :mod:`config._validation` to keep that file under the
+project's 512-line cap and to keep the three provider-axis modules
+(:mod:`_provider_registry`, :mod:`_provider_types`,
+:mod:`_provider_validation`) cohesive.
+
+ADR-0011 extension (operator directive 2026-05-28 msg 6783):
+``spec.claude.provider`` now accepts a registered string identifier
+(``provider: mimo``) in addition to the existing
+``{base_url, auth_token_env}`` dict form. The string form is resolved
+through :mod:`_provider_registry`; unknown names surface a loud error
+listing the registered providers.
+
+The dict form rule is unchanged: an incomplete dict override would
+silently fall back to Anthropic at runtime, which we refuse to allow.
+"""
+
+from __future__ import annotations
+
+
+def validate_provider(provider_block: object) -> list[str]:
+    """Validate ``spec.claude.provider`` (vendor backend override).
+
+    Accepts:
+
+    * **string** — a registered provider name (see
+      :mod:`config._provider_registry`). Unknown names surface a loud
+      error listing the registered providers.
+    * **dict** ``{base_url, auth_token_env}`` — existing shape; both
+      fields must be non-empty strings.
+    * anything else (absent, explicit-null) → no errors (provider
+      feature unused).
+    """
+    if isinstance(provider_block, str):
+        from ._provider_registry import list_providers, resolve_provider
+
+        if resolve_provider(provider_block) is None:
+            known = ", ".join(list_providers())
+            return [
+                f"spec.claude.provider='{provider_block}' is not a registered "
+                f"provider name. Known providers: {known}. To add a new "
+                "backend, append it to PROVIDERS in "
+                "scitex_agent_container/config/_provider_registry.py."
+            ]
+        return []
+    if not isinstance(provider_block, dict):
+        return []
+    errors: list[str] = []
+    for field_name in ("base_url", "auth_token_env"):
+        val = provider_block.get(field_name)
+        if val is None or val == "":
+            errors.append(
+                f"spec.claude.provider.{field_name} is required and must be "
+                "non-empty when spec.claude.provider is declared."
+            )
+        elif not isinstance(val, str):
+            errors.append(
+                f"spec.claude.provider.{field_name} must be a string, got "
+                f"{type(val).__name__}"
+            )
+    return errors
+
+
+def provider_is_active(provider_block: object) -> bool:
+    """Return ``True`` when ``provider_block`` declares an active backend
+    override.
+
+    Used by the validator's mutual-exclusion check against
+    ``spec.claude.account``. Tracks the same "active" semantics as the
+    runtime side: a registered string-form name with a non-null
+    ``base_url`` in the registry, OR a dict with both fields set.
+
+    A registered name whose registry entry has ``base_url=None`` (e.g.
+    ``"anthropic"`` — the "use the default OAuth backend" sentinel) is
+    NOT active; it is parser-equivalent to ``provider: ~``.
+    """
+    if isinstance(provider_block, str):
+        from ._provider_registry import resolve_provider
+
+        entry = resolve_provider(provider_block)
+        if entry is None:
+            return False
+        return bool(entry.get("base_url"))
+    return isinstance(provider_block, dict)
+
+
+__all__ = ["validate_provider", "provider_is_active"]

--- a/src/scitex_agent_container/config/_validation.py
+++ b/src/scitex_agent_container/config/_validation.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import yaml
 
 from ._acl_validation import validate_phase3_acl
+from ._provider_validation import provider_is_active, validate_provider
 
 # Accepted shapes for ``spec.model`` (F-CS7).
 #
@@ -132,30 +133,9 @@ _V3_REMOVED_FIELDS: dict[str, str] = {
 }
 
 
-def _validate_provider(provider_block: object) -> list[str]:
-    """Validate ``spec.claude.provider`` (vendor backend override).
-
-    Absent / non-dict → no errors (provider feature unused). When the
-    block is a dict, both ``base_url`` and ``auth_token_env`` must be
-    non-empty strings — an incomplete override would silently fall back
-    to Anthropic at runtime, which we refuse to allow.
-    """
-    if not isinstance(provider_block, dict):
-        return []
-    errors: list[str] = []
-    for field_name in ("base_url", "auth_token_env"):
-        val = provider_block.get(field_name)
-        if val is None or val == "":
-            errors.append(
-                f"spec.claude.provider.{field_name} is required and must be "
-                "non-empty when spec.claude.provider is declared."
-            )
-        elif not isinstance(val, str):
-            errors.append(
-                f"spec.claude.provider.{field_name} must be a string, got "
-                f"{type(val).__name__}"
-            )
-    return errors
+# ``_validate_provider`` moved to ``_provider_validation.validate_provider``
+# (ADR-0011 extension — provider as registered string identifier; see
+# the sibling module for the dict + string forms).
 
 
 def validate_raw(raw: dict, path: str) -> list[str]:
@@ -276,8 +256,8 @@ def validate_raw(raw: dict, path: str) -> list[str]:
         # is the provider's own (e.g. 'deepseek-chat') and the claude-*
         # regex below is skipped. Absent → behaviour unchanged.
         provider_block = claude_block.get("provider")
-        has_provider = isinstance(provider_block, dict)
-        errors.extend(_validate_provider(provider_block))
+        has_provider = provider_is_active(provider_block)
+        errors.extend(validate_provider(provider_block))
         model = claude_block.get("model")
         if model is not None:
             if not isinstance(model, str):

--- a/src/scitex_agent_container/runtimes/_apptainer_provider.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_provider.py
@@ -155,7 +155,7 @@ def provider_env_flags(config: AgentConfig) -> list[str]:
     # Per-agent clean config dir — the conflict-breaker. Distinct from the
     # OAuth path's /tmp/sac-claude so a stale OAuth bind can never win.
     config_dir = f"/tmp/sac-{config.name}-provider-cfg"
-    return [
+    flags = [
         "--env",
         f"ANTHROPIC_BASE_URL={base_url}",
         "--env",
@@ -163,6 +163,17 @@ def provider_env_flags(config: AgentConfig) -> list[str]:
         "--env",
         f"CLAUDE_CONFIG_DIR={config_dir}",
     ]
+    # ADR-0011 extension (lead-learnings/05 pitfall fix): auto-inject
+    # ``ANTHROPIC_MODEL`` from ``spec.claude.model`` whenever a provider
+    # is active. Without this, the SDK's built-in default model id wins
+    # over the spec — every turn talks to the provider's gateway but
+    # against the wrong model alias, and operators have to duplicate
+    # the model id into ``raw_args.env`` to work around it. Skipped
+    # when ``model`` is empty (the SDK's default is then intentional).
+    model = (getattr(claude, "model", "") or "") if claude is not None else ""
+    if model:
+        flags.extend(["--env", f"ANTHROPIC_MODEL={model}"])
+    return flags
 
 
 __all__ = ["ProviderEnvError", "provider_active", "provider_env_flags"]

--- a/tests/scitex_agent_container/config/_parsers/test__claude.py
+++ b/tests/scitex_agent_container/config/_parsers/test__claude.py
@@ -248,9 +248,52 @@ def test_provider_block_parses_auth_token_env_field():
 
 
 def test_provider_non_dict_value_yields_none_provider():
-    # Arrange — a malformed (non-mapping) provider collapses to None so
-    # the validator surfaces the shape error, not the parser.
+    # Arrange — an unregistered (non-mapping, non-registered-name)
+    # provider collapses to None so the validator surfaces the shape
+    # error, not the parser.
     spec = {"claude": {"provider": "garbage"}}
+    # Act
+    result = parse_claude(spec)
+    # Assert
+    assert result.provider is None
+
+
+# ---------------------------------------------------------------------------
+# String-form provider (ADR-0011 extension, operator directive 2026-05-28)
+# ---------------------------------------------------------------------------
+
+
+def test_provider_string_form_mimo_resolves_to_xiaomi_base_url():
+    # Arrange
+    spec = {"claude": {"provider": "mimo"}}
+    # Act
+    result = parse_claude(spec)
+    # Assert
+    assert result.provider.base_url == "https://token-plan-sgp.xiaomimimo.com/anthropic"
+
+
+def test_provider_string_form_mimo_resolves_to_xiaomi_auth_env():
+    # Arrange
+    spec = {"claude": {"provider": "mimo"}}
+    # Act
+    result = parse_claude(spec)
+    # Assert
+    assert result.provider.auth_token_env == "XIAOMI_API_KEY"
+
+
+def test_provider_string_form_deepseek_resolves_to_deepseek_base_url():
+    # Arrange
+    spec = {"claude": {"provider": "deepseek"}}
+    # Act
+    result = parse_claude(spec)
+    # Assert
+    assert result.provider.base_url == "https://api.deepseek.com/anthropic"
+
+
+def test_provider_string_form_anthropic_sentinel_yields_no_override():
+    # Arrange — registered name with base_url=None means
+    # "use the default Anthropic OAuth backend, no override".
+    spec = {"claude": {"provider": "anthropic"}}
     # Act
     result = parse_claude(spec)
     # Assert

--- a/tests/scitex_agent_container/config/test__provider_registry.py
+++ b/tests/scitex_agent_container/config/test__provider_registry.py
@@ -1,0 +1,92 @@
+"""Tests for ``config._provider_registry`` (PS-204 mirror).
+
+Backend metadata for ``spec.claude.provider`` as a registered string
+identifier (ADR-0011 extension, operator directive 2026-05-28 msg 6783).
+Each test pins one observable fact (TQ007), AAA markers on separate
+lines (TQ002), descriptive name with ≥3 tokens (TQ003).
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container.config._provider_registry import (
+    PROVIDERS,
+    list_providers,
+    resolve_provider,
+)
+
+
+def test_resolve_provider_returns_dict_for_known_mimo():
+    # Arrange
+    name = "mimo"
+    # Act
+    entry = resolve_provider(name)
+    # Assert
+    assert entry == {
+        "base_url": "https://token-plan-sgp.xiaomimimo.com/anthropic",
+        "auth_token_env": "XIAOMI_API_KEY",
+    }
+
+
+def test_resolve_provider_returns_dict_for_known_deepseek():
+    # Arrange
+    name = "deepseek"
+    # Act
+    entry = resolve_provider(name)
+    # Assert
+    assert entry == {
+        "base_url": "https://api.deepseek.com/anthropic",
+        "auth_token_env": "DEEPSEEK_API_KEY",
+    }
+
+
+def test_resolve_provider_returns_none_for_unknown_name():
+    # Arrange
+    name = "this-provider-does-not-exist"
+    # Act
+    entry = resolve_provider(name)
+    # Assert
+    assert entry is None
+
+
+def test_resolve_provider_anthropic_has_no_overrides_set():
+    # Arrange
+    name = "anthropic"
+    # Act
+    entry = resolve_provider(name)
+    # Assert
+    assert entry == {"base_url": None, "auth_token_env": None}
+
+
+def test_resolve_provider_returns_copy_not_shared_reference():
+    # Arrange
+    name = "deepseek"
+    # Act
+    entry = resolve_provider(name)
+    entry["base_url"] = "mutated"
+    # Assert
+    assert PROVIDERS["deepseek"]["base_url"] != "mutated"
+
+
+def test_list_providers_includes_mimo_and_deepseek():
+    # Arrange
+    expected = {"mimo", "deepseek", "anthropic", "xiaomi"}
+    # Act
+    names = set(list_providers())
+    # Assert
+    assert expected.issubset(names)
+
+
+def test_list_providers_returns_sorted_order_for_stable_diagnostics():
+    # Arrange
+    # Act
+    names = list_providers()
+    # Assert
+    assert names == sorted(names)
+
+
+def test_xiaomi_alias_resolves_to_same_backend_as_mimo():
+    # Arrange
+    # Act
+    xiaomi = resolve_provider("xiaomi")
+    # Assert
+    assert xiaomi == resolve_provider("mimo")

--- a/tests/scitex_agent_container/config/test__provider_validation.py
+++ b/tests/scitex_agent_container/config/test__provider_validation.py
@@ -1,0 +1,157 @@
+"""Tests for ``config._provider_validation`` (PS-204 mirror).
+
+Validation rules for ``spec.claude.provider`` — string form via
+registry lookup + existing dict form back-compat. ADR-0011 extension,
+operator directive 2026-05-28 msg 6783. Each test pins one observable
+fact (TQ007), AAA markers on separate lines (TQ002), descriptive name
+with ≥3 tokens (TQ003).
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container.config._provider_validation import (
+    provider_is_active,
+    validate_provider,
+)
+
+_VALID_DICT = {
+    "base_url": "https://api.deepseek.com/anthropic",
+    "auth_token_env": "DEEPSEEK_API_KEY",
+}
+
+
+# ---------------------------------------------------------------------------
+# String form
+# ---------------------------------------------------------------------------
+
+
+def test_string_form_known_provider_returns_no_errors():
+    # Arrange
+    block = "mimo"
+    # Act
+    errors = validate_provider(block)
+    # Assert
+    assert errors == []
+
+
+def test_string_form_unknown_provider_returns_loud_error():
+    # Arrange
+    block = "not-a-real-provider"
+    # Act
+    errors = validate_provider(block)
+    # Assert
+    assert any("not a registered provider name" in e for e in errors)
+
+
+def test_string_form_unknown_provider_lists_known_providers_in_error():
+    # Arrange
+    block = "not-a-real-provider"
+    # Act
+    errors = validate_provider(block)
+    # Assert
+    assert any("mimo" in e and "deepseek" in e for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# Dict form (back-compat unchanged)
+# ---------------------------------------------------------------------------
+
+
+def test_dict_form_complete_block_returns_no_errors():
+    # Arrange
+    block = dict(_VALID_DICT)
+    # Act
+    errors = validate_provider(block)
+    # Assert
+    assert errors == []
+
+
+def test_dict_form_missing_base_url_returns_required_error():
+    # Arrange
+    block = {"auth_token_env": "X_KEY"}
+    # Act
+    errors = validate_provider(block)
+    # Assert
+    assert any("base_url" in e and "required" in e for e in errors)
+
+
+def test_dict_form_missing_auth_token_env_returns_required_error():
+    # Arrange
+    block = {"base_url": "https://x.example.com"}
+    # Act
+    errors = validate_provider(block)
+    # Assert
+    assert any("auth_token_env" in e and "required" in e for e in errors)
+
+
+def test_dict_form_non_string_base_url_returns_type_error():
+    # Arrange
+    block = {"base_url": 42, "auth_token_env": "X_KEY"}
+    # Act
+    errors = validate_provider(block)
+    # Assert
+    assert any("base_url" in e and "must be a string" in e for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# Absent / null
+# ---------------------------------------------------------------------------
+
+
+def test_absent_provider_block_returns_no_errors():
+    # Arrange
+    block = None
+    # Act
+    errors = validate_provider(block)
+    # Assert
+    assert errors == []
+
+
+# ---------------------------------------------------------------------------
+# Active predicate (mutual-exclusion with account)
+# ---------------------------------------------------------------------------
+
+
+def test_active_predicate_true_for_known_string_with_base_url():
+    # Arrange
+    block = "deepseek"
+    # Act
+    result = provider_is_active(block)
+    # Assert
+    assert result is True
+
+
+def test_active_predicate_false_for_anthropic_sentinel_string():
+    # Arrange
+    block = "anthropic"
+    # Act
+    result = provider_is_active(block)
+    # Assert
+    assert result is False
+
+
+def test_active_predicate_false_for_unknown_provider_string():
+    # Arrange
+    block = "not-a-provider"
+    # Act
+    result = provider_is_active(block)
+    # Assert
+    assert result is False
+
+
+def test_active_predicate_true_for_valid_dict_form():
+    # Arrange
+    block = dict(_VALID_DICT)
+    # Act
+    result = provider_is_active(block)
+    # Assert
+    assert result is True
+
+
+def test_active_predicate_false_for_missing_block():
+    # Arrange
+    block = None
+    # Act
+    result = provider_is_active(block)
+    # Assert
+    assert result is False

--- a/tests/scitex_agent_container/runtimes/test__apptainer_provider.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_provider.py
@@ -15,6 +15,8 @@ and a descriptive name (TQ003).
 
 from __future__ import annotations
 
+from pathlib import Path  # noqa: F401  # used in string annotation on line ~179
+
 import pytest
 
 from scitex_agent_container.config import AgentConfig, ClaudeSpec, ProviderSpec
@@ -245,3 +247,32 @@ def test_home_dotenv_supports_quoted_and_export_prefixed_lines(
     env = _env_dict(provider_env_flags(cfg))
     # Assert — quotes stripped, ``export`` prefix tolerated.
     assert env["SAC_ANTHROPIC_API_KEY"] == "sk-quoted-export"
+
+
+# ---------------------------------------------------------------------------
+# ANTHROPIC_MODEL auto-injection (ADR-0011 extension, lead-learnings/05 fix)
+# ---------------------------------------------------------------------------
+
+
+def test_flags_inject_anthropic_model_from_spec_when_set(env_save_restore):
+    # Arrange — provider active and spec.claude.model = "deepseek-chat";
+    # auto-injected so the SDK's built-in default doesn't silently win.
+    env_save_restore.set("DEEPSEEK_API_KEY", "sk-injected")
+    cfg = _provider_config()
+    # Act
+    env = _env_dict(provider_env_flags(cfg))
+    # Assert
+    assert env["ANTHROPIC_MODEL"] == "deepseek-chat"
+
+
+def test_flags_omit_anthropic_model_when_spec_model_empty(env_save_restore):
+    # Arrange — provider active but no model set; SDK's default model
+    # is then intentional and should not be overridden by a stray
+    # ANTHROPIC_MODEL flag.
+    env_save_restore.set("DEEPSEEK_API_KEY", "sk-injected")
+    cfg = _provider_config()
+    cfg.claude.model = ""
+    # Act
+    env = _env_dict(provider_env_flags(cfg))
+    # Assert
+    assert "ANTHROPIC_MODEL" not in env


### PR DESCRIPTION
## Why

Operator directive 2026-05-28 (Telegram msg 6783): the current `spec.claude.provider: {base_url, auth_token_env}` dict shape leaks the abstraction. The canonical operator action is *"I want this agent on mimo / deepseek / anthropic"*; sac should know the rest. Spelling out `base_url` and `auth_token_env` per-spec also creates a duplication trap with `spec.claude.model` (the lead-learnings/05 pitfall — `ANTHROPIC_MODEL` is not auto-injected, so the SDK's default model id silently wins over the spec).

## Target shape

```yaml
spec:
  claude:
    provider: mimo            # registered name; sac knows the rest
    model: mimo-v2.5-pro      # auto-injected as ANTHROPIC_MODEL
```

Legacy dict shape (still accepted, back-compat):

```yaml
spec:
  claude:
    provider:
      base_url: https://token-plan-sgp.xiaomimimo.com/anthropic
      auth_token_env: XIAOMI_API_KEY
```

## Changes

| File | Change |
|---|---|
| `config/_provider_registry.py` (new) | Flat `PROVIDERS` dict + `resolve_provider()` + `list_providers()`. Initial entries: `anthropic` (sentinel), `deepseek`, `mimo`, `xiaomi` (alias). |
| `config/_provider_validation.py` (new) | Extracted from `_validation.py`. Validates string-form against registry (loud error listing known providers); dict form unchanged. `provider_is_active()` drives mutual-exclusion. |
| `config/_validation.py` | Now imports the extracted validator. **523 → 481 lines** (was over the 512 cap before this PR's edits; used the documented REFACTORING.md escape hatch while landing the refactor). |
| `config/_parsers/_claude.py` | `_parse_provider` accepts string OR dict. `anthropic` sentinel parses to `None`. |
| `runtimes/_apptainer_provider.py` | Auto-injects `ANTHROPIC_MODEL` from `spec.claude.model` whenever provider is active. **Closes the lead-learnings/05 pitfall.** |

## Tests

77 tests in touched files pass locally. All NM-compliant (no `unittest.mock` / `Mock` / `patch` / `monkeypatch`-as-fixture-param) and TQ-compliant (single assertion, AAA on separate lines, ≥3 tokens after `test_`).

- `test__provider_registry.py` — 8 single-assertion tests
- `test__provider_validation.py` — 13 single-assertion tests
- `test__claude.py` — 4 new single-assertion tests
- `test__apptainer_provider.py` — 2 new single-assertion tests

## Docs

- Skill `01_config-v3.md`: provider row updated to show both shapes, marks string form canonical, notes ANTHROPIC_MODEL auto-injection, documents "add one entry to PROVIDERS" extension pattern.
- ADR-0011: Extension section (2026-05-28) covers registry, parser, validator extraction, runtime change, back-compat surface, and a worked "add a new provider" example.

## Pre-existing problems noted (NOT silent-fixed)

- **F821 pre-existing in `test__apptainer_provider.py:179`** — `"Path"` used as a string annotation without `from pathlib import Path`. Pre-existing on develop; surfaced by local lint hook (stricter than CI's F401/F811-only config). Trivial 1-line maintenance fix added with `# noqa: F401` to keep the hook unblocked. Not in scope for the feature; documented in commit body for transparency.

## Out of scope (per lead brief)

- `spec.claude.account` for non-anthropic providers — ADR-0016 Phase 4. Keep `account=null/unset` for non-anthropic in the registry entries.
- Reference handyman-deepseek / handyman-mimo specs — they live in the operator's `~/.scitex/agent-container/agents/`, outside this repo. They will pick up the new string shape on next edit by the operator without any sac-side changes needed.

## How to verify

```bash
PYTHONPATH=src python -m pytest \
  tests/scitex_agent_container/config/test__provider_registry.py \
  tests/scitex_agent_container/config/test__provider_validation.py \
  tests/scitex_agent_container/config/test__validation_provider.py \
  tests/scitex_agent_container/config/_parsers/test__claude.py \
  tests/scitex_agent_container/runtimes/test__apptainer_provider.py \
  -q
```

## CI gate

Standard: pytest matrix py3.{11,12,13}, ruff, scitex-dev-quality-audit (NM+TQ), import-smoke, sphinx, RTD, CLA, codecov/patch.