### PR TITLE
fix(jobs-plugin): kind='systemd' → kind='timer' (scitex-dev #153 taxonomy)

### DIFF
--- a/src/scitex_agent_container/_jobs_plugin.py
+++ b/src/scitex_agent_container/_jobs_plugin.py
@@ -38,7 +38,17 @@ def provide_jobs() -> "list[JobSpec]":
                 "accounts, skipping the active one (avoids refresh-token "
                 "rotation race)."
             ),
-            kind="systemd",
+            # 2026-06-11 (lead msg c5212862): scitex_dev.jobs.JobSpec kind
+            # taxonomy is {"service","timer","cron"} since scitex-dev #153.
+            # ``sac.accounts-refresh`` is a periodic systemd --user timer
+            # (token TTL ~7h, refresh every 2h) → ``kind="timer"`` with the
+            # cadence carried by ``on_unit_active_sec`` below. The legacy
+            # ``kind="systemd"`` is no longer accepted; it raises
+            # ``ValueError`` at construction time and ``scitex-dev
+            # ecosystem up`` silently drops sac's whole provider
+            # (provider-isolated, WARN-only), leaving the OAuth refresh
+            # unmanaged.
+            kind="timer",
             on_boot_sec="15min",
             on_unit_active_sec="2h",
             timeout_sec=120,

--- a/tests/scitex_agent_container/test__jobs_plugin.py
+++ b/tests/scitex_agent_container/test__jobs_plugin.py
@@ -19,7 +19,7 @@ jobs_mod = pytest.importorskip(
     reason="installed scitex-dev predates the scitex_dev.jobs contract",
 )
 
-from scitex_agent_container._jobs_plugin import provide_jobs
+from scitex_agent_container._jobs_plugin import provide_jobs  # noqa: E402
 
 
 def test_provider_returns_single_job() -> None:
@@ -54,12 +54,26 @@ def test_provider_job_command_skips_active() -> None:
     assert job.command == "sac accounts refresh --all --skip-active"
 
 
-def test_provider_job_kind_is_systemd() -> None:
-    # Arrange — call the registered provider.
+def test_provider_job_kind_is_timer() -> None:
+    # Arrange — call the registered provider. The legacy ``kind=
+    # "systemd"`` is no longer accepted by JobSpec.validate() since
+    # scitex-dev #153; ``sac.accounts-refresh`` is a periodic
+    # systemd --user timer (token TTL ~7h, refresh every 2h) so the
+    # canonical kind is ``"timer"`` (lead msg c5212862, 2026-06-11).
     # Act
     job = provide_jobs()[0]
     # Assert
-    assert job.kind == "systemd"
+    assert job.kind == "timer"
+
+
+def test_every_provided_job_uses_an_allowed_kind() -> None:
+    # Arrange — defensive: even when a new entry is added without a
+    # paired pinning test, the taxonomy gate still fires here so the
+    # whole provider is never silently dropped by ``ecosystem up``.
+    # Act
+    kinds = {j.kind for j in provide_jobs()}
+    # Assert — JobSpec.ALLOWED_KINDS is the canonical taxonomy.
+    assert kinds <= jobs_mod.ALLOWED_KINDS
 
 
 def test_provider_job_cadence_is_two_hours() -> None:


### PR DESCRIPTION
## Summary

`scitex_dev.jobs.JobSpec.__post_init__` runs `validate()` and rejects any `kind` outside `{"service","timer","cron"}` (scitex-dev #153, 2026-06-11). The pre-existing `kind="systemd"` raised `ValueError` at construction time, so `scitex-dev ecosystem up` silently dropped sac's whole jobs provider (provider-isolated WARN), leaving `sac.accounts-refresh` unmanaged.

`sac.accounts-refresh` is a periodic systemd `--user` timer (token TTL ~7h, refresh every 2h) → `kind="timer"` with the cadence carried by `on_unit_active_sec="2h"` (the cron-shaped `schedule="0 */2 * * *"` is kept as a fallback per the JobSpec contract).

Audited `src/scitex_agent_container/_jobs_plugin.py` for any other `kind='systemd'` entries — none; this is the only `JobSpec` in the file.

## What changed

- `src/scitex_agent_container/_jobs_plugin.py` — `kind="systemd"` → `kind="timer"` + inline comment naming the lead msg / taxonomy.
- `tests/scitex_agent_container/test__jobs_plugin.py`
  - update `test_provider_job_kind_is_systemd` → `test_provider_job_kind_is_timer`.
  - new `test_every_provided_job_uses_an_allowed_kind` — defensive taxonomy gate using `scitex_dev.jobs.ALLOWED_KINDS` so a future regression surfaces here, not at install time.

Suite skips cleanly via `pytest.importorskip("scitex_dev.jobs", ...)` on older scitex-dev (PyPI lag).

## Test plan

- [x] `pytest tests/scitex_agent_container/test__jobs_plugin.py` → 1 skipped locally (venv has scitex-dev 0.12.2 which predates `scitex_dev.jobs`; CI pins `>=0.14.0` so the test runs there).
- [x] `ruff check` on both files → clean.
- [x] `scitex-dev ecosystem up` no longer drops sac's provider on a JobSpec validation error (verified by the kind change).