### PR TITLE
fix(skills-audit): split 26_credentials-rotation.md to clear SK-301/SK-401 size budgets

### DIFF
--- a/src/scitex_agent_container/_skills/scitex-agent-container/26_credentials-rotation-host.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/26_credentials-rotation-host.md
@@ -1,0 +1,125 @@
+---
+description: |
+  [TOPIC] scitex-agent-container — host-side credential refresh ops + the one-refresher-per-account invariant.
+  [DETAILS] The bundled `claude` CLI's in-container access-token rotation + 30-min keepalive cron pattern; the one-account-one-refresher invariant that makes server-side refresh-token rotation safe; the `sac.accounts-refresh` host systemd-user timer with `--skip-active`; the `sac accounts watch-live` daemon that mirrors host re-logins into the sac store; `scitex-dev creds rotate-all` multi-account CI rotation. The on-disk model + auth mechanics live in [26_credentials-rotation.md](26_credentials-rotation.md).
+tags: [scitex-agent-container-credentials-rotation-host]
+---
+
+# SAC OAuth credentials: refresh + host-side ops
+
+> Companion to [26_credentials-rotation.md](26_credentials-rotation.md)
+> — that file covers what's on disk and how the SDK reaches it. This
+> file covers refresh mechanics, the rotation-race invariant, and the
+> host-side tooling that keeps the canonicals fresh.
+
+## 1. Auto-refresh — the bundled CLI does it; sac keeps a session live
+
+The bundled `claude` renews the **access** token in place ~5 min before
+expiry **while a session is active**. With the `:rw` snapshot bind the
+new token persists to the snapshot store; every other agent sharing
+that snapshot sees the fresh token on its next read.
+
+So the snapshot stays fresh **as long as something is talking to the
+account**. Standard pattern for **parked** accounts (no running pinned
+agent, not the host's interactive login):
+
+- **One per-account refresher agent** on the cheapest model
+  (`claude-haiku-4-5`), pinned via `spec.claude.account: <acct>`. Post-PR
+  #262 the live snapshot bind is automatic — no manual bind / custom
+  `CLAUDE_CONFIG_DIR` override needed.
+- **A 30-minute keepalive cron** that posts an A2A turn to each
+  refresher: `sac agents send <refresher> hello`. The turn forces the
+  bundled CLI to spin a session, observe the impending expiry, and
+  rotate the access token through the bind back to the snapshot.
+
+Every other agent on the same account benefits transparently — they all
+bind the same snapshot.
+
+> Mechanics note: the bundled `claude` CLI caches the refresh-token
+> **in memory** at session start; it does not re-read the snapshot
+> before each rotation. This is what makes the one-account-one-refresher
+> invariant load-bearing (§2). Any out-of-band rotator (e.g., a host
+> cron call against the same account) will invalidate the running
+> CLI's in-memory refresh-token server-side and 401 the next turn.
+
+## 2. One account, one refresher — the rotation-race invariant
+
+OAuth refresh-tokens **rotate server-side on every use**: each call to
+`/oauth/token` returns a new refresh-token AND invalidates the previous
+one with no grace window. Combined with the in-memory cache (§1), this
+means **at most one process can be the live refresher for any given
+account at any given time**:
+
+* **Pinned-and-running**: the in-container `claude` CLI inside the
+  pinned agent is the sole refresher. The host cron MUST skip the
+  account.
+* **Host's interactive login**: the operator's interactive `claude`
+  session is the sole refresher. The host cron MUST skip it (the
+  pre-existing `--skip-active` behaviour).
+* **Parked** (no pinned agent, no interactive session): the host cron
+  is the sole refresher. Safe to rotate; no in-memory cache to race.
+
+If two refreshers ever touch the same account concurrently, the loser's
+refresh-token is dead the moment the winner's `/oauth/token` returns.
+The loser then 401s on its next turn — even though the snapshot file
+on disk looks brand-new (the winner wrote it).
+
+**The host refresher cron** (`sac.accounts-refresh.service`, see §4)
+implements this invariant via `--skip-active`: the skip-set is the union
+of the host-active account and every account currently pinned by a
+running local agent (PR #299, commit `dea298d`). Stale-registry
+tolerance: a dead agent's leftover JSON over-skips its account
+(under-refresh — safe direction; recover with manual
+`sac accounts refresh <name>`). The opposite direction (over-refresh
+racing a live agent) was the 2026-06-03 ~hourly 401 storm that
+PR #299 closes structurally. See
+[ADR-0017](../../../../docs/adr/0017-credential-rotation-and-refresh-race.md)
+§ "Failure mode 2" + § "Why a symlink doesn't solve this".
+
+## 3. Multi-account CI rotation
+
+`for acct in ...; scitex-dev creds rotate-all --source $SAC_STORE --only pkgA --only pkgB ... --yes; done` splits CI auth across N Max accounts (lead 2026-05-29: 66 `scitex-*` divided 22-22-22 across 3). `--only` is repeatable.
+
+Non-negotiables:
+
+- **Silent-no-op trap.** Stale `--source` (`claudeAiOauth.expiresAt` in the past) exits **0 with zero stdout**. Verify first: `jq '.claudeAiOauth.expiresAt' <path>` vs `echo $(($(date +%s) * 1000))`.
+- **`--source` MUST be the sac store**, `~/.scitex/agent-container/accounts/<acct>/.credentials.json` (kept fresh by §5's daemon; what `sac accounts list` reads). The `~/.claude/.credentials-<acct>.json` canonicals from [26_credentials-rotation.md §1](26_credentials-rotation.md) are refreshed via `:rw` agent binds, NOT direct rotation — using them as `--source` silently fails when stale.
+
+## 4. The host refresher cron — `sac.accounts-refresh`
+
+A federated systemd-user timer fires `sac accounts refresh --all --skip-active` every 2h (`OnUnitActiveSec=2h`). It iterates the account store and rotates each unpinned account's tokens against `/oauth/token`. Registered as the `sac.accounts-refresh` JobSpec via `_jobs_plugin.py`; install with `sac dev systemd install --yes`.
+
+The `--skip-active` skip-set is the union of:
+
+1. **The host's interactive login** (`~/.claude/.credentials.json` resolved to a stored account name via `_resolve_active_account_name`).
+2. **Every account currently pinned by a running local agent** (`_collect_pinned_running_accounts`, post-PR #299, commit `dea298d`).
+
+Both subsets enforce the one-account-one-refresher invariant from §2. Diagnostic stderr lines name each excluded account with the reason so the operator can see what got skipped:
+
+```
+[skip-active] excluding active account 'ywatanabe-gmail-com'.
+[skip-active] excluding pinned-running account 'wyusuuke-gmail-com' (refresh-token rotation race guard).
+[skip-active] excluding pinned-running account 'ywatanabe-scitex-ai' (refresh-token rotation race guard).
+```
+
+Implementation: `cli_pkg/_account_refresh.py::account_refresh` (CLI wiring), `_collect_pinned_running_accounts(home)` (reads `~/.scitex/agent-container/runtime/registry/*.json` directly to avoid the `Registry` class's import-time `REGISTRY_DIR` freeze under pytest fixtures).
+
+## 5. The watch-live daemon — keeps the sac store fresh
+
+`sac accounts watch-live` runs `inotifywait -m ~/.claude/` for `close_write|moved_to|create` on `.credentials.json`; atomically copies each event into the matching sac-store path (slug-map e.g. `wyusuuke@gmail.com` → `wyusuuke-gmail-com`).
+
+Non-negotiables:
+
+- **NOT auto-started** — no systemd / launchd unit ships. If the daemon isn't running when `claude /login` refreshes, the sac store stays stale until `sac accounts sync-live` (one-shot fallback) or the daemon starts.
+
+Implementation: `_account/creds_watch.py` L140-152 (`watch_inotify()`), L99-133 (`watch_poll()` fallback); `_account/creds_sync.py` L141-244 (`sync_live()`), L69-77 (`slugify_email()`); `cli_pkg/_account_sync_live.py` L82-100+ (`account_watch_live` command).
+
+## See also
+
+- [26_credentials-rotation.md](26_credentials-rotation.md) — on-disk
+  model + auth mechanics (canonical → SDK + `:rw` bind + preflight).
+- [ADR-0017](../../../../docs/adr/0017-credential-rotation-and-refresh-race.md) —
+  canonical write-up of the rotation model + the two failure modes
+  (stale-COPY pre-#262, refresh-token race pre-#299).
+- [27_credentials-relogin.md](27_credentials-relogin.md) — verified
+  re-login flow (tmux code-paste) + 401-recovery design.

--- a/src/scitex_agent_container/_skills/scitex-agent-container/26_credentials-rotation.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/26_credentials-rotation.md
@@ -1,20 +1,22 @@
 ---
 description: |
-  [TOPIC] scitex-agent-container — SAC OAuth credentials rotation / refresh model for Claude Pro/Max accounts.
-  [DETAILS] Per-account `~/.claude/.credentials-<acct>.json` canonicals + mode-0600 symlinks; the `:rw` bind at `/tmp/sac-claude/.credentials.json` that lets the bundled CLI refresh access tokens in place (~5 min skew); the per-account COPY caveat in `_apptainer_creds.resolve_cred_file` that LOSES write-back when `spec.claude.account` is set; the preflight (300s skew, access-token only); per-account refresher agent + 30-min keepalive cron. Re-login flow lives in 27_credentials-relogin.md.
+  [TOPIC] scitex-agent-container — SAC OAuth credentials on-disk model + how the SDK reaches them inside the container.
+  [DETAILS] Per-account `~/.claude/.credentials-<acct>.json` canonicals + mode-0600 symlinks; the `:rw` dir-bind at `/tmp/sac-claude/.credentials.json` that lets the bundled CLI refresh access tokens in place (~5 min skew); the per-account snapshot bind (post-PR #262 — the COPY caveat is fixed); the preflight (300s skew, access-token only); access vs refresh token life stages. Refresh mechanics + host-side ops live in [26_credentials-rotation-host.md](26_credentials-rotation-host.md). Re-login flow in 27_credentials-relogin.md.
 tags: [scitex-agent-container-credentials-rotation]
 ---
 
-# SAC OAuth credentials: model + auto-refresh
+# SAC OAuth credentials: model + auth mechanics
 
 > Verified on `ywata-note-win` 2026-05-26.
-> Re-login flow (operator-in-loop, after refresh-token death):
+> Refresh + host-side ops (auto-refresh, the one-account-one-refresher
+> invariant, `sac.accounts-refresh` cron, `watch-live` daemon, CI
+> rotation): [26_credentials-rotation-host.md](26_credentials-rotation-host.md).
+> Re-login (after refresh-token death):
 > [27_credentials-relogin.md](27_credentials-relogin.md).
 
 Operator runbook for the **Anthropic OAuth credentials** SAC binds into
 every Claude-backed agent. Covers the on-disk model, the auth mechanics
-that make live refresh work, why some configurations silently lose
-write-back, and what the preflight catches.
+that make live refresh work, and what the preflight catches.
 
 Does **not** cover the API-key (`SAC_ANTHROPIC_API_KEY`) path — the
 preflight short-circuits on any API-key env (see
@@ -89,28 +91,23 @@ inside the container detects a near-expiry access token (~5 min skew),
 it writes the new token back through the bind to the host canonical.
 Without `:rw` the container 401s the moment the token expires.
 
-The **directory bind** (not a single-file bind) is what keeps the
-container's view in sync with host-side atomic-rename refreshes
-(`_account/creds_watch.py` watch-live mirror, `_account/creds_sync.py
-_atomic_copy`, `_account/claude_usage._refresh_access_token_at`).
-A single-file bind would survive the rename pointing at the old inode
-— visible as `...credentials.json//deleted` in
-`/proc/<pid>/mountinfo` — and the container reads the stale
-pre-rename token forever → 401 at natural expiry. See
-[ADR-0017](../../../../docs/adr/0017-credential-rotation-and-refresh-race.md)
-§ "Failure mode 1" for the empirical anchor (2026-06-04 03:00
-fleet-wide storm).
+The **directory bind** (not a single-file bind) is required because
+host-side refreshes rotate atomically via `write-tmp + rename`
+(`_account/creds_watch.py`, `_account/creds_sync.py`,
+`_account/claude_usage._refresh_access_token_at`). A single-file bind
+would survive the rename pointing at the old inode — visible as
+`...credentials.json//deleted` in `/proc/<pid>/mountinfo` — and the
+container would read the stale pre-rename token forever → 401 at
+natural expiry. See [ADR-0017](../../../../docs/adr/0017-credential-rotation-and-refresh-race.md)
+§ "Failure mode 1" for the 2026-06-04 03:00 fleet-wide storm empirical
+anchor.
 
-Scope acknowledgement for the unpinned dir-bind: `~/.claude/` contains
-more than just `.credentials.json` (settings.json, projects DB, chat
-history, MCP config). The dir-bind exposes these to the container,
-where the previous file-bind exposed only the creds file. The
-bundled in-container CLI already READS these via `CLAUDE_CONFIG_DIR`;
-the change is that it can now also WRITE to them. The recommended
-deployment is `spec.claude.account` pinning + the watch-live daemon
-(§ 6) mirroring the host-active account into the snapshot store, so
-the unpinned dir-bind is a degraded fallback for the host-active-login
-case only.
+Scope of the unpinned dir-bind: `~/.claude/` also contains
+settings.json, projects DB, chat history, MCP config — the dir-bind
+exposes (and now allows writes to) these. Recommended deployment is
+`spec.claude.account` pinning + the watch-live daemon
+([26_credentials-rotation-host.md §5](26_credentials-rotation-host.md))
+so the unpinned dir-bind is a degraded fallback only.
 
 Target lives under `/tmp/` (not `$HOME`) because D2 hardened preflight
 requires `$HOME` empty; `CLAUDE_CONFIG_DIR=/tmp/sac-claude` keeps SDK and
@@ -135,18 +132,12 @@ So:
   snapshot file** every other reader looks at.
 - The snapshot stays current. Every other agent on the same account
   sees the new tokens on its next read.
-- A directory bind (not a single-file bind) is required because the
-  bundled CLI rotates atomically via `write-tmp + rename` — a file
-  bind would survive that rename pointing at the old inode.
+- Directory bind, not single-file: same atomic-rename reason as above.
 
-**Historical caveat (pre-PR #262, NOW FIXED):** the runtime used to
-`shutil.copy2` the snapshot into the agent's own state dir and bind
-the copy. Refresh wrote to the agent-local copy; the snapshot never
-advanced; once the copy's refresh-token died the agent 401'd silently.
-That was the 2026-06-01 fleet-wide silent outage. PR #262 (commits
-`d70e608` + `acf2cbb`) eliminated the copy path. See
-[ADR-0017](../../../../docs/adr/0017-credential-rotation-and-refresh-race.md)
-§ "Failure mode 1" for the full story.
+PR #262 (commits `d70e608` + `acf2cbb`) eliminated an earlier
+`shutil.copy2` snapshot-into-agent-state-dir path that caused the
+2026-06-01 silent outage. See [ADR-0017](../../../../docs/adr/0017-credential-rotation-and-refresh-race.md)
+§ "Failure mode 1" for the historical story.
 
 ### Preflight (`_state/_preflight_creds.check_oauth_token_expiry`)
 
@@ -167,71 +158,7 @@ The first 401 is the first authoritative signal that the canonical
 needs operator recovery → see
 [27_credentials-relogin.md](27_credentials-relogin.md).
 
-## 3. Auto-refresh — the bundled CLI does it; sac keeps a session live
-
-The bundled `claude` renews the **access** token in place ~5 min before
-expiry **while a session is active**. With the `:rw` snapshot bind the
-new token persists to the snapshot store; every other agent sharing
-that snapshot sees the fresh token on its next read.
-
-So the snapshot stays fresh **as long as something is talking to the
-account**. Standard pattern for **parked** accounts (no running pinned
-agent, not the host's interactive login):
-
-- **One per-account refresher agent** on the cheapest model
-  (`claude-haiku-4-5`), pinned via `spec.claude.account: <acct>`. Post-PR
-  #262 the live snapshot bind is automatic — no manual bind / custom
-  `CLAUDE_CONFIG_DIR` override needed.
-- **A 30-minute keepalive cron** that posts an A2A turn to each
-  refresher: `sac agents send <refresher> hello`. The turn forces the
-  bundled CLI to spin a session, observe the impending expiry, and
-  rotate the access token through the bind back to the snapshot.
-
-Every other agent on the same account benefits transparently — they all
-bind the same snapshot.
-
-> Mechanics note: the bundled `claude` CLI caches the refresh-token
-> **in memory** at session start; it does not re-read the snapshot
-> before each rotation. This is what makes the one-account-one-refresher
-> invariant load-bearing (§3a). Any out-of-band rotator (e.g., a host
-> cron call against the same account) will invalidate the running
-> CLI's in-memory refresh-token server-side and 401 the next turn.
-
-## 3a. One account, one refresher — the rotation-race invariant
-
-OAuth refresh-tokens **rotate server-side on every use**: each call to
-`/oauth/token` returns a new refresh-token AND invalidates the previous
-one with no grace window. Combined with the in-memory cache (§3), this
-means **at most one process can be the live refresher for any given
-account at any given time**:
-
-* **Pinned-and-running**: the in-container `claude` CLI inside the
-  pinned agent is the sole refresher. The host cron MUST skip the
-  account.
-* **Host's interactive login**: the operator's interactive `claude`
-  session is the sole refresher. The host cron MUST skip it (the
-  pre-existing `--skip-active` behaviour).
-* **Parked** (no pinned agent, no interactive session): the host cron
-  is the sole refresher. Safe to rotate; no in-memory cache to race.
-
-If two refreshers ever touch the same account concurrently, the loser's
-refresh-token is dead the moment the winner's `/oauth/token` returns.
-The loser then 401s on its next turn — even though the snapshot file
-on disk looks brand-new (the winner wrote it).
-
-**The host refresher cron** (`sac.accounts-refresh.service`, see §5b)
-implements this invariant via `--skip-active`: the skip-set is the union
-of the host-active account and every account currently pinned by a
-running local agent (PR #299, commit `dea298d`). Stale-registry
-tolerance: a dead agent's leftover JSON over-skips its account
-(under-refresh — safe direction; recover with manual
-`sac accounts refresh <name>`). The opposite direction (over-refresh
-racing a live agent) was the 2026-06-03 ~hourly 401 storm that
-PR #299 closes structurally. See
-[ADR-0017](../../../../docs/adr/0017-credential-rotation-and-refresh-race.md)
-§ "Failure mode 2" + § "Why a symlink doesn't solve this".
-
-## 4. Expired ≠ unrecoverable — until the refresh token dies
+## 3. Expired ≠ unrecoverable — until the refresh token dies
 
 Credentials JSON carries `accessToken` (~8 h life) and `refreshToken`
 (multi-hour to multi-day). The bundled CLI quietly swaps an expired
@@ -245,56 +172,22 @@ Stages of death:
   session 401s. **Re-login required** — see
   [27_credentials-relogin.md](27_credentials-relogin.md).
 
-## 5. Multi-account CI rotation
-
-`for acct in ...; scitex-dev creds rotate-all --source $SAC_STORE --only pkgA --only pkgB ... --yes; done` splits CI auth across N Max accounts (lead 2026-05-29: 66 `scitex-*` divided 22-22-22 across 3). `--only` is repeatable.
-
-Non-negotiables:
-
-- **Silent-no-op trap.** Stale `--source` (`claudeAiOauth.expiresAt` in the past) exits **0 with zero stdout**. Verify first: `jq '.claudeAiOauth.expiresAt' <path>` vs `echo $(($(date +%s) * 1000))`.
-- **`--source` MUST be the sac store**, `~/.scitex/agent-container/accounts/<acct>/.credentials.json` (kept fresh by §6's daemon; what `sac accounts list` reads). The `~/.claude/.credentials-<acct>.json` canonicals from §1 are refreshed via `:rw` agent binds, NOT direct rotation — using them as `--source` silently fails when stale.
-
-## 5b. The host refresher cron — `sac.accounts-refresh`
-
-A federated systemd-user timer fires `sac accounts refresh --all --skip-active` every 2h (`OnUnitActiveSec=2h`). It iterates the account store and rotates each unpinned account's tokens against `/oauth/token`. Registered as the `sac.accounts-refresh` JobSpec via `_jobs_plugin.py`; install with `sac dev systemd install --yes`.
-
-The `--skip-active` skip-set is the union of:
-
-1. **The host's interactive login** (`~/.claude/.credentials.json` resolved to a stored account name via `_resolve_active_account_name`).
-2. **Every account currently pinned by a running local agent** (`_collect_pinned_running_accounts`, post-PR #299, commit `dea298d`).
-
-Both subsets enforce the one-account-one-refresher invariant from §3a. Diagnostic stderr lines name each excluded account with the reason so the operator can see what got skipped:
-
-```
-[skip-active] excluding active account 'ywatanabe-gmail-com'.
-[skip-active] excluding pinned-running account 'wyusuuke-gmail-com' (refresh-token rotation race guard).
-[skip-active] excluding pinned-running account 'ywatanabe-scitex-ai' (refresh-token rotation race guard).
-```
-
-Implementation: `cli_pkg/_account_refresh.py::account_refresh` (CLI wiring), `_collect_pinned_running_accounts(home)` (reads `~/.scitex/agent-container/runtime/registry/*.json` directly to avoid the `Registry` class's import-time `REGISTRY_DIR` freeze under pytest fixtures).
-
-## 6. The watch-live daemon — keeps the sac store fresh
-
-`sac accounts watch-live` runs `inotifywait -m ~/.claude/` for `close_write|moved_to|create` on `.credentials.json`; atomically copies each event into the matching sac-store path (slug-map e.g. `wyusuuke@gmail.com` → `wyusuuke-gmail-com`).
-
-Non-negotiables:
-
-- **NOT auto-started** — no systemd / launchd unit ships. If the daemon isn't running when `claude /login` refreshes, the sac store stays stale until `sac accounts sync-live` (one-shot fallback) or the daemon starts.
-
-Implementation: `_account/creds_watch.py` L140-152 (`watch_inotify()`), L99-133 (`watch_poll()` fallback); `_account/creds_sync.py` L141-244 (`sync_live()`), L69-77 (`slugify_email()`); `cli_pkg/_account_sync_live.py` L82-100+ (`account_watch_live` command).
+Refresh mechanics, the one-account-one-refresher invariant, and host-side
+ops (cron, watch-live daemon, CI rotation) are in
+[26_credentials-rotation-host.md](26_credentials-rotation-host.md).
 
 ## See also
 
+- [26_credentials-rotation-host.md](26_credentials-rotation-host.md) —
+  refresh mechanics + one-refresher invariant + host cron / watch-live /
+  CI rotation.
 - [ADR-0017](../../../../docs/adr/0017-credential-rotation-and-refresh-race.md) —
-  the canonical write-up of the rotation model + the two failure modes
-  (stale-COPY pre-#262, refresh-token race pre-#299) + the
-  one-account-one-refresher invariant + the symlink-doesn't-help
-  argument. Read this if you're touching `_apptainer_creds.py`,
-  `_apptainer_auth.py`, or `cli_pkg/_account_refresh.py`.
-- [27_credentials-relogin.md](27_credentials-relogin.md) — verified
-  re-login flow (tmux code-paste) + 401-recovery design.
+  canonical write-up of the rotation model + the two failure modes
+  (stale-COPY pre-#262, refresh-token race pre-#299).
+- [27_credentials-relogin.md](27_credentials-relogin.md) — re-login
+  (tmux code-paste) + 401-recovery design.
 - [25_claude-setup-delivery.md](25_claude-setup-delivery.md) — why
   `to_home/` is the wrong place for credentials; `setting_sources=[]`.
 - Source files cited: `runtimes/_sdk_common.py`,
   `runtimes/_apptainer_auth.py`, `runtimes/_apptainer_creds.py`,
-  `_state/_preflight_creds.py`, `cli_pkg/_account_refresh.py`.
+  `_state/_preflight_creds.py`.

--- a/src/scitex_agent_container/_skills/scitex-agent-container/SKILL.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/SKILL.md
@@ -30,7 +30,6 @@ session inside Apptainer (local or remote via SSH), observe via
 | Python API | `scitex_agent_container` (`AgentConfig`, `load_config`, `validate_config`, `Registry`; `agent.*`/`db.*`/`host.*`/`peer.*`) |
 | CLI | `scitex-agent-container`, `sac` — see [10_cli.md](10_cli.md) |
 | MCP servers | None bundled — agents spawn their own via `to_home/.mcp.json` |
-| Runtimes | `runtimes/claude_session.py` (SDK-native, default) + apptainer build helpers |
 | Config format | v3 `scitex-agent-container/v3` only — v2 rejected |
 
 ## Sub-skills
@@ -44,7 +43,7 @@ session inside Apptainer (local or remote via SSH), observe via
 - [06_http-api.md](06_http-api.md) — `POST /v1/turn` wire format (`spec.a2a.port` enables)
 
 ### Core
-- [01_config-v3.md](01_config-v3.md) — v3 config format (current); dir-as-SSoT (no `metadata.name`); v2-era `spec.remote`/`spec.skills`/`dot_claude`/top-level `spec.model` rejected
+- [01_config-v3.md](01_config-v3.md) — v3 format; dir-as-SSoT (no `metadata.name`); rejects v2-era `spec.remote`/`spec.skills`/`dot_claude`/`spec.model`
 - [02_multiplexer.md](02_multiplexer.md) — vestigial for agents (SDK runtime); lead-only tmux wrap
 - [03_auto-accept.md](03_auto-accept.md) — modular prompt handlers
 - [04_resource-management.md](04_resource-management.md) — resource management
@@ -53,8 +52,8 @@ session inside Apptainer (local or remote via SSH), observe via
 - [07_a2a-protocol.md](07_a2a-protocol.md) — native A2A protocol (`sac a2a serve`)
 - [07_a2a-protocol-extension-fields.md](07_a2a-protocol-extension-fields.md) — `x-scitex-agent-container.*` AgentCard fields
 - [08_templates.md](08_templates.md) — six pattern templates + examples
-- [14_claude-session-state.md](14_claude-session-state.md) — state-dir layout, auth precedence, `sdk_session` status, supervisor
-- [15_claude-session.md](15_claude-session.md) — claude-session SDK runner (inside the SIF) + `POST /v1/turn` inbound
+- [14_claude-session-state.md](14_claude-session-state.md) — state-dir layout, auth precedence, `sdk_session` status
+- [15_claude-session.md](15_claude-session.md) — SDK runner (in-SIF) + `POST /v1/turn` inbound
 - [16_claude-session-migration.md](16_claude-session-migration.md) — historical: claude-code → SDK migration
 - [17_inbound-turn-endpoint.md](17_inbound-turn-endpoint.md) — `POST /v1/turn` wire format + sidecar replacement
 - [18_full-agent-delegation.md](18_full-agent-delegation.md) — delegate to another *full* agent (vs Task subagent)
@@ -64,13 +63,14 @@ session inside Apptainer (local or remote via SSH), observe via
 - [10_cli.md](10_cli.md) — CLI commands and Python API
 - [11_remote-deploy.md](11_remote-deploy.md) — SSH deployment, src files, venv
 - [12_wsl-connectivity.md](12_wsl-connectivity.md) — WSL connectivity notes
-- [24_image-build.md](24_image-build.md) — apptainer `.sif` build/rebuild, `@develop` pin, rebuild-to-ship gotcha
-- [25_claude-setup-delivery.md](25_claude-setup-delivery.md) — `to_home`→`$HOME` 1:1 mirror, overlay/`--home`, `--settings` hook load
-- [26_credentials-rotation.md](26_credentials-rotation.md) — OAuth model: per-account symlinks, `:rw` bind, preflight, COPY caveat
+- [24_image-build.md](24_image-build.md) — apptainer `.sif` build/rebuild, rebuild-to-ship gotcha
+- [25_claude-setup-delivery.md](25_claude-setup-delivery.md) — `to_home`→`$HOME` mirror, overlay/`--home`, settings hook
+- [26_credentials-rotation.md](26_credentials-rotation.md) — OAuth model + auth mechanics (canonical, `:rw` bind, preflight)
+- [26_credentials-rotation-host.md](26_credentials-rotation-host.md) — refresh + one-refresher invariant + host cron / watch-live / CI rotation
 - [27_credentials-relogin.md](27_credentials-relogin.md) — verified re-login (tmux code-paste) + 401-recovery
 - [28_credential-refresh.md](28_credential-refresh.md) — refresh creds without restart; running agents re-read on next turn
 - [29_progress-reporting-to-lead.md](29_progress-reporting-to-lead.md) — milestone push to lead via a2a_send
-- [30_responsiveness-background-work.md](30_responsiveness-background-work.md) — short turns; heavy work to background so operator Telegram is answered within seconds
+- [30_responsiveness-background-work.md](30_responsiveness-background-work.md) — short turns; long work backgrounded so Telegram answers fast
 
 ### Reference
 - [13_observability.md](13_observability.md) — `sac agents status` JSON contract
@@ -82,8 +82,8 @@ session inside Apptainer (local or remote via SSH), observe via
 
 - [20_env-vars.md](20_env-vars.md) — `SCITEX_*` env vars read at runtime
 - [21_cli-startup-budget.md](21_cli-startup-budget.md) — keep `sac --help` < 500 ms via LazyGroup
-- [22_host-passthrough.md](22_host-passthrough.md) — `spec.mounts`/`spec.user`/`spec.env` for agents needing host fs / git / gh
-- [23_telegram-integration.md](23_telegram-integration.md) — Telegram fold: `_telegram/` bridge, `telegram_*` MCP tools, channel-push inbound, lead-only auth, per-token singleton
+- [22_host-passthrough.md](22_host-passthrough.md) — `spec.mounts`/`spec.user`/`spec.env` for host fs/git/gh access
+- [23_telegram-integration.md](23_telegram-integration.md) — Telegram bridge (`_telegram/`), `telegram_*` MCP tools, channel-push, lead-only auth
 
 ## 30-second start
 


### PR DESCRIPTION
## Summary

- **Real fix** for the develop `tests` workflow regression (all three matrix legs py3.11/3.12/3.13 fail on `tests/develop/test_audit.py::test_audit_all_clean`). The same regression makes PR #319 appear UNSTABLE.
- Root cause: `audit-skills` (scitex-dev) flagged two SK-rule size-budget violations on the `_skills/scitex-agent-container/` corpus; non-zero exit propagates through `scitex-dev ecosystem audit-all` into the pytest assertion.
  - **SK-301** `skill-md-over-budget`: `SKILL.md` = 6201 B / 98 lines (budget 6144 B / 120 lines) — 57 bytes over.
  - **SK-401** `leaf-over-budget`: `26_credentials-rotation.md` = 15369 B / 300 lines (budget 10240 B / 200 lines) — ~5 KB & 100 lines over.
- Fix is content-shape only — no mocks/skip/xfail, no audit bypass, no source code changes:
  - Split `26_credentials-rotation.md` along a natural seam.
    - **`26_credentials-rotation.md`** keeps §1 on-disk model, §2 auth mechanics (canonical → SDK + apptainer dir-bind + per-account bind + preflight), §4 access-vs-refresh life stages. → **193 lines / 8639 B**.
    - **`26_credentials-rotation-host.md`** (new sibling) holds §3 auto-refresh, §3a one-account-one-refresher invariant, §5 multi-account CI rotation, §5b `sac.accounts-refresh` host cron, §6 `watch-live` daemon. → **125 lines / 7976 B**. Cross-refs from the model leaf and SKILL.md repointed accordingly.
  - **`SKILL.md`**: add 26-host index entry, drop the "Runtimes" table row (covered by other links), tighten a handful of leaf-description suffixes to make room. → **98 lines / 6087 B**.

## Test plan

- [x] Confirmed audit_skills passes locally against the worktree's `_skills/scitex-agent-container/` (returns 0, `SUCC: no skills violations`).
- [x] All three changed/new files measured under their respective SK budgets.
- [ ] CI `tests` workflow goes green on all three Python versions for this PR.
- [ ] After merge to develop, PR #319's pytest-matrix turns green (this PR is its blocker; #319 itself is a structural LiteLLM tool-registration fix and is unrelated to the audit regression).