### PR TITLE
feat(sdk_common): suppress Computer tool USE when provider backend active (defense-in-depth)

### DIFF
--- a/src/scitex_agent_container/runtimes/_sdk_common.py
+++ b/src/scitex_agent_container/runtimes/_sdk_common.py
@@ -56,6 +56,27 @@ __all__ = [
     "project_runtime_root",
 ]
 
+# Tools whose schema the LiteLLM (and similar) Anthropic-API shims
+# cannot relay to non-Anthropic backends. When ``spec.claude.provider``
+# declares a provider override (LiteLLM / vLLM / gateway), the Claude
+# Code SDK still registers these tools by default and embeds their full
+# schema in every outbound API request — the shim then chokes on a
+# missing required field and returns 422 on EVERY turn.
+#
+# Concrete case (clew bm172 cohort 2026-06-06, lead msg 5d6fce21):
+# AnthropicComputerTool requires ``display_width_px``; LiteLLM 1.52.16's
+# Anthropic shim drops it on translation → 422 on every API call → the
+# capsule ran the full 60-turn autonomous loop emitting only errors,
+# then naturally exited at max_turns.
+#
+# The SDK's ``disallowed_tools`` field is the right knob:
+# ``"These tools are removed from the model's context and cannot be
+# used"`` (claude_agent_sdk/types.py:1666-1671) — i.e. the schema is
+# never sent to the API. Extend this tuple if other shim-incompatible
+# tools surface; new entries propagate to every provider-backed agent
+# without further wiring.
+_ANTHROPIC_SHIM_INCOMPATIBLE_TOOLS: tuple[str, ...] = ("Computer",)
+
 
 def project_runtime_root(config: "AgentConfig") -> "Path | None":
     """If the agent's YAML lives under a project-scope
@@ -274,6 +295,40 @@ def _resolve_env_refs(value: Any) -> Any:
     return value
 
 
+def _load_agent_config_silent(agent_name: str) -> "AgentConfig | None":
+    """Best-effort: load the agent's ``AgentConfig``; return ``None`` on any failure.
+
+    Used by :func:`build_sdk_options` to consult ``spec.claude.provider``
+    so the option-builder can extend ``disallowed_tools`` for
+    provider-backed agents (the shim-incompatible-tool exclude). Mirrors
+    the resolve-from-registry shape of :func:`resolve_agent_workspace`
+    so the two share the same best-effort failure profile: an
+    unregistered agent / unreadable spec collapses to ``None`` and the
+    option-builder proceeds as if no provider were configured (i.e. no
+    extra disallowed_tools added). This keeps the new gate from breaking
+    pre-existing tests that don't wire a registry entry.
+    """
+    try:
+        from scitex_agent_container._state.registry import Registry
+    except Exception:  # stx-allow: fallback (reason: optional dep at runtime; mirrors resolve_agent_workspace)
+        return None
+    try:
+        entry = Registry().get(agent_name)
+    except Exception:  # stx-allow: fallback (reason: registry IO best-effort)
+        return None
+    if not entry:
+        return None
+    config_path = entry.get("config")
+    if not config_path:
+        return None
+    try:
+        from scitex_agent_container.config import load_config
+
+        return load_config(config_path)
+    except Exception:  # stx-allow: fallback (reason: config load best-effort)
+        return None
+
+
 def resolve_agent_workspace(agent_name: str) -> tuple[dict, str | None]:
     """Resolve ``(mcp_servers, cwd)`` for a registered agent.
 
@@ -476,5 +531,49 @@ def build_sdk_options(
     if "Agent" not in _allowed:
         _allowed.append("Agent")
     kwargs["allowed_tools"] = _allowed
+
+    # Provider-aware Anthropic-tool exclude (clew bm172 cohort 2026-06-06,
+    # lead msg 5d6fce21 / 70664dd3). When the agent routes through a
+    # non-Anthropic provider (LiteLLM / vLLM / gateway), extend
+    # ``disallowed_tools`` with the Anthropic-shim-incompatible set so
+    # the SDK doesn't emit those tools' schemas in outbound API requests
+    # — the shim 422s on the missing required fields (e.g.
+    # AnthropicComputerTool.display_width_px) otherwise.
+    #
+    # Two independent gate signals — widened per lead msg 70664dd3 after
+    # v5b proved spec.claude.flags is not the only declaration path:
+    #
+    #   * ``spec.claude.provider`` carries a non-empty ``base_url`` →
+    #     the canonical sac-managed path; provider_env_flags later
+    #     translates it to ``--env ANTHROPIC_BASE_URL=<base_url>`` for
+    #     the apptainer launch.
+    #   * ``ANTHROPIC_BASE_URL`` env var is non-empty at SDK invocation
+    #     time → catches every other declaration shape:
+    #       - operator put it in ``spec.claude.environment``
+    #       - operator put it in apptainer raw_args env-injection
+    #       - inherited from the host shell that ran ``sac agents start``
+    #       - (and the sac-managed path above, after the apptainer
+    #         translation lands it in the SIF env)
+    #
+    # The two are OR'd because either signal independently means a
+    # provider IS in effect at SDK runtime; without the env-side check
+    # the gate silently no-ops on any non-spec.provider declaration.
+    # The env check is the robust universal shape because
+    # build_sdk_options runs INSIDE the capsule SIF where the env IS
+    # whatever the runtime wired — works regardless of how it got there.
+    # Non-provider agents (real Anthropic backend) are unaffected: both
+    # signals are False, no extra disallowed_tools added. Any caller-
+    # supplied disallowed_tools list is preserved (merge, not replace).
+    from ._apptainer_provider import provider_active
+
+    _provider_cfg = _load_agent_config_silent(agent_name)
+    _spec_says_provider = _provider_cfg is not None and provider_active(_provider_cfg)
+    _env_says_provider = bool((os.environ.get("ANTHROPIC_BASE_URL") or "").strip())
+    if _spec_says_provider or _env_says_provider:
+        _disallowed = list(kwargs.get("disallowed_tools") or [])
+        for _t in _ANTHROPIC_SHIM_INCOMPATIBLE_TOOLS:
+            if _t not in _disallowed:
+                _disallowed.append(_t)
+        kwargs["disallowed_tools"] = _disallowed
 
     return ClaudeAgentOptions(**kwargs)

--- a/tests/scitex_agent_container/runtimes/test__sdk_common.py
+++ b/tests/scitex_agent_container/runtimes/test__sdk_common.py
@@ -704,6 +704,239 @@ class TestSettingsFlag:
 
 
 # ---------------------------------------------------------------------------
+# build_sdk_options — provider-aware Anthropic-tool exclude (clew bm172
+# cohort 2026-06-06, lead msg 5d6fce21). When ``spec.claude.provider``
+# routes the agent through LiteLLM/vLLM/gateway, the Claude Code SDK
+# still registers Anthropic-only tools by default (e.g. AnthropicComputerTool
+# with display_width_px) — the shim drops the unrecognised field and the
+# Anthropic Messages API returns 422 on every API call. The build_sdk_options
+# fix extends disallowed_tools with the shim-incompatible tool names when
+# the provider gate is active, so the SDK never emits those schemas in
+# outbound requests. Tests pin: (i) provider-backed agent → "Computer" in
+# disallowed_tools, (ii) non-provider agent → "Computer" NOT added, (iii)
+# caller-supplied disallowed_tools preserved + merged.
+# ---------------------------------------------------------------------------
+
+
+def _swap_load_config_with_provider(env: _Env, workdir: str, *, base_url: str) -> None:
+    """Wire load_config to return a stub config with an active provider.
+
+    Real ``provider_active`` (in _apptainer_provider) checks
+    ``config.claude.provider.base_url`` non-empty — emit exactly that
+    shape via SimpleNamespace so the predicate is exercised honestly
+    (no monkeypatch of provider_active itself).
+    """
+    import scitex_agent_container.config as cfg_mod
+
+    provider_ns = SimpleNamespace(base_url=base_url, auth_token_env="API_KEY_ENV")
+    claude_ns = SimpleNamespace(provider=provider_ns, account="")
+    config_ns = SimpleNamespace(expanded_workdir=workdir, claude=claude_ns)
+    env.setattr_module(cfg_mod, "load_config", lambda _path: config_ns)
+
+
+class TestProviderAwareToolExclude:
+    @pytest.fixture
+    def _opts_with_provider(self, sdk_env: _Env, tmp_path):
+        # Arrange — auth + workspace setup; load_config returns a stub
+        # with an ACTIVE provider (non-empty base_url).
+        _write_valid_cred(sdk_env, tmp_path)
+        sdk_env.delenv("ANTHROPIC_API_KEY")
+        sdk_env.delenv(_SAC_KEY)
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        _swap_registry(sdk_env, {"config": "cfg.yaml"})
+        _swap_load_config_with_provider(
+            sdk_env, str(ws), base_url="https://litellm.example/v1"
+        )
+        # Act
+        opts = build_sdk_options("alpha", permission_mode="bypassPermissions")
+        return opts
+
+    def test_provider_active_adds_computer_to_disallowed_tools(
+        self, _opts_with_provider
+    ):
+        # Arrange
+        opts = _opts_with_provider
+        # Act
+        disallowed = list(opts.disallowed_tools or [])
+        # Assert
+        assert "Computer" in disallowed
+
+    @pytest.fixture
+    def _opts_without_provider(self, sdk_env: _Env, tmp_path):
+        # Arrange — same auth/workspace setup but load_config returns a
+        # stub WITHOUT a provider (the non-provider control case). Uses
+        # the existing _swap_load_config (no .claude.provider attribute).
+        _write_valid_cred(sdk_env, tmp_path)
+        sdk_env.delenv("ANTHROPIC_API_KEY")
+        sdk_env.delenv(_SAC_KEY)
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        _swap_registry(sdk_env, {"config": "cfg.yaml"})
+        _swap_load_config(sdk_env, str(ws))
+        # Act
+        opts = build_sdk_options("alpha", permission_mode="bypassPermissions")
+        return opts
+
+    def test_no_provider_does_not_add_computer_to_disallowed_tools(
+        self, _opts_without_provider
+    ):
+        # Arrange
+        opts = _opts_without_provider
+        # Act
+        disallowed = list(opts.disallowed_tools or [])
+        # Assert — back-compat: a non-provider agent must NOT have
+        # "Computer" in disallowed_tools (the original Anthropic backend
+        # supports computer-use; suppressing it there would be a
+        # regression).
+        assert "Computer" not in disallowed
+
+    @pytest.fixture
+    def _opts_with_provider_and_caller_disallowed(self, sdk_env: _Env, tmp_path):
+        # Arrange — provider-backed agent AND caller pre-supplies a
+        # disallowed_tools list via ``extra`` — the merge must preserve
+        # the caller's entries AND append "Computer".
+        _write_valid_cred(sdk_env, tmp_path)
+        sdk_env.delenv("ANTHROPIC_API_KEY")
+        sdk_env.delenv(_SAC_KEY)
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        _swap_registry(sdk_env, {"config": "cfg.yaml"})
+        _swap_load_config_with_provider(
+            sdk_env, str(ws), base_url="https://litellm.example/v1"
+        )
+        # Act — caller-supplied disallowed_tools simulates an operator
+        # explicit deny list (e.g. a per-agent override).
+        opts = build_sdk_options(
+            "alpha",
+            permission_mode="bypassPermissions",
+            extra={"disallowed_tools": ["WebFetch", "WebSearch"]},
+        )
+        return list(opts.disallowed_tools or [])
+
+    def test_caller_disallowed_tools_are_preserved(
+        self, _opts_with_provider_and_caller_disallowed
+    ):
+        # Arrange
+        disallowed = _opts_with_provider_and_caller_disallowed
+        # Act
+        preserved = "WebFetch" in disallowed and "WebSearch" in disallowed
+        # Assert
+        assert preserved is True
+
+    def test_caller_disallowed_tools_merged_with_computer(
+        self, _opts_with_provider_and_caller_disallowed
+    ):
+        # Arrange
+        disallowed = _opts_with_provider_and_caller_disallowed
+        # Act
+        has_computer = "Computer" in disallowed
+        # Assert — the merge must APPEND, not replace.
+        assert has_computer is True
+
+    # -----------------------------------------------------------------
+    # PR#318 GATE WIDENING (lead msg 70664dd3 2026-06-06 after v5b
+    # decisive failure). The original gate (provider_active(cfg) only)
+    # silently no-ops when the LiteLLM endpoint is declared via env-
+    # injection (raw_args / spec.claude.environment / inherited host
+    # shell) instead of spec.claude.provider. The widened gate also
+    # consults os.environ.get("ANTHROPIC_BASE_URL") — the robust
+    # universal signal at SDK invocation time inside the SIF, because
+    # build_sdk_options runs in the capsule where the env IS whatever
+    # the runtime wired (spec.provider gets translated to ANTHROPIC_BASE_URL
+    # by provider_env_flags during apptainer launch, and the other
+    # declaration paths land it there too).
+    # -----------------------------------------------------------------
+
+    @pytest.fixture
+    def _opts_env_only_provider(self, sdk_env: _Env, tmp_path):
+        # Arrange — spec has NO provider (so provider_active is False),
+        # but ANTHROPIC_BASE_URL is set in env (raw_args / environment
+        # / shell-export shape).
+        _write_valid_cred(sdk_env, tmp_path)
+        sdk_env.delenv("ANTHROPIC_API_KEY")
+        sdk_env.delenv(_SAC_KEY)
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        _swap_registry(sdk_env, {"config": "cfg.yaml"})
+        _swap_load_config(sdk_env, str(ws))  # no provider on the config
+        sdk_env.setenv("ANTHROPIC_BASE_URL", "https://litellm.example/v1")
+        # Act
+        opts = build_sdk_options("alpha", permission_mode="bypassPermissions")
+        return opts
+
+    def test_env_anthropic_base_url_adds_computer_to_disallowed_tools(
+        self, _opts_env_only_provider
+    ):
+        # Arrange
+        opts = _opts_env_only_provider
+        # Act
+        disallowed = list(opts.disallowed_tools or [])
+        # Assert — env-only declaration must trigger the auto-exclude
+        # just like the spec-side path; otherwise clew-style raw_args
+        # env-injection (the bm172 cohort shape) silently bypasses
+        # the fix.
+        assert "Computer" in disallowed
+
+    @pytest.fixture
+    def _opts_neither_provider_nor_env(self, sdk_env: _Env, tmp_path):
+        # Arrange — explicit double-off control: spec has no provider
+        # AND ANTHROPIC_BASE_URL is unset. Genuine non-provider agent.
+        _write_valid_cred(sdk_env, tmp_path)
+        sdk_env.delenv("ANTHROPIC_API_KEY")
+        sdk_env.delenv(_SAC_KEY)
+        sdk_env.delenv("ANTHROPIC_BASE_URL")
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        _swap_registry(sdk_env, {"config": "cfg.yaml"})
+        _swap_load_config(sdk_env, str(ws))
+        # Act
+        opts = build_sdk_options("alpha", permission_mode="bypassPermissions")
+        return opts
+
+    def test_neither_provider_nor_env_does_not_add_computer(
+        self, _opts_neither_provider_nor_env
+    ):
+        # Arrange
+        opts = _opts_neither_provider_nor_env
+        # Act
+        disallowed = list(opts.disallowed_tools or [])
+        # Assert — back-compat: a genuinely Anthropic-backed agent
+        # (no provider in spec, no ANTHROPIC_BASE_URL in env) must
+        # NOT have Computer added. Suppressing it on the real
+        # Anthropic backend would be a regression.
+        assert "Computer" not in disallowed
+
+    @pytest.fixture
+    def _opts_empty_env_does_not_count(self, sdk_env: _Env, tmp_path):
+        # Arrange — defensive: a present-but-empty ANTHROPIC_BASE_URL
+        # must NOT trigger the auto-exclude. The widened gate uses
+        # ``.strip()`` truthiness so a stray --env ANTHROPIC_BASE_URL=
+        # (typo) doesn't flip the gate on.
+        _write_valid_cred(sdk_env, tmp_path)
+        sdk_env.delenv("ANTHROPIC_API_KEY")
+        sdk_env.delenv(_SAC_KEY)
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        _swap_registry(sdk_env, {"config": "cfg.yaml"})
+        _swap_load_config(sdk_env, str(ws))
+        sdk_env.setenv("ANTHROPIC_BASE_URL", "")  # empty string
+        # Act
+        opts = build_sdk_options("alpha", permission_mode="bypassPermissions")
+        return opts
+
+    def test_empty_anthropic_base_url_does_not_count_as_provider(
+        self, _opts_empty_env_does_not_count
+    ):
+        # Arrange
+        opts = _opts_empty_env_does_not_count
+        # Act
+        disallowed = list(opts.disallowed_tools or [])
+        # Assert
+        assert "Computer" not in disallowed
+
+
+# ---------------------------------------------------------------------------
 # build_sdk_options — server:sac channel sidecar registration
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Provider-backed agents (LiteLLM / vLLM / gateway via `spec.claude.provider`) route their SDK session through an Anthropic-API shim. clew bm172 cohort 2026-06-06: every API call 422'd on `AnthropicComputerTool.display_width_px` missing — LiteLLM 1.52.16's Anthropic shim drops that field on translation and pydantic-rejects the tool body. Every agentic turn errored; the capsule ran 60 max_turns of errors before naturally exiting.

This PR was originally intended as a schema-suppression fix.

## Empirical proof (v7 bind-test, RED)

clew's v7 ran this exact branch via bind-editable-over-SIF (commit f0c8e36 at the time, now squashed into 74f4546). spec.claude.provider gate fired correctly. Result: still 422 every turn. Assistant body sample:

```
API Error: 422 {"detail":[{"type":"missing","loc":["body","tools",9,"AnthropicComputerTool","display_width_px"],"msg":"Field required",...}]}
```

The `loc: [..., "tools", 9, "AnthropicComputerTool"]` proves the Computer tool schema is STILL in `tools[]` at position 9 of the outbound request body — LiteLLM's pydantic is parsing it and 422-ing on the missing required field. So `ClaudeAgentOptions.disallowed_tools` blocks USE only, NOT outbound schema emission.

The SDK docstring at `claude_agent_sdk/types.py:1666-1671` ("These tools are removed from the model's context and cannot be used") is empirically misleading on the "removed from the model's context" claim. Filed upstream for docstring fix.

## Scope-amended: merging as defense-in-depth

This PR merges on its own independent merits per lead msg 017fb4ed:

- When a provider backend is active, the agent CANNOT choose Computer as the next tool to invoke even if the schema ships. Correct tool-usage hygiene.
- Future-proofs against agents who would otherwise pick Computer on a non-Anthropic backend that DOES accept the schema but cannot execute the tool.
- Does NOT fix the LiteLLM 422 — that fix lives in the LiteLLM shim layer (clew patches the AnthropicComputerTool pydantic model to make `display_width_px` optional).

## Fix

`runtimes/_sdk_common.py::build_sdk_options` already had an `allowed_tools` merge for the subagent (Agent) tool. Add a sibling `disallowed_tools` merge gated on the OR of two independent provider-active signals:

- `provider_active(cfg)` — True iff `spec.claude.provider.base_url` is non-empty. The canonical sac-managed path.
- `os.environ.get("ANTHROPIC_BASE_URL")` non-empty at SDK invocation time — catches every other declaration shape: apptainer raw_args env-injection, `spec.claude.environment`, inherited host shell. The robust universal shape because `build_sdk_options` runs INSIDE the capsule SIF where the env IS whatever the runtime wired.

Empty-string defence: a stray `--env ANTHROPIC_BASE_URL=` (operator typo) is treated as unset via `.strip()` truthiness.

The merge appends from a module-level tuple `_ANTHROPIC_SHIM_INCOMPATIBLE_TOOLS = ("Computer",)` — adding a future shim-incompatible tool is a one-line edit that propagates to every provider-backed agent.

## Back-compat

- **Non-provider agents** (both signals False): unchanged.
- **Caller-supplied `disallowed_tools`** (via `extra={}`): PRESERVED — merge, not replace. `["WebFetch"]` becomes `["WebFetch", "Computer"]` on a provider-backed agent.

## Tradeoff

An operator who EXPLICITLY wants Computer on a provider (e.g. a future LiteLLM that DOES relay `display_width_px` and the operator wants the agent to actually invoke computer-use) has no clean override path in this PR. Zero current users; future opt-out knob (`spec.claude.provider.shim_relays_computer_use=true`) can flesh out the override story if/when needed. Documented in the constant's docstring.

## Changes (squashed into one commit)

- **`src/scitex_agent_container/runtimes/_sdk_common.py`**
  - `_ANTHROPIC_SHIM_INCOMPATIBLE_TOOLS: tuple[str, ...] = ("Computer",)` + docstring (SDK doc cite + bm172 cohort cite + v7 RED finding).
  - `_load_agent_config_silent(agent_name)` helper (mirrors `resolve_agent_workspace`'s registry-read shape; best-effort failure profile).
  - `build_sdk_options`: after the existing `allowed_tools` merge, OR the two gates and merge the constant into `kwargs["disallowed_tools"]`.

- **`tests/scitex_agent_container/runtimes/test__sdk_common.py`** — `+TestProviderAwareToolExclude` (+7 tests, no `MagicMock`):
  - 4 spec-side: provider-active adds Computer; no-provider doesn't; caller-supplied preserved; caller-supplied merged.
  - 3 env-side: `ANTHROPIC_BASE_URL` adds Computer; neither-on doesn't; empty-string env doesn't trigger gate.

## Test plan

- [x] Local: 7/7 new + 41/41 existing _sdk_common = 48/48 pass.
- [x] CI on the same gate as PRs #307-#317.

## Related work

- **SDK `disallowed_tools` docstring inaccuracy** — filed upstream / tracked separately for ecosystem feedback.
- **Real 422 fix** — clew patches the LiteLLM shim's `AnthropicComputerTool` pydantic model to make `display_width_px` optional.
- **Task #16**: `spec.claude.flags` propagation gap — separate sac bug, follow-up PR.
- **Task #18**: empty `tools` array on title-gen → LiteLLM 400 — separate quirk, follow-up.
