### PR TITLE
fix(runtime): redirect $TMPDIR to a per-agent /opt/tmp host bind (#50 option 4)

### DIFF
--- a/src/scitex_agent_container/runtimes/_apptainer_runtime.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_runtime.py
@@ -272,9 +272,18 @@ class ApptainerContainerRuntime(RuntimeBase):
         # when the operator already declared --workdir in raw_args. The
         # flag is curated (emitted before raw_args) so an operator's own
         # --workdir still wins via the helper's raw_args skip.
-        from ._apptainer_tmpfs import tmpfs_workdir_flags
+        from ._apptainer_tmpfs import opt_tmp_flags, tmpfs_workdir_flags
 
         argv += tmpfs_workdir_flags(config, state_dir)
+
+        # Second tmpfs-overflow defence: bind a per-agent host scratch
+        # dir at /opt/tmp inside the container and redirect $TMPDIR
+        # there. Stops heavy ML capsules (TF/Keras tokenizer caches,
+        # BERT preprocessing) from wedging on the small writable-tmpfs
+        # overlay when they use ``tempfile.gettempdir()`` instead of
+        # literal /tmp. Per #50 option 4 (lead a2a 7d14d69b); confirmed
+        # live on proj-paper-scitex-clew capsule-0238624.
+        argv += opt_tmp_flags(config, state_dir)
 
         # Anthropic-auth argv — emits the backend wiring (env + creds
         # bind). Branches internally on whether spec.claude.provider is

--- a/src/scitex_agent_container/runtimes/_apptainer_tmpfs.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_tmpfs.py
@@ -1,4 +1,4 @@
-"""Sized ``/tmp`` scratch for the apptainer runtime.
+"""Sized ``/tmp`` scratch + ``TMPDIR=/opt/tmp`` redirect for apptainer.
 
 Why this exists
 ---------------
@@ -10,34 +10,48 @@ pytest fixtures with file IO routinely fill that 64 MB tmpfs mid-run
 and fail with "No space left on device" (the symptom that triggered
 this feature — see the FUTURE note ``sac-container-tmpfs-size.md``).
 
+Heavy ML capsules (TF/Keras tokenizer caches, BERT preprocessing) hit
+the SAME wall through a slightly different path: ``tempfile.gettempdir()``
+honours ``$TMPDIR`` before falling through to ``/tmp``. If the workload
+writes a multi-GB dataset to its tempdir under ``--writable-tmpfs``,
+the writable-tmpfs overlay (also a small in-memory tmpfs) fills and
+the process wedges silently — the symptom proj-paper-scitex-clew hit
+on cohort-A capsule-0238624 (a2a ``d346a786``, 2026-06-07).
+
 What we do
 ----------
-Apptainer's ``-W/--workdir <dir>`` flag relocates the in-container
-``/tmp`` and ``/var/tmp`` (and ``$HOME`` under ``--contain``, but sac
-pins ``$HOME`` via ``--home`` so that part is moot) onto a host
-directory, replacing the tiny session tmpfs with the host filesystem's
-capacity. We create a per-agent scratch dir under
-``<state_dir>/tmp-scratch`` and emit ``--workdir <dir>``.
+TWO independent measures, both default-on:
 
-``spec.apptainer.tmpfs_size`` (default ``"2G"``) is the **minimum
-free-space guarantee**: before launch we verify the host filesystem
-backing the scratch dir has at least that many bytes free, and fail
-loud (``TmpfsSpaceError``) if not — rather than letting the agent
-discover the shortfall mid-run with an opaque ENOSPC. It is NOT a hard
-cap: an unprivileged apptainer user cannot mount a size-capped tmpfs
-(``--mount type=tmpfs`` is rejected by apptainer 1.4 — only ``bind`` is
-supported), so the honest contract is "at least this much room",
-backed by the host disk. Setting ``tmpfs_size: ""`` opts out entirely
-(no ``--workdir``; the legacy 64 MB tmpfs is used).
+1. **``--workdir <state_dir>/tmp-scratch``** (function
+   :func:`tmpfs_workdir_flags`). Apptainer's ``-W/--workdir <dir>``
+   flag relocates the in-container ``/tmp`` and ``/var/tmp`` onto a
+   host directory, replacing the tiny session tmpfs with the host
+   filesystem's capacity. ``spec.apptainer.tmpfs_size`` (default
+   ``"2G"``) is the minimum free-space guarantee: before launch we
+   verify the host filesystem backing the scratch dir has at least
+   that many bytes free, raising :class:`TmpfsSpaceError` if not.
+
+2. **``--bind <state_dir>/opt-tmp:/opt/tmp`` + ``--env TMPDIR=/opt/tmp``**
+   (function :func:`opt_tmp_flags`). Apps that write to ``$TMPDIR``
+   instead of literal ``/tmp`` (Python's ``tempfile``, sqlite3
+   wal-shm, TF/Keras caches) land on the bound per-agent host
+   scratch dir rather than the writable-tmpfs overlay. Per #50
+   lead-decision option 4 (a2a ``7d14d69b``, 2026-06-07), confirmed
+   live by proj-paper-scitex-clew capsule-0238624 (submission.json
+   T+7min after the TMPDIR=/opt/tmp fix landed). No host-/tmp leak
+   (per-agent scratch dir, not host ``/tmp``).
+
+Both measures key on ``spec.apptainer.tmpfs_size`` — setting it to
+``""`` opts out of BOTH (legacy 64 MB tmpfs everywhere). Operator
+escape hatches (their own ``--workdir`` in ``raw_args``; their own
+``TMPDIR`` in ``apptainer.env``; their own bind to ``/opt/tmp``) all
+win — sac never overrides an explicit operator choice.
 
 Compatibility
 -------------
-``--workdir`` composes cleanly with the hardened default flags
+Both flag sets compose cleanly with the hardened default flags
 (``--containall --cleanenv --writable-tmpfs --home /home/agent``) and
-with PR #183's overlay upper-home bind — verified end-to-end. When the
-operator already declares their own ``-W``/``--workdir`` in
-``apptainer.raw_args`` (relaxed escape-hatch), sac skips its own to
-avoid a duplicate/conflicting flag.
+with PR #183's overlay upper-home bind — verified end-to-end.
 """
 
 from __future__ import annotations
@@ -128,4 +142,89 @@ def tmpfs_workdir_flags(config, state_dir: Path) -> list[str]:
     return ["--workdir", str(scratch)]
 
 
-__all__ = ["tmpfs_workdir_flags", "parse_tmpfs_size_bytes", "TmpfsSpaceError"]
+def opt_tmp_flags(config, state_dir: Path) -> list[str]:
+    """Return ``--bind`` + ``--env`` flags to redirect ``$TMPDIR`` onto
+    a per-agent host scratch dir at ``/opt/tmp`` inside the container.
+
+    Default emission (under the default ``ApptainerSpec``):
+
+    .. code-block:: text
+
+        --bind <state_dir>/opt-tmp:/opt/tmp --env TMPDIR=/opt/tmp
+
+    The bind makes ``/opt/tmp`` inside the container point at a host
+    directory (so writes hit real disk, not the writable-tmpfs overlay
+    or the 64 MB session tmpfs). The ``TMPDIR`` env redirects Python's
+    ``tempfile.gettempdir()``, sqlite3 wal-shm files, and most C-lib
+    tempdir lookups to that path. Together these stop heavy ML
+    capsules (TF/Keras tokenizer caches, BERT preprocessing, multi-GB
+    pickles) from wedging on a small in-memory tmpfs.
+
+    Per #50 lead-decision option 4 (a2a ``7d14d69b``, 2026-06-07);
+    confirmed live by proj-paper-scitex-clew capsule-0238624
+    (a2a ``d346a786``).
+
+    Returns ``[]`` (no-op) when:
+      * ``spec.apptainer.tmpfs_size`` is empty (operator opt-out,
+        consistent with :func:`tmpfs_workdir_flags`).
+
+    Operator overrides are respected:
+      * If ``spec.apptainer.env.TMPDIR`` is set (any value), sac does
+        not append its own ``--env TMPDIR=...`` (last-wins would have
+        won, but emitting our own would be wasted argv noise and
+        confusing in logs).
+      * If ``spec.apptainer.binds`` already includes any entry whose
+        container side is ``/opt/tmp``, sac skips its own bind to
+        avoid a duplicate-mount error.
+
+    Creates ``<state_dir>/opt-tmp`` if it doesn't exist (mode 0o700
+    via apptainer's default umask). Does NOT preflight free space —
+    the user-facing knob for that is ``spec.apptainer.tmpfs_size``,
+    which :func:`tmpfs_workdir_flags` already polices.
+    """
+    ap = getattr(config, "apptainer", None)
+    if ap is None:
+        size = "2G"
+        env: dict = {}
+        binds: list = []
+    else:
+        size = getattr(ap, "tmpfs_size", "2G")
+        env = dict(getattr(ap, "env", None) or {})
+        binds = list(getattr(ap, "binds", None) or [])
+
+    if not size:
+        # Operator opted out of sac's tmpfs management; don't
+        # surreptitiously inject /opt/tmp bind+env either.
+        return []
+
+    flags: list[str] = []
+
+    # Skip the bind if the operator already mapped something to
+    # /opt/tmp. The container side is the LAST colon-separated field
+    # (possibly followed by an optional :ro/:rw mode), so we check
+    # whether any bind entry mentions ``:/opt/tmp`` as its container
+    # path. This is a substring check by design — bind grammar is
+    # ``host:container[:mode]``, container paths never contain colons,
+    # so ``:/opt/tmp`` (or ``:/opt/tmp:``) is unambiguous.
+    operator_owns_opt_tmp_bind = any(
+        ":/opt/tmp" in b and (b.endswith(":/opt/tmp") or ":/opt/tmp:" in b)
+        for b in binds
+    )
+    if not operator_owns_opt_tmp_bind:
+        opt_scratch = state_dir.expanduser() / "opt-tmp"
+        opt_scratch.mkdir(parents=True, exist_ok=True)
+        flags += ["--bind", f"{opt_scratch}:/opt/tmp"]
+
+    # Skip the TMPDIR env if the operator already set it (any value).
+    if "TMPDIR" not in env:
+        flags += ["--env", "TMPDIR=/opt/tmp"]
+
+    return flags
+
+
+__all__ = [
+    "tmpfs_workdir_flags",
+    "opt_tmp_flags",
+    "parse_tmpfs_size_bytes",
+    "TmpfsSpaceError",
+]

--- a/tests/scitex_agent_container/runtimes/test__apptainer_runtime.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_runtime.py
@@ -223,6 +223,66 @@ def test_argv_emits_workdir_bind_mount(tmp_path: Path) -> None:
     assert any(b.endswith(":/work") and str(workdir) in b for b in binds)
 
 
+def test_argv_emits_opt_tmp_bind(tmp_path: Path) -> None:
+    # Arrange — #50 option 4 (lead a2a 7d14d69b): every agent gets
+    # /opt/tmp bound to a per-agent host scratch dir by default so
+    # ML workloads writing to $TMPDIR hit real disk, not the writable-
+    # tmpfs overlay. Verified live on clew capsule-0238624.
+    rt = ApptainerContainerRuntime()
+    state_dir = tmp_path / "state"
+    cfg = _config(tmp_path / "wd")
+    # Act
+    argv = rt.build_run_argv(cfg, state_dir=state_dir, sif_path=tmp_path / "x.sif")
+    # Assert
+    bind_idxs = [i for i, a in enumerate(argv) if a == "--bind"]
+    binds = [argv[i + 1] for i in bind_idxs]
+    assert any(b.endswith(":/opt/tmp") and str(state_dir) in b for b in binds), (
+        f"expected a bind to /opt/tmp under {state_dir}; binds={binds}"
+    )
+
+
+def test_argv_emits_tmpdir_env_pointing_at_opt_tmp(tmp_path: Path) -> None:
+    # Arrange — companion of the bind above: $TMPDIR must point at
+    # /opt/tmp so tempfile.gettempdir() lands there. Otherwise heavy
+    # ML caps (TF/Keras tokenizer caches) fall through to /tmp and
+    # we're back to the wedge.
+    rt = ApptainerContainerRuntime()
+    cfg = _config(tmp_path / "wd")
+    # Act
+    argv = rt.build_run_argv(
+        cfg, state_dir=tmp_path / "state", sif_path=tmp_path / "x.sif"
+    )
+    # Assert
+    env_idxs = [i for i, a in enumerate(argv) if a == "--env"]
+    env_pairs = [argv[i + 1] for i in env_idxs]
+    assert "TMPDIR=/opt/tmp" in env_pairs
+
+
+def test_argv_skips_opt_tmp_bind_when_operator_owns_it(tmp_path: Path) -> None:
+    # Arrange — operator already mapped a host dir to /opt/tmp via
+    # spec.apptainer.binds; sac must NOT add its own (apptainer rejects
+    # duplicate mounts at the same container path).
+    rt = ApptainerContainerRuntime()
+    cfg = _config(
+        tmp_path / "wd",
+        apptainer=ApptainerSpec(binds=["/host/scratch:/opt/tmp"]),
+    )
+    # Act
+    argv = rt.build_run_argv(
+        cfg, state_dir=tmp_path / "state", sif_path=tmp_path / "x.sif"
+    )
+    # Assert
+    bind_idxs = [i for i, a in enumerate(argv) if a == "--bind"]
+    binds = [argv[i + 1] for i in bind_idxs]
+    # Operator's bind appears
+    assert "/host/scratch:/opt/tmp" in binds
+    # sac's per-agent bind does NOT — count of /opt/tmp binds is 1
+    opt_tmp_binds = [b for b in binds if b.endswith(":/opt/tmp")]
+    assert len(opt_tmp_binds) == 1, (
+        f"expected exactly 1 /opt/tmp bind; got {opt_tmp_binds}"
+    )
+
+
 def test_argv_emits_state_dir_bind_mount(tmp_path: Path) -> None:
     # Arrange — state_dir is bound at /state/<name>, not /state.
     rt = ApptainerContainerRuntime()

--- a/tests/scitex_agent_container/runtimes/test__apptainer_tmpfs.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_tmpfs.py
@@ -1,4 +1,5 @@
-"""Tests for runtimes/_apptainer_tmpfs.py — sized /tmp scratch helper."""
+"""Tests for runtimes/_apptainer_tmpfs.py — sized /tmp scratch helper
++ /opt/tmp redirect helper (#50 option 4, lead a2a 7d14d69b)."""
 
 from __future__ import annotations
 
@@ -9,6 +10,7 @@ import pytest
 from scitex_agent_container.config._types import ApptainerSpec
 from scitex_agent_container.runtimes._apptainer_tmpfs import (
     TmpfsSpaceError,
+    opt_tmp_flags,
     parse_tmpfs_size_bytes,
     tmpfs_workdir_flags,
 )
@@ -150,3 +152,115 @@ def test_flags_propagates_parse_error_on_bad_size(tmp_path: Path) -> None:
     # Assert
     with ctx:
         tmpfs_workdir_flags(cfg, tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# opt_tmp_flags — #50 option 4 (lead a2a 7d14d69b, clew capsule-0238624)
+# ---------------------------------------------------------------------------
+
+
+def test_opt_tmp_flags_default_emits_bind_and_env(tmp_path: Path) -> None:
+    # Arrange — default ApptainerSpec; no operator override.
+    cfg = _Cfg(ApptainerSpec())
+    # Act
+    flags = opt_tmp_flags(cfg, tmp_path)
+    # Assert
+    assert flags == [
+        "--bind",
+        f"{tmp_path / 'opt-tmp'}:/opt/tmp",
+        "--env",
+        "TMPDIR=/opt/tmp",
+    ]
+
+
+def test_opt_tmp_flags_creates_scratch_dir(tmp_path: Path) -> None:
+    # Arrange
+    cfg = _Cfg(ApptainerSpec())
+    # Act
+    opt_tmp_flags(cfg, tmp_path)
+    # Assert
+    assert (tmp_path / "opt-tmp").is_dir()
+
+
+def test_opt_tmp_flags_empty_tmpfs_size_opts_out(tmp_path: Path) -> None:
+    # Arrange — tmpfs_size="" disables BOTH measures consistently.
+    cfg = _Cfg(ApptainerSpec(tmpfs_size=""))
+    # Act
+    flags = opt_tmp_flags(cfg, tmp_path)
+    # Assert
+    assert flags == []
+
+
+def test_opt_tmp_flags_no_apptainer_block_still_defaults(tmp_path: Path) -> None:
+    # Arrange — bare runtime: apptainer agent still gets the redirect.
+    cfg = _Cfg(None)
+    # Act
+    flags = opt_tmp_flags(cfg, tmp_path)
+    # Assert
+    assert flags == [
+        "--bind",
+        f"{tmp_path / 'opt-tmp'}:/opt/tmp",
+        "--env",
+        "TMPDIR=/opt/tmp",
+    ]
+
+
+def test_opt_tmp_flags_respects_operator_tmpdir_override(tmp_path: Path) -> None:
+    # Arrange — operator already set TMPDIR=/scratch/their-own; sac
+    # must NOT append its own --env TMPDIR=/opt/tmp on top.
+    cfg = _Cfg(ApptainerSpec(env={"TMPDIR": "/scratch/their-own"}))
+    # Act
+    flags = opt_tmp_flags(cfg, tmp_path)
+    # Assert
+    assert "--env" not in flags
+    assert "TMPDIR=/opt/tmp" not in flags
+
+
+def test_opt_tmp_flags_still_binds_when_operator_overrides_tmpdir(
+    tmp_path: Path,
+) -> None:
+    # Arrange — operator overrode TMPDIR but didn't bind /opt/tmp;
+    # the bind still emits so /opt/tmp is real-disk-backed even if
+    # nobody's writing there (cheap and harmless).
+    cfg = _Cfg(ApptainerSpec(env={"TMPDIR": "/scratch/their-own"}))
+    # Act
+    flags = opt_tmp_flags(cfg, tmp_path)
+    # Assert
+    assert flags == ["--bind", f"{tmp_path / 'opt-tmp'}:/opt/tmp"]
+
+
+def test_opt_tmp_flags_respects_operator_bind_to_opt_tmp(tmp_path: Path) -> None:
+    # Arrange — operator already bound /host/scratch to /opt/tmp; sac
+    # must NOT emit a duplicate bind (apptainer rejects duplicates).
+    cfg = _Cfg(ApptainerSpec(binds=["/host/scratch:/opt/tmp"]))
+    # Act
+    flags = opt_tmp_flags(cfg, tmp_path)
+    # Assert
+    assert "--bind" not in flags
+    # But TMPDIR injection still fires — the operator bound the path
+    # but didn't redirect TMPDIR there, so sac completes the contract.
+    assert flags == ["--env", "TMPDIR=/opt/tmp"]
+
+
+def test_opt_tmp_flags_respects_operator_bind_with_mode(tmp_path: Path) -> None:
+    # Arrange — operator's bind carries an explicit :rw mode suffix;
+    # sac must still recognise this as owning /opt/tmp.
+    cfg = _Cfg(ApptainerSpec(binds=["/host/scratch:/opt/tmp:rw"]))
+    # Act
+    flags = opt_tmp_flags(cfg, tmp_path)
+    # Assert
+    assert "--bind" not in flags
+
+
+def test_opt_tmp_flags_skips_both_when_both_overridden(tmp_path: Path) -> None:
+    # Arrange — full operator opt-out via env + bind.
+    cfg = _Cfg(
+        ApptainerSpec(
+            binds=["/host/scratch:/opt/tmp"],
+            env={"TMPDIR": "/scratch/their-own"},
+        )
+    )
+    # Act
+    flags = opt_tmp_flags(cfg, tmp_path)
+    # Assert
+    assert flags == []


### PR DESCRIPTION
## Summary

Closes operator-blocking bug #50 — capsule `/tmp` overflow under apptainer's `--writable-tmpfs --containall`, blocking proj-paper-scitex-clew cohort-A (stalled at 19/47 capsules) and downstream the operator's paper deliverable.

**Root cause:** heavy ML workloads (TF/Keras tokenizer caches, BERT preprocessing, multi-GB pickles) write via `tempfile.gettempdir()`, which honours `$TMPDIR` before falling through to `/tmp`. With `$TMPDIR` unset, those writes land on either the small writable-tmpfs overlay or the 64M `--containall` session tmpfs and the process stalls on ENOSPC.

**Fix (lead-decision Option 4, a2a `7d14d69b`):** auto-inject `TMPDIR=/opt/tmp` into the container env, and bind a per-agent host scratch dir at `/opt/tmp` inside the container so `$TMPDIR` writes hit real disk regardless of overlay choice. Proved live by proj-paper-scitex-clew on capsule-0238624 (`submission.json` produced T+7min after the override landed in their PR #112).

### Implementation

- **New helper** `opt_tmp_flags(config, state_dir)` in `runtimes/_apptainer_tmpfs.py` — emits `--bind <state_dir>/opt-tmp:/opt/tmp --env TMPDIR=/opt/tmp` under the default `ApptainerSpec`.
- **Wired** into `runtimes/_apptainer_runtime.build_run_argv` right after `tmpfs_workdir_flags` — the two defences compose (workdir relocates `/tmp` + `/var/tmp` to host disk; `opt_tmp` redirects `\$TMPDIR` to a separate per-agent bind).
- **Operator escape hatches** respected (never silently overridden):
  - `spec.apptainer.tmpfs_size=""` opts out of BOTH measures (consistent with existing `tmpfs_workdir_flags`)
  - `spec.apptainer.env.TMPDIR=<any>` skips the env injection
  - `spec.apptainer.binds=[<host>:/opt/tmp]` skips the bind (substring match handles plain + `:rw`/`:ro` mode suffix)
- **No new spec fields. No `.def` edits.** `tmpfs_size` default (`"2G"`) unchanged.

### Why Option 4 over the earlier Option 2 (bind /tmp:/tmp fallback)

Option 2 (`--bind /tmp:/tmp` when state_dir filesystem overflows) was rejected mid-flight by lead in favor of Option 4 because:
- No host-`/tmp` leak (per-agent scratch dir, not the host's global `/tmp`)
- Proved live in production by clew on capsule-0238624 (Option 2 was theoretical)
- Smaller surface (~30 LOC vs. ~50 LOC fallback logic)

## Test plan

- [x] 9 new unit tests on `opt_tmp_flags()` covering: default emission, scratch-dir creation, opt-out via `tmpfs_size=""`, no `apptainer` block, `TMPDIR` operator override (env-only skip + bind still emitted), bind operator override (bind-only skip + env still emitted, plain + `:rw` mode), combined opt-out
- [x] 3 new integration tests on `build_run_argv` asserting `--bind .../opt-tmp:/opt/tmp` + `--env TMPDIR=/opt/tmp` appear in the assembled argv plus the operator-owns-bind dedup
- [x] All 16 targeted tests green locally
- [x] Full suite green: 6506 passed / 28 skipped (excluding the pre-existing `tests/develop/test_audit.py::test_audit_all_clean` failure already being addressed by the in-flight `fix/audit-clean-on-develop` branch — NOT introduced by this PR)
- [ ] CI green
- [x] proj-paper-scitex-clew notified (a2a `94d8eb75`) — they will retire their `_emit.py` spec-side TMPDIR override once this lands

## Cross-references

- Issue #50
- Lead a2a `7d14d69b` (Option 4 confirmation)
- Lead a2a `0c4446c1` (Option 4 re-confirmation after crossed messages)
- proj-paper-scitex-clew a2a `d346a786` (production proof + capsule-0238624)
- proj-paper-scitex-clew PR #112 (their spec-side workaround — removable on merge)
- Investigation report at `.tmp-audit/issue-50-investigation.md`