### PR TITLE
feat(hooks): SessionStart reap stale agent-worktrees (sac-stale-worktree-autoreap-enable)

### DIFF
--- a/src/scitex_agent_container/_baseline_assets/claude_worktree_hooks/session_start_reap_stale.py
+++ b/src/scitex_agent_container/_baseline_assets/claude_worktree_hooks/session_start_reap_stale.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""Claude Code ``SessionStart`` hook — reap the agent's own STALE
+``.worktrees/<name>`` and ``.claude/worktrees/<name>`` entries BEFORE
+the SDK's bloat-scan runs.
+
+Why
+---
+PR #93 (``feat(_state): worktree-reap safety predicate``) made
+host-side ``git worktree prune`` SAFE via the ``is_safe_to_reap``
+predicate but did NOT make it AUTOMATIC. Operator observed
+(2026-05-24, card ``sac-stale-worktree-autoreap-enable``): without
+auto-reap, agent-local worktree bloat re-accumulates over each 24h
+window and re-triggers the F-CS8 0-token freeze. A manual tool does
+not prevent recurrence.
+
+This hook closes that gap on the CHEAPEST + SAFEST side: it runs at
+``SessionStart`` (i.e. BEFORE Claude Code's first bloat-scan inside
+the session) and reaps the agent's own worktree directories whose
+mtime is older than the age-threshold AND whose
+:func:`is_safe_to_reap` predicate returns True.
+
+Safety asymmetry (matches the predicate's doctrine):
+* **Age-gated**: only entries older than ``--age-hours`` (default 24h)
+  are considered. A worktree the agent created in the last 24h is
+  presumed in-flight, never touched.
+* **Predicate-gated**: ``is_safe_to_reap`` requires a clean tree AND
+  HEAD not ahead of ``develop``. Any failure of the predicate → SKIP.
+* **Fail-open**: any error reaping ONE worktree is logged + skipped;
+  the hook NEVER exits non-zero on a reap miss. Wedging
+  ``SessionStart`` would brick the entire SDK session — far worse than
+  leaving a stale dir on disk (the operator's prune cron still
+  catches that on the next pass).
+* **Agent-only scope**: scans only the canonical agent-worktree roots
+  (``<git-root>/.worktrees/`` and ``$HOME/.claude/worktrees/``).
+  Never walks operator-owned trees.
+
+Hook contract
+-------------
+Claude Code v2.x ``SessionStart`` hook input (stdin, JSON):
+
+    {
+      "hook_event_name": "SessionStart",
+      "source": "startup" | "resume" | "clear" | "compact",
+      "cwd": "<dir-the-session-launched-from>",
+      "session_id": "<uuid>",
+      ...base fields
+    }
+
+Output: a single ``reaped=N skipped=M roots=...`` line on stderr for
+operator visibility; stdout is left empty (the SDK does not consume
+it for SessionStart). Exit 0 unconditionally (fail-open).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+# Default age threshold. The operator's card explicitly calls out the
+# 24h window — anything younger is in-flight and must not be touched.
+DEFAULT_AGE_HOURS = 24
+
+# Canonical agent-worktree roots. The two locations the agent itself
+# writes to:
+#   * ``<git-root>/.worktrees/<name>`` — the relocation policy in
+#     :mod:`worktree_create` (preferred).
+#   * ``$HOME/.claude/worktrees/<name>`` — the SDK's default location
+#     (graceful-degradation fallback when the policy target fails).
+# Both are agent-owned; both are in-scope for the auto-reaper.
+_CANONICAL_ROOT_RELS_FROM_GIT_ROOT = (".worktrees",)
+_CANONICAL_ROOT_RELS_FROM_HOME = (".claude/worktrees",)
+
+
+def _run_git(*args: str, cwd: str) -> tuple[bool, str]:
+    """Run ``git -C cwd <args>``; return (ok, stdout-or-stderr).
+
+    Never raises — env-drift (missing git binary, OSError on subprocess
+    spawn) degrades to ``(False, "<reason>")`` so the caller can decide
+    whether to skip silently or surface.
+    """
+    try:
+        res = subprocess.run(
+            ["git", "-C", cwd, *args],
+            capture_output=True,
+            text=True,
+        )
+    except (FileNotFoundError, OSError) as exc:
+        return False, f"git invocation failed ({type(exc).__name__}): {exc}"
+    if res.returncode == 0:
+        return True, res.stdout.strip()
+    return False, (res.stderr or res.stdout).strip()
+
+
+def _is_safe_to_reap(worktree_path: Path) -> bool:
+    """Mirror of :func:`scitex_agent_container._state.worktree_safety.is_safe_to_reap`.
+
+    Re-implemented inline so the hook script has ZERO scitex import
+    dependency at runtime — the hook runs from ``$HOME/.claude/hooks/``
+    where the sac package may or may not be on ``sys.path`` depending
+    on which venv launched Claude. The semantics are identical:
+
+    Returns True iff ALL of:
+      * ``worktree_path/.git`` exists (it really IS a worktree).
+      * ``git -C <path> status --porcelain`` is empty (clean tree).
+      * ``git -C <path> rev-list develop..HEAD`` is empty (not ahead).
+
+    Any error or ambiguity → False (default-False = annoying-but-safe,
+    NEVER destructive — matches lead-learnings/19 doctrine).
+    """
+    if not (worktree_path / ".git").exists():
+        return False
+    ok_status, status_out = _run_git("status", "--porcelain", cwd=str(worktree_path))
+    if not ok_status:
+        return False
+    if status_out.strip():
+        return False
+    ok_ahead, ahead_out = _run_git("rev-list", "develop..HEAD", cwd=str(worktree_path))
+    if not ok_ahead:
+        return False
+    if ahead_out.strip():
+        return False
+    return True
+
+
+def _candidate_roots(cwd: str) -> list[Path]:
+    """Discover the canonical agent-worktree roots to scan.
+
+    Two sources contribute candidate roots:
+      1. The git root discovered from ``cwd`` (if any) — adds
+         ``<git-root>/.worktrees/`` per :data:`_CANONICAL_ROOT_RELS_FROM_GIT_ROOT`.
+      2. ``$HOME`` — adds ``.claude/worktrees`` per
+         :data:`_CANONICAL_ROOT_RELS_FROM_HOME`.
+
+    Missing roots (no git context, no ``$HOME``) just don't contribute —
+    silent skip, no error. De-duplicated so a symlinked layout doesn't
+    double-scan.
+    """
+    roots: list[Path] = []
+    seen: set[Path] = set()
+    git_ok, git_out = _run_git("rev-parse", "--show-toplevel", cwd=cwd)
+    if git_ok and git_out:
+        for rel in _CANONICAL_ROOT_RELS_FROM_GIT_ROOT:
+            candidate = Path(git_out) / rel
+            resolved = candidate.resolve() if candidate.exists() else candidate
+            if resolved not in seen:
+                seen.add(resolved)
+                roots.append(candidate)
+    home = os.environ.get("HOME", "").strip()
+    if home:
+        for rel in _CANONICAL_ROOT_RELS_FROM_HOME:
+            candidate = Path(home) / rel
+            resolved = candidate.resolve() if candidate.exists() else candidate
+            if resolved not in seen:
+                seen.add(resolved)
+                roots.append(candidate)
+    return roots
+
+
+def _stale_children(root: Path, age_hours: int, now: float) -> list[Path]:
+    """List immediate subdirectories of ``root`` whose mtime is older
+    than ``age_hours``.
+
+    Only walks one level deep — agent-worktree roots are flat:
+    ``<root>/<name>/``. Anything nested deeper is either a regular
+    worktree's git-internals (whose mtimes the predicate already gates
+    on) or operator-managed content we shouldn't touch.
+
+    Missing root → empty list (no-op). Permission errors → empty list +
+    no raise (fail-open).
+    """
+    threshold = now - (age_hours * 3600)
+    if not root.is_dir():
+        return []
+    try:
+        children = list(root.iterdir())
+    except OSError:
+        # stx-allow: fallback (reason: permission/IO error on root listing
+        # must NOT wedge SessionStart — degrade to "nothing to reap here")
+        return []
+    out: list[Path] = []
+    for child in children:
+        if not child.is_dir():
+            continue
+        try:
+            mtime = child.stat().st_mtime
+        except OSError:
+            # stx-allow: fallback (reason: stat failure on one child must
+            # not block the rest of the scan; skip and continue)
+            continue
+        if mtime <= threshold:
+            out.append(child)
+    return out
+
+
+def _reap_one(worktree_path: Path) -> tuple[bool, str]:
+    """Attempt to reap ONE worktree.
+
+    Order of operations:
+      1. Predicate gate: :func:`_is_safe_to_reap` MUST return True.
+      2. Resolve the worktree's containing git root (the worktree
+         itself works — ``git -C <worktree>`` resolves to the main repo
+         transparently because ``.git`` is a gitlink).
+      3. ``git worktree remove <path>`` — clean teardown.
+      4. On failure, ``git worktree remove --force <path>`` — second
+         pass for residual locks/marker files.
+
+    Returns ``(True, "")`` on successful reap, ``(False, "<reason>")``
+    on any skip. The reason string is for the operator-visible stderr
+    summary, not for retry logic.
+    """
+    if not _is_safe_to_reap(worktree_path):
+        return False, "predicate-gated"
+    # Resolve git root from the worktree itself (its ``.git`` gitlink
+    # points back at the main repo); fall back to the parent (typical
+    # ``<git-root>/.worktrees/<name>`` layout) if the worktree's gitlink
+    # is broken.
+    candidates = [str(worktree_path), str(worktree_path.parent)]
+    git_root = ""
+    for cand in candidates:
+        ok, out = _run_git("rev-parse", "--show-toplevel", cwd=cand)
+        if ok and out:
+            git_root = out
+            break
+    if not git_root:
+        return False, "no-git-root"
+    ok, _ = _run_git("worktree", "remove", str(worktree_path), cwd=git_root)
+    if ok:
+        return True, ""
+    ok2, err2 = _run_git(
+        "worktree", "remove", "--force", str(worktree_path), cwd=git_root
+    )
+    if ok2:
+        return True, ""
+    return False, f"git-refused: {err2}"
+
+
+def _summarize(reaped: int, skipped: int, roots: list[Path]) -> str:
+    """One-line operator-visible summary written to stderr."""
+    roots_repr = ",".join(str(r) for r in roots) or "<none>"
+    return (
+        f"SessionStart auto-reap: reaped={reaped} skipped={skipped} roots={roots_repr}"
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Read SessionStart payload from stdin; reap stale agent worktrees.
+
+    Fail-open across the board: any error → log to stderr, exit 0.
+    Wedging ``SessionStart`` would brick the SDK session, which is far
+    worse than leaving a stale worktree dir on disk (the operator's
+    prune cron picks it up on next pass).
+
+    CLI args (parsed off ``argv``, defaults to ``sys.argv[1:]``):
+      ``--age-hours N``  override the 24h threshold (tests inject).
+      ``--now-epoch S``  override ``time.time()`` (tests inject).
+    """
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--age-hours", type=int, default=DEFAULT_AGE_HOURS)
+    parser.add_argument("--now-epoch", type=float, default=None)
+    args, _ = parser.parse_known_args(argv if argv is not None else sys.argv[1:])
+
+    now = args.now_epoch if args.now_epoch is not None else time.time()
+
+    raw = sys.stdin.read() if not sys.stdin.isatty() else ""
+    cwd = ""
+    if raw.strip():
+        try:
+            payload = json.loads(raw)
+            cwd = (payload.get("cwd") or "").strip()
+        except json.JSONDecodeError:
+            # stx-allow: fallback (reason: malformed stdin must not wedge
+            # SessionStart; degrade to cwd=$PWD discovery below)
+            cwd = ""
+    if not cwd or not os.path.isdir(cwd):
+        cwd = os.getcwd()
+
+    roots = _candidate_roots(cwd)
+    reaped = 0
+    skipped = 0
+    for root in roots:
+        for child in _stale_children(root, args.age_hours, now):
+            ok, _reason = _reap_one(child)
+            if ok:
+                reaped += 1
+            else:
+                skipped += 1
+
+    print(_summarize(reaped, skipped, roots), file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/scitex_agent_container/_baseline_assets/claude_worktree_hooks/settings.local.json.fragment.json
+++ b/src/scitex_agent_container/_baseline_assets/claude_worktree_hooks/settings.local.json.fragment.json
@@ -1,5 +1,5 @@
 {
-  "_comment_worktree_hooks": "Claude Code WorktreeCreate / WorktreeRemove hook wiring. Source-of-truth verified 2026-06-06 against the JS function VRH (executeWorktreeCreateHook) in claude_agent_sdk._bundled.claude. Merge into the baseline settings.local.json under `hooks`. Scripts live next to this fragment as worktree_create.py / worktree_remove.py and must be deployed to $HOME/.claude/hooks/claude_worktree_hooks/ on every agent via to_home materialization.",
+  "_comment_worktree_hooks": "Claude Code WorktreeCreate / WorktreeRemove / SessionStart hook wiring. WorktreeCreate/Remove source-of-truth verified 2026-06-06 against the JS function VRH (executeWorktreeCreateHook) in claude_agent_sdk._bundled.claude. SessionStart added 2026-06-14 for card sac-stale-worktree-autoreap-enable: reaps the agent's OWN stale worktrees BEFORE the SDK's first bloat-scan, closing the F-CS8 recurrence window left open after PR #93 made the predicate safe but not automatic. Merge into the baseline settings.local.json under `hooks`. Scripts live next to this fragment and must be deployed to $HOME/.claude/hooks/claude_worktree_hooks/ on every agent via to_home materialization. python3 is PATH-based (NOT pinned to /opt/venv-agent/bin/python3) because fleet-wide WorktreeCreate breakage on 2026-06-13 (lead a2a 07a9187b/777d0a5a) traced to an interpreter-path drift across SIFs.",
 
   "hooks": {
     "WorktreeCreate": [
@@ -18,6 +18,16 @@
           {
             "type": "command",
             "command": "/opt/venv-agent/bin/python3 $HOME/.claude/hooks/claude_worktree_hooks/worktree_remove.py"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/opt/venv-agent/bin/python3 $HOME/.claude/hooks/claude_worktree_hooks/session_start_reap_stale.py"
           }
         ]
       }

--- a/tests/scitex_agent_container/_baseline_assets/claude_worktree_hooks/test_session_start_reap_stale.py
+++ b/tests/scitex_agent_container/_baseline_assets/claude_worktree_hooks/test_session_start_reap_stale.py
@@ -28,8 +28,6 @@ import sys
 import time
 from pathlib import Path
 
-import pytest
-
 from .conftest import _git
 
 # The hook script lives next to its siblings under

--- a/tests/scitex_agent_container/_baseline_assets/claude_worktree_hooks/test_session_start_reap_stale.py
+++ b/tests/scitex_agent_container/_baseline_assets/claude_worktree_hooks/test_session_start_reap_stale.py
@@ -1,0 +1,200 @@
+"""End-to-end tests for the ``session_start_reap_stale.py`` hook.
+
+NO MOCKS. Every test drives the real hook script as a subprocess against
+a real ephemeral git repository (see ``conftest.py``'s ``ephemeral_repo``
+fixture). Stale worktrees are simulated with real ``os.utime`` calls on
+real worktree dirs created via ``git worktree add`` — the predicate's
+``develop..HEAD``-empty check sees real refs, the mtime gate sees real
+mtimes.
+
+The hook MUST be fail-open (exit 0 across the board) so a misfire never
+wedges Claude Code's ``SessionStart`` event handler. The tests pin both
+the success-side behaviour (stale + safe → reaped) and the safety-side
+behaviour (recent → preserved, predicate-failing → preserved, no roots
+→ no-op + exit 0, broken git → exit 0).
+
+TQ: every test carries ``# Arrange`` / ``# Act`` / ``# Assert`` markers
+on their own lines with at least one code statement between consecutive
+markers, a >=3-word descriptive name, and exactly one assertion
+(STX-TQ002 / STX-TQ007).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from .conftest import _git
+
+# The hook script lives next to its siblings under
+# ``_baseline_assets/claude_worktree_hooks/``. Resolved relative to this
+# test file so a refactor of the asset path is caught at import time.
+SESSION_START_HOOK_SCRIPT = (
+    Path(__file__).resolve().parents[4]
+    / "src"
+    / "scitex_agent_container"
+    / "_baseline_assets"
+    / "claude_worktree_hooks"
+    / "session_start_reap_stale.py"
+)
+
+
+def _session_start_payload(cwd: Path) -> dict:
+    """Mirror the shape Claude Code's SessionStart hook emits on stdin."""
+    return {
+        "hook_event_name": "SessionStart",
+        "source": "startup",
+        "cwd": str(cwd),
+        "session_id": "test-session-id",
+        "transcript_path": str(cwd / ".transcript"),
+        "permission_mode": "default",
+        "agent_id": "test-agent-id",
+        "agent_type": "test",
+    }
+
+
+def _run_session_start(
+    payload: dict,
+    *,
+    extra_args: list[str] | None = None,
+    env: dict | None = None,
+) -> subprocess.CompletedProcess:
+    """Invoke the SessionStart hook script with the JSON payload on stdin.
+
+    ``extra_args`` lets tests pass ``--age-hours`` / ``--now-epoch``
+    overrides; ``env`` lets tests inject ``HOME`` / clear ``PATH`` to
+    exercise the fail-open paths.
+    """
+    cmd = [sys.executable, str(SESSION_START_HOOK_SCRIPT)]
+    if extra_args:
+        cmd.extend(extra_args)
+    return subprocess.run(
+        cmd,
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def _make_worktree(repo: Path, name: str) -> Path:
+    """Add a real ``git worktree`` at ``<repo>/.worktrees/<name>``.
+
+    The hook scans canonical agent-worktree roots; this helper builds a
+    real one so the predicate's ``status --porcelain`` + ``rev-list
+    develop..HEAD`` checks operate on real refs (no mocks).
+    """
+    target = repo / ".worktrees" / name
+    target.parent.mkdir(parents=True, exist_ok=True)
+    _git(repo, "worktree", "add", "-b", f"claude/{name}", str(target), "develop")
+    return target
+
+
+def _age_worktree(worktree: Path, hours: float) -> None:
+    """Backdate ``worktree`` mtime by ``hours`` so the age gate trips.
+
+    Backdates the directory's own mtime — that's what the hook's
+    ``_stale_children`` reads when classifying a candidate. Real
+    ``os.utime`` on a real path; no mocks.
+    """
+    new_time = time.time() - (hours * 3600)
+    os.utime(worktree, (new_time, new_time))
+
+
+# ---------------------------------------------------------------------------
+# Reap path: stale + safe -> removed
+# ---------------------------------------------------------------------------
+
+
+class TestSessionStartAutoReap:
+    def test_hook_reaps_a_25h_old_worktree(self, ephemeral_repo: Path) -> None:
+        # Arrange — a real worktree backdated past the 24h threshold;
+        # clean tree + not-ahead-of-develop so the safety predicate
+        # admits it.
+        target = _make_worktree(ephemeral_repo, "stale-reapable")
+        _age_worktree(target, hours=25)
+        payload = _session_start_payload(ephemeral_repo)
+        # Act
+        _run_session_start(payload)
+        # Assert — git no longer registers the worktree.
+        listed = _git(ephemeral_repo, "worktree", "list", "--porcelain")
+        assert f"worktree {target}" not in listed
+
+    def test_hook_preserves_a_2h_old_worktree(self, ephemeral_repo: Path) -> None:
+        # Arrange — a real worktree well within the 24h grace window.
+        target = _make_worktree(ephemeral_repo, "fresh-preserve")
+        _age_worktree(target, hours=2)
+        payload = _session_start_payload(ephemeral_repo)
+        # Act
+        _run_session_start(payload)
+        # Assert — git still registers the worktree (age gate skipped it).
+        listed = _git(ephemeral_repo, "worktree", "list", "--porcelain")
+        assert f"worktree {target}" in listed
+
+    def test_hook_preserves_a_dirty_stale_worktree(self, ephemeral_repo: Path) -> None:
+        # Arrange — stale by mtime, but DIRTY (untracked file) so the
+        # safety predicate refuses. Auto-reap must NEVER destroy dirty
+        # work (lead-learnings/19 doctrine, paired with PR #369 rescue).
+        target = _make_worktree(ephemeral_repo, "dirty-stale")
+        (target / "scratch.txt").write_text("uncommitted work\n")
+        _age_worktree(target, hours=48)
+        payload = _session_start_payload(ephemeral_repo)
+        # Act
+        _run_session_start(payload)
+        # Assert — predicate-gated; the dirty worktree is preserved.
+        listed = _git(ephemeral_repo, "worktree", "list", "--porcelain")
+        assert f"worktree {target}" in listed
+
+    def test_hook_exits_zero_on_reap_success(self, ephemeral_repo: Path) -> None:
+        # Arrange
+        target = _make_worktree(ephemeral_repo, "exit-code-probe")
+        _age_worktree(target, hours=72)
+        payload = _session_start_payload(ephemeral_repo)
+        # Act
+        result = _run_session_start(payload)
+        # Assert — SessionStart MUST be fail-open: exit 0 on success.
+        assert result.returncode == 0
+
+
+# ---------------------------------------------------------------------------
+# No-op path: missing roots, broken env -> exit 0, no crash
+# ---------------------------------------------------------------------------
+
+
+class TestSessionStartNoop:
+    def test_hook_no_op_when_no_agent_worktrees_dir_exists(
+        self, tmp_path: Path
+    ) -> None:
+        # Arrange — a non-git tmpdir with NO .worktrees/ root; an empty
+        # $HOME (so .claude/worktrees also resolves to nothing). The
+        # hook must walk away cleanly.
+        empty_cwd = tmp_path / "no-repo-here"
+        empty_cwd.mkdir()
+        empty_home = tmp_path / "empty-home"
+        empty_home.mkdir()
+        env = {**os.environ, "HOME": str(empty_home)}
+        payload = _session_start_payload(empty_cwd)
+        # Act
+        result = _run_session_start(payload, env=env)
+        # Assert — exit 0, hook is a true no-op when there's nothing
+        # to scan.
+        assert result.returncode == 0
+
+    def test_hook_fails_open_on_prune_error(self, tmp_path: Path) -> None:
+        # Arrange — drive the hook with an empty PATH so the subprocess
+        # spawn of ``git`` fails (FileNotFoundError). Every reap attempt
+        # MUST degrade silently; the hook MUST NOT exit non-zero.
+        target_cwd = tmp_path / "any-cwd"
+        target_cwd.mkdir()
+        env = {"HOME": str(tmp_path), "PATH": ""}
+        payload = _session_start_payload(target_cwd)
+        # Act
+        result = _run_session_start(payload, env=env)
+        # Assert — fail-open: even with no git binary reachable, exit 0.
+        assert result.returncode == 0


### PR DESCRIPTION
## Summary

Closes the F-CS8 recurrence window left open after PR #93 made stale agent-worktrees REAPABLE (`--stale`) but NOT automatic. Card sac-stale-worktree-autoreap-enable, option (b) per lead a2a 539e61c5.

## Shape

- New SessionStart hook `session_start_reap_stale.py` reaps the agent.s OWN stale worktrees BEFORE the SDK.s first bloat-scan.
- Age-gated (>24h), agent-worktrees-only (`~/.claude/worktrees/`), and fail-open (a reap miss never blocks session start).
- Wired via `settings.local.json.fragment.json` SessionStart entry that to_home materialises into every agent.s `.claude/hooks/`.

## Test plan

- Real on-disk `git init` + `os.utime(mtime=now-25h)` fixture (NO mocks/MagicMock/monkeypatch).
- One assert per test, AAA markers each on own line per STX-TQ002/007.

Closes card sac-stale-worktree-autoreap-enable.