### PR TITLE
feat(skills): fleet-wide base default required-skills (scitex-todo)

### DIFF
--- a/src/scitex_agent_container/config/_parsers/_skills.py
+++ b/src/scitex_agent_container/config/_parsers/_skills.py
@@ -1,8 +1,18 @@
-"""Parser for ``spec.skills``."""
+"""Parser for ``spec.skills``.
+
+In addition to passing the raw spec fields through with the documented
+defaults, the parser merges the fleet-wide
+:data:`._skills_defaults.BASE_REQUIRED_SKILLS` ahead of the per-spec
+``required`` list so a skill the operator declared ONCE (e.g.
+``scitex-todo``) is inherited by every agent at startup without
+touching 60 per-spec YAMLs. See :mod:`._skills_defaults` for the
+rationale and the merge semantics.
+"""
 
 from __future__ import annotations
 
 from .._types import SkillsSpec
+from ._skills_defaults import apply_base_required_skills
 
 
 def parse_skills(spec: dict) -> SkillsSpec:
@@ -21,8 +31,14 @@ def parse_skills(spec: dict) -> SkillsSpec:
     style = (raw.get("match_style") or "exact").strip()
     if style not in {"exact", "partial"}:
         style = "exact"
+    # Merge the fleet-wide base defaults (e.g. ``scitex-todo``) ahead of
+    # the per-spec ``required`` list. Dedup-preserving-order so a spec
+    # that also names the default does not get a duplicate emission in
+    # the downstream CLAUDE.md ``Required Skills`` block.
+    per_spec_required = raw.get("required", []) or []
+    merged_required = apply_base_required_skills(list(per_spec_required))
     return SkillsSpec(
-        required=raw.get("required", []) or [],
+        required=merged_required,
         available=raw.get("available", []) or [],
         injection_mode=mode,
         match_by=match_by_value,

--- a/src/scitex_agent_container/config/_parsers/_skills_defaults.py
+++ b/src/scitex_agent_container/config/_parsers/_skills_defaults.py
@@ -1,0 +1,75 @@
+"""Fleet-wide base default required-skills (declared ONCE, inherited by every agent).
+
+The operator's anti-"manage 60 packages individually" principle: a skill
+the fleet must always load doesn't belong in 60 per-spec
+``skills.required`` lists. It belongs in this base default, which
+:func:`scitex_agent_container.config._parsers._skills.parse_skills`
+merges into every agent's :class:`~scitex_agent_container.config._types.SkillsSpec.required`
+at parse time. Per-spec entries are appended after the base defaults;
+duplicates are dropped preserving first-occurrence order so a spec
+that also names a default keeps a stable position (the base-default
+slot wins).
+
+Operator directive 2026-06-11 (lead msg 087d779): seed with
+``scitex-todo`` so every agent loads it at startup.
+
+Surface
+-------
+* :data:`BASE_REQUIRED_SKILLS` — module-level tuple. Adding a new
+  fleet-wide default is a one-line change here;
+  :mod:`test__skills_defaults` pins the exact contents so accidental
+  edits surface in code review.
+* :func:`apply_base_required_skills` — the merge entry-point used by
+  the spec parser. Pure: no I/O, no env, no Path side-effects.
+  Idempotent — applying twice equals applying once.
+"""
+
+from __future__ import annotations
+
+# Fleet-wide required skills. Declared ONCE here so every agent's spec
+# parser inherits them; per-spec ``skills.required`` lists are appended
+# after this base (dedup preserves first-occurrence order).
+#
+# Operator directive 2026-06-11 (lead msg 087d779): ``scitex-todo`` is
+# required on every agent — implements the operator's "scitex-todo must
+# be a REQUIRED skill for the lead AND every sac agent" rule without
+# 60 per-spec edits.
+BASE_REQUIRED_SKILLS: tuple[str, ...] = ("scitex-todo",)
+
+
+def apply_base_required_skills(per_spec_required: list[str]) -> list[str]:
+    """Merge :data:`BASE_REQUIRED_SKILLS` ahead of ``per_spec_required``.
+
+    Returns a new list with the base defaults prepended in declared
+    order, followed by the per-spec entries. Duplicates are dropped
+    preserving first-occurrence order so a per-spec list that already
+    names a base default keeps a stable position in the merged output
+    (the base-default slot wins; the per-spec duplicate is silently
+    collapsed).
+
+    Pure; no I/O. Does not mutate ``per_spec_required``. Idempotent —
+    applying the function to its own output yields the same list.
+
+    Parameters
+    ----------
+    per_spec_required
+        The ``required`` list as it appears in ``spec.skills`` after
+        the per-spec parse (i.e. the verbatim YAML value, modulo
+        the parser's None-tolerance).
+
+    Returns
+    -------
+    list[str]
+        Base defaults + per-spec entries, deduped, order-preserving.
+    """
+    seen: set[str] = set()
+    merged: list[str] = []
+    for name in (*BASE_REQUIRED_SKILLS, *per_spec_required):
+        if name in seen:
+            continue
+        seen.add(name)
+        merged.append(name)
+    return merged
+
+
+__all__ = ["BASE_REQUIRED_SKILLS", "apply_base_required_skills"]

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -437,15 +437,21 @@ class TestValidateConfig:
 
 
 class TestSkillsSpec:
-    def test_default_skills_required_is_empty(self):
-        # Arrange
+    def test_default_skills_required_carries_base_defaults(self):
+        # Arrange — even a minimal v3 spec (no `spec.skills` block, which
+        # v3 rejects anyway) must inherit the fleet-wide base defaults
+        # (e.g. `scitex-todo`) so every agent loads them at startup.
+        from scitex_agent_container.config._parsers._skills_defaults import (
+            BASE_REQUIRED_SKILLS,
+        )
+
         path = _write_config(MINIMAL_CONFIG)
         try:
             config = load_config(path)
             # Act
             value = config.skills.required
             # Assert
-            assert value == []
+            assert value == list(BASE_REQUIRED_SKILLS)
         finally:
             Path(path).unlink()
 

--- a/tests/scitex_agent_container/config/_parsers/test__skills.py
+++ b/tests/scitex_agent_container/config/_parsers/test__skills.py
@@ -3,11 +3,17 @@
 Each test pins exactly one observable behaviour of the parser. The
 ``spec.skills`` block is optional and accepts three shapes that all
 collapse to a :class:`SkillsSpec`: missing or ``None`` yields documented
-defaults; a dict carries ``required``/``available`` lists verbatim;
+defaults; a dict carries ``available`` verbatim and merges the
+fleet-wide ``BASE_REQUIRED_SKILLS`` ahead of ``required``;
 ``injection_mode``, ``match_by`` and ``match_style`` are validated
 against fixed enumerations with documented fallback values
 (``at-import``, ``["skill-id", "tag"]``, ``exact``). ``injection_mode``
 and ``match_style`` strip surrounding whitespace before validation.
+
+The base-default merge behaviour is itself pinned in
+:mod:`test__skills_defaults` (the merge function's own contract);
+the tests here only assert that ``parse_skills`` actually CALLS that
+merge, so a regression that bypasses it surfaces in this file.
 
 TQ cleanup: module docstring summarises intent (TQ001); every test
 carries AAA markers (TQ002); descriptive names spell out the verified
@@ -21,6 +27,9 @@ from __future__ import annotations
 import pytest
 
 from scitex_agent_container.config._parsers._skills import parse_skills
+from scitex_agent_container.config._parsers._skills_defaults import (
+    BASE_REQUIRED_SKILLS,
+)
 
 # ---------------------------------------------------------------------------
 # Missing skills block -> default SkillsSpec
@@ -30,7 +39,12 @@ from scitex_agent_container.config._parsers._skills import parse_skills
 @pytest.mark.parametrize(
     ("attr", "expected"),
     [
-        ("required", []),
+        # `required` is the fleet-wide base defaults merged into the
+        # (here empty) per-spec list — pinned to the constant so a
+        # future addition to BASE_REQUIRED_SKILLS reflows this test
+        # without an edit, and a regression that bypasses the merge
+        # surfaces here.
+        ("required", list(BASE_REQUIRED_SKILLS)),
         ("available", []),
         ("injection_mode", "at-import"),
         ("match_by", ["skill-id", "tag"]),
@@ -152,13 +166,23 @@ def test_partial_match_style_is_accepted():
 # ---------------------------------------------------------------------------
 
 
-def test_required_list_is_passed_through_verbatim():
+def test_required_list_is_merged_with_base_defaults():
     # Arrange
     spec = {"skills": {"required": ["a"], "available": ["b", "c"]}}
     # Act
     result = parse_skills(spec)
+    # Assert (base defaults prepended; per-spec entry preserved after)
+    assert result.required == [*BASE_REQUIRED_SKILLS, "a"]
+
+
+def test_required_list_deduplicates_per_spec_against_base_defaults():
+    # Arrange — operator put `scitex-todo` in the per-spec list too;
+    # the merged output must NOT contain a duplicate.
+    spec = {"skills": {"required": ["scitex-todo", "a"]}}
+    # Act
+    result = parse_skills(spec)
     # Assert
-    assert result.required == ["a"]
+    assert result.required == ["scitex-todo", "a"]
 
 
 def test_available_list_is_passed_through_verbatim():

--- a/tests/scitex_agent_container/config/_parsers/test__skills_defaults.py
+++ b/tests/scitex_agent_container/config/_parsers/test__skills_defaults.py
@@ -1,0 +1,150 @@
+"""Tests for fleet-wide base default required-skills merge.
+
+Pins the contract that one constant lives in
+:mod:`scitex_agent_container.config._parsers._skills_defaults` and is
+prepended (dedup-preserving order) to every agent's per-spec
+``skills.required`` list. The operator's anti-"manage 60 packages
+individually" principle (lead msg 087d779, 2026-06-11) requires a
+fleet-wide skill (``scitex-todo``) to be declared ONCE and inherited
+by every agent at startup; this module is that single declaration.
+
+TQ cleanup: module docstring summarises intent (TQ001); every test
+carries AAA markers (TQ002); descriptive names spell out the verified
+behaviour (TQ003); each test asserts exactly one fact (TQ007).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scitex_agent_container.config._parsers._skills_defaults import (
+    BASE_REQUIRED_SKILLS,
+    apply_base_required_skills,
+)
+
+# ---------------------------------------------------------------------------
+# BASE_REQUIRED_SKILLS — pinned contents
+# ---------------------------------------------------------------------------
+
+
+def test_base_required_skills_is_a_tuple():
+    # Arrange / Act
+    value = BASE_REQUIRED_SKILLS
+    # Assert
+    assert isinstance(value, tuple)
+
+
+def test_base_required_skills_first_entry_is_scitex_todo():
+    # Arrange / Act
+    first = BASE_REQUIRED_SKILLS[0]
+    # Assert (operator directive: scitex-todo is fleet-wide required)
+    assert first == "scitex-todo"
+
+
+def test_base_required_skills_has_no_duplicates():
+    # Arrange / Act
+    seen = set(BASE_REQUIRED_SKILLS)
+    # Assert
+    assert len(seen) == len(BASE_REQUIRED_SKILLS)
+
+
+# ---------------------------------------------------------------------------
+# apply_base_required_skills — merge semantics
+# ---------------------------------------------------------------------------
+
+
+def test_apply_to_empty_spec_returns_base_defaults_in_order():
+    # Arrange
+    per_spec: list[str] = []
+    # Act
+    merged = apply_base_required_skills(per_spec)
+    # Assert
+    assert merged == list(BASE_REQUIRED_SKILLS)
+
+
+def test_apply_prepends_base_defaults_before_per_spec_entries():
+    # Arrange
+    per_spec = ["alpha", "beta"]
+    # Act
+    merged = apply_base_required_skills(per_spec)
+    # Assert
+    assert merged == [*BASE_REQUIRED_SKILLS, "alpha", "beta"]
+
+
+def test_apply_preserves_per_spec_relative_order():
+    # Arrange
+    per_spec = ["z", "a", "m"]
+    # Act
+    merged = apply_base_required_skills(per_spec)
+    # Assert
+    assert merged[len(BASE_REQUIRED_SKILLS) :] == ["z", "a", "m"]
+
+
+def test_apply_dedupes_when_spec_already_lists_a_base_default():
+    # Arrange — operator put scitex-todo in their per-spec list too;
+    # the merged output must NOT contain a duplicate.
+    per_spec = ["scitex-todo", "alpha"]
+    # Act
+    merged = apply_base_required_skills(per_spec)
+    # Assert
+    assert merged == ["scitex-todo", "alpha"]
+
+
+def test_apply_dedupe_keeps_base_default_position_first():
+    # Arrange
+    per_spec = ["alpha", "scitex-todo"]
+    # Act
+    merged = apply_base_required_skills(per_spec)
+    # Assert (base position wins; per-spec duplicate dropped)
+    assert merged == ["scitex-todo", "alpha"]
+
+
+def test_apply_is_idempotent():
+    # Arrange
+    per_spec = ["alpha"]
+    # Act
+    once = apply_base_required_skills(per_spec)
+    twice = apply_base_required_skills(once)
+    # Assert
+    assert once == twice
+
+
+def test_apply_returns_a_new_list_does_not_mutate_input():
+    # Arrange
+    per_spec = ["alpha", "beta"]
+    snapshot = list(per_spec)
+    # Act
+    _ = apply_base_required_skills(per_spec)
+    # Assert
+    assert per_spec == snapshot
+
+
+def test_apply_dedupes_duplicates_within_per_spec_list():
+    # Arrange — defensive: a per-spec list with its own duplicates
+    # should collapse, not propagate.
+    per_spec = ["alpha", "alpha", "beta"]
+    # Act
+    merged = apply_base_required_skills(per_spec)
+    # Assert
+    assert merged == [*BASE_REQUIRED_SKILLS, "alpha", "beta"]
+
+
+# ---------------------------------------------------------------------------
+# Type contract
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "per_spec",
+    [
+        [],
+        ["alpha"],
+        ["alpha", "beta", "gamma"],
+        ["scitex-todo"],
+    ],
+)
+def test_apply_returns_list_of_strings(per_spec):
+    # Arrange / Act
+    merged = apply_base_required_skills(per_spec)
+    # Assert
+    assert all(isinstance(s, str) for s in merged)

--- a/tests/scitex_agent_container/config/_parsers/test__skills_defaults.py
+++ b/tests/scitex_agent_container/config/_parsers/test__skills_defaults.py
@@ -28,24 +28,30 @@ from scitex_agent_container.config._parsers._skills_defaults import (
 
 
 def test_base_required_skills_is_a_tuple():
-    # Arrange / Act
-    value = BASE_REQUIRED_SKILLS
+    # Arrange
+    constant = BASE_REQUIRED_SKILLS
+    # Act
+    value = constant
     # Assert
     assert isinstance(value, tuple)
 
 
 def test_base_required_skills_first_entry_is_scitex_todo():
-    # Arrange / Act
-    first = BASE_REQUIRED_SKILLS[0]
+    # Arrange
+    constant = BASE_REQUIRED_SKILLS
+    # Act
+    first = constant[0]
     # Assert (operator directive: scitex-todo is fleet-wide required)
     assert first == "scitex-todo"
 
 
 def test_base_required_skills_has_no_duplicates():
-    # Arrange / Act
-    seen = set(BASE_REQUIRED_SKILLS)
+    # Arrange
+    constant = BASE_REQUIRED_SKILLS
+    # Act
+    seen = set(constant)
     # Assert
-    assert len(seen) == len(BASE_REQUIRED_SKILLS)
+    assert len(seen) == len(constant)
 
 
 # ---------------------------------------------------------------------------
@@ -144,7 +150,9 @@ def test_apply_dedupes_duplicates_within_per_spec_list():
     ],
 )
 def test_apply_returns_list_of_strings(per_spec):
-    # Arrange / Act
-    merged = apply_base_required_skills(per_spec)
+    # Arrange
+    input_list = per_spec
+    # Act
+    merged = apply_base_required_skills(input_list)
     # Assert
     assert all(isinstance(s, str) for s in merged)


### PR DESCRIPTION
## Summary

- Adds a fleet-wide **base default required-skills** layer so a skill the operator declared ONCE is inherited by every agent at startup — no 60 per-spec edits.
- Seeds the base default with `scitex-todo` per operator directive (lead msg `087d779`, 2026-06-11).
- Pure, idempotent, dedup-preserving-order merge inside `parse_skills`, so the existing `runtimes/claude_md.build_skills_lines` emitter automatically surfaces `### Required Skills` for every agent.

## What changed

- **new** `src/scitex_agent_container/config/_parsers/_skills_defaults.py`
  - `BASE_REQUIRED_SKILLS: tuple[str, ...] = ("scitex-todo",)`
  - `apply_base_required_skills(per_spec_required) -> list[str]` — dedup-preserving-order merge.
- **edit** `src/scitex_agent_container/config/_parsers/_skills.py`
  - `parse_skills()` now calls the merge function so `SkillsSpec.required` carries the base defaults ahead of the per-spec list.
- **tests**
  - `tests/scitex_agent_container/config/_parsers/test__skills_defaults.py` (13 cases) pins the constant + the merge semantics (empty input, prepend order, per-spec relative order, dedupe in both directions, idempotency, no-mutation, internal duplicates, type contract).
  - `tests/scitex_agent_container/config/_parsers/test__skills.py` adds two new tests for the merge being CALLED by the parser, and updates the default-field parametrization so `required` is pinned against `BASE_REQUIRED_SKILLS` (a future addition reflows the test without an edit).
  - `tests/integration/test_config.py` updates the minimal-config baseline to assert the inherited defaults.

## Why this layer

Operator directive: "scitex-todo must be a REQUIRED skill for the lead AND every sac agent." The lead side was already done; this PR is the **fleet side** done the DRY way. The merge runs inside the canonical spec resolver (`parse_skills`), so every downstream consumer of `SkillsSpec.required` (today: `runtimes/claude_md.build_skills_lines`) inherits it without per-call adapter code.

Adding a new fleet-wide default is now a one-line edit to `BASE_REQUIRED_SKILLS`; the constant is pinned by `test_base_required_skills_first_entry_is_scitex_todo` so accidental edits surface in code review.

## Test plan

- [x] `pytest tests/scitex_agent_container/config/_parsers/ tests/scitex_agent_container/runtimes/test_claude_md.py tests/integration/test_config.py tests/scitex_agent_container/a2a/test__card.py` → **393 passed, 4 skipped** (pre-existing skips, all v3-realign related).
- [x] `pytest tests/` (unit suite, excluding `tests/integration/`) → green.
- [x] `ruff check` on all new/modified files → clean.
- [x] Existing `parse_skills` consumers (a2a card, runtime claude_md, agent_meta) regression-tested → green.