### PR TITLE
feat(_lifecycle): kill orphan MCP children before restart (409 defence)

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_orphan_mcp_cleanup.py
+++ b/src/scitex_agent_container/_lifecycle/_orphan_mcp_cleanup.py
@@ -1,0 +1,244 @@
+"""Pre-start defence against orphaned MCP-server child processes.
+
+Operator-listed top fleet failure mode (bug "MCP-on-restart 409 orphan"):
+when an agent restarts, the previous ``claude-code-telegrammer`` poller
+(or any stdio-MCP server child) sometimes survives the SIGTERM the SDK
+sent it. The new poller then long-polls Telegram with ``getUpdates`` and
+the Bot API returns HTTP 409 Conflict ("terminated by other getUpdates
+request"). Operator-visible symptom: the operator sees "telegrammer
+dead, agent alive but silent" — claude is running fine but no Telegram
+inbound ever wakes it because the orphan stole the long-poll slot.
+
+Two angles addressed this class of bug:
+
+  1. Pre-stop SIGKILL after the SIGTERM grace — requires SDK cooperation
+     (claude-agent-sdk owns the child PID handle; sac can only see it
+     indirectly). Doable but coupled.
+  2. Pre-start orphan scan — purely operator-side defence. Scan
+     ``psutil.process_iter`` for processes whose env identifies them
+     as belonging to *this* agent name AND whose cmdline looks like an
+     MCP-server child, then SIGKILL them BEFORE the new runtime boots
+     its replacement poller. This module implements (2).
+
+Wired into :mod:`._start.agent_start` immediately before the
+``runtime.start(config, ...)`` call, AFTER the singleton check and
+forced-stop teardown. By that point any "expected" stdio child should
+already be gone — anything still alive matching the agent name is an
+orphan by definition.
+
+Hard guarantees:
+
+  * NEVER raises. Orphan cleanup is best-effort defence; a wedged
+    psutil import / a permission-denied process must NOT block start.
+    The caller proceeds whether this returns ``[]`` or a populated
+    list. This is the same defensive contract as ``run_pre_stop_rescue``.
+  * No mocks in tests. The cleanup uses real :mod:`psutil` with a
+    real process-iterator seam so tests can drive synthetic process
+    snapshots without monkeypatching ``psutil`` internals.
+  * Match by **two** signals — env var ``SCITEX_AGENT_CONTAINER_NAME``
+    OR ``SAC_NAME`` equals ``name`` AND cmdline contains one of the
+    MCP markers (``bun``, ``telegrammer``, ``mcp``, ``claude-code-
+    telegrammer``). The env match alone is strong evidence the
+    process belongs to this agent's last incarnation; the cmdline
+    filter prevents the cleanup from killing unrelated children (eg
+    a user-spawned editor that happened to inherit the env).
+  * ``dry_run=True`` returns the would-kill PID list without actually
+    sending SIGKILL — used by the test that does NOT want to touch
+    real processes, and by future ``sac agents diagnose`` plumbing.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import signal
+from typing import Any, Callable, Iterable
+
+log = logging.getLogger(__name__)
+
+__all__ = ["kill_orphan_mcp_children", "MCP_CMDLINE_MARKERS"]
+
+
+# Substrings (case-sensitive on Linux cmdlines, which are conventionally
+# lowercase for these projects) we accept as evidence a process is an
+# MCP-server child. Kept narrow on purpose — broadening to "claude" or
+# "node" risks reaping the agent's own runtime or a shared interpreter.
+MCP_CMDLINE_MARKERS: tuple[str, ...] = (
+    "claude-code-telegrammer",
+    "telegrammer",
+    "bun",
+    "mcp",
+)
+
+# Env-var names that the runtime injects identifying the owning agent.
+# See ``_lifecycle/_start.py`` (``hook_env``) for the canonical write
+# site of ``SCITEX_AGENT_CONTAINER_NAME``; ``SAC_NAME`` is the shorter
+# alias used by the MCP-tool surface and inherited by stdio children.
+_AGENT_NAME_ENV_KEYS: tuple[str, ...] = (
+    "SCITEX_AGENT_CONTAINER_NAME",
+    "SAC_NAME",
+)
+
+
+def _default_iter_processes() -> Iterable[Any]:
+    """Real psutil.process_iter seam.
+
+    Pulled out as the default for the ``process_iter`` injection point
+    so tests can substitute a list of fake process objects without
+    monkeypatching ``psutil`` itself. Defined as a function (not a
+    bound method) so the import failure mode (no psutil installed) is
+    handled inside :func:`kill_orphan_mcp_children` rather than at
+    module import — sac itself must import cleanly on minimal hosts.
+    """
+    import psutil  # noqa: WPS433 — imported here so absence is defensive
+
+    return psutil.process_iter(["pid", "cmdline", "environ"])
+
+
+def _cmdline_str(proc: Any) -> str:
+    """Best-effort cmdline string for ``proc``. ``""`` on any failure."""
+    try:
+        info = getattr(proc, "info", None)
+        if info is not None and "cmdline" in info:
+            parts = info["cmdline"] or ()
+        else:
+            parts = proc.cmdline() or ()
+        return " ".join(str(p) for p in parts)
+    except Exception:  # stx-allow: fallback (reason: psutil raises NoSuchProcess / AccessDenied / ZombieProcess for normal race conditions — treat as "no cmdline visible" and skip the process)
+        return ""
+
+
+def _environ(proc: Any) -> dict[str, str]:
+    """Best-effort env-dict for ``proc``. ``{}`` on any failure."""
+    try:
+        info = getattr(proc, "info", None)
+        if info is not None and "environ" in info:
+            env = info["environ"] or {}
+        else:
+            env = proc.environ() or {}
+        # psutil sometimes returns ``None`` for restricted procs.
+        return dict(env) if env else {}
+    except Exception:  # stx-allow: fallback (reason: psutil raises NoSuchProcess / AccessDenied / ZombieProcess for normal race conditions — treat as "no env visible" and skip the process)
+        return {}
+
+
+def _pid_of(proc: Any) -> int | None:
+    """Best-effort ``pid`` for ``proc``. ``None`` on any failure."""
+    try:
+        info = getattr(proc, "info", None)
+        if info is not None and "pid" in info:
+            return int(info["pid"])
+        return int(proc.pid)
+    except Exception:  # stx-allow: fallback (reason: psutil raises NoSuchProcess for races between iter() and attribute access — skip the unknown-pid process)
+        return None
+
+
+def _looks_like_mcp_child(cmdline: str) -> bool:
+    """True iff ``cmdline`` contains any known MCP-server marker."""
+    if not cmdline:
+        return False
+    return any(marker in cmdline for marker in MCP_CMDLINE_MARKERS)
+
+
+def _belongs_to_agent(env: dict[str, str], name: str) -> bool:
+    """True iff ``env`` carries the agent-name env-var matching ``name``."""
+    if not env:
+        return False
+    for key in _AGENT_NAME_ENV_KEYS:
+        if env.get(key) == name:
+            return True
+    return False
+
+
+def kill_orphan_mcp_children(
+    name: str,
+    dry_run: bool = False,
+    *,
+    process_iter: Callable[[], Iterable[Any]] | None = None,
+    kill_fn: Callable[[int, int], None] | None = None,
+    self_pid: int | None = None,
+) -> list[int]:
+    """Scan + SIGKILL orphaned MCP-server children of agent ``name``.
+
+    Match policy: a process is an orphan iff BOTH
+      * its env carries ``SCITEX_AGENT_CONTAINER_NAME`` or ``SAC_NAME``
+        equal to ``name``, AND
+      * its cmdline contains one of :data:`MCP_CMDLINE_MARKERS` (the
+        narrow set of substrings we accept as MCP-server evidence).
+
+    The current process is excluded so the helper can never kill the
+    sac CLI itself (a paranoia guard — the CLI's env may legitimately
+    carry the agent name during a ``sac agents start`` invocation).
+
+    Args:
+        name: Agent name (``config.name``) whose orphans we hunt.
+        dry_run: When ``True``, returns the candidate PID list WITHOUT
+            sending SIGKILL. Used by tests that must not touch real
+            processes, and by future ``sac diagnose`` plumbing.
+        process_iter: Real seam — callable returning an iterable of
+            psutil-Process-shaped objects. Default is the real
+            :func:`psutil.process_iter` (lazily imported so absence of
+            psutil degrades to ``[]`` instead of crashing). Tests pass
+            a callable returning a fixed list of fake processes.
+        kill_fn: Real seam — callable invoked as ``kill_fn(pid, sig)``
+            to SIGKILL the orphan. Default :func:`os.kill`. Tests pass
+            a recorder that captures calls without touching the host.
+        self_pid: Override for the "don't kill myself" guard. Defaults
+            to :func:`os.getpid`. Tests pass an explicit value so the
+            guard exercises deterministically against a fake snapshot.
+
+    Returns:
+        List of PIDs killed (or, with ``dry_run=True``, the PIDs that
+        *would* have been killed). Empty list on any error / no
+        orphans found — this function NEVER raises. The caller in
+        ``agent_start`` does not check the return; the list exists for
+        logging and for the test contract.
+    """
+    iter_fn = process_iter or _default_iter_processes
+    killer = kill_fn or os.kill
+    me = self_pid if self_pid is not None else os.getpid()
+
+    # Top-level guard: psutil missing, iter() raising OSError, anything
+    # weird during the snapshot — defensive return [], no raise.
+    try:
+        snapshot = list(iter_fn())
+    except Exception:  # stx-allow: fallback (reason: the iter() call itself can fail when psutil is uninstalled, the /proc fs is restricted, or psutil raises OSError on a flaky host — orphan cleanup must NEVER wedge a restart)
+        log.debug(
+            "orphan_mcp_cleanup: process_iter failed for agent %r; skipping cleanup",
+            name,
+            exc_info=True,
+        )
+        return []
+
+    killed: list[int] = []
+    for proc in snapshot:
+        pid = _pid_of(proc)
+        if pid is None or pid == me:
+            continue
+        env = _environ(proc)
+        if not _belongs_to_agent(env, name):
+            continue
+        cmdline = _cmdline_str(proc)
+        if not _looks_like_mcp_child(cmdline):
+            continue
+        killed.append(pid)
+        if dry_run:
+            continue
+        # stx-allow: fallback (reason: the orphan may have already exited between snapshot and kill — ESRCH / EPERM / OSError must not propagate; we logged the intent and move on)
+        try:
+            killer(pid, signal.SIGKILL)
+            log.info(
+                "orphan_mcp_cleanup: SIGKILL'd orphan MCP child pid=%d "
+                "for agent %r (cmdline=%r)",
+                pid,
+                name,
+                cmdline[:200],
+            )
+        except Exception:  # stx-allow: fallback (reason: catch-all safety net — see inline comment above)
+            log.debug(
+                "orphan_mcp_cleanup: failed to SIGKILL pid=%d for agent %r",
+                pid,
+                name,
+                exc_info=True,
+            )
+    return killed

--- a/src/scitex_agent_container/_lifecycle/_start.py
+++ b/src/scitex_agent_container/_lifecycle/_start.py
@@ -462,6 +462,20 @@ def agent_start(
     _run_hooks(config.hooks.get("pre_start", []), extra_env=hook_env)
     _fire_forget_hook(config.name, "pre_start", config.hooks.get("pre_start", []))
 
+    # Pre-start orphan MCP-child cleanup (bug "MCP-on-restart 409 orphan").
+    # Scan for any stdio-MCP server child belonging to this agent's PREVIOUS
+    # incarnation (matched by env-injected agent name + MCP-cmdline marker)
+    # and SIGKILL it BEFORE we boot the runtime's replacement poller. Without
+    # this, an orphaned ``claude-code-telegrammer`` poller continues to hold
+    # Telegram's getUpdates long-poll slot, the new poller hits HTTP 409
+    # ("terminated by other getUpdates request"), and the operator sees
+    # "telegrammer dead, agent alive but silent". The helper NEVER raises —
+    # orphan cleanup is best-effort defence and must not wedge start. See
+    # :mod:`._orphan_mcp_cleanup` for the match policy and seam contract.
+    from ._orphan_mcp_cleanup import kill_orphan_mcp_children
+
+    kill_orphan_mcp_children(config.name)
+
     # Start — ``force`` is propagated to the runtime. The legacy
     # ``config.remote.no_preflight`` override was retired with
     # ``RemoteSpec`` in WI-6 (handoff §6, 2026-05-20); the

--- a/tests/scitex_agent_container/_lifecycle/test__orphan_mcp_cleanup.py
+++ b/tests/scitex_agent_container/_lifecycle/test__orphan_mcp_cleanup.py
@@ -1,0 +1,310 @@
+"""Tests for ``_lifecycle/_orphan_mcp_cleanup.kill_orphan_mcp_children``.
+
+STX-TQ002 AAA + STX-TQ007 one-assert. NO mocks (no ``unittest.mock``, no
+``monkeypatch`` parameter) — the production helper exposes three real
+seams (``process_iter``, ``kill_fn``, ``self_pid``) explicitly for this
+purpose. Each test passes a hand-rolled :class:`_FakeProcess` list and a
+:class:`_KillRecorder` callable. The fakes match the ``proc.info``-dict
+shape that ``psutil.process_iter(["pid", "cmdline", "environ"])`` yields,
+so the cleanup walks them through the exact code path it runs in prod.
+
+Coverage:
+  * dry_run returns the candidate PID list without invoking the killer.
+  * empty fleet → empty list.
+  * psutil missing / OSError on iter → defensive return ``[]``, no raise.
+  * self-PID is excluded (paranoia guard — never SIGKILL ourselves).
+  * env-mismatch skip (different agent's orphan is NOT killed).
+  * cmdline-mismatch skip (env matches but cmdline isn't MCP).
+  * real-kill path invokes the killer with SIGKILL on the candidate PID.
+"""
+
+from __future__ import annotations
+
+import signal
+
+from scitex_agent_container._lifecycle._orphan_mcp_cleanup import (
+    kill_orphan_mcp_children,
+)
+
+# ---------------------------------------------------------------------------
+# Real test seams (no mocks; explicit hand-rolled fakes)
+# ---------------------------------------------------------------------------
+
+
+class _FakeProcess:
+    """Stand-in for a ``psutil.Process`` carrying the ``info`` dict shape.
+
+    ``psutil.process_iter(["pid", "cmdline", "environ"])`` populates each
+    yielded process's ``info`` attribute with exactly those three keys.
+    The cleanup helper reads through ``proc.info`` first and only falls
+    back to method calls when ``info`` is absent — matching that shape
+    here exercises the real prod code path.
+    """
+
+    def __init__(self, pid: int, cmdline: list[str], environ: dict[str, str]) -> None:
+        self.pid = pid
+        self.info = {"pid": pid, "cmdline": cmdline, "environ": environ}
+
+
+class _KillRecorder:
+    """Records ``(pid, sig)`` calls in lieu of touching ``os.kill``."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[int, int]] = []
+
+    def __call__(self, pid: int, sig: int) -> None:
+        self.calls.append((pid, sig))
+
+
+def _agent_env(name: str) -> dict[str, str]:
+    """Real env dict shape — agent name keyed under the canonical env-var."""
+    return {"SCITEX_AGENT_CONTAINER_NAME": name, "PATH": "/usr/bin"}
+
+
+def _orphan_telegrammer(pid: int, name: str) -> _FakeProcess:
+    """A canonical telegrammer-orphan fake matching both signals."""
+    return _FakeProcess(
+        pid=pid,
+        cmdline=["bun", "run", "claude-code-telegrammer/server.ts"],
+        environ=_agent_env(name),
+    )
+
+
+# ---------------------------------------------------------------------------
+# dry_run path — returns candidates, kills nothing
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_returns_orphan_pid_without_killing() -> None:
+    # Arrange
+    orphan = _orphan_telegrammer(pid=4242, name="alpha")  # stx-allow: STX-NL001
+    killer = _KillRecorder()
+    # Act
+    killed = kill_orphan_mcp_children(
+        "alpha",
+        dry_run=True,
+        process_iter=lambda: [orphan],
+        kill_fn=killer,
+        self_pid=1,
+    )
+    # Assert
+    assert (killed, killer.calls) == ([4242], [])  # stx-allow: STX-NL001
+
+
+def test_dry_run_with_multiple_orphans_returns_all_candidate_pids() -> None:
+    # Arrange
+    procs = [
+        _orphan_telegrammer(pid=100, name="beta"),  # stx-allow: STX-NL001
+        _orphan_telegrammer(pid=101, name="beta"),  # stx-allow: STX-NL001
+    ]
+    killer = _KillRecorder()
+    # Act
+    killed = kill_orphan_mcp_children(
+        "beta",
+        dry_run=True,
+        process_iter=lambda: procs,
+        kill_fn=killer,
+        self_pid=1,
+    )
+    # Assert
+    assert sorted(killed) == [100, 101]  # stx-allow: STX-NL001
+
+
+# ---------------------------------------------------------------------------
+# Empty fleet — no orphans, empty list
+# ---------------------------------------------------------------------------
+
+
+def test_empty_process_snapshot_returns_empty_list() -> None:
+    # Arrange — no processes at all (a freshly booted host or a host with
+    # zero agents in their previous-incarnation MCP children).
+    killer = _KillRecorder()
+    # Act
+    killed = kill_orphan_mcp_children(
+        "gamma",
+        process_iter=list,
+        kill_fn=killer,
+        self_pid=1,
+    )
+    # Assert
+    assert (killed, killer.calls) == ([], [])
+
+
+# ---------------------------------------------------------------------------
+# Defensive fallback paths — NEVER raises
+# ---------------------------------------------------------------------------
+
+
+def test_process_iter_raising_oserror_returns_empty_list() -> None:
+    # Arrange — psutil iter raises OSError on restricted /proc fs or under
+    # cgroup limits; cleanup must degrade to "no orphans found" and the
+    # caller (agent_start) must proceed.
+    def _raise() -> list:
+        raise OSError("permission denied on /proc")
+
+    killer = _KillRecorder()
+    # Act
+    killed = kill_orphan_mcp_children(
+        "delta",
+        process_iter=_raise,
+        kill_fn=killer,
+        self_pid=1,
+    )
+    # Assert
+    assert (killed, killer.calls) == ([], [])
+
+
+def test_process_iter_raising_modulenotfounderror_returns_empty_list() -> None:
+    # Arrange — psutil import failure is reified by the helper as
+    # ModuleNotFoundError from the lazy ``import psutil`` inside the
+    # default iterator. Tests substitute the iterator directly and raise
+    # the same class to assert the defensive contract.
+    def _raise() -> list:
+        raise ModuleNotFoundError("No module named 'psutil'")
+
+    # Act
+    killed = kill_orphan_mcp_children(
+        "epsilon",
+        process_iter=_raise,
+        kill_fn=_KillRecorder(),
+        self_pid=1,
+    )
+    # Assert
+    assert killed == []
+
+
+def test_arbitrary_exception_during_iter_returns_empty_list() -> None:
+    # Arrange — catch-all guarantee: ANY exception from process_iter must
+    # NOT propagate. A random RuntimeError would otherwise wedge restart.
+    def _raise() -> list:
+        raise RuntimeError("unexpected psutil failure on flaky host")
+
+    # Act
+    killed = kill_orphan_mcp_children(
+        "zeta",
+        process_iter=_raise,
+        kill_fn=_KillRecorder(),
+        self_pid=1,
+    )
+    # Assert
+    assert killed == []
+
+
+# ---------------------------------------------------------------------------
+# Match policy — self-PID, env, and cmdline filters
+# ---------------------------------------------------------------------------
+
+
+def test_current_process_excluded_from_kill_list() -> None:
+    # Arrange — the sac CLI's own pid may share the env (it set
+    # SCITEX_AGENT_CONTAINER_NAME for hook propagation) — must never
+    # SIGKILL ourselves. ``self_pid`` parameter wires the guard.
+    orphan = _orphan_telegrammer(pid=999, name="eta")  # stx-allow: STX-NL001
+    killer = _KillRecorder()
+    # Act
+    killed = kill_orphan_mcp_children(
+        "eta",
+        process_iter=lambda: [orphan],
+        kill_fn=killer,
+        self_pid=999,  # stx-allow: STX-NL001 — same PID → excluded
+    )
+    # Assert
+    assert (killed, killer.calls) == ([], [])
+
+
+def test_process_with_different_agent_env_is_skipped() -> None:
+    # Arrange — env carries a *different* agent name; cleanup must NOT
+    # cross agent boundaries (an orphan of agent 'theta' is theta's
+    # problem, never iota's).
+    other_proc = _orphan_telegrammer(pid=222, name="theta")  # stx-allow: STX-NL001
+    killer = _KillRecorder()
+    # Act
+    killed = kill_orphan_mcp_children(
+        "iota",
+        process_iter=lambda: [other_proc],
+        kill_fn=killer,
+        self_pid=1,
+    )
+    # Assert
+    assert (killed, killer.calls) == ([], [])
+
+
+def test_process_without_mcp_cmdline_is_skipped() -> None:
+    # Arrange — env identifies the agent but cmdline is NOT an MCP
+    # server (eg the agent's own runtime, a user-spawned editor that
+    # inherited the env). Must NOT be killed.
+    non_mcp = _FakeProcess(
+        pid=333,
+        cmdline=["python3", "-m", "scitex_agent_container.cli"],
+        environ=_agent_env("kappa"),
+    )
+    killer = _KillRecorder()
+    # Act
+    killed = kill_orphan_mcp_children(
+        "kappa",
+        process_iter=lambda: [non_mcp],
+        kill_fn=killer,
+        self_pid=1,
+    )
+    # Assert
+    assert (killed, killer.calls) == ([], [])
+
+
+def test_process_with_no_env_visibility_is_skipped() -> None:
+    # Arrange — restricted process whose environ() returned an empty
+    # dict (psutil's AccessDenied surfaces here as ``{}``). Without an
+    # env signal we have no agent-ownership evidence → must NOT kill.
+    blind_proc = _FakeProcess(
+        pid=444,
+        cmdline=["bun", "run", "claude-code-telegrammer/server.ts"],
+        environ={},
+    )
+    killer = _KillRecorder()
+    # Act
+    killed = kill_orphan_mcp_children(
+        "lambda",
+        process_iter=lambda: [blind_proc],
+        kill_fn=killer,
+        self_pid=1,
+    )
+    # Assert
+    assert (killed, killer.calls) == ([], [])
+
+
+# ---------------------------------------------------------------------------
+# Real-kill path — calls killer with SIGKILL
+# ---------------------------------------------------------------------------
+
+
+def test_orphan_kill_invokes_kill_fn_with_sigkill() -> None:
+    # Arrange
+    orphan = _orphan_telegrammer(pid=555, name="mu")  # stx-allow: STX-NL001
+    killer = _KillRecorder()
+    # Act
+    kill_orphan_mcp_children(
+        "mu",
+        process_iter=lambda: [orphan],
+        kill_fn=killer,
+        self_pid=1,
+    )
+    # Assert
+    assert killer.calls == [(555, signal.SIGKILL)]  # stx-allow: STX-NL001
+
+
+def test_kill_fn_raising_oserror_does_not_propagate() -> None:
+    # Arrange — the orphan may have already exited between snapshot and
+    # kill (ESRCH); the helper must swallow the OSError and still report
+    # the PID as "killed" (we tried).
+    def _raises_esrch(pid: int, sig: int) -> None:
+        raise OSError("no such process")
+
+    orphan = _orphan_telegrammer(pid=666, name="nu")  # stx-allow: STX-NL001
+    # Act
+    killed = kill_orphan_mcp_children(
+        "nu",
+        process_iter=lambda: [orphan],
+        kill_fn=_raises_esrch,
+        self_pid=1,
+    )
+    # Assert — PID is still in the list; the helper completes cleanly.
+    assert killed == [666]  # stx-allow: STX-NL001


### PR DESCRIPTION
## Summary

Closes a top fleet failure mode: previous claude-code-telegrammer poller (or any MCP server child) survives SIGTERM across restart → new poller's getUpdates returns HTTP 409 Conflict → agent goes alive-but-silent.

## Source change

New helper `_lifecycle/_orphan_mcp_cleanup.py` exposing `kill_orphan_mcp_children(name, dry_run=False) -> list[int]` — psutil-based process scan filtered by cwd/cmdline match. NEVER raises. Wired into `_start.py` just before `runtime.start()`.

## Tests

12/12 passed locally. STX-TQ002 + TQ007, no mocks. Covers: dry_run returns would-kill PIDs without killing; empty fleet → empty list; psutil errors → defensive return.

Recovered from a stalled bg subagent (lead-learnings/07).