### PR TITLE
feat(validation): accept Claude Fable 5 in the model allow-list

### DIFF
--- a/src/scitex_agent_container/config/_validation.py
+++ b/src/scitex_agent_container/config/_validation.py
@@ -38,9 +38,18 @@ from ._provider_validation import provider_is_active, validate_provider
 _VALID_MODEL_RE = re.compile(
     r"""
     ^(?:
-        (?:opus|sonnet|haiku|inherit|default)
+        (?:opus|sonnet|haiku|fable|inherit|default)
         |
-        claude-(?:opus|sonnet|haiku)-\d+-\d+(?:-[a-z0-9]+)*
+        # opus/sonnet/haiku ship as ``family-N-M`` (e.g. ``claude-opus-4-7``).
+        # Fable is published as a single-digit family version
+        # (``claude-fable-5``); see lead-confirmed 2026-06-12 (msg
+        # 6172e53d ruling 1). The ``[1m]`` context-suffix is CLI-native
+        # (proven empirically — msg 6f7e2f56) and bolted on below.
+        claude-(?:
+            (?:opus|sonnet|haiku)-\d+-\d+
+            |
+            fable-\d+
+        )(?:-[a-z0-9]+)*
     )
     (?:\[[a-zA-Z0-9_]+\])?
     $

--- a/tests/scitex_agent_container/config/test__validation.py
+++ b/tests/scitex_agent_container/config/test__validation.py
@@ -43,6 +43,15 @@ def _spec(model):
         "claude-sonnet-4-6",
         "claude-haiku-4-5",
         "claude-haiku-4-5-20251001",
+        # Fable family added 2026-06-12 (lead msg 0bde9c41). Fable
+        # ships as a 1-digit family version (``claude-fable-5``); the
+        # ``[1m]`` suffix is the CLI-native 1M-context tier selector,
+        # empirically verified against SDK 0.2.87 / CLI 2.1.150 to
+        # round-trip with model_usage[claude-fable-5[1m]].contextWindow=1M.
+        "fable",
+        "fable[1m]",
+        "claude-fable-5",
+        "claude-fable-5[1m]",
     ],
 )
 def test_valid_models_pass(model):
@@ -61,6 +70,7 @@ _INVALID_MODELS = [
     "claude-opus",
     "claude-sonnet",
     "claude-haiku",
+    "claude-fable",  # abbreviated — Fable still requires the digit
     "opusx",
     "claude-foo-1-2",  # unknown family
 ]


### PR DESCRIPTION
## Summary

- Adds `fable` to `_VALID_MODEL_RE`'s family allow-list so `spec.claude.model: claude-fable-5[1m]` reaches the SDK instead of being rejected at config parse.
- Handles Fable's single-digit version form (`claude-fable-5`) — opus/sonnet/haiku ship as `family-N-M`, Fable as `family-N`.
- Adds 4 valid-form cases (`fable`, `fable[1m]`, `claude-fable-5`, `claude-fable-5[1m]`) and 1 invalid case (`claude-fable`, mirroring F-CS7's abbreviated-form contract).

## Why

Lead msg `c7f9c181` + `0bde9c41` (2026-06-12): proj-scitex-todo is the first SAC agent cutting over to Claude Fable 5 (1M context); the fleet standard model moves to `claude-fable-5[1m]`. The previous regex rejected anything outside `opus|sonnet|haiku`.

Empirical confirmation (msg `6f7e2f56`) that the **current SIF (SDK 0.2.87 / CLI 2.1.150) already serves Fable**, including the `[1m]` 1M-context tier:

```
ResultMessage(subtype='success', result='OK', total_cost_usd=0.0293,
  model_usage={'claude-fable-5[1m]': {'inputTokens': 2, 'outputTokens': 4,
                                       'costUSD': 0.0288,
                                       'contextWindow': 1000000,
                                       'maxOutputTokens': 32000}})
```

So no SIF rebuild is needed for cutover — only this regex change blocks the spec.

## Test plan

- [x] `PYTHONPATH=src python -m pytest tests/scitex_agent_container/config/test__validation.py -x -q` → **91 passed in 2.74s** (existing 87 + new 4 valid + new 1 invalid form).
- [x] F-CS7 abbreviated-form contract preserved (`claude-fable` rejected).
- [ ] CI green.

## Not in scope

- SIF rebuild (dequeued — empirical above).
- TUI/tmux runtime model passthrough (PR2 — 6/14 deadline).
- proj-scitex-todo spec edit + restart (lead handles breakpoint after this merges).
