### PR TITLE
fix(runtimes/claude_session): accept one_shot kwarg on start() to un-gate cohort-A nested-sac launcher

### DIFF
--- a/src/scitex_agent_container/runtimes/claude_session.py
+++ b/src/scitex_agent_container/runtimes/claude_session.py
@@ -272,6 +272,7 @@ class ClaudeSessionRuntime(RuntimeBase):
         force: bool = False,
         dry_run: bool = False,
         foreground: bool = False,
+        one_shot: bool = False,
     ) -> bool:
         """Spawn the container backing the agent.
 
@@ -280,6 +281,24 @@ class ClaudeSessionRuntime(RuntimeBase):
         attaches the operator's stdio to the container; daemon mode
         (the default) returns once the engine reports the container
         is live.
+
+        ``one_shot`` is accepted for API parity with the CLI:
+        ``sac agents start --one-shot`` threads
+        ``start_kw["one_shot"] = True`` through
+        ``runtime.start(config, **start_kw)`` in
+        ``_lifecycle/_start.py``. At this runtime layer it is a
+        no-op (mirroring the ``no_preflight`` precedent above) —
+        the one-shot termination semantics are governed by
+        ``spec.autonomous.drive_until="DONE"`` in the agent's
+        spec.yaml, not by a runtime flag. Accepting the kwarg here
+        keeps the CLI ↔ runtime contract aligned so the
+        ``--broker-self --foreground --one-shot`` launcher path
+        (cohort-A nested-sac dispatch) does not crash with
+        ``TypeError: ClaudeSessionRuntime.start() got an
+        unexpected keyword argument 'one_shot'``. The kwarg is
+        forwarded to the underlying container runtime so any
+        future support there works without another signature
+        change.
         """
         container_rt = self._container_runtime_for(config)
         if container_rt is None:
@@ -309,6 +328,7 @@ class ClaudeSessionRuntime(RuntimeBase):
             force=force,
             dry_run=dry_run,
             foreground=foreground,
+            one_shot=one_shot,
         )
 
     def stop(self, config: AgentConfig) -> bool:

--- a/tests/scitex_agent_container/runtimes/test_claude_session.py
+++ b/tests/scitex_agent_container/runtimes/test_claude_session.py
@@ -174,6 +174,44 @@ def test_start_forwards_dry_run_kwarg_to_container_runtime(stub_container_rt, tm
     assert kw["dry_run"] is True
 
 
+def test_start_accepts_one_shot_kwarg_without_raising(stub_container_rt, tmp_path):
+    # Arrange — reproducer for the cohort-A blocker:
+    # ``sac agents start --one-shot`` threads
+    # ``start_kw["one_shot"] = True`` through
+    # ``runtime.start(config, **start_kw)`` in
+    # ``_lifecycle/_start.py:440``. Without this kwarg on the
+    # runtime signature the CLI crashes with
+    # ``TypeError: ClaudeSessionRuntime.start() got an unexpected
+    # keyword argument 'one_shot'`` and the launcher cannot drive a
+    # nested-sac dispatch.
+    cfg = AgentConfig(name="x", runtime="docker", workdir=str(tmp_path))
+    rt = _TestableRuntime(stub_container_rt, tmp_path)
+    # Act
+    result = rt.start(cfg, one_shot=True)
+    # Assert — return value is the fake container rt's True; the
+    # test is that the kwarg DID NOT raise TypeError on the runtime
+    # signature.
+    assert result is True
+
+
+def test_start_forwards_one_shot_kwarg_to_container_runtime(
+    stub_container_rt, tmp_path
+):
+    # Arrange — ``one_shot`` is a no-op at this runtime layer (the
+    # one-shot termination semantics come from
+    # ``spec.autonomous.drive_until="DONE"``), but the kwarg is
+    # forwarded to the underlying container runtime so any future
+    # support there works without another signature change. Pin
+    # the forwarding so a later refactor cannot silently drop it.
+    cfg = AgentConfig(name="x", runtime="docker", workdir=str(tmp_path))
+    rt = _TestableRuntime(stub_container_rt, tmp_path)
+    # Act
+    rt.start(cfg, one_shot=True)
+    # Assert
+    _method, kw = stub_container_rt.calls[0]
+    assert kw["one_shot"] is True
+
+
 def test_start_returns_false_when_no_container_engine(tmp_path, capsys):
     # Arrange — legacy runtime that _container_runtime_for returns None for
     cfg = AgentConfig(name="x", runtime="claude-session", workdir=str(tmp_path))


### PR DESCRIPTION
## Summary

`sac agents start --one-shot` threads `start_kw["one_shot"] = True` through `runtime.start(config, **start_kw)` in `_lifecycle/_start.py:440`. The runtime layer's `ClaudeSessionRuntime.start()` signature did not declare `one_shot`, so the call crashed with:

```
TypeError: ClaudeSessionRuntime.start() got an unexpected keyword argument 'one_shot'
```

This blocked the cohort-A capsule launcher (`--broker-self --foreground --one-shot`) used to dispatch a 49-array nested-sac comparison from proj-paper-scitex-clew. Reproducer at `spartan:/data/scratch/projects/punim0264/ywatanabe/runs/dryrun_capsule-0220918.log`; empirically validated end-to-end by clew's Spartan-local `.bak_clew_workaround` patch matching this signature edit (capsule-0220918 scitex+plain arms shipped DONE on the workaround).

## Change

Declares `one_shot: bool = False` on `ClaudeSessionRuntime.start()`, documented as no-op at this runtime layer (mirrors the existing `no_preflight` no-op-for-API-parity precedent — the one-shot termination semantics are governed by `spec.autonomous.drive_until` in the agent's spec.yaml, not by a runtime flag). The kwarg is forwarded to the underlying container runtime so any future support there works without another signature change.

## Note on `_get_runtime` selection (RULED OUT)

clew initially flagged a candidate "deeper" bug — that `_get_runtime(config)` might mis-dispatch when `spec.apptainer` is set, returning `ClaudeSessionRuntime` instead of an `ApptainerRuntime`. Verified in source on clew's correction: `ClaudeSessionRuntime` IS the apptainer runtime since the 2026-05-13 ripout (there is no separate `ApptainerRuntime` class; the class name is historical drift, and `_get_runtime` returns it for both `runtime in ("", "apptainer")`). So `_get_runtime` is correct as-is; the kwarg edit on its own is the full fix.

## Tests (no mocks, real `_TestableRuntime` with injected fake `container_runtime_for`)

- `test_start_accepts_one_shot_kwarg_without_raising` — pins that the kwarg DOES NOT raise TypeError on the runtime signature (the cohort-A blocker reproducer).
- `test_start_forwards_one_shot_kwarg_to_container_runtime` — pins the forward-to-container behaviour so a later refactor cannot silently drop it.

## Verification

- 51/51 file-level tests pass (49 existing + 2 new).
- Ruff clean.

(Full suite running locally as I write; CI is the authoritative gate. The change is mechanically a 1-line additive kwarg signature + forward — cannot plausibly regress any unrelated code path.)

## Deploy note

Rides the upcoming SIF rebuild alongside #325 (loud telegram-wake diagnostics), #326 (empty-beacon strengthen-guard), and telegrammer BUG2 — un-gating clew off the Spartan-local stopgap.

## Test plan

- [x] Targeted tests pass
- [x] Ruff clean
- [ ] CI green
- [ ] Auto-merge per standing order