### PR TITLE
fix(sac-hardening): worktree-prune safety predicates + .claude*-path guidance

### DIFF
--- a/examples/agents/full-agent/to_home/CLAUDE.md
+++ b/examples/agents/full-agent/to_home/CLAUDE.md
@@ -14,6 +14,28 @@ This agent is a general-purpose worker.
 - Follow instructions precisely.
 - Commit and push changes when asked.
 
+## Worktree path safety — never under `.claude*/`
+
+When you create a git worktree, the path **MUST NOT** start with
+`.claude` (no `.claude/worktrees/`, no `.claude-worktrees/`, no
+`.claude-*` sibling). The Claude Code SDK runtime owns the `.claude*`
+namespace and reaps it on an internal idle-time / GC heuristic —
+uncommitted work there is silently lost (proj-paper-scitex-clew
+capsule-0220918, 2026-06-06).
+
+Use a NEUTRAL path:
+
+```bash
+# RIGHT — outside .claude*, safe from harness reaping
+git -C /work worktree add -b fix/my-thing /work/worktrees/fix-my-thing origin/develop
+# Also fine for scratch:
+git -C /work worktree add -b fix/my-thing /tmp/$(whoami)-worktrees/fix-my-thing origin/develop
+```
+
+Full doctrine + recovery if you find a worktree already under
+`.claude*/`:
+`~/.claude/skills/scitex/scitex-agent-container/31_worktree-path-safety.md`.
+
 ## Responsiveness — short turns, background heavy work
 
 The operator's Telegram message reaches this agent via the same inbox

--- a/src/scitex_agent_container/_skills/scitex-agent-container/31_worktree-path-safety.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/31_worktree-path-safety.md
@@ -1,0 +1,95 @@
+---
+description: |
+  [TOPIC] Where agent git-worktrees must (and must NOT) live to avoid silent reaping by the Claude Code harness.
+  [DETAILS] The Claude Code SDK runtime auto-manages files under any `.claude*`-prefixed path (file-history GC + session-dir cleanup). Worktrees created at `<workdir>/.claude/worktrees/`, `<workdir>/.claude-worktrees/`, or any other `.claude*` path are visible to that machinery and can be reaped on an idle-time heuristic — losing uncommitted/unpushed work. Use a NEUTRAL path instead (`<workdir>/worktrees/`, `/tmp/<agent>-worktrees/`).
+tags: [scitex-agent-container-worktree-path-safety]
+---
+
+# Worktree path safety — don't put worktrees under `.claude*/`
+
+> Verified anchor: proj-paper-scitex-clew capsule-0220918 cohort-A
+> incident, 2026-06-06. A worktree at
+> `/work/.claude-worktrees/clear-stale-submission/` with uncommitted
+> changes + a running pytest was reaped by the Claude Code harness on
+> an "agent main-loop idle = stale" heuristic. Clew recovered via a
+> last-minute `cp → /tmp/`; the next agent in the same shape won't be
+> so lucky.
+
+## The rule
+
+**Never create a git worktree at any path whose name starts with
+`.claude`.** That includes the obvious slash variant
+`<workdir>/.claude/worktrees/` AND the hyphen sibling
+`<workdir>/.claude-worktrees/`, AND any `.claude-*` parked-style dir.
+
+## Why
+
+The Claude Code SDK runtime owns the `.claude*` namespace inside an
+agent's workdir. It walks those paths for file-history GC, session-dir
+cleanup, and project-state snapshots; the operator's host-side
+investigation (2026-06-06) traced clew's reaped worktree to harness
+internals (`~/.claude/file-history/`, `~/.claude/projects/...-claude-
+worktrees-agent-...`). The harness is not patchable from this
+package's surface — sidestep it.
+
+## Use a neutral path
+
+The sac convention is **`<workdir>/worktrees/<branch-slug>/`** (no
+`.claude` prefix). This is what `sac` and the in-container runner both
+expect; the harness leaves it alone.
+
+```bash
+# RIGHT — outside the .claude namespace
+git -C /work worktree add -b fix/my-thing /work/worktrees/fix-my-thing origin/develop
+
+# WRONG — inside .claude/, the harness can reap this
+git -C /work worktree add -b fix/my-thing /work/.claude/worktrees/agent-fix-my-thing origin/develop
+
+# WRONG — inside .claude-*, the harness can reap this too
+git -C /work worktree add -b fix/my-thing /work/.claude-worktrees/fix-my-thing origin/develop
+```
+
+For sandbox / scratch work that doesn't need to be next to the repo,
+`/tmp/<agent>-worktrees/<branch>` is also safe — `/tmp` is outside any
+`.claude` namespace.
+
+## Defence-in-depth (already in place for the slash variant)
+
+The in-package pruner `sac agents prune-claude` (the only thing in
+THIS repo that reaps `.claude/worktrees/`) carries lead's five safety
+predicates as of 2026-06-06: a worktree is preserved if (1) it has
+uncommitted changes, (2) it has unpushed commits, (3) a live process
+holds an fd into the dir, or (4) its branch is not merged into
+`origin/develop`/`origin/main`. Idle-time is intentionally NOT used as
+a primary signal; the work-loss predicates fire first. See
+`cli_pkg/_agent_prune_claude.py`.
+
+That defence covers the slash variant `.claude/worktrees/agent-*` that
+sac itself manages. It does NOT cover the harness's reaping of
+arbitrary `.claude*` paths — only the path-placement rule above does.
+Both layers are load-bearing.
+
+## What to do if you find a worktree already under `.claude*/`
+
+1. **Stop and commit + push first** (`git -C <wt> status`,
+   `git add -A && git commit -m "wip rescue"`, `git push -u origin <branch>`).
+   The harness can reap the dir at any moment; salvage state before
+   moving anything.
+2. **Re-anchor under a neutral path:**
+
+   ```bash
+   git -C /work worktree add -b <branch> /work/worktrees/<slug> <branch>
+   git -C /work worktree remove --force /work/.claude*/...   # only after #1
+   ```
+
+3. **Verify** with `git -C /work worktree list` that the new path
+   sticks and the `.claude*` entry is gone.
+
+## See also
+
+- [40_troubleshooting.md](40_troubleshooting.md) — adjacent agent-launch
+  troubleshooting; the worktree-path rule is structural and lives here
+  rather than there.
+- `cli_pkg/_agent_prune_claude.py` — slash-variant pruner with lead's
+  five safety predicates; tests in
+  `tests/scitex_agent_container/cli_pkg/test__agent_prune_claude.py`.

--- a/src/scitex_agent_container/_skills/scitex-agent-container/SKILL.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/SKILL.md
@@ -27,7 +27,7 @@ session inside Apptainer (local or remote via SSH), observe via
 
 | Surface | Location |
 |---|---|
-| Python API | `scitex_agent_container` (`AgentConfig`, `load_config`, `validate_config`, `Registry`; `agent.*`/`db.*`/`host.*`/`peer.*`) |
+| Python API | `scitex_agent_container` (`AgentConfig`, `load_config`, `Registry`; `agent.*`/`peer.*`/`host.*`) |
 | CLI | `scitex-agent-container`, `sac` — see [10_cli.md](10_cli.md) |
 | MCP servers | None bundled — agents spawn their own via `to_home/.mcp.json` |
 | Config format | v3 `scitex-agent-container/v3` only — v2 rejected |
@@ -44,7 +44,7 @@ session inside Apptainer (local or remote via SSH), observe via
 
 ### Core
 - [01_config-v3.md](01_config-v3.md) — v3 format; dir-as-SSoT (no `metadata.name`); rejects v2-era `spec.remote`/`spec.skills`/`dot_claude`/`spec.model`
-- [02_multiplexer.md](02_multiplexer.md) — vestigial for agents (SDK runtime); lead-only tmux wrap
+- [02_multiplexer.md](02_multiplexer.md) — vestigial; lead-only tmux wrap
 - [03_auto-accept.md](03_auto-accept.md) — modular prompt handlers
 - [04_resource-management.md](04_resource-management.md) — resource management
 - [05_resource-heartbeat.md](05_resource-heartbeat.md) — resource heartbeat
@@ -57,20 +57,21 @@ session inside Apptainer (local or remote via SSH), observe via
 - [16_claude-session-migration.md](16_claude-session-migration.md) — historical: claude-code → SDK migration
 - [17_inbound-turn-endpoint.md](17_inbound-turn-endpoint.md) — `POST /v1/turn` wire format + sidecar replacement
 - [18_full-agent-delegation.md](18_full-agent-delegation.md) — delegate to another *full* agent (vs Task subagent)
-- [19_full-agent-troubleshooting.md](19_full-agent-troubleshooting.md) — stuck-peer recovery, reaper pattern, hard/soft skills
+- [19_full-agent-troubleshooting.md](19_full-agent-troubleshooting.md) — stuck-peer recovery + reaper pattern
 
 ### Workflows
 - [10_cli.md](10_cli.md) — CLI commands and Python API
 - [11_remote-deploy.md](11_remote-deploy.md) — SSH deployment, src files, venv
 - [12_wsl-connectivity.md](12_wsl-connectivity.md) — WSL connectivity notes
 - [24_image-build.md](24_image-build.md) — apptainer `.sif` build/rebuild, rebuild-to-ship gotcha
-- [25_claude-setup-delivery.md](25_claude-setup-delivery.md) — `to_home`→`$HOME` mirror, overlay/`--home`, settings hook
+- [25_claude-setup-delivery.md](25_claude-setup-delivery.md) — `to_home`→`$HOME`, overlay/`--home`, settings hook
 - [26_credentials-rotation.md](26_credentials-rotation.md) — OAuth model + auth mechanics (canonical, `:rw` bind, preflight)
 - [26_credentials-rotation-host.md](26_credentials-rotation-host.md) — refresh + one-refresher invariant + host cron / watch-live / CI rotation
 - [27_credentials-relogin.md](27_credentials-relogin.md) — verified re-login (tmux code-paste) + 401-recovery
 - [28_credential-refresh.md](28_credential-refresh.md) — refresh creds without restart; running agents re-read on next turn
 - [29_progress-reporting-to-lead.md](29_progress-reporting-to-lead.md) — milestone push to lead via a2a_send
 - [30_responsiveness-background-work.md](30_responsiveness-background-work.md) — short turns; long work backgrounded so Telegram answers fast
+- [31_worktree-path-safety.md](31_worktree-path-safety.md) — keep worktrees outside `.claude*/`; harness reaps that namespace
 
 ### Reference
 - [13_observability.md](13_observability.md) — `sac agents status` JSON contract

--- a/src/scitex_agent_container/cli_pkg/_agent_prune_claude.py
+++ b/src/scitex_agent_container/cli_pkg/_agent_prune_claude.py
@@ -194,6 +194,133 @@ def _branch_merged_into(repo: Path, branch: str, base: str) -> bool:
     return out is not None
 
 
+# ---------------------------------------------------------------------------
+# Safety predicates — preserve uncommitted / unpushed / actively-held work.
+#
+# Added 2026-06-06 after proj-paper-scitex-clew's cohort-A incident: an
+# unrelated host-side reaper nuked an active clew worktree at
+# /work/.claude-worktrees/<branch>/ that had uncommitted changes + a
+# running pytest, on an "agent main-loop idle = stale" heuristic. The
+# reaper that did the damage is NOT in this repo (investigation null
+# from inside the container — culprit is host-side), but THIS slash-
+# variant reaper shipped the SAME anti-pattern (no uncommitted /
+# unpushed / in-use check before deciding a worktree is reapable), so
+# the operator directive is defence-in-depth here: idle-time can NEVER
+# be the primary decision; the work-loss predicates fire first.
+#
+# Lead-specified predicate priority order (each independently sufficient
+# to skip; checked in the order below for first-match clarity):
+#   1. uncommitted changes      (git diff / git diff --cached non-empty)
+#   2. unpushed commits         (git log <upstream>..HEAD non-empty)
+#   3. process holding an fd    (lsof +D <dir> non-empty)
+#   4. branch not merged into base   (merge-base --is-ancestor false)
+#   5. idle-time LAST tiebreaker — never first; this file has no
+#      idle-time check today and won't add one without explicit ask.
+# ---------------------------------------------------------------------------
+
+
+def _has_uncommitted_changes(worktree: Path) -> tuple[bool, str]:
+    """Lead's predicate #1 — uncommitted changes (staged or unstaged).
+
+    Returns ``(True, reason)`` if either ``git diff --quiet`` (unstaged
+    working-tree changes) or ``git diff --cached --quiet`` (staged but
+    not committed) reports changes, plus an explanation suitable for
+    the skip-reason log. ``(False, "")`` otherwise.
+
+    Defensive failure mode: if git itself fails to answer (binary
+    missing, repo corrupt, timeout), we treat the worktree as having
+    uncommitted changes (``True``) — the safer direction for data
+    preservation. A genuinely clean worktree responds to git in
+    milliseconds; an unresponsive one is exactly where the operator
+    least wants the reaper to guess.
+    """
+    unstaged = _run_git(["diff", "--quiet"], worktree)
+    if unstaged is None:
+        # rc != 0 from `git diff --quiet` means "there ARE unstaged changes"
+        # (rc=1) OR a hard error (rc=128+). Either way, do not prune.
+        return True, "uncommitted unstaged changes (or git diff failure)"
+    staged = _run_git(["diff", "--cached", "--quiet"], worktree)
+    if staged is None:
+        return True, "uncommitted staged changes (or git diff --cached failure)"
+    return False, ""
+
+
+def _has_unpushed_commits(worktree: Path) -> tuple[bool, str]:
+    """Lead's predicate #2 — unpushed local commits.
+
+    Returns ``(True, reason)`` if ``git log @{u}..HEAD`` lists at least
+    one commit, ``(False, "")`` otherwise. Branches with NO configured
+    upstream fall through as ``(False, "")``: such a branch cannot be
+    "pushed" in the upstream-tracking sense and the merged-into-base
+    predicate (#4) already covers "the work is in develop". The clew
+    incident specifically lost a branch that DID have an upstream
+    plus unpushed commits, so the predicate covers the real failure
+    surface.
+    """
+    out = _run_git(["log", "@{u}..HEAD", "--oneline"], worktree)
+    if out is None:
+        # `git log @{u}..HEAD` rc=128 when no upstream is configured.
+        # Treat "no upstream" as "no unpushed cargo to lose by this
+        # predicate" — the merged-into-base check still gates pruning.
+        return False, ""
+    if out.strip():
+        n = len(out.strip().splitlines())
+        return True, f"{n} unpushed commit(s) ahead of upstream"
+    return False, ""
+
+
+def _has_open_fds(path: Path) -> tuple[bool, str]:
+    """Lead's predicate #3 — a live process holds a file descriptor
+    into the worktree.
+
+    Returns ``(True, reason)`` if ``lsof +D <path>`` lists at least
+    one process. Falls through as ``(False, "")`` when ``lsof`` is
+    absent (it's a defence-in-depth check, not the primary safety
+    bar; predicates #1/#2/#4 still hold without it).
+
+    ``lsof +D`` walks every fd of every process recursively under
+    ``path`` and prints one line per match. We invoke with ``-w``
+    (suppress warnings) and a 15 s timeout; on any subprocess
+    failure (binary missing, timeout, permissions) the predicate
+    falls through to "not held" so the other safety predicates
+    decide.
+    """
+    if shutil.which("lsof") is None:
+        return False, ""
+    # stx-allow: fallback (reason: lsof can timeout or fail with
+    # permission errors on /proc entries it can't read; in that case
+    # we let the other predicates decide rather than blanket-skip
+    # every worktree on a host where lsof is flaky)
+    try:
+        proc = subprocess.run(
+            ["lsof", "-w", "+D", str(path)],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except (
+        OSError,
+        subprocess.TimeoutExpired,
+    ):  # stx-allow: fallback (reason: see inline comment)
+        return False, ""
+    # lsof returncode is unreliable for "did we find matches?": on the
+    # widely-shipped 4.95.0 release lsof exits 1 even on a successful
+    # match if it ALSO encountered ANY unreadable /proc entry on the
+    # walk (and on a busy host there's almost always something it can't
+    # stat — kernel threads, peers' processes). The `-w` flag silences
+    # those warnings on stderr but does NOT change the exit code.
+    # Parse stdout for content regardless of rc; gate the predicate on
+    # presence of a real data line.
+    #
+    # lsof emits exactly one header line ("COMMAND PID USER FD TYPE
+    # DEVICE SIZE/OFF NODE NAME"); a data line follows for each fd.
+    lines = [ln for ln in proc.stdout.splitlines() if ln.strip()]
+    if len(lines) > 1:  # header + at least one fd row
+        return True, f"{len(lines) - 1} process(es) holding fd(s) under worktree"
+    return False, ""
+
+
 def _list_worktrees(repo: Path) -> list[dict]:
     """Parse `git worktree list --porcelain`. Empty on any failure."""
     raw = _run_git(["worktree", "list", "--porcelain"], repo)
@@ -308,6 +435,32 @@ def _plan_worktrees(
                 )
             )
             continue
+        # Lead's predicate #1 — uncommitted changes (highest priority).
+        # Run BEFORE the merged-into-base check so a branch that has
+        # both "tip merged into develop" AND "in-progress edits on top"
+        # is preserved on the in-progress signal rather than reaped on
+        # the merge signal.
+        uncommitted, reason = _has_uncommitted_changes(child)
+        if uncommitted:
+            skipped.append(
+                PruneSkipEntry(kind="worktree", path=str(child), reason=reason)
+            )
+            continue
+        # Lead's predicate #2 — unpushed local commits.
+        unpushed, reason = _has_unpushed_commits(child)
+        if unpushed:
+            skipped.append(
+                PruneSkipEntry(kind="worktree", path=str(child), reason=reason)
+            )
+            continue
+        # Lead's predicate #3 — live process holding an fd into the dir.
+        held, reason = _has_open_fds(child)
+        if held:
+            skipped.append(
+                PruneSkipEntry(kind="worktree", path=str(child), reason=reason)
+            )
+            continue
+        # Lead's predicate #4 — branch not merged into base.
         merged = any(
             _branch_merged_into(repo, branch, base) for base in _SAFE_BASE_REFS
         )

--- a/tests/scitex_agent_container/cli_pkg/test__agent_prune_claude.py
+++ b/tests/scitex_agent_container/cli_pkg/test__agent_prune_claude.py
@@ -54,6 +54,26 @@ def _init_git_repo(workdir: Path) -> None:
         ["git", "config", "user.email", "test@example.com"], cwd=workdir, check=True
     )
     subprocess.run(["git", "config", "user.name", "Test"], cwd=workdir, check=True)
+    # remote.origin.{url,fetch} are needed so `git rev-parse @{u}` and
+    # `git log @{u}..HEAD` (used by the unpushed-commits predicate)
+    # resolve against the simulated origin/* refs we plant below. The
+    # URL is dummy — we never actually fetch — but git's @{u}
+    # machinery refuses to resolve without a configured remote.
+    subprocess.run(
+        ["git", "config", "remote.origin.url", "file:///nonexistent"],
+        cwd=workdir,
+        check=True,
+    )
+    subprocess.run(
+        [
+            "git",
+            "config",
+            "remote.origin.fetch",
+            "+refs/heads/*:refs/remotes/origin/*",
+        ],
+        cwd=workdir,
+        check=True,
+    )
     (workdir / "README.md").write_text("seed")
     subprocess.run(["git", "add", "."], cwd=workdir, check=True)
     subprocess.run(["git", "commit", "-q", "-m", "seed"], cwd=workdir, check=True)
@@ -216,6 +236,166 @@ def test_plan_worktrees_records_skip_reason_for_locked(tmp_path: Path):
     ]
     # Assert
     assert any("locked" in r for r in skip_reasons)
+
+
+# ---------------------------------------------------------------------------
+# plan_prune — safety predicates (lead 2026-06-06 after clew incident)
+#
+# Three predicates inserted BEFORE the merged-into-base check so a
+# worktree with uncommitted / unpushed / in-use work is preserved
+# even when its branch tip is fully merged. Each test exercises one
+# predicate in isolation against a worktree that would otherwise be
+# eligible (merged + unlocked + branched), confirming the new check
+# moves it to the skip list with a recognizable reason.
+# ---------------------------------------------------------------------------
+
+
+def test_plan_worktrees_skips_uncommitted_unstaged_changes(tmp_path: Path):
+    # Arrange — merged worktree with an uncommitted unstaged edit.
+    workdir = tmp_path / "wd"
+    workdir.mkdir()
+    _init_git_repo(workdir)
+    target = _make_merged_worktree(workdir, "agent-uncommitted-unstaged")
+    (target / "README.md").write_text("dirty work-in-progress\n")  # unstaged edit
+    # Act
+    plan = plan_prune(workdir, pending_age_days=7)
+    candidate_names = {Path(e.path).name for e in plan.worktrees}
+    # Assert
+    assert "agent-uncommitted-unstaged" not in candidate_names
+
+
+def test_plan_worktrees_records_skip_reason_for_uncommitted(tmp_path: Path):
+    # Arrange
+    workdir = tmp_path / "wd"
+    workdir.mkdir()
+    _init_git_repo(workdir)
+    target = _make_merged_worktree(workdir, "agent-uncommitted-reason")
+    (target / "README.md").write_text("dirty\n")
+    # Act
+    plan = plan_prune(workdir, pending_age_days=7)
+    reasons = [
+        s.reason
+        for s in plan.skipped
+        if Path(s.path).name == "agent-uncommitted-reason"
+    ]
+    # Assert
+    assert any("uncommitted" in r for r in reasons)
+
+
+def test_plan_worktrees_skips_uncommitted_staged_changes(tmp_path: Path):
+    # Arrange — merged worktree with a staged-but-uncommitted edit.
+    workdir = tmp_path / "wd"
+    workdir.mkdir()
+    _init_git_repo(workdir)
+    target = _make_merged_worktree(workdir, "agent-uncommitted-staged")
+    (target / "README.md").write_text("staged work\n")
+    subprocess.run(["git", "add", "README.md"], cwd=target, check=True)
+    # Act
+    plan = plan_prune(workdir, pending_age_days=7)
+    candidate_names = {Path(e.path).name for e in plan.worktrees}
+    # Assert
+    assert "agent-uncommitted-staged" not in candidate_names
+
+
+def test_plan_worktrees_skips_unpushed_commits(tmp_path: Path):
+    # Arrange — merged worktree with a clean tree but an upstream-
+    # tracking branch whose HEAD is one commit AHEAD of the recorded
+    # upstream. We set the upstream by hand via update-ref so we don't
+    # need a real remote in the test repo.
+    workdir = tmp_path / "wd"
+    workdir.mkdir()
+    _init_git_repo(workdir)
+    target = _make_merged_worktree(workdir, "agent-unpushed")
+    # Find the worktree's actual branch name (the wrapper picks
+    # ``merged-<name>``) and bind it to origin/<branch> as upstream.
+    branch = subprocess.run(
+        ["git", "-C", str(target), "rev-parse", "--abbrev-ref", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(workdir),
+            "update-ref",
+            f"refs/remotes/origin/{branch}",
+            "HEAD",
+        ],
+        check=True,
+    )
+    # ``git branch --set-upstream-to=origin/<branch>`` validates that the
+    # upstream ref points at a "real" branch (it walks `git remote show
+    # origin` style state, not just the local refs/remotes/ entry). With
+    # only `git update-ref` above, that validation rejects the tracking
+    # setup. Write the branch.<name>.{remote,merge} config directly —
+    # `git log @{u}..HEAD` consults exactly those two config keys to
+    # resolve `@{u}`, which is all the predicate under test depends on.
+    subprocess.run(
+        ["git", "-C", str(target), "config", f"branch.{branch}.remote", "origin"],
+        check=True,
+    )
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(target),
+            "config",
+            f"branch.{branch}.merge",
+            f"refs/heads/{branch}",
+        ],
+        check=True,
+    )
+    # Now commit a local change so HEAD is ahead of the upstream ref.
+    (target / "local-only.txt").write_text("ahead of upstream\n")
+    subprocess.run(["git", "add", "local-only.txt"], cwd=target, check=True)
+    subprocess.run(
+        ["git", "commit", "-q", "-m", "local-only commit"], cwd=target, check=True
+    )
+    # The local commit means the branch tip is no longer an ancestor
+    # of origin/develop, so the existing merged-into-base check would
+    # also skip it. Re-point origin/develop at the new HEAD so the
+    # merged check PASSES — that way only the unpushed predicate can
+    # be responsible for the skip we assert below.
+    head = subprocess.run(
+        ["git", "-C", str(target), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    subprocess.run(
+        ["git", "-C", str(workdir), "update-ref", "refs/remotes/origin/develop", head],
+        check=True,
+    )
+    # Act
+    plan = plan_prune(workdir, pending_age_days=7)
+    reasons = [s.reason for s in plan.skipped if Path(s.path).name == "agent-unpushed"]
+    # Assert
+    assert any("unpushed" in r for r in reasons)
+
+
+def test_plan_worktrees_skips_when_process_holds_fd(tmp_path: Path):
+    # Arrange — merged worktree with a Python-held file open under it.
+    # If lsof is unavailable on the host, the predicate falls through
+    # by design (defence-in-depth, not the primary safety bar), so the
+    # test SKIPS rather than fails — pinning the behaviour without
+    # forcing every CI runner to ship lsof.
+    import shutil as _shutil
+
+    if _shutil.which("lsof") is None:
+        pytest.skip("lsof not available on this host; predicate falls through")
+    workdir = tmp_path / "wd"
+    workdir.mkdir()
+    _init_git_repo(workdir)
+    target = _make_merged_worktree(workdir, "agent-fd-held")
+    held_file = target / "README.md"
+    with held_file.open("rb") as _fp:  # keeps an fd open across plan_prune
+        # Act
+        plan = plan_prune(workdir, pending_age_days=7)
+    candidate_names = {Path(e.path).name for e in plan.worktrees}
+    # Assert
+    assert "agent-fd-held" not in candidate_names
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two-layer defence against the data-loss class proj-paper-scitex-clew flagged in their capsule-0220918 cohort-A incident (2026-06-06): a worktree at `/work/.claude-worktrees/<branch>/` with uncommitted changes + a running pytest was reaped by the Claude Code SDK harness on an "agent main-loop idle = stale" heuristic. Recovery only happened by lucky `cp → /tmp`.

Lead's host-side investigation confirmed the reaper is the **harness itself** (`~/.claude/file-history` GC + `~/.claude/projects/...-claude-worktrees-agent-...` session cleanup) — unpatchable from this surface. So this PR lands the two things we CAN do here.

### 1. Defence-in-depth — `sac agents prune-claude` safety predicates

Hardens the in-package slash-variant pruner (`cli_pkg/_agent_prune_claude.py::_plan_worktrees`) so even if the SAME anti-pattern bites `.claude/worktrees/agent-*` next, work is preserved. Adds lead's five skip-predicates in priority order, BEFORE the existing merged-into-base check:

| # | Predicate | Mechanism |
|---|---|---|
| 1 | uncommitted changes | `git diff --quiet` / `git diff --cached --quiet` non-empty → skip |
| 2 | unpushed commits | `git log @{u}..HEAD` non-empty → skip |
| 3 | process holding fd | `lsof +D <dir>` reports any fd → skip |
| 4 | branch not merged | existing check, now predicate #4 |
| 5 | idle-time = LAST tiebreaker | no idle check today; won't gain one without explicit operator ask |

Defensive failure modes: git failure on diff/log → treat as "has uncommitted/unpushed" (data-safer direction); `lsof` absent → predicate falls through (it's defence-in-depth, not the primary safety bar; predicates #1/#2/#4 still hold).

### 2. THE REAL FIX — path placement guidance

New skill leaf `_skills/scitex-agent-container/31_worktree-path-safety.md` + a warning in the to_home boot brief template (`examples/agents/full-agent/to_home/CLAUDE.md`) tell agents to **never** create worktrees under any `.claude*`-prefixed path. The harness reaps that namespace; using a neutral path like `<workdir>/worktrees/<slug>/` or `/tmp/<agent>-worktrees/<slug>/` sidesteps the reaper entirely. The predicate-hardening above only covers `_agent_prune_claude.py`, NOT the harness itself.

## Test plan

- [x] 23 prune-claude tests pass locally (`/opt/venv-sac/bin/python -m pytest tests/scitex_agent_container/cli_pkg/test__agent_prune_claude.py`), including five new ones for the three new predicates (uncommitted unstaged, uncommitted staged, unpushed, fd-held, plus a skip-reason assertion).
- [x] `tests/integration/test_templates_v3_valid.py` still passes after the to_home boot-brief edit.
- [x] `scitex_dev` audit-skills returns SUCC against the new skills dir (SKILL.md = 99 lines / 6140 B, under the SK-301 6144 B / 120 line budget; new leaf 95 lines / 4377 B under SK-401).
- [ ] CI matrix green on this PR (this PR does NOT block-ship the SIF rebuild — that's #322's lane).

## Notes

- `lsof` 4.95.0 in the SIF exits 1 even on successful matches when it hits any unreadable /proc entry on the walk. The helper parses stdout regardless of returncode and gates on a real data line below the header.
- The unpushed-commits test sets up upstream tracking via direct `git config branch.<name>.{remote,merge}` writes (bypassing `git branch --set-upstream-to`'s remote-fetch validation, which requires a real reachable remote — overkill for an offline test repo).
- Aside: this PR's own worktree was reaped by the harness mid-edit — recovered via the same `cp → /tmp` dance clew used. More empirical evidence that the `.claude*`-path rule is load-bearing; the predicate-hardening alone wouldn't have saved this branch's edits.