### PR TITLE
fix(channel): suppress empty-content delivery acks at the sender

### DIFF
--- a/src/scitex_agent_container/_mcp/_channel_ack_filter.py
+++ b/src/scitex_agent_container/_mcp/_channel_ack_filter.py
@@ -1,0 +1,76 @@
+"""Sender-side noise filter for contentless delivery acks.
+
+The sac channel adapter emits two-stage receipts: stage 1 is the publish
+response's ``delivered_subscriber_count``; stage 2 is an automatic
+``a2a_ack`` posted back to the sender on injection. The stage-2 ack
+carries an empty body and ``metadata.ack=True``.
+
+A receive-side loop-guard already exists (``channel._should_auto_ack``
+refuses to ack an ack), but the operator's stronger contract is to drop
+empty-content acks at the **sender** *before* they leave the outbound
+queue:
+
+* sender-side filtering avoids the symmetric "did we send?" / "did they
+  receive?" doubt that receiver-side filtering would create — the wire
+  carries only messages with semantic content;
+* it short-circuits the loop one hop earlier, before the network packet
+  is ever built or sent.
+
+The marker convention matches the rest of the channel code:
+``params.metadata.ack`` truthy AND ``params.message.parts[0].text``
+empty/whitespace. An ack carrying actual content (non-empty text) is
+NOT a contentless delivery confirmation — it is a normal message and
+must pass through untouched. An empty-content message WITHOUT the
+``ack`` marker is also untouched (the empty payload is intentional —
+e.g. a wake ping or an external protocol). Only the join of both
+conditions is suppressed.
+
+This module is intentionally tiny (one pure predicate) so both
+``_mcp.channel`` (auto-ack path) and ``_mcp._channel_tools`` (the
+explicit ``a2a_ack`` tool) can import it without a circular dependency
+or growing either of those modules past their size budget.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = ["envelope_is_contentless_ack"]
+
+
+def envelope_is_contentless_ack(envelope: dict[str, Any]) -> bool:
+    """Return True iff ``envelope`` is an empty-content delivery ack.
+
+    ``envelope`` is the JSON-RPC ``message/send`` (or ``SendMessage``)
+    body — ``{"jsonrpc": ..., "method": ..., "params": {"message": ...,
+    "metadata": ...}}``. The check is structural (looks at
+    ``params.metadata.ack`` and ``params.message.parts[0].text``); any
+    structurally-malformed envelope returns False (caller decides what
+    to do — this helper is only for the empty-ack case).
+
+    Examples (all from the live ``a2a_ack`` / ``_post_auto_ack`` paths):
+
+    * ``metadata.ack=True`` + ``parts[0].text=""``           → True (drop)
+    * ``metadata.ack=True`` + ``parts[0].text="   "``        → True (drop)
+    * ``metadata.ack=True`` + ``parts=[]``                   → True (drop)
+    * ``metadata.ack=True`` + ``parts[0].text="got it"``     → False (keep)
+    * ``metadata.ack=False`` (or absent) + empty text        → False (keep)
+    """
+    params = envelope.get("params") if isinstance(envelope, dict) else None
+    if not isinstance(params, dict):
+        return False
+    metadata = params.get("metadata")
+    if not isinstance(metadata, dict) or not metadata.get("ack"):
+        return False
+    message = params.get("message")
+    if not isinstance(message, dict):
+        return False
+    parts = message.get("parts")
+    if not isinstance(parts, list) or not parts:
+        # No parts at all is morally an empty body — drop alongside "".
+        return True
+    first = parts[0]
+    text = first.get("text") if isinstance(first, dict) else None
+    if not isinstance(text, str):
+        return False
+    return text.strip() == ""

--- a/src/scitex_agent_container/_mcp/_channel_auto_ack.py
+++ b/src/scitex_agent_container/_mcp/_channel_auto_ack.py
@@ -1,0 +1,224 @@
+"""sac channel adapter — auto-ack subsystem.
+
+Extracted from :mod:`scitex_agent_container._mcp.channel` to keep that
+module under the line-size budget. Hosts the stage-2 read-receipt
+machinery the receive-side adapter triggers after a successful
+inbox-event injection:
+
+* :func:`_auto_ack_enabled` — env-gated master switch
+  (``SAC_CHANNEL_AUTO_ACK``).
+* :func:`_should_auto_ack` — per-event loop-guard predicate (never ack an
+  ack, never ack an event with no identifiable sender).
+* :func:`_auto_ack_rate_limits` / :func:`_auto_ack_rate_allow` and the
+  ``_auto_ack_window`` / ``_auto_ack_tripped`` state — belt-and-suspenders
+  sliding-window rate cap so any regression in loop-guarding self-
+  terminates after the budget is exhausted.
+* :func:`_post_auto_ack` — the outbound POST itself. Honors the operator's
+  sender-side empty-ack noise filter (drops contentless acks BEFORE they
+  leave the outbound queue — see :mod:`._channel_ack_filter`).
+
+``channel.py`` re-exports every name here for historical import paths
+(``from scitex_agent_container._mcp.channel import _post_auto_ack``).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from collections import deque
+from typing import Any
+
+from .._env import getenv as _sac_env
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "_AUTO_ACK_RATE_MAX_DEFAULT",
+    "_AUTO_ACK_RATE_WINDOW_DEFAULT",
+    "_auto_ack_enabled",
+    "_auto_ack_rate_allow",
+    "_auto_ack_rate_limits",
+    "_auto_ack_tripped",
+    "_auto_ack_window",
+    "_post_auto_ack",
+    "_should_auto_ack",
+]
+
+
+def _auto_ack_enabled() -> bool:
+    """Whether the receive-side adapter emits an automatic ``a2a_ack`` the
+    moment it injects a received bus event into the session.
+
+    Two-stage receipt, infra-automatic: the receiving agent calls nothing —
+    the channel adapter does. Stage 1 ("delivered") is the send response's
+    ``delivered_subscriber_count``; stage 2 ("read") is this auto-ack,
+    emitted on injection. Default ON; set ``SAC_CHANNEL_AUTO_ACK`` to one of
+    ``0/false/no/off`` (case-insensitive) to disable.
+    """
+    raw = os.environ.get("SAC_CHANNEL_AUTO_ACK")
+    if raw is None:
+        return True
+    return raw.strip().lower() not in ("0", "false", "no", "off")
+
+
+def _should_auto_ack(event: dict[str, Any]) -> bool:
+    """Loop-guard for the auto-ack side-effect.
+
+    An auto-ack is itself a message that lands in the sender's inbox and is
+    injected by *their* adapter — which would auto-ack back, ad infinitum.
+    Break the cycle:
+
+    - never auto-ack an event that is itself an ack (truthy ``ack`` flag —
+      the same metadata flag the ``a2a_ack`` tool stamps), and
+    - never auto-ack an event with no identifiable original sender
+      (``from_agent`` missing/empty): there is nowhere to send the receipt.
+    """
+    if not event.get("from_agent"):
+        return False
+    if event.get("ack"):
+        return False
+    return True
+
+
+# --- Auto-ack rate limiter (belt-and-suspenders loop breaker) -------------
+# Even with the ack-flag loop-guard (``_should_auto_ack``), a future
+# regression in flag propagation could restart an ack-on-ack cycle. This
+# sliding-window cap ensures any such loop self-terminates: once a sender
+# exceeds the budget within the window we stop auto-acking it and log
+# loudly (fail-loud, never a silent drop).
+_AUTO_ACK_RATE_MAX_DEFAULT = 20
+_AUTO_ACK_RATE_WINDOW_DEFAULT = 60.0
+# Per-sender sliding window of auto-ack emission timestamps.
+_auto_ack_window: "dict[str, deque[float]]" = {}
+# Senders currently over budget — latches the loud log to once per trip.
+_auto_ack_tripped: "set[str]" = set()
+
+
+def _auto_ack_rate_limits() -> "tuple[int, float]":
+    """Resolve ``(max_acks, window_seconds)`` for the auto-ack cap.
+
+    Configurable via ``SAC_AUTO_ACK_RATE_MAX`` / ``SAC_AUTO_ACK_RATE_WINDOW_S``
+    (and their ``SCITEX_AGENT_CONTAINER_*`` aliases). A non-positive max
+    disables the cap (explicit opt-out).
+    """
+    raw_max = _sac_env("AUTO_ACK_RATE_MAX")
+    raw_win = _sac_env("AUTO_ACK_RATE_WINDOW_S")
+    try:
+        max_n = int(raw_max) if raw_max is not None else _AUTO_ACK_RATE_MAX_DEFAULT
+    except (TypeError, ValueError):
+        max_n = _AUTO_ACK_RATE_MAX_DEFAULT
+    try:
+        window = (
+            float(raw_win) if raw_win is not None else _AUTO_ACK_RATE_WINDOW_DEFAULT
+        )
+    except (TypeError, ValueError):
+        window = _AUTO_ACK_RATE_WINDOW_DEFAULT
+    return max_n, window
+
+
+def _auto_ack_rate_allow(sender: str, *, now: "float | None" = None) -> bool:
+    """Whether an auto-ack to ``sender`` is within the rate budget.
+
+    Sliding-window cap keyed by sender. Returns ``True`` and records the
+    emission when within budget; returns ``False`` (logging loudly, once
+    per trip) when the cap is exceeded inside the window. After the window
+    clears, emission resumes and the loud-log latch resets so a fresh loop
+    is reported again. ``now`` is injectable for deterministic tests.
+    """
+    max_n, window = _auto_ack_rate_limits()
+    if max_n <= 0:
+        return True
+    ts = time.monotonic() if now is None else now
+    dq = _auto_ack_window.setdefault(sender, deque())
+    cutoff = ts - window
+    while dq and dq[0] < cutoff:
+        dq.popleft()
+    if len(dq) >= max_n:
+        if sender not in _auto_ack_tripped:
+            _auto_ack_tripped.add(sender)
+            log.warning(
+                "sac channel: auto-ack rate cap hit for sender %r "
+                "(%d auto-acks within %.0fs) — suppressing further "
+                "auto-acks to this sender until the window clears. "
+                "Possible ack loop.",
+                sender,
+                len(dq),
+                window,
+            )
+        return False
+    dq.append(ts)
+    _auto_ack_tripped.discard(sender)
+    return True
+
+
+async def _post_auto_ack(
+    event: dict[str, Any],
+    *,
+    agent_name: str,
+    listen_url: str,
+    bearer: str | None,
+) -> None:
+    """POST an automatic ``a2a_ack`` back to the sender of ``event``.
+
+    Reuses the exact ``/agents/<sender>/message:send`` path and metadata
+    shape the ``a2a_ack`` tool uses (``ack=True``, ``in_reply_to`` the
+    original ``msg_id``, same ``conversation_id``). ``ack=True`` is the
+    loop-guard marker: the sender's adapter sees it and won't ack back.
+
+    Caller guarantees ``event`` passed :func:`_should_auto_ack` (so
+    ``from_agent`` is present and the event is not itself an ack).
+
+    **Sender-side empty-ack noise filter:** before the outbound POST is
+    built and sent, the assembled envelope is checked against
+    :func:`._channel_ack_filter.envelope_is_contentless_ack`. A
+    contentless ack (empty body + ``metadata.ack=True``) is dropped
+    silently with a debug log — it carries no semantic payload and the
+    operator's contract is to keep noise off the wire. The receive-side
+    ``_should_auto_ack`` loop-guard above stays in place as belt-and-
+    suspenders.
+    """
+    import uuid as _uuid
+
+    import httpx
+
+    from ._channel_ack_filter import envelope_is_contentless_ack
+
+    target = event["from_agent"]
+    metadata: dict[str, Any] = {"from_agent": agent_name, "ack": True}
+    msg_id = event.get("msg_id")
+    if msg_id:
+        metadata["in_reply_to"] = msg_id
+    conversation_id = event.get("conversation_id")
+    if conversation_id:
+        metadata["conversation_id"] = conversation_id
+    payload = {
+        "jsonrpc": "2.0",
+        "id": _uuid.uuid4().hex,
+        "method": "SendMessage",
+        "params": {
+            "message": {
+                "message_id": _uuid.uuid4().hex,
+                "role": "ROLE_USER",
+                "parts": [{"text": ""}],
+            },
+            "metadata": metadata,
+        },
+    }
+    if envelope_is_contentless_ack(payload):
+        log.debug(
+            "sac channel: suppressing empty-content auto-ack to %r "
+            "(in_reply_to=%s) — sender-side noise filter (operator contract)",
+            target,
+            msg_id,
+        )
+        return
+    base = listen_url.rstrip("/")
+    headers = {"Content-Type": "application/json"}
+    if bearer:
+        headers["Authorization"] = f"Bearer {bearer}"
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        resp = await client.post(
+            f"{base}/agents/{target}/message:send", json=payload, headers=headers
+        )
+        resp.raise_for_status()

--- a/src/scitex_agent_container/_mcp/_channel_tools.py
+++ b/src/scitex_agent_container/_mcp/_channel_tools.py
@@ -140,8 +140,41 @@ def register_tools(
         responses (cross-host forwards) don't carry it, and inventing a
         zero would be a false-positive failure. Only an explicit ``0``
         from the local publish path is the no-subscriber signal.
+
+        **Sender-side empty-ack noise filter:** before the outbound POST,
+        the assembled envelope is checked against
+        :func:`._channel_ack_filter.envelope_is_contentless_ack`. A
+        contentless ack (empty body + ``metadata.ack=True``) is dropped
+        silently with a debug log and a synthetic
+        ``{"status": 200, "body": {"suppressed": "empty_ack", ...}}``
+        result is returned — the operator's contract is to keep empty
+        delivery confirmations off the wire (sender-side, never receiver-
+        side, to avoid the symmetric "did we send? / did they receive?"
+        doubt). Non-empty acks and empty-content non-ack messages pass
+        through untouched (the join of empty body AND ``ack=True`` is
+        the only suppressed shape).
         """
         import httpx
+
+        from ._channel_ack_filter import envelope_is_contentless_ack
+
+        if envelope_is_contentless_ack(payload):
+            log.debug(
+                "sac a2a: suppressing empty-content ack to %r at %s "
+                "— sender-side noise filter (operator contract)",
+                target,
+                path,
+            )
+            return {
+                "status": 200,
+                "body": {
+                    "suppressed": "empty_ack",
+                    "reason": (
+                        "empty-content delivery ack dropped at sender "
+                        "(operator contract: no contentless acks on the wire)"
+                    ),
+                },
+            }
 
         try:
             res = await _post(path, payload)

--- a/src/scitex_agent_container/_mcp/channel.py
+++ b/src/scitex_agent_container/_mcp/channel.py
@@ -39,11 +39,8 @@ import asyncio
 import json
 import logging
 import os
-import time
 from collections import deque
 from typing import Any
-
-from .._env import getenv as _sac_env
 
 log = logging.getLogger(__name__)
 
@@ -54,117 +51,26 @@ _INBOX_CAP = 200
 _recent: "deque[dict[str, Any]]" = deque(maxlen=_INBOX_CAP)
 
 
-def _auto_ack_enabled() -> bool:
-    """Whether the receive-side adapter emits an automatic ``a2a_ack`` the
-    moment it injects a received bus event into the session.
-
-    Two-stage receipt, infra-automatic: the receiving agent calls nothing —
-    the channel adapter does. Stage 1 ("delivered") is the send response's
-    ``delivered_subscriber_count``; stage 2 ("read") is this auto-ack,
-    emitted on injection. Default ON; set ``SAC_CHANNEL_AUTO_ACK`` to one of
-    ``0/false/no/off`` (case-insensitive) to disable.
-    """
-    raw = os.environ.get("SAC_CHANNEL_AUTO_ACK")
-    if raw is None:
-        return True
-    return raw.strip().lower() not in ("0", "false", "no", "off")
-
-
 # WI-1 wake-on-push primitives live in ``_channel_wake`` (extracted to keep
 # this receive-side adapter under the module size budget). Re-exported here
 # so the historical ``from .channel import _wake_turn`` import path — used by
 # ``_push_channel_event`` below and the test suite — keeps working.
+# Auto-ack subsystem (env gate, loop-guard, rate limiter, outbound POST)
+# lives in ``_channel_auto_ack`` so this receive-side adapter stays under
+# the size budget. Re-exported here for historical import paths:
+# ``from scitex_agent_container._mcp.channel import _post_auto_ack``.
+from ._channel_auto_ack import (  # noqa: E402,F401
+    _AUTO_ACK_RATE_MAX_DEFAULT,
+    _AUTO_ACK_RATE_WINDOW_DEFAULT,
+    _auto_ack_enabled,
+    _auto_ack_rate_allow,
+    _auto_ack_rate_limits,
+    _auto_ack_tripped,
+    _auto_ack_window,
+    _post_auto_ack,
+    _should_auto_ack,
+)
 from ._channel_wake import _should_wake_turn, _wake_text, _wake_turn  # noqa: E402,F401
-
-
-def _should_auto_ack(event: dict[str, Any]) -> bool:
-    """Loop-guard for the auto-ack side-effect.
-
-    An auto-ack is itself a message that lands in the sender's inbox and is
-    injected by *their* adapter — which would auto-ack back, ad infinitum.
-    Break the cycle:
-
-    - never auto-ack an event that is itself an ack (truthy ``ack`` flag —
-      the same metadata flag the ``a2a_ack`` tool stamps), and
-    - never auto-ack an event with no identifiable original sender
-      (``from_agent`` missing/empty): there is nowhere to send the receipt.
-    """
-    if not event.get("from_agent"):
-        return False
-    if event.get("ack"):
-        return False
-    return True
-
-
-# --- Auto-ack rate limiter (belt-and-suspenders loop breaker) -------------
-# Even with the ack-flag loop-guard (``_should_auto_ack``), a future
-# regression in flag propagation could restart an ack-on-ack cycle. This
-# sliding-window cap ensures any such loop self-terminates: once a sender
-# exceeds the budget within the window we stop auto-acking it and log
-# loudly (fail-loud, never a silent drop).
-_AUTO_ACK_RATE_MAX_DEFAULT = 20
-_AUTO_ACK_RATE_WINDOW_DEFAULT = 60.0
-# Per-sender sliding window of auto-ack emission timestamps.
-_auto_ack_window: "dict[str, deque[float]]" = {}
-# Senders currently over budget — latches the loud log to once per trip.
-_auto_ack_tripped: "set[str]" = set()
-
-
-def _auto_ack_rate_limits() -> "tuple[int, float]":
-    """Resolve ``(max_acks, window_seconds)`` for the auto-ack cap.
-
-    Configurable via ``SAC_AUTO_ACK_RATE_MAX`` / ``SAC_AUTO_ACK_RATE_WINDOW_S``
-    (and their ``SCITEX_AGENT_CONTAINER_*`` aliases). A non-positive max
-    disables the cap (explicit opt-out).
-    """
-    raw_max = _sac_env("AUTO_ACK_RATE_MAX")
-    raw_win = _sac_env("AUTO_ACK_RATE_WINDOW_S")
-    try:
-        max_n = int(raw_max) if raw_max is not None else _AUTO_ACK_RATE_MAX_DEFAULT
-    except (TypeError, ValueError):
-        max_n = _AUTO_ACK_RATE_MAX_DEFAULT
-    try:
-        window = (
-            float(raw_win) if raw_win is not None else _AUTO_ACK_RATE_WINDOW_DEFAULT
-        )
-    except (TypeError, ValueError):
-        window = _AUTO_ACK_RATE_WINDOW_DEFAULT
-    return max_n, window
-
-
-def _auto_ack_rate_allow(sender: str, *, now: "float | None" = None) -> bool:
-    """Whether an auto-ack to ``sender`` is within the rate budget.
-
-    Sliding-window cap keyed by sender. Returns ``True`` and records the
-    emission when within budget; returns ``False`` (logging loudly, once
-    per trip) when the cap is exceeded inside the window. After the window
-    clears, emission resumes and the loud-log latch resets so a fresh loop
-    is reported again. ``now`` is injectable for deterministic tests.
-    """
-    max_n, window = _auto_ack_rate_limits()
-    if max_n <= 0:
-        return True
-    ts = time.monotonic() if now is None else now
-    dq = _auto_ack_window.setdefault(sender, deque())
-    cutoff = ts - window
-    while dq and dq[0] < cutoff:
-        dq.popleft()
-    if len(dq) >= max_n:
-        if sender not in _auto_ack_tripped:
-            _auto_ack_tripped.add(sender)
-            log.warning(
-                "sac channel: auto-ack rate cap hit for sender %r "
-                "(%d auto-acks within %.0fs) — suppressing further "
-                "auto-acks to this sender until the window clears. "
-                "Possible ack loop.",
-                sender,
-                len(dq),
-                window,
-            )
-        return False
-    dq.append(ts)
-    _auto_ack_tripped.discard(sender)
-    return True
 
 
 async def _consume_sse(
@@ -272,59 +178,6 @@ def _build_notification(event: dict[str, Any]) -> dict[str, Any]:
         "content": event.get("content", ""),
         "meta": meta,
     }
-
-
-async def _post_auto_ack(
-    event: dict[str, Any],
-    *,
-    agent_name: str,
-    listen_url: str,
-    bearer: str | None,
-) -> None:
-    """POST an automatic ``a2a_ack`` back to the sender of ``event``.
-
-    Reuses the exact ``/agents/<sender>/message:send`` path and metadata
-    shape the ``a2a_ack`` tool uses (``ack=True``, ``in_reply_to`` the
-    original ``msg_id``, same ``conversation_id``). ``ack=True`` is the
-    loop-guard marker: the sender's adapter sees it and won't ack back.
-
-    Caller guarantees ``event`` passed :func:`_should_auto_ack` (so
-    ``from_agent`` is present and the event is not itself an ack).
-    """
-    import uuid as _uuid
-
-    import httpx
-
-    target = event["from_agent"]
-    metadata: dict[str, Any] = {"from_agent": agent_name, "ack": True}
-    msg_id = event.get("msg_id")
-    if msg_id:
-        metadata["in_reply_to"] = msg_id
-    conversation_id = event.get("conversation_id")
-    if conversation_id:
-        metadata["conversation_id"] = conversation_id
-    payload = {
-        "jsonrpc": "2.0",
-        "id": _uuid.uuid4().hex,
-        "method": "SendMessage",
-        "params": {
-            "message": {
-                "message_id": _uuid.uuid4().hex,
-                "role": "ROLE_USER",
-                "parts": [{"text": ""}],
-            },
-            "metadata": metadata,
-        },
-    }
-    base = listen_url.rstrip("/")
-    headers = {"Content-Type": "application/json"}
-    if bearer:
-        headers["Authorization"] = f"Bearer {bearer}"
-    async with httpx.AsyncClient(timeout=10.0) as client:
-        resp = await client.post(
-            f"{base}/agents/{target}/message:send", json=payload, headers=headers
-        )
-        resp.raise_for_status()
 
 
 async def _push_channel_event(

--- a/tests/scitex_agent_container/_mcp/test__channel_ack_filter.py
+++ b/tests/scitex_agent_container/_mcp/test__channel_ack_filter.py
@@ -278,3 +278,127 @@ async def test_a2a_ack_returns_structured_suppression_marker(
     body = json.loads(out[0].text)
     # Assert
     assert body.get("body", {}).get("suppressed") == "empty_ack"
+
+
+# ---------------------------------------------------------------------------
+# (3) Defensive branch coverage — predicate + rate-limit env parsing
+#
+# These tests target the structural "give-up" branches the predicate and
+# the rate-limit env helpers take on malformed input. Without explicit
+# coverage these branches sit untested at the codecov-patch threshold;
+# fail-loud invariants for the operator's "no silent acks" contract
+# deserve test pins so a future refactor cannot turn one into a silent
+# True/False flip.
+# ---------------------------------------------------------------------------
+
+
+def test_predicate_returns_false_when_message_is_not_a_dict():
+    # Arrange — params.message is a string (malformed envelope).
+    bad: dict[str, Any] = {
+        "jsonrpc": "2.0",
+        "id": "rid",
+        "method": "SendMessage",
+        "params": {
+            "message": "not-a-dict",
+            "metadata": {"ack": True, "from_agent": "alice"},
+        },
+    }
+    # Act
+    decision = envelope_is_contentless_ack(bad)
+    # Assert
+    assert decision is False
+
+
+def test_predicate_returns_false_when_text_is_not_a_string():
+    # Arrange — parts[0].text is an int (some buggy producer).
+    bad: dict[str, Any] = {
+        "jsonrpc": "2.0",
+        "id": "rid",
+        "method": "SendMessage",
+        "params": {
+            "message": {
+                "message_id": "mid",
+                "role": "ROLE_USER",
+                "parts": [{"text": 42}],
+            },
+            "metadata": {"ack": True, "from_agent": "alice"},
+        },
+    }
+    # Act
+    decision = envelope_is_contentless_ack(bad)
+    # Assert
+    assert decision is False
+
+
+def test_auto_ack_rate_limit_non_numeric_max_falls_back_to_default(
+    monkeypatch_safe_env,
+):
+    # Arrange — bad env value; the helper must fall back rather than
+    # raise. ``monkeypatch_safe_env`` (defined below as a yield-style
+    # save/restore fixture, no monkeypatch.setattr on production code)
+    # sets the env for the call window only.
+    monkeypatch_safe_env("SAC_AUTO_ACK_RATE_MAX", "not-a-number")
+    from scitex_agent_container._mcp._channel_auto_ack import (
+        _auto_ack_rate_limits,
+    )
+
+    # Act
+    max_n, _window = _auto_ack_rate_limits()
+    # Assert — fell back to the module default (positive int).
+    assert isinstance(max_n, int) and max_n > 0
+
+
+def test_auto_ack_rate_limit_non_numeric_window_falls_back_to_default(
+    monkeypatch_safe_env,
+):
+    # Arrange
+    monkeypatch_safe_env("SAC_AUTO_ACK_RATE_WINDOW_S", "abc")
+    from scitex_agent_container._mcp._channel_auto_ack import (
+        _auto_ack_rate_limits,
+    )
+
+    # Act
+    _max_n, window = _auto_ack_rate_limits()
+    # Assert
+    assert isinstance(window, float) and window > 0
+
+
+def test_auto_ack_rate_disabled_when_max_is_zero(monkeypatch_safe_env):
+    # Arrange — non-positive max is the explicit opt-out per the
+    # docstring contract ("A non-positive max disables the cap").
+    monkeypatch_safe_env("SAC_AUTO_ACK_RATE_MAX", "0")
+    from scitex_agent_container._mcp._channel_auto_ack import (
+        _auto_ack_rate_allow,
+    )
+
+    # Act
+    decision = _auto_ack_rate_allow("alice")
+    # Assert — disabled → always allow.
+    assert decision is True
+
+
+@pytest.fixture
+def monkeypatch_safe_env():
+    """Yield-style env setter that save/restores per key — no monkeypatch.
+
+    The audit gate forbids ``monkeypatch.setattr`` on production
+    internals; this fixture wraps a real ``os.environ`` mutation in
+    a try/finally so the test never leaks env into siblings.
+    """
+    import os as _os
+
+    saved: dict[str, str | None] = {}
+
+    def _set(key: str, value: str) -> None:
+        if key not in saved:
+            saved[key] = _os.environ.get(key)
+        _os.environ[key] = value
+
+    try:
+        yield _set
+    finally:
+        for k, prev in saved.items():
+            if prev is None:
+                _os.environ.pop(k, None)
+            else:
+                _os.environ[k] = prev

--- a/tests/scitex_agent_container/_mcp/test__channel_ack_filter.py
+++ b/tests/scitex_agent_container/_mcp/test__channel_ack_filter.py
@@ -1,0 +1,281 @@
+"""Tests for the sender-side empty-content-ack noise filter.
+
+Two surfaces are covered:
+
+1. The pure structural predicate
+   :func:`scitex_agent_container._mcp._channel_ack_filter.envelope_is_contentless_ack`
+   — empty body + ``metadata.ack`` truthy ⇒ True; every other shape ⇒
+   False. No I/O, no mocks, just structural checks.
+
+2. The integration of that predicate at the two outbound chokepoints —
+   ``_channel_tools._send_or_raise`` (driven through the ``a2a_send``
+   tool) and ``channel._post_auto_ack`` (driven through
+   ``_push_channel_event``) — verified end-to-end against the real
+   asyncio HTTP/1.1 ``_FakeListenServer`` from
+   ``tests/.../_mcp/test__channel_tools.py``. No mocks, no monkeypatch.
+
+Per the operator's contract:
+- (a) empty-content ack is dropped at the sender;
+- (b) non-empty ack passes through;
+- (c) empty content WITHOUT the ack marker is NOT dropped;
+- (d) the drop is logged at DEBUG.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Any
+
+import pytest
+import pytest_asyncio
+
+pytest.importorskip("mcp.types")
+
+from scitex_agent_container._mcp._channel_ack_filter import (  # noqa: E402
+    envelope_is_contentless_ack,
+)
+from scitex_agent_container._mcp._channel_tools import register_tools  # noqa: E402
+from scitex_agent_container._mcp.channel import (  # noqa: E402
+    _post_auto_ack,
+    _recent,
+)
+
+# Reuse the real HTTP fake from the sibling test module — it's a real
+# asyncio.start_server-backed HTTP/1.1 listener, no mocks.
+from tests.scitex_agent_container._mcp.test__channel_tools import (  # noqa: E402
+    _FakeListenServer,
+    _ToolRecorder,
+)
+
+# ---------------------------------------------------------------------------
+# (1) Pure structural predicate
+# ---------------------------------------------------------------------------
+
+
+def _envelope(
+    *, content: str | None, ack: bool, include_parts: bool = True
+) -> dict[str, Any]:
+    """Build a minimal JSON-RPC ``SendMessage`` envelope for the predicate.
+
+    ``include_parts=False`` models the no-parts edge case (the helper
+    treats no-parts as empty body).
+    """
+    message: dict[str, Any] = {"message_id": "mid", "role": "ROLE_USER"}
+    if include_parts:
+        # ``content=None`` here means: parts present but with no ``text`` key,
+        # which the predicate treats as structurally-malformed (False).
+        if content is None:
+            message["parts"] = [{}]
+        else:
+            message["parts"] = [{"text": content}]
+    metadata: dict[str, Any] = {"from_agent": "alice"}
+    if ack:
+        metadata["ack"] = True
+    return {
+        "jsonrpc": "2.0",
+        "id": "rid",
+        "method": "SendMessage",
+        "params": {"message": message, "metadata": metadata},
+    }
+
+
+def test_predicate_drops_empty_string_content_ack():
+    # Arrange
+    env = _envelope(content="", ack=True)
+    # Act
+    decision = envelope_is_contentless_ack(env)
+    # Assert
+    assert decision is True
+
+
+def test_predicate_drops_whitespace_only_content_ack():
+    # Arrange
+    env = _envelope(content="   \n\t  ", ack=True)
+    # Act
+    decision = envelope_is_contentless_ack(env)
+    # Assert
+    assert decision is True
+
+
+def test_predicate_keeps_non_empty_content_ack():
+    """Operator constraint (b): an ack that carries actual content is a
+    normal message — must pass through untouched."""
+    # Arrange
+    env = _envelope(content="got it", ack=True)
+    # Act
+    decision = envelope_is_contentless_ack(env)
+    # Assert
+    assert decision is False
+
+
+def test_predicate_keeps_empty_content_without_ack_marker():
+    """Operator constraint (c): an empty-content message that is NOT an
+    ack (no ``ack`` flag, or ``ack=False``) is left alone — the empty
+    payload may be intentional (wake ping, etc.)."""
+    # Arrange
+    env = _envelope(content="", ack=False)
+    # Act
+    decision = envelope_is_contentless_ack(env)
+    # Assert
+    assert decision is False
+
+
+def test_predicate_handles_no_parts_at_all_as_empty():
+    """No ``parts`` list at all is morally an empty body — drop alongside
+    the explicit empty-string form so partial envelopes can't slip past
+    the filter."""
+    # Arrange
+    env = _envelope(content="", ack=True, include_parts=False)
+    # Act
+    decision = envelope_is_contentless_ack(env)
+    # Assert
+    assert decision is True
+
+
+def test_predicate_is_safe_on_malformed_envelope():
+    """The helper is structural — anything it cannot recognise as the
+    target shape returns False (caller decides). No crashes on garbage."""
+    # Arrange
+    bad: dict[str, Any] = {"params": "not-a-dict"}
+    # Act
+    decision = envelope_is_contentless_ack(bad)
+    # Assert
+    assert decision is False
+
+
+# ---------------------------------------------------------------------------
+# (2) Integration at the outbound chokepoints — real HTTP fake, no mocks.
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def fake_listen():
+    server = _FakeListenServer()
+    await server.start()
+    try:
+        yield server
+    finally:
+        await server.stop()
+
+
+@pytest.fixture
+def registered_tools(fake_listen):
+    rec = _ToolRecorder()
+    register_tools(
+        rec, agent_name="alice", listen_url=fake_listen.base_url, bearer=None
+    )
+    return rec
+
+
+@pytest.fixture(autouse=True)
+def _clear_recent_ring():
+    _recent.clear()
+    yield
+    _recent.clear()
+
+
+@pytest.mark.asyncio
+async def test_a2a_ack_tool_does_not_emit_a_network_post(
+    registered_tools: _ToolRecorder, fake_listen
+):
+    """Constraint (a): an empty-content ack from the ``a2a_ack`` tool is
+    dropped at the sender — zero HTTP POSTs reach the fake listen."""
+    # Arrange
+    _recent.append({"msg_id": "m1", "from_agent": "carol", "conversation_id": "c1"})
+    call_fn = registered_tools.call_tool_fn
+    # Act
+    await call_fn("a2a_ack", {"msg_id": "m1"})
+    # Assert
+    assert fake_listen.posts == []
+
+
+@pytest.mark.asyncio
+async def test_a2a_send_with_real_content_still_reaches_listen(
+    registered_tools: _ToolRecorder, fake_listen
+):
+    """Constraint: non-ack messages with content are NOT affected by the
+    filter — the regular send path is untouched. Lock that in."""
+    # Arrange
+    call_fn = registered_tools.call_tool_fn
+    # Act
+    await call_fn("a2a_send", {"target": "bob", "content": "hello"})
+    paths = [p for p, _ in fake_listen.posts]
+    # Assert
+    assert "/agents/bob/message:send" in paths
+
+
+@pytest.mark.asyncio
+async def test_post_auto_ack_is_suppressed_at_sender(fake_listen):
+    """Constraint (a): the receive-side adapter's stage-2 receipt always
+    builds an empty + ``ack=True`` envelope — the sender-side filter must
+    drop it before any HTTP POST is made to the fake listen."""
+    # Arrange
+    event = {"from_agent": "bob", "content": "hi", "msg_id": "m1"}
+    # Act
+    await _post_auto_ack(
+        event, agent_name="alice", listen_url=fake_listen.base_url, bearer=None
+    )
+    # Assert
+    assert fake_listen.posts == []
+
+
+@pytest.mark.asyncio
+async def test_a2a_ack_tool_drop_is_logged_at_debug(
+    registered_tools: _ToolRecorder, fake_listen, caplog
+):
+    """Constraint (d): the drop is logged. The send-side helper logs at
+    DEBUG ('suppressing empty-content ack ...'). Capture that record."""
+    # Arrange
+    _recent.append({"msg_id": "m1", "from_agent": "carol", "conversation_id": "c1"})
+    call_fn = registered_tools.call_tool_fn
+    # Act
+    with caplog.at_level(
+        logging.DEBUG, logger="scitex_agent_container._mcp._channel_tools"
+    ):
+        await call_fn("a2a_ack", {"msg_id": "m1"})
+    matched = [
+        r for r in caplog.records if "suppressing empty-content ack" in r.message
+    ]
+    # Assert
+    assert matched and matched[0].levelno == logging.DEBUG
+
+
+@pytest.mark.asyncio
+async def test_post_auto_ack_drop_is_logged_at_debug(fake_listen, caplog):
+    """Constraint (d): the auto-ack drop is logged at DEBUG with the
+    'suppressing empty-content auto-ack' message — distinct from the
+    send-tool drop log so operators can tell the two chokepoints apart."""
+    # Arrange
+    event = {"from_agent": "bob", "content": "hi", "msg_id": "m1"}
+    # Act
+    with caplog.at_level(
+        logging.DEBUG, logger="scitex_agent_container._mcp._channel_auto_ack"
+    ):
+        await _post_auto_ack(
+            event, agent_name="alice", listen_url=fake_listen.base_url, bearer=None
+        )
+    matched = [
+        r for r in caplog.records if "suppressing empty-content auto-ack" in r.message
+    ]
+    # Assert
+    assert matched and matched[0].levelno == logging.DEBUG
+
+
+@pytest.mark.asyncio
+async def test_a2a_ack_returns_structured_suppression_marker(
+    registered_tools: _ToolRecorder, fake_listen
+):
+    """The dropped ack still returns a structured ``{suppressed: empty_ack}``
+    body to the caller so an awaiting flow can distinguish 'we suppressed'
+    from 'we delivered'. This is the sender-side contract: silent on the
+    wire, but explicit to the caller."""
+    # Arrange
+    _recent.append({"msg_id": "m1", "from_agent": "carol", "conversation_id": "c1"})
+    call_fn = registered_tools.call_tool_fn
+    # Act
+    out = await call_fn("a2a_ack", {"msg_id": "m1"})
+    body = json.loads(out[0].text)
+    # Assert
+    assert body.get("body", {}).get("suppressed") == "empty_ack"

--- a/tests/scitex_agent_container/_mcp/test__channel_ack_filter.py
+++ b/tests/scitex_agent_container/_mcp/test__channel_ack_filter.py
@@ -23,7 +23,6 @@ Per the operator's contract:
 
 from __future__ import annotations
 
-import asyncio
 import json
 import logging
 from typing import Any

--- a/tests/scitex_agent_container/_mcp/test__channel_tools.py
+++ b/tests/scitex_agent_container/_mcp/test__channel_tools.py
@@ -413,17 +413,36 @@ async def test_call_tool_a2a_ack_unknown_sender_returns_error(
 
 
 @pytest.mark.asyncio
-async def test_call_tool_a2a_ack_posts_ack_metadata(
+async def test_call_tool_a2a_ack_is_suppressed_at_sender(
     registered_tools: _ToolRecorder, fake_listen
 ):
+    """The ``a2a_ack`` tool always builds an empty-content + ``ack=True``
+    payload — the exact shape the sender-side noise filter is designed to
+    drop. The HTTP POST must NOT reach the listen (the wire stays quiet).
+    """
     # Arrange
     _recent.append({"msg_id": "m1", "from_agent": "carol", "conversation_id": "c1"})
     call_fn = registered_tools.call_tool_fn
     # Act
     await call_fn("a2a_ack", {"msg_id": "m1"})
-    _, payload = fake_listen.posts[-1]
     # Assert
-    assert payload["params"]["metadata"]["ack"] is True
+    assert fake_listen.posts == []
+
+
+@pytest.mark.asyncio
+async def test_call_tool_a2a_ack_returns_suppression_marker(
+    registered_tools: _ToolRecorder, fake_listen
+):
+    """The dropped ack still returns a structured result to the caller so a
+    flow that ``await``ed it can distinguish "suppressed" from "delivered"."""
+    # Arrange
+    _recent.append({"msg_id": "m1", "from_agent": "carol", "conversation_id": "c1"})
+    call_fn = registered_tools.call_tool_fn
+    # Act
+    out = await call_fn("a2a_ack", {"msg_id": "m1"})
+    body = json.loads(out[0].text)
+    # Assert
+    assert body.get("body", {}).get("suppressed") == "empty_ack"
 
 
 @pytest.mark.asyncio
@@ -641,15 +660,20 @@ async def test_a2a_reply_no_subscriber_returns_loud_error(
 
 
 @pytest.mark.asyncio
-async def test_a2a_ack_no_subscriber_returns_loud_error(
+async def test_a2a_ack_is_suppressed_before_subscriber_check(
     registered_tools: _ToolRecorder, fake_listen
 ):
-    """The explicit ack tool also fails loud when it reaches no subscriber."""
-    # Arrange
+    """Sender-side noise filter runs *before* the HTTP POST, so the
+    no-subscriber check downstream never sees the contentless ack — even
+    when the listen would have reported zero subscribers, the ack is
+    dropped silently with no loud error (it is noise, not a delivery
+    failure)."""
+    # Arrange — would-be-zero subscriber response: irrelevant, we never POST.
     _recent.append({"msg_id": "orig2", "from_agent": "bob", "conversation_id": "c2"})
     fake_listen.send_response = {"delivered_subscriber_count": 0}
     call_fn = registered_tools.call_tool_fn
     # Act
     out = await call_fn("a2a_ack", {"msg_id": "orig2"})
+    body = json.loads(out[0].text)
     # Assert
-    assert "no live subscriber" in (_err(out) or "")
+    assert _err(out) is None and body.get("body", {}).get("suppressed") == "empty_ack"

--- a/tests/scitex_agent_container/_mcp/test_channel.py
+++ b/tests/scitex_agent_container/_mcp/test_channel.py
@@ -949,7 +949,13 @@ async def test_push_channel_event_still_injects_notification(fake_listen):
 
 
 @pytest.mark.asyncio
-async def test_push_channel_event_auto_acks_to_sender_path(fake_listen):
+async def test_push_channel_event_auto_ack_is_suppressed_at_sender(fake_listen):
+    """Operator contract: the stage-2 read-receipt auto-ack is contentless
+    (empty body + ``metadata.ack=True``), so the sender-side noise filter
+    drops it BEFORE it leaves the outbound queue. The wire stays quiet —
+    the receive-side ``_should_auto_ack`` guard remains as belt-and-
+    suspenders. Pre-filter behaviour (a POST to ``/agents/bob/message:send``)
+    is replaced by zero POSTs."""
     # Arrange
     from scitex_agent_container._mcp.channel import _push_channel_event
 
@@ -963,15 +969,14 @@ async def test_push_channel_event_auto_acks_to_sender_path(fake_listen):
         listen_url=fake_listen.base_url,
         bearer=None,
     )
-    paths = [p for p, _ in fake_listen.posts]
-    # Assert — the receipt went back to the original sender's send path.
-    assert "/agents/bob/message:send" in paths
+    # Assert — no auto-ack reached the listen.
+    assert fake_listen.posts == []
 
 
 @pytest.mark.asyncio
-async def test_push_channel_event_auto_ack_carries_ack_marker(fake_listen):
-    """The auto-ack must stamp ``ack=True`` — that flag IS the loop-guard
-    marker the receiving adapter checks before re-acking."""
+async def test_push_channel_event_still_injects_when_ack_suppressed(fake_listen):
+    """Suppressing the auto-ack must not block the primary injection: the
+    inbound event still reaches the session as a channel notification."""
     # Arrange
     from scitex_agent_container._mcp.channel import _push_channel_event
 
@@ -985,29 +990,8 @@ async def test_push_channel_event_auto_ack_carries_ack_marker(fake_listen):
         listen_url=fake_listen.base_url,
         bearer=None,
     )
-    _, payload = fake_listen.posts[-1]
-    # Assert
-    assert payload["params"]["metadata"]["ack"] is True
-
-
-@pytest.mark.asyncio
-async def test_push_channel_event_auto_ack_references_original_msg_id(fake_listen):
-    # Arrange
-    from scitex_agent_container._mcp.channel import _push_channel_event
-
-    session = _CapturingSession()
-    event = {"from_agent": "bob", "content": "hi", "msg_id": "m1"}
-    # Act
-    await _push_channel_event(
-        session,
-        event,
-        agent_name="alice",
-        listen_url=fake_listen.base_url,
-        bearer=None,
-    )
-    _, payload = fake_listen.posts[-1]
-    # Assert
-    assert payload["params"]["metadata"]["in_reply_to"] == "m1"
+    # Assert — the notification was delivered through the session.
+    assert len(session.sent) == 1
 
 
 @pytest.mark.asyncio
@@ -1032,17 +1016,19 @@ async def test_push_channel_event_does_not_auto_ack_an_ack(fake_listen):
 
 
 @pytest.mark.asyncio
-async def test_two_adapters_do_not_ping_pong_to_a_fixed_point(fake_listen):
-    """Drive the full bounce: adapter A injects B's message → auto-acks B;
-    then feed A's ack into adapter B's inject path. B must NOT ack back, so
-    the exchange terminates after exactly one ack rather than diverging."""
+async def test_two_adapters_emit_zero_acks_under_sender_side_filter(fake_listen):
+    """End-to-end ping-pong cannot start under the sender-side filter: A's
+    would-be auto-ack to B is dropped at A before it reaches the wire, so
+    there is nothing for B's adapter to bounce back. Pre-filter behaviour
+    (exactly one ack on the wire) is replaced by zero acks on the wire.
+    Replaces ``test_two_adapters_do_not_ping_pong_to_a_fixed_point`` —
+    the loop terminates one hop earlier."""
     # Arrange
     from scitex_agent_container._mcp.channel import _push_channel_event
 
     session_a = _CapturingSession()
-    session_b = _CapturingSession()
     inbound_to_a = {"from_agent": "bob", "content": "hi", "msg_id": "m1"}
-    # Act — A receives B's message and auto-acks (1 POST expected).
+    # Act — A receives B's message; the auto-ack is suppressed at A.
     await _push_channel_event(
         session_a,
         inbound_to_a,
@@ -1050,25 +1036,8 @@ async def test_two_adapters_do_not_ping_pong_to_a_fixed_point(fake_listen):
         listen_url=fake_listen.base_url,
         bearer=None,
     )
-    _, ack_payload = fake_listen.posts[-1]
-    # Reconstruct the bus event B's adapter would see from A's ack POST.
-    ack_meta = ack_payload["params"]["metadata"]
-    inbound_to_b = {
-        "from_agent": ack_meta["from_agent"],
-        "content": "",
-        "msg_id": "m2",
-        "ack": ack_meta.get("ack"),
-    }
-    # B injects A's ack — the loop-guard must stop here.
-    await _push_channel_event(
-        session_b,
-        inbound_to_b,
-        agent_name="bob",
-        listen_url=fake_listen.base_url,
-        bearer=None,
-    )
-    # Assert — exactly one ack total; B did not bounce another back.
-    assert len(fake_listen.posts) == 1
+    # Assert — no ack reached the wire.
+    assert fake_listen.posts == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Empty-content delivery acks (``metadata.ack=True`` + empty/whitespace
body) now get dropped at the **sender** before they leave the outbound
queue — at both channel-push chokepoints — so the ping-pong loop never
starts. The receive-side ``_should_auto_ack`` loop-guard stays in place
as belt-and-suspenders.

- New pure structural predicate
  ``_channel_ack_filter.envelope_is_contentless_ack`` — only the join of
  ``metadata.ack`` truthy AND empty ``parts[0].text`` is suppressed; any
  other shape passes through.
- Wired into ``_channel_tools._send_or_raise`` (covers ``a2a_send`` /
  ``a2a_reply`` / ``a2a_ack``) — drops silently with a DEBUG log and
  returns a structured ``{suppressed: empty_ack}`` body so awaiting
  callers can tell suppression apart from delivery.
- Wired into ``_channel.auto_ack._post_auto_ack`` (the stage-2 read-
  receipt) — drops at the same check with a distinct DEBUG message so
  operators can tell the two chokepoints apart in logs.
- ``channel.py`` was already over the per-file line budget; extracted
  the auto-ack subsystem (env gate, loop-guard, rate limiter, outbound
  POST) to a new ``_channel_auto_ack`` module to land the filter
  cleanly. ``channel.py`` re-exports the names for backward
  compatibility.

Operator constraint honoured: **sender-side only** — never filter at the
receiver (would create the symmetric "did we send? / did they receive?"
doubt).

## Test plan

- [x] Pure predicate: empty string + ack=True → drop
- [x] Pure predicate: whitespace-only + ack=True → drop
- [x] Pure predicate: non-empty content + ack=True → pass through
- [x] Pure predicate: empty content + ack absent/false → pass through
- [x] Pure predicate: no ``parts`` at all + ack=True → drop
- [x] Pure predicate: malformed envelope → False (safe, no crash)
- [x] Integration: ``a2a_ack`` tool emits zero HTTP POSTs (real fake listen)
- [x] Integration: ``a2a_send`` with content still POSTs (regression
  guard for non-ack pass-through)
- [x] Integration: ``_post_auto_ack`` emits zero HTTP POSTs
- [x] Integration: drop is logged at DEBUG at both chokepoints
- [x] Integration: dropped ack returns
  ``{status: 200, body: {suppressed: empty_ack, ...}}`` to caller
- [x] Existing affected tests rewritten to the new contract; all 273
  ``tests/scitex_agent_container/_mcp/`` tests pass (12 new + 261
  existing, including the rate-limit suite after the
  ``_channel_auto_ack`` extraction).
- [x] Verified one pre-existing unrelated failure
  (``test_claude_session_channels_without_port_raises_handler_error``)
  is present on stashed/unmodified ``fix/empty-ack-noise-suppression``
  HEAD too — not introduced by this change.

No mocks; tests use the real ``_FakeListenServer`` asyncio HTTP/1.1
loopback fake already in the suite.