### PR TITLE
feat(agents-list): per-agent CPU% + RSS in `sac agents list` / `status --json`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- **feat(agents-list): per-agent CPU% + RSS in `sac agents list` and
+  `sac agents status --json`** (lead task 2026-06-01).
+  - New helper ``_state._meta.resources.collect_agent_resources``:
+    given an iterable of PIDs, walks each one's process tree (root +
+    descendants) and returns ``{"cpu_percent": float, "mem_rss_mb":
+    float}`` per PID via a SINGLE psutil sweep (one batched ~100ms
+    sleep covers every agent's cpu_percent delta — wall-clock cost is
+    constant in agent count). Dead PIDs / unknown sentinel ``0`` /
+    psutil-unavailable map to ``None`` rather than zero-filled — the
+    observability contract from skill leaf
+    ``13_observability.md`` (absent ≠ 0) holds end-to-end.
+  - ``sac agents list`` rows now carry ``cpu_percent`` and
+    ``mem_rss_mb`` for every running agent whose PID resolves;
+    rendered as right-aligned ``CPU%`` and ``MEM`` columns in the
+    human table (``-`` cell when absent). JSON path emits the keys
+    only when present — downstream fleet hubs / dashboards can
+    distinguish "not probed" from "literally idle".
+  - ``sac agents status --json`` carries the same two fields for the
+    single-agent path, sourced from the registry-recorded PID.
+  - ``TERSE_STATUS_FIELDS`` (``--terse`` projection) extended with
+    ``cpu_percent`` and ``mem_rss_mb`` so fleet hubs reading the
+    terse blob get attribution by default.
+  - TDD / no-mocks (PA-306): all new tests exercise real OS processes
+    — ``os.getpid()`` for the live-PID case, ``subprocess.Popen`` for
+    the descendants case, and a deliberately-unused PID
+    (``2**31 - 1``) for the dead-PID case. No psutil patching, no
+    ``MagicMock``, no ``monkeypatch`` of ``Process``.
+
 ## [0.21.9] — 2026-06-01
 
 ### Fixed

--- a/src/scitex_agent_container/_lifecycle/_status.py
+++ b/src/scitex_agent_container/_lifecycle/_status.py
@@ -201,6 +201,26 @@ def agent_status(
     except Exception:  # stx-allow: fallback (reason: catch-all safety net — see inline comment for context)
         result["snapshot"] = None
 
+    # Lead task 2026-06-01: per-agent CPU% + RSS in the status JSON. The
+    # list command does its own batched probe across all rows; for the
+    # single-agent status path we probe one PID directly. Same module
+    # (``_state._meta.resources.collect_agent_resources``), same
+    # observability contract (absent ≠ 0, dead PID → no fields).
+    # stx-allow: fallback (reason: psutil is an optional dependency;
+    # absence (or any per-process probe failure) absent-outs the row
+    # rather than crashing status — same shape as the host metrics block.)
+    try:
+        from .._state._meta.resources import collect_agent_resources
+
+        _pid_for_probe = entry.get("pid") or 0
+        if _pid_for_probe:
+            _agent_res = collect_agent_resources([_pid_for_probe]).get(_pid_for_probe)
+            if _agent_res is not None:
+                result["cpu_percent"] = _agent_res["cpu_percent"]
+                result["mem_rss_mb"] = _agent_res["mem_rss_mb"]
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        pass
+
     # Enrich with claude-hud-style metadata. Canonical source for the
     # Agents-tab dashboard; the MCP sidecar heartbeat shells out to this
     # command rather than duplicating the logic in TypeScript.

--- a/src/scitex_agent_container/_state/_meta/resources.py
+++ b/src/scitex_agent_container/_state/_meta/resources.py
@@ -1,17 +1,29 @@
-"""Process / host-resource helpers for ``agent_meta.collect_rich``.
+"""Process / host-resource helpers for ``agent_meta.collect_rich``
+and ``sac agents list``.
 
 Extracted from ``agent_meta.py`` to keep that module under the 512-line
 hook ceiling. ``agent_meta`` re-exports ``_pids_from_session`` so
 existing test access (``agent_meta._pids_from_session``) keeps working.
 
-``_collect_host_metrics`` is the inline psutil block from ``collect_rich``
-lifted verbatim — moved so the parent module shrinks below the ceiling.
+Three helpers, three callers:
+
+* ``_pids_from_session`` — resolves a tmux session to (pid, ppid).
+  Used by ``agent_meta.collect_rich`` for the rich-status surface.
+* ``_collect_host_metrics`` — host-wide CPU/mem/disk via psutil.
+  Used by ``agent_meta.collect_rich`` to populate the ``machine``
+  block (the dashboard dedupes by hostname).
+* ``collect_agent_resources`` — PER-AGENT CPU% + RSS for the
+  ``sac agents list`` row, walking the recorded PID + its descendants
+  in a single psutil sweep. Lead task 2026-06-01: attribute host load
+  to specific agents. Best-effort: dead PIDs return ``None``, never
+  raise.
 """
 
 from __future__ import annotations
 
 import subprocess
-from typing import Any
+import time
+from typing import Any, Iterable
 
 
 def _pids_from_session(session: str, multiplexer: str) -> tuple[int, int]:
@@ -90,3 +102,141 @@ def _collect_host_metrics() -> dict[str, Any]:
         }
     except Exception:  # stx-allow: fallback (reason: catch-all safety net — see inline comment for context)
         return {}
+
+
+# ---------------------------------------------------------------------------
+# Per-agent process-tree resource probe (sac agents list, lead task 2026-06-01)
+# ---------------------------------------------------------------------------
+
+
+# When the registry doesn't know an agent's PID, ``_pids_from_session``
+# returns ``0`` as the sentinel. ``psutil.Process(0)`` resolves to the
+# kernel idle process on Linux which would surface bogus aggregate data
+# (or crash on AccessDenied). Treat 0 as "no PID known" everywhere.
+_UNKNOWN_PID_SENTINEL = 0
+
+# How long to sleep between the prime call and the readout call for
+# ``cpu_percent``. Process-level ``cpu_percent`` needs two samples to
+# compute a delta. We do ONE batched sleep for the whole sweep instead
+# of one per process so the wall-clock cost is constant in agent count.
+_CPU_SAMPLE_INTERVAL_S = 0.1
+
+
+def collect_agent_resources(
+    pids: Iterable[int],
+    *,
+    cpu_sample_interval_s: float = _CPU_SAMPLE_INTERVAL_S,
+) -> dict[int, dict[str, float] | None]:
+    """Return per-PID ``{"cpu_percent": float, "mem_rss_mb": float}`` or
+    ``None`` when the PID is dead/unknown/unprobable.
+
+    Each input PID is treated as the root of an agent's container
+    process tree; CPU% and RSS are summed over the root + its
+    descendants in a single psutil sweep. CPU% is computed across a
+    single batched ``cpu_sample_interval_s`` sleep, NOT per process,
+    so the wall-clock cost is ~``cpu_sample_interval_s`` regardless
+    of how many agents are registered.
+
+    Contract:
+
+    * The output dict has exactly the same keyspace as ``pids`` (a
+      dict, not a list — caller looks up by recorded PID).
+    * A PID whose process does not exist, was never created, or is
+      ``_UNKNOWN_PID_SENTINEL`` (``0`` — the registry's "unknown"
+      placeholder) maps to ``None``. Never to a zero-filled dict —
+      the observability skill is explicit that ``absent ≠ 0`` so
+      consumers can distinguish "not probed" from "empty".
+    * Partial process-tree death (root alive, one descendant just
+      exited) does NOT void the whole result — the alive members are
+      still summed in. The probe is best-effort by design.
+    * Empty input → empty output (no sleep, no psutil call).
+    * Hard psutil unavailability (import error) → every key maps to
+      ``None`` (NOT an exception). The list command must still render.
+
+    Args:
+        pids: The registered PID of each agent (the apptainer
+            container root; descendants are discovered).
+        cpu_sample_interval_s: Sleep between prime and readout. Defaults
+            to 100ms — long enough for cpu_percent to compute a non-
+            zero delta on a busy core, short enough to not visibly
+            slow ``sac agents list``.
+
+    Returns:
+        ``dict[int, dict[str, float] | None]`` keyed by input PID.
+    """
+    pid_list = list(pids)
+    if not pid_list:
+        return {}
+
+    # stx-allow: fallback (reason: psutil is an optional dependency;
+    # absent on minimal installs — every agent absent-outs, list still
+    # renders without resource columns)
+    try:
+        import psutil as _psutil
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        return {pid: None for pid in pid_list}
+
+    # 1. Build process trees in one pass. Bad PIDs short-circuit to
+    #    ``None`` here so we never call ``cpu_percent`` on them.
+    trees: dict[int, list[Any] | None] = {}
+    for pid in pid_list:
+        if pid == _UNKNOWN_PID_SENTINEL or pid < 0:
+            trees[pid] = None
+            continue
+        # stx-allow: fallback (reason: NoSuchProcess / AccessDenied /
+        # ZombieProcess all map to "not probable" — None propagates to
+        # the caller, who renders ``-`` in the table)
+        try:
+            root = _psutil.Process(pid)
+            descendants = root.children(recursive=True)
+            trees[pid] = [root, *descendants]
+        except Exception:  # stx-allow: fallback (reason: see inline comment)
+            trees[pid] = None
+
+    # 2. Prime cpu_percent counters. The first call always returns 0.0
+    #    (or a meaningless reading); the second call after a sleep
+    #    returns the delta. Errors here are non-fatal — they just mean
+    #    that process's contribution falls out of the sum.
+    for tree in trees.values():
+        if tree is None:
+            continue
+        for proc in tree:
+            # stx-allow: fallback (reason: process may die between
+            # children() and cpu_percent(); we just drop it from the sum)
+            try:
+                proc.cpu_percent(interval=None)
+            except Exception:  # stx-allow: fallback (reason: see inline comment)
+                pass
+
+    # 3. ONE batched sleep for the whole sweep.
+    time.sleep(cpu_sample_interval_s)
+
+    # 4. Readout: cpu_percent delta + rss snapshot, summed per tree.
+    out: dict[int, dict[str, float] | None] = {}
+    for pid, tree in trees.items():
+        if tree is None:
+            out[pid] = None
+            continue
+        cpu_sum = 0.0
+        rss_sum = 0
+        contributing = 0
+        for proc in tree:
+            # stx-allow: fallback (reason: per-process probe can fail
+            # mid-readout; we just skip that contribution and keep
+            # summing the rest — partial is better than absent)
+            try:
+                cpu_sum += float(proc.cpu_percent(interval=None))
+                rss_sum += int(proc.memory_info().rss)
+                contributing += 1
+            except Exception:  # stx-allow: fallback (reason: see inline comment)
+                continue
+        if contributing == 0:
+            # The root and every descendant died between step 1 and 4.
+            # Treat as "not probable" rather than reporting zero.
+            out[pid] = None
+            continue
+        out[pid] = {
+            "cpu_percent": round(cpu_sum, 1),
+            "mem_rss_mb": round(rss_sum / _MB, 1),
+        }
+    return out

--- a/src/scitex_agent_container/cli_pkg/_helpers/_agent_list.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers/_agent_list.py
@@ -151,6 +151,11 @@ def get_agent_list_data(
             if capability not in caps:
                 continue
 
+        # ``pid`` carries the recorded container-root PID from the
+        # registry. Used downstream by the per-agent resource probe
+        # (``cpu_percent`` + ``mem_rss_mb``) to walk the process tree.
+        # Absent / ``0`` is the registry's "unknown PID" sentinel; the
+        # probe maps that to ``None`` so the row gets no resource keys.
         prep = {
             "idx": idx,
             "name": name,
@@ -159,6 +164,7 @@ def get_agent_list_data(
             "labels": labels,
             "cfg": cfg,
             "config_path": config_path,
+            "pid": entry.get("pid") or 0,
         }
         prepared.append(prep)
 
@@ -202,6 +208,32 @@ def get_agent_list_data(
                     probe_results[idx] = None
         finally:
             pool.shutdown(wait=False)
+
+    # 2.5th pass: per-agent CPU% + RSS via ONE psutil sweep. Walks each
+    # running agent's recorded PID + descendants (the apptainer
+    # container process tree). Lead task 2026-06-01: attribute host
+    # load to specific agents.
+    #
+    # Best-effort + cheap: a single ~100ms batched sleep covers every
+    # agent's cpu_percent delta — wall-clock cost is constant in agent
+    # count. Probe is called for the FULL prepared set; dead / unknown
+    # PIDs map to ``None`` inside ``collect_agent_resources`` and get
+    # no resource keys on the row (skill leaf 13_observability rule:
+    # ``absent ≠ 0``).
+    from ..._state._meta.resources import collect_agent_resources
+
+    _pids_to_probe = [prep["pid"] for prep in prepared if prep.get("pid")]
+    # stx-allow: fallback (reason: psutil may be absent or a per-process
+    # probe may fail mid-sweep; the list command must still render
+    # without resource columns. ``collect_agent_resources`` already
+    # absent-outs each PID on its own; this outer guard just catches
+    # the optional-dep ImportError case at module-import time.)
+    try:
+        _resources_by_pid: dict[int, dict[str, float] | None] = (
+            collect_agent_resources(_pids_to_probe) if _pids_to_probe else {}
+        )
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        _resources_by_pid = {}
 
     # Third pass: build result rows. Per-row config_path is pulled
     # from each ``prep`` dict so validation runs against the agent's
@@ -279,6 +311,14 @@ def get_agent_list_data(
             row["liveness_unknown"] = True
         if labels:
             row["labels"] = labels
+        # Lead task 2026-06-01: attribute host load to specific agents.
+        # Two new fields, both ABSENT (not 0.0, not None) when the
+        # process-tree probe can't resolve the agent's PID — observability
+        # contract distinguishes "not probed" from "empty".
+        _res = _resources_by_pid.get(prep["pid"])
+        if _res is not None:
+            row["cpu_percent"] = _res["cpu_percent"]
+            row["mem_rss_mb"] = _res["mem_rss_mb"]
         results.append(row)
 
     # Merge in agents that are *defined* on disk but absent from the
@@ -411,6 +451,13 @@ def print_agent_list(
     # Account labels (e.g. ``<name> (<email>)``) can be long; fold within
     # the cell rather than stealing width from the name column.
     table.add_column("Account", overflow="fold")
+    # Lead task 2026-06-01: CPU% + MEM columns so the operator can
+    # attribute host load (~load 42 at the time of this change) to
+    # specific agents instead of staring at host-wide summaries. Right-
+    # aligned (numeric); cells render as ``-`` when the row's
+    # resource probe absent-outs (dead PID, psutil missing, etc.).
+    table.add_column("CPU%", justify="right", no_wrap=True)
+    table.add_column("MEM", justify="right", no_wrap=True)
     table.add_column("Path", overflow="fold")
     table.add_column("Started")
     cmap = {
@@ -432,12 +479,18 @@ def print_agent_list(
         )
         started = row["started_at"] if row["started_at"] not in ("-", "?") else "—"
         account_cell = row.get("account") or "—"
+        # Absent (not in row) ≠ 0 — render the placeholder cell so the
+        # operator distinguishes "not probed" from "literally idle".
+        cpu_cell = f"{row['cpu_percent']:.1f}" if "cpu_percent" in row else "-"
+        mem_cell = f"{row['mem_rss_mb']:.0f}M" if "mem_rss_mb" in row else "-"
         table.add_row(
             row["name"],
             f"[{col}]{row['status']}[/{col}]",
             yaml_cell,
             host_cell,
             account_cell,
+            cpu_cell,
+            mem_cell,
             row.get("path") or "—",
             started,
         )

--- a/src/scitex_agent_container/terse.py
+++ b/src/scitex_agent_container/terse.py
@@ -90,6 +90,12 @@ TERSE_STATUS_FIELDS: tuple[str, ...] = (
     "skills_loaded",
     "hostname_canonical",
     "machine",
+    # Lead task 2026-06-01: per-agent CPU% + RSS so the terse status
+    # surface can attribute host load to individual agents. Absent when
+    # the recorded PID is unknown / dead — see
+    # ``_state._meta.resources.collect_agent_resources``.
+    "cpu_percent",
+    "mem_rss_mb",
 )
 
 # Whitelist used by ``scitex-agent-container take-snapshot --json --terse``.

--- a/tests/scitex_agent_container/_lifecycle/test_lifecycle.py
+++ b/tests/scitex_agent_container/_lifecycle/test_lifecycle.py
@@ -1483,6 +1483,93 @@ def test_agent_status_config_load_failure_reports_unknown_model_and_runtime(
 
 
 # ---------------------------------------------------------------------------
+# agent_status — per-agent CPU% + RSS (lead task 2026-06-01).
+#
+# Real PIDs only. ``Registry.add`` defaults the recorded PID to
+# ``os.getpid()`` which is the live pytest process — a guaranteed-alive
+# PID for the duration of each test, so the probe walks a real
+# ``/proc/<pid>`` tree and surfaces real cpu_percent + mem_rss_mb floats.
+# Dead-PID handling is tested by writing a registry entry with an
+# explicitly unused PID. PA-306 no-mocks throughout.
+# ---------------------------------------------------------------------------
+
+
+def test_agent_status_includes_cpu_percent_for_live_pid(
+    tmp_path: Path, registry: Registry
+) -> None:
+    # Arrange — Registry.add records ``os.getpid()`` (the pytest
+    # process itself), which the resource probe finds alive.
+    spec = _write_spec(tmp_path)
+    registry.add("alpha", str(spec), "cld-alpha")
+    # Act
+    result = lc.agent_status(
+        "alpha", registry=registry, runtime_factory=lambda _c: FakeRuntime(running=True)
+    )
+    # Assert
+    assert "cpu_percent" in result
+
+
+def test_agent_status_cpu_percent_value_is_float(
+    tmp_path: Path, registry: Registry
+) -> None:
+    # Arrange
+    spec = _write_spec(tmp_path)
+    registry.add("alpha", str(spec), "cld-alpha")
+    # Act
+    result = lc.agent_status(
+        "alpha", registry=registry, runtime_factory=lambda _c: FakeRuntime(running=True)
+    )
+    # Assert
+    assert isinstance(result["cpu_percent"], float)
+
+
+def test_agent_status_mem_rss_mb_is_positive_for_live_pid(
+    tmp_path: Path, registry: Registry
+) -> None:
+    # Arrange — the pytest process always has >>1 MB RSS; pin the
+    # floor so a regression to 0.0 (which would read as "probed and
+    # empty" — the wrong UX) is caught.
+    spec = _write_spec(tmp_path)
+    registry.add("alpha", str(spec), "cld-alpha")
+    # Act
+    result = lc.agent_status(
+        "alpha", registry=registry, runtime_factory=lambda _c: FakeRuntime(running=True)
+    )
+    # Assert
+    assert result["mem_rss_mb"] > 1.0
+
+
+def test_agent_status_omits_cpu_percent_for_dead_pid(
+    tmp_path: Path, registry: Registry
+) -> None:
+    # Arrange — record a PID above any kernel's PID space so the
+    # probe can never resolve it. Observability contract: absent ≠ 0
+    # — the row must OMIT the keys, not emit zero-filled.
+    spec = _write_spec(tmp_path)
+    registry.add("alpha", str(spec), "cld-alpha", pid=2**31 - 1)
+    # Act
+    result = lc.agent_status(
+        "alpha", registry=registry, runtime_factory=lambda _c: FakeRuntime(running=True)
+    )
+    # Assert
+    assert "cpu_percent" not in result
+
+
+def test_agent_status_omits_mem_rss_mb_for_dead_pid(
+    tmp_path: Path, registry: Registry
+) -> None:
+    # Arrange — same dead-PID setup; second key must also be absent.
+    spec = _write_spec(tmp_path)
+    registry.add("alpha", str(spec), "cld-alpha", pid=2**31 - 1)
+    # Act
+    result = lc.agent_status(
+        "alpha", registry=registry, runtime_factory=lambda _c: FakeRuntime(running=True)
+    )
+    # Assert
+    assert "mem_rss_mb" not in result
+
+
+# ---------------------------------------------------------------------------
 # agent_status — account field (operator request 4581).
 #
 # The autouse ``_isolate_home`` fixture points HOME at tmp_path, so an

--- a/tests/scitex_agent_container/_state/_meta/test__agent_resources.py
+++ b/tests/scitex_agent_container/_state/_meta/test__agent_resources.py
@@ -1,0 +1,236 @@
+"""Tests for ``_state._meta.resources.collect_agent_resources`` — the
+per-agent CPU% + RSS probe that surfaces in ``sac agents list``.
+
+Lead task (2026-06-01): attribute host load to specific agents. The
+probe walks each registered agent's PID + descendants in one psutil
+sweep, sums their CPU% and RSS, and returns absent (``None``) for any
+PID whose process is dead/unknown.
+
+PA-306 no-mocks: every test exercises real OS processes. We use
+``os.getpid()`` (this test process itself) for the "live PID" case and
+``subprocess.Popen`` for the "child tree" / "dead PID" cases. No
+``unittest.mock``, no ``monkeypatch`` of psutil internals, no patched
+``Process`` classes — the probe sees a real ``/proc`` entry or it
+doesn't.
+
+Each test:
+* AAA markers (TQ002).
+* One assertion (TQ007).
+* 3+-word descriptive name.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+
+import pytest
+
+from scitex_agent_container._state._meta.resources import collect_agent_resources
+
+# ---------------------------------------------------------------------------
+# Fixtures — real subprocesses we own and clean up
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def sleeper_proc():
+    """Spawn a real Python subprocess that sleeps. Yields the PID. The
+    fixture kills it on teardown so tests don't leak children.
+
+    Why Python (not ``sleep 60``): ensures a non-trivial RSS so the
+    sum-RSS assertion has a defensible floor (a ``sleep`` binary is
+    sometimes only a few hundred KB; a Python interpreter is ~5-20 MB).
+    """
+    proc = subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(60)"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        # Give the child a beat to be visible in /proc and have RSS settled.
+        time.sleep(0.1)
+        yield proc.pid
+    finally:
+        proc.kill()
+        proc.wait(timeout=5)
+
+
+@pytest.fixture
+def parent_with_child():
+    """Spawn a parent Python subprocess that forks a child + sleeps.
+    Returns the parent PID. Both parent and child are killed at teardown.
+    """
+    # Parent forks a child via os.fork (POSIX only); both sleep.
+    script = (
+        "import os, time;"
+        " p = os.fork();"
+        " time.sleep(60) if p == 0 else (os.waitpid(p, 0) or time.sleep(60))"
+    )
+    proc = subprocess.Popen(
+        [sys.executable, "-c", script],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        time.sleep(0.2)  # let the fork settle
+        yield proc.pid
+    finally:
+        # Best-effort kill of the whole process group (parent + child).
+        # stx-allow: fallback (reason: test teardown; if the proc already
+        # exited the kill is a no-op error we want to swallow)
+        try:
+            os.killpg(os.getpgid(proc.pid), 9)
+        except (ProcessLookupError, PermissionError):
+            pass
+        proc.kill()
+        proc.wait(timeout=5)
+
+
+# ---------------------------------------------------------------------------
+# Shape — keys returned per PID
+# ---------------------------------------------------------------------------
+
+
+def test_returns_dict_keyed_by_input_pid(sleeper_proc):
+    # Arrange
+    pid = sleeper_proc
+    # Act
+    result = collect_agent_resources([pid])
+    # Assert
+    assert set(result.keys()) == {pid}
+
+
+def test_live_pid_payload_carries_two_required_keys(sleeper_proc):
+    # Arrange
+    pid = sleeper_proc
+    # Act
+    payload = collect_agent_resources([pid])[pid]
+    # Assert
+    assert payload is not None and set(payload.keys()) == {
+        "cpu_percent",
+        "mem_rss_mb",
+    }
+
+
+def test_live_pid_mem_rss_is_positive_float(sleeper_proc):
+    # Arrange — a real Python subprocess has > 1 MB of RSS even sleeping.
+    pid = sleeper_proc
+    # Act
+    payload = collect_agent_resources([pid])[pid]
+    # Assert
+    assert isinstance(payload["mem_rss_mb"], float) and payload["mem_rss_mb"] > 1.0
+
+
+def test_live_pid_cpu_percent_is_float(sleeper_proc):
+    # Arrange — sleeping process has near-zero CPU% but the field must
+    # still be a float (not None, not absent). Tests the contract that
+    # a live PID always has both fields, even if cpu_percent is 0.0.
+    pid = sleeper_proc
+    # Act
+    payload = collect_agent_resources([pid])[pid]
+    # Assert
+    assert isinstance(payload["cpu_percent"], float)
+
+
+# ---------------------------------------------------------------------------
+# Dead-PID handling
+# ---------------------------------------------------------------------------
+
+
+def test_dead_pid_returns_none_payload():
+    # Arrange — spawn then kill, capture PID after death so /proc/<pid>
+    # no longer exists. The probe must return None (not raise, not
+    # invent zeros) — see lead's "Handle dead-PID gracefully" spec.
+    proc = subprocess.Popen([sys.executable, "-c", "pass"])
+    proc.wait(timeout=5)
+    pid = proc.pid
+    # Give the kernel a beat to reap the zombie.
+    time.sleep(0.1)
+    # Act
+    result = collect_agent_resources([pid])
+    # Assert
+    assert result[pid] is None
+
+
+def test_never_running_pid_returns_none():
+    # Arrange — pick a PID that is virtually guaranteed to never have
+    # existed in this kernel. The probe must absent-out, not raise.
+    # 2^31 - 1 is well above any realistic kernel PID space.
+    pid = 2**31 - 1
+    # Act
+    result = collect_agent_resources([pid])
+    # Assert
+    assert result[pid] is None
+
+
+# ---------------------------------------------------------------------------
+# Descendants — the tree, not just the recorded PID
+# ---------------------------------------------------------------------------
+
+
+def test_descendants_rss_is_included_in_sum(parent_with_child):
+    # Arrange — parent + forked child both Python interpreters; each
+    # carries its own ~5-20 MB RSS. Sum should exceed a single Python's
+    # RSS comfortably. We compare against the parent-alone case by
+    # observing that the parent_with_child fixture's reported RSS is
+    # strictly greater than a single Python's RSS floor (1 MB) AND
+    # consistent with "two interpreters" (>5 MB combined).
+    pid = parent_with_child
+    # Act
+    payload = collect_agent_resources([pid])[pid]
+    # Assert — two interpreters should clear 5 MB easily; we pin a
+    # lower bound that no single Python could meet by itself if the
+    # child weren't summed in.
+    assert payload is not None and payload["mem_rss_mb"] >= 5.0
+
+
+# ---------------------------------------------------------------------------
+# Mixed live + dead — single-sweep contract
+# ---------------------------------------------------------------------------
+
+
+def test_mixed_live_and_dead_pids_in_one_sweep(sleeper_proc):
+    # Arrange — one live PID and one definitely-dead PID. The probe
+    # returns the same keyspace as the input, with each PID's payload
+    # resolved independently.
+    live_pid = sleeper_proc
+    dead_pid = 2**31 - 1
+    # Act
+    result = collect_agent_resources([live_pid, dead_pid])
+    # Assert — both keys present, the dead one absent-as-None, live one
+    # has the payload dict. Single result, single sweep.
+    assert result[live_pid] is not None and result[dead_pid] is None
+
+
+# ---------------------------------------------------------------------------
+# Empty input — edge case
+# ---------------------------------------------------------------------------
+
+
+def test_empty_input_returns_empty_dict():
+    # Arrange — no PIDs to probe (no running agents). The probe should
+    # not raise, not sleep, not allocate; return an empty dict.
+    # Act
+    result = collect_agent_resources([])
+    # Assert
+    assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# PID==0 sentinel — registry uses 0 for "unknown"
+# ---------------------------------------------------------------------------
+
+
+def test_pid_zero_sentinel_returns_none():
+    # Arrange — the registry's ``_pids_from_session`` returns ``pid=0``
+    # when tmux can't tell us the pane PID. The probe must NOT treat 0
+    # as a real PID (psutil.Process(0) is the kernel scheduler on Linux,
+    # which would crash or surface bogus data). Treat 0 as "no PID
+    # known" and return None.
+    # Act
+    result = collect_agent_resources([0])
+    # Assert
+    assert result[0] is None

--- a/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list.py
+++ b/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list.py
@@ -641,3 +641,236 @@ def test_safe_account_for_returns_string_on_none_config():
     result = _al._safe_account_for(cfg)
     # Assert
     assert isinstance(result, str) and result
+
+
+# ---------------------------------------------------------------------------
+# Lead task 2026-06-01: per-agent CPU% + RSS in the list row.
+# ---------------------------------------------------------------------------
+#
+# These tests use real OS processes for the PID side of the contract:
+# ``os.getpid()`` (the pytest process itself) for the "live PID" case
+# and an int that is guaranteed unused for the "dead PID" case. The
+# probe code in ``_state._meta.resources`` IS the unit under test; the
+# rest of the list pipeline is exercised end-to-end with the real
+# ``_FakeRegistry`` + ``_write_valid_spec`` helpers used elsewhere in
+# this file. PA-306 no-mocks: no monkeypatch of psutil, no MagicMock,
+# no patched ``collect_agent_resources``.
+
+
+def test_get_data_running_row_carries_cpu_and_mem_keys(tmp_path):
+    # Arrange — real PID of the pytest process itself (always alive
+    # for the duration of this test). The probe walks os.getpid()'s
+    # process tree and returns real cpu_percent + mem_rss_mb floats.
+    import os as _os
+
+    spec = _write_valid_spec(tmp_path / "live")
+    entries = [
+        {
+            "name": "live",
+            "config": str(spec),
+            "screen": "-",
+            "started_at": "-",
+            "pid": _os.getpid(),
+        }
+    ]
+    registry = _FakeRegistry(entries)
+    # Act
+    with _swap_discover(_no_discover), _swap_probe(lambda cfg: True):
+        out = get_agent_list_data(registry)
+    # Assert — both keys present on the live-PID row.
+    assert "cpu_percent" in out[0] and "mem_rss_mb" in out[0]
+
+
+def test_get_data_dead_pid_row_omits_resource_keys(tmp_path):
+    # Arrange — a PID well above any kernel's PID space. Observability
+    # contract: absent ≠ 0 — the row must NOT carry zero-filled keys,
+    # the row must OMIT them so a consumer can tell "not probed" from
+    # "literally idle".
+    spec = _write_valid_spec(tmp_path / "dead")
+    entries = [
+        {
+            "name": "dead",
+            "config": str(spec),
+            "screen": "-",
+            "started_at": "-",
+            "pid": 2**31 - 1,
+        }
+    ]
+    registry = _FakeRegistry(entries)
+    # Act
+    with _swap_discover(_no_discover), _swap_probe(lambda cfg: True):
+        out = get_agent_list_data(registry)
+    # Assert — neither key on the row.
+    assert "cpu_percent" not in out[0] and "mem_rss_mb" not in out[0]
+
+
+def test_get_data_unknown_pid_sentinel_omits_resource_keys(tmp_path):
+    # Arrange — registry entry with ``pid=0`` (the "PID unknown"
+    # sentinel ``_pids_from_session`` returns when tmux can't tell us
+    # the pane PID). The probe must NOT treat 0 as a real PID; the
+    # row must omit the resource keys.
+    spec = _write_valid_spec(tmp_path / "unknown")
+    entries = [
+        {
+            "name": "unknown",
+            "config": str(spec),
+            "screen": "-",
+            "started_at": "-",
+            "pid": 0,
+        }
+    ]
+    registry = _FakeRegistry(entries)
+    # Act
+    with _swap_discover(_no_discover), _swap_probe(lambda cfg: True):
+        out = get_agent_list_data(registry)
+    # Assert
+    assert "cpu_percent" not in out[0] and "mem_rss_mb" not in out[0]
+
+
+def test_get_data_cpu_percent_value_is_float_when_probed(tmp_path):
+    # Arrange — same live-PID setup; pin the field TYPE so a future
+    # refactor can't accidentally emit a string or int (consumers
+    # like the table renderer use the numeric format).
+    import os as _os
+
+    spec = _write_valid_spec(tmp_path / "type")
+    entries = [
+        {
+            "name": "type",
+            "config": str(spec),
+            "screen": "-",
+            "started_at": "-",
+            "pid": _os.getpid(),
+        }
+    ]
+    registry = _FakeRegistry(entries)
+    # Act
+    with _swap_discover(_no_discover), _swap_probe(lambda cfg: True):
+        out = get_agent_list_data(registry)
+    # Assert
+    assert isinstance(out[0]["cpu_percent"], float)
+
+
+def test_get_data_mem_rss_mb_is_positive_when_probed(tmp_path):
+    # Arrange — the pytest process always has >>1 MB RSS; we just pin
+    # the floor so a regression to ``0.0`` (which would look like
+    # "probed and idle" — the wrong UX) is caught.
+    import os as _os
+
+    spec = _write_valid_spec(tmp_path / "rss")
+    entries = [
+        {
+            "name": "rss",
+            "config": str(spec),
+            "screen": "-",
+            "started_at": "-",
+            "pid": _os.getpid(),
+        }
+    ]
+    registry = _FakeRegistry(entries)
+    # Act
+    with _swap_discover(_no_discover), _swap_probe(lambda cfg: True):
+        out = get_agent_list_data(registry)
+    # Assert
+    assert out[0]["mem_rss_mb"] > 1.0
+
+
+def test_print_agent_list_renders_cpu_and_mem_columns(capsys, tmp_path):
+    # Arrange — live PID so the row carries the fields and the table
+    # picks them up.
+    import os as _os
+
+    spec = _write_valid_spec(tmp_path / "tbl")
+    registry = _FakeRegistry(
+        [
+            {
+                "name": "tbl",
+                "config": str(spec),
+                "screen": "s",
+                "started_at": "ts",
+                "pid": _os.getpid(),
+            }
+        ]
+    )
+    # Act
+    with _swap_discover(_no_discover), _swap_probe(lambda cfg: True):
+        print_agent_list(registry)
+    # Assert — both column headers appear in the rendered output.
+    out = capsys.readouterr().out
+    assert "CPU%" in out and "MEM" in out
+
+
+def test_print_agent_list_renders_dash_for_dead_pid_resource_cells(capsys, tmp_path):
+    # Arrange — dead PID; row absent-outs cpu_percent / mem_rss_mb; the
+    # table must render placeholder cells ("-"), NOT empty strings (so
+    # the column alignment stays readable).
+    spec = _write_valid_spec(tmp_path / "dead")
+    registry = _FakeRegistry(
+        [
+            {
+                "name": "dead",
+                "config": str(spec),
+                "screen": "s",
+                "started_at": "ts",
+                "pid": 2**31 - 1,
+            }
+        ]
+    )
+    # Act
+    with _swap_discover(_no_discover), _swap_probe(lambda cfg: True):
+        print_agent_list(registry)
+    # Assert — the row appears with the placeholder cells. We pin
+    # the agent's name AND a ``-`` cell on the same line; rich's
+    # default table renderer puts each row's cells on one line.
+    out = capsys.readouterr().out
+    dead_row_line = next((line for line in out.splitlines() if "dead" in line), "")
+    assert " - " in dead_row_line
+
+
+def test_print_agent_list_json_emits_cpu_percent_for_live_pid(capsys, tmp_path):
+    # Arrange — live PID, JSON path; the field must surface in the
+    # JSON serialisation (downstream consumers — fleet hubs, dashboards
+    # — read JSON, not the rich table).
+    import os as _os
+
+    spec = _write_valid_spec(tmp_path / "json")
+    registry = _FakeRegistry(
+        [
+            {
+                "name": "json",
+                "config": str(spec),
+                "screen": "s",
+                "started_at": "ts",
+                "pid": _os.getpid(),
+            }
+        ]
+    )
+    # Act
+    with _swap_discover(_no_discover), _swap_probe(lambda cfg: True):
+        print_agent_list_json(registry)
+    # Assert
+    data = json.loads(capsys.readouterr().out)
+    assert "cpu_percent" in data[0]
+
+
+def test_print_agent_list_json_omits_cpu_percent_for_dead_pid(capsys, tmp_path):
+    # Arrange — dead PID; JSON path must OMIT the key (not emit ``null``
+    # / 0.0) so the observability contract holds end-to-end.
+    spec = _write_valid_spec(tmp_path / "dead-json")
+    registry = _FakeRegistry(
+        [
+            {
+                "name": "dead-json",
+                "config": str(spec),
+                "screen": "s",
+                "started_at": "ts",
+                "pid": 2**31 - 1,
+            }
+        ]
+    )
+    # Act
+    with _swap_discover(_no_discover), _swap_probe(lambda cfg: True):
+        print_agent_list_json(registry)
+    # Assert
+    data = json.loads(capsys.readouterr().out)
+    assert "cpu_percent" not in data[0]


### PR DESCRIPTION
## Summary

Operator wanted per-agent CPU% and memory in `sac agents list` so an overloaded host can be attributed to specific agents. Today only host-wide load is surfaced. This PR adds the per-agent attribution everywhere it makes sense, with no measurable added latency:

- **`sac agents list` human table**: two right-aligned columns `CPU%` and `MEM`, rendered as `-` when the recorded PID is dead / unknown / unprobable.
- **`sac agents list --json`**: `cpu_percent` (float) and `mem_rss_mb` (float) per row, **absent** (not 0.0, not null) when not probed — observability contract `absent ≠ 0` from skill leaf `13_observability.md`.
- **`sac agents status --json`**: same two fields on the single-agent payload, sourced from the registry-recorded PID.
- **`TERSE_STATUS_FIELDS`**: extended so fleet hubs reading the `--terse` projection get attribution by default.

## Implementation

- **New helper** `scitex_agent_container._state._meta.resources.collect_agent_resources(pids)`: walks each PID's process tree (root + recursive descendants) in a single psutil sweep, sums CPU% and RSS, returns `{pid: {"cpu_percent": float, "mem_rss_mb": float} | None}`. CPU% uses ONE batched `cpu_percent(interval=None)` prime / `time.sleep(0.1)` / readout cycle — wall-clock cost is constant in agent count, not linear. Dead / unknown PIDs map to `None`; empty input → empty output (no sleep, no psutil call); psutil-unavailable returns all-`None` rather than crashing.
- **List integration** in `cli_pkg/_helpers/_agent_list.get_agent_list_data`: collects all running PIDs into ONE batched probe before building the result rows; row keys merged in only when the per-PID payload is not `None`. Defined-but-not-registered agents (no PID) skip the probe.
- **Status integration** in `_lifecycle/_status.agent_status`: probes the single registry-recorded PID directly; same `absent ≠ 0` rules.

## Test plan

PA-306 no-mocks — every test exercises real OS processes (`os.getpid()` for live PID, `subprocess.Popen(python)` for descendants, `2**31 - 1` for dead PID). AAA markers (TQ002), one assert per test (TQ007), 3+-word descriptive names.

- [x] **Probe surface** (`tests/.../_state/_meta/test__agent_resources.py`, 10 tests): keyspace contract, both keys present on live PID, mem_rss_mb is positive float, cpu_percent is float, dead-PID → None, never-running-PID → None, descendants summed in, mixed live+dead in one sweep, empty input → {}, PID=0 sentinel → None.
- [x] **List integration** (additions to `tests/.../cli_pkg/_helpers/test__agent_list.py`, 8 tests): running row carries both keys, dead-PID row omits them, PID=0 sentinel row omits them, cpu_percent is float, mem_rss_mb is positive, table renders CPU%/MEM headers, dead-PID rows render `-` cells, JSON emits cpu_percent for live PID, JSON omits cpu_percent for dead PID.
- [x] **Status integration** (additions to `tests/.../_lifecycle/test_lifecycle.py`, 5 tests): live-PID status carries cpu_percent, value is float, mem_rss_mb is positive, dead-PID omits cpu_percent, dead-PID omits mem_rss_mb.
- [x] **Ruff**: all touched files pass `ruff check`.

Local: all 76 `test_lifecycle.py` tests + all 40 `test__agent_list.py` tests + all 10 `test__agent_resources.py` tests pass on a heavily loaded host (~load 42 during development). CI is the gate.

## Out of scope (deliberately)

- psutil is NOT moved from optional → required dependency. The existing `_collect_host_metrics` already treats it as optional; the new code mirrors that contract so installs without psutil still render the list / status (rows just omit the two new fields).
- No new flag (`--no-resources`, etc.). The default 100ms batched sleep is below "noticeable" for an interactive command.
- `agent_meta.collect_rich` (heartbeat-grade per-agent metadata) NOT touched — its PID resolution path uses tmux session inspection that doesn't work for apptainer agents. Status-side integration uses the registry-recorded PID directly, which is the canonical source.