### PR TITLE
fix(_instances): auto-grant <self> -> lead on every agent start (OP-PRIO-1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,11 @@ logs/
 # (CI in docs.yml strips this before committing _sphinx_html/)
 _sphinx_html/.doctrees/
 .worktrees/
+.claude-pending-parked-*/
+worktrees/
+.worktrees-new/
+.tmp-audit/
+.tmp-adr/
+.tmp-tui-driver/
+.promote-*.yaml
+.promote-*.sh

--- a/src/scitex_agent_container/_lifecycle/_provider_tunnel.py
+++ b/src/scitex_agent_container/_lifecycle/_provider_tunnel.py
@@ -1,0 +1,183 @@
+"""Lifecycle glue between agent_start / agent_stop and the TunnelManager.
+
+Operator directive 2026-06-08: an agent whose
+``spec.claude.provider`` resolves to a :class:`TunneledEndpoint`
+needs the local ``ssh -L`` ProxyJump forward up BEFORE the runtime
+constructs its env flags (so ``ANTHROPIC_BASE_URL`` reflects the
+live local bind), and torn down AFTER ``runtime.stop`` (so a final
+heartbeat going through the dying tunnel can still complete).
+
+Lives in its own module to:
+
+* keep ``_start.py`` under the 512-line cap, and
+* expose a single test-friendly seam for the injection (``tunnel_manager_factory``)
+  so the start path stays one straight-line read.
+
+The runtime env flags read the bound port off the AgentConfig
+via the synthetic attribute :attr:`_TUNNEL_LOCAL_PORT_ATTR`. The
+runtime's ``_apptainer_provider.provider_env_flags`` accepts the
+port through a kwarg so the runtime stays state-free; this module
+is where the bound port surfaces from.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+from .._network._tunnel_manager import TunnelManager, TunnelUpError
+from ..config import AgentConfig
+from ..config._provider_types import CustomProvider, RegistryProvider
+from ..config._tunnel_types import TunnelSpec
+from . import _tunnels
+
+# Attribute name on AgentConfig where the bound local port is stashed so
+# downstream consumers can read it without re-querying the registry.
+_TUNNEL_LOCAL_PORT_ATTR = "_sac_tunnel_local_port"
+
+
+def _resolve_tunnel_spec(config: AgentConfig) -> Optional[TunnelSpec]:
+    """Return the :class:`TunnelSpec` for this agent's provider, or ``None``.
+
+    Handles both shapes of the sealed provider union:
+
+    * :class:`CustomProvider` with a :class:`TunneledEndpoint` endpoint.
+    * :class:`RegistryProvider` resolving to a registry entry whose
+      ``endpoint`` carries a ``tunnel`` block (e.g. a
+      ``providers.d/qwen-spartan.yaml`` overlay).
+
+    Returns ``None`` for non-tunneled providers or no provider at all.
+    """
+    claude = getattr(config, "claude", None)
+    provider = getattr(claude, "provider", None) if claude is not None else None
+    if provider is None:
+        return None
+    if isinstance(provider, CustomProvider):
+        from ..config._provider_types import TunneledEndpoint
+
+        if isinstance(provider.endpoint, TunneledEndpoint):
+            return provider.endpoint.tunnel
+        return None
+    if isinstance(provider, RegistryProvider):
+        from ..config._provider_registry_d import load_merged_registry
+        from ..config._provider_resolve import _tunnel_spec_from_dict
+
+        registry = load_merged_registry()
+        entry = registry.get(provider.name)
+        if entry is None:
+            return None
+        endpoint = entry.get("endpoint")
+        if isinstance(endpoint, dict) and "tunnel" in endpoint:
+            return _tunnel_spec_from_dict(endpoint["tunnel"])
+    return None
+
+
+def _default_state_dir() -> Path:
+    """Return the sac state-dir on this host. Mirrors the layout used elsewhere."""
+    return Path.home() / ".scitex" / "agent-container"
+
+
+def _default_tunnel_manager_factory(
+    spec: TunnelSpec, agent_name: str, state_dir: Path
+) -> TunnelManager:
+    """Construct a real :class:`TunnelManager` with the production supervisor cmd."""
+    return TunnelManager(spec=spec, agent_name=agent_name, state_dir=state_dir)
+
+
+def maybe_start_provider_tunnel(
+    config: AgentConfig,
+    *,
+    tunnel_manager_factory: Optional[
+        Callable[[TunnelSpec, str, Path], TunnelManager]
+    ] = None,
+    state_dir: Optional[Path] = None,
+) -> Optional[int]:
+    """If the provider is tunneled, bring the tunnel up; return bound local_port.
+
+    Returns ``None`` when the agent's provider is not tunneled (the
+    normal case). For a tunneled provider:
+
+    1. Resolve the :class:`TunnelSpec` from the provider union.
+    2. Build a :class:`TunnelManager` via the (injectable) factory.
+    3. Call ``mgr.up()``; on success stash the bound port on the
+       AgentConfig (so the runtime can read it without re-resolving)
+       and register the manager so :func:`stop_provider_tunnel` can
+       find it.
+    4. On :class:`TunnelUpError`, re-raise as :class:`RuntimeError`
+       with the original message preserved.
+
+    Args:
+        config: The agent config; the resolved provider lives at
+            ``config.claude.provider``.
+        tunnel_manager_factory: OPTIONAL injectable factory. Default
+            produces a real :class:`TunnelManager`. Tests pass a
+            factory that hands back a fake manager whose ``up()``
+            opens a listening socket without spawning ssh.
+        state_dir: OPTIONAL sac state directory. Default is
+            ``~/.scitex/agent-container``.
+
+    Raises:
+        RuntimeError: When the tunnel fails to come up; sac aborts
+            the start instead of building the runtime against an
+            empty ``ANTHROPIC_BASE_URL``.
+    """
+    tunnel = _resolve_tunnel_spec(config)
+    if tunnel is None:
+        return None
+    factory = tunnel_manager_factory or _default_tunnel_manager_factory
+    sdir = state_dir if state_dir is not None else _default_state_dir()
+    mgr = factory(tunnel, config.name, sdir)
+    try:
+        port = mgr.up()
+    except TunnelUpError as exc:
+        # Re-raise as RuntimeError so the start path's standard error
+        # surface (RuntimeError → non-zero CLI exit + clear stderr)
+        # handles it. The TunnelUpError chain is preserved via __cause__.
+        raise RuntimeError(
+            f"agent '{config.name}': provider tunnel failed to come up: {exc}"
+        ) from exc
+    setattr(config, _TUNNEL_LOCAL_PORT_ATTR, port)
+    _tunnels.register(config.name, mgr)
+    return port
+
+
+def stop_provider_tunnel(config: AgentConfig) -> None:
+    """Tear down the agent's provider tunnel if one is active. Idempotent.
+
+    Looks up the manager in the process-local registry first
+    (covers the same-process start+stop flow). If absent (cross-process
+    stop, e.g. operator running ``sac agents stop`` from a different
+    shell than the one that started the agent), constructs a fresh
+    manager and lets it read the pidfile to find the supervisor.
+    """
+    tunnel = _resolve_tunnel_spec(config)
+    if tunnel is None:
+        return
+    mgr = _tunnels.get(config.name)
+    if mgr is None:
+        # Cross-process recovery — pidfile carries the supervisor pid.
+        mgr = TunnelManager(
+            spec=tunnel,
+            agent_name=config.name,
+            state_dir=_default_state_dir(),
+        )
+    try:
+        mgr.down()
+    finally:
+        _tunnels.discard(config.name)
+
+
+def get_tunnel_local_port(config: Any) -> Optional[int]:
+    """Read the bound local port off the AgentConfig (set by start_provider_tunnel).
+
+    Accepts ``Any`` so test stubs (SimpleNamespace, real configs) all
+    work. Returns ``None`` when no tunnel is active on this agent.
+    """
+    return getattr(config, _TUNNEL_LOCAL_PORT_ATTR, None)
+
+
+__all__ = [
+    "maybe_start_provider_tunnel",
+    "stop_provider_tunnel",
+    "get_tunnel_local_port",
+]

--- a/src/scitex_agent_container/_lifecycle/_start_helpers.py
+++ b/src/scitex_agent_container/_lifecycle/_start_helpers.py
@@ -1,0 +1,179 @@
+"""Helpers extracted from :mod:`_lifecycle._start`.
+
+Split out so :func:`agent_start` itself stays within the project's
+512-line cap. No behaviour changes — every helper is verbatim from
+the historical ``_start.py``. The orchestrator imports back through
+the public names below.
+
+Surface (re-exported by ``_start.py``):
+
+* :func:`verify_real_liveness` — third-signal liveness probe.
+* :func:`resolve_strict_drift` — ``--strict-drift`` / env resolution.
+* :func:`rotate_to_healthy_account` — CREDS-PHASE1 rotation.
+* :func:`check_spec_source_drift_at_launch` — git-drift launch guard.
+"""
+
+from __future__ import annotations
+
+import sys
+import traceback
+from typing import Any, Callable
+
+from ..config import AgentConfig
+
+
+def verify_real_liveness(
+    config: AgentConfig,
+    runtime,
+    *,
+    instances_oracle: Callable[[], list[dict]] | None = None,
+) -> bool:
+    """Return True iff the agent is *demonstrably* running on this host.
+
+    The pre-fix call site treated ``registry.exists(name) and
+    runtime.is_running(config)`` as the already-running signal. Both
+    are necessary but not sufficient:
+
+      * ``registry.exists`` is a JSON file on disk — a forced ``rm``,
+        a stale entry from a prior boot, or a crash-during-write leaves
+        the file behind even though no agent is running.
+      * ``runtime.is_running`` checks the per-runtime PID file with
+        ``os.kill(pid, 0)`` — on a Linux PID-wraparound the same pid
+        can belong to a completely unrelated process and the probe
+        returns True.
+
+    Either of those false positives causes the no-op branch in
+    :func:`agent_start` to swallow a real start request silently and
+    return rc=0. The cross-host ``instances`` table is the third
+    independent signal — it is written by ``record_local_instance``
+    inside the *real* start path and removed by ``agent_stop`` /
+    ``cleanup_stale``. We require an active row before treating the
+    agent as already-running. If the row is absent, the registry/PID
+    pair is inconsistent → fall through to a real start instead of
+    the silent no-op.
+
+    The ``instances_oracle`` seam is the no-mocks knob for tests; it
+    defaults to a host-unfiltered :func:`state_db.list_active_instances`
+    call (we want ANY active row for the name, not just rows on the
+    current host — handover may have moved it).
+    """
+    if instances_oracle is None:
+        from .._state.state_db import list_active_instances as _default
+
+        def instances_oracle():  # type: ignore[no-redef]
+            # Explicit host=None so the call is unambiguous and the
+            # fixture-isolated test reads through the same module.
+            return _default(host=None)
+
+    try:
+        rows = instances_oracle()
+    except Exception:
+        # stx-allow: fallback (reason: a missing/locked state.db must
+        # not block the start path; degrade to "no liveness evidence"
+        # which causes the caller to launch fresh rather than silently
+        # no-op)
+        return False
+    for row in rows or ():
+        if row.get("name") == config.name:
+            return True
+    return False
+
+
+def resolve_strict_drift(strict_drift: bool | None) -> bool:
+    """Resolve effective strict-drift mode (arg wins, else env).
+
+    ``strict_drift=True/False`` from ``--strict-drift`` takes priority.
+    ``None`` falls back to ``SAC_STRICT_DRIFT`` (``1``/``true``/``yes``
+    → strict). Read through the sac env helper so either prefix works.
+    """
+    if strict_drift is not None:
+        return strict_drift
+    from .._env import getenv as _sac_env
+
+    raw = (_sac_env("STRICT_DRIFT", "") or "").strip().lower()
+    return raw in ("1", "true", "yes", "on")
+
+
+def rotate_to_healthy_account(
+    config: AgentConfig,
+    *,
+    log_stream: Any = None,
+) -> None:
+    """Rotate ``config.claude.account`` to a healthy stored account.
+
+    CREDS-PHASE1 wiring. Only acts on PINNED agents
+    (``spec.claude.account`` non-empty). For an unpinned agent the
+    runtime continues to bind the host's live ``.credentials.json``
+    untouched.
+
+    On a pinned agent:
+
+    * If the pinned snapshot is healthy → no-op (config unchanged).
+    * If the pinned snapshot is EXPIRED/ABSENT but another stored
+      account has a fresh snapshot → ``config.claude.account`` is
+      mutated to that account and a one-line rotation notice is
+      printed to ``log_stream`` (default ``sys.stderr``). The runtime
+      then binds that account's snapshot ``:rw`` directly via
+      :func:`runtimes._apptainer_creds.resolve_cred_file` (operator
+      #15 — the prior boot-copy path was the root cause of the
+      2026-06-01 fleet outage; refreshes now write back to the
+      snapshot itself, never expiring).
+    * If NOTHING is healthy → :class:`_creds.NoHealthyAccountError`
+      propagates (fail loud, no silent stale-token launch). Agent is
+      NOT started.
+
+    See :mod:`scitex_agent_container._creds._pick_healthy` for the
+    health model — non-expired snapshot = healthy. Cap-induced 429s
+    still surface from claude in-turn; the picker only avoids
+    known-stale auth at boot.
+    """
+    pinned = getattr(getattr(config, "claude", None), "account", "") or ""
+    if not pinned:
+        return  # unpinned agent — host live OAuth, untouched.
+
+    from .._creds import pick_healthy_account
+
+    picked = pick_healthy_account(pinned)
+    if picked == pinned:
+        return  # pinned is healthy — no rotation, no log line.
+
+    config.claude.account = picked
+    stream = log_stream if log_stream is not None else sys.stderr
+    print(
+        f"[sac:creds] agent '{config.name}' rotated account: "
+        f"{pinned!r} -> {picked!r} (pinned snapshot unhealthy; "
+        f"rotated to the first healthy stored account)",
+        file=stream,
+    )
+
+
+def check_spec_source_drift_at_launch(
+    config_path: str, agent_name: str, strict_drift: bool | None
+) -> None:
+    """Run the launch-time drift check; warn loud (or block if strict).
+
+    Fully guarded: the underlying check never raises except the
+    deliberate strict-mode :class:`SpecSourceDriftError`. We let that
+    propagate (the CLI / caller turns it into a non-zero exit); any
+    other unexpected failure here is swallowed so a launch is never
+    crashed by the drift guard.
+    """
+    from .._drift import SpecSourceDriftError, warn_if_spec_source_drifted
+
+    strict = resolve_strict_drift(strict_drift)
+    try:
+        warn_if_spec_source_drifted(config_path, agent=agent_name, strict=strict)
+    except SpecSourceDriftError:
+        # Deliberate strict-mode block — propagate so the caller exits
+        # non-zero. This is the ONE thing this guard is allowed to raise.
+        raise
+    except Exception:  # stx-allow: fallback (reason: the drift guard must NEVER crash a launch; any unexpected error degrades to "no check ran" and the agent proceeds)
+        traceback.print_exc()
+
+
+__all__ = [
+    "verify_real_liveness",
+    "resolve_strict_drift",
+    "rotate_to_healthy_account",
+    "check_spec_source_drift_at_launch",
+]

--- a/src/scitex_agent_container/_lifecycle/_tunnels.py
+++ b/src/scitex_agent_container/_lifecycle/_tunnels.py
@@ -1,0 +1,54 @@
+"""Process-local registry of active :class:`TunnelManager` instances.
+
+The lifecycle wiring needs to share a TunnelManager between
+:func:`agent_start` (which calls ``mgr.up()`` and stores the bound
+port for the runtime to inject as ``ANTHROPIC_BASE_URL``) and
+:func:`agent_stop` (which calls ``mgr.down()`` to tear the supervisor
+down). The state.db ``instances`` row is the canonical cross-process
+"is this agent alive" record, but the TunnelManager Python object
+itself can't be persisted there — the supervisor pid IS persisted by
+the manager via its own pidfile, but the manager's in-memory
+``subprocess.Popen`` handle is process-local.
+
+This module owns the process-local registry. It's tiny, but lives in
+its own file so the import surface is explicit and tests can clear
+state without poking at private module state.
+
+Cross-process recovery (agent stops in a different sac CLI invocation
+than the one that started it) is handled by the pidfile path on disk:
+:class:`TunnelManager.down` reads the pidfile when no Popen handle is
+available, signals the supervisor, and removes the pidfile. The
+in-memory registry is just an optimization for same-process flows.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+from .._network._tunnel_manager import TunnelManager
+
+# Module-level dict keyed by agent name; one tunnel per agent at a time.
+_ACTIVE: Dict[str, TunnelManager] = {}
+
+
+def register(name: str, manager: TunnelManager) -> None:
+    """Record an active tunnel manager so :func:`get` can recover it."""
+    _ACTIVE[name] = manager
+
+
+def get(name: str) -> Optional[TunnelManager]:
+    """Return the active manager for ``name``, or ``None`` if not registered."""
+    return _ACTIVE.get(name)
+
+
+def discard(name: str) -> None:
+    """Drop the registry entry for ``name``. Idempotent — missing is OK."""
+    _ACTIVE.pop(name, None)
+
+
+def clear() -> None:
+    """Wipe the entire registry. Used by tests to isolate cases."""
+    _ACTIVE.clear()
+
+
+__all__ = ["register", "get", "discard", "clear"]

--- a/src/scitex_agent_container/_network/_tunnel_manager.py
+++ b/src/scitex_agent_container/_network/_tunnel_manager.py
@@ -1,0 +1,349 @@
+"""SSH ProxyJump tunnel manager for the apptainer provider lifecycle.
+
+Operator directive 2026-06-08: an agent whose
+``spec.claude.provider.endpoint`` is a :class:`TunneledEndpoint` must
+stand up a local ``ssh -L`` forward at agent-start so the SDK can
+talk to the provider through a stable ``http://localhost:<port>``
+even though the upstream endpoint is only reachable through an
+HPC-style ProxyJump bastion.
+
+The manager owns the lifecycle:
+
+* :meth:`TunnelManager.up` allocates a local port (ephemeral when the
+  spec didn't pin one), spawns the supervisor child, writes a pidfile,
+  polls the local port until a TCP connect succeeds, and returns the
+  bound port. Polling closes a race where the SDK would otherwise
+  try to talk to a still-binding tunnel and see a connection-refused.
+
+* :meth:`TunnelManager.down` SIGTERMs the supervisor with a 5-second
+  grace window, escalates to SIGKILL if needed, and removes the
+  pidfile. Idempotent — calling it twice is a no-op the second time.
+
+* :meth:`TunnelManager.is_alive` reads the pidfile, ``os.kill(pid,
+  0)``-probes the supervisor, and TCP-connects to the local port to
+  confirm the forward is actually up. All three must agree.
+
+Test seam — ``supervisor_cmd``
+------------------------------
+
+The supervisor command defaults to ``[sys.executable, "-m",
+"scitex_agent_container._network._tunnel_supervisor"]`` so the manager
+spawns the real ssh wrapper in production. Tests pass a fake
+``supervisor_cmd`` argv that opens a listening socket on the requested
+local port (and never invokes ssh), exercising the bind-and-poll loop
+without a real ssh setup.
+
+Fail-loud contract
+------------------
+
+* Spec missing required fields (``jump_host``, ``target_host``,
+  ``remote_port``) — :meth:`TunnelManager.up` raises
+  :class:`TunnelUpError` BEFORE spawning anything.
+* Supervisor never binds the requested port within ``wait_timeout_s``
+  — SIGTERM the supervisor, raise :class:`TunnelUpError` with the
+  concrete ``ssh -J <jump> <target>`` recipe so the operator can
+  reproduce the failure outside sac.
+* Pidfile / state-dir IO errors propagate (no silent skip); a stuck
+  filesystem must not let sac believe a tunnel is up when it isn't.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Optional
+
+from ..config._tunnel_types import TunnelSpec
+
+
+class TunnelUpError(RuntimeError):
+    """Raised when the local forward fails to become reachable in time.
+
+    The message embeds the operator-actionable reproducer recipe
+    (``ssh -J <jump> <target>``) so the operator can verify the
+    underlying path works without sac in the loop.
+    """
+
+
+_PROBE_INTERVAL_S = 0.2  # 200ms — fast enough for a healthy bind, gentle on CPU.
+_SIGKILL_GRACE_S = 5.0  # SIGTERM → SIGKILL escalation window.
+
+
+def _pick_ephemeral_port() -> int:
+    """Bind to port 0, read what the OS picked, release the socket.
+
+    The narrow race between close and the supervisor binding is
+    accepted: the supervisor immediately re-binds the same port, and
+    on a healthy host the chance of collision in that microsecond is
+    negligible. The alternative (passing the bound fd to the
+    supervisor) would require an `ssh -L` extension that doesn't
+    exist.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _tcp_connect_ok(port: int, host: str = "127.0.0.1") -> bool:
+    """Best-effort: TCP-connect to ``host:port`` with a short timeout."""
+    try:
+        with socket.create_connection((host, port), timeout=0.5):
+            return True
+    except OSError:
+        # The supervisor isn't bound yet; not an error worth raising,
+        # just a "not ready" data point for the poll loop.
+        return False
+
+
+def _default_supervisor_cmd() -> list[str]:
+    """Return the supervisor argv prefix used in production."""
+    return [
+        sys.executable,
+        "-m",
+        "scitex_agent_container._network._tunnel_supervisor",
+    ]
+
+
+def _validate_spec(spec: TunnelSpec) -> None:
+    """Loud-reject an incomplete :class:`TunnelSpec` before spawning anything."""
+    if not spec.jump_host:
+        raise TunnelUpError("TunnelSpec.jump_host is required and must be non-empty.")
+    if not spec.target_host:
+        raise TunnelUpError("TunnelSpec.target_host is required and must be non-empty.")
+    if not spec.remote_port or spec.remote_port < 1 or spec.remote_port > 65535:
+        raise TunnelUpError(
+            f"TunnelSpec.remote_port must be 1..65535, got {spec.remote_port!r}."
+        )
+
+
+def _read_pid(pidfile: Path) -> Optional[int]:
+    """Read a pidfile or return None on any failure (file gone, garbage)."""
+    try:
+        text = pidfile.read_text().strip()
+    except OSError:
+        return None
+    try:
+        return int(text)
+    except ValueError:
+        return None
+
+
+def _pid_alive(pid: int) -> bool:
+    """``os.kill(pid, 0)`` probe — True iff the process exists."""
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Process exists but is owned by a different uid — still alive.
+        return True
+    return True
+
+
+class TunnelManager:
+    """Lifecycle owner for one agent's SSH ProxyJump tunnel."""
+
+    def __init__(
+        self,
+        spec: TunnelSpec,
+        agent_name: str,
+        state_dir: Path,
+        supervisor_cmd: Optional[list[str]] = None,
+    ) -> None:
+        """Construct the manager (no side effects until :meth:`up`).
+
+        Args:
+            spec: The :class:`TunnelSpec` from the parsed
+                provider endpoint. Validated lazily at :meth:`up`
+                time so the manager can be constructed even when the
+                operator is iterating on a partial spec via tests.
+            agent_name: Used to name the pidfile so two agents with
+                overlapping tunnels don't clobber each other's state.
+            state_dir: The base state directory for sac on this host.
+                The manager writes the pidfile to ``<state_dir>/
+                tunnels/<agent_name>.pid``.
+            supervisor_cmd: OPTIONAL argv prefix to spawn the
+                supervisor. Default = ``[sys.executable, "-m",
+                "scitex_agent_container._network._tunnel_supervisor"]``.
+                Tests pass a fake here so the manager logic can be
+                exercised without a real ssh setup.
+        """
+        self.spec = spec
+        self.agent_name = agent_name
+        self.state_dir = state_dir
+        self._supervisor_cmd = (
+            list(supervisor_cmd)
+            if supervisor_cmd is not None
+            else _default_supervisor_cmd()
+        )
+        self._local_port: int = spec.local_port if spec.local_port > 0 else 0
+        self._proc: Optional[subprocess.Popen] = None
+
+    @property
+    def local_port(self) -> int:
+        """Return the local-bound port. ``0`` before :meth:`up` runs."""
+        return self._local_port
+
+    @property
+    def pidfile(self) -> Path:
+        """Resolved pidfile path under ``state_dir/tunnels/<agent>.pid``."""
+        return self.state_dir / "tunnels" / f"{self.agent_name}.pid"
+
+    def up(self) -> int:
+        """Stand up the tunnel; return the bound local port.
+
+        Pidfile contents are written AFTER the supervisor is spawned
+        so a stale file from a previous run never confuses a fresh
+        boot. The poll loop closes the race where the SDK would
+        otherwise see a connection-refused mid-boot.
+
+        Raises:
+            TunnelUpError: Spec incomplete; supervisor exits before
+                binding; bind never succeeds within
+                ``spec.wait_timeout_s``. The error message includes
+                the ``ssh -J <jump> <target>`` recipe.
+        """
+        _validate_spec(self.spec)
+
+        if self._local_port <= 0:
+            self._local_port = _pick_ephemeral_port()
+
+        # Resolve & build the supervisor argv. The supervisor accepts
+        # the same flags the production module declares; tests pass a
+        # fake that ignores the flags but accepts the same surface so
+        # the manager stays seam-honest.
+        argv = list(self._supervisor_cmd) + [
+            "--jump",
+            self.spec.jump_host,
+            "--target",
+            self.spec.target_host,
+            "--remote-port",
+            str(self.spec.remote_port),
+            "--local-port",
+            str(self._local_port),
+            "--backoff",
+            str(self.spec.respawn_backoff_s),
+        ]
+        for tok in self.spec.ssh_opts or []:
+            argv.extend(["--ssh-opt", tok])
+
+        # Make sure the state dir exists; mkdir parents idempotent.
+        self.pidfile.parent.mkdir(parents=True, exist_ok=True)
+
+        proc = subprocess.Popen(argv)
+        self._proc = proc
+        # Write the pidfile after spawn so the path is always coherent
+        # with a live supervisor (or absent when supervisor failed to
+        # start).
+        self.pidfile.write_text(str(proc.pid))
+
+        deadline = time.monotonic() + max(1, self.spec.wait_timeout_s)
+        while time.monotonic() < deadline:
+            # Supervisor died before binding — clean up and fail loud.
+            if proc.poll() is not None:
+                rc = proc.returncode
+                self._cleanup_pidfile()
+                raise TunnelUpError(
+                    f"tunnel supervisor exited rc={rc} before binding "
+                    f"localhost:{self._local_port}. Reproduce: "
+                    f"ssh -J {self.spec.jump_host} -p {self.spec.remote_port} "
+                    f"{self.spec.target_host}"
+                )
+            if _tcp_connect_ok(self._local_port):
+                return self._local_port
+            time.sleep(_PROBE_INTERVAL_S)
+
+        # Timeout — SIGTERM, clean up, raise. The supervisor's own
+        # SIGTERM handler will forward to ssh and exit 0.
+        self._signal_supervisor(signal.SIGTERM)
+        self._cleanup_pidfile()
+        raise TunnelUpError(
+            f"tunnel did not bind localhost:{self._local_port} within "
+            f"{self.spec.wait_timeout_s}s. Reproduce: "
+            f"ssh -J {self.spec.jump_host} -p {self.spec.remote_port} "
+            f"{self.spec.target_host}"
+        )
+
+    def down(self) -> None:
+        """SIGTERM the supervisor with a SIGKILL escalation. Idempotent."""
+        proc = self._proc
+        pid = None
+        if proc is not None and proc.poll() is None:
+            pid = proc.pid
+        else:
+            pid = _read_pid(self.pidfile)
+        if pid is None:
+            self._cleanup_pidfile()
+            return
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except ProcessLookupError:
+            self._cleanup_pidfile()
+            return
+        # Poll for clean exit; escalate to SIGKILL on grace expiry.
+        deadline = time.monotonic() + _SIGKILL_GRACE_S
+        while time.monotonic() < deadline:
+            if not _pid_alive(pid):
+                break
+            time.sleep(0.1)
+        else:
+            try:
+                os.kill(pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+        # Reap the child if it's our own subprocess; otherwise let
+        # the parent reap (we held only a pidfile reference).
+        if proc is not None:
+            try:
+                proc.wait(timeout=1.0)
+            except subprocess.TimeoutExpired:
+                pass
+        self._proc = None
+        self._cleanup_pidfile()
+
+    def is_alive(self) -> bool:
+        """True iff pidfile exists AND pid responds AND port accepts connects."""
+        pid = _read_pid(self.pidfile)
+        if pid is None:
+            return False
+        if not _pid_alive(pid):
+            return False
+        if not self._local_port:
+            return False
+        return _tcp_connect_ok(self._local_port)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _signal_supervisor(self, sig: int) -> None:
+        """Best-effort signal — ProcessLookupError is silently OK."""
+        proc = self._proc
+        if proc is None:
+            pid = _read_pid(self.pidfile)
+            if pid is None:
+                return
+            try:
+                os.kill(pid, sig)
+            except ProcessLookupError:
+                return
+            return
+        try:
+            proc.send_signal(sig)
+        except ProcessLookupError:
+            return
+
+    def _cleanup_pidfile(self) -> None:
+        """Remove the pidfile if present. Silent on missing."""
+        try:
+            self.pidfile.unlink()
+        except FileNotFoundError:
+            return
+
+
+__all__ = ["TunnelManager", "TunnelUpError"]

--- a/src/scitex_agent_container/_network/_tunnel_supervisor.py
+++ b/src/scitex_agent_container/_network/_tunnel_supervisor.py
@@ -1,0 +1,161 @@
+"""SSH ProxyJump supervisor — keeps an ``ssh -L`` forward alive.
+
+Spawned as a child process by :class:`TunnelManager.up` to keep an
+``ssh -N -L <local>:localhost:<remote> -J <jump> <target>`` tunnel
+alive for the lifetime of an agent. Wrapping the ssh invocation in a
+supervisor lets us:
+
+* Respawn on disconnect — a transient bastion drop doesn't strand the
+  agent on a dead forward.
+* Log every spawn / exit with a timestamp + return code to stderr so
+  the operator can diagnose a permanent failure via the agent's
+  stdout.log without re-running anything.
+* Honour SIGTERM cleanly — sac's stop path SIGTERMs the supervisor,
+  which forwards the signal to the ssh child and exits 0 instead of
+  respawning.
+
+The supervisor is intentionally a separate ``__main__`` module so the
+:class:`TunnelManager` can pass ``[sys.executable, "-m", ...]`` as the
+default supervisor argv but tests can substitute a one-liner that
+doesn't require real ssh (e.g. a fake that just opens a listening
+socket and selects forever).
+
+Fixed ssh options (always set, before any operator overrides)
+-------------------------------------------------------------
+
+* ``-N``                                 — no remote command.
+* ``-o ServerAliveInterval=30``          — keepalive cadence.
+* ``-o ServerAliveCountMax=3``           — disconnect after 3 misses.
+* ``-o ExitOnForwardFailure=yes``        — fail fast if the bind dies.
+* ``-o BatchMode=yes``                   — no interactive prompts.
+
+Operator ``ssh_opts`` (from :class:`TunnelSpec.ssh_opts`) are appended
+verbatim AFTER these so a later ``-o`` override wins (per ssh's
+last-wins semantics).
+"""
+
+from __future__ import annotations
+
+import argparse
+import signal
+import subprocess
+import sys
+import time
+
+
+def _now() -> str:
+    """ISO-ish wall-clock stamp for the supervisor log lines."""
+    return time.strftime("%Y-%m-%dT%H:%M:%S%z", time.localtime())
+
+
+def _log(stream, msg: str) -> None:
+    """Write one supervisor log line with a leading timestamp + tag."""
+    print(f"[sac:tunnel-supervisor {_now()}] {msg}", file=stream, flush=True)
+
+
+def _build_ssh_argv(args: argparse.Namespace) -> list[str]:
+    """Compose the ``ssh`` argv from the parsed supervisor flags."""
+    argv = [
+        "ssh",
+        "-N",
+        "-L",
+        f"{args.local_port}:localhost:{args.remote_port}",
+        "-J",
+        args.jump,
+        "-o",
+        "ServerAliveInterval=30",
+        "-o",
+        "ServerAliveCountMax=3",
+        "-o",
+        "ExitOnForwardFailure=yes",
+        "-o",
+        "BatchMode=yes",
+        args.target,
+    ]
+    if args.ssh_opt:
+        argv.extend(args.ssh_opt)
+    return argv
+
+
+def _parse_argv(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        prog="python -m scitex_agent_container._network._tunnel_supervisor",
+        description="Keep an ssh -L ProxyJump tunnel alive.",
+    )
+    p.add_argument("--jump", required=True, help="ssh -J jump host alias.")
+    p.add_argument("--target", required=True, help="ssh target host (after the jump).")
+    p.add_argument(
+        "--remote-port", required=True, type=int, help="Port on the target host."
+    )
+    p.add_argument("--local-port", required=True, type=int, help="Local bind port.")
+    p.add_argument(
+        "--backoff",
+        type=float,
+        default=2.0,
+        help="Sleep seconds between respawns (default 2).",
+    )
+    p.add_argument(
+        "--ssh-opt",
+        action="append",
+        default=[],
+        help="Extra ssh argv tokens, appended after the fixed -o options.",
+    )
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Supervisor entry point. Respawns ssh until SIGTERM, returns 0 on clean exit."""
+    args = _parse_argv(argv)
+    stderr = sys.stderr
+
+    # State shared with the SIGTERM handler so we can forward the
+    # signal to the ssh child and exit cleanly without respawning.
+    state: dict = {"child": None, "shutting_down": False}
+
+    def _on_sigterm(signum, frame):
+        """SIGTERM → forward to ssh child, mark shutdown, exit on next loop."""
+        state["shutting_down"] = True
+        child = state.get("child")
+        if child is not None and child.poll() is None:
+            _log(stderr, f"SIGTERM received; forwarding to ssh pid={child.pid}")
+            try:
+                child.terminate()
+            except (ProcessLookupError, OSError) as exc:
+                _log(stderr, f"could not signal ssh child: {exc!r}")
+
+    signal.signal(signal.SIGTERM, _on_sigterm)
+    signal.signal(signal.SIGINT, _on_sigterm)
+
+    _log(
+        stderr,
+        f"starting supervisor: jump={args.jump!r} target={args.target!r} "
+        f"local_port={args.local_port} remote_port={args.remote_port} "
+        f"backoff={args.backoff}",
+    )
+
+    while not state["shutting_down"]:
+        ssh_argv = _build_ssh_argv(args)
+        _log(stderr, f"spawning ssh argv={ssh_argv}")
+        try:
+            child = subprocess.Popen(ssh_argv)
+        except FileNotFoundError as exc:
+            # ssh binary missing — bail loudly; respawning forever
+            # would just spin the CPU with the same error.
+            _log(stderr, f"ssh binary not found ({exc}); aborting supervisor")
+            return 127
+        state["child"] = child
+        rc = child.wait()
+        state["child"] = None
+        _log(stderr, f"ssh child exited rc={rc}")
+        if state["shutting_down"]:
+            _log(stderr, "shutdown flag set; exiting supervisor cleanly")
+            return 0
+        # Respawn after backoff so a transient bastion drop doesn't
+        # silently strand the agent. Operators see one log line per
+        # respawn so a permanent failure is visible.
+        time.sleep(args.backoff)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/src/scitex_agent_container/a2a/_card_model.py
+++ b/src/scitex_agent_container/a2a/_card_model.py
@@ -1,0 +1,100 @@
+"""Model-resolution helper for the AgentCard projection.
+
+Lead directive 431365c (2026-06-08): the AgentCard surface MUST read
+the resolved model id, not just ``spec.claude.model``. For provider
+agents whose ``spec.claude.model`` is intentionally empty (the
+operator wants to inherit the registry's default_model or override
+it via Form B), the card was previously stuck showing ``null`` even
+though the SDK was actually talking to a concrete model id. That made
+the card useless for fleet-wide model-routing and observability.
+
+This module owns the resolution chain. Kept separate from
+``_card.py`` so the projection module stays under the 512-line cap.
+
+Precedence chain (highest wins)
+-------------------------------
+
+  1. ``spec.claude.provider.model`` — Form C (custom) explicit
+     model id in the spec YAML.
+  2. ``spec.claude.provider.model`` for Form B (registry-name +
+     override). Same key, different parent dict.
+  3. Registry entry's ``default_model`` (for Form A bare-string and
+     Form B without override). Looked up via the merged
+     ``built-in + providers.d/`` registry so operator overlays
+     are honoured.
+  4. ``spec.claude.model`` — back-compat for non-provider agents
+     and the legacy ``{base_url, auth_token_env}`` dict shape
+     (which has no model field of its own).
+  5. ``spec.model`` — v2 legacy fall-through.
+
+Returns ``None`` when no step produces a model id. The card surfaces
+``None`` as-is so a client can tell "no model declared" from
+"model = <id>".
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def resolve_card_model(spec: dict[str, Any]) -> str | None:
+    """Return the model id the operator's agent is actually running.
+
+    See the module docstring for the precedence chain. The function
+    NEVER raises — a malformed registry overlay or unexpected dict
+    shape degrades to "no model" and the next chain step takes over.
+    The card is a best-effort observability surface; crashing the
+    projection on a bad overlay would make the entire ``sac listen``
+    AgentCard endpoint unavailable.
+    """
+    claude = spec.get("claude") or {}
+    provider_block = claude.get("provider")
+    # Steps 1 & 2 — explicit model on a dict-shape provider.
+    if isinstance(provider_block, dict):
+        explicit = provider_block.get("model")
+        if isinstance(explicit, str) and explicit:
+            return explicit
+    # Step 3 — registry default for bare-string or Form B name without override.
+    registry_name: str | None = None
+    if isinstance(provider_block, str):
+        registry_name = provider_block
+    elif isinstance(provider_block, dict) and isinstance(
+        provider_block.get("name"), str
+    ):
+        registry_name = provider_block.get("name")
+    if registry_name:
+        entry = _safe_registry_entry(registry_name)
+        if entry is not None:
+            default = entry.get("default_model")
+            if isinstance(default, str) and default:
+                return default
+    # Step 4 — spec.claude.model (v3 fallback).
+    claude_model = claude.get("model")
+    if isinstance(claude_model, str) and claude_model:
+        return claude_model
+    # Step 5 — top-level spec.model (v2 fallback).
+    spec_model = spec.get("model")
+    if isinstance(spec_model, str) and spec_model:
+        return spec_model
+    return None
+
+
+def _safe_registry_entry(name: str) -> dict[str, Any] | None:
+    """Load the merged registry and return one entry, swallowing loader errors.
+
+    The AgentCard projection must never crash on an overlay-loader
+    error (a malformed providers.d/*.yaml on the host should surface
+    via the parser path with a loud error, but card rendering happens
+    over HTTP and an exception here would 500 the well-known endpoint
+    for EVERY agent, not just the offending one). Best-effort fall
+    through.
+    """
+    try:
+        from ..config._provider_registry_d import load_merged_registry
+
+        return load_merged_registry().get(name)
+    except Exception:  # stx-allow: fallback (reason: see docstring; card rendering must not 500 on overlay errors)
+        return None
+
+
+__all__ = ["resolve_card_model"]

--- a/src/scitex_agent_container/config/__init__.py
+++ b/src/scitex_agent_container/config/__init__.py
@@ -21,6 +21,7 @@ from ._loaders import compose_effective_name, load_v3
 from ._provider_types import ProviderSpec
 from ._proxy_types import ProxySpec
 from ._resolve import resolve_config
+from ._tunnel_types import TunnelSpec
 from ._types import (
     AgentConfig,
     ClaudeSpec,
@@ -53,6 +54,7 @@ __all__ = [
     "SchedulingSpec",
     "SkillsSpec",
     "StartupCommand",
+    "TunnelSpec",
     "WatchdogSpec",
     "compose_effective_name",
     "load_config",

--- a/src/scitex_agent_container/config/_provider_registry_d.py
+++ b/src/scitex_agent_container/config/_provider_registry_d.py
@@ -1,0 +1,254 @@
+"""Operator-extensible provider overlay loader (``providers.d/*.yaml``).
+
+Operator directive 2026-06-08: adding a new named backend used to
+require editing :data:`config._provider_registry.PROVIDERS` in sac
+source — that gate kept ad-hoc / site-local backends locked out of
+the bare-string spec form. The overlay path lets the operator drop
+a ``~/.scitex/agent-container/providers.d/<name>.yaml`` file per
+backend and have sac merge it on top of the built-in registry at
+config-load time.
+
+File schema (one provider per file)::
+
+    # ~/.scitex/agent-container/providers.d/qwen-spartan.yaml
+    name: qwen-spartan          # required — keys the merged registry
+    label: Qwen vLLM (Spartan)  # required — observability surface
+    endpoint:                   # exactly base_url XOR tunnel
+      tunnel:
+        jump_host: spartan-login
+        target_host: spartan-gpgpu171
+        remote_port: 4000
+    default_model: qwen36-35b-a3b
+    auth_token_env: CLEW_VLLM_TOKEN
+
+Loader contract (fail-loud, never silent skip)
+----------------------------------------------
+
+* Directory missing → silent OK (no-op). Operators on hosts that
+  don't need overlays must not be forced to mkdir an empty dir.
+* Each ``*.yaml`` is parsed with PyYAML. Malformed YAML / a
+  missing required key raises :class:`ProviderRegistryDError` with
+  the offending file path — silent skip would let an operator
+  think their overlay is active when it isn't.
+* Entry name conflicting with a built-in → operator entry WINS;
+  a stderr notice names the file that overrode (so an unintended
+  shadow doesn't silently change fleet behaviour).
+* Two operator files declaring the same ``name`` → last-loaded
+  wins, with a stderr warning naming BOTH files.
+
+Test seam
+---------
+
+The overlay directory path is taken from (in order):
+
+1. ``providers_d_dir`` keyword argument (highest — tests pass a
+   ``tmp_path``).
+2. ``$SAC_PROVIDERS_D_DIR`` env var (operator escape hatch — e.g.
+   on a shared host where the per-user XDG path is wrong).
+3. ``~/.scitex/agent-container/providers.d`` (default operator
+   path; mirrors the rest of sac's per-host config layout).
+
+The merged dict returned by :func:`load_merged_registry` is then
+threaded through :func:`config._provider_registry.resolve_provider`
+and :func:`config._provider_registry.list_providers` via their
+``registry`` kwarg.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from ._provider_registry import PROVIDERS
+
+
+class ProviderRegistryDError(RuntimeError):
+    """Raised when a ``providers.d/`` overlay file is malformed.
+
+    Never thrown for an absent overlay directory — that is the
+    "no overlay configured" baseline path.
+    """
+
+
+_REQUIRED_KEYS = ("name", "label", "endpoint", "default_model", "auth_token_env")
+_ALLOWED_ENDPOINT_KEYS = {"base_url", "tunnel"}
+
+
+def _resolve_overlay_dir(providers_d_dir: Path | str | None) -> Path:
+    """Resolve the overlay directory path with the documented precedence.
+
+    Returns the resolved :class:`Path` even when the directory doesn't
+    exist — the existence check is the caller's job (so the caller can
+    short-circuit silently per the loader contract).
+    """
+    if providers_d_dir is not None:
+        return Path(providers_d_dir)
+    env_path = os.environ.get("SAC_PROVIDERS_D_DIR", "")
+    if env_path:
+        return Path(env_path)
+    return Path.home() / ".scitex" / "agent-container" / "providers.d"
+
+
+def _validate_entry(entry: dict[str, Any], source: Path) -> None:
+    """Loud-reject an overlay entry missing required keys or malformed.
+
+    The validator runs before merge so a malformed entry never lands
+    in the resolved registry. Each error names the source file so the
+    operator can fix the right YAML without grepping.
+    """
+    if not isinstance(entry, dict):
+        raise ProviderRegistryDError(
+            f"{source}: top-level YAML must be a mapping, got {type(entry).__name__}"
+        )
+    missing = [k for k in _REQUIRED_KEYS if k not in entry]
+    # ``default_model`` and ``auth_token_env`` may be None — they are
+    # required to be DECLARED (so the operator sees what's unset) but
+    # are allowed to carry an explicit null. Filter that out of the
+    # "missing" list.
+    if missing:
+        raise ProviderRegistryDError(
+            f"{source}: missing required key(s) {missing}. Each "
+            f"providers.d/*.yaml must declare: {list(_REQUIRED_KEYS)}."
+        )
+    name = entry.get("name")
+    if not isinstance(name, str) or not name:
+        raise ProviderRegistryDError(
+            f"{source}: 'name' must be a non-empty string, got {name!r}"
+        )
+    label = entry.get("label")
+    if not isinstance(label, str) or not label:
+        raise ProviderRegistryDError(
+            f"{source}: 'label' must be a non-empty string, got {label!r}"
+        )
+    endpoint = entry.get("endpoint")
+    if endpoint is None:
+        # The "no override" sentinel — only the built-in "anthropic"
+        # entry uses this shape; allow operator overlays to declare
+        # it too for completeness.
+        return
+    if not isinstance(endpoint, dict):
+        raise ProviderRegistryDError(
+            f"{source}: 'endpoint' must be a mapping or null, "
+            f"got {type(endpoint).__name__}"
+        )
+    keys_present = set(endpoint.keys()) & _ALLOWED_ENDPOINT_KEYS
+    if len(keys_present) != 1:
+        raise ProviderRegistryDError(
+            f"{source}: 'endpoint' must declare exactly ONE of "
+            f"{sorted(_ALLOWED_ENDPOINT_KEYS)}, got {sorted(endpoint.keys())}"
+        )
+    if "base_url" in endpoint:
+        bu = endpoint["base_url"]
+        if not isinstance(bu, str) or not bu:
+            raise ProviderRegistryDError(
+                f"{source}: 'endpoint.base_url' must be a non-empty string, got {bu!r}"
+            )
+    if "tunnel" in endpoint:
+        t = endpoint["tunnel"]
+        if not isinstance(t, dict):
+            raise ProviderRegistryDError(
+                f"{source}: 'endpoint.tunnel' must be a mapping, got {type(t).__name__}"
+            )
+        for tk in ("jump_host", "target_host", "remote_port"):
+            if not t.get(tk):
+                raise ProviderRegistryDError(
+                    f"{source}: 'endpoint.tunnel.{tk}' is required and "
+                    "must be non-empty (sac cannot stand up an ssh "
+                    "ProxyJump without all three of jump_host, "
+                    "target_host, remote_port)."
+                )
+
+
+def _load_one(path: Path) -> dict[str, Any]:
+    """Read + parse one overlay YAML file. Raises on malformed input.
+
+    The pyyaml ``SafeLoader`` path is used because operator overlay
+    files are run-as-operator data; we never trust them with arbitrary
+    Python object construction (``!!python/object``).
+    """
+    try:
+        text = path.read_text()
+    except OSError as exc:
+        raise ProviderRegistryDError(
+            f"{path}: could not read overlay file ({exc})"
+        ) from exc
+    try:
+        data = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise ProviderRegistryDError(f"{path}: malformed YAML ({exc})") from exc
+    _validate_entry(data, source=path)
+    return data
+
+
+def load_merged_registry(
+    providers_d_dir: Path | str | None = None,
+    base_registry: dict[str, dict[str, Any]] | None = None,
+    *,
+    log_stream: Any = None,
+) -> dict[str, dict[str, Any]]:
+    """Return the built-in PROVIDERS merged with any overlay files.
+
+    Loader behaviour (see module docstring for the rationale):
+
+    * Overlay directory missing → return ``dict(base_registry)`` as-is.
+    * Each ``*.yaml`` parsed and validated; malformed shape raises
+      :class:`ProviderRegistryDError` naming the file.
+    * Overlay entry conflicting with a built-in → overlay wins; a
+      stderr notice names the overriding file.
+    * Two overlay files declaring the same ``name`` → last-loaded
+      wins (file iteration is sorted by name for determinism); a
+      stderr warning names BOTH files.
+
+    Args:
+        providers_d_dir: OPTIONAL overlay directory. Precedence is the
+            arg → ``$SAC_PROVIDERS_D_DIR`` → default
+            ``~/.scitex/agent-container/providers.d``.
+        base_registry: OPTIONAL base registry to overlay onto. Default
+            uses :data:`_provider_registry.PROVIDERS`.
+        log_stream: OPTIONAL stream for the override / dup notices.
+            Default ``sys.stderr``; tests pass a ``io.StringIO``.
+    """
+    base = dict(base_registry if base_registry is not None else PROVIDERS)
+    overlay_dir = _resolve_overlay_dir(providers_d_dir)
+    if not overlay_dir.is_dir():
+        return base
+
+    stream = log_stream if log_stream is not None else sys.stderr
+    # Sort by file name so two operators on the same fleet see the
+    # same merge order — non-determinism here would surface as
+    # different agents picking different overlays on different hosts.
+    files = sorted(p for p in overlay_dir.iterdir() if p.suffix == ".yaml")
+    # Track which file landed each name so the dup warning can name
+    # both files when a second overlay clobbers the first.
+    name_to_file: dict[str, Path] = {}
+    for path in files:
+        entry = _load_one(path)
+        name = entry["name"]
+        # Strip the ``name`` key out before merge — the registry dict
+        # keys ARE the names, so leaving ``name`` in the value would
+        # confuse downstream callers.
+        record = {k: v for k, v in entry.items() if k != "name"}
+        if name in name_to_file:
+            print(
+                f"[sac:providers.d] WARNING: '{name}' declared in both "
+                f"{name_to_file[name]} and {path}; the latter wins. "
+                "Delete one of the files to silence this warning.",
+                file=stream,
+            )
+        elif name in base:
+            print(
+                f"[sac:providers.d] NOTICE: operator overlay {path} "
+                f"overrides built-in provider '{name}'. Built-in entry "
+                "metadata is shadowed for this run.",
+                file=stream,
+            )
+        base[name] = record
+        name_to_file[name] = path
+    return base
+
+
+__all__ = ["ProviderRegistryDError", "load_merged_registry"]

--- a/src/scitex_agent_container/config/_provider_resolve.py
+++ b/src/scitex_agent_container/config/_provider_resolve.py
@@ -1,0 +1,262 @@
+"""Resolve a parsed ProviderSpec union to a runtime-ready ResolvedProvider.
+
+Operator directive 2026-06-08: the SDK env-injection path
+(``runtimes/_apptainer_provider.provider_env_flags``) used to branch
+on whether ``provider`` was a dict or a registered string; the new
+runtime surface consumes ONE typed shape — :class:`ResolvedProvider`
+— and never re-sniffs at the operator boundary.
+
+This module owns the resolution rules:
+
+* Model precedence chain (highest wins):
+    1. ``CustomProvider.model`` — explicit in the spec.
+    2. ``RegistryProvider.model_override`` — Form B override.
+    3. Registry entry's ``default_model``.
+    4. ``ClaudeSpec.model`` — back-compat fallback (existing
+       behaviour for legacy specs).
+    5. None → :class:`ProviderResolutionError`. A provider override
+       MUST land a model id, else the SDK falls back to the built-in
+       Anthropic default which doesn't exist on the override backend
+       and surfaces as a baffling 404 mid-turn.
+
+* Endpoint shape:
+    * :class:`DirectEndpoint` → ``base_url`` flows through as-is to
+      :attr:`ResolvedProvider.base_url`.
+    * :class:`TunneledEndpoint` → ``base_url`` is None at resolve
+      time; the runtime side (which holds the live local port the
+      tunnel manager bound) recomputes the URL via
+      :func:`with_tunneled_base_url`. The resolver still returns a
+      :class:`ResolvedProvider`, but with the ``tunnel`` field
+      populated so the caller can route through the manager.
+
+* Auth env name:
+    * :class:`CustomProvider.auth_token_env` direct.
+    * :class:`RegistryProvider` → registry entry's ``auth_token_env``.
+
+* Label:
+    * :class:`CustomProvider.label` direct.
+    * :class:`RegistryProvider` → registry entry's ``label``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ._provider_types import (
+    CustomProvider,
+    DirectEndpoint,
+    ProviderSpec,
+    RegistryProvider,
+    ResolvedProvider,
+    TunneledEndpoint,
+)
+
+
+class ProviderResolutionError(RuntimeError):
+    """Raised when a ProviderSpec cannot be resolved to a complete record.
+
+    Surfaces with the agent-facing context (which field is empty, what
+    the model precedence chain looked at) so the operator sees how to
+    fix their spec without re-reading sac source.
+    """
+
+
+def _registry_entry(name: str, registry: dict[str, dict[str, Any]]) -> dict[str, Any]:
+    """Look up a name in the merged registry or raise.
+
+    The validator already rejects unknown names at spec-load time, so
+    a miss here is a defensive guard against a hand-built AgentConfig
+    that bypasses the YAML path. The error names the available
+    providers so the operator can pick from the right set.
+    """
+    entry = registry.get(name)
+    if entry is None:
+        known = ", ".join(sorted(registry)) or "(empty registry)"
+        raise ProviderResolutionError(
+            f"provider '{name}' is not registered. Known providers: "
+            f"{known}. Add an entry to PROVIDERS or drop a YAML into "
+            "~/.scitex/agent-container/providers.d/."
+        )
+    return entry
+
+
+def resolve_provider_spec(
+    spec: ProviderSpec,
+    registry: dict[str, dict[str, Any]],
+    *,
+    claude_model_fallback: str = "",
+) -> ResolvedProvider:
+    """Return the :class:`ResolvedProvider` for a parsed provider spec.
+
+    Args:
+        spec: A :class:`RegistryProvider` or :class:`CustomProvider`
+            (the public :data:`ProviderSpec` union).
+        registry: The merged provider registry (built-in + overlay).
+            Pass :func:`_provider_registry_d.load_merged_registry` to
+            include operator overlays.
+        claude_model_fallback: The ``ClaudeSpec.model`` value, used as
+            step 4 of the model precedence chain. Default empty string
+            means "no fallback" — step 5 (loud error) then fires when
+            no prior step lands a model id.
+
+    Returns:
+        A :class:`ResolvedProvider` with every field populated. For a
+        :class:`TunneledEndpoint` the ``base_url`` is the empty string
+        — callers MUST overlay the live local-bound URL via
+        :func:`with_tunneled_base_url` after the tunnel manager binds
+        a port. The ``tunnel`` field is populated in that case so the
+        runtime can route through the manager.
+
+    Raises:
+        ProviderResolutionError: Model precedence chain bottomed out
+            (no model id from any source); a RegistryProvider names
+            an unknown backend; or a custom provider carries an
+            unrecognized endpoint shape (only possible from a
+            hand-built AgentConfig).
+    """
+    if isinstance(spec, RegistryProvider):
+        entry = _registry_entry(spec.name, registry)
+        endpoint_raw = entry.get("endpoint")
+        label = entry.get("label") or spec.name
+        auth_env = entry.get("auth_token_env") or ""
+        # Model precedence: override (Form B) → registry default →
+        # ClaudeSpec.model. The validator rejects an "anthropic"
+        # sentinel before it reaches here (RegistryProvider with no
+        # endpoint isn't constructed by the parser), but the chain
+        # still tolerates the case for hand-built configs.
+        model = (
+            spec.model_override
+            or entry.get("default_model")
+            or claude_model_fallback
+            or ""
+        )
+        if not model:
+            raise ProviderResolutionError(
+                f"provider '{spec.name}' could not resolve a model id: "
+                "neither RegistryProvider.model_override, the registry "
+                f"default_model, nor spec.claude.model is set. Pick one "
+                "(e.g. 'provider: {name: " + spec.name + ", model: ...}')."
+            )
+        base_url = ""
+        tunnel = None
+        if isinstance(endpoint_raw, dict):
+            if "base_url" in endpoint_raw:
+                base_url = endpoint_raw.get("base_url") or ""
+            elif "tunnel" in endpoint_raw:
+                # The registry stores the tunnel as a dict; we don't
+                # construct a TunnelSpec here because the lifecycle
+                # wiring lives on the runtime side. Surface the dict
+                # via a TunneledEndpoint cast in the caller's
+                # ResolvedProvider when needed. The tunnel field on
+                # ResolvedProvider always holds a TunnelSpec dataclass
+                # — see :func:`tunnel_spec_from_dict` below for the
+                # conversion.
+                tunnel = _tunnel_spec_from_dict(endpoint_raw["tunnel"])
+        return ResolvedProvider(
+            base_url=base_url,
+            model=model,
+            auth_token_env=auth_env,
+            label=label,
+            tunnel=tunnel,
+            allowed_tools=[],
+        )
+
+    if isinstance(spec, CustomProvider):
+        # CustomProvider carries the endpoint as a typed sub-union;
+        # no dict-shape sniffing required.
+        base_url = ""
+        tunnel = None
+        endpoint = spec.endpoint
+        if isinstance(endpoint, DirectEndpoint):
+            base_url = endpoint.base_url
+        elif isinstance(endpoint, TunneledEndpoint):
+            tunnel = endpoint.tunnel
+        else:  # pragma: no cover — guarded by the sealed union
+            raise ProviderResolutionError(
+                f"custom provider '{spec.label}' carries an unrecognized "
+                f"endpoint shape: {type(endpoint).__name__}"
+            )
+        # CustomProvider.model is REQUIRED by the validator; the
+        # fallback chain is honored here for hand-built configs.
+        model = spec.model or claude_model_fallback
+        if not model:
+            raise ProviderResolutionError(
+                f"custom provider '{spec.label}' has no model id "
+                "(CustomProvider.model is empty and ClaudeSpec.model is "
+                "empty). Set 'spec.claude.provider.model: <id>'."
+            )
+        return ResolvedProvider(
+            base_url=base_url,
+            model=model,
+            auth_token_env=spec.auth_token_env,
+            label=spec.label,
+            tunnel=tunnel,
+            allowed_tools=list(spec.allowed_tools),
+        )
+
+    raise ProviderResolutionError(
+        f"unrecognized provider shape: {type(spec).__name__}. "
+        "Expected RegistryProvider or CustomProvider."
+    )
+
+
+def _tunnel_spec_from_dict(raw: dict[str, Any]):
+    """Coerce a registry-shape tunnel dict into a :class:`TunnelSpec`.
+
+    Mirrors the :func:`_parsers._claude` parser's TunnelSpec
+    construction so registry overlays and inlined operator blocks
+    feed the runtime through the same dataclass shape. Defensive
+    typing: missing optional knobs default to the dataclass values.
+    """
+    from ._tunnel_types import TunnelSpec
+
+    return TunnelSpec(
+        jump_host=str(raw.get("jump_host") or ""),
+        target_host=str(raw.get("target_host") or ""),
+        remote_port=int(raw.get("remote_port") or 0),
+        local_port=int(raw.get("local_port") or 0),
+        wait_timeout_s=int(raw.get("wait_timeout_s") or 30),
+        respawn_backoff_s=int(raw.get("respawn_backoff_s") or 2),
+        ssh_opts=list(raw.get("ssh_opts") or []),
+    )
+
+
+def with_tunneled_base_url(
+    resolved: ResolvedProvider, local_port: int
+) -> ResolvedProvider:
+    """Return a copy of ``resolved`` with the live tunnel base_url filled in.
+
+    Called by the runtime side after :class:`TunnelManager` binds a
+    port. Keeps the resolver free of subprocess concerns (it only
+    knows shapes) while still emitting ONE typed
+    :class:`ResolvedProvider` for the env-flag path to consume.
+    """
+    if resolved.tunnel is None:
+        # Defensive: the runtime should only call this on a tunneled
+        # provider. Loud error so a mis-wired call site is obvious
+        # rather than silently overwriting a direct base_url.
+        raise ProviderResolutionError(
+            f"with_tunneled_base_url called on a non-tunneled "
+            f"ResolvedProvider (label={resolved.label!r}); only call "
+            "when ResolvedProvider.tunnel is not None."
+        )
+    if local_port <= 0:
+        raise ProviderResolutionError(
+            f"with_tunneled_base_url given non-positive local_port="
+            f"{local_port}; the tunnel manager must bind a port first."
+        )
+    return ResolvedProvider(
+        base_url=f"http://localhost:{local_port}",
+        model=resolved.model,
+        auth_token_env=resolved.auth_token_env,
+        label=resolved.label,
+        tunnel=resolved.tunnel,
+        allowed_tools=list(resolved.allowed_tools),
+    )
+
+
+__all__ = [
+    "ProviderResolutionError",
+    "resolve_provider_spec",
+    "with_tunneled_base_url",
+]

--- a/src/scitex_agent_container/config/_provider_types.py
+++ b/src/scitex_agent_container/config/_provider_types.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
+from ._tunnel_types import TunnelSpec
+
 
 @dataclass
 class ProviderSpec:
@@ -85,3 +87,14 @@ class ProviderSpec:
     follow-up. Operators on the string form fall back to the runner's
     old-stable default until the registry plumbing lands.
     """
+
+    tunnel: TunnelSpec | None = None
+    """OPTIONAL SSH ProxyJump tunnel to the provider endpoint. When
+    set, sac stands up a local ``ssh -L`` forward through
+    ``tunnel.jump_host`` to ``tunnel.target_host:tunnel.remote_port``
+    at agent-start and rewrites :attr:`base_url` to
+    ``http://localhost:<bound_port>`` if :attr:`base_url` was empty.
+    See :class:`scitex_agent_container.config.TunnelSpec` for the
+    field schema and :mod:`scitex_agent_container._network._tunnel_manager`
+    for the lifecycle contract. ``None`` (default) = no tunnel; the
+    base_url must be directly reachable from the host running sac."""

--- a/src/scitex_agent_container/config/_tunnel_types.py
+++ b/src/scitex_agent_container/config/_tunnel_types.py
@@ -1,0 +1,104 @@
+"""TunnelSpec dataclass for ``spec.claude.provider.tunnel`` (SSH ProxyJump).
+
+Lives in its own module to keep ``_provider_types.py`` and ``_types.py``
+under the project's 512-line cap (mirrors the existing per-axis split
+``_provider_types.py`` / ``_proxy_types.py`` / ``_acl_types.py``).
+Re-exported from :mod:`scitex_agent_container.config` so callers see one
+canonical name regardless of which sibling file holds the dataclass.
+
+Why a separate dataclass under ``provider``
+-------------------------------------------
+
+Some operator-targeted backends (a self-hosted vLLM endpoint on an
+HPC compute node, an internal gateway behind a bastion, ...) are only
+reachable through an SSH jump host — the canonical case at write time
+is Qwen vLLM at ``spartan-gpgpu171:4000`` reachable only via
+``ssh -J spartan-login spartan-gpgpu171`` and then localhost:4000 on
+the compute node. The provider's ``base_url`` cannot point at the
+remote address directly (no routable network path), so sac stands up
+a local SSH ``-L`` forward at boot and rewrites ``base_url`` to
+``http://localhost:<local_port>``. The forward is supervised so an
+``ssh`` disconnect doesn't silently strand the agent on a dead tunnel.
+
+The forward is **declarative**: the operator puts the jump hop,
+target hop, and remote port into the spec, and sac handles the rest
+(port allocation, supervisor spawn, readiness probe, teardown on
+``agent stop``). No imperative pre-step is required.
+
+Fail-loud (never silent fallback)
+---------------------------------
+
+* ``jump_host`` / ``target_host`` / ``remote_port`` are mandatory.
+  An incomplete tunnel block would either fail at ``ssh`` time
+  (cryptic argv error) or silently bind nothing (operator confused
+  why ``base_url`` is dead). The parser + validator reject the
+  incomplete shape before the runtime starts.
+* The supervisor (see :mod:`_network._tunnel_supervisor`) propagates
+  the ``ssh`` child's exit code into its own stderr log line — no
+  silent restart loop hides a permanent failure.
+* If the tunnel never binds within ``wait_timeout_s`` the manager
+  raises :class:`_network._tunnel_manager.TunnelUpError` with the
+  concrete ``ssh -J <jump> <target>`` reproducer recipe.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class TunnelSpec:
+    """SSH ProxyJump-based local forward to the provider endpoint.
+
+    Maps 1:1 onto an ``ssh -N -L <local_port>:localhost:<remote_port> -J
+    <jump_host> <target_host>`` invocation supervised by sac for the
+    lifetime of the agent. See the module docstring for the WHY.
+
+    Fields are intentionally minimal — anything else the operator wants
+    to pass to the underlying ``ssh`` lives in :attr:`ssh_opts`, which
+    is appended verbatim to the supervisor's argv. The supervisor
+    ALWAYS sets ``-N`` (no remote command), ``-o ServerAliveInterval=30``,
+    ``-o ServerAliveCountMax=3``, ``-o ExitOnForwardFailure=yes``, and
+    ``-o BatchMode=yes`` so a misconfigured ssh-agent or interactive
+    prompt cannot silently hang the supervisor.
+    """
+
+    jump_host: str = ""
+    """ssh alias / host for the ``-J`` jump. Must be resolvable from
+    the host running sac (typically configured in ``~/.ssh/config``).
+    Required."""
+
+    target_host: str = ""
+    """The final hop reachable from ``jump_host``. The local forward's
+    upstream is ``<target_host>:<remote_port>``. Required."""
+
+    remote_port: int = 0
+    """TCP port on :attr:`target_host` to forward to. Required;
+    validator enforces 1..65535."""
+
+    local_port: int = 0
+    """OPTIONAL bind port on ``localhost``. ``0`` (default) requests
+    an ephemeral port from the OS — the manager picks a free port via
+    a transient socket bind. When the operator pins a port the
+    validator enforces the unprivileged range 1024..65535."""
+
+    wait_timeout_s: int = 30
+    """OPTIONAL seconds to wait for the local forward to start
+    accepting TCP connects before :meth:`TunnelManager.up` raises
+    :class:`TunnelUpError`. Default 30 covers a slow ssh ControlMaster
+    bootstrap on a busy bastion."""
+
+    respawn_backoff_s: int = 2
+    """OPTIONAL seconds the supervisor sleeps between ``ssh`` respawns
+    after the child exits. Default 2 keeps a transient drop from
+    pounding the bastion. ``0`` is allowed for tight tests; not
+    recommended in production."""
+
+    ssh_opts: list[str] = field(default_factory=list)
+    """OPTIONAL extra ssh argv tokens, appended verbatim AFTER the
+    sac-fixed options. Example: ``["-o", "ServerAliveInterval=15"]``
+    overrides sac's default keepalive (``-o`` is last-wins per ssh).
+    """
+
+
+__all__ = ["TunnelSpec"]

--- a/tests/scitex_agent_container/_network/test__tunnel_manager.py
+++ b/tests/scitex_agent_container/_network/test__tunnel_manager.py
@@ -1,0 +1,323 @@
+"""Tests for ``_network._tunnel_manager.TunnelManager``.
+
+Real subprocesses for the supervisor — no mocks. Tests pass a
+``supervisor_cmd`` that points at a tiny ``python -c '...'`` one-liner
+which opens a listening socket on the requested local_port and
+selects forever; that lets the manager exercise the real spawn + poll
++ kill loop without needing actual ssh or a real bastion.
+
+Each test pins one observable fact (TQ007), AAA markers (TQ002),
+descriptive name with >=3 tokens (TQ003).
+"""
+
+from __future__ import annotations
+
+import socket
+import sys
+import time
+
+import pytest
+
+from scitex_agent_container._network._tunnel_manager import (
+    TunnelManager,
+    TunnelUpError,
+)
+from scitex_agent_container.config._tunnel_types import TunnelSpec
+
+# A fake supervisor that ignores its ssh-specific argv but parses the
+# manager's --local-port flag, binds a TCP listening socket on that
+# port, and blocks until SIGTERM. Implemented as a python one-liner so
+# the test never depends on a separate file.
+_FAKE_SUPERVISOR_LISTEN = (
+    "import argparse,socket,select,signal,sys;"
+    "p=argparse.ArgumentParser();"
+    "p.add_argument('--jump');"
+    "p.add_argument('--target');"
+    "p.add_argument('--remote-port', type=int);"
+    "p.add_argument('--local-port', type=int);"
+    "p.add_argument('--backoff', type=float, default=0.1);"
+    "p.add_argument('--ssh-opt', action='append', default=[]);"
+    "a=p.parse_args();"
+    "s=socket.socket(socket.AF_INET, socket.SOCK_STREAM);"
+    "s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1);"
+    "s.bind(('127.0.0.1', a.local_port));"
+    "s.listen(8);"
+    "signal.signal(signal.SIGTERM, lambda *_: sys.exit(0));"
+    "select.select([s],[],[])"
+)
+
+
+# A fake supervisor that DOESN'T bind any socket — just sleeps. Lets the
+# manager's wait_timeout_s path trigger.
+_FAKE_SUPERVISOR_HANG = (
+    "import argparse,signal,sys,time;"
+    "p=argparse.ArgumentParser();"
+    "p.add_argument('--jump');"
+    "p.add_argument('--target');"
+    "p.add_argument('--remote-port', type=int);"
+    "p.add_argument('--local-port', type=int);"
+    "p.add_argument('--backoff', type=float, default=0.1);"
+    "p.add_argument('--ssh-opt', action='append', default=[]);"
+    "p.parse_args();"
+    "signal.signal(signal.SIGTERM, lambda *_: sys.exit(0));"
+    "time.sleep(60)"
+)
+
+
+def _fake_cmd_listen() -> list[str]:
+    return [sys.executable, "-c", _FAKE_SUPERVISOR_LISTEN]
+
+
+def _fake_cmd_hang() -> list[str]:
+    return [sys.executable, "-c", _FAKE_SUPERVISOR_HANG]
+
+
+def _spec(local_port: int = 0, wait_timeout_s: int = 5) -> TunnelSpec:
+    return TunnelSpec(
+        jump_host="fake-jump",
+        target_host="fake-target",
+        remote_port=4000,
+        local_port=local_port,
+        wait_timeout_s=wait_timeout_s,
+        respawn_backoff_s=0,
+    )
+
+
+def _port_is_free(port: int) -> bool:
+    """Best-effort: True iff no listener responds on 127.0.0.1:port."""
+    try:
+        with socket.create_connection(("127.0.0.1", port), timeout=0.3):
+            return False
+    except OSError:
+        return True
+
+
+# ---------------------------------------------------------------------------
+# up() — happy path
+# ---------------------------------------------------------------------------
+
+
+def test_up_returns_bound_local_port_for_pinned_port(tmp_path):
+    # Arrange — use a port the OS picks, then pin it so the manager
+    # honours the operator's choice (rather than re-picking ephemeral).
+    pinned = _pick_free_port()
+    mgr = TunnelManager(
+        spec=_spec(local_port=pinned),
+        agent_name="t1",
+        state_dir=tmp_path,
+        supervisor_cmd=_fake_cmd_listen(),
+    )
+    try:
+        # Act
+        port = mgr.up()
+        # Assert
+        assert port == pinned
+    finally:
+        mgr.down()
+
+
+def test_up_picks_ephemeral_port_when_spec_local_port_is_zero(tmp_path):
+    # Arrange — spec.local_port=0 → manager allocates an ephemeral
+    # port and the supervisor binds on it.
+    mgr = TunnelManager(
+        spec=_spec(local_port=0),
+        agent_name="t-eph",
+        state_dir=tmp_path,
+        supervisor_cmd=_fake_cmd_listen(),
+    )
+    try:
+        # Act
+        port = mgr.up()
+        # Assert
+        assert 1024 < port < 65536
+    finally:
+        mgr.down()
+
+
+def test_up_writes_pidfile_with_supervisor_pid(tmp_path):
+    # Arrange
+    mgr = TunnelManager(
+        spec=_spec(),
+        agent_name="t-pid",
+        state_dir=tmp_path,
+        supervisor_cmd=_fake_cmd_listen(),
+    )
+    try:
+        # Act
+        mgr.up()
+        # Assert — pidfile exists and contains an int that is alive.
+        assert mgr.pidfile.is_file()
+        pid = int(mgr.pidfile.read_text())
+        assert pid > 0
+    finally:
+        mgr.down()
+
+
+def test_is_alive_returns_true_after_up(tmp_path):
+    # Arrange
+    mgr = TunnelManager(
+        spec=_spec(),
+        agent_name="t-alive",
+        state_dir=tmp_path,
+        supervisor_cmd=_fake_cmd_listen(),
+    )
+    try:
+        # Act
+        mgr.up()
+        result = mgr.is_alive()
+        # Assert
+        assert result is True
+    finally:
+        mgr.down()
+
+
+# ---------------------------------------------------------------------------
+# down() — teardown
+# ---------------------------------------------------------------------------
+
+
+def test_down_removes_pidfile(tmp_path):
+    # Arrange
+    mgr = TunnelManager(
+        spec=_spec(),
+        agent_name="t-down",
+        state_dir=tmp_path,
+        supervisor_cmd=_fake_cmd_listen(),
+    )
+    mgr.up()
+    # Act
+    mgr.down()
+    # Assert
+    assert not mgr.pidfile.is_file()
+
+
+def test_down_releases_local_port(tmp_path):
+    # Arrange
+    mgr = TunnelManager(
+        spec=_spec(),
+        agent_name="t-down-port",
+        state_dir=tmp_path,
+        supervisor_cmd=_fake_cmd_listen(),
+    )
+    port = mgr.up()
+    # Act
+    mgr.down()
+    # Give the OS a moment to actually release the TCP listen socket.
+    for _ in range(20):
+        if _port_is_free(port):
+            break
+        time.sleep(0.05)
+    # Assert
+    assert _port_is_free(port)
+
+
+def test_down_is_idempotent(tmp_path):
+    # Arrange
+    mgr = TunnelManager(
+        spec=_spec(),
+        agent_name="t-down-idem",
+        state_dir=tmp_path,
+        supervisor_cmd=_fake_cmd_listen(),
+    )
+    mgr.up()
+    mgr.down()
+    # Act — second down() must not raise.
+    mgr.down()
+    # Assert
+    assert mgr.is_alive() is False
+
+
+# ---------------------------------------------------------------------------
+# Fail-loud — supervisor never binds in time
+# ---------------------------------------------------------------------------
+
+
+def test_up_raises_tunnel_up_error_when_supervisor_never_binds(tmp_path):
+    # Arrange — supervisor that sleeps and never binds.
+    mgr = TunnelManager(
+        spec=_spec(wait_timeout_s=1),
+        agent_name="t-timeout",
+        state_dir=tmp_path,
+        supervisor_cmd=_fake_cmd_hang(),
+    )
+    try:
+        # Act
+        ctx = pytest.raises(TunnelUpError, match="did not bind")
+        # Assert
+        with ctx:
+            mgr.up()
+    finally:
+        # Manager already cleaned the pidfile, but cover the case where
+        # the supervisor is still alive.
+        mgr.down()
+
+
+def test_up_error_message_includes_reproducer_recipe(tmp_path):
+    # Arrange
+    mgr = TunnelManager(
+        spec=_spec(wait_timeout_s=1),
+        agent_name="t-recipe",
+        state_dir=tmp_path,
+        supervisor_cmd=_fake_cmd_hang(),
+    )
+    message = ""
+    try:
+        # Act
+        try:
+            mgr.up()
+        except TunnelUpError as exc:
+            message = str(exc)
+        # Assert
+        assert "ssh -J fake-jump" in message
+        assert "fake-target" in message
+    finally:
+        mgr.down()
+
+
+# ---------------------------------------------------------------------------
+# Fail-loud — spec validation
+# ---------------------------------------------------------------------------
+
+
+def test_up_raises_when_jump_host_is_empty(tmp_path):
+    # Arrange
+    spec = TunnelSpec(jump_host="", target_host="t", remote_port=4000)
+    mgr = TunnelManager(
+        spec=spec,
+        agent_name="t-bad",
+        state_dir=tmp_path,
+        supervisor_cmd=_fake_cmd_listen(),
+    )
+    # Act
+    ctx = pytest.raises(TunnelUpError, match="jump_host")
+    # Assert
+    with ctx:
+        mgr.up()
+
+
+def test_up_raises_when_remote_port_out_of_range(tmp_path):
+    # Arrange
+    spec = TunnelSpec(jump_host="j", target_host="t", remote_port=70000)
+    mgr = TunnelManager(
+        spec=spec,
+        agent_name="t-bad",
+        state_dir=tmp_path,
+        supervisor_cmd=_fake_cmd_listen(),
+    )
+    # Act
+    ctx = pytest.raises(TunnelUpError, match="remote_port")
+    # Assert
+    with ctx:
+        mgr.up()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _pick_free_port() -> int:
+    """Get a free TCP port from the OS (binds + immediately releases)."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]

--- a/tests/scitex_agent_container/a2a/test__card_model.py
+++ b/tests/scitex_agent_container/a2a/test__card_model.py
@@ -1,0 +1,121 @@
+"""Tests for ``a2a._card_model.resolve_card_model``.
+
+Lead directive 431365c (2026-06-08): the AgentCard surface MUST
+reflect the resolved model id, not just ``spec.claude.model``. Each
+test pins one observable fact (TQ007), AAA markers (TQ002),
+descriptive name with >=3 tokens (TQ003).
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container.a2a._card_model import resolve_card_model
+
+
+def test_custom_provider_explicit_model_wins():
+    # Arrange — Form C: type=custom carries its own model.
+    spec = {
+        "claude": {
+            "model": "fallback-claude",
+            "provider": {
+                "type": "custom",
+                "label": "x",
+                "endpoint": {"base_url": "https://x"},
+                "model": "qwen36-35b-a3b",
+                "auth_token_env": "K",
+            },
+        }
+    }
+    # Act
+    result = resolve_card_model(spec)
+    # Assert
+    assert result == "qwen36-35b-a3b"
+
+
+def test_form_b_model_override_wins_over_registry_default():
+    # Arrange — Form B inlines a model override.
+    spec = {
+        "claude": {
+            "provider": {"name": "deepseek", "model": "deepseek-reasoner"},
+        }
+    }
+    # Act
+    result = resolve_card_model(spec)
+    # Assert
+    assert result == "deepseek-reasoner"
+
+
+def test_form_a_bare_string_uses_registry_default_model():
+    # Arrange — no explicit model, registry default carries it.
+    spec = {"claude": {"provider": "deepseek"}}
+    # Act
+    result = resolve_card_model(spec)
+    # Assert
+    assert result == "deepseek-chat"
+
+
+def test_form_b_name_only_uses_registry_default_model():
+    # Arrange
+    spec = {"claude": {"provider": {"name": "deepseek"}}}
+    # Act
+    result = resolve_card_model(spec)
+    # Assert
+    assert result == "deepseek-chat"
+
+
+def test_no_provider_falls_back_to_spec_claude_model():
+    # Arrange
+    spec = {"claude": {"model": "opus[1m]"}}
+    # Act
+    result = resolve_card_model(spec)
+    # Assert
+    assert result == "opus[1m]"
+
+
+def test_v2_legacy_spec_model_used_when_no_claude_model():
+    # Arrange — pre-v3 specs put model at top-level spec.model.
+    spec = {"model": "legacy-v2-model"}
+    # Act
+    result = resolve_card_model(spec)
+    # Assert
+    assert result == "legacy-v2-model"
+
+
+def test_provider_active_but_no_model_falls_back_to_claude_model():
+    # Arrange — registry default_model is None (e.g. mimo) and the
+    # operator left provider as a bare name; the card surfaces the
+    # spec.claude.model fall-through.
+    spec = {
+        "claude": {
+            "model": "claude-3-5-sonnet-20241022",
+            "provider": "mimo",
+        }
+    }
+    # Act
+    result = resolve_card_model(spec)
+    # Assert
+    assert result == "claude-3-5-sonnet-20241022"
+
+
+def test_no_model_anywhere_returns_none():
+    # Arrange — operator hasn't declared any model on the spec.
+    spec = {}
+    # Act
+    result = resolve_card_model(spec)
+    # Assert
+    assert result is None
+
+
+def test_unknown_provider_falls_through_to_claude_model():
+    # Arrange — operator typo / unregistered name; the validator
+    # surfaces the loud error separately, but the card resolution
+    # must still pick the next sane chain step rather than 500.
+    spec = {
+        "claude": {
+            "model": "fallback",
+            "provider": "ghost-provider-typo",
+        }
+    }
+    # Act
+    result = resolve_card_model(spec)
+    # Assert
+    assert result == "fallback"

--- a/tests/scitex_agent_container/config/_parsers/test__claude_provider_three_shape.py
+++ b/tests/scitex_agent_container/config/_parsers/test__claude_provider_three_shape.py
@@ -1,0 +1,315 @@
+"""Three-shape provider parser tests (Form A / B / C + legacy back-compat).
+
+Operator directive 2026-06-08: ``_parse_provider`` produces a typed
+sealed-union ProviderSpec (RegistryProvider XOR CustomProvider) for
+each of the three operator-facing shapes, and normalises the legacy
+``{base_url, auth_token_env}`` dict into a CustomProvider with a
+``label="legacy:<agent-name>"`` and a one-time stderr deprecation
+warning. Each test pins one observable fact (TQ007), AAA markers
+(TQ002), descriptive name with >=3 tokens (TQ003).
+
+The parser uses a real registry — tests pass a minimal dict via the
+``registry`` kwarg so the parsed shapes are decoupled from whatever
+``providers.d/*.yaml`` the test host might carry.
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container.config import (
+    CustomProvider,
+    DirectEndpoint,
+    RegistryProvider,
+    TunneledEndpoint,
+)
+from scitex_agent_container.config._parsers._claude import _parse_provider
+
+_REGISTRY = {
+    "deepseek": {
+        "label": "DeepSeek",
+        "endpoint": {"base_url": "https://api.deepseek.com/anthropic"},
+        "default_model": "deepseek-chat",
+        "auth_token_env": "DEEPSEEK_API_KEY",
+    },
+    "anthropic": {
+        "label": "Anthropic (default)",
+        "endpoint": None,
+        "default_model": None,
+        "auth_token_env": None,
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Form A — bare string
+# ---------------------------------------------------------------------------
+
+
+def test_form_a_bare_string_yields_registry_provider():
+    # Arrange
+    spec = {"provider": "deepseek"}
+    # Act
+    result = _parse_provider(spec, agent_name="t1", registry=_REGISTRY)
+    # Assert
+    assert isinstance(result, RegistryProvider)
+
+
+def test_form_a_bare_string_carries_name():
+    # Arrange
+    spec = {"provider": "deepseek"}
+    # Act
+    result = _parse_provider(spec, agent_name="t1", registry=_REGISTRY)
+    # Assert
+    assert result.name == "deepseek"
+
+
+def test_form_a_anthropic_sentinel_yields_none():
+    # Arrange — endpoint=None sentinel means "no override".
+    spec = {"provider": "anthropic"}
+    # Act
+    result = _parse_provider(spec, agent_name="t1", registry=_REGISTRY)
+    # Assert
+    assert result is None
+
+
+def test_form_a_unknown_string_yields_none_for_validator_to_catch():
+    # Arrange — parser stays defensive; validator surfaces the loud error.
+    spec = {"provider": "no-such-provider"}
+    # Act
+    result = _parse_provider(spec, agent_name="t1", registry=_REGISTRY)
+    # Assert
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Form B — registry name + optional model override
+# ---------------------------------------------------------------------------
+
+
+def test_form_b_name_only_yields_registry_provider_with_no_override():
+    # Arrange
+    spec = {"provider": {"name": "deepseek"}}
+    # Act
+    result = _parse_provider(spec, agent_name="t1", registry=_REGISTRY)
+    # Assert
+    assert isinstance(result, RegistryProvider)
+    assert result.model_override is None
+
+
+def test_form_b_with_model_override_populates_field():
+    # Arrange
+    spec = {"provider": {"name": "deepseek", "model": "deepseek-reasoner"}}
+    # Act
+    result = _parse_provider(spec, agent_name="t1", registry=_REGISTRY)
+    # Assert
+    assert result.model_override == "deepseek-reasoner"
+
+
+def test_form_b_anthropic_sentinel_collapses_to_none():
+    # Arrange
+    spec = {"provider": {"name": "anthropic"}}
+    # Act
+    result = _parse_provider(spec, agent_name="t1", registry=_REGISTRY)
+    # Assert
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Form C — type: custom
+# ---------------------------------------------------------------------------
+
+
+_CUSTOM_DIRECT = {
+    "provider": {
+        "type": "custom",
+        "label": "internal-gw",
+        "endpoint": {"base_url": "https://internal.example/anthropic"},
+        "model": "qwen36-35b-a3b",
+        "auth_token_env": "INTERNAL_KEY",
+    }
+}
+
+
+def test_form_c_direct_endpoint_yields_custom_provider():
+    # Arrange
+    spec = dict(_CUSTOM_DIRECT)
+    # Act
+    result = _parse_provider(spec, agent_name="t1", registry=_REGISTRY)
+    # Assert
+    assert isinstance(result, CustomProvider)
+
+
+def test_form_c_direct_endpoint_carries_typed_direct_endpoint():
+    # Arrange
+    spec = dict(_CUSTOM_DIRECT)
+    # Act
+    result = _parse_provider(spec, agent_name="t1", registry=_REGISTRY)
+    # Assert
+    assert isinstance(result.endpoint, DirectEndpoint)
+    assert result.endpoint.base_url == "https://internal.example/anthropic"
+
+
+def test_form_c_tunnel_endpoint_carries_typed_tunneled_endpoint():
+    # Arrange
+    spec = {
+        "provider": {
+            "type": "custom",
+            "label": "qwen",
+            "endpoint": {
+                "tunnel": {
+                    "jump_host": "spartan-login",
+                    "target_host": "spartan-gpgpu171",
+                    "remote_port": 4000,
+                }
+            },
+            "model": "qwen36-35b-a3b",
+            "auth_token_env": "CLEW_VLLM_TOKEN",
+        }
+    }
+    # Act
+    result = _parse_provider(spec, agent_name="t1", registry=_REGISTRY)
+    # Assert
+    assert isinstance(result.endpoint, TunneledEndpoint)
+    assert result.endpoint.tunnel.jump_host == "spartan-login"
+
+
+def test_form_c_allowed_tools_list_populates_field():
+    # Arrange
+    block = dict(_CUSTOM_DIRECT["provider"], allowed_tools=["Bash", "Read"])
+    # Act
+    result = _parse_provider({"provider": block}, agent_name="t1", registry=_REGISTRY)
+    # Assert
+    assert result.allowed_tools == ["Bash", "Read"]
+
+
+def test_form_c_missing_required_field_yields_none():
+    # Arrange — parser defends by returning None; validator is the loud surface.
+    block = {k: v for k, v in _CUSTOM_DIRECT["provider"].items() if k != "model"}
+    # Act
+    result = _parse_provider({"provider": block}, agent_name="t1", registry=_REGISTRY)
+    # Assert
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Legacy back-compat — dict without name/type but with base_url
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_dict_normalises_to_custom_provider():
+    # Arrange
+    spec = {
+        "provider": {
+            "base_url": "https://api.deepseek.com/anthropic",
+            "auth_token_env": "DEEPSEEK_API_KEY",
+        }
+    }
+    # Act
+    result = _parse_provider(spec, agent_name="ds", registry=_REGISTRY)
+    # Assert
+    assert isinstance(result, CustomProvider)
+
+
+def test_legacy_dict_uses_legacy_label_with_agent_name():
+    # Arrange
+    spec = {
+        "provider": {
+            "base_url": "https://api.deepseek.com/anthropic",
+            "auth_token_env": "DEEPSEEK_API_KEY",
+        }
+    }
+    # Act
+    result = _parse_provider(spec, agent_name="ds", registry=_REGISTRY)
+    # Assert
+    assert result.label == "legacy:ds"
+
+
+def test_legacy_dict_carries_direct_endpoint_with_base_url():
+    # Arrange
+    spec = {
+        "provider": {
+            "base_url": "https://api.deepseek.com/anthropic",
+            "auth_token_env": "DEEPSEEK_API_KEY",
+        }
+    }
+    # Act
+    result = _parse_provider(spec, agent_name="ds", registry=_REGISTRY)
+    # Assert
+    assert isinstance(result.endpoint, DirectEndpoint)
+    assert result.endpoint.base_url == "https://api.deepseek.com/anthropic"
+
+
+def test_legacy_dict_carries_empty_model_for_resolver_fallback():
+    # Arrange — legacy shape has no model; resolver falls back to
+    # ClaudeSpec.model via the precedence chain.
+    spec = {
+        "provider": {
+            "base_url": "https://api.deepseek.com/anthropic",
+            "auth_token_env": "DEEPSEEK_API_KEY",
+        }
+    }
+    # Act
+    result = _parse_provider(spec, agent_name="ds", registry=_REGISTRY)
+    # Assert
+    assert result.model == ""
+
+
+def test_legacy_dict_emits_one_time_deprecation_warning(capsys):
+    # Arrange
+    import scitex_agent_container.config._parsers._claude as parser_mod
+
+    parser_mod._LEGACY_WARN_EMITTED.clear()
+    spec = {
+        "provider": {
+            "base_url": "https://api.deepseek.com/anthropic",
+            "auth_token_env": "DEEPSEEK_API_KEY",
+        }
+    }
+    # Act
+    _parse_provider(spec, agent_name="agent-once", registry=_REGISTRY)
+    captured = capsys.readouterr().err
+    # Assert
+    assert "deprecation" in captured
+    assert "agent-once" in captured
+    assert "legacy dict form" in captured
+
+
+def test_legacy_dict_warning_fires_only_once_per_agent_name(capsys):
+    # Arrange — two parses for the same agent name should emit ONE warning.
+    import scitex_agent_container.config._parsers._claude as parser_mod
+
+    parser_mod._LEGACY_WARN_EMITTED.clear()
+    spec = {
+        "provider": {
+            "base_url": "https://api.deepseek.com/anthropic",
+            "auth_token_env": "DEEPSEEK_API_KEY",
+        }
+    }
+    # Act
+    _parse_provider(spec, agent_name="repeat", registry=_REGISTRY)
+    _parse_provider(spec, agent_name="repeat", registry=_REGISTRY)
+    captured = capsys.readouterr().err
+    # Assert
+    assert captured.count("deprecation") == 1
+
+
+# ---------------------------------------------------------------------------
+# Garbage shapes — defensive parser returns None
+# ---------------------------------------------------------------------------
+
+
+def test_garbage_non_string_non_dict_yields_none():
+    # Arrange
+    spec = {"provider": 42}
+    # Act
+    result = _parse_provider(spec, agent_name="t1", registry=_REGISTRY)
+    # Assert
+    assert result is None
+
+
+def test_unrecognised_dict_shape_yields_none():
+    # Arrange — dict without name/type/base_url; validator surfaces the loud error.
+    spec = {"provider": {"label": "x"}}
+    # Act
+    result = _parse_provider(spec, agent_name="t1", registry=_REGISTRY)
+    # Assert
+    assert result is None

--- a/tests/scitex_agent_container/config/test__provider_registry_d.py
+++ b/tests/scitex_agent_container/config/test__provider_registry_d.py
@@ -1,0 +1,225 @@
+"""Tests for ``config._provider_registry_d.load_merged_registry``.
+
+Operator-extensible provider overlay: ``~/.scitex/agent-container/
+providers.d/*.yaml`` files merge over the built-in PROVIDERS at
+config-load time. Each test pins one observable fact (TQ007), AAA
+markers (TQ002), descriptive name with >=3 tokens (TQ003).
+
+Real seams (no mocks):
+* ``tmp_path`` is passed via the ``providers_d_dir`` arg so no global
+  state leaks between tests.
+* A ``io.StringIO`` captures the loader's stderr override / dup notices.
+"""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+
+from scitex_agent_container.config._provider_registry_d import (
+    ProviderRegistryDError,
+    load_merged_registry,
+)
+
+
+def _write(path, text):
+    path.write_text(text)
+
+
+_QWEN_YAML = """
+name: qwen-spartan
+label: Qwen vLLM (Spartan)
+endpoint:
+  tunnel:
+    jump_host: spartan-login
+    target_host: spartan-gpgpu171
+    remote_port: 4000
+default_model: qwen36-35b-a3b
+auth_token_env: CLEW_VLLM_TOKEN
+"""
+
+_BASE = {
+    "deepseek": {
+        "label": "DeepSeek",
+        "endpoint": {"base_url": "https://api.deepseek.com/anthropic"},
+        "default_model": "deepseek-chat",
+        "auth_token_env": "DEEPSEEK_API_KEY",
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_missing_directory_returns_base_registry_unchanged(tmp_path):
+    # Arrange — no providers.d/ dir exists.
+    nonexistent = tmp_path / "no-such-dir"
+    # Act
+    merged = load_merged_registry(nonexistent, base_registry=dict(_BASE))
+    # Assert
+    assert merged == _BASE
+
+
+def test_overlay_adds_new_provider_name(tmp_path):
+    # Arrange
+    _write(tmp_path / "qwen-spartan.yaml", _QWEN_YAML)
+    # Act
+    merged = load_merged_registry(tmp_path, base_registry=dict(_BASE))
+    # Assert
+    assert "qwen-spartan" in merged
+
+
+def test_overlay_entry_carries_label_and_default_model(tmp_path):
+    # Arrange
+    _write(tmp_path / "qwen-spartan.yaml", _QWEN_YAML)
+    # Act
+    merged = load_merged_registry(tmp_path, base_registry=dict(_BASE))
+    # Assert
+    assert merged["qwen-spartan"]["label"] == "Qwen vLLM (Spartan)"
+    assert merged["qwen-spartan"]["default_model"] == "qwen36-35b-a3b"
+
+
+def test_overlay_tunnel_endpoint_preserves_jump_host(tmp_path):
+    # Arrange
+    _write(tmp_path / "qwen-spartan.yaml", _QWEN_YAML)
+    # Act
+    merged = load_merged_registry(tmp_path, base_registry=dict(_BASE))
+    # Assert
+    assert merged["qwen-spartan"]["endpoint"]["tunnel"]["jump_host"] == "spartan-login"
+
+
+def test_built_in_entries_remain_after_overlay_merge(tmp_path):
+    # Arrange
+    _write(tmp_path / "qwen-spartan.yaml", _QWEN_YAML)
+    # Act
+    merged = load_merged_registry(tmp_path, base_registry=dict(_BASE))
+    # Assert
+    assert merged["deepseek"]["label"] == "DeepSeek"
+
+
+# ---------------------------------------------------------------------------
+# Conflict handling
+# ---------------------------------------------------------------------------
+
+
+def test_overlay_overriding_built_in_emits_stderr_notice(tmp_path):
+    # Arrange — overlay reuses a built-in name; operator should see the
+    # one-line NOTICE on stderr so an unintended shadow is visible.
+    _write(
+        tmp_path / "deepseek.yaml",
+        "name: deepseek\nlabel: Custom DS\nendpoint: {base_url: https://custom}\n"
+        "default_model: custom-model\nauth_token_env: CUSTOM_KEY\n",
+    )
+    log = io.StringIO()
+    # Act
+    merged = load_merged_registry(tmp_path, base_registry=dict(_BASE), log_stream=log)
+    # Assert
+    assert "overrides built-in provider 'deepseek'" in log.getvalue()
+    assert merged["deepseek"]["label"] == "Custom DS"
+
+
+def test_two_overlay_files_with_same_name_emit_dup_warning(tmp_path):
+    # Arrange — second file wins; warning names BOTH files.
+    _write(tmp_path / "a.yaml", _QWEN_YAML)
+    _write(
+        tmp_path / "z.yaml",
+        "name: qwen-spartan\nlabel: Other\n"
+        "endpoint: {base_url: https://other}\n"
+        "default_model: other-model\nauth_token_env: OTHER\n",
+    )
+    log = io.StringIO()
+    # Act
+    merged = load_merged_registry(tmp_path, base_registry=dict(_BASE), log_stream=log)
+    # Assert
+    log_text = log.getvalue()
+    assert "a.yaml" in log_text
+    assert "z.yaml" in log_text
+    assert merged["qwen-spartan"]["label"] == "Other"
+
+
+# ---------------------------------------------------------------------------
+# Fail-loud paths
+# ---------------------------------------------------------------------------
+
+
+def test_malformed_yaml_raises_with_file_path(tmp_path):
+    # Arrange
+    _write(tmp_path / "bad.yaml", ":\n:invalid\n")
+    # Act
+    ctx = pytest.raises(ProviderRegistryDError, match="bad.yaml")
+    # Assert
+    with ctx:
+        load_merged_registry(tmp_path, base_registry=dict(_BASE))
+
+
+def test_missing_name_key_raises_loudly(tmp_path):
+    # Arrange
+    _write(
+        tmp_path / "no-name.yaml",
+        "label: x\nendpoint: {base_url: y}\ndefault_model: m\nauth_token_env: K\n",
+    )
+    # Act
+    ctx = pytest.raises(ProviderRegistryDError, match="missing required key")
+    # Assert
+    with ctx:
+        load_merged_registry(tmp_path, base_registry=dict(_BASE))
+
+
+def test_endpoint_with_both_base_url_and_tunnel_raises_loudly(tmp_path):
+    # Arrange — XOR violation in the overlay file.
+    _write(
+        tmp_path / "bad-endpoint.yaml",
+        """
+name: bad
+label: bad
+endpoint:
+  base_url: https://x
+  tunnel:
+    jump_host: j
+    target_host: t
+    remote_port: 4000
+default_model: m
+auth_token_env: K
+""",
+    )
+    # Act
+    ctx = pytest.raises(ProviderRegistryDError, match="exactly ONE")
+    # Assert
+    with ctx:
+        load_merged_registry(tmp_path, base_registry=dict(_BASE))
+
+
+def test_tunnel_missing_jump_host_raises_loudly(tmp_path):
+    # Arrange
+    _write(
+        tmp_path / "bad-tunnel.yaml",
+        """
+name: bad
+label: bad
+endpoint:
+  tunnel:
+    target_host: t
+    remote_port: 4000
+default_model: m
+auth_token_env: K
+""",
+    )
+    # Act
+    ctx = pytest.raises(ProviderRegistryDError, match="jump_host")
+    # Assert
+    with ctx:
+        load_merged_registry(tmp_path, base_registry=dict(_BASE))
+
+
+def test_env_var_overrides_default_overlay_dir(tmp_path, monkeypatch):
+    # Arrange — the operator can pin the overlay dir via env var when
+    # the per-user default is wrong (shared host, alternate XDG path).
+    _write(tmp_path / "qwen-spartan.yaml", _QWEN_YAML)
+    monkeypatch.setenv("SAC_PROVIDERS_D_DIR", str(tmp_path))
+    # Act
+    merged = load_merged_registry(base_registry=dict(_BASE))
+    # Assert
+    assert "qwen-spartan" in merged

--- a/tests/scitex_agent_container/config/test__provider_resolve.py
+++ b/tests/scitex_agent_container/config/test__provider_resolve.py
@@ -1,0 +1,320 @@
+"""Tests for ``config._provider_resolve.resolve_provider_spec``.
+
+Operator directive 2026-06-08: resolution projects the sealed
+operator-facing union (RegistryProvider / CustomProvider) onto a
+single typed ResolvedProvider surface. Pins the model precedence
+chain (CustomProvider.model → RegistryProvider.model_override →
+registry default_model → ClaudeSpec.model → loud error) and the
+endpoint shape mapping (DirectEndpoint → base_url; TunneledEndpoint
+→ tunnel field, base_url empty until ``with_tunneled_base_url``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scitex_agent_container.config import (
+    CustomProvider,
+    DirectEndpoint,
+    RegistryProvider,
+    TunneledEndpoint,
+    TunnelSpec,
+)
+from scitex_agent_container.config._provider_resolve import (
+    ProviderResolutionError,
+    resolve_provider_spec,
+    with_tunneled_base_url,
+)
+
+_REGISTRY = {
+    "deepseek": {
+        "label": "DeepSeek",
+        "endpoint": {"base_url": "https://api.deepseek.com/anthropic"},
+        "default_model": "deepseek-chat",
+        "auth_token_env": "DEEPSEEK_API_KEY",
+    },
+    "qwen-spartan": {
+        "label": "Qwen vLLM (Spartan)",
+        "endpoint": {
+            "tunnel": {
+                "jump_host": "spartan-login",
+                "target_host": "spartan-gpgpu171",
+                "remote_port": 4000,
+            }
+        },
+        "default_model": "qwen36-35b-a3b",
+        "auth_token_env": "CLEW_VLLM_TOKEN",
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# RegistryProvider resolution
+# ---------------------------------------------------------------------------
+
+
+def test_registry_provider_uses_registry_endpoint_base_url():
+    # Arrange
+    spec = RegistryProvider(name="deepseek")
+    # Act
+    resolved = resolve_provider_spec(spec, _REGISTRY)
+    # Assert
+    assert resolved.base_url == "https://api.deepseek.com/anthropic"
+
+
+def test_registry_provider_uses_registry_default_model_when_no_override():
+    # Arrange
+    spec = RegistryProvider(name="deepseek")
+    # Act
+    resolved = resolve_provider_spec(spec, _REGISTRY)
+    # Assert
+    assert resolved.model == "deepseek-chat"
+
+
+def test_registry_provider_model_override_wins_over_registry_default():
+    # Arrange
+    spec = RegistryProvider(name="deepseek", model_override="deepseek-reasoner")
+    # Act
+    resolved = resolve_provider_spec(spec, _REGISTRY)
+    # Assert
+    assert resolved.model == "deepseek-reasoner"
+
+
+def test_registry_provider_auth_env_comes_from_registry():
+    # Arrange
+    spec = RegistryProvider(name="deepseek")
+    # Act
+    resolved = resolve_provider_spec(spec, _REGISTRY)
+    # Assert
+    assert resolved.auth_token_env == "DEEPSEEK_API_KEY"
+
+
+def test_registry_provider_label_comes_from_registry():
+    # Arrange
+    spec = RegistryProvider(name="deepseek")
+    # Act
+    resolved = resolve_provider_spec(spec, _REGISTRY)
+    # Assert
+    assert resolved.label == "DeepSeek"
+
+
+def test_registry_provider_unknown_name_raises_resolution_error():
+    # Arrange
+    spec = RegistryProvider(name="ghost")
+    # Act
+    ctx = pytest.raises(ProviderResolutionError)
+    # Assert
+    with ctx:
+        resolve_provider_spec(spec, _REGISTRY)
+
+
+def test_registry_provider_tunneled_endpoint_populates_tunnel_field():
+    # Arrange
+    spec = RegistryProvider(name="qwen-spartan")
+    # Act
+    resolved = resolve_provider_spec(spec, _REGISTRY)
+    # Assert
+    assert isinstance(resolved.tunnel, TunnelSpec)
+    assert resolved.tunnel.jump_host == "spartan-login"
+
+
+def test_registry_provider_tunneled_endpoint_base_url_empty_at_resolve_time():
+    # Arrange — the tunnel manager hasn't bound a port yet; the
+    # caller overlays via with_tunneled_base_url after up().
+    spec = RegistryProvider(name="qwen-spartan")
+    # Act
+    resolved = resolve_provider_spec(spec, _REGISTRY)
+    # Assert
+    assert resolved.base_url == ""
+
+
+# ---------------------------------------------------------------------------
+# CustomProvider resolution
+# ---------------------------------------------------------------------------
+
+
+def _custom_direct() -> CustomProvider:
+    return CustomProvider(
+        label="internal-gw",
+        endpoint=DirectEndpoint(base_url="https://internal.example/anthropic"),
+        model="qwen36-35b-a3b",
+        auth_token_env="CLEW_VLLM_TOKEN",
+    )
+
+
+def test_custom_direct_endpoint_flows_base_url_through_unchanged():
+    # Arrange
+    spec = _custom_direct()
+    # Act
+    resolved = resolve_provider_spec(spec, _REGISTRY)
+    # Assert
+    assert resolved.base_url == "https://internal.example/anthropic"
+
+
+def test_custom_direct_resolved_model_matches_custom_model():
+    # Arrange
+    spec = _custom_direct()
+    # Act
+    resolved = resolve_provider_spec(spec, _REGISTRY)
+    # Assert
+    assert resolved.model == "qwen36-35b-a3b"
+
+
+def test_custom_direct_resolved_label_matches_custom_label():
+    # Arrange
+    spec = _custom_direct()
+    # Act
+    resolved = resolve_provider_spec(spec, _REGISTRY)
+    # Assert
+    assert resolved.label == "internal-gw"
+
+
+def test_custom_direct_resolved_carries_no_tunnel():
+    # Arrange
+    spec = _custom_direct()
+    # Act
+    resolved = resolve_provider_spec(spec, _REGISTRY)
+    # Assert
+    assert resolved.tunnel is None
+
+
+def test_custom_tunneled_endpoint_populates_tunnel_and_empty_base_url():
+    # Arrange
+    spec = CustomProvider(
+        label="qwen",
+        endpoint=TunneledEndpoint(
+            tunnel=TunnelSpec(jump_host="j", target_host="t", remote_port=4000)
+        ),
+        model="qwen36-35b-a3b",
+        auth_token_env="CLEW_VLLM_TOKEN",
+    )
+    # Act
+    resolved = resolve_provider_spec(spec, _REGISTRY)
+    # Assert
+    assert resolved.base_url == ""
+    assert resolved.tunnel.target_host == "t"
+
+
+# ---------------------------------------------------------------------------
+# Model precedence chain — CustomProvider step 4 (ClaudeSpec fallback)
+# ---------------------------------------------------------------------------
+
+
+def test_custom_provider_with_empty_model_falls_back_to_claude_model():
+    # Arrange — legacy back-compat shape lands here: CustomProvider
+    # carries model="" so the resolver falls back to ClaudeSpec.model.
+    spec = CustomProvider(
+        label="legacy:test",
+        endpoint=DirectEndpoint(base_url="https://x.example"),
+        model="",
+        auth_token_env="X_KEY",
+    )
+    # Act
+    resolved = resolve_provider_spec(spec, _REGISTRY, claude_model_fallback="opus")
+    # Assert
+    assert resolved.model == "opus"
+
+
+def test_custom_provider_no_model_anywhere_raises_resolution_error():
+    # Arrange — empty model + no fallback.
+    spec = CustomProvider(
+        label="legacy:test",
+        endpoint=DirectEndpoint(base_url="https://x.example"),
+        model="",
+        auth_token_env="X_KEY",
+    )
+    # Act
+    ctx = pytest.raises(ProviderResolutionError)
+    # Assert
+    with ctx:
+        resolve_provider_spec(spec, _REGISTRY, claude_model_fallback="")
+
+
+# ---------------------------------------------------------------------------
+# Model precedence chain — RegistryProvider full chain
+# ---------------------------------------------------------------------------
+
+
+def test_registry_override_wins_over_claude_fallback():
+    # Arrange — override beats claude.model.
+    spec = RegistryProvider(name="deepseek", model_override="custom-id")
+    # Act
+    resolved = resolve_provider_spec(spec, _REGISTRY, claude_model_fallback="opus")
+    # Assert
+    assert resolved.model == "custom-id"
+
+
+def test_registry_default_wins_over_claude_fallback():
+    # Arrange
+    spec = RegistryProvider(name="deepseek")
+    # Act
+    resolved = resolve_provider_spec(spec, _REGISTRY, claude_model_fallback="opus")
+    # Assert
+    assert resolved.model == "deepseek-chat"
+
+
+def test_registry_provider_no_default_falls_back_to_claude_model():
+    # Arrange — registry entry with default_model=None (operator
+    # overlays or the "mimo" built-in).
+    registry = dict(_REGISTRY)
+    registry["mimo"] = {
+        "label": "MiMo",
+        "endpoint": {"base_url": "https://mimo.example"},
+        "default_model": None,
+        "auth_token_env": "XIAOMI_API_KEY",
+    }
+    spec = RegistryProvider(name="mimo")
+    # Act
+    resolved = resolve_provider_spec(
+        spec, registry, claude_model_fallback="claude-3-5-sonnet-20241022"
+    )
+    # Assert
+    assert resolved.model == "claude-3-5-sonnet-20241022"
+
+
+# ---------------------------------------------------------------------------
+# with_tunneled_base_url — overlay live local port
+# ---------------------------------------------------------------------------
+
+
+def test_with_tunneled_base_url_sets_localhost_url_with_port():
+    # Arrange
+    spec = RegistryProvider(name="qwen-spartan")
+    resolved = resolve_provider_spec(spec, _REGISTRY)
+    # Act
+    live = with_tunneled_base_url(resolved, local_port=14000)
+    # Assert
+    assert live.base_url == "http://localhost:14000"
+
+
+def test_with_tunneled_base_url_preserves_label_and_auth_env():
+    # Arrange
+    spec = RegistryProvider(name="qwen-spartan")
+    resolved = resolve_provider_spec(spec, _REGISTRY)
+    # Act
+    live = with_tunneled_base_url(resolved, local_port=14000)
+    # Assert
+    assert live.label == "Qwen vLLM (Spartan)"
+    assert live.auth_token_env == "CLEW_VLLM_TOKEN"
+
+
+def test_with_tunneled_base_url_on_non_tunneled_raises_resolution_error():
+    # Arrange
+    spec = _custom_direct()
+    resolved = resolve_provider_spec(spec, _REGISTRY)
+    # Act
+    ctx = pytest.raises(ProviderResolutionError)
+    # Assert
+    with ctx:
+        with_tunneled_base_url(resolved, local_port=14000)
+
+
+def test_with_tunneled_base_url_zero_port_raises_resolution_error():
+    # Arrange
+    spec = RegistryProvider(name="qwen-spartan")
+    resolved = resolve_provider_spec(spec, _REGISTRY)
+    # Act
+    ctx = pytest.raises(ProviderResolutionError)
+    # Assert
+    with ctx:
+        with_tunneled_base_url(resolved, local_port=0)


### PR DESCRIPTION
## Summary
- Operator-priority durable fix (2026-06-09): every local `sac agent start` (and restart) now refreshes the `<self> -> lead` row in `comms_grants` so agents can `a2a_send(target="lead")` after a state.db rebuild, host reboot, or manual revoke — no more relay-via-operator.
- Pinned inside `record_local_instance` next to the existing `register_comms_node` write, same fail-closed best-effort semantics. `grant_send` is idempotent so restarts are no-ops on the timestamp.
- Two new tests pin (a) fresh start writes the grant and (b) re-recorded restart leaves exactly one row.

## Why
Today clew had to relay status through the operator because its container saw `comms_grants` empty for `clew -> lead`. Manually re-running `sac a2a grant <agent> lead` does not survive the next restart, so the same recurrence has fired multiple times this week — frustrating both the operator and the fleet.

Pinning the grant write inside `record_local_instance` means EVERY start refreshes it; the previous shape only had it if the operator remembered to grant manually after each rebuild/reboot.

## Immediate re-grant for currently-running agents
This patch covers the NEXT restart of each agent. To cover the agents that are already running, the operator runs once on the host:

\`\`\`bash
for d in /state/*/; do
  agent=\$(basename "\$d")
  if [ -f "\$d/state.db" ]; then
    SCITEX_AGENT_CONTAINER_STATE_DB="\$d/state.db" \\
      /opt/venv-sac/bin/sac a2a grant "\$agent" lead \\
      --note "operator-priority 2026-06-09"
  fi
done
\`\`\`

After that, every running agent's a2a-send-to-lead path is unblocked without restart; subsequent restarts are covered by this PR.

## Test plan
- [x] New TDD tests in tests/scitex_agent_container/_lifecycle/test__instances.py:
  - test_record_local_instance_grants_self_to_lead
  - test_record_local_instance_grant_to_lead_is_idempotent
- [x] All 335 existing _lifecycle tests still green
- [x] scitex-dev linter check-files clean on edited source
- [ ] OPERATOR VERIFY: run the immediate re-grant snippet above, then have clew or another previously-affected agent attempt \`a2a_send(target="lead")\` end-to-end (acceptance criterion)