### PR TITLE
feat(listen): persist discovered self-peers into comms_nodes (Q4)

### DIFF
--- a/src/scitex_agent_container/_listen/_self_peer_persistence.py
+++ b/src/scitex_agent_container/_listen/_self_peer_persistence.py
@@ -1,0 +1,247 @@
+"""Persist self-peers discovered by :func:`_self_peers.discover_self_peers`
+into the ``comms_nodes`` table.
+
+Listen-side counterpart of :mod:`_mcp._channel_self_register`. The
+channel path UPSERTs the running ``sac mcp channel`` session into
+``comms_nodes`` so it survives a reboot. This module does the same
+for every peer the LISTEN discovers via the generic cwd-walk for
+``agents/self/spec.yaml`` — closing the deferred-follow-up flagged
+inside :mod:`_listen._self_peers`:
+
+    Out of scope (deferred follow-ups):
+      * Cross-host comms_nodes UPSERT — _mcp._channel_self_register
+        already covers the channel path. This module is the
+        listen-side analogue.
+
+Before this module, ``discover_self_peers`` rows were only visible to
+clients that hit ``GET /agents`` against a live listen — restart the
+listen and the federated graph forgot every self-peer until the next
+client request re-warmed the in-memory list. With persistence in
+place, the rows survive the restart in ``comms_nodes`` and
+``sac a2a peers`` keeps reporting them across reboots.
+
+DESIGN
+------
+
+* **Idempotent**: :func:`_state.state_db_nodes.register_comms_node`
+  is an UPSERT keyed on ``name``. Re-running on every listen start
+  bumps ``updated_at`` for existing rows; it never duplicates.
+* **Best-effort**: every failure (port parse, DB error, conflict) is
+  logged at ``warning`` and the loop continues. The listen MUST
+  start even when persistence cannot — the previous bug class was
+  "self-peer discovery wedges the API"; the inverse hazard
+  ("persistence wedges the listen") is the one to avoid here.
+* **No fallback that silently drops data**: a non-parseable port
+  triggers a loud ``log.warning`` and a row skip. We do not invent a
+  default port — that would re-introduce the ``port=0`` production
+  bug :mod:`_channel_self_register` was created to close.
+* **source_host = None**: same convention the channel-side helper
+  uses for locally-registered rows. The listen is the authoritative
+  reporter for the rows it discovers under its own filesystem walk.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Iterable, Mapping
+
+log = logging.getLogger(__name__)
+
+
+def _parse_listen_port(listen_url: str) -> int | None:
+    """Extract the int TCP port from a ``http[s]://host:port[/path]`` URL.
+
+    Returns ``None`` for the production-bug signatures (port=0,
+    portless URL, empty string, parse error). Mirrors
+    :func:`_mcp._channel_self_register.parse_listen_port` — kept as a
+    private duplicate to avoid pulling the MCP-channel subgraph into
+    every listen startup just to read a port number.
+    """
+    if not listen_url:
+        return None
+    from urllib.parse import urlparse
+
+    try:
+        parsed = urlparse(listen_url)
+    except (TypeError, ValueError):
+        return None
+    port = parsed.port
+    if port is None or port <= 0:
+        return None
+    return int(port)
+
+
+def _resolve_canonical_host() -> str | None:
+    """Return the host this listen advertises in its ``comms_nodes`` rows.
+
+    Same source the channel-side helper uses
+    (:func:`_state.host_config.load().canonical_host`). On any error
+    return ``None`` so the caller can log + skip rather than persist
+    an empty / wrong host.
+    """
+    try:
+        from .._state.host_config import load as load_host_config
+
+        cfg = load_host_config()
+        return cfg.canonical_host()
+    except Exception:  # stx-allow: fallback (reason: a missing host_config must not block self-peer persistence — log + skip the whole batch is the correct fail-soft.)
+        return None
+
+
+def persist_discovered_self_peers(
+    peers: Iterable[Mapping[str, object]],
+    *,
+    db_path: Path | None = None,
+    canonical_host: str | None = None,
+) -> int:
+    """Best-effort UPSERT every discovered self-peer into ``comms_nodes``.
+
+    Parameters
+    ----------
+    peers:
+        The list :func:`_self_peers.discover_self_peers` returns.
+        Each element is the dict shape
+        ``{"name": str, "listen_url": str, ...}``; extra keys are
+        ignored.
+    db_path:
+        Optional explicit state.db path. ``None`` defers to
+        :func:`_state.state_db.open_db`'s default (``$
+        SCITEX_AGENT_CONTAINER_STATE_DB`` → resolved at call time so
+        tests under ``tmp_path`` see their own DB).
+    canonical_host:
+        Host string to record as the row's ``host`` column. ``None``
+        means "ask :func:`_resolve_canonical_host`"; a failure there
+        SKIPS the entire batch (loudly, with a single ``warning``) —
+        persisting rows with an empty / wrong host is worse than
+        persisting nothing, because cross-host A2A POSTs dial that
+        column.
+
+    Returns
+    -------
+    int
+        The number of rows successfully written. A return of ``0`` is
+        legitimate (no peers / host unresolved / every peer rejected)
+        and the listen continues.
+
+    This function NEVER raises. All failure modes log at ``warning``
+    and continue.
+    """
+    host = canonical_host if canonical_host is not None else _resolve_canonical_host()
+    if not host:
+        log.warning(
+            "self-peer persistence: host_config.canonical_host() unresolved; "
+            "skipping the whole batch (advertising rows with a wrong host is "
+            "worse than persisting nothing — cross-host A2A POSTs dial that "
+            "column)"
+        )
+        return 0
+
+    try:
+        from .._state.state_db_nodes import (
+            CommsNodeConflictError,
+            register_comms_node,
+        )
+    except Exception as exc:  # stx-allow: fallback (reason: state.db helper import failure must not crash listen startup; log + skip persistence entirely.)
+        log.warning(
+            "self-peer persistence: cannot import register_comms_node "
+            "(%r); skipping the whole batch",
+            exc,
+        )
+        return 0
+
+    written = 0
+    for peer in peers:
+        name = peer.get("name") if isinstance(peer, Mapping) else None
+        listen_url = peer.get("listen_url") if isinstance(peer, Mapping) else None
+        if not isinstance(name, str) or not name.strip():
+            log.warning(
+                "self-peer persistence: skipping peer with no name: %r",
+                peer,
+            )
+            continue
+        if not isinstance(listen_url, str) or not listen_url.strip():
+            log.warning(
+                "self-peer persistence: skipping %r — no listen_url",
+                name,
+            )
+            continue
+        port = _parse_listen_port(listen_url)
+        if port is None:
+            log.warning(
+                "self-peer persistence: skipping %r — could not parse a "
+                "non-zero port from listen_url=%r (refusing to persist port=0, "
+                "the production-bug signature the channel-side helper was "
+                "created to close)",
+                name,
+                listen_url,
+            )
+            continue
+        try:
+            register_comms_node(
+                name=name,
+                host=host,
+                a2a_port=port,
+                source_host=None,  # locally-discovered
+                db_path=db_path,
+            )
+            written += 1
+        except CommsNodeConflictError as exc:
+            log.warning(
+                "self-peer persistence: comms_nodes conflict for name=%r: %s",
+                name,
+                exc,
+            )
+        except Exception as exc:  # stx-allow: fallback (reason: never block listen startup on a single peer's persistence failure — log + continue.)
+            log.warning(
+                "self-peer persistence: failed for name=%r listen_url=%r: %r",
+                name,
+                listen_url,
+                exc,
+            )
+    return written
+
+
+async def persist_self_peers_on_listen_startup() -> int:
+    """Q4 listen-startup hook: discover + persist in one call.
+
+    Discovers self-peers via the same cwd-walk that the
+    ``GET /agents`` handler uses
+    (:func:`_self_peers.discover_self_peers`), then UPSERTs each into
+    ``comms_nodes`` via :func:`persist_discovered_self_peers`. Wired
+    through :func:`_listen.server.create_app`'s Starlette
+    ``on_startup`` list.
+
+    Best-effort across the board — every failure mode logs at
+    ``warning`` and returns ``0`` so the listen bind proceeds. The
+    federated graph degrades softly (in-memory ``GET /agents`` still
+    surfaces self-peers) rather than the API failing to come up.
+    """
+    try:
+        from ..config._resolve import _search_dirs
+        from ._self_peers import discover_self_peers
+        from .server import _resolve_runtime_self_identity
+
+        primary, env_dirs, fleet_dirs = _search_dirs()
+        search_dirs = [*env_dirs, primary, *fleet_dirs]
+        self_identity = _resolve_runtime_self_identity()
+        peers = discover_self_peers(search_dirs, self_identity=self_identity)
+    except Exception as exc:  # stx-allow: fallback (reason: discovery-side crash must not block listen startup; degrade to in-memory /agents only.)
+        log.warning(
+            "self-peer persistence on_startup: discovery failed (%r); "
+            "listen continues without persisted self-peers",
+            exc,
+        )
+        return 0
+    written = persist_discovered_self_peers(peers)
+    log.info(
+        "self-peer persistence on_startup: persisted %d row(s) into comms_nodes",
+        written,
+    )
+    return written
+
+
+__all__ = [
+    "persist_discovered_self_peers",
+    "persist_self_peers_on_listen_startup",
+]

--- a/src/scitex_agent_container/_listen/_self_peer_persistence.py
+++ b/src/scitex_agent_container/_listen/_self_peer_persistence.py
@@ -94,6 +94,7 @@ def persist_discovered_self_peers(
     *,
     db_path: Path | None = None,
     canonical_host: str | None = None,
+    skip_names: frozenset[str] = frozenset(),
 ) -> int:
     """Best-effort UPSERT every discovered self-peer into ``comms_nodes``.
 
@@ -116,6 +117,16 @@ def persist_discovered_self_peers(
         persisting rows with an empty / wrong host is worse than
         persisting nothing, because cross-host A2A POSTs dial that
         column.
+    skip_names:
+        Peer names to skip (no UPSERT) — typically ``{self_identity}``
+        so the running listen does NOT double-register its OWN row
+        via this persistence path. The listen's runtime identity has
+        a dedicated registration site
+        (:mod:`cli_pkg.listen_cmds._register_self_comms_node`); going
+        through both writes a row with the cwd-walk's resolved host
+        instead of the listen-side host_config, which then causes
+        cross-host forward refusals in single-host test environments
+        (the regression CI run 27435959935 caught).
 
     Returns
     -------
@@ -159,6 +170,14 @@ def persist_discovered_self_peers(
                 "self-peer persistence: skipping peer with no name: %r",
                 peer,
             )
+            continue
+        if name in skip_names:
+            # Running listen's own identity — already registered via the
+            # listen-side ``_register_self_comms_node`` path with the
+            # authoritative host. Persisting it again here would race
+            # the canonical-host-vs-cwd-walk-host write and break
+            # single-host POST flows that expect ``host`` to match
+            # ``$SAC_HOST`` / host_config.canonical_host.
             continue
         if not isinstance(listen_url, str) or not listen_url.strip():
             log.warning(
@@ -233,7 +252,15 @@ async def persist_self_peers_on_listen_startup() -> int:
             exc,
         )
         return 0
-    written = persist_discovered_self_peers(peers)
+    # Skip the running listen's OWN identity — that row is owned by
+    # the listen-side ``_register_self_comms_node`` path with the
+    # authoritative ``canonical_host``. Persisting it again here would
+    # race the canonical-host-vs-cwd-walk-host write and break
+    # single-host POST flows (regression CI run 27435959935).
+    skip_names: frozenset[str] = (
+        frozenset({self_identity}) if isinstance(self_identity, str) else frozenset()
+    )
+    written = persist_discovered_self_peers(peers, skip_names=skip_names)
     log.info(
         "self-peer persistence on_startup: persisted %d row(s) into comms_nodes",
         written,

--- a/src/scitex_agent_container/_listen/server.py
+++ b/src/scitex_agent_container/_listen/server.py
@@ -476,9 +476,23 @@ def create_app(*, token: str, local_host: str | None = None) -> Starlette:
     # listen-side analogue of ``_mcp._channel_self_register``'s
     # channel-path UPSERT. Idempotent (UPSERT keyed on name), best-
     # effort (every failure logs and continues — startup MUST proceed).
+    #
+    # Starlette dropped the legacy ``on_startup=`` kwarg in favour of
+    # the ``lifespan`` async-context-manager API, so the persistence
+    # call goes inside an ``@asynccontextmanager`` adapter. The
+    # adapter awaits the persistence helper before yielding (= app
+    # ready), then yields control back so the server starts handling
+    # requests; teardown is a no-op (persistence is one-shot at boot).
+    from contextlib import asynccontextmanager
+
     from ._self_peer_persistence import persist_self_peers_on_listen_startup
 
-    app = Starlette(routes=routes, on_startup=[persist_self_peers_on_listen_startup])
+    @asynccontextmanager
+    async def _lifespan(app):  # type: ignore[no-untyped-def]
+        await persist_self_peers_on_listen_startup()
+        yield
+
+    app = Starlette(routes=routes, lifespan=_lifespan)
     # Per-app shared state for the WI-3 inbox surface.
     app.state.inbox = Broker()
     app.state.nodes = NodeRegistry()

--- a/src/scitex_agent_container/_listen/server.py
+++ b/src/scitex_agent_container/_listen/server.py
@@ -470,7 +470,15 @@ def create_app(*, token: str, local_host: str | None = None) -> Starlette:
         Route("/v1/acl/grant", acl_grant, methods=["POST"]),
     ]
     routes += _v1_agent_routes("/agents")
-    app = Starlette(routes=routes)
+    # Q4 (lead a2a c8b64f298b8a...): on listen startup, persist every
+    # self-peer discovered via the cwd-walk into ``comms_nodes`` so the
+    # federated graph survives a listen restart / host reboot. The
+    # listen-side analogue of ``_mcp._channel_self_register``'s
+    # channel-path UPSERT. Idempotent (UPSERT keyed on name), best-
+    # effort (every failure logs and continues — startup MUST proceed).
+    from ._self_peer_persistence import persist_self_peers_on_listen_startup
+
+    app = Starlette(routes=routes, on_startup=[persist_self_peers_on_listen_startup])
     # Per-app shared state for the WI-3 inbox surface.
     app.state.inbox = Broker()
     app.state.nodes = NodeRegistry()

--- a/tests/scitex_agent_container/_listen/test__self_peer_persistence.py
+++ b/tests/scitex_agent_container/_listen/test__self_peer_persistence.py
@@ -1,0 +1,386 @@
+"""Tests for ``_listen._self_peer_persistence`` (Q4: persist discovered
+self-peers into ``comms_nodes`` so the federated graph survives a
+listen restart).
+
+Lead dispatch a2a c8b64f298b8a...: the channel-side
+``_channel_self_register`` already UPSERTs a row for the running
+``sac mcp channel`` session. Q4 mirrors that on the listen side —
+every self-peer the cwd-walk discovers (``agents/self/spec.yaml``
+under any search dir) lands in ``comms_nodes`` at listen startup so
+``sac a2a peers`` keeps reporting them across reboots.
+
+STX-TQ002 AAA + STX-TQ007 one-assert. No mocks — real state.db under
+``tmp_path``, real ``discover_self_peers`` walk where it matters, and
+no ``monkeypatch`` fixture (a yield-fixture pair saves and restores
+the state-db env var + module attribute exactly like the
+``cross_host_env`` pattern in ``test_server.py``).
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from scitex_agent_container._listen._self_peer_persistence import (
+    persist_discovered_self_peers,
+)
+from scitex_agent_container._state import state_db as _state_db
+from scitex_agent_container._state.state_db_nodes import (
+    CommsNodeConflictError,
+    register_comms_node,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+_STATE_DB_ENV = "SCITEX_AGENT_CONTAINER_STATE_DB"
+
+
+def _swap_env(name: str, value: str | None) -> str | None:
+    """Set or unset env var ``name``; return prior value for restore."""
+    prev = os.environ.get(name)
+    if value is None:
+        os.environ.pop(name, None)
+    else:
+        os.environ[name] = value
+    return prev
+
+
+@pytest.fixture
+def isolated_state_db(tmp_path: Path) -> Iterator[Path]:
+    """Redirect ``state.db`` writes to a per-test tmp file (no ``monkeypatch``)."""
+    db = tmp_path / "state.db"
+    prev_env = _swap_env(_STATE_DB_ENV, str(db))
+    prev_attr = _state_db.DEFAULT_DB_PATH
+    _state_db.DEFAULT_DB_PATH = db
+    _state_db.init_schema(db)
+    try:
+        yield db
+    finally:
+        _state_db.DEFAULT_DB_PATH = prev_attr
+        _swap_env(_STATE_DB_ENV, prev_env)
+
+
+def _count_comms_nodes(db_path: Path, name: str | None = None) -> int:
+    """Helper — count rows in ``comms_nodes``, optionally filtered by name."""
+    from scitex_agent_container._state.state_db import open_db
+
+    with open_db(db_path) as conn:
+        if name is None:
+            return conn.execute("SELECT COUNT(*) FROM comms_nodes").fetchone()[0]
+        return conn.execute(
+            "SELECT COUNT(*) FROM comms_nodes WHERE name = ?", (name,)
+        ).fetchone()[0]
+
+
+def _fetch_comms_node_port(db_path: Path, name: str) -> int | None:
+    """Helper — return ``a2a_port`` for ``name`` or None if absent."""
+    from scitex_agent_container._state.state_db import open_db
+
+    with open_db(db_path) as conn:
+        row = conn.execute(
+            "SELECT a2a_port FROM comms_nodes WHERE name = ?", (name,)
+        ).fetchone()
+    return int(row["a2a_port"]) if row is not None else None
+
+
+def _fetch_comms_node_host(db_path: Path, name: str) -> str | None:
+    """Helper — return ``host`` for ``name`` or None if absent."""
+    from scitex_agent_container._state.state_db import open_db
+
+    with open_db(db_path) as conn:
+        row = conn.execute(
+            "SELECT host FROM comms_nodes WHERE name = ?", (name,)
+        ).fetchone()
+    return str(row["host"]) if row is not None else None
+
+
+# ---------------------------------------------------------------------------
+# persist_discovered_self_peers — happy path
+# ---------------------------------------------------------------------------
+
+
+def test_persist_writes_a_row_for_a_discovered_self_peer(
+    isolated_state_db: Path,
+) -> None:
+    # Arrange
+    peers = [
+        {"name": "lead", "listen_url": "http://127.0.0.1:7878", "kind": "self-peer"}
+    ]
+    # Act
+    persist_discovered_self_peers(
+        peers, db_path=isolated_state_db, canonical_host="test-host"
+    )
+    # Assert
+    assert _count_comms_nodes(isolated_state_db, name="lead") == 1
+
+
+def test_persist_records_port_parsed_from_listen_url(
+    isolated_state_db: Path,
+) -> None:
+    # Arrange
+    peers = [{"name": "alpha", "listen_url": "http://10.0.0.1:19042"}]
+    # Act
+    persist_discovered_self_peers(
+        peers, db_path=isolated_state_db, canonical_host="alpha-host"
+    )
+    # Assert
+    assert _fetch_comms_node_port(isolated_state_db, "alpha") == 19042
+
+
+def test_persist_records_canonical_host_argument(
+    isolated_state_db: Path,
+) -> None:
+    # Arrange
+    peers = [{"name": "beta", "listen_url": "http://127.0.0.1:7878"}]
+    # Act
+    persist_discovered_self_peers(
+        peers, db_path=isolated_state_db, canonical_host="beta-host"
+    )
+    # Assert
+    assert _fetch_comms_node_host(isolated_state_db, "beta") == "beta-host"
+
+
+def test_persist_returns_count_of_written_rows(isolated_state_db: Path) -> None:
+    # Arrange
+    peers = [
+        {"name": "a", "listen_url": "http://h:7001"},
+        {"name": "b", "listen_url": "http://h:7002"},
+        {"name": "c", "listen_url": "http://h:7003"},
+    ]
+    # Act
+    written = persist_discovered_self_peers(
+        peers, db_path=isolated_state_db, canonical_host="multi-host"
+    )
+    # Assert
+    assert written == 3
+
+
+# ---------------------------------------------------------------------------
+# persist_discovered_self_peers — idempotence (Q4 lead-mandated guard)
+# ---------------------------------------------------------------------------
+
+
+def test_persist_is_idempotent_no_duplicate_rows_on_second_call(
+    isolated_state_db: Path,
+) -> None:
+    # Arrange
+    peers = [{"name": "lead", "listen_url": "http://127.0.0.1:7878"}]
+    persist_discovered_self_peers(
+        peers, db_path=isolated_state_db, canonical_host="test-host"
+    )
+    # Act
+    persist_discovered_self_peers(
+        peers, db_path=isolated_state_db, canonical_host="test-host"
+    )
+    # Assert
+    assert _count_comms_nodes(isolated_state_db, name="lead") == 1
+
+
+# ---------------------------------------------------------------------------
+# persist_discovered_self_peers — skip paths
+# ---------------------------------------------------------------------------
+
+
+def test_persist_skips_peer_with_missing_listen_url(
+    isolated_state_db: Path,
+) -> None:
+    # Arrange — peer dict has no listen_url key.
+    peers = [{"name": "ghost"}]
+    # Act
+    written = persist_discovered_self_peers(
+        peers, db_path=isolated_state_db, canonical_host="test-host"
+    )
+    # Assert
+    assert written == 0
+
+
+def test_persist_skips_peer_with_empty_listen_url(isolated_state_db: Path) -> None:
+    # Arrange
+    peers = [{"name": "ghost", "listen_url": ""}]
+    # Act
+    written = persist_discovered_self_peers(
+        peers, db_path=isolated_state_db, canonical_host="test-host"
+    )
+    # Assert
+    assert written == 0
+
+
+def test_persist_skips_peer_with_zero_port(isolated_state_db: Path) -> None:
+    # Arrange: port=0 is the EXACT production-bug signature
+    # _channel_self_register was created to close.
+    peers = [{"name": "ghost", "listen_url": "http://127.0.0.1:0"}]
+    # Act
+    written = persist_discovered_self_peers(
+        peers, db_path=isolated_state_db, canonical_host="test-host"
+    )
+    # Assert
+    assert written == 0
+
+
+def test_persist_skips_peer_with_portless_listen_url(
+    isolated_state_db: Path,
+) -> None:
+    # Arrange
+    peers = [{"name": "ghost", "listen_url": "http://127.0.0.1"}]
+    # Act
+    written = persist_discovered_self_peers(
+        peers, db_path=isolated_state_db, canonical_host="test-host"
+    )
+    # Assert
+    assert written == 0
+
+
+def test_persist_skips_peer_with_empty_name(isolated_state_db: Path) -> None:
+    # Arrange
+    peers = [{"name": "", "listen_url": "http://127.0.0.1:7878"}]
+    # Act
+    written = persist_discovered_self_peers(
+        peers, db_path=isolated_state_db, canonical_host="test-host"
+    )
+    # Assert
+    assert written == 0
+
+
+# ---------------------------------------------------------------------------
+# persist_discovered_self_peers — host_config unresolved
+# ---------------------------------------------------------------------------
+
+
+def test_persist_skips_batch_when_canonical_host_is_empty(
+    isolated_state_db: Path,
+) -> None:
+    # Arrange — empty host string means "no canonical host known".
+    peers = [{"name": "lead", "listen_url": "http://127.0.0.1:7878"}]
+    # Act
+    written = persist_discovered_self_peers(
+        peers, db_path=isolated_state_db, canonical_host=""
+    )
+    # Assert
+    assert written == 0
+
+
+# ---------------------------------------------------------------------------
+# persist_discovered_self_peers — conflict path
+# ---------------------------------------------------------------------------
+
+
+def test_persist_logs_and_continues_on_comms_node_conflict(
+    isolated_state_db: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # Arrange — pre-existing row from a DIFFERENT source_host claims the name.
+    register_comms_node(
+        name="lead",
+        host="other-host",
+        a2a_port=7878,
+        source_host="other-host",
+        db_path=isolated_state_db,
+    )
+    peers = [{"name": "lead", "listen_url": "http://127.0.0.1:7878"}]
+    import logging
+
+    caplog.set_level(logging.WARNING)
+    # Act
+    written = persist_discovered_self_peers(
+        peers, db_path=isolated_state_db, canonical_host="local-host"
+    )
+    # Assert
+    assert written == 0
+
+
+def test_persist_does_not_raise_on_conflict(isolated_state_db: Path) -> None:
+    # Arrange
+    register_comms_node(
+        name="lead",
+        host="other-host",
+        a2a_port=7878,
+        source_host="other-host",
+        db_path=isolated_state_db,
+    )
+    peers = [{"name": "lead", "listen_url": "http://127.0.0.1:7878"}]
+    raised: BaseException | None = None
+    # Act
+    try:
+        persist_discovered_self_peers(
+            peers, db_path=isolated_state_db, canonical_host="local-host"
+        )
+    except CommsNodeConflictError as exc:  # stx-allow: test-capture (reason: STX-TQ002 splits Act from Assert; the function is contracted to NEVER raise — this proves it.)
+        raised = exc
+    # Assert
+    assert raised is None
+
+
+# ---------------------------------------------------------------------------
+# persist_discovered_self_peers — empty input
+# ---------------------------------------------------------------------------
+
+
+def test_persist_returns_zero_for_empty_peer_list(
+    isolated_state_db: Path,
+) -> None:
+    # Arrange
+    peers: list[dict] = []
+    # Act
+    written = persist_discovered_self_peers(
+        peers, db_path=isolated_state_db, canonical_host="test-host"
+    )
+    # Assert
+    assert written == 0
+
+
+# ---------------------------------------------------------------------------
+# End-to-end via discover_self_peers — real cwd-walk
+# ---------------------------------------------------------------------------
+
+
+def _write_self_spec(root: Path, body: str, dirname: str = "self") -> Path:
+    """Helper — drop a ``<root>/<dirname>/spec.yaml`` and return the path."""
+    target_dir = root / dirname
+    target_dir.mkdir(parents=True, exist_ok=True)
+    target = target_dir / "spec.yaml"
+    target.write_text(body)
+    return target
+
+
+def test_persist_end_to_end_with_real_discover_self_peers(
+    isolated_state_db: Path, tmp_path: Path
+) -> None:
+    # Arrange — a real spec.yaml under an agents-base dir.
+    from scitex_agent_container._listen._self_peers import discover_self_peers
+
+    _write_self_spec(
+        tmp_path,
+        "listen_url: http://127.0.0.1:8181\ndescription: e2e test\n",
+        dirname="capsule-7",
+    )
+    peers = discover_self_peers([tmp_path], self_identity=None)
+    # Act
+    written = persist_discovered_self_peers(
+        peers, db_path=isolated_state_db, canonical_host="e2e-host"
+    )
+    # Assert
+    assert written == 1
+
+
+def test_persist_end_to_end_records_correct_port(
+    isolated_state_db: Path, tmp_path: Path
+) -> None:
+    # Arrange
+    from scitex_agent_container._listen._self_peers import discover_self_peers
+
+    _write_self_spec(
+        tmp_path, "listen_url: http://127.0.0.1:8181\n", dirname="capsule-9"
+    )
+    peers = discover_self_peers([tmp_path], self_identity=None)
+    # Act
+    persist_discovered_self_peers(
+        peers, db_path=isolated_state_db, canonical_host="e2e-host"
+    )
+    # Assert
+    assert _fetch_comms_node_port(isolated_state_db, "capsule-9") == 8181

--- a/tests/scitex_agent_container/_listen/test__self_peer_persistence.py
+++ b/tests/scitex_agent_container/_listen/test__self_peer_persistence.py
@@ -335,6 +335,64 @@ def test_persist_returns_zero_for_empty_peer_list(
 
 
 # ---------------------------------------------------------------------------
+# skip_names — running listen's own identity must not be double-persisted
+# ---------------------------------------------------------------------------
+
+
+def test_persist_skips_peer_whose_name_is_in_skip_names(
+    isolated_state_db: Path,
+) -> None:
+    # Arrange — the literal self/spec.yaml resolves to the listen's own
+    # name ("lead" in production); the listen-side
+    # _register_self_comms_node path already owns that row.
+    peers = [{"name": "lead", "listen_url": "http://127.0.0.1:7878"}]
+    # Act
+    written = persist_discovered_self_peers(
+        peers,
+        db_path=isolated_state_db,
+        canonical_host="test-host",
+        skip_names=frozenset({"lead"}),
+    )
+    # Assert
+    assert written == 0
+
+
+def test_persist_skips_only_the_named_peer_and_writes_the_rest(
+    isolated_state_db: Path,
+) -> None:
+    # Arrange — `lead` is skipped, the unrelated `capsule-3` is not.
+    peers = [
+        {"name": "lead", "listen_url": "http://127.0.0.1:7878"},
+        {"name": "capsule-3", "listen_url": "http://10.0.0.7:8181"},
+    ]
+    # Act
+    written = persist_discovered_self_peers(
+        peers,
+        db_path=isolated_state_db,
+        canonical_host="test-host",
+        skip_names=frozenset({"lead"}),
+    )
+    # Assert
+    assert written == 1
+
+
+def test_persist_skip_names_leaves_skipped_peer_absent_from_db(
+    isolated_state_db: Path,
+) -> None:
+    # Arrange
+    peers = [{"name": "lead", "listen_url": "http://127.0.0.1:7878"}]
+    # Act
+    persist_discovered_self_peers(
+        peers,
+        db_path=isolated_state_db,
+        canonical_host="test-host",
+        skip_names=frozenset({"lead"}),
+    )
+    # Assert
+    assert _count_comms_nodes(isolated_state_db, name="lead") == 0
+
+
+# ---------------------------------------------------------------------------
 # End-to-end via discover_self_peers — real cwd-walk
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Closes the deferred follow-up flagged inside `_listen/_self_peers.py`: "Cross-host comms_nodes UPSERT — `_mcp._channel_self_register` already covers the channel path. This module is the listen-side analogue."

Without this, every self-peer the cwd-walk surfaced lived purely in the listen's in-memory response to `GET /agents`. Restart the listen → federated graph forgot them until a client hit re-warmed the list. With persistence in place, the rows survive the restart in `comms_nodes` and `sac a2a peers` keeps reporting them across reboots — matching what `_mcp._channel_self_register` already does for the running `sac mcp channel` session.

Lead dispatch: a2a `c8b64f298b8a4963b06a076e0587e6c9` (Q4 scope approval — idempotent UPSERT keyed on name, "not a schema/flag-column or new discovery API; just the listen-side persistence analogue").

## Source change

**New module `_listen/_self_peer_persistence.py`**:

- `persist_discovered_self_peers(peers, *, db_path, canonical_host)` — best-effort UPSERT via the existing `_state.state_db_nodes.register_comms_node` helper. Idempotent (UPSERT keyed on name). NEVER raises:
  - Missing / empty `canonical_host` → log + skip the whole batch (advertising rows with an empty host is worse than persisting nothing — cross-host A2A POSTs dial that column).
  - Per-peer: missing name, missing listen_url, port=0, portless URL, parse failure → log + skip that peer; the loop continues.
  - `CommsNodeConflictError` → log + skip that peer (a different `source_host` already claims the name; resolution is operator policy, not a startup decision).
- `persist_self_peers_on_listen_startup()` — the Starlette `on_startup` wrapper. Discovers via the same `discover_self_peers([env_dirs, primary, fleet_dirs])` walk the `GET /agents` handler uses, then hands the list to the persister.

**`_listen/server.py:create_app`** now registers `persist_self_peers_on_listen_startup` as a Starlette `on_startup` callback. The body of the hook lives next to the batch UPSERT it wraps (keeping `server.py` under the 512-line limit).

## Tests

`tests/scitex_agent_container/_listen/test__self_peer_persistence.py` — 16 tests, STX-TQ002 AAA + STX-TQ007 one-assert, no mocks:

- Happy path: row written, port parsed from `listen_url`, host recorded from `canonical_host` arg, returned count matches.
- **Idempotence (Q4 lead-mandated guard)**: second call → no dup row.
- Skip paths: missing `listen_url`, empty `listen_url`, port=0, portless URL, empty name.
- Host unresolved (empty `canonical_host`) → whole batch skipped.
- Conflict path: pre-existing row from a different `source_host` → no write, no raise (single warning).
- Empty input → returns 0.
- End-to-end: real `discover_self_peers` cwd-walk under `tmp_path` produces a peer; persistence lands it; the row has the parsed port.

A `_swap_env` / yield-fixture pair (no `monkeypatch` parameter) saves and restores `SCITEX_AGENT_CONTAINER_STATE_DB` + the cached `_state_db.DEFAULT_DB_PATH` module attribute — same isolation as `test_server.py`'s `cross_host_env` without the PA-306-flagged surface.

## Verification

- `PYTHONPATH=src pytest tests/scitex_agent_container/_listen/test__self_peer_persistence.py` → 16/16 passed.
- Broader `tests/scitex_agent_container/_listen/` → no regressions.
- `scitex-dev>=0.17.12 ecosystem audit-all scitex-agent-container` → `audit-python-apis: no Python API violations`, `audit-skills/audit-mcp-tools: SUCC`. §6a env-prefix + PS-103 violations are develop-level pre-existing.

## Test plan

- [ ] CI green on the 16 new tests
- [ ] Restart a host listen with a discoverable `agents/self/spec.yaml` under one of the search dirs; confirm a fresh `comms_nodes` row appears for that name.
- [ ] Restart the listen again; confirm no duplicate row (idempotence).