### PR TITLE
fix(runtimes): expand ~ in fleet-default bind sources (literal-~ boot-crash)

### DIFF
--- a/src/scitex_agent_container/runtimes/_p3a_default_binds.py
+++ b/src/scitex_agent_container/runtimes/_p3a_default_binds.py
@@ -8,11 +8,11 @@ Two classes of fleet-wide bind live here today:
   fleet-wide. Operator directive
   ``feedback_scitex_todo_single_shared_store``
   (lead-learnings/22, P3a unlock). Lead a2a
-  ``214dd26d3fd24e088c75a34329895fa4``. The dotfiles
-  ``_base/spec.yaml`` carries the explicit bind line for immediate
-  coverage; this module makes the bind survive spec churn — every
-  sac-launched agent gets the default bind even if its spec doesn't
-  carry the explicit line.
+  ``214dd26d3fd24e088c75a34329895fa4``. This module is the SOLE
+  source of the bind — no fleet ``_base/spec.yaml`` carries an
+  explicit ``~/.scitex/todo:`` line (lead audit 2026-06-13 a2a
+  ``f33cbc78c2074594b513439d93748810``), so the helper here is what
+  every sac-launched agent picks up at boot.
 
 * **2026-06-13 SAC overlay stopgap** — bind the host's working
   ``scitex_agent_container`` source over the in-SIF install so
@@ -110,17 +110,25 @@ def default_binds_for_host() -> tuple[str, ...]:
     the host (the bound layout's ownership lives with whoever owns
     the source tree, e.g. scitex-todo for ``~/.scitex/todo/``).
 
-    The returned tuple uses the ORIGINAL (un-expanded) ``~`` form so
-    the caller can hand it directly to apptainer's ``--bind``, which
-    expands ``~`` itself per its own resolution rules.
+    The returned tuple uses the EXPANDED absolute host path —
+    apptainer's ``--bind`` does NOT expand ``~`` (it resolves it as a
+    literal dir relative to CWD, causing a FATAL mount failure), so we
+    expand against ``$HOME`` here before handing it to ``--bind``.
     """
     out: list[str] = []
     for bind_str in _FLEET_DEFAULT_BINDS:
         if ":" not in bind_str:
             continue
-        host_src, _, _ = bind_str.partition(":")
-        if Path(host_src).expanduser().is_dir():
-            out.append(bind_str)
+        host_src, _, rest = bind_str.partition(":")
+        expanded = Path(host_src).expanduser()
+        if expanded.is_dir():
+            # Return the EXPANDED absolute host path. apptainer's
+            # ``--bind`` does NOT expand ``~`` (it treats it as a
+            # literal dir relative to CWD -> FATAL mount failure), so
+            # we must hand it an absolute source. Bug fix 2026-06-13:
+            # the literal ``~/.scitex/todo`` form broke every agent's
+            # boot on restart.
+            out.append(f"{expanded}:{rest}")
     return tuple(out)
 
 

--- a/tests/scitex_agent_container/runtimes/test__p3a_default_binds.py
+++ b/tests/scitex_agent_container/runtimes/test__p3a_default_binds.py
@@ -221,3 +221,36 @@ def test_apply_default_binds_lets_explicit_spec_override_sac_overlay(
         if "/opt/venv-sac/lib/python3.12/site-packages/scitex_agent_container" in b
     ]
     assert sac_entries == [custom_override]
+
+
+# ---------------------------------------------------------------------------
+# 2026-06-13 literal-~ regression guard (lead a2a 8db5081b8aed)
+#
+# apptainer's ``--bind`` does NOT expand ``~`` — it treats the leading
+# ``~`` as a literal directory relative to CWD and aborts container
+# creation with a FATAL mount failure. Every fleet agent that restarted
+# through ``default_binds_for_host()`` crashed at boot because the
+# helper handed back the un-expanded ``~/.scitex/todo:...`` form. The
+# fix is to expand against ``$HOME`` before returning, so the bind
+# source is always an ABSOLUTE host path with NO leading ``~``.
+# ---------------------------------------------------------------------------
+
+
+def test_default_binds_for_host_returns_absolute_host_paths_only(
+    fake_home: Path,
+) -> None:
+    # Arrange — both fleet-default host sources EXIST so every entry in
+    # _FLEET_DEFAULT_BINDS produces a bind string we must inspect.
+    (fake_home / ".scitex" / "todo").mkdir(parents=True)
+    (
+        fake_home / "proj" / "scitex-agent-container" / "src" / "scitex_agent_container"
+    ).mkdir(parents=True)
+    # Act
+    binds = default_binds_for_host()
+    # Assert — every bind's host source (the chunk before the first
+    # colon) is an absolute path with no leading ``~``. A single
+    # violation would re-introduce the fleet-wide boot crash.
+    host_sources = [b.partition(":")[0] for b in binds]
+    assert all(
+        not src.startswith("~") and Path(src).is_absolute() for src in host_sources
+    )


### PR DESCRIPTION
## Summary
- apptainer's `--bind` does NOT expand `~` — it treats the leading `~` as a literal dir relative to CWD and aborts container creation with a FATAL mount failure. `default_binds_for_host()` was returning the raw `~/.scitex/todo:...` (and the SAC overlay) strings, so every fleet agent that restarted crashed at boot. This PR lands the lead's live hot-fix from /work onto develop so it survives a pull + ships to origin.
- New AAA regression guard `test_default_binds_for_host_returns_absolute_host_paths_only` asserts every returned bind's host source has no leading `~` AND `Path.is_absolute()` — a single violation re-introduces the fleet-wide boot crash.
- Module docstring (P3a-2 paragraph) cleaned up per lead audit a2a `f33cbc78c2074594b513439d93748810`: no `_base/spec.yaml` carries an explicit `~/.scitex/todo:` bind line, so this module is the SOLE source of the bind. Removes the stale "carries the explicit bind line" claim so the next reader doesn't chase a non-existent spec entry.

Lead a2a `8db5081b8aed4bda9b8dd8e5223a22b1` opened this; merging LIFTS the fleet-restart pause.

## Test plan
- [x] `pytest tests/scitex_agent_container/runtimes/test__p3a_default_binds.py` — 13 passed (12 existing + 1 new).
- [x] Full suite `pytest -q --ignore=tests/develop -n auto` — 6845 passed, 38 skipped. 4 pre-existing flakes under xdist load (cross-host SSH shim x3 + cli help budget x1) re-pass cleanly in isolation; unrelated to the bind helper.
- [x] `tests/develop/test_audit.py::test_audit_all_clean` — pre-existing failure on develop HEAD too (trips on the untracked top-level `worktrees/` junk dir on host-bound checkouts). CI's clean clone is unaffected; out of scope here.
- [ ] CI green on PR.