### PR TITLE
fix(_session_hooks): categorical empty-beacon guard + emit-state diagnostic (#326-part-2)

### DIFF
--- a/src/scitex_agent_container/_runners/_session_hooks.py
+++ b/src/scitex_agent_container/_runners/_session_hooks.py
@@ -41,6 +41,7 @@ does NOT crash the agent — the turn already completed; the hook returns
 from __future__ import annotations
 
 import logging
+import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Optional
@@ -110,19 +111,30 @@ async def emit_completion_push(
       a bare runner with no host control-plane has nowhere to push;
     * the turn had no requester (a mission/boot turn answers to no peer);
     * this turn was already pushed; or
-    * the push would be structurally empty (see the fleet-noise guards
-      inline below): the summary is empty/whitespace AND either there is
-      no ledger correlation (``dispatch_id is None``) OR no honest
-      outcome was recorded (``status == STATUS_UNKNOWN``). Every empty
-      push burns the requester's turn cycle for zero signal; the union
-      catches both noise patterns observed in the wild without dropping
-      any signal-carrying push.
+    * the push would not carry information the requester can act on.
+      The CATEGORICAL guard (lead 2026-06-07, #326-part-2): suppress
+      UNLESS BOTH ``status in {SUCCESS, FAILURE}`` AND
+      ``summary_stripped`` is non-empty. The previous union-style guard
+      still leaked ~4% of empty beacons (60 wild leaks observed under
+      #326 in a single 30-min idle window, all ``status="unknown"``,
+      escaping the union because some path repopulated ``.summary``
+      without flipping ``.status``). The categorical form removes the
+      ambiguity: no real outcome OR no content → drop. Anything else
+      is signal and flows.
 
     Status is taken verbatim from ``turn_context.status`` — set honestly by
     the conversation (``success`` on clean drain, ``failure`` on SDK error).
     A ``None`` status (the push fired before the conversation recorded an
     outcome — should not happen, since Stop comes after the ResultMessage)
     is reported as ``unknown``, NEVER fabricated as success.
+
+    A diagnostic ``log.warning("completion-push emit-state ...")`` is
+    emitted on every reachable call so the next SIF cycle captures the
+    actual emit-state at leak-time — root-causing both the residual
+    leak path AND bug #2 (legitimate success pushes silently suppressed
+    by a Stop-hook-fires-before-finally race that flips ``pushed=True``
+    prematurely). The diagnostic stays in until bug #2 is filed and
+    root-caused; it can then drop to DEBUG.
 
     A delivery failure is LOUD (logged at WARNING, requester named) but
     never re-raised: the turn already completed, and a flaky receipt must
@@ -134,38 +146,69 @@ async def emit_completion_push(
     if not requester or turn_context.pushed:
         return
 
-    from ._session_completion import STATUS_UNKNOWN, build_completion_report
+    from ._session_completion import (
+        STATUS_FAILURE,
+        STATUS_SUCCESS,
+        STATUS_UNKNOWN,
+        build_completion_report,
+    )
 
     status = turn_context.status or STATUS_UNKNOWN
     summary_stripped = (turn_context.summary or "").strip()
 
-    # Fleet-noise guards — suppress structurally-empty pings at the
-    # source. Either signature flips the noise gate:
+    # Diagnostic: stamp WHO called us + the full state at emit time so
+    # we can correlate against the stdout warning + the inbox-side leak
+    # next SIF cycle. Stack-introspection (rather than a new kwarg) keeps
+    # the seam stable for the two call sites (Stop hook + _drive_turn
+    # finally) and any future caller. Bounded summary repr so a runaway
+    # turn cannot bloat the log line.
+    _caller_frame = sys._getframe(1)
+    _caller_name = (
+        f"{_caller_frame.f_code.co_filename.rsplit('/', 1)[-1]}:"
+        f"{_caller_frame.f_code.co_name}"
+    )
+    log.warning(
+        "completion-push emit-state requester=%r dispatch_id=%r "
+        "status=%r summary=%r pushed=%r caller=%s",
+        requester,
+        turn_context.dispatch_id,
+        turn_context.status,
+        (turn_context.summary or "")[:80],
+        turn_context.pushed,
+        _caller_name,
+    )
+
+    # Categorical fleet-noise guard (#326-part-2, 2026-06-07).
     #
-    # (1) PR #309 (2026-06-05): no ledger correlation AND no content.
-    #     The wire signature
-    #     ``{"agent": <name>, "dispatch_id": null, "status": "unknown",
-    #     "summary": ""}`` is the canonical "nothing real to report"
-    #     payload — every idle/wake turn that had no incoming
-    #     dispatch_id and produced no assistant text used to fire one.
+    # A completion push only carries information for the requester when
+    # BOTH legs are honest:
+    #   * ``status in {SUCCESS, FAILURE}`` — the conversation reached a
+    #     real outcome (clean ResultMessage or a caught exception). Any
+    #     other status, including the ``STATUS_UNKNOWN`` coercion of a
+    #     ``None`` ``turn_context.status``, means the emit fired before
+    #     the conversation recorded an outcome — by definition nothing
+    #     to report.
+    #   * ``summary_stripped`` is non-empty — the assistant produced
+    #     content the requester can read. A whitespace-only summary
+    #     counts as empty (strip first).
     #
-    # (2) Lead 2026-06-07 (conv 62b0f613104048c6adae11c73d9f8b63): no
-    #     honest outcome AND no content, REGARDLESS of dispatch_id. A
-    #     push with ``status:"unknown"`` + empty summary carries no
-    #     information for the requester even when a dispatch_id is
-    #     set — "we tried this dispatch and have nothing to say about
-    #     it" is worse than useless. Observed in the wild: roughly 1
-    #     in 6 empty pings from a stuck sibling rode a real
-    #     dispatch_id and leaked past guard (1).
+    # If EITHER leg fails, drop. The previous union-style guard
+    # (``status == UNKNOWN`` OR ``dispatch_id is None``, gated on empty
+    # summary) still leaked: in a single 30-min idle window on the
+    # post-#326 SIF, 60 empty ``status="unknown"`` beacons escaped to
+    # clew/neurovista alongside ZERO ``status="success"`` failures —
+    # i.e. some path repopulated ``.summary`` without flipping
+    # ``.status``, slipping past the ``not summary_stripped`` clause.
+    # The categorical form removes that ambiguity by predicating on the
+    # honest-state AND-condition the requester actually needs.
     #
-    # Signal preserved: a push with non-empty summary always emits; a
-    # push with empty summary but an honest status (``success`` or
-    # ``failure``) AND a dispatch_id still emits so the requester can
-    # correlate. ``pushed = True`` still flips so a re-entrant Stop
-    # hook on the same turn re-evaluates and skips identically.
-    if not summary_stripped and (
-        turn_context.dispatch_id is None or status == STATUS_UNKNOWN
-    ):
+    # Bug #2 follow-up (separate from this guard): the absence of any
+    # ``status="success"`` failure in the same window strongly suggests
+    # legitimate success pushes are being suppressed by a Stop-hook /
+    # finally race that flips ``pushed=True`` before the success state
+    # is recorded. Root-caused later with the diagnostic above; the
+    # operator's empty-ping goal is met without it.
+    if status not in (STATUS_SUCCESS, STATUS_FAILURE) or not summary_stripped:
         turn_context.pushed = True
         return
 

--- a/tests/scitex_agent_container/_runners/test__session_completion.py
+++ b/tests/scitex_agent_container/_runners/test__session_completion.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import os
 import socket
 from pathlib import Path
@@ -620,11 +621,16 @@ class TestSuppressEmptyCompletions:
         # Assert
         assert observed == []
 
-    def test_emit_when_dispatch_id_present_even_with_empty_summary(self) -> None:
-        # Arrange — a dispatched turn that legitimately produced no
-        # assistant text (acks, hook-only turns) MUST still report so
-        # the requester can correlate by dispatch_id. The guard only
-        # suppresses the BOTH-empty case.
+    def test_suppress_success_with_dispatch_id_when_summary_empty(self) -> None:
+        # Arrange — #326-part-2 categorical-guard flip: a SUCCESS turn
+        # with a real dispatch_id but EMPTY summary is now suppressed.
+        # The previous guard let it through (dispatch_id-as-rescue), but
+        # the wild leak under #326 proved the union form was unsafe; the
+        # categorical form predicates on (real-status AND real-summary)
+        # — empty summary alone fails the AND regardless of dispatch_id.
+        # An empty-summary success is acceptable to drop: it carries no
+        # information beyond the dispatch_id itself (which the sender
+        # already minted and the requester already has).
         ctx = TurnContext()
         ctx.begin(requester="lead", dispatch_id="d-no-summary")
         ctx.finish(status=STATUS_SUCCESS, summary="")
@@ -639,8 +645,10 @@ class TestSuppressEmptyCompletions:
 
         # Act
         observed = asyncio.run(_scenario())
-        # Assert
-        assert len(observed) == 1
+        # Assert — push_fn was NEVER invoked: the SUCCESS status alone
+        # cannot rescue an empty-summary payload under the categorical
+        # guard.
+        assert observed == []
 
     def test_emit_when_summary_present_even_without_dispatch_id(self) -> None:
         # Arrange — symmetric: a non-dispatched turn with REAL content
@@ -734,12 +742,18 @@ class TestSuppressEmptyCompletions:
         # Assert
         assert observed == []
 
-    def test_emit_failure_with_dispatch_id_even_with_empty_summary(self) -> None:
-        # Arrange — signal preservation: a dispatched failure that
-        # produced no captured detail is still a real outcome the
-        # requester needs to hear about (the failure status itself is
-        # signal); the strengthened guard MUST NOT swallow it. Only the
-        # status==unknown path is suppressed when summary is empty.
+    def test_suppress_failure_with_dispatch_id_when_summary_empty(self) -> None:
+        # Arrange — #326-part-2 categorical-guard flip: a FAILURE turn
+        # with a real dispatch_id but EMPTY summary is now suppressed.
+        # The previous guard kept it ("failure is signal even without
+        # summary text"), but the wild leak under #326 proved the union
+        # form was unsafe; the categorical form predicates on
+        # (real-status AND real-summary) — empty summary alone fails
+        # the AND regardless of status. A bare ``status=failure`` with
+        # no detail is unactionable for the requester anyway; the
+        # _drive_turn except-branch always sets ``summary=str(exc)``
+        # which is never empty in practice, so this drop loses no real
+        # signal.
         ctx = TurnContext()
         ctx.begin(requester="lead", dispatch_id="d-honest-fail")
         ctx.finish(status=STATUS_FAILURE, summary="")
@@ -754,16 +768,21 @@ class TestSuppressEmptyCompletions:
 
         # Act
         observed = asyncio.run(_scenario())
-        # Assert — failure-status push still emits despite the empty
-        # summary; failure is signal even without summary text.
-        assert len(observed) == 1
+        # Assert — push_fn was NEVER invoked: empty summary fails the
+        # AND-condition even with a real failure status.
+        assert observed == []
 
-    def test_status_unknown_with_real_summary_still_emits(self) -> None:
-        # Arrange — symmetric to the non-empty-content branch in #309:
-        # an honest "unknown" status that DID capture summary text is
-        # signal (e.g. partial output before an interrupt); don't
-        # suppress just because the conversation never reached a clean
-        # ResultMessage / exception path.
+    def test_suppress_status_unknown_even_with_real_summary(self) -> None:
+        # Arrange — #326-part-2 categorical-guard flip: a status=unknown
+        # turn with a REAL summary is now suppressed. The previous
+        # behaviour kept it (status=unknown + content was treated as
+        # signal), but the leak data showed turn_context.summary can
+        # become non-empty while .status stays None on at least one
+        # path — that's exactly how the 60 wild leaks escaped. The
+        # categorical form drops the entire ``status not in
+        # {SUCCESS, FAILURE}`` cone, so no future repopulate-summary-
+        # without-flipping-status race can produce a leak again.
+        # Real-status+real-summary remains the ONLY emit branch.
         ctx = TurnContext()
         ctx.begin(requester="lead", dispatch_id="d-partial")
         ctx.finish(status=STATUS_UNKNOWN, summary="partial output then interrupt")
@@ -778,8 +797,216 @@ class TestSuppressEmptyCompletions:
 
         # Act
         observed = asyncio.run(_scenario())
+        # Assert — push_fn was NEVER invoked: status=unknown alone
+        # fails the AND-condition regardless of summary content.
+        assert observed == []
+
+
+# ---------------------------------------------------------------------------
+# emit_completion_push — #326-part-2 categorical guard (load-bearing
+# regression test). The headline fix is: suppress ANY beacon that isn't
+# (real-status AND real-summary). The three legs below cover the entire
+# truth table at the guard:
+#
+#   leg A — status ∉ {SUCCESS, FAILURE}: drop (regardless of summary)
+#   leg B — summary empty/whitespace:    drop (regardless of status)
+#   leg C — real-status AND real-summary: push
+#
+# Real TurnContext, real push_fn closure (in-process recorder), no mocks.
+# ---------------------------------------------------------------------------
+
+
+class TestCategoricalGuard:
+    @pytest.mark.parametrize(
+        ("status", "summary"),
+        [
+            # leg A (typed-status variant) — explicit non-real statuses
+            # set via finish(). Each row drops regardless of summary
+            # content. Covers STATUS_UNKNOWN (the dominant wild leak
+            # signature) plus a non-canonical string the guard must
+            # also catch (defensive cone: anything-not-real → drop).
+            (STATUS_UNKNOWN, ""),
+            (STATUS_UNKNOWN, "    "),
+            (STATUS_UNKNOWN, "looks like real content but status says otherwise"),
+            ("garbage-not-in-set", "anything"),
+        ],
+    )
+    def test_leg_a_status_not_real_drops_explicit(
+        self, status: str, summary: str
+    ) -> None:
+        # Arrange — guard leg A (explicit non-real status): any status
+        # outside {SUCCESS, FAILURE} means the conversation never
+        # recorded a real outcome; the push is information-free
+        # regardless of summary contents. This row mirrors the wild
+        # leak shape (status=unknown + dispatch_id set + summary
+        # populated by some unaccounted path).
+        ctx = TurnContext()
+        ctx.begin(requester="lead", dispatch_id="d-leg-a")
+        ctx.finish(status=status, summary=summary)
+        calls: list = []
+
+        async def _push_fn(report, requester, dispatch_id):
+            calls.append(report)
+
+        async def _scenario():
+            await emit_completion_push(ctx, _push_fn, agent_name="worker")
+            return calls
+
+        # Act
+        observed = asyncio.run(_scenario())
         # Assert
+        assert observed == []
+
+    @pytest.mark.parametrize(
+        "summary",
+        [
+            # leg A (None-status variant) — the mid-stream-emit shape:
+            # begin() set status=None, finish() never ran. summary may
+            # have been repopulated by some unaccounted path (mirrors
+            # the residual leak hypothesis). The guard must still drop.
+            "",
+            "stream interrupted mid-turn",
+        ],
+    )
+    def test_leg_a_status_none_drops(self, summary: str) -> None:
+        # Arrange — guard leg A (raw-None status): begin() set
+        # status=None; assignment-bypass on .summary mimics the
+        # observed wild leak — where some path repopulated the summary
+        # without flipping .status. The status==UNKNOWN coercion in
+        # emit_completion_push fires (None → "unknown"); the
+        # categorical guard then drops the push as leg A intends.
+        ctx = TurnContext()
+        ctx.begin(requester="lead", dispatch_id="d-leg-a-none")
+        ctx.summary = summary  # direct assignment; finish() not called
+        calls: list = []
+
+        async def _push_fn(report, requester, dispatch_id):
+            calls.append(report)
+
+        async def _scenario():
+            await emit_completion_push(ctx, _push_fn, agent_name="worker")
+            return calls
+
+        # Act
+        observed = asyncio.run(_scenario())
+        # Assert
+        assert observed == []
+
+    @pytest.mark.parametrize(
+        ("status", "summary"),
+        [
+            # leg B — summary is empty/whitespace; status varies. Every
+            # row MUST drop regardless of status, including the honest
+            # SUCCESS/FAILURE cases the previous union-guard let through
+            # under dispatch_id rescue.
+            (STATUS_SUCCESS, ""),
+            (STATUS_SUCCESS, "  \n\t  "),
+            (STATUS_FAILURE, ""),
+            (STATUS_FAILURE, "\n"),
+        ],
+    )
+    def test_leg_b_summary_empty_drops(self, status: str, summary: str) -> None:
+        # Arrange — guard leg B: an empty/whitespace summary carries no
+        # information for the requester even when status is real. The
+        # categorical drop replaces the previous "rescue via dispatch_id"
+        # branch that proved unsafe in production (#326-part-2).
+        ctx = TurnContext()
+        ctx.begin(requester="lead", dispatch_id="d-leg-b")
+        ctx.finish(status=status, summary=summary)
+        calls: list = []
+
+        async def _push_fn(report, requester, dispatch_id):
+            calls.append(report)
+
+        async def _scenario():
+            await emit_completion_push(ctx, _push_fn, agent_name="worker")
+            return calls
+
+        # Act
+        observed = asyncio.run(_scenario())
+        # Assert
+        assert observed == []
+
+    @pytest.mark.parametrize(
+        ("status", "summary"),
+        [
+            # leg C — real-status AND real-summary; the only emit branch.
+            # Both dispatch_id-present and dispatch_id-absent flows must
+            # push: the requester correlates by dispatch_id when set, by
+            # content otherwise; either way the payload is signal.
+            (STATUS_SUCCESS, "real assistant reply"),
+            (STATUS_SUCCESS, "x"),  # minimal but non-empty
+            (STATUS_FAILURE, "ProcessError: claude exited 1"),
+        ],
+    )
+    def test_leg_c_real_status_and_real_summary_pushes(
+        self, status: str, summary: str
+    ) -> None:
+        # Arrange — guard leg C: the ONLY honest emit branch. Confirms
+        # the categorical drop doesn't over-reach and silence legitimate
+        # completions. Mirrors the clean ResultMessage path
+        # (status=SUCCESS, summary=chunks) and the caught-exception path
+        # (status=FAILURE, summary=str(exc)) in _drive_turn verbatim.
+        ctx = TurnContext()
+        ctx.begin(requester="lead", dispatch_id="d-leg-c")
+        ctx.finish(status=status, summary=summary)
+        calls: list = []
+
+        async def _push_fn(report, requester, dispatch_id):
+            calls.append(report)
+
+        async def _scenario():
+            await emit_completion_push(ctx, _push_fn, agent_name="worker")
+            return calls
+
+        # Act
+        observed = asyncio.run(_scenario())
+        # Assert — exactly one push fired, carrying the honest payload
+        # the requester needs.
         assert len(observed) == 1
+
+
+class TestDiagnosticEmitState:
+    def test_diagnostic_log_fires_on_every_reachable_emit_call(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # Arrange — the diagnostic ``log.warning("completion-push
+        # emit-state ...")`` is load-bearing for root-causing the
+        # residual leak path AND bug #2 (legitimate success pushes
+        # silently suppressed by the Stop-hook / finally race). It MUST
+        # fire on every call that reaches the guard, regardless of
+        # whether the guard drops or the push fires. Two scenarios:
+        # a guard-drop (status=unknown) and a clean push (SUCCESS +
+        # real summary).
+        caplog.set_level(
+            logging.WARNING, logger="scitex_agent_container._runners._session_hooks"
+        )
+        ctx_drop = TurnContext()
+        ctx_drop.begin(requester="lead", dispatch_id="d-drop")
+        ctx_drop.finish(status=STATUS_UNKNOWN, summary="")
+        ctx_push = TurnContext()
+        ctx_push.begin(requester="lead", dispatch_id="d-push")
+        ctx_push.finish(status=STATUS_SUCCESS, summary="real reply")
+        calls: list = []
+
+        async def _push_fn(report, requester, dispatch_id):
+            calls.append(report)
+
+        async def _scenario():
+            await emit_completion_push(ctx_drop, _push_fn, agent_name="worker")
+            await emit_completion_push(ctx_push, _push_fn, agent_name="worker")
+
+        # Act
+        asyncio.run(_scenario())
+        # Assert — both reachable calls emitted the emit-state diagnostic;
+        # caller= stamp lets us distinguish Stop-hook vs finally vs other
+        # next SIF cycle without rebuilding for diagnostic logging.
+        diag_lines = [
+            rec
+            for rec in caplog.records
+            if rec.getMessage().startswith("completion-push emit-state")
+        ]
+        assert len(diag_lines) == 2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **Categorical guard** replaces the union-style guard from #326: a completion push only emits when BOTH ``status in {SUCCESS, FAILURE}`` AND ``summary_stripped`` is non-empty. Anything else drops.
- **Emit-state diagnostic** (``log.warning('completion-push emit-state requester=... dispatch_id=... status=... summary=... pushed=... caller=...')``) stamps every reachable call with stack-introspected caller info so the next SIF cycle captures the actual emit-state at leak-time. Lets us root-cause bug #2 (legitimate success pushes silently suppressed by a Stop-hook / finally race) without a dedicated diagnostic rebuild.
- **Regression tests** cover all three legs of the new categorical truth table (status not real → drop; summary empty → drop; real-status + real-summary → push) plus a caplog assertion that the diagnostic fires on every reachable call. Three existing union-guard tests had their expectations flipped to match the new behaviour.

## Why this is needed
The strengthened guard from #326 still leaked. In a single 30-min idle window on the post-#326 SIF (this agent's runner), **60 ``completion push failed (status=unknown dispatch_id=...)`` warnings escaped** to clew/neurovista alongside **ZERO ``status=success`` failures** — i.e. some emit path repopulated ``turn_context.summary`` without flipping ``.status``, slipping past the ``not summary_stripped`` clause of the union. The categorical AND-form removes the ambiguity by predicating on the honest-state AND-condition the requester actually needs.

The data also surfaced bug #2: the absence of any ``status=success`` failure in the same window strongly suggests legitimate success pushes are being silently suppressed by a Stop-hook / finally race that flips ``pushed=True`` before the success state is recorded. That is a SEPARATE bug, filed for follow-up — the operator's headline empty-ping goal is met without it because the fleet communicates via explicit ``a2a_send``. The emit-state diagnostic lands now so root-causing #2 is one SIF cycle of data away rather than a dedicated rebuild.

## Test plan
- [x] ``tests/scitex_agent_container/_runners/test__session_completion.py`` — all 44 pass (3 existing tests' expectations updated; 9 new parametrised regression rows + 1 caplog test added).
- [x] Full ``tests/_runners/`` — 379 pass.
- [x] Full repo suite — 6466 passed, 38 skipped. The 7 sequential-mode failures are pre-existing infra issues (3 cross-host SSH tests parallel-flaky / pass alone, 1 broker env-restore parallel-flaky / pass alone, 1 CLI startup-budget perf miss, 1 audit-test failing on pre-existing repo-level violations like the workflow-secret prefix, 1 worktree-dir from this exact PR's worktree-based development). None are introduced by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)