### PR TITLE
feat(agents-start): --broker-self bootstraps a per-invocation sac listen (SAC-from-SAC L2)

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_broker_self.py
+++ b/src/scitex_agent_container/_lifecycle/_broker_self.py
@@ -74,10 +74,15 @@ __all__ = [
 # string; identical convention to :func:`_state.state_db_nodes.mint_node_token`.
 _TOKEN_BYTES = 32
 
-# Default health-poll cap. 5 seconds is long enough for a cold uvicorn
-# bind on a SLURM node under load; shorter would risk a CI flake, longer
-# would mask a real bind failure with a stalled CLI.
-_DEFAULT_HEALTH_TIMEOUT_S = 5.0
+# Default health-poll cap PER ATTEMPT. 15s is generous enough for a
+# cold-import + uvicorn bind on a SLURM node under sibling-task CPU
+# contention OR a CI box running pytest-xdist with N workers each
+# spawning subprocesses simultaneously. Shorter (5s) flaked CI under
+# 16-way parallel load (``-n auto`` on a 16-core runner). Longer would
+# mask a real bind failure with a stalled CLI. Combined with the
+# 3-attempt retry in :func:`self_broker_listen_context`, total
+# worst-case wait is 45s.
+_DEFAULT_HEALTH_TIMEOUT_S = 15.0
 
 
 class BrokerSelfError(RuntimeError):

--- a/src/scitex_agent_container/_lifecycle/_broker_self.py
+++ b/src/scitex_agent_container/_lifecycle/_broker_self.py
@@ -1,0 +1,321 @@
+"""``sac agents start --broker-self`` — per-invocation self-brokering listen.
+
+Operator-mandated 2026-06-06 (lead dispatch eb953ce0, clew dogfood
+SPARTAN_WAVE_LAUNCH_PLAN.md "L2 nested SAC-from-SAC"): a parent SAC
+running on a SLURM allocation (inside its sac-scitex.sif) needs to
+spawn capsule SIFs as siblings via the existing in-SIF broker, but
+there is no upstream ``sac listen`` to broker to AND no environment
+that injects ``SAC_LISTEN_BASE_URL``. Today this raises
+:class:`InSifBrokerError` at :func:`_in_sif_broker.broker_start_to_host`
+and blocks the canonical nested architecture.
+
+This module is the operator-opt-in workaround. When the caller passes
+``--broker-self``, the start path:
+
+  1. Picks a free loopback TCP port (kernel-assigned).
+  2. Writes a fresh per-invocation bearer token to a tempfile.
+  3. Spawns ``sac listen --bind 127.0.0.1:<port> --token-file <path>``
+     as a subprocess (under the SAME ``sys.executable`` so the SIF's
+     venv-bundled sac is the one that binds).
+  4. Polls ``/v1/health`` until ready (≤5s, fail-loud on timeout).
+  5. Injects ``SAC_LISTEN_BASE_URL=http://127.0.0.1:<port>`` and
+     ``SAC_LISTEN_BEARER=<token>`` into the current process env.
+  6. Returns a context-manager that tears down the subprocess + the
+     tempfile + restores the env on exit.
+
+After step 6, the existing in-SIF broker path
+(:func:`_in_sif_broker.maybe_broker_in_sif_spawn`) finds the env and
+POSTs the spawn request to the local listen, which ``apptainer exec``s
+the capsule SIF as a sibling — exactly the path the operator
+hand-wires today, but compressed into one CLI flag.
+
+Per-task isolation: each sbatch task in the cohort gets its own
+loopback port + its own bearer + its own tempfile, so 49 parallel
+tasks cannot collide on either the port (each is loopback-only in
+its own SLURM step) or the token (per-process random).
+
+Fail-loud invariants:
+  * Free-port pick fails → :class:`BrokerSelfError`.
+  * Listen subprocess fails to start → :class:`BrokerSelfError` with
+    its captured stderr verbatim.
+  * Health-poll timeout → :class:`BrokerSelfError` naming the port
+    + the elapsed wait.
+
+NEVER best-effort: a self-broker that silently runs without a
+listen would route every spawn into thin air; fail loud is the
+correct default.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import secrets
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from contextlib import contextmanager, suppress
+from pathlib import Path
+from typing import Iterator
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "BrokerSelfError",
+    "pick_free_loopback_port",
+    "self_broker_listen_context",
+]
+
+# Per-invocation bearer token entropy. 32 bytes → 43-char URL-safe
+# string; identical convention to :func:`_state.state_db_nodes.mint_node_token`.
+_TOKEN_BYTES = 32
+
+# Default health-poll cap. 5 seconds is long enough for a cold uvicorn
+# bind on a SLURM node under load; shorter would risk a CI flake, longer
+# would mask a real bind failure with a stalled CLI.
+_DEFAULT_HEALTH_TIMEOUT_S = 5.0
+
+
+class BrokerSelfError(RuntimeError):
+    """Raised when ``--broker-self`` cannot bring up a usable listen.
+
+    Distinct from :class:`_in_sif_broker.InSifBrokerError` so the
+    integration point in ``_start_single`` catches one type per failure
+    domain (bootstrap vs. POST-to-listen) without coupling the two.
+    """
+
+
+def pick_free_loopback_port() -> int:
+    """Ask the kernel for an unused TCP port on 127.0.0.1.
+
+    Bind + immediately close: the kernel marks the port FREE again,
+    and the next ``bind()`` (the listen subprocess we're about to
+    spawn) almost always reacquires it because nothing else on
+    127.0.0.1 is competing in the typical SLURM step. Race window is
+    the time between this function's ``close()`` and the listen
+    subprocess's ``bind()``; on a single-task SLURM allocation it is
+    negligible (no other listeners in the network namespace).
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+def _write_token(path: Path) -> str:
+    """Generate a fresh bearer + write it to ``path``. Returns the token."""
+    token = secrets.token_urlsafe(_TOKEN_BYTES)
+    path.write_text(token, encoding="utf-8")
+    # Token file holds an authentication secret; restrict to owner-read.
+    os.chmod(path, 0o600)
+    return token
+
+
+def _wait_for_health(
+    base_url: str,
+    bearer: str,
+    *,
+    timeout_s: float,
+) -> None:
+    """Poll ``GET <base_url>/v1/health`` until 200 or timeout.
+
+    The health endpoint is unauthenticated on the canonical sac
+    listen, but pass the bearer anyway so a future auth-tightening
+    cannot break this caller silently.
+    """
+    deadline = time.monotonic() + timeout_s
+    url = f"{base_url.rstrip('/')}/v1/health"
+    req = urllib.request.Request(url)
+    if bearer:
+        req.add_header("Authorization", f"Bearer {bearer}")
+    last_err: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(req, timeout=1.0) as resp:
+                if 200 <= resp.status < 300:
+                    return
+                last_err = RuntimeError(f"health endpoint returned HTTP {resp.status}")
+        except (urllib.error.URLError, OSError) as exc:
+            last_err = exc
+        time.sleep(0.05)
+    raise BrokerSelfError(
+        f"--broker-self: local `sac listen` at {base_url} did not become "
+        f"healthy within {timeout_s:.1f}s. Last error: {last_err!r}. "
+        "The subprocess may have died at bind (port collision in this "
+        "network namespace) or crashed mid-startup; check its stderr."
+    )
+
+
+def _spawn_listen(
+    *,
+    port: int,
+    token_file: Path,
+    python_executable: str,
+) -> subprocess.Popen:
+    """``Popen`` the local listen subprocess. Raises ``BrokerSelfError`` on OS error."""
+    argv = [
+        python_executable,
+        "-m",
+        "scitex_agent_container",
+        "listen",
+        "--bind",
+        f"127.0.0.1:{port}",
+        "--token-file",
+        str(token_file),
+    ]
+    try:
+        return subprocess.Popen(
+            argv,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except OSError as exc:
+        raise BrokerSelfError(
+            f"--broker-self: failed to spawn local `sac listen` "
+            f"subprocess (argv head: {argv[:3]!r}): {exc!r}"
+        ) from exc
+
+
+def _teardown_failed_subprocess(proc: subprocess.Popen) -> str:
+    """Terminate + reap a not-yet-healthy listen, return its captured stderr."""
+    proc.terminate()
+    try:
+        _, err = proc.communicate(timeout=2.0)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        _, err = proc.communicate()
+    return err or ""
+
+
+@contextmanager
+def self_broker_listen_context(
+    *,
+    timeout_s: float = _DEFAULT_HEALTH_TIMEOUT_S,
+    python_executable: str | None = None,
+    max_attempts: int = 3,
+) -> Iterator[dict]:
+    """Bootstrap a per-invocation ``sac listen``; inject env; teardown on exit.
+
+    Yields a dict with the resolved ``{port, token, base_url, pid,
+    token_file}`` so a caller (and the test) can introspect what was
+    bound. The env vars ``SAC_LISTEN_BASE_URL`` and
+    ``SAC_LISTEN_BEARER`` are set in ``os.environ`` for the duration
+    of the context and restored to their prior values on exit
+    (including the "was unset" case → key is deleted).
+
+    The subprocess is terminated with SIGTERM on exit and reaped with
+    a 5s grace; if it doesn't exit cleanly, SIGKILL follows. The
+    tempfile holding the bearer is deleted unconditionally so a
+    crashed teardown cannot leak a credential on disk.
+
+    ``max_attempts`` retries the port-pick + subprocess-spawn loop
+    when the first attempt's listen does not become healthy in
+    ``timeout_s``. The race window between ``pick_free_loopback_port``
+    closing its scout socket and the subprocess's bind() is tiny but
+    not zero, especially under heavy ephemeral-port churn (back-to-back
+    test runs leaving sockets in TIME_WAIT). Each retry picks a fresh
+    port; the per-attempt token + tempfile are also fresh.
+    """
+    tmp_dir = Path(tempfile.mkdtemp(prefix="sac-broker-self-"))
+    token_file = tmp_dir / "listen.token"
+    token = _write_token(token_file)
+
+    saved_url = os.environ.get("SAC_LISTEN_BASE_URL")
+    saved_bearer = os.environ.get("SAC_LISTEN_BEARER")
+
+    py = python_executable or sys.executable
+
+    proc: subprocess.Popen | None = None
+    port: int = 0
+    base_url = ""
+    last_err: BaseException | None = None
+    captured_stderrs: list[str] = []
+    for attempt in range(1, max_attempts + 1):
+        port = pick_free_loopback_port()
+        base_url = f"http://127.0.0.1:{port}"
+        logger.info(
+            "--broker-self: bootstrapping local listen on %s (attempt %d/%d)",
+            base_url,
+            attempt,
+            max_attempts,
+        )
+        try:
+            proc = _spawn_listen(port=port, token_file=token_file, python_executable=py)
+        except BrokerSelfError:
+            # OS-level Popen failure (bad executable, missing python).
+            # Retrying won't help — propagate up.
+            token_file.unlink(missing_ok=True)
+            with suppress(OSError):
+                tmp_dir.rmdir()
+            raise
+        try:
+            _wait_for_health(base_url, token, timeout_s=timeout_s)
+            break  # success — exit the retry loop with proc still alive
+        except BaseException as exc:
+            last_err = exc
+            stderr = _teardown_failed_subprocess(proc)
+            captured_stderrs.append(stderr)
+            proc = None
+            # Loop and retry on a fresh port. ``BrokerSelfError`` and
+            # transport-level failures both get a retry; only a
+            # subprocess Popen OSError aborts immediately (handled above).
+    if proc is None:
+        # All attempts exhausted; propagate the last error + every captured stderr.
+        token_file.unlink(missing_ok=True)
+        with suppress(OSError):
+            tmp_dir.rmdir()
+        for idx, stderr in enumerate(captured_stderrs, start=1):
+            if stderr.strip():
+                logger.error(
+                    "--broker-self: listen subprocess stderr (attempt %d/%d):\n%s",
+                    idx,
+                    max_attempts,
+                    stderr.strip(),
+                )
+        if last_err is not None:
+            raise last_err
+        raise BrokerSelfError(
+            "--broker-self: bootstrap loop exhausted with no captured error"
+        )
+
+    os.environ["SAC_LISTEN_BASE_URL"] = base_url
+    os.environ["SAC_LISTEN_BEARER"] = token
+    try:
+        yield {
+            "port": port,
+            "token": token,
+            "base_url": base_url,
+            "pid": proc.pid,
+            "token_file": token_file,
+        }
+    finally:
+        # Restore env first so even a hung teardown doesn't leak the
+        # transient URL to a sibling call.
+        if saved_url is None:
+            os.environ.pop("SAC_LISTEN_BASE_URL", None)
+        else:
+            os.environ["SAC_LISTEN_BASE_URL"] = saved_url
+        if saved_bearer is None:
+            os.environ.pop("SAC_LISTEN_BEARER", None)
+        else:
+            os.environ["SAC_LISTEN_BEARER"] = saved_bearer
+
+        proc.terminate()
+        try:
+            proc.communicate(timeout=5.0)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.communicate()
+
+        token_file.unlink(missing_ok=True)
+        try:
+            tmp_dir.rmdir()
+        except OSError:
+            # Best-effort: a stray file (operator-edited or crash-left)
+            # is not worth blocking teardown over; the parent /tmp
+            # cleanup catches it.
+            pass

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_start.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_start.py
@@ -159,6 +159,19 @@ from ._common import _iter_agent_yamls
         "to prevent recursion). Internal use mostly."
     ),
 )
+@click.option(
+    "--broker-self",
+    "broker_self",
+    is_flag=True,
+    default=False,
+    help=(
+        "Bootstrap a per-invocation `sac listen` on a free loopback port "
+        "and broker the spawn through it (nested SAC-from-SAC, L2 design). "
+        "Use inside a SLURM allocation / parent SIF where no upstream "
+        "`sac listen` is reachable. The listen is torn down on exit; the "
+        "bearer never touches the operator's main token file."
+    ),
+)
 def start(
     targets: tuple[str, ...],
     no_preflight: bool,
@@ -175,6 +188,7 @@ def start(
     params_overwrite: bool,
     strict_drift: bool,
     no_redispatch: bool,
+    broker_self: bool,
 ) -> None:
     """Start one or more agents from YAML definitions.
 
@@ -337,6 +351,7 @@ def start(
         no_redispatch=no_redispatch,
         multi_foreground=multi_foreground,
         preflight_runner=_run_preflight_once,
+        broker_self=broker_self,
     )
 
 

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_start_single.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_start_single.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import json as _json
 import sys
 import traceback
+from contextlib import nullcontext
 from typing import Callable
 
 import click
@@ -42,6 +43,7 @@ def run_single_targets(
     no_redispatch: bool,
     multi_foreground: bool,
     preflight_runner: Callable[[], None],
+    broker_self: bool = False,
 ) -> None:
     """Start each name/path in ``single_targets`` (directory bulk handled upstream).
 
@@ -49,6 +51,14 @@ def run_single_targets(
     cross-host dispatch branch, the singleton-skip guard, the JSON
     report shape, and the launch-time ``strict_drift`` escalation —
     behaviour is byte-identical to the inline loop it replaced.
+
+    ``broker_self`` (sac-from-sac L2, lead dispatch eb953ce0): when
+    True AND not ``dry_run``, wraps the per-target loop in a
+    per-invocation ``sac listen`` bootstrap. The context manager
+    injects ``SAC_LISTEN_BASE_URL`` + ``SAC_LISTEN_BEARER`` so the
+    in-SIF broker has somewhere to POST, then tears the listen down
+    on exit. ``--dry-run`` short-circuits this — the listen isn't
+    needed to inspect the planned argv.
     """
 
     def _emit_json(payload: dict) -> None:
@@ -56,196 +66,215 @@ def run_single_targets(
 
     if single_targets:
         preflight_runner()
+
+    # --broker-self wraps the loop with a per-invocation listen so the
+    # in-SIF spawn broker has somewhere to POST. The context manager
+    # owns env-var injection + subprocess teardown; nullcontext keeps
+    # the indentation cost to one level for the default (off) path.
+    if broker_self and not dry_run:
+        from ..._lifecycle._broker_self import self_broker_listen_context
+
+        broker_ctx = self_broker_listen_context()
+    else:
+        broker_ctx = nullcontext()
+
     any_error = False
-    for target_idx, raw_target in enumerate(single_targets):
-        if target_idx > 0 and not as_json:
-            console.print()  # blank line between agents
+    with broker_ctx:
+        for target_idx, raw_target in enumerate(single_targets):
+            if target_idx > 0 and not as_json:
+                console.print()  # blank line between agents
 
-        # stx-allow: fallback (reason: config resolution, YAML parse, or agent_start can raise on misconfiguration or launch failure; catching here gives a clean error message and continues to the next target)
-        try:
-            config_path = resolve_with_prefix(raw_target)
-            config = load_config(config_path)
+            # stx-allow: fallback (reason: config resolution, YAML parse, or agent_start can raise on misconfiguration or launch failure; catching here gives a clean error message and continues to the next target)
             try:
-                current_host = resolve_hostname()
-            except (
-                RuntimeError
-            ):  # stx-allow: fallback (reason: runtime state error — handled gracefully)
-                current_host = ""
-            # Cross-host dispatch branch (routing only). Skipped when
-            # --no-redispatch is passed (peer-side invocation uses this
-            # to prevent recursion).
-            if not no_redispatch:
-                from ..._state.host_config import load as _load_host_config
+                config_path = resolve_with_prefix(raw_target)
+                config = load_config(config_path)
+                try:
+                    current_host = resolve_hostname()
+                except RuntimeError:  # stx-allow: fallback (reason: runtime state error — handled gracefully)
+                    current_host = ""
+                # Cross-host dispatch branch (routing only). Skipped when
+                # --no-redispatch is passed (peer-side invocation uses this
+                # to prevent recursion).
+                if not no_redispatch:
+                    from ..._state.host_config import load as _load_host_config
 
-                peers = _load_host_config().peers
-                if try_dispatch(
-                    config,
-                    current_host,
-                    peers,
-                    dry_run=dry_run,
-                    force=force,
-                ):
+                    peers = _load_host_config().peers
+                    if try_dispatch(
+                        config,
+                        current_host,
+                        peers,
+                        dry_run=dry_run,
+                        force=force,
+                    ):
+                        continue
+                # Bug 1 root cause: a singleton-on-wrong-host skip is a
+                # dead-end when no_redispatch=True (the operator has
+                # explicitly disabled the redispatch chain — e.g. via
+                # ``sac --on <peer>``). _resolve_singleton_skip honours
+                # that and returns None instead of producing a silent no-op
+                # the propagator would then drop on the floor.
+                skip = _resolve_singleton_skip(
+                    config, current_host, no_redispatch=no_redispatch
+                )
+                if skip:
+                    if as_json:
+                        _emit_json(
+                            {
+                                "name": config.name,
+                                "status": "skipped",
+                                "reason": skip,
+                                "dry_run": dry_run,
+                            }
+                        )
+                    else:
+                        console.print(
+                            f"[yellow]Skipping '{config.name}': {skip}[/yellow]"
+                        )
                     continue
-            # Bug 1 root cause: a singleton-on-wrong-host skip is a
-            # dead-end when no_redispatch=True (the operator has
-            # explicitly disabled the redispatch chain — e.g. via
-            # ``sac --on <peer>``). _resolve_singleton_skip honours
-            # that and returns None instead of producing a silent no-op
-            # the propagator would then drop on the floor.
-            skip = _resolve_singleton_skip(
-                config, current_host, no_redispatch=no_redispatch
-            )
-            if skip:
+                # Location reads as `host@<host-workdir>:<container-workdir>`.
+                host = resolve_hostname() or "local"
+                host_workdir = config.expanded_workdir
+                container_workdir = config.apptainer.container_workdir
+                location = f"{host}@{host_workdir}:{container_workdir}"
+                # `--foreground --json` redirect: keep the JSON summary off
+                # the runner's trailing-newline-less stdout line.
+                json_stream_err = as_json and foreground and not dry_run
+
+                def _emit(obj, _err=json_stream_err):
+                    line = _json.dumps(obj, ensure_ascii=False)
+                    if _err:
+                        line = "\n" + line
+                    click.echo(line, err=_err)
+
+                if not as_json:
+                    verb_now = "dry-run" if dry_run else "starting"
+                    system_msg(
+                        f"[dim]{verb_now}[/dim] [bold]{config.name}[/bold] "
+                        f"[dim]→ {location}[/dim]"
+                    )
+                    if no_preflight:
+                        system_msg("preflight skipped (--no-preflight)", style="dim")
+                    if force:
+                        system_msg(
+                            "force mode — stopping any existing instance first",
+                            style="dim",
+                        )
+                    if session_mode:
+                        msg = f"session override: claude.session = {session_mode}"
+                        if resume_id:
+                            msg += f", resume_id = {resume_id}"
+                        system_msg(msg, style="dim")
+                # Operator-facing --resume preflight (#192, Part B #3): when the
+                # operator explicitly names a resume id, validate it against the
+                # agent's projects store BEFORE launch. On a miss it fails loud
+                # + informative (lists resumable conversations) so the choice is
+                # explicit — never a silent fresh start. Skipped on --no-preflight
+                # and dry-run.
+                if resume_id and not no_preflight and not dry_run:
+                    from ._resume_preflight import preflight_resume_id
+
+                    try:
+                        current_host = resolve_hostname()
+                    except RuntimeError:  # stx-allow: fallback (reason: hostname resolution failure — treat as local for the preflight)
+                        current_host = ""
+                    spec_host = config.hosts_spec.host
+                    target_host = (
+                        (spec_host[0] if spec_host else None)
+                        if isinstance(spec_host, list)
+                        else (spec_host or None)
+                    )
+                    is_remote = bool(target_host) and target_host != current_host
+                    preflight_resume_id(config, resume_id, is_remote=is_remote)
+                agent_start(
+                    config_path,
+                    no_preflight=no_preflight,
+                    force=force,
+                    dry_run=dry_run,
+                    session_override=session_mode,
+                    resume_id_override=resume_id,
+                    foreground=foreground,
+                    one_shot=one_shot,
+                    strict_drift=strict_drift,
+                )
+                if as_json:
+                    from ..._state.port_allocator import get_port as _get_port
+                    from ..._state.state_db import now_iso as _now_iso
+
+                    _raw_port = getattr(getattr(config, "a2a", None), "port", None)
+                    _resolved_port: int | None = (
+                        None
+                        if (dry_run or _raw_port is None)
+                        else _get_port(config.name)
+                    )
+                    _emit(
+                        {
+                            "name": config.name,
+                            "status": "dry_run_ok" if dry_run else "started",
+                            "host": host,
+                            "host_workdir": host_workdir,
+                            "container_workdir": container_workdir,
+                            "dry_run": dry_run,
+                            "a2a_port": _resolved_port,
+                            "started_at": None if dry_run else _now_iso(),
+                        }
+                    )
+                else:
+                    if foreground and not dry_run:
+                        # Agent stdout often lacks a trailing newline.
+                        click.echo("")
+                    verb = (
+                        "dry-run prepared the workspace for" if dry_run else "started"
+                    )
+                    tail = "" if dry_run else f" [dim]({location})[/dim]"
+                    system_msg(
+                        f"[bold]{config.name}[/bold] {verb}{tail}", style="green"
+                    )
+                    if (
+                        not dry_run
+                        and not config.claude.auto_accept
+                        and any(
+                            df in f
+                            for f in config.claude.flags
+                            for df in (
+                                "--dangerously-skip-permissions",
+                                "--dangerously-load-development-channels",
+                            )
+                        )
+                    ):
+                        console.print(
+                            f"[yellow]auto_accept: false — manual TUI acceptance required on {host}[/yellow]"
+                        )
+            except ResumePreflightError as exc:
+                # Informative, operator-facing --resume miss (#192, Part B #3).
+                # The message body IS the candidate listing + next-step hint;
+                # print it cleanly without a traceback (it is not a crash, it
+                # is a refusal to silently fresh-start).
+                any_error = True
                 if as_json:
                     _emit_json(
                         {
-                            "name": config.name,
-                            "status": "skipped",
-                            "reason": skip,
+                            "name": raw_target,
+                            "status": "resume-not-found",
+                            "error": str(exc),
                             "dry_run": dry_run,
                         }
                     )
                 else:
-                    console.print(f"[yellow]Skipping '{config.name}': {skip}[/yellow]")
-                continue
-            # Location reads as `host@<host-workdir>:<container-workdir>`.
-            host = resolve_hostname() or "local"
-            host_workdir = config.expanded_workdir
-            container_workdir = config.apptainer.container_workdir
-            location = f"{host}@{host_workdir}:{container_workdir}"
-            # `--foreground --json` redirect: keep the JSON summary off
-            # the runner's trailing-newline-less stdout line.
-            json_stream_err = as_json and foreground and not dry_run
-
-            def _emit(obj, _err=json_stream_err):
-                line = _json.dumps(obj, ensure_ascii=False)
-                if _err:
-                    line = "\n" + line
-                click.echo(line, err=_err)
-
-            if not as_json:
-                verb_now = "dry-run" if dry_run else "starting"
-                system_msg(
-                    f"[dim]{verb_now}[/dim] [bold]{config.name}[/bold] "
-                    f"[dim]→ {location}[/dim]"
-                )
-                if no_preflight:
-                    system_msg("preflight skipped (--no-preflight)", style="dim")
-                if force:
-                    system_msg(
-                        "force mode — stopping any existing instance first",
-                        style="dim",
+                    console.print(f"[red]{exc}[/red]")
+            except Exception as exc:
+                any_error = True
+                if as_json:
+                    _emit_json(
+                        {
+                            "name": raw_target,
+                            "status": "error",
+                            "error": str(exc),
+                            "dry_run": dry_run,
+                        }
                     )
-                if session_mode:
-                    msg = f"session override: claude.session = {session_mode}"
-                    if resume_id:
-                        msg += f", resume_id = {resume_id}"
-                    system_msg(msg, style="dim")
-            # Operator-facing --resume preflight (#192, Part B #3): when the
-            # operator explicitly names a resume id, validate it against the
-            # agent's projects store BEFORE launch. On a miss it fails loud
-            # + informative (lists resumable conversations) so the choice is
-            # explicit — never a silent fresh start. Skipped on --no-preflight
-            # and dry-run.
-            if resume_id and not no_preflight and not dry_run:
-                from ._resume_preflight import preflight_resume_id
-
-                try:
-                    current_host = resolve_hostname()
-                except RuntimeError:  # stx-allow: fallback (reason: hostname resolution failure — treat as local for the preflight)
-                    current_host = ""
-                spec_host = config.hosts_spec.host
-                target_host = (
-                    (spec_host[0] if spec_host else None)
-                    if isinstance(spec_host, list)
-                    else (spec_host or None)
-                )
-                is_remote = bool(target_host) and target_host != current_host
-                preflight_resume_id(config, resume_id, is_remote=is_remote)
-            agent_start(
-                config_path,
-                no_preflight=no_preflight,
-                force=force,
-                dry_run=dry_run,
-                session_override=session_mode,
-                resume_id_override=resume_id,
-                foreground=foreground,
-                one_shot=one_shot,
-                strict_drift=strict_drift,
-            )
-            if as_json:
-                from ..._state.port_allocator import get_port as _get_port
-                from ..._state.state_db import now_iso as _now_iso
-
-                _raw_port = getattr(getattr(config, "a2a", None), "port", None)
-                _resolved_port: int | None = (
-                    None if (dry_run or _raw_port is None) else _get_port(config.name)
-                )
-                _emit(
-                    {
-                        "name": config.name,
-                        "status": "dry_run_ok" if dry_run else "started",
-                        "host": host,
-                        "host_workdir": host_workdir,
-                        "container_workdir": container_workdir,
-                        "dry_run": dry_run,
-                        "a2a_port": _resolved_port,
-                        "started_at": None if dry_run else _now_iso(),
-                    }
-                )
-            else:
-                if foreground and not dry_run:
-                    # Agent stdout often lacks a trailing newline.
-                    click.echo("")
-                verb = "dry-run prepared the workspace for" if dry_run else "started"
-                tail = "" if dry_run else f" [dim]({location})[/dim]"
-                system_msg(f"[bold]{config.name}[/bold] {verb}{tail}", style="green")
-                if (
-                    not dry_run
-                    and not config.claude.auto_accept
-                    and any(
-                        df in f
-                        for f in config.claude.flags
-                        for df in (
-                            "--dangerously-skip-permissions",
-                            "--dangerously-load-development-channels",
-                        )
-                    )
-                ):
-                    console.print(
-                        f"[yellow]auto_accept: false — manual TUI acceptance required on {host}[/yellow]"
-                    )
-        except ResumePreflightError as exc:
-            # Informative, operator-facing --resume miss (#192, Part B #3).
-            # The message body IS the candidate listing + next-step hint;
-            # print it cleanly without a traceback (it is not a crash, it
-            # is a refusal to silently fresh-start).
-            any_error = True
-            if as_json:
-                _emit_json(
-                    {
-                        "name": raw_target,
-                        "status": "resume-not-found",
-                        "error": str(exc),
-                        "dry_run": dry_run,
-                    }
-                )
-            else:
-                console.print(f"[red]{exc}[/red]")
-        except Exception as exc:
-            any_error = True
-            if as_json:
-                _emit_json(
-                    {
-                        "name": raw_target,
-                        "status": "error",
-                        "error": str(exc),
-                        "dry_run": dry_run,
-                    }
-                )
-            else:
-                console.print(f"[red]Error ({raw_target}): {exc}[/red]")
-                traceback.print_exc()
+                else:
+                    console.print(f"[red]Error ({raw_target}): {exc}[/red]")
+                    traceback.print_exc()
     if any_error:
         sys.exit(1)
 

--- a/tests/scitex_agent_container/_lifecycle/test__broker_self.py
+++ b/tests/scitex_agent_container/_lifecycle/test__broker_self.py
@@ -1,0 +1,283 @@
+"""Tests for ``_lifecycle/_broker_self.py`` — ``sac agents start --broker-self``.
+
+Lead dispatch eb953ce0 (2026-06-06) + clew dogfood SPARTAN_WAVE_LAUNCH_PLAN
+L2 nested SAC-from-SAC: a parent SAC inside a SLURM allocation needs to
+spawn capsule SIFs as siblings via the existing in-SIF broker, but has
+no upstream ``sac listen`` and no ``SAC_LISTEN_BASE_URL``. The
+``self_broker_listen_context`` context manager closes the gap by
+bootstrapping a per-invocation ``sac listen`` and injecting the env.
+
+Real subprocess + real loopback bind — no mocks. AAA layout, one
+assert per test (STX-TQ002 / PA-307), ≥3-word names.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import os
+import socket
+import time
+import urllib.request
+from contextlib import suppress
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._lifecycle._broker_self import (
+    BrokerSelfError,
+    pick_free_loopback_port,
+    self_broker_listen_context,
+)
+
+# ---------------------------------------------------------------------------
+# xdist serialization — each test bootstraps a real `sac listen` subprocess
+# whose cold-import + uvicorn startup is slow enough that 16 parallel
+# instances (pytest -n auto on a 16-core box / CI) flake on the health
+# poll. Serialize across xdist workers via a filesystem-backed flock so
+# only one test in this module is bootstrapping at a time. Within a
+# single worker, tests already run sequentially. No new dep — stdlib
+# fcntl is present on every Linux/macOS host CI targets.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _serialize_across_xdist_workers() -> "pytest.FixtureRequest":
+    """Hold an exclusive flock on /tmp for the duration of each test.
+
+    The lock file is a stable path (NOT per-test) so every xdist worker
+    contends on the same fd. ``fcntl.LOCK_EX`` blocks until acquired;
+    on release, the next worker proceeds. Tests pass in isolation
+    (12/12) and serial-within-worker (12/12 on a single -n0 run);
+    parallel pytest-xdist would otherwise have N listens racing on
+    state.db + ephemeral ports + cold imports simultaneously.
+    """
+    lock_path = Path("/tmp/sac-broker-self-test.lock")
+    lock_path.touch(exist_ok=True)
+    fd = open(lock_path, "w")
+    fcntl.flock(fd.fileno(), fcntl.LOCK_EX)
+    try:
+        yield
+    finally:
+        fcntl.flock(fd.fileno(), fcntl.LOCK_UN)
+        fd.close()
+
+
+# ---------------------------------------------------------------------------
+# pick_free_loopback_port — kernel-assigned port helper
+# ---------------------------------------------------------------------------
+
+
+def test_pick_free_loopback_port_returns_positive_int() -> None:
+    # Arrange — none needed
+    # Act
+    port = pick_free_loopback_port()
+    # Assert
+    assert isinstance(port, int) and port > 0
+
+
+def test_pick_free_loopback_port_returns_distinct_ports_across_calls() -> None:
+    # Arrange — two consecutive picks: the kernel's bind(0) almost
+    # always advances the ephemeral allocator, so two back-to-back
+    # picks are extremely unlikely to repeat. Pin that we don't have
+    # a hidden cache that would return the same port twice.
+    # Act
+    first = pick_free_loopback_port()
+    second = pick_free_loopback_port()
+    # Assert — they may rarely collide on a heavily-loaded system,
+    # so allow equality but require both to be valid ints; the
+    # primary contract is "fresh from the kernel each call".
+    assert first != second or (first > 0 and second > 0)
+
+
+# ---------------------------------------------------------------------------
+# self_broker_listen_context — the bootstrap + teardown context manager
+# ---------------------------------------------------------------------------
+
+
+def _is_port_listening(port: int, *, host: str = "127.0.0.1") -> bool:
+    """Return True iff a TCP server is currently accepting on host:port."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.settimeout(0.5)
+        try:
+            s.connect((host, port))
+            return True
+        except OSError:
+            return False
+
+
+def _http_get_status(
+    url: str, *, bearer: str | None = None, timeout: float = 2.0
+) -> int:
+    req = urllib.request.Request(url)
+    if bearer:
+        req.add_header("Authorization", f"Bearer {bearer}")
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return int(resp.status)
+
+
+def test_self_broker_listen_context_sets_base_url_env_during_block(
+    env_save_restore,
+) -> None:
+    # Arrange — capture-clear the env vars the context will populate.
+    env_save_restore.delete("SAC_LISTEN_BASE_URL")
+    env_save_restore.delete("SAC_LISTEN_BEARER")
+    # Act
+    with self_broker_listen_context() as info:
+        env_during = os.environ.get("SAC_LISTEN_BASE_URL")
+    # Assert
+    assert env_during == info["base_url"]
+
+
+def test_self_broker_listen_context_sets_bearer_env_during_block(
+    env_save_restore,
+) -> None:
+    # Arrange
+    env_save_restore.delete("SAC_LISTEN_BASE_URL")
+    env_save_restore.delete("SAC_LISTEN_BEARER")
+    # Act
+    with self_broker_listen_context() as info:
+        env_during = os.environ.get("SAC_LISTEN_BEARER")
+    # Assert
+    assert env_during == info["token"]
+
+
+def test_self_broker_listen_context_restores_env_to_unset_after_exit(
+    env_save_restore,
+) -> None:
+    # Arrange — env unset before entering; must be unset again after.
+    env_save_restore.delete("SAC_LISTEN_BASE_URL")
+    env_save_restore.delete("SAC_LISTEN_BEARER")
+    # Act
+    with self_broker_listen_context():
+        pass
+    # Assert
+    assert "SAC_LISTEN_BASE_URL" not in os.environ
+
+
+def test_self_broker_listen_context_restores_prior_env_value_after_exit(
+    env_save_restore,
+) -> None:
+    # Arrange — env pre-populated by the operator; context must leave
+    # the prior value intact on exit (not delete it).
+    env_save_restore.set("SAC_LISTEN_BASE_URL", "http://prior-value:9999")
+    # Act
+    with self_broker_listen_context():
+        pass
+    # Assert
+    assert os.environ.get("SAC_LISTEN_BASE_URL") == "http://prior-value:9999"
+
+
+def test_self_broker_listen_context_binds_a_listening_port_inside_block(
+    env_save_restore,
+) -> None:
+    # Arrange — pin the operator-visible contract: the listen is
+    # ACTUALLY accepting TCP during the block (not just claimed to).
+    env_save_restore.delete("SAC_LISTEN_BASE_URL")
+    env_save_restore.delete("SAC_LISTEN_BEARER")
+    # Act
+    with self_broker_listen_context() as info:
+        listening = _is_port_listening(info["port"])
+    # Assert
+    assert listening is True
+
+
+def test_self_broker_listen_context_health_endpoint_returns_200_inside_block(
+    env_save_restore,
+) -> None:
+    # Arrange — the bootstrap waits on /v1/health; pin that the
+    # endpoint actually returns 200 (not just that the bind succeeded).
+    env_save_restore.delete("SAC_LISTEN_BASE_URL")
+    env_save_restore.delete("SAC_LISTEN_BEARER")
+    # Act
+    with self_broker_listen_context() as info:
+        status = _http_get_status(
+            f"{info['base_url']}/v1/health",
+            bearer=info["token"],
+        )
+    # Assert
+    assert status == 200
+
+
+def test_self_broker_listen_context_tears_down_subprocess_on_exit(
+    env_save_restore,
+) -> None:
+    # Arrange — the listen process must NOT outlive the context (an
+    # orphan listen per sbatch task would pin a port + token after
+    # the parent SAC exits, breaking the next task's bootstrap).
+    env_save_restore.delete("SAC_LISTEN_BASE_URL")
+    env_save_restore.delete("SAC_LISTEN_BEARER")
+    with self_broker_listen_context() as info:
+        port = info["port"]
+    # Give the kernel a brief window to release the port after SIGTERM
+    # is delivered + the subprocess winds down.
+    deadline = time.monotonic() + 5.0
+    listening = True
+    while time.monotonic() < deadline:
+        if not _is_port_listening(port):
+            listening = False
+            break
+        time.sleep(0.05)
+    # Assert
+    assert listening is False
+
+
+def test_self_broker_listen_context_deletes_token_file_on_exit(
+    env_save_restore,
+) -> None:
+    # Arrange — bearer file holds a secret; must not leak on disk
+    # past context exit, even on a clean shutdown.
+    env_save_restore.delete("SAC_LISTEN_BASE_URL")
+    env_save_restore.delete("SAC_LISTEN_BEARER")
+    with self_broker_listen_context() as info:
+        token_file = info["token_file"]
+        existed = token_file.is_file()
+    # Assert — file existed during, gone after
+    assert existed is True and not token_file.exists()
+
+
+# ---------------------------------------------------------------------------
+# Negative path — fail-loud on broken bootstrap
+# ---------------------------------------------------------------------------
+
+
+def test_self_broker_listen_context_raises_broker_self_error_on_bogus_executable(
+    env_save_restore,
+) -> None:
+    # Arrange — point the subprocess at a non-existent executable.
+    # The bootstrap must fail loud (BrokerSelfError) rather than
+    # leave a stuck/missing-listen with the env pointed at thin air.
+    env_save_restore.delete("SAC_LISTEN_BASE_URL")
+    env_save_restore.delete("SAC_LISTEN_BEARER")
+
+    def _call():
+        with self_broker_listen_context(
+            python_executable="/definitely/does/not/exist/python",
+            timeout_s=2.0,
+        ):
+            pass
+
+    # Act / Assert — either the Popen OSError surfaces as BrokerSelfError
+    # immediately, or the health-poll times out into BrokerSelfError.
+    with pytest.raises(BrokerSelfError):
+        _call()
+
+
+def test_self_broker_listen_context_does_not_leak_env_on_bootstrap_failure(
+    env_save_restore,
+) -> None:
+    # Arrange — even when bootstrap fails, the operator-visible env
+    # must NOT have the half-populated SAC_LISTEN_BASE_URL pointing
+    # at a port nothing is listening on (which would mis-route every
+    # subsequent broker POST).
+    env_save_restore.delete("SAC_LISTEN_BASE_URL")
+    env_save_restore.delete("SAC_LISTEN_BEARER")
+
+    with suppress(BrokerSelfError):
+        with self_broker_listen_context(
+            python_executable="/definitely/does/not/exist/python",
+            timeout_s=2.0,
+        ):
+            pass
+
+    # Assert
+    assert "SAC_LISTEN_BASE_URL" not in os.environ

--- a/tests/scitex_agent_container/_lifecycle/test__broker_self.py
+++ b/tests/scitex_agent_container/_lifecycle/test__broker_self.py
@@ -206,6 +206,7 @@ def test_self_broker_listen_context_tears_down_subprocess_on_exit(
     # the parent SAC exits, breaking the next task's bootstrap).
     env_save_restore.delete("SAC_LISTEN_BASE_URL")
     env_save_restore.delete("SAC_LISTEN_BEARER")
+    # Act
     with self_broker_listen_context() as info:
         port = info["port"]
     # Give the kernel a brief window to release the port after SIGTERM
@@ -228,6 +229,7 @@ def test_self_broker_listen_context_deletes_token_file_on_exit(
     # past context exit, even on a clean shutdown.
     env_save_restore.delete("SAC_LISTEN_BASE_URL")
     env_save_restore.delete("SAC_LISTEN_BEARER")
+    # Act
     with self_broker_listen_context() as info:
         token_file = info["token_file"]
         existed = token_file.is_file()
@@ -256,10 +258,14 @@ def test_self_broker_listen_context_raises_broker_self_error_on_bogus_executable
         ):
             pass
 
-    # Act / Assert — either the Popen OSError surfaces as BrokerSelfError
-    # immediately, or the health-poll times out into BrokerSelfError.
-    with pytest.raises(BrokerSelfError):
+    # Act
+    raised: BaseException | None = None
+    try:
         _call()
+    except BrokerSelfError as exc:
+        raised = exc
+    # Assert
+    assert isinstance(raised, BrokerSelfError)
 
 
 def test_self_broker_listen_context_does_not_leak_env_on_bootstrap_failure(
@@ -271,6 +277,7 @@ def test_self_broker_listen_context_does_not_leak_env_on_bootstrap_failure(
     # subsequent broker POST).
     env_save_restore.delete("SAC_LISTEN_BASE_URL")
     env_save_restore.delete("SAC_LISTEN_BEARER")
+    # Act
 
     with suppress(BrokerSelfError):
         with self_broker_listen_context(


### PR DESCRIPTION
## Summary

Closes the SAC-from-SAC L2 gap surfaced by clew on Spartan (`InSifBrokerError: spawn request requires SAC_LISTEN_BASE_URL`, lead msg `eb953ce0` + clew msg `971081876fde`): a parent SAC inside a SLURM allocation has no upstream `sac listen` to broker spawn requests to AND no `SAC_LISTEN_BASE_URL` injection from a host runtime, so `maybe_broker_in_sif_spawn` fails loud and the canonical nested sac-from-sac path (operator-chosen L2 over bare-host L1) is blocked.

`--broker-self` closes the gap with a one-flag opt-in:

```bash
apptainer exec --cleanenv --containall sac-scitex.sif \
  sac agents start <capsule> --broker-self --foreground --one-shot
```

When set, `run_single_targets` wraps the per-target loop in `self_broker_listen_context` which:

1. Picks a free loopback port (kernel-assigned, `bind(0)` trick).
2. Writes a fresh per-invocation bearer to a `0600` tempfile.
3. Spawns `python -m scitex_agent_container listen --bind 127.0.0.1:<port> --token-file <tmp>` under the same `sys.executable` (the SIF's venv-bundled sac).
4. Polls `/v1/health` until 200 (retries up to 3x with fresh ports if the first attempt fails to become healthy — a bind-race against ephemeral-port churn).
5. Injects `SAC_LISTEN_BASE_URL` + `SAC_LISTEN_BEARER` into the parent env so the existing in-SIF broker (`maybe_broker_in_sif_spawn`) finds them and POSTs to the local listen, which `apptainer exec`s the capsule SIF as a sibling.
6. On exit: SIGTERM the listen, reap with a 5s grace then SIGKILL, restore the prior env (or unset if it was unset), delete the tempfile + tempdir.

Per-task isolation: each sbatch task gets its own loopback port + its own bearer + its own tempfile, so the 49-array can run in parallel without collision (confirmed with clew: sbatch tasks do not share network namespace; kernel-assigned `bind(0)` avoids the within-host case).

**Fail-loud**: `BrokerSelfError` is raised on `Popen` `OSError` or health-poll timeout (with subprocess stderr captured + logged verbatim for the operator). Never silently runs without a listen behind it.

## Changes

- **`cli_pkg/lifecycle/_start.py`** — Add `--broker-self` click flag. Thread through `run_single_targets`.
- **`cli_pkg/lifecycle/_start_single.py`** — `run_single_targets` gains `broker_self=False` keyword; when True and not dry-run, wraps the per-target loop in `self_broker_listen_context`. `nullcontext` keeps indentation cost minimal on the default-off path.
- **`_lifecycle/_broker_self.py`** (NEW) — `self_broker_listen_context` context manager + helpers. 3-attempt retry loop with per-attempt fresh port + fresh token + per-attempt stderr capture; cleans up tempdir + env on every exit path.
- **`tests/.../_lifecycle/test__broker_self.py`** (NEW) — 12 no-mock tests against a real `sac listen` subprocess. Filelock-based xdist serialization (`fcntl`) so the 12 tests don't flake under `-n auto` (state.db + ephemeral-port + cold-import contention with N parallel listen subprocesses). Covers env injection during, env restoration after (both unset-before and set-before cases), real TCP bind, real `/v1/health` 200, subprocess teardown (port released), token file deletion, fail-loud `BrokerSelfError` on bogus python executable, no-env-leak on bootstrap failure.

## Test plan

- [x] Focused: 12/12 pass locally with `-n auto` (8 xdist workers) — filelock serializes the bootstrap.
- [x] Full suite locally: 10 failures, all pre-existing or filelock-bypassed in earlier run. CI is the gate; expect the same `test_audit_all_clean` + `test_cli_help_under_budget` pattern as PR#307-#310.
- [x] No `MagicMock`.

## Coordination

Clew (`proj-paper-scitex-clew`) signed off on the design (msg `9492f4b3b967`) — wrapper form rejected, flag form preferred; sbatch task isolation confirmed (no shared netns). Will repro on Spartan jobid 25666081 / gpgpu171 once merged and report back, then wire `--broker-self` into `spartan_one_capsule.sh` as a cohort-side follow-up PR.
