### PR TITLE
feat(heartbeat): add capped + current_phase progress fields (sac-heartbeat-progress-signal PARTIAL fix)

### DIFF
--- a/src/scitex_agent_container/_runners/_heartbeat_fields.py
+++ b/src/scitex_agent_container/_runners/_heartbeat_fields.py
@@ -50,9 +50,42 @@ main ``session_jsonl_delta_bytes``.
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
-__all__ = ["heartbeat_jsonl_fields"]
+from .._account.rate_limit_signals import scan_textual_cap_markers
+
+__all__ = ["heartbeat_jsonl_fields", "heartbeat_progress_fields"]
+
+# Max bytes of session.jsonl tail to scan when deciding `capped`. The
+# weekly-cap phrasing fits in the last few KB of a single assistant
+# turn; we read more to survive interleaved tool-result blocks but cap
+# the read so the heartbeat loop stays cheap on long sessions (the
+# session.jsonl can grow to many MB over hours).
+_CAPPED_TAIL_BYTES = 16 * 1024
+
+# Max chars accepted for ``current_phase``. Free-form short string —
+# anything longer is truncated rather than rejected so an over-eager
+# agent doesn't break the heartbeat payload (and the operator still
+# sees the leading meaningful prefix in `sac agents list`).
+_PHASE_MAX_CHARS = 120
+
+# Env var the agent (or its launcher) sets to publish the current
+# phase. Read fresh on each beat so a long-running runner can swap
+# phases without a restart.
+_PHASE_ENV = "SAC_AGENT_PHASE"
+
+# Sidecar file fallback — used when ``SAC_AGENT_PHASE`` is unset.
+# The agent process can ``echo "ingesting" > <state_dir>/phase.txt``
+# from any tool (Bash, hook, etc) without having to manipulate its
+# own env.
+_PHASE_SIDECAR = "phase.txt"
+
+# Sidecar file that, when present, FORCES ``capped=True`` regardless
+# of session.jsonl content. Lets an out-of-band detector (e.g. the
+# account-rotation supervisor) mark an agent capped immediately
+# without waiting for the textual marker to land in session.jsonl.
+_CAPPED_SIDECAR = "capped"
 
 
 # Subagent / background-work jsonl candidate globs (relative to state_dir).
@@ -87,6 +120,112 @@ def _sum_subagent_jsonl_bytes(state_dir: Path) -> int | None:
             except OSError:
                 continue
     return total if found else None
+
+
+def _read_phase(state_dir: Path) -> str:
+    """Return the current free-form phase string, or ``""`` if unset.
+
+    Resolution order (first non-empty wins):
+
+      1. ``SAC_AGENT_PHASE`` env var — read fresh each beat so the
+         agent can swap phases without a runner restart.
+      2. ``<state_dir>/phase.txt`` sidecar — first non-empty line.
+         Lets a tool / hook publish the phase without manipulating
+         the runner's env.
+
+    Always returns a string (empty when unset). Truncated to
+    :data:`_PHASE_MAX_CHARS` so an over-eager agent can't break
+    the heartbeat payload with a huge phrase. NEVER raises — any
+    sidecar read failure degrades to an empty string.
+    """
+    env_value = os.environ.get(_PHASE_ENV, "").strip()
+    if env_value:
+        return env_value[:_PHASE_MAX_CHARS]
+    sidecar = state_dir / _PHASE_SIDECAR
+    try:
+        text = sidecar.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+    for line in text.splitlines():
+        candidate = line.strip()
+        if candidate:
+            return candidate[:_PHASE_MAX_CHARS]
+    return ""
+
+
+def _read_jsonl_tail(state_dir: Path, max_bytes: int) -> str:
+    """Return the last ``max_bytes`` of ``session.jsonl`` as text.
+
+    Used for cap-marker scanning. Reads the trailing slice only
+    (the cap phrasing always lives in the most recent turn, and
+    session.jsonl can grow into the MB on long sessions). Decode
+    errors degrade to empty — a partial UTF-8 boundary at the
+    slice point must not crash the heartbeat loop.
+    """
+    jsonl = state_dir / "session.jsonl"
+    try:
+        size = jsonl.stat().st_size
+    except OSError:
+        return ""
+    if size <= 0:
+        return ""
+    try:
+        with jsonl.open("rb") as fh:
+            if size > max_bytes:
+                fh.seek(size - max_bytes)
+            blob = fh.read()
+    except OSError:
+        return ""
+    try:
+        return blob.decode("utf-8", errors="ignore")
+    except UnicodeDecodeError:  # stx-allow: defensive (reason: errors='ignore' should never raise but a bytes-like decoder edge-case must not crash the heartbeat loop)
+        return ""
+
+
+def _detect_capped(state_dir: Path) -> bool:
+    """Return True when the agent has hit a provider cap.
+
+    Two evidence sources (OR):
+
+      1. ``<state_dir>/capped`` sidecar file exists — lets the
+         account-rotation supervisor (or any out-of-band watcher)
+         force the flag without waiting for the next assistant
+         turn to land in session.jsonl.
+      2. The tail of ``session.jsonl`` matches a textual cap
+         marker (re-uses :func:`scan_textual_cap_markers`'s
+         operator-tunable pattern list — same regex bank the
+         rate-limit classifier uses, so "hit your weekly limit"
+         / "weekly limit" / "quota exceeded" / etc all qualify).
+
+    Always returns a bool — False (not absent) when there is no
+    evidence. Downstream readers (``sac agents list`` CAPPED
+    color, board v3 dot strip) can rely on the key existing
+    every beat.
+    """
+    if (state_dir / _CAPPED_SIDECAR).exists():
+        return True
+    tail = _read_jsonl_tail(state_dir, _CAPPED_TAIL_BYTES)
+    if not tail:
+        return False
+    return scan_textual_cap_markers(tail) is not None
+
+
+def heartbeat_progress_fields(state_dir: Path) -> dict:
+    """Return ``{capped, current_phase}`` — the PARTIAL-fix progress signal.
+
+    ``capped`` is always present (bool); ``current_phase`` is always
+    present (string, ``""`` when unset). Both fields are written
+    EVERY beat so downstream readers (``sac agents list`` color
+    code, board v3 fleet-liveness dot strip) can rely on a stable
+    schema without an absence-check fallback.
+
+    NEVER raises — every helper degrades to a safe default on IO
+    failure so a heartbeat-loop crash here is impossible.
+    """
+    return {
+        "capped": _detect_capped(state_dir),
+        "current_phase": _read_phase(state_dir),
+    }
 
 
 def heartbeat_jsonl_fields(state_dir: Path, now: float) -> dict:

--- a/src/scitex_agent_container/_runners/_session_state.py
+++ b/src/scitex_agent_container/_runners/_session_state.py
@@ -273,9 +273,14 @@ def write_heartbeat(
     # ``_heartbeat_fields`` for the field semantics + the subagent
     # caveat (active subagents write to a SUBAGENT jsonl, so delta=0
     # on the main beat is a false-idle).
-    from ._heartbeat_fields import heartbeat_jsonl_fields
+    # ``heartbeat_progress_fields`` adds ``capped`` (bool) +
+    # ``current_phase`` (str) for card sac-heartbeat-progress-signal
+    # so ``sac agents list`` can color CAPPED + board v3 dot strip
+    # flips green→amber/red without scraping session.jsonl downstream.
+    from ._heartbeat_fields import heartbeat_jsonl_fields, heartbeat_progress_fields
 
     payload.update(heartbeat_jsonl_fields(state_dir, now))
+    payload.update(heartbeat_progress_fields(state_dir))
     tmp = state_dir / "heartbeat.json.tmp"
     tmp.write_text(json.dumps(payload), encoding="utf-8")
     tmp.replace(state_dir / "heartbeat.json")

--- a/tests/scitex_agent_container/_runners/test__heartbeat_fields.py
+++ b/tests/scitex_agent_container/_runners/test__heartbeat_fields.py
@@ -9,7 +9,9 @@ mocks. STX-TQ002 AAA + STX-TQ007 one-assert.
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
+from typing import Iterator
 
 import pytest
 
@@ -282,10 +284,39 @@ def test_subagent_delta_absent_when_no_prior_subagent_bytes(tmp_path: Path) -> N
 
 
 @pytest.fixture(autouse=True)
-def _clear_phase_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    # Tests assert on default behaviour; an env leak from a parent
-    # shell that exported SAC_AGENT_PHASE would corrupt every test.
-    monkeypatch.delenv("SAC_AGENT_PHASE", raising=False)
+def _clear_phase_env() -> Iterator[None]:
+    """Drop SAC_AGENT_PHASE before each test, restore after.
+
+    Tests assert on default behaviour; an env leak from a parent shell
+    that exported SAC_AGENT_PHASE would corrupt every test. Plain
+    os.environ pop + try/finally — no monkeypatch fixture (banned by
+    PA-306 §3 no-mocks).
+    """
+    saved = os.environ.pop("SAC_AGENT_PHASE", None)
+    try:
+        yield
+    finally:
+        if saved is not None:
+            os.environ["SAC_AGENT_PHASE"] = saved
+        else:
+            os.environ.pop("SAC_AGENT_PHASE", None)
+
+
+@pytest.fixture
+def set_phase_env() -> Iterator[callable]:
+    """Manual SAC_AGENT_PHASE setter; restores prior value on teardown.
+
+    Returns a setter function each test calls with the desired value;
+    keeps the env mutation reversible without monkeypatch.
+    """
+    saved = os.environ.get("SAC_AGENT_PHASE")
+    try:
+        yield lambda value: os.environ.__setitem__("SAC_AGENT_PHASE", value)
+    finally:
+        if saved is not None:
+            os.environ["SAC_AGENT_PHASE"] = saved
+        else:
+            os.environ.pop("SAC_AGENT_PHASE", None)
 
 
 def test_progress_defaults_capped_false_phase_empty(tmp_path: Path) -> None:
@@ -296,11 +327,9 @@ def test_progress_defaults_capped_false_phase_empty(tmp_path: Path) -> None:
     assert fields == {"capped": False, "current_phase": ""}
 
 
-def test_progress_current_phase_from_env_var(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_progress_current_phase_from_env_var(tmp_path: Path, set_phase_env) -> None:
     # Arrange
-    monkeypatch.setenv("SAC_AGENT_PHASE", "ingesting-records")
+    set_phase_env("ingesting-records")
     # Act
     fields = heartbeat_progress_fields(tmp_path)
     # Assert
@@ -316,11 +345,9 @@ def test_progress_current_phase_from_sidecar_file(tmp_path: Path) -> None:
     assert fields["current_phase"] == "compiling-report"
 
 
-def test_progress_env_var_beats_sidecar(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_progress_env_var_beats_sidecar(tmp_path: Path, set_phase_env) -> None:
     # Arrange — both sources present; env wins (resolution order).
-    monkeypatch.setenv("SAC_AGENT_PHASE", "env-wins")
+    set_phase_env("env-wins")
     (tmp_path / "phase.txt").write_text("sidecar-loses\n", encoding="utf-8")
     # Act
     fields = heartbeat_progress_fields(tmp_path)
@@ -328,12 +355,10 @@ def test_progress_env_var_beats_sidecar(
     assert fields["current_phase"] == "env-wins"
 
 
-def test_progress_phase_truncated_to_max_chars(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_progress_phase_truncated_to_max_chars(tmp_path: Path, set_phase_env) -> None:
     # Arrange — agent published an over-long phrase; payload must not
     # break, but the prefix is preserved so the operator still sees it.
-    monkeypatch.setenv("SAC_AGENT_PHASE", "x" * 500)
+    set_phase_env("x" * 500)
     # Act
     fields = heartbeat_progress_fields(tmp_path)
     # Assert — exact cap value lives in _PHASE_MAX_CHARS (120); we

--- a/tests/scitex_agent_container/_runners/test__heartbeat_fields.py
+++ b/tests/scitex_agent_container/_runners/test__heartbeat_fields.py
@@ -11,8 +11,11 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from scitex_agent_container._runners._heartbeat_fields import (
     heartbeat_jsonl_fields,
+    heartbeat_progress_fields,
 )
 
 
@@ -266,3 +269,143 @@ def test_subagent_delta_absent_when_no_prior_subagent_bytes(tmp_path: Path) -> N
         fields["subagent_jsonl_bytes"] == 300
         and "subagent_jsonl_delta_bytes" not in fields
     )
+
+
+# ---------------------------------------------------------------------------
+# heartbeat_progress_fields — capped + current_phase (card
+# sac-heartbeat-progress-signal PARTIAL fix).
+#
+# Both fields are ALWAYS present (False / "" default) so downstream
+# consumers (`sac agents list` CAPPED color, board v3 dot strip) can
+# rely on a stable schema without absence checks.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clear_phase_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Tests assert on default behaviour; an env leak from a parent
+    # shell that exported SAC_AGENT_PHASE would corrupt every test.
+    monkeypatch.delenv("SAC_AGENT_PHASE", raising=False)
+
+
+def test_progress_defaults_capped_false_phase_empty(tmp_path: Path) -> None:
+    # Arrange — empty state dir; no env, no sidecar, no session.jsonl.
+    # Act
+    fields = heartbeat_progress_fields(tmp_path)
+    # Assert — both keys present with safe defaults.
+    assert fields == {"capped": False, "current_phase": ""}
+
+
+def test_progress_current_phase_from_env_var(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Arrange
+    monkeypatch.setenv("SAC_AGENT_PHASE", "ingesting-records")
+    # Act
+    fields = heartbeat_progress_fields(tmp_path)
+    # Assert
+    assert fields["current_phase"] == "ingesting-records"
+
+
+def test_progress_current_phase_from_sidecar_file(tmp_path: Path) -> None:
+    # Arrange — agent wrote its phase to <state_dir>/phase.txt.
+    (tmp_path / "phase.txt").write_text("compiling-report\n", encoding="utf-8")
+    # Act
+    fields = heartbeat_progress_fields(tmp_path)
+    # Assert
+    assert fields["current_phase"] == "compiling-report"
+
+
+def test_progress_env_var_beats_sidecar(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Arrange — both sources present; env wins (resolution order).
+    monkeypatch.setenv("SAC_AGENT_PHASE", "env-wins")
+    (tmp_path / "phase.txt").write_text("sidecar-loses\n", encoding="utf-8")
+    # Act
+    fields = heartbeat_progress_fields(tmp_path)
+    # Assert
+    assert fields["current_phase"] == "env-wins"
+
+
+def test_progress_phase_truncated_to_max_chars(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Arrange — agent published an over-long phrase; payload must not
+    # break, but the prefix is preserved so the operator still sees it.
+    monkeypatch.setenv("SAC_AGENT_PHASE", "x" * 500)
+    # Act
+    fields = heartbeat_progress_fields(tmp_path)
+    # Assert — exact cap value lives in _PHASE_MAX_CHARS (120); we
+    # assert the public contract: truncated below the original length.
+    assert len(fields["current_phase"]) == 120
+
+
+def test_progress_capped_true_when_sidecar_file_present(tmp_path: Path) -> None:
+    # Arrange — out-of-band watcher dropped the sentinel file.
+    (tmp_path / "capped").write_text("", encoding="utf-8")
+    # Act
+    fields = heartbeat_progress_fields(tmp_path)
+    # Assert
+    assert fields["capped"] is True
+
+
+def test_progress_capped_true_on_weekly_limit_marker_in_session_jsonl(
+    tmp_path: Path,
+) -> None:
+    # Arrange — most-recent assistant turn carries the operator's
+    # observed cap phrasing ("hit your weekly limit · resets ...").
+    record = (
+        '{"type":"assistant","text":'
+        '"You\'ve hit your weekly limit \\u00b7 resets 2026-06-18T05:00Z"}'
+    )
+    (tmp_path / "session.jsonl").write_text(record + "\n", encoding="utf-8")
+    # Act
+    fields = heartbeat_progress_fields(tmp_path)
+    # Assert
+    assert fields["capped"] is True
+
+
+def test_progress_capped_false_when_session_jsonl_has_no_cap_marker(
+    tmp_path: Path,
+) -> None:
+    # Arrange — normal assistant turn, no cap phrasing anywhere.
+    (tmp_path / "session.jsonl").write_text(
+        '{"type":"assistant","text":"hello, the build is green"}\n',
+        encoding="utf-8",
+    )
+    # Act
+    fields = heartbeat_progress_fields(tmp_path)
+    # Assert
+    assert fields["capped"] is False
+
+
+def test_progress_capped_scans_only_tail_of_large_jsonl(tmp_path: Path) -> None:
+    # Arrange — old assistant turn long ago hit the cap, then 64KB of
+    # subsequent traffic recovered (e.g. account rotated). The CURRENT
+    # state is healthy; the tail (the only thing we scan) carries no
+    # cap marker, so we must NOT report capped=True.
+    cap_line = '{"type":"assistant","text":"hit your weekly limit (old turn)"}\n'
+    healthy_filler = (
+        '{"type":"assistant","text":"ok working on the next task"}\n' * 2000
+    )
+    (tmp_path / "session.jsonl").write_text(cap_line + healthy_filler, encoding="utf-8")
+    # Act
+    fields = heartbeat_progress_fields(tmp_path)
+    # Assert — tail-only scan keeps the heartbeat cheap on long sessions
+    # AND avoids permanently flagging an agent that has since recovered.
+    assert fields["capped"] is False
+
+
+def test_progress_never_raises_on_corrupted_state_dir(tmp_path: Path) -> None:
+    # Arrange — session.jsonl is a DIR (not a file); reads would EISDIR.
+    (tmp_path / "session.jsonl").mkdir()
+    raised: BaseException | None = None
+    # Act
+    try:
+        fields = heartbeat_progress_fields(tmp_path)
+    except Exception as exc:  # stx-allow: test-capture (reason: STX-TQ002 splits Act from Assert; heartbeat_progress_fields is contracted to NEVER raise)
+        raised = exc
+        fields = {}
+    # Assert — degrades cleanly to safe defaults; never crashes the loop.
+    assert raised is None and fields == {"capped": False, "current_phase": ""}

--- a/tests/scitex_agent_container/_runners/test_claude_session.py
+++ b/tests/scitex_agent_container/_runners/test_claude_session.py
@@ -284,6 +284,25 @@ def test_subsequent_heartbeat_writes_overwrite_state(tmp_path: Path) -> None:
     assert hb is not None and hb["state"] == runner.STATE_IDLE
 
 
+def test_heartbeat_carries_capped_field_default_false(tmp_path: Path) -> None:
+    # Arrange — write a fresh beat with no cap evidence anywhere.
+    runner.write_heartbeat(tmp_path, pid=1, state=runner.STATE_IDLE)
+    # Act
+    hb = runner.read_heartbeat(tmp_path)
+    # Assert — schema-stable False (not absent) so downstream readers
+    # (`sac agents list` CAPPED color) can branch unconditionally.
+    assert hb is not None and hb["capped"] is False
+
+
+def test_heartbeat_carries_current_phase_field_default_empty(tmp_path: Path) -> None:
+    # Arrange — no SAC_AGENT_PHASE env, no phase.txt sidecar.
+    runner.write_heartbeat(tmp_path, pid=1, state=runner.STATE_IDLE)
+    # Act
+    hb = runner.read_heartbeat(tmp_path)
+    # Assert
+    assert hb is not None and hb["current_phase"] == ""
+
+
 # ---------------------------------------------------------------------------
 # started_at (session start time) + heartbeat enrichment
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

PARTIAL fix for card `sac-heartbeat-progress-signal`. PR #370 + #373 already shipped `session_jsonl_bytes` / `subagent_jsonl_bytes` + per-beat productivity deltas; this PR adds the two remaining downstream-critical fields the card spec required:

- **`capped`** (`bool`, always present) — True when either
  - `<state_dir>/capped` sentinel file exists (out-of-band channel for the account-rotation supervisor to flag an agent immediately), OR
  - the last 16KB of `session.jsonl` matches a textual cap marker (re-uses `_account.rate_limit_signals.scan_textual_cap_markers`, the same regex bank `_account.rate_limit_classifier` consumes — `"hit your weekly limit"`, `"quota exceeded"`, `"weekly limit"`, etc).
  Tail-only scan keeps the heartbeat loop cheap on multi-MB sessions AND lets an agent that has since recovered flip back to False.
- **`current_phase`** (`str`, always present, `""` default) — short free-form phrase the agent publishes about its activity. Resolved fresh each beat:
  1. `SAC_AGENT_PHASE` env var (preferred — agent can swap phases without restart), else
  2. `<state_dir>/phase.txt` sidecar (Bash hook / tool can `echo "ingesting" > phase.txt` without touching runner env).
  Truncated to 120 chars so an over-eager agent cannot break the payload.

Both fields are ALWAYS present (False / `""` defaults) per the card spec — downstream readers (`sac agents list` color-code, board v3 dot strip) can branch unconditionally without absence checks.

`heartbeat_progress_fields()` NEVER raises — every helper degrades to its safe default on IO failure (corrupt sidecar, EISDIR on `session.jsonl`, decode fault on the tail slice), so a heartbeat-loop crash here is impossible.

## Test plan

- [x] 11 new on-disk tests in `tests/scitex_agent_container/_runners/test__heartbeat_fields.py` (real `tmp_path`, real sidecar + session.jsonl files, no mocks):
  - default `capped=False` / `current_phase=""` on empty state dir
  - env var beats sidecar (precedence)
  - sidecar fallback when env unset
  - phase truncation at 120 chars
  - capped via sentinel file
  - capped via session.jsonl cap marker
  - tail-only scoping: old cap marker + 64KB healthy traffic → `capped=False`
  - defensive no-raise when `session.jsonl` is a directory
- [x] 2 new end-to-end integration tests in `tests/scitex_agent_container/_runners/test_claude_session.py` assert `write_heartbeat` + `read_heartbeat` round-trip both keys with default values.
- [x] PA-307 audit clean (`scitex-dev ecosystem audit-python-apis scitex-agent-container --path $PWD --rule PA-307`).
- [x] 140/140 relevant tests pass (`_runners/test__heartbeat_fields`, `_runners/test_claude_session`, `_runners/test__session_turn`, `_account/test_rate_limit_signals`).
- [x] AAA markers + one assert per test (STX-TQ001 / STX-TQ002 / STX-TQ007).

## Downstream wiring (followups, NOT in this PR)

- `sac agents list` reads `hb["capped"]` to color-code CAPPED.
- board v3 fleet-liveness dot strip flips green→amber/red when `capped=True`.
- Renderers MAY show `hb["current_phase"]` next to the agent name when non-empty.

Card body lives in `/home/agent/.scitex/todo/tasks.yaml` near `id: sac-heartbeat-progress-signal`.
