### PR TITLE
feat(cli): sac agents new — scaffold fresh v3 spec.yaml + to_home/ (sac-fresh-agent-specs)

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_new.py
+++ b/src/scitex_agent_container/cli_pkg/_new.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""``sac agents new NAME`` — scaffold a fresh v3 agent spec.
+
+Card sac-fresh-agent-specs (2026-06-13). "Author fresh specs from a
+clean template, not in-place repair" — operators get a v3-clean
+``spec.yaml`` + ``to_home/`` skeleton next to it, ready to edit. The
+templates here are the canonical reference; they must always satisfy
+:func:`scitex_agent_container.config._validation.validate_config`
+without any operator edits (the tests assert this invariant).
+
+Two templates ship out of the box:
+
+  * ``minimal`` (default) — bare-minimum spec mirroring
+    ``examples/agents/minimal-agent/``. Three blocks: ``apptainer.image``,
+    ``claude.model``, ``claude.flags``. Use as the starting point for new
+    agents you'll customise yourself.
+  * ``full`` — full-fat spec mirroring
+    ``examples/agents/full-agent/`` (sans the inline tutorial comments).
+    Use when you want every knob present so you can delete what you
+    don't need rather than look up what's available.
+
+The CLI refuses to overwrite an existing ``spec.yaml`` unless ``--force``
+is passed — protects the "60 stale ``*-quality`` specs already pending
+uncommitted" scenario the card calls out.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import click
+
+# Agent names follow the dir-as-SSoT convention: lowercase letters,
+# digits, dashes, underscores. Slashes / dots would write outside the
+# base dir or shadow YAML extension suffixes. Mirrors the constraints
+# enforced by the lifecycle dispatcher.
+_VALID_NAME_CHARS = set("abcdefghijklmnopqrstuvwxyz0123456789-_")
+
+
+def _is_valid_agent_name(name: str) -> bool:
+    """Return True iff ``name`` is safe to use as a directory name.
+
+    Pure predicate — used by the CLI for an early reject so we never
+    write ``spec.yaml`` outside ``base_dir`` via a slash-bearing name.
+    """
+    if not name:
+        return False
+    return all(ch in _VALID_NAME_CHARS for ch in name)
+
+
+_MINIMAL_TEMPLATE = """\
+# {name} — fresh v3 spec scaffolded by ``sac agents new``.
+#
+# This is the minimal shape: image, model, permissions flag. Add health,
+# restart, startup_prompts, etc. as you need them — see
+# ``examples/agents/full-agent/spec.yaml`` for the full annotated tour.
+
+apiVersion: scitex-agent-container/v3
+kind: Agent
+
+spec:
+  runtime: apptainer
+
+  apptainer:
+    image: ~/.scitex/agent-container/containers/sac-base.sif
+
+  claude:
+    model: haiku
+    flags:
+      - --dangerously-skip-permissions
+
+# EOF
+"""
+
+
+_FULL_TEMPLATE = """\
+# {name} — fresh v3 spec scaffolded by ``sac agents new --template full``.
+#
+# Every field below validates against the live v3 schema. Delete blocks
+# you don't need rather than chase the spec reference for what's
+# available.
+
+apiVersion: scitex-agent-container/v3
+kind: Agent
+
+metadata:
+  labels:
+    role: worker
+    team: scitex
+    description: |
+      {name} — fresh v3 agent. Replace this description and the
+      startup prompt with your agent's actual mission.
+    function: scaffolded
+    capabilities: scaffolded
+    skills: ""
+    cardinality: singleton
+
+spec:
+  runtime: apptainer
+
+  to_home: ./to_home
+
+  python-venv: auto
+
+  apptainer:
+    image: ~/.scitex/agent-container/containers/sac-scitex.sif
+    relaxed: false
+
+  claude:
+    model: sonnet
+    flags:
+      - --dangerously-skip-permissions
+    session: continue
+    auto_accept: true
+
+  startup_prompts:
+    - |
+      You are {name}. Replace this prompt with your agent's actual
+      mission. Reply READY when initialized.
+
+  health:
+    enabled: true
+    interval: 60
+    timeout: 10
+    method: sdk-alive
+
+  restart:
+    policy: on-failure
+    max_retries: 3
+    backoff:
+      initial: 10
+      max: 120
+      multiplier: 2
+
+  a2a:
+    port: auto
+
+# EOF
+"""
+
+
+_TEMPLATES = {
+    "minimal": _MINIMAL_TEMPLATE,
+    "full": _FULL_TEMPLATE,
+}
+
+
+def _default_base_dir() -> Path:
+    """Return ``~/.scitex/agent-container/agents`` (sac's primary root).
+
+    Resolved lazily so the CLI can be imported without touching the
+    filesystem (matters for cold-start budget + tab-completion).
+    """
+    return Path.home() / ".scitex" / "agent-container" / "agents"
+
+
+@click.command(name="new")
+@click.argument("name", type=str)
+@click.option(
+    "--template",
+    "template_name",
+    type=click.Choice(sorted(_TEMPLATES), case_sensitive=False),
+    default="minimal",
+    show_default=True,
+    help=(
+        "Template preset to scaffold. 'minimal' = bare-minimum spec "
+        "(image + model). 'full' = annotated v3 spec with every "
+        "common block pre-filled."
+    ),
+)
+@click.option(
+    "--base-dir",
+    "base_dir",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=None,
+    help=(
+        "Parent directory under which ``<name>/spec.yaml`` is written. "
+        "Default: ~/.scitex/agent-container/agents/ (sac's primary "
+        "agents root, matches the resolver search-chain entry #1)."
+    ),
+)
+@click.option(
+    "--force",
+    is_flag=True,
+    default=False,
+    help=(
+        "Overwrite an existing spec.yaml. Off by default so accidental "
+        "re-runs cannot clobber a customised spec."
+    ),
+)
+def new(name: str, template_name: str, base_dir: Path | None, force: bool) -> None:
+    """Scaffold a fresh v3 ``spec.yaml`` for a new agent.
+
+    Writes ``<base-dir>/<name>/spec.yaml`` (plus an empty ``to_home/``
+    sibling) from the chosen template. The template is guaranteed to
+    pass ``validate_config`` without operator edits.
+
+    Examples:
+
+    \b
+        sac agents new my-agent
+        sac agents new my-agent --template full
+        sac agents new my-agent --base-dir ./agents --force
+    """
+    if not _is_valid_agent_name(name):
+        raise click.UsageError(
+            f"Invalid agent name {name!r}. Use lowercase letters, "
+            "digits, '-', and '_' only (dir-as-SSoT convention)."
+        )
+
+    base = base_dir if base_dir is not None else _default_base_dir()
+    agent_dir = base / name
+    spec_path = agent_dir / "spec.yaml"
+
+    if spec_path.exists() and not force:
+        raise click.ClickException(
+            f"Refusing to overwrite existing spec at {spec_path}. "
+            "Re-run with --force to replace, or pick a different name."
+        )
+
+    template = _TEMPLATES[template_name.lower()]
+    body = template.format(name=name)
+
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    spec_path.write_text(body)
+
+    # to_home/ sibling — the runtime auto-discovers it as the materialised
+    # container $HOME source (ADR-0006). Empty dir is fine; operator
+    # adds CLAUDE.md / .mcp.json / .claude/... as needed.
+    to_home = agent_dir / "to_home"
+    to_home.mkdir(parents=True, exist_ok=True)
+
+    print(
+        f"Wrote {spec_path} (template={template_name}).",
+        file=sys.stderr,
+        flush=True,
+    )
+
+
+__all__ = ["new"]

--- a/src/scitex_agent_container/cli_pkg/agent_group.py
+++ b/src/scitex_agent_container/cli_pkg/agent_group.py
@@ -14,6 +14,7 @@ import click
 
 from ._agent_prune_claude import prune_claude as _prune_claude_impl
 from ._helpers import HelpRecursiveGroup
+from ._new import new as _new_impl
 from .agents_prune_claude import archive_claude_bloat as _archive_claude_bloat_impl
 from .build_cmds import check as _check_impl
 from .info_cmds import find as _find_impl
@@ -47,7 +48,7 @@ class _AgentsGroup(HelpRecursiveGroup):
     COMMAND_CATEGORIES = [
         (
             "Lifecycle",
-            ["start", "stop", "restart", "delete", "forget", "spawn-from-here"],
+            ["new", "start", "stop", "restart", "delete", "forget", "spawn-from-here"],
         ),
         ("Interact", ["send"]),
         ("Inspect", ["list", "status", "health", "tail", "recall"]),
@@ -64,6 +65,10 @@ def agent_group() -> None:
 
 
 # Lifecycle verbs
+# `new` scaffolds a fresh v3 spec.yaml + to_home/ skeleton (card
+# sac-fresh-agent-specs, 2026-06-13). Placed FIRST in the lifecycle
+# block — authoring precedes start/stop.
+agent_group.add_command(_rebind(_new_impl, "new"))
 agent_group.add_command(_rebind(_start_impl, "start"))
 agent_group.add_command(_rebind(_stop_impl, "stop"))
 agent_group.add_command(_rebind(_restart_impl, "restart"))

--- a/tests/scitex_agent_container/cli_pkg/test__new.py
+++ b/tests/scitex_agent_container/cli_pkg/test__new.py
@@ -1,0 +1,149 @@
+"""Tests for ``sac agents new`` — scaffold a fresh v3 spec.yaml.
+
+Card sac-fresh-agent-specs (2026-06-13). Authoring policy is "fresh
+template, not in-place repair": the operator runs ``sac agents new
+<name>`` and gets a v3-clean spec.yaml + to_home/ skeleton next to it,
+ready to edit. The validator must accept the output as-is.
+
+Discipline: AAA markers each on their own line; one literal ``assert``
+per test; real filesystem fixtures (``tmp_path``), no mocks.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+from click.testing import CliRunner
+
+from scitex_agent_container.cli_pkg._new import new as new_cmd
+from scitex_agent_container.config._validation import validate_config
+
+
+def test_new_writes_spec_yaml_at_target(tmp_path: Path) -> None:
+    # Arrange
+    runner = CliRunner()
+    base = tmp_path / "agents"
+    # Act
+    runner.invoke(new_cmd, ["my-agent", "--base-dir", str(base)])
+    # Assert
+    assert (base / "my-agent" / "spec.yaml").is_file()
+
+
+def test_new_minimal_template_passes_v3_validator(tmp_path: Path) -> None:
+    # Arrange
+    runner = CliRunner()
+    base = tmp_path / "agents"
+    # Act
+    runner.invoke(
+        new_cmd, ["fresh-agent", "--base-dir", str(base), "--template", "minimal"]
+    )
+    errors = validate_config(base / "fresh-agent" / "spec.yaml")
+    # Assert — fresh template must satisfy the live validator (zero errors).
+    assert errors == []
+
+
+def test_new_full_template_passes_v3_validator(tmp_path: Path) -> None:
+    # Arrange
+    runner = CliRunner()
+    base = tmp_path / "agents"
+    # Act
+    runner.invoke(
+        new_cmd, ["full-fresh", "--base-dir", str(base), "--template", "full"]
+    )
+    errors = validate_config(base / "full-fresh" / "spec.yaml")
+    # Assert
+    assert errors == []
+
+
+def test_new_default_template_is_minimal(tmp_path: Path) -> None:
+    # Arrange
+    runner = CliRunner()
+    base = tmp_path / "agents"
+    runner.invoke(new_cmd, ["defaulty", "--base-dir", str(base)])
+    # Act — parse the spec YAML to inspect the rendered config keys, NOT
+    # the prose docstring (the comment legitimately MENTIONS the field
+    # name as an "add this if you need it" pointer).
+    parsed = yaml.safe_load((base / "defaulty" / "spec.yaml").read_text())
+    # Assert — minimal template omits startup_prompts; the full template ships it.
+    assert "startup_prompts" not in parsed.get("spec", {})
+
+
+def test_new_creates_to_home_skeleton(tmp_path: Path) -> None:
+    # Arrange
+    runner = CliRunner()
+    base = tmp_path / "agents"
+    # Act
+    runner.invoke(new_cmd, ["agent-x", "--base-dir", str(base)])
+    # Assert — to_home/ exists as a sibling of spec.yaml so the runtime
+    # auto-discovers it (spec-reference §to_home).
+    assert (base / "agent-x" / "to_home").is_dir()
+
+
+def test_new_refuses_to_overwrite_existing_spec(tmp_path: Path) -> None:
+    # Arrange
+    runner = CliRunner()
+    base = tmp_path / "agents"
+    (base / "dupe").mkdir(parents=True)
+    (base / "dupe" / "spec.yaml").write_text("# pre-existing\n")
+    # Act
+    result = runner.invoke(new_cmd, ["dupe", "--base-dir", str(base)])
+    # Assert — non-zero exit so accidental clobber is impossible without --force.
+    assert result.exit_code != 0
+
+
+def test_new_force_overwrites_existing_spec(tmp_path: Path) -> None:
+    # Arrange
+    runner = CliRunner()
+    base = tmp_path / "agents"
+    (base / "dupe2").mkdir(parents=True)
+    (base / "dupe2" / "spec.yaml").write_text("# stale\n")
+    # Act
+    runner.invoke(new_cmd, ["dupe2", "--base-dir", str(base), "--force"])
+    text = (base / "dupe2" / "spec.yaml").read_text()
+    # Assert — fresh template replaces the stale stub (apiVersion line is canonical).
+    assert "scitex-agent-container/v3" in text
+
+
+def test_new_rejects_unknown_template(tmp_path: Path) -> None:
+    # Arrange
+    runner = CliRunner()
+    base = tmp_path / "agents"
+    # Act
+    result = runner.invoke(
+        new_cmd, ["bad", "--base-dir", str(base), "--template", "nope"]
+    )
+    # Assert — Click's Choice raises UsageError (exit code 2).
+    assert result.exit_code != 0
+
+
+def test_new_emits_canonical_apiversion_header(tmp_path: Path) -> None:
+    # Arrange
+    runner = CliRunner()
+    base = tmp_path / "agents"
+    # Act
+    runner.invoke(new_cmd, ["headered", "--base-dir", str(base)])
+    first_lines = (base / "headered" / "spec.yaml").read_text().splitlines()[:10]
+    # Assert — apiVersion appears in the file head (no buried boilerplate).
+    assert any("apiVersion: scitex-agent-container/v3" in line for line in first_lines)
+
+
+def test_new_template_kind_is_agent_not_agentproxy(tmp_path: Path) -> None:
+    # Arrange
+    runner = CliRunner()
+    base = tmp_path / "agents"
+    # Act
+    runner.invoke(new_cmd, ["kindly", "--base-dir", str(base)])
+    text = (base / "kindly" / "spec.yaml").read_text()
+    # Assert — default scaffold is the common case (SDK runner).
+    assert "kind: Agent" in text
+
+
+def test_new_rejects_invalid_agent_name(tmp_path: Path) -> None:
+    # Arrange — names with slashes would write outside the base dir.
+    runner = CliRunner()
+    base = tmp_path / "agents"
+    # Act
+    result = runner.invoke(new_cmd, ["bad/name", "--base-dir", str(base)])
+    # Assert
+    assert result.exit_code != 0


### PR DESCRIPTION
## Summary

Card `sac-fresh-agent-specs` — scaffold a fresh v3-clean `spec.yaml` next to a new agent dir via a new `sac agents new <name>` CLI subcommand. Authoring policy is "fresh template, not in-place repair" (per the card body: discipline via tooling, not prompt text).

## Substance

- New `cli_pkg/_new.py` — Click subcommand `sac agents new <name> [--base-dir DIR] [--template minimal|full]`. Writes `spec.yaml` + `to_home/` skeleton next to it. Template options pick between a minimal (image+model+permissions only) and a full annotated tour.
- `cli_pkg/agent_group.py` — wires the new subcommand into the existing `sac agents` group.

## Tests

11 tests (one assert each, AAA markers each on own line, no mocks). Real `tmp_path` fixtures, real `validate_config` round-trip to confirm the generated spec passes the validator end-to-end.

## Out of scope

- Bulk-delete of the 60 stale `*-quality` specs referenced in the card body (operator-local concern, not a sac code change).
- Pre-commit hook to warn on stale ids (separate follow-up PR).
