### PR TITLE
docs(systemd): document SIGTERM-hang lockfile recovery sequence

### DIFF
--- a/scripts/systemd/README.md
+++ b/scripts/systemd/README.md
@@ -59,6 +59,49 @@ systemctl --user daemon-reload
   task #26 sub (2)). A `systemctl --user restart sac-listen` does
   NOT require any agent restart.
 
+### Operational gotcha: SIGTERM hang holding the lockfile
+
+Observed during the 2026-06-03 host listen restart (lead): a SIGTERM
+that releases the port but **doesn't fully exit** (sub-second hang
+during in-flight SSE shutdown) leaves the flock-backed
+`listen-<port>.pid` file behind. The next start refuses with:
+
+```
+another sac listen already running (pid <N>)
+```
+
+even though `<N>` is dead. The kernel releases the flock on dirty
+exit, but the pidfile on disk is independent of the flock and only
+gets cleared by a CLEAN shutdown. Recovery sequence:
+
+```bash
+# 1. Identify the named pid in the stale lockfile (path varies by --bind)
+pid=$(cat ~/.scitex/sac/listen-7878.pid 2>/dev/null) && echo "named: $pid"
+
+# 2. Check if it's actually alive
+kill -0 "$pid" 2>/dev/null && echo ALIVE || echo DEAD-STALE-LOCK
+
+# 3. If DEAD: harmlessly re-send SIGKILL (no-op if already gone),
+#    clear the stale pidfile, then restart through the unit
+kill -9 "$pid" 2>/dev/null
+rm -f ~/.scitex/sac/listen-7878.pid
+systemctl --user restart sac-listen.service
+
+# 4. Verify
+systemctl --user status sac-listen.service
+curl -s http://127.0.0.1:7878/v1/health
+```
+
+The lockfile-clean-then-restart sequence is **non-destructive** —
+state.db is persistent on disk, agents auto-reconnect their SSE
+streams on the new listen via the existing backoff loop, and the
+flock guard means a second concurrent listen process cannot bind the
+port even if the recovery race ran twice.
+
+A future `sac listen --restart` verb will collapse this dance into a
+single atomic stop-clean-relaunch call; this manual recipe is the
+canonical recovery until that lands.
+
 ### Notes
 
 * `ExecStart=/usr/bin/env sac listen` resolves `sac` against the


### PR DESCRIPTION
## Summary

Captures the operational gotcha lead hit during the 2026-06-03 host \`sac listen\` restart: SIGTERM can release the port but leave the flock-backed \`listen-<port>.pid\` file behind when the listen process hangs sub-second during in-flight SSE shutdown. The next start refuses with:

\`\`\`
another sac listen already running (pid <N>)
\`\`\`

even though \`<N>\` is dead. The kernel releases the flock on dirty exit, but the pidfile on disk only clears on CLEAN shutdown.

The recovery dance (kernel-verify the pid is dead, SIGKILL, \`rm -f\` the stale pidfile, \`systemctl --user restart\`) was re-derived on-host under time pressure. This PR documents it next to the existing \`sac-listen.service\` section so the next operator finds the canonical fix without re-deriving.

## What ships

One file changed: \`scripts/systemd/README.md\`.

New subsection **"Operational gotcha: SIGTERM hang holding the lockfile"** added to the existing \`### Restart policy + companion guards\` block:

- Symptom (the exact error string)
- 4-step recovery (kill -0 verify / kill -9 / rm pidfile / systemctl --user restart)
- Non-destructive guarantee callouts (state.db persistence, agent SSE auto-reconnect, flock guard against double-bind)
- Forward-pointer to a future \`sac listen --restart\` verb (queued separately) as the proper durable fix

## Backstory

Lead msg [\`03c4b441b0084762b1fea5cf7df5c0a9\`](#) flagged the gotcha after restarting the host listen + upgrading to the post-3bc8bfb binary (which loads the Mode-A fail-loud markers + the PR-1/2/3 STARTUP_FAILED lifecycle):

> SIGTERM did NOT cleanly stop the old daemon — it released the port but hung half-alive holding the lock file (listen-7878.pid), so the relaunch was refused. I had to SIGKILL + manually clear the stale lock. Your restart-safety doc should add: SIGTERM → wait → if process survives OR lock is stale (pid dead), SIGKILL + rm the pidfile before relaunch.

Lead's GREEN-LIGHT for this docs PR at msg \`eaaf9389c0a340fa8e0a356e85bb1c2f\`.

## Out of scope (separate PR, queued behind this)

- \`sac listen --restart\` verb (atomic stop-clean-relaunch). Larger; ships as a follow-up. This docs PR is the cheap immediate-value win.

## Test plan

- [x] Markdown renders cleanly (visual inspection)
- [ ] CI green on the lint/docs gates (ruff/sphinx don't fail on prose changes)