### PR TITLE
feat(sif): install scitex-todo[mcp] into apptainer-base (P3a-1.5)

### DIFF
--- a/src/scitex_agent_container/containers/apptainer-base.def
+++ b/src/scitex_agent_container/containers/apptainer-base.def
@@ -274,8 +274,17 @@ From: ubuntu:24.04
     # it explicitly rather than rely on the build shell.
     python3 -m venv /opt/venv-sac
     export PATH=/root/.local/bin:/usr/local/bin:$PATH
+    # P3a-1.5 (operator directive feedback_scitex_todo_single_shared_store,
+    # lead a2a 5c0c1fe32a9a43888e01151d6fc0fb9e): scitex-todo[mcp] is part
+    # of EVERY agent's runtime so the in-container `scitex-todo mcp start`
+    # path (the P3a MCP wiring) succeeds even on the minimal base layer.
+    # The [mcp] extra pulls in fastmcp>=2.0 — the FastMCP server backing
+    # `scitex_todo._mcp_server:mcp`. scitex-todo's hard deps (click,
+    # pyyaml, ruamel-yaml) are already SAC-transitive via the runner
+    # plumbing, so the [mcp] extra adds just fastmcp.
     uv pip install --python /opt/venv-sac/bin/python \
         "claude-agent-sdk==0.2.87" \
+        "scitex-todo[mcp]>=0.3.0" \
         /opt/scitex-agent-container-src
 
     # Surface the SDK's bundled claude CLI on PATH so humans can

--- a/tests/integration/test_apptainer_base_def_scitex_todo.py
+++ b/tests/integration/test_apptainer_base_def_scitex_todo.py
@@ -1,0 +1,98 @@
+"""Static contract: ``apptainer-base.def`` must install scitex-todo[mcp].
+
+P3a-1.5 (operator directive ``feedback_scitex_todo_single_shared_store``,
+lead a2a ``5c0c1fe32a9a43888e01151d6fc0fb9e``): every sac-launched
+agent must be able to attach the scitex-todo MCP and write to the
+shared store. The MCP wiring (P3a) lands a ``.mcp.json`` entry that
+invokes ``scitex-todo mcp start`` — but that only works when
+``scitex-todo`` is on PATH inside the SIF. The ``[mcp]`` extra pulls
+in fastmcp>=2.0 (the FastMCP server backing
+``scitex_todo._mcp_server:mcp``) without which ``mcp start`` exits
+with a missing-extra hint.
+
+This test pins both requirements as code: drop scitex-todo or its
+``[mcp]`` extra from the .def and CI yells before a SIF rebuild
+ships an agent that can't reach its shared todo store.
+
+The sibling ``test_apptainer_scitex_def_libxcb.py`` sets the same
+contract pattern at the :scitex layer; this file enforces the
+:base layer.
+
+STX-TQ002 AAA + STX-TQ007 one-assert per test.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_BASE_DEF = (
+    _REPO_ROOT / "src" / "scitex_agent_container" / "containers" / "apptainer-base.def"
+)
+
+
+@pytest.fixture(scope="module")
+def base_def_text() -> str:
+    # Arrange
+    return _BASE_DEF.read_text()
+
+
+def _uv_pip_install_block(text: str) -> str:
+    """Return the first ``uv pip install ...`` continuation chunk joined."""
+    lines = text.splitlines()
+    out: list[str] = []
+    in_block = False
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("uv pip install"):
+            in_block = True
+        if in_block:
+            out.append(stripped.rstrip("\\").strip())
+            if not stripped.endswith("\\"):
+                break
+    return " ".join(out)
+
+
+# ---------------------------------------------------------------------------
+# scitex-todo install line is present + carries the [mcp] extra
+# ---------------------------------------------------------------------------
+
+
+def test_uv_pip_install_block_mentions_scitex_todo(base_def_text: str) -> None:
+    # Arrange
+    block = _uv_pip_install_block(base_def_text)
+    # Act
+    present = "scitex-todo" in block
+    # Assert
+    assert present, (
+        f"scitex-todo missing from uv pip install in apptainer-base.def:\n{block}"
+    )
+
+
+def test_uv_pip_install_block_carries_mcp_extra(base_def_text: str) -> None:
+    # Arrange
+    block = _uv_pip_install_block(base_def_text)
+    # Act
+    present = "scitex-todo[mcp]" in block
+    # Assert
+    assert present, (
+        "scitex-todo install must carry the [mcp] extra (pulls fastmcp>=2.0)"
+        f" in apptainer-base.def:\n{block}"
+    )
+
+
+def test_uv_pip_install_block_pins_scitex_todo_minimum_version(
+    base_def_text: str,
+) -> None:
+    # Arrange — a versioned constraint ensures the SIF gets at least
+    # the version with FastMCP 2.x compatibility + the 16-tool surface.
+    block = _uv_pip_install_block(base_def_text)
+    # Act
+    has_version_pin = ">=0.3.0" in block or "==0.3.0" in block or ">=0.3" in block
+    # Assert
+    assert has_version_pin, (
+        "scitex-todo install must carry a version pin (>=0.3 or stricter)"
+        f" in apptainer-base.def:\n{block}"
+    )


### PR DESCRIPTION
## Summary

P3a-1.5 (operator directive `feedback_scitex_todo_single_shared_store`, lead a2a `5c0c1fe32a9a43888e01151d6fc0fb9e`). Closes the base-layer tail of the P3a fleet rollout: today's MCP wiring (P3a) lands a `.mcp.json` entry that runs `scitex-todo mcp start`, but that only works when `scitex-todo` is on PATH inside the SIF.

Today `apptainer-base.def` installs `claude-agent-sdk` + `scitex-agent-container-src` into `/opt/venv-sac`. `scitex-todo` is NOT installed — any agent built FROM `sac-base.sif` (or any layer that doesn't add its own scitex-todo install) gets a missing-CLI error when the MCP server tries to start.

## Source change

Single line of additions to `src/scitex_agent_container/containers/apptainer-base.def`'s uv pip install block:

```
uv pip install --python /opt/venv-sac/bin/python \
    "claude-agent-sdk==0.2.87" \
    "scitex-todo[mcp]>=0.3.0" \
    /opt/scitex-agent-container-src
```

The `[mcp]` extra pulls `fastmcp>=2.0` (the FastMCP backing `scitex_todo._mcp_server:mcp`). scitex-todo's hard deps (click, pyyaml, ruamel-yaml) are already SAC-transitive via the runner plumbing — net delta is just fastmcp + scitex-todo.

`apptainer-scitex.def` builds from `sac-base.sif` (`Bootstrap: localimage / From: ./sac-base.sif`), so the `:scitex` layer inherits the install automatically — no scitex.def edit needed.

## Tests

`tests/integration/test_apptainer_base_def_scitex_todo.py` — 3 static-contract tests mirroring the sibling `test_apptainer_scitex_def_libxcb.py` pattern:

- uv pip install block mentions `scitex-todo`,
- carries the `[mcp]` extra,
- pins a `>=0.3` version.

Drop the install line or the extra and CI yells before a SIF rebuild ships an agent that can't reach its shared todo store. Local: 3/3 passed.

## Cross-thread

- **P3a (MCP wiring)** — dotfiles fragment staged for lead to apply in the unified delivery commit.
- **P3a-2 (shared-store bind)** — MERGED via #365 + dotfiles `_base/spec.yaml`. Every sac-launched agent inherits the bind.
- **P3a-3 (CLAUDE.md scope=agent:<name>)** — staged in the same dotfiles set.

After this PR merges, the next sac-{base,scitex}.sif rebuild ships the full P3a stack to the operator's fleet.

## Test plan

- [ ] CI green on the 3 new static-contract tests.
- [ ] After SIF rebuild + a representative agent restart: `apptainer exec sac-{base,scitex}.sif scitex-todo --version` exits 0 and reports `0.3.0+`.
- [ ] `apptainer exec ... scitex-todo mcp list-tools` enumerates the 16 tools.