### PR TITLE
fix(accounts): tz-local + live TTL + table renderer for `sac accounts list`

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_account_list_render.py
+++ b/src/scitex_agent_container/cli_pkg/_account_list_render.py
@@ -1,0 +1,474 @@
+"""Renderer for ``sac accounts list`` — Stored-accounts table + helpers.
+
+Split out of ``account_group.py`` to keep that file under the per-file
+line cap (same pattern as ``_account_status.py`` and ``_account_refresh.py``)
+and so the renderer is unit-testable without going through ``CliRunner``.
+
+Three concerns live here, one per public helper:
+
+1. :func:`local_timezone` / :func:`format_dt_local` — render an ISO-8601
+   timestamp in the operator's local timezone. Precedence:
+   ``SCITEX_AGENT_CONTAINER_TZ`` env wins, else ``TZ`` env, else the
+   system local timezone (``datetime.astimezone()`` with no arg). This
+   is the bullet-1 fix: the prior renderer emitted UTC.
+
+2. :func:`format_ttl_live` / :func:`format_snapshot_age` — render the
+   credential TTL and the per-account usage snapshot age with enough
+   resolution that a 60-second tick is VISIBLE under ``watch -n1``. The
+   prior ``+2.8h`` collapsed any sub-hour change into the same string,
+   making the operator think the value was cached. TTL is computed
+   live from ``expiresAt`` on every call; this module only formats it.
+
+3. :func:`render_stored_table` — render the Stored-accounts block as a
+   ``rich.table.Table`` with aligned columns:
+
+       ID | Email | Plan | Status(+TTL) | 5h% | 7d% | As-of
+
+   ``As-of`` is the per-account usage snapshot age in short day+hour
+   form (``Sun 21h``), not microsecond ISO.
+
+The JSON-output path of ``sac accounts list --json`` is NOT touched —
+it still emits ISO-8601 ``as_of`` strings. Only the human renderer
+reformats at display time.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone, tzinfo
+
+from rich.console import Console
+from rich.table import Table
+
+# ---------------------------------------------------------------------------
+# Timezone resolution (bullet 1)
+# ---------------------------------------------------------------------------
+
+# Project-specific env wins over the standard POSIX ``TZ`` so a host-wide
+# ``TZ`` doesn't accidentally override an explicit per-tool preference.
+_PROJECT_TZ_ENV = "SCITEX_AGENT_CONTAINER_TZ"
+
+
+def local_timezone(env: dict[str, str] | None = None) -> tzinfo | None:
+    """Return the effective render timezone for the operator.
+
+    Precedence:
+
+    1. ``SCITEX_AGENT_CONTAINER_TZ`` env — project-specific override.
+    2. ``TZ`` env — standard POSIX.
+    3. ``None`` — caller should pass ``None`` through to
+       ``datetime.astimezone()`` which then picks up the system local
+       timezone.
+
+    Args:
+        env: Override for ``os.environ`` (tests pass a dict).
+
+    Returns:
+        A ``tzinfo`` if one of the env vars resolves, else ``None``.
+        Unknown / unparseable values silently fall through (we never
+        want a typo in ``TZ`` to crash ``sac accounts list``).
+    """
+    src = env if env is not None else os.environ
+    for key in (_PROJECT_TZ_ENV, "TZ"):
+        name = src.get(key)
+        if not name:
+            continue
+        tz = _resolve_tz(name)
+        if tz is not None:
+            return tz
+    return None
+
+
+def _resolve_tz(name: str) -> tzinfo | None:
+    """Return a ``tzinfo`` for IANA ``name`` (``Asia/Tokyo``), or None.
+
+    Uses the stdlib ``zoneinfo`` so no third-party dependency creeps in.
+    Returns ``None`` on any failure so a bad env value falls through to
+    the next layer of the precedence chain rather than crashing.
+    """
+    # stx-allow: fallback (reason: a bad TZ env value (typo, missing
+    # tzdata on the host) must not crash `sac accounts list` — fall
+    # through to the next precedence layer and ultimately system local.)
+    try:
+        from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+        return ZoneInfo(name)
+    except (ZoneInfoNotFoundError, ValueError, ModuleNotFoundError):
+        return None
+    except (
+        Exception
+    ):  # stx-allow: fallback (reason: catch-all safety net — see inline comment)
+        return None
+
+
+def format_dt_local(
+    iso_or_dt: str | datetime | None,
+    *,
+    env: dict[str, str] | None = None,
+) -> str:
+    """Render an ISO-8601 timestamp (or aware datetime) in local TZ.
+
+    Returns ``"-"`` for ``None`` / empty / unparseable input. Naive
+    datetimes are assumed UTC (matches what the JSON path writes).
+    """
+    dt = _coerce_dt(iso_or_dt)
+    if dt is None:
+        return "-"
+    tz = local_timezone(env)
+    if tz is None:
+        # No env override → system local (astimezone with no arg).
+        return dt.astimezone().isoformat(timespec="seconds")
+    return dt.astimezone(tz).isoformat(timespec="seconds")
+
+
+def _coerce_dt(value: str | datetime | None) -> datetime | None:
+    """Coerce ``value`` to an aware datetime; ``None`` on any failure."""
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    if not isinstance(value, str) or not value.strip():
+        return None
+    # stx-allow: fallback (reason: ISO parser is strict; a malformed
+    # cache timestamp must render as "-" rather than crash the table.)
+    try:
+        dt = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# TTL + age formatting (bullet 2 — must tick under watch -n1)
+# ---------------------------------------------------------------------------
+
+
+def format_ttl_live(hours: float | None) -> str:
+    """Render signed-hours-to-expiry with minute-resolution.
+
+    Prior format ``+2.8h`` collapsed a 60-second tick into the same
+    string. This renders as ``+2h48m`` / ``-138h35m`` / ``+45s`` so a
+    one-second tick under ``watch -n1`` is visible after ~60s.
+
+    ``None`` → ``"-"``.
+    """
+    if hours is None:
+        return "-"
+    total_seconds = int(round(hours * 3600.0))
+    sign = "+" if total_seconds >= 0 else "-"
+    s = abs(total_seconds)
+    h, rem = divmod(s, 3600)
+    m, sec = divmod(rem, 60)
+    if h:
+        return f"{sign}{h}h{m:02d}m"
+    if m:
+        return f"{sign}{m}m{sec:02d}s"
+    return f"{sign}{sec}s"
+
+
+def format_snapshot_age(
+    snapshot_iso: str | datetime | None,
+    *,
+    now: datetime | None = None,
+) -> str:
+    """Render the per-account usage snapshot age as ``3m`` / ``1h`` / ``12s``.
+
+    Used in the bullet-2 fix: the upstream usage% API is expensive to
+    refetch on every render, so the snapshot is intentionally cached.
+    Showing the age next to the % makes a stale number OBVIOUS instead
+    of silently shipping yesterday's percentage as if it were live.
+
+    ``None`` / unparseable → ``"?"``.
+    """
+    dt = _coerce_dt(snapshot_iso)
+    if dt is None:
+        return "?"
+    now_dt = now or datetime.now(timezone.utc)
+    if now_dt.tzinfo is None:
+        now_dt = now_dt.replace(tzinfo=timezone.utc)
+    delta_s = int((now_dt - dt).total_seconds())
+    if delta_s < 0:
+        delta_s = 0
+    if delta_s < 60:
+        return f"{delta_s}s"
+    if delta_s < 3600:
+        return f"{delta_s // 60}m"
+    if delta_s < 86400:
+        return f"{delta_s // 3600}h"
+    return f"{delta_s // 86400}d"
+
+
+def format_as_of_short(
+    iso_or_dt: str | datetime | None,
+    *,
+    env: dict[str, str] | None = None,
+) -> str:
+    """Render an As-of timestamp as day-of-week + hour: ``Sun 21h``.
+
+    Uses the local-tz precedence chain (project env > TZ env > system
+    local) so a UTC ``as_of`` lands in the operator's wall clock. The
+    output is intentionally low-resolution — the operator only needs
+    to know whether the value is from this hour, two hours ago, or
+    yesterday. Sub-hour resolution is the snapshot AGE column's job
+    (see :func:`format_snapshot_age`).
+
+    ``None`` / unparseable → ``"-"``.
+    """
+    dt = _coerce_dt(iso_or_dt)
+    if dt is None:
+        return "-"
+    tz = local_timezone(env)
+    local = dt.astimezone(tz) if tz is not None else dt.astimezone()
+    # %a = Sun/Mon/...; %H = 00-23.
+    return local.strftime("%a %Hh")
+
+
+# ---------------------------------------------------------------------------
+# Row data model + table renderer (bullet 3)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AccountRow:
+    """One row's worth of pre-resolved display data.
+
+    The dataclass keeps the renderer pure (no I/O, no time calls), so a
+    test can hand-roll a row and assert the exact cells without
+    monkeypatching the clock.
+
+    Attributes
+    ----------
+    name
+        Account ID (stored slug, e.g. ``ywatanabe-scitex-ai``).
+    email
+        Display email or ``(no email)`` placeholder.
+    plan_label
+        Human plan label (``Pro`` / ``Max 5x`` / ``Max 20x`` / ``?``).
+    tier
+        Rate-limit tier slug.
+    freshness_state
+        ``"VALID"`` / ``"EXPIRED"`` / ``"ABSENT"``.
+    freshness_hours
+        Signed hours to expiry, or ``None`` for ABSENT.
+    used_pct_5h, used_pct_7d
+        Float percentages or ``None``.
+    snapshot_as_of
+        ISO-8601 string from the usage cache, or ``None``.
+    """
+
+    name: str
+    email: str
+    plan_label: str
+    tier: str
+    freshness_state: str
+    freshness_hours: float | None
+    used_pct_5h: float | None
+    used_pct_7d: float | None
+    snapshot_as_of: str | None
+
+
+def _fmt_pct(value: float | None) -> str:
+    return "-" if value is None else f"{float(value):.0f}%"
+
+
+def _fmt_status(state: str, hours: float | None) -> str:
+    if state == "ABSENT" or hours is None:
+        return "ABSENT"
+    return f"{state} {format_ttl_live(hours)}"
+
+
+def _fmt_as_of_cell(snapshot_as_of: str | None, *, now: datetime | None = None) -> str:
+    """Combine short day+hour with age suffix: ``Sun 21h (3m)`` / ``- (?)``."""
+    if not snapshot_as_of:
+        return "-"
+    return f"{format_as_of_short(snapshot_as_of)} ({format_snapshot_age(snapshot_as_of, now=now)})"
+
+
+def render_stored_table(
+    rows: list[AccountRow],
+    *,
+    now: datetime | None = None,
+) -> Table:
+    """Build a ``rich.table.Table`` for the Stored-accounts block.
+
+    Columns (left-to-right):
+      ID | Email | Plan | Status(+TTL) | 5h% | 7d% | As-of
+
+    ``now`` is an injection seam so the bullet-2 liveness tests can
+    drive the snapshot-age cell deterministically without monkeypatching
+    ``datetime.now``.
+    """
+    table = Table(title="Stored accounts", title_justify="left", show_lines=False)
+    table.add_column("ID", style="bold")
+    table.add_column("Email")
+    table.add_column("Plan")
+    table.add_column("Status(+TTL)")
+    table.add_column("5h%", justify="right")
+    table.add_column("7d%", justify="right")
+    table.add_column("As-of")
+    for r in rows:
+        table.add_row(
+            r.name,
+            r.email,
+            f"{r.plan_label} [{r.tier}]",
+            _fmt_status(r.freshness_state, r.freshness_hours),
+            _fmt_pct(r.used_pct_5h),
+            _fmt_pct(r.used_pct_7d),
+            _fmt_as_of_cell(r.snapshot_as_of, now=now),
+        )
+    return table
+
+
+def render_stored_table_to_str(
+    rows: list[AccountRow],
+    *,
+    now: datetime | None = None,
+    width: int = 120,
+) -> str:
+    """Render the Stored-accounts table to a plain string.
+
+    Used by the CLI tests to assert column alignment without coupling
+    to terminal width. ``Console(record=True)`` captures the rendered
+    output verbatim.
+    """
+    console = Console(record=True, width=width, file=open(os.devnull, "w"))
+    try:
+        console.print(render_stored_table(rows, now=now))
+        return console.export_text()
+    finally:
+        console.file.close()
+
+
+# ---------------------------------------------------------------------------
+# Per-account usage fetch + JSON/human orchestrators
+# ---------------------------------------------------------------------------
+
+
+def _per_account_usage_cache_path(name: str):
+    """Return the absolute path of the per-account ``usage.json`` cache."""
+    from pathlib import Path
+
+    from .._state.account_store import _store_path
+
+    return _store_path(None, Path.home()) / name / "usage.json"
+
+
+def usage_for_account(acct_meta: dict, *, refresh: bool = False) -> dict | None:
+    """Live PER-ACCOUNT usage fetch (5-min cache); ``--refresh`` busts it.
+
+    The snapshot lives at
+    ``~/.scitex/agent-container/accounts/<name>/.credentials.json``
+    (cascade-resolved via ``_store_path``); the fetch result is cached
+    next to that file as ``usage.json`` so the same
+    ``read_account_usage_cache`` reader sees the live value across
+    invocations. Any failure (missing snapshot, expired token, network
+    error) returns ``None`` → caller renders ``"-"`` for that row only;
+    the rest of the list keeps rendering.
+
+    When ``refresh`` is true the on-disk ``usage.json`` is removed
+    before the fetch so the API is hit even when the cache is fresh —
+    wiring for ``sac accounts list --refresh``.
+    """
+    from pathlib import Path
+
+    from .._account.claude_usage import fetch_usage_for_credentials
+    from .._state.account_store import _store_path, read_account_usage_cache
+
+    name = acct_meta.get("name")
+    if not name:
+        return None
+    store = _store_path(None, Path.home())
+    creds_path = store / name / ".credentials.json"
+    if not creds_path.is_file():
+        return read_account_usage_cache(name)
+    if refresh:
+        cache_path = _per_account_usage_cache_path(name)
+        # stx-allow: fallback (reason: best-effort cache bust; if the
+        # file is already gone or locked, the next call still re-fetches
+        # because the cache reader gracefully returns None.)
+        try:
+            cache_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+    # stx-allow: fallback (reason: fetch_usage_for_credentials is documented never-raise, but defence-in-depth so one bad row never crashes `account list`)
+    try:
+        result = fetch_usage_for_credentials(creds_path)
+    except Exception:  # stx-allow: fallback (reason: catch-all safety net — see inline comment for context)
+        return read_account_usage_cache(name)
+    if result.get("error") or result.get("used_pct_5h") is None:
+        cached = read_account_usage_cache(name)
+        return cached if cached else None
+    return result
+
+
+def build_stored_rows(
+    accounts: list[dict], *, refresh: bool = False
+) -> list[AccountRow]:
+    """Convert stored-account dicts into :class:`AccountRow` for the table.
+
+    Pure orchestration: pulls plan/tier (offline), credential freshness
+    (live recompute from ``expiresAt`` on every call), and usage% (cached
+    or re-fetched depending on ``refresh``).
+    """
+    from .._account.creds_sync import account_freshness
+    from .._state.account_store import read_account_plan
+
+    rows: list[AccountRow] = []
+    for acct in accounts:
+        name = acct["name"]
+        plan = read_account_plan(name)
+        fresh = account_freshness(name)
+        usage = usage_for_account(acct, refresh=refresh) or {}
+        rows.append(
+            AccountRow(
+                name=name,
+                email=acct.get("email_address") or "(no email)",
+                plan_label=plan.get("plan_label") or "?",
+                tier=plan.get("rate_limit_tier") or "?",
+                freshness_state=fresh.state,
+                freshness_hours=fresh.hours,
+                used_pct_5h=usage.get("used_pct_5h"),
+                used_pct_7d=usage.get("used_pct_7d"),
+                snapshot_as_of=usage.get("as_of") or usage.get("fetched_at"),
+            )
+        )
+    return rows
+
+
+def build_stored_json(accounts: list[dict], *, refresh: bool = False) -> list[dict]:
+    """Enrich stored-account dicts for ``sac accounts list --json``.
+
+    Each entry carries OFFLINE plan/tier, credential FRESHNESS
+    (``state`` + signed hours), and the per-account usage payload.
+    Timestamps remain ISO-8601 for JSON consumers — only the human
+    renderer reformats.
+    """
+    from .._account.creds_sync import account_freshness
+    from .._state.account_store import read_account_plan
+
+    stored: list[dict] = []
+    for acct in accounts:
+        entry = dict(acct)
+        entry.update(read_account_plan(acct["name"]))
+        fresh = account_freshness(acct["name"])
+        entry["freshness"] = fresh.state
+        entry["freshness_hours"] = fresh.hours
+        entry["usage"] = usage_for_account(acct, refresh=refresh)
+        stored.append(entry)
+    return stored
+
+
+__all__ = [
+    "AccountRow",
+    "build_stored_json",
+    "build_stored_rows",
+    "format_as_of_short",
+    "format_dt_local",
+    "format_snapshot_age",
+    "format_ttl_live",
+    "local_timezone",
+    "render_stored_table",
+    "render_stored_table_to_str",
+    "usage_for_account",
+]

--- a/src/scitex_agent_container/cli_pkg/account_group.py
+++ b/src/scitex_agent_container/cli_pkg/account_group.py
@@ -111,57 +111,39 @@ def account_save(name: str, email: str | None, dry_run: bool, yes: bool) -> None
     default=False,
     help="Emit a JSON array on stdout instead of human prose.",
 )
-def account_list(as_json: bool) -> None:
+@click.option(
+    "--refresh",
+    "--live",
+    "refresh",
+    is_flag=True,
+    default=False,
+    help=(
+        "Force a fresh upstream usage fetch by discarding the per-account "
+        "usage.json cache before rendering. Without this flag the 5-min "
+        "cache is consulted to avoid hammering the API; the As-of column "
+        "always shows the snapshot age so a stale number is obvious."
+    ),
+)
+def account_list(as_json: bool, refresh: bool) -> None:
     """List stored accounts and show the currently active one.
 
     \b
     Example:
       $ sac account list
       $ sac account list --json
+      $ sac account list --refresh    # force upstream usage% refetch
     """
     import json as _json
-    from pathlib import Path as _Path
 
-    from .._account.claude_usage import fetch_usage_for_credentials
     from .._account.credentials import read_credentials_metadata
-    from .._account.creds_sync import account_freshness
-    from .._state.account_store import (
-        _store_path,
-        list_accounts,
-        read_account_plan,
-        read_account_usage_cache,
+    from .._state.account_store import list_accounts
+    from ._account_list_render import (
+        build_stored_json,
+        build_stored_rows,
+        render_stored_table,
     )
     from ._helpers import console
     from .status_cmds import _format_claude_account_block
-
-    def _usage_for_account(acct_meta: dict) -> dict | None:
-        # Live PER-ACCOUNT fetch using the stored snapshot's tokens. The
-        # snapshot lives at
-        # ``~/.scitex/agent-container/accounts/<name>/.credentials.json``
-        # (cascade-resolved via ``_store_path``); the fetch result is
-        # cached next to that file as ``usage.json`` so the same
-        # ``read_account_usage_cache`` reader sees the live value across
-        # invocations. Any failure (missing snapshot, expired token,
-        # network error) returns None → caller renders ``usage: —`` for
-        # that row only; never crashes the whole list.
-        name = acct_meta.get("name")
-        if not name:
-            return None
-        store = _store_path(None, _Path.home())
-        creds_path = store / name / ".credentials.json"
-        if not creds_path.is_file():
-            return read_account_usage_cache(name)
-        # stx-allow: fallback (reason: fetch_usage_for_credentials is documented never-raise, but defence-in-depth so one bad row never crashes `account list`)
-        try:
-            result = fetch_usage_for_credentials(creds_path)
-        except Exception:  # stx-allow: fallback (reason: catch-all safety net — see inline comment for context)
-            return read_account_usage_cache(name)
-        if result.get("error") or result.get("used_pct_5h") is None:
-            # No live data — try the cache reader as a final fallback so
-            # a stale-but-readable cache still shows something.
-            cached = read_account_usage_cache(name)
-            return cached if cached else None
-        return result
 
     accounts = list_accounts()
 
@@ -171,21 +153,14 @@ def account_list(as_json: bool) -> None:
             active = read_credentials_metadata()
         except (OSError, _json.JSONDecodeError):
             active = {}
-        # Enrich each stored account with OFFLINE plan/tier, credential
-        # FRESHNESS (VALID/EXPIRED/ABSENT + signed hours), and a LIVE
-        # per-account usage fetch (cached for 5 min next to the snapshot).
-        stored = []
-        for acct in accounts:
-            entry = dict(acct)
-            entry.update(read_account_plan(acct["name"]))
-            fresh = account_freshness(acct["name"])
-            entry["freshness"] = fresh.state
-            entry["freshness_hours"] = fresh.hours
-            entry["usage"] = _usage_for_account(acct)
-            stored.append(entry)
         click.echo(
             _json.dumps(
-                {"active": active, "stored": stored}, ensure_ascii=False, indent=2
+                {
+                    "active": active,
+                    "stored": build_stored_json(accounts, refresh=refresh),
+                },
+                ensure_ascii=False,
+                indent=2,
             )
         )
         return
@@ -207,33 +182,7 @@ def account_list(as_json: bool) -> None:
             "No accounts stored. Use: scitex-agent-container account save <name>"
         )
         return
-    click.echo("Stored accounts:")
-    for acct in accounts:
-        name = acct["name"]
-        email = acct.get("email_address") or "(no email)"
-        # OFFLINE plan/tier from the snapshot — free, no network.
-        plan = read_account_plan(name)
-        plan_label = plan.get("plan_label") or "?"
-        tier = plan.get("rate_limit_tier") or "?"
-        # OFFLINE credential freshness from the snapshot's expiresAt —
-        # VALID (+Xh) / EXPIRED (-Xh) / ABSENT. The signal that tells the
-        # operator at a glance which stores have rotted and need a
-        # `sac accounts sync-live` (or a `claude /login`).
-        fresh = account_freshness(name).label()
-        # LIVE per-account usage (5-min cache next to the snapshot). On
-        # any failure the helper returns None → "—" for that row only;
-        # the rest of the list keeps rendering.
-        usage = _usage_for_account(acct)
-        usage_str = "—"
-        if usage:
-            pct5 = usage.get("used_pct_5h")
-            pct7 = usage.get("used_pct_7d")
-            as_of = usage.get("as_of") or usage.get("timestamp") or "?"
-            usage_str = f"5h={pct5}% 7d={pct7}% (as of {as_of})"
-        click.echo(
-            f"  {name:20s}  {email:28s}  {plan_label} [{tier}]  "
-            f"{fresh:18s}  usage: {usage_str}"
-        )
+    console.print(render_stored_table(build_stored_rows(accounts, refresh=refresh)))
 
 
 @account.command("delete")

--- a/tests/scitex_agent_container/cli_pkg/test__account_list_render.py
+++ b/tests/scitex_agent_container/cli_pkg/test__account_list_render.py
@@ -75,8 +75,10 @@ def test_local_timezone_no_env_returns_none(env_save_restore):
     # Arrange
     env_save_restore.delete("TZ")
     env_save_restore.delete("SCITEX_AGENT_CONTAINER_TZ")
-    # Act + Assert
-    assert local_timezone() is None
+    # Act
+    tz = local_timezone()
+    # Assert
+    assert tz is None
 
 
 def test_local_timezone_tz_env_resolves(env_save_restore):
@@ -128,11 +130,21 @@ def test_format_dt_local_project_env_wins(env_save_restore):
 
 
 def test_format_dt_local_none_renders_dash():
-    assert format_dt_local(None) == "-"
+    # Arrange — None input.
+    value = None
+    # Act
+    rendered = format_dt_local(value)
+    # Assert
+    assert rendered == "-"
 
 
 def test_format_dt_local_unparseable_renders_dash():
-    assert format_dt_local("not-a-timestamp") == "-"
+    # Arrange — non-ISO string.
+    value = "not-a-timestamp"
+    # Act
+    rendered = format_dt_local(value)
+    # Assert
+    assert rendered == "-"
 
 
 # ---------------------------------------------------------------------------
@@ -141,22 +153,39 @@ def test_format_dt_local_unparseable_renders_dash():
 
 
 def test_format_ttl_live_minute_resolution_positive():
-    # 2.8h = 10080s. 10080 // 3600 = 2h, rem 880s = 14m40s, rounded → 2h15m.
-    assert format_ttl_live(2.8) == "+2h48m"
+    # Arrange — 2.8h = 10080s. 10080 // 3600 = 2h, rem 880s = 14m40s → 2h48m.
+    hours = 2.8
+    # Act
+    rendered = format_ttl_live(hours)
+    # Assert
+    assert rendered == "+2h48m"
 
 
 def test_format_ttl_live_negative():
-    assert format_ttl_live(-138.6) == "-138h36m"
+    # Arrange
+    hours = -138.6
+    # Act
+    rendered = format_ttl_live(hours)
+    # Assert
+    assert rendered == "-138h36m"
 
 
 def test_format_ttl_live_sub_hour():
-    # 0.5h = 30 minutes exactly.
-    assert format_ttl_live(0.5) == "+30m00s"
+    # Arrange — 0.5h = 30 minutes exactly.
+    hours = 0.5
+    # Act
+    rendered = format_ttl_live(hours)
+    # Assert
+    assert rendered == "+30m00s"
 
 
 def test_format_ttl_live_sub_minute():
-    # 1/3600 h = 1 second.
-    assert format_ttl_live(1.0 / 3600.0) == "+1s"
+    # Arrange — 1/3600 h = 1 second.
+    hours = 1.0 / 3600.0
+    # Act
+    rendered = format_ttl_live(hours)
+    # Assert
+    assert rendered == "+1s"
 
 
 def test_format_ttl_live_ticks_under_60s_elapsed():
@@ -177,7 +206,12 @@ def test_format_ttl_live_ticks_under_60s_elapsed():
 
 
 def test_format_ttl_live_none_renders_dash():
-    assert format_ttl_live(None) == "-"
+    # Arrange
+    hours = None
+    # Act
+    rendered = format_ttl_live(hours)
+    # Assert
+    assert rendered == "-"
 
 
 # ---------------------------------------------------------------------------
@@ -186,27 +220,48 @@ def test_format_ttl_live_none_renders_dash():
 
 
 def test_format_snapshot_age_seconds():
+    # Arrange — 30s gap.
     now = datetime(2026, 5, 31, 12, 1, 0, tzinfo=timezone.utc)
-    assert format_snapshot_age("2026-05-31T12:00:30+00:00", now=now) == "30s"
+    # Act
+    rendered = format_snapshot_age("2026-05-31T12:00:30+00:00", now=now)
+    # Assert
+    assert rendered == "30s"
 
 
 def test_format_snapshot_age_minutes():
+    # Arrange — 3-minute gap.
     now = datetime(2026, 5, 31, 12, 14, 0, tzinfo=timezone.utc)
-    assert format_snapshot_age("2026-05-31T12:11:00+00:00", now=now) == "3m"
+    # Act
+    rendered = format_snapshot_age("2026-05-31T12:11:00+00:00", now=now)
+    # Assert
+    assert rendered == "3m"
 
 
 def test_format_snapshot_age_hours():
+    # Arrange — 1.5-hour gap rounds down to "1h".
     now = datetime(2026, 5, 31, 13, 0, 0, tzinfo=timezone.utc)
-    assert format_snapshot_age("2026-05-31T11:30:00+00:00", now=now) == "1h"
+    # Act
+    rendered = format_snapshot_age("2026-05-31T11:30:00+00:00", now=now)
+    # Assert
+    assert rendered == "1h"
 
 
 def test_format_snapshot_age_days():
+    # Arrange — 2-day gap.
     now = datetime(2026, 5, 31, 12, 0, 0, tzinfo=timezone.utc)
-    assert format_snapshot_age("2026-05-29T12:00:00+00:00", now=now) == "2d"
+    # Act
+    rendered = format_snapshot_age("2026-05-29T12:00:00+00:00", now=now)
+    # Assert
+    assert rendered == "2d"
 
 
 def test_format_snapshot_age_unparseable():
-    assert format_snapshot_age("not-a-time") == "?"
+    # Arrange
+    value = "not-a-time"
+    # Act
+    rendered = format_snapshot_age(value)
+    # Assert
+    assert rendered == "?"
 
 
 def test_format_snapshot_age_future_clamps_to_zero():
@@ -241,16 +296,43 @@ def test_format_as_of_short_jst(env_save_restore):
     assert rendered == "Sun 21h"
 
 
-def test_format_as_of_short_not_microsecond_iso(env_save_restore):
-    """The whole reason this column exists: NOT the full ISO timestamp."""
+def test_format_as_of_short_strips_microseconds(env_save_restore):
+    """``format_as_of_short`` removes the microsecond component."""
     # Arrange
     env_save_restore.set("TZ", "Asia/Tokyo")
     # Act
     rendered = format_as_of_short("2026-05-31T12:11:23.756321+00:00")
     # Assert
-    assert "." not in rendered  # no microseconds
-    assert "+" not in rendered  # no offset
-    assert "T" not in rendered  # not ISO
+    assert "." not in rendered
+
+
+def test_format_as_of_short_strips_offset(env_save_restore):
+    """``format_as_of_short`` does not carry the ``+HH:MM`` UTC offset."""
+    # Arrange
+    env_save_restore.set("TZ", "Asia/Tokyo")
+    # Act
+    rendered = format_as_of_short("2026-05-31T12:11:23.756321+00:00")
+    # Assert
+    assert "+" not in rendered
+
+
+def test_format_as_of_short_strips_t_separator(env_save_restore):
+    """``format_as_of_short`` returns a non-ISO short form (no ``T``)."""
+    # Arrange
+    env_save_restore.set("TZ", "Asia/Tokyo")
+    # Act
+    rendered = format_as_of_short("2026-05-31T12:11:23.756321+00:00")
+    # Assert
+    assert "T" not in rendered
+
+
+def test_format_as_of_short_under_8_chars(env_save_restore):
+    """``format_as_of_short`` is bounded to the ``Day HHh`` shape (≤8 chars)."""
+    # Arrange
+    env_save_restore.set("TZ", "Asia/Tokyo")
+    # Act
+    rendered = format_as_of_short("2026-05-31T12:11:23.756321+00:00")
+    # Assert
     assert len(rendered) <= 8
 
 
@@ -277,50 +359,67 @@ def test_render_stored_table_has_column_headers():
         assert col in out, f"missing column header: {col!r}\n---\n{out}"
 
 
-def test_render_stored_table_aligned_columns():
-    """Each row's cells line up under their headers (rich draws box edges)."""
-    # Arrange
-    rows = [
-        AccountRow(
-            name="aa",
-            email="a@example.com",
-            plan_label="Pro",
-            tier="default_claude_pro",
-            freshness_state="VALID",
-            freshness_hours=1.0,
-            used_pct_5h=10.0,
-            used_pct_7d=2.0,
-            snapshot_as_of="2026-05-31T12:00:00+00:00",
-        ),
-        AccountRow(
-            name="bbbb",
-            email="bbbb@example.com",
-            plan_label="Max 20x",
-            tier="default_claude_max_20x",
-            freshness_state="EXPIRED",
-            freshness_hours=-5.0,
-            used_pct_5h=None,
-            used_pct_7d=None,
-            snapshot_as_of=None,
-        ),
-    ]
+_TWO_ROW_TABLE_ROWS = [
+    AccountRow(
+        name="aa",
+        email="a@example.com",
+        plan_label="Pro",
+        tier="default_claude_pro",
+        freshness_state="VALID",
+        freshness_hours=1.0,
+        used_pct_5h=10.0,
+        used_pct_7d=2.0,
+        snapshot_as_of="2026-05-31T12:00:00+00:00",
+    ),
+    AccountRow(
+        name="bbbb",
+        email="bbbb@example.com",
+        plan_label="Max 20x",
+        tier="default_claude_max_20x",
+        freshness_state="EXPIRED",
+        freshness_hours=-5.0,
+        used_pct_5h=None,
+        used_pct_7d=None,
+        snapshot_as_of=None,
+    ),
+]
+
+
+def _two_row_table_cell_lines() -> list[str]:
+    """Render the canonical 2-row rich table and return non-blank cell lines."""
     now = datetime(2026, 5, 31, 12, 14, 0, tzinfo=timezone.utc)
-    # Act
-    out = render_stored_table_to_str(rows, now=now)
-    # Assert — every non-blank rendered line that contains data has the
-    # same number of column-separator characters. The rich table uses
-    # `┃` for the header row and `│` for data rows; both forms are
-    # counted together so a misalignment between header and body fails.
+    out = render_stored_table_to_str(_TWO_ROW_TABLE_ROWS, now=now)
     lines = [ln for ln in out.splitlines() if ln.strip()]
-    cell_lines = [ln for ln in lines if "│" in ln or "┃" in ln]
-    assert len(cell_lines) >= 3  # header + 2 data rows
+    return [ln for ln in lines if "│" in ln or "┃" in ln]
+
+
+def test_render_stored_table_emits_header_plus_two_data_rows():
+    """Rich draws 1 header row + 2 data rows = ≥3 cell-bearing lines."""
+    # Arrange — uses the shared 2-row fixture data above.
+    rows = _TWO_ROW_TABLE_ROWS
+    # Act
+    cell_lines = _two_row_table_cell_lines()
+    # Assert
+    assert len(cell_lines) >= 3, (
+        f"expected ≥3 cell lines for header + 2 rows, got {len(cell_lines)}"
+    )
+    _ = rows  # silence flake; rows is the input to the helper above
+
+
+def test_render_stored_table_columns_are_uniformly_separated():
+    """Each row uses the same separator count (header ``┃`` + data ``│``)."""
+    # Arrange — same 2-row fixture (so a misalignment shows up).
+    rows = _TWO_ROW_TABLE_ROWS
+    # Act
+    cell_lines = _two_row_table_cell_lines()
     sep_counts = {ln.count("│") + ln.count("┃") for ln in cell_lines}
-    assert len(sep_counts) == 1, f"columns mis-aligned: {sep_counts}\n---\n{out}"
+    # Assert — exactly one distinct count means every line aligns.
+    assert len(sep_counts) == 1, f"columns mis-aligned: {sep_counts}"
+    _ = rows  # silence flake; rows is the input to the helper above
 
 
-def test_render_stored_table_as_of_is_short_form(env_save_restore):
-    # Arrange
-    env_save_restore.set("TZ", "Asia/Tokyo")
+def _as_of_short_form_table_out() -> str:
+    """Render a 1-row table whose As-of carries microseconds for short-form tests."""
     rows = [
         AccountRow(
             name="work",
@@ -335,11 +434,27 @@ def test_render_stored_table_as_of_is_short_form(env_save_restore):
         ),
     ]
     now = datetime(2026, 5, 31, 12, 14, 0, tzinfo=timezone.utc)
+    return render_stored_table_to_str(rows, now=now)
+
+
+def test_render_stored_table_as_of_uses_short_day_hour_form(env_save_restore):
+    """As-of cell renders the JST day-of-week + hour (``Sun 21h``)."""
+    # Arrange
+    env_save_restore.set("TZ", "Asia/Tokyo")
     # Act
-    out = render_stored_table_to_str(rows, now=now)
-    # Assert — As-of cell rendered as ``Sun 21h (3m)``; no microsecond ISO.
+    out = _as_of_short_form_table_out()
+    # Assert
     assert "Sun 21h" in out
-    assert "756321" not in out  # no microseconds leaked through
+
+
+def test_render_stored_table_as_of_strips_microseconds(env_save_restore):
+    """The microsecond payload from the snapshot does NOT leak to the table."""
+    # Arrange
+    env_save_restore.set("TZ", "Asia/Tokyo")
+    # Act
+    out = _as_of_short_form_table_out()
+    # Assert
+    assert "756321" not in out
 
 
 def test_render_stored_table_shows_age_next_to_pct():
@@ -398,34 +513,65 @@ def _stage_account_with_expiry_seconds(
     )
 
 
-def test_build_stored_rows_ttl_ticks_between_calls(sandbox_home):
-    """Two calls 60s apart, SAME on-disk state, must show different TTL.
+def _ttl_tick_pair(sandbox_home) -> tuple[list, list]:
+    """Stage one account with ~2h48m runway, read; restage at +60s closer, re-read.
 
     Exercises the bullet-2 contract end-to-end: ``account_freshness`` re-
     reads ``expiresAt`` and subtracts ``time.time()`` on every call;
     paired with the minute-resolution renderer, the result MUST tick.
     """
-    # Arrange — single account with ~2h48m runway.
     _stage_account_with_expiry_seconds(
         sandbox_home, "work", expires_in_s=2 * 3600 + 48 * 60
     )
     accounts = [{"name": "work", "email_address": "w@x"}]
-    # Act — first render.
     rows_t0 = build_stored_rows(accounts)
-    # Wall-clock the second read at +60s by faking the snapshot expiry
-    # 60s closer (equivalent — the renderer reads expiresAt on every call).
     _stage_account_with_expiry_seconds(
         sandbox_home, "work", expires_in_s=2 * 3600 + 47 * 60
     )
     rows_t1 = build_stored_rows(accounts)
-    # Assert — the freshness_hours differs by ~60s (~0.0167h).
+    return rows_t0, rows_t1
+
+
+def test_build_stored_rows_first_call_emits_freshness_hours(sandbox_home):
+    """First call against a fresh credential reports a numeric TTL."""
+    # Arrange — fresh ``$HOME`` (sandbox_home autouse fixture).
+    home = sandbox_home
+    # Act — stage + read the TTL pair, then take the first read.
+    rows_t0, _ = _ttl_tick_pair(home)
+    # Assert
     assert rows_t0[0].freshness_hours is not None
+
+
+def test_build_stored_rows_second_call_emits_freshness_hours(sandbox_home):
+    """Second call after a +60s restage still reports a numeric TTL."""
+    # Arrange — fresh ``$HOME`` (sandbox_home autouse fixture).
+    home = sandbox_home
+    # Act — stage + read the TTL pair, then take the second read.
+    _, rows_t1 = _ttl_tick_pair(home)
+    # Assert
     assert rows_t1[0].freshness_hours is not None
+
+
+def test_build_stored_rows_60s_apart_delta_about_60s(sandbox_home):
+    """Two calls bracketing a 60-second restage yield ~60s of TTL delta."""
+    # Arrange — fresh ``$HOME`` (sandbox_home autouse fixture).
+    home = sandbox_home
+    # Act
+    rows_t0, rows_t1 = _ttl_tick_pair(home)
     delta_s = (rows_t0[0].freshness_hours - rows_t1[0].freshness_hours) * 3600
+    # Assert
     assert 50 < delta_s < 70, f"expected ~60s TTL delta, got {delta_s:.1f}s"
-    # And the rendered TTL string differs (proof the format exposes it).
+
+
+def test_build_stored_rows_60s_apart_rendered_ttl_differs(sandbox_home):
+    """The minute-resolution renderer surfaces the 60s tick as a string change."""
+    # Arrange — fresh ``$HOME`` (sandbox_home autouse fixture).
+    home = sandbox_home
+    # Act
+    rows_t0, rows_t1 = _ttl_tick_pair(home)
     s0 = format_ttl_live(rows_t0[0].freshness_hours)
     s1 = format_ttl_live(rows_t1[0].freshness_hours)
+    # Assert
     assert s0 != s1, f"rendered TTL did not tick: {s0!r} == {s1!r}"
 
 
@@ -454,15 +600,8 @@ def test_cli_list_live_alias_is_accepted(sandbox_home):
     assert result.exit_code == 0, result.output
 
 
-def test_cli_list_refresh_busts_usage_cache(sandbox_home):
-    """``--refresh`` deletes the per-account usage.json before render.
-
-    Real on-disk cache + a callable fake injected via the documented
-    ``opener`` seam of ``fetch_usage_for_credentials`` would require a
-    live OAuth handshake; instead we verify the cache file is gone after
-    a ``--refresh`` invocation, which is the observable contract.
-    """
-    # Arrange — stored account with a stale usage.json cache.
+def _seed_stale_usage_cache(sandbox_home) -> Path:
+    """Stage a stored account with a populated usage.json cache and return its path."""
     save_account("work", {"email_address": "w@example.com"}, home=sandbox_home)
     accts_dir = sandbox_home / ".scitex" / "agent-container" / "accounts" / "work"
     (accts_dir / ".credentials.json").write_text(
@@ -479,7 +618,29 @@ def test_cli_list_refresh_busts_usage_cache(sandbox_home):
             }
         )
     )
+    return cache_file
+
+
+def test_seed_stale_usage_cache_produces_a_file(sandbox_home):
+    """Verifies the shared seed helper actually writes a cache file on disk."""
+    # Arrange — fresh ``$HOME`` (sandbox_home autouse fixture).
+    home = sandbox_home
+    # Act
+    cache_file = _seed_stale_usage_cache(home)
+    # Assert
     assert cache_file.is_file()
+
+
+def test_cli_list_refresh_busts_usage_cache(sandbox_home):
+    """``--refresh`` deletes the per-account usage.json before render.
+
+    Real on-disk cache + a callable fake injected via the documented
+    ``opener`` seam of ``fetch_usage_for_credentials`` would require a
+    live OAuth handshake; instead we verify the cache file is gone after
+    a ``--refresh`` invocation, which is the observable contract.
+    """
+    # Arrange — stored account with a stale usage.json cache.
+    cache_file = _seed_stale_usage_cache(sandbox_home)
     # Act — invoke renderer through the public helper with refresh=True
     # but disable the network call by yanking the access token (no
     # tokens → fetcher errors out → cache reader fallback runs after the
@@ -525,10 +686,8 @@ def test_cli_list_human_renders_table_columns(sandbox_home):
         assert col in result.output, f"missing column {col!r}:\n{result.output}"
 
 
-def test_cli_list_json_still_emits_iso8601(sandbox_home):
-    """JSON path must keep ISO ``fetched_at`` / ``as_of`` for downstream
-    consumers — only the human renderer reformats."""
-    # Arrange
+def _seed_account_with_iso_usage_cache(sandbox_home) -> None:
+    """Stage a stored account with a deterministic ISO usage.json snapshot."""
     save_account("work", {"email_address": "w@example.com"}, home=sandbox_home)
     accts = sandbox_home / ".scitex" / "agent-container" / "accounts" / "work"
     (accts / "usage.json").write_text(
@@ -541,14 +700,38 @@ def test_cli_list_json_still_emits_iso8601(sandbox_home):
             }
         )
     )
+
+
+def test_cli_list_json_does_not_leak_day_of_week(sandbox_home):
+    """``--json`` output must NOT carry the human-renderer's day-of-week."""
+    # Arrange
+    _seed_account_with_iso_usage_cache(sandbox_home)
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(account, ["list", "--json"])
+    # Assert — `Sun 21h` is a human-renderer artifact; never in JSON.
+    assert "Sun" not in result.output
+
+
+def test_cli_list_json_usage_as_of_keeps_iso_t_separator(sandbox_home):
+    """``--json`` carries through the ISO-8601 ``T`` separator on ``as_of``.
+
+    The usage payload's ``as_of`` ISO string must NOT be reformatted —
+    downstream consumers parse it as ISO-8601. We deterministically seed
+    the usage cache so the JSON path always has an ``as_of`` to assert on
+    (no conditional skip).
+    """
+    # Arrange
+    _seed_account_with_iso_usage_cache(sandbox_home)
     runner = CliRunner()
     # Act
     result = runner.invoke(account, ["list", "--json"])
     payload = json.loads(result.output)
-    # Assert — usage.as_of carried through unmodified ISO; no day-of-week.
     usage = payload["stored"][0]["usage"]
-    # The usage payload may be None if fetch fails; here we only verify
-    # the JSON path is structurally unchanged (no `Sun 21h` reformatting).
-    assert "Sun" not in result.output  # the day-of-week never leaks to JSON
-    if usage is not None and usage.get("as_of"):
-        assert "T" in usage["as_of"]  # still ISO-8601
+    # Assert — usage payload present + carries ISO ``T``. If the renderer
+    # ever drops the cache, this assertion fires loudly so we notice.
+    as_of = (usage or {}).get("as_of") or ""
+    assert "T" in as_of, (
+        f"--json must carry through ISO `T` separator on usage.as_of; "
+        f"got {as_of!r} (usage={usage!r})"
+    )

--- a/tests/scitex_agent_container/cli_pkg/test_account_group.py
+++ b/tests/scitex_agent_container/cli_pkg/test_account_group.py
@@ -754,8 +754,12 @@ def test_account_list_human_shows_usage_dash_when_no_cache(sandbox_home):
     runner = CliRunner()
     # Act
     result = runner.invoke(account, ["list"])
-    # Assert — cache-only usage renders the em-dash placeholder.
-    assert "usage: —" in result.output
+    # Assert — the rich table renders ``-`` cells for missing usage% and
+    # As-of (the prior ``usage: —`` was a flat-line format; the new
+    # renderer emits a `rich.table.Table` with one cell per metric).
+    assert "5h%" in result.output and "7d%" in result.output
+    # Confirm the empty-data cells are rendered as `-`.
+    assert " - " in result.output
 
 
 def test_account_list_json_includes_plan_label(sandbox_home):

--- a/tests/scitex_agent_container/cli_pkg/test_account_group.py
+++ b/tests/scitex_agent_container/cli_pkg/test_account_group.py
@@ -746,20 +746,44 @@ def test_account_list_human_shows_offline_plan_label(sandbox_home):
     assert "Max 20x" in result.output
 
 
-def test_account_list_human_shows_usage_dash_when_no_cache(sandbox_home):
-    # Arrange — snapshot present, but no per-account usage.json cache.
+def _invoke_account_list_with_no_usage_cache(sandbox_home) -> str:
+    """Stage a stored account with NO usage.json cache and run ``sac account list``."""
     _write_plan_snapshot(
         sandbox_home, "work", subscription="pro", tier="default_claude_pro"
     )
     runner = CliRunner()
+    return runner.invoke(account, ["list"]).output
+
+
+def test_account_list_human_shows_5h_pct_column_when_no_cache(sandbox_home):
+    """Rich table emits the ``5h%`` column header even when usage is absent."""
+    # Arrange — fresh ``$HOME`` (sandbox_home autouse fixture).
+    home = sandbox_home
     # Act
-    result = runner.invoke(account, ["list"])
-    # Assert — the rich table renders ``-`` cells for missing usage% and
-    # As-of (the prior ``usage: —`` was a flat-line format; the new
-    # renderer emits a `rich.table.Table` with one cell per metric).
-    assert "5h%" in result.output and "7d%" in result.output
-    # Confirm the empty-data cells are rendered as `-`.
-    assert " - " in result.output
+    output = _invoke_account_list_with_no_usage_cache(home)
+    # Assert
+    assert "5h%" in output
+
+
+def test_account_list_human_shows_7d_pct_column_when_no_cache(sandbox_home):
+    """Rich table emits the ``7d%`` column header even when usage is absent."""
+    # Arrange — fresh ``$HOME`` (sandbox_home autouse fixture).
+    home = sandbox_home
+    # Act
+    output = _invoke_account_list_with_no_usage_cache(home)
+    # Assert
+    assert "7d%" in output
+
+
+def test_account_list_human_shows_dash_cells_when_no_cache(sandbox_home):
+    """Empty-data cells render as ``-`` (rich table) when usage is absent."""
+    # Arrange — fresh ``$HOME`` (sandbox_home autouse fixture).
+    home = sandbox_home
+    # Act
+    output = _invoke_account_list_with_no_usage_cache(home)
+    # Assert — the prior ``usage: —`` was a flat-line format; the new
+    # renderer emits one cell per metric, with ``-`` for missing values.
+    assert " - " in output
 
 
 def test_account_list_json_includes_plan_label(sandbox_home):

--- a/tests/scitex_agent_container/cli_pkg/test_account_list_render.py
+++ b/tests/scitex_agent_container/cli_pkg/test_account_list_render.py
@@ -1,0 +1,554 @@
+"""Tests for the ``sac accounts list`` Stored-accounts renderer.
+
+PA-306 no-mocks: every test exercises real production helpers. The
+``env_save_restore`` fixture mutates real ``os.environ`` keys and
+auto-reverts (parallel pattern to ``sandbox_home`` in
+``test_account_group.py``); no monkeypatching of stdlib internals.
+
+The renderer module is the bullet-1/2/3 fix surface:
+
+* bullet 1 — operator timezone (``SCITEX_AGENT_CONTAINER_TZ`` > ``TZ`` >
+  system local).
+* bullet 2 — credential TTL ticks under ``watch -n1`` (minute-resolution
+  format) and the per-account usage snapshot age is rendered next to
+  the % so a stale number is obvious.
+* bullet 3 — ``rich.table.Table`` with aligned columns, short ``As-of``.
+
+The ``--refresh`` flag is asserted via the CLI surface (click invocation)
+with a real fake fetcher injected through a temporary monkey of the
+``fetch_usage_for_credentials`` symbol the renderer imports at call-time
+(the import lives inside ``usage_for_account``, so a single attribute
+replace on the ``_account.claude_usage`` module is the honest seam).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from scitex_agent_container._state.account_store import save_account
+from scitex_agent_container.cli_pkg._account_list_render import (
+    AccountRow,
+    build_stored_rows,
+    format_as_of_short,
+    format_dt_local,
+    format_snapshot_age,
+    format_ttl_live,
+    local_timezone,
+    render_stored_table_to_str,
+    usage_for_account,
+)
+from scitex_agent_container.cli_pkg.account_group import account
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def sandbox_home(tmp_path, env_save_restore):
+    """Redirect ``$HOME`` so ``Path.home()`` lands inside ``tmp_path``.
+
+    Same shape as ``test_account_group.py::sandbox_home`` so the
+    account-store cascade stays in the test's tmpdir. Also clears any
+    TZ env that pytest may have inherited from the parent process so
+    each test starts from a known precedence baseline.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    env_save_restore.set("HOME", str(home))
+    env_save_restore.delete("TZ")
+    env_save_restore.delete("SCITEX_AGENT_CONTAINER_TZ")
+    return home
+
+
+# ---------------------------------------------------------------------------
+# Bullet 1 — timezone precedence
+# ---------------------------------------------------------------------------
+
+
+def test_local_timezone_no_env_returns_none(env_save_restore):
+    # Arrange
+    env_save_restore.delete("TZ")
+    env_save_restore.delete("SCITEX_AGENT_CONTAINER_TZ")
+    # Act + Assert
+    assert local_timezone() is None
+
+
+def test_local_timezone_tz_env_resolves(env_save_restore):
+    # Arrange
+    env_save_restore.set("TZ", "Asia/Tokyo")
+    # Act
+    tz = local_timezone()
+    # Assert
+    assert tz is not None and "Tokyo" in str(tz)
+
+
+def test_local_timezone_project_env_wins_over_tz(env_save_restore):
+    # Arrange
+    env_save_restore.set("TZ", "America/New_York")
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_TZ", "Asia/Tokyo")
+    # Act
+    tz = local_timezone()
+    # Assert — project-specific override wins
+    assert "Tokyo" in str(tz)
+
+
+def test_local_timezone_bad_value_falls_through(env_save_restore):
+    # Arrange — typo in project env, real TZ valid → real TZ wins
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_TZ", "Not/A/Real/Zone")
+    env_save_restore.set("TZ", "Asia/Tokyo")
+    # Act
+    tz = local_timezone()
+    # Assert
+    assert tz is not None and "Tokyo" in str(tz)
+
+
+def test_format_dt_local_jst_offset(env_save_restore):
+    # Arrange — fixed UTC instant; assert it renders +09:00.
+    env_save_restore.set("TZ", "Asia/Tokyo")
+    # Act
+    rendered = format_dt_local("2026-05-31T12:11:23+00:00")
+    # Assert — 12:11 UTC = 21:11 JST.
+    assert "21:11:23" in rendered and "+09:00" in rendered
+
+
+def test_format_dt_local_project_env_wins(env_save_restore):
+    # Arrange
+    env_save_restore.set("TZ", "America/New_York")
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_TZ", "Asia/Tokyo")
+    # Act
+    rendered = format_dt_local("2026-05-31T12:11:23+00:00")
+    # Assert — JST not EST.
+    assert "+09:00" in rendered and "-04:00" not in rendered
+
+
+def test_format_dt_local_none_renders_dash():
+    assert format_dt_local(None) == "-"
+
+
+def test_format_dt_local_unparseable_renders_dash():
+    assert format_dt_local("not-a-timestamp") == "-"
+
+
+# ---------------------------------------------------------------------------
+# Bullet 2a — credential TTL must tick under watch -n1
+# ---------------------------------------------------------------------------
+
+
+def test_format_ttl_live_minute_resolution_positive():
+    # 2.8h = 10080s. 10080 // 3600 = 2h, rem 880s = 14m40s, rounded → 2h15m.
+    assert format_ttl_live(2.8) == "+2h48m"
+
+
+def test_format_ttl_live_negative():
+    assert format_ttl_live(-138.6) == "-138h36m"
+
+
+def test_format_ttl_live_sub_hour():
+    # 0.5h = 30 minutes exactly.
+    assert format_ttl_live(0.5) == "+30m00s"
+
+
+def test_format_ttl_live_sub_minute():
+    # 1/3600 h = 1 second.
+    assert format_ttl_live(1.0 / 3600.0) == "+1s"
+
+
+def test_format_ttl_live_ticks_under_60s_elapsed():
+    """Two calls 60s apart on the SAME cached snapshot must differ.
+
+    This is the bullet-2 spec: TTL has to tick down when ``watch -n1``
+    refreshes the renderer between minutes. The prior ``+2.8h`` format
+    collapsed the change; the new ``+2h48m`` format exposes it.
+    """
+    # Arrange — t0 = 2h48m remaining, t1 = 60s later → 2h47m remaining.
+    hours_t0 = (2 * 3600 + 48 * 60) / 3600.0
+    hours_t1 = hours_t0 - 60 / 3600.0
+    # Act
+    s0 = format_ttl_live(hours_t0)
+    s1 = format_ttl_live(hours_t1)
+    # Assert
+    assert s0 != s1, f"60-second tick must change the rendered TTL: {s0} vs {s1}"
+
+
+def test_format_ttl_live_none_renders_dash():
+    assert format_ttl_live(None) == "-"
+
+
+# ---------------------------------------------------------------------------
+# Bullet 2b — snapshot age column makes stale data obvious
+# ---------------------------------------------------------------------------
+
+
+def test_format_snapshot_age_seconds():
+    now = datetime(2026, 5, 31, 12, 1, 0, tzinfo=timezone.utc)
+    assert format_snapshot_age("2026-05-31T12:00:30+00:00", now=now) == "30s"
+
+
+def test_format_snapshot_age_minutes():
+    now = datetime(2026, 5, 31, 12, 14, 0, tzinfo=timezone.utc)
+    assert format_snapshot_age("2026-05-31T12:11:00+00:00", now=now) == "3m"
+
+
+def test_format_snapshot_age_hours():
+    now = datetime(2026, 5, 31, 13, 0, 0, tzinfo=timezone.utc)
+    assert format_snapshot_age("2026-05-31T11:30:00+00:00", now=now) == "1h"
+
+
+def test_format_snapshot_age_days():
+    now = datetime(2026, 5, 31, 12, 0, 0, tzinfo=timezone.utc)
+    assert format_snapshot_age("2026-05-29T12:00:00+00:00", now=now) == "2d"
+
+
+def test_format_snapshot_age_unparseable():
+    assert format_snapshot_age("not-a-time") == "?"
+
+
+def test_format_snapshot_age_future_clamps_to_zero():
+    # Arrange — snapshot ts is AFTER now (clock skew); never go negative.
+    now = datetime(2026, 5, 31, 12, 0, 0, tzinfo=timezone.utc)
+    # Act
+    rendered = format_snapshot_age("2026-05-31T12:00:30+00:00", now=now)
+    # Assert
+    assert rendered == "0s"
+
+
+# ---------------------------------------------------------------------------
+# Bullet 3 — short As-of and table shape
+# ---------------------------------------------------------------------------
+
+
+def test_format_as_of_short_day_hour(env_save_restore):
+    # Arrange
+    env_save_restore.set("TZ", "UTC")
+    # Act — Sunday 2026-05-31, 21:00 UTC.
+    rendered = format_as_of_short("2026-05-31T21:00:00+00:00")
+    # Assert — `Sun 21h` shape.
+    assert rendered == "Sun 21h"
+
+
+def test_format_as_of_short_jst(env_save_restore):
+    # Arrange — 12:11 UTC = 21:11 JST → "Sun 21h".
+    env_save_restore.set("TZ", "Asia/Tokyo")
+    # Act
+    rendered = format_as_of_short("2026-05-31T12:11:00+00:00")
+    # Assert
+    assert rendered == "Sun 21h"
+
+
+def test_format_as_of_short_not_microsecond_iso(env_save_restore):
+    """The whole reason this column exists: NOT the full ISO timestamp."""
+    # Arrange
+    env_save_restore.set("TZ", "Asia/Tokyo")
+    # Act
+    rendered = format_as_of_short("2026-05-31T12:11:23.756321+00:00")
+    # Assert
+    assert "." not in rendered  # no microseconds
+    assert "+" not in rendered  # no offset
+    assert "T" not in rendered  # not ISO
+    assert len(rendered) <= 8
+
+
+def test_render_stored_table_has_column_headers():
+    # Arrange — one row.
+    rows = [
+        AccountRow(
+            name="work",
+            email="w@example.com",
+            plan_label="Max 20x",
+            tier="default_claude_max_20x",
+            freshness_state="VALID",
+            freshness_hours=2.8,
+            used_pct_5h=42.0,
+            used_pct_7d=15.0,
+            snapshot_as_of="2026-05-31T12:11:00+00:00",
+        ),
+    ]
+    now = datetime(2026, 5, 31, 12, 14, 0, tzinfo=timezone.utc)
+    # Act
+    out = render_stored_table_to_str(rows, now=now)
+    # Assert — every column header is present.
+    for col in ("ID", "Email", "Plan", "Status(+TTL)", "5h%", "7d%", "As-of"):
+        assert col in out, f"missing column header: {col!r}\n---\n{out}"
+
+
+def test_render_stored_table_aligned_columns():
+    """Each row's cells line up under their headers (rich draws box edges)."""
+    # Arrange
+    rows = [
+        AccountRow(
+            name="aa",
+            email="a@example.com",
+            plan_label="Pro",
+            tier="default_claude_pro",
+            freshness_state="VALID",
+            freshness_hours=1.0,
+            used_pct_5h=10.0,
+            used_pct_7d=2.0,
+            snapshot_as_of="2026-05-31T12:00:00+00:00",
+        ),
+        AccountRow(
+            name="bbbb",
+            email="bbbb@example.com",
+            plan_label="Max 20x",
+            tier="default_claude_max_20x",
+            freshness_state="EXPIRED",
+            freshness_hours=-5.0,
+            used_pct_5h=None,
+            used_pct_7d=None,
+            snapshot_as_of=None,
+        ),
+    ]
+    now = datetime(2026, 5, 31, 12, 14, 0, tzinfo=timezone.utc)
+    # Act
+    out = render_stored_table_to_str(rows, now=now)
+    # Assert — every non-blank rendered line that contains data has the
+    # same number of column-separator characters. The rich table uses
+    # `┃` for the header row and `│` for data rows; both forms are
+    # counted together so a misalignment between header and body fails.
+    lines = [ln for ln in out.splitlines() if ln.strip()]
+    cell_lines = [ln for ln in lines if "│" in ln or "┃" in ln]
+    assert len(cell_lines) >= 3  # header + 2 data rows
+    sep_counts = {ln.count("│") + ln.count("┃") for ln in cell_lines}
+    assert len(sep_counts) == 1, f"columns mis-aligned: {sep_counts}\n---\n{out}"
+
+
+def test_render_stored_table_as_of_is_short_form(env_save_restore):
+    # Arrange
+    env_save_restore.set("TZ", "Asia/Tokyo")
+    rows = [
+        AccountRow(
+            name="work",
+            email="w@example.com",
+            plan_label="Pro",
+            tier="default_claude_pro",
+            freshness_state="VALID",
+            freshness_hours=2.8,
+            used_pct_5h=42.0,
+            used_pct_7d=15.0,
+            snapshot_as_of="2026-05-31T12:11:23.756321+00:00",
+        ),
+    ]
+    now = datetime(2026, 5, 31, 12, 14, 0, tzinfo=timezone.utc)
+    # Act
+    out = render_stored_table_to_str(rows, now=now)
+    # Assert — As-of cell rendered as ``Sun 21h (3m)``; no microsecond ISO.
+    assert "Sun 21h" in out
+    assert "756321" not in out  # no microseconds leaked through
+
+
+def test_render_stored_table_shows_age_next_to_pct():
+    """The bullet-2 contract: snapshot age MUST appear next to the %."""
+    # Arrange
+    rows = [
+        AccountRow(
+            name="work",
+            email="w@example.com",
+            plan_label="Pro",
+            tier="default_claude_pro",
+            freshness_state="VALID",
+            freshness_hours=2.8,
+            used_pct_5h=42.0,
+            used_pct_7d=15.0,
+            snapshot_as_of="2026-05-31T12:11:00+00:00",
+        ),
+    ]
+    now = datetime(2026, 5, 31, 12, 14, 0, tzinfo=timezone.utc)
+    # Act
+    out = render_stored_table_to_str(rows, now=now)
+    # Assert — `(3m)` appears in the As-of column.
+    assert "(3m)" in out
+
+
+# ---------------------------------------------------------------------------
+# Bullet 2c — TTL liveness across two real ``build_stored_rows`` calls
+# ---------------------------------------------------------------------------
+
+
+def _stage_account_with_expiry_seconds(
+    home: Path, name: str, *, expires_in_s: int
+) -> None:
+    """Write a real account snapshot with a forward-looking ``expiresAt``.
+
+    expiresAt is stored as unix-ms by claude-code; the freshness reader
+    accepts both seconds and ms (treats values > 1e12 as ms). We write
+    ms to match the production shape.
+    """
+    import time
+
+    save_account(name, {"email_address": f"{name}@x"}, home=home)
+    accts_dir = home / ".scitex" / "agent-container" / "accounts" / name
+    expires_at_ms = int((time.time() + expires_in_s) * 1000)
+    (accts_dir / ".credentials.json").write_text(
+        json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "sk-ant-SECRET",
+                    "expiresAt": expires_at_ms,
+                    "subscriptionType": "max",
+                    "rateLimitTier": "default_claude_max_5x",
+                }
+            }
+        )
+    )
+
+
+def test_build_stored_rows_ttl_ticks_between_calls(sandbox_home):
+    """Two calls 60s apart, SAME on-disk state, must show different TTL.
+
+    Exercises the bullet-2 contract end-to-end: ``account_freshness`` re-
+    reads ``expiresAt`` and subtracts ``time.time()`` on every call;
+    paired with the minute-resolution renderer, the result MUST tick.
+    """
+    # Arrange — single account with ~2h48m runway.
+    _stage_account_with_expiry_seconds(
+        sandbox_home, "work", expires_in_s=2 * 3600 + 48 * 60
+    )
+    accounts = [{"name": "work", "email_address": "w@x"}]
+    # Act — first render.
+    rows_t0 = build_stored_rows(accounts)
+    # Wall-clock the second read at +60s by faking the snapshot expiry
+    # 60s closer (equivalent — the renderer reads expiresAt on every call).
+    _stage_account_with_expiry_seconds(
+        sandbox_home, "work", expires_in_s=2 * 3600 + 47 * 60
+    )
+    rows_t1 = build_stored_rows(accounts)
+    # Assert — the freshness_hours differs by ~60s (~0.0167h).
+    assert rows_t0[0].freshness_hours is not None
+    assert rows_t1[0].freshness_hours is not None
+    delta_s = (rows_t0[0].freshness_hours - rows_t1[0].freshness_hours) * 3600
+    assert 50 < delta_s < 70, f"expected ~60s TTL delta, got {delta_s:.1f}s"
+    # And the rendered TTL string differs (proof the format exposes it).
+    s0 = format_ttl_live(rows_t0[0].freshness_hours)
+    s1 = format_ttl_live(rows_t1[0].freshness_hours)
+    assert s0 != s1, f"rendered TTL did not tick: {s0!r} == {s1!r}"
+
+
+# ---------------------------------------------------------------------------
+# CLI surface — --refresh flag wired through to the renderer
+# ---------------------------------------------------------------------------
+
+
+def test_cli_list_refresh_flag_is_accepted(sandbox_home):
+    # Arrange — single stored account.
+    save_account("work", {"email_address": "w@example.com"}, home=sandbox_home)
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(account, ["list", "--refresh"])
+    # Assert
+    assert result.exit_code == 0, result.output
+
+
+def test_cli_list_live_alias_is_accepted(sandbox_home):
+    # Arrange
+    save_account("work", {"email_address": "w@example.com"}, home=sandbox_home)
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(account, ["list", "--live"])
+    # Assert
+    assert result.exit_code == 0, result.output
+
+
+def test_cli_list_refresh_busts_usage_cache(sandbox_home):
+    """``--refresh`` deletes the per-account usage.json before render.
+
+    Real on-disk cache + a callable fake injected via the documented
+    ``opener`` seam of ``fetch_usage_for_credentials`` would require a
+    live OAuth handshake; instead we verify the cache file is gone after
+    a ``--refresh`` invocation, which is the observable contract.
+    """
+    # Arrange — stored account with a stale usage.json cache.
+    save_account("work", {"email_address": "w@example.com"}, home=sandbox_home)
+    accts_dir = sandbox_home / ".scitex" / "agent-container" / "accounts" / "work"
+    (accts_dir / ".credentials.json").write_text(
+        json.dumps({"claudeAiOauth": {"subscriptionType": "pro"}})
+    )
+    cache_file = accts_dir / "usage.json"
+    cache_file.write_text(
+        json.dumps(
+            {
+                "used_pct_5h": 99.0,
+                "used_pct_7d": 99.0,
+                "as_of": "2026-05-31T00:00:00+00:00",
+                "fetched_at": "2026-05-31T00:00:00+00:00",
+            }
+        )
+    )
+    assert cache_file.is_file()
+    # Act — invoke renderer through the public helper with refresh=True
+    # but disable the network call by yanking the access token (no
+    # tokens → fetcher errors out → cache reader fallback runs after the
+    # cache was already deleted).
+    _ = usage_for_account({"name": "work"}, refresh=True)
+    # Assert — the cache file was removed by the refresh path.
+    assert not cache_file.exists(), "--refresh must bust the on-disk cache"
+
+
+# ---------------------------------------------------------------------------
+# CLI surface — table rendering for the full list command
+# ---------------------------------------------------------------------------
+
+
+def _seed_full_account(home: Path, name: str, *, email: str) -> None:
+    """Write a stored account with a credential snapshot + plan fields."""
+    import time
+
+    save_account(name, {"email_address": email}, home=home)
+    accts = home / ".scitex" / "agent-container" / "accounts" / name
+    (accts / ".credentials.json").write_text(
+        json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "sk-ant-SECRET",
+                    "expiresAt": int((time.time() + 3 * 3600) * 1000),
+                    "subscriptionType": "max",
+                    "rateLimitTier": "default_claude_max_5x",
+                }
+            }
+        )
+    )
+
+
+def test_cli_list_human_renders_table_columns(sandbox_home):
+    # Arrange
+    _seed_full_account(sandbox_home, "work", email="w@example.com")
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(account, ["list"])
+    # Assert — column headers from the rich table.
+    for col in ("ID", "Email", "Plan", "Status(+TTL)", "5h%", "7d%", "As-of"):
+        assert col in result.output, f"missing column {col!r}:\n{result.output}"
+
+
+def test_cli_list_json_still_emits_iso8601(sandbox_home):
+    """JSON path must keep ISO ``fetched_at`` / ``as_of`` for downstream
+    consumers — only the human renderer reformats."""
+    # Arrange
+    save_account("work", {"email_address": "w@example.com"}, home=sandbox_home)
+    accts = sandbox_home / ".scitex" / "agent-container" / "accounts" / "work"
+    (accts / "usage.json").write_text(
+        json.dumps(
+            {
+                "used_pct_5h": 42.0,
+                "used_pct_7d": 15.0,
+                "fetched_at": "2026-05-31T12:11:23.756321+00:00",
+                "as_of": "2026-05-31T12:11:23.756321+00:00",
+            }
+        )
+    )
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(account, ["list", "--json"])
+    payload = json.loads(result.output)
+    # Assert — usage.as_of carried through unmodified ISO; no day-of-week.
+    usage = payload["stored"][0]["usage"]
+    # The usage payload may be None if fetch fails; here we only verify
+    # the JSON path is structurally unchanged (no `Sun 21h` reformatting).
+    assert "Sun" not in result.output  # the day-of-week never leaks to JSON
+    if usage is not None and usage.get("as_of"):
+        assert "T" in usage["as_of"]  # still ISO-8601


### PR DESCRIPTION
## Summary

Three operator-reported regressions in the human renderer of `sac accounts list`, all fixed surgically without touching the JSON output shape.

- **TZ**: renderer was emitting UTC ISO with microseconds. Now renders in operator-local timezone with precedence `SCITEX_AGENT_CONTAINER_TZ` > `TZ` > system local (`datetime.astimezone()` no-arg). Project-specific env wins so a host-wide `TZ` never overrides an explicit per-tool preference.
- **Live TTL**: `account_freshness` already recomputed `expiresAt` on every call, but the display format `+2.8h` rounded sub-hour ticks to the same string so `watch -n1` showed no movement. Reformatted as `+2h48m` / `-138h36m` / `+45s` — a 60-second tick is now visible. Usage% (5h/7d) still uses the 5-min per-account cache to avoid hammering the upstream API; the new **As-of column shows the snapshot age** (`Sun 21h (3m)`) so a stale number is obvious. New `--refresh` / `--live` flag busts the on-disk `usage.json` cache before render.
- **Readability**: printf-style line-per-account replaced with `rich.table.Table` aligned across `ID | Email | Plan | Status(+TTL) | 5h% | 7d% | As-of`. As-of column is short day+hour form (`Sun 21h`), not microsecond ISO.

JSON path (`--json`) is unchanged — still emits ISO-8601 `as_of` / `fetched_at` for downstream consumers. Only the human renderer reformats at display time.

## Structure

Renderer extracted into `src/scitex_agent_container/cli_pkg/_account_list_render.py` (same pattern as `_account_status.py` / `_account_refresh.py`) so `account_group.py` stays under the per-file line cap and the renderer is unit-testable without `CliRunner`. Pure functions take a `now=` injection seam where applicable; TTL liveness is asserted end-to-end by writing two real snapshots 60s apart and confirming the rendered TTL string differs.

## Test plan

- [x] `local_timezone()` returns `None` with no env, the resolved zone with `TZ` set, and `SCITEX_AGENT_CONTAINER_TZ` wins over `TZ`.
- [x] Bad `SCITEX_AGENT_CONTAINER_TZ` value falls through to `TZ`.
- [x] `format_dt_local()` renders the same UTC instant with the correct `+09:00` offset under JST.
- [x] `format_ttl_live()` exposes a 60-second tick (two values differing by 60s render to different strings).
- [x] `format_snapshot_age()` produces `30s` / `3m` / `1h` / `2d` and clamps future timestamps to `0s`.
- [x] `format_as_of_short()` emits `Sun 21h` (no microseconds, no offset, no `T`).
- [x] `render_stored_table()` includes every expected column header and aligns separators across header + data rows.
- [x] As-of cell renders the short form (no microseconds) and includes the age suffix `(3m)`.
- [x] `build_stored_rows()` produces different `freshness_hours` for two calls 60s apart on the same on-disk state — and the rendered TTL string differs accordingly.
- [x] `sac account list --refresh` / `--live` exit 0 and delete the per-account `usage.json` cache before rendering.
- [x] Human path renders the new table columns (`ID`, `Email`, `Plan`, `Status(+TTL)`, `5h%`, `7d%`, `As-of`); empty-data cells render as `-`.
- [x] JSON path (`--json`) unchanged: `as_of` stays ISO-8601, no day-of-week tokens leak through.
- [x] `tests/scitex_agent_container/cli_pkg/test_account_list_render.py` — 33 tests, all green.
- [x] `tests/scitex_agent_container/cli_pkg/test_account_group.py` — 55 tests, all green (one assertion updated to reflect the new table cells).
- [x] Adjacent suites (`test_account_group_{sync_live,status,refresh,refresh_skip_active}`, `_state/test_account_store{,_plan_usage}`) — 66 tests, all green.