### PR TITLE
fix(_runners/_session_hooks): suppress empty no-dispatch completion pushes

### DIFF
--- a/src/scitex_agent_container/_runners/_session_hooks.py
+++ b/src/scitex_agent_container/_runners/_session_hooks.py
@@ -126,6 +126,23 @@ async def emit_completion_push(
     requester = turn_context.requester
     if not requester or turn_context.pushed:
         return
+
+    # Fleet-noise guard (lead task PR3, 2026-06-05): suppress a push that
+    # carries NO ledger correlation AND NO content. The wire signature
+    # ``{"agent": <name>, "dispatch_id": null, "status": "unknown",
+    # "summary": ""}`` is the canonical "nothing real to report"
+    # payload — every idle/wake turn that had no incoming dispatch_id
+    # and produced no assistant text fires one. Multiplied across an
+    # N-agent fleet post-restart, those empties eat every subscriber's
+    # turn cycle for zero signal. The completion contract is "tell the
+    # requester something useful happened"; without a dispatch_id OR
+    # summary content, nothing useful did. ``pushed = True`` still flips
+    # so a re-entrant Stop hook on the same turn re-evaluates and skips
+    # identically (no double-evaluation cost).
+    if turn_context.dispatch_id is None and not (turn_context.summary or "").strip():
+        turn_context.pushed = True
+        return
+
     turn_context.pushed = True
 
     from ._session_completion import STATUS_UNKNOWN, build_completion_report

--- a/tests/scitex_agent_container/_runners/test__session_completion.py
+++ b/tests/scitex_agent_container/_runners/test__session_completion.py
@@ -565,6 +565,128 @@ class TestEmitOnceGuard:
 
 
 # ---------------------------------------------------------------------------
+# emit_completion_push — fleet-noise guard (PR3, 2026-06-05)
+#
+# Wire signature the fleet was spamming:
+#   {"agent": <name>, "dispatch_id": null, "status": "unknown", "summary": ""}
+#
+# That payload is what an idle/wake turn emits when it had no incoming
+# dispatch_id AND produced no assistant text. The guard suppresses it
+# so the requester's inbox cycle isn't burned on a zero-signal report.
+# Real receivers / real push_fn closures — no MagicMock.
+# ---------------------------------------------------------------------------
+
+
+class TestSuppressEmptyCompletions:
+    def test_suppress_when_dispatch_id_none_and_summary_empty(self) -> None:
+        # Arrange — exact reproduction of the noise payload's TurnContext
+        # state (begin() set a requester, no dispatch_id; finish() ran
+        # with status=unknown and empty summary).
+        ctx = TurnContext()
+        ctx.begin(requester="lead", dispatch_id=None)
+        ctx.finish(status=STATUS_UNKNOWN, summary="")
+        calls: list = []
+
+        async def _push_fn(report, requester, dispatch_id):
+            calls.append(report)
+
+        async def _scenario():
+            await emit_completion_push(ctx, _push_fn, agent_name="worker")
+            return calls
+
+        # Act
+        observed = asyncio.run(_scenario())
+        # Assert — push_fn was NEVER invoked (the noise payload was suppressed).
+        assert observed == []
+
+    def test_suppress_when_summary_is_whitespace_only(self) -> None:
+        # Arrange — a whitespace-only summary counts as "no content"; the
+        # original empty-string check was naïve and a model that emits
+        # "\n" or "   " would slip past it. The guard strips first.
+        ctx = TurnContext()
+        ctx.begin(requester="lead", dispatch_id=None)
+        ctx.finish(status=STATUS_UNKNOWN, summary="   \n\t  ")
+        calls: list = []
+
+        async def _push_fn(report, requester, dispatch_id):
+            calls.append(report)
+
+        async def _scenario():
+            await emit_completion_push(ctx, _push_fn, agent_name="worker")
+            return calls
+
+        # Act
+        observed = asyncio.run(_scenario())
+        # Assert
+        assert observed == []
+
+    def test_emit_when_dispatch_id_present_even_with_empty_summary(self) -> None:
+        # Arrange — a dispatched turn that legitimately produced no
+        # assistant text (acks, hook-only turns) MUST still report so
+        # the requester can correlate by dispatch_id. The guard only
+        # suppresses the BOTH-empty case.
+        ctx = TurnContext()
+        ctx.begin(requester="lead", dispatch_id="d-no-summary")
+        ctx.finish(status=STATUS_SUCCESS, summary="")
+        calls: list = []
+
+        async def _push_fn(report, requester, dispatch_id):
+            calls.append(report)
+
+        async def _scenario():
+            await emit_completion_push(ctx, _push_fn, agent_name="worker")
+            return calls
+
+        # Act
+        observed = asyncio.run(_scenario())
+        # Assert
+        assert len(observed) == 1
+
+    def test_emit_when_summary_present_even_without_dispatch_id(self) -> None:
+        # Arrange — symmetric: a non-dispatched turn with REAL content
+        # is signal (the lead may forward / surface it). Don't suppress
+        # just because dispatch_id is absent.
+        ctx = TurnContext()
+        ctx.begin(requester="lead", dispatch_id=None)
+        ctx.finish(status=STATUS_SUCCESS, summary="real reply text")
+        calls: list = []
+
+        async def _push_fn(report, requester, dispatch_id):
+            calls.append(report)
+
+        async def _scenario():
+            await emit_completion_push(ctx, _push_fn, agent_name="worker")
+            return calls
+
+        # Act
+        observed = asyncio.run(_scenario())
+        # Assert
+        assert len(observed) == 1
+
+    def test_suppressed_turn_still_marks_pushed_to_prevent_reentry(self) -> None:
+        # Arrange — pin that a suppressed turn flips ``pushed`` so a
+        # double-fire of the Stop hook for the same turn re-evaluates
+        # and skips identically (no double-evaluation cost). Mirrors
+        # the once-per-turn guard's contract.
+        ctx = TurnContext()
+        ctx.begin(requester="lead", dispatch_id=None)
+        ctx.finish(status=STATUS_UNKNOWN, summary="")
+        calls: list = []
+
+        async def _push_fn(report, requester, dispatch_id):
+            calls.append(report)
+
+        async def _scenario():
+            await emit_completion_push(ctx, _push_fn, agent_name="worker")
+            return ctx.pushed
+
+        # Act
+        pushed = asyncio.run(_scenario())
+        # Assert
+        assert pushed is True
+
+
+# ---------------------------------------------------------------------------
 # Full conversation → requester push (real run_conversation, fake SDK module)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Closes the fleet-noise pattern the lead surfaced (msg `296be3c4`): idle/wake turns with no incoming `dispatch_id` AND no assistant text were emitting an empty Stop-hook completion through `push_completion`:

```
{"agent": <name>, "dispatch_id": null, "status": "unknown", "summary": ""}
```

The completion contract is *"tell the requester something useful happened"*; without a `dispatch_id` (no ledger correlation) AND without summary content, nothing useful did. Multiplied across the fleet post-restart (~30 agents from proj-grant + several scitex-* peers + paper-scitex-clew), each empty push burns every other agent's turn cycle. The fix is the literal rule the lead asked for: suppress when *both* are empty.

## Changes

- **`src/scitex_agent_container/_runners/_session_hooks.py`** — `emit_completion_push` skips when `dispatch_id is None` AND `summary.strip()` is empty. `pushed = True` still flips so a re-entrant Stop hook on the same turn re-evaluates and skips identically (no double-evaluation cost).

The guard is narrow:
- Dispatched turns with empty summary (acks, hook-only turns) **still emit** — the requester needs to correlate by `dispatch_id`.
- Non-dispatched turns with real summary content **still emit** — the lead may surface / forward that.
- Only the both-empty noise case is silenced.

## Tests

Five new no-mock tests in `test__session_completion.py::TestSuppressEmptyCompletions`:

- `test_suppress_when_dispatch_id_none_and_summary_empty` — the exact noise payload.
- `test_suppress_when_summary_is_whitespace_only` — closes the `"\n"` / `"   "` loophole.
- `test_emit_when_dispatch_id_present_even_with_empty_summary` — correlation signal preserved.
- `test_emit_when_summary_present_even_without_dispatch_id` — content signal preserved.
- `test_suppressed_turn_still_marks_pushed_to_prevent_reentry` — re-entry safety.

Real receivers, real `push_fn` closures, no `MagicMock`. AAA, one assert per test.

## Test plan

- [x] Focused: 26/26 pass locally (21 existing + 5 new).
- [x] Full suite: `2 failed, 6361 passed, 38 skipped` — same pre-existing failures from PR#307 / PR#308 (`test_audit_all_clean` scitex-dev MCP TypeError; `test_cli_help_under_budget` local-host load flake). Zero new failures.
- [x] No `MagicMock`.