### PR TITLE
docs(deploy-runbook): host-venv install gap + mountinfo verify protocol

### DIFF
--- a/docs/deploy-runbook.md
+++ b/docs/deploy-runbook.md
@@ -8,16 +8,27 @@ means the code is correct — not that any agent is running it.
 
 ## Where this bites
 
-Two real incidents on 2026-06-03 illustrate the gap:
+Three real incidents from 2026-06-03 → 2026-06-04 illustrate the gap:
 
-| Incident | Code merged | SIF rebuilt? | Agents restarted? | Symptom |
-|----------|-------------|--------------|-------------------|---------|
-| Account-pinned creds live-bind fix | 2026-06-01 (`d70e608` + `acf2cbb` on develop) | **No** (SIF built 2026-05-28) | n/a | Stale OAuth token after refresh → Claude 401 |
-| SAC-from-SAC broker fail-loud (PRs #287/#288/#289) | 2026-06-03 | **No** (pre-existing SIFs) | n/a | Silent-200 disease persisted in running agents |
+| Incident | Code merged | SIF rebuilt? | Host venv `pip install -U`? | Agents restarted? | Symptom |
+|----------|-------------|--------------|-----------------------------|-------------------|---------|
+| Account-pinned creds live-bind fix | 2026-06-01 (`d70e608` + `acf2cbb` on develop) | **No** (SIF built 2026-05-28) | **No** | n/a | Stale OAuth token after refresh → Claude 401 |
+| SAC-from-SAC broker fail-loud (PRs #287/#288/#289) | 2026-06-03 | **No** (pre-existing SIFs) | n/a | n/a | Silent-200 disease persisted in running agents |
+| Same creds fix, take two — **2026-06-04 03:00 storm** | 2026-06-01 (`d70e608` + `acf2cbb` already merged + `git pull`-ed) | Yes (SIF 0.21.9) | **No** (host venv still 0.21.3) | Yes | `//deleted` mounts fleet-wide → 401 at natural token expiry |
 
-Both were diagnosed as "the fix is broken" before recon showed the fix
-was on `develop` but had never reached the SIF the running agents were
-actually using.
+The first two were diagnosed as "the fix is broken" before recon showed
+the fix was on `develop` but had never reached the SIF the running
+agents were actually using.
+
+**The third bite is the subtle one** and is the reason this section
+deserves its own row in the table above: `git pull` on the source tree
+updates **the source files**. It does **not** update the installed
+`sac` binary in the host's venv. For any spawn-time argv builder
+under `runtimes/_apptainer_*` (which lives in the host binary and
+emits the apptainer `--bind` argv), the **installed wheel is what
+matters**, not the source tree. The fix can be on disk in
+`~/proj/scitex-agent-container/src/...` and still not be running on
+the agents.
 
 ## Why a rebuild is required (not just a host install)
 
@@ -43,6 +54,56 @@ the **old argv** — so changes there only take effect on the next
 `sac agent spawn`. A running agent stays on its frozen argv until it
 exits.
 
+## Why a host install is required (not just a `git pull`)
+
+When the host sac is installed in a venv via `pip install`, the venv
+holds a **frozen wheel** built at install time. `git pull` updates the
+source tree on disk; the venv's `sac` binary keeps running whatever
+version was wheeled in when the venv was last bumped.
+
+The canonical resolution check:
+
+```bash
+# What sac is on PATH, and what version does it run?
+which sac
+sac --version
+
+# Where does the source tree on disk think it is?
+git -C ~/proj/scitex-agent-container describe --tags --always
+git -C ~/proj/scitex-agent-container log --oneline -1
+
+# If the two differ, the installed binary is stale. `git pull` alone
+# fixes nothing for any host-side argv emission.
+```
+
+Two install modes and what to do:
+
+| Mode | Install command | What `git pull` does | What you ALSO need |
+|------|-----------------|----------------------|--------------------|
+| **Editable** | `pip install -e ~/proj/scitex-agent-container` | Updates source AND binary in lockstep | Nothing — `git pull` is sufficient |
+| **Wheel** | `pip install scitex-agent-container` or `pip install git+...@develop` | Updates source only; binary stays pinned | `pip install -U git+...@develop` against the same venv |
+
+If you don't know which mode you're in:
+
+```bash
+~/.env-3.11/bin/pip show scitex-agent-container | grep -E "Version|Location"
+# "Location" pointing at site-packages → wheel mode (need pip install -U)
+# "Location" pointing at ~/proj/scitex-agent-container/src → editable mode
+```
+
+**Recovery command** for wheel mode (this is what the 2026-06-04 storm
+needed):
+
+```bash
+~/.env-3.11/bin/pip install -U git+https://github.com/ywatanabe1989/scitex-agent-container.git@develop
+~/.env-3.11/bin/sac --version    # confirm new version
+```
+
+After `pip install -U`, **every running agent still has its old argv
+in flight**. The host binary update only affects NEW spawns. To deploy
+to running agents: a full agent restart cycle (the same one a SIF
+rebuild needs).
+
 ## The deploy checklist
 
 After merging any of the following surfaces to `develop`, the deploy
@@ -66,22 +127,30 @@ boundary is unclear.
 ## Canonical rebuild sequence
 
 ```bash
-# 1. Make sure the host install is current (sac wheel that gets baked).
+# 1. Update the source tree on disk.
 git -C ~/proj/scitex-agent-container fetch origin develop
 git -C ~/proj/scitex-agent-container switch develop
 git -C ~/proj/scitex-agent-container pull --ff-only
 
-# 2. Rebuild both layers. :base does not strictly need rebuilding
+# 2. Re-install the host sac binary so changes to runtimes/_apptainer_*,
+#    cli_pkg, and any other host-side code actually take effect.
+#    (Skip ONLY if the venv is editable mode — see "Why a host install
+#    is required" above for how to check.)
+~/.env-3.11/bin/pip install -U git+https://github.com/ywatanabe1989/scitex-agent-container.git@develop
+~/.env-3.11/bin/sac --version    # confirm new version on PATH
+
+# 3. Rebuild both layers. :base does not strictly need rebuilding
 #    for sac-only changes, but :scitex pins to a local :base SIF
 #    file, so rebuilding :base first guarantees freshness.
 sac image build base    -y    # ~15-25 min
 sac image build scitex  -y    # ~10-20 min  (FROM :base)
 
-# 3. Restart the host listen daemon (picks up _listen/* changes).
+# 4. Restart the host listen daemon (picks up _listen/* changes).
 sac listen restart            # or: systemctl --user restart sac-listen.service
 
-# 4. Restart agents. They re-spawn against the freshly built SIF +
-#    pick up new host-side argv from the updated runtimes/_apptainer_*.
+# 5. Restart agents. They re-spawn against the freshly built SIF +
+#    pick up new host-side argv from the updated (re-installed!)
+#    runtimes/_apptainer_*.
 #    The exact verb depends on how the agent was launched —
 #    `sac agent stop <name> && sac agent start <name>`, or the
 #    operator's job-scheduler hook.
@@ -113,6 +182,57 @@ git -C ~/proj/scitex-agent-container log --oneline -1 \
 
 This single check would have saved both of today's misdiagnoses.
 
+## Verification: "one clean cycle ≠ closed"
+
+The 2026-06-04 03:00 storm proved the discipline: a single passing
+refresh cycle after a creds-related deploy is **insufficient evidence**
+that the fix took. The 19:35 cycle on 2026-06-03 passed clean, the fix
+was declared closed, and then 23:35 storm-ed — because no
+account-rotation had happened to break the file-bind in the 19:35
+window. The bind was already broken on disk; we just hadn't tripped the
+read.
+
+### The mountinfo probe protocol for creds-related deploys
+
+Use this **after any deploy that touches `runtimes/_apptainer_creds`,
+`runtimes/_apptainer_auth`, or `_account/{credentials,claude_usage}`**.
+Declare closed only when the probe stays clean across ≥2 full refresh
+cycles (≥4-6h with the standard 2h `OnUnitActiveSec`).
+
+```bash
+# Probe — run right after fleet restart, then again at +2h and +4h.
+for pid in $(pgrep -f "_runners.claude_session"); do
+  d=$(grep -c '//deleted' /proc/$pid/mountinfo 2>/dev/null)
+  s=$(readlink /proc/$pid/exe 2>/dev/null | xargs -I{} basename {})
+  echo "pid=$pid deleted=$d exe=$s"
+done
+```
+
+Expected at every probe: `deleted=0` for every running agent. If any
+row shows `deleted≥1`, the bind has been unlinked by a refresher's
+atomic rename — the agent will 401 at next token expiry.
+
+A useful one-shot check that surfaces only the broken bind:
+
+```bash
+for pid in $(pgrep -f "_runners.claude_session"); do
+  grep '/tmp/sac-claude' /proc/$pid/mountinfo 2>/dev/null | grep -q '//deleted' \
+    && echo "BROKEN: pid=$pid (// deleted in /tmp/sac-claude mount)"
+done
+# Silent = clean.
+```
+
+For the desired post-fix shape on every running agent:
+
+```
+$snapshot_parent on /tmp/sac-claude type none (rw,bind)
+```
+
+A **file** bind (`$snapshot_dir/.credentials.json on /tmp/sac-claude/.credentials.json`)
+is the broken shape — that's the spawn-time argv before #262, and is
+what surfaced in the 2026-06-04 storm because the host venv hadn't
+been bumped past 0.21.3.
+
 ## Related docs
 
 * `docs/images.md` — full build / sandbox / freeze / rollback flow,
@@ -124,3 +244,9 @@ This single check would have saved both of today's misdiagnoses.
   that `runtimes/_apptainer_*` injects; if these change, a host
   reinstall is enough for the argv builder, but running agents still
   need to be respawned to use the new argv.
+* `docs/adr/0017-credential-rotation-and-refresh-race.md` — the
+  credential-rotation model, the live-bind requirement, and why a
+  single-file bind goes `//deleted` under any rotator that uses atomic
+  `tmp + rename`. The 2026-06-04 storm was caused by the host venv
+  shipping the pre-`#262` file-bind argv, exactly the failure mode the
+  ADR's § "Failure mode 1" describes.


### PR DESCRIPTION
## Summary

The 2026-06-04 03:00 storm exposed two runbook gaps that PR #298 didn't catch. This PR closes both.

## Gap 1: \`git pull\` ≠ host binary update

When the host \`sac\` is in a pip-installed (non-editable) venv, \`git pull\` on the source tree updates the source files but does **NOT** update the installed \`sac\` binary. The binary keeps emitting the version that was wheeled in at install time.

**The exact failure:** PR #262's directory-bind fix was merged 2026-06-01 + host source tree had it pulled. But \`~/.env-3.11/bin/sac\` was still 0.21.3 — emitted single-file binds at agent spawn → atomic-rename refresher unlinked the bound inode → \`//deleted\` mounts fleet-wide → 401 at every running agent's natural token expiry. ~25+ 401s on neurovista alone before mountinfo probe identified it.

This PR adds:

- **Third row** in the incident table covering the 2026-06-04 storm + a new \"Host venv pip install -U?\" column making the source-vs-binary distinction explicit
- **\"Why a host install is required\" section** with canonical resolution check, editable-vs-wheel install mode table, and recovery command
- **Step 2 (\`pip install -U\`)** inserted between the \`git pull\` and the SIF rebuild in the canonical rebuild sequence

## Gap 2: \"One clean cycle ≠ closed\"

PR #299 was declared closed at 19:35 on 2026-06-03 after one clean refresh cycle. The bind was already broken; the 19:35 window just hadn't tripped a rotator-fired rename yet. 23:35 had the same setup and timing that did trip it → storm.

This PR adds:

- **\"Verification: 'one clean cycle ≠ closed'\" section** codifying the mountinfo probe protocol: declare closed only when \`/proc/<pid>/mountinfo\` shows 0 \`//deleted\` entries across **≥2 full refresh cycles** (≥4-6h with the standard 2h \`OnUnitActiveSec\`).
- A useful one-shot \`grep //deleted\` check that surfaces only broken binds.
- The desired post-fix bind shape (\`<snapshot_parent> on /tmp/sac-claude type none (rw,bind)\`) vs the broken shape (single-file bind on \`/tmp/sac-claude/.credentials.json\`) so engineers can recognize either at a glance.

## Cross-ref

Updated the See-also block to point at **ADR-0017 § Failure mode 1** — this storm is exactly the failure mode the ADR documents, but the runbook hadn't named the deploy-side gap that lets it recur.

## Empirical anchor

Lead's probe output at storm-time showed \`deleted_binds≥1\` on EVERY running runner (neurovista=1, ywata1989=2, others up to 5) with host sac=0.21.3 and SIF=0.21.9. Exactly the source-vs-installed divergence the doc now calls out.

## Test plan

- [x] Markdown renders correctly
- [x] Cross-refs resolve (ADR-0017 link, related docs)
- [x] No code changes — docs-only PR
- [x] Backwards compatible with existing canonical-rebuild references
- [x] All section anchors stable (no breaking link changes)