### PR TITLE
release(v0.21.6): bump version + finalise CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,44 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.21.6] — 2026-06-01
+
+### Added
+- **feat(agents): `sac agents forget <name>`** (#270, operator
+  backlog #3). New local-only registry-reset recovery verb for the
+  "agent is gone, only stale rows persist" case (SLURM-reclaimed
+  node, crashed peer that came back fresh, etc.). Tombstones the
+  ``instances`` row with ``exit_reason='operator-forget'`` and
+  unregisters the ``comms_nodes`` pin. NO ssh, NO local process
+  signal. Refuses to act on a live instance unless ``--force`` is
+  passed. Idempotent: no rows = no-op exit 0.
+
+### Fixed
+- **fix(start): preserve apptainer stderr in SIF build failures**
+  (#271, operator backlog #4 partial). Pre-fix shape:
+  ``_build_sif_from_{uri,def}`` returned ``False`` on apptainer
+  build failure, silently dropping the stderr — callers saw only a
+  generic "Failed to start agent" upstream with no diagnostic.
+  Now ``capture_output=True`` + raises ``RuntimeError`` with the
+  apptainer stderr verbatim. Success path unchanged.
+- **fix(tests): drop unused `time` / `typing.Iterator` imports**
+  (#273, ruff F401 cleanup on develop).
+- **fix(tests): replace `monkeypatch` with `subprocess_shim` in
+  test__forget** (#274, PA-306 §3 no-mocks). The new ``forget``
+  test used ``monkeypatch.setattr`` which the audit gate
+  forbids; refactored to the project's standard no-mocks
+  ``subprocess_shim`` fixture (real fake ssh on $PATH).
+- **fix(tests): drop literal `# noqa` from comment in
+  test__handlers.py** (#275, ruff invalid-directive warning
+  cleanup).
+
+### Docs
+- **docs(readme): refresh to v0.21.5** (#272). Adds ``sac agents
+  forget``, the SAC-from-SAC broker subsection, the
+  ``sac-listen.service`` systemd unit install recipe, the
+  ``sac dev {systemd,cron,daemon}`` group, and ``sac registry
+  sync``. Timestamp bumped.
+
 ## [0.21.5] — 2026-06-01
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-agent-container"
-version = "0.21.5"
+version = "0.21.6"
 description = "Declarative YAML-based framework for defining, managing, and orchestrating AI coding agent instances"
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
PATCH release v0.21.6 — accumulated develop work since v0.21.5.

## Contents

### Added
- #270 feat(agents): `sac agents forget` — local-only registry-reset recovery

### Fixed
- #271 fix(start): preserve apptainer stderr in SIF build failures
- #273 fix(tests): unused `time` / `typing.Iterator` imports
- #274 fix(tests): replace `monkeypatch` with `subprocess_shim` (PA-306)
- #275 fix(tests): drop literal `# noqa` from comment

### Docs
- #272 docs(readme): refresh to v0.21.5

## Changes
- `pyproject.toml`: `0.21.5` → `0.21.6`
- `CHANGELOG.md`: promote `[0.21.6] - 2026-06-01`

## After merge
- Tag `v0.21.6` (unsigned annotated) off the merge commit
- Push tag → `pypi-publish-and-github-release-on-tag` workflow fires

No production code change in this PR — release plumbing only.