### PR TITLE
fix(status_cmds): degrade in-SIF status to local read when no listen URL

### DIFF
--- a/src/scitex_agent_container/cli_pkg/status_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/status_cmds.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json as json_mod
+import os
 import sys
 
 import click
@@ -209,9 +210,23 @@ def status(
         # exit code. The lineage-scoped ACL on the host side enforces
         # that the caller can only inspect itself or its lineage
         # descendants.
+        #
+        # PR#316 (lead msg 4cb474fc, clew L3 diag 2026-06-06): the
+        # host-listen-call path needs SAC_LISTEN_BASE_URL. In sac-from-sac
+        # L2 broker-self / bare-host-with-stale-SINGULARITY_CONTAINER
+        # contexts that env var IS absent — the operator's shell isn't
+        # a real apptainer container, and there's no host listen to
+        # broker the read to. Pre-PR#316 this surfaced as
+        # ``HostListenTransportError: in-SIF host-listen call requires
+        # SAC_LISTEN_BASE_URL`` (a stillborn-read masquerading as a
+        # transport error). Fix: degrade gracefully — fall through to
+        # the local registry read when the env var is missing. The
+        # local read picks up the agent's instances/state.db row
+        # directly; on the broker-self happy path the agent's runtime
+        # dir is bind-visible to the same state.db the local read uses.
         from .._lifecycle._in_sif_broker import is_in_sif
 
-        if is_in_sif():
+        if is_in_sif() and (os.environ.get("SAC_LISTEN_BASE_URL") or "").strip():
             _status_via_host_listen(name)
             return  # noreturn — _status_via_host_listen sys.exits
 

--- a/tests/scitex_agent_container/cli_pkg/test_status_cmds_in_sif_auto_fallback.py
+++ b/tests/scitex_agent_container/cli_pkg/test_status_cmds_in_sif_auto_fallback.py
@@ -232,3 +232,64 @@ def test_fleet_view_does_not_proxy(fake_host_listen):
     runner.invoke(status, [])
     # Assert — the fake server saw NO requests.
     assert fake_host_listen.captured == []
+
+
+# ---------------------------------------------------------------------------
+# PR#316: graceful degrade when SAC_LISTEN_BASE_URL is missing in-SIF
+#
+# Lead msg 4cb474fc / clew L3 diag 2026-06-06: sac-from-sac L2 contexts
+# (broker-self orchestrator, bare-host with stale SINGULARITY_CONTAINER
+# env from a launcher hint) hit is_in_sif() == True but have no
+# host-listen to proxy to — SAC_LISTEN_BASE_URL is empty. Pre-PR#316
+# this surfaced as a stillborn-read masquerading as a transport error
+# (HostListenTransportError "in-SIF host-listen call requires
+# SAC_LISTEN_BASE_URL ... Got empty/unset."). Fix: fall through to the
+# local Registry read instead — the broker-self happy path has the
+# agent's state.db row reachable locally anyway. Tests pin the
+# "no-listen-url → local read, not transport error" contract.
+# ---------------------------------------------------------------------------
+
+
+def test_status_in_sif_without_listen_url_does_not_proxy_to_http(
+    env_save_restore, fake_host_listen
+):
+    # Arrange — in-SIF (APPTAINER_CONTAINER set by the fixture) but
+    # SAC_LISTEN_BASE_URL is empty (operator-shell case, broker-self).
+    # The fake_host_listen fixture installed a URL; explicitly unset
+    # to simulate the broken-listen case.
+    env_save_restore.set("SAC_LISTEN_BASE_URL", "")
+    runner = CliRunner()
+    # Act
+    runner.invoke(status, ["any-target-name"])
+    # Assert — the fake host listen received NO request: the in-SIF
+    # path degraded gracefully to the local Registry read.
+    assert fake_host_listen.captured == []
+
+
+def test_status_in_sif_with_unset_listen_url_does_not_proxy_to_http(
+    env_save_restore, fake_host_listen
+):
+    # Arrange — same scenario but env var is fully unset rather than
+    # empty-string. Both shapes must degrade identically.
+    env_save_restore.delete("SAC_LISTEN_BASE_URL")
+    runner = CliRunner()
+    # Act
+    runner.invoke(status, ["any-target-name"])
+    # Assert
+    assert fake_host_listen.captured == []
+
+
+def test_status_in_sif_without_listen_url_exit_is_not_transport_error(
+    env_save_restore, fake_host_listen
+):
+    # Arrange — pin that the degraded path does NOT emit the
+    # PR-3 outcome JSON with kind=transport (which the pre-PR#316
+    # behaviour did). Whatever the local read returns is fine; the
+    # contract is "not a stillborn transport error from the
+    # host-listen call".
+    env_save_restore.set("SAC_LISTEN_BASE_URL", "")
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(status, ["any-target-name"])
+    # Assert — output (if any) is NOT the in-SIF transport outcome.
+    assert '"in-SIF host-listen call requires SAC_LISTEN_BASE_URL"' not in result.output


### PR DESCRIPTION
## Summary

Lead msg `4cb474fc` + clew L3 diag 2026-06-06: the L2 spawn chain works end-to-end (capsule runs, heartbeat written, no `STARTUP_FAILED` fires from PR#313's probe), but `sac agents status` from the parent shell errors with `HostListenTransportError: in-SIF host-listen call requires SAC_LISTEN_BASE_URL ... Got empty/unset`. Result: the capsule is **invisible** to operator-side observability tooling even though it's running fine.

## Root cause

`status_cmds.py` routed every `is_in_sif() == True` invocation through `host_listen_call` (the PR-3 in-SIF auto-fallback), which hard-requires `SAC_LISTEN_BASE_URL`. In sac-from-sac L2 contexts (`--broker-self` parent, bare-host with a stale `SINGULARITY_CONTAINER` hint from a launcher) the env var is absent and there's no host listen to broker to — the read should not have been routed through a transport that doesn't exist.

## Fix

Tighten the in-SIF guard to also check `SAC_LISTEN_BASE_URL`. When in-SIF but the env var is empty/unset, fall through to the local Registry read instead of erroring. The broker-self happy path has the agent's `state.db` row reachable locally anyway (the runtime dir is bind-visible to the local read).

## Changes

- **`cli_pkg/status_cmds.py`**
  - `if is_in_sif():` → `if is_in_sif() and (os.environ.get("SAC_LISTEN_BASE_URL") or "").strip():`
  - `import os` added at top.
  - Inline comment explains the two L2 contexts that trip the pre-PR#316 stillborn-read.

- **`tests/.../cli_pkg/test_status_cmds_in_sif_auto_fallback.py`** — +3 new tests:
  - `test_status_in_sif_without_listen_url_does_not_proxy_to_http` (empty-string env: degraded path skips HTTP)
  - `test_status_in_sif_with_unset_listen_url_does_not_proxy_to_http` (fully-unset env: same degrade)
  - `test_status_in_sif_without_listen_url_exit_is_not_transport_error` (negative guard: output does NOT carry the pre-PR#316 transport-error message body)

## Scope

Scope-locked to `status`. `delete` / `send` / `tail` also use the host-listen-call path but they are mutations / streaming that genuinely need the host listen — degrading them silently would be wrong. PR-3 fail-loud semantics stay intact for those verbs.

## Test plan

- [x] Focused: 13/13 pass locally (10 existing + 3 new).
- [x] No `MagicMock` — uses the existing `fake_host_listen` fixture (a real in-process HTTP server).
- [x] CI on the same gate as PRs #307-#315.
