### PR TITLE
feat(acl): in-container broker for sac a2a {unblock,block,grant} (task #27 PR B of 2)

### DIFF
--- a/src/scitex_agent_container/_listen/_acl_routes.py
+++ b/src/scitex_agent_container/_listen/_acl_routes.py
@@ -1,0 +1,122 @@
+"""ACL decision routes for ``sac listen`` (task #27 PR B).
+
+The bare host's lead runs ``sac a2a {unblock,block,grant}`` directly
+and writes the host's runtime/state.db (correct). An IN-CONTAINER
+agent that runs the same CLI today writes ITS OWN per-container
+state.db — silently ineffective against the host listen's ACL
+checks (lead FUTURE item 4 / operator greenlit Q5).
+
+These routes give the in-container CLI a way to TARGET the host
+listen's state.db over HTTP, mirroring the SAC-from-SAC
+``_lifecycle._spawn_client`` → host ``POST /agents`` broker
+pattern from #261. The CLI detects in-SIF and POSTs here; on the
+bare host it skips the broker entirely.
+
+Endpoints (loopback-only, bearer-auth):
+
+    POST /v1/acl/unblock   body {"sender", "target", "note"?}
+    POST /v1/acl/block     body {"sender", "target", "note"?}
+    POST /v1/acl/grant     body {"sender", "target", "note"?}     (= unblock alias)
+
+Each handler calls the same DB-only helper the CLI's bare-host
+path uses (``grant_flush.unblock_and_clear_pending`` /
+``block_and_clear_pending``), so a future operator who reads the
+server log sees the same operation either way.
+
+The handlers are AUTHORITATIVE: the listen-server's ``state.db`` is
+where the source-of-truth ACL writes land. There is no
+sender-identity check on the body — the operator that runs the
+CLI is implicitly trusted by the bearer (the bearer is host-wide).
+A future PR could add per-token grant authority if needed.
+"""
+
+from __future__ import annotations
+
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+__all__ = [
+    "acl_block",
+    "acl_grant",
+    "acl_unblock",
+]
+
+
+async def _body_json(request: Request) -> dict | None:
+    try:
+        return await request.json()
+    except Exception:  # stx-allow: fallback (reason: malformed JSON → 400)
+        return None
+
+
+def _extract_pair(body: dict) -> tuple[str, str, str | None] | JSONResponse:
+    """Pull ``sender`` + ``target`` (+ optional ``note``) from the body.
+
+    Returns either ``(sender, target, note)`` on success or a
+    :class:`JSONResponse` with status 400 + a clear reason on
+    invalid input. Inputs MUST be non-empty strings — empty is
+    rejected loudly, never coerced.
+    """
+    sender = body.get("sender") if isinstance(body, dict) else None
+    target = body.get("target") if isinstance(body, dict) else None
+    note = body.get("note") if isinstance(body, dict) else None
+    if not isinstance(sender, str) or not sender:
+        return JSONResponse(
+            {"error": "missing or empty 'sender' string"}, status_code=400
+        )
+    if not isinstance(target, str) or not target:
+        return JSONResponse(
+            {"error": "missing or empty 'target' string"}, status_code=400
+        )
+    if note is not None and not isinstance(note, str):
+        return JSONResponse(
+            {"error": "'note' must be a string if present"}, status_code=400
+        )
+    return sender, target, note
+
+
+async def acl_unblock(request: Request) -> JSONResponse:
+    """``POST /v1/acl/unblock`` — write grant + clear block + clear pending."""
+    body = await _body_json(request)
+    if body is None:
+        return JSONResponse({"error": "body must be JSON"}, status_code=400)
+    parsed = _extract_pair(body)
+    if isinstance(parsed, JSONResponse):
+        return parsed
+    sender, target, note = parsed
+    from .._state.grant_flush import unblock_and_clear_pending
+
+    try:
+        result = unblock_and_clear_pending(sender=sender, target=target, note=note)
+    except ValueError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=400)
+    return JSONResponse(result)
+
+
+async def acl_block(request: Request) -> JSONResponse:
+    """``POST /v1/acl/block`` — write block + clear pending."""
+    body = await _body_json(request)
+    if body is None:
+        return JSONResponse({"error": "body must be JSON"}, status_code=400)
+    parsed = _extract_pair(body)
+    if isinstance(parsed, JSONResponse):
+        return parsed
+    sender, target, note = parsed
+    from .._state.grant_flush import block_and_clear_pending
+
+    try:
+        result = block_and_clear_pending(sender=sender, target=target, note=note)
+    except ValueError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=400)
+    return JSONResponse(result)
+
+
+async def acl_grant(request: Request) -> JSONResponse:
+    """``POST /v1/acl/grant`` — alias of ``/v1/acl/unblock`` for back-compat.
+
+    Body shape identical. Kept so existing scripts that POST to
+    ``/v1/acl/grant`` keep working — the receiver-driven framing
+    introduced in task #27 prefers ``unblock``, but the legacy
+    name remains valid.
+    """
+    return await acl_unblock(request)

--- a/src/scitex_agent_container/_listen/server.py
+++ b/src/scitex_agent_container/_listen/server.py
@@ -276,9 +276,19 @@ def create_app(*, token: str, local_host: str | None = None) -> Starlette:
     Passing the value explicitly matters for in-process multi-host
     tests where the env is shared.
     """
+    # Task #27 PR B — ACL decision routes for the in-container
+    # broker. The bare-host lead writes the host's state.db directly
+    # via the CLI; an in-container ``sac a2a {unblock,block,grant}``
+    # posts here so the writes land on the HOST listen's state.db
+    # (rather than the silently-ineffective per-container copy).
+    from ._acl_routes import acl_block, acl_grant, acl_unblock
+
     routes: list[Route] = [
         Route("/v1/health", health, methods=["GET"]),
         Route("/.well-known/agent-card.json", fleet_card_handler, methods=["GET"]),
+        Route("/v1/acl/unblock", acl_unblock, methods=["POST"]),
+        Route("/v1/acl/block", acl_block, methods=["POST"]),
+        Route("/v1/acl/grant", acl_grant, methods=["POST"]),
     ]
     routes += _v1_agent_routes("/agents")
     app = Starlette(routes=routes)

--- a/src/scitex_agent_container/_state/_acl_broker_client.py
+++ b/src/scitex_agent_container/_state/_acl_broker_client.py
@@ -1,0 +1,216 @@
+"""In-container HTTP client for the host-side ACL decision endpoints.
+
+Task #27 PR B. Lets an in-container ``sac a2a {unblock,block,grant}``
+write to the HOST listen's state.db instead of the per-container
+state.db. Without this broker the in-container CLI writes silently
+miss — the host listen's ACL checks consult ITS OWN state.db, not
+the container's, so a "grant" written inside a container has no
+effect on the host's ACL gate (lead FUTURE item 4, operator-greenlit
+2026-06-01).
+
+Mirrors the SAC-from-SAC ``_lifecycle._spawn_client`` shape:
+
+* stdlib-only ``urllib.request`` (no httpx) — minimal deps inside
+  the container; one one-shot POST per call, no streaming, no async
+* injectable ``opener`` for tests — no monkeypatch
+* ``BrokerRequestError`` — fail-loud on missing base URL / non-2xx /
+  transport failure / malformed body. Never silently downgrade to
+  "ok with empty result".
+
+The CLI's dispatch logic chooses between this broker (in-SIF) and
+the local DB-only helpers (bare host). Detection reuses
+``_lifecycle._in_sif_broker.is_in_sif`` so the two broker paths
+share the same in-SIF signal.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Callable
+from urllib import error as urlerror
+from urllib import request as urlrequest
+
+logger = logging.getLogger(__name__)
+
+
+__all__ = [
+    "AclBrokerError",
+    "broker_acl_decision",
+]
+
+
+_DEFAULT_TIMEOUT_S = 10.0
+
+
+class AclBrokerError(RuntimeError):
+    """Raised when the in-container ACL broker cannot reach the host listen.
+
+    Carries the structured failure shape:
+
+    * ``status`` — HTTP status code from the listen server (``None``
+      for transport / missing-env failures).
+    * ``body`` — parsed response dict / text fallback / ``None``.
+
+    The fail-loud invariants this class encodes:
+
+    * Missing ``SAC_LISTEN_BASE_URL`` → error with the env var name
+      named in the message (apptainer runtime forgot to inject; never
+      silently skip the broker and write to the wrong db).
+    * Transport / 4xx / 5xx / malformed body → status + body
+      preserved verbatim.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status: int | None = None,
+        body: Any = None,
+    ) -> None:
+        super().__init__(message)
+        self.status = status
+        self.body = body
+
+
+def _resolve_base_url(explicit: str | None) -> str:
+    """Return the listen-server base URL or raise loudly.
+
+    Resolution order: explicit argument → ``SAC_LISTEN_BASE_URL``
+    via :func:`_env.getenv` (so either prefix works). Trailing
+    slash is stripped so the caller can safely concatenate
+    ``/v1/acl/...``.
+    """
+    if explicit:
+        return explicit.rstrip("/")
+    from .._env import getenv
+
+    raw = (getenv("LISTEN_BASE_URL", "") or "").strip()
+    if not raw:
+        raise AclBrokerError(
+            "ACL broker requires SAC_LISTEN_BASE_URL (the host-stable "
+            "`sac listen` URL injected into the container by the apptainer "
+            "runtime). Got empty/unset."
+        )
+    return raw.rstrip("/")
+
+
+def _resolve_bearer(explicit: str | None) -> str | None:
+    """Return the listen-server bearer token, or ``None`` if unset.
+
+    Unlike ``SAC_LISTEN_BASE_URL``, an absent bearer is not fatal:
+    a listen started without bearer auth still accepts the call.
+    The server enforces its own auth contract.
+    """
+    if explicit is not None:
+        return explicit or None
+    from .._env import getenv
+
+    return ((getenv("LISTEN_BEARER", "") or "").strip()) or None
+
+
+def _parse_body(raw: bytes) -> Any:
+    if not raw:
+        return None
+    try:
+        return json.loads(raw)
+    except ValueError:  # stx-allow: fallback (reason: non-JSON body surfaced verbatim to caller via AclBrokerError.body; never silently dropped)
+        return raw.decode("utf-8", errors="replace")
+
+
+def broker_acl_decision(
+    decision: str,
+    *,
+    sender: str,
+    target: str,
+    note: str | None = None,
+    base_url: str | None = None,
+    bearer: str | None = None,
+    timeout_s: float = _DEFAULT_TIMEOUT_S,
+    opener: Callable | None = None,
+) -> dict:
+    """POST an ACL decision (``unblock`` / ``block`` / ``grant``) to host listen.
+
+    ``decision`` selects the route — must be one of ``"unblock"``,
+    ``"block"``, ``"grant"`` (the last is an alias of ``unblock``
+    accepted server-side for back-compat).
+
+    Returns the host's JSON response on 2xx — the listen handler
+    returns the same envelope shape the local helper does
+    (``{"sender", "target", "granted"|"blocked", "unblocked",
+    "cleared_pending"}``). Raises :class:`AclBrokerError` on
+    transport / 4xx / 5xx / malformed-body / missing-env failure.
+    """
+    if decision not in ("unblock", "block", "grant"):
+        raise AclBrokerError(
+            f"unknown ACL decision {decision!r} — expected "
+            "'unblock', 'block', or 'grant'"
+        )
+    if not sender or not target:
+        raise AclBrokerError("broker_acl_decision: sender and target must be non-empty")
+
+    base = _resolve_base_url(base_url)
+    tok = _resolve_bearer(bearer)
+    body: dict[str, Any] = {"sender": sender, "target": target}
+    if note is not None:
+        body["note"] = note
+    payload = json.dumps(body).encode("utf-8")
+    url = f"{base}/v1/acl/{decision}"
+    headers = {"Content-Type": "application/json", "Accept": "application/json"}
+    if tok:
+        headers["Authorization"] = f"Bearer {tok}"
+
+    req = urlrequest.Request(url, data=payload, method="POST", headers=headers)
+    opener_fn = opener if opener is not None else urlrequest.urlopen
+
+    try:
+        with opener_fn(req, timeout=timeout_s) as resp:
+            raw = resp.read()
+            status = int(getattr(resp, "status", 200))
+    except urlerror.HTTPError as exc:
+        raw_body = b""
+        try:
+            raw_body = exc.read() or b""
+        except Exception:  # stx-allow: defensive — half-closed HTTPError body read may itself fail; we already have code + URL  # noqa: BLE001
+            pass
+        parsed = _parse_body(raw_body)
+        logger.warning(
+            "acl_broker: POST %s returned HTTP %s body=%r",
+            url,
+            exc.code,
+            parsed,
+        )
+        raise AclBrokerError(
+            f"ACL {decision} of {sender!r}→{target!r} rejected: listen "
+            f"returned HTTP {exc.code} ({parsed!r})",
+            status=exc.code,
+            body=parsed,
+        ) from exc
+    except (urlerror.URLError, OSError, ValueError) as exc:
+        logger.warning("acl_broker: POST %s transport error: %s", url, exc)
+        raise AclBrokerError(
+            f"ACL {decision} of {sender!r}→{target!r} failed: cannot reach "
+            f"listen at {base!r} ({exc})"
+        ) from exc
+
+    parsed = _parse_body(raw)
+    if status < 200 or status >= 300:
+        logger.warning(
+            "acl_broker: POST %s returned HTTP %s body=%r",
+            url,
+            status,
+            parsed,
+        )
+        raise AclBrokerError(
+            f"ACL {decision} of {sender!r}→{target!r} rejected: listen "
+            f"returned HTTP {status} ({parsed!r})",
+            status=status,
+            body=parsed,
+        )
+    if not isinstance(parsed, dict):
+        raise AclBrokerError(
+            f"ACL {decision} of {sender!r}→{target!r} got non-JSON body: {parsed!r}",
+            status=status,
+            body=parsed,
+        )
+    return parsed

--- a/src/scitex_agent_container/cli_pkg/_a2a_acl_dispatch.py
+++ b/src/scitex_agent_container/cli_pkg/_a2a_acl_dispatch.py
@@ -1,0 +1,64 @@
+"""ACL-decision dispatch for ``sac a2a {unblock,block,grant}`` (task #27 PR B).
+
+Extracted from ``a2a_group.py`` to keep that file under the 512-line
+cap. The CLI verbs in ``a2a_group.py`` call into here; this module
+owns the in-SIF detection + routing logic.
+
+Routing rule:
+
+* In-SIF → POST to host listen via :func:`_state._acl_broker_client.
+  broker_acl_decision`. The decision lands on the HOST'S state.db
+  (where ``sac listen`` runs), NOT the per-container copy that would
+  otherwise be a silent no-op (lead FUTURE item 4, operator
+  greenlit Q5 on 2026-06-01).
+* Bare host → call the local DB-only helpers in
+  :mod:`_state.grant_flush` directly. The lead runs ``sac listen``
+  on the bare host so a local write IS the host write — no HTTP
+  hop needed.
+
+Detection uses :func:`_lifecycle._in_sif_broker.is_in_sif` (added
+in PR #261) so the two broker paths (SAC-from-SAC spawn + this
+ACL decision) share the same in-SIF signal.
+"""
+
+from __future__ import annotations
+
+__all__ = ["dispatch_acl_decision"]
+
+
+def dispatch_acl_decision(
+    decision: str,
+    *,
+    sender: str,
+    target: str,
+    note: str | None,
+) -> dict:
+    """Route an ACL decision to the right backend.
+
+    ``decision`` is one of ``"unblock"`` / ``"block"`` / ``"grant"``
+    (the last is an alias of unblock; the host listen route accepts
+    it for back-compat).
+
+    Returns the result dict the backend produced. Raises
+    :class:`_state._acl_broker_client.AclBrokerError` (in-SIF) or
+    ``ValueError`` (bare-host empties) on failure.
+    """
+    from .._lifecycle._in_sif_broker import is_in_sif
+
+    if is_in_sif():
+        from .._state._acl_broker_client import broker_acl_decision
+
+        return broker_acl_decision(decision, sender=sender, target=target, note=note)
+
+    # Bare-host path — write the host's state.db directly via the
+    # local helpers. "unblock" and the legacy "grant" alias share
+    # one write path (matches the server's
+    # :func:`_listen._acl_routes.acl_grant` alias).
+    from .._state.grant_flush import (
+        block_and_clear_pending,
+        unblock_and_clear_pending,
+    )
+
+    if decision == "block":
+        return block_and_clear_pending(sender=sender, target=target, note=note)
+    return unblock_and_clear_pending(sender=sender, target=target, note=note)

--- a/src/scitex_agent_container/cli_pkg/a2a_group.py
+++ b/src/scitex_agent_container/cli_pkg/a2a_group.py
@@ -261,26 +261,34 @@ def _emit(result: dict, as_json: bool) -> None:
 def _do_unblock(sender: str, target: str, note: str | None) -> None:
     """Shared implementation for both ``grant`` (legacy) and ``unblock``.
 
-    Both verbs UNBLOCK ``SENDER → TARGET``: write the
-    ``comms_grants`` row (sender's future messages pass), remove any
-    ``comms_blocks`` row (if previously blocked), and clear any
-    ``pending_prompts`` row so the receiver is not re-prompted on
-    the next denied attempt. Per lead's task #27 amendment, NO held
-    message is replayed — the sender resends if needed.
+    Task #27 PR B: dispatches via
+    :func:`_a2a_acl_dispatch.dispatch_acl_decision` which routes
+    in-SIF → host listen HTTP (so the write lands on the host's
+    state.db) and bare-host → local DB helpers directly.
     """
-    from .._state.grant_flush import unblock_and_clear_pending
+    from ._a2a_acl_dispatch import dispatch_acl_decision
 
     try:
-        result = unblock_and_clear_pending(sender=sender, target=target, note=note)
+        result = dispatch_acl_decision(
+            "unblock", sender=sender, target=target, note=note
+        )
+    except click.ClickException:
+        raise
     except ValueError as exc:
         click.echo(f"error: {exc}", err=True)
         raise SystemExit(2) from exc
+    except Exception as exc:
+        # In-SIF broker raised an AclBrokerError (or transport
+        # error). Surface as a clean ClickException so the
+        # operator sees a single-line stderr instead of a
+        # traceback.
+        raise click.ClickException(str(exc)) from exc
     from ._helpers import console
 
     extras = []
-    if result["unblocked"]:
+    if result.get("unblocked"):
         extras.append("removed block")
-    if result["cleared_pending"]:
+    if result.get("cleared_pending"):
         extras.append("cleared pending prompt")
     tail = f" [dim]({'; '.join(extras)})[/dim]" if extras else ""
     console.print(f"[green]ok[/green]  unblocked  {sender}  ->  {target}{tail}")
@@ -366,16 +374,22 @@ def a2a_block(sender: str, target: str, note: str | None) -> None:
       $ sac a2a block worker-a lead
       $ sac a2a block worker-a lead --note "prompt msg_id abc123"
     """
-    from .._state.grant_flush import block_and_clear_pending
+    from ._a2a_acl_dispatch import dispatch_acl_decision
 
     try:
-        result = block_and_clear_pending(sender=sender, target=target, note=note)
+        result = dispatch_acl_decision("block", sender=sender, target=target, note=note)
+    except click.ClickException:
+        raise
     except ValueError as exc:
         click.echo(f"error: {exc}", err=True)
         raise SystemExit(2) from exc
+    except Exception as exc:
+        raise click.ClickException(str(exc)) from exc
     from ._helpers import console
 
-    tail = " [dim](cleared pending prompt)[/dim]" if result["cleared_pending"] else ""
+    tail = (
+        " [dim](cleared pending prompt)[/dim]" if result.get("cleared_pending") else ""
+    )
     console.print(f"[yellow]ok[/yellow]  blocked  {sender}  ->  {target}{tail}")
 
 

--- a/tests/scitex_agent_container/_listen/test__acl_routes.py
+++ b/tests/scitex_agent_container/_listen/test__acl_routes.py
@@ -1,0 +1,201 @@
+"""End-to-end tests for the host listen's ACL routes (task #27 PR B).
+
+The in-container CLI POSTs to ``/v1/acl/{unblock,block,grant}`` to
+target the HOST listen's state.db instead of the per-container
+copy. These tests exercise the routes against a real Starlette
+``TestClient`` and assert they call the same DB-only helpers the
+bare-host CLI uses (so the operator log + state.db forensics see
+the same operation either way).
+
+No-mocks (PA-306): real on-disk state.db, real TestClient, real
+bearer auth.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+from starlette.testclient import TestClient
+
+from scitex_agent_container._listen.server import create_app
+from scitex_agent_container._state import state_db
+from scitex_agent_container._state.state_db_blocks import has_block
+from scitex_agent_container._state.state_db_nodes import has_grant
+
+_TOKEN = "test-token-acl-routes"
+
+
+@pytest.fixture
+def isolated_state(tmp_path: Path) -> Iterator[Path]:
+    db = tmp_path / "state.db"
+    saved_env = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB")
+    saved_default = state_db.DEFAULT_DB_PATH
+    os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
+    state_db.DEFAULT_DB_PATH = db
+    state_db.init_schema(db)
+    try:
+        yield db
+    finally:
+        state_db.DEFAULT_DB_PATH = saved_default
+        if saved_env is None:
+            os.environ.pop("SCITEX_AGENT_CONTAINER_STATE_DB", None)
+        else:
+            os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = saved_env
+
+
+def _auth() -> dict[str, str]:
+    return {"authorization": f"Bearer {_TOKEN}"}
+
+
+# ---------------------------------------------------------------------------
+# /v1/acl/unblock — writes comms_grants
+# ---------------------------------------------------------------------------
+
+
+def test_unblock_route_writes_comms_grants_row(isolated_state: Path) -> None:
+    # Arrange
+    app = create_app(token=_TOKEN)
+    # Act
+    with TestClient(app) as client:
+        r = client.post(
+            "/v1/acl/unblock",
+            json={"sender": "alice", "target": "lead"},
+            headers=_auth(),
+        )
+    # Assert
+    assert has_grant(sender="alice", target="lead", db_path=isolated_state)
+
+
+def test_unblock_route_returns_200(isolated_state: Path) -> None:
+    # Arrange
+    app = create_app(token=_TOKEN)
+    # Act
+    with TestClient(app) as client:
+        r = client.post(
+            "/v1/acl/unblock",
+            json={"sender": "alice", "target": "lead"},
+            headers=_auth(),
+        )
+    # Assert
+    assert r.status_code == 200
+
+
+def test_unblock_route_response_envelope_carries_decision_fields(
+    isolated_state: Path,
+) -> None:
+    # Arrange
+    app = create_app(token=_TOKEN)
+    # Act
+    with TestClient(app) as client:
+        r = client.post(
+            "/v1/acl/unblock",
+            json={"sender": "alice", "target": "lead"},
+            headers=_auth(),
+        )
+    body = r.json()
+    # Assert
+    assert body.get("granted") is True
+
+
+# ---------------------------------------------------------------------------
+# /v1/acl/block — writes comms_blocks
+# ---------------------------------------------------------------------------
+
+
+def test_block_route_writes_comms_blocks_row(isolated_state: Path) -> None:
+    # Arrange
+    app = create_app(token=_TOKEN)
+    # Act
+    with TestClient(app) as client:
+        client.post(
+            "/v1/acl/block",
+            json={"sender": "alice", "target": "lead"},
+            headers=_auth(),
+        )
+    # Assert
+    assert has_block(sender="alice", target="lead", db_path=isolated_state)
+
+
+# ---------------------------------------------------------------------------
+# /v1/acl/grant — alias of unblock
+# ---------------------------------------------------------------------------
+
+
+def test_grant_route_writes_comms_grants_like_unblock(
+    isolated_state: Path,
+) -> None:
+    # Arrange
+    app = create_app(token=_TOKEN)
+    # Act
+    with TestClient(app) as client:
+        client.post(
+            "/v1/acl/grant",
+            json={"sender": "alice", "target": "lead"},
+            headers=_auth(),
+        )
+    # Assert
+    assert has_grant(sender="alice", target="lead", db_path=isolated_state)
+
+
+# ---------------------------------------------------------------------------
+# Bad input — fail loud with 400
+# ---------------------------------------------------------------------------
+
+
+def test_missing_sender_returns_400(isolated_state: Path) -> None:
+    # Arrange
+    app = create_app(token=_TOKEN)
+    # Act
+    with TestClient(app) as client:
+        r = client.post(
+            "/v1/acl/unblock",
+            json={"target": "lead"},
+            headers=_auth(),
+        )
+    # Assert
+    assert r.status_code == 400
+
+
+def test_missing_target_returns_400(isolated_state: Path) -> None:
+    # Arrange
+    app = create_app(token=_TOKEN)
+    # Act
+    with TestClient(app) as client:
+        r = client.post(
+            "/v1/acl/block",
+            json={"sender": "alice"},
+            headers=_auth(),
+        )
+    # Assert
+    assert r.status_code == 400
+
+
+def test_malformed_body_returns_400(isolated_state: Path) -> None:
+    # Arrange
+    app = create_app(token=_TOKEN)
+    # Act
+    with TestClient(app) as client:
+        r = client.post(
+            "/v1/acl/unblock",
+            content=b"not-json",
+            headers={**_auth(), "Content-Type": "application/json"},
+        )
+    # Assert
+    assert r.status_code == 400
+
+
+def test_missing_bearer_returns_401_or_403(isolated_state: Path) -> None:
+    # Arrange — no Authorization header.
+    app = create_app(token=_TOKEN)
+    # Act
+    with TestClient(app) as client:
+        r = client.post(
+            "/v1/acl/unblock",
+            json={"sender": "alice", "target": "lead"},
+        )
+    # Assert — middleware rejects (some configs use 401, some 403;
+    # accept either as long as it is NOT a 2xx success).
+    assert r.status_code >= 400 and r.status_code < 500

--- a/tests/scitex_agent_container/_state/test__acl_broker_client.py
+++ b/tests/scitex_agent_container/_state/test__acl_broker_client.py
@@ -1,0 +1,301 @@
+"""Tests for the in-container ACL broker HTTP client (task #27 PR B).
+
+Mirrors :mod:`tests/.../_lifecycle/test__spawn_client` shape — no
+mocks, real ``urllib.request.Request`` shape inspection via an
+injectable ``opener`` callable, real env save/restore (no
+monkeypatch on production internals).
+
+The broker translates an ACL decision into a single POST against
+the host listen's ``/v1/acl/{decision}`` route, carrying the
+``SAC_LISTEN_BEARER`` token when present.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+from typing import Iterator
+from urllib import error as urlerror
+
+import pytest
+
+from scitex_agent_container._state._acl_broker_client import (
+    AclBrokerError,
+    broker_acl_decision,
+)
+
+# ---------------------------------------------------------------------------
+# Fake response + opener factories (real objects, urllib protocol)
+# ---------------------------------------------------------------------------
+
+
+class _FakeResp:
+    def __init__(self, body: bytes, status: int = 200) -> None:
+        self._body = body
+        self.status = status
+
+    def __enter__(self) -> "_FakeResp":
+        return self
+
+    def __exit__(self, *args: object) -> bool:
+        return False
+
+    def read(self) -> bytes:
+        return self._body
+
+
+def _opener_returning(body: bytes, status: int = 200):
+    captured: dict = {}
+
+    def opener(req, timeout=None):
+        captured["url"] = req.full_url
+        captured["method"] = req.get_method()
+        captured["body"] = req.data
+        captured["headers"] = {k.lower(): v for k, v in dict(req.headers).items()}
+        captured["timeout"] = timeout
+        return _FakeResp(body, status)
+
+    return opener, captured
+
+
+# ---------------------------------------------------------------------------
+# Env fixtures — toggle SAC_LISTEN_BASE_URL + SAC_LISTEN_BEARER
+# ---------------------------------------------------------------------------
+
+
+_LISTEN_KEYS = (
+    "SAC_LISTEN_BASE_URL",
+    "SCITEX_AGENT_CONTAINER_LISTEN_BASE_URL",
+    "SAC_LISTEN_BEARER",
+    "SCITEX_AGENT_CONTAINER_LISTEN_BEARER",
+)
+
+
+@pytest.fixture
+def listen_env() -> Iterator[callable]:
+    saved = {k: os.environ.get(k) for k in _LISTEN_KEYS}
+    for k in _LISTEN_KEYS:
+        os.environ.pop(k, None)
+
+    def _set(suffix: str, value: str | None) -> None:
+        short = f"SAC_{suffix}"
+        long_ = f"SCITEX_AGENT_CONTAINER_{suffix}"
+        os.environ.pop(long_, None)
+        if value is None:
+            os.environ.pop(short, None)
+        else:
+            os.environ[short] = value
+
+    try:
+        yield _set
+    finally:
+        for k in _LISTEN_KEYS:
+            os.environ.pop(k, None)
+        for k, prev in saved.items():
+            if prev is not None:
+                os.environ[k] = prev
+
+
+# ---------------------------------------------------------------------------
+# Missing base URL — fail loud
+# ---------------------------------------------------------------------------
+
+
+def test_missing_base_url_raises_acl_broker_error(listen_env) -> None:
+    # Arrange — env is clean (fixture pre-clears).
+    msg = ""
+    # Act
+    try:
+        broker_acl_decision(
+            "unblock",
+            sender="a",
+            target="b",
+            opener=lambda req, timeout=None: _FakeResp(b"", 200),
+        )
+    except AclBrokerError as exc:
+        msg = str(exc)
+    # Assert — the env var name must appear in the message so the
+    # operator knows which container var the apptainer runtime
+    # missed.
+    assert "SAC_LISTEN_BASE_URL" in msg
+
+
+# ---------------------------------------------------------------------------
+# Happy path — POST shape
+# ---------------------------------------------------------------------------
+
+
+def test_post_targets_unblock_route(listen_env) -> None:
+    # Arrange
+    listen_env("LISTEN_BASE_URL", "http://host:9100/")  # trailing slash
+    opener, captured = _opener_returning(b'{"granted":true}')
+    # Act
+    broker_acl_decision("unblock", sender="a", target="b", opener=opener)
+    # Assert
+    assert captured["url"] == "http://host:9100/v1/acl/unblock"
+
+
+def test_post_targets_block_route(listen_env) -> None:
+    # Arrange
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    opener, captured = _opener_returning(b'{"blocked":true}')
+    # Act
+    broker_acl_decision("block", sender="a", target="b", opener=opener)
+    # Assert
+    assert captured["url"] == "http://host:9100/v1/acl/block"
+
+
+def test_post_targets_grant_route(listen_env) -> None:
+    # Arrange — legacy alias of unblock.
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    opener, captured = _opener_returning(b'{"granted":true}')
+    # Act
+    broker_acl_decision("grant", sender="a", target="b", opener=opener)
+    # Assert
+    assert captured["url"] == "http://host:9100/v1/acl/grant"
+
+
+def test_post_uses_http_post_method(listen_env) -> None:
+    # Arrange
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    opener, captured = _opener_returning(b"{}")
+    # Act
+    broker_acl_decision("unblock", sender="a", target="b", opener=opener)
+    # Assert
+    assert captured["method"] == "POST"
+
+
+def test_post_body_includes_sender_and_target(listen_env) -> None:
+    # Arrange
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    opener, captured = _opener_returning(b"{}")
+    # Act
+    broker_acl_decision("block", sender="alice", target="lead", opener=opener)
+    # Assert
+    body = json.loads(captured["body"])
+    assert body["sender"] == "alice" and body["target"] == "lead"
+
+
+def test_post_body_omits_note_when_absent(listen_env) -> None:
+    # Arrange — note is optional; absence is normal.
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    opener, captured = _opener_returning(b"{}")
+    # Act
+    broker_acl_decision("unblock", sender="a", target="b", opener=opener)
+    # Assert
+    assert "note" not in json.loads(captured["body"])
+
+
+def test_post_body_includes_note_when_set(listen_env) -> None:
+    # Arrange
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    opener, captured = _opener_returning(b"{}")
+    # Act
+    broker_acl_decision(
+        "unblock",
+        sender="a",
+        target="b",
+        note="prompt msg_id abc123",
+        opener=opener,
+    )
+    # Assert
+    assert json.loads(captured["body"])["note"] == "prompt msg_id abc123"
+
+
+def test_bearer_attached_as_authorization_header(listen_env) -> None:
+    # Arrange
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    listen_env("LISTEN_BEARER", "tok-abc")
+    opener, captured = _opener_returning(b"{}")
+    # Act
+    broker_acl_decision("unblock", sender="a", target="b", opener=opener)
+    # Assert
+    assert captured["headers"].get("authorization") == "Bearer tok-abc"
+
+
+def test_no_authorization_header_when_bearer_unset(listen_env) -> None:
+    # Arrange
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    opener, captured = _opener_returning(b"{}")
+    # Act
+    broker_acl_decision("unblock", sender="a", target="b", opener=opener)
+    # Assert
+    assert "authorization" not in captured["headers"]
+
+
+def test_returns_parsed_server_body_on_success(listen_env) -> None:
+    # Arrange
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    body = {
+        "sender": "alice",
+        "target": "lead",
+        "granted": True,
+        "unblocked": False,
+        "cleared_pending": True,
+    }
+    opener, _ = _opener_returning(json.dumps(body).encode())
+    # Act
+    result = broker_acl_decision(
+        "unblock", sender="alice", target="lead", opener=opener
+    )
+    # Assert
+    assert result["cleared_pending"] is True
+
+
+# ---------------------------------------------------------------------------
+# Failure modes — fail loud, surface status + body verbatim
+# ---------------------------------------------------------------------------
+
+
+def test_http_4xx_raises_with_status_in_error(listen_env) -> None:
+    # Arrange
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+
+    def opener(req, timeout=None):
+        raise urlerror.HTTPError(
+            req.full_url, 400, "Bad Request", {}, io.BytesIO(b'{"error":"x"}')
+        )
+
+    status = None
+    # Act
+    try:
+        broker_acl_decision("unblock", sender="a", target="b", opener=opener)
+    except AclBrokerError as exc:
+        status = exc.status
+    # Assert
+    assert status == 400
+
+
+def test_transport_error_raises_with_clear_reason(listen_env) -> None:
+    # Arrange — host listen unreachable.
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+
+    def opener(req, timeout=None):
+        raise urlerror.URLError("Connection refused")
+
+    msg = ""
+    # Act
+    try:
+        broker_acl_decision("unblock", sender="a", target="b", opener=opener)
+    except AclBrokerError as exc:
+        msg = str(exc)
+    # Assert
+    assert "cannot reach listen" in msg
+
+
+def test_unknown_decision_raises_loudly() -> None:
+    # Arrange
+    # Act
+    # Assert
+    with pytest.raises(AclBrokerError, match="unknown ACL decision"):
+        broker_acl_decision("nope", sender="a", target="b")
+
+
+def test_empty_sender_raises_loudly(listen_env) -> None:
+    # Arrange
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    # Act
+    # Assert
+    with pytest.raises(AclBrokerError, match="non-empty"):
+        broker_acl_decision("unblock", sender="", target="b")


### PR DESCRIPTION
## Summary

Operator-greenlit Q5 / lead FUTURE item 4. Today the in-container CLI verbs `sac a2a {unblock,block,grant}` write the per-container state.db — silently ineffective against the host listen's ACL checks (which consult the HOST'S state.db, a different file).

This PR closes that gap by giving the in-container CLI a way to TARGET the host listen's state.db over HTTP, mirroring the SAC-from-SAC `_lifecycle._spawn_client` → `POST /agents` broker pattern from #261.

**Stack:** this is **PR B of 2**. PR A (#278, MERGED) added the local-only block/unblock primitive.

## What's added

**Listen routes** (new `_listen/_acl_routes.py`):
- `POST /v1/acl/unblock`  body `{sender, target, note?}`
- `POST /v1/acl/block`    body `{sender, target, note?}`
- `POST /v1/acl/grant`    body `{sender, target, note?}` (legacy alias of unblock)

Each calls the SAME DB helper the bare-host CLI uses (`unblock_and_clear_pending` / `block_and_clear_pending`), so a future operator who reads the server log sees the same operation either way.

**Broker client** (new `_state/_acl_broker_client.py`):
- `broker_acl_decision(decision, sender, target, note, ...)` — stdlib-only `urllib.request` POST.
- Resolves `SAC_LISTEN_BASE_URL` + `SAC_LISTEN_BEARER` from env via `_env.getenv` (both prefix forms).
- Fails loud via `AclBrokerError` carrying `status` + parsed body on any transport / 4xx / 5xx / missing-env failure.

**CLI dispatch** (new `cli_pkg/_a2a_acl_dispatch.py`):
- `dispatch_acl_decision(...)` — detects in-SIF via `_lifecycle._in_sif_broker.is_in_sif` (added in #261, same signal as the SAC-from-SAC broker) and routes:
  - in-SIF  → `broker_acl_decision` (host listen HTTP)
  - bare    → local DB-only helpers (no extra hop, no HTTP)
- `cli_pkg/a2a_group.py::_do_unblock` + `a2a_block` swapped to call this helper; `AclBrokerError` surfaces as a clean `click.ClickException` instead of a traceback.

## Test plan

22 new no-mocks tests (14 broker client + 8 listen routes), all green locally:

- [x] `_state/test__acl_broker_client.py` — POST shape (URL + method + body), bearer attached when set, missing base URL fails loud, 4xx surfaces status, transport error surfaces clear reason, unknown decision rejected, empty inputs raise.
- [x] `_listen/test__acl_routes.py` — each route writes the right state.db table, returns 2xx + envelope, missing fields → 400, malformed body → 400, missing bearer → 4xx.
- [x] All 59 task #27 tests green (incl. the 35 from PR A re-run against this branch — no regression).

## Scope

This is the LAST follow-on PR for task #27. With this landing:
- Cross-group denied sends emit ONE receiver-facing prompt with both `sac a2a unblock` / `sac a2a block` commands embedded.
- Receiver runs either verb from ANY context (bare host OR in-container) and the write lands on the HOST listen's state.db.
- Block precedence honoured everywhere; pending prompt cleared on either decision; no held-message replay; no TTL knob.