### PR TITLE
feat(listen): propagate --foreground/--one-shot through SAC-from-SAC broker

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_in_sif_broker.py
+++ b/src/scitex_agent_container/_lifecycle/_in_sif_broker.py
@@ -124,6 +124,8 @@ def broker_start_to_host(
     bearer: str | None = None,
     timeout_s: float = 30.0,
     opener: Callable | None = None,
+    foreground: bool = False,
+    one_shot: bool = False,
 ) -> dict:
     """POST a spawn request to the host-side ``sac listen``; FAIL LOUD on error.
 
@@ -200,6 +202,8 @@ def broker_start_to_host(
             bearer=bearer,
             timeout_s=timeout_s,
             opener=opener,
+            foreground=foreground,
+            one_shot=one_shot,
         )
     except SpawnRequestError as exc:
         # Re-throw under the broker's own error type so the integration
@@ -221,6 +225,8 @@ def maybe_broker_in_sif_spawn(
     *,
     dry_run: bool,
     opener: Callable | None = None,
+    foreground: bool = False,
+    one_shot: bool = False,
 ) -> bool:
     """Single-call broker chokepoint for the in-SIF redirect in agent_start.
 
@@ -248,11 +254,30 @@ def maybe_broker_in_sif_spawn(
       * Host accepted the request but ``sac agent start`` itself failed
         → :class:`RuntimeError` naming the agent and returncode, with
         the full host response in the message for debug-without-ssh.
+
+    ``foreground`` / ``one_shot``: when the parent ``sac agents start``
+    invocation carried these flags, propagate them through the body so
+    the host listen's ``/agents`` handler appends ``--foreground`` /
+    ``--one-shot`` to its inner ``sac agents start`` argv. This switches
+    the host-side apptainer runtime to the foreground branch
+    (``subprocess.run`` blocks until the capsule exits) so the
+    capsule's actual exit code + stderr flow up the chain and land in
+    ``STARTUP_FAILED.stderr_tail`` on crash — the cohort one-shot
+    diagnostic clew needs (lead msg d96a468c 2026-06-06). Without this
+    propagation, the inner runtime takes the background branch (Popen
+    + return rc=0 immediately) and the post-ack liveness probe sees a
+    still-alive Popen pid, returning SUCC while the capsule dies
+    silently later.
     """
     if dry_run or not is_in_sif():
         return False
 
-    result = broker_start_to_host(name, opener=opener)
+    result = broker_start_to_host(
+        name,
+        opener=opener,
+        foreground=foreground,
+        one_shot=one_shot,
+    )
     rc = result.get("returncode") if isinstance(result, dict) else None
     if rc != 0:
         raise RuntimeError(

--- a/src/scitex_agent_container/_lifecycle/_spawn_client.py
+++ b/src/scitex_agent_container/_lifecycle/_spawn_client.py
@@ -175,6 +175,8 @@ def request_spawn(
     bearer: str | None = None,
     timeout_s: float = _DEFAULT_TIMEOUT_S,
     opener: Callable | None = None,
+    foreground: bool = False,
+    one_shot: bool = False,
 ) -> dict:
     """POST a spawn request to the host listen server; FAIL LOUD on error.
 
@@ -208,6 +210,23 @@ def request_spawn(
         Optional ``urllib.request.urlopen``-shaped callable. Default
         ``urlrequest.urlopen``; tests inject a fake opener that returns
         a ``urllib.response``-shaped object (no monkeypatching).
+    foreground
+        Forwarded as ``foreground: true`` in the POST body when set.
+        The host listen's ``/agents`` handler appends ``--foreground``
+        to its inner ``sac agents start`` argv, so the apptainer runtime
+        takes the foreground branch (``subprocess.run`` blocks until the
+        capsule exits) instead of the background branch (Popen + return
+        rc=0 immediately). Required for the one-shot cohort case so the
+        capsule's actual rc + stderr surface up the chain into
+        ``STARTUP_FAILED.stderr_tail`` (clew dogfood 2026-06-06: without
+        this, the post-ack liveness probe sees a still-alive Popen pid
+        and reports SUCC, but the capsule dies later, silently).
+    one_shot
+        Forwarded as ``one_shot: true`` in the POST body when set.
+        The host listen propagates ``--one-shot`` to its inner argv;
+        the capsule runs one SDK turn (its ``startup_prompts``) and
+        exits. Pairs naturally with ``foreground=True`` for the
+        cohort capsule shape.
 
     Returns
     -------
@@ -238,6 +257,13 @@ def request_spawn(
     if spec is not None:
         body["spec"] = spec
         body["overwrite"] = bool(overwrite)
+    # Cohort one-shot diagnostic (clew dogfood 2026-06-06, lead msg
+    # d96a468c): only emit the keys when truthy so the wire shape is
+    # back-compat with pre-α brokers (they ignore the absent fields).
+    if foreground:
+        body["foreground"] = True
+    if one_shot:
+        body["one_shot"] = True
 
     payload = json.dumps(body).encode("utf-8")
     url = f"{base}/agents"
@@ -276,8 +302,7 @@ def request_spawn(
     except (urlerror.URLError, OSError, ValueError) as exc:
         logger.warning("spawn_client: POST %s transport error: %s", url, exc)
         raise SpawnRequestError(
-            f"spawn of {child_name!r} failed: cannot reach listen at "
-            f"{base!r} ({exc})"
+            f"spawn of {child_name!r} failed: cannot reach listen at {base!r} ({exc})"
         ) from exc
 
     parsed = _parse_body(raw)

--- a/src/scitex_agent_container/_lifecycle/_start.py
+++ b/src/scitex_agent_container/_lifecycle/_start.py
@@ -235,7 +235,19 @@ def agent_start(
     # contract lives in :func:`_in_sif_broker.maybe_broker_in_sif_spawn`.
     from ._in_sif_broker import maybe_broker_in_sif_spawn
 
-    if maybe_broker_in_sif_spawn(config.name, dry_run=dry_run, opener=in_sif_opener):
+    # PR-α (lead msg d96a468c 2026-06-06): propagate --foreground /
+    # --one-shot through the broker so the host listen's /agents handler
+    # appends them to its inner `sac agents start` argv. The cohort
+    # one-shot capsule runs synchronously → real rc + real stderr land
+    # in STARTUP_FAILED on crash (the diagnostic clew needs to find
+    # WHY the bm172 capsule dies after one heartbeat).
+    if maybe_broker_in_sif_spawn(
+        config.name,
+        dry_run=dry_run,
+        opener=in_sif_opener,
+        foreground=foreground,
+        one_shot=one_shot,
+    ):
         return True
 
     # Launch-time LOCAL spec-source drift check. Verifies the git repo

--- a/src/scitex_agent_container/_listen/_agent_exec.py
+++ b/src/scitex_agent_container/_listen/_agent_exec.py
@@ -393,6 +393,29 @@ async def agents_start(request: Request) -> JSONResponse:
         return JSONResponse(
             {"error": "'caller' must be a string if present"}, status_code=400
         )
+
+    # PR-α (lead msg d96a468c 2026-06-06): cohort one-shot diagnostic.
+    # When the parent's ``sac agents start`` carried --foreground /
+    # --one-shot, the spawn client (_lifecycle/_spawn_client.py) emits
+    # these as body fields. Propagate to the inner argv so the host's
+    # apptainer runtime takes the foreground/one-shot branch
+    # (subprocess.run blocks until the capsule exits) — the capsule's
+    # actual exit code + stderr then flow up into STARTUP_FAILED on
+    # crash, instead of the background branch's "Popen + rc=0
+    # immediately" lie. Each flag is independent + back-compat absent
+    # (default False → no flag, pre-α behaviour).
+    foreground = body.get("foreground", False)
+    if not isinstance(foreground, bool):
+        return JSONResponse(
+            {"error": "'foreground' must be a boolean if present"},
+            status_code=400,
+        )
+    one_shot = body.get("one_shot", False)
+    if not isinstance(one_shot, bool):
+        return JSONResponse(
+            {"error": "'one_shot' must be a boolean if present"},
+            status_code=400,
+        )
     decision, reason = check_spawn(caller=caller)
     if decision == "deny":
         return deny_response(reason or "spawn denied")
@@ -457,9 +480,19 @@ async def agents_start(request: Request) -> JSONResponse:
     child_env = dict(os.environ)
     child_env.pop("APPTAINER_CONTAINER", None)
     child_env.pop("SINGULARITY_CONTAINER", None)
+    # PR-α: propagate --foreground / --one-shot to the inner argv per the
+    # body fields validated above. Order matches the click signature on
+    # `sac agents start` (flags before/after positional name are
+    # equivalent, but keep the positional last for the canonical shape).
+    inner_argv = [sac_bin, "agents", "start"]
+    if foreground:
+        inner_argv.append("--foreground")
+    if one_shot:
+        inner_argv.append("--one-shot")
+    inner_argv.append(name)
     proc = await asyncio.to_thread(
         subprocess.run,
-        [sac_bin, "agents", "start", name],
+        inner_argv,
         capture_output=True,
         text=True,
         check=False,
@@ -530,6 +563,24 @@ async def agents_start(request: Request) -> JSONResponse:
     # Loud failures write a fresh STARTUP_FAILED with the new kind
     # AND downgrade the response to 502 so the operator-side recv
     # path can show a real diagnostic instead of a misleading SUCC.
+    #
+    # PR-α: skip the probe when foreground=True. The inner subprocess
+    # already blocked (apptainer runtime's foreground branch is
+    # subprocess.run, not Popen) and explicitly does NOT write
+    # apptainer_pid — the probe would always report
+    # post_ack_no_apptainer_pid on a successful one-shot run. The real
+    # signal is the inner rc captured above; rc!=0 already wrote
+    # STARTUP_FAILED with stderr_tail (the cohort one-shot diagnostic).
+    if foreground:
+        return JSONResponse(
+            {
+                "name": name,
+                "returncode": proc.returncode,
+                "stdout": proc.stdout,
+                "stderr": proc.stderr,
+            },
+            status_code=200,
+        )
     from .._lifecycle._startup_failed import write_marker
     from .._runners._session_state import state_dir_for
 

--- a/tests/scitex_agent_container/_lifecycle/test__in_sif_broker.py
+++ b/tests/scitex_agent_container/_lifecycle/test__in_sif_broker.py
@@ -284,6 +284,55 @@ def test_broker_raises_on_host_listen_acl_deny(listen_env) -> None:
 
 
 # ---------------------------------------------------------------------------
+# PR-α (lead msg d96a468c 2026-06-06): cohort one-shot diagnostic chain.
+# ``broker_start_to_host`` and ``maybe_broker_in_sif_spawn`` forward
+# ``foreground`` / ``one_shot`` to ``request_spawn`` → body fields → host
+# listen's /agents handler argv. Three forwarding tests so a refactor
+# that drops either kwarg trips a red test before the diagnostic value
+# silently regresses.
+# ---------------------------------------------------------------------------
+
+
+def test_broker_forwards_foreground_to_body(listen_env) -> None:
+    # Arrange
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    opener, captured = _opener_returning(b'{"name":"c","returncode":0}')
+    # Act
+    broker_start_to_host("child", opener=opener, foreground=True)
+    # Assert
+    assert json.loads(captured["body"])["foreground"] is True
+
+
+def test_broker_forwards_one_shot_to_body(listen_env) -> None:
+    # Arrange
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    opener, captured = _opener_returning(b'{"name":"c","returncode":0}')
+    # Act
+    broker_start_to_host("child", opener=opener, one_shot=True)
+    # Assert
+    assert json.loads(captured["body"])["one_shot"] is True
+
+
+def test_maybe_broker_in_sif_forwards_foreground_to_body(sif_env, listen_env) -> None:
+    # Arrange — flip is_in_sif() to True so the chokepoint actually
+    # brokers (rather than returning False for the bare-host path).
+    from scitex_agent_container._lifecycle._in_sif_broker import (
+        maybe_broker_in_sif_spawn,
+    )
+
+    sif_env("/path/to/parent.sif", key="APPTAINER_CONTAINER")
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    opener, captured = _opener_returning(b'{"name":"c","returncode":0}')
+    # Act
+    maybe_broker_in_sif_spawn(
+        "child", dry_run=False, opener=opener, foreground=True, one_shot=True
+    )
+    # Assert
+    body = json.loads(captured["body"])
+    assert body["foreground"] is True and body["one_shot"] is True
+
+
+# ---------------------------------------------------------------------------
 # agent_start integration — in-SIF detection redirects to broker
 # ---------------------------------------------------------------------------
 

--- a/tests/scitex_agent_container/_lifecycle/test__spawn_client.py
+++ b/tests/scitex_agent_container/_lifecycle/test__spawn_client.py
@@ -234,6 +234,49 @@ def test_inline_spec_is_forwarded_with_overwrite_flag(listen_env) -> None:
     assert body["spec"] == spec and body["overwrite"] is True
 
 
+# ---------------------------------------------------------------------------
+# PR-α (lead msg d96a468c 2026-06-06): cohort one-shot diagnostic.
+# request_spawn emits ``foreground`` / ``one_shot`` body fields only when
+# truthy so the wire shape is back-compat with pre-α brokers (those
+# ignore absent fields). The host listen's /agents handler reads each
+# field and appends the matching CLI flag to its inner argv.
+# ---------------------------------------------------------------------------
+
+
+def test_body_includes_foreground_true_when_requested(listen_env) -> None:
+    # Arrange
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    opener, captured = _opener_returning(b'{"name":"c","returncode":0}')
+    # Act
+    request_spawn("c", foreground=True, opener=opener)
+    # Assert
+    assert json.loads(captured["body"])["foreground"] is True
+
+
+def test_body_includes_one_shot_true_when_requested(listen_env) -> None:
+    # Arrange
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    opener, captured = _opener_returning(b'{"name":"c","returncode":0}')
+    # Act
+    request_spawn("c", one_shot=True, opener=opener)
+    # Assert
+    assert json.loads(captured["body"])["one_shot"] is True
+
+
+def test_body_omits_foreground_and_one_shot_when_default_false(
+    listen_env,
+) -> None:
+    # Arrange — default kwargs absent on the call.
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    opener, captured = _opener_returning(b'{"name":"c","returncode":0}')
+    # Act
+    request_spawn("c", opener=opener)
+    # Assert — both keys must be ABSENT (not present-but-false) so the
+    # wire shape is byte-identical to pre-α brokers.
+    body = json.loads(captured["body"])
+    assert "foreground" not in body and "one_shot" not in body
+
+
 def test_bearer_token_attached_as_authorization_header(listen_env) -> None:
     # Arrange
     listen_env("LISTEN_BASE_URL", "http://host:9100")
@@ -336,9 +379,7 @@ def test_server_500_raises_spawn_request_error(listen_env) -> None:
     # Arrange — a 500 must propagate as a fail-loud error, not return None.
     listen_env("LISTEN_BASE_URL", "http://host:9100")
     opener = _opener_raising(
-        urlerror.HTTPError(
-            "http://host:9100/agents", 500, "boom", {}, io.BytesIO(b"")
-        )
+        urlerror.HTTPError("http://host:9100/agents", 500, "boom", {}, io.BytesIO(b""))
     )
     captured_status = None
     # Act
@@ -368,7 +409,7 @@ def test_non_dict_2xx_body_raises_spawn_request_error(listen_env) -> None:
     # Arrange — server returns a JSON array instead of an object; must
     # fail loud rather than silently corrupt the caller's downstream use.
     listen_env("LISTEN_BASE_URL", "http://host:9100")
-    opener, _ = _opener_returning(b'[1,2,3]', status=200)
+    opener, _ = _opener_returning(b"[1,2,3]", status=200)
     raised = False
     # Act
     try:

--- a/tests/scitex_agent_container/_listen/test__agent_exec_subprocess.py
+++ b/tests/scitex_agent_container/_listen/test__agent_exec_subprocess.py
@@ -442,3 +442,237 @@ def test_agents_start_post_ack_failure_returns_502(
         )
     # Assert
     assert resp.status_code == 502
+
+
+# ---------------------------------------------------------------------------
+# PR-α (lead msg d96a468c 2026-06-06): cohort one-shot diagnostic.
+#
+# The pre-α handler runs `sac agents start <name>` WITHOUT --foreground /
+# --one-shot, even when the operator's parent invocation carried them.
+# The apptainer runtime's background branch (Popen + write apptainer_pid +
+# return rc=0 immediately) means the inner subprocess returns success
+# before the capsule has actually proven viable; the PR#313 liveness probe
+# then sees a still-alive Popen pid and returns SUCC even when the capsule
+# crashes seconds later. clew's bm172 repro 2026-06-06: parent rc=0 +
+# "SUCC started" (async ack), 5 min later capsule dead with empty
+# stdout.log, single heartbeat, no fresh STARTUP_FAILED — operator-side
+# observability had nothing to triage. The fix: parent's body now carries
+# ``foreground``/``one_shot`` flags; this handler propagates them to the
+# inner argv → the inner runtime takes the foreground branch
+# (subprocess.run blocks until the capsule exits) → the capsule's real
+# rc + stderr surface up the chain → STARTUP_FAILED.stderr_tail finally
+# tells WHY the capsule crashed. PR#313's probe is skipped on this branch
+# (the foreground subprocess already blocked + the foreground apptainer
+# runtime explicitly does NOT write apptainer_pid; the probe would always
+# false-fail post_ack_no_apptainer_pid).
+# ---------------------------------------------------------------------------
+
+
+def _install_argv_recording_sac_shim(bin_dir: Path) -> Path:
+    """Install a sac shim that records its argv to a sibling log.
+
+    Writes ``<bin_dir>/sac.argv.jsonl`` with one JSON list per
+    invocation, ``[arg1, arg2, ...]``. Returns the path to the log.
+    """
+    import json
+    import sys
+
+    argv_log = bin_dir / "sac.argv.jsonl"
+    script = bin_dir / "sac"
+    body = (
+        f"#!{sys.executable}\n"
+        "import json, sys\n"
+        f"with open({json.dumps(str(argv_log))}, 'a') as fh:\n"
+        "    fh.write(json.dumps(sys.argv[1:]) + '\\n')\n"
+        "sys.exit(0)\n"
+    )
+    script.write_text(body)
+    script.chmod(0o755)
+    return argv_log
+
+
+def test_agents_start_propagates_foreground_flag_to_inner_argv(
+    isolated_listen_env, env_save_restore, tmp_path: Path
+) -> None:
+    """``foreground: true`` body field → inner argv carries ``--foreground``."""
+    # Arrange — argv-recording sac shim; body sets foreground=true.
+    import json
+
+    bin_dir = tmp_path / "sac_bin_fg_argv"
+    bin_dir.mkdir()
+    argv_log = _install_argv_recording_sac_shim(bin_dir)
+    env_save_restore.set("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
+    env_save_restore.set("SAC_LISTEN_POST_ACK_LIVENESS_TIMEOUT_S", "0")
+    app = create_app(token=_TOKEN)
+    # Act
+    with TestClient(app) as client:
+        client.post(
+            "/agents",
+            json={"name": "cohort-child", "foreground": True},
+            headers={"authorization": f"Bearer {_TOKEN}"},
+        )
+    recorded = json.loads(argv_log.read_text().splitlines()[-1])
+    # Assert — --foreground appears between "start" and the positional name.
+    assert "--foreground" in recorded
+
+
+def test_agents_start_propagates_one_shot_flag_to_inner_argv(
+    isolated_listen_env, env_save_restore, tmp_path: Path
+) -> None:
+    """``one_shot: true`` body field → inner argv carries ``--one-shot``."""
+    # Arrange
+    import json
+
+    bin_dir = tmp_path / "sac_bin_os_argv"
+    bin_dir.mkdir()
+    argv_log = _install_argv_recording_sac_shim(bin_dir)
+    env_save_restore.set("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
+    env_save_restore.set("SAC_LISTEN_POST_ACK_LIVENESS_TIMEOUT_S", "0")
+    app = create_app(token=_TOKEN)
+    # Act
+    with TestClient(app) as client:
+        client.post(
+            "/agents",
+            json={"name": "cohort-child", "one_shot": True},
+            headers={"authorization": f"Bearer {_TOKEN}"},
+        )
+    recorded = json.loads(argv_log.read_text().splitlines()[-1])
+    # Assert
+    assert "--one-shot" in recorded
+
+
+def test_agents_start_no_flags_back_compat_inner_argv_unchanged(
+    isolated_listen_env, env_save_restore, tmp_path: Path
+) -> None:
+    """Body without ``foreground`` / ``one_shot`` → inner argv = pre-α shape.
+
+    Back-compat for pre-α brokers (the absent body fields default to
+    False; no flag is appended). Pre-α inner argv was
+    ``["agents", "start", <name>]`` — preserve that exact shape so a
+    future refactor that always-on the flags trips a red test.
+    """
+    # Arrange
+    import json
+
+    bin_dir = tmp_path / "sac_bin_noflags_argv"
+    bin_dir.mkdir()
+    argv_log = _install_argv_recording_sac_shim(bin_dir)
+    env_save_restore.set("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
+    env_save_restore.set("SAC_LISTEN_POST_ACK_LIVENESS_TIMEOUT_S", "0")
+    app = create_app(token=_TOKEN)
+    # Act
+    with TestClient(app) as client:
+        client.post(
+            "/agents",
+            json={"name": "back-compat-child"},
+            headers={"authorization": f"Bearer {_TOKEN}"},
+        )
+    recorded = json.loads(argv_log.read_text().splitlines()[-1])
+    # Assert
+    assert recorded == ["agents", "start", "back-compat-child"]
+
+
+def test_agents_start_rejects_non_bool_foreground(
+    isolated_listen_env, env_save_restore, tmp_path: Path
+) -> None:
+    """``foreground: "yes"`` → 400, never silently coerced.
+
+    Wire shape must be a JSON boolean; string "true" / "1" / "yes" are
+    NOT accepted because the handler propagates to a CLI flag — a typo
+    or schema drift on the caller's side must fail loud, not silently
+    behave one way or the other.
+    """
+    # Arrange
+    env_save_restore.set("SAC_LISTEN_POST_ACK_LIVENESS_TIMEOUT_S", "0")
+    app = create_app(token=_TOKEN)
+    # Act
+    with TestClient(app) as client:
+        resp = client.post(
+            "/agents",
+            json={"name": "x", "foreground": "yes"},
+            headers={"authorization": f"Bearer {_TOKEN}"},
+        )
+    # Assert
+    assert resp.status_code == 400
+
+
+def test_agents_start_foreground_skips_post_ack_liveness_probe(
+    isolated_listen_env, env_save_restore, tmp_path: Path
+) -> None:
+    """``foreground=True`` MUST skip the PR#313 post-ack liveness probe.
+
+    Why: the apptainer runtime's foreground branch is ``subprocess.run``
+    (not Popen), so it doesn't write apptainer_pid at all. The probe
+    would always false-fail with ``post_ack_no_apptainer_pid`` and
+    spuriously downgrade a successful one-shot run to 502 +
+    STARTUP_FAILED. With foreground, the inner subprocess has already
+    blocked — the rc captured above IS the truth.
+    """
+    # Arrange — sac shim that returns rc=0 and does NOT write
+    # apptainer_pid (mirrors the foreground-runtime behaviour). Set a
+    # short timeout so a pre-α probe regression would fire a marker
+    # within the test window.
+    bin_dir = tmp_path / "sac_bin_fg_no_probe"
+    bin_dir.mkdir()
+    _install_sac_shim_writing_pid_file(
+        bin_dir, runtime_dir=tmp_path / "unused", pid_value=None
+    )
+    env_save_restore.set("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
+    env_save_restore.set("SAC_LISTEN_POST_ACK_LIVENESS_TIMEOUT_S", "0.5")
+    app = create_app(token=_TOKEN)
+    # Act
+    with TestClient(app) as client:
+        resp = client.post(
+            "/agents",
+            json={"name": "cohort-child", "foreground": True},
+            headers={"authorization": f"Bearer {_TOKEN}"},
+        )
+    # Assert — without the foreground skip, the probe would mark
+    # STARTUP_FAILED + 502; with it, the handler returns 200.
+    assert resp.status_code == 200
+
+
+def test_agents_start_foreground_rc_nonzero_writes_stderr_tail_to_marker(
+    isolated_listen_env, env_save_restore, tmp_path: Path
+) -> None:
+    """Cohort diagnostic: capsule crash → STARTUP_FAILED.stderr_tail.
+
+    With foreground propagated, the inner ``sac agents start`` runs the
+    apptainer runtime in subprocess.run-blocks mode. If the capsule
+    crashes, rc != 0 and the runtime's stderr (the apptainer FATAL
+    line, the in-SIF entrypoint trace, etc.) bubbles back to this
+    handler's ``proc.stderr`` and into ``STARTUP_FAILED.stderr_tail``.
+    PR-α folds in PR9: this contract is THE unblock for finding why
+    clew's bm172 capsule dies after one heartbeat.
+    """
+    # Arrange — sac shim that simulates a capsule crash: emits a
+    # recognisable stderr line and exits non-zero. (No mocks; real
+    # subprocess + real handler + real marker write.)
+    import sys
+
+    bin_dir = tmp_path / "sac_bin_fg_crash"
+    bin_dir.mkdir()
+    script = bin_dir / "sac"
+    script.write_text(
+        f"#!{sys.executable}\n"
+        "import sys\n"
+        'sys.stderr.write("FATAL: capsule crashed for the test\\n")\n'
+        "sys.exit(42)\n"
+    )
+    script.chmod(0o755)
+    env_save_restore.set("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
+    env_save_restore.set("SAC_LISTEN_POST_ACK_LIVENESS_TIMEOUT_S", "0")
+    app = create_app(token=_TOKEN)
+    # Act
+    with TestClient(app) as client:
+        client.post(
+            "/agents",
+            json={"name": "crash-child", "foreground": True},
+            headers={"authorization": f"Bearer {_TOKEN}"},
+        )
+    from scitex_agent_container._lifecycle._startup_failed import read_marker
+    from scitex_agent_container._runners._session_state import state_dir_for
+
+    marker = read_marker(state_dir_for("crash-child"))
+    # Assert
+    assert marker is not None and "FATAL: capsule crashed" in marker["stderr_tail"]


### PR DESCRIPTION
## Summary

`sac agents start --foreground --one-shot <child>` was returning ASYNC from the parent when the spawn was brokered through `sac listen`'s POST /agents handler — the operator's `--foreground` intent was dropped on the chain. Capsule's parent returned rc=0 + "SUCC started" within seconds while the inner `sac agents start` had taken the apptainer runtime's BACKGROUND branch (Popen + write apptainer_pid + return 0 immediately) and the capsule was still running asynchronously. PR#313's 5-second post-ack liveness probe saw the still-alive Popen pid and reported SUCC even when the capsule later died (lead msgs d96a468c, 5d6fce21, e19eef3b).

## Fix

Thread `foreground` / `one_shot` body fields through the in-SIF broker chain. The listen's `/agents` handler now appends `--foreground` / `--one-shot` to its inner `sac agents start` argv. The apptainer runtime's foreground branch is `subprocess.run` (not Popen) → blocks until capsule exits → real exit code + stderr flow up the chain → `STARTUP_FAILED.stderr_tail` captures the actual crash detail on rc!=0. The PR#313 post-ack liveness probe is skipped on the foreground branch (the foreground runtime explicitly does not write `apptainer_pid`, so the probe would always false-fail `post_ack_no_apptainer_pid` and downgrade a successful one-shot run to 502).

## Wire shape (back-compat)

```
POST /agents
{
  "name":       "<child>",
  "caller":     "<parent>",
  "foreground": true,   // NEW — optional, default false
  "one_shot":   true,   // NEW — optional, default false
}
```

Pre-α brokers and admin/MCP callers that omit the fields keep the prior async behaviour (defaults false → no flag → background branch).

## Chain

```
sac agents start --foreground --one-shot
  → _lifecycle/_start.agent_start (NEW: passes flags through)
    → _in_sif_broker.maybe_broker_in_sif_spawn (NEW: forwards)
      → _in_sif_broker.broker_start_to_host    (NEW: forwards)
        → _spawn_client.request_spawn          (NEW: emits truthy fields)
          → POST /agents body
            → _listen/_agent_exec.agents_start (NEW: body → argv)
              → subprocess.run([..., "--foreground", "--one-shot", name])
                → apptainer runtime foreground branch (subprocess.run, blocks)
                  → capsule exits → real rc/stderr → STARTUP_FAILED on crash
```

## Changes (4 src, 3 tests)

- `src/scitex_agent_container/_lifecycle/_spawn_client.py` — `request_spawn` accepts `foreground=False, one_shot=False`; emits truthy fields only.
- `src/scitex_agent_container/_lifecycle/_in_sif_broker.py` — `broker_start_to_host` + `maybe_broker_in_sif_spawn` forward both kwargs; docstring on the chokepoint explains the cohort one-shot diagnostic.
- `src/scitex_agent_container/_lifecycle/_start.py` — `agent_start` passes its click `--foreground` / `--one-shot` flags to `maybe_broker_in_sif_spawn`.
- `src/scitex_agent_container/_listen/_agent_exec.py` — `agents_start` reads body params (must be bool, else 400), composes inner argv with flags between `start` and the positional name, returns 200 directly when foreground=True (skips probe).

Tests (no-mock per PA-306, AAA per PA-307):

- `tests/.../_listen/test__agent_exec_subprocess.py` — +6 tests pinning argv propagation, back-compat, 400 type guard, probe skip on foreground, and the cohort diagnostic (real shim emits stderr → marker carries it).
- `tests/.../_lifecycle/test__spawn_client.py` — +3 tests pinning body field emission (truthy only, absent on default).
- `tests/.../_lifecycle/test__in_sif_broker.py` — +3 tests pinning forwarding through both broker functions.

## Scope

`(β)` the long-running supervisor for BACKGROUND spawns (49-array case) stays queued as the proper long-term shape for that scenario. This PR is scope-locked to the `--foreground/--one-shot` semantic. PR9 (stderr-tail capture) folds in: the rc!=0 STARTUP_FAILED path already carried `proc.stderr`, which on the foreground branch finally fills with the capsule's real crash output (the pre-α background branch had empty stderr because the Popen'd apptainer inherited stdio to the runtime dir's `stdout.log` / `stderr.log`, not the inner sac's captured streams).

## Test plan

- [x] Focused: 57/57 pass locally (12 new + 45 existing affected).
- [x] No `MagicMock` — real subprocess shims, real opener seam, real STARTUP_FAILED marker round-trip.
- [x] Broader: 1058/1058 pass (listen + lifecycle + cli_pkg/lifecycle).
- [x] CI on the same gate as PRs #307-#316.
