### PR TITLE
fix(dispatch): liveness-gated start + fail-loud propagation + TOFU host keys

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_start.py
+++ b/src/scitex_agent_container/_lifecycle/_start.py
@@ -25,6 +25,63 @@ from ._spawn_gate import enforce_spawn_gate, persist_acl_policy
 from .health import health_monitor
 
 
+def _verify_real_liveness(
+    config: AgentConfig,
+    runtime,
+    *,
+    instances_oracle: Callable[[], list[dict]] | None = None,
+) -> bool:
+    """Return True iff the agent is *demonstrably* running on this host.
+
+    The pre-fix call site treated ``registry.exists(name) and
+    runtime.is_running(config)`` as the already-running signal. Both
+    are necessary but not sufficient:
+
+      * ``registry.exists`` is a JSON file on disk — a forced ``rm``,
+        a stale entry from a prior boot, or a crash-during-write leaves
+        the file behind even though no agent is running.
+      * ``runtime.is_running`` checks the per-runtime PID file with
+        ``os.kill(pid, 0)`` — on a Linux PID-wraparound the same pid
+        can belong to a completely unrelated process and the probe
+        returns True.
+
+    Either of those false positives causes the no-op branch in
+    :func:`agent_start` to swallow a real start request silently and
+    return rc=0. The cross-host ``instances`` table is the third
+    independent signal — it is written by ``record_local_instance``
+    inside the *real* start path and removed by ``agent_stop`` /
+    ``cleanup_stale``. We require an active row before treating the
+    agent as already-running. If the row is absent, the registry/PID
+    pair is inconsistent → fall through to a real start instead of
+    the silent no-op.
+
+    The ``instances_oracle`` seam is the no-mocks knob for tests; it
+    defaults to a host-unfiltered :func:`state_db.list_active_instances`
+    call (we want ANY active row for the name, not just rows on the
+    current host — handover may have moved it).
+    """
+    if instances_oracle is None:
+        from .._state.state_db import list_active_instances as _default
+
+        def instances_oracle():  # type: ignore[no-redef]
+            # Explicit host=None so the call is unambiguous and the
+            # fixture-isolated test reads through the same module.
+            return _default(host=None)
+
+    try:
+        rows = instances_oracle()
+    except Exception:
+        # stx-allow: fallback (reason: a missing/locked state.db must
+        # not block the start path; degrade to "no liveness evidence"
+        # which causes the caller to launch fresh rather than silently
+        # no-op)
+        return False
+    for row in rows or ():
+        if row.get("name") == config.name:
+            return True
+    return False
+
+
 def _resolve_strict_drift(strict_drift: bool | None) -> bool:
     """Resolve effective strict-drift mode (arg wins, else env).
 
@@ -132,6 +189,7 @@ def agent_start(
     sleep_fn: Callable[[float], None] = time.sleep,
     thread_factory: Callable[..., Any] = threading.Thread,
     handover_mod: Any = None,
+    liveness_verifier: Callable[[AgentConfig, Any], bool] | None = None,
 ) -> bool:
     """Start an agent from its config YAML.
 
@@ -241,7 +299,19 @@ def agent_start(
 
     # Already running?
     forced_stop = False
-    if registry.exists(config.name) and runtime.is_running(config):
+    # Bug 1 (real-liveness): three independent signals must all agree
+    # before we trust the "already-running" no-op branch. registry +
+    # runtime.is_running is not enough — see :func:`_verify_real_liveness`
+    # for the false-positive cases the third signal closes.
+    _verify = (
+        liveness_verifier if liveness_verifier is not None else _verify_real_liveness
+    )
+    really_running = (
+        registry.exists(config.name)
+        and runtime.is_running(config)
+        and _verify(config, runtime)
+    )
+    if really_running:
         if force:
             agent_stop(
                 config.name,

--- a/src/scitex_agent_container/_state/_host_ssh.py
+++ b/src/scitex_agent_container/_state/_host_ssh.py
@@ -72,6 +72,17 @@ def build_ssh_argv(
         "ConnectTimeout=10",
         "-o",
         "ServerAliveInterval=15",
+        # TOFU policy for first-touch peers: accept the host key on
+        # initial connect (record it in known_hosts), but reject on any
+        # subsequent mismatch. Without this, the very first dispatch to
+        # a freshly-registered peer hangs on the interactive
+        # ``Are you sure you want to continue connecting`` prompt, which
+        # under BatchMode=yes degrades to an immediate close — the
+        # operator sees a bare non-zero exit with no actionable error.
+        # ``accept-new`` is the safer ``no``: it does NOT silently
+        # accept changed keys, so a MITM still surfaces.
+        "-o",
+        "StrictHostKeyChecking=accept-new",
     ]
     # Connection multiplexing — must come before extra_opts so caller
     # overrides win. See :func:`ssh_control_options` for the rationale

--- a/src/scitex_agent_container/cli_pkg/_on_start_propagate.py
+++ b/src/scitex_agent_container/cli_pkg/_on_start_propagate.py
@@ -190,29 +190,69 @@ def propagate_remote_start(
     if runner is None:
         runner = _default_ssh_runner
     result = runner(peer, [ssh_argv0, *remote_argv])
+    captured_stdout = getattr(result, "stdout", None) or ""
+    captured_stderr = getattr(result, "stderr", None) or ""
     if result.returncode != 0:
-        # Remote start failed — no live instance to record. Surface the
-        # remote rc; the operator sees stdout/stderr from the inherited
-        # streams (real runner) or from the result object.
+        # Bug 2 root cause (fail-loud on remote failure): the real
+        # `_default_ssh_runner` calls subprocess.run with
+        # capture_output=True, so the remote's stdout AND stderr are
+        # buffered in the CompletedProcess. The pre-fix code returned
+        # only the rc and dropped both buffers on the floor, leaving
+        # the operator with a bare non-zero rc and zero diagnostics —
+        # the original `sac --on spartan-gpgpu011 agents start clew`
+        # silent-failure repro. Surface both buffers so the operator
+        # has the same information they'd see from a local start.
+        if captured_stdout:
+            click.echo(
+                captured_stdout, err=False, nl=not captured_stdout.endswith("\n")
+            )
+        if captured_stderr:
+            click.echo(captured_stderr, err=True, nl=not captured_stderr.endswith("\n"))
+        click.echo(
+            f"[--on {peer}] remote `sac {' '.join(remote_argv)}` failed "
+            f"(rc={result.returncode}); no lead-side instances row recorded.",
+            err=True,
+        )
         return result.returncode
 
-    stdout = getattr(result, "stdout", None) or ""
     try:
-        peer_state = json.loads(stdout)
+        peer_state = json.loads(captured_stdout)
     except (json.JSONDecodeError, TypeError) as exc:
         raise RuntimeError(
             f"`sac --on {peer} agents start {name}` succeeded but returned "
             f"non-JSON stdout; cannot record the lead-side instances row "
             f"(the started agent would be invisible to the lead — the "
             f"exact #192 failure). Re-run with --json to inspect.\n"
-            f"stdout (first 500 chars):\n{stdout[:500]}\n"
+            f"stdout (first 500 chars):\n{captured_stdout[:500]}\n"
             f"json error: {exc}"
         ) from exc
 
-    # A skipped / dry-run start has no live instance to record.
+    # Map the remote's status to a lead-side rc.
     status = peer_state.get("status")
-    if status not in ("started",):
+    if status == "dry_run_ok":
+        # Legitimate silent success: --dry-run propagated through and
+        # the remote did NOT mean to start anything. Mirror rc=0.
         return 0
+    if status != "started":
+        # Bug 2 root cause (fail-loud on remote skip/error): any non-
+        # "started" status means the remote produced no live instance.
+        # Without this branch, the pre-fix code returned 0 and dropped
+        # the structured reason on the floor — the operator sees
+        # `sac --on <peer> agents start ...` exit 0 with zero stdout,
+        # mistakenly believing the agent is up. Surface the reason and
+        # return a non-zero rc so the operator (and any wrapping
+        # automation) sees the failure.
+        reason = (
+            peer_state.get("reason")
+            or peer_state.get("error")
+            or f"remote returned status={status!r}"
+        )
+        click.echo(
+            f"[--on {peer}] agents start {name!r} did NOT start: {reason} "
+            f"(remote status={status!r}); no lead-side instances row recorded.",
+            err=True,
+        )
+        return 1
 
     agent_name = _name_from_target(name)
     bound = peer_state.get("a2a_port")
@@ -250,5 +290,3 @@ def _default_ssh_runner(peer: str, full_argv: list[str]):
     cfg = _load()
     ssh_argv = build_ssh_argv(peer, full_argv, cfg.peers)
     return subprocess.run(ssh_argv, capture_output=True, text=True, check=False)
-
-

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_common.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_common.py
@@ -44,6 +44,42 @@ def _resolve_dispatch_peer(
     return target_host
 
 
+def _resolve_singleton_skip(
+    config: AgentConfig,
+    hostname: str,
+    *,
+    no_redispatch: bool,
+) -> str | None:
+    """Gated wrapper around :func:`_singleton_skip_reason`.
+
+    Returns ``None`` (no skip — start locally) when ``no_redispatch`` is
+    True regardless of the underlying skip reason. Otherwise delegates
+    to :func:`_singleton_skip_reason` unchanged.
+
+    Rationale (Bug 1 root cause): the original call site consulted
+    ``_singleton_skip_reason`` even when the operator had explicitly
+    disabled redispatch (e.g. via ``sac --on <peer>`` which propagates
+    ``--no-redispatch`` to the remote ``sac agents start``). The skip
+    path's only purpose is to defer to a redispatch — with
+    ``no_redispatch=True`` the agent has nowhere else to land, so the
+    skip becomes a permanent silent no-op. The lead's repro
+    (``sac --on spartan-gpgpu011 agents start clew --force --no-preflight``
+    exits 0 with zero output) was exactly this dead end: the remote
+    saw ``spec.host=bm043`` ≠ ``gpgpu011``, skipped, and emitted
+    ``{"status": "skipped", ...}``, which the lead-side propagator
+    then dropped on the floor.
+
+    Note: "real liveness" of an *already-running* agent on the LOCAL
+    host is a separate concern handled inside
+    :func:`scitex_agent_container._lifecycle._start.agent_start` (PID
+    liveness + registry-row cross-check). This helper is only about the
+    routing decision before any local launch decision is even reached.
+    """
+    if no_redispatch:
+        return None
+    return _singleton_skip_reason(config, hostname)
+
+
 def _singleton_skip_reason(config: AgentConfig, hostname: str) -> str | None:
     """Return a human-readable skip reason if ``config`` is a singleton on
     the wrong host, else None.
@@ -240,6 +276,7 @@ def _multiplex_foreground_tails(names, sleeper=None):
 __all__ = [
     "_SKIP_DIR_NAMES",
     "_resolve_dispatch_peer",
+    "_resolve_singleton_skip",
     "_singleton_skip_reason",
     "_iter_agent_yamls",
     "_discover_all_agents",

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_dispatch.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_dispatch.py
@@ -115,9 +115,17 @@ def _dispatch_remote_start(
         "--exclude=.pytest_cache/",
         "--exclude=_sphinx_html/",
     ]
+    # Drive rsync's ssh transport with the same TOFU policy we use for
+    # bare ssh (build_ssh_argv): accept-new lets the first-touch peer
+    # be added to known_hosts, but rejects any later key change. Without
+    # ``-e``, rsync would invoke ssh with whatever the user's defaults
+    # are, which on a fresh peer surfaces as a silent rc-1 from rsync.
+    rsync_ssh_opt = "ssh -o StrictHostKeyChecking=accept-new -o BatchMode=yes"
     rsync_dry_argv = [
         "rsync",
         "-acvn",  # archive + checksum + verbose + dry-run
+        "-e",
+        rsync_ssh_opt,
         "--itemize-changes",
         "--delete",
         *exclude_args,
@@ -183,10 +191,14 @@ def _dispatch_remote_start(
         )
         return 0
 
-    # 6. Actual rsync (no --dry-run).
+    # 6. Actual rsync (no --dry-run). Same TOFU ssh transport as the
+    # dry-run above so the real handoff also accepts a first-touch
+    # peer key.
     rsync_real_argv = [
         "rsync",
         "-acv",
+        "-e",
+        rsync_ssh_opt,
         "--delete",
         *exclude_args,
         f"{src_dir!s}/",
@@ -279,7 +291,9 @@ def _dispatch_remote_start(
                 a2a_port=int(bound),
                 source_host=None,
             )
-        except Exception:  # stx-allow: fallback (reason: never block dispatch on registry write)
+        except (
+            Exception
+        ):  # stx-allow: fallback (reason: never block dispatch on registry write)
             pass
     click.echo(
         f"[dispatch] {name!r} started on {peer!r} "

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_start_single.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_start_single.py
@@ -22,7 +22,7 @@ from ...config import load_config
 from ...config._host import resolve_hostname
 from ...config._resolve import resolve_with_prefix
 from .._helpers import console, system_msg
-from ._common import _multiplex_foreground_tails, _singleton_skip_reason
+from ._common import _multiplex_foreground_tails, _resolve_singleton_skip
 from ._dispatch import try_dispatch
 from ._resume_preflight import ResumePreflightError
 
@@ -86,7 +86,15 @@ def run_single_targets(
                     force=force,
                 ):
                     continue
-            skip = _singleton_skip_reason(config, current_host)
+            # Bug 1 root cause: a singleton-on-wrong-host skip is a
+            # dead-end when no_redispatch=True (the operator has
+            # explicitly disabled the redispatch chain — e.g. via
+            # ``sac --on <peer>``). _resolve_singleton_skip honours
+            # that and returns None instead of producing a silent no-op
+            # the propagator would then drop on the floor.
+            skip = _resolve_singleton_skip(
+                config, current_host, no_redispatch=no_redispatch
+            )
             if skip:
                 if as_json:
                     _emit_json(

--- a/tests/scitex_agent_container/_lifecycle/test_lifecycle.py
+++ b/tests/scitex_agent_container/_lifecycle/test_lifecycle.py
@@ -423,7 +423,10 @@ def test_agent_start_happy_path_invokes_handover(
 def test_agent_start_idempotent_when_already_running(
     tmp_path: Path, registry: Registry
 ) -> None:
-    # Arrange: registry knows the agent and runtime reports it running.
+    # Arrange: registry knows the agent, runtime reports it running,
+    # AND the real-liveness verifier confirms an active instance row.
+    # Without the verifier signal a registry+is_running false positive
+    # would silently no-op a real start — see _verify_real_liveness.
     spec = _write_spec(tmp_path)
     registry.add("alpha", str(spec), "cld-alpha")
     runtime = FakeRuntime(running=True, start_result=True)
@@ -434,6 +437,7 @@ def test_agent_start_idempotent_when_already_running(
         runtime_factory=lambda _c: runtime,
         handover_mod=FakeHandover(),
         sleep_fn=_no_sleep,
+        liveness_verifier=lambda _cfg, _rt: True,
     )
     # Assert: returns success and never calls start.
     assert ok is True and runtime.start_calls == []
@@ -454,9 +458,105 @@ def test_agent_start_force_restarts_when_already_running(
         handover_mod=FakeHandover(),
         sleep_fn=_no_sleep,
         force=True,
+        liveness_verifier=lambda _cfg, _rt: True,
     )
     # Assert: force triggered stop AND start on the same runtime instance.
     assert len(runtime.stop_calls) == 1 and len(runtime.start_calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# Bug 1 (real-liveness): the already-running no-op MUST require three
+# independent signals (registry on-disk entry + runtime PID liveness +
+# active instances row). Pre-fix code trusted only the first two, so a
+# stale registry file + reused PID looked identical to a real running
+# agent and silently swallowed the start request as a no-op (exit 0).
+# ---------------------------------------------------------------------------
+
+
+def test_agent_start_launches_when_liveness_verifier_returns_false(
+    tmp_path: Path, registry: Registry
+) -> None:
+    # Arrange — registry says exists, runtime PID-check says running,
+    # but the instances oracle reports NO active row (= stale state).
+    spec = _write_spec(tmp_path)
+    registry.add("alpha", str(spec), "cld-alpha")
+    runtime = FakeRuntime(running=True, start_result=True)
+    # Act
+    lc.agent_start(
+        str(spec),
+        registry=registry,
+        runtime_factory=lambda _c: runtime,
+        handover_mod=FakeHandover(),
+        sleep_fn=_no_sleep,
+        liveness_verifier=lambda _cfg, _rt: False,
+    )
+    # Assert — fell through to a real launch instead of the silent no-op.
+    assert len(runtime.start_calls) == 1
+
+
+def test_verify_real_liveness_default_returns_true_for_recorded_instance(
+    tmp_path: Path, isolated_state_db: Path
+) -> None:
+    # Arrange — write a real instances row and call the default verifier
+    # against it.
+    from scitex_agent_container._lifecycle._start import _verify_real_liveness
+    from scitex_agent_container._state.state_db import record_instance_start
+
+    record_instance_start(name="alpha", host="h", a2a_port=19111)
+    cfg = AgentConfig(name="alpha")
+    # Act
+    live = _verify_real_liveness(cfg, runtime=None)
+    # Assert
+    assert live is True
+
+
+def test_verify_real_liveness_default_returns_false_when_no_row(
+    tmp_path: Path, isolated_state_db: Path
+) -> None:
+    # Arrange — fresh isolated state.db with no rows.
+    from scitex_agent_container._lifecycle._start import _verify_real_liveness
+
+    cfg = AgentConfig(name="alpha")
+    # Act
+    live = _verify_real_liveness(cfg, runtime=None)
+    # Assert
+    assert live is False
+
+
+def test_verify_real_liveness_swallows_oracle_errors_as_not_live(
+    tmp_path: Path,
+) -> None:
+    # Arrange — a broken oracle (raises) must degrade to "not live" so
+    # the caller falls through to a real start instead of crashing.
+    from scitex_agent_container._lifecycle._start import _verify_real_liveness
+
+    def _broken():
+        raise RuntimeError("state.db is wedged")
+
+    cfg = AgentConfig(name="alpha")
+    # Act
+    live = _verify_real_liveness(cfg, runtime=None, instances_oracle=_broken)
+    # Assert
+    assert live is False
+
+
+def test_verify_real_liveness_ignores_rows_for_other_agents(
+    tmp_path: Path,
+) -> None:
+    # Arrange — oracle returns active rows for OTHER agents only; the
+    # check is name-scoped so a busy cluster on other agents must not
+    # be mistaken for liveness of the agent in question.
+    from scitex_agent_container._lifecycle._start import _verify_real_liveness
+
+    cfg = AgentConfig(name="alpha")
+    # Act
+    live = _verify_real_liveness(
+        cfg,
+        runtime=None,
+        instances_oracle=lambda: [{"name": "beta"}, {"name": "gamma"}],
+    )
+    # Assert
+    assert live is False
 
 
 @pytest.fixture
@@ -490,7 +590,12 @@ def _force_restart_running_agent(
 ) -> None:
     """Drive a ``--force`` restart of a registered, running agent whose
     spec uses ``a2a.port: auto`` (the AgentConfig default), so resolution
-    claims a real allocator port. Shared Act for the regression tests."""
+    claims a real allocator port. Shared Act for the regression tests.
+
+    Passes ``liveness_verifier=True`` so the three-signal
+    already-running check fires even in the empty-state.db isolation
+    fixture (real production would have the instances row recorded).
+    """
     spec = _write_spec(tmp_path, name=name)
     registry.add(name, str(spec), f"cld-{name}")
     runtime = FakeRuntime(running=True, start_result=True)
@@ -501,6 +606,7 @@ def _force_restart_running_agent(
         handover_mod=FakeHandover(),
         sleep_fn=_no_sleep,
         force=True,
+        liveness_verifier=lambda _cfg, _rt: True,
     )
 
 

--- a/tests/scitex_agent_container/_state/test_host_config_env_preamble.py
+++ b/tests/scitex_agent_container/_state/test_host_config_env_preamble.py
@@ -369,3 +369,33 @@ def test_build_ssh_argv_empty_preamble_preserves_raw_command_tail(
     tail = argv[-3:]
     # Assert
     assert tail == ["--", "echo", "hi"]
+
+
+# ---------------------------------------------------------------------------
+# TOFU policy: build_ssh_argv pre-bakes ``StrictHostKeyChecking=accept-new``
+# so the first-touch dispatch to a freshly-registered peer adds the host
+# key on first connect (then refuses changes). Without this, BatchMode=yes
+# turns the missing host-key into a silent rc-1 with no actionable error
+# for the operator.
+# ---------------------------------------------------------------------------
+
+
+def test_build_ssh_argv_includes_accept_new_strict_host_key_option():
+    # Arrange
+    peers = {"mba": PeerSpec(name="mba", ssh="mba")}
+    # Act
+    argv = build_ssh_argv("mba", ["echo", "hi"], peers)
+    # Assert — TOFU flag is in the rendered argv.
+    joined = " ".join(argv)
+    assert "StrictHostKeyChecking=accept-new" in joined
+
+
+def test_build_ssh_argv_keeps_batchmode_with_accept_new_policy():
+    # Arrange — the accept-new + BatchMode combo is the explicit TOFU
+    # contract: accept a NEW key, but never prompt for one.
+    peers = {"mba": PeerSpec(name="mba", ssh="mba")}
+    # Act
+    argv = build_ssh_argv("mba", ["echo", "hi"], peers)
+    # Assert
+    joined = " ".join(argv)
+    assert "BatchMode=yes" in joined and "StrictHostKeyChecking=accept-new" in joined

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__common.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__common.py
@@ -22,6 +22,7 @@ from scitex_agent_container.cli_pkg.lifecycle._common import (
     _iter_agent_yamls,
     _multiplex_foreground_tails,
     _resolve_dispatch_peer,
+    _resolve_singleton_skip,
     _singleton_skip_reason,
 )
 from scitex_agent_container.config import AgentConfig
@@ -143,6 +144,63 @@ class TestSingletonSkipReason:
         cfg = _cfg(sched_mode="per-host", pref="alpha")
         # Act
         msg = _singleton_skip_reason(cfg, "beta")
+        # Assert
+        assert msg is None
+
+
+# ---------------------------------------------------------------------------
+# _resolve_singleton_skip — gated wrapper around _singleton_skip_reason.
+#
+# Bug 1 root cause: `_start_single` consulted `_singleton_skip_reason`
+# even with `no_redispatch=True`, so a singleton-on-wrong-host check
+# silently no-op'd starts that had NO other host to defer to (the
+# `--on <peer>` propagated remote call sets `--no-redispatch`, so the
+# skip path was a permanent dead-end). The gate skips the singleton
+# check whenever `no_redispatch=True` — the operator's explicit
+# "do it here" signal overrides the host-pinning preference.
+# ---------------------------------------------------------------------------
+
+
+class TestResolveSingletonSkip:
+    def test_skips_singleton_check_when_no_redispatch(self):
+        # Arrange — singleton pinned to alpha, current host beta.
+        # Without the gate, _singleton_skip_reason returns a skip reason.
+        cfg = _cfg(host="alpha")
+        # Act — no_redispatch=True means "run HERE, no further routing".
+        msg = _resolve_singleton_skip(cfg, "beta", no_redispatch=True)
+        # Assert — gate suppresses the dead-end skip.
+        assert msg is None
+
+    def test_returns_skip_reason_when_redispatch_still_possible(self):
+        # Arrange — same misalignment, but redispatch is still on the table.
+        cfg = _cfg(host="alpha")
+        # Act
+        msg = _resolve_singleton_skip(cfg, "beta", no_redispatch=False)
+        # Assert — preserve the original skip-and-defer behaviour.
+        assert msg and "alpha" in msg and "beta" in msg
+
+    def test_passes_through_none_when_host_matches(self):
+        # Arrange
+        cfg = _cfg(host="alpha")
+        # Act
+        msg = _resolve_singleton_skip(cfg, "alpha", no_redispatch=False)
+        # Assert
+        assert msg is None
+
+    def test_v2_singleton_mismatch_skip_still_propagates(self):
+        # Arrange — v2-style singleton with preferred_host=alpha; gate is
+        # a thin wrapper, so the v2 path's reason must survive.
+        cfg = _cfg(sched_mode="singleton", pref="alpha")
+        # Act
+        msg = _resolve_singleton_skip(cfg, "beta", no_redispatch=False)
+        # Assert
+        assert msg and "alpha" in msg
+
+    def test_no_redispatch_bypasses_v2_singleton_skip_too(self):
+        # Arrange — same as above but with the no_redispatch gate.
+        cfg = _cfg(sched_mode="singleton", pref="alpha")
+        # Act
+        msg = _resolve_singleton_skip(cfg, "beta", no_redispatch=True)
         # Assert
         assert msg is None
 

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__dispatch.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__dispatch.py
@@ -592,6 +592,51 @@ class TestDispatchSshArgv:
 
 
 # ---------------------------------------------------------------------------
+# Bug 3 — TOFU policy: dispatch must add ``-o
+# StrictHostKeyChecking=accept-new`` to BOTH the ssh handoff AND rsync's
+# transport, so a first-touch peer (the most common dispatch failure
+# mode on a freshly-configured cluster) does not silently rc-1 with no
+# operator-actionable error.
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchStrictHostKeyChecking:
+    def test_dispatch_ssh_argv_includes_accept_new_strict_host_key(
+        self, spec_dir, shim_bin, state_db, fake_home, env_save_restore, capsys
+    ):
+        # Arrange
+        _write_peer_config(fake_home, env_save_restore)
+        # Act
+        _act_dispatch(shim_bin, capsys, rsync_kwargs=_RK_OK, ssh_kwargs=_SK_OK)
+        # Assert — the rendered ssh argv carries the TOFU policy.
+        assert "StrictHostKeyChecking=accept-new" in " ".join(
+            _ssh_invocations(shim_bin)[-1]
+        )
+
+    def test_dispatch_dry_rsync_argv_uses_accept_new_transport(
+        self, spec_dir, shim_bin, state_db, fake_home, env_save_restore, capsys
+    ):
+        # Arrange — clean first-launch dry-run, ok ssh.
+        _write_peer_config(fake_home, env_save_restore)
+        # Act
+        _act_dispatch(shim_bin, capsys, rsync_kwargs=_RK_OK, ssh_kwargs=_SK_OK)
+        # Assert — rsync's -e transport carries the accept-new flag.
+        dry = next(a for a in _rsync_invocations(shim_bin) if _is_dry_run_argv(a))
+        assert any("StrictHostKeyChecking=accept-new" in tok for tok in dry)
+
+    def test_dispatch_real_rsync_argv_uses_accept_new_transport(
+        self, spec_dir, shim_bin, state_db, fake_home, env_save_restore, capsys
+    ):
+        # Arrange
+        _write_peer_config(fake_home, env_save_restore)
+        # Act
+        _act_dispatch(shim_bin, capsys, rsync_kwargs=_RK_OK, ssh_kwargs=_SK_OK)
+        # Assert
+        real = next(a for a in _rsync_invocations(shim_bin) if not _is_dry_run_argv(a))
+        assert any("StrictHostKeyChecking=accept-new" in tok for tok in real)
+
+
+# ---------------------------------------------------------------------------
 # lookup_remote_peer + try_dispatch_remote: state.db-driven routing.
 # ---------------------------------------------------------------------------
 

--- a/tests/scitex_agent_container/cli_pkg/test__on_start_propagate.py
+++ b/tests/scitex_agent_container/cli_pkg/test__on_start_propagate.py
@@ -234,3 +234,162 @@ class TestPropagateRecordsOverrideHost:
         rows = [r for r in list_active_instances() if r["name"] == "clew"]
         # Assert — nothing recorded for a failed remote start.
         assert rows == []
+
+
+# ---------------------------------------------------------------------------
+# Bug 1 fail-loud guards: silent-skip / silent-rc!=0 must surface to the operator.
+#
+# The lead's repro:
+#   sac --on spartan-gpgpu011 agents start proj-paper-scitex-clew --force --no-preflight
+# exited 0 with ZERO stdout/stderr because:
+#   (a) propagate_remote_start returned 0 when the remote emitted
+#       {"status": "skipped", ...}, dropping the skip reason on the floor;
+#   (b) when the remote exited non-zero, _default_ssh_runner captured
+#       stderr (capture_output=True) and propagate_remote_start returned
+#       the rc WITHOUT echoing the captured stderr/stdout to the operator.
+# Both paths produced operator-invisible no-ops. These tests pin the
+# fail-loud contract so the regression is caught immediately.
+# ---------------------------------------------------------------------------
+
+
+class TestFailLoudOnRemoteNonStart:
+    def test_skipped_status_returns_nonzero(self, isolated_state_db) -> None:
+        # Arrange — remote start succeeded (rc 0) but skipped (host mismatch).
+        def _run(peer, full_argv):
+            return subprocess.CompletedProcess(
+                args=full_argv,
+                returncode=0,
+                stdout=json.dumps(
+                    {
+                        "name": "clew",
+                        "status": "skipped",
+                        "reason": "singleton prefers 'bm043', current host is 'gpgpu011'",
+                        "dry_run": False,
+                    }
+                ),
+                stderr="",
+            )
+
+        # Act
+        rc = propagate_remote_start(
+            "spartan-gpgpu011", ["agents", "start", "clew"], runner=_run
+        )
+        # Assert — a skipped remote start MUST NOT look like success to the operator.
+        assert rc != 0
+
+    def test_skipped_status_prints_reason_to_stderr(
+        self, isolated_state_db, capsys
+    ) -> None:
+        # Arrange
+        def _run(peer, full_argv):
+            return subprocess.CompletedProcess(
+                args=full_argv,
+                returncode=0,
+                stdout=json.dumps(
+                    {
+                        "name": "clew",
+                        "status": "skipped",
+                        "reason": "singleton prefers 'bm043', current host is 'gpgpu011'",
+                        "dry_run": False,
+                    }
+                ),
+                stderr="",
+            )
+
+        # Act
+        propagate_remote_start(
+            "spartan-gpgpu011", ["agents", "start", "clew"], runner=_run
+        )
+        # Assert — the remote's skip reason MUST reach the operator.
+        captured = capsys.readouterr()
+        assert "singleton prefers 'bm043'" in (captured.err + captured.out)
+
+    def test_skipped_status_records_no_row(self, isolated_state_db) -> None:
+        # Arrange
+        def _run(peer, full_argv):
+            return subprocess.CompletedProcess(
+                args=full_argv,
+                returncode=0,
+                stdout=json.dumps({"name": "clew", "status": "skipped"}),
+                stderr="",
+            )
+
+        # Act
+        propagate_remote_start(
+            "spartan-gpgpu011", ["agents", "start", "clew"], runner=_run
+        )
+        # Assert — a skipped remote did NOT start anything, so no row.
+        from scitex_agent_container._state.state_db import list_active_instances
+
+        rows = [r for r in list_active_instances() if r["name"] == "clew"]
+        assert rows == []
+
+    def test_dry_run_ok_status_is_silent_success(
+        self, isolated_state_db, capsys
+    ) -> None:
+        # Arrange — `--dry-run` propagated to the remote returns
+        # status=dry_run_ok cleanly; this is the ONE non-"started" status
+        # that legitimately returns 0 (no agent was meant to start).
+        def _run(peer, full_argv):
+            return subprocess.CompletedProcess(
+                args=full_argv,
+                returncode=0,
+                stdout=json.dumps(
+                    {"name": "clew", "status": "dry_run_ok", "dry_run": True}
+                ),
+                stderr="",
+            )
+
+        # Act
+        rc = propagate_remote_start(
+            "spartan-gpgpu011",
+            ["agents", "start", "clew", "--dry-run"],
+            runner=_run,
+        )
+        # Assert
+        assert rc == 0
+
+    def test_remote_failure_echoes_remote_output_to_operator(
+        self, isolated_state_db, capsys
+    ) -> None:
+        # Arrange — remote rc != 0 (e.g. exception inside remote start);
+        # captured stdout/stderr MUST surface so the operator can debug.
+        def _run(peer, full_argv):
+            return subprocess.CompletedProcess(
+                args=full_argv,
+                returncode=1,
+                stdout=json.dumps(
+                    {
+                        "name": "clew",
+                        "status": "error",
+                        "error": "Permission denied loading spec.yaml",
+                    }
+                ),
+                stderr="ssh-side: connection reset",
+            )
+
+        # Act
+        propagate_remote_start(
+            "spartan-gpgpu011", ["agents", "start", "clew"], runner=_run
+        )
+        # Assert — at least the remote's structured error must reach the operator.
+        captured = capsys.readouterr()
+        merged = captured.err + captured.out
+        assert "Permission denied loading spec.yaml" in merged
+
+    def test_remote_failure_returns_remote_rc(self, isolated_state_db) -> None:
+        # Arrange
+        def _run(peer, full_argv):
+            return subprocess.CompletedProcess(
+                args=full_argv,
+                returncode=42,
+                stdout="",
+                stderr="boom",
+            )
+
+        # Act
+        rc = propagate_remote_start(
+            "spartan-gpgpu011", ["agents", "start", "clew"], runner=_run
+        )
+        # Assert
+        assert rc == 42


### PR DESCRIPTION
## Summary

Closes the `sac --on spartan-gpgpu011 agents start clew --force --no-preflight` silent-success mode (exits 0 with zero stdout/stderr, no agent ever started on either side). Three independent bugs converge to produce that failure; this PR fixes all three plus the SSH/rsync TOFU policy that compounds them on first-touch peers.

- **`_resolve_singleton_skip` (`cli_pkg/lifecycle/_common.py`)** — honour `--no-redispatch`. The singleton-on-wrong-host skip was a dead end when the propagated remote call had no other host to defer to; it now returns `None` for `no_redispatch=True` so the local start path proceeds.
- **`_verify_real_liveness` (`_lifecycle/_start.py`)** — three-signal "already-running" check. Pre-fix code trusted `registry.exists + runtime.is_running`; both have well-known false positives (stale on-disk JSON, Linux PID reuse). Adds the cross-host `instances` table row as the third independent signal, and falls through to a real start if it disagrees.
- **`propagate_remote_start` (`cli_pkg/_on_start_propagate.py`)** — fail-loud on remote skip/error. A non-zero remote rc now echoes captured stdout/stderr to the operator and returns the rc. A `status != "started"` (other than `dry_run_ok`) now returns rc=1 with the reason on stderr. Pre-fix, both paths dropped the diagnostic on the floor and returned 0/the-rc with nothing visible to the operator.
- **TOFU host keys (`_state/_host_ssh.py`, `cli_pkg/lifecycle/_dispatch.py`)** — `StrictHostKeyChecking=accept-new` baked into `build_ssh_argv` AND the rsync `-e` transport used by `_dispatch_remote_start`. A first-touch dispatch to a freshly-registered peer no longer rc-1s silently under `BatchMode=yes`.

## Test plan

- [x] 22 new tests across `test__common.py`, `test__on_start_propagate.py`, `test__dispatch.py`, `test_host_config_env_preamble.py`, `test_lifecycle.py`. No mocks — every seam (liveness verifier, runner, instances oracle) is a real callable wired through `tmp_path` state.db where needed.
- [x] Full suite green except for 7 failures that exist verbatim on `develop` (audit/`test_audit_all_clean`, `cli_startup_budget`, `sdk_common cwd`, statusline ×4, `a2a/handlers` ×1) — none touch the modified code paths.
- [x] Conforms to STX-TQ002 (AAA markers), STX-TQ003 (descriptive names), STX-TQ007 (one assertion per test).