### PR TITLE
feat(telegram_hooks): 5 PreToolUse format-enforcers for telegram reply (OP-PRIO-FMT)

### DIFF
--- a/.scitex/dev/config/forbidden-words.yaml
+++ b/.scitex/dev/config/forbidden-words.yaml
@@ -31,3 +31,10 @@ forbidden_word:
   - word: 無関係
     reason: 'distancing/disowning: 「関係ない」と同様。問題を遠ざける言い回し。'
     use_instead: '別件であれば「別件: ...」、優先度判断であれば「優先度低: ...」と明示する。'
+  # ---- Katakana-jargon (operator 2026-06-09) ----------------------------
+  - word: ナッジ
+    reason: 'katakana jargon: 動詞「促す」「ヒント」など日本語で十分な意味をカタカナで隠す。'
+    use_instead: '日本語で具体的に言う (例: ``リマインダー`` → ``通知``、``ヒント``、``一言促す``、``NUDGE`` ラベルは英語そのまま)。'
+  - word: なっじ
+    reason: 'katakana jargon (hiragana spelling): same as ナッジ.'
+    use_instead: '日本語で具体的に言う (``通知`` / ``ヒント`` / ``一言促す``)。'

--- a/.scitex/dev/config/forbidden-words.yaml
+++ b/.scitex/dev/config/forbidden-words.yaml
@@ -1,0 +1,33 @@
+# Project-level forbidden-words config for the
+# ``forbidden_words.sh`` pre-tool-use hook (canonical schema +
+# loader owned by scitex-dev). Pre-send Telegram messages whose
+# text matches any entry below are BLOCKED with the entry's
+# ``reason`` + ``use_instead`` text.
+#
+# Lead directive 2026-06-09: distancing / disowning phrases
+# defuse ownership of a problem (it is "ours" until proven
+# otherwise; never "pre-existing", "unrelated", or "irrelevant").
+# Block them at the comms layer so the agent rephrases before
+# the operator ever reads the dodge.
+#
+# Schema: forbidden_word: [ {word | pattern, reason, use_instead}, ... ]
+# Loader path order (UNION; project ADDS to global):
+#   ~/.scitex/dev/config/forbidden-words.yaml      (global)
+#   <cwd>/.scitex/dev/config/forbidden-words.yaml  (this file when cwd=/work)
+#
+# Operators on other hosts get the same rules by copying or
+# symlinking _baseline_assets/telegram_hooks/forbidden-words.yaml
+# into ~/.scitex/dev/config/ — see that file's sibling README.md
+# for the deployment recipe.
+
+forbidden_word:
+  # ---- Disowning phrases (lead 2026-06-09) ------------------------------
+  - word: 既存の問題
+    reason: 'distancing/disowning: 問題は「我々の」もの。「既存」と呼ぶことで責任を切り離す印象を与える。'
+    use_instead: '「(我々の)問題」と中立に呼ぶ、または事実だけを述べる (例: ``X が失敗している``)。'
+  - word: 関係ない
+    reason: 'distancing/disowning: 問題を「関係ない」と切ることで責任放棄に読まれる。'
+    use_instead: '事実ベースで言う (例: ``X とは別件``)、または「私の担当範囲外なので Y に依頼します」と所有を移譲する。'
+  - word: 無関係
+    reason: 'distancing/disowning: 「関係ない」と同様。問題を遠ざける言い回し。'
+    use_instead: '別件であれば「別件: ...」、優先度判断であれば「優先度低: ...」と明示する。'

--- a/.scitex/dev/config/forbidden-words.yaml
+++ b/.scitex/dev/config/forbidden-words.yaml
@@ -10,6 +10,11 @@
 # Block them at the comms layer so the agent rephrases before
 # the operator ever reads the dodge.
 #
+# Operator 2026-06-09 (comprehensive update): every katakana-jargon
+# entry has an English equivalent ALSO banned, so the same word in
+# either script is caught. English patterns are case-insensitive
+# with word boundaries — "fallback", "Fallback", "FALLBACK" all hit.
+#
 # Schema: forbidden_word: [ {word | pattern, reason, use_instead}, ... ]
 # Loader path order (UNION; project ADDS to global):
 #   ~/.scitex/dev/config/forbidden-words.yaml      (global)
@@ -25,11 +30,11 @@ forbidden_word:
   - word: 既存の問題
     reason: 'distancing/disowning: 問題は「我々の」もの。「既存」と呼ぶことで責任を切り離す印象を与える。'
     use_instead: '「(我々の)問題」と中立に呼ぶ、または事実だけを述べる (例: ``X が失敗している``)。'
-  - word: 関係ない
-    reason: 'distancing/disowning: 問題を「関係ない」と切ることで責任放棄に読まれる。'
+  - pattern: '関係(ない|無い)'
+    reason: 'distancing/disowning: 問題を「関係(ない|無い)」と切ることで責任放棄に読まれる。'
     use_instead: '事実ベースで言う (例: ``X とは別件``)、または「私の担当範囲外なので Y に依頼します」と所有を移譲する。'
   - word: 無関係
-    reason: 'distancing/disowning: 「関係ない」と同様。問題を遠ざける言い回し。'
+    reason: 'distancing/disowning: 「関係(ない|無い)」と同様。問題を遠ざける言い回し。'
     use_instead: '別件であれば「別件: ...」、優先度判断であれば「優先度低: ...」と明示する。'
   # ---- Katakana-jargon (operator 2026-06-09) ----------------------------
   - word: ナッジ
@@ -38,3 +43,38 @@ forbidden_word:
   - word: なっじ
     reason: 'katakana jargon (hiragana spelling): same as ナッジ.'
     use_instead: '日本語で具体的に言う (``通知`` / ``ヒント`` / ``一言促す``)。'
+  - word: ステイル
+    reason: 'katakana jargon: ``stale`` の日本語化。「古い」「陳腐化」など普通の語を隠す。'
+    use_instead: '日本語で言う (``古い`` / ``陳腐化`` / ``期限切れ``)。'
+  - word: フォールバック
+    reason: 'katakana jargon: ``fallback`` の日本語化。「代替」「次善策」「予備経路」など具体語を隠す。'
+    use_instead: '具体語で言う (``代替`` / ``予備経路`` / ``二次パス``)。'
+  - word: ロールバック
+    reason: 'katakana jargon: ``rollback`` の日本語化。「巻き戻し」「差し戻し」など具体語を隠す。'
+    use_instead: '具体語で言う (``巻き戻し`` / ``差し戻し`` / ``前バージョンに戻す``)。'
+  - word: ウェッジ
+    reason: 'katakana jargon: ``wedge`` の日本語化。「詰まり」「ハング」「ブロック」など具体的な失敗様態を隠す。'
+    use_instead: '具体的な失敗様態で言う (``詰まり`` / ``ハング`` / ``応答無し`` / ``ブロック``)。'
+  # ---- English equivalents of katakana jargon (operator 2026-06-09) -----
+  # Case-insensitive, word-bounded so substrings inside legitimate
+  # identifiers (``fallback_path``, ``rollback_safe``, etc.) still trip —
+  # the operator wants these broadly covered. NUDGE the ALL-CAPS label
+  # stays allowed by the wider hook ecosystem; the rule fires on the
+  # word as a token, but a deliberately-uppercased acronym at the start
+  # of a status report (e.g. "[NUDGE] ...") still reads as English
+  # markup and is part of the comms convention.
+  - pattern: '(?i)\bnudge\b'
+    reason: 'english equivalent of ナッジ: same hidden-verb objection.'
+    use_instead: 'use concrete English (``reminder`` / ``hint`` / ``one-liner``) or the JP equivalent.'
+  - pattern: '(?i)\bstale\b'
+    reason: 'english equivalent of ステイル: same hidden-meaning objection.'
+    use_instead: 'use concrete English (``out-of-date`` / ``expired`` / ``no longer current``).'
+  - pattern: '(?i)\bfallback\b'
+    reason: 'english equivalent of フォールバック: hides the actual alternative path.'
+    use_instead: 'name the path (``secondary route`` / ``backup`` / ``alternative``).'
+  - pattern: '(?i)\brollback\b'
+    reason: 'english equivalent of ロールバック: hides the actual revert step.'
+    use_instead: 'name the step (``revert to <ref>`` / ``undo`` / ``restore previous``).'
+  - pattern: '(?i)\bwedge\b'
+    reason: 'english equivalent of ウェッジ: hides the failure mode.'
+    use_instead: 'name the failure mode (``hang`` / ``stuck`` / ``deadlocked`` / ``no response``).'

--- a/src/scitex_agent_container/_baseline_assets/telegram_hooks/README.md
+++ b/src/scitex_agent_container/_baseline_assets/telegram_hooks/README.md
@@ -1,0 +1,72 @@
+# Telegram format-hook scripts (OP-PRIO-FMT, 2026-06-09)
+
+Canonical, version-controlled implementations of the 5 telegram-message
+format enforcers the operator priortised on 2026-06-09. Ships alongside
+`claude_worktree_hooks/` under
+`scitex_agent_container/_baseline_assets/telegram_hooks/`, but is
+**not** auto-deployed — the operator copies (or symlinks) the scripts
+into their dotfile baseline tree so the runtime's `to_home`
+materializer drops them into every agent's `$HOME/.claude/hooks/
+pre-tool-use/` on every start.
+
+The matcher is **the FQ MCP tool name** (`mcp__claude-code-telegrammer__reply`).
+A literal `"telegram"` matcher does NOT fire on MCP tool names — that
+was the OP-PRIO-2 bug fixed the same day; do not regress it.
+
+## Scripts
+
+| Script | Rule | Behaviour | Escape env |
+|---|---|---|---|
+| `enforce_telegram_numbering.sh` | 1. Lettered options must be numbered (`1a/1b` or `1./2.`) | BLOCK | `CC_ALLOW_LETTERED_OPTIONS=1` |
+| `enforce_telegram_no_bare_issue.sh` | 2. A message can't be just `#162` (bare issue/PR number) | BLOCK | `CC_ALLOW_BARE_ISSUE=1` |
+| `enforce_telegram_use_lists.sh` | 3. 3+ enumerated items must be a list, not run-on prose | BLOCK | `CC_ALLOW_PROSE_ENUM=1` |
+| `enforce_telegram_no_filler.sh` | 4. No filler / hedging words (`basically`, `actually`, `一旦`, `とりあえず`, ...) | BLOCK | `CC_ALLOW_FILLER=1` |
+| `encourage_telegram_terse_style.sh` | 5. Long sentences should end in a terse closer (`します/しました/done/...`) | REMINDER (stderr nudge, rc=0) | `CC_ALLOW_NON_TERSE=1` |
+
+Each script supports `--self-test` and emits a `pass=N fail=M` summary
+plus rc=0 (all pass) / rc=1 (any fail). The companion pytest at
+`tests/scitex_agent_container/_baseline_assets/test_telegram_hooks.py`
+runs every script's self-test in CI so a regression to either the
+script logic or the test contract surfaces on PR.
+
+## Deployment (operator)
+
+The operator's dotfile baseline tree (`_shared/to_home/` — see
+`runtimes/_to_home.py`, OP-PRIO-3 rename) is the materialization
+source. Two acceptable layouts:
+
+1. **Copy** the scripts into the dotfile:
+
+       cp <repo>/src/scitex_agent_container/_baseline_assets/telegram_hooks/*.sh \
+          ~/.dotfiles/src/.scitex/agent-container/agents/_shared/to_home/.claude/hooks/pre-tool-use/
+
+2. **Symlink** the dotfile directory to the canonical version:
+
+       ln -s <repo>/src/scitex_agent_container/_baseline_assets/telegram_hooks/*.sh \
+          ~/.dotfiles/src/.scitex/agent-container/agents/_shared/to_home/.claude/hooks/pre-tool-use/
+
+   Symlinks under `to_home/` are dereference-copied at materialize time
+   (see `_symlink_resolve.deref_copy_symlink`), so the agent's
+   `$HOME/.claude/hooks/...` ends up holding real script content.
+
+After the copy/symlink, merge the wiring into
+`_shared/to_home/.claude/settings.local.json` — the
+`settings.local.json.fragment.json` sibling shows the exact JSON to
+splice into the top-level `hooks.PreToolUse` array.
+
+Restart agents (or wait for next natural restart). NO SIF REBUILD —
+`_to_home.deploy_to_home` runs on every start and lays the new
+scripts + settings before Claude Code reads its config.
+
+## Live-fire verify
+
+After deployment, send a deliberately violating Telegram message from
+ANY restarted agent (the operator's preferred verification path):
+
+    1a) packed numbered  -> telegram_line_spacing.sh blocks
+    1b) bare #162        -> enforce_telegram_no_bare_issue.sh blocks
+    1c) "Basically X"    -> enforce_telegram_no_filler.sh blocks
+
+If any rule fires NUDGE (not BLOCK), the matcher fix did NOT land —
+re-check `settings.local.json` for the `mcp__claude-code-telegrammer__reply`
+FQ matcher (OP-PRIO-2).

--- a/src/scitex_agent_container/_baseline_assets/telegram_hooks/README.md
+++ b/src/scitex_agent_container/_baseline_assets/telegram_hooks/README.md
@@ -70,3 +70,34 @@ ANY restarted agent (the operator's preferred verification path):
 If any rule fires NUDGE (not BLOCK), the matcher fix did NOT land —
 re-check `settings.local.json` for the `mcp__claude-code-telegrammer__reply`
 FQ matcher (OP-PRIO-2).
+
+## Forbidden-words YAML (lead directive 2026-06-09)
+
+A separate hook (`forbidden_words.sh`, canonical schema + loader owned
+by scitex-dev) is already wired into the operator's dotfile baseline
+under the same matcher block. It reads a YAML config at:
+
+* `~/.scitex/dev/config/forbidden-words.yaml` (global)
+* `<cwd>/.scitex/dev/config/forbidden-words.yaml` (project-specific)
+
+The lead added three **distancing/disowning** phrases to ban
+fleet-wide on 2026-06-09: `既存の問題`, `関係ない`, `無関係`. The
+data lives in two version-controlled places:
+
+1. `<repo>/.scitex/dev/config/forbidden-words.yaml` — picked up
+   automatically when an agent runs with `cwd=/work` (the project-local
+   layer in the loader's UNION).
+2. `<repo>/src/scitex_agent_container/_baseline_assets/telegram_hooks/forbidden-words.yaml`
+   — canonical deployable; operators copy or symlink it into
+   `~/.scitex/dev/config/forbidden-words.yaml` so every host (and the
+   lead's own session) blocks the same words.
+
+       cp <repo>/src/scitex_agent_container/_baseline_assets/telegram_hooks/forbidden-words.yaml \
+          ~/.scitex/dev/config/forbidden-words.yaml
+
+After deployment a Telegram reply containing any of the three phrases
+hits `rc=2` + a stderr nudge naming the word, the reason it is
+forbidden, and the suggested replacement. The pytest at
+`tests/scitex_agent_container/_baseline_assets/telegram_hooks/test_forbidden_words_yaml.py`
+pins both YAML copies stay in sync on the disowning trio so a
+project-local override never silently drops a phrase.

--- a/src/scitex_agent_container/_baseline_assets/telegram_hooks/encourage_telegram_terse_style.sh
+++ b/src/scitex_agent_container/_baseline_assets/telegram_hooks/encourage_telegram_terse_style.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+# -*- coding: utf-8 -*-
+# Timestamp: "2026-06-09 (OP-PRIO-FMT rule 5)"
+# File: ~/.claude/hooks/pre-tool-use/encourage_telegram_terse_style.sh
+#
+# OP-PRIO-FMT rule 5 (operator 2026-06-09): prefer the terse
+# ``します`` / ``しました`` style. Messages should read as concise
+# INTENT (will do) or completed FACT (done) — not as rambling
+# narration. This rule is SUBJECTIVE — Japanese sentence structure
+# admits too many valid endings to mechanically demand only ``する``
+# system verbs. Instead this hook acts as a STRONG REMINDER: it
+# emits a stderr nudge but always exits 0 (non-blocking) so legit
+# variants pass while the agent stays aware of the convention.
+#
+# Heuristic: a single sentence > 35 chars whose end (last 15
+# chars) does NOT contain a ``する/した/します/しました`` ending,
+# nor a terse English sentence verb (did/done/opened/merged), gets
+# the nudge. JP chars are visually denser than ASCII so 35 is a
+# realistic floor for "long enough to deserve a terse closer".
+#
+# Fires on: tool_name matches the matcher in settings.local.json
+# (must be the FQ mcp__claude-code-telegrammer__reply name — operator
+# 2026-06-09 OP-PRIO-2 matcher fix is a hard prerequisite).
+# FAIL-OPEN on any parse error or unexpected payload shape. ALWAYS
+# exits 0 — this hook is a reminder, not a blocker.
+# Escape: CC_ALLOW_NON_TERSE=1 silences the reminder entirely.
+
+set -u
+[[ "${CC_ALLOW_NON_TERSE:-}" == "1" ]] && exit 0
+
+if [[ "${1:-}" == "--self-test" ]]; then
+    echo "=== Self-test: $(basename "$0") ==="
+    pass=0
+    fail=0
+    run() {
+        local desc="$1" tool="$2" text="$3" rc
+        # Reminder hook: always rc=0. We pin the rc=0 contract here,
+        # AND we pin whether stderr carries the nudge (test by length).
+        local want_nudge="$4" stderr
+        stderr=$(printf '%s' "{\"tool_name\":\"$tool\",\"tool_input\":{\"chat_id\":\"1\",\"text\":$(printf '%s' "$text" | python3 -c 'import sys,json;print(json.dumps(sys.stdin.read()))')}}" \
+            | "$0" 2>&1 >/dev/null)
+        rc=$?
+        local has_nudge=0
+        [[ -n "$stderr" ]] && has_nudge=1
+        if [[ "$rc" == "0" && "$has_nudge" == "$want_nudge" ]]; then
+            echo "  PASS rc=$rc nudge=$has_nudge $desc"; pass=$((pass+1))
+        else
+            echo "  FAIL rc=$rc nudge=$has_nudge want_nudge=$want_nudge: $desc"; fail=$((fail+1))
+        fi
+    }
+    T="mcp__claude-code-telegrammer__reply"
+    run "terse JP します ending             -> no nudge" "$T" "PR #343 opened します" 0
+    run "terse JP しました ending           -> no nudge" "$T" "rename commit しました" 0
+    run "terse EN done                      -> no nudge" "$T" "merge done" 0
+    run "long rambling JP no terse ending   -> NUDGE"   "$T" "色々と調べた結果、結局のところよくわからなかったので、後で確認する予定です、たぶん" 1
+    run "short non-terse                    -> no nudge" "$T" "hi" 0
+    run "non-telegram tool ignored          -> no nudge" "Bash" "rambling rambling rambling rambling rambling rambling rambling" 0
+    echo "pass=$pass fail=$fail"
+    [[ "$fail" == "0" ]] && exit 0 || exit 1
+fi
+
+exec python3 -c '
+import json
+import re
+import sys
+
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+tool = data.get("tool_name", "")
+if "claude-code-telegrammer__reply" not in tool:
+    sys.exit(0)
+text = (data.get("tool_input", {}) or {}).get("text", "") or ""
+if not text:
+    sys.exit(0)
+# Heuristic: long sentences (> 60 chars) whose tail (last 15 chars)
+# carries no terse ending get the nudge. Tail tokens we accept:
+TERSE_TAILS = (
+    "します", "しました", "ました", "した", "する", "した。", "します。", "しました。",
+    "done", "opened", "merged", "fixed", "shipped", "verified", "pushed",
+    "closed", "completed",
+)
+def is_terse_tail(s):
+    # Require the trimmed sentence to END WITH one of the terse tokens
+    # (not merely CONTAIN one in the last 15 chars). Otherwise a tail
+    # like "確認する予定です、たぶん" would match "する" mid-string and
+    # bypass the nudge even though the sentence actually ends with
+    # the hedging "たぶん".
+    stripped = s.rstrip().rstrip("。").rstrip(".").lower()
+    return any(stripped.endswith(t.rstrip("。").lower()) for t in TERSE_TAILS)
+
+sentences = re.split(r"[。\n]", text)
+for s in sentences:
+    s = s.strip()
+    if not s or len(s) <= 35:
+        continue
+    if is_terse_tail(s):
+        continue
+    sys.stderr.write(
+        "REMINDER from encourage_telegram_terse_style.sh: long "
+        f"sentence ({len(s)} chars) lacks a terse closer "
+        "(します / しました / done / opened / merged / etc.). "
+        "Operator (2026-06-09) prefers messages that read as "
+        "INTENT (will do) or FACT (done), not rambling narration. "
+        "Consider tightening or splitting.\n\n"
+        f"  offending tail: ...{s[-30:]!r}\n\n"
+        "Silence this hook entirely: set env CC_ALLOW_NON_TERSE=1.\n"
+    )
+    break  # one nudge per message is enough
+sys.exit(0)
+'
+exit $?

--- a/src/scitex_agent_container/_baseline_assets/telegram_hooks/enforce_telegram_no_bare_issue.sh
+++ b/src/scitex_agent_container/_baseline_assets/telegram_hooks/enforce_telegram_no_bare_issue.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# -*- coding: utf-8 -*-
+# Timestamp: "2026-06-09 (OP-PRIO-FMT rule 2)"
+# File: ~/.claude/hooks/pre-tool-use/enforce_telegram_no_bare_issue.sh
+#
+# OP-PRIO-FMT rule 2 (operator 2026-06-09): a Telegram message MUST NOT
+# be a bare issue/PR number ("#162") with no surrounding context. The
+# operator's phone shows the message itself; an opaque "#162" forces
+# the operator to open GitHub to learn what is being reported. Demand
+# at least a verb + the noun the issue describes.
+#
+# Detection: the WHOLE message text (trimmed of leading/trailing
+# whitespace and outer brackets) reduces to ONLY one or more bare
+# ``#\d+`` tokens. ``#162``, ``#162 #163``, ``[#162]`` → BLOCK.
+# ``#162 figrecipe caption overlap`` → ALLOW. ``fix #162`` → ALLOW.
+#
+# Fires on: tool_name matches the matcher in settings.local.json
+# (must be the FQ mcp__claude-code-telegrammer__reply name — operator
+# 2026-06-09 OP-PRIO-2 matcher fix is a hard prerequisite).
+# FAIL-OPEN on any parse error or unexpected payload shape.
+# Escape: CC_ALLOW_BARE_ISSUE=1.
+
+set -u
+[[ "${CC_ALLOW_BARE_ISSUE:-}" == "1" ]] && exit 0
+
+if [[ "${1:-}" == "--self-test" ]]; then
+    echo "=== Self-test: $(basename "$0") ==="
+    pass=0
+    fail=0
+    run() {
+        local desc="$1" tool="$2" text="$3" want="$4" rc
+        printf '%s' "{\"tool_name\":\"$tool\",\"tool_input\":{\"chat_id\":\"1\",\"text\":$(printf '%s' "$text" | python3 -c 'import sys,json;print(json.dumps(sys.stdin.read()))')}}" \
+            | "$0" >/dev/null 2>&1
+        rc=$?
+        if [[ "$rc" == "$want" ]]; then echo "  PASS ($rc) $desc"; pass=$((pass+1));
+        else echo "  FAIL got $rc want $want: $desc"; fail=$((fail+1)); fi
+    }
+    T="mcp__claude-code-telegrammer__reply"
+    run "bare single   #162                    -> block" "$T" "#162" 2
+    run "bare in brackets [#162]               -> block" "$T" "[#162]" 2
+    run "two bare      #162 #163               -> block" "$T" "#162 #163" 2
+    run "trimmed       \"  #162  \"            -> block" "$T" "  #162  " 2
+    run "verb + #      fix #162                -> allow" "$T" "fix #162" 0
+    run "noun + #      #162 figrecipe caption  -> allow" "$T" "#162 figrecipe caption" 0
+    run "prose only    we are looking at issue -> allow" "$T" "we are looking at issue" 0
+    run "non-telegram  Bash tool ignored       -> allow" "Bash" "#162" 0
+    run "empty text                            -> allow" "$T" "" 0
+    # Escape-var contract: when ``CC_ALLOW_BARE_ISSUE=1`` is exported the
+    # script must early-exit 0 even on a bare ``#NNN``. Tested by invoking
+    # the script in a child shell that exports the var first.
+    if CC_ALLOW_BARE_ISSUE=1 \
+        printf '%s' "{\"tool_name\":\"$T\",\"tool_input\":{\"chat_id\":\"1\",\"text\":\"#162\"}}" \
+        | CC_ALLOW_BARE_ISSUE=1 "$0" >/dev/null 2>&1; then
+        echo "  PASS (0) escape var honored                    -> allow"
+        pass=$((pass+1))
+    else
+        echo "  FAIL escape var honored                    -> allow"
+        fail=$((fail+1))
+    fi
+    echo "pass=$pass fail=$fail"
+    [[ "$fail" == "0" ]] && exit 0 || exit 1
+fi
+
+exec python3 -c '
+import json
+import os
+import re
+import sys
+
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+tool = data.get("tool_name", "")
+if "claude-code-telegrammer__reply" not in tool:
+    sys.exit(0)
+text = (data.get("tool_input", {}) or {}).get("text", "") or ""
+if not text:
+    sys.exit(0)
+stripped = text.strip()
+# Strip outer brackets if the WHOLE message is wrapped.
+inner = stripped
+if (inner.startswith("[") and inner.endswith("]")) or (inner.startswith("(") and inner.endswith(")")):
+    inner = inner[1:-1].strip()
+# Tokenise: are ALL tokens bare #NNN?
+tokens = inner.split()
+if not tokens:
+    sys.exit(0)
+bare_issue = re.compile(r"^#\d+$")
+if all(bare_issue.match(tok) for tok in tokens):
+    sys.stderr.write(
+        "BLOCKED by enforce_telegram_no_bare_issue.sh: the whole message "
+        f"is a bare issue/PR number ({inner!r}). The operator reads on a "
+        "phone; an opaque #NNN forces a GitHub round-trip just to learn "
+        "what is being reported.\n\n"
+        "  - Add the verb + noun: \"figrecipe #162 caption overlap "
+        "reproduced (3 bugs)\".\n"
+        "  - Or report the STATE: \"merged #343 (lead a2a auto-grant)\".\n\n"
+        "Rare one-off override: set env CC_ALLOW_BARE_ISSUE=1.\n"
+    )
+    sys.exit(2)
+sys.exit(0)
+'
+exit $?

--- a/src/scitex_agent_container/_baseline_assets/telegram_hooks/enforce_telegram_no_filler.sh
+++ b/src/scitex_agent_container/_baseline_assets/telegram_hooks/enforce_telegram_no_filler.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# -*- coding: utf-8 -*-
+# Timestamp: "2026-06-09 (OP-PRIO-FMT rule 4)"
+# File: ~/.claude/hooks/pre-tool-use/enforce_telegram_no_filler.sh
+#
+# OP-PRIO-FMT rule 4 (operator 2026-06-09, 無駄口): a Telegram message
+# MUST NOT contain filler / hedging words that pad the line without
+# adding signal. The operator wants terse status, not narration.
+# Detects common Japanese + English fillers; BLOCKS with a list of the
+# offending tokens.
+#
+# Fires on: tool_name matches the matcher in settings.local.json
+# (must be the FQ mcp__claude-code-telegrammer__reply name — operator
+# 2026-06-09 OP-PRIO-2 matcher fix is a hard prerequisite).
+# FAIL-OPEN on any parse error or unexpected payload shape.
+# Escape: CC_ALLOW_FILLER=1.
+
+set -u
+[[ "${CC_ALLOW_FILLER:-}" == "1" ]] && exit 0
+
+if [[ "${1:-}" == "--self-test" ]]; then
+    echo "=== Self-test: $(basename "$0") ==="
+    pass=0
+    fail=0
+    run() {
+        local desc="$1" tool="$2" text="$3" want="$4" rc
+        printf '%s' "{\"tool_name\":\"$tool\",\"tool_input\":{\"chat_id\":\"1\",\"text\":$(printf '%s' "$text" | python3 -c 'import sys,json;print(json.dumps(sys.stdin.read()))')}}" \
+            | "$0" >/dev/null 2>&1
+        rc=$?
+        if [[ "$rc" == "$want" ]]; then echo "  PASS ($rc) $desc"; pass=$((pass+1));
+        else echo "  FAIL got $rc want $want: $desc"; fail=$((fail+1)); fi
+    }
+    T="mcp__claude-code-telegrammer__reply"
+    run "EN: basically X is Y              -> block" "$T" "Basically, X is Y." 2
+    run "EN: actually we did it            -> block" "$T" "Actually we did it." 2
+    run "EN: just a quick update           -> block" "$T" "Just a quick update on PR." 2
+    run "JP: とりあえず restart             -> block" "$T" "とりあえず restart します" 2
+    run "JP: なんか log が出てる            -> block" "$T" "なんか log が出てる" 2
+    run "JP: 一旦 保留                      -> block" "$T" "一旦 保留" 2
+    run "clean: PR #343 opened             -> allow" "$T" "PR #343 opened" 0
+    run "clean: 完了報告: rename committed -> allow" "$T" "完了報告: rename committed" 0
+    run "non-telegram tool ignored         -> allow" "Bash" "Just a test" 0
+    run "empty text                        -> allow" "$T" "" 0
+    echo "pass=$pass fail=$fail"
+    [[ "$fail" == "0" ]] && exit 0 || exit 1
+fi
+
+exec python3 -c '
+import json
+import re
+import sys
+
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+tool = data.get("tool_name", "")
+if "claude-code-telegrammer__reply" not in tool:
+    sys.exit(0)
+text = (data.get("tool_input", {}) or {}).get("text", "") or ""
+if not text:
+    sys.exit(0)
+# English filler — match as whole words, case-insensitive.
+EN_FILLER = [
+    "actually", "basically", "just", "really", "honestly", "obviously",
+    "kinda", "sorta", "anyway", "anyways", "literally", "essentially",
+]
+# Japanese filler — substring match (no word boundaries in JP).
+JP_FILLER = [
+    "一旦", "とりあえず", "ちょっと", "なんか", "まあ", "えーと",
+    "やはり", "つまり", "結局", "なんとなく", "そうですね",
+]
+hits = []
+for w in EN_FILLER:
+    if re.search(rf"(?<![A-Za-z]){re.escape(w)}(?![A-Za-z])", text, re.IGNORECASE):
+        hits.append(w)
+for w in JP_FILLER:
+    if w in text:
+        hits.append(w)
+if hits:
+    sys.stderr.write(
+        "BLOCKED by enforce_telegram_no_filler.sh: filler/hedging words "
+        f"found: {sorted(set(hits))!r}. Operator wants terse status, not "
+        "narration. Strip the filler and report the bare fact.\n\n"
+        "  - \"Basically we did X\" -> \"did X\".\n"
+        "  - \"一旦 保留\" -> \"保留\".\n"
+        "  - \"actually it works\" -> \"works\".\n\n"
+        "Rare one-off override: set env CC_ALLOW_FILLER=1.\n"
+    )
+    sys.exit(2)
+sys.exit(0)
+'
+exit $?

--- a/src/scitex_agent_container/_baseline_assets/telegram_hooks/enforce_telegram_numbering.sh
+++ b/src/scitex_agent_container/_baseline_assets/telegram_hooks/enforce_telegram_numbering.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# -*- coding: utf-8 -*-
+# Timestamp: "2026-06-09 (OP-PRIO-FMT rule 1)"
+# File: ~/.claude/hooks/pre-tool-use/enforce_telegram_numbering.sh
+#
+# OP-PRIO-FMT rule 1 (operator 2026-06-09): a Telegram message that
+# OFFERS OPTIONS / CHOICES MUST number them in the operator's
+# preferred 1a / 1b style (or plain 1. / 2. enumeration). The
+# motivation is one-tap quoting on a phone: the operator selects
+# by INDEX, not by hunting for the letter mid-paragraph.
+#
+# Detection: the message contains ``A)`` AND ``B)`` (the lettered
+# option pattern) anywhere — without a parallel ``1.`` / ``1a.`` /
+# ``1)`` numbered alternative ALSO present. Lettered-only options
+# BLOCK with a nudge to renumber.
+#
+# Fires on: tool_name matches the matcher in settings.local.json
+# (must be the FQ mcp__claude-code-telegrammer__reply name — operator
+# 2026-06-09 OP-PRIO-2 matcher fix is a hard prerequisite).
+# FAIL-OPEN on any parse error or unexpected payload shape.
+# Escape: CC_ALLOW_LETTERED_OPTIONS=1.
+
+set -u
+[[ "${CC_ALLOW_LETTERED_OPTIONS:-}" == "1" ]] && exit 0
+
+if [[ "${1:-}" == "--self-test" ]]; then
+    echo "=== Self-test: $(basename "$0") ==="
+    pass=0
+    fail=0
+    run() {
+        local desc="$1" tool="$2" text="$3" want="$4" rc
+        printf '%s' "{\"tool_name\":\"$tool\",\"tool_input\":{\"chat_id\":\"1\",\"text\":$(printf '%s' "$text" | python3 -c 'import sys,json;print(json.dumps(sys.stdin.read()))')}}" \
+            | "$0" >/dev/null 2>&1
+        rc=$?
+        if [[ "$rc" == "$want" ]]; then echo "  PASS ($rc) $desc"; pass=$((pass+1));
+        else echo "  FAIL got $rc want $want: $desc"; fail=$((fail+1)); fi
+    }
+    T="mcp__claude-code-telegrammer__reply"
+    run "lettered A) + B) only           -> block" "$T" $'A) issue\nB) fix\nC) workaround' 2
+    run "lettered A) B) inline           -> block" "$T" 'Pick: A) ship now B) hold' 2
+    run "lettered + numbered 1a/1b mix   -> allow" "$T" $'1a) issue\n1b) fix\n1c) workaround' 0
+    run "plain numbered 1. 2.            -> allow" "$T" $'1. issue\n2. fix' 0
+    run "no options at all               -> allow" "$T" "completed PR-A merge." 0
+    run "prose with A something          -> allow" "$T" "A new issue was opened." 0
+    run "non-telegram tool ignored       -> allow" "Bash" "A) x B) y" 0
+    run "empty text                      -> allow" "$T" "" 0
+    echo "pass=$pass fail=$fail"
+    [[ "$fail" == "0" ]] && exit 0 || exit 1
+fi
+
+exec python3 -c '
+import json
+import re
+import sys
+
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+tool = data.get("tool_name", "")
+if "claude-code-telegrammer__reply" not in tool:
+    sys.exit(0)
+text = (data.get("tool_input", {}) or {}).get("text", "") or ""
+if not text:
+    sys.exit(0)
+# Lettered options: at least TWO of {A) B) C) D) E)} appear as option
+# markers — either at the start of a line, or after a space + letter +
+# close-paren. We anchor on space-or-line-start so prose like "A new
+# issue" does not trip.
+lettered_pat = re.compile(r"(?:^|\s)([A-E])\)\s", re.MULTILINE)
+letters_found = set(lettered_pat.findall(text))
+if len(letters_found) < 2:
+    sys.exit(0)
+# If the same text ALSO has a parallel numbered enumeration (1. / 1a.
+# / 1)), let it pass — the operator can still tap by index.
+numbered_pat = re.compile(r"(?:^|\s)(\d+[a-z]?[.)])\s", re.MULTILINE)
+if numbered_pat.search(text):
+    sys.exit(0)
+sys.stderr.write(
+    "BLOCKED by enforce_telegram_numbering.sh: lettered options "
+    f"detected ({sorted(letters_found)!r}) without a parallel "
+    "numbered enumeration. Operator (2026-06-09): use 1a/1b/1c "
+    "(or 1./2./3.) so options can be quoted by INDEX on a phone, "
+    "not by hunting for a letter mid-paragraph.\n\n"
+    "  - Bad : \"A) ship now  B) hold  C) revert\".\n"
+    "  - Good: \"1a) ship now\\n1b) hold\\n1c) revert\".\n\n"
+    "Rare one-off override: set env CC_ALLOW_LETTERED_OPTIONS=1.\n"
+)
+sys.exit(2)
+'
+exit $?

--- a/src/scitex_agent_container/_baseline_assets/telegram_hooks/enforce_telegram_use_lists.sh
+++ b/src/scitex_agent_container/_baseline_assets/telegram_hooks/enforce_telegram_use_lists.sh
@@ -5,13 +5,19 @@
 #
 # OP-PRIO-FMT rule 3 (operator 2026-06-09): a Telegram message that
 # enumerates 3+ items MUST present them as a list, not as run-on
-# prose. The operator skims structured lists; commma-soup hides the
-# count and forces re-reading.
+# prose. The operator skims structured lists; comma-soup AND
+# slash-cramming hide the count and force re-reading.
 #
-# Detection: a single non-list line contains 3+ comma-separated
-# fragments joined by "and" / "or" / "、" / "，". Lines that already
-# start with a list marker (``-``, ``*``, ``1.``, ``1a.``, ``A)``,
-# etc.) are exempt.
+# Detection (any one of these on a single non-list line fires):
+#   - 3+ comma-separated fragments (EN ``,`` with ``and``/``or``
+#     conjunction, OR JP ``、`` / ``，`` 2+ occurrences), OR
+#   - 3+ items separated by `` / `` (slash with SURROUNDING spaces).
+#     The operator's most common run-on form (lead 2026-06-09):
+#     ``やること: 認証PR / ボード整理 / スキル更新 / 通知設定``.
+#     URL / path slashes (``http://...``, ``/home/...``) are guarded
+#     because their slashes have NO surrounding spaces.
+# Lines that already start with a list marker (``-``, ``*``, ``1.``,
+# ``1a.``, ``A)``, etc.) are exempt.
 #
 # Fires on: tool_name matches the matcher in settings.local.json
 # (must be the FQ mcp__claude-code-telegrammer__reply name — operator
@@ -37,11 +43,18 @@ if [[ "${1:-}" == "--self-test" ]]; then
     T="mcp__claude-code-telegrammer__reply"
     run "prose 3 items \"A, B, and C\"      -> block" "$T" "did A, B, and C in one pass." 2
     run "prose 3 items JP 「A、B、C」        -> block" "$T" "A、B、C を実装した。" 2
+    # Lead 2026-06-09 detection-gap repro: slash-separated cramming.
+    run "slash 4 items JP やること:...      -> block" "$T" "やること: 認証PR / ボード整理 / スキル更新 / 通知設定" 2
+    run "slash 3 items EN \"A / B / C\"     -> block" "$T" "did A / B / C in parallel" 2
+    run "slash 2 items only \"A / B\"       -> allow" "$T" "ran A / B" 0
+    # URL/path slashes must NOT trip (no spaces around the slashes).
+    run "URL with many slashes              -> allow" "$T" "see https://example.com/path/to/file" 0
+    run "POSIX path many slashes            -> allow" "$T" "edited /home/agent/.claude/hooks/x.sh" 0
     run "two items only \"A and B\"         -> allow" "$T" "did A and B." 0
     run "list already \"- A\\n- B\\n- C\"   -> allow" "$T" $'- A\n- B\n- C' 0
     run "numbered list \"1. A\\n2. B\\n3.C\" -> allow" "$T" $'1. A\n2. B\n3. C' 0
     run "non-enumeration prose             -> allow" "$T" "PR opened" 0
-    run "non-telegram tool ignored         -> allow" "Bash" "A, B, and C" 0
+    run "non-telegram tool ignored         -> allow" "Bash" "A / B / C" 0
     run "empty text                        -> allow" "$T" "" 0
     echo "pass=$pass fail=$fail"
     [[ "$fail" == "0" ]] && exit 0 || exit 1
@@ -68,6 +81,11 @@ LIST_PREFIX = re.compile(r"^\s*(?:[-*•]|\d+[a-z]?[.)]|[A-E]\))\s")
 #   - 2+ commas (EN: ",") OR 2+ JP commas ("、" / "，")
 #   - AND a closing conjunction ("and " / "or " / "、" trailing).
 EN_PROSE = re.compile(r"\b(?:and|or)\b\s+\S", re.IGNORECASE)
+# Slash-cramming detector (lead 2026-06-09 gap fix). Matches a literal
+# slash with REQUIRED surrounding spaces, so URLs (``http://``) and
+# POSIX paths (``/home/...``) — whose slashes have no spaces around
+# them — never trip. 2+ occurrences = 3+ items = "use a list".
+SLASH_SEP = re.compile(r" / ")
 for raw in text.split("\n"):
     line = raw.strip()
     if not line:
@@ -77,13 +95,16 @@ for raw in text.split("\n"):
     en_commas = line.count(",")
     jp_commas = line.count("、") + line.count("，")
     has_conjunction = bool(EN_PROSE.search(line)) or line.count("、") >= 2
-    if (en_commas >= 2 and has_conjunction) or jp_commas >= 2:
+    slash_seps = len(SLASH_SEP.findall(line))
+    if (en_commas >= 2 and has_conjunction) or jp_commas >= 2 or slash_seps >= 2:
         sys.stderr.write(
             "BLOCKED by enforce_telegram_use_lists.sh: prose "
             f"enumeration detected in line {line!r}. Operator "
             "(2026-06-09) wants 3+ items as a list — comma-soup "
-            "hides the count and forces re-reading on the phone.\n\n"
+            "AND slash-cramming hide the count and force "
+            "re-reading on the phone.\n\n"
             "  - Bad : \"did A, B, and C in one pass.\"\n"
+            "  - Bad : \"やること: 認証PR / ボード整理 / スキル更新 / 通知設定\"\n"
             "  - Good: \"- A\\n- B\\n- C\" (or numbered 1./2./3.).\n\n"
             "Rare one-off override: set env CC_ALLOW_PROSE_ENUM=1.\n"
         )

--- a/src/scitex_agent_container/_baseline_assets/telegram_hooks/enforce_telegram_use_lists.sh
+++ b/src/scitex_agent_container/_baseline_assets/telegram_hooks/enforce_telegram_use_lists.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# -*- coding: utf-8 -*-
+# Timestamp: "2026-06-09 (OP-PRIO-FMT rule 3)"
+# File: ~/.claude/hooks/pre-tool-use/enforce_telegram_use_lists.sh
+#
+# OP-PRIO-FMT rule 3 (operator 2026-06-09): a Telegram message that
+# enumerates 3+ items MUST present them as a list, not as run-on
+# prose. The operator skims structured lists; commma-soup hides the
+# count and forces re-reading.
+#
+# Detection: a single non-list line contains 3+ comma-separated
+# fragments joined by "and" / "or" / "、" / "，". Lines that already
+# start with a list marker (``-``, ``*``, ``1.``, ``1a.``, ``A)``,
+# etc.) are exempt.
+#
+# Fires on: tool_name matches the matcher in settings.local.json
+# (must be the FQ mcp__claude-code-telegrammer__reply name — operator
+# 2026-06-09 OP-PRIO-2 matcher fix is a hard prerequisite).
+# FAIL-OPEN on any parse error or unexpected payload shape.
+# Escape: CC_ALLOW_PROSE_ENUM=1.
+
+set -u
+[[ "${CC_ALLOW_PROSE_ENUM:-}" == "1" ]] && exit 0
+
+if [[ "${1:-}" == "--self-test" ]]; then
+    echo "=== Self-test: $(basename "$0") ==="
+    pass=0
+    fail=0
+    run() {
+        local desc="$1" tool="$2" text="$3" want="$4" rc
+        printf '%s' "{\"tool_name\":\"$tool\",\"tool_input\":{\"chat_id\":\"1\",\"text\":$(printf '%s' "$text" | python3 -c 'import sys,json;print(json.dumps(sys.stdin.read()))')}}" \
+            | "$0" >/dev/null 2>&1
+        rc=$?
+        if [[ "$rc" == "$want" ]]; then echo "  PASS ($rc) $desc"; pass=$((pass+1));
+        else echo "  FAIL got $rc want $want: $desc"; fail=$((fail+1)); fi
+    }
+    T="mcp__claude-code-telegrammer__reply"
+    run "prose 3 items \"A, B, and C\"      -> block" "$T" "did A, B, and C in one pass." 2
+    run "prose 3 items JP 「A、B、C」        -> block" "$T" "A、B、C を実装した。" 2
+    run "two items only \"A and B\"         -> allow" "$T" "did A and B." 0
+    run "list already \"- A\\n- B\\n- C\"   -> allow" "$T" $'- A\n- B\n- C' 0
+    run "numbered list \"1. A\\n2. B\\n3.C\" -> allow" "$T" $'1. A\n2. B\n3. C' 0
+    run "non-enumeration prose             -> allow" "$T" "PR opened" 0
+    run "non-telegram tool ignored         -> allow" "Bash" "A, B, and C" 0
+    run "empty text                        -> allow" "$T" "" 0
+    echo "pass=$pass fail=$fail"
+    [[ "$fail" == "0" ]] && exit 0 || exit 1
+fi
+
+exec python3 -c '
+import json
+import re
+import sys
+
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+tool = data.get("tool_name", "")
+if "claude-code-telegrammer__reply" not in tool:
+    sys.exit(0)
+text = (data.get("tool_input", {}) or {}).get("text", "") or ""
+if not text:
+    sys.exit(0)
+# A line that already STARTS with a list marker is exempt.
+LIST_PREFIX = re.compile(r"^\s*(?:[-*•]|\d+[a-z]?[.)]|[A-E]\))\s")
+# Detect run-on prose enumeration on a single line:
+#   - 2+ commas (EN: ",") OR 2+ JP commas ("、" / "，")
+#   - AND a closing conjunction ("and " / "or " / "、" trailing).
+EN_PROSE = re.compile(r"\b(?:and|or)\b\s+\S", re.IGNORECASE)
+for raw in text.split("\n"):
+    line = raw.strip()
+    if not line:
+        continue
+    if LIST_PREFIX.match(line):
+        continue
+    en_commas = line.count(",")
+    jp_commas = line.count("、") + line.count("，")
+    has_conjunction = bool(EN_PROSE.search(line)) or line.count("、") >= 2
+    if (en_commas >= 2 and has_conjunction) or jp_commas >= 2:
+        sys.stderr.write(
+            "BLOCKED by enforce_telegram_use_lists.sh: prose "
+            f"enumeration detected in line {line!r}. Operator "
+            "(2026-06-09) wants 3+ items as a list — comma-soup "
+            "hides the count and forces re-reading on the phone.\n\n"
+            "  - Bad : \"did A, B, and C in one pass.\"\n"
+            "  - Good: \"- A\\n- B\\n- C\" (or numbered 1./2./3.).\n\n"
+            "Rare one-off override: set env CC_ALLOW_PROSE_ENUM=1.\n"
+        )
+        sys.exit(2)
+sys.exit(0)
+'
+exit $?

--- a/src/scitex_agent_container/_baseline_assets/telegram_hooks/forbidden-words.yaml
+++ b/src/scitex_agent_container/_baseline_assets/telegram_hooks/forbidden-words.yaml
@@ -15,17 +15,22 @@
 # "pre-existing", "unrelated", or "irrelevant"). Block them at the
 # comms layer so the agent rephrases before the operator reads the
 # dodge.
+#
+# Operator 2026-06-09 (comprehensive update): every katakana-jargon
+# entry has an English equivalent ALSO banned so the same word in
+# either script is caught. English patterns are case-insensitive with
+# word boundaries — ``fallback``, ``Fallback``, ``FALLBACK`` all hit.
 
 forbidden_word:
   # ---- Disowning phrases (lead 2026-06-09) ------------------------------
   - word: 既存の問題
     reason: 'distancing/disowning: 問題は「我々の」もの。「既存」と呼ぶことで責任を切り離す印象を与える。'
     use_instead: '「(我々の)問題」と中立に呼ぶ、または事実だけを述べる (例: ``X が失敗している``)。'
-  - word: 関係ない
-    reason: 'distancing/disowning: 問題を「関係ない」と切ることで責任放棄に読まれる。'
+  - pattern: '関係(ない|無い)'
+    reason: 'distancing/disowning: 問題を「関係(ない|無い)」と切ることで責任放棄に読まれる。'
     use_instead: '事実ベースで言う (例: ``X とは別件``)、または「私の担当範囲外なので Y に依頼します」と所有を移譲する。'
   - word: 無関係
-    reason: 'distancing/disowning: 「関係ない」と同様。問題を遠ざける言い回し。'
+    reason: 'distancing/disowning: 「関係(ない|無い)」と同様。問題を遠ざける言い回し。'
     use_instead: '別件であれば「別件: ...」、優先度判断であれば「優先度低: ...」と明示する。'
   # ---- Katakana-jargon (operator 2026-06-09) ----------------------------
   - word: ナッジ
@@ -34,3 +39,31 @@ forbidden_word:
   - word: なっじ
     reason: 'katakana jargon (hiragana spelling): same as ナッジ.'
     use_instead: '日本語で具体的に言う (``通知`` / ``ヒント`` / ``一言促す``)。'
+  - word: ステイル
+    reason: 'katakana jargon: ``stale`` の日本語化。「古い」「陳腐化」など普通の語を隠す。'
+    use_instead: '日本語で言う (``古い`` / ``陳腐化`` / ``期限切れ``)。'
+  - word: フォールバック
+    reason: 'katakana jargon: ``fallback`` の日本語化。「代替」「次善策」「予備経路」など具体語を隠す。'
+    use_instead: '具体語で言う (``代替`` / ``予備経路`` / ``二次パス``)。'
+  - word: ロールバック
+    reason: 'katakana jargon: ``rollback`` の日本語化。「巻き戻し」「差し戻し」など具体語を隠す。'
+    use_instead: '具体語で言う (``巻き戻し`` / ``差し戻し`` / ``前バージョンに戻す``)。'
+  - word: ウェッジ
+    reason: 'katakana jargon: ``wedge`` の日本語化。「詰まり」「ハング」「ブロック」など具体的な失敗様態を隠す。'
+    use_instead: '具体的な失敗様態で言う (``詰まり`` / ``ハング`` / ``応答無し`` / ``ブロック``)。'
+  # ---- English equivalents of katakana jargon (operator 2026-06-09) -----
+  - pattern: '(?i)\bnudge\b'
+    reason: 'english equivalent of ナッジ: same hidden-verb objection.'
+    use_instead: 'use concrete English (``reminder`` / ``hint`` / ``one-liner``) or the JP equivalent.'
+  - pattern: '(?i)\bstale\b'
+    reason: 'english equivalent of ステイル: same hidden-meaning objection.'
+    use_instead: 'use concrete English (``out-of-date`` / ``expired`` / ``no longer current``).'
+  - pattern: '(?i)\bfallback\b'
+    reason: 'english equivalent of フォールバック: hides the actual alternative path.'
+    use_instead: 'name the path (``secondary route`` / ``backup`` / ``alternative``).'
+  - pattern: '(?i)\brollback\b'
+    reason: 'english equivalent of ロールバック: hides the actual revert step.'
+    use_instead: 'name the step (``revert to <ref>`` / ``undo`` / ``restore previous``).'
+  - pattern: '(?i)\bwedge\b'
+    reason: 'english equivalent of ウェッジ: hides the failure mode.'
+    use_instead: 'name the failure mode (``hang`` / ``stuck`` / ``deadlocked`` / ``no response``).'

--- a/src/scitex_agent_container/_baseline_assets/telegram_hooks/forbidden-words.yaml
+++ b/src/scitex_agent_container/_baseline_assets/telegram_hooks/forbidden-words.yaml
@@ -17,6 +17,7 @@
 # dodge.
 
 forbidden_word:
+  # ---- Disowning phrases (lead 2026-06-09) ------------------------------
   - word: 既存の問題
     reason: 'distancing/disowning: 問題は「我々の」もの。「既存」と呼ぶことで責任を切り離す印象を与える。'
     use_instead: '「(我々の)問題」と中立に呼ぶ、または事実だけを述べる (例: ``X が失敗している``)。'
@@ -26,3 +27,10 @@ forbidden_word:
   - word: 無関係
     reason: 'distancing/disowning: 「関係ない」と同様。問題を遠ざける言い回し。'
     use_instead: '別件であれば「別件: ...」、優先度判断であれば「優先度低: ...」と明示する。'
+  # ---- Katakana-jargon (operator 2026-06-09) ----------------------------
+  - word: ナッジ
+    reason: 'katakana jargon: 動詞「促す」「ヒント」など日本語で十分な意味をカタカナで隠す。'
+    use_instead: '日本語で具体的に言う (例: ``リマインダー`` → ``通知``、``ヒント``、``一言促す``、``NUDGE`` ラベルは英語そのまま)。'
+  - word: なっじ
+    reason: 'katakana jargon (hiragana spelling): same as ナッジ.'
+    use_instead: '日本語で具体的に言う (``通知`` / ``ヒント`` / ``一言促す``)。'

--- a/src/scitex_agent_container/_baseline_assets/telegram_hooks/forbidden-words.yaml
+++ b/src/scitex_agent_container/_baseline_assets/telegram_hooks/forbidden-words.yaml
@@ -1,0 +1,28 @@
+# Canonical, version-controlled forbidden-words config for the
+# ``forbidden_words.sh`` pre-tool-use hook (schema + loader owned by
+# scitex-dev). Operators on every host pick this file up by copying or
+# symlinking it into the path the hook reads:
+#
+#   cp <repo>/src/scitex_agent_container/_baseline_assets/telegram_hooks/forbidden-words.yaml \
+#      ~/.scitex/dev/config/forbidden-words.yaml
+#
+# After deployment, any agent OR the lead session that sends an
+# outbound Telegram message containing one of the words below is
+# BLOCKED with the listed ``reason`` + ``use_instead`` text.
+#
+# Lead directive 2026-06-09: distancing / disowning phrases defuse
+# ownership of a problem (it is "ours" until proven otherwise; never
+# "pre-existing", "unrelated", or "irrelevant"). Block them at the
+# comms layer so the agent rephrases before the operator reads the
+# dodge.
+
+forbidden_word:
+  - word: 既存の問題
+    reason: 'distancing/disowning: 問題は「我々の」もの。「既存」と呼ぶことで責任を切り離す印象を与える。'
+    use_instead: '「(我々の)問題」と中立に呼ぶ、または事実だけを述べる (例: ``X が失敗している``)。'
+  - word: 関係ない
+    reason: 'distancing/disowning: 問題を「関係ない」と切ることで責任放棄に読まれる。'
+    use_instead: '事実ベースで言う (例: ``X とは別件``)、または「私の担当範囲外なので Y に依頼します」と所有を移譲する。'
+  - word: 無関係
+    reason: 'distancing/disowning: 「関係ない」と同様。問題を遠ざける言い回し。'
+    use_instead: '別件であれば「別件: ...」、優先度判断であれば「優先度低: ...」と明示する。'

--- a/src/scitex_agent_container/_baseline_assets/telegram_hooks/settings.local.json.fragment.json
+++ b/src/scitex_agent_container/_baseline_assets/telegram_hooks/settings.local.json.fragment.json
@@ -1,0 +1,30 @@
+{
+  "_comment_telegram_format_hooks": "OP-PRIO-FMT (2026-06-09 operator priority) — splice this matcher block into _shared/to_home/.claude/settings.local.json under hooks.PreToolUse. Matcher MUST be the FQ MCP tool name mcp__claude-code-telegrammer__reply (OP-PRIO-2 hard prerequisite). See _baseline_assets/telegram_hooks/README.md for the full deployment recipe.",
+  "PreToolUse": [
+    {
+      "matcher": "mcp__claude-code-telegrammer__reply",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "$HOME/.claude/hooks/pre-tool-use/enforce_telegram_numbering.sh"
+        },
+        {
+          "type": "command",
+          "command": "$HOME/.claude/hooks/pre-tool-use/enforce_telegram_no_bare_issue.sh"
+        },
+        {
+          "type": "command",
+          "command": "$HOME/.claude/hooks/pre-tool-use/enforce_telegram_use_lists.sh"
+        },
+        {
+          "type": "command",
+          "command": "$HOME/.claude/hooks/pre-tool-use/enforce_telegram_no_filler.sh"
+        },
+        {
+          "type": "command",
+          "command": "$HOME/.claude/hooks/pre-tool-use/encourage_telegram_terse_style.sh"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/integration/telegram_hooks/test_forbidden_words_yaml.py
+++ b/tests/integration/telegram_hooks/test_forbidden_words_yaml.py
@@ -33,7 +33,7 @@ from pathlib import Path
 import pytest
 import yaml
 
-_REPO_ROOT = Path(__file__).resolve().parents[4]
+_REPO_ROOT = Path(__file__).resolve().parents[3]
 _PROJECT_YAML = _REPO_ROOT / ".scitex" / "dev" / "config" / "forbidden-words.yaml"
 _BASELINE_YAML = (
     _REPO_ROOT
@@ -90,8 +90,10 @@ def _entries(data: dict) -> list[dict]:
 )
 class TestForbiddenWordsYaml:
     def test_yaml_loads_cleanly(self, path: Path) -> None:
-        # Arrange / Act
-        data = _load(path)
+        # Arrange
+        loader = _load
+        # Act
+        data = loader(path)
         # Assert
         assert isinstance(data.get("forbidden_word"), list)
 

--- a/tests/integration/telegram_hooks/test_telegram_hooks_self_tests.py
+++ b/tests/integration/telegram_hooks/test_telegram_hooks_self_tests.py
@@ -24,7 +24,7 @@ from pathlib import Path
 import pytest
 
 _HOOKS_DIR = (
-    Path(__file__).resolve().parents[4]
+    Path(__file__).resolve().parents[3]
     / "src"
     / "scitex_agent_container"
     / "_baseline_assets"
@@ -44,10 +44,12 @@ def _run_self_test(script_name: str) -> subprocess.CompletedProcess[str]:
     )
 
 
-def _assert_self_test_clean(result: subprocess.CompletedProcess[str]) -> None:
+def _summary_tail(result: subprocess.CompletedProcess[str]) -> str:
+    """Helper for the failure message: surface the script's own
+    `pass=N fail=M` summary line plus a tail of stdout/stderr.
+    """
     summary = result.stdout.splitlines()[-1] if result.stdout else ""
-    assert result.returncode == 0, (
-        f"self-test returned rc={result.returncode}; expected 0.\n"
+    return (
         f"summary line: {summary!r}\n"
         f"stdout tail:\n{result.stdout[-800:]}\n"
         f"stderr tail:\n{result.stderr[-400:]}"
@@ -56,37 +58,47 @@ def _assert_self_test_clean(result: subprocess.CompletedProcess[str]) -> None:
 
 def test_enforce_telegram_no_bare_issue_self_test_passes():
     # Arrange
-    result = _run_self_test("enforce_telegram_no_bare_issue.sh")
-    # Act / Assert
-    _assert_self_test_clean(result)
+    script_name = "enforce_telegram_no_bare_issue.sh"
+    # Act
+    result = _run_self_test(script_name)
+    # Assert
+    assert result.returncode == 0, _summary_tail(result)
 
 
 def test_enforce_telegram_no_filler_self_test_passes():
     # Arrange
-    result = _run_self_test("enforce_telegram_no_filler.sh")
-    # Act / Assert
-    _assert_self_test_clean(result)
+    script_name = "enforce_telegram_no_filler.sh"
+    # Act
+    result = _run_self_test(script_name)
+    # Assert
+    assert result.returncode == 0, _summary_tail(result)
 
 
 def test_enforce_telegram_numbering_self_test_passes():
     # Arrange
-    result = _run_self_test("enforce_telegram_numbering.sh")
-    # Act / Assert
-    _assert_self_test_clean(result)
+    script_name = "enforce_telegram_numbering.sh"
+    # Act
+    result = _run_self_test(script_name)
+    # Assert
+    assert result.returncode == 0, _summary_tail(result)
 
 
 def test_enforce_telegram_use_lists_self_test_passes():
     # Arrange
-    result = _run_self_test("enforce_telegram_use_lists.sh")
-    # Act / Assert
-    _assert_self_test_clean(result)
+    script_name = "enforce_telegram_use_lists.sh"
+    # Act
+    result = _run_self_test(script_name)
+    # Assert
+    assert result.returncode == 0, _summary_tail(result)
 
 
 def test_encourage_telegram_terse_style_self_test_passes():
     # Arrange
-    result = _run_self_test("encourage_telegram_terse_style.sh")
-    # Act / Assert
-    _assert_self_test_clean(result)
+    script_name = "encourage_telegram_terse_style.sh"
+    # Act
+    result = _run_self_test(script_name)
+    # Assert
+    assert result.returncode == 0, _summary_tail(result)
 
 
 @pytest.mark.parametrize(

--- a/tests/scitex_agent_container/_baseline_assets/telegram_hooks/test_forbidden_words_yaml.py
+++ b/tests/scitex_agent_container/_baseline_assets/telegram_hooks/test_forbidden_words_yaml.py
@@ -1,0 +1,114 @@
+"""Pin the disowning-phrase entries in the version-controlled
+forbidden-words YAML configs (lead directive 2026-06-09).
+
+The forbidden_words.sh hook (canonical schema + loader owned by
+scitex-dev, materialised into agent + lead containers via the
+dotfile baseline) reads YAML configs at:
+
+* ``~/.scitex/dev/config/forbidden-words.yaml`` (global)
+* ``<cwd>/.scitex/dev/config/forbidden-words.yaml`` (project-specific)
+
+This repo ships TWO copies of the same data so the hook fires in
+both contexts:
+
+1. ``.scitex/dev/config/forbidden-words.yaml`` — picked up by the
+   hook when an agent runs with ``cwd=/work`` (the project-local
+   path the loader checks second).
+2. ``src/scitex_agent_container/_baseline_assets/telegram_hooks/forbidden-words.yaml``
+   — the canonical, version-controlled deployable. Operators copy
+   or symlink THIS file into ``~/.scitex/dev/config/forbidden-words.yaml``
+   on every host so the hook fires for cross-host sessions too.
+
+These tests pin: (a) both YAMLs load cleanly, (b) both contain the
+THREE lead-mandated disowning phrases (`既存の問題`, `関係ない`,
+`無関係`), and (c) every entry carries the schema-required
+``word``/``pattern`` + ``reason`` + ``use_instead`` keys so the
+hook's nudge message is informative on a hit.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_PROJECT_YAML = _REPO_ROOT / ".scitex" / "dev" / "config" / "forbidden-words.yaml"
+_BASELINE_YAML = (
+    _REPO_ROOT
+    / "src"
+    / "scitex_agent_container"
+    / "_baseline_assets"
+    / "telegram_hooks"
+    / "forbidden-words.yaml"
+)
+
+_REQUIRED_DISOWNING_PHRASES = ("既存の問題", "関係ない", "無関係")
+
+
+def _load(path: Path) -> dict:
+    assert path.is_file(), f"forbidden-words config missing: {path}"
+    with path.open(encoding="utf-8") as f:
+        return yaml.safe_load(f) or {}
+
+
+def _entries(data: dict) -> list[dict]:
+    return [e for e in (data.get("forbidden_word") or []) if isinstance(e, dict)]
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        pytest.param(_PROJECT_YAML, id="project-cwd"),
+        pytest.param(_BASELINE_YAML, id="baseline-deployable"),
+    ],
+)
+class TestForbiddenWordsYaml:
+    def test_yaml_loads_cleanly(self, path: Path) -> None:
+        # Arrange / Act
+        data = _load(path)
+        # Assert
+        assert isinstance(data.get("forbidden_word"), list)
+
+    def test_carries_all_required_disowning_phrases(self, path: Path) -> None:
+        # Arrange — three phrases the lead mandated 2026-06-09.
+        data = _load(path)
+        words = {e.get("word") for e in _entries(data)}
+        # Act
+        missing = [w for w in _REQUIRED_DISOWNING_PHRASES if w not in words]
+        # Assert
+        assert missing == []
+
+    def test_every_entry_has_required_schema_fields(self, path: Path) -> None:
+        # Arrange — the hook's nudge message names ``reason`` +
+        # ``use_instead`` for every blocked word; missing either field
+        # would surface an empty/None in the operator's view.
+        data = _load(path)
+        # Act
+        bad = [
+            e
+            for e in _entries(data)
+            if not (e.get("word") or e.get("pattern"))
+            or not e.get("reason")
+            or not e.get("use_instead")
+        ]
+        # Assert
+        assert bad == [], f"entries missing required keys: {bad!r}"
+
+
+def test_project_and_baseline_carry_identical_disowning_set() -> None:
+    """Drift guard: the project-local config + the canonical
+    deployable must stay in sync on the disowning trio so a
+    project-local override never silently drops a phrase from the
+    fleet-wide ban list.
+    """
+    # Arrange
+    proj = {e.get("word") for e in _entries(_load(_PROJECT_YAML))}
+    baseline = {e.get("word") for e in _entries(_load(_BASELINE_YAML))}
+    required = set(_REQUIRED_DISOWNING_PHRASES)
+    # Act
+    proj_has = required & proj
+    baseline_has = required & baseline
+    # Assert
+    assert (proj_has, baseline_has) == (required, required)

--- a/tests/scitex_agent_container/_baseline_assets/telegram_hooks/test_forbidden_words_yaml.py
+++ b/tests/scitex_agent_container/_baseline_assets/telegram_hooks/test_forbidden_words_yaml.py
@@ -44,12 +44,31 @@ _BASELINE_YAML = (
     / "forbidden-words.yaml"
 )
 
-_REQUIRED_DISOWNING_PHRASES = ("既存の問題", "関係ない", "無関係")
-# Operator added 2026-06-09: katakana jargon "ナッジ" + hiragana
-# spelling "なっじ" are banned the same way (lead applies "nudge"
-# the English label in NUDGE/REMINDER context; the katakana
-# Japanese-ification of it is what's banned).
-_REQUIRED_KATAKANA_JARGON = ("ナッジ", "なっじ")
+# Disowning phrases — three required entries. The "関係" form is a
+# REGEX (operator 2026-06-09: covers both 関係ない and 関係無い).
+# The other two are literal words.
+_REQUIRED_DISOWNING_WORDS = ("既存の問題", "無関係")
+_REQUIRED_DISOWNING_PATTERNS = ("関係(ない|無い)",)
+# Operator 2026-06-09 (comprehensive): every katakana-jargon entry has
+# an English equivalent ALSO banned. The katakana entries are literal
+# words (Japanese has no word boundaries) and the English ones are
+# regex patterns with ``(?i)\b...\b`` so case-insensitive word-bounded
+# matches catch "fallback", "Fallback", "FALLBACK" alike.
+_REQUIRED_KATAKANA_JARGON_WORDS = (
+    "ナッジ",
+    "なっじ",
+    "ステイル",
+    "フォールバック",
+    "ロールバック",
+    "ウェッジ",
+)
+_REQUIRED_ENGLISH_EQUIVALENT_PATTERNS = (
+    r"(?i)\bnudge\b",
+    r"(?i)\bstale\b",
+    r"(?i)\bfallback\b",
+    r"(?i)\brollback\b",
+    r"(?i)\bwedge\b",
+)
 
 
 def _load(path: Path) -> dict:
@@ -76,21 +95,43 @@ class TestForbiddenWordsYaml:
         # Assert
         assert isinstance(data.get("forbidden_word"), list)
 
-    def test_carries_all_required_disowning_phrases(self, path: Path) -> None:
-        # Arrange — three phrases the lead mandated 2026-06-09.
+    def test_carries_all_required_disowning_words(self, path: Path) -> None:
+        # Arrange — literal-word disowning phrases the lead mandated 2026-06-09.
         data = _load(path)
         words = {e.get("word") for e in _entries(data)}
         # Act
-        missing = [w for w in _REQUIRED_DISOWNING_PHRASES if w not in words]
+        missing = [w for w in _REQUIRED_DISOWNING_WORDS if w not in words]
         # Assert
         assert missing == []
 
-    def test_carries_all_required_katakana_jargon(self, path: Path) -> None:
-        # Arrange — katakana-jargon entries the operator mandated 2026-06-09.
+    def test_carries_all_required_disowning_patterns(self, path: Path) -> None:
+        # Arrange — regex disowning pattern (関係(ない|無い)) the lead mandated 2026-06-09.
+        data = _load(path)
+        patterns = {e.get("pattern") for e in _entries(data)}
+        # Act
+        missing = [p for p in _REQUIRED_DISOWNING_PATTERNS if p not in patterns]
+        # Assert
+        assert missing == []
+
+    def test_carries_all_required_katakana_jargon_words(self, path: Path) -> None:
+        # Arrange — katakana-jargon literal-word entries the operator
+        # mandated 2026-06-09 (comprehensive update).
         data = _load(path)
         words = {e.get("word") for e in _entries(data)}
         # Act
-        missing = [w for w in _REQUIRED_KATAKANA_JARGON if w not in words]
+        missing = [w for w in _REQUIRED_KATAKANA_JARGON_WORDS if w not in words]
+        # Assert
+        assert missing == []
+
+    def test_carries_all_required_english_equivalent_patterns(self, path: Path) -> None:
+        # Arrange — English equivalents of every katakana-jargon entry,
+        # banned via case-insensitive word-bounded regex (operator 2026-06-09).
+        data = _load(path)
+        patterns = {e.get("pattern") for e in _entries(data)}
+        # Act
+        missing = [
+            p for p in _REQUIRED_ENGLISH_EQUIVALENT_PATTERNS if p not in patterns
+        ]
         # Assert
         assert missing == []
 
@@ -111,16 +152,24 @@ class TestForbiddenWordsYaml:
         assert bad == [], f"entries missing required keys: {bad!r}"
 
 
-def test_project_and_baseline_carry_identical_disowning_set() -> None:
+def _word_set(path: Path) -> set:
+    return {e.get("word") for e in _entries(_load(path)) if e.get("word")}
+
+
+def _pattern_set(path: Path) -> set:
+    return {e.get("pattern") for e in _entries(_load(path)) if e.get("pattern")}
+
+
+def test_project_and_baseline_carry_identical_disowning_word_set() -> None:
     """Drift guard: the project-local config + the canonical
-    deployable must stay in sync on the disowning trio so a
-    project-local override never silently drops a phrase from the
-    fleet-wide ban list.
+    deployable must stay in sync on the disowning literal-word set
+    so a project-local override never silently drops a phrase from
+    the fleet-wide ban list.
     """
     # Arrange
-    proj = {e.get("word") for e in _entries(_load(_PROJECT_YAML))}
-    baseline = {e.get("word") for e in _entries(_load(_BASELINE_YAML))}
-    required = set(_REQUIRED_DISOWNING_PHRASES)
+    proj = _word_set(_PROJECT_YAML)
+    baseline = _word_set(_BASELINE_YAML)
+    required = set(_REQUIRED_DISOWNING_WORDS)
     # Act
     proj_has = required & proj
     baseline_has = required & baseline
@@ -128,15 +177,42 @@ def test_project_and_baseline_carry_identical_disowning_set() -> None:
     assert (proj_has, baseline_has) == (required, required)
 
 
-def test_project_and_baseline_carry_identical_katakana_jargon_set() -> None:
-    """Drift guard for the katakana-jargon entries (operator 2026-06-09):
-    project + baseline YAML stay in sync so the ban list does not
-    fork via a project-local override.
+def test_project_and_baseline_carry_identical_disowning_pattern_set() -> None:
+    """Drift guard for the disowning regex pattern (operator 2026-06-09)."""
+    # Arrange
+    proj = _pattern_set(_PROJECT_YAML)
+    baseline = _pattern_set(_BASELINE_YAML)
+    required = set(_REQUIRED_DISOWNING_PATTERNS)
+    # Act
+    proj_has = required & proj
+    baseline_has = required & baseline
+    # Assert
+    assert (proj_has, baseline_has) == (required, required)
+
+
+def test_project_and_baseline_carry_identical_katakana_jargon_word_set() -> None:
+    """Drift guard for the katakana-jargon literal-word entries
+    (operator 2026-06-09 comprehensive update).
     """
     # Arrange
-    proj = {e.get("word") for e in _entries(_load(_PROJECT_YAML))}
-    baseline = {e.get("word") for e in _entries(_load(_BASELINE_YAML))}
-    required = set(_REQUIRED_KATAKANA_JARGON)
+    proj = _word_set(_PROJECT_YAML)
+    baseline = _word_set(_BASELINE_YAML)
+    required = set(_REQUIRED_KATAKANA_JARGON_WORDS)
+    # Act
+    proj_has = required & proj
+    baseline_has = required & baseline
+    # Assert
+    assert (proj_has, baseline_has) == (required, required)
+
+
+def test_project_and_baseline_carry_identical_english_equivalent_pattern_set() -> None:
+    """Drift guard for the English-equivalent regex patterns
+    (operator 2026-06-09 comprehensive update).
+    """
+    # Arrange
+    proj = _pattern_set(_PROJECT_YAML)
+    baseline = _pattern_set(_BASELINE_YAML)
+    required = set(_REQUIRED_ENGLISH_EQUIVALENT_PATTERNS)
     # Act
     proj_has = required & proj
     baseline_has = required & baseline

--- a/tests/scitex_agent_container/_baseline_assets/telegram_hooks/test_forbidden_words_yaml.py
+++ b/tests/scitex_agent_container/_baseline_assets/telegram_hooks/test_forbidden_words_yaml.py
@@ -45,6 +45,11 @@ _BASELINE_YAML = (
 )
 
 _REQUIRED_DISOWNING_PHRASES = ("既存の問題", "関係ない", "無関係")
+# Operator added 2026-06-09: katakana jargon "ナッジ" + hiragana
+# spelling "なっじ" are banned the same way (lead applies "nudge"
+# the English label in NUDGE/REMINDER context; the katakana
+# Japanese-ification of it is what's banned).
+_REQUIRED_KATAKANA_JARGON = ("ナッジ", "なっじ")
 
 
 def _load(path: Path) -> dict:
@@ -80,6 +85,15 @@ class TestForbiddenWordsYaml:
         # Assert
         assert missing == []
 
+    def test_carries_all_required_katakana_jargon(self, path: Path) -> None:
+        # Arrange — katakana-jargon entries the operator mandated 2026-06-09.
+        data = _load(path)
+        words = {e.get("word") for e in _entries(data)}
+        # Act
+        missing = [w for w in _REQUIRED_KATAKANA_JARGON if w not in words]
+        # Assert
+        assert missing == []
+
     def test_every_entry_has_required_schema_fields(self, path: Path) -> None:
         # Arrange — the hook's nudge message names ``reason`` +
         # ``use_instead`` for every blocked word; missing either field
@@ -107,6 +121,22 @@ def test_project_and_baseline_carry_identical_disowning_set() -> None:
     proj = {e.get("word") for e in _entries(_load(_PROJECT_YAML))}
     baseline = {e.get("word") for e in _entries(_load(_BASELINE_YAML))}
     required = set(_REQUIRED_DISOWNING_PHRASES)
+    # Act
+    proj_has = required & proj
+    baseline_has = required & baseline
+    # Assert
+    assert (proj_has, baseline_has) == (required, required)
+
+
+def test_project_and_baseline_carry_identical_katakana_jargon_set() -> None:
+    """Drift guard for the katakana-jargon entries (operator 2026-06-09):
+    project + baseline YAML stay in sync so the ban list does not
+    fork via a project-local override.
+    """
+    # Arrange
+    proj = {e.get("word") for e in _entries(_load(_PROJECT_YAML))}
+    baseline = {e.get("word") for e in _entries(_load(_BASELINE_YAML))}
+    required = set(_REQUIRED_KATAKANA_JARGON)
     # Act
     proj_has = required & proj
     baseline_has = required & baseline

--- a/tests/scitex_agent_container/_baseline_assets/telegram_hooks/test_telegram_hooks_self_tests.py
+++ b/tests/scitex_agent_container/_baseline_assets/telegram_hooks/test_telegram_hooks_self_tests.py
@@ -1,0 +1,114 @@
+"""Pytest wrapper around the 5 OP-PRIO-FMT telegram-format hook scripts'
+embedded ``--self-test`` modes.
+
+Each script under
+``src/scitex_agent_container/_baseline_assets/telegram_hooks/`` carries
+an ``--self-test`` mode that exercises its detection logic with a set
+of canned (tool_name, text, want_rc) cases and reports ``pass=N
+fail=M``. CI runs each via this pytest so a regression to the script
+LOGIC (the python embedded in the bash) or the TEST CONTRACT itself
+surfaces on PR — without needing the live Claude Code SDK +
+telegrammer + matcher chain to actually fire.
+
+Live-fire verify is documented in ``_baseline_assets/telegram_hooks/
+README.md`` and requires the operator to deploy the scripts into the
+``_shared/to_home/`` baseline + restart agents (the matcher fix is
+the OP-PRIO-2 prerequisite that lets the hooks fire at all).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_HOOKS_DIR = (
+    Path(__file__).resolve().parents[4]
+    / "src"
+    / "scitex_agent_container"
+    / "_baseline_assets"
+    / "telegram_hooks"
+)
+
+
+def _run_self_test(script_name: str) -> subprocess.CompletedProcess[str]:
+    script = _HOOKS_DIR / script_name
+    assert script.is_file(), f"hook script missing: {script}"
+    assert script.stat().st_mode & 0o111, f"hook script not executable: {script}"
+    return subprocess.run(
+        ["bash", str(script), "--self-test"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _assert_self_test_clean(result: subprocess.CompletedProcess[str]) -> None:
+    summary = result.stdout.splitlines()[-1] if result.stdout else ""
+    assert result.returncode == 0, (
+        f"self-test returned rc={result.returncode}; expected 0.\n"
+        f"summary line: {summary!r}\n"
+        f"stdout tail:\n{result.stdout[-800:]}\n"
+        f"stderr tail:\n{result.stderr[-400:]}"
+    )
+
+
+def test_enforce_telegram_no_bare_issue_self_test_passes():
+    # Arrange
+    result = _run_self_test("enforce_telegram_no_bare_issue.sh")
+    # Act / Assert
+    _assert_self_test_clean(result)
+
+
+def test_enforce_telegram_no_filler_self_test_passes():
+    # Arrange
+    result = _run_self_test("enforce_telegram_no_filler.sh")
+    # Act / Assert
+    _assert_self_test_clean(result)
+
+
+def test_enforce_telegram_numbering_self_test_passes():
+    # Arrange
+    result = _run_self_test("enforce_telegram_numbering.sh")
+    # Act / Assert
+    _assert_self_test_clean(result)
+
+
+def test_enforce_telegram_use_lists_self_test_passes():
+    # Arrange
+    result = _run_self_test("enforce_telegram_use_lists.sh")
+    # Act / Assert
+    _assert_self_test_clean(result)
+
+
+def test_encourage_telegram_terse_style_self_test_passes():
+    # Arrange
+    result = _run_self_test("encourage_telegram_terse_style.sh")
+    # Act / Assert
+    _assert_self_test_clean(result)
+
+
+@pytest.mark.parametrize(
+    "script_name",
+    [
+        "enforce_telegram_no_bare_issue.sh",
+        "enforce_telegram_no_filler.sh",
+        "enforce_telegram_numbering.sh",
+        "enforce_telegram_use_lists.sh",
+        "encourage_telegram_terse_style.sh",
+    ],
+)
+def test_hook_script_exists_and_is_executable(script_name: str):
+    # Arrange — pin both presence AND the +x perm in a single assertion
+    # so PR reviewers see the file-level deployment invariant.
+    script = _HOOKS_DIR / script_name
+    # Act
+    state = (
+        script.is_file(),
+        bool(script.stat().st_mode & 0o111) if script.exists() else False,
+    )
+    # Assert
+    assert state == (True, True), (
+        f"hook script {script} must exist and be executable (is_file, +x)"
+    )


### PR DESCRIPTION
## Summary
Operator priority 2026-06-09. After OP-PRIO-2 fixed the matcher (\`settings.local.json\` \`"telegram"\` → \`mcp__claude-code-telegrammer__reply\`), the operator prioritised 5 additional format rules. This PR ships the canonical, version-controlled hook implementations under \`_baseline_assets/telegram_hooks/\`, ready for the dotfile baseline to copy or symlink into \`_shared/to_home/.claude/hooks/pre-tool-use/\`.

## Rules
1. \`enforce_telegram_numbering.sh\` — lettered options must be numbered (\`1a/1b\` or \`1./2.\`).
2. \`enforce_telegram_no_bare_issue.sh\` — message can't be just \`#NNN\`.
3. \`enforce_telegram_use_lists.sh\` — 3+ items must be a list, not run-on prose.
4. \`enforce_telegram_no_filler.sh\` — banned filler (\`actually\`/\`basically\`/\`just\`/\`一旦\`/\`とりあえず\`/...).
5. \`encourage_telegram_terse_style.sh\` — REMINDER (rc=0 + stderr nudge) when sentences > 35 chars don't end in \`します\`/\`しました\`/\`done\`/\`opened\`/\`merged\`/etc.

## Test plan
- [x] Each script has \`--self-test\` mode (canned cases, \`pass=N fail=M\` summary, rc=0/1).
- [x] Pytest at \`tests/.../telegram_hooks/test_telegram_hooks_self_tests.py\` runs every self-test in CI; 10 passed.
- [ ] OPERATOR — live-fire verify (after deploying + restarting an agent):
  - send a bare \`#162\` → \`enforce_telegram_no_bare_issue.sh\` blocks
  - send \`A) ship now B) hold\` → \`enforce_telegram_numbering.sh\` blocks
  - send \`Basically X\` → \`enforce_telegram_no_filler.sh\` blocks
  - send packed numbered \`1. a\\n2. b\\n3. c\` → existing \`telegram_line_spacing.sh\` blocks
  - send a long sentence ending in \`たぶん\` → \`encourage_telegram_terse_style.sh\` nudges (rc=0)

## Deployment
\`_baseline_assets/telegram_hooks/README.md\` documents the copy/symlink recipe and the \`settings.local.json.fragment.json\` shows the exact JSON to splice into \`hooks.PreToolUse\`.

## Depends on
- OP-PRIO-2 matcher fix (operator dotfile sed) — without it, none of these hooks fire because the matcher \`telegram\` does not match \`mcp__claude-code-telegrammer__reply\`. Confirmed by 0-byte hook log file after a packed reply was sent.