### PR TITLE
feat(spec): v4 spec.model.<label>.* schema + parser + validation (ADR-0018 PR A)

### DIFF
--- a/src/scitex_agent_container/config/__init__.py
+++ b/src/scitex_agent_container/config/__init__.py
@@ -16,8 +16,10 @@ from pathlib import Path
 
 import yaml
 
+from ._env_var_substitution import is_env_var_ref, resolve_env_var_ref
 from ._host import resolve_hostname, substitute_hostnames
 from ._loaders import compose_effective_name, load_v3
+from ._model_chain_types import ModelChain, ModelLabel
 from ._provider_types import ProviderSpec
 from ._proxy_types import ProxySpec
 from ._resolve import resolve_config
@@ -47,6 +49,8 @@ __all__ = [
     "HookSpec",
     "HostsSpec",
     "ListenPort",
+    "ModelChain",
+    "ModelLabel",
     "ProviderSpec",
     "ProxySpec",
     "RestartSpec",
@@ -55,6 +59,8 @@ __all__ = [
     "StartupCommand",
     "WatchdogSpec",
     "compose_effective_name",
+    "is_env_var_ref",
+    "resolve_env_var_ref",
     "load_config",
     "resolve_config",
     "resolve_hostname",

--- a/src/scitex_agent_container/config/_env_var_substitution.py
+++ b/src/scitex_agent_container/config/_env_var_substitution.py
@@ -1,0 +1,127 @@
+"""Tiny env-var-reference parser for ``spec.model.<label>.api_key``.
+
+ADR-0018 §"`api_key` field semantics" defines three accepted forms
+for ``spec.model.<label>.api_key``:
+
+1. ``$VAR`` or ``${VAR}`` — env-var reference. Resolved at agent
+   START to the host env var's value. Fail loud at start if the
+   env var is undefined.
+
+2. Literal value (``sk-ant-...``) — accepted but warned at start
+   ("secrets in spec.yaml is anti-pattern; spec.yaml syncs via
+   dotfiles git").
+
+3. Omitted (empty string) — falls back to the provider registry's
+   ``auth_token_env`` (the PR #244 mechanism).
+
+PR A (this module) only needs to RECOGNIZE the shape so the parser
+can store the raw value and the validator can warn on literal
+secrets. The actual env-var resolution at agent START lands in PR B
+(see ADR-0018 §"Implementation outline" — runtime fallback
+dispatcher). Splitting recognition out here keeps the parser pure
+(no env access at parse time, important when the validator runs on
+a different host than where the agent will eventually launch — env
+vars belong to the target host, not the controller).
+
+The format is intentionally a STRICT SUBSET of POSIX shell variable
+syntax: only ``$VAR`` and ``${VAR}`` with valid identifier characters
+are env refs. Numeric (``$1``), empty-braces (``${}``), bare ``$``,
+and any other shell-y form is treated as a LITERAL — operators who
+really want a literal that starts with ``$`` get the expected
+"this is a literal" semantics rather than a confusing parse error.
+
+A valid identifier follows the C / POSIX rule: starts with a letter
+or underscore, continues with letters / digits / underscores. We do
+NOT accept lowercase env names — convention across the fleet is
+ALL_CAPS env vars, and matching anything looser would shadow normal
+secret-looking literals (``$superkey``) into accidental env refs.
+"""
+
+from __future__ import annotations
+
+import re
+
+# POSIX-shell-conforming identifier (uppercase / underscore / digit,
+# starting with letter or underscore). Pinned uppercase-only because
+# every fleet env var the runtime reads (``ANTHROPIC_API_KEY``,
+# ``DEEPSEEK_API_KEY``, ``XIAOMI_API_KEY``, ``SAC_*``) is uppercase, and
+# the broader pattern would silently route a typo'd-lowercase literal
+# like ``$superkey`` through the env-var path → at-start KeyError on a
+# value the operator typed as a literal secret. Fail loud at validate
+# time on the misspelling instead.
+#
+# Operators who genuinely need a lowercase env var (vanishingly rare —
+# I cannot find one in the current fleet config) get a clear miss here
+# and can rename the env var to uppercase; that's a one-line workaround
+# for an edge case we explicitly do not want to expand the format to
+# cover.
+_ENV_NAME_RE = re.compile(r"^[A-Z_][A-Z0-9_]*$")
+
+
+def resolve_env_var_ref(raw: str) -> tuple[str, str | None]:
+    """Classify ``raw`` as an env-var reference, a literal, or empty.
+
+    Returns ``(kind, var_name)`` where:
+
+    * ``kind == "ref"`` — ``raw`` is ``$VAR`` or ``${VAR}`` and
+      ``VAR`` is a valid POSIX-style uppercase identifier. ``var_name``
+      is the bare identifier (no ``$`` / ``${}``). The CALLER (PR B
+      runtime, not this module) does the actual ``os.environ`` lookup
+      at agent START — splitting recognition from resolution lets the
+      controller host validate a spec without needing the target host's
+      env vars set.
+
+    * ``kind == "literal"`` — ``raw`` is a non-empty string that
+      isn't an env-ref. The PR B runtime emits a stderr warning at
+      start ("secrets in spec.yaml is anti-pattern; spec.yaml syncs
+      via dotfiles git") and uses ``raw`` verbatim as the API key.
+      ``var_name`` is ``None``.
+
+    * ``kind == "empty"`` — ``raw`` is the empty string (the parsed
+      sentinel for "field omitted"). The PR B runtime falls back to
+      the provider registry's ``auth_token_env``. ``var_name`` is
+      ``None``.
+
+    Edge cases (documented choices, NOT silently coerced):
+
+    * ``"$"`` alone — literal. There's no identifier to resolve.
+    * ``"${}"`` empty braces — literal. Same reason.
+    * ``"$1"`` numeric — literal. POSIX positional params don't
+      apply to env vars; treating this as a literal matches operator
+      intent (probably a copy-pasted token).
+    * ``"$lowercase"`` — literal. See module docstring on the
+      uppercase-only choice.
+    * ``"${MIXED_case}"`` — literal. Same reason.
+
+    Non-string input (None, int, ...) is treated as ``empty`` —
+    matches the parser's "stay non-raising; validator surfaces shape
+    errors" contract. The validator separately rejects non-string
+    ``api_key`` against the raw block.
+    """
+    if not isinstance(raw, str) or raw == "":
+        return ("empty", None)
+    if raw.startswith("${") and raw.endswith("}"):
+        inner = raw[2:-1]
+        if _ENV_NAME_RE.match(inner):
+            return ("ref", inner)
+        return ("literal", None)
+    if raw.startswith("$"):
+        inner = raw[1:]
+        if _ENV_NAME_RE.match(inner):
+            return ("ref", inner)
+        return ("literal", None)
+    return ("literal", None)
+
+
+def is_env_var_ref(raw: str) -> bool:
+    """Return ``True`` iff ``raw`` parses as an env-var reference.
+
+    Convenience wrapper around :func:`resolve_env_var_ref` for sites
+    that don't need the bare identifier — currently the validator's
+    "literal secret in spec.yaml" warning path.
+    """
+    kind, _ = resolve_env_var_ref(raw)
+    return kind == "ref"
+
+
+__all__ = ["resolve_env_var_ref", "is_env_var_ref"]

--- a/src/scitex_agent_container/config/_loaders.py
+++ b/src/scitex_agent_container/config/_loaders.py
@@ -21,6 +21,7 @@ from ._parsers import (
     parse_hosts_spec,
     parse_lineage,
     parse_listen,
+    parse_model_chain,
     parse_proxy,
     parse_restart,
     parse_skills,
@@ -241,6 +242,13 @@ def load_v3(raw: dict, path: Path) -> AgentConfig:
     # back-compat consumers and populated from the new homes.
     claude_spec = parse_claude(spec)
     apptainer_spec = parse_apptainer(spec)
+    # ADR-0018 v4 cascade chain. PR A scope: parser produces the chain
+    # (v4 ``spec.model`` or v3 ``spec.claude.*`` aliased to a single
+    # ``legacy`` label). Runtime continues reading ``claude_spec`` for
+    # the moment; the chain rides on AgentConfig for the PR B/C/D
+    # follow-ups to consume. See ``config/_parsers/_model_chain.py``
+    # for the parse rules and the one-shot deprecation warning behavior.
+    model_chain_spec = parse_model_chain(spec, agent_name=name)
     model = claude_spec.model or "sonnet"
     display_model = MODEL_DISPLAY_NAMES.get(model, model)
     auto_env["SCITEX_AGENT_CONTAINER_MODEL"] = display_model
@@ -303,6 +311,7 @@ def load_v3(raw: dict, path: Path) -> AgentConfig:
         labels=labels,
         container=parse_container(spec),
         claude=claude_spec,
+        model_chain=model_chain_spec,
         health=parse_health(spec),
         watchdog=parse_watchdog(spec),
         restart=parse_restart(spec),

--- a/src/scitex_agent_container/config/_model_chain_types.py
+++ b/src/scitex_agent_container/config/_model_chain_types.py
@@ -1,0 +1,156 @@
+"""ModelLabel / ModelChain dataclasses for ``spec.model.<label>.*`` (ADR-0018 v4).
+
+ADR-0018 (operator-co-designed 2026-05-28→29 via Telegram msgs
+6816-6831) replaces the Anthropic-centric ``spec.claude.*`` shape
+(PR #244, ADR-0011, ADR-0016) with a label-keyed dict where each label
+declares a COMPLETE provider config, and the dict's insertion order
+IS the implicit fallback cascade order. See
+``/work/.tmp-adr/ADR-0018.md`` for the full motivation.
+
+This module owns the parsed in-memory shape. It is intentionally tiny
+and side-effect-free so it can be imported from both parser and
+validator without a circular dependency on
+:mod:`config._provider_registry` (registry resolution stays in the
+validator). The dataclass mirrors :mod:`config._provider_types`'s tone
+on purpose — operators read both side-by-side.
+
+Lives in its own module to keep ``_types.py`` under the project's
+512-line cap (mirrors ``_proxy_types.py`` /
+``_provider_types.py``). Re-exported from
+:mod:`scitex_agent_container.config` alongside the rest of the spec
+dataclasses.
+
+PR A scope (this file): schema-only — no runtime fallback dispatch.
+The runtime continues to read ``spec.claude.*`` via the v3-to-v4 alias
+populated in :mod:`config._parsers._model_chain`. Runtime fallback
+dispatch lands in PR B (ADR-0018 §"Implementation outline").
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ModelLabel:
+    """Parsed shape of one ``spec.model.<label>.*`` entry (ADR-0018 v4).
+
+    Each label is a COMPLETE provider configuration — provider name,
+    model id, and exactly one auth surface (Anthropic OAuth ``account``
+    XOR generic ``api_key``). The label key (the dict key under
+    ``spec.model``) is operator-chosen — semantic (``primary`` /
+    ``backup-xiaomi``) or neutral (``label-1`` / ``label-2``) both
+    fine; ``<label-N>`` is the canonical example form for
+    documentation. The label key is NOT stored on the instance because
+    it IS the dict key of the surrounding :data:`ModelChain` mapping;
+    keeping it implicit avoids the dict-key-vs-attribute drift bug
+    class.
+
+    Field semantics (per ADR-0018 §"Key naming"):
+
+    * :attr:`provider` — REQUIRED. Registered provider name in
+      :data:`config._provider_registry.PROVIDERS` (the existing PR
+      #244 registry). Unknown names surface a loud validator error
+      with the known-providers list. PR A does NOT extend the
+      registry.
+
+    * :attr:`model_id` — REQUIRED. Non-empty string. Renamed from
+      ``model`` (v3 spec.claude.model) so the field name doesn't
+      collide with the outer ``spec.model`` dict key. The provider
+      decides the accepted form (``claude-sonnet-4-6`` for
+      Anthropic, ``mimo-v2.5-pro`` for Xiaomi, etc.); v4 does NOT
+      apply the v3 ``claude-*`` regex here.
+
+    * :attr:`account` — OPTIONAL. Used only for Anthropic-OAuth
+      providers (operator's stored Max account selector — see
+      :class:`config._types.ClaudeSpec.account` for the snapshot
+      semantics). For non-Anthropic providers, declaring it is a
+      validation WARNING (not a hard error — operators may copy-paste
+      labels and forget to remove the Anthropic-only field).
+      Empty-string default means "use the host's live OAuth file".
+
+    * :attr:`api_key` — OPTIONAL. Stores the RAW value (env-ref or
+      literal) as authored in spec.yaml. Three accepted forms (see
+      :mod:`config._env_var_substitution` for parsing semantics):
+
+        1. ``$VAR`` or ``${VAR}`` — env-var reference, resolved at
+           agent START (PR B). PR A only recognizes the shape; the
+           validator does NOT resolve the env var because the spec
+           may be loaded on a different host than where the agent
+           will run.
+
+        2. Literal string (``sk-ant-...``) — accepted but emits a
+           stderr warning at start: "secrets in spec.yaml is
+           anti-pattern; spec.yaml syncs via dotfiles git". PR A
+           surfaces this warning at VALIDATE time as a non-fatal
+           hint string.
+
+        3. Omitted (empty string default) — falls back to the
+           provider registry's ``auth_token_env`` (the existing
+           PR #244 mechanism). Most agents use this path.
+
+      :attr:`api_key` and :attr:`account` are MUTUALLY EXCLUSIVE
+      within a single label — an API-key backend needs no OAuth, and
+      declaring both forces the runtime to guess which auth path
+      wins. The validator rejects this combination with a clear
+      message naming the offending label.
+
+    Frozen on purpose: a parsed label is the operator's declared
+    intent; mutating it post-parse is always a code smell (the
+    runtime should rebuild the chain rather than patch a label
+    in-place). Hashable via the frozen contract so labels can sit in
+    sets when the dispatcher (PR B) tracks ``disabled-this-session``
+    state.
+    """
+
+    provider: str = ""
+    """Registered provider name (see
+    :mod:`config._provider_registry`). Empty string is the parsed
+    sentinel for "field missing"; the validator surfaces the loud
+    "required field" error against the raw block — the parser stays
+    non-raising so a partially malformed spec still produces an
+    inspectable shape."""
+
+    model_id: str = ""
+    """Provider-specific model identifier. Empty string is the parsed
+    sentinel for "field missing"; the validator surfaces the loud
+    "required field" error against the raw block."""
+
+    account: str = ""
+    """Saved-account name (Anthropic Max OAuth selector) — same
+    semantics as :class:`config._types.ClaudeSpec.account`. Empty =
+    no OAuth pin. Mutually exclusive with :attr:`api_key`."""
+
+    api_key: str = ""
+    """RAW api-key value as authored in spec.yaml — env-var reference
+    (``$VAR`` / ``${VAR}``) or literal. Empty = fall back to the
+    provider registry's ``auth_token_env``. Mutually exclusive with
+    :attr:`account`. PR A does NOT resolve env-var references; PR B
+    does the at-start resolution + the literal-string stderr warning."""
+
+
+# A ``ModelChain`` is just the parsed mapping ``label -> ModelLabel``.
+# Insertion order IS the fallback cascade order — this is the only
+# meaningful semantic this alias carries beyond ``dict[str, ModelLabel]``.
+# Python dicts preserve insertion order since 3.7, and PyYAML's
+# ``SafeLoader`` builds mappings in source order; parser callers MUST
+# preserve that order on the way through (no sort, no re-key).
+#
+# Spelled as a ``type`` alias rather than ``TypeAlias`` to keep this
+# module import-cycle-free with the runtime typing stack — none of
+# the call sites (parser, validator, AgentConfig) need the runtime
+# alias type; they all just declare ``dict[str, ModelLabel]`` in their
+# annotations. The alias exists for documentation / re-export from
+# :mod:`scitex_agent_container.config`.
+ModelChain = dict[str, ModelLabel]
+"""Parsed ``spec.model`` block: ``label-name -> ModelLabel``.
+
+The mapping's insertion order IS the fallback cascade order (ADR-0018
+§"Target shape"). Callers that iterate the chain (PR B dispatcher) MUST
+iterate via ``chain.items()`` to honor that order; do NOT sort the
+keys. Empty dict means "no v4 model chain configured" — the loader
+falls back to the v3 ``spec.claude.*`` shape via the parser's v3-alias
+path (see :mod:`config._parsers._model_chain`)."""
+
+
+__all__ = ["ModelLabel", "ModelChain"]

--- a/src/scitex_agent_container/config/_model_chain_validation.py
+++ b/src/scitex_agent_container/config/_model_chain_validation.py
@@ -1,0 +1,199 @@
+"""Validation for ``spec.model.<label>.*`` (ADR-0018 v4 PR A).
+
+Single entry point: :func:`validate_model_chain`. Returns a list of
+human-readable error strings (empty list = clean). Mirrors
+:mod:`config._provider_validation`'s shape so the top-level
+:mod:`config._validation` can extend its existing error list with our
+output.
+
+Error strings are operator-targeted: every error names the offending
+label, the offending field, and (when applicable) the closed set of
+valid values. The known-providers list is emitted via
+:func:`config._provider_registry.list_providers` so the diagnostic
+stays in sync with whatever entries the registry actually carries.
+
+Field semantics enforced (per ADR-0018 §"Key naming"):
+
+* ``provider`` REQUIRED, non-empty string, must resolve via
+  :mod:`_provider_registry`.
+* ``model_id`` REQUIRED, non-empty string.
+* ``account`` and ``api_key`` MUTUALLY EXCLUSIVE within a single
+  label.
+* ``account`` declared on a NON-Anthropic provider → soft warning
+  (operator may have copy-pasted from a v3 spec; not a hard fail).
+* ``api_key`` literal (not a ``$VAR`` / ``${VAR}`` ref) → soft
+  warning ("secrets in spec.yaml is anti-pattern").
+
+PR A does NOT resolve env-var references; the parsed value is the
+RAW string. PR B does the at-start resolution. Splitting recognition
+out keeps the validator host-independent (the controller validates
+specs that will run on remote hosts whose env vars it cannot read).
+
+The "is this an Anthropic provider" check is recovered from the
+registry: a registered entry with ``auth_token_env == None`` is the
+"default Anthropic OAuth backend" sentinel. Any other entry is a
+non-Anthropic provider that uses an API key, not OAuth. We do NOT
+hard-code "anthropic" in name comparisons — the registry IS the
+truth.
+"""
+
+from __future__ import annotations
+
+from ._env_var_substitution import is_env_var_ref
+from ._provider_registry import list_providers, resolve_provider
+
+
+def _provider_uses_oauth(provider_name: str) -> bool:
+    """Return ``True`` when ``provider_name`` is the Anthropic-OAuth shape.
+
+    Recovered from the registry: an entry with ``auth_token_env ==
+    None`` (the "default Anthropic OAuth backend" sentinel)
+    represents the OAuth-based Anthropic provider. Every other
+    registered entry has an ``auth_token_env`` and uses an API key.
+
+    Unknown provider names return ``False`` — the validator already
+    surfaces an "unknown provider" error on the same label, and we
+    do not want to ALSO claim the unknown name "may have copy-paste
+    issues" (would distract from the actionable error).
+    """
+    entry = resolve_provider(provider_name)
+    if entry is None:
+        return False
+    return entry.get("auth_token_env") is None
+
+
+def _validate_label(
+    label_name: str, label_entry: object, *, agent_name: str | None
+) -> list[str]:
+    """Validate one ``spec.model.<label>`` entry. Returns error strings.
+
+    Per-label errors are prefixed with ``spec.model.<label>.<field>``
+    so the operator sees exactly which line of yaml to fix.
+    """
+    errors: list[str] = []
+    if not isinstance(label_entry, dict):
+        errors.append(
+            f"spec.model.{label_name} must be a mapping with provider/model_id/"
+            f"(account|api_key) keys; got {type(label_entry).__name__}"
+        )
+        return errors
+
+    provider = label_entry.get("provider")
+    if not isinstance(provider, str) or not provider:
+        errors.append(
+            f"spec.model.{label_name}.provider is required and must be a "
+            "non-empty string naming a registered provider "
+            f"(known: {', '.join(list_providers())})."
+        )
+    else:
+        if resolve_provider(provider) is None:
+            errors.append(
+                f"spec.model.{label_name}.provider='{provider}' is not a "
+                f"registered provider name. Known providers: "
+                f"{', '.join(list_providers())}. To add a new backend, "
+                "append it to PROVIDERS in "
+                "scitex_agent_container/config/_provider_registry.py."
+            )
+
+    model_id = label_entry.get("model_id")
+    if not isinstance(model_id, str) or not model_id:
+        errors.append(
+            f"spec.model.{label_name}.model_id is required and must be a "
+            "non-empty string (provider-specific model identifier — "
+            "e.g. 'claude-sonnet-4-6' for Anthropic, 'mimo-v2.5-pro' "
+            "for Xiaomi)."
+        )
+
+    account_val = label_entry.get("account")
+    api_key_val = label_entry.get("api_key")
+    has_account = isinstance(account_val, str) and account_val
+    has_api_key = isinstance(api_key_val, str) and api_key_val
+
+    if has_account and has_api_key:
+        errors.append(
+            f"spec.model.{label_name}.account and "
+            f"spec.model.{label_name}.api_key are mutually exclusive — "
+            "an API-key backend needs no OAuth, and an OAuth backend uses "
+            "stored credentials, not a key. Set exactly one."
+        )
+
+    # Soft warnings — non-fatal but surfaced. Prefixed with [warn] so a
+    # caller can split them out from the fatal errors. PR A's validator
+    # caller (top-level `_validation.validate_raw`) treats every entry
+    # as an error; the [warn] prefix preserves the signal for the
+    # follow-up split (PR B / PR C observability).
+    if has_account and isinstance(provider, str) and provider:
+        if not _provider_uses_oauth(provider):
+            errors.append(
+                f"[warn] spec.model.{label_name}.account is set on a "
+                f"non-Anthropic provider ('{provider}'); the account "
+                "field selects an Anthropic OAuth Max account and has no "
+                "effect for API-key backends. Remove the field or move "
+                "to api_key."
+            )
+
+    if has_api_key and not is_env_var_ref(str(api_key_val)):
+        errors.append(
+            f"[warn] spec.model.{label_name}.api_key is a literal value; "
+            "secrets in spec.yaml is anti-pattern (spec.yaml syncs via "
+            "dotfiles git). Use the $VAR or ${VAR} form to reference an "
+            "env var instead."
+        )
+
+    return errors
+
+
+def validate_model_chain(
+    model_block: object,
+    *,
+    agent_name: str | None = None,
+) -> list[str]:
+    """Validate the raw ``spec.model`` block. Returns error strings.
+
+    ``model_block`` is the raw yaml value (``spec.get("model")``) —
+    not the parsed :class:`ModelChain`. We validate against the raw
+    block so the parser can stay non-raising; the validator is the
+    single source of "this spec is wrong" diagnostics.
+
+    ``None`` / absent (key not in spec) → empty list. v4 is OPTIONAL
+    if the v3 ``spec.claude.*`` alias provides the chain — the
+    top-level :mod:`_validation` enforces the "at least one chain
+    source" rule across both keys.
+
+    Empty dict ``{}`` → error. An explicit empty block is operator
+    intent that we cannot interpret; better to surface "declare at
+    least one label" loudly than silently fall back.
+
+    Non-dict → error naming the type.
+
+    ``agent_name`` is currently unused (no per-agent error
+    customization yet) — kept in the signature for symmetry with
+    :func:`config._parsers._model_chain.parse_model_chain` and to
+    enable future per-agent warnings (PR B / PR C).
+    """
+    if model_block is None:
+        return []
+
+    if not isinstance(model_block, dict):
+        return [
+            "spec.model must be a dict of label → config (label name = "
+            "operator-chosen string; config = {provider, model_id, "
+            f"account|api_key}}); got {type(model_block).__name__}"
+        ]
+
+    if not model_block:
+        return [
+            "spec.model is empty; declare at least one label entry. "
+            "Even single-config specs require a label "
+            "(e.g. 'default:'). See ADR-0018 §'Single-config case'."
+        ]
+
+    errors: list[str] = []
+    for label_name, label_entry in model_block.items():
+        errors.extend(
+            _validate_label(str(label_name), label_entry, agent_name=agent_name)
+        )
+    return errors
+
+
+__all__ = ["validate_model_chain"]

--- a/src/scitex_agent_container/config/_parsers/__init__.py
+++ b/src/scitex_agent_container/config/_parsers/__init__.py
@@ -28,6 +28,7 @@ from ._hooks import parse_hooks
 from ._hosts import _VALID_SCHEDULING_MODES, parse_hosts_spec, parse_scheduling
 from ._listen import parse_listen
 from ._mcp import interpolate_mcp_servers
+from ._model_chain import parse_model_chain
 from ._proxy import parse_proxy
 from ._restart import parse_restart
 from ._skills import parse_skills
@@ -53,6 +54,7 @@ __all__ = [
     "parse_hosts_spec",
     "parse_lineage",
     "parse_listen",
+    "parse_model_chain",
     "parse_proxy",
     "parse_restart",
     "parse_scheduling",

--- a/src/scitex_agent_container/config/_parsers/_model_chain.py
+++ b/src/scitex_agent_container/config/_parsers/_model_chain.py
@@ -1,0 +1,244 @@
+"""Parser for ``spec.model.<label>.*`` and the v3 ``spec.claude.*`` alias.
+
+ADR-0018 (operator-co-designed 2026-05-28→29 via Telegram msgs
+6816-6831) replaces the Anthropic-centric ``spec.claude.*`` shape
+with a label-keyed dict where each label is a complete provider
+config, and the dict's insertion order IS the implicit fallback
+cascade order. See ``/work/.tmp-adr/ADR-0018.md`` for the full
+motivation.
+
+This parser:
+
+* Reads ``spec.model`` (a dict of label → entry) into a
+  :class:`config._model_chain_types.ModelChain` preserving operator
+  insertion order (= fallback cascade order). Python dicts preserve
+  insertion order since 3.7 and PyYAML's ``SafeLoader`` builds
+  mappings in source order, so the contract is honored end-to-end
+  with no sort or re-key on this side.
+
+* When ``spec.model`` is absent AND ``spec.claude`` is present,
+  rewrites the v3 block into a single-label chain under the key
+  ``"legacy"`` so the runtime keeps reading a usable shape during
+  the v3→v4 transition. Emits a one-time stderr deprecation warning
+  per agent at parse time.
+
+* When BOTH ``spec.model`` and ``spec.claude`` are present, returns
+  an empty chain — the validator (``_model_chain_validation``)
+  surfaces the loud mutual-exclusion error against the raw block.
+  Returning empty here keeps the parser non-raising; we do not want
+  one operator typo to crash the controller before the validator
+  even sees the spec.
+
+The parser is intentionally NON-RAISING for shape errors; the
+validator is the single source of "this spec is wrong" diagnostics.
+This mirrors :mod:`config._parsers._claude` which silently returns a
+``None`` provider for shape errors and lets ``_provider_validation``
+emit the named error.
+
+PR A scope: v3 alias path covers the registered-name and bare-string
+``spec.claude.provider`` shapes only. The custom-endpoint dict shape
+(``{base_url, auth_token_env}``) and the legacy dict shape DO NOT map
+cleanly to a single label (the registry-name → backend-metadata
+mapping is one-way; reversing it from a custom ``base_url`` would
+require a registry round-trip the operator should make explicit).
+For those shapes, the alias produces ``provider=""`` so the validator
+surfaces a "migrate directly to v4" error pointing at ADR-0018.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from .._model_chain_types import ModelChain, ModelLabel
+from .._provider_registry import resolve_provider
+
+# One-shot stderr deprecation warning tracker (module-level set).
+# Keyed by agent name (None when the loader didn't pass a name in,
+# which only happens in direct-parser unit tests). Operators see
+# ONE warning per agent per controller process — repeated parses of
+# the same spec (e.g. during a config reload) don't re-spam.
+#
+# Mirrors the "warn once per agent" pattern future modules will adopt;
+# kept private so test suites can clear it via the helper below when
+# they need to assert the warning fires.
+_LEGACY_WARN_EMITTED: set[str | None] = set()
+
+
+def _emit_v3_alias_warn_once(agent_name: str | None) -> None:
+    """Print the v3 alias deprecation warning to stderr at most once.
+
+    Guarded by :data:`_LEGACY_WARN_EMITTED`. Called from the v3→v4
+    alias path only — a pure v4 spec is silent at parse time.
+
+    Why stderr instead of ``warnings.warn``: operator runs
+    ``sac agent list`` / ``sac agent restart`` interactively, and a
+    Python warning would get filtered by their shell or routed to a
+    log file they don't tail. Stderr is the channel they see.
+
+    Why one-shot per agent: repeated parses (config reload, dry-run
+    + start) would otherwise produce a stutter of identical lines;
+    operators ignore stutter, defeating the deprecation push.
+    """
+    if agent_name in _LEGACY_WARN_EMITTED:
+        return
+    _LEGACY_WARN_EMITTED.add(agent_name)
+    label = agent_name or "<unnamed>"
+    sys.stderr.write(
+        f"[sac:deprecation] agent '{label}': spec.claude.* is deprecated "
+        "— migrate to spec.model.<label>.* (see ADR-0018). v3 specs "
+        "continue to load via the spec.model.legacy alias for now.\n"
+    )
+    sys.stderr.flush()
+
+
+def _reset_v3_alias_warn_tracker_for_tests() -> None:
+    """Test-only helper to clear :data:`_LEGACY_WARN_EMITTED`.
+
+    Exposed so per-test ``capsys`` fixtures observe the warning
+    consistently regardless of preceding tests in the session. NOT
+    part of the public API; callers outside the test suite should
+    never need to reset this.
+    """
+    _LEGACY_WARN_EMITTED.clear()
+
+
+def _v3_to_v4_alias(claude_block: dict, agent_name: str | None) -> ModelChain:
+    """Rewrite a v3 ``spec.claude.*`` block as a single-label v4 chain.
+
+    The v4 chain has exactly one entry under the key ``"legacy"``
+    so the runtime keeps reading a consistent shape during the
+    transition. Emits the one-time deprecation warning unconditionally
+    — even if the alias produces an empty / malformed label, the
+    operator should see the migration nudge.
+
+    Supported v3 ``spec.claude.provider`` shapes (mapped to v4):
+
+    * **string name** (``provider: deepseek``) → ``provider=name``,
+      ``model_id=spec.claude.model``.
+
+    * **registered-name dict** (``provider: {name: deepseek}`` — not
+      currently a v3 shape but accepted defensively) → same as string.
+
+    * **custom dict** (``{base_url, auth_token_env}`` or
+      ``{type: custom, ...}``) → UNSUPPORTED in the v3 alias path.
+      Returns a label with ``provider=""`` so the validator surfaces
+      a "migrate directly to v4" error pointing at ADR-0018. These
+      operators want the env-var-substitution path PR A introduces
+      anyway, so making them migrate directly is the right call.
+
+    The :attr:`ModelLabel.account` field passes through verbatim from
+    ``spec.claude.account``. v3 had no ``api_key`` field on
+    ``spec.claude.*`` (the key was the dict-form provider's
+    ``auth_token_env``), so the alias leaves :attr:`ModelLabel.api_key`
+    empty — the runtime falls back to the provider registry's
+    ``auth_token_env`` exactly as v3 did. Backward-compatible.
+    """
+    _emit_v3_alias_warn_once(agent_name)
+    provider_block = claude_block.get("provider")
+    provider_name = ""
+    if isinstance(provider_block, str):
+        if resolve_provider(provider_block) is not None:
+            provider_name = provider_block
+        else:
+            # Unknown provider name — keep "" so validator surfaces
+            # the loud "unknown provider" error via the same code
+            # path a v4 spec with a bad provider goes through.
+            provider_name = provider_block
+    elif isinstance(provider_block, dict):
+        # Dict-form provider in v3 was the custom-endpoint or registered-name
+        # dict; either way it does NOT map cleanly to a single v4 label.
+        # Leave provider_name="" so validator points the operator at
+        # ADR-0018 with a clear "migrate directly" message.
+        nested_name = provider_block.get("name")
+        if isinstance(nested_name, str) and resolve_provider(nested_name) is not None:
+            provider_name = nested_name
+        # else: leave "" — custom dict shape can't be reduced.
+    # ``None`` / absent provider block → leave provider_name="";
+    # validator surfaces the required-field error.
+
+    model_id = str(claude_block.get("model", "") or "")
+    account = str(claude_block.get("account", "") or "")
+    return {
+        "legacy": ModelLabel(
+            provider=provider_name,
+            model_id=model_id,
+            account=account,
+            api_key="",
+        )
+    }
+
+
+def parse_model_chain(spec: dict, agent_name: str | None = None) -> ModelChain:
+    """Parse ``spec.model`` into a :data:`ModelChain` (ADR-0018 PR A).
+
+    Behaviour matrix:
+
+    * ``spec.model`` present, ``spec.claude`` absent → parse v4
+      directly. Operator insertion order is preserved.
+
+    * ``spec.model`` absent, ``spec.claude`` present → rewrite via
+      :func:`_v3_to_v4_alias`. Emits the one-time deprecation
+      warning. Returns a single-label chain under ``"legacy"``.
+
+    * Both present → return empty dict. The validator surfaces the
+      loud mutual-exclusion error against the raw block. We do NOT
+      raise here; the parser stays non-raising.
+
+    * Neither present → return empty dict (no chain configured;
+      validator treats absence as "model chain optional in v4 too if
+      spec.claude provides one" — see
+      :func:`config._model_chain_validation.validate_model_chain`).
+
+    The parser is defensive against per-label non-dict entries: a
+    ``None`` / scalar value for a label produces a default
+    :class:`ModelLabel` (all fields empty), letting the validator
+    surface a structured "field X is required" error per label rather
+    than a parser KeyError.
+    """
+    raw_model = spec.get("model")
+    raw_claude = spec.get("claude")
+
+    has_model = isinstance(raw_model, dict) and raw_model
+    has_claude = isinstance(raw_claude, dict) and raw_claude
+
+    if has_model and has_claude:
+        # Mutex; defer to validator. Empty dict means "no usable chain".
+        return {}
+
+    if not has_model and has_claude:
+        return _v3_to_v4_alias(raw_claude, agent_name)
+
+    if not has_model:
+        # Neither v4 chain nor v3 alias — empty chain (legitimate
+        # "no model configured" case; loader will still produce an
+        # AgentConfig with defaults).
+        return {}
+
+    # has_model: parse v4 chain in insertion order.
+    chain: ModelChain = {}
+    for label_name, label_entry in raw_model.items():
+        # Defensive: a per-label non-dict (yaml typo, accidental scalar)
+        # produces an all-empty ModelLabel rather than a parser raise.
+        # Validator surfaces the per-field "required" errors.
+        if not isinstance(label_entry, dict):
+            chain[str(label_name)] = ModelLabel()
+            continue
+        provider = str(label_entry.get("provider", "") or "")
+        model_id = str(label_entry.get("model_id", "") or "")
+        account = str(label_entry.get("account", "") or "")
+        api_key = str(label_entry.get("api_key", "") or "")
+        chain[str(label_name)] = ModelLabel(
+            provider=provider,
+            model_id=model_id,
+            account=account,
+            api_key=api_key,
+        )
+    return chain
+
+
+__all__ = [
+    "parse_model_chain",
+    "_v3_to_v4_alias",
+    "_emit_v3_alias_warn_once",
+    "_reset_v3_alias_warn_tracker_for_tests",
+]

--- a/src/scitex_agent_container/config/_types.py
+++ b/src/scitex_agent_container/config/_types.py
@@ -9,6 +9,7 @@ from typing import Any, Dict
 # Phase-3 ACL dataclasses (kept in a sibling module under the per-file
 # line cap; re-exported here for the :class:`AgentConfig` field defaults).
 from ._acl_types import CommsSpec, LineageSpec  # noqa: E402,F401
+from ._model_chain_types import ModelChain  # noqa: F401 — used in TYPE-quoted field
 from ._provider_types import ProviderSpec
 
 
@@ -436,6 +437,15 @@ class AgentConfig:
     labels: dict[str, str] = field(default_factory=dict)
     container: ContainerSpec = field(default_factory=ContainerSpec)
     claude: ClaudeSpec = field(default_factory=ClaudeSpec)
+    # ADR-0018 v4 cascade-fallback model chain. Label-keyed dict where
+    # each entry is a complete provider config; the dict's INSERTION
+    # ORDER is the implicit fallback cascade order (PR B runtime
+    # dispatcher walks this on 429/auth errors). Empty default keeps
+    # back-compat: v3 specs declare ``spec.claude.*`` and the loader
+    # rewrites that into a single-label ``model_chain['legacy']``
+    # entry via :func:`config._parsers._model_chain.parse_model_chain`.
+    # See :mod:`config._model_chain_types` for the dataclass schema.
+    model_chain: "ModelChain" = field(default_factory=dict)
     health: HealthSpec = field(default_factory=HealthSpec)
     watchdog: WatchdogSpec = field(default_factory=WatchdogSpec)
     restart: RestartSpec = field(default_factory=RestartSpec)

--- a/src/scitex_agent_container/config/_validation.py
+++ b/src/scitex_agent_container/config/_validation.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import yaml
 
 from ._acl_validation import validate_phase3_acl
+from ._model_chain_validation import validate_model_chain
 from ._provider_validation import provider_is_active, validate_provider
 
 # Accepted shapes for ``spec.model`` (F-CS7).
@@ -95,6 +96,9 @@ _KNOWN_SPEC_KEYS = frozenset(
         "to_home",  # ADR-0006 — directory mirrored into container $HOME
         "comms",  # Phase-3 ACL: outbound/inbound + a2a listen toggle
         "lineage",  # Phase-3 ACL: group=solitary + may_spawn
+        "model",  # ADR-0018 v4: spec.model.<label>.* cascade-fallback chain
+        # (label-keyed dict). String-form values are still rejected
+        # below as the deprecated v2 alias; only dicts are honored.
         # v3 removed (rejected explicitly below with relocation hints):
         # image (→ spec.apptainer.image), mounts (→ spec.apptainer.binds),
         # env (→ spec.apptainer.env), model (→ spec.claude.model),
@@ -105,11 +109,17 @@ _KNOWN_SPEC_KEYS = frozenset(
 
 # v3-realign: top-level fields that moved into engine blocks. Reject
 # loudly with a hint pointing to the new home (§3 Removed from v3).
+#
+# ADR-0018 caveat: top-level ``spec.model`` is REINTRODUCED as a v4 dict
+# (label-keyed cascade chain). The validator below treats a STRING value
+# as the deprecated v2/v3 shape and points at ``spec.claude.model``; a
+# DICT value is the v4 cascade and gets handed to validate_model_chain.
+# Empty / list / other shapes fall through to the v3 relocation hint
+# (operators see the same advice the legacy path emitted).
 _V3_RELOCATED_FIELDS: dict[str, str] = {
     "image": "spec.apptainer.image",
     "mounts": "spec.apptainer.binds",
     "env": "spec.apptainer.env",
-    "model": "spec.claude.model",
 }
 
 # v3-realign: fields removed outright (no relocation — different owners).
@@ -288,6 +298,49 @@ def validate_raw(raw: dict, path: str) -> list[str]:
                 "exclusive — a provider backend uses an API key, not "
                 "Anthropic OAuth. Set exactly one."
             )
+
+        # ADR-0018 v4 — spec.model.<label>.* cascade-fallback chain.
+        # When present, validate every label entry through the dedicated
+        # validator. A STRING-form value at the top level is the
+        # deprecated v2 alias (the v3 home is spec.claude.model); reject
+        # with the same hint the v3 relocation map emitted. A non-dict
+        # non-string is a type error. Absent → no-op (v3 specs work
+        # unchanged via the spec.claude alias path inside
+        # parse_model_chain).
+        spec_model = spec.get("model")
+        if spec_model is not None:
+            if isinstance(spec_model, str):
+                errors.append(
+                    "spec.model is no longer accepted at the top level as a "
+                    "string; move it to spec.claude.model (v3 spec realignment "
+                    "§3). For the ADR-0018 v4 cascade-fallback shape, use a "
+                    "dict: spec.model.<label>.{provider, model_id, account|api_key}."
+                )
+            elif not isinstance(spec_model, dict):
+                errors.append(
+                    f"spec.model must be a dict of label → config, got "
+                    f"{type(spec_model).__name__} (ADR-0018 v4)."
+                )
+            else:
+                errors.extend(
+                    validate_model_chain(
+                        spec_model,
+                        agent_name=(metadata or {}).get("name"),
+                    )
+                )
+                # spec.claude and spec.model are mutually exclusive — both
+                # declare the same provider/auth axis. The parser's v3
+                # alias path covers the back-compat case (v3 declares
+                # only spec.claude; v4 declares only spec.model);
+                # declaring BOTH leaves the runtime guessing which wins.
+                if claude_block:
+                    errors.append(
+                        "spec.claude and spec.model are mutually exclusive — "
+                        "v3 specs use spec.claude.* (auto-aliased to a single "
+                        "'legacy' label internally); v4 specs use "
+                        "spec.model.<label>.*. Remove the deprecated "
+                        "spec.claude block when adopting v4."
+                    )
 
         # container.runtime
         container = spec.get("container", {}) or {}

--- a/tests/scitex_agent_container/config/_parsers/test__model_chain_parser.py
+++ b/tests/scitex_agent_container/config/_parsers/test__model_chain_parser.py
@@ -1,0 +1,394 @@
+"""Tests for ``config._parsers._model_chain.parse_model_chain`` (ADR-0018 PR A).
+
+PR A — pure additive: existing v3 specs continue to load via the
+``spec.model.legacy`` alias, AND a new v4 ``spec.model.<label>.*`` shape
+parses cleanly preserving insertion order. The mutex case (both keys
+present) collapses to an empty chain so the validator can surface the
+loud error against the raw block; the parser is intentionally
+non-raising.
+
+AAA markers (TQ002), descriptive names (TQ003), one assert per test
+(TQ007).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scitex_agent_container.config._model_chain_types import ModelLabel
+from scitex_agent_container.config._parsers._model_chain import (
+    _reset_v3_alias_warn_tracker_for_tests,
+    parse_model_chain,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_v3_alias_warn():
+    """Clear the per-agent one-shot warn tracker before every test.
+
+    The tracker is module-level so warns fire exactly once per agent
+    per process; tests need a fresh slate to assert the warning
+    consistently regardless of preceding tests.
+    """
+    _reset_v3_alias_warn_tracker_for_tests()
+    yield
+    _reset_v3_alias_warn_tracker_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# Empty / absent paths
+# ---------------------------------------------------------------------------
+
+
+def test_no_model_and_no_claude_yields_empty_chain():
+    # Arrange
+    spec: dict = {}
+    # Act
+    chain = parse_model_chain(spec)
+    # Assert
+    assert chain == {}
+
+
+def test_empty_model_dict_yields_empty_chain():
+    # Arrange — ``spec.model: {}`` is operator-explicit "no chain"; the
+    # validator surfaces the "declare at least one label" error.
+    spec: dict = {"model": {}}
+    # Act
+    chain = parse_model_chain(spec)
+    # Assert
+    assert chain == {}
+
+
+# ---------------------------------------------------------------------------
+# v4 happy path — single label
+# ---------------------------------------------------------------------------
+
+
+def test_single_label_chain_has_one_entry():
+    # Arrange
+    spec = {
+        "model": {
+            "default": {
+                "provider": "anthropic",
+                "model_id": "claude-sonnet-4-6",
+                "account": "ywatanabe-scitex-ai",
+            }
+        }
+    }
+    # Act
+    chain = parse_model_chain(spec)
+    # Assert
+    assert len(chain) == 1
+
+
+def test_single_label_chain_uses_operator_label_key():
+    # Arrange
+    spec = {
+        "model": {
+            "default": {
+                "provider": "anthropic",
+                "model_id": "claude-sonnet-4-6",
+            }
+        }
+    }
+    # Act
+    chain = parse_model_chain(spec)
+    # Assert
+    assert list(chain.keys()) == ["default"]
+
+
+def test_single_label_chain_surfaces_provider_field():
+    # Arrange
+    spec = {
+        "model": {
+            "default": {
+                "provider": "anthropic",
+                "model_id": "claude-sonnet-4-6",
+            }
+        }
+    }
+    # Act
+    chain = parse_model_chain(spec)
+    # Assert
+    assert chain["default"].provider == "anthropic"
+
+
+def test_single_label_chain_surfaces_model_id_field():
+    # Arrange
+    spec = {
+        "model": {
+            "default": {
+                "provider": "anthropic",
+                "model_id": "claude-sonnet-4-6",
+            }
+        }
+    }
+    # Act
+    chain = parse_model_chain(spec)
+    # Assert
+    assert chain["default"].model_id == "claude-sonnet-4-6"
+
+
+def test_single_label_chain_surfaces_account_field():
+    # Arrange
+    spec = {
+        "model": {
+            "default": {
+                "provider": "anthropic",
+                "model_id": "claude-sonnet-4-6",
+                "account": "ywatanabe-scitex-ai",
+            }
+        }
+    }
+    # Act
+    chain = parse_model_chain(spec)
+    # Assert
+    assert chain["default"].account == "ywatanabe-scitex-ai"
+
+
+# ---------------------------------------------------------------------------
+# v4 multi-label — insertion order preserved (= fallback cascade order).
+# ---------------------------------------------------------------------------
+
+
+def test_multi_label_chain_has_three_entries():
+    # Arrange — operator declares primary + 2 fallbacks.
+    spec = {
+        "model": {
+            "label-1": {"provider": "anthropic", "model_id": "claude-sonnet-4-6"},
+            "label-2": {"provider": "xiaomi", "model_id": "mimo-v2.5-pro"},
+            "label-3": {"provider": "deepseek", "model_id": "deepseek-v4-pro"},
+        }
+    }
+    # Act
+    chain = parse_model_chain(spec)
+    # Assert
+    assert len(chain) == 3
+
+
+def test_multi_label_chain_preserves_insertion_order():
+    # Arrange — ADR-0018: dict insertion order IS the fallback order.
+    spec = {
+        "model": {
+            "label-1": {"provider": "anthropic", "model_id": "claude-sonnet-4-6"},
+            "label-2": {"provider": "xiaomi", "model_id": "mimo-v2.5-pro"},
+            "label-3": {"provider": "deepseek", "model_id": "deepseek-v4-pro"},
+        }
+    }
+    # Act
+    chain = parse_model_chain(spec)
+    # Assert
+    assert list(chain.keys()) == ["label-1", "label-2", "label-3"]
+
+
+def test_multi_label_chain_third_label_provider_is_deepseek():
+    # Arrange
+    spec = {
+        "model": {
+            "label-1": {"provider": "anthropic", "model_id": "claude-sonnet-4-6"},
+            "label-2": {"provider": "xiaomi", "model_id": "mimo-v2.5-pro"},
+            "label-3": {"provider": "deepseek", "model_id": "deepseek-v4-pro"},
+        }
+    }
+    # Act
+    chain = parse_model_chain(spec)
+    # Assert
+    assert chain["label-3"].provider == "deepseek"
+
+
+# ---------------------------------------------------------------------------
+# api_key — raw value pass-through (parser does NOT resolve env vars).
+# ---------------------------------------------------------------------------
+
+
+def test_api_key_dollar_var_form_stored_raw():
+    # Arrange
+    spec = {
+        "model": {
+            "default": {
+                "provider": "xiaomi",
+                "model_id": "mimo-v2.5-pro",
+                "api_key": "$XIAOMI_API_KEY",
+            }
+        }
+    }
+    # Act
+    chain = parse_model_chain(spec)
+    # Assert — env-var resolution lands in PR B; parser stores raw.
+    assert chain["default"].api_key == "$XIAOMI_API_KEY"
+
+
+def test_api_key_dollar_brace_form_stored_raw():
+    # Arrange
+    spec = {
+        "model": {
+            "default": {
+                "provider": "deepseek",
+                "model_id": "deepseek-v4-pro",
+                "api_key": "${DEEPSEEK_API_KEY}",
+            }
+        }
+    }
+    # Act
+    chain = parse_model_chain(spec)
+    # Assert
+    assert chain["default"].api_key == "${DEEPSEEK_API_KEY}"
+
+
+def test_api_key_literal_form_stored_raw():
+    # Arrange — literal secret in spec; validator emits the warning.
+    spec = {
+        "model": {
+            "default": {
+                "provider": "anthropic",
+                "model_id": "claude-sonnet-4-6",
+                "api_key": "sk-ant-literal",
+            }
+        }
+    }
+    # Act
+    chain = parse_model_chain(spec)
+    # Assert
+    assert chain["default"].api_key == "sk-ant-literal"
+
+
+# ---------------------------------------------------------------------------
+# v3 alias — single-label "legacy" chain + one-shot stderr deprecation warning
+# ---------------------------------------------------------------------------
+
+
+def test_v3_string_provider_alias_creates_legacy_label():
+    # Arrange — v3 string-form: provider name + model + account.
+    spec = {
+        "claude": {
+            "provider": "deepseek",
+            "model": "deepseek-chat",
+            "account": "ywatanabe-scitex-ai",
+        }
+    }
+    # Act
+    chain = parse_model_chain(spec, agent_name="agent-a")
+    # Assert
+    assert "legacy" in chain
+
+
+def test_v3_string_provider_alias_provider_matches_v3_name():
+    # Arrange
+    spec = {
+        "claude": {"provider": "deepseek", "model": "deepseek-chat"},
+    }
+    # Act
+    chain = parse_model_chain(spec, agent_name="agent-b")
+    # Assert
+    assert chain["legacy"].provider == "deepseek"
+
+
+def test_v3_string_provider_alias_model_id_promoted_from_claude_model():
+    # Arrange — v3 ``spec.claude.model`` maps to v4 ``model_id``.
+    spec = {
+        "claude": {"provider": "deepseek", "model": "deepseek-chat"},
+    }
+    # Act
+    chain = parse_model_chain(spec, agent_name="agent-c")
+    # Assert
+    assert chain["legacy"].model_id == "deepseek-chat"
+
+
+def test_v3_string_provider_alias_account_passes_through():
+    # Arrange
+    spec = {
+        "claude": {
+            "provider": "anthropic",
+            "model": "sonnet",
+            "account": "ywatanabe-scitex-ai",
+        }
+    }
+    # Act
+    chain = parse_model_chain(spec, agent_name="agent-d")
+    # Assert
+    assert chain["legacy"].account == "ywatanabe-scitex-ai"
+
+
+def test_v3_alias_emits_deprecation_warning_to_stderr(capsys):
+    # Arrange
+    spec = {"claude": {"provider": "deepseek", "model": "deepseek-chat"}}
+    # Act
+    parse_model_chain(spec, agent_name="warn-agent")
+    captured = capsys.readouterr()
+    # Assert
+    assert "[sac:deprecation]" in captured.err
+
+
+def test_v3_alias_warning_mentions_agent_name(capsys):
+    # Arrange
+    spec = {"claude": {"provider": "deepseek", "model": "deepseek-chat"}}
+    # Act
+    parse_model_chain(spec, agent_name="my-specific-agent")
+    captured = capsys.readouterr()
+    # Assert
+    assert "my-specific-agent" in captured.err
+
+
+def test_v3_alias_warning_emits_only_once_per_agent(capsys):
+    # Arrange
+    spec = {"claude": {"provider": "deepseek", "model": "deepseek-chat"}}
+    # Act — parse twice for the same agent.
+    parse_model_chain(spec, agent_name="once-agent")
+    parse_model_chain(spec, agent_name="once-agent")
+    captured = capsys.readouterr()
+    # Assert — one occurrence of the deprecation header in stderr.
+    assert captured.err.count("[sac:deprecation]") == 1
+
+
+def test_v3_alias_warning_emits_independently_per_agent(capsys):
+    # Arrange — distinct agents each get their own one-shot warning.
+    spec = {"claude": {"provider": "deepseek", "model": "deepseek-chat"}}
+    # Act
+    parse_model_chain(spec, agent_name="agent-x")
+    parse_model_chain(spec, agent_name="agent-y")
+    captured = capsys.readouterr()
+    # Assert
+    assert captured.err.count("[sac:deprecation]") == 2
+
+
+# ---------------------------------------------------------------------------
+# Mutex — both spec.model AND spec.claude present → parser defers to validator
+# ---------------------------------------------------------------------------
+
+
+def test_both_model_and_claude_present_yields_empty_chain():
+    # Arrange — mutex violation; parser stays non-raising, returns
+    # empty so validator can surface the named error.
+    spec = {
+        "model": {
+            "default": {"provider": "anthropic", "model_id": "claude-sonnet-4-6"}
+        },
+        "claude": {"provider": "deepseek", "model": "deepseek-chat"},
+    }
+    # Act
+    chain = parse_model_chain(spec, agent_name="mutex-agent")
+    # Assert
+    assert chain == {}
+
+
+# ---------------------------------------------------------------------------
+# Defensive — malformed per-label entries do not raise
+# ---------------------------------------------------------------------------
+
+
+def test_non_dict_label_entry_yields_empty_label_object():
+    # Arrange — a yaml typo: label value is a scalar, not a mapping.
+    spec = {"model": {"broken": "not-a-dict"}}
+    # Act
+    chain = parse_model_chain(spec)
+    # Assert — parser does not raise; produces default ModelLabel.
+    assert chain["broken"] == ModelLabel()
+
+
+def test_partial_label_entry_fills_missing_fields_with_defaults():
+    # Arrange — only provider declared; everything else defaults.
+    spec = {"model": {"partial": {"provider": "anthropic"}}}
+    # Act
+    chain = parse_model_chain(spec)
+    # Assert
+    assert chain["partial"].model_id == ""

--- a/tests/scitex_agent_container/config/test__env_var_substitution.py
+++ b/tests/scitex_agent_container/config/test__env_var_substitution.py
@@ -1,0 +1,184 @@
+"""Tests for ``config._env_var_substitution`` (ADR-0018 PR A).
+
+``resolve_env_var_ref`` classifies a raw string from
+``spec.model.<label>.api_key`` into one of three kinds: ``ref`` (env
+var reference, returns the bare identifier), ``literal``, or
+``empty``. PR A only recognizes the shape; actual ``os.environ``
+lookup at agent start lands in PR B.
+
+Edge cases (``$``, ``${}``, ``$1``, lowercase) are LITERALS by
+intent — see :mod:`config._env_var_substitution` module docstring on
+the uppercase-only choice.
+
+AAA markers (TQ002), descriptive names (TQ003), one assert per test
+(TQ007).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scitex_agent_container.config._env_var_substitution import (
+    is_env_var_ref,
+    resolve_env_var_ref,
+)
+
+# ---------------------------------------------------------------------------
+# Happy-path classification — ref / literal / empty
+# ---------------------------------------------------------------------------
+
+
+def test_dollar_var_form_classifies_as_ref():
+    # Arrange / Act
+    kind, name = resolve_env_var_ref("$XIAOMI_API_KEY")
+    # Assert
+    assert kind == "ref"
+
+
+def test_dollar_var_form_returns_bare_identifier():
+    # Arrange / Act
+    _, name = resolve_env_var_ref("$XIAOMI_API_KEY")
+    # Assert
+    assert name == "XIAOMI_API_KEY"
+
+
+def test_dollar_brace_var_form_classifies_as_ref():
+    # Arrange / Act
+    kind, name = resolve_env_var_ref("${DEEPSEEK_API_KEY}")
+    # Assert
+    assert kind == "ref"
+
+
+def test_dollar_brace_var_form_returns_bare_identifier():
+    # Arrange / Act
+    _, name = resolve_env_var_ref("${DEEPSEEK_API_KEY}")
+    # Assert
+    assert name == "DEEPSEEK_API_KEY"
+
+
+def test_anthropic_api_key_literal_classifies_as_literal():
+    # Arrange / Act
+    kind, _ = resolve_env_var_ref("sk-ant-xxx")
+    # Assert — operator pasted the actual secret into spec.yaml.
+    assert kind == "literal"
+
+
+def test_literal_returns_no_var_name():
+    # Arrange / Act
+    _, name = resolve_env_var_ref("sk-ant-xxx")
+    # Assert
+    assert name is None
+
+
+def test_empty_string_classifies_as_empty():
+    # Arrange / Act — empty = field omitted = fall back to registry.
+    kind, _ = resolve_env_var_ref("")
+    # Assert
+    assert kind == "empty"
+
+
+def test_empty_string_returns_no_var_name():
+    # Arrange / Act
+    _, name = resolve_env_var_ref("")
+    # Assert
+    assert name is None
+
+
+# ---------------------------------------------------------------------------
+# Edge cases — DOCUMENTED literal interpretations.
+# ---------------------------------------------------------------------------
+
+
+def test_bare_dollar_sign_is_a_literal():
+    # Arrange — no identifier after $, treat as literal.
+    # Act
+    kind, _ = resolve_env_var_ref("$")
+    # Assert
+    assert kind == "literal"
+
+
+def test_empty_braces_dollar_brace_is_a_literal():
+    # Arrange — ${} has no identifier inside the braces.
+    # Act
+    kind, _ = resolve_env_var_ref("${}")
+    # Assert
+    assert kind == "literal"
+
+
+def test_numeric_positional_dollar_one_is_a_literal():
+    # Arrange — POSIX positional params don't apply to env vars;
+    # this is almost certainly a copy-pasted token literal.
+    # Act
+    kind, _ = resolve_env_var_ref("$1")
+    # Assert
+    assert kind == "literal"
+
+
+def test_lowercase_dollar_var_is_a_literal():
+    # Arrange — ALL_CAPS env-var convention pins the uppercase-only
+    # parse; ``$superkey`` is treated as a literal, NOT an env ref.
+    # Act
+    kind, _ = resolve_env_var_ref("$superkey")
+    # Assert
+    assert kind == "literal"
+
+
+def test_mixed_case_dollar_brace_is_a_literal():
+    # Arrange / Act
+    kind, _ = resolve_env_var_ref("${Mixed_CASE}")
+    # Assert
+    assert kind == "literal"
+
+
+def test_underscore_leading_env_var_is_a_ref():
+    # Arrange — POSIX accepts leading underscore in identifiers.
+    # Act
+    kind, name = resolve_env_var_ref("$_PRIVATE_KEY")
+    # Assert
+    assert (kind, name) == ("ref", "_PRIVATE_KEY")
+
+
+def test_digit_in_env_var_name_after_letter_is_a_ref():
+    # Arrange — identifiers may contain digits after the first char.
+    # Act
+    kind, name = resolve_env_var_ref("$XIAOMI2_API_KEY")
+    # Assert
+    assert (kind, name) == ("ref", "XIAOMI2_API_KEY")
+
+
+# ---------------------------------------------------------------------------
+# Defensive: non-string input
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad", [None, 0, 42, [], {}, object()])
+def test_non_string_input_classifies_as_empty(bad):
+    # Arrange / Act — parser stays non-raising; validator surfaces
+    # the shape error against the raw block.
+    kind, name = resolve_env_var_ref(bad)
+    # Assert
+    assert (kind, name) == ("empty", None)
+
+
+# ---------------------------------------------------------------------------
+# is_env_var_ref convenience wrapper
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("$XIAOMI_API_KEY", True),
+        ("${DEEPSEEK_API_KEY}", True),
+        ("sk-ant-xxx", False),
+        ("", False),
+        ("$", False),
+        ("${}", False),
+        ("$1", False),
+    ],
+)
+def test_is_env_var_ref_matches_kind_classification(raw, expected):
+    # Arrange / Act
+    actual = is_env_var_ref(raw)
+    # Assert
+    assert actual is expected

--- a/tests/scitex_agent_container/config/test__loaders_model_chain.py
+++ b/tests/scitex_agent_container/config/test__loaders_model_chain.py
@@ -22,6 +22,10 @@ spec declaring both blocks raises with the mutex message.
 
 PA-306 fixtures: real ``tmp_path`` + real YAML loading; no
 ``unittest.mock.patch``.
+
+STX-TQ007 split: every test below holds a single assertion. When a
+prior test verified N facets, this file now carries N one-assert
+tests sharing a small Arrange+Act helper.
 """
 
 from __future__ import annotations
@@ -64,16 +68,37 @@ def _write_spec(tmp_path, body: str) -> "pytest.Path":
     return spec
 
 
+def _load_or_capture_error(tmp_path, body: str) -> str:
+    """Arrange + Act helper for the validator-error cases.
+
+    Writes ``body`` as a spec and calls :func:`load_config`; expects it
+    to raise :class:`ValueError`. Returns ``str(exception)`` so each
+    split test can assert on a single substring without re-running the
+    loader. If no exception fires, raises ``AssertionError`` so the
+    test setup itself is obviously broken (we never silently return).
+    """
+    spec = _write_spec(tmp_path, body)
+    try:
+        load_config(spec)
+    except ValueError as exc:
+        return str(exc)
+    raise AssertionError(
+        "_load_or_capture_error expected ValueError from load_config but "
+        "none was raised"
+    )
+
+
 # ---------------------------------------------------------------------------
 # v4 path — spec.model.<label>.*
+#
+# The two-label spec below is loaded once per test (the loader is cheap
+# and tmp_path is per-test). Each test pins ONE facet of the resulting
+# AgentConfig.
 # ---------------------------------------------------------------------------
 
-
-def test_v4_spec_populates_model_chain(tmp_path):
-    spec = _write_spec(
-        tmp_path,
-        _BASELINE_SPEC
-        + """\
+_TWO_LABEL_V4_BODY = (
+    _BASELINE_SPEC
+    + """\
   model:
     primary:
       provider: anthropic
@@ -83,17 +108,48 @@ def test_v4_spec_populates_model_chain(tmp_path):
       provider: deepseek
       model_id: deepseek-chat
       api_key: $DEEPSEEK_API_KEY
-""",
-    )
+"""
+)
+
+
+def test_v4_spec_model_chain_is_a_dict(tmp_path):
+    # Arrange
+    spec = _write_spec(tmp_path, _TWO_LABEL_V4_BODY)
+    # Act
     cfg = load_config(spec)
+    # Assert
     assert isinstance(cfg.model_chain, dict)
+
+
+def test_v4_spec_model_chain_preserves_label_order(tmp_path):
+    # Arrange
+    spec = _write_spec(tmp_path, _TWO_LABEL_V4_BODY)
+    # Act
+    cfg = load_config(spec)
+    # Assert
     assert list(cfg.model_chain.keys()) == ["primary", "backup"]
+
+
+def test_v4_spec_primary_label_carries_anthropic_account_form(tmp_path):
+    # Arrange
+    spec = _write_spec(tmp_path, _TWO_LABEL_V4_BODY)
+    # Act
+    cfg = load_config(spec)
+    # Assert
     assert cfg.model_chain["primary"] == ModelLabel(
         provider="anthropic",
         model_id="claude-sonnet-4-6",
         account="ywatanabe-scitex-ai",
         api_key="",
     )
+
+
+def test_v4_spec_backup_label_carries_api_key_form(tmp_path):
+    # Arrange
+    spec = _write_spec(tmp_path, _TWO_LABEL_V4_BODY)
+    # Act
+    cfg = load_config(spec)
+    # Assert
     assert cfg.model_chain["backup"] == ModelLabel(
         provider="deepseek",
         model_id="deepseek-chat",
@@ -104,6 +160,7 @@ def test_v4_spec_populates_model_chain(tmp_path):
 
 def test_v4_single_label_still_requires_label_key(tmp_path):
     """Operator must wrap a single config in a label (ADR-0018 §"Single-config")."""
+    # Arrange
     spec = _write_spec(
         tmp_path,
         _BASELINE_SPEC
@@ -115,7 +172,9 @@ def test_v4_single_label_still_requires_label_key(tmp_path):
       account: ywatanabe-scitex-ai
 """,
     )
+    # Act
     cfg = load_config(spec)
+    # Assert
     assert list(cfg.model_chain.keys()) == ["default"]
 
 
@@ -123,6 +182,7 @@ def test_v4_insertion_order_preserved_through_loader(tmp_path):
     """Cascade fallback semantics depend on dict insertion order — verify the
     loader preserves the operator's intended order through validation.
     """
+    # Arrange
     spec = _write_spec(
         tmp_path,
         _BASELINE_SPEC
@@ -142,35 +202,73 @@ def test_v4_insertion_order_preserved_through_loader(tmp_path):
       api_key: $XIAOMI_API_KEY
 """,
     )
+    # Act
     cfg = load_config(spec)
+    # Assert
     assert list(cfg.model_chain.keys()) == ["zebra", "aardvark", "middle"]
 
 
 # ---------------------------------------------------------------------------
-# v3 alias path — spec.claude.provider (registered name)
+# v3 alias path — spec.claude.provider (registered name).
+#
+# The shared spec below populates spec.claude with deepseek; the v3
+# alias produces a single "legacy" label AND keeps claude_spec
+# populated for back-compat consumers. Each split test verifies one
+# facet.
 # ---------------------------------------------------------------------------
 
-
-def test_v3_registered_provider_aliases_to_legacy_label(tmp_path):
-    spec = _write_spec(
-        tmp_path,
-        _BASELINE_SPEC
-        + """\
+_V3_DEEPSEEK_CLAUDE_BODY = (
+    _BASELINE_SPEC
+    + """\
   claude:
     model: deepseek-chat
     provider: deepseek
-""",
-    )
+"""
+)
+
+
+def test_v3_registered_provider_aliases_to_single_legacy_label(tmp_path):
+    # Arrange
+    spec = _write_spec(tmp_path, _V3_DEEPSEEK_CLAUDE_BODY)
+    # Act
     cfg = load_config(spec)
-    # Legacy alias produces a single "legacy" label populated from the
-    # v3 spec.claude block. The claude_spec ALSO populates for back-
-    # compat consumers.
+    # Assert
     assert list(cfg.model_chain.keys()) == ["legacy"]
-    legacy = cfg.model_chain["legacy"]
-    assert legacy.provider == "deepseek"
-    assert legacy.model_id == "deepseek-chat"
-    assert legacy.account == ""
-    # claude block still populates (existing runtime continues to work).
+
+
+def test_v3_legacy_label_provider_matches_spec_claude_provider(tmp_path):
+    # Arrange
+    spec = _write_spec(tmp_path, _V3_DEEPSEEK_CLAUDE_BODY)
+    # Act
+    cfg = load_config(spec)
+    # Assert
+    assert cfg.model_chain["legacy"].provider == "deepseek"
+
+
+def test_v3_legacy_label_model_id_matches_spec_claude_model(tmp_path):
+    # Arrange
+    spec = _write_spec(tmp_path, _V3_DEEPSEEK_CLAUDE_BODY)
+    # Act
+    cfg = load_config(spec)
+    # Assert
+    assert cfg.model_chain["legacy"].model_id == "deepseek-chat"
+
+
+def test_v3_legacy_label_account_defaults_to_empty(tmp_path):
+    # Arrange
+    spec = _write_spec(tmp_path, _V3_DEEPSEEK_CLAUDE_BODY)
+    # Act
+    cfg = load_config(spec)
+    # Assert
+    assert cfg.model_chain["legacy"].account == ""
+
+
+def test_v3_claude_block_still_populates_for_back_compat(tmp_path):
+    # Arrange
+    spec = _write_spec(tmp_path, _V3_DEEPSEEK_CLAUDE_BODY)
+    # Act
+    cfg = load_config(spec)
+    # Assert — existing runtime code reading cfg.claude continues to work.
     assert cfg.claude.model == "deepseek-chat"
 
 
@@ -183,44 +281,79 @@ def test_no_spec_claude_no_spec_model_yields_empty_chain(tmp_path):
     """When the spec declares NEITHER spec.claude NOR spec.model, the
     chain is empty — the v3 alias only fires when spec.claude exists.
     """
+    # Arrange
     spec = _write_spec(tmp_path, _BASELINE_SPEC)
+    # Act
     cfg = load_config(spec)
+    # Assert
     assert cfg.model_chain == {}
 
 
-def test_v3_spec_claude_model_only_aliases_to_legacy_with_empty_provider(tmp_path):
-    """When spec.claude has model but no provider, the v3 alias still
-    fires and produces a single 'legacy' label with the model id but an
-    empty provider. The validator will reject this at strict-mode
-    enforcement time (PR B); for PR A the schema is permissive — the
-    parser doesn't try to invent a provider.
-    """
-    spec = _write_spec(
-        tmp_path,
-        _BASELINE_SPEC
-        + """\
+# ---------------------------------------------------------------------------
+# v3 — spec.claude.model only (no provider).
+#
+# The v3 alias still fires and produces a single 'legacy' label with
+# the model id but an empty provider. The validator will reject this at
+# strict-mode enforcement time (PR B); for PR A the schema is
+# permissive — the parser doesn't try to invent a provider.
+# ---------------------------------------------------------------------------
+
+_V3_CLAUDE_MODEL_ONLY_BODY = (
+    _BASELINE_SPEC
+    + """\
   claude:
     model: sonnet
-""",
-    )
+"""
+)
+
+
+def test_v3_spec_claude_model_only_aliases_to_single_legacy_label(tmp_path):
+    # Arrange
+    spec = _write_spec(tmp_path, _V3_CLAUDE_MODEL_ONLY_BODY)
+    # Act
     cfg = load_config(spec)
+    # Assert
     assert list(cfg.model_chain.keys()) == ["legacy"]
-    legacy = cfg.model_chain["legacy"]
-    assert legacy.model_id == "sonnet"
-    assert legacy.provider == ""  # operator declared no provider
+
+
+def test_v3_spec_claude_model_only_legacy_label_carries_model_id(tmp_path):
+    # Arrange
+    spec = _write_spec(tmp_path, _V3_CLAUDE_MODEL_ONLY_BODY)
+    # Act
+    cfg = load_config(spec)
+    # Assert
+    assert cfg.model_chain["legacy"].model_id == "sonnet"
+
+
+def test_v3_spec_claude_model_only_legacy_label_provider_is_empty(tmp_path):
+    # Arrange
+    spec = _write_spec(tmp_path, _V3_CLAUDE_MODEL_ONLY_BODY)
+    # Act
+    cfg = load_config(spec)
+    # Assert — operator declared no provider; parser does not invent one.
+    assert cfg.model_chain["legacy"].provider == ""
+
+
+def test_v3_spec_claude_model_only_claude_block_still_populates(tmp_path):
+    # Arrange
+    spec = _write_spec(tmp_path, _V3_CLAUDE_MODEL_ONLY_BODY)
+    # Act
+    cfg = load_config(spec)
+    # Assert
     assert cfg.claude.model == "sonnet"
 
 
 # ---------------------------------------------------------------------------
-# Mutex — spec.claude + spec.model both present
+# Mutex — spec.claude + spec.model both present.
+#
+# The validator must reject. Split into (a) "the call raises" and
+# (b) "the message names the mutex" so a future phrasing tweak only
+# breaks one of the two tests.
 # ---------------------------------------------------------------------------
 
-
-def test_spec_claude_and_spec_model_both_present_rejected(tmp_path):
-    spec = _write_spec(
-        tmp_path,
-        _BASELINE_SPEC
-        + """\
+_BOTH_BLOCKS_BODY = (
+    _BASELINE_SPEC
+    + """\
   claude:
     model: claude-sonnet-4-6
   model:
@@ -228,44 +361,81 @@ def test_spec_claude_and_spec_model_both_present_rejected(tmp_path):
       provider: anthropic
       model_id: claude-sonnet-4-6
       account: ywatanabe-scitex-ai
-""",
-    )
-    with pytest.raises(ValueError) as excinfo:
+"""
+)
+
+
+def test_spec_claude_and_spec_model_both_present_raises(tmp_path):
+    # Arrange
+    spec = _write_spec(tmp_path, _BOTH_BLOCKS_BODY)
+    # Act + Assert (single `pytest.raises` block — one assertion)
+    with pytest.raises(ValueError):
         load_config(spec)
-    msg = str(excinfo.value)
+
+
+def test_spec_claude_and_spec_model_both_present_error_names_mutex(tmp_path):
+    # Arrange + Act
+    msg = _load_or_capture_error(tmp_path, _BOTH_BLOCKS_BODY)
+    # Assert
     assert "spec.claude and spec.model are mutually exclusive" in msg
 
 
-def test_spec_model_string_rejected_as_v2_alias(tmp_path):
+# ---------------------------------------------------------------------------
+# Type rejections — spec.model: <string> (deprecated v2 alias).
+# ---------------------------------------------------------------------------
+
+_SPEC_MODEL_STRING_BODY = (
+    _BASELINE_SPEC
+    + """\
+  model: claude-sonnet-4-6
+"""
+)
+
+
+def test_spec_model_string_raises(tmp_path):
+    # Arrange
+    spec = _write_spec(tmp_path, _SPEC_MODEL_STRING_BODY)
+    # Act + Assert
+    with pytest.raises(ValueError):
+        load_config(spec)
+
+
+def test_spec_model_string_error_points_to_spec_claude_model(tmp_path):
     """Top-level ``spec.model: <string>`` is the deprecated v2 alias —
     the validator must reject with the v3 relocation hint pointing at
     ``spec.claude.model``."""
-    spec = _write_spec(
-        tmp_path,
-        _BASELINE_SPEC
-        + """\
-  model: claude-sonnet-4-6
-""",
-    )
-    with pytest.raises(ValueError) as excinfo:
-        load_config(spec)
-    msg = str(excinfo.value)
+    # Arrange + Act
+    msg = _load_or_capture_error(tmp_path, _SPEC_MODEL_STRING_BODY)
+    # Assert
     assert "spec.model is no longer accepted at the top level as a string" in msg
 
 
-def test_spec_model_list_rejected_as_wrong_type(tmp_path):
-    spec = _write_spec(
-        tmp_path,
-        _BASELINE_SPEC
-        + """\
+# ---------------------------------------------------------------------------
+# Type rejections — spec.model: <list> (wrong shape).
+# ---------------------------------------------------------------------------
+
+_SPEC_MODEL_LIST_BODY = (
+    _BASELINE_SPEC
+    + """\
   model:
     - foo
     - bar
-""",
-    )
-    with pytest.raises(ValueError) as excinfo:
+"""
+)
+
+
+def test_spec_model_list_raises(tmp_path):
+    # Arrange
+    spec = _write_spec(tmp_path, _SPEC_MODEL_LIST_BODY)
+    # Act + Assert
+    with pytest.raises(ValueError):
         load_config(spec)
-    msg = str(excinfo.value)
+
+
+def test_spec_model_list_error_says_must_be_dict_of_label(tmp_path):
+    # Arrange + Act
+    msg = _load_or_capture_error(tmp_path, _SPEC_MODEL_LIST_BODY)
+    # Assert
     assert "spec.model must be a dict of label" in msg
 
 
@@ -273,59 +443,112 @@ def test_spec_model_list_rejected_as_wrong_type(tmp_path):
 # Validation through validate_model_chain — wired correctly?
 # ---------------------------------------------------------------------------
 
-
-def test_v4_unknown_provider_surfaces_validator_error(tmp_path):
-    spec = _write_spec(
-        tmp_path,
-        _BASELINE_SPEC
-        + """\
+_UNKNOWN_PROVIDER_BODY = (
+    _BASELINE_SPEC
+    + """\
   model:
     primary:
       provider: not-a-registered-provider
       model_id: some-model
       api_key: $SOME_KEY
-""",
-    )
-    with pytest.raises(ValueError) as excinfo:
+"""
+)
+
+
+def test_v4_unknown_provider_raises(tmp_path):
+    # Arrange
+    spec = _write_spec(tmp_path, _UNKNOWN_PROVIDER_BODY)
+    # Act + Assert
+    with pytest.raises(ValueError):
         load_config(spec)
-    msg = str(excinfo.value)
-    # validate_model_chain emits a "not a registered provider" error
-    # that mentions the known providers; we don't tie the test to the
-    # exact phrasing, just the substring that identifies the diagnostic.
+
+
+def test_v4_unknown_provider_error_mentions_offending_provider_name(tmp_path):
+    """``validate_model_chain`` emits a "not a registered provider" error
+    that mentions the known providers; we don't tie the test to the
+    exact phrasing, just the substring that identifies the diagnostic.
+    """
+    # Arrange + Act
+    msg = _load_or_capture_error(tmp_path, _UNKNOWN_PROVIDER_BODY)
+    # Assert
     assert "not-a-registered-provider" in msg
 
 
-def test_v4_api_key_and_account_both_set_rejected(tmp_path):
-    spec = _write_spec(
-        tmp_path,
-        _BASELINE_SPEC
-        + """\
+# ---------------------------------------------------------------------------
+# Validation — api_key + account mutex on a single label.
+#
+# Three facets pinned: the validator raises, the diagnostic names the
+# label, and the diagnostic names the conflicting field. Split into
+# three one-assert tests.
+# ---------------------------------------------------------------------------
+
+_API_KEY_AND_ACCOUNT_BOTH_BODY = (
+    _BASELINE_SPEC
+    + """\
   model:
     primary:
       provider: anthropic
       model_id: claude-sonnet-4-6
       account: ywatanabe-scitex-ai
       api_key: $SOME_KEY
-""",
-    )
-    with pytest.raises(ValueError) as excinfo:
+"""
+)
+
+
+def test_v4_api_key_and_account_both_set_raises(tmp_path):
+    # Arrange
+    spec = _write_spec(tmp_path, _API_KEY_AND_ACCOUNT_BOTH_BODY)
+    # Act + Assert
+    with pytest.raises(ValueError):
         load_config(spec)
-    msg = str(excinfo.value)
-    # The exact phrasing is validator-owned; just verify the mutex
-    # diagnostic fires for label 'primary'.
+
+
+def test_v4_api_key_and_account_both_set_error_names_the_label(tmp_path):
+    # Arrange + Act
+    msg = _load_or_capture_error(tmp_path, _API_KEY_AND_ACCOUNT_BOTH_BODY)
+    # Assert — the diagnostic must identify which label is in violation.
     assert "primary" in msg
+
+
+def test_v4_api_key_and_account_both_set_error_names_conflicting_field(tmp_path):
+    # Arrange + Act
+    msg = _load_or_capture_error(tmp_path, _API_KEY_AND_ACCOUNT_BOTH_BODY)
+    # Assert — the diagnostic must name at least one of the two
+    # conflicting fields (exact phrasing is validator-owned).
     assert "api_key" in msg or "account" in msg
 
 
-def test_model_chain_typing_is_dict(tmp_path):
-    """Smoke — ``ModelChain`` is a plain dict alias; runtime callers can
-    iterate and index without isinstance-on-a-protocol gymnastics."""
-    chain: ModelChain = {
+# ---------------------------------------------------------------------------
+# ModelChain typing smoke
+# ---------------------------------------------------------------------------
+
+
+def _build_alpha_only_chain() -> ModelChain:
+    """Arrange helper: a single-label chain used by the typing smoke tests."""
+    return {
         "alpha": ModelLabel(
             provider="anthropic",
             model_id="claude-sonnet-4-6",
             account="ywatanabe-scitex-ai",
         )
     }
-    assert isinstance(chain, dict)
-    assert list(chain.keys()) == ["alpha"]
+
+
+def test_model_chain_typing_is_a_plain_dict():
+    """``ModelChain`` is a plain dict alias; runtime callers can iterate
+    and index without isinstance-on-a-protocol gymnastics."""
+    # Arrange
+    chain = _build_alpha_only_chain()
+    # Act
+    instance_check = isinstance(chain, dict)
+    # Assert
+    assert instance_check is True
+
+
+def test_model_chain_typing_round_trips_inserted_label_key():
+    # Arrange
+    chain = _build_alpha_only_chain()
+    # Act
+    keys = list(chain.keys())
+    # Assert
+    assert keys == ["alpha"]

--- a/tests/scitex_agent_container/config/test__loaders_model_chain.py
+++ b/tests/scitex_agent_container/config/test__loaders_model_chain.py
@@ -1,0 +1,331 @@
+"""Integration tests: ``load_v3`` populates ``AgentConfig.model_chain``.
+
+Verifies the ADR-0018 PR A wiring end-to-end at the loader surface:
+
+* v4 spec (``spec.model.<label>.*`` dict) → ``AgentConfig.model_chain``
+  carries one :class:`ModelLabel` per declared label, in operator
+  insertion order. ``AgentConfig.claude`` is the default-empty
+  :class:`ClaudeSpec` (v4 has no ``spec.claude`` block).
+
+* v3 spec (``spec.claude.{provider, model, account}``) →
+  ``AgentConfig.model_chain`` carries a SINGLE ``"legacy"`` label
+  synthesised by the parser's v3 alias path. ``AgentConfig.claude``
+  ALSO populates from the same block (so existing runtime code keeps
+  reading the legacy view; the chain rides alongside for PR B/C/D).
+
+* spec with NEITHER ``spec.claude.provider`` NOR ``spec.model`` →
+  empty ``model_chain``, no errors.
+
+The validator's spec.claude/spec.model mutex check is exercised here
+because :func:`load_config` runs the validator before the loader; a
+spec declaring both blocks raises with the mutex message.
+
+PA-306 fixtures: real ``tmp_path`` + real YAML loading; no
+``unittest.mock.patch``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scitex_agent_container.config import (
+    ModelChain,
+    ModelLabel,
+    load_config,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers — write a minimal v3-valid spec.yaml to ``tmp_path`` and return
+# the path. Each test mutates the dict in-place before write, so the
+# baseline stays in ONE place.
+# ---------------------------------------------------------------------------
+
+_BASELINE_SPEC = """\
+apiVersion: scitex-agent-container/v3
+kind: Agent
+spec:
+  runtime: apptainer
+  apptainer:
+    image: ~/.scitex/agent-container/containers/sac-scitex.sif
+"""
+
+
+def _write_spec(tmp_path, body: str) -> "pytest.Path":
+    """Write ``body`` to ``<tmp_path>/<agent>/spec.yaml`` and return the path.
+
+    The agent name comes from the parent dir (per v3 §"agent name is
+    derived from the parent dir name"), so we put the file under a
+    named sub-dir.
+    """
+    agent_dir = tmp_path / "test-agent"
+    agent_dir.mkdir()
+    spec = agent_dir / "spec.yaml"
+    spec.write_text(body)
+    return spec
+
+
+# ---------------------------------------------------------------------------
+# v4 path — spec.model.<label>.*
+# ---------------------------------------------------------------------------
+
+
+def test_v4_spec_populates_model_chain(tmp_path):
+    spec = _write_spec(
+        tmp_path,
+        _BASELINE_SPEC
+        + """\
+  model:
+    primary:
+      provider: anthropic
+      model_id: claude-sonnet-4-6
+      account: ywatanabe-scitex-ai
+    backup:
+      provider: deepseek
+      model_id: deepseek-chat
+      api_key: $DEEPSEEK_API_KEY
+""",
+    )
+    cfg = load_config(spec)
+    assert isinstance(cfg.model_chain, dict)
+    assert list(cfg.model_chain.keys()) == ["primary", "backup"]
+    assert cfg.model_chain["primary"] == ModelLabel(
+        provider="anthropic",
+        model_id="claude-sonnet-4-6",
+        account="ywatanabe-scitex-ai",
+        api_key="",
+    )
+    assert cfg.model_chain["backup"] == ModelLabel(
+        provider="deepseek",
+        model_id="deepseek-chat",
+        account="",
+        api_key="$DEEPSEEK_API_KEY",
+    )
+
+
+def test_v4_single_label_still_requires_label_key(tmp_path):
+    """Operator must wrap a single config in a label (ADR-0018 §"Single-config")."""
+    spec = _write_spec(
+        tmp_path,
+        _BASELINE_SPEC
+        + """\
+  model:
+    default:
+      provider: anthropic
+      model_id: claude-sonnet-4-6
+      account: ywatanabe-scitex-ai
+""",
+    )
+    cfg = load_config(spec)
+    assert list(cfg.model_chain.keys()) == ["default"]
+
+
+def test_v4_insertion_order_preserved_through_loader(tmp_path):
+    """Cascade fallback semantics depend on dict insertion order — verify the
+    loader preserves the operator's intended order through validation.
+    """
+    spec = _write_spec(
+        tmp_path,
+        _BASELINE_SPEC
+        + """\
+  model:
+    zebra:
+      provider: anthropic
+      model_id: claude-sonnet-4-6
+      account: ywatanabe-scitex-ai
+    aardvark:
+      provider: deepseek
+      model_id: deepseek-chat
+      api_key: $DEEPSEEK_API_KEY
+    middle:
+      provider: mimo
+      model_id: mimo-v2.5-pro
+      api_key: $XIAOMI_API_KEY
+""",
+    )
+    cfg = load_config(spec)
+    assert list(cfg.model_chain.keys()) == ["zebra", "aardvark", "middle"]
+
+
+# ---------------------------------------------------------------------------
+# v3 alias path — spec.claude.provider (registered name)
+# ---------------------------------------------------------------------------
+
+
+def test_v3_registered_provider_aliases_to_legacy_label(tmp_path):
+    spec = _write_spec(
+        tmp_path,
+        _BASELINE_SPEC
+        + """\
+  claude:
+    model: deepseek-chat
+    provider: deepseek
+""",
+    )
+    cfg = load_config(spec)
+    # Legacy alias produces a single "legacy" label populated from the
+    # v3 spec.claude block. The claude_spec ALSO populates for back-
+    # compat consumers.
+    assert list(cfg.model_chain.keys()) == ["legacy"]
+    legacy = cfg.model_chain["legacy"]
+    assert legacy.provider == "deepseek"
+    assert legacy.model_id == "deepseek-chat"
+    assert legacy.account == ""
+    # claude block still populates (existing runtime continues to work).
+    assert cfg.claude.model == "deepseek-chat"
+
+
+# ---------------------------------------------------------------------------
+# Empty path — neither block
+# ---------------------------------------------------------------------------
+
+
+def test_no_spec_claude_no_spec_model_yields_empty_chain(tmp_path):
+    """When the spec declares NEITHER spec.claude NOR spec.model, the
+    chain is empty — the v3 alias only fires when spec.claude exists.
+    """
+    spec = _write_spec(tmp_path, _BASELINE_SPEC)
+    cfg = load_config(spec)
+    assert cfg.model_chain == {}
+
+
+def test_v3_spec_claude_model_only_aliases_to_legacy_with_empty_provider(tmp_path):
+    """When spec.claude has model but no provider, the v3 alias still
+    fires and produces a single 'legacy' label with the model id but an
+    empty provider. The validator will reject this at strict-mode
+    enforcement time (PR B); for PR A the schema is permissive — the
+    parser doesn't try to invent a provider.
+    """
+    spec = _write_spec(
+        tmp_path,
+        _BASELINE_SPEC
+        + """\
+  claude:
+    model: sonnet
+""",
+    )
+    cfg = load_config(spec)
+    assert list(cfg.model_chain.keys()) == ["legacy"]
+    legacy = cfg.model_chain["legacy"]
+    assert legacy.model_id == "sonnet"
+    assert legacy.provider == ""  # operator declared no provider
+    assert cfg.claude.model == "sonnet"
+
+
+# ---------------------------------------------------------------------------
+# Mutex — spec.claude + spec.model both present
+# ---------------------------------------------------------------------------
+
+
+def test_spec_claude_and_spec_model_both_present_rejected(tmp_path):
+    spec = _write_spec(
+        tmp_path,
+        _BASELINE_SPEC
+        + """\
+  claude:
+    model: claude-sonnet-4-6
+  model:
+    primary:
+      provider: anthropic
+      model_id: claude-sonnet-4-6
+      account: ywatanabe-scitex-ai
+""",
+    )
+    with pytest.raises(ValueError) as excinfo:
+        load_config(spec)
+    msg = str(excinfo.value)
+    assert "spec.claude and spec.model are mutually exclusive" in msg
+
+
+def test_spec_model_string_rejected_as_v2_alias(tmp_path):
+    """Top-level ``spec.model: <string>`` is the deprecated v2 alias —
+    the validator must reject with the v3 relocation hint pointing at
+    ``spec.claude.model``."""
+    spec = _write_spec(
+        tmp_path,
+        _BASELINE_SPEC
+        + """\
+  model: claude-sonnet-4-6
+""",
+    )
+    with pytest.raises(ValueError) as excinfo:
+        load_config(spec)
+    msg = str(excinfo.value)
+    assert "spec.model is no longer accepted at the top level as a string" in msg
+
+
+def test_spec_model_list_rejected_as_wrong_type(tmp_path):
+    spec = _write_spec(
+        tmp_path,
+        _BASELINE_SPEC
+        + """\
+  model:
+    - foo
+    - bar
+""",
+    )
+    with pytest.raises(ValueError) as excinfo:
+        load_config(spec)
+    msg = str(excinfo.value)
+    assert "spec.model must be a dict of label" in msg
+
+
+# ---------------------------------------------------------------------------
+# Validation through validate_model_chain — wired correctly?
+# ---------------------------------------------------------------------------
+
+
+def test_v4_unknown_provider_surfaces_validator_error(tmp_path):
+    spec = _write_spec(
+        tmp_path,
+        _BASELINE_SPEC
+        + """\
+  model:
+    primary:
+      provider: not-a-registered-provider
+      model_id: some-model
+      api_key: $SOME_KEY
+""",
+    )
+    with pytest.raises(ValueError) as excinfo:
+        load_config(spec)
+    msg = str(excinfo.value)
+    # validate_model_chain emits a "not a registered provider" error
+    # that mentions the known providers; we don't tie the test to the
+    # exact phrasing, just the substring that identifies the diagnostic.
+    assert "not-a-registered-provider" in msg
+
+
+def test_v4_api_key_and_account_both_set_rejected(tmp_path):
+    spec = _write_spec(
+        tmp_path,
+        _BASELINE_SPEC
+        + """\
+  model:
+    primary:
+      provider: anthropic
+      model_id: claude-sonnet-4-6
+      account: ywatanabe-scitex-ai
+      api_key: $SOME_KEY
+""",
+    )
+    with pytest.raises(ValueError) as excinfo:
+        load_config(spec)
+    msg = str(excinfo.value)
+    # The exact phrasing is validator-owned; just verify the mutex
+    # diagnostic fires for label 'primary'.
+    assert "primary" in msg
+    assert "api_key" in msg or "account" in msg
+
+
+def test_model_chain_typing_is_dict(tmp_path):
+    """Smoke — ``ModelChain`` is a plain dict alias; runtime callers can
+    iterate and index without isinstance-on-a-protocol gymnastics."""
+    chain: ModelChain = {
+        "alpha": ModelLabel(
+            provider="anthropic",
+            model_id="claude-sonnet-4-6",
+            account="ywatanabe-scitex-ai",
+        )
+    }
+    assert isinstance(chain, dict)
+    assert list(chain.keys()) == ["alpha"]

--- a/tests/scitex_agent_container/config/test__model_chain_types.py
+++ b/tests/scitex_agent_container/config/test__model_chain_types.py
@@ -1,0 +1,121 @@
+"""Tests for ``config._model_chain_types`` (ADR-0018 v4 schema).
+
+The :class:`ModelLabel` dataclass is the parsed shape of one
+``spec.model.<label>.*`` entry. The :data:`ModelChain` alias is the
+parsed shape of the whole ``spec.model`` block (label -> ModelLabel,
+insertion order = fallback order).
+
+Each test pins exactly one observable behaviour. AAA markers (TQ002),
+descriptive names (TQ003), one assert per test (TQ007).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scitex_agent_container.config._model_chain_types import ModelChain, ModelLabel
+
+# ---------------------------------------------------------------------------
+# Default-construction invariants (every field has a documented "missing" sentinel)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("attr", "expected"),
+    [
+        ("provider", ""),
+        ("model_id", ""),
+        ("account", ""),
+        ("api_key", ""),
+    ],
+)
+def test_default_model_label_uses_empty_string_sentinel(attr, expected):
+    # Arrange
+    label = ModelLabel()
+    # Act
+    actual = getattr(label, attr)
+    # Assert
+    assert actual == expected
+
+
+# ---------------------------------------------------------------------------
+# Explicit-construction pass-through (every field is keyword-settable)
+# ---------------------------------------------------------------------------
+
+
+def test_model_label_provider_field_round_trips():
+    # Arrange / Act
+    label = ModelLabel(provider="anthropic")
+    # Assert
+    assert label.provider == "anthropic"
+
+
+def test_model_label_model_id_field_round_trips():
+    # Arrange / Act
+    label = ModelLabel(model_id="claude-sonnet-4-6")
+    # Assert
+    assert label.model_id == "claude-sonnet-4-6"
+
+
+def test_model_label_account_field_round_trips():
+    # Arrange / Act
+    label = ModelLabel(account="ywatanabe-scitex-ai")
+    # Assert
+    assert label.account == "ywatanabe-scitex-ai"
+
+
+def test_model_label_api_key_field_round_trips():
+    # Arrange / Act
+    label = ModelLabel(api_key="$XIAOMI_API_KEY")
+    # Assert
+    assert label.api_key == "$XIAOMI_API_KEY"
+
+
+# ---------------------------------------------------------------------------
+# Frozen contract — labels are operator intent, immutable post-parse.
+# ---------------------------------------------------------------------------
+
+
+def test_model_label_is_frozen_against_mutation():
+    # Arrange
+    label = ModelLabel(provider="anthropic", model_id="claude-sonnet-4-6")
+    # Act / Assert — dataclasses.FrozenInstanceError subclasses AttributeError.
+    with pytest.raises(AttributeError):
+        label.provider = "mimo"  # type: ignore[misc]
+
+
+def test_model_label_is_hashable_so_dispatcher_state_can_use_sets():
+    # Arrange — PR B's dispatcher tracks ``disabled-this-session``
+    # state by label; sets require hash, which the frozen contract gives.
+    label = ModelLabel(provider="anthropic", model_id="claude-sonnet-4-6")
+    # Act / Assert
+    assert hash(label) is not None
+
+
+# ---------------------------------------------------------------------------
+# ModelChain alias — just a dict, but its insertion order is the contract.
+# ---------------------------------------------------------------------------
+
+
+def test_model_chain_alias_is_assignable_to_dict_of_labels():
+    # Arrange / Act — the alias is documentary; runtime is just dict.
+    chain: ModelChain = {
+        "primary": ModelLabel(provider="anthropic", model_id="claude-sonnet-4-6"),
+        "backup": ModelLabel(provider="mimo", model_id="mimo-v2.5-pro"),
+    }
+    # Assert
+    assert isinstance(chain, dict)
+
+
+def test_model_chain_preserves_insertion_order_for_fallback_cascade():
+    # Arrange — ADR-0018: dict insertion order IS the fallback cascade
+    # order. Pin the Python-dict contract so the dispatcher contract
+    # (PR B) cannot regress silently.
+    chain: ModelChain = {}
+    chain["label-1"] = ModelLabel(provider="anthropic", model_id="claude-sonnet-4-6")
+    chain["label-2"] = ModelLabel(provider="mimo", model_id="mimo-v2.5-pro")
+    chain["label-3"] = ModelLabel(provider="deepseek", model_id="deepseek-v4-pro")
+    # Act
+    ordered_keys = list(chain.keys())
+    # Assert
+    assert ordered_keys == ["label-1", "label-2", "label-3"]

--- a/tests/scitex_agent_container/config/test__model_chain_validation.py
+++ b/tests/scitex_agent_container/config/test__model_chain_validation.py
@@ -1,0 +1,315 @@
+"""Tests for ``config._model_chain_validation.validate_model_chain`` (ADR-0018 PR A).
+
+Returns a list of error strings (empty = clean). Soft warnings are
+prefixed with ``[warn]``. Errors are operator-targeted — naming the
+offending label, field, and (when applicable) closed set of valid
+values.
+
+AAA markers (TQ002), descriptive names (TQ003), one assert per test
+(TQ007).
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container.config._model_chain_validation import validate_model_chain
+
+# ---------------------------------------------------------------------------
+# Absent / empty / non-dict
+# ---------------------------------------------------------------------------
+
+
+def test_absent_model_block_yields_no_errors():
+    # Arrange / Act — None means key not present in spec.
+    errors = validate_model_chain(None)
+    # Assert
+    assert errors == []
+
+
+def test_non_dict_model_block_yields_typed_error():
+    # Arrange / Act
+    errors = validate_model_chain("garbage")
+    # Assert
+    assert any("spec.model must be a dict" in e for e in errors)
+
+
+def test_empty_dict_model_block_yields_declare_at_least_one_label_error():
+    # Arrange / Act
+    errors = validate_model_chain({})
+    # Assert
+    assert any("at least one label" in e for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# provider — required, must be registered.
+# ---------------------------------------------------------------------------
+
+
+def test_missing_provider_yields_required_field_error():
+    # Arrange
+    block = {"default": {"model_id": "claude-sonnet-4-6"}}
+    # Act
+    errors = validate_model_chain(block)
+    # Assert
+    assert any("spec.model.default.provider is required" in e for e in errors)
+
+
+def test_empty_string_provider_yields_required_field_error():
+    # Arrange
+    block = {"default": {"provider": "", "model_id": "claude-sonnet-4-6"}}
+    # Act
+    errors = validate_model_chain(block)
+    # Assert
+    assert any("spec.model.default.provider is required" in e for e in errors)
+
+
+def test_unknown_provider_yields_known_providers_list():
+    # Arrange — operator typo'd or invented a provider name.
+    block = {"default": {"provider": "myprovider", "model_id": "x"}}
+    # Act
+    errors = validate_model_chain(block)
+    # Assert
+    assert any(
+        "is not a registered provider name" in e and "Known providers" in e
+        for e in errors
+    )
+
+
+def test_known_provider_yields_no_provider_error():
+    # Arrange — anthropic is registered.
+    block = {"default": {"provider": "anthropic", "model_id": "claude-sonnet-4-6"}}
+    # Act
+    errors = validate_model_chain(block)
+    # Assert
+    assert not any("provider" in e and "not a registered" in e for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# model_id — required, non-empty.
+# ---------------------------------------------------------------------------
+
+
+def test_missing_model_id_yields_required_field_error():
+    # Arrange
+    block = {"default": {"provider": "anthropic"}}
+    # Act
+    errors = validate_model_chain(block)
+    # Assert
+    assert any("spec.model.default.model_id is required" in e for e in errors)
+
+
+def test_empty_string_model_id_yields_required_field_error():
+    # Arrange
+    block = {"default": {"provider": "anthropic", "model_id": ""}}
+    # Act
+    errors = validate_model_chain(block)
+    # Assert
+    assert any("spec.model.default.model_id is required" in e for e in errors)
+
+
+def test_non_string_model_id_yields_required_field_error():
+    # Arrange — yaml ``model_id: 42`` (int).
+    block = {"default": {"provider": "anthropic", "model_id": 42}}
+    # Act
+    errors = validate_model_chain(block)
+    # Assert
+    assert any("spec.model.default.model_id is required" in e for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# account XOR api_key — mutual exclusion.
+# ---------------------------------------------------------------------------
+
+
+def test_both_account_and_api_key_set_yields_mutex_error():
+    # Arrange
+    block = {
+        "default": {
+            "provider": "anthropic",
+            "model_id": "claude-sonnet-4-6",
+            "account": "ywatanabe-scitex-ai",
+            "api_key": "$ANTHROPIC_API_KEY",
+        }
+    }
+    # Act
+    errors = validate_model_chain(block)
+    # Assert
+    assert any(
+        "spec.model.default.account" in e
+        and "spec.model.default.api_key" in e
+        and "mutually exclusive" in e
+        for e in errors
+    )
+
+
+def test_neither_account_nor_api_key_set_yields_no_mutex_error():
+    # Arrange — both omitted; falls back to provider registry's
+    # auth_token_env (PR #244 path). Validator is clean on this axis.
+    block = {
+        "default": {
+            "provider": "deepseek",
+            "model_id": "deepseek-v4-pro",
+        }
+    }
+    # Act
+    errors = validate_model_chain(block)
+    # Assert
+    assert not any("mutually exclusive" in e for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# Soft warnings — account on non-Anthropic, literal api_key.
+# ---------------------------------------------------------------------------
+
+
+def test_account_on_non_anthropic_provider_yields_soft_warning():
+    # Arrange — operator copy-pasted account field from a v3 anthropic
+    # spec; deepseek doesn't use OAuth.
+    block = {
+        "default": {
+            "provider": "deepseek",
+            "model_id": "deepseek-v4-pro",
+            "account": "ywatanabe-scitex-ai",
+        }
+    }
+    # Act
+    errors = validate_model_chain(block)
+    # Assert
+    assert any(
+        e.startswith("[warn]") and "account is set on a non-Anthropic" in e
+        for e in errors
+    )
+
+
+def test_account_on_anthropic_provider_yields_no_warning():
+    # Arrange — the intended use case; no warning.
+    block = {
+        "default": {
+            "provider": "anthropic",
+            "model_id": "claude-sonnet-4-6",
+            "account": "ywatanabe-scitex-ai",
+        }
+    }
+    # Act
+    errors = validate_model_chain(block)
+    # Assert
+    assert not any("account is set on a non-Anthropic" in e for e in errors)
+
+
+def test_literal_api_key_yields_soft_secret_warning():
+    # Arrange — operator pasted secret value into spec.yaml.
+    block = {
+        "default": {
+            "provider": "anthropic",
+            "model_id": "claude-sonnet-4-6",
+            "api_key": "sk-ant-literal-paste",
+        }
+    }
+    # Act
+    errors = validate_model_chain(block)
+    # Assert
+    assert any(
+        e.startswith("[warn]") and "secrets in spec.yaml is anti-pattern" in e
+        for e in errors
+    )
+
+
+def test_env_ref_api_key_yields_no_secret_warning():
+    # Arrange — env var ref form; no warning.
+    block = {
+        "default": {
+            "provider": "anthropic",
+            "model_id": "claude-sonnet-4-6",
+            "api_key": "$ANTHROPIC_API_KEY",
+        }
+    }
+    # Act
+    errors = validate_model_chain(block)
+    # Assert
+    assert not any("secrets in spec.yaml" in e for e in errors)
+
+
+def test_dollar_brace_api_key_yields_no_secret_warning():
+    # Arrange — ${VAR} form is also valid.
+    block = {
+        "default": {
+            "provider": "anthropic",
+            "model_id": "claude-sonnet-4-6",
+            "api_key": "${ANTHROPIC_API_KEY}",
+        }
+    }
+    # Act
+    errors = validate_model_chain(block)
+    # Assert
+    assert not any("secrets in spec.yaml" in e for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# Multi-label — errors carry the offending label name.
+# ---------------------------------------------------------------------------
+
+
+def test_multi_label_errors_name_offending_label():
+    # Arrange — label-1 clean, label-2 missing model_id.
+    block = {
+        "label-1": {"provider": "anthropic", "model_id": "claude-sonnet-4-6"},
+        "label-2": {"provider": "xiaomi"},
+    }
+    # Act
+    errors = validate_model_chain(block)
+    # Assert
+    assert any("spec.model.label-2.model_id" in e for e in errors)
+
+
+def test_multi_label_clean_chain_validates_with_no_errors():
+    # Arrange — three valid labels, no warnings.
+    block = {
+        "label-1": {"provider": "anthropic", "model_id": "claude-sonnet-4-6"},
+        "label-2": {"provider": "xiaomi", "model_id": "mimo-v2.5-pro"},
+        "label-3": {"provider": "deepseek", "model_id": "deepseek-v4-pro"},
+    }
+    # Act
+    errors = validate_model_chain(block)
+    # Assert
+    assert errors == []
+
+
+def test_non_dict_label_entry_yields_typed_error():
+    # Arrange — yaml typo: label value is a string.
+    block = {"broken": "not-a-dict"}
+    # Act
+    errors = validate_model_chain(block)
+    # Assert
+    assert any("spec.model.broken must be a mapping" in e for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# Label-ordered iteration — validator visits labels in insertion order.
+# ---------------------------------------------------------------------------
+
+
+def test_label_iteration_preserves_insertion_order_in_error_list():
+    # Arrange — label-1 broken, label-2 broken; label-1's error must
+    # appear before label-2's in the returned list.
+    block = {
+        "label-1": {},  # missing both provider and model_id
+        "label-2": {},
+    }
+    # Act
+    errors = validate_model_chain(block)
+    # Filter to just the per-label provider errors so we know the order.
+    provider_errors = [e for e in errors if "provider is required" in e]
+    # Assert
+    assert provider_errors[0].startswith("spec.model.label-1.")
+
+
+def test_label_iteration_second_label_provider_error_appears_second():
+    # Arrange
+    block = {
+        "label-1": {},
+        "label-2": {},
+    }
+    # Act
+    errors = validate_model_chain(block)
+    provider_errors = [e for e in errors if "provider is required" in e]
+    # Assert
+    assert provider_errors[1].startswith("spec.model.label-2.")


### PR DESCRIPTION
## Summary

ADR-0018 PR A — the first of five staged cuts replacing the Anthropic-centric `spec.claude.*` with `spec.model.<label>.*`, a label-keyed dict where each label is a complete provider config and the dict's insertion order IS the implicit fallback cascade order.

**PR A scope is PURELY ADDITIVE**: schema + parser + validation only. The runtime continues to read `spec.claude.*` via the v3-to-v4 alias the parser populates internally. **No runtime fallback dispatch yet** — that's PR B.

ADR doc (lead-delivered): `/work/.tmp-adr/ADR-0018.md`.

## Schema (operator-locked via Telegram 6816-6832)

```yaml
spec:
  model:
    label-1:
      provider: anthropic         # registry name (PR #244)
      model_id: claude-sonnet-4-6
      account: ywatanabe-scitex-ai    # Anthropic OAuth Max account selector

    label-2:
      provider: xiaomi
      model_id: mimo-v2.5-pro
      api_key: $XIAOMI_API_KEY    # env var substitution

    label-3:
      provider: deepseek
      model_id: deepseek-v4-pro
      api_key: ${DEEPSEEK_API_KEY}     # ${...} form also accepted
```

Field rules:
- `provider` — REQUIRED. Must resolve in `_provider_registry::PROVIDERS`.
- `model_id` — REQUIRED. Non-empty string (renamed from `model` to avoid the outer `spec.model` dict key collision).
- `account` — OPTIONAL. Anthropic-OAuth account selector.
- `api_key` — OPTIONAL. `$VAR` / `${VAR}` / literal (warn) / omitted (registry default).
- `api_key` XOR `account` per label — validator rejects both.
- Single-config case still requires a label key (e.g. `default: {...}`).

## v3 back-compat (no spec breaks)

The parser auto-aliases `spec.claude.*` → `spec.model.legacy.{provider, model_id, account}` and emits a ONE-TIME stderr deprecation warning per agent. v3 specs continue to load + run unchanged because `AgentConfig.claude` is still populated.

`spec.claude` AND `spec.model` both present → validation error (mutex).

## Touched files (6 commits)

- `config/_model_chain_types.py` (NEW) — `ModelLabel` dataclass + `ModelChain` type alias.
- `config/_env_var_substitution.py` (NEW) — `resolve_env_var_ref` / `is_env_var_ref` for `$VAR` / `${VAR}` / literal classification.
- `config/_parsers/_model_chain.py` (NEW) — `parse_model_chain` + v3 alias with one-shot deprecation warning.
- `config/_model_chain_validation.py` (NEW) — per-label validator (required fields + api_key XOR account + soft warns for cross-provider mismatches).
- `config/_types.py` — `AgentConfig.model_chain: ModelChain = {}` field.
- `config/_loaders.py` — calls `parse_model_chain` and passes the result to `AgentConfig`.
- `config/_validation.py` — adds `"model"` to `_KNOWN_SPEC_KEYS` (dict-only — string-form `spec.model` remains the deprecated v2 alias). Calls `validate_model_chain`. Adds the spec.claude / spec.model mutex check.
- `config/__init__.py` — re-exports `ModelLabel`, `ModelChain`, env-var helpers.

## Tests

- `test__model_chain_types.py` — dataclass roundtrips, defaults, immutability.
- `test__env_var_substitution.py` — `$VAR`, `${VAR}`, literal, empty, edge cases.
- `test__model_chain_parser.py` — v4 multi-label + order, v3 alias, both-blocks deferred to validator, malformed shape → defensive degrade.
- `test__model_chain_validation.py` — required fields, unknown provider, api_key XOR account, soft warnings.
- `test__loaders_model_chain.py` (NEW INTEGRATION) — `load_config` produces populated `AgentConfig.model_chain` for v4, single 'legacy' label for v3, empty for neither, validator mutex rejection of v3+v4 both present, v2-string rejection.

Config suite before: ~525 passed; after: 537 passed.

## Staging (per ADR-0018)

- **PR A (THIS)**: schema + parser + validation. No runtime fallback.
- **PR B**: runtime dispatcher (failover on 401/402/429/500-503/530/conn-refused, healing back to label-1 next turn, disable-after-5).
- **PR C**: observability (session.jsonl `provider_used` + `agent_status.current_provider`).
- **PR D**: migration tool (`sac dev migrate-spec-v3-to-v4`) + edit handyman/handyman-mimo/proj-* specs to v4 shape.
- **PR E** (later): drop the v3 alias after fleet migration completes.

## Test plan

- [ ] CI green on this PR.
- [ ] Verify v3 specs (e.g. `examples/agents/deepseek-agent/spec.yaml`) continue to load.
- [ ] Verify deprecation warning fires once per agent at load time for v3 specs.