### PR TITLE
fix(tests): satisfy STX-TQ002 AAA-marker rule on safety-gate raises tests

### DIFF
--- a/tests/scitex_agent_container/runtimes/test__apptainer_creds_rw_bind.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_creds_rw_bind.py
@@ -167,7 +167,8 @@ def test_pinned_absent_snapshot_raises_pinned_account_error(
 ) -> None:
     # Arrange — pinned to an account whose store dir does not exist.
     state_dir = tmp_path / "state"
-    # Act / Assert
+    # Act
+    # Assert — pytest.raises is the assertion (TQ007: one per test).
     with pytest.raises(PinnedAccountError, match="has no credential snapshot"):
         resolve_cred_file(
             _config(tmp_path / "wd", account="missing-acct"),
@@ -185,7 +186,8 @@ def test_pinned_expired_snapshot_raises_pinned_account_error(
     now = time.time()
     _write_snapshot(home_redirect, "alpha", now - 60)
     state_dir = tmp_path / "state"
-    # Act / Assert
+    # Act
+    # Assert — pytest.raises is the assertion (TQ007: one per test).
     with pytest.raises(PinnedAccountError, match="expired"):
         resolve_cred_file(
             _config(tmp_path / "wd", account="alpha"),
@@ -204,7 +206,8 @@ def test_pinned_snapshot_missing_expiry_field_raises(
     acct_dir.mkdir(parents=True)
     (acct_dir / ".credentials.json").write_text(json.dumps({"claudeAiOauth": {}}))
     state_dir = tmp_path / "state"
-    # Act / Assert
+    # Act
+    # Assert — pytest.raises is the assertion (TQ007: one per test).
     with pytest.raises(PinnedAccountError, match="expiresAt"):
         resolve_cred_file(
             _config(tmp_path / "wd", account="alpha"),


### PR DESCRIPTION
## Summary

Follow-up to #262. The audit gate `tests/develop/test_audit.py::test_audit_all_clean` reported 3 STX-TQ002 violations in the newly-added `test__apptainer_creds_rw_bind.py` (the safety-gate tests for absent / expired / missing-`expiresAt` snapshots). #262 was auto-merged before the pytest-matrix completed, so the violations slipped onto develop.

## Fix

The three safety-gate tests used a combined `# Act / Assert` comment. The audit rule (PA-307 §3 STX-TQ002) requires `# Arrange`, `# Act`, `# Assert` each on its own line. Mirrors the sibling style in `test__apptainer_creds.py::test_resolver_refuses_expired_snapshot`:

```python
# Act
# Assert — pytest.raises is the assertion (TQ007: one per test).
with pytest.raises(...):
    ...
```

No production code change; 9 affected tests still pass.

## Test plan

- [x] All 7 tests in `test__apptainer_creds_rw_bind.py` green locally
- [x] `scitex-dev ecosystem audit-all scitex-agent-container` clean