### PR TITLE
feat(runners): sum subagent jsonl deltas in heartbeat (close #370 caveat)

### DIFF
--- a/src/scitex_agent_container/_runners/_heartbeat_fields.py
+++ b/src/scitex_agent_container/_runners/_heartbeat_fields.py
@@ -19,13 +19,32 @@ liveness ts so a single heartbeat read answers both. Fields:
     truncate can't mislead with a negative.
   * ``seconds_since_last_beat``  — wall-clock gap to the prior beat.
 
-CAVEAT — subagent/background work writes to a SUBAGENT jsonl, NOT
-the main ``session.jsonl``. An active subagent + idle main session
-therefore shows ``delta=0`` on the main beat (the false-idle hit
-live on dev/todo flat-main while bg scanners ran). A follow-up PR
-can opt into summing per-subagent jsonl deltas — deferred so the
-operator can decide when the extra walk-I/O cost is worth the
-precision.
+Subagent / background-work productivity (false-idle gap CLOSED for
+the layouts below):
+
+  * ``subagent_jsonl_bytes``       — summed size of every candidate
+    subagent jsonl found under ``state_dir`` (see below).
+  * ``subagent_jsonl_delta_bytes`` — delta vs the PRIOR beat's
+    ``subagent_jsonl_bytes``, clamped to >=0.
+
+Both fields are ABSENT (not zero) when no candidate dir exists at
+all — so the operator can distinguish "no subagent infrastructure
+on this agent" from "subagents present but idle this beat".
+
+Candidate layouts walked (``Path.glob``, stat-only, per-file
+``OSError`` swallowed):
+
+  * ``<state_dir>/subagents/*/session.jsonl`` — Claude Code sub-task
+    sessions (one dir per spawned subagent).
+  * ``<state_dir>/.tasks/*/output``           — sac background-task
+    output files (dotfile layout).
+  * ``<state_dir>/tasks/*/output``            — sac background-task
+    output files (non-dot layout).
+
+This closes the false-idle CAVEAT from PR #370: an active subagent
++ idle main session now surfaces as a positive
+``subagent_jsonl_delta_bytes`` instead of a misleading zero on the
+main ``session_jsonl_delta_bytes``.
 """
 
 from __future__ import annotations
@@ -34,6 +53,40 @@ import json
 from pathlib import Path
 
 __all__ = ["heartbeat_jsonl_fields"]
+
+
+# Subagent / background-work jsonl candidate globs (relative to state_dir).
+# Walked stat-only — never read. See module docstring for rationale.
+_SUBAGENT_JSONL_GLOBS: tuple[str, ...] = (
+    "subagents/*/session.jsonl",
+    ".tasks/*/output",
+    "tasks/*/output",
+)
+
+
+def _sum_subagent_jsonl_bytes(state_dir: Path) -> int | None:
+    """Sum file sizes for every candidate subagent jsonl under ``state_dir``.
+
+    Returns ``None`` when NO candidate path produced any match — the
+    caller turns that into ABSENT keys so the operator can distinguish
+    "no subagent infrastructure" from "subagents present but idle".
+    Per-file ``OSError`` is swallowed (a racing rotate during the
+    walk must not mask the rest of the productivity signal).
+    """
+    found = False
+    total = 0
+    for pattern in _SUBAGENT_JSONL_GLOBS:
+        try:
+            matches = list(state_dir.glob(pattern))
+        except OSError:
+            continue
+        for path in matches:
+            found = True
+            try:
+                total += path.stat().st_size
+            except OSError:
+                continue
+    return total if found else None
 
 
 def heartbeat_jsonl_fields(state_dir: Path, now: float) -> dict:
@@ -52,6 +105,13 @@ def heartbeat_jsonl_fields(state_dir: Path, now: float) -> dict:
     except OSError:
         return out
     out["session_jsonl_bytes"] = int(current_bytes)
+    # Subagent walk runs even if prior heartbeat read fails below — the
+    # current-size signal is independently useful (operator sees
+    # subagent output now, even on first beat or after a corrupted
+    # prior heartbeat.json).
+    subagent_bytes = _sum_subagent_jsonl_bytes(state_dir)
+    if subagent_bytes is not None:
+        out["subagent_jsonl_bytes"] = int(subagent_bytes)
     prior_path = state_dir / "heartbeat.json"
     try:
         prior_text = prior_path.read_text(encoding="utf-8")
@@ -70,4 +130,12 @@ def heartbeat_jsonl_fields(state_dir: Path, now: float) -> dict:
         # would otherwise produce a negative delta and mislead the
         # operator into thinking the agent destroyed work.
         out["session_jsonl_delta_bytes"] = max(0, int(current_bytes) - prior_bytes)
+    if subagent_bytes is not None:
+        prior_subagent = prior.get("subagent_jsonl_bytes")
+        if isinstance(prior_subagent, int) and prior_subagent >= 0:
+            # Clamp >=0 — subagent rotate / dir cleanup between beats
+            # would otherwise surface as a misleading negative.
+            out["subagent_jsonl_delta_bytes"] = max(
+                0, int(subagent_bytes) - prior_subagent
+            )
     return out

--- a/tests/scitex_agent_container/_runners/test__heartbeat_fields.py
+++ b/tests/scitex_agent_container/_runners/test__heartbeat_fields.py
@@ -29,6 +29,21 @@ def _write_jsonl(state_dir: Path, *, size: int) -> None:
     (state_dir / "session.jsonl").write_bytes(b"x" * size)
 
 
+def _write_subagent_session(state_dir: Path, *, name: str, size: int) -> None:
+    sub = state_dir / "subagents" / name
+    sub.mkdir(parents=True, exist_ok=True)
+    (sub / "session.jsonl").write_bytes(b"y" * size)
+
+
+def _write_task_output(
+    state_dir: Path, *, layout: str, task_id: str, size: int
+) -> None:
+    # layout is ".tasks" or "tasks"
+    task = state_dir / layout / task_id
+    task.mkdir(parents=True, exist_ok=True)
+    (task / "output").write_bytes(b"z" * size)
+
+
 # ---------------------------------------------------------------------------
 # session_jsonl_bytes
 # ---------------------------------------------------------------------------
@@ -159,3 +174,95 @@ def test_missing_session_jsonl_returns_zero_not_error(tmp_path: Path) -> None:
     fields = heartbeat_jsonl_fields(tmp_path, now=100.0)
     # Assert
     assert fields["session_jsonl_bytes"] == 0
+
+
+# ---------------------------------------------------------------------------
+# subagent_jsonl_bytes / subagent_jsonl_delta_bytes
+#
+# Closes the PR #370 false-idle CAVEAT: an active subagent + idle main
+# beat used to show ``delta=0``; now the operator sees the subagent
+# production summed across every candidate layout.
+# ---------------------------------------------------------------------------
+
+
+def test_subagent_keys_absent_when_no_subagent_dirs_exist(tmp_path: Path) -> None:
+    # Arrange — only the main session.jsonl; no subagents/, .tasks/, tasks/.
+    _write_jsonl(tmp_path, size=1000)
+    # Act
+    fields = heartbeat_jsonl_fields(tmp_path, now=100.0)
+    # Assert — ABSENT (not zero) so operator distinguishes "no
+    # subagent infra" from "subagents present but idle".
+    assert (
+        "subagent_jsonl_bytes" not in fields
+        and "subagent_jsonl_delta_bytes" not in fields
+    )
+
+
+def test_subagent_jsonl_bytes_sums_subagents_layout(tmp_path: Path) -> None:
+    # Arrange — two subagent dirs under subagents/<name>/session.jsonl.
+    _write_jsonl(tmp_path, size=0)
+    _write_subagent_session(tmp_path, name="sub-a", size=300)
+    _write_subagent_session(tmp_path, name="sub-b", size=700)
+    # Act
+    fields = heartbeat_jsonl_fields(tmp_path, now=100.0)
+    # Assert
+    assert fields["subagent_jsonl_bytes"] == 1000
+
+
+def test_subagent_jsonl_bytes_sums_all_three_layouts(tmp_path: Path) -> None:
+    # Arrange — one file per supported layout, simultaneously present.
+    _write_jsonl(tmp_path, size=0)
+    _write_subagent_session(tmp_path, name="sub-1", size=100)
+    _write_task_output(tmp_path, layout=".tasks", task_id="t-dot", size=200)
+    _write_task_output(tmp_path, layout="tasks", task_id="t-plain", size=400)
+    # Act
+    fields = heartbeat_jsonl_fields(tmp_path, now=100.0)
+    # Assert — 100 + 200 + 400 across the three candidate globs.
+    assert fields["subagent_jsonl_bytes"] == 700
+
+
+def test_subagent_delta_bytes_matches_sum_growth(tmp_path: Path) -> None:
+    # Arrange — prior beat saw subagent total of 500; now files sum to 1200.
+    _write_jsonl(tmp_path, size=0)
+    _write_subagent_session(tmp_path, name="sub-a", size=800)
+    _write_task_output(tmp_path, layout="tasks", task_id="t1", size=400)
+    (tmp_path / "heartbeat.json").write_text(
+        json.dumps({"ts": 90.0, "session_jsonl_bytes": 0, "subagent_jsonl_bytes": 500}),
+        encoding="utf-8",
+    )
+    # Act
+    fields = heartbeat_jsonl_fields(tmp_path, now=100.0)
+    # Assert — 800 + 400 - 500 == 700.
+    assert fields["subagent_jsonl_delta_bytes"] == 700
+
+
+def test_subagent_delta_clamped_to_zero_on_rotate(tmp_path: Path) -> None:
+    # Arrange — prior saw 5000 subagent bytes; a subagent dir got cleaned
+    # up and current sums to 100. Negative delta would mislead operator.
+    _write_jsonl(tmp_path, size=0)
+    _write_subagent_session(tmp_path, name="sub-survivor", size=100)
+    (tmp_path / "heartbeat.json").write_text(
+        json.dumps(
+            {"ts": 90.0, "session_jsonl_bytes": 0, "subagent_jsonl_bytes": 5000}
+        ),
+        encoding="utf-8",
+    )
+    # Act
+    fields = heartbeat_jsonl_fields(tmp_path, now=100.0)
+    # Assert
+    assert fields["subagent_jsonl_delta_bytes"] == 0
+
+
+def test_subagent_delta_absent_when_no_prior_subagent_bytes(tmp_path: Path) -> None:
+    # Arrange — prior heartbeat exists but pre-dates the new field; the
+    # delta cannot be computed and must be ABSENT (not a misleading 0).
+    _write_jsonl(tmp_path, size=0)
+    _write_subagent_session(tmp_path, name="sub-a", size=300)
+    _write_prior_beat(tmp_path, ts=90.0, jsonl_bytes=0)
+    # Act
+    fields = heartbeat_jsonl_fields(tmp_path, now=100.0)
+    # Assert — current size IS reported, delta is not.
+    assert (
+        fields["subagent_jsonl_bytes"] == 300
+        and "subagent_jsonl_delta_bytes" not in fields
+    )


### PR DESCRIPTION
## Summary

Closes the false-idle CAVEAT documented in just-merged #370. The helper
`_runners/_heartbeat_fields.heartbeat_jsonl_fields` previously only
reported `session_jsonl_bytes` / `session_jsonl_delta_bytes` for the
MAIN session. Subagent / background work writes to a SUBAGENT jsonl,
NOT the main one, so an active subagent + idle main session showed
`delta=0` on the main beat — false-idle.

This PR walks subagent jsonl candidates under `state_dir` and reports
sum totals so the operator sees production from subagents alongside
main-session signals.

New fields on `heartbeat_jsonl_fields` output (ABSENT, not zero, when
no candidate dir exists — distinguishable from idle):
- `subagent_jsonl_bytes` — sum of all candidate sizes now
- `subagent_jsonl_delta_bytes` — delta vs prior beat, clamped >=0

Candidate layouts walked (`Path.glob`, stat-only, per-file `OSError`
swallowed):
- `<state_dir>/subagents/*/session.jsonl` — Claude Code sub-task sessions
- `<state_dir>/.tasks/*/output`           — sac bg-task (dot layout)
- `<state_dir>/tasks/*/output`            — sac bg-task (non-dot layout)

The subagent walk runs even when the prior `heartbeat.json` is missing
or corrupted — current-beat sum stays observable. The delta is only
emitted when the prior beat carries the new field, so pre-existing
prior records yield ABSENT delta (not a misleading zero) on the first
upgraded beat.

## Test plan

- [x] `PYTHONPATH=src pytest tests/scitex_agent_container/_runners/test__heartbeat_fields.py -q --no-cov` => 17 / 17 passed (11 prior + 6 new)
- [x] No regression on prior tests for `session_jsonl_*` fields
- [x] 6 new STX-TQ002 AAA + STX-TQ007 one-assert tests, no mocks, real `tmp_path`:
  - subagent keys ABSENT when no candidate dir exists
  - `subagents/<name>/session.jsonl` layout summed
  - all three layouts summed simultaneously
  - delta matches sum growth across multiple layouts
  - delta clamped to 0 on rotate / dir cleanup
  - delta ABSENT when prior beat pre-dates the field (back-compat)
- [x] Module docstring CAVEAT rewritten to note the gap is now CLOSED for the three documented layouts
- [x] Both touched files stay well under the 512-line cap

Cross-ref: #370 (deferred follow-up).