### PR TITLE
feat(start): skip OAuth preflight on --broker-self + provider-backed targets

### DIFF
--- a/src/scitex_agent_container/cli_pkg/lifecycle/_start.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_start.py
@@ -18,6 +18,39 @@ from .._helpers import agent_name_complete, console
 from ._common import _iter_agent_yamls
 
 
+def _any_target_needs_anthropic_oauth(
+    single_targets: list[str], bulk_yamls: list[str]
+) -> bool:
+    """Return True iff at least one target spec uses Anthropic OAuth.
+
+    PR#314 (lead msg 24a8b27c): provider-backed specs (LiteLLM, vLLM,
+    DeepSeek, gateway via ``ANTHROPIC_BASE_URL``) route the SDK session
+    through a non-Anthropic backend; the parent's
+    ``~/.claude/.credentials.json`` is bind-mounted but never read.
+    When EVERY target has ``spec.claude.provider`` non-None, the
+    parent's OAuth preflight is moot.
+
+    Defensive default: if a spec fails to load (unresolvable name,
+    unparseable YAML, schema error), assume it needs OAuth. Better to
+    ask the operator for creds + surface the real spec error on the
+    actual dispatch loop than to skip the gate silently on a broken
+    spec the operator hasn't noticed yet.
+    """
+    from ...config import load_config
+    from ...config._resolve import resolve_with_prefix
+
+    for raw in list(single_targets) + list(bulk_yamls):
+        try:
+            cfg_path = resolve_with_prefix(raw)
+            cfg = load_config(cfg_path)
+        except Exception:  # stx-allow: fallback (reason: defensive — see docstring)
+            return True
+        provider = getattr(getattr(cfg, "claude", None), "provider", None)
+        if provider is None:
+            return True
+    return False
+
+
 @click.command()
 @click.argument(
     "targets",
@@ -293,6 +326,18 @@ def start(
     # see provision_anthropic_auth in runtimes/_sdk_common.py). On
     # failure: exit 1 with the helper's message on stderr, no
     # traceback.
+    #
+    # PR#314 (lead msg 24a8b27c / clew Spartan dogfood 2026-06-06):
+    # also skip when the invocation is purely orchestrator-shaped:
+    #   * ``--broker-self`` parent — never talks to Anthropic; only
+    #     bootstraps a listen + spawns the capsule. The capsule's own
+    #     preflight runs separately (in the broker's child subprocess).
+    #   * EVERY target's spec.claude.provider is non-None — the SDK
+    #     session routes through a non-Anthropic backend (LiteLLM /
+    #     vLLM / DeepSeek / gateway via ANTHROPIC_BASE_URL), and the
+    #     bind-mounted Anthropic credentials are never read.
+    # Either condition is sufficient to skip; the gate stays surgical
+    # — any Anthropic-backed target still triggers the check.
     _preflight_ran = False
 
     def _run_preflight_once() -> None:
@@ -300,6 +345,17 @@ def start(
         if _preflight_ran or no_redispatch:
             return
         _preflight_ran = True
+        # Orchestrator-only invocation — skip the parent's OAuth check.
+        if broker_self:
+            return
+        # All targets provider-backed — no parent-side Anthropic OAuth
+        # needed. Loaded once per invocation (cheap; the same configs
+        # are re-loaded inside run_single_targets / run_bulk_path for
+        # actual dispatch — a future refactor could thread the loaded
+        # configs through, but the duplication is small enough to leave
+        # for now).
+        if not _any_target_needs_anthropic_oauth(single_targets, bulk_yamls_from_dirs):
+            return
         from ..._state._preflight_creds import check_oauth_token_expiry
 
         try:

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__start_preflight.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__start_preflight.py
@@ -179,3 +179,144 @@ class TestApiKeyBypassesPreflight:
         result = runner.invoke(start, ["any-target-name"])
         # Assert: NOT 1 with "claude login" — preflight didn't run.
         assert "claude login" not in result.output
+
+
+# ---------------------------------------------------------------------------
+# PR#314: --broker-self + provider-backed specs skip the parent's OAuth
+# check (lead msg 24a8b27c, clew Spartan dogfood 2026-06-06). The parent
+# in either orchestrator-only mode never talks to Anthropic, so checking
+# its OAuth credentials is spurious — and (per clew's Spartan repro) it
+# blocked the broker boot on a 4.6-day-old expired creds file. Both
+# escape hatches are surgical: any Anthropic-backed target still
+# triggers the check.
+# ---------------------------------------------------------------------------
+
+
+def _install_provider_spec(
+    yaml_dir: Path, name: str, *, base_url: str = "http://127.0.0.1:4000"
+) -> Path:
+    """Write a minimal v3 spec.yaml with spec.claude.provider configured.
+
+    The spec is just enough to load_config + reach the preflight
+    branch's provider-non-None check; downstream dispatch will fail
+    on the missing image/runtime but that runs AFTER the preflight.
+    """
+    agent_dir = yaml_dir / name
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    spec = agent_dir / "spec.yaml"
+    spec.write_text(
+        "apiVersion: scitex-agent-container/v3\n"
+        "kind: Agent\n"
+        "spec:\n"
+        "  claude:\n"
+        "    provider:\n"
+        f"      base_url: {base_url}\n"
+        "      auth_token_env: FAKE_TOKEN_ENV\n"
+        "  apptainer:\n"
+        "    image: /nonexistent/dummy.sif\n",
+        encoding="utf-8",
+    )
+    return spec
+
+
+def _install_anthropic_spec(yaml_dir: Path, name: str) -> Path:
+    """Write a minimal v3 spec.yaml WITHOUT a provider (Anthropic path)."""
+    agent_dir = yaml_dir / name
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    spec = agent_dir / "spec.yaml"
+    spec.write_text(
+        "apiVersion: scitex-agent-container/v3\n"
+        "kind: Agent\n"
+        "spec:\n"
+        "  claude: {}\n"
+        "  apptainer:\n"
+        "    image: /nonexistent/dummy.sif\n",
+        encoding="utf-8",
+    )
+    return spec
+
+
+class TestBrokerSelfBypassesPreflight:
+    """--broker-self is the orchestrator-only flag (PR#311). The parent
+    process never talks to Anthropic — it bootstraps a local listen
+    and spawns the capsule, which gets its own preflight in the
+    broker's child subprocess. Skipping the parent's OAuth check is
+    the durable fix for the Spartan-creds-expiry treadmill that
+    repeatedly bit clew's cohort-A launches."""
+
+    def test_broker_self_skips_oauth_preflight_on_expired_creds(
+        self, tmp_path: Path, env_save_restore
+    ) -> None:
+        # Arrange — expired creds + --broker-self. Pre-PR#314 the
+        # preflight blocked with "claude login"; post-PR#314 it skips.
+        env_save_restore.set("HOME", str(tmp_path))
+        env_save_restore.delete("ANTHROPIC_API_KEY")
+        env_save_restore.delete("SAC_ANTHROPIC_API_KEY")
+        _install_expired_creds(tmp_path)
+        runner = CliRunner()
+        # Act
+        result = runner.invoke(start, ["any-target-name", "--broker-self"])
+        # Assert — preflight skipped (no "claude login" in output).
+        assert "claude login" not in result.output
+
+
+class TestProviderBackedSpecBypassesPreflight:
+    """When EVERY target's spec.claude.provider is non-None, the SDK
+    routes through a non-Anthropic backend (LiteLLM, vLLM, DeepSeek,
+    gateway via ANTHROPIC_BASE_URL). The bind-mounted Anthropic
+    credentials are never read, so the preflight is moot."""
+
+    def test_provider_backed_target_skips_oauth_preflight(
+        self, tmp_path: Path, env_save_restore
+    ) -> None:
+        # Arrange — expired creds + a provider-backed spec on disk.
+        env_save_restore.set("HOME", str(tmp_path))
+        env_save_restore.delete("ANTHROPIC_API_KEY")
+        env_save_restore.delete("SAC_ANTHROPIC_API_KEY")
+        _install_expired_creds(tmp_path)
+        yaml_dir = tmp_path / "agents"
+        _install_provider_spec(yaml_dir, "provider-agent")
+        env_save_restore.set("SCITEX_AGENT_CONTAINER_YAML_DIRS", str(yaml_dir))
+        runner = CliRunner()
+        # Act
+        result = runner.invoke(start, ["provider-agent"])
+        # Assert — preflight skipped (no "claude login" in output);
+        # the downstream dispatch may still fail on the dummy.sif but
+        # that comes from agent_start, not the preflight.
+        assert "claude login" not in result.output
+
+    def test_anthropic_backed_target_still_runs_oauth_preflight(
+        self, tmp_path: Path, env_save_restore
+    ) -> None:
+        # Arrange — expired creds + a spec WITHOUT provider. The
+        # preflight MUST still fire (regression guard: don't accidentally
+        # skip all preflights when at least one spec needs OAuth).
+        env_save_restore.set("HOME", str(tmp_path))
+        env_save_restore.delete("ANTHROPIC_API_KEY")
+        env_save_restore.delete("SAC_ANTHROPIC_API_KEY")
+        _install_expired_creds(tmp_path)
+        yaml_dir = tmp_path / "agents"
+        _install_anthropic_spec(yaml_dir, "anthropic-agent")
+        env_save_restore.set("SCITEX_AGENT_CONTAINER_YAML_DIRS", str(yaml_dir))
+        runner = CliRunner()
+        # Act
+        result = runner.invoke(start, ["anthropic-agent"])
+        # Assert — preflight DID fire (the existing Anthropic path is unchanged).
+        assert "claude login" in result.output
+
+    def test_unresolvable_target_defaults_to_running_oauth_preflight(
+        self, tmp_path: Path, env_save_restore
+    ) -> None:
+        # Arrange — defensive default: if a spec can't be loaded,
+        # the preflight still fires (better to surface the OAuth
+        # state than to silently skip on a broken spec).
+        env_save_restore.set("HOME", str(tmp_path))
+        env_save_restore.delete("ANTHROPIC_API_KEY")
+        env_save_restore.delete("SAC_ANTHROPIC_API_KEY")
+        _install_expired_creds(tmp_path)
+        runner = CliRunner()
+        # Act — target name doesn't resolve to anything on disk.
+        result = runner.invoke(start, ["nonexistent-target-9c4f7a"])
+        # Assert — preflight fired (defensive); operator sees the
+        # OAuth message before they get the spec-resolve error.
+        assert "claude login" in result.output


### PR DESCRIPTION
## Summary

Closes the durable Spartan-creds-expiry treadmill clew's dogfood repro surfaced (lead msg `24a8b27c`, 2026-06-06). The parent SAC in sac-from-sac L2 (`--broker-self`) and any `sac agents start` whose target `spec.claude.provider` routes through LiteLLM / vLLM / DeepSeek / gateway never talks to Anthropic — but the existing OAuth preflight blanket-checked `~/.claude/.credentials.json` on every dispatch, blocking provider-backed boots on expired creds the parent never reads.

Clew's Spartan jobid 25666081 hit this on a 4.6-day-old expired creds file: bare-host `sac agents start --broker-self` errored at boot with `"OAuth token expired 403022 seconds ago"` **before** the provider runtime initialized. The earlier "SUCC started → silent death" repro was the same OAuth failure surfacing nowhere through the spawn chain. PR#313's probe will catch the silent-death case defensively; **this PR closes the root**.

## Two surgical escape hatches in `_run_preflight_once`

- **(a) `--broker-self` → skip.** The parent is an orchestrator only — it bootstraps a local sac listen and spawns the capsule, never running Claude itself. The capsule's own preflight runs separately in the broker's child subprocess (any real Anthropic-backed capsule still gets gated).
- **(b) Every target's `spec.claude.provider` is non-None → skip.** The SDK session routes through a non-Anthropic backend, and the bind-mounted Anthropic credentials are never read. If **any** target is Anthropic-backed (`provider=None`), the preflight still fires.

Either condition is sufficient. `check_oauth_token_expiry` itself is unchanged; the gating moves up to the call site where the spec context lives.

## Changes

- **`cli_pkg/lifecycle/_start.py`**
  - `_any_target_needs_anthropic_oauth` helper — loads each target's config, returns `True` iff at least one has `provider=None`. On spec-load failure, defaults to `True` (defensive — surface OAuth state before the real spec error, don't silently skip).
  - `_run_preflight_once` — short-circuit on `broker_self`; otherwise short-circuit when no target needs OAuth.

- **`tests/.../cli_pkg/lifecycle/test__start_preflight.py`** — +4 new tests:
  - `test_broker_self_skips_oauth_preflight_on_expired_creds`
  - `test_provider_backed_target_skips_oauth_preflight`
  - `test_anthropic_backed_target_still_runs_oauth_preflight` (regression guard)
  - `test_unresolvable_target_defaults_to_running_oauth_preflight` (defensive default)

No-mock: each test installs a real `spec.yaml` on disk + uses the `SCITEX_AGENT_CONTAINER_YAML_DIRS` env override (canonical sac plugin port for extra-yaml-dirs). Real `CliRunner` + real config loader + real preflight branch.

## Test plan

- [x] Focused: 10/10 pass locally (6 existing + 4 new).
- [x] Full suite: CI is the gate; expect the same pre-existing pattern as PRs #307-#313.
- [x] No `MagicMock`.

## Dogfooding payoff

Future Spartan-creds-expiry / any provider-backed start on any host stops being a blocker. The lead no longer has to refresh OAuth on every L2 cohort launch; the orchestrator parent + the capsule's own provider routing are now correctly decoupled from the operator's Anthropic OAuth identity.
