### PR TITLE
fix(_listen/agent_exec): fail-loud post-spawn-ack liveness probe (PR#312 layer-3)

### DIFF
--- a/src/scitex_agent_container/_listen/_agent_exec.py
+++ b/src/scitex_agent_container/_listen/_agent_exec.py
@@ -23,6 +23,8 @@ import json as _json
 import os
 import shutil
 import subprocess
+import time
+from pathlib import Path
 
 from starlette.requests import Request
 from starlette.responses import JSONResponse, Response, StreamingResponse
@@ -39,6 +41,113 @@ __all__ = [
     "agent_send",
     "agents_start",
 ]
+
+
+# Layer-3 fail-loud (clew dogfood repro 2026-06-06, lead msg 57f1632a).
+# Grace window the listen waits AFTER `sac agents start <child>` returns
+# rc=0 before it accepts the spawn as "running and healthy". Long enough
+# for the real apptainer instance to come up on a SLURM-allocation host
+# under typical load; short enough that a stillborn instance is caught
+# before the operator's recv path treats SUCC as truth.
+_POST_ACK_LIVENESS_TIMEOUT_S = 5.0
+
+# How often to re-check the apptainer_pid file inside the grace window.
+_POST_ACK_LIVENESS_POLL_INTERVAL_S = 0.1
+
+
+def _pid_alive(pid: int) -> bool:
+    """``kill -0`` style liveness check. Returns False iff pid is reaped.
+
+    ``PermissionError`` means the kernel refused us (e.g. pid owned by
+    another uid), but the process exists — we treat that as alive.
+    Only ``ProcessLookupError`` (and the equivalent ``OSError(ESRCH)``)
+    counts as dead. ``pid <= 0`` is treated as dead defensively (the
+    file may have been written truncated / partial).
+    """
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def _probe_post_ack_liveness(
+    runtime_dir: Path,
+    *,
+    timeout_s: float = _POST_ACK_LIVENESS_TIMEOUT_S,
+    poll_interval_s: float = _POST_ACK_LIVENESS_POLL_INTERVAL_S,
+) -> tuple[str, str] | None:
+    """Return ``None`` if the spawned instance is live by deadline.
+
+    Returns ``(kind, hint)`` tuple on loud failure, suitable for the
+    :func:`_lifecycle._startup_failed.write_marker` ``kind_override``
+    + the operator-facing diagnostic hint:
+
+    * ``"post_ack_no_apptainer_pid"`` — the child subprocess returned
+      0 but never wrote ``<runtime_dir>/apptainer_pid``. The wrapper
+      bypassed the apptainer runtime path entirely (broken config,
+      missing image, runtime mis-resolved, etc.).
+    * ``"post_ack_apptainer_pid_dead"`` — ``apptainer_pid`` was
+      written but the process is dead (or never was alive). The SIF
+      instance came up and immediately exited; ``stderr.log`` in the
+      runtime dir usually has the actual cause.
+
+    Implementation: poll for the file to appear; once it does, check
+    liveness via ``os.kill(pid, 0)``. The check repeats until either
+    deadline OR a non-alive pid is observed, whichever comes first.
+    """
+    if timeout_s <= 0.0:
+        # Test escape hatch: zero/negative timeout skips the probe. The
+        # listen handler honours SAC_LISTEN_POST_ACK_LIVENESS_TIMEOUT_S
+        # to set this from the env so legacy tests that don't simulate
+        # the apptainer-pid write can opt out (the probe's contract is
+        # asserted by the dedicated probe-tests below).
+        return None
+    pid_file = runtime_dir / "apptainer_pid"
+    deadline = time.monotonic() + max(0.0, timeout_s)
+    saw_pid_file = False
+    last_seen_pid: int | None = None
+
+    while True:
+        if pid_file.is_file():
+            saw_pid_file = True
+            try:
+                pid = int(pid_file.read_text(encoding="utf-8").strip())
+            except (OSError, ValueError):
+                pid = -1
+            last_seen_pid = pid
+            if pid > 0 and _pid_alive(pid):
+                return None  # live → happy path
+        if time.monotonic() >= deadline:
+            break
+        time.sleep(poll_interval_s)
+
+    if not saw_pid_file:
+        return (
+            "post_ack_no_apptainer_pid",
+            f"`sac agents start` returned rc=0 but no apptainer_pid "
+            f"file appeared in {runtime_dir} within "
+            f"{timeout_s:.1f}s. The child subprocess bypassed the "
+            "apptainer runtime path (broken wrapper / missing config / "
+            "runtime mis-resolved). Inspect the runtime_dir for any "
+            "stdout/stderr the child captured, and verify the agent's "
+            "spec.apptainer block resolves to a real SIF on disk.",
+        )
+    return (
+        "post_ack_apptainer_pid_dead",
+        f"apptainer_pid={last_seen_pid} in {runtime_dir} was reaped "
+        f"within {timeout_s:.1f}s of the spawn-ack. The SIF instance "
+        "came up and exited silently — check the runtime_dir's "
+        "stderr.log for the apptainer FATAL line. Common causes: "
+        "missing bind source on host, SIF binary missing on host, "
+        "in-SIF entrypoint crashing on a startup-prompt eval.",
+    )
 
 
 def _find_claude_binary() -> str:
@@ -386,6 +495,90 @@ async def agents_start(request: Request) -> JSONResponse:
         except Exception:  # stx-allow: fallback (reason: see inline comment)
             pass
 
+        return JSONResponse(
+            {
+                "name": name,
+                "returncode": proc.returncode,
+                "stdout": proc.stdout,
+                "stderr": proc.stderr,
+            },
+            status_code=502,
+        )
+
+    # Layer-3 fail-loud (clew dogfood repro 2026-06-06, lead msg
+    # 57f1632a): `sac agents start <child>` returning rc=0 was being
+    # treated as "instance is running and healthy", but the apptainer
+    # exec the child spawned can die SILENTLY post-ack — empty
+    # stdout.log, dead apptainer_pid, no fresh STARTUP_FAILED marker.
+    # The "SUCC: started" body of this 200 response lied.
+    #
+    # Probe the runtime_dir for liveness: wait up to
+    # ``_POST_ACK_LIVENESS_TIMEOUT_S`` for ``apptainer_pid`` to appear
+    # AND for that pid to still be alive (``kill -0``). Three loud
+    # failure modes:
+    #
+    #   * apptainer_pid never appears within the grace → the child
+    #     subprocess returned 0 without invoking the apptainer
+    #     runtime path (broken wrapper, missing config, etc.).
+    #     kind = "post_ack_no_apptainer_pid"
+    #   * apptainer_pid appears but the pid is dead by the time we
+    #     check → the SIF instance came up and immediately died.
+    #     kind = "post_ack_apptainer_pid_dead"
+    #   * apptainer_pid was alive at grace-deadline → return 200/SUCC
+    #     (the existing happy path).
+    #
+    # Loud failures write a fresh STARTUP_FAILED with the new kind
+    # AND downgrade the response to 502 so the operator-side recv
+    # path can show a real diagnostic instead of a misleading SUCC.
+    from .._lifecycle._startup_failed import write_marker
+    from .._runners._session_state import state_dir_for
+
+    runtime_dir = state_dir_for(name)
+    # Test escape hatch: ``SAC_LISTEN_POST_ACK_LIVENESS_TIMEOUT_S`` env
+    # var lets the suite skip / shorten the probe (≤0 → skip entirely).
+    # Production callers leave it unset and get the default 5s grace.
+    try:
+        env_timeout = float(
+            os.environ.get(
+                "SAC_LISTEN_POST_ACK_LIVENESS_TIMEOUT_S",
+                str(_POST_ACK_LIVENESS_TIMEOUT_S),
+            )
+        )
+    except ValueError:
+        env_timeout = _POST_ACK_LIVENESS_TIMEOUT_S
+    liveness_failure = _probe_post_ack_liveness(
+        runtime_dir,
+        timeout_s=env_timeout,
+    )
+    if liveness_failure is not None:
+        kind, hint = liveness_failure
+        # stx-allow: fallback (reason: marker write is observability;
+        # a write failure here must not shadow the underlying
+        # post-ack-died signal that the listen is about to return)
+        try:
+            write_marker(
+                runtime_dir,
+                started_at=started_at,
+                phase="post_ack_liveness",
+                exit_code=0,
+                stdout=proc.stdout or "",
+                stderr=(proc.stderr or "")
+                + f"\n\n[listen post-ack liveness probe] {kind}: {hint}\n",
+                kind_override=kind,
+            )
+        except Exception:  # stx-allow: fallback (reason: see inline comment)
+            pass
+        return JSONResponse(
+            {
+                "name": name,
+                "returncode": proc.returncode,
+                "stdout": proc.stdout,
+                "stderr": proc.stderr,
+                "post_ack_liveness": {"kind": kind, "hint": hint},
+            },
+            status_code=502,
+        )
+
     return JSONResponse(
         {
             "name": name,
@@ -393,5 +586,5 @@ async def agents_start(request: Request) -> JSONResponse:
             "stdout": proc.stdout,
             "stderr": proc.stderr,
         },
-        status_code=200 if proc.returncode == 0 else 502,
+        status_code=200,
     )

--- a/tests/scitex_agent_container/_listen/test__agent_exec_subprocess.py
+++ b/tests/scitex_agent_container/_listen/test__agent_exec_subprocess.py
@@ -69,7 +69,7 @@ def isolated_listen_env(tmp_path: Path):
 
 
 def test_agents_start_shells_plural_agents_form(
-    isolated_listen_env, subprocess_shim
+    isolated_listen_env, env_save_restore, subprocess_shim
 ) -> None:
     """The handler MUST shell ``["sac", "agents", "start", <name>]``.
 
@@ -78,6 +78,10 @@ def test_agents_start_shells_plural_agents_form(
     which manifests as a 502 from every brokered SAC-from-SAC spawn.
     """
     # Arrange — drop a fake ``sac`` on PATH that records its argv.
+    # Disable the post-ack liveness probe (PR7) for this test — the
+    # shim doesn't simulate the apptainer-pid write; the probe's
+    # contract is asserted by the dedicated probe tests below.
+    env_save_restore.set("SAC_LISTEN_POST_ACK_LIVENESS_TIMEOUT_S", "0")
     subprocess_shim.install("sac", stdout="ok", exit=0)
     app = create_app(token=_TOKEN)
     # Act — admin spawn (no caller) so the gate trivially allows and we
@@ -96,10 +100,11 @@ def test_agents_start_shells_plural_agents_form(
 
 
 def test_agents_start_does_not_use_singular_agent_form(
-    isolated_listen_env, subprocess_shim
+    isolated_listen_env, env_save_restore, subprocess_shim
 ) -> None:
     """Explicit negative — the buggy singular form must NOT recur."""
     # Arrange
+    env_save_restore.set("SAC_LISTEN_POST_ACK_LIVENESS_TIMEOUT_S", "0")
     subprocess_shim.install("sac", stdout="ok", exit=0)
     app = create_app(token=_TOKEN)
     # Act
@@ -171,6 +176,9 @@ def test_agents_start_strips_apptainer_container_env_from_child(
     bin_dir.mkdir()
     env_log = _install_env_recording_sac_shim(bin_dir)
     env_save_restore.set("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
+    # Disable the PR7 post-ack liveness probe — these tests assert
+    # env-strip semantics, not apptainer-instance health.
+    env_save_restore.set("SAC_LISTEN_POST_ACK_LIVENESS_TIMEOUT_S", "0")
     env_save_restore.set("APPTAINER_CONTAINER", "/path/to/parent-sac.sif")
     app = create_app(token=_TOKEN)
     # Act
@@ -205,6 +213,9 @@ def test_agents_start_strips_singularity_container_env_from_child(
     bin_dir.mkdir()
     env_log = _install_env_recording_sac_shim(bin_dir)
     env_save_restore.set("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
+    # Disable the PR7 post-ack liveness probe — these tests assert
+    # env-strip semantics, not apptainer-instance health.
+    env_save_restore.set("SAC_LISTEN_POST_ACK_LIVENESS_TIMEOUT_S", "0")
     env_save_restore.set("SINGULARITY_CONTAINER", "/path/to/parent-sac.sif")
     app = create_app(token=_TOKEN)
     # Act
@@ -248,6 +259,9 @@ def test_agents_start_preserves_unrelated_env_vars_to_child(
     script.write_text(body)
     script.chmod(0o755)
     env_save_restore.set("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
+    # Disable the PR7 post-ack liveness probe — these tests assert
+    # env-strip semantics, not apptainer-instance health.
+    env_save_restore.set("SAC_LISTEN_POST_ACK_LIVENESS_TIMEOUT_S", "0")
     env_save_restore.set("SAC_BROKER_SELF_TEST_CANARY", "must-survive-strip")
     env_save_restore.set("APPTAINER_CONTAINER", "/parent.sif")
     app = create_app(token=_TOKEN)
@@ -261,3 +275,170 @@ def test_agents_start_preserves_unrelated_env_vars_to_child(
     recorded = json.loads(env_log.read_text().splitlines()[-1])
     # Assert
     assert recorded["CANARY"] == "must-survive-strip"
+
+
+# ---------------------------------------------------------------------------
+# Layer-3 fail-loud post-spawn-ack liveness probe (PR7, clew dogfood
+# repro 2026-06-06, lead msg 57f1632a). The listen's /agents handler
+# was returning 200 "SUCC: started" on `sac agents start` rc=0 without
+# verifying the apptainer instance actually came up; clew's repro on
+# Spartan jobid 25666081 saw the listen ack the spawn, then the
+# instance died silently (empty stdout.log, dead apptainer_pid, no
+# fresh STARTUP_FAILED). The probe (waits up to N seconds for an
+# alive apptainer_pid) makes the silent death LOUD: STARTUP_FAILED
+# marker + 502 response.
+#
+# Each test installs a custom sac shim that simulates one of the three
+# branches (no pid file written / pid file written but pid dead / pid
+# file written and pid alive) so the probe's contract is exercised
+# end-to-end against a real subprocess + real handler + real marker
+# write. No MagicMock.
+# ---------------------------------------------------------------------------
+
+
+def _install_sac_shim_writing_pid_file(
+    bin_dir: Path, *, runtime_dir: Path, pid_value: int | None
+) -> None:
+    """Install a sac shim that writes ``<runtime_dir>/apptainer_pid``.
+
+    ``pid_value=None`` → don't write the file (simulates the "child
+    never reached apptainer runtime" branch). Otherwise write the int.
+    ``runtime_dir`` is created before the file is written so the shim
+    can run on a fresh isolated_listen_env.
+    """
+    import json as _json
+    import sys as _sys
+
+    script = bin_dir / "sac"
+    if pid_value is None:
+        body = f"#!{_sys.executable}\nimport sys\nsys.exit(0)\n"
+    else:
+        runtime_dir_s = _json.dumps(str(runtime_dir))
+        body = (
+            f"#!{_sys.executable}\n"
+            "import pathlib, sys\n"
+            f"rd = pathlib.Path({runtime_dir_s})\n"
+            "rd.mkdir(parents=True, exist_ok=True)\n"
+            f"(rd / 'apptainer_pid').write_text('{int(pid_value)}\\n')\n"
+            "sys.exit(0)\n"
+        )
+    script.write_text(body)
+    script.chmod(0o755)
+
+
+def test_agents_start_writes_startup_failed_when_no_apptainer_pid(
+    isolated_listen_env, env_save_restore, tmp_path: Path
+) -> None:
+    """Probe must fail loud when the child returned rc=0 without writing pid."""
+    # Arrange — shim returns 0 but never touches the runtime_dir.
+    bin_dir = tmp_path / "sac_bin_no_pid"
+    bin_dir.mkdir()
+    _install_sac_shim_writing_pid_file(
+        bin_dir, runtime_dir=tmp_path / "unused", pid_value=None
+    )
+    env_save_restore.set("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
+    env_save_restore.set("SAC_LISTEN_POST_ACK_LIVENESS_TIMEOUT_S", "0.5")
+    app = create_app(token=_TOKEN)
+    # Act
+    with TestClient(app) as client:
+        client.post(
+            "/agents",
+            json={"name": "broker-child"},
+            headers={"authorization": f"Bearer {_TOKEN}"},
+        )
+    from scitex_agent_container._lifecycle._startup_failed import read_marker
+    from scitex_agent_container._runners._session_state import state_dir_for
+
+    marker = read_marker(state_dir_for("broker-child"))
+    # Assert
+    assert marker is not None and marker["kind"] == "post_ack_no_apptainer_pid"
+
+
+def test_agents_start_writes_startup_failed_when_apptainer_pid_dead(
+    isolated_listen_env, env_save_restore, tmp_path: Path
+) -> None:
+    """Probe must fail loud when the pid file points at a reaped pid."""
+    # Arrange — shim writes apptainer_pid with a pid that is definitely
+    # not alive (a very high value the kernel won't have allocated to
+    # any running process in this test session).
+    from scitex_agent_container._runners._session_state import state_dir_for
+
+    runtime_dir = state_dir_for("broker-child")
+    bin_dir = tmp_path / "sac_bin_dead_pid"
+    bin_dir.mkdir()
+    _install_sac_shim_writing_pid_file(
+        bin_dir, runtime_dir=runtime_dir, pid_value=2147483646
+    )
+    env_save_restore.set("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
+    env_save_restore.set("SAC_LISTEN_POST_ACK_LIVENESS_TIMEOUT_S", "0.5")
+    app = create_app(token=_TOKEN)
+    # Act
+    with TestClient(app) as client:
+        client.post(
+            "/agents",
+            json={"name": "broker-child"},
+            headers={"authorization": f"Bearer {_TOKEN}"},
+        )
+    from scitex_agent_container._lifecycle._startup_failed import read_marker
+
+    marker = read_marker(runtime_dir)
+    # Assert
+    assert marker is not None and marker["kind"] == "post_ack_apptainer_pid_dead"
+
+
+def test_agents_start_returns_200_when_apptainer_pid_is_alive(
+    isolated_listen_env, env_save_restore, tmp_path: Path
+) -> None:
+    """Probe happy path — alive apptainer_pid → 200, no STARTUP_FAILED."""
+    # Arrange — shim writes apptainer_pid pointing at the pytest
+    # process pid (alive for the entire test session).
+    from scitex_agent_container._runners._session_state import state_dir_for
+
+    runtime_dir = state_dir_for("broker-child")
+    bin_dir = tmp_path / "sac_bin_live_pid"
+    bin_dir.mkdir()
+    _install_sac_shim_writing_pid_file(
+        bin_dir, runtime_dir=runtime_dir, pid_value=os.getpid()
+    )
+    env_save_restore.set("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
+    env_save_restore.set("SAC_LISTEN_POST_ACK_LIVENESS_TIMEOUT_S", "2.0")
+    app = create_app(token=_TOKEN)
+    # Act
+    with TestClient(app) as client:
+        resp = client.post(
+            "/agents",
+            json={"name": "broker-child"},
+            headers={"authorization": f"Bearer {_TOKEN}"},
+        )
+    # Assert
+    assert resp.status_code == 200
+
+
+def test_agents_start_post_ack_failure_returns_502(
+    isolated_listen_env, env_save_restore, tmp_path: Path
+) -> None:
+    """The loud signal: a post-ack failure must downgrade the response.
+
+    The pre-PR7 behaviour returned 200 with "SUCC: started" even when
+    the apptainer instance was stillborn — clew's Spartan repro hit
+    this. Pin the new contract: failure → 502 so the operator-side
+    recv path sees a real diagnostic.
+    """
+    # Arrange
+    bin_dir = tmp_path / "sac_bin_502"
+    bin_dir.mkdir()
+    _install_sac_shim_writing_pid_file(
+        bin_dir, runtime_dir=tmp_path / "unused", pid_value=None
+    )
+    env_save_restore.set("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
+    env_save_restore.set("SAC_LISTEN_POST_ACK_LIVENESS_TIMEOUT_S", "0.5")
+    app = create_app(token=_TOKEN)
+    # Act
+    with TestClient(app) as client:
+        resp = client.post(
+            "/agents",
+            json={"name": "broker-child"},
+            headers={"authorization": f"Bearer {_TOKEN}"},
+        )
+    # Assert
+    assert resp.status_code == 502


### PR DESCRIPTION
## Summary

PR#311 + PR#312 layer-3 follow-up. Clew's Spartan dogfood repro (msg `b9ef346c`; lead msg `57f1632a`) confirmed both prior fixes landed cleanly but exposed a deeper bug: the listen's `/agents` handler treats `sac agents start <child>` `rc=0` as "instance is running and healthy", and clew saw the spawn ack come back `SUCC` while the actual apptainer instance died silently post-ack (empty `stdout.log`, dead `apptainer_pid`, no fresh `STARTUP_FAILED`, `apptainer instance list` empty). The 200 response lied.

This PR makes the silent death **loud**.

After `proc.returncode == 0`, poll the runtime_dir for liveness — wait up to 5s (env-overridable) for `<runtime_dir>/apptainer_pid` to appear AND for that pid to be alive (`os.kill(pid, 0)`). Three loud failure modes write a fresh `STARTUP_FAILED` marker + downgrade the response to **502**:

- `post_ack_no_apptainer_pid` — file never appeared. Child returned 0 without invoking the apptainer runtime path (broken wrapper, missing config, runtime mis-resolved).
- `post_ack_apptainer_pid_dead` — file appeared but the pid is reaped. SIF instance came up and exited immediately.
- Happy path: pid alive at deadline → 200/SUCC unchanged.

`PermissionError` on `os.kill(pid, 0)` is treated as alive (the kernel said "exists, can't signal it" — different uid / namespace, not "no such pid"). Only `ProcessLookupError` counts as dead.

## Changes

- **`src/.../_listen/_agent_exec.py`**
  - `_pid_alive` — stdlib-only kill(0) helper with correct ProcessLookupError vs PermissionError semantics.
  - `_probe_post_ack_liveness` — poll + verify. `timeout_s <= 0` skips the probe (test escape hatch).
  - `agents_start` — invoke the probe after `rc=0`; on failure, write `STARTUP_FAILED` with `kind_override` + 502.
  - `SAC_LISTEN_POST_ACK_LIVENESS_TIMEOUT_S` env var override (test escape hatch + operator-tunable knob).

- **`tests/.../_listen/test__agent_exec_subprocess.py`** — +5 new no-mock tests using a custom `_install_sac_shim_writing_pid_file` helper (no-pid / dead-pid / live-pid `os.getpid()` / 502 status downgrade pin). 4 existing tests (argv-shape + env-strip from PR#312) gained `SAC_LISTEN_POST_ACK_LIVENESS_TIMEOUT_S=0` so they don't time out on the new probe; the probe's contract is pinned by the dedicated probe tests, not those.

## Test plan

- [x] Focused: 9/9 pass locally.
- [x] Full suite: CI is the gate; expect the same pre-existing pattern as PRs #307-#312.
- [x] No `MagicMock`.

## NOT in this PR (deferred per lead's "prioritize the diagnostic part first")

- Why the apptainer-exec layer is dying silently in clew's real repro. **The probe surfaces it**; the next clew smoke pass will have a fresh `STARTUP_FAILED` with the actual cause, which is when the real-cause investigation begins.
- Stale `STARTUP_FAILED` archiving (clew's pre-#312 marker wasn't cleared on the next attempt). Tiny follow-up in its own PR if it bites again.

## Coordination

Clew (`proj-paper-scitex-clew`) is waiting on this merge to re-repro on Spartan jobid 25666081/gpgpu171. The next pass should produce a real STARTUP_FAILED with kind=`post_ack_*` instead of the silent SUCC, unblocking real-cause diagnosis.
