### PR TITLE
fix(apptainer): bind per-account credential DIR not single file (#11)

### DIFF
--- a/src/scitex_agent_container/runtimes/_apptainer_auth.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_auth.py
@@ -75,30 +75,66 @@ def auth_argv(config: AgentConfig, state_dir: Path) -> list[str]:
     # a manual scp-from-lead dance to re-seed peers. The CLI's
     # refresh code-path itself is responsible for any concurrency
     # locking — the bind is just a file passthrough.
+    #
     # Per-agent OAuth account pinning (spec.claude.account). When set,
-    # we bind the saved account's snapshot file at
-    # ~/.scitex/agent-container/accounts/<acct>/.credentials.json
-    # directly as ``:rw`` (operator task #15). The in-container Claude
-    # CLI's ~1h OAuth refresh writes back to the SAME file every
-    # same-account agent reads from, so the snapshot is self-healing
-    # and never expires while ANY pinned agent keeps running. Different
-    # accounts have different snapshots → no cross-account interference.
-    # The prior implementation COPIED the snapshot into a per-agent
-    # state-dir; refresh writes landed on that copy, the snapshot
-    # itself drifted stale, and after ~8h every SDK turn 401'd silently
-    # (the 2026-06-01 fleet-wide outage). ``account=""`` → host live
-    # ``~/.claude/.credentials.json`` (unchanged behaviour; also RW
-    # for the same refresh-in-place reason).
+    # we bind the per-account DIRECTORY
+    # (``~/.scitex/agent-container/accounts/<acct>/``) at
+    # ``/tmp/sac-claude`` ``:rw``. CLAUDE_CONFIG_DIR points the
+    # in-container Claude CLI at that dir so it reads
+    # ``.credentials.json`` from within the bound directory.
+    #
+    # Why a DIRECTORY bind, not a single-file bind (operator task #11):
+    # the per-account snapshot is rewritten by host-side atomic-replace
+    # paths — ``_account.creds_sync._atomic_copy`` (sync-live),
+    # ``_state.account_store.switch_account``, and
+    # ``_account.claude_usage._refresh_access_token_at`` — all using
+    # ``tmp + os.replace``. A single-file bind mount is on the file's
+    # dentry/inode; an atomic-replace orphans that inode (the bind
+    # surfaces as ``...credentials.json//deleted`` in
+    # ``/proc/<pid>/mountinfo``) and every already-running pinned agent
+    # silently loses the shared snapshot, regressing into the per-copy
+    # collision-401 disease that the snapshot model was meant to fix
+    # (PR #262 / task #15). A DIRECTORY bind resolves child files by
+    # name through the underlying filesystem on every open, so a
+    # tmp+rename inside the dir is visible to the container immediately
+    # — in BOTH directions (host writes seen by the container, and
+    # in-container CLI refresh writes seen by host writers).
+    #
+    # ``account=""`` → host live ``~/.claude/.credentials.json``
+    # (unchanged behaviour; single-file bind preserved because we MUST
+    # NOT expose the entire host ``~/.claude/`` directory — chat
+    # history, projects DB, MCP settings — into the container).
     from ._apptainer_creds import resolve_cred_file
 
     cred_file = resolve_cred_file(config, state_dir)
-    if cred_file is not None and cred_file.is_file():
-        argv += [
-            "--bind",
-            f"{cred_file}:/tmp/sac-claude/.credentials.json:rw",
-            "--env",
-            "CLAUDE_CONFIG_DIR=/tmp/sac-claude",
-        ]
+    if cred_file is None or not cred_file.is_file():
+        return argv
+
+    pinned_account = bool(getattr(getattr(config, "claude", None), "account", "") or "")
+    if pinned_account:
+        # Bind the per-account DIRECTORY; tmp+rename of the snapshot
+        # inside it stays visible to the container. Account-store
+        # metadata (``account.json``) is co-bound but harmless — the
+        # in-container CLI only opens ``.credentials.json``.
+        bind_src = cred_file.parent
+        bind_dest = "/tmp/sac-claude"
+    else:
+        # Unpinned: keep the legacy single-file bind. The host live
+        # ``~/.claude/.credentials.json`` is rewritten only by manual
+        # ``claude /login`` / ``sac accounts switch`` events; the
+        # routine in-container refresh writeback into a bound regular
+        # file at ``/tmp/sac-claude/.credentials.json`` is the
+        # documented contract. Binding ``~/.claude/`` itself would
+        # leak the host's full claude state into the container.
+        bind_src = cred_file
+        bind_dest = "/tmp/sac-claude/.credentials.json"
+
+    argv += [
+        "--bind",
+        f"{bind_src}:{bind_dest}:rw",
+        "--env",
+        "CLAUDE_CONFIG_DIR=/tmp/sac-claude",
+    ]
     return argv
 
 

--- a/tests/scitex_agent_container/runtimes/test__apptainer_auth_dir_bind.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_auth_dir_bind.py
@@ -197,25 +197,43 @@ def test_pinned_claude_config_dir_env_unchanged(
 # ---------------------------------------------------------------------------
 
 
-def test_host_atomic_replace_inside_account_dir_is_visible_via_bind_source(
+def test_auth_argv_emits_bind_for_tmp_sac_claude_target(
     tmp_path: Path, home_redirect: Path
 ) -> None:
-    # Arrange — boot a pinned agent's auth flow, then simulate the
+    # Arrange — precondition for the atomic-replace regression below:
+    # auth_argv must emit a bind whose dest is /tmp/sac-claude. Without
+    # the bind, the in-container CLI has no shared snapshot at all.
+    # Split out of the host-replace test for TQ007 (one assert per test);
+    # the replace test relies on this precondition holding.
+    now = time.time()
+    _write_snapshot(home_redirect, "alpha", now + 3_600)
+    cfg = _pinned_config(tmp_path / "wd", account="alpha")
+    # Act
+    argv = auth_argv(cfg, state_dir=tmp_path / "state")
+    bind_src = _extract_bind_source_for_target(argv, "/tmp/sac-claude")
+    # Assert
+    assert bind_src is not None
+
+
+def test_dir_bind_reflects_host_atomic_replace_with_new_token(
+    tmp_path: Path, home_redirect: Path
+) -> None:
+    # Arrange — boot a pinned agent's auth flow, then prepare the
     # host-side atomic-replace path that creds_sync._atomic_copy +
     # account_store.switch_account + claude_usage._refresh_access_token_at
-    # all share: write .credentials.json.tmp, then os.replace onto the
-    # snapshot. With a directory bind, opening
-    # ``<bind_source>/.credentials.json`` after the replace MUST yield
-    # the NEW token (NEW inode resolved via dir lookup). The legacy
-    # single-file bind detached under exactly this sequence.
+    # all share: write .credentials.json.tmp alongside the snapshot.
+    # With a directory bind, opening ``<bind_source>/.credentials.json``
+    # after the replace MUST yield the NEW token (NEW inode resolved via
+    # dir lookup). The legacy single-file bind detached under exactly
+    # this sequence. The precondition that auth_argv emits the bind at
+    # all is covered by
+    # ``test_auth_argv_emits_bind_for_tmp_sac_claude_target``; here we
+    # let ``Path(None)`` raise TypeError loudly if that ever regresses.
     now = time.time()
     snap = _write_snapshot(home_redirect, "alpha", now + 3_600, token="boot-token")
     cfg = _pinned_config(tmp_path / "wd", account="alpha")
     argv = auth_argv(cfg, state_dir=tmp_path / "state")
-    bind_src = _extract_bind_source_for_target(argv, "/tmp/sac-claude")
-    assert bind_src is not None, "auth_argv did not emit /tmp/sac-claude bind"
-    bind_src_path = Path(bind_src)
-    # Act — host atomic-replace: write tmp sibling, then os.replace.
+    bind_src_path = Path(_extract_bind_source_for_target(argv, "/tmp/sac-claude"))
     new_body = {
         "claudeAiOauth": {
             "accessToken": "refreshed-token-after-host-replace",
@@ -224,6 +242,7 @@ def test_host_atomic_replace_inside_account_dir_is_visible_via_bind_source(
     }
     tmp_file = snap.with_suffix(snap.suffix + ".tmp")
     tmp_file.write_text(json.dumps(new_body))
+    # Act — host atomic-replace: rename tmp sibling onto the snapshot.
     os.replace(tmp_file, snap)
     # Assert — re-reading through the bind source's dir view picks up
     # the NEW content. Pre-fix file-bind would have read the orphan.

--- a/tests/scitex_agent_container/runtimes/test__apptainer_auth_dir_bind.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_auth_dir_bind.py
@@ -1,0 +1,234 @@
+"""Pinned-account OAuth bind must be a DIRECTORY bind (task #11 regression).
+
+Why this exists
+---------------
+PR #262 (operator task #15) made ``resolve_cred_file`` return the
+per-account snapshot path directly and the runtime bound that
+snapshot file ``:rw`` into ``/tmp/sac-claude/.credentials.json``.
+This fixed the boot-copy / stale-token outage but introduced a
+namespace-level regression that the lead observed live on 4 of 5
+running account-pinned agents: a SINGLE-FILE bind mount is on the
+file's dentry/inode. Host-side writers — ``creds_sync._atomic_copy``
+(line ~138), ``account_store.switch_account`` (line ~307),
+``claude_usage._refresh_access_token_at`` (line ~284) — all replace
+the snapshot via ``tmp + os.replace`` (atomic rename). After the
+rename the bind mount still points at the ORPHAN inode (visible as
+``...credentials.json//deleted`` in ``/proc/<pid>/mountinfo``), so
+every already-running pinned agent silently loses the shared
+snapshot and the per-copy collision-401 disease returns.
+
+The structural fix: bind the per-account DIRECTORY
+(``~/.scitex/agent-container/accounts/<acct>/``) at ``/tmp/sac-claude``
+instead of the single file. A directory bind resolves files by name
+through the underlying filesystem on every open, so an atomic-replace
+inside the dir is reflected immediately in the container without a
+restart. ``CLAUDE_CONFIG_DIR=/tmp/sac-claude`` is unchanged — the
+in-container Claude CLI still finds ``.credentials.json`` under it.
+
+No mocks (STX-NM / PA-306): real ``$HOME`` redirect, real account-store
+on disk, real ``auth_argv`` and ``resolve_cred_file`` invocations.
+Each test pins one observable fact (TQ007) with AAA markers (TQ002)
+and a descriptive name (TQ003).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container.config import AgentConfig
+from scitex_agent_container.config._types import ClaudeSpec
+from scitex_agent_container.runtimes._apptainer_auth import auth_argv
+
+# ---------------------------------------------------------------------------
+# Fixtures + helpers (mirror the other apptainer test modules' shape)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def home_redirect(tmp_path: Path, env_save_restore) -> Path:
+    """Redirect ``$HOME`` so credential resolution stays in the sandbox."""
+    home = tmp_path / "home"
+    home.mkdir()
+    env_save_restore.set("HOME", str(home))
+    return home
+
+
+def _write_snapshot(
+    home: Path, name: str, expires_at_seconds: float, *, token: str = "boot-token"
+) -> Path:
+    """Materialise a real saved-account snapshot at the on-disk layout
+    that ``sac accounts save`` writes."""
+    acct_dir = home / ".scitex" / "agent-container" / "accounts" / name
+    acct_dir.mkdir(parents=True, exist_ok=True)
+    snap = acct_dir / ".credentials.json"
+    body = {
+        "claudeAiOauth": {
+            "accessToken": token,
+            "expiresAt": int(expires_at_seconds * 1_000),
+        }
+    }
+    snap.write_text(json.dumps(body))
+    return snap
+
+
+def _pinned_config(workdir: Path, account: str) -> AgentConfig:
+    return AgentConfig(
+        name="pinned-agent",
+        runtime="apptainer",
+        workdir=str(workdir),
+        claude=ClaudeSpec(account=account),
+    )
+
+
+def _extract_bind_source_for_target(argv: list[str], target: str) -> str | None:
+    """Return the source path of the first ``--bind src:dest[:opts]`` whose
+    dest equals ``target``. Returns ``None`` if no such bind exists."""
+    for i, tok in enumerate(argv):
+        if tok != "--bind":
+            continue
+        if i + 1 >= len(argv):
+            continue
+        spec = argv[i + 1]
+        parts = spec.split(":")
+        if len(parts) < 2:
+            continue
+        src, dest = parts[0], parts[1]
+        if dest == target:
+            return src
+    return None
+
+
+def _extract_bind_spec_for_target_prefix(
+    argv: list[str], target_prefix: str
+) -> str | None:
+    """Return the FULL ``src:dest[:opts]`` spec whose dest starts with
+    ``target_prefix``. Used to also catch the legacy single-file bind whose
+    dest is ``/tmp/sac-claude/.credentials.json`` (prefix match)."""
+    for i, tok in enumerate(argv):
+        if tok != "--bind":
+            continue
+        if i + 1 >= len(argv):
+            continue
+        spec = argv[i + 1]
+        parts = spec.split(":")
+        if len(parts) < 2:
+            continue
+        if parts[1].startswith(target_prefix):
+            return spec
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Pinned-account dir-bind shape (the structural fix)
+# ---------------------------------------------------------------------------
+
+
+def test_pinned_bind_source_is_the_account_directory(
+    tmp_path: Path, home_redirect: Path
+) -> None:
+    # Arrange — a healthy pinned snapshot. The expected source of the
+    # /tmp/sac-claude bind is the account DIR (not the snapshot file).
+    now = time.time()
+    snap = _write_snapshot(home_redirect, "alpha", now + 3_600)
+    cfg = _pinned_config(tmp_path / "wd", account="alpha")
+    # Act
+    argv = auth_argv(cfg, state_dir=tmp_path / "state")
+    src = _extract_bind_source_for_target(argv, "/tmp/sac-claude")
+    # Assert — the bind source is the account dir, not the snapshot file.
+    # File binds detach under host atomic-replace ("//deleted" in
+    # /proc/<pid>/mountinfo); a dir bind survives.
+    assert src == str(snap.parent)
+
+
+def test_pinned_bind_destination_is_directory_not_file_path(
+    tmp_path: Path, home_redirect: Path
+) -> None:
+    # Arrange — the legacy single-file bind targeted
+    # /tmp/sac-claude/.credentials.json. The new dir-bind targets the
+    # dir itself; CLAUDE_CONFIG_DIR is unchanged.
+    now = time.time()
+    _write_snapshot(home_redirect, "alpha", now + 3_600)
+    cfg = _pinned_config(tmp_path / "wd", account="alpha")
+    # Act
+    argv = auth_argv(cfg, state_dir=tmp_path / "state")
+    spec = _extract_bind_spec_for_target_prefix(argv, "/tmp/sac-claude")
+    # Assert — the dest is exactly /tmp/sac-claude (dir), not
+    # /tmp/sac-claude/.credentials.json (the file the legacy bind hit).
+    assert spec is not None and spec.split(":")[1] == "/tmp/sac-claude"
+
+
+def test_pinned_bind_is_rw(tmp_path: Path, home_redirect: Path) -> None:
+    # Arrange — the bind must stay :rw so refresh writeback by the
+    # in-container Claude CLI lands on the shared snapshot.
+    now = time.time()
+    _write_snapshot(home_redirect, "alpha", now + 3_600)
+    cfg = _pinned_config(tmp_path / "wd", account="alpha")
+    # Act
+    argv = auth_argv(cfg, state_dir=tmp_path / "state")
+    spec = _extract_bind_spec_for_target_prefix(argv, "/tmp/sac-claude")
+    # Assert
+    assert spec is not None and spec.split(":")[-1] == "rw"
+
+
+def test_pinned_claude_config_dir_env_unchanged(
+    tmp_path: Path, home_redirect: Path
+) -> None:
+    # Arrange — the dir-bind fix MUST keep CLAUDE_CONFIG_DIR pointing at
+    # /tmp/sac-claude so the in-container CLI finds .credentials.json
+    # inside the bound dir.
+    now = time.time()
+    _write_snapshot(home_redirect, "alpha", now + 3_600)
+    cfg = _pinned_config(tmp_path / "wd", account="alpha")
+    # Act
+    argv = auth_argv(cfg, state_dir=tmp_path / "state")
+    # Assert
+    assert "CLAUDE_CONFIG_DIR=/tmp/sac-claude" in argv
+
+
+# ---------------------------------------------------------------------------
+# Host atomic-replace regression: the bind source's view of
+# .credentials.json must reflect the NEW inode after a tmp+os.replace
+# (this is the failure mode that knocked 4/5 pinned agents offline).
+# ---------------------------------------------------------------------------
+
+
+def test_host_atomic_replace_inside_account_dir_is_visible_via_bind_source(
+    tmp_path: Path, home_redirect: Path
+) -> None:
+    # Arrange — boot a pinned agent's auth flow, then simulate the
+    # host-side atomic-replace path that creds_sync._atomic_copy +
+    # account_store.switch_account + claude_usage._refresh_access_token_at
+    # all share: write .credentials.json.tmp, then os.replace onto the
+    # snapshot. With a directory bind, opening
+    # ``<bind_source>/.credentials.json`` after the replace MUST yield
+    # the NEW token (NEW inode resolved via dir lookup). The legacy
+    # single-file bind detached under exactly this sequence.
+    now = time.time()
+    snap = _write_snapshot(home_redirect, "alpha", now + 3_600, token="boot-token")
+    cfg = _pinned_config(tmp_path / "wd", account="alpha")
+    argv = auth_argv(cfg, state_dir=tmp_path / "state")
+    bind_src = _extract_bind_source_for_target(argv, "/tmp/sac-claude")
+    assert bind_src is not None, "auth_argv did not emit /tmp/sac-claude bind"
+    bind_src_path = Path(bind_src)
+    # Act — host atomic-replace: write tmp sibling, then os.replace.
+    new_body = {
+        "claudeAiOauth": {
+            "accessToken": "refreshed-token-after-host-replace",
+            "expiresAt": int((now + 86_400) * 1_000),
+        }
+    }
+    tmp_file = snap.with_suffix(snap.suffix + ".tmp")
+    tmp_file.write_text(json.dumps(new_body))
+    os.replace(tmp_file, snap)
+    # Assert — re-reading through the bind source's dir view picks up
+    # the NEW content. Pre-fix file-bind would have read the orphan.
+    container_visible = json.loads((bind_src_path / ".credentials.json").read_text())
+    assert (
+        container_visible["claudeAiOauth"]["accessToken"]
+        == "refreshed-token-after-host-replace"
+    )

--- a/tests/scitex_agent_container/runtimes/test__apptainer_runtime.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_runtime.py
@@ -1145,14 +1145,18 @@ def _save_snapshot(home: Path, name: str, body: str | None = None) -> Path:
     return snap
 
 
-def test_argv_pins_account_binds_snapshot_path_directly_not_host_file(
+def test_argv_pins_account_binds_snapshot_directory_not_host_file(
     tmp_path: Path, home_redirect: Path
 ) -> None:
     # Arrange — host live file AND a saved snapshot both exist; the pin
-    # must bind the SNAPSHOT FILE ITSELF (operator task #15 — the prior
-    # copy-into-state-dir path was the root cause of the 2026-06-01
-    # fleet outage: refreshes landed on the copy, the snapshot drifted
-    # stale, every SDK turn 401'd after ~8h).
+    # must bind the snapshot's per-account DIRECTORY (task #11 — the
+    # prior single-file bind orphaned its inode under the host's
+    # atomic-replace writers in creds_sync / account_store /
+    # claude_usage, regressing into the per-copy collision-401 disease
+    # the snapshot model was meant to fix). The bound dir's child
+    # ``.credentials.json`` remains the snapshot itself; refresh
+    # writeback by the in-container CLI lands in the same on-disk file
+    # every same-account agent reads from.
     host_creds = home_redirect / ".claude" / ".credentials.json"
     host_creds.parent.mkdir(parents=True, exist_ok=True)
     host_creds.write_text('{"host": true}')
@@ -1163,10 +1167,15 @@ def test_argv_pins_account_binds_snapshot_path_directly_not_host_file(
     cfg = _config(tmp_path, claude=ClaudeSpec(account="alpha"))
     # Act
     argv = rt.build_run_argv(cfg, state_dir=state_dir, sif_path=tmp_path / "x.sif")
-    creds_arg = next(a for a in argv if "/tmp/sac-claude/.credentials.json" in a)
-    # Assert — the bound host-side path IS the snapshot file, neither
-    # a per-agent copy nor the host live file.
-    assert creds_arg.startswith(str(snap))
+    creds_arg = next(
+        a
+        for a in argv
+        if a.startswith(str(snap.parent) + ":") and a.endswith(":/tmp/sac-claude:rw")
+    )
+    # Assert — the bound host-side source IS the account directory
+    # (snapshot.parent), neither the snapshot file alone, a per-agent
+    # copy, nor the host live file.
+    assert creds_arg.split(":")[0] == str(snap.parent)
 
 
 def test_argv_pins_account_does_not_create_state_dir_copy(


### PR DESCRIPTION
Fixes the single-file :rw bind detaching on host-side atomic snapshot replace (//deleted in mountinfo) which silently 401s the fleet. Binds the per-account directory instead. NOTE: one test (test_status_json / scitex_dev audit summary) is failing — flag for review, may be pre-existing.