### PR TITLE
fix(start): preserve apptainer stderr in SIF build failures (backlog #4)

### DIFF
--- a/src/scitex_agent_container/runtimes/_apptainer_build.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_build.py
@@ -138,10 +138,28 @@ def _create_overlay_image(path: Path, size: str) -> None:
 
 
 def _build_sif_from_uri(sif_path: Path, uri: str) -> bool:
-    """``apptainer build <sif> <uri>`` — pulls + converts an OCI image."""
+    """``apptainer build <sif> <uri>`` — pulls + converts an OCI image.
+
+    Returns ``True`` on success. Raises :class:`RuntimeError` carrying
+    the apptainer stderr verbatim on non-zero rc — backlog #4 fail-loud
+    contract. The pre-fix shape was ``return result.returncode == 0``
+    which silently dropped the stderr; callers saw only ``False`` and
+    the operator had no diagnostic about why the build failed
+    (network, missing registry credentials, malformed reference, ...).
+    """
     sif_path.parent.mkdir(parents=True, exist_ok=True)
-    result = subprocess.run(["apptainer", "build", str(sif_path), uri])
-    return result.returncode == 0
+    result = subprocess.run(
+        ["apptainer", "build", str(sif_path), uri],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"apptainer build {uri!r} → {sif_path} failed "
+            f"(rc={result.returncode}). stderr:\n{result.stderr.strip()}\n"
+            f"stdout:\n{result.stdout.strip()}"
+        )
+    return True
 
 
 def _build_sif_from_def(sif_path: Path, def_file: Path) -> bool:
@@ -150,10 +168,24 @@ def _build_sif_from_def(sif_path: Path, def_file: Path) -> bool:
     No docker daemon required even if the .def starts with
     ``Bootstrap: docker`` — apptainer's docker compatibility runs
     entirely over OCI registry pulls.
+
+    Returns ``True`` on success. Raises :class:`RuntimeError` carrying
+    the apptainer stderr verbatim on non-zero rc — backlog #4 fail-loud
+    contract (see :func:`_build_sif_from_uri` for the same rationale).
     """
     sif_path.parent.mkdir(parents=True, exist_ok=True)
-    result = subprocess.run(["apptainer", "build", str(sif_path), str(def_file)])
-    return result.returncode == 0
+    result = subprocess.run(
+        ["apptainer", "build", str(sif_path), str(def_file)],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"apptainer build {def_file} → {sif_path} failed "
+            f"(rc={result.returncode}). stderr:\n{result.stderr.strip()}\n"
+            f"stdout:\n{result.stdout.strip()}"
+        )
+    return True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scitex_agent_container/runtimes/test__apptainer_runtime.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_runtime.py
@@ -1762,6 +1762,44 @@ def test_build_sif_from_def_invokes_apptainer_build_subcommand(
 
 
 # ---------------------------------------------------------------------------
+# Fail-loud regression (backlog #4) — _build_sif_from_* MUST surface
+# the apptainer stderr on non-zero rc rather than swallowing it into a
+# bare ``False`` return. The pre-fix shape ate the diagnostic and the
+# operator saw only a generic "Failed to start agent" upstream.
+# ---------------------------------------------------------------------------
+
+
+def test_build_sif_from_uri_raises_runtime_error_on_apptainer_failure(
+    tmp_path: Path, subprocess_shim
+) -> None:
+    # Arrange — install a fake apptainer that fails with a distinctive
+    # stderr the test asserts on (proves the stderr is forwarded, not
+    # just that the call raises).
+    subprocess_shim.install(
+        "apptainer", exit=1, stderr="OCI pull failed: image not found"
+    )
+    # Act
+    # Assert — pytest.raises is the assertion (TQ007: one per test).
+    with pytest.raises(RuntimeError, match="OCI pull failed: image not found"):
+        mod._build_sif_from_uri(tmp_path / "out.sif", "docker://nope")
+
+
+def test_build_sif_from_def_raises_runtime_error_on_apptainer_failure(
+    tmp_path: Path, subprocess_shim
+) -> None:
+    # Arrange
+    def_file = tmp_path / "x.def"
+    def_file.write_text("Bootstrap: docker\n")
+    subprocess_shim.install(
+        "apptainer", exit=1, stderr="def parse error: missing Bootstrap"
+    )
+    # Act
+    # Assert — pytest.raises is the assertion (TQ007: one per test).
+    with pytest.raises(RuntimeError, match="def parse error: missing Bootstrap"):
+        mod._build_sif_from_def(tmp_path / "out.sif", def_file)
+
+
+# ---------------------------------------------------------------------------
 # A2A wiring guard — spec.a2a.port → --a2a-port, plus card-yaml path
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Operator backlog #4: verify+harden audit of the start path against silent-exit-0 / swallowed-failure paths. PRs #252 / #253 covered the dispatch + force-release legs; this PR closes the remaining SIF-build leg.

## The bug

Pre-fix shape — `_build_sif_from_uri` / `_build_sif_from_def` returned `bool`:

```python
def _build_sif_from_uri(sif_path, uri) -> bool:
    result = subprocess.run(["apptainer", "build", str(sif_path), uri])
    return result.returncode == 0
```

On `apptainer build` failure (network drop, missing OCI credentials, malformed registry reference, def-parse error), `subprocess.run` emitted stderr to the operator's terminal but the return value was just `False`. That `False` propagated:

```
_build_sif_from_uri  →  False
resolve_sif          →  None
ApptainerContainerRuntime.start  →  return False
agent_start          →  raise RuntimeError(f"Failed to start agent {name!r}")
```

The operator saw `Failed to start agent 'foo'` with NO indication of whether it was a build, network, permission, or registry-credentials issue.

## Fix

Capture stderr/stdout (`capture_output=True, text=True`) and raise `RuntimeError` carrying the apptainer stderr verbatim on non-zero rc. Success path unchanged — still returns `True` so existing callers and tests (`assert ok is True`) keep working.

## Tests

Two new regression tests:
- [x] `test_build_sif_from_uri_raises_runtime_error_on_apptainer_failure` — asserts both `RuntimeError` IS raised AND the stderr substring appears in the message (proves stderr is forwarded, not just that the call raises).
- [x] `test_build_sif_from_def_raises_runtime_error_on_apptainer_failure` — mirrors the same shape for the .def path.

All 6 existing `build_sif`-named tests still pass (success path unchanged).

## Out of scope (separate PRs if operator approves)

Subagent surfaced other audit findings:
- foreground-runtime `subprocess.run(argv).returncode == 0` in `_apptainer_runtime.start` — same shape, similar fix, but the foreground path's stderr already reaches the operator's terminal in real time, so the diagnostic is less hidden.
- health-monitor restart-loop silent swallow + hook-runner non-zero rc warn-only — both involve semantic changes (when to escalate) that deserve operator review before behaviour change.
- hub-client / drift-guard / liveness-DB-lock fallbacks have explicit comments documenting the silent-on-failure choice as intentional resilience — not fail-loud violations per existing design.

This PR closes the unambiguous "silently lose stderr on a hard subprocess failure" violation. The rest get follow-ups if needed.