### PR TITLE
docs(adr-0017): credential rotation, live-bind, refresh-token race

### DIFF
--- a/docs/adr/0017-credential-rotation-and-refresh-race.md
+++ b/docs/adr/0017-credential-rotation-and-refresh-race.md
@@ -1,0 +1,161 @@
+# ADR-0017 — Credential rotation, live-bind, and the refresh-token race (2026-06-03)
+
+## Status
+
+Accepted. Ships in two PRs:
+
+* **PR #262 / commits d70e608 + acf2cbb (2026-06-01)** — `_apptainer_creds.resolve_cred_file` returns the **snapshot path itself** for pinned accounts, and `_apptainer_auth.py` binds the snapshot's parent directory `:rw` into the agent at `/tmp/sac-claude`. The pre-existing stale-COPY path is gone.
+* **PR #299 / commit dea298d (2026-06-03)** — `cli_pkg/_account_refresh.py::_collect_pinned_running_accounts()` extends `sac accounts refresh --all --skip-active` so the host cron skips **every** account currently pinned by a running local agent, not just the host's `~/.claude` active login.
+
+This ADR exists because the operator asked, after the two-incident night of 2026-06-03, that the failure model and its two fixes be written down explicitly so the next maintainer does not re-derive them from a 401-storm.
+
+## Context
+
+Each Anthropic Pro / Max account that sac knows about lives in **one** canonical credential file under
+`~/.scitex/agent-container/accounts/<account>/.credentials.json`
+(the per-account "snapshot store" — see ADR-0016 §account axis and skill `26_credentials-rotation.md`).
+Spec authors point a single agent at a specific account by setting
+`spec.claude.account: <name>`; the runtime then binds **that account's** credentials into the agent.
+
+Two facts about the underlying Anthropic OAuth flow are load-bearing here. Neither is sac-specific, both are easy to forget:
+
+1. **Refresh-tokens rotate on use.**
+   Every call to `/oauth/token` with `grant_type=refresh_token` returns a NEW `access_token` AND a NEW `refresh_token`, and **invalidates the previous refresh_token server-side immediately**. There is no grace window. If two independent processes refresh against the same account, whichever completes first wins; the other's already-spent refresh_token is dead.
+
+2. **The bundled `claude` CLI caches the refresh-token in memory at startup.**
+   The CLI loads `<config_dir>/.credentials.json` once when the SDK session is created and holds the refresh-token in process memory. When the access-token nears expiry the CLI rotates using the IN-MEMORY refresh-token, then writes the new pair back to disk via the `:rw` bind. It does **not** re-read the file before each rotation. So an out-of-band rotation that updates the file does **not** propagate into a running CLI — until that CLI exits and respawns.
+
+These two facts combined with sac's deployment shape (a host that fans out to N pinned agents AND runs a periodic refresh cron) produce a class of failure where the snapshot file looks healthy to the operator, the running agent looks healthy to the heartbeat, and yet every API turn 401s.
+
+The on-disk artifacts that make this concrete:
+
+* `~/.scitex/agent-container/accounts/<acct>/.credentials.json` — the per-account snapshot. This is what `sac accounts list` shows and what the cron refresher rewrites.
+* `~/.claude/.credentials.json` — the host's currently-active login (a real file or a symlink). What the operator's interactive `claude` session uses.
+* `/tmp/sac-claude/.credentials.json` (inside each container) — where the in-SIF Claude CLI reads creds from; populated by the `--bind` argv the runtime emits at spawn time.
+
+The runtime stitches these together via `_apptainer_creds.resolve_cred_file` + `_apptainer_auth.auth_argv`.
+
+### Failure mode 1 — stale COPY (pre-#262)
+
+Before #262, when `spec.claude.account` was set,
+`_apptainer_creds.resolve_cred_file` called `shutil.copy2` from the snapshot into the agent's own per-agent state dir and returned **the copy path**. `_apptainer_auth.auth_argv` then bound that per-agent copy `:rw` into the agent at `/tmp/sac-claude/.credentials.json`.
+
+The consequence:
+
+* The in-container CLI refreshed the access-token by writing through the bind — but the bind target was the **agent-local copy**, not the snapshot store.
+* The snapshot store never advanced past the boot-time access-token.
+* When `claude /login` (or `sac accounts watch-live`, or the cron) refreshed the snapshot externally, the in-container CLI's per-agent copy stayed frozen — the bind pointed at the wrong file.
+* Once the per-agent copy's refresh-token died (~8h to multi-day, depending on session activity), every turn 401'd. The heartbeat still ticked because the SDK session didn't crash; it just couldn't talk to the API.
+
+This was the 2026-06-01 fleet-wide silent outage diagnosed by the operator. Fixed by **PR #262**.
+
+### Failure mode 2 — refresh-token rotation RACE (pre-#299)
+
+After #262 landed, the snapshot store became the single source of truth: the in-container CLI binds it `:rw` directly, rotations there propagate up to the snapshot, the snapshot stays current, and every agent on the same account sees the new tokens at next read.
+
+But sac also runs a host-side refresher: the federated systemd-user timer `sac.accounts-refresh.service` fires `sac accounts refresh --all --skip-active` every 2h (`OnUnitActiveSec=2h`), iterating the account store and rotating each account's tokens against `/oauth/token`. The `--skip-active` flag was designed to leave the **currently active host login** alone (the account `~/.claude/.credentials.json` symlink points at) so the operator's interactive session never had its refresh-token yanked.
+
+What `--skip-active` did NOT skip: any account **pinned by a running agent** that is NOT the host's interactive login.
+
+So on a host with three Max accounts where:
+
+* Operator's interactive `claude` is logged in as `ywatanabe-gmail-com`.
+* `proj-neurovista` is pinned to `wyusuuke-gmail-com`.
+* `clew` is pinned to `ywatanabe-scitex-ai`.
+
+Every 2h the cron rotated **both** `wyusuuke-gmail-com` and `ywatanabe-scitex-ai`'s refresh-tokens. The in-container CLIs for neurovista and clew were holding the **previous** refresh-tokens in memory (fact 2 above), so their next rotation attempt — when their access-token expired ~1h later — used a refresh-token Anthropic had already invalidated when the cron rotated it.
+
+→ 401 storm, recurring on the 2h cron boundary, indistinguishable from a working credential to anyone reading the snapshot file (which the cron had just rewritten with brand-new tokens).
+
+The 2026-06-03 17:35 401 storm matched the cron's `OnUnitActiveSec=2h` boundary to the minute (last firing at ~15:35, next at 17:35). Fixed by **PR #299**.
+
+### Why a symlink doesn't solve this
+
+Reframing the snapshot store as a directory of symlinks pointing at `~/.claude/.credentials-<acct>.json` (or any other single-canonical scheme) does **not** close the race. Both processes — the host cron and the in-container CLI — would still issue independent `/oauth/token` calls with the same starting refresh-token in their respective memories. Server-side rotation invalidates the loser's refresh-token regardless of how many filesystem indirections the loser dereferenced to find that token. The race is a **server-state race against the OAuth provider**, not a filesystem race; symlinks and atomic renames have nothing to address.
+
+The only thing that closes it is structural: **one account, one refresher.**
+
+## Decision
+
+### Invariant: one account, one refresher
+
+For any Anthropic account, exactly one process refreshes its OAuth tokens at any given time. Concretely:
+
+* **When the account is pinned by a running local agent**: the in-container `claude` CLI is the sole refresher. The host cron MUST skip it. Other agents on the same host pinned to the same account ride the snapshot the first agent's CLI wrote.
+* **When the account is parked** (no running agent, no interactive host login): the host cron is the sole refresher.
+* **When the account is the host's interactive login** (`~/.claude/.credentials.json` resolves to it): the interactive `claude` CLI is the sole refresher; the host cron skips it via the pre-existing `--skip-active`/`_resolve_active_account_name` mechanism.
+
+The skip-set is the **union** of the host-active account and the set of accounts pinned by running local agents. Neither subset overlaps with the other in steady state; both must be excluded from the refresh batch.
+
+### Implementation
+
+#### Live `:rw` dir-bind (PR #262)
+
+`runtimes/_apptainer_creds.resolve_cred_file` returns:
+
+* For an **unpinned** agent: `~/.claude/.credentials.json` (the host's active login, single-file bind at `/tmp/sac-claude/.credentials.json:rw`).
+* For a **pinned** agent (`spec.claude.account: <acct>`): the **snapshot Path** `~/.scitex/agent-container/accounts/<acct>/.credentials.json` — no copy.
+
+`runtimes/_apptainer_auth.auth_argv` then chooses bind shape:
+
+```python
+if pinned_account:
+    bind_src = cred_file.parent         # the account's snapshot DIRECTORY
+    bind_dest = "/tmp/sac-claude"
+else:
+    bind_src = cred_file                # single file
+    bind_dest = "/tmp/sac-claude/.credentials.json"
+argv += ["--bind", f"{bind_src}:{bind_dest}:rw", ...]
+```
+
+The directory bind matters because the bundled CLI writes the new credentials file atomically (write-to-tmp + rename). A single-file bind would survive that rename for the OLD inode and miss the new file. A directory bind lets the in-container CLI see the new file under the same `/tmp/sac-claude/.credentials.json` path no matter how it was written.
+
+#### Skip-set extension (PR #299)
+
+`cli_pkg/_account_refresh.py` adds `_collect_pinned_running_accounts(home: Path | None = None) -> set[str]`:
+
+* Reads the local file-based agent registry at `~/.scitex/agent-container/runtime/registry/*.json` (same JSONs `sac status` reads, written by `_lifecycle/_start` at spawn time).
+* For each entry, loads its `config` spec via the production `load_config()` and extracts `spec.claude.account`.
+* Returns the union of non-empty account names.
+
+The `account_refresh` command unions this set with the result of `_resolve_active_account_name` (the existing host-active resolver) and excludes the union from the refresh batch. A stderr diagnostic names each excluded pinned-running account with the reason ("refresh-token rotation race guard") so the operator can see what got skipped.
+
+Helper signature accepts an explicit `home` parameter and reads the registry directory via `_resolve_registry_dir(home)` (env override + HOME-derived fallback evaluated per-call). The pre-existing `Registry` class freezes its `REGISTRY_DIR` at module-import time; reading per-call rather than via that class is what makes the helper testable under pytest's HOME-redirect fixtures.
+
+Tolerant on every read path: registry JSON parse failure, missing `config` field, missing or invalid spec, missing `claude.account` — each maps to "this entry contributes nothing" so one bad row never crashes the whole refresh.
+
+#### Deploy shape
+
+Both fixes have different deploy paths and the difference matters:
+
+* **#262 (`_apptainer_creds` + `_apptainer_auth`)**: host-side argv builder, but the change affects what gets bound into NEW agent spawns. Running agents stay on their boot-time argv. Deploy = host `git pull` + agent restart.
+* **#299 (`_account_refresh`)**: host-side cron command; runs from the editable install on `sac.accounts-refresh.service`'s `ExecStart` PATH lookup. NO SIF involvement. Deploy = host `git pull`; next 2h timer firing picks it up automatically.
+
+See `docs/deploy-runbook.md` for the surface-by-surface deploy table. The merged≠deployed lesson applies; the runbook's "Host runtime — restart only" row is exactly #299, the "rebuild + restart agents" row is exactly the SIF half of #262.
+
+## Consequences
+
+**What gets better.**
+
+* The 2h-cyclic 401 storm on pinned agents is closed structurally. Verified empirically: PR #299 force-probe at deploy time named all three pinned-running accounts in the operator's fleet (wyusuuke-gmail-com / ywatanabe-scitex-ai / ywata1989-gmail-com); the 19:35 cron cycle on 2026-06-03 passed with zero new 401 on the pinned neurovista agent.
+* The single-source-of-truth model becomes meaningfully single. Before #262 the snapshot existed but was authoritative for **nobody** in a pinned-agent deployment (the agent wrote to its per-agent copy, the cron wrote to the snapshot, neither could see the other). After #262 + #299 the snapshot is what the in-container CLI binds to AND what the cron leaves alone when it's in use.
+* The in-container CLI's in-memory cache stops being a foot-gun for sac itself. (It still IS one for any out-of-band rotator. The skip-set extension is what prevents sac from being its own out-of-band rotator.)
+
+**What gets worse.**
+
+* Stale registry entries over-skip. If an agent dies un-cleanly and leaves a JSON in `~/.scitex/agent-container/runtime/registry/`, the cron will skip that account until `Registry.cleanup_stale` (or a manual `rm`) removes the entry. Failure mode: under-refresh — the operator eventually notices an account whose snapshot hasn't moved in days and runs `sac accounts refresh <name>` manually. This is the **safe** direction. The opposite (over-refresh racing a live agent) is the bug being fixed.
+* The refresh path now reads each running agent's spec at refresh time. On a host with N running pinned agents this is N spec parses per cron firing. At today's fleet sizes (≤10) this is invisible; if it ever grows to hundreds, cache the parsed account or add a `pinned_account` column to the `instances` table (see "Notes / open items" below).
+
+**Known open items.**
+
+* **Parked accounts still rely on the host cron alone.** An account that is stored but has neither a running agent nor an interactive host login depends entirely on the cron to keep its refresh-token alive. If the cron is paused (e.g., during operator maintenance) for longer than the refresh-token's expiry window, the parked account needs a real `claude /login` — see skill `27_credentials-relogin.md`. This is by design (parked accounts have no in-memory cache to race) but worth naming explicitly.
+* **Watch-live daemon (skill 26 §6) is separate.** `sac accounts watch-live` listens to `~/.claude/` and syncs the operator's interactive logins into the snapshot store. It is not part of the rotation cron and is not affected by either fix. The `inotifywait` semantics — atomic copy on `close_write|moved_to|create` — interact correctly with both #262 (the snapshot is the bind source) and #299 (it doesn't rotate, it just mirrors the active login).
+* **Write-side `pinned_account` column** on the `instances` table would let the cron query the skip-set with one SQL query instead of N spec-parses. Not done because (a) the spec-parse path is already tolerant and fast at current scale, and (b) it would require a schema migration. Filed as a possible follow-up.
+
+## Notes
+
+* **Why not use `Registry().list_all()` directly in the helper.** The `Registry` class computes `REGISTRY_DIR` at module-import time from the then-current `$HOME` / `SCITEX_AGENT_CONTAINER_REGISTRY_DIR`. Tests that redirect `$HOME` via pytest fixtures see a stale `REGISTRY_DIR` because the module was imported earlier under the test process's original `$HOME`. Reading the directory path per-call (via `_resolve_registry_dir(home)`) sidesteps the freeze and is honest under fixtures. Production callers pay nothing — `Path.home()` is a cheap stdlib call.
+* **Why a directory bind, not a file bind, for the pinned case.** The bundled CLI writes atomically (`tmp + rename`), so a single-file `:rw` bind would point at the pre-rename inode and miss the post-rename file. The dir-bind lets the in-container CLI see whichever file currently sits at `/tmp/sac-claude/.credentials.json` regardless of how it got there.
+* **Why `--skip-active` keeps existing semantics.** The host-active account is the operator's interactive session; the in-memory cache argument from fact 2 applies to it just as it does to a pinned agent. The skip-set is just two subsets of the same invariant. Keeping the existing flag name + behaviour + adding the pinned-running subset preserves the "with `--all`, exclude the in-use refresh-token" mental model operators already had.
+* **What this does NOT change.** The OAuth API contract; the preflight (`_state/_preflight_creds`); the watch-live daemon (`_account/creds_watch`); the `sac.accounts-refresh` systemd timer schedule (still 2h); the re-login flow (skill 27); the symlink convention for `~/.claude/.credentials-<acct>.json` host-side canonicals when sac is wired to use that scheme. The two PRs are surgical patches on top of an existing model — they fix what was structurally wrong, not what was working.
+* Related ADRs: **0001** (isolation flags including HOME pinning) — the `--home /home/agent` flag and the `/tmp/sac-claude` choice for the bind target both come from there. **0016** (provider × account axes) — the conceptual home of `spec.claude.account` and the snapshot-store layout. **0009** (claude-setup delivery to home first) — why credentials never live in `to_home/` and the rationale for binding into `/tmp/`, not `$HOME`.

--- a/src/scitex_agent_container/_skills/scitex-agent-container/26_credentials-rotation.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/26_credentials-rotation.md
@@ -86,29 +86,37 @@ Target lives under `/tmp/` (not `$HOME`) because D2 hardened preflight
 requires `$HOME` empty; `CLAUDE_CONFIG_DIR=/tmp/sac-claude` keeps SDK and
 CLI in sync without polluting `$HOME`.
 
-### Per-account COPY caveat — **write-back is lost**
+### Per-account bind — **live snapshot, not a copy** (post-PR #262)
 
 When `spec.claude.account` is non-empty,
-`runtimes/_apptainer_creds.resolve_cred_file` **`shutil.copy2`**s the
-store snapshot into the agent's own state dir and returns that path; the
-caller binds **the copy** `:rw`. So:
+`runtimes/_apptainer_creds.resolve_cred_file` returns the **snapshot
+path itself** (`~/.scitex/agent-container/accounts/<acct>/.credentials.json`).
+`runtimes/_apptainer_auth.auth_argv` then binds the snapshot's **parent
+directory** `:rw`:
 
-- The container's refresh writes into the **agent-local copy**.
-- The host canonical never advances.
-- The agent stays alive until the frozen copy's refresh token dies, then
-  401s with no host-visible recovery.
-
-**Implication for a refresher agent:** do **not** use
-`spec.claude.account`. Bind the host canonical directly:
-
-```yaml
-apptainer:
-  binds:
-    - "/home/<user>/.claude/.credentials-<account>.json:/tmp/sac-claude-<account>/.credentials.json:rw"
-env:
-  CLAUDE_CONFIG_DIR: "/tmp/sac-claude-<account>"
-# leave spec.claude.account UNSET
 ```
+--bind <snapshot_parent>:/tmp/sac-claude:rw
+--env  CLAUDE_CONFIG_DIR=/tmp/sac-claude
+```
+
+So:
+
+- The container's refresh writes through the bind to the **same
+  snapshot file** every other reader looks at.
+- The snapshot stays current. Every other agent on the same account
+  sees the new tokens on its next read.
+- A directory bind (not a single-file bind) is required because the
+  bundled CLI rotates atomically via `write-tmp + rename` — a file
+  bind would survive that rename pointing at the old inode.
+
+**Historical caveat (pre-PR #262, NOW FIXED):** the runtime used to
+`shutil.copy2` the snapshot into the agent's own state dir and bind
+the copy. Refresh wrote to the agent-local copy; the snapshot never
+advanced; once the copy's refresh-token died the agent 401'd silently.
+That was the 2026-06-01 fleet-wide silent outage. PR #262 (commits
+`d70e608` + `acf2cbb`) eliminated the copy path. See
+[ADR-0017](../../../../docs/adr/0017-credential-rotation-and-refresh-race.md)
+§ "Failure mode 1" for the full story.
 
 ### Preflight (`_state/_preflight_creds.check_oauth_token_expiry`)
 
@@ -132,23 +140,66 @@ needs operator recovery → see
 ## 3. Auto-refresh — the bundled CLI does it; sac keeps a session live
 
 The bundled `claude` renews the **access** token in place ~5 min before
-expiry **while a session is active**. With the `:rw` bind the new token
-persists to the host canonical; every other agent and refresher sharing
-that canonical sees the fresh token on its next read.
+expiry **while a session is active**. With the `:rw` snapshot bind the
+new token persists to the snapshot store; every other agent sharing
+that snapshot sees the fresh token on its next read.
 
-So the canonical stays fresh **as long as something is talking to the
-account**. Standard pattern:
+So the snapshot stays fresh **as long as something is talking to the
+account**. Standard pattern for **parked** accounts (no running pinned
+agent, not the host's interactive login):
 
 - **One per-account refresher agent** on the cheapest model
-  (`claude-haiku-4-5`), direct-bound to the canonical with a custom
-  `CLAUDE_CONFIG_DIR` (see YAML snippet above).
+  (`claude-haiku-4-5`), pinned via `spec.claude.account: <acct>`. Post-PR
+  #262 the live snapshot bind is automatic — no manual bind / custom
+  `CLAUDE_CONFIG_DIR` override needed.
 - **A 30-minute keepalive cron** that posts an A2A turn to each
   refresher: `sac agents send <refresher> hello`. The turn forces the
   bundled CLI to spin a session, observe the impending expiry, and
-  rotate the access token through the bind back to the canonical.
+  rotate the access token through the bind back to the snapshot.
 
 Every other agent on the same account benefits transparently — they all
-bind the same canonical.
+bind the same snapshot.
+
+> Mechanics note: the bundled `claude` CLI caches the refresh-token
+> **in memory** at session start; it does not re-read the snapshot
+> before each rotation. This is what makes the one-account-one-refresher
+> invariant load-bearing (§3a). Any out-of-band rotator (e.g., a host
+> cron call against the same account) will invalidate the running
+> CLI's in-memory refresh-token server-side and 401 the next turn.
+
+## 3a. One account, one refresher — the rotation-race invariant
+
+OAuth refresh-tokens **rotate server-side on every use**: each call to
+`/oauth/token` returns a new refresh-token AND invalidates the previous
+one with no grace window. Combined with the in-memory cache (§3), this
+means **at most one process can be the live refresher for any given
+account at any given time**:
+
+* **Pinned-and-running**: the in-container `claude` CLI inside the
+  pinned agent is the sole refresher. The host cron MUST skip the
+  account.
+* **Host's interactive login**: the operator's interactive `claude`
+  session is the sole refresher. The host cron MUST skip it (the
+  pre-existing `--skip-active` behaviour).
+* **Parked** (no pinned agent, no interactive session): the host cron
+  is the sole refresher. Safe to rotate; no in-memory cache to race.
+
+If two refreshers ever touch the same account concurrently, the loser's
+refresh-token is dead the moment the winner's `/oauth/token` returns.
+The loser then 401s on its next turn — even though the snapshot file
+on disk looks brand-new (the winner wrote it).
+
+**The host refresher cron** (`sac.accounts-refresh.service`, see §5b)
+implements this invariant via `--skip-active`: the skip-set is the union
+of the host-active account and every account currently pinned by a
+running local agent (PR #299, commit `dea298d`). Stale-registry
+tolerance: a dead agent's leftover JSON over-skips its account
+(under-refresh — safe direction; recover with manual
+`sac accounts refresh <name>`). The opposite direction (over-refresh
+racing a live agent) was the 2026-06-03 ~hourly 401 storm that
+PR #299 closes structurally. See
+[ADR-0017](../../../../docs/adr/0017-credential-rotation-and-refresh-race.md)
+§ "Failure mode 2" + § "Why a symlink doesn't solve this".
 
 ## 4. Expired ≠ unrecoverable — until the refresh token dies
 
@@ -173,6 +224,25 @@ Non-negotiables:
 - **Silent-no-op trap.** Stale `--source` (`claudeAiOauth.expiresAt` in the past) exits **0 with zero stdout**. Verify first: `jq '.claudeAiOauth.expiresAt' <path>` vs `echo $(($(date +%s) * 1000))`.
 - **`--source` MUST be the sac store**, `~/.scitex/agent-container/accounts/<acct>/.credentials.json` (kept fresh by §6's daemon; what `sac accounts list` reads). The `~/.claude/.credentials-<acct>.json` canonicals from §1 are refreshed via `:rw` agent binds, NOT direct rotation — using them as `--source` silently fails when stale.
 
+## 5b. The host refresher cron — `sac.accounts-refresh`
+
+A federated systemd-user timer fires `sac accounts refresh --all --skip-active` every 2h (`OnUnitActiveSec=2h`). It iterates the account store and rotates each unpinned account's tokens against `/oauth/token`. Registered as the `sac.accounts-refresh` JobSpec via `_jobs_plugin.py`; install with `sac dev systemd install --yes`.
+
+The `--skip-active` skip-set is the union of:
+
+1. **The host's interactive login** (`~/.claude/.credentials.json` resolved to a stored account name via `_resolve_active_account_name`).
+2. **Every account currently pinned by a running local agent** (`_collect_pinned_running_accounts`, post-PR #299, commit `dea298d`).
+
+Both subsets enforce the one-account-one-refresher invariant from §3a. Diagnostic stderr lines name each excluded account with the reason so the operator can see what got skipped:
+
+```
+[skip-active] excluding active account 'ywatanabe-gmail-com'.
+[skip-active] excluding pinned-running account 'wyusuuke-gmail-com' (refresh-token rotation race guard).
+[skip-active] excluding pinned-running account 'ywatanabe-scitex-ai' (refresh-token rotation race guard).
+```
+
+Implementation: `cli_pkg/_account_refresh.py::account_refresh` (CLI wiring), `_collect_pinned_running_accounts(home)` (reads `~/.scitex/agent-container/runtime/registry/*.json` directly to avoid the `Registry` class's import-time `REGISTRY_DIR` freeze under pytest fixtures).
+
 ## 6. The watch-live daemon — keeps the sac store fresh
 
 `sac accounts watch-live` runs `inotifywait -m ~/.claude/` for `close_write|moved_to|create` on `.credentials.json`; atomically copies each event into the matching sac-store path (slug-map e.g. `wyusuuke@gmail.com` → `wyusuuke-gmail-com`).
@@ -185,10 +255,16 @@ Implementation: `_account/creds_watch.py` L140-152 (`watch_inotify()`), L99-133 
 
 ## See also
 
+- [ADR-0017](../../../../docs/adr/0017-credential-rotation-and-refresh-race.md) —
+  the canonical write-up of the rotation model + the two failure modes
+  (stale-COPY pre-#262, refresh-token race pre-#299) + the
+  one-account-one-refresher invariant + the symlink-doesn't-help
+  argument. Read this if you're touching `_apptainer_creds.py`,
+  `_apptainer_auth.py`, or `cli_pkg/_account_refresh.py`.
 - [27_credentials-relogin.md](27_credentials-relogin.md) — verified
   re-login flow (tmux code-paste) + 401-recovery design.
 - [25_claude-setup-delivery.md](25_claude-setup-delivery.md) — why
   `to_home/` is the wrong place for credentials; `setting_sources=[]`.
 - Source files cited: `runtimes/_sdk_common.py`,
   `runtimes/_apptainer_auth.py`, `runtimes/_apptainer_creds.py`,
-  `_state/_preflight_creds.py`.
+  `_state/_preflight_creds.py`, `cli_pkg/_account_refresh.py`.


### PR DESCRIPTION
## Summary

Operator-requested follow-up to the 2026-06-03 incident night: write down the credential-rotation model + the two-bug/two-fix story so future maintainers don't re-derive it from a 401-storm.

## What's in the ADR

`docs/adr/0017-credential-rotation-and-refresh-race.md` — full 6-section ADR (Status / Context / Decision / Consequences / Notes) covering:

- **The model**: per-account snapshot store at \`~/.scitex/agent-container/accounts/<acct>/.credentials.json\`, the \`:rw\` live dir-bind into agents at \`/tmp/sac-claude\`, the OAuth refresh-token rotation semantics (server-side invalidation on use), and the bundled Claude CLI's **in-memory** refresh-token cache (no per-rotation re-read).
- **Failure mode 1 (stale-COPY, pre-#262)**: runtime copied snapshot → per-agent state dir → bound the copy. Refresh wrote to the copy; snapshot never advanced; agents 401'd once the copy's refresh-token died. Fixed by \`d70e608\` + \`acf2cbb\`.
- **Failure mode 2 (refresh-token RACE, pre-#299)**: host \`sac.accounts-refresh\` systemd cron's \`--skip-active\` only excluded the host's interactive login, NOT accounts pinned by running agents. Cron rotated pinned accounts' refresh-tokens every 2h; in-container CLIs held the previous refresh-tokens in memory; loser's next turn 401'd at the cron boundary. Fixed by \`dea298d\`.
- **Why a symlink doesn't solve it**: the race is against the OAuth provider's server-side state, not against the filesystem.
- **The one-account-one-refresher invariant**: at most one process refreshes any given account at a time; skip-set = host-active ∪ running-pinned.
- **Consequences**: parked-account residual (rely on cron alone — safe by design but worth naming); stale-registry over-skip (under-refresh is the safe direction).
- **Notes**: why \`_collect_pinned_running_accounts\` reads the registry directory per call instead of using \`Registry()\` (import-time \`REGISTRY_DIR\` freeze is brittle under pytest HOME-redirect fixtures).

## Skill update

\`_skills/scitex-agent-container/26_credentials-rotation.md\`:

- **Replaces the OBSOLETE "Per-account COPY caveat"** with the post-#262 reality (live snapshot bind, dir bind for atomic-rename safety). Keeps the historical note for context + cross-refs ADR.
- **Adds §3a** — one-account-one-refresher invariant with the in-memory-cache mechanism note.
- **Adds §5b** — the host refresher cron (\`sac.accounts-refresh\`) + the skip-set composition, with the operator-visible diagnostic stderr shape.
- **Updates §3** — parked-account refresher pattern now notes the live snapshot bind is automatic for pinned accounts post-#262 (no manual bind / custom \`CLAUDE_CONFIG_DIR\` override).
- **Cross-refs ADR-0017** in the See-Also block.

## Accuracy

Both documents accurate to shipped code:
- PR #262 → commits \`d70e608\` + \`acf2cbb\` (2026-06-01)
- PR #299 → commit \`dea298d\` (2026-06-03)

Empirically verified by operator: 2026-06-03 19:35 cron cycle passed with zero new 401 on pinned neurovista (lead msg \`aed150d4\`).

## Test plan

- [x] Markdown renders correctly
- [x] Relative cross-refs resolve (skill→ADR: \`../../../../docs/adr/0017-...md\` — 4 levels up from skill dir)
- [x] No code changes — docs-only PR
- [x] ADR uses the standard 6-section template (Status / Context / Decision / Consequences / Notes)
- [x] Next ADR number confirmed (0017 — 0016 is the latest before this)