### PR TITLE
fix(dev): align sac dev daemon verbs (list/exec) with scitex-dev ecosystem

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_dev_jobs.py
+++ b/src/scitex_agent_container/cli_pkg/_dev_jobs.py
@@ -1,9 +1,20 @@
 """``sac dev {cron,daemon,systemd}`` — sac's federated scheduled jobs.
 
 Surfaces sac's OWN jobs (``sac.*``) by delegating to scitex-dev's
-ecosystem aggregator (``scitex_dev.jobs``). ``install`` / ``uninstall``
-delegate to ``scitex-dev ecosystem <kind> {install,uninstall}`` so the
-unit/cron generation stays single-sourced in scitex-dev.
+ecosystem aggregator (``scitex_dev.jobs``).
+
+The verbs per job-kind mirror scitex-dev's canonical ecosystem
+aggregator exactly (``scitex-dev ecosystem <kind> <verb>``):
+
+* ``cron``    → ``list`` / ``install`` / ``uninstall``
+* ``systemd`` → ``list`` / ``install`` / ``uninstall``
+* ``daemon``  → ``list`` / ``exec``   (a daemon is *run*, not "installed")
+
+``install`` / ``uninstall`` delegate to
+``scitex-dev ecosystem <kind> {install,uninstall} --name <name>`` so the
+unit/cron generation stays single-sourced in scitex-dev; ``exec``
+delegates to ``scitex-dev ecosystem daemon exec <name>`` (positional
+job-name argument, like scitex-dev's own ``daemon exec``).
 
 Graceful degradation: a scitex-dev that predates the ``scitex_dev.jobs``
 contract (PyPI lag — the contract is unreleased at the time of writing)
@@ -52,8 +63,15 @@ def _load_sac_jobs(kind: str) -> list:
     return [j for j in jobs_of_kind(kind) if j.name.startswith(_SAC_PREFIX)]
 
 
-def _ecosystem_delegate(kind: str, verb: str, name: str, yes: bool) -> int:
-    """Delegate to ``scitex-dev ecosystem <kind> <verb> --name <name>``.
+def _ecosystem_delegate(kind: str, verb: str, name: str, yes: bool = False) -> int:
+    """Delegate to ``scitex-dev ecosystem <kind> <verb> ... <name>``.
+
+    The job-name is passed the way each canonical verb expects it:
+
+    * ``daemon exec`` takes a *positional* ``NAME`` argument (and no
+      ``--yes``), matching ``scitex-dev ecosystem daemon exec <name>``.
+    * ``cron``/``systemd`` ``install``/``uninstall`` take ``--name
+      <name>`` (and optionally ``--yes``).
 
     Returns the subprocess exit code. ``scitex-dev`` is a hard dependency
     of this package, so the console script is expected on PATH; a missing
@@ -64,30 +82,19 @@ def _ecosystem_delegate(kind: str, verb: str, name: str, yes: bool) -> int:
         raise click.ClickException(
             "`scitex-dev` console script not found on PATH; " + _degrade_msg()
         )
+    if kind == "daemon" and verb == "exec":
+        # `daemon exec` runs in the foreground via a positional NAME.
+        return subprocess.call([exe, "ecosystem", kind, verb, name])
     cmd = [exe, "ecosystem", kind, verb, "--name", name]
     if yes:
         cmd.append("--yes")
     return subprocess.call(cmd)
 
 
-def _make_kind_group(kind: str):
-    """Build a ``sac dev <kind>`` group with list/install/uninstall."""
+def _add_list_command(grp, kind: str) -> None:
+    """Attach the shared ``list`` read-verb onto a kind group."""
 
-    @click.group(kind, invoke_without_command=True)
-    @click.pass_context
-    def _grp(ctx):
-        if ctx.invoked_subcommand is None:
-            click.echo(ctx.get_help())
-
-    _grp.help = (
-        f"sac's federated {kind} jobs (delegates to scitex-dev ecosystem).\n\n"
-        "\b\nVerbs:\n"
-        "  list       — show sac's own jobs of this kind\n"
-        "  install    — generate + install them via scitex-dev\n"
-        "  uninstall  — remove them via scitex-dev"
-    )
-
-    @_grp.command("list")
+    @grp.command("list")
     @click.option("--json", "as_json", is_flag=True, help="Output as JSON.")
     def _list(as_json):
         """List sac's own jobs of this kind."""
@@ -95,7 +102,7 @@ def _make_kind_group(kind: str):
 
         try:
             jobs = _load_sac_jobs(kind)
-        except ImportError:
+        except ImportError:  # stx-allow: fallback (reason: old scitex-dev lacks scitex_dev.jobs — print upgrade hint, not a stack trace)
             click.echo(_degrade_msg(), err=True)
             raise SystemExit(3)
         if as_json:
@@ -123,6 +130,31 @@ def _make_kind_group(kind: str):
             click.echo(f"  {'':24s} {j.command}")
             click.echo(f"  {'':24s} {j.description}")
 
+
+def _make_installable_group(kind: str):
+    """Build a ``sac dev <kind>`` group with list/install/uninstall.
+
+    Used for the ``cron`` and ``systemd`` job-kinds — both of which are
+    *installed* (materialised into a crontab block / systemd unit files)
+    by scitex-dev. Mirrors ``scitex-dev ecosystem <kind>``.
+    """
+
+    @click.group(kind, invoke_without_command=True)
+    @click.pass_context
+    def _grp(ctx):
+        if ctx.invoked_subcommand is None:
+            click.echo(ctx.get_help())
+
+    _grp.help = (
+        f"sac's federated {kind} jobs (delegates to scitex-dev ecosystem).\n\n"
+        "\b\nVerbs:\n"
+        "  list       — show sac's own jobs of this kind\n"
+        "  install    — generate + install them via scitex-dev\n"
+        "  uninstall  — remove them via scitex-dev"
+    )
+
+    _add_list_command(_grp, kind)
+
     @_grp.command("install")
     @click.option(
         "-y",
@@ -135,7 +167,7 @@ def _make_kind_group(kind: str):
         """Install sac's jobs of this kind via scitex-dev."""
         try:
             jobs = _load_sac_jobs(kind)
-        except ImportError:
+        except ImportError:  # stx-allow: fallback (reason: old scitex-dev lacks scitex_dev.jobs — print upgrade hint, not a stack trace)
             click.echo(_degrade_msg(), err=True)
             raise SystemExit(3)
         if not jobs:
@@ -159,7 +191,7 @@ def _make_kind_group(kind: str):
         """Uninstall sac's jobs of this kind via scitex-dev."""
         try:
             jobs = _load_sac_jobs(kind)
-        except ImportError:
+        except ImportError:  # stx-allow: fallback (reason: old scitex-dev lacks scitex_dev.jobs — print upgrade hint, not a stack trace)
             click.echo(_degrade_msg(), err=True)
             raise SystemExit(3)
         if not jobs:
@@ -174,10 +206,59 @@ def _make_kind_group(kind: str):
     return _grp
 
 
+def _make_daemon_group():
+    """Build the ``sac dev daemon`` group with list/exec.
+
+    A daemon is a long-running process that is *run* (not "installed"),
+    so this group exposes ``exec`` (run one job in the foreground) rather
+    than install/uninstall — matching ``scitex-dev ecosystem daemon``.
+    """
+
+    @click.group("daemon", invoke_without_command=True)
+    @click.pass_context
+    def _grp(ctx):
+        if ctx.invoked_subcommand is None:
+            click.echo(ctx.get_help())
+
+    _grp.help = (
+        "sac's federated daemon jobs (delegates to scitex-dev ecosystem).\n\n"
+        "\b\nVerbs:\n"
+        "  list  — show sac's own daemon jobs\n"
+        "  exec  — run one sac daemon job in the foreground via scitex-dev"
+    )
+
+    _add_list_command(_grp, "daemon")
+
+    @_grp.command("exec")
+    @click.argument("name")
+    def _exec(name):
+        """Run the sac daemon job NAME in the foreground via scitex-dev.
+
+        \b
+        Blocks until the process exits; the caller is responsible for
+        backgrounding / supervision. Delegates to
+        `scitex-dev ecosystem daemon exec <name>`.
+        """
+        try:
+            jobs = {j.name: j for j in _load_sac_jobs("daemon")}
+        except ImportError:  # stx-allow: fallback (reason: old scitex-dev lacks scitex_dev.jobs — print upgrade hint, not a stack trace)
+            click.echo(_degrade_msg(), err=True)
+            raise SystemExit(3)
+        if name not in jobs:
+            known = ", ".join(sorted(jobs)) or "(none)"
+            raise click.ClickException(
+                f"unknown sac daemon job: {name!r}. Known jobs: {known}"
+            )
+        raise SystemExit(_ecosystem_delegate("daemon", "exec", name))
+
+    return _grp
+
+
 def register_dev_jobs_commands(dev_group: click.Group) -> None:
     """Attach the ``cron`` / ``daemon`` / ``systemd`` groups onto ``sac dev``."""
-    for kind in ("cron", "daemon", "systemd"):
-        dev_group.add_command(_make_kind_group(kind))
+    for kind in ("cron", "systemd"):
+        dev_group.add_command(_make_installable_group(kind))
+    dev_group.add_command(_make_daemon_group())
 
 
 __all__ = ["register_dev_jobs_commands"]

--- a/tests/scitex_agent_container/cli_pkg/test__dev_jobs.py
+++ b/tests/scitex_agent_container/cli_pkg/test__dev_jobs.py
@@ -153,3 +153,114 @@ def test_install_degrades_when_jobs_absent() -> None:
     # Assert
     text = (result.output or "") + (getattr(result, "stderr", "") or "")
     assert "requires scitex-dev>=" in text
+
+
+# ---------------------------------------------------------------------------
+# verb consistency with scitex-dev ecosystem aggregator
+#
+# Canonical verbs per job-kind (scitex-dev ecosystem):
+#   cron    → list / install / uninstall
+#   systemd → list / install / uninstall
+#   daemon  → list / exec   (a daemon is *run*, not "installed")
+# ---------------------------------------------------------------------------
+
+
+def _verbs_of(kind: str) -> set[str]:
+    """The leaf subcommand names exposed under ``sac dev <kind>``."""
+    grp = dev_group.commands[kind]
+    return set(grp.commands)  # type: ignore[attr-defined]
+
+
+def test_cron_verbs_are_list_install_uninstall() -> None:
+    # Arrange
+    kind = "cron"
+    # Act
+    verbs = _verbs_of(kind)
+    # Assert
+    assert verbs == {"list", "install", "uninstall"}
+
+
+def test_systemd_verbs_are_list_install_uninstall() -> None:
+    # Arrange
+    kind = "systemd"
+    # Act
+    verbs = _verbs_of(kind)
+    # Assert
+    assert verbs == {"list", "install", "uninstall"}
+
+
+def test_daemon_verbs_are_list_exec() -> None:
+    # Arrange — daemon is run, not installed: list + exec, no
+    # install/uninstall (matches scitex-dev ecosystem daemon).
+    kind = "daemon"
+    # Act
+    verbs = _verbs_of(kind)
+    # Assert
+    assert verbs == {"list", "exec"}
+
+
+def test_daemon_has_no_install_verb() -> None:
+    # Arrange
+    kind = "daemon"
+    # Act
+    verbs = _verbs_of(kind)
+    # Assert — explicit: the wrong install/uninstall verbs are gone.
+    assert "install" not in verbs and "uninstall" not in verbs
+
+
+def test_daemon_exec_takes_positional_name_argument() -> None:
+    # Arrange — exec mirrors `scitex-dev ecosystem daemon exec <name>`.
+    exec_cmd = dev_group.commands["daemon"].commands["exec"]  # type: ignore[attr-defined]
+    # Act
+    arg_names = [p.name for p in exec_cmd.params if p.param_type_name == "argument"]
+    # Assert
+    assert arg_names == ["name"]
+
+
+def _sac_daemon_job() -> _Job:
+    return _Job(
+        name="sac.watcher",
+        schedule="-",
+        command="sac listen --forever",
+        description="Long-running sac watcher.",
+        kind="daemon",
+    )
+
+
+def test_daemon_exec_delegates_to_scitex_dev_with_positional_name() -> None:
+    # Arrange — capture the (kind, verb, name) the exec verb delegates with.
+    import scitex_agent_container.cli_pkg._dev_jobs as dj
+
+    captured: list[tuple] = []
+    original = dj._ecosystem_delegate
+    dj._ecosystem_delegate = lambda *a, **k: (captured.append(a) or 0)  # type: ignore[assignment]
+    try:
+        with _jobs_present([_sac_daemon_job()]):
+            runner = CliRunner()
+            # Act
+            runner.invoke(dev_group, ["daemon", "exec", "sac.watcher"])
+    finally:
+        dj._ecosystem_delegate = original  # type: ignore[assignment]
+    # Assert — delegated as (kind="daemon", verb="exec", name="sac.watcher").
+    assert captured == [("daemon", "exec", "sac.watcher")]
+
+
+def test_daemon_exec_rejects_unknown_job() -> None:
+    # Arrange — only sac.watcher exists.
+    with _jobs_present([_sac_daemon_job()]):
+        runner = CliRunner()
+        # Act
+        result = runner.invoke(dev_group, ["daemon", "exec", "does.not.exist"])
+    # Assert — clean ClickException, not a delegated run.
+    assert result.exit_code != 0 and "unknown sac daemon job" in result.output
+
+
+def test_daemon_exec_degrades_when_jobs_absent() -> None:
+    # Arrange
+    with _jobs_absent():
+        runner = CliRunner()
+        # Act
+        result = runner.invoke(dev_group, ["daemon", "exec", "sac.watcher"])
+    # Assert
+    text = (result.output or "") + (getattr(result, "stderr", "") or "")
+    assert "requires scitex-dev>=" in text


### PR DESCRIPTION
## Problem

`sac dev {cron,daemon,systemd}` built all three job-kind subgroups with the
same `list / install / uninstall` verbs via a single `_make_kind_group`. That
left the **daemon** subgroup wrongly exposing `install` / `uninstall` and
lacking `exec` — diverging from scitex-dev's canonical ecosystem aggregator,
where a daemon is *run*, not "installed".

## Canonical verbs (scitex-dev `ecosystem`)

| kind    | verbs                        |
|---------|------------------------------|
| cron    | list / install / uninstall   |
| systemd | list / install / uninstall   |
| daemon  | **list / exec**              |

(Confirmed against `scitex_dev/_cli/ecosystem/_cmds/_jobs_{cron,daemon,systemd}.py`.)

## Change

- Split the builder into `_make_installable_group` (cron/systemd) and
  `_make_daemon_group` (list + exec), sharing the `list` read-verb.
- `daemon exec` takes a **positional `NAME`** and delegates to
  `scitex-dev ecosystem daemon exec <name>` — matching scitex-dev's own
  `daemon exec` (no `--name`, no `--yes`).
- `_ecosystem_delegate` now maps `daemon`->`exec` (positional name) vs
  `cron`/`systemd`->`install`/`uninstall` (`--name` / `--yes`).
- Graceful-degradation upgrade hint preserved on every verb (old scitex-dev
  without `scitex_dev.jobs`).

## Tests

Extended `tests/.../test__dev_jobs.py`:
- per-kind verb sets (`cron`/`systemd` = list/install/uninstall; `daemon` = list/exec)
- explicit assertion that daemon has **no** install/uninstall
- `daemon exec` takes a positional `name` and delegates as `("daemon","exec",name)`
- unknown-job rejection + graceful degrade for `exec`

14 `_dev_jobs` tests pass; full `cli_pkg/` suite: 1035 passed.

The noun-verb CLI audit (`scitex-dev quality audit-cli scitex-agent-container`)
passes with **zero** violations (`exec` is the audit-approved transitive verb —
which is why scitex-dev uses `exec`, not `run`).