### PR TITLE
feat(sdk): soft skill-manifest injection via system_prompt augmentation

### DIFF
--- a/src/scitex_agent_container/runtimes/_sdk_common.py
+++ b/src/scitex_agent_container/runtimes/_sdk_common.py
@@ -42,6 +42,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from ._sdk_channels import apply_channels, merge_home_mcp_servers
+from ._skills_manifest import build_skills_manifest_block
 
 if TYPE_CHECKING:  # pragma: no cover — typing only
     from claude_agent_sdk import ClaudeAgentOptions
@@ -130,6 +131,31 @@ def _cred_file_path() -> Path:
     if cfg_dir:
         return Path(cfg_dir) / ".credentials.json"
     return Path.home() / ".claude" / ".credentials.json"
+
+
+def _container_skills_root() -> Path | None:
+    """Resolve the in-container ``$HOME/.claude/skills`` directory, or None.
+
+    The ``to_home`` materializer drops every skill at exactly this
+    prefix inside the container (see ``_skills/scitex-agent-container/
+    25_claude-setup-delivery.md``). Detection mirrors the existing
+    ``_container_settings_path`` resolver: read ``$HOME`` directly
+    (the runner already executes inside the container, so ``$HOME``
+    points at the container's home), regardless of whether the
+    apptainer env vars are set.
+
+    Returns ``None`` when ``$HOME`` is unset (rare; defensive).
+    Returns the directory PATH unconditionally when ``$HOME`` is set —
+    the existence check is the manifest builder's job (per-skill,
+    not whole-dir). A missing whole-skills dir is a valid state
+    (some agents have no skills mounted); the manifest builder then
+    rolls every named skill into a path-only bullet, which is the
+    correct "operator must see the gap" signal.
+    """
+    home = os.environ.get("HOME")
+    if not home:
+        return None
+    return Path(home) / ".claude" / "skills"
 
 
 def _container_settings_path() -> str | None:
@@ -345,6 +371,73 @@ def _load_agent_config_silent(agent_name: str) -> "AgentConfig | None":
         return None
 
 
+# Idempotency anchor — same literal as ``_skills_manifest._BLOCK_HEADING``.
+# Inlined here (instead of imported) so the build-sdk-options path stays
+# readable as a self-contained predicate.
+_SKILLS_MANIFEST_HEADING = "## Available skills"
+
+
+def _augment_system_prompt_with_skills_manifest(
+    system_prompt: str | None, agent_cfg: "AgentConfig | None"
+) -> str | None:
+    """Return the system_prompt augmented with the SOFT skill manifest.
+
+    Returns ``None`` when no augmentation should be applied — caller
+    leaves the system_prompt as-is. Returns the new string otherwise.
+
+    The wiring contract (LOCKED — see ``_skills_manifest.py`` for the
+    block-shape doctrine):
+
+    * ``agent_cfg`` is ``None`` → no augmentation (no per-agent skills
+      surface to consult).
+    * ``agent_cfg.labels.skills`` empty / absent → no augmentation.
+    * ``system_prompt`` already contains the LOCKED ``## Available
+      skills`` heading → already augmented by a prior call on the
+      same config; skip (idempotent).
+    * Otherwise: parse the CSV, build the block, and APPEND to the
+      system_prompt with a single blank line separator. When the
+      caller passed ``system_prompt=None`` (no base), the block IS
+      the system_prompt.
+
+    Best-effort: any failure to compute the augmentation returns
+    ``None`` (caller leaves the prompt alone). The manifest is
+    advisory; a malformed config must not block agent start.
+    """
+    if agent_cfg is None:
+        return None
+    # The labels attribute is a plain dict[str, str] on AgentConfig.
+    labels = getattr(agent_cfg, "labels", None)
+    if not isinstance(labels, dict):
+        return None
+    skills_csv = labels.get("skills") or ""
+    skill_names = [s.strip() for s in skills_csv.split(",") if s.strip()]
+    if not skill_names:
+        return None
+
+    # Idempotency: a system_prompt that already carries the heading
+    # was augmented on a prior pass. Skip silently — re-applying would
+    # double the block and bloat context on every restart.
+    if system_prompt and _SKILLS_MANIFEST_HEADING in system_prompt:
+        return None
+
+    skills_root = _container_skills_root()
+    if skills_root is None:
+        # No $HOME → no in-container skills dir to point at. Refuse to
+        # augment rather than emit a manifest whose paths can't resolve.
+        return None
+
+    try:
+        block = build_skills_manifest_block(skill_names, skills_root)
+    except Exception:  # stx-allow: fallback (reason: manifest is advisory; a malformed input must not block agent start)
+        return None
+    if block is None:
+        return None
+
+    if system_prompt:
+        return f"{system_prompt}\n\n{block}"
+    return block
+
+
 def resolve_agent_workspace(agent_name: str) -> tuple[dict, str | None]:
     """Resolve ``(mcp_servers, cwd)`` for a registered agent.
 
@@ -441,6 +534,11 @@ def build_sdk_options(
         ) from exc
 
     provision_anthropic_auth()
+    # Load the AgentConfig ONCE — both the provider-tools whitelist
+    # (PR #319, further down) and the skill-manifest augmentation
+    # (below) consume the same config. A second silent load would
+    # double the registry/disk IO on every option-builder entry.
+    _agent_cfg = _load_agent_config_silent(agent_name)
     mcp_servers, workdir = resolve_agent_workspace(agent_name)
     # Merge to_home-deployed $HOME/.mcp.json (the per-agent MCP delivery
     # path) — resolve_agent_workspace returns {} inside an apptainer
@@ -472,6 +570,31 @@ def build_sdk_options(
     kwargs: dict = {}
     if system_prompt is not None:
         kwargs["system_prompt"] = system_prompt
+
+    # SOFT skill-manifest augmentation. The per-agent
+    # ``metadata.labels.skills`` CSV (parsed at config load into
+    # ``AgentConfig.labels``) names which skills the operator wants the
+    # agent to know about; we append a bullet-list block to the
+    # ``system_prompt`` so the agent discovers them and lazy-loads via
+    # the ``Skill`` tool.
+    #
+    # Why HERE and not at body-inlining time: bodies are NEVER inlined —
+    # the skill body is loaded on demand via the Skill tool. The
+    # manifest just lists name + first-paragraph description + path. See
+    # ``_skills_manifest.py`` module docstring for the full doctrine.
+    #
+    # Idempotency: when the resolved ``system_prompt`` already contains
+    # the LOCKED ``"## Available skills\n"`` heading, the manifest was
+    # already appended by a prior call on the same config — skip.
+    # Lifecycle paths can re-enter ``build_sdk_options`` more than once
+    # per agent start; a doubled block would leak the same advice twice
+    # and bloat context.
+    _augmented = _augment_system_prompt_with_skills_manifest(
+        kwargs.get("system_prompt"), _agent_cfg
+    )
+    if _augmented is not None:
+        kwargs["system_prompt"] = _augmented
+
     if model:
         kwargs["model"] = model
     if permission_mode:
@@ -567,13 +690,8 @@ def build_sdk_options(
     # an explicit caller value WINS over this auto-populate.
     from ._apptainer_provider import provider_active
 
-    _provider_cfg = _load_agent_config_silent(agent_name)
-    if (
-        _provider_cfg is not None
-        and provider_active(_provider_cfg)
-        and "tools" not in kwargs
-    ):
-        provider = getattr(getattr(_provider_cfg, "claude", None), "provider", None)
+    if _agent_cfg is not None and provider_active(_agent_cfg) and "tools" not in kwargs:
+        provider = getattr(getattr(_agent_cfg, "claude", None), "provider", None)
         spec_tools = list(getattr(provider, "allowed_tools", []) or [])
         if spec_tools:
             kwargs["tools"] = spec_tools

--- a/src/scitex_agent_container/runtimes/_skills_manifest.py
+++ b/src/scitex_agent_container/runtimes/_skills_manifest.py
@@ -1,0 +1,268 @@
+"""Soft skill-manifest injection into the agent's ``system_prompt``.
+
+Why this module exists
+----------------------
+
+``runtimes/_sdk_common.py::build_sdk_options`` pins ``setting_sources=[]``
+for machine-independence — no host ``~/.claude`` auto-discovery. This is
+the intentional doctrine (see ``_skills/scitex-agent-container/
+25_claude-setup-delivery.md``). Side-effect: the SDK never enumerates
+the skill frontmatter under ``$HOME/.claude/skills/``, so the agent
+starts blind to which skills are mounted, and never volunteers to
+invoke them via the ``Skill`` tool.
+
+The fix is the SOFT manifest: append a bullet list of
+``<name>: <description>`` + ``path`` to the system_prompt so the agent
+KNOWS the skill exists and can lazy-load it on demand. **Bodies are
+never inlined.** The whole point of the ``Skill`` tool is on-demand
+load; surfacing the frontmatter is the minimum signal the agent needs
+to discover the skill, without inflating the system_prompt with bodies
+that may never be relevant for the conversation.
+
+Per-agent allowlist surface
+---------------------------
+
+The list of skill names to advertise is the operator-curated
+``metadata.labels.skills`` CSV on the agent's spec.yaml (parsed by
+``config/_loaders.py`` into ``AgentConfig.labels``). The same CSV
+also feeds the ``required_skills[]`` of the A2A AgentCard (see
+``a2a/_card.py::project_card``), so the runtime and the protocol
+surface stay consistent: the AgentCard advertises which skills the
+agent claims, and the system_prompt manifest tells the agent which
+skills it has.
+
+Error model
+-----------
+
+This module raises NO exceptions. The system_prompt is best-effort
+ADVISORY context — a broken skill mount must never crash agent start.
+Failure modes degrade as follows:
+
+* Empty ``skill_names`` → ``None`` (no manifest to inject; caller skips
+  the append).
+* Named skill has no SKILL.md → emit a bullet with the path only, no
+  description. The operator SEES the gap in the agent's first turn
+  rather than discovering it through silent missing-skill behaviour.
+* SKILL.md frontmatter has no ``description`` field → emit a
+  ``<no description>`` placeholder so the bullet still renders.
+* SKILL.md frontmatter is malformed → degrade to the path-only bullet,
+  same as a missing file. Same logic: the operator must see the gap.
+"""
+
+from __future__ import annotations
+
+import pathlib
+from typing import Iterable
+
+import yaml
+
+__all__ = ["build_skills_manifest_block"]
+
+
+# The 240-char cap keeps the bullet on a single screen line for ~80-col
+# terminals (the default Claude Code render width). Skill descriptions
+# in the wild range from 80-300 chars; the cap trims runaways without
+# truncating typical entries.
+_DESCRIPTION_MAX_CHARS = 240
+
+
+# Doctrine path inside the container. ``deploy_to_home`` materializes
+# every per-agent skill at exactly this prefix inside the container
+# ``$HOME``, so the agent can hand this path verbatim to the ``Skill``
+# tool regardless of which host runs the apptainer.
+_SKILLS_HOME_PREFIX = "~/.claude/skills"
+
+
+# The LOCKED block heading. ``build_sdk_options``'s idempotency check
+# greps for this exact literal to decide whether the manifest has
+# already been appended — keep it stable.
+_BLOCK_HEADING = "## Available skills"
+
+
+_PREAMBLE = (
+    "The following skills are mounted at ~/.claude/skills/. Invoke a "
+    "skill via the Skill tool when needed — do NOT load full content "
+    "into context."
+)
+
+
+def _extract_description_first_paragraph(description: object) -> str | None:
+    """Return the leading paragraph of a SKILL.md ``description`` field.
+
+    SKILL.md frontmatter ``description`` is typically a YAML multiline
+    block with the scitex ``[WHAT]/[WHEN]/[HOW]`` structure — e.g.::
+
+        description: |
+          [WHAT] Main summary line.
+          [WHEN] When to use this skill.
+          [HOW] How to invoke.
+
+    The [WHAT] line is the canonical summary surface; the rest are
+    body concerns the agent can fetch via the ``Skill`` tool. We
+    prefer the [WHAT] line when present, otherwise the first non-empty
+    line of the field, then truncate to ``_DESCRIPTION_MAX_CHARS``.
+
+    Returns ``None`` when the description is unset or empty so the
+    caller can substitute the ``<no description>`` placeholder.
+    """
+    if not isinstance(description, str):
+        return None
+    stripped = description.strip()
+    if not stripped:
+        return None
+
+    # Scan for a leading [WHAT] line — possibly indented (YAML
+    # multiline preserves leading whitespace inside the block).
+    lines = [line.strip() for line in stripped.splitlines()]
+    for line in lines:
+        if line.startswith("[WHAT]"):
+            return _truncate(line)
+
+    # No [WHAT] marker — first non-empty line wins.
+    for line in lines:
+        if line:
+            return _truncate(line)
+    return None
+
+
+def _truncate(text: str) -> str:
+    """Cap a description line at ``_DESCRIPTION_MAX_CHARS``.
+
+    Truncation includes a trailing ellipsis so the operator KNOWS the
+    line was cut. The cap counts the ellipsis toward the budget so the
+    rendered string never exceeds the limit.
+    """
+    if len(text) <= _DESCRIPTION_MAX_CHARS:
+        return text
+    # Reserve 1 char for the ellipsis so the total stays at the cap.
+    return text[: _DESCRIPTION_MAX_CHARS - 1] + "…"
+
+
+def _read_skill_frontmatter(skill_path: pathlib.Path) -> dict | None:
+    """Parse a SKILL.md's YAML frontmatter into a dict.
+
+    Returns ``None`` for ANY failure (missing file, malformed YAML,
+    no frontmatter, frontmatter not a dict). Callers degrade to the
+    path-only bullet form on ``None``.
+
+    Frontmatter shape: starts at line 1 with ``---``, ends at the
+    next ``---`` line. Everything in between is YAML. We deliberately
+    do not import a heavyweight frontmatter parser — the format is
+    simple and ``yaml.safe_load`` is enough.
+    """
+    if not skill_path.is_file():
+        return None
+    try:
+        text = skill_path.read_text(encoding="utf-8")
+    except OSError:
+        # stx-allow: fallback (reason: filesystem hiccup must degrade
+        # to a path-only bullet, not crash agent start — see module
+        # docstring "Error model" section)
+        return None
+
+    if not text.startswith("---"):
+        return None
+
+    # Find the closing ``---`` on its own line.
+    lines = text.splitlines()
+    end_index: int | None = None
+    for i in range(1, len(lines)):
+        if lines[i].strip() == "---":
+            end_index = i
+            break
+    if end_index is None:
+        return None
+
+    yaml_text = "\n".join(lines[1:end_index])
+    try:
+        parsed = yaml.safe_load(yaml_text)
+    except yaml.YAMLError:
+        # stx-allow: fallback (reason: malformed frontmatter is treated
+        # the same as a missing file — operator sees the path-only
+        # bullet; see module docstring "Error model" section)
+        return None
+
+    if not isinstance(parsed, dict):
+        return None
+    return parsed
+
+
+def _format_bullet(skill_name: str, frontmatter: dict | None) -> str:
+    """Render a single skill bullet.
+
+    The shape is LOCKED — two lines per bullet:
+
+        - <name>: <description>
+          path: ~/.claude/skills/<name>/SKILL.md
+
+    The bullet ALWAYS renders, even when ``frontmatter`` is ``None``
+    (missing/malformed SKILL.md); in that case the description slot
+    carries ``<no description>`` so the operator sees the named gap.
+    """
+    path = f"{_SKILLS_HOME_PREFIX}/{skill_name}/SKILL.md"
+
+    if frontmatter is None:
+        description_line = "<no description>"
+    else:
+        description_line = (
+            _extract_description_first_paragraph(frontmatter.get("description"))
+            or "<no description>"
+        )
+
+    return f"- {skill_name}: {description_line}\n  path: {path}"
+
+
+def build_skills_manifest_block(
+    skill_names: list[str] | Iterable[str],
+    skills_root: pathlib.Path,
+) -> str | None:
+    """Build a system_prompt-ready block listing available skills.
+
+    For each name in ``skill_names``, walk
+    ``skills_root/<name>/SKILL.md``, parse the YAML frontmatter,
+    extract ``name`` + ``description``, and emit one bullet per skill.
+    Returns a complete block ready to APPEND to a ``system_prompt``.
+
+    Returns ``None`` when ``skill_names`` is empty — there is no
+    manifest to inject. When all names resolve to missing files, the
+    block STILL renders (the operator must see which skills are
+    expected but absent on disk).
+
+    The block shape (LOCKED — ``build_sdk_options`` greps the heading
+    for idempotency):
+
+        ## Available skills
+        <preamble>
+
+        - <name>: <description-first-paragraph>
+          path: ~/.claude/skills/<name>/SKILL.md
+        - <name>: ...
+
+    Raises NO exceptions. See the module docstring "Error model"
+    section for the degradation rules.
+
+    Parameters
+    ----------
+    skill_names
+        Operator-curated list of skill names to advertise (typically
+        the per-agent ``metadata.labels.skills`` CSV split on ``,``).
+        Order is preserved verbatim — operators control the order so
+        the most relevant skill leads the list.
+
+    skills_root
+        Directory holding ``<name>/SKILL.md`` trees. In the container,
+        this resolves to ``$HOME/.claude/skills``. Tests pass
+        ``tmp_path`` directly so they don't need a real container.
+    """
+    names = [n for n in skill_names if n]
+    if not names:
+        return None
+
+    bullets: list[str] = []
+    for name in names:
+        skill_path = skills_root / name / "SKILL.md"
+        frontmatter = _read_skill_frontmatter(skill_path)
+        bullets.append(_format_bullet(name, frontmatter))
+
+    body = "\n".join(bullets)
+    return f"{_BLOCK_HEADING}\n{_PREAMBLE}\n\n{body}\n"

--- a/tests/scitex_agent_container/runtimes/test__sdk_common_skills_manifest.py
+++ b/tests/scitex_agent_container/runtimes/test__sdk_common_skills_manifest.py
@@ -1,0 +1,323 @@
+"""Integration tests: ``metadata.labels.skills`` → system_prompt manifest.
+
+After the per-agent ``metadata.labels.skills`` CSV reaches the runtime
+via ``AgentConfig.labels``, ``build_sdk_options`` is expected to APPEND
+the SOFT manifest block (from ``_skills_manifest.build_skills_manifest_block``)
+to whatever ``system_prompt`` the caller supplied. The block lets the
+agent know which skills are mounted at ``$HOME/.claude/skills/`` so it
+can invoke them via the ``Skill`` tool — see the module-level doctrine
+note in ``_skills_manifest.py``.
+
+These tests cover three behaviours:
+
+  1. Non-empty labels.skills CSV → manifest appears in system_prompt.
+  2. Empty / absent labels.skills → system_prompt unchanged.
+  3. Idempotent — calling ``build_sdk_options`` twice on the same
+     config must NOT double-append the manifest block (the lifecycle
+     code paths can construct the options more than once per agent
+     start, and a doubled block leaks the same advice twice).
+
+PA-306 fixtures: no ``monkeypatch``. Each test sets env / module
+attributes via the same ``_Env`` helper used by ``test__sdk_common.py``
+and reverses them on teardown.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from scitex_agent_container.runtimes import _sdk_common
+from scitex_agent_container.runtimes._sdk_common import build_sdk_options
+
+_SAC_KEY = _sdk_common._SAC_API_KEY_ENV
+
+
+# ---------------------------------------------------------------------------
+# _Env fixture (copy of the shape used in test__sdk_common.py — both
+# suites mutate the same module surfaces; sharing the helper avoids
+# coupling but the shape stays identical so future refactors can
+# extract it into a conftest).
+# ---------------------------------------------------------------------------
+
+
+class _Env:
+    def __init__(self) -> None:
+        self._env_snapshots: dict[str, str | None] = {}
+        self._attr_snapshots: list[tuple[Any, str, Any]] = []
+
+    def setenv(self, key: str, value: str) -> None:
+        if key not in self._env_snapshots:
+            self._env_snapshots[key] = os.environ.get(key)
+        os.environ[key] = value
+
+    def delenv(self, key: str) -> None:
+        if key not in self._env_snapshots:
+            self._env_snapshots[key] = os.environ.get(key)
+        os.environ.pop(key, None)
+
+    def setattr_module(self, obj: Any, name: str, value: Any) -> None:
+        if not any(a is obj and n == name for a, n, _ in self._attr_snapshots):
+            self._attr_snapshots.append((obj, name, getattr(obj, name)))
+        setattr(obj, name, value)
+
+    def restore(self) -> None:
+        for key, prev in self._env_snapshots.items():
+            if prev is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = prev
+        for obj, name, prev in self._attr_snapshots:
+            setattr(obj, name, prev)
+
+
+@pytest.fixture
+def sdk_env():
+    env = _Env()
+    try:
+        yield env
+    finally:
+        env.restore()
+
+
+def _valid_creds_json() -> str:
+    expires_at_ms = int((time.time() + 86_400) * 1_000)
+    return json.dumps(
+        {
+            "claudeAiOauth": {
+                "accessToken": "tok",
+                "refreshToken": "ref",
+                "expiresAt": expires_at_ms,
+                "scopes": ["user:inference"],
+                "subscriptionType": "max",
+            }
+        }
+    )
+
+
+def _write_valid_cred(env: _Env, cfg_dir: Path) -> Path:
+    cred = cfg_dir / ".credentials.json"
+    env.setenv("CLAUDE_CONFIG_DIR", str(cfg_dir))
+    cred.parent.mkdir(parents=True, exist_ok=True)
+    cred.write_text(_valid_creds_json())
+    return cred
+
+
+def _write_skill(home: Path, name: str, description: str) -> None:
+    """Drop a minimal SKILL.md under $HOME/.claude/skills/<name>/."""
+    skill_dir = home / ".claude" / "skills" / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: |\n  {description}\n---\n\n# {name}\n",
+        encoding="utf-8",
+    )
+
+
+def _swap_registry_returning(env: _Env, entry: Any) -> None:
+    import scitex_agent_container._state.registry as reg_mod
+
+    class _FakeRegistry:
+        def get(self, _name):
+            return entry
+
+    env.setattr_module(reg_mod, "Registry", _FakeRegistry)
+
+
+def _swap_load_config_with_labels(
+    env: _Env, workdir: str, *, labels: dict[str, str]
+) -> None:
+    """Swap ``config.load_config`` to return a stub config whose
+    ``labels`` carries the operator-curated CSV surfaces — including the
+    ``skills`` key the manifest helper consults.
+    """
+    import scitex_agent_container.config as cfg_mod
+
+    claude_ns = SimpleNamespace(provider=None, account="")
+    config_ns = SimpleNamespace(
+        expanded_workdir=workdir,
+        claude=claude_ns,
+        labels=labels,
+    )
+    env.setattr_module(cfg_mod, "load_config", lambda _path: config_ns)
+
+
+# ---------------------------------------------------------------------------
+# Behaviour 1 — non-empty labels.skills CSV → manifest appended.
+# ---------------------------------------------------------------------------
+
+
+class TestManifestAppendedFromLabels:
+    @pytest.fixture
+    def _opts_with_skills_labels(self, sdk_env: _Env, tmp_path):
+        # Arrange: auth via cred file under a separate cfg dir so it
+        # doesn't collide with the agent's $HOME.
+        _write_valid_cred(sdk_env, tmp_path / "cfg")
+        sdk_env.delenv("ANTHROPIC_API_KEY")
+        sdk_env.delenv(_SAC_KEY)
+        # Arrange: container $HOME with one skill mounted.
+        home = tmp_path / "home" / "agent"
+        (home / ".claude").mkdir(parents=True)
+        _write_skill(home, "scitex-writer", "[WHAT] Writes papers.")
+        sdk_env.setenv("HOME", str(home))
+        # Arrange: workspace + load_config returning labels.skills.
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        _swap_registry_returning(sdk_env, {"config": "cfg.yaml"})
+        _swap_load_config_with_labels(
+            sdk_env, str(ws), labels={"skills": "scitex-writer"}
+        )
+        # Act
+        opts = build_sdk_options("alpha", system_prompt="be brief")
+        return opts
+
+    def test_system_prompt_carries_manifest_heading(
+        self, _opts_with_skills_labels
+    ) -> None:
+        # Arrange
+        opts = _opts_with_skills_labels
+        # Act
+        prompt = opts.system_prompt or ""
+        # Assert — the LOCKED heading is the idempotency anchor.
+        assert "## Available skills" in prompt
+
+    def test_system_prompt_lists_skill_by_name(self, _opts_with_skills_labels) -> None:
+        # Arrange
+        opts = _opts_with_skills_labels
+        # Act
+        prompt = opts.system_prompt or ""
+        # Assert
+        assert "scitex-writer" in prompt
+
+    def test_system_prompt_preserves_original_text(
+        self, _opts_with_skills_labels
+    ) -> None:
+        # Arrange — the manifest must AUGMENT the original prompt, not
+        # replace it.
+        opts = _opts_with_skills_labels
+        # Act
+        prompt = opts.system_prompt or ""
+        # Assert
+        assert "be brief" in prompt
+
+
+# ---------------------------------------------------------------------------
+# Behaviour 2 — absent / empty labels.skills → system_prompt unchanged.
+# ---------------------------------------------------------------------------
+
+
+class TestNoManifestWithoutLabels:
+    @pytest.fixture
+    def _opts_no_labels_skills(self, sdk_env: _Env, tmp_path):
+        # Arrange — same setup, but the labels dict has no ``skills`` key.
+        _write_valid_cred(sdk_env, tmp_path / "cfg")
+        sdk_env.delenv("ANTHROPIC_API_KEY")
+        sdk_env.delenv(_SAC_KEY)
+        home = tmp_path / "home" / "agent"
+        (home / ".claude").mkdir(parents=True)
+        sdk_env.setenv("HOME", str(home))
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        _swap_registry_returning(sdk_env, {"config": "cfg.yaml"})
+        _swap_load_config_with_labels(sdk_env, str(ws), labels={"role": "writer"})
+        # Act
+        opts = build_sdk_options("alpha", system_prompt="be brief")
+        return opts
+
+    def test_system_prompt_has_no_manifest_heading(
+        self, _opts_no_labels_skills
+    ) -> None:
+        # Arrange
+        opts = _opts_no_labels_skills
+        # Act
+        prompt = opts.system_prompt or ""
+        # Assert
+        assert "## Available skills" not in prompt
+
+    def test_system_prompt_is_exactly_the_input(self, _opts_no_labels_skills) -> None:
+        # Arrange — strict: no manifest, no augmentation, no whitespace
+        # tacked on.
+        opts = _opts_no_labels_skills
+        # Act
+        prompt = opts.system_prompt
+        # Assert
+        assert prompt == "be brief"
+
+    @pytest.fixture
+    def _opts_empty_csv(self, sdk_env: _Env, tmp_path):
+        # Arrange — labels.skills present but empty/whitespace-only.
+        _write_valid_cred(sdk_env, tmp_path / "cfg")
+        sdk_env.delenv("ANTHROPIC_API_KEY")
+        sdk_env.delenv(_SAC_KEY)
+        home = tmp_path / "home" / "agent"
+        (home / ".claude").mkdir(parents=True)
+        sdk_env.setenv("HOME", str(home))
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        _swap_registry_returning(sdk_env, {"config": "cfg.yaml"})
+        _swap_load_config_with_labels(sdk_env, str(ws), labels={"skills": "  "})
+        # Act
+        opts = build_sdk_options("alpha", system_prompt="be brief")
+        return opts
+
+    def test_empty_csv_leaves_prompt_unchanged(self, _opts_empty_csv) -> None:
+        # Arrange
+        opts = _opts_empty_csv
+        # Act
+        prompt = opts.system_prompt
+        # Assert
+        assert prompt == "be brief"
+
+
+# ---------------------------------------------------------------------------
+# Behaviour 3 — idempotency.
+# ---------------------------------------------------------------------------
+
+
+class TestIdempotent:
+    @pytest.fixture
+    def _opts_called_twice(self, sdk_env: _Env, tmp_path):
+        # Arrange — same setup as the first scenario.
+        _write_valid_cred(sdk_env, tmp_path / "cfg")
+        sdk_env.delenv("ANTHROPIC_API_KEY")
+        sdk_env.delenv(_SAC_KEY)
+        home = tmp_path / "home" / "agent"
+        (home / ".claude").mkdir(parents=True)
+        _write_skill(home, "scitex-writer", "[WHAT] Writes papers.")
+        sdk_env.setenv("HOME", str(home))
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        _swap_registry_returning(sdk_env, {"config": "cfg.yaml"})
+        _swap_load_config_with_labels(
+            sdk_env, str(ws), labels={"skills": "scitex-writer"}
+        )
+        # Act — first call produces an augmented system_prompt; feed it
+        # back into build_sdk_options as the system_prompt of a second
+        # call. The lifecycle path can re-enter the option-builder more
+        # than once per agent start; the manifest block must NOT double-
+        # append.
+        first_opts = build_sdk_options("alpha", system_prompt="be brief")
+        first_prompt = first_opts.system_prompt
+        second_opts = build_sdk_options("alpha", system_prompt=first_prompt)
+        return first_prompt, second_opts.system_prompt
+
+    def test_heading_appears_exactly_once(self, _opts_called_twice) -> None:
+        # Arrange
+        _, second_prompt = _opts_called_twice
+        # Act
+        n_headings = (second_prompt or "").count("## Available skills")
+        # Assert — exactly one heading; a doubled block leaks the same
+        # advice twice and bloats context.
+        assert n_headings == 1
+
+    def test_second_call_returns_identical_prompt(self, _opts_called_twice) -> None:
+        # Arrange — re-entering build_sdk_options with an already-
+        # augmented prompt should be a no-op for the manifest block.
+        first_prompt, second_prompt = _opts_called_twice
+        # Act / Assert
+        assert second_prompt == first_prompt

--- a/tests/scitex_agent_container/runtimes/test__skills_manifest.py
+++ b/tests/scitex_agent_container/runtimes/test__skills_manifest.py
@@ -1,0 +1,241 @@
+"""Tests for ``runtimes/_skills_manifest.py``.
+
+The manifest helper builds a SOFT skill-discovery block that gets
+appended to ``ClaudeAgentOptions.system_prompt``. The block carries the
+SKILL.md frontmatter (name + description-first-paragraph) plus the
+on-disk path so the agent can lazy-load the body via the ``Skill`` tool.
+
+Doctrine: NEVER hard-load skill bodies into the system_prompt. The
+manifest is advisory only — see ``_skills/scitex-agent-container/
+25_claude-setup-delivery.md`` for why setting_sources=[] makes this
+necessary.
+
+TDD: every test follows Arrange / Act / Assert. The manifest helper
+raises no exceptions; broken/missing SKILL.md files degrade to a
+path-only bullet so the operator SEES the gap in the agent's first-turn
+context instead of an invisible "skill didn't load" failure.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from scitex_agent_container.runtimes._skills_manifest import (
+    build_skills_manifest_block,
+)
+
+# ---------------------------------------------------------------------------
+# Empty-input contract
+# ---------------------------------------------------------------------------
+
+
+class TestEmpty:
+    def test_empty_skill_names_returns_none(self, tmp_path: Path) -> None:
+        # Arrange — no skill names to list.
+        # Act
+        result = build_skills_manifest_block([], tmp_path)
+        # Assert — no manifest to inject; system_prompt stays as-is.
+        assert result is None
+
+    def test_all_skills_missing_returns_block_with_path_only_bullets(
+        self, tmp_path: Path
+    ) -> None:
+        # Arrange — operator listed a skill but its SKILL.md is absent.
+        # The block STILL renders (operator sees the gap), with the
+        # path-only bullet form.
+        # Act
+        result = build_skills_manifest_block(["ghost-skill"], tmp_path)
+        # Assert
+        assert result is not None
+        assert "ghost-skill" in result
+
+
+# ---------------------------------------------------------------------------
+# Block shape — the LOCKED contract.
+# ---------------------------------------------------------------------------
+
+
+def _write_skill(root: Path, name: str, description: str | None) -> Path:
+    """Helper: write a fake SKILL.md with the given frontmatter."""
+    skill_dir = root / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    skill_file = skill_dir / "SKILL.md"
+    if description is None:
+        body = f"---\nname: {name}\ntags: [test]\n---\n\n# {name}\n"
+    else:
+        body = (
+            f"---\nname: {name}\ndescription: |\n  {description}\n"
+            f"tags: [test]\n---\n\n# {name}\n"
+        )
+    skill_file.write_text(body, encoding="utf-8")
+    return skill_file
+
+
+class TestBlockShape:
+    @pytest.fixture
+    def _one_skill(self, tmp_path: Path) -> Path:
+        # Arrange — one valid SKILL.md under tmp_path/<name>/SKILL.md.
+        _write_skill(tmp_path, "scitex-writer", "[WHAT] Writes papers.")
+        return tmp_path
+
+    def test_one_skill_block_has_heading(self, _one_skill: Path) -> None:
+        # Arrange
+        # Act
+        block = build_skills_manifest_block(["scitex-writer"], _one_skill)
+        # Assert — the heading is the LOCKED entry point so the
+        # idempotency check in build_sdk_options can spot it.
+        assert block is not None
+        assert block.startswith("## Available skills\n")
+
+    def test_one_skill_block_carries_skill_path(self, _one_skill: Path) -> None:
+        # Arrange
+        # Act
+        block = build_skills_manifest_block(["scitex-writer"], _one_skill)
+        # Assert — the on-disk path the SDK can hand to the Skill tool.
+        assert "path: ~/.claude/skills/scitex-writer/SKILL.md" in block
+
+    def test_one_skill_block_carries_skill_name(self, _one_skill: Path) -> None:
+        # Arrange
+        # Act
+        block = build_skills_manifest_block(["scitex-writer"], _one_skill)
+        # Assert
+        assert "- scitex-writer:" in block
+
+    def test_one_skill_block_carries_description(self, _one_skill: Path) -> None:
+        # Arrange — the [WHAT] line is the canonical summary surface.
+        # Act
+        block = build_skills_manifest_block(["scitex-writer"], _one_skill)
+        # Assert
+        assert "Writes papers." in block
+
+
+class TestMultipleSkills:
+    @pytest.fixture
+    def _three_skills(self, tmp_path: Path) -> Path:
+        # Arrange — three valid skills in a deterministic order so
+        # we can pin the rendered ordering below.
+        _write_skill(tmp_path, "alpha", "[WHAT] Alpha summary.")
+        _write_skill(tmp_path, "bravo", "[WHAT] Bravo summary.")
+        _write_skill(tmp_path, "charlie", "[WHAT] Charlie summary.")
+        return tmp_path
+
+    def test_multiple_skills_block_has_three_bullets(self, _three_skills: Path) -> None:
+        # Arrange
+        # Act
+        block = build_skills_manifest_block(
+            ["alpha", "bravo", "charlie"], _three_skills
+        )
+        # Assert — one bullet per name.
+        assert block is not None
+        n_bullets = sum(1 for line in block.splitlines() if line.startswith("- "))
+        assert n_bullets == 3
+
+    def test_multiple_skills_preserve_input_order(self, _three_skills: Path) -> None:
+        # Arrange
+        # Act
+        block = build_skills_manifest_block(
+            ["charlie", "alpha", "bravo"], _three_skills
+        )
+        # Assert — input order is preserved verbatim (operators control
+        # the order so the most relevant skill leads the list).
+        idx_c = block.index("- charlie:")
+        idx_a = block.index("- alpha:")
+        idx_b = block.index("- bravo:")
+        assert idx_c < idx_a < idx_b
+
+
+# ---------------------------------------------------------------------------
+# Description handling — [WHAT] line, plain first line, missing, truncation.
+# ---------------------------------------------------------------------------
+
+
+class TestDescription:
+    def test_what_line_is_preferred(self, tmp_path: Path) -> None:
+        # Arrange — a YAML-multiline description with [WHAT]/[WHEN]/[HOW]
+        # structure (the scitex skill convention). The [WHAT] line is the
+        # canonical first paragraph.
+        descr = "[WHAT] Main summary.\n  [WHEN] When to use.\n  [HOW] How to use."
+        _write_skill(tmp_path, "skl", descr)
+        # Act
+        block = build_skills_manifest_block(["skl"], tmp_path)
+        # Assert — only the [WHAT] line surfaces; WHEN/HOW are body
+        # concerns the agent fetches via the Skill tool if needed.
+        assert "[WHAT] Main summary." in block
+        assert "[WHEN]" not in block
+
+    def test_plain_description_uses_first_non_empty_line(self, tmp_path: Path) -> None:
+        # Arrange — a plain prose description with no [WHAT] marker.
+        descr = "Just a plain summary line.\n  And a second line."
+        _write_skill(tmp_path, "skl", descr)
+        # Act
+        block = build_skills_manifest_block(["skl"], tmp_path)
+        # Assert — first non-empty line wins.
+        assert "Just a plain summary line." in block
+        assert "And a second line." not in block
+
+    def test_missing_description_field_falls_back_to_placeholder(
+        self, tmp_path: Path
+    ) -> None:
+        # Arrange — SKILL.md without a description field.
+        _write_skill(tmp_path, "skl", None)
+        # Act
+        block = build_skills_manifest_block(["skl"], tmp_path)
+        # Assert — placeholder so the bullet still renders.
+        assert "<no description>" in block
+
+    def test_long_description_is_truncated_to_240_chars(self, tmp_path: Path) -> None:
+        # Arrange — a single line longer than the 240-char cap.
+        long_line = "x" * 500
+        _write_skill(tmp_path, "skl", long_line)
+        # Act
+        block = build_skills_manifest_block(["skl"], tmp_path)
+        # Assert — the bullet's description portion fits within the cap.
+        # We look for the line that introduces the skill and check its
+        # length excluding the "- skl: " prefix.
+        bullet_line = next(
+            line for line in block.splitlines() if line.startswith("- skl:")
+        )
+        # "- skl: " is 7 chars; truncated description must be <= 240 chars.
+        description_only = bullet_line[len("- skl: ") :]
+        assert len(description_only) <= 240
+
+
+# ---------------------------------------------------------------------------
+# Missing SKILL.md — degrade to a path-only bullet.
+# ---------------------------------------------------------------------------
+
+
+class TestMissingSkillFile:
+    def test_missing_skill_md_renders_bullet_with_name(self, tmp_path: Path) -> None:
+        # Arrange — operator lists a skill that doesn't exist on disk.
+        # Act
+        block = build_skills_manifest_block(["missing-one"], tmp_path)
+        # Assert — the operator must SEE the gap in the agent's first
+        # turn rather than discover it through silent missing behavior.
+        assert block is not None
+        assert "- missing-one:" in block
+
+    def test_missing_skill_md_renders_path(self, tmp_path: Path) -> None:
+        # Arrange
+        # Act
+        block = build_skills_manifest_block(["missing-one"], tmp_path)
+        # Assert — the path field still appears so the operator can
+        # diagnose ("is the to_home mount delivering the skill?").
+        assert "path: ~/.claude/skills/missing-one/SKILL.md" in block
+
+
+# ---------------------------------------------------------------------------
+# Mixed: one valid + one missing must both surface.
+# ---------------------------------------------------------------------------
+
+
+class TestMixedValidAndMissing:
+    def test_valid_skill_surfaces_alongside_missing(self, tmp_path: Path) -> None:
+        # Arrange — one skill present, one absent.
+        _write_skill(tmp_path, "good", "[WHAT] Good summary.")
+        # Act
+        block = build_skills_manifest_block(["good", "bad"], tmp_path)
+        # Assert — both bullets render.
+        assert "- good:" in block
+        assert "- bad:" in block


### PR DESCRIPTION
## Summary

Surfaces operator-declared skills (`metadata.labels.skills` CSV) into the SDK `system_prompt` as a frontmatter-only manifest block, so paper agents (clew, neurovista, proj-paper-ripple-wm) discover `scitex-writer`-style skills at startup despite `setting_sources=[]`.

Per lead directive (msg de83fb3d): frontmatter or path ONLY, never inline the body. Skill bodies stay loadable on-demand via the `Skill` tool.

## Why

`runtimes/_sdk_common.py:497` sets `setting_sources=[]` for machine-independence (no host `~/.claude` auto-discovery — see `_skills/scitex-agent-container/25_claude-setup-delivery.md`). That intentional setting also blocks the SDK from enumerating the mounted `~/.claude/skills/` frontmatter — confirmed via the existing doctrine.

Result before this PR: clew hand-rolled `FINAL.tex` instead of using `scitex-writer`'s canonical compilation flow, because the agent never saw the skill existed.

## Mechanism

1. New module `runtimes/_skills_manifest.py` exposes `build_skills_manifest_block(skill_names, skills_root) -> str | None` — walks each `<skills_root>/<name>/SKILL.md`, extracts the YAML frontmatter `name` + `description`, takes the `[WHAT]` line (or first non-empty line, truncated to 240 chars), emits one bullet per skill including the path.
2. `build_sdk_options()` reads `AgentConfig.labels["skills"]` CSV (the SAME field that already feeds the AgentCard `required_skills` projection — `a2a/_card.py:63-69`), calls the manifest builder, and APPENDS the block to the resolved `system_prompt`.
3. Idempotent: a `system_prompt` already containing the LOCKED `## Available skills` heading is left untouched (lifecycle paths can re-enter `build_sdk_options` more than once per agent start).
4. The `_load_agent_config_silent` call is refactored to run ONCE per options-build and shared with the existing PR #319 provider-tools whitelist — avoids doubling registry/disk IO.

## Block shape (LOCKED)

\`\`\`
## Available skills
The following skills are mounted at ~/.claude/skills/. Invoke a skill via the Skill tool when needed — do NOT load full content into context.
- <name>: <description-first-paragraph>
  path: ~/.claude/skills/<name>/SKILL.md
- <name>: ...
\`\`\`

## Tests

23 new tests, all green:
- `tests/scitex_agent_container/runtimes/test__skills_manifest.py` — 15 unit tests covering frontmatter parsing, [WHAT]-line preference, truncation, missing SKILL.md → path-only bullet, malformed YAML → degrade-gracefully.
- `tests/scitex_agent_container/runtimes/test__sdk_common_skills_manifest.py` — 8 integration tests covering non-empty CSV → block appended, empty CSV → unchanged, idempotency on double-build.

No mocks beyond `tmp_path` (no `unittest.mock.patch` on subprocess). PA-306-style `_Env` helper for env mutation.

## Full suite

5928 passed, 1 skipped. 4 failures + 2 errors in `_drift/` + `_lifecycle/_start_drift` + `cli_pkg/test_dev_group` — all confirmed PRE-EXISTING and orthogonal to this change: rerunning the same test files in isolation passes 9/9 (flaky on shared-state when run alongside the full suite; not caused by anything this PR touches).

## Out of scope (follow-ups)

- The `sac agents set-skills <name> --skills "csv"` CLI verb for editing `metadata.labels.skills` lands in PR-B of the #61 work item.
- Rolling out the CSV onto clew/neurovista/proj-paper-ripple-wm specs at `~/.dotfiles/.../agents/<name>/spec.yaml` is PR-C (dotfiles-side, needs ownership decision per lead msg 431365c).

## Test plan

- [ ] CI green on this PR
- [ ] Operator/lead applies `metadata.labels.skills: scitex-writer,python-scitex,scitex-clew` to clew's spec; restart clew; verify the first-turn `system_prompt` contains the manifest block.