### PR TITLE
feat(runtime): fleet-default bind host sac src over in-SIF install (lead a2a b6f3916c)

### DIFF
--- a/src/scitex_agent_container/runtimes/_p3a_default_binds.py
+++ b/src/scitex_agent_container/runtimes/_p3a_default_binds.py
@@ -1,14 +1,28 @@
-"""P3a-2 default-bind helpers — single-shared-store fleet wiring.
+"""Fleet-default bind helpers.
 
-Operator directive ``feedback_scitex_todo_single_shared_store``
-(lead-learnings/22, P3a unlock). Lead a2a
-``214dd26d3fd24e088c75a34329895fa4`` — every agent's apptainer
-container mounts the host's ``~/.scitex/todo/`` so scitex-todo's
-precedence-4 user-scope store resolves to the SAME global
-``tasks.yaml`` fleet-wide. The dotfiles ``_base/spec.yaml`` carries
-the explicit bind line for immediate coverage; THIS module makes
-the bind survive spec churn — every sac-launched agent gets the
-default bind even if its spec doesn't carry the explicit line.
+Two classes of fleet-wide bind live here today:
+
+* **P3a-2 single-shared-store** — every agent's apptainer container
+  mounts the host's ``~/.scitex/todo/`` so scitex-todo's precedence-4
+  user-scope store resolves to the SAME global ``tasks.yaml``
+  fleet-wide. Operator directive
+  ``feedback_scitex_todo_single_shared_store``
+  (lead-learnings/22, P3a unlock). Lead a2a
+  ``214dd26d3fd24e088c75a34329895fa4``. The dotfiles
+  ``_base/spec.yaml`` carries the explicit bind line for immediate
+  coverage; this module makes the bind survive spec churn — every
+  sac-launched agent gets the default bind even if its spec doesn't
+  carry the explicit line.
+
+* **2026-06-13 SAC overlay stopgap** — bind the host's working
+  ``scitex_agent_container`` source over the in-SIF install so
+  agents pick up new CLI surface (e.g., ``sac pytest spartan run``
+  from PR #375) WITHOUT a 30-minute SIF rebuild. Read-only because
+  the host-side tree is the source of truth; nothing inside the
+  container should mutate it. Lead a2a ``b6f3916cdf3544a9`` opened
+  this as the fast-path for the spartan-pytest hook rollout.
+  Removable: delete the overlay entry once a SIF rebuild folds the
+  new package version back into the canonical install.
 
 Mechanism — see :func:`apply_default_binds`:
   * The list of default binds is :data:`_FLEET_DEFAULT_BINDS` —
@@ -19,9 +33,9 @@ Mechanism — see :func:`apply_default_binds`:
     wins; we de-dupe by destination, not by full string).
   * Missing host source dir → SKIP that default silently. The
     operator may not have a ``~/.scitex/todo/`` yet (clean
-    install, fresh laptop); we don't create it from sac code
-    because the operator's todo init is a separate workflow
-    that owns the layout.
+    install, fresh laptop), or a fresh deploy host may not have
+    the canonical ``~/proj/scitex-agent-container/`` checkout —
+    we don't create either from sac code.
 
 This module is intentionally tiny so the sites that consume the
 default-bind list (``_apptainer_runtime.py``) stay under the
@@ -46,6 +60,29 @@ _FLEET_DEFAULT_BINDS: tuple[str, ...] = (
     # P3a-2 — scitex-todo single shared store (operator directive
     # feedback_scitex_todo_single_shared_store).
     "~/.scitex/todo:/home/agent/.scitex/todo:rw",
+    # 2026-06-13 STOPGAP (lead a2a b6f3916c) — bind the host's working
+    # ``scitex_agent_container`` source over the in-SIF install so
+    # agents pick up new CLI surface (e.g., ``sac pytest spartan run``
+    # from PR #375) WITHOUT a 30-minute SIF rebuild. Read-only because
+    # the host-side tree is the source of truth; nothing inside the
+    # container should mutate it.
+    #
+    # Removable: delete this entry once a SIF rebuild folds the new
+    # package version back into the canonical install. The
+    # ``default_binds_for_host`` skip-if-missing filter makes the
+    # entry a no-op on hosts that don't carry the canonical repo
+    # path (e.g., a fresh deploy box). Per-agent spec overrides via
+    # ``apptainer.binds`` for the SAME destination still win
+    # through ``apply_default_binds``'s de-dup-by-destination merge.
+    #
+    # Pinned to python3.12 because every SAC SIF def
+    # (apptainer-base.def + apptainer-scitex.def) uses ``/opt/venv-sac``
+    # with Python 3.12 today; the bind silently skips if a future SIF
+    # moves to 3.13 (the destination dir won't exist inside that SIF,
+    # apptainer surfaces a benign warning) — operator notices and
+    # either updates the entry or drops it after the SIF refresh.
+    "~/proj/scitex-agent-container/src/scitex_agent_container"
+    ":/opt/venv-sac/lib/python3.12/site-packages/scitex_agent_container:ro",
 )
 
 

--- a/tests/scitex_agent_container/runtimes/test__p3a_default_binds.py
+++ b/tests/scitex_agent_container/runtimes/test__p3a_default_binds.py
@@ -157,3 +157,67 @@ def test_apply_default_binds_preserves_explicit_spec_bind_order(
     result = apply_default_binds(spec_binds)
     # Assert — spec order preserved AFTER the defaults.
     assert result[-2:] == spec_binds
+
+
+# ---------------------------------------------------------------------------
+# 2026-06-13 SAC overlay stopgap — host scitex_agent_container -> in-SIF install
+# (lead a2a b6f3916c; removable once a SIF rebuild folds in the new install)
+# ---------------------------------------------------------------------------
+
+
+def test_default_binds_returns_sac_overlay_when_host_repo_exists(
+    fake_home: Path,
+) -> None:
+    # Arrange — synthesise the canonical host repo path under the
+    # sandboxed $HOME so the helper's expanduser() check picks it up.
+    sac_src = (
+        fake_home / "proj" / "scitex-agent-container" / "src" / "scitex_agent_container"
+    )
+    sac_src.mkdir(parents=True)
+    # Act
+    binds = default_binds_for_host()
+    # Assert — destination path is the in-SIF site-packages location.
+    assert any(
+        ":/opt/venv-sac/lib/python3.12/site-packages/scitex_agent_container:ro" in b
+        for b in binds
+    )
+
+
+def test_default_binds_skips_sac_overlay_when_host_repo_missing(
+    fake_home: Path,
+) -> None:
+    # Arrange — fake_home (tmp_path) has no proj/scitex-agent-container
+    # subtree; deploy-host case where the operator hasn't cloned the
+    # repo at the canonical path.
+    # Act
+    binds = default_binds_for_host()
+    # Assert
+    assert not any(
+        "/opt/venv-sac/lib/python3.12/site-packages/scitex_agent_container" in b
+        for b in binds
+    )
+
+
+def test_apply_default_binds_lets_explicit_spec_override_sac_overlay(
+    fake_home: Path,
+) -> None:
+    # Arrange — operator pins a custom host source for the overlay
+    # via spec; the spec entry MUST win (de-dup by destination).
+    sac_src = (
+        fake_home / "proj" / "scitex-agent-container" / "src" / "scitex_agent_container"
+    )
+    sac_src.mkdir(parents=True)
+    custom_override = (
+        "/opt/local-sac-src"
+        ":/opt/venv-sac/lib/python3.12/site-packages/scitex_agent_container:rw"
+    )
+    spec_binds = [custom_override]
+    # Act
+    result = apply_default_binds(spec_binds)
+    # Assert — exactly one entry whose destination is the in-SIF install path.
+    sac_entries = [
+        b
+        for b in result
+        if "/opt/venv-sac/lib/python3.12/site-packages/scitex_agent_container" in b
+    ]
+    assert sac_entries == [custom_override]


### PR DESCRIPTION
## Summary

Stopgap for the fleet rollout of the Spartan-pytest hook (the lead's `route_pytest_to_spartan.sh` hook BLOCKs local pytest and routes to `sac pytest spartan run`). PR #375 landed that subcommand on develop, but existing SIFs were built BEFORE the merge and don't carry the new subpackage. Without this PR the agent-facing hook landing would hook-block the fleet with no in-container route target.

This PR adds a single new entry to the `_FLEET_DEFAULT_BINDS` tuple in `runtimes/_p3a_default_binds.py`:

```python
"~/proj/scitex-agent-container/src/scitex_agent_container"
":/opt/venv-sac/lib/python3.12/site-packages/scitex_agent_container:ro"
```

The bind shadows the SIF's installed `scitex_agent_container/` package with the host's working tree. Read-only because the host-side tree is the source of truth.

### Why this design

- **Reuses the existing merge machinery** (`apply_default_binds`): skip-if-source-missing handles fresh deploy hosts cleanly; explicit `spec.apptainer.binds` overrides still win via de-dup-by-destination.
- **Single tuple entry, no new module**: keeps the call-site `_apptainer_build_argv.py` untouched (it already calls `apply_default_binds`).
- **Pinned to `python3.12`** because every SAC SIF def today uses `/opt/venv-sac` with Python 3.12. A future 3.13 SIF will see the dest dir missing inside the SIF; apptainer surfaces a benign warning and the operator updates or drops the entry.
- **Read-only mode**: host-side tree is the source of truth; the container should never mutate it.
- **Removable**: delete the entry once a SIF rebuild folds the latest package version back into the canonical install. Explicitly documented in the module docstring + per-entry comment as a 2026-06-13 stopgap.

### Tests

3 new tests cover the new entry:
- Entry present in `default_binds_for_host()` when host repo exists
- Entry skipped silently when host repo missing (deploy-host case)
- Explicit `spec.apptainer.binds` override still wins for the SAC overlay destination

## Test plan

- [x] `pytest tests/.../test__p3a_default_binds.py -q --no-cov` → **12/12 pass** locally (9 existing P3a-2 + 3 new overlay)
- [x] `scitex-dev ecosystem audit-project scitex-agent-container` → zero violations introduced
- [ ] CI: pytest matrix on 3.11/3.12/3.13, ruff, audit-project, import-smoke, rtd-sphinx-build

## Cross-thread

- Lead-landed HOST hook copy (a2a `b6f3916c`)
- Lead deferring AGENT-facing hook until this bind PR lands + agents restart (to_home re-materializes anyway on restart)
- Pairs with PR #379 (baseline-hooks graceful-degradation) — both are STOPGAP/follow-up work after lead's `b7745dc0` dotfiles landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)