### PR TITLE
feat(claude_md): inject Todo Store Conventions section per-agent (P3a-3)

### DIFF
--- a/src/scitex_agent_container/runtimes/claude_md.py
+++ b/src/scitex_agent_container/runtimes/claude_md.py
@@ -343,6 +343,12 @@ def setup_claude_md(config: AgentConfig, workdir: str) -> None:
     if role:
         lines.append(f"- Role: {role}")
     lines.append(f"- ID: {agent_env_id}")
+    lines.append("")
+    lines.append("### Todo Store Conventions")
+    lines.append(
+        f'- Default scope for scitex-todo writes: `scope="agent:{agent_env_id}"`.'
+    )
+    lines.append("- See `_base/to_home/CLAUDE.md` for the full convention.")
     lines.append(f'<!-- agent-container:end id="{agent_id}" -->')
 
     section = "\n".join(lines)

--- a/tests/scitex_agent_container/runtimes/test_claude_md.py
+++ b/tests/scitex_agent_container/runtimes/test_claude_md.py
@@ -577,6 +577,29 @@ def test_setup_no_role_when_unset(tmp_path):
     assert "Role:" not in (tmp_path / ".claude" / "CLAUDE.md").read_text()
 
 
+def test_setup_emits_todo_store_conventions_section(tmp_path):
+    # Arrange
+    cfg = _cfg(name="todo-section")
+    # Act
+    setup_claude_md(cfg, str(tmp_path))
+    # Assert
+    assert (
+        "### Todo Store Conventions" in (tmp_path / ".claude" / "CLAUDE.md").read_text()
+    )
+
+
+def test_setup_todo_scope_substitutes_agent_id(tmp_path):
+    # Arrange
+    cfg = _cfg(name="alpha")
+    cfg.env = {"SCITEX_AGENT_CONTAINER_ID": "alpha-prime"}
+    # Act
+    setup_claude_md(cfg, str(tmp_path))
+    # Assert
+    assert (
+        'scope="agent:alpha-prime"' in (tmp_path / ".claude" / "CLAUDE.md").read_text()
+    )
+
+
 # ---------------------------------------------------------------------------
 # cleanup_claude_md
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

P3a-3 (lead-approved task #20, operator directive `feedback_scitex_todo_single_shared_store`). Programmatically substitutes the agent's own name into a `scope=agent:<name>` recommendation in the auto-generated CLAUDE.md section so the fleet-shared scitex-todo board stays readable.

Closes the documentation half of the P3a unlock:
- **P3a** (MCP wiring) — fragment delivered to lead for dotfiles landing.
- **P3a-2** (#365) — bind-mount of `~/.scitex/todo` shipped fleet-wide.
- **P3a-1.5** (#366) — `scitex-todo[mcp]` in apptainer-base.def.
- **P3a-3 (this PR)** — every agent's CLAUDE.md programmatically tells the agent to scope its writes.

## Source change

`runtimes/claude_md.py:setup_claude_md` — after the existing `### Agent Role` block, append `### Todo Store Conventions` substituting `agent_env_id` (the agent's name as `$SCITEX_AGENT_CONTAINER_ID`):

```
### Todo Store Conventions
- Default scope for scitex-todo writes: `scope="agent:<agent_env_id>"`.
- See `_base/to_home/CLAUDE.md` for the full convention.
```

The existing `<!-- agent-container:start/end -->` HTML-comment delimiters stay intact so the block is rewritable on subsequent starts.

## Tests

Existing `tests/scitex_agent_container/runtimes/test_claude_md.py` extended with 2 new tests covering the new section (no mocks, real `tmp_path`):
- the rendered CLAUDE.md carries the `### Todo Store Conventions` header
- the substituted agent name appears in the scope recommendation

Local: 51/51 passed.

## Process note

Originally launched as a bg subagent (operator-driven fan-out wave). The subagent stalled mid-task (lead-learnings/07 — write subagents acknowledge then exit before commit). Recovered + finalized inline.