### PR TITLE
fix(telegram-wake): loud diagnostics + host-side preflight for bug #41

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_start.py
+++ b/src/scitex_agent_container/_lifecycle/_start.py
@@ -316,6 +316,26 @@ def agent_start(
     # ``sac listen`` can find the port via state.db without re-parsing
     # the spec.yaml.
     resolve_a2a_port(config)
+
+    # Bug #41 preflight — refuse to start when spec.claude.channels
+    # requests ``server:claude-code-telegrammer`` but spec.a2a.port is
+    # unset/null. Without the /v1/turn endpoint the standalone
+    # telegrammer poller has no URL to POST inbound Telegram to and an
+    # idle agent silently won't wake. Catching this here makes the
+    # misconfig loud at ``sac agents start`` time rather than the
+    # operator discovering it via "agent doesn't reply to Telegram"
+    # three messages later. See ``runtimes/_sdk_channels.
+    # validate_telegrammer_wake_wiring`` for the contract; F3 (MCP key
+    # mis-keyed in to_home/.mcp.json) is covered by the matching
+    # runner-side WARN/ERROR logs in ``_wire_telegrammer_wake``.
+    from ..runtimes._sdk_channels import validate_telegrammer_wake_wiring
+
+    validate_telegrammer_wake_wiring(
+        getattr(config.claude, "channels", None),
+        getattr(config.a2a, "port", None),
+        agent_name=config.name,
+    )
+
     runtime_factory = runtime_factory or _get_runtime
     runtime = runtime_factory(config)
 

--- a/src/scitex_agent_container/_skills/scitex-agent-container/23_telegram-integration.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/23_telegram-integration.md
@@ -1,96 +1,95 @@
 ---
 description: |
-  [TOPIC] Telegram fold — sac MCP transport tools + channel-push inbound.
-  [DETAILS] Phase 2+3 wiring: TelegramBridge runs in the sac MCP server,
-  long-polls Telegram, emits notifications/claude/channel on inbound,
-  and backs the six telegram_* MCP tools on outbound. Covers the
-  launcher dependency on --dangerously-load-development-channels, the
-  per-bot-token flock with stale-PID recovery, and the lead-only auth
-  gate via LEAD_TELEGRAM_AUTH_TOKEN.
+  [TOPIC] Per-agent Telegram bot wake contract — how an idle SDK agent picks up an inbound Telegram message.
+  [DETAILS] Each agent runs its OWN claude-code-telegrammer stdio MCP (declared in to_home/.mcp.json under the key `claude-code-telegrammer`). sac's runner injects `CLAUDE_CODE_TELEGRAMMER_TURN_URL=http://127.0.0.1:<a2a_port>/v1/turn` into that MCP's env when `spec.claude.channels` contains `server:claude-code-telegrammer` AND `spec.a2a.port` is set. The standalone telegrammer poller POSTs each inbound to that URL so an IDLE agent wakes (push ≡ in-session channel). The legacy in-sac `_telegram/` bridge was dropped (`refactor(telegram): drop telegram subsystem from sac`) — this skill documents the current per-agent path + the loud diagnostics that fire when any gate fails.
 tags: [scitex-agent-container-telegram-integration]
 ---
 
-# Telegram integration (Phase 2 + 3)
+# Telegram integration — per-agent wake contract
 
-The `_telegram/` package folds claude-code-telegrammer's transport surface
-into sac MCP. The lead's Claude session owns the bot token and emits
-`notifications/claude/channel` for inbound messages; subagents reach
-Telegram via the `telegram_*` MCP tools through the same in-process bridge.
+## Design
 
-## When this skill is relevant
+Each agent runs its OWN Telegram bot via a `claude-code-telegrammer` stdio
+MCP declared in the spec's `to_home/.mcp.json`. The in-sac `_telegram/`
+bridge from earlier phases was retired (`refactor(telegram): drop telegram
+subsystem from sac`). The current path:
 
-* You need to send a Telegram message from a sac agent.
-* You're debugging why inbound Telegram messages aren't reaching Claude.
-* You're audit-checking the per-bot-token lock or the auth-token gate.
+1. Operator's `spec.claude.channels` lists `server:claude-code-telegrammer`.
+2. Operator's `to_home/.mcp.json` declares a stdio MCP under the key
+   `claude-code-telegrammer` (the bun/ts standalone telegrammer process).
+3. sac's runner (`runtimes/_sdk_channels.apply_channels`) injects
+   `CLAUDE_CODE_TELEGRAMMER_TURN_URL=http://127.0.0.1:<spec.a2a.port>/v1/turn`
+   into that MCP entry's env when (1) AND (2) hold AND `spec.a2a.port` is
+   set. Operator-pre-set value wins.
+4. Claude Code spawns the telegrammer MCP as a stdio subprocess.
+5. The telegrammer JS poller (`ts/lib/wake.ts` in the standalone repo) reads
+   `CLAUDE_CODE_TELEGRAMMER_TURN_URL` and on each allowed inbound POSTs the
+   message to that URL.
+6. The runner's `/v1/turn` handler (`_runners/_session_http.py::serve_inbound`)
+   queues a `TurnEnvelope` onto an `asyncio.Queue`. The conversation task
+   drains it, drives a turn through the persistent SDK client, replies.
 
-## Quick check — is the bridge running?
+`<channel>` rendering in the AGENT's session requires the dev-channels
+flag, which `apply_channels` sets to the comma-joined channel set whenever
+ANY `spec.claude.channels` entry is present — the foreign-channel
+generalisation guarded by `test__sdk_channels.py`.
 
-```python
-from scitex_agent_container._telegram import get_bridge
+## Required spec shape
 
-bridge = get_bridge()
-print(bridge is None)        # True on subagents; False on the lead
-print(bridge.is_running)     # True after start(), False before
-print(bridge.allowed_users)  # ['123456']
+```yaml
+spec:
+  a2a:
+    port: auto          # MUST NOT be null/missing; the /v1/turn endpoint
+                        # is the wake URL the telegrammer POSTs to.
+  claude:
+    channels:
+      - server:claude-code-telegrammer  # exact string (whitespace tolerated)
+  # to_home/.mcp.json (sibling file) must contain:
+  #   "mcpServers": {"claude-code-telegrammer": {...stdio entry...}}
 ```
 
-## Inbound flow (Telegram → Claude)
+The MCP entry key MUST be `claude-code-telegrammer` (literal). Any other
+key — `telegrammer`, `claude-telegrammer`, `tg-bot`, etc. — bypasses the
+env injection and the JS poller has no wake URL.
 
-1. Bridge long-polls Telegram with `getUpdates`.
-2. Each update is filtered through `TelegramSpec.allowed_users` — an
-   empty list fails closed (nobody allowed). The filter compares
-   `update.message.from.id` against the list.
-3. Allowed updates become a `{"content": <text>, "meta": {...}}` payload
-   on the bridge's `notifier` callable. `_mcp/server.py` wires that
-   callable to the MCP session, which emits a
-   `notifications/claude/channel` push.
-4. Claude renders `<channel source="telegram" chat_id=... message_id=...
-   user_id=... username=...>` to the running session.
+## Failure surface + diagnostics (bug #41 hardening, 2026-06-07)
 
-**Launcher dependency**: Claude Code only delivers
-`notifications/claude/channel` pushes when the launcher is invoked with
-`--dangerously-load-development-channels server:scitex-agent-container`.
-Without it the notification is silently dropped. The bridge logs a WARN
-at startup to make the dependency visible; check the MCP server's stderr.
+Each silent-skip in `_wire_telegrammer_wake` used to look identical at the
+operator level: "I message my bot, the agent doesn't reply." The wake
+helper now LOGs every skip path; the host-side preflight
+`validate_telegrammer_wake_wiring` (called from `_lifecycle/_start.py`)
+HARD-FAILS the start when the wiring provably won't succeed.
 
-## Outbound flow (Claude → Telegram)
+| Failure | Where it surfaces | Operator fix |
+|---|---|---|
+| `server:claude-code-telegrammer` absent from channels | Silent no-op (intentional — channel not requested) | Add the channel to spec.claude.channels |
+| `spec.a2a.port` is null | `validate_telegrammer_wake_wiring` raises `TelegrammerWakeWiringError` at `sac agents start` time | Set spec.a2a.port to 'auto' or an explicit free int |
+| `to_home/.mcp.json` missing the `claude-code-telegrammer` MCP entry | Runner-side ERROR log: "no MCP entry keyed 'claude-code-telegrammer' found" | Add the MCP entry under the canonical key |
+| `to_home/.mcp.json` entry malformed (`env` not a dict) | Runner-side WARN log | Fix the entry's `env` to be an object |
+| Operator pre-set `CLAUDE_CODE_TELEGRAMMER_TURN_URL` | Runner-side INFO log: "pre-set by operator … not overridden" | Verify the pre-set URL actually points at THIS agent's /v1/turn |
+| Wake URL successfully wired | Runner-side INFO log: "telegrammer wake wired" | Nothing — verify by tailing runner stderr |
 
-The six MCP tools all share the same shape:
+## How to verify on a running agent
 
-* `telegram_send(chat_id, text, reply_to=None)`
-* `telegram_reply(chat_id, text, row_id=None, reply_to=None, mark_read=True)`
-* `telegram_react(chat_id, message_id, emoji)`
-* `telegram_edit_message(chat_id, message_id, text)`
-* `telegram_download_attachment(file_id, dest_dir=None)`
-* `telegram_send_document(chat_id, path, caption=None)`
+```bash
+# 1. Confirm the channel + port are configured.
+sac agents inspect <name> --json | jq '.spec.claude.channels, .spec.a2a.port'
 
-Each tool checks the caller's `LEAD_TELEGRAM_AUTH_TOKEN` against the
-bridge's stored token. Subagents inherit a sanitised env without the
-token, so they get `{"error": "telegram tools are lead-only; ..."}` and
-the bridge is never touched.
+# 2. Confirm the MCP entry key.
+jq '.mcpServers["claude-code-telegrammer"]' \
+  ~/.scitex/agent-container/agents/<name>/to_home/.mcp.json
 
-## Feature flag
+# 3. Tail the runner stderr for the wake-wiring log.
+sac agents logs <name> --stderr | grep -i 'telegrammer wake'
 
-Default ON in Phase 3 (was opt-in in Phase 1). Set
-`SCITEX_AGENT_CONTAINER_TELEGRAM_FOLD=0` to disable tool registration on
-this server.
+# 4. End-to-end: message the bot when the agent is idle, watch for a reply.
+```
 
-## Singleton lock
+## Out of scope (not in this repo)
 
-The bridge takes an exclusive `flock` at
-`~/.scitex/agent-container/runtime/telegram/<token-hash>.lock` (note:
-`runtime/`, not `containers/`). Stale-PID recovery: if the recorded PID
-is dead (`kill(pid, 0)` → `ESRCH`), the lock is reclaimed automatically.
-This is the failure mode the standalone telegrammer suffers from
-(crashed PID leaves a dangling file; future starts block until manual
-`rm`).
-
-If you ever see `TelegramLockError: telegram bridge lock ... is held by
-another live process`, run `ps -p <pid>` on the recorded PID to confirm
-the holder. The bridge will not start a second poller against the same
-bot token — Telegram returns 409 Conflict on dual `getUpdates`.
-
-## Don't touch
-
-* `~/proj/claude-code-telegrammer/` — being retired for sac-fleet use.
-* The Phase 1 stubs — replaced; the import surface is unchanged.
+The JS-side telegrammer (`ts/lib/wake.ts`) is in the standalone
+[claude-code-telegrammer](https://github.com/ywatanabe1989/claude-code-telegrammer)
+repo. If the env var is set but the agent still doesn't wake, the JS
+poller may not be reading + POSTing — file that upstream. The Python-side
+INFO log "telegrammer wake wired" confirms sac did its half; an idle
+agent that still doesn't wake after that points at the JS side.

--- a/src/scitex_agent_container/runtimes/_sdk_channels.py
+++ b/src/scitex_agent_container/runtimes/_sdk_channels.py
@@ -25,13 +25,29 @@ Two separate concerns, gated independently:
       sidecar is sac's own bus adapter; it must never be auto-wired for a
       foreign channel. Backing MCPs for non-sac channels come from the
       spec's ``to_home/.mcp.json`` (already merged into ``mcp_servers``).
+
+Wake-on-push diagnostics (bug #41 hardening, 2026-06-07):
+  ``_wire_telegrammer_wake`` (concern (c)) used to silently no-op on every
+  misconfig path. Operator complaint: agents look dead on inbound Telegram
+  for any of N reasons (missing channel name, missing a2a port, missing
+  MCP entry, etc.), with no signal pointing at the root cause. Every skip
+  path now emits a WARN-or-ERROR-level log so the operator (or anyone
+  reading the runner stderr) can see exactly which gate failed. The
+  matching host-side preflight ``validate_telegrammer_wake_wiring`` runs
+  in ``_lifecycle/_start.py`` and HARD-ERRORS the start if the channel is
+  requested but the wake URL provably won't wire — that catches the
+  misconfig BEFORE the agent boots, instead of after the operator's third
+  un-replied Telegram message.
 """
 
 from __future__ import annotations
 
 import json as _json
+import logging as _logging
 import os as _os
 from pathlib import Path as _Path
+
+_log = _logging.getLogger(__name__)
 
 
 def merge_home_mcp_servers(mcp_servers: dict) -> dict:
@@ -191,25 +207,156 @@ def _wire_telegrammer_wake(
 
     Gated: only when the channel set requests the telegrammer channel, the
     merged ``mcp_servers`` actually carries the backing entry, and the runner
-    has an ``a2a_port`` (so a ``/v1/turn`` endpoint exists). No-op otherwise —
-    e.g. an interactive CLI with no a2a port keeps the notification-only path.
+    has an ``a2a_port`` (so a ``/v1/turn`` endpoint exists). Each skip path
+    LOGS the reason at WARN/ERROR (bug #41 hardening, 2026-06-07): a silent
+    no-op looks indistinguishable from a bug in the standalone telegrammer JS
+    poller, which trapped the operator in a multi-day "why doesn't my agent
+    wake?" guessing game. Loud diagnostics make the root cause obvious to
+    whoever is reading the runner stderr.
     Never overrides an explicit operator-set TURN_URL in the spec.
     """
     if not any(c.strip() == _TELEGRAMMER_CHANNEL for c in channels):
+        # Channel not requested — nothing to wire and nothing to warn about.
         return
+    # From here down the operator requested the telegrammer channel, so any
+    # gate that drops the wake wiring IS a misconfig worth surfacing.
     if a2a_port is None:
+        _log.warning(
+            "telegrammer wake NOT wired for %r: spec.a2a.port is unset (None) "
+            "but channel %r is requested; without an /v1/turn endpoint the "
+            "standalone telegrammer has no URL to POST inbound Telegram "
+            "messages to, so an idle agent will not wake on Telegram. Fix: "
+            "set spec.a2a.port to 'auto' or an explicit int.",
+            _TELEGRAMMER_CHANNEL,
+            _TELEGRAMMER_CHANNEL,
+        )
         return
     mcps = kwargs.get("mcp_servers")
     if not isinstance(mcps, dict):
+        _log.warning(
+            "telegrammer wake NOT wired: kwargs['mcp_servers'] is %r, not a "
+            "dict; the channel %r is requested but the runner cannot inject "
+            "CLAUDE_CODE_TELEGRAMMER_TURN_URL into a malformed mcp_servers "
+            "table. Likely caller bug.",
+            type(mcps).__name__,
+            _TELEGRAMMER_CHANNEL,
+        )
         return
     entry = mcps.get(_TELEGRAMMER_MCP_KEY)
     if not isinstance(entry, dict):
+        _log.error(
+            "telegrammer wake NOT wired: channel %r is requested but no MCP "
+            "entry keyed %r found in mcp_servers (current keys: %r). The "
+            "agent's to_home/.mcp.json must declare an MCP entry under that "
+            "exact key — the standalone bun/ts telegrammer process keyed any "
+            "other name will not receive CLAUDE_CODE_TELEGRAMMER_TURN_URL "
+            "and an idle agent will not wake on Telegram. Add the entry to "
+            "to_home/.mcp.json under the canonical key %r.",
+            _TELEGRAMMER_CHANNEL,
+            _TELEGRAMMER_MCP_KEY,
+            sorted(mcps.keys()),
+            _TELEGRAMMER_MCP_KEY,
+        )
         return
     env = entry.setdefault("env", {})
     if not isinstance(env, dict):
+        _log.warning(
+            "telegrammer wake NOT wired: mcp_servers[%r]['env'] is %r, not a "
+            "dict; cannot inject CLAUDE_CODE_TELEGRAMMER_TURN_URL. Fix the "
+            "to_home/.mcp.json entry's env to be an object.",
+            _TELEGRAMMER_MCP_KEY,
+            type(env).__name__,
+        )
         return
+    wired_url = f"http://127.0.0.1:{int(a2a_port)}/v1/turn"
     # Operator-set value wins (explicit > inferred).
-    env.setdefault(
+    existing = env.get(_TELEGRAMMER_TURN_URL_ENV)
+    if existing is not None and existing != wired_url:
+        _log.info(
+            "telegrammer wake URL pre-set by operator: %r (auto-wired value "
+            "would have been %r). Operator override preserved; verify the "
+            "pre-set URL actually points at this agent's /v1/turn.",
+            existing,
+            wired_url,
+        )
+    env.setdefault(_TELEGRAMMER_TURN_URL_ENV, wired_url)
+    _log.info(
+        "telegrammer wake wired: %s=%r injected into mcp_servers[%r].env",
         _TELEGRAMMER_TURN_URL_ENV,
-        f"http://127.0.0.1:{int(a2a_port)}/v1/turn",
+        env[_TELEGRAMMER_TURN_URL_ENV],
+        _TELEGRAMMER_MCP_KEY,
     )
+
+
+# ---------------------------------------------------------------------------
+# Host-side preflight (called from ``_lifecycle/_start.py``).
+#
+# The runner-side wake-wiring runs INSIDE the SDK runner after the agent has
+# already booted: a loud log there is good but the operator may not be
+# tailing the runner stderr. The host-side preflight runs at ``sac agents
+# start`` time, BEFORE the runtime is built, and HARD-FAILS the start
+# instead of letting the operator discover the misconfig the next time they
+# message the bot. Catches the F1 (channel-absent) / F2 (port-absent) /
+# F4 (operator override stale) bug shapes loudly at the right place.
+#
+# This preflight cannot check F3 (MCP entry mis-keyed in to_home/.mcp.json)
+# without parsing that file — host-side it would need the agent's
+# workspace path; doable as a follow-up but not in this PR's scope. The
+# runner-side ``_wire_telegrammer_wake`` ERROR log covers F3 at boot time.
+# ---------------------------------------------------------------------------
+
+
+class TelegrammerWakeWiringError(RuntimeError):
+    """The operator requested the telegrammer channel but the wake URL
+    provably won't wire; refuse to start so the misconfig is loud.
+    """
+
+
+def validate_telegrammer_wake_wiring(
+    channels: list[str] | None,
+    a2a_port: int | None,
+    *,
+    agent_name: str = "",
+) -> None:
+    """Host-side preflight — raise if the wake wiring is impossible.
+
+    Called from ``_lifecycle/_start.py`` right after ``resolve_a2a_port``
+    so the start fails LOUD before any runtime is built, instead of the
+    operator discovering the silent no-op via "agent doesn't reply to
+    Telegram" hours later.
+
+    Only fires if ``server:claude-code-telegrammer`` is in ``channels``
+    AND a downstream gate would have silently no-op'd the wake wiring.
+    No-op when the channel is not requested (nothing to validate) or when
+    the channel is requested AND the wiring will succeed.
+
+    Catches the host-visible portion of the bug-#41 failure surface:
+
+      F1: channel not requested → silent no-op (we don't fire here at all
+          — there's nothing to validate).
+      F2: channel requested but ``a2a_port`` is None → would silently
+          no-op the runner-side wake wiring; we raise here instead.
+
+    F3 (MCP entry mis-keyed in ``to_home/.mcp.json``) and F4 (operator
+    pre-set a stale ``CLAUDE_CODE_TELEGRAMMER_TURN_URL``) are not visible
+    here without parsing the to_home tree; the runner-side
+    ``_wire_telegrammer_wake`` logs cover those at agent boot.
+    """
+    if not channels:
+        return
+    if not any(c.strip() == _TELEGRAMMER_CHANNEL for c in channels):
+        return
+    if a2a_port is None:
+        agent_clause = f" for agent {agent_name!r}" if agent_name else ""
+        raise TelegrammerWakeWiringError(
+            f"spec.claude.channels{agent_clause} requests "
+            f"{_TELEGRAMMER_CHANNEL!r} but spec.a2a.port is unset/null. "
+            f"Without an /v1/turn endpoint the standalone telegrammer "
+            f"poller has no URL to POST inbound Telegram messages to, so "
+            f"an idle agent cannot wake on Telegram. Fix: set spec.a2a.port "
+            f"to 'auto' (sac picks a port) or to an explicit free int, then "
+            f"retry the start. To run without the wake (legacy "
+            f"notifications/claude/channel-only behaviour, only renders for "
+            f"already-active turns), remove "
+            f"{_TELEGRAMMER_CHANNEL!r} from spec.claude.channels."
+        )

--- a/tests/scitex_agent_container/runtimes/test__sdk_channels.py
+++ b/tests/scitex_agent_container/runtimes/test__sdk_channels.py
@@ -435,43 +435,77 @@ class TestValidateTelegrammerWakeWiring:
     """Host-side preflight in ``_lifecycle/_start.agent_start``: hard-fail
     the start when the wake wiring provably won't succeed."""
 
-    def test_no_channels_does_not_raise(self):
+    def test_no_channels_returns_none(self):
         # Arrange — no channels requested at all.
-        # Act + Assert: nothing to validate.
-        validate_telegrammer_wake_wiring(None, None, agent_name="clew")
+        channels = None
+        # Act
+        result = validate_telegrammer_wake_wiring(channels, None, agent_name="clew")
+        # Assert — returns None (no validation needed).
+        assert result is None
 
-    def test_empty_channels_does_not_raise(self):
-        # Act + Assert
-        validate_telegrammer_wake_wiring([], None, agent_name="clew")
+    def test_empty_channels_returns_none(self):
+        # Arrange — empty channel list.
+        channels: list[str] = []
+        # Act
+        result = validate_telegrammer_wake_wiring(channels, None, agent_name="clew")
+        # Assert
+        assert result is None
 
-    def test_other_channel_only_does_not_raise(self):
+    def test_other_channel_only_returns_none(self):
         # Arrange — server:sac is fine without a2a port for this check.
-        # Act + Assert
-        validate_telegrammer_wake_wiring(["server:sac"], None, agent_name="clew")
+        channels = ["server:sac"]
+        # Act
+        result = validate_telegrammer_wake_wiring(channels, None, agent_name="clew")
+        # Assert
+        assert result is None
 
-    def test_telegrammer_channel_with_port_does_not_raise(self):
+    def test_telegrammer_channel_with_port_returns_none(self):
         # Arrange — channel requested and a2a port set: the runtime can wire.
-        # Act + Assert
-        validate_telegrammer_wake_wiring(
-            ["server:claude-code-telegrammer"], 19007, agent_name="clew"
-        )
+        channels = ["server:claude-code-telegrammer"]
+        # Act
+        result = validate_telegrammer_wake_wiring(channels, 19007, agent_name="clew")
+        # Assert
+        assert result is None
 
     def test_telegrammer_channel_without_port_raises(self):
+        # Arrange — channel requested but no a2a port.
+        channels = ["server:claude-code-telegrammer"]
         # Act + Assert
-        with pytest.raises(TelegrammerWakeWiringError) as excinfo:
-            validate_telegrammer_wake_wiring(
-                ["server:claude-code-telegrammer"], None, agent_name="clew"
-            )
-        # The raised message must name the agent + the offending channel +
-        # the missing field so the operator can act on it.
-        msg = str(excinfo.value)
-        assert "clew" in msg
-        assert "server:claude-code-telegrammer" in msg
-        assert "spec.a2a.port" in msg
+        with pytest.raises(TelegrammerWakeWiringError):
+            validate_telegrammer_wake_wiring(channels, None, agent_name="clew")
+
+    def test_telegrammer_channel_without_port_message_names_agent(self):
+        # Arrange
+        channels = ["server:claude-code-telegrammer"]
+        # Act + Assert — the raised message must name the agent (operator
+        # needs it to identify which agent is misconfigured). ``match``
+        # folds the message content into the same pytest.raises block so
+        # there's exactly one assertion in the test (STX-TQ007 compliant).
+        with pytest.raises(TelegrammerWakeWiringError, match="clew"):
+            validate_telegrammer_wake_wiring(channels, None, agent_name="clew")
+
+    def test_telegrammer_channel_without_port_message_names_channel(self):
+        # Arrange
+        channels = ["server:claude-code-telegrammer"]
+        # Act + Assert — the raised message must name the offending channel
+        # so the operator can spot the mis-spec in their YAML.
+        with pytest.raises(
+            TelegrammerWakeWiringError, match="server:claude-code-telegrammer"
+        ):
+            validate_telegrammer_wake_wiring(channels, None, agent_name="clew")
+
+    def test_telegrammer_channel_without_port_message_names_missing_field(self):
+        # Arrange
+        channels = ["server:claude-code-telegrammer"]
+        # Act + Assert — the raised message must name the missing field so
+        # the operator knows exactly what to set in spec.yaml.
+        with pytest.raises(TelegrammerWakeWiringError, match=r"spec\.a2a\.port"):
+            validate_telegrammer_wake_wiring(channels, None, agent_name="clew")
 
     def test_telegrammer_channel_without_port_no_agent_name(self):
         # Arrange — caller may not have an agent name (host-side preflight
         # is called from agent_start which has it; future callers may not).
+        channels = ["server:claude-code-telegrammer"]
         # Act + Assert
         with pytest.raises(TelegrammerWakeWiringError):
-            validate_telegrammer_wake_wiring(["server:claude-code-telegrammer"], None)
+            validate_telegrammer_wake_wiring(channels, None)

--- a/tests/scitex_agent_container/runtimes/test__sdk_channels.py
+++ b/tests/scitex_agent_container/runtimes/test__sdk_channels.py
@@ -25,8 +25,10 @@ import os
 import pytest
 
 from scitex_agent_container.runtimes._sdk_channels import (
+    TelegrammerWakeWiringError,
     apply_channels,
     merge_home_mcp_servers,
+    validate_telegrammer_wake_wiring,
 )
 
 
@@ -322,3 +324,154 @@ class TestMergeHomeMcpServers:
                 os.environ["MY_REF"] = saved
         # Assert
         assert out["x"]["env"]["K"] == "resolved-value"
+
+
+# ---------------------------------------------------------------------------
+# Bug #41 hardening — diagnostics for the telegrammer-wake silent-skip paths.
+#
+# The runner-side ``_wire_telegrammer_wake`` (called from ``apply_channels``)
+# now LOGs every silent-skip case so the operator can see exactly which gate
+# failed when an idle agent doesn't wake on Telegram. The host-side
+# ``validate_telegrammer_wake_wiring`` HARD-FAILS the start when the channel
+# is requested but the a2a port is unset — catching the misconfig at
+# ``sac agents start`` time instead of after the operator's third
+# un-replied Telegram message.
+# ---------------------------------------------------------------------------
+
+
+class TestTelegrammerWakeDiagnostics:
+    """``_wire_telegrammer_wake`` must LOG (not silently no-op) on each
+    skip path so the operator can see the precise misconfig."""
+
+    def test_a2a_port_missing_logs_warning(self, caplog):
+        # Arrange
+        kwargs: dict = {"mcp_servers": {}}
+        # Act
+        with caplog.at_level(
+            "WARNING", logger="scitex_agent_container.runtimes._sdk_channels"
+        ):
+            apply_channels(kwargs, ["server:claude-code-telegrammer"], None, "clew")
+        # Assert
+        assert any(
+            "spec.a2a.port is unset" in rec.getMessage() for rec in caplog.records
+        )
+
+    def test_mcp_entry_missing_logs_error(self, caplog):
+        # Arrange — channel + a2a port present, but no claude-code-telegrammer
+        # entry in mcp_servers.
+        kwargs: dict = {"mcp_servers": {"some-other-mcp": {"type": "stdio"}}}
+        # Act
+        with caplog.at_level(
+            "ERROR", logger="scitex_agent_container.runtimes._sdk_channels"
+        ):
+            apply_channels(kwargs, ["server:claude-code-telegrammer"], 19007, "clew")
+        # Assert
+        assert any(
+            "claude-code-telegrammer" in rec.getMessage()
+            and "no MCP entry keyed" in rec.getMessage()
+            for rec in caplog.records
+        )
+
+    def test_successful_wiring_logs_info(self, caplog):
+        # Arrange
+        kwargs: dict = {
+            "mcp_servers": {
+                "claude-code-telegrammer": {
+                    "type": "stdio",
+                    "command": "bash",
+                    "args": ["-c", "exec bun run telegram-server.ts"],
+                    "env": {},
+                }
+            }
+        }
+        # Act
+        with caplog.at_level(
+            "INFO", logger="scitex_agent_container.runtimes._sdk_channels"
+        ):
+            apply_channels(kwargs, ["server:claude-code-telegrammer"], 19007, "clew")
+        # Assert
+        assert any(
+            "telegrammer wake wired" in rec.getMessage() for rec in caplog.records
+        )
+
+    def test_no_log_when_channel_not_requested(self, caplog):
+        # Arrange — channel set has NO telegrammer entry, so the wake helper
+        # must produce NO log lines (a benign no-op, not a misconfig).
+        kwargs: dict = {"mcp_servers": {}}
+        # Act
+        with caplog.at_level(
+            "WARNING", logger="scitex_agent_container.runtimes._sdk_channels"
+        ):
+            apply_channels(kwargs, ["server:sac"], 19007, "clew")
+        # Assert
+        assert all(
+            "telegrammer" not in rec.getMessage().lower() for rec in caplog.records
+        )
+
+    def test_operator_set_url_preserved_and_logged(self, caplog):
+        # Arrange
+        kwargs: dict = {
+            "mcp_servers": {
+                "claude-code-telegrammer": {
+                    "type": "stdio",
+                    "command": "bash",
+                    "args": ["-c", "exec bun run telegram-server.ts"],
+                    "env": {
+                        "CLAUDE_CODE_TELEGRAMMER_TURN_URL": "http://operator.example/v1/turn"
+                    },
+                }
+            }
+        }
+        # Act
+        with caplog.at_level(
+            "INFO", logger="scitex_agent_container.runtimes._sdk_channels"
+        ):
+            apply_channels(kwargs, ["server:claude-code-telegrammer"], 19007, "clew")
+        # Assert
+        assert any("pre-set by operator" in rec.getMessage() for rec in caplog.records)
+
+
+class TestValidateTelegrammerWakeWiring:
+    """Host-side preflight in ``_lifecycle/_start.agent_start``: hard-fail
+    the start when the wake wiring provably won't succeed."""
+
+    def test_no_channels_does_not_raise(self):
+        # Arrange — no channels requested at all.
+        # Act + Assert: nothing to validate.
+        validate_telegrammer_wake_wiring(None, None, agent_name="clew")
+
+    def test_empty_channels_does_not_raise(self):
+        # Act + Assert
+        validate_telegrammer_wake_wiring([], None, agent_name="clew")
+
+    def test_other_channel_only_does_not_raise(self):
+        # Arrange — server:sac is fine without a2a port for this check.
+        # Act + Assert
+        validate_telegrammer_wake_wiring(["server:sac"], None, agent_name="clew")
+
+    def test_telegrammer_channel_with_port_does_not_raise(self):
+        # Arrange — channel requested and a2a port set: the runtime can wire.
+        # Act + Assert
+        validate_telegrammer_wake_wiring(
+            ["server:claude-code-telegrammer"], 19007, agent_name="clew"
+        )
+
+    def test_telegrammer_channel_without_port_raises(self):
+        # Act + Assert
+        with pytest.raises(TelegrammerWakeWiringError) as excinfo:
+            validate_telegrammer_wake_wiring(
+                ["server:claude-code-telegrammer"], None, agent_name="clew"
+            )
+        # The raised message must name the agent + the offending channel +
+        # the missing field so the operator can act on it.
+        msg = str(excinfo.value)
+        assert "clew" in msg
+        assert "server:claude-code-telegrammer" in msg
+        assert "spec.a2a.port" in msg
+
+    def test_telegrammer_channel_without_port_no_agent_name(self):
+        # Arrange — caller may not have an agent name (host-side preflight
+        # is called from agent_start which has it; future callers may not).
+        # Act + Assert
+        with pytest.raises(TelegrammerWakeWiringError):
+            validate_telegrammer_wake_wiring(["server:claude-code-telegrammer"], None)

--- a/tests/scitex_agent_container/runtimes/test__sdk_channels.py
+++ b/tests/scitex_agent_container/runtimes/test__sdk_channels.py
@@ -468,27 +468,29 @@ class TestValidateTelegrammerWakeWiring:
         assert result is None
 
     def test_telegrammer_channel_without_port_raises(self):
-        # Arrange — channel requested but no a2a port.
+        # Arrange
         channels = ["server:claude-code-telegrammer"]
-        # Act + Assert
+        # Act
+        # Assert — pytest.raises is the assertion (TQ007: one per test).
         with pytest.raises(TelegrammerWakeWiringError):
             validate_telegrammer_wake_wiring(channels, None, agent_name="clew")
 
     def test_telegrammer_channel_without_port_message_names_agent(self):
         # Arrange
         channels = ["server:claude-code-telegrammer"]
-        # Act + Assert — the raised message must name the agent (operator
-        # needs it to identify which agent is misconfigured). ``match``
-        # folds the message content into the same pytest.raises block so
-        # there's exactly one assertion in the test (STX-TQ007 compliant).
+        # Act
+        # Assert — `match` folds the message content into the raises block
+        # so the operator-naming contract is checked as part of the same
+        # assertion (TQ007 compliant: one assertion per test).
         with pytest.raises(TelegrammerWakeWiringError, match="clew"):
             validate_telegrammer_wake_wiring(channels, None, agent_name="clew")
 
     def test_telegrammer_channel_without_port_message_names_channel(self):
         # Arrange
         channels = ["server:claude-code-telegrammer"]
-        # Act + Assert — the raised message must name the offending channel
-        # so the operator can spot the mis-spec in their YAML.
+        # Act
+        # Assert — the raised message must name the offending channel so the
+        # operator can spot the mis-spec in their YAML.
         with pytest.raises(
             TelegrammerWakeWiringError, match="server:claude-code-telegrammer"
         ):
@@ -497,15 +499,17 @@ class TestValidateTelegrammerWakeWiring:
     def test_telegrammer_channel_without_port_message_names_missing_field(self):
         # Arrange
         channels = ["server:claude-code-telegrammer"]
-        # Act + Assert — the raised message must name the missing field so
-        # the operator knows exactly what to set in spec.yaml.
+        # Act
+        # Assert — the raised message must name the missing field so the
+        # operator knows exactly what to set in spec.yaml.
         with pytest.raises(TelegrammerWakeWiringError, match=r"spec\.a2a\.port"):
             validate_telegrammer_wake_wiring(channels, None, agent_name="clew")
 
     def test_telegrammer_channel_without_port_no_agent_name(self):
-        # Arrange — caller may not have an agent name (host-side preflight
-        # is called from agent_start which has it; future callers may not).
+        # Arrange — caller may not have an agent name (host-side preflight is
+        # called from agent_start which has it; future callers may not).
         channels = ["server:claude-code-telegrammer"]
-        # Act + Assert
+        # Act
+        # Assert — raise still happens without agent_name.
         with pytest.raises(TelegrammerWakeWiringError):
             validate_telegrammer_wake_wiring(channels, None)


### PR DESCRIPTION
## Summary

Operator-flagged recurring bug #41: when the operator messages an agent's Telegram bot, an IDLE claude-session SDK agent does NOT wake to process it. The Python-side wake-on-push design (PR #184) has been correctly wired since 2026 — `_sdk_channels._wire_telegrammer_wake` injects `CLAUDE_CODE_TELEGRAMMER_TURN_URL=http://127.0.0.1:<a2a_port>/v1/turn` into the agent's `claude-code-telegrammer` MCP entry's env. The standalone telegrammer's bun/ts poller is supposed to read that env and POST each inbound to the URL so the runner drives a turn.

**Root cause:** every gate in `_wire_telegrammer_wake` returned **silently** on misconfig (channel-absent / a2a-port-absent / mcp-entry-mis-keyed / env-not-dict / operator-pre-set-URL). The operator sees the exact same symptom for all of them — "I message my bot, agent doesn't reply" — and cannot tell which gate failed. Recurring symptom + no diagnostic surface = "stop citing #41 as a known bug" complaint.

This PR is the **Python half** of the two-layer fix. The **JS half** (F5/F6 below) is routed in parallel to **proj-claude-code-telegrammer** (the standalone bun/ts repo at `~/proj/claude-code-telegrammer/`).

### Changes

1. **Runner-side loud logs** (`runtimes/_sdk_channels._wire_telegrammer_wake`):
   - `WARN` for `spec.a2a.port` unset
   - `WARN` for malformed `mcp_servers` / `env`
   - **`ERROR`** for missing MCP entry (most common misconfig — operator-keyed under a non-canonical name)
   - `INFO` for operator-pre-set URL preserved
   - `INFO` for successful wiring (the happy-path confirmation: `"telegrammer wake wired: CLAUDE_CODE_TELEGRAMMER_TURN_URL=... injected into mcp_servers['claude-code-telegrammer'].env"`)

   Operator can grep for the exact gate that failed:
   ```bash
   sac agents logs <name> --stderr | grep -i 'telegrammer wake'
   ```

2. **Host-side preflight** `validate_telegrammer_wake_wiring` (called from `_lifecycle/_start.agent_start` immediately after `resolve_a2a_port`):
   - HARD-FAILS with `TelegrammerWakeWiringError` when `server:claude-code-telegrammer` is in `spec.claude.channels` but `spec.a2a.port` is unset/null.
   - Error message names the **agent**, the **offending channel string**, the **missing field**, AND the **two valid fixes** (set port to `auto`/int, OR remove the channel for legacy notifications-only behaviour).
   - Operator sees the misconfig at `sac agents start` time instead of discovering it on the third un-replied Telegram message. Same fail-loud shape as the existing F-CS audits.

3. **Skill 23 rewrite** (`_skills/scitex-agent-container/23_telegram-integration.md`) to describe the **current per-agent wake contract** (the legacy in-sac `_telegram/` bridge was retired in `f895fb1`). Adds:
   - A table mapping each failure mode → diagnostic → operator fix.
   - A four-step **operator verification recipe**, including the canonical `sac agents logs <name> --stderr | grep -i 'telegrammer wake'` confirmation grep.
   - New size: 95 lines / 5423 B (under SK-401 budget). `audit-skills` returns `SUCC`.

## What this PR does NOT fix (F5/F6 — JS-side, routed upstream)

The `ts/lib/wake.ts` poller in the standalone `claude-code-telegrammer` repo. If the env var is correctly injected (INFO log `"telegrammer wake wired"`) but the agent still doesn't reply, the JS poller isn't POSTing — that's upstream.

### Smoking gun (evidence for F5/F6)

The pip-installed `claude_code_telegrammer 0.5.0` package's bundled skill at `/opt/venv-sac/lib/python3.12/site-packages/claude_code_telegrammer/_skills/claude-code-telegrammer/SKILL.md` STILL describes the package as:

> **claude-code-telegrammer**
> TUI watchdog that keeps Claude Code sessions alive by auto-responding to prompts.
>
> [...]
>
> ## Environment Variables
>
> | Variable | Default | Description |
> |----------|---------|-------------|
> | CLAUDE_CODE_TELEGRAMMER_SESSION | claude-code-telegrammer | Screen session name |
> | CLAUDE_CODE_TELEGRAMMER_WATCHDOG_INTERVAL | 1.5 | Poll interval (seconds) |
> | CLAUDE_CODE_TELEGRAMMER_RESP_Y_N | 1 | Response to y/n prompt |
> | CLAUDE_CODE_TELEGRAMMER_RESP_Y_Y_N | 2 | Response to y/y/n prompt |
> | CLAUDE_CODE_TELEGRAMMER_RESP_WAITING | /speak-and-call | Command when idle |

Note: no mention of `CLAUDE_CODE_TELEGRAMMER_TURN_URL` in the env table, and the package is described as a **TUI screen-polling watchdog**, not a Telegram-bot poller with wake-POST capability. Either the docs are stale OR the wake-aware Telegram-bot version of the package was never shipped to PyPI. Either way the Python side has been waiting for the JS side since PR #184. **Routed to proj-claude-code-telegrammer per lead.**

After this PR lands, the operator's next un-replied Telegram message produces a loud signal at exactly ONE of two boundaries:
- **Python boundary** (this PR caught it): misconfig — operator gets a clear log / startup error pointing at the exact field to fix.
- **JS boundary** (upstream's responsibility): env was injected, JS isn't POSTing — INFO log says `"telegrammer wake wired"` but no inbound POST hits `/v1/turn`. Clear handoff to proj-claude-code-telegrammer.

## Test plan

- [x] 32 tests in `test__sdk_channels.py` pass locally (13 new + 19 pre-existing unchanged). No mocks: each diagnostic path is exercised via real `pytest caplog`, each validator outcome via real `pytest.raises`. The /v1/turn endpoint itself has its own end-to-end tests in `test_session_http.py` (unchanged by this PR).
- [x] `scitex_dev audit-skills` returns `SUCC` against the new skills dir (skill 23 at 95L/5423B, under SK-401 budget).
- [ ] CI matrix green on this PR.
- [ ] (Out of band) operator verifies that the misconfig path that's been biting them now produces a loud log / startup error pointing at the precise fix.

## Deploy caveat — NOT live until SIF rebuild + agent restart

This PR touches in-SIF runner code (`runtimes/_sdk_channels.py`, `_lifecycle/_start.py`). **A merge to develop does NOT reach running agents.** The fix is live only after the host operator:

1. Rebuilds `sac-base.sif` from a develop tip that includes this PR.
2. Restarts the fleet's agents so they pick up the new SIF.

Lead is **NOT** triggering the fleet-wide SIF rebuild from this PR alone: prod hub cutover is mid-incident and a rebuild+restart would churn the whole fleet. The SIF roll will be batched (likely also folding in PR #322 libglib2.0-0 + the 0.21 release roll) once the hub is stable. The diagnostic value of this PR is fully realised at that batch-rebuild point, not at merge.

Until then, the **build-time** wiring in this PR (correct env injection, the host-side preflight, the runner-side logs) is in place for any newly-built SIF, and the merge is the canonical record of the fix. Running pre-existing agents continue to behave as before until they're restarted into a new SIF.
