### PR TITLE
skills(scitex-agent-container): document multi-account rotation + watch-live daemon

### DIFF
--- a/src/scitex_agent_container/_skills/scitex-agent-container/26_credentials-rotation.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/26_credentials-rotation.md
@@ -164,6 +164,79 @@ Stages of death:
   session 401s. **Re-login required** — see
   [27_credentials-relogin.md](27_credentials-relogin.md).
 
+## 5. Multi-account CI rotation
+
+Operator splits CI auth across N Anthropic Max accounts to load-balance the
+per-account 429 rate. Lead 2026-05-29 example: 66 `scitex-*` packages divided
+22-22-22 across `wyusuuke-gmail-com`, `ywata1989-gmail-com`,
+`ywatanabe-scitex-ai`.
+
+Recipe:
+
+```bash
+for acct in wyusuuke-gmail-com ywata1989-gmail-com ywatanabe-scitex-ai; do
+    SRC=/home/ywatanabe/.scitex/agent-container/accounts/$acct/.credentials.json
+    scitex-dev creds rotate-all --source "$SRC" --only pkg1 --only pkg2 ... --yes
+done
+```
+
+`--only` is repeatable; pass each package once per account.
+
+Non-negotiables:
+
+- **Silent-no-op trap.** If `--source` points to a file whose
+  `claudeAiOauth.expiresAt` is in the past, `rotate-all` exits 0 with **zero
+  stdout** (not error, not warning). Looks like success, does nothing. Always
+  verify expiry before invoking.
+- **Two locations, only one valid for `--source`:**
+  - **Sac-store path — USE THIS:** `~/.scitex/agent-container/accounts/<acct>/.credentials.json`,
+    kept fresh by the watch-live daemon (§6); what `sac accounts list` reads.
+  - **Stale standalone copies — DO NOT USE:** `~/.claude/.credentials-<acct>.json`,
+    written once at account-add time, never refreshed, expire in ~8 h. These
+    are the canonicals §1 describes — they receive write-back via the `:rw`
+    bind of a running agent, not via direct rotation.
+
+Diagnosis:
+
+```bash
+jq '.claudeAiOauth.expiresAt' <path>   # epoch ms
+echo $(($(date +%s) * 1000))           # now in ms
+```
+
+Or `sac accounts list` reports freshness for every account in the sac store.
+
+## 6. The watch-live daemon — what keeps the sac store fresh
+
+`sac accounts watch-live` runs `inotifywait -m` on `~/.claude/` for
+`close_write|moved_to|create` events on `.credentials.json`. On every event it
+atomically copies the live credential to the matching sac-store path; the slug
+map turns the account email into a store name (e.g. `wyusuuke@gmail.com` →
+`wyusuuke-gmail-com`).
+
+```bash
+sac accounts watch-live    # long-running; foreground or explicit & / supervisor
+```
+
+Non-negotiables:
+
+- **NOT auto-started.** No systemd / launchd unit ships by default. If the
+  daemon isn't running when `claude /login` updates the live cred, the sac
+  store stays stale until the operator manually runs `sac accounts sync-live`
+  or starts the daemon.
+- **Manual one-shot fallback:** `sac accounts sync-live` runs the same atomic
+  copy once without the daemon — use after a `claude /login` performed with
+  the daemon stopped, or to catch up before a rotation.
+
+Implementation:
+
+- `src/scitex_agent_container/_account/creds_watch.py` L140-152
+  (`watch_inotify()`), L99-133 (`watch_poll()` polling fallback for hosts
+  without `inotifywait`), L35 (imports + calls into `sync_live()`).
+- `src/scitex_agent_container/_account/creds_sync.py` L141-244 (`sync_live()`:
+  atomic copy + freshness check), L69-77 (`slugify_email()`).
+- `src/scitex_agent_container/cli_pkg/_account_sync_live.py` L82-100+
+  (`account_watch_live` click command — daemon entry point).
+
 ## See also
 
 - [27_credentials-relogin.md](27_credentials-relogin.md) — verified

--- a/src/scitex_agent_container/_skills/scitex-agent-container/26_credentials-rotation.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/26_credentials-rotation.md
@@ -166,76 +166,22 @@ Stages of death:
 
 ## 5. Multi-account CI rotation
 
-Operator splits CI auth across N Anthropic Max accounts to load-balance the
-per-account 429 rate. Lead 2026-05-29 example: 66 `scitex-*` packages divided
-22-22-22 across `wyusuuke-gmail-com`, `ywata1989-gmail-com`,
-`ywatanabe-scitex-ai`.
-
-Recipe:
-
-```bash
-for acct in wyusuuke-gmail-com ywata1989-gmail-com ywatanabe-scitex-ai; do
-    SRC=/home/ywatanabe/.scitex/agent-container/accounts/$acct/.credentials.json
-    scitex-dev creds rotate-all --source "$SRC" --only pkg1 --only pkg2 ... --yes
-done
-```
-
-`--only` is repeatable; pass each package once per account.
+`for acct in ...; scitex-dev creds rotate-all --source $SAC_STORE --only pkgA --only pkgB ... --yes; done` splits CI auth across N Max accounts (lead 2026-05-29: 66 `scitex-*` divided 22-22-22 across 3). `--only` is repeatable.
 
 Non-negotiables:
 
-- **Silent-no-op trap.** If `--source` points to a file whose
-  `claudeAiOauth.expiresAt` is in the past, `rotate-all` exits 0 with **zero
-  stdout** (not error, not warning). Looks like success, does nothing. Always
-  verify expiry before invoking.
-- **Two locations, only one valid for `--source`:**
-  - **Sac-store path — USE THIS:** `~/.scitex/agent-container/accounts/<acct>/.credentials.json`,
-    kept fresh by the watch-live daemon (§6); what `sac accounts list` reads.
-  - **Stale standalone copies — DO NOT USE:** `~/.claude/.credentials-<acct>.json`,
-    written once at account-add time, never refreshed, expire in ~8 h. These
-    are the canonicals §1 describes — they receive write-back via the `:rw`
-    bind of a running agent, not via direct rotation.
+- **Silent-no-op trap.** Stale `--source` (`claudeAiOauth.expiresAt` in the past) exits **0 with zero stdout**. Verify first: `jq '.claudeAiOauth.expiresAt' <path>` vs `echo $(($(date +%s) * 1000))`.
+- **`--source` MUST be the sac store**, `~/.scitex/agent-container/accounts/<acct>/.credentials.json` (kept fresh by §6's daemon; what `sac accounts list` reads). The `~/.claude/.credentials-<acct>.json` canonicals from §1 are refreshed via `:rw` agent binds, NOT direct rotation — using them as `--source` silently fails when stale.
 
-Diagnosis:
+## 6. The watch-live daemon — keeps the sac store fresh
 
-```bash
-jq '.claudeAiOauth.expiresAt' <path>   # epoch ms
-echo $(($(date +%s) * 1000))           # now in ms
-```
-
-Or `sac accounts list` reports freshness for every account in the sac store.
-
-## 6. The watch-live daemon — what keeps the sac store fresh
-
-`sac accounts watch-live` runs `inotifywait -m` on `~/.claude/` for
-`close_write|moved_to|create` events on `.credentials.json`. On every event it
-atomically copies the live credential to the matching sac-store path; the slug
-map turns the account email into a store name (e.g. `wyusuuke@gmail.com` →
-`wyusuuke-gmail-com`).
-
-```bash
-sac accounts watch-live    # long-running; foreground or explicit & / supervisor
-```
+`sac accounts watch-live` runs `inotifywait -m ~/.claude/` for `close_write|moved_to|create` on `.credentials.json`; atomically copies each event into the matching sac-store path (slug-map e.g. `wyusuuke@gmail.com` → `wyusuuke-gmail-com`).
 
 Non-negotiables:
 
-- **NOT auto-started.** No systemd / launchd unit ships by default. If the
-  daemon isn't running when `claude /login` updates the live cred, the sac
-  store stays stale until the operator manually runs `sac accounts sync-live`
-  or starts the daemon.
-- **Manual one-shot fallback:** `sac accounts sync-live` runs the same atomic
-  copy once without the daemon — use after a `claude /login` performed with
-  the daemon stopped, or to catch up before a rotation.
+- **NOT auto-started** — no systemd / launchd unit ships. If the daemon isn't running when `claude /login` refreshes, the sac store stays stale until `sac accounts sync-live` (one-shot fallback) or the daemon starts.
 
-Implementation:
-
-- `src/scitex_agent_container/_account/creds_watch.py` L140-152
-  (`watch_inotify()`), L99-133 (`watch_poll()` polling fallback for hosts
-  without `inotifywait`), L35 (imports + calls into `sync_live()`).
-- `src/scitex_agent_container/_account/creds_sync.py` L141-244 (`sync_live()`:
-  atomic copy + freshness check), L69-77 (`slugify_email()`).
-- `src/scitex_agent_container/cli_pkg/_account_sync_live.py` L82-100+
-  (`account_watch_live` click command — daemon entry point).
+Implementation: `_account/creds_watch.py` L140-152 (`watch_inotify()`), L99-133 (`watch_poll()` fallback); `_account/creds_sync.py` L141-244 (`sync_live()`), L69-77 (`slugify_email()`); `cli_pkg/_account_sync_live.py` L82-100+ (`account_watch_live` command).
 
 ## See also
 


### PR DESCRIPTION
## Summary

Patches `src/scitex_agent_container/_skills/scitex-agent-container/26_credentials-rotation.md` with two previously-undocumented mechanics that bit the lead's 2026-05-29 66-package 22-22-22 CI auth rotation:

1. **§5 multi-account CI rotation** — the `for acct in ...; scitex-dev creds rotate-all --source ... --only ... --yes` pattern, the silent-no-op trap when `--source` is a stale file (`expiresAt` in the past → exit 0, zero stdout), and the sac-store-vs-`~/.claude/.credentials-<acct>.json` distinction.
2. **§6 watch-live daemon** — what `sac accounts watch-live` actually does (inotify on `~/.claude/`, atomic copy to sac-store), and the critical caveat that it is NOT auto-started.

Pointer-only update to the lead-skill leaf in dotfiles ships separately as ywatanabe1989/.dotfiles#95 (already merged) per the SSoT directive — this skill is the canonical source.

## Test plan
- [x] Combined §5+§6 = 73 lines (≤ 120 ceiling)
- [x] Voice matches existing leaf (terse, numbered, "Non-negotiables:")
- [x] Implementation citations point at real file:line ranges
- [x] No restate of §1-§4