### PR TITLE
fix(apptainer-auth): retire single-file bind for unpinned branch (task #13)

### DIFF
--- a/docs/adr/0017-credential-rotation-and-refresh-race.md
+++ b/docs/adr/0017-credential-rotation-and-refresh-race.md
@@ -89,26 +89,24 @@ The skip-set is the **union** of the host-active account and the set of accounts
 
 ### Implementation
 
-#### Live `:rw` dir-bind (PR #262)
+#### Live `:rw` dir-bind (PR #262 + the unpinned-branch follow-up)
 
 `runtimes/_apptainer_creds.resolve_cred_file` returns:
 
-* For an **unpinned** agent: `~/.claude/.credentials.json` (the host's active login, single-file bind at `/tmp/sac-claude/.credentials.json:rw`).
+* For an **unpinned** agent: `~/.claude/.credentials.json` (the host's active login).
 * For a **pinned** agent (`spec.claude.account: <acct>`): the **snapshot Path** `~/.scitex/agent-container/accounts/<acct>/.credentials.json` — no copy.
 
-`runtimes/_apptainer_auth.auth_argv` then chooses bind shape:
+`runtimes/_apptainer_auth.auth_argv` then dir-binds **unconditionally**:
 
 ```python
-if pinned_account:
-    bind_src = cred_file.parent         # the account's snapshot DIRECTORY
-    bind_dest = "/tmp/sac-claude"
-else:
-    bind_src = cred_file                # single file
-    bind_dest = "/tmp/sac-claude/.credentials.json"
+bind_src = cred_file.parent     # ~/.claude/ or accounts/<acct>/
+bind_dest = "/tmp/sac-claude"
 argv += ["--bind", f"{bind_src}:{bind_dest}:rw", ...]
 ```
 
-The directory bind matters because the bundled CLI writes the new credentials file atomically (write-to-tmp + rename). A single-file bind would survive that rename for the OLD inode and miss the new file. A directory bind lets the in-container CLI see the new file under the same `/tmp/sac-claude/.credentials.json` path no matter how it was written.
+The directory bind matters because both refresh paths — the bundled in-container CLI rotating the access-token in place, AND the host-side watch-live / sync-live daemons mirroring `~/.claude/.credentials.json` into the snapshot store — write atomically (write-to-tmp + rename). A single-file bind would survive that rename pointing at the OLD inode (visible as `...credentials.json//deleted` in `/proc/<pid>/mountinfo`), so the container reads the stale pre-rename token forever and 401s at natural expiry. A directory bind resolves child files by name through the underlying filesystem on every open, so a tmp+rename inside the dir is visible to the container immediately in both directions.
+
+**Initial PR #262 made only the pinned branch dir-bind**, leaving the unpinned/host-live branch as the legacy single-file bind (justified at the time by "don't expose ~/.claude/" — but the cred-refresher agents are unpinned by design, and they hit the //deleted regression on 2026-06-04 03:00 fleet-wide). The follow-up retiring the single-file branch (Task #13) makes both branches dir-bind. The unpinned bound dir is `~/.claude/` (over-binds settings.json + chat history + projects DB compared to the per-account snapshot dir, but the recommended deployment is `spec.claude.account` pinning + watch-live daemon mirroring the host-active account into the snapshot store, so the unpinned dir-bind is a degraded fallback for the host-active-login case only).
 
 #### Skip-set extension (PR #299)
 

--- a/src/scitex_agent_container/_skills/scitex-agent-container/26_credentials-rotation.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/26_credentials-rotation.md
@@ -70,17 +70,47 @@ to the same file.
 
 ### Apptainer bind (`runtimes/_apptainer_auth.py::auth_argv`)
 
-Default (host-live) path:
+Both paths (host-live AND pinned-account) dir-bind unconditionally
+(post task #13):
 
 ```
---bind <cred_file>:/tmp/sac-claude/.credentials.json:rw
+--bind <cred_file_parent>:/tmp/sac-claude:rw
 --env  CLAUDE_CONFIG_DIR=/tmp/sac-claude
 ```
+
+* `cred_file_parent` = `~/.claude/` for unpinned / host-live (the
+  agent picks up whatever account the operator is currently logged
+  in as).
+* `cred_file_parent` = `~/.scitex/agent-container/accounts/<acct>/`
+  for pinned (the snapshot dir for the named account).
 
 The **`:rw`** is why live refresh works: when the bundled `claude`
 inside the container detects a near-expiry access token (~5 min skew),
 it writes the new token back through the bind to the host canonical.
 Without `:rw` the container 401s the moment the token expires.
+
+The **directory bind** (not a single-file bind) is what keeps the
+container's view in sync with host-side atomic-rename refreshes
+(`_account/creds_watch.py` watch-live mirror, `_account/creds_sync.py
+_atomic_copy`, `_account/claude_usage._refresh_access_token_at`).
+A single-file bind would survive the rename pointing at the old inode
+— visible as `...credentials.json//deleted` in
+`/proc/<pid>/mountinfo` — and the container reads the stale
+pre-rename token forever → 401 at natural expiry. See
+[ADR-0017](../../../../docs/adr/0017-credential-rotation-and-refresh-race.md)
+§ "Failure mode 1" for the empirical anchor (2026-06-04 03:00
+fleet-wide storm).
+
+Scope acknowledgement for the unpinned dir-bind: `~/.claude/` contains
+more than just `.credentials.json` (settings.json, projects DB, chat
+history, MCP config). The dir-bind exposes these to the container,
+where the previous file-bind exposed only the creds file. The
+bundled in-container CLI already READS these via `CLAUDE_CONFIG_DIR`;
+the change is that it can now also WRITE to them. The recommended
+deployment is `spec.claude.account` pinning + the watch-live daemon
+(§ 6) mirroring the host-active account into the snapshot store, so
+the unpinned dir-bind is a degraded fallback for the host-active-login
+case only.
 
 Target lives under `/tmp/` (not `$HOME`) because D2 hardened preflight
 requires `$HOME` empty; `CLAUDE_CONFIG_DIR=/tmp/sac-claude` keeps SDK and

--- a/src/scitex_agent_container/runtimes/_apptainer_auth.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_auth.py
@@ -76,58 +76,80 @@ def auth_argv(config: AgentConfig, state_dir: Path) -> list[str]:
     # refresh code-path itself is responsible for any concurrency
     # locking — the bind is just a file passthrough.
     #
-    # Per-agent OAuth account pinning (spec.claude.account). When set,
-    # we bind the per-account DIRECTORY
-    # (``~/.scitex/agent-container/accounts/<acct>/``) at
-    # ``/tmp/sac-claude`` ``:rw``. CLAUDE_CONFIG_DIR points the
-    # in-container Claude CLI at that dir so it reads
-    # ``.credentials.json`` from within the bound directory.
+    # OAuth credentials bind shape: DIRECTORY bind, unconditionally
+    # (operator task #11 + task #13).
     #
-    # Why a DIRECTORY bind, not a single-file bind (operator task #11):
-    # the per-account snapshot is rewritten by host-side atomic-replace
-    # paths — ``_account.creds_sync._atomic_copy`` (sync-live),
-    # ``_state.account_store.switch_account``, and
+    # The per-account snapshot AND the host-live ``~/.claude/`` file are
+    # both rewritten by host-side atomic-replace paths —
+    # ``_account.creds_sync._atomic_copy`` (sync-live + watch-live),
+    # ``_state.account_store.switch_account``,
     # ``_account.claude_usage._refresh_access_token_at`` — all using
     # ``tmp + os.replace``. A single-file bind mount is on the file's
     # dentry/inode; an atomic-replace orphans that inode (the bind
     # surfaces as ``...credentials.json//deleted`` in
-    # ``/proc/<pid>/mountinfo``) and every already-running pinned agent
-    # silently loses the shared snapshot, regressing into the per-copy
-    # collision-401 disease that the snapshot model was meant to fix
-    # (PR #262 / task #15). A DIRECTORY bind resolves child files by
-    # name through the underlying filesystem on every open, so a
-    # tmp+rename inside the dir is visible to the container immediately
-    # — in BOTH directions (host writes seen by the container, and
-    # in-container CLI refresh writes seen by host writers).
+    # ``/proc/<pid>/mountinfo``) and every already-running agent
+    # silently loses the shared file, regressing into the per-copy
+    # collision-401 disease the snapshot model was meant to fix.
+    # A DIRECTORY bind resolves child files by name through the
+    # underlying filesystem on every open, so a tmp+rename inside the
+    # dir is visible to the container immediately — in BOTH directions
+    # (host writes seen by the container, and in-container CLI refresh
+    # writes seen by host writers).
     #
-    # ``account=""`` → host live ``~/.claude/.credentials.json``
-    # (unchanged behaviour; single-file bind preserved because we MUST
-    # NOT expose the entire host ``~/.claude/`` directory — chat
-    # history, projects DB, MCP settings — into the container).
+    # PR #262 (task #11) made the PINNED branch dir-bind; this module
+    # (task #13) makes the UNPINNED/host-live branch dir-bind too. The
+    # legacy single-file-bind code path is fully retired.
+    #
+    # BOTH branches dir-bind (operator task #13, 2026-06-04 cred-refresher
+    # storm root cause).
+    #
+    # Previously the unpinned/host-live branch single-file-bound
+    # ``~/.claude/.credentials.json`` at ``/tmp/sac-claude/.credentials.json``.
+    # The comment justifying that choice said the host live file is
+    # "rewritten only by manual claude /login / sac accounts switch" —
+    # this was wrong on the live system: ``_account/creds_watch.py``
+    # (the watch-live daemon mirroring ``~/.claude/`` into the snapshot
+    # store) AND ``_account/creds_sync._atomic_copy`` both atomic-replace
+    # the file. Any such rename orphans the bind's inode → bind goes
+    # ``//deleted`` in ``/proc/<pid>/mountinfo`` → container reads the
+    # stale pre-rename token forever → 401 at natural expiry. The
+    # cred-refresher agents (unpinned by design, since they refresh
+    # whatever ``~/.claude`` resolves to) hit this fleet-wide on
+    # 2026-06-04 03:00.
+    #
+    # Fix: the unpinned branch now dir-binds ``~/.claude/`` at
+    # ``/tmp/sac-claude``. Same shape as the pinned branch; ONLY the
+    # source dir differs. Atomic rename inside the bound dir is
+    # immediately visible to the container.
+    #
+    # Scope acknowledgement: this exposes the operator's host
+    # ``~/.claude/`` (settings.json, chat history, projects DB) to the
+    # container, where before only ``.credentials.json`` was visible.
+    # The bundled in-container ``claude`` CLI already READS these via
+    # ``CLAUDE_CONFIG_DIR=/tmp/sac-claude``; the change is that it can
+    # now also WRITE to them. The cleaner long-term fix is to resolve
+    # the active host login to its snapshot dir (per ADR-0017's
+    # one-account-one-refresher invariant), which only exposes
+    # ``.credentials.json``. The recommended deployment is to pin via
+    # ``spec.claude.account`` and let the unpinned dir-bind be the
+    # degraded fallback for the host-active-login case. The watch-live
+    # daemon (skill 26 § 6) mirrors operator relogins into the snapshot
+    # store so a pinned agent tracks the active login automatically.
     from ._apptainer_creds import resolve_cred_file
 
     cred_file = resolve_cred_file(config, state_dir)
     if cred_file is None or not cred_file.is_file():
         return argv
 
-    pinned_account = bool(getattr(getattr(config, "claude", None), "account", "") or "")
-    if pinned_account:
-        # Bind the per-account DIRECTORY; tmp+rename of the snapshot
-        # inside it stays visible to the container. Account-store
-        # metadata (``account.json``) is co-bound but harmless — the
-        # in-container CLI only opens ``.credentials.json``.
-        bind_src = cred_file.parent
-        bind_dest = "/tmp/sac-claude"
-    else:
-        # Unpinned: keep the legacy single-file bind. The host live
-        # ``~/.claude/.credentials.json`` is rewritten only by manual
-        # ``claude /login`` / ``sac accounts switch`` events; the
-        # routine in-container refresh writeback into a bound regular
-        # file at ``/tmp/sac-claude/.credentials.json`` is the
-        # documented contract. Binding ``~/.claude/`` itself would
-        # leak the host's full claude state into the container.
-        bind_src = cred_file
-        bind_dest = "/tmp/sac-claude/.credentials.json"
+    # Dir-bind unconditionally. ``cred_file.parent`` is:
+    #   - Pinned:   ~/.scitex/agent-container/accounts/<acct>/  (snapshot dir,
+    #               narrowly scoped to .credentials.json + account.json).
+    #   - Unpinned: ~/.claude/  (legacy host live, over-binds; see
+    #               scope-acknowledgement comment above).
+    # CLAUDE_CONFIG_DIR points the in-container CLI at the bound dir
+    # so it finds .credentials.json inside it.
+    bind_src = cred_file.parent
+    bind_dest = "/tmp/sac-claude"
 
     argv += [
         "--bind",

--- a/tests/scitex_agent_container/runtimes/test__apptainer_auth.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_auth.py
@@ -121,16 +121,30 @@ def test_provider_argv_omits_oauth_config_dir(
 
 
 def test_oauth_argv_binds_credentials_when_present(tmp_path: Path, home_redirect: Path):
-    # Arrange — no provider, real host creds file → OAuth bind emitted.
+    # Arrange — no provider, real host creds file → OAuth dir-bind emitted.
+    # Post task #13 the unpinned branch dir-binds ``~/.claude/`` at
+    # ``/tmp/sac-claude`` (same shape as the pinned branch). The bind
+    # source is the credentials file's PARENT (``~/.claude/``), not
+    # the file itself.
     creds = _write_host_creds(home_redirect)
     cfg = _oauth_config(tmp_path / "wd")
     # Act
     argv = auth_argv(cfg, state_dir=tmp_path / "state")
-    # Assert
-    assert any(
-        a.startswith(str(creds)) and "/tmp/sac-claude/.credentials.json:rw" in a
-        for a in argv
-    )
+    # Assert — dir-bind at /tmp/sac-claude (NOT /tmp/sac-claude/.credentials.json).
+    assert any(a == f"{creds.parent}:/tmp/sac-claude:rw" for a in argv)
+
+
+def test_oauth_argv_does_not_emit_legacy_file_bind(tmp_path: Path, home_redirect: Path):
+    # Arrange — task #13 retired the single-file bind to
+    # ``/tmp/sac-claude/.credentials.json``. Make sure it does not slip
+    # back in (atomic-rename refreshes orphan the bind → //deleted →
+    # 401 at expiry).
+    _write_host_creds(home_redirect)
+    cfg = _oauth_config(tmp_path / "wd")
+    # Act
+    argv = auth_argv(cfg, state_dir=tmp_path / "state")
+    # Assert — no bind whose dest is the credentials file path.
+    assert not any(":/tmp/sac-claude/.credentials.json:" in a for a in argv)
 
 
 def test_oauth_argv_sets_oauth_config_dir(tmp_path: Path, home_redirect: Path):

--- a/tests/scitex_agent_container/runtimes/test__apptainer_runtime.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_runtime.py
@@ -1042,10 +1042,14 @@ def test_argv_emits_rocm_flag_when_requested(tmp_path: Path) -> None:
     assert "--rocm" in argv
 
 
-def test_argv_mounts_credentials_file_when_present(
+def test_argv_mounts_credentials_dir_when_present(
     tmp_path: Path, home_redirect: Path
 ) -> None:
     # Arrange — Path.home() reads $HOME, redirected by the fixture.
+    # Post task #13 the unpinned branch dir-binds ``~/.claude/`` at
+    # ``/tmp/sac-claude`` (same shape as the pinned branch). The legacy
+    # single-file bind to ``/tmp/sac-claude/.credentials.json`` is
+    # retired — atomic-replace refresh would unlink the bound inode.
     creds = home_redirect / ".claude" / ".credentials.json"
     creds.parent.mkdir(parents=True, exist_ok=True)
     creds.write_text("{}")
@@ -1053,11 +1057,8 @@ def test_argv_mounts_credentials_file_when_present(
     cfg = _config(tmp_path)
     # Act
     argv = rt.build_run_argv(cfg, state_dir=tmp_path, sif_path=tmp_path / "x.sif")
-    # Assert
-    assert any(
-        a.startswith(str(creds)) and "/tmp/sac-claude/.credentials.json:rw" in a
-        for a in argv
-    )
+    # Assert — bind source is the credentials file's PARENT (~/.claude/).
+    assert any(a == f"{creds.parent}:/tmp/sac-claude:rw" for a in argv)
 
 
 def test_argv_credentials_bind_is_read_write(
@@ -1073,7 +1074,7 @@ def test_argv_credentials_bind_is_read_write(
     cfg = _config(tmp_path)
     # Act
     argv = rt.build_run_argv(cfg, state_dir=tmp_path, sif_path=tmp_path / "x.sif")
-    creds_arg = next(a for a in argv if "/tmp/sac-claude/.credentials.json" in a)
+    creds_arg = next(a for a in argv if ":/tmp/sac-claude:" in a)
     # Assert
     assert ":ro" not in creds_arg
 
@@ -1201,10 +1202,13 @@ def test_argv_pins_account_does_not_create_state_dir_copy(
     assert not legacy_copy.exists()
 
 
-def test_argv_no_account_binds_host_live_file(
+def test_argv_no_account_dir_binds_host_claude(
     tmp_path: Path, home_redirect: Path
 ) -> None:
-    # Arrange — account="" (default) keeps the legacy host-file bind.
+    # Arrange — account="" (unpinned default) now dir-binds ``~/.claude/``
+    # at ``/tmp/sac-claude`` (post task #13, same shape as the pinned
+    # branch). The legacy single-file bind is retired — atomic-replace
+    # refreshes orphaned the bound inode → //deleted → 401 at expiry.
     host_creds = home_redirect / ".claude" / ".credentials.json"
     host_creds.parent.mkdir(parents=True, exist_ok=True)
     host_creds.write_text("{}")
@@ -1212,9 +1216,9 @@ def test_argv_no_account_binds_host_live_file(
     cfg = _config(tmp_path, claude=ClaudeSpec(account=""))
     # Act
     argv = rt.build_run_argv(cfg, state_dir=tmp_path, sif_path=tmp_path / "x.sif")
-    creds_arg = next(a for a in argv if "/tmp/sac-claude/.credentials.json" in a)
-    # Assert
-    assert creds_arg.startswith(str(host_creds))
+    # Assert — bind source is the credentials file's PARENT (~/.claude/);
+    # bind dest is the DIRECTORY /tmp/sac-claude, not the file inside it.
+    assert any(a == f"{host_creds.parent}:/tmp/sac-claude:rw" for a in argv)
 
 
 def test_argv_pinned_account_missing_snapshot_raises_pinned_account_error(


### PR DESCRIPTION
## Summary

The 2026-06-04 03:00 fleet-wide 401 storm exposed the asymmetry left by PR #262: only the **pinned** branch of \`auth_argv\` was dir-binding the credentials parent. The **unpinned** branch (agents without \`spec.claude.account\`; including the cred-refresher agents by design) still single-file-bound \`~/.claude/.credentials.json\` at \`/tmp/sac-claude/.credentials.json\`. Any host-side atomic-replace (watch-live daemon mirror, sync-live, or the refresher cron itself) orphans the bound inode → \`//deleted\` → container reads stale token forever → 401 at natural token expiry.

Lead's probe at storm time: every running runner had \`deleted_binds ≥ 1\`. The 2 cred-refresher agents (started 2026-06-01 21:55) bound \`~/.claude/.credentials.json\` directly as a FILE → couldn't self-heal on restart (matches Task #13's "restart doesn't clear" symptom).

## Fix

The unpinned branch now dir-binds \`cred_file.parent\` (\`~/.claude/\`) at \`/tmp/sac-claude:rw\`, mirroring the pinned branch's shape. The single-file-bind code path is fully retired.

## Scope acknowledgement

The unpinned dir-bind exposes the operator's host \`~/.claude/\` (settings.json, projects DB, chat history, MCP config) to the container. Before, only \`.credentials.json\` was visible. The bundled in-container CLI already READS these via \`CLAUDE_CONFIG_DIR=/tmp/sac-claude\`; the change is that it can now also WRITE to them.

The **recommended deployment** is \`spec.claude.account\` pinning + the watch-live daemon mirroring the host-active account into the snapshot store; the unpinned dir-bind is a degraded fallback for the host-active-login case only. The cleaner long-term fix (resolve active host login → snapshot dir, per ADR-0017's one-account-one-refresher invariant) is out of scope for this PR; filed as a follow-up.

## Test plan

- [x] Existing pinned-account dir-bind tests still green (\`test__apptainer_auth_dir_bind.py\`)
- [x] Existing host-live unpinned tests updated to assert dir-bind shape
- [x] New regression test \`test_oauth_argv_does_not_emit_legacy_file_bind\` defends against re-introduction
- [x] Renamed \`test_argv_mounts_credentials_file_when_present\` → \`test_argv_mounts_credentials_dir_when_present\` (name now matches reality)
- [x] Renamed \`test_argv_no_account_binds_host_live_file\` → \`test_argv_no_account_dir_binds_host_claude\`
- [x] 686/686 \`tests/scitex_agent_container/runtimes/\` green
- [x] Ruff clean
- [x] Line cap clean (\`_apptainer_auth.py\` 163/512)

## Docs

- \`docs/adr/0017-credential-rotation-and-refresh-race.md\` § "Live :rw dir-bind": simplified to show both branches use the same shape; added context for PR #262's initial pinned-only scope and why the unpinned regression surfaced in the 2026-06-04 storm.
- \`_skills/scitex-agent-container/26_credentials-rotation.md\` § "Apptainer bind": unified host-live and pinned-account sections under the single dir-bind shape; added explicit scope-acknowledgement for the \`~/.claude/\` dir exposure; cross-ref to ADR-0017's empirical anchor.

## Deploy impact

Host-side argv builder change → already-running agents stay on file-bind argv until they restart. The storm-affected cred-refresher agents need this code in their respawn argv to self-heal. Per \`docs/deploy-runbook.md\`:

1. Merge → CI green → \`git pull\` on host (editable install — no \`pip install -U\` needed for this venv per lead's 2026-06-04 diagnosis).
2. Restart cred-refresher agents (and any other unpinned agents).
3. Mountinfo verification per the \"≥2 full refresh cycles, deleted=0\" protocol (also added in #301).