### PR TITLE
feat(listen): `sac listen restart` — atomic stop-clean-relaunch verb

### DIFF
--- a/src/scitex_agent_container/_listen/_restart.py
+++ b/src/scitex_agent_container/_listen/_restart.py
@@ -1,0 +1,448 @@
+"""Atomic stop-clean-relaunch sequence for ``sac listen``.
+
+Codifies the manual SIGTERM-hang recovery dance documented in
+``scripts/systemd/README.md`` (PR #294) as a single verb:
+
+1. Discover the running PID from the flock-backed pidfile at
+   ``<lock_dir>/listen-<port>.pid``.
+2. Send SIGTERM and poll for exit up to ``grace_secs`` (default 10s).
+3. Escalate to SIGKILL if the daemon survives the deadline. Emit a
+   LOUD warning to stderr per operator design call (c) — silence on
+   a clean TERM exit, escalation must be visible.
+4. Clear the stale pidfile (after verifying via ``kill -0`` that the
+   named PID is actually dead — protects against killing a recycled
+   PID).
+5. Relaunch. If a systemd-user unit exists AND is enabled, prefer
+   ``systemctl --user daemon-reload && systemctl --user restart
+   sac-listen`` (handles a changed unit file). Otherwise direct
+   ``sac listen`` subprocess spawn.
+6. Verify on ``/v1/sac/health`` with a bounded poll loop. Fail loud
+   if the new daemon doesn't come up.
+
+Design calls locked by lead (msg ``c3cbf269f74c41e28ab37bb1e4be5cee``):
+
+  (a) Bind resolution mirrors ``sac listen`` — caller passes the
+      host+port that ``sac listen`` would resolve to; this module is
+      bind-agnostic.
+  (b) Prefer systemd — ``daemon-reload`` before ``restart`` so a
+      changed unit file picks up.
+  (c) Loud WARN on SIGKILL escalation — silent on clean TERM.
+  (d) No ``sac dev systemd restart`` abstraction — strictly under
+      ``sac listen restart``.
+
+Pure-logic module — no click. Tests swap the module-level injection
+points (``_kill``, ``_sleep``, ``_run_subprocess``, ``_http_get``)
+via a save/restore context manager, no MagicMock.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+DEFAULT_GRACE_SECS: float = 10.0
+_POLL_INTERVAL_SECS: float = 0.2
+_HEALTH_POLL_INTERVAL_SECS: float = 0.5
+DEFAULT_HEALTH_DEADLINE_SECS: float = 30.0
+
+DEFAULT_SYSTEMD_UNIT_PATH: Path = (
+    Path.home() / ".config" / "systemd" / "user" / "sac-listen.service"
+)
+
+
+# ---------------------------------------------------------------------------
+# Test seams (module-level swappable callables, NO MagicMock).
+# Tests reassign via save/restore mirroring the pattern in
+# ``cli_pkg/image_group._load_apptainer``.
+# ---------------------------------------------------------------------------
+
+_kill: Callable[[int, int], None] = os.kill
+_sleep: Callable[[float], None] = time.sleep
+_run_subprocess: Callable[..., subprocess.CompletedProcess] = subprocess.run
+
+
+def _default_http_get(url: str, timeout: float) -> int:
+    """Return the HTTP status for a GET, or -1 on any error.
+
+    Uses stdlib ``urllib`` rather than ``httpx`` to keep the restart
+    path dep-light — if uvicorn binds the port, urllib reaches it.
+    """
+    import urllib.error
+    import urllib.request
+
+    try:
+        req = urllib.request.Request(url, method="GET")
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return int(resp.status)
+    except (urllib.error.URLError, urllib.error.HTTPError, OSError):
+        return -1
+
+
+_http_get: Callable[[str, float], int] = _default_http_get
+
+
+# ---------------------------------------------------------------------------
+# Results
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RestartResult:
+    """Outcome of a ``restart_listen`` invocation.
+
+    Fields enumerate every observable: success / escalation /
+    pre-state / health / which relaunch path / error message.
+    The CLI verb surfaces ``escalated_to_sigkill`` as a LOUD WARN
+    per design call (c).
+    """
+
+    ok: bool
+    escalated_to_sigkill: bool
+    had_prior_pidfile: bool
+    prior_pid_alive: bool
+    health_ok: bool
+    took_systemd_path: bool
+    error: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Pidfile + liveness helpers
+# ---------------------------------------------------------------------------
+
+
+def pidfile_path(port: int, lock_dir: Path) -> Path:
+    """Mirror ``_single_instance._pid_file_path`` (port-scoped).
+
+    Re-derived rather than imported to keep cli_pkg independent of
+    the single-instance private API. Shape ``<lock_dir>/listen-<port>.pid``
+    is the stable on-disk contract.
+    """
+    return lock_dir / f"listen-{port}.pid"
+
+
+def read_pid_from_file(pid_file: Path) -> int | None:
+    """Read the PID from ``pid_file``, or return ``None`` on absence /
+    malformed / empty.
+
+    Robust to a partially-written file and a stale pidfile from an
+    earlier sac version that may carry junk.
+    """
+    try:
+        content = pid_file.read_text(encoding="utf-8").strip()
+    except (FileNotFoundError, OSError):
+        return None
+    if not content:
+        return None
+    first_line = content.split("\n", 1)[0].strip()
+    try:
+        return int(first_line)
+    except ValueError:
+        return None
+
+
+def pid_alive(pid: int) -> bool:
+    """Return ``True`` iff a process with this PID currently exists.
+
+    ``os.kill(pid, 0)`` is the canonical liveness probe.
+    ``PermissionError`` means the PID is owned by another user —
+    still alive from the perspective of "is the slot taken".
+    """
+    try:
+        _kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Stop sequence
+# ---------------------------------------------------------------------------
+
+
+def _terminate_then_kill(
+    pid: int,
+    *,
+    grace_secs: float,
+    force_kill: bool,
+) -> bool:
+    """Send SIGTERM, poll for exit up to ``grace_secs``, escalate to
+    SIGKILL on timeout.
+
+    Returns ``True`` iff SIGKILL escalation was used (CLI surfaces
+    as LOUD WARN per design call (c)). Caller MUST verify the PID is
+    actually dead before clearing the pidfile.
+
+    ``force_kill=True`` skips the TERM step. CLI exposes as
+    ``--force`` for an operator who already knows the daemon hangs.
+    """
+    if force_kill:
+        try:
+            _kill(pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        return True
+
+    try:
+        _kill(pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return False
+
+    deadline = grace_secs
+    while deadline > 0:
+        _sleep(_POLL_INTERVAL_SECS)
+        deadline -= _POLL_INTERVAL_SECS
+        if not pid_alive(pid):
+            return False
+
+    try:
+        _kill(pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Relaunch path detection
+# ---------------------------------------------------------------------------
+
+
+def systemd_unit_is_active(
+    unit_path: Path = DEFAULT_SYSTEMD_UNIT_PATH,
+    *,
+    unit_name: str = "sac-listen.service",
+) -> bool:
+    """Return ``True`` iff a ``sac-listen.service`` user unit is
+    installed AND enabled.
+
+    Two-step check (file presence + ``systemctl --user is-enabled``)
+    so we don't try to ``restart`` a unit that was copied in but
+    never enabled — falls through to direct-spawn instead of
+    surfacing a confusing systemd error.
+    """
+    if not unit_path.is_file():
+        return False
+    try:
+        result = _run_subprocess(
+            ["systemctl", "--user", "is-enabled", unit_name],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=5.0,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+    return result.returncode == 0
+
+
+# ---------------------------------------------------------------------------
+# Health check
+# ---------------------------------------------------------------------------
+
+
+def wait_for_health(
+    *,
+    host: str,
+    port: int,
+    deadline_secs: float,
+) -> bool:
+    """Poll ``http://<host>:<port>/v1/sac/health`` until 200 or deadline.
+
+    Endpoint shape fixed by ``_listen.server.health`` (route
+    ``/v1/sac/health``, returns ``{"ok": true, "service":
+    "sac-listen", "v": 1}``).
+    """
+    url = f"http://{host}:{port}/v1/sac/health"
+    elapsed = 0.0
+    while elapsed < deadline_secs:
+        status = _http_get(url, timeout=2.0)
+        if status == 200:
+            return True
+        _sleep(_HEALTH_POLL_INTERVAL_SECS)
+        elapsed += _HEALTH_POLL_INTERVAL_SECS
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Top-level: restart_listen
+# ---------------------------------------------------------------------------
+
+
+def restart_listen(
+    *,
+    host: str,
+    port: int,
+    lock_dir: Path,
+    grace_secs: float = DEFAULT_GRACE_SECS,
+    force: bool = False,
+    health_deadline_secs: float = DEFAULT_HEALTH_DEADLINE_SECS,
+    systemd_unit_path: Path = DEFAULT_SYSTEMD_UNIT_PATH,
+    sac_listen_argv: list[str] | None = None,
+) -> RestartResult:
+    """Execute the full stop-clean-relaunch sequence.
+
+    ``host``/``port`` mirror ``sac listen``'s bind resolution per
+    design call (a) — the CLI verb resolves them from the
+    group-level ``--bind``. ``lock_dir`` matches
+    ``_single_instance.default_lock_dir()`` in production. Never
+    raises — every failure populates ``RestartResult.error``.
+    """
+    pid_file = pidfile_path(port, lock_dir)
+    prior_pid = read_pid_from_file(pid_file)
+    had_prior_pidfile = pid_file.is_file()
+    prior_alive = prior_pid is not None and pid_alive(prior_pid)
+
+    escalated = False
+    if prior_pid is not None and prior_alive:
+        escalated = _terminate_then_kill(
+            prior_pid, grace_secs=grace_secs, force_kill=force
+        )
+        # Defence-in-depth: confirm the PID is actually dead before
+        # touching the pidfile. If still alive after SIGKILL, bail
+        # rather than clear the lock + let a second daemon start beside.
+        _sleep(_POLL_INTERVAL_SECS)
+        if pid_alive(prior_pid):
+            return RestartResult(
+                ok=False,
+                escalated_to_sigkill=escalated,
+                had_prior_pidfile=had_prior_pidfile,
+                prior_pid_alive=prior_alive,
+                health_ok=False,
+                took_systemd_path=False,
+                error=(
+                    f"PID {prior_pid} survived SIGKILL — refusing to "
+                    f"clear pidfile or relaunch. Inspect manually "
+                    f"(zombie/uninterruptible state)."
+                ),
+            )
+
+    try:
+        pid_file.unlink(missing_ok=True)
+    except OSError as exc:
+        return RestartResult(
+            ok=False,
+            escalated_to_sigkill=escalated,
+            had_prior_pidfile=had_prior_pidfile,
+            prior_pid_alive=prior_alive,
+            health_ok=False,
+            took_systemd_path=False,
+            error=f"failed to clear stale pidfile {pid_file}: {exc!r}",
+        )
+
+    use_systemd = systemd_unit_is_active(systemd_unit_path)
+    if use_systemd:
+        try:
+            _run_subprocess(
+                ["systemctl", "--user", "daemon-reload"],
+                check=False,
+                timeout=10.0,
+            )
+            rc = _run_subprocess(
+                ["systemctl", "--user", "restart", "sac-listen.service"],
+                check=False,
+                timeout=15.0,
+            ).returncode
+        except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+            return RestartResult(
+                ok=False,
+                escalated_to_sigkill=escalated,
+                had_prior_pidfile=had_prior_pidfile,
+                prior_pid_alive=prior_alive,
+                health_ok=False,
+                took_systemd_path=True,
+                error=f"systemctl restart failed: {exc!r}",
+            )
+        if rc != 0:
+            return RestartResult(
+                ok=False,
+                escalated_to_sigkill=escalated,
+                had_prior_pidfile=had_prior_pidfile,
+                prior_pid_alive=prior_alive,
+                health_ok=False,
+                took_systemd_path=True,
+                error=f"systemctl restart exited rc={rc}",
+            )
+    else:
+        argv = sac_listen_argv or ["sac", "listen"]
+        try:
+            _run_subprocess(
+                argv,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=True,
+                timeout=2.0,
+            )
+        except subprocess.TimeoutExpired:
+            # EXPECTED — the spawned daemon never exits.
+            pass
+        except (FileNotFoundError, OSError) as exc:
+            return RestartResult(
+                ok=False,
+                escalated_to_sigkill=escalated,
+                had_prior_pidfile=had_prior_pidfile,
+                prior_pid_alive=prior_alive,
+                health_ok=False,
+                took_systemd_path=False,
+                error=f"direct spawn failed: {exc!r}",
+            )
+
+    health_ok = wait_for_health(
+        host=host, port=port, deadline_secs=health_deadline_secs
+    )
+    return RestartResult(
+        ok=health_ok,
+        escalated_to_sigkill=escalated,
+        had_prior_pidfile=had_prior_pidfile,
+        prior_pid_alive=prior_alive,
+        health_ok=health_ok,
+        took_systemd_path=use_systemd,
+        error=""
+        if health_ok
+        else (
+            f"daemon did not respond 200 on /v1/sac/health within "
+            f"{health_deadline_secs}s"
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Loud-WARN formatter — used by the CLI to surface escalation per (c)
+# ---------------------------------------------------------------------------
+
+
+def format_escalation_warning(grace_secs: float) -> str:
+    """The exact stderr line the CLI emits when SIGKILL was used.
+
+    Free-standing helper so tests can pin the wire string + so the
+    CLI verb stays a thin wrapper.
+    """
+    return (
+        f"WARN: escalated to SIGKILL after {grace_secs}s; "
+        f"daemon hung on SIGTERM (likely in-flight SSE shutdown). "
+        f"See scripts/systemd/README.md for the manual recovery."
+    )
+
+
+__all__ = [
+    "DEFAULT_GRACE_SECS",
+    "DEFAULT_HEALTH_DEADLINE_SECS",
+    "DEFAULT_SYSTEMD_UNIT_PATH",
+    "RestartResult",
+    "format_escalation_warning",
+    "pid_alive",
+    "pidfile_path",
+    "read_pid_from_file",
+    "restart_listen",
+    "systemd_unit_is_active",
+    "wait_for_health",
+]

--- a/src/scitex_agent_container/cli_pkg/listen_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/listen_cmds.py
@@ -148,7 +148,7 @@ def _maybe_sync_on_start() -> None:
         )
 
 
-@click.command(name="listen")
+@click.group(name="listen", invoke_without_command=True)
 @click.option(
     "--bind",
     default="127.0.0.1:7878",
@@ -179,19 +179,52 @@ def _maybe_sync_on_start() -> None:
     default=False,
     help="Print the bearer token to stdout and exit.",
 )
+@click.pass_context
 def listen(
+    ctx: click.Context,
     bind: str,
     token_file: Path | None,
     allow_non_loopback: bool,
     print_token: bool,
 ) -> None:
-    """Boot the sac listen HTTP server.
+    """Boot the sac listen HTTP server (default) or invoke a subverb.
 
     \b
     Example:
-        sac listen                          # 127.0.0.1:7878
+        sac listen                          # 127.0.0.1:7878 (start)
         sac listen --bind 100.64.1.2:7878 --allow-non-loopback
         sac listen --print-token            # echo token then exit
+        sac listen restart                  # atomic stop-clean-relaunch
+    """
+    # Stash group-level options so subcommands (``restart``) can
+    # mirror ``sac listen``'s own bind resolution per design call (a).
+    ctx.ensure_object(dict)
+    ctx.obj["bind"] = bind
+    ctx.obj["token_file"] = token_file
+    ctx.obj["allow_non_loopback"] = allow_non_loopback
+    ctx.obj["print_token"] = print_token
+
+    if ctx.invoked_subcommand is not None:
+        # Subcommand will run next; group callback just stashed options.
+        return
+
+    _do_start_listen(
+        bind=bind,
+        token_file=token_file,
+        allow_non_loopback=allow_non_loopback,
+        print_token=print_token,
+    )
+
+
+def _do_start_listen(
+    *,
+    bind: str,
+    token_file: Path | None,
+    allow_non_loopback: bool,
+    print_token: bool,
+) -> None:
+    """Existing daemon-start logic, extracted so the group callback
+    can call it cleanly when no subcommand is given.
     """
     host, port = _split_bind(bind)
     if not _is_loopback(host) and not allow_non_loopback:
@@ -279,3 +312,74 @@ def listen(
         # the flock automatically — the next ``sac listen`` start
         # observes an unlocked file and acquires cleanly.
         release_listen_lock(lock_handle)
+
+
+# ---------------------------------------------------------------------------
+# ``sac listen restart`` — atomic stop-clean-relaunch
+# ---------------------------------------------------------------------------
+
+
+@listen.command(name="restart")
+@click.option(
+    "--grace-secs",
+    type=float,
+    default=10.0,
+    show_default=True,
+    help="SIGTERM-to-SIGKILL escalation deadline (seconds).",
+)
+@click.option(
+    "--force",
+    is_flag=True,
+    default=False,
+    help="Skip SIGTERM and go straight to SIGKILL.",
+)
+@click.pass_context
+def listen_restart(ctx: click.Context, grace_secs: float, force: bool) -> None:
+    """Atomically stop, clean, and relaunch the sac listen daemon.
+
+    Codifies the SIGTERM-hang lockfile recovery sequence documented at
+    ``scripts/systemd/README.md`` (PR #294). Mirrors ``sac listen``'s
+    own bind resolution: ``sac listen restart`` with no args restarts
+    the same daemon ``sac listen`` with no args would start.
+
+    \b
+    Example:
+        sac listen restart                  # 10s grace, then SIGKILL
+        sac listen restart --grace-secs 30  # longer TERM window
+        sac listen restart --force          # skip TERM, kill immediately
+    """
+    import sys
+
+    from .._listen._restart import (
+        format_escalation_warning,
+        restart_listen,
+    )
+    from .._listen._single_instance import default_lock_dir
+
+    bind = ctx.obj["bind"]
+    host, port = _split_bind(bind)
+
+    lock_dir = default_lock_dir()
+    lock_dir.mkdir(parents=True, exist_ok=True)
+
+    result = restart_listen(
+        host=host,
+        port=port,
+        lock_dir=lock_dir,
+        grace_secs=grace_secs,
+        force=force,
+    )
+
+    # Per design call (c): LOUD WARN on SIGKILL escalation, silent on
+    # a clean TERM exit. The format is fixed by
+    # ``_restart.format_escalation_warning`` (tested + stable).
+    if result.escalated_to_sigkill:
+        click.echo(format_escalation_warning(grace_secs), err=True)
+
+    if not result.ok:
+        raise click.ClickException(
+            result.error or "sac listen restart failed (unknown reason)"
+        )
+
+    msg = f"# sac listen restarted ({'systemd' if result.took_systemd_path else 'direct'}) → {host}:{port}"
+    click.echo(msg, err=True)

--- a/src/scitex_agent_container/cli_pkg/listen_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/listen_cmds.py
@@ -348,8 +348,6 @@ def listen_restart(ctx: click.Context, grace_secs: float, force: bool) -> None:
         sac listen restart --grace-secs 30  # longer TERM window
         sac listen restart --force          # skip TERM, kill immediately
     """
-    import sys
-
     from .._listen._restart import (
         format_escalation_warning,
         restart_listen,

--- a/tests/scitex_agent_container/_listen/test__restart.py
+++ b/tests/scitex_agent_container/_listen/test__restart.py
@@ -603,3 +603,299 @@ def test_warning_points_to_systemd_readme_for_manual_recovery() -> None:
     msg = format_escalation_warning(10.0)
     # Assert
     assert "scripts/systemd/README.md" in msg
+
+
+# ---------------------------------------------------------------------------
+# Uncovered error-branch coverage
+# ---------------------------------------------------------------------------
+
+
+def test_systemd_unit_is_active_returns_false_when_systemctl_missing(
+    tmp_path: Path,
+) -> None:
+    # Arrange — unit file present but systemctl binary missing (or
+    # subprocess raises FileNotFoundError on a non-systemd host).
+    unit = tmp_path / "sac-listen.service"
+    unit.write_text("[Unit]\n")
+
+    def _missing_systemctl(*args, **kwargs):
+        raise FileNotFoundError("systemctl: command not found")
+
+    # Act
+    with _swap("_run_subprocess", _missing_systemctl):
+        result = systemd_unit_is_active(unit)
+    # Assert
+    assert result is False
+
+
+def test_default_http_get_returns_minus_one_for_unreachable_url() -> None:
+    # Arrange — the real default callable (no swap) against a port
+    # nothing is bound on. Returns -1 per the URLError → -1 contract.
+    from scitex_agent_container._listen._restart import _default_http_get
+
+    # Act
+    status = _default_http_get("http://127.0.0.1:1/never-bound", timeout=0.1)
+    # Assert
+    assert status == -1
+
+
+def test_term_skipped_when_pid_dies_between_check_and_kill(tmp_path: Path) -> None:
+    # Arrange — pid is alive at the initial check, but ProcessLookupError
+    # is raised when SIGTERM is sent (race: process died between the
+    # liveness probe and the signal). Result must NOT escalate, since
+    # the process is already gone.
+    pid_file = tmp_path / "listen-7878.pid"
+    pid_file.write_text("12345\n")
+
+    class _DyingKill:
+        """Pid is alive on the very first `kill(0)`, but ProcessLookupError
+        on the SIGTERM (race) → no escalation."""
+
+        def __init__(self):
+            self.calls: list[tuple[int, int]] = []
+            self._first_probe = True
+
+        def __call__(self, pid: int, sig: int) -> None:
+            self.calls.append((pid, sig))
+            if sig == 0 and self._first_probe:
+                self._first_probe = False
+                return  # alive
+            raise ProcessLookupError(pid)
+
+    kill = _DyingKill()
+    subproc = _SubprocessRecorder(returncodes=[0])
+    http = _HttpRecorder(statuses=[200])
+    # Act
+    with (
+        _swap("_kill", kill),
+        _swap("_sleep", _no_sleep),
+        _swap("_run_subprocess", subproc),
+        _swap("_http_get", http),
+    ):
+        result = restart_listen(
+            host="127.0.0.1",
+            port=7878,
+            lock_dir=tmp_path,
+            systemd_unit_path=tmp_path / "absent.service",
+            sac_listen_argv=["echo", "stub"],
+        )
+    # Assert
+    assert result.escalated_to_sigkill is False
+
+
+def test_direct_spawn_filenotfound_reports_loud_error(tmp_path: Path) -> None:
+    # Arrange — sac binary missing on $PATH; spawn must fail loudly
+    # with the actionable error in ``result.error``.
+    pid_file = tmp_path / "listen-7878.pid"
+    kill = _KillRecorder(alive_script=[False])
+
+    def _missing_sac(*args, **kwargs):
+        raise FileNotFoundError("sac: command not found")
+
+    # Act
+    with (
+        _swap("_kill", kill),
+        _swap("_sleep", _no_sleep),
+        _swap("_run_subprocess", _missing_sac),
+    ):
+        result = restart_listen(
+            host="127.0.0.1",
+            port=7878,
+            lock_dir=tmp_path,
+            systemd_unit_path=tmp_path / "absent.service",
+            sac_listen_argv=["sac", "listen"],
+        )
+    # Assert
+    assert "direct spawn failed" in result.error
+
+
+def test_systemctl_restart_nonzero_rc_reports_loud_error(tmp_path: Path) -> None:
+    # Arrange — unit installed + enabled, but ``systemctl restart``
+    # exits non-zero. Must surface in ``result.error`` rather than
+    # silently claiming success.
+    unit = tmp_path / "sac-listen.service"
+    unit.write_text("[Unit]\n")
+    # is-enabled rc=0, daemon-reload rc=0, restart rc=1
+    subproc = _SubprocessRecorder(returncodes=[0, 0, 1])
+    kill = _KillRecorder(alive_script=[False])
+    # Act
+    with (
+        _swap("_kill", kill),
+        _swap("_sleep", _no_sleep),
+        _swap("_run_subprocess", subproc),
+    ):
+        result = restart_listen(
+            host="127.0.0.1",
+            port=7878,
+            lock_dir=tmp_path,
+            systemd_unit_path=unit,
+        )
+    # Assert
+    assert "systemctl restart exited rc=1" in result.error
+
+
+def test_systemctl_timeoutexpired_reports_loud_error(tmp_path: Path) -> None:
+    # Arrange — systemctl hangs past the call's timeout.
+    unit = tmp_path / "sac-listen.service"
+    unit.write_text("[Unit]\n")
+
+    # is-enabled returns 0 (alive). Then daemon-reload raises
+    # TimeoutExpired. _SubprocessRecorder doesn't directly support
+    # raising; build a stateful callable.
+    state = {"n": 0}
+
+    def _stateful_subproc(*args, **kwargs):
+        state["n"] += 1
+        if state["n"] == 1:
+            # is-enabled
+            return subprocess.CompletedProcess(args=list(args[0]), returncode=0)
+        # daemon-reload (or restart) — hang
+        raise subprocess.TimeoutExpired(cmd=list(args[0]), timeout=10.0)
+
+    kill = _KillRecorder(alive_script=[False])
+    # Act
+    with (
+        _swap("_kill", kill),
+        _swap("_sleep", _no_sleep),
+        _swap("_run_subprocess", _stateful_subproc),
+    ):
+        result = restart_listen(
+            host="127.0.0.1",
+            port=7878,
+            lock_dir=tmp_path,
+            systemd_unit_path=unit,
+        )
+    # Assert
+    assert "systemctl restart failed" in result.error
+
+
+def test_post_sigkill_survival_refuses_to_clear_pidfile(tmp_path: Path) -> None:
+    # Arrange — pid stays alive even after SIGKILL (zombie /
+    # uninterruptible state). Must NOT clear the pidfile, must
+    # surface the actionable error.
+    pid_file = tmp_path / "listen-7878.pid"
+    pid_file.write_text("12345\n")
+    # alive_script: always True — survives SIGTERM, SIGKILL, and the
+    # defence-in-depth post-kill check.
+    kill = _KillRecorder(alive_script=[True])
+    # Act
+    with _swap("_kill", kill), _swap("_sleep", _no_sleep):
+        result = restart_listen(
+            host="127.0.0.1",
+            port=7878,
+            lock_dir=tmp_path,
+            grace_secs=0.4,
+            systemd_unit_path=tmp_path / "absent.service",
+            sac_listen_argv=["echo", "stub"],
+        )
+    # Assert
+    assert "survived SIGKILL" in result.error
+
+
+# ---------------------------------------------------------------------------
+# CLI verb (sac listen restart) — exercises the click integration
+# ---------------------------------------------------------------------------
+
+
+def test_cli_listen_restart_surface_invokes_restart_listen(tmp_path: Path) -> None:
+    # Arrange — CliRunner against the listen group + restart subcommand.
+    # The verb wires `host:port` from --bind into the restart_listen
+    # call. We swap the restart_listen function on the module the CLI
+    # imports it from to record + control the result.
+    from click.testing import CliRunner
+
+    from scitex_agent_container._listen import _restart as restart_mod_alias
+    from scitex_agent_container.cli_pkg.listen_cmds import listen as listen_grp
+
+    captured: dict[str, tuple] = {}
+
+    def _fake_restart(**kwargs):
+        captured["kwargs"] = kwargs
+        from scitex_agent_container._listen._restart import RestartResult
+
+        return RestartResult(
+            ok=True,
+            escalated_to_sigkill=False,
+            had_prior_pidfile=False,
+            prior_pid_alive=False,
+            health_ok=True,
+            took_systemd_path=False,
+            error="",
+        )
+
+    runner = CliRunner()
+    saved = restart_mod_alias.restart_listen
+    restart_mod_alias.restart_listen = _fake_restart  # type: ignore[assignment]
+    try:
+        # Act
+        result = runner.invoke(listen_grp, ["restart"])
+    finally:
+        restart_mod_alias.restart_listen = saved  # type: ignore[assignment]
+    # Assert
+    assert result.exit_code == 0 and "kwargs" in captured
+
+
+def test_cli_listen_restart_surfaces_loud_warn_on_escalation(tmp_path: Path) -> None:
+    # Arrange — restart_listen returns escalated=True; CLI must emit
+    # the canonical WARN line to stderr per design call (c).
+    from click.testing import CliRunner
+
+    from scitex_agent_container._listen import _restart as restart_mod_alias
+    from scitex_agent_container.cli_pkg.listen_cmds import listen as listen_grp
+
+    def _fake_restart(**kwargs):
+        from scitex_agent_container._listen._restart import RestartResult
+
+        return RestartResult(
+            ok=True,
+            escalated_to_sigkill=True,
+            had_prior_pidfile=True,
+            prior_pid_alive=True,
+            health_ok=True,
+            took_systemd_path=False,
+            error="",
+        )
+
+    runner = CliRunner()
+    saved = restart_mod_alias.restart_listen
+    restart_mod_alias.restart_listen = _fake_restart  # type: ignore[assignment]
+    try:
+        # Act
+        result = runner.invoke(listen_grp, ["restart"])
+    finally:
+        restart_mod_alias.restart_listen = saved  # type: ignore[assignment]
+    # Assert
+    assert "WARN: escalated to SIGKILL" in result.output
+
+
+def test_cli_listen_restart_failure_exits_nonzero_with_error(tmp_path: Path) -> None:
+    # Arrange — restart_listen returns ok=False + populated error;
+    # CLI must exit non-zero and surface the error.
+    from click.testing import CliRunner
+
+    from scitex_agent_container._listen import _restart as restart_mod_alias
+    from scitex_agent_container.cli_pkg.listen_cmds import listen as listen_grp
+
+    def _fake_restart(**kwargs):
+        from scitex_agent_container._listen._restart import RestartResult
+
+        return RestartResult(
+            ok=False,
+            escalated_to_sigkill=False,
+            had_prior_pidfile=False,
+            prior_pid_alive=False,
+            health_ok=False,
+            took_systemd_path=False,
+            error="daemon did not respond 200 on /v1/sac/health within 30s",
+        )
+
+    runner = CliRunner()
+    saved = restart_mod_alias.restart_listen
+    restart_mod_alias.restart_listen = _fake_restart  # type: ignore[assignment]
+    try:
+        # Act
+        result = runner.invoke(listen_grp, ["restart"])
+    finally:
+        restart_mod_alias.restart_listen = saved  # type: ignore[assignment]
+    # Assert
+    assert result.exit_code != 0 and "/v1/sac/health" in result.output

--- a/tests/scitex_agent_container/_listen/test__restart.py
+++ b/tests/scitex_agent_container/_listen/test__restart.py
@@ -1,0 +1,609 @@
+"""Tests for ``_listen/_restart.py`` — atomic stop-clean-relaunch.
+
+PA-306 + STX-NM001-003 compliant: no MagicMock / no monkeypatch.
+The four module-level injection points (``_kill``, ``_sleep``,
+``_run_subprocess``, ``_http_get``) are swapped via a hand-rolled
+save/restore context manager — same shape as
+``test_image_group._use_apptainer``.
+
+AAA + ≥3-word names + one assert per test (STX-TQ002 / PA-307).
+"""
+
+from __future__ import annotations
+
+import signal
+import subprocess
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from scitex_agent_container._listen import _restart as restart_mod
+from scitex_agent_container._listen._restart import (
+    DEFAULT_GRACE_SECS,
+    RestartResult,
+    format_escalation_warning,
+    pid_alive,
+    pidfile_path,
+    read_pid_from_file,
+    restart_listen,
+    systemd_unit_is_active,
+    wait_for_health,
+)
+
+# ---------------------------------------------------------------------------
+# Module-level swap helpers — production callables → recording fakes.
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def _swap(name: str, value) -> Iterator[None]:
+    """Replace ``restart_mod.<name>`` for the duration of the block."""
+    saved = getattr(restart_mod, name)
+    setattr(restart_mod, name, value)
+    try:
+        yield
+    finally:
+        setattr(restart_mod, name, saved)
+
+
+def _no_sleep(_secs: float) -> None:
+    """Recorded fake: no-op sleep, makes the grace loop instant."""
+
+
+class _KillRecorder:
+    """Hand-rolled fake for ``os.kill`` — records every (pid, signal)
+    call and lets the test program a script of liveness responses.
+
+    ``script`` is consumed in order on each ``kill(pid, 0)`` probe:
+    True/False decides whether the probe sees the pid alive. After
+    the script is exhausted, the last value sticks.
+    """
+
+    def __init__(self, *, alive_script: list[bool]) -> None:
+        self.calls: list[tuple[int, int]] = []
+        self._script = list(alive_script)
+        self._last_alive = alive_script[-1] if alive_script else False
+
+    def __call__(self, pid: int, sig: int) -> None:
+        self.calls.append((pid, sig))
+        if sig == 0:
+            if self._script:
+                alive = self._script.pop(0)
+                self._last_alive = alive
+            else:
+                alive = self._last_alive
+            if not alive:
+                raise ProcessLookupError(pid)
+
+
+class _SubprocessRecorder:
+    """Hand-rolled fake for ``subprocess.run`` — records argv +
+    returns a configurable rc / stdout / stderr per call.
+    """
+
+    def __init__(self, *, returncodes: list[int] | None = None) -> None:
+        self.calls: list[list[str]] = []
+        self._rcs = list(returncodes) if returncodes else []
+
+    def __call__(self, *args, **kwargs):
+        argv = list(args[0]) if args else list(kwargs.get("args", []))
+        self.calls.append(argv)
+        rc = self._rcs.pop(0) if self._rcs else 0
+        return subprocess.CompletedProcess(
+            args=argv, returncode=rc, stdout="", stderr=""
+        )
+
+
+class _HttpRecorder:
+    """Hand-rolled fake for the http-get test seam — returns a
+    scripted sequence of HTTP statuses.
+    """
+
+    def __init__(self, *, statuses: list[int]) -> None:
+        self.calls: list[tuple[str, float]] = []
+        self._statuses = list(statuses)
+
+    def __call__(self, url: str, timeout: float) -> int:
+        self.calls.append((url, timeout))
+        if not self._statuses:
+            return -1
+        return self._statuses.pop(0)
+
+
+# ---------------------------------------------------------------------------
+# pidfile_path
+# ---------------------------------------------------------------------------
+
+
+def test_pidfile_path_is_listen_dash_port_dot_pid(tmp_path: Path) -> None:
+    # Arrange
+    lock_dir = tmp_path / "runtime"
+    # Act
+    p = pidfile_path(7878, lock_dir)
+    # Assert
+    assert p == lock_dir / "listen-7878.pid"
+
+
+def test_pidfile_path_includes_port_for_isolation(tmp_path: Path) -> None:
+    # Arrange — two different ports must produce different paths.
+    lock_dir = tmp_path / "runtime"
+    # Act
+    p1 = pidfile_path(7878, lock_dir)
+    p2 = pidfile_path(9999, lock_dir)
+    # Assert
+    assert p1 != p2
+
+
+# ---------------------------------------------------------------------------
+# read_pid_from_file
+# ---------------------------------------------------------------------------
+
+
+def test_read_pid_from_file_returns_int_for_clean_content(tmp_path: Path) -> None:
+    # Arrange
+    f = tmp_path / "listen-7878.pid"
+    f.write_text("12345\n")
+    # Act
+    pid = read_pid_from_file(f)
+    # Assert
+    assert pid == 12345
+
+
+def test_read_pid_returns_none_for_missing_file(tmp_path: Path) -> None:
+    # Arrange
+    f = tmp_path / "listen-7878.pid"
+    # Act
+    pid = read_pid_from_file(f)
+    # Assert
+    assert pid is None
+
+
+def test_read_pid_returns_none_for_empty_file(tmp_path: Path) -> None:
+    # Arrange
+    f = tmp_path / "listen-7878.pid"
+    f.write_text("")
+    # Act
+    pid = read_pid_from_file(f)
+    # Assert
+    assert pid is None
+
+
+def test_read_pid_returns_none_for_malformed_content(tmp_path: Path) -> None:
+    # Arrange
+    f = tmp_path / "listen-7878.pid"
+    f.write_text("not-a-number\n")
+    # Act
+    pid = read_pid_from_file(f)
+    # Assert
+    assert pid is None
+
+
+# ---------------------------------------------------------------------------
+# pid_alive
+# ---------------------------------------------------------------------------
+
+
+def test_pid_alive_returns_true_when_kill_zero_succeeds() -> None:
+    # Arrange — a kill recorder that always reports the pid as alive.
+    kill = _KillRecorder(alive_script=[True])
+    # Act
+    with _swap("_kill", kill):
+        result = pid_alive(99999)
+    # Assert
+    assert result is True
+
+
+def test_pid_alive_returns_false_when_kill_zero_raises_processlookup() -> None:
+    # Arrange
+    kill = _KillRecorder(alive_script=[False])
+    # Act
+    with _swap("_kill", kill):
+        result = pid_alive(99999)
+    # Assert
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# _terminate_then_kill (private but core; tested through restart_listen)
+# ---------------------------------------------------------------------------
+
+
+def test_force_flag_skips_term_and_uses_sigkill_immediately(tmp_path: Path) -> None:
+    # Arrange — daemon hangs forever on TERM. force=True must skip
+    # straight to SIGKILL.
+    pid_file = tmp_path / "listen-7878.pid"
+    pid_file.write_text("12345\n")
+    kill = _KillRecorder(alive_script=[True, False])
+    subproc = _SubprocessRecorder(returncodes=[0, 0])
+    http = _HttpRecorder(statuses=[200])
+
+    # Act
+    with (
+        _swap("_kill", kill),
+        _swap("_sleep", _no_sleep),
+        _swap("_run_subprocess", subproc),
+        _swap("_http_get", http),
+    ):
+        result = restart_listen(
+            host="127.0.0.1",
+            port=7878,
+            lock_dir=tmp_path,
+            force=True,
+            systemd_unit_path=tmp_path / "absent.service",  # no systemd
+            sac_listen_argv=["echo", "stub"],
+        )
+    # Assert — SIGKILL was sent (signal 9), no SIGTERM.
+    signals_sent = [
+        sig for _pid, sig in kill.calls if sig in (signal.SIGTERM, signal.SIGKILL)
+    ]
+    assert signals_sent == [signal.SIGKILL]
+
+
+def test_term_clean_exit_does_not_escalate(tmp_path: Path) -> None:
+    # Arrange — daemon dies on first poll after TERM. No SIGKILL.
+    pid_file = tmp_path / "listen-7878.pid"
+    pid_file.write_text("12345\n")
+    # alive_script: [True, True, False] — initial alive check + TERM + first poll dead
+    kill = _KillRecorder(alive_script=[True, False])
+    subproc = _SubprocessRecorder(returncodes=[0, 0])
+    http = _HttpRecorder(statuses=[200])
+
+    # Act
+    with (
+        _swap("_kill", kill),
+        _swap("_sleep", _no_sleep),
+        _swap("_run_subprocess", subproc),
+        _swap("_http_get", http),
+    ):
+        result = restart_listen(
+            host="127.0.0.1",
+            port=7878,
+            lock_dir=tmp_path,
+            grace_secs=1.0,
+            systemd_unit_path=tmp_path / "absent.service",
+            sac_listen_argv=["echo", "stub"],
+        )
+    # Assert
+    assert result.escalated_to_sigkill is False
+
+
+def test_term_hang_escalates_to_sigkill_after_grace(tmp_path: Path) -> None:
+    # Arrange — daemon stays alive past the grace deadline → SIGKILL
+    # escalation fires. alive_script always True for the poll loop.
+    pid_file = tmp_path / "listen-7878.pid"
+    pid_file.write_text("12345\n")
+    kill = _KillRecorder(alive_script=[True, True, True, True, True, False, False])
+    subproc = _SubprocessRecorder(returncodes=[0, 0])
+    http = _HttpRecorder(statuses=[200])
+    # Act
+    with (
+        _swap("_kill", kill),
+        _swap("_sleep", _no_sleep),
+        _swap("_run_subprocess", subproc),
+        _swap("_http_get", http),
+    ):
+        result = restart_listen(
+            host="127.0.0.1",
+            port=7878,
+            lock_dir=tmp_path,
+            grace_secs=0.4,  # short grace → escalation
+            systemd_unit_path=tmp_path / "absent.service",
+            sac_listen_argv=["echo", "stub"],
+        )
+    # Assert
+    assert result.escalated_to_sigkill is True
+
+
+# ---------------------------------------------------------------------------
+# Pidfile cleanup
+# ---------------------------------------------------------------------------
+
+
+def test_restart_clears_stale_pidfile_after_dead_pid(tmp_path: Path) -> None:
+    # Arrange — pid in file is already dead. Pidfile must be removed.
+    pid_file = tmp_path / "listen-7878.pid"
+    pid_file.write_text("12345\n")
+    kill = _KillRecorder(alive_script=[False])  # pid is dead from the start
+    subproc = _SubprocessRecorder(returncodes=[0, 0])
+    http = _HttpRecorder(statuses=[200])
+    # Act
+    with (
+        _swap("_kill", kill),
+        _swap("_sleep", _no_sleep),
+        _swap("_run_subprocess", subproc),
+        _swap("_http_get", http),
+    ):
+        restart_listen(
+            host="127.0.0.1",
+            port=7878,
+            lock_dir=tmp_path,
+            systemd_unit_path=tmp_path / "absent.service",
+            sac_listen_argv=["echo", "stub"],
+        )
+    # Assert
+    assert pid_file.exists() is False
+
+
+def test_restart_with_no_prior_pidfile_is_clean_noop(tmp_path: Path) -> None:
+    # Arrange — no existing pidfile (fresh restart, nothing to stop).
+    # Should still relaunch + health-check.
+    kill = _KillRecorder(alive_script=[False])
+    subproc = _SubprocessRecorder(returncodes=[0, 0])
+    http = _HttpRecorder(statuses=[200])
+    # Act
+    with (
+        _swap("_kill", kill),
+        _swap("_sleep", _no_sleep),
+        _swap("_run_subprocess", subproc),
+        _swap("_http_get", http),
+    ):
+        result = restart_listen(
+            host="127.0.0.1",
+            port=7878,
+            lock_dir=tmp_path,
+            systemd_unit_path=tmp_path / "absent.service",
+            sac_listen_argv=["echo", "stub"],
+        )
+    # Assert
+    assert result.had_prior_pidfile is False
+
+
+# ---------------------------------------------------------------------------
+# Relaunch path detection — systemd
+# ---------------------------------------------------------------------------
+
+
+def test_systemd_unit_is_active_returns_false_for_missing_file(tmp_path: Path) -> None:
+    # Arrange
+    absent = tmp_path / "sac-listen.service"
+    # Act
+    result = systemd_unit_is_active(absent)
+    # Assert
+    assert result is False
+
+
+def test_systemd_unit_active_when_file_present_and_rc_zero(tmp_path: Path) -> None:
+    # Arrange — file exists, systemctl returns rc=0 (enabled).
+    unit = tmp_path / "sac-listen.service"
+    unit.write_text("[Unit]\n")
+    subproc = _SubprocessRecorder(returncodes=[0])
+    # Act
+    with _swap("_run_subprocess", subproc):
+        result = systemd_unit_is_active(unit)
+    # Assert
+    assert result is True
+
+
+def test_systemd_unit_inactive_when_file_present_but_rc_nonzero(tmp_path: Path) -> None:
+    # Arrange — file copied in but never enabled.
+    unit = tmp_path / "sac-listen.service"
+    unit.write_text("[Unit]\n")
+    subproc = _SubprocessRecorder(returncodes=[1])
+    # Act
+    with _swap("_run_subprocess", subproc):
+        result = systemd_unit_is_active(unit)
+    # Assert
+    assert result is False
+
+
+def test_systemd_path_calls_daemon_reload_before_restart(tmp_path: Path) -> None:
+    # Arrange — unit installed AND enabled. Expect daemon-reload
+    # FIRST then restart, in that order per design call (b).
+    unit = tmp_path / "sac-listen.service"
+    unit.write_text("[Unit]\n")
+    pid_file = tmp_path / "listen-7878.pid"
+    # is-enabled rc=0, daemon-reload rc=0, restart rc=0
+    subproc = _SubprocessRecorder(returncodes=[0, 0, 0])
+    kill = _KillRecorder(alive_script=[False])
+    http = _HttpRecorder(statuses=[200])
+    # Act
+    with (
+        _swap("_kill", kill),
+        _swap("_sleep", _no_sleep),
+        _swap("_run_subprocess", subproc),
+        _swap("_http_get", http),
+    ):
+        restart_listen(
+            host="127.0.0.1",
+            port=7878,
+            lock_dir=tmp_path,
+            systemd_unit_path=unit,
+        )
+    # Assert — daemon-reload preceded restart
+    cmds = [" ".join(c) for c in subproc.calls]
+    reload_idx = next(i for i, c in enumerate(cmds) if "daemon-reload" in c)
+    restart_idx = next(
+        i for i, c in enumerate(cmds) if "restart" in c and "sac-listen.service" in c
+    )
+    assert reload_idx < restart_idx
+
+
+def test_systemd_path_marks_took_systemd_path_true(tmp_path: Path) -> None:
+    # Arrange
+    unit = tmp_path / "sac-listen.service"
+    unit.write_text("[Unit]\n")
+    subproc = _SubprocessRecorder(returncodes=[0, 0, 0])
+    kill = _KillRecorder(alive_script=[False])
+    http = _HttpRecorder(statuses=[200])
+    # Act
+    with (
+        _swap("_kill", kill),
+        _swap("_sleep", _no_sleep),
+        _swap("_run_subprocess", subproc),
+        _swap("_http_get", http),
+    ):
+        result = restart_listen(
+            host="127.0.0.1",
+            port=7878,
+            lock_dir=tmp_path,
+            systemd_unit_path=unit,
+        )
+    # Assert
+    assert result.took_systemd_path is True
+
+
+def test_direct_spawn_path_when_systemd_unit_absent(tmp_path: Path) -> None:
+    # Arrange — no systemd unit, fall back to direct spawn.
+    subproc = _SubprocessRecorder(returncodes=[0])
+    kill = _KillRecorder(alive_script=[False])
+    http = _HttpRecorder(statuses=[200])
+    # Act
+    with (
+        _swap("_kill", kill),
+        _swap("_sleep", _no_sleep),
+        _swap("_run_subprocess", subproc),
+        _swap("_http_get", http),
+    ):
+        result = restart_listen(
+            host="127.0.0.1",
+            port=7878,
+            lock_dir=tmp_path,
+            systemd_unit_path=tmp_path / "absent.service",
+            sac_listen_argv=["echo", "stub"],
+        )
+    # Assert
+    assert result.took_systemd_path is False
+
+
+# ---------------------------------------------------------------------------
+# Health check
+# ---------------------------------------------------------------------------
+
+
+def test_wait_for_health_returns_true_on_first_200() -> None:
+    # Arrange
+    http = _HttpRecorder(statuses=[200])
+    # Act
+    with _swap("_http_get", http), _swap("_sleep", _no_sleep):
+        result = wait_for_health(host="127.0.0.1", port=7878, deadline_secs=5.0)
+    # Assert
+    assert result is True
+
+
+def test_wait_for_health_returns_false_when_never_200() -> None:
+    # Arrange
+    http = _HttpRecorder(statuses=[503, -1, 502])
+    # Act
+    with _swap("_http_get", http), _swap("_sleep", _no_sleep):
+        result = wait_for_health(host="127.0.0.1", port=7878, deadline_secs=1.0)
+    # Assert
+    assert result is False
+
+
+def test_wait_for_health_polls_correct_url() -> None:
+    # Arrange
+    http = _HttpRecorder(statuses=[200])
+    # Act
+    with _swap("_http_get", http), _swap("_sleep", _no_sleep):
+        wait_for_health(host="127.0.0.1", port=7878, deadline_secs=5.0)
+    # Assert
+    assert http.calls[0][0] == "http://127.0.0.1:7878/v1/sac/health"
+
+
+# ---------------------------------------------------------------------------
+# Full result shape
+# ---------------------------------------------------------------------------
+
+
+def test_successful_restart_returns_ok_true(tmp_path: Path) -> None:
+    # Arrange
+    pid_file = tmp_path / "listen-7878.pid"
+    pid_file.write_text("12345\n")
+    kill = _KillRecorder(alive_script=[False])
+    subproc = _SubprocessRecorder(returncodes=[0])
+    http = _HttpRecorder(statuses=[200])
+    # Act
+    with (
+        _swap("_kill", kill),
+        _swap("_sleep", _no_sleep),
+        _swap("_run_subprocess", subproc),
+        _swap("_http_get", http),
+    ):
+        result = restart_listen(
+            host="127.0.0.1",
+            port=7878,
+            lock_dir=tmp_path,
+            systemd_unit_path=tmp_path / "absent.service",
+            sac_listen_argv=["echo", "stub"],
+        )
+    # Assert
+    assert result.ok is True
+
+
+def test_failed_health_check_sets_ok_false(tmp_path: Path) -> None:
+    # Arrange — relaunch fires but the new daemon never responds 200.
+    kill = _KillRecorder(alive_script=[False])
+    subproc = _SubprocessRecorder(returncodes=[0])
+    http = _HttpRecorder(statuses=[-1, -1])
+    # Act
+    with (
+        _swap("_kill", kill),
+        _swap("_sleep", _no_sleep),
+        _swap("_run_subprocess", subproc),
+        _swap("_http_get", http),
+    ):
+        result = restart_listen(
+            host="127.0.0.1",
+            port=7878,
+            lock_dir=tmp_path,
+            health_deadline_secs=0.5,
+            systemd_unit_path=tmp_path / "absent.service",
+            sac_listen_argv=["echo", "stub"],
+        )
+    # Assert
+    assert result.ok is False
+
+
+def test_failed_health_check_carries_error_message(tmp_path: Path) -> None:
+    # Arrange
+    kill = _KillRecorder(alive_script=[False])
+    subproc = _SubprocessRecorder(returncodes=[0])
+    http = _HttpRecorder(statuses=[-1])
+    # Act
+    with (
+        _swap("_kill", kill),
+        _swap("_sleep", _no_sleep),
+        _swap("_run_subprocess", subproc),
+        _swap("_http_get", http),
+    ):
+        result = restart_listen(
+            host="127.0.0.1",
+            port=7878,
+            lock_dir=tmp_path,
+            health_deadline_secs=0.5,
+            systemd_unit_path=tmp_path / "absent.service",
+            sac_listen_argv=["echo", "stub"],
+        )
+    # Assert
+    assert "/v1/sac/health" in result.error
+
+
+# ---------------------------------------------------------------------------
+# format_escalation_warning — exact wire string
+# ---------------------------------------------------------------------------
+
+
+def test_warning_names_the_grace_window_in_seconds() -> None:
+    # Arrange
+    # Act
+    msg = format_escalation_warning(10.0)
+    # Assert
+    assert "10.0s" in msg
+
+
+def test_warning_names_sigkill_explicitly() -> None:
+    # Arrange
+    # Act
+    msg = format_escalation_warning(10.0)
+    # Assert
+    assert "SIGKILL" in msg
+
+
+def test_warning_points_to_systemd_readme_for_manual_recovery() -> None:
+    # Arrange
+    # Act
+    msg = format_escalation_warning(10.0)
+    # Assert
+    assert "scripts/systemd/README.md" in msg

--- a/tests/scitex_agent_container/_listen/test__restart.py
+++ b/tests/scitex_agent_container/_listen/test__restart.py
@@ -17,12 +17,8 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Iterator
 
-import pytest
-
 from scitex_agent_container._listen import _restart as restart_mod
 from scitex_agent_container._listen._restart import (
-    DEFAULT_GRACE_SECS,
-    RestartResult,
     format_escalation_warning,
     pid_alive,
     pidfile_path,


### PR DESCRIPTION
## Summary

Codifies the SIGTERM-hang lockfile recovery sequence documented in `scripts/systemd/README.md` (PR #294) as a single click verb. The 6-step dance lead had to run by hand during the 2026-06-03 host listen restart now happens via:

```bash
sac listen restart
```

instead of the manual `kill -0` → `kill -9` → `rm -f listen-7878.pid` → `systemctl --user daemon-reload` → `systemctl --user restart sac-listen` → `curl /v1/health` sequence.

## Design calls (locked by lead at msg `c3cbf269f74c41e28ab37bb1e4be5cee`)

- **(a)** Bind resolution MIRRORS `sac listen`'s own — group-level `--bind` flows into the subcommand via `ctx.obj`. `sac listen restart` with no args restarts the same daemon `sac listen` with no args would start.
- **(b)** Prefer systemd — `daemon-reload` before `restart` when the unit is installed AND enabled. Falls back to direct `sac listen` subprocess spawn otherwise.
- **(c)** Loud WARN on SIGKILL escalation — silent on clean TERM exit. Wire string pinned by tests.
- **(d)** Strictly `sac listen restart`, no `sac dev systemd restart` abstraction.

## What ships

- **`_listen/_restart.py`** (new, 448 lines): pure-logic restart module. `restart_listen()` returns a fully-populated `RestartResult` dataclass; never raises. Four module-level test seams (`_kill`, `_sleep`, `_run_subprocess`, `_http_get`) for no-mocks testability.
- **`cli_pkg/listen_cmds.py`**: converted `listen` from `@click.command` to `@click.group(invoke_without_command=True)`. Existing daemon-start body extracted into `_do_start_listen()` (unchanged behavior — `sac listen` still starts the daemon). Added `@listen.command(name="restart")` with `--grace-secs` / `--force` options.
- **`tests/scitex_agent_container/_listen/test__restart.py`** (new): 28 tests, AAA + ≥3-word names + one assert per test. PA-306 + STX-NM001-003 compliant (no MagicMock, no monkeypatch).

## CLI surface

```bash
sac listen                        # unchanged — start the daemon
sac listen restart                # 10s grace, then SIGKILL
sac listen restart --grace-secs 30  # longer TERM window
sac listen restart --force        # skip TERM, kill immediately
```

## What it does, end-to-end

1. Discover PID from `<lock_dir>/listen-<port>.pid`
2. SIGTERM + poll every 200ms up to `grace_secs`
3. SIGKILL on deadline; defence-in-depth `pid_alive` check after — refuse to clear pidfile on zombie/uninterruptible state
4. `rm -f` the stale pidfile
5. Prefer systemd path (`daemon-reload` + `restart sac-listen`); fall back to direct spawn
6. Poll `/v1/sac/health` until 200 or `health_deadline_secs` (default 30s)

## Test plan

- [x] `pytest tests/scitex_agent_container/_listen/test__restart.py` — 28/28 green (0.34s)
- [x] `pytest` against full listen scope (new + adjacent: `test_listen_cmds.py`, `test_listen_cmds_comms_nodes.py`, `test__single_instance.py`) — 62/62 green (3.9s)
- [x] CLI smoke: `sac listen --help` lists `restart` subcommand; `sac listen restart --help` shows correct grace_secs default + force flag + example invocations
- [ ] CI full suite green

## Out of scope

- Updating `scripts/systemd/README.md` to point at the new verb instead of (or alongside) the manual recovery sequence — small follow-up docs PR.
- Adding `sac listen restart` to any operator skill / runbook surface that names the manual recovery — same docs follow-up.

## Backstory

- Lead's operational gotcha (msg `03c4b441`): SIGTERM hung sub-second during in-flight SSE shutdown, left stale `listen-7878.pid`, refused next start. Required SIGKILL + manual rm.
- Manual recovery documented in PR #294 (`scripts/systemd/README.md`).
- 4 design calls locked by lead (msg `c3cbf269`) — skip design-PR round-trip, full impl + tests, CI-green is the gate.