### PR TITLE
fix(image-build): mirror lead's hand-built SIF (SDK 0.2.87, dundee gdu, auto-fakeroot)

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_image_source_build.py
+++ b/src/scitex_agent_container/cli_pkg/_image_source_build.py
@@ -235,10 +235,24 @@ def _default_apptainer_build_runner(
 
     Returns the apptainer exit code (0 on success). Sandbox builds use
     ``--fakeroot`` (apptainer's sandbox-from-def path requires it on
-    rootless installs); SIF builds use ``sudo`` because the default sac
-    install doesn't grant the build user setuid privileges, mirroring
-    how ``scitex_container.apptainer.build`` invokes apptainer.
+    rootless installs).
+
+    SIF builds prefer ``--fakeroot`` when the user already has
+    ``/etc/subuid`` + ``/etc/subgid`` mappings (the lead's hand-built
+    SIF on 2026-06-05 used this path), and fall back to ``sudo
+    apptainer build`` only when no mappings exist. The sudo fallback
+    works on an interactive shell but fails silently in headless /
+    detached / no-tty contexts (sudo prompts for a password) — which
+    is exactly what bit the lead's ``sac image build`` invocation
+    earlier today. The fakeroot probe lives in
+    :mod:`runtimes._apptainer_build` so both the lifecycle build and
+    this CLI build agree on the heuristic.
     """
+    # Local import — runtimes/_apptainer_build pulls config etc. and
+    # we don't want to pay that cost on the cold ``sac image`` startup
+    # path until the actual build runs.
+    from ..runtimes._apptainer_build import _should_use_fakeroot_for_build
+
     if sandbox:
         argv = [
             "apptainer",
@@ -249,7 +263,16 @@ def _default_apptainer_build_runner(
         if force:
             argv.append("--force")
         argv += [str(output_path), str(staged_def)]
+    elif _should_use_fakeroot_for_build():
+        # Rootless user-namespace build — no sudo prompt. This is the
+        # path the lead's hand-built SIF used today.
+        argv = ["apptainer", "build", "--fakeroot"]
+        if force:
+            argv.append("--force")
+        argv += [str(output_path), str(staged_def)]
     else:
+        # No subuid mappings: fall back to sudo. Works interactively;
+        # FAILS in headless contexts (silent password prompt).
         argv = ["sudo", "apptainer", "build"]
         if force:
             argv.append("--force")

--- a/src/scitex_agent_container/containers/apptainer-base.def
+++ b/src/scitex_agent_container/containers/apptainer-base.def
@@ -44,8 +44,13 @@ From: ubuntu:24.04
     # 5 (apt ships an older 2.0.x; we want 2.1.3 features).
     #
     # Agent-useful, non-interactive CLI tool set:
-    #   fd-find ripgrep bat eza tree jq git-delta gdu (apt)
+    #   fd-find ripgrep bat eza tree jq git-delta (apt)
     #   yq sd dust (sections 4a / 4b — not in apt)
+    #   gdu — NOT from apt: Ubuntu's `gdu` package is the ambiguous
+    #         "gnu-disk-usage" build with no machine-readable output;
+    #         sac's .claude size-audit needs the dundee/gdu
+    #         `gdu -o-` JSON path, so we pull a pinned dundee binary
+    #         in section 4c.
     # Interactive-only tools (htop, top, ncdu, fzf TUI mode) are
     # intentionally excluded — sac agents are headless; an agent has
     # no TTY to drive a curses UI and `htop` is dead weight in the SIF.
@@ -67,7 +72,7 @@ From: ubuntu:24.04
         iputils-ping dnsutils netcat-openbsd \
         nano jq \
         fd-find ripgrep bat eza \
-        git-delta gdu \
+        git-delta \
         tini
     locale-gen en_US.UTF-8
 
@@ -161,10 +166,10 @@ From: ubuntu:24.04
     #
     # Both are useful to a headless agent (scripted refactors, "what is
     # eating my overlay") and ship from cargo because Ubuntu 24.04 has
-    # neither in apt. The interactive disk-explorer cousins
-    # (``ncdu``, ``gdu`` TUI mode) are deliberately NOT installed —
-    # ``gdu --non-interactive`` from apt covers the headless case in
-    # section 1.
+    # neither in apt. The interactive disk-explorer cousin ``ncdu`` is
+    # deliberately NOT installed — the dundee/``gdu`` binary fetched
+    # in section 4c covers the headless ``gdu -o-`` JSON case sac
+    # itself needs (apt's ambiguous ``gdu`` package was dropped).
     #
     # For the operator's hand-curated extra Rust-CLI set (per-host,
     # post-launch in an overlay) see ``~/.bin/installers/install_rust_clis.sh``
@@ -193,6 +198,24 @@ From: ubuntu:24.04
         -o /usr/local/bin/yq
     chmod +x /usr/local/bin/yq
 
+    # ---- 4c. gdu — dundee/gdu (pinned), NOT Ubuntu's gnu-disk-usage --
+    # Ubuntu 24.04's apt `gdu` is the ambiguous "gnu-disk-usage" build
+    # (no `-o-` machine-readable JSON). sac's .claude size-audit
+    # (F-CS8, _workdir_audit.py) hard-depends on dundee/gdu's
+    # `gdu -o- <path>` JSON contract — different binary, same name.
+    # Pull a PINNED static release tarball from the dundee/gdu GitHub
+    # releases page so the .claude audit's JSON parser stays stable
+    # across SIF rebuilds.
+    GDU_VERSION=5.31.0
+    curl -fsSL \
+        "https://github.com/dundee/gdu/releases/download/v${GDU_VERSION}/gdu_linux_amd64.tgz" \
+        -o /tmp/gdu.tgz
+    tar -xzf /tmp/gdu.tgz -C /tmp
+    install -m 0755 /tmp/gdu_linux_amd64 /usr/local/bin/gdu
+    rm -f /tmp/gdu.tgz /tmp/gdu_linux_amd64
+    # Verify: dundee/gdu's --version line starts with "Version:	v5.31.0".
+    /usr/local/bin/gdu --version
+
     # ---- 5. tree v2.1.3 from source ------------------------------------
     curl -fsSL https://gitlab.com/OldManProgrammer/unix-tree/-/archive/2.1.3/unix-tree-2.1.3.tar.gz \
         | tar xz -C /tmp
@@ -217,14 +240,16 @@ From: ubuntu:24.04
     # just these two into a dedicated venv so /usr/bin/python3 stays
     # untouched and per-agent overlays own their own scientific stack.
     #
-    # claude-agent-sdk PINNED to 0.1.72 — newer 0.1.81 bundles claude
-    # CLI 2.1.139, which has a regression that hangs on the startup
-    # `GET /v1/mcp_servers` call inside apptainer (proven against the
-    # host's working 0.1.72/2.1.112 pair, same SIF, same creds,
-    # same network — only the bundled binary differs). The SDK
-    # bundles its CLI under `_bundled/claude`, so pinning the Python
-    # version also pins the binary — no separate `claude` install
-    # needed (see Anthropic's claude-agent-sdk-python README). 2026-05-12.
+    # claude-agent-sdk PINNED to 0.2.87 — bundles claude CLI 2.1.150
+    # (verified in-apptainer 2026-06-05, including Bash
+    # run_in_background). The old 0.1.72 pin was a workaround for a
+    # since-fixed 2.1.139 startup hang on `GET /v1/mcp_servers`; the
+    # SDK has rolled forward across the affected window and the
+    # currently shipping pair is the one the lead's hand-built SIF
+    # uses today. The SDK bundles its CLI under `_bundled/claude`, so
+    # pinning the Python version also pins the binary — no separate
+    # `claude` install needed (see Anthropic's claude-agent-sdk-python
+    # README).
     #
     # sac itself is installed from /opt/scitex-agent-container-src/ —
     # the package's OWN source tree, copied in by the %files section
@@ -239,7 +264,7 @@ From: ubuntu:24.04
     python3 -m venv /opt/venv-sac
     export PATH=/root/.local/bin:/usr/local/bin:$PATH
     uv pip install --python /opt/venv-sac/bin/python \
-        "claude-agent-sdk==0.1.72" \
+        "claude-agent-sdk==0.2.87" \
         /opt/scitex-agent-container-src
 
     # Surface the SDK's bundled claude CLI on PATH so humans can

--- a/src/scitex_agent_container/containers/apptainer-scitex.def
+++ b/src/scitex_agent_container/containers/apptainer-scitex.def
@@ -63,12 +63,16 @@ From: ./sac-base.sif
     # package's OWN source tree, copied in by the %files section above.
     # The SIF's sac version is structurally pinned to the source tree
     # that shipped this .def; no `git+...@main` snapshot drift.
+    # claude-agent-sdk MUST be pinned here too — leaving it unpinned
+    # lets uv/pip drift away from the base layer's 0.2.87 pin (the
+    # version that bundles the working claude CLI 2.1.150). Keep
+    # both branches' version in lockstep with apptainer-base.def.
     if command -v uv >/dev/null; then
         uv pip install --python /opt/venv-sac/bin/python \
             black flake8 \
             ipython ipdb \
             pytest pytest-cov \
-            claude-agent-sdk \
+            "claude-agent-sdk==0.2.87" \
             "scitex[all]" \
             /opt/scitex-agent-container-src
     else
@@ -78,7 +82,7 @@ From: ./sac-base.sif
             black flake8 \
             ipython ipdb \
             pytest pytest-cov \
-            claude-agent-sdk \
+            "claude-agent-sdk==0.2.87" \
             "scitex[all]" \
             /opt/scitex-agent-container-src
     fi

--- a/tests/scitex_agent_container/cli_pkg/test__image_source_build.py
+++ b/tests/scitex_agent_container/cli_pkg/test__image_source_build.py
@@ -39,6 +39,7 @@ import pytest
 import scitex_agent_container
 from scitex_agent_container.cli_pkg import _image_source_build as isb
 from scitex_agent_container.cli_pkg.image_group import _LAYERS, _RECIPES_DIR
+from scitex_agent_container.runtimes import _apptainer_build as build_mod
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -98,6 +99,23 @@ def _use_apptainer_runner(runner_fn) -> Iterator[list[tuple]]:
         yield calls
     finally:
         isb._apptainer_build_runner = saved  # type: ignore[assignment]
+
+
+@contextmanager
+def _force_fakeroot_probe(value: bool) -> Iterator[None]:
+    """Swap ``runtimes._apptainer_build._should_use_fakeroot_for_build``.
+
+    The runner imports the probe lazily on each call, so swapping the
+    module attribute deterministically controls which SIF-build branch
+    the runner takes regardless of the host's actual ``/etc/subuid``
+    state. No MagicMock — a plain ``lambda`` returning the desired value.
+    """
+    saved = build_mod._should_use_fakeroot_for_build
+    build_mod._should_use_fakeroot_for_build = lambda: value  # type: ignore[assignment]
+    try:
+        yield
+    finally:
+        build_mod._should_use_fakeroot_for_build = saved  # type: ignore[assignment]
 
 
 # ---------------------------------------------------------------------------
@@ -457,8 +475,10 @@ def test_build_layer_from_source_stages_source_at_known_relative_name(
 # ---------------------------------------------------------------------------
 
 
-def test_default_runner_sif_argv_uses_sudo_apptainer_build(tmp_path):
-    # Arrange — swap subprocess.run for a real recording callable.
+def test_default_runner_sif_argv_uses_sudo_when_subuid_absent(tmp_path):
+    # Arrange — fakeroot probe forced False (no /etc/subuid mapping for
+    # this user) so the runner takes the sudo fallback branch. Swap
+    # subprocess.run for a real recording callable.
     seen: dict = {}
 
     class _FakeResult:
@@ -473,13 +493,14 @@ def test_default_runner_sif_argv_uses_sudo_apptainer_build(tmp_path):
     isb.subprocess.run = _fake_run  # type: ignore[assignment]
     try:
         # Act
-        rc = isb._default_apptainer_build_runner(
-            output_path=tmp_path / "x.sif",
-            staged_def=tmp_path / "x.def",
-            cwd=tmp_path,
-            sandbox=False,
-            force=True,
-        )
+        with _force_fakeroot_probe(False):
+            rc = isb._default_apptainer_build_runner(
+                output_path=tmp_path / "x.sif",
+                staged_def=tmp_path / "x.def",
+                cwd=tmp_path,
+                sandbox=False,
+                force=True,
+            )
     finally:
         isb.subprocess.run = saved  # type: ignore[assignment]
     # Assert
@@ -487,9 +508,45 @@ def test_default_runner_sif_argv_uses_sudo_apptainer_build(tmp_path):
         rc == 0
         and seen["argv"][:3] == ["sudo", "apptainer", "build"]
         and "--force" in seen["argv"]
+        and "--fakeroot" not in seen["argv"]
         and str(tmp_path / "x.sif") in seen["argv"]
         and str(tmp_path / "x.def") in seen["argv"]
         and seen["cwd"] == str(tmp_path)
+    )
+
+
+def test_default_runner_sif_argv_uses_fakeroot_when_subuid_present(
+    tmp_path: Path, subprocess_shim
+):
+    """Lead's hand-built SIF on 2026-06-05 used the rootless fakeroot
+    path because /etc/subuid had a mapping; ``sac image build`` had
+    been falling back to sudo (silent password prompt in headless
+    contexts). Real PATH-installed ``apptainer`` shim records argv;
+    the production runner shells out via the real ``subprocess.run``
+    and the shim writes the argv to a log we read back. No MagicMock.
+    """
+    # Arrange — install a recording apptainer shim, force the probe True.
+    subprocess_shim.install("apptainer", exit=0)
+    # Act
+    with _force_fakeroot_probe(True):
+        rc = isb._default_apptainer_build_runner(
+            output_path=tmp_path / "x.sif",
+            staged_def=tmp_path / "x.def",
+            cwd=tmp_path,
+            sandbox=False,
+            force=True,
+        )
+    argv = subprocess_shim.argv_for("apptainer")
+    # Assert — argv carries --fakeroot, no sudo, and the build target.
+    assert (
+        rc == 0
+        and argv is not None
+        and argv[0] == "build"
+        and "--fakeroot" in argv
+        and "sudo" not in argv
+        and "--force" in argv
+        and str(tmp_path / "x.sif") in argv
+        and str(tmp_path / "x.def") in argv
     )
 
 


### PR DESCRIPTION
## Summary

Make the package defs at `src/scitex_agent_container/containers/` + the `sac image build` runner reproduce the SIF the lead hand-built today (SDK 0.2.87 + claude CLI 2.1.150 + dundee gdu v5.31.0). Without this, a future `sac image build` would silently REGRESS the SIF — the runtime `.def` copy under `~/.scitex/.../build-context/` was the only place the lead's fix lived; that copy is overwritten from these package defs on every build.

## Changes

- **`apptainer-base.def`**
  - `claude-agent-sdk==0.1.72` → `claude-agent-sdk==0.2.87` (bundles CLI 2.1.150; the old pin worked around a since-fixed 2.1.139 startup hang).
  - Drop apt's ambiguous `gnu-disk-usage` `gdu`; pull pinned dundee `gdu` v5.31.0 binary tarball into `/usr/local/bin/gdu`. The `.claude` size audit (`_workdir_audit.py`, F-CS8) hard-depends on dundee's `gdu -o-` JSON contract that apt `gdu` does not provide.
- **`apptainer-scitex.def`** — pin `claude-agent-sdk==0.2.87` in BOTH the uv branch and the pip-fallback branch (unpinned previously let resolve drift away from base's pin).
- **`cli_pkg/_image_source_build.py`** — `_default_apptainer_build_runner` SIF path now prefers `--fakeroot` when `_should_use_fakeroot_for_build()` is True (uses the same probe as `runtimes/_apptainer_build.py` so the lifecycle build and the CLI build agree). Sudo is kept as the fallback for hosts without `/etc/subuid`+`/etc/subgid` mappings. Avoids the silent "sudo: a password is required" failure that bit `sac image build` in the lead's detached / no-tty context.

## Test plan

- [x] Focused: `tests/scitex_agent_container/cli_pkg/test__image_source_build.py` — 39/39 pass (incl. new `test_default_runner_sif_argv_uses_fakeroot_when_subuid_present`).
- [x] Fakeroot probe: `tests/scitex_agent_container/runtimes/test__apptainer_build_fakeroot.py` — 17/17 pass.
- [x] No mocks — new test uses the project's `subprocess_shim` fixture (real PATH-installed `apptainer` shim records argv on disk; production code runs the real `subprocess.run`).
- [x] Full suite locally: 6353 passed, 38 skipped, 5 failed — all 5 failures are PRE-EXISTING on `develop` (verified by re-running the same tests against `/work` on develop): three `_listen/test_server.py::test_cross_host_send_*` are flaky under xdist parallel load (pass in isolation on both develop and this branch); `test_cli_help_under_budget` floors at 0.619s on develop vs 0.632s on this branch (13 ms = host-load noise); `test_audit_all_clean` fails on develop due to a stray `--fakeroot` top-level junk file + pre-existing SKILL.md / `26_credentials-rotation.md` budget violations + a `scitex_dev` MCP audit TypeError — none introduced by this PR (`audit-python-apis` is `SUCC` on this branch).

## Notes for review

- The runner's lazy `from ..runtimes._apptainer_build import _should_use_fakeroot_for_build` keeps `sac --help` startup cost untouched (the import only runs inside `_default_apptainer_build_runner`, not at module load).
- The `.def`-contract tests (`test_def_*`) still pass — both updated `.defs` still declare the bundled-source `%files` entry and never reference `git+...`.