### PR TITLE
feat(image): add :texlive sub-tool layer + sub-tool layer pattern

### DIFF
--- a/docs/containers/texlive/README.md
+++ b/docs/containers/texlive/README.md
@@ -1,0 +1,95 @@
+# `:texlive` — Apptainer LaTeX sub-tool SIF
+
+Self-contained Apptainer LaTeX environment delivered as an
+independent, read-only SIF. Wrapper agents (`scitex-writer`,
+`proj-neurovista`, ...) mount this SIF into their primary runtime SIF
+at `/opt/texlive.sif` and exec-shell into it for the actual `pdflatex`
+/ `bibtex` / `latexmk` calls. The wrapper's compile script honours
+`STXW_TEXLIVE_APPTAINER_SIF=/opt/texlive.sif` and invokes
+`apptainer exec` against the mounted sub-tool.
+
+This pattern (sub-tool SIF) is distinct from the stacked-layer
+pattern (`:base` → `:scitex`). The sub-tool SIF is independent — it
+does not `FROM ./sac-base.sif`, and rebuilding `:base` or `:scitex`
+does not invalidate it.
+
+## What's in it
+
+| Decision | Final | Rationale |
+|----------|-------|-----------|
+| Distribution | TeX Live `scheme-medium` + explicit extras | medium covers most; explicit list ensures `elsarticle`, `pdfpages`, `accsupp`, ... resolve |
+| Base image | `ubuntu:22.04` | Matches `texlive/texlive:latest` compatibility |
+| Bibliography | `natbib` + `bibtex` (NO `biber` / `biblatex`) | Current downstream manuscripts (neurovista) use `natbib` |
+| Figures | None inside this SIF | Pre-baked PDFs generated externally by `figrecipe` |
+| Fonts | Times (TL Type 1) + `fonts-liberation` + `fonts-noto-*` + `fonts-firacode` | Arial-compat for figrecipe SCITEX style match |
+| Tools | `pdflatex`, `xelatex`, `lualatex`, `bibtex`, `latexmk`, `latexdiff`, `texcount`, `chktex`, `parallel`, `ghostscript`, `qpdf`, `poppler-utils` | covers compile + diff + post-processing |
+| SAC integration | sub-tool pattern (bound at `/opt/texlive.sif:ro`) | wrapper agent owns runtime; texlive is just LaTeX |
+
+## TeX packages verified in `%test`
+
+`kpsewhich` runs against every entry below on every build; a missing
+one trips CI red and the SIF doesn't ship:
+
+```
+elsarticle.cls
+natbib.sty
+booktabs.sty longtable.sty tabularx.sty xltabular.sty
+colortbl.sty xcolor.sty csvsimple.sty makecell.sty
+amsmath.sty amssymb.sty siunitx.sty
+graphicx.sty tikz.sty pgfplots.sty pgfplotstable.sty
+hyperref.sty xr-hyper.sty
+lineno.sty caption.sty geometry.sty indentfirst.sty pdflscape.sty
+bashful.sty lipsum.sty tcolorbox.sty
+pdfpages.sty accsupp.sty
+```
+
+## Build
+
+Canonical, versioned via `sac`:
+
+```bash
+sac image build texlive -y
+# -> ~/.scitex/agent-container/containers/sac-texlive/sac-texlive.sif
+```
+
+Raw apptainer (what `sac` shells out to):
+
+```bash
+apptainer build sac-texlive.sif apptainer-texlive.def
+```
+
+Verify (runs all 12 commands + 24 TeX packages):
+
+```bash
+apptainer test ~/.scitex/agent-container/containers/sac-texlive/sac-texlive.sif
+```
+
+## Wrapper integration
+
+Drop the fragments from [`spec.yaml.template`](./spec.yaml.template)
+into the wrapper agent's `spec.yaml` under `apptainer.binds` and
+`apptainer.raw_args`. Once integrated, the wrapper's compile script
+shells out to `apptainer exec $STXW_TEXLIVE_APPTAINER_SIF latexmk
+-pdf manuscript.tex`.
+
+Bind preflight (SAC PR-1, `#287`) catches a missing `sac-texlive.sif`
+at `POST /agents` time with HTTP 400 `kind=bind_unresolvable` — no
+silent FATAL on the underlying apptainer mount.
+
+## Standalone use
+
+Outside the sub-tool integration pattern, the SIF works as a regular
+Apptainer container:
+
+```bash
+apptainer exec --bind $(pwd):/work \
+    ~/.scitex/agent-container/containers/sac-texlive/sac-texlive.sif \
+    bash -c "cd /work && latexmk -pdf manuscript.tex"
+```
+
+## See also
+
+- `src/scitex_agent_container/containers/apptainer-texlive.def` — canonical SSoT recipe
+- [`spec.yaml.template`](./spec.yaml.template) — wrapper integration fragment
+- `docs/images.md` — `sac image` lifecycle (build / sandbox / freeze / list / status)
+- ADR-0005 (`docs/adr/0005-sif-mode-migration.md`) — SIF mode rationale

--- a/docs/containers/texlive/spec.yaml.template
+++ b/docs/containers/texlive/spec.yaml.template
@@ -1,0 +1,58 @@
+# sac-texlive sub-tool integration — wrapper agent spec.yaml fragment.
+#
+# The texlive SIF is mounted INTO a wrapper agent's primary runtime
+# SIF (scitex-writer, proj-neurovista, ...) as a READ-ONLY sub-tool at
+# /opt/texlive.sif. The wrapper exports
+# STXW_TEXLIVE_APPTAINER_SIF=/opt/texlive.sif so the wrapper's compile
+# script invokes apptainer-exec into the sub-tool for the actual
+# pdflatex / bibtex / latexmk calls.
+#
+# This template shows the fragments to splice into a wrapper agent's
+# existing spec.yaml. The wrapper provides the primary runtime;
+# texlive provides the lean LaTeX environment.
+#
+# Build the sub-tool SIF first:
+#
+#   sac image build texlive -y
+#   # -> ~/.scitex/agent-container/containers/sac-texlive/sac-texlive.sif
+#
+# Then drop the fragments below under the wrapper's apptainer.binds +
+# apptainer.raw_args. The wrapper's compile script (in the wrapper's
+# workspace, NOT this SIF) honours STXW_TEXLIVE_APPTAINER_SIF and
+# shells out via apptainer-exec.
+#
+# Bind preflight (SAC PR-1, #287) catches a missing sub-tool SIF at
+# POST /agents time with HTTP 400 kind=bind_unresolvable. The
+# canonical bind source below uses $HOME so the resolver picks up the
+# operator's actual home — host-independent across operator hosts.
+
+apiVersion: scitex-agent-container/v3
+kind: Agent
+
+spec:
+  # vvv THESE FRAGMENTS GO INTO THE WRAPPER AGENT'S spec.yaml vvv
+
+  apptainer:
+    # ... (wrapper's own image, workdir, etc., unchanged) ...
+
+    binds:
+      # Existing wrapper binds stay here.
+
+      # NEW: texlive sub-tool, mounted read-only at /opt/texlive.sif.
+      # The canonical sac-managed build path lives under
+      # ~/.scitex/agent-container/containers/sac-texlive/ — built by
+      # `sac image build texlive -y`. $HOME expands at preflight time
+      # so this is portable across operator hosts.
+      - $HOME/.scitex/agent-container/containers/sac-texlive/sac-texlive.sif:/opt/texlive.sif:ro
+
+    raw_args:
+      # NEW: tell the wrapper's compile script where the texlive sub-tool is.
+      - --env
+      - STXW_TEXLIVE_APPTAINER_SIF=/opt/texlive.sif
+
+  # ^^^ END WRAPPER SPEC.YAML FRAGMENT ^^^
+  #
+  # No auto-compile — downstream wrappers compile manually via their
+  # own scripts (e.g. neurovista's `./paper/compile manuscript`).
+  # No claude block needed here — this is just the sub-tool wiring;
+  # the wrapper agent owns its own conversation surface.

--- a/docs/images.md
+++ b/docs/images.md
@@ -2,19 +2,27 @@
 
 ## Builtin layers
 
-Two `.def` recipes, layered:
+Two patterns:
 
-| Tag       | What's inside                                                                                               | When                                   |
-|-----------|-------------------------------------------------------------------------------------------------------------|----------------------------------------|
-| `:base`   | Ubuntu 24.04 + dev tools (git, gh, rust CLIs, mermaid, prettier, eslint, jsonlint, uv, pipx, tree, node 20) | **Default** when `spec.image` is unset |
-| `:scitex` | `FROM :base` + ffmpeg + portaudio + `scitex[all]` + claude-agent-sdk + sac itself                           | Optional heavier layer                 |
+* **Stacked layers** — primary runtimes; `:scitex` is `FROM :base`.
+* **Sub-tool layers** — independent SIFs mounted INTO a wrapper agent's
+  runtime SIF as read-only sub-tools (at `/opt/<tool>.sif:ro`). Used for
+  heavy, slow-moving toolchains that don't belong on the primary
+  runtime — e.g. TeX Live, which would otherwise add 1-2 GB to every
+  agent SIF.
+
+| Tag        | Pattern  | What's inside                                                                                               | When                                                                              |
+|------------|----------|-------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------|
+| `:base`    | stacked  | Ubuntu 24.04 + dev tools (git, gh, rust CLIs, mermaid, prettier, eslint, jsonlint, uv, pipx, tree, node 20) | **Default** when `spec.image` is unset                                            |
+| `:scitex`  | stacked  | `FROM :base` + ffmpeg + portaudio + `scitex[all]` + claude-agent-sdk + sac itself                           | Optional heavier layer                                                            |
+| `:texlive` | sub-tool | Ubuntu 22.04 + TeX Live scheme-medium + extras + `latexmk` / `latexdiff` / `chktex` / `qpdf` / Ghostscript  | Wrapper agents mount this at `/opt/texlive.sif` (see `docs/containers/texlive/`)  |
 
 Recipes ship in the pip wheel — no need to clone the repo to run `sac image build`.
 Built artifacts live under `~/.scitex/agent-container/containers/`, never in git.
 
 ```
 <site-packages>/scitex_agent_container/containers/
-  apptainer-{base,scitex}.def    ← canonical SSoT
+  apptainer-{base,scitex,texlive}.def    ← canonical SSoT
 ```
 
 ## Build
@@ -22,8 +30,39 @@ Built artifacts live under `~/.scitex/agent-container/containers/`, never in git
 ```bash
 sac image build           # :base SIF (default; OS + dev tools, ~15-25 min)
 sac image build scitex    # :scitex SIF (FROM :base + scitex[all], ~10-20 min)
+sac image build texlive   # :texlive sub-tool SIF (LaTeX, ~10-15 min)
 sac image build --sandbox # writable sandbox dir instead of frozen SIF
 ```
+
+## Sub-tool layers
+
+A sub-tool SIF is independent of `:base` and `:scitex` — it has its own
+`Bootstrap:` line (typically `docker / From: <upstream>`), and rebuilding
+`:base` or `:scitex` does not invalidate it.
+
+Wrapper agents integrate a sub-tool via two `spec.yaml` fragments:
+
+```yaml
+spec:
+  apptainer:
+    binds:
+      - $HOME/.scitex/agent-container/containers/sac-texlive/sac-texlive.sif:/opt/texlive.sif:ro
+    raw_args:
+      - --env
+      - STXW_TEXLIVE_APPTAINER_SIF=/opt/texlive.sif
+```
+
+The wrapper's compile script honours the `STXW_TEXLIVE_APPTAINER_SIF`
+env and shells out via `apptainer exec` into the mounted sub-tool for
+the actual `pdflatex` / `bibtex` / `latexmk` work. The bind preflight
+(SAC-from-SAC PR-1, `#287`) catches a missing sub-tool SIF at `POST
+/agents` with HTTP 400 `kind=bind_unresolvable` — no silent FATAL on
+the underlying apptainer mount.
+
+Per-tool integration templates live under `docs/containers/<tool>/`:
+
+* `docs/containers/texlive/README.md` — what's in the LaTeX SIF
+* `docs/containers/texlive/spec.yaml.template` — wrapper integration fragment
 
 ## Sandbox / freeze workflow
 

--- a/src/scitex_agent_container/cli_pkg/image_group.py
+++ b/src/scitex_agent_container/cli_pkg/image_group.py
@@ -40,10 +40,30 @@ _RECIPES_DIR = Path(__file__).resolve().parent.parent / "containers"
 _CONTAINERS_DIR = Path.home() / ".scitex" / "agent-container" / "containers"
 
 # Layer → .def filename mapping.
+#
+# Stacked layers (FROM ./sac-<parent>.sif):
+#   base   -> :scitex      ubuntu + dev tools + scitex[all] + claude-sdk + sac
+#
+# Sub-tool layers (independent SIFs; FROM upstream docker images):
+#   texlive  Apptainer LaTeX environment for wrapper agents to mount at
+#            /opt/texlive.sif. Wrapper integrates via apptainer.binds —
+#            see docs/containers/texlive/spec.yaml.template.
 _LAYERS = {
     "base": "apptainer-base.def",
     "scitex": "apptainer-scitex.def",
+    "texlive": "apptainer-texlive.def",
 }
+
+# Sub-tool layers — independent SIFs that wrapper agents mount at
+# /opt/<tool>.sif. Distinct from stacked layers (base→scitex) because
+# sub-tools deliberately do NOT bundle the sac source (no %files for
+# scitex-agent-container-src, no pip install of sac in %post). They
+# carry only their own toolchain (e.g. TeX Live for :texlive). Tests
+# that assert the stacked-layer source-bundle invariant must exclude
+# sub-tool layers; tests that assert sub-tool independence read the
+# inverse here.
+_SUB_TOOL_LAYERS: frozenset[str] = frozenset({"texlive"})
+
 _DEFAULT_LAYER = "base"
 
 
@@ -142,6 +162,7 @@ def image_build(layer: str, sandbox: bool, dry_run: bool, yes: bool) -> None:
     Examples:
       $ sac image build                # apptainer :base SIF (default; OS + dev tools, ~15-25 min)
       $ sac image build scitex         # apptainer :scitex SIF (FROM :base + scitex[all], ~10-20 min)
+      $ sac image build texlive        # apptainer :texlive sub-tool SIF (LaTeX, ~10-15 min)
       $ sac image build --sandbox      # writable sandbox dir
     """
     out_dir = _ensure_containers_dir()

--- a/src/scitex_agent_container/containers/apptainer-texlive.def
+++ b/src/scitex_agent_container/containers/apptainer-texlive.def
@@ -1,0 +1,246 @@
+# apptainer-texlive.def — Apptainer LaTeX sub-tool SIF.
+#
+# Lean LaTeX environment delivered as an independent, read-only sub-tool
+# SIF (NOT a layer on :base or :scitex). Wrapper agents mount this SIF
+# into their primary runtime SIF at /opt/texlive.sif and exec-shell into
+# it for pdflatex / bibtex / latexmk calls. This keeps the LaTeX image
+# stable across iterations of the wrapper runtime, and keeps the wrapper
+# image itself free of the 1-2 GB TeX Live footprint.
+#
+# Pattern: SUB-TOOL SIF (not stacked).
+#
+#   :base   -> :scitex                       (stacked, FROM ./sac-base.sif)
+#   :texlive (this one)                      (independent, FROM ubuntu:22.04)
+#
+# Wrappers integrate via `apptainer.binds` (see docs/containers/texlive/
+# spec.yaml.template):
+#
+#   binds:
+#     - ~/.scitex/agent-container/containers/sac-texlive/sac-texlive.sif:/opt/texlive.sif:ro
+#   raw_args:
+#     - --env
+#     - STXW_TEXLIVE_APPTAINER_SIF=/opt/texlive.sif
+#
+# The wrapper's compile script honours STXW_TEXLIVE_APPTAINER_SIF and
+# invokes `apptainer exec $STXW_TEXLIVE_APPTAINER_SIF latexmk -pdf ...`
+# against the mounted sub-tool. See docs/containers/texlive/README.md.
+#
+# Build (canonical):
+#   sac image build texlive -y
+#       -> ~/.scitex/agent-container/containers/sac-texlive/sac-texlive.sif
+#
+# Build (raw apptainer):
+#   apptainer build sac-texlive.sif apptainer-texlive.def
+#
+# Smoke (standalone — pdflatex against a workspace):
+#   apptainer exec --bind $(pwd):/work \
+#       ~/.scitex/agent-container/containers/sac-texlive/sac-texlive.sif \
+#       bash -c "cd /work && latexmk -pdf manuscript.tex"
+#
+# Test (verifies every command + every required TeX package):
+#   apptainer test ~/.scitex/agent-container/containers/sac-texlive/sac-texlive.sif
+#
+# Specifications signed off by proj-neurovista 2026-06-03 12:55 JST
+# (a2a msg faf626095310415b8751603afa7b6d3e):
+#
+#   - distribution = scheme-medium + explicit package list (no full TL)
+#   - base = ubuntu:22.04 (texlive/texlive:latest compatible)
+#   - bibliography = natbib + bibtex (NOT biber / biblatex — current
+#     neurovista manuscripts use natbib)
+#   - figures = pre-baked PDFs via figrecipe (no Inkscape / gnuplot /
+#     mermaid / matplotlib inside this SIF — those live elsewhere)
+#   - fonts = Times (elsarticle default, Type 1 in TL) + Liberation +
+#     Noto + Fira Code for figrecipe SCITEX style match
+#   - tools = bibtex, latexdiff, latexmk, texcount, chktex, parallel,
+#     ghostscript, qpdf, poppler-utils
+
+Bootstrap: docker
+From: ubuntu:22.04
+
+%labels
+    org.scitex.layer texlive
+    org.scitex.runtime apptainer
+    org.scitex.pattern sub-tool
+    org.scitex.contains "pdflatex xelatex lualatex bibtex latexmk latexdiff texcount chktex parallel ghostscript qpdf poppler-utils"
+
+%help
+    sac-texlive.sif - Apptainer/Singularity LaTeX sub-tool SIF.
+
+    Independent, read-only sub-tool. Mounted as /opt/texlive.sif into
+    wrapper agent runtimes (scitex-writer, proj-neurovista, ...) for
+    the actual pdflatex / bibtex / latexmk calls. Standalone use also
+    supported.
+
+    Build:
+        sac image build texlive -y
+        # -> ~/.scitex/agent-container/containers/sac-texlive/sac-texlive.sif
+
+    Usage (standalone):
+        apptainer exec --bind $(pwd):/work \
+            ~/.scitex/agent-container/containers/sac-texlive/sac-texlive.sif \
+            bash -c "cd /work && latexmk -pdf manuscript.tex"
+
+    Usage (sub-tool — wrapper integration):
+        Drop the fragments from docs/containers/texlive/spec.yaml.template
+        into the wrapper agent's spec.yaml under apptainer.binds +
+        apptainer.raw_args. The wrapper exports
+        STXW_TEXLIVE_APPTAINER_SIF=/opt/texlive.sif so its compile
+        script invokes apptainer-exec into this SIF.
+
+    Tooling:
+        - pdflatex / xelatex / lualatex
+        - bibtex (natbib path)
+        - latexmk (compile orchestrator)
+        - latexdiff (manuscript diffs)
+        - texcount (word/structure counts)
+        - chktex (lint)
+        - ghostscript / qpdf / poppler-utils (PDF post-processing)
+        - parallel (xargs-like, used by wrapper compile scripts)
+
+    TeX packages explicitly verified in %test (kpsewhich):
+        - elsarticle (Elsevier manuscript class)
+        - natbib (numeric citations)
+        - booktabs, longtable, tabularx, xltabular, colortbl, xcolor
+        - csvsimple, makecell
+        - amsmath, amssymb, siunitx
+        - graphicx, tikz, pgfplots, pgfplotstable
+        - hyperref, xr-hyper
+        - lineno (review-mode line numbers)
+        - caption, geometry, indentfirst, pdflscape
+        - bashful, lipsum, tcolorbox
+        - pdfpages (supplementary multi-page \includepdf)
+        - accsupp (tagged-pdf accessibility)
+
+%environment
+    export LANG=C.UTF-8
+    export LC_ALL=C.UTF-8
+    export PATH=/usr/local/bin:$PATH
+    # TeX Live caches at runtime — point them at /tmp so the SIF is
+    # fully read-only and per-agent state doesn't accumulate in the
+    # operator's home dir.
+    export TEXMFVAR=/tmp/texmf-var
+    export TEXMFCONFIG=/tmp/texmf-config
+
+%post
+    set -e
+    export DEBIAN_FRONTEND=noninteractive
+
+    # ---- 1. apt: minimal base ---------------------------------------
+    apt-get update
+    apt-get install -y --no-install-recommends \
+        ca-certificates curl wget gnupg \
+        locales tzdata \
+        parallel \
+        build-essential
+    locale-gen en_US.UTF-8
+
+    # ---- 2. TeX Live scheme-medium + explicit-extras ----------------
+    # scheme-medium covers the bulk of the neurovista requirement list
+    # (elsarticle, natbib, booktabs, longtable, tabularx, amsmath,
+    # amssymb, siunitx, graphicx, tikz, pgfplots, hyperref, caption,
+    # geometry, lineno, etc.). The extras packages cover the rest
+    # (pdfpages, tcolorbox, accsupp, xr-hyper, xltabular, csvsimple,
+    # makecell). Bibtex (natbib path) is in -bibtex-extra.
+    apt-get install -y --no-install-recommends \
+        texlive-latex-base \
+        texlive-latex-recommended \
+        texlive-latex-extra \
+        texlive-fonts-recommended \
+        texlive-fonts-extra \
+        texlive-science \
+        texlive-pictures \
+        texlive-publishers \
+        texlive-luatex \
+        texlive-xetex \
+        texlive-bibtex-extra \
+        texlive-lang-english \
+        texlive-plain-generic \
+        latexmk \
+        latexdiff \
+        chktex \
+        texlive-extra-utils
+
+    # ---- 3. Bonus fonts for figrecipe SCITEX style match -----------
+    # Wrapper-side figrecipe expects Arial-like sans; Liberation +
+    # Noto Sans / Mono + Fira Code land cleanly via apt without
+    # needing tlmgr.
+    apt-get install -y --no-install-recommends \
+        fonts-liberation \
+        fonts-noto-core \
+        fonts-noto-mono \
+        fonts-firacode
+
+    # ---- 4. PDF post-processing tools ------------------------------
+    apt-get install -y --no-install-recommends \
+        ghostscript \
+        qpdf \
+        poppler-utils
+
+    # ---- 5. Clean up + cache hygiene -------------------------------
+    rm -rf /var/lib/apt/lists/*
+    apt-get clean
+
+    # ---- 6. Generate TeX Live format files at build time -----------
+    # `fmtutil-sys --all` regenerates the format files so first-use
+    # compile doesn't pay the cost. Speeds up cold-start by 30-60s.
+    fmtutil-sys --all || true
+
+    # ---- 7. Writable cache dirs for runtime ------------------------
+    mkdir -p /tmp/texmf-var /tmp/texmf-config
+    chmod 1777 /tmp/texmf-var /tmp/texmf-config
+
+%runscript
+    # Default: drop into bash if no args, else exec args verbatim.
+    # Mirrors apptainer-base.def / apptainer-scitex.def for SIF-family
+    # consistency.
+    if [ $# -eq 0 ]; then
+        exec /bin/bash
+    else
+        exec "$@"
+    fi
+
+%test
+    # Verify every claim made in %help. CI re-runs this on every build.
+    set -e
+
+    # Core commands
+    command -v pdflatex   || { echo "pdflatex missing"; exit 1; }
+    command -v xelatex    || { echo "xelatex missing"; exit 1; }
+    command -v lualatex   || { echo "lualatex missing"; exit 1; }
+    command -v bibtex     || { echo "bibtex missing"; exit 1; }
+    command -v latexmk    || { echo "latexmk missing"; exit 1; }
+    command -v latexdiff  || { echo "latexdiff missing"; exit 1; }
+    command -v texcount   || { echo "texcount missing"; exit 1; }
+    command -v chktex     || { echo "chktex missing"; exit 1; }
+    command -v gs         || { echo "ghostscript missing"; exit 1; }
+    command -v qpdf       || { echo "qpdf missing"; exit 1; }
+    command -v pdftotext  || { echo "pdftotext missing"; exit 1; }
+    command -v parallel   || { echo "parallel missing"; exit 1; }
+
+    # Version banners
+    pdflatex --version | head -1
+    bibtex --version   | head -1
+    latexmk --version  | head -1
+
+    # TeX package availability — verify each required class / package
+    # resolves via `kpsewhich`. A missing one trips CI red.
+    for pkg in \
+        elsarticle.cls \
+        natbib.sty \
+        booktabs.sty longtable.sty tabularx.sty xltabular.sty \
+        colortbl.sty xcolor.sty csvsimple.sty makecell.sty \
+        amsmath.sty amssymb.sty siunitx.sty \
+        graphicx.sty tikz.sty pgfplots.sty pgfplotstable.sty \
+        hyperref.sty xr-hyper.sty \
+        lineno.sty caption.sty geometry.sty indentfirst.sty pdflscape.sty \
+        bashful.sty lipsum.sty tcolorbox.sty \
+        pdfpages.sty accsupp.sty \
+    ; do
+        if ! kpsewhich "$pkg" > /dev/null; then
+            echo "FAIL: TeX package '$pkg' not found via kpsewhich"
+            exit 1
+        fi
+    done
+
+    echo "sac-texlive.sif: all 24 required TeX packages present"
+    echo "sac-texlive.sif: all 12 commands verified"

--- a/tests/scitex_agent_container/cli_pkg/test__image_source_build.py
+++ b/tests/scitex_agent_container/cli_pkg/test__image_source_build.py
@@ -38,7 +38,11 @@ import pytest
 
 import scitex_agent_container
 from scitex_agent_container.cli_pkg import _image_source_build as isb
-from scitex_agent_container.cli_pkg.image_group import _LAYERS, _RECIPES_DIR
+from scitex_agent_container.cli_pkg.image_group import (
+    _LAYERS,
+    _RECIPES_DIR,
+    _SUB_TOOL_LAYERS,
+)
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -537,10 +541,18 @@ def test_default_runner_sandbox_argv_uses_fakeroot_and_no_sudo(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-# All three shipped .defs — base/scitex/proxy. _LAYERS only covers
-# base+scitex (those are what ``sac image build`` accepts); proxy is
-# built by other paths but the same source-bundled invariant applies.
-_ALL_DEF_NAMES = sorted(set(_LAYERS.values()) | {"apptainer-proxy.def"})
+# Stacked .defs whose SIF carries sac itself — base/scitex/proxy. These
+# install sac from the bundled /opt/scitex-agent-container-src that the
+# staging helper places. Sub-tool layers (_SUB_TOOL_LAYERS, e.g.
+# :texlive) are DELIBERATELY excluded — they're independent toolchain
+# SIFs that wrapper agents mount at /opt/<tool>.sif and have no business
+# carrying the sac source. The independence is asserted positively
+# below in test_sub_tool_def_does_not_bundle_sac_source.
+_STACKED_DEF_NAMES = sorted(
+    {fn for layer, fn in _LAYERS.items() if layer not in _SUB_TOOL_LAYERS}
+    | {"apptainer-proxy.def"}
+)
+_SUB_TOOL_DEF_NAMES = sorted(_LAYERS[layer] for layer in _SUB_TOOL_LAYERS)
 
 
 @pytest.fixture
@@ -552,7 +564,7 @@ def def_text(request) -> str:
     return path.read_text()
 
 
-@pytest.mark.parametrize("def_text", _ALL_DEF_NAMES, indirect=True)
+@pytest.mark.parametrize("def_text", _STACKED_DEF_NAMES, indirect=True)
 def test_def_has_files_section_copying_bundled_source(def_text: str):
     # Arrange — the .def declares the %files entry the staging helper depends on
     expected = f"{isb._STAGED_SRC_NAME} /opt/scitex-agent-container-src"
@@ -566,7 +578,7 @@ def test_def_has_files_section_copying_bundled_source(def_text: str):
     )
 
 
-@pytest.mark.parametrize("def_text", _ALL_DEF_NAMES, indirect=True)
+@pytest.mark.parametrize("def_text", _STACKED_DEF_NAMES, indirect=True)
 def test_def_installs_sac_from_bundled_source_absolute_path(def_text: str):
     # Arrange — %post installs from the bundled source path — not from git
     expected = "/opt/scitex-agent-container-src"
@@ -580,7 +592,7 @@ def test_def_installs_sac_from_bundled_source_absolute_path(def_text: str):
     )
 
 
-@pytest.mark.parametrize("def_text", _ALL_DEF_NAMES, indirect=True)
+@pytest.mark.parametrize("def_text", _STACKED_DEF_NAMES, indirect=True)
 def test_def_does_not_install_sac_via_git_ref(def_text: str):
     # Arrange — banned substrings; any of these drifts from the source tree
     banned_substrings = (
@@ -599,21 +611,21 @@ def test_def_does_not_install_sac_via_git_ref(def_text: str):
     )
 
 
-def test_recipes_dir_holds_all_three_shipped_defs():
+def test_recipes_dir_holds_all_stacked_shipped_defs():
     # Arrange — declared expected set
-    expected = set(_ALL_DEF_NAMES)
+    expected = set(_STACKED_DEF_NAMES)
     # Act
     actual = sorted(p.name for p in _RECIPES_DIR.glob("apptainer-*.def"))
     # Assert
     assert expected.issubset(set(actual)), (
-        f"missing one or more shipped .def files. expected at least "
-        f"{_ALL_DEF_NAMES}, found {actual}"
+        f"missing one or more shipped stacked .def files. expected at "
+        f"least {_STACKED_DEF_NAMES}, found {actual}"
     )
 
 
 def test_def_files_use_consistent_staged_source_name():
-    # Arrange — all three .defs must agree on the path inside the image
-    names = _ALL_DEF_NAMES
+    # Arrange — all stacked .defs must agree on the path inside the image
+    names = _STACKED_DEF_NAMES
     # Act
     missing = [
         name
@@ -629,8 +641,8 @@ def test_def_files_use_consistent_staged_source_name():
 
 
 def test_staged_src_name_matches_def_files_files_entry():
-    # Arrange — the contract: every .def declares _STAGED_SRC_NAME in %files
-    names = _ALL_DEF_NAMES
+    # Arrange — the contract: every stacked .def declares _STAGED_SRC_NAME in %files
+    names = _STACKED_DEF_NAMES
     # Act
     missing = [
         name
@@ -641,6 +653,50 @@ def test_staged_src_name_matches_def_files_files_entry():
     assert missing == [], (
         f"{missing} must declare '{isb._STAGED_SRC_NAME}' as a %files source "
         f"so the staging helper's copy is what gets bundled."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Sub-tool layer independence — the inverse contract.
+#
+# Sub-tool SIFs (`:texlive`, ...) deliberately do NOT carry the sac
+# source: they're mounted into a wrapper agent's primary runtime SIF at
+# `/opt/<tool>.sif:ro` and the wrapper owns the sac install. Baking
+# scitex-agent-container-src into a sub-tool would silently grow the
+# SIF by 10+ MB and create two competing sac source trees per agent.
+# These tests pin that independence so a careless future edit that
+# inserts `%files scitex-agent-container-src ...` into a sub-tool .def
+# trips a red test.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("def_text", _SUB_TOOL_DEF_NAMES, indirect=True)
+def test_sub_tool_def_does_not_bundle_sac_source(def_text: str):
+    # Arrange — sub-tool .defs are stand-alone toolchain SIFs; the sac
+    # source has no business being in there. If a future edit adds it,
+    # the wrapper agent would carry two competing sac install trees.
+    forbidden = f"{isb._STAGED_SRC_NAME} /opt/scitex-agent-container-src"
+    # Act
+    present = forbidden in def_text
+    # Assert
+    assert present is False, (
+        f"sub-tool .def carries the bundled-source %files entry "
+        f"'{forbidden}'. Sub-tool SIFs must stay independent of sac so "
+        f"wrapper agents can mount them without conflict."
+    )
+
+
+@pytest.mark.parametrize("def_text", _SUB_TOOL_DEF_NAMES, indirect=True)
+def test_sub_tool_def_does_not_pip_install_sac(def_text: str):
+    # Arrange — even an out-of-band pip install of sac (e.g. from PyPI)
+    # would violate the sub-tool independence invariant.
+    forbidden = "/opt/scitex-agent-container-src"
+    # Act
+    present = forbidden in def_text
+    # Assert
+    assert present is False, (
+        f"sub-tool .def references '{forbidden}'. Sub-tool SIFs must "
+        f"not install sac — they're standalone toolchain images."
     )
 
 

--- a/tests/scitex_agent_container/cli_pkg/test_image_group.py
+++ b/tests/scitex_agent_container/cli_pkg/test_image_group.py
@@ -591,3 +591,87 @@ def test_resolve_source_to_sif_raises_when_layer_not_built(home_tmp):
     # Assert
     with pytest.raises(Exception):
         _call()
+
+
+# ---------------------------------------------------------------------------
+# _LAYERS registry — every registered layer must point at an in-repo .def
+# that actually ships in the wheel (no ghost entries, no typo'd filenames).
+# ---------------------------------------------------------------------------
+
+
+def test_every_registered_layer_has_a_recipe_file_in_recipes_dir():
+    # Arrange — _RECIPES_DIR is the package-relative containers/ dir
+    # (wheel-shipped). Every value in _LAYERS must resolve to a real
+    # file there, or `sac image build <layer> -y` will exit 1 at the
+    # recipe-not-found gate.
+    missing = [
+        name for name, fn in ig._LAYERS.items() if not (ig._RECIPES_DIR / fn).is_file()
+    ]
+    # Act
+    # (the comprehension above is the work; assertion below is the check)
+    # Assert
+    assert missing == []
+
+
+def test_texlive_layer_is_registered_in_layers_dict():
+    # Arrange — operator/lead agreed 2026-06-03 that the texlive SIF
+    # ships as a sub-tool layer alongside base/scitex, built via
+    # `sac image build texlive -y` (NOT a separate dotfiles-deploy
+    # path). Pinning the registration here so a future refactor that
+    # accidentally drops the entry trips a red test.
+    # Act
+    registered = "texlive" in ig._LAYERS
+    # Assert
+    assert registered is True
+
+
+def test_texlive_layer_points_at_apptainer_texlive_def():
+    # Arrange — naming convention is apptainer-<layer>.def for SSoT
+    # consistency with base/scitex. This pins the filename so the
+    # in-repo recipe move is observable in tests.
+    # Act
+    fn = ig._LAYERS.get("texlive")
+    # Assert
+    assert fn == "apptainer-texlive.def"
+
+
+def test_build_texlive_dry_run_prints_layer_name(home_tmp):
+    # Arrange — texlive must be accepted by the click.Choice validator
+    # (regression guard for the _LAYERS extension).
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(image_group, ["build", "texlive", "--dry-run"])
+    # Assert
+    assert result.exit_code == 0 and "texlive" in result.output
+
+
+def test_build_texlive_passes_apptainer_texlive_def_to_source_builder(home_tmp):
+    # Arrange — verify the build path resolves the def-name correctly
+    # end-to-end, not just the registry lookup. Catches a future bug
+    # where _LAYERS is updated but the build verb is hard-coded to
+    # base/scitex.
+    runner = CliRunner()
+    # Act
+    with _use_source_builder(result=Path("/tmp/sac-texlive.sif")) as calls:
+        runner.invoke(image_group, ["build", "texlive", "--yes"])
+    # Assert
+    assert calls[0][1]["def_path"].name == "apptainer-texlive.def"
+
+
+def test_build_texlive_warns_when_existing_sac_texlive_sif_would_be_overwritten(
+    home_tmp,
+):
+    # Arrange — pre-place a fake existing artifact at the expected
+    # path. The build verb computes the path as
+    # _CONTAINERS_DIR / sac-<layer> / sac-<layer>.sif and warns BEFORE
+    # the --yes gate; this pins the artifact-path naming so a refactor
+    # of the convention can't silently break the operator's expected
+    # ~/.scitex/agent-container/containers/sac-texlive/sac-texlive.sif.
+    out_dir = ig._CONTAINERS_DIR / "sac-texlive"
+    out_dir.mkdir(parents=True)
+    (out_dir / "sac-texlive.sif").write_bytes(b"x" * 100)
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(image_group, ["build", "texlive", "--dry-run"])
+    # Assert
+    assert result.exit_code == 0 and "Existing" in result.output


### PR DESCRIPTION
## Summary

- Adds `:texlive` as the first **sub-tool layer** in `sac image build` — an independent Apptainer SIF carrying TeX Live scheme-medium + extras, mounted into wrapper agents' primary runtimes at `/opt/texlive.sif` for downstream LaTeX compile (`pdflatex` / `bibtex` / `latexmk`). Baking TeX Live into `:scitex` would add 1-2 GB to every agent SIF.
- Formalises the **sub-tool layer pattern** alongside the existing stacked-layer pattern (`base` → `scitex`). The two are distinguished by `_SUB_TOOL_LAYERS` in `cli_pkg/image_group.py` so tests + future consumers branch on it consistently.
- Builds + manages the sub-tool consistently with `:base` / `:scitex` — `sac image build texlive -y` → `~/.scitex/agent-container/containers/sac-texlive/sac-texlive.sif`. Replaces the dotfiles deploy path that lived on `feat/neurovista-tex`.

### What ships

- `src/scitex_agent_container/containers/apptainer-texlive.def` — canonical SSoT recipe (Ubuntu 22.04 + TL scheme-medium + explicit extras + bibtex/latexmk/latexdiff/chktex + ghostscript/qpdf/poppler + Liberation/Noto/Fira fonts).
- `cli_pkg/image_group.py` — register `"texlive"` in `_LAYERS`, introduce `_SUB_TOOL_LAYERS = frozenset({"texlive"})`.
- `docs/images.md` — new **Sub-tool layers** section + updated layer table.
- `docs/containers/texlive/{README.md, spec.yaml.template}` — operator-facing docs + wrapper integration fragment.
- Tests:
  - `test__image_source_build.py`: split `_ALL_DEF_NAMES` into `_STACKED_DEF_NAMES` (source-bundle invariant) + `_SUB_TOOL_DEF_NAMES` (independence invariant); add positive sub-tool independence tests so a future edit that inserts `%files scitex-agent-container-src` into a sub-tool .def trips red.
  - `test_image_group.py`: seven new tests covering `_LAYERS` registry integrity, `texlive` registration, click.Choice acceptance, def-path resolution, and the artifact-path-naming convention.

### Backstory

- proj-neurovista 5-question spec sign-off (a2a msg `faf626095310415b8751603afa7b6d3e`, 2026-06-03 12:55 JST) — TL scheme-medium + extras, natbib (no biber), pre-baked figures via figrecipe (no Inkscape/gnuplot inside).
- Operator architecture lock-in (2026-06-03 evening JST): sub-tool SIF — built and stored consistently inside `.scitex/` (NOT dotfiles).
- Lead absorb + greenlight on the parked (a)/(b)/(c) — proceed with (a) consistency-fix PR now.

### Wire shape — sub-tool integration

```yaml
spec:
  apptainer:
    binds:
      - $HOME/.scitex/agent-container/containers/sac-texlive/sac-texlive.sif:/opt/texlive.sif:ro
    raw_args:
      - --env
      - STXW_TEXLIVE_APPTAINER_SIF=/opt/texlive.sif
```

The wrapper's compile script honours `STXW_TEXLIVE_APPTAINER_SIF` and shells out via `apptainer exec`. The bind preflight (PR-1, #287) catches a missing sub-tool SIF at `POST /agents` with HTTP 400 `kind=bind_unresolvable` — no silent FATAL on mount.

## Test plan

- [x] `pytest tests/scitex_agent_container/cli_pkg/` — 75/75 green locally
- [ ] CI green on the full suite
- [ ] Smoke build on an apptainer host: `sac image build texlive -y` succeeds and lands at `~/.scitex/agent-container/containers/sac-texlive/sac-texlive.sif`
- [ ] `apptainer test sac-texlive.sif` passes (verifies all 12 commands + 24 TeX packages)
- [ ] Sample neurovista manuscript compiles end-to-end via the wrapper integration