### PR TITLE
fix(_to_home): rename baseline sibling _base -> _shared with back-compat (OP-PRIO-3)

### DIFF
--- a/src/scitex_agent_container/_baseline_assets/claude_worktree_hooks/README.md
+++ b/src/scitex_agent_container/_baseline_assets/claude_worktree_hooks/README.md
@@ -32,13 +32,13 @@ prevention and cleanup meet in the same tree.
 
 1. Copy `worktree_create.py` and `worktree_remove.py` to the baseline:
 
-       <agents_dir>/_base/to_home/.claude/hooks/claude_worktree_hooks/
+       <agents_dir>/_shared/to_home/.claude/hooks/claude_worktree_hooks/
 
    The runtime's `_to_home.py` materializes that tree into every
    agent's `$HOME/.claude/hooks/claude_worktree_hooks/` on each start.
 
 2. Merge the `hooks` block from `settings.local.json.fragment.json`
-   into `<agents_dir>/_base/to_home/.claude/settings.local.json`
+   into `<agents_dir>/_shared/to_home/.claude/settings.local.json`
    (under the top-level `hooks` key). The fragment's `_comment_*`
    string carries the source-of-truth audit trail and should be
    preserved.

--- a/src/scitex_agent_container/_skills/scitex-agent-container/01_config-v3.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/01_config-v3.md
@@ -105,7 +105,7 @@ Every path under `to_home/` lands at the same relative path under
 `$HOME`. `CLAUDE.md` / `state.md` get a marker-protected merge; `.env`
 gets mode 0600; everything else is a full overwrite. `${VAR}` and
 `${metadata.name}` are interpolated in text files. A shared baseline
-`to_home/` (`<agents_dir>/_base/to_home`, override `$SAC_TO_HOME_BASELINE`)
+`to_home/` (`<agents_dir>/_shared/to_home`, override `$SAC_TO_HOME_BASELINE`)
 is applied first; the per-agent `to_home/` overlays on top.
 
 | Source | Destination | Mode | Semantics |

--- a/src/scitex_agent_container/_skills/scitex-agent-container/25_claude-setup-delivery.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/25_claude-setup-delivery.md
@@ -84,8 +84,10 @@ agents/<name>/to_home/
                        resolved to real content — see below)
 ```
 
-A shared baseline (`<agents_dir>/_base/to_home/`, or `$SAC_TO_HOME_BASELINE`)
+A shared baseline (`<agents_dir>/_shared/to_home/`, or `$SAC_TO_HOME_BASELINE`)
 is applied first; the per-agent `to_home/` overlays on top (per-agent wins).
+The legacy sibling name `<agents_dir>/_base/to_home/` is still accepted as a
+fallback for operators mid-rename (OP-PRIO-3, 2026-06-09).
 See `runtimes/_to_home.py` and ADR-0006 for the per-entry semantics. **This
 is general** — `to_home` is not a `.claude` delivery mechanism, it is a `$HOME`
 delivery mechanism.
@@ -95,7 +97,7 @@ delivery mechanism.
 The definition is the **sole source of truth**; the runtime **never auto-reads
 host state**. Materialization enforces this at the symlink level:
 
-- **Every** symlink under `_base/to_home/` and per-agent `to_home/` is
+- **Every** symlink under `_shared/to_home/` and per-agent `to_home/` is
   **dereference-copied**: the target resolves to real content (a file or whole
   tree, nested symlinks dereferenced too) and lands at the destination. The
   container `$HOME` holds only real, self-contained files — closed to apptainer
@@ -106,7 +108,7 @@ host state**. Materialization enforces this at the symlink level:
 - **No** keep-literal / warn-and-keep / naming behavior and **no** unconditional
   host `~/.claude/skills` auto-read. Host content enters only via an
   **explicit** `to_home/` symlink — e.g.
-  `_base/to_home/.claude/skills -> ~/.claude/skills` — resolved at deploy time
+  `_shared/to_home/.claude/skills -> ~/.claude/skills` — resolved at deploy time
   (explicit-pass). Applies to skills, hooks, `.env`, etc. An in-container
   literal symlink is made via `startup_commands`.
 

--- a/src/scitex_agent_container/_skills/scitex-agent-container/29_progress-reporting-to-lead.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/29_progress-reporting-to-lead.md
@@ -1,7 +1,7 @@
 ---
 description: |
   [TOPIC] Push progress reports to the lead's a2a inbox at every milestone, so fleet coordination stops requiring polls.
-  [DETAILS] sac agents send `mcp__sac__a2a_send(target='lead', ...)` push updates on PR open/merge/close, BLOCKED, DONE, or any significant context change. The lead reads its inbox to coordinate the fleet without reading every agent's `agent_logs` / `gh` state by hand. Speak/Telegram are for the OPERATOR; a2a push is for the LEAD. Both happen at milestones — not exclusive channels. Includes the KIND vocabulary, when-to / when-not-to thresholds, the one-time per-agent ACL grant the lead has to issue (`sac a2a grant --sender <name> --target lead`), and pointers to the companion Stop-hook reminder shipped via the dotfiles `_base/to_home/` overlay.
+  [DETAILS] sac agents send `mcp__sac__a2a_send(target='lead', ...)` push updates on PR open/merge/close, BLOCKED, DONE, or any significant context change. The lead reads its inbox to coordinate the fleet without reading every agent's `agent_logs` / `gh` state by hand. Speak/Telegram are for the OPERATOR; a2a push is for the LEAD. Both happen at milestones — not exclusive channels. Includes the KIND vocabulary, when-to / when-not-to thresholds, the one-time per-agent ACL grant the lead has to issue (`sac a2a grant --sender <name> --target lead`), and pointers to the companion Stop-hook reminder shipped via the dotfiles `_shared/to_home/` overlay.
 tags: [scitex-agent-container-progress-reporting-to-lead]
 ---
 
@@ -87,7 +87,7 @@ ACL-based send restrictions are not currently enforced in sac (verified 2026-05-
 
 ## Companion Stop-hook reminder
 
-A turn-end reminder hook ships via the dotfiles `_base/to_home/` overlay at `~/.claude/hooks/stop/report_to_lead_on_stop.{sh,md}`. The shell shim emits a stderr nudge at every Stop; the `.md` is the agent-facing protocol crib pointing right back to this skill. The hook is gated on `SCITEX_AGENT_CONTAINER_NAME` so non-sac sessions (including the lead session itself) do not inherit the reminder.
+A turn-end reminder hook ships via the dotfiles `_shared/to_home/` overlay at `~/.claude/hooks/stop/report_to_lead_on_stop.{sh,md}`. The shell shim emits a stderr nudge at every Stop; the `.md` is the agent-facing protocol crib pointing right back to this skill. The hook is gated on `SCITEX_AGENT_CONTAINER_NAME` so non-sac sessions (including the lead session itself) do not inherit the reminder.
 
 ## Cross-references
 

--- a/src/scitex_agent_container/_skills/scitex-agent-container/30_responsiveness-background-work.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/30_responsiveness-background-work.md
@@ -13,7 +13,7 @@ tags: [scitex-agent-container-responsiveness-background-work, telegram-latency, 
 > **Structural enforcement**: a pre-tool-use hook
 > ``~/.claude/hooks/pre-tool-use/force_background_bash.sh`` (shipped
 > under ``examples/agents/full-agent/to_home/.claude/hooks/`` and
-> deployed fleet-wide via the ``agents/_base/to_home/`` overlay)
+> deployed fleet-wide via the ``agents/_shared/to_home/`` overlay)
 > BLOCKS any unbounded foreground Bash with a WHY message that
 > explains the relaunch routes. This skill explains the rationale;
 > the hook is the wall. If the hook blocks you, the relaunch

--- a/src/scitex_agent_container/_skills/scitex-agent-container/41_claude-worktree-relocation.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/41_claude-worktree-relocation.md
@@ -46,11 +46,11 @@ diagnostics.
 1. Copy both `worktree_create.py` and `worktree_remove.py` into the
    baseline to_home tree:
 
-       <agents_dir>/_base/to_home/.claude/hooks/claude_worktree_hooks/
+       <agents_dir>/_shared/to_home/.claude/hooks/claude_worktree_hooks/
 
 2. Merge the `hooks` block from
    `settings.local.json.fragment.json` into
-   `<agents_dir>/_base/to_home/.claude/settings.local.json` (under the
+   `<agents_dir>/_shared/to_home/.claude/settings.local.json` (under the
    top-level `hooks` key). Preserve the `_comment_worktree_hooks`
    string — it carries the source-of-truth audit trail.
 
@@ -83,7 +83,7 @@ silent schema drift would break the relocation.
 
 The hook scripts are canonical, version-controlled, regression-tested
 implementations of a fleet-wide policy. Shipping them here (instead of
-ad-hoc in the operator's dotfiles `_base/to_home/`) means:
+ad-hoc in the operator's dotfiles `_shared/to_home/`) means:
 
 * The implementation has an audit trail (commit history + PR review).
 * The hook contract is pinned by tests, not by the operator's memory.

--- a/src/scitex_agent_container/_walk_exclusions.py
+++ b/src/scitex_agent_container/_walk_exclusions.py
@@ -9,7 +9,7 @@ Two on-start walkers in SAC enumerate large trees synchronously:
   ``to_home`` symlink-dereference step. ``shutil.copytree(...,
   symlinks=False)`` copies the whole resolved target tree into the
   container overlay; a baseline symlink like
-  ``_base/to_home/.claude/skills -> ~/.claude/skills`` transitively
+  ``_shared/to_home/.claude/skills -> ~/.claude/skills`` transitively
   pulls in anything reachable under that target.
 
 Both walkers used to descend into ``worktrees/`` subtrees, which are

--- a/src/scitex_agent_container/runtimes/_symlink_resolve.py
+++ b/src/scitex_agent_container/runtimes/_symlink_resolve.py
@@ -12,7 +12,7 @@ filesystem layout.
 
 A symlink under ``to_home/`` is the operator's *explicit* opt-in to
 pull host content into the definition (e.g.
-``_base/to_home/.claude/skills -> ~/.claude/skills``). That is
+``_shared/to_home/.claude/skills -> ~/.claude/skills``). That is
 explicit-pass, which is fine; the link is resolved to real content at
 deploy time. A symlink whose target cannot be resolved (dangling) is a
 real defect in the definition and hard-aborts the deploy via
@@ -58,7 +58,7 @@ def deref_copy_symlink(src: Path, dst: Path) -> None:
     the ``ignore`` callable handed to ``shutil.copytree`` — most
     importantly ``worktrees/`` directories anywhere in the resolved
     tree. Without this, a baseline symlink like
-    ``_base/to_home/.claude/skills -> ~/.claude/skills`` would
+    ``_shared/to_home/.claude/skills -> ~/.claude/skills`` would
     transitively pull every git worktree nested under the host's
     ``~/.claude/`` into the container overlay at start time — one of
     the two SAC-side walkers behind the original F-CS8 outage class

--- a/src/scitex_agent_container/runtimes/_to_home.py
+++ b/src/scitex_agent_container/runtimes/_to_home.py
@@ -55,9 +55,13 @@ dereference-copy).
 Baseline location (see :func:`resolve_baseline_to_home_dir`):
 
   - ``$SAC_TO_HOME_BASELINE`` — explicit override (absolute dir), or
-  - ``<agents_dir>/_base/to_home/`` — a sibling ``_base`` dir under the
-    agents root (agents live at ``<agents_dir>/<name>/``, so the agents
-    root is the spec dir's parent).
+  - ``<agents_dir>/_shared/to_home/`` — canonical sibling under the
+    agents root (OP-PRIO-3 rename 2026-06-09; was ``_base/``). Agents
+    live at ``<agents_dir>/<name>/``, so the agents root is the spec
+    dir's parent.
+  - ``<agents_dir>/_base/to_home/`` — legacy fallback honoured so an
+    in-place dotfile rename can land without a flag-day. The canonical
+    ``_shared/`` wins when both exist.
 
 Absent baseline dir → behaves exactly as before (no baseline = current
 behavior; fully backward compatible).
@@ -153,13 +157,24 @@ _MARKER_PROTECTED_BASENAMES = frozenset({"CLAUDE.md", "state.md"})
 _TIGHT_PERM_BASENAMES = frozenset({".env"})
 
 # Env var: explicit override for the shared/common baseline to_home dir.
-# Absolute path. When unset we fall back to ``<agents_dir>/_base/to_home``.
+# Absolute path. When unset we fall back first to ``<agents_dir>/_shared/
+# to_home`` (canonical, OP-PRIO-3 rename 2026-06-09), then to the legacy
+# ``<agents_dir>/_base/to_home`` for operators mid-rename.
 _BASELINE_ENV_VAR = "SAC_TO_HOME_BASELINE"
 
 # Name of the sibling dir (under the agents root) that holds the common
 # baseline. Agents live at ``<agents_dir>/<name>/``, so the agents root
-# is the spec dir's parent and the baseline is ``<parent>/_base/to_home``.
-_BASELINE_DIR_NAME = "_base"
+# is the spec dir's parent and the baseline is
+# ``<parent>/_shared/to_home``.
+#
+# Operator rename 2026-06-09 (OP-PRIO-3): the canonical name moved from
+# ``_base`` to ``_shared`` — "shared" reads as a noun + describes the
+# overlay-precedence semantics more honestly (every agent shares this
+# layer; per-agent ``to_home`` overlays on top). The legacy ``_base``
+# remains accepted as a fallback so an in-place rename of the dotfile
+# does not need a flag-day — see :func:`resolve_baseline_to_home_dir`.
+_BASELINE_DIR_NAME = "_shared"
+_LEGACY_BASELINE_DIR_NAME = "_base"
 
 
 # --- public API ------------------------------------------------------------
@@ -196,9 +211,14 @@ def resolve_baseline_to_home_dir(spec_dir: Path | None) -> Path | None:
 
     Resolution order:
       1. ``$SAC_TO_HOME_BASELINE`` (absolute dir) — explicit override.
-      2. ``<agents_dir>/_base/to_home`` — a sibling ``_base`` dir under
-         the agents root. Agents live at ``<agents_dir>/<name>/``, so the
-         agents root is ``spec_dir.parent``.
+      2. ``<agents_dir>/_shared/to_home`` — canonical sibling under the
+         agents root (OP-PRIO-3 rename 2026-06-09). Agents live at
+         ``<agents_dir>/<name>/``, so the agents root is
+         ``spec_dir.parent``.
+      3. ``<agents_dir>/_base/to_home`` — legacy fallback so an
+         in-place dotfile rename can land without a flag-day. The
+         canonical ``_shared/`` wins when both exist, so a partial
+         rename does not silently fall back to stale ``_base/`` content.
 
     Returns ``None`` when no baseline dir can be resolved (no baseline =
     current behavior; fully backward compatible).
@@ -209,8 +229,11 @@ def resolve_baseline_to_home_dir(spec_dir: Path | None) -> Path | None:
         return p if p.is_dir() else None
     if spec_dir is None:
         return None
-    p = spec_dir.parent / _BASELINE_DIR_NAME / "to_home"
-    return p if p.is_dir() else None
+    canonical = spec_dir.parent / _BASELINE_DIR_NAME / "to_home"
+    if canonical.is_dir():
+        return canonical
+    legacy = spec_dir.parent / _LEGACY_BASELINE_DIR_NAME / "to_home"
+    return legacy if legacy.is_dir() else None
 
 
 def materialize_to_home(spec_dir: Path, workspace_home: Path) -> None:

--- a/tests/scitex_agent_container/runtimes/test__to_home.py
+++ b/tests/scitex_agent_container/runtimes/test__to_home.py
@@ -642,6 +642,58 @@ class TestResolveBaselineToHomeDir:
         # Assert
         assert resolved is None
 
+    def test_resolves_sibling_shared_dir_under_agents_root(self, tmp_path):
+        """OP-PRIO-3 (2026-06-09 operator rename): the canonical baseline
+        sibling is now ``_shared/`` (was ``_base/``). When only ``_shared/``
+        exists, the resolver picks it.
+        """
+        # Arrange — spec dir with a sibling _shared/to_home (no _base).
+        agents_root = tmp_path / "agents"
+        spec_dir = agents_root / "test-agent"
+        spec_dir.mkdir(parents=True)
+        shared_baseline = agents_root / "_shared" / "to_home"
+        shared_baseline.mkdir(parents=True)
+        # Act
+        resolved = resolve_baseline_to_home_dir(spec_dir)
+        # Assert
+        assert resolved == shared_baseline
+
+    def test_resolves_legacy_base_dir_when_shared_absent(self, tmp_path):
+        """OP-PRIO-3 back-compat: an operator who has not yet renamed the
+        dotfile from ``_base/`` to ``_shared/`` must keep working —
+        legacy ``_base/`` is honoured as a fallback when ``_shared/``
+        is absent.
+        """
+        # Arrange — only legacy _base/to_home present.
+        agents_root = tmp_path / "agents"
+        spec_dir = agents_root / "test-agent"
+        spec_dir.mkdir(parents=True)
+        legacy_baseline = agents_root / "_base" / "to_home"
+        legacy_baseline.mkdir(parents=True)
+        # Act
+        resolved = resolve_baseline_to_home_dir(spec_dir)
+        # Assert
+        assert resolved == legacy_baseline
+
+    def test_shared_wins_over_legacy_base_when_both_present(self, tmp_path):
+        """OP-PRIO-3 transition: during a half-finished rename the operator
+        may have BOTH ``_shared/`` AND legacy ``_base/`` on disk. The
+        canonical ``_shared/`` must win so a partial-rename does not
+        silently fall back to stale ``_base/`` content.
+        """
+        # Arrange — both layouts exist simultaneously.
+        agents_root = tmp_path / "agents"
+        spec_dir = agents_root / "test-agent"
+        spec_dir.mkdir(parents=True)
+        shared_baseline = agents_root / "_shared" / "to_home"
+        shared_baseline.mkdir(parents=True)
+        legacy_baseline = agents_root / "_base" / "to_home"
+        legacy_baseline.mkdir(parents=True)
+        # Act
+        resolved = resolve_baseline_to_home_dir(spec_dir)
+        # Assert
+        assert resolved == shared_baseline
+
 
 class TestMaterializeBaselineOverlay:
     def test_baseline_only_file_lands_in_home(self, tmp_path):


### PR DESCRIPTION
## Summary
- Operator-priority rename (2026-06-09, OP-PRIO-3): canonical baseline sibling under \`<agents_dir>/\` is now \`_shared/\` (was \`_base/\`). "shared" reads as the noun it is and matches the overlay-precedence semantics — every agent SHARES this layer; the per-agent \`to_home/\` overlays on top.
- Legacy \`_base/\` is honoured as a fallback so the operator can rename the dotfile in place without a flag-day. Canonical \`_shared/\` wins when both exist, so a partial rename never silently falls back to stale \`_base/\` content.

## What changed
- \`runtimes/_to_home.py\`: \`_BASELINE_DIR_NAME = "_shared"\` (was \`"_base"\`); add \`_LEGACY_BASELINE_DIR_NAME = "_base"\`; \`resolve_baseline_to_home_dir\` now prefers \`_shared/\` then falls back to \`_base/\`.
- Module + function docstrings updated; back-compat note added.
- Skill docs + \`runtimes/_symlink_resolve.py\` + \`_walk_exclusions.py\` + \`_baseline_assets/claude_worktree_hooks/README.md\` updated to the canonical name.

## Test plan
- [x] 3 new TDD tests in \`tests/scitex_agent_container/runtimes/test__to_home.py\` (canonical, back-compat, _shared-wins-over-_base)
- [x] All 64 _to_home tests green
- [x] Full \`tests/scitex_agent_container/runtimes/\` green (no regression from doc updates)
- [ ] OPERATOR: rename the dotfile \`~/.dotfiles/.../agents/_base/\` -> \`agents/_shared/\` (or symlink one to the other). Runtime accepts either; canonical is \`_shared\`.