### PR TITLE
fix(tests): replace monkeypatch with subprocess_shim in test__forget (PA-306)

### DIFF
--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__forget.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__forget.py
@@ -192,29 +192,24 @@ def test_forget_force_overrides_live_safety_gate(isolated_state: Path) -> None:
 
 
 def test_forget_does_not_spawn_ssh_subprocess(
-    isolated_state: Path, monkeypatch
+    isolated_state: Path, subprocess_shim
 ) -> None:
-    # Arrange — install a poison subprocess.run that raises if called
-    # with an ssh argv. Forget MUST be local-only and never reach for
-    # ssh (that is what `stop` does; `forget` is the recovery path
-    # for when ssh is hopeless).
-    import subprocess as _subprocess
-
-    real_run = _subprocess.run
-    saw_ssh = []
-
-    def _no_ssh_run(argv, *a, **kw):
-        if argv and isinstance(argv, (list, tuple)) and argv and "ssh" in str(argv[0]):
-            saw_ssh.append(argv)
-            raise AssertionError(f"forget must not ssh: {argv}")
-        return real_run(argv, *a, **kw)
-
-    monkeypatch.setattr(_subprocess, "run", _no_ssh_run)
+    # Arrange — install a real fake ``ssh`` binary on ``$PATH`` via the
+    # package's no-mocks ``subprocess_shim`` fixture (the same pattern
+    # the listen-side argv regression test uses). The shim records each
+    # invocation; ``forget`` MUST be local-only and never reach for ssh
+    # (that is what ``stop`` does; ``forget`` is the recovery path for
+    # when ssh is hopeless). PA-306 §3 forbids ``monkeypatch.setattr``
+    # — the production code's real ``subprocess.run`` does its real
+    # PATH lookup, finds the shim, and the shim's argv log is what we
+    # read back.
+    subprocess_shim.install("ssh", stdout="", exit=0)
     _seed_active_instance("ghost", db_path=isolated_state)
     # Act
     _run_forget("ghost", "--force")
-    # Assert
-    assert saw_ssh == []
+    # Assert — the shim records zero invocations because forget never
+    # shelled out to ssh in the first place.
+    assert subprocess_shim.call_count("ssh") == 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

scitex-dev audit-python-apis on develop is flagging `test__forget.py::test_forget_does_not_spawn_ssh_subprocess` for PA-306 §3 (no-mocks): the test used `monkeypatch.setattr` to install a poison `subprocess.run` that raised on ssh argv. `monkeypatch` is forbidden in this project (PA-306 §3).

This violation slipped onto develop via PR #270 (`sac agents forget`) and now blocks every downstream PR's `test_audit_all_clean` check across py3.11 / 3.12 / 3.13.

## Fix

Replace `monkeypatch.setattr` with the package's no-mocks `subprocess_shim` fixture (same pattern `test__agent_exec_subprocess.py` already uses):

- Install a REAL fake `ssh` binary on `$PATH` via the shim
- Production's REAL `subprocess.run` does a REAL PATH lookup, finds the shim, calls it
- The shim records its argv; test asserts `call_count('ssh') == 0`

Behaviour invariant unchanged: `sac agents forget` never shells out to ssh, proven without mocking anything.

## Why this unblocks CI

`tests/develop/test_audit.py::test_audit_all_clean` invokes `scitex-dev ecosystem audit-all scitex-agent-container` which runs audit-python-apis. With the violation fixed, the gate passes on all 3 Python versions.

## Test plan

- [x] All 10 tests in `test__forget.py` still green locally
- [x] `scitex-dev ecosystem audit-python-apis` clean post-fix (verified after the editable .pth resolves to the new content)