### PR TITLE
feat(to_home,skills): force_background_bash.sh hook + responsiveness doctrine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,11 @@ GITIGNORED/
 .claude/
 docs/to_claude/
 
+# But: example agent to_home/.claude/ trees ARE part of the package — they
+# ship as the documented reference template fleet operators copy from.
+!examples/agents/*/to_home/.claude/
+!examples/agents/*/to_home/.claude/**
+
 # dev artifacts
 .coverage
 .coverage.*

--- a/examples/agents/full-agent/to_home/.claude/hooks/pre-tool-use/force_background_bash.sh
+++ b/examples/agents/full-agent/to_home/.claude/hooks/pre-tool-use/force_background_bash.sh
@@ -1,0 +1,242 @@
+#!/bin/bash
+# -*- coding: utf-8 -*-
+# Timestamp: "2026-06-04 (proj-scitex-agent-container)"
+# File: examples/agents/full-agent/to_home/.claude/hooks/pre-tool-use/force_background_bash.sh
+#
+# Description: Force foreground Bash into the background for SAC agents
+# so the conversation runner's main turn stays SHORT and inbound
+# operator Telegram is answered within seconds — exactly how the lead
+# stays responsive while working.
+#
+# Foreground Bash is allowed ONLY if BOUNDED:
+#   * run_in_background: true  ─ primary; SDK delivers a completion
+#                                notification on a later turn.
+#   * explicit detach          ─ trailing `&`, OR contains
+#                                `nohup`/`setsid`/`disown`.
+#   * `timeout <=7[s]`         ─ wrapped with a 1–7 second timeout.
+#   * short trivial check      ─ <=50 chars AND no pipe/redirect/chain
+#                                AND first token is NOT in the known
+#                                long-runner set.
+# Everything else (pytest / pdflatex / make / long pipes / training
+# / unbounded jobs) is BLOCKED with a WHY message instructing the
+# agent to relaunch via one of the background mechanisms.
+#
+# Policy mirrored verbatim from the lead's _base/to_home copy
+# (dotfiles commit ac582483); the role-agnostic complement to the
+# coordinator-only `enforce_delegation.sh` and the Agent/Task-tool
+# counterpart `force_background_agents_always.sh`.
+#
+# Escape: CC_ALLOW_FOREGROUND_HEAVY=1
+# Doctrine: ~/.claude/skills/scitex/scitex-agent-container/30_responsiveness-background-work.md
+
+set -u
+
+SHORT_CMD_MAX_LEN=50
+LONG_RE='(^|[[:space:]/;&|(])(pytest|py\.test|pdflatex|xelatex|lualatex|latexmk|tectonic|make|cmake|ninja|sphinx-build|nbconvert|jupyter|cargo|npm|yarn|pnpm|sleep)([[:space:]]|$)'
+TIMEOUT_RE='(^|[;&|][[:space:]]*|&&[[:space:]]*)timeout[[:space:]]+(-[^[:space:]]+[[:space:]]+)*[1-7]s?([[:space:]]|$)'
+
+# --- self-test -------------------------------------------------------------
+if [[ "${1:-}" == "--self-test" ]]; then
+    echo "=== Self-test: $(basename "$0") ==="
+    pass=0
+    fail=0
+    run() {
+        local desc="$1" payload="$2" want="$3" rc env_prefix="${4:-}"
+        if [[ -n "$env_prefix" ]]; then
+            rc=$(env $env_prefix bash -c "printf '%s' \"\$0\" | \"$0\" >/dev/null 2>&1; echo \$?" "$payload")
+        else
+            printf '%s' "$payload" | "$0" >/dev/null 2>&1
+            rc=$?
+        fi
+        if [[ "$rc" == "$want" ]]; then
+            echo "  PASS ($rc) $desc"
+            pass=$((pass + 1))
+        else
+            echo "  FAIL got $rc want $want: $desc"
+            fail=$((fail + 1))
+        fi
+    }
+
+    # ---- BLOCK (10) — the lead's verbatim cases ---------------------------
+    run "pytest tests/ -x" '{"tool_name":"Bash","tool_input":{"command":"pytest tests/ -x"}}' 2
+    run "pdflatex paper.tex" '{"tool_name":"Bash","tool_input":{"command":"pdflatex paper.tex"}}' 2
+    run "make -C builddir" '{"tool_name":"Bash","tool_input":{"command":"make -C builddir"}}' 2
+    run "tectonic manuscript.tex" '{"tool_name":"Bash","tool_input":{"command":"tectonic manuscript.tex"}}' 2
+    run "find with pipe" '{"tool_name":"Bash","tool_input":{"command":"find /work -name '"'"'*.py'"'"' | head -20"}}' 2
+    run "install && pytest" '{"tool_name":"Bash","tool_input":{"command":"uv pip install -e .[all] && python -m pytest -q"}}' 2
+    run "timeout 60 pytest" '{"tool_name":"Bash","tool_input":{"command":"timeout 60 pytest tests/"}}' 2
+    run "timeout 7m pytest" '{"tool_name":"Bash","tool_input":{"command":"timeout 7m pytest tests/"}}' 2
+    run "sleep 30" '{"tool_name":"Bash","tool_input":{"command":"sleep 30"}}' 2
+    run "long npm install" '{"tool_name":"Bash","tool_input":{"command":"npm install --no-audit --legacy-peer-deps"}}' 2
+
+    # ---- ALLOW (10) — the lead's verbatim cases ---------------------------
+    run "timeout 7 pytest" '{"tool_name":"Bash","tool_input":{"command":"timeout 7 pytest tests/ -x"}}' 0
+    run "timeout 7s pdflatex" '{"tool_name":"Bash","tool_input":{"command":"timeout 7s pdflatex paper.tex"}}' 0
+    run "timeout -k 1 5 make" '{"tool_name":"Bash","tool_input":{"command":"timeout -k 1 5 make -C builddir"}}' 0
+    run "pytest run_in_background" '{"tool_name":"Bash","tool_input":{"command":"pytest tests/ -x","run_in_background":true}}' 0
+    run "setsid nohup pdflatex &" '{"tool_name":"Bash","tool_input":{"command":"setsid nohup pdflatex paper.tex >/tmp/x.log 2>&1 &"}}' 0
+    run "make detached &" '{"tool_name":"Bash","tool_input":{"command":"make all >/tmp/b.log 2>&1 &"}}' 0
+    run "pwd" '{"tool_name":"Bash","tool_input":{"command":"pwd"}}' 0
+    run "date" '{"tool_name":"Bash","tool_input":{"command":"date"}}' 0
+    run "git -C /work status -s" '{"tool_name":"Bash","tool_input":{"command":"git -C /work status -s"}}' 0
+    run "ls -la" '{"tool_name":"Bash","tool_input":{"command":"ls -la"}}' 0
+
+    # ---- Additional invariants (non-Bash, escape hatch) -------------------
+    run "Read (non-Bash)" '{"tool_name":"Read","tool_input":{"file_path":"/etc/hosts"}}' 0
+    run "escape hatch on pytest" '{"tool_name":"Bash","tool_input":{"command":"pytest tests/"}}' 0 'CC_ALLOW_FOREGROUND_HEAVY=1'
+
+    # ---- Numeric tool_input.timeout (enforce_delegation-style) ------------
+    # Allow when the Bash tool's own `timeout` param is <=7000ms; block
+    # when it's higher or missing for a heavy command.
+    run "pytest with tool timeout 5000" \
+        '{"tool_name":"Bash","tool_input":{"command":"pytest tests/","timeout":5000}}' 0
+    run "pdflatex with tool timeout 7000" \
+        '{"tool_name":"Bash","tool_input":{"command":"pdflatex paper.tex","timeout":7000}}' 0
+    run "pytest with tool timeout 15000" \
+        '{"tool_name":"Bash","tool_input":{"command":"pytest tests/","timeout":15000}}' 2
+    run "pytest with tool timeout 0" \
+        '{"tool_name":"Bash","tool_input":{"command":"pytest tests/","timeout":0}}' 2
+
+    echo "pass=$pass fail=$fail"
+    [[ $fail -eq 0 ]] && exit 0 || exit 1
+fi
+
+# --- entry -----------------------------------------------------------------
+
+# Escape hatch via env var (rare — when the caller KNOWS the command
+# is sub-second despite hitting a long-runner name).
+[[ "${CC_ALLOW_FOREGROUND_HEAVY:-}" == "1" ]] && exit 0
+
+input=$(cat)
+
+tool_name=$(printf '%s' "$input" | python3 -c '
+import sys, json
+try:
+    print(json.load(sys.stdin).get("tool_name", ""))
+except Exception:
+    print("")
+' 2>/dev/null)
+
+[[ "$tool_name" != "Bash" ]] && exit 0
+
+cmd=$(printf '%s' "$input" | python3 -c '
+import sys, json
+try:
+    print(json.load(sys.stdin).get("tool_input", {}).get("command", "") or "")
+except Exception:
+    print("")
+' 2>/dev/null)
+
+run_bg=$(printf '%s' "$input" | python3 -c '
+import sys, json
+try:
+    v = json.load(sys.stdin).get("tool_input", {}).get("run_in_background", False)
+    print("True" if v is True else "False")
+except Exception:
+    print("False")
+' 2>/dev/null)
+
+# Bash tool's `timeout` parameter (milliseconds, JSON field — NOT the
+# shell `timeout` command). Bounded to <=7000ms is an allowed
+# foreground variant. Lead asked for this enforce_delegation-style
+# numeric parse because it's structured data — more robust than a
+# regex on the command text.
+tool_timeout=$(printf '%s' "$input" | python3 -c '
+import sys, json
+try:
+    v = json.load(sys.stdin).get("tool_input", {}).get("timeout", None)
+    if isinstance(v, (int, float)):
+        print(int(v))
+    else:
+        print(-1)
+except Exception:
+    print(-1)
+' 2>/dev/null)
+
+# Allow path 1: run_in_background=true.
+[[ "$run_bg" == "True" ]] && exit 0
+
+# Allow path 2: explicit detach (& at end, nohup, setsid, disown).
+if printf '%s' "$cmd" | grep -qE '&[[:space:]]*$|nohup|setsid|disown'; then
+    exit 0
+fi
+
+# Allow path 3a: Bash tool's `timeout` param <= 7000ms (numeric).
+if [[ "$tool_timeout" != "-1" ]] && [[ "$tool_timeout" -ge 1 ]] && [[ "$tool_timeout" -le 7000 ]] 2>/dev/null; then
+    exit 0
+fi
+
+# Allow path 3b: shell `timeout [1-7][s]?` wrapper (regex fallback).
+if printf '%s' "$cmd" | grep -qE "$TIMEOUT_RE"; then
+    exit 0
+fi
+
+# Allow path 4: short trivial — short, no pipe/redirect/chain, not a
+# known long-runner.
+if [[ ${#cmd} -le $SHORT_CMD_MAX_LEN ]] \
+    && ! printf '%s' "$cmd" | grep -qE '[|<>]|&&|;' \
+    && ! printf '%s' "$cmd" | grep -qE "$LONG_RE"; then
+    exit 0
+fi
+
+# --- block -----------------------------------------------------------------
+log_file="${HOME}/.claude/hooks/pre-tool-use/.force_background_bash.sh.log"
+mkdir -p "$(dirname "$log_file")" 2>/dev/null || true
+printf '[%s] BLOCK unbounded foreground Bash: cmd=%q\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$cmd" >>"$log_file" 2>/dev/null || true
+
+cat >&2 <<EOF
+BLOCKED by force_background_bash.sh: unbounded foreground Bash command.
+Only BACKGROUND (or <=7s-bounded) Bash is allowed.
+
+cmd: ${cmd:0:200}
+
+WHY THIS IS BLOCKED (operator's #1 fleet UX rule, 2026-06-04):
+
+  Your conversation runner reads ONE inbox sequentially. While THIS
+  turn is busy with a long Bash, every inbound Telegram message from
+  the operator queues behind it and is NOT processed until the Bash
+  finishes. A 4-minute compile = a 4-minute Telegram silence — the
+  operator hits this repeatedly and loses trust in the agent.
+
+  Fix: keep your main loop FREE so you can answer the operator within
+  SECONDS, exactly like the lead does. The work itself is NOT
+  interrupted; it CONTINUES off the main loop, and you handle the
+  result when the runtime delivers the completion notification.
+
+  Operator wording (8843 / 8845): "作業中断はしてほしくない" — don't
+  interrupt the work; just keep the main loop free.
+
+Do ONE of:
+
+  (a) Bash(..., run_in_background=true)     ← primary; 95% of cases.
+        Pure shell command, SDK delivers a <task-notification> with
+        stdout/stderr on a later turn.
+
+  (b) setsid nohup <cmd> >/tmp/job.log 2>&1 </dev/null &
+        ← explicit detach; survives agent restart. Tail the log on a
+          later turn.
+
+  (c) Task / Agent(..., run_in_background=true)
+        ← for genuine MULTI-STEP delegated work only (research,
+          audit, code review). Don't spawn a subagent just to run
+          pytest — use (a).
+
+  (d) timeout 7 <cmd>
+        ← if the command truly finishes in <=7 seconds, just bound
+          it. (\`timeout 7\` and \`timeout 7s\` both work.)
+
+Then END YOUR TURN promptly. Do not stay in this turn watching the
+background job — the runtime wakes you on completion.
+
+Short trivial checks (<=50 chars, no pipe/redirect/chain, not a
+build/test/training command) are always allowed in the foreground —
+e.g. \`pwd\`, \`date\`, \`git -C /work status -s\`, \`ls -la\`.
+
+Bypass (rare — only when you KNOW it is sub-second despite the
+heavy pattern, e.g. \`pytest --version\`):
+  set in the shell: \`CC_ALLOW_FOREGROUND_HEAVY=1\`
+
+Doctrine: ~/.claude/skills/scitex/scitex-agent-container/30_responsiveness-background-work.md
+EOF
+exit 2

--- a/examples/agents/full-agent/to_home/CLAUDE.md
+++ b/examples/agents/full-agent/to_home/CLAUDE.md
@@ -13,3 +13,56 @@ This agent is a general-purpose worker.
 
 - Follow instructions precisely.
 - Commit and push changes when asked.
+
+## Responsiveness — short turns, background heavy work
+
+The operator's Telegram message reaches this agent via the same inbox
+the conversation reads. While a turn is in flight, inbound messages
+queue and are NOT processed until the turn ends. So a 4-minute LaTeX
+compile in the foreground means a 4-minute Telegram delay — which is
+the operator's #1 UX pain.
+
+**Default rule:** never block the main turn on long-running work.
+Launch it in the background, end the turn promptly, and handle the
+result when the runtime delivers the completion notification. The
+work itself is NOT interrupted; it CONTINUES off the main loop. The
+operator was explicit (8843): "作業中断はしてほしくない" — don't
+interrupt the work; just keep the main loop free.
+
+Heavy work → background. In order of preference:
+
+  (a) **`Bash(..., run_in_background=True)`** — primary; ~95% of
+      cases. Pure shell command (LaTeX compile, figure / mermaid
+      render, image build, `pytest` longer than ~7s, training /
+      inference, large data jobs, CI watches like `gh pr checks
+      --watch`, large downloads). SDK delivers a completion
+      notification on a later turn.
+
+  (b) **`setsid nohup <cmd> >log 2>&1 </dev/null &`** — explicit
+      detach when the job must survive the agent process restarting
+      (multi-hour training across credential rotations).
+
+  (c) **`Task` / `Agent(..., run_in_background=True)`** — for
+      genuine MULTI-STEP delegated work (research, audits, code
+      review, compile-and-report). Don't spawn a subagent just to
+      run pytest — use (a).
+
+  (d) **`timeout 7 <cmd>`** — if the command truly finishes in ≤7
+      seconds, just bound it.
+
+Foreground is fine for short trivial checks (≤50 chars, no pipe /
+redirect / chain, no known long-runner first token): `pwd`, `date`,
+`git -C /work status -s`, `ls -la`.
+
+After spawning background work: acknowledge once, then **end the
+turn**. Do not stay in the turn to watch progress — the runtime
+wakes you on completion.
+
+Doctrine + full mechanism ladder + cross-references:
+`~/.claude/skills/scitex/scitex-agent-container/30_responsiveness-background-work.md`.
+
+This rule is **structurally enforced** by the pre-tool-use hook
+`~/.claude/hooks/pre-tool-use/force_background_bash.sh` (shipped in
+this template). An unbounded foreground Bash is BLOCKED with a WHY
+message + relaunch guidance. Escape hatch (rare):
+`CC_ALLOW_FOREGROUND_HEAVY=1`.

--- a/src/scitex_agent_container/_skills/scitex-agent-container/30_responsiveness-background-work.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/30_responsiveness-background-work.md
@@ -1,0 +1,202 @@
+---
+description: |
+  [TOPIC] Stay responsive to the operator by doing every heavy job in the background.
+  [DETAILS] Default doctrine for every sac agent: never block the main conversation turn on long-running work (LaTeX compile, figure builds, pytest, training, big git ops, image builds, large data downloads). Launch heavy work as a BACKGROUND process — `Bash run_in_background=true` or `Agent run_in_background=true` — end the current turn promptly, and handle the result when the runtime delivers the completion notification. The operator's Telegram message is delivered to the same inbox the conversation reads; while a turn is in flight, new Telegram messages QUEUE and are not picked up until the turn ends. The cure is a short turn, not a more clever interrupt. Short turns also keep the prompt cache warm (5-min TTL) and let other peers/the lead drive the agent without waiting minutes per round-trip.
+tags: [scitex-agent-container-responsiveness, background-work, telegram-latency, short-turns]
+---
+
+# Responsiveness — short turns + background heavy work
+
+> Operator UX rule (lead directive, 2026-06-04): the operator's
+> Telegram message must be answered within seconds, never minutes.
+
+> **Structural enforcement**: a pre-tool-use hook
+> ``~/.claude/hooks/pre-tool-use/force_background_bash.sh`` (shipped
+> under ``examples/agents/full-agent/to_home/.claude/hooks/`` and
+> deployed fleet-wide via the ``agents/_base/to_home/`` overlay)
+> BLOCKS any unbounded foreground Bash with a WHY message that
+> explains the relaunch routes. This skill explains the rationale;
+> the hook is the wall. If the hook blocks you, the relaunch
+> guidance comes from the hook itself — don't fight it, do not
+> bypass except via the documented escape hatch.
+>
+> **Hook layering** (PreToolUse on the Bash matcher):
+>   1. ``enforce_delegation.sh`` (lead-side, dotfiles) — fires only
+>      for coordinator roles (``lead``, ``head-*``, ``telegram``,
+>      ``proj-*``). Adds the coordinator-extra "delegate to a SAC
+>      peer" guidance on top of the bounded-foreground rule.
+>   2. ``force_background_bash.sh`` (this hook, role-agnostic) —
+>      fires for every agent regardless of role, applies the same
+>      bounded-foreground policy verbatim. The fleet's safety net.
+>   3. ``force_background_agents_always.sh`` (sibling, Agent/Task
+>      matcher) — forces every Agent/Task subagent invocation to use
+>      ``run_in_background=true`` so the parent never blocks on
+>      child work.
+>
+> The three hooks compose: 1 + 2 give "no unbounded foreground
+> Bash"; 3 gives "no foreground subagents".
+
+## The problem (why this rule exists)
+
+The conversation runner reads its inbox sequentially:
+``_runners/_session_conversation.py`` blocks on ``await inbox.get()``
+between turns. Telegram messages, A2A turns, and the autonomous loop
+all post ``TurnEnvelope``s onto the SAME inbox. While ``_drive_turn``
+is running, new envelopes are accepted and queued but **NOT
+processed** until the current turn finishes.
+
+So if your turn is a 4-minute LaTeX compile, the operator's "stop
+that and check this instead" arrives, sits in the queue, and is
+answered four minutes later. The operator hits this repeatedly and
+loses trust in the agent.
+
+The fix is not a smarter interrupt — it is a shorter turn.
+
+## The rule
+
+**Never block the main turn on long-running work.** Launch it in the
+background, end the turn promptly, and handle the result when the
+notification fires.
+
+### Heavy work that MUST go to the background
+
+| Operation | Tool | Background invocation |
+|---|---|---|
+| ``pytest`` (anything > 7s) | Bash | ``Bash(... , run_in_background=True)`` |
+| LaTeX compile (``pdflatex`` / ``xelatex`` / ``latexmk`` / ``tectonic``) | Bash | ``Bash(... , run_in_background=True)`` |
+| Figure build, mermaid render, nbconvert | Bash | ``Bash(... , run_in_background=True)`` |
+| ``make`` / ``cmake`` / ``ninja`` / ``sphinx-build`` | Bash | ``Bash(... , run_in_background=True)`` |
+| Training / inference / large numpy jobs | Bash | ``Bash(... , run_in_background=True)`` |
+| Big git ops (clone of multi-GB repo, ``git filter-repo``) | Bash | ``Bash(... , run_in_background=True)`` |
+| Apptainer / Docker image build | Bash | ``Bash(... , run_in_background=True)`` |
+| ``cargo`` / ``npm`` / ``yarn`` / ``pnpm`` / ``pip install`` | Bash | ``Bash(... , run_in_background=True)`` |
+| ``jupyter`` / nbconvert long render | Bash | ``Bash(... , run_in_background=True)`` |
+| ``sleep N`` for N ≥ 1 | Bash | ``Bash(... , run_in_background=True)`` |
+| Multi-step research / code-review delegation | Agent | ``Agent(... , run_in_background=True)`` |
+| ``gh pr checks --watch`` / CI poll | Bash | ``Bash(... , run_in_background=True)`` |
+| Any download > 100 MB | Bash | ``Bash(... , run_in_background=True)`` |
+| Anything chained with ``&&`` / ``||`` / ``;`` or piped | Bash | ``Bash(... , run_in_background=True)`` |
+
+If you are not sure whether the job is heavy, assume it is. The cost
+of mis-classifying a 2-second job as background is one extra
+notification round-trip; the cost of mis-classifying a 4-minute job
+as foreground is operator frustration.
+
+### Foreground is fine for
+
+Short trivial checks — defined by the hook as ≤50 characters, no
+pipe/redirect/chain (``|`` / ``<`` / ``>`` / ``&&`` / ``;``), and
+no first-token in the known long-runner set:
+
+- Single ``Read`` / ``Edit`` / ``Write`` / ``Grep`` calls (non-Bash).
+- ``pwd``, ``date``, ``whoami``, ``hostname``, ``id``, ``uname``.
+- ``ls -la``, ``cat /etc/hostname``, ``echo ...``, ``head -5 file``.
+- ``git -C /work status -s``, ``git log --oneline -5``, ``git diff HEAD~1``.
+- Anything wrapped in ``timeout N`` where N is 1–7 (with or without
+  the ``s`` suffix).
+
+If the trivial-foreground check fails, the hook blocks you and asks
+you to relaunch via mechanism (1)–(4) above.
+
+## The shape of a responsive turn
+
+```
+Turn N    (operator: "audit the build")
+  ├─ Acknowledge in one line via Telegram reply.
+  ├─ Spawn Agent(run_in_background=true, prompt="audit ...").
+  └─ END THE TURN. ← critical
+        (Inbox is now free; if the operator follows up,
+         it is processed immediately.)
+
+Turn N+1  (notification: agent completed)
+  ├─ Read the agent's report.
+  ├─ Relay summary to operator via Telegram.
+  └─ END THE TURN.
+```
+
+The wrong shape — and the one that produces operator frustration:
+
+```
+Turn N    (operator: "audit the build")
+  ├─ Acknowledge.
+  ├─ Run pytest in the foreground for 90 seconds.
+  ├─ Run gh pr checks --watch for 3 minutes.
+  ├─ Compile LaTeX for another 4 minutes.
+  └─ ... operator's "actually never mind, check X" sat in the queue
+        the whole time.
+```
+
+## Available mechanisms (in claude-agent-sdk + sac runner)
+
+Verified for the bundled Claude Code CLI ``2.1.150`` shipped with
+``claude-agent-sdk 0.2.87`` (the version sac runs inside its SIF):
+
+1. **``Bash(..., run_in_background=True)``** — primary; ~95% of
+   cases. Pure shell command (LaTeX compile, image build, ``pytest``,
+   training, CI watch, large download). The CLI binary 2.1.150
+   exposes ``run_in_background`` on Bash; the sac runner does not
+   strip the parameter (``runtimes/_sdk_common.py:475-478`` only
+   appends "Agent" to ``allowed_tools``). The runtime delivers a
+   completion notification with stdout/stderr on a later turn.
+
+2. **``setsid nohup <cmd> >log 2>&1 </dev/null &``** — explicit
+   detach. Use when the job must survive the agent process itself
+   restarting (e.g. a multi-hour training that should outlive a
+   credential rotation). Pair with a ``tail`` / status-file pattern
+   on a later turn to pick up results. Recognised by the
+   ``force_background_bash.sh`` hook as a valid background route.
+
+3. **``Task`` / ``Agent(..., run_in_background=True)``** — for
+   genuine MULTI-STEP delegated work (research, audits, code
+   review, compile-and-report). The runner explicitly enables
+   Subagents (same line above); the CLI exposes ``run_in_background``
+   on Task. Don't spawn a subagent just to run pytest — use (1).
+   Right when the work has reasoning around it.
+
+4. **``timeout N <cmd>``** where N is 1–7 seconds — bounded
+   foreground. The ``force_background_bash.sh`` hook treats this as
+   an allowed foreground variant. Use only when you genuinely
+   expect the command to finish in ≤7s.
+
+5. **Full-agent peer delegation (`sac peer post-turn ...`)** — for
+   the heaviest, longest-horizon work (days). Spawns another sac
+   agent. See ``18_full-agent-delegation.md``.
+
+Pick the highest-level mechanism that fits. (1) is almost always
+right; (3) when the work has multi-step reasoning around it; (2)
+when the job must survive a restart.
+
+## What "end the turn promptly" means
+
+End the turn as soon as you have:
+
+1. Acknowledged the request (one short reply to the operator).
+2. Spawned the background work.
+3. Done any sub-5-second foreground prep needed to start the
+   background job correctly.
+
+Do **not** stay in the turn to "watch" the background job. The
+runtime delivers a ``<task-notification>`` (for Agent runs) or a
+shell-completion notification (for Bash ``run_in_background``)
+automatically; you will be woken when there is something to do.
+
+## Cache + responsiveness side benefit
+
+Short turns also keep the Anthropic prompt cache warm. The TTL is
+five minutes; a long uninterrupted turn that reads many files at the
+start eats the cache budget even when the model is idle between tool
+calls. Short turns + background offload keep more of the next turn's
+input on cache hits.
+
+## Cross-references
+
+- ``18_full-agent-delegation.md`` — full-agent peer pattern (also
+  inherently async; the launcher's turn ends, the peer runs for hours).
+- ``17_inbound-turn-endpoint.md`` — how ``POST /v1/turn`` envelopes
+  reach the same inbox Telegram posts to (so a short turn matters
+  for *any* inbound, not just operator).
+- ``29_progress-reporting-to-lead.md`` — the lead is also a consumer
+  of "agent reachable now" — push milestones, don't make the lead
+  poll while you sit in a 4-minute compile.
+- ``23_telegram-integration.md`` — the Telegram delivery path that
+  this rule exists to keep responsive.

--- a/src/scitex_agent_container/_skills/scitex-agent-container/SKILL.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/SKILL.md
@@ -70,6 +70,7 @@ session inside Apptainer (local or remote via SSH), observe via
 - [27_credentials-relogin.md](27_credentials-relogin.md) — verified re-login flow (tmux code-paste) + 401-recovery design
 - [28_credential-refresh.md](28_credential-refresh.md) — refresh creds without restart: a running agent re-reads the mounted credential on its next turn (`sac agents send "continue"`); cold `start` only for parked
 - [29_progress-reporting-to-lead.md](29_progress-reporting-to-lead.md) — milestone push to lead via a2a_send
+- [30_responsiveness-background-work.md](30_responsiveness-background-work.md) — agent default: short turns, heavy work to background, so operator Telegram is answered within seconds
 
 ### Reference
 - [13_observability.md](13_observability.md) — `sac agents status` JSON contract

--- a/tests/examples/test_force_background_bash_hook.py
+++ b/tests/examples/test_force_background_bash_hook.py
@@ -1,0 +1,312 @@
+"""Pre-tool-use hook: structurally enforce background launch of unbounded Bash.
+
+The operator's #1 fleet UX pain (lead directive 2026-06-04, operator
+messages 8843 / 8845 / 8847 / 8852 / 8861 / 8862 / 8864): a foreground
+Bash that runs for minutes blocks the conversation runner and delays
+operator Telegram. Enforcement is a pre-tool-use hook — structural,
+not behavioural — so an agent CANNOT accidentally run an unbounded
+foreground Bash and queue the operator behind it.
+
+Canonical policy (mirrors the lead's _base/to_home copy, dotfiles
+commit ac582483):
+
+  Allow foreground ONLY if BOUNDED:
+    * ``run_in_background: true``                ← primary
+    * explicit detach: trailing ``&``, ``nohup``, ``setsid``, ``disown``
+    * ``timeout [1-7]s?`` wrapper
+    * short trivial (<=50 chars, no pipe/redirect/chain, no
+      long-runner first token)
+  Else BLOCK with a WHY message that explains the Telegram-latency
+  cause and offers four relaunch routes (Bash bg / setsid nohup / Task
+  subagent / timeout 7).
+
+  Escape: ``CC_ALLOW_FOREGROUND_HEAVY=1``.
+
+The hook ships in the example agent template so future agents inherit
+it; the lead's identical-policy copy in dotfiles ``_base/to_home`` is
+the fleet rollout surface.
+
+Each test asserts a single observable invariant. AAA layout. No mocks.
+The hook script is invoked as a real subprocess on real stdin payloads.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+HOOK = (
+    REPO_ROOT
+    / "examples"
+    / "agents"
+    / "full-agent"
+    / "to_home"
+    / ".claude"
+    / "hooks"
+    / "pre-tool-use"
+    / "force_background_bash.sh"
+)
+
+
+def _bash_payload(
+    command: str,
+    *,
+    run_in_background: bool | None = None,
+    timeout: int | None = None,
+) -> str:
+    body: dict = {"tool_name": "Bash", "tool_input": {"command": command}}
+    if run_in_background is not None:
+        body["tool_input"]["run_in_background"] = run_in_background
+    if timeout is not None:
+        body["tool_input"]["timeout"] = timeout
+    return json.dumps(body)
+
+
+def _run_hook(payload: str, *, env_override: dict[str, str] | None = None):
+    env = os.environ.copy()
+    if env_override:
+        env.update(env_override)
+    return subprocess.run(
+        ["bash", str(HOOK)],
+        input=payload,
+        text=True,
+        capture_output=True,
+        env=env,
+    )
+
+
+# --- file / executable / self-test -----------------------------------------
+
+
+def test_hook_file_exists() -> None:
+    # Arrange
+    target = HOOK
+    # Act
+    present = target.is_file()
+    # Assert
+    assert present, f"expected hook at {target}"
+
+
+def test_hook_is_executable() -> None:
+    # Arrange
+    mode = HOOK.stat().st_mode
+    # Act
+    executable = bool(mode & stat.S_IXUSR)
+    # Assert
+    assert executable, "hook must have user-executable bit set"
+
+
+def test_hook_self_test_passes() -> None:
+    # Arrange
+    cmd = ["bash", str(HOOK), "--self-test"]
+    # Act
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    # Assert
+    assert result.returncode == 0, (
+        f"self-test failed (rc={result.returncode}):\n"
+        f"--- stdout ---\n{result.stdout}\n"
+        f"--- stderr ---\n{result.stderr}"
+    )
+
+
+# --- BLOCK cases mirrored from the lead's verbatim self-test --------------
+
+
+def test_blocks_pytest() -> None:
+    assert _run_hook(_bash_payload("pytest tests/ -x")).returncode == 2
+
+
+def test_blocks_pdflatex() -> None:
+    assert _run_hook(_bash_payload("pdflatex paper.tex")).returncode == 2
+
+
+def test_blocks_make() -> None:
+    assert _run_hook(_bash_payload("make -C builddir")).returncode == 2
+
+
+def test_blocks_tectonic() -> None:
+    assert _run_hook(_bash_payload("tectonic manuscript.tex")).returncode == 2
+
+
+def test_blocks_pipe_chain() -> None:
+    # `find ... | head -20` — has a pipe, so not "short trivial"
+    assert (
+        _run_hook(_bash_payload("find /work -name '*.py' | head -20")).returncode == 2
+    )
+
+
+def test_blocks_install_then_pytest_chain() -> None:
+    # && chain — not trivial; contains heavy pytest tail.
+    cmd = "uv pip install -e .[all] && python -m pytest -q"
+    assert _run_hook(_bash_payload(cmd)).returncode == 2
+
+
+def test_blocks_timeout_greater_than_seven_seconds() -> None:
+    # timeout 60 is well above the 1-7s bounded window.
+    assert _run_hook(_bash_payload("timeout 60 pytest tests/")).returncode == 2
+
+
+def test_blocks_timeout_with_minutes_unit() -> None:
+    # 7m is minutes — the policy only accepts 1-7 seconds (s or no unit).
+    assert _run_hook(_bash_payload("timeout 7m pytest tests/")).returncode == 2
+
+
+def test_blocks_long_sleep() -> None:
+    # sleep is in LONG_RE; not trivial; no bound.
+    assert _run_hook(_bash_payload("sleep 30")).returncode == 2
+
+
+def test_blocks_long_unbounded_install() -> None:
+    # npm install is in LONG_RE; > 50 chars so not trivial-allowed.
+    cmd = "npm install --no-audit --legacy-peer-deps"
+    assert _run_hook(_bash_payload(cmd)).returncode == 2
+
+
+# --- ALLOW cases mirrored from the lead's verbatim self-test --------------
+
+
+def test_allows_timeout_7_pytest() -> None:
+    assert _run_hook(_bash_payload("timeout 7 pytest tests/ -x")).returncode == 0
+
+
+def test_allows_timeout_7s_pdflatex() -> None:
+    assert _run_hook(_bash_payload("timeout 7s pdflatex paper.tex")).returncode == 0
+
+
+def test_allows_timeout_kill_flag_5s_make() -> None:
+    # timeout -k 1 5 make ... — timeout flag + value 5 (within 1-7).
+    assert _run_hook(_bash_payload("timeout -k 1 5 make -C builddir")).returncode == 0
+
+
+def test_allows_pytest_run_in_background_true() -> None:
+    assert (
+        _run_hook(_bash_payload("pytest tests/ -x", run_in_background=True)).returncode
+        == 0
+    )
+
+
+def test_allows_setsid_nohup_explicit_detach() -> None:
+    cmd = "setsid nohup pdflatex paper.tex >/tmp/x.log 2>&1 &"
+    assert _run_hook(_bash_payload(cmd)).returncode == 0
+
+
+def test_allows_make_detached_with_trailing_ampersand() -> None:
+    cmd = "make all >/tmp/b.log 2>&1 &"
+    assert _run_hook(_bash_payload(cmd)).returncode == 0
+
+
+def test_allows_short_pwd() -> None:
+    assert _run_hook(_bash_payload("pwd")).returncode == 0
+
+
+def test_allows_short_date() -> None:
+    assert _run_hook(_bash_payload("date")).returncode == 0
+
+
+def test_allows_short_git_status() -> None:
+    assert _run_hook(_bash_payload("git -C /work status -s")).returncode == 0
+
+
+def test_allows_short_ls() -> None:
+    assert _run_hook(_bash_payload("ls -la")).returncode == 0
+
+
+# --- numeric tool_input.timeout (enforce_delegation-style, lead-asked) ---
+
+
+def test_allows_heavy_command_with_tool_timeout_5000ms() -> None:
+    # Arrange — pytest is heavy, but the Bash tool's own timeout caps it.
+    payload = _bash_payload("pytest tests/", timeout=5000)
+    # Act + Assert
+    assert _run_hook(payload).returncode == 0
+
+
+def test_allows_heavy_command_with_tool_timeout_exactly_7000ms() -> None:
+    payload = _bash_payload("pdflatex paper.tex", timeout=7000)
+    assert _run_hook(payload).returncode == 0
+
+
+def test_blocks_heavy_command_with_tool_timeout_15000ms() -> None:
+    # Arrange — timeout is set but too large.
+    payload = _bash_payload("pytest tests/", timeout=15000)
+    # Act + Assert
+    assert _run_hook(payload).returncode == 2
+
+
+def test_blocks_heavy_command_with_tool_timeout_zero() -> None:
+    # Arrange — timeout=0 must NOT be treated as bounded.
+    payload = _bash_payload("pytest tests/", timeout=0)
+    # Act + Assert
+    assert _run_hook(payload).returncode == 2
+
+
+# --- non-Bash tool + escape hatch -----------------------------------------
+
+
+def test_allows_non_bash_tool() -> None:
+    payload = json.dumps(
+        {"tool_name": "Read", "tool_input": {"file_path": "/etc/hosts"}}
+    )
+    assert _run_hook(payload).returncode == 0
+
+
+def test_honors_escape_hatch_env() -> None:
+    payload = _bash_payload("pytest tests/")
+    result = _run_hook(payload, env_override={"CC_ALLOW_FOREGROUND_HEAVY": "1"})
+    assert result.returncode == 0
+
+
+# --- block message must explain the WHY (operator 8852 "説明も入れて") ----
+
+
+def test_block_message_names_telegram_latency_cost() -> None:
+    result = _run_hook(_bash_payload("pytest tests/"))
+    stderr = result.stderr.lower()
+    assert result.returncode == 2
+    assert "telegram" in stderr, "block message must name the Telegram-latency cost"
+
+
+def test_block_message_explains_inbox_mechanism() -> None:
+    result = _run_hook(_bash_payload("pytest tests/"))
+    stderr = result.stderr.lower()
+    assert result.returncode == 2
+    assert "inbox" in stderr or "main loop" in stderr or "main turn" in stderr, (
+        "block message must explain the inbox/main-loop mechanism"
+    )
+
+
+def test_block_message_states_work_is_not_interrupted() -> None:
+    result = _run_hook(_bash_payload("pytest tests/"))
+    stderr = result.stderr.lower()
+    assert result.returncode == 2
+    assert (
+        "not interrupt" in stderr
+        or "continues" in stderr
+        or "off the main loop" in stderr
+    ), "block message must reassure that work CONTINUES, just off the main loop"
+
+
+def test_block_message_lists_all_four_relaunch_options() -> None:
+    stderr = _run_hook(_bash_payload("pytest tests/")).stderr
+    assert "run_in_background" in stderr, "must offer Bash run_in_background"
+    assert "setsid nohup" in stderr, "must offer setsid nohup detach"
+    assert "Task" in stderr or "Agent" in stderr, "must offer Task/Agent subagent"
+    assert "timeout 7" in stderr, "must offer timeout 7 bounded fallback"
+
+
+def test_block_message_documents_escape_hatch() -> None:
+    stderr = _run_hook(_bash_payload("pytest tests/")).stderr
+    assert "CC_ALLOW_FOREGROUND_HEAVY" in stderr, "must document the escape hatch"
+
+
+def test_block_message_quotes_operator_wording() -> None:
+    # Operator's exact wording reframes the rule for any future agent.
+    stderr = _run_hook(_bash_payload("pytest tests/")).stderr
+    assert "作業中断はしてほしくない" in stderr, (
+        "must include operator's wording 8843/8845"
+    )

--- a/tests/scitex_agent_container/_skills/scitex-agent-container/test_responsiveness_doctrine.py
+++ b/tests/scitex_agent_container/_skills/scitex-agent-container/test_responsiveness_doctrine.py
@@ -1,0 +1,171 @@
+"""Fleet-wide responsiveness doctrine — durable rollout invariants.
+
+The operator's #1 UX pain (lead directive 2026-06-04): a Telegram
+message must NOT wait until the agent's current heavy turn finishes.
+The chosen primary fix is doctrine — never block the main turn on
+long-running work; launch it in the background, end the turn promptly,
+handle the result on completion. This file pins that doctrine into
+two delivery surfaces so every agent on next restart inherits it:
+
+  * The shipped skill ``30_responsiveness-background-work.md`` —
+    auto-delivered to every agent's ``~/.claude/skills/scitex/
+    scitex-agent-container/`` via the package's ``_skills`` tree.
+  * The example agent ``to_home/CLAUDE.md`` template — the canonical
+    reference fleet operators copy from.
+  * The skill index ``SKILL.md`` — lists the new skill so it surfaces
+    in the package's table of contents.
+
+Each test asserts a single observable invariant. AAA layout. No mocks.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+
+SKILL_FILE = (
+    REPO_ROOT
+    / "src"
+    / "scitex_agent_container"
+    / "_skills"
+    / "scitex-agent-container"
+    / "30_responsiveness-background-work.md"
+)
+
+SKILL_INDEX = (
+    REPO_ROOT
+    / "src"
+    / "scitex_agent_container"
+    / "_skills"
+    / "scitex-agent-container"
+    / "SKILL.md"
+)
+
+EXAMPLE_CLAUDE_MD = (
+    REPO_ROOT / "examples" / "agents" / "full-agent" / "to_home" / "CLAUDE.md"
+)
+
+
+def test_skill_file_exists() -> None:
+    # Arrange
+    target = SKILL_FILE
+    # Act
+    present = target.is_file()
+    # Assert
+    assert present, f"expected shipped skill at {target}"
+
+
+def test_skill_has_frontmatter_description() -> None:
+    # Arrange
+    text = SKILL_FILE.read_text(encoding="utf-8")
+    # Act
+    has_fm = text.startswith("---\n") and "\n---\n" in text[4:]
+    has_desc = "description:" in text.split("\n---\n", 1)[0]
+    # Assert
+    assert has_fm and has_desc, (
+        "skill must open with YAML frontmatter including description"
+    )
+
+
+def test_skill_has_tags() -> None:
+    # Arrange
+    text = SKILL_FILE.read_text(encoding="utf-8")
+    front = text.split("\n---\n", 1)[0]
+    # Act
+    has_tags = "tags:" in front
+    # Assert
+    assert has_tags, "skill must declare tags in frontmatter"
+
+
+def test_skill_mentions_background_launch() -> None:
+    # Arrange
+    text = SKILL_FILE.read_text(encoding="utf-8").lower()
+    # Act
+    mentions = "background" in text and "run_in_background" in text
+    # Assert
+    assert mentions, "skill must direct heavy work to background (run_in_background)"
+
+
+def test_skill_mentions_short_turns_for_telegram() -> None:
+    # Arrange
+    text = SKILL_FILE.read_text(encoding="utf-8").lower()
+    # Act
+    has_short = "short" in text and "turn" in text
+    has_telegram = "telegram" in text
+    # Assert
+    assert has_short and has_telegram, (
+        "skill must explain SHORT turns so operator Telegram stays responsive"
+    )
+
+
+def test_skill_lists_heavy_work_examples() -> None:
+    # Arrange
+    text = SKILL_FILE.read_text(encoding="utf-8").lower()
+    # Act — at least three canonical heavy operations must be called out
+    examples = ("latex", "pytest", "figure", "training", "git")
+    hits = sum(1 for kw in examples if kw in text)
+    # Assert
+    assert hits >= 3, f"expected ≥3 of {examples!r} in skill, found {hits}"
+
+
+def test_skill_index_references_new_skill() -> None:
+    # Arrange
+    index_text = SKILL_INDEX.read_text(encoding="utf-8")
+    # Act
+    referenced = "30_responsiveness-background-work.md" in index_text
+    # Assert
+    assert referenced, "SKILL.md must link the new responsiveness skill"
+
+
+def test_example_claude_md_has_responsiveness_section() -> None:
+    # Arrange
+    text = EXAMPLE_CLAUDE_MD.read_text(encoding="utf-8")
+    # Act
+    has_heading = "Responsiveness" in text
+    # Assert
+    assert has_heading, "example to_home/CLAUDE.md must carry a Responsiveness section"
+
+
+def test_example_claude_md_directs_heavy_work_to_background() -> None:
+    # Arrange
+    text = EXAMPLE_CLAUDE_MD.read_text(encoding="utf-8").lower()
+    # Act
+    directs = "background" in text and (
+        "run_in_background" in text or "long-running" in text
+    )
+    # Assert
+    assert directs, "example CLAUDE.md must direct heavy work to the background"
+
+
+def test_example_claude_md_calls_out_telegram_responsiveness() -> None:
+    # Arrange
+    text = EXAMPLE_CLAUDE_MD.read_text(encoding="utf-8").lower()
+    # Act
+    mentions = "telegram" in text
+    # Assert
+    assert mentions, "example CLAUDE.md must mention Telegram responsiveness as the why"
+
+
+def test_example_claude_md_references_enforcement_hook() -> None:
+    # Arrange — operator wants structural enforcement (hook), not just rule.
+    text = EXAMPLE_CLAUDE_MD.read_text(encoding="utf-8")
+    # Act
+    referenced = "force_background_bash.sh" in text
+    # Assert
+    assert referenced, (
+        "example CLAUDE.md must point at the enforcement hook so future "
+        "agents know it's structural, not behavioural"
+    )
+
+
+def test_skill_references_enforcement_hook() -> None:
+    # Arrange
+    text = SKILL_FILE.read_text(encoding="utf-8")
+    # Act
+    referenced = "force_background_bash.sh" in text
+    # Assert
+    assert referenced, (
+        "skill must point at the enforcement hook so rationale + wall live "
+        "next to each other"
+    )


### PR DESCRIPTION
## Summary

Lands the operator's #1 fleet UX rule (2026-06-04, operator msgs
8843–8865 routed via lead) as **structural enforcement + doctrine**:
agents must answer Telegram within seconds, not after a heavy turn
finishes. Heavy work runs in the BACKGROUND so the main loop stays
free; the work itself is **not interrupted** (operator 8843
"作業中断はしてほしくない").

### What ships

| File | Purpose |
|---|---|
| `examples/agents/full-agent/to_home/.claude/hooks/pre-tool-use/force_background_bash.sh` | The hook — role-agnostic, allow-only-bounded, mirrors the lead's `_base/to_home` copy (dotfiles `ac582483`) verbatim |
| `src/scitex_agent_container/_skills/scitex-agent-container/30_responsiveness-background-work.md` | Doctrine skill — auto-delivers to every agent on container rebuild + restart |
| `examples/agents/full-agent/to_home/CLAUDE.md` | Responsiveness section directing heavy work to background |
| `src/scitex_agent_container/_skills/scitex-agent-container/SKILL.md` | Indexes the new skill |
| `tests/examples/test_force_background_bash_hook.py` | 32 hook tests (lead's 20 verbatim cases + numeric-timeout + WHY-message invariants) |
| `tests/scitex_agent_container/_skills/scitex-agent-container/test_responsiveness_doctrine.py` | 15 doctrine tests (skill/CLAUDE.md content pins) |
| `.gitignore` | Allow `examples/**/.claude/` (the example template ships as package data) |

### Hook policy (verbatim from lead's dotfiles copy)

Foreground Bash allowed ONLY if BOUNDED:
- `run_in_background:true`
- explicit detach (`&` / `nohup` / `setsid` / `disown`)
- Bash tool's numeric `timeout ≤ 7000ms` (enforce_delegation-style — added per lead's robustness ask)
- shell `timeout [1-7]s?` wrapper (regex fallback)
- short trivial (≤50 chars, no pipe/redirect/chain, not in long-runner set)

Else exit 2 with a doctrine-rich WHY message: explains the Telegram-latency cause, quotes the operator's wording, and offers four relaunch routes in lead-blessed priority order:
1. `Bash(..., run_in_background=True)` — primary; ~95%
2. `setsid nohup <cmd> >log 2>&1 </dev/null &` — survive-restart
3. `Task / Agent(..., run_in_background=True)` — multi-step delegation only
4. `timeout 7 <cmd>` — bounded foreground when truly sub-7s

Escape: `CC_ALLOW_FOREGROUND_HEAVY=1`.

Tests pin the WHY content so a future refactor can't strip it (operator 8852 "説明も入れて" structurally enforced).

### Hook layering (no overlap, fleet-wide coverage)

1. `enforce_delegation.sh` (lead-side dotfiles) — coordinator-only roles (lead / head-* / telegram / proj-*); adds the "delegate to SAC peer" extra layer.
2. **This hook (`force_background_bash.sh`, role-agnostic)** — fills the role-coverage gap so worker roles like proj-neurovista (role `project-maintainer`) are also gated.
3. `force_background_agents_always.sh` (existing dotfiles, Agent matcher) — forces every Agent/Task subagent to use `run_in_background:true`.

### Mechanism verified

- claude-agent-sdk 0.2.87 bundles Claude Code CLI 2.1.150 (`_cli_version.py:3`)
- CLI 2.1.150 exposes `run_in_background` on both Bash and Task tools
- sac runner does not strip either: `runtimes/_sdk_common.py:475-478` only appends `Agent` to `allowed_tools` (Subagents enabler); `permission_mode=bypassPermissions`
- Hook self-test: `pass=26 fail=0`
- Pytest mirror (TDD red→green): 47/47

## Test plan

- [x] Hook `--self-test` passes (26 cases — lead's 20 verbatim + 4 numeric-timeout + 2 non-Bash/escape)
- [x] Pytest hook suite green (32 tests covering BLOCK/ALLOW/WHY-invariants)
- [x] Pytest doctrine suite green (15 tests pinning skill + CLAUDE.md content)
- [x] Full repo suite: **5893/5895 pass** (2 failures unrelated to this PR — see below)
- [ ] CI green
- [ ] Lead reviews + merges; then swaps the canonical version into the dotfiles `_base/to_home/` copy

### Known pre-existing failures (not blockers)

- `tests/develop/test_audit.py::test_audit_all_clean` — upstream `scitex_dev._cli.audit._summary._mcp_audit.py:133` TypeError (`Path(None)` on `bridge_pkg.__file__`). Pre-existing on develop tip; unrelated to this PR.
- `tests/scitex_agent_container/_state/test_state_db.py::test_export_state_filters_out_instance_rows_older_than_since_cutoff` — passes in isolation; flaky under concurrent full-suite load. Pre-existing; unrelated to this PR.

## Fleet rollout

When this lands green, the lead replaces the existing `_base/to_home/` copy with this canonical version. Same filename (`force_background_bash.sh`) and same env var (`CC_ALLOW_FOREGROUND_HEAVY=1`) so no `settings.local.json` re-registration is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)