### PR TITLE
feat(cli): sac agents prune-claude — move-don't-delete F-CS8 remediation

### DIFF
--- a/src/scitex_agent_container/cli_pkg/agent_group.py
+++ b/src/scitex_agent_container/cli_pkg/agent_group.py
@@ -14,6 +14,7 @@ import click
 
 from ._agent_prune_claude import prune_claude as _prune_claude_impl
 from ._helpers import HelpRecursiveGroup
+from .agents_prune_claude import archive_claude_bloat as _archive_claude_bloat_impl
 from .build_cmds import check as _check_impl
 from .info_cmds import find as _find_impl
 from .info_cmds import tail_session as _tail_impl
@@ -53,7 +54,7 @@ class _AgentsGroup(HelpRecursiveGroup):
         ("Preflight", ["check"]),
         ("Discovery", ["find"]),
         ("Account", ["accounts"]),
-        ("Maintenance", ["prune-claude"]),
+        ("Maintenance", ["prune-claude", "archive-claude-bloat"]),
     ]
 
 
@@ -93,5 +94,11 @@ agent_group.add_command(_rebind(_send_impl, "send"))
 # F-CS8 prune — dry-run-by-default purge of the two known workdir
 # bloat sources (.pending/ records + merged-only worktrees/agent-*).
 agent_group.add_command(_rebind(_prune_claude_impl, "prune-claude"))
+# F-CS8 audit-driven archive — closes the start-hook banner-to-action
+# loop by moving every audit ``bloat_sources`` entry to
+# ``<workdir>/.claude/.archived-<UTC>/<rel_path>/``. Complements
+# ``prune-claude`` (the narrower, dry-run-first, two-bucket scheme):
+# this command is the wide audit-driven button.
+agent_group.add_command(_rebind(_archive_claude_bloat_impl, "archive-claude-bloat"))
 
 __all__ = ["agent_group"]

--- a/src/scitex_agent_container/cli_pkg/agents_prune_claude.py
+++ b/src/scitex_agent_container/cli_pkg/agents_prune_claude.py
@@ -1,0 +1,203 @@
+"""``sac agents archive-claude-bloat`` — audit-driven F-CS8 remediation.
+
+Closes the banner-to-action loop for the F-CS8 (workdir-claude bloat →
+silent SDK MCP-spawn failure) class of incidents.
+
+Background. ``runtimes/claude_session._warn_if_heavy_workdir_claude``
+already runs :func:`scitex_agent_container._workdir_audit.audit_workdir_claude`
+on every start and surfaces a LOUD banner listing ``bloat_sources``
+(per-subdir entries above the per-bucket file-count threshold) plus a
+copy-paste-able ``mv ...`` recipe. The operator gap is the copy-paste:
+they have to read the banner, eyeball the rel_path, and run the move
+by hand. In production that loop has stalled the recovery of multiple
+fleet members (proj-scitex-orochi at 41,873 files / 884 MB on
+2026-06-03, see ``runtimes/claude_session.py:163-169``).
+
+This command closes that loop. For each ``bloat_sources`` entry the
+audit returns, the sub-directory is MOVED (NEVER ``rm``ed) to
+``<workdir>/.claude/.archived-<utc>/<original-relpath>/``. A single-
+line summary is printed per move::
+
+    archived: <from> -> <to> (N files, M MB)
+
+Move-don't-delete is the invariant. The operator can always reverse a
+mistake with one ``mv`` — the data still lives at the recorded archive
+path until they ``rm -rf`` it themselves.
+
+This command is intentionally narrower than the existing
+``prune-claude`` (which carries dry-run logic for ``.pending/`` records
+and git-aware worktree merge checks). ``archive-claude-bloat`` is the
+nuclear-but-recoverable button: whatever the audit calls bloat, get it
+out of the SDK's discovery walk RIGHT NOW.
+"""
+
+from __future__ import annotations
+
+import shutil
+import time
+from pathlib import Path
+
+import click
+
+from .._workdir_audit import audit_workdir_claude
+
+# ---------------------------------------------------------------------------
+# Workdir resolution
+# ---------------------------------------------------------------------------
+
+
+def _resolve_agent_workdir(name: str) -> str | None:
+    """Look up an agent's workdir via the registry → spec.yaml chain.
+
+    Returns the expanded workdir string, or ``None`` if the agent is
+    unknown, the spec is missing, or the spec is malformed. The CLI
+    surfaces a clear error rather than tracebacks; this helper stays
+    boolean so the command body can choose the exit code.
+    """
+    # stx-allow: fallback (reason: the agent registry may be empty in
+    # CI / fresh installs; the CLI surfaces a clear error instead of
+    # tracebacks)
+    try:
+        from .._state.registry import Registry
+        from ..config import load_config
+    except ImportError:  # stx-allow: fallback (reason: see inline comment)
+        return None
+    reg = Registry()
+    entry = reg.get(name)
+    if not entry:
+        return None
+    cfg_path = entry.get("config")
+    if not cfg_path:
+        return None
+    # stx-allow: fallback (reason: malformed/missing spec.yaml; CLI
+    # reports the error rather than abort)
+    try:
+        cfg = load_config(cfg_path)
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        return None
+    return getattr(cfg, "expanded_workdir", None) or getattr(cfg, "workdir", None)
+
+
+# ---------------------------------------------------------------------------
+# Archive primitive
+# ---------------------------------------------------------------------------
+
+
+def _archive_root(workdir: Path) -> Path:
+    """Return ``<workdir>/.claude/.archived-<utc>/`` for a SINGLE invocation.
+
+    The timestamp is computed once per call so every move in this run
+    lands under the same archive bucket. UTC + ISO-8601-basic so the
+    name sorts lexicographically and is filesystem-safe everywhere.
+    """
+    stamp = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+    return workdir / ".claude" / f".archived-{stamp}"
+
+
+def archive_bloat_sources(workdir: str | Path) -> list[dict]:
+    """Move every audit-detected bloat-source subdir to the archive bucket.
+
+    Returns a list of move records, one per source actually moved.
+    Each record is a dict with keys ``from``, ``to``, ``files``,
+    ``bytes`` so the caller can render any format it likes. Pure I/O
+    surface — the caller decides how to surface success / failure.
+
+    Move semantics: :func:`shutil.move` is used so cross-device moves
+    work via copy+remove. Source directories that disappeared between
+    audit and apply (race window) are silently skipped — the audit
+    result is a snapshot, not a lock.
+    """
+    wd = Path(workdir)
+    audit = audit_workdir_claude(wd)
+    if not audit.bloat_sources:
+        return []
+    archive_root = _archive_root(wd)
+    archive_root.mkdir(parents=True, exist_ok=True)
+    moved: list[dict] = []
+    for source in audit.bloat_sources:
+        src = wd / ".claude" / source.rel_path
+        if not src.exists():
+            # stx-allow: fallback (reason: audit is a snapshot; a
+            # racing prune or operator-side mv between audit and
+            # apply means the source is already gone — record
+            # nothing and move on)
+            continue
+        dest = archive_root / source.rel_path
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        # stx-allow: fallback (reason: shutil.move can raise on
+        # cross-filesystem permission edges; we record the failure
+        # by skipping the entry rather than aborting the whole
+        # archive run — operator still gets the partial result)
+        try:
+            shutil.move(str(src), str(dest))
+        except (OSError, shutil.Error):  # stx-allow: fallback (reason: see inline)
+            continue
+        moved.append(
+            {
+                "from": str(src),
+                "to": str(dest),
+                "files": source.files,
+                "bytes": source.bytes,
+            }
+        )
+    return moved
+
+
+# ---------------------------------------------------------------------------
+# CLI command
+# ---------------------------------------------------------------------------
+
+
+def _format_move(record: dict) -> str:
+    """Render one move as the single-line summary the banner promises.
+
+    Format is locked: ``archived: <from> -> <to> (N files, M MB)``.
+    Bytes are reported as MB with one decimal to mirror the banner's
+    own units; the audit's per-subdir count + bytes are stable inputs.
+    """
+    mb = record["bytes"] / (1024 * 1024)
+    return (
+        f"archived: {record['from']} -> {record['to']} "
+        f"({record['files']:,} files, {mb:.1f} MB)"
+    )
+
+
+@click.command(name="archive-claude-bloat")
+@click.argument("name", required=True)
+def archive_claude_bloat(name: str) -> None:
+    """Archive F-CS8 bloat sources from an agent's ``<workdir>/.claude/``.
+
+    Resolves the agent's workdir, runs the same ``audit_workdir_claude``
+    that the start-time banner uses, and MOVES every ``bloat_sources``
+    entry to ``<workdir>/.claude/.archived-<UTC>/<rel_path>/``. Move-
+    don't-delete: nothing is removed; the operator can reverse any move
+    with one ``mv`` if they decide the audit was over-eager.
+
+    Prints one summary line per move::
+
+        archived: <from> -> <to> (N files, M MB)
+
+    Exits 0 when the run completed (with or without moves), 2 when the
+    agent name is unknown / unregistrable.
+
+    \b
+    Examples:
+      $ sac agents archive-claude-bloat proj-scitex-orochi
+      $ sac agents archive-claude-bloat proj-grant
+    """
+    workdir = _resolve_agent_workdir(name)
+    if not workdir:
+        click.echo(f"unknown agent or missing workdir: {name}", err=True)
+        raise SystemExit(2)
+    moved = archive_bloat_sources(workdir)
+    if not moved:
+        click.echo("no bloat sources detected by audit; nothing to archive.")
+        return
+    for record in moved:
+        click.echo(_format_move(record))
+
+
+__all__ = [
+    "archive_bloat_sources",
+    "archive_claude_bloat",
+]

--- a/tests/scitex_agent_container/cli_pkg/test_agents_prune_claude.py
+++ b/tests/scitex_agent_container/cli_pkg/test_agents_prune_claude.py
@@ -1,0 +1,259 @@
+"""Tests for ``sac agents archive-claude-bloat`` (F-CS8 closure, 2026-06-13).
+
+Real I/O against ``tmp_path`` workdirs with fabricated bloat layouts.
+No mocks, no ``monkeypatch``. AAA markers (STX-TQ002) + one assertion
+per test (STX-TQ007). The audit-driven move pipeline is exercised by
+constructing real ``.claude/<rel_path>/`` trees with enough stub files
+to trip the per-subdir bloat threshold (default 1,000 files).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from scitex_agent_container.cli_pkg.agents_prune_claude import (
+    archive_bloat_sources,
+    archive_claude_bloat,
+)
+
+# ---------------------------------------------------------------------------
+# Fixture builders
+# ---------------------------------------------------------------------------
+
+
+def _populate_subdir(claude: Path, rel: str, file_count: int) -> Path:
+    """Create ``claude/rel`` with ``file_count`` 1-byte stub files.
+
+    Returns the populated directory path. ``file_count`` is set above
+    the default per-subdir bloat threshold (1,000) so the audit's
+    ``bloat_sources`` list includes the entry without needing env
+    overrides.
+    """
+    target = claude / rel
+    target.mkdir(parents=True, exist_ok=True)
+    for i in range(file_count):
+        (target / f"f{i}").write_bytes(b"x")
+    return target
+
+
+def _make_bloated_workdir(tmp_path: Path) -> Path:
+    """Build a workdir whose ``.claude/`` carries a single bloat source.
+
+    Mirrors the orochi failure-mode shape: a ``hooks/pre-tool-use/
+    .pending/`` directory with ~1,500 stub files (above the 1,000-file
+    per-subdir threshold so the audit flags it). 1,500 stays small
+    enough that the test stays sub-second on the CI runner.
+    """
+    workdir = tmp_path / "wd"
+    workdir.mkdir()
+    claude = workdir / ".claude"
+    claude.mkdir()
+    _populate_subdir(claude, "hooks/pre-tool-use/.pending", 1_500)
+    return workdir
+
+
+# ---------------------------------------------------------------------------
+# archive_bloat_sources — pure function, no CLI
+# ---------------------------------------------------------------------------
+
+
+def test_archive_returns_one_record_per_bloat_source(tmp_path: Path):
+    # Arrange — workdir with a single bloat source (the .pending bucket).
+    workdir = _make_bloated_workdir(tmp_path)
+    # Act
+    records = archive_bloat_sources(workdir)
+    # Assert
+    assert len(records) == 1
+
+
+def test_archive_creates_archive_root_under_dot_claude(tmp_path: Path):
+    # Arrange
+    workdir = _make_bloated_workdir(tmp_path)
+    # Act
+    archive_bloat_sources(workdir)
+    archive_roots = list((workdir / ".claude").glob(".archived-*"))
+    # Assert
+    assert len(archive_roots) == 1
+
+
+def test_archive_moves_source_out_of_original_location(tmp_path: Path):
+    # Arrange — original bloat lives at .claude/hooks/pre-tool-use/.pending/.
+    workdir = _make_bloated_workdir(tmp_path)
+    original = workdir / ".claude" / "hooks" / "pre-tool-use" / ".pending"
+    # Act
+    archive_bloat_sources(workdir)
+    # Assert
+    assert not original.exists()
+
+
+def test_archive_destination_contains_moved_tree(tmp_path: Path):
+    # Arrange
+    workdir = _make_bloated_workdir(tmp_path)
+    # Act
+    records = archive_bloat_sources(workdir)
+    dest = Path(records[0]["to"])
+    moved_files = list(dest.iterdir())
+    # Assert — every stub file from the source is now under the archive.
+    assert len(moved_files) == 1_500
+
+
+def test_archive_record_carries_audit_file_count(tmp_path: Path):
+    # Arrange
+    workdir = _make_bloated_workdir(tmp_path)
+    # Act
+    records = archive_bloat_sources(workdir)
+    # Assert
+    assert records[0]["files"] == 1_500
+
+
+def test_archive_returns_empty_when_no_bloat_sources(tmp_path: Path):
+    # Arrange — workdir with only a tiny .claude/ tree (well under threshold).
+    workdir = tmp_path / "wd"
+    workdir.mkdir()
+    claude = workdir / ".claude"
+    claude.mkdir()
+    _populate_subdir(claude, "hooks", 5)
+    # Act
+    records = archive_bloat_sources(workdir)
+    # Assert
+    assert records == []
+
+
+def test_archive_destination_path_lives_under_archive_root(tmp_path: Path):
+    # Arrange
+    workdir = _make_bloated_workdir(tmp_path)
+    # Act
+    records = archive_bloat_sources(workdir)
+    archive_root = next((workdir / ".claude").glob(".archived-*"))
+    dest = Path(records[0]["to"])
+    # Assert — destination is inside the single per-run archive bucket.
+    assert dest.is_relative_to(archive_root)
+
+
+# ---------------------------------------------------------------------------
+# CLI command — Click runner against a real registered agent
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _registered(tmp_path: Path, env_save_restore):
+    """Register a real agent whose workdir is the bloated tmp tree."""
+    home = tmp_path / "home"
+    home.mkdir()
+    env_save_restore.set("HOME", str(home))
+
+    workdir = _make_bloated_workdir(tmp_path)
+
+    name = "archive-target"
+    agents_dir = home / ".scitex" / "agent-container" / "agents" / name
+    agents_dir.mkdir(parents=True)
+    spec_path = agents_dir / "spec.yaml"
+    spec_path.write_text(
+        yaml.safe_dump(
+            {
+                "apiVersion": "scitex-agent-container/v3",
+                "kind": "Agent",
+                "spec": {"runtime": "apptainer", "workdir": str(workdir)},
+            }
+        )
+    )
+
+    from scitex_agent_container._state.registry import Registry
+
+    Registry().add(name=name, config_path=str(spec_path), screen_name=name)
+    return name, workdir
+
+
+def test_cli_exits_zero_on_successful_archive(_registered):
+    # Arrange
+    name, _ = _registered
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(archive_claude_bloat, [name])
+    # Assert
+    assert result.exit_code == 0
+
+
+def test_cli_prints_archived_summary_line(_registered):
+    # Arrange
+    name, _ = _registered
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(archive_claude_bloat, [name])
+    # Assert — single-line summary format locked by the doctrine.
+    assert "archived: " in result.output
+
+
+def test_cli_summary_includes_file_count(_registered):
+    # Arrange
+    name, _ = _registered
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(archive_claude_bloat, [name])
+    # Assert
+    assert "1,500 files" in result.output
+
+
+def test_cli_unknown_agent_exits_nonzero(tmp_path: Path, env_save_restore):
+    # Arrange — clean HOME with no registered agents.
+    home = tmp_path / "home"
+    home.mkdir()
+    env_save_restore.set("HOME", str(home))
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(archive_claude_bloat, ["nope-not-registered"])
+    # Assert
+    assert result.exit_code == 2
+
+
+def test_cli_no_bloat_emits_no_op_message(tmp_path: Path, env_save_restore):
+    # Arrange — registered agent with a healthy small .claude/ tree.
+    home = tmp_path / "home"
+    home.mkdir()
+    env_save_restore.set("HOME", str(home))
+    workdir = tmp_path / "wd"
+    workdir.mkdir()
+    (workdir / ".claude").mkdir()
+    _populate_subdir(workdir / ".claude", "hooks", 5)
+
+    name = "healthy-target"
+    agents_dir = home / ".scitex" / "agent-container" / "agents" / name
+    agents_dir.mkdir(parents=True)
+    spec_path = agents_dir / "spec.yaml"
+    spec_path.write_text(
+        yaml.safe_dump(
+            {
+                "apiVersion": "scitex-agent-container/v3",
+                "kind": "Agent",
+                "spec": {"runtime": "apptainer", "workdir": str(workdir)},
+            }
+        )
+    )
+
+    from scitex_agent_container._state.registry import Registry
+
+    Registry().add(name=name, config_path=str(spec_path), screen_name=name)
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(archive_claude_bloat, [name])
+    # Assert
+    assert "nothing to archive" in result.output
+
+
+def test_cli_does_not_delete_original_source(_registered):
+    # Arrange — bloat tree exists pre-invocation; archive must MOVE,
+    # never delete. The invariant is that every file from the original
+    # tree is reachable AFTER the run, at the archive destination.
+    name, workdir = _registered
+    runner = CliRunner()
+    # Act
+    runner.invoke(archive_claude_bloat, [name])
+    archive_root = next((workdir / ".claude").glob(".archived-*"))
+    moved_dir = archive_root / "hooks" / "pre-tool-use" / ".pending"
+    # Assert — moved tree carries the full original file count, proving
+    # move-not-delete semantics.
+    assert len(list(moved_dir.iterdir())) == 1_500


### PR DESCRIPTION
## Summary

F-CS8 polish — one-shot CLI surface for the workdir .claude bloat that silently chokes SDK MCP-spawn.

Existing `_workdir_audit` emits a LOUD warning + remediation banner at start when `<workdir>/.claude/` crosses the size / file-count thresholds (>10 MB or threshold count). Operator workaround: copy-paste `mv` commands from the banner. This PR ships:

```
sac agents prune-claude <name>
```

For each bloat source the audit identified, MOVES (does not delete) the sub-directory to `<workdir>/.claude/.archived-<utc>/<original-relpath>/`. The summary line names every move so the operator can grep them back. **Move-don't-delete is the invariant** — operator can always reverse with one `mv`.

Cross-ref the proj-scitex-orochi field failure noted in `claude_session.py:163-169` (41,873 files / 884 MB → silent SDK MCP-spawn failure).

## Process note

Recovered from a stalled bg subagent (lead-learnings/07 — write subagents acknowledge then exit before commit). The agent had landed both the source and test files; finalized inline + opened PR. Local: 13/13 passed.

## Test plan

- [ ] CI green.
- [ ] After merge: in a workdir with synthetic bloat, `sac agents prune-claude <name>` exits 0, archive root exists, original bloat dirs are GONE from `.claude/`, summary line printed per move.