### PR TITLE
docs(skill): bind-editable-sac pattern for no-sudo/no-subuid HPCs

### DIFF
--- a/src/scitex_agent_container/_skills/scitex-agent-container/11_remote-deploy.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/11_remote-deploy.md
@@ -148,8 +148,36 @@ in-process callers.
 | `spec.remote.user`, `spec.remote.timeout`, `spec.remote.login_shell` | declared in `config.yaml::peers.<peer>` (not per-agent) |
 | `spec.venv` (remote-only path) | `spec.apptainer.image` + in-container venv at `/opt/venv-agent` |
 
+## HPC deployment — no-sudo / no-subuid sites (Spartan etc.)
+
+On HPC sites where `sudo` is forbidden AND the user has no `/etc/subuid`
+mapping, `apptainer build` cannot run at all — neither sudo nor fakeroot
+namespace ops are available. You **cannot** `sac image build` on such
+hosts.
+
+The canonical workaround: bind-mount the host editable
+`scitex_agent_container` package over the SIF's site-packages copy, so
+the SIF's `/opt/venv-sac/bin/sac` runs HOST code without rebuild. Add to
+`spec.apptainer.binds`:
+
+```yaml
+spec:
+  apptainer:
+    binds:
+      - source: /abs/path/to/scitex-agent-container/src/scitex_agent_container
+        target: /opt/venv-sac/lib/python3.12/site-packages/scitex_agent_container
+        read_only: true
+```
+
+`git pull` on the host install is then the entire SIF-update loop.
+Caveats + the operator one-shot `apptainer exec --bind ...` form are
+in [24_image-build.md](24_image-build.md) under "When `sac image build`
+is impossible".
+
 ## See also
 
 - `docs/spec-reference.md` "Top-level shape" — host/hosts canonical reference
 - `07_a2a-protocol-extension-fields.md` — `x-scitex-agent-container.scheduling`
   card field derived from `spec.host` / `spec.hosts`
+- [24_image-build.md](24_image-build.md) — image build/rebuild + the
+  bind-editable workaround for no-sudo/no-subuid HPCs

--- a/src/scitex_agent_container/_skills/scitex-agent-container/24_image-build.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/24_image-build.md
@@ -76,3 +76,64 @@ sac image build scitex -y
 
 This is the concrete mechanism behind a "stable vs develop" SAC split: the agent
 image = the pinned stable runner; bump it deliberately.
+
+## When `sac image build` is impossible — bind the host editable over the SIF
+
+On HPC sites (e.g. Spartan) where `sudo` is forbidden AND the user has **no
+`/etc/subuid` mapping** (no unprivileged user-namespace), `apptainer build`
+cannot run at all — neither the sudo path nor the auto-fakeroot path from
+`sac image build` (PR #307) succeeds. Verify with:
+
+```bash
+grep "$USER" /etc/subuid /etc/subgid    # empty → fakeroot is unavailable
+```
+
+In that case you **cannot rebuild the SIF**. The canonical workaround is to
+**bind-mount the host editable `scitex_agent_container` package over the SIF's
+site-packages copy**. The SIF's `/opt/venv-sac/bin/sac` is a click entry-point
+wrapper that imports `scitex_agent_container`; if that package path is
+bind-overridden by the host editable, the SIF's `sac` transparently runs the
+host code without any rebuild — `git pull` + re-exec is the whole update loop.
+
+### Spec-level bind (recommended for fleet)
+
+Add to the agent's `spec.apptainer.binds` so every launch picks it up:
+
+```yaml
+spec:
+  apptainer:
+    binds:
+      - source: /abs/path/to/scitex-agent-container/src/scitex_agent_container
+        target: /opt/venv-sac/lib/python3.12/site-packages/scitex_agent_container
+        read_only: true
+```
+
+### Direct `apptainer exec` (operator one-shot)
+
+For a quick test before baking into spec:
+
+```bash
+apptainer exec \
+  --bind /abs/.../src/scitex_agent_container:/opt/venv-sac/lib/python3.12/site-packages/scitex_agent_container:ro \
+  sac-scitex.sif \
+  sac --version    # → reports the HOST editable's version, not the SIF-baked one
+```
+
+### Caveats
+
+* The host editable's **Python deps must be a subset** of what the SIF's venv
+  already has installed. If a sac PR adds a new dep (rare — most PRs are
+  code-only), `import scitex_agent_container` inside the SIF will hit
+  `ModuleNotFoundError` for the new dep. That's the signal a real rebuild
+  is needed.
+* The host repo's `src/scitex_agent_container/` path **must exist on a
+  filesystem the SIF can see** (typically a shared `/data/...` mount on HPC).
+* Use `read_only: true` (or `:ro` on the CLI) so the in-SIF process can't
+  mutate host source files.
+* This is a workaround for the no-sudo/no-subuid case; on hosts where
+  rebuild IS possible, prefer `sac image build` so the SIF is a real
+  point-in-time snapshot (auditability, reproducibility).
+
+This pattern is also documented in [11_remote-deploy.md](11_remote-deploy.md)
+under the HPC-deployment section — the deploy-side reader gets the same
+workaround without having to spelunk image-build docs first.


### PR DESCRIPTION
## Summary

Doc-only note on the bind-editable-sac pattern for no-sudo / no-subuid HPCs (Spartan-class). Lead msg `9517b197` (2026-06-06): `grep ywatanabe /etc/subuid` came back empty on Spartan AND apptainer requires `module load Apptainer` — neither the sudo path nor the auto-fakeroot path (PR#307) can run, so `apptainer build` (and `sac image build`) are literally impossible. clew's cohort-A dogfood validated the bind-mount workaround end-to-end.

## Changes

- **`_skills/.../24_image-build.md`** (canonical home) — new "When `sac image build` is impossible — bind the host editable over the SIF" section: spec-level form (`spec.apptainer.binds`), direct-apptainer-exec form (operator one-shot), caveats (deps-must-be-subset / shared-fs / read-only / prefer-rebuild-when-possible), cross-link to remote-deploy.
- **`_skills/.../11_remote-deploy.md`** — new "HPC deployment — no-sudo / no-subuid sites" section with the minimal bind snippet + back-link to `24_image-build.md` for caveats. Plus a "See also" entry pointing the deploy-side reader to the image-build doc.

## Why this lands as a real doc note

- HPC is a first-class sac target (cohort-A on Spartan, ongoing dogfood).
- Future operators hitting "can't rebuild SIF on HPC" will spend hours reverse-engineering this without the doc.
- The pattern has subtle caveats (deps subset, shared filesystem visibility, read-only enforcement) that need to be spelled out so it's not misapplied.

Scope-locked to the bind-mount workaround; no other HPC-onboarding content slipped in.

## Test plan

- [x] Doc-only — no code changes, no new tests needed.
- [x] CI on the same gate as PRs #307-#314 (expect the pre-existing audit-flake-only pattern).
