### PR TITLE
fix(sif:scitex): apt-install libxcb1 + libgl1 + libglib2.0-0 in scitex layer

### DIFF
--- a/src/scitex_agent_container/containers/apptainer-scitex.def
+++ b/src/scitex_agent_container/containers/apptainer-scitex.def
@@ -37,10 +37,21 @@ From: ./sac-base.sif
     export DEBIAN_FRONTEND=noninteractive
 
     # ---- 1. Audio / video system deps ----------------------------------
+    # libxcb1 / libgl1 / libglib2.0-0 are REQUIRED by scitex_cv (cv2):
+    # without libxcb.so.1, ``import scitex`` → ``scitex_cv`` → ``cv2`` raises
+    # ``libxcb.so.1: cannot open shared object file``, which parks every
+    # downstream ripple-wm lane (ripple / gpfa / nt / memory_load — they
+    # all `import scitex` at module load). libgl1 pairs with libxcb to
+    # cover cv2's headless OpenGL probe. libglib2.0-0 is already in the
+    # :base layer (lib-gthread silent-fallback fix, 2026-06-06) but kept
+    # here belt-and-suspenders so a future :base trim cannot resurrect
+    # the silent-fallback path inside :scitex. (Lead a2a 2026-06-08:
+    # SIF rebuild was blocking ALL ripple-wm compute lanes.)
     apt-get update
     apt-get install -y --no-install-recommends \
         ffmpeg \
-        portaudio19-dev
+        portaudio19-dev \
+        libxcb1 libgl1 libglib2.0-0
     rm -rf /var/lib/apt/lists/*
 
     # ---- 2. Python venv + scitex stack ---------------------------------

--- a/tests/scitex_agent_container/containers/test_apptainer_scitex_def_libxcb.py
+++ b/tests/scitex_agent_container/containers/test_apptainer_scitex_def_libxcb.py
@@ -1,0 +1,98 @@
+"""Static contract: ``apptainer-scitex.def`` must apt-install libxcb1 + libgl1
++ libglib2.0-0.
+
+Why these specific packages live in the :scitex layer's %post apt-get:
+
+* ``libxcb1``  — ``import scitex`` pulls in ``scitex_cv`` which imports
+  ``cv2`` which dlopens ``libxcb.so.1`` (cv2's headless GUI shim still
+  links against xcb even with no display). Missing → ``ImportError:
+  libxcb.so.1: cannot open shared object file``. This parked every
+  ripple-wm compute lane (ripple / gpfa / nt / memory_load) until the
+  2026-06-08 SIF rebuild.
+* ``libgl1``   — pairs with libxcb to cover cv2's OpenGL probe; without
+  it cv2 crashes inside ``cv2.imread`` on Spartan compute nodes that
+  lack the mesa-dev runtime.
+* ``libglib2.0-0`` — already in the :base layer (lib-gthread silent-
+  fallback fix, 2026-06-06) but kept here belt-and-suspenders so a
+  future :base trim cannot silently regress the :scitex layer.
+
+This test pins the requirement as code: drop a package from the .def
+and CI yells before the SIF rebuild lands a regression.
+
+TQ002 markers (AAA) per repo convention; one assertion per test (TQ007).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+# Resolve the .def relative to this test file so the test works regardless
+# of the worktree path. tests/scitex_agent_container/containers/ is 3
+# levels below the repo root; .def is at src/scitex_agent_container/
+# containers/apptainer-scitex.def.
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SCITEX_DEF = (
+    _REPO_ROOT
+    / "src"
+    / "scitex_agent_container"
+    / "containers"
+    / "apptainer-scitex.def"
+)
+
+
+@pytest.fixture(scope="module")
+def scitex_def_text() -> str:
+    # Arrange
+    assert _SCITEX_DEF.exists(), f"apptainer-scitex.def missing at {_SCITEX_DEF}"
+    return _SCITEX_DEF.read_text()
+
+
+def _apt_install_block(text: str) -> str:
+    """Return the first ``apt-get install ...`` chunk (joined lines)."""
+    lines = text.splitlines()
+    out: list[str] = []
+    in_block = False
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("apt-get install"):
+            in_block = True
+        if in_block:
+            out.append(stripped.rstrip("\\").strip())
+            if not stripped.endswith("\\"):
+                break
+    return " ".join(out)
+
+
+def test_apt_install_block_lists_libxcb1(scitex_def_text: str) -> None:
+    # Arrange
+    block = _apt_install_block(scitex_def_text)
+    # Act
+    present = "libxcb1" in block.split()
+    # Assert
+    assert present, (
+        f"libxcb1 missing from apt-get install in apptainer-scitex.def:\n{block}"
+    )
+
+
+def test_apt_install_block_lists_libgl1(scitex_def_text: str) -> None:
+    # Arrange
+    block = _apt_install_block(scitex_def_text)
+    # Act
+    present = "libgl1" in block.split()
+    # Assert
+    assert present, (
+        f"libgl1 missing from apt-get install in apptainer-scitex.def:\n{block}"
+    )
+
+
+def test_apt_install_block_lists_libglib2_0_0(scitex_def_text: str) -> None:
+    # Arrange
+    block = _apt_install_block(scitex_def_text)
+    # Act
+    present = "libglib2.0-0" in block.split()
+    # Assert
+    assert present, (
+        f"libglib2.0-0 missing from apt-get install in apptainer-scitex.def:\n{block}"
+    )


### PR DESCRIPTION
## Summary

Without `libxcb.so.1` in the scitex-layer SIF, `import scitex` fails on the `scitex_cv` → `cv2` dlopen probe with `libxcb.so.1: cannot open shared object file`. That single missing apt package parked **every** ripple-wm compute lane (ripple / gpfa / nt / memory_load — all `import scitex` at module load) until the 2026-06-08 SIF rebuild.

This PR adds three packages to the `:scitex` layer's apt-install (`apptainer-scitex.def` §1):

| pkg | why |
|---|---|
| `libxcb1` | cv2's headless GUI shim still links against xcb even with no display attached. |
| `libgl1` | pairs with libxcb to satisfy cv2's OpenGL probe on Spartan compute nodes lacking the mesa-dev runtime. |
| `libglib2.0-0` | already in `:base` (lib-gthread silent-fallback fix, 2026-06-06) but kept here belt-and-suspenders so a future `:base` trim cannot silently regress `:scitex` without surfacing as a build break. |

A new test module (`tests/scitex_agent_container/containers/test_apptainer_scitex_def_libxcb.py`, 3 cases) pins the requirement statically so the next .def trim yells in CI before the SIF rebuild lands a regression.

## Real-world validation

SIF rebuilt + verified on Spartan today (2026-06-08, ~13 min wall):

- Build log: `/data/gpfs/projects/punim2354/ywatanabe/sac-containers/sac-scitex.build-2026-0608-190036.log` (`[wrapper] exit=0`)
- New SIF: `/data/gpfs/projects/punim2354/ywatanabe/sac-containers/sac-scitex.sif.libxcb-2026-0608-190036` (7.0 GB)
- Canonical (`~/.dotfiles/.../sac-scitex/sac-scitex.sif`) now symlinks → libxcb SIF.
- `apptainer exec <new.sif> python -c "import scitex_cv._draw"` → `scitex_cv._draw OK /opt/venv-sac/lib/python3.12/site-packages/scitex_cv/_draw.py`
- `dpkg -l | grep libxcb1` → `libxcb1:amd64 1.15-1ubuntu2`
- `ldconfig -p | grep libxcb.so.1` → `/lib/x86_64-linux-gnu/libxcb.so.1`

## Test plan

- [x] `pytest tests/scitex_agent_container/containers/` — 3/3 green (new pin tests)
- [x] `pytest tests/scitex_agent_container/cli_pkg/test_image_group.py tests/scitex_agent_container/cli_pkg/test__image_source_build.py` — 86/86 green (no image-build regressions)
- [x] Real SIF rebuild on Spartan exits 0 + libxcb1 / libgl1 dpkg-installed + `import scitex_cv._draw` works inside the new SIF
- [ ] CI on PR (auto-merge once green)

Refs: lead a2a 2026-06-08 (ripple-wm fully parked, blocking ALL ripple / gpfa / nt / memory_load compute lanes).