### PR TITLE
feat(sdk_common): provider.allowed_tools → ClaudeAgentOptions.tools (suppress shim-unknown builtins from outbound)

### DIFF
--- a/src/scitex_agent_container/config/_parsers/_claude.py
+++ b/src/scitex_agent_container/config/_parsers/_claude.py
@@ -41,9 +41,19 @@ def _parse_provider(raw: dict) -> ProviderSpec | None:
         return ProviderSpec(base_url=base_url, auth_token_env=auth_token_env)
     if not isinstance(block, dict):
         return None
+    # PR #319 (lead msg a456b610 2026-06-06): provider.allowed_tools
+    # whitelist → ClaudeAgentOptions.tools. Validated to list[str] by
+    # _provider_validation.validate_provider; here we coerce defensively
+    # so an unvalidated path (tests / fixture configs) still produces a
+    # sane shape rather than crashing the runner.
+    raw_allowed = block.get("allowed_tools")
+    allowed_tools: list[str] = []
+    if isinstance(raw_allowed, list):
+        allowed_tools = [str(t) for t in raw_allowed if isinstance(t, str) and t]
     return ProviderSpec(
         base_url=str(block.get("base_url", "") or ""),
         auth_token_env=str(block.get("auth_token_env", "") or ""),
+        allowed_tools=allowed_tools,
     )
 
 

--- a/src/scitex_agent_container/config/_provider_types.py
+++ b/src/scitex_agent_container/config/_provider_types.py
@@ -8,7 +8,7 @@ dataclasses.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 
 @dataclass
@@ -51,3 +51,37 @@ class ProviderSpec:
     ``DEEPSEEK_API_KEY``) — NOT the key value. The operator sources the
     secret file; sac reads the env var's value at start and never logs
     it. Required when the provider block is present."""
+
+    allowed_tools: list[str] = field(default_factory=list)
+    """Whitelist of built-in Claude Code tools to REGISTER when this
+    provider is active. Maps directly to
+    ``ClaudeAgentOptions.tools`` (the SDK ``--tools <csv>`` knob, see
+    ``claude_agent_sdk/_internal/transport/subprocess_cli.py:241-250``),
+    which controls the REGISTERED tool set rather than the use-allow
+    list (``--allowedTools`` / ``--disallowedTools`` only affect
+    permission, not whether the tool's JSON-schema ships in the
+    outbound API request body — confirmed empirically by clew bm172
+    cohort v7 bind-test 2026-06-06).
+
+    Why this matters: an Anthropic-API shim (LiteLLM / vLLM /
+    gateway) may not recognize newer Claude Code built-ins
+    (``ExitPlanMode``, ``BashOutput``, ``KillShell`` were added
+    after LiteLLM 1.52.16). When the shim sees such a tool in the
+    outbound ``tools[]`` it falls through its pydantic Union to the
+    last subclass (``AnthropicComputerTool``), which requires
+    ``display_width_px`` that the unknown tool's payload doesn't
+    have → 422 on every API call → capsule errors all 60 turns.
+    Whitelisting only the shim-recognized tools suppresses the
+    unrecognized builtins at REGISTRATION, so they never enter
+    the outbound body.
+
+    Empty list (the default) means "use the runner's old-stable
+    default whitelist when the provider is active, otherwise leave
+    ``tools`` unset and let the CLI's full default register" — the
+    runner picks the safe shape automatically.
+
+    The string-form provider (e.g. ``provider: mimo``) doesn't carry
+    this field today; the per-registry ``allowed_tools`` plumbing is a
+    follow-up. Operators on the string form fall back to the runner's
+    old-stable default until the registry plumbing lands.
+    """

--- a/src/scitex_agent_container/config/_provider_validation.py
+++ b/src/scitex_agent_container/config/_provider_validation.py
@@ -59,6 +59,25 @@ def validate_provider(provider_block: object) -> list[str]:
                 f"spec.claude.provider.{field_name} must be a string, got "
                 f"{type(val).__name__}"
             )
+    # PR #319 (lead msg a456b610 2026-06-06): optional allowed_tools
+    # whitelist. If present it MUST be a list of non-empty strings;
+    # anything else is a loud config error (silent type-coercion would
+    # let a yaml string-not-list propagate into ClaudeAgentOptions.tools
+    # and downstream the CLI / SDK would fail in less actionable ways).
+    if "allowed_tools" in provider_block:
+        raw = provider_block.get("allowed_tools")
+        if not isinstance(raw, list):
+            errors.append(
+                "spec.claude.provider.allowed_tools must be a list of "
+                f"strings, got {type(raw).__name__}"
+            )
+        else:
+            for idx, item in enumerate(raw):
+                if not isinstance(item, str) or not item:
+                    errors.append(
+                        f"spec.claude.provider.allowed_tools[{idx}] must be a "
+                        f"non-empty string, got {item!r}"
+                    )
     return errors
 
 

--- a/src/scitex_agent_container/runtimes/_sdk_common.py
+++ b/src/scitex_agent_container/runtimes/_sdk_common.py
@@ -48,6 +48,45 @@ if TYPE_CHECKING:  # pragma: no cover — typing only
 
     from ..config._types import AgentConfig
 
+# PR #319 (lead msg a456b610 2026-06-06): provider-aware tool whitelist.
+#
+# Root cause v8: LiteLLM 1.52.16's Anthropic-shim doesn't recognize newer
+# Claude Code builtins (ExitPlanMode, BashOutput, KillShell — added after
+# the LiteLLM version pinned in the cohort's vLLM stack). The shim's
+# pydantic Union of recognized AnthropicTool subclasses falls through to
+# the last subclass (``AnthropicComputerTool``), which requires
+# ``display_width_px`` that the unknown tool's payload doesn't have →
+# 422 on every API call → capsule errors all 60 turns.
+#
+# Fix: when a provider backend is active, REGISTER only the
+# shim-recognized tool set so unrecognized builtins never enter the
+# outbound ``tools[]`` array. ``ClaudeAgentOptions.tools`` is the
+# registration knob — maps to ``--tools <csv>`` per the SDK transport
+# layer at ``claude_agent_sdk/_internal/transport/subprocess_cli.py
+# :241-250``, where the CLI honours it as "the list of available tools
+# from the built-in set" (CLI ``--help``).
+#
+# Spec-side override: ``spec.claude.provider.allowed_tools: list[str]``
+# lets an operator declare their shim's recognized set explicitly. When
+# absent, the default below applies. The default is calibrated for
+# LiteLLM-1.52.16-known tools (clew bm172 cohort 2026-06-06 baseline) +
+# the ``Agent`` subagent registrar; bump this list as the shim ecosystem
+# catches up.
+_PROVIDER_DEFAULT_ALLOWED_TOOLS: tuple[str, ...] = (
+    "Bash",
+    "Read",
+    "Edit",
+    "Write",
+    "Glob",
+    "Grep",
+    "WebFetch",
+    "WebSearch",
+    "TodoWrite",
+    "Task",
+    "NotebookEdit",
+    "Agent",
+)
+
 __all__ = [
     "SDKCommonError",
     "provision_anthropic_auth",
@@ -274,6 +313,38 @@ def _resolve_env_refs(value: Any) -> Any:
     return value
 
 
+def _load_agent_config_silent(agent_name: str) -> "AgentConfig | None":
+    """Best-effort: load the agent's ``AgentConfig``; return ``None`` on any failure.
+
+    Used by :func:`build_sdk_options` to consult ``spec.claude.provider``
+    for the registered-tools whitelist (PR #319). Mirrors the
+    resolve-from-registry shape of :func:`resolve_agent_workspace` so
+    the two share the same best-effort failure profile: an unregistered
+    agent / unreadable spec collapses to ``None`` and the option-builder
+    proceeds as if no provider were configured (i.e. no tools= override),
+    keeping pre-existing tests that don't wire a registry green.
+    """
+    try:
+        from scitex_agent_container._state.registry import Registry
+    except Exception:  # stx-allow: fallback (reason: optional dep at runtime; mirrors resolve_agent_workspace)
+        return None
+    try:
+        entry = Registry().get(agent_name)
+    except Exception:  # stx-allow: fallback (reason: registry IO best-effort)
+        return None
+    if not entry:
+        return None
+    config_path = entry.get("config")
+    if not config_path:
+        return None
+    try:
+        from scitex_agent_container.config import load_config
+
+        return load_config(config_path)
+    except Exception:  # stx-allow: fallback (reason: config load best-effort)
+        return None
+
+
 def resolve_agent_workspace(agent_name: str) -> tuple[dict, str | None]:
     """Resolve ``(mcp_servers, cwd)`` for a registered agent.
 
@@ -476,5 +547,37 @@ def build_sdk_options(
     if "Agent" not in _allowed:
         _allowed.append("Agent")
     kwargs["allowed_tools"] = _allowed
+
+    # PR #319: provider-aware tool REGISTRATION whitelist. When the
+    # agent routes through a non-Anthropic provider (LiteLLM / vLLM /
+    # gateway via ``spec.claude.provider``), restrict the registered
+    # built-in tool set so unrecognized newer Claude Code builtins
+    # (ExitPlanMode, BashOutput, KillShell) never enter the outbound
+    # API request body. See the module-level constant docstring for
+    # the root-cause + spec contract. Resolution order:
+    #
+    #   1. ``spec.claude.provider.allowed_tools`` (operator override) —
+    #      used verbatim; the operator KNOWS their shim's recognized set.
+    #   2. ``_PROVIDER_DEFAULT_ALLOWED_TOOLS`` (runner default) — the
+    #      LiteLLM-1.52.16-known set + Agent.
+    #
+    # Non-provider agents (real Anthropic backend) leave ``tools``
+    # unset → CLI registers its full default toolset (back-compat).
+    # The caller can also explicitly pass ``tools=...`` via ``extra``;
+    # an explicit caller value WINS over this auto-populate.
+    from ._apptainer_provider import provider_active
+
+    _provider_cfg = _load_agent_config_silent(agent_name)
+    if (
+        _provider_cfg is not None
+        and provider_active(_provider_cfg)
+        and "tools" not in kwargs
+    ):
+        provider = getattr(getattr(_provider_cfg, "claude", None), "provider", None)
+        spec_tools = list(getattr(provider, "allowed_tools", []) or [])
+        if spec_tools:
+            kwargs["tools"] = spec_tools
+        else:
+            kwargs["tools"] = list(_PROVIDER_DEFAULT_ALLOWED_TOOLS)
 
     return ClaudeAgentOptions(**kwargs)

--- a/tests/scitex_agent_container/config/_parsers/test__claude.py
+++ b/tests/scitex_agent_container/config/_parsers/test__claude.py
@@ -298,3 +298,83 @@ def test_provider_string_form_anthropic_sentinel_yields_no_override():
     result = parse_claude(spec)
     # Assert
     assert result.provider is None
+
+
+# ---------------------------------------------------------------------------
+# PR #319 (lead msg a456b610 2026-06-06): provider.allowed_tools whitelist.
+# Operator declares which built-in tools their shim recognizes; the runner
+# uses that to populate ClaudeAgentOptions.tools so unrecognized newer
+# Claude Code builtins (ExitPlanMode, BashOutput, KillShell) never enter
+# the outbound API request body. Root cause: LiteLLM 1.52.16's pydantic
+# Union mis-routes unrecognized tools → AnthropicComputerTool → 422.
+# ---------------------------------------------------------------------------
+
+
+def test_provider_dict_form_parses_allowed_tools_list():
+    # Arrange
+    spec = {
+        "claude": {
+            "provider": {
+                "base_url": "http://127.0.0.1:4000",
+                "auth_token_env": "VLLM_TOKEN",
+                "allowed_tools": ["Bash", "Read", "Edit"],
+            }
+        }
+    }
+    # Act
+    result = parse_claude(spec)
+    # Assert
+    assert result.provider.allowed_tools == ["Bash", "Read", "Edit"]
+
+
+def test_provider_dict_form_default_allowed_tools_is_empty_list():
+    # Arrange — back-compat: omit allowed_tools entirely.
+    spec = {
+        "claude": {
+            "provider": {
+                "base_url": "http://127.0.0.1:4000",
+                "auth_token_env": "VLLM_TOKEN",
+            }
+        }
+    }
+    # Act
+    result = parse_claude(spec)
+    # Assert — the runner treats [] as "use the runner default".
+    assert result.provider.allowed_tools == []
+
+
+def test_provider_dict_form_non_list_allowed_tools_coerces_to_empty():
+    # Arrange — defensive: a string-not-list (yaml quirk) coerces to [].
+    # The validator separately surfaces this as a loud config error;
+    # the parser keeps the agent from crashing while validation runs.
+    spec = {
+        "claude": {
+            "provider": {
+                "base_url": "http://127.0.0.1:4000",
+                "auth_token_env": "VLLM_TOKEN",
+                "allowed_tools": "Bash,Read",
+            }
+        }
+    }
+    # Act
+    result = parse_claude(spec)
+    # Assert
+    assert result.provider.allowed_tools == []
+
+
+def test_provider_dict_form_non_string_entries_filtered():
+    # Arrange — defensive: drop non-string entries so a partial-bad
+    # yaml doesn't propagate ints/None into ClaudeAgentOptions.tools.
+    spec = {
+        "claude": {
+            "provider": {
+                "base_url": "http://127.0.0.1:4000",
+                "auth_token_env": "VLLM_TOKEN",
+                "allowed_tools": ["Bash", 42, None, "Read", ""],
+            }
+        }
+    }
+    # Act
+    result = parse_claude(spec)
+    # Assert — only the valid non-empty strings survive.
+    assert result.provider.allowed_tools == ["Bash", "Read"]

--- a/tests/scitex_agent_container/config/test__provider_validation.py
+++ b/tests/scitex_agent_container/config/test__provider_validation.py
@@ -155,3 +155,57 @@ def test_active_predicate_false_for_missing_block():
     result = provider_is_active(block)
     # Assert
     assert result is False
+
+
+# ---------------------------------------------------------------------------
+# PR #319 (lead msg a456b610): provider.allowed_tools whitelist validation.
+# The field is optional; when present it must be a list of non-empty
+# strings. Loud errors on any other shape — silent type-coercion would
+# let a yaml string-not-list propagate into ClaudeAgentOptions.tools
+# and the CLI/SDK would fail in less actionable ways downstream.
+# ---------------------------------------------------------------------------
+
+
+def test_allowed_tools_field_absent_returns_no_errors():
+    # Arrange — back-compat: pre-PR#319 specs don't carry this field.
+    block = dict(_VALID_DICT)
+    # Act
+    errors = validate_provider(block)
+    # Assert
+    assert errors == []
+
+
+def test_allowed_tools_valid_list_of_strings_returns_no_errors():
+    # Arrange
+    block = dict(_VALID_DICT, allowed_tools=["Bash", "Read", "Edit"])
+    # Act
+    errors = validate_provider(block)
+    # Assert
+    assert errors == []
+
+
+def test_allowed_tools_string_not_list_returns_loud_error():
+    # Arrange — yaml-quirk: allowed_tools: "Bash,Read" instead of a list.
+    block = dict(_VALID_DICT, allowed_tools="Bash,Read")
+    # Act
+    errors = validate_provider(block)
+    # Assert
+    assert any("must be a list" in e for e in errors)
+
+
+def test_allowed_tools_with_empty_string_entry_returns_loud_error():
+    # Arrange
+    block = dict(_VALID_DICT, allowed_tools=["Bash", "", "Read"])
+    # Act
+    errors = validate_provider(block)
+    # Assert
+    assert any("[1]" in e for e in errors)
+
+
+def test_allowed_tools_with_non_string_entry_returns_loud_error():
+    # Arrange
+    block = dict(_VALID_DICT, allowed_tools=["Bash", 42, "Read"])
+    # Act
+    errors = validate_provider(block)
+    # Assert
+    assert any("[1]" in e for e in errors)

--- a/tests/scitex_agent_container/runtimes/test__sdk_common.py
+++ b/tests/scitex_agent_container/runtimes/test__sdk_common.py
@@ -644,6 +644,177 @@ class TestBuildOptions:
 
 
 # ---------------------------------------------------------------------------
+# PR #319 (lead msg a456b610 2026-06-06): provider-aware tool REGISTRATION
+# whitelist. When ``spec.claude.provider`` declares a non-Anthropic backend
+# (LiteLLM / vLLM / gateway), populate ``ClaudeAgentOptions.tools`` so the
+# CLI only REGISTERS the shim-recognized tool set — newer Claude Code
+# builtins (ExitPlanMode, BashOutput, KillShell) never enter the outbound
+# API request body. Root cause: LiteLLM 1.52.16's pydantic Union mis-routes
+# unrecognized tools → AnthropicComputerTool → 422 every turn.
+#
+# Resolution order tested:
+#   1. spec.claude.provider.allowed_tools (operator override) — verbatim.
+#   2. _PROVIDER_DEFAULT_ALLOWED_TOOLS (runner default) — when no spec list.
+#   3. Caller-supplied ``extra={"tools": ...}`` WINS over both above.
+#   4. No provider in cfg → ``tools`` left unset (back-compat).
+# ---------------------------------------------------------------------------
+
+
+def _swap_load_config_with_provider_tools(
+    env: _Env, workdir: str, *, base_url: str, allowed_tools: list[str] | None = None
+) -> None:
+    """Wire load_config to return a stub config with provider + allowed_tools.
+
+    The runner's provider gate consults
+    ``config.claude.provider.base_url`` (non-empty → active). We also
+    expose ``provider.allowed_tools`` so PR #319 can resolve from it.
+    Uses real SimpleNamespace (no monkeypatch of the predicate itself).
+    """
+    import scitex_agent_container.config as cfg_mod
+
+    provider_ns = SimpleNamespace(
+        base_url=base_url,
+        auth_token_env="API_KEY_ENV",
+        allowed_tools=list(allowed_tools or []),
+    )
+    claude_ns = SimpleNamespace(provider=provider_ns, account="")
+    config_ns = SimpleNamespace(expanded_workdir=workdir, claude=claude_ns)
+    env.setattr_module(cfg_mod, "load_config", lambda _path: config_ns)
+
+
+class TestProviderToolsWhitelist:
+    @pytest.fixture
+    def _opts_provider_default_tools(self, sdk_env: _Env, tmp_path):
+        # Arrange — provider active, allowed_tools NOT set in spec.
+        _write_valid_cred(sdk_env, tmp_path)
+        sdk_env.delenv("ANTHROPIC_API_KEY")
+        sdk_env.delenv(_SAC_KEY)
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        _swap_registry(sdk_env, {"config": "cfg.yaml"})
+        _swap_load_config_with_provider_tools(
+            sdk_env, str(ws), base_url="http://127.0.0.1:4000", allowed_tools=[]
+        )
+        # Act
+        opts = build_sdk_options("alpha", permission_mode="bypassPermissions")
+        return opts
+
+    def test_default_tools_excludes_exit_plan_mode(self, _opts_provider_default_tools):
+        # Arrange
+        opts = _opts_provider_default_tools
+        # Act
+        tools = list(opts.tools or [])
+        # Assert — the LiteLLM-1.52.16-incompatible builtin must NOT be
+        # in the runner-default whitelist; clew's v8 422 cascade was
+        # rooted in ExitPlanMode at tools[9] of the outbound body.
+        assert "ExitPlanMode" not in tools
+
+    def test_default_tools_includes_bash(self, _opts_provider_default_tools):
+        # Arrange
+        opts = _opts_provider_default_tools
+        # Act
+        tools = list(opts.tools or [])
+        # Assert — sanity: Bash is the most basic Claude Code builtin.
+        assert "Bash" in tools
+
+    def test_default_tools_includes_agent_for_subagents(
+        self, _opts_provider_default_tools
+    ):
+        # Arrange — Agent must be in the registration list AND
+        # allowed_tools (the existing subagent enablement); the PR #319
+        # default carries it so both lists stay coherent.
+        opts = _opts_provider_default_tools
+        # Act
+        tools = list(opts.tools or [])
+        # Assert
+        assert "Agent" in tools
+
+    @pytest.fixture
+    def _opts_provider_spec_tools(self, sdk_env: _Env, tmp_path):
+        # Arrange — operator OVERRIDES the default with an explicit
+        # allowed_tools list. The runner must honour it verbatim.
+        _write_valid_cred(sdk_env, tmp_path)
+        sdk_env.delenv("ANTHROPIC_API_KEY")
+        sdk_env.delenv(_SAC_KEY)
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        _swap_registry(sdk_env, {"config": "cfg.yaml"})
+        _swap_load_config_with_provider_tools(
+            sdk_env,
+            str(ws),
+            base_url="http://127.0.0.1:4000",
+            allowed_tools=["Bash", "Read"],
+        )
+        # Act
+        opts = build_sdk_options("alpha", permission_mode="bypassPermissions")
+        return opts
+
+    def test_spec_allowed_tools_overrides_default(self, _opts_provider_spec_tools):
+        # Arrange
+        opts = _opts_provider_spec_tools
+        # Act
+        tools = list(opts.tools or [])
+        # Assert — the operator's explicit list wins; the default
+        # (which would have added Edit/Write/Glob/etc.) must NOT leak.
+        assert tools == ["Bash", "Read"]
+
+    @pytest.fixture
+    def _opts_no_provider(self, sdk_env: _Env, tmp_path):
+        # Arrange — back-compat: real Anthropic backend (no provider
+        # block). PR #319's auto-populate must NOT touch ``tools``.
+        _write_valid_cred(sdk_env, tmp_path)
+        sdk_env.delenv("ANTHROPIC_API_KEY")
+        sdk_env.delenv(_SAC_KEY)
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        _swap_registry(sdk_env, {"config": "cfg.yaml"})
+        _swap_load_config(sdk_env, str(ws))  # no provider on the config
+        # Act
+        opts = build_sdk_options("alpha", permission_mode="bypassPermissions")
+        return opts
+
+    def test_no_provider_leaves_tools_unset(self, _opts_no_provider):
+        # Arrange
+        opts = _opts_no_provider
+        # Act
+        tools = opts.tools
+        # Assert — the CLI's full default toolset registers; suppressing
+        # ExitPlanMode/BashOutput/KillShell on an Anthropic backend that
+        # supports them would be a regression.
+        assert tools is None
+
+    @pytest.fixture
+    def _opts_caller_tools_wins(self, sdk_env: _Env, tmp_path):
+        # Arrange — provider active AND caller pre-supplies tools=
+        # via ``extra``. The caller's explicit value MUST win — the
+        # PR #319 auto-populate is "only when caller didn't say".
+        _write_valid_cred(sdk_env, tmp_path)
+        sdk_env.delenv("ANTHROPIC_API_KEY")
+        sdk_env.delenv(_SAC_KEY)
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        _swap_registry(sdk_env, {"config": "cfg.yaml"})
+        _swap_load_config_with_provider_tools(
+            sdk_env, str(ws), base_url="http://127.0.0.1:4000", allowed_tools=[]
+        )
+        # Act
+        opts = build_sdk_options(
+            "alpha",
+            permission_mode="bypassPermissions",
+            extra={"tools": ["OnlyThisOne"]},
+        )
+        return opts
+
+    def test_caller_tools_extra_wins_over_auto_populate(self, _opts_caller_tools_wins):
+        # Arrange
+        opts = _opts_caller_tools_wins
+        # Act
+        tools = list(opts.tools or [])
+        # Assert
+        assert tools == ["OnlyThisOne"]
+
+
+# ---------------------------------------------------------------------------
 # build_sdk_options — explicit --settings load (hooks/settings)
 #
 # setting_sources stays [] (machine-independence: no host ~/.claude


### PR DESCRIPTION
## Summary

Real root cause of clew bm172 cohort 422 cascade (lead msg a456b610 2026-06-06): LiteLLM 1.52.16's Anthropic shim doesn't recognize newer Claude Code builtins (ExitPlanMode, BashOutput, KillShell, added after the LiteLLM version pinned in the cohort's vLLM stack). The shim's pydantic Union of recognized AnthropicTool subclasses falls through to the last subclass (`AnthropicComputerTool`), which requires `display_width_px` — the unrecognized tool's payload doesn't have it → 422 on every API call → capsule errors all 60 turns.

The earlier "Computer schema" diagnosis was the discriminator-failure **symptom**, not the root cause. PR #318 (block Computer USE via `disallowed_tools`) is the wrong layer because Computer was never in the outbound body — ExitPlanMode was, mis-validated by LiteLLM's pydantic against AnthropicComputerTool. PR #318 merges separately on its defense-in-depth merits.

## Fix

When a provider backend is active, REGISTER only the shim-recognized tool set so unrecognized builtins never enter the outbound `tools[]` array.

`ClaudeAgentOptions.tools` is the registration knob (the SDK translates `tools=["Bash", ...]` to `--tools Bash,...` per `claude_agent_sdk/_internal/transport/subprocess_cli.py:241-250`). The CLI documents it as "the list of available tools from the built-in set". Setting it to the LiteLLM-known subset suppresses the rest at registration.

## Spec contract

```yaml
spec:
  claude:
    provider:
      base_url: http://127.0.0.1:4000
      auth_token_env: VLLM_TOKEN
      allowed_tools: [Bash, Read, Edit]    # NEW — optional list[str]
```

- **Operator override**: `spec.claude.provider.allowed_tools: list[str]` declares "my shim recognizes these N tools".
- **Default fallback** (`allowed_tools` absent or empty): the runner uses `_PROVIDER_DEFAULT_ALLOWED_TOOLS`, calibrated for LiteLLM 1.52.16 + the `Agent` subagent registrar:
  ```
  Bash, Read, Edit, Write, Glob, Grep, WebFetch, WebSearch, TodoWrite, Task, NotebookEdit, Agent
  ```
- **Gate**: `provider_active(cfg)` — non-provider agents (real Anthropic backend) leave `tools` unset → CLI's full default registers (back-compat unchanged).
- **Caller-supplied `extra={"tools": ...}`** wins over both — the auto-populate is "only when caller didn't say".

## Changes

- **`src/scitex_agent_container/config/_provider_types.py`** — `ProviderSpec.allowed_tools: list[str]` + docstring documenting the LiteLLM-Union-fall-through root cause + the registration-vs-permission distinction.
- **`src/scitex_agent_container/config/_parsers/_claude.py`** — `_parse_provider` (dict form) reads `allowed_tools` defensively (drops non-string / empty entries) so partial-bad YAML doesn't crash the runner; validator surfaces the loud diagnostic.
- **`src/scitex_agent_container/config/_provider_validation.py`** — Validates `allowed_tools` (when present) is `list[str]` of non-empty strings; loud per-index error otherwise.
- **`src/scitex_agent_container/runtimes/_sdk_common.py`** — `_PROVIDER_DEFAULT_ALLOWED_TOOLS` constant + `_load_agent_config_silent` helper + the gated auto-populate in `build_sdk_options`.

## Tests (+13 new, no MagicMock)

- `tests/.../config/_parsers/test__claude.py` (+4): parses verbatim, default empty when absent, defensive coercion, non-string entries filtered.
- `tests/.../config/test__provider_validation.py` (+5): absent → ok, valid → ok, string-not-list → loud, empty-string entry → loud, non-string entry → loud.
- `tests/.../runtimes/test__sdk_common.py` (+TestProviderToolsWhitelist, 6 tests): default excludes ExitPlanMode (the cohort root-cause builtin), default includes Bash + Agent (sanity), spec override wins, no provider → tools unset (back-compat), caller `extra={"tools":...}` wins over auto-populate.

## Test plan

- [x] 60/60 affected (parser + validator + sdk_common subset) pass locally.
- [ ] **CRITICAL pre-merge**: bind-test against clew's bm172 cohort capsule to empirically confirm `tools=` actually suppresses the unrecognized builtins from the outbound API body. `subprocess_cli.py:241-250` says it should, but PR #318's `disallowed_tools`-surprise (use-block-only despite docstring) means we verify before merge.
- [x] CI on the same gate as PRs #307-#318.

## Relationship to other in-flight work

- **PR #318** (Computer defense-in-depth) merges independently — different surfaces.
- **clew's upstream LiteLLM Union patch** races this PR; first green path unblocks the cohort.
- **Task #16** (spec.claude.flags / raw_options propagation gap): separate sac bug, follow-up PR.
- **Task #18** (empty tools array → LiteLLM 400 on title-gen): separate quirk, follow-up.
- **Task #19** (claude-agent-sdk upstream docstring fix): file upstream.

Registry-form provider (`provider: mimo`) `allowed_tools` plumbing is a follow-up; operators on the string form fall back to the runner default until that lands.
