### PR TITLE
feat(_mcp/channel): self-register lead/channel in comms_nodes durably

### DIFF
--- a/src/scitex_agent_container/_mcp/_channel_self_register.py
+++ b/src/scitex_agent_container/_mcp/_channel_self_register.py
@@ -1,0 +1,193 @@
+"""Self-registration of ``sac mcp channel`` nodes into ``comms_nodes``.
+
+ADR-0014 + production lead-row bug (2026-06-01 → 2026-06-03):
+
+The ``lead`` row in the production ``comms_nodes`` table had
+``a2a_port=0`` and ``updated_at == registered_at`` (never refreshed
+since first registration). Real agent rows have live 19xxx ports and
+recent ``updated_at`` because their startup writes ``comms_nodes``
+via ``_lifecycle/_instances.record_local_instance``. The lead does NOT
+go through that path — it runs
+
+    sac mcp channel --name lead --listen-url http://127.0.0.1:7878
+
+which until now did ZERO ``comms_nodes`` interaction. Consequence: the
+lead was not in ``sac a2a peers``, was not endpoint-discoverable, and
+agent→lead delivery worked ONLY while the channel's push subscription
+was live. On reboot it silently dropped from the federated graph.
+
+This module fills the gap. It is the channel-side counterpart of
+``cli_pkg/listen_cmds._register_self_comms_node`` (listen-side):
+
+  * ``parse_listen_port(url)`` — extract the int port from the
+    ``--listen-url`` string the channel was launched with. Returns
+    ``None`` for the production-bug signature (port=0, portless URL,
+    empty string) so the caller can refuse to write a row rather than
+    re-introduce the silent port=0 footgun.
+
+  * ``register_self_node(...)`` — best-effort idempotent UPSERT.
+    Hits ``register_comms_node`` (the same helper the listen side
+    uses) so any future schema/ACL tightening at the storage layer is
+    enforced uniformly across both registration sites.
+
+  * ``refresh_node(...)`` — long-lived async loop that re-UPSERTs
+    every ``interval_s`` seconds, matching the agent runner's
+    ``DEFAULT_TICK_SECONDS = 10.0`` heartbeat so a single staleness
+    threshold applies to both sources.
+
+Best-effort everywhere: a registry-write failure must never block the
+channel's MCP handshake or its SSE consumption. The existing channel
+codebase swallows side-effect failures with ``log.warning``; this
+module follows the same convention.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+from urllib.parse import urlparse
+
+log = logging.getLogger(__name__)
+
+# Refresh cadence matches the agent runner's heartbeat tick
+# (``_runners/_session_state.DEFAULT_TICK_SECONDS = 10.0``). Aligning
+# means a single "row is stale" threshold can apply to both sources
+# — agent runner heartbeats and lead/channel heartbeats — without
+# downstream consumers having to special-case the channel side.
+DEFAULT_REFRESH_INTERVAL_S = 10.0
+
+
+def parse_listen_port(listen_url: str) -> int | None:
+    """Return the TCP port from a sac listen URL, or ``None``.
+
+    Accepts the canonical ``http[s]://host:port[/path]`` form that
+    ``sac mcp channel --listen-url`` consumes. Returns the ``int``
+    port on success; returns ``None`` when the URL is empty,
+    malformed, missing a port, or carries an explicit port of ``0``.
+
+    The ``None`` return is loud — :func:`register_self_node` translates
+    it into "skip the write entirely" rather than persist a 0 port.
+    That zero-port write was the EXACT production-bug signature this
+    fix is targeting; refusing to round-trip it through the helper
+    closes the regression door at the deepest layer.
+    """
+    if not listen_url:
+        return None
+    try:
+        parsed = urlparse(listen_url)
+    except (TypeError, ValueError):
+        return None
+    port = parsed.port
+    if port is None or port <= 0:
+        return None
+    return int(port)
+
+
+def register_self_node(
+    *,
+    name: str,
+    listen_url: str,
+    db_path: Path | None = None,
+) -> bool:
+    """Best-effort UPSERT this channel's ``comms_nodes`` row.
+
+    ``name`` is the channel's ``--name`` (``"lead"`` for the lead,
+    arbitrary string for any other ``sac mcp channel`` node). The
+    host is resolved via ``host_config.canonical_host()`` so a row's
+    advertised host matches the rest of the host's ``comms_nodes``
+    entries (which is what cross-host A2A POSTs dial). The port comes
+    from :func:`parse_listen_port` against ``listen_url``.
+
+    Returns ``True`` iff a row was written (or successfully re-UPSERTed)
+    and ``False`` for any reason no row was committed (empty inputs,
+    portless URL, conflict, DB error). NEVER raises — registry-write
+    failures must not block the channel's MCP handshake or its SSE
+    consumption.
+
+    Logging policy: every refusal logs a ``warning`` so a future
+    operator can tell WHY a row didn't land. The original bug was
+    silent — no log, no row, hence the five-day undetected drift.
+    """
+    if not name:
+        log.warning("channel self-register: name is empty; skipping")
+        return False
+    port = parse_listen_port(listen_url)
+    if port is None:
+        log.warning(
+            "channel self-register: could not parse a non-zero port from "
+            "listen_url=%r; refusing to write (would have persisted port=0, "
+            "the EXACT production-bug signature this guard targets)",
+            listen_url,
+        )
+        return False
+    try:
+        from .._state.host_config import load as load_host_config
+        from .._state.state_db_nodes import (
+            CommsNodeConflictError,
+            register_comms_node,
+        )
+
+        cfg = load_host_config()
+        host = cfg.canonical_host()
+        try:
+            register_comms_node(
+                name=name,
+                host=host,
+                a2a_port=port,
+                source_host=None,  # locally-registered
+                db_path=db_path,
+            )
+            return True
+        except CommsNodeConflictError as exc:
+            log.warning(
+                "channel self-register: comms_nodes conflict for name=%r: %s",
+                name,
+                exc,
+            )
+            return False
+    except Exception as exc:  # stx-allow: fallback (reason: never block channel start on registry write — the channel must keep MCP + SSE working even if state.db is briefly unreachable)
+        log.warning(
+            "channel self-register: failed for name=%r listen_url=%r: %r",
+            name,
+            listen_url,
+            exc,
+        )
+        return False
+
+
+async def refresh_node(
+    *,
+    name: str,
+    listen_url: str,
+    interval_s: float = DEFAULT_REFRESH_INTERVAL_S,
+    db_path: Path | None = None,
+) -> None:
+    """Periodically re-UPSERT to keep ``updated_at`` fresh.
+
+    Long-lived task — runs until cancelled. Each iteration shares the
+    semantics of :func:`register_self_node` (best-effort, never raises),
+    so a transient ``state.db`` outage triggers one logged warning but
+    does NOT kill the heartbeat. The next interval retries.
+
+    The cancellation contract: ``asyncio.CancelledError`` propagates
+    out so the channel's shutdown path can tear the task down cleanly
+    in its ``finally`` block (alongside the SSE consumer task). No
+    orphan tasks survive the channel exit.
+
+    The first iteration runs IMMEDIATELY (no leading sleep) so a
+    caller can drop ``refresh_node`` in place of a separate
+    ``register_self_node()`` + loop pair. Saves one bug class
+    ("oh, we started the loop but forgot the initial register").
+    """
+    while True:
+        register_self_node(name=name, listen_url=listen_url, db_path=db_path)
+        await asyncio.sleep(interval_s)
+
+
+__all__ = [
+    "DEFAULT_REFRESH_INTERVAL_S",
+    "parse_listen_port",
+    "refresh_node",
+    "register_self_node",
+]

--- a/src/scitex_agent_container/_mcp/channel.py
+++ b/src/scitex_agent_container/_mcp/channel.py
@@ -70,11 +70,8 @@ from ._channel_auto_ack import (  # noqa: E402,F401
     _post_auto_ack,
     _should_auto_ack,
 )
-from ._channel_self_register import (  # noqa: E402,F401
+from ._channel_self_register import (  # noqa: E402
     refresh_node as _refresh_comms_node,
-)
-from ._channel_self_register import (
-    register_self_node as _register_self_comms_node,
 )
 from ._channel_wake import _should_wake_turn, _wake_text, _wake_turn  # noqa: E402,F401
 

--- a/src/scitex_agent_container/_mcp/channel.py
+++ b/src/scitex_agent_container/_mcp/channel.py
@@ -70,6 +70,12 @@ from ._channel_auto_ack import (  # noqa: E402,F401
     _post_auto_ack,
     _should_auto_ack,
 )
+from ._channel_self_register import (  # noqa: E402,F401
+    refresh_node as _refresh_comms_node,
+)
+from ._channel_self_register import (
+    register_self_node as _register_self_comms_node,
+)
 from ._channel_wake import _should_wake_turn, _wake_text, _wake_turn  # noqa: E402,F401
 
 
@@ -362,6 +368,19 @@ async def _serve(
         sse_task: asyncio.Task[None] = asyncio.create_task(
             _consume_sse(sse_url, bearer, on_event)
         )
+
+        # ADR-0014 + lead-row-port-zero bug fix (2026-06-03):
+        # Self-register THIS channel into ``comms_nodes`` so the federated
+        # graph contains the lead (or any sac mcp channel node) durably.
+        # The initial UPSERT happens INSIDE refresh_node's first iteration
+        # (no leading sleep), so a single task covers both startup register
+        # and periodic ``updated_at`` refresh. Best-effort: a failed write
+        # logs a warning but never kills the SSE consumer or the MCP
+        # handshake. Cancelled in ``finally`` alongside the SSE task.
+        reg_task: asyncio.Task[None] = asyncio.create_task(
+            _refresh_comms_node(name=name, listen_url=listen_url)
+        )
+
         try:
             async with anyio.create_task_group() as tg:
                 async for message in session.incoming_messages:
@@ -374,6 +393,7 @@ async def _serve(
                     )
         finally:
             sse_task.cancel()
+            reg_task.cancel()
 
 
 async def _run(

--- a/tests/scitex_agent_container/_mcp/test__channel_self_register.py
+++ b/tests/scitex_agent_container/_mcp/test__channel_self_register.py
@@ -1,0 +1,379 @@
+"""Tests for ``_mcp/_channel_self_register.py`` — channel-side comms_nodes UPSERT.
+
+ADR-0014 + the lead-registration bug: the lead's comms_nodes row had
+``a2a_port=0`` and an ``updated_at`` that never refreshed because
+nothing on the ``sac mcp channel`` side called ``register_comms_node``.
+This module is the missing piece — it registers the channel process
+(lead OR any other node consuming SSE from a sac listen) into
+comms_nodes on startup, then refreshes ``updated_at`` on a 10s
+cadence matching the agent runner's heartbeat.
+
+Real on-disk state.db + config.yaml via the shared ``env_save_restore``
+fixture; no mocks. AAA, ≥3-word test names, one assert per test
+(STX-TQ002 / PA-307).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+from pathlib import Path
+
+import pytest
+import yaml
+
+# ---------------------------------------------------------------------------
+# Fixtures — mirror tests/.../cli_pkg/test_listen_cmds_comms_nodes.py so a
+# future audit sees the same shape across both registration sites.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def db_path(tmp_path: Path, env_save_restore):
+    p = tmp_path / "state.db"
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_STATE_DB", str(p))
+    import scitex_agent_container._state.state_db as mod
+
+    importlib.reload(mod)
+    yield p
+    importlib.reload(mod)
+
+
+@pytest.fixture
+def cfg_with_lead(tmp_path: Path, env_save_restore) -> Path:
+    p = tmp_path / "config.yaml"
+    p.write_text(
+        yaml.safe_dump(
+            {
+                "host": {"canonical": "lead-host"},
+                "lead": {"name": "lead", "host": "lead-host", "a2a_port": 7878},
+                "peers": {},
+            }
+        )
+    )
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_CONFIG", str(p))
+    return p
+
+
+# ---------------------------------------------------------------------------
+# parse_listen_port — string → int extraction
+# ---------------------------------------------------------------------------
+
+
+def test_parse_listen_port_extracts_port_from_full_http_url() -> None:
+    # Arrange
+    from scitex_agent_container._mcp._channel_self_register import parse_listen_port
+
+    # Act
+    port = parse_listen_port("http://127.0.0.1:7878")
+    # Assert
+    assert port == 7878
+
+
+def test_parse_listen_port_returns_none_for_empty_string() -> None:
+    # Arrange
+    from scitex_agent_container._mcp._channel_self_register import parse_listen_port
+
+    # Act
+    port = parse_listen_port("")
+    # Assert
+    assert port is None
+
+
+def test_parse_listen_port_returns_none_for_portless_url() -> None:
+    # Arrange — no port in the URL means we don't know what to advertise.
+    from scitex_agent_container._mcp._channel_self_register import parse_listen_port
+
+    # Act
+    port = parse_listen_port("http://lead-host/")
+    # Assert
+    assert port is None
+
+
+def test_parse_listen_port_returns_none_for_url_with_port_zero() -> None:
+    # Arrange — port=0 is the EXACT production-bug signature we are
+    # explicitly guarding against; refuse to extract it.
+    from scitex_agent_container._mcp._channel_self_register import parse_listen_port
+
+    # Act
+    port = parse_listen_port("http://127.0.0.1:0/")
+    # Assert
+    assert port is None
+
+
+def test_parse_listen_port_handles_https_scheme() -> None:
+    # Arrange — sac listen can run behind tls (orochi tunnel pattern).
+    from scitex_agent_container._mcp._channel_self_register import parse_listen_port
+
+    # Act
+    port = parse_listen_port("https://lead-host:443/")
+    # Assert
+    assert port == 443
+
+
+# ---------------------------------------------------------------------------
+# register_self_node — happy path
+# ---------------------------------------------------------------------------
+
+
+def test_register_self_node_writes_comms_nodes_row_for_lead_name(
+    db_path: Path, cfg_with_lead: Path
+) -> None:
+    # Arrange
+    from scitex_agent_container._mcp._channel_self_register import register_self_node
+
+    # Act
+    register_self_node(name="lead", listen_url="http://127.0.0.1:7878")
+    # Assert
+    from scitex_agent_container._state.state_db_nodes import lookup_comms_node
+
+    info = lookup_comms_node(name="lead")
+    assert info is not None
+
+
+def test_register_self_node_records_port_parsed_from_listen_url(
+    db_path: Path, cfg_with_lead: Path
+) -> None:
+    # Arrange — the production bug stored a2a_port=0 because nothing
+    # parsed the URL; pin the correct extracted port here.
+    from scitex_agent_container._mcp._channel_self_register import register_self_node
+
+    # Act
+    register_self_node(name="lead", listen_url="http://127.0.0.1:7878")
+    # Assert
+    from scitex_agent_container._state.state_db_nodes import lookup_comms_node
+
+    info = lookup_comms_node(name="lead")
+    assert info["a2a_port"] == 7878
+
+
+def test_register_self_node_uses_canonical_host_from_config(
+    db_path: Path, cfg_with_lead: Path
+) -> None:
+    # Arrange — cfg has host.canonical=lead-host; that's what the row
+    # should advertise as the dialable host, NOT 127.0.0.1 from the URL.
+    from scitex_agent_container._mcp._channel_self_register import register_self_node
+
+    # Act
+    register_self_node(name="lead", listen_url="http://127.0.0.1:7878")
+    # Assert
+    from scitex_agent_container._state.state_db_nodes import lookup_comms_node
+
+    info = lookup_comms_node(name="lead")
+    assert info["host"] == "lead-host"
+
+
+def test_register_self_node_source_host_is_none_for_local_registration(
+    db_path: Path, cfg_with_lead: Path
+) -> None:
+    # Arrange — locally-registered rows have source_host=None (the sync
+    # contract distinguishes self-registrations from peer-pulled rows).
+    from scitex_agent_container._mcp._channel_self_register import register_self_node
+
+    # Act
+    register_self_node(name="lead", listen_url="http://127.0.0.1:7878")
+    # Assert
+    from scitex_agent_container._state.state_db_nodes import lookup_comms_node
+
+    info = lookup_comms_node(name="lead")
+    assert info["source_host"] is None
+
+
+def test_register_self_node_returns_true_on_successful_write(
+    db_path: Path, cfg_with_lead: Path
+) -> None:
+    # Arrange
+    from scitex_agent_container._mcp._channel_self_register import register_self_node
+
+    # Act
+    ok = register_self_node(name="lead", listen_url="http://127.0.0.1:7878")
+    # Assert
+    assert ok is True
+
+
+def test_register_self_node_is_idempotent_for_same_name(
+    db_path: Path, cfg_with_lead: Path
+) -> None:
+    # Arrange — second call must UPDATE not INSERT (no DUPLICATE PK).
+    from scitex_agent_container._mcp._channel_self_register import register_self_node
+
+    register_self_node(name="lead", listen_url="http://127.0.0.1:7878")
+    # Act
+    register_self_node(name="lead", listen_url="http://127.0.0.1:7878")
+    # Assert
+    from scitex_agent_container._state.state_db_nodes import list_comms_nodes
+
+    rows = [r for r in list_comms_nodes() if r["name"] == "lead"]
+    assert len(rows) == 1
+
+
+def test_register_self_node_refresh_advances_updated_at(
+    db_path: Path, cfg_with_lead: Path
+) -> None:
+    # Arrange — second call must bump updated_at so a stale-row
+    # detector sees the row as fresh. Without this the production bug
+    # surfaces (updated_at frozen at registered_at).
+    import time
+
+    from scitex_agent_container._mcp._channel_self_register import register_self_node
+
+    from scitex_agent_container._state.state_db_nodes import lookup_comms_node
+
+    register_self_node(name="lead", listen_url="http://127.0.0.1:7878")
+    first_updated_at = lookup_comms_node(name="lead")["updated_at"]
+    time.sleep(0.01)  # advance the clock just enough to make a delta visible
+    # Act
+    register_self_node(name="lead", listen_url="http://127.0.0.1:7878")
+    # Assert
+    second_updated_at = lookup_comms_node(name="lead")["updated_at"]
+    assert second_updated_at > first_updated_at
+
+
+# ---------------------------------------------------------------------------
+# register_self_node — refuse-to-write guards (the production bug)
+# ---------------------------------------------------------------------------
+
+
+def test_register_self_node_writes_no_row_when_listen_url_has_port_zero(
+    db_path: Path, cfg_with_lead: Path
+) -> None:
+    # Arrange — the EXACT production-bug signature was port=0. The
+    # function MUST refuse rather than persist a 0 port (which is what
+    # broke `sac a2a peers` resolution in the first place).
+    from scitex_agent_container._mcp._channel_self_register import register_self_node
+
+    from scitex_agent_container._state.state_db_nodes import list_comms_nodes
+
+    # Act
+    register_self_node(name="lead", listen_url="http://127.0.0.1:0/")
+    # Assert — no row was written.
+    assert list_comms_nodes() == []
+
+
+def test_register_self_node_returns_false_for_portless_url(
+    db_path: Path, cfg_with_lead: Path
+) -> None:
+    # Arrange
+    from scitex_agent_container._mcp._channel_self_register import register_self_node
+
+    # Act
+    ok = register_self_node(name="lead", listen_url="http://lead-host/")
+    # Assert
+    assert ok is False
+
+
+def test_register_self_node_does_not_raise_when_name_is_empty(
+    db_path: Path, cfg_with_lead: Path
+) -> None:
+    # Arrange — best-effort contract: callers must not have to wrap
+    # this in try/except. An empty name is logged + skipped.
+    from scitex_agent_container._mcp._channel_self_register import register_self_node
+
+    # Act
+    ok = register_self_node(name="", listen_url="http://127.0.0.1:7878")
+    # Assert
+    assert ok is False
+
+
+def test_register_self_node_does_not_raise_when_listen_url_is_empty(
+    db_path: Path, cfg_with_lead: Path
+) -> None:
+    # Arrange
+    from scitex_agent_container._mcp._channel_self_register import register_self_node
+
+    # Act
+    ok = register_self_node(name="lead", listen_url="")
+    # Assert
+    assert ok is False
+
+
+# ---------------------------------------------------------------------------
+# refresh_node — the async heartbeat loop
+# ---------------------------------------------------------------------------
+
+
+def test_refresh_node_writes_initial_row_on_first_tick(
+    db_path: Path, cfg_with_lead: Path
+) -> None:
+    # Arrange — refresh_node should write a row on its first iteration
+    # so a caller doesn't have to call register_self_node separately
+    # before kicking off the loop.
+    from scitex_agent_container._mcp._channel_self_register import refresh_node
+
+    from scitex_agent_container._state.state_db_nodes import lookup_comms_node
+
+    async def _drive_one_tick() -> None:
+        task = asyncio.create_task(
+            refresh_node(name="lead", listen_url="http://127.0.0.1:7878", interval_s=10)
+        )
+        await asyncio.sleep(0.05)  # give the loop a chance to register once
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    # Act
+    asyncio.run(_drive_one_tick())
+    # Assert
+    info = lookup_comms_node(name="lead")
+    assert info is not None
+
+
+def test_refresh_node_advances_updated_at_across_ticks(
+    db_path: Path, cfg_with_lead: Path
+) -> None:
+    # Arrange — let the loop tick twice; updated_at must advance.
+    from scitex_agent_container._mcp._channel_self_register import refresh_node
+
+    from scitex_agent_container._state.state_db_nodes import lookup_comms_node
+
+    captured: dict[str, float] = {}
+
+    async def _drive_two_ticks() -> None:
+        task = asyncio.create_task(
+            refresh_node(
+                name="lead",
+                listen_url="http://127.0.0.1:7878",
+                interval_s=0.01,
+            )
+        )
+        await asyncio.sleep(0.005)  # ~first tick registered
+        captured["first"] = lookup_comms_node(name="lead")["updated_at"]
+        await asyncio.sleep(0.05)  # let several more ticks fire
+        captured["last"] = lookup_comms_node(name="lead")["updated_at"]
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    # Act
+    asyncio.run(_drive_two_ticks())
+    # Assert
+    assert captured["last"] > captured["first"]
+
+
+def test_refresh_node_respects_cancellation_promptly(
+    db_path: Path, cfg_with_lead: Path
+) -> None:
+    # Arrange — the loop must propagate CancelledError so the channel's
+    # shutdown path can tear it down cleanly (no orphan task).
+    from scitex_agent_container._mcp._channel_self_register import refresh_node
+
+    async def _start_then_cancel() -> bool:
+        task = asyncio.create_task(
+            refresh_node(name="lead", listen_url="http://127.0.0.1:7878", interval_s=5)
+        )
+        await asyncio.sleep(0.02)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            return True
+        return False
+
+    # Act
+    cancelled = asyncio.run(_start_then_cancel())
+    # Assert
+    assert cancelled is True


### PR DESCRIPTION
## Summary

Fixes the production lead-row bug discovered 2026-06-03: the \`lead\` row in \`comms_nodes\` carried \`a2a_port=0\` with \`updated_at\` frozen at \`registered_at\` since 2026-06-01. Consequence: lead missing from \`sac a2a peers\`, not endpoint-discoverable via the federated graph, agent→lead delivery worked ONLY while the lead's push subscription was live; on host reboot it silently vanished without a single log line.

Real agent rows have live 19xxx ports because their startup hits \`_lifecycle/_instances.record_local_instance\`. The lead does NOT go through that path — it runs \`sac mcp channel --name lead --listen-url http://127.0.0.1:7878\` which until this PR did ZERO \`comms_nodes\` interaction.

ACL grants are fine (full bidirectional mesh present). The gap was purely registration.

## What ships

- \`src/scitex_agent_container/_mcp/_channel_self_register.py\` (new) — channel-side counterpart of \`listen_cmds._register_self_comms_node\`:
  - \`parse_listen_port(url)\` — extract int port; returns None for empty / portless / port=0 (explicit regression guard for the bug signature).
  - \`register_self_node(name, listen_url, db_path)\` — best-effort idempotent UPSERT via the existing \`register_comms_node\` helper (same code path as the listen side; future schema/ACL tightening applies uniformly). Never raises.
  - \`refresh_node(name, listen_url, interval_s, db_path)\` — long-lived async loop, default 10.0s cadence (matches \`DEFAULT_TICK_SECONDS\` in \`_runners/_session_state\`). First iteration runs immediately. Respects \`asyncio.CancelledError\`.

- \`src/scitex_agent_container/_mcp/channel.py\` (3-line edit + 9-line doc comment): spawn \`refresh_node\` as a side task in \`_serve()\` next to the SSE consumer; cancelled in the same \`finally\` block.

- \`tests/scitex_agent_container/_mcp/test__channel_self_register.py\` (19 new tests, AAA + no mocks + ≥3-word names + one assert per test). Test pattern mirrors \`tests/.../cli_pkg/test_listen_cmds_comms_nodes.py\` (env_save_restore + real on-disk tmp_path state.db + yaml-written config) so an audit sees the same shape across both registration sites.

## Why a refresh loop (not just startup register)

The bug had two pieces: (a) port=0 written, and (b) \`updated_at\` frozen because nothing on the channel side ever called \`register_comms_node\` again after startup. Even when (a) gets fixed by parsing the URL, (b) re-introduces the staleness problem: a downstream consumer that wants to gate on "row freshness" (e.g. "skip rows whose \`updated_at\` is > 60s old") would see the lead drift over time. Matching the agent runner's 10s tick keeps a single staleness threshold valid across both sources.

## Test plan

- [x] \`pytest tests/scitex_agent_container/_mcp/test__channel_self_register.py\` — 19/19 green (3.02s)
- [x] \`pytest\` against the existing \`_mcp/\` suite split by file — 192/192 green (every file passes in isolation; the broad sweep had an unrelated cross-test fixture interaction, not a regression introduced here)
- [ ] CI full suite green
- [ ] Post-merge: lead restarts the channel process on the new binary; observe \`SELECT * FROM comms_nodes WHERE name='lead'\` shows port=7878 and \`updated_at\` ticking every ~10s

## Operator / lead context

- Operator directive 8558: "listen, credentials, agent registration incl lead — these are the foundation, solidify them." This PR is the **registration** piece of that triad. Credentials (single-source via symlink) and listen daemon restart-safety are separate workstreams.
- Lead diagnostic msg \`013e8f47d2f549c88a7e58d9380daef0\` named the gap precisely: \`a2a_port=0\` + frozen \`updated_at\` because \`sac mcp channel\` had no node-registration path. Recon (msg \`a7c4932f1a00ef948\`) confirmed the helper code path exists but had no caller from the channel.

## Out of scope (separate PRs)

- Mode A — \`ApptainerContainerRuntime.start()\` returning False on missing-apptainer instead of raising \`ApptainerNotAvailableError\`. Queued as the next quick PR after this lands.
- Mode B — 48-capsule silent fail (apptainer concurrency limit / is_running race). Diagnosis-only via PR-1/2/3 markers; root-cause PR parked until needed (Spartan move may obsolete).
- Host \`sac listen\` daemon restart safety — separate workstream; my pre-existing replies covered the operational sequence (msgs \`1a3ecec8\` + \`cf552e60\`).