### PR TITLE
fix(audit): add SAC_ env_allowlist for §6a per-package opt-out

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -213,6 +213,36 @@ Documentation = "https://scitex-agent-container.readthedocs.io"
 # legitimately expose far more MCP tools than Python-API functions").
 mcp_parity_exempt = true
 
+# §6a — per-package env-var prefix allowlist.
+#
+# scitex-agent-container ships an operator-facing ``SAC_*`` env-var
+# surface that pre-dates the SciTeX-ecosystem ``SCITEX_<PKG>_*``
+# convention. Operator-authored shell exports, ~/.dotfiles, agent
+# spec ``env:`` blocks, and the dotfiles hook ecosystem all reference
+# these literal names; renaming them to ``SCITEX_AGENT_CONTAINER_*``
+# would break every running deployment without buying any operator-
+# visible upside (the brand prefix IS the established operator
+# surface, not a noise-silencer for new code that should have used
+# the canonical prefix).
+#
+# Examples of the surface this opts in:
+#   * ``SAC_LISTEN_BEARER`` / ``SAC_LISTEN_BASE_URL`` — bus auth +
+#     dial address the channel reads at startup.
+#   * ``SAC_HOST`` / ``SAC_NAME`` — runtime identity overrides.
+#   * ``SAC_ANTHROPIC_API_KEY`` / ``SAC_CHANNEL_AUTO_ACK`` —
+#     channel-mode operator toggles.
+#   * ``SAC_SSH_CONTROL_DIR`` / ``SAC_PROBE_LOG_ROOT`` /
+#     ``SAC_HOST_IDENTITY_PATH`` /
+#     ``SAC_LISTEN_POST_ACK_LIVENESS_TIMEOUT_S`` — operations knobs.
+#
+# Spec: scitex_dev/_cli/audit/_summary/_env_allowlist.py — the entry
+# applies "equal-to-stripped or prefix-match", so ``"SAC_"`` matches
+# every ``SAC_*`` env var without listing them individually. New
+# code that does not need brand-compat MUST still use the canonical
+# ``SCITEX_AGENT_CONTAINER_*`` prefix — this allowlist closes the
+# audit-cli ERROR on the legacy surface, not on future regressions.
+env_allowlist = ["SAC_"]
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/scitex_agent_container"]
 


### PR DESCRIPTION
## Summary

`scitex-dev>=0.17.12 ecosystem audit-all` reports 12 §6a errors on develop — every `SAC_*` env var the codebase references (`SAC_LISTEN_BEARER`, `SAC_NAME`, `SAC_HOST`, `SAC_ANTHROPIC_API_KEY`, …). The brand prefix IS the established operator surface (shell exports, `~/.dotfiles` hooks, agent spec `env:` blocks, operator muscle-memory) — renaming would break every running deployment without buying any operator-visible upside.

scitex-dev ships the exact opt-out path: `[tool.scitex_dev] env_allowlist = ["SAC_"]`, read by `_cli/audit/_summary/_env_allowlist.py` with "equal-to-stripped or prefix-match" semantics. The single `"SAC_"` entry covers every existing `SAC_*` var.

Lead a2a `cf5e03e410b743e2b4ce266e14acac12`: "§6a env-prefix (`SAC_*` should be `SCITEX_AGENT_CONTAINER_*` — note this likely needs an exceptions entry instead, `SAC_*` is your established surface)."

## Change

Single new key in `[tool.scitex_dev]`:

```toml
env_allowlist = ["SAC_"]
```

Inline comment documents the brand-compat rationale + the reminder that NEW code without brand-compat reason MUST still use the canonical `SCITEX_AGENT_CONTAINER_*` prefix.

## Verification limit

The scitex-dev ecosystem registry resolves `scitex-agent-container` to `/home/agent/proj/scitex-agent-container` (= `/work` on develop), NOT to the worktree's pyproject. So `scitex-dev ecosystem audit-all scitex-agent-container` locally won't reflect this change until the file lands on develop. CI's `scitex-dev-quality-audit` job picks up the package's checked-out pyproject directly, so CI confirms.

## Test plan

- [ ] CI green (`scitex-dev-quality-audit` job).
- [ ] After merge: re-run `scitex-dev ecosystem audit-all scitex-agent-container` from a fresh dev checkout; the 12 §6a errors should be gone. PS-103 develop-local junk (`--fakeroot`, `worktrees/`) remains as a separate cleanup card.