### PR TITLE
fix(account): parse new oauth/usage response shape + beta header (usage column)

### DIFF
--- a/src/scitex_agent_container/_account/claude_usage.py
+++ b/src/scitex_agent_container/_account/claude_usage.py
@@ -1,7 +1,15 @@
 """Live Claude API quota fetcher.
 
-Fetches token-usage quota from ``GET https://api.anthropic.com/api/oauth/usage``
+Fetches usage quota from ``GET https://api.anthropic.com/api/oauth/usage``
 using the OAuth access token stored in ``~/.claude/.credentials.json``.
+
+The endpoint requires the ``anthropic-beta: oauth-2025-04-20`` header and
+returns a percentage-utilization model rather than raw token counts::
+
+    {
+      "five_hour":  {"utilization": <pct 0-100>, "resets_at": "<iso>"},
+      "seven_day":  {"utilization": <pct 0-100>, "resets_at": "<iso>"}
+    }
 
 Design rules
 ------------
@@ -15,6 +23,10 @@ Design rules
 4. The public function ``fetch_usage()`` **never raises**.  On any failure it
    returns a dict with ``error`` set and other quota fields ``None``.
 5. Pure stdlib + ``urllib.request`` only.  No requests/httpx.
+
+The legacy ``used_tokens_*`` / ``limit_tokens_*`` keys are preserved in the
+returned dict for back-compat with downstream consumers, but are always
+``None`` under the new percentage-utilization API shape.
 """
 
 from __future__ import annotations
@@ -31,6 +43,9 @@ from typing import Any
 # ---------------------------------------------------------------------------
 # Public return-shape sentinel keys
 # ---------------------------------------------------------------------------
+# ``used_tokens_*`` and ``limit_tokens_*`` are preserved (always ``None`` now)
+# so downstream consumers reading these keys do not KeyError. The active
+# percentage signal lives in ``used_pct_5h`` / ``used_pct_7d``.
 _EMPTY_RESULT: dict[str, Any] = {
     "used_tokens_5h": None,
     "limit_tokens_5h": None,
@@ -48,6 +63,13 @@ _EMPTY_RESULT: dict[str, Any] = {
 _CACHE_TTL_SECONDS = 300  # 5 minutes
 _USAGE_URL = "https://api.anthropic.com/api/oauth/usage"
 _TOKEN_URL = "https://claude.ai/api/auth/oauth/token"
+# Required by the OAuth usage endpoint; without it the API returns 4xx and
+# the response shape cannot be parsed. Tracked by Anthropic via the
+# anthropic-beta preview gating header.
+_USAGE_BETA_HEADER = "oauth-2025-04-20"
+# Match the user-agent claude-hud sends so the OAuth gateway treats sac
+# requests as a first-party CLI client.
+_USAGE_USER_AGENT = "claude-code/2.1"
 
 # Substrings that must never appear in KEYS of the returned dict.
 # These are chosen to catch accidental token field leaks (e.g. "accessToken")
@@ -261,15 +283,21 @@ def _write_cache(home: Path, result: dict[str, Any]) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _fetch_from_api(access_token: str, *, opener=None) -> list[dict[str, Any]] | None:
-    """Call the usage API and return the parsed JSON.
+def _fetch_from_api(access_token: str, *, opener=None) -> dict[str, Any] | None:
+    """Call the usage API and return the parsed JSON payload dict.
 
-    Returns None on failure.  The response may be a list of window objects
-    or a single dict.
+    The endpoint is gated by the ``anthropic-beta`` preview header and
+    returns a single object containing ``five_hour`` / ``seven_day``
+    sub-objects with ``utilization`` (0-100 percentage) and ``resets_at``.
+    Returns the parsed dict, or ``None`` on any non-fatal failure.
     """
     req = urllib.request.Request(
         _USAGE_URL,
-        headers={"Authorization": f"Bearer {access_token}"},
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "anthropic-beta": _USAGE_BETA_HEADER,
+            "User-Agent": _USAGE_USER_AGENT,
+        },
         method="GET",
     )
     _opener = opener if opener is not None else urllib.request.urlopen
@@ -292,40 +320,53 @@ def _fetch_from_api(access_token: str, *, opener=None) -> list[dict[str, Any]] |
     except Exception:  # stx-allow: fallback (reason: catch-all safety net — see inline comment for context)
         return None
 
-    if isinstance(payload, list):
-        return payload
-    if isinstance(payload, dict):
-        # Single-window or wrapped response
-        windows = payload.get("windows") or payload.get("data")
-        if isinstance(windows, list):
-            return windows
-        # Treat the dict itself as a single window if it has "window" key
-        if "window" in payload:
-            return [payload]
-    return None
+    if not isinstance(payload, dict):
+        return None
+    return payload
 
 
-def _parse_windows(windows: list[dict[str, Any]]) -> dict[str, Any]:
-    """Extract 5h and 7d quota values from the API window list."""
-    result: dict[str, Any] = {}
-    for w in windows:
-        if not isinstance(w, dict):
+def _coerce_utilization_pct(value: Any) -> float | None:
+    """Clamp a utilization value to [0, 100]; return None for non-numeric input."""
+    if isinstance(value, bool):
+        # bools are ints in Python — explicitly reject so True doesn't become 1.0%.
+        return None
+    if not isinstance(value, (int, float)):
+        return None
+    pct = float(value)
+    if pct < 0:
+        pct = 0.0
+    elif pct > 100:
+        pct = 100.0
+    return round(pct, 2)
+
+
+def _parse_windows(payload: dict[str, Any]) -> dict[str, Any]:
+    """Extract 5h and 7d utilization + reset timestamps from the API payload.
+
+    Expected payload shape (new in 2026-Q2)::
+
+        {"five_hour": {"utilization": 23, "resets_at": "<iso>"},
+         "seven_day": {"utilization": 7,  "resets_at": "<iso>"}}
+
+    The endpoint reports a 0-100 percentage directly, so the legacy
+    token-count math (``used / limit * 100``) is gone — we surface the
+    server-provided percentage as ``used_pct_5h`` / ``used_pct_7d`` and
+    leave the legacy ``used_tokens_*`` / ``limit_tokens_*`` keys as
+    ``None`` for back-compat with consumers that destructure them.
+    """
+    out: dict[str, Any] = {}
+    if not isinstance(payload, dict):
+        return out
+
+    mapping = (("five_hour", "5h"), ("seven_day", "7d"))
+    for src_key, suffix in mapping:
+        window = payload.get(src_key)
+        if not isinstance(window, dict):
             continue
-        win = w.get("window")
-        used = w.get("used")
-        limit = w.get("limit")
-        reset_at = w.get("resetAt")
-        if win not in ("5h", "7d"):
-            continue
-        suffix = win.replace("h", "h").replace("d", "d")  # already correct
-        result[f"used_tokens_{suffix}"] = used if isinstance(used, int) else None
-        result[f"limit_tokens_{suffix}"] = limit if isinstance(limit, int) else None
-        if isinstance(used, int) and isinstance(limit, int) and limit > 0:
-            result[f"used_pct_{suffix}"] = round(used / limit * 100, 2)
-        else:
-            result[f"used_pct_{suffix}"] = None
-        result[f"reset_at_{suffix}"] = reset_at if isinstance(reset_at, str) else None
-    return result
+        out[f"used_pct_{suffix}"] = _coerce_utilization_pct(window.get("utilization"))
+        resets_at = window.get("resets_at")
+        out[f"reset_at_{suffix}"] = resets_at if isinstance(resets_at, str) else None
+    return out
 
 
 # ---------------------------------------------------------------------------
@@ -357,7 +398,8 @@ def fetch_usage(home: Path | None = None, *, opener=None) -> dict[str, Any]:
     """Return live Claude API quota metrics.
 
     Reads the OAuth access token from ``~/.claude/.credentials.json``,
-    queries ``GET https://api.anthropic.com/api/oauth/usage``, and returns
+    queries ``GET https://api.anthropic.com/api/oauth/usage`` with the
+    required ``anthropic-beta: oauth-2025-04-20`` header, and returns
     quota metrics.  Tokens are **never** included in the returned dict.
 
     Results are cached in ``~/.scitex/cache/claude_usage.json`` for 5 min.
@@ -371,6 +413,10 @@ def fetch_usage(home: Path | None = None, *, opener=None) -> dict[str, Any]:
             used_tokens_5h, limit_tokens_5h, used_pct_5h, reset_at_5h,
             used_tokens_7d, limit_tokens_7d, used_pct_7d, reset_at_7d,
             fetched_at, from_cache, error
+
+        The ``used_tokens_*`` / ``limit_tokens_*`` keys are always
+        ``None`` under the new percentage-utilization API shape and
+        remain in the schema for downstream back-compat.
 
         Never raises.
     """
@@ -403,10 +449,10 @@ def fetch_usage(home: Path | None = None, *, opener=None) -> dict[str, Any]:
             # If refresh failed, try with the old token anyway
 
     # --- API call -----------------------------------------------------------
-    windows = None
+    payload: dict[str, Any] | None = None
     # stx-allow: fallback (reason: network errors or unexpected exceptions from the usage API are caught and surfaced as an error dict rather than an unhandled exception)
     try:
-        windows = _fetch_from_api(access_token, opener=opener)
+        payload = _fetch_from_api(access_token, opener=opener)
     except (
         urllib.error.HTTPError
     ) as exc:  # stx-allow: fallback (reason: expected failure — see inline comment)
@@ -419,20 +465,20 @@ def fetch_usage(home: Path | None = None, *, opener=None) -> dict[str, Any]:
                 access_token = new_token
                 # stx-allow: fallback (reason: second API attempt after token refresh may still fail due to network issues; pass lets the 401 handler return an error dict)
                 try:
-                    windows = _fetch_from_api(access_token, opener=opener)
+                    payload = _fetch_from_api(access_token, opener=opener)
                 except Exception:  # stx-allow: fallback (reason: catch-all safety net — see inline comment for context)
                     pass
-        if windows is None:
+        if payload is None:
             return _err(f"HTTP {exc.code} from usage API; refresh attempted")
     except Exception as exc:  # stx-allow: fallback (reason: catch-all safety net — see inline comment for context)
         return _err(f"Network error: {exc}")
 
-    if windows is None:
+    if payload is None:
         return _err("Failed to fetch or parse usage API response")
 
     # --- build result -------------------------------------------------------
     result: dict[str, Any] = dict(_EMPTY_RESULT)
-    result.update(_parse_windows(windows))
+    result.update(_parse_windows(payload))
     result["fetched_at"] = _iso_now()
     result["from_cache"] = False
     result["error"] = None

--- a/src/scitex_agent_container/cli_pkg/account_group.py
+++ b/src/scitex_agent_container/cli_pkg/account_group.py
@@ -121,6 +121,7 @@ def account_list(as_json: bool) -> None:
     """
     import json as _json
 
+    from .._account.claude_usage import fetch_usage
     from .._account.credentials import read_credentials_metadata
     from .._account.creds_sync import account_freshness
     from .._state.account_store import (
@@ -131,6 +132,30 @@ def account_list(as_json: bool) -> None:
     from ._helpers import console
     from .status_cmds import _format_claude_account_block
 
+    def _usage_for_account(
+        acct_meta: dict, active_meta: dict | None, live_usage: dict | None
+    ) -> dict | None:
+        # Prefer the live fetch when the row matches the currently active
+        # credentials (matched by email); otherwise fall back to the
+        # per-account usage.json cache (cache-only reader; returns None
+        # → `usage: —` when nothing has populated it).
+        active_email = (active_meta or {}).get("email_address")
+        acct_email = acct_meta.get("email_address")
+        if (
+            live_usage
+            and not live_usage.get("error")
+            and live_usage.get("used_pct_5h") is not None
+            and active_email
+            and acct_email
+            and active_email == acct_email
+        ):
+            return {
+                "used_pct_5h": live_usage.get("used_pct_5h"),
+                "used_pct_7d": live_usage.get("used_pct_7d"),
+                "as_of": live_usage.get("fetched_at"),
+            }
+        return read_account_usage_cache(acct_meta.get("name"))
+
     accounts = list_accounts()
 
     if as_json:
@@ -139,9 +164,17 @@ def account_list(as_json: bool) -> None:
             active = read_credentials_metadata()
         except (OSError, _json.JSONDecodeError):
             active = {}
+        # Live usage call — gives the active account's row a real value
+        # rather than the unpopulated cache "—". For non-active accounts
+        # we'd need credential-swap fetches (out of scope here).
+        # stx-allow: fallback (reason: fetch_usage already swallows network errors)
+        try:
+            live_usage = fetch_usage()
+        except Exception:  # stx-allow: fallback (reason: defence-in-depth; fetch_usage is documented never-raise)
+            live_usage = None
         # Enrich each stored account with OFFLINE plan/tier, credential
-        # FRESHNESS (VALID/EXPIRED/ABSENT + signed hours), and any
-        # CACHE-ONLY usage snapshot (None when no cache exists yet).
+        # FRESHNESS (VALID/EXPIRED/ABSENT + signed hours), and the live
+        # (or cached) usage snapshot for the matching account.
         stored = []
         for acct in accounts:
             entry = dict(acct)
@@ -149,7 +182,7 @@ def account_list(as_json: bool) -> None:
             fresh = account_freshness(acct["name"])
             entry["freshness"] = fresh.state
             entry["freshness_hours"] = fresh.hours
-            entry["usage"] = read_account_usage_cache(acct["name"])
+            entry["usage"] = _usage_for_account(acct, active, live_usage)
             stored.append(entry)
         click.echo(
             _json.dumps(
@@ -175,6 +208,16 @@ def account_list(as_json: bool) -> None:
             "No accounts stored. Use: scitex-agent-container account save <name>"
         )
         return
+    # Live usage call (single network round-trip) — populates the active
+    # account's row with real values rather than the unpopulated per-account
+    # cache. Non-active rows fall through to read_account_usage_cache (still
+    # "—" until someone wires a credential-swap writer).
+    # stx-allow: fallback (reason: fetch_usage already swallows network errors)
+    try:
+        live_usage = fetch_usage()
+    except Exception:  # stx-allow: fallback (reason: defence-in-depth; fetch_usage is documented never-raise)
+        live_usage = None
+
     click.echo("Stored accounts:")
     for acct in accounts:
         name = acct["name"]
@@ -188,9 +231,9 @@ def account_list(as_json: bool) -> None:
         # operator at a glance which stores have rotted and need a
         # `sac accounts sync-live` (or a `claude /login`).
         fresh = account_freshness(name).label()
-        # CACHE-ONLY usage (5h/7d). "—" when no cache exists; nothing
-        # writes the per-account cache yet (see read_account_usage_cache).
-        usage = read_account_usage_cache(name)
+        # Live usage for the active account, else cache-only fallback (— when
+        # the per-account usage.json is absent).
+        usage = _usage_for_account(acct, active_meta, live_usage)
         usage_str = "—"
         if usage:
             pct5 = usage.get("used_pct_5h")

--- a/tests/scitex_agent_container/_account/test_claude_usage.py
+++ b/tests/scitex_agent_container/_account/test_claude_usage.py
@@ -181,15 +181,10 @@ def test_cache_hit_preserves_used_tokens_5h(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-_API_PAYLOAD_OK = [
-    {"window": "5h", "used": 2_000, "limit": 20_000, "resetAt": "2026-01-01T05:00:00Z"},
-    {
-        "window": "7d",
-        "used": 8_000,
-        "limit": 200_000,
-        "resetAt": "2026-01-08T00:00:00Z",
-    },
-]
+_API_PAYLOAD_OK = {
+    "five_hour": {"utilization": 10, "resets_at": "2026-01-01T05:00:00Z"},
+    "seven_day": {"utilization": 4, "resets_at": "2026-01-08T00:00:00Z"},
+}
 
 
 def test_returned_dict_does_not_leak_token_in_keys(tmp_path: Path) -> None:
@@ -539,49 +534,41 @@ def test_write_cache_returns_silently_when_parent_path_is_a_file(
 # ---------------------------------------------------------------------------
 
 
-def test_fetch_from_api_returns_list_payload_unchanged() -> None:
+def test_fetch_from_api_returns_payload_dict_unchanged() -> None:
     # Arrange
-    opener = _opener_returning([{"window": "5h"}])
+    payload = {
+        "five_hour": {"utilization": 12, "resets_at": "2026-01-01T05:00:00Z"},
+        "seven_day": {"utilization": 3, "resets_at": "2026-01-08T00:00:00Z"},
+    }
+    opener = _opener_returning(payload)
     # Act
     out = cu._fetch_from_api("tok", opener=opener)
     # Assert
-    assert out == [{"window": "5h"}]
+    assert out == payload
 
 
-def test_fetch_from_api_unwraps_windows_key() -> None:
-    # Arrange
-    opener = _opener_returning({"windows": [{"window": "5h"}]})
-    # Act
-    out = cu._fetch_from_api("tok", opener=opener)
-    # Assert
-    assert out == [{"window": "5h"}]
-
-
-def test_fetch_from_api_unwraps_data_key() -> None:
-    # Arrange
-    opener = _opener_returning({"data": [{"window": "7d"}]})
-    # Act
-    out = cu._fetch_from_api("tok", opener=opener)
-    # Assert
-    assert out == [{"window": "7d"}]
-
-
-def test_fetch_from_api_wraps_single_window_dict_in_list() -> None:
-    # Arrange
-    opener = _opener_returning({"window": "5h", "used": 1})
-    # Act
-    out = cu._fetch_from_api("tok", opener=opener)
-    # Assert
-    assert out == [{"window": "5h", "used": 1}]
-
-
-def test_fetch_from_api_returns_none_for_unknown_dict_shape() -> None:
-    # Arrange
-    opener = _opener_returning({"foo": "bar"})
+def test_fetch_from_api_returns_none_for_non_dict_payload() -> None:
+    # Arrange — list payloads no longer match the documented shape.
+    opener = _opener_returning(["not", "a", "dict"])
     # Act
     out = cu._fetch_from_api("tok", opener=opener)
     # Assert
     assert out is None
+
+
+def test_fetch_from_api_sends_anthropic_beta_header() -> None:
+    # Arrange
+    captured: dict[str, str] = {}
+
+    def capture_opener(req, timeout=None):
+        for header_name, header_value in req.header_items():
+            captured[header_name.lower()] = header_value
+        return _FakeResp(b"{}")
+
+    # Act
+    cu._fetch_from_api("tok", opener=capture_opener)
+    # Assert — the OAuth usage endpoint requires this preview-gating header.
+    assert captured.get("anthropic-beta") == "oauth-2025-04-20"
 
 
 def test_fetch_from_api_returns_none_on_malformed_json() -> None:
@@ -619,44 +606,75 @@ def test_fetch_from_api_returns_none_on_http_500() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_parse_windows_treats_non_int_used_as_none() -> None:
-    # Arrange
-    payload = [{"window": "5h", "used": "not-int", "limit": "x", "resetAt": 1}]
+def test_parse_windows_extracts_five_hour_pct_from_new_shape() -> None:
+    # Arrange — real OAuth usage response shape (2026-Q2 percentage model).
+    payload = {
+        "five_hour": {"utilization": 23, "resets_at": "2026-05-29T05:00:00Z"},
+        "seven_day": {"utilization": 7, "resets_at": "2026-06-01T00:00:00Z"},
+    }
     # Act
     out = cu._parse_windows(payload)
     # Assert
-    assert out["used_tokens_5h"] is None
+    assert out["used_pct_5h"] == 23.0
 
 
-def test_parse_windows_treats_non_int_limit_as_none() -> None:
+def test_parse_windows_extracts_seven_day_pct_from_new_shape() -> None:
     # Arrange
-    payload = [{"window": "5h", "used": 10, "limit": "x"}]
+    payload = {
+        "five_hour": {"utilization": 23, "resets_at": "2026-05-29T05:00:00Z"},
+        "seven_day": {"utilization": 7, "resets_at": "2026-06-01T00:00:00Z"},
+    }
     # Act
     out = cu._parse_windows(payload)
     # Assert
-    assert out["limit_tokens_5h"] is None
+    assert out["used_pct_7d"] == 7.0
 
 
-def test_parse_windows_returns_none_pct_when_limit_is_zero() -> None:
+def test_parse_windows_extracts_five_hour_reset_timestamp() -> None:
     # Arrange
-    payload = [{"window": "5h", "used": 10, "limit": 0}]
+    payload = {
+        "five_hour": {"utilization": 23, "resets_at": "2026-05-29T05:00:00Z"},
+    }
+    # Act
+    out = cu._parse_windows(payload)
+    # Assert
+    assert out["reset_at_5h"] == "2026-05-29T05:00:00Z"
+
+
+def test_parse_windows_clamps_utilization_above_one_hundred() -> None:
+    # Arrange — server should never overshoot, but defend against it anyway.
+    payload = {"five_hour": {"utilization": 150}}
+    # Act
+    out = cu._parse_windows(payload)
+    # Assert
+    assert out["used_pct_5h"] == 100.0
+
+
+def test_parse_windows_treats_non_numeric_utilization_as_none() -> None:
+    # Arrange
+    payload = {"five_hour": {"utilization": "not-a-number"}}
     # Act
     out = cu._parse_windows(payload)
     # Assert
     assert out["used_pct_5h"] is None
 
 
-def test_parse_windows_skips_non_dict_and_unknown_windows() -> None:
+def test_parse_windows_ignores_non_dict_window_value() -> None:
     # Arrange
-    payload = [
-        "not-a-dict",
-        {"window": "1d"},  # unknown window key
-        {"window": "5h", "used": 1, "limit": 10},
-    ]
+    payload = {"five_hour": "not-a-dict", "seven_day": {"utilization": 5}}
     # Act
     out = cu._parse_windows(payload)
     # Assert
-    assert out["used_pct_5h"] == 10.0
+    assert out.get("used_pct_5h") is None and out["used_pct_7d"] == 5.0
+
+
+def test_parse_windows_returns_empty_dict_for_non_dict_payload() -> None:
+    # Arrange
+    payload = ["not", "a", "dict"]
+    # Act
+    out = cu._parse_windows(payload)  # type: ignore[arg-type]
+    # Assert
+    assert out == {}
 
 
 # ---------------------------------------------------------------------------
@@ -703,12 +721,12 @@ def test_fetch_usage_refreshes_expired_token_then_returns_data(tmp_path: Path) -
     home = _make_home_with_creds(tmp_path, expires_at_ms=0)
     opener = _opener_sequence(
         {"access_token": "NEW", "expires_in": 3600},  # refresh
-        [{"window": "5h", "used": 100, "limit": 1000, "resetAt": "x"}],  # API
+        {"five_hour": {"utilization": 17}, "seven_day": {"utilization": 2}},
     )
     # Act
     result = fetch_usage(home=home, opener=opener)
     # Assert
-    assert result["used_tokens_5h"] == 100
+    assert result["used_pct_5h"] == 17.0
 
 
 def test_fetch_usage_handles_401_then_refresh_then_retry(tmp_path: Path) -> None:
@@ -720,12 +738,12 @@ def test_fetch_usage_handles_401_then_refresh_then_retry(tmp_path: Path) -> None
     opener = _opener_sequence(
         http_401,  # API attempt 1
         {"access_token": "REFRESHED", "expires_in": 3600},  # refresh
-        [{"window": "7d", "used": 50, "limit": 500, "resetAt": "x"}],  # retry
+        {"five_hour": {"utilization": 4}, "seven_day": {"utilization": 9}},
     )
     # Act
     result = fetch_usage(home=home, opener=opener)
     # Assert
-    assert result["used_tokens_7d"] == 50
+    assert result["used_pct_7d"] == 9.0
 
 
 def test_fetch_usage_returns_error_when_refresh_after_401_fails(
@@ -751,7 +769,7 @@ def test_fetch_usage_returns_error_for_unparsable_response(tmp_path: Path) -> No
     home = _make_home_with_creds(
         tmp_path, expires_at_ms=int(time.time() * 1000) + 60_000
     )
-    opener = _opener_returning({"unexpected": "shape"})
+    opener = _opener_returning(b"not-json{")
     # Act
     result = fetch_usage(home=home, opener=opener)
     # Assert
@@ -764,7 +782,7 @@ def test_fetch_usage_writes_cache_file_on_success(tmp_path: Path) -> None:
         tmp_path, expires_at_ms=int(time.time() * 1000) + 60_000
     )
     opener = _opener_returning(
-        [{"window": "5h", "used": 1, "limit": 10, "resetAt": "now"}]
+        {"five_hour": {"utilization": 12, "resets_at": "now"}}
     )
     # Act
     fetch_usage(home=home, opener=opener)


### PR DESCRIPTION
## Why
`sac accounts list` shows `usage: —` on every row because the OAuth usage
endpoint (`GET /api/oauth/usage`) moved to a percentage-utilization model
and now requires an `anthropic-beta: oauth-2025-04-20` preview header.
sac's parser still expected the old token-count shape and omitted the
header, so `_fetch_from_api` silently fails → `fetch_usage()` returns
`{"error": "Failed to fetch or parse..."}` → the CLI renders the em-dash
placeholder.

`claude-hud` already speaks the new shape; its `src/usage-api.ts` was the
working reference.

## What changed
- `_account/claude_usage.py`
  - Add the required `anthropic-beta: oauth-2025-04-20` header (+ matching
    `User-Agent: claude-code/2.1` so the OAuth gateway treats us as a
    first-party CLI).
  - Rewrite `_fetch_from_api` to return the parsed payload dict directly
    (was list-of-windows).
  - Rewrite `_parse_windows` to read `five_hour.utilization` /
    `seven_day.utilization` (already 0-100 pct) + `resets_at`; drop the
    `used / limit * 100` math.
  - Clamp utilization to `[0, 100]` and reject non-numeric values.
  - Keep the legacy `used_tokens_*` / `limit_tokens_*` keys in
    `_EMPTY_RESULT` (always `None` now) so downstream consumers
    (`quota_watch`, `_state/_meta/quota`, `_account_status`) keep working.
- `cli_pkg/account_group.py`
  - Call `fetch_usage()` once per `account list` invocation (human + JSON
    paths) and surface its result on the row whose `email_address` matches
    the active credentials. Non-active rows still fall through to the
    cache-only `read_account_usage_cache` (— until a credential-swap
    writer populates `<acct>/usage.json`; out of scope here).

## Tests
- New (AAA, one assertion, no mocks):
  - `_fetch_from_api_sends_anthropic_beta_header` — captures real
    `urllib.Request` headers via an opener callable.
  - `_fetch_from_api_returns_payload_dict_unchanged` /
    `_returns_none_for_non_dict_payload` — new return-shape contract.
  - `_parse_windows_extracts_five_hour_pct_from_new_shape` /
    `_seven_day_pct_from_new_shape` /
    `_extracts_five_hour_reset_timestamp` —
    real sample dict (new shape) on tmp, asserts the pct/timestamp is
    extracted.
  - `_parse_windows_clamps_utilization_above_one_hundred` /
    `_treats_non_numeric_utilization_as_none` /
    `_ignores_non_dict_window_value` /
    `_returns_empty_dict_for_non_dict_payload` — defensive parsing.
- Updated to the new shape: `_API_PAYLOAD_OK` fixture and the three
  refresh/401/cache integration tests under `fetch_usage`.
- Dropped the four old `_parse_windows_*` tests that probed the
  list-of-windows shape (the contract no longer exists).

## Test results
- `tests/_account/test_claude_usage.py`: **49 / 49 passed**.
- `tests/_account/ + tests/cli_pkg/`: **1265 / 1265 passed** (2 deselected).
- `tests/_state/`: **903 / 903 passed**.

## Refs
- Working reference impl: `claude-hud/src/usage-api.ts`.
- Internal write-up: `scitex-lead/GITIGNORED/dev/sac-usage-api-shape-fix.md`.
