### PR TITLE
feat(lifecycle): fleet-default pre-stop rescue for dirty worktrees

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_pre_stop_rescue.py
+++ b/src/scitex_agent_container/_lifecycle/_pre_stop_rescue.py
@@ -1,0 +1,294 @@
+"""Fleet-default pre-stop rescue — commit + push dirty worktrees before stop.
+
+Operator priority (lead a2a ``efa48850daf248ed9fe3ae5232677b2b``): make
+restart cheap. Before this module, ``sac agents stop`` would happily
+SIGTERM the apptainer process with uncommitted work in the agent's
+worktrees still sitting there — on the next start the work was gone.
+Operator-declared ``pre_stop`` hooks could rescue it, but no fleet
+default shipped, so every agent had to opt in by spec edit (the
+band-aid the operator explicitly dislikes).
+
+This module is the SAC-side auto-rescue. It runs once per
+``agent_stop`` call, BEFORE the operator's ``pre_stop`` hooks fire,
+walks every git worktree under the agent's work roots, and for each
+DIRTY worktree:
+
+* Commits the dirty changes locally with a stable rescue message.
+* Pushes the branch to its tracking remote IF the branch is non-
+  protected (no ``main`` / ``master`` / ``release/*``).
+* On push failure or protected branch: writes a diff-tarball under
+  ``<state_dir>/rescue/<branch>-<utc>.tar.gz`` so the next start can
+  re-apply.
+
+The whole pass is bounded by ``RESCUE_GRACE_SECONDS`` (default 60s)
+so the rescue can NEVER wedge a restart — if the budget elapses,
+whatever has been committed locally + the diff-tarballs landed are
+preserved. Operator's directive: never lose, never wedge.
+
+Walked roots (per lead refinement):
+  * ``config.workdir`` — primary tree.
+  * ``<workdir>/.worktrees/*`` — subagent worktrees (the in-container
+    claude session creates them; restart kills them; the reap-bug
+    lead-learnings/19 also destroys them silently — unify here).
+  * ``<workdir>/worktrees/*`` — legacy convention still in use.
+
+Git-op primitives live in :mod:`_pre_stop_rescue_git` (split for the
+per-file line cap).
+
+No mocks. Real ``tmp_path`` git repos in tests.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from pathlib import Path
+from typing import Iterable
+
+from ._pre_stop_rescue_git import (
+    commit_dirty,
+    current_branch,
+    is_dirty,
+    is_git_worktree,
+    push_branch,
+    write_diff_tarball,
+)
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "RESCUE_DIR_NAME",
+    "RESCUE_GRACE_SECONDS",
+    "is_protected_branch",
+    "rescue_worktree",
+    "rescue_worktrees_for_agent",
+    "run_pre_stop_rescue",
+]
+
+
+RESCUE_GRACE_SECONDS: float = 60.0
+RESCUE_DIR_NAME: str = "rescue"
+
+# Branch-name protection list — operator-mandated. Auto-COMMIT on these
+# branches is fine; auto-PUSH is refused; diff-tarball fallback used.
+_PROTECTED_BRANCH_PREFIXES: tuple[str, ...] = (
+    "main",
+    "master",
+    "release",
+)
+
+
+def is_protected_branch(branch: str) -> bool:
+    """Return True if ``branch`` matches the push-deny list.
+
+    Exact match OR prefix-with-``/`` (``release`` matches ``release``
+    and ``release/2.0`` but NOT ``release-notes``). Empty / detached
+    (``""``) → True (refuse to push the unclassifiable).
+    """
+    if not branch:
+        return True
+    for prefix in _PROTECTED_BRANCH_PREFIXES:
+        if branch == prefix or branch.startswith(prefix + "/"):
+            return True
+    return False
+
+
+def rescue_worktree(
+    path: Path,
+    *,
+    agent_name: str,
+    timestamp: str,
+    rescue_root: Path,
+    timeout: float,
+) -> dict[str, object]:
+    """Run the rescue sequence on a single git worktree.
+
+    Returns a dict with: ``path``, ``branch``, ``committed``,
+    ``pushed``, ``tarball`` (Path or None), ``protected``, ``error``.
+    NEVER raises.
+    """
+    result: dict[str, object] = {
+        "path": path,
+        "branch": "",
+        "committed": False,
+        "pushed": False,
+        "tarball": None,
+        "protected": False,
+        "error": "",
+    }
+    if not is_git_worktree(path):
+        result["error"] = "not a git worktree"
+        return result
+    if not is_dirty(path, timeout=timeout):
+        return result  # clean — nothing to rescue
+    branch = current_branch(path, timeout=timeout)
+    result["branch"] = branch
+    ok_commit, commit_msg = commit_dirty(
+        path, agent_name=agent_name, timestamp=timestamp, timeout=timeout
+    )
+    result["committed"] = ok_commit
+    if not ok_commit:
+        result["error"] = commit_msg
+        # Even when commit fails, write a tarball so work survives.
+        result["tarball"] = write_diff_tarball(
+            path,
+            rescue_root=rescue_root,
+            branch=branch,
+            agent_name=agent_name,
+            timestamp=timestamp,
+            timeout=timeout,
+        )
+        return result
+    protected = is_protected_branch(branch)
+    result["protected"] = protected
+    if protected:
+        result["tarball"] = write_diff_tarball(
+            path,
+            rescue_root=rescue_root,
+            branch=branch,
+            agent_name=agent_name,
+            timestamp=timestamp,
+            timeout=timeout,
+        )
+        return result
+    ok_push, push_err = push_branch(path, branch, timeout=timeout)
+    result["pushed"] = ok_push
+    if not ok_push:
+        result["error"] = push_err
+        result["tarball"] = write_diff_tarball(
+            path,
+            rescue_root=rescue_root,
+            branch=branch,
+            agent_name=agent_name,
+            timestamp=timestamp,
+            timeout=timeout,
+        )
+    return result
+
+
+def _candidate_roots(workdir: Path) -> Iterable[Path]:
+    """Yield the directories the pass walks for rescue candidates.
+
+    Per lead refinement (a2a efa48850): cover the subagent
+    ``.worktrees/*`` and the legacy ``worktrees/*`` — those are
+    exactly what restart kills + what the reap-bug
+    (lead-learnings/19) silently destroys.
+    """
+    yield workdir
+    sub = workdir / ".worktrees"
+    if sub.is_dir():
+        for child in sorted(sub.iterdir()):
+            if child.is_dir():
+                yield child
+    legacy = workdir / "worktrees"
+    if legacy.is_dir():
+        for child in sorted(legacy.iterdir()):
+            if child.is_dir():
+                yield child
+
+
+def rescue_worktrees_for_agent(
+    *,
+    agent_name: str,
+    workdir: Path,
+    state_dir: Path,
+    grace_seconds: float = RESCUE_GRACE_SECONDS,
+    timestamp: str | None = None,
+) -> list[dict[str, object]]:
+    """Walk + rescue every dirty worktree under ``workdir`` within ``grace_seconds``.
+
+    Bounds the pass by ``grace_seconds`` so a single slow worktree
+    can't wedge restart. On budget exhaustion the remaining
+    candidates are skipped and a structured log line names them;
+    whatever has been committed and tarballed so far is preserved.
+
+    Returns one result dict per scanned candidate (clean ones produce
+    an entry with ``committed=False`` and no error so the caller can
+    count rescues vs no-ops in the same log).
+    """
+    rescue_root = state_dir / RESCUE_DIR_NAME
+    if timestamp is None:
+        timestamp = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+    results: list[dict[str, object]] = []
+    deadline = time.monotonic() + grace_seconds
+    per_candidate_timeout = max(2.0, grace_seconds / 4.0)
+    for candidate in _candidate_roots(workdir):
+        if time.monotonic() >= deadline:
+            log.warning(
+                "pre-stop rescue: grace budget elapsed before scanning %s; "
+                "remaining candidates skipped, preserved work stays",
+                candidate,
+            )
+            results.append(
+                {
+                    "path": candidate,
+                    "branch": "",
+                    "committed": False,
+                    "pushed": False,
+                    "tarball": None,
+                    "protected": False,
+                    "error": "grace budget elapsed",
+                }
+            )
+            continue
+        results.append(
+            rescue_worktree(
+                candidate,
+                agent_name=agent_name,
+                timestamp=timestamp,
+                rescue_root=rescue_root,
+                timeout=min(per_candidate_timeout, deadline - time.monotonic()),
+            )
+        )
+    return results
+
+
+def run_pre_stop_rescue(config) -> None:
+    """Lifecycle entry point — called by ``_lifecycle/_stop.agent_stop``.
+
+    Resolves the agent's workdir + state_dir from ``config``, runs
+    the rescue pass with the default grace budget, and emits one
+    structured log line summarising the outcome. NEVER raises — the
+    rescue is best-effort defence in depth; the operator's
+    ``pre_stop`` hooks still get to do project-specific work after.
+    """
+    try:
+        workdir_str = (
+            getattr(config, "expanded_workdir", None)
+            or getattr(config, "workdir", None)
+            or ""
+        )
+        if not workdir_str:
+            return
+        workdir = Path(str(workdir_str)).expanduser()
+        if not workdir.is_dir():
+            return
+        from .._runners._session_state import state_dir_for
+
+        state_dir = Path(state_dir_for(getattr(config, "name", "")))
+    except (
+        Exception
+    ) as exc:  # stx-allow: fallback (reason: rescue setup must never block stop.)
+        log.warning("pre-stop rescue: setup failed (%r); skipping", exc)
+        return
+    try:
+        results = rescue_worktrees_for_agent(
+            agent_name=getattr(config, "name", "?"),
+            workdir=workdir,
+            state_dir=state_dir,
+        )
+    except Exception as exc:  # stx-allow: fallback (reason: rescue must never block stop; the per-worktree loop is already defensive.)
+        log.warning("pre-stop rescue: unexpected failure (%r); skipping", exc)
+        return
+    committed = sum(1 for r in results if r.get("committed"))
+    pushed = sum(1 for r in results if r.get("pushed"))
+    tarballed = sum(1 for r in results if r.get("tarball"))
+    skipped = sum(1 for r in results if r.get("error"))
+    log.info(
+        "pre-stop rescue: agent=%s committed=%d pushed=%d tarballed=%d skipped=%d",
+        getattr(config, "name", "?"),
+        committed,
+        pushed,
+        tarballed,
+        skipped,
+    )

--- a/src/scitex_agent_container/_lifecycle/_pre_stop_rescue_git.py
+++ b/src/scitex_agent_container/_lifecycle/_pre_stop_rescue_git.py
@@ -1,0 +1,177 @@
+"""Git-operation primitives for ``_pre_stop_rescue``.
+
+Extracted from the orchestrator to keep both files under the per-file
+line cap. The orchestrator
+(:mod:`_lifecycle._pre_stop_rescue`) owns the policy (which roots to
+walk, when to skip, when to push vs tarball); this module owns the
+how (subprocess wrappers, branch detection, diff-tarball writing).
+
+No mocks. Real subprocesses against real git worktrees.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "commit_dirty",
+    "current_branch",
+    "is_dirty",
+    "is_git_worktree",
+    "push_branch",
+    "write_diff_tarball",
+]
+
+
+def _run(cmd: list[str], *, cwd: Path, timeout: float) -> tuple[int, str, str]:
+    """Run ``cmd`` under ``cwd`` capturing output. NEVER raises."""
+    try:
+        proc = subprocess.run(
+            cmd,
+            cwd=str(cwd),
+            timeout=timeout,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.TimeoutExpired as exc:  # stx-allow: fallback (reason: the rescue budget is the caller's invariant.)
+        return (-1, "", f"timeout: {exc}")
+    except (
+        OSError,
+        FileNotFoundError,
+    ) as exc:  # stx-allow: fallback (reason: missing git / unreadable cwd must not crash the rescue pass.)
+        return (-1, "", str(exc))
+    return (proc.returncode, proc.stdout, proc.stderr)
+
+
+def is_git_worktree(path: Path) -> bool:
+    """Return True if ``path/.git`` exists (regular repo OR linked worktree)."""
+    if not path.is_dir():
+        return False
+    return (path / ".git").exists()
+
+
+def current_branch(path: Path, *, timeout: float) -> str:
+    """Return the current branch name; empty string for detached/error."""
+    rc, out, _ = _run(
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=path, timeout=timeout
+    )
+    if rc != 0:
+        return ""
+    branch = out.strip()
+    return "" if branch == "HEAD" else branch
+
+
+def is_dirty(path: Path, *, timeout: float) -> bool:
+    """Return True iff ``git status --porcelain`` reports any changes."""
+    rc, out, _ = _run(["git", "status", "--porcelain"], cwd=path, timeout=timeout)
+    if rc != 0:
+        # Treat git errors as "presumed dirty" — never silently skip a
+        # possibly-real rescue case.
+        return True
+    return bool(out.strip())
+
+
+def commit_dirty(
+    path: Path, *, agent_name: str, timestamp: str, timeout: float
+) -> tuple[bool, str]:
+    """Stage + commit. Returns (ok, message_or_error).
+
+    Commit message: ``rescue: pre-stop autosave <agent>@<UTC>`` — stable
+    so the operator can grep their history for rescued commits.
+    """
+    rc_add, _, err_add = _run(["git", "add", "-A"], cwd=path, timeout=timeout)
+    if rc_add != 0:
+        return (False, f"git add failed: {err_add.strip()}")
+    msg = f"rescue: pre-stop autosave {agent_name}@{timestamp}"
+    rc_commit, _, err_commit = _run(
+        ["git", "commit", "-m", msg], cwd=path, timeout=timeout
+    )
+    if rc_commit != 0:
+        return (False, f"git commit failed: {err_commit.strip()}")
+    return (True, msg)
+
+
+def push_branch(path: Path, branch: str, *, timeout: float) -> tuple[bool, str]:
+    """Push ``branch`` to ``origin`` with ``--force-with-lease -u``."""
+    rc, _, err = _run(
+        ["git", "push", "--force-with-lease", "-u", "origin", branch],
+        cwd=path,
+        timeout=timeout,
+    )
+    if rc != 0:
+        return (False, err.strip() or "push failed")
+    return (True, "")
+
+
+def write_diff_tarball(
+    path: Path,
+    *,
+    rescue_root: Path,
+    branch: str,
+    agent_name: str,
+    timestamp: str,
+    timeout: float,
+) -> Path | None:
+    """Write a ``.tar.gz`` bundling the worktree's last-commit patch + manifest.
+
+    Lands under ``<rescue_root>/<safe-branch>-<timestamp>.tar.gz``.
+    Used as the fallback when ``push_branch`` couldn't ship the work
+    upstream. Returns the written path on success, ``None`` on
+    failure (logged once, never raised).
+    """
+    rescue_root.mkdir(parents=True, exist_ok=True)
+    safe_branch = branch.replace("/", "-") or "_detached"
+    tarball = rescue_root / f"{safe_branch}-{timestamp}.tar.gz"
+    diff_path = rescue_root / f".{safe_branch}-{timestamp}.diff"
+    rc, _, _ = _run(
+        ["git", "format-patch", "-1", "--stdout"], cwd=path, timeout=timeout
+    )
+    if rc != 0:
+        # No parent commit (first commit case) — fall back to diff HEAD.
+        rc_diff, out_diff, _ = _run(["git", "diff", "HEAD"], cwd=path, timeout=timeout)
+        diff_path.write_text(out_diff if rc_diff == 0 else "")
+    else:
+        # Re-run capturing stdout to file — single source of truth.
+        proc = subprocess.run(
+            ["git", "format-patch", "-1", "--stdout"],
+            cwd=str(path),
+            timeout=timeout,
+            capture_output=True,
+            text=True,
+        )
+        diff_path.write_text(proc.stdout)
+    manifest_path = rescue_root / f".{safe_branch}-{timestamp}.manifest"
+    manifest_path.write_text(
+        f"agent: {agent_name}\nbranch: {branch}\ntimestamp: {timestamp}\n"
+        f"worktree: {path}\nreason: pre-stop rescue, push fallback\n"
+    )
+    rc_tar, _, err_tar = _run(
+        [
+            "tar",
+            "-czf",
+            str(tarball),
+            "-C",
+            str(rescue_root),
+            diff_path.name,
+            manifest_path.name,
+        ],
+        cwd=rescue_root,
+        timeout=timeout,
+    )
+    if rc_tar != 0:
+        log.warning(
+            "pre-stop rescue: tar fallback failed for %s (%s)",
+            path,
+            err_tar.strip(),
+        )
+        return None
+    for staging in (diff_path, manifest_path):
+        try:
+            staging.unlink()
+        except FileNotFoundError:  # stx-allow: fallback (reason: tar may have left the staging files in place on some platforms.)
+            pass
+    return tarball

--- a/src/scitex_agent_container/_lifecycle/_stop.py
+++ b/src/scitex_agent_container/_lifecycle/_stop.py
@@ -96,6 +96,16 @@ def agent_stop(
     except Exception:
         traceback.print_exc()
 
+    # Fleet-default pre-stop rescue (operator priority, lead a2a
+    # efa48850daf248ed9fe3ae5232677b2b). Commits + pushes every dirty
+    # worktree (or diff-tarballs them on protected/push-failure) before
+    # the agent dies, so restart never silently loses uncommitted work.
+    # NEVER raises — bounded by RESCUE_GRACE_SECONDS; whatever finished
+    # before the budget elapsed is preserved.
+    from ._pre_stop_rescue import run_pre_stop_rescue
+
+    run_pre_stop_rescue(config)
+
     # Pre-stop hooks
     # stx-allow: fallback (reason: hook commands may reference paths or env vars absent at stop time; force-stop must continue regardless)
     try:

--- a/tests/scitex_agent_container/_lifecycle/test__pre_stop_rescue.py
+++ b/tests/scitex_agent_container/_lifecycle/test__pre_stop_rescue.py
@@ -93,32 +93,59 @@ def _make_dirty(root: Path) -> None:
 
 
 def test_is_protected_branch_main_blocks_push():
-    # Arrange + Act + Assert (constant policy — single boolean answer)
-    assert is_protected_branch("main") is True
+    # Arrange
+    branch = "main"
+    # Act
+    result = is_protected_branch(branch)
+    # Assert
+    assert result is True
 
 
 def test_is_protected_branch_master_blocks_push():
-    assert is_protected_branch("master") is True
+    # Arrange
+    branch = "master"
+    # Act
+    result = is_protected_branch(branch)
+    # Assert
+    assert result is True
 
 
 def test_is_protected_branch_release_prefix_blocks_push():
-    assert is_protected_branch("release/2.0") is True
+    # Arrange
+    branch = "release/2.0"
+    # Act
+    result = is_protected_branch(branch)
+    # Assert
+    assert result is True
 
 
 def test_is_protected_branch_feature_branch_allows_push():
-    assert is_protected_branch("feature/topic") is False
+    # Arrange
+    branch = "feature/topic"
+    # Act
+    result = is_protected_branch(branch)
+    # Assert
+    assert result is False
 
 
 def test_is_protected_branch_release_notes_is_not_protected():
     # Arrange — guard the prefix-match against false positives on names
     # that just begin with the same letters but don't share the ``/``.
-    assert is_protected_branch("release-notes") is False
+    branch = "release-notes"
+    # Act
+    result = is_protected_branch(branch)
+    # Assert
+    assert result is False
 
 
 def test_is_protected_branch_empty_branch_is_protected():
     # Arrange — detached HEAD / unknown branch returns "" from the
     # branch query; refuse to push the unclassifiable.
-    assert is_protected_branch("") is True
+    branch = ""
+    # Act
+    result = is_protected_branch(branch)
+    # Assert
+    assert result is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scitex_agent_container/_lifecycle/test__pre_stop_rescue.py
+++ b/tests/scitex_agent_container/_lifecycle/test__pre_stop_rescue.py
@@ -1,0 +1,344 @@
+"""Tests for ``_lifecycle/_pre_stop_rescue`` — fleet-default rescue pass.
+
+Operator priority (lead a2a ``efa48850daf248ed9fe3ae5232677b2b``): make
+restart cheap. Walks the agent's worktrees, commits dirty changes,
+pushes to non-protected branches, falls back to diff-tarballs when
+push isn't possible — all bounded by a 60s grace timeout so the
+rescue can never wedge a restart.
+
+STX-TQ002 AAA + STX-TQ007 one-assert. No mocks — real ``tmp_path``
+git repos exercised through real ``git`` invocations.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._lifecycle._pre_stop_rescue import (
+    RESCUE_DIR_NAME,
+    is_protected_branch,
+    rescue_worktree,
+    rescue_worktrees_for_agent,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures — real git environments, no monkeypatch
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def git_env_save_restore(tmp_path: Path):
+    """Make git invocations deterministic + sandboxed.
+
+    Pins commit author + committer so the test repos don't depend on
+    the runner's global ``~/.gitconfig`` (CI runners often have none).
+    Re-points ``HOME`` to ``tmp_path`` so any per-user git state lands
+    in the tmp dir and is wiped with the test. Yields the prior
+    environment values restored on teardown — explicit save/restore,
+    NO ``monkeypatch`` fixture (PA-306 §3).
+    """
+    keys = [
+        "HOME",
+        "GIT_AUTHOR_NAME",
+        "GIT_AUTHOR_EMAIL",
+        "GIT_COMMITTER_NAME",
+        "GIT_COMMITTER_EMAIL",
+    ]
+    saved = {k: os.environ.get(k) for k in keys}
+    os.environ["HOME"] = str(tmp_path)
+    for k, v in [
+        ("GIT_AUTHOR_NAME", "Rescue Tester"),
+        ("GIT_AUTHOR_EMAIL", "rescue@example.invalid"),
+        ("GIT_COMMITTER_NAME", "Rescue Tester"),
+        ("GIT_COMMITTER_EMAIL", "rescue@example.invalid"),
+    ]:
+        os.environ[k] = v
+    try:
+        yield
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+def _git(args: list[str], *, cwd: Path) -> None:
+    """Run ``git <args>`` synchronously; raise on non-zero so tests fail loud."""
+    subprocess.check_call(["git", *args], cwd=str(cwd))
+
+
+def _init_repo(root: Path, *, branch: str = "feature/topic") -> Path:
+    """Create a fresh git repo at ``root`` on ``branch`` with one commit."""
+    root.mkdir(parents=True, exist_ok=True)
+    _git(["init", "--initial-branch=" + branch, "--quiet"], cwd=root)
+    (root / "README.md").write_text("# tmp\n")
+    _git(["add", "README.md"], cwd=root)
+    _git(["commit", "-m", "init", "--quiet"], cwd=root)
+    return root
+
+
+def _make_dirty(root: Path) -> None:
+    """Append a dirty change so ``git status --porcelain`` reports it."""
+    (root / "README.md").write_text("# tmp\n# rescue-target\n")
+
+
+# ---------------------------------------------------------------------------
+# is_protected_branch — denylist policy
+# ---------------------------------------------------------------------------
+
+
+def test_is_protected_branch_main_blocks_push():
+    # Arrange + Act + Assert (constant policy — single boolean answer)
+    assert is_protected_branch("main") is True
+
+
+def test_is_protected_branch_master_blocks_push():
+    assert is_protected_branch("master") is True
+
+
+def test_is_protected_branch_release_prefix_blocks_push():
+    assert is_protected_branch("release/2.0") is True
+
+
+def test_is_protected_branch_feature_branch_allows_push():
+    assert is_protected_branch("feature/topic") is False
+
+
+def test_is_protected_branch_release_notes_is_not_protected():
+    # Arrange — guard the prefix-match against false positives on names
+    # that just begin with the same letters but don't share the ``/``.
+    assert is_protected_branch("release-notes") is False
+
+
+def test_is_protected_branch_empty_branch_is_protected():
+    # Arrange — detached HEAD / unknown branch returns "" from the
+    # branch query; refuse to push the unclassifiable.
+    assert is_protected_branch("") is True
+
+
+# ---------------------------------------------------------------------------
+# rescue_worktree — single repo, no remote → tarball fallback
+# ---------------------------------------------------------------------------
+
+
+def test_rescue_worktree_commits_dirty_changes(
+    git_env_save_restore, tmp_path: Path
+) -> None:
+    # Arrange
+    repo = _init_repo(tmp_path / "repo")
+    _make_dirty(repo)
+    rescue_root = tmp_path / "state" / RESCUE_DIR_NAME
+    # Act
+    result = rescue_worktree(
+        repo,
+        agent_name="agent-x",
+        timestamp="20260613T000000Z",
+        rescue_root=rescue_root,
+        timeout=10.0,
+    )
+    # Assert
+    assert result["committed"] is True
+
+
+def test_rescue_worktree_writes_tarball_when_no_remote(
+    git_env_save_restore, tmp_path: Path
+) -> None:
+    # Arrange — the repo has no ``origin`` remote configured, so push
+    # MUST fail and the diff-tarball fallback MUST land.
+    repo = _init_repo(tmp_path / "repo")
+    _make_dirty(repo)
+    rescue_root = tmp_path / "state" / RESCUE_DIR_NAME
+    # Act
+    result = rescue_worktree(
+        repo,
+        agent_name="agent-x",
+        timestamp="20260613T000000Z",
+        rescue_root=rescue_root,
+        timeout=10.0,
+    )
+    # Assert
+    assert isinstance(result.get("tarball"), Path) and Path(result["tarball"]).is_file()
+
+
+def test_rescue_worktree_protected_branch_skips_push(
+    git_env_save_restore, tmp_path: Path
+) -> None:
+    # Arrange — branch=main is denylisted; commit lands but push doesn't.
+    repo = _init_repo(tmp_path / "repo", branch="main")
+    _make_dirty(repo)
+    rescue_root = tmp_path / "state" / RESCUE_DIR_NAME
+    # Act
+    result = rescue_worktree(
+        repo,
+        agent_name="agent-x",
+        timestamp="20260613T000000Z",
+        rescue_root=rescue_root,
+        timeout=10.0,
+    )
+    # Assert
+    assert result["pushed"] is False and result["protected"] is True
+
+
+def test_rescue_worktree_protected_branch_still_commits(
+    git_env_save_restore, tmp_path: Path
+) -> None:
+    # Arrange
+    repo = _init_repo(tmp_path / "repo", branch="main")
+    _make_dirty(repo)
+    rescue_root = tmp_path / "state" / RESCUE_DIR_NAME
+    # Act
+    result = rescue_worktree(
+        repo,
+        agent_name="agent-x",
+        timestamp="20260613T000000Z",
+        rescue_root=rescue_root,
+        timeout=10.0,
+    )
+    # Assert
+    assert result["committed"] is True
+
+
+def test_rescue_worktree_clean_worktree_no_op(
+    git_env_save_restore, tmp_path: Path
+) -> None:
+    # Arrange — clean repo, nothing to rescue.
+    repo = _init_repo(tmp_path / "repo")
+    rescue_root = tmp_path / "state" / RESCUE_DIR_NAME
+    # Act
+    result = rescue_worktree(
+        repo,
+        agent_name="agent-x",
+        timestamp="20260613T000000Z",
+        rescue_root=rescue_root,
+        timeout=10.0,
+    )
+    # Assert
+    assert (
+        result["committed"] is False
+        and result["pushed"] is False
+        and result["tarball"] is None
+    )
+
+
+def test_rescue_worktree_non_repo_returns_error(tmp_path: Path) -> None:
+    # Arrange — plain directory, NOT a git repo.
+    plain = tmp_path / "not-a-repo"
+    plain.mkdir()
+    rescue_root = tmp_path / "state" / RESCUE_DIR_NAME
+    # Act
+    result = rescue_worktree(
+        plain,
+        agent_name="agent-x",
+        timestamp="20260613T000000Z",
+        rescue_root=rescue_root,
+        timeout=10.0,
+    )
+    # Assert
+    assert result["error"] == "not a git worktree"
+
+
+# ---------------------------------------------------------------------------
+# rescue_worktrees_for_agent — walks .worktrees/* + worktrees/*
+# ---------------------------------------------------------------------------
+
+
+def test_rescue_for_agent_finds_dotworktrees_subagent(
+    git_env_save_restore, tmp_path: Path
+) -> None:
+    # Arrange — primary workdir is clean; a .worktrees/agent-foo sibling
+    # carries the dirty work that restart would otherwise destroy.
+    workdir = _init_repo(tmp_path / "wd")
+    sub = _init_repo(workdir / ".worktrees" / "agent-foo")
+    _make_dirty(sub)
+    state_dir = tmp_path / "state"
+    # Act
+    results = rescue_worktrees_for_agent(
+        agent_name="parent",
+        workdir=workdir,
+        state_dir=state_dir,
+    )
+    # Assert — the subagent worktree's result records a commit.
+    sub_results = [r for r in results if Path(r["path"]).samefile(sub)]
+    assert sub_results and sub_results[0]["committed"] is True
+
+
+def test_rescue_for_agent_finds_legacy_worktrees_dir(
+    git_env_save_restore, tmp_path: Path
+) -> None:
+    # Arrange — legacy worktrees/legacy-feat carries the dirty work.
+    workdir = _init_repo(tmp_path / "wd")
+    legacy = _init_repo(workdir / "worktrees" / "legacy-feat")
+    _make_dirty(legacy)
+    state_dir = tmp_path / "state"
+    # Act
+    results = rescue_worktrees_for_agent(
+        agent_name="parent",
+        workdir=workdir,
+        state_dir=state_dir,
+    )
+    # Assert
+    legacy_results = [r for r in results if Path(r["path"]).samefile(legacy)]
+    assert legacy_results and legacy_results[0]["committed"] is True
+
+
+def test_rescue_for_agent_clean_workdir_returns_no_op_entries(
+    git_env_save_restore, tmp_path: Path
+) -> None:
+    # Arrange — single clean repo, no subagent worktrees.
+    workdir = _init_repo(tmp_path / "wd")
+    state_dir = tmp_path / "state"
+    # Act
+    results = rescue_worktrees_for_agent(
+        agent_name="parent",
+        workdir=workdir,
+        state_dir=state_dir,
+    )
+    # Assert — at least one entry (the primary workdir) and none committed.
+    committed = [r for r in results if r["committed"]]
+    assert committed == []
+
+
+def test_rescue_for_agent_respects_grace_budget(
+    git_env_save_restore, tmp_path: Path
+) -> None:
+    # Arrange — tiny grace budget guarantees the loop's deadline check
+    # short-circuits before scanning every worktree, recording the
+    # ``grace budget elapsed`` skip path.
+    workdir = _init_repo(tmp_path / "wd")
+    for i in range(3):
+        sub = _init_repo(workdir / ".worktrees" / f"agent-{i}")
+        _make_dirty(sub)
+    state_dir = tmp_path / "state"
+    # Act
+    results = rescue_worktrees_for_agent(
+        agent_name="parent",
+        workdir=workdir,
+        state_dir=state_dir,
+        grace_seconds=0.0,  # impossible budget → first deadline check fires
+    )
+    # Assert — at least one result carries the budget-elapsed marker.
+    elapsed = [r for r in results if r.get("error") == "grace budget elapsed"]
+    assert elapsed != []
+
+
+def test_rescue_for_agent_rescue_dir_named_correctly(
+    git_env_save_restore, tmp_path: Path
+) -> None:
+    # Arrange — make sure the rescue dir lands under ``state_dir/rescue/``
+    # (the documented operator path so they can find the diff-tarballs).
+    workdir = _init_repo(tmp_path / "wd")
+    _make_dirty(workdir)
+    state_dir = tmp_path / "state"
+    # Act
+    rescue_worktrees_for_agent(
+        agent_name="parent",
+        workdir=workdir,
+        state_dir=state_dir,
+    )
+    # Assert
+    assert (state_dir / RESCUE_DIR_NAME).is_dir()


### PR DESCRIPTION
## Summary

Operator priority — make restart cheap (lead a2a `efa48850daf248ed9fe3ae5232677b2b`, Option B). Before this PR, `sac agents stop` / `sac agents restart` would SIGTERM the apptainer process with uncommitted work in the agent's worktrees still sitting there — on the next start that work was gone. Operator-declared `pre_stop` hooks could rescue it, but no fleet default shipped, so every agent had to opt in by spec edit (the band-aid the operator dislikes).

This PR is the sac-side auto-rescue. Walks the agent's primary tree + `.worktrees/*` subagent worktrees + legacy `worktrees/*` and, for each DIRTY worktree, commits, pushes (when the branch is non-protected), or falls back to a diff-tarball. Bounded by a 60s grace timeout — never lose, never wedge.

## Source change

**New module `_lifecycle/_pre_stop_rescue.py`** (orchestrator):
- `is_protected_branch` — denylist (main / master / release/* + empty for detached HEAD).
- `rescue_worktree` — single-repo sequence: clean check → commit → push (non-protected only) → diff-tarball on failure or protected.
- `rescue_worktrees_for_agent` — walks primary + `<workdir>/.worktrees/*` + `<workdir>/worktrees/*` (per lead refinement — these are exactly what restart kills + what the reap-bug `lead-learnings/19` destroys silently). Bounded by `RESCUE_GRACE_SECONDS = 60.0`. Per-candidate timeout adapts to remaining budget.
- `run_pre_stop_rescue(config)` — lifecycle entry; NEVER raises; emits one structured log line.

**New module `_lifecycle/_pre_stop_rescue_git.py`** (git primitives, split for the 512-line cap):
- `is_git_worktree`, `current_branch`, `is_dirty`, `commit_dirty`, `push_branch`, `write_diff_tarball` — thin subprocess wrappers around real git.

**`_lifecycle/_stop.py`** wires `run_pre_stop_rescue(config)` right after `push_pre_stop_snapshot()` and right before the operator's `config.hooks.get('pre_stop', [])` fire. Order: rescue → operator hook → `runtime.stop`.

## Refinements landed (per lead a2a)

- ✅ Walk the subagent `.worktrees/agent-*` + legacy `worktrees/*`, not just the primary repo.
- ✅ Denylist `main`/`master`/`release/*`: auto-commit yes, auto-push no, diff-tarball fallback.
- ✅ 60s grace timeout; on budget exhaustion, remaining candidates logged + skipped — preserved work stays.
- ✅ Diff-tarball fallback on push failure, no-remote, protected branch.

## Tests

17 new tests in `tests/scitex_agent_container/_lifecycle/test__pre_stop_rescue.py` — real `tmp_path` git repos, no mocks, explicit env save/restore fixture (no `monkeypatch`, PA-306 §3):

- `is_protected_branch` matrix (main / master / release prefix / feature / `release-notes` false-positive guard / empty branch).
- `rescue_worktree` happy path, tarball fallback when no remote, protected-branch skips push but still commits, clean = no-op, non-repo records error.
- `rescue_worktrees_for_agent` finds `.worktrees/agent-*` + legacy `worktrees/*`, respects grace budget (impossible budget → `grace budget elapsed` marker), creates `state_dir/rescue/`.

Verification:
- `PYTHONPATH=src pytest tests/scitex_agent_container/_lifecycle/test__pre_stop_rescue.py` → **17/17 passed**.
- `PYTHONPATH=src pytest tests/scitex_agent_container/_lifecycle/` → **95/95 passed** (broader regression).

## Cross-thread

Pairs with worktree-reap safety (`lead-learnings/19`): once a dirty worktree is rescued + pushed, it's safe to reap. This PR doesn't yet REMOVE the rescued worktrees — that's a separate janitor concern; the immediate operator-visible win is "restart never silently loses work."

## Test plan

- [ ] CI green.
- [ ] After merge: restart any running agent with dirty work in `.worktrees/agent-*` — verify a rescue commit on the branch (or a diff-tarball at `<state_dir>/rescue/<branch>-<utc>.tar.gz`) before the agent comes back.