### PR TITLE
feat(accounts): clarify `sac accounts list` window-reset display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.21.10] — 2026-06-09
+
+### Changed
+- **feat(accounts): `sac accounts list` window-reset display**
+  (operator gripe via lead, 2026-06-09). Three operator-visible
+  clarifications to the Stored-accounts table; no behaviour change
+  in the JSON path (`sac accounts list --json` schema is stable):
+  - Column header `As-of` renamed to `Last Update` — the operator
+    could not parse the abbreviation.
+  - 5h%/7d% cells now carry an inline reset hint computed from the
+    Anthropic OAuth usage API's `resets_at` field (parsed by
+    `_account.claude_usage` into `reset_at_5h` / `reset_at_7d`).
+    Example shapes: `42% (→21:05)` for the 5-hour rolling window,
+    `15% (→Thu 17h)` for the 7-day rolling window. Local-tz
+    precedence chain unchanged
+    (`SCITEX_AGENT_CONTAINER_TZ` > `TZ` > system local).
+  - When the upstream API did NOT return reset timestamps (older
+    caches / API outage) the CLI prints a one-line legend below
+    the table — `5h = rolling 5-hour window; 7d = rolling 7-day
+    window` — so the operator still knows the windows are rolling
+    rather than calendar-day. Headers stay compact so the table
+    fits a typical ~120-col terminal.
+
+  Implementation lifted the pure formatting helpers out of
+  `_account_list_render.py` into a sibling `_account_list_format.py`
+  so neither module exceeds the 512-line per-file cap (the renderer
+  re-exports the helpers so existing imports keep working).
+  Two new fields on `AccountRow`: `reset_at_5h` / `reset_at_7d`
+  (optional, default `None`). `build_stored_rows` propagates them
+  from the per-account `usage.json` cache.
+
 ## [0.21.9] — 2026-06-01
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-agent-container"
-version = "0.21.9"
+version = "0.21.10"
 description = "Declarative YAML-based framework for defining, managing, and orchestrating AI coding agent instances"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/src/scitex_agent_container/cli_pkg/_account_list_format.py
+++ b/src/scitex_agent_container/cli_pkg/_account_list_format.py
@@ -1,0 +1,280 @@
+"""Pure formatting helpers for ``sac accounts list``.
+
+Split out of ``_account_list_render.py`` to keep that file under the
+per-file line cap once the per-row reset-hint renderers (gripe #2 of
+the 2026-06-09 task) landed. Every helper here is pure (no I/O, no
+clock, no environment side-effects beyond reading ``os.environ``) so
+each can be unit-tested in isolation.
+
+Concerns covered:
+
+1. :func:`local_timezone` / :func:`format_dt_local` — render an
+   ISO-8601 timestamp in the operator's local timezone. Precedence:
+   ``SCITEX_AGENT_CONTAINER_TZ`` env wins, else ``TZ`` env, else the
+   system local timezone (``datetime.astimezone()`` with no arg).
+
+2. :func:`format_ttl_live` / :func:`format_snapshot_age` — render the
+   credential TTL and the per-account usage snapshot age with enough
+   resolution that a 60-second tick is visible under ``watch -n1``.
+
+3. :func:`format_as_of_short` — render an As-of (Last-Update)
+   timestamp as ``Sun 21h``.
+
+4. :func:`format_reset_hhmm` / :func:`format_reset_day_hour` —
+   render the per-window reset timestamp the Anthropic OAuth usage
+   API returns (``resets_at`` → ``reset_at_5h`` / ``reset_at_7d``).
+   Used by the 5h%/7d% cells to surface ``(→21:05)`` and
+   ``(→Sun 17h)`` reset hints.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone, tzinfo
+
+# ---------------------------------------------------------------------------
+# Timezone resolution
+# ---------------------------------------------------------------------------
+
+# Project-specific env wins over the standard POSIX ``TZ`` so a host-wide
+# ``TZ`` doesn't accidentally override an explicit per-tool preference.
+_PROJECT_TZ_ENV = "SCITEX_AGENT_CONTAINER_TZ"
+
+
+def local_timezone(env: dict[str, str] | None = None) -> tzinfo | None:
+    """Return the effective render timezone for the operator.
+
+    Precedence:
+
+    1. ``SCITEX_AGENT_CONTAINER_TZ`` env — project-specific override.
+    2. ``TZ`` env — standard POSIX.
+    3. ``None`` — caller should pass ``None`` through to
+       ``datetime.astimezone()`` which then picks up the system local
+       timezone.
+
+    Args:
+        env: Override for ``os.environ`` (tests pass a dict).
+
+    Returns:
+        A ``tzinfo`` if one of the env vars resolves, else ``None``.
+        Unknown / unparseable values silently fall through (we never
+        want a typo in ``TZ`` to crash ``sac accounts list``).
+    """
+    src = env if env is not None else os.environ
+    for key in (_PROJECT_TZ_ENV, "TZ"):
+        name = src.get(key)
+        if not name:
+            continue
+        tz = _resolve_tz(name)
+        if tz is not None:
+            return tz
+    return None
+
+
+def _resolve_tz(name: str) -> tzinfo | None:
+    """Return a ``tzinfo`` for IANA ``name`` (``Asia/Tokyo``), or None.
+
+    Uses the stdlib ``zoneinfo`` so no third-party dependency creeps in.
+    Returns ``None`` on any failure so a bad env value falls through to
+    the next layer of the precedence chain rather than crashing.
+    """
+    # stx-allow: fallback (reason: a bad TZ env value (typo, missing
+    # tzdata on the host) must not crash `sac accounts list` — fall
+    # through to the next precedence layer and ultimately system local.)
+    try:
+        from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+        return ZoneInfo(name)
+    except (ZoneInfoNotFoundError, ValueError, ModuleNotFoundError):
+        return None
+    except (
+        Exception
+    ):  # stx-allow: fallback (reason: catch-all safety net — see inline comment)
+        return None
+
+
+def format_dt_local(
+    iso_or_dt: str | datetime | None,
+    *,
+    env: dict[str, str] | None = None,
+) -> str:
+    """Render an ISO-8601 timestamp (or aware datetime) in local TZ.
+
+    Returns ``"-"`` for ``None`` / empty / unparseable input. Naive
+    datetimes are assumed UTC (matches what the JSON path writes).
+    """
+    dt = _coerce_dt(iso_or_dt)
+    if dt is None:
+        return "-"
+    tz = local_timezone(env)
+    if tz is None:
+        # No env override → system local (astimezone with no arg).
+        return dt.astimezone().isoformat(timespec="seconds")
+    return dt.astimezone(tz).isoformat(timespec="seconds")
+
+
+def _coerce_dt(value: str | datetime | None) -> datetime | None:
+    """Coerce ``value`` to an aware datetime; ``None`` on any failure."""
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    if not isinstance(value, str) or not value.strip():
+        return None
+    # stx-allow: fallback (reason: ISO parser is strict; a malformed
+    # cache timestamp must render as "-" rather than crash the table.)
+    try:
+        dt = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# TTL + age formatting (must tick under watch -n1)
+# ---------------------------------------------------------------------------
+
+
+def format_ttl_live(hours: float | None) -> str:
+    """Render signed-hours-to-expiry with minute-resolution.
+
+    Prior format ``+2.8h`` collapsed a 60-second tick into the same
+    string. This renders as ``+2h48m`` / ``-138h35m`` / ``+45s`` so a
+    one-second tick under ``watch -n1`` is visible after ~60s.
+
+    ``None`` → ``"-"``.
+    """
+    if hours is None:
+        return "-"
+    total_seconds = int(round(hours * 3600.0))
+    sign = "+" if total_seconds >= 0 else "-"
+    s = abs(total_seconds)
+    h, rem = divmod(s, 3600)
+    m, sec = divmod(rem, 60)
+    if h:
+        return f"{sign}{h}h{m:02d}m"
+    if m:
+        return f"{sign}{m}m{sec:02d}s"
+    return f"{sign}{sec}s"
+
+
+def format_snapshot_age(
+    snapshot_iso: str | datetime | None,
+    *,
+    now: datetime | None = None,
+) -> str:
+    """Render the per-account usage snapshot age as ``3m`` / ``1h`` / ``12s``.
+
+    Used in the bullet-2 fix: the upstream usage% API is expensive to
+    refetch on every render, so the snapshot is intentionally cached.
+    Showing the age next to the % makes a stale number obvious instead
+    of silently shipping yesterday's percentage as if it were live.
+
+    ``None`` / unparseable → ``"?"``.
+    """
+    dt = _coerce_dt(snapshot_iso)
+    if dt is None:
+        return "?"
+    now_dt = now or datetime.now(timezone.utc)
+    if now_dt.tzinfo is None:
+        now_dt = now_dt.replace(tzinfo=timezone.utc)
+    delta_s = int((now_dt - dt).total_seconds())
+    if delta_s < 0:
+        delta_s = 0
+    if delta_s < 60:
+        return f"{delta_s}s"
+    if delta_s < 3600:
+        return f"{delta_s // 60}m"
+    if delta_s < 86400:
+        return f"{delta_s // 3600}h"
+    return f"{delta_s // 86400}d"
+
+
+def format_as_of_short(
+    iso_or_dt: str | datetime | None,
+    *,
+    env: dict[str, str] | None = None,
+) -> str:
+    """Render an As-of timestamp as day-of-week + hour: ``Sun 21h``.
+
+    Uses the local-tz precedence chain (project env > TZ env > system
+    local) so a UTC ``as_of`` lands in the operator's wall clock. The
+    output is intentionally low-resolution — the operator only needs
+    to know whether the value is from this hour, two hours ago, or
+    yesterday. Sub-hour resolution is the snapshot AGE column's job
+    (see :func:`format_snapshot_age`).
+
+    ``None`` / unparseable → ``"-"``.
+    """
+    dt = _coerce_dt(iso_or_dt)
+    if dt is None:
+        return "-"
+    tz = local_timezone(env)
+    local = dt.astimezone(tz) if tz is not None else dt.astimezone()
+    # %a = Sun/Mon/...; %H = 00-23.
+    return local.strftime("%a %Hh")
+
+
+# ---------------------------------------------------------------------------
+# Reset-time hints for the 5h% / 7d% cells (operator gripe #2, 2026-06-09)
+# ---------------------------------------------------------------------------
+
+
+def format_reset_hhmm(
+    reset_iso: str | datetime | None,
+    *,
+    env: dict[str, str] | None = None,
+) -> str:
+    """Render a 5h-window reset timestamp as ``→HH:MM`` (local-tz).
+
+    Operator gripe #2 (2026-06-09): ``5h%`` never said WHEN the
+    rolling window resets. This renders just the local wall-clock
+    time because a 5h window always resets within a one-day horizon
+    (or, at the day boundary, very early tomorrow — context makes it
+    obvious which).
+
+    Returns ``""`` when the timestamp is missing/unparseable so the
+    caller can fall back to the bare percentage cell rather than
+    fabricate a value. Never raises.
+    """
+    dt = _coerce_dt(reset_iso)
+    if dt is None:
+        return ""
+    tz = local_timezone(env)
+    local = dt.astimezone(tz) if tz is not None else dt.astimezone()
+    return f"→{local.strftime('%H:%M')}"
+
+
+def format_reset_day_hour(
+    reset_iso: str | datetime | None,
+    *,
+    env: dict[str, str] | None = None,
+) -> str:
+    """Render a 7d-window reset timestamp as ``→Day HHh`` (local-tz).
+
+    Operator gripe #2 (2026-06-09): ``7d%`` never said WHEN the
+    rolling 7-day window resets. Because the answer can land any day
+    of the next week, we include the day-of-week abbreviation in
+    addition to the hour. Minute resolution is intentionally dropped
+    — for a 7d window the hour is the operationally useful
+    resolution and the cell stays narrow.
+
+    Returns ``""`` on missing/unparseable input — never fabricates.
+    """
+    dt = _coerce_dt(reset_iso)
+    if dt is None:
+        return ""
+    tz = local_timezone(env)
+    local = dt.astimezone(tz) if tz is not None else dt.astimezone()
+    return f"→{local.strftime('%a %Hh')}"
+
+
+__all__ = [
+    "format_as_of_short",
+    "format_dt_local",
+    "format_reset_day_hour",
+    "format_reset_hhmm",
+    "format_snapshot_age",
+    "format_ttl_live",
+    "local_timezone",
+]

--- a/src/scitex_agent_container/cli_pkg/_account_list_render.py
+++ b/src/scitex_agent_container/cli_pkg/_account_list_render.py
@@ -4,228 +4,51 @@ Split out of ``account_group.py`` to keep that file under the per-file
 line cap (same pattern as ``_account_status.py`` and ``_account_refresh.py``)
 and so the renderer is unit-testable without going through ``CliRunner``.
 
-Three concerns live here, one per public helper:
+This module now holds the THREE pieces that need on-disk state:
 
-1. :func:`local_timezone` / :func:`format_dt_local` — render an ISO-8601
-   timestamp in the operator's local timezone. Precedence:
-   ``SCITEX_AGENT_CONTAINER_TZ`` env wins, else ``TZ`` env, else the
-   system local timezone (``datetime.astimezone()`` with no arg). This
-   is the bullet-1 fix: the prior renderer emitted UTC.
+1. :class:`AccountRow` — pre-resolved row dataclass (pure data; the
+   formatting helpers live in :mod:`._account_list_format`).
+2. :func:`render_stored_table` — turn rows into a ``rich.table.Table``.
+3. :func:`usage_for_account`, :func:`build_stored_rows`,
+   :func:`build_stored_json` — fetch / shape the data the CLI command
+   feeds into the renderer or the JSON path.
 
-2. :func:`format_ttl_live` / :func:`format_snapshot_age` — render the
-   credential TTL and the per-account usage snapshot age with enough
-   resolution that a 60-second tick is VISIBLE under ``watch -n1``. The
-   prior ``+2.8h`` collapsed any sub-hour change into the same string,
-   making the operator think the value was cached. TTL is computed
-   live from ``expiresAt`` on every call; this module only formats it.
+Pure formatting helpers (``local_timezone``, ``format_dt_local``,
+``format_ttl_live``, ``format_snapshot_age``, ``format_as_of_short``,
+``format_reset_hhmm``, ``format_reset_day_hour``) are re-exported from
+:mod:`._account_list_format` so existing callers (and the historical
+test surface) keep importing them from this module without churn.
 
-3. :func:`render_stored_table` — render the Stored-accounts block as a
-   ``rich.table.Table`` with aligned columns:
-
-       ID | Email | Plan | Status(+TTL) | 5h% | 7d% | As-of
-
-   ``As-of`` is the per-account usage snapshot age in short day+hour
-   form (``Sun 21h``), not microsecond ISO.
-
-The JSON-output path of ``sac accounts list --json`` is NOT touched —
-it still emits ISO-8601 ``as_of`` strings. Only the human renderer
-reformats at display time.
+Header note (2026-06-09 task): the human renderer's last column was
+renamed ``As-of`` → ``Last Update`` because the operator could not
+parse the abbreviation. The 5h%/7d% cells now carry an inline reset
+hint (``→HH:MM`` for 5h, ``→Day HHh`` for 7d) computed from the
+Anthropic OAuth usage API's ``resets_at`` field. The JSON output path
+(``sac accounts list --json``) is NOT touched — its schema stays the
+machine-readable contract downstream consumers parse.
 """
 
 from __future__ import annotations
 
 import os
 from dataclasses import dataclass
-from datetime import datetime, timezone, tzinfo
+from datetime import datetime
 
 from rich.console import Console
 from rich.table import Table
 
-# ---------------------------------------------------------------------------
-# Timezone resolution (bullet 1)
-# ---------------------------------------------------------------------------
-
-# Project-specific env wins over the standard POSIX ``TZ`` so a host-wide
-# ``TZ`` doesn't accidentally override an explicit per-tool preference.
-_PROJECT_TZ_ENV = "SCITEX_AGENT_CONTAINER_TZ"
-
-
-def local_timezone(env: dict[str, str] | None = None) -> tzinfo | None:
-    """Return the effective render timezone for the operator.
-
-    Precedence:
-
-    1. ``SCITEX_AGENT_CONTAINER_TZ`` env — project-specific override.
-    2. ``TZ`` env — standard POSIX.
-    3. ``None`` — caller should pass ``None`` through to
-       ``datetime.astimezone()`` which then picks up the system local
-       timezone.
-
-    Args:
-        env: Override for ``os.environ`` (tests pass a dict).
-
-    Returns:
-        A ``tzinfo`` if one of the env vars resolves, else ``None``.
-        Unknown / unparseable values silently fall through (we never
-        want a typo in ``TZ`` to crash ``sac accounts list``).
-    """
-    src = env if env is not None else os.environ
-    for key in (_PROJECT_TZ_ENV, "TZ"):
-        name = src.get(key)
-        if not name:
-            continue
-        tz = _resolve_tz(name)
-        if tz is not None:
-            return tz
-    return None
-
-
-def _resolve_tz(name: str) -> tzinfo | None:
-    """Return a ``tzinfo`` for IANA ``name`` (``Asia/Tokyo``), or None.
-
-    Uses the stdlib ``zoneinfo`` so no third-party dependency creeps in.
-    Returns ``None`` on any failure so a bad env value falls through to
-    the next layer of the precedence chain rather than crashing.
-    """
-    # stx-allow: fallback (reason: a bad TZ env value (typo, missing
-    # tzdata on the host) must not crash `sac accounts list` — fall
-    # through to the next precedence layer and ultimately system local.)
-    try:
-        from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
-
-        return ZoneInfo(name)
-    except (ZoneInfoNotFoundError, ValueError, ModuleNotFoundError):
-        return None
-    except (
-        Exception
-    ):  # stx-allow: fallback (reason: catch-all safety net — see inline comment)
-        return None
-
-
-def format_dt_local(
-    iso_or_dt: str | datetime | None,
-    *,
-    env: dict[str, str] | None = None,
-) -> str:
-    """Render an ISO-8601 timestamp (or aware datetime) in local TZ.
-
-    Returns ``"-"`` for ``None`` / empty / unparseable input. Naive
-    datetimes are assumed UTC (matches what the JSON path writes).
-    """
-    dt = _coerce_dt(iso_or_dt)
-    if dt is None:
-        return "-"
-    tz = local_timezone(env)
-    if tz is None:
-        # No env override → system local (astimezone with no arg).
-        return dt.astimezone().isoformat(timespec="seconds")
-    return dt.astimezone(tz).isoformat(timespec="seconds")
-
-
-def _coerce_dt(value: str | datetime | None) -> datetime | None:
-    """Coerce ``value`` to an aware datetime; ``None`` on any failure."""
-    if value is None:
-        return None
-    if isinstance(value, datetime):
-        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
-    if not isinstance(value, str) or not value.strip():
-        return None
-    # stx-allow: fallback (reason: ISO parser is strict; a malformed
-    # cache timestamp must render as "-" rather than crash the table.)
-    try:
-        dt = datetime.fromisoformat(value)
-    except ValueError:
-        return None
-    return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
-
+from ._account_list_format import (
+    format_as_of_short,
+    format_dt_local,
+    format_reset_day_hour,
+    format_reset_hhmm,
+    format_snapshot_age,
+    format_ttl_live,
+    local_timezone,
+)
 
 # ---------------------------------------------------------------------------
-# TTL + age formatting (bullet 2 — must tick under watch -n1)
-# ---------------------------------------------------------------------------
-
-
-def format_ttl_live(hours: float | None) -> str:
-    """Render signed-hours-to-expiry with minute-resolution.
-
-    Prior format ``+2.8h`` collapsed a 60-second tick into the same
-    string. This renders as ``+2h48m`` / ``-138h35m`` / ``+45s`` so a
-    one-second tick under ``watch -n1`` is visible after ~60s.
-
-    ``None`` → ``"-"``.
-    """
-    if hours is None:
-        return "-"
-    total_seconds = int(round(hours * 3600.0))
-    sign = "+" if total_seconds >= 0 else "-"
-    s = abs(total_seconds)
-    h, rem = divmod(s, 3600)
-    m, sec = divmod(rem, 60)
-    if h:
-        return f"{sign}{h}h{m:02d}m"
-    if m:
-        return f"{sign}{m}m{sec:02d}s"
-    return f"{sign}{sec}s"
-
-
-def format_snapshot_age(
-    snapshot_iso: str | datetime | None,
-    *,
-    now: datetime | None = None,
-) -> str:
-    """Render the per-account usage snapshot age as ``3m`` / ``1h`` / ``12s``.
-
-    Used in the bullet-2 fix: the upstream usage% API is expensive to
-    refetch on every render, so the snapshot is intentionally cached.
-    Showing the age next to the % makes a stale number OBVIOUS instead
-    of silently shipping yesterday's percentage as if it were live.
-
-    ``None`` / unparseable → ``"?"``.
-    """
-    dt = _coerce_dt(snapshot_iso)
-    if dt is None:
-        return "?"
-    now_dt = now or datetime.now(timezone.utc)
-    if now_dt.tzinfo is None:
-        now_dt = now_dt.replace(tzinfo=timezone.utc)
-    delta_s = int((now_dt - dt).total_seconds())
-    if delta_s < 0:
-        delta_s = 0
-    if delta_s < 60:
-        return f"{delta_s}s"
-    if delta_s < 3600:
-        return f"{delta_s // 60}m"
-    if delta_s < 86400:
-        return f"{delta_s // 3600}h"
-    return f"{delta_s // 86400}d"
-
-
-def format_as_of_short(
-    iso_or_dt: str | datetime | None,
-    *,
-    env: dict[str, str] | None = None,
-) -> str:
-    """Render an As-of timestamp as day-of-week + hour: ``Sun 21h``.
-
-    Uses the local-tz precedence chain (project env > TZ env > system
-    local) so a UTC ``as_of`` lands in the operator's wall clock. The
-    output is intentionally low-resolution — the operator only needs
-    to know whether the value is from this hour, two hours ago, or
-    yesterday. Sub-hour resolution is the snapshot AGE column's job
-    (see :func:`format_snapshot_age`).
-
-    ``None`` / unparseable → ``"-"``.
-    """
-    dt = _coerce_dt(iso_or_dt)
-    if dt is None:
-        return "-"
-    tz = local_timezone(env)
-    local = dt.astimezone(tz) if tz is not None else dt.astimezone()
-    # %a = Sun/Mon/...; %H = 00-23.
-    return local.strftime("%a %Hh")
-
-
-# ---------------------------------------------------------------------------
-# Row data model + table renderer (bullet 3)
+# Row data model
 # ---------------------------------------------------------------------------
 
 
@@ -255,6 +78,12 @@ class AccountRow:
         Float percentages or ``None``.
     snapshot_as_of
         ISO-8601 string from the usage cache, or ``None``.
+    reset_at_5h, reset_at_7d
+        ISO-8601 reset timestamps from the Anthropic OAuth usage API
+        (``resets_at`` field, parsed by :mod:`._account.claude_usage`).
+        ``None`` when the API did not return them (older caches /
+        outages); the renderer falls back to the bare percentage cell
+        in that case rather than fabricating a value.
     """
 
     name: str
@@ -266,10 +95,35 @@ class AccountRow:
     used_pct_5h: float | None
     used_pct_7d: float | None
     snapshot_as_of: str | None
+    reset_at_5h: str | None = None
+    reset_at_7d: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Table renderer
+# ---------------------------------------------------------------------------
 
 
 def _fmt_pct(value: float | None) -> str:
+    """Render a percentage as ``42%``; ``None`` → ``-``."""
     return "-" if value is None else f"{float(value):.0f}%"
+
+
+def _fmt_pct_with_reset(value: float | None, hint: str) -> str:
+    """Combine percentage + reset hint: ``42% (→21:05)`` / ``-`` / ``42%``.
+
+    ``hint`` is the output of :func:`format_reset_hhmm` or
+    :func:`format_reset_day_hour` — empty string when the API didn't
+    return a reset timestamp, in which case the cell is just ``42%``
+    (and the column header carries the ``(rolling)`` qualifier so the
+    operator still knows it's a rolling window).
+    """
+    if value is None:
+        return "-"
+    pct = f"{float(value):.0f}%"
+    if not hint:
+        return pct
+    return f"{pct} ({hint})"
 
 
 def _fmt_status(state: str, hours: float | None) -> str:
@@ -278,7 +132,9 @@ def _fmt_status(state: str, hours: float | None) -> str:
     return f"{state} {format_ttl_live(hours)}"
 
 
-def _fmt_as_of_cell(snapshot_as_of: str | None, *, now: datetime | None = None) -> str:
+def _fmt_last_update_cell(
+    snapshot_as_of: str | None, *, now: datetime | None = None
+) -> str:
     """Combine short day+hour with age suffix: ``Sun 21h (3m)`` / ``- (?)``."""
     if not snapshot_as_of:
         return "-"
@@ -293,10 +149,20 @@ def render_stored_table(
     """Build a ``rich.table.Table`` for the Stored-accounts block.
 
     Columns (left-to-right):
-      ID | Email | Plan | Status(+TTL) | 5h% | 7d% | As-of
+      ID | Email | Plan | Status(+TTL) | 5h% | 7d% | Last Update
 
-    ``now`` is an injection seam so the bullet-2 liveness tests can
-    drive the snapshot-age cell deterministically without monkeypatching
+    The 5h% / 7d% cells carry an inline reset hint when the upstream
+    Anthropic usage API returned one for that row (operator gripe #2
+    of 2026-06-09: "いつ区切りが戻るのか分からない"). When the API
+    did NOT return any reset timestamps, the operator still needs to
+    know the windows are ROLLING (not calendar-day) — for that case
+    the CLI prints a one-line legend below the table; see
+    :func:`needs_rolling_legend` / :func:`rolling_legend_line`. The
+    column header stays compact (``5h%`` / ``7d%``) so the table fits
+    in a typical operator terminal.
+
+    ``now`` is an injection seam so the snapshot-age tests can drive
+    the Last-Update cell deterministically without monkeypatching
     ``datetime.now``.
     """
     table = Table(title="Stored accounts", title_justify="left", show_lines=False)
@@ -306,18 +172,44 @@ def render_stored_table(
     table.add_column("Status(+TTL)")
     table.add_column("5h%", justify="right")
     table.add_column("7d%", justify="right")
-    table.add_column("As-of")
+    table.add_column("Last Update")
     for r in rows:
         table.add_row(
             r.name,
             r.email,
             f"{r.plan_label} [{r.tier}]",
             _fmt_status(r.freshness_state, r.freshness_hours),
-            _fmt_pct(r.used_pct_5h),
-            _fmt_pct(r.used_pct_7d),
-            _fmt_as_of_cell(r.snapshot_as_of, now=now),
+            _fmt_pct_with_reset(r.used_pct_5h, format_reset_hhmm(r.reset_at_5h)),
+            _fmt_pct_with_reset(r.used_pct_7d, format_reset_day_hour(r.reset_at_7d)),
+            _fmt_last_update_cell(r.snapshot_as_of, now=now),
         )
     return table
+
+
+def needs_rolling_legend(rows: list[AccountRow]) -> bool:
+    """Return True iff at least one row lacks BOTH reset_at fields.
+
+    Used by the CLI to decide whether to print the explanatory legend
+    below the table. When EVERY row has a per-row reset hint, the
+    legend would be redundant — the cells already carry the
+    information.
+    """
+    if not rows:
+        return False
+    return any(r.reset_at_5h is None and r.reset_at_7d is None for r in rows)
+
+
+def rolling_legend_line() -> str:
+    """One-line legend operators see when reset_at is missing.
+
+    Per the 2026-06-09 task contract: "リセットのアンカーが取れない
+    場合は列凡例/ヘッダで5h=直近5時間ローリング, 7d=直近7日ローリン
+    グと明示". English wording matches the rest of the table.
+    """
+    return (
+        "Legend: 5h = rolling 5-hour window; 7d = rolling 7-day window. "
+        "(→HH:MM / →Day HHh next to the % marks the next reset.)"
+    )
 
 
 def render_stored_table_to_str(
@@ -409,7 +301,9 @@ def build_stored_rows(
 
     Pure orchestration: pulls plan/tier (offline), credential freshness
     (live recompute from ``expiresAt`` on every call), and usage% (cached
-    or re-fetched depending on ``refresh``).
+    or re-fetched depending on ``refresh``). Also carries through the
+    per-window ``reset_at_5h`` / ``reset_at_7d`` so the cells can render
+    the inline reset hint (gripe #2 of 2026-06-09).
     """
     from .._account.creds_sync import account_freshness
     from .._state.account_store import read_account_plan
@@ -431,6 +325,8 @@ def build_stored_rows(
                 used_pct_5h=usage.get("used_pct_5h"),
                 used_pct_7d=usage.get("used_pct_7d"),
                 snapshot_as_of=usage.get("as_of") or usage.get("fetched_at"),
+                reset_at_5h=usage.get("reset_at_5h"),
+                reset_at_7d=usage.get("reset_at_7d"),
             )
         )
     return rows
@@ -442,7 +338,9 @@ def build_stored_json(accounts: list[dict], *, refresh: bool = False) -> list[di
     Each entry carries OFFLINE plan/tier, credential FRESHNESS
     (``state`` + signed hours), and the per-account usage payload.
     Timestamps remain ISO-8601 for JSON consumers — only the human
-    renderer reformats.
+    renderer reformats. The usage dict already carries
+    ``reset_at_5h`` / ``reset_at_7d`` from the upstream API, so JSON
+    consumers can compute their own reset hints if they want one.
     """
     from .._account.creds_sync import account_freshness
     from .._state.account_store import read_account_plan
@@ -465,10 +363,14 @@ __all__ = [
     "build_stored_rows",
     "format_as_of_short",
     "format_dt_local",
+    "format_reset_day_hour",
+    "format_reset_hhmm",
     "format_snapshot_age",
     "format_ttl_live",
     "local_timezone",
+    "needs_rolling_legend",
     "render_stored_table",
     "render_stored_table_to_str",
+    "rolling_legend_line",
     "usage_for_account",
 ]

--- a/src/scitex_agent_container/cli_pkg/account_group.py
+++ b/src/scitex_agent_container/cli_pkg/account_group.py
@@ -120,8 +120,8 @@ def account_save(name: str, email: str | None, dry_run: bool, yes: bool) -> None
     help=(
         "Force a fresh upstream usage fetch by discarding the per-account "
         "usage.json cache before rendering. Without this flag the 5-min "
-        "cache is consulted to avoid hammering the API; the As-of column "
-        "always shows the snapshot age so a stale number is obvious."
+        "cache is consulted to avoid hammering the API; the Last Update "
+        "column always shows the snapshot age so a stale number is obvious."
     ),
 )
 def account_list(as_json: bool, refresh: bool) -> None:
@@ -140,7 +140,9 @@ def account_list(as_json: bool, refresh: bool) -> None:
     from ._account_list_render import (
         build_stored_json,
         build_stored_rows,
+        needs_rolling_legend,
         render_stored_table,
+        rolling_legend_line,
     )
     from ._helpers import console
     from .status_cmds import _format_claude_account_block
@@ -182,7 +184,14 @@ def account_list(as_json: bool, refresh: bool) -> None:
             "No accounts stored. Use: scitex-agent-container account save <name>"
         )
         return
-    console.print(render_stored_table(build_stored_rows(accounts, refresh=refresh)))
+    rows = build_stored_rows(accounts, refresh=refresh)
+    console.print(render_stored_table(rows))
+    # When the upstream usage API didn't return per-row reset
+    # timestamps (older caches / API outage), the per-cell `(→...)`
+    # hint can't render. Print a one-line legend so the operator
+    # still sees the rolling-window contract instead of guessing.
+    if needs_rolling_legend(rows):
+        console.print(rolling_legend_line())
 
 
 @account.command("delete")

--- a/tests/scitex_agent_container/cli_pkg/test__account_list_render.py
+++ b/tests/scitex_agent_container/cli_pkg/test__account_list_render.py
@@ -12,7 +12,11 @@ The renderer module is the bullet-1/2/3 fix surface:
 * bullet 2 — credential TTL ticks under ``watch -n1`` (minute-resolution
   format) and the per-account usage snapshot age is rendered next to
   the % so a stale number is obvious.
-* bullet 3 — ``rich.table.Table`` with aligned columns, short ``As-of``.
+* bullet 3 — ``rich.table.Table`` with aligned columns, short
+  ``Last Update`` (renamed from ``As-of`` per the 2026-06-09 operator
+  ask). Per-row 5h%/7d% cells carry an inline ``→HH:MM`` /
+  ``→Day HHh`` reset hint when the upstream Anthropic usage API
+  returned a ``resets_at`` timestamp for that window.
 
 The ``--refresh`` flag is asserted via the CLI surface (click invocation)
 with a real fake fetcher injected through a temporary monkey of the
@@ -36,10 +40,14 @@ from scitex_agent_container.cli_pkg._account_list_render import (
     build_stored_rows,
     format_as_of_short,
     format_dt_local,
+    format_reset_day_hour,
+    format_reset_hhmm,
     format_snapshot_age,
     format_ttl_live,
     local_timezone,
+    needs_rolling_legend,
     render_stored_table_to_str,
+    rolling_legend_line,
     usage_for_account,
 )
 from scitex_agent_container.cli_pkg.account_group import account
@@ -274,7 +282,7 @@ def test_format_snapshot_age_future_clamps_to_zero():
 
 
 # ---------------------------------------------------------------------------
-# Bullet 3 — short As-of and table shape
+# Bullet 3 — short Last Update (renamed from As-of) and table shape
 # ---------------------------------------------------------------------------
 
 
@@ -355,7 +363,7 @@ def test_render_stored_table_has_column_headers():
     # Act
     out = render_stored_table_to_str(rows, now=now)
     # Assert — every column header is present.
-    for col in ("ID", "Email", "Plan", "Status(+TTL)", "5h%", "7d%", "As-of"):
+    for col in ("ID", "Email", "Plan", "Status(+TTL)", "5h%", "7d%", "Last Update"):
         assert col in out, f"missing column header: {col!r}\n---\n{out}"
 
 
@@ -476,8 +484,340 @@ def test_render_stored_table_shows_age_next_to_pct():
     now = datetime(2026, 5, 31, 12, 14, 0, tzinfo=timezone.utc)
     # Act
     out = render_stored_table_to_str(rows, now=now)
-    # Assert — `(3m)` appears in the As-of column.
+    # Assert — `(3m)` appears in the Last Update column.
     assert "(3m)" in out
+
+
+# ---------------------------------------------------------------------------
+# 2026-06-09 task — per-window reset hint on 5h% / 7d% cells
+# ---------------------------------------------------------------------------
+
+
+def test_format_reset_hhmm_renders_arrow_hhmm(env_save_restore):
+    """``format_reset_hhmm`` emits ``→HH:MM`` in the operator's local tz."""
+    # Arrange — 12:05 UTC = 21:05 JST.
+    env_save_restore.set("TZ", "Asia/Tokyo")
+    # Act
+    rendered = format_reset_hhmm("2026-05-31T12:05:00+00:00")
+    # Assert
+    assert rendered == "→21:05"
+
+
+def test_format_reset_hhmm_none_returns_empty():
+    # Arrange
+    value = None
+    # Act
+    rendered = format_reset_hhmm(value)
+    # Assert
+    assert rendered == ""
+
+
+def test_format_reset_hhmm_unparseable_returns_empty():
+    """A malformed reset timestamp must NOT crash the table — empty string."""
+    # Arrange
+    value = "not-a-timestamp"
+    # Act
+    rendered = format_reset_hhmm(value)
+    # Assert
+    assert rendered == ""
+
+
+def test_format_reset_day_hour_renders_arrow_day_hour(env_save_restore):
+    """``format_reset_day_hour`` emits ``→Day HHh`` in the operator's local tz."""
+    # Arrange — 2026-06-04 08:00 UTC = 2026-06-04 17:00 JST → Thu 17h.
+    env_save_restore.set("TZ", "Asia/Tokyo")
+    # Act
+    rendered = format_reset_day_hour("2026-06-04T08:00:00+00:00")
+    # Assert
+    assert rendered == "→Thu 17h"
+
+
+def test_format_reset_day_hour_none_returns_empty():
+    # Arrange
+    value = None
+    # Act
+    rendered = format_reset_day_hour(value)
+    # Assert
+    assert rendered == ""
+
+
+def test_format_reset_day_hour_unparseable_returns_empty():
+    # Arrange
+    value = "not-a-timestamp"
+    # Act
+    rendered = format_reset_day_hour(value)
+    # Assert
+    assert rendered == ""
+
+
+def test_render_stored_table_5h_cell_carries_reset_hint(env_save_restore):
+    """5h% cell renders ``42% (→HH:MM)`` when ``reset_at_5h`` is present."""
+    # Arrange — 12:05 UTC = 21:05 JST.
+    env_save_restore.set("TZ", "Asia/Tokyo")
+    rows = [
+        AccountRow(
+            name="work",
+            email="w@example.com",
+            plan_label="Pro",
+            tier="default_claude_pro",
+            freshness_state="VALID",
+            freshness_hours=2.8,
+            used_pct_5h=42.0,
+            used_pct_7d=15.0,
+            snapshot_as_of="2026-05-31T12:11:00+00:00",
+            reset_at_5h="2026-05-31T12:05:00+00:00",
+            reset_at_7d=None,
+        ),
+    ]
+    now = datetime(2026, 5, 31, 12, 14, 0, tzinfo=timezone.utc)
+    # Act
+    out = render_stored_table_to_str(rows, now=now)
+    # Assert — operator example shape from the 2026-06-09 task.
+    assert "42% (→21:05)" in out
+
+
+def test_render_stored_table_7d_cell_carries_reset_hint(env_save_restore):
+    """7d% cell renders ``15% (→Day HHh)`` when ``reset_at_7d`` is present."""
+    # Arrange — 2026-06-04 08:00 UTC = 2026-06-04 17:00 JST = Thu 17h.
+    env_save_restore.set("TZ", "Asia/Tokyo")
+    rows = [
+        AccountRow(
+            name="work",
+            email="w@example.com",
+            plan_label="Pro",
+            tier="default_claude_pro",
+            freshness_state="VALID",
+            freshness_hours=2.8,
+            used_pct_5h=42.0,
+            used_pct_7d=15.0,
+            snapshot_as_of="2026-05-31T12:11:00+00:00",
+            reset_at_5h=None,
+            reset_at_7d="2026-06-04T08:00:00+00:00",
+        ),
+    ]
+    now = datetime(2026, 5, 31, 12, 14, 0, tzinfo=timezone.utc)
+    # Act
+    out = render_stored_table_to_str(rows, now=now)
+    # Assert
+    assert "15% (→Thu 17h)" in out
+
+
+def test_render_stored_table_falls_back_to_bare_pct_when_no_reset_5h():
+    """No ``reset_at_5h`` → cell is just ``42%``; no fabricated reset hint."""
+    # Arrange
+    rows = [
+        AccountRow(
+            name="work",
+            email="w@example.com",
+            plan_label="Pro",
+            tier="default_claude_pro",
+            freshness_state="VALID",
+            freshness_hours=2.8,
+            used_pct_5h=42.0,
+            used_pct_7d=None,
+            snapshot_as_of="2026-05-31T12:11:00+00:00",
+            reset_at_5h=None,
+            reset_at_7d=None,
+        ),
+    ]
+    now = datetime(2026, 5, 31, 12, 14, 0, tzinfo=timezone.utc)
+    # Act
+    out = render_stored_table_to_str(rows, now=now)
+    # Assert — bare percentage, no `(→` arrow that would fake a reset.
+    assert "42%" in out and "(→" not in out
+
+
+def test_needs_rolling_legend_true_when_row_lacks_both_resets():
+    """When a row carries neither reset_at, the CLI needs the legend line."""
+    # Arrange
+    rows = [
+        AccountRow(
+            name="work",
+            email="w@example.com",
+            plan_label="Pro",
+            tier="default_claude_pro",
+            freshness_state="VALID",
+            freshness_hours=2.8,
+            used_pct_5h=42.0,
+            used_pct_7d=15.0,
+            snapshot_as_of="2026-05-31T12:11:00+00:00",
+            reset_at_5h=None,
+            reset_at_7d=None,
+        ),
+    ]
+    # Act
+    need = needs_rolling_legend(rows)
+    # Assert
+    assert need is True
+
+
+def test_needs_rolling_legend_false_when_every_row_has_resets():
+    """Per-row hint already discloses the rolling contract — no legend needed."""
+    # Arrange
+    rows = [
+        AccountRow(
+            name="work",
+            email="w@example.com",
+            plan_label="Pro",
+            tier="default_claude_pro",
+            freshness_state="VALID",
+            freshness_hours=2.8,
+            used_pct_5h=42.0,
+            used_pct_7d=15.0,
+            snapshot_as_of="2026-05-31T12:11:00+00:00",
+            reset_at_5h="2026-05-31T12:05:00+00:00",
+            reset_at_7d="2026-06-04T08:00:00+00:00",
+        ),
+    ]
+    # Act
+    need = needs_rolling_legend(rows)
+    # Assert
+    assert need is False
+
+
+def test_needs_rolling_legend_false_when_no_rows():
+    """An empty stored-accounts list never needs the legend."""
+    # Arrange
+    rows: list[AccountRow] = []
+    # Act
+    need = needs_rolling_legend(rows)
+    # Assert
+    assert need is False
+
+
+def test_rolling_legend_line_explains_both_windows():
+    """The legend names BOTH windows so the operator knows what 5h/7d mean."""
+    # Arrange
+    # (no setup)
+    # Act
+    legend = rolling_legend_line()
+    # Assert
+    assert "5h" in legend and "7d" in legend and "rolling" in legend
+
+
+def test_render_stored_table_header_stays_compact_when_no_reset():
+    """The 5h%/7d% column headers stay compact (no ``(rolling)`` cram).
+
+    Width gripe #3: don't blow up the header. The rolling-contract
+    disclosure now lives in a one-line legend printed by the CLI
+    below the table; the table header is just ``5h%`` / ``7d%``.
+    """
+    # Arrange — neither row has reset_at.
+    rows = [
+        AccountRow(
+            name="work",
+            email="w@example.com",
+            plan_label="Pro",
+            tier="default_claude_pro",
+            freshness_state="VALID",
+            freshness_hours=2.8,
+            used_pct_5h=42.0,
+            used_pct_7d=15.0,
+            snapshot_as_of="2026-05-31T12:11:00+00:00",
+            reset_at_5h=None,
+            reset_at_7d=None,
+        ),
+    ]
+    now = datetime(2026, 5, 31, 12, 14, 0, tzinfo=timezone.utc)
+    # Act
+    out = render_stored_table_to_str(rows, now=now)
+    # Assert — bare headers; no ``(rolling)`` smashed into the column.
+    assert "5h% (rolling)" not in out and "7d% (rolling)" not in out
+
+
+def test_render_stored_table_last_update_header_pinned():
+    """The Last-Update column header is the new name (was ``As-of``).
+
+    Gripe #1 of the 2026-06-09 operator ask: ``As-of`` was unreadable.
+    """
+    # Arrange
+    rows = [
+        AccountRow(
+            name="work",
+            email="w@example.com",
+            plan_label="Pro",
+            tier="default_claude_pro",
+            freshness_state="VALID",
+            freshness_hours=2.8,
+            used_pct_5h=42.0,
+            used_pct_7d=15.0,
+            snapshot_as_of="2026-05-31T12:11:00+00:00",
+        ),
+    ]
+    now = datetime(2026, 5, 31, 12, 14, 0, tzinfo=timezone.utc)
+    # Act
+    out = render_stored_table_to_str(rows, now=now)
+    # Assert — new header present, old header gone.
+    assert "Last Update" in out
+    assert "As-of" not in out
+
+
+def test_render_stored_table_width_fits_120_cols(env_save_restore):
+    """Operator gripe #3: the table must stay readable on ~120 cols.
+
+    Renders a representative row with both reset hints + day-hour
+    Last-Update + multi-character TTL. Each line of the rich-drawn
+    table must fit within the explicit 120-column width budget the
+    renderer is asked to honour.
+    """
+    # Arrange — JST so the reset hints carry the operator's wall clock.
+    env_save_restore.set("TZ", "Asia/Tokyo")
+    rows = [
+        AccountRow(
+            name="ywatanabe-scitex-ai",
+            email="ywatanabe@scitex.ai",
+            plan_label="Max 20x",
+            tier="default_claude_max_20x",
+            freshness_state="VALID",
+            freshness_hours=2.8,
+            used_pct_5h=42.0,
+            used_pct_7d=15.0,
+            snapshot_as_of="2026-05-31T12:11:00+00:00",
+            reset_at_5h="2026-05-31T12:05:00+00:00",
+            reset_at_7d="2026-06-04T08:00:00+00:00",
+        ),
+    ]
+    now = datetime(2026, 5, 31, 12, 14, 0, tzinfo=timezone.utc)
+    # Act
+    out = render_stored_table_to_str(rows, now=now, width=120)
+    lines = out.splitlines()
+    # Assert — every rendered line must fit in 120 columns.
+    over = [(i, len(ln)) for i, ln in enumerate(lines) if len(ln) > 120]
+    assert not over, f"lines exceed 120 cols: {over}\n---\n{out}"
+
+
+def test_build_stored_rows_propagates_reset_at_from_cache(sandbox_home):
+    """``build_stored_rows`` carries ``reset_at_5h`` / ``reset_at_7d`` from cache.
+
+    The Anthropic OAuth usage API returns ``resets_at`` for both
+    windows; the per-account ``usage.json`` cache writer in
+    :mod:`._account.claude_usage` persists those as ``reset_at_5h``
+    / ``reset_at_7d``. ``build_stored_rows`` must propagate them so
+    the renderer can show the per-row hint.
+    """
+    # Arrange — stage a stored account whose usage.json carries both reset_at_*.
+    save_account("work", {"email_address": "w@x"}, home=sandbox_home)
+    accts = sandbox_home / ".scitex" / "agent-container" / "accounts" / "work"
+    (accts / ".credentials.json").write_text(
+        json.dumps({"claudeAiOauth": {"subscriptionType": "pro"}})
+    )
+    (accts / "usage.json").write_text(
+        json.dumps(
+            {
+                "used_pct_5h": 42.0,
+                "used_pct_7d": 15.0,
+                "reset_at_5h": "2026-05-31T12:05:00+00:00",
+                "reset_at_7d": "2026-06-04T08:00:00+00:00",
+                "fetched_at": "2026-05-31T12:11:00+00:00",
+                "as_of": "2026-05-31T12:11:00+00:00",
+            }
+        )
+    )
+    # Act
+    rows = build_stored_rows([{"name": "work", "email_address": "w@x"}])
+    # Assert
+    assert rows[0].reset_at_5h == "2026-05-31T12:05:00+00:00"
+    assert rows[0].reset_at_7d == "2026-06-04T08:00:00+00:00"
 
 
 # ---------------------------------------------------------------------------
@@ -682,7 +1022,7 @@ def test_cli_list_human_renders_table_columns(sandbox_home):
     # Act
     result = runner.invoke(account, ["list"])
     # Assert — column headers from the rich table.
-    for col in ("ID", "Email", "Plan", "Status(+TTL)", "5h%", "7d%", "As-of"):
+    for col in ("ID", "Email", "Plan", "Status(+TTL)", "5h%", "7d%", "Last Update"):
         assert col in result.output, f"missing column {col!r}:\n{result.output}"
 
 
@@ -734,4 +1074,105 @@ def test_cli_list_json_usage_as_of_keeps_iso_t_separator(sandbox_home):
     assert "T" in as_of, (
         f"--json must carry through ISO `T` separator on usage.as_of; "
         f"got {as_of!r} (usage={usage!r})"
+    )
+
+
+# ---------------------------------------------------------------------------
+# JSON schema stability — header rename + reset-hint feature must NOT mutate
+# the machine-readable contract downstream consumers parse.
+# ---------------------------------------------------------------------------
+
+
+def _seed_account_with_full_usage_cache(sandbox_home) -> None:
+    """Stage a stored account whose usage.json carries every field the API ships."""
+    save_account("work", {"email_address": "w@example.com"}, home=sandbox_home)
+    accts = sandbox_home / ".scitex" / "agent-container" / "accounts" / "work"
+    (accts / "usage.json").write_text(
+        json.dumps(
+            {
+                "used_pct_5h": 42.0,
+                "used_pct_7d": 15.0,
+                "reset_at_5h": "2026-05-31T12:05:00+00:00",
+                "reset_at_7d": "2026-06-04T08:00:00+00:00",
+                "fetched_at": "2026-05-31T12:11:00+00:00",
+                "as_of": "2026-05-31T12:11:00+00:00",
+            }
+        )
+    )
+
+
+def test_cli_list_json_does_not_introduce_last_update_key(sandbox_home):
+    """The ``As-of`` → ``Last Update`` rename is HUMAN-RENDER-ONLY.
+
+    The JSON path must not start emitting a ``last_update`` key (or
+    anything similar) — downstream consumers parse ``as_of``.
+    """
+    # Arrange
+    _seed_account_with_full_usage_cache(sandbox_home)
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(account, ["list", "--json"])
+    # Assert — neither the new nor the old human-renderer header
+    # appears as a JSON key.
+    assert "last_update" not in result.output.lower()
+    assert "Last Update" not in result.output
+
+
+def test_cli_list_json_carries_through_reset_at_5h(sandbox_home):
+    """``--json`` exposes ``reset_at_5h`` from the upstream API.
+
+    The renderer reads ``reset_at_5h`` from the per-account
+    ``usage.json`` cache for its inline hint; the JSON path must
+    carry the SAME key through so JSON consumers can compute their
+    own reset display.
+    """
+    # Arrange
+    _seed_account_with_full_usage_cache(sandbox_home)
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(account, ["list", "--json"])
+    payload = json.loads(result.output)
+    usage = payload["stored"][0]["usage"]
+    # Assert
+    assert usage["reset_at_5h"] == "2026-05-31T12:05:00+00:00"
+
+
+def test_cli_list_json_carries_through_reset_at_7d(sandbox_home):
+    """``--json`` exposes ``reset_at_7d`` from the upstream API."""
+    # Arrange
+    _seed_account_with_full_usage_cache(sandbox_home)
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(account, ["list", "--json"])
+    payload = json.loads(result.output)
+    usage = payload["stored"][0]["usage"]
+    # Assert
+    assert usage["reset_at_7d"] == "2026-06-04T08:00:00+00:00"
+
+
+def test_cli_list_human_shows_reset_hint_when_cache_has_reset_at(sandbox_home):
+    """End-to-end: cache → renderer → operator sees ``42% (→...)``.
+
+    The bullet-2 contract of the 2026-06-09 task: when the per-account
+    cache carries ``reset_at_5h``, the human-rendered table cell must
+    show the inline reset hint. We don't pin a specific local time
+    (tests run on hosts in arbitrary timezones) — only the arrow
+    marker, which is the renderer's unambiguous reset signal.
+    """
+    # Arrange — full account + a credentials snapshot so the live
+    # fetcher path is taken; with no real OAuth token the fetcher
+    # falls back to the cached ``usage.json`` we seed below.
+    _seed_account_with_full_usage_cache(sandbox_home)
+    accts = sandbox_home / ".scitex" / "agent-container" / "accounts" / "work"
+    (accts / ".credentials.json").write_text(
+        json.dumps({"claudeAiOauth": {"subscriptionType": "pro"}})
+    )
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(account, ["list"])
+    # Assert — bullet-2 contract: the inline arrow marker reaches the
+    # operator. The exact local time depends on the host TZ; assert
+    # on the marker shape so the test is timezone-independent.
+    assert "(→" in result.output, (
+        f"missing inline reset hint in human table:\n{result.output}"
     )


### PR DESCRIPTION
## Summary

Three operator-visible clarifications to the Stored-accounts human
table (operator gripes via lead, 2026-06-09); JSON output schema
unchanged. Closes the 2026-06-09 ask.

1. **Header rename**: `As-of` -> `Last Update`. Operator could not
   parse the abbreviation.

2. **Per-row reset hint on 5h%/7d% cells**, computed from the
   Anthropic OAuth usage API's `resets_at` field (already parsed
   into `reset_at_5h` / `reset_at_7d` by `_account.claude_usage`
   and persisted in the per-account `usage.json` cache):
   - 5h window: `42% (->21:05)` — local wall-clock
   - 7d window: `15% (->Thu 17h)` — day + hour, local
   - Local-tz precedence chain unchanged
     (`SCITEX_AGENT_CONTAINER_TZ` > `TZ` > system local).

3. **Width-friendly** (~120 cols). When the API did NOT return reset
   timestamps (older caches / outage), the CLI prints a one-line
   legend below the table explaining the rolling-window contract;
   column headers stay compact.

## Before / after

Before:

```
┃ ID   ┃ Email           ┃ Plan    ┃ Status(+TTL) ┃ 5h% ┃ 7d% ┃ As-of        ┃
│ work │ w@example.com   │ Max 20x │ VALID +2h48m │ 42% │ 15% │ Sun 21h (3m) │
```

After:

```
┃ ID                  ┃ Email                 ┃ Plan     ┃ Status(+TTL) ┃   5h%        ┃    7d%         ┃ Last Update  ┃
│ ywatanabe-scitex-ai │ ywatanabe@scitex.ai   │ Max 20x  │ VALID +2h48m │ 42% (->21:05)│ 15% (->Thu 17h)│ Sun 21h (3m) │
│ ywatanabe-spartan   │ ywatanabe@unimelb.ed… │ Max 5x   │ VALID +1h12m │           85%│             64%│ Sun 21h (4m) │

Legend: 5h = rolling 5-hour window; 7d = rolling 7-day window. (->HH:MM / ->Day HHh next to the % marks the next reset.)
```

## Anthropic API window-end question

The Anthropic OAuth usage endpoint
(`GET https://api.anthropic.com/api/oauth/usage`) returns
`resets_at` (ISO-8601) for both `five_hour` and `seven_day` blocks.
`_account.claude_usage._parse_windows` already extracts these into
`reset_at_5h` / `reset_at_7d` and persists them in the per-account
`usage.json` cache. No new fetcher work was needed — the renderer
just consumes the existing fields.

## JSON schema stability

`sac accounts list --json` is NOT mutated by the header rename:
- The new human-render header `Last Update` does NOT appear as a
  JSON key (no `last_update` snake-case alias either).
- `usage.reset_at_5h` and `usage.reset_at_7d` are carried through
  verbatim from the cache (they were already inside the
  usage dict).

## Refactor

Pulled the pure formatting helpers (timezone resolve, ttl-live,
snapshot age, as-of-short, reset hhmm, reset day-hour) into a
sibling module `_account_list_format.py` so neither file exceeds
the 512-line per-file cap. The renderer re-exports the helpers so
existing call-sites and the test suite keep their imports unchanged.

## Test plan

- [x] TDD: 21 new tests cover header rename, per-row reset hint
  rendering (5h + 7d), empty-string fallback on missing/unparseable
  reset_at, legend behaviour (true when any row lacks both resets),
  width fits 120 cols, JSON-schema stability.
- [x] Existing 43 renderer tests still pass.
- [x] 555 tests pass across the targeted account-related suite
  (`test__account_list_render`, `test_account_group*`,
  `test__account_refresh_pinned_running`, `test_status_cmds`,
  `tests/scitex_agent_container/_account/`).
- [ ] CI green (pytest matrix on py3.11 / 3.12 / 3.13, ruff, sphinx).
- [ ] Self-merge to `develop` once CI is green; bump tag
  `v0.21.10` for PyPI publish.