### PR TITLE
feat(accounts): countdown delta on 5h + 7d reset cells (P3 / op 12866)

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_account_list_format.py
+++ b/src/scitex_agent_container/cli_pkg/_account_list_format.py
@@ -224,14 +224,21 @@ def format_reset_hhmm(
     reset_iso: str | datetime | None,
     *,
     env: dict[str, str] | None = None,
+    now: datetime | None = None,
 ) -> str:
-    """Render a 5h-window reset timestamp as ``→HH:MM`` (local-tz).
+    """Render a 5h-window reset timestamp as ``→HH:MM (in 2h 14m)`` (local-tz).
 
     Operator gripe #2 (2026-06-09): ``5h%`` never said WHEN the
-    rolling window resets. This renders just the local wall-clock
-    time because a 5h window always resets within a one-day horizon
-    (or, at the day boundary, very early tomorrow — context makes it
-    obvious which).
+    rolling window resets. P3 follow-up (operator 12866, lead a2a
+    b1be44d0): the absolute time alone forces the operator to
+    compute the remaining-time delta by hand. Now appends a
+    countdown ``(in Xh Ym)`` qualifier so the operator sees the
+    delta and the wall clock in the same cell.
+
+    ``now`` is an injection seam for tests; defaults to ``datetime.
+    now(tz)`` at call time. Past resets render the time without the
+    qualifier (the API hasn't observed the rollover yet — surfacing
+    "0s / -3m" would be louder than useful).
 
     Returns ``""`` when the timestamp is missing/unparseable so the
     caller can fall back to the bare percentage cell rather than
@@ -242,22 +249,30 @@ def format_reset_hhmm(
         return ""
     tz = local_timezone(env)
     local = dt.astimezone(tz) if tz is not None else dt.astimezone()
-    return f"→{local.strftime('%H:%M')}"
+    delta_hint = _format_countdown_delta(local, now=now)
+    head = f"→{local.strftime('%H:%M')}"
+    return f"{head} ({delta_hint})" if delta_hint else head
 
 
 def format_reset_day_hour(
     reset_iso: str | datetime | None,
     *,
     env: dict[str, str] | None = None,
+    now: datetime | None = None,
 ) -> str:
-    """Render a 7d-window reset timestamp as ``→Day HHh`` (local-tz).
+    """Render a 7d-window reset timestamp as ``→Day HHh (in 1d 4h 23m)``.
 
     Operator gripe #2 (2026-06-09): ``7d%`` never said WHEN the
-    rolling 7-day window resets. Because the answer can land any day
-    of the next week, we include the day-of-week abbreviation in
-    addition to the hour. Minute resolution is intentionally dropped
-    — for a 7d window the hour is the operationally useful
-    resolution and the cell stays narrow.
+    rolling 7-day window resets. P3 follow-up (operator 12866):
+    appends a countdown ``(in Xd Yh Zm)`` qualifier so the operator
+    sees both the wall day-hour and the time-until-reset in the
+    same cell. The day-of-week prefix already pins the absolute
+    side; the qualifier covers the "is that THIS Sun or NEXT Sun"
+    ambiguity directly.
+
+    ``now`` is an injection seam for tests; defaults to ``datetime.
+    now(tz)`` at call time. Past resets render without the
+    qualifier — the API hasn't observed the rollover yet.
 
     Returns ``""`` on missing/unparseable input — never fabricates.
     """
@@ -266,7 +281,54 @@ def format_reset_day_hour(
         return ""
     tz = local_timezone(env)
     local = dt.astimezone(tz) if tz is not None else dt.astimezone()
-    return f"→{local.strftime('%a %Hh')}"
+    delta_hint = _format_countdown_delta(local, now=now)
+    head = f"→{local.strftime('%a %Hh')}"
+    return f"{head} ({delta_hint})" if delta_hint else head
+
+
+def _format_countdown_delta(target: datetime, *, now: datetime | None = None) -> str:
+    """Render ``in Xd Yh Zm`` for the gap between ``now`` and ``target``.
+
+    Used by :func:`format_reset_hhmm` / :func:`format_reset_day_hour`
+    to append a delta-from-now to the rendered reset timestamp.
+
+    Output by remaining magnitude:
+      * ``target`` already past   → ``""`` (caller falls through).
+      * ``< 60 s``                → ``"in <1m"``.
+      * ``< 60 m``                → ``"in Ym"``.
+      * ``< 24 h``                → ``"in Xh Ym"`` (Ym dropped when zero).
+      * ``>= 24 h``               → ``"in Dd Xh Ym"`` (zero Y/m dropped
+                                    only at the tail; "in 1d 0h 5m"
+                                    keeps the 0h so the unit grid stays
+                                    aligned).
+
+    ``now`` defaults to ``datetime.now(target.tzinfo)`` so the
+    subtraction is timezone-aware. Returns ``""`` whenever the
+    delta cannot be rendered (None inputs, parse failure, past).
+    """
+    if target is None:
+        return ""
+    n = now if now is not None else datetime.now(target.tzinfo)
+    delta = target - n
+    total = int(delta.total_seconds())
+    if total <= 0:
+        return ""
+    if total < 60:
+        return "in <1m"
+    minutes_total = total // 60
+    if minutes_total < 60:
+        return f"in {minutes_total}m"
+    hours_total = minutes_total // 60
+    minutes_part = minutes_total - hours_total * 60
+    if hours_total < 24:
+        return (
+            f"in {hours_total}h {minutes_part}m"
+            if minutes_part
+            else f"in {hours_total}h"
+        )
+    days = hours_total // 24
+    hours_part = hours_total - days * 24
+    return f"in {days}d {hours_part}h {minutes_part}m"
 
 
 __all__ = [

--- a/tests/scitex_agent_container/cli_pkg/test__account_list_render.py
+++ b/tests/scitex_agent_container/cli_pkg/test__account_list_render.py
@@ -550,6 +550,96 @@ def test_format_reset_day_hour_unparseable_returns_empty():
     assert rendered == ""
 
 
+# ---------------------------------------------------------------------------
+# P3 task — countdown delta on the per-window reset hint (op 12866 / lead a2a
+# b1be44d0). The 5h / 7d reset cells now carry an ``(in Xh Ym)`` /
+# ``(in Xd Yh Zm)`` qualifier so the operator sees the wall time AND the
+# time-until-reset in the same cell. ``now`` is injected so tests are
+# deterministic.
+# ---------------------------------------------------------------------------
+
+
+def test_format_reset_hhmm_appends_countdown_delta_under_one_hour(env_save_restore):
+    # Arrange — 12:05 UTC = 21:05 JST; now = 10:55 UTC (= 19:55 JST) →
+    # delta = 1h10m → "in 1h 10m".
+    env_save_restore.set("TZ", "Asia/Tokyo")
+    now = datetime(2026, 5, 31, 10, 55, tzinfo=timezone.utc)
+    # Act
+    rendered = format_reset_hhmm("2026-05-31T12:05:00+00:00", now=now)
+    # Assert
+    assert rendered == "→21:05 (in 1h 10m)"
+
+
+def test_format_reset_hhmm_omits_minute_when_zero(env_save_restore):
+    # Arrange — exactly 2h ahead.
+    env_save_restore.set("TZ", "Asia/Tokyo")
+    now = datetime(2026, 5, 31, 10, 5, tzinfo=timezone.utc)
+    # Act
+    rendered = format_reset_hhmm("2026-05-31T12:05:00+00:00", now=now)
+    # Assert
+    assert rendered == "→21:05 (in 2h)"
+
+
+def test_format_reset_hhmm_uses_in_under_one_min_for_sub_minute_delta(
+    env_save_restore,
+):
+    # Arrange — only 30 seconds out.
+    env_save_restore.set("TZ", "Asia/Tokyo")
+    now = datetime(2026, 5, 31, 12, 4, 30, tzinfo=timezone.utc)
+    # Act
+    rendered = format_reset_hhmm("2026-05-31T12:05:00+00:00", now=now)
+    # Assert
+    assert rendered == "→21:05 (in <1m)"
+
+
+def test_format_reset_hhmm_drops_delta_when_target_already_past(
+    env_save_restore,
+):
+    # Arrange — reset already in the past; cell falls back to bare time.
+    env_save_restore.set("TZ", "Asia/Tokyo")
+    now = datetime(2026, 5, 31, 13, 0, tzinfo=timezone.utc)
+    # Act
+    rendered = format_reset_hhmm("2026-05-31T12:05:00+00:00", now=now)
+    # Assert
+    assert rendered == "→21:05"
+
+
+def test_format_reset_day_hour_appends_multi_day_countdown(env_save_restore):
+    # Arrange — 2026-06-04 08:00 UTC = 2026-06-04 17:00 JST → Thu 17h.
+    # now = 2026-06-03 03:36 UTC → delta = 1d 4h 24m → "in 1d 4h 24m".
+    env_save_restore.set("TZ", "Asia/Tokyo")
+    now = datetime(2026, 6, 3, 3, 36, tzinfo=timezone.utc)
+    # Act
+    rendered = format_reset_day_hour("2026-06-04T08:00:00+00:00", now=now)
+    # Assert
+    assert rendered == "→Thu 17h (in 1d 4h 24m)"
+
+
+def test_format_reset_day_hour_drops_delta_when_target_already_past(
+    env_save_restore,
+):
+    # Arrange — reset is in the past for this fake now.
+    env_save_restore.set("TZ", "Asia/Tokyo")
+    now = datetime(2026, 6, 5, 8, 0, tzinfo=timezone.utc)
+    # Act
+    rendered = format_reset_day_hour("2026-06-04T08:00:00+00:00", now=now)
+    # Assert
+    assert rendered == "→Thu 17h"
+
+
+def test_format_reset_day_hour_handles_under_one_day_delta(env_save_restore):
+    # Arrange — same-day reset still uses Day Hh prefix; delta falls in
+    # the ``X h Y m`` branch.
+    env_save_restore.set("TZ", "Asia/Tokyo")
+    # 2026-06-04 08:00 UTC = 17:00 JST (Thu 17h); now = 2026-06-04
+    # 05:00 UTC = 14:00 JST → delta = 3h.
+    now = datetime(2026, 6, 4, 5, 0, tzinfo=timezone.utc)
+    # Act
+    rendered = format_reset_day_hour("2026-06-04T08:00:00+00:00", now=now)
+    # Assert
+    assert rendered == "→Thu 17h (in 3h)"
+
+
 def test_render_stored_table_5h_cell_carries_reset_hint(env_save_restore):
     """5h% cell renders ``42% (→HH:MM)`` when ``reset_at_5h`` is present."""
     # Arrange — 12:05 UTC = 21:05 JST.


### PR DESCRIPTION
## Summary

Operator request TG 12866 (lead a2a `b1be44d0`): `sac accounts list` shows the 5h% and 7d% reset times as absolute (`→21:05` / `→Thu 17h`), forcing the operator to compute the time-until-reset by hand. P3 fix: append `(in Xh Ym)` / `(in Xd Yh Zm)` to the same cell.

## Source change

Two functions in `cli_pkg/_account_list_format.py`:

- `format_reset_hhmm(reset_iso, *, env=None, now=None)` — gains a `now` injection seam (defaults to `datetime.now(tz)`) and appends `(in …)` when the delta is positive.
- `format_reset_day_hour(reset_iso, *, env=None, now=None)` — same treatment.

New helper `_format_countdown_delta(target, *, now)` does the formatting:

| Delta magnitude | Output |
| --- | --- |
| past | `""` (caller falls through to bare arrow) |
| < 60 s | `in <1m` |
| < 60 m | `in Ym` |
| < 24 h | `in Xh Ym` (Ym dropped when 0) |
| ≥ 24 h | `in Dd Xh Ym` |

The renderer (`_account_list_render.py`) is untouched — both formatters already feed `_fmt_pct_with_reset`, yielding `42% (→21:05 (in 1h 10m))`.

## Tests

`tests/scitex_agent_container/cli_pkg/test__account_list_render.py` — 7 new tests under the existing P3 section, STX-TQ002 AAA + STX-TQ007 one-assert, no mocks:

- **5h**: under-one-hour, exact-hour (Ym dropped), sub-minute (`in <1m`), past target (no qualifier).
- **7d**: multi-day (`in 1d 4h 24m`), past target (no qualifier), under-one-day still uses Day Hh prefix.

Existing tests pass unchanged (historical reset timestamps sit in the past → new code path returns `""` delta → original `→HH:MM` / `→Day HHh` output).

Local: `PYTHONPATH=src pytest tests/scitex_agent_container/cli_pkg/test__account_list_render.py` → **74 / 74 passed**.

## Test plan

- [ ] CI green on the existing 67 + 7 new tests.
- [ ] After merge: `sac accounts list` cell renders `42% (→21:05 (in 2h 14m))` on accounts whose API returned a reset timestamp; falls back to `42% (→21:05)` only when the reset is already past (rollover not yet observed).