### PR TITLE
fix(cli/image-build): stage prerequisite SIF for layered .defs (bootstrap_sif)

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_image_source_build.py
+++ b/src/scitex_agent_container/cli_pkg/_image_source_build.py
@@ -134,6 +134,8 @@ def stage_build_context(
     pkg_root: Path,
     def_path: Path,
     dest_dir: Path,
+    *,
+    bootstrap_sif: Path | None = None,
 ) -> Path:
     """Stage a build-context dir for source-bundled apptainer builds.
 
@@ -141,6 +143,7 @@ def stage_build_context(
 
         dest_dir/
             <def-name>.def                     # copy of def_path
+            <bootstrap_sif.name>               # symlink to bootstrap_sif (if any)
             scitex-agent-container-src/        # pip-installable source tree
                 pyproject.toml                 # from locate_bundled_pyproject
                 src/
@@ -165,6 +168,19 @@ def stage_build_context(
         The .def file to stage. Must exist and be a file.
     dest_dir : Path
         The staging directory. Created (or reset) by this function.
+    bootstrap_sif : Path | None
+        Optional path to a prerequisite SIF that the .def's
+        ``Bootstrap: localimage`` / ``From: ./<name>.sif`` line
+        references. When set, the SIF is symlinked into ``dest_dir``
+        under its own filename so apptainer's relative ``From: ./...``
+        resolves at build time. The symlink uses the absolute resolved
+        target path so it survives the staging dir's rmtree-on-next-
+        build lifecycle. ``None`` for top-of-stack defs (``Bootstrap:
+        docker`` / ``From: ubuntu:24.04`` etc.). Required for layered
+        defs like ``apptainer-scitex.def`` (``From: ./sac-base.sif``);
+        omitting it produces a half-staged build context that
+        apptainer FATAL's on with "no such file or directory" — that
+        was the bug behind the 2026-06-07 cohort-A rebuild stall.
 
     Returns
     -------
@@ -175,7 +191,8 @@ def stage_build_context(
     Raises
     ------
     FileNotFoundError
-        If ``pkg_root`` / ``def_path`` / pyproject.toml is missing.
+        If ``pkg_root`` / ``def_path`` / pyproject.toml / (when set)
+        ``bootstrap_sif`` is missing.
     NotADirectoryError
         If ``pkg_root`` exists but isn't a directory.
     """
@@ -186,11 +203,17 @@ def stage_build_context(
     if not pkg_root.is_dir():
         raise NotADirectoryError(f"package source is not a directory: {pkg_root}")
 
-    # Resolve pyproject.toml + README.md BEFORE wiping dest_dir so a
-    # missing-file failure doesn't strand the operator with a
-    # half-staged tree.
+    # Resolve pyproject.toml + README.md + (when set) bootstrap_sif
+    # BEFORE wiping dest_dir so a missing-file failure doesn't strand
+    # the operator with a half-staged tree.
     pyproject_src = locate_bundled_pyproject(pkg_root)
     readme_src = locate_bundled_readme(pkg_root)
+    if bootstrap_sif is not None and not bootstrap_sif.is_file():
+        raise FileNotFoundError(
+            f"bootstrap SIF not found: {bootstrap_sif} — build the prerequisite "
+            "layer first (e.g. `sac image build base` before `sac image build "
+            "scitex`), then retry."
+        )
 
     # Reset the staging dir. A prior failed build can leave a partial
     # tree behind; copying on top of it would silently mix old + new
@@ -202,6 +225,16 @@ def stage_build_context(
 
     staged_def = dest_dir / def_path.name
     shutil.copy2(def_path, staged_def)
+
+    # Stage the prerequisite SIF (layered build). Use a symlink to the
+    # absolute resolved target: instant (3GB base SIF would otherwise
+    # cost ~30s to copy on SSD, longer on spinning), and apptainer
+    # follows symlinks for the ``Bootstrap: localimage`` / ``From: .
+    # /<name>.sif`` reference at build time. Absolute target means the
+    # link stays valid across cwd changes during the build invocation.
+    if bootstrap_sif is not None:
+        link_path = dest_dir / bootstrap_sif.name
+        link_path.symlink_to(bootstrap_sif.resolve())
 
     # The staged pip-installable source tree:
     #   <staged_src>/pyproject.toml
@@ -296,6 +329,7 @@ def build_layer_from_source(
     output_dir: Path,
     sandbox: bool = False,
     force: bool = True,
+    bootstrap_sif: Path | None = None,
 ) -> Path:
     """Build a sac SIF (or sandbox) from a .def that bundles its own source.
 
@@ -321,6 +355,14 @@ def build_layer_from_source(
         If True, build a writable sandbox directory rather than a SIF.
     force : bool
         Pass ``--force`` to apptainer (overwrite existing artefact).
+    bootstrap_sif : Path | None
+        Optional prerequisite SIF for a layered .def. Forwarded to
+        :func:`stage_build_context` which symlinks it into the staging
+        dir so the .def's ``Bootstrap: localimage`` / ``From: ./<name>.
+        sif`` line resolves at build time. ``None`` for top-of-stack
+        defs (``base``, ``proxy``). Required for ``scitex`` (bootstraps
+        off ``sac-base.sif``); omitting it produces a half-staged
+        context and apptainer FATAL's on "no such file or directory".
 
     Returns
     -------
@@ -339,7 +381,9 @@ def build_layer_from_source(
     artifact_dir.mkdir(parents=True, exist_ok=True)
 
     staging_dir = artifact_dir / "build-context"
-    staged_def = stage_build_context(pkg_root, def_path, staging_dir)
+    staged_def = stage_build_context(
+        pkg_root, def_path, staging_dir, bootstrap_sif=bootstrap_sif
+    )
 
     output_path = artifact_dir / (
         f"sac-{layer}.sandbox" if sandbox else f"sac-{layer}.sif"

--- a/src/scitex_agent_container/cli_pkg/image_group.py
+++ b/src/scitex_agent_container/cli_pkg/image_group.py
@@ -215,6 +215,30 @@ def image_build(layer: str, sandbox: bool, dry_run: bool, yes: bool) -> None:
     # scitex-container backend since they operate on already-built
     # SIFs and don't need build-context staging.
     pkg_root = _RECIPES_DIR.parent
+
+    # Layered .defs (currently: ``scitex``) bootstrap off a prior
+    # layer's SIF via ``Bootstrap: localimage`` / ``From: ./<name>.sif``
+    # — the .def references the SIF as a sibling of itself in the
+    # build-context dir. Resolve the prerequisite SIF path here so
+    # build_layer_from_source can symlink it into the staging dir, and
+    # FAIL LOUD when the prerequisite is missing rather than letting
+    # apptainer FATAL on a half-staged context (the 2026-06-07 cohort-
+    # A rebuild stall: ``sac image build scitex`` ran without the
+    # freshly-built sac-base.sif staged → apptainer FATAL "no such
+    # file or directory" mid-build).
+    bootstrap_sif: Path | None = None
+    if layer == "scitex":
+        bootstrap_sif = out_dir / "sac-base" / "sac-base.sif"
+        if not bootstrap_sif.is_file():
+            click.echo(
+                f"error: scitex layer requires a built sac-base.sif at "
+                f"{bootstrap_sif}; build the base layer first:\n"
+                f"  $ sac image build base -y\n"
+                f"then retry `sac image build scitex -y`.",
+                err=True,
+            )
+            sys.exit(1)
+
     try:
         output = _build_layer_from_source(
             layer=layer,
@@ -223,6 +247,7 @@ def image_build(layer: str, sandbox: bool, dry_run: bool, yes: bool) -> None:
             output_dir=out_dir,
             sandbox=sandbox,
             force=True,  # -y already gated above
+            bootstrap_sif=bootstrap_sif,
         )
     except (FileNotFoundError, RuntimeError) as exc:
         click.echo(f"error: apptainer build failed: {exc}", err=True)

--- a/tests/scitex_agent_container/cli_pkg/test__image_source_build.py
+++ b/tests/scitex_agent_container/cli_pkg/test__image_source_build.py
@@ -27,6 +27,7 @@ swap module-level references the same way ``test_image_group`` does.
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 import zipfile
@@ -361,6 +362,89 @@ def test_stage_build_context_pkg_root_is_file_raises_NotADirectoryError(
 
 
 # ---------------------------------------------------------------------------
+# stage_build_context — bootstrap_sif (layered .def support)
+# ---------------------------------------------------------------------------
+
+
+def test_stage_build_context_symlinks_bootstrap_sif_when_provided(
+    tmp_path, fake_pkg_root, fake_def
+):
+    # Arrange — layered .def case: a prerequisite SIF must be staged
+    # next to the .def so apptainer's relative ``From: ./<name>.sif``
+    # resolves at build time. We use a small fake file; the helper
+    # symlinks (not copies) for instant staging of the real ~3 GB
+    # base SIF.
+    dest = tmp_path / "staging"
+    fake_base_sif = tmp_path / "sac-base.sif"
+    fake_base_sif.write_bytes(b"fake SIF bytes")
+    # Act
+    isb.stage_build_context(fake_pkg_root, fake_def, dest, bootstrap_sif=fake_base_sif)
+    # Assert — staged entry is a symlink (not a copy) pointing at the
+    # absolute resolved source-SIF path; survives the dest_dir's
+    # rmtree-on-next-build lifecycle because the target lives outside.
+    staged = dest / "sac-base.sif"
+    assert staged.is_symlink() and Path(os.readlink(staged)) == fake_base_sif.resolve()
+
+
+def test_stage_build_context_omits_bootstrap_sif_entry_when_not_provided(
+    tmp_path, fake_pkg_root, fake_def
+):
+    # Arrange — top-of-stack .def (``base``, ``proxy``) has no
+    # prerequisite SIF. The staging dir must NOT carry a stray .sif
+    # entry that a non-layered build could trip over.
+    dest = tmp_path / "staging"
+    # Act
+    isb.stage_build_context(fake_pkg_root, fake_def, dest)
+    # Assert
+    sifs = list(dest.glob("*.sif"))
+    assert sifs == []
+
+
+def test_stage_build_context_raises_when_bootstrap_sif_missing(
+    tmp_path, fake_pkg_root, fake_def
+):
+    # Arrange — the operator asked for a layered build but the
+    # prerequisite SIF was never produced (e.g. forgot ``sac image
+    # build base`` first). The helper must FAIL LOUD with a message
+    # that names the missing path AND explains the fix — not let
+    # apptainer crash mid-build on a half-staged context (the
+    # 2026-06-07 cohort-A rebuild stall).
+    dest = tmp_path / "staging"
+    ghost_sif = tmp_path / "does-not-exist.sif"
+
+    # Act
+    def _call():
+        isb.stage_build_context(fake_pkg_root, fake_def, dest, bootstrap_sif=ghost_sif)
+
+    # Assert
+    with pytest.raises(FileNotFoundError, match=r"bootstrap SIF not found"):
+        _call()
+
+
+def test_stage_build_context_preserves_staging_dir_when_bootstrap_sif_missing(
+    tmp_path, fake_pkg_root, fake_def
+):
+    # Arrange — when the bootstrap-sif check fails, the staging dir
+    # must NOT have been wiped. Pairs with the resolve-before-wipe
+    # rule already covering pyproject.toml / README.md so prior good
+    # state survives a misconfig.
+    dest = tmp_path / "staging"
+    dest.mkdir()
+    sentinel = dest / "operator-state.txt"
+    sentinel.write_text("must survive a failed stage_build_context call\n")
+    ghost_sif = tmp_path / "does-not-exist.sif"
+
+    # Act
+    try:
+        isb.stage_build_context(fake_pkg_root, fake_def, dest, bootstrap_sif=ghost_sif)
+    except FileNotFoundError:
+        pass
+
+    # Assert
+    assert sentinel.is_file()
+
+
+# ---------------------------------------------------------------------------
 # build_layer_from_source
 # ---------------------------------------------------------------------------
 
@@ -468,6 +552,35 @@ def test_build_layer_from_source_stages_source_at_known_relative_name(
         and (staged_src / "pyproject.toml").is_file()
         and (staged_src / "src" / "scitex_agent_container" / "__init__.py").is_file()
     )
+
+
+def test_build_layer_from_source_forwards_bootstrap_sif_to_staging(
+    tmp_path, fake_pkg_root, fake_def
+):
+    # Arrange — pin that the public builder forwards ``bootstrap_sif``
+    # through to ``stage_build_context`` so the staged context for a
+    # layered .def actually carries the prerequisite SIF. Without this,
+    # apptainer would FATAL on a half-staged context (the 2026-06-07
+    # cohort-A rebuild stall).
+    out_dir = tmp_path / "out"
+    fake_base_sif = tmp_path / "sac-base.sif"
+    fake_base_sif.write_bytes(b"fake SIF")
+
+    # Act
+    with _use_apptainer_runner(lambda *a, **kw: 0):
+        isb.build_layer_from_source(
+            layer="scitex",
+            def_path=fake_def,
+            pkg_root=fake_pkg_root,
+            output_dir=out_dir,
+            bootstrap_sif=fake_base_sif,
+        )
+
+    # Assert — the staging dir for the scitex layer now carries the
+    # bootstrap SIF as a sibling of the staged .def, ready for
+    # apptainer's relative ``From: ./sac-base.sif`` to resolve.
+    staged_base = out_dir / "sac-scitex" / "build-context" / "sac-base.sif"
+    assert staged_base.exists() and staged_base.is_symlink()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scitex_agent_container/cli_pkg/test_image_group.py
+++ b/tests/scitex_agent_container/cli_pkg/test_image_group.py
@@ -299,6 +299,54 @@ def test_build_reports_apptainer_failure_with_exit_code_1(home_tmp):
     assert result.exit_code == 1 and "apptainer build failed" in result.output
 
 
+def test_build_scitex_passes_bootstrap_sif_pointing_at_built_base_sif(home_tmp):
+    # Arrange — the scitex layer's .def bootstraps off ``sac-base.sif``
+    # at a path RELATIVE to the build-context dir. The CLI must resolve
+    # the prerequisite SIF and forward it as ``bootstrap_sif`` so the
+    # staging helper symlinks it next to the staged .def.
+    base_dir = ig._CONTAINERS_DIR / "sac-base"
+    base_dir.mkdir(parents=True)
+    base_sif = base_dir / "sac-base.sif"
+    base_sif.write_bytes(b"fake base SIF")
+    runner = CliRunner()
+    # Act
+    with _use_source_builder(result=Path("/tmp/sac-scitex.sif")) as calls:
+        result = runner.invoke(image_group, ["build", "scitex", "--yes"])
+    # Assert
+    kwargs = calls[0][1]
+    assert (
+        result.exit_code == 0
+        and kwargs["layer"] == "scitex"
+        and kwargs["bootstrap_sif"] == base_sif
+    )
+
+
+def test_build_base_passes_none_bootstrap_sif(home_tmp):
+    # Arrange — top-of-stack ``base`` .def has no prerequisite SIF;
+    # CLI must NOT make one up (would dangle a stale symlink in the
+    # staging dir).
+    runner = CliRunner()
+    # Act
+    with _use_source_builder(result=Path("/tmp/sac-base.sif")) as calls:
+        runner.invoke(image_group, ["build", "base", "--yes"])
+    # Assert
+    assert calls[0][1]["bootstrap_sif"] is None
+
+
+def test_build_scitex_errors_loud_when_base_sif_missing(home_tmp):
+    # Arrange — the operator asked for scitex but never built (or
+    # successfully overwrote) sac-base.sif first. The CLI must FAIL
+    # LOUD before invoking the builder, with the exact remediation
+    # command in the error text — not let apptainer FATAL on a half-
+    # staged context (the 2026-06-07 cohort-A rebuild stall).
+    runner = CliRunner()
+    # Act — no _use_source_builder: the failure must short-circuit
+    # before the builder is ever called.
+    result = runner.invoke(image_group, ["build", "scitex", "--yes"])
+    # Assert
+    assert result.exit_code == 1 and "sac image build base" in result.output
+
+
 # ---------------------------------------------------------------------------
 # sandbox
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes the 2026-06-07 cohort-A SIF rebuild stall durably. The CLI's source-bundled build path staged the .def + bundled sac source into a build-context dir, but **never staged the prerequisite SIF** that a layered .def needs at `./<name>.sif`. `apptainer-scitex.def` opens with `Bootstrap: localimage` / `From: ./sac-base.sif` (relative to cwd), so apptainer looks for `<build-context>/sac-base.sif` and finds nothing:

```
failed to retrieve path for sac-base.sif: lstat <build-context>/sac-base.sif: no such file or directory
apptainer build failed (rc=255) for layer=scitex
```

Lead worked around it for the immediate rebuild with a manual stage-then-apptainer-build sequence; this PR is the durable fix so the next `sac image build scitex` works out of the box and a future operator doesn't rediscover it.

## Change

- **`_image_source_build.stage_build_context`** accepts `bootstrap_sif: Path | None`. When set, the helper **symlinks** (not copies) the SIF into the staging dir under its own filename, using the absolute resolved target path so the link survives `rmtree`-on-next-build and arbitrary cwd switches. Symlink chosen because the real base SIF is ~3 GB — copying every build would cost ~30 s on SSD, and apptainer follows symlinks for the `Bootstrap: localimage` / `From: ./...` reference at build time. Validation runs BEFORE the staging-dir wipe so a missing-prereq failure doesn't strand the operator with a half-staged tree.
- **`_image_source_build.build_layer_from_source`** adds the matching `bootstrap_sif` kwarg, forwarded to `stage_build_context`.
- **`cli_pkg/image_group.image_build`** auto-detects layered .defs (currently `scitex`) and resolves the prerequisite SIF path to `<containers_dir>/sac-base/sac-base.sif`. **FAILS LOUD** with the exact remediation command (`sac image build base -y`) when the prereq SIF is missing — no silent apptainer crash mid-build, no half-built broken SIF.

`None` for top-of-stack defs (`base`, `proxy`) — no SIF is staged so a non-layered build cannot trip over a stray entry.

## Tests (no mocks, real fixtures, AAA markers)

`test__image_source_build.py`:
- `test_stage_build_context_symlinks_bootstrap_sif_when_provided` — symlink, absolute target, no copy
- `test_stage_build_context_omits_bootstrap_sif_entry_when_not_provided` — no stray `.sif` for top-of-stack
- `test_stage_build_context_raises_when_bootstrap_sif_missing` — loud `FileNotFoundError`
- `test_stage_build_context_preserves_staging_dir_when_bootstrap_sif_missing` — validate-before-wipe
- `test_build_layer_from_source_forwards_bootstrap_sif_to_staging` — passthrough through the public builder

`test_image_group.py`:
- `test_build_scitex_passes_bootstrap_sif_pointing_at_built_base_sif` — CLI resolves the path
- `test_build_base_passes_none_bootstrap_sif` — no symlink for top-of-stack
- `test_build_scitex_errors_loud_when_base_sif_missing` — pre-flight fail with the remediation string

## Verification

- 83/83 file-level tests pass (75 existing + 8 new).
- Ruff clean on all 4 changed files.
- (Full suite not blocked on a re-run; the change touches only the staging+CLI surface that the targeted tests cover end-to-end. CI is the authoritative gate.)

## Deploy note

Per lead msg `c13283f39c1c43feb695effed816be05` (2026-06-07): I'm last in the staggered rolling restart. This PR landing on develop is the prerequisite for the next host-side `sac image build` cycle to be self-sufficient (no manual workaround), and is also the prerequisite for restarting me onto a SIF that already carries its own durable build-context fix.

## Test plan

- [x] Targeted tests pass (83/83)
- [x] Ruff clean
- [ ] CI green
- [ ] Auto-merge per standing order
- [ ] Next `sac image build scitex` invocation works without manual staging