### PR TITLE
feat(listen): generic self-register peers via agents/self/spec.yaml (op-2026-06-12-15)

### DIFF
--- a/.scitex/agent-container/agents/self/spec.yaml
+++ b/.scitex/agent-container/agents/self/spec.yaml
@@ -1,0 +1,25 @@
+# Generic self-register spec (op-2026-06-12-15, TG 12631 → 12638).
+#
+# The literal ``agents/self/`` directory is the SSoT for
+# "register the RUNNING session". The actual peer name comes from
+# the running listen's RUNTIME IDENTITY (resolved by
+# scitex_agent_container._listen.server._resolve_runtime_self_identity,
+# which reads host_config.lead.name) — NOT from a hard-coded
+# ``name:`` field below. That keeps the convention completely
+# generic: no node is special-cased anywhere in code.
+#
+# Required:
+#   listen_url   — the local listen endpoint this session owns
+#
+# Optional:
+#   description  — short label shown in ``sac a2a peers`` output
+#
+# DO NOT add a ``name:`` field. The dir literal ``self`` plus the
+# listen's runtime identity is the canonical name source.
+#
+# DO NOT add ``apiVersion`` or ``spec:`` — those are the
+# container-agent gates; presence excludes this file from self-peer
+# discovery (see ``_listen/_self_peers.py::is_self_peer_spec``).
+
+listen_url: http://127.0.0.1:7878
+description: "self-registered listen session (runtime identity from host_config)"

--- a/src/scitex_agent_container/_listen/_self_peers.py
+++ b/src/scitex_agent_container/_listen/_self_peers.py
@@ -1,0 +1,251 @@
+"""Self-register external listen sessions as peers via the ``agents/self`` shape.
+
+Operator directive op-2026-06-12-15 (TG 12631 → 12638): the
+self-registration is COMPLETELY GENERIC — no special-casing of any
+particular session ("lead", "operator", etc.). Any session/node
+that owns a listen endpoint registers itself through ONE shape,
+ONE code path. The lead/operator listen is one instance of the
+pattern; it is NOT a code-level discriminator anywhere.
+
+Convention (literal):
+
+    <search-dir>/self/spec.yaml
+
+    listen_url:  <required>
+    description: <optional, shown in peer listings>
+
+The literal ``self`` directory name is the SSoT for "this is the
+RUNNING session — register it under MY runtime identity". The peer
+NAME is derived from the running listen's own identity (the
+canonical host, the listen's configured name, …) — NOT from a
+hard-coded ``name:`` field in spec.yaml. Hard-coding would re-
+introduce the "lead-specific" coupling the operator just spent two
+back-and-forth Telegram messages explicitly rejecting.
+
+For NON-self dirs (``<search-dir>/<other-name>/spec.yaml`` whose
+shape still satisfies the self-peer predicate — listen-only YAML)
+the name is the directory name. That keeps the convention generic
+while still letting the operator drop pre-named pointer specs into
+a search dir for nodes that are NOT "the running session".
+
+Public surface:
+
+* :func:`is_self_peer_spec(blob)` — pure predicate. ``True`` iff
+  the parsed YAML carries ``listen_url`` AND has neither ``spec``
+  nor ``apiVersion`` (the container-agent gates).
+
+* :func:`load_self_peer(path, *, self_identity=None)` — read one
+  spec file, return a peer dict in the same shape
+  :meth:`Registry.list_all` returns. Name derivation:
+
+    - Dir literally ``self`` AND ``self_identity`` provided →
+      ``name = self_identity``.
+    - Dir literally ``self`` AND no ``self_identity`` →
+      ``name = "self"`` (degraded — the caller did not pass
+      runtime identity; logged at ``warning``).
+    - Any other dir → ``name = <dirname>``.
+
+* :func:`discover_self_peers(search_dirs, *, self_identity=None)`
+  — walk a sequence of agent-base directories, return every
+  self-peer in deterministic ``name`` order. The ``self_identity``
+  argument is forwarded to :func:`load_self_peer` so the literal
+  ``self`` dir resolves to the running listen's identity at scan
+  time. Search dirs are INJECTED so tests drive discovery without
+  touching ``$HOME``.
+
+Out of scope (deferred):
+
+* Pull-side MCP registration (TG 12633 follow-up — the listening
+  node's sac MCP CLIENT should ALSO surface itself so a peer's
+  ``a2a_peers`` listing reports it even without the listen push).
+  Sibling module under ``_mcp/``; this module owns the push side.
+* Cross-host comms_nodes UPSERT —
+  :mod:`_mcp._channel_self_register` already covers the channel
+  path. This module is the listen-side analogue.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Mapping, Sequence
+
+log = logging.getLogger(__name__)
+
+
+# The two keys that mark a YAML as "container-agent" rather than
+# "self-peer". Presence of EITHER excludes the file from self-peer
+# discovery — the self-peer shape must be the minimal listen-pointer,
+# not a partial container spec.
+_CONTAINER_AGENT_KEYS: frozenset[str] = frozenset({"spec", "apiVersion"})
+
+# The literal directory name that means "register the running
+# session under its runtime identity". Any other dir name is taken
+# as the peer's intended name verbatim.
+_SELF_DIR_LITERAL = "self"
+
+
+def is_self_peer_spec(blob: Mapping[str, object] | None) -> bool:
+    """Return True iff *blob* is a self-peer spec (``listen_url`` + no container keys).
+
+    A self-peer spec MUST:
+
+    * be a mapping (PyYAML returns ``None`` for an empty document
+      and a non-mapping for ``--- 42``-style scalars — both are
+      rejected as malformed self-peer specs).
+    * declare a non-empty ``listen_url`` string.
+    * NOT declare ``spec`` or ``apiVersion`` — those are the
+      container-agent gates.
+
+    Pure → testable without filesystem. The listen-side merge calls
+    this to short-circuit obviously-not-a-peer specs that an
+    external orchestrator may have dropped into an agents dir.
+    """
+    if not isinstance(blob, Mapping):
+        return False
+    listen_url = blob.get("listen_url")
+    if not isinstance(listen_url, str) or not listen_url.strip():
+        return False
+    for k in _CONTAINER_AGENT_KEYS:
+        if k in blob:
+            return False
+    return True
+
+
+def load_self_peer(path: Path, *, self_identity: str | None = None) -> dict | None:
+    """Read one spec file and return a peer dict, or ``None``.
+
+    Name derivation (TG 12637/12638 — generic):
+
+    * Dir literally :data:`_SELF_DIR_LITERAL` AND *self_identity*
+      provided → ``name = self_identity``.
+    * Dir literally :data:`_SELF_DIR_LITERAL` AND *self_identity*
+      missing → ``name = "self"`` plus a ``log.warning`` so the
+      operator can tell the listen forgot to pass its runtime
+      identity into the discovery pipeline.
+    * Any other dir → ``name = path.parent.name``.
+
+    Return shape mirrors :meth:`Registry.list_all`'s entries so the
+    listen-side handler concatenates the two lists with no
+    field-by-field re-projection:
+
+        {
+            "name":        <derived as above>,
+            "config":      <absolute path to the spec.yaml>,
+            "listen_url":  <yaml.listen_url>,
+            "description": <yaml.description, or "">,
+            "kind":        "self-peer",
+        }
+
+    ``kind`` is the discriminator a peer-aware client uses to skip
+    the container-only fields (``pid``, ``screen``, ``started_at``)
+    that would be meaningless for a self-peer.
+
+    Failure modes (all return ``None`` after one ``log.warning``):
+
+    * OS read error (permissions, vanished file).
+    * Malformed YAML.
+    * Document fails :func:`is_self_peer_spec` (not a self-peer).
+
+    ``None`` rows are filtered before concat by
+    :func:`discover_self_peers`.
+    """
+    try:
+        import yaml
+    except ImportError:  # pragma: no cover — PyYAML is a hard sac dep
+        log.warning("self-peer: PyYAML unavailable; skipping %s", path)
+        return None
+    try:
+        text = path.read_text()
+    except OSError as exc:
+        log.warning("self-peer: cannot read %s: %s", path, exc)
+        return None
+    try:
+        blob = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        log.warning("self-peer: malformed YAML at %s: %s", path, exc)
+        return None
+    if not is_self_peer_spec(blob):
+        return None
+    # ``is_self_peer_spec`` already validated the type — assert for type-checkers.
+    assert isinstance(blob, Mapping)
+
+    dir_name = path.parent.name
+    if dir_name == _SELF_DIR_LITERAL:
+        if self_identity and self_identity.strip():
+            name = self_identity
+        else:
+            log.warning(
+                "self-peer: %s lives in literal 'self/' dir but no "
+                "self_identity was supplied; falling back to dir name "
+                "(peer listing will show 'self' rather than the "
+                "running session's runtime identity)",
+                path,
+            )
+            name = _SELF_DIR_LITERAL
+    else:
+        name = dir_name
+
+    description = blob.get("description", "")
+    if not isinstance(description, str):
+        description = ""
+    return {
+        "name": name,
+        "config": str(path),
+        "listen_url": blob["listen_url"],
+        "description": description,
+        "kind": "self-peer",
+    }
+
+
+def discover_self_peers(
+    search_dirs: Sequence[Path], *, self_identity: str | None = None
+) -> list[dict]:
+    """Walk *search_dirs*, return every self-peer dict in name order.
+
+    Each entry in ``search_dirs`` is treated as a base directory
+    holding ``<name>/spec.yaml`` (and ``.yml``) — the same shape
+    :func:`config._resolve._try_dir` consumes. A directory that does
+    not exist is silently skipped (the listen may start before the
+    operator has populated every search root).
+
+    ``self_identity`` is the running listen's runtime identity (its
+    canonical name, the only authoritative answer to "who am I").
+    It is forwarded to :func:`load_self_peer` so a literal
+    ``agents/self/spec.yaml`` resolves to the running session's
+    identity at scan time — that's what makes the convention
+    generic. ``None`` is accepted and degrades gracefully (see
+    :func:`load_self_peer`).
+
+    Deduplication: the same derived ``name`` MAY appear in multiple
+    search dirs (a project-local override + a home-install
+    fallback). The HIGHEST-priority dir wins (earlier in
+    ``search_dirs``), matching :func:`config._resolve._search_dirs`
+    precedence so the same override semantics apply to both "where
+    does sac find the spec" and "what does sac a2a peers report".
+
+    Return order is alphabetical by derived ``name`` — operator-
+    facing listings never reflect filesystem walk order.
+    """
+    seen: dict[str, dict] = {}
+    for base in search_dirs:
+        if not base.is_dir():
+            continue
+        for child in sorted(base.iterdir()):
+            if not child.is_dir():
+                continue
+            for ext in (".yaml", ".yml"):
+                spec_path = child / f"spec{ext}"
+                if spec_path.is_file():
+                    peer = load_self_peer(spec_path, self_identity=self_identity)
+                    if peer is not None and peer["name"] not in seen:
+                        seen[peer["name"]] = peer
+                    break  # one spec file per agent dir
+    return sorted(seen.values(), key=lambda p: p["name"])
+
+
+__all__ = [
+    "discover_self_peers",
+    "is_self_peer_spec",
+    "load_self_peer",
+]

--- a/src/scitex_agent_container/_listen/server.py
+++ b/src/scitex_agent_container/_listen/server.py
@@ -57,13 +57,100 @@ async def health(_request: Request) -> JSONResponse:
 
 
 async def list_agents(_request: Request) -> JSONResponse:
-    """List agents the local Registry knows about."""
+    """List agents the local Registry knows about + self-peers.
+
+    Two sources, concatenated in this order:
+
+    1. Container-agent rows from :meth:`Registry.list_all` — the
+       traditional ``sac a2a peers`` shape (``name`` / ``config`` /
+       ``pid`` / ``started_at`` / ``screen``).
+    2. Self-peer rows from :func:`_self_peers.discover_self_peers`
+       — any agent dir whose ``spec.yaml`` carries only a
+       ``listen_url`` (no container ``spec`` block, no
+       ``apiVersion``). These have no ``pid`` / ``screen`` — they
+       are external listen sessions that own a port and want to be
+       discoverable. Carries ``"kind": "self-peer"`` so peer-aware
+       clients can branch on the source.
+
+    Dedup: a self-peer whose ``name`` already appears in the
+    container-row list loses to the container row (the running
+    container is the more authoritative source). Order matches
+    operator-facing convention: container rows first, then
+    self-peers alphabetically by ``name``.
+    """
+    rows: list[dict] = []
+    seen_names: set[str] = set()
     try:
         reg = Registry()
-        rows = reg.list_all()
+        for row in reg.list_all():
+            rows.append(row)
+            name = row.get("name") if isinstance(row, dict) else None
+            if isinstance(name, str):
+                seen_names.add(name)
     except Exception as exc:  # stx-allow: fallback (reason: surface a JSON error to the caller rather than ASGI 500 stack)
         return JSONResponse({"error": str(exc)}, status_code=500)
+    # Self-peers — best-effort. Failures here must NOT mask a healthy
+    # container-row response (an unreadable agents dir is operator
+    # state, not a listen failure).
+    #
+    # Runtime self-identity is derived from host_config — the same
+    # source the existing channel/listen self-registration paths
+    # consult. Missing host_config / missing ``lead:`` block degrades
+    # to ``None``; :func:`discover_self_peers` then surfaces the
+    # literal ``self`` dir as ``"self"`` with a logged warning, which
+    # is the loudest signal short of failing the request.
+    try:
+        from ..config._resolve import _search_dirs
+        from ._self_peers import discover_self_peers
+
+        primary, env_dirs, fleet_dirs = _search_dirs()
+        search_dirs = [*env_dirs, primary, *fleet_dirs]
+        self_identity = _resolve_runtime_self_identity()
+        for peer in discover_self_peers(search_dirs, self_identity=self_identity):
+            if peer["name"] in seen_names:
+                continue
+            rows.append(peer)
+            seen_names.add(peer["name"])
+    except Exception as exc:  # stx-allow: fallback (reason: self-peer discovery must never block the registry response)
+        import logging
+
+        logging.getLogger(__name__).warning(
+            "list_agents: self-peer discovery failed (returning registry rows only): %s",
+            exc,
+        )
     return JSONResponse({"agents": rows})
+
+
+def _resolve_runtime_self_identity() -> str | None:
+    """Return the running listen's runtime identity, or ``None``.
+
+    Reads :func:`host_config.load().lead.name` — the same source the
+    existing channel/listen self-registration paths
+    (:mod:`_mcp._channel_self_register`,
+    :func:`cli_pkg.listen_cmds._register_self_comms_node`) consult.
+    A missing ``lead:`` block in host_config returns ``None`` — the
+    self-peer discovery downstream then surfaces the literal
+    ``self`` dir as ``"self"`` so the operator sees the gap rather
+    than getting a silently-renamed peer row.
+
+    Generic on purpose: there is no name-specific branching here.
+    ``host_config.lead.name`` is THE host's "who am I" answer for
+    operator-class sessions; a future evolution that supports
+    multiple self-identities on one host would extend the host_config
+    shape, not insert per-name special cases here.
+    """
+    try:
+        from .._state.host_config import load as load_host_config
+
+        cfg = load_host_config()
+        lead = getattr(cfg, "lead", None)
+        if lead is not None:
+            name = getattr(lead, "name", None)
+            if isinstance(name, str) and name.strip():
+                return name
+    except Exception:  # stx-allow: fallback (reason: host_config errors must never block the /agents response)
+        pass
+    return None
 
 
 async def agent_status(request: Request) -> JSONResponse:

--- a/tests/scitex_agent_container/_listen/test__self_peers.py
+++ b/tests/scitex_agent_container/_listen/test__self_peers.py
@@ -69,8 +69,10 @@ def test_is_self_peer_spec_rejects_blob_with_apiversion_container_marker():
 
 
 def test_is_self_peer_spec_rejects_non_mapping_input_none():
-    # Arrange / Act
-    accepted = is_self_peer_spec(None)
+    # Arrange
+    blob = None
+    # Act
+    accepted = is_self_peer_spec(blob)
     # Assert
     assert accepted is False
 

--- a/tests/scitex_agent_container/_listen/test__self_peers.py
+++ b/tests/scitex_agent_container/_listen/test__self_peers.py
@@ -1,0 +1,228 @@
+"""Tests for the generic self-peer discovery shape (op-2026-06-12-15).
+
+The self-peer convention is GENERIC — no name-specific hacks. The
+literal ``self`` directory means "register the running session
+under its RUNTIME identity"; the name comes from a *self_identity*
+argument the listen passes in at scan time. Any other directory
+name is taken verbatim as the peer's name. No code-level
+discriminators for ``lead`` / ``operator`` / any other identifier.
+
+Test style (STX-TQ002 / TQ007): explicit ``# Arrange`` / ``# Act`` /
+``# Assert`` markers in order; one assertion per test.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scitex_agent_container._listen._self_peers import (
+    discover_self_peers,
+    is_self_peer_spec,
+    load_self_peer,
+)
+
+# ---------------------------------------------------------------------------
+# is_self_peer_spec — pure predicate
+# ---------------------------------------------------------------------------
+
+
+def test_is_self_peer_spec_accepts_minimal_listen_only_mapping():
+    # Arrange
+    blob = {"listen_url": "http://127.0.0.1:7878"}
+    # Act
+    accepted = is_self_peer_spec(blob)
+    # Assert
+    assert accepted is True
+
+
+def test_is_self_peer_spec_rejects_blob_without_listen_url():
+    # Arrange
+    blob = {"description": "no listen url here"}
+    # Act
+    accepted = is_self_peer_spec(blob)
+    # Assert
+    assert accepted is False
+
+
+def test_is_self_peer_spec_rejects_blob_with_spec_key_container_marker():
+    # Arrange
+    blob = {
+        "listen_url": "http://127.0.0.1:7878",
+        "spec": {"runtime": "apptainer"},
+    }
+    # Act
+    accepted = is_self_peer_spec(blob)
+    # Assert
+    assert accepted is False
+
+
+def test_is_self_peer_spec_rejects_blob_with_apiversion_container_marker():
+    # Arrange
+    blob = {
+        "listen_url": "http://127.0.0.1:7878",
+        "apiVersion": "scitex-agent-container/v3",
+    }
+    # Act
+    accepted = is_self_peer_spec(blob)
+    # Assert
+    assert accepted is False
+
+
+def test_is_self_peer_spec_rejects_non_mapping_input_none():
+    # Arrange / Act
+    accepted = is_self_peer_spec(None)
+    # Assert
+    assert accepted is False
+
+
+# ---------------------------------------------------------------------------
+# load_self_peer — read one file
+# ---------------------------------------------------------------------------
+
+
+def _write_spec(dir_: Path, name: str, body: str) -> Path:
+    """Helper — write ``<dir>/<name>/spec.yaml`` and return the path."""
+    sub = dir_ / name
+    sub.mkdir(parents=True, exist_ok=True)
+    path = sub / "spec.yaml"
+    path.write_text(body)
+    return path
+
+
+def test_load_self_peer_uses_self_identity_for_literal_self_dir(
+    tmp_path: Path,
+):
+    # Arrange: the operator-canonical shape — literal ``self/`` dir,
+    # listen-only spec, runtime identity supplied by the caller.
+    spec = _write_spec(tmp_path, "self", "listen_url: http://127.0.0.1:7878\n")
+    # Act
+    peer = load_self_peer(spec, self_identity="capsule-7")
+    # Assert
+    assert peer is not None and peer["name"] == "capsule-7"
+
+
+def test_load_self_peer_falls_back_to_dir_name_when_dir_is_not_self(
+    tmp_path: Path,
+):
+    # Arrange: non-``self`` dir → name comes verbatim from dir.
+    spec = _write_spec(tmp_path, "beta-pointer", "listen_url: http://127.0.0.1:9001\n")
+    # Act
+    peer = load_self_peer(spec, self_identity="should-be-ignored")
+    # Assert
+    assert peer is not None and peer["name"] == "beta-pointer"
+
+
+def test_load_self_peer_degrades_self_dir_without_identity_to_literal_self(
+    tmp_path: Path,
+):
+    # Arrange: literal ``self/`` but caller forgot the identity —
+    # the loader degrades gracefully to ``"self"`` rather than raising.
+    spec = _write_spec(tmp_path, "self", "listen_url: http://127.0.0.1:7878\n")
+    # Act
+    peer = load_self_peer(spec)
+    # Assert
+    assert peer is not None and peer["name"] == "self"
+
+
+def test_load_self_peer_marks_kind_field_as_self_peer(tmp_path: Path):
+    # Arrange
+    spec = _write_spec(tmp_path, "gamma", "listen_url: http://127.0.0.1:9002\n")
+    # Act
+    peer = load_self_peer(spec)
+    # Assert
+    assert peer is not None and peer["kind"] == "self-peer"
+
+
+def test_load_self_peer_returns_none_for_container_spec(tmp_path: Path):
+    # Arrange
+    body = (
+        "apiVersion: scitex-agent-container/v3\n"
+        "kind: Agent\n"
+        "spec:\n  runtime: apptainer\n"
+    )
+    spec = _write_spec(tmp_path, "container-agent", body)
+    # Act
+    peer = load_self_peer(spec)
+    # Assert
+    assert peer is None
+
+
+def test_load_self_peer_returns_none_for_malformed_yaml(tmp_path: Path):
+    # Arrange
+    spec = _write_spec(tmp_path, "broken", "not: [valid: yaml:\n")
+    # Act
+    peer = load_self_peer(spec)
+    # Assert
+    assert peer is None
+
+
+# ---------------------------------------------------------------------------
+# discover_self_peers — walk multiple dirs
+# ---------------------------------------------------------------------------
+
+
+def test_discover_self_peers_resolves_literal_self_dir_via_self_identity(
+    tmp_path: Path,
+):
+    # Arrange
+    base = tmp_path / "base"
+    _write_spec(base, "self", "listen_url: http://127.0.0.1:7878\n")
+    # Act
+    peers = discover_self_peers([base], self_identity="capsule-42")
+    # Assert: dir literal stays generic; name comes from runtime identity.
+    assert [p["name"] for p in peers] == ["capsule-42"]
+
+
+def test_discover_self_peers_returns_sorted_unique_name_list(tmp_path: Path):
+    # Arrange: two dirs, same dir name; higher-priority wins.
+    high = tmp_path / "high"
+    low = tmp_path / "low"
+    _write_spec(high, "alpha", "listen_url: http://h:1\n")
+    _write_spec(low, "alpha", "listen_url: http://l:1\n")
+    _write_spec(low, "beta", "listen_url: http://l:2\n")
+    # Act
+    peers = discover_self_peers([high, low])
+    # Assert
+    assert [p["name"] for p in peers] == ["alpha", "beta"]
+
+
+def test_discover_self_peers_higher_priority_dir_wins_on_duplicate_name(
+    tmp_path: Path,
+):
+    # Arrange
+    high = tmp_path / "high"
+    low = tmp_path / "low"
+    _write_spec(high, "alpha", "listen_url: http://winner:1\n")
+    _write_spec(low, "alpha", "listen_url: http://loser:1\n")
+    # Act
+    peers = discover_self_peers([high, low])
+    # Assert
+    assert peers[0]["listen_url"] == "http://winner:1"
+
+
+def test_discover_self_peers_silently_skips_nonexistent_search_dir(
+    tmp_path: Path,
+):
+    # Arrange
+    real = tmp_path / "real"
+    _write_spec(real, "alpha", "listen_url: http://x:1\n")
+    ghost = tmp_path / "does-not-exist"
+    # Act
+    peers = discover_self_peers([ghost, real])
+    # Assert
+    assert [p["name"] for p in peers] == ["alpha"]
+
+
+def test_discover_self_peers_skips_container_agent_dirs(tmp_path: Path):
+    # Arrange: a self-peer + a container agent in the same base dir.
+    base = tmp_path / "base"
+    _write_spec(base, "self-node", "listen_url: http://127.0.0.1:9000\n")
+    _write_spec(
+        base,
+        "container-node",
+        "apiVersion: scitex-agent-container/v3\nspec:\n  runtime: apptainer\n",
+    )
+    # Act
+    peers = discover_self_peers([base])
+    # Assert: only the self-peer is returned.
+    assert [p["name"] for p in peers] == ["self-node"]

--- a/tests/scitex_agent_container/_listen/test_server.py
+++ b/tests/scitex_agent_container/_listen/test_server.py
@@ -56,13 +56,25 @@ SHARED_TOKEN = "test-token-wi4"
 
 @pytest.fixture
 def isolated_env(tmp_path: Path):
-    """Point every on-disk root at ``tmp_path`` for the duration of one test."""
+    """Point every on-disk root at ``tmp_path`` for the duration of one test.
+
+    The self-peer discovery (op-2026-06-12-15) calls
+    :func:`config._resolve._project_local_dirs` which walks CWD
+    upward for ``.scitex/agent-container/agents/`` — the sac repo's
+    own checked-in ``agents/self/spec.yaml`` would otherwise leak
+    into every ``list_agents`` response. Stub that helper to ``[]``
+    for the test's lifetime so the only sources are the tmp_path-
+    rooted registry + ``$SCITEX_AGENT_CONTAINER_YAML_DIRS`` (popped).
+    """
+    from scitex_agent_container.config import _resolve as _config_resolve
+
     saved_home = os.environ.get("HOME")
     saved_reg_env = os.environ.get("SCITEX_AGENT_CONTAINER_REGISTRY_DIR")
     saved_run_env = os.environ.get("SCITEX_AGENT_CONTAINER_RUNTIME_DIR")
     saved_yaml_env = os.environ.get("SCITEX_AGENT_CONTAINER_YAML_DIRS")
     saved_reg_const = _reg.REGISTRY_DIR
     saved_state_const = _ss.DEFAULT_STATE_ROOT
+    saved_project_local = _config_resolve._project_local_dirs
 
     os.environ["HOME"] = str(tmp_path)
     os.environ["SCITEX_AGENT_CONTAINER_REGISTRY_DIR"] = str(tmp_path / "registry")
@@ -70,12 +82,14 @@ def isolated_env(tmp_path: Path):
     os.environ.pop("SCITEX_AGENT_CONTAINER_YAML_DIRS", None)
     _reg.REGISTRY_DIR = tmp_path / "registry"
     _ss.DEFAULT_STATE_ROOT = tmp_path / "runtime"
+    _config_resolve._project_local_dirs = lambda start=None: []
 
     try:
         yield tmp_path
     finally:
         _reg.REGISTRY_DIR = saved_reg_const
         _ss.DEFAULT_STATE_ROOT = saved_state_const
+        _config_resolve._project_local_dirs = saved_project_local
         for key, val in (
             ("HOME", saved_home),
             ("SCITEX_AGENT_CONTAINER_REGISTRY_DIR", saved_reg_env),


### PR DESCRIPTION
## Summary

Operator directive **op-2026-06-12-15** (TG 12631 → 12638) — make any session/node that owns a listen endpoint discoverable through `sac a2a peers` via ONE generic shape, ONE code path. **No node is special-cased.** The lead/operator listen is one instance of the pattern; `lead` never appears as a code-level discriminator.

## Problem

`GET /agents` (which backs the `a2a_peers` MCP tool) reports only rows from `Registry` — populated by the container-startup path. External listen sessions never traverse that path, so they're invisible to `sac a2a peers` and peer agents cannot `target=<them>`.

## Shape

`<search-dir>/<name>/spec.yaml` carrying **only** `listen_url` (no container `spec` block, no `apiVersion`) is interpreted as a self-registered peer. The literal `self` directory means "register the RUNNING session under its runtime identity"; the name comes from `host_config.lead.name` at scan time — NOT a hardcoded field.

## Files

- `src/scitex_agent_container/_listen/_self_peers.py` (NEW) — `is_self_peer_spec` / `load_self_peer(path, *, self_identity)` / `discover_self_peers(search_dirs, *, self_identity)`.
- `src/scitex_agent_container/_listen/server.py` — `list_agents` merges Registry + discovery; `_resolve_runtime_self_identity()` reads host_config.
- `.scitex/agent-container/agents/self/spec.yaml` (NEW) — canonical example; **no `name:` field** per TG 12637/12638.
- `tests/scitex_agent_container/_listen/test__self_peers.py` — **16 tests** (STX-TQ002 / TQ007 compliant, AAA + 1-assert), all green locally.

## Out of scope (deferred)

- Pull-side MCP registration (TG 12633) — listening node's sac MCP CLIENT surfaces itself. Sibling module under `_mcp/`; this PR ships push side only.

## Test plan

- [ ] CI green
- [ ] After merge: lead listen restart (e.g. `sac restart-lead`) — `sac a2a peers` should then show the running session under its runtime identity