### PR TITLE
fix(push): render channel-push timestamps as ISO8601

### DIFF
--- a/src/scitex_agent_container/_mcp/channel.py
+++ b/src/scitex_agent_container/_mcp/channel.py
@@ -259,10 +259,18 @@ def _build_notification(event: dict[str, Any]) -> dict[str, Any]:
 
     Every ``meta`` value is stringified via :func:`_meta_str` — the
     client schema rejects non-string values (see that helper).
+    ``meta.ts`` is rendered as ISO-8601 UTC via
+    :func:`_state.state_db_channel.format_ts_iso` so a receiving
+    session sees ``<channel ts="2026-04-21T09:30:00Z" ...>`` instead
+    of the raw unix-seconds float the bus stores. On-disk storage of
+    ``channel_events.ts`` is unchanged — only the rendered form
+    here is ISO-8601.
     """
+    from .._state.state_db_channel import format_ts_iso
+
     meta: dict[str, Any] = {
         "source": _meta_str(event.get("from_agent", "unknown")),
-        "ts": _meta_str(event.get("ts", "")),
+        "ts": format_ts_iso(event.get("ts", "")),
         "msg_id": _meta_str(event.get("msg_id", "")),
     }
     for k in ("conversation_id", "in_reply_to", "priority", "requires_reply"):

--- a/src/scitex_agent_container/_state/state_db_channel.py
+++ b/src/scitex_agent_container/_state/state_db_channel.py
@@ -37,15 +37,82 @@ from __future__ import annotations
 
 import json
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable
 
 __all__ = [
+    "format_ts_iso",
     "persist_event",
     "list_undelivered",
     "list_since_id",
     "mark_delivered",
 ]
+
+
+def format_ts_iso(ts: object) -> str:
+    """Render a stored channel-event ``ts`` as an ISO-8601 UTC string.
+
+    Display formatter for emitters that surface a ``ts`` from the
+    ``channel_events`` table or a minted bus envelope (where ``ts`` is
+    unix-seconds, see :func:`persist_event` and
+    :func:`a2a._inbox_bus.mint_event`). On-disk storage stays
+    unix-seconds (``channel_events.ts REAL``); ONLY the rendered /
+    emitted form is ISO-8601, matching the legacy
+    :func:`state_db.now_iso` wire shape (trailing ``Z`` for UTC).
+
+    Used by the channel-push notification path
+    (:mod:`scitex_agent_container._mcp.channel`) so a receiving Claude
+    session sees ``<channel ts="2026-04-21T09:30:00Z" ...>`` instead of
+    the raw ``"1777766006.95"`` that was previously stringified
+    verbatim. A canonical helper here keeps every channel-push display
+    caller on one formatter (no per-call ``strftime`` duplication).
+
+    Numeric input is rendered via
+    ``datetime.fromtimestamp(ts, tz=utc).strftime("%Y-%m-%dT%H:%M:%SZ")``.
+    A string that already parses as ISO-8601 is round-tripped verbatim
+    so a double-format does not corrupt an upstream ISO value. A
+    numeric-looking string (the common JSON round-trip case) is coerced
+    to float and re-rendered. Anything else falls through to ``str(ts)``
+    — defensive: a display helper must never raise; the on-disk column
+    is the source of truth and a malformed display value would only
+    obscure the underlying data.
+
+    Empty / missing input (``""`` or ``None``) renders as ``""`` — the
+    receive-side notification meta passes ``event.get("ts", "")``, and
+    an empty stays empty (no ``1970-01-01T00:00:00Z`` surprise).
+    """
+    if ts is None:
+        return ""
+    if isinstance(ts, bool):
+        # bool is a subclass of int — guard explicitly so a stray
+        # ``True`` does not get rendered as a 1970 epoch timestamp.
+        return str(ts)
+    if isinstance(ts, (int, float)):
+        return datetime.fromtimestamp(float(ts), tz=timezone.utc).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+    if isinstance(ts, str):
+        s = ts.strip()
+        if not s:
+            return ""
+        # Tolerate an already-ISO string (with or without trailing 'Z')
+        # so render-helper composition never loses the timezone.
+        candidate = s[:-1] if s.endswith("Z") else s
+        try:
+            datetime.fromisoformat(candidate)
+            return s
+        except ValueError:
+            pass
+        # Common path: JSON round-trip of a float ts arrives as a string
+        # like ``"1777766006.95"``. Coerce and re-render.
+        try:
+            return datetime.fromtimestamp(float(s), tz=timezone.utc).strftime(
+                "%Y-%m-%dT%H:%M:%SZ"
+            )
+        except (TypeError, ValueError):
+            return s
+    return str(ts)
 
 
 def persist_event(

--- a/tests/scitex_agent_container/_mcp/test_channel.py
+++ b/tests/scitex_agent_container/_mcp/test_channel.py
@@ -238,13 +238,45 @@ def test_build_notification_carries_msg_id():
     assert meta["msg_id"] == "abc123"
 
 
-def test_build_notification_ts_is_stringified():
+def test_build_notification_ts_renders_iso8601_utc_from_unix_seconds():
+    # Arrange — 1_700_000_000 is 2023-11-14T22:13:20Z (no surprise epoch).
+    event = {"ts": 1_700_000_000, "from_agent": "bob", "content": "x"}
+    # Act
+    meta = _build_notification(event)["meta"]
+    # Assert — exact-round-trip: the rendered form is the canonical
+    # ISO-8601 UTC string the formatter emits.
+    assert meta["ts"] == "2023-11-14T22:13:20Z"
+
+
+def test_build_notification_ts_matches_iso8601_shape():
+    """Regression: channel-push timestamps must render as ISO-8601 (the
+    operator-greenlit format fix). The old behaviour stringified the
+    bus's raw unix-seconds float (e.g. ``"1234"``) which receiving
+    sessions saw as an unreadable number in the ``<channel ts=...>``
+    tag. Pin the rendered shape so a future regression to ``str(ts)``
+    fails loudly here instead of silently degrading the display."""
+    import re
+
+    # Arrange — float ts (the actual bus type, see mint_event).
+    event = {"ts": 1_777_766_006.95, "from_agent": "bob", "content": "x"}
+    # Act
+    rendered = _build_notification(event)["meta"]["ts"]
+    # Assert — basic ISO-8601 shape (date 'T' time, optional fractional
+    # seconds, optional timezone suffix).
+    assert re.match(
+        r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:?\d{2})?$",
+        rendered,
+    ), rendered
+
+
+def test_build_notification_ts_empty_when_absent():
+    """Missing ``ts`` stays empty — no surprise 1970 epoch."""
     # Arrange
-    event = {"ts": 1_234, "from_agent": "bob", "content": "x"}
+    event = {"from_agent": "bob", "content": "x"}
     # Act
     meta = _build_notification(event)["meta"]
     # Assert
-    assert meta["ts"] == "1234"
+    assert meta["ts"] == ""
 
 
 @pytest.mark.parametrize(

--- a/tests/scitex_agent_container/_state/test_state_db_channel.py
+++ b/tests/scitex_agent_container/_state/test_state_db_channel.py
@@ -277,8 +277,10 @@ def test_format_ts_iso_renders_unix_seconds_as_utc_z() -> None:
 
 def test_format_ts_iso_renders_int_unix_seconds() -> None:
     """Int ts (e.g. legacy callers) renders the same as float."""
-    # Arrange / Act
-    rendered = format_ts_iso(1_700_000_000)
+    # Arrange — same unix-seconds value as the float case, as int.
+    ts = 1_700_000_000
+    # Act
+    rendered = format_ts_iso(ts)
     # Assert
     assert rendered == "2023-11-14T22:13:20Z"
 
@@ -288,8 +290,10 @@ def test_format_ts_iso_matches_iso8601_shape() -> None:
     seconds, optional ``Z`` / ``+HH:MM`` offset)."""
     import re
 
-    # Arrange / Act
-    rendered = format_ts_iso(1_777_766_006.95)
+    # Arrange — a fractional-seconds float value.
+    ts = 1_777_766_006.95
+    # Act
+    rendered = format_ts_iso(ts)
     # Assert
     assert re.match(
         r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:?\d{2})?$",
@@ -300,16 +304,20 @@ def test_format_ts_iso_matches_iso8601_shape() -> None:
 def test_format_ts_iso_empty_string_stays_empty() -> None:
     """A missing-ts default (the receive-side passes ``event.get('ts', '')``)
     must NOT render as the 1970 epoch."""
-    # Arrange / Act
-    rendered = format_ts_iso("")
+    # Arrange — the sentinel empty-string used by missing-ts callers.
+    ts = ""
+    # Act
+    rendered = format_ts_iso(ts)
     # Assert
     assert rendered == ""
 
 
 def test_format_ts_iso_none_renders_empty() -> None:
     """A ``None`` ts (missing from envelope) renders empty, same as ``""``."""
-    # Arrange / Act
-    rendered = format_ts_iso(None)
+    # Arrange — None is the other missing-ts shape envelopes carry.
+    ts = None
+    # Act
+    rendered = format_ts_iso(ts)
     # Assert
     assert rendered == ""
 
@@ -328,8 +336,10 @@ def test_format_ts_iso_already_iso_string_is_passed_through() -> None:
 def test_format_ts_iso_numeric_string_is_coerced_and_rendered() -> None:
     """The JSON-round-trip case: a float ts arrives as ``"1700000000.0"``
     after meta_json (de)serialization. Coerce and render."""
-    # Arrange / Act
-    rendered = format_ts_iso("1700000000.0")
+    # Arrange — JSON-serialised float ts shape.
+    ts = "1700000000.0"
+    # Act
+    rendered = format_ts_iso(ts)
     # Assert
     assert rendered == "2023-11-14T22:13:20Z"
 
@@ -337,7 +347,9 @@ def test_format_ts_iso_numeric_string_is_coerced_and_rendered() -> None:
 def test_format_ts_iso_does_not_render_bool_as_epoch() -> None:
     """``bool`` is an int subclass — guard so a stray ``True`` does not
     silently become the 1970-01-01T00:00:01Z epoch."""
-    # Arrange / Act
-    rendered = format_ts_iso(True)
+    # Arrange — bool is the isinstance(_, int) footgun we're guarding.
+    ts = True
+    # Act
+    rendered = format_ts_iso(ts)
     # Assert
     assert rendered == "True"

--- a/tests/scitex_agent_container/_state/test_state_db_channel.py
+++ b/tests/scitex_agent_container/_state/test_state_db_channel.py
@@ -18,8 +18,9 @@ import pytest
 
 from scitex_agent_container._state import state_db
 from scitex_agent_container._state.state_db_channel import (
-    list_undelivered,
+    format_ts_iso,
     list_since_id,
+    list_undelivered,
     mark_delivered,
     persist_event,
 )
@@ -60,8 +61,7 @@ def test_channel_events_has_column(db_path: Path, column: str) -> None:
     # Act
     with conn_ctx as conn:
         cols = {
-            r[1]
-            for r in conn.execute("PRAGMA table_info(channel_events)").fetchall()
+            r[1] for r in conn.execute("PRAGMA table_info(channel_events)").fetchall()
         }
     # Assert
     assert column in cols
@@ -254,3 +254,90 @@ def test_list_since_id_returns_all_when_cursor_is_zero(db_path: Path) -> None:
     # Assert
     ids = [r["id"] for r in rows]
     assert ids == [r1, r2]
+
+
+# ---------------------------------------------------------------------------
+# format_ts_iso — display helper for channel-push timestamps
+#
+# Storage stays unix-seconds (channel_events.ts REAL); only the
+# rendered/emitted form is ISO-8601. The helper is the canonical
+# formatter every display caller routes through (see
+# scitex_agent_container._mcp.channel._build_notification).
+# ---------------------------------------------------------------------------
+
+
+def test_format_ts_iso_renders_unix_seconds_as_utc_z() -> None:
+    """Float ts (the bus envelope shape) renders as a trailing-Z ISO."""
+    # Arrange — 1_700_000_000 is 2023-11-14T22:13:20 UTC.
+    # Act
+    rendered = format_ts_iso(1_700_000_000.0)
+    # Assert — exact-round-trip the canonical formatter emits.
+    assert rendered == "2023-11-14T22:13:20Z"
+
+
+def test_format_ts_iso_renders_int_unix_seconds() -> None:
+    """Int ts (e.g. legacy callers) renders the same as float."""
+    # Arrange / Act
+    rendered = format_ts_iso(1_700_000_000)
+    # Assert
+    assert rendered == "2023-11-14T22:13:20Z"
+
+
+def test_format_ts_iso_matches_iso8601_shape() -> None:
+    """Basic ISO-8601 shape regex (date 'T' time, optional fractional
+    seconds, optional ``Z`` / ``+HH:MM`` offset)."""
+    import re
+
+    # Arrange / Act
+    rendered = format_ts_iso(1_777_766_006.95)
+    # Assert
+    assert re.match(
+        r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:?\d{2})?$",
+        rendered,
+    ), rendered
+
+
+def test_format_ts_iso_empty_string_stays_empty() -> None:
+    """A missing-ts default (the receive-side passes ``event.get('ts', '')``)
+    must NOT render as the 1970 epoch."""
+    # Arrange / Act
+    rendered = format_ts_iso("")
+    # Assert
+    assert rendered == ""
+
+
+def test_format_ts_iso_none_renders_empty() -> None:
+    """A ``None`` ts (missing from envelope) renders empty, same as ``""``."""
+    # Arrange / Act
+    rendered = format_ts_iso(None)
+    # Assert
+    assert rendered == ""
+
+
+def test_format_ts_iso_already_iso_string_is_passed_through() -> None:
+    """An already-ISO string (a sender that pre-formatted ts) round-trips
+    verbatim — composition of render helpers must not corrupt tz."""
+    # Arrange
+    iso = "2026-04-21T09:30:00+00:00"
+    # Act
+    rendered = format_ts_iso(iso)
+    # Assert
+    assert rendered == iso
+
+
+def test_format_ts_iso_numeric_string_is_coerced_and_rendered() -> None:
+    """The JSON-round-trip case: a float ts arrives as ``"1700000000.0"``
+    after meta_json (de)serialization. Coerce and render."""
+    # Arrange / Act
+    rendered = format_ts_iso("1700000000.0")
+    # Assert
+    assert rendered == "2023-11-14T22:13:20Z"
+
+
+def test_format_ts_iso_does_not_render_bool_as_epoch() -> None:
+    """``bool`` is an int subclass — guard so a stray ``True`` does not
+    silently become the 1970-01-01T00:00:01Z epoch."""
+    # Arrange / Act
+    rendered = format_ts_iso(True)
+    # Assert
+    assert rendered == "True"


### PR DESCRIPTION
## Summary

- The receive-side MCP channel adapter (`_mcp.channel._build_notification`) stringified the bus event's raw unix-seconds float verbatim into `meta.ts`, so a receiving Claude session saw `<channel ts="1777766006.95" ...>` — an unreadable number where a timestamp belongs.
- Added a canonical display formatter `format_ts_iso(ts) -> str` in `_state.state_db_channel` (alongside the existing storage helpers `persist_event` / `list_undelivered` / ...) that renders unix-seconds as ISO-8601 UTC with trailing `Z`, matching the legacy `state_db.now_iso` wire shape.
- Routed `_build_notification` through it so every channel-push notification emits an ISO-8601 `ts`.

The helper tolerates already-ISO strings (no double-format), coerces JSON-round-trip numeric strings (`"1700000000.0"`), and renders empty / `None` as `""` (no surprise 1970 epoch when `ts` is absent).

**Storage is unchanged.** `channel_events.ts REAL` and the bus envelope `ts` both stay unix-seconds; only the rendered / emitted form is ISO-8601.

## Scope

One emitter rewired:

- `_mcp.channel._build_notification` — `meta.ts` now formatted via `format_ts_iso`.

Other surfaces audited and confirmed already-ISO or unaffected:
- `_state.lead_inbox.build_lead_envelope` — no timestamp in the envelope.
- `a2a._handlers` — no timestamp in handler payloads.
- `_listen._tail` — tails JSONL records that already store ISO ts.
- `_state.event_log` / `_state._meta.quota` / `_network.probe` — already write ISO ts.

## Test plan

- [x] `tests/scitex_agent_container/_state/test_state_db_channel.py` — 8 new tests for `format_ts_iso`: int / float / regex shape / empty / None / already-ISO / numeric-string / bool guard.
- [x] `tests/scitex_agent_container/_mcp/test_channel.py` — 3 tests for the rewired emitter: exact-round-trip ISO render from unix-seconds float, ISO-8601 shape regex, empty-when-absent. The old `test_build_notification_ts_is_stringified` (which pinned the broken `"1234"` shape) was replaced.
- [x] `PYTHONPATH=$(pwd)/src /opt/venv-agent/bin/python -m pytest tests/scitex_agent_container/_state/test_state_db_channel.py tests/scitex_agent_container/_mcp/test_channel.py --rootdir=$(pwd) -q` — **91 passed**.
- [x] Broader run on `_mcp/`, `a2a/`, and `_state/test_state_db_channel.py` — 462 passed; one pre-existing failure on `develop` in `test__handlers.py::test_claude_session_channels_without_port_raises_handler_error` (unrelated, verified by stashing this branch's changes and re-running on clean develop).

No mocks; tests use fixed unix-seconds inputs and assert exact ISO output plus the regex shape.