### PR TITLE
fix(sif/apt): add libglib2.0-0 to sac-base.def (scitex.io minimal-mode silent fallback)

### DIFF
--- a/src/scitex_agent_container/containers/apptainer-base.def
+++ b/src/scitex_agent_container/containers/apptainer-base.def
@@ -60,12 +60,21 @@ From: ubuntu:24.04
     # git/curl/ca-certificates/openssh-client are listed here so any
     # future base-image trim cannot silently drop them — sac runtime
     # hard-depends on each one (HTTPS verify chain, SSH dispatch, git).
+    #
+    # libglib2.0-0 is REQUIRED by the scitex stack: without it,
+    # libgthread-2.0.so.0 is missing and `import scitex.io` silently
+    # falls back to "minimal mode" — runs look green but lose the
+    # full IO surface. Caught by clew's capsule-0220918 cohort-A
+    # audit (2026-06-06); the silent fallback is the real bug, the
+    # missing system lib is the immediate fix. Added on the lib row
+    # because it's a runtime system library (no -dev companion needed
+    # for the consumers that hit the silent-fallback path).
     apt-get update
     apt-get install -y --no-install-recommends \
         ca-certificates curl wget gnupg \
         git openssh-client sshpass autossh git-crypt \
         build-essential pkg-config \
-        libffi-dev libssl-dev libgl1-mesa-dev libc6-dev \
+        libffi-dev libssl-dev libgl1-mesa-dev libc6-dev libglib2.0-0 \
         python3 python3-pip python3-venv python3-dev \
         locales tzdata \
         procps lsof strace less \


### PR DESCRIPTION
## Summary

- **Operator-directed env-standardization** (lead, 2026-06-06). Adds `libglib2.0-0` to `apptainer-base.def`'s `apt-get install` block — the missing system library whose absence was making `scitex.io` silently fall back to "minimal mode" inside sac-base.sif / sac-scitex.sif capsules. Caught by proj-paper-scitex-clew's capsule-0220918 cohort-A audit.
- `libglib2.0-0` provides `libgthread-2.0.so.0`; without it, `scitex.io`'s full DAG path can't load and silently degrades. Runs look green under the fallback, but the full IO surface is silently disabled — that silent fallback is the real underlying bug, the missing lib is the immediate fix.
- **Batched scope** confirmed with clew (a2a 8d1f78bbae1b…): clew's full env-pain-point list resolves to exactly **one** apt-installable item — `libglib2.0-0`. Everything else they enumerated is env-var / wrapper / shell-semantics, not SIF apt deps. A wider `__system_deps__` pass (lead's task #11 for proj-scitex-dev, "next session") can land as a separate PR / rebuild — this PR is intentionally narrow because the cohort-A blocker is real and worth shipping immediately.
- Edit only touches `apptainer-base.def`; `apptainer-scitex.def` Boots from `./sac-base.sif` (`Bootstrap: localimage`) so it inherits the new lib automatically — no companion edit needed.

## Post-merge handoff (per lead)

- Host SIF rebuild is the lead's (ywata-note-win has fakeroot/sudo; this container does not).
- Verification (lead, post-rebuild):
  - `python -c 'import ctypes; ctypes.CDLL("libgthread-2.0.so.0")'` succeeds.
  - `python -c 'import scitex.io as io; print(io.__file__)'` loads in **full** (not minimal) mode.
- New SIF deploys to every capsule on next agent restart.

## Test plan

- [x] `libglib2.0-0` confirmed absent from develop tip's apptainer-base.def apt-get block (lines 64-76).
- [x] Inline comment explains rationale + cohort-A anchor so a future trim won't silently re-drop it.
- [ ] CI green on this PR (no test impact expected — `.def` is build-time only).
- [ ] Lead rebuilds the SIF + verifies libgthread + scitex.io full mode.