### PR TITLE
fix(state): fail loud on same-source comms_nodes overwrite (PR L1 — defense-in-depth)

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_instances.py
+++ b/src/scitex_agent_container/_lifecycle/_instances.py
@@ -115,8 +115,18 @@ def record_local_instance(config: AgentConfig, runtime: Any) -> str | None:
                 host=host,
                 a2a_port=int(a2a_port),
                 source_host=None,
+                # PR L1 (operator directive 12847) — discriminator
+                # for the loud-collision error message. ``spec``
+                # claims the spec-driven origin; ``source_path`` is
+                # the agent's spec-resolved file (best-effort —
+                # config.config_path may be None for synthesised
+                # configs from tests).
+                kind="spec",
+                source_path=getattr(config, "config_path", None)
+                or getattr(config, "spec_path", None)
+                or f"<spec:{config.name}>",
             )
-        except Exception:  # stx-allow: fallback (reason: never block agent start on registry write)
+        except Exception:  # stx-allow: fallback (reason: never block agent start on registry write; PR L1's CommsNodeConflictError surfaces here as a logged collision rather than a silent shadow.)
             pass
 
     state_dir = _state_dir_for(config, runtime)
@@ -160,7 +170,9 @@ def end_local_instance(config: AgentConfig, runtime: Any) -> bool:
             from .._state.state_db_nodes import unregister_comms_node
 
             unregister_comms_node(name=config.name)
-        except Exception:  # stx-allow: fallback (reason: never block agent stop on registry write)
+        except (
+            Exception
+        ):  # stx-allow: fallback (reason: never block agent stop on registry write)
             pass
 
     if state_dir is not None:

--- a/src/scitex_agent_container/_listen/_self_peer_persistence.py
+++ b/src/scitex_agent_container/_listen/_self_peer_persistence.py
@@ -197,12 +197,20 @@ def persist_discovered_self_peers(
             )
             continue
         try:
+            spec_path = peer.get("config") if isinstance(peer, Mapping) else None
             register_comms_node(
                 name=name,
                 host=host,
                 a2a_port=port,
                 source_host=None,  # locally-discovered
                 db_path=db_path,
+                # PR L1 (operator directive 12847) — discriminator for
+                # the loud-collision error message. Q4 always writes
+                # self-peer rows; the discovered spec file's path goes
+                # in ``source_path`` so a collision visibly names WHICH
+                # spec.yaml tried to register.
+                kind="self-peer",
+                source_path=str(spec_path) if spec_path else None,
             )
             written += 1
         except CommsNodeConflictError as exc:

--- a/src/scitex_agent_container/_mcp/_channel_self_register.py
+++ b/src/scitex_agent_container/_mcp/_channel_self_register.py
@@ -137,6 +137,14 @@ def register_self_node(
                 a2a_port=port,
                 source_host=None,  # locally-registered
                 db_path=db_path,
+                # PR L1 (operator directive 12847) — discriminator
+                # for the loud-collision error message. The channel
+                # is a self-peer registration source by definition.
+                # ``source_path`` carries the listen_url so a
+                # collision error visibly names the URL the channel
+                # tried to bind.
+                kind="self-peer",
+                source_path=listen_url,
             )
             return True
         except CommsNodeConflictError as exc:

--- a/src/scitex_agent_container/_state/state_db_comms_nodes.py
+++ b/src/scitex_agent_container/_state/state_db_comms_nodes.py
@@ -24,10 +24,11 @@ from __future__ import annotations
 
 import time
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 __all__ = [
     "CommsNodeConflictError",
+    "RegisterCommsNodeKind",
     "list_comms_nodes",
     "lookup_comms_node",
     "register_comms_node",
@@ -36,21 +37,52 @@ __all__ = [
 ]
 
 
-class CommsNodeConflictError(RuntimeError):
-    """Two hosts claim the same ``name`` with different ``(host, a2a_port)``.
+RegisterCommsNodeKind = Literal["spec", "self-peer", "manual"]
+"""Discriminator passed by callers of :func:`register_comms_node`.
 
-    Raised by :func:`register_comms_node` when the existing row was
-    sync'd from a different ``source_host`` than the caller and the
-    new (host, a2a_port) pair disagrees with what's already stored.
+``spec`` — the row is being written from the canonical container-spec
+path (``_lifecycle/_instances._record_local_instance`` after a spec-
+driven ``sac start``).
+
+``self-peer`` — the row is being written from a self-peer registration
+path (``_mcp/_channel_self_register.register_self_node`` or the Q4
+``_listen/_self_peer_persistence.persist_discovered_self_peers``).
+
+``manual`` — operator-driven ``sac registry register`` or a test
+fixture. Default when the caller doesn't pass one explicitly. The
+kind is NOT persisted into ``comms_nodes`` (no schema change) — it
+flows into :class:`CommsNodeConflictError`'s message so the operator
+sees WHICH path tried to overwrite WHICH.
+"""
+
+
+class CommsNodeConflictError(RuntimeError):
+    """Two registrations disagree on a ``name``'s ``(host, a2a_port)``.
+
+    Raised by :func:`register_comms_node` whenever a write would
+    silently OVERWRITE an existing row with a different
+    ``(host, a2a_port)``. Two collision shapes share this exception
+    (operator directive 12847 — fail-loud, no silent winner):
+
+    1. **Cross-host conflict.** Existing row was sync'd from
+       ``source_host=A``; the caller registers with
+       ``source_host=B`` and a different ``(host, a2a_port)``.
+       Two hosts independently claim the same name — neither has
+       authority over the other.
+    2. **Same-source different-target conflict (PR L1).** Existing
+       row and caller both have the SAME ``source_host`` (e.g. both
+       are local registrations with ``source_host=None``) but the
+       caller's ``(host, a2a_port)`` differs from what's stored.
+       Until PR L1 this silently last-writer-wins; that is the exact
+       silent-shadow the operator's directive locks out. The caller
+       must pass ``replace=True`` to opt into the overwrite (only
+       reached deliberately through the upcoming ``--prefer`` flag,
+       which is the explicit-client-option half of the directive).
 
     ADR-0014 conflict policy: fail-loud (α) over last-writer-wins (β).
-    Silent LWW would let a misconfigured peer stomp the authoritative
-    row on the next pull; making the operator resolve the collision
-    is the safe default.
-
-    The exception carries enough context (name, existing host/port +
-    source, new host/port + source) for the caller's log line to point
-    at the misconfig directly.
+    The exception carries enough context (kind, source_path, existing
+    host/port + source, new host/port + source) for the caller's log
+    line to point at the misconfig directly.
     """
 
 
@@ -61,10 +93,14 @@ def register_comms_node(
     a2a_port: int,
     source_host: str | None = None,
     db_path: Path | None = None,
+    kind: RegisterCommsNodeKind = "manual",
+    source_path: str | None = None,
+    replace: bool = False,
 ) -> None:
     """Idempotent upsert into ``comms_nodes``.
 
-    Behaviour:
+    Behaviour (PR L1, operator directive 12847 — fail-loud, no silent
+    last-writer-wins overwrite):
 
     * No existing row → INSERT a new one. ``registered_at`` and
       ``updated_at`` are set to ``time.time()``.
@@ -73,14 +109,43 @@ def register_comms_node(
       a tombstoned row, which is the natural way a "node came back"
       sync converges).
     * Existing row with DIFFERENT ``(host, a2a_port)`` AND a different
-      ``source_host`` → raise :class:`CommsNodeConflictError`. Same
-      ``source_host`` overwriting is allowed (the originating host is
-      the authoritative reporter for its own rows).
+      ``source_host`` → raise :class:`CommsNodeConflictError`. Two
+      hosts independently claim the same name; neither has authority
+      over the other (operator-rename is the only resolution).
+    * Existing row with DIFFERENT ``(host, a2a_port)`` but the SAME
+      ``source_host`` — until PR L1 this silently overwrote the row.
+      It now raises :class:`CommsNodeConflictError` UNLESS the caller
+      opts in with ``replace=True``. The opt-in is wired by the
+      upcoming ``--prefer spec|self`` operator flag (the explicit-
+      client-option half of the directive). Default callers — the
+      spec-driven paired-write, the channel self-register, the Q4
+      self-peer persistence — do NOT set ``replace=True``; they catch
+      the exception and log, so a real collision surfaces in the
+      operator's logs and no row is silently shadowed.
 
-    The ``source_host`` distinguishes "I'm hearing about this node
-    from peer X" (sync) from "this is a local registration" (NULL).
-    Two hosts independently claiming the same name is the collision
-    case fail-loud is designed to catch.
+    Parameters
+    ----------
+    kind:
+        Discriminator for the calling path (``spec`` / ``self-peer``
+        / ``manual``). Flows into the error message so the operator
+        sees WHICH path tried to overwrite WHICH; NOT persisted (no
+        schema change). Default ``"manual"`` keeps the existing
+        public surface backwards-compatible for callers that don't
+        pass it (operator-driven ``sac registry register``, tests).
+    source_path:
+        Optional caller-supplied source identifier (the spec file
+        path for ``kind="spec"``, the discovered
+        ``agents/<n>/spec.yaml`` path for ``kind="self-peer"``, a
+        CLI invocation tag for ``kind="manual"``). Surfaces in the
+        error message so the operator can disambiguate by path
+        (per operator's "distinguishable by path anyway" hint).
+    replace:
+        Opt-in to overwrite an existing same-source row with a
+        different ``(host, a2a_port)``. Wired by the ``--prefer``
+        flag once that PR lands; passing it from elsewhere is the
+        explicit-replace contract and bypasses the loud-fail check.
+        Has no effect on the cross-host (different ``source_host``)
+        conflict — that one ALWAYS raises.
     """
     if not name:
         raise ValueError("register_comms_node: name must be non-empty")
@@ -109,8 +174,7 @@ def register_comms_node(
             )
             return
         same_target = (
-            str(existing["host"]) == host
-            and int(existing["a2a_port"]) == a2a_port
+            str(existing["host"]) == host and int(existing["a2a_port"]) == a2a_port
         )
         existing_source = existing["source_host"]
         if same_target:
@@ -121,22 +185,45 @@ def register_comms_node(
                 (now, source_host, name),
             )
             return
-        # Different target — only allow when the SAME source is updating
-        # its own row (e.g. an operator re-bound the listen on a new port).
-        if existing_source == source_host:
-            conn.execute(
-                "UPDATE comms_nodes SET host = ?, a2a_port = ?, "
-                "updated_at = ?, ended_at = NULL WHERE name = ?",
-                (host, a2a_port, now, name),
+        # Different target.
+        if existing_source != source_host:
+            # Cross-host conflict — always raise; operator rename is the
+            # only resolvable path.
+            raise CommsNodeConflictError(
+                f"comms_nodes name conflict for {name!r}: "
+                f"existing=(host={existing['host']!r}, "
+                f"port={int(existing['a2a_port'])}, "
+                f"source={existing_source!r}) "
+                f"new=(kind={kind!r}, host={host!r}, port={a2a_port}, "
+                f"source={source_host!r}, source_path={source_path!r}). "
+                f"ADR-0014: names are globally unique. Rename or "
+                f"unregister one and re-run `sac registry sync --all`."
             )
-            return
-        raise CommsNodeConflictError(
-            f"comms_nodes name conflict for {name!r}: "
-            f"existing=(host={existing['host']!r}, port={int(existing['a2a_port'])}, "
-            f"source={existing_source!r}) "
-            f"new=(host={host!r}, port={a2a_port}, source={source_host!r}). "
-            f"ADR-0014: names are globally unique. Rename or unregister one "
-            f"and re-run `sac registry sync --all`."
+        # Same source, different target. PR L1 (operator directive
+        # 12847) — fail loud on collision, no silent last-writer-wins.
+        if not replace:
+            other_kind = "spec" if kind == "self-peer" else "self-peer pointer"
+            raise CommsNodeConflictError(
+                f"comms_nodes silent-overwrite refused for {name!r} "
+                f"(operator directive 12847, PR L1): "
+                f"existing=(host={existing['host']!r}, "
+                f"port={int(existing['a2a_port'])}, "
+                f"source={existing_source!r}) "
+                f"incoming=(kind={kind!r}, host={host!r}, "
+                f"port={a2a_port}, source={source_host!r}, "
+                f"source_path={source_path!r}). "
+                f"Two registrations for the same name disagree on the "
+                f"(host, a2a_port) target. Resolve by either:\n"
+                f"  - rerunning the canonical writer with "
+                f"`--prefer {kind}` to declare intent (overwrites), or\n"
+                f"  - removing/renaming the conflicting {other_kind} "
+                f"so a single source owns this name."
+            )
+        # Explicit replace — operator-confirmed via --prefer flag.
+        conn.execute(
+            "UPDATE comms_nodes SET host = ?, a2a_port = ?, "
+            "updated_at = ?, ended_at = NULL WHERE name = ?",
+            (host, a2a_port, now, name),
         )
 
 
@@ -208,9 +295,7 @@ def lookup_comms_node(
         "source_host": (
             str(row["source_host"]) if row["source_host"] is not None else None
         ),
-        "ended_at": (
-            float(row["ended_at"]) if row["ended_at"] is not None else None
-        ),
+        "ended_at": (float(row["ended_at"]) if row["ended_at"] is not None else None),
     }
 
 
@@ -264,9 +349,7 @@ def list_comms_nodes(
             "source_host": (
                 str(r["source_host"]) if r["source_host"] is not None else None
             ),
-            "ended_at": (
-                float(r["ended_at"]) if r["ended_at"] is not None else None
-            ),
+            "ended_at": (float(r["ended_at"]) if r["ended_at"] is not None else None),
         }
         for r in rows
     ]

--- a/tests/scitex_agent_container/_state/test_state_db_comms_nodes.py
+++ b/tests/scitex_agent_container/_state/test_state_db_comms_nodes.py
@@ -201,8 +201,9 @@ def test_register_comms_node_same_source_different_target_raises_without_replace
         source_host=None,
         db_path=db_path,
     )
-    # Act + Assert
-    with pytest.raises(CommsNodeConflictError):
+    raised: BaseException | None = None
+    # Act
+    try:
         register_comms_node(
             name="lead",
             host="mba",
@@ -210,6 +211,10 @@ def test_register_comms_node_same_source_different_target_raises_without_replace
             source_host=None,
             db_path=db_path,
         )
+    except CommsNodeConflictError as exc:  # stx-allow: test-capture (reason: STX-TQ002 splits Act from Assert; the function is contracted to raise on same-source different-target without replace=True.)
+        raised = exc
+    # Assert
+    assert isinstance(raised, CommsNodeConflictError)
 
 
 def test_register_comms_node_same_source_different_target_overwrites_with_replace(

--- a/tests/scitex_agent_container/_state/test_state_db_comms_nodes.py
+++ b/tests/scitex_agent_container/_state/test_state_db_comms_nodes.py
@@ -189,8 +189,33 @@ def test_register_comms_node_idempotent_same_target(db_path: Path) -> None:
     assert second["updated_at"] >= first["updated_at"]
 
 
-def test_register_comms_node_same_source_can_update_target(db_path: Path) -> None:
-    # Arrange
+def test_register_comms_node_same_source_different_target_raises_without_replace(
+    db_path: Path,
+) -> None:
+    # Arrange — PR L1 (operator directive 12847): same-source same-name
+    # with a DIFFERENT (host, a2a_port) must NOT silently overwrite.
+    register_comms_node(
+        name="lead",
+        host="mba",
+        a2a_port=8642,
+        source_host=None,
+        db_path=db_path,
+    )
+    # Act + Assert
+    with pytest.raises(CommsNodeConflictError):
+        register_comms_node(
+            name="lead",
+            host="mba",
+            a2a_port=9000,
+            source_host=None,
+            db_path=db_path,
+        )
+
+
+def test_register_comms_node_same_source_different_target_overwrites_with_replace(
+    db_path: Path,
+) -> None:
+    # Arrange — opt-in via replace=True (wired by upcoming --prefer flag).
     register_comms_node(
         name="lead",
         host="mba",
@@ -205,10 +230,175 @@ def test_register_comms_node_same_source_can_update_target(db_path: Path) -> Non
         a2a_port=9000,
         source_host=None,
         db_path=db_path,
+        replace=True,
     )
     info = lookup_comms_node(name="lead", db_path=db_path)
     # Assert
     assert info["a2a_port"] == 9000
+
+
+def test_register_comms_node_error_message_names_incoming_kind(
+    db_path: Path,
+) -> None:
+    # Arrange
+    register_comms_node(
+        name="lead",
+        host="mba",
+        a2a_port=8642,
+        source_host=None,
+        db_path=db_path,
+    )
+    raised: BaseException | None = None
+    # Act
+    try:
+        register_comms_node(
+            name="lead",
+            host="mba",
+            a2a_port=9000,
+            source_host=None,
+            db_path=db_path,
+            kind="self-peer",
+        )
+    except CommsNodeConflictError as exc:  # stx-allow: test-capture (reason: STX-TQ002 splits Act from Assert; the only thing the assert checks is that the message contains the kind.)
+        raised = exc
+    # Assert
+    assert raised is not None and "self-peer" in str(raised)
+
+
+def test_register_comms_node_error_message_names_incoming_source_path(
+    db_path: Path,
+) -> None:
+    # Arrange
+    register_comms_node(
+        name="lead",
+        host="mba",
+        a2a_port=8642,
+        source_host=None,
+        db_path=db_path,
+    )
+    incoming_path = "/home/agent/proj/foo/agents/lead/spec.yaml"
+    raised: BaseException | None = None
+    # Act
+    try:
+        register_comms_node(
+            name="lead",
+            host="mba",
+            a2a_port=9000,
+            source_host=None,
+            db_path=db_path,
+            kind="self-peer",
+            source_path=incoming_path,
+        )
+    except (
+        CommsNodeConflictError
+    ) as exc:  # stx-allow: test-capture (reason: STX-TQ002 splits Act from Assert.)
+        raised = exc
+    # Assert
+    assert raised is not None and incoming_path in str(raised)
+
+
+def test_register_comms_node_error_message_names_existing_target(
+    db_path: Path,
+) -> None:
+    # Arrange
+    register_comms_node(
+        name="lead",
+        host="mba",
+        a2a_port=8642,
+        source_host=None,
+        db_path=db_path,
+    )
+    raised: BaseException | None = None
+    # Act
+    try:
+        register_comms_node(
+            name="lead",
+            host="mba",
+            a2a_port=9000,
+            source_host=None,
+            db_path=db_path,
+        )
+    except (
+        CommsNodeConflictError
+    ) as exc:  # stx-allow: test-capture (reason: STX-TQ002 splits Act from Assert.)
+        raised = exc
+    # Assert
+    assert raised is not None and "8642" in str(raised)
+
+
+def test_register_comms_node_error_message_mentions_prefer_flag_hint(
+    db_path: Path,
+) -> None:
+    # Arrange
+    register_comms_node(
+        name="lead",
+        host="mba",
+        a2a_port=8642,
+        source_host=None,
+        db_path=db_path,
+    )
+    raised: BaseException | None = None
+    # Act
+    try:
+        register_comms_node(
+            name="lead",
+            host="mba",
+            a2a_port=9000,
+            source_host=None,
+            db_path=db_path,
+            kind="self-peer",
+        )
+    except (
+        CommsNodeConflictError
+    ) as exc:  # stx-allow: test-capture (reason: STX-TQ002 splits Act from Assert.)
+        raised = exc
+    # Assert
+    assert raised is not None and "--prefer" in str(raised)
+
+
+def test_register_comms_node_replace_false_does_not_change_row(
+    db_path: Path,
+) -> None:
+    # Arrange
+    register_comms_node(
+        name="lead",
+        host="mba",
+        a2a_port=8642,
+        source_host=None,
+        db_path=db_path,
+    )
+    raised: BaseException | None = None
+    # Act
+    try:
+        register_comms_node(
+            name="lead",
+            host="mba",
+            a2a_port=9000,
+            source_host=None,
+            db_path=db_path,
+        )
+    except CommsNodeConflictError as exc:  # stx-allow: test-capture (reason: STX-TQ002 splits Act from Assert; assert is the row stayed unchanged.)
+        raised = exc
+    info = lookup_comms_node(name="lead", db_path=db_path)
+    # Assert
+    assert raised is not None and info["a2a_port"] == 8642
+
+
+def test_register_comms_node_default_kind_keeps_backwards_compat(
+    db_path: Path,
+) -> None:
+    # Arrange — no kwargs beyond the pre-L1 surface; an INSERT must succeed.
+    # Act
+    register_comms_node(
+        name="alpha",
+        host="mba",
+        a2a_port=12345,
+        source_host=None,
+        db_path=db_path,
+    )
+    info = lookup_comms_node(name="alpha", db_path=db_path)
+    # Assert
+    assert info is not None
 
 
 def test_register_comms_node_conflict_different_source_raises(


### PR DESCRIPTION
## Summary

PR L1 of operator directive 12847 — comms_nodes UPSERT must FAIL LOUDLY on a same-source different-target collision, never silently last-writer-win. **Operator's later reframe (12857) — adding a `runtime: TUI | claude-agent-sdk` selector field to spec.yaml so the spec stays the single SSoT — likely eliminates the COMMON-case collision structurally; L1 stays as defense-in-depth so the storage layer can NEVER silently shadow regardless of any caller-layer regression.**

Lead a2a `bb3fe98a33b34811b8b0b8563714495b` approved PR L1 with locked defaults; lead a2a `513df13bd05e4940b2b7cc827cd539f0` reframed the higher-level design to the spec-field approach (this PR is unaffected — still the right storage-layer invariant).

## Change

`_state/state_db_comms_nodes.register_comms_node` gains three new keyword-only parameters:

- `kind: Literal["spec", "self-peer", "manual"] = "manual"` — discriminator for the loud error message; NOT persisted.
- `source_path: str | None = None` — caller-supplied source identifier (spec path / discovered path / CLI tag); flows into the error message so the operator disambiguates by path.
- `replace: bool = False` — explicit opt-in to overwrite an existing same-source row with a different `(host, a2a_port)`. Wired by the upcoming `--prefer` flag (PR L3, currently held).

Behaviour change (the locked-fail-loud directive):

- Same-source same-target → bump `updated_at` (unchanged).
- Same-source **different**-target → **RAISE** `CommsNodeConflictError` unless `replace=True`. Error message names both contenders and points the operator at `--prefer <kind>`.
- Different-source different-target → still raises (cross-host conflict; behaviour preserved).
- No schema change; no migration.

Three callers updated to pass `kind` + `source_path` for the error context (none opt into `replace=True`):

- `_lifecycle/_instances.py` — `kind="spec"`, `source_path=config.config_path`.
- `_mcp/_channel_self_register.py` — `kind="self-peer"`, `source_path=listen_url`.
- `_listen/_self_peer_persistence.py` (Q4) — `kind="self-peer"`, `source_path` per-peer.

All three sites already catch `CommsNodeConflictError` (or generic Exception) and log a warning — the new loud-fail surfaces as a structured log line rather than blocking startup.

## Tests

`tests/scitex_agent_container/_state/test_state_db_comms_nodes.py` — the pre-L1 silent-overwrite test inverts into two:

- `…_same_source_different_target_raises_without_replace`
- `…_same_source_different_target_overwrites_with_replace`

Plus six new tests on the error message (kind / source_path / existing target / `--prefer` hint), row-stability after the raise, and the `kind="manual"` default keeping backwards compatibility.

Verification:

- `PYTHONPATH=src pytest tests/scitex_agent_container/_state/test_state_db_comms_nodes.py` → 38/38 passed.
- Focused L1-affected suite (`_state_db_nodes` + `_state_db_export_comms_nodes_sync` + `_self_peer_persistence` + `_channel_self_register`) → 116/116 passed.
- Lifecycle broader run (the sac-start paired-write path) → green.

## Status of the broader plan

- **L1 (this PR)** — kept regardless of the runtime-field reframe; cheap safety. Lands now.
- **L2 (discovery soft-skip + WARN)** + **L3 (`--prefer` flag)** — held until I confirm the runtime-field reframe eliminates them. If the spec-as-single-SSoT route holds, both probably become unnecessary; this PR's defense-in-depth covers any caller-layer regression.

## Test plan

- [ ] CI green on the 38 / 116 / lifecycle test runs.
- [ ] No regression in `sac start` paired-write path (live agents continue to land their `comms_nodes` rows).
- [ ] After merge, monitor logs for any newly-surfaced same-source different-target collisions — they are visible now where they were silent before; expect them rare on develop's current state.