### PR TITLE
deps: add scitex-todo>=0.3.0 as hard-dep (ADR-0008 D5)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,26 @@ dependencies = [
     "scitex-container>=0.1.0",
     "scitex-logging>=0.1.5",
     "scitex-ssh>=1.0.0",
+    # Canonical YAML task store (`<git-root>/.scitex/todo/tasks.yaml`)
+    # used by the per-agent runtime skill so each project agent records
+    # its own work-in-flight as a queryable dependency graph instead of
+    # in private memory. ADR-0008 D5 (hard-dep rollout) — fleet-wide
+    # skill-propagation needs the verbs to be importable everywhere,
+    # not gated behind a per-agent venv install.
+    #
+    # Lazy-load contract (verified by proj-scitex-todo 2026-06-07,
+    # a2a 87095307): `import scitex_todo` is zero-file-I/O — module
+    # level only does `import yaml` + closed-enum tuples + the dataclass;
+    # `_model.load_tasks(path)` is called solely by explicit mutation
+    # verbs; the `fcntl.flock` is on a sibling `.lock` file opened
+    # INSIDE the `_store_lock()` contextmanager (request-scoped, not
+    # session-scoped). Two idle agents importing it cause zero contention.
+    #
+    # v0.3.0 is the release that shipped the public CLI surface sac's
+    # `_session_cli.py` and the agent skill rely on (`scitex-todo add /
+    # update / done / list-tasks / summary / resolve-store / init-store`);
+    # that is our hard minimum.
+    "scitex-todo>=0.3.0",
     # A2A protocol surface — Phase 1 SDK adoption (see GITIGNORED/A2A_MIGRATION.md).
     # `[http-server]` extras pull in starlette + sse-starlette for the
     # JSON-RPC + SSE routes we mount in `a2a/_server.py`.


### PR DESCRIPTION
## Summary

Promotes `scitex-todo` from an ad-hoc per-agent venv install to a declared `[project.dependencies]` entry. Per ADR-0008 D5 (lead-coordinated rollout, green-lit 2026-06-07 a2a `17e09e34`).

- **What:** add `scitex-todo>=0.3.0` to `dependencies` in `pyproject.toml` with an in-place comment quoting the lazy-load contract verbatim so the audit trail lives next to the dep.
- **Why:** the per-agent runtime skill writes work-in-flight to `<git-root>/.scitex/todo/tasks.yaml` via the `scitex-todo` CLI/Python API. Today each project agent installs it ad-hoc; the fleet's skill-propagation needs the verbs importable everywhere by default.
- **Safety:** `import scitex_todo` is zero-file-I/O — verified by proj-scitex-todo (a2a `87095307`, 2026-06-07). Module-level only imports `yaml` + closed-enum tuples + the dataclass; `_model.load_tasks(path)` is only called by explicit mutation verbs; `fcntl.flock` is on a sibling `.lock` file opened inside the `_store_lock()` contextmanager (request-scoped, not session-scoped). Two idle agents importing it cause zero contention.
- **Version pin:** `>=0.3.0` is the release that shipped the public CLI surface sac depends on (`add` / `update` / `done` / `list-tasks` / `summary` / `resolve-store` / `init-store`). Will retroactively bump to `>=0.4.0` once proj-scitex-todo's PR #65 (field-flag expansion) lands.
- **Runtime behaviour:** unchanged. scitex-todo is already installed ad-hoc in agent venvs today; this PR just promotes the install from "agent does it on first use" to "pip resolves it at sac install time."

## Test plan

- [x] `pyproject.toml` parses cleanly via `tomllib`; dep is present in `[project.dependencies]`
- [x] Lazy-load contract confirmed by proj-scitex-todo (a2a `87095307`)
- [x] Local install of `scitex-todo==0.3.0` against `/opt/venv-agent` succeeds and `scitex-todo --version` works
- [x] Full test suite passes locally except for `tests/develop/test_audit.py::test_audit_all_clean` which is **pre-existing tech debt on `develop`** (confirmed by the existing in-flight branches `fix/audit-clean-on-develop` and `fix/develop-audit-all-clean`; the audit failures are: 3 STX-TQ002/TQ007 violations in `_lifecycle/test_lifecycle.py`, 4 PS-103/PS-107/PS-110 README + top-level junk-file issues, and 1 audit-mcp-tools tooling crash — none of these touch the pyproject edit)
- [ ] CI green
- [ ] proj-scitex-todo notified that the dep is in flight (already done via a2a `382497d9`)

## Cross-references

- ADR-0008 D5 rollout
- proj-scitex-todo a2a `87095307` (lazy-load proof)
- Lead a2a `17e09e34` (route-C hold + dep-PR green-light)
- proj-scitex-todo a2a `ffff7404` (PR #64/#65 CI-RED — bump-target deferred)