### PR TITLE
fix(claude-worktree): relocate Claude Code worktree creations to <root>/.worktrees (F-CS8 prevention)

### DIFF
--- a/src/scitex_agent_container/_baseline_assets/claude_worktree_hooks/README.md
+++ b/src/scitex_agent_container/_baseline_assets/claude_worktree_hooks/README.md
@@ -1,0 +1,108 @@
+# Claude Code worktree-relocation hooks
+
+Canonical, version-controlled implementation of Claude Code's
+`WorktreeCreate` / `WorktreeRemove` hooks for the SAC fleet. Verified
+2026-06-06 against the `executeWorktreeCreateHook` function in the
+`claude_agent_sdk._bundled.claude` binary shipped with the runner's
+venv.
+
+## Why
+
+Claude Code's default worktree mode creates `.claude/worktrees/<name>`
+under the project root. That tree is never self-cleaned and
+accumulates multi-GB / 100k-file bloat that wedges agents (F-CS8
+recurrence ~100×; wedged neurovista at 22.9 GB / 80k files → 0-output
+turns). The operator's daily prune cron already maintains hygiene on
+`<root>/.worktrees/` — these hooks relocate creations there so
+prevention and cleanup meet in the same tree.
+
+## What
+
+- `worktree_create.py` — reads hook input on stdin, creates
+  `<git-root>/.worktrees/<name>` via `git worktree add` on a fresh
+  `claude/<name>` branch off `origin/develop` (or HEAD as fallback),
+  echoes the absolute path on stdout. Idempotent on re-trigger.
+- `worktree_remove.py` — reads hook input on stdin, runs
+  `git worktree remove` (with a `--force` second pass on failure).
+  Idempotent.
+- `settings.local.json.fragment.json` — the hooks-section snippet to
+  merge into the baseline `to_home/.claude/settings.local.json`.
+
+## How to deploy fleet-wide
+
+1. Copy `worktree_create.py` and `worktree_remove.py` to the baseline:
+
+       <agents_dir>/_base/to_home/.claude/hooks/claude_worktree_hooks/
+
+   The runtime's `_to_home.py` materializes that tree into every
+   agent's `$HOME/.claude/hooks/claude_worktree_hooks/` on each start.
+
+2. Merge the `hooks` block from `settings.local.json.fragment.json`
+   into `<agents_dir>/_base/to_home/.claude/settings.local.json`
+   (under the top-level `hooks` key). The fragment's `_comment_*`
+   string carries the source-of-truth audit trail and should be
+   preserved.
+
+3. Restart agents (or wait for next natural restart). NO SIF REBUILD
+   IS NEEDED: `_to_home.py` runs on every agent start, the hook
+   scripts and the settings file land in `$HOME` from the host-side
+   baseline at materialize time, and Claude Code reads
+   `~/.claude/settings.local.json` on each session boot.
+
+## Hook contract — what the SDK guarantees and demands
+
+`WorktreeCreate` input (stdin, JSON):
+
+```json
+{
+  "hook_event_name": "WorktreeCreate",
+  "name": "<worktree-name>",
+  "cwd": "<dir-the-session-launched-from>",
+  "session_id": "<uuid>",
+  "transcript_path": "<path>",
+  "permission_mode": "<mode>",
+  "agent_id": "<id>",
+  "agent_type": "<type>"
+}
+```
+
+Required output: a single line on stdout = absolute path of the
+created worktree (which MUST be a real directory by the time the
+process exits). Any other shape → Claude Code rejects with
+`WorktreeCreate hook failed: hook succeeded but returned no worktree
+path` or `... returned a path that is not a directory`.
+
+`WorktreeRemove` input mirrors the above with `worktree_path`
+replacing `name`. The hook just needs to succeed; stdout is not read.
+
+## Verification
+
+Regression tests in
+`tests/scitex_agent_container/_baseline_assets/claude_worktree_hooks/`
+drive both hooks against a real ephemeral git repo (no mocks, no
+patches) and assert: target path lands under `.worktrees/`,
+`git worktree list` reflects it, idempotent re-trigger emits the same
+path, invalid input fails loud, remove tears it down cleanly.
+
+## Source-of-truth audit
+
+The hook event names + I/O shape were verified against the
+deobfuscated `_bundled/claude` binary's `VRH` function:
+
+```js
+async function VRH(H){
+  let $ = {...b5(void 0), hook_event_name: "WorktreeCreate", name: H};
+  let q = await O2({hookInput: $, timeoutMs: Y_});
+  let K = q.find(A => A.succeeded && A.output.trim().length > 0);
+  if (!K) {
+    if (q.length === 0)
+      throw Error("WorktreeCreate hook failed: hook is configured but did not run...");
+    ...
+  }
+  return {worktreePath: K.output.trim()};
+}
+```
+
+(and `x$$` for WorktreeRemove with `worktree_path`). If a future SDK
+upgrade changes the schema, the regression tests below will detect it
+on probe — DO NOT skip the live-probe step before fleet-wide rollout.

--- a/src/scitex_agent_container/_baseline_assets/claude_worktree_hooks/settings.local.json.fragment.json
+++ b/src/scitex_agent_container/_baseline_assets/claude_worktree_hooks/settings.local.json.fragment.json
@@ -1,0 +1,26 @@
+{
+  "_comment_worktree_hooks": "Claude Code WorktreeCreate / WorktreeRemove hook wiring. Source-of-truth verified 2026-06-06 against the JS function VRH (executeWorktreeCreateHook) in claude_agent_sdk._bundled.claude. Merge into the baseline settings.local.json under `hooks`. Scripts live next to this fragment as worktree_create.py / worktree_remove.py and must be deployed to $HOME/.claude/hooks/claude_worktree_hooks/ on every agent via to_home materialization.",
+
+  "hooks": {
+    "WorktreeCreate": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/opt/venv-agent/bin/python3 $HOME/.claude/hooks/claude_worktree_hooks/worktree_create.py"
+          }
+        ]
+      }
+    ],
+    "WorktreeRemove": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/opt/venv-agent/bin/python3 $HOME/.claude/hooks/claude_worktree_hooks/worktree_remove.py"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/scitex_agent_container/_baseline_assets/claude_worktree_hooks/worktree_create.py
+++ b/src/scitex_agent_container/_baseline_assets/claude_worktree_hooks/worktree_create.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Claude Code ``WorktreeCreate`` hook — relocates worktree creation to
+``<git-root>/.worktrees/<name>`` instead of the SDK's default
+``.claude/worktrees/<name>``.
+
+Why
+---
+Claude Code's bundled binary (Agent SDK) creates session/agent worktrees
+under ``.claude/worktrees/<name>`` by default. That directory is never
+self-cleaned and accumulates into multi-GB / 100k-file bloat that wedges
+agents (F-CS8 recurrence ~100×; wedged neurovista at 22.9 GB / 80k files
+→ 0-output turns). The operator already runs a daily prune cron over the
+``<root>/.worktrees/`` tree (mtime-gated, never touches ``.claude/``);
+relocating creations there hooks the prevention side of the same policy.
+
+How
+---
+Claude Code v2.x supports a ``WorktreeCreate`` hook in ``settings.json``
+that supersedes its built-in worktree creation. The hook reads a JSON
+blob from stdin:
+
+    {
+        "hook_event_name": "WorktreeCreate",
+        "name": "<worktree-name>",
+        "cwd": "<dir-the-session-launched-from>",
+        "session_id": "<uuid>",
+        ...base fields
+    }
+
+and MUST do TWO things:
+
+1. Create a fresh git worktree on disk at a real directory.
+2. Echo the absolute path of that directory to stdout (single line).
+
+The hook contract is enforced loudly by the SDK — if we echo a path that
+isn't a directory, or echo nothing, Claude Code rejects with
+``WorktreeCreate hook returned a path that is not a directory`` /
+``hook succeeded but returned no worktree path``. The deobfuscated
+binary's ``VRH`` (executeWorktreeCreateHook) function is the contract
+source-of-truth verified 2026-06-06 against the
+``claude_agent_sdk._bundled.claude`` binary shipped with this venv.
+
+Policy
+------
+* **Target dir**: ``<git-root>/.worktrees/<name>`` — under ``.worktrees``,
+  NOT ``.claude/worktrees``. The operator's cron already maintains hygiene
+  on this tree.
+* **Branch ref**: ``origin/develop`` when fetchable, ``HEAD`` otherwise.
+  Mirrors Claude's own "fresh" default (clean tree from the trunk).
+* **Branch name**: ``claude/<name>`` — namespaced so a bulk
+  ``git branch -D 'claude/*'`` reaps them cleanly.
+* **Idempotence**: if the target worktree path already exists in
+  ``git worktree list``, we just re-emit its path (no double-create).
+* **Existing branch**: if ``claude/<name>`` already exists, we attach the
+  worktree to it (worktree add without ``-b``). Lets the operator/agent
+  resume a worktree across restarts without manual fixup.
+
+Failure mode
+------------
+Every failure exits non-zero with a diagnostic on stderr. The SDK
+surfaces stderr in its ``WorktreeCreate hook failed`` error so the
+operator sees what went wrong instead of a silent fall-through to the
+hardcoded default.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _run_git(*args: str, cwd: str) -> str:
+    """Run ``git -C cwd <args>``; return stdout stripped. Raises CalledProcessError on non-zero exit."""
+    res = subprocess.run(
+        ["git", "-C", cwd, *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return res.stdout.strip()
+
+
+def _try_git(*args: str, cwd: str) -> tuple[bool, str]:
+    """Try ``git -C cwd <args>``; return (ok, stdout-or-stderr). No raise."""
+    res = subprocess.run(
+        ["git", "-C", cwd, *args],
+        capture_output=True,
+        text=True,
+    )
+    if res.returncode == 0:
+        return True, res.stdout.strip()
+    return False, (res.stderr or res.stdout).strip()
+
+
+def _worktree_already_exists(git_root: str, target: Path) -> bool:
+    """``git worktree list --porcelain`` includes a ``worktree <abs-path>`` line per worktree."""
+    out = _run_git("worktree", "list", "--porcelain", cwd=git_root)
+    needle = f"worktree {target}"
+    return any(line == needle for line in out.splitlines())
+
+
+def _branch_exists(git_root: str, branch: str) -> bool:
+    ok, _ = _try_git(
+        "rev-parse", "--verify", "--quiet", f"refs/heads/{branch}", cwd=git_root
+    )
+    return ok
+
+
+def _resolve_base(git_root: str) -> str:
+    """Branch source policy: ``origin/develop`` when present, else HEAD."""
+    if _branch_exists(git_root, "develop"):
+        # Local develop fast-path — usually already up-to-date with origin.
+        pass
+    ok, _ = _try_git("rev-parse", "--verify", "--quiet", "origin/develop", cwd=git_root)
+    if ok:
+        return "origin/develop"
+    return "HEAD"
+
+
+def main() -> int:
+    """Read the hook input from stdin, create the worktree, echo its path.
+
+    Returns the process exit code (0 on success; non-zero with stderr
+    diagnostic on any failure, so the SDK shows the real reason).
+    """
+    raw = sys.stdin.read()
+    if not raw.strip():
+        print("WorktreeCreate hook: empty stdin (expected JSON)", file=sys.stderr)
+        return 2
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        print(f"WorktreeCreate hook: stdin is not valid JSON: {exc}", file=sys.stderr)
+        return 2
+
+    name = (payload.get("name") or "").strip()
+    cwd = (payload.get("cwd") or "").strip()
+    if not name:
+        print("WorktreeCreate hook: 'name' missing in input", file=sys.stderr)
+        return 2
+    if not cwd or not os.path.isdir(cwd):
+        print(
+            f"WorktreeCreate hook: 'cwd' missing or not a dir: {cwd!r}", file=sys.stderr
+        )
+        return 2
+
+    # ``name`` arrives from Claude Code's session bookkeeping; we treat
+    # it as a path segment and reject any traversal/separator nasties
+    # so the hook can never write outside ``<git-root>/.worktrees/``.
+    if "/" in name or ".." in name.split("."):
+        print(
+            f"WorktreeCreate hook: invalid 'name' (path-traversal): {name!r}",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        git_root = _run_git("rev-parse", "--show-toplevel", cwd=cwd)
+    except subprocess.CalledProcessError as exc:
+        print(
+            f"WorktreeCreate hook: {cwd!r} is not in a git repository: {exc.stderr.strip()}",
+            file=sys.stderr,
+        )
+        return 2
+    if not git_root:
+        print(
+            f"WorktreeCreate hook: 'git rev-parse' returned empty toplevel for {cwd!r}",
+            file=sys.stderr,
+        )
+        return 2
+
+    target = Path(git_root) / ".worktrees" / name
+    branch = f"claude/{name}"
+
+    # Pre-create the .worktrees container so `git worktree add` has
+    # somewhere to land. Idempotent.
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    if _worktree_already_exists(git_root, target):
+        # Resume case — operator/agent restart picked the same name.
+        print(str(target))
+        return 0
+
+    base = _resolve_base(git_root)
+
+    if _branch_exists(git_root, branch):
+        # Branch lingered from a previous worktree; attach without -b so
+        # the existing branch stays the source of truth.
+        ok, err = _try_git("worktree", "add", str(target), branch, cwd=git_root)
+    else:
+        ok, err = _try_git(
+            "worktree", "add", "-b", branch, str(target), base, cwd=git_root
+        )
+
+    if not ok:
+        print(
+            f"WorktreeCreate hook: 'git worktree add' failed for "
+            f"name={name!r} target={target} branch={branch} base={base}: {err}",
+            file=sys.stderr,
+        )
+        return 2
+
+    if not target.is_dir():
+        # SDK enforces this — fail loud rather than letting the SDK's
+        # generic "not a directory" error swallow our diagnostic.
+        print(
+            f"WorktreeCreate hook: target {target} not a directory after "
+            "'git worktree add' (filesystem race or post-create deletion)",
+            file=sys.stderr,
+        )
+        return 2
+
+    print(str(target))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/scitex_agent_container/_baseline_assets/claude_worktree_hooks/worktree_remove.py
+++ b/src/scitex_agent_container/_baseline_assets/claude_worktree_hooks/worktree_remove.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Claude Code ``WorktreeRemove`` hook — counterpart to
+:mod:`worktree_create`. Removes a worktree previously created by the
+relocation hook.
+
+Input (stdin, JSON)::
+
+    {
+        "hook_event_name": "WorktreeRemove",
+        "worktree_path": "<abs-path-the-create-hook-echoed>",
+        "session_id": "<uuid>",
+        ...base fields
+    }
+
+The hook runs ``git worktree remove <path>`` from a discoverable git
+root and exits 0 on success. Any failure is loud on stderr + non-zero
+so the SDK surfaces it (its built-in default for WorktreeRemove leaves
+orphans behind silently; ours fails loud).
+
+Idempotence
+-----------
+If the worktree is already gone (operator pruned via the daily cron, or
+the directory was removed out-of-band), we report success — the desired
+end-state is "this worktree is no longer registered", and that's
+already true.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _try_git(*args: str, cwd: str) -> tuple[bool, str]:
+    res = subprocess.run(
+        ["git", "-C", cwd, *args],
+        capture_output=True,
+        text=True,
+    )
+    if res.returncode == 0:
+        return True, res.stdout.strip()
+    return False, (res.stderr or res.stdout).strip()
+
+
+def _worktree_registered(git_root: str, target: str) -> bool:
+    ok, out = _try_git("worktree", "list", "--porcelain", cwd=git_root)
+    if not ok:
+        return False
+    needle = f"worktree {target}"
+    return any(line == needle for line in out.splitlines())
+
+
+def _git_root_for(start: str) -> str | None:
+    """Resolve a discoverable git root: prefer the worktree itself, fall
+    back to its parent (``.worktrees/`` is inside the main repo)."""
+    candidate_dirs: list[str] = []
+    if os.path.isdir(start):
+        candidate_dirs.append(start)
+    parent = str(Path(start).parent)
+    if parent and parent != start and os.path.isdir(parent):
+        candidate_dirs.append(parent)
+    grandparent = str(Path(start).parent.parent)
+    if (
+        grandparent
+        and grandparent not in (start, parent)
+        and os.path.isdir(grandparent)
+    ):
+        candidate_dirs.append(grandparent)
+    for cand in candidate_dirs:
+        ok, out = _try_git("rev-parse", "--show-toplevel", cwd=cand)
+        if ok and out:
+            return out
+    return None
+
+
+def main() -> int:
+    raw = sys.stdin.read()
+    if not raw.strip():
+        print("WorktreeRemove hook: empty stdin (expected JSON)", file=sys.stderr)
+        return 2
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        print(f"WorktreeRemove hook: stdin is not valid JSON: {exc}", file=sys.stderr)
+        return 2
+
+    worktree_path = (payload.get("worktree_path") or "").strip()
+    if not worktree_path:
+        print("WorktreeRemove hook: 'worktree_path' missing in input", file=sys.stderr)
+        return 2
+
+    git_root = _git_root_for(worktree_path)
+    if not git_root:
+        # Idempotent: the worktree's containing repo is gone too —
+        # nothing to do; succeed (no work, no orphan to clean).
+        return 0
+
+    if not _worktree_registered(git_root, worktree_path):
+        # Already unregistered — desired end-state achieved.
+        return 0
+
+    ok, err = _try_git("worktree", "remove", worktree_path, cwd=git_root)
+    if not ok:
+        # Try --force as a second pass — the worktree may have local
+        # changes the operator's cron didn't trip on. Still better than
+        # silent orphan.
+        ok2, err2 = _try_git(
+            "worktree", "remove", "--force", worktree_path, cwd=git_root
+        )
+        if not ok2:
+            print(
+                f"WorktreeRemove hook: 'git worktree remove' failed for "
+                f"{worktree_path!r}: {err}; force-remove also failed: {err2}",
+                file=sys.stderr,
+            )
+            return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/scitex_agent_container/_skills/scitex-agent-container/41_claude-worktree-relocation.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/41_claude-worktree-relocation.md
@@ -1,3 +1,14 @@
+---
+description: |
+  [TOPIC] Claude Code worktree relocation hooks (F-CS8 prevention)
+  [DETAILS] Canonical WorktreeCreate/WorktreeRemove hook scripts that relocate
+  Claude Code's default `.claude/worktrees/<name>` creations to
+  `<git-root>/.worktrees/<name>` where the operator's prune cron maintains
+  hygiene. Stops the recurring multi-GB / 100k-file accumulation that wedges
+  agents (F-CS8 recurrence ~100×, neurovista wedge 22.9 GB / 80k files).
+tags: [scitex-agent-container-claude-worktree]
+---
+
 # Claude Code worktree relocation — F-CS8 prevention
 
 Claude Code's bundled binary creates session/agent worktrees under

--- a/src/scitex_agent_container/_skills/scitex-agent-container/41_claude-worktree-relocation.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/41_claude-worktree-relocation.md
@@ -1,0 +1,85 @@
+# Claude Code worktree relocation — F-CS8 prevention
+
+Claude Code's bundled binary creates session/agent worktrees under
+`.claude/worktrees/<name>` by default. That tree is never self-cleaned
+and accumulates multi-GB / 100k-file bloat that wedges agents (F-CS8
+recurrence ~100×; wedged neurovista at 22.9 GB / 80k files → 0-output
+turns). The operator's daily prune cron maintains hygiene on
+`<root>/.worktrees/` (mtime-gated, never touches `.claude/`). The
+`WorktreeCreate` / `WorktreeRemove` hooks land the prevention side of
+the same policy: relocate every creation to the cron-maintained tree.
+
+## Canonical asset location
+
+The verified hook scripts + settings fragment live in this repo at:
+
+    src/scitex_agent_container/_baseline_assets/claude_worktree_hooks/
+      ├── worktree_create.py
+      ├── worktree_remove.py
+      ├── settings.local.json.fragment.json
+      └── README.md
+
+Regression tests:
+
+    tests/scitex_agent_container/_baseline_assets/claude_worktree_hooks/
+      └── test_worktree_hooks.py
+
+The tests drive the real scripts as subprocesses against an ephemeral
+on-disk git repo (`tmp_path` + `git init`) — no mocks, no patches. They
+pin the I/O contract, the relocation invariant, the `claude/<name>`
+branch policy, the idempotence guarantees, and the loud-fail
+diagnostics.
+
+## Deployment (operator-side)
+
+1. Copy both `worktree_create.py` and `worktree_remove.py` into the
+   baseline to_home tree:
+
+       <agents_dir>/_base/to_home/.claude/hooks/claude_worktree_hooks/
+
+2. Merge the `hooks` block from
+   `settings.local.json.fragment.json` into
+   `<agents_dir>/_base/to_home/.claude/settings.local.json` (under the
+   top-level `hooks` key). Preserve the `_comment_worktree_hooks`
+   string — it carries the source-of-truth audit trail.
+
+3. Restart agents (or wait for next natural restart). NO SIF REBUILD.
+   The runtime's `deploy_to_home` (see `runtimes/_to_home.py`)
+   materializes the baseline tree into every agent's `$HOME` on every
+   start, so the hooks + settings land before Claude Code reads its
+   config.
+
+## Verification before fleet-wide
+
+The hook event names + the I/O shape were verified 2026-06-06 against
+the deobfuscated `executeWorktreeCreateHook` (`VRH`) function in the
+`claude_agent_sdk._bundled.claude` binary shipped with the runner's
+venv. The regression tests pin both. The live-probe on
+proj-scitex-agent-container's runtime container (2026-06-06) drove the
+real hook against the real `/work` repo and:
+
+* `worktree_create.py` echoed `/work/.worktrees/live-probe-1`, created
+  the dir, registered it in `git worktree list`, and put it on branch
+  `claude/live-probe-1` based at `origin/develop`.
+* `worktree_remove.py` unregistered the worktree on the matching
+  payload, exited 0.
+
+Before broad deploy on any new SDK version, re-run the live-probe and
+the regression tests — the SDK is the contract source-of-truth and
+silent schema drift would break the relocation.
+
+## Why this lives in sac, not in dotfiles
+
+The hook scripts are canonical, version-controlled, regression-tested
+implementations of a fleet-wide policy. Shipping them here (instead of
+ad-hoc in the operator's dotfiles `_base/to_home/`) means:
+
+* The implementation has an audit trail (commit history + PR review).
+* The hook contract is pinned by tests, not by the operator's memory.
+* SDK upgrades have a single place to re-verify.
+* The dotfiles baseline syncs from a single source-of-truth path.
+
+The deployment step (copy + settings-merge) is operator-driven because
+the dotfiles tree is the operator's, not sac's. Future work could
+package this as a `sac to_home seed-baseline` CLI command that pulls
+the canonical assets into the dotfiles baseline tree automatically.

--- a/src/scitex_agent_container/_skills/scitex-agent-container/41_claude-worktree-relocation.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/41_claude-worktree-relocation.md
@@ -6,7 +6,7 @@ description: |
   `<git-root>/.worktrees/<name>` where the operator's prune cron maintains
   hygiene. Stops the recurring multi-GB / 100k-file accumulation that wedges
   agents (F-CS8 recurrence ~100×, neurovista wedge 22.9 GB / 80k files).
-tags: [scitex-agent-container-claude-worktree]
+tags: [scitex-agent-container-claude-worktree-relocation]
 ---
 
 # Claude Code worktree relocation — F-CS8 prevention

--- a/src/scitex_agent_container/_skills/scitex-agent-container/SKILL.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/SKILL.md
@@ -77,7 +77,7 @@ session inside Apptainer (local or remote via SSH), observe via
 
 ### Lessons
 - [40_troubleshooting.md](40_troubleshooting.md) — Common issues and debugging
-- [41_claude-worktree-relocation.md](41_claude-worktree-relocation.md) — WorktreeCreate/WorktreeRemove hooks that relocate Claude Code's `.claude/worktrees/` creations to `<root>/.worktrees/` (F-CS8 prevention)
+- [41_claude-worktree-relocation.md](41_claude-worktree-relocation.md) — F-CS8 prevention
 
 ## Environment
 

--- a/src/scitex_agent_container/_skills/scitex-agent-container/SKILL.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/SKILL.md
@@ -77,7 +77,7 @@ session inside Apptainer (local or remote via SSH), observe via
 
 ### Lessons
 - [40_troubleshooting.md](40_troubleshooting.md) — Common issues and debugging
-- [41_claude-worktree-relocation.md](41_claude-worktree-relocation.md) — F-CS8 prevention
+- [41](41_claude-worktree-relocation.md)
 
 ## Environment
 

--- a/src/scitex_agent_container/_skills/scitex-agent-container/SKILL.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/SKILL.md
@@ -77,6 +77,7 @@ session inside Apptainer (local or remote via SSH), observe via
 
 ### Lessons
 - [40_troubleshooting.md](40_troubleshooting.md) — Common issues and debugging
+- [41_claude-worktree-relocation.md](41_claude-worktree-relocation.md) — WorktreeCreate/WorktreeRemove hooks that relocate Claude Code's `.claude/worktrees/` creations to `<root>/.worktrees/` (F-CS8 prevention)
 
 ## Environment
 

--- a/tests/scitex_agent_container/_baseline_assets/claude_worktree_hooks/conftest.py
+++ b/tests/scitex_agent_container/_baseline_assets/claude_worktree_hooks/conftest.py
@@ -1,0 +1,119 @@
+"""Shared fixtures + helpers for the claude_worktree_hooks tests.
+
+Lives next to ``test_worktree_create.py`` / ``test_worktree_remove.py``;
+pytest auto-loads ``conftest.py`` from the test dir so both files share
+the ephemeral-git-repo fixture, the path constants, and the JSON-payload
+builders without duplicating the bootstrap.
+
+Audit (PS-204 §2): each test file mirrors a single src module, so the
+shared scaffolding HAS to live here — putting it in either test file
+would create a duplicate-helper-source-of-truth split.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+# The hook scripts live alongside the source-of-truth asset dir; the
+# tests resolve them by package-relative import so a refactor of the
+# asset path is caught at import time, not at script-spawn time.
+HOOK_DIR = (
+    Path(__file__).resolve().parents[4]
+    / "src"
+    / "scitex_agent_container"
+    / "_baseline_assets"
+    / "claude_worktree_hooks"
+)
+CREATE_SCRIPT = HOOK_DIR / "worktree_create.py"
+REMOVE_SCRIPT = HOOK_DIR / "worktree_remove.py"
+
+
+def _git(cwd: Path, *args: str) -> str:
+    """Run ``git -C cwd <args>``; assert success and return stdout."""
+    res = subprocess.run(
+        ["git", "-C", str(cwd), *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return res.stdout.strip()
+
+
+def _run_hook(
+    script: Path, payload: dict, cwd: Path | None = None
+) -> subprocess.CompletedProcess:
+    """Invoke the hook script with the given JSON payload on stdin.
+
+    Returns the completed process so individual tests can assert on
+    returncode / stdout / stderr without retrying or coupling.
+    """
+    return subprocess.run(
+        [sys.executable, str(script)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        cwd=str(cwd) if cwd else None,
+    )
+
+
+def _create_payload(name: str, cwd: Path) -> dict:
+    """Mirror the shape Claude Code's ``executeWorktreeCreateHook``
+    constructs at runtime (verified 2026-06-06 against the bundled binary)."""
+    return {
+        "hook_event_name": "WorktreeCreate",
+        "name": name,
+        "cwd": str(cwd),
+        "session_id": "test-session-id",
+        "transcript_path": str(cwd / ".transcript"),
+        "permission_mode": "default",
+        "agent_id": "test-agent-id",
+        "agent_type": "test",
+    }
+
+
+def _remove_payload(worktree_path: str, cwd: Path | str) -> dict:
+    """Mirror the shape Claude Code's ``executeWorktreeRemoveHook`` constructs."""
+    return {
+        "hook_event_name": "WorktreeRemove",
+        "worktree_path": worktree_path,
+        "session_id": "test-session-id",
+        "transcript_path": str(Path(str(cwd)) / ".transcript"),
+        "permission_mode": "default",
+        "agent_id": "test-agent-id",
+        "agent_type": "test",
+        "cwd": str(cwd),
+    }
+
+
+@pytest.fixture
+def ephemeral_repo(tmp_path: Path) -> Iterator[Path]:
+    """Create a real on-disk git repo with a ``develop`` branch + initial commit.
+
+    The hooks' "fresh-from-origin/develop-else-HEAD" base-resolution path
+    needs SOMETHING to branch from; an empty fresh repo (no commits) has
+    no resolvable HEAD and would fail in a way that's noise here. We
+    seed a single commit on ``develop`` so the create-hook exercises its
+    real base-resolution branch instead of an edge case.
+
+    No ``origin`` is configured — that exercises the "HEAD fallback"
+    branch of ``_resolve_base`` and keeps the test self-contained (no
+    network, no shared remote). A separate test pins the
+    ``origin/develop`` branch when an origin IS configured.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "--initial-branch=develop")
+    # Identity is required for ``git commit``; tests must not depend on
+    # the host's ``git config user.*``.
+    _git(repo, "config", "user.email", "test@example.invalid")
+    _git(repo, "config", "user.name", "SAC Test")
+    (repo / "README.md").write_text("seed\n")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-q", "-m", "seed")
+    yield repo

--- a/tests/scitex_agent_container/_baseline_assets/claude_worktree_hooks/test_worktree_create.py
+++ b/tests/scitex_agent_container/_baseline_assets/claude_worktree_hooks/test_worktree_create.py
@@ -1,8 +1,8 @@
-"""End-to-end tests for the Claude Code worktree-relocation hooks.
+"""End-to-end tests for the ``worktree_create.py`` hook.
 
 NO MOCKS. Every test drives the real hook script as a subprocess against
-a real ephemeral git repository created via ``tmp_path`` and ``git
-init``. The hook contract is what Claude Code's bundled binary enforces
+a real ephemeral git repository (see ``conftest.py``'s ``ephemeral_repo``
+fixture). The hook contract is what Claude Code's bundled binary enforces
 at runtime (verified 2026-06-06 in the deobfuscated
 ``executeWorktreeCreateHook`` JS function); the regression coverage
 below pins both directions of the I/O contract + the policy invariants.
@@ -13,106 +13,19 @@ a ≥3-word descriptive name, and exactly one assertion.
 
 from __future__ import annotations
 
-import json
 import subprocess
 import sys
 from pathlib import Path
-from typing import Iterator
 
-import pytest
-
-# The hook scripts live alongside the source-of-truth asset dir; the
-# tests resolve them by package-relative import so a refactor of the
-# asset path is caught at import time, not at script-spawn time.
-HOOK_DIR = (
-    Path(__file__).resolve().parents[4]
-    / "src"
-    / "scitex_agent_container"
-    / "_baseline_assets"
-    / "claude_worktree_hooks"
+from .conftest import (
+    CREATE_SCRIPT,
+    _create_payload,
+    _git,
+    _run_hook,
 )
-CREATE_SCRIPT = HOOK_DIR / "worktree_create.py"
-REMOVE_SCRIPT = HOOK_DIR / "worktree_remove.py"
-
 
 # ---------------------------------------------------------------------------
-# Real ephemeral git repo — used by every test that exercises hook IO
-# ---------------------------------------------------------------------------
-
-
-@pytest.fixture
-def ephemeral_repo(tmp_path: Path) -> Iterator[Path]:
-    """Create a real on-disk git repo with a ``develop`` branch + initial commit.
-
-    The hooks' "fresh-from-origin/develop-else-HEAD" base-resolution path
-    needs SOMETHING to branch from; an empty fresh repo (no commits) has
-    no resolvable HEAD and would fail in a way that's noise here. We
-    seed a single commit on ``develop`` so the create-hook exercises its
-    real base-resolution branch instead of an edge case.
-
-    No ``origin`` is configured — that exercises the "HEAD fallback"
-    branch of ``_resolve_base`` and keeps the test self-contained (no
-    network, no shared remote). A separate test pins the
-    ``origin/develop`` branch when an origin IS configured.
-    """
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    _git(repo, "init", "-q", "--initial-branch=develop")
-    # Identity is required for ``git commit``; tests must not depend on
-    # the host's ``git config user.*``.
-    _git(repo, "config", "user.email", "test@example.invalid")
-    _git(repo, "config", "user.name", "SAC Test")
-    (repo / "README.md").write_text("seed\n")
-    _git(repo, "add", "README.md")
-    _git(repo, "commit", "-q", "-m", "seed")
-    yield repo
-
-
-def _git(cwd: Path, *args: str) -> str:
-    """Run ``git -C cwd <args>``; assert success and return stdout."""
-    res = subprocess.run(
-        ["git", "-C", str(cwd), *args],
-        capture_output=True,
-        text=True,
-        check=True,
-    )
-    return res.stdout.strip()
-
-
-def _run_hook(
-    script: Path, payload: dict, cwd: Path | None = None
-) -> subprocess.CompletedProcess:
-    """Invoke the hook script with the given JSON payload on stdin.
-
-    Returns the completed process so individual tests can assert on
-    returncode / stdout / stderr without retrying or coupling.
-    """
-    return subprocess.run(
-        [sys.executable, str(script)],
-        input=json.dumps(payload),
-        capture_output=True,
-        text=True,
-        cwd=str(cwd) if cwd else None,
-    )
-
-
-def _create_payload(name: str, cwd: Path) -> dict:
-    """Mirror the shape Claude Code's ``executeWorktreeCreateHook``
-    constructs at runtime (verified 2026-06-06 against the bundled binary)."""
-    return {
-        "hook_event_name": "WorktreeCreate",
-        "name": name,
-        "cwd": str(cwd),
-        "session_id": "test-session-id",
-        "transcript_path": str(cwd / ".transcript"),
-        "permission_mode": "default",
-        "agent_id": "test-agent-id",
-        "agent_type": "test",
-    }
-
-
-# ---------------------------------------------------------------------------
-# worktree_create.py — the headline relocation: target lands under .worktrees/
+# Relocation invariant — target lands under .worktrees/, NOT .claude/worktrees
 # ---------------------------------------------------------------------------
 
 
@@ -123,10 +36,8 @@ class TestWorktreeCreateRelocation:
         # Arrange — the whole point of the hook: stop creations under
         # ``.claude/worktrees/`` and put them under ``.worktrees/``.
         payload = _create_payload("relocate-probe", ephemeral_repo)
-
         # Act
         result = _run_hook(CREATE_SCRIPT, payload)
-
         # Assert — single-line stdout = absolute path under .worktrees/
         emitted = result.stdout.strip()
         assert emitted == str(ephemeral_repo / ".worktrees" / "relocate-probe")
@@ -222,10 +133,8 @@ class TestWorktreeCreateOnLingeringBranch:
         name = "lingering-branch"
         _git(ephemeral_repo, "branch", f"claude/{name}")
         payload = _create_payload(name, ephemeral_repo)
-
         # Act
         result = _run_hook(CREATE_SCRIPT, payload)
-
         # Assert
         assert result.returncode == 0
 
@@ -277,7 +186,7 @@ class TestWorktreeCreateLoudFailure:
         # Assert
         assert result.returncode != 0
 
-    def test_empty_stdin_exits_nonzero(self, tmp_path: Path) -> None:
+    def test_empty_stdin_exits_nonzero(self) -> None:
         # Arrange — hook fired with no input (misconfiguration) must
         # fail loud, not silently echo something the SDK will accept.
         script = CREATE_SCRIPT
@@ -328,119 +237,12 @@ class TestWorktreeCreateBaseResolution:
         (ephemeral_repo / "newer.txt").write_text("local-only\n")
         _git(ephemeral_repo, "add", "newer.txt")
         _git(ephemeral_repo, "commit", "-q", "-m", "local-only")
-
         origin_develop_sha = _git(ephemeral_repo, "rev-parse", "origin/develop")
         payload = _create_payload("base-resolve-probe", ephemeral_repo)
-
         # Act
         result = _run_hook(CREATE_SCRIPT, payload)
         target = Path(result.stdout.strip())
-
         # Assert — the new worktree's HEAD == origin/develop (NOT
         # the local develop HEAD which has the extra commit).
         new_sha = _git(target, "rev-parse", "HEAD")
         assert new_sha == origin_develop_sha
-
-
-# ---------------------------------------------------------------------------
-# worktree_remove.py — counterpart, idempotent + loud on failure
-# ---------------------------------------------------------------------------
-
-
-class TestWorktreeRemove:
-    def test_remove_unregisters_a_created_worktree(self, ephemeral_repo: Path) -> None:
-        # Arrange — create one via the create-hook, then run the
-        # remove-hook against the path it returned.
-        create_payload = _create_payload("remove-probe", ephemeral_repo)
-        created = _run_hook(CREATE_SCRIPT, create_payload).stdout.strip()
-        remove_payload = {
-            "hook_event_name": "WorktreeRemove",
-            "worktree_path": created,
-            "session_id": "test-session-id",
-            "transcript_path": str(ephemeral_repo / ".transcript"),
-            "permission_mode": "default",
-            "agent_id": "test-agent-id",
-            "agent_type": "test",
-            "cwd": str(ephemeral_repo),
-        }
-
-        # Act
-        _run_hook(REMOVE_SCRIPT, remove_payload)
-
-        # Assert
-        listed = _git(ephemeral_repo, "worktree", "list", "--porcelain")
-        assert f"worktree {created}" not in listed
-
-    def test_remove_exits_zero_on_success(self, ephemeral_repo: Path) -> None:
-        # Arrange
-        create_payload = _create_payload("remove-exit-probe", ephemeral_repo)
-        created = _run_hook(CREATE_SCRIPT, create_payload).stdout.strip()
-        remove_payload = {
-            "hook_event_name": "WorktreeRemove",
-            "worktree_path": created,
-            "session_id": "s",
-            "transcript_path": str(ephemeral_repo / ".transcript"),
-            "permission_mode": "default",
-            "agent_id": "a",
-            "agent_type": "t",
-            "cwd": str(ephemeral_repo),
-        }
-        # Act
-        result = _run_hook(REMOVE_SCRIPT, remove_payload)
-        # Assert
-        assert result.returncode == 0
-
-    def test_remove_is_idempotent_on_already_gone_path(self, tmp_path: Path) -> None:
-        # Arrange — operator's daily prune cron already wiped the
-        # worktree; SDK re-fires the remove hook on a vanished path.
-        # The desired end-state ("this path is no longer a worktree")
-        # is already true, so the hook must succeed silently.
-        gone_path = tmp_path / "gone" / "worktree"
-        remove_payload = {
-            "hook_event_name": "WorktreeRemove",
-            "worktree_path": str(gone_path),
-            "session_id": "s",
-            "transcript_path": str(tmp_path / ".transcript"),
-            "permission_mode": "default",
-            "agent_id": "a",
-            "agent_type": "t",
-            "cwd": str(tmp_path),
-        }
-        # Act
-        result = _run_hook(REMOVE_SCRIPT, remove_payload)
-        # Assert
-        assert result.returncode == 0
-
-    def test_remove_with_empty_stdin_exits_nonzero(self) -> None:
-        # Arrange
-        script = REMOVE_SCRIPT
-        # Act
-        result = subprocess.run(
-            [sys.executable, str(script)],
-            input="",
-            capture_output=True,
-            text=True,
-        )
-        # Assert
-        assert result.returncode != 0
-
-    def test_remove_with_missing_worktree_path_exits_nonzero(self) -> None:
-        # Arrange
-        payload = {
-            "hook_event_name": "WorktreeRemove",
-            "session_id": "s",
-            "transcript_path": "/tmp/t",
-            "permission_mode": "default",
-            "agent_id": "a",
-            "agent_type": "t",
-            "cwd": "/tmp",
-        }
-        # Act
-        result = subprocess.run(
-            [sys.executable, str(REMOVE_SCRIPT)],
-            input=json.dumps(payload),
-            capture_output=True,
-            text=True,
-        )
-        # Assert
-        assert result.returncode != 0

--- a/tests/scitex_agent_container/_baseline_assets/claude_worktree_hooks/test_worktree_hooks.py
+++ b/tests/scitex_agent_container/_baseline_assets/claude_worktree_hooks/test_worktree_hooks.py
@@ -14,7 +14,6 @@ a ≥3-word descriptive name, and exactly one assertion.
 from __future__ import annotations
 
 import json
-import os
 import subprocess
 import sys
 from pathlib import Path

--- a/tests/scitex_agent_container/_baseline_assets/claude_worktree_hooks/test_worktree_hooks.py
+++ b/tests/scitex_agent_container/_baseline_assets/claude_worktree_hooks/test_worktree_hooks.py
@@ -280,8 +280,10 @@ class TestWorktreeCreateLoudFailure:
     def test_empty_stdin_exits_nonzero(self, tmp_path: Path) -> None:
         # Arrange — hook fired with no input (misconfiguration) must
         # fail loud, not silently echo something the SDK will accept.
+        script = CREATE_SCRIPT
+        # Act
         result = subprocess.run(
-            [sys.executable, str(CREATE_SCRIPT)],
+            [sys.executable, str(script)],
             input="",
             capture_output=True,
             text=True,
@@ -291,9 +293,12 @@ class TestWorktreeCreateLoudFailure:
 
     def test_malformed_json_stdin_exits_nonzero(self) -> None:
         # Arrange
+        script = CREATE_SCRIPT
+        bad_input = "not json at all"
+        # Act
         result = subprocess.run(
-            [sys.executable, str(CREATE_SCRIPT)],
-            input="not json at all",
+            [sys.executable, str(script)],
+            input=bad_input,
             capture_output=True,
             text=True,
         )
@@ -408,8 +413,10 @@ class TestWorktreeRemove:
 
     def test_remove_with_empty_stdin_exits_nonzero(self) -> None:
         # Arrange
+        script = REMOVE_SCRIPT
+        # Act
         result = subprocess.run(
-            [sys.executable, str(REMOVE_SCRIPT)],
+            [sys.executable, str(script)],
             input="",
             capture_output=True,
             text=True,

--- a/tests/scitex_agent_container/_baseline_assets/claude_worktree_hooks/test_worktree_hooks.py
+++ b/tests/scitex_agent_container/_baseline_assets/claude_worktree_hooks/test_worktree_hooks.py
@@ -1,0 +1,440 @@
+"""End-to-end tests for the Claude Code worktree-relocation hooks.
+
+NO MOCKS. Every test drives the real hook script as a subprocess against
+a real ephemeral git repository created via ``tmp_path`` and ``git
+init``. The hook contract is what Claude Code's bundled binary enforces
+at runtime (verified 2026-06-06 in the deobfuscated
+``executeWorktreeCreateHook`` JS function); the regression coverage
+below pins both directions of the I/O contract + the policy invariants.
+
+TQ: every test carries ``# Arrange`` / ``# Act`` / ``# Assert`` markers,
+a ≥3-word descriptive name, and exactly one assertion.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+# The hook scripts live alongside the source-of-truth asset dir; the
+# tests resolve them by package-relative import so a refactor of the
+# asset path is caught at import time, not at script-spawn time.
+HOOK_DIR = (
+    Path(__file__).resolve().parents[4]
+    / "src"
+    / "scitex_agent_container"
+    / "_baseline_assets"
+    / "claude_worktree_hooks"
+)
+CREATE_SCRIPT = HOOK_DIR / "worktree_create.py"
+REMOVE_SCRIPT = HOOK_DIR / "worktree_remove.py"
+
+
+# ---------------------------------------------------------------------------
+# Real ephemeral git repo — used by every test that exercises hook IO
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def ephemeral_repo(tmp_path: Path) -> Iterator[Path]:
+    """Create a real on-disk git repo with a ``develop`` branch + initial commit.
+
+    The hooks' "fresh-from-origin/develop-else-HEAD" base-resolution path
+    needs SOMETHING to branch from; an empty fresh repo (no commits) has
+    no resolvable HEAD and would fail in a way that's noise here. We
+    seed a single commit on ``develop`` so the create-hook exercises its
+    real base-resolution branch instead of an edge case.
+
+    No ``origin`` is configured — that exercises the "HEAD fallback"
+    branch of ``_resolve_base`` and keeps the test self-contained (no
+    network, no shared remote). A separate test pins the
+    ``origin/develop`` branch when an origin IS configured.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "--initial-branch=develop")
+    # Identity is required for ``git commit``; tests must not depend on
+    # the host's ``git config user.*``.
+    _git(repo, "config", "user.email", "test@example.invalid")
+    _git(repo, "config", "user.name", "SAC Test")
+    (repo / "README.md").write_text("seed\n")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-q", "-m", "seed")
+    yield repo
+
+
+def _git(cwd: Path, *args: str) -> str:
+    """Run ``git -C cwd <args>``; assert success and return stdout."""
+    res = subprocess.run(
+        ["git", "-C", str(cwd), *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return res.stdout.strip()
+
+
+def _run_hook(
+    script: Path, payload: dict, cwd: Path | None = None
+) -> subprocess.CompletedProcess:
+    """Invoke the hook script with the given JSON payload on stdin.
+
+    Returns the completed process so individual tests can assert on
+    returncode / stdout / stderr without retrying or coupling.
+    """
+    return subprocess.run(
+        [sys.executable, str(script)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        cwd=str(cwd) if cwd else None,
+    )
+
+
+def _create_payload(name: str, cwd: Path) -> dict:
+    """Mirror the shape Claude Code's ``executeWorktreeCreateHook``
+    constructs at runtime (verified 2026-06-06 against the bundled binary)."""
+    return {
+        "hook_event_name": "WorktreeCreate",
+        "name": name,
+        "cwd": str(cwd),
+        "session_id": "test-session-id",
+        "transcript_path": str(cwd / ".transcript"),
+        "permission_mode": "default",
+        "agent_id": "test-agent-id",
+        "agent_type": "test",
+    }
+
+
+# ---------------------------------------------------------------------------
+# worktree_create.py — the headline relocation: target lands under .worktrees/
+# ---------------------------------------------------------------------------
+
+
+class TestWorktreeCreateRelocation:
+    def test_create_lands_under_dotworktrees_not_dotclaude(
+        self, ephemeral_repo: Path
+    ) -> None:
+        # Arrange — the whole point of the hook: stop creations under
+        # ``.claude/worktrees/`` and put them under ``.worktrees/``.
+        payload = _create_payload("relocate-probe", ephemeral_repo)
+
+        # Act
+        result = _run_hook(CREATE_SCRIPT, payload)
+
+        # Assert — single-line stdout = absolute path under .worktrees/
+        emitted = result.stdout.strip()
+        assert emitted == str(ephemeral_repo / ".worktrees" / "relocate-probe")
+
+    def test_create_returns_zero_on_success(self, ephemeral_repo: Path) -> None:
+        # Arrange
+        payload = _create_payload("zero-exit", ephemeral_repo)
+        # Act
+        result = _run_hook(CREATE_SCRIPT, payload)
+        # Assert — SDK fails loud on any non-zero exit; pin success.
+        assert result.returncode == 0
+
+    def test_created_path_is_a_real_directory(self, ephemeral_repo: Path) -> None:
+        # Arrange — SDK enforces "WorktreeCreate hook returned a path
+        # that is not a directory" if we echo a non-existent path. The
+        # hook MUST create the dir before returning.
+        payload = _create_payload("real-dir-probe", ephemeral_repo)
+        # Act
+        result = _run_hook(CREATE_SCRIPT, payload)
+        # Assert
+        target = Path(result.stdout.strip())
+        assert target.is_dir()
+
+    def test_created_worktree_registered_with_git(self, ephemeral_repo: Path) -> None:
+        # Arrange — relocation is meaningless if it doesn't go through
+        # ``git worktree add``: the human-side cron prunes by mtime
+        # AND by registered status. Pin the registration.
+        payload = _create_payload("registered-probe", ephemeral_repo)
+        # Act
+        result = _run_hook(CREATE_SCRIPT, payload)
+        target = Path(result.stdout.strip())
+        # Assert
+        listed = _git(ephemeral_repo, "worktree", "list", "--porcelain")
+        assert f"worktree {target}" in listed
+
+    def test_created_worktree_branch_is_claude_namespaced(
+        self, ephemeral_repo: Path
+    ) -> None:
+        # Arrange — branch naming policy: ``claude/<name>`` so bulk
+        # prune (``git branch -D 'claude/*'``) works.
+        payload = _create_payload("branch-policy-probe", ephemeral_repo)
+        # Act
+        _run_hook(CREATE_SCRIPT, payload)
+        # Assert — the branch list shows ``claude/<name>``.
+        branches = _git(ephemeral_repo, "branch", "--list", "claude/*")
+        assert "claude/branch-policy-probe" in branches
+
+
+# ---------------------------------------------------------------------------
+# Idempotence — re-trigger MUST NOT double-create / collide
+# ---------------------------------------------------------------------------
+
+
+class TestWorktreeCreateIdempotence:
+    def test_second_trigger_with_same_name_re_emits_same_path(
+        self, ephemeral_repo: Path
+    ) -> None:
+        # Arrange — Claude Code may re-trigger on session resume; the
+        # hook MUST be safe to call twice without erroring out on
+        # "worktree already exists".
+        payload = _create_payload("idempotent-probe", ephemeral_repo)
+        first = _run_hook(CREATE_SCRIPT, payload)
+        # Act
+        second = _run_hook(CREATE_SCRIPT, payload)
+        # Assert
+        assert second.stdout.strip() == first.stdout.strip()
+
+    def test_second_trigger_with_same_name_exits_clean(
+        self, ephemeral_repo: Path
+    ) -> None:
+        # Arrange
+        payload = _create_payload("idempotent-exit", ephemeral_repo)
+        _run_hook(CREATE_SCRIPT, payload)
+        # Act
+        second = _run_hook(CREATE_SCRIPT, payload)
+        # Assert — even when the worktree exists, returncode is 0.
+        assert second.returncode == 0
+
+
+# ---------------------------------------------------------------------------
+# Lingering-branch case — branch exists but worktree doesn't (post-prune)
+# ---------------------------------------------------------------------------
+
+
+class TestWorktreeCreateOnLingeringBranch:
+    def test_lingering_branch_attaches_without_recreation_attempt(
+        self, ephemeral_repo: Path
+    ) -> None:
+        # Arrange — operator pruned the worktree dir (via cron) but the
+        # ``claude/<name>`` branch lingers in refs/heads/. A re-trigger
+        # MUST re-attach a fresh worktree to the existing branch,
+        # not fail with "branch already exists".
+        name = "lingering-branch"
+        _git(ephemeral_repo, "branch", f"claude/{name}")
+        payload = _create_payload(name, ephemeral_repo)
+
+        # Act
+        result = _run_hook(CREATE_SCRIPT, payload)
+
+        # Assert
+        assert result.returncode == 0
+
+
+# ---------------------------------------------------------------------------
+# Loud-fail input validation — every failure path returns >0 + stderr
+# ---------------------------------------------------------------------------
+
+
+class TestWorktreeCreateLoudFailure:
+    def test_missing_name_exits_nonzero(self, ephemeral_repo: Path) -> None:
+        # Arrange
+        payload = _create_payload("ignored", ephemeral_repo)
+        payload.pop("name")
+        # Act
+        result = _run_hook(CREATE_SCRIPT, payload)
+        # Assert
+        assert result.returncode != 0
+
+    def test_missing_name_stderr_names_the_field(self, ephemeral_repo: Path) -> None:
+        # Arrange — SDK surfaces stderr in its hook-failure message;
+        # operator must see WHICH field was missing.
+        payload = _create_payload("ignored", ephemeral_repo)
+        payload.pop("name")
+        # Act
+        result = _run_hook(CREATE_SCRIPT, payload)
+        # Assert
+        assert "name" in result.stderr
+
+    def test_non_git_cwd_exits_nonzero(self, tmp_path: Path) -> None:
+        # Arrange — ``cwd`` exists but isn't a git repo (no .git, no
+        # toplevel resolvable). Hook must refuse, not write to random
+        # filesystem paths.
+        non_repo = tmp_path / "not-a-repo"
+        non_repo.mkdir()
+        payload = _create_payload("no-repo", non_repo)
+        # Act
+        result = _run_hook(CREATE_SCRIPT, payload)
+        # Assert
+        assert result.returncode != 0
+
+    def test_invalid_name_traversal_is_rejected(self, ephemeral_repo: Path) -> None:
+        # Arrange — ``name`` arrives from session bookkeeping; defense-
+        # in-depth, reject any path-traversal-shaped input so the hook
+        # can never write outside ``<git-root>/.worktrees/``.
+        payload = _create_payload("../escape", ephemeral_repo)
+        # Act
+        result = _run_hook(CREATE_SCRIPT, payload)
+        # Assert
+        assert result.returncode != 0
+
+    def test_empty_stdin_exits_nonzero(self, tmp_path: Path) -> None:
+        # Arrange — hook fired with no input (misconfiguration) must
+        # fail loud, not silently echo something the SDK will accept.
+        result = subprocess.run(
+            [sys.executable, str(CREATE_SCRIPT)],
+            input="",
+            capture_output=True,
+            text=True,
+        )
+        # Assert
+        assert result.returncode != 0
+
+    def test_malformed_json_stdin_exits_nonzero(self) -> None:
+        # Arrange
+        result = subprocess.run(
+            [sys.executable, str(CREATE_SCRIPT)],
+            input="not json at all",
+            capture_output=True,
+            text=True,
+        )
+        # Assert
+        assert result.returncode != 0
+
+
+# ---------------------------------------------------------------------------
+# Base-ref resolution — origin/develop wins when configured, else HEAD
+# ---------------------------------------------------------------------------
+
+
+class TestWorktreeCreateBaseResolution:
+    def test_origin_develop_wins_when_configured(
+        self, ephemeral_repo: Path, tmp_path: Path
+    ) -> None:
+        # Arrange — wire an ``origin`` remote pointing at a sibling
+        # bare repo so ``origin/develop`` is fetch-resolvable, then
+        # confirm the hook branches off that tip and NOT off HEAD.
+        upstream = tmp_path / "upstream.git"
+        _git(tmp_path, "init", "-q", "--bare", str(upstream))
+        _git(ephemeral_repo, "remote", "add", "origin", str(upstream))
+        _git(ephemeral_repo, "push", "-q", "origin", "develop")
+        # Add an EXTRA commit on local develop AFTER pushing; the
+        # remote tip stays at the seed. A correctly-resolving base
+        # picks ``origin/develop`` (seed tip), not HEAD (local tip).
+        (ephemeral_repo / "newer.txt").write_text("local-only\n")
+        _git(ephemeral_repo, "add", "newer.txt")
+        _git(ephemeral_repo, "commit", "-q", "-m", "local-only")
+
+        origin_develop_sha = _git(ephemeral_repo, "rev-parse", "origin/develop")
+        payload = _create_payload("base-resolve-probe", ephemeral_repo)
+
+        # Act
+        result = _run_hook(CREATE_SCRIPT, payload)
+        target = Path(result.stdout.strip())
+
+        # Assert — the new worktree's HEAD == origin/develop (NOT
+        # the local develop HEAD which has the extra commit).
+        new_sha = _git(target, "rev-parse", "HEAD")
+        assert new_sha == origin_develop_sha
+
+
+# ---------------------------------------------------------------------------
+# worktree_remove.py — counterpart, idempotent + loud on failure
+# ---------------------------------------------------------------------------
+
+
+class TestWorktreeRemove:
+    def test_remove_unregisters_a_created_worktree(self, ephemeral_repo: Path) -> None:
+        # Arrange — create one via the create-hook, then run the
+        # remove-hook against the path it returned.
+        create_payload = _create_payload("remove-probe", ephemeral_repo)
+        created = _run_hook(CREATE_SCRIPT, create_payload).stdout.strip()
+        remove_payload = {
+            "hook_event_name": "WorktreeRemove",
+            "worktree_path": created,
+            "session_id": "test-session-id",
+            "transcript_path": str(ephemeral_repo / ".transcript"),
+            "permission_mode": "default",
+            "agent_id": "test-agent-id",
+            "agent_type": "test",
+            "cwd": str(ephemeral_repo),
+        }
+
+        # Act
+        _run_hook(REMOVE_SCRIPT, remove_payload)
+
+        # Assert
+        listed = _git(ephemeral_repo, "worktree", "list", "--porcelain")
+        assert f"worktree {created}" not in listed
+
+    def test_remove_exits_zero_on_success(self, ephemeral_repo: Path) -> None:
+        # Arrange
+        create_payload = _create_payload("remove-exit-probe", ephemeral_repo)
+        created = _run_hook(CREATE_SCRIPT, create_payload).stdout.strip()
+        remove_payload = {
+            "hook_event_name": "WorktreeRemove",
+            "worktree_path": created,
+            "session_id": "s",
+            "transcript_path": str(ephemeral_repo / ".transcript"),
+            "permission_mode": "default",
+            "agent_id": "a",
+            "agent_type": "t",
+            "cwd": str(ephemeral_repo),
+        }
+        # Act
+        result = _run_hook(REMOVE_SCRIPT, remove_payload)
+        # Assert
+        assert result.returncode == 0
+
+    def test_remove_is_idempotent_on_already_gone_path(self, tmp_path: Path) -> None:
+        # Arrange — operator's daily prune cron already wiped the
+        # worktree; SDK re-fires the remove hook on a vanished path.
+        # The desired end-state ("this path is no longer a worktree")
+        # is already true, so the hook must succeed silently.
+        gone_path = tmp_path / "gone" / "worktree"
+        remove_payload = {
+            "hook_event_name": "WorktreeRemove",
+            "worktree_path": str(gone_path),
+            "session_id": "s",
+            "transcript_path": str(tmp_path / ".transcript"),
+            "permission_mode": "default",
+            "agent_id": "a",
+            "agent_type": "t",
+            "cwd": str(tmp_path),
+        }
+        # Act
+        result = _run_hook(REMOVE_SCRIPT, remove_payload)
+        # Assert
+        assert result.returncode == 0
+
+    def test_remove_with_empty_stdin_exits_nonzero(self) -> None:
+        # Arrange
+        result = subprocess.run(
+            [sys.executable, str(REMOVE_SCRIPT)],
+            input="",
+            capture_output=True,
+            text=True,
+        )
+        # Assert
+        assert result.returncode != 0
+
+    def test_remove_with_missing_worktree_path_exits_nonzero(self) -> None:
+        # Arrange
+        payload = {
+            "hook_event_name": "WorktreeRemove",
+            "session_id": "s",
+            "transcript_path": "/tmp/t",
+            "permission_mode": "default",
+            "agent_id": "a",
+            "agent_type": "t",
+            "cwd": "/tmp",
+        }
+        # Act
+        result = subprocess.run(
+            [sys.executable, str(REMOVE_SCRIPT)],
+            input=json.dumps(payload),
+            capture_output=True,
+            text=True,
+        )
+        # Assert
+        assert result.returncode != 0

--- a/tests/scitex_agent_container/_baseline_assets/claude_worktree_hooks/test_worktree_remove.py
+++ b/tests/scitex_agent_container/_baseline_assets/claude_worktree_hooks/test_worktree_remove.py
@@ -1,0 +1,99 @@
+"""End-to-end tests for the ``worktree_remove.py`` hook.
+
+NO MOCKS. Every test drives the real hook script as a subprocess against
+a real ephemeral git repository (see ``conftest.py``'s ``ephemeral_repo``
+fixture). Covers the SDK's ``WorktreeRemove`` contract: tear down a
+worktree on the matching payload, succeed silently on an already-gone
+path (operator's cron may have already pruned), fail loud on bad input.
+
+TQ: every test carries ``# Arrange`` / ``# Act`` / ``# Assert`` markers,
+a ≥3-word descriptive name, and exactly one assertion.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from .conftest import (
+    CREATE_SCRIPT,
+    REMOVE_SCRIPT,
+    _create_payload,
+    _git,
+    _remove_payload,
+    _run_hook,
+)
+
+
+class TestWorktreeRemove:
+    def test_remove_unregisters_a_created_worktree(self, ephemeral_repo: Path) -> None:
+        # Arrange — create one via the create-hook, then run the
+        # remove-hook against the path it returned.
+        created = _run_hook(
+            CREATE_SCRIPT, _create_payload("remove-probe", ephemeral_repo)
+        ).stdout.strip()
+        payload = _remove_payload(created, ephemeral_repo)
+        # Act
+        _run_hook(REMOVE_SCRIPT, payload)
+        # Assert
+        listed = _git(ephemeral_repo, "worktree", "list", "--porcelain")
+        assert f"worktree {created}" not in listed
+
+    def test_remove_exits_zero_on_success(self, ephemeral_repo: Path) -> None:
+        # Arrange
+        created = _run_hook(
+            CREATE_SCRIPT, _create_payload("remove-exit-probe", ephemeral_repo)
+        ).stdout.strip()
+        payload = _remove_payload(created, ephemeral_repo)
+        # Act
+        result = _run_hook(REMOVE_SCRIPT, payload)
+        # Assert
+        assert result.returncode == 0
+
+    def test_remove_is_idempotent_on_already_gone_path(self, tmp_path: Path) -> None:
+        # Arrange — operator's daily prune cron already wiped the
+        # worktree; SDK re-fires the remove hook on a vanished path.
+        # The desired end-state ("this path is no longer a worktree")
+        # is already true, so the hook must succeed silently.
+        gone_path = tmp_path / "gone" / "worktree"
+        payload = _remove_payload(str(gone_path), tmp_path)
+        # Act
+        result = _run_hook(REMOVE_SCRIPT, payload)
+        # Assert
+        assert result.returncode == 0
+
+    def test_remove_with_empty_stdin_exits_nonzero(self) -> None:
+        # Arrange
+        script = REMOVE_SCRIPT
+        # Act
+        result = subprocess.run(
+            [sys.executable, str(script)],
+            input="",
+            capture_output=True,
+            text=True,
+        )
+        # Assert
+        assert result.returncode != 0
+
+    def test_remove_with_missing_worktree_path_exits_nonzero(self) -> None:
+        # Arrange
+        payload = {
+            "hook_event_name": "WorktreeRemove",
+            "session_id": "s",
+            "transcript_path": "/tmp/t",
+            "permission_mode": "default",
+            "agent_id": "a",
+            "agent_type": "t",
+            "cwd": "/tmp",
+        }
+        # Act
+        result = subprocess.run(
+            [sys.executable, str(REMOVE_SCRIPT)],
+            input=json.dumps(payload),
+            capture_output=True,
+            text=True,
+        )
+        # Assert
+        assert result.returncode != 0


### PR DESCRIPTION
## Summary
- **Canonical, version-controlled WorktreeCreate / WorktreeRemove hook implementation** shipped under `src/scitex_agent_container/_baseline_assets/claude_worktree_hooks/`. Relocates Claude Code's default `.claude/worktrees/<name>` (which never self-cleans and wedged neurovista at 22.9 GB / 80k files) to `<git-root>/.worktrees/<name>` where the operator's daily prune cron already maintains hygiene.
- **20 regression tests, NO MOCKS** — every test drives the real script as a subprocess against an ephemeral on-disk git repo (`tmp_path` + `git init`). Coverage: relocation invariant, `git worktree list` registration, `claude/<name>` branch policy, idempotent re-trigger, attach-on-lingering-branch, all loud-fail input-validation paths, `origin/develop` base resolution wins over local HEAD, remove unregisters + idempotent on gone path + loud on bad input.
- **Skill doc** `41_claude-worktree-relocation.md` documents the audit trail, deployment steps, and re-verify requirement on SDK upgrades.

## Verification — hook contract is real, not hallucinated
The `WorktreeCreate` / `WorktreeRemove` hook event names + the stdin/stdout I/O shape were verified 2026-06-06 against the **deobfuscated `executeWorktreeCreateHook` (`VRH`) function** in the `claude_agent_sdk._bundled.claude` binary shipped with the runner's venv:

```js
async function VRH(H){
  let $ = {...b5(void 0), hook_event_name: "WorktreeCreate", name: H};
  let q = await O2({hookInput: $, timeoutMs: Y_});
  let K = q.find(A => A.succeeded && A.output.trim().length > 0);
  if (!K) { ...throw "hook is configured but did not run / returned no worktree path"... }
  return {worktreePath: K.output.trim()};
}
```

(strings dump excerpts in README.md alongside the scripts). The SDK enforces ≥1 line on stdout that resolves to an existing directory; any other shape fails loud with `WorktreeCreate hook failed: hook succeeded but returned no worktree path` / `... returned a path that is not a directory`. Our regression tests pin both.

## Live-probe on this agent's runtime container
Drove the real hook against the real `/work` repo:

- `worktree_create.py` echoed `/work/.worktrees/live-probe-1`, created the dir, registered it in `git worktree list`, on branch `claude/live-probe-1` based at `origin/develop` (matches `3a8e3e5`).
- `worktree_remove.py` unregistered the worktree, exited 0. Subsequent `git branch -D claude/live-probe-1` cleaned up.

## Deployment (operator-side, NO SIF REBUILD)
1. Copy `worktree_create.py` + `worktree_remove.py` to `<agents_dir>/_base/to_home/.claude/hooks/claude_worktree_hooks/`.
2. Merge the `hooks` block from `settings.local.json.fragment.json` into the baseline `_base/to_home/.claude/settings.local.json` under the top-level `hooks` key.
3. Restart agents — runtime's `deploy_to_home` materializes the baseline tree into every agent's `$HOME` on every start; Claude Code reads the new settings on the next session.

## Test plan
- [x] 20/20 regression tests pass (`pytest tests/scitex_agent_container/_baseline_assets/claude_worktree_hooks/`)
- [x] Live-probe on proj-scitex-agent-container's runtime confirmed end-to-end create + remove + branch cleanup
- [ ] Operator merges + deploys, observes new sessions create worktrees under `.worktrees/` not `.claude/worktrees/`
- [ ] Re-run the live probe + regression tests on any SDK upgrade (the SDK is the contract source-of-truth)

🤖 Generated with [Claude Code](https://claude.com/claude-code)