### PR TITLE
feat(SAC-from-SAC): fail-loud bind preflight + STARTUP_FAILED lifecycle (PR-1)

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_startup_failed.py
+++ b/src/scitex_agent_container/_lifecycle/_startup_failed.py
@@ -43,10 +43,18 @@ so we can extend without breaking the existing readers:
      "phase":        "container_creation",
      "kind":         "apptainer_mount_failed",
      "exit_code":    255,
+     "runtime_dir":  "<host abs path to per-instance state dir>",
      "stdout_tail":  "<last N lines>",
      "stderr_tail":  "<last N lines>",
      "remediation_hint": "..."
    }
+
+The ``runtime_dir`` field is the host-absolute path to the per-instance
+state directory carrying this marker (and any peer ``stdout.log`` /
+``stderr.log`` if the spawn captured them). Echoing it in the JSON
+spares wire-shape consumers (clew launcher, ``sac agents delete``
+410 body) having to recompute or guess the path — the marker is
+self-describing.
 
 Tail capture is bounded so a runaway log doesn't bloat the marker.
 """
@@ -196,6 +204,12 @@ def write_marker(
         "phase": phase,
         "kind": kind,
         "exit_code": int(exit_code),
+        # Host-absolute path to the per-instance state directory so the
+        # marker is self-describing. The DELETE 410 / STATUS bodies
+        # echo this verbatim so a clew launcher (or human operator)
+        # can `cat <runtime_dir>/stderr.log` without recomputing the
+        # path from <name>.
+        "runtime_dir": str(runtime_dir.resolve()),
         "stdout_tail": _tail_text(stdout),
         "stderr_tail": _tail_text(stderr),
         "remediation_hint": hint,

--- a/src/scitex_agent_container/_lifecycle/_startup_failed.py
+++ b/src/scitex_agent_container/_lifecycle/_startup_failed.py
@@ -1,0 +1,240 @@
+"""STARTUP_FAILED lifecycle marker for stillborn agents.
+
+A stillborn agent is one whose container fails during creation —
+apptainer FATAL on a missing bind source is the canonical example,
+but the marker covers any failure between ``sac agents start <name>``
+returning and the SDK runner writing its first heartbeat. The
+clew-cohort-a-capsule-0201225 incident on 2026-06-02 was the
+motivating case:
+
+  * ``POST /agents`` returned HTTP 200 because the subprocess to
+    ``sac agents start`` exited 0 after the apptainer wrapper itself
+    handed off to the next stage,
+  * but the apptainer container creation FATAL'd with "mount source
+    /work/... doesn't exist",
+  * the SDK runner never started → no pidfile, no session.jsonl, no
+    heartbeat,
+  * ``GET /agents/<name>/status`` returned ``session_id: null``,
+    ``DELETE /agents/<name>`` returned 404 "no pid file", ``POST
+    /agents/<name>/send`` returned 400 "no live session".
+
+The host had silently lost a request and the operator had three
+different shaped failures to triage. This module adds a single
+on-disk marker (``runtime_dir/STARTUP_FAILED``) so:
+
+  * the marker IS the record of the stillborn lifecycle event,
+  * ``DELETE`` returns ``410 Gone`` (resource existed, has been removed)
+    with the failure detail in the body instead of ``404 Not Found``,
+  * ``STATUS`` reports ``status=startup_failed`` with the same body so
+    the operator and any orchestrator see a unified shape,
+  * future automation can drive an off-host ``forget`` of any agent
+    whose state-dir has only ``STARTUP_FAILED`` + no pidfile (= it
+    never started, never will, safe to GC).
+
+The on-disk shape is intentionally minimal JSON with a schema version
+so we can extend without breaking the existing readers:
+
+.. code-block:: json
+
+   {
+     "schema_version": 1,
+     "started_at":   "<ISO-8601 UTC>",
+     "failed_at":    "<ISO-8601 UTC>",
+     "phase":        "container_creation",
+     "kind":         "apptainer_mount_failed",
+     "exit_code":    255,
+     "stdout_tail":  "<last N lines>",
+     "stderr_tail":  "<last N lines>",
+     "remediation_hint": "..."
+   }
+
+Tail capture is bounded so a runaway log doesn't bloat the marker.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+# Schema version. Bump when the shape changes; readers should
+# downgrade gracefully on a higher value.
+SCHEMA_VERSION = 1
+
+# Bound on how much of stdout / stderr we copy into the marker.
+# Generous enough to capture a FATAL block + surrounding context;
+# small enough that a `runtime_dir/STARTUP_FAILED` stays a single
+# struct-readable file.
+_TAIL_BYTES_LIMIT = 8 * 1024  # 8 KiB
+
+# Marker filename. Capital-letters convention mirrors ``CHANGELOG.md``-
+# style sentinel files — easy to grep, hard to mistake for runtime
+# state the agent owns.
+MARKER_FILENAME = "STARTUP_FAILED"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _tail_text(text: str, limit: int = _TAIL_BYTES_LIMIT) -> str:
+    """Return the last ``limit`` bytes of ``text`` (decoded as-is).
+
+    Avoids splitting in the middle of a multi-byte UTF-8 sequence by
+    re-encoding to bytes, slicing, then decoding with ``errors="replace"``
+    so an arbitrary truncation point doesn't raise.
+    """
+    if not text:
+        return ""
+    raw = text.encode("utf-8", errors="replace")
+    if len(raw) <= limit:
+        return text
+    return raw[-limit:].decode("utf-8", errors="replace")
+
+
+def classify_apptainer_failure(stdout: str, stderr: str) -> tuple[str, str]:
+    """Best-effort ``(kind, remediation_hint)`` for apptainer FATAL stdout.
+
+    Pattern-matches the well-known failure shapes so the marker carries
+    an actionable kind tag rather than a free-form blob. Falls back to
+    ``"container_creation_unknown"`` with a generic hint if the trace
+    isn't recognised.
+
+    Recognised today:
+
+      * ``"mount source ... doesn't exist"`` → ``"apptainer_mount_failed"``
+        — the historical clew case + most SAC-from-SAC bind-rewrite gaps.
+      * ``"image ... is not a valid SIF image"`` → ``"sif_invalid"``
+        — the host SIF path is wrong / partial download / wrong arch.
+      * ``"No space left on device"`` → ``"disk_full"``.
+
+    The detection list is intentionally short — adding a new shape
+    later only needs a regex + hint pair.
+    """
+    blob = (stdout or "") + "\n" + (stderr or "")
+    if "mount source" in blob and "doesn't exist" in blob:
+        return (
+            "apptainer_mount_failed",
+            "one or more bind sources do not exist on the host; "
+            "rewrite the offending path(s) or have the parent expose "
+            "them via a host-visible bind. The inline-spec POST /agents "
+            "preflight (PR-1) catches this when the spec is submitted; "
+            "if you saw this marker, the failure escaped the preflight "
+            "(e.g. host-side spec was edited after preflight).",
+        )
+    if "is not a valid SIF image" in blob or "Failed to load SIF" in blob:
+        return (
+            "sif_invalid",
+            "the apptainer SIF at spec.apptainer.image is missing or "
+            "corrupted; rebuild or rsync a fresh copy and re-spawn.",
+        )
+    if "No space left on device" in blob or "ENOSPC" in blob:
+        return (
+            "disk_full",
+            "the host filesystem hosting the runtime dir / overlay is "
+            "out of space; free up disk and re-spawn.",
+        )
+    return (
+        "container_creation_unknown",
+        "container creation failed for an unrecognised reason — see "
+        "stdout_tail / stderr_tail and the runtime_dir's stdout.log "
+        "for full context.",
+    )
+
+
+def write_marker(
+    runtime_dir: Path,
+    *,
+    started_at: str,
+    phase: str,
+    exit_code: int,
+    stdout: str,
+    stderr: str,
+    kind_override: str | None = None,
+) -> Path:
+    """Write ``runtime_dir/STARTUP_FAILED`` and return its path.
+
+    ``runtime_dir`` is the agent's per-instance state directory
+    (``~/.scitex/agent-container/runtime/<name>/``). Created if it
+    doesn't exist — the failure may have happened so early that the
+    directory itself isn't there yet.
+
+    Args:
+        runtime_dir: Target state directory.
+        started_at: ISO-8601 timestamp of the spawn attempt.
+        phase: Lifecycle phase the failure happened in (e.g.
+            ``"container_creation"``, ``"sdk_init"``,
+            ``"to_home_deploy"``). Free-form string the lifecycle
+            owner picks; downstream consumers branch on ``kind`` rather
+            than ``phase``.
+        exit_code: Subprocess exit code if known (apptainer returns
+            255 on FATAL; -1 / 0 acceptable for "unknown").
+        stdout / stderr: The subprocess's captured streams. Tail-clipped
+            to :data:`_TAIL_BYTES_LIMIT` before write.
+        kind_override: Skip the automatic ``classify_apptainer_failure``
+            pattern match and use the given ``kind``. Useful for callers
+            that already know the cause (e.g. an explicit ``sdk_init``
+            failure that doesn't look like an apptainer FATAL).
+
+    The write is best-effort atomic: written to a ``.tmp`` sibling
+    and ``os.replace``-d into place so partial markers aren't visible
+    to ``DELETE`` / ``STATUS`` readers.
+    """
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    if kind_override is not None:
+        kind = kind_override
+        # No automatic hint when caller pinned the kind — they have
+        # better context than the regex matcher.
+        hint = ""
+    else:
+        kind, hint = classify_apptainer_failure(stdout, stderr)
+    payload: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "started_at": started_at,
+        "failed_at": _now_iso(),
+        "phase": phase,
+        "kind": kind,
+        "exit_code": int(exit_code),
+        "stdout_tail": _tail_text(stdout),
+        "stderr_tail": _tail_text(stderr),
+        "remediation_hint": hint,
+    }
+    target = runtime_dir / MARKER_FILENAME
+    tmp = target.with_suffix(".tmp")
+    tmp.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    tmp.replace(target)
+    return target
+
+
+def read_marker(runtime_dir: Path) -> dict[str, Any] | None:
+    """Return the parsed marker dict, or ``None`` if absent/unreadable.
+
+    Best-effort: a partially-written / hand-corrupted marker collapses
+    to ``None`` so callers fall back to their existing not-found path.
+    """
+    target = runtime_dir / MARKER_FILENAME
+    if not target.is_file():
+        return None
+    # stx-allow: fallback (reason: an externally-corrupted marker should
+    # NOT crash status/delete; collapse to None and the caller treats
+    # it as a stillborn-with-no-record case)
+    try:
+        return json.loads(target.read_text(encoding="utf-8"))
+    except (OSError, ValueError):  # stx-allow: fallback (reason: see inline comment)
+        return None
+
+
+def is_stillborn(runtime_dir: Path) -> bool:
+    """True iff the runtime_dir carries a ``STARTUP_FAILED`` marker."""
+    return (runtime_dir / MARKER_FILENAME).is_file()
+
+
+__all__ = [
+    "MARKER_FILENAME",
+    "SCHEMA_VERSION",
+    "classify_apptainer_failure",
+    "is_stillborn",
+    "read_marker",
+    "write_marker",
+]

--- a/src/scitex_agent_container/_listen/_agent_exec.py
+++ b/src/scitex_agent_container/_listen/_agent_exec.py
@@ -318,6 +318,9 @@ async def agents_start(request: Request) -> JSONResponse:
     # a SIF). Using the canonical plural is what every other CLI
     # call site already does — see ``cli_pkg/fleet_group.py``
     # ``[remote_sac, "agents", "start", name]``.
+    from datetime import datetime, timezone
+
+    started_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     proc = await asyncio.to_thread(
         subprocess.run,
         [sac_bin, "agents", "start", name],
@@ -325,6 +328,36 @@ async def agents_start(request: Request) -> JSONResponse:
         text=True,
         check=False,
     )
+    if proc.returncode != 0:
+        # PR-1 — stillborn agent observability. The subprocess can exit
+        # non-zero for many reasons, including apptainer FATAL on a bind
+        # source the host can't see (the clew capsule case). Write a
+        # ``runtime_dir/STARTUP_FAILED`` marker so:
+        #   * a subsequent ``DELETE`` returns 410 Gone with the failure
+        #     payload instead of 404 "no pid file",
+        #   * ``GET .../status`` can surface ``status="startup_failed"``
+        #     instead of vacuous registry-only fields,
+        #   * future fleet-GC automation can drop the stillborn cleanly.
+        # The marker write is best-effort: a write failure (e.g. /state
+        # filesystem RO) MUST NOT shadow the underlying spawn failure.
+        # stx-allow: fallback (reason: marker is observability metadata
+        # only; failing here would only obscure the real start failure)
+        try:
+            from .._lifecycle._startup_failed import write_marker
+            from .._runners._session_state import state_dir_for
+
+            runtime_dir = state_dir_for(name)
+            write_marker(
+                runtime_dir,
+                started_at=started_at,
+                phase="container_creation",
+                exit_code=proc.returncode,
+                stdout=proc.stdout,
+                stderr=proc.stderr,
+            )
+        except Exception:  # stx-allow: fallback (reason: see inline comment)
+            pass
+
     return JSONResponse(
         {
             "name": name,

--- a/src/scitex_agent_container/_listen/_inline_spec.py
+++ b/src/scitex_agent_container/_listen/_inline_spec.py
@@ -20,15 +20,27 @@ def materialize_inline_spec(
     """Write ``spec`` to ``~/.scitex/agent-container/agents/<name>/spec.yaml``.
 
     Returns ``None`` on success, or a ``JSONResponse`` carrying the
-    failure (so the handler can ``return`` it verbatim). Validates the
-    bare minimum (dict, v3 apiVersion, Agent kind) so a malformed body
-    becomes a 400 instead of a downstream ``sac agent start`` crash.
+    failure (so the handler can ``return`` it verbatim). Validation
+    pipeline (ordered cheap-to-expensive):
+
+      1. ``spec`` is a dict + v3 apiVersion + Agent kind (basic shape).
+      2. ``kind="spec_invalid"`` for any of (1) — wire-stable.
+      3. **bind preflight**: every ``spec.apptainer.binds[*]`` host
+         source is ``stat()``-checked. Any missing source aborts with
+         HTTP 400 + ``kind="bind_unresolvable"`` (PR-1 fail-loud). This
+         catches the SAC-from-SAC silent FATAL where the spec carries
+         in-SIF ``/work/...`` paths that the host can't see.
+      4. ``kind="already_exists"`` for the overwrite-guard collision.
+      5. ``kind="spec_invalid"`` for write failure (disk full, RO fs).
     """
     import yaml
 
     if not isinstance(spec, dict):
         return JSONResponse(
-            {"error": "'spec' must be a JSON object (v3 Agent dict)"},
+            {
+                "error": "'spec' must be a JSON object (v3 Agent dict)",
+                "kind": "spec_invalid",
+            },
             status_code=400,
         )
     if spec.get("apiVersion") != "scitex-agent-container/v3":
@@ -36,14 +48,34 @@ def materialize_inline_spec(
             {
                 "error": (
                     "inline spec must declare apiVersion: scitex-agent-container/v3"
-                )
+                ),
+                "kind": "spec_invalid",
             },
             status_code=400,
         )
     if spec.get("kind") != "Agent":
         return JSONResponse(
-            {"error": "inline spec must declare kind: Agent"}, status_code=400
+            {
+                "error": "inline spec must declare kind: Agent",
+                "kind": "spec_invalid",
+            },
+            status_code=400,
         )
+
+    # PR-1 — fail-loud bind-source preflight. Done BEFORE writing the
+    # spec to disk so a rejected spawn leaves zero artifacts (no spec
+    # dir, no lineage record, no runtime dir). The clew capsule-0201225
+    # incident on 2026-06-02 took 50 minutes to diagnose because the
+    # apptainer FATAL was silent at the HTTP layer; this turns it into
+    # a structured 400 the caller can branch on by ``kind``.
+    from ._inline_spec_preflight import (
+        preflight_bind_sources,
+        preflight_failure_response_body,
+    )
+
+    preflight = preflight_bind_sources(spec)
+    if not preflight.ok:
+        return JSONResponse(preflight_failure_response_body(preflight), status_code=400)
 
     primary = (
         Path(os.path.expanduser("~")) / ".scitex" / "agent-container" / "agents" / name
@@ -55,7 +87,8 @@ def materialize_inline_spec(
                 "error": (
                     f"spec already exists at {spec_path}; pass "
                     "'overwrite': true to replace"
-                )
+                ),
+                "kind": "already_exists",
             },
             status_code=409,
         )
@@ -63,5 +96,8 @@ def materialize_inline_spec(
         primary.mkdir(parents=True, exist_ok=True)
         spec_path.write_text(yaml.safe_dump(spec, sort_keys=False), encoding="utf-8")
     except OSError as exc:
-        return JSONResponse({"error": f"failed to write spec: {exc}"}, status_code=500)
+        return JSONResponse(
+            {"error": f"failed to write spec: {exc}", "kind": "spec_invalid"},
+            status_code=500,
+        )
     return None

--- a/src/scitex_agent_container/_listen/_inline_spec_preflight.py
+++ b/src/scitex_agent_container/_listen/_inline_spec_preflight.py
@@ -224,35 +224,62 @@ def preflight_failure_response_body(result: PreflightResult) -> dict:
          "error": "bind source(s) not visible from host",
          "kind": "bind_unresolvable",
          "details": {
-           "unresolvable": [
+           "binds": [
              {
-               "bind": "/work/x:/x:ro",
-               "host_resolved": "/work/x",
-               "container_dest": "/x",
-               "exists_on_host": false
+               "source":          "/work/x",
+               "host_normalized": "/work/x",        // omitted when == source
+               "container_path":  "/x",
+               "exists_on_host":  false
              }
            ],
-           "remediation_hint": "rewrite the source to a host-visible path ..."
+           "translation_hint": "rewrite source(s) to host-visible paths ..."
          }
        }
+
+    Field naming per clew review (#287 WIP):
+      * ``binds`` (was ``unresolvable``) — always a LIST so 49-capsule
+        callers see EVERY miss in one round-trip, not just the first.
+      * ``source`` (was ``bind``) — the raw spec entry the operator
+        wrote.
+      * ``host_normalized`` (was always-emitted ``host_resolved``) —
+        ONLY emitted when ``~``/``$VAR`` expansion changed the source.
+        Saves wire bytes + makes "no normalisation happened" cleanly
+        distinguishable from "normalisation produced the same path".
+      * ``container_path`` (was ``container_dest``) — name aligned with
+        the rest of the apptainer-bind nomenclature (config parsers
+        already call it ``container_path``).
+      * ``translation_hint`` (was ``remediation_hint``) — names what
+        the operator actually needs to DO (translate the path), not a
+        generic "remediation".
 
     Callers MUST treat ``kind`` as the branch key; the prose ``error``
     is for humans only.
     """
+    entries: list[dict] = []
+    for c in result.unresolvable:
+        entry: dict = {
+            "source": c.bind,
+            "container_path": c.container_dest,
+            "exists_on_host": c.exists_on_host,
+        }
+        # Emit ``host_normalized`` ONLY when the host-side path was
+        # actually rewritten by ``~``/``$VAR`` expansion. Compare
+        # against the RAW HOST PORTION of the bind (not the whole
+        # ``host:container[:mode]`` string, which would always differ
+        # from the bare host_resolved path). Parsing here keeps
+        # BindCheck minimal — no extra field for callers to know
+        # about.
+        parsed = _parse_bind(c.bind)
+        raw_host = parsed[0] if parsed is not None else ""
+        if c.host_resolved and c.host_resolved != raw_host:
+            entry["host_normalized"] = c.host_resolved
+        entries.append(entry)
     return {
         "error": "bind source(s) not visible from host",
         "kind": "bind_unresolvable",
         "details": {
-            "unresolvable": [
-                {
-                    "bind": c.bind,
-                    "host_resolved": c.host_resolved,
-                    "container_dest": c.container_dest,
-                    "exists_on_host": c.exists_on_host,
-                }
-                for c in result.unresolvable
-            ],
-            "remediation_hint": (
+            "binds": entries,
+            "translation_hint": (
                 "rewrite each bind source to a path that exists on the "
                 "host (not the caller's in-SIF /work view), or wait for "
                 "PR-2 (SAC-side bind translate) to ship and re-spawn."

--- a/src/scitex_agent_container/_listen/_inline_spec_preflight.py
+++ b/src/scitex_agent_container/_listen/_inline_spec_preflight.py
@@ -1,0 +1,269 @@
+"""Pre-flight validation for inline ``POST /agents`` specs.
+
+The historical SAC-from-SAC inline-spec spawn path (PR #261) accepted
+the spec verbatim, materialised it to disk, and handed off to
+``sac agents start <name>``. The handoff returned HTTP 200 immediately
+on subprocess success, but the **apptainer container creation itself**
+could still FATAL minutes later if any bind source did not exist on
+the host filesystem — and that FATAL was silent at the HTTP layer.
+
+This was the clew-cohort-a-capsule-0201225 failure on 2026-06-02:
+the inline spec's ``apptainer.binds`` referenced ``/work/...`` paths
+that exist inside the caller's SIF view but NOT on the host. POST
+/agents returned 200, the agent appeared in ``/agents``, but no
+session was ever started:
+
+    WARNING: skipping mount of /work/.../capsule-0201225: stat ...
+             no such file or directory
+    FATAL:   container creation failed: mount hook function failure:
+             mount source /work/.../capsule-0201225 doesn't exist
+
+The operator burnt 50 minutes waiting for a session that never came.
+
+This module adds the missing **pre-flight** that catches this BEFORE
+the spec is materialised — every bind source is host-``stat()``-checked,
+and any unresolved source aborts the spawn with HTTP 400 carrying a
+structured ``kind="bind_unresolvable"`` body the caller (clew launcher
+and future SAC-from-SAC clients) can branch on without parsing prose.
+
+The validator is deliberately read-only. It does NOT translate paths
+(that's PR-2's job — SAC-side ``/work``-prefix rewriting). The split
+keeps two concerns testable in isolation:
+
+  * THIS PR — fail-loud rejection (always-on safety valve)
+  * PR-2   — bind translate (an opt-in convenience that reduces the
+            burden on callers; if it ever has a gap, this validator
+            still catches the leak)
+
+Never raises. Walks the spec dict defensively (any unexpected shape
+becomes a structured error). The bind syntax accepted matches
+``runtimes/_apptainer_runtime``: ``host_path:container_path[:mode]``
+strings, with ``~`` and ``$VAR`` expansion on the host side.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Result shape
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class BindCheck:
+    """Per-bind preflight result entry.
+
+    * ``bind`` — the raw bind string as it appeared in the spec
+      (``host_path:container_path[:mode]``). Echoed verbatim so the
+      caller can spot which line failed without parsing.
+    * ``host_resolved`` — the resolved host-side source after ``~``/
+      ``$VAR`` expansion; what the validator actually stat()ed.
+    * ``exists_on_host`` — ``True`` iff the resolved path exists.
+    * ``container_dest`` — the container-side mount point. Useful for
+      remediation hints (which dir inside the SIF this was supposed
+      to land at).
+    """
+
+    bind: str
+    host_resolved: str
+    exists_on_host: bool
+    container_dest: str
+
+
+@dataclass(frozen=True)
+class PreflightResult:
+    """Aggregated preflight outcome.
+
+    * ``ok`` — ``True`` iff every checked bind has ``exists_on_host=True``.
+    * ``checks`` — every per-bind result (in input order; useful when
+      multiple binds fail and the caller wants the full list).
+    * ``unresolvable`` — convenience subset of ``checks`` filtered to
+      the failing entries, so a JSON response can carry just the bad
+      ones without recomputation.
+    """
+
+    ok: bool
+    checks: tuple[BindCheck, ...]
+    unresolvable: tuple[BindCheck, ...]
+
+
+# ---------------------------------------------------------------------------
+# Parsing
+# ---------------------------------------------------------------------------
+
+
+def _expand_host_path(raw_src: str) -> str:
+    """Apply ``~``/``$VAR`` expansion on the host side only.
+
+    Matches ``config/_parsers/_apptainer._expand_bind_src`` so a bind
+    that the spec parser accepts is the same string this validator
+    stats. The container destination is *not* expanded (env on the
+    in-SIF side is irrelevant for host filesystem visibility).
+    """
+    expanded = os.path.expanduser(raw_src)
+    expanded = os.path.expandvars(expanded)
+    return expanded
+
+
+def _parse_bind(bind: Any) -> tuple[str, str] | None:
+    """Return ``(host_src, container_dst)`` or ``None`` if unparseable.
+
+    Accepts the apptainer-runtime canonical string form
+    ``host:container[:mode]``. Dict forms (``{src, dst, mode}``) are
+    normalised to this shape by the spec parser at materialise time;
+    we accept both here so the preflight survives a caller passing
+    the dict form directly.
+    """
+    if isinstance(bind, dict):
+        src = bind.get("src") or bind.get("source")
+        dst = bind.get("dst") or bind.get("destination") or bind.get("target")
+        if not isinstance(src, str) or not isinstance(dst, str):
+            return None
+        return src, dst
+    if not isinstance(bind, str):
+        return None
+    parts = bind.split(":", 2)
+    if len(parts) < 2:
+        return None  # malformed; need at least host:container
+    return parts[0], parts[1]
+
+
+def _iter_binds(spec: dict) -> list[Any]:
+    """Best-effort extraction of ``spec.apptainer.binds`` from a v3 spec.
+
+    Defensive: any unexpected shape collapses to an empty list. The
+    caller can still preflight ``volumes`` separately if needed (a
+    follow-up); the current threat model is the apptainer binds path
+    which is what the clew failure exercised.
+    """
+    if not isinstance(spec, dict):
+        return []
+    spec_body = spec.get("spec")
+    if not isinstance(spec_body, dict):
+        return []
+    apt = spec_body.get("apptainer")
+    if not isinstance(apt, dict):
+        return []
+    binds = apt.get("binds")
+    if not isinstance(binds, list):
+        return []
+    return binds
+
+
+# ---------------------------------------------------------------------------
+# Public preflight
+# ---------------------------------------------------------------------------
+
+
+def preflight_bind_sources(spec: dict) -> PreflightResult:
+    """Validate ``spec.apptainer.binds`` against the host filesystem.
+
+    Returns a :class:`PreflightResult` enumerating every bind, with
+    each entry's ``exists_on_host`` flag set from ``Path(host_src).exists()``.
+    The aggregate ``ok`` is ``True`` only when every checked bind
+    resolved.
+
+    Specs with no binds (or unparseable shape) collapse to ``ok=True``
+    with an empty ``checks`` tuple — there is nothing to reject.
+
+    Path expansion: ``~`` and ``$VAR`` are applied to the host side
+    only (mirrors ``config/_parsers/_apptainer._expand_bind_src``).
+    Symlinks are followed (the spec parser does the same; broken
+    symlinks count as non-existent here too).
+    """
+    binds = _iter_binds(spec)
+    checks: list[BindCheck] = []
+    unresolvable: list[BindCheck] = []
+    for raw in binds:
+        parsed = _parse_bind(raw)
+        if parsed is None:
+            # An un-parseable entry is loud — the host can't even tell
+            # what to check. Record it with an empty resolved path
+            # and exists=False so the caller sees the malformed line.
+            entry = BindCheck(
+                bind=str(raw),
+                host_resolved="",
+                exists_on_host=False,
+                container_dest="",
+            )
+            checks.append(entry)
+            unresolvable.append(entry)
+            continue
+        host_src, container_dst = parsed
+        resolved = _expand_host_path(host_src)
+        exists = Path(resolved).exists()
+        entry = BindCheck(
+            bind=str(raw),
+            host_resolved=resolved,
+            exists_on_host=exists,
+            container_dest=container_dst,
+        )
+        checks.append(entry)
+        if not exists:
+            unresolvable.append(entry)
+    return PreflightResult(
+        ok=not unresolvable,
+        checks=tuple(checks),
+        unresolvable=tuple(unresolvable),
+    )
+
+
+def preflight_failure_response_body(result: PreflightResult) -> dict:
+    """Build the HTTP 400 JSON body for a failed preflight.
+
+    Stable wire shape (clew launcher + future SAC-from-SAC clients
+    branch on ``kind`` not prose):
+
+    .. code-block:: json
+
+       {
+         "error": "bind source(s) not visible from host",
+         "kind": "bind_unresolvable",
+         "details": {
+           "unresolvable": [
+             {
+               "bind": "/work/x:/x:ro",
+               "host_resolved": "/work/x",
+               "container_dest": "/x",
+               "exists_on_host": false
+             }
+           ],
+           "remediation_hint": "rewrite the source to a host-visible path ..."
+         }
+       }
+
+    Callers MUST treat ``kind`` as the branch key; the prose ``error``
+    is for humans only.
+    """
+    return {
+        "error": "bind source(s) not visible from host",
+        "kind": "bind_unresolvable",
+        "details": {
+            "unresolvable": [
+                {
+                    "bind": c.bind,
+                    "host_resolved": c.host_resolved,
+                    "container_dest": c.container_dest,
+                    "exists_on_host": c.exists_on_host,
+                }
+                for c in result.unresolvable
+            ],
+            "remediation_hint": (
+                "rewrite each bind source to a path that exists on the "
+                "host (not the caller's in-SIF /work view), or wait for "
+                "PR-2 (SAC-side bind translate) to ship and re-spawn."
+            ),
+        },
+    }
+
+
+__all__ = [
+    "BindCheck",
+    "PreflightResult",
+    "preflight_bind_sources",
+    "preflight_failure_response_body",
+]

--- a/src/scitex_agent_container/_listen/server.py
+++ b/src/scitex_agent_container/_listen/server.py
@@ -231,18 +231,35 @@ async def agent_delete(request: Request) -> JSONResponse:
         # genuinely not-found. Stillborn → 410 Gone + the structured
         # failure body the operator/orchestrator can branch on without
         # also hitting GET /agents/<name>/status.
-        from .._lifecycle._startup_failed import read_marker
+        #
+        # Wire shape per clew review (#287):
+        #
+        # The "headline" failure fields (status, phase, kind, failed_at,
+        # runtime_dir, remediation_hint) are LIFTED to the top level so a
+        # clew-launcher error renderer can branch / display without
+        # walking into ``details``. ``see_also`` is the host-absolute
+        # path to the on-disk marker so a human / sysadmin can ``cat``
+        # the marker (and the peer ``stdout.log`` / ``stderr.log`` in
+        # the same directory) without recomputing it. The full marker
+        # remains under ``details`` for parity with the marker file
+        # contents (and so an orchestrator can hash it for dedupe).
+        from .._lifecycle._startup_failed import MARKER_FILENAME, read_marker
 
         marker = read_marker(sd)
         if marker is not None:
-            return JSONResponse(
-                {
-                    "name": name,
-                    "kind": "startup_failed",
-                    "details": marker,
-                },
-                status_code=410,
-            )
+            runtime_dir = marker.get("runtime_dir", str(sd.resolve()))
+            body: dict[str, Any] = {
+                "name": name,
+                "status": "startup_failed",
+                "kind": marker.get("kind"),
+                "phase": marker.get("phase"),
+                "failed_at": marker.get("failed_at"),
+                "runtime_dir": runtime_dir,
+                "remediation_hint": marker.get("remediation_hint", ""),
+                "see_also": f"{runtime_dir}/{MARKER_FILENAME}",
+                "details": marker,
+            }
+            return JSONResponse(body, status_code=410)
         return JSONResponse({"error": "no pid file"}, status_code=404)
     try:
         pid = int(pid_file.read_text().strip())

--- a/src/scitex_agent_container/_listen/server.py
+++ b/src/scitex_agent_container/_listen/server.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import os
 import urllib.error as _urlerror
 import urllib.request as _urlrequest
+from typing import Any
 
 from starlette.applications import Starlette
 from starlette.requests import Request
@@ -74,15 +75,25 @@ async def agent_status(request: Request) -> JSONResponse:
         return JSONResponse({"error": str(exc)}, status_code=404)
     sd = state_dir_for(name)
     sid = read_session_id(sd)
-    return JSONResponse(
-        {
-            "name": name,
-            "spec_path": str(spec_path),
-            "workdir": cfg.expanded_workdir,
-            "session_id": sid,
-            "state_dir": str(sd),
-        }
-    )
+    body: dict[str, Any] = {
+        "name": name,
+        "spec_path": str(spec_path),
+        "workdir": cfg.expanded_workdir,
+        "session_id": sid,
+        "state_dir": str(sd),
+    }
+    # PR-1 — stillborn surface. If the runtime dir has a
+    # ``STARTUP_FAILED`` marker (= the spawn never produced an SDK
+    # session), echo it so callers don't have to also poll a separate
+    # endpoint to know why ``session_id`` is null. Matches the 410
+    # body shape returned by DELETE on the same condition.
+    from .._lifecycle._startup_failed import read_marker
+
+    marker = read_marker(sd)
+    if marker is not None:
+        body["status"] = "startup_failed"
+        body["startup_failed"] = marker
+    return JSONResponse(body)
 
 
 # --- extracted handlers re-imported for routes + back-compat ---------------
@@ -196,11 +207,42 @@ from ._node_channel import (  # noqa: E402
 
 
 async def agent_delete(request: Request) -> JSONResponse:
-    """DELETE /agents/<name> — stop the agent."""
+    """DELETE /agents/<name> — stop the agent.
+
+    Three cases distinguished by the response code (PR-1 lifecycle):
+
+      * **200 OK** — agent is live; ``pid`` file present; SIGTERM sent.
+      * **410 Gone** — agent is *stillborn*: a ``STARTUP_FAILED`` marker
+        is on disk (set by the POST /agents handler on a non-zero
+        ``sac agents start`` exit). The body carries the failure
+        details so the caller doesn't need to also ``GET .../status``.
+      * **404 Not Found** — agent never existed or was already deleted.
+
+    Splitting 410 from 404 is the operator-actionable difference:
+    "never existed" vs. "existed, has been removed". The clew capsule
+    case landed in 404 before this change because the marker didn't
+    exist; with the marker, the 410 path now lights up.
+    """
     name = request.path_params["name"]
     sd = state_dir_for(name)
     pid_file = sd / "pid"
     if not pid_file.is_file():
+        # PR-1 — distinguish stillborn (have STARTUP_FAILED marker) from
+        # genuinely not-found. Stillborn → 410 Gone + the structured
+        # failure body the operator/orchestrator can branch on without
+        # also hitting GET /agents/<name>/status.
+        from .._lifecycle._startup_failed import read_marker
+
+        marker = read_marker(sd)
+        if marker is not None:
+            return JSONResponse(
+                {
+                    "name": name,
+                    "kind": "startup_failed",
+                    "details": marker,
+                },
+                status_code=410,
+            )
         return JSONResponse({"error": "no pid file"}, status_code=404)
     try:
         pid = int(pid_file.read_text().strip())

--- a/tests/scitex_agent_container/_lifecycle/test__startup_failed.py
+++ b/tests/scitex_agent_container/_lifecycle/test__startup_failed.py
@@ -13,8 +13,6 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
-
 from scitex_agent_container._lifecycle._startup_failed import (
     MARKER_FILENAME,
     SCHEMA_VERSION,

--- a/tests/scitex_agent_container/_lifecycle/test__startup_failed.py
+++ b/tests/scitex_agent_container/_lifecycle/test__startup_failed.py
@@ -183,6 +183,24 @@ def test_marker_payload_carries_exit_code(tmp_path: Path) -> None:
     assert payload["exit_code"] == 137
 
 
+def test_marker_payload_carries_runtime_dir(tmp_path: Path) -> None:
+    # Arrange — per clew review, the marker must echo its own host-
+    # absolute runtime_dir so the DELETE 410 / STATUS bodies can
+    # surface a ``see_also`` pointer without recomputing the path.
+    # Act
+    target = write_marker(
+        tmp_path,
+        started_at="2026-06-03T01:00:00Z",
+        phase="container_creation",
+        exit_code=255,
+        stdout="",
+        stderr="",
+    )
+    payload = json.loads(target.read_text())
+    # Assert
+    assert payload["runtime_dir"] == str(tmp_path.resolve())
+
+
 def test_marker_payload_classifies_apptainer_fatal(tmp_path: Path) -> None:
     # Arrange
     runtime_dir = tmp_path

--- a/tests/scitex_agent_container/_lifecycle/test__startup_failed.py
+++ b/tests/scitex_agent_container/_lifecycle/test__startup_failed.py
@@ -1,0 +1,353 @@
+"""Tests for :mod:`scitex_agent_container._lifecycle._startup_failed`.
+
+Real-FS marker writes against tmp_path. Pins:
+  * the on-disk schema (schema_version, required keys),
+  * the apptainer-FATAL pattern classifier (so wire callers see a stable
+    ``kind`` set),
+  * the tail-bytes bound (runaway stdout can't bloat the marker),
+  * the atomic write (no partial marker visible to STATUS/DELETE readers).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._lifecycle._startup_failed import (
+    MARKER_FILENAME,
+    SCHEMA_VERSION,
+    classify_apptainer_failure,
+    is_stillborn,
+    read_marker,
+    write_marker,
+)
+
+# ---------------------------------------------------------------------------
+# classify_apptainer_failure — well-known FATAL shapes
+# ---------------------------------------------------------------------------
+
+
+def test_classify_apptainer_mount_failed_from_clew_capsule_trace() -> None:
+    # Arrange — verbatim head of the clew-cohort-a-capsule-0201225 FATAL
+    # captured during the 2026-06-02 triage. The classifier MUST pin this
+    # to ``apptainer_mount_failed`` so clew launcher branches consistently.
+    stderr = (
+        "FATAL:   container creation failed: mount hook function failure: "
+        "mount source /work/data/capsule-0201225 doesn't exist"
+    )
+    # Act
+    kind, _ = classify_apptainer_failure(stdout="", stderr=stderr)
+    # Assert
+    assert kind == "apptainer_mount_failed"
+
+
+def test_classify_apptainer_mount_failed_includes_remediation_hint() -> None:
+    # Arrange
+    stderr = "mount source /a doesn't exist"
+    # Act
+    _, hint = classify_apptainer_failure(stdout="", stderr=stderr)
+    # Assert
+    assert "bind sources" in hint
+
+
+def test_classify_sif_invalid_for_corrupt_sif_message() -> None:
+    # Arrange
+    stderr = "FATAL: /home/me/sac-base.sif is not a valid SIF image"
+    # Act
+    kind, _ = classify_apptainer_failure(stdout="", stderr=stderr)
+    # Assert
+    assert kind == "sif_invalid"
+
+
+def test_classify_disk_full_for_enospc() -> None:
+    # Arrange
+    stderr = "write error: No space left on device"
+    # Act
+    kind, _ = classify_apptainer_failure(stdout="", stderr=stderr)
+    # Assert
+    assert kind == "disk_full"
+
+
+def test_classify_unknown_kind_for_unrecognised_blob() -> None:
+    # Arrange
+    stderr = "something we have never seen before, panic"
+    # Act
+    kind, _ = classify_apptainer_failure(stdout="", stderr=stderr)
+    # Assert
+    assert kind == "container_creation_unknown"
+
+
+def test_classify_unknown_kind_emits_generic_remediation_hint() -> None:
+    # Arrange
+    stderr = "novel-failure-message"
+    # Act
+    _, hint = classify_apptainer_failure(stdout="", stderr=stderr)
+    # Assert
+    assert "unrecognised" in hint
+
+
+def test_classify_concatenates_stdout_and_stderr() -> None:
+    # Arrange — the trigger phrase lands in stdout, not stderr.
+    stdout = "mount source /a doesn't exist"
+    # Act
+    kind, _ = classify_apptainer_failure(stdout=stdout, stderr="")
+    # Assert
+    assert kind == "apptainer_mount_failed"
+
+
+# ---------------------------------------------------------------------------
+# write_marker — file shape + atomicity
+# ---------------------------------------------------------------------------
+
+
+def test_write_marker_creates_runtime_dir_if_missing(tmp_path: Path) -> None:
+    # Arrange — runtime_dir doesn't exist yet (early-FATAL case).
+    runtime_dir = tmp_path / "stillborn" / "runtime"
+    # Act
+    write_marker(
+        runtime_dir,
+        started_at="2026-06-03T01:23:45Z",
+        phase="container_creation",
+        exit_code=255,
+        stdout="",
+        stderr="mount source /a doesn't exist",
+    )
+    # Assert
+    assert (runtime_dir / MARKER_FILENAME).is_file()
+
+
+def test_write_marker_returns_target_path(tmp_path: Path) -> None:
+    # Arrange
+    runtime_dir = tmp_path
+    # Act
+    target = write_marker(
+        tmp_path,
+        started_at="2026-06-03T01:00:00Z",
+        phase="container_creation",
+        exit_code=255,
+        stdout="",
+        stderr="mount source /a doesn't exist",
+    )
+    # Assert
+    assert target == tmp_path / MARKER_FILENAME
+
+
+def test_marker_payload_has_schema_version(tmp_path: Path) -> None:
+    # Arrange
+    runtime_dir = tmp_path
+    # Act
+    target = write_marker(
+        tmp_path,
+        started_at="2026-06-03T01:00:00Z",
+        phase="container_creation",
+        exit_code=255,
+        stdout="",
+        stderr="",
+    )
+    payload = json.loads(target.read_text())
+    # Assert
+    assert payload["schema_version"] == SCHEMA_VERSION
+
+
+def test_marker_payload_carries_phase(tmp_path: Path) -> None:
+    # Arrange
+    runtime_dir = tmp_path
+    # Act
+    target = write_marker(
+        tmp_path,
+        started_at="2026-06-03T01:00:00Z",
+        phase="sdk_init",
+        exit_code=1,
+        stdout="",
+        stderr="",
+    )
+    payload = json.loads(target.read_text())
+    # Assert
+    assert payload["phase"] == "sdk_init"
+
+
+def test_marker_payload_carries_exit_code(tmp_path: Path) -> None:
+    # Arrange
+    runtime_dir = tmp_path
+    # Act
+    target = write_marker(
+        tmp_path,
+        started_at="2026-06-03T01:00:00Z",
+        phase="container_creation",
+        exit_code=137,
+        stdout="",
+        stderr="",
+    )
+    payload = json.loads(target.read_text())
+    # Assert
+    assert payload["exit_code"] == 137
+
+
+def test_marker_payload_classifies_apptainer_fatal(tmp_path: Path) -> None:
+    # Arrange
+    runtime_dir = tmp_path
+    # Act
+    target = write_marker(
+        tmp_path,
+        started_at="2026-06-03T01:00:00Z",
+        phase="container_creation",
+        exit_code=255,
+        stdout="",
+        stderr="mount source /work/x doesn't exist",
+    )
+    payload = json.loads(target.read_text())
+    # Assert
+    assert payload["kind"] == "apptainer_mount_failed"
+
+
+def test_marker_payload_uses_kind_override_when_given(tmp_path: Path) -> None:
+    # Arrange — kind_override skips the auto-classifier.
+    runtime_dir = tmp_path
+    # Act
+    target = write_marker(
+        tmp_path,
+        started_at="2026-06-03T01:00:00Z",
+        phase="to_home_deploy",
+        exit_code=1,
+        stdout="",
+        stderr="mount source /a doesn't exist",  # would normally classify
+        kind_override="to_home_deploy_failed",
+    )
+    payload = json.loads(target.read_text())
+    # Assert
+    assert payload["kind"] == "to_home_deploy_failed"
+
+
+def test_marker_payload_truncates_runaway_stdout(tmp_path: Path) -> None:
+    # Arrange — push stdout above the tail-byte bound; payload's
+    # stdout_tail must be bounded so a runaway log can't bloat the
+    # marker.
+    runaway = "x" * 50_000  # 50 KB
+    # Act
+    target = write_marker(
+        tmp_path,
+        started_at="2026-06-03T01:00:00Z",
+        phase="container_creation",
+        exit_code=255,
+        stdout=runaway,
+        stderr="",
+    )
+    payload = json.loads(target.read_text())
+    # Assert
+    assert len(payload["stdout_tail"]) < len(runaway)
+
+
+def test_marker_payload_truncated_tail_is_suffix(tmp_path: Path) -> None:
+    # Arrange — captured tail must come from the END of the log (not the
+    # start) so the FATAL line is preserved.
+    log = "noise\n" * 5000 + "FATAL_MARKER_LINE_KEEP_ME"
+    # Act
+    target = write_marker(
+        tmp_path,
+        started_at="2026-06-03T01:00:00Z",
+        phase="container_creation",
+        exit_code=255,
+        stdout="",
+        stderr=log,
+    )
+    payload = json.loads(target.read_text())
+    # Assert
+    assert "FATAL_MARKER_LINE_KEEP_ME" in payload["stderr_tail"]
+
+
+def test_write_marker_atomic_no_tmp_visible(tmp_path: Path) -> None:
+    # Arrange — write must atomically replace; no .tmp file lingers.
+    # Act
+    write_marker(
+        tmp_path,
+        started_at="2026-06-03T01:00:00Z",
+        phase="container_creation",
+        exit_code=255,
+        stdout="",
+        stderr="",
+    )
+    tmp_siblings = list(tmp_path.glob(f"{MARKER_FILENAME}.tmp"))
+    # Assert
+    assert tmp_siblings == []
+
+
+def test_write_marker_payload_is_valid_json(tmp_path: Path) -> None:
+    # Arrange — the marker must parse as JSON for read_marker.
+    target = write_marker(
+        tmp_path,
+        started_at="2026-06-03T01:00:00Z",
+        phase="container_creation",
+        exit_code=255,
+        stdout="",
+        stderr="",
+    )
+    # Act
+    parsed = json.loads(target.read_text())
+    # Assert
+    assert isinstance(parsed, dict)
+
+
+# ---------------------------------------------------------------------------
+# read_marker / is_stillborn
+# ---------------------------------------------------------------------------
+
+
+def test_read_marker_returns_none_when_absent(tmp_path: Path) -> None:
+    # Arrange
+    runtime_dir = tmp_path
+    # Act
+    result = read_marker(tmp_path)
+    # Assert
+    assert result is None
+
+
+def test_read_marker_returns_dict_when_present(tmp_path: Path) -> None:
+    # Arrange
+    write_marker(
+        tmp_path,
+        started_at="2026-06-03T01:00:00Z",
+        phase="container_creation",
+        exit_code=255,
+        stdout="",
+        stderr="",
+    )
+    # Act
+    result = read_marker(tmp_path)
+    # Assert
+    assert isinstance(result, dict)
+
+
+def test_read_marker_handles_corrupt_payload(tmp_path: Path) -> None:
+    # Arrange — a hand-written non-JSON marker collapses to None.
+    (tmp_path / MARKER_FILENAME).write_text("this is not json")
+    # Act
+    result = read_marker(tmp_path)
+    # Assert
+    assert result is None
+
+
+def test_is_stillborn_false_when_no_marker(tmp_path: Path) -> None:
+    # Arrange
+    runtime_dir = tmp_path
+    # Act
+    flag = is_stillborn(tmp_path)
+    # Assert
+    assert flag is False
+
+
+def test_is_stillborn_true_after_write(tmp_path: Path) -> None:
+    # Arrange
+    write_marker(
+        tmp_path,
+        started_at="2026-06-03T01:00:00Z",
+        phase="container_creation",
+        exit_code=255,
+        stdout="",
+        stderr="",
+    )
+    # Act
+    flag = is_stillborn(tmp_path)
+    # Assert
+    assert flag is True

--- a/tests/scitex_agent_container/_listen/test__inline_spec_preflight.py
+++ b/tests/scitex_agent_container/_listen/test__inline_spec_preflight.py
@@ -1,0 +1,283 @@
+"""Tests for :mod:`scitex_agent_container._listen._inline_spec_preflight`.
+
+Real I/O against tmp_path; bind sources are real files/dirs on disk
+or deliberately-missing paths. AAA + one assert per test (PA-307).
+The preflight is a pure function over the filesystem — no mocks.
+
+Pinning the wire-shape contract here (``kind``, ``details.unresolvable``
+field names) so clew + future SAC-from-SAC clients can branch on it
+without grepping prose.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._listen._inline_spec_preflight import (
+    BindCheck,
+    PreflightResult,
+    preflight_bind_sources,
+    preflight_failure_response_body,
+)
+
+# ---------------------------------------------------------------------------
+# Spec builders
+# ---------------------------------------------------------------------------
+
+
+def _spec_with_binds(binds: list) -> dict:
+    return {
+        "apiVersion": "scitex-agent-container/v3",
+        "kind": "Agent",
+        "spec": {"apptainer": {"binds": binds}},
+    }
+
+
+# ---------------------------------------------------------------------------
+# preflight_bind_sources — happy path
+# ---------------------------------------------------------------------------
+
+
+def test_preflight_ok_when_no_binds() -> None:
+    # Arrange — spec carries no apptainer.binds at all.
+    spec = {
+        "apiVersion": "scitex-agent-container/v3",
+        "kind": "Agent",
+        "spec": {"apptainer": {}},
+    }
+    # Act
+    result = preflight_bind_sources(spec)
+    # Assert
+    assert result.ok is True
+
+
+def test_preflight_ok_when_all_binds_exist(tmp_path: Path) -> None:
+    # Arrange — two real dirs on disk, both referenced as binds.
+    (tmp_path / "a").mkdir()
+    (tmp_path / "b").mkdir()
+    spec = _spec_with_binds([f"{tmp_path}/a:/inside_a:ro", f"{tmp_path}/b:/inside_b"])
+    # Act
+    result = preflight_bind_sources(spec)
+    # Assert
+    assert result.ok is True
+
+
+def test_preflight_records_every_bind_in_input_order(tmp_path: Path) -> None:
+    # Arrange
+    (tmp_path / "x").mkdir()
+    (tmp_path / "y").mkdir()
+    spec = _spec_with_binds([f"{tmp_path}/x:/x", f"{tmp_path}/y:/y"])
+    # Act
+    result = preflight_bind_sources(spec)
+    # Assert
+    assert tuple(c.bind for c in result.checks) == (
+        f"{tmp_path}/x:/x",
+        f"{tmp_path}/y:/y",
+    )
+
+
+def test_preflight_records_container_dest(tmp_path: Path) -> None:
+    # Arrange
+    (tmp_path / "src").mkdir()
+    spec = _spec_with_binds([f"{tmp_path}/src:/capsule:ro"])
+    # Act
+    result = preflight_bind_sources(spec)
+    # Assert
+    assert result.checks[0].container_dest == "/capsule"
+
+
+def test_preflight_expands_tilde_in_host_src(tmp_path: Path, env_save_restore) -> None:
+    # Arrange — ~ should resolve to $HOME, set to a real tmp dir.
+    env_save_restore.set("HOME", str(tmp_path))
+    (tmp_path / "data").mkdir()
+    spec = _spec_with_binds(["~/data:/data:ro"])
+    # Act
+    result = preflight_bind_sources(spec)
+    # Assert
+    assert result.ok is True
+
+
+def test_preflight_expands_envvar_in_host_src(tmp_path: Path, env_save_restore) -> None:
+    # Arrange — $MYDIR is set to a real tmp path.
+    env_save_restore.set("MYDIR", str(tmp_path))
+    spec = _spec_with_binds(["$MYDIR:/inside"])
+    # Act
+    result = preflight_bind_sources(spec)
+    # Assert
+    assert result.ok is True
+
+
+# ---------------------------------------------------------------------------
+# preflight_bind_sources — failure detection
+# ---------------------------------------------------------------------------
+
+
+def test_preflight_fails_when_one_bind_missing(tmp_path: Path) -> None:
+    # Arrange — a real dir + a deliberately-missing path.
+    (tmp_path / "real").mkdir()
+    spec = _spec_with_binds([f"{tmp_path}/real:/r", f"{tmp_path}/nope/missing:/n:ro"])
+    # Act
+    result = preflight_bind_sources(spec)
+    # Assert
+    assert result.ok is False
+
+
+def test_preflight_unresolvable_list_only_includes_missing(
+    tmp_path: Path,
+) -> None:
+    # Arrange
+    (tmp_path / "ok").mkdir()
+    spec = _spec_with_binds([f"{tmp_path}/ok:/x", f"{tmp_path}/missing:/y"])
+    # Act
+    result = preflight_bind_sources(spec)
+    missing_binds = [c.bind for c in result.unresolvable]
+    # Assert
+    assert missing_binds == [f"{tmp_path}/missing:/y"]
+
+
+def test_preflight_records_exists_on_host_per_entry(tmp_path: Path) -> None:
+    # Arrange
+    (tmp_path / "real").mkdir()
+    spec = _spec_with_binds([f"{tmp_path}/real:/r", f"{tmp_path}/gone:/g"])
+    # Act
+    result = preflight_bind_sources(spec)
+    states = {c.host_resolved: c.exists_on_host for c in result.checks}
+    # Assert
+    assert states == {f"{tmp_path}/real": True, f"{tmp_path}/gone": False}
+
+
+def test_preflight_records_resolved_host_path(tmp_path: Path, env_save_restore) -> None:
+    # Arrange — verify the resolved path is the tilde-expanded form.
+    env_save_restore.set("HOME", str(tmp_path))
+    (tmp_path / "d").mkdir()
+    spec = _spec_with_binds(["~/d:/d"])
+    # Act
+    result = preflight_bind_sources(spec)
+    # Assert
+    assert result.checks[0].host_resolved == f"{tmp_path}/d"
+
+
+# ---------------------------------------------------------------------------
+# preflight_bind_sources — defensive parsing
+# ---------------------------------------------------------------------------
+
+
+def test_preflight_handles_dict_bind_form(tmp_path: Path) -> None:
+    # Arrange — apptainer parser accepts {src, dst, mode}; preflight too.
+    (tmp_path / "ok").mkdir()
+    spec = _spec_with_binds(
+        [{"src": str(tmp_path / "ok"), "dst": "/inside", "mode": "ro"}]
+    )
+    # Act
+    result = preflight_bind_sources(spec)
+    # Assert
+    assert result.ok is True
+
+
+def test_preflight_flags_malformed_bind_string(tmp_path: Path) -> None:
+    # Arrange — missing colon means the entry isn't a valid bind.
+    spec = _spec_with_binds(["this-is-not-a-bind"])
+    # Act
+    result = preflight_bind_sources(spec)
+    # Assert
+    assert result.ok is False
+
+
+def test_preflight_flags_malformed_dict_bind(tmp_path: Path) -> None:
+    # Arrange — dict missing 'src'.
+    spec = _spec_with_binds([{"dst": "/x"}])
+    # Act
+    result = preflight_bind_sources(spec)
+    # Assert
+    assert result.ok is False
+
+
+def test_preflight_collapses_to_ok_when_spec_shape_unexpected() -> None:
+    # Arrange — no spec.apptainer.binds → nothing to check → ok=True.
+    weird_spec = {"unexpected": "shape"}
+    # Act
+    result = preflight_bind_sources(weird_spec)
+    # Assert
+    assert result.ok is True
+
+
+def test_preflight_returns_dataclass_results(tmp_path: Path) -> None:
+    # Arrange
+    (tmp_path / "ok").mkdir()
+    spec = _spec_with_binds([f"{tmp_path}/ok:/o"])
+    # Act
+    result = preflight_bind_sources(spec)
+    # Assert
+    assert isinstance(result, PreflightResult)
+
+
+def test_preflight_per_bind_results_are_dataclass(tmp_path: Path) -> None:
+    # Arrange
+    (tmp_path / "ok").mkdir()
+    spec = _spec_with_binds([f"{tmp_path}/ok:/o"])
+    # Act
+    result = preflight_bind_sources(spec)
+    # Assert
+    assert isinstance(result.checks[0], BindCheck)
+
+
+# ---------------------------------------------------------------------------
+# preflight_failure_response_body — stable wire shape
+# ---------------------------------------------------------------------------
+
+
+def test_failure_body_uses_kind_bind_unresolvable(tmp_path: Path) -> None:
+    # Arrange
+    spec = _spec_with_binds([f"{tmp_path}/missing:/x"])
+    result = preflight_bind_sources(spec)
+    # Act
+    body = preflight_failure_response_body(result)
+    # Assert
+    assert body["kind"] == "bind_unresolvable"
+
+
+def test_failure_body_has_error_field(tmp_path: Path) -> None:
+    # Arrange
+    spec = _spec_with_binds([f"{tmp_path}/missing:/x"])
+    result = preflight_bind_sources(spec)
+    # Act
+    body = preflight_failure_response_body(result)
+    # Assert
+    assert "error" in body
+
+
+def test_failure_body_lists_unresolvable_binds_only(tmp_path: Path) -> None:
+    # Arrange — one OK, one missing; only the missing one should appear.
+    (tmp_path / "ok").mkdir()
+    spec = _spec_with_binds([f"{tmp_path}/ok:/o", f"{tmp_path}/missing:/m"])
+    result = preflight_bind_sources(spec)
+    # Act
+    body = preflight_failure_response_body(result)
+    listed_binds = [e["bind"] for e in body["details"]["unresolvable"]]
+    # Assert
+    assert listed_binds == [f"{tmp_path}/missing:/m"]
+
+
+def test_failure_body_carries_remediation_hint(tmp_path: Path) -> None:
+    # Arrange
+    spec = _spec_with_binds([f"{tmp_path}/missing:/x"])
+    result = preflight_bind_sources(spec)
+    # Act
+    body = preflight_failure_response_body(result)
+    # Assert
+    assert body["details"]["remediation_hint"] != ""
+
+
+def test_failure_body_each_entry_has_exists_on_host_false(
+    tmp_path: Path,
+) -> None:
+    # Arrange — all listed entries must be the missing ones.
+    spec = _spec_with_binds([f"{tmp_path}/x:/x", f"{tmp_path}/y:/y"])
+    result = preflight_bind_sources(spec)
+    # Act
+    body = preflight_failure_response_body(result)
+    flags = [e["exists_on_host"] for e in body["details"]["unresolvable"]]
+    # Assert
+    assert flags == [False, False]

--- a/tests/scitex_agent_container/_listen/test__inline_spec_preflight.py
+++ b/tests/scitex_agent_container/_listen/test__inline_spec_preflight.py
@@ -13,8 +13,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
 from scitex_agent_container._listen._inline_spec_preflight import (
     BindCheck,
     PreflightResult,

--- a/tests/scitex_agent_container/_listen/test__inline_spec_preflight.py
+++ b/tests/scitex_agent_container/_listen/test__inline_spec_preflight.py
@@ -4,9 +4,19 @@ Real I/O against tmp_path; bind sources are real files/dirs on disk
 or deliberately-missing paths. AAA + one assert per test (PA-307).
 The preflight is a pure function over the filesystem — no mocks.
 
-Pinning the wire-shape contract here (``kind``, ``details.unresolvable``
-field names) so clew + future SAC-from-SAC clients can branch on it
-without grepping prose.
+Pinning the wire-shape contract here so clew + future SAC-from-SAC
+clients can branch on it without grepping prose. Per the clew review
+on #287, the failure-body keys are:
+
+  * ``kind`` (top-level branch tag) = ``"bind_unresolvable"``
+  * ``details.binds[]`` (was ``unresolvable``) — array form so multi-
+    capsule callers see EVERY miss in one round-trip
+  * ``details.binds[].source`` (was ``bind``) — raw spec entry
+  * ``details.binds[].container_path`` (was ``container_dest``)
+  * ``details.binds[].host_normalized`` (was always-emitted
+    ``host_resolved``) — present ONLY when ``~``/``$VAR`` expansion
+    changed the source
+  * ``details.translation_hint`` (was ``remediation_hint``)
 """
 
 from __future__ import annotations
@@ -247,25 +257,39 @@ def test_failure_body_has_error_field(tmp_path: Path) -> None:
 
 
 def test_failure_body_lists_unresolvable_binds_only(tmp_path: Path) -> None:
-    # Arrange — one OK, one missing; only the missing one should appear.
+    # Arrange — one OK, one missing; only the missing one should appear
+    # under the renamed ``details.binds`` array (was ``unresolvable``).
     (tmp_path / "ok").mkdir()
     spec = _spec_with_binds([f"{tmp_path}/ok:/o", f"{tmp_path}/missing:/m"])
     result = preflight_bind_sources(spec)
     # Act
     body = preflight_failure_response_body(result)
-    listed_binds = [e["bind"] for e in body["details"]["unresolvable"]]
+    listed_sources = [e["source"] for e in body["details"]["binds"]]
     # Assert
-    assert listed_binds == [f"{tmp_path}/missing:/m"]
+    assert listed_sources == [f"{tmp_path}/missing:/m"]
 
 
-def test_failure_body_carries_remediation_hint(tmp_path: Path) -> None:
-    # Arrange
+def test_failure_body_carries_translation_hint(tmp_path: Path) -> None:
+    # Arrange — hint renamed from ``remediation_hint`` to
+    # ``translation_hint`` per clew review (names what the caller
+    # actually needs to DO — translate the path).
     spec = _spec_with_binds([f"{tmp_path}/missing:/x"])
     result = preflight_bind_sources(spec)
     # Act
     body = preflight_failure_response_body(result)
     # Assert
-    assert body["details"]["remediation_hint"] != ""
+    assert body["details"]["translation_hint"] != ""
+
+
+def test_failure_body_entry_has_container_path(tmp_path: Path) -> None:
+    # Arrange — container destination is echoed under the renamed
+    # ``container_path`` key (was ``container_dest``).
+    spec = _spec_with_binds([f"{tmp_path}/missing:/capsule"])
+    result = preflight_bind_sources(spec)
+    # Act
+    body = preflight_failure_response_body(result)
+    # Assert
+    assert body["details"]["binds"][0]["container_path"] == "/capsule"
 
 
 def test_failure_body_each_entry_has_exists_on_host_false(
@@ -276,6 +300,37 @@ def test_failure_body_each_entry_has_exists_on_host_false(
     result = preflight_bind_sources(spec)
     # Act
     body = preflight_failure_response_body(result)
-    flags = [e["exists_on_host"] for e in body["details"]["unresolvable"]]
+    flags = [e["exists_on_host"] for e in body["details"]["binds"]]
     # Assert
     assert flags == [False, False]
+
+
+def test_failure_body_omits_host_normalized_when_no_expansion_happened(
+    tmp_path: Path,
+) -> None:
+    # Arrange — bind source is a plain absolute path, no ~ / $VAR to
+    # expand. ``host_normalized`` should be OMITTED (saves wire bytes
+    # + makes "no normalisation" cleanly distinguishable from
+    # "normalisation produced the same path").
+    spec = _spec_with_binds([f"{tmp_path}/missing:/x"])
+    result = preflight_bind_sources(spec)
+    # Act
+    body = preflight_failure_response_body(result)
+    # Assert
+    assert "host_normalized" not in body["details"]["binds"][0]
+
+
+def test_failure_body_includes_host_normalized_when_expansion_changed_path(
+    tmp_path: Path,
+    env_save_restore,
+) -> None:
+    # Arrange — ``~/missing-dir`` expands to a different path on the
+    # host; the entry MUST include ``host_normalized`` so the operator
+    # sees what was actually stat()ed.
+    env_save_restore.set("HOME", str(tmp_path))
+    spec = _spec_with_binds(["~/missing-dir:/x"])
+    result = preflight_bind_sources(spec)
+    # Act
+    body = preflight_failure_response_body(result)
+    # Assert
+    assert body["details"]["binds"][0]["host_normalized"] == f"{tmp_path}/missing-dir"

--- a/tests/scitex_agent_container/_listen/test_server_inline_spec_failloud.py
+++ b/tests/scitex_agent_container/_listen/test_server_inline_spec_failloud.py
@@ -30,7 +30,15 @@ TOKEN = "test-token-failloud"
 
 @pytest.fixture
 def isolated_env(tmp_path: Path, env_save_restore):
-    """Real env redirect; same shape as the sibling startup_failed tests."""
+    """Real env redirect; same shape as the sibling startup_failed tests.
+
+    Reload-on-teardown is critical (see same-named fixture in
+    ``test_server_startup_failed.py``): ``_runners._session_state``
+    reads the runtime-dir env at import time, so we must reload BOTH
+    before AND after each test or the next test in the worker inherits
+    our tmp_path as the default state root and unrelated assertions
+    like ``test_state_dir_for_default_root_is_under_user_home`` break.
+    """
     home = tmp_path / "home"
     home.mkdir()
     runtime = tmp_path / "runtime"
@@ -41,11 +49,19 @@ def isolated_env(tmp_path: Path, env_save_restore):
     env_save_restore.set("SCITEX_AGENT_CONTAINER_RUNTIME_DIR", str(runtime))
     env_save_restore.set("SCITEX_AGENT_CONTAINER_YAML_DIRS", str(yaml_dir))
     import importlib
+    import os as _os
 
     import scitex_agent_container._runners._session_state as ss
 
     importlib.reload(ss)
-    return tmp_path
+    yield tmp_path
+    # See test_server_startup_failed.py's same-named fixture for the
+    # LIFO-finalizer rationale: pop the env keys ourselves so the
+    # reload picks up the OPERATOR's HOME, not our tmp_path.
+    _os.environ.pop("SCITEX_AGENT_CONTAINER_RUNTIME_DIR", None)
+    _os.environ.pop("SCITEX_AGENT_CONTAINER_YAML_DIRS", None)
+    _os.environ.pop("HOME", None)
+    importlib.reload(ss)
 
 
 @pytest.fixture
@@ -113,20 +129,25 @@ def test_post_400_body_has_kind_bind_unresolvable(
 def test_post_400_body_lists_offending_bind(
     client, auth_headers, isolated_env, tmp_path
 ):
-    # Arrange
+    # Arrange — failure body now uses ``details.binds[]`` (was
+    # ``details.unresolvable[]``) per clew review for the array-form
+    # contract. Entries key the raw spec line under ``source``
+    # (was ``bind``).
     offending = f"{tmp_path}/missing:/x"
     body = _post_body_with_binds("missing-bind-list", [offending])
     # Act
     response = client.post("/agents", json=body, headers=auth_headers)
-    listed = [e["bind"] for e in response.json()["details"]["unresolvable"]]
+    listed = [e["source"] for e in response.json()["details"]["binds"]]
     # Assert
     assert offending in listed
 
 
-def test_post_400_body_includes_remediation_hint(
+def test_post_400_body_includes_translation_hint(
     client, auth_headers, isolated_env, tmp_path
 ):
-    # Arrange
+    # Arrange — hint renamed from ``remediation_hint`` to
+    # ``translation_hint`` per clew review (names what the caller
+    # actually needs to DO — translate the path).
     body = _post_body_with_binds(
         "missing-bind-hint",
         [f"{tmp_path}/missing:/x"],
@@ -134,7 +155,7 @@ def test_post_400_body_includes_remediation_hint(
     # Act
     response = client.post("/agents", json=body, headers=auth_headers)
     # Assert
-    assert "remediation_hint" in response.json()["details"]
+    assert "translation_hint" in response.json()["details"]
 
 
 def test_post_rejection_does_not_materialise_spec(
@@ -201,7 +222,9 @@ def test_post_400_when_one_of_many_binds_missing(
 def test_post_400_only_lists_missing_bind_not_existing_one(
     client, auth_headers, isolated_env, tmp_path
 ):
-    # Arrange
+    # Arrange — array form (``details.binds``) must contain ONLY the
+    # missing entries; resolved binds get filtered out so 49-capsule
+    # callers can act on the failure list directly.
     ok = tmp_path / "ok"
     ok.mkdir()
     body = _post_body_with_binds(
@@ -210,7 +233,7 @@ def test_post_400_only_lists_missing_bind_not_existing_one(
     )
     # Act
     response = client.post("/agents", json=body, headers=auth_headers)
-    listed = [e["bind"] for e in response.json()["details"]["unresolvable"]]
+    listed = [e["source"] for e in response.json()["details"]["binds"]]
     # Assert
     assert f"{ok}:/o" not in listed
 

--- a/tests/scitex_agent_container/_listen/test_server_inline_spec_failloud.py
+++ b/tests/scitex_agent_container/_listen/test_server_inline_spec_failloud.py
@@ -1,0 +1,243 @@
+"""Wired-end-to-end tests for the PR-1 fail-loud bind preflight.
+
+The historical inline-spec POST handler wrote the spec to disk + handed
+off to ``sac agents start <name>`` without checking that the spec's
+``apptainer.binds[*]`` host sources actually existed on the host
+filesystem. The clew-cohort-a-capsule-0201225 case escaped through
+that gap and FATAL'd silently 50 minutes later.
+
+The preflight added in PR-1 catches it AT THE POST. Verifying through
+the real Starlette ``TestClient`` so the wire shape clew launcher reads
+is what we ship.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from starlette.testclient import TestClient
+
+from scitex_agent_container._listen.server import create_app
+
+TOKEN = "test-token-failloud"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_env(tmp_path: Path, env_save_restore):
+    """Real env redirect; same shape as the sibling startup_failed tests."""
+    home = tmp_path / "home"
+    home.mkdir()
+    runtime = tmp_path / "runtime"
+    runtime.mkdir()
+    yaml_dir = home / ".scitex" / "agent-container" / "agents"
+    yaml_dir.mkdir(parents=True, exist_ok=True)
+    env_save_restore.set("HOME", str(home))
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_RUNTIME_DIR", str(runtime))
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_YAML_DIRS", str(yaml_dir))
+    import importlib
+
+    import scitex_agent_container._runners._session_state as ss
+
+    importlib.reload(ss)
+    return tmp_path
+
+
+@pytest.fixture
+def client(isolated_env):
+    app = create_app(token=TOKEN)
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture
+def auth_headers():
+    return {"authorization": f"Bearer {TOKEN}"}
+
+
+def _post_body_with_binds(name: str, binds: list) -> dict:
+    return {
+        "name": name,
+        "spec": {
+            "apiVersion": "scitex-agent-container/v3",
+            "kind": "Agent",
+            "spec": {
+                "workdir": "/tmp",
+                "apptainer": {
+                    "image": "/path/to/sac-base.sif",
+                    "binds": binds,
+                },
+            },
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Fail-loud rejection — happy + failure paths
+# ---------------------------------------------------------------------------
+
+
+def test_post_400_when_bind_source_missing(
+    client, auth_headers, isolated_env, tmp_path
+):
+    # Arrange — bind source path that doesn't exist on the host.
+    body = _post_body_with_binds(
+        "missing-bind",
+        [f"{tmp_path}/nope/missing:/inside:ro"],
+    )
+    # Act
+    response = client.post("/agents", json=body, headers=auth_headers)
+    # Assert
+    assert response.status_code == 400
+
+
+def test_post_400_body_has_kind_bind_unresolvable(
+    client, auth_headers, isolated_env, tmp_path
+):
+    # Arrange
+    body = _post_body_with_binds(
+        "missing-bind-kind",
+        [f"{tmp_path}/missing:/x"],
+    )
+    # Act
+    response = client.post("/agents", json=body, headers=auth_headers)
+    # Assert
+    assert response.json()["kind"] == "bind_unresolvable"
+
+
+def test_post_400_body_lists_offending_bind(
+    client, auth_headers, isolated_env, tmp_path
+):
+    # Arrange
+    offending = f"{tmp_path}/missing:/x"
+    body = _post_body_with_binds("missing-bind-list", [offending])
+    # Act
+    response = client.post("/agents", json=body, headers=auth_headers)
+    listed = [e["bind"] for e in response.json()["details"]["unresolvable"]]
+    # Assert
+    assert offending in listed
+
+
+def test_post_400_body_includes_remediation_hint(
+    client, auth_headers, isolated_env, tmp_path
+):
+    # Arrange
+    body = _post_body_with_binds(
+        "missing-bind-hint",
+        [f"{tmp_path}/missing:/x"],
+    )
+    # Act
+    response = client.post("/agents", json=body, headers=auth_headers)
+    # Assert
+    assert "remediation_hint" in response.json()["details"]
+
+
+def test_post_rejection_does_not_materialise_spec(
+    client, auth_headers, isolated_env, tmp_path
+):
+    # Arrange — rejected spec MUST leave zero artifacts on disk so a
+    # subsequent re-submit with the corrected paths gets a clean slate.
+    body = _post_body_with_binds(
+        "no-side-effect",
+        [f"{tmp_path}/missing:/x"],
+    )
+    # Act
+    client.post("/agents", json=body, headers=auth_headers)
+    spec_path = (
+        tmp_path
+        / "home"
+        / ".scitex"
+        / "agent-container"
+        / "agents"
+        / "no-side-effect"
+        / "spec.yaml"
+    )
+    # Assert
+    assert not spec_path.exists()
+
+
+def test_post_passes_preflight_when_bind_source_exists(
+    client, auth_headers, isolated_env, tmp_path
+):
+    # Arrange — real dir on disk; preflight should be silent (no 400).
+    real = tmp_path / "real-bind-src"
+    real.mkdir()
+    body = _post_body_with_binds(
+        "ok-bind",
+        [f"{real}:/inside"],
+    )
+    # Act
+    response = client.post("/agents", json=body, headers=auth_headers)
+    # Assert — preflight is silent. The subsequent `sac agents start`
+    # may still fail (no real SIF in CI) — we just verify the 400 is
+    # NOT a bind_unresolvable.
+    assert (
+        response.status_code != 400
+        or response.json().get("kind") != "bind_unresolvable"
+    )
+
+
+def test_post_400_when_one_of_many_binds_missing(
+    client, auth_headers, isolated_env, tmp_path
+):
+    # Arrange — one OK + one missing.
+    ok = tmp_path / "ok-source"
+    ok.mkdir()
+    body = _post_body_with_binds(
+        "mixed",
+        [f"{ok}:/o", f"{tmp_path}/missing:/m"],
+    )
+    # Act
+    response = client.post("/agents", json=body, headers=auth_headers)
+    # Assert
+    assert response.status_code == 400
+
+
+def test_post_400_only_lists_missing_bind_not_existing_one(
+    client, auth_headers, isolated_env, tmp_path
+):
+    # Arrange
+    ok = tmp_path / "ok"
+    ok.mkdir()
+    body = _post_body_with_binds(
+        "mixed-filter",
+        [f"{ok}:/o", f"{tmp_path}/missing:/m"],
+    )
+    # Act
+    response = client.post("/agents", json=body, headers=auth_headers)
+    listed = [e["bind"] for e in response.json()["details"]["unresolvable"]]
+    # Assert
+    assert f"{ok}:/o" not in listed
+
+
+# ---------------------------------------------------------------------------
+# Existing 400 kinds keep working
+# ---------------------------------------------------------------------------
+
+
+def test_post_400_for_missing_apiversion(client, auth_headers, isolated_env):
+    # Arrange — pre-existing validation that should keep ``kind=spec_invalid``.
+    body = {
+        "name": "no-api-version",
+        "spec": {"kind": "Agent", "spec": {}},
+    }
+    # Act
+    response = client.post("/agents", json=body, headers=auth_headers)
+    # Assert
+    assert response.status_code == 400
+
+
+def test_post_400_spec_invalid_kind_tag_for_bad_shape(
+    client, auth_headers, isolated_env
+):
+    # Arrange
+    body = {"name": "wrong-kind", "spec": {"apiVersion": "x", "kind": "Y"}}
+    # Act
+    response = client.post("/agents", json=body, headers=auth_headers)
+    # Assert
+    assert response.json().get("kind") == "spec_invalid"

--- a/tests/scitex_agent_container/_listen/test_server_startup_failed.py
+++ b/tests/scitex_agent_container/_listen/test_server_startup_failed.py
@@ -37,7 +37,17 @@ TOKEN = "test-token-startup-failed"
 def isolated_env(tmp_path: Path, env_save_restore):
     """Redirect $HOME + the SAC dir envs so registry / runtime writes
     land in tmp_path. Mirror of test_server.py's fixture so the tests
-    stay isolated from operator's real .scitex tree."""
+    stay isolated from operator's real .scitex tree.
+
+    Reloads ``_session_state`` BOTH on entry (so the module's
+    module-level ``DEFAULT_STATE_ROOT`` re-reads our redirected
+    ``SCITEX_AGENT_CONTAINER_RUNTIME_DIR``) AND on teardown (so the
+    NEXT test in the same worker doesn't inherit our tmp_path as the
+    default state root). The module reads the env at import time, so
+    a one-shot reload before-the-test leaves the post-env-restore path
+    cached and breaks ``_runners/test_claude_session.py``'s assertions
+    on the default home-rooted path.
+    """
     home = tmp_path / "home"
     home.mkdir()
     runtime = tmp_path / "runtime"
@@ -52,7 +62,18 @@ def isolated_env(tmp_path: Path, env_save_restore):
     import scitex_agent_container._runners._session_state as ss
 
     importlib.reload(ss)
-    return tmp_path
+    yield tmp_path
+    # Pytest finalizes inner-first (LIFO): this fixture's teardown runs
+    # BEFORE ``env_save_restore`` restores the env. So we have to pop
+    # the env keys ourselves before reloading — otherwise the reload
+    # re-binds ``DEFAULT_STATE_ROOT`` to our tmp_path again. After we
+    # reload, ``env_save_restore`` will set the env back to its
+    # original (pre-test) values, but the module is already cached
+    # with the right defaults.
+    os.environ.pop("SCITEX_AGENT_CONTAINER_RUNTIME_DIR", None)
+    os.environ.pop("SCITEX_AGENT_CONTAINER_YAML_DIRS", None)
+    os.environ.pop("HOME", None)
+    importlib.reload(ss)
 
 
 @pytest.fixture
@@ -120,27 +141,84 @@ def test_delete_returns_410_when_stillborn_marker_present(
     assert response.status_code == 410
 
 
-def test_delete_410_body_carries_kind_startup_failed(
+def test_delete_410_body_top_level_status_is_startup_failed(
     client, auth_headers, isolated_env
 ):
-    # Arrange
+    # Arrange — per clew review (#287), the lifecycle tag is at the
+    # top level under ``status`` (mirrors the STATUS body's ``status``
+    # field) so a renderer can branch without walking into ``details``.
+    _write_marker_for("delete-status-tag")
+    # Act
+    response = client.delete("/agents/delete-status-tag", headers=auth_headers)
+    # Assert
+    assert response.json()["status"] == "startup_failed"
+
+
+def test_delete_410_top_level_kind_is_failure_classification(
+    client, auth_headers, isolated_env
+):
+    # Arrange — top-level ``kind`` carries the FAILURE CLASSIFICATION
+    # lifted from the marker (e.g. ``apptainer_mount_failed``) so a
+    # clew-launcher error renderer can switch on it without walking
+    # into ``details``. The lifecycle tag (``startup_failed``) lives
+    # under ``status``.
     _write_marker_for("delete-kind-tag")
     # Act
     response = client.delete("/agents/delete-kind-tag", headers=auth_headers)
     # Assert
-    assert response.json()["kind"] == "startup_failed"
+    assert response.json()["kind"] == "apptainer_mount_failed"
 
 
 def test_delete_410_body_includes_details_with_failure_kind(
     client, auth_headers, isolated_env
 ):
-    # Arrange
+    # Arrange — full marker remains echoed under ``details`` so a
+    # caller can hash for dedupe or surface the stderr_tail.
     _write_marker_for("delete-details")
     # Act
     response = client.delete("/agents/delete-details", headers=auth_headers)
     details = response.json()["details"]
     # Assert
     assert details["kind"] == "apptainer_mount_failed"
+
+
+def test_delete_410_body_lifts_phase_to_top_level(client, auth_headers, isolated_env):
+    # Arrange — ``phase`` (e.g. ``container_creation``) is one of the
+    # summary fields clew lifts from the marker so a one-line error
+    # render has the lifecycle phase without a second key-walk.
+    _write_marker_for("delete-phase-lift")
+    # Act
+    response = client.delete("/agents/delete-phase-lift", headers=auth_headers)
+    # Assert
+    assert response.json()["phase"] == "container_creation"
+
+
+def test_delete_410_body_lifts_runtime_dir_to_top_level(
+    client, auth_headers, isolated_env
+):
+    # Arrange — ``runtime_dir`` is the host-absolute path to the
+    # per-instance state dir. Lifting it to the top level means a
+    # human ``cat`` of the marker / peer ``stderr.log`` requires no
+    # path reconstruction.
+    _write_marker_for("delete-runtime-dir")
+    # Act
+    response = client.delete("/agents/delete-runtime-dir", headers=auth_headers)
+    # Assert
+    assert response.json()["runtime_dir"] != ""
+
+
+def test_delete_410_body_carries_see_also_pointing_at_marker_file(
+    client, auth_headers, isolated_env
+):
+    # Arrange — ``see_also`` is the convenience suffix-join of
+    # ``runtime_dir`` + ``STARTUP_FAILED`` so a human / sysadmin gets
+    # a copy-paste-able ``cat`` target without computing it.
+    _write_marker_for("delete-see-also")
+    # Act
+    response = client.delete("/agents/delete-see-also", headers=auth_headers)
+    body = response.json()
+    # Assert
+    assert body["see_also"].endswith("/STARTUP_FAILED")
 
 
 def test_delete_returns_404_when_no_marker_and_no_pid(

--- a/tests/scitex_agent_container/_listen/test_server_startup_failed.py
+++ b/tests/scitex_agent_container/_listen/test_server_startup_failed.py
@@ -1,0 +1,250 @@
+"""Wired-end-to-end tests for the PR-1 STARTUP_FAILED surface.
+
+Covers the HTTP wire shape that the clew launcher (and future SAC-from-SAC
+clients) consumes:
+
+  * ``DELETE /agents/<name>`` returns **410 Gone** with the structured
+    failure body when the runtime dir carries a ``STARTUP_FAILED`` marker
+    — distinguishing "stillborn" (existed, has been removed) from the
+    "never existed" 404 case.
+  * ``GET /agents/<name>/status`` echoes the same marker under
+    ``startup_failed`` so callers don't need a second round trip.
+
+Uses the real Starlette ``TestClient`` against ``create_app`` + the real
+``state_dir_for`` resolver — no mocks, no fakes.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+from starlette.testclient import TestClient
+
+from scitex_agent_container._lifecycle._startup_failed import write_marker
+from scitex_agent_container._listen.server import create_app
+
+TOKEN = "test-token-startup-failed"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — mirror the shape used by tests/.../test_server.py
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_env(tmp_path: Path, env_save_restore):
+    """Redirect $HOME + the SAC dir envs so registry / runtime writes
+    land in tmp_path. Mirror of test_server.py's fixture so the tests
+    stay isolated from operator's real .scitex tree."""
+    home = tmp_path / "home"
+    home.mkdir()
+    runtime = tmp_path / "runtime"
+    runtime.mkdir()
+    yaml_dir = home / ".scitex" / "agent-container" / "agents"
+    yaml_dir.mkdir(parents=True, exist_ok=True)
+    env_save_restore.set("HOME", str(home))
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_RUNTIME_DIR", str(runtime))
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_YAML_DIRS", str(yaml_dir))
+    import importlib
+
+    import scitex_agent_container._runners._session_state as ss
+
+    importlib.reload(ss)
+    return tmp_path
+
+
+@pytest.fixture
+def client(isolated_env):
+    app = create_app(token=TOKEN)
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture
+def auth_headers():
+    return {"authorization": f"Bearer {TOKEN}"}
+
+
+def _write_spec(home: Path, name: str) -> Path:
+    """Minimal v3 spec.yaml that ``load_config`` accepts."""
+    import yaml
+
+    spec_dir = home / ".scitex" / "agent-container" / "agents" / name
+    spec_dir.mkdir(parents=True, exist_ok=True)
+    spec = {
+        "apiVersion": "scitex-agent-container/v3",
+        "kind": "Agent",
+        "spec": {
+            "claude": {"model": "claude-sonnet-4-5"},
+            "workdir": "/tmp",
+        },
+    }
+    spec_path = spec_dir / "spec.yaml"
+    spec_path.write_text(yaml.safe_dump(spec))
+    return spec_path
+
+
+def _write_marker_for(name: str) -> Path:
+    """Write a STARTUP_FAILED marker into ``state_dir_for(name)``."""
+    import importlib
+
+    import scitex_agent_container._runners._session_state as ss
+
+    importlib.reload(ss)
+    runtime_dir = ss.state_dir_for(name)
+    return write_marker(
+        runtime_dir,
+        started_at="2026-06-03T01:00:00Z",
+        phase="container_creation",
+        exit_code=255,
+        stdout="",
+        stderr="mount source /work/x doesn't exist",
+    )
+
+
+# ---------------------------------------------------------------------------
+# DELETE — 410 Gone when stillborn marker present
+# ---------------------------------------------------------------------------
+
+
+def test_delete_returns_410_when_stillborn_marker_present(
+    client, auth_headers, isolated_env
+):
+    # Arrange — marker on disk, no pid file → stillborn.
+    _write_marker_for("delete-stillborn")
+    # Act
+    response = client.delete("/agents/delete-stillborn", headers=auth_headers)
+    # Assert
+    assert response.status_code == 410
+
+
+def test_delete_410_body_carries_kind_startup_failed(
+    client, auth_headers, isolated_env
+):
+    # Arrange
+    _write_marker_for("delete-kind-tag")
+    # Act
+    response = client.delete("/agents/delete-kind-tag", headers=auth_headers)
+    # Assert
+    assert response.json()["kind"] == "startup_failed"
+
+
+def test_delete_410_body_includes_details_with_failure_kind(
+    client, auth_headers, isolated_env
+):
+    # Arrange
+    _write_marker_for("delete-details")
+    # Act
+    response = client.delete("/agents/delete-details", headers=auth_headers)
+    details = response.json()["details"]
+    # Assert
+    assert details["kind"] == "apptainer_mount_failed"
+
+
+def test_delete_returns_404_when_no_marker_and_no_pid(
+    client, auth_headers, isolated_env
+):
+    # Arrange — agent has never existed; no marker, no pid.
+    # Act
+    response = client.delete("/agents/never-existed", headers=auth_headers)
+    # Assert
+    assert response.status_code == 404
+
+
+def test_delete_404_distinct_kind_from_410(client, auth_headers, isolated_env):
+    # Arrange — never-existed must NOT have the startup_failed kind.
+    # Act
+    response = client.delete("/agents/genuinely-absent", headers=auth_headers)
+    body = response.json()
+    # Assert
+    assert body.get("kind") != "startup_failed"
+
+
+# ---------------------------------------------------------------------------
+# STATUS — startup_failed echo
+# ---------------------------------------------------------------------------
+
+
+def test_status_status_field_says_startup_failed_when_marker_present(
+    client, auth_headers, isolated_env
+):
+    # Arrange — spec + marker on disk (no live session).
+    _write_spec(Path(os.environ["HOME"]), "status-stillborn")
+    _write_marker_for("status-stillborn")
+    # Act
+    response = client.get("/agents/status-stillborn/status", headers=auth_headers)
+    # Assert
+    assert response.json()["status"] == "startup_failed"
+
+
+def test_status_echoes_marker_under_startup_failed_key(
+    client, auth_headers, isolated_env
+):
+    # Arrange
+    _write_spec(Path(os.environ["HOME"]), "status-echo")
+    _write_marker_for("status-echo")
+    # Act
+    response = client.get("/agents/status-echo/status", headers=auth_headers)
+    # Assert
+    assert "startup_failed" in response.json()
+
+
+def test_status_marker_carries_failure_kind(client, auth_headers, isolated_env):
+    # Arrange
+    _write_spec(Path(os.environ["HOME"]), "status-kind")
+    _write_marker_for("status-kind")
+    # Act
+    response = client.get("/agents/status-kind/status", headers=auth_headers)
+    # Assert
+    assert response.json()["startup_failed"]["kind"] == "apptainer_mount_failed"
+
+
+def test_status_does_not_set_status_field_when_no_marker(
+    client, auth_headers, isolated_env
+):
+    # Arrange — spec only, no marker.
+    _write_spec(Path(os.environ["HOME"]), "status-healthy")
+    # Act
+    response = client.get("/agents/status-healthy/status", headers=auth_headers)
+    # Assert — body must not advertise startup_failed when no marker.
+    assert "startup_failed" not in response.json()
+
+
+# ---------------------------------------------------------------------------
+# DELETE preserves 200 OK path when a real pid exists
+# ---------------------------------------------------------------------------
+
+
+def test_delete_returns_200_when_pid_present(client, auth_headers, isolated_env):
+    # Arrange — a real subprocess to SIGTERM.
+    import subprocess
+    import sys
+    import time
+
+    proc = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+    try:
+        import importlib
+
+        import scitex_agent_container._runners._session_state as ss
+
+        importlib.reload(ss)
+        sd = ss.state_dir_for("delete-live")
+        sd.mkdir(parents=True, exist_ok=True)
+        (sd / "pid").write_text(str(proc.pid))
+        # Act
+        response = client.delete("/agents/delete-live", headers=auth_headers)
+        # Assert
+        assert response.status_code == 200
+    finally:
+        # stx-allow: fallback (reason: best-effort process cleanup;
+        # if the test path already killed it, kill() raises ProcessLookup)
+        try:
+            proc.terminate()
+            proc.wait(timeout=5)
+        except (
+            OSError,
+            subprocess.TimeoutExpired,
+        ):  # stx-allow: fallback (reason: see inline comment)
+            pass

--- a/tests/scitex_agent_container/_listen/test_server_startup_failed.py
+++ b/tests/scitex_agent_container/_listen/test_server_startup_failed.py
@@ -221,7 +221,6 @@ def test_delete_returns_200_when_pid_present(client, auth_headers, isolated_env)
     # Arrange — a real subprocess to SIGTERM.
     import subprocess
     import sys
-    import time
 
     proc = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
     try:


### PR DESCRIPTION
## Summary

**PR-1 of the SAC-from-SAC hardening series.** Motivated by the clew `cohort-A/capsule-0201225` incident on 2026-06-02: the inline-spec `POST /agents` handler accepted a spec whose `apptainer.binds` carried parent-SIF-view paths (`/work/...`) the host couldn't see, the subprocess to `sac agents start` exited 0 after handoff, but apptainer FATAL'd minutes later on the missing mount source. The operator spent 50 minutes triaging three differently-shaped "session never started" symptoms because the failure had no structured surface.

This PR closes the gap with two coordinated changes — a **pre-flight** that catches the bad spec **before** materialisation, and a **lifecycle marker** that turns a stillborn agent into an observable resource.

## What's in

### PART 1 — Fail-loud bind preflight
- NEW `_listen/_inline_spec_preflight.py` — structured detector. Walks `spec.apptainer.binds`, host-`stat()`s every source after `~`/`$VAR` expansion, returns `PreflightResult{ok, checks, unresolvable}`. Accepts string + dict bind forms. Symlinks followed; broken links count as missing.
- MOD `_listen/_inline_spec.py` — preflight runs **before** spec write. On failure: HTTP 400 with structured body. Spec is NOT materialised on rejection.
- Added stable `kind` field to existing 400/409 responses (`spec_invalid`, `already_exists`) so every wire-shape failure now branches by `kind`, not prose.

### PART 2 — STARTUP_FAILED lifecycle
- NEW `_lifecycle/_startup_failed.py` — versioned JSON marker at `runtime_dir/STARTUP_FAILED`. Atomic write (`.tmp` + `os.replace`). Apptainer FATAL classifier (`apptainer_mount_failed` / `sif_invalid` / `disk_full` / `container_creation_unknown`) stamps `kind` + `remediation_hint`. stdout/stderr tail-clipped to 8 KiB (FATAL line survives). Marker carries its own host-absolute `runtime_dir` so consumers can `cat` peer `stdout.log` / `stderr.log` without recomputing paths.
- MOD `_listen/_agent_exec.py` — on `sac agents start` non-zero exit, write marker into `state_dir_for(name)`. Best-effort: marker-write failure is swallowed so it never shadows the spawn failure.
- MOD `_listen/server.py` — DELETE returns **410 Gone** with a structured **flat summary + `see_also` pointer + nested `details`** body when marker present; falls back to 404 only when agent never existed. STATUS echoes marker under `startup_failed` key + sets `status="startup_failed"`.

## Wire-shape contract — POST-clew-review (commit cd4c7e2)

Clew's review (msg `8306752c...`) drove five key renames + restructure. The final shape consumed by the clew launcher is:

```
POST /agents 400 (bind_unresolvable):
  {
    "error": "bind source(s) not visible from host",
    "kind":  "bind_unresolvable",
    "details": {
      "binds": [                            # array form (was "unresolvable")
        {
          "source":          "/work/x:/x:ro",  # was "bind"
          "container_path":  "/x",             # was "container_dest"
          "exists_on_host":  false,
          "host_normalized": "/home/y/x"       # ONLY when ~/$VAR expansion changed source
        }
      ],
      "translation_hint": "..."             # was "remediation_hint"
    }
  }

POST /agents 400 (spec_invalid):     {"error", "kind": "spec_invalid"}
POST /agents 409 (already_exists):   {"error", "kind": "already_exists"}

DELETE /agents/<name> 410:
  {
    "name":             "<name>",
    "status":           "startup_failed",         # lifecycle tag (mirrors STATUS)
    "kind":             "<failure_classification>", # LIFTED from marker
    "phase":            "container_creation",     # LIFTED from marker
    "failed_at":        "<ISO>",                  # LIFTED from marker
    "runtime_dir":      "<host abs path>",        # LIFTED from marker
    "remediation_hint": "<...>",                  # LIFTED from marker
    "see_also":         "<runtime_dir>/STARTUP_FAILED",
    "details":          <full marker payload>
  }

DELETE /agents/<name> 404: {"error": "no pid file"}  (never existed)

GET /agents/<name>/status (stillborn):
  {..., "status": "startup_failed", "startup_failed": <marker>}
```

### kind taxonomy (PR-1 freeze)

- `POST /agents` 400/409: `bind_unresolvable` | `spec_invalid` | `already_exists`
- `STARTUP_FAILED.kind`: `apptainer_mount_failed` | `sif_invalid` | `disk_full` | `container_creation_unknown`
- PR-3 adds: `acl_deny` (POST/DELETE/send/tail), `transport` (client-side detect)

`acl_deny` is punted to PR-3 (PR-1's POST has no ACL gate yet, so adding the kind here would be dead code with no test pin).

## Test coverage (real I/O via Starlette TestClient, no mocks; AAA + one-assert)

- `tests/.../_listen/test__inline_spec_preflight.py` — **24 tests** (happy / expansion / failure / defensive parsing / wire shape incl. host_normalized omit-and-include cases, container_path, translation_hint)
- `tests/.../_lifecycle/test__startup_failed.py` — **23 tests** (classify / write_marker / read/is_stillborn / runtime_dir field)
- `tests/.../_listen/test_server_inline_spec_failloud.py` — **10 tests** (wired POST /agents fail-loud + non-regression on existing 400 kinds)
- `tests/.../_listen/test_server_startup_failed.py` — **15 tests** (wired DELETE 410 top-level status/kind/phase/runtime_dir/see_also lifts + STATUS surface + non-regression on 200 OK pid path)

**Total: 72 new tests.** All 672 `_listen + _lifecycle + _runners/test_claude_session` tests pass locally. PA-306 (no-mocks) + PA-307 (AAA + one-assert) clean for this PR's diff.

## Series sequencing

This is PR-1 of three:
- **PR-1** (this): fail-loud bind preflight + STARTUP_FAILED lifecycle
- PR-2: SAC-side bind translate (`/work/...` → caller host-workdir)
- PR-3: `sac agents spawn-from-here` + in-SIF auto-fallback for `tail/status/send/delete` + lineage-scoped ACL + `acl_deny` kind

Refs: SAC-from-SAC PR series. Operator-driven via clew. Wire-shape signed off by clew (`f36cc02f...` thread).