### PR TITLE
fix(sif/apt+pip): add libglib2.0-0 (base) + xarray (scitex) to close scitex.io silent-fallback paths

### DIFF
--- a/src/scitex_agent_container/containers/apptainer-base.def
+++ b/src/scitex_agent_container/containers/apptainer-base.def
@@ -60,12 +60,23 @@ From: ubuntu:24.04
     # git/curl/ca-certificates/openssh-client are listed here so any
     # future base-image trim cannot silently drop them — sac runtime
     # hard-depends on each one (HTTPS verify chain, SSH dispatch, git).
+    #
+    # libglib2.0-0 is REQUIRED by the scitex stack: without it,
+    # libgthread-2.0.so.0 is missing and ``import scitex.io`` silently
+    # falls back to "minimal mode" — runs look green but lose the
+    # full IO surface. Also blocks clew's H2 full-DAG tamper-detection
+    # (``chain_verified`` needs the gthread shim). Caught by clew's
+    # capsule-0220918 cohort-A audit (2026-06-06); the silent fallback
+    # is the real bug, the missing system lib is the immediate fix.
+    # Added on the lib row because it's a runtime system library (no
+    # -dev companion needed for the consumers that hit the silent-
+    # fallback path). Supersedes the standalone PR #322.
     apt-get update
     apt-get install -y --no-install-recommends \
         ca-certificates curl wget gnupg \
         git openssh-client sshpass autossh git-crypt \
         build-essential pkg-config \
-        libffi-dev libssl-dev libgl1-mesa-dev libc6-dev \
+        libffi-dev libssl-dev libgl1-mesa-dev libc6-dev libglib2.0-0 \
         python3 python3-pip python3-venv python3-dev \
         locales tzdata \
         procps lsof strace less \

--- a/src/scitex_agent_container/containers/apptainer-scitex.def
+++ b/src/scitex_agent_container/containers/apptainer-scitex.def
@@ -67,6 +67,17 @@ From: ./sac-base.sif
     # lets uv/pip drift away from the base layer's 0.2.87 pin (the
     # version that bundles the working claude CLI 2.1.150). Keep
     # both branches' version in lockstep with apptainer-base.def.
+    #
+    # ``xarray`` is listed EXPLICITLY here because ``scitex[all]``'s
+    # current extras set does not pull it. Without xarray, clew's
+    # ``scitex.io`` preflight on Spartan fails its import probe and
+    # silently falls back to "minimal mode" — runs look green but
+    # lose the labelled-array surface the cohort-A capsules need.
+    # Pinned explicit so a future ``scitex[all]`` re-bake cannot
+    # silently drop the dep without surfacing as a build-time
+    # uv/pip failure. (Caught by clew's capsule-0220918 audit,
+    # 2026-06-06; symmetric with the apt-side libglib2.0-0 add in
+    # apptainer-base.def — both close silent-fallback paths.)
     if command -v uv >/dev/null; then
         uv pip install --python /opt/venv-sac/bin/python \
             black flake8 \
@@ -74,6 +85,7 @@ From: ./sac-base.sif
             pytest pytest-cov \
             "claude-agent-sdk==0.2.87" \
             "scitex[all]" \
+            xarray \
             /opt/scitex-agent-container-src
     else
         /opt/venv-sac/bin/pip install --no-cache-dir --upgrade \
@@ -84,6 +96,7 @@ From: ./sac-base.sif
             pytest pytest-cov \
             "claude-agent-sdk==0.2.87" \
             "scitex[all]" \
+            xarray \
             /opt/scitex-agent-container-src
     fi
 


### PR DESCRIPTION
## Summary

Two coordinated SIF-def additions for the next host-side `sac image build base → scitex` cycle — both close `scitex.io` "minimal mode" silent-fallback paths that the cohort-A capsule audit (clew's `capsule-0220918`, 2026-06-06) tripped on.

Per lead msg `47fa8f092b464cc98d2bc614c7c1afea` (2026-06-07), this rides the next SIF rebuild alongside #325, #326, #327, and telegrammer doc-caption BUG2.

## Changes

### `apptainer-base.def` (system layer)
- Add `libglib2.0-0` to the `apt-get install` row. Provides `libgthread-2.0.so.0`, which the scitex stack hard-loads at `import scitex.io`. Without it, the import path falls back to "minimal mode" — code paths return success but lose the full IO surface. Also unblocks clew's H2 full-DAG tamper-detection (`chain_verified` depends on the gthread shim).
- **Supersedes the standalone PR #322** (same edit + inline rationale comment, just folded so one PR rides the SIF rebuild rather than two).

### `apptainer-scitex.def` (scitex layer)
- Add `xarray` as an explicit dep on **both** the `uv pip install` and the `uv-missing` `pip install` fallback rows (keeps lockstep). `scitex[all]`'s current extras set does NOT pull xarray; without it, clew's preflight fails its import probe and the same minimal-mode fallback fires.
- Pinned explicit so a future `scitex[all]` extras re-bake cannot silently drop the dep without surfacing as a build-time uv/pip resolution failure.

## Symmetry

Both closures are "system or python-side library missing → silent minimal-mode fallback". The real bug (silent fallback) is **out of scope here**; this PR just plugs the two specific missing libs so cohort-A capsules ship the full-fat surface on the next SIF.

## Verification

- No code or test changes — def files are static recipes that bake into the SIF at host-side `sac image build` time.
- Ruff / pytest N/A for these files.
- Audit-skills / -python-apis / -project / -cli stay green (def-file edits don't touch the audited surface).
- CI's pytest-matrix runs the same suite that already passes on #326's tip (c0c5f98).

## Test plan

- [x] Files committed at the correct paths (`src/scitex_agent_container/containers/apptainer-base.def`, `apptainer-scitex.def`)
- [x] uv path AND pip-fallback path both updated for xarray (no drift)
- [x] Inline rationale comments explaining the silent-fallback path each lib closes
- [ ] CI green
- [ ] Host-side SIF rebuild picks up both deps
- [ ] Cohort-A capsules ship full-fat scitex.io surface (no minimal-mode banner)

## Closes

- Closes #322 (folded — same libglib2.0-0 edit)