### PR TITLE
fix(ci): prefix cla.yml secret with SCITEX_AGENT_CONTAINER_ (PS-168)

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -20,7 +20,18 @@ jobs:
         uses: contributor-assistant/github-action@v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          # PS-168 §1 (workflow-secret-env-prefix): per-package secrets in
+          # .github/workflows/ must carry the SCITEX_AGENT_CONTAINER_ prefix.
+          # GITHUB_TOKEN above is the GitHub-builtin (cross-cutting, allow-
+          # listed); GH_PERSONAL_ACCESS_TOKEN is a repo-set secret the CLA
+          # assistant needs for writing to the cla-signatures branch on behalf
+          # of external contributors, so it MUST carry the package prefix.
+          # The repo secret must be added under the prefixed name in GitHub
+          # Settings → Secrets → Actions for this workflow to function for
+          # non-allow-listed contributors; ywatanabe1989's own PRs are
+          # allow-listed below and never exercise this token, so a missing
+          # secret is recoverable without breaking maintainer flow.
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.SCITEX_AGENT_CONTAINER_GH_PERSONAL_ACCESS_TOKEN }}
         with:
           path-to-signatures: "signatures/cla.json"
           path-to-document: "https://github.com/ywatanabe1989/scitex-agent-container/blob/main/CLA.md"


### PR DESCRIPTION
## Summary

Unblocks the develop pytest-matrix CI which has been red since Jun 5 (last 5 develop runs all failed on this single audit violation).

`tests/develop/test_audit.py::test_audit_all_clean` invokes `scitex-dev ecosystem audit-all scitex-agent-container` and fails because audit-project finds:

```
[E] [PS-168 §1 secret-env-prefix-missing] .github/workflows/cla.yml:23:
secret name "GH_PERSONAL_ACCESS_TOKEN" should be prefixed
"SCITEX_AGENT_CONTAINER_GH_PERSONAL_ACCESS_TOKEN" (per-package secrets
in `.github/workflows/` must carry the `SCITEX_AGENT_CONTAINER_`
prefix; cross-cutting names are allow-listed)
```

All other audit families (audit-cli / audit-mcp-tools / audit-skills / audit-python-apis / audit-django) report SUCC. The matrix red boils down to **this single line**.

## Fix

`.github/workflows/cla.yml:23`

```diff
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.SCITEX_AGENT_CONTAINER_GH_PERSONAL_ACCESS_TOKEN }}
```

`GITHUB_TOKEN` (the GitHub-builtin) is cross-cutting and allow-listed. `GH_PERSONAL_ACCESS_TOKEN` is a repo-set secret the CLA Assistant action needs for writing to the `cla-signatures` branch on behalf of external contributors, so it MUST carry the package prefix.

Inline comment block explains the rule, the cross-cutting carve-out for `GITHUB_TOKEN`, and the recoverable failure mode below.

## Action required at deploy

Add the repo-level secret under the new prefixed name in **GitHub → Settings → Secrets and variables → Actions** (or rename the existing `GH_PERSONAL_ACCESS_TOKEN` to `SCITEX_AGENT_CONTAINER_GH_PERSONAL_ACCESS_TOKEN`).

Until that lands, the CLA workflow resolves `${{ secrets.SCITEX_AGENT_CONTAINER_GH_PERSONAL_ACCESS_TOKEN }}` to empty — but the existing `allowlist: bot*,ywatanabe1989` means the CLA path is **never exercised for maintainer PRs**, so a missing secret is recoverable without breaking the merge flow. Only an external contributor's first PR would surface the empty token, and that's exactly the case the prefix rename serves anyway.

Lead has confirmed they'll add the secret as part of the coordinated deploy after this merges.

## Test plan

- [ ] `pytest tests/develop/test_audit.py::test_audit_all_clean` in the CI matrix (py3.11 + py3.13) goes green.
- [ ] No other audit family regresses (all currently SUCC).
- [ ] CLA Assistant workflow still triggers on `pull_request_target` open events (env var rename only — workflow shape unchanged).

## Why no skip/xfail

Per lead's instruction: the gate is correct — the secret really WAS missing the prefix. The fix is the rename, not silencing the gate.

## Unblocks

- `#333` (docs) — currently red on this same gate.
- `#334` (bug #42 — restart race / telegrammer MCP drops) — currently red on this same gate.

After this merges → develop green → both #333 and #334 unblock → lead does the coordinated deploy (add secret + `git pull` + `sac agents cleanup --apply` + `sac agents restart`), which ships #58's telegrammer-MCP-restart fix and the in-flight docs.

## Forensics

Verified by `gh run view 27060656995 -R ywatanabe1989/scitex-agent-container --log-failed`:

```
tests/develop/test_audit.py::test_audit_all_clean FAILED                 [  0%]
...
AssertionError: audit-all reported violations for 'scitex-agent-container' (exit=1).
...
=== audit-project ===
ERRO: scitex-agent-container (...): 1 error(s)
ERRO:   [E] [PS-168 §1 secret-env-prefix-missing] .github/workflows/cla.yml:23:
```

Local audit in this container additionally shows PS-103 violations for `--fakeroot` and `worktrees/` — those are **local dev artifacts** in `/work` and don't exist in the CI clean checkout (confirmed: the failing CI log lists ONLY the PS-168 error).

Refs: bug #42, PRs #333 / #334.