### PR TITLE
feat(registry): sac registry register CLI verb + channel-start e2e test (#27)

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_registry_register.py
+++ b/src/scitex_agent_container/cli_pkg/_registry_register.py
@@ -1,0 +1,141 @@
+"""``sac registry register`` — write a comms_nodes row directly.
+
+Operator-repair path for missing federated-graph rows (ADR-0014). The
+existing self-register helpers (``sac listen``'s
+``_register_self_comms_node``; ``sac mcp channel``'s
+``_refresh_comms_node`` task) only run on **process start**. Two real
+failure modes the operator cannot fix without this verb:
+
+  1. A long-running ``sac mcp channel --name lead --listen-url ...``
+     process predates the self-register feature
+     (commit 1f54b4a). Its in-memory code has no
+     ``register_comms_node`` call, so until the operator restarts it
+     no ``comms_nodes`` row for ``lead`` exists on the lead's host
+     and ``resolve_node_host('lead')`` returns ``None`` everywhere.
+  2. A host's ``listen`` started before its config gained a
+     ``lead:`` block — ``_register_self_comms_node`` saw
+     ``cfg.lead is None`` and silently skipped. Re-reading config
+     requires a listen restart, which an operator may want to defer.
+
+This verb closes both gaps. The operator runs::
+
+    sac registry register --name lead --host lead-host --a2a-port 7878
+
+and the row lands in ``comms_nodes`` immediately. Other hosts pull it
+via ``sac registry sync --from lead-host`` (ADR-0014 anti-entropy).
+No process restart required.
+
+Failure policy — **fail loud**, not best-effort. ``sac listen`` and
+``sac mcp channel`` swallow registry-write failures with
+``log.warning`` because their MCP / SSE handshakes are the primary
+job and a missed row can be re-tried next tick. This verb's primary
+job IS the registry write, invoked by a human; a silent
+:class:`CommsNodeConflictError` would defeat the operator's intent.
+We surface the conflict via ``click.ClickException`` (exit 1) with the
+underlying error message so the operator can ``--unregister`` /
+re-typed-args their way out.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+
+from .._state.state_db_nodes import (
+    CommsNodeConflictError,
+    register_comms_node,
+)
+
+
+@click.command("register")
+@click.option(
+    "--name",
+    required=True,
+    type=str,
+    help="Node name to register (e.g. 'lead', 'spartan-listen').",
+)
+@click.option(
+    "--host",
+    required=True,
+    type=str,
+    help="Canonical host the node lives on (matches the host's "
+    "host_config.canonical_host()).",
+)
+@click.option(
+    "--a2a-port",
+    "a2a_port",
+    required=True,
+    type=int,
+    help="TCP port the node's a2a HTTP endpoint listens on.",
+)
+@click.option(
+    "--source-host",
+    "source_host",
+    type=str,
+    default=None,
+    help=(
+        "Source-of-record host. Defaults to None — the row is treated "
+        "as locally-registered (matches what `sac listen` and `sac mcp "
+        "channel` self-register write). Set this only when relaying a "
+        "peer's row from a third host (rare; ``sac registry sync`` is "
+        "the supported anti-entropy path for that)."
+    ),
+)
+@click.option(
+    "--db-path",
+    "db_path",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=None,
+    help="Override the state.db path. Defaults to the standard location.",
+)
+def registry_register(
+    name: str,
+    host: str,
+    a2a_port: int,
+    source_host: str | None,
+    db_path: Path | None,
+) -> None:
+    """Write a ``comms_nodes`` row directly. ADR-0014 operator-repair path.
+
+    Use cases:
+
+      * The lead's row never landed (the lead's mcp channel process
+        predates the self-register feature) — write it manually so other
+        agents resolve ``lead`` immediately. Restart the lead's channel
+        at leisure to pick up the heartbeat refresh.
+      * A peer host's listen started before its config gained a
+        ``lead:`` block — register the row manually without restarting
+        the listen.
+
+    Fail-loud on conflict (different existing host/port from a
+    different source): exits 1 with the conflict message so the
+    operator can resolve it explicitly. Silent overwrite is the wrong
+    default for a verb the human typed.
+
+    \\b
+    Examples:
+      $ sac registry register --name lead --host lead-host --a2a-port 7878
+      $ sac registry register --name spartan-2 --host spartan-2.lan --a2a-port 7878
+    """
+    try:
+        register_comms_node(
+            name=name,
+            host=host,
+            a2a_port=a2a_port,
+            source_host=source_host,
+            db_path=db_path,
+        )
+    except CommsNodeConflictError as exc:
+        raise click.ClickException(str(exc)) from exc
+    except ValueError as exc:
+        # Bad inputs (empty name/host, non-positive port). Click's own
+        # validators catch most, but register_comms_node enforces too.
+        raise click.UsageError(str(exc)) from exc
+    click.echo(
+        f"registered comms_nodes: name={name!r} host={host!r} "
+        f"a2a_port={a2a_port} source_host={source_host!r}"
+    )
+
+
+__all__ = ["registry_register"]

--- a/src/scitex_agent_container/cli_pkg/registry_group.py
+++ b/src/scitex_agent_container/cli_pkg/registry_group.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import click
 
 from ._helpers import HelpRecursiveGroup, renamed_redirect
+from ._registry_register import registry_register as _registry_register_cmd
 from ._registry_sync import registry_sync as _registry_sync_cmd
 from .priority_cmds import singleton_reconcile as _reconcile_impl
 
@@ -64,6 +65,10 @@ registry_group.add_command(
 registry_group.add_command(_rebind(_reconcile_impl, "reconcile"))
 # ADR-0014 Stage 1 — symmetric federated comms_nodes anti-entropy sync.
 registry_group.add_command(_registry_sync_cmd)
+# ADR-0014 — operator-repair: write a comms_nodes row directly without
+# requiring a process restart of the node that "owns" it. See
+# _registry_register.py for the failure modes this targets.
+registry_group.add_command(_registry_register_cmd)
 
 
 __all__ = ["registry_group"]

--- a/tests/scitex_agent_container/_mcp/test__channel_self_register.py
+++ b/tests/scitex_agent_container/_mcp/test__channel_self_register.py
@@ -216,7 +216,6 @@ def test_register_self_node_refresh_advances_updated_at(
     import time
 
     from scitex_agent_container._mcp._channel_self_register import register_self_node
-
     from scitex_agent_container._state.state_db_nodes import lookup_comms_node
 
     register_self_node(name="lead", listen_url="http://127.0.0.1:7878")
@@ -241,7 +240,6 @@ def test_register_self_node_writes_no_row_when_listen_url_has_port_zero(
     # function MUST refuse rather than persist a 0 port (which is what
     # broke `sac a2a peers` resolution in the first place).
     from scitex_agent_container._mcp._channel_self_register import register_self_node
-
     from scitex_agent_container._state.state_db_nodes import list_comms_nodes
 
     # Act
@@ -299,7 +297,6 @@ def test_refresh_node_writes_initial_row_on_first_tick(
     # so a caller doesn't have to call register_self_node separately
     # before kicking off the loop.
     from scitex_agent_container._mcp._channel_self_register import refresh_node
-
     from scitex_agent_container._state.state_db_nodes import lookup_comms_node
 
     async def _drive_one_tick() -> None:
@@ -325,7 +322,6 @@ def test_refresh_node_advances_updated_at_across_ticks(
 ) -> None:
     # Arrange — let the loop tick twice; updated_at must advance.
     from scitex_agent_container._mcp._channel_self_register import refresh_node
-
     from scitex_agent_container._state.state_db_nodes import lookup_comms_node
 
     captured: dict[str, float] = {}
@@ -377,3 +373,46 @@ def test_refresh_node_respects_cancellation_promptly(
     cancelled = asyncio.run(_start_then_cancel())
     # Assert
     assert cancelled is True
+
+
+# ---------------------------------------------------------------------------
+# End-to-end — channel-start → resolve_node_host('lead') succeeds
+#
+# The lead's request (msg a26da20, 2026-06-05): pin the contract that
+# after the channel's refresh task fires its first iteration, the
+# resolver every cross-host A2A POST uses (resolve_node_host, not just
+# lookup_comms_node) returns the right row. Without this, a future
+# regression that breaks the channel→resolver seam (e.g. someone
+# decoupling the registration target from the resolver) would land
+# silently — the lower-level lookup_comms_node tests above would still
+# pass while production cross-host routing broke.
+# ---------------------------------------------------------------------------
+
+
+def test_refresh_node_makes_lead_resolvable_via_resolve_node_host(
+    db_path: Path, cfg_with_lead: Path
+) -> None:
+    # Arrange — drive one refresh tick (the same path channel.py
+    # _serve() schedules at startup) then ask the production resolver.
+    from scitex_agent_container._mcp._channel_self_register import refresh_node
+    from scitex_agent_container._state.state_db_nodes import resolve_node_host
+
+    async def _drive_one_tick() -> None:
+        task = asyncio.create_task(
+            refresh_node(name="lead", listen_url="http://127.0.0.1:7878", interval_s=10)
+        )
+        await asyncio.sleep(
+            0.05
+        )  # one tick is enough; first iteration runs immediately
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    # Act
+    asyncio.run(_drive_one_tick())
+    info = resolve_node_host(name="lead")
+    # Assert — the full {host, a2a_port} dict, from canonical_host + the
+    # parsed listen_url port. host comes from cfg_with_lead's "lead-host".
+    assert info == {"host": "lead-host", "a2a_port": 7878}

--- a/tests/scitex_agent_container/cli_pkg/test__registry_register.py
+++ b/tests/scitex_agent_container/cli_pkg/test__registry_register.py
@@ -1,0 +1,320 @@
+"""Tests for ``cli_pkg/_registry_register.py`` — ``sac registry register``.
+
+ADR-0014 + lead-row repair flow. The verb writes a ``comms_nodes`` row
+directly so the operator can fix a missing federated entry without
+restarting whatever process "owns" it (the lead's mcp channel, a
+peer's listen).
+
+Real on-disk state.db via the shared ``env_save_restore`` fixture +
+``click.testing.CliRunner`` — no MagicMock anywhere. AAA, one assert
+per test (STX-TQ002 / PA-307), ≥3-word names.
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from scitex_agent_container.cli_pkg._registry_register import registry_register
+
+# ---------------------------------------------------------------------------
+# Fixtures — point state.db at a per-test tmp file so we don't touch
+# the operator's real registry.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def db_path(tmp_path: Path, env_save_restore) -> Path:
+    p = tmp_path / "state.db"
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_STATE_DB", str(p))
+    import scitex_agent_container._state.state_db as mod
+
+    importlib.reload(mod)
+    yield p
+    importlib.reload(mod)
+
+
+# ---------------------------------------------------------------------------
+# Happy path — the row lands in comms_nodes
+# ---------------------------------------------------------------------------
+
+
+def test_registry_register_writes_comms_nodes_row_with_given_name(
+    db_path: Path,
+) -> None:
+    # Arrange
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(
+        registry_register,
+        ["--name", "lead", "--host", "lead-host", "--a2a-port", "7878"],
+    )
+    # Assert
+    from scitex_agent_container._state.state_db_nodes import lookup_comms_node
+
+    assert result.exit_code == 0 and lookup_comms_node(name="lead") is not None
+
+
+def test_registry_register_records_host_and_port_verbatim(db_path: Path) -> None:
+    # Arrange — pin that the verb persists the args the operator typed,
+    # not some derived value.
+    runner = CliRunner()
+    # Act
+    runner.invoke(
+        registry_register,
+        ["--name", "lead", "--host", "lead-host", "--a2a-port", "7878"],
+    )
+    # Assert
+    from scitex_agent_container._state.state_db_nodes import lookup_comms_node
+
+    info = lookup_comms_node(name="lead")
+    assert info["host"] == "lead-host" and info["a2a_port"] == 7878
+
+
+def test_registry_register_defaults_source_host_to_none_local(
+    db_path: Path,
+) -> None:
+    # Arrange — locally-registered rows have source_host=None so the
+    # ADR-0014 conflict detector treats them as authoritative for the
+    # registering host. The verb must default to this.
+    runner = CliRunner()
+    # Act
+    runner.invoke(
+        registry_register,
+        ["--name", "lead", "--host", "lead-host", "--a2a-port", "7878"],
+    )
+    # Assert
+    from scitex_agent_container._state.state_db_nodes import lookup_comms_node
+
+    info = lookup_comms_node(name="lead")
+    assert info["source_host"] is None
+
+
+def test_registry_register_explicit_source_host_is_stored(db_path: Path) -> None:
+    # Arrange — the operator may relay a peer's row from a third host;
+    # --source-host is the supported way to tag it correctly.
+    runner = CliRunner()
+    # Act
+    runner.invoke(
+        registry_register,
+        [
+            "--name",
+            "peer-2",
+            "--host",
+            "peer-2.lan",
+            "--a2a-port",
+            "7878",
+            "--source-host",
+            "relay-host",
+        ],
+    )
+    # Assert
+    from scitex_agent_container._state.state_db_nodes import lookup_comms_node
+
+    info = lookup_comms_node(name="peer-2")
+    assert info["source_host"] == "relay-host"
+
+
+def test_registry_register_after_resolves_via_resolve_node_host(
+    db_path: Path,
+) -> None:
+    # Arrange — the operator-facing contract: after `sac registry register`
+    # succeeds, resolve_node_host (the production lookup callers use to
+    # route cross-host A2A) must return the row. This guards the seam
+    # between the verb and the resolver.
+    runner = CliRunner()
+    runner.invoke(
+        registry_register,
+        ["--name", "lead", "--host", "lead-host", "--a2a-port", "7878"],
+    )
+    # Act
+    from scitex_agent_container._state.state_db_nodes import resolve_node_host
+
+    info = resolve_node_host(name="lead")
+    # Assert
+    assert info == {"host": "lead-host", "a2a_port": 7878}
+
+
+# ---------------------------------------------------------------------------
+# Re-registration — idempotent UPSERT, no conflict on same (host, port)
+# ---------------------------------------------------------------------------
+
+
+def test_registry_register_idempotent_when_same_host_and_port(
+    db_path: Path,
+) -> None:
+    # Arrange — second invocation with identical args must NOT exit
+    # non-zero and must NOT create a duplicate row.
+    runner = CliRunner()
+    runner.invoke(
+        registry_register,
+        ["--name", "lead", "--host", "lead-host", "--a2a-port", "7878"],
+    )
+    # Act
+    second = runner.invoke(
+        registry_register,
+        ["--name", "lead", "--host", "lead-host", "--a2a-port", "7878"],
+    )
+    # Assert
+    from scitex_agent_container._state.state_db_nodes import list_comms_nodes
+
+    rows = [r for r in list_comms_nodes() if r["name"] == "lead"]
+    assert second.exit_code == 0 and len(rows) == 1
+
+
+# ---------------------------------------------------------------------------
+# Fail-loud — conflict from a different source_host must exit non-zero
+# ---------------------------------------------------------------------------
+
+
+def test_registry_register_exits_nonzero_on_cross_source_conflict(
+    db_path: Path,
+) -> None:
+    # Arrange — first registration claims (host=A, port=7878), second
+    # tries to overwrite with (host=B, port=7878) from a DIFFERENT
+    # source_host. ADR-0014 says fail-loud; the verb must surface
+    # CommsNodeConflictError as a non-zero exit.
+    runner = CliRunner()
+    runner.invoke(
+        registry_register,
+        [
+            "--name",
+            "lead",
+            "--host",
+            "host-a",
+            "--a2a-port",
+            "7878",
+            "--source-host",
+            "src-a",
+        ],
+    )
+    # Act
+    result = runner.invoke(
+        registry_register,
+        [
+            "--name",
+            "lead",
+            "--host",
+            "host-b",
+            "--a2a-port",
+            "7878",
+            "--source-host",
+            "src-b",
+        ],
+    )
+    # Assert
+    assert result.exit_code != 0
+
+
+def test_registry_register_does_not_overwrite_existing_row_on_conflict(
+    db_path: Path,
+) -> None:
+    # Arrange — pair with the exit-code test above: the existing row
+    # must survive the rejected second invocation untouched.
+    runner = CliRunner()
+    runner.invoke(
+        registry_register,
+        [
+            "--name",
+            "lead",
+            "--host",
+            "host-a",
+            "--a2a-port",
+            "7878",
+            "--source-host",
+            "src-a",
+        ],
+    )
+    runner.invoke(
+        registry_register,
+        [
+            "--name",
+            "lead",
+            "--host",
+            "host-b",
+            "--a2a-port",
+            "7878",
+            "--source-host",
+            "src-b",
+        ],
+    )
+    # Act
+    from scitex_agent_container._state.state_db_nodes import lookup_comms_node
+
+    info = lookup_comms_node(name="lead")
+    # Assert — original row is intact
+    assert info["host"] == "host-a"
+
+
+# ---------------------------------------------------------------------------
+# Input validation — required flags, port>0
+# ---------------------------------------------------------------------------
+
+
+def test_registry_register_requires_name_flag(db_path: Path) -> None:
+    # Arrange
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(
+        registry_register,
+        ["--host", "lead-host", "--a2a-port", "7878"],
+    )
+    # Assert — missing --name is a click UsageError
+    assert result.exit_code != 0
+
+
+def test_registry_register_requires_host_flag(db_path: Path) -> None:
+    # Arrange
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(
+        registry_register,
+        ["--name", "lead", "--a2a-port", "7878"],
+    )
+    # Assert
+    assert result.exit_code != 0
+
+
+def test_registry_register_requires_a2a_port_flag(db_path: Path) -> None:
+    # Arrange
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(
+        registry_register,
+        ["--name", "lead", "--host", "lead-host"],
+    )
+    # Assert
+    assert result.exit_code != 0
+
+
+def test_registry_register_rejects_non_positive_port(db_path: Path) -> None:
+    # Arrange — register_comms_node enforces a2a_port > 0; the verb
+    # surfaces that as a UsageError (exit 2). The 0-port footgun was
+    # the EXACT production-bug signature ADR-0014 closed the door on.
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(
+        registry_register,
+        ["--name", "lead", "--host", "lead-host", "--a2a-port", "0"],
+    )
+    # Assert
+    assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# Wiring — the verb is reachable via `sac registry register`
+# ---------------------------------------------------------------------------
+
+
+def test_registry_register_is_wired_into_registry_group() -> None:
+    # Arrange — guard the registry_group wiring (regression: someone
+    # adds a new verb file but forgets to add_command it).
+    from scitex_agent_container.cli_pkg.registry_group import registry_group
+
+    # Act
+    commands = set(registry_group.commands.keys())
+    # Assert
+    assert "register" in commands


### PR DESCRIPTION
## Summary

Closes the operator-repair gap in the ADR-0014 federated `comms_nodes` graph: existing self-register helpers (`sac listen`'s `_register_self_comms_node`; `sac mcp channel`'s `_refresh_comms_node` task) write the row only on **process start**. Two real failure modes the operator could not fix without restarting the owning process:

1. A long-running `sac mcp channel --name lead --listen-url ...` predates the self-register feature (commit 1f54b4a). Its in-memory code has no `register_comms_node` call → no `lead` row → `resolve_node_host('lead')` returns `None` for every agent until a restart.
2. A host's listen started before its config gained a `lead:` block → `_register_self_comms_node` saw `cfg.lead is None` and silently skipped.

New verb:

```
sac registry register --name lead --host lead-host --a2a-port 7878
```

writes the `comms_nodes` row immediately; other hosts pull it via the existing `sac registry sync --from lead-host` (ADR-0014 anti-entropy). No process restart required — exactly the no-restart-repair path requested in the lead's diagnosis routing (msg `a26da20`).

## Changes

- **`cli_pkg/_registry_register.py`** (NEW) — thin click wrapper over the same `register_comms_node` helper `sac listen` / `sac mcp channel` use. **Fail-loud** on `CommsNodeConflictError` (non-zero exit + conflict message) — divergent from the lifecycle paths' best-effort `log.warning` because **this** verb's primary job IS the write, typed by a human; silent stomping of a peer's row is the wrong default.
- **`cli_pkg/registry_group.py`** — `add_command` wires the new verb into `sac registry`.
- **`tests/.../cli_pkg/test__registry_register.py`** (NEW) — 13 single-assert AAA tests, real on-disk state.db + `click.testing.CliRunner`. No `MagicMock`. Covers happy path, end-to-end `resolve_node_host` lookup after the verb, idempotency, fail-loud conflict, input validation (incl. the `--a2a-port 0` footgun), and group wiring.
- **`tests/.../_mcp/test__channel_self_register.py`** — adds the end-to-end channel-start → `resolve_node_host('lead')` test the lead explicitly asked for. Drives the same `refresh_node` task `channel.py _serve()` schedules and asserts `resolve_node_host` (the production lookup) returns the right `{host, a2a_port}`. Guards the channel→resolver seam from a silent regression that would still pass the lower-level `lookup_comms_node` tests.

## Out of scope (per lead direction)

- Option B (host_config.lead fallback in `resolve_node_host`) — skipped; doesn't help hosts whose config has `cfg.lead = None`.
- Option C (periodic re-register heartbeat on `sac listen`) — needs to gracefully tolerate `cfg.lead = None` first; deferred.
- `sac listen`'s silent skip when `cfg.lead is None` — separate follow-up issue.

## Test plan

- [x] Focused: 13 new CLI tests + 19 existing `test__channel_self_register.py` tests + 1 new e2e test = 33/33 pass locally.
- [x] Full suite: `2 failed, 6369 passed, 38 skipped` — same pre-existing failures documented on PR#307 (`test_audit_all_clean` scitex-dev MCP TypeError; `test_cli_help_under_budget` host-load flake). Zero new failures.
- [x] No mocks anywhere.