### PR TITLE
feat(runners): per-beat session.jsonl movement signals on heartbeat (#24)

### DIFF
--- a/src/scitex_agent_container/_runners/_heartbeat_fields.py
+++ b/src/scitex_agent_container/_runners/_heartbeat_fields.py
@@ -1,0 +1,73 @@
+"""Per-beat enrichment fields for ``_session_state.write_heartbeat``.
+
+The session_jsonl movement signals live here (rather than alongside
+``_heartbeat_usage_fields`` in ``_session_state``) so the
+``_session_state`` module stays under the per-file line cap. Pure
+read-side helpers — no subprocess, no side effects on the agent
+state — so a heartbeat-loop crash here is impossible.
+
+Operator-requested (``feedback_sac_heartbeat_observability``,
+2026-06-13): embed "is this agent PRODUCING?" right next to the
+liveness ts so a single heartbeat read answers both. Fields:
+
+  * ``session_jsonl_bytes``       — current size of
+    ``<state_dir>/session.jsonl`` (0 if absent).
+  * ``session_jsonl_delta_bytes`` — bytes added since the previous
+    heartbeat (positive = producing, 0 = idle though the beat
+    fired). Computed against the PRIOR ``heartbeat.json``'s
+    recorded value, clamped to >=0 so a session.jsonl rotate /
+    truncate can't mislead with a negative.
+  * ``seconds_since_last_beat``  — wall-clock gap to the prior beat.
+
+CAVEAT — subagent/background work writes to a SUBAGENT jsonl, NOT
+the main ``session.jsonl``. An active subagent + idle main session
+therefore shows ``delta=0`` on the main beat (the false-idle hit
+live on dev/todo flat-main while bg scanners ran). A follow-up PR
+can opt into summing per-subagent jsonl deltas — deferred so the
+operator can decide when the extra walk-I/O cost is worth the
+precision.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+__all__ = ["heartbeat_jsonl_fields"]
+
+
+def heartbeat_jsonl_fields(state_dir: Path, now: float) -> dict:
+    """Return the session-jsonl movement signals for a heartbeat record.
+
+    NEVER raises — any read failure degrades to an empty / partial
+    dict so the heartbeat loop can splat it onto the payload without
+    risking a runner crash. Absent keys (rather than zero values)
+    let the operator distinguish "first beat ever" / "missed prior
+    beat" / "rotate happened" from a clean zero-delta idle.
+    """
+    out: dict = {}
+    jsonl = state_dir / "session.jsonl"
+    try:
+        current_bytes = jsonl.stat().st_size if jsonl.is_file() else 0
+    except OSError:
+        return out
+    out["session_jsonl_bytes"] = int(current_bytes)
+    prior_path = state_dir / "heartbeat.json"
+    try:
+        prior_text = prior_path.read_text(encoding="utf-8")
+    except OSError:
+        return out
+    try:
+        prior = json.loads(prior_text) if prior_text else {}
+    except json.JSONDecodeError:
+        return out
+    prior_ts = prior.get("ts")
+    if isinstance(prior_ts, (int, float)) and prior_ts > 0:
+        out["seconds_since_last_beat"] = round(max(0.0, now - prior_ts), 3)
+    prior_bytes = prior.get("session_jsonl_bytes")
+    if isinstance(prior_bytes, int) and prior_bytes >= 0:
+        # Clamp >=0 — a session.jsonl rotate/truncate between beats
+        # would otherwise produce a negative delta and mislead the
+        # operator into thinking the agent destroyed work.
+        out["session_jsonl_delta_bytes"] = max(0, int(current_bytes) - prior_bytes)
+    return out

--- a/src/scitex_agent_container/_runners/_session_state.py
+++ b/src/scitex_agent_container/_runners/_session_state.py
@@ -267,6 +267,15 @@ def write_heartbeat(
     payload = {"ts": now, "pid": pid, "state": state}
     payload.update(_heartbeat_usage_fields(state_dir, now))
     payload.update(_tmp_pressure_fields())
+    # Operator-requested (feedback_sac_heartbeat_observability):
+    # surface session.jsonl movement next to liveness so one read
+    # answers "alive AND producing?". Extracted helper — see
+    # ``_heartbeat_fields`` for the field semantics + the subagent
+    # caveat (active subagents write to a SUBAGENT jsonl, so delta=0
+    # on the main beat is a false-idle).
+    from ._heartbeat_fields import heartbeat_jsonl_fields
+
+    payload.update(heartbeat_jsonl_fields(state_dir, now))
     tmp = state_dir / "heartbeat.json.tmp"
     tmp.write_text(json.dumps(payload), encoding="utf-8")
     tmp.replace(state_dir / "heartbeat.json")

--- a/tests/scitex_agent_container/_runners/test__heartbeat_fields.py
+++ b/tests/scitex_agent_container/_runners/test__heartbeat_fields.py
@@ -1,0 +1,161 @@
+"""Tests for ``_runners/_heartbeat_fields.heartbeat_jsonl_fields``.
+
+Operator-requested per-beat productivity signal
+(``feedback_sac_heartbeat_observability``). Real ``tmp_path`` state
+dir with real ``session.jsonl`` + ``heartbeat.json`` files — no
+mocks. STX-TQ002 AAA + STX-TQ007 one-assert.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scitex_agent_container._runners._heartbeat_fields import (
+    heartbeat_jsonl_fields,
+)
+
+
+def _write_prior_beat(state_dir: Path, *, ts: float, jsonl_bytes: int) -> None:
+    state_dir.mkdir(parents=True, exist_ok=True)
+    (state_dir / "heartbeat.json").write_text(
+        json.dumps({"ts": ts, "session_jsonl_bytes": jsonl_bytes}),
+        encoding="utf-8",
+    )
+
+
+def _write_jsonl(state_dir: Path, *, size: int) -> None:
+    state_dir.mkdir(parents=True, exist_ok=True)
+    (state_dir / "session.jsonl").write_bytes(b"x" * size)
+
+
+# ---------------------------------------------------------------------------
+# session_jsonl_bytes
+# ---------------------------------------------------------------------------
+
+
+def test_session_jsonl_bytes_reflects_current_file_size(tmp_path: Path) -> None:
+    # Arrange
+    _write_jsonl(tmp_path, size=2048)
+    # Act
+    fields = heartbeat_jsonl_fields(tmp_path, now=100.0)
+    # Assert
+    assert fields["session_jsonl_bytes"] == 2048
+
+
+def test_session_jsonl_bytes_is_zero_when_file_absent(tmp_path: Path) -> None:
+    # Arrange — empty state dir, no session.jsonl, no prior beat.
+    # Act
+    fields = heartbeat_jsonl_fields(tmp_path, now=100.0)
+    # Assert
+    assert fields["session_jsonl_bytes"] == 0
+
+
+# ---------------------------------------------------------------------------
+# session_jsonl_delta_bytes
+# ---------------------------------------------------------------------------
+
+
+def test_delta_bytes_positive_when_jsonl_grew(tmp_path: Path) -> None:
+    # Arrange — prior beat saw 1000 bytes; current size is 1500.
+    _write_jsonl(tmp_path, size=1500)
+    _write_prior_beat(tmp_path, ts=90.0, jsonl_bytes=1000)
+    # Act
+    fields = heartbeat_jsonl_fields(tmp_path, now=100.0)
+    # Assert
+    assert fields["session_jsonl_delta_bytes"] == 500
+
+
+def test_delta_bytes_zero_when_jsonl_unchanged(tmp_path: Path) -> None:
+    # Arrange — idle agent: prior == current.
+    _write_jsonl(tmp_path, size=1000)
+    _write_prior_beat(tmp_path, ts=90.0, jsonl_bytes=1000)
+    # Act
+    fields = heartbeat_jsonl_fields(tmp_path, now=100.0)
+    # Assert
+    assert fields["session_jsonl_delta_bytes"] == 0
+
+
+def test_delta_bytes_clamped_to_zero_on_rotate(tmp_path: Path) -> None:
+    # Arrange — rotate / truncate: prior saw 5000, now 100; delta must
+    # NOT be negative (operator would misread it as destroyed work).
+    _write_jsonl(tmp_path, size=100)
+    _write_prior_beat(tmp_path, ts=90.0, jsonl_bytes=5000)
+    # Act
+    fields = heartbeat_jsonl_fields(tmp_path, now=100.0)
+    # Assert
+    assert fields["session_jsonl_delta_bytes"] == 0
+
+
+def test_delta_bytes_absent_when_no_prior_beat(tmp_path: Path) -> None:
+    # Arrange — first beat ever; no prior heartbeat.json on disk.
+    _write_jsonl(tmp_path, size=1500)
+    # Act
+    fields = heartbeat_jsonl_fields(tmp_path, now=100.0)
+    # Assert
+    assert "session_jsonl_delta_bytes" not in fields
+
+
+# ---------------------------------------------------------------------------
+# seconds_since_last_beat
+# ---------------------------------------------------------------------------
+
+
+def test_seconds_since_last_beat_reflects_gap(tmp_path: Path) -> None:
+    # Arrange — prior beat at ts=90, now=100 → 10s gap.
+    _write_jsonl(tmp_path, size=1000)
+    _write_prior_beat(tmp_path, ts=90.0, jsonl_bytes=1000)
+    # Act
+    fields = heartbeat_jsonl_fields(tmp_path, now=100.0)
+    # Assert
+    assert fields["seconds_since_last_beat"] == 10.0
+
+
+def test_seconds_since_last_beat_absent_when_no_prior_beat(tmp_path: Path) -> None:
+    # Arrange — fresh state, only session.jsonl is present.
+    _write_jsonl(tmp_path, size=500)
+    # Act
+    fields = heartbeat_jsonl_fields(tmp_path, now=100.0)
+    # Assert
+    assert "seconds_since_last_beat" not in fields
+
+
+def test_seconds_since_last_beat_absent_when_prior_ts_malformed(tmp_path: Path) -> None:
+    # Arrange — prior heartbeat carries a non-numeric ts (corrupted file).
+    _write_jsonl(tmp_path, size=500)
+    (tmp_path / "heartbeat.json").write_text(
+        json.dumps({"ts": "not-a-number"}), encoding="utf-8"
+    )
+    # Act
+    fields = heartbeat_jsonl_fields(tmp_path, now=100.0)
+    # Assert
+    assert "seconds_since_last_beat" not in fields
+
+
+# ---------------------------------------------------------------------------
+# Robustness — malformed prior heartbeat must NEVER crash the runner
+# ---------------------------------------------------------------------------
+
+
+def test_malformed_prior_heartbeat_json_does_not_raise(tmp_path: Path) -> None:
+    # Arrange — corrupted prior heartbeat.json (not valid JSON).
+    _write_jsonl(tmp_path, size=500)
+    (tmp_path / "heartbeat.json").write_text("not-json", encoding="utf-8")
+    raised: BaseException | None = None
+    # Act
+    try:
+        fields = heartbeat_jsonl_fields(tmp_path, now=100.0)
+    except Exception as exc:  # stx-allow: test-capture (reason: STX-TQ002 splits Act from Assert; the helper is contracted to NEVER raise.)
+        raised = exc
+        fields = {}
+    # Assert — never raises; current jsonl bytes still observable.
+    assert raised is None and fields.get("session_jsonl_bytes") == 500
+
+
+def test_missing_session_jsonl_returns_zero_not_error(tmp_path: Path) -> None:
+    # Arrange — only a prior heartbeat exists; session.jsonl never created.
+    _write_prior_beat(tmp_path, ts=90.0, jsonl_bytes=0)
+    # Act
+    fields = heartbeat_jsonl_fields(tmp_path, now=100.0)
+    # Assert
+    assert fields["session_jsonl_bytes"] == 0


### PR DESCRIPTION
## Summary

Operator-requested (`feedback_sac_heartbeat_observability`, 2026-06-13). Before this PR, `heartbeat.json` carried liveness (ts/pid/state) + tokens + tmp pressure, but answered nothing about "is this agent PRODUCING right now?". Operator workaround: `ls -l <state_dir>/session.jsonl` between beats.

New fields on every beat:

| Field | Meaning |
| --- | --- |
| `session_jsonl_bytes` | current size of `<state_dir>/session.jsonl` (0 if absent) |
| `session_jsonl_delta_bytes` | bytes added since prior beat, clamped to ≥0 |
| `seconds_since_last_beat` | wall-clock gap to the prior beat |

## Source change

- **New module `_runners/_heartbeat_fields.py`** — pure read-side helper. NEVER raises; degrades to absent dict keys on any error so the operator can distinguish "first beat ever" / "missed prior" / "rotate happened" from a clean zero-delta idle.
- **`_runners/_session_state.write_heartbeat`** splats the new fields onto the payload alongside the existing usage + tmp-pressure enrichment. Helper lives in a separate module to keep `_session_state` under the 512-line cap.

## CAVEAT (baked into the docstring + call site)

Subagent/background work writes to a SUBAGENT jsonl, NOT the main `session.jsonl`. An active subagent + idle main session therefore shows `delta=0` on the main beat (the false-idle hit live on dev/todo flat-main while bg scanners ran). Summing per-subagent jsonls is deferred to a follow-up so the operator decides when the extra walk-I/O is worth the precision.

## Tests

`tests/scitex_agent_container/_runners/test__heartbeat_fields.py` — 11 tests, STX-TQ002 AAA + STX-TQ007 one-assert, no mocks (real `tmp_path` `session.jsonl` + `heartbeat.json` files):

- `session_jsonl_bytes` reflects current file size; zero when absent.
- `delta_bytes`: positive when grew, zero when unchanged, clamped on rotate, absent when no prior beat.
- `seconds_since_last_beat`: reflects gap; absent when no prior beat; absent when prior ts malformed.
- Robustness: malformed prior `heartbeat.json` doesn't raise; missing `session.jsonl` returns 0 not error.

Local: `PYTHONPATH=src pytest test__heartbeat_fields.py + test_claude_session.py` → **97/97 passed** (no regression on the broader heartbeat writer).

## Test plan

- [ ] CI green.
- [ ] After merge: `cat <state_dir>/heartbeat.json | jq` on any running agent shows the three new keys.
- [ ] Operator status flows (agent_status --json, MCP sidecar dashboard) that already read `heartbeat.json` see the fields without code change.