### PR TITLE
fix(beacon): suppress empty completion beacons at the sender

### DIFF
--- a/src/scitex_agent_container/_runners/_session_hooks.py
+++ b/src/scitex_agent_container/_runners/_session_hooks.py
@@ -117,6 +117,18 @@ async def emit_completion_push(
     outcome — should not happen, since Stop comes after the ResultMessage)
     is reported as ``unknown``, NEVER fabricated as success.
 
+    Empty-beacon guard (fleet-wide noise suppression)
+    -------------------------------------------------
+    A beacon whose ``status`` is :data:`STATUS_UNKNOWN` AND whose summary is
+    empty / whitespace carries no information for the requester — the
+    conversation never recorded an outcome and there is no reply text to
+    relay. Peers across the fleet were seeing dozens of these structurally-
+    identical empty beacons per agent, degrading the a2a channel. We
+    SUPPRESS the dispatch at the sender (loud-skip beats silent noise): the
+    skip is logged at WARNING with the agent / requester / dispatch_id so a
+    stuck emitter is observable in the agent log, and ``pushed`` is set so
+    the failure-path's redundant emit cannot retry the same empty beacon.
+
     A delivery failure is LOUD (logged at WARNING, requester named) but
     never re-raised: the turn already completed, and a flaky receipt must
     not crash the agent or abort the SDK control flow.
@@ -126,16 +138,38 @@ async def emit_completion_push(
     requester = turn_context.requester
     if not requester or turn_context.pushed:
         return
-    turn_context.pushed = True
 
     from ._session_completion import STATUS_UNKNOWN, build_completion_report
 
     status = turn_context.status or STATUS_UNKNOWN
+    summary = turn_context.summary or ""
+    # Sender-side empty-beacon guard. The join (status==unknown AND empty
+    # summary) is the structural signature of a noise beacon: the
+    # conversation never populated an outcome, so there is nothing for the
+    # requester to act on. Suppress LOUDLY (skip the wire dispatch, log a
+    # WARNING that names the emitter) rather than relay information-free
+    # noise. ``pushed`` is set BEFORE returning so the failure-path's
+    # redundant emit cannot retry the same empty beacon.
+    if status == STATUS_UNKNOWN and not summary.strip():
+        turn_context.pushed = True
+        log.warning(
+            "completion push SUPPRESSED (empty beacon) for requester %r "
+            "(agent=%s dispatch_id=%s): status=%r and summary is empty — "
+            "the conversation never recorded an outcome; skipping the "
+            "wire dispatch rather than relaying information-free noise",
+            requester,
+            agent_name,
+            turn_context.dispatch_id,
+            status,
+        )
+        return
+
+    turn_context.pushed = True
     report = build_completion_report(
         agent=agent_name,
         dispatch_id=turn_context.dispatch_id,
         status=status,
-        summary_text=turn_context.summary,
+        summary_text=summary,
     )
     try:
         await push_fn(report, requester, turn_context.dispatch_id)

--- a/tests/scitex_agent_container/_runners/test__session_completion.py
+++ b/tests/scitex_agent_container/_runners/test__session_completion.py
@@ -565,6 +565,161 @@ class TestEmitOnceGuard:
 
 
 # ---------------------------------------------------------------------------
+# emit_completion_push — sender-side empty-beacon noise suppression
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyBeaconSuppression:
+    """Sender-side guard: status==unknown AND empty summary → SKIP dispatch.
+
+    The conversation never populated an outcome (no ResultMessage, no
+    exception caught) so the beacon would carry no actionable information
+    for the requester. Across the fleet these structurally-identical empty
+    beacons were noise; suppressing at the SENDER (loud-skip beats silent
+    noise) keeps the a2a channel signal-only.
+    """
+
+    def test_unknown_status_with_empty_summary_is_suppressed(self) -> None:
+        # Arrange — begin opens turn (status=None, summary=""); never finished.
+        ctx = TurnContext()
+        ctx.begin(requester="lead", dispatch_id="d-empty")
+        calls: list = []
+
+        async def _push_fn(report, requester, dispatch_id):
+            calls.append(report)
+
+        async def _scenario():
+            await emit_completion_push(ctx, _push_fn, agent_name="worker")
+            return calls
+
+        # Act
+        observed = asyncio.run(_scenario())
+        # Assert
+        assert observed == []
+
+    def test_unknown_status_with_whitespace_only_summary_is_suppressed(self) -> None:
+        # Arrange — whitespace summary is treated as empty (no real signal).
+        ctx = TurnContext()
+        ctx.begin(requester="lead", dispatch_id="d-ws")
+        ctx.finish(status=STATUS_UNKNOWN, summary="   \n\t  ")
+        calls: list = []
+
+        async def _push_fn(report, requester, dispatch_id):
+            calls.append(report)
+
+        async def _scenario():
+            await emit_completion_push(ctx, _push_fn, agent_name="worker")
+            return calls
+
+        # Act
+        observed = asyncio.run(_scenario())
+        # Assert
+        assert observed == []
+
+    def test_unknown_status_with_real_summary_still_dispatches(self) -> None:
+        # Arrange — summary carries signal; honest "unknown" must still go.
+        ctx = TurnContext()
+        ctx.begin(requester="lead", dispatch_id="d-known-unk")
+        ctx.finish(status=STATUS_UNKNOWN, summary="partial output then SDK stalled")
+        calls: list = []
+
+        async def _push_fn(report, requester, dispatch_id):
+            calls.append(report)
+
+        async def _scenario():
+            await emit_completion_push(ctx, _push_fn, agent_name="worker")
+            return calls
+
+        # Act
+        observed = asyncio.run(_scenario())
+        # Assert
+        assert len(observed) == 1
+
+    def test_success_status_with_empty_summary_still_dispatches(self) -> None:
+        # Arrange — a clean turn that happened to produce no text is still
+        # a real outcome the requester needs to hear about.
+        ctx = TurnContext()
+        ctx.begin(requester="lead", dispatch_id="d-empty-success")
+        ctx.finish(status=STATUS_SUCCESS, summary="")
+        calls: list = []
+
+        async def _push_fn(report, requester, dispatch_id):
+            calls.append(report)
+
+        async def _scenario():
+            await emit_completion_push(ctx, _push_fn, agent_name="worker")
+            return calls
+
+        # Act
+        observed = asyncio.run(_scenario())
+        # Assert
+        assert len(observed) == 1
+
+    def test_failure_status_with_empty_summary_still_dispatches(self) -> None:
+        # Arrange — honest failure with no captured detail is still signal.
+        ctx = TurnContext()
+        ctx.begin(requester="lead", dispatch_id="d-empty-fail")
+        ctx.finish(status=STATUS_FAILURE, summary="")
+        calls: list = []
+
+        async def _push_fn(report, requester, dispatch_id):
+            calls.append(report)
+
+        async def _scenario():
+            await emit_completion_push(ctx, _push_fn, agent_name="worker")
+            return calls
+
+        # Act
+        observed = asyncio.run(_scenario())
+        # Assert
+        assert len(observed) == 1
+
+    def test_suppressed_empty_beacon_marks_turn_pushed(self) -> None:
+        # Arrange — pushed=True after suppression so the failure-path's
+        # redundant emit_completion_push() in _drive_turn.finally cannot
+        # retry the same empty beacon.
+        ctx = TurnContext()
+        ctx.begin(requester="lead", dispatch_id="d-once-empty")
+        calls: list = []
+
+        async def _push_fn(report, requester, dispatch_id):
+            calls.append(report)
+
+        async def _scenario():
+            await emit_completion_push(ctx, _push_fn, agent_name="worker")
+            return ctx.pushed
+
+        # Act
+        pushed = asyncio.run(_scenario())
+        # Assert
+        assert pushed is True
+
+    def test_suppressed_empty_beacon_logs_loud_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # Arrange — suppress must be LOUD (WARNING) so a stuck emitter is
+        # observable in the agent log; silent drops are the anti-pattern.
+        ctx = TurnContext()
+        ctx.begin(requester="lead", dispatch_id="d-loud")
+        calls: list = []
+
+        async def _push_fn(report, requester, dispatch_id):
+            calls.append(report)
+
+        async def _scenario():
+            with caplog.at_level(
+                "WARNING", logger="scitex_agent_container._runners._session_hooks"
+            ):
+                await emit_completion_push(ctx, _push_fn, agent_name="worker")
+            return caplog.records
+
+        # Act
+        records = asyncio.run(_scenario())
+        # Assert
+        assert any("SUPPRESSED" in r.getMessage() for r in records)
+
+
+# ---------------------------------------------------------------------------
 # Full conversation → requester push (real run_conversation, fake SDK module)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

A turn whose conversation never recorded an outcome (no `ResultMessage`, no exception caught) leaves `turn_context.status` at `None` (→ coerced to `STATUS_UNKNOWN`) and `turn_context.summary` at `""`. The prior emit path still dispatched that contentless beacon to the requester's inbox. Peers across the fleet were observing 35–55+ structurally-identical empty beacons per agent (this PR's own session counted 55+ before merge), degrading the a2a channel.

Sender-side guard inside `emit_completion_push`: if the resolved `status == STATUS_UNKNOWN` AND `summary` is empty / whitespace, **skip the wire dispatch** and log a **loud WARNING** that names agent + requester + dispatch_id. `turn_context.pushed = True` is set before returning so the failure-path's redundant emit in `_drive_turn.finally` cannot retry the same empty beacon. Loud-skip beats silent drop — a stuck emitter stays observable.

## Lead-directed scope assessment (auth-bypass angle, RULED OUT)

scitex-dev escalated the report from emitter-hygiene to potential bus-correctness because the same `dispatch_id` was observed on both legs of a round trip with opposing `from_agent`. Trace findings (already a2a'd to lead and acknowledged):

- **Round-trip correlation is by design.** A turn dispatched dev→clew rides `dispatch_id=X` with `from_agent=dev`; the completion beacon carries the same `dispatch_id=X` back to dev with `from_agent=<recipient agent>`. Both peers seeing the same id with opposing `from_agent` is the intended pattern — not a bus echo.
- **ACL boundary intact.** `_listen._node_channel.node_message_send` runs `_acl.check_send_acl` BEFORE persist/publish. With a per-node bearer the call REQUIRES `metadata.from_agent == authenticated_node`, else 403 "identity spoof". Only the host-wide bearer (administrative / cross-host forwarder) honors `from_agent` verbatim, by design.
- **No fan-out, no rewriter.** `broker.publish(target, event)` is keyed to a single target's subscribers; no code path re-publishes one inbound event to multiple targets, and nothing rewrites `from_agent` during routing.

**Severity: cosmetic mislabeling on contentless beacons, NOT an identity-swap / auth-bypass exposure.** Lead acknowledged this severity assessment and confirmed normal-track shipping. Single-fix branch.

If, after this PR + the deploy rebuild, the same-dispatch-id round-trip pattern is *still* misread as echo, the next look is receive-side persistence dedup in `_state.state_db_channel.persist_event` — out of scope here since the noise should be gone first.

## Tests (no mocks)

Added to `tests/scitex_agent_container/_runners/test__session_completion.py::TestEmptyBeaconSuppression` (7 new tests, real collaborators only):

- `status==unknown` + empty summary → **SUPPRESS** (no dispatch).
- `status==unknown` + whitespace-only summary → **SUPPRESS**.
- `status==unknown` + real summary → **STILL DISPATCH** (honest signal preserved).
- `status==success` + empty summary → **STILL DISPATCH** (clean turn that happened to produce no text is still signal).
- `status==failure` + empty summary → **STILL DISPATCH**.
- Suppression marks `turn_context.pushed=True` (idempotency).
- Suppression logs a WARNING containing `"SUPPRESSED"`.

All 28 tests in the affected file pass (existing 21 + 7 new). Full suite: 6277 passed, 38 skipped, 9 deselected. Two failures **reproduce on untouched develop** (verified with `git -C /work` against tip 016d39b):

- `tests/develop/test_audit.py::test_audit_all_clean` — pre-existing `--fakeroot` top-level junk file from prior PR #297 work + pre-existing `26_credentials-rotation.md` leaf-over-budget.
- `tests/integration/test_cli_startup_budget.py::test_cli_help_under_budget` — environmental timing (0.55–0.66s vs 0.50s budget). My edit is in `_runners/_session_hooks.py`, not on the CLI startup import path.

## Deploy note

This change ships inside the agent SIF, so **a SIF rebuild + agent restart is required to take effect**. Lead is coordinating that step.

## Test plan

- [x] Targeted unit tests for the suppression guard (real `TurnContext`, real `caplog`)
- [x] Full repo test suite green (modulo two pre-existing failures reproduced on develop tip)
- [x] Trace audit of the listen path for identity-swap / fan-out (no findings)