### PR TITLE
release(v0.21.7): pin hatchling<1.28 to unblock pypi-publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.21.7] — 2026-06-01
+
+### Fixed
+- **fix(build): pin `hatchling<1.28` to dodge twine
+  Metadata-Version 2.5 rejection.** hatchling ≥1.28 emits
+  ``Metadata-Version: 2.5`` which the pypa-publish action's bundled
+  twine rejects with ``InvalidDistribution: '2.5' is not a valid
+  metadata version`` (verified on the v0.21.6 release build,
+  workflow run 26728715926 — pypi-publish failed; no artifact landed
+  on PyPI and no GitHub Release was created). Hatchling 1.27 emits
+  ``Metadata-Version: 2.4`` which twine accepts. Same code contents
+  as the unpublished v0.21.6 (see ``[0.21.6]`` section below for the
+  feature/fix list); re-evaluate the pin when
+  ``pypa/gh-action-pypi-publish`` ships a newer twine.
+
 ## [0.21.6] — 2026-06-01
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,17 @@
 [build-system]
-requires = ["hatchling"]
+# Pin hatchling below 1.28 — hatchling >=1.28 emits
+# ``Metadata-Version: 2.5`` which the pypa-publish action's bundled
+# twine rejects with ``InvalidDistribution: '2.5' is not a valid
+# metadata version`` (verified on the v0.21.6 release build,
+# workflow run 26728715926). Hatchling 1.27 emits
+# ``Metadata-Version: 2.4`` which twine accepts. Re-evaluate this
+# pin when pypa/gh-action-pypi-publish ships a newer twine.
+requires = ["hatchling<1.28"]
 build-backend = "hatchling.build"
 
 [project]
 name = "scitex-agent-container"
-version = "0.21.6"
+version = "0.21.7"
 description = "Declarative YAML-based framework for defining, managing, and orchestrating AI coding agent instances"
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
v0.21.6's pypi-publish failed because hatchling 1.28+ emits `Metadata-Version: 2.5` which the pypa-publish action's twine rejects:

```
Checking dist/scitex_agent_container-0.21.6-py3-none-any.whl:
ERROR InvalidDistribution: Invalid distribution metadata:
'2.5' is not a valid metadata version
```

v0.21.5 (minutes earlier) published cleanly with hatchling <1.28. The runner image refreshed hatchling between the two release runs.

## Fix

Pin `hatchling<1.28` in `[build-system].requires`. Hatchling 1.27 emits `Metadata-Version: 2.4` which twine accepts.

## Same code contents as v0.21.6 (the unpublished one)

v0.21.6 is functionally a "ghost" version — tag exists on GitHub but the PyPI artifact never landed and no GitHub Release was created. Operators should install `scitex-agent-container==0.21.7` to get the v0.21.6 feature/fix list + this build fix:

- #270 feat(agents): `sac agents forget`
- #271 fix(start): preserve apptainer stderr in SIF build failures
- #272 docs(readme): refresh to v0.21.5
- #273 / #274 / #275 audit + lint cleanup

## After merge

- Tag `v0.21.7` off the merge commit
- Push tag → pypa-publish re-runs with hatchling 1.27 → Metadata-Version 2.4 → accepted

## Follow-up (out of scope)

Re-evaluate the pin when `pypa/gh-action-pypi-publish` ships a twine that accepts Metadata-Version 2.5.