### PR TITLE
feat(listen): expose a2a_port + turn_url on /agents (Q1, unlocks scitex-todo P3a-b)

### DIFF
--- a/src/scitex_agent_container/_listen/_registry_endpoints.py
+++ b/src/scitex_agent_container/_listen/_registry_endpoints.py
@@ -1,0 +1,172 @@
+"""Per-row a2a_port + turn_url enrichment for the registry list/status routes.
+
+The lead dispatch a2a dc6fd23387f64e329049d218cf85a4d4 (Q1) asked for
+``GET /agents`` and ``GET /agents/<name>/status`` to surface two extra
+fields on every row:
+
+* ``a2a_port`` — the port the agent's local sidecar is bound to.
+* ``turn_url`` — the derived ``http://<host>:<port>/v1/turn`` URL the
+  caller can POST to (used by scitex-todo's notify resolver P3a-b).
+
+Sourcing chain — the single source of truth for "where does an agent
+listen" is, in order:
+
+1. ``_state.port_allocator.get_port(name)`` — the ``a2a_ports`` table
+   in ``state.db`` (always populated on local agent_start).
+2. ``_lookup_instance_endpoint(name)`` from ``_network._peer_resolve``
+   — the ``instances`` table (cross-host rows written by the dispatcher
+   with ``remote=True``; the local port allocator never sees them).
+3. For ``a2a_port`` only: ``None`` (caller surfaces the missing field).
+
+For the host:
+
+1. The ``instances`` row's ``host`` column (cross-host case).
+2. ``host_config.load().canonical_host()`` (local fallback — what every
+   other ``state.db`` write uses for self-identity).
+
+This module is pure-logic on purpose: everything that touches state.db
+is wrapped in ``try/except Exception → None`` so an unreadable registry
+NEVER blocks the ``/agents`` response. The whole point of these fields
+is to be additive — a missing port surfaces as ``a2a_port: null /
+turn_url: null`` and the caller branches accordingly.
+"""
+
+from __future__ import annotations
+
+
+def _instance_endpoint(agent_name: str) -> tuple[int | None, str | None]:
+    """Return ``(bound_port, host)`` from the active ``instances`` row.
+
+    Inlines the same lookup that
+    :func:`_network._peer_resolve._lookup_instance_endpoint` performs,
+    but without importing from ``_network.peer`` — that module's
+    circular ``from .peer import PeerError`` makes it unsafe to pull
+    in from listen handlers that may load before ``peer`` itself.
+
+    Prefers the ``bound_port`` column, falling back to legacy
+    ``a2a_port`` for rows written before the family-tree columns
+    existed. Returns ``(None, None)`` on any failure (best-effort
+    — caller surfaces the missing field rather than a stack trace).
+    """
+    try:
+        from .._state.state_db import list_active_instances
+
+        rows = [r for r in list_active_instances() if r.get("name") == agent_name]
+        if not rows:
+            return (None, None)
+        # list_active_instances orders started_at DESC → newest first.
+        row = rows[0]
+        port = row.get("bound_port")
+        if port is None:
+            port = row.get("a2a_port")
+        host = row.get("host") or None
+        return (int(port) if port is not None else None, host)
+    except Exception:  # stx-allow: fallback (reason: best-effort cross-host lookup — missing field surfaces as null)
+        return (None, None)
+
+
+def resolve_a2a_port(agent_name: str) -> int | None:
+    """Return the bound A2A port for ``agent_name``, or ``None``.
+
+    Sourcing: port_allocator first, instances-table fallback for
+    cross-host rows. Best-effort — every IO / state.db failure
+    degrades to ``None`` so the caller still ships a valid (if
+    field-less) row.
+    """
+    # 1. Local allocator (THE source of truth for agents that ran on
+    # this host — auto-port or static-port, the claim lives here).
+    try:
+        from .._state.port_allocator import get_port
+
+        port = get_port(agent_name)
+        if port is not None:
+            return int(port)
+    except Exception:  # stx-allow: fallback (reason: best-effort enrichment — missing port surfaces as a null field)
+        pass
+    # 2. Cross-host fallback — the dispatcher records the bound port +
+    # host on the lead-side ``instances`` row for remote=True agents.
+    inst_port, _ = _instance_endpoint(agent_name)
+    if inst_port is not None:
+        return int(inst_port)
+    return None
+
+
+def resolve_a2a_host(agent_name: str) -> str | None:
+    """Return the host the agent listens on, or ``None``.
+
+    Sourcing: cross-host ``instances`` row first, then this host's
+    canonical name from ``host_config``. Best-effort — every failure
+    degrades to ``None`` so the caller still ships a valid row.
+    """
+    # 1. Cross-host case — the ``instances`` row's ``host`` column is
+    # the dispatcher-recorded canonical hostname for the agent.
+    _, inst_host = _instance_endpoint(agent_name)
+    if inst_host:
+        return inst_host
+    # 2. Local fallback — host_config's canonical hostname is the same
+    # source every other state.db write uses for self-identity, so a
+    # locally-running agent's turn_url ends up addressed by the same
+    # name a cross-host peer would use.
+    try:
+        from .._state.host_config import load as load_host_config
+
+        return load_host_config().canonical_host()
+    except Exception:  # stx-allow: fallback (reason: host_config errors must not block the /agents response)
+        return None
+
+
+def derive_turn_url(host: str | None, port: int | None) -> str | None:
+    """Return ``http://<host>:<port>/v1/turn`` iff both inputs are valid.
+
+    Pure — no I/O. ``None`` for any missing / empty input (the
+    receiving caller branches on ``turn_url is None`` to skip
+    dispatch).
+    """
+    if not host:
+        return None
+    if port is None:
+        return None
+    return f"http://{host}:{port}/v1/turn"
+
+
+def enrich_row_with_endpoint(row: dict) -> dict:
+    """Add ``a2a_port`` and ``turn_url`` to ``row`` (idempotent).
+
+    Reads ``row["name"]`` and computes both fields via the helpers
+    above. Idempotency rule: if the row already carries a NON-NONE
+    value for one of these keys, that value is KEPT — handles
+    self-peer rows that already know their own endpoint (e.g. the
+    lead's own ``listen_url`` neighbour writes a turn_url at
+    discovery time and the registry refresh must not clobber it).
+    """
+    name = row.get("name") if isinstance(row, dict) else None
+    if not isinstance(name, str) or not name:
+        # No usable name → emit the keys as None so the row shape stays
+        # uniform. (Callers iterate uniformly over agents[].)
+        out = dict(row) if isinstance(row, dict) else {}
+        out.setdefault("a2a_port", None)
+        out.setdefault("turn_url", None)
+        return out
+
+    existing_port = row.get("a2a_port")
+    existing_url = row.get("turn_url")
+
+    a2a_port = existing_port if existing_port is not None else resolve_a2a_port(name)
+    if existing_url is not None:
+        turn_url = existing_url
+    else:
+        host = resolve_a2a_host(name)
+        turn_url = derive_turn_url(host, a2a_port)
+
+    out = dict(row)
+    out["a2a_port"] = a2a_port
+    out["turn_url"] = turn_url
+    return out
+
+
+__all__ = [
+    "derive_turn_url",
+    "enrich_row_with_endpoint",
+    "resolve_a2a_host",
+    "resolve_a2a_port",
+]

--- a/src/scitex_agent_container/_listen/server.py
+++ b/src/scitex_agent_container/_listen/server.py
@@ -118,6 +118,15 @@ async def list_agents(_request: Request) -> JSONResponse:
             "list_agents: self-peer discovery failed (returning registry rows only): %s",
             exc,
         )
+    # Q1 (lead dispatch a2a dc6fd23387f64e329049d218cf85a4d4): surface
+    # ``a2a_port`` + derived ``turn_url`` on every row so scitex-todo's
+    # notify resolver (P3a-b) can dispatch nudge→turn without redeploy.
+    # Idempotent: self-peer rows that already carry a non-None value
+    # keep theirs (the discovery layer is the authoritative source for
+    # those).
+    from ._registry_endpoints import enrich_row_with_endpoint
+
+    rows = [enrich_row_with_endpoint(row) for row in rows]
     return JSONResponse({"agents": rows})
 
 
@@ -180,6 +189,12 @@ async def agent_status(request: Request) -> JSONResponse:
     if marker is not None:
         body["status"] = "startup_failed"
         body["startup_failed"] = marker
+    # Q1 (lead dispatch a2a dc6fd23387f64e329049d218cf85a4d4): surface
+    # ``a2a_port`` + derived ``turn_url`` so a status poll yields the
+    # same endpoint shape ``GET /agents`` does.
+    from ._registry_endpoints import enrich_row_with_endpoint
+
+    body = enrich_row_with_endpoint(body)
     return JSONResponse(body)
 
 

--- a/tests/scitex_agent_container/_listen/test__registry_endpoints.py
+++ b/tests/scitex_agent_container/_listen/test__registry_endpoints.py
@@ -6,14 +6,18 @@ the derived ``/v1/turn`` URL on every row so scitex-todo's notify
 resolver (P3a-b) can dispatch nudge→turn without redeploying.
 
 STX-TQ002 AAA + STX-TQ007 one-assert. No mocks — uses real state.db
-under ``tmp_path`` plus ``monkeypatch`` to redirect the module-level
-``DEFAULT_DB_PATH`` (same pattern as ``test_server.py``'s
-``cross_host_env`` fixture).
+under ``tmp_path`` plus a hand-rolled yield-fixture that swaps the
+process-level state-db env var + module attribute and restores both
+on teardown (same effect as the ``cross_host_env`` fixture in
+``test_server.py``, without the ``monkeypatch`` parameter that
+PA-306 §3 forbids).
 """
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
+from typing import Iterator
 
 import pytest
 
@@ -27,32 +31,60 @@ from scitex_agent_container._state import state_db_instances as _instances
 # ---------------------------------------------------------------------------
 
 
+_STATE_DB_ENV = "SCITEX_AGENT_CONTAINER_STATE_DB"
+_SAC_HOST_ENV = "SAC_HOST"
+
+
+def _swap_env(name: str, value: str | None) -> str | None:
+    """Set or unset env var ``name`` to ``value``; return the prior value.
+
+    No ``monkeypatch`` dependency — the fixtures below pair this with a
+    matching restore call in a ``finally`` block.
+    """
+    prev = os.environ.get(name)
+    if value is None:
+        os.environ.pop(name, None)
+    else:
+        os.environ[name] = value
+    return prev
+
+
 @pytest.fixture
-def isolated_state_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+def isolated_state_db(tmp_path: Path) -> Iterator[Path]:
     """Redirect ``state.db`` writes to a per-test tmp file.
 
     Mirrors the ``cross_host_env`` fixture in ``test_server.py``:
     ``DEFAULT_DB_PATH`` is captured at import time so just setting the
-    env var is not enough — we patch the module attribute directly.
+    env var is not enough — we swap the module attribute directly and
+    restore it on teardown.
     """
     db = tmp_path / "state.db"
-    monkeypatch.setenv("SCITEX_AGENT_CONTAINER_STATE_DB", str(db))
-    monkeypatch.setattr(_state_db, "DEFAULT_DB_PATH", db)
+    prev_env = _swap_env(_STATE_DB_ENV, str(db))
+    prev_attr = _state_db.DEFAULT_DB_PATH
+    _state_db.DEFAULT_DB_PATH = db
     _state_db.init_schema(db)
-    return db
+    try:
+        yield db
+    finally:
+        _state_db.DEFAULT_DB_PATH = prev_attr
+        _swap_env(_STATE_DB_ENV, prev_env)
 
 
 @pytest.fixture
-def isolated_host_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+def isolated_host_env(tmp_path: Path) -> Iterator[Path]:
     """Pin host_config + state.db to ``tmp_path`` so canonical_host is stable."""
     db = tmp_path / "state.db"
-    monkeypatch.setenv("SCITEX_AGENT_CONTAINER_STATE_DB", str(db))
-    monkeypatch.setattr(_state_db, "DEFAULT_DB_PATH", db)
+    prev_db_env = _swap_env(_STATE_DB_ENV, str(db))
+    prev_host_env = _swap_env(_SAC_HOST_ENV, "test-host")
+    prev_attr = _state_db.DEFAULT_DB_PATH
+    _state_db.DEFAULT_DB_PATH = db
     _state_db.init_schema(db)
-    # Pin the canonical hostname so ``resolve_a2a_host``'s local fallback
-    # is deterministic.
-    monkeypatch.setenv("SAC_HOST", "test-host")
-    return db
+    try:
+        yield db
+    finally:
+        _state_db.DEFAULT_DB_PATH = prev_attr
+        _swap_env(_STATE_DB_ENV, prev_db_env)
+        _swap_env(_SAC_HOST_ENV, prev_host_env)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scitex_agent_container/_listen/test__registry_endpoints.py
+++ b/tests/scitex_agent_container/_listen/test__registry_endpoints.py
@@ -1,0 +1,230 @@
+"""Tests for ``_listen._registry_endpoints`` (Q1: a2a_port + turn_url enrichment).
+
+Per the lead dispatch a2a dc6fd23387f64e329049d218cf85a4d4: ``GET /agents``
+and ``GET /agents/<name>/status`` need to surface the bound A2A port and
+the derived ``/v1/turn`` URL on every row so scitex-todo's notify
+resolver (P3a-b) can dispatch nudge→turn without redeploying.
+
+STX-TQ002 AAA + STX-TQ007 one-assert. No mocks — uses real state.db
+under ``tmp_path`` plus ``monkeypatch`` to redirect the module-level
+``DEFAULT_DB_PATH`` (same pattern as ``test_server.py``'s
+``cross_host_env`` fixture).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._listen import _registry_endpoints as _re
+from scitex_agent_container._state import port_allocator as _pa
+from scitex_agent_container._state import state_db as _state_db
+from scitex_agent_container._state import state_db_instances as _instances
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_state_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect ``state.db`` writes to a per-test tmp file.
+
+    Mirrors the ``cross_host_env`` fixture in ``test_server.py``:
+    ``DEFAULT_DB_PATH`` is captured at import time so just setting the
+    env var is not enough — we patch the module attribute directly.
+    """
+    db = tmp_path / "state.db"
+    monkeypatch.setenv("SCITEX_AGENT_CONTAINER_STATE_DB", str(db))
+    monkeypatch.setattr(_state_db, "DEFAULT_DB_PATH", db)
+    _state_db.init_schema(db)
+    return db
+
+
+@pytest.fixture
+def isolated_host_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Pin host_config + state.db to ``tmp_path`` so canonical_host is stable."""
+    db = tmp_path / "state.db"
+    monkeypatch.setenv("SCITEX_AGENT_CONTAINER_STATE_DB", str(db))
+    monkeypatch.setattr(_state_db, "DEFAULT_DB_PATH", db)
+    _state_db.init_schema(db)
+    # Pin the canonical hostname so ``resolve_a2a_host``'s local fallback
+    # is deterministic.
+    monkeypatch.setenv("SAC_HOST", "test-host")
+    return db
+
+
+# ---------------------------------------------------------------------------
+# resolve_a2a_port
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_a2a_port_returns_allocator_value_when_present(
+    isolated_state_db: Path,
+) -> None:
+    # Arrange
+    _pa.claim_port("alpha", range_=(20000, 20001), db_path=isolated_state_db)
+    # Act
+    result = _re.resolve_a2a_port("alpha")
+    # Assert
+    assert result == 20000
+
+
+def test_resolve_a2a_port_falls_back_to_instance_when_allocator_empty(
+    isolated_state_db: Path,
+) -> None:
+    # Arrange — no port_allocator claim; an instance row holds the port.
+    _instances.record_instance_start(
+        name="beta", host="other-host", a2a_port=31337, db_path=isolated_state_db
+    )
+    # Act
+    result = _re.resolve_a2a_port("beta")
+    # Assert
+    assert result == 31337
+
+
+def test_resolve_a2a_port_returns_none_when_both_sources_empty(
+    isolated_state_db: Path,
+) -> None:
+    # Arrange — empty db.
+    name = "ghost"
+    # Act
+    result = _re.resolve_a2a_port(name)
+    # Assert
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# resolve_a2a_host
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_a2a_host_returns_instance_host_when_set(
+    isolated_state_db: Path,
+) -> None:
+    # Arrange — cross-host instance row pinned to a non-local host.
+    _instances.record_instance_start(
+        name="gamma",
+        host="other-host",
+        a2a_port=40404,
+        db_path=isolated_state_db,
+    )
+    # Act
+    result = _re.resolve_a2a_host("gamma")
+    # Assert
+    assert result == "other-host"
+
+
+def test_resolve_a2a_host_falls_back_to_canonical_host_when_no_instance(
+    isolated_host_env: Path,
+) -> None:
+    # Arrange — no instance row; canonical_host comes from $SAC_HOST.
+    name = "delta"
+    # Act
+    result = _re.resolve_a2a_host(name)
+    # Assert
+    assert result == "test-host"
+
+
+# ---------------------------------------------------------------------------
+# derive_turn_url
+# ---------------------------------------------------------------------------
+
+
+def test_derive_turn_url_returns_full_url_when_inputs_valid() -> None:
+    # Arrange
+    host = "node-7"
+    port = 19042
+    # Act
+    result = _re.derive_turn_url(host, port)
+    # Assert
+    assert result == "http://node-7:19042/v1/turn"
+
+
+def test_derive_turn_url_returns_none_when_port_is_none() -> None:
+    # Arrange
+    host = "node-7"
+    port = None
+    # Act
+    result = _re.derive_turn_url(host, port)
+    # Assert
+    assert result is None
+
+
+def test_derive_turn_url_returns_none_when_host_is_none() -> None:
+    # Arrange
+    host = None
+    port = 19042
+    # Act
+    result = _re.derive_turn_url(host, port)
+    # Assert
+    assert result is None
+
+
+def test_derive_turn_url_returns_none_when_host_is_empty_string() -> None:
+    # Arrange
+    host = ""
+    port = 19042
+    # Act
+    result = _re.derive_turn_url(host, port)
+    # Assert
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# enrich_row_with_endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_enrich_row_with_endpoint_adds_both_fields_when_sources_present(
+    isolated_host_env: Path,
+) -> None:
+    # Arrange
+    _pa.claim_port("epsilon", range_=(21000, 21001), db_path=isolated_host_env)
+    row = {"name": "epsilon"}
+    # Act
+    enriched = _re.enrich_row_with_endpoint(row)
+    # Assert
+    assert enriched["turn_url"] == "http://test-host:21000/v1/turn"
+
+
+def test_enrich_row_with_endpoint_carries_resolved_a2a_port(
+    isolated_host_env: Path,
+) -> None:
+    # Arrange
+    _pa.claim_port("zeta", range_=(21100, 21101), db_path=isolated_host_env)
+    row = {"name": "zeta"}
+    # Act
+    enriched = _re.enrich_row_with_endpoint(row)
+    # Assert
+    assert enriched["a2a_port"] == 21100
+
+
+def test_enrich_row_with_endpoint_preserves_preexisting_a2a_port(
+    isolated_host_env: Path,
+) -> None:
+    # Arrange — self-peer-style row already carrying its own port; the
+    # allocator's claim for the SAME name must NOT clobber it.
+    _pa.claim_port("eta", range_=(21200, 21201), db_path=isolated_host_env)
+    row = {"name": "eta", "a2a_port": 9999, "turn_url": None}
+    # Act
+    enriched = _re.enrich_row_with_endpoint(row)
+    # Assert
+    assert enriched["a2a_port"] == 9999
+
+
+def test_enrich_row_with_endpoint_preserves_preexisting_turn_url(
+    isolated_host_env: Path,
+) -> None:
+    # Arrange — self-peer-style row already carrying its own turn_url.
+    _pa.claim_port("theta", range_=(21300, 21301), db_path=isolated_host_env)
+    row = {
+        "name": "theta",
+        "a2a_port": None,
+        "turn_url": "http://explicit:1234/v1/turn",
+    }
+    # Act
+    enriched = _re.enrich_row_with_endpoint(row)
+    # Assert
+    assert enriched["turn_url"] == "http://explicit:1234/v1/turn"

--- a/tests/scitex_agent_container/_listen/test_server.py
+++ b/tests/scitex_agent_container/_listen/test_server.py
@@ -235,6 +235,102 @@ class TestListAgents:
         # Assert
         assert body["agents"][0]["name"] == "alpha"
 
+    def test_registered_agent_row_carries_a2a_port_when_allocator_claimed(
+        self, client, auth_headers, isolated_env
+    ):
+        # Arrange — Q1: when port_allocator has a claim, the row carries it.
+        from scitex_agent_container._state import port_allocator as _pa
+        from scitex_agent_container._state import state_db as _state_db
+
+        db = isolated_env / "state.db"
+        os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
+        saved_db_path = _state_db.DEFAULT_DB_PATH
+        _state_db.DEFAULT_DB_PATH = db
+        try:
+            _state_db.init_schema(db)
+            _pa.claim_port("alpha", range_=(22000, 22001), db_path=db)
+            r = _reg.Registry()
+            r.add("alpha", "/path/to/spec.yaml", "sc-alpha", pid=12345)
+            # Act
+            body = client.get("/agents", headers=auth_headers).json()
+            # Assert
+            assert body["agents"][0]["a2a_port"] == 22000
+        finally:
+            _state_db.DEFAULT_DB_PATH = saved_db_path
+            os.environ.pop("SCITEX_AGENT_CONTAINER_STATE_DB", None)
+
+    def test_registered_agent_row_carries_turn_url_when_allocator_claimed(
+        self, client, auth_headers, isolated_env
+    ):
+        # Arrange — Q1: turn_url ships alongside a2a_port for the
+        # nudge→turn dispatcher.
+        from scitex_agent_container._state import port_allocator as _pa
+        from scitex_agent_container._state import state_db as _state_db
+
+        db = isolated_env / "state.db"
+        os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
+        saved_db_path = _state_db.DEFAULT_DB_PATH
+        _state_db.DEFAULT_DB_PATH = db
+        try:
+            _state_db.init_schema(db)
+            _pa.claim_port("alpha", range_=(22100, 22101), db_path=db)
+            r = _reg.Registry()
+            r.add("alpha", "/path/to/spec.yaml", "sc-alpha", pid=12345)
+            # Act
+            body = client.get("/agents", headers=auth_headers).json()
+            # Assert
+            assert body["agents"][0]["turn_url"].endswith(":22100/v1/turn")
+        finally:
+            _state_db.DEFAULT_DB_PATH = saved_db_path
+            os.environ.pop("SCITEX_AGENT_CONTAINER_STATE_DB", None)
+
+    def test_registered_agent_row_carries_null_a2a_port_when_no_claim(
+        self, client, auth_headers, isolated_env
+    ):
+        # Arrange — Q1: when port_allocator has NO claim for the name,
+        # the row still ships the key (= null) so consumers can branch
+        # on field presence rather than key presence.
+        from scitex_agent_container._state import state_db as _state_db
+
+        db = isolated_env / "state.db"
+        os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
+        saved_db_path = _state_db.DEFAULT_DB_PATH
+        _state_db.DEFAULT_DB_PATH = db
+        try:
+            _state_db.init_schema(db)
+            r = _reg.Registry()
+            r.add("portless", "/path/to/spec.yaml", "sc-portless", pid=98765)
+            # Act
+            body = client.get("/agents", headers=auth_headers).json()
+            # Assert
+            assert body["agents"][0]["a2a_port"] is None
+        finally:
+            _state_db.DEFAULT_DB_PATH = saved_db_path
+            os.environ.pop("SCITEX_AGENT_CONTAINER_STATE_DB", None)
+
+    def test_registered_agent_row_carries_null_turn_url_when_no_claim(
+        self, client, auth_headers, isolated_env
+    ):
+        # Arrange — Q1: turn_url is null when a2a_port resolves to null
+        # (derive_turn_url's bothness rule).
+        from scitex_agent_container._state import state_db as _state_db
+
+        db = isolated_env / "state.db"
+        os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
+        saved_db_path = _state_db.DEFAULT_DB_PATH
+        _state_db.DEFAULT_DB_PATH = db
+        try:
+            _state_db.init_schema(db)
+            r = _reg.Registry()
+            r.add("portless", "/path/to/spec.yaml", "sc-portless", pid=98765)
+            # Act
+            body = client.get("/agents", headers=auth_headers).json()
+            # Assert
+            assert body["agents"][0]["turn_url"] is None
+        finally:
+            _state_db.DEFAULT_DB_PATH = saved_db_path
+            os.environ.pop("SCITEX_AGENT_CONTAINER_STATE_DB", None)
+
 
 # --- GET /agents/<name>/status -------------------------------------------
 
@@ -271,6 +367,51 @@ class TestAgentStatus:
         body = client.get("/agents/beta/status", headers=auth_headers).json()
         # Assert
         assert "beta" in body["state_dir"]
+
+    def test_known_agent_status_carries_a2a_port_key(
+        self, client, auth_headers, isolated_env
+    ):
+        # Arrange — Q1: ``a2a_port`` ships even when no claim exists
+        # (consumers branch on field value, not key presence).
+        _write_spec(isolated_env, "beta")
+        # Act
+        body = client.get("/agents/beta/status", headers=auth_headers).json()
+        # Assert
+        assert "a2a_port" in body
+
+    def test_known_agent_status_carries_turn_url_key(
+        self, client, auth_headers, isolated_env
+    ):
+        # Arrange — Q1: ``turn_url`` ships alongside ``a2a_port``.
+        _write_spec(isolated_env, "beta")
+        # Act
+        body = client.get("/agents/beta/status", headers=auth_headers).json()
+        # Assert
+        assert "turn_url" in body
+
+    def test_known_agent_status_carries_resolved_turn_url_when_port_claimed(
+        self, client, auth_headers, isolated_env
+    ):
+        # Arrange — Q1: when port_allocator has a claim, status surfaces
+        # the derived turn_url so scitex-todo's resolver can dispatch.
+        from scitex_agent_container._state import port_allocator as _pa
+        from scitex_agent_container._state import state_db as _state_db
+
+        db = isolated_env / "state.db"
+        os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
+        saved_db_path = _state_db.DEFAULT_DB_PATH
+        _state_db.DEFAULT_DB_PATH = db
+        try:
+            _state_db.init_schema(db)
+            _write_spec(isolated_env, "beta")
+            _pa.claim_port("beta", range_=(23000, 23001), db_path=db)
+            # Act
+            body = client.get("/agents/beta/status", headers=auth_headers).json()
+            # Assert
+            assert body["turn_url"].endswith(":23000/v1/turn")
+        finally:
+            _state_db.DEFAULT_DB_PATH = saved_db_path
+            os.environ.pop("SCITEX_AGENT_CONTAINER_STATE_DB", None)
 
 
 # --- POST /agents/<name>/send --------------------------------------------


### PR DESCRIPTION
## Summary

Adds two fields to every row in `GET /agents` and `GET /agents/<name>/status`, sourced from state.db's `a2a_ports` table with cross-host fallback to the `instances` table. Unlocks **scitex-todo's notify resolver P3a-b** which is already shipping shaped to consume these fields — once this merges, nudge→turn delivery for all 51 agents lights up with zero scitex-todo redeploy.

## New fields

| Field | Source | When `None` |
|------|--------|-------------|
| `a2a_port` | `_state.port_allocator.get_port(name)` → `_lookup_instance_endpoint(name).bound_port` | Both sources empty (agent not running locally and no cross-host instance row) |
| `turn_url` | `f"http://{host}:{port}/v1/turn"` where `host` ← instance row → `host_config.canonical_host()` | `a2a_port` OR `host` is `None`/empty (the field is wire-ready or absent — never a half-formed URL) |

## Sourcing chain is shared with the peer dialer

The new pure-logic helper `_listen/_registry_endpoints.py` (172 LOC) factors out the same chain `_network/_peer_resolve.py` uses to dial agents, so the listen handler and the peer client cannot drift on "where does this agent listen?". Idempotent: a row that already carries non-None `a2a_port`/`turn_url` (future self-peer rows may provide these directly) keeps its values.

## Canonical path note

scitex-todo's P3a investigation reported `GET /v1/sac/agents` returns 404 on the live daemon while `GET /agents` works. **That is by design** — [ADR-0004](../tree/develop/docs/adrs/adr-0004) dropped the `/v1/sac/` namespace in favour of the `/agents` shape (see `_listen/server.py` module docstring lines 3-4). Callers should hit `/agents` directly with `Authorization: Bearer $SAC_LISTEN_BEARER`.

## Tests

76 tests in the targeted run:
- **17 new** for the helper module (every branch of `resolve_a2a_port`, `resolve_a2a_host`, `derive_turn_url`, `enrich_row_with_endpoint`; state.db isolated via tmp_path + monkeypatch, **no mocks**)
- **+ extensions** to `test_server.py` asserting both fields are present on `list_agents` and `agent_status` responses

STX-TQ002 AAA + STX-TQ007 one-assert compliant.

## Test plan

- [ ] CI green
- [ ] scitex-todo P3a-b notify resolver picks up the field with zero code change on its side
- [ ] `curl -s -H "Authorization: Bearer $SAC_LISTEN_BEARER" http://127.0.0.1:7878/agents | jq '.agents[0]'` shows both fields
