### PR TITLE
fix(tests): drop literal '# noqa' from comment in test__handlers.py (ruff warning cleanup)

### DIFF
--- a/tests/scitex_agent_container/a2a/test__handlers.py
+++ b/tests/scitex_agent_container/a2a/test__handlers.py
@@ -389,9 +389,10 @@ def test_handlers_registry_contains_all_four_keys(key: str, expected: object) ->
     assert actual == expected_value or actual is expected_value
 
 
-# Keep ``sys`` referenced for tooling that doesn't follow ``# noqa`` on imports
-# in some checkers — we no longer monkeypatch sys.modules but the import is
-# harmless to retain.
+# Keep ``sys`` referenced so unused-import checkers do not flag the
+# module-level ``import sys`` even after the prior sys.modules monkey-
+# stubs were removed. The reference itself is the suppression — no
+# lint directive needed.
 _ = sys
 
 


### PR DESCRIPTION
## Summary

Operator 2026-06-01: "audit を全部直して、ワーニングも含めて" — fix audits including warnings. With #273 + #274 landed, the ruff F401 error and PA-306 audit violations are both clean on develop. The remaining ruff warning is:

```
warning: Invalid `# noqa` directive on tests/scitex_agent_container/a2a/test__handlers.py:392: expected `:` followed by a comma-separated list of codes (e.g., `# noqa: F401, F841`).
```

## Cause

Line 392 was a comment explaining why `_ = sys` is kept after the prior sys.modules monkey-stubs were removed. The comment text **literally contained** the string `# noqa`, which ruff parses as a (malformed) suppression directive.

## Fix

Rephrased the comment to explain the intent without using the literal directive marker. No code change; comment-only edit.

## Test plan

- [x] `ruff check --select F401,F811 src/ tests/` → "All checks passed!" (no error, no warning)
- [x] `python -m scitex_dev ecosystem audit-python-apis scitex-agent-container` → SUCC, no violations