### PR TITLE
fix(tests): drop unused time import in test__forget.py (ruff F401)

### DIFF
--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__forget.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__forget.py
@@ -25,7 +25,6 @@ from __future__ import annotations
 
 import json
 import os
-import time
 from pathlib import Path
 from typing import Iterator
 


### PR DESCRIPTION
Ruff F401 cleanup on develop. The unused `import time` slipped onto develop via PR #270 (the `sac agents forget` introduction) and now blocks every downstream PR's `ruff-on-ubuntu-latest` check. README PR #272 hit this and was merged anyway because auto-merge in this repo evidently doesn't gate on `ruff-on-ubuntu-latest`; the lint fix that should have ridden with #272 missed the merge train.

One-line cleanup. No behavioral change.

\`\`\`
F401 [*] \`time\` imported but unused
  --> tests/scitex_agent_container/cli_pkg/lifecycle/test__forget.py:28:8
\`\`\`