### PR TITLE
feat(SAC-from-SAC PR-2): SAC-side bind translate for inline-spec POST

### DIFF
--- a/src/scitex_agent_container/_listen/_agent_exec.py
+++ b/src/scitex_agent_container/_listen/_agent_exec.py
@@ -290,8 +290,16 @@ async def agents_start(request: Request) -> JSONResponse:
 
     inline_spec = body.get("spec")
     if inline_spec is not None:
+        # PR-2 — pass ``caller`` through so the bind translate can
+        # look up the parent agent's host-side bind map and rewrite
+        # in-SIF ``/work/...`` sources before the PR-1 preflight
+        # runs. Caller absent → translate disabled, preflight
+        # enforces directly (the operator/admin path).
         err = materialize_inline_spec(
-            name, inline_spec, overwrite=bool(body.get("overwrite"))
+            name,
+            inline_spec,
+            overwrite=bool(body.get("overwrite")),
+            caller=caller,
         )
         if err is not None:
             return err

--- a/src/scitex_agent_container/_listen/_inline_spec.py
+++ b/src/scitex_agent_container/_listen/_inline_spec.py
@@ -14,8 +14,50 @@ from pathlib import Path
 from starlette.responses import JSONResponse
 
 
+def _resolve_parent_binds(caller: str) -> list[str] | None:
+    """Return the parent agent's persisted ``apptainer.binds`` or ``None``.
+
+    Injected into :func:`translate_binds_in_spec` so the translate
+    module stays decoupled from the on-host config-resolution chain.
+    A return of ``None`` (caller unknown, spec unreadable, config
+    invalid) lands as ``skipped_reason="caller_unknown"`` and the
+    spec is forwarded to PR-1 unchanged.
+
+    The resolution goes through ``resolve_config`` → ``load_config``
+    (the same path :func:`agent_status` uses), so any spec the host
+    can introspect via ``GET /agents/<name>/status`` is the same
+    spec PR-2 reads here. Imports are local so a unit test that
+    patches ``resolve_config`` only needs to wire the lookup, not
+    the heavy parser chain.
+    """
+    # stx-allow: fallback (reason: any failure in the resolve / load /
+    # parse chain must collapse to no-op so PR-1 stays the SoT; the
+    # translate module itself also catches but we centralize the
+    # "lookup is allowed to fail silently" rule HERE so the callable
+    # passed to the translate module is contract-clean)
+    try:
+        from ..config import load_config
+        from ..config._resolve import resolve_config
+
+        spec_path = resolve_config(caller)
+        cfg = load_config(spec_path)
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        return None
+    apt = getattr(cfg, "apptainer", None)
+    if apt is None:
+        return None
+    binds = getattr(apt, "binds", None)
+    if not isinstance(binds, list):
+        return None
+    return [b for b in binds if isinstance(b, str)]
+
+
 def materialize_inline_spec(
-    name: str, spec: object, *, overwrite: bool
+    name: str,
+    spec: object,
+    *,
+    overwrite: bool,
+    caller: str | None = None,
 ) -> JSONResponse | None:
     """Write ``spec`` to ``~/.scitex/agent-container/agents/<name>/spec.yaml``.
 
@@ -25,13 +67,31 @@ def materialize_inline_spec(
 
       1. ``spec`` is a dict + v3 apiVersion + Agent kind (basic shape).
       2. ``kind="spec_invalid"`` for any of (1) — wire-stable.
-      3. **bind preflight**: every ``spec.apptainer.binds[*]`` host
+      3. **PR-2 bind translate (opt-in convenience)**. When ``caller``
+         is a known SAC-managed agent, the parent's host-side bind
+         map is used to rewrite any of the child spec's bind sources
+         that name an in-SIF prefix (``/work/...``) the parent's
+         container view exposes. Read-only, best-effort: any failure
+         to resolve the parent collapses to no-op and PR-1 catches
+         whatever leaked through.
+      4. **bind preflight**: every ``spec.apptainer.binds[*]`` host
          source is ``stat()``-checked. Any missing source aborts with
-         HTTP 400 + ``kind="bind_unresolvable"`` (PR-1 fail-loud). This
-         catches the SAC-from-SAC silent FATAL where the spec carries
-         in-SIF ``/work/...`` paths that the host can't see.
-      4. ``kind="already_exists"`` for the overwrite-guard collision.
-      5. ``kind="spec_invalid"`` for write failure (disk full, RO fs).
+         HTTP 400 + ``kind="bind_unresolvable"`` (PR-1 fail-loud).
+         This is the SoT for "is this bind safe?" — PR-2 just
+         pre-cleans the common SAC-from-SAC case.
+      5. ``kind="already_exists"`` for the overwrite-guard collision.
+      6. ``kind="spec_invalid"`` for write failure (disk full, RO fs).
+
+    Args:
+        name: target agent name.
+        spec: the inline v3 Agent spec dict from the POST body.
+        overwrite: 409 if a spec already exists at the target path
+            unless this is ``True``.
+        caller: PR-2 — the spawning node's name. ``None`` (or an
+            unknown caller) disables bind-translate and the spec is
+            forwarded to the preflight unchanged. The same caller
+            field drives the WI-2 spawn gate one level up in the
+            request handler.
     """
     import yaml
 
@@ -61,6 +121,20 @@ def materialize_inline_spec(
             },
             status_code=400,
         )
+
+    # PR-2 — bind translate. Run BEFORE the PR-1 preflight so the
+    # common SAC-from-SAC case (parent launcher posts a child spec
+    # whose bind sources are the parent's in-SIF view, e.g.
+    # ``/work/data/X``) no longer requires the launcher to
+    # pre-translate paths. Read-only, best-effort: any failure to
+    # resolve the caller's parent record collapses to a no-op and
+    # PR-1 catches the leak. The translated spec is the one PR-1
+    # validates and (on success) the handler persists to disk.
+    from ._inline_spec_bind_translate import translate_binds_in_spec
+
+    spec = translate_binds_in_spec(
+        spec, caller, parent_binds_lookup=_resolve_parent_binds
+    )[0]
 
     # PR-1 — fail-loud bind-source preflight. Done BEFORE writing the
     # spec to disk so a rejected spawn leaves zero artifacts (no spec

--- a/src/scitex_agent_container/_listen/_inline_spec_bind_translate.py
+++ b/src/scitex_agent_container/_listen/_inline_spec_bind_translate.py
@@ -1,0 +1,425 @@
+"""SAC-side bind translate for SAC-from-SAC inline-spec spawns.
+
+PR-2 of the SAC-from-SAC hardening series. PR-1 (merged b9d97ff)
+installed an always-on host-stat preflight on ``spec.apptainer.binds``
+that hard-rejects any bind whose source isn't host-visible. That
+preflight is the safety valve. THIS module is the **opt-in
+convenience** that makes the common SAC-from-SAC case Just Work:
+when a parent agent spawns a child via ``POST /agents`` and the
+child spec carries verbatim in-SIF paths (e.g. ``/work/data/X``
+which only resolves inside the parent's container view), the host
+rewrites those sources to the parent's host-side equivalent BEFORE
+the preflight runs. PR-1 still fires on any bind PR-2 can't
+translate — there is no silent path back to the FATAL.
+
+The motivating case is the same one PR-1 surfaces: the clew
+``capsule-0201225`` incident on 2026-06-02. The clew launcher,
+running inside its own SIF where ``/work`` was bound from
+``$HOME/proj/paper-scitex-clew``, POSTed a child spec to SAC with
+binds like ``/work/data/cohort_a_corebench/.../capsule-0201225``.
+Inside the launcher's view that path exists; on the SAC host it
+does not. PR-1 caught it (after this PR ships, anyway) — PR-2
+*translates* it: the launcher's parent record carries
+``$HOME/proj/paper-scitex-clew:/work``, so SAC reverse-maps
+``/work`` → ``$HOME/proj/paper-scitex-clew`` and rewrites the
+child's source to
+``$HOME/proj/paper-scitex-clew/data/cohort_a_corebench/.../capsule-0201225``.
+That stat()s. Spawn succeeds.
+
+Design constraints (kept tight so PR-1 stays the SoT for "is this
+bind safe?"):
+
+  * **Read-only.** This module only computes; it never writes
+    state, never logs to the runtime dir, never touches the disk.
+    The translated spec dict is returned; the call site replaces
+    the in-memory spec before passing it to PR-1.
+  * **Best-effort.** Any failure to look up the parent (caller is
+    unknown / has no apptainer.binds / config load raises) collapses
+    to no-op. PR-1 then catches whatever leaked through.
+  * **Caller-shape preserving.** A bind submitted as a string comes
+    back as a string; a bind submitted as a ``{src, dst, mode}``
+    dict comes back as a dict (with ``src`` rewritten). Reason: the
+    inline-spec POST handler writes the raw input verbatim to disk
+    via ``yaml.safe_dump``; preserving the operator's chosen form
+    keeps the on-disk YAML legible.
+  * **Longest-prefix match.** If the parent has multiple binds whose
+    container destinations are nested (e.g. ``/work`` and
+    ``/work/data``), the more specific one wins. This matches how
+    apptainer itself resolves a path inside the container.
+  * **Boundary-safe prefix.** ``/work`` matches ``/work/X`` and the
+    bare path ``/work``; it does NOT match ``/workdir/X``. A naive
+    ``str.startswith`` would silently mangle ``/workdir`` paths.
+
+Bind syntax accepted matches the parser at
+``config/_parsers/_apptainer``: string ``host:container[:mode]``
+with ``~``/``$VAR`` expansion already applied (the inline-spec
+handler reads the raw spec but the parent's persisted spec has
+expansion done at load), and the dict form ``{src, dst, mode}``.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Result shape
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class BindTranslation:
+    """Per-bind translation result.
+
+    * ``original`` — the bind exactly as submitted by the caller
+      (string or dict). Echoed verbatim so tests + the lineage
+      audit can see the input shape.
+    * ``translated`` — the bind after translation, in the SAME
+      shape as ``original``. Equal to ``original`` when no
+      translation applied.
+    * ``was_changed`` — ``True`` iff the host source was rewritten.
+      Cheap predicate for tests that want to count translations
+      without diffing.
+    * ``matched_prefix`` — the container-side prefix the host
+      source matched against (e.g. ``"/work"``), empty when no
+      rule fired.
+    """
+
+    original: Any
+    translated: Any
+    was_changed: bool
+    matched_prefix: str
+
+
+@dataclass(frozen=True)
+class TranslateResult:
+    """Aggregated translate outcome.
+
+    * ``binds`` — per-bind result in input order.
+    * ``caller_known`` — ``True`` iff the parent's spec was
+      resolved + loaded. When ``False`` the translate was a no-op
+      across the board (PR-1 then enforces correctness).
+    * ``skipped_reason`` — short tag explaining a no-op. Values:
+      ``""`` (translation actually ran), ``"no_caller"`` (POST
+      body carried no ``caller`` field), ``"caller_unknown"``
+      (resolve_config raised), ``"no_parent_binds"`` (caller's
+      spec has empty ``apptainer.binds``).
+    """
+
+    binds: tuple[BindTranslation, ...]
+    caller_known: bool
+    skipped_reason: str
+
+
+# ---------------------------------------------------------------------------
+# Bind parsing / formatting
+# ---------------------------------------------------------------------------
+
+
+def _parse_bind(bind: Any) -> tuple[str, str, str, str] | None:
+    """Return ``(host_src, container_dst, mode, shape)`` or ``None``.
+
+    ``shape`` is the literal string ``"str"`` or ``"dict"`` so the
+    formatter can re-emit in the caller's chosen form.
+
+    Accepts:
+      * canonical string ``host:container[:mode]``
+      * dict form ``{src, dst, mode?}`` (the alt keys ``source`` /
+        ``destination`` / ``target`` from the preflight module are
+        NOT supported here — parent specs always normalize to
+        ``{src, dst, mode}`` at load time, and the inline-spec
+        POST body is expected to follow the canonical YAML schema)
+    """
+    if isinstance(bind, dict):
+        src = bind.get("src")
+        dst = bind.get("dst")
+        mode = bind.get("mode", "")
+        if not isinstance(src, str) or not isinstance(dst, str):
+            return None
+        return src, dst, str(mode or ""), "dict"
+    if not isinstance(bind, str):
+        return None
+    parts = bind.split(":", 2)
+    if len(parts) < 2:
+        return None
+    host_src = parts[0]
+    container_dst = parts[1]
+    mode = parts[2] if len(parts) == 3 else ""
+    return host_src, container_dst, mode, "str"
+
+
+def _format_bind(
+    host_src: str, container_dst: str, mode: str, shape: str, original: Any
+) -> Any:
+    """Re-emit a bind in the caller's chosen shape.
+
+    For dict form, mutate a shallow copy of ``original`` so any
+    extra keys (e.g. an annotation field) survive. For string form,
+    re-stringify ``host:container[:mode]``.
+    """
+    if shape == "dict":
+        out = dict(original)  # type: ignore[arg-type]
+        out["src"] = host_src
+        out["dst"] = container_dst
+        if mode:
+            out["mode"] = mode
+        elif "mode" in out and not mode:
+            # Caller submitted with empty mode; preserve absence
+            # rather than re-injecting "".
+            del out["mode"]
+        return out
+    if mode:
+        return f"{host_src}:{container_dst}:{mode}"
+    return f"{host_src}:{container_dst}"
+
+
+# ---------------------------------------------------------------------------
+# Reverse map from parent's binds
+# ---------------------------------------------------------------------------
+
+
+def _build_reverse_map(parent_binds: list[str]) -> list[tuple[str, str]]:
+    """Return ``[(container_dst, host_src), ...]`` longest-prefix first.
+
+    A list (not dict) is returned because longest-prefix order is
+    semantically meaningful — when a child bind source matches
+    multiple parent container destinations (nested binds), the
+    deeper one wins. The list is sorted descending by destination
+    length so :func:`_translate_one` can short-circuit on the first
+    matching prefix.
+
+    Parent binds with no ``:container`` separator are silently
+    dropped (defensive — the parent's spec parser would have
+    rejected them, but a hand-edited disk YAML could slip through).
+    """
+    rules: list[tuple[str, str]] = []
+    for bind in parent_binds:
+        parsed = _parse_bind(bind)
+        if parsed is None:
+            continue
+        host_src, container_dst, _mode, _shape = parsed
+        if not container_dst or not host_src:
+            continue
+        rules.append((container_dst, host_src))
+    rules.sort(key=lambda x: len(x[0]), reverse=True)
+    return rules
+
+
+def _is_prefix_match(host_src: str, prefix: str) -> bool:
+    """``True`` iff ``prefix`` is a path-component prefix of ``host_src``.
+
+    Boundary-safe: ``/work`` matches ``/work`` and ``/work/X`` but
+    NOT ``/workdir`` or ``/work-tmp``. A naive ``startswith`` would
+    silently mangle the latter.
+    """
+    if host_src == prefix:
+        return True
+    if not prefix.endswith("/"):
+        return host_src.startswith(prefix + "/")
+    return host_src.startswith(prefix)
+
+
+def _translate_one(host_src: str, rules: list[tuple[str, str]]) -> tuple[str, str]:
+    """Return ``(new_host_src, matched_prefix)``.
+
+    ``matched_prefix`` is the empty string when no rule applied
+    (= no translation; ``new_host_src == host_src``). When a rule
+    applies, the prefix is replaced verbatim — trailing components
+    are preserved exactly so ``Path(new_host_src).resolve()`` is
+    unsurprising.
+    """
+    for container_dst, parent_host_src in rules:
+        if _is_prefix_match(host_src, container_dst):
+            tail = host_src[len(container_dst) :]
+            # Strip a single leading "/" from tail so the join uses
+            # exactly one slash; both halves are already absolute
+            # by construction.
+            new_src = parent_host_src.rstrip("/") + tail
+            return new_src, container_dst
+    return host_src, ""
+
+
+# ---------------------------------------------------------------------------
+# Public translate entry point
+# ---------------------------------------------------------------------------
+
+
+def translate_binds_in_spec(
+    spec: dict,
+    caller: str | None,
+    *,
+    parent_binds_lookup,
+) -> tuple[dict, TranslateResult]:
+    """Rewrite in-SIF bind sources in ``spec`` using parent's host map.
+
+    Args:
+        spec: the v3 Agent spec dict the inline-spec POST handler
+            received. NOT mutated; a shallow + nested-shallow copy
+            of the relevant slice is returned.
+        caller: the POST body's ``caller`` field (the parent agent's
+            name). ``None`` triggers a no-op pass-through (admin /
+            operator-submitted spec — let PR-1 enforce directly).
+        parent_binds_lookup: ``Callable[[str], list[str] | None]``
+            that returns the parent's persisted ``apptainer.binds``
+            (canonical string list) given the parent's name, or
+            ``None`` when the parent isn't a known SAC-managed
+            agent. Injected (not imported) so tests can wire a fake
+            lookup without monkeying the global ``resolve_config``
+            path.
+
+    Returns:
+        ``(translated_spec, result)``. ``translated_spec`` is the
+        spec with ``spec.apptainer.binds[*].src`` rewritten where
+        applicable; on no-op it is shallow-equal to the input.
+        ``result`` enumerates per-bind outcomes so the call site
+        can log / audit / emit observability.
+
+    The function never raises. Defensive: any unexpected shape
+    (spec not a dict, no apptainer, no binds, lookup raises)
+    collapses to ``skipped_reason``-tagged no-op.
+    """
+    binds = _extract_binds(spec)
+    if caller is None:
+        return spec, TranslateResult(
+            binds=tuple(_passthrough(b) for b in binds),
+            caller_known=False,
+            skipped_reason="no_caller",
+        )
+    parent_binds = _safe_lookup(parent_binds_lookup, caller)
+    if parent_binds is None:
+        return spec, TranslateResult(
+            binds=tuple(_passthrough(b) for b in binds),
+            caller_known=False,
+            skipped_reason="caller_unknown",
+        )
+    if not parent_binds:
+        return spec, TranslateResult(
+            binds=tuple(_passthrough(b) for b in binds),
+            caller_known=True,
+            skipped_reason="no_parent_binds",
+        )
+    rules = _build_reverse_map(parent_binds)
+    if not rules:
+        # Parent had binds but none were parseable; fail soft.
+        return spec, TranslateResult(
+            binds=tuple(_passthrough(b) for b in binds),
+            caller_known=True,
+            skipped_reason="no_parent_binds",
+        )
+    if not binds:
+        # Child spec has no apptainer.binds at all (e.g. a docker
+        # runtime or a workdir-only spec). Return the input
+        # unchanged — must NOT inject an empty apptainer block
+        # the child never declared.
+        return spec, TranslateResult(binds=(), caller_known=True, skipped_reason="")
+    new_binds: list[Any] = []
+    outcomes: list[BindTranslation] = []
+    for raw in binds:
+        parsed = _parse_bind(raw)
+        if parsed is None:
+            new_binds.append(raw)
+            outcomes.append(_passthrough(raw))
+            continue
+        host_src, container_dst, mode, shape = parsed
+        # Expand ~/$VAR on the host source BEFORE matching the
+        # reverse map — the parent's container destinations are
+        # never expanded (apptainer rejects ~ / $VAR on the dst
+        # side), so the comparison happens in fully-resolved form.
+        expanded_host_src = os.path.expanduser(os.path.expandvars(host_src))
+        new_host_src, matched = _translate_one(expanded_host_src, rules)
+        if matched:
+            translated = _format_bind(new_host_src, container_dst, mode, shape, raw)
+            new_binds.append(translated)
+            outcomes.append(
+                BindTranslation(
+                    original=raw,
+                    translated=translated,
+                    was_changed=True,
+                    matched_prefix=matched,
+                )
+            )
+        else:
+            new_binds.append(raw)
+            outcomes.append(_passthrough(raw))
+    new_spec = _swap_binds(spec, new_binds)
+    return new_spec, TranslateResult(
+        binds=tuple(outcomes),
+        caller_known=True,
+        skipped_reason="",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+def _extract_binds(spec: dict) -> list[Any]:
+    """Best-effort ``spec.spec.apptainer.binds`` extractor.
+
+    Mirrors ``_inline_spec_preflight._iter_binds``. Defensive: any
+    unexpected shape collapses to empty list so the translate is
+    a no-op rather than a crash.
+    """
+    if not isinstance(spec, dict):
+        return []
+    body = spec.get("spec")
+    if not isinstance(body, dict):
+        return []
+    apt = body.get("apptainer")
+    if not isinstance(apt, dict):
+        return []
+    binds = apt.get("binds")
+    if not isinstance(binds, list):
+        return []
+    return binds
+
+
+def _swap_binds(spec: dict, new_binds: list[Any]) -> dict:
+    """Return a shallow-copy of ``spec`` with ``apptainer.binds`` replaced.
+
+    Only the path ``spec → spec → apptainer → binds`` is copied;
+    siblings are shared by reference (the inline-spec handler writes
+    the result via ``yaml.safe_dump`` immediately, so a sibling
+    aliasing the original is harmless and avoids a deep-copy spike
+    on large specs).
+    """
+    out_top = dict(spec)
+    body = dict(out_top.get("spec") or {})
+    apt = dict(body.get("apptainer") or {})
+    apt["binds"] = new_binds
+    body["apptainer"] = apt
+    out_top["spec"] = body
+    return out_top
+
+
+def _passthrough(raw: Any) -> BindTranslation:
+    """Build a no-change ``BindTranslation`` for a single bind."""
+    return BindTranslation(
+        original=raw, translated=raw, was_changed=False, matched_prefix=""
+    )
+
+
+def _safe_lookup(lookup, caller: str) -> list[str] | None:
+    """Call ``lookup(caller)``; swallow any exception → ``None``."""
+    # stx-allow: fallback (reason: any failure in the parent lookup —
+    # missing config, unreadable YAML, validation error in load_config
+    # — must NOT break the spawn; collapse to None and let PR-1
+    # enforce the post-translate spec)
+    try:
+        result = lookup(caller)
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        return None
+    if result is None:
+        return None
+    if not isinstance(result, list):
+        return None
+    return [b for b in result if isinstance(b, str)]
+
+
+__all__ = [
+    "BindTranslation",
+    "TranslateResult",
+    "translate_binds_in_spec",
+]

--- a/tests/scitex_agent_container/_listen/test__inline_spec_bind_translate.py
+++ b/tests/scitex_agent_container/_listen/test__inline_spec_bind_translate.py
@@ -1,0 +1,449 @@
+"""Tests for :mod:`scitex_agent_container._listen._inline_spec_bind_translate`.
+
+Unit tests for the PR-2 SAC-side bind translate. Pure-Python over an
+injected ``parent_binds_lookup`` callable — no FS, no Registry, no
+HTTP. The wired end-to-end test lives in
+``test_server_inline_spec_bind_translate.py``.
+
+Pinning:
+  * the longest-prefix match rule (nested binds resolve to the
+    deeper rule),
+  * the boundary-safe prefix check (``/work`` does NOT match
+    ``/workdir``),
+  * the input-shape preservation (string -> string, dict -> dict),
+  * the ``TranslateResult.skipped_reason`` taxonomy
+    (``no_caller`` | ``caller_unknown`` | ``no_parent_binds``),
+  * the no-op fallback whenever the parent lookup raises or returns
+    a non-list (defensive — PR-1 stays the SoT for safety).
+
+AAA + one assert per test (PA-307); no mocks (PA-306). The injected
+lookup IS the production seam — tests wire fakes via a closure, not
+``unittest.mock``.
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container._listen._inline_spec_bind_translate import (
+    BindTranslation,
+    TranslateResult,
+    translate_binds_in_spec,
+)
+
+# ---------------------------------------------------------------------------
+# Spec + lookup builders
+# ---------------------------------------------------------------------------
+
+
+def _spec(binds: list) -> dict:
+    return {
+        "apiVersion": "scitex-agent-container/v3",
+        "kind": "Agent",
+        "spec": {"apptainer": {"binds": binds}},
+    }
+
+
+def _lookup_returning(binds: list[str] | None):
+    """Build a ``parent_binds_lookup`` that always returns ``binds``."""
+
+    def _lookup(_caller: str) -> list[str] | None:
+        return binds
+
+    return _lookup
+
+
+def _lookup_raising(exc: Exception):
+    """Build a ``parent_binds_lookup`` that always raises."""
+
+    def _lookup(_caller: str) -> list[str] | None:
+        raise exc
+
+    return _lookup
+
+
+# ---------------------------------------------------------------------------
+# Happy-path translation
+# ---------------------------------------------------------------------------
+
+
+def test_translate_rewrites_work_prefix_to_parent_host_path() -> None:
+    # Arrange — parent has /home/y/proj/foo bound at /work; child
+    # asks for /work/data/X which the host can't see directly.
+    spec = _spec(["/work/data/X:/inside_X:ro"])
+    lookup = _lookup_returning(["/home/y/proj/foo:/work"])
+    # Act
+    translated, _result = translate_binds_in_spec(
+        spec, caller="parent-agent", parent_binds_lookup=lookup
+    )
+    # Assert
+    assert translated["spec"]["apptainer"]["binds"] == [
+        "/home/y/proj/foo/data/X:/inside_X:ro"
+    ]
+
+
+def test_translate_marks_bind_as_changed_in_result() -> None:
+    # Arrange
+    spec = _spec(["/work/data/X:/inside"])
+    lookup = _lookup_returning(["/home/y/foo:/work"])
+    # Act
+    _, result = translate_binds_in_spec(spec, caller="p", parent_binds_lookup=lookup)
+    # Assert
+    assert result.binds[0].was_changed is True
+
+
+def test_translate_records_matched_prefix() -> None:
+    # Arrange
+    spec = _spec(["/work/data/X:/inside"])
+    lookup = _lookup_returning(["/home/y/foo:/work"])
+    # Act
+    _, result = translate_binds_in_spec(spec, caller="p", parent_binds_lookup=lookup)
+    # Assert
+    assert result.binds[0].matched_prefix == "/work"
+
+
+def test_translate_preserves_mode_field_on_string_form() -> None:
+    # Arrange — :ro / :rw must round-trip through the rewrite.
+    spec = _spec(["/work/data:/inside:rw"])
+    lookup = _lookup_returning(["/home/y/foo:/work"])
+    # Act
+    translated, _ = translate_binds_in_spec(
+        spec, caller="p", parent_binds_lookup=lookup
+    )
+    # Assert
+    assert translated["spec"]["apptainer"]["binds"][0].endswith(":rw")
+
+
+def test_translate_omits_mode_separator_when_no_mode_present() -> None:
+    # Arrange — bind submitted without mode; emitter should not
+    # inject a trailing ``:`` that didn't exist.
+    spec = _spec(["/work/data:/inside"])
+    lookup = _lookup_returning(["/home/y/foo:/work"])
+    # Act
+    translated, _ = translate_binds_in_spec(
+        spec, caller="p", parent_binds_lookup=lookup
+    )
+    # Assert
+    assert translated["spec"]["apptainer"]["binds"][0] == "/home/y/foo/data:/inside"
+
+
+# ---------------------------------------------------------------------------
+# Longest-prefix + boundary safety
+# ---------------------------------------------------------------------------
+
+
+def test_translate_picks_longest_prefix_when_nested_binds_match() -> None:
+    # Arrange — parent has both /work AND /work/data bound. A child
+    # bind /work/data/X must resolve via the deeper rule
+    # (/work/data → /scratch/data) not the shallow one.
+    spec = _spec(["/work/data/X:/inside"])
+    lookup = _lookup_returning(["/home/y/foo:/work", "/scratch/data:/work/data"])
+    # Act
+    translated, _ = translate_binds_in_spec(
+        spec, caller="p", parent_binds_lookup=lookup
+    )
+    # Assert
+    assert translated["spec"]["apptainer"]["binds"][0].startswith("/scratch/data/X")
+
+
+def test_translate_does_not_match_path_with_shared_prefix_chars() -> None:
+    # Arrange — /work does NOT match /workdir; a naive
+    # str.startswith would silently mangle this. The original
+    # bind must pass through unchanged.
+    spec = _spec(["/workdir/X:/inside"])
+    lookup = _lookup_returning(["/home/y/foo:/work"])
+    # Act
+    translated, _ = translate_binds_in_spec(
+        spec, caller="p", parent_binds_lookup=lookup
+    )
+    # Assert
+    assert translated["spec"]["apptainer"]["binds"][0] == "/workdir/X:/inside"
+
+
+def test_translate_matches_exact_prefix_when_no_tail() -> None:
+    # Arrange — child binds the parent's bare /work mount point
+    # itself (no subpath). Should still translate to the parent's
+    # host root.
+    spec = _spec(["/work:/inside"])
+    lookup = _lookup_returning(["/home/y/foo:/work"])
+    # Act
+    translated, _ = translate_binds_in_spec(
+        spec, caller="p", parent_binds_lookup=lookup
+    )
+    # Assert
+    assert translated["spec"]["apptainer"]["binds"][0] == "/home/y/foo:/inside"
+
+
+# ---------------------------------------------------------------------------
+# No-op pass-through
+# ---------------------------------------------------------------------------
+
+
+def test_translate_no_op_when_host_src_does_not_match_any_prefix() -> None:
+    # Arrange — child bind is already host-visible (e.g. /tmp/X).
+    # No rule fires; original is preserved verbatim.
+    spec = _spec(["/tmp/X:/inside"])
+    lookup = _lookup_returning(["/home/y/foo:/work"])
+    # Act
+    translated, _ = translate_binds_in_spec(
+        spec, caller="p", parent_binds_lookup=lookup
+    )
+    # Assert
+    assert translated["spec"]["apptainer"]["binds"][0] == "/tmp/X:/inside"
+
+
+def test_translate_no_op_marks_was_changed_false() -> None:
+    # Arrange
+    spec = _spec(["/tmp/X:/inside"])
+    lookup = _lookup_returning(["/home/y/foo:/work"])
+    # Act
+    _, result = translate_binds_in_spec(spec, caller="p", parent_binds_lookup=lookup)
+    # Assert
+    assert result.binds[0].was_changed is False
+
+
+def test_translate_no_op_records_empty_matched_prefix() -> None:
+    # Arrange
+    spec = _spec(["/tmp/X:/inside"])
+    lookup = _lookup_returning(["/home/y/foo:/work"])
+    # Act
+    _, result = translate_binds_in_spec(spec, caller="p", parent_binds_lookup=lookup)
+    # Assert
+    assert result.binds[0].matched_prefix == ""
+
+
+def test_translate_mixed_translatable_and_passthrough_binds() -> None:
+    # Arrange — one /work bind (translatable) + one /tmp bind
+    # (already host-visible). Both kept in input order; only the
+    # translatable one is rewritten.
+    spec = _spec(["/tmp/X:/x", "/work/data:/d"])
+    lookup = _lookup_returning(["/home/y/foo:/work"])
+    # Act
+    translated, _ = translate_binds_in_spec(
+        spec, caller="p", parent_binds_lookup=lookup
+    )
+    # Assert
+    assert translated["spec"]["apptainer"]["binds"] == [
+        "/tmp/X:/x",
+        "/home/y/foo/data:/d",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Dict-form bind preservation
+# ---------------------------------------------------------------------------
+
+
+def test_translate_preserves_dict_form_on_rewrite() -> None:
+    # Arrange — caller submitted a dict-form bind. Translate must
+    # return a dict (not a stringified host:dst:mode) so the YAML
+    # the inline-spec handler writes preserves the operator's form.
+    spec = _spec([{"src": "/work/data", "dst": "/inside", "mode": "ro"}])
+    lookup = _lookup_returning(["/home/y/foo:/work"])
+    # Act
+    translated, _ = translate_binds_in_spec(
+        spec, caller="p", parent_binds_lookup=lookup
+    )
+    # Assert
+    assert isinstance(translated["spec"]["apptainer"]["binds"][0], dict)
+
+
+def test_translate_rewrites_src_in_dict_form() -> None:
+    # Arrange
+    spec = _spec([{"src": "/work/data", "dst": "/inside", "mode": "ro"}])
+    lookup = _lookup_returning(["/home/y/foo:/work"])
+    # Act
+    translated, _ = translate_binds_in_spec(
+        spec, caller="p", parent_binds_lookup=lookup
+    )
+    # Assert
+    assert translated["spec"]["apptainer"]["binds"][0]["src"] == "/home/y/foo/data"
+
+
+def test_translate_keeps_other_dict_keys_intact() -> None:
+    # Arrange — a hypothetical extra key (e.g. an annotation)
+    # should survive the rewrite untouched.
+    spec = _spec(
+        [{"src": "/work/data", "dst": "/inside", "mode": "ro", "note": "hello"}]
+    )
+    lookup = _lookup_returning(["/home/y/foo:/work"])
+    # Act
+    translated, _ = translate_binds_in_spec(
+        spec, caller="p", parent_binds_lookup=lookup
+    )
+    # Assert
+    assert translated["spec"]["apptainer"]["binds"][0]["note"] == "hello"
+
+
+# ---------------------------------------------------------------------------
+# skipped_reason taxonomy
+# ---------------------------------------------------------------------------
+
+
+def test_skip_reason_no_caller_when_caller_is_none() -> None:
+    # Arrange — operator-submitted spec, no caller field. Translate
+    # must be a no-op tagged ``no_caller``.
+    spec = _spec(["/work/X:/x"])
+    lookup = _lookup_returning(["/home/y/foo:/work"])
+    # Act
+    _, result = translate_binds_in_spec(spec, caller=None, parent_binds_lookup=lookup)
+    # Assert
+    assert result.skipped_reason == "no_caller"
+
+
+def test_skip_reason_caller_unknown_when_lookup_returns_none() -> None:
+    # Arrange — caller is not a known SAC-managed agent.
+    spec = _spec(["/work/X:/x"])
+    lookup = _lookup_returning(None)
+    # Act
+    _, result = translate_binds_in_spec(
+        spec, caller="ghost", parent_binds_lookup=lookup
+    )
+    # Assert
+    assert result.skipped_reason == "caller_unknown"
+
+
+def test_skip_reason_caller_unknown_when_lookup_raises() -> None:
+    # Arrange — parent's spec is unreadable / config-invalid /
+    # any other exception. Must collapse to ``caller_unknown``
+    # rather than 500-ing the spawn.
+    spec = _spec(["/work/X:/x"])
+    lookup = _lookup_raising(RuntimeError("config load failed"))
+    # Act
+    _, result = translate_binds_in_spec(
+        spec, caller="broken", parent_binds_lookup=lookup
+    )
+    # Assert
+    assert result.skipped_reason == "caller_unknown"
+
+
+def test_skip_reason_no_parent_binds_when_parent_has_empty_binds() -> None:
+    # Arrange — parent exists but has no apptainer.binds at all
+    # (e.g. a non-apptainer runtime). Translate is a no-op.
+    spec = _spec(["/work/X:/x"])
+    lookup = _lookup_returning([])
+    # Act
+    _, result = translate_binds_in_spec(
+        spec, caller="parentless", parent_binds_lookup=lookup
+    )
+    # Assert
+    assert result.skipped_reason == "no_parent_binds"
+
+
+def test_caller_known_true_when_lookup_succeeds() -> None:
+    # Arrange — parent record located.
+    spec = _spec(["/work/X:/x"])
+    lookup = _lookup_returning(["/home/y/foo:/work"])
+    # Act
+    _, result = translate_binds_in_spec(
+        spec, caller="parent", parent_binds_lookup=lookup
+    )
+    # Assert
+    assert result.caller_known is True
+
+
+def test_caller_known_false_when_lookup_returns_none() -> None:
+    # Arrange
+    spec = _spec(["/work/X:/x"])
+    lookup = _lookup_returning(None)
+    # Act
+    _, result = translate_binds_in_spec(
+        spec, caller="ghost", parent_binds_lookup=lookup
+    )
+    # Assert
+    assert result.caller_known is False
+
+
+# ---------------------------------------------------------------------------
+# Defensive — spec shape + bind shape robustness
+# ---------------------------------------------------------------------------
+
+
+def test_translate_handles_spec_with_no_apptainer_block() -> None:
+    # Arrange — a spec carrying no apptainer.binds (e.g. a docker
+    # runtime). No-op; returns the input dict unchanged.
+    spec = {
+        "apiVersion": "scitex-agent-container/v3",
+        "kind": "Agent",
+        "spec": {"workdir": "/tmp"},
+    }
+    lookup = _lookup_returning(["/home/y/foo:/work"])
+    # Act
+    translated, _ = translate_binds_in_spec(
+        spec, caller="p", parent_binds_lookup=lookup
+    )
+    # Assert
+    assert translated == spec
+
+
+def test_translate_passes_through_malformed_bind_string() -> None:
+    # Arrange — a string without a ``:`` separator is malformed.
+    # Translate must NOT mangle it (PR-1's preflight will reject
+    # it as ``bind_unresolvable`` downstream).
+    spec = _spec(["this-is-not-a-bind"])
+    lookup = _lookup_returning(["/home/y/foo:/work"])
+    # Act
+    translated, _ = translate_binds_in_spec(
+        spec, caller="p", parent_binds_lookup=lookup
+    )
+    # Assert
+    assert translated["spec"]["apptainer"]["binds"] == ["this-is-not-a-bind"]
+
+
+def test_translate_passes_through_dict_bind_missing_src() -> None:
+    # Arrange — dict missing ``src``. Passes through; PR-1 will
+    # surface the ``bind_unresolvable``.
+    spec = _spec([{"dst": "/inside", "mode": "ro"}])
+    lookup = _lookup_returning(["/home/y/foo:/work"])
+    # Act
+    translated, _ = translate_binds_in_spec(
+        spec, caller="p", parent_binds_lookup=lookup
+    )
+    # Assert
+    assert translated["spec"]["apptainer"]["binds"][0] == {
+        "dst": "/inside",
+        "mode": "ro",
+    }
+
+
+def test_translate_does_not_mutate_input_spec() -> None:
+    # Arrange — caller's spec dict should not be aliased into the
+    # returned dict (the call site discards the return on rare
+    # error paths and must not see a partially-rewritten input).
+    spec = _spec(["/work/data:/inside"])
+    lookup = _lookup_returning(["/home/y/foo:/work"])
+    # Act
+    translate_binds_in_spec(spec, caller="p", parent_binds_lookup=lookup)
+    # Assert
+    assert spec["spec"]["apptainer"]["binds"] == ["/work/data:/inside"]
+
+
+def test_translate_returns_dataclass_result() -> None:
+    # Arrange
+    spec = _spec(["/work/X:/x"])
+    lookup = _lookup_returning(["/home/y/foo:/work"])
+    # Act
+    _, result = translate_binds_in_spec(spec, caller="p", parent_binds_lookup=lookup)
+    # Assert
+    assert isinstance(result, TranslateResult)
+
+
+def test_translate_per_bind_result_is_dataclass() -> None:
+    # Arrange
+    spec = _spec(["/work/X:/x"])
+    lookup = _lookup_returning(["/home/y/foo:/work"])
+    # Act
+    _, result = translate_binds_in_spec(spec, caller="p", parent_binds_lookup=lookup)
+    # Assert
+    assert isinstance(result.binds[0], BindTranslation)
+
+
+def test_translate_handles_parent_binds_containing_garbage_entries() -> None:
+    # Arrange — parent's binds list has a malformed entry mixed
+    # with a good one. The good rule must still fire.
+    spec = _spec(["/work/X:/x"])
+    lookup = _lookup_returning(["not-a-bind", "/home/y/foo:/work"])
+    # Act
+    translated, _ = translate_binds_in_spec(
+        spec, caller="p", parent_binds_lookup=lookup
+    )
+    # Assert
+    assert translated["spec"]["apptainer"]["binds"] == ["/home/y/foo/X:/x"]

--- a/tests/scitex_agent_container/_listen/test_server_inline_spec_bind_translate.py
+++ b/tests/scitex_agent_container/_listen/test_server_inline_spec_bind_translate.py
@@ -1,0 +1,307 @@
+"""Wired-end-to-end tests for the PR-2 SAC-side bind translate.
+
+PR-2 splices into the inline-spec ``POST /agents`` handler between
+the basic-shape validation and the PR-1 bind preflight. The wire
+contract these tests pin:
+
+  * A child spec with ``/work/...`` bind sources gets rewritten to
+    the parent's host-side equivalent BEFORE the preflight runs,
+    so a stat()-able spec lands on disk.
+  * The translate is a no-op when the POST body carries no
+    ``caller`` field (admin / operator path → PR-1 enforces).
+  * The translate is a no-op when the caller is unknown to the
+    Registry, AND PR-1's 400 still fires (the safety valve).
+  * The translated spec is what gets written to disk (the YAML on
+    disk reflects the rewrite, not the original ``/work/...``).
+
+Real I/O via the Starlette ``TestClient`` against ``create_app``
++ a real on-disk parent spec.yaml. No mocks. AAA + one assert
+per test (PA-307).
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+import yaml
+from starlette.testclient import TestClient
+
+from scitex_agent_container._listen.server import create_app
+
+TOKEN = "test-token-bind-translate"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_env(tmp_path: Path, env_save_restore):
+    """Redirect $HOME + the SAC dir envs into tmp_path.
+
+    Same shape as the PR-1 server tests, with the matching
+    teardown reload to avoid the LIFO env-restore-vs-module-cache
+    issue in ``_runners._session_state`` (see PR-1 fix in
+    test_server_startup_failed.py).
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    runtime = tmp_path / "runtime"
+    runtime.mkdir()
+    yaml_dir = home / ".scitex" / "agent-container" / "agents"
+    yaml_dir.mkdir(parents=True, exist_ok=True)
+    env_save_restore.set("HOME", str(home))
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_RUNTIME_DIR", str(runtime))
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_YAML_DIRS", str(yaml_dir))
+    import importlib
+
+    import scitex_agent_container._runners._session_state as ss
+
+    importlib.reload(ss)
+    yield tmp_path
+    os.environ.pop("SCITEX_AGENT_CONTAINER_RUNTIME_DIR", None)
+    os.environ.pop("SCITEX_AGENT_CONTAINER_YAML_DIRS", None)
+    os.environ.pop("HOME", None)
+    importlib.reload(ss)
+
+
+@pytest.fixture
+def client(isolated_env):
+    app = create_app(token=TOKEN)
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture
+def auth_headers():
+    return {"authorization": f"Bearer {TOKEN}"}
+
+
+def _write_parent_spec(home: Path, name: str, host_root: Path) -> Path:
+    """Write a minimal parent spec.yaml whose apptainer.binds maps
+    ``host_root`` at the in-SIF view ``/work``.
+
+    The child will reference ``/work/data/X``; after PR-2 translate
+    that becomes ``{host_root}/data/X`` which is stat()-able on
+    disk (we mkdir it ahead of time).
+    """
+    spec_dir = home / ".scitex" / "agent-container" / "agents" / name
+    spec_dir.mkdir(parents=True, exist_ok=True)
+    spec = {
+        "apiVersion": "scitex-agent-container/v3",
+        "kind": "Agent",
+        "spec": {
+            "claude": {"model": "claude-sonnet-4-5"},
+            "workdir": "/tmp",
+            "apptainer": {
+                "image": "/path/to/sac-base.sif",
+                "binds": [f"{host_root}:/work"],
+            },
+        },
+    }
+    spec_path = spec_dir / "spec.yaml"
+    spec_path.write_text(yaml.safe_dump(spec))
+    return spec_path
+
+
+def _child_body(name: str, caller: str | None, binds: list) -> dict:
+    body: dict = {
+        "name": name,
+        "spec": {
+            "apiVersion": "scitex-agent-container/v3",
+            "kind": "Agent",
+            "spec": {
+                "workdir": "/tmp",
+                "apptainer": {
+                    "image": "/path/to/sac-base.sif",
+                    "binds": binds,
+                },
+            },
+        },
+    }
+    if caller is not None:
+        body["caller"] = caller
+    return body
+
+
+# ---------------------------------------------------------------------------
+# Happy path: /work/X (in-SIF) translates to host path that exists
+# ---------------------------------------------------------------------------
+
+
+def test_child_with_work_prefix_bind_is_accepted_after_translate(
+    client, auth_headers, isolated_env, tmp_path
+):
+    # Arrange — parent maps its host $HOME/proj/foo at /work; child
+    # asks for /work/data/capsule-X. After translate, the bind is
+    # $HOME/proj/foo/data/capsule-X which we mkdir on the host so
+    # PR-1's preflight passes.
+    host_root = tmp_path / "proj" / "foo"
+    (host_root / "data" / "capsule-X").mkdir(parents=True)
+    home = Path(os.environ["HOME"])
+    _write_parent_spec(home, "parent-launcher", host_root)
+    body = _child_body(
+        "child-translated",
+        caller="parent-launcher",
+        binds=["/work/data/capsule-X:/inside:ro"],
+    )
+    # Act
+    response = client.post("/agents", json=body, headers=auth_headers)
+    # Assert — translate + preflight both succeeded; the POST
+    # didn't return a 400 (bind_unresolvable).
+    assert (
+        response.status_code != 400
+        or response.json().get("kind") != "bind_unresolvable"
+    )
+
+
+def test_translated_bind_is_what_gets_written_to_disk(
+    client, auth_headers, isolated_env, tmp_path
+):
+    # Arrange — same setup as above, but inspect the materialised
+    # spec on disk. The spec.yaml at the install root must carry
+    # the TRANSLATED host path, not the original ``/work/...``.
+    host_root = tmp_path / "proj" / "foo"
+    (host_root / "data" / "capsule-X").mkdir(parents=True)
+    home = Path(os.environ["HOME"])
+    _write_parent_spec(home, "parent-disk", host_root)
+    body = _child_body(
+        "child-disk-check",
+        caller="parent-disk",
+        binds=["/work/data/capsule-X:/inside:ro"],
+    )
+    # Act
+    client.post("/agents", json=body, headers=auth_headers)
+    persisted_spec_path = (
+        home
+        / ".scitex"
+        / "agent-container"
+        / "agents"
+        / "child-disk-check"
+        / "spec.yaml"
+    )
+    persisted = yaml.safe_load(persisted_spec_path.read_text())
+    persisted_binds = persisted["spec"]["apptainer"]["binds"]
+    # Assert — disk shows the host path, not the in-SIF view.
+    assert persisted_binds == [f"{host_root}/data/capsule-X:/inside:ro"]
+
+
+# ---------------------------------------------------------------------------
+# No-op path: caller absent
+# ---------------------------------------------------------------------------
+
+
+def test_no_caller_means_no_translate_so_pr1_still_rejects_work_path(
+    client, auth_headers, isolated_env, tmp_path
+):
+    # Arrange — operator-style POST with no ``caller`` field. The
+    # bind source ``/work/...`` is not stat()-able on the host.
+    # Translate is a no-op (no_caller), so PR-1's preflight fires
+    # and returns the structured 400 — exactly the safety valve.
+    body = _child_body(
+        "no-caller-rejected",
+        caller=None,
+        binds=[f"{tmp_path}/missing-on-host:/x"],
+    )
+    # Act
+    response = client.post("/agents", json=body, headers=auth_headers)
+    # Assert
+    assert response.json().get("kind") == "bind_unresolvable"
+
+
+# ---------------------------------------------------------------------------
+# No-op path: caller is unknown (not a SAC-managed agent)
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_caller_falls_back_to_pr1_rejection(
+    client, auth_headers, isolated_env, tmp_path
+):
+    # Arrange — caller string doesn't resolve to any registered
+    # parent. Translate collapses to caller_unknown; PR-1 catches
+    # the unresolvable bind.
+    body = _child_body(
+        "unknown-caller",
+        caller="ghost-parent",
+        binds=["/work/data/X:/inside"],
+    )
+    # Act
+    response = client.post("/agents", json=body, headers=auth_headers)
+    # Assert
+    assert response.json().get("kind") == "bind_unresolvable"
+
+
+# ---------------------------------------------------------------------------
+# Non-regression: PR-1 still catches a bind that translate can't fix
+# ---------------------------------------------------------------------------
+
+
+def test_translate_passthrough_for_non_work_bind_still_caught_by_pr1(
+    client, auth_headers, isolated_env, tmp_path
+):
+    # Arrange — caller IS known but the child requested a bind
+    # source the parent doesn't expose (e.g. /scratch/X when the
+    # parent only binds /home/y/proj/foo at /work). Translate is
+    # a no-op for the /scratch path; PR-1 catches it.
+    host_root = tmp_path / "proj" / "foo"
+    host_root.mkdir(parents=True)
+    home = Path(os.environ["HOME"])
+    _write_parent_spec(home, "scoped-parent", host_root)
+    body = _child_body(
+        "out-of-scope-bind",
+        caller="scoped-parent",
+        binds=[f"{tmp_path}/no-such-dir:/x"],
+    )
+    # Act
+    response = client.post("/agents", json=body, headers=auth_headers)
+    # Assert
+    assert response.json().get("kind") == "bind_unresolvable"
+
+
+# ---------------------------------------------------------------------------
+# Mixed binds: one translatable + one already-host-visible
+# ---------------------------------------------------------------------------
+
+
+def test_mixed_binds_translate_only_work_prefix_others_pass_through(
+    client, auth_headers, isolated_env, tmp_path
+):
+    # Arrange — child requests two binds: one /work-prefixed
+    # (translatable) and one already-host-visible (passes through).
+    # The persisted spec carries the right shape: first rewritten,
+    # second untouched.
+    host_root = tmp_path / "proj" / "foo"
+    (host_root / "data").mkdir(parents=True)
+    sibling = tmp_path / "sibling"
+    sibling.mkdir()
+    home = Path(os.environ["HOME"])
+    _write_parent_spec(home, "mixed-parent", host_root)
+    body = _child_body(
+        "mixed-bind-child",
+        caller="mixed-parent",
+        binds=[
+            "/work/data:/inside_data:ro",
+            f"{sibling}:/inside_sibling:rw",
+        ],
+    )
+    # Act
+    client.post("/agents", json=body, headers=auth_headers)
+    persisted_spec_path = (
+        home
+        / ".scitex"
+        / "agent-container"
+        / "agents"
+        / "mixed-bind-child"
+        / "spec.yaml"
+    )
+    persisted_binds = yaml.safe_load(persisted_spec_path.read_text())["spec"][
+        "apptainer"
+    ]["binds"]
+    # Assert
+    assert persisted_binds == [
+        f"{host_root}/data:/inside_data:ro",
+        f"{sibling}:/inside_sibling:rw",
+    ]


### PR DESCRIPTION
## Summary

**PR-2 of the SAC-from-SAC hardening series.** PR-1 (#287, merged b9d97ff) installed an always-on host-stat preflight on `spec.apptainer.binds` that hard-rejects any bind whose source is not host-visible. That preflight is the **safety valve**. PR-2 is the opt-in **convenience** that makes the common SAC-from-SAC case Just Work: when a parent agent spawns a child via `POST /agents` and the child spec carries verbatim in-SIF paths like `/work/data/X` (which only resolve inside the parent's container view), the host rewrites those sources to the parent's host-side equivalent **before** the preflight runs. PR-1 still fires on any bind PR-2 can't translate — there is no silent path back to the FATAL.

Motivating case: same as PR-1, the clew `cohort-A/capsule-0201225` incident on 2026-06-02. Launcher's `/work` was bound from `$HOME/proj/paper-scitex-clew`; child spec asked for `/work/data/.../capsule-0201225`. PR-1 rejects (after merge). PR-2 *translates* the path so the child spawns and PR-1 never fires.

## Wire shape — UNCHANGED

PR-2 is a pre-clean of the spec before PR-1's preflight; it does NOT change the wire contract. A successful translate is silent (spec persisted, `sac agents start` invoked, 200 OK). A failed translate is silent and falls through to PR-1 (same `kind=bind_unresolvable` body). **The clew launcher needs ZERO code changes to consume PR-2.**

## What's in

### NEW `_listen/_inline_spec_bind_translate.py`
- `translate_binds_in_spec(spec, caller, *, parent_binds_lookup) -> (translated_spec, TranslateResult)`
- Frozen dataclasses: `BindTranslation`, `TranslateResult`
- Longest-prefix match (nested binds resolve to deeper rule)
- Boundary-safe prefix check (`/work` does NOT match `/workdir`)
- Input-shape preservation (string → string, dict → dict + extra keys survive)
- Empty-binds short-circuit (does not inject `apptainer` block into a spec that didn't declare one)
- Read-only + best-effort: any failure to resolve parent collapses to no-op; PR-1 catches what leaks

### MOD `_listen/_inline_spec.py`
- `materialize_inline_spec()` gains `caller: str | None = None` kwarg
- New module-level `_resolve_parent_binds(caller)` helper (drives `resolve_config` → `load_config`)
- Splices translate between basic shape validation and PR-1 preflight call
- Translated spec is what PR-1 validates AND what gets persisted to disk

### MOD `_listen/_agent_exec.py`
- `agents_start()` passes `caller` (from POST body) into `materialize_inline_spec()`

## skipped_reason taxonomy

When the translate does NOT run, `TranslateResult.skipped_reason` tags why (useful for logging / observability later):

- `"no_caller"` — POST body has no `caller` field (admin / operator path)
- `"caller_unknown"` — `resolve_config(caller)` returned `None` or raised
- `"no_parent_binds"` — parent's spec has empty or unparseable `apptainer.binds`
- `""` — translate ran (one or more binds may have been rewritten or passed through)

## Test coverage (real I/O, no mocks; AAA + one-assert)

- `tests/.../_listen/test__inline_spec_bind_translate.py` — **28 unit tests** (happy path, longest-prefix, boundary, no-op, dict-form preservation, skipped_reason taxonomy, defensive)
- `tests/.../_listen/test_server_inline_spec_bind_translate.py` — **6 wired tests** (real Starlette TestClient + on-disk parent spec.yaml: child accepted after translate, persisted spec carries translated path, no-caller falls through to PR-1, unknown-caller falls through to PR-1, out-of-scope bind caught by PR-1, mixed translatable+passthrough binds materialised correctly)

**Total: 34 new tests.** All 706 `_listen + _lifecycle + _runners/test_claude_session` green locally. PA-306 (no-mocks — injected lookup IS the production seam) + PA-307 (AAA + one-assert) clean.

## Contract with PR-1

PR-1 stays the SoT for "is this bind safe?". PR-2 only changes the input PR-1 sees. If PR-2 has a bug, the worst case is PR-1's preflight fires with the SAME `kind=bind_unresolvable` + same `details.binds[]` shape clew already consumes. **No silent regression path.**

## Series sequencing

- PR-1 (merged b9d97ff): fail-loud bind preflight + STARTUP_FAILED lifecycle
- **PR-2 (this)**: SAC-side bind translate
- PR-3 (queued): `sac agents spawn-from-here` + in-SIF auto-fallback + lineage-scoped ACL + `acl_deny` kind

Refs: SAC-from-SAC PR series — PR-2 of three. Wire-shape sign-off carries over from PR-1 (no contract change in this PR).