### PR TITLE
feat(_runners): Anthropic auth token classifier (OAuth/api_key mismap defence)

### DIFF
--- a/src/scitex_agent_container/_runners/_anthropic_auth_classify.py
+++ b/src/scitex_agent_container/_runners/_anthropic_auth_classify.py
@@ -1,0 +1,155 @@
+"""Classify an Anthropic auth token by prefix; refuse OAuth-as-api-key.
+
+Fleet failure mode (lead, top-5):
+    *OAuth-token-as-api-key mismap.* When the agent's Anthropic auth
+    carries an OAuth token (``sk-ant-oat-...``) but the runner / SDK
+    mis-classifies it as an API key (``ANTHROPIC_API_KEY=<oat>``),
+    every request 401s silently and the agent goes "alive but
+    silent". The supervisor sees a running process; the operator
+    sees nothing — exactly the "alive but silent" stall.
+
+Background — the two Anthropic credential shapes:
+
+* **OAuth access token** — issued by ``claude login`` (Pro/Max). Prefix
+  ``sk-ant-oat-``. NOT a valid ``ANTHROPIC_API_KEY`` value; the API
+  rejects it as ``invalid api key``. The canonical wiring is the
+  ``.credentials.json`` file bound into the container at
+  ``CLAUDE_CONFIG_DIR=/tmp/sac-claude`` — the in-container SDK reads
+  the file directly and the OAuth flow rotates ``accessToken`` in
+  place. See ``runtimes/_apptainer_auth.py``.
+
+* **API key** — issued from the Anthropic console (pay-per-token).
+  Prefix ``sk-ant-api-``. This is what ``ANTHROPIC_API_KEY`` /
+  ``SAC_ANTHROPIC_API_KEY`` are for; the SDK uses the bare env var.
+
+This module is the prefix classifier + the defensive guard:
+
+* :func:`is_oauth_token` — True for ``sk-ant-oat-…``.
+* :func:`is_api_key`   — True for ``sk-ant-api-…``.
+* :func:`classify`     — returns ``"oauth"`` / ``"api_key"`` /
+  ``"unknown"`` (the explicit three-way so a caller can treat
+  "unknown" however its risk profile demands).
+* :func:`assert_api_key` — LOUDLY refuses an OAuth token in an
+  API-key slot. The error names the prefix it saw, names the
+  canonical remediation, and points at the credentials-bind path.
+
+Phase 1 lands the classifier + tests only. The caller wiring
+(injecting this guard into ``_apptainer_auth.auth_argv`` /
+``_state._preflight_creds`` so a misrouted OAuth token never reaches
+``ANTHROPIC_API_KEY=...``) is a follow-up PR.
+
+Pure stdlib, no SDK import — unit-testable as a pure prefix check.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+__all__ = [
+    "OAUTH_PREFIX",
+    "API_KEY_PREFIX",
+    "is_oauth_token",
+    "is_api_key",
+    "classify",
+    "assert_api_key",
+]
+
+# Canonical Anthropic credential prefixes (2026-06).
+#
+# These are stable enough to defend on — the OAuth/api-key split has
+# been the Anthropic shape since ``claude login`` shipped, and the
+# operator-facing remediation hinges on the user reading the prefix
+# correctly. If Anthropic adds a third shape, ``classify`` returns
+# ``"unknown"`` and ``assert_api_key`` accepts it (fail-open on
+# unrecognised; fail-closed only on the *known* OAuth shape, which
+# is the documented mismap).
+OAUTH_PREFIX = "sk-ant-oat-"
+API_KEY_PREFIX = "sk-ant-api-"
+
+
+def is_oauth_token(token: str) -> bool:
+    """Return True iff ``token`` is an Anthropic OAuth access token.
+
+    Recognised by the canonical ``sk-ant-oat-`` prefix. Whitespace is
+    stripped because operators routinely paste tokens with a trailing
+    newline; an OAuth token with surrounding whitespace is still an
+    OAuth token, and we must not accept it as an API key just because
+    the prefix check tripped on the leading space.
+    """
+    if not isinstance(token, str):
+        return False
+    return token.strip().startswith(OAUTH_PREFIX)
+
+
+def is_api_key(token: str) -> bool:
+    """Return True iff ``token`` is an Anthropic API key.
+
+    Recognised by the canonical ``sk-ant-api-`` prefix. Same
+    whitespace-strip rationale as :func:`is_oauth_token`.
+    """
+    if not isinstance(token, str):
+        return False
+    return token.strip().startswith(API_KEY_PREFIX)
+
+
+def classify(token: str) -> Literal["oauth", "api_key", "unknown"]:
+    """Classify ``token`` by its Anthropic credential prefix.
+
+    Returns ``"oauth"`` for the OAuth shape, ``"api_key"`` for the
+    API-key shape, ``"unknown"`` for anything else (including empty
+    strings, ``None``-coerced inputs, and future Anthropic prefixes
+    we don't yet recognise). The three-way return is deliberate:
+    callers that want fail-closed semantics ("only accept what we
+    explicitly recognise") can check ``== "api_key"``, while callers
+    that only want to defend against the known mismap can use
+    :func:`assert_api_key`.
+    """
+    if is_oauth_token(token):
+        return "oauth"
+    if is_api_key(token):
+        return "api_key"
+    return "unknown"
+
+
+def assert_api_key(token: str) -> None:
+    """Refuse to treat an OAuth token as an API key.
+
+    Raises :class:`ValueError` with a LOUD, structured operator-facing
+    message when ``token`` is an OAuth access token (``sk-ant-oat-…``)
+    but a caller is about to inject it as ``ANTHROPIC_API_KEY`` /
+    ``SAC_ANTHROPIC_API_KEY``. The error names:
+
+    * the prefix it saw (so the operator can grep their env / logs),
+    * the canonical remediation ("use SAC_ANTHROPIC_API_KEY only for
+      sk-ant-api-… tokens; the OAuth path is the credentials.json
+      bind"),
+    * the file the OAuth flow actually uses
+      (``~/.claude/.credentials.json`` bind at ``CLAUDE_CONFIG_DIR``).
+
+    Accepts ``sk-ant-api-…`` tokens silently (the intended shape) and
+    accepts the ``unknown`` bucket silently too — see :func:`classify`
+    for the fail-open rationale. The guard is *narrow*: only the known
+    OAuth shape is refused. Unknown shapes are passed through so a
+    future Anthropic prefix doesn't brick the fleet on upgrade day.
+    """
+    kind = classify(token)
+    if kind != "oauth":
+        return
+    # LOUD: name the prefix, name the env var, name the remediation,
+    # name the file. The operator must be able to fix this from the
+    # message alone, without grepping the codebase for the rule.
+    prefix_seen = token.strip()[: len(OAUTH_PREFIX)]
+    raise ValueError(
+        "Anthropic auth mismap: refusing to inject an OAuth token "
+        f"(prefix {prefix_seen!r}) as an API-key env var. "
+        "OAuth tokens (sk-ant-oat-…) are NOT valid ANTHROPIC_API_KEY / "
+        "SAC_ANTHROPIC_API_KEY values — the Anthropic API rejects them "
+        "as 'invalid api key' and the agent goes alive-but-silent. "
+        "Use SAC_ANTHROPIC_API_KEY only for sk-ant-api-… (console) "
+        "tokens; the OAuth path is the credentials.json bind "
+        "(~/.claude/.credentials.json mounted at "
+        "CLAUDE_CONFIG_DIR=/tmp/sac-claude). "
+        "If you ran `claude login` you have an OAuth token — drop the "
+        "ANTHROPIC_API_KEY env and let the credentials.json bind do "
+        "the work."
+    )

--- a/tests/scitex_agent_container/_runners/test__anthropic_auth_classify.py
+++ b/tests/scitex_agent_container/_runners/test__anthropic_auth_classify.py
@@ -102,30 +102,45 @@ class TestAssertApiKeyRefusesOauth:
     def test_oauth_token_raises_value_error(self) -> None:
         # Arrange
         token = "sk-ant-oat-01-IIIIIIII"
-        # Act / Assert
-        with pytest.raises(ValueError):
+        raised: BaseException | None = None
+        # Act
+        try:
             assert_api_key(token)
+        except ValueError as exc:  # stx-allow: test-capture (reason: STX-TQ002 splits Act from Assert; the helper is contracted to raise on OAuth.)
+            raised = exc
+        # Assert
+        assert isinstance(raised, ValueError)
 
     def test_oauth_error_message_names_the_canonical_env_var(self) -> None:
         # Arrange — operator-facing remediation must mention the env var
         # they have to drop, so a grep on the error finds the fix.
         token = "sk-ant-oat-01-JJJJJJJJ"
+        raised: BaseException | None = None
         # Act
-        with pytest.raises(ValueError) as excinfo:
+        try:
             assert_api_key(token)
+        except (
+            ValueError
+        ) as exc:  # stx-allow: test-capture (reason: STX-TQ002 splits Act from Assert.)
+            raised = exc
         # Assert
-        assert "SAC_ANTHROPIC_API_KEY" in str(excinfo.value)
+        assert raised is not None and "SAC_ANTHROPIC_API_KEY" in str(raised)
 
     def test_oauth_error_message_points_at_credentials_bind(self) -> None:
         # Arrange — the remediation is the credentials.json bind; the
         # error must name it so the operator knows where the OAuth
         # token actually belongs.
         token = "sk-ant-oat-01-KKKKKKKK"
+        raised: BaseException | None = None
         # Act
-        with pytest.raises(ValueError) as excinfo:
+        try:
             assert_api_key(token)
+        except (
+            ValueError
+        ) as exc:  # stx-allow: test-capture (reason: STX-TQ002 splits Act from Assert.)
+            raised = exc
         # Assert
-        assert "credentials.json" in str(excinfo.value)
+        assert raised is not None and "credentials.json" in str(raised)
 
 
 class TestAssertApiKeyAcceptsNonOauth:

--- a/tests/scitex_agent_container/_runners/test__anthropic_auth_classify.py
+++ b/tests/scitex_agent_container/_runners/test__anthropic_auth_classify.py
@@ -1,0 +1,169 @@
+"""Tests for the Anthropic auth-token prefix classifier.
+
+Guard purpose (see module docstring): defend against the
+"OAuth-token-as-api-key mismap" fleet failure mode. The classifier is
+a pure prefix check on the Anthropic credential shape:
+
+* ``sk-ant-oat-…`` → OAuth access token (from ``claude login``); the
+  canonical wiring is the ``.credentials.json`` bind, NOT an env var.
+* ``sk-ant-api-…`` → console API key; this is what
+  ``ANTHROPIC_API_KEY`` / ``SAC_ANTHROPIC_API_KEY`` are for.
+
+Style: STX-TQ002 AAA markers, STX-TQ007 one assert per test, no mocks
+(the classifier is a pure function — there is nothing to mock).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scitex_agent_container._runners._anthropic_auth_classify import (
+    API_KEY_PREFIX,
+    OAUTH_PREFIX,
+    assert_api_key,
+    classify,
+    is_api_key,
+    is_oauth_token,
+)
+
+
+class TestIsOauthToken:
+    """``sk-ant-oat-…`` tokens classify as OAuth; nothing else does."""
+
+    def test_oauth_prefix_is_recognised(self) -> None:
+        # Arrange
+        token = "sk-ant-oat-01-AAAAAAAA"
+        # Act
+        result = is_oauth_token(token)
+        # Assert
+        assert result is True
+
+    def test_api_key_prefix_is_not_oauth(self) -> None:
+        # Arrange
+        token = "sk-ant-api-03-BBBBBBBB"
+        # Act
+        result = is_oauth_token(token)
+        # Assert
+        assert result is False
+
+    def test_oauth_token_with_surrounding_whitespace_still_classifies(self) -> None:
+        # Arrange — operators routinely paste tokens with trailing \n.
+        token = "  sk-ant-oat-01-CCCCCCCC\n"
+        # Act
+        result = is_oauth_token(token)
+        # Assert
+        assert result is True
+
+
+class TestIsApiKey:
+    """``sk-ant-api-…`` tokens classify as API key; OAuth tokens do not."""
+
+    def test_api_key_prefix_is_recognised(self) -> None:
+        # Arrange
+        token = "sk-ant-api-03-DDDDDDDD"
+        # Act
+        result = is_api_key(token)
+        # Assert
+        assert result is True
+
+    def test_oauth_prefix_is_not_api_key(self) -> None:
+        # Arrange
+        token = "sk-ant-oat-01-EEEEEEEE"
+        # Act
+        result = is_api_key(token)
+        # Assert
+        assert result is False
+
+
+class TestClassify:
+    """Three-way return: oauth / api_key / unknown."""
+
+    @pytest.mark.parametrize(
+        ("token", "expected"),
+        [
+            ("sk-ant-oat-01-FFFFFFFF", "oauth"),
+            ("sk-ant-api-03-GGGGGGGG", "api_key"),
+            ("sk-something-else-HHHHHHHH", "unknown"),
+            ("", "unknown"),
+        ],
+    )
+    def test_prefix_maps_to_expected_bucket(self, token: str, expected: str) -> None:
+        # Arrange — token + expected come from parametrize.
+        bucket = expected
+        # Act
+        result = classify(token)
+        # Assert
+        assert result == bucket
+
+
+class TestAssertApiKeyRefusesOauth:
+    """``assert_api_key`` must raise — LOUDLY — on a known OAuth token."""
+
+    def test_oauth_token_raises_value_error(self) -> None:
+        # Arrange
+        token = "sk-ant-oat-01-IIIIIIII"
+        # Act / Assert
+        with pytest.raises(ValueError):
+            assert_api_key(token)
+
+    def test_oauth_error_message_names_the_canonical_env_var(self) -> None:
+        # Arrange — operator-facing remediation must mention the env var
+        # they have to drop, so a grep on the error finds the fix.
+        token = "sk-ant-oat-01-JJJJJJJJ"
+        # Act
+        with pytest.raises(ValueError) as excinfo:
+            assert_api_key(token)
+        # Assert
+        assert "SAC_ANTHROPIC_API_KEY" in str(excinfo.value)
+
+    def test_oauth_error_message_points_at_credentials_bind(self) -> None:
+        # Arrange — the remediation is the credentials.json bind; the
+        # error must name it so the operator knows where the OAuth
+        # token actually belongs.
+        token = "sk-ant-oat-01-KKKKKKKK"
+        # Act
+        with pytest.raises(ValueError) as excinfo:
+            assert_api_key(token)
+        # Assert
+        assert "credentials.json" in str(excinfo.value)
+
+
+class TestAssertApiKeyAcceptsNonOauth:
+    """``assert_api_key`` must NOT raise on API keys or unknown shapes."""
+
+    def test_api_key_is_accepted_silently(self) -> None:
+        # Arrange
+        token = "sk-ant-api-03-LLLLLLLL"
+        # Act
+        result = assert_api_key(token)
+        # Assert — function returns None on accept.
+        assert result is None
+
+    def test_unknown_shape_is_accepted_silently(self) -> None:
+        # Arrange — fail-open on unknown so a future Anthropic prefix
+        # doesn't brick the fleet on the day Anthropic ships it.
+        token = "sk-future-shape-MMMMMMMM"
+        # Act
+        result = assert_api_key(token)
+        # Assert
+        assert result is None
+
+
+class TestPrefixConstants:
+    """The exported prefix constants are the canonical Anthropic shapes."""
+
+    def test_oauth_prefix_is_canonical(self) -> None:
+        # Arrange
+        prefix = OAUTH_PREFIX
+        # Act
+        actual = str(prefix)
+        # Assert
+        assert actual == "sk-ant-oat-"
+
+    def test_api_key_prefix_is_canonical(self) -> None:
+        # Arrange
+        prefix = API_KEY_PREFIX
+        # Act
+        actual = str(prefix)
+        # Assert
+        assert actual == "sk-ant-api-"


### PR DESCRIPTION
## Summary

Phase 1 — lands the defensive classifier for the **OAuth-token-as-api-key mismap** fleet failure mode (lead's top-5):

- When the agent's Anthropic auth carries an OAuth token (`sk-ant-oat-...`) but the runner / SDK mis-classifies it as an API key (`ANTHROPIC_API_KEY=<oat>`), every request 401s silently and the agent goes "alive but silent" — the supervisor sees a running process, the operator sees nothing.

New module `src/scitex_agent_container/_runners/_anthropic_auth_classify.py`:

- `is_oauth_token(token)` / `is_api_key(token)` — canonical-prefix predicates (`sk-ant-oat-` / `sk-ant-api-`).
- `classify(token) -> Literal["oauth", "api_key", "unknown"]` — three-way bucket.
- `assert_api_key(token)` — LOUD `ValueError` on OAuth-in-API-key-slot, naming the prefix it saw, the env var (`SAC_ANTHROPIC_API_KEY`), and the canonical remediation (the `.credentials.json` bind at `CLAUDE_CONFIG_DIR=/tmp/sac-claude`). Fail-open on `unknown` so a future Anthropic prefix doesn't brick the fleet on upgrade day.

Pure stdlib, no SDK import. 16 unit tests cover each prefix shape, the LOUD-error contract, and the fail-open-on-unknown shape.

**Phase 1 only** — caller wiring (injecting this into `runtimes/_apptainer_auth.auth_argv` / `_state._preflight_creds` so a misrouted OAuth token never reaches `ANTHROPIC_API_KEY=...`) is a follow-up PR.

## Test plan

- [x] `PYTHONPATH=src pytest tests/scitex_agent_container/_runners/test__anthropic_auth_classify.py -q --no-cov` → 16 passed
- [x] Style: STX-TQ002 (AAA markers) + STX-TQ007 (one assert per test), no mocks (pure-function input)
- [ ] CI green on develop checks