### PR TITLE
fix(sif): split scitex-layer install so source tree is not shadowed by PyPI

### DIFF
--- a/src/scitex_agent_container/containers/apptainer-scitex.def
+++ b/src/scitex_agent_container/containers/apptainer-scitex.def
@@ -78,6 +78,36 @@ From: ./sac-base.sif
     # uv/pip failure. (Caught by clew's capsule-0220918 audit,
     # 2026-06-06; symmetric with the apt-side libglib2.0-0 add in
     # apptainer-base.def — both close silent-fallback paths.)
+    # Two-pass install — single-pass shipped pre-#41 (0.21.9) sac for
+    # every scitex-layer rebuild after the scitex PyPI cut.
+    #
+    # Why: ``scitex[all]`` has a transitive
+    # ``scitex-agent-container==0.21.9; extra == "all"`` (verified
+    # against PyPI metadata 2026-06-07). Resolved alongside the
+    # bundled local source ``/opt/scitex-agent-container-src`` in ONE
+    # ``uv pip install``, uv installs the PyPI 0.21.9 wheel for the
+    # transitive constraint, then sees the local source resolves to
+    # the SAME version (0.21.9; develop hasn't bumped) and SKIPS the
+    # re-install under its "version-already-satisfied" check. The SIF
+    # quietly ships pre-#41 sac despite the .def staging the .def-time
+    # source tree. Lead a2a ``f3f9bfa0`` + ``ce08f1d0`` (2026-06-07)
+    # caught this on the #41 deploy attempt — the rebuilt SIF didn't
+    # carry ``WakeableInbox`` even though the git pin was on develop HEAD.
+    #
+    # Fix: split into two install invocations.
+    #   step 1: scitex[all] + everything else (resolves the transitive
+    #     scitex-agent-container==0.21.9 from PyPI; that wheel is OK to
+    #     install — it'll get overwritten in step 2).
+    #   step 2: ``--force-reinstall --no-deps /opt/scitex-agent-container-src``
+    #     — force-reinstall because uv/pip's version-already-satisfied
+    #     check would otherwise skip; --no-deps because step 1 already
+    #     resolved every transitive, re-resolving here would thrash for
+    #     no gain.
+    #
+    # ``--reinstall-package scitex-agent-container`` is the uv-specific
+    # shorthand (narrower blast radius) and would also work; we use the
+    # portable ``--force-reinstall --no-deps`` form so the pip-fallback
+    # branch below uses the same flags.
     if command -v uv >/dev/null; then
         uv pip install --python /opt/venv-sac/bin/python \
             black flake8 \
@@ -85,7 +115,9 @@ From: ./sac-base.sif
             pytest pytest-cov \
             "claude-agent-sdk==0.2.87" \
             "scitex[all]" \
-            xarray \
+            xarray
+        uv pip install --python /opt/venv-sac/bin/python \
+            --force-reinstall --no-deps \
             /opt/scitex-agent-container-src
     else
         /opt/venv-sac/bin/pip install --no-cache-dir --upgrade \
@@ -96,7 +128,9 @@ From: ./sac-base.sif
             pytest pytest-cov \
             "claude-agent-sdk==0.2.87" \
             "scitex[all]" \
-            xarray \
+            xarray
+        /opt/venv-sac/bin/pip install --no-cache-dir \
+            --force-reinstall --no-deps \
             /opt/scitex-agent-container-src
     fi
 


### PR DESCRIPTION
## Summary

Closes the SILENT shadow that has been shipping pre-#41 (0.21.9) `scitex-agent-container` in EVERY `:scitex` SIF rebuild since `scitex`'s `agent-container` extra was published — surfaced today during the #41 (wake-on-inbound) deploy attempt when the rebuilt SIF didn't carry `WakeableInbox` despite the .def staging develop HEAD.

### Root cause

`apptainer-scitex.def` installs the bundled source tree `/opt/scitex-agent-container-src` alongside `scitex[all]` in ONE `uv pip install` invocation. PyPI metadata for `scitex==2.30.1` declares `scitex-agent-container==0.21.9` under the `[all]` extra. Verified 2026-06-07:

```
scitex-agent-container==0.21.9; extra == "agent-container"
scitex-agent-container==0.21.9; extra == "all"
scitex-agent-container==0.21.9; extra == "dev"
```

So uv resolves and installs the PyPI 0.21.9 wheel for the transitive constraint. When it then evaluates the local source's direct install, it sees the version resolves to `0.21.9` too (develop hasn't bumped) and **SKIPS the re-install** under its "version-already-satisfied" check. The SIF quietly ships pre-#41 sac despite the .def staging the .def-time source tree.

### Fix

Split the install into two passes:

1. `scitex[all]` + everything else (resolves the transitive `scitex-agent-container==0.21.9` from PyPI; that wheel is OK to install — it gets overwritten in pass 2)
2. `--force-reinstall --no-deps /opt/scitex-agent-container-src`. `--force-reinstall` because uv/pip's version-already-satisfied check otherwise skips; `--no-deps` because pass 1 already resolved every transitive — re-resolving would thrash for no gain.

Both `uv` and the `pip`-fallback branches updated symmetrically.

### Out of scope (intentional)

`apptainer-base.def` does NOT have this shadow — its install line is just `claude-agent-sdk==0.2.87 + /opt/scitex-agent-container-src` (no `scitex[all]`, so the transitive constraint never enters the resolve). No `base.def` change needed.

## Test plan

- [x] PyPI metadata for `scitex==2.30.1` inspected; confirmed `scitex-agent-container==0.21.9; extra == "all"` is present (the shadow source).
- [x] Lead reproduced the shadow on a live SIF rebuild (a2a `f3f9bfa0`): `apptainer exec sac-scitex.sif python3 -c "import scitex_agent_container._runners._session_inbox as m; print('WakeableInbox' in dir(m))"` → `False` despite git pin on `fdf38e3` (= origin/develop HEAD = #338 merge).
- [ ] Lead applies the same split to the live host `.def`, rebuilds, and verifies the import line above prints `True` (the deploy gate).
- [ ] CI green on this PR.

## Cross-references

- Lead a2a `f3f9bfa0` (deploy gate diagnostic)
- Lead a2a `ce08f1d0` (root-cause proof + fix shape)
- PR #338 (#41 wake-on-inbound — the runner change that surfaced this)