### PR TITLE
fix(baseline-hooks): graceful degradation for WorktreeCreate/Remove (lead a2a 87af519791)

### DIFF
--- a/src/scitex_agent_container/_baseline_assets/claude_worktree_hooks/worktree_create.py
+++ b/src/scitex_agent_container/_baseline_assets/claude_worktree_hooks/worktree_create.py
@@ -55,12 +55,22 @@ Policy
   worktree to it (worktree add without ``-b``). Lets the operator/agent
   resume a worktree across restarts without manual fixup.
 
-Failure mode
-------------
-Every failure exits non-zero with a diagnostic on stderr. The SDK
-surfaces stderr in its ``WorktreeCreate hook failed`` error so the
-operator sees what went wrong instead of a silent fall-through to the
-hardcoded default.
+Graceful degradation (operator priority — fleet-wide WorktreeCreate hook
+breakage observed 2026-06-13, lead a2a 07a9187b/777d0a5a):
+* The HARD FAILURE that broke the fleet was an interpreter-path drift —
+  the dotfiles JSON wired ``/opt/venv-agent/bin/python3`` which was
+  absent in some SIFs. That has been fixed at the wiring layer (PATH-
+  based ``python3``). THIS file additionally hardens the SCRIPT
+  itself: when the .worktrees/<name> policy CANNOT be honoured (the
+  cwd isn't a git repo, git is missing, the directory is read-only, …),
+  the hook falls back to the SDK's own default location
+  ``<cwd>/.claude/worktrees/<name>``, creates a real git worktree there,
+  and echoes that path. Operator sees a WARN on stderr explaining the
+  policy was skipped; the Agent SPAWN PROCEEDS. The operator's prune
+  cron eventually catches the .claude/worktrees/ bloat through the
+  existing F-CS8 audit surface.
+* Only when BOTH the policy AND the fallback fail do we exit 2 with a
+  diagnostic — there is no plausible recovery beyond that.
 """
 
 from __future__ import annotations
@@ -120,11 +130,96 @@ def _resolve_base(git_root: str) -> str:
     return "HEAD"
 
 
+def _try_policy_target(name: str, cwd: str) -> str | None:
+    """Try the ``<git-root>/.worktrees/<name>`` relocation policy.
+
+    Returns the absolute path on success; ``None`` on any failure
+    (graceful-degradation entry point — the caller falls back to the
+    SDK default location on ``None``).
+    """
+    try:
+        git_root = _run_git("rev-parse", "--show-toplevel", cwd=cwd)
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        return None
+    if not git_root:
+        return None
+
+    target = Path(git_root) / ".worktrees" / name
+    branch = f"claude/{name}"
+
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        return None
+
+    try:
+        if _worktree_already_exists(git_root, target):
+            return str(target)
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        return None
+
+    base = _resolve_base(git_root)
+
+    if _branch_exists(git_root, branch):
+        ok, _err = _try_git(
+            "worktree", "add", str(target), branch, cwd=git_root
+        )
+    else:
+        ok, _err = _try_git(
+            "worktree", "add", "-b", branch, str(target), base, cwd=git_root
+        )
+
+    if not ok or not target.is_dir():
+        return None
+    return str(target)
+
+
+def _try_sdk_default_fallback(name: str, cwd: str) -> str | None:
+    """Create a worktree at the SDK's default ``<cwd>/.claude/worktrees/<name>``.
+
+    Used when ``_try_policy_target`` fails so the Agent spawn proceeds
+    instead of hard-failing. NO bookkeeping for the prune cron — the
+    operator's F-CS8 audit surface still picks the .claude/worktrees
+    bloat up via the existing daily sweep.
+    """
+    target = Path(cwd).resolve() / ".claude" / "worktrees" / name
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        return None
+    # Use the same git-worktree-add machinery so the dir is a real
+    # worktree the SDK can drive. Discover the git root again here
+    # so the fallback doesn't require the policy walk to have succeeded.
+    try:
+        git_root = _run_git("rev-parse", "--show-toplevel", cwd=cwd)
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        return None
+    if not git_root:
+        return None
+    branch = f"claude/{name}"
+    if _branch_exists(git_root, branch):
+        ok, _err = _try_git(
+            "worktree", "add", str(target), branch, cwd=git_root
+        )
+    else:
+        base = _resolve_base(git_root)
+        ok, _err = _try_git(
+            "worktree", "add", "-b", branch, str(target), base, cwd=git_root
+        )
+    if not ok or not target.is_dir():
+        return None
+    return str(target)
+
+
 def main() -> int:
     """Read the hook input from stdin, create the worktree, echo its path.
 
-    Returns the process exit code (0 on success; non-zero with stderr
-    diagnostic on any failure, so the SDK shows the real reason).
+    Graceful-degradation order:
+      1. Try the ``.worktrees/<name>`` policy target.
+      2. On failure, fall back to the SDK's ``.claude/worktrees/<name>``
+         default (WARN on stderr; the Agent spawn still proceeds).
+      3. Only exit 2 when BOTH paths fail — no plausible recovery
+         beyond that, so surface the SDK's "hook failed" error.
     """
     raw = sys.stdin.read()
     if not raw.strip():
@@ -149,7 +244,7 @@ def main() -> int:
 
     # ``name`` arrives from Claude Code's session bookkeeping; we treat
     # it as a path segment and reject any traversal/separator nasties
-    # so the hook can never write outside ``<git-root>/.worktrees/``.
+    # so the hook can never write outside the worktree roots.
     if "/" in name or ".." in name.split("."):
         print(
             f"WorktreeCreate hook: invalid 'name' (path-traversal): {name!r}",
@@ -157,64 +252,33 @@ def main() -> int:
         )
         return 2
 
-    try:
-        git_root = _run_git("rev-parse", "--show-toplevel", cwd=cwd)
-    except subprocess.CalledProcessError as exc:
-        print(
-            f"WorktreeCreate hook: {cwd!r} is not in a git repository: {exc.stderr.strip()}",
-            file=sys.stderr,
-        )
-        return 2
-    if not git_root:
-        print(
-            f"WorktreeCreate hook: 'git rev-parse' returned empty toplevel for {cwd!r}",
-            file=sys.stderr,
-        )
-        return 2
-
-    target = Path(git_root) / ".worktrees" / name
-    branch = f"claude/{name}"
-
-    # Pre-create the .worktrees container so `git worktree add` has
-    # somewhere to land. Idempotent.
-    target.parent.mkdir(parents=True, exist_ok=True)
-
-    if _worktree_already_exists(git_root, target):
-        # Resume case — operator/agent restart picked the same name.
-        print(str(target))
+    policy_path = _try_policy_target(name, cwd)
+    if policy_path is not None:
+        print(policy_path)
         return 0
 
-    base = _resolve_base(git_root)
-
-    if _branch_exists(git_root, branch):
-        # Branch lingered from a previous worktree; attach without -b so
-        # the existing branch stays the source of truth.
-        ok, err = _try_git("worktree", "add", str(target), branch, cwd=git_root)
-    else:
-        ok, err = _try_git(
-            "worktree", "add", "-b", branch, str(target), base, cwd=git_root
-        )
-
-    if not ok:
+    # Policy failed — fall back to SDK default so the Agent spawn still
+    # proceeds. Operator sees a single-line WARN naming the fallback so
+    # the prune cron is the implicit cleanup contract.
+    fallback_path = _try_sdk_default_fallback(name, cwd)
+    if fallback_path is not None:
         print(
-            f"WorktreeCreate hook: 'git worktree add' failed for "
-            f"name={name!r} target={target} branch={branch} base={base}: {err}",
+            f"WorktreeCreate hook: policy target .worktrees/{name} failed; "
+            f"falling back to SDK default {fallback_path} so the Agent "
+            f"spawn proceeds (operator F-CS8 audit + prune cron applies).",
             file=sys.stderr,
         )
-        return 2
+        print(fallback_path)
+        return 0
 
-    if not target.is_dir():
-        # SDK enforces this — fail loud rather than letting the SDK's
-        # generic "not a directory" error swallow our diagnostic.
-        print(
-            f"WorktreeCreate hook: target {target} not a directory after "
-            "'git worktree add' (filesystem race or post-create deletion)",
-            file=sys.stderr,
-        )
-        return 2
-
-    print(str(target))
-    return 0
+    print(
+        f"WorktreeCreate hook: BOTH policy target .worktrees/{name} AND "
+        f"SDK fallback .claude/worktrees/{name} failed; no plausible "
+        f"recovery. cwd={cwd!r}. Check git availability + write "
+        f"permissions on both candidate paths.",
+        file=sys.stderr,
+    )
+    return 2
 
 
 if __name__ == "__main__":

--- a/src/scitex_agent_container/_baseline_assets/claude_worktree_hooks/worktree_remove.py
+++ b/src/scitex_agent_container/_baseline_assets/claude_worktree_hooks/worktree_remove.py
@@ -13,9 +13,14 @@ Input (stdin, JSON)::
     }
 
 The hook runs ``git worktree remove <path>`` from a discoverable git
-root and exits 0 on success. Any failure is loud on stderr + non-zero
-so the SDK surfaces it (its built-in default for WorktreeRemove leaves
-orphans behind silently; ours fails loud).
+root and exits 0 on success. The SDK's built-in WorktreeRemove default
+leaves orphans silently; ours tries harder (force-remove second-pass)
+and is loud on stderr when the work cannot be done — but ONLY when the
+worktree provably still exists AND we have a working git binary. When
+the environment itself is broken (git missing, interpreter drift, the
+worktree's repo gone), we WARN+exit 0: the operator's prune cron
+catches residual ``.worktrees/`` bloat through the existing F-CS8
+audit surface, so wedging the SDK teardown buys nothing.
 
 Idempotence
 -----------
@@ -23,6 +28,20 @@ If the worktree is already gone (operator pruned via the daily cron, or
 the directory was removed out-of-band), we report success — the desired
 end-state is "this worktree is no longer registered", and that's
 already true.
+
+Graceful degradation (operator priority — fleet-wide WorktreeCreate
+hook breakage observed 2026-06-13, lead a2a 07a9187b/777d0a5a):
+* The HARD FAILURE that broke the fleet was an interpreter-path drift
+  on the CREATE hook; the wiring layer (``settings.local.json``) is
+  fixed, but THIS file additionally hardens the remove script body so
+  the same class of breakage (git binary missing, transient OSError on
+  the subprocess invocation) cannot wedge SDK teardown across the
+  fleet. WARN on stderr names the failure; exit 0 lets teardown
+  proceed; operator's prune cron still cleans the orphan via the F-CS8
+  audit surface.
+* Hard exit 2 is reserved for the case we can actually act on but
+  ``git worktree remove`` itself refuses — that's a real surface worth
+  the operator seeing.
 """
 
 from __future__ import annotations
@@ -35,11 +54,22 @@ from pathlib import Path
 
 
 def _try_git(*args: str, cwd: str) -> tuple[bool, str]:
-    res = subprocess.run(
-        ["git", "-C", cwd, *args],
-        capture_output=True,
-        text=True,
-    )
+    """Try ``git -C cwd <args>``; return (ok, stdout-or-stderr).
+
+    Catches the env-drift exception classes so a missing/broken git
+    binary degrades to (False, "<reason>") instead of raising into
+    main(). The caller picks the policy on a False (idempotent
+    success vs. hard-fail) based on whether the orphan it leaves
+    behind is one the operator's prune cron will catch.
+    """
+    try:
+        res = subprocess.run(
+            ["git", "-C", cwd, *args],
+            capture_output=True,
+            text=True,
+        )
+    except (FileNotFoundError, OSError) as exc:
+        return False, f"git invocation failed ({type(exc).__name__}): {exc}"
     if res.returncode == 0:
         return True, res.stdout.strip()
     return False, (res.stderr or res.stdout).strip()
@@ -77,20 +107,48 @@ def _git_root_for(start: str) -> str | None:
 
 
 def main() -> int:
+    """Read the hook input from stdin, remove the worktree, exit 0.
+
+    Graceful-degradation order:
+      1. If we can locate the git root AND the worktree is registered,
+         try ``git worktree remove`` and then ``--force`` — if both
+         fail, surface the error (exit 2) so the operator sees it.
+      2. If we cannot locate the git root, or the worktree is already
+         unregistered, succeed silently (desired end-state achieved).
+      3. If the environment itself is broken (git binary missing,
+         OSError on subprocess invocation), WARN on stderr but exit 0
+         — wedging SDK teardown across the fleet on env drift buys
+         nothing the operator's F-CS8 prune cron doesn't already
+         catch.
+    """
     raw = sys.stdin.read()
     if not raw.strip():
-        print("WorktreeRemove hook: empty stdin (expected JSON)", file=sys.stderr)
-        return 2
+        # Contract violation, but nothing to remove and wedging SDK
+        # teardown to flag a parser bug buys nothing. WARN + exit 0.
+        print(
+            "WorktreeRemove hook: empty stdin (expected JSON); "
+            "skipping cleanup (operator cron will catch any orphan).",
+            file=sys.stderr,
+        )
+        return 0
     try:
         payload = json.loads(raw)
     except json.JSONDecodeError as exc:
-        print(f"WorktreeRemove hook: stdin is not valid JSON: {exc}", file=sys.stderr)
-        return 2
+        print(
+            f"WorktreeRemove hook: stdin is not valid JSON ({exc}); "
+            f"skipping cleanup (operator cron will catch any orphan).",
+            file=sys.stderr,
+        )
+        return 0
 
     worktree_path = (payload.get("worktree_path") or "").strip()
     if not worktree_path:
-        print("WorktreeRemove hook: 'worktree_path' missing in input", file=sys.stderr)
-        return 2
+        print(
+            "WorktreeRemove hook: 'worktree_path' missing in input; "
+            "skipping cleanup (operator cron will catch any orphan).",
+            file=sys.stderr,
+        )
+        return 0
 
     git_root = _git_root_for(worktree_path)
     if not git_root:
@@ -111,6 +169,10 @@ def main() -> int:
             "worktree", "remove", "--force", worktree_path, cwd=git_root
         )
         if not ok2:
+            # We located the git root AND the worktree was registered,
+            # but git itself refuses to remove it. This is a real
+            # surface the operator should see (vs. env-drift WARNs
+            # above which are recoverable via prune cron).
             print(
                 f"WorktreeRemove hook: 'git worktree remove' failed for "
                 f"{worktree_path!r}: {err}; force-remove also failed: {err2}",

--- a/tests/scitex_agent_container/_baseline_assets/claude_worktree_hooks/test_worktree_remove.py
+++ b/tests/scitex_agent_container/_baseline_assets/claude_worktree_hooks/test_worktree_remove.py
@@ -64,8 +64,11 @@ class TestWorktreeRemove:
         # Assert
         assert result.returncode == 0
 
-    def test_remove_with_empty_stdin_exits_nonzero(self) -> None:
-        # Arrange
+    def test_remove_with_empty_stdin_exits_zero_with_warning(self) -> None:
+        # Arrange — parser-contract violation; the remove-hook MUST NOT
+        # wedge SDK teardown on these (lead a2a 07a9187b/777d0a5a):
+        # operator's F-CS8 prune cron catches any orphan, so wedging
+        # buys nothing. Soft-fail = WARN on stderr + exit 0.
         script = REMOVE_SCRIPT
         # Act
         result = subprocess.run(
@@ -74,11 +77,27 @@ class TestWorktreeRemove:
             capture_output=True,
             text=True,
         )
-        # Assert
-        assert result.returncode != 0
+        # Assert — exit 0 (soft-fail), the WARN message is asserted separately.
+        assert result.returncode == 0
 
-    def test_remove_with_missing_worktree_path_exits_nonzero(self) -> None:
-        # Arrange
+    def test_remove_with_empty_stdin_warns_on_stderr(self) -> None:
+        # Arrange — operator must still SEE the parser-contract bug
+        # (just not as a hard fail). The stderr WARN names the issue.
+        script = REMOVE_SCRIPT
+        # Act
+        result = subprocess.run(
+            [sys.executable, str(script)],
+            input="",
+            capture_output=True,
+            text=True,
+        )
+        # Assert — stderr mentions "stdin" so the bug surfaces in logs.
+        assert "stdin" in result.stderr
+
+    def test_remove_with_missing_worktree_path_exits_zero_with_warning(self) -> None:
+        # Arrange — same soft-fail policy: missing field is a parser
+        # contract bug, not a teardown-blocker. Operator cron handles
+        # any orphan via F-CS8 audit surface.
         payload = {
             "hook_event_name": "WorktreeRemove",
             "session_id": "s",
@@ -96,4 +115,74 @@ class TestWorktreeRemove:
             text=True,
         )
         # Assert
-        assert result.returncode != 0
+        assert result.returncode == 0
+
+    def test_remove_with_missing_worktree_path_warns_on_stderr(self) -> None:
+        # Arrange
+        payload = {
+            "hook_event_name": "WorktreeRemove",
+            "session_id": "s",
+            "transcript_path": "/tmp/t",
+            "permission_mode": "default",
+            "agent_id": "a",
+            "agent_type": "t",
+            "cwd": "/tmp",
+        }
+        # Act
+        result = subprocess.run(
+            [sys.executable, str(REMOVE_SCRIPT)],
+            input=json.dumps(payload),
+            capture_output=True,
+            text=True,
+        )
+        # Assert — stderr names the missing field so the operator can fix it.
+        assert "worktree_path" in result.stderr
+
+    def test_remove_with_malformed_json_exits_zero_with_warning(self) -> None:
+        # Arrange — bad JSON is a parser-contract violation; same
+        # soft-fail policy as the other two parser bugs.
+        script = REMOVE_SCRIPT
+        # Act
+        result = subprocess.run(
+            [sys.executable, str(script)],
+            input="not json at all {[}",
+            capture_output=True,
+            text=True,
+        )
+        # Assert
+        assert result.returncode == 0
+
+    def test_remove_genuine_git_failure_still_exits_nonzero(
+        self, ephemeral_repo: Path
+    ) -> None:
+        # Arrange — the OPPOSITE of soft-fail: when we located the git
+        # root AND the worktree IS registered AND git itself refuses
+        # to remove it, we DO exit 2. That's a surface the operator
+        # can act on, not env drift.
+        #
+        # Construct that state: create a worktree, then make its
+        # contents dirty + drop a read-only marker file that prevents
+        # plain ``git worktree remove`` AND simulate the --force path
+        # also failing by removing write perms on the parent dir.
+        #
+        # In practice the simplest reproducer is: create the worktree,
+        # then chmod 000 the worktree dir so git can't traverse it.
+        # We restore perms in the teardown so the tmp fixture cleans.
+        import os
+        import stat
+
+        created = _run_hook(
+            CREATE_SCRIPT, _create_payload("hard-fail-probe", ephemeral_repo)
+        ).stdout.strip()
+        target = Path(created)
+        # Make the worktree unreadable so even ``--force`` git refuses.
+        os.chmod(target, 0)
+        try:
+            payload = _remove_payload(created, ephemeral_repo)
+            # Act
+            result = _run_hook(REMOVE_SCRIPT, payload)
+            # Assert — exit 2 surfaces the genuinely-actionable failure.
+            returncode = result.returncode
+        finally:
+            os.chmod(target, stat.S_IRWXU)
+        assert returncode == 2


### PR DESCRIPTION
## Summary

- Mirrors the script-side graceful-degradation that lead landed in dotfiles `b7745dc0` (canonical to_home tree, runs at runtime today) — but against the **package baseline** under `src/scitex_agent_container/_baseline_assets/claude_worktree_hooks/`.
- That copy ships INSIDE the SIF and is the durable home for fresh SIF builds + package consumers. Without this patch a re-occurrence of the 2026-06-13 env-drift class of failure (lead a2a `07a9187b`: `/opt/venv-agent/bin/python3: not found`) bricks the fleet again on the next SIF rebuild.
- `worktree_create.py` now falls back to the SDK's own `<cwd>/.claude/worktrees/<name>` when the `.worktrees/<name>` policy can't be honoured; only exits 2 when BOTH paths fail. Operator's F-CS8 prune cron catches the fallback bloat.
- `worktree_remove.py` softens parser-contract failures (empty stdin / bad JSON / missing field) to WARN+exit 0 — wedging SDK teardown buys nothing the prune cron doesn't already catch. Hard exit 2 preserved for the actionable surface (`git worktree remove [--force]` itself refuses on a registered worktree).

## Test plan

- [x] `pytest tests/scitex_agent_container/_baseline_assets/claude_worktree_hooks/` → **24/24 pass** locally (15 create + 9 remove; the 4 new remove tests cover the parser-soft-fail contract + the genuine-git-failure hard-fail path via a chmod 000 trick)
- [x] `scitex-dev ecosystem audit-project scitex-agent-container` → zero violations introduced (pre-existing PS-103 on operator-local `worktrees/` is unrelated)
- [ ] CI: pytest matrix on 3.11/3.12/3.13, ruff, audit-project, import-smoke, rtd-sphinx-build

## Cross-thread

- **dotfiles to_home**: covered at `b7745dc0` (lead-landed; runs at runtime today)
- **package baseline**: this PR (durable home; ships INSIDE next SIF)
- **overlays/* and runtime/***: derived, auto-materialized — don't hand-edit (lead invariant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)