### PR TITLE
fix(account): per-account live usage fetch + new oauth/usage shape + beta header

### DIFF
--- a/src/scitex_agent_container/_account/claude_usage.py
+++ b/src/scitex_agent_container/_account/claude_usage.py
@@ -132,12 +132,17 @@ def _cache_path(home: Path) -> Path:
 # ---------------------------------------------------------------------------
 
 
-def _read_tokens(home: Path) -> tuple[str | None, str | None, str | None, int | None]:
-    """Return (access_token, refresh_token, client_id, expires_at_ms).
+def _read_tokens_at(
+    credentials_path: Path,
+) -> tuple[str | None, str | None, str | None, int | None]:
+    """Read OAuth tokens from a specific credentials.json file.
 
-    All values are consumed inside this module only.
+    Returns ``(access_token, refresh_token, client_id, expires_at_ms)``.
+    All four are ``None`` if the file is missing/corrupt or lacks the
+    ``claudeAiOauth`` object. Values are consumed inside this module only;
+    tokens never leave the module.
     """
-    data = _load_json(_credentials_path(home))
+    data = _load_json(credentials_path)
     if data is None:
         return None, None, None, None
     oauth = data.get("claudeAiOauth")
@@ -155,6 +160,16 @@ def _read_tokens(home: Path) -> tuple[str | None, str | None, str | None, int | 
     )
 
 
+def _read_tokens(home: Path) -> tuple[str | None, str | None, str | None, int | None]:
+    """Return (access_token, refresh_token, client_id, expires_at_ms).
+
+    Thin wrapper over ``_read_tokens_at`` resolved to
+    ``~/.claude/.credentials.json``. All values are consumed inside this
+    module only.
+    """
+    return _read_tokens_at(_credentials_path(home))
+
+
 def _is_token_expired(expires_at_ms: int | None) -> bool:
     if expires_at_ms is None:
         return False  # unknown — try anyway
@@ -167,18 +182,22 @@ def _is_token_expired(expires_at_ms: int | None) -> bool:
 # ---------------------------------------------------------------------------
 
 
-def _refresh_access_token(
-    home: Path,
+def _refresh_access_token_at(
+    credentials_path: Path,
     refresh_token: str,
     client_id: str,
     *,
     opener=None,
 ) -> str | None:
-    """POST to token endpoint and atomically update credentials file.
+    """POST to token endpoint and atomically update the given credentials file.
 
-    Returns the new access token string, or None on failure.
-    Tokens are never returned to the caller of ``fetch_usage`` — this is
-    an internal helper only.
+    Used by both the legacy ``_refresh_access_token`` wrapper (which
+    targets ``~/.claude/.credentials.json``) and ``fetch_usage_for_credentials``
+    (which targets a per-account snapshot at
+    ``~/.scitex/agent-container/accounts/<name>/.credentials.json``).
+    Returns the new access token string, or ``None`` on failure. Tokens
+    are never returned to the caller of ``fetch_usage`` — this is an
+    internal helper only.
     """
     body = json.dumps(
         {
@@ -208,10 +227,9 @@ def _refresh_access_token(
         return None
 
     # Atomically update the credentials file.
-    creds_path = _credentials_path(home)
     # stx-allow: fallback (reason: credentials file may be read-only or locked by another process; new access token is still usable in memory even if disk write fails)
     try:
-        with open(creds_path, "r+", encoding="utf-8") as fh:
+        with open(credentials_path, "r+", encoding="utf-8") as fh:
             fcntl.flock(fh, fcntl.LOCK_EX)
             try:
                 data = json.load(fh)
@@ -224,16 +242,35 @@ def _refresh_access_token(
                         expires_in * 1000
                     )
                 # Write to .tmp then rename for atomicity.
-                tmp_path = Path(str(creds_path) + ".tmp")
+                tmp_path = Path(str(credentials_path) + ".tmp")
                 with open(tmp_path, "w", encoding="utf-8") as tmp_fh:
                     json.dump(data, tmp_fh, indent=2)
-                tmp_path.rename(creds_path)
+                tmp_path.rename(credentials_path)
             finally:
                 fcntl.flock(fh, fcntl.LOCK_UN)
     except Exception:  # stx-allow: fallback (reason: catch-all safety net — see inline comment for context)
         pass  # best-effort write; we still have the new token in memory
 
     return new_access
+
+
+def _refresh_access_token(
+    home: Path,
+    refresh_token: str,
+    client_id: str,
+    *,
+    opener=None,
+) -> str | None:
+    """POST to token endpoint and atomically update credentials file.
+
+    Thin wrapper over ``_refresh_access_token_at`` resolved to
+    ``~/.claude/.credentials.json``. Returns the new access token string,
+    or ``None`` on failure. Tokens are never returned to the caller of
+    ``fetch_usage`` — this is an internal helper only.
+    """
+    return _refresh_access_token_at(
+        _credentials_path(home), refresh_token, client_id, opener=opener
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -493,3 +530,165 @@ def fetch_usage(home: Path | None = None, *, opener=None) -> dict[str, Any]:
 
     _write_cache(_home, result)
     return result
+
+
+# ---------------------------------------------------------------------------
+# Per-account fetch — uses an explicit credentials file, NOT the active one
+# ---------------------------------------------------------------------------
+
+
+def _per_account_cache_path(credentials_path: Path) -> Path:
+    """Cache the per-account usage snapshot next to its credentials file.
+
+    ``<account_dir>/usage.json`` is also the file
+    ``_state.account_store.read_account_usage_cache`` reads, so populating
+    it makes writers and readers symmetric — the ``account list`` JSON
+    path can transparently pick up the cached value across sac
+    invocations without changing the reader.
+    """
+    return credentials_path.parent / "usage.json"
+
+
+def _read_per_account_cache(path: Path) -> dict[str, Any] | None:
+    """Per-account cache reader; same 5-min TTL as the shared cache."""
+    data = _load_json(path)
+    if data is None:
+        return None
+    fetched_at_str = data.get("fetched_at") or data.get("as_of")
+    if not isinstance(fetched_at_str, str):
+        return None
+    # stx-allow: fallback (reason: cache file may contain a malformed timestamp; returning None forces a fresh API fetch)
+    try:
+        fetched_at = datetime.fromisoformat(fetched_at_str)
+        if fetched_at.tzinfo is None:
+            fetched_at = fetched_at.replace(tzinfo=timezone.utc)
+    except ValueError:  # stx-allow: fallback (reason: type coercion or format mismatch)
+        return None
+    age = (_now_utc() - fetched_at).total_seconds()
+    if age < _CACHE_TTL_SECONDS:
+        data["from_cache"] = True
+        return data
+    return None
+
+
+def _write_per_account_cache(path: Path, result: dict[str, Any]) -> None:
+    """Write per-account usage cache atomically; never raises."""
+    # stx-allow: fallback (reason: per-account cache file may be on a read-only filesystem or disk-full; cache is a performance optimisation and callers are unaffected)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = Path(str(path) + ".tmp")
+        with open(tmp, "w", encoding="utf-8") as fh:
+            json.dump(result, fh, indent=2)
+        tmp.rename(path)
+    except Exception:  # stx-allow: fallback (reason: catch-all safety net — see inline comment for context)
+        pass
+
+
+def fetch_usage_for_credentials(
+    credentials_path: Path,
+    *,
+    opener=None,
+) -> dict[str, Any]:
+    """Fetch usage data using the OAuth credentials at ``credentials_path``.
+
+    Per-account variant of :func:`fetch_usage`: reads access/refresh tokens
+    from ``credentials_path`` (NOT ``~/.claude/.credentials.json``),
+    refreshes on expiry by atomically writing back to that same file,
+    fetches the OAuth usage API, and caches the result at
+    ``credentials_path.parent / "usage.json"`` (the same file
+    ``_state.account_store.read_account_usage_cache`` reads, so writers
+    + readers are symmetric).
+
+    The cache is intentionally keyed per-account by the file location:
+    one stored account's cache never masks another's. The TTL matches
+    :func:`fetch_usage` (5 min) so repeated ``sac account list`` calls
+    don't hammer the API.
+
+    Args:
+        credentials_path: Path to the per-account ``.credentials.json``.
+        opener: Optional injection seam for tests.
+
+    Returns:
+        A dict with the same keys as :func:`fetch_usage` plus an extra
+        ``as_of`` (ISO timestamp). Never raises; ``error`` is populated
+        on any failure path.
+    """
+    creds = Path(credentials_path)
+
+    def _err(msg: str) -> dict[str, Any]:
+        r = dict(_EMPTY_RESULT)
+        now = _iso_now()
+        r["fetched_at"] = now
+        r["as_of"] = now
+        r["error"] = msg
+        return r
+
+    # --- cache check (per-account) -----------------------------------------
+    cache_path = _per_account_cache_path(creds)
+    cached = _read_per_account_cache(cache_path)
+    if cached is not None:
+        return cached
+
+    # --- read tokens (never returned) --------------------------------------
+    access_token, refresh_token, client_id, expires_at_ms = _read_tokens_at(creds)
+    if not access_token:
+        return _err(f"No access token in {creds}")
+
+    # --- refresh if expired -------------------------------------------------
+    if _is_token_expired(expires_at_ms):
+        if refresh_token and client_id:
+            new_token = _refresh_access_token_at(
+                creds, refresh_token, client_id, opener=opener
+            )
+            if new_token:
+                access_token = new_token
+            # If refresh failed, try with the old token anyway.
+
+    # --- API call -----------------------------------------------------------
+    payload: dict[str, Any] | None = None
+    # stx-allow: fallback (reason: network errors or unexpected exceptions from the usage API are caught and surfaced as an error dict rather than an unhandled exception)
+    try:
+        payload = _fetch_from_api(access_token, opener=opener)
+    except (
+        urllib.error.HTTPError
+    ) as exc:  # stx-allow: fallback (reason: expected failure — see inline comment)
+        if exc.code == 401 and refresh_token and client_id:
+            # Try refresh once on 401.
+            new_token = _refresh_access_token_at(
+                creds, refresh_token, client_id, opener=opener
+            )
+            if new_token:
+                access_token = new_token
+                # stx-allow: fallback (reason: second API attempt after token refresh may still fail due to network issues; pass lets the 401 handler return an error dict)
+                try:
+                    payload = _fetch_from_api(access_token, opener=opener)
+                except Exception:  # stx-allow: fallback (reason: catch-all safety net — see inline comment for context)
+                    pass
+        if payload is None:
+            return _err(f"HTTP {exc.code} from usage API; refresh attempted")
+    except Exception as exc:  # stx-allow: fallback (reason: catch-all safety net — see inline comment for context)
+        return _err(f"Network error: {exc}")
+
+    if payload is None:
+        return _err("Failed to fetch or parse usage API response")
+
+    # --- build result -------------------------------------------------------
+    result: dict[str, Any] = dict(_EMPTY_RESULT)
+    result.update(_parse_windows(payload))
+    now = _iso_now()
+    result["fetched_at"] = now
+    result["as_of"] = now
+    result["from_cache"] = False
+    result["error"] = None
+
+    # Security guard — must run before cache write.
+    try:
+        _check_no_token_leak(result)
+    except (
+        RuntimeError
+    ) as exc:  # stx-allow: fallback (reason: runtime state error — handled gracefully)
+        return _err(str(exc))
+
+    _write_per_account_cache(cache_path, result)
+    return result
+

--- a/src/scitex_agent_container/cli_pkg/account_group.py
+++ b/src/scitex_agent_container/cli_pkg/account_group.py
@@ -120,11 +120,13 @@ def account_list(as_json: bool) -> None:
       $ sac account list --json
     """
     import json as _json
+    from pathlib import Path as _Path
 
-    from .._account.claude_usage import fetch_usage
+    from .._account.claude_usage import fetch_usage_for_credentials
     from .._account.credentials import read_credentials_metadata
     from .._account.creds_sync import account_freshness
     from .._state.account_store import (
+        _store_path,
         list_accounts,
         read_account_plan,
         read_account_usage_cache,
@@ -132,29 +134,34 @@ def account_list(as_json: bool) -> None:
     from ._helpers import console
     from .status_cmds import _format_claude_account_block
 
-    def _usage_for_account(
-        acct_meta: dict, active_meta: dict | None, live_usage: dict | None
-    ) -> dict | None:
-        # Prefer the live fetch when the row matches the currently active
-        # credentials (matched by email); otherwise fall back to the
-        # per-account usage.json cache (cache-only reader; returns None
-        # → `usage: —` when nothing has populated it).
-        active_email = (active_meta or {}).get("email_address")
-        acct_email = acct_meta.get("email_address")
-        if (
-            live_usage
-            and not live_usage.get("error")
-            and live_usage.get("used_pct_5h") is not None
-            and active_email
-            and acct_email
-            and active_email == acct_email
-        ):
-            return {
-                "used_pct_5h": live_usage.get("used_pct_5h"),
-                "used_pct_7d": live_usage.get("used_pct_7d"),
-                "as_of": live_usage.get("fetched_at"),
-            }
-        return read_account_usage_cache(acct_meta.get("name"))
+    def _usage_for_account(acct_meta: dict) -> dict | None:
+        # Live PER-ACCOUNT fetch using the stored snapshot's tokens. The
+        # snapshot lives at
+        # ``~/.scitex/agent-container/accounts/<name>/.credentials.json``
+        # (cascade-resolved via ``_store_path``); the fetch result is
+        # cached next to that file as ``usage.json`` so the same
+        # ``read_account_usage_cache`` reader sees the live value across
+        # invocations. Any failure (missing snapshot, expired token,
+        # network error) returns None → caller renders ``usage: —`` for
+        # that row only; never crashes the whole list.
+        name = acct_meta.get("name")
+        if not name:
+            return None
+        store = _store_path(None, _Path.home())
+        creds_path = store / name / ".credentials.json"
+        if not creds_path.is_file():
+            return read_account_usage_cache(name)
+        # stx-allow: fallback (reason: fetch_usage_for_credentials is documented never-raise, but defence-in-depth so one bad row never crashes `account list`)
+        try:
+            result = fetch_usage_for_credentials(creds_path)
+        except Exception:  # stx-allow: fallback (reason: catch-all safety net — see inline comment for context)
+            return read_account_usage_cache(name)
+        if result.get("error") or result.get("used_pct_5h") is None:
+            # No live data — try the cache reader as a final fallback so
+            # a stale-but-readable cache still shows something.
+            cached = read_account_usage_cache(name)
+            return cached if cached else None
+        return result
 
     accounts = list_accounts()
 
@@ -164,17 +171,9 @@ def account_list(as_json: bool) -> None:
             active = read_credentials_metadata()
         except (OSError, _json.JSONDecodeError):
             active = {}
-        # Live usage call — gives the active account's row a real value
-        # rather than the unpopulated cache "—". For non-active accounts
-        # we'd need credential-swap fetches (out of scope here).
-        # stx-allow: fallback (reason: fetch_usage already swallows network errors)
-        try:
-            live_usage = fetch_usage()
-        except Exception:  # stx-allow: fallback (reason: defence-in-depth; fetch_usage is documented never-raise)
-            live_usage = None
         # Enrich each stored account with OFFLINE plan/tier, credential
-        # FRESHNESS (VALID/EXPIRED/ABSENT + signed hours), and the live
-        # (or cached) usage snapshot for the matching account.
+        # FRESHNESS (VALID/EXPIRED/ABSENT + signed hours), and a LIVE
+        # per-account usage fetch (cached for 5 min next to the snapshot).
         stored = []
         for acct in accounts:
             entry = dict(acct)
@@ -182,7 +181,7 @@ def account_list(as_json: bool) -> None:
             fresh = account_freshness(acct["name"])
             entry["freshness"] = fresh.state
             entry["freshness_hours"] = fresh.hours
-            entry["usage"] = _usage_for_account(acct, active, live_usage)
+            entry["usage"] = _usage_for_account(acct)
             stored.append(entry)
         click.echo(
             _json.dumps(
@@ -208,16 +207,6 @@ def account_list(as_json: bool) -> None:
             "No accounts stored. Use: scitex-agent-container account save <name>"
         )
         return
-    # Live usage call (single network round-trip) — populates the active
-    # account's row with real values rather than the unpopulated per-account
-    # cache. Non-active rows fall through to read_account_usage_cache (still
-    # "—" until someone wires a credential-swap writer).
-    # stx-allow: fallback (reason: fetch_usage already swallows network errors)
-    try:
-        live_usage = fetch_usage()
-    except Exception:  # stx-allow: fallback (reason: defence-in-depth; fetch_usage is documented never-raise)
-        live_usage = None
-
     click.echo("Stored accounts:")
     for acct in accounts:
         name = acct["name"]
@@ -231,9 +220,10 @@ def account_list(as_json: bool) -> None:
         # operator at a glance which stores have rotted and need a
         # `sac accounts sync-live` (or a `claude /login`).
         fresh = account_freshness(name).label()
-        # Live usage for the active account, else cache-only fallback (— when
-        # the per-account usage.json is absent).
-        usage = _usage_for_account(acct, active_meta, live_usage)
+        # LIVE per-account usage (5-min cache next to the snapshot). On
+        # any failure the helper returns None → "—" for that row only;
+        # the rest of the list keeps rendering.
+        usage = _usage_for_account(acct)
         usage_str = "—"
         if usage:
             pct5 = usage.get("used_pct_5h")

--- a/tests/scitex_agent_container/_account/test_claude_usage.py
+++ b/tests/scitex_agent_container/_account/test_claude_usage.py
@@ -788,3 +788,193 @@ def test_fetch_usage_writes_cache_file_on_success(tmp_path: Path) -> None:
     fetch_usage(home=home, opener=opener)
     # Assert
     assert (home / ".scitex" / "cache" / "claude_usage.json").is_file()
+
+
+# ---------------------------------------------------------------------------
+# fetch_usage_for_credentials — per-account variant.
+# ---------------------------------------------------------------------------
+
+
+def _make_creds_at(path: Path, *, expires_at_ms: int | None = None) -> None:
+    """Write a full Claude Code credentials.json at ``path``."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    creds: dict[str, Any] = {
+        "claudeAiOauth": {
+            "accessToken": "acc",
+            "refreshToken": "ref",
+            "clientId": "cid",
+            "subscriptionType": "pro",
+        }
+    }
+    if expires_at_ms is not None:
+        creds["claudeAiOauth"]["expiresAt"] = expires_at_ms
+    path.write_text(json.dumps(creds))
+
+
+def test_fetch_usage_for_credentials_extracts_pct_from_new_shape(tmp_path: Path) -> None:
+    # Arrange — per-account snapshot with valid token + real new-shape payload.
+    creds = tmp_path / "acct" / ".credentials.json"
+    _make_creds_at(creds, expires_at_ms=int(time.time() * 1000) + 60_000)
+    opener = _opener_returning(
+        {"five_hour": {"utilization": 33}, "seven_day": {"utilization": 11}}
+    )
+    # Act
+    result = cu.fetch_usage_for_credentials(creds, opener=opener)
+    # Assert
+    assert result["used_pct_5h"] == 33.0
+
+
+def test_fetch_usage_for_credentials_writes_usage_json_next_to_creds(
+    tmp_path: Path,
+) -> None:
+    # Arrange
+    creds = tmp_path / "acct" / ".credentials.json"
+    _make_creds_at(creds, expires_at_ms=int(time.time() * 1000) + 60_000)
+    opener = _opener_returning(
+        {"five_hour": {"utilization": 5}, "seven_day": {"utilization": 1}}
+    )
+    # Act
+    cu.fetch_usage_for_credentials(creds, opener=opener)
+    # Assert — cache lands at <acct>/usage.json (same path read by
+    # `_state.account_store.read_account_usage_cache`).
+    assert (tmp_path / "acct" / "usage.json").is_file()
+
+
+def test_fetch_usage_for_credentials_cache_hit_skips_network(tmp_path: Path) -> None:
+    # Arrange — seed a fresh per-account cache.
+    creds = tmp_path / "acct" / ".credentials.json"
+    _make_creds_at(creds, expires_at_ms=int(time.time() * 1000) + 60_000)
+    cache_path = tmp_path / "acct" / "usage.json"
+    cache_path.write_text(
+        json.dumps(
+            {
+                "used_pct_5h": 42,
+                "used_pct_7d": 7,
+                "fetched_at": datetime.now(timezone.utc).isoformat(),
+            }
+        )
+    )
+
+    def must_not_call(req, timeout=None):
+        raise AssertionError("opener called despite fresh per-account cache")
+
+    # Act
+    result = cu.fetch_usage_for_credentials(creds, opener=must_not_call)
+    # Assert
+    assert result["used_pct_5h"] == 42
+
+
+def test_fetch_usage_for_credentials_returns_error_when_no_access_token(
+    tmp_path: Path,
+) -> None:
+    # Arrange — credentials file with no accessToken.
+    creds = tmp_path / "acct" / ".credentials.json"
+    creds.parent.mkdir(parents=True)
+    creds.write_text(json.dumps({"claudeAiOauth": {"subscriptionType": "pro"}}))
+    # Act
+    result = cu.fetch_usage_for_credentials(creds)
+    # Assert
+    assert "No access token" in (result["error"] or "")
+
+
+def test_fetch_usage_for_credentials_returns_error_for_missing_creds_file(
+    tmp_path: Path,
+) -> None:
+    # Arrange
+    creds = tmp_path / "nonexistent" / ".credentials.json"
+    # Act
+    result = cu.fetch_usage_for_credentials(creds)
+    # Assert
+    assert isinstance(result["error"], str) and result["error"]
+
+
+def test_fetch_usage_for_credentials_does_not_leak_tokens_in_result(
+    tmp_path: Path,
+) -> None:
+    # Arrange
+    creds = tmp_path / "acct" / ".credentials.json"
+    _make_creds_at(creds, expires_at_ms=int(time.time() * 1000) + 60_000)
+    opener = _opener_returning(
+        {"five_hour": {"utilization": 10}, "seven_day": {"utilization": 2}}
+    )
+    forbidden = ("accesstoken", "refreshtoken", "sk-ant-", "bearer")
+    # Act
+    result = cu.fetch_usage_for_credentials(creds, opener=opener)
+    # Assert
+    for key in result:
+        kl = key.lower()
+        for needle in forbidden:
+            assert needle not in kl
+
+
+def test_fetch_usage_for_credentials_sets_as_of_iso_timestamp(tmp_path: Path) -> None:
+    # Arrange
+    creds = tmp_path / "acct" / ".credentials.json"
+    _make_creds_at(creds, expires_at_ms=int(time.time() * 1000) + 60_000)
+    opener = _opener_returning(
+        {"five_hour": {"utilization": 8}, "seven_day": {"utilization": 1}}
+    )
+    # Act
+    result = cu.fetch_usage_for_credentials(creds, opener=opener)
+    # Assert — `as_of` is what account_group.py's display path reads.
+    assert isinstance(result["as_of"], str) and result["as_of"]
+
+
+def test_fetch_usage_for_credentials_refreshes_expired_token(tmp_path: Path) -> None:
+    # Arrange — expired token; opener returns refresh then API response.
+    creds = tmp_path / "acct" / ".credentials.json"
+    _make_creds_at(creds, expires_at_ms=0)
+    opener = _opener_sequence(
+        {"access_token": "NEW", "expires_in": 3600},  # refresh
+        {"five_hour": {"utilization": 19}, "seven_day": {"utilization": 3}},
+    )
+    # Act
+    result = cu.fetch_usage_for_credentials(creds, opener=opener)
+    # Assert
+    assert result["used_pct_5h"] == 19.0
+
+
+def test_fetch_usage_for_credentials_writes_refreshed_token_to_same_file(
+    tmp_path: Path,
+) -> None:
+    # Arrange — expired token, refresh succeeds.
+    creds = tmp_path / "acct" / ".credentials.json"
+    _make_creds_at(creds, expires_at_ms=0)
+    opener = _opener_sequence(
+        {"access_token": "ROTATED", "expires_in": 3600},  # refresh
+        {"five_hour": {"utilization": 1}},  # API
+    )
+    # Act
+    cu.fetch_usage_for_credentials(creds, opener=opener)
+    # Assert — rotated token written back to the per-account credentials file.
+    written = json.loads(creds.read_text())
+    assert written["claudeAiOauth"]["accessToken"] == "ROTATED"
+
+
+def test_fetch_usage_for_credentials_per_account_cache_isolation(
+    tmp_path: Path,
+) -> None:
+    # Arrange — two separate accounts with their own creds files.
+    acct_a = tmp_path / "acct-a" / ".credentials.json"
+    acct_b = tmp_path / "acct-b" / ".credentials.json"
+    _make_creds_at(acct_a, expires_at_ms=int(time.time() * 1000) + 60_000)
+    _make_creds_at(acct_b, expires_at_ms=int(time.time() * 1000) + 60_000)
+    # Seed only acct-a's per-account cache.
+    (tmp_path / "acct-a" / "usage.json").write_text(
+        json.dumps(
+            {
+                "used_pct_5h": 99,
+                "fetched_at": datetime.now(timezone.utc).isoformat(),
+            }
+        )
+    )
+    # acct-b opener returns a different value, proving its cache lookup
+    # is NOT hit by acct-a's cache file.
+    opener = _opener_returning(
+        {"five_hour": {"utilization": 4}, "seven_day": {"utilization": 1}}
+    )
+    # Act
+    result_b = cu.fetch_usage_for_credentials(acct_b, opener=opener)
+    # Assert
+    assert result_b["used_pct_5h"] == 4.0
+


### PR DESCRIPTION
## Why
Follow-up to merged PR #247 (which fixed `claude_usage.py` parser + beta
header). After #247, `fetch_usage()` returns real `used_pct_5h` /
`used_pct_7d` for the currently active account, but `sac account list`
still rendered `usage: —` on every stored row because the list reader
only consulted a per-account cache that nothing populated, and the live
`fetch_usage()` call only covered the active account.

This PR makes every row in `sac account list` show real percentages.

## What changed
### `_account/claude_usage.py`
- Extract path-based helpers `_read_tokens_at(credentials_path)` and
  `_refresh_access_token_at(credentials_path, …)`. The legacy
  `_read_tokens(home)` / `_refresh_access_token(home, …)` are now thin
  wrappers so existing tests targeting those signatures still pass
  unchanged.
- New public `fetch_usage_for_credentials(credentials_path, *, opener=None)`:
  - reads tokens from the given file (NOT `~/.claude/.credentials.json`),
  - refreshes on expiry by atomically writing back to that same file,
  - fetches the OAuth usage API (preserving the `anthropic-beta:
    oauth-2025-04-20` header + `claude-code/2.1` UA from #247),
  - caches the result at `<credentials_path.parent>/usage.json` — the
    same file `_state.account_store.read_account_usage_cache` reads, so
    writers and readers are symmetric,
  - cache TTL matches `fetch_usage` (5 min) so repeated `account list`
    calls don't hammer the API,
  - result dict includes an extra `as_of` key (matches the friendlier key
    the account-list display path consumes).
- Per-account cache lives next to its credentials file (one stored
  account's cache never masks another's).

### `cli_pkg/account_group.py`
- Replace the active-only `fetch_usage()` + email-match helper with
  `_usage_for_account(acct)` which calls `fetch_usage_for_credentials`
  on the row's snapshot at
  `~/.scitex/agent-container/accounts/<name>/.credentials.json`
  (resolved via `_store_path`). Every row gets a live (or
  fresh-cached) value. A fetch failure for one account renders `—`
  for that row only — the rest of the list keeps rendering.

### `tests/_account/test_claude_usage.py`
- +10 new AAA / one-assert / no-mocks tests for `fetch_usage_for_credentials`:
  parser on real new-shape dict, `usage.json` written next to creds,
  cache-hit skips opener, error path when no access token, error path
  when creds file missing, no token leak in result keys, `as_of`
  populated, expired-token refresh, refresh writes new token back to
  the SAME file, per-account cache isolation (acct-a's cache does not
  bleed into acct-b's fetch).

## Test results
- `tests/_account/test_claude_usage.py`: **59 / 59 passed** (was 49 in
  the merged #247; +10 new per-account tests, all green; ~1.2s).
- `tests/_account/ + tests/cli_pkg/`: **1275 / 1275 passed** (2
  deselected; was 1265 — same +10).
- Verified operationally: `sac accounts list` shows real percentages for
  every stored account (per lead's confirmation).

## Compliance
- No mocks (PA-306). AAA marker comments. One assert per test.
- No `Co-Authored-By: Claude` trailer.
- `uv pip install -e .` editable install for local validation.
- Worktree branched off `origin/develop`.
