### PR TITLE
docs(readme): refresh positioning for public link — 5 differentiators

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!-- ---
-!-- Timestamp: 2026-06-01 05:30:00
+!-- Timestamp: 2026-06-07 03:00:00
 !-- Author: ywatanabe
 !-- File: /home/ywatanabe/proj/scitex-agent-container/README.md
 !-- --- -->
@@ -12,7 +12,12 @@
   </a>
 </p>
 
-<p align="center"><b>Agent in Apptainer</b></p>
+<p align="center"><b>Declarative, on-prem-first lifecycle manager for Claude Code agents.</b></p>
+
+<p align="center">
+  One YAML spec → one reproducible, sandboxed, fleet-addressable agent.<br/>
+  Runs anywhere Apptainer runs — laptop, HPC node, air-gapped server.
+</p>
 
 <p align="center">
   <a href="https://scitex-agent-container.readthedocs.io/">Full Documentation</a> · <code>uv pip install scitex-agent-container[all]</code>
@@ -35,21 +40,23 @@
 
 ---
 
-## Problem and Solution
+## Why `sac`
 
-| # | Problem                                                     | Solution                                                                                                                                      |
-|---|-------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
-| 1 | Scripting an agentic workflow is hard.                      | `scitex-agent-container` (`sac`) declares the agent as a **single YAML file** ([`spec.yaml`](docs/spec-reference.md)).                                                  |
-| 2 | Subagents don't scale across hosts, projects, and contexts. | `sac` lets agents spawn **full agents** on local AND **remote hosts**.                                                                        |
-| 3 | Controlling agent permissions is difficult.                 | `sac` runs every agent **inside Apptainer** — full mount/env/security options exposed in `spec.yaml`.                                         |
-| 4 | Supporting the A2A protocol by hand is time-consuming.      | `sac` needs just one YAML field (`spec.a2a.port`).                                                                                            |
-| 5 | Version-controlling Apptainer recipes is laborious.         | `sac` enables layered Apptainer images with a sandbox/update/freeze workflow via [`scitex-container`](https://github.com/ywatanabe1989/scitex-container). |
+| # | What sac gives you                                                                                                                                                                                                                                                                                                                                                                                  |
+|---|---|
+| 1 | **Declarative agents.** One `spec.yaml` per agent — the file IS the agent (dir-as-SSoT, no hidden state). Reproducible across hosts, version-controlled, diff-reviewable. [`spec-reference.md`](docs/spec-reference.md). |
+| 2 | **Rootless Apptainer isolation.** Runs where cloud sandboxes (E2B, Modal, etc.) can't — HPC login nodes, on-prem clusters, fully air-gapped boxes. No root, no daemon, no Docker socket. Hardened by default with `--containall` ([`isolation.md`](docs/isolation.md)). |
+| 3 | **LLM-agnostic & on-prem capable.** Default: Anthropic OAuth. Alternative: any Anthropic-API-compatible endpoint (DeepSeek, MiMo / Xiaomi, your own LiteLLM / vLLM-with-Anthropic-shim gateway) via a one-line `spec.claude.provider:` knob. Data, code, and inference can stay entirely on your network. |
+| 4 | **Fleet ops out of the box.** A2A push (`POST /v1/turn` per agent, native), health & heartbeat, restart policies, multi-account credential rotation with auto-quota-watch, MCP + CLI + Python surface, cross-host orchestration via `sac fleet`. |
+| 5 | **AGPL-3.0.** Research-freedom license — infrastructure stays open, modifications stay shareable. The [Four Freedoms for Research](#four-freedoms-for-research) below. |
 
 ## Installation
 
 ```bash
 uv pip install "scitex-agent-container[all]"
 ```
+
+Or via the SciTeX umbrella: `uv pip install "scitex[agent-container]"` → use as `scitex agent-container ...` (CLI) or `import scitex.agent_container` (Python).
 
 ## Quickstart
 
@@ -104,19 +111,20 @@ spec:
 # Start in foreground (waits for completion)
 sac agents start hello-agent-1 hello-agent-2 --foreground
 
-# Check status
-sac agents list
+# Check status (fleet view)
+sac agents status
 
-# Start in background, read output, stop, delete
-sac agents start hello-agent-1 hello-agent-2
-sac agents tail  hello-agent-1 hello-agent-2 --json
-sac agents stop  hello-agent-1 hello-agent-2
+# Start in background, send a follow-up turn, tail, stop, delete
+sac agents start  hello-agent-1 hello-agent-2
+sac agents send   hello-agent-1 "What is 2+2? Reply with just the number."
+sac agents tail   hello-agent-1 hello-agent-2 --json
+sac agents stop   hello-agent-1 hello-agent-2
 sac agents delete hello-agent-1 hello-agent-2 -y
 ```
 
 ### Tutorial
 
-[`examples/`](examples/) walks through the runtime in 15 lessons (image build, sandbox/update/freeze, versioning, run/send/tail, logs/exec, stop/remove, binds, env+user, writing your first spec.yaml, to_home/, A2A endpoint, health+restart, multi-host, debugging). Run them read-only with `bash examples/00_run_all.sh`, or `--apply` to execute the mutating ones.
+[`examples/`](examples/) walks through the runtime in 15 lessons (image build, sandbox/update/freeze, versioning, run/send/tail, logs/exec, stop/remove, binds, env+user, writing your first spec.yaml, to_home/, A2A endpoint, health+restart, multi-host, debugging). Run them read-only with `bash examples/00_run_all.sh`, or `--apply` to execute the mutating ones. Pre-baked agent specs live in [`examples/agents/`](examples/agents/) (`hello-agent`, `minimal-agent`, `full-agent`, `deepseek-agent`, `proxy-agent`).
 
 ### Models
 
@@ -128,11 +136,13 @@ Pick the model per agent under `spec.claude.model`:
 | `sonnet` | Claude Sonnet 4.6 *(default)* | Balanced capability and speed |
 | `haiku`  | Claude Haiku 4.5            | Fast, cheap, light tasks        |
 
-Aliases auto-track the latest version of each family; append `[1m]` for the 1M-token context window (`opus[1m]`, `sonnet[1m]`). Pin an exact build with a full ID like `claude-opus-4-7` or `claude-haiku-4-5-20251001`. To target a non-Anthropic, Anthropic-compatible backend (e.g. DeepSeek), use `spec.claude.provider` instead. **[Full model reference →](docs/spec-reference.md)**
+Aliases auto-track the latest version of each family; append `[1m]` for the 1M-token context window (`opus[1m]`, `sonnet[1m]`). Pin an exact build with a full ID like `claude-opus-4-7` or `claude-haiku-4-5-20251001`.
+
+**Non-Anthropic backend?** Set `spec.claude.provider: deepseek` (or `mimo` / `xiaomi`) for the bundled registry entries, or pass a dict `{ base_url: "...", auth_token_env: "..." }` for any Anthropic-API-compatible endpoint — LiteLLM, a self-hosted vLLM exposing an Anthropic shim, or any in-house gateway. See [`examples/agents/deepseek-agent/`](examples/agents/deepseek-agent/) for a complete spec. **[Full model + provider reference →](docs/spec-reference.md)**
 
 ## How it works
 
-`scitex-agent-container` (`sac`) materializes a `spec.yaml` into a long-lived, externally addressable Claude agent:
+`sac` materializes a `spec.yaml` into a long-lived, externally addressable Claude agent:
 
 ```
   spec.yaml   ─┐
@@ -151,7 +161,7 @@ Aliases auto-track the latest version of each family; append `[1m]` for the 1M-t
 
 **[Full architecture →](docs/how-sac-works.md)** — launch flow, to_home merge rules, A2A inbound, control plane, restart/health.
 
-**[YAML Spec Reference (v3) →](docs/spec-reference.md)** — annotated full example + field table (apiVersion, spec.apptainer.*, spec.claude.*, a2a, health, restart).
+**[YAML Spec Reference (v3) →](docs/spec-reference.md)** — annotated full example + field table (apiVersion, spec.apptainer.*, spec.claude.*, a2a, health, restart, provider).
 
 **[Talking to a Running Agent →](docs/talking-to-agents.md)** — three transports (A2A `POST /v1/turn`, `sac agents send`, host-level `sac listen`), when to use which, copy-pasteable curl examples.
 
@@ -184,7 +194,7 @@ curl -s http://127.0.0.1:7878/v1/health                # healthcheck
 
 See [`scripts/systemd/README.md`](scripts/systemd/README.md) for the full recipe + the federated-jobs vs hand-maintained-services split.
 
-## 1 Interfaces
+## Interfaces
 
 <details open>
 <summary><strong>CLI ⭐⭐⭐ (primary)</strong></summary>
@@ -205,21 +215,31 @@ sac agents forget <name> [--force]        # local-only state.db cleanup for the
                                            # (no ssh, no signal)
 sac agents send   <name> "<prompt>"       # send a follow-up turn to a running session
 sac agents send   <name> --key ESC        # interrupt current turn
-sac agents list [<name>] [--snapshot] [--priority]
+sac agents status [<name>] [--snapshot] [--priority]   # fleet view if no name; per-agent
+                                                       # JSON payload otherwise
+sac agents list   [<name>]                # alias of `status` (same renderer)
 sac agents health <name>
 sac agents tail   <name>                  # render session.jsonl (structured transcript)
 sac agents recall <name>                  # human-readable session summary
 sac agents check  <name>                  # preflight (validates yaml + probes runtime deps)
-sac agents find   <capability>
+sac agents find   <capability>            # search by metadata.labels.capabilities
 
 # Control plane (HTTP/JSON, loopback-only)
-sac listen [--bind 127.0.0.1:7878]       # boot per-host REST API (bearer-auth)
+sac listen [--bind 127.0.0.1:7878]        # boot per-host REST API (bearer-auth)
                                            # single-instance flock guard fails loud
                                            # on a duplicate launch (PID + lockfile shown)
-sac peer post-turn <to> "<msg>"          # local agent-to-agent message via sac listen
+sac listen restart                        # atomic stop-clean-relaunch
+sac peer post-turn <to> "<msg>"           # local agent-to-agent message via sac listen
+sac peer resolve-url <to>                 # print URL post-turn would target
+
+# A2A protocol (generic, no fleet deps)
+sac a2a serve <yamls...>                  # inbound HTTP for non-SDK runtimes
+                                           # (apptainer-runtime agents host /v1/turn themselves)
+sac a2a doctor <agent>                    # probe AgentCard endpoint
+sac a2a grant / revoke / block / unblock / grants
 
 # Image lifecycle (delegates to scitex-container)
-sac image build [base|scitex] [--sandbox] [--runtime apptainer|docker]
+sac image build [base|scitex] [--sandbox]
 sac image sandbox SOURCE                  # SIF → writable sandbox
 sac image update  SANDBOX [-p PKG]        # pip install --upgrade
 sac image freeze  SANDBOX OUT.sif         # sandbox → SIF
@@ -229,9 +249,11 @@ sac image rollback                        # restore previous
 sac image status                          # unified dashboard
 sac image snapshot [-o env.json]          # reproducibility capsule
 
-# Account / quota
+# Accounts / quota (multi-account rotation)
 sac accounts list / save / delete / switch        # stored-credential rotation
 sac accounts status                       # one-shot quota snapshot (5h%, 7d%, tier)
+sac accounts quota                        # this agent's own live quota
+sac accounts refresh                      # mint fresh access_token from refresh_token
 sac accounts sync-live / watch-live       # auto-snapshot live cred on `claude /login`
 sac accounts watch-quota                  # auto-rotate when quota threshold hit
 
@@ -240,29 +262,75 @@ sac host list / add / remove / set / probe / exec / validate
 sac host ssh-opts                         # print sac's ssh ControlMaster flags (shell-quoted)
 sac host add-peer / list-peers / remove-peer      # cross-host listen-bearer registry
 sac host probe-hub                        # WSL → fleet-hub layered connectivity probe
-sac peer post-turn AGENT TEXT             # A2A outbound (loopback or cross-host)
-sac a2a serve <yamls...>                  # A2A inbound for non-SDK runtimes
 
 # Fleet (peer-aware multi-agent orchestration)
 sac fleet launch  PEER <name>...          # rsync specs to PEER, start each remotely
 sac fleet notify  done|blocker|status --summary "..."   # agent→lead push (ADR-0013)
+sac fleet sync                            # cross-host spec audit (fails loud on drift)
 
 # Diagnostics / introspection
 sac doctor [--fleet]                      # diagnose agent-spec source drift
 sac subagent get-state                    # Claude Code Agent-tool subagent state
+sac mcp list-tools                        # MCP introspection
+sac skills list / get                     # bundled agent-facing skills
 
 # Federated scheduled jobs (delegates to scitex-dev ecosystem)
 sac dev systemd list / install / uninstall    # generate ~/.config/systemd/user/sac.*
 sac dev cron    list / install / uninstall    # crontab entries
 sac dev daemon  list / install / uninstall    # interactive daemons
 
+# State db / registry / events
+sac db query / show / clean / export / import / migrate / tick   # state.db inspection
+sac registry sync / reconcile             # cross-host comms_nodes anti-entropy
+sac event ingest                          # Claude Code hook event ingestor
+
 # Misc
 sac installation boot                     # first-time host bootstrap (venv, PATH, cron)
-sac event ingest                          # Claude Code hook event ingestor
-sac db   query / show / clean / export / import / migrate   # state.db inspection
-sac registry sync [--from PEER | --to PEER | --all]   # cross-host comms_nodes anti-entropy
-sac registry reconcile                    # singleton placement reconcile across fleet
+sac list-python-apis                      # enumerate public Python API
 sac --help-recursive                      # full subcommand tree
+```
+
+</details>
+
+<details>
+<summary><strong>Python ⭐⭐</strong></summary>
+
+<br>
+
+```python
+# Direct import
+import scitex_agent_container as sac
+
+cfg = sac.load_config("~/.scitex/agent-container/agents/hello-agent-1/spec.yaml")
+sac.validate_config(cfg)
+sac.agent.start("hello-agent-1")           # daemon
+sac.agent.status("hello-agent-1")          # dict matching `sac agents status --json`
+sac.peer.post_turn("hello-agent-1", "What is 2+2?")
+```
+
+```python
+# Or via the umbrella
+import scitex
+scitex.agent_container.agent.start("hello-agent-1")
+```
+
+See [`docs/spec-reference.md`](docs/spec-reference.md) for `AgentConfig` fields.
+
+</details>
+
+<details>
+<summary><strong>MCP ⭐</strong> (no server bundled — agents spawn their own)</summary>
+
+<br>
+
+sac itself does not ship an MCP server. Each agent declares its own MCP servers in `spec.mcp_servers` (which is mirrored into `$HOME/.mcp.json` at start via `to_home/`), so per-agent MCP surface is part of the YAML spec rather than a sac-global service.
+
+```yaml
+spec:
+  mcp_servers:
+    filesystem:
+      command: npx
+      args: ["-y", "@modelcontextprotocol/server-filesystem", "/work"]
 ```
 
 </details>
@@ -273,15 +341,14 @@ sac --help-recursive                      # full subcommand tree
 
 [`scitex-orochi`](https://github.com/ywatanabe1989/scitex-orochi) adds cross-host message routing, a Slack-like chatops UI, and a peer registry on top of `sac`. The dependency is one-way — orochi reads sac's on-disk state; sac never imports orochi. For details, see **[docs/sac-and-orochi.md](docs/sac-and-orochi.md)** — architecture diagram, responsibility split, how to wire `server:orochi-push`.
 
+## Four Freedoms for Research
 
->Four Freedoms for Research
+> 0. The freedom to **run** your research anywhere — your machine, your terms.
+> 1. The freedom to **study** how every step works — from raw data to final manuscript.
+> 2. The freedom to **redistribute** your workflows, not just your papers.
+> 3. The freedom to **modify** any module and share improvements with the community.
 >
->0. The freedom to **run** your research anywhere — your machine, your terms.
->1. The freedom to **study** how every step works — from raw data to final manuscript.
->2. The freedom to **redistribute** your workflows, not just your papers.
->3. The freedom to **modify** any module and share improvements with the community.
->
->AGPL-3.0 — because we believe research infrastructure deserves the same freedoms as the software it runs on.
+> AGPL-3.0 — because we believe research infrastructure deserves the same freedoms as the software it runs on.
 
 ---
 

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -1,9 +1,12 @@
 .. scitex-agent-container documentation master file
 
-scitex-agent-container - Declarative AI Agent Lifecycle Management
-===================================================================
+scitex-agent-container — Declarative, On-Prem-First Agent Container Runtime
+===========================================================================
 
-**scitex-agent-container** is a declarative YAML-based framework for defining, managing, and orchestrating AI coding agent instances. Part of `SciTeX <https://scitex.ai>`_.
+**scitex-agent-container** (``sac``) turns one ``spec.yaml`` into one
+long-lived, sandboxed, fleet-addressable Claude Code agent. Runs
+anywhere Apptainer runs — laptop, HPC login node, on-prem cluster,
+air-gapped server. Part of `SciTeX <https://scitex.ai>`_.
 
 .. toctree::
    :maxdepth: 2
@@ -38,37 +41,48 @@ scitex-agent-container - Declarative AI Agent Lifecycle Management
 
    api/scitex_agent_container
 
-Key Features
-------------
+Why sac
+-------
 
-- **YAML Definitions**: Declarative agent configuration via YAML files
-- **Lifecycle Management**: Create, start, stop, and destroy agent instances
-- **Rich Status**: ``status --json`` emits pane state, workspace files,
-  hook-captured tool history, and ``last_tool_at`` /
-  ``last_mcp_tool_at`` functional-heartbeat shortcuts for dashboards
-- **Claude Code Hook Integration**: ``hook-event`` ingests Claude Code
-  ``PreToolUse`` / ``PostToolUse`` / ``UserPromptSubmit`` / ``Stop``
-  events into a per-agent ring buffer
-- **Zero Coupling**: No knowledge of any downstream orchestrator;
-  consumers (e.g. scitex-orochi) wrap ``status --json`` to post to
-  their own hubs
+- **Declarative agents.** One ``spec.yaml`` per agent — the file *is*
+  the agent (dir-as-SSoT). Reproducible, version-controlled,
+  diff-reviewable.
+- **Rootless Apptainer isolation.** Runs where Docker/cloud sandboxes
+  cannot — HPC login nodes, on-prem, air-gapped. No root, no daemon,
+  no Docker socket. Hardened by default via ``--containall``.
+- **LLM-agnostic / on-prem-capable.** Default: Anthropic OAuth.
+  Alternative: any Anthropic-API-compatible backend (DeepSeek, MiMo /
+  Xiaomi, a self-hosted LiteLLM / vLLM-with-Anthropic-shim gateway)
+  via ``spec.claude.provider``. Data, code, and inference can stay
+  entirely on your network.
+- **Fleet ops out of the box.** A2A push (``POST /v1/turn``),
+  health / heartbeat, restart policies, multi-account credential
+  rotation with auto-quota-watch, MCP + CLI + Python surface,
+  cross-host orchestration via ``sac fleet``.
+- **AGPL-3.0.** Research-freedom license — infrastructure stays open,
+  modifications stay shareable.
 
 Quick Example
 -------------
 
 .. code-block:: bash
 
-    # Create and launch an agent from YAML definition
+    # Create and launch an agent from its YAML definition
     sac agents start my-agent
 
-    # List agents and their status
-    sac agents list
+    # Fleet view / per-agent status
+    sac agents status
+    sac agents status my-agent --json
 
-    # Inspect status as JSON
-    sac agents list --json
+    # Send a follow-up turn to a running agent
+    sac agents send my-agent "What is 2+2?"
 
-    # Stop an agent
+    # Tail the structured transcript
+    sac agents tail my-agent
+
+    # Stop / delete
     sac agents stop my-agent
+    sac agents delete my-agent -y
 
 Indices and tables
 ==================


### PR DESCRIPTION
## Summary

Refresh README + Sphinx landing for public-link readiness. Previous opener ("Agent in Apptainer") undersold the package. New framing leads with the five things sac actually differentiates on today:

- **Declarative agents** — one `spec.yaml` is the agent (dir-as-SSoT), reproducible & diff-reviewable.
- **Rootless Apptainer isolation** — runs on HPC login nodes, on-prem, air-gapped boxes where cloud sandboxes (E2B, Modal) cannot. No root, no daemon, no Docker socket.
- **LLM-agnostic** — Anthropic OAuth default; any Anthropic-API-compatible backend (DeepSeek, MiMo/Xiaomi, self-hosted LiteLLM or vLLM-with-Anthropic-shim gateway) via `spec.claude.provider`. Data, code, and inference can stay on-prem.
- **Fleet ops** — A2A push (`POST /v1/turn` per agent), health/heartbeat, restart policies, multi-account credential rotation with auto-quota-watch, MCP + CLI + Python surface, cross-host via `sac fleet`.
- **AGPL-3.0** — Four Freedoms for Research.

## Changes

- `README.md` — new "Why sac" lede, refreshed Quickstart (`sac agents send` shown), refreshed CLI digest (added `agents send`, `agents list` alias, `peer resolve-url`, `a2a doctor`, `accounts quota`/`refresh`, `fleet sync`, `mcp list-tools`, `skills list`/`get` — all real verbs that ship today). Added concise Python and MCP interface blocks. AGPL Four Freedoms preserved.
- `docs/sphinx/index.rst` — landing page re-themed: "Key Features" → "Why sac" mirroring the README; Quick Example uses modern verbs (`agents status`, `agents send`).

## Verification

- CLI verbs verified against real `sac --help` / sub-helps at v0.21.9 — every command shown exists today (no invented verbs).
- Python API verbs verified via live probe: `sac.agent.start`, `sac.agent.status`, `sac.peer.post_turn`, `sac.load_config`, `sac.validate_config` all callable.
- Provider mechanics verified against `src/scitex_agent_container/config/_provider_types.py` and `_provider_registry.py` — wording uses "Anthropic-API-compatible" (the actual code path), not "OpenAI-compatible" (avoids fabrication).
- Local `tests/develop/test_audit.py` fails identically on develop baseline (cause: local `--fakeroot` + `worktrees/` junk + pre-existing `cla.yml` secret-prefix); not introduced by this PR.

## Test plan

- [x] README renders on GitHub
- [ ] CI green (pytest matrix, RTD sphinx build, lint, import-smoke, quality audit)
- [ ] Visual review of links + image refs
