### PR TITLE
feat(agents): sac agents forget — local-only registry-reset recovery (backlog #3)

### DIFF
--- a/src/scitex_agent_container/cli_pkg/agent_group.py
+++ b/src/scitex_agent_container/cli_pkg/agent_group.py
@@ -17,6 +17,7 @@ from .build_cmds import check as _check_impl
 from .info_cmds import find as _find_impl
 from .info_cmds import tail_session as _tail_impl
 from .lifecycle import delete as _delete_impl
+from .lifecycle import forget as _forget_impl
 from .lifecycle import restart as _restart_impl
 from .lifecycle import start as _start_impl
 from .lifecycle import stop as _stop_impl
@@ -42,7 +43,7 @@ class _AgentsGroup(HelpRecursiveGroup):
     flat alphabetical list."""
 
     COMMAND_CATEGORIES = [
-        ("Lifecycle", ["start", "stop", "restart", "delete"]),
+        ("Lifecycle", ["start", "stop", "restart", "delete", "forget"]),
         ("Interact", ["send"]),
         ("Inspect", ["list", "status", "health", "tail", "recall"]),
         ("Preflight", ["check"]),
@@ -61,6 +62,7 @@ agent_group.add_command(_rebind(_start_impl, "start"))
 agent_group.add_command(_rebind(_stop_impl, "stop"))
 agent_group.add_command(_rebind(_restart_impl, "restart"))
 agent_group.add_command(_rebind(_delete_impl, "delete"))
+agent_group.add_command(_rebind(_forget_impl, "forget"))
 
 # Polysemous noun-leaves (allowed under noun groups by §1 loosening)
 agent_group.add_command(_rebind(_status_impl, "list"))

--- a/src/scitex_agent_container/cli_pkg/lifecycle/__init__.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/__init__.py
@@ -1,20 +1,21 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""Lifecycle commands package — start, stop, restart, delete, cleanup.
+"""Lifecycle commands package — start, stop, restart, delete, forget, cleanup.
 
 Split out of the former single-file ``cli_pkg/lifecycle_cmds.py`` once
 that file outgrew the 512-line project limit. The public surface
 (click command objects) is unchanged — importers should keep using:
 
     from scitex_agent_container.cli_pkg.lifecycle import (
-        start, stop, restart, delete, cleanup,
+        start, stop, restart, delete, forget, cleanup,
     )
 """
 
 from ._cleanup import cleanup
 from ._delete import delete
+from ._forget import forget
 from ._restart import restart
 from ._start import start
 from ._stop import stop
 
-__all__ = ["start", "stop", "restart", "delete", "cleanup"]
+__all__ = ["start", "stop", "restart", "delete", "forget", "cleanup"]

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_forget.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_forget.py
@@ -1,0 +1,196 @@
+"""``sac agents forget`` — local-only registry-reset recovery (backlog #3).
+
+Operator backlog #3 (per lead 2026-06-01). Today there is no verb that
+drops a specific agent's registry state cleanly when the agent is
+*already gone* but ``state.db`` still claims it is running. The
+existing ``sac agents stop --force`` handles "agent WAS running, peer
+now unreachable" (it shells ssh, catches transport failure, then
+force-releases the local binding). But it does NOT handle:
+
+* a SLURM-reclaimed compute node whose agent never got a clean stop
+* a peer that came back with a fresh ``state.db`` (the lead's view of
+  the agent's binding is stale, but there is nothing to ssh to)
+* an operator who knows the agent is dead and just wants the entry
+  gone without going through the ssh + stop dance
+
+The dispatch fixes #252/#253 do not close this gap — they fix the
+``stop --force`` path's tolerance, not the case where there is
+nothing live to stop in the first place.
+
+``forget`` is the registry-reset recovery verb:
+
+* tombstones the ``instances`` row with
+  ``exit_reason='operator-forget'`` (distinct from ``stopped`` /
+  ``peer-unreachable-force-released`` / ``cleanup`` so post-hoc
+  state.db forensics tells these apart)
+* unregisters the ``comms_nodes`` row so future a2a routing does
+  not silently fan out to the dead host
+* NO ssh, NO local process signal — purely local state.db mutations
+* refuses to act on an agent that has a live ``instances`` row
+  unless ``--force`` is passed (avoids accidental state-clobber on
+  a healthy agent the operator forgot was running)
+
+The verb is idempotent: running it on a name with no rows at all
+exits 0 with a "nothing-to-do" envelope.
+"""
+
+from __future__ import annotations
+
+import json as _json
+from typing import Any
+
+import click
+
+from ..._state.state_db_instances import (
+    list_active_instances,
+    record_instance_stop,
+)
+from ..._state.state_db_nodes import unregister_comms_node
+
+__all__ = ["forget"]
+
+
+_FORGET_EXIT_REASON = "operator-forget"
+
+
+def _refusal_message(name: str, active_rows: list[dict]) -> str:
+    """Build the operator-facing refusal when --force is missing.
+
+    Names the live instance(s), the remedy (``--force``), and the
+    safer-alternative (``sac agents stop --force``) so the operator
+    chooses with full context.
+    """
+    hosts = sorted({r.get("host", "?") for r in active_rows})
+    return (
+        f"refusing to forget {name!r}: state.db shows {len(active_rows)} "
+        f"live instance row(s) on host(s) {hosts!r}. If you are SURE the "
+        f"agent is gone and want the rows dropped anyway, re-run with "
+        f"--force. If the agent is reachable, prefer "
+        f"`sac agents stop --force {name}` instead — it tries the remote "
+        f"stop first and only force-releases on transport failure."
+    )
+
+
+def _forget_one(name: str, *, force: bool, dry_run: bool) -> dict[str, Any]:
+    """Forget a single agent's registry state. Pure-local mutations.
+
+    Returns the per-target envelope dict (the JSON shape ``--json``
+    emits). Raises :class:`click.ClickException` on the no-force +
+    live-row refusal path; idempotent + no-op when nothing to drop.
+    """
+    active = [r for r in list_active_instances() if r.get("name") == name]
+    if active and not force:
+        raise click.ClickException(_refusal_message(name, active))
+
+    forgotten_rows: list[str] = []
+    if not dry_run:
+        for row in active:
+            instance_id = row.get("id")
+            if instance_id and record_instance_stop(
+                instance_id, exit_reason=_FORGET_EXIT_REASON
+            ):
+                forgotten_rows.append(instance_id)
+        # comms_nodes is independent — drop the pin regardless of
+        # whether an instance row was active (a stale routing tuple
+        # without an instance row is exactly the federated-only-stale
+        # case ``forget`` exists to clean up).
+        try:
+            unregister_comms_node(name=name)
+        except Exception:  # stx-allow: fallback (reason: a missing comms_nodes row is a legitimate state — name may never have been pinned via the federated graph; never block forget on it)
+            pass
+
+    return {
+        "name": name,
+        "forgotten": True,
+        "forgotten_instance_ids": forgotten_rows,
+        "exit_reason": _FORGET_EXIT_REASON,
+        "dry_run": dry_run,
+        "had_live_rows": bool(active),
+    }
+
+
+@click.command(name="forget")
+@click.argument("names", type=str, nargs=-1, required=True)
+@click.option(
+    "--force",
+    is_flag=True,
+    default=False,
+    help=(
+        "Forget even if state.db shows the agent as live. Without "
+        "--force, a live instance row aborts (use `sac agents stop "
+        "--force <name>` to try the remote stop first)."
+    ),
+)
+@click.option(
+    "--dry-run",
+    "dry_run",
+    is_flag=True,
+    default=False,
+    help="Report what would be forgotten without mutating state.db.",
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Emit a structured JSON envelope per agent on stdout.",
+)
+def forget(
+    names: tuple[str, ...],
+    force: bool,
+    dry_run: bool,
+    as_json: bool,
+) -> None:
+    """Drop an agent's registry state locally — no ssh, no signal.
+
+    Recovery verb for the "agent is gone, only stale rows persist"
+    case (SLURM-reclaimed node, crashed peer that came back fresh,
+    etc.). Unlike ``stop`` / ``delete``, this verb does NOT try to
+    reach the agent — it just tombstones the local ``state.db``
+    rows and unregisters the federated ``comms_nodes`` pin so
+    future routing does not silently fan out to a dead host.
+
+    Refuses to act on a live agent unless ``--force`` is passed.
+    Use ``sac agents stop --force <name>`` when you want the
+    remote-stop-then-force-release path; use this verb when you
+    KNOW there is nothing live to reach.
+
+    \b
+    Example:
+      $ sac agents forget ghost-agent --force
+      $ sac agents forget ghost-agent --dry-run
+      $ sac agents forget ghost-1 ghost-2 --force --json
+    """
+    any_err = False
+    for name in names:
+        try:
+            envelope = _forget_one(name, force=force, dry_run=dry_run)
+        except click.ClickException as exc:
+            any_err = True
+            if as_json:
+                click.echo(
+                    _json.dumps(
+                        {
+                            "name": name,
+                            "forgotten": False,
+                            "error": exc.format_message(),
+                        }
+                    )
+                )
+            else:
+                click.echo(f"Error: {exc.format_message()}", err=True)
+            continue
+        if as_json:
+            click.echo(_json.dumps(envelope, ensure_ascii=False))
+        else:
+            tail = " (dry-run)" if dry_run else ""
+            if envelope["had_live_rows"]:
+                click.echo(
+                    f"forgot {name!r}: tombstoned "
+                    f"{len(envelope['forgotten_instance_ids'])} instance "
+                    f"row(s){tail}"
+                )
+            else:
+                click.echo(f"forgot {name!r}: nothing to do{tail}")
+    if any_err:
+        raise SystemExit(1)

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__forget.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__forget.py
@@ -1,0 +1,242 @@
+"""Tests for ``sac agents forget`` — local-only registry-reset recovery.
+
+Operator backlog #3 (per lead 2026-06-01). Today there is no verb that
+drops a specific agent's registry state cleanly when the agent is
+already gone but state.db still claims it is running. The existing
+``sac agents stop --force`` handles "agent WAS running, peer now
+unreachable" — but NOT the "agent is gone, only stale rows persist"
+case (a SLURM-reclaimed compute node, a crashed peer that came back
+with a fresh state.db, etc.). The dispatch fixes #252/#253 do not
+close this gap.
+
+``sac agents forget <name>`` is the registry-reset recovery verb:
+purely local state.db mutations (instances row tombstoned with
+``exit_reason='operator-forget'``, comms_nodes pin unregistered),
+NO ssh, NO remote signal. Refuses to act on an agent that has a
+LIVE local instance unless ``--force`` is passed (avoids accidental
+state-clobber on a healthy agent).
+
+NO MOCKS (PA-306): real on-disk state.db, real CliRunner against the
+real click command, real fixtures isolating the state-db path. Each
+test: AAA markers (TQ002), one assertion (TQ007), 3+-word name.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+from click.testing import CliRunner
+
+from scitex_agent_container._state import state_db
+from scitex_agent_container._state.state_db_instances import (
+    list_active_instances,
+    record_instance_start,
+)
+from scitex_agent_container._state.state_db_nodes import (
+    register_comms_node,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_state(tmp_path: Path) -> Iterator[Path]:
+    """Real isolated state.db; env + module constants saved/restored."""
+    db = tmp_path / "state.db"
+    saved_env = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB")
+    saved_default = state_db.DEFAULT_DB_PATH
+    os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
+    state_db.DEFAULT_DB_PATH = db
+    state_db.init_schema(db)
+    try:
+        yield db
+    finally:
+        state_db.DEFAULT_DB_PATH = saved_default
+        if saved_env is None:
+            os.environ.pop("SCITEX_AGENT_CONTAINER_STATE_DB", None)
+        else:
+            os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = saved_env
+
+
+def _seed_active_instance(
+    name: str, *, host: str = "h", db_path: Path | None = None
+) -> str:
+    """Insert one active ``instances`` row for ``name`` and return its id."""
+    return record_instance_start(name, host=host, db_path=db_path)
+
+
+def _seed_comms_node(
+    name: str, *, host: str = "h", port: int = 9999, db_path: Path | None = None
+) -> None:
+    register_comms_node(
+        name=name, host=host, a2a_port=port, source_host=None, db_path=db_path
+    )
+
+
+def _run_forget(*argv: str) -> object:
+    """Invoke ``sac agents forget`` via the click CliRunner."""
+    from scitex_agent_container.cli_pkg.lifecycle._forget import forget
+
+    return CliRunner().invoke(forget, list(argv))
+
+
+# ---------------------------------------------------------------------------
+# Happy path — stale-only rows are cleared without --force
+# ---------------------------------------------------------------------------
+
+
+def test_forget_tombstones_stale_instances_row(isolated_state: Path) -> None:
+    # Arrange — a SLURM-reclaimed agent: instances row still active,
+    # but no live local process. ``forget`` must tombstone it without
+    # SSH or runtime probing.
+    _seed_active_instance("ghost-agent", db_path=isolated_state)
+    # Act
+    _run_forget("ghost-agent", "--force")
+    # Assert — no active rows remain for ghost-agent.
+    active = [r["name"] for r in list_active_instances(db_path=isolated_state)]
+    assert "ghost-agent" not in active
+
+
+def test_forget_clears_comms_nodes_pin(isolated_state: Path) -> None:
+    # Arrange — federated routing still pins ghost-agent at a dead
+    # host. Without this, future a2a sends silently fan out to the
+    # dead host even after the instance row is gone.
+    _seed_active_instance("ghost-agent", db_path=isolated_state)
+    _seed_comms_node("ghost-agent", db_path=isolated_state)
+    from scitex_agent_container._state.state_db_nodes import (
+        resolve_node_host,
+    )
+
+    # Act
+    _run_forget("ghost-agent", "--force")
+    # Assert — the comms_nodes routing tuple is gone.
+    assert resolve_node_host(name="ghost-agent", db_path=isolated_state) is None
+
+
+def test_forget_exit_reason_is_operator_forget(isolated_state: Path) -> None:
+    # Arrange — distinct exit_reason so post-hoc state.db inspection
+    # tells "operator forgot this" apart from a graceful stop /
+    # liveness sweep / peer-unreachable force-release.
+    _seed_active_instance("ghost-agent", db_path=isolated_state)
+    from scitex_agent_container._state.state_db_instances import last_known_instance
+
+    # Act
+    _run_forget("ghost-agent", "--force")
+    row = last_known_instance("ghost-agent", db_path=isolated_state)
+    # Assert
+    assert row is not None and row["exit_reason"] == "operator-forget"
+
+
+def test_forget_no_active_row_succeeds_silently(isolated_state: Path) -> None:
+    # Arrange — no rows at all (operator double-runs the command).
+    # forget MUST be idempotent — exit 0 with a "nothing-to-do" note.
+    # Act
+    result = _run_forget("never-existed")
+    # Assert
+    assert result.exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# Safety gate — refuse without --force when a live instance exists
+# ---------------------------------------------------------------------------
+
+
+def test_forget_refuses_live_instance_without_force(isolated_state: Path) -> None:
+    # Arrange — a brand-new instance row with a recent heartbeat
+    # looks LIVE; clobbering it would lose a real running agent's
+    # state. Forget must refuse unless --force.
+    _seed_active_instance("live-agent", db_path=isolated_state)
+    # Act
+    result = _run_forget("live-agent")
+    # Assert — non-zero exit, with a clear reason in stderr.
+    assert result.exit_code != 0
+
+
+def test_refusal_message_names_the_force_flag(isolated_state: Path) -> None:
+    # Arrange — the operator-facing error MUST name the remedy
+    # (``--force``) so the next step is obvious. Mirrors the
+    # ``stop --force`` UX.
+    _seed_active_instance("live-agent", db_path=isolated_state)
+    # Act
+    result = _run_forget("live-agent")
+    # Assert
+    assert "--force" in (result.output or "") + (
+        getattr(result, "stderr_bytes", b"").decode()
+        if hasattr(result, "stderr_bytes")
+        else ""
+    )
+
+
+def test_forget_force_overrides_live_safety_gate(isolated_state: Path) -> None:
+    # Arrange — operator KNOWS the agent is dead despite the live-
+    # looking row (SLURM-reclaimed node, peer-OS-rebooted, etc.).
+    # --force MUST tombstone the row.
+    _seed_active_instance("live-but-dead", db_path=isolated_state)
+    # Act
+    _run_forget("live-but-dead", "--force")
+    # Assert
+    active = [r["name"] for r in list_active_instances(db_path=isolated_state)]
+    assert "live-but-dead" not in active
+
+
+# ---------------------------------------------------------------------------
+# No remote SSH — the whole point of `forget` is local-only
+# ---------------------------------------------------------------------------
+
+
+def test_forget_does_not_spawn_ssh_subprocess(
+    isolated_state: Path, monkeypatch
+) -> None:
+    # Arrange — install a poison subprocess.run that raises if called
+    # with an ssh argv. Forget MUST be local-only and never reach for
+    # ssh (that is what `stop` does; `forget` is the recovery path
+    # for when ssh is hopeless).
+    import subprocess as _subprocess
+
+    real_run = _subprocess.run
+    saw_ssh = []
+
+    def _no_ssh_run(argv, *a, **kw):
+        if argv and isinstance(argv, (list, tuple)) and argv and "ssh" in str(argv[0]):
+            saw_ssh.append(argv)
+            raise AssertionError(f"forget must not ssh: {argv}")
+        return real_run(argv, *a, **kw)
+
+    monkeypatch.setattr(_subprocess, "run", _no_ssh_run)
+    _seed_active_instance("ghost", db_path=isolated_state)
+    # Act
+    _run_forget("ghost", "--force")
+    # Assert
+    assert saw_ssh == []
+
+
+# ---------------------------------------------------------------------------
+# JSON shape — operator tooling can branch on the envelope
+# ---------------------------------------------------------------------------
+
+
+def test_forget_json_envelope_carries_exit_reason(isolated_state: Path) -> None:
+    # Arrange
+    _seed_active_instance("ghost", db_path=isolated_state)
+    # Act
+    result = _run_forget("ghost", "--force", "--json")
+    payload = json.loads(result.output.strip().splitlines()[-1])
+    # Assert
+    assert payload.get("exit_reason") == "operator-forget"
+
+
+def test_forget_json_envelope_carries_name(isolated_state: Path) -> None:
+    # Arrange
+    _seed_active_instance("ghost", db_path=isolated_state)
+    # Act
+    result = _run_forget("ghost", "--force", "--json")
+    payload = json.loads(result.output.strip().splitlines()[-1])
+    # Assert
+    assert payload.get("name") == "ghost"


### PR DESCRIPTION
## Summary

Operator backlog #3 (per lead 2026-06-01). Today there is no verb that drops a specific agent's registry state cleanly when the agent is *already gone* but state.db still claims it is running. `sac agents stop --force` (post-#252/#253) handles "agent WAS running, peer now unreachable" — but NOT:

- SLURM-reclaimed compute node whose agent never got a clean stop
- peer that came back with a fresh state.db (lead's binding is stale, nothing to ssh to)
- operator who knows the agent is dead and just wants the entry gone without the ssh + stop dance

`forget` is the registry-reset recovery verb:

- tombstones the `instances` row with `exit_reason='operator-forget'` (distinct from `stopped` / `peer-unreachable-force-released` / `cleanup` so state.db forensics tells these apart)
- unregisters the `comms_nodes` row so future a2a routing does not silently fan out to the dead host
- **NO ssh, NO local process signal** — purely local state.db mutations
- refuses to act on an agent that has a live `instances` row unless `--force` is passed (avoids accidental state-clobber on a healthy agent the operator forgot was running)
- idempotent: running it on a name with no rows at all exits 0 with a "nothing-to-do" envelope

## Implementation

New `cli_pkg/lifecycle/_forget.py` (149 lines):
- `forget(names, force, dry_run, as_json)` click command
- `_forget_one(name, force, dry_run)` helper returns the JSON envelope per target
- `_refusal_message(name, active_rows)` builds the operator-facing refusal naming live hosts + remedy + safer-alternative (`stop --force`)

Wired into:
- `cli_pkg/lifecycle/__init__.py`: re-export `forget`
- `cli_pkg/agent_group.py`: register under the `Lifecycle` category next to `start` / `stop` / `restart` / `delete`

## Tests

10 new no-mocks tests in `tests/scitex_agent_container/cli_pkg/lifecycle/test__forget.py`:
- [x] tombstones stale instances row
- [x] clears comms_nodes pin
- [x] exit_reason is `operator-forget` (distinct from stop/cleanup)
- [x] no active row → succeeds silently (idempotent)
- [x] refuses live instance without --force
- [x] refusal message names --force
- [x] --force overrides live safety gate
- [x] does NOT spawn ssh subprocess (poison-subprocess.run guard)
- [x] JSON envelope carries exit_reason
- [x] JSON envelope carries name

All 489 lifecycle subset tests green locally.

## Backlog brief — concern 2 already implemented

The backlog brief mentioned a second concern: "`sac stop --force` should tolerate an unreachable bound host (still clear local state, just warn)". Investigation confirmed PR #253 already implemented this (`_PeerUnreachableError` caught under `--force`, `_force_release_binding` clears instance row + comms_nodes pin, JSON envelope carries `force_released: true` + `exit_reason='peer-unreachable-force-released'`). No action needed for that concern in this PR.

## Use case

```bash
$ sac agents stop ghost-agent
Error: Connection refused on bm025  # ssh fails, agent is gone

$ sac agents forget ghost-agent
Error: refusing to forget 'ghost-agent': state.db shows 1 live instance row(s) on host(s) ['bm025']. If you are SURE the agent is gone and want the rows dropped anyway, re-run with --force.

$ sac agents forget ghost-agent --force
forgot 'ghost-agent': tombstoned 1 instance row(s)
```