### PR TITLE
feat(broker): SAC-from-SAC — in-SIF agent_start brokers to host listen

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_in_sif_broker.py
+++ b/src/scitex_agent_container/_lifecycle/_in_sif_broker.py
@@ -1,0 +1,263 @@
+"""SAC-from-SAC broker — in-SIF detection + host-listen spawn POST.
+
+Operator-mandated 2026-06-01: an agent running INSIDE an apptainer SIF
+must NOT try to ``apptainer exec`` a child (no nested apptainer on most
+HPCs / on the supported deployment shape). Instead, when ``sac agents
+start <child>`` (or the ``agent.start`` API) is invoked inside a SIF,
+the spawn MUST be brokered through the host-side ``sac listen`` server,
+which lives on the bare host, owns container lifecycle, and shells the
+real ``sac agent start`` against the bare host's apptainer.
+
+This module is the in-SIF half of that broker. Two collaborators:
+
+* :func:`is_in_sif` — pure env detection (``APPTAINER_CONTAINER`` or the
+  legacy ``SINGULARITY_CONTAINER`` set non-empty).
+* :func:`broker_start_to_host` — thin wrapper over
+  :func:`_lifecycle._spawn_client.request_spawn` that surfaces a
+  distinct :class:`InSifBrokerError` so the integration point in
+  :func:`_lifecycle._start.agent_start` can fail loud with one error
+  type instead of leaking ``SpawnRequestError``.
+
+Wiring contract (see ``runtimes._apptainer_listen_env``):
+
+* ``SAC_LISTEN_BASE_URL`` and ``SAC_LISTEN_BEARER`` are injected at
+  container launch by the apptainer runtime — both are already in
+  place for every sac-managed agent.
+* The host listen ``POST /agents`` handler re-runs
+  :func:`_listen._acl.check_spawn` and records the ``caller → child``
+  lineage edge, so the gate is enforced by the host (the single source
+  of truth) regardless of how the in-SIF caller asked.
+
+FAIL-LOUD invariants (ADR-0010 / handoff §0):
+
+* Missing ``SAC_LISTEN_BASE_URL`` → :class:`InSifBrokerError` with the
+  env var name in the message (operator must fix the runtime
+  injection); never silently treated as "skip the broker".
+* Host listen unreachable → :class:`InSifBrokerError` carrying the
+  transport reason verbatim; never silently swallowed.
+* 403 / 409 / 5xx from host listen → :class:`InSifBrokerError` with
+  ``status`` populated; never converted to "ok with empty result".
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "IN_SIF_ENV_VARS",
+    "InSifBrokerError",
+    "broker_start_to_host",
+    "is_in_sif",
+    "maybe_broker_in_sif_spawn",
+]
+
+
+# Apptainer sets ``APPTAINER_CONTAINER`` to the SIF path; legacy
+# Singularity sets ``SINGULARITY_CONTAINER``. Both are honoured because
+# operators routinely run apptainer compiled with singularity-compat
+# (and some HPC sites still ship the older binary under the original
+# name). An empty value is treated as "not in a SIF" — a stray
+# ``--env APPTAINER_CONTAINER=`` should not flip the broker on.
+IN_SIF_ENV_VARS = ("APPTAINER_CONTAINER", "SINGULARITY_CONTAINER")
+
+
+class InSifBrokerError(RuntimeError):
+    """Raised when the in-SIF spawn broker cannot reach the host listen.
+
+    Carries the structured failure shape so the caller (CLI / MCP tool /
+    log line) can show *why* the spawn failed without re-parsing the
+    free-text message:
+
+    * ``status`` — HTTP status code from the host listen server
+      (``None`` for transport errors / missing env failures).
+    * ``body`` — parsed response dict / text fallback / ``None``.
+
+    A separate error type (rather than re-raising
+    :class:`_spawn_client.SpawnRequestError`) keeps the integration
+    point in :func:`_lifecycle._start.agent_start` clean: one ``except``
+    catches every in-SIF broker failure mode without coupling that file
+    to the spawn-client transport details.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status: int | None = None,
+        body: Any = None,
+    ) -> None:
+        super().__init__(message)
+        self.status = status
+        self.body = body
+
+
+def is_in_sif() -> bool:
+    """Return True iff the current process is running inside an apptainer SIF.
+
+    Pure env detection — no syscalls, no filesystem probes. Apptainer
+    sets ``APPTAINER_CONTAINER`` (the SIF path) inside every container;
+    legacy Singularity uses ``SINGULARITY_CONTAINER``. Either non-empty
+    value signals "in a SIF". An explicit empty value (e.g. ``--env
+    APPTAINER_CONTAINER=``) is treated as "not in a SIF" — the agent's
+    runtime never emits an empty value, so a present-but-empty form is
+    almost always operator typo and would be confusing to trigger the
+    broker on.
+    """
+    for name in IN_SIF_ENV_VARS:
+        val = os.environ.get(name)
+        if val:  # non-empty string
+            return True
+    return False
+
+
+def broker_start_to_host(
+    child_name: str,
+    *,
+    caller: str | None = None,
+    spec: dict | None = None,
+    overwrite: bool = False,
+    base_url: str | None = None,
+    bearer: str | None = None,
+    timeout_s: float = 30.0,
+    opener: Callable | None = None,
+) -> dict:
+    """POST a spawn request to the host-side ``sac listen``; FAIL LOUD on error.
+
+    Thin re-shape of :func:`_lifecycle._spawn_client.request_spawn` that
+    translates every failure mode into :class:`InSifBrokerError`. This
+    keeps the integration point in :func:`agent_start` from importing
+    spawn-client internals (it imports only this module and catches
+    one error type).
+
+    Parameters
+    ----------
+    child_name
+        The agent to start. Must be registered on the host OR provided
+        inline via ``spec``.
+    caller
+        Override the auto-resolved caller identity. Defaults to
+        ``SAC_NAME`` from the container env (resolved by the spawn
+        client), which is what the host's ``check_spawn`` gate keys
+        off. ``None`` and the empty string are both normalised to the
+        admin path inside the spawn client.
+    spec
+        Optional inline spec dict ``{apiVersion, kind, spec}`` — the
+        host materialises it under ``~/.scitex/agent-container/agents/
+        <name>/spec.yaml`` and then starts it. Use for ephemeral /
+        per-turn children whose YAML is not yet on the host.
+    overwrite
+        Forwarded as the ``overwrite`` body field; only meaningful with
+        ``spec``. Defaults to ``False`` (409 on clash, surfaced as
+        :class:`InSifBrokerError`).
+    base_url
+        Override ``SAC_LISTEN_BASE_URL``. Tests pass an in-process URL;
+        production passes ``None`` so the env-injected value wins.
+    bearer
+        Override ``SAC_LISTEN_BEARER``. Tests pass an explicit value or
+        ``""`` to force the unauthenticated branch; production passes
+        ``None``.
+    timeout_s
+        Per-request HTTP timeout (seconds). Defaults to 30 — long
+        enough for the host's ``sac agent start`` subprocess to return
+        on a healthy box.
+    opener
+        Optional ``urllib.request.urlopen``-shaped callable. The
+        in-SIF integration tests pass a fake opener so the wire shape
+        is exercised without an actual network round-trip.
+
+    Returns
+    -------
+    dict
+        The host's parsed JSON body on 2xx — the ``agents_start``
+        handler returns ``{name, returncode, stdout, stderr}``. The
+        caller can branch on ``returncode``; ``returncode != 0`` means
+        the gate passed but the host-side ``sac agent start`` itself
+        failed (e.g. a spec validation error on the host).
+
+    Raises
+    ------
+    InSifBrokerError
+        On missing base URL, transport failure, non-2xx HTTP status
+        (including 403 ACL deny), or malformed response body.
+    """
+    # Local import — the spawn-client module is small and stdlib-only,
+    # but routing the import through here keeps the module-level
+    # surface lean and avoids a cycle if the spawn client ever grows
+    # back-references to lifecycle modules.
+    from ._spawn_client import SpawnRequestError, request_spawn
+
+    try:
+        return request_spawn(
+            child_name,
+            caller=caller,
+            spec=spec,
+            overwrite=overwrite,
+            base_url=base_url,
+            bearer=bearer,
+            timeout_s=timeout_s,
+            opener=opener,
+        )
+    except SpawnRequestError as exc:
+        # Re-throw under the broker's own error type so the integration
+        # point in :func:`agent_start` catches one type instead of two.
+        # Status + body are preserved verbatim — the operator-facing
+        # message in the spawn client already names ``SAC_LISTEN_BASE_URL``
+        # when relevant, so the fail-loud invariant carries through.
+        logger.warning(
+            "in-SIF broker spawn of %r failed: %s (status=%s)",
+            child_name,
+            exc,
+            exc.status,
+        )
+        raise InSifBrokerError(str(exc), status=exc.status, body=exc.body) from exc
+
+
+def maybe_broker_in_sif_spawn(
+    name: str,
+    *,
+    dry_run: bool,
+    opener: Callable | None = None,
+) -> bool:
+    """Single-call broker chokepoint for the in-SIF redirect in agent_start.
+
+    Encodes the full operator-mandated SAC-from-SAC dispatch contract so
+    the integration point in :func:`_lifecycle._start.agent_start` stays
+    a one-liner. Behaviour:
+
+    * Not in a SIF, or ``dry_run`` — returns ``False`` (caller continues
+      with the existing local flow). ``--dry-run`` is for inspecting the
+      planned LOCAL workspace argv / files, never the host's — so we
+      leave it alone.
+    * In a SIF — POSTs the spawn RPC to host listen via
+      :func:`broker_start_to_host`. On host-accepted + ``returncode==0``
+      returns ``True`` (caller MUST return True and skip the local
+      runtime). On host-accepted + ``returncode!=0``, raises
+      :class:`RuntimeError` with the host's response embedded. On any
+      transport / 4xx / 5xx failure, the underlying
+      :class:`InSifBrokerError` propagates unchanged.
+
+    Fail-loud invariants:
+      * Missing ``SAC_LISTEN_BASE_URL`` → :class:`InSifBrokerError`
+        (apptainer runtime forgot to inject it; never silently skip).
+      * Host listen 4xx / 5xx / transport error → :class:`InSifBrokerError`
+        carrying status + body verbatim.
+      * Host accepted the request but ``sac agent start`` itself failed
+        → :class:`RuntimeError` naming the agent and returncode, with
+        the full host response in the message for debug-without-ssh.
+    """
+    if dry_run or not is_in_sif():
+        return False
+
+    result = broker_start_to_host(name, opener=opener)
+    rc = result.get("returncode") if isinstance(result, dict) else None
+    if rc != 0:
+        raise RuntimeError(
+            f"sac-from-sac broker: host listen accepted the spawn of "
+            f"{name!r} but `sac agent start` on the host failed "
+            f"(returncode={rc}). Host response: {result!r}"
+        )
+    return True

--- a/src/scitex_agent_container/_lifecycle/_start.py
+++ b/src/scitex_agent_container/_lifecycle/_start.py
@@ -190,6 +190,7 @@ def agent_start(
     thread_factory: Callable[..., Any] = threading.Thread,
     handover_mod: Any = None,
     liveness_verifier: Callable[[AgentConfig, Any], bool] | None = None,
+    in_sif_opener: Optional[Callable[..., Any]] = None,
 ) -> bool:
     """Start an agent from its config YAML.
 
@@ -223,6 +224,18 @@ def agent_start(
     config_path = resolve_config(config_path)
     registry = registry or Registry()
     config = load_config(config_path)
+
+    # SAC-from-SAC broker (operator-mandated 2026-06-01). When running
+    # INSIDE an apptainer SIF, apptainer-in-apptainer is unsupported on
+    # the deployment shape we target — POST the spawn to bare-host
+    # ``sac listen`` instead. The host re-runs ``check_spawn`` + records
+    # lineage + shells the real ``sac agent start``. Bypassed on
+    # dry-run (dry-run inspects the LOCAL planned workspace). Fail-loud
+    # contract lives in :func:`_in_sif_broker.maybe_broker_in_sif_spawn`.
+    from ._in_sif_broker import maybe_broker_in_sif_spawn
+
+    if maybe_broker_in_sif_spawn(config.name, dry_run=dry_run, opener=in_sif_opener):
+        return True
 
     # Launch-time LOCAL spec-source drift check. Verifies the git repo
     # backing this spec.yaml (on these hosts ``~/.scitex/agent-container/

--- a/src/scitex_agent_container/_listen/_agent_exec.py
+++ b/src/scitex_agent_container/_listen/_agent_exec.py
@@ -310,9 +310,17 @@ async def agents_start(request: Request) -> JSONResponse:
             return JSONResponse({"error": str(exc)}, status_code=409)
 
     sac_bin = shutil.which("sac") or "sac"
+    # ``agents`` (plural) is the canonical command group; the singular
+    # ``agent`` form was removed in the F-CS13 rename and the host CLI
+    # no longer exposes it (verified 2026-06-01 by the SAC-from-SAC
+    # live test: the singular form returned "Error: No such command
+    # 'agent'." with rc=2, breaking every brokered spawn from inside
+    # a SIF). Using the canonical plural is what every other CLI
+    # call site already does — see ``cli_pkg/fleet_group.py``
+    # ``[remote_sac, "agents", "start", name]``.
     proc = await asyncio.to_thread(
         subprocess.run,
-        [sac_bin, "agent", "start", name],
+        [sac_bin, "agents", "start", name],
         capture_output=True,
         text=True,
         check=False,

--- a/src/scitex_agent_container/_mcp/_tools/_agent.py
+++ b/src/scitex_agent_container/_mcp/_tools/_agent.py
@@ -94,13 +94,18 @@ def agent_start(name: str, foreground: bool = False) -> dict[str, Any]:
     directly.
 
     .. note::
-       Runs the CLI **inside the current container**. Inside an
-       apptainer-isolated agent that means apptainer-in-apptainer
-       (blocked on most HPCs) or a bare-runner fallback. Use
-       :func:`agent_spawn` instead to ask the bare HOST to start the
-       child via the sac-listen control plane — that path goes through
-       the server-side ACL gate and records the parent→child lineage
-       edge automatically (ADR-0010 mechanism #3).
+       In-SIF dispatch: as of the SAC-from-SAC broker (operator-
+       mandated 2026-06-01), an ``agent_start`` call from inside an
+       apptainer SIF (``APPTAINER_CONTAINER`` / ``SINGULARITY_CONTAINER``
+       set) auto-redirects to the host-side ``sac listen`` control
+       plane via :mod:`_lifecycle._in_sif_broker`. The host re-runs
+       ``check_spawn``, records the parent→child lineage edge, and
+       shells the real ``sac agent start`` against the bare host's
+       apptainer. On the bare host the local lifecycle is unchanged.
+       Use :func:`agent_spawn` when you need to pass an *inline*
+       spec dict (the host materialises it) or to be explicit about
+       broker semantics in a hybrid script that might also run on
+       the bare host.
     """
     argv = ["agents", "start", name]
     if foreground:
@@ -157,9 +162,7 @@ def agent_spawn(
     from ..._lifecycle._spawn_client import SpawnRequestError, request_spawn
 
     try:
-        result = request_spawn(
-            name, caller=caller, spec=spec, overwrite=overwrite
-        )
+        result = request_spawn(name, caller=caller, spec=spec, overwrite=overwrite)
     except SpawnRequestError as exc:
         return {
             "status": "error",

--- a/src/scitex_agent_container/_skills/scitex-agent-container/20_env-vars.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/20_env-vars.md
@@ -126,6 +126,26 @@ fails on hub absence.
 Downstream fleet implementations (e.g. scitex-orochi) own their own env
 namespace; sac does not read fleet-specific vars directly.
 
+## Host listen — SAC-from-SAC broker
+
+When an agent runs INSIDE an apptainer SIF, ``sac agents start <child>``
+cannot ``apptainer exec`` locally (no nested apptainer on the supported
+HPC shape). The runtime injects the bare-host ``sac listen`` address +
+bearer into every container so the in-SIF CLI can POST the spawn RPC to
+the host instead; the host re-runs ``check_spawn``, records the
+``caller → child`` lineage edge, and shells the real ``sac agent
+start`` against the bare host's apptainer.
+
+| Variable | Purpose | Default | Type |
+|---|---|---|---|
+| `SAC_LISTEN_BASE_URL` | Host-stable ``sac listen`` base URL the in-SIF CLI POSTs spawn requests against (also used by the in-container channel adapter to subscribe to the bus). Auto-injected by the apptainer runtime from ``listen.host`` / ``listen.port`` in ``~/.scitex/agent-container/config.yaml``. | `http://127.0.0.1:7878` | URL |
+| `SAC_LISTEN_BEARER` | Bearer token presented as ``Authorization: Bearer ...`` to the host listen server. Auto-injected from the host's bearer-token file; required when ``server:sac`` is in ``spec.claude.channels`` (the runtime fails loud at launch otherwise). | `—` | string |
+
+Fail-loud: when the broker runs in a SIF and ``SAC_LISTEN_BASE_URL`` is
+unset, ``sac agents start`` raises ``InSifBrokerError`` (apptainer
+runtime forgot to inject it). Never silently downgrades to "skip the
+broker" / "try local apptainer anyway".
+
 ## Feature flags
 
 - **opt-out:** `SAC_COMPACT_ENABLED=false` disables context compaction.

--- a/tests/scitex_agent_container/_lifecycle/test__in_sif_broker.py
+++ b/tests/scitex_agent_container/_lifecycle/test__in_sif_broker.py
@@ -26,19 +26,18 @@ markers (TQ002), one assertion (TQ007), 3+-word name.
 
 from __future__ import annotations
 
-import io
 import json
 import os
 from pathlib import Path
 from typing import Any, Iterator
 
 import pytest
+
 from scitex_agent_container._lifecycle._in_sif_broker import (
     InSifBrokerError,
     broker_start_to_host,
     is_in_sif,
 )
-
 from scitex_agent_container._lifecycle._start import agent_start
 from scitex_agent_container._state import state_db
 from scitex_agent_container._state.registry import Registry

--- a/tests/scitex_agent_container/_lifecycle/test__in_sif_broker.py
+++ b/tests/scitex_agent_container/_lifecycle/test__in_sif_broker.py
@@ -1,0 +1,464 @@
+"""SAC-from-SAC broker — in-SIF detection + host-listen spawn POST.
+
+When ``sac agents start <child>`` runs INSIDE an apptainer SIF, the
+runtime cannot exec ``apptainer`` locally (no nested apptainer on most
+HPCs). The fix is to detect the in-SIF condition early in
+``agent_start`` and POST the spawn RPC to the host-side ``sac listen``
+server instead — the host has ``apptainer`` and owns container
+lifecycle (operator-mandated 2026-06-01).
+
+This module tests two collaborators:
+
+* :func:`_in_sif_broker.is_in_sif` — pure env-detection.
+* :func:`_in_sif_broker.broker_start_to_host` — POSTs to host listen
+  via the existing :mod:`_spawn_client` (same wire as ``agent_spawn``).
+
+And the integration point:
+
+* :func:`agent_start` in-SIF redirects to the broker BEFORE any runtime
+  / drift / rotation / ACL work runs locally; not-in-SIF path is
+  unchanged (regression guard).
+
+NO MOCKS — the spawn-client opener seam is the real injection surface
+(:mod:`test__spawn_client` uses it the same way). Each test: AAA
+markers (TQ002), one assertion (TQ007), 3+-word name.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+from pathlib import Path
+from typing import Any, Iterator
+
+import pytest
+from scitex_agent_container._lifecycle._in_sif_broker import (
+    InSifBrokerError,
+    broker_start_to_host,
+    is_in_sif,
+)
+
+from scitex_agent_container._lifecycle._start import agent_start
+from scitex_agent_container._state import state_db
+from scitex_agent_container._state.registry import Registry
+from scitex_agent_container.config import AgentConfig
+
+# ---------------------------------------------------------------------------
+# Real (non-mock) fake response + opener (urllib protocol)
+# ---------------------------------------------------------------------------
+
+
+class _FakeResp:
+    def __init__(self, body: bytes, status: int = 200) -> None:
+        self._body = body
+        self.status = status
+
+    def __enter__(self) -> "_FakeResp":
+        return self
+
+    def __exit__(self, *args: object) -> bool:
+        return False
+
+    def read(self) -> bytes:
+        return self._body
+
+
+def _opener_returning(body: bytes, status: int = 200):
+    captured: dict = {}
+
+    def opener(req, timeout=None):
+        captured["url"] = req.full_url
+        captured["method"] = req.get_method()
+        captured["body"] = req.data
+        captured["headers"] = {k.lower(): v for k, v in dict(req.headers).items()}
+        captured["timeout"] = timeout
+        return _FakeResp(body, status)
+
+    return opener, captured
+
+
+# ---------------------------------------------------------------------------
+# Env fixtures — toggle the in-SIF env vars + the listen base URL
+# ---------------------------------------------------------------------------
+
+
+_SIF_KEYS = ("APPTAINER_CONTAINER", "SINGULARITY_CONTAINER")
+_LISTEN_KEYS = (
+    "SAC_LISTEN_BASE_URL",
+    "SCITEX_AGENT_CONTAINER_LISTEN_BASE_URL",
+    "SAC_LISTEN_BEARER",
+    "SCITEX_AGENT_CONTAINER_LISTEN_BEARER",
+    "SAC_NAME",
+    "SCITEX_AGENT_CONTAINER_NAME",
+)
+
+
+@pytest.fixture
+def sif_env() -> Iterator[Any]:
+    """Yield a setter for the in-SIF env vars (both apptainer + singularity)."""
+    saved = {k: os.environ.get(k) for k in _SIF_KEYS}
+    for k in _SIF_KEYS:
+        os.environ.pop(k, None)
+
+    def _set(value: str | None, *, key: str = "APPTAINER_CONTAINER") -> None:
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
+
+    try:
+        yield _set
+    finally:
+        for k, prev in saved.items():
+            if prev is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = prev
+
+
+@pytest.fixture
+def listen_env() -> Iterator[Any]:
+    """Yield a setter for SAC_LISTEN_* + SAC_NAME (mirrors test__spawn_client)."""
+    saved = {k: os.environ.get(k) for k in _LISTEN_KEYS}
+    for k in _LISTEN_KEYS:
+        os.environ.pop(k, None)
+
+    def _set(suffix: str, value: str | None) -> None:
+        short = f"SAC_{suffix}"
+        long_ = f"SCITEX_AGENT_CONTAINER_{suffix}"
+        os.environ.pop(long_, None)
+        if value is None:
+            os.environ.pop(short, None)
+        else:
+            os.environ[short] = value
+
+    try:
+        yield _set
+    finally:
+        for k in _LISTEN_KEYS:
+            os.environ.pop(k, None)
+        for k, prev in saved.items():
+            if prev is not None:
+                os.environ[k] = prev
+
+
+# ---------------------------------------------------------------------------
+# is_in_sif — pure env detection
+# ---------------------------------------------------------------------------
+
+
+def test_is_in_sif_true_when_apptainer_container_env_set(sif_env) -> None:
+    # Arrange — apptainer auto-sets APPTAINER_CONTAINER to the SIF path.
+    sif_env("/path/to/agent.sif", key="APPTAINER_CONTAINER")
+    # Act
+    detected = is_in_sif()
+    # Assert
+    assert detected is True
+
+
+def test_is_in_sif_true_when_singularity_container_env_set(sif_env) -> None:
+    # Arrange — legacy singularity name; the runtime must honour both.
+    sif_env("/path/to/agent.sif", key="SINGULARITY_CONTAINER")
+    # Act
+    detected = is_in_sif()
+    # Assert
+    assert detected is True
+
+
+def test_is_in_sif_false_when_both_env_vars_unset(sif_env) -> None:
+    # Arrange — neither var set → bare host.
+    sif_env(None, key="APPTAINER_CONTAINER")
+    sif_env(None, key="SINGULARITY_CONTAINER")
+    # Act
+    detected = is_in_sif()
+    # Assert
+    assert detected is False
+
+
+def test_is_in_sif_false_when_apptainer_container_empty_string(sif_env) -> None:
+    # Arrange — defensive: an explicit empty string is still "not in SIF".
+    sif_env("", key="APPTAINER_CONTAINER")
+    # Act
+    detected = is_in_sif()
+    # Assert
+    assert detected is False
+
+
+# ---------------------------------------------------------------------------
+# broker_start_to_host — POST shape via the spawn_client opener seam
+# ---------------------------------------------------------------------------
+
+
+def test_broker_posts_to_agents_route_on_host_listen(listen_env) -> None:
+    # Arrange
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    opener, captured = _opener_returning(b'{"name":"child","returncode":0}')
+    # Act
+    broker_start_to_host("child", opener=opener)
+    # Assert
+    assert captured["url"] == "http://host:9100/agents"
+
+
+def test_broker_uses_http_post_method(listen_env) -> None:
+    # Arrange
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    opener, captured = _opener_returning(b'{"name":"child","returncode":0}')
+    # Act
+    broker_start_to_host("child", opener=opener)
+    # Assert
+    assert captured["method"] == "POST"
+
+
+def test_broker_body_includes_child_name(listen_env) -> None:
+    # Arrange
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    opener, captured = _opener_returning(b'{"name":"child","returncode":0}')
+    # Act
+    broker_start_to_host("child", opener=opener)
+    # Assert
+    assert json.loads(captured["body"])["name"] == "child"
+
+
+def test_broker_forwards_sac_name_as_caller(listen_env) -> None:
+    # Arrange — SAC_NAME identifies the parent inside the SIF.
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    listen_env("NAME", "parent-bot")
+    opener, captured = _opener_returning(b'{"name":"child","returncode":0}')
+    # Act
+    broker_start_to_host("child", opener=opener)
+    # Assert
+    assert json.loads(captured["body"])["caller"] == "parent-bot"
+
+
+def test_broker_forwards_bearer_token_when_set(listen_env) -> None:
+    # Arrange — runtime injects the bus bearer alongside the base URL.
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    listen_env("LISTEN_BEARER", "tok-abc")
+    opener, captured = _opener_returning(b'{"name":"child","returncode":0}')
+    # Act
+    broker_start_to_host("child", opener=opener)
+    # Assert
+    assert captured["headers"].get("authorization") == "Bearer tok-abc"
+
+
+def test_broker_returns_server_returncode_on_success(listen_env) -> None:
+    # Arrange — the server's agents_start handler returns rc=0 on success.
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    opener, _ = _opener_returning(b'{"name":"child","returncode":0,"stdout":"ok"}')
+    # Act
+    result = broker_start_to_host("child", opener=opener)
+    # Assert
+    assert result["returncode"] == 0
+
+
+def test_broker_raises_when_listen_base_url_missing(listen_env) -> None:
+    # Arrange — runtime forgot to inject SAC_LISTEN_BASE_URL.
+    listen_env("LISTEN_BASE_URL", None)
+    raised = False
+    msg = ""
+    # Act
+    try:
+        broker_start_to_host(
+            "child", opener=lambda req, timeout=None: _FakeResp(b"", 200)
+        )
+    except InSifBrokerError as exc:
+        raised = True
+        msg = str(exc)
+    # Assert — fail-loud with the env var name (operator can find the gap).
+    assert raised is True and "SAC_LISTEN_BASE_URL" in msg
+
+
+def test_broker_raises_on_host_listen_acl_deny(listen_env) -> None:
+    # Arrange — host listen rejects with 403 (child caller, root-only policy).
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    listen_env("NAME", "worker-a")
+    opener, _ = _opener_returning(b'{"error":"spawn denied"}', status=403)
+    raised_status = None
+    # Act
+    try:
+        broker_start_to_host("child", opener=opener)
+    except InSifBrokerError as exc:
+        raised_status = exc.status
+    # Assert — 403 surfaces verbatim, never silently swallowed.
+    assert raised_status == 403
+
+
+# ---------------------------------------------------------------------------
+# agent_start integration — in-SIF detection redirects to broker
+# ---------------------------------------------------------------------------
+
+
+class _RuntimeRecorder:
+    """Honest fake runtime — records whether start() was called.
+
+    The whole point of the in-SIF redirect is that we MUST NOT touch a
+    runtime when we are inside a SIF. This recorder makes that
+    observable without mocks.
+    """
+
+    def __init__(self) -> None:
+        self.start_called = False
+
+    def is_running(self, config: AgentConfig) -> bool:
+        return False
+
+    def start(self, config: AgentConfig, **kwargs: Any) -> bool:
+        self.start_called = True
+        return True
+
+
+class _FakeHandover:
+    def ensure_instance_uuid(self, config: AgentConfig) -> str:
+        return "uuid"
+
+    def hydrate_from_hub(self, config: AgentConfig) -> bool:
+        return True
+
+    def start_failback_poller(self, config: AgentConfig) -> None:
+        pass
+
+
+@pytest.fixture
+def isolated_state(tmp_path: Path) -> Iterator[Path]:
+    """Real isolated state.db + runtime dir + HOME (mirrors test__start_spawn_acl)."""
+    db = tmp_path / "state.db"
+    runtime_dir = tmp_path / "runtime"
+    home = tmp_path / "home"
+    home.mkdir()
+    keys = {
+        "SCITEX_AGENT_CONTAINER_STATE_DB": str(db),
+        "SCITEX_AGENT_CONTAINER_RUNTIME_DIR": str(runtime_dir),
+        "HOME": str(home),
+        "SCITEX_DIR": str(home / ".scitex"),
+    }
+    saved = {k: os.environ.get(k) for k in keys}
+    saved_default = state_db.DEFAULT_DB_PATH
+    os.environ.update(keys)
+    state_db.DEFAULT_DB_PATH = db
+    state_db.init_schema(db)
+    try:
+        yield db
+    finally:
+        state_db.DEFAULT_DB_PATH = saved_default
+        for k, prev in saved.items():
+            if prev is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = prev
+
+
+def _write_spec(yaml_root: Path, name: str) -> Path:
+    agent_dir = yaml_root / name
+    agent_dir.mkdir(parents=True)
+    spec = agent_dir / "spec.yaml"
+    spec.write_text(
+        "apiVersion: scitex-agent-container/v3\n"
+        "kind: Agent\n"
+        "spec:\n"
+        "  runtime: apptainer\n"
+        f"  workdir: {yaml_root / (name + '-work')}\n"
+        "  claude:\n"
+        "    model: sonnet\n"
+        "  health:\n"
+        "    enabled: false\n"
+    )
+    return spec
+
+
+def test_agent_start_in_sif_skips_local_runtime_start(
+    isolated_state, sif_env, listen_env, tmp_path
+) -> None:
+    # Arrange — inside a SIF; the broker takes over BEFORE any runtime work.
+    sif_env("/path/to/agent.sif", key="APPTAINER_CONTAINER")
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    spec = _write_spec(tmp_path / "yaml", "capsule-child")
+    recorder = _RuntimeRecorder()
+    opener, _ = _opener_returning(b'{"name":"capsule-child","returncode":0}')
+    # Act — opener seam is injected via _in_sif_broker_opener kwarg (real seam).
+    agent_start(
+        str(spec),
+        registry=Registry(registry_dir=tmp_path / "reg"),
+        runtime_factory=lambda _c: recorder,
+        handover_mod=_FakeHandover(),
+        sleep_fn=lambda _s: None,
+        in_sif_opener=opener,
+    )
+    # Assert — runtime.start() was NEVER called; the broker took over.
+    assert recorder.start_called is False
+
+
+def test_agent_start_in_sif_posts_to_host_listen(
+    isolated_state, sif_env, listen_env, tmp_path
+) -> None:
+    # Arrange — confirms the redirect actually POSTs to /agents on the host.
+    sif_env("/path/to/agent.sif", key="APPTAINER_CONTAINER")
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    listen_env("NAME", "parent-root")
+    spec = _write_spec(tmp_path / "yaml", "capsule-child")
+    opener, captured = _opener_returning(b'{"name":"capsule-child","returncode":0}')
+    # Act
+    agent_start(
+        str(spec),
+        registry=Registry(registry_dir=tmp_path / "reg"),
+        runtime_factory=lambda _c: _RuntimeRecorder(),
+        handover_mod=_FakeHandover(),
+        sleep_fn=lambda _s: None,
+        in_sif_opener=opener,
+    )
+    # Assert — exactly one POST to /agents with the child name in the body.
+    body = json.loads(captured["body"])
+    assert (
+        captured["url"] == "http://host:9100/agents" and body["name"] == "capsule-child"
+    )
+
+
+def test_agent_start_in_sif_raises_when_listen_url_missing(
+    isolated_state, sif_env, listen_env, tmp_path
+) -> None:
+    # Arrange — in-SIF but the runtime forgot to inject SAC_LISTEN_BASE_URL.
+    sif_env("/path/to/agent.sif", key="APPTAINER_CONTAINER")
+    listen_env("LISTEN_BASE_URL", None)
+    spec = _write_spec(tmp_path / "yaml", "capsule-child")
+    raised_msg = ""
+    # Act
+    try:
+        agent_start(
+            str(spec),
+            registry=Registry(registry_dir=tmp_path / "reg"),
+            runtime_factory=lambda _c: _RuntimeRecorder(),
+            handover_mod=_FakeHandover(),
+            sleep_fn=lambda _s: None,
+            in_sif_opener=lambda req, timeout=None: _FakeResp(b"", 200),
+        )
+    except InSifBrokerError as exc:
+        raised_msg = str(exc)
+    # Assert — fail-loud names the missing env var so the operator can fix.
+    assert "SAC_LISTEN_BASE_URL" in raised_msg
+
+
+def test_agent_start_not_in_sif_uses_local_runtime(
+    isolated_state, sif_env, listen_env, tmp_path
+) -> None:
+    # Arrange — NO in-SIF env vars set → regression guard: local flow intact.
+    sif_env(None, key="APPTAINER_CONTAINER")
+    sif_env(None, key="SINGULARITY_CONTAINER")
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    spec = _write_spec(tmp_path / "yaml", "capsule-child")
+    recorder = _RuntimeRecorder()
+
+    # Opener that EXPLODES if called → proves the broker was NOT taken.
+    def _exploding_opener(req, timeout=None):
+        raise AssertionError("broker must not run when not in SIF")
+
+    # Act
+    agent_start(
+        str(spec),
+        registry=Registry(registry_dir=tmp_path / "reg"),
+        runtime_factory=lambda _c: recorder,
+        handover_mod=_FakeHandover(),
+        sleep_fn=lambda _s: None,
+        in_sif_opener=_exploding_opener,
+    )
+    # Assert — runtime.start() WAS called; broker not invoked.
+    assert recorder.start_called is True

--- a/tests/scitex_agent_container/_listen/test__agent_exec_subprocess.py
+++ b/tests/scitex_agent_container/_listen/test__agent_exec_subprocess.py
@@ -1,0 +1,114 @@
+"""Listen-side ``agents_start`` handler shells the canonical CLI argv.
+
+Regression test for the singular-vs-plural bug exposed by the
+SAC-from-SAC live test (operator-mandated 2026-06-01): the handler in
+:mod:`_listen._agent_exec` used to shell ``["sac", "agent", "start",
+name]`` (singular ``agent``), but the F-CS13 rename removed the
+singular group — the host's ``sac`` binary now responds with
+``Error: No such command 'agent'.`` and exits non-zero. That single
+character broke every brokered spawn end-to-end.
+
+The fix is one token (``agent`` → ``agents``). This test pins the argv
+shape so the regression cannot return silently: a future refactor that
+flips the form back to singular will fail here, not at 3am when an
+in-SIF agent tries to spawn a child and the host listen returns 502.
+
+NO MOCKS — uses the :func:`subprocess_shim` helper from the package
+conftest. A real fake ``sac`` binary is dropped on ``$PATH``; the
+handler's real ``shutil.which("sac")`` resolves to the shim; the shim
+records its argv; the test reads the argv back. This is the same
+no-mocks pattern :mod:`tests/scitex_agent_container/cli_pkg/lifecycle`
+already uses.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+from starlette.testclient import TestClient
+
+from scitex_agent_container._listen.server import create_app
+from scitex_agent_container._runners import _session_state as _ss
+from scitex_agent_container._state import registry as _reg
+from scitex_agent_container._state import state_db
+
+_TOKEN = "test-token-agent-exec"
+
+
+@pytest.fixture
+def isolated_listen_env(tmp_path: Path):
+    """Isolated state.db + registry/runtime dirs (mirrors test__acl.py shape)."""
+    db = tmp_path / "state.db"
+    saved_env_db = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB")
+    saved_default_db = state_db.DEFAULT_DB_PATH
+    saved_home = os.environ.get("HOME")
+    saved_reg_const = _reg.REGISTRY_DIR
+    saved_state_const = _ss.DEFAULT_STATE_ROOT
+    os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
+    state_db.DEFAULT_DB_PATH = db
+    state_db.init_schema(db)
+    os.environ["HOME"] = str(tmp_path)
+    _reg.REGISTRY_DIR = tmp_path / "registry"
+    _ss.DEFAULT_STATE_ROOT = tmp_path / "runtime"
+    try:
+        yield tmp_path
+    finally:
+        state_db.DEFAULT_DB_PATH = saved_default_db
+        _reg.REGISTRY_DIR = saved_reg_const
+        _ss.DEFAULT_STATE_ROOT = saved_state_const
+        if saved_env_db is None:
+            os.environ.pop("SCITEX_AGENT_CONTAINER_STATE_DB", None)
+        else:
+            os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = saved_env_db
+        if saved_home is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = saved_home
+
+
+def test_agents_start_shells_plural_agents_form(
+    isolated_listen_env, subprocess_shim
+) -> None:
+    """The handler MUST shell ``["sac", "agents", "start", <name>]``.
+
+    The singular ``"agent"`` form was removed in F-CS13; using it here
+    makes the host's CLI exit non-zero with "No such command 'agent'",
+    which manifests as a 502 from every brokered SAC-from-SAC spawn.
+    """
+    # Arrange — drop a fake ``sac`` on PATH that records its argv.
+    subprocess_shim.install("sac", stdout="ok", exit=0)
+    app = create_app(token=_TOKEN)
+    # Act — admin spawn (no caller) so the gate trivially allows and we
+    # reach the subprocess shell-out. Body is the minimum the handler
+    # accepts.
+    with TestClient(app) as client:
+        client.post(
+            "/agents",
+            json={"name": "broker-child"},
+            headers={"authorization": f"Bearer {_TOKEN}"},
+        )
+    argv = subprocess_shim.argv_for("sac")
+    # Assert — the canonical PLURAL form. A regression to singular
+    # (``"agent"``) would fail here loudly.
+    assert argv == ["agents", "start", "broker-child"], argv
+
+
+def test_agents_start_does_not_use_singular_agent_form(
+    isolated_listen_env, subprocess_shim
+) -> None:
+    """Explicit negative — the buggy singular form must NOT recur."""
+    # Arrange
+    subprocess_shim.install("sac", stdout="ok", exit=0)
+    app = create_app(token=_TOKEN)
+    # Act
+    with TestClient(app) as client:
+        client.post(
+            "/agents",
+            json={"name": "broker-child"},
+            headers={"authorization": f"Bearer {_TOKEN}"},
+        )
+    argv = subprocess_shim.argv_for("sac")
+    # Assert — single-token regression guard.
+    assert argv is not None and argv[0] != "agent", argv

--- a/tests/scitex_agent_container/a2a/test__handlers.py
+++ b/tests/scitex_agent_container/a2a/test__handlers.py
@@ -472,41 +472,32 @@ def test_claude_session_missing_sdk_raises_handler_error(
         invoke()
 
 
-@pytest.mark.skipif(
-    not _has_anthropic_creds(),
-    reason=(
-        "build_sdk_options fails earlier with auth-missing when no "
-        "Anthropic credentials available (CI runners). Set "
-        "SAC_ANTHROPIC_API_KEY or run `claude /login` to enable."
-    ),
-)
-def test_claude_session_channels_without_port_raises_handler_error(
-    isolated_env: Path,
-) -> None:
-    """``server:sac`` channel with no a2a_port drives a real SDK turn that fails.
-
-    With Anthropic creds present, ``build_sdk_options`` succeeds (it does
-    NOT validate a2a_port — see runtimes/_sdk_common.py:439-508, where a
-    missing port merely omits the sidecar ``--turn-url``). Control then
-    reaches the REAL ``claude-agent-sdk`` turn via ``query()``. That turn
-    cannot satisfy ``--dangerously-load-development-channels server:sac`` in
-    this minimal headless context, so the handler's broad ``except Exception``
-    re-raises as :class:`HandlerError`. The exact message is
-    non-deterministic across runs (live SDK error vs. per-call timeout), so
-    we assert only on the type — the stable contract is "this misconfiguration
-    is rejected, loudly". No mocks: a genuine ``build_sdk_options`` +
-    ``query()`` round-trip.
-    """
-    # Arrange
-    call = lambda: h.handle_claude_session(
-        "never-registered-agent", "hi", channels=["server:sac"], a2a_port=None
-    )
-    raises_ctx = pytest.raises(h.HandlerError)
-    # Act
-    invoke = lambda: call()
-    # Assert
-    with raises_ctx:
-        invoke()
+# Removed (2026-06-01): ``test_claude_session_channels_without_port_
+# raises_handler_error`` asserted that ``channels=["server:sac"]`` +
+# ``a2a_port=None`` would cause the live SDK turn to error out. The
+# premise has drifted out from under the test:
+#
+#   * The handler comment at lines 161-165 of
+#     ``src/scitex_agent_container/a2a/_handlers.py`` documents that
+#     ``server:sac`` subscribes to the BUS (``sac listen``, resolved
+#     from ``SAC_LISTEN_BASE_URL``) — NOT to the agent's own a2a_port.
+#     The two are unrelated: a2a_port is forwarded only so the SDK can
+#     register ``/v1/turn``. So the combination "server:sac + no
+#     a2a_port" is a *valid* configuration, not a misconfiguration.
+#   * Current ``claude-agent-sdk`` accepts the
+#     ``--dangerously-load-development-channels server:sac`` argument
+#     and completes the turn happily (verified by direct invocation:
+#     ``handle_claude_session("never-registered-agent", "hi",
+#     channels=["server:sac"], a2a_port=None)`` returns "Hi! How can
+#     I help you today?" rather than raising).
+#
+# Keeping the test would assert a contract that no longer holds. The
+# ``SDKCommonError → HandlerError`` translation path it was meant to
+# exercise is already covered by
+# ``test_claude_session_propagates_sdk_common_error_as_handler_error``
+# above; the ``except Exception → HandlerError`` re-raise is covered
+# by ``test_claude_session_missing_sdk_raises_handler_error``. No
+# observable behaviour goes untested by this removal.
 
 
 def test_claude_session_reads_model_env_for_options(isolated_env: Path) -> None:

--- a/tests/scitex_agent_container/conftest.py
+++ b/tests/scitex_agent_container/conftest.py
@@ -1,0 +1,82 @@
+"""Package-wide test conftest — neutralise production-env pollution.
+
+The test process itself runs inside the proj-scitex-agent-container
+apptainer SIF (the dev / agent runtime ships pre-built). Production-
+intended env vars (``APPTAINER_CONTAINER`` for in-SIF detection,
+``SCITEX_AGENT_CONTAINER_AGENT`` for the agent's own identity) are
+therefore set in the test process's env. Tests that read those vars
+expecting "bare host, no agent identity" silently pick up the running
+agent's values and fail with hard-to-debug "wrong file path" /
+"unexpected branch" errors.
+
+Two autouse fixtures here. Both yield with the polluting vars
+cleared and restore on teardown — never delete pre-existing values
+permanently. Tests that *want* the polluting var set drop it back
+themselves (e.g. ``_lifecycle/test__in_sif_broker.py::sif_env``).
+
+(1) ``_clear_in_sif_env`` — clears ``APPTAINER_CONTAINER`` /
+``SINGULARITY_CONTAINER``. Required by the SAC-from-SAC broker
+(operator-mandated 2026-06-01): every ``agent_start`` call now
+detects in-SIF and routes through the host listen instead of the
+local runtime. Without clearing here, the lifecycle tests'
+hand-rolled runtime fakes are never reached.
+
+(2) ``_clear_agent_identity`` — clears ``SCITEX_AGENT_CONTAINER_AGENT``
+/ ``SAC_AGENT``. The statusline ``_agent_name()`` reads these to
+discover which agent the running session belongs to. With the running
+agent's name leaking through, tests that set ``CLAUDE_AGENT_ID`` to
+control the persist filename end up writing to the running agent's
+file instead — assertions on the test-controlled filename then fail
+with ``FileNotFoundError``.
+
+Both fixtures cover the WHOLE package's test tree (this conftest is
+at ``tests/scitex_agent_container/``). Putting them here is simpler
+than re-implementing under every nested test dir.
+
+No production code is mutated by these fixtures; they only touch the
+test process env.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Iterator
+
+import pytest
+
+_IN_SIF_KEYS = ("APPTAINER_CONTAINER", "SINGULARITY_CONTAINER")
+_AGENT_IDENTITY_KEYS = (
+    "SCITEX_AGENT_CONTAINER_AGENT",
+    "SAC_AGENT",
+)
+
+
+def _save_restore_yield(keys: tuple[str, ...]) -> Iterator[None]:
+    """Real save / clear / yield / restore for a set of env keys."""
+    saved = {k: os.environ.get(k) for k in keys}
+    for k in keys:
+        os.environ.pop(k, None)
+    try:
+        yield
+    finally:
+        for k, prev in saved.items():
+            if prev is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = prev
+
+
+@pytest.fixture(autouse=True)
+def _clear_in_sif_env() -> Iterator[None]:
+    """Yield with in-SIF env vars cleared; restore on teardown."""
+    yield from _save_restore_yield(_IN_SIF_KEYS)
+
+
+@pytest.fixture(autouse=True)
+def _clear_agent_identity() -> Iterator[None]:
+    """Yield with ``SAC_AGENT`` / long-form cleared; restore on teardown.
+
+    Statusline + a couple of identity-keyed CLIs read this; the running
+    agent's value would otherwise win over test-controlled overrides.
+    """
+    yield from _save_restore_yield(_AGENT_IDENTITY_KEYS)


### PR DESCRIPTION
## Summary

Operator-mandated 2026-06-01: an agent running INSIDE an apptainer SIF must be able to spawn a child SAC agent on the bare host. Nested apptainer is unsupported on the supported HPC shape — `sac agents start <child>` inside a SIF must NOT exec apptainer locally, it must POST the spawn RPC to the host-side `sac listen`, which has apptainer + owns container lifecycle.

This PR adds the in-SIF detection + broker redirect in `_lifecycle._start.agent_start`, fixes a latent listen-side bug that was blocking the live test, and cleans up 8 pre-existing in-SIF env-pollution test regressions that were surfaced during verification.

## In-SIF redirect (the main feature)

- **`_lifecycle/_in_sif_broker.py`** (new) — `is_in_sif()` env detection on `APPTAINER_CONTAINER` / `SINGULARITY_CONTAINER`, `broker_start_to_host()` thin re-shape of the existing `_spawn_client.request_spawn` with its own `InSifBrokerError`, and `maybe_broker_in_sif_spawn()` single chokepoint the lifecycle calls.
- **`_lifecycle/_start.py::agent_start`** — adds `in_sif_opener` injection seam + an early `maybe_broker_in_sif_spawn` call that, when in a SIF and not `--dry-run`, POSTs to the host's `/agents` endpoint and returns. The host re-runs `check_spawn`, records the parent → child lineage edge, and shells `sac agent start <name>` against the bare host's apptainer. The local drift / rotation / ACL / runtime path is unchanged on bare host.

**Wiring contract** — reuses existing `runtimes/_apptainer_listen_env.listen_env_flags` env injection:
- `SAC_LISTEN_BASE_URL` — host listen URL the broker POSTs to
- `SAC_LISTEN_BEARER` — bearer auth token
- `SAC_NAME` — auto-resolved as the spawn caller for ACL gating

**Fail-loud invariants** — never silently downgrade (ADR-0010 / handoff §0):
- Missing `SAC_LISTEN_BASE_URL` → `InSifBrokerError` with the env var name in the message
- Transport / 4xx / 5xx / malformed body → `InSifBrokerError` carrying status + body verbatim
- Host accepted but `sac agent start` itself failed → `RuntimeError` naming the agent + returncode + host response

## Listen-side fix (latent bug, exposed by the live test)

`_listen/_agent_exec.py::agents_start` used to shell `["sac", "agent", "start", name]` (singular `agent`). The singular CLI group was removed in F-CS13; the host's binary now returns `Error: No such command 'agent'.` and exits non-zero, manifesting as a 502 from every brokered spawn. One-token fix (singular → plural) plus a regression test (`test__agent_exec_subprocess.py`) that pins the argv shape via the no-mocks `subprocess_shim` helper.

## Test hygiene — `tests/scitex_agent_container/conftest.py` (new)

Two autouse fixtures clear production-intended env vars that pollute the test process when pytest itself runs inside an agent SIF:

1. `APPTAINER_CONTAINER` / `SINGULARITY_CONTAINER` — would otherwise route every test's `agent_start` through the new broker before hand-rolled runtime fakes are reached.
2. `SCITEX_AGENT_CONTAINER_AGENT` / `SAC_AGENT` — leaked into statusline tests, made them write to the running agent's file instead of the test-controlled one.

Tests that *want* the polluting var set drop it back themselves (e.g. `test__in_sif_broker.py::sif_env`). Fixes 8 pre-existing in-SIF env regressions across `test_statusline.py` (4), `test__sdk_common.py::test_compose_sets_cwd_from_workspace` (1), and `cli_pkg/lifecycle/test__start_force_clears_session.py` (4).

Also drops `test_claude_session_channels_without_port_raises_handler_error` — its premise (`server:sac` channel + no a2a_port should make the SDK error out) no longer holds: the handler's own comment documents that `server:sac` subscribes to the BUS via `SAC_LISTEN_BASE_URL`, NOT to the a2a_port. The combination is a valid configuration; current Claude SDK completes the turn happily. The `SDKCommonError → HandlerError` and `except Exception → HandlerError` paths it was meant to cover are exercised deterministically by the two sibling tests.

## Live evidence — in-SIF broker against host listen (collected 2026-06-01)

Running INSIDE `proj-scitex-agent-container` SIF, against the host's `sac listen` on `http://127.0.0.1:7878`:

```
==> ENVIRONMENT (in-SIF detection inputs)
  APPTAINER_CONTAINER=/home/ywatanabe/.dotfiles/src/.scitex/agent-container/contai
  SINGULARITY_CONTAINER=/home/ywatanabe/.dotfiles/src/.scitex/agent-container/contai
  SAC_LISTEN_BASE_URL=http://127.0.0.1:7878
  SAC_LISTEN_BEARER=<set>
  SAC_NAME=<unset>
  is_in_sif() => True

==> broker_start_to_host("proj-scitex-todo")
  InSifBrokerError: spawn rejected: listen returned HTTP 502
  ({'name': 'proj-scitex-todo', 'returncode': 2, 'stdout': '',
    'stderr': "Error: No such command 'agent'."})
```

The 502 + `"No such command 'agent'"` confirms:
- in-SIF detection works ✓
- broker correctly POSTs to host `/agents` ✓
- bearer auth works ✓
- host listen receives + ACL gate passes + structured response returned ✓
- failure mode is **exactly** the singular `agent` → plural `agents` listen-side bug this PR also fixes ✓

**Full end-to-end ("child SAC agent RUNNING on the host") becomes available once this PR merges and the host's `sac listen` is restarted to pick up the listen-side plural fix.** I do not have host privileges to restart the production listen from inside this SIF; flagging here for the operator's restart hand-off as part of the merge ritual.

## Test plan

- [x] 16 new TDD tests for `_in_sif_broker` (`is_in_sif`, `broker_start_to_host`, `agent_start` redirect integration) — all green
- [x] 2 new regression tests for the listen-side plural fix (`test__agent_exec_subprocess.py`) — all green
- [x] All 244 `_lifecycle/` tests green
- [x] All 1626 touched-surfaces tests green (lifecycle / listen / runtimes / mcp / cli_pkg.lifecycle / _state)
- [x] Live in-SIF broker test (evidence captured above)
- [x] Full suite: **5049 passed**, 1 transient sleep-based flake (`test_export_state_filters_out_instance_rows_older_than_since_cutoff` — passes in isolation + when run with the full `_state/` dir alone (910 passed), pre-existing flake unrelated to this PR's changes)

## Backward compatibility

The bare-host code path is unchanged (`is_in_sif()` returns False outside a SIF → existing flow). Existing CI / dev workflows do not change.

## Spec key (operator request: "document the spec key")

`SAC_LISTEN_BASE_URL` is the broker URL — already wired into the apptainer runtime, documented in `_skills/scitex-agent-container/20_env-vars.md` under the new "Host listen — SAC-from-SAC broker" section.