### PR TITLE
fix(account-refresh): --skip-active excludes pinned-and-running accounts

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_account_refresh.py
+++ b/src/scitex_agent_container/cli_pkg/_account_refresh.py
@@ -60,6 +60,91 @@ def _resolve_active_account_name(
     return None
 
 
+def _resolve_registry_dir(home: Path) -> Path:
+    """Resolve the file-based agent registry directory.
+
+    Mirrors the ``Registry`` class's path-resolution rule (honors
+    ``SCITEX_AGENT_CONTAINER_REGISTRY_DIR``, else
+    ``<home>/.scitex/agent-container/runtime/registry``), but READ per
+    call rather than frozen at module-import time. The freeze on
+    ``Registry`` is fine in production (HOME doesn't change) but is
+    brittle under pytest where the sandbox HOME is set after the test
+    process started.
+    """
+    import os
+
+    env_override = os.environ.get("SCITEX_AGENT_CONTAINER_REGISTRY_DIR")
+    if env_override:
+        return Path(env_override)
+    return home / ".scitex" / "agent-container" / "runtime" / "registry"
+
+
+def _collect_pinned_running_accounts(home: Path | None = None) -> set[str]:
+    """Return stored-account NAMES currently pinned by running local agents.
+
+    Closes the refresh-token rotation race: when an agent is spawned with
+    ``spec.claude.account: <name>``, its in-container Claude CLI refreshes
+    that account's token through the live :rw dir-bind on the snapshot.
+    If the host ``sac accounts refresh --all --skip-active`` cron ALSO
+    refreshes the same account every 2h, the two refreshers rotate each
+    other's refresh_token (OAuth refresh-tokens invalidate on use) and
+    whichever raced last leaves the other with a now-invalid token —
+    next API call hits 401.
+
+    This helper enumerates the local file-based agent registry (the same
+    JSON files ``sac status`` reads, written by ``_lifecycle/_start`` at
+    spawn time), loads each entry's ``config`` spec, and extracts
+    ``spec.claude.account`` when set. The caller unions the result with
+    the host-active account into a single skip-set so the cron never
+    refreshes a token currently in use by a running agent.
+
+    Cross-host scope: only LOCAL running agents matter — the cron runs
+    against the LOCAL snapshot store, and agents on other hosts have
+    their own local snapshot stores (and their own refresher cron).
+
+    Stale-registry tolerance: a registry entry left behind by a crashed
+    agent will over-skip its account (the cron won't refresh it until
+    the stale entry is cleaned via ``Registry.cleanup_stale``). The
+    failure mode is safe: under-refresh, eventually requiring manual
+    ``sac accounts refresh <name>``. The opposite (over-refresh racing
+    a live agent) is the bug we're fixing.
+
+    Tolerant: any registry / spec read failure is mapped to "this entry
+    contributes nothing" so refresh proceeds against the rest of the
+    set rather than crashing on one bad row.
+    """
+    import json as _json
+
+    home = home if home is not None else Path.home()
+    reg_dir = _resolve_registry_dir(home)
+    pinned: set[str] = set()
+    if not reg_dir.is_dir():
+        return pinned
+    # stx-allow: fallback (reason: skip-set construction is best-effort;
+    # any registry / spec read failure maps to "skip nothing extra" so
+    # refresh proceeds against the remaining accounts.)
+    try:
+        from ..config import load_config
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        return pinned
+    for entry_path in sorted(reg_dir.glob("*.json")):
+        try:
+            entry = _json.loads(entry_path.read_text())
+        except Exception:  # stx-allow: fallback (reason: see inline comment)
+            continue
+        cfg_path = entry.get("config") if isinstance(entry, dict) else None
+        if not isinstance(cfg_path, str) or not cfg_path:
+            continue
+        try:
+            cfg = load_config(Path(cfg_path))
+        except Exception:  # stx-allow: fallback (reason: see inline comment)
+            continue
+        acct = getattr(getattr(cfg, "claude", None), "account", "") or ""
+        if isinstance(acct, str) and acct.strip():
+            pinned.add(acct.strip())
+    return pinned
+
+
 @click.command("refresh")
 @click.argument("name", required=False)
 @click.option(
@@ -135,18 +220,28 @@ def account_refresh(
         targets = [a["name"] for a in accounts]
         if skip_active:
             active_name = _resolve_active_account_name(home, accounts)
+            pinned_running = _collect_pinned_running_accounts(home)
             if active_name is None:
                 click.echo(
                     "[skip-active] no active account resolvable; "
-                    "refreshing all stored accounts.",
+                    "host-active skip is a no-op.",
                     err=True,
                 )
             elif active_name in targets:
-                targets = [t for t in targets if t != active_name]
                 click.echo(
                     f"[skip-active] excluding active account '{active_name}'.",
                     err=True,
                 )
+            for pinned_name in sorted(pinned_running & set(targets)):
+                click.echo(
+                    f"[skip-active] excluding pinned-running account "
+                    f"'{pinned_name}' (refresh-token rotation race guard).",
+                    err=True,
+                )
+            skip_set: set[str] = set(pinned_running)
+            if active_name:
+                skip_set.add(active_name)
+            targets = [t for t in targets if t not in skip_set]
     else:
         targets = [name]  # type: ignore[list-item]
 

--- a/tests/scitex_agent_container/cli_pkg/test__account_refresh_pinned_running.py
+++ b/tests/scitex_agent_container/cli_pkg/test__account_refresh_pinned_running.py
@@ -1,0 +1,398 @@
+"""Tests for ``--skip-active`` excluding pinned-and-running accounts.
+
+Regression coverage for the 2026-06-04 neurovista 401 storm: the
+host-side ``sac accounts refresh --all --skip-active`` cron (every 2h
+via the federated systemd-user timer) was rotating refresh_tokens for
+accounts CURRENTLY pinned by running agents (``spec.claude.account:
+<name>``). Both refreshers (host cron + in-container CLI) used the
+same refresh_token, OAuth refresh-tokens invalidate on use → race →
+401 ~hourly. The fix extends ``--skip-active``'s skip-set with the
+account names enumerated from the local file-based agent registry
+(the same JSONs ``sac status`` reads, written by
+``_lifecycle/_start`` at spawn time).
+
+No-mocks (PA-306): real on-disk registry JSON + real on-disk
+``spec.yaml`` files; ``load_config`` is the production parser. HTTP
+is injected at ``urllib.request.urlopen`` (the production seam)
+via the same ``opener_swap`` shape the sibling refresh tests use.
+
+AAA marker comments; one assertion per test; ≥3-word names.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Iterator
+
+import pytest
+from click.testing import CliRunner
+
+from scitex_agent_container._state.account_store import save_account
+from scitex_agent_container.cli_pkg._account_refresh import (
+    _collect_pinned_running_accounts,
+    _resolve_registry_dir,
+)
+from scitex_agent_container.cli_pkg.account_group import account
+
+# ---------------------------------------------------------------------------
+# Sandbox + helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def sandbox_home(tmp_path, env_save_restore):
+    """Redirect ``$HOME`` so ``Path.home()`` lands inside ``tmp_path``."""
+    home = tmp_path / "home"
+    home.mkdir()
+    env_save_restore.set("HOME", str(home))
+    # Some tests check the env override path explicitly; default the
+    # explicit override OFF so HOME-derived resolution is exercised.
+    env_save_restore.delete("SCITEX_AGENT_CONTAINER_REGISTRY_DIR")
+    return home
+
+
+def _seed_account(home: Path, name: str, *, refresh: str = "the-refresh") -> Path:
+    save_account(name, {"email_address": f"{name}@x"}, home=home)
+    creds = (
+        home / ".scitex" / "agent-container" / "accounts" / name / ".credentials.json"
+    )
+    creds.write_text(
+        json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "OLD-ACCESS",
+                    "refreshToken": refresh,
+                    "clientId": "cid",
+                }
+            }
+        )
+    )
+    return creds
+
+
+def _write_pinned_spec(parent: Path, *, name: str, account: str) -> Path:
+    """Materialise ``<parent>/<name>/spec.yaml`` pinned to ``account``."""
+    spec_dir = parent / name
+    spec_dir.mkdir(parents=True, exist_ok=True)
+    spec = spec_dir / "spec.yaml"
+    spec.write_text(
+        "apiVersion: scitex-agent-container/v3\n"
+        "kind: Agent\n"
+        "spec:\n"
+        "  runtime: apptainer\n"
+        f"  claude:\n"
+        f"    account: {account}\n"
+    )
+    return spec
+
+
+def _write_unpinned_spec(parent: Path, *, name: str) -> Path:
+    spec_dir = parent / name
+    spec_dir.mkdir(parents=True, exist_ok=True)
+    spec = spec_dir / "spec.yaml"
+    spec.write_text(
+        "apiVersion: scitex-agent-container/v3\n"
+        "kind: Agent\n"
+        "spec:\n"
+        "  runtime: apptainer\n"
+    )
+    return spec
+
+
+def _register_running(home: Path, *, name: str, config_path: str | None) -> Path:
+    """Write a registry JSON the way ``_lifecycle/_start`` writes it."""
+    reg_dir = home / ".scitex" / "agent-container" / "runtime" / "registry"
+    reg_dir.mkdir(parents=True, exist_ok=True)
+    entry = reg_dir / f"{name}.json"
+    payload: dict[str, Any] = {
+        "name": name,
+        "pid": 1,
+        "started_at": "2026-06-04T17:35:00Z",
+        "screen": name,
+    }
+    if config_path is not None:
+        payload["config"] = config_path
+    entry.write_text(json.dumps(payload))
+    return entry
+
+
+class _FakeResp:
+    def __init__(self, body: bytes):
+        self._body = body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return False
+
+    def read(self):
+        return self._body
+
+
+@pytest.fixture
+def opener_swap() -> Iterator[dict]:
+    """Swap ``urllib.request.urlopen`` at the production HTTP boundary."""
+    import urllib.request
+
+    state: dict[str, Any] = {"response": {"access_token": "NEW", "expires_in": 3600}}
+    saved = urllib.request.urlopen
+
+    def fake_urlopen(req, timeout=None):
+        resp = state["response"]
+        if isinstance(resp, Exception):
+            raise resp
+        return _FakeResp(json.dumps(resp).encode())
+
+    urllib.request.urlopen = fake_urlopen  # type: ignore[assignment]
+    try:
+        yield state
+    finally:
+        urllib.request.urlopen = saved  # type: ignore[assignment]
+
+
+# ---------------------------------------------------------------------------
+# _resolve_registry_dir: env override + HOME-derived fallback
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_registry_dir_uses_home_subdirectory_by_default(
+    sandbox_home,
+) -> None:
+    # Arrange — no env override (autouse fixture deletes it).
+    # Act
+    resolved = _resolve_registry_dir(sandbox_home)
+    # Assert
+    assert (
+        resolved
+        == sandbox_home / ".scitex" / "agent-container" / "runtime" / "registry"
+    )
+
+
+def test_resolve_registry_dir_honors_env_override_when_set(
+    sandbox_home, env_save_restore, tmp_path
+) -> None:
+    # Arrange
+    override = tmp_path / "elsewhere"
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_REGISTRY_DIR", str(override))
+    # Act
+    resolved = _resolve_registry_dir(sandbox_home)
+    # Assert — env override wins over HOME-derived default.
+    assert resolved == override
+
+
+# ---------------------------------------------------------------------------
+# _collect_pinned_running_accounts: the new helper
+# ---------------------------------------------------------------------------
+
+
+def test_collect_pinned_returns_empty_when_no_registry_dir_exists(
+    sandbox_home,
+) -> None:
+    # Arrange — sandbox HOME has NO registry subdirectory at all.
+    # Act
+    pinned = _collect_pinned_running_accounts(sandbox_home)
+    # Assert
+    assert pinned == set()
+
+
+def test_collect_pinned_returns_empty_when_no_running_agents(
+    sandbox_home,
+) -> None:
+    # Arrange — empty registry directory.
+    (sandbox_home / ".scitex" / "agent-container" / "runtime" / "registry").mkdir(
+        parents=True
+    )
+    # Act
+    pinned = _collect_pinned_running_accounts(sandbox_home)
+    # Assert
+    assert pinned == set()
+
+
+def test_collect_pinned_returns_account_for_one_pinned_agent(
+    sandbox_home, tmp_path
+) -> None:
+    # Arrange — a single running agent pinned to ``wyusuuke``.
+    spec = _write_pinned_spec(tmp_path / "specs", name="alpha", account="wyusuuke")
+    _register_running(sandbox_home, name="alpha", config_path=str(spec))
+    # Act
+    pinned = _collect_pinned_running_accounts(sandbox_home)
+    # Assert
+    assert pinned == {"wyusuuke"}
+
+
+def test_collect_pinned_returns_empty_for_running_unpinned_agent(
+    sandbox_home, tmp_path
+) -> None:
+    # Arrange — running agent with NO ``spec.claude.account``.
+    spec = _write_unpinned_spec(tmp_path / "specs", name="alpha")
+    _register_running(sandbox_home, name="alpha", config_path=str(spec))
+    # Act
+    pinned = _collect_pinned_running_accounts(sandbox_home)
+    # Assert
+    assert pinned == set()
+
+
+def test_collect_pinned_unions_multiple_pinned_agents(sandbox_home, tmp_path) -> None:
+    # Arrange — two running agents pinned to two distinct accounts.
+    a = _write_pinned_spec(tmp_path / "specs", name="alpha", account="acct-a")
+    b = _write_pinned_spec(tmp_path / "specs", name="beta", account="acct-b")
+    _register_running(sandbox_home, name="alpha", config_path=str(a))
+    _register_running(sandbox_home, name="beta", config_path=str(b))
+    # Act
+    pinned = _collect_pinned_running_accounts(sandbox_home)
+    # Assert — both account names surface; order doesn't matter (set).
+    assert pinned == {"acct-a", "acct-b"}
+
+
+def test_collect_pinned_dedupes_two_agents_on_same_account(
+    sandbox_home, tmp_path
+) -> None:
+    # Arrange — two running agents BOTH pinned to ``shared``.
+    a = _write_pinned_spec(tmp_path / "specs", name="alpha", account="shared")
+    b = _write_pinned_spec(tmp_path / "specs", name="beta", account="shared")
+    _register_running(sandbox_home, name="alpha", config_path=str(a))
+    _register_running(sandbox_home, name="beta", config_path=str(b))
+    # Act
+    pinned = _collect_pinned_running_accounts(sandbox_home)
+    # Assert — set semantics dedupe the duplicate ``shared`` entry.
+    assert pinned == {"shared"}
+
+
+def test_collect_pinned_tolerates_registry_entry_without_config_field(
+    sandbox_home,
+) -> None:
+    # Arrange — registry entry missing the ``config`` key entirely.
+    _register_running(sandbox_home, name="alpha", config_path=None)
+    # Act
+    pinned = _collect_pinned_running_accounts(sandbox_home)
+    # Assert — tolerantly skipped, returns empty rather than crashing.
+    assert pinned == set()
+
+
+def test_collect_pinned_tolerates_unreadable_spec_path(
+    sandbox_home,
+) -> None:
+    # Arrange — registry entry points at a spec that does not exist.
+    _register_running(sandbox_home, name="alpha", config_path="/nonexistent/spec.yaml")
+    # Act
+    pinned = _collect_pinned_running_accounts(sandbox_home)
+    # Assert
+    assert pinned == set()
+
+
+def test_collect_pinned_tolerates_malformed_registry_json(
+    sandbox_home,
+) -> None:
+    # Arrange — corrupted registry JSON.
+    reg_dir = sandbox_home / ".scitex" / "agent-container" / "runtime" / "registry"
+    reg_dir.mkdir(parents=True)
+    (reg_dir / "alpha.json").write_text("{not valid json")
+    # Act
+    pinned = _collect_pinned_running_accounts(sandbox_home)
+    # Assert — one bad row must not crash the whole skip-set build.
+    assert pinned == set()
+
+
+def test_collect_pinned_recovers_after_one_bad_row(sandbox_home, tmp_path) -> None:
+    # Arrange — one corrupt entry plus one healthy entry pinned to ``good``.
+    reg_dir = sandbox_home / ".scitex" / "agent-container" / "runtime" / "registry"
+    reg_dir.mkdir(parents=True)
+    (reg_dir / "bad.json").write_text("{corrupt")
+    spec = _write_pinned_spec(tmp_path / "specs", name="alpha", account="good")
+    _register_running(sandbox_home, name="alpha", config_path=str(spec))
+    # Act
+    pinned = _collect_pinned_running_accounts(sandbox_home)
+    # Assert — the healthy entry survives the corrupt sibling.
+    assert pinned == {"good"}
+
+
+# ---------------------------------------------------------------------------
+# CLI integration: --all --skip-active also excludes pinned-running
+# ---------------------------------------------------------------------------
+
+
+def test_skip_active_excludes_pinned_running_account_from_refresh(
+    sandbox_home, opener_swap, tmp_path
+) -> None:
+    # Arrange — two stored accounts; alpha pinned to a running agent, beta unpinned.
+    creds_a = _seed_account(sandbox_home, "alpha")
+    _seed_account(sandbox_home, "beta")
+    spec = _write_pinned_spec(tmp_path / "specs", name="agent-x", account="alpha")
+    _register_running(sandbox_home, name="agent-x", config_path=str(spec))
+    runner = CliRunner()
+    # Act
+    runner.invoke(account, ["refresh", "--all", "--skip-active"])
+    # Assert — alpha's stored token was NOT rotated (still the seeded value).
+    written_alpha = json.loads(creds_a.read_text())["claudeAiOauth"]["accessToken"]
+    assert written_alpha == "OLD-ACCESS"
+
+
+def test_skip_active_still_refreshes_unpinned_account_when_other_pinned(
+    sandbox_home, opener_swap, tmp_path
+) -> None:
+    # Arrange — alpha pinned to running agent; beta unpinned + unrelated.
+    _seed_account(sandbox_home, "alpha")
+    creds_b = _seed_account(sandbox_home, "beta")
+    spec = _write_pinned_spec(tmp_path / "specs", name="agent-x", account="alpha")
+    _register_running(sandbox_home, name="agent-x", config_path=str(spec))
+    runner = CliRunner()
+    # Act
+    runner.invoke(account, ["refresh", "--all", "--skip-active"])
+    # Assert — beta was refreshed (not pinned-running, not host-active).
+    written_beta = json.loads(creds_b.read_text())["claudeAiOauth"]["accessToken"]
+    assert written_beta == "NEW"
+
+
+def test_skip_active_logs_pinned_running_exclusion_to_stderr(
+    sandbox_home, opener_swap, tmp_path
+) -> None:
+    # Arrange
+    _seed_account(sandbox_home, "alpha")
+    spec = _write_pinned_spec(tmp_path / "specs", name="agent-x", account="alpha")
+    _register_running(sandbox_home, name="agent-x", config_path=str(spec))
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(account, ["refresh", "--all", "--skip-active"])
+    # Assert — operator gets a diagnostic naming the excluded account + reason.
+    # click >=8.2 separates stderr; <8.2 merges it. Tolerate both.
+    stderr_text = getattr(result, "stderr", "") or ""
+    all_out = (result.output or "") + stderr_text
+    assert "pinned-running" in all_out and "alpha" in all_out
+
+
+def test_skip_active_without_pinned_running_still_refreshes_target(
+    sandbox_home, opener_swap
+) -> None:
+    # Arrange — no running agents at all; beta is the only target.
+    creds_b = _seed_account(sandbox_home, "beta")
+    runner = CliRunner()
+    # Act
+    runner.invoke(account, ["refresh", "--all", "--skip-active"])
+    # Assert — without any pinned-running set, the normal refresh proceeds.
+    written = json.loads(creds_b.read_text())["claudeAiOauth"]["accessToken"]
+    assert written == "NEW"
+
+
+def test_skip_active_excludes_both_pinned_running_and_host_active(
+    sandbox_home, opener_swap, tmp_path
+) -> None:
+    # Arrange — alpha pinned-running; beta is the host's ~/.claude active login.
+    creds_a = _seed_account(sandbox_home, "alpha")
+    creds_b = _seed_account(sandbox_home, "beta")
+    # Pin alpha to a running agent.
+    spec = _write_pinned_spec(tmp_path / "specs", name="agent-x", account="alpha")
+    _register_running(sandbox_home, name="agent-x", config_path=str(spec))
+    # Seed the host's ~/.claude.json so beta resolves as the active account
+    # (email field matches what save_account stored above).
+    (sandbox_home / ".claude.json").write_text(
+        json.dumps({"oauthAccount": {"emailAddress": "beta@x"}})
+    )
+    runner = CliRunner()
+    # Act
+    runner.invoke(account, ["refresh", "--all", "--skip-active"])
+    # Assert — neither alpha (pinned-running) nor beta (host-active) was touched.
+    a = json.loads(creds_a.read_text())["claudeAiOauth"]["accessToken"]
+    b = json.loads(creds_b.read_text())["claudeAiOauth"]["accessToken"]
+    assert a == "OLD-ACCESS" and b == "OLD-ACCESS"


### PR DESCRIPTION
## Summary

Closes the recurring ~hourly OAuth 401 storm on agents pinned via `spec.claude.account` (operator's "solidify creds" target). Root cause: the host `sac.accounts-refresh` systemd-user timer runs `sac accounts refresh --all --skip-active` every 2h, and `--skip-active` ONLY excluded the host's `~/.claude` live login. For an agent pinned to a DIFFERENT account, the cron rotated that account's `refresh_token` in the snapshot while the in-container Claude CLI was using the prior one. OAuth `refresh_tokens` invalidate on use → the two refreshers raced each other to invalidation → 401 on the loser's next API call.

**Timing match (conclusive):** The 2026-06-04 neurovista 401 storm hit at ts ~17:35; `OnUnitActiveSec=2h` means the timer last fired at ~15:35 → next firing exactly at 17:35.

## Fix

Extends `--skip-active`'s skip-set with the account names enumerated from the local file-based agent registry (the same JSONs `sac status` reads, written by `_lifecycle/_start` at spawn time). For each running entry, load the spec via the production `load_config()` and union `spec.claude.account` into the exclude-set before refresh.

Scope: only LOCAL running agents (the cron operates on the LOCAL snapshot store; cross-host agents have their own local snapshot stores and their own refresher cron). Stale-registry tolerance: a crashed agent's leftover entry over-skips its account (under-refresh — safe failure mode; eventually surfaces as a manual `sac accounts refresh <name>`). The opposite — over-refresh racing a live agent — is the bug being fixed.

## Implementation

* `_collect_pinned_running_accounts(home)` reads registry JSONs **directly** rather than importing the `Registry` class, which freezes `REGISTRY_DIR` at module-import time and is brittle under pytest's HOME-redirect fixtures.
* `_resolve_registry_dir(home)` mirrors `Registry`'s path rules (env override + HOME-derived fallback) but READS per call.
* Diagnostic stderr line per excluded pinned-running account names BOTH the account and the reason (\`refresh-token rotation race guard\`) so the operator sees what got skipped and why.
* Helper is tolerant: registry/spec/parse failures map to "this entry contributes nothing" so one bad row never crashes the whole refresh.

## Deployment

**Host-side fix only — NO SIF rebuild needed.**

`sac.accounts-refresh.service` ExecStart resolves \`sac\` via host PATH (the editable install), NOT inside any SIF. Deploy = merge + \`git -C ~/proj/scitex-agent-container pull --ff-only\` on the host. Next timer firing picks up the new code. See \`docs/deploy-runbook.md\` "Host runtime — restart only" row.

## Test plan

- [x] 17 new tests against the helper + CLI integration (skip behavior, dedup, multi-pinned, tolerance to bad rows, env-override path, host-active + pinned-running both excluded)
- [x] 14 existing \`test_account_group_refresh.py\` tests still pass (no regression)
- [x] 94% combined patch coverage on \`_account_refresh.py\` (>=80% codecov gate)
- [x] Full \`cli_pkg/\` suite: 1285 passed, 2 deselected, no regressions
- [x] Ruff clean on changed files
- [x] PA-306 (no mocks): real on-disk registry JSON + real spec.yaml + production \`load_config\` + HTTP at \`urllib.request.urlopen\` production seam
- [x] PA-307 / STX-TQ002: AAA markers, one assertion per test, ≥3-word names
- [x] Line cap clean (\`_account_refresh.py\` 289/512)