### PR TITLE
fix(creds): :rw bind per-account snapshot directly — no boot-time copy (task #15)

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_start.py
+++ b/src/scitex_agent_container/_lifecycle/_start.py
@@ -116,10 +116,11 @@ def _rotate_to_healthy_account(
       account has a fresh snapshot → ``config.claude.account`` is
       mutated to that account and a one-line rotation notice is
       printed to ``log_stream`` (default ``sys.stderr``). The runtime
-      then re-copies that account's snapshot into the per-agent
-      writable boot-copy via the existing
-      :func:`runtimes._apptainer_creds.resolve_cred_file` path — the
-      in-container ~1h token refresh on that copy keeps working.
+      then binds that account's snapshot ``:rw`` directly via
+      :func:`runtimes._apptainer_creds.resolve_cred_file` (operator
+      #15 — the prior boot-copy path was the root cause of the
+      2026-06-01 fleet outage; refreshes now write back to the
+      snapshot itself, never expiring).
     * If NOTHING is healthy → :class:`_creds.NoHealthyAccountError`
       propagates (fail loud, no silent stale-token launch). Agent is
       NOT started.

--- a/src/scitex_agent_container/runtimes/_apptainer_auth.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_auth.py
@@ -76,13 +76,19 @@ def auth_argv(config: AgentConfig, state_dir: Path) -> list[str]:
     # refresh code-path itself is responsible for any concurrency
     # locking — the bind is just a file passthrough.
     # Per-agent OAuth account pinning (spec.claude.account). When set,
-    # we COPY that saved account's .credentials.json into the agent's
-    # own state dir (frozen boot-copy) and bind THAT — so two agents
-    # pinned to two accounts never share one mount, and a host /login
-    # never moves a pinned agent. Changing the assigned account needs
-    # a `sac agent restart` to re-copy. ``account=""`` → host live
-    # file (unchanged behaviour). Bind stays RW so the in-container
-    # CLI can refresh the OAuth token on the agent's private copy.
+    # we bind the saved account's snapshot file at
+    # ~/.scitex/agent-container/accounts/<acct>/.credentials.json
+    # directly as ``:rw`` (operator task #15). The in-container Claude
+    # CLI's ~1h OAuth refresh writes back to the SAME file every
+    # same-account agent reads from, so the snapshot is self-healing
+    # and never expires while ANY pinned agent keeps running. Different
+    # accounts have different snapshots → no cross-account interference.
+    # The prior implementation COPIED the snapshot into a per-agent
+    # state-dir; refresh writes landed on that copy, the snapshot
+    # itself drifted stale, and after ~8h every SDK turn 401'd silently
+    # (the 2026-06-01 fleet-wide outage). ``account=""`` → host live
+    # ``~/.claude/.credentials.json`` (unchanged behaviour; also RW
+    # for the same refresh-in-place reason).
     from ._apptainer_creds import resolve_cred_file
 
     cred_file = resolve_cred_file(config, state_dir)

--- a/src/scitex_agent_container/runtimes/_apptainer_creds.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_creds.py
@@ -9,27 +9,49 @@ host-side ``.credentials.json`` gets bound into an agent container:
 
 * ``spec.claude.account`` empty → the host's live
   ``~/.claude/.credentials.json`` (shared OAuth — current default).
-* ``spec.claude.account`` set → a FROZEN BOOT-COPY of that saved
-  account's snapshot, copied into the agent's own state dir so two
-  agents pinned to two accounts never fight one mount, and a host
-  ``/login`` never moves a pinned agent.
+  Bound ``:rw`` by the caller so the in-container Claude CLI's ~1h
+  OAuth refresh writes back to the host live file.
 
-The copy is bound ``:rw`` by the caller so the in-container Claude CLI
-can refresh the OAuth ``accessToken`` (~1h cadence) on the agent's
-private copy. Changing ``spec.claude.account`` only takes effect on the
-next ``sac agent restart`` (the copy happens at start).
+* ``spec.claude.account`` set → the saved account's snapshot itself at
+  ``~/.scitex/agent-container/accounts/<acct>/.credentials.json``,
+  bound ``:rw`` by the caller. Refresh writes by the in-container
+  Claude CLI land on the snapshot **directly** so the snapshot is
+  self-healing and never expires while the agent keeps running.
+
+Fix for the 2026-06-01 fleet-wide silent outage (operator task #15):
+the prior implementation COPIED the snapshot into a per-agent state-dir
+``dest`` and bound that copy. Refreshes landed on the copy; the source
+snapshot drifted stale. After ~8h, every SDK turn 401'd silently (the
+telegram bridge still marked inbound 👀, but the agent could not
+complete a turn). The fix is structural — bind the snapshot itself.
+With the ``:rw`` bind the in-container CLI keeps the snapshot fresh
+for ALL agents pinned to that account, and an agent crash/restart
+cycle no longer loses the freshly-refreshed token (it was always
+written to the snapshot, not a per-agent copy).
 
 Fail-loud (no silent fallbacks): when ``spec.claude.account`` is set
-but the pinned store is ABSENT or EXPIRED, the start aborts with
-:class:`PinnedAccountError` carrying the exact remedy. A pinned agent
-must NEVER silently fall back to the host live file (a different
-account) or run with a stale token — that would defeat the whole point
-of account pinning and hand the agent the wrong identity.
+but the pinned snapshot is ABSENT, has no numeric ``expiresAt``, or is
+ALREADY EXPIRED, the start aborts with :class:`PinnedAccountError`
+carrying the exact remedy. A pinned agent must NEVER silently fall
+back to the host live file (a different account) or run with a stale
+token — that would defeat the whole point of account pinning and hand
+the agent the wrong identity.
+
+Sharing semantics with the :rw bind:
+
+* Different accounts → different snapshot files → no conflict.
+* Same account, multiple agents → all share the SAME snapshot mount.
+  The in-container Claude CLI uses an atomic write (tmp + rename) for
+  refresh writeback, so concurrent refreshes converge on whichever
+  finishes last — the token is fungible across agents pinned to the
+  same account by definition, so a refresh by agent A is also fresh
+  for agent B. The shared-mount footgun the prior copy avoided does
+  not apply here: same-account agents share an IDENTITY, sharing the
+  file matches the model.
 """
 
 from __future__ import annotations
 
-import shutil
 import time
 from pathlib import Path
 
@@ -58,10 +80,22 @@ def resolve_cred_file(
     With no ``spec.claude.account`` set, returns the host live file
     (``None`` only when it does not exist — caller skips the bind).
 
-    With ``spec.claude.account`` set, returns a frozen boot-copy of that
-    store's snapshot. Raises :class:`PinnedAccountError` when the store
-    is absent or its credential is already expired — NEVER falls back to
-    the host live file for a pinned agent. See module docstring.
+    With ``spec.claude.account`` set, returns the per-account SNAPSHOT
+    file directly (no per-agent copy). The caller binds it ``:rw`` so
+    the in-container Claude CLI's ~1h OAuth refresh writes back to the
+    snapshot itself — the snapshot is the single source of truth for
+    every agent pinned to this account.
+
+    Raises :class:`PinnedAccountError` when the snapshot is absent, has
+    no numeric ``expiresAt``, or is already expired — NEVER falls back
+    to the host live file for a pinned agent and NEVER hands out a
+    dead token. See module docstring.
+
+    The ``state_dir`` parameter is preserved in the signature for
+    backward compatibility with the caller's existing kwarg shape
+    (``_apptainer_auth.auth_argv``); it is no longer used because the
+    resolver no longer copies the snapshot into ``state_dir``. The
+    ``now`` parameter remains a real-time injection seam for tests.
     """
     host_cred = Path.home() / ".claude" / ".credentials.json"
     acct = getattr(getattr(config, "claude", None), "account", "") or ""
@@ -100,18 +134,11 @@ def resolve_cred_file(
             f"`sac accounts sync-live`, and restart this agent."
         )
 
-    dest = Path(state_dir).expanduser() / "claude" / ".credentials.json"
-    dest.parent.mkdir(parents=True, exist_ok=True)
-    # Preserve the per-agent dest if it is already fresher than the
-    # snapshot. Without this guard, an agent restart would clobber a
-    # token the in-container Claude CLI just refreshed (on its private
-    # ``:rw`` copy) with the stale boot-time snapshot — and auth would
-    # die at the next refresh cycle. Only overwrite when dest is
-    # absent OR the snapshot's OAuth expiresAt is strictly newer.
-    dest_expiry = _read_oauth_expiry_seconds(dest) if dest.is_file() else None
-    if dest_expiry is None or expiry > dest_expiry:
-        shutil.copy2(snapshot, dest)
-    return dest
+    # Return the SNAPSHOT itself — the caller binds it ``:rw``, so the
+    # in-container Claude CLI's refresh writes land on this file
+    # directly. No per-agent copy, no stale-copy clobber risk, no
+    # auth-dies-after-8h failure mode (operator task #15).
+    return snapshot
 
 
 __all__ = ["PinnedAccountError", "resolve_cred_file"]

--- a/tests/scitex_agent_container/runtimes/test__apptainer_creds.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_creds.py
@@ -1,18 +1,22 @@
 """Tests for ``runtimes._apptainer_creds`` — per-agent OAuth resolver.
 
-Regression guard for the "boot-snapshot clobbers fresh per-agent
-token" bug that recurred fleet-wide: the in-container Claude CLI
-refreshes its OAuth ``accessToken`` (~1h cadence) directly on the
-per-agent ``:rw`` copy at ``state_dir/claude/.credentials.json``.
-Before this guard, every ``sac agent restart`` re-ran
-:func:`resolve_cred_file` and unconditionally
-``shutil.copy2(snapshot, dest)`` — silently overwriting the freshly
-refreshed token with the stale boot-time snapshot. Auth then died at
-the next refresh cycle.
+After operator task #15 (2026-06-01 fleet-wide silent outage fix), the
+pinned-account resolver returns the SNAPSHOT FILE ITSELF — not a
+boot-copy into the per-agent state-dir. The companion module
+:mod:`test__apptainer_creds_rw_bind` covers the new positive contract
+(``resolved == snapshot``, no per-agent dest is written, mid-session
+refresh writeback through the ``:rw`` bind is visible without restart).
+
+This module keeps the **safety-gate** half of the contract (preserved
+from the legacy resolver): pinned agents NEVER silently launch with
+an absent / unverifiable / already-expired token. A pinned agent that
+cannot reach a healthy snapshot must hard-error so the operator's
+remedy path (``claude /login`` + ``sac accounts sync-live`` or
+``sac accounts save``) is forced.
 
 No-mocks (PA-306): the tests drive the REAL public function with REAL
-files on disk (tmp ``$HOME``, real ``.credentials.json`` JSON bodies,
-real ``shutil.copy2``). The OAuth-expiry helper is the production
+files on disk (tmp ``$HOME``, real ``.credentials.json`` JSON bodies).
+The OAuth-expiry helper is the production
 :func:`_account.creds_sync._read_oauth_expiry_seconds`, exercised
 through the resolver — no test-side reimplementation.
 """
@@ -32,7 +36,6 @@ from scitex_agent_container.runtimes._apptainer_creds import (
     resolve_cred_file,
 )
 
-
 # ---------------------------------------------------------------------------
 # Fixtures — real $HOME, real account-store layout, real credentials JSON
 # ---------------------------------------------------------------------------
@@ -51,7 +54,7 @@ def home_redirect(tmp_path: Path, env_save_restore) -> Path:
 
 def _write_snapshot(home: Path, name: str, expires_at_seconds: float) -> Path:
     """Materialise a real saved-account snapshot at the same on-disk
-    layout ``sac account save`` writes (``~/.scitex/agent-container/
+    layout ``sac accounts save`` writes (``~/.scitex/agent-container/
     accounts/<name>/.credentials.json``) with a numeric OAuth
     ``expiresAt`` in MILLISECONDS (matching the claude-code wire
     format). Returns the snapshot path."""
@@ -68,10 +71,11 @@ def _write_snapshot(home: Path, name: str, expires_at_seconds: float) -> Path:
     return snap
 
 
-def _write_dest(state_dir: Path, expires_at_seconds: float, token: str) -> Path:
-    """Materialise a per-agent dest at the exact path the resolver
-    writes (``<state_dir>/claude/.credentials.json``) with the given
-    OAuth ``expiresAt`` (seconds, stored as milliseconds on disk)."""
+def _write_legacy_dest(state_dir: Path, expires_at_seconds: float, token: str) -> Path:
+    """Materialise a per-agent legacy dest at the exact path the OLD
+    resolver used to write (``<state_dir>/claude/.credentials.json``).
+    Used to prove the new resolver leaves leftover legacy state alone
+    rather than touching it."""
     dest = state_dir / "claude" / ".credentials.json"
     dest.parent.mkdir(parents=True, exist_ok=True)
     body = {
@@ -94,84 +98,45 @@ def _config(workdir: Path, *, account: str) -> AgentConfig:
 
 
 # ---------------------------------------------------------------------------
-# REGRESSION — fresher dest must not be clobbered by a stale snapshot
+# Safety gate — pinned snapshot must be healthy or hard-error
 # ---------------------------------------------------------------------------
 
 
-def test_fresher_dest_token_is_preserved_when_snapshot_is_older(
-    tmp_path: Path, home_redirect: Path
-) -> None:
-    # Arrange — a saved snapshot with a valid (1h-ahead) expiry and a
-    # per-agent dest that was refreshed in-container to a much-newer
-    # token (24h-ahead). This is the EXACT shape of the recurring auth
-    # bug: agent restart re-runs the resolver and (pre-fix)
-    # unconditionally copies the older snapshot over the newer dest.
-    now = time.time()
-    snapshot_expiry = now + 3_600  # +1h — valid, not expired
-    dest_expiry = now + 86_400  # +24h — much fresher (post-refresh)
-    _write_snapshot(home_redirect, "alpha", snapshot_expiry)
-    state_dir = tmp_path / "state"
-    fresh_token = "in-container-refreshed-token"
-    dest = _write_dest(state_dir, dest_expiry, token=fresh_token)
-    # Act — resolver runs at agent restart.
-    resolve_cred_file(_config(tmp_path / "wd", account="alpha"), state_dir, now=now)
-    # Assert — the per-agent dest still carries the FRESH in-container
-    # token; the resolver did NOT clobber it with the stale snapshot.
-    body = json.loads(dest.read_text())
-    assert body["claudeAiOauth"]["accessToken"] == fresh_token
-
-
-def test_missing_dest_is_populated_from_snapshot(
-    tmp_path: Path, home_redirect: Path
-) -> None:
-    # Arrange — first-ever start: no dest exists yet, snapshot is valid.
-    # (The non-existence of dest is implicit in the empty state_dir;
-    # asserting it would be a second assertion and trip TQ007.)
-    now = time.time()
-    snapshot_expiry = now + 3_600
-    snap = _write_snapshot(home_redirect, "alpha", snapshot_expiry)
-    state_dir = tmp_path / "state"
-    # Act
-    resolve_cred_file(_config(tmp_path / "wd", account="alpha"), state_dir, now=now)
-    # Assert — dest now exists with the snapshot's bytes (cold-start path).
-    dest = state_dir / "claude" / ".credentials.json"
-    assert dest.read_text() == snap.read_text()
-
-
-def test_older_dest_is_overwritten_when_snapshot_is_newer(
-    tmp_path: Path, home_redirect: Path
-) -> None:
-    # Arrange — operator just ran `sac account save alpha` with a
-    # freshly-logged-in token; the per-agent dest still holds the
-    # older pre-rotation token. On restart, the snapshot SHOULD win
-    # because it is strictly newer.
-    now = time.time()
-    snapshot_expiry = now + 86_400  # +24h — the newer one
-    dest_expiry = now + 3_600  # +1h  — older
-    snap = _write_snapshot(home_redirect, "alpha", snapshot_expiry)
-    state_dir = tmp_path / "state"
-    _write_dest(state_dir, dest_expiry, token="stale-pre-rotation-token")
-    dest = state_dir / "claude" / ".credentials.json"
-    # Act
-    resolve_cred_file(_config(tmp_path / "wd", account="alpha"), state_dir, now=now)
-    # Assert — the resolver overwrote dest with the newer snapshot.
-    assert dest.read_text() == snap.read_text()
-
-
-def test_resolver_refuses_expired_snapshot_even_with_fresh_dest(
-    tmp_path: Path, home_redirect: Path
-) -> None:
-    # Arrange — pinned-account safety is upstream of the freshness
-    # guard: an EXPIRED snapshot must hard-error (PinnedAccountError)
-    # regardless of dest state, so the operator is forced to re-login
-    # instead of the agent silently running off the per-agent copy.
+def test_resolver_refuses_expired_snapshot(tmp_path: Path, home_redirect: Path) -> None:
+    # Arrange — pinned-account safety: an EXPIRED snapshot must
+    # hard-error (PinnedAccountError) so the operator is forced to
+    # re-login instead of the agent silently running off a dead token.
     now = time.time()
     _write_snapshot(home_redirect, "alpha", now - 60)  # already expired
     state_dir = tmp_path / "state"
-    _write_dest(state_dir, now + 86_400, token="fresh-but-irrelevant")
     # Act
     # Assert — pytest.raises is the assertion (TQ007: one per test).
     with pytest.raises(PinnedAccountError, match="expired"):
-        resolve_cred_file(
-            _config(tmp_path / "wd", account="alpha"), state_dir, now=now
-        )
+        resolve_cred_file(_config(tmp_path / "wd", account="alpha"), state_dir, now=now)
+
+
+# ---------------------------------------------------------------------------
+# Legacy tolerance — leftover per-agent dest from the OLD resolver
+# must not surprise an operator. The new resolver does not WRITE to
+# the legacy dest (covered in test__apptainer_creds_rw_bind), and a
+# pre-existing dest is NEITHER read nor mutated by the resolver. The
+# bind target is the snapshot regardless of dest state.
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_dest_is_not_touched_by_resolver(
+    tmp_path: Path, home_redirect: Path
+) -> None:
+    # Arrange — operator upgrades to the :rw bind fix; the per-agent
+    # state dir still carries a stale dest from the pre-fix runtime.
+    # The new resolver must leave it ALONE — not read, not overwrite,
+    # not mutate. The bind target is the snapshot itself.
+    now = time.time()
+    _write_snapshot(home_redirect, "alpha", now + 3_600)
+    state_dir = tmp_path / "state"
+    dest = _write_legacy_dest(state_dir, now + 86_400, token="legacy-leftover")
+    dest_bytes_before = dest.read_bytes()
+    # Act
+    resolve_cred_file(_config(tmp_path / "wd", account="alpha"), state_dir, now=now)
+    # Assert — the legacy dest is byte-identical post-resolver.
+    assert dest.read_bytes() == dest_bytes_before

--- a/tests/scitex_agent_container/runtimes/test__apptainer_creds_rw_bind.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_creds_rw_bind.py
@@ -1,0 +1,239 @@
+"""Writable bind of the live per-account credential file (operator #15).
+
+Root cause of the 2026-06-01 fleet-wide silent outage (operator brief):
+agents pinned via ``spec.claude.account`` got a FROZEN BOOT-COPY of the
+saved account's snapshot in their state dir. When the in-container
+Claude CLI refreshed the OAuth ``accessToken`` (~1h cadence), the refresh
+landed on that per-agent copy — not on the source snapshot. After the
+~8h refresh-token TTL elapsed (or the per-agent copy drifted across
+restarts), every SDK turn 401'd. The telegram bridge still marked
+inbound 👀, but the agent could not complete a turn → silent. Hit hub,
+orochi, and proj-scitex-agent-container (revived only by restart).
+
+Fix (operator-approved): mount the per-account live credential file
+DIRECTLY as a ``:rw`` bind. The agent always reads the latest token AND
+OAuth refresh writes back to the same file → the source snapshot is
+self-healing and never expires while the in-container CLI keeps
+refreshing.
+
+This module is the TDD proof that the new resolver returns the
+**snapshot path itself** (not a per-agent copy), so the existing
+``:rw`` bind in :mod:`runtimes._apptainer_auth` lands on the snapshot
+and refresh writes back. The companion :mod:`test__apptainer_auth`
+asserts the bind is actually emitted as ``:rw``.
+
+NO MOCKS (PA-306): real ``$HOME`` redirect, real on-disk snapshot, real
+OAuth-expiry resolution via the production
+:func:`_account.creds_sync._read_oauth_expiry_seconds`. Each test:
+AAA markers (TQ002), one assertion (TQ007), 3+-word name.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container.config import AgentConfig
+from scitex_agent_container.config._types import ClaudeSpec
+from scitex_agent_container.runtimes._apptainer_creds import (
+    PinnedAccountError,
+    resolve_cred_file,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures + helpers (mirrors test__apptainer_creds.py shape)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def home_redirect(tmp_path: Path, env_save_restore) -> Path:
+    """Redirect ``$HOME`` so ``Path.home()`` reads from tmp_path."""
+    home = tmp_path / "home"
+    home.mkdir()
+    env_save_restore.set("HOME", str(home))
+    return home
+
+
+def _write_snapshot(
+    home: Path, name: str, expires_at_seconds: float, *, token: str = "tok"
+) -> Path:
+    """Materialise a real saved-account snapshot at the same on-disk
+    layout ``sac accounts save`` writes."""
+    acct_dir = home / ".scitex" / "agent-container" / "accounts" / name
+    acct_dir.mkdir(parents=True, exist_ok=True)
+    snap = acct_dir / ".credentials.json"
+    body = {
+        "claudeAiOauth": {
+            "accessToken": token,
+            "expiresAt": int(expires_at_seconds * 1_000),
+        }
+    }
+    snap.write_text(json.dumps(body))
+    return snap
+
+
+def _config(workdir: Path, *, account: str) -> AgentConfig:
+    return AgentConfig(
+        name="alpha",
+        runtime="apptainer",
+        workdir=str(workdir),
+        claude=ClaudeSpec(account=account),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pinned-account branch — resolver returns the LIVE snapshot path
+# ---------------------------------------------------------------------------
+
+
+def test_pinned_returns_snapshot_path_itself_not_per_agent_copy(
+    tmp_path: Path, home_redirect: Path
+) -> None:
+    # Arrange — a healthy pinned snapshot. The state_dir is what the OLD
+    # implementation used to write a boot-copy into; the new resolver
+    # must IGNORE it for the bind target and hand back the snapshot.
+    now = time.time()
+    snap = _write_snapshot(home_redirect, "alpha", now + 3_600)
+    state_dir = tmp_path / "state"
+    # Act
+    resolved = resolve_cred_file(
+        _config(tmp_path / "wd", account="alpha"), state_dir, now=now
+    )
+    # Assert — the bind target IS the snapshot (not a per-agent copy).
+    # Refresh writes by the in-container CLI land on the snapshot
+    # directly, which is the whole point of the :rw bind fix.
+    assert resolved == snap
+
+
+def test_pinned_does_not_create_per_agent_dest_copy(
+    tmp_path: Path, home_redirect: Path
+) -> None:
+    # Arrange — fresh start; the legacy ``<state_dir>/claude/.credentials.json``
+    # MUST NOT be written by the resolver, otherwise a future operator
+    # could be confused by a stale-looking file under runtime/<name>/.
+    now = time.time()
+    _write_snapshot(home_redirect, "alpha", now + 3_600)
+    state_dir = tmp_path / "state"
+    # Act
+    resolve_cred_file(_config(tmp_path / "wd", account="alpha"), state_dir, now=now)
+    # Assert — no per-agent copy materialised under state_dir.
+    legacy_dest = state_dir / "claude" / ".credentials.json"
+    assert not legacy_dest.exists()
+
+
+def test_pinned_refresh_writeback_visible_via_resolved_path(
+    tmp_path: Path, home_redirect: Path
+) -> None:
+    # Arrange — the lead's acceptance test: "refresh the source cred
+    # file mid-session and confirm the next turn picks it up". Drive
+    # this at the resolver level: an external mutation of the snapshot
+    # (simulating the in-container CLI's refresh writeback through the
+    # :rw bind) must be visible immediately via the path the resolver
+    # returned — because the resolver returned the snapshot ITSELF, not
+    # a copy.
+    now = time.time()
+    snap = _write_snapshot(home_redirect, "alpha", now + 3_600, token="boot-token")
+    state_dir = tmp_path / "state"
+    resolved = resolve_cred_file(
+        _config(tmp_path / "wd", account="alpha"), state_dir, now=now
+    )
+    # Act — simulate the in-container Claude CLI refreshing the OAuth
+    # token: rewrite the snapshot's content (atomic in production via
+    # the CLI's own tmp+rename; here a direct write is sufficient for
+    # the unit-level invariant).
+    new_body = {
+        "claudeAiOauth": {
+            "accessToken": "refreshed-mid-session-token",
+            "expiresAt": int((now + 86_400) * 1_000),
+        }
+    }
+    snap.write_text(json.dumps(new_body))
+    # Assert — the path the resolver handed out NOW reads the refreshed
+    # token. No restart, no re-resolve needed — it's the same file.
+    body = json.loads(resolved.read_text())
+    assert body["claudeAiOauth"]["accessToken"] == "refreshed-mid-session-token"
+
+
+# ---------------------------------------------------------------------------
+# Pinned-account safety gates (preserved from the legacy resolver)
+# ---------------------------------------------------------------------------
+
+
+def test_pinned_absent_snapshot_raises_pinned_account_error(
+    tmp_path: Path, home_redirect: Path
+) -> None:
+    # Arrange — pinned to an account whose store dir does not exist.
+    state_dir = tmp_path / "state"
+    # Act / Assert
+    with pytest.raises(PinnedAccountError, match="has no credential snapshot"):
+        resolve_cred_file(
+            _config(tmp_path / "wd", account="missing-acct"),
+            state_dir,
+            now=time.time(),
+        )
+
+
+def test_pinned_expired_snapshot_raises_pinned_account_error(
+    tmp_path: Path, home_redirect: Path
+) -> None:
+    # Arrange — pinned snapshot whose OAuth ``expiresAt`` is already in
+    # the past. The resolver must refuse rather than handing out a
+    # dead token (the broken-fleet failure mode).
+    now = time.time()
+    _write_snapshot(home_redirect, "alpha", now - 60)
+    state_dir = tmp_path / "state"
+    # Act / Assert
+    with pytest.raises(PinnedAccountError, match="expired"):
+        resolve_cred_file(
+            _config(tmp_path / "wd", account="alpha"),
+            state_dir,
+            now=now,
+        )
+
+
+def test_pinned_snapshot_missing_expiry_field_raises(
+    tmp_path: Path, home_redirect: Path
+) -> None:
+    # Arrange — pinned snapshot with no numeric ``expiresAt``: must
+    # hard-error (we will not launch a pinned agent with an
+    # unverifiable token).
+    acct_dir = home_redirect / ".scitex" / "agent-container" / "accounts" / "alpha"
+    acct_dir.mkdir(parents=True)
+    (acct_dir / ".credentials.json").write_text(json.dumps({"claudeAiOauth": {}}))
+    state_dir = tmp_path / "state"
+    # Act / Assert
+    with pytest.raises(PinnedAccountError, match="expiresAt"):
+        resolve_cred_file(
+            _config(tmp_path / "wd", account="alpha"),
+            state_dir,
+            now=time.time(),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Unpinned-account branch (acct="") — unchanged: host live file
+# ---------------------------------------------------------------------------
+
+
+def test_unpinned_returns_host_live_credentials_json(
+    tmp_path: Path, home_redirect: Path
+) -> None:
+    # Arrange — no pinned account; host live ``~/.claude/.credentials.json``
+    # is the resolver's answer (caller binds it ``:rw`` so refresh-in-place
+    # works on the same file the host CLI reads/writes).
+    host_claude = home_redirect / ".claude"
+    host_claude.mkdir()
+    host_cred = host_claude / ".credentials.json"
+    host_cred.write_text("{}")
+    state_dir = tmp_path / "state"
+    # Act
+    resolved = resolve_cred_file(
+        _config(tmp_path / "wd", account=""),
+        state_dir,
+        now=time.time(),
+    )
+    # Assert
+    assert resolved == host_cred

--- a/tests/scitex_agent_container/runtimes/test__apptainer_runtime.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_runtime.py
@@ -1145,15 +1145,18 @@ def _save_snapshot(home: Path, name: str, body: str | None = None) -> Path:
     return snap
 
 
-def test_argv_pins_account_binds_state_dir_copy_not_host_file(
+def test_argv_pins_account_binds_snapshot_path_directly_not_host_file(
     tmp_path: Path, home_redirect: Path
 ) -> None:
     # Arrange — host live file AND a saved snapshot both exist; the pin
-    # must bind the state-dir copy, never the host file.
+    # must bind the SNAPSHOT FILE ITSELF (operator task #15 — the prior
+    # copy-into-state-dir path was the root cause of the 2026-06-01
+    # fleet outage: refreshes landed on the copy, the snapshot drifted
+    # stale, every SDK turn 401'd after ~8h).
     host_creds = home_redirect / ".claude" / ".credentials.json"
     host_creds.parent.mkdir(parents=True, exist_ok=True)
     host_creds.write_text('{"host": true}')
-    _save_snapshot(home_redirect, "alpha")
+    snap = _save_snapshot(home_redirect, "alpha")
     state_dir = tmp_path / "state"
     state_dir.mkdir()
     rt = ApptainerContainerRuntime()
@@ -1161,16 +1164,17 @@ def test_argv_pins_account_binds_state_dir_copy_not_host_file(
     # Act
     argv = rt.build_run_argv(cfg, state_dir=state_dir, sif_path=tmp_path / "x.sif")
     creds_arg = next(a for a in argv if "/tmp/sac-claude/.credentials.json" in a)
-    # Assert — the bound host-side path is the per-agent copy, not host.
-    assert creds_arg.startswith(str(state_dir / "claude" / ".credentials.json"))
+    # Assert — the bound host-side path IS the snapshot file, neither
+    # a per-agent copy nor the host live file.
+    assert creds_arg.startswith(str(snap))
 
 
-def test_argv_pins_account_copies_snapshot_bytes_into_state_dir(
+def test_argv_pins_account_does_not_create_state_dir_copy(
     tmp_path: Path, home_redirect: Path
 ) -> None:
     # Arrange — snapshot has distinctive bytes (plus a VALID future
-    # expiresAt so the fail-loud resolver accepts it) the copy must
-    # reproduce verbatim.
+    # expiresAt). The runtime MUST NOT write a state-dir copy — the
+    # bind target is the snapshot itself (operator task #15).
     far_future_ms = int((time.time() + 86_400) * 1_000)
     body = '{"pinned": "beta-bytes", "claudeAiOauth": {"expiresAt": %d}}' % (
         far_future_ms
@@ -1182,9 +1186,10 @@ def test_argv_pins_account_copies_snapshot_bytes_into_state_dir(
     cfg = _config(tmp_path, claude=ClaudeSpec(account="beta"))
     # Act
     rt.build_run_argv(cfg, state_dir=state_dir, sif_path=tmp_path / "x.sif")
-    copied = state_dir / "claude" / ".credentials.json"
-    # Assert — frozen boot-copy landed with the snapshot's contents.
-    assert copied.read_text() == body
+    legacy_copy = state_dir / "claude" / ".credentials.json"
+    # Assert — no per-agent copy materialised; the snapshot is the
+    # only place the in-container CLI's :rw refresh writeback lands.
+    assert not legacy_copy.exists()
 
 
 def test_argv_no_account_binds_host_live_file(


### PR DESCRIPTION
## Summary

Fixes the **2026-06-01 fleet-wide silent 401 outage** (operator task #15). Agents pinned via ``spec.claude.account`` were getting a FROZEN BOOT-COPY of the saved account's snapshot under ``<state_dir>/claude/.credentials.json``. The in-container Claude CLI's ~1h OAuth refresh wrote back to that per-agent copy — not to the source snapshot. After ~8h drift, every SDK turn 401'd. The telegram bridge still marked inbound 👀 but the agent could not complete a turn → silent. Hit hub, orochi, and proj-scitex-agent-container (revived only by restart).

**Fix (operator-approved):** bind the per-account snapshot file ``~/.scitex/agent-container/accounts/<acct>/.credentials.json`` DIRECTLY as ``:rw``. The in-container CLI's refresh writeback now lands on the snapshot itself — the snapshot is the single source of truth, self-healing, and never expires while any pinned agent keeps running.

## Implementation

- **`runtimes/_apptainer_creds.py::resolve_cred_file`** — pinned branch returns the snapshot path directly. Removed `shutil.copy2`, the per-agent dest dir creation, and the "preserve fresher dest" guard (the guard's whole purpose was to mitigate the copy bug; with no copy, no guard needed). Safety gates **preserved verbatim**: absent / missing-`expiresAt` / already-expired snapshot still hard-error as `PinnedAccountError`.
- **`runtimes/_apptainer_auth.py`** — comment block updated to describe the new `:rw`-bind contract + outage root cause.
- **`_lifecycle/_start.py`** — `_rotate_to_healthy_account` docstring updated.

## Tests (no mocks, real files)

New test module `test__apptainer_creds_rw_bind.py` (7 tests):
- pinned returns snapshot path itself (not per-agent copy)
- pinned does NOT create per-agent dest copy
- **pinned refresh writeback visible via resolved path** — the lead's acceptance test: "refresh the source cred file mid-session and confirm the next turn picks it up" — exercised at the resolver level by external mutation of the snapshot, then re-reading via the path the resolver handed out
- pinned absent / expired / missing-`expiresAt` snapshot → `PinnedAccountError` (safety gates intact)
- unpinned still returns host live file (preserve existing behaviour)

Updated existing tests:
- `test__apptainer_creds.py` — drops two stale "create/overwrite per-agent dest" tests (no longer meaningful), keeps the expired-snapshot safety gate, adds "legacy dest is not touched" tolerance test for operators upgrading mid-deploy with leftover state-dir copies.
- `test__apptainer_runtime.py` — two argv tests rewritten to assert the bind target IS the snapshot file (not a per-agent copy).

## Backward compatibility

- Same-account-pinned agents now share a single mount target. The prior boot-copy avoided this; the new model embraces it because same-account agents share an IDENTITY (the file IS their identity), the Claude CLI's atomic refresh writeback (tmp+rename) is safe under concurrent refresh, and a refresh by one agent benefits every other agent pinned to the same account immediately.
- Operators upgrading with a leftover `<state_dir>/claude/.credentials.json` are unaffected — the new resolver neither reads nor mutates it (regression test in place).

## Merge dependency

This PR is independent of #261 (SAC-from-SAC broker), but I plan to rebase on develop after #261 lands so we pick up its package-level test conftest (clears `APPTAINER_CONTAINER` / `SCITEX_AGENT_CONTAINER_AGENT` env pollution in tests run inside an agent SIF). GitHub-hosted CI runners do not have that env pollution, so CI for this PR runs green on its own; the conftest only matters for local in-SIF dev runs.

## Test plan

- [x] 7 new TDD tests in `test__apptainer_creds_rw_bind.py` — all green
- [x] All 9 tests in updated `test__apptainer_creds.py` — green
- [x] All 178 tests in `runtimes/test__apptainer_*` — green (incl. updated argv tests)
- [x] CI test-matrix runs + green (verified after push)