### PR TITLE
fix(_runners/_session_hooks): strengthen empty-beacon guard to status==unknown regardless of dispatch_id

### DIFF
--- a/src/scitex_agent_container/_runners/_session_hooks.py
+++ b/src/scitex_agent_container/_runners/_session_hooks.py
@@ -108,8 +108,15 @@ async def emit_completion_push(
 
     * the seams aren't wired (``turn_context`` / ``push_fn`` is ``None``) —
       a bare runner with no host control-plane has nowhere to push;
-    * the turn had no requester (a mission/boot turn answers to no peer); or
-    * this turn was already pushed.
+    * the turn had no requester (a mission/boot turn answers to no peer);
+    * this turn was already pushed; or
+    * the push would be structurally empty (see the fleet-noise guards
+      inline below): the summary is empty/whitespace AND either there is
+      no ledger correlation (``dispatch_id is None``) OR no honest
+      outcome was recorded (``status == STATUS_UNKNOWN``). Every empty
+      push burns the requester's turn cycle for zero signal; the union
+      catches both noise patterns observed in the wild without dropping
+      any signal-carrying push.
 
     Status is taken verbatim from ``turn_context.status`` — set honestly by
     the conversation (``success`` on clean drain, ``failure`` on SDK error).
@@ -127,27 +134,43 @@ async def emit_completion_push(
     if not requester or turn_context.pushed:
         return
 
-    # Fleet-noise guard (lead task PR3, 2026-06-05): suppress a push that
-    # carries NO ledger correlation AND NO content. The wire signature
-    # ``{"agent": <name>, "dispatch_id": null, "status": "unknown",
-    # "summary": ""}`` is the canonical "nothing real to report"
-    # payload — every idle/wake turn that had no incoming dispatch_id
-    # and produced no assistant text fires one. Multiplied across an
-    # N-agent fleet post-restart, those empties eat every subscriber's
-    # turn cycle for zero signal. The completion contract is "tell the
-    # requester something useful happened"; without a dispatch_id OR
-    # summary content, nothing useful did. ``pushed = True`` still flips
-    # so a re-entrant Stop hook on the same turn re-evaluates and skips
-    # identically (no double-evaluation cost).
-    if turn_context.dispatch_id is None and not (turn_context.summary or "").strip():
+    from ._session_completion import STATUS_UNKNOWN, build_completion_report
+
+    status = turn_context.status or STATUS_UNKNOWN
+    summary_stripped = (turn_context.summary or "").strip()
+
+    # Fleet-noise guards — suppress structurally-empty pings at the
+    # source. Either signature flips the noise gate:
+    #
+    # (1) PR #309 (2026-06-05): no ledger correlation AND no content.
+    #     The wire signature
+    #     ``{"agent": <name>, "dispatch_id": null, "status": "unknown",
+    #     "summary": ""}`` is the canonical "nothing real to report"
+    #     payload — every idle/wake turn that had no incoming
+    #     dispatch_id and produced no assistant text used to fire one.
+    #
+    # (2) Lead 2026-06-07 (conv 62b0f613104048c6adae11c73d9f8b63): no
+    #     honest outcome AND no content, REGARDLESS of dispatch_id. A
+    #     push with ``status:"unknown"`` + empty summary carries no
+    #     information for the requester even when a dispatch_id is
+    #     set — "we tried this dispatch and have nothing to say about
+    #     it" is worse than useless. Observed in the wild: roughly 1
+    #     in 6 empty pings from a stuck sibling rode a real
+    #     dispatch_id and leaked past guard (1).
+    #
+    # Signal preserved: a push with non-empty summary always emits; a
+    # push with empty summary but an honest status (``success`` or
+    # ``failure``) AND a dispatch_id still emits so the requester can
+    # correlate. ``pushed = True`` still flips so a re-entrant Stop
+    # hook on the same turn re-evaluates and skips identically.
+    if not summary_stripped and (
+        turn_context.dispatch_id is None or status == STATUS_UNKNOWN
+    ):
         turn_context.pushed = True
         return
 
     turn_context.pushed = True
 
-    from ._session_completion import STATUS_UNKNOWN, build_completion_report
-
-    status = turn_context.status or STATUS_UNKNOWN
     report = build_completion_report(
         agent=agent_name,
         dispatch_id=turn_context.dispatch_id,

--- a/tests/scitex_agent_container/_runners/test__session_completion.py
+++ b/tests/scitex_agent_container/_runners/test__session_completion.py
@@ -685,6 +685,102 @@ class TestSuppressEmptyCompletions:
         # Assert
         assert pushed is True
 
+    def test_suppress_when_status_unknown_even_with_dispatch_id(self) -> None:
+        # Arrange — closes the remaining gap that PR #309 left: a beacon
+        # carrying a real ledger ``dispatch_id`` but ``status=="unknown"``
+        # and empty summary is still information-free for the requester
+        # ("we tried this dispatch and have nothing to say about it"), so
+        # the lead's 2026-06-07 spec requires suppression. Observed in
+        # the wild as ~1-in-6 of a stuck sibling's empty-beacon burst.
+        ctx = TurnContext()
+        ctx.begin(requester="lead", dispatch_id="d-leaked-unk")
+        ctx.finish(status=STATUS_UNKNOWN, summary="")
+        calls: list = []
+
+        async def _push_fn(report, requester, dispatch_id):
+            calls.append(report)
+
+        async def _scenario():
+            await emit_completion_push(ctx, _push_fn, agent_name="worker")
+            return calls
+
+        # Act
+        observed = asyncio.run(_scenario())
+        # Assert — push_fn was NEVER invoked: the dispatch_id by itself
+        # cannot rescue a status==unknown + empty summary payload.
+        assert observed == []
+
+    def test_suppress_when_status_unknown_whitespace_summary_with_dispatch_id(
+        self,
+    ) -> None:
+        # Arrange — whitespace summary still counts as empty for the
+        # status-based guard, so the strip-first contract holds even
+        # when a dispatch_id is set. Guards against a future regression
+        # that special-cases "any non-empty char" without stripping.
+        ctx = TurnContext()
+        ctx.begin(requester="lead", dispatch_id="d-ws-unk")
+        ctx.finish(status=STATUS_UNKNOWN, summary="\n  \t  ")
+        calls: list = []
+
+        async def _push_fn(report, requester, dispatch_id):
+            calls.append(report)
+
+        async def _scenario():
+            await emit_completion_push(ctx, _push_fn, agent_name="worker")
+            return calls
+
+        # Act
+        observed = asyncio.run(_scenario())
+        # Assert
+        assert observed == []
+
+    def test_emit_failure_with_dispatch_id_even_with_empty_summary(self) -> None:
+        # Arrange — signal preservation: a dispatched failure that
+        # produced no captured detail is still a real outcome the
+        # requester needs to hear about (the failure status itself is
+        # signal); the strengthened guard MUST NOT swallow it. Only the
+        # status==unknown path is suppressed when summary is empty.
+        ctx = TurnContext()
+        ctx.begin(requester="lead", dispatch_id="d-honest-fail")
+        ctx.finish(status=STATUS_FAILURE, summary="")
+        calls: list = []
+
+        async def _push_fn(report, requester, dispatch_id):
+            calls.append(report)
+
+        async def _scenario():
+            await emit_completion_push(ctx, _push_fn, agent_name="worker")
+            return calls
+
+        # Act
+        observed = asyncio.run(_scenario())
+        # Assert — failure-status push still emits despite the empty
+        # summary; failure is signal even without summary text.
+        assert len(observed) == 1
+
+    def test_status_unknown_with_real_summary_still_emits(self) -> None:
+        # Arrange — symmetric to the non-empty-content branch in #309:
+        # an honest "unknown" status that DID capture summary text is
+        # signal (e.g. partial output before an interrupt); don't
+        # suppress just because the conversation never reached a clean
+        # ResultMessage / exception path.
+        ctx = TurnContext()
+        ctx.begin(requester="lead", dispatch_id="d-partial")
+        ctx.finish(status=STATUS_UNKNOWN, summary="partial output then interrupt")
+        calls: list = []
+
+        async def _push_fn(report, requester, dispatch_id):
+            calls.append(report)
+
+        async def _scenario():
+            await emit_completion_push(ctx, _push_fn, agent_name="worker")
+            return calls
+
+        # Act
+        observed = asyncio.run(_scenario())
+        # Assert
+        assert len(observed) == 1
+
 
 # ---------------------------------------------------------------------------
 # Full conversation → requester push (real run_conversation, fake SDK module)


### PR DESCRIPTION
## Summary

Strengthens PR #309's sender-side empty-beacon guard to close a remaining gap that was leaking ~1 of every 6 empty completion pings observed in the wild.

**Root cause** (confirmed against lead msg `c2704d081d90455ca6f806d31dea8d6e` 2026-06-07 + clew's runtime-auto-emit theory): `_runners/_session_hooks.py::emit_completion_push` fires on every turn-end via the SDK Stop hook + the `_drive_turn.finally` shared emit. When `TurnContext.finish()` never ran for a turn (idle/wake turn with no clean `ResultMessage` AND no caught exception), `turn_context.status` stays `None` (coerced to `"unknown"`) and `turn_context.summary` stays `""`. The push went out as the canonical noise payload `{dispatch_id: <id-or-null>, status: "unknown", summary: ""}` — emitted by the runtime, not by `a2a_send`, which is why every restarted agent in a cohort started spamming peers without consciously sending anything.

**PR #309** (merged 2026-06-05) added the first guard: suppress when `dispatch_id is None AND empty summary`. Catches the dispatch_id=null variant.

**Gap closed here**: a beacon riding a real `dispatch_id` but still `status: "unknown"` + empty summary leaked past #309's guard. Live samples from `proj-paper-scitex-clew` carrying real ledger ids (e.g. `8e64595c851f4ee2b532e4f77a2f56cd`, `3f0cd2a9341249758443c91a352ccd17`) confirmed the gap during this session.

## Change

`emit_completion_push` now suppresses when `not summary.strip() AND (dispatch_id is None OR status == STATUS_UNKNOWN)` — the union of the two structural noise patterns observed.

**Signal preserved**:
- Push with non-empty summary → always emits.
- Push with empty summary + honest `success` / `failure` status + real `dispatch_id` → still emits so the requester can correlate by ledger id.
- Only the both-empty noise case is silenced.

`pushed = True` flips on suppression as before, so a re-entrant Stop hook on the same turn re-evaluates and skips identically.

## Tests (no mocks, real `TurnContext`, real receivers)

Existing `TestSuppressEmptyCompletions` (from #309) — all 5 still pass. New 4 tests covering the strengthened predicate:

- `test_suppress_when_status_unknown_even_with_dispatch_id` — the exact gap-case the operator cited.
- `test_suppress_when_status_unknown_whitespace_summary_with_dispatch_id` — whitespace-only summary still counts as empty for the status-based guard.
- `test_emit_failure_with_dispatch_id_even_with_empty_summary` — pin signal preservation: failure-status is signal, even without summary text.
- `test_status_unknown_with_real_summary_still_emits` — pin signal preservation: honest unknown with partial output (e.g. interrupted turn) still emits.

## Verification

- 30/30 file-level tests pass.
- Full suite: 6447 passed, 37 skipped, 9 deselected, 1 failed.
  - The single failure is `test_cli_help_under_budget` (0.66s vs 0.5s budget on a heavily-loaded local host). Pre-existing environmental flake PR #309's own body explicitly called out; this change touches `_session_hooks.py`, not the CLI startup import chain.
- Ruff clean on both changed files.

## Deploy note

Rides the upcoming SIF rebuild as gate-item #2 (alongside telegrammer doc+caption BUG2). With #309 + this patch on develop, the post-rebuild fleet stops emitting both noise signatures at the source.

## Test plan

- [x] Strengthened guard suppresses the exact wire-observed gap-case
- [x] Signal-carrying pushes still emit
- [x] Full suite green (modulo pre-existing host-load flake)
- [x] Ruff clean