### PR TITLE
feat(image): generic ~/.scitex/<pkg>/containers/ discovery glob

### DIFF
--- a/docs/images.md
+++ b/docs/images.md
@@ -17,6 +17,31 @@ Built artifacts live under `~/.scitex/agent-container/containers/`, never in git
   apptainer-{base,scitex}.def    ← canonical SSoT
 ```
 
+## Cross-package convention: `~/.scitex/<pkg>/{containers,bin}`
+
+Sac owns `~/.scitex/agent-container/` for its own (base / scitex) artifacts.
+Other scitex-* packages own their own siblings under `~/.scitex/<pkg>/`:
+
+```
+~/.scitex/
+├── agent-container/containers/    ← sac's own SIFs (base, scitex, ...)
+├── writer/containers/             ← scitex-writer's SIFs (texlive, mermaid, ...)
+└── <pkg>/containers/              ← any future package follows the same shape
+```
+
+`sac image list` scans `~/.scitex/*/containers/*.sif` generically — sac
+does **not** know any other package by name, and new packages light up
+automatically with no sac code change. Each owning package ships its
+own installer CLI (e.g. `scitex-writer install texlive-sif`) that drops
+its SIF at the conventional path. Wrapper agents bind from there
+(`~/.scitex/writer/containers/texlive.sif:/opt/texlive.sif:ro`).
+
+This mirrors the `scitex_dev.*` entry_points pattern already in use
+across the ecosystem (`scitex_dev.docs`, `scitex_dev.skills`,
+`scitex_dev.linter.plugins`, `scitex_dev.jobs`): each package owns its
+own surface, the aggregator never hard-codes downstream names. Per
+operator design 8566; ecosystem doctrine of minimal scope.
+
 ## Build
 
 ```bash

--- a/src/scitex_agent_container/cli_pkg/image_group.py
+++ b/src/scitex_agent_container/cli_pkg/image_group.py
@@ -37,7 +37,22 @@ _build_layer_from_source = _image_source_build.build_layer_from_source
 _RECIPES_DIR = Path(__file__).resolve().parent.parent / "containers"
 
 # Built artifacts live in user state (persistent, never in the repo).
+#
+# sac OWNS this directory for its own (base / scitex) artifacts. Other
+# scitex-* packages own their own siblings under ``~/.scitex/<pkg>/``
+# per the ``~/.scitex/<pkg>/{containers,bin}`` convention (operator
+# design 8566): scitex-writer → ``~/.scitex/writer/containers/``,
+# scitex-neurovista → ``~/.scitex/neurovista/containers/``, etc. sac
+# does NOT host other packages' SIFs in its own namespace — minimal
+# scope per the ecosystem doctrine.
 _CONTAINERS_DIR = Path.home() / ".scitex" / "agent-container" / "containers"
+
+# Generic cross-package discovery root. ``sac image list`` globs
+# ``<root>/*/containers/*.sif`` so any package following the convention
+# becomes visible without sac knowing the package by name. Mirrors the
+# ``scitex_dev.*`` entry_points discovery pattern (each package owns its
+# own surface; the aggregator never hard-codes package names).
+_SCITEX_USER_STATE_ROOT = Path.home() / ".scitex"
 
 # Layer → .def filename mapping.
 _LAYERS = {
@@ -300,7 +315,11 @@ def image_freeze(sandbox_dir: Path, output_sif: Path) -> None:
 @image_group.command("list")
 @click.option("--json", "as_json", is_flag=True, help="Output as JSON.")
 def image_list(as_json: bool) -> None:
-    """List installed SIF versions.
+    """List installed SIFs across every scitex-* package.
+
+    Discovers via the ``~/.scitex/<pkg>/containers/*.sif`` convention
+    (operator design 8566) — sac does NOT know any other package by
+    name; new packages light up automatically.
 
     \b
     Example:
@@ -308,17 +327,12 @@ def image_list(as_json: bool) -> None:
       $ sac image list --json
     """
     _ensure_containers_dir()
-    # Match our own naming pattern. SIFs are single files
-    # (scitex-agent-container-*.sif); sandboxes are writable directories
-    # (scitex-agent-container-*.sandbox/). Both count as installed images.
-    # We don't delegate to scitex-container's list_versions because that
-    # regex is hard-coded to the legacy ``scitex-v*.sif`` form.
     entries: list[Path] = []
-    entries.extend(sorted(_CONTAINERS_DIR.glob("scitex-agent-container-*.sif")))
+    entries.extend(sorted(_SCITEX_USER_STATE_ROOT.glob("*/containers/*.sif")))
     entries.extend(
         sorted(
             p
-            for p in _CONTAINERS_DIR.glob("scitex-agent-container-*.sandbox")
+            for p in _SCITEX_USER_STATE_ROOT.glob("*/containers/*.sandbox")
             if p.is_dir()
         )
     )
@@ -339,6 +353,7 @@ def image_list(as_json: bool) -> None:
         size_bytes = _dir_size_bytes(p) if is_sandbox else p.stat().st_size
         versions.append(
             {
+                "package": p.parent.parent.name,
                 "name": p.name,
                 "path": str(p),
                 "kind": "sandbox" if is_sandbox else "sif",
@@ -346,20 +361,22 @@ def image_list(as_json: bool) -> None:
                 "mtime": p.stat().st_mtime,
             }
         )
-    console.print(f"[dim]containers dir: {_CONTAINERS_DIR}[/dim]")
+    console.print(f"[dim]scan root: {_SCITEX_USER_STATE_ROOT}/*/containers/[/dim]")
     if as_json:
         click.echo(json.dumps(versions, indent=2, default=str))
         return
     if not versions:
         console.print(
-            f"[dim](no SIFs in {_CONTAINERS_DIR} — run "
-            f"`sac image build base -y && sac image build scitex -y` to populate)[/dim]"
+            f"[dim](no SIFs under {_SCITEX_USER_STATE_ROOT}/*/containers/ — "
+            f"run `sac image build base -y && sac image build scitex -y` to "
+            f"populate; downstream packages populate their own siblings)[/dim]"
         )
         return
     for v in versions:
         size_mb = v["size_bytes"] / (1024 * 1024)
         tag = "sandbox" if v["kind"] == "sandbox" else "sif"
-        console.print(f"  {tag:<7s}  {v['name']:50s} {size_mb:>8.1f} MB")
+        label = f"{v['package']}/{v['name']}"
+        console.print(f"  {tag:<7s}  {label:50s} {size_mb:>8.1f} MB")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scitex_agent_container/cli_pkg/test_image_group.py
+++ b/tests/scitex_agent_container/cli_pkg/test_image_group.py
@@ -166,7 +166,9 @@ def home_tmp(tmp_path: Path) -> Iterator[Path]:
     saved_home = os.environ.get("HOME")
     os.environ["HOME"] = str(home)
     saved_containers_dir = ig._CONTAINERS_DIR
+    saved_state_root = ig._SCITEX_USER_STATE_ROOT
     ig._CONTAINERS_DIR = home / ".scitex" / "agent-container" / "containers"  # type: ignore[assignment]
+    ig._SCITEX_USER_STATE_ROOT = home / ".scitex"  # type: ignore[assignment]
     try:
         yield tmp_path
     finally:
@@ -175,6 +177,7 @@ def home_tmp(tmp_path: Path) -> Iterator[Path]:
         else:
             os.environ["HOME"] = saved_home
         ig._CONTAINERS_DIR = saved_containers_dir  # type: ignore[assignment]
+        ig._SCITEX_USER_STATE_ROOT = saved_state_root  # type: ignore[assignment]
 
 
 # ---------------------------------------------------------------------------
@@ -591,3 +594,118 @@ def test_resolve_source_to_sif_raises_when_layer_not_built(home_tmp):
     # Assert
     with pytest.raises(Exception):
         _call()
+
+
+# ---------------------------------------------------------------------------
+# Cross-package discovery — ``~/.scitex/<pkg>/containers/*.sif`` convention
+# (operator design 8566). sac does NOT know any package by name; the glob
+# spans every package that follows the convention, with no _LAYERS edit
+# required for new packages to appear.
+# ---------------------------------------------------------------------------
+
+
+def test_list_discovers_sif_in_downstream_package_dir(home_tmp):
+    # Arrange — scitex-writer drops a SIF at the canonical convention
+    # path. sac should surface it via the generic glob without any
+    # package-name awareness.
+    writer_dir = ig._SCITEX_USER_STATE_ROOT / "writer" / "containers"
+    writer_dir.mkdir(parents=True)
+    (writer_dir / "texlive.sif").write_bytes(b"x" * 100)
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(image_group, ["list"])
+    # Assert
+    assert result.exit_code == 0 and "texlive.sif" in result.output
+
+
+def test_list_labels_downstream_sif_with_package_name(home_tmp):
+    # Arrange — the rendered row carries ``<package>/<sif>`` so the
+    # operator sees the owning package at a glance.
+    writer_dir = ig._SCITEX_USER_STATE_ROOT / "writer" / "containers"
+    writer_dir.mkdir(parents=True)
+    (writer_dir / "texlive.sif").write_bytes(b"x" * 100)
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(image_group, ["list"])
+    # Assert
+    assert "writer/texlive.sif" in result.output
+
+
+def test_list_json_carries_package_field_for_each_entry(home_tmp):
+    # Arrange — JSON consumers need the package as a structured field,
+    # not parsed out of the rendered label.
+    writer_dir = ig._SCITEX_USER_STATE_ROOT / "writer" / "containers"
+    writer_dir.mkdir(parents=True)
+    (writer_dir / "texlive.sif").write_bytes(b"x" * 100)
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(image_group, ["list", "--json"])
+    start = result.output.index("[")
+    end = result.output.rindex("]") + 1
+    data = json.loads(result.output[start:end])
+    # Assert
+    assert data[0]["package"] == "writer"
+
+
+def test_list_finds_sifs_across_multiple_packages_simultaneously(home_tmp):
+    # Arrange — agent-container/sac-base.sif AND writer/texlive.sif
+    # AND neurovista/whatever.sif should all surface from a single
+    # scan. The convention is generic; new packages slot in without
+    # sac code changes.
+    ac_dir = ig._SCITEX_USER_STATE_ROOT / "agent-container" / "containers"
+    ac_dir.mkdir(parents=True)
+    (ac_dir / "sac-base.sif").write_bytes(b"x")
+    writer_dir = ig._SCITEX_USER_STATE_ROOT / "writer" / "containers"
+    writer_dir.mkdir(parents=True)
+    (writer_dir / "texlive.sif").write_bytes(b"x")
+    nv_dir = ig._SCITEX_USER_STATE_ROOT / "neurovista" / "containers"
+    nv_dir.mkdir(parents=True)
+    (nv_dir / "experiment.sif").write_bytes(b"x")
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(image_group, ["list"])
+    # Assert
+    assert all(
+        marker in result.output
+        for marker in ("sac-base.sif", "texlive.sif", "experiment.sif")
+    )
+
+
+def test_list_does_not_descend_below_containers_subdir(home_tmp):
+    # Arrange — the glob is ``*/containers/*.sif`` (exactly 2 levels).
+    # A SIF buried deeper (e.g. ``writer/containers/legacy/old.sif``)
+    # is deliberately NOT surfaced — keeps the scan bounded and
+    # forces packages onto the flat convention.
+    nested = ig._SCITEX_USER_STATE_ROOT / "writer" / "containers" / "legacy"
+    nested.mkdir(parents=True)
+    (nested / "deep.sif").write_bytes(b"x")
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(image_group, ["list"])
+    # Assert — deep.sif must NOT appear in output.
+    assert "deep.sif" not in result.output
+
+
+def test_list_ignores_sifs_outside_containers_subdir(home_tmp):
+    # Arrange — a stray SIF directly under ``~/.scitex/writer/`` (not
+    # under the ``containers/`` subdir) is OUTSIDE the convention and
+    # must not surface. The scan is conventional, not free-form.
+    stray = ig._SCITEX_USER_STATE_ROOT / "writer"
+    stray.mkdir(parents=True)
+    (stray / "stray.sif").write_bytes(b"x")
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(image_group, ["list"])
+    # Assert
+    assert "stray.sif" not in result.output
+
+
+def test_scitex_user_state_root_is_dotscitex_under_home():
+    # Arrange — pin the root constant so a refactor that moves it
+    # silently (e.g. into a config var) trips a red test. The
+    # convention's location is operator contract.
+    expected = Path.home() / ".scitex"
+    # Act
+    actual = ig._SCITEX_USER_STATE_ROOT
+    # Assert
+    assert actual == expected


### PR DESCRIPTION
## Summary

Per operator design 8566 + lead's GO at \`adba9375\`: generalises \`sac image list\` discovery from a sac-namespace-locked scan to the ecosystem-wide \`~/.scitex/<pkg>/containers/\` convention. **sac stays minimal-scope** — does NOT know any other package by name; new scitex-* packages light up automatically when they drop a SIF at the conventional path.

Mirrors the live entry_points pattern already in the ecosystem (\`scitex_dev.docs\`, \`scitex_dev.skills\`, \`scitex_dev.linter.plugins\`, \`scitex_dev.jobs\`). Each package owns its own surface; the aggregator never hard-codes downstream names.

## Changes

- \`src/scitex_agent_container/cli_pkg/image_group.py\` — add \`_SCITEX_USER_STATE_ROOT\` constant (\`Path.home() / ".scitex"\`); rewrite \`image_list\` to glob \`<root>/*/containers/*.sif\` plus \`<root>/*/containers/*.sandbox\`. Each row carries a new \`package\` field so operators see \`<pkg>/<sif>\` labels (e.g. \`writer/texlive.sif\`, \`agent-container/sac-base.sif\`).
- \`docs/images.md\` — new **Cross-package convention** section.
- \`tests/scitex_agent_container/cli_pkg/test_image_group.py\` — \`home_tmp\` fixture extended to override \`_SCITEX_USER_STATE_ROOT\` alongside \`_CONTAINERS_DIR\`. Seven new tests pin: downstream SIF discovery, \`<pkg>/<sif>\` label, JSON \`package\` field, multi-package scan, depth-bounded glob (no \`**\` recursion), out-of-convention SIFs ignored, root constant matches \`~/.scitex\`.

## Tested

- [x] \`pytest tests/scitex_agent_container/cli_pkg/test_image_group.py tests/scitex_agent_container/cli_pkg/test__image_source_build.py\` — 74/74 green (30s)
- [ ] CI full suite green

## Context

- Follow-up to closed PR #291 (which violated the operator principle by adding \`texlive\` to sac's \`_LAYERS\`). This PR is the **sac-side** of the architectural correction — generic discovery, zero downstream knowledge.
- Scitex-writer side (own \`texlive.def\` + installer CLI dropping at \`~/.scitex/writer/containers/texlive.sif\`) is a separate PR, gated on bare-host clean-tree check per lead's standing rule. Reported the path constraint at \`ccfd8d6b\` / \`d7e52ff6\`.
- Neurovista's tonight texlive SIF build runs on bare host per lead (apptainer not available in SAC SIF — Mode A constraint).

## Out of scope (separate PRs)

- Old \`sac-<layer>/sac-<layer>.sif\` naming refactor — drop the redundant \`sac-\` prefix in a follow-up release with deprecation warn. Not blocking this convention adoption (existing build artifacts still discoverable via their existing symlinks/files).
- Mode A \`ApptainerNotAvailableError\` raise-not-return-False fix at \`runtimes/_apptainer_runtime.py\` — separate quick PR per \`cf552e60\`.