### PR TITLE
feat(listen): single-instance flock guard for sac listen (task #26 sub 1)

### DIFF
--- a/src/scitex_agent_container/_listen/_single_instance.py
+++ b/src/scitex_agent_container/_listen/_single_instance.py
@@ -1,0 +1,199 @@
+"""Single-instance guard for ``sac listen`` (operator task #26 sub (1)).
+
+Background: before this guard, starting a second ``sac listen`` while
+one already held the bound port resulted in uvicorn's
+``OSError: [Errno 98] Address already in use`` and a hard-crash with a
+Python traceback. The crash was loud (good) but the operator had no
+diagnostic about which process held the port — they got a traceback,
+not a clean message naming the holding PID.
+
+This module replaces that experience with a flock-backed pidfile
+guard. Three properties combined:
+
+1. **flock-atomic**: ``fcntl.flock(LOCK_EX | LOCK_NB)`` is the source
+   of truth for "is another listen running". The kernel releases the
+   flock on process exit (even after SIGKILL / OOM), so a crashed
+   listen never permanently jams the port. No stale-lock
+   reconciliation needed.
+
+2. **PID written for diagnostics**: the pidfile body carries the
+   current PID so the conflict error message can name the holding
+   process — ``kill <pid>`` is actionable without ``lsof`` or
+   ``netstat``.
+
+3. **Port-scoped**: the pidfile path is ``<lock_dir>/listen-<port>.pid``
+   so two listens on different ports (e.g. a dev instance on 7879)
+   don't fight each other.
+
+NEVER bypassed by a stale pidfile: if a prior listen crashed leaving
+its PID in the file, the flock is already released; the next
+acquire finds an unlocked file, takes the flock, overwrites the PID.
+This is the "stale pidfile + no live holder" path covered by
+:func:`tests/.../_listen/test__single_instance.py::
+test_stale_pidfile_with_no_flock_holder_can_be_reacquired`.
+
+The caller MUST keep ``LockHandle.fd`` open for the lifetime of the
+process — closing the fd releases the flock. Use :func:`release_listen_lock`
+on clean exit; the kernel handles dirty exit.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+__all__ = [
+    "LockHandle",
+    "ListenAlreadyRunningError",
+    "acquire_listen_lock",
+    "release_listen_lock",
+]
+
+
+@dataclass
+class LockHandle:
+    """Opaque handle to an acquired listen lock.
+
+    ``fd`` is the OS file descriptor holding the flock; closing it
+    releases the lock. ``pid_file`` is the on-disk pidfile path, kept
+    so :func:`release_listen_lock` can clean up.
+    """
+
+    fd: int
+    pid_file: Path
+
+
+class ListenAlreadyRunningError(RuntimeError):
+    """Raised when another ``sac listen`` already holds the port lock.
+
+    Carries the holding PID (read from the pidfile body) and the lock
+    file path so the operator can both name and clear the conflict
+    without external tooling.
+    """
+
+
+def _pid_file_path(port: int, lock_dir: Path) -> Path:
+    """Return the pidfile path for ``port`` under ``lock_dir``.
+
+    Port-scoped so two listens on different ports do not fight. No
+    side-effects — the caller is responsible for ``mkdir -p`` on
+    ``lock_dir`` (or relying on the default-path helper).
+    """
+    return lock_dir / f"listen-{port}.pid"
+
+
+def _read_holding_pid(fd: int) -> str:
+    """Best-effort read of the PID from the pidfile content.
+
+    Returns an empty-ish placeholder (``"<unreadable>"``) on any read
+    error — this is purely for the diagnostic message, never branched
+    on. The flock itself is the source of truth.
+    """
+    try:
+        os.lseek(fd, 0, os.SEEK_SET)
+        return os.read(fd, 256).decode("utf-8", "replace").strip() or "<unknown>"
+    except OSError:  # stx-allow: fallback (reason: diagnostic-only — file may be empty/unreadable; flock decision already made)
+        return "<unreadable>"
+
+
+def acquire_listen_lock(
+    *,
+    port: int,
+    lock_dir: Path,
+) -> LockHandle:
+    """Acquire an exclusive flock for the listen-on-``port`` instance.
+
+    Parameters
+    ----------
+    port
+        TCP port the listen will bind. The pidfile name is scoped to
+        the port so an operator running multiple listens on different
+        ports does not fight a single lock.
+    lock_dir
+        Directory holding the pidfile. Must exist (caller's
+        responsibility — :mod:`cli_pkg/listen_cmds` ``mkdir -p`` s the
+        default ``~/.scitex/agent-container/runtime/`` before calling).
+        Passed in (rather than read from ``$HOME``) so tests can
+        isolate without env juggling.
+
+    Returns
+    -------
+    LockHandle
+        Carries the open fd holding the flock + the pidfile path. The
+        caller MUST keep the handle alive for the lifetime of the
+        process (closing the fd releases the lock).
+
+    Raises
+    ------
+    ListenAlreadyRunningError
+        When another live process already holds the flock. The error
+        message names the holding PID and the lock file path so the
+        operator can both diagnose and clear the conflict without
+        external tooling (``lsof`` / ``netstat`` / ``ss``).
+    """
+    pid_file = _pid_file_path(port, lock_dir)
+    fd = os.open(str(pid_file), os.O_CREAT | os.O_RDWR, 0o644)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError as exc:
+        holding_pid = _read_holding_pid(fd)
+        os.close(fd)
+        raise ListenAlreadyRunningError(
+            f"another sac listen is already running on port {port} "
+            f"(holding PID {holding_pid}, lock file {pid_file}). "
+            f"To take over: stop that process (`kill {holding_pid}`) "
+            "and retry."
+        ) from exc
+
+    # We now hold the exclusive flock. Stamp our PID in the file body
+    # so a future conflict can name us. Truncate first so a longer
+    # prior body (e.g. crashed-process PID) doesn't leave trailing
+    # bytes. Any write error here is loud — we hold the lock, so a
+    # subsequent caller would still see *some* PID, but a structurally
+    # bad write deserves to surface.
+    os.ftruncate(fd, 0)
+    os.write(fd, f"{os.getpid()}\n".encode("utf-8"))
+    return LockHandle(fd=fd, pid_file=pid_file)
+
+
+def release_listen_lock(handle: LockHandle) -> None:
+    """Release the flock + remove the pidfile.
+
+    Best-effort: any error is swallowed because process-exit (with the
+    fd still open) is the safe fallback — the kernel releases the
+    flock unconditionally on close, and a leftover pidfile is just a
+    stale diagnostic the next acquire will overwrite. We try to clean
+    up explicitly so operators inspecting the runtime dir between
+    listens don't see noise, but we never raise.
+    """
+    try:
+        fcntl.flock(handle.fd, fcntl.LOCK_UN)
+    except OSError:  # stx-allow: fallback (reason: best-effort cleanup; kernel-released-on-close is the durable contract)
+        pass
+    try:
+        os.close(handle.fd)
+    except (
+        OSError
+    ):  # stx-allow: fallback (reason: fd already closed / invalid — non-fatal)
+        pass
+    try:
+        handle.pid_file.unlink()
+    except (
+        FileNotFoundError
+    ):  # stx-allow: fallback (reason: already removed by a prior call)
+        pass
+    except OSError:  # stx-allow: fallback (reason: best-effort; a leftover pidfile is harmless — next acquire overwrites)
+        pass
+
+
+def default_lock_dir() -> Path:
+    """Return the default lock dir under ``$HOME/.scitex/agent-container/runtime``.
+
+    The CLI uses this; tests pass an explicit ``lock_dir`` to avoid
+    touching the operator's runtime. Caller is responsible for
+    ``mkdir -p`` — :func:`acquire_listen_lock` does NOT create the
+    directory (avoid surprising the operator with auto-created paths).
+    """
+    return Path.home() / ".scitex" / "agent-container" / "runtime"

--- a/src/scitex_agent_container/cli_pkg/listen_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/listen_cmds.py
@@ -80,7 +80,9 @@ def _register_self_comms_node(*, port: int) -> None:
                 f"# WARN: comms_nodes self-register conflict: {exc}",
                 err=True,
             )
-    except Exception as exc:  # stx-allow: fallback (reason: never block listen on registry write)
+    except (
+        Exception
+    ) as exc:  # stx-allow: fallback (reason: never block listen on registry write)
         click.echo(
             f"# WARN: comms_nodes self-register failed: {exc!r}",
             err=True,
@@ -122,9 +124,7 @@ def _maybe_sync_on_start() -> None:
             return
         # Only run when there is at least one static peer; skip silently
         # otherwise so single-host installs don't spam warnings.
-        static_peers = [
-            n for n in cfg.peers.keys() if not any(c in n for c in "*?[")
-        ]
+        static_peers = [n for n in cfg.peers.keys() if not any(c in n for c in "*?[")]
         if not static_peers:
             return
         from ._registry_sync import registry_sync_impl
@@ -224,9 +224,36 @@ def listen(
             f"Install with: pip install 'scitex-agent-container[listen]'"
         ) from exc
 
+    # Operator task #26 sub (1) — single-instance guard. A second
+    # ``sac listen`` while one already holds the port used to crash
+    # uvicorn with bare EADDRINUSE + a Python traceback (loud, but the
+    # operator had no diagnostic about which process held the port).
+    # The flock-backed pidfile guard FAILS LOUD with a structured
+    # message naming the holding PID + lock file path so
+    # ``kill <pid>`` is actionable without ``lsof``. The flock is
+    # kernel-released on process exit (even SIGKILL) so a crashed
+    # listen never permanently jams the port. Acquired BEFORE the
+    # comms_nodes / startup-sync hooks so a duplicate launch never
+    # touches the federated registry — a conflicting second start
+    # exits cleanly with no side effects.
+    from .._listen._single_instance import (
+        ListenAlreadyRunningError,
+        acquire_listen_lock,
+        default_lock_dir,
+        release_listen_lock,
+    )
+
+    lock_dir = default_lock_dir()
+    lock_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        lock_handle = acquire_listen_lock(port=port, lock_dir=lock_dir)
+    except ListenAlreadyRunningError as exc:
+        raise click.ClickException(str(exc)) from exc
+
     click.echo(f"# sac listen v1 → {host}:{port}", err=True)
     click.echo(f"# token file: {tok_path}", err=True)
     click.echo(f"# health: curl http://{host}:{port}/v1/sac/health", err=True)
+    click.echo(f"# pidfile: {lock_handle.pid_file}", err=True)
 
     # ADR-0014 Stage 1 — register the host's operator identity into
     # comms_nodes so cross-host peers can resolve it after a sync.
@@ -244,4 +271,11 @@ def listen(
     # websockets.legacy which has churned across the websockets package
     # major versions (broken in >=14). Disabling it avoids a startup
     # crash that silently kills a detached ``sac listen``.
-    uvicorn.run(app, host=host, port=port, log_level="info", ws="none")
+    try:
+        uvicorn.run(app, host=host, port=port, log_level="info", ws="none")
+    finally:
+        # Best-effort release on clean exit; kernel handles dirty
+        # exit (SIGKILL / crash / OOM) by closing fds and releasing
+        # the flock automatically — the next ``sac listen`` start
+        # observes an unlocked file and acquires cleanly.
+        release_listen_lock(lock_handle)

--- a/tests/scitex_agent_container/_listen/test__single_instance.py
+++ b/tests/scitex_agent_container/_listen/test__single_instance.py
@@ -1,0 +1,198 @@
+"""Single-instance guard for ``sac listen`` (operator task #26 sub (1)).
+
+Background: today the host's ``sac listen`` was found DOWN with nothing
+restarting it, and starting a second instance while one already holds
+``127.0.0.1:7878`` causes a hard EADDRINUSE crash in uvicorn. The
+crash is loud (good) but the operator has no diagnostic about which
+process holds the port — they get a Python traceback, not a clean
+message naming the holding PID.
+
+Fix: a flock-backed pidfile guard. The flock is the source of truth
+(atomic, kernel-released on process death — survives SIGKILL); the
+pidfile holds the diagnostic. On conflict, the caller gets a
+:class:`ListenAlreadyRunningError` naming the holding PID + the
+remedy.
+
+No-mocks (PA-306): real ``os.open`` / ``fcntl.flock`` against a real
+tmp-path lock dir. Tests inject the lock dir via a fixture rather
+than touching ``$HOME``. Each test: AAA markers (TQ002), one
+assertion (TQ007), 3+-word name.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+from scitex_agent_container._listen._single_instance import (
+    ListenAlreadyRunningError,
+    acquire_listen_lock,
+    release_listen_lock,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def lock_dir(tmp_path: Path) -> Path:
+    """Isolated lock dir; each test gets a fresh one."""
+    d = tmp_path / "runtime"
+    d.mkdir()
+    return d
+
+
+# ---------------------------------------------------------------------------
+# Acquire — happy path
+# ---------------------------------------------------------------------------
+
+
+def test_acquire_returns_open_fd_for_the_lock(lock_dir: Path) -> None:
+    # Arrange
+    port = 7878
+    # Act
+    handle = acquire_listen_lock(port=port, lock_dir=lock_dir)
+    # Assert
+    try:
+        assert handle.fd >= 0
+    finally:
+        release_listen_lock(handle)
+
+
+def test_acquire_writes_current_pid_into_pidfile(lock_dir: Path) -> None:
+    # Arrange — first acquire wins.
+    port = 7878
+    # Act
+    handle = acquire_listen_lock(port=port, lock_dir=lock_dir)
+    try:
+        body = (lock_dir / f"listen-{port}.pid").read_text().strip()
+    finally:
+        release_listen_lock(handle)
+    # Assert
+    assert int(body) == os.getpid()
+
+
+def test_acquire_uses_port_specific_lock_path(lock_dir: Path) -> None:
+    # Arrange — two different ports must not collide; both can acquire.
+    handle1 = acquire_listen_lock(port=7878, lock_dir=lock_dir)
+    # Act
+    handle2 = acquire_listen_lock(port=7879, lock_dir=lock_dir)
+    # Assert
+    try:
+        assert (lock_dir / "listen-7878.pid").is_file() and (
+            lock_dir / "listen-7879.pid"
+        ).is_file()
+    finally:
+        release_listen_lock(handle1)
+        release_listen_lock(handle2)
+
+
+# ---------------------------------------------------------------------------
+# Conflict — second acquire fails loudly with the holder's PID
+# ---------------------------------------------------------------------------
+
+
+def test_second_acquire_raises_listen_already_running_error(
+    lock_dir: Path,
+) -> None:
+    # Arrange — first acquire holds the flock; second must fail loud.
+    port = 7878
+    h1 = acquire_listen_lock(port=port, lock_dir=lock_dir)
+    raised = False
+    # Act
+    try:
+        h2 = acquire_listen_lock(port=port, lock_dir=lock_dir)
+        release_listen_lock(h2)  # defensive — should never reach here
+    except ListenAlreadyRunningError:
+        raised = True
+    finally:
+        release_listen_lock(h1)
+    # Assert
+    assert raised is True
+
+
+def test_conflict_error_message_names_holding_pid(lock_dir: Path) -> None:
+    # Arrange — the deny path's value to the operator is naming the
+    # process that is blocking them. The error message must carry the
+    # holding PID so `kill <pid>` is actionable without grep.
+    port = 7878
+    h1 = acquire_listen_lock(port=port, lock_dir=lock_dir)
+    captured_msg = ""
+    # Act
+    try:
+        try:
+            h2 = acquire_listen_lock(port=port, lock_dir=lock_dir)
+            release_listen_lock(h2)
+        except ListenAlreadyRunningError as exc:
+            captured_msg = str(exc)
+    finally:
+        release_listen_lock(h1)
+    # Assert
+    assert str(os.getpid()) in captured_msg
+
+
+def test_conflict_error_message_names_lock_path(lock_dir: Path) -> None:
+    # Arrange — operator needs to find the lock file on disk to
+    # diagnose / clear stale state. Error message MUST name it.
+    port = 7878
+    h1 = acquire_listen_lock(port=port, lock_dir=lock_dir)
+    captured_msg = ""
+    # Act
+    try:
+        try:
+            h2 = acquire_listen_lock(port=port, lock_dir=lock_dir)
+            release_listen_lock(h2)
+        except ListenAlreadyRunningError as exc:
+            captured_msg = str(exc)
+    finally:
+        release_listen_lock(h1)
+    # Assert
+    assert f"listen-{port}.pid" in captured_msg
+
+
+# ---------------------------------------------------------------------------
+# Release — clean re-acquire after release
+# ---------------------------------------------------------------------------
+
+
+def test_release_lets_subsequent_acquire_succeed(lock_dir: Path) -> None:
+    # Arrange — first acquire + clean release; the next acquire must
+    # NOT raise ListenAlreadyRunningError (the flock is gone).
+    port = 7878
+    h1 = acquire_listen_lock(port=port, lock_dir=lock_dir)
+    release_listen_lock(h1)
+    # Act
+    h2 = acquire_listen_lock(port=port, lock_dir=lock_dir)
+    # Assert
+    try:
+        assert h2.fd >= 0
+    finally:
+        release_listen_lock(h2)
+
+
+# ---------------------------------------------------------------------------
+# Stale pidfile — kernel-released flock after dead-process exit
+# ---------------------------------------------------------------------------
+
+
+def test_stale_pidfile_with_no_flock_holder_can_be_reacquired(
+    lock_dir: Path,
+) -> None:
+    # Arrange — simulate a process that crashed without releasing the
+    # pidfile content (kernel released the flock on exit, but the
+    # pidfile still names the dead PID). A fresh listen must acquire
+    # cleanly — the flock is the source of truth, not the pidfile
+    # text.
+    port = 7878
+    stale_pid_file = lock_dir / f"listen-{port}.pid"
+    stale_pid_file.write_text("999999999\n")  # implausibly-high PID
+    # Act — no live holder → must succeed.
+    handle = acquire_listen_lock(port=port, lock_dir=lock_dir)
+    # Assert
+    try:
+        assert handle.fd >= 0
+    finally:
+        release_listen_lock(handle)

--- a/tests/scitex_agent_container/_listen/test__single_instance.py
+++ b/tests/scitex_agent_container/_listen/test__single_instance.py
@@ -23,9 +23,9 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import Iterator
 
 import pytest
+
 from scitex_agent_container._listen._single_instance import (
     ListenAlreadyRunningError,
     acquire_listen_lock,


### PR DESCRIPTION
## Summary

Operator task #26 sub (1) — single-instance guard for `sac listen`. Before this guard, a second `sac listen` while one already held the port crashed uvicorn with bare `EADDRINUSE` + a Python traceback. The crash was loud (good) but the operator had no diagnostic about which process held the port.

This PR replaces that with a **flock-backed pidfile guard** that fails loud with a structured message naming the holding PID + lock file path, and is kernel-released on crash (no stale-lock reconciliation needed).

## Implementation

New `_listen/_single_instance.py`:
- `acquire_listen_lock(port, lock_dir)` — opens `<lock_dir>/listen-<port>.pid`, takes `fcntl.flock(LOCK_EX | LOCK_NB)`, stamps current PID. Returns `LockHandle` the caller keeps alive.
- `release_listen_lock(handle)` — best-effort unlock + close + unlink; kernel handles dirty exits.
- `ListenAlreadyRunningError` — names the holding PID + lock file path so `kill <pid>` is actionable without `lsof` / `netstat`.
- `default_lock_dir()` — `~/.scitex/agent-container/runtime/`.

Wired into `cli_pkg/listen_cmds.py::listen`:
- Lock acquired BEFORE `_register_self_comms_node` / `_maybe_sync_on_start` so a duplicate launch never touches the federated registry.
- Pidfile path echoed alongside existing token-file / health diagnostics.
- `release_listen_lock` runs in `finally` after `uvicorn.run` for clean shutdown.

## Three properties combined

1. **flock-atomic** — kernel releases on process exit (even SIGKILL / OOM); no stale-lock reconciliation.
2. **PID for diagnostics** — pidfile body powers the operator-facing message, never branched on.
3. **Port-scoped** — two listens on different ports don't fight.

## Test plan

8 new no-mocks tests in `tests/scitex_agent_container/_listen/test__single_instance.py`:
- [x] acquire returns open fd
- [x] acquire writes current PID
- [x] port-scoped (different ports both acquire)
- [x] second acquire raises ListenAlreadyRunningError
- [x] error message names holding PID
- [x] error message names lock file path
- [x] release lets subsequent acquire succeed
- [x] stale pidfile + no live flock holder can be re-acquired (kernel-released flock after crashed prior process)

All 246 tests in `tests/scitex_agent_container/_listen/` green.

## Follow-up PRs (task #26)

- Sub (2): regression test for the existing exponential-backoff SSE reconnect in `_mcp/channel.py:170-237` (auto-reconnect ALREADY IMPLEMENTED — just verification needed).
- Sub (3): systemd-user `sac-listen.service` unit (`Type=simple` + `Restart=on-failure`, mirror sac-accounts-refresh shape).