### PR TITLE
fix(dispatch): release stale singleton binding when bound host unreachable

### DIFF
--- a/src/scitex_agent_container/cli_pkg/lifecycle/_common.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_common.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable
 
 import click
 
@@ -19,6 +19,11 @@ from ...config import AgentConfig
 
 if TYPE_CHECKING:
     from ..._state.host_config import PeerSpec
+
+# (name, host) -> True iff the registry holds an active instances row
+# for ``name`` on ``host``. Used by :func:`_resolve_singleton_skip` to
+# liveness-gate the spec-host preference.
+BoundHostLivenessOracle = Callable[[str, str], bool]
 
 _SKIP_DIR_NAMES = {"legacy-agents", "shared", "GITIGNORED"}
 
@@ -44,40 +49,116 @@ def _resolve_dispatch_peer(
     return target_host
 
 
+def _bound_host(config: AgentConfig) -> str | None:
+    """Return the spec-bound preferred host for a singleton config.
+
+    Mirrors :func:`_singleton_skip_reason`'s head-of-chain selection —
+    the v3 ``spec.host`` (str or first element of list) wins, then the
+    v2 ``scheduling.preferred_host`` fallback. Returns None when the
+    config is multi-instance or unpinned (no skip would fire and no
+    liveness check is meaningful).
+    """
+    spec = config.hosts_spec
+    if spec.hosts:
+        return None
+    host = spec.host
+    if host:
+        if isinstance(host, str):
+            return host or None
+        return host[0] if host else None
+    sched = config.scheduling
+    if sched.mode != "singleton":
+        return None
+    return sched.preferred_host or None
+
+
+def _registry_active_on(name: str, host: str) -> bool:
+    """Default bound-host liveness oracle: True iff the lead-side
+    ``instances`` table holds an active row for ``name`` on ``host``.
+
+    Reads :func:`state_db.list_active_instances` (host-unfiltered) and
+    matches name+host exactly. Any failure (state.db missing, schema
+    mismatch, OS error) yields False — "no evidence of liveness" —
+    which is the conservative answer for the caller
+    (:func:`_resolve_singleton_skip` will treat the spec-host pin as
+    stale and fall through to a local start, breaking the stale-binding
+    dead end the lead's bm025 repro identified).
+    """
+    # stx-allow: fallback (reason: state.db read failure is treated as
+    # "no liveness evidence" so the stale spec-host binding is released
+    # and the start path proceeds; this is the conservative answer that
+    # never blocks)
+    try:
+        from ..._state.state_db import list_active_instances
+
+        rows = list_active_instances(host=None)
+    except Exception:
+        return False
+    for row in rows or ():
+        if row.get("name") == name and row.get("host") == host:
+            return True
+    return False
+
+
 def _resolve_singleton_skip(
     config: AgentConfig,
     hostname: str,
     *,
     no_redispatch: bool,
+    liveness_oracle: BoundHostLivenessOracle | None = None,
 ) -> str | None:
-    """Gated wrapper around :func:`_singleton_skip_reason`.
+    """Liveness-gated wrapper around :func:`_singleton_skip_reason`.
 
-    Returns ``None`` (no skip — start locally) when ``no_redispatch`` is
-    True regardless of the underlying skip reason. Otherwise delegates
-    to :func:`_singleton_skip_reason` unchanged.
+    Returns ``None`` (no skip — start locally) in any of:
 
-    Rationale (Bug 1 root cause): the original call site consulted
-    ``_singleton_skip_reason`` even when the operator had explicitly
-    disabled redispatch (e.g. via ``sac --on <peer>`` which propagates
-    ``--no-redispatch`` to the remote ``sac agents start``). The skip
-    path's only purpose is to defer to a redispatch — with
-    ``no_redispatch=True`` the agent has nowhere else to land, so the
-    skip becomes a permanent silent no-op. The lead's repro
-    (``sac --on spartan-gpgpu011 agents start clew --force --no-preflight``
-    exits 0 with zero output) was exactly this dead end: the remote
-    saw ``spec.host=bm043`` ≠ ``gpgpu011``, skipped, and emitted
-    ``{"status": "skipped", ...}``, which the lead-side propagator
-    then dropped on the floor.
+      1. ``no_redispatch=True`` — operator explicitly disabled the
+         redispatch chain (e.g. via ``sac --on <peer>`` which propagates
+         ``--no-redispatch`` to the remote ``sac agents start``). With
+         redispatch off there is nowhere else for the skip to defer to,
+         so honouring it would produce a silent no-op the propagator
+         then drops on the floor. (PR #252 / Bug 1.)
+      2. The singleton check itself yields no skip (host matches, or
+         multi-instance config).
+      3. The singleton check WOULD fire, but the liveness oracle reports
+         no active instance row on the bound host — the spec-host pin
+         is stale. The lead's bm025 repro (clew pinned to a dead prior
+         host with no live row + ``pam_slurm_adopt`` rejecting any ssh
+         to it) hung clew because the skip kept deferring to a host
+         that had nothing live and was unreachable. Falling through
+         lets the operator's actual target take over.
 
-    Note: "real liveness" of an *already-running* agent on the LOCAL
-    host is a separate concern handled inside
-    :func:`scitex_agent_container._lifecycle._start.agent_start` (PID
-    liveness + registry-row cross-check). This helper is only about the
-    routing decision before any local launch decision is even reached.
+    Returns the human-readable skip reason ONLY when the singleton
+    check fires AND the agent has a verified-live row on the bound
+    host (the legitimate "it IS running over there, defer" case).
+
+    Args:
+        config: Agent spec.
+        hostname: Current host's resolved canonical name.
+        no_redispatch: Operator's ``--no-redispatch`` flag (when True,
+            never skip).
+        liveness_oracle: Optional ``(name, host) -> bool`` seam for
+            checking whether the agent is already active on its bound
+            host. Defaults to :func:`_registry_active_on` (real state.db
+            read).
     """
     if no_redispatch:
         return None
-    return _singleton_skip_reason(config, hostname)
+    reason = _singleton_skip_reason(config, hostname)
+    if reason is None:
+        return None
+    bound = _bound_host(config)
+    if bound is None:
+        # No explicit pin → no liveness check can apply; preserve
+        # behaviour.
+        return reason
+    oracle = liveness_oracle if liveness_oracle is not None else _registry_active_on
+    if not oracle(config.name, bound):
+        # Spec says "should be on X" but the registry has no live row
+        # on X. Skipping would leave the agent unlaunched anywhere —
+        # fall through and start locally instead. This is the lead's
+        # bm025 stale-binding repro.
+        return None
+    return reason
 
 
 def _singleton_skip_reason(config: AgentConfig, hostname: str) -> str | None:
@@ -275,6 +356,9 @@ def _multiplex_foreground_tails(names, sleeper=None):
 
 __all__ = [
     "_SKIP_DIR_NAMES",
+    "BoundHostLivenessOracle",
+    "_bound_host",
+    "_registry_active_on",
     "_resolve_dispatch_peer",
     "_resolve_singleton_skip",
     "_singleton_skip_reason",

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_stop.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_stop.py
@@ -22,19 +22,89 @@ from ..._lifecycle.lifecycle import agent_stop
 from ..._state.host_config import build_ssh_argv
 from ..._state.host_config import load as _load_host_config
 from ..._state.state_db import now_iso, record_instance_stop
+from ..._state.state_db_comms_nodes import unregister_comms_node
 from ...config import load_config
 from ...config._resolve import resolve_with_prefix
 from .._helpers import agent_name_complete, console
 from ._common import _iter_agent_yamls
 from ._dispatch import try_dispatch_remote
 
+# Stable exit_reason marker for the release-on-unreachable path so a
+# follow-up audit can grep state.db for stale-binding releases and
+# distinguish them from clean stops.
+_FORCE_RELEASED_EXIT_REASON = "peer-unreachable-force-released"
+
+
+class _PeerUnreachableError(RuntimeError):
+    """Raised when ``_dispatch_remote_stop`` cannot reach the bound peer
+    via ssh — distinct from generic ``RuntimeError`` so the caller can
+    decide to release the stale binding locally (with ``--force``) rather
+    than aborting the whole stop loop on a transport failure.
+
+    Carries the full message that would have been raised (so the caller
+    can still echo it to the operator when force-release fires), plus a
+    flag indicating whether the failure was at the ssh transport layer
+    (rc != 0 with no parseable JSON envelope, or no stdout at all) — i.e.
+    the peer is genuinely unreachable, not "the remote sac returned an
+    error envelope we should respect".
+    """
+
+    def __init__(self, message: str, *, peer: str) -> None:
+        super().__init__(message)
+        self.peer = peer
+
+
+def _force_release_binding(name: str, row: dict, peer: str) -> dict:
+    """Tombstone the lead-side instances row + remove the comms_nodes
+    pin so a subsequent start can re-bind the singleton to its current
+    spec.host.
+
+    Called from the stop loop when ``_dispatch_remote_stop`` raises
+    :class:`_PeerUnreachableError` AND the operator passed ``--force``.
+    The release MUST clear BOTH stores — the user's bm025 repro hung on
+    the unreachable peer precisely because the singleton's instance row
+    AND comms_nodes binding both still pointed there, so any subsequent
+    routing (``stop``, ``send``, ``--on``-propagated ``start``) re-tried
+    the dead host. Without comms_nodes also being cleared, future a2a
+    routing would still try bm025 even after the instance row was
+    closed.
+
+    Returns the envelope the caller would otherwise have parsed from the
+    peer, so the per-target JSON shape stays stable.
+    """
+    instance_id = row.get("id")
+    if instance_id:
+        record_instance_stop(instance_id, exit_reason=_FORCE_RELEASED_EXIT_REASON)
+    # stx-allow: fallback (reason: a missing comms_nodes row is a
+    # legitimate state — the singleton may never have been pinned via
+    # the federated graph — and must not block the release)
+    try:
+        unregister_comms_node(name=name)
+    except Exception:
+        pass
+    return {
+        "name": name,
+        "stopped": True,
+        "force_released": True,
+        "host": peer,
+        "exit_reason": _FORCE_RELEASED_EXIT_REASON,
+        "ended_at": now_iso(),
+        "dispatched": False,
+    }
+
 
 def _dispatch_remote_stop(peer: str, row: dict, peers: dict, name: str) -> dict:
     """SSH into ``peer`` and run ``sac agents stop <name> --json``.
 
     Updates the lead-side ``instances`` row via :func:`record_instance_stop`
-    on success.  Raises ``RuntimeError`` with the full ssh argv + stderr
-    on failure (per the project's no-silent-fallback rule).
+    on success. Raises :class:`_PeerUnreachableError` when the ssh
+    transport itself fails (rc != 0; covers
+    ``Connection refused`` / ``pam_slurm_adopt denied`` / hostname
+    resolution failure / etc.) so the caller can fall through to
+    :func:`_force_release_binding` under ``--force``. Raises plain
+    ``RuntimeError`` for ``--json`` parse failures (peer sac responded
+    but spoke a different shape — operator must reconcile, not
+    auto-release).
 
     Returns the parsed JSON envelope from the peer's stdout.
     """
@@ -50,12 +120,13 @@ def _dispatch_remote_stop(peer: str, row: dict, peers: dict, name: str) -> dict:
         check=False,
     )
     if result.returncode != 0:
-        raise RuntimeError(
+        raise _PeerUnreachableError(
             f"Remote `sac agents stop {name}` failed on {peer!r} "
             f"(rc={result.returncode}):\n"
             f"argv: {' '.join(shlex.quote(a) for a in ssh_argv)}\n"
             f"stdout:\n{result.stdout}\n"
-            f"stderr:\n{result.stderr}"
+            f"stderr:\n{result.stderr}",
+            peer=peer,
         )
     try:
         envelope = _json.loads(result.stdout)
@@ -197,13 +268,49 @@ def stop(
     for name, raw_target in pairs:
         try:
             envelope_holder: dict = {}
+            release_holder: dict = {}
 
-            def _handler(peer, row, ps, _name=name, _holder=envelope_holder):
-                _holder.update(_dispatch_remote_stop(peer, row, ps, _name))
-                _holder["_peer"] = peer
+            def _handler(
+                peer,
+                row,
+                ps,
+                _name=name,
+                _holder=envelope_holder,
+                _release=release_holder,
+                _force=force,
+            ):
+                try:
+                    _holder.update(_dispatch_remote_stop(peer, row, ps, _name))
+                    _holder["_peer"] = peer
+                except _PeerUnreachableError as exc:
+                    if not _force:
+                        # No force → surface the ssh failure unchanged.
+                        # The outer try/except records it as an error.
+                        raise
+                    # --force on an unreachable peer: release the stale
+                    # binding locally so the operator isn't blocked by
+                    # an unreachable prior host (the lead's bm025
+                    # repro). The release writes BOTH the instances
+                    # tombstone AND the comms_nodes pin removal so
+                    # subsequent routing re-binds to the current
+                    # spec.host.
+                    _release.update(_force_release_binding(_name, row, peer))
+                    _release["_underlying_error"] = str(exc)
 
             dispatched = try_dispatch_remote(name, "stop", peers, handler=_handler)
             if dispatched:
+                if release_holder:
+                    # Force-released path.
+                    if as_json:
+                        click.echo(_json.dumps(release_holder))
+                    else:
+                        console.print(
+                            f"[yellow]Agent '{name}' force-released on "
+                            f"'{release_holder.get('host')}' "
+                            f"(peer unreachable; "
+                            f"{_FORCE_RELEASED_EXIT_REASON})[/yellow]"
+                        )
+                    continue
                 if as_json:
                     click.echo(
                         _json.dumps(

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__common.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__common.py
@@ -365,16 +365,31 @@ class TestBoundHost:
 # ---------------------------------------------------------------------------
 
 
+def _reload_state_db_at(path: Path, env_save_restore):
+    """Redirect DEFAULT_DB_PATH at ``path`` and reload the state_db
+    module so the rebound path takes effect.
+
+    PA-306 §3 no-mocks: uses the project ``env_save_restore`` fixture
+    (NOT pytest's ``monkeypatch``) to manage the env var save/restore.
+    Returns the reloaded module so the caller can call its
+    ``record_instance_start`` etc. against the redirected DB.
+    """
+    import importlib
+
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_STATE_DB", str(path))
+    import scitex_agent_container._state.state_db as state_db_mod
+
+    importlib.reload(state_db_mod)
+    return state_db_mod
+
+
 class TestRegistryActiveOn:
-    def test_missing_state_db_treated_as_not_live(self, tmp_path, monkeypatch):
+    def test_missing_state_db_treated_as_not_live(self, tmp_path, env_save_restore):
         # Arrange — point state.db at a non-existent path; reload module
         # so DEFAULT_DB_PATH is recomputed.
         import importlib
 
-        monkeypatch.setenv("SCITEX_AGENT_CONTAINER_STATE_DB", str(tmp_path / "nope.db"))
-        import scitex_agent_container._state.state_db as state_db_mod
-
-        importlib.reload(state_db_mod)
+        state_db_mod = _reload_state_db_at(tmp_path / "nope.db", env_save_restore)
         try:
             # Act
             live = _registry_active_on("ghost", "alpha")
@@ -383,16 +398,11 @@ class TestRegistryActiveOn:
         finally:
             importlib.reload(state_db_mod)
 
-    def test_recorded_instance_seen_as_live(self, tmp_path, monkeypatch):
+    def test_recorded_instance_seen_as_live(self, tmp_path, env_save_restore):
         # Arrange
         import importlib
 
-        monkeypatch.setenv(
-            "SCITEX_AGENT_CONTAINER_STATE_DB", str(tmp_path / "state.db")
-        )
-        import scitex_agent_container._state.state_db as state_db_mod
-
-        importlib.reload(state_db_mod)
+        state_db_mod = _reload_state_db_at(tmp_path / "state.db", env_save_restore)
         try:
             state_db_mod.record_instance_start(
                 name="clew",
@@ -409,16 +419,13 @@ class TestRegistryActiveOn:
         finally:
             importlib.reload(state_db_mod)
 
-    def test_instance_on_other_host_not_live_on_target(self, tmp_path, monkeypatch):
+    def test_instance_on_other_host_not_live_on_target(
+        self, tmp_path, env_save_restore
+    ):
         # Arrange — row recorded on beta, asking about alpha.
         import importlib
 
-        monkeypatch.setenv(
-            "SCITEX_AGENT_CONTAINER_STATE_DB", str(tmp_path / "state.db")
-        )
-        import scitex_agent_container._state.state_db as state_db_mod
-
-        importlib.reload(state_db_mod)
+        state_db_mod = _reload_state_db_at(tmp_path / "state.db", env_save_restore)
         try:
             state_db_mod.record_instance_start(
                 name="clew",
@@ -435,18 +442,13 @@ class TestRegistryActiveOn:
         finally:
             importlib.reload(state_db_mod)
 
-    def test_ended_instance_not_live(self, tmp_path, monkeypatch):
+    def test_ended_instance_not_live(self, tmp_path, env_save_restore):
         # Arrange — record then end; the row's ended_at != NULL so it
         # must not be reported as live (mirrors what stop --force would
         # do via the new release path).
         import importlib
 
-        monkeypatch.setenv(
-            "SCITEX_AGENT_CONTAINER_STATE_DB", str(tmp_path / "state.db")
-        )
-        import scitex_agent_container._state.state_db as state_db_mod
-
-        importlib.reload(state_db_mod)
+        state_db_mod = _reload_state_db_at(tmp_path / "state.db", env_save_restore)
         try:
             row_id = state_db_mod.record_instance_start(
                 name="clew",

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__common.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__common.py
@@ -18,9 +18,11 @@ import pytest
 
 from scitex_agent_container._state.host_config import PeerSpec
 from scitex_agent_container.cli_pkg.lifecycle._common import (
+    _bound_host,
     _discover_all_agents,
     _iter_agent_yamls,
     _multiplex_foreground_tails,
+    _registry_active_on,
     _resolve_dispatch_peer,
     _resolve_singleton_skip,
     _singleton_skip_reason,
@@ -161,21 +163,39 @@ class TestSingletonSkipReason:
 # ---------------------------------------------------------------------------
 
 
+def _live(*_args, **_kwargs) -> bool:
+    """Oracle stub: 'agent IS live on the bound host' — preserves the
+    pre-liveness-gate skip behaviour for tests that target the
+    no_redispatch / multi-instance branches."""
+    return True
+
+
+def _dead(*_args, **_kwargs) -> bool:
+    """Oracle stub: 'agent is NOT live on the bound host' — the stale
+    spec-host binding the lead's bm025 repro identified."""
+    return False
+
+
 class TestResolveSingletonSkip:
     def test_skips_singleton_check_when_no_redispatch(self):
         # Arrange — singleton pinned to alpha, current host beta.
         # Without the gate, _singleton_skip_reason returns a skip reason.
         cfg = _cfg(host="alpha")
         # Act — no_redispatch=True means "run HERE, no further routing".
-        msg = _resolve_singleton_skip(cfg, "beta", no_redispatch=True)
+        msg = _resolve_singleton_skip(
+            cfg, "beta", no_redispatch=True, liveness_oracle=_live
+        )
         # Assert — gate suppresses the dead-end skip.
         assert msg is None
 
-    def test_returns_skip_reason_when_redispatch_still_possible(self):
-        # Arrange — same misalignment, but redispatch is still on the table.
+    def test_returns_skip_reason_when_bound_host_has_live_row(self):
+        # Arrange — same misalignment, redispatch on, oracle says
+        # the agent IS live on alpha → skip-and-defer is the right call.
         cfg = _cfg(host="alpha")
         # Act
-        msg = _resolve_singleton_skip(cfg, "beta", no_redispatch=False)
+        msg = _resolve_singleton_skip(
+            cfg, "beta", no_redispatch=False, liveness_oracle=_live
+        )
         # Assert — preserve the original skip-and-defer behaviour.
         assert msg and "alpha" in msg and "beta" in msg
 
@@ -183,16 +203,21 @@ class TestResolveSingletonSkip:
         # Arrange
         cfg = _cfg(host="alpha")
         # Act
-        msg = _resolve_singleton_skip(cfg, "alpha", no_redispatch=False)
+        msg = _resolve_singleton_skip(
+            cfg, "alpha", no_redispatch=False, liveness_oracle=_live
+        )
         # Assert
         assert msg is None
 
-    def test_v2_singleton_mismatch_skip_still_propagates(self):
+    def test_v2_singleton_mismatch_skip_still_propagates_when_live(self):
         # Arrange — v2-style singleton with preferred_host=alpha; gate is
-        # a thin wrapper, so the v2 path's reason must survive.
+        # a thin wrapper, so the v2 path's reason must survive when the
+        # bound host has a live row.
         cfg = _cfg(sched_mode="singleton", pref="alpha")
         # Act
-        msg = _resolve_singleton_skip(cfg, "beta", no_redispatch=False)
+        msg = _resolve_singleton_skip(
+            cfg, "beta", no_redispatch=False, liveness_oracle=_live
+        )
         # Assert
         assert msg and "alpha" in msg
 
@@ -203,6 +228,241 @@ class TestResolveSingletonSkip:
         msg = _resolve_singleton_skip(cfg, "beta", no_redispatch=True)
         # Assert
         assert msg is None
+
+    # -----------------------------------------------------------------
+    # Liveness gate — the lead's bm025 stale-binding repro.
+    #
+    # When the spec-bound host has no active instances row for the
+    # singleton, the binding is stale (the operator already moved the
+    # spec to a new host but the prior host still pins the skip). With
+    # no live agent over there, deferring is a dead-end — release the
+    # binding and fall through to a local start instead.
+    # -----------------------------------------------------------------
+
+    def test_falls_through_when_bound_host_has_no_live_row(self):
+        # Arrange — singleton pinned to alpha; we're on beta; registry
+        # says no live row for the agent anywhere.
+        cfg = _cfg(host="alpha")
+        # Act
+        msg = _resolve_singleton_skip(
+            cfg, "beta", no_redispatch=False, liveness_oracle=_dead
+        )
+        # Assert — stale binding released, fall through to local start.
+        assert msg is None
+
+    def test_oracle_invoked_with_agent_name_and_bound_host(self):
+        # Arrange — pin contract: oracle sees (name, bound_host).
+        cfg = _cfg(host="alpha")
+        calls: list[tuple[str, str]] = []
+
+        def _capture(name: str, host: str) -> bool:
+            calls.append((name, host))
+            return True
+
+        # Act
+        _resolve_singleton_skip(
+            cfg, "beta", no_redispatch=False, liveness_oracle=_capture
+        )
+        # Assert
+        assert calls == [("a", "alpha")]
+
+    def test_oracle_uses_head_of_chain_for_bound_host(self):
+        # Arrange — chain ['a','b','c'], we're on 'z'; head 'a' is bound.
+        cfg = _cfg(host=["a", "b", "c"])
+        calls: list[tuple[str, str]] = []
+
+        def _capture(name: str, host: str) -> bool:
+            calls.append((name, host))
+            return True
+
+        # Act
+        _resolve_singleton_skip(cfg, "z", no_redispatch=False, liveness_oracle=_capture)
+        # Assert
+        assert calls == [("a", "a")]
+
+    def test_oracle_not_consulted_when_no_redispatch_true(self):
+        # Arrange — no_redispatch shortcut MUST short-circuit the oracle.
+        cfg = _cfg(host="alpha")
+        called: list[bool] = []
+
+        def _boom(*_a, **_k) -> bool:
+            called.append(True)
+            return True
+
+        # Act
+        _resolve_singleton_skip(cfg, "beta", no_redispatch=True, liveness_oracle=_boom)
+        # Assert
+        assert called == []
+
+    def test_oracle_not_consulted_when_singleton_check_returns_none(self):
+        # Arrange — host matches → skip returns None upfront, oracle
+        # never invoked.
+        cfg = _cfg(host="alpha")
+        called: list[bool] = []
+
+        def _boom(*_a, **_k) -> bool:
+            called.append(True)
+            return True
+
+        # Act
+        _resolve_singleton_skip(
+            cfg, "alpha", no_redispatch=False, liveness_oracle=_boom
+        )
+        # Assert
+        assert called == []
+
+
+# ---------------------------------------------------------------------------
+# _bound_host — accessor for the head-of-chain spec-host pin used by
+# the liveness gate.
+# ---------------------------------------------------------------------------
+
+
+class TestBoundHost:
+    def test_str_host_returned_verbatim(self):
+        # Arrange
+        cfg = _cfg(host="alpha")
+        # Act
+        h = _bound_host(cfg)
+        # Assert
+        assert h == "alpha"
+
+    def test_list_host_returns_head(self):
+        # Arrange
+        cfg = _cfg(host=["a", "b", "c"])
+        # Act
+        h = _bound_host(cfg)
+        # Assert
+        assert h == "a"
+
+    def test_multi_instance_returns_none(self):
+        # Arrange
+        cfg = _cfg(hosts=["a", "b"])
+        # Act
+        h = _bound_host(cfg)
+        # Assert
+        assert h is None
+
+    def test_no_pin_returns_none(self):
+        # Arrange
+        cfg = _cfg()
+        # Act
+        h = _bound_host(cfg)
+        # Assert
+        assert h is None
+
+    def test_v2_singleton_preferred_host_returned(self):
+        # Arrange
+        cfg = _cfg(sched_mode="singleton", pref="alpha")
+        # Act
+        h = _bound_host(cfg)
+        # Assert
+        assert h == "alpha"
+
+
+# ---------------------------------------------------------------------------
+# _registry_active_on — default bound-host liveness oracle (state.db).
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryActiveOn:
+    def test_missing_state_db_treated_as_not_live(self, tmp_path, monkeypatch):
+        # Arrange — point state.db at a non-existent path; reload module
+        # so DEFAULT_DB_PATH is recomputed.
+        import importlib
+
+        monkeypatch.setenv("SCITEX_AGENT_CONTAINER_STATE_DB", str(tmp_path / "nope.db"))
+        import scitex_agent_container._state.state_db as state_db_mod
+
+        importlib.reload(state_db_mod)
+        try:
+            # Act
+            live = _registry_active_on("ghost", "alpha")
+            # Assert
+            assert live is False
+        finally:
+            importlib.reload(state_db_mod)
+
+    def test_recorded_instance_seen_as_live(self, tmp_path, monkeypatch):
+        # Arrange
+        import importlib
+
+        monkeypatch.setenv(
+            "SCITEX_AGENT_CONTAINER_STATE_DB", str(tmp_path / "state.db")
+        )
+        import scitex_agent_container._state.state_db as state_db_mod
+
+        importlib.reload(state_db_mod)
+        try:
+            state_db_mod.record_instance_start(
+                name="clew",
+                host="alpha",
+                a2a_port=19100,
+                bound_port=19100,
+                remote=False,
+                spawned_by="cli",
+            )
+            # Act
+            live = _registry_active_on("clew", "alpha")
+            # Assert
+            assert live is True
+        finally:
+            importlib.reload(state_db_mod)
+
+    def test_instance_on_other_host_not_live_on_target(self, tmp_path, monkeypatch):
+        # Arrange — row recorded on beta, asking about alpha.
+        import importlib
+
+        monkeypatch.setenv(
+            "SCITEX_AGENT_CONTAINER_STATE_DB", str(tmp_path / "state.db")
+        )
+        import scitex_agent_container._state.state_db as state_db_mod
+
+        importlib.reload(state_db_mod)
+        try:
+            state_db_mod.record_instance_start(
+                name="clew",
+                host="beta",
+                a2a_port=19101,
+                bound_port=19101,
+                remote=False,
+                spawned_by="cli",
+            )
+            # Act
+            live = _registry_active_on("clew", "alpha")
+            # Assert
+            assert live is False
+        finally:
+            importlib.reload(state_db_mod)
+
+    def test_ended_instance_not_live(self, tmp_path, monkeypatch):
+        # Arrange — record then end; the row's ended_at != NULL so it
+        # must not be reported as live (mirrors what stop --force would
+        # do via the new release path).
+        import importlib
+
+        monkeypatch.setenv(
+            "SCITEX_AGENT_CONTAINER_STATE_DB", str(tmp_path / "state.db")
+        )
+        import scitex_agent_container._state.state_db as state_db_mod
+
+        importlib.reload(state_db_mod)
+        try:
+            row_id = state_db_mod.record_instance_start(
+                name="clew",
+                host="alpha",
+                a2a_port=19100,
+                bound_port=19100,
+                remote=False,
+                spawned_by="cli",
+            )
+            state_db_mod.record_instance_stop(row_id, exit_reason="released")
+            # Act
+            live = _registry_active_on("clew", "alpha")
+            # Assert
+            assert live is False
+        finally:
+            importlib.reload(state_db_mod)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__start.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__start.py
@@ -252,12 +252,47 @@ def _write_singleton_yaml(parent: Path, name: str, host: str) -> Path:
     return y
 
 
+def _record_live_singleton(
+    state_db_path: Path, env_save_restore, name: str, host: str
+) -> None:
+    """Redirect state.db + record an active ``instances`` row for ``name``
+    on ``host`` so :func:`_resolve_singleton_skip`'s liveness gate sees
+    "live elsewhere" and preserves the legitimate skip path.
+
+    Required because the gate (added in the follow-up to PR #252's
+    real-liveness pattern) treats a singleton-on-wrong-host check as a
+    stale dead-end binding when the registry has NO live row on the
+    bound host — the lead's bm025 stale-binding repro. Tests that want
+    the skip to fire MUST first prove there's a live agent on the bound
+    host (otherwise the gate's release semantics rightly trigger).
+    """
+    import importlib
+
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_STATE_DB", str(state_db_path))
+    import scitex_agent_container._state.state_db as _state_db_mod
+
+    importlib.reload(_state_db_mod)
+    _state_db_mod.record_instance_start(
+        name=name,
+        host=host,
+        a2a_port=19200,
+        bound_port=19200,
+        remote=True,
+        spawned_by="cli",
+    )
+
+
 class TestSingletonHostSkip:
     def test_single_target_singleton_skip_exits_clean(self, tmp_path, env_save_restore):
-        # Arrange
+        # Arrange — live row on the bound host preserves the legitimate
+        # skip path (without it, the liveness gate would release the
+        # binding and fall through to a local start).
         env_save_restore.set("SCITEX_AGENT_CONTAINER_HOSTNAME", "this-host")
         env_save_restore.set("HOME", str(tmp_path))
         _install_fresh_creds(tmp_path)
+        _record_live_singleton(
+            tmp_path / "state.db", env_save_restore, "mini", "nowhere-host"
+        )
         yaml_path = _write_singleton_yaml(tmp_path, "mini", "nowhere-host")
         runner = CliRunner()
         # Act
@@ -272,6 +307,9 @@ class TestSingletonHostSkip:
         env_save_restore.set("SCITEX_AGENT_CONTAINER_HOSTNAME", "this-host")
         env_save_restore.set("HOME", str(tmp_path))
         _install_fresh_creds(tmp_path)
+        _record_live_singleton(
+            tmp_path / "state.db", env_save_restore, "mini", "nowhere-host"
+        )
         yaml_path = _write_singleton_yaml(tmp_path, "mini", "nowhere-host")
         runner = CliRunner()
         # Act
@@ -286,12 +324,44 @@ class TestSingletonHostSkip:
         env_save_restore.set("SCITEX_AGENT_CONTAINER_HOSTNAME", "this-host")
         env_save_restore.set("HOME", str(tmp_path))
         _install_fresh_creds(tmp_path)
+        _record_live_singleton(
+            tmp_path / "state.db", env_save_restore, "mini", "nowhere-host"
+        )
         yaml_path = _write_singleton_yaml(tmp_path, "mini", "nowhere-host")
         runner = CliRunner()
         # Act
         result = runner.invoke(start, [str(yaml_path), "--json"])
         # Assert
         assert '"status": "skipped"' in result.output
+
+    def test_single_target_singleton_dead_binding_releases_and_starts_local(
+        self, tmp_path, env_save_restore
+    ):
+        # Arrange — singleton pinned to nowhere-host, NO live row recorded.
+        # The new liveness gate must release the stale binding and fall
+        # through to a real start path. We can't run apptainer in tests,
+        # so we just verify the skip JSON was NOT emitted (i.e. the gate
+        # did NOT short-circuit). Real start fails downstream, that's fine
+        # — what we're pinning is that the skip path didn't fire.
+        env_save_restore.set("SCITEX_AGENT_CONTAINER_HOSTNAME", "this-host")
+        env_save_restore.set("HOME", str(tmp_path))
+        _install_fresh_creds(tmp_path)
+        # Redirect state.db to ensure the registry is empty for this name.
+        import importlib
+
+        env_save_restore.set(
+            "SCITEX_AGENT_CONTAINER_STATE_DB", str(tmp_path / "state.db")
+        )
+        import scitex_agent_container._state.state_db as _state_db_mod
+
+        importlib.reload(_state_db_mod)
+        yaml_path = _write_singleton_yaml(tmp_path, "mini", "nowhere-host")
+        runner = CliRunner()
+        # Act
+        result = runner.invoke(start, [str(yaml_path), "--json"])
+        # Assert — no "skipped" status; the start path proceeded past
+        # the skip gate (whether it then errored is independent).
+        assert '"status": "skipped"' not in result.output
 
     def test_bulk_directory_singleton_skip_renders_skip_line(
         self, tmp_path, env_save_restore
@@ -337,6 +407,9 @@ class TestResumeAndForeground:
         env_save_restore.set("SCITEX_AGENT_CONTAINER_HOSTNAME", "this-host")
         env_save_restore.set("HOME", str(tmp_path))
         _install_fresh_creds(tmp_path)
+        _record_live_singleton(
+            tmp_path / "state.db", env_save_restore, "mini", "nowhere-host"
+        )
         yaml_path = _write_singleton_yaml(tmp_path, "mini", "nowhere-host")
         runner = CliRunner()
         # Act
@@ -351,6 +424,9 @@ class TestResumeAndForeground:
         env_save_restore.set("SCITEX_AGENT_CONTAINER_HOSTNAME", "this-host")
         env_save_restore.set("HOME", str(tmp_path))
         _install_fresh_creds(tmp_path)
+        _record_live_singleton(
+            tmp_path / "state.db", env_save_restore, "mini", "nowhere-host"
+        )
         yaml_path = _write_singleton_yaml(tmp_path, "mini", "nowhere-host")
         runner = CliRunner()
         # Act
@@ -370,6 +446,22 @@ class TestResumeAndForeground:
         env_save_restore.set("SCITEX_AGENT_CONTAINER_HOSTNAME", "this-host")
         env_save_restore.set("HOME", str(tmp_path))
         _install_fresh_creds(tmp_path)
+        # Two live rows so both singleton skips preserve the original
+        # short-circuit (one helper call seeds state.db redirect, the
+        # second adds the second row via the now-redirected default).
+        _record_live_singleton(
+            tmp_path / "state.db", env_save_restore, "mini1", "nowhere-host"
+        )
+        from scitex_agent_container._state.state_db import record_instance_start
+
+        record_instance_start(
+            name="mini2",
+            host="nowhere-host",
+            a2a_port=19201,
+            bound_port=19201,
+            remote=True,
+            spawned_by="cli",
+        )
         y1 = _write_singleton_yaml(tmp_path, "mini1", "nowhere-host")
         y2 = _write_singleton_yaml(tmp_path, "mini2", "nowhere-host")
         runner = CliRunner()
@@ -519,12 +611,17 @@ class TestDispatchBranch:
         # Arrange — spec.host is NOT in the peer registry AND NOT the
         # current host. Resolver returns None ("caller decides"), the
         # routing branch falls through, and singleton-skip emits the
-        # ``Skipping 'mini'`` line.
+        # ``Skipping 'mini'`` line. A live row on the bound host
+        # preserves the original short-circuit (liveness gate sees the
+        # agent IS running over there, so deferring is meaningful).
         env_save_restore.set("SCITEX_AGENT_CONTAINER_HOSTNAME", "this-host")
         env_save_restore.set("HOME", str(tmp_path))
         _install_fresh_creds(tmp_path)
         cfg = _write_peer_config(tmp_path, "remote-host")
         env_save_restore.set("SCITEX_AGENT_CONTAINER_CONFIG", str(cfg))
+        _record_live_singleton(
+            tmp_path / "state.db", env_save_restore, "mini", "unknown-host"
+        )
         yaml_path = _write_singleton_yaml(tmp_path, "mini", "unknown-host")
         runner = CliRunner()
         # Act

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__stop.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__stop.py
@@ -485,3 +485,168 @@ def test_cross_host_stop_json_envelope_marks_dispatched(remote_row_for_zeta, ssh
     envelope = _json.loads(result.output.strip().splitlines()[-1])
     # Assert
     assert envelope.get("dispatched") is True
+
+
+# ---------------------------------------------------------------------------
+# stop --force release-on-unreachable.
+#
+# Lead's bm025 stale-binding repro: a singleton's instances row pointed
+# at a dead prior host (no SLURM job → pam_slurm_adopt denied ssh), so
+# stop --force itself aborted on the transport failure and the stale
+# binding never cleared. With the new fall-through, --force on an
+# unreachable peer tombstones the instances row + removes the
+# comms_nodes pin so the singleton can re-bind to the current spec.host.
+# WITHOUT --force, the ssh failure still surfaces as an error (operator
+# must opt in to the destructive release).
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def ssh_shim_unreachable(tmp_path):
+    """PATH-prepended fake ssh that mimics an unreachable peer
+    (rc 255, stderr line that resembles ``pam_slurm_adopt`` denial)."""
+    import json as _json
+    import sys
+
+    bin_dir = tmp_path / "_shim_bin_unreachable"
+    bin_dir.mkdir(exist_ok=True)
+    log = bin_dir / "ssh.argv.jsonl"
+    script = bin_dir / "ssh"
+    script.write_text(
+        f"#!{sys.executable}\n"
+        "import json, sys\n"
+        f"with open({_json.dumps(str(log))}, 'a') as fh:\n"
+        "    fh.write(json.dumps(sys.argv[1:]) + '\\n')\n"
+        "sys.stderr.write('Access denied by pam_slurm_adopt: "
+        "you have no SLURM jobs on this node.\\n')\n"
+        "sys.exit(255)\n"
+    )
+    script.chmod(0o755)
+    saved_path = os.environ.get("PATH", "")
+    os.environ["PATH"] = f"{bin_dir}{os.pathsep}{saved_path}"
+    try:
+        yield bin_dir
+    finally:
+        os.environ["PATH"] = saved_path
+
+
+@pytest.fixture
+def remote_row_for_clew(cross_host_state_db):
+    """Seed an active singleton row for ``clew`` on the unreachable
+    peer ``peer-x`` AND the matching comms_nodes pin so the test can
+    verify BOTH stores are cleared on force-release."""
+    from scitex_agent_container._state.state_db import record_instance_start
+    from scitex_agent_container._state.state_db_comms_nodes import register_comms_node
+
+    iid = record_instance_start(
+        name="clew", host="peer-x", a2a_port=19500, bound_port=19500, remote=True
+    )
+    register_comms_node(name="clew", host="peer-x", a2a_port=19500, source_host=None)
+    return iid
+
+
+def test_force_release_on_unreachable_peer_exits_zero(
+    remote_row_for_clew, ssh_shim_unreachable
+):
+    # Arrange
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(stop, ["clew", "--force"])
+    # Assert — operator unblocked (otherwise the bm025 repro returns rc=1).
+    assert result.exit_code == 0, result.output
+
+
+def test_force_release_tombstones_instance_row(
+    remote_row_for_clew, ssh_shim_unreachable
+):
+    # Arrange
+    from scitex_agent_container._state.state_db import list_active_instances
+
+    runner = CliRunner()
+    # Act
+    runner.invoke(stop, ["clew", "--force"])
+    # Assert — no active row for clew anywhere; the binding was released.
+    rows = [r for r in list_active_instances() if r["name"] == "clew"]
+    assert rows == []
+
+
+def test_force_release_clears_comms_nodes_binding(
+    remote_row_for_clew, ssh_shim_unreachable
+):
+    # Arrange — the federated comms_nodes pin must ALSO clear, otherwise
+    # subsequent a2a routing still tries the unreachable peer even after
+    # the instances row is closed.
+    from scitex_agent_container._state.state_db_comms_nodes import lookup_comms_node
+
+    runner = CliRunner()
+    # Act
+    runner.invoke(stop, ["clew", "--force"])
+    # Assert
+    assert lookup_comms_node(name="clew") is None
+
+
+def test_force_release_json_envelope_carries_force_released_flag(
+    remote_row_for_clew, ssh_shim_unreachable
+):
+    import json as _json
+
+    # Arrange
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(stop, ["clew", "--force", "--json"])
+    envelope = _json.loads(result.output.strip().splitlines()[-1])
+    # Assert
+    assert envelope.get("force_released") is True
+
+
+def test_force_release_json_envelope_carries_release_exit_reason(
+    remote_row_for_clew, ssh_shim_unreachable
+):
+    import json as _json
+
+    # Arrange
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(stop, ["clew", "--force", "--json"])
+    envelope = _json.loads(result.output.strip().splitlines()[-1])
+    # Assert
+    assert envelope.get("exit_reason") == "peer-unreachable-force-released"
+
+
+def test_no_force_on_unreachable_peer_exits_nonzero(
+    remote_row_for_clew, ssh_shim_unreachable
+):
+    # Arrange — without --force, the ssh transport failure MUST surface
+    # as an error (operator hasn't opted in to the destructive release).
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(stop, ["clew"])
+    # Assert
+    assert result.exit_code != 0
+
+
+def test_no_force_on_unreachable_peer_leaves_instance_row(
+    remote_row_for_clew, ssh_shim_unreachable
+):
+    # Arrange — without --force, the binding MUST remain so the
+    # operator can investigate before discarding it.
+    from scitex_agent_container._state.state_db import list_active_instances
+
+    runner = CliRunner()
+    # Act
+    runner.invoke(stop, ["clew"])
+    # Assert
+    rows = [r for r in list_active_instances() if r["name"] == "clew"]
+    assert len(rows) == 1
+
+
+def test_no_force_on_unreachable_peer_message_surfaces_peer_diagnostic(
+    remote_row_for_clew, ssh_shim_unreachable
+):
+    # Arrange — operator needs the underlying ssh stderr to diagnose
+    # (per the project's no-silent-fallback rule).
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(stop, ["clew"])
+    # Assert
+    assert "pam_slurm_adopt" in result.output or "peer-x" in result.output


### PR DESCRIPTION
## Summary

Follow-up to PR #252's fail-loud start path. Closes the **clew #1-priority blocker**: clew was pinned in the registry to a dead prior host (spartan-bm025, no SLURM job → `pam_slurm_adopt` denies any ssh). Both the new singleton-skip and `stop --force` chased the dead host and hung:

- `sac --on spartan-gpgpu011 agents start clew` → "singleton prefers spartan-bm025, current host spartan-gpgpu011, remote status=skipped" (PR #252's fail-loud caught the silent skip, but the underlying stale binding still needed a release path).
- `sac agents stop clew --force` aborted on rc=255 ssh transport failure to bm025, so the stale `instances` row + `comms_nodes` pin never cleared — every subsequent routing decision re-tried the dead host.

Two changes, same robustness class as PR #252's three-signal `_verify_real_liveness`:

1. **Liveness-gated `_resolve_singleton_skip`** (`cli_pkg/lifecycle/_common.py`): the skip now consults a `BoundHostLivenessOracle` (default: `state_db.list_active_instances`). If the bound host has no active row for this agent, the binding is stale → return `None` → fall through to a local start. If the bound host has a live row, the original "skip and defer" preserved.

2. **`stop --force` releases stale binding on unreachable peer** (`cli_pkg/lifecycle/_stop.py`): `_dispatch_remote_stop` now raises a typed `_PeerUnreachableError` for ssh transport failures (rc!=0). The stop loop catches it ONLY when `--force` is set and falls through to `_force_release_binding`, which tombstones the instances row with `exit_reason='peer-unreachable-force-released'` AND clears the `comms_nodes` pin. Without `--force`, the ssh failure still surfaces as an error.

JSON envelope on the force-release path carries `"force_released": true` so wrapping automation can distinguish a clean cross-host stop from a stale-binding release.

## Test plan

- [x] 8 new no-mocks tests for stop --force release path (real `state.db`, PATH-prepended fake ssh emitting rc=255 with a `pam_slurm_adopt` stderr).
- [x] 5 new tests for the singleton-skip liveness gate (live oracle preserves skip; dead oracle releases binding; oracle scope + call shape pinned).
- [x] Existing `TestSingletonHostSkip` / `TestResumeAndForeground` integration tests updated to populate a live `state.db` row so the gate's release semantics don't fire unexpectedly.
- [x] Full suite green except for pre-existing develop-baseline failures (audit, cli_startup_budget, statusline ×4, a2a/handlers, sdk_common cwd).
- [x] STX-TQ002 (AAA markers), STX-TQ003 (descriptive names), STX-TQ007 (one assertion per test).