### PR TITLE
feat(_listen): preflight catch for bash-malformed startup_commands

### DIFF
--- a/src/scitex_agent_container/_listen/_inline_spec.py
+++ b/src/scitex_agent_container/_listen/_inline_spec.py
@@ -79,8 +79,17 @@ def materialize_inline_spec(
          HTTP 400 + ``kind="bind_unresolvable"`` (PR-1 fail-loud).
          This is the SoT for "is this bind safe?" — PR-2 just
          pre-cleans the common SAC-from-SAC case.
-      5. ``kind="already_exists"`` for the overwrite-guard collision.
-      6. ``kind="spec_invalid"`` for write failure (disk full, RO fs).
+      5. **startup_commands lint**: every
+         ``spec.startup_commands[*].command`` first token is checked
+         via :func:`shlex.split` + :func:`shutil.which` against the
+         SAC host PATH. Misses, colon-suffixed prompt-text barewords
+         (the ``"You:"`` smoking gun from the clew launcher #70
+         incident on 2026-06-03), and shell-syntax errors abort
+         with HTTP 400 + ``kind="spec_invalid"`` carrying a per-entry
+         ``reason`` sub-shade enum. Mirrors PR-1's wire shape so the
+         caller can branch on ``kind`` + per-entry ``reason``.
+      6. ``kind="already_exists"`` for the overwrite-guard collision.
+      7. ``kind="spec_invalid"`` for write failure (disk full, RO fs).
 
     Args:
         name: target agent name.
@@ -150,6 +159,28 @@ def materialize_inline_spec(
     preflight = preflight_bind_sources(spec)
     if not preflight.ok:
         return JSONResponse(preflight_failure_response_body(preflight), status_code=400)
+
+    # Follow-up to PR-1/2/3 — startup_commands first-token lint. The
+    # clew launcher #70 incident on 2026-06-03 put the agent's CLAUDE
+    # mission prompt into spec.startup_commands by mistake; the first
+    # line ``"You: ..."`` ran as a shell command and bash logged
+    # ``You: command not found``. The bind preflight above does not
+    # cover startup_commands, so this sibling preflight catches the
+    # class. Done AFTER bind preflight so the cheap-to-expensive order
+    # holds (shlex+which is cheap but the bind stat() chain is even
+    # cheaper). Wire shape: ``kind="spec_invalid"`` (re-using the
+    # existing enum already used by apiVersion/kind validation above)
+    # with per-entry ``reason`` sub-shade enum.
+    from ._inline_spec_startup_lint import (
+        preflight_failure_response_body as startup_lint_failure_body,
+    )
+    from ._inline_spec_startup_lint import (
+        preflight_startup_commands,
+    )
+
+    startup_lint = preflight_startup_commands(spec)
+    if not startup_lint.ok:
+        return JSONResponse(startup_lint_failure_body(startup_lint), status_code=400)
 
     primary = (
         Path(os.path.expanduser("~")) / ".scitex" / "agent-container" / "agents" / name

--- a/src/scitex_agent_container/_listen/_inline_spec_startup_lint.py
+++ b/src/scitex_agent_container/_listen/_inline_spec_startup_lint.py
@@ -1,0 +1,446 @@
+"""Pre-flight lint of ``spec.startup_commands[*].command`` first-tokens.
+
+The follow-up to the SAC-from-SAC PR-1/2/3 series. On 2026-06-03 the
+clew launcher (PR clew#70) materialised a child Agent spec where the
+agent's CLAUDE-mission prompt text was accidentally placed in
+``spec.startup_commands[*].command`` instead of ``spec.startup_prompts``.
+The first line of the prompt was ``"You: ..."``, which the SAC
+runtime faithfully executed as a shell command:
+
+    /bin/bash: line 1: You: command not found
+
+The agent SIF spawned + restart-looped, the cohort burnt ~30 min of
+operator triage, and the wire-shape contract from PR-1
+(``kind="bind_unresolvable"``) did not catch it because the bind
+preflight only sees ``apptainer.binds``, not ``startup_commands``.
+
+This module adds a sibling pre-flight that runs AFTER bind-translate +
+bind-preflight (PR-1+2) and BEFORE the spec is materialised. It
+inspects every ``startup_commands[*].command``, tokenises via
+:func:`shlex.split`, drops leading ``KEY=VAL`` env assignments, and
+applies a deliberately-conservative set of checks to the first
+remaining bareword:
+
+  * **Shell-syntax**: :func:`shlex.split` exception → fail-loud with
+    ``reason="shell_syntax_malformed"``. Unbalanced quotes / stray
+    backslashes would have failed at container exec time anyway —
+    we just surface the error at HTTP 400 instead.
+  * **Prompt-text smoking gun**: if the first bareword contains a
+    colon (``:``), it is almost certainly leaked prompt content.
+    The clew incident's ``"You:"`` is the canonical example. Fail
+    with ``reason="first_token_looks_like_prompt_text"`` and a
+    suggestion that points at ``spec.startup_prompts``.
+  * **Host PATH resolution**: :func:`shutil.which` on the bareword.
+    Misses on the SAC host PATH → ``reason="first_token_not_on_path"``.
+    Allowlisted shell built-ins (``cd``, ``echo``, ``:``, …) pass
+    through.
+
+Pass-through (never rejected — out of scope for this preflight):
+
+  * Empty / missing ``command`` (already dropped by
+    ``parse_startup_commands``).
+  * Absolute paths (``/opt/x``) or relative paths
+    (``./x``, ``../x``) — we can't probe SIF-internal paths from
+    the host; trust the operator.
+  * Variable-prefixed commands (``$HOME/bin/x``) — same reason.
+
+The validator is read-only. Any unexpected spec shape collapses to
+"nothing to check", same defensive pattern as the bind preflight.
+
+Wire shape (kept in lockstep with PR-1's ``bind_unresolvable``):
+
+.. code-block:: json
+
+   {
+     "error": "startup_commands[*].command first-token validation failed",
+     "kind": "spec_invalid",
+     "details": {
+       "startup_commands": [
+         {
+           "index": 0,
+           "command": "You: please do X",
+           "first_token": "You:",
+           "reason": "first_token_looks_like_prompt_text"
+         }
+       ],
+       "suggestion": "..."
+     }
+   }
+
+Callers MUST branch on ``kind`` + ``details.startup_commands[].reason``
+(stable enum), not on the prose ``error`` or ``suggestion``.
+"""
+
+from __future__ import annotations
+
+import shlex
+import shutil
+from dataclasses import dataclass
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Allowlist — POSIX-ish shell built-ins that are not on $PATH but always
+# available inside any bash invocation. Kept as a frozenset constant so
+# tests can introspect it without importing internals.
+# ---------------------------------------------------------------------------
+
+_SHELL_BUILTINS: frozenset[str] = frozenset(
+    {
+        # control flow & no-op
+        ":",
+        ".",
+        "true",
+        "false",
+        "exit",
+        "return",
+        "break",
+        "continue",
+        "shift",
+        # I/O
+        "echo",
+        "printf",
+        "read",
+        # vars
+        "export",
+        "unset",
+        "set",
+        "declare",
+        "local",
+        "typeset",
+        "readonly",
+        # eval & source
+        "eval",
+        "exec",
+        "source",
+        # navigation
+        "cd",
+        "pwd",
+        "pushd",
+        "popd",
+        "dirs",
+        # test
+        "test",
+        "[",
+        "[[",
+        # job control
+        "jobs",
+        "bg",
+        "fg",
+        "wait",
+        "kill",
+        "trap",
+        # misc
+        "umask",
+        "ulimit",
+        "times",
+        "type",
+        "hash",
+        "alias",
+        "unalias",
+        "getopts",
+        "let",
+        "command",
+        "help",
+        "history",
+        "fc",
+        "logout",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Result shape
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class StartupCommandIssue:
+    """Per-entry preflight result for a single ``startup_commands`` item.
+
+    * ``index`` — position in the original ``startup_commands`` list.
+      Stable across reorderings done by upstream parsers so the caller
+      can point operators at the exact line.
+    * ``command`` — verbatim ``command`` string from the spec entry.
+      Echoed so the caller does not have to cross-reference the spec
+      it just POST'd.
+    * ``first_token`` — the bareword we evaluated (post ``KEY=VAL``
+      stripping). Empty string if the spec entry was malformed.
+    * ``reason`` — stable enum the caller branches on. See the module
+      docstring for the value taxonomy.
+    """
+
+    index: int
+    command: str
+    first_token: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class StartupLintResult:
+    """Aggregated startup_commands lint outcome.
+
+    * ``ok`` — ``True`` iff every entry passed (or was pass-through:
+      empty command, absolute/relative path, variable-prefixed).
+    * ``issues`` — every failing entry in input order. The caller can
+      render all misses in one shot instead of stop-on-first.
+    """
+
+    ok: bool
+    issues: tuple[StartupCommandIssue, ...]
+
+
+# ---------------------------------------------------------------------------
+# Spec extraction
+# ---------------------------------------------------------------------------
+
+
+def _iter_startup_commands(spec: dict) -> list[Any]:
+    """Best-effort extraction of ``spec.startup_commands`` from a v3 spec.
+
+    Defensive: any unexpected shape collapses to an empty list. Same
+    pattern as :func:`_inline_spec_preflight._iter_binds`.
+    """
+    if not isinstance(spec, dict):
+        return []
+    spec_body = spec.get("spec")
+    if not isinstance(spec_body, dict):
+        return []
+    cmds = spec_body.get("startup_commands")
+    if not isinstance(cmds, list):
+        return []
+    return cmds
+
+
+def _extract_command(entry: Any) -> str | None:
+    """Pull the ``command`` string out of a single startup_commands entry.
+
+    Accepts the canonical dict form ``{delay: int, command: str}``.
+    Returns ``None`` for any unexpected shape; the lint then skips
+    the entry (the downstream parser will drop it anyway, so this is
+    not a host-visible signal we need to enforce).
+    """
+    if not isinstance(entry, dict):
+        return None
+    cmd = entry.get("command")
+    if not isinstance(cmd, str):
+        return None
+    return cmd
+
+
+def _strip_env_assignments(tokens: list[str]) -> list[str]:
+    """Drop leading ``KEY=VAL`` shell env-var assignments.
+
+    ``FOO=bar BAZ=qux mycmd arg`` → ``["mycmd", "arg"]``.
+
+    A token counts as an env-var assignment when it matches
+    ``[A-Za-z_][A-Za-z0-9_]*=...`` (POSIX identifier prefix +
+    literal ``=`` + anything). Stops at the first non-matching
+    token; any later ``=`` characters in arguments are NOT stripped.
+    """
+    stripped: list[str] = list(tokens)
+    while stripped:
+        head = stripped[0]
+        eq = head.find("=")
+        if eq <= 0:
+            break
+        ident = head[:eq]
+        if not ident[0].isalpha() and ident[0] != "_":
+            break
+        if not all(c.isalnum() or c == "_" for c in ident):
+            break
+        stripped.pop(0)
+    return stripped
+
+
+# ---------------------------------------------------------------------------
+# Public preflight
+# ---------------------------------------------------------------------------
+
+
+def preflight_startup_commands(spec: dict) -> StartupLintResult:
+    """Validate every ``spec.startup_commands[*].command`` first token.
+
+    Returns a :class:`StartupLintResult` with ``ok=False`` and an
+    ``issues`` list when one or more entries fail. See the module
+    docstring for the per-issue ``reason`` taxonomy.
+
+    Specs with no startup_commands (or unparseable shape) collapse to
+    ``ok=True`` with empty ``issues`` — there is nothing to reject.
+    """
+    issues: list[StartupCommandIssue] = []
+    for index, entry in enumerate(_iter_startup_commands(spec)):
+        cmd = _extract_command(entry)
+        # Empty / missing command: pass-through. The downstream
+        # ``parse_startup_commands`` drops these, and we do not want
+        # to false-positive on a spec that includes an obviously-empty
+        # entry the operator will discover at parse time.
+        if cmd is None or cmd.strip() == "":
+            continue
+
+        try:
+            raw_tokens = shlex.split(cmd, comments=False, posix=True)
+        except ValueError as exc:
+            issues.append(
+                StartupCommandIssue(
+                    index=index,
+                    command=cmd,
+                    first_token="",
+                    reason="shell_syntax_malformed",
+                )
+            )
+            # Don't try to keep parsing — record + move on. The shlex
+            # message itself is not surfaced (callers don't branch on
+            # prose); the bare ``shell_syntax_malformed`` enum is the
+            # contract. ``exc`` retained for trace context only.
+            del exc
+            continue
+
+        tokens = _strip_env_assignments(raw_tokens)
+        if not tokens:
+            # All-env-assignments command (``FOO=bar BAZ=qux``).
+            # Technically legal but a no-op; not our preflight's job
+            # to flag style. Pass-through.
+            continue
+
+        first = tokens[0]
+
+        # Pass-through cases — we cannot resolve these from the host
+        # side without container introspection, so trust the operator.
+        if first.startswith("/"):
+            continue  # absolute path
+        if first.startswith("./") or first.startswith("../"):
+            continue  # relative path
+        if first.startswith("$"):
+            continue  # shell variable prefix
+        if first.startswith("~"):
+            continue  # home expansion (apptainer keeps $HOME in-SIF)
+
+        # High-confidence prompt-text signal. The clew incident's
+        # ``"You:"`` is the canonical case: a colon-suffixed bareword
+        # at the start of what should be a shell command is almost
+        # never a real executable. We surface this BEFORE the PATH
+        # check so the suggestion message can be specific.
+        if ":" in first:
+            issues.append(
+                StartupCommandIssue(
+                    index=index,
+                    command=cmd,
+                    first_token=first,
+                    reason="first_token_looks_like_prompt_text",
+                )
+            )
+            continue
+
+        # Shell built-ins are not on $PATH but always work. Allowlist.
+        if first in _SHELL_BUILTINS:
+            continue
+
+        # Final check: host PATH resolution. ``shutil.which`` honours
+        # ``$PATH`` from the SAC host process, which is the same
+        # environment that runs ``apptainer exec``, so a miss here
+        # reliably predicts a miss at container start. False positives
+        # are possible (command exists only in the SIF, not on host),
+        # which is why the suggestion message includes the
+        # absolute-path escape hatch.
+        if shutil.which(first) is None:
+            issues.append(
+                StartupCommandIssue(
+                    index=index,
+                    command=cmd,
+                    first_token=first,
+                    reason="first_token_not_on_path",
+                )
+            )
+
+    return StartupLintResult(ok=not issues, issues=tuple(issues))
+
+
+# ---------------------------------------------------------------------------
+# HTTP failure body
+# ---------------------------------------------------------------------------
+
+
+# Suggestion strings keyed by ``reason``. Centralised so any future
+# tweak goes in one place (e.g. when we add a docs URL the operator can
+# follow). The first-token field is interpolated at body-build time;
+# the ``{first_token}`` placeholder MUST stay verbatim in the table.
+_REASON_SUGGESTIONS: dict[str, str] = {
+    "first_token_looks_like_prompt_text": (
+        "First token '{first_token}' contains ':' and looks like "
+        "leaked prompt text. spec.startup_commands runs as shell "
+        "commands BEFORE the agent starts; the agent's mission goes "
+        "in spec.startup_prompts (which is fed to the SDK as the "
+        "first user message). Move this content there."
+    ),
+    "first_token_not_on_path": (
+        "First token '{first_token}' was not found on the SAC host "
+        "PATH and is not a recognised shell built-in. If this "
+        "command exists only inside the SIF, use an absolute "
+        "container path (e.g. /opt/scitex/bin/{first_token}). If it "
+        "is prompt text, move it to spec.startup_prompts."
+    ),
+    "shell_syntax_malformed": (
+        "Command failed shell tokenisation (shlex). Check for "
+        "unbalanced quotes or stray backslashes; the runtime would "
+        "have hit the same error at container start."
+    ),
+}
+
+
+def preflight_failure_response_body(result: StartupLintResult) -> dict:
+    """Build the HTTP 400 JSON body for a failed startup_commands lint.
+
+    Stable wire shape:
+
+    .. code-block:: json
+
+       {
+         "error": "startup_commands[*].command first-token validation failed",
+         "kind": "spec_invalid",
+         "details": {
+           "startup_commands": [
+             {
+               "index": 0,
+               "command": "You: please do X",
+               "first_token": "You:",
+               "reason": "first_token_looks_like_prompt_text",
+               "suggestion": "..."
+             }
+           ]
+         }
+       }
+
+    Callers branch on ``kind`` + ``details.startup_commands[].reason``;
+    the prose ``error`` + per-entry ``suggestion`` are for humans.
+
+    Note: ``kind`` is the existing ``"spec_invalid"`` enum already in
+    use by :mod:`_inline_spec` for malformed-spec rejection (apiVersion
+    mismatch, kind mismatch, etc.). Re-using the enum keeps the
+    consumer-side branch table small; the per-entry ``reason`` carries
+    the sub-shade.
+    """
+    entries: list[dict] = []
+    for issue in result.issues:
+        entry: dict = {
+            "index": issue.index,
+            "command": issue.command,
+            "first_token": issue.first_token,
+            "reason": issue.reason,
+        }
+        template = _REASON_SUGGESTIONS.get(issue.reason)
+        if template is not None:
+            entry["suggestion"] = template.format(first_token=issue.first_token)
+        entries.append(entry)
+    return {
+        "error": "startup_commands[*].command first-token validation failed",
+        "kind": "spec_invalid",
+        "details": {"startup_commands": entries},
+    }
+
+
+__all__ = [
+    "StartupCommandIssue",
+    "StartupLintResult",
+    "preflight_startup_commands",
+    "preflight_failure_response_body",
+]

--- a/tests/scitex_agent_container/_listen/test__inline_spec.py
+++ b/tests/scitex_agent_container/_listen/test__inline_spec.py
@@ -195,3 +195,59 @@ class TestMaterializeOverwriteSemantics:
         loaded = yaml.safe_load(spec_path.read_text(encoding="utf-8"))
         # Assert
         assert loaded["spec"]["role"] == "worker"
+
+
+class TestMaterializeStartupCommandsLintWireIn:
+    """Integration of the startup_commands first-token lint into the
+    inline-spec materialise pipeline. Unit-level branch coverage of the
+    lint itself lives in :mod:`test__inline_spec_startup_lint`; this
+    class only confirms the wire-in at the materialise entrypoint.
+    """
+
+    def test_prompt_text_command_returns_400(self, home_root: Path):
+        # Arrange — the clew launcher #70 canonical bug: agent's CLAUDE
+        # mission prompt was placed in startup_commands by mistake.
+        spec = _valid_spec()
+        spec["spec"]["startup_commands"] = [
+            {"command": "You: run the experiment with seed=42"}
+        ]
+        # Act
+        result = materialize_inline_spec("alpha", spec, overwrite=False)
+        # Assert
+        assert result.status_code == 400
+
+    def test_prompt_text_command_kind_is_spec_invalid(self, home_root: Path):
+        # Arrange
+        spec = _valid_spec()
+        spec["spec"]["startup_commands"] = [{"command": "You: do thing"}]
+        # Act
+        result = materialize_inline_spec("alpha", spec, overwrite=False)
+        # Assert
+        assert _body(result)["kind"] == "spec_invalid"
+
+    def test_prompt_text_command_does_not_write_spec_file(self, home_root: Path):
+        # Arrange — fail-loud rejection must leave zero artifacts (no
+        # spec dir, no spec.yaml). Same fail-loud contract PR-1 holds
+        # for bind_unresolvable.
+        spec = _valid_spec()
+        spec["spec"]["startup_commands"] = [{"command": "You: leaked"}]
+        spec_path = (
+            home_root / ".scitex" / "agent-container" / "agents" / "alpha" / "spec.yaml"
+        )
+        # Act
+        materialize_inline_spec("alpha", spec, overwrite=False)
+        # Assert
+        assert not spec_path.exists()
+
+    def test_well_formed_startup_commands_pass_through(self, home_root: Path):
+        # Arrange — ``echo`` + ``ls`` (both available as builtin /
+        # PATH executable) should not block the materialise.
+        spec = _valid_spec()
+        spec["spec"]["startup_commands"] = [
+            {"command": "echo starting"},
+            {"command": "ls /tmp"},
+        ]
+        # Act
+        result = materialize_inline_spec("alpha", spec, overwrite=False)
+        # Assert
+        assert result is None

--- a/tests/scitex_agent_container/_listen/test__inline_spec_startup_lint.py
+++ b/tests/scitex_agent_container/_listen/test__inline_spec_startup_lint.py
@@ -1,0 +1,462 @@
+"""Tests for :mod:`scitex_agent_container._listen._inline_spec_startup_lint`.
+
+Real :func:`shutil.which` against the test process ``$PATH``; no
+mocks. AAA + one assert per test (PA-307). Pinning the wire-shape
+contract here so clew + future SAC-from-SAC clients can branch on
+it without grepping prose. Per the PR-1 review pattern, the
+failure-body keys are:
+
+  * ``kind`` (top-level branch tag) = ``"spec_invalid"`` (re-uses the
+    existing enum already in use by apiVersion/kind validation in
+    :mod:`_inline_spec`; the per-entry ``reason`` carries the sub-shade)
+  * ``details.startup_commands[]`` (array form so multi-entry callers
+    see EVERY miss in one round-trip)
+  * ``details.startup_commands[].index`` (stable position pointer)
+  * ``details.startup_commands[].command`` (verbatim spec entry)
+  * ``details.startup_commands[].first_token`` (the bareword we
+    evaluated, post env-assignment stripping)
+  * ``details.startup_commands[].reason`` (stable enum:
+    ``shell_syntax_malformed`` | ``first_token_looks_like_prompt_text``
+    | ``first_token_not_on_path``)
+  * ``details.startup_commands[].suggestion`` (human prose, present
+    for every recognised reason)
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container._listen._inline_spec_startup_lint import (
+    StartupCommandIssue,
+    StartupLintResult,
+    preflight_failure_response_body,
+    preflight_startup_commands,
+)
+
+# ---------------------------------------------------------------------------
+# Spec builders
+# ---------------------------------------------------------------------------
+
+
+def _spec_with_startup_commands(cmds: list) -> dict:
+    return {
+        "apiVersion": "scitex-agent-container/v3",
+        "kind": "Agent",
+        "spec": {"startup_commands": cmds},
+    }
+
+
+# ---------------------------------------------------------------------------
+# preflight_startup_commands — happy path (pass-through)
+# ---------------------------------------------------------------------------
+
+
+def test_preflight_ok_when_no_startup_commands() -> None:
+    # Arrange — spec carries no startup_commands at all.
+    spec = {
+        "apiVersion": "scitex-agent-container/v3",
+        "kind": "Agent",
+        "spec": {},
+    }
+    # Act
+    result = preflight_startup_commands(spec)
+    # Assert
+    assert result.ok is True
+
+
+def test_preflight_ok_when_startup_commands_empty_list() -> None:
+    # Arrange
+    spec = _spec_with_startup_commands([])
+    # Act
+    result = preflight_startup_commands(spec)
+    # Assert
+    assert result.ok is True
+
+
+def test_preflight_ok_for_real_executable_on_path() -> None:
+    # Arrange — ``echo`` is a shell builtin AND is in /usr/bin/echo
+    # on every POSIX system; ``ls`` is also a stable PATH executable.
+    spec = _spec_with_startup_commands([{"command": "ls -la /tmp"}])
+    # Act
+    result = preflight_startup_commands(spec)
+    # Assert
+    assert result.ok is True
+
+
+def test_preflight_ok_for_shell_builtin_echo() -> None:
+    # Arrange — ``echo`` is in the builtins allowlist.
+    spec = _spec_with_startup_commands([{"command": "echo hello"}])
+    # Act
+    result = preflight_startup_commands(spec)
+    # Assert
+    assert result.ok is True
+
+
+def test_preflight_ok_for_absolute_path_command() -> None:
+    # Arrange — absolute path commands are pass-through (we can't
+    # introspect SIF-internal paths from the host).
+    spec = _spec_with_startup_commands(
+        [{"command": "/opt/scitex/bin/this-does-not-exist-on-host arg"}]
+    )
+    # Act
+    result = preflight_startup_commands(spec)
+    # Assert
+    assert result.ok is True
+
+
+def test_preflight_ok_for_relative_path_command() -> None:
+    # Arrange
+    spec = _spec_with_startup_commands([{"command": "./does-not-exist-relative-x"}])
+    # Act
+    result = preflight_startup_commands(spec)
+    # Assert
+    assert result.ok is True
+
+
+def test_preflight_ok_for_variable_prefixed_command() -> None:
+    # Arrange — ``$HOME/bin/x`` is pass-through; we can't expand
+    # ``$HOME`` against the container's env from the host.
+    spec = _spec_with_startup_commands(
+        [{"command": "$HOME/bin/never-exists-on-host-tool"}]
+    )
+    # Act
+    result = preflight_startup_commands(spec)
+    # Assert
+    assert result.ok is True
+
+
+def test_preflight_ok_for_leading_env_var_assignments() -> None:
+    # Arrange — env-var assignments are dropped; ``echo`` remains.
+    spec = _spec_with_startup_commands([{"command": "FOO=bar BAZ=qux echo done"}])
+    # Act
+    result = preflight_startup_commands(spec)
+    # Assert
+    assert result.ok is True
+
+
+def test_preflight_ok_when_command_is_all_env_assignments() -> None:
+    # Arrange — degenerate but legal. After stripping there is no
+    # bareword to check; we pass-through (style not our problem).
+    spec = _spec_with_startup_commands([{"command": "FOO=bar BAZ=qux"}])
+    # Act
+    result = preflight_startup_commands(spec)
+    # Assert
+    assert result.ok is True
+
+
+def test_preflight_ok_for_empty_command_string() -> None:
+    # Arrange — empty command is dropped by the parser anyway; not
+    # our job to flag.
+    spec = _spec_with_startup_commands([{"command": ""}])
+    # Act
+    result = preflight_startup_commands(spec)
+    # Assert
+    assert result.ok is True
+
+
+# ---------------------------------------------------------------------------
+# preflight_startup_commands — sad path
+# ---------------------------------------------------------------------------
+
+
+def test_preflight_rejects_prompt_text_with_colon() -> None:
+    # Arrange — the clew launcher #70 canonical bug: ``You: ...``
+    # prompt content was placed in startup_commands instead of
+    # startup_prompts. Colon in first bareword is the smoking gun.
+    spec = _spec_with_startup_commands(
+        [{"command": "You: please run the experiment with seed=42"}]
+    )
+    # Act
+    result = preflight_startup_commands(spec)
+    # Assert
+    assert result.issues[0].reason == "first_token_looks_like_prompt_text"
+
+
+def test_preflight_rejects_unknown_bareword() -> None:
+    # Arrange — clearly not a real executable, not a builtin, not
+    # absolute/relative, no colon. Pure typo / nonsense.
+    spec = _spec_with_startup_commands(
+        [{"command": "this-binary-definitely-does-not-exist-on-any-system"}]
+    )
+    # Act
+    result = preflight_startup_commands(spec)
+    # Assert
+    assert result.issues[0].reason == "first_token_not_on_path"
+
+
+def test_preflight_rejects_shlex_unbalanced_quote() -> None:
+    # Arrange — unbalanced single quote makes shlex.split raise.
+    spec = _spec_with_startup_commands([{"command": "echo 'unterminated quote here"}])
+    # Act
+    result = preflight_startup_commands(spec)
+    # Assert
+    assert result.issues[0].reason == "shell_syntax_malformed"
+
+
+def test_preflight_records_index_of_failing_entry() -> None:
+    # Arrange — first entry OK, second entry has prompt-text leak,
+    # third entry OK. Index should pin the bad one at 1.
+    spec = _spec_with_startup_commands(
+        [
+            {"command": "echo first"},
+            {"command": "You: leaked prompt"},
+            {"command": "ls /tmp"},
+        ]
+    )
+    # Act
+    result = preflight_startup_commands(spec)
+    # Assert
+    assert result.issues[0].index == 1
+
+
+def test_preflight_records_verbatim_command_string() -> None:
+    # Arrange
+    spec = _spec_with_startup_commands([{"command": "You: do thing X"}])
+    # Act
+    result = preflight_startup_commands(spec)
+    # Assert
+    assert result.issues[0].command == "You: do thing X"
+
+
+def test_preflight_records_first_token_after_env_strip() -> None:
+    # Arrange — env vars come off the front; the recorded first_token
+    # is the bareword that actually failed, not the K=V prefix.
+    spec = _spec_with_startup_commands([{"command": "FOO=bar nonexistent-cmd-xyz arg"}])
+    # Act
+    result = preflight_startup_commands(spec)
+    # Assert
+    assert result.issues[0].first_token == "nonexistent-cmd-xyz"
+
+
+def test_preflight_emits_every_miss_in_input_order() -> None:
+    # Arrange — two bad entries; both must surface in one round-trip.
+    spec = _spec_with_startup_commands(
+        [
+            {"command": "You: prompt-text-A"},
+            {"command": "alsofake-binary-zyx"},
+        ]
+    )
+    # Act
+    result = preflight_startup_commands(spec)
+    # Assert
+    assert len(result.issues) == 2
+
+
+# ---------------------------------------------------------------------------
+# Defensive — bad spec shape collapses to ok=True
+# ---------------------------------------------------------------------------
+
+
+def test_preflight_ok_when_spec_is_not_a_dict() -> None:
+    # Arrange — caller passed something weird; collapse to ok=True
+    # (downstream validators will reject the shape).
+    spec = ["not", "a", "dict"]
+    # Act
+    result = preflight_startup_commands(spec)  # type: ignore[arg-type]
+    # Assert
+    assert result.ok is True
+
+
+def test_preflight_ok_when_spec_body_is_not_a_dict() -> None:
+    # Arrange
+    spec = {"apiVersion": "scitex-agent-container/v3", "kind": "Agent", "spec": "oops"}
+    # Act
+    result = preflight_startup_commands(spec)
+    # Assert
+    assert result.ok is True
+
+
+def test_preflight_ok_when_startup_commands_is_not_a_list() -> None:
+    # Arrange — wrong shape (dict instead of list); skip entirely.
+    spec = {
+        "apiVersion": "scitex-agent-container/v3",
+        "kind": "Agent",
+        "spec": {"startup_commands": {"command": "echo hi"}},
+    }
+    # Act
+    result = preflight_startup_commands(spec)
+    # Assert
+    assert result.ok is True
+
+
+def test_preflight_skips_entry_that_is_not_a_dict() -> None:
+    # Arrange — one bare-string entry (wrong shape, parser drops it)
+    # and one valid dict entry that should still be evaluated.
+    spec = _spec_with_startup_commands(["just a string entry", {"command": "echo ok"}])
+    # Act
+    result = preflight_startup_commands(spec)
+    # Assert
+    assert result.ok is True
+
+
+def test_preflight_skips_entry_with_non_string_command() -> None:
+    # Arrange
+    spec = _spec_with_startup_commands([{"command": 42}])
+    # Act
+    result = preflight_startup_commands(spec)
+    # Assert
+    assert result.ok is True
+
+
+# ---------------------------------------------------------------------------
+# Failure response body — wire-shape contract
+# ---------------------------------------------------------------------------
+
+
+def test_response_body_kind_is_spec_invalid() -> None:
+    # Arrange
+    result = StartupLintResult(
+        ok=False,
+        issues=(
+            StartupCommandIssue(
+                index=0,
+                command="You: x",
+                first_token="You:",
+                reason="first_token_looks_like_prompt_text",
+            ),
+        ),
+    )
+    # Act
+    body = preflight_failure_response_body(result)
+    # Assert
+    assert body["kind"] == "spec_invalid"
+
+
+def test_response_body_top_level_error_is_present() -> None:
+    # Arrange
+    result = StartupLintResult(
+        ok=False,
+        issues=(
+            StartupCommandIssue(
+                index=0,
+                command="You: x",
+                first_token="You:",
+                reason="first_token_looks_like_prompt_text",
+            ),
+        ),
+    )
+    # Act
+    body = preflight_failure_response_body(result)
+    # Assert
+    assert "startup_commands" in body["error"]
+
+
+def test_response_body_details_carries_array_form() -> None:
+    # Arrange — two failing entries; body must list both.
+    result = StartupLintResult(
+        ok=False,
+        issues=(
+            StartupCommandIssue(
+                index=0,
+                command="You: a",
+                first_token="You:",
+                reason="first_token_looks_like_prompt_text",
+            ),
+            StartupCommandIssue(
+                index=2,
+                command="fake-xyz",
+                first_token="fake-xyz",
+                reason="first_token_not_on_path",
+            ),
+        ),
+    )
+    # Act
+    body = preflight_failure_response_body(result)
+    # Assert
+    assert len(body["details"]["startup_commands"]) == 2
+
+
+def test_response_body_entry_carries_index() -> None:
+    # Arrange
+    result = StartupLintResult(
+        ok=False,
+        issues=(
+            StartupCommandIssue(
+                index=7,
+                command="bad",
+                first_token="bad",
+                reason="first_token_not_on_path",
+            ),
+        ),
+    )
+    # Act
+    body = preflight_failure_response_body(result)
+    # Assert
+    assert body["details"]["startup_commands"][0]["index"] == 7
+
+
+def test_response_body_entry_carries_reason_enum() -> None:
+    # Arrange
+    result = StartupLintResult(
+        ok=False,
+        issues=(
+            StartupCommandIssue(
+                index=0,
+                command="You: x",
+                first_token="You:",
+                reason="first_token_looks_like_prompt_text",
+            ),
+        ),
+    )
+    # Act
+    body = preflight_failure_response_body(result)
+    # Assert
+    assert (
+        body["details"]["startup_commands"][0]["reason"]
+        == "first_token_looks_like_prompt_text"
+    )
+
+
+def test_response_body_entry_carries_suggestion_for_prompt_text_reason() -> None:
+    # Arrange
+    result = StartupLintResult(
+        ok=False,
+        issues=(
+            StartupCommandIssue(
+                index=0,
+                command="You: x",
+                first_token="You:",
+                reason="first_token_looks_like_prompt_text",
+            ),
+        ),
+    )
+    # Act
+    body = preflight_failure_response_body(result)
+    # Assert
+    assert "startup_prompts" in body["details"]["startup_commands"][0]["suggestion"]
+
+
+def test_response_body_entry_carries_suggestion_for_not_on_path_reason() -> None:
+    # Arrange
+    result = StartupLintResult(
+        ok=False,
+        issues=(
+            StartupCommandIssue(
+                index=0,
+                command="myfaketool",
+                first_token="myfaketool",
+                reason="first_token_not_on_path",
+            ),
+        ),
+    )
+    # Act
+    body = preflight_failure_response_body(result)
+    # Assert
+    assert "myfaketool" in body["details"]["startup_commands"][0]["suggestion"]
+
+
+def test_response_body_entry_carries_suggestion_for_shell_syntax_reason() -> None:
+    # Arrange
+    result = StartupLintResult(
+        ok=False,
+        issues=(
+            StartupCommandIssue(
+                index=0,
+                command="echo 'oops",
+                first_token="",
+                reason="shell_syntax_malformed",
+            ),
+        ),
+    )
+    # Act
+    body = preflight_failure_response_body(result)
+    # Assert
+    assert "shlex" in body["details"]["startup_commands"][0]["suggestion"]


### PR DESCRIPTION
## Summary

Follow-up to the SAC-from-SAC PR-1/2/3 series (#287/#288/#289).
Catches the bug class that bit the clew launcher on 2026-06-03 —
agent's CLAUDE-mission prompt text was placed in `spec.startup_commands`
instead of `spec.startup_prompts`, and the SAC runtime faithfully
executed `"You: ..."` as a shell command:

```
/bin/bash: line 1: You: command not found
```

The PR-1 bind preflight (`kind=bind_unresolvable`) does not catch this
class — it only inspects `apptainer.binds`, not `startup_commands`.

## What this PR adds

New module `_listen/_inline_spec_startup_lint.py` that runs AFTER bind
preflight and BEFORE the spec is materialised. For every
`spec.startup_commands[*].command`:

1. `shlex.split` the command, drop leading `KEY=VAL` env assignments
2. Check the first remaining bareword:
   - **`shell_syntax_malformed`** — `shlex.split` raised
   - **`first_token_looks_like_prompt_text`** — first bareword has `:` (the `"You:"` smoking gun)
   - **`first_token_not_on_path`** — `shutil.which()` miss + not in shell-builtin allowlist

Pass-through (trust the operator):
- absolute paths (`/opt/x`), relative paths (`./x`, `../x`)
- variable-prefixed (`\$HOME/bin/x`), tilde-prefixed (`~/bin/x`)
- empty / missing command (parser drops these)

## Wire shape

Lockstep with PR-1's `bind_unresolvable`. Re-uses `kind=\"spec_invalid\"`
(already in use by apiVersion/kind validation in `_inline_spec`); the
per-entry `reason` carries the sub-shade so the consumer branch table
stays small.

```json
{
  \"error\": \"startup_commands[*].command first-token validation failed\",
  \"kind\": \"spec_invalid\",
  \"details\": {
    \"startup_commands\": [
      {
        \"index\": 0,
        \"command\": \"You: please do X\",
        \"first_token\": \"You:\",
        \"reason\": \"first_token_looks_like_prompt_text\",
        \"suggestion\": \"... Did you mean spec.startup_prompts? ...\"
      }
    ]
  }
}
```

Callers branch on `kind` + per-entry `reason` (stable enums); prose
`error` + `suggestion` are for humans.

## Test plan

- [x] 30 unit tests for the lint module (happy path, pass-through cases, all 3 fail-loud reasons, wire-shape contract)
- [x] 4 integration tests wired through `materialize_inline_spec` covering the canonical clew #70 case
- [x] All 416 `_listen/` tests pass
- [x] `ruff check` clean
- [x] AAA markers separated per PA-307/STX-TQ002
- [x] PA-306 (no-mocks): real `shlex.split` + real `shutil.which` against test process \$PATH

## Background

Operator: \`A\` (chose option a — start preflight PR now) at 2026-06-03 evening JST.
Lead: GREEN LIGHT in msg \`4f1fab5238e54398b85564abecf346ee\`.
Clew incident root-cause docs: see clew PR #71 (self-merged) — launcher field misuse (`startup_commands` instead of `startup_prompts`).