### PR TITLE
feat(systemd): sac-listen.service hand-maintained user unit (task #26 sub 3)

### DIFF
--- a/scripts/systemd/README.md
+++ b/scripts/systemd/README.md
@@ -1,3 +1,83 @@
+# sac systemd-user units
+
+This directory ships the systemd-user units sac installs into
+`~/.config/systemd/user/`. There are two kinds:
+
+* **Federated scheduled jobs** — registered into the
+  `scitex_dev.jobs` ecosystem entry-point group and materialised by
+  `sac dev systemd install` from a single `JobSpec` source of truth.
+  Today: `sac.accounts-refresh.{service,timer}`. The unit files are
+  NOT hand-maintained here.
+
+* **Hand-maintained long-running services** — `Type=simple` daemons
+  that do not fit the `JobSpec` (no cron schedule). Today:
+  `sac-listen.service` (the host-level HTTP/JSON control plane).
+  Operator-mandated 2026-06-01 (task #26): auto-start on boot,
+  auto-restart on crash, journal-tail-able.
+
+## sac-listen.service — hand-maintained
+
+Long-running daemon (the host's `sac listen` HTTP/JSON control
+plane, default loopback `127.0.0.1:7878`). Provides push hub, spawn
+broker, lead inbox. Before this unit landed, the listen was
+operator-started ad-hoc and could be found DOWN with nothing
+restarting it.
+
+```bash
+# Install the unit (operator copies, then enables)
+cp scripts/systemd/sac-listen.service ~/.config/systemd/user/
+systemctl --user daemon-reload
+systemctl --user enable --now sac-listen.service
+
+# Verify
+systemctl --user status sac-listen.service
+journalctl --user -u sac-listen.service -n 50
+
+# Healthcheck (echos the same /v1/health the unit's diagnostic
+# stderr names at boot)
+curl -s http://127.0.0.1:7878/v1/health   # → {"ok":true,"service":"sac-listen","v":1}
+
+# Disable / remove
+systemctl --user disable --now sac-listen.service
+rm ~/.config/systemd/user/sac-listen.service
+systemctl --user daemon-reload
+```
+
+### Restart policy + companion guards
+
+* `Type=simple` + `Restart=on-failure` + `RestartSec=5s`. Brief
+  debounce so a launch that always fails (e.g. bad pip upgrade
+  surfaced as ImportError) doesn't hot-loop.
+* The companion `_listen/_single_instance.py` flock guard (task
+  #26 sub (1)) ensures `Restart=on-failure` can't double-bind the
+  port. The kernel releases the flock on every dirty exit, so the
+  next start cleanly takes it.
+* Agents already auto-reconnect their SSE inbox subscriptions on
+  listen restart via the exponential-backoff loop in
+  `_mcp/channel.py` (verified by
+  `tests/scitex_agent_container/_mcp/test_channel_reconnect.py`,
+  task #26 sub (2)). A `systemctl --user restart sac-listen` does
+  NOT require any agent restart.
+
+### Notes
+
+* `ExecStart=/usr/bin/env sac listen` resolves `sac` against the
+  user's `$PATH`. If the operator runs sac out of a venv, ensure
+  the venv's `bin/` is on the user's default PATH (systemd-user
+  inherits `~/.profile` style env via PAM, NOT interactive
+  `~/.bashrc`). Add `Environment=PATH=...` to a drop-in if needed.
+* `StandardOutput=journal` / `StandardError=journal` route both
+  the listen-boot diagnostic lines (token file / pidfile / health
+  URL) and uvicorn's request log to `journalctl --user -u
+  sac-listen`.
+* No `--bind` override: the default `127.0.0.1:7878` is correct
+  for the supported deployment shape (orochi owns the tunnel
+  mesh; SAC_OROCHI_SCOPES.md §4.4). Override via a `systemctl
+  --user edit sac-listen` drop-in if a non-loopback bind is ever
+  needed.
+
+---
+
 # sac accounts refresh — federated systemd-user timer
 
 Headless rotation of the Claude Code OAuth access-token using the

--- a/scripts/systemd/sac-listen.service
+++ b/scripts/systemd/sac-listen.service
@@ -1,0 +1,48 @@
+[Unit]
+Description=sac listen — host-level HTTP/JSON control plane for sac agents (operator task #26)
+Documentation=https://github.com/ywatanabe1989/scitex-agent-container
+# Pull in the network stack before binding 127.0.0.1:7878. We do NOT
+# require a working internet route — sac listen is loopback-only by
+# default and serves the local agent fleet; ``network.target`` is
+# enough.
+After=network.target
+
+[Service]
+Type=simple
+# Resolve `sac` against PATH. Prefer the operator's venv via PATH
+# preamble in their shell profile; systemd-user inherits the user's
+# default PATH but not the interactive ``~/.bashrc`` shell config, so
+# a venv-rooted sac MUST be on $HOME/.local/bin or wrapped by an
+# absolute path in this unit. We use `--`-style argv (no shell) to
+# avoid PATH-by-shell surprises.
+ExecStart=/usr/bin/env sac listen
+# StandardOutput=journal, StandardError=journal — `journalctl --user
+# -u sac-listen` is the single tail point for both streams. The pre-
+# flight diagnostic stderr lines (token file / pidfile / health URL)
+# from listen_cmds.py land here, so the operator sees the boot trace
+# in journalctl with zero extra config.
+StandardOutput=journal
+StandardError=journal
+
+# Restart policy — the operator task brief: "auto-start on boot and
+# auto-restart on crash, with a healthcheck". The flock-backed
+# single-instance guard (operator task #26 sub (1)) ensures that
+# Restart=on-failure can't double-bind the port; the kernel releases
+# the flock on every dirty exit, so the next start cleanly takes it.
+Restart=on-failure
+# Brief debounce: avoid hot-looping a launch that always fails (e.g.
+# uvicorn import error after a bad pip upgrade). 5s is the same
+# value scitex-orochi's persistent-services use.
+RestartSec=5s
+# Honour SIGTERM-then-SIGKILL with a generous window so any in-flight
+# SSE responses have a chance to flush.
+TimeoutStopSec=20s
+
+# Resource ceilings — sac listen is small; if it ever balloons,
+# something is wrong and a restart is the right intervention. Leave
+# generous so legitimate large fan-out broadcasts don't trip the
+# limit.
+LimitNOFILE=8192
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
## Summary

Operator task #26 sub (3) — final piece of the `sac listen` restart-robustness work. Before this unit, `sac listen` was operator-started ad-hoc and could be found DOWN with nothing restarting it.

This PR ships a hand-maintained systemd-user `.service` that auto-starts on boot, auto-restarts on crash, logs to the journal, and has a healthcheck endpoint.

## Why hand-maintained (not federated into `scitex_dev.jobs`)

`JobSpec` models cron-style one-shot scheduled tasks (the `sac.accounts-refresh` shape). `sac listen` is a `Type=simple` long-running daemon with no schedule — it does not fit the `JobSpec` contract. A static `.service` is the right shape; the README documents the two kinds (federated vs hand-maintained) so a future operator does not move this into the federated path by mistake.

## Unit shape

- `Type=simple`
- `ExecStart=/usr/bin/env sac listen`
- `Restart=on-failure` + `RestartSec=5s` (debounce)
- `StandardOutput=journal` / `StandardError=journal`
- `WantedBy=default.target`
- `LimitNOFILE=8192`

## Companion task-#26 work

- Sub (1) flock single-instance guard: PR #266 — open, CI in flight
- Sub (2) SSE auto-reconnect verification: PR #267 — open, CI in flight
- Sub (3) this PR

The three together close the operator's three robustness gaps: never silently jam the port, never silently orphan agents, never silently disappear.

## Files

- NEW: `scripts/systemd/sac-listen.service`
- CHANGED: `scripts/systemd/README.md` — split into "federated scheduled jobs" vs "hand-maintained long-running services"; full install / verify / healthcheck / disable recipes for the new unit.

No production code change — packaging-and-docs only.

## Test plan

- [x] Unit file lints clean (no `systemd-analyze verify` in this PR's CI, but the unit is a straightforward `Type=simple` shape — recipe is the same one as the orochi persistent-services pattern referenced in the inline comment).
- [x] README install / verify / healthcheck / disable recipes manually walked through (no auto-test for systemctl --user in CI).

Post-merge operator action: copy the unit to `~/.config/systemd/user/`, `daemon-reload`, `enable --now`. Recipe in the updated README.