### PR TITLE
fix(restart): wait for previous runtime to exit before starting next (#58)

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_stop.py
+++ b/src/scitex_agent_container/_lifecycle/_stop.py
@@ -6,6 +6,7 @@ Extracted from the former monolithic ``lifecycle.py`` (split for the
 
 from __future__ import annotations
 
+import logging
 import time
 import traceback
 from pathlib import Path
@@ -18,6 +19,22 @@ from ._handover_loader import _load_handover_module
 from ._hook_runner import _fire_forget_hook, _run_hooks
 from ._instances import end_local_instance as _end_local_instance
 from ._runtime_select import _get_runtime
+
+logger = logging.getLogger(__name__)
+
+# Default upper bound on how long ``agent_restart`` will wait for the
+# previous runtime to actually exit before starting the new one. Tuned
+# for apptainer healthy teardown (~0.5–2 s); 15 s leaves comfortable
+# headroom for a loaded host. The race this closes: new container boots
+# while the old one still holds /home/agent overlay + per-agent stdio MCP
+# child still holds its PID lock file → new bun child's ``acquireLock``
+# sees the live old PID and exits 1 → claude silently drops the MCP.
+_DEFAULT_WAIT_FOR_STOP_TIMEOUT_S = 15.0
+# Poll interval while waiting. 0.25 s is small enough that a 1-second
+# teardown costs <=4 polls; large enough that a healthy host doesn't
+# spend measurable CPU on the loop. ``sleep_fn`` controls real-time
+# behavior; tests pass ``_no_sleep`` to spin as fast as Python allows.
+_WAIT_FOR_STOP_POLL_INTERVAL_S = 0.25
 
 
 def agent_stop(
@@ -150,6 +167,56 @@ def agent_stop_all(
     return results
 
 
+def _wait_for_previous_runtime_to_exit(
+    name: str,
+    config_path: str,
+    *,
+    runtime_factory: Optional[Callable[[AgentConfig], Any]],
+    sleep_fn: Callable[[float], None],
+    timeout_s: float,
+) -> bool:
+    """Block until the previous runtime instance is no longer running.
+
+    Returns True if the runtime stopped cleanly within ``timeout_s``,
+    False on timeout (caller proceeds anyway after a LOUD warning — see
+    ``agent_restart`` docstring for the race this closes). ``timeout_s
+    <= 0`` skips the gate entirely (legacy ``sleep_fn(2)`` behaviour,
+    preserved for callers that want the bypass).
+    """
+    if timeout_s <= 0:
+        sleep_fn(2)
+        return True
+    # Load once: config is stable across the gate and re-loading per poll
+    # would multiply YAML parsing on a busy host.
+    try:
+        config = load_config(config_path)
+    except Exception:  # stx-allow: fallback (reason: YAML may have been edited mid-restart; fall back to the legacy fixed sleep instead of blocking the restart on a transient parse error — the new container will surface the real error when it boots)
+        sleep_fn(2)
+        return True
+    factory = runtime_factory or _get_runtime
+    runtime = factory(config)
+    deadline = time.monotonic() + timeout_s
+    while runtime.is_running(config):
+        if time.monotonic() >= deadline:
+            logger.warning(
+                "agent_restart for %r: previous runtime still running after "
+                "%.2fs (SIGTERM ignored or teardown hung); proceeding to "
+                "start anyway. WARNING: this may trigger the apptainer "
+                'double-mount race ("destination is already in the mount '
+                'point list") and stdio-MCP lock-file contention (the '
+                "standalone bun telegrammer poller exits 1 on lock held by "
+                "the orphaned previous PID, claude then silently drops the "
+                "MCP). If %r repeatedly fails to honor SIGTERM, investigate "
+                "the runtime stop path (see ApptainerContainerRuntime.stop).",
+                name,
+                timeout_s,
+                name,
+            )
+            return False
+        sleep_fn(_WAIT_FOR_STOP_POLL_INTERVAL_S)
+    return True
+
+
 def agent_restart(
     name: str,
     registry: Registry | None = None,
@@ -158,6 +225,7 @@ def agent_restart(
     sleep_fn: Callable[[float], None] = time.sleep,
     handover_mod: Any = None,
     config_resolver: Optional[Callable[[str], str]] = None,
+    wait_for_stop_timeout_s: float = _DEFAULT_WAIT_FOR_STOP_TIMEOUT_S,
 ) -> bool:
     """Restart an agent by name: resolve spec → stop → settle → start.
 
@@ -183,6 +251,26 @@ def agent_restart(
     recorded host before reaching here, like ``stop`` does). By the
     time control reaches this function the target is local.
 
+    Teardown gate (2026-06-07, bug #42 — telegrammer drops after restart):
+    Between ``agent_stop`` (which sends SIGTERM and returns immediately —
+    ``ApptainerContainerRuntime.stop`` says "No wait loop yet — sac's
+    outer lifecycle does its own poll") and ``agent_start``, this function
+    now polls ``runtime.is_running`` until False or
+    ``wait_for_stop_timeout_s`` elapses. The legacy fixed ``sleep_fn(2)``
+    was the SOLE settle window — it raced the apptainer teardown on a
+    loaded host. Operator-visible symptom: the new container booted while
+    the old one still held the ``/home/agent`` overlay (apptainer warned
+    "destination is already in the mount point list"), AND the old SDK's
+    per-agent stdio MCP child (the standalone bun telegrammer poller)
+    was still alive holding ``$HOME/.claude-code-telegrammer-*/...lock``.
+    The new bun child's ``acquireLock`` then hit ``process.kill(old_pid,
+    0)`` SUCCESS → ``process.exit(1)``, claude silently marked the MCP
+    failed and never retried it. ``sac`` + Mermaid MCPs reloaded fine
+    (no inter-instance lock for those), masking the bug as "only Telegram
+    broke." On timeout we LOG LOUD (so a stuck previous instance is
+    self-diagnosing from stdout.log) and proceed — silently spinning
+    forever locks the operator out of restart entirely.
+
     Args:
         name: Agent name.
         registry: Optional registry instance.
@@ -194,6 +282,11 @@ def agent_restart(
             :func:`config.resolve_config`). Injected for tests so the
             no-registry-row fallback can be exercised against a real
             on-disk spec without monkeypatching internals.
+        wait_for_stop_timeout_s: Upper bound on the previous-runtime
+            readiness gate (see "Teardown gate" above). Default 15 s —
+            ~10× a healthy apptainer teardown. Set to 0 to skip the gate
+            entirely (legacy behaviour, retained for tests of unrelated
+            code paths).
 
     Raises:
         RuntimeError: When ``name`` has neither a registry row NOR a
@@ -236,7 +329,13 @@ def agent_restart(
         runtime_factory=runtime_factory,
         handover_mod=handover_mod,
     )
-    sleep_fn(2)
+    _wait_for_previous_runtime_to_exit(
+        name,
+        config_path,
+        runtime_factory=runtime_factory,
+        sleep_fn=sleep_fn,
+        timeout_s=wait_for_stop_timeout_s,
+    )
     # Clear BOTH the persisted session_id AND session_id_history before the
     # restart. A plain ``agent_restart`` previously called ``agent_start``
     # WITHOUT force=True (so no session reset ran at all), and the

--- a/src/scitex_agent_container/_runners/_session_conversation.py
+++ b/src/scitex_agent_container/_runners/_session_conversation.py
@@ -280,6 +280,27 @@ async def run_conversation(
             _drain_failed_inbox(inbox, exc)
             return
 
+        # Instrumentation (bug #42 hardening, 2026-06-07): name every
+        # stdio MCP we are about to hand to the SDK so a future "MCP X
+        # silently dropped" recurrence (operator-visible symptom: bot
+        # stopped responding after restart) leaves a self-diagnosing
+        # trail in stdout.log. The corresponding ``apptainer_restart``
+        # mount + lock race that originally caused this is closed in
+        # ``_lifecycle/_stop.py::_wait_for_previous_runtime_to_exit``;
+        # this log is the OBSERVABILITY half so a regression of either
+        # the race or the SDK's per-MCP launch is visible without
+        # bouncing the agent or attaching to its stderr.
+        try:
+            mcp_keys = sorted((getattr(options, "mcp_servers", None) or {}).keys())
+        except Exception:  # stx-allow: fallback (reason: options surface is SDK-version-dependent — never fail the conversation on a logging probe)
+            mcp_keys = ["<unreadable>"]
+        logger.info(
+            "claude-session %s: launching SDK (attempt=%d resume=%s mcp_servers=%r)",
+            name,
+            attempt,
+            current_sid,
+            mcp_keys,
+        )
         try:
             async with ClaudeSDKClient(options=options) as client:
                 while True:

--- a/tests/scitex_agent_container/_lifecycle/test_lifecycle.py
+++ b/tests/scitex_agent_container/_lifecycle/test_lifecycle.py
@@ -1330,6 +1330,142 @@ def test_agent_restart_no_row_uses_default_resolver_discovery_chain(
     assert ok is True and len(runtime.start_calls) == 1
 
 
+class _StaggeredRuntime(FakeRuntime):
+    """Real fake whose ``is_running`` returns the next bool from a stage list.
+
+    Models the apptainer teardown race: after ``stop()`` sends SIGTERM the
+    container takes several ``is_running`` polls to actually exit. Used by
+    ``test_agent_restart_waits_for_runtime_to_stop_before_starting`` to
+    pin the bug shape (start was called WHILE the previous instance was
+    still running) and verify the fix.
+    """
+
+    def __init__(self, *, stages: list[bool]) -> None:
+        super().__init__(start_result=True)
+        # Copy so the test can keep the list intact for assertions later.
+        self._stages = list(stages)
+        self.is_running_calls = 0
+        self.was_running_at_start: bool | None = None
+
+    def is_running(self, config: AgentConfig) -> bool:
+        i = self.is_running_calls
+        self.is_running_calls += 1
+        # After the stage list is exhausted, stay at the last value (False
+        # on a healthy teardown).
+        if i < len(self._stages):
+            return self._stages[i]
+        return self._stages[-1] if self._stages else False
+
+    def start(self, config: AgentConfig, **kwargs: Any) -> bool:
+        # Record whether the previous instance was STILL RUNNING at the
+        # moment start() fired — this is the exact bug shape we're fixing.
+        # Read directly off the stage list so the recording itself doesn't
+        # consume a poll slot.
+        i = self.is_running_calls
+        if i == 0:
+            self.was_running_at_start = self._stages[0] if self._stages else False
+        else:
+            idx = min(i - 1, len(self._stages) - 1)
+            self.was_running_at_start = self._stages[idx]
+        return super().start(config, **kwargs)
+
+
+def test_agent_restart_waits_for_runtime_to_stop_before_starting(
+    tmp_path: Path, registry: Registry
+) -> None:
+    """Restart MUST wait for the previous container to actually exit.
+
+    Bug shape (2026-06-07, operator-visible): ``agent_restart`` called
+    ``runtime.stop()`` (which sends SIGTERM and returns immediately) then
+    slept a fixed 2 s and called ``runtime.start()``. With apptainer, the
+    old container's ``/home/agent`` overlay was still mounted when the
+    new one booted ("destination is already in the mount point list"
+    warning in stdout.log), and the old SDK's per-agent stdio MCP
+    children (the standalone bun telegrammer poller) were still alive
+    holding their PID lock file. The new bun child then hit
+    ``acquireLock`` against the live old PID and exited 1; claude
+    silently marked the MCP failed and never retried it. Symptom: the
+    Telegram bot stopped responding after every ``sac agents restart``
+    even though ``sac`` + Mermaid MCPs reloaded fine (no inter-instance
+    lock for those).
+
+    Fix: poll ``runtime.is_running`` until it returns False (with a
+    bounded timeout) BEFORE calling ``runtime.start``. The fixed
+    ``sleep_fn(2)`` is replaced by a real readiness gate.
+    """
+    # Arrange — a runtime that reports "still running" for the first
+    # three polls after stop and only flips to "stopped" on the fourth.
+    # This mirrors a realistic apptainer teardown (~0.5–2 s under
+    # healthy load).
+    spec = _write_spec(tmp_path)
+    registry.add("alpha", str(spec), "cld-alpha")
+    runtime = _StaggeredRuntime(stages=[True, True, True, False])
+
+    # Act
+    ok = lc.agent_restart(
+        "alpha",
+        registry=registry,
+        runtime_factory=lambda _c: runtime,
+        sleep_fn=_no_sleep,
+        handover_mod=FakeHandover(),
+    )
+
+    # Assert — start was called AND only after is_running flipped to False.
+    assert ok is True
+    assert len(runtime.start_calls) == 1
+    assert runtime.was_running_at_start is False, (
+        "agent_restart called runtime.start() while runtime.is_running() was "
+        "still True — this is the apptainer mount + telegrammer lock race "
+        f"(stages={runtime._stages}, polls={runtime.is_running_calls})"
+    )
+    # And it must have polled at least the number of "still running" stages.
+    assert runtime.is_running_calls >= 4, (
+        f"agent_restart should poll runtime.is_running until False; got "
+        f"{runtime.is_running_calls} polls"
+    )
+
+
+def test_agent_restart_warns_and_proceeds_when_previous_runtime_will_not_exit(
+    tmp_path: Path, registry: Registry, caplog: Any
+) -> None:
+    """If the previous runtime ignores SIGTERM past the wait timeout,
+    ``agent_restart`` must emit a LOUD warning naming the operator-visible
+    consequences (mount race + telegrammer lock contention) and proceed —
+    a stuck container is rare, but silently spinning forever locks the
+    operator out of restart entirely.
+    """
+    import logging as _logging
+
+    spec = _write_spec(tmp_path)
+    registry.add("alpha", str(spec), "cld-alpha")
+    # is_running stays True forever — models a previous instance that
+    # never honors SIGTERM in budget.
+    runtime = _StaggeredRuntime(stages=[True])
+
+    caplog.set_level(_logging.WARNING, logger="scitex_agent_container._lifecycle._stop")
+    ok = lc.agent_restart(
+        "alpha",
+        registry=registry,
+        runtime_factory=lambda _c: runtime,
+        sleep_fn=_no_sleep,
+        handover_mod=FakeHandover(),
+        # Short timeout so the test is fast; ``_no_sleep`` makes the poll
+        # loop spin as fast as Python allows.
+        wait_for_stop_timeout_s=0.05,
+    )
+
+    # Started despite the timeout (loud-but-proceed semantics).
+    assert ok is True
+    assert len(runtime.start_calls) == 1
+    # And there is a WARN-level log naming the race so a future
+    # "telegrammer dropped after restart" recurrence is self-diagnosing
+    # from stdout.log.
+    messages = " ".join(rec.getMessage() for rec in caplog.records)
+    assert "still running" in messages or "SIGTERM" in messages, (
+        f"expected loud warning about the unkilled previous instance; got: {messages!r}"
+    )
+
+
 # ---------------------------------------------------------------------------
 # agent_status
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`agent_restart` previously sent SIGTERM via `runtime.stop()` (which returns immediately), slept a fixed `sleep_fn(2)`, then called `agent_start`. The 2-second sleep raced the apptainer teardown — on a loaded host the new container booted while the old one still held:

- **the `/home/agent` overlay** — apptainer warned `destination is already in the mount point list` in stdout.log (visible in the prod log around any `sac agents restart`); and
- **the old SDK's per-agent stdio MCP child** — the standalone bun telegrammer poller still alive holding `$HOME/.claude-code-telegrammer-*/...lock`.

The new bun child's `acquireLock` then hit `process.kill(old_pid, 0)` → SUCCESS → `process.exit(1)`. claude silently marked the MCP failed and **never retried it**. Operator-visible symptom: Telegram bot stopped responding after every restart even though sac + Mermaid MCPs reloaded fine (no inter-instance lock for those — hence the bug only manifested on the telegrammer channel).

## What changed

1. **`_lifecycle/_stop.py`** — new `_wait_for_previous_runtime_to_exit` helper. `agent_restart` now polls `runtime.is_running` until False or `wait_for_stop_timeout_s` (default **15 s**, ~10× a healthy apptainer teardown) elapses. On timeout it LOGs LOUD at WARNING naming the apptainer mount race + telegrammer lock contention, then proceeds — silently spinning forever would lock the operator out of restart entirely.
2. **`_runners/_session_conversation.py`** — one-line INFO log per SDK launch attempt naming the sorted `mcp_servers` keys handed to the SDK. So a future "MCP X silently dropped" recurrence leaves a self-diagnosing trail in `stdout.log` without bouncing the agent.

## Tests (no mocks)

Two new tests in `tests/scitex_agent_container/_lifecycle/test_lifecycle.py`:

- `test_agent_restart_waits_for_runtime_to_stop_before_starting` — pins the bug shape. A `_StaggeredRuntime` reports `is_running=True` for 3 polls, then False. Old code called `start` while `was_running_at_start=True` (the exact race). New code asserts `was_running_at_start is False` AND `is_running_calls >= 4`.
- `test_agent_restart_warns_and_proceeds_when_previous_runtime_will_not_exit` — pins the timeout fallback. `is_running` stays True forever; with `wait_for_stop_timeout_s=0.05` the helper warns LOUD and starts anyway. Asserts the warning mentions `still running` or `SIGTERM`.

Full **lifecycle + runners + cli_pkg/lifecycle** suite (972 tests) stays green.

## Forensics that motivated this fix

From inside this agent's container (proj-scitex-agent-container) after the operator reported bot silence on 2026-06-07:

- `getWebhookInfo` returned `url="", pending_update_count=6` — Telegram had messages queued and **nothing was calling `getUpdates`**.
- `ps -ef` showed **no `bun` child** for the telegrammer MCP, even though `/proc/31/cmdline` (the inner claude SDK) had it in `--mcp-config`.
- Manually re-spawned the same `bash -c "... bun run telegram-server.ts"` with the same env: the bun process started cleanly (stale-lock detection worked, MCP stdio handshake, preflight passed). So the bun spawn path is healthy in isolation.
- The host runner log (`stdout.log`) showed `WARNING: While bind mounting '...overlays/proj-scitex-agent-container/upper/home/agent:/home/agent': destination is already in the mount point list` repeated across restarts, plus `RuntimeError: Event loop is closed` from `BaseSubprocessTransport.__del__` during the previous run's cleanup.

That pointed at the restart sequencing in `_lifecycle/_stop.py::agent_restart`. The `sleep_fn(2)` between stop and start was the smoking gun — it's a fixed sleep, not a readiness gate.

## Operational note

Until this fix is deployed, the agent runs a sidecar bun telegrammer (`/tmp/agent-container-telegram-sidecar.pid`) launched manually. The sidecar must be killed before the next clean restart, otherwise it 409s against the SDK's MCP poller when that finally loads.

Likely fleet-wide: lead reported `proj-neurovista`, `proj-paper-ripple-wm`, `proj-scitex-todo` also silent on Telegram. Same restart race; the sac runtime fix covers them all once they're rebuilt.

## Test plan

- [ ] `pytest tests/scitex_agent_container/_lifecycle/test_lifecycle.py -k 'waits_for_runtime_to_stop or warns_and_proceeds'` — both new tests pass
- [ ] `pytest tests/scitex_agent_container/_lifecycle/ tests/scitex_agent_container/_runners/ tests/scitex_agent_container/cli_pkg/lifecycle/` — full 972-test surface green
- [ ] After merge + rebuild on this host: kill the manual sidecar, `sac agents restart proj-scitex-agent-container`, confirm the bun child is alive after restart (`ps -eo args | grep telegram-server.ts`) and `getWebhookInfo` shows the new poller draining updates.
- [ ] Same restart check on `proj-neurovista`, `proj-paper-ripple-wm`, `proj-scitex-todo`.

Refs: bug #42 / #58.