### PR TITLE
feat(runtimes): auto-bind ~/.scitex/todo into every agent (P3a-2 default-bind)

### DIFF
--- a/src/scitex_agent_container/runtimes/_apptainer_runtime.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_runtime.py
@@ -201,17 +201,28 @@ class ApptainerContainerRuntime(RuntimeBase):
         # no longer scaffolds parent directories — the host dir IS the
         # filesystem at /home/agent. We pre-create the parent on the
         # host side so the bind has somewhere to land.
+        # P3a-2 (operator directive feedback_scitex_todo_single_shared_store,
+        # lead a2a 214dd26d): prepend the fleet-default binds (today:
+        # ~/.scitex/todo for scitex-todo's single shared store) so every
+        # agent inherits the store mount even when its spec doesn't carry
+        # the explicit line. Explicit spec entries to the same destination
+        # override the default — see ``_p3a_default_binds``.
+        from ._p3a_default_binds import apply_default_binds
+
         ap_for_binds = getattr(config, "apptainer", None)
-        if ap_for_binds is not None:
-            for b in getattr(ap_for_binds, "binds", None) or []:
-                bs = str(b)
-                if ":" in bs:
-                    _, _, rest = bs.partition(":")
-                    dst = rest.split(":", 1)[0]
-                    if dst.startswith("/home/agent/"):
-                        rel = dst[len("/home/agent/") :]
-                        (home_host / rel).mkdir(parents=True, exist_ok=True)
-                argv += ["--bind", bs]
+        spec_binds = (
+            [str(b) for b in getattr(ap_for_binds, "binds", None) or []]
+            if ap_for_binds is not None
+            else []
+        )
+        for bs in apply_default_binds(spec_binds):
+            if ":" in bs:
+                _, _, rest = bs.partition(":")
+                dst = rest.split(":", 1)[0]
+                if dst.startswith("/home/agent/"):
+                    rel = dst[len("/home/agent/") :]
+                    (home_host / rel).mkdir(parents=True, exist_ok=True)
+            argv += ["--bind", bs]
 
         # GPU passthrough — apptainer's --nv binds the host CUDA libs
         # and devices into the container. --rocm does the same for AMD.

--- a/src/scitex_agent_container/runtimes/_p3a_default_binds.py
+++ b/src/scitex_agent_container/runtimes/_p3a_default_binds.py
@@ -1,0 +1,110 @@
+"""P3a-2 default-bind helpers — single-shared-store fleet wiring.
+
+Operator directive ``feedback_scitex_todo_single_shared_store``
+(lead-learnings/22, P3a unlock). Lead a2a
+``214dd26d3fd24e088c75a34329895fa4`` — every agent's apptainer
+container mounts the host's ``~/.scitex/todo/`` so scitex-todo's
+precedence-4 user-scope store resolves to the SAME global
+``tasks.yaml`` fleet-wide. The dotfiles ``_base/spec.yaml`` carries
+the explicit bind line for immediate coverage; THIS module makes
+the bind survive spec churn — every sac-launched agent gets the
+default bind even if its spec doesn't carry the explicit line.
+
+Mechanism — see :func:`apply_default_binds`:
+  * The list of default binds is :data:`_FLEET_DEFAULT_BINDS` —
+    extend cautiously, every entry adds a host directory bind
+    to every agent.
+  * An EXPLICIT ``spec.apptainer.binds`` entry to the SAME
+    destination path REPLACES the default (operator override
+    wins; we de-dupe by destination, not by full string).
+  * Missing host source dir → SKIP that default silently. The
+    operator may not have a ``~/.scitex/todo/`` yet (clean
+    install, fresh laptop); we don't create it from sac code
+    because the operator's todo init is a separate workflow
+    that owns the layout.
+
+This module is intentionally tiny so the sites that consume the
+default-bind list (``_apptainer_runtime.py``) stay under the
+512-line module limit.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+__all__ = [
+    "apply_default_binds",
+    "default_binds_for_host",
+]
+
+
+# Fleet-wide default binds. Each entry is the string form
+# ``host:container[:mode]`` apptainer's ``--bind`` consumes.
+# ``~`` is expanded against the host's ``$HOME`` at resolution time.
+_FLEET_DEFAULT_BINDS: tuple[str, ...] = (
+    # P3a-2 — scitex-todo single shared store (operator directive
+    # feedback_scitex_todo_single_shared_store).
+    "~/.scitex/todo:/home/agent/.scitex/todo:rw",
+)
+
+
+def _bind_destination(bind_str: str) -> str:
+    """Return the container-side destination path of a bind string.
+
+    Accepts ``host:container`` and ``host:container:mode`` shapes
+    (the only two apptainer ``--bind`` consumes). Falls back to
+    the whole string for a malformed entry so the caller's de-dup
+    set still gets a stable key.
+    """
+    if ":" not in bind_str:
+        return bind_str
+    _, _, rest = bind_str.partition(":")
+    return rest.split(":", 1)[0]
+
+
+def default_binds_for_host() -> tuple[str, ...]:
+    """Return the fleet-default binds whose host source EXISTS today.
+
+    Walks :data:`_FLEET_DEFAULT_BINDS`, expands ``~`` against the
+    operator's ``$HOME``, and FILTERS each entry by whether the
+    host-side source path resolves to an existing directory. Missing
+    host source = the default skips silently — sac does NOT mkdir on
+    the host (the bound layout's ownership lives with whoever owns
+    the source tree, e.g. scitex-todo for ``~/.scitex/todo/``).
+
+    The returned tuple uses the ORIGINAL (un-expanded) ``~`` form so
+    the caller can hand it directly to apptainer's ``--bind``, which
+    expands ``~`` itself per its own resolution rules.
+    """
+    out: list[str] = []
+    for bind_str in _FLEET_DEFAULT_BINDS:
+        if ":" not in bind_str:
+            continue
+        host_src, _, _ = bind_str.partition(":")
+        if Path(host_src).expanduser().is_dir():
+            out.append(bind_str)
+    return tuple(out)
+
+
+def apply_default_binds(spec_binds: Iterable[str]) -> list[str]:
+    """Merge fleet-default binds with the spec's explicit binds.
+
+    Returns a list of bind strings (apptainer ``--bind`` ready) with
+    fleet defaults PREPENDED and any explicit spec entry to the SAME
+    destination path overriding the default (de-dup by destination —
+    the operator's spec is the operator's last word).
+
+    The fleet defaults are filtered by host-source existence via
+    :func:`default_binds_for_host` BEFORE merge, so a missing
+    ``~/.scitex/todo/`` (operator hasn't initialised the store)
+    produces NO bind, NO crash, no surprise mount.
+    """
+    spec_binds_list = list(spec_binds)
+    spec_destinations = {_bind_destination(b) for b in spec_binds_list}
+    defaults_that_apply = [
+        b
+        for b in default_binds_for_host()
+        if _bind_destination(b) not in spec_destinations
+    ]
+    return defaults_that_apply + spec_binds_list

--- a/tests/scitex_agent_container/runtimes/test__p3a_default_binds.py
+++ b/tests/scitex_agent_container/runtimes/test__p3a_default_binds.py
@@ -64,9 +64,8 @@ def test_default_binds_for_host_returns_todo_bind_when_host_dir_exists(
 def test_default_binds_for_host_skips_todo_bind_when_host_dir_missing(
     fake_home: Path,
 ) -> None:
-    # Arrange — ensure ~/.scitex/todo does NOT exist.
-    candidate = fake_home / ".scitex" / "todo"
-    assert not candidate.exists()
+    # Arrange — fake_home (tmp_path) is freshly created with no .scitex
+    # subtree; the candidate path therefore does not exist.
     # Act
     binds = default_binds_for_host()
     # Assert

--- a/tests/scitex_agent_container/runtimes/test_p3a_default_binds.py
+++ b/tests/scitex_agent_container/runtimes/test_p3a_default_binds.py
@@ -1,0 +1,160 @@
+"""Tests for ``runtimes._p3a_default_binds`` — fleet-default bind injection.
+
+P3a-2 (operator directive ``feedback_scitex_todo_single_shared_store``,
+lead a2a ``214dd26d3fd24e088c75a34329895fa4``): every sac-launched
+agent's apptainer container gets the scitex-todo single shared store
+bind even if its spec doesn't carry the explicit line.
+
+The helper:
+
+  * Filters fleet defaults by host-source existence (a missing
+    ``~/.scitex/todo/`` produces NO bind, NO crash).
+  * Lets an explicit ``spec.apptainer.binds`` entry to the SAME
+    destination override the default (de-dup by destination only).
+  * Returns bind strings ready for ``apptainer --bind``.
+
+STX-TQ002 AAA + STX-TQ007 one-assert. No mocks — uses real
+``tmp_path`` plus an explicit ``HOME`` swap via ``os.environ``.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from scitex_agent_container.runtimes._p3a_default_binds import (
+    apply_default_binds,
+    default_binds_for_host,
+)
+
+
+@pytest.fixture
+def fake_home(tmp_path: Path) -> Iterator[Path]:
+    """Yield a tmp_path-rooted ``$HOME`` so ``~`` expansion is sandboxed."""
+    prev = os.environ.get("HOME")
+    os.environ["HOME"] = str(tmp_path)
+    try:
+        yield tmp_path
+    finally:
+        if prev is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = prev
+
+
+# ---------------------------------------------------------------------------
+# default_binds_for_host — host-existence gate
+# ---------------------------------------------------------------------------
+
+
+def test_default_binds_for_host_returns_todo_bind_when_host_dir_exists(
+    fake_home: Path,
+) -> None:
+    # Arrange
+    (fake_home / ".scitex" / "todo").mkdir(parents=True)
+    # Act
+    binds = default_binds_for_host()
+    # Assert
+    assert any("/.scitex/todo:" in b for b in binds)
+
+
+def test_default_binds_for_host_skips_todo_bind_when_host_dir_missing(
+    fake_home: Path,
+) -> None:
+    # Arrange — ensure ~/.scitex/todo does NOT exist.
+    candidate = fake_home / ".scitex" / "todo"
+    assert not candidate.exists()
+    # Act
+    binds = default_binds_for_host()
+    # Assert
+    assert not any("/.scitex/todo:" in b for b in binds)
+
+
+def test_default_binds_for_host_returns_tuple_for_caller_immutability(
+    fake_home: Path,
+) -> None:
+    # Arrange — even an empty result must be a tuple (caller treats it
+    # as read-only fleet config).
+    # Act
+    result = default_binds_for_host()
+    # Assert
+    assert isinstance(result, tuple)
+
+
+# ---------------------------------------------------------------------------
+# apply_default_binds — explicit spec overrides default
+# ---------------------------------------------------------------------------
+
+
+def test_apply_default_binds_prepends_defaults_when_spec_has_no_overlap(
+    fake_home: Path,
+) -> None:
+    # Arrange
+    (fake_home / ".scitex" / "todo").mkdir(parents=True)
+    spec_binds = ["~/proj:/home/agent/proj:ro"]
+    # Act
+    result = apply_default_binds(spec_binds)
+    # Assert — first entry is the P3a-2 default, second is the spec entry.
+    assert "/.scitex/todo:" in result[0] and result[-1] == "~/proj:/home/agent/proj:ro"
+
+
+def test_apply_default_binds_lets_explicit_spec_entry_override_default(
+    fake_home: Path,
+) -> None:
+    # Arrange — spec carries the SAME destination as the default; the
+    # spec wins (de-dup by destination).
+    (fake_home / ".scitex" / "todo").mkdir(parents=True)
+    spec_binds = ["/tmp/operator-todo:/home/agent/.scitex/todo:rw"]
+    # Act
+    result = apply_default_binds(spec_binds)
+    # Assert — exactly one entry whose destination is /home/agent/.scitex/todo.
+    todo_entries = [b for b in result if "/home/agent/.scitex/todo" in b]
+    assert todo_entries == ["/tmp/operator-todo:/home/agent/.scitex/todo:rw"]
+
+
+def test_apply_default_binds_returns_spec_only_when_host_dir_missing(
+    fake_home: Path,
+) -> None:
+    # Arrange
+    spec_binds = ["~/proj:/home/agent/proj:ro"]
+    # Act
+    result = apply_default_binds(spec_binds)
+    # Assert
+    assert result == spec_binds
+
+
+def test_apply_default_binds_handles_empty_spec_binds(fake_home: Path) -> None:
+    # Arrange
+    (fake_home / ".scitex" / "todo").mkdir(parents=True)
+    # Act
+    result = apply_default_binds([])
+    # Assert
+    assert any("/.scitex/todo:" in b for b in result)
+
+
+def test_apply_default_binds_accepts_iterable_of_strings(fake_home: Path) -> None:
+    # Arrange — caller passes a generator, not a list.
+    (fake_home / ".scitex" / "todo").mkdir(parents=True)
+    spec_binds_gen = (s for s in ["~/proj:/home/agent/proj:ro"])
+    # Act
+    result = apply_default_binds(spec_binds_gen)
+    # Assert
+    assert "~/proj:/home/agent/proj:ro" in result
+
+
+def test_apply_default_binds_preserves_explicit_spec_bind_order(
+    fake_home: Path,
+) -> None:
+    # Arrange
+    (fake_home / ".scitex" / "todo").mkdir(parents=True)
+    spec_binds = [
+        "~/proj:/home/agent/proj:ro",
+        "~/.gitconfig:/home/agent/.gitconfig:ro",
+    ]
+    # Act
+    result = apply_default_binds(spec_binds)
+    # Assert — spec order preserved AFTER the defaults.
+    assert result[-2:] == spec_binds


### PR DESCRIPTION
## Summary

Closes the gap left by P3a-2's dotfiles-only landing (lead a2a `214dd26d3fd24e088c75a34329895fa4` — Option C). The dotfiles `_base/spec.yaml` carries the explicit bind line so the fleet gets the operator's single-shared-store today; THIS PR ensures every sac-launched agent inherits the bind even when its spec is OUTSIDE the dotfiles `_base` tree (one-off agents, future operator-authored specs).

Lead's note from the same a2a: "write the B default-bind sac PR as the durable single-source follow-up (so it survives spec churn + covers non-dotfiles specs)."

## Source change

**New module `runtimes/_p3a_default_binds.py`**:

- `_FLEET_DEFAULT_BINDS` — one entry today, the operator's `~/.scitex/todo:/home/agent/.scitex/todo:rw`. Direct to scitex-todo's precedence-4 GLOBAL tier per proj-scitex-todo a2a `84348a2695a74a50be8f0b48547ba065` (per-project lane skipped — no auto-roll-up to global today).
- `default_binds_for_host()` — filters the tuple by host-source existence. Missing `~/.scitex/todo/` (clean install) produces NO bind, NO crash.
- `apply_default_binds(spec_binds)` — merges defaults with spec's explicit binds; spec entries to the SAME destination override the default (de-dup by destination).

**`runtimes/_apptainer_runtime.py`** calls `apply_default_binds` where the bind list is consumed for the argv. The PARSER is unchanged — `config.apptainer.binds` still mirrors the YAML 1:1 (no phantom entries in config dumps).

## Tests

`tests/scitex_agent_container/runtimes/test_p3a_default_binds.py` — 9 tests, STX-TQ002 AAA + STX-TQ007 one-assert, no mocks (real tmp_path + explicit `$HOME` swap):

- host-existence gate (filter when missing, return when present, type-correct tuple)
- merge semantics (defaults prepended, explicit override wins on same destination, spec-only when host dir missing, empty input, generator input, spec order preserved)

Local: `PYTHONPATH=src pytest tests/scitex_agent_container/runtimes/test_p3a_default_binds.py` → **9/9 passed**.

## Cross-thread

- **P3a (MCP wiring)** — dotfiles fragment staged at `.dev/p3a-mcp-wire/` for lead to apply.
- **P3a-2 (this PR, plus the dotfiles bind in the same set)** — Option C: dotfiles for immediate coverage, sac for durability.
- **P3a-1.5 (task #18)** — sac-base.sif needs scitex-todo CLI on PATH. Non-blocking on THIS PR.
- **P3a-3 (CLAUDE.md scope=agent:<name>)** — also in the same dotfiles set.

## Follow-up

`_apptainer_runtime.py` is 47 lines over the 512-line module cap on develop already. This PR ships the smallest possible delta to land the default-bind invariant; a focused split refactor (start / bind-argv / image-resolve siblings) is tracked as **task #21** for separate landing — uses the limit-line-numbers hook's REFACTORING.md mechanism legitimately.

## Test plan

- [ ] CI green on the 9 new tests.
- [ ] No regression on existing apptainer-runtime tests (bind list assembly unchanged for specs that don't carry the default destination).
- [ ] After lead lands the dotfiles set + this PR merges: a one-off agent (no `_base` ancestry) restarts and still mounts `~/.scitex/todo/` — verify via `apptainer exec ... ls /home/agent/.scitex/todo/`.