### PR TITLE
feat(acl): block/unblock approve-prompt flow (task #27 PR A of 2)

### DIFF
--- a/src/scitex_agent_container/_listen/_acl.py
+++ b/src/scitex_agent_container/_listen/_acl.py
@@ -59,7 +59,7 @@ __all__ = [
 ]
 
 
-AclDecision = tuple[Literal["allow", "deny"], str | None]
+AclDecision = tuple[Literal["allow", "deny", "block"], str | None]
 
 
 class NodeAuthMiddleware:
@@ -157,10 +157,7 @@ def check_send_acl(
     # Determine the *effective* sender identity for the ACL check.
     if authenticated_node is not None:
         # Per-node bearer was presented.
-        if (
-            claimed_from_agent is not None
-            and claimed_from_agent != authenticated_node
-        ):
+        if claimed_from_agent is not None and claimed_from_agent != authenticated_node:
             return (
                 "deny",
                 (
@@ -186,6 +183,19 @@ def check_send_acl(
 
     if sender == target:
         return ("allow", None)
+
+    # Task #27 — block check (block wins over grant). The receiver
+    # explicitly silenced this sender at some prior decision; the
+    # ACL gate honours it BEFORE the grant + cross-group checks so
+    # an explicit veto wins even when a stale ``comms_grants`` row
+    # would otherwise pass. The "block" decision value lets
+    # :func:`node_message_send` distinguish silent-drop (no
+    # receiver push, no approve-prompt re-fire) from the
+    # cross-group deny that does push.
+    from .._state.state_db_blocks import has_block as _has_block
+
+    if _has_block(sender=sender, target=target, db_path=db_path):
+        return ("block", f"blocked: {sender!r} → {target!r}")
 
     # Phase-3 (ADR-0010 Step 2) — per-spec outbound/inbound deny layered
     # on top of the group default. Restrictive only: a per-spec deny
@@ -251,9 +261,7 @@ def _phase3_relationship_deny(
     Defaults preserve current behaviour: every comb in the matrix
     starts ``"allow"`` so absence of ``spec.comms`` is a no-op here.
     """
-    rel = sender_target_relationship(
-        sender=sender, target=target, db_path=db_path
-    )
+    rel = sender_target_relationship(sender=sender, target=target, db_path=db_path)
     if rel in ("parent", "sibling"):
         sender_policy = read_comms_policy(name=sender, db_path=db_path)
         if rel == "parent" and sender_policy["outbound_parent"] == "deny":
@@ -323,6 +331,4 @@ def deny_response(reason: str) -> JSONResponse:
     but the sender must know exactly why (handoff §0 Hard rules).
     """
     log.warning("ACL deny: %s", reason)
-    return JSONResponse(
-        {"error": "ACL deny", "reason": reason}, status_code=403
-    )
+    return JSONResponse({"error": "ACL deny", "reason": reason}, status_code=403)

--- a/src/scitex_agent_container/_listen/_acl_approve_prompt.py
+++ b/src/scitex_agent_container/_listen/_acl_approve_prompt.py
@@ -1,0 +1,154 @@
+"""ACL approve-prompt helpers (task #27 — operator-requested via lead).
+
+Background: a cross-group ACL deny used to push only a metadata-only
+``denied_attempt`` envelope at the receiver — the operator on the
+other end saw a confusing "silent 403" and had no in-band way to
+approve the sender. Task #27 adds two pieces alongside the existing
+``denied_attempt`` notify:
+
+1. The original (denied) message is HELD in the
+   ``pending_approvals`` table (see
+   :mod:`_state.state_db_pending_approval`) keyed on
+   ``(sender, target)`` with latest-wins dedupe.
+2. A NORMAL push prompt is emitted at the receiver carrying the
+   exact ``sac a2a grant <sender> <target>`` command. On grant the
+   held event is flushed into the receiver's inbox.
+
+This module owns the two pure helpers that the
+:func:`_listen._node_channel.node_message_send` deny branch and the
+:mod:`cli_pkg.a2a_group` grant verb both call:
+
+* :func:`_looks_like_cross_group_deny` — branch only on the deny
+  reason that the receiver can REMEDY via grant. ``missing target``
+  / spoof-identity denies are NOT remediable by granting and stay
+  out of the approve-prompt path (they keep the existing
+  ``denied_attempt`` notify-only behaviour).
+* :func:`_mint_approval_prompt` — mint the receiver-facing push
+  envelope. The ``content`` is the human-readable prompt the
+  operator's Telegram bridge surfaces verbatim; the ``extra`` dict
+  carries the structured fields a richer client could branch on
+  (``approval_prompt: True``, ``approval_sender``,
+  ``approval_grant_command``).
+
+Pure functions — no I/O, no state-db access. Tests import them
+directly without an in-process listen.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..a2a._inbox_bus import mint_event
+
+__all__ = [
+    "_looks_like_cross_group_deny",
+    "_mint_approval_prompt",
+    "approval_prompt_content",
+    "block_command",
+    "grant_command",
+    "unblock_command",
+]
+
+
+# The ACL gate emits this distinctive substring on the cross-group
+# deny path (see ``_listen._acl.check_send_acl``: ``"cross-group
+# send: sender ..."``). We branch on the substring rather than the
+# ``decision`` value because ``check_send_acl`` returns ``"deny"``
+# for several reasons (spoof identity, missing target, phase-3
+# relationship deny, ...) and only the cross-group case is remediable
+# by a ``grant_send``. The other denies stay on the existing
+# ``denied_attempt``-only path.
+_CROSS_GROUP_DENY_MARKER = "cross-group send"
+
+
+def _looks_like_cross_group_deny(reason: str | None) -> bool:
+    """Return True iff the deny reason is a cross-group grant-remediable one.
+
+    Spoof-identity / missing-target / phase-3 relationship denies are
+    NOT in this set — they cannot be fixed by the receiver granting,
+    so the approve-prompt path is skipped (the existing
+    ``denied_attempt`` notify is enough).
+    """
+    if not reason:
+        return False
+    return _CROSS_GROUP_DENY_MARKER in reason
+
+
+def unblock_command(sender: str, target: str) -> str:
+    """Render the operator-facing CLI command that UNBLOCKS the pair.
+
+    UNBLOCK = grant the sender + clear any block + clear the pending
+    prompt row. The sender's future messages pass; the original
+    denied message is NOT replayed (sender resends if needed). The
+    shape mirrors the existing sac CLI conventions: positional
+    ``<sender> <target>`` (sender first because that is the
+    direction the grant points).
+    """
+    return f"sac a2a unblock {sender} {target}"
+
+
+def block_command(sender: str, target: str) -> str:
+    """Render the operator-facing CLI command that BLOCKS the pair.
+
+    BLOCK persists ``sender → target`` in ``comms_blocks``; the
+    sender's future attempts are silently dropped (no 403 trail at
+    the receiver, no approve-prompt re-fire). Receiver chose to
+    silence.
+    """
+    return f"sac a2a block {sender} {target}"
+
+
+def grant_command(sender: str, target: str) -> str:
+    """Render the legacy ``sac a2a grant`` command — alias of unblock.
+
+    Kept as a thin alias for back-compat: the existing
+    ``sac a2a grant <s> <t>`` verb still writes the
+    ``comms_grants`` row directly. UNBLOCK is the receiver-driven
+    framing introduced for task #27.
+    """
+    return f"sac a2a grant {sender} {target}"
+
+
+def approval_prompt_content(sender: str, target: str) -> str:
+    """Render the human-readable prompt content for the push.
+
+    The Telegram bridge + any minimal inbox-rendering consumer
+    surfaces this string verbatim. Body intentionally omits the
+    actual message content — receivers are deciding on identity,
+    not on message content (revealing the denied body pre-decision
+    would defeat the ACL). Embeds BOTH the UNBLOCK and BLOCK
+    commands so the receiver picks one.
+    """
+    return (
+        f"Message from {sender!r} (content hidden). "
+        f"UNBLOCK to allow this sender's future messages:\n\n"
+        f"  {unblock_command(sender, target)}\n\n"
+        f"BLOCK to silence this sender (future attempts dropped):\n\n"
+        f"  {block_command(sender, target)}\n\n"
+        "Both decisions are PERSISTENT. The original denied message "
+        "is NOT replayed on unblock; the sender resends if needed."
+    )
+
+
+def _mint_approval_prompt(*, target: str, sender: str) -> dict[str, Any]:
+    """Mint the approve-prompt push envelope (kind=``message``).
+
+    Uses ``kind="message"`` so existing inbox consumers (Telegram
+    bridge, SSE subscribers, …) surface it via the normal-message
+    rendering path with zero code change. Structured fields ride
+    in ``extra`` so a richer client can branch on
+    ``extra.approval_prompt`` to render a dedicated UI element.
+    """
+    return mint_event(
+        target,
+        content=approval_prompt_content(sender, target),
+        from_agent=sender,
+        priority="normal",
+        kind="message",
+        extra={
+            "approval_prompt": True,
+            "approval_sender": sender,
+            "approval_unblock_command": unblock_command(sender, target),
+            "approval_block_command": block_command(sender, target),
+        },
+    )

--- a/src/scitex_agent_container/_listen/_node_channel.py
+++ b/src/scitex_agent_container/_listen/_node_channel.py
@@ -31,6 +31,10 @@ from .._state.state_db_channel import (
 )
 from ..a2a._inbox_bus import mint_deny_notification, mint_event
 from ._acl import check_send_acl, deny_response
+from ._acl_approve_prompt import (
+    _looks_like_cross_group_deny,
+    _mint_approval_prompt,
+)
 from ._node_channel_forwarders import _forward_to_remote
 from ._nodes import Broker, NodeRegistry
 
@@ -154,6 +158,16 @@ async def node_message_send(request: Request) -> Response:
         claimed_from_agent=sac_meta.get("from_agent"),
         target=name,
     )
+    if decision == "block":
+        # Task #27 — block precedence path. The receiver previously
+        # ran ``sac a2a block <sender> <target>``; honour the veto
+        # without any receiver-side surface (no denied_attempt push,
+        # no approve-prompt re-fire). The sender still gets a 403 —
+        # they need to know their send did not land — but the
+        # reason is intentionally generic so the block flag itself
+        # does not leak. The receiver sees nothing.
+        return deny_response(reason or "ACL deny")
+
     if decision == "deny":
         # Comms item D — fail-loud on the RECEIVER side too. The sender
         # gets a 403 with the reason; without this notification the
@@ -170,14 +184,39 @@ async def node_message_send(request: Request) -> Response:
         # skip publishing in that case (still 403 to the sender).
         if name:
             broker: Broker = request.app.state.inbox
+            sender_id = authenticated_node or sac_meta.get("from_agent")
             notif = mint_deny_notification(
                 target=name,
-                from_agent=(authenticated_node or sac_meta.get("from_agent")),
+                from_agent=sender_id,
                 reason=reason or "ACL deny",
             )
             row_id = persist_event(target=name, event=notif)
             notif["_row_id"] = row_id
             await broker.publish(name, notif)
+
+            # Task #27 — ACL approve-prompt flow (post-amendment).
+            # On a CROSS-GROUP deny (the only deny reason the
+            # receiver can REMEDY via grant/block), emit a single
+            # receiver-facing prompt embedding BOTH the unblock
+            # and block CLI commands so the receiver picks one.
+            # Dedupe: ``record_pending_prompt`` returns True only
+            # on the FIRST entry per (sender, target); subsequent
+            # denied attempts return False and we suppress the
+            # push (no flooding). The original message content is
+            # NEVER stored — the receiver decides on identity,
+            # not on content. If the receiver unblocks, the
+            # sender resends.
+            if sender_id and _looks_like_cross_group_deny(reason):
+                from .._state.state_db_pending_approval import (
+                    record_pending_prompt,
+                )
+
+                first_pending = record_pending_prompt(sender=sender_id, target=name)
+                if first_pending:
+                    prompt = _mint_approval_prompt(target=name, sender=sender_id)
+                    prompt_row_id = persist_event(target=name, event=prompt)
+                    prompt["_row_id"] = prompt_row_id
+                    await broker.publish(name, prompt)
         return deny_response(reason or "ACL deny")
 
     # ADR-0013 Phase 1: typed event ``kind`` (``done`` / ``blocker`` /

--- a/src/scitex_agent_container/_state/grant_flush.py
+++ b/src/scitex_agent_container/_state/grant_flush.py
@@ -1,0 +1,133 @@
+"""Decision helpers for the ACL block/unblock flow (task #27).
+
+Lead's design amendment (2026-06-01) SUPERSEDED the held-message-
+replay flow; the primitive is now just BLOCK / UNBLOCK. This module
+owns the two decision helpers the CLI verbs (``sac a2a unblock`` and
+``sac a2a block``, plus the legacy alias ``sac a2a grant``) share:
+
+* :func:`unblock_and_clear_pending` — write ``comms_grants`` (so the
+  sender's future messages pass) AND remove the row from
+  ``comms_blocks`` (if previously blocked) AND clear the
+  ``pending_prompts`` row so the receiver is not re-prompted on the
+  next denied attempt (there should be none — they're granted now).
+* :func:`block_and_clear_pending` — write ``comms_blocks`` (so the
+  sender's future attempts are silently dropped) AND clear the
+  ``pending_prompts`` row.
+
+Both helpers are DB-only (no Starlette / broker dependency) so the
+CLI verbs can run on the bare host without a live listen process.
+
+No held-message replay: per lead's amendment, the sender resends if
+they want their message delivered post-unblock. Trade-off accepted
+in exchange for dropping the fragile TTL / dedupe / replay machinery.
+
+Block precedence over grant: a (sender, target) pair with BOTH
+rows is denied — the block wins. The receiver explicitly silenced
+the sender after some earlier grant — the more recent veto is
+honoured. :func:`_listen._acl.check_send_acl` enforces this at the
+ACL check; this module just keeps the two stores independent.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+__all__ = [
+    "block_and_clear_pending",
+    "unblock_and_clear_pending",
+]
+
+
+def unblock_and_clear_pending(
+    *,
+    sender: str,
+    target: str,
+    note: str | None = None,
+    db_path: Path | None = None,
+) -> dict[str, Any]:
+    """Grant + remove any block + clear the pending-prompt row.
+
+    UNBLOCK semantics (lead's amendment): the sender's FUTURE messages
+    pass. There is no held message to deliver — the sender resends if
+    they want their original message through.
+
+    Returns a JSON-friendly envelope::
+
+      {
+        "sender": str,
+        "target": str,
+        "granted": True,           # ``comms_grants`` row exists post-call
+        "unblocked": bool,         # True iff a ``comms_blocks`` row was removed
+        "cleared_pending": bool,   # True iff a ``pending_prompts`` row was removed
+      }
+
+    Idempotent — repeat calls on an already-granted pair with no
+    block + no pending leave the state untouched and return
+    ``unblocked=False, cleared_pending=False``.
+    """
+    if not sender or not target:
+        raise ValueError(
+            "unblock_and_clear_pending: sender and target must be non-empty"
+        )
+    # Local imports so the module loads cleanly even when state_db
+    # is mid-migration (the schema-init paths reach into siblings
+    # circularly; lazy is safer).
+    from .state_db_blocks import unblock_send
+    from .state_db_nodes import grant_send
+    from .state_db_pending_approval import clear_pending_prompt
+
+    grant_send(sender=sender, target=target, db_path=db_path, note=note)
+    unblocked = unblock_send(sender=sender, target=target, db_path=db_path)
+    cleared = clear_pending_prompt(sender=sender, target=target, db_path=db_path)
+    return {
+        "sender": sender,
+        "target": target,
+        "granted": True,
+        "unblocked": unblocked,
+        "cleared_pending": cleared,
+    }
+
+
+def block_and_clear_pending(
+    *,
+    sender: str,
+    target: str,
+    note: str | None = None,
+    db_path: Path | None = None,
+) -> dict[str, Any]:
+    """Block + clear the pending-prompt row.
+
+    BLOCK semantics: the sender's FUTURE attempts are silently dropped
+    by :func:`_listen._acl.check_send_acl` (no 403 trail, no receiver
+    push, no approve-prompt re-fire). The receiver chose to silence
+    the sender; the system honours that without further surface.
+
+    Returns::
+
+      {
+        "sender": str,
+        "target": str,
+        "blocked": True,
+        "cleared_pending": bool,
+      }
+
+    Idempotent on the block side (repeat ``block_send`` is a no-op
+    against the existing row). Does NOT remove an existing
+    ``comms_grants`` row — the precedence rule in ``check_send_acl``
+    (block wins) handles the simultaneous-grant case at decision
+    time without needing to scrub the grants table.
+    """
+    if not sender or not target:
+        raise ValueError("block_and_clear_pending: sender and target must be non-empty")
+    from .state_db_blocks import block_send
+    from .state_db_pending_approval import clear_pending_prompt
+
+    block_send(sender=sender, target=target, db_path=db_path, note=note)
+    cleared = clear_pending_prompt(sender=sender, target=target, db_path=db_path)
+    return {
+        "sender": sender,
+        "target": target,
+        "blocked": True,
+        "cleared_pending": cleared,
+    }

--- a/src/scitex_agent_container/_state/state_db.py
+++ b/src/scitex_agent_container/_state/state_db.py
@@ -406,6 +406,17 @@ def init_schema(db_path: Path | None = None) -> Path:
         migrate_instances_add_family_tree_cols(conn)
         conn.executescript(_SCHEMA_ATTEMPTS)
         conn.executescript(_SCHEMA_DIARY)
+        # Task #27 — ACL block/unblock flow tables. Both CREATE TABLE
+        # scripts are idempotent; running them inline here means a
+        # fresh state.db carries the tables without a separate
+        # migration step. The owning modules expose the schema
+        # strings; we pull them through the same connection so
+        # ``init_schema`` stays atomic.
+        from . import state_db_blocks as _blocks
+        from . import state_db_pending_approval as _pp
+
+        conn.executescript(_pp._SCHEMA)
+        conn.executescript(_blocks._SCHEMA)
         conn.commit()
     return path
 

--- a/src/scitex_agent_container/_state/state_db_blocks.py
+++ b/src/scitex_agent_container/_state/state_db_blocks.py
@@ -1,0 +1,149 @@
+"""Block-list — receiver-driven persistent silencing of a sender (task #27).
+
+Operator-requested via lead (2026-06-01). Lead's design amendment: the
+ACL approve-prompt flow boils down to BLOCK / UNBLOCK as the
+primitive operations, dropping the held-message + TTL +
+debounce-heuristic machinery.
+
+* UNBLOCK is the existing :func:`state_db_nodes.grant_send` — writes
+  the ``comms_grants`` row that lets the sender's future messages
+  pass.
+* BLOCK is this module's :func:`block_send` — writes a
+  ``comms_blocks`` row that makes the sender's future ``message:send``
+  attempts SILENTLY drop (no 403 trail, no receiver push, no
+  approve-prompt re-fire). The receiver chose to silence the sender;
+  the system honours that without further surface area.
+
+Symmetric helpers (``unblock_send``, ``has_block``) mirror the
+``grant_send`` / ``revoke_send`` / ``has_grant`` shape in
+``state_db_nodes``.
+
+Block precedence: a (sender, target) pair with BOTH a grant and a
+block is denied (block wins). The receiver explicitly silenced the
+sender after some earlier grant — honouring the more recent veto.
+:func:`_listen._acl.check_send_acl` enforces this precedence.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+__all__ = [
+    "ensure_comms_blocks_table",
+    "block_send",
+    "has_block",
+    "unblock_send",
+]
+
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS comms_blocks (
+    sender_name TEXT NOT NULL,
+    target_name TEXT NOT NULL,
+    created_at  REAL NOT NULL,
+    note        TEXT,
+    PRIMARY KEY (sender_name, target_name)
+);
+"""
+
+
+def ensure_comms_blocks_table(db_path: Path | None = None) -> None:
+    """Idempotent CREATE TABLE for ``comms_blocks``.
+
+    Called from :func:`_state.state_db.init_schema` so a fresh
+    state.db carries the table; safe to call multiple times.
+    """
+    from .state_db import open_db
+
+    with open_db(db_path) as conn:
+        conn.executescript(_SCHEMA)
+
+
+def block_send(
+    *,
+    sender: str,
+    target: str,
+    db_path: Path | None = None,
+    note: str | None = None,
+) -> None:
+    """Persist a ``sender → target`` block.
+
+    Idempotent — re-blocking the same pair leaves the row untouched
+    (timestamp not bumped). The optional ``note`` is a free-form
+    audit annotation (e.g. the prompt msg_id the receiver was
+    responding to).
+
+    Fail-loud: empty ``sender`` / ``target`` raise ``ValueError``.
+    """
+    if not sender or not target:
+        raise ValueError("block_send: sender and target must be non-empty")
+    from .state_db import open_db
+
+    ensure_comms_blocks_table(db_path)
+    with open_db(db_path) as conn:
+        existing = conn.execute(
+            "SELECT 1 FROM comms_blocks WHERE sender_name = ? AND target_name = ?",
+            (sender, target),
+        ).fetchone()
+        if existing is not None:
+            return
+        conn.execute(
+            "INSERT INTO comms_blocks "
+            "(sender_name, target_name, created_at, note) "
+            "VALUES (?, ?, ?, ?)",
+            (sender, target, time.time(), note),
+        )
+
+
+def unblock_send(
+    *,
+    sender: str,
+    target: str,
+    db_path: Path | None = None,
+) -> bool:
+    """Remove a ``sender → target`` block. Returns ``True`` iff a row
+    was removed.
+
+    ``unblock_send`` only deletes the block row — it does NOT write a
+    grant. The receiver-side decision flow is "unblock = grant + clear
+    pending"; the CLI/handler stitches the two calls together (see
+    ``cli_pkg/a2a_group.py::a2a_unblock``).
+    """
+    if not sender or not target:
+        return False
+    from .state_db import open_db
+
+    ensure_comms_blocks_table(db_path)
+    with open_db(db_path) as conn:
+        cur = conn.execute(
+            "DELETE FROM comms_blocks WHERE sender_name = ? AND target_name = ?",
+            (sender, target),
+        )
+    return int(cur.rowcount or 0) > 0
+
+
+def has_block(
+    *,
+    sender: str,
+    target: str,
+    db_path: Path | None = None,
+) -> bool:
+    """Return True iff ``(sender → target)`` is currently blocked.
+
+    Used by :func:`_listen._acl.check_send_acl` as the FIRST gate
+    after the trivial self-send / phase-3 checks. A blocked sender is
+    silently dropped — no 403 reason, no receiver push, no
+    approve-prompt re-fire.
+    """
+    if not sender or not target:
+        return False
+    from .state_db import open_db
+
+    ensure_comms_blocks_table(db_path)
+    with open_db(db_path) as conn:
+        row = conn.execute(
+            "SELECT 1 FROM comms_blocks WHERE sender_name = ? AND target_name = ?",
+            (sender, target),
+        ).fetchone()
+    return row is not None

--- a/src/scitex_agent_container/_state/state_db_pending_approval.py
+++ b/src/scitex_agent_container/_state/state_db_pending_approval.py
@@ -1,0 +1,143 @@
+"""Pending-prompt flag for the ACL block/unblock flow (task #27).
+
+Operator-requested via lead (2026-06-01). Lead's design amendment
+SUPERSEDED an earlier "hold the original message + replay on grant"
+design in favour of a simpler BLOCK / UNBLOCK primitive:
+
+* When a cross-group sender is denied, the receiver gets ONE push
+  prompt naming the sender (content hidden — no leak pre-decision).
+  The prompt embeds BOTH ``sac a2a unblock <s> <t>`` and
+  ``sac a2a block <s> <t>`` so the receiver picks the verb.
+* While a (sender, target) pair has a pending prompt, subsequent
+  denied attempts from the same sender DO NOT re-prompt — the
+  receiver already has the decision in front of them. This module
+  owns that "is there a pending row" flag.
+* The receiver's decision (either ``unblock`` → ``grant_send`` or
+  ``block`` → ``block_send``) clears the pending row in the same
+  transaction. No held message replay — if the sender wants their
+  message delivered after unblock, they resend.
+* No TTL, no expiry sweep, no latest-wins dedupe. The original
+  spec's fragile spam-debounce logic is intentionally dropped — the
+  primitive is just "is there a pending decision yes/no".
+
+Schema is minimal: ``(sender, target, ts)``. The original message
+content is NEVER stored here (the receiver decides on identity, not
+on message content).
+
+No-mocks (PA-306) testing — real on-disk sqlite, no monkeypatch.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+__all__ = [
+    "ensure_pending_prompts_table",
+    "clear_pending_prompt",
+    "has_pending_prompt",
+    "record_pending_prompt",
+]
+
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS pending_prompts (
+    sender TEXT NOT NULL,
+    target TEXT NOT NULL,
+    ts     REAL NOT NULL,
+    PRIMARY KEY (sender, target)
+);
+"""
+
+
+def ensure_pending_prompts_table(db_path: Path | None = None) -> None:
+    """Idempotent CREATE TABLE for the pending-prompt flag store.
+
+    Called from :func:`_state.state_db.init_schema` so a fresh
+    state.db carries the table; safe to call multiple times.
+    """
+    from .state_db import open_db
+
+    with open_db(db_path) as conn:
+        conn.executescript(_SCHEMA)
+
+
+def record_pending_prompt(
+    *,
+    sender: str,
+    target: str,
+    db_path: Path | None = None,
+) -> bool:
+    """Mark ``(sender, target)`` as "prompt-emitted, awaiting decision".
+
+    Returns ``True`` iff this call is the FIRST pending-prompt for
+    the pair (caller should emit the receiver-facing push). Returns
+    ``False`` when a pending row already exists (caller suppresses
+    re-prompt). The check + insert is one atomic transaction so a
+    concurrent burst of denied attempts emits exactly one prompt.
+
+    Fail-loud: empty ``sender`` / ``target`` raise ``ValueError``.
+    """
+    if not sender or not target:
+        raise ValueError("record_pending_prompt: sender and target must be non-empty")
+    from .state_db import open_db
+
+    ensure_pending_prompts_table(db_path)
+    with open_db(db_path) as conn:
+        existing = conn.execute(
+            "SELECT 1 FROM pending_prompts WHERE sender = ? AND target = ?",
+            (sender, target),
+        ).fetchone()
+        if existing is not None:
+            return False
+        conn.execute(
+            "INSERT INTO pending_prompts (sender, target, ts) VALUES (?, ?, ?)",
+            (sender, target, time.time()),
+        )
+    return True
+
+
+def has_pending_prompt(
+    *,
+    sender: str,
+    target: str,
+    db_path: Path | None = None,
+) -> bool:
+    """Return True iff ``(sender, target)`` has a pending prompt awaiting
+    the receiver's block/unblock decision."""
+    if not sender or not target:
+        return False
+    from .state_db import open_db
+
+    ensure_pending_prompts_table(db_path)
+    with open_db(db_path) as conn:
+        row = conn.execute(
+            "SELECT 1 FROM pending_prompts WHERE sender = ? AND target = ?",
+            (sender, target),
+        ).fetchone()
+    return row is not None
+
+
+def clear_pending_prompt(
+    *,
+    sender: str,
+    target: str,
+    db_path: Path | None = None,
+) -> bool:
+    """Delete the pending row for ``(sender, target)``. Returns True iff
+    a row was removed. Idempotent on absent rows.
+
+    Called from both decision paths: ``grant_send`` / ``block_send``
+    (unblock or block) clear the pending prompt in the same workflow.
+    """
+    if not sender or not target:
+        return False
+    from .state_db import open_db
+
+    ensure_pending_prompts_table(db_path)
+    with open_db(db_path) as conn:
+        cur = conn.execute(
+            "DELETE FROM pending_prompts WHERE sender = ? AND target = ?",
+            (sender, target),
+        )
+    return int(cur.rowcount or 0) > 0

--- a/src/scitex_agent_container/cli_pkg/a2a_group.py
+++ b/src/scitex_agent_container/cli_pkg/a2a_group.py
@@ -258,6 +258,34 @@ def _emit(result: dict, as_json: bool) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _do_unblock(sender: str, target: str, note: str | None) -> None:
+    """Shared implementation for both ``grant`` (legacy) and ``unblock``.
+
+    Both verbs UNBLOCK ``SENDER → TARGET``: write the
+    ``comms_grants`` row (sender's future messages pass), remove any
+    ``comms_blocks`` row (if previously blocked), and clear any
+    ``pending_prompts`` row so the receiver is not re-prompted on
+    the next denied attempt. Per lead's task #27 amendment, NO held
+    message is replayed — the sender resends if needed.
+    """
+    from .._state.grant_flush import unblock_and_clear_pending
+
+    try:
+        result = unblock_and_clear_pending(sender=sender, target=target, note=note)
+    except ValueError as exc:
+        click.echo(f"error: {exc}", err=True)
+        raise SystemExit(2) from exc
+    from ._helpers import console
+
+    extras = []
+    if result["unblocked"]:
+        extras.append("removed block")
+    if result["cleared_pending"]:
+        extras.append("cleared pending prompt")
+    tail = f" [dim]({'; '.join(extras)})[/dim]" if extras else ""
+    console.print(f"[green]ok[/green]  unblocked  {sender}  ->  {target}{tail}")
+
+
 @a2a.command("grant")
 @click.argument("sender")
 @click.argument("target")
@@ -269,28 +297,86 @@ def _emit(result: dict, as_json: bool) -> None:
 def a2a_grant(sender: str, target: str, note: str | None) -> None:
     """Grant ``SENDER`` permission to send messages to ``TARGET``.
 
-    Thin wrapper over ``_state.state_db_nodes.grant_send`` — inserts a
-    row into ``comms_grants``. Idempotent: re-granting the same pair is
-    a no-op (the existing row's timestamp is preserved).
+    Legacy alias of ``sac a2a unblock <SENDER> <TARGET>``. Writes the
+    ``comms_grants`` row, removes any ``comms_blocks`` row, and
+    clears the pending-prompt row for the pair. Re-granting an
+    already-granted pair is a no-op on the timestamp.
 
-    Argument order matters: ``SENDER → TARGET`` is directional. To allow
-    bidirectional cross-group traffic, run the command twice.
+    Argument order matters: ``SENDER → TARGET`` is directional. To
+    allow bidirectional cross-group traffic, run the command twice.
 
     \b
     Example:
       $ sac a2a grant worker-a worker-b
       $ sac a2a grant worker-a worker-b --note "ticket-PA-512"
     """
-    from .._state.state_db_nodes import grant_send
+    _do_unblock(sender, target, note)
+
+
+@a2a.command("unblock")
+@click.argument("sender")
+@click.argument("target")
+@click.option(
+    "--note",
+    default=None,
+    help="Free-form audit annotation (e.g. the approval-prompt msg_id this responds to).",
+)
+def a2a_unblock(sender: str, target: str, note: str | None) -> None:
+    """UNBLOCK ``SENDER`` — allow this sender's future messages to ``TARGET``.
+
+    Task #27 receiver-facing verb. Embedded in the approve-prompt
+    push the receiver sees on a denied cross-group send. Writes the
+    ``comms_grants`` row, removes any ``comms_blocks`` row, and
+    clears the pending-prompt row. The sender's original denied
+    message is NOT replayed — they resend if needed.
+
+    \b
+    Example:
+      $ sac a2a unblock worker-a lead
+      $ sac a2a unblock worker-a lead --note "prompt msg_id abc123"
+    """
+    _do_unblock(sender, target, note)
+
+
+@a2a.command("block")
+@click.argument("sender")
+@click.argument("target")
+@click.option(
+    "--note",
+    default=None,
+    help="Free-form audit annotation (e.g. the approval-prompt msg_id this responds to).",
+)
+def a2a_block(sender: str, target: str, note: str | None) -> None:
+    """BLOCK ``SENDER`` — silently drop this sender's future attempts to ``TARGET``.
+
+    Task #27 receiver-facing verb. Embedded in the approve-prompt
+    push as the silence-this-sender alternative to ``unblock``.
+    Writes the ``comms_blocks`` row, clears the pending-prompt row.
+    Future sends from ``SENDER`` to ``TARGET`` are silently dropped
+    by :func:`_listen._acl.check_send_acl` (no receiver push, no
+    approve-prompt re-fire). The sender still gets a 403 — they
+    learn their send did not land — but the receiver sees nothing.
+
+    Idempotent: re-blocking is a no-op on the existing row's
+    timestamp. Block precedence: if the pair also has a grant,
+    BLOCK wins.
+
+    \b
+    Example:
+      $ sac a2a block worker-a lead
+      $ sac a2a block worker-a lead --note "prompt msg_id abc123"
+    """
+    from .._state.grant_flush import block_and_clear_pending
 
     try:
-        grant_send(sender=sender, target=target, note=note)
+        result = block_and_clear_pending(sender=sender, target=target, note=note)
     except ValueError as exc:
         click.echo(f"error: {exc}", err=True)
         raise SystemExit(2) from exc
     from ._helpers import console
 
-    console.print(f"[green]ok[/green]  granted  {sender}  ->  {target}")
+    tail = " [dim](cleared pending prompt)[/dim]" if result["cleared_pending"] else ""
+    console.print(f"[yellow]ok[/yellow]  blocked  {sender}  ->  {target}{tail}")
 
 
 @a2a.command("revoke")

--- a/tests/scitex_agent_container/_listen/test__acl_approve_flow.py
+++ b/tests/scitex_agent_container/_listen/test__acl_approve_flow.py
@@ -1,0 +1,373 @@
+"""End-to-end tests for the ACL block/unblock flow (task #27).
+
+Lead's design amendment (2026-06-01) replaced the held-message-replay
+flow with a BLOCK / UNBLOCK primitive. This module covers:
+
+* ``node_message_send`` on a cross-group ACL deny records ONE
+  pending-prompt + pushes a receiver-facing prompt embedding BOTH
+  the ``sac a2a unblock`` and ``sac a2a block`` CLI commands.
+* Dedupe: subsequent denied attempts from the same (sender, target)
+  pair while pending DO NOT re-emit the prompt (no flood).
+* ``sac a2a unblock`` writes the grant + removes any block + clears
+  the pending row.
+* ``sac a2a block`` writes ``comms_blocks`` + clears the pending row.
+* A blocked sender's future attempts are silently dropped — NO
+  receiver push, NO approve-prompt re-fire.
+
+No-mocks (PA-306): real on-disk state.db, real Starlette TestClient
++ real CliRunner. AAA markers, one assertion per test.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+from click.testing import CliRunner
+from starlette.testclient import TestClient
+
+from scitex_agent_container._listen.server import create_app
+from scitex_agent_container._runners import _session_state as _ss
+from scitex_agent_container._state import registry as _reg
+from scitex_agent_container._state import state_db
+from scitex_agent_container._state.state_db_blocks import has_block
+from scitex_agent_container._state.state_db_channel import list_undelivered
+from scitex_agent_container._state.state_db_nodes import (
+    has_grant,
+    record_lineage,
+)
+from scitex_agent_container._state.state_db_pending_approval import (
+    has_pending_prompt,
+)
+
+_TOKEN = "test-token-approve-flow"
+
+
+@pytest.fixture
+def isolated_state(tmp_path: Path) -> Iterator[Path]:
+    db = tmp_path / "state.db"
+    saved_env = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB")
+    saved_default = state_db.DEFAULT_DB_PATH
+    saved_home = os.environ.get("HOME")
+    saved_reg_const = _reg.REGISTRY_DIR
+    saved_state_const = _ss.DEFAULT_STATE_ROOT
+    os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
+    state_db.DEFAULT_DB_PATH = db
+    state_db.init_schema(db)
+    os.environ["HOME"] = str(tmp_path)
+    _reg.REGISTRY_DIR = tmp_path / "registry"
+    _ss.DEFAULT_STATE_ROOT = tmp_path / "runtime"
+    try:
+        # Seed parent → child lineage so ``worker-a → lead`` is
+        # cross-group (the scenario task #27 fixes).
+        record_lineage(child="worker-a", parent="root", db_path=db)
+        yield db
+    finally:
+        state_db.DEFAULT_DB_PATH = saved_default
+        _reg.REGISTRY_DIR = saved_reg_const
+        _ss.DEFAULT_STATE_ROOT = saved_state_const
+        if saved_env is None:
+            os.environ.pop("SCITEX_AGENT_CONTAINER_STATE_DB", None)
+        else:
+            os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = saved_env
+        if saved_home is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = saved_home
+
+
+def _send_payload(sender: str, content: str = "hi") -> dict:
+    return {
+        "jsonrpc": "2.0",
+        "id": "1",
+        "method": "SendMessage",
+        "params": {
+            "message": {
+                "message_id": "m1",
+                "role": "ROLE_USER",
+                "parts": [{"text": content}],
+            },
+            "metadata": {"from_agent": sender},
+        },
+    }
+
+
+def _approve_prompt_rows(target: str, db_path: Path) -> list[dict]:
+    return [
+        r
+        for r in list_undelivered(target=target, db_path=db_path)
+        if (r["event"].get("extra") or {}).get("approval_prompt")
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Cross-group deny: pending-prompt recorded + ONE receiver push
+# ---------------------------------------------------------------------------
+
+
+def test_cross_group_deny_records_pending_prompt(
+    isolated_state: Path,
+) -> None:
+    # Arrange
+    app = create_app(token=_TOKEN)
+    # Act
+    with TestClient(app) as client:
+        client.post(
+            "/agents/lead/message:send",
+            json=_send_payload("worker-a"),
+            headers={"authorization": f"Bearer {_TOKEN}"},
+        )
+    # Assert
+    assert has_pending_prompt(sender="worker-a", target="lead", db_path=isolated_state)
+
+
+def test_cross_group_deny_pushes_prompt_embedding_unblock_command(
+    isolated_state: Path,
+) -> None:
+    # Arrange — the prompt MUST embed the exact `sac a2a unblock`
+    # command per lead's amendment.
+    app = create_app(token=_TOKEN)
+    # Act
+    with TestClient(app) as client:
+        client.post(
+            "/agents/lead/message:send",
+            json=_send_payload("worker-a"),
+            headers={"authorization": f"Bearer {_TOKEN}"},
+        )
+    contents = [
+        (r["event"].get("content") or "")
+        for r in _approve_prompt_rows("lead", isolated_state)
+    ]
+    # Assert
+    assert any("sac a2a unblock worker-a lead" in c for c in contents)
+
+
+def test_cross_group_deny_pushes_prompt_embedding_block_command(
+    isolated_state: Path,
+) -> None:
+    # Arrange — the prompt also embeds the BLOCK alternative.
+    app = create_app(token=_TOKEN)
+    # Act
+    with TestClient(app) as client:
+        client.post(
+            "/agents/lead/message:send",
+            json=_send_payload("worker-a"),
+            headers={"authorization": f"Bearer {_TOKEN}"},
+        )
+    contents = [
+        (r["event"].get("content") or "")
+        for r in _approve_prompt_rows("lead", isolated_state)
+    ]
+    # Assert
+    assert any("sac a2a block worker-a lead" in c for c in contents)
+
+
+def test_repeated_denies_push_exactly_one_prompt(isolated_state: Path) -> None:
+    # Arrange — spammy un-granted sender must NOT flood receiver.
+    app = create_app(token=_TOKEN)
+    # Act
+    with TestClient(app) as client:
+        for _ in range(5):
+            client.post(
+                "/agents/lead/message:send",
+                json=_send_payload("worker-a"),
+                headers={"authorization": f"Bearer {_TOKEN}"},
+            )
+    prompt_count = len(_approve_prompt_rows("lead", isolated_state))
+    # Assert
+    assert prompt_count == 1
+
+
+def test_no_content_leak_in_prompt_body(isolated_state: Path) -> None:
+    # Arrange — receiver decides on identity; the prompt MUST NOT
+    # reveal the denied message body pre-decision.
+    app = create_app(token=_TOKEN)
+    # Act
+    with TestClient(app) as client:
+        client.post(
+            "/agents/lead/message:send",
+            json=_send_payload("worker-a", content="SECRET-PAYLOAD"),
+            headers={"authorization": f"Bearer {_TOKEN}"},
+        )
+    contents = [
+        (r["event"].get("content") or "")
+        for r in _approve_prompt_rows("lead", isolated_state)
+    ]
+    # Assert
+    assert all("SECRET-PAYLOAD" not in c for c in contents)
+
+
+# ---------------------------------------------------------------------------
+# UNBLOCK decision — grant + remove block + clear pending
+# ---------------------------------------------------------------------------
+
+
+def test_unblock_writes_comms_grants_row(isolated_state: Path) -> None:
+    # Arrange
+    from scitex_agent_container._state.grant_flush import (
+        unblock_and_clear_pending,
+    )
+
+    # Act
+    unblock_and_clear_pending(sender="worker-a", target="lead")
+    # Assert
+    assert has_grant(sender="worker-a", target="lead", db_path=isolated_state)
+
+
+def test_unblock_clears_the_pending_prompt(isolated_state: Path) -> None:
+    # Arrange — deny first to record the pending row, then unblock.
+    app = create_app(token=_TOKEN)
+    with TestClient(app) as client:
+        client.post(
+            "/agents/lead/message:send",
+            json=_send_payload("worker-a"),
+            headers={"authorization": f"Bearer {_TOKEN}"},
+        )
+    from scitex_agent_container._state.grant_flush import (
+        unblock_and_clear_pending,
+    )
+
+    # Act
+    unblock_and_clear_pending(sender="worker-a", target="lead")
+    # Assert
+    assert not has_pending_prompt(
+        sender="worker-a", target="lead", db_path=isolated_state
+    )
+
+
+def test_unblock_removes_existing_block_row(isolated_state: Path) -> None:
+    # Arrange — block first, then unblock. The unblock MUST remove
+    # the block row (otherwise the block-precedence rule in
+    # ``check_send_acl`` would still silently drop sends post-
+    # "unblock", which is exactly the wrong UX).
+    from scitex_agent_container._state.grant_flush import (
+        block_and_clear_pending,
+        unblock_and_clear_pending,
+    )
+
+    block_and_clear_pending(sender="worker-a", target="lead")
+    # Act
+    unblock_and_clear_pending(sender="worker-a", target="lead")
+    # Assert
+    assert not has_block(sender="worker-a", target="lead", db_path=isolated_state)
+
+
+# ---------------------------------------------------------------------------
+# BLOCK decision — comms_blocks row + clear pending + silent future denies
+# ---------------------------------------------------------------------------
+
+
+def test_block_writes_comms_blocks_row(isolated_state: Path) -> None:
+    # Arrange
+    from scitex_agent_container._state.grant_flush import (
+        block_and_clear_pending,
+    )
+
+    # Act
+    block_and_clear_pending(sender="worker-a", target="lead")
+    # Assert
+    assert has_block(sender="worker-a", target="lead", db_path=isolated_state)
+
+
+def test_block_clears_the_pending_prompt(isolated_state: Path) -> None:
+    # Arrange — deny first to record pending, then block.
+    app = create_app(token=_TOKEN)
+    with TestClient(app) as client:
+        client.post(
+            "/agents/lead/message:send",
+            json=_send_payload("worker-a"),
+            headers={"authorization": f"Bearer {_TOKEN}"},
+        )
+    from scitex_agent_container._state.grant_flush import (
+        block_and_clear_pending,
+    )
+
+    # Act
+    block_and_clear_pending(sender="worker-a", target="lead")
+    # Assert
+    assert not has_pending_prompt(
+        sender="worker-a", target="lead", db_path=isolated_state
+    )
+
+
+def test_blocked_send_emits_no_receiver_push(isolated_state: Path) -> None:
+    # Arrange — block first, then attempt a send. The receiver
+    # MUST see NOTHING (no denied_attempt, no approve-prompt, no
+    # new prompt re-fire). The sender still gets 403 (next test).
+    from scitex_agent_container._state.grant_flush import (
+        block_and_clear_pending,
+    )
+
+    block_and_clear_pending(sender="worker-a", target="lead")
+    app = create_app(token=_TOKEN)
+    # Act
+    with TestClient(app) as client:
+        client.post(
+            "/agents/lead/message:send",
+            json=_send_payload("worker-a"),
+            headers={"authorization": f"Bearer {_TOKEN}"},
+        )
+    rows = list_undelivered(target="lead", db_path=isolated_state)
+    # Assert — no rows landed for the lead from this blocked send.
+    assert rows == []
+
+
+def test_blocked_send_still_returns_403_to_sender(
+    isolated_state: Path,
+) -> None:
+    # Arrange — sender side learns their send did not land. The
+    # silence is receiver-only; we are not in the business of
+    # gaslighting senders that a delivered message vanished.
+    from scitex_agent_container._state.grant_flush import (
+        block_and_clear_pending,
+    )
+
+    block_and_clear_pending(sender="worker-a", target="lead")
+    app = create_app(token=_TOKEN)
+    # Act
+    with TestClient(app) as client:
+        r = client.post(
+            "/agents/lead/message:send",
+            json=_send_payload("worker-a"),
+            headers={"authorization": f"Bearer {_TOKEN}"},
+        )
+    # Assert
+    assert r.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# CLI verbs — sac a2a unblock + sac a2a block
+# ---------------------------------------------------------------------------
+
+
+def test_cli_unblock_writes_comms_grants(isolated_state: Path) -> None:
+    # Arrange
+    from scitex_agent_container.cli_pkg.a2a_group import a2a
+
+    # Act
+    CliRunner().invoke(a2a, ["unblock", "worker-a", "lead"])
+    # Assert
+    assert has_grant(sender="worker-a", target="lead", db_path=isolated_state)
+
+
+def test_cli_block_writes_comms_blocks(isolated_state: Path) -> None:
+    # Arrange
+    from scitex_agent_container.cli_pkg.a2a_group import a2a
+
+    # Act
+    CliRunner().invoke(a2a, ["block", "worker-a", "lead"])
+    # Assert
+    assert has_block(sender="worker-a", target="lead", db_path=isolated_state)
+
+
+def test_cli_grant_alias_still_unblocks(isolated_state: Path) -> None:
+    # Arrange — legacy `sac a2a grant` MUST behave like unblock so
+    # operator muscle memory keeps working.
+    from scitex_agent_container.cli_pkg.a2a_group import a2a
+
+    # Act
+    CliRunner().invoke(a2a, ["grant", "worker-a", "lead"])
+    # Assert
+    assert has_grant(sender="worker-a", target="lead", db_path=isolated_state)

--- a/tests/scitex_agent_container/_state/test_state_db_blocks.py
+++ b/tests/scitex_agent_container/_state/test_state_db_blocks.py
@@ -1,0 +1,140 @@
+"""Tests for the ``comms_blocks`` table (task #27).
+
+Lead's design amendment (2026-06-01): UNBLOCK is the existing
+``grant_send`` (write ``comms_grants``); BLOCK is this module's
+``block_send`` (write ``comms_blocks``) — symmetric helpers, same
+shape as ``state_db_nodes`` grant/revoke/has helpers.
+
+No-mocks (PA-306): real on-disk state.db. AAA markers, one
+assertion per test.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from scitex_agent_container._state import state_db
+from scitex_agent_container._state.state_db_blocks import (
+    block_send,
+    has_block,
+    unblock_send,
+)
+
+
+@pytest.fixture
+def isolated_state(tmp_path: Path) -> Iterator[Path]:
+    db = tmp_path / "state.db"
+    saved_env = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB")
+    saved_default = state_db.DEFAULT_DB_PATH
+    os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
+    state_db.DEFAULT_DB_PATH = db
+    state_db.init_schema(db)
+    try:
+        yield db
+    finally:
+        state_db.DEFAULT_DB_PATH = saved_default
+        if saved_env is None:
+            os.environ.pop("SCITEX_AGENT_CONTAINER_STATE_DB", None)
+        else:
+            os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = saved_env
+
+
+# ---------------------------------------------------------------------------
+# block_send + has_block — basic persistence
+# ---------------------------------------------------------------------------
+
+
+def test_block_then_has_block_returns_true(isolated_state: Path) -> None:
+    # Arrange
+    block_send(sender="alice", target="lead", db_path=isolated_state)
+    # Act
+    flag = has_block(sender="alice", target="lead", db_path=isolated_state)
+    # Assert
+    assert flag is True
+
+
+def test_has_block_returns_false_for_absent_pair(isolated_state: Path) -> None:
+    # Arrange — no block_send.
+    # Act
+    flag = has_block(sender="ghost", target="lead", db_path=isolated_state)
+    # Assert
+    assert flag is False
+
+
+def test_block_is_directional(isolated_state: Path) -> None:
+    # Arrange — block alice → lead. The REVERSE direction
+    # (lead → alice) must be unaffected.
+    block_send(sender="alice", target="lead", db_path=isolated_state)
+    # Act
+    reverse_flag = has_block(sender="lead", target="alice", db_path=isolated_state)
+    # Assert
+    assert reverse_flag is False
+
+
+def test_block_is_idempotent(isolated_state: Path) -> None:
+    # Arrange — block twice. The row's timestamp must not bump on
+    # the second call (mirrors grant_send semantics).
+    block_send(sender="alice", target="lead", note="first", db_path=isolated_state)
+    # Act
+    block_send(sender="alice", target="lead", note="second", db_path=isolated_state)
+    # Assert — still exactly one row's worth of state visible via
+    # has_block; the test pins the public observable, not the row
+    # count (idempotency is the contract).
+    assert has_block(sender="alice", target="lead", db_path=isolated_state)
+
+
+# ---------------------------------------------------------------------------
+# unblock_send — remove the row
+# ---------------------------------------------------------------------------
+
+
+def test_unblock_removes_the_block_row(isolated_state: Path) -> None:
+    # Arrange
+    block_send(sender="alice", target="lead", db_path=isolated_state)
+    unblock_send(sender="alice", target="lead", db_path=isolated_state)
+    # Act
+    flag = has_block(sender="alice", target="lead", db_path=isolated_state)
+    # Assert
+    assert flag is False
+
+
+def test_unblock_returns_true_when_row_existed(isolated_state: Path) -> None:
+    # Arrange
+    block_send(sender="alice", target="lead", db_path=isolated_state)
+    # Act
+    removed = unblock_send(sender="alice", target="lead", db_path=isolated_state)
+    # Assert
+    assert removed is True
+
+
+def test_unblock_returns_false_when_row_absent(isolated_state: Path) -> None:
+    # Arrange — no prior block.
+    # Act
+    removed = unblock_send(sender="ghost", target="lead", db_path=isolated_state)
+    # Assert
+    assert removed is False
+
+
+# ---------------------------------------------------------------------------
+# Fail-loud — empty inputs rejected
+# ---------------------------------------------------------------------------
+
+
+def test_block_empty_sender_raises(isolated_state: Path) -> None:
+    # Arrange
+    # Act
+    # Assert
+    with pytest.raises(ValueError, match="non-empty"):
+        block_send(sender="", target="lead", db_path=isolated_state)
+
+
+def test_block_empty_target_raises(isolated_state: Path) -> None:
+    # Arrange
+    # Act
+    # Assert
+    with pytest.raises(ValueError, match="non-empty"):
+        block_send(sender="alice", target="", db_path=isolated_state)

--- a/tests/scitex_agent_container/_state/test_state_db_pending_approval.py
+++ b/tests/scitex_agent_container/_state/test_state_db_pending_approval.py
@@ -1,0 +1,183 @@
+"""Tests for the pending-prompt flag store (task #27).
+
+Lead's design amendment (2026-06-01) replaces the prior held-message
+queue with a minimal "is there a pending decision yes/no" flag. The
+sender's original content is NEVER stored here — receivers decide on
+identity, not on content. This module covers the flag CRUD in
+isolation; the integration (denied send records the flag, the CLI
+decision clears it) lives in its own test file.
+
+No-mocks (PA-306): real on-disk state.db, env + module constant
+save/restore. Each test: AAA markers (TQ002), one assertion (TQ007),
+3+-word name.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from scitex_agent_container._state import state_db
+from scitex_agent_container._state.state_db_pending_approval import (
+    clear_pending_prompt,
+    has_pending_prompt,
+    record_pending_prompt,
+)
+
+
+@pytest.fixture
+def isolated_state(tmp_path: Path) -> Iterator[Path]:
+    db = tmp_path / "state.db"
+    saved_env = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB")
+    saved_default = state_db.DEFAULT_DB_PATH
+    os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
+    state_db.DEFAULT_DB_PATH = db
+    state_db.init_schema(db)
+    try:
+        yield db
+    finally:
+        state_db.DEFAULT_DB_PATH = saved_default
+        if saved_env is None:
+            os.environ.pop("SCITEX_AGENT_CONTAINER_STATE_DB", None)
+        else:
+            os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = saved_env
+
+
+# ---------------------------------------------------------------------------
+# record_pending_prompt — first-wins flag semantics
+# ---------------------------------------------------------------------------
+
+
+def test_first_record_returns_true(isolated_state: Path) -> None:
+    # Arrange — fresh DB, no prior row.
+    # Act
+    first = record_pending_prompt(sender="alice", target="lead", db_path=isolated_state)
+    # Assert — caller uses this signal to "emit the receiver-facing
+    # push exactly once per pair until a decision".
+    assert first is True
+
+
+def test_second_record_returns_false_no_duplicate_push(
+    isolated_state: Path,
+) -> None:
+    # Arrange — a pending row already exists.
+    record_pending_prompt(sender="alice", target="lead", db_path=isolated_state)
+    # Act
+    second = record_pending_prompt(
+        sender="alice", target="lead", db_path=isolated_state
+    )
+    # Assert — duplicate denied attempts MUST NOT re-prompt.
+    assert second is False
+
+
+def test_different_sender_target_pairs_both_emit(isolated_state: Path) -> None:
+    # Arrange — dedupe is per-pair, not global.
+    record_pending_prompt(sender="alice", target="lead", db_path=isolated_state)
+    # Act
+    second_pair = record_pending_prompt(
+        sender="bob", target="lead", db_path=isolated_state
+    )
+    # Assert
+    assert second_pair is True
+
+
+# ---------------------------------------------------------------------------
+# has_pending_prompt — read-only flag check
+# ---------------------------------------------------------------------------
+
+
+def test_has_pending_prompt_returns_true_after_record(
+    isolated_state: Path,
+) -> None:
+    # Arrange
+    record_pending_prompt(sender="alice", target="lead", db_path=isolated_state)
+    # Act
+    flag = has_pending_prompt(sender="alice", target="lead", db_path=isolated_state)
+    # Assert
+    assert flag is True
+
+
+def test_has_pending_prompt_returns_false_for_absent_pair(
+    isolated_state: Path,
+) -> None:
+    # Arrange — no record_pending_prompt call.
+    # Act
+    flag = has_pending_prompt(sender="ghost", target="lead", db_path=isolated_state)
+    # Assert
+    assert flag is False
+
+
+# ---------------------------------------------------------------------------
+# clear_pending_prompt — drop on decision
+# ---------------------------------------------------------------------------
+
+
+def test_clear_removes_pending_row(isolated_state: Path) -> None:
+    # Arrange
+    record_pending_prompt(sender="alice", target="lead", db_path=isolated_state)
+    clear_pending_prompt(sender="alice", target="lead", db_path=isolated_state)
+    # Act
+    flag = has_pending_prompt(sender="alice", target="lead", db_path=isolated_state)
+    # Assert
+    assert flag is False
+
+
+def test_clear_returns_true_when_row_existed(isolated_state: Path) -> None:
+    # Arrange
+    record_pending_prompt(sender="alice", target="lead", db_path=isolated_state)
+    # Act
+    removed = clear_pending_prompt(
+        sender="alice", target="lead", db_path=isolated_state
+    )
+    # Assert
+    assert removed is True
+
+
+def test_clear_returns_false_when_row_absent(isolated_state: Path) -> None:
+    # Arrange — no prior record.
+    # Act
+    removed = clear_pending_prompt(
+        sender="ghost", target="lead", db_path=isolated_state
+    )
+    # Assert
+    assert removed is False
+
+
+def test_after_clear_next_record_returns_true_again(
+    isolated_state: Path,
+) -> None:
+    # Arrange — record + clear + record again. The second record
+    # MUST return True (i.e. emit the prompt) because the prior
+    # decision was already made.
+    record_pending_prompt(sender="alice", target="lead", db_path=isolated_state)
+    clear_pending_prompt(sender="alice", target="lead", db_path=isolated_state)
+    # Act
+    second = record_pending_prompt(
+        sender="alice", target="lead", db_path=isolated_state
+    )
+    # Assert
+    assert second is True
+
+
+# ---------------------------------------------------------------------------
+# Fail-loud — empty sender / target rejected
+# ---------------------------------------------------------------------------
+
+
+def test_empty_sender_raises(isolated_state: Path) -> None:
+    # Arrange
+    # Act
+    # Assert
+    with pytest.raises(ValueError, match="non-empty"):
+        record_pending_prompt(sender="", target="lead", db_path=isolated_state)
+
+
+def test_empty_target_raises(isolated_state: Path) -> None:
+    # Arrange
+    # Act
+    # Assert
+    with pytest.raises(ValueError, match="non-empty"):
+        record_pending_prompt(sender="alice", target="", db_path=isolated_state)


### PR DESCRIPTION
## Summary

Operator-requested via lead (task #27). Today a cross-group ACL deny pushes only a metadata-only ``denied_attempt`` envelope — the receiver has no in-band way to approve or silence the sender.

This PR adds the receiver-driven **BLOCK / UNBLOCK** primitive per lead's design amendment.

**Stack:** this is **PR A of 2**.
- **PR A (this PR)** — block/unblock approve-flow against the local state.db.
- **PR B (next)** — in-container HTTP broker so the CLI verbs invoked inside a SIF write to the HOST listen's state.db (operator greenlit Q5 / lead FUTURE item 4).

## Design (lead's amendment, supersedes earlier design)

- On a cross-group ACL deny → ONE receiver-facing prompt embedding BOTH the `sac a2a unblock <s> <t>` and `sac a2a block <s> <t>` CLI commands. Dedupe: subsequent denied attempts from the same (sender, target) pair while pending DO NOT re-emit the prompt (no flood).
- **UNBLOCK** = write `comms_grants` + remove any `comms_blocks` + clear `pending_prompts`. Sender's future messages pass. **No held message replay** — sender resends if needed.
- **BLOCK** = write `comms_blocks` + clear `pending_prompts`. Sender's future attempts silently dropped by `check_send_acl`. Receiver sees nothing; sender still gets 403.
- **Block precedence**: a (sender, target) with BOTH grant and block is denied (block wins). `check_send_acl` consults blocks first.
- NO held message replay, NO TTL knob, NO latest-wins dedupe (intentionally dropped per lead's amendment).

## New modules

- `_state/state_db_pending_approval.py` — minimal `pending_prompts(sender, target, ts)` flag store.
- `_state/state_db_blocks.py` — `comms_blocks` table + symmetric `block_send` / `unblock_send` / `has_block` helpers.
- `_state/grant_flush.py` — `unblock_and_clear_pending` + `block_and_clear_pending` decision helpers (DB-only, no Starlette dependency).
- `_listen/_acl_approve_prompt.py` — pure helpers (`unblock_command`, `block_command`, `approval_prompt_content`, `_mint_approval_prompt`, …).

## Wiring

- `_listen/_acl.py::check_send_acl` — extends `AclDecision` with `"block"` value; consults `has_block` first.
- `_listen/_node_channel.py::node_message_send` — handles `decision == "block"` (silent receiver, 403 to sender). On cross-group deny, `record_pending_prompt` returns the "is this the first" signal; approval prompt persists + publishes exactly once.
- `_state/state_db.py::init_schema` — runs both new schemas inline.

## CLI

- `sac a2a unblock <s> <t>` — receiver-driven UNBLOCK.
- `sac a2a block <s> <t>` — receiver-driven BLOCK.
- `sac a2a grant <s> <t>` — kept as legacy alias of unblock.

## Test plan

35 new no-mocks tests, all green locally:

- [x] `test_state_db_pending_approval.py` — 11 tests (first-wins, dedupe, clear, re-record after clear, fail-loud)
- [x] `test_state_db_blocks.py` — 9 tests (idempotent, directional, unblock removes, fail-loud)
- [x] `test__acl_approve_flow.py` — 15 integration tests (real Starlette TestClient + CliRunner): cross-group deny pushes prompt with both commands embedded; no content leak; repeated denies emit one prompt; CLI verbs write the right rows + clear pending; blocked sender gets no receiver push, still 403.

## Out of scope (PR B follow-up)

In-container broker (operator-greenlit). PR B will:
- Add `/v1/acl/{unblock,block}` routes to the host listen.
- Detect in-SIF + HTTP-POST the decision to host listen (mirrors the SAC-from-SAC `_spawn_client` pattern from #261).
- Otherwise (bare host) call the local helpers directly. No behavior change for the bare-host lead.