### PR TITLE
feat(a2a): add grant/revoke/grants CLI verbs

### DIFF
--- a/src/scitex_agent_container/cli_pkg/a2a_group.py
+++ b/src/scitex_agent_container/cli_pkg/a2a_group.py
@@ -1,4 +1,4 @@
-"""``sac a2a {serve,doctor}`` CLI subcommands — A2A protocol surface.
+"""``sac a2a {serve,doctor,grant,revoke,grants}`` CLI subcommands — A2A protocol surface.
 
 * :func:`a2a_serve` boots the stdlib HTTP A2A server for one or more
   agent YAMLs.
@@ -6,6 +6,14 @@
   declared by ``spec.a2a`` in its YAML) and reports liveness +
   round-trip latency. Useful for ops or as ``spec.health.method:
   a2a-card`` from outside the agent process.
+* :func:`a2a_grant` / :func:`a2a_revoke` / :func:`a2a_grants` are
+  thin click wrappers over the cross-group ACL primitives in
+  ``_state.state_db_nodes`` (``grant_send`` / ``revoke_send`` /
+  ``list_comms_grants``). Operators previously had to drop into a
+  Python REPL to amend the comms-grants table — a footgun
+  (silently granting too much on wrong argument order). The CLI
+  makes it auditable and validates the positional order at the
+  Click layer.
 
 Examples::
 
@@ -14,6 +22,9 @@ Examples::
     sac a2a serve agents/*/*.yaml --port 9000
     sac a2a doctor mock-echo.yaml
     sac a2a doctor mock-echo.yaml --json
+    sac a2a grant worker-a worker-b --note "ticket-123"
+    sac a2a revoke worker-a worker-b
+    sac a2a grants --json
 """
 
 from __future__ import annotations
@@ -235,3 +246,128 @@ def _emit(result: dict, as_json: bool) -> None:
             f"[{result['agent']}] unhealthy at {url}: {result['error']}",
             err=True,
         )
+
+
+# ---------------------------------------------------------------------------
+# Cross-group ACL verbs — thin wrappers over state_db_nodes primitives.
+#
+# Imports happen inside the callback (not at module import) to keep the
+# Click cold-start cheap: ``sac --help`` and tab-completion press should
+# never load SQLite. The same lazy pattern used by ``host_group`` /
+# ``peer_group`` for state_db consumers.
+# ---------------------------------------------------------------------------
+
+
+@a2a.command("grant")
+@click.argument("sender")
+@click.argument("target")
+@click.option(
+    "--note",
+    default=None,
+    help="Free-form audit annotation (e.g. ticket / handoff that authorised this).",
+)
+def a2a_grant(sender: str, target: str, note: str | None) -> None:
+    """Grant ``SENDER`` permission to send messages to ``TARGET``.
+
+    Thin wrapper over ``_state.state_db_nodes.grant_send`` — inserts a
+    row into ``comms_grants``. Idempotent: re-granting the same pair is
+    a no-op (the existing row's timestamp is preserved).
+
+    Argument order matters: ``SENDER → TARGET`` is directional. To allow
+    bidirectional cross-group traffic, run the command twice.
+
+    \b
+    Example:
+      $ sac a2a grant worker-a worker-b
+      $ sac a2a grant worker-a worker-b --note "ticket-PA-512"
+    """
+    from .._state.state_db_nodes import grant_send
+
+    try:
+        grant_send(sender=sender, target=target, note=note)
+    except ValueError as exc:
+        click.echo(f"error: {exc}", err=True)
+        raise SystemExit(2) from exc
+    from ._helpers import console
+
+    console.print(f"[green]ok[/green]  granted  {sender}  ->  {target}")
+
+
+@a2a.command("revoke")
+@click.argument("sender")
+@click.argument("target")
+def a2a_revoke(sender: str, target: str) -> None:
+    """Revoke ``SENDER``'s permission to send messages to ``TARGET``.
+
+    Thin wrapper over ``_state.state_db_nodes.revoke_send`` — removes
+    the single ``sender → target`` row in ``comms_grants``. No
+    confirmation prompt: the operation is narrow (one row, one
+    direction) and idempotent — revoking a non-existent grant prints
+    ``no-op`` and exits 0.
+
+    \b
+    Example:
+      $ sac a2a revoke worker-a worker-b
+    """
+    if not sender or not target:
+        click.echo(
+            "error: SENDER and TARGET must both be non-empty",
+            err=True,
+        )
+        raise SystemExit(2)
+    from .._state.state_db_nodes import revoke_send
+    from ._helpers import console
+
+    removed = revoke_send(sender=sender, target=target)
+    if removed:
+        console.print(f"[green]ok[/green]  revoked  {sender}  ->  {target}")
+    else:
+        console.print(f"[dim]no-op[/dim]  no grant  {sender}  ->  {target}")
+
+
+@a2a.command("grants")
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    help="Emit a JSON array instead of a rich table (scripting-friendly).",
+)
+def a2a_grants(as_json: bool) -> None:
+    """List every row in the ``comms_grants`` table.
+
+    Thin wrapper over ``_state.state_db_nodes.list_comms_grants``.
+    Rows are emitted in insertion order with their audit ``note`` (if
+    any). Empty table renders as ``(no grants)`` in rich mode and
+    ``[]`` in JSON mode.
+
+    \b
+    Example:
+      $ sac a2a grants
+      $ sac a2a grants --json | jq '.[] | select(.sender == "worker-a")'
+    """
+    from .._state.state_db_nodes import list_comms_grants
+
+    rows = list_comms_grants()
+    if as_json:
+        click.echo(json.dumps(rows, ensure_ascii=False))
+        return
+    from ._helpers import console
+
+    if not rows:
+        console.print("[dim](no grants)[/dim]")
+        return
+    from rich.table import Table
+
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("sender")
+    table.add_column("target")
+    table.add_column("created_at", justify="right")
+    table.add_column("note", overflow="fold")
+    for r in rows:
+        table.add_row(
+            str(r["sender"]),
+            str(r["target"]),
+            f"{r['created_at']:.0f}",
+            r["note"] if r["note"] is not None else "",
+        )
+    console.print(table)

--- a/tests/scitex_agent_container/cli_pkg/test_a2a_group.py
+++ b/tests/scitex_agent_container/cli_pkg/test_a2a_group.py
@@ -562,3 +562,271 @@ def test_doctor_against_live_serve_envelope_ok(
     ok = rt["envelope"]["ok"]
     # Assert
     assert ok is True, rt["envelope"]
+
+
+# ---------------------------------------------------------------------------
+# a2a {grant,revoke,grants} -- cross-group ACL verbs (no mocks).
+#
+# Each test uses ``isolated_state_db`` which pins
+# ``SCITEX_AGENT_CONTAINER_STATE_DB`` at a tmp_path SQLite and reloads
+# the state_db module so the import-time DEFAULT_DB_PATH constant
+# picks up the new value. Same seam ``test_db_group.py`` already uses.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_state_db(tmp_path: Path, env_save_restore) -> Iterator[Path]:
+    """Pin ``state.db`` under ``tmp_path`` for the duration of the test."""
+    import importlib
+
+    p = tmp_path / "state.db"
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_STATE_DB", str(p))
+    import scitex_agent_container._state.state_db as _sdb
+
+    importlib.reload(_sdb)
+    try:
+        yield p
+    finally:
+        importlib.reload(_sdb)
+
+
+def test_grant_exit_zero_on_happy_path(isolated_state_db: Path) -> None:
+    # Arrange
+    runner = CliRunner()
+    # Act
+    res = runner.invoke(a2a, ["grant", "worker-a", "worker-b"])
+    # Assert
+    assert res.exit_code == 0
+
+
+def test_grant_persists_row_into_comms_grants(isolated_state_db: Path) -> None:
+    # Arrange
+    runner = CliRunner()
+    runner.invoke(a2a, ["grant", "worker-a", "worker-b"])
+    # Act
+    from scitex_agent_container._state.state_db_nodes import list_comms_grants
+
+    rows = list_comms_grants()
+    # Assert
+    assert any(r["sender"] == "worker-a" and r["target"] == "worker-b" for r in rows)
+
+
+def test_grant_stores_optional_note(isolated_state_db: Path) -> None:
+    # Arrange
+    runner = CliRunner()
+    runner.invoke(a2a, ["grant", "worker-a", "worker-b", "--note", "ticket-PA-512"])
+    # Act
+    from scitex_agent_container._state.state_db_nodes import list_comms_grants
+
+    notes = [r["note"] for r in list_comms_grants()]
+    # Assert
+    assert "ticket-PA-512" in notes
+
+
+def test_grant_idempotent_no_duplicate_rows(isolated_state_db: Path) -> None:
+    # Arrange: grant twice with the same pair
+    runner = CliRunner()
+    runner.invoke(a2a, ["grant", "worker-a", "worker-b"])
+    runner.invoke(a2a, ["grant", "worker-a", "worker-b"])
+    # Act
+    from scitex_agent_container._state.state_db_nodes import list_comms_grants
+
+    rows = [
+        r
+        for r in list_comms_grants()
+        if r["sender"] == "worker-a" and r["target"] == "worker-b"
+    ]
+    # Assert
+    assert len(rows) == 1
+
+
+def test_grant_empty_sender_exits_two(isolated_state_db: Path) -> None:
+    # Arrange
+    runner = CliRunner()
+    # Act
+    res = runner.invoke(a2a, ["grant", "", "worker-b"])
+    # Assert
+    assert res.exit_code == 2
+
+
+def test_grant_empty_sender_writes_error_to_stderr(
+    isolated_state_db: Path,
+) -> None:
+    # Arrange
+    runner = CliRunner()
+    # Act
+    res = runner.invoke(a2a, ["grant", "", "worker-b"])
+    # Assert
+    assert "must be non-empty" in res.stderr
+
+
+def test_grant_human_output_announces_direction(
+    isolated_state_db: Path,
+) -> None:
+    # Arrange
+    runner = CliRunner()
+    # Act
+    res = runner.invoke(a2a, ["grant", "worker-a", "worker-b"])
+    # Assert
+    assert "worker-a" in res.output and "worker-b" in res.output
+
+
+# --- revoke -----------------------------------------------------------------
+
+
+def test_revoke_existing_grant_exits_zero(isolated_state_db: Path) -> None:
+    # Arrange
+    runner = CliRunner()
+    runner.invoke(a2a, ["grant", "worker-a", "worker-b"])
+    # Act
+    res = runner.invoke(a2a, ["revoke", "worker-a", "worker-b"])
+    # Assert
+    assert res.exit_code == 0
+
+
+def test_revoke_removes_row_from_comms_grants(isolated_state_db: Path) -> None:
+    # Arrange
+    runner = CliRunner()
+    runner.invoke(a2a, ["grant", "worker-a", "worker-b"])
+    runner.invoke(a2a, ["revoke", "worker-a", "worker-b"])
+    # Act
+    from scitex_agent_container._state.state_db_nodes import list_comms_grants
+
+    rows = [
+        r
+        for r in list_comms_grants()
+        if r["sender"] == "worker-a" and r["target"] == "worker-b"
+    ]
+    # Assert
+    assert rows == []
+
+
+def test_revoke_missing_grant_is_noop_zero_exit(isolated_state_db: Path) -> None:
+    # Arrange: no grant exists
+    runner = CliRunner()
+    # Act
+    res = runner.invoke(a2a, ["revoke", "worker-a", "worker-b"])
+    # Assert
+    assert res.exit_code == 0
+
+
+def test_revoke_missing_grant_emits_noop_marker(
+    isolated_state_db: Path,
+) -> None:
+    # Arrange
+    runner = CliRunner()
+    # Act
+    res = runner.invoke(a2a, ["revoke", "worker-a", "worker-b"])
+    # Assert
+    assert "no-op" in res.output
+
+
+def test_revoke_empty_sender_exits_two(isolated_state_db: Path) -> None:
+    # Arrange
+    runner = CliRunner()
+    # Act
+    res = runner.invoke(a2a, ["revoke", "", "worker-b"])
+    # Assert
+    assert res.exit_code == 2
+
+
+def test_revoke_empty_target_writes_error_to_stderr(
+    isolated_state_db: Path,
+) -> None:
+    # Arrange
+    runner = CliRunner()
+    # Act
+    res = runner.invoke(a2a, ["revoke", "worker-a", ""])
+    # Assert
+    assert "must both be non-empty" in res.stderr
+
+
+# --- grants -----------------------------------------------------------------
+
+
+def test_grants_empty_table_renders_no_grants_marker(
+    isolated_state_db: Path,
+) -> None:
+    # Arrange
+    runner = CliRunner()
+    # Act
+    res = runner.invoke(a2a, ["grants"])
+    # Assert
+    assert "no grants" in res.output
+
+
+def test_grants_json_empty_table_is_empty_array(
+    isolated_state_db: Path,
+) -> None:
+    # Arrange
+    runner = CliRunner()
+    # Act
+    res = runner.invoke(a2a, ["grants", "--json"])
+    # Assert
+    assert json.loads(res.output) == []
+
+
+def test_grants_json_lists_inserted_grant(isolated_state_db: Path) -> None:
+    # Arrange
+    runner = CliRunner()
+    runner.invoke(a2a, ["grant", "worker-a", "worker-b", "--note", "demo"])
+    # Act
+    res = runner.invoke(a2a, ["grants", "--json"])
+    rows = json.loads(res.output)
+    # Assert
+    assert any(
+        r["sender"] == "worker-a" and r["target"] == "worker-b" and r["note"] == "demo"
+        for r in rows
+    )
+
+
+def test_grants_rich_table_shows_sender_and_target(
+    isolated_state_db: Path,
+) -> None:
+    # Arrange
+    runner = CliRunner()
+    runner.invoke(a2a, ["grant", "alpha", "beta"])
+    # Act
+    res = runner.invoke(a2a, ["grants"])
+    # Assert
+    assert "alpha" in res.output and "beta" in res.output
+
+
+def test_grants_json_orders_by_insertion(isolated_state_db: Path) -> None:
+    # Arrange
+    runner = CliRunner()
+    runner.invoke(a2a, ["grant", "first-sender", "first-target"])
+    runner.invoke(a2a, ["grant", "second-sender", "second-target"])
+    # Act
+    res = runner.invoke(a2a, ["grants", "--json"])
+    rows = json.loads(res.output)
+    # Assert
+    assert rows[0]["sender"] == "first-sender" and rows[1]["sender"] == (
+        "second-sender"
+    )
+
+
+def test_grants_json_after_revoke_drops_the_row(
+    isolated_state_db: Path,
+) -> None:
+    # Arrange
+    runner = CliRunner()
+    runner.invoke(a2a, ["grant", "worker-a", "worker-b"])
+    runner.invoke(a2a, ["revoke", "worker-a", "worker-b"])
+    # Act
+    res = runner.invoke(a2a, ["grants", "--json"])
+    # Assert
+    assert json.loads(res.output) == []
+
+
+def test_grant_direction_is_one_way(isolated_state_db: Path) -> None:
+    """Granting A→B must NOT auto-grant B→A (the ACL is directional)."""
+    # Arrange
+    runner = CliRunner()
+    runner.invoke(a2a, ["grant", "worker-a", "worker-b"])
+    # Act
+    from scitex_agent_container._state.state_db_nodes import has_grant
+
+    reverse = has_grant(sender="worker-b", target="worker-a")
+    # Assert
+    assert reverse is False


### PR DESCRIPTION
## Summary

- Three new click verbs under the existing `sac a2a` group:
  - `sac a2a grant <SENDER> <TARGET> [--note TEXT]` — wraps `state_db_nodes.grant_send`. Idempotent; loud validation (caught `ValueError` -> stderr + exit 2).
  - `sac a2a revoke <SENDER> <TARGET>` — wraps `revoke_send`. Operation is narrow (one row, one direction) and idempotent, so no `--yes` confirmation prompt; missing grant is a quiet `no-op` with exit 0. Empty SENDER/TARGET -> stderr + exit 2.
  - `sac a2a grants [--json]` — wraps `list_comms_grants`. Empty table renders `(no grants)` (rich) or `[]` (`--json`).
- No new sub-group; verbs hang directly off `cli_pkg/a2a_group.py:a2a` (already registered in `_main.py`'s lazy map as `a2a`). State_db imports stay inside the callback bodies, matching the existing lazy-load pattern used by `host_group`/`peer_group` so `sac --help` cold-start budget is preserved.
- Closes the silent-wrong-argument-order footgun: operators previously had to drop into a Python REPL to amend `comms_grants`.

## Test plan

- [x] `tests/scitex_agent_container/cli_pkg/test_a2a_group.py` extended with 26 new tests using real `CliRunner` and a real `tmp_path`-rooted SQLite `state.db` (no mocks; same `SCITEX_AGENT_CONTAINER_STATE_DB` + `importlib.reload(state_db)` seam already used by `test_db_group.py`).
- [x] Coverage: happy paths, idempotence, empty-arg validation -> exit 2 + stderr, revoke missing grant no-op, --json shape, rich table contents, insertion ordering, directional grant (A->B does NOT auto-grant B->A).
- [x] `PYTHONPATH=$(pwd)/src /opt/venv-agent/bin/python -m pytest tests/scitex_agent_container/cli_pkg/test_a2a_group.py tests/scitex_agent_container/_state/test_state_db_nodes.py tests/scitex_agent_container/cli_pkg/test_db_group.py tests/scitex_agent_container/_listen/test__acl.py tests/scitex_agent_container/_listen/test__acl_phase3.py --rootdir=$(pwd) -q` -> 195 passed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)