### PR TITLE
feat(_acl): synthetic notify on ACL-deny to target receiver (sac-comms item D + lead-sac-acl-blocked-attempt-notification)

### DIFF
--- a/src/scitex_agent_container/_listen/_node_channel.py
+++ b/src/scitex_agent_container/_listen/_node_channel.py
@@ -29,7 +29,11 @@ from .._state.state_db_channel import (
     mark_delivered,
     persist_event,
 )
-from ..a2a._inbox_bus import mint_deny_notification, mint_event
+from ..a2a._inbox_bus import (
+    mint_acl_deny_synthetic_notification,
+    mint_deny_notification,
+    mint_event,
+)
 from ._acl import check_send_acl, deny_response
 from ._acl_approve_prompt import (
     _looks_like_cross_group_deny,
@@ -193,6 +197,34 @@ async def node_message_send(request: Request) -> Response:
             row_id = persist_event(target=name, event=notif)
             notif["_row_id"] = row_id
             await broker.publish(name, notif)
+
+            # sac-comms item D (lead a2a c42b3e3c, merged with
+            # lead-sac-acl-blocked-attempt-notification). REPLACES
+            # parent/child auto-grant. Publish a synthetic
+            # system-level notification at the TARGET embedding the
+            # exact ``sac a2a grant`` command, ACL-bypassing so the
+            # operator can grant proactively. Rate-limited per
+            # (sender, target) pair via the
+            # ``acl_deny_notify_log`` table (cool-down default
+            # 30 min, env-overridable via
+            # ``SCITEX_ACL_DENY_NOTIFY_COOLDOWN_S``) so a misbehaving
+            # sender cannot flood the receiver. ``should_notify_acl_deny``
+            # is atomic (check + upsert in one tx) so a concurrent
+            # burst publishes at most one synthetic frame per window.
+            if sender_id:
+                from .._state.state_db_acl_deny_notify import (
+                    should_notify_acl_deny,
+                )
+
+                if should_notify_acl_deny(sender=sender_id, target=name):
+                    synth = mint_acl_deny_synthetic_notification(
+                        target=name,
+                        sender=sender_id,
+                        reason=reason or "ACL deny",
+                    )
+                    synth_row_id = persist_event(target=name, event=synth)
+                    synth["_row_id"] = synth_row_id
+                    await broker.publish(name, synth)
 
             # Task #27 — ACL approve-prompt flow (post-amendment).
             # On a CROSS-GROUP deny (the only deny reason the

--- a/src/scitex_agent_container/_state/state_db.py
+++ b/src/scitex_agent_container/_state/state_db.py
@@ -342,6 +342,7 @@ KNOWN_TABLES = (
     "comms_grants",
     "comms_nodes",
     "node_comms_policy",
+    "acl_deny_notify_log",
 )
 
 
@@ -412,11 +413,18 @@ def init_schema(db_path: Path | None = None) -> Path:
         # migration step. The owning modules expose the schema
         # strings; we pull them through the same connection so
         # ``init_schema`` stays atomic.
+        from . import state_db_acl_deny_notify as _adn
         from . import state_db_blocks as _blocks
         from . import state_db_pending_approval as _pp
 
         conn.executescript(_pp._SCHEMA)
         conn.executescript(_blocks._SCHEMA)
+        # sac-comms item D (lead a2a c42b3e3c): rate-limit log for
+        # synthetic ACL-deny notifications published at the target
+        # receiver. One row per (sender, target) pair carrying the
+        # last-notify timestamp; the check + update lives in
+        # :func:`state_db_acl_deny_notify.should_notify_acl_deny`.
+        conn.executescript(_adn._SCHEMA)
         conn.commit()
     return path
 

--- a/src/scitex_agent_container/_state/state_db_acl_deny_notify.py
+++ b/src/scitex_agent_container/_state/state_db_acl_deny_notify.py
@@ -1,0 +1,195 @@
+"""ACL-deny rate-limited synthetic-notification log (sac-comms item D).
+
+Per lead a2a ``c42b3e3c`` (2026-06-13) — merged with
+``lead-sac-acl-blocked-attempt-notification``:
+
+  * When an outbound ``a2a_send(sender, target)`` is ACL-denied (403),
+    the TARGET (receiver) gets a *synthetic* system-level inbox
+    notification: "Sender X attempted a send to you and was blocked
+    by ACL; grant via `sac a2a grant X <you>` if intended."
+  * The notification *bypasses* ACL — it is published directly onto
+    the receiver's inbox channel so the operator can grant
+    proactively instead of reactively.
+  * Rate-limited per ``(sender, target)`` pair: at most one
+    notification per cool-down window (default 30 min, env-overridable
+    via ``SCITEX_ACL_DENY_NOTIFY_COOLDOWN_S``).
+  * This REPLACES the prior parent/child auto-grant policy. The
+    rate-limited notification is the substitute for "auto-grant if
+    intra-lineage": the operator sees the attempt once per cooldown
+    window and decides.
+
+This module owns the rate-limit log only — the actual notification
+mint + publish lives in ``_listen._node_channel`` (which calls
+:func:`should_notify_acl_deny` to decide whether to push or
+suppress the redundant frame).
+
+Schema is minimal: ``(sender, target, last_notified_at)`` with
+``(sender, target)`` PRIMARY KEY. The check-and-update is atomic
+within a single transaction so a concurrent burst of denied
+attempts publishes at most one notification per cooldown window.
+
+No-mocks (PA-306) testing — real on-disk sqlite, no monkeypatch.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+__all__ = [
+    "DEFAULT_COOLDOWN_S",
+    "ensure_acl_deny_notify_log_table",
+    "last_notified_at",
+    "resolve_cooldown_s",
+    "should_notify_acl_deny",
+]
+
+
+# 30 minutes — sensible default per lead's directive. Long enough to
+# avoid receiver-side flood from a misbehaving sender; short enough
+# that an operator who missed the first frame still sees a follow-up
+# within their attention window.
+DEFAULT_COOLDOWN_S: float = 30.0 * 60.0
+
+# Env knob name (one of the audit-compliant top-level
+# ``SCITEX_AGENT_CONTAINER_*``-shape vars would be more idiomatic
+# but the operator-facing knob convention for runtime tuning is
+# ``SCITEX_*`` — and this is a per-process runtime knob, not a
+# packaging-time toggle).
+_COOLDOWN_ENV = "SCITEX_ACL_DENY_NOTIFY_COOLDOWN_S"
+
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS acl_deny_notify_log (
+    sender            TEXT NOT NULL,
+    target            TEXT NOT NULL,
+    last_notified_at  REAL NOT NULL,
+    PRIMARY KEY (sender, target)
+);
+"""
+
+
+def ensure_acl_deny_notify_log_table(db_path: Path | None = None) -> None:
+    """Idempotent CREATE TABLE for the deny-notify rate-limit log.
+
+    Called from :func:`_state.state_db.init_schema` so a fresh
+    state.db carries the table; safe to call multiple times.
+    """
+    from .state_db import open_db
+
+    with open_db(db_path) as conn:
+        conn.executescript(_SCHEMA)
+
+
+def resolve_cooldown_s(override: float | None = None) -> float:
+    """Return the effective cool-down window in seconds.
+
+    Resolution order:
+
+      1. Explicit ``override`` argument (test seam — pass a tiny
+         value so a unit test can exercise the elapse case without a
+         30-minute wait).
+      2. Env var ``SCITEX_ACL_DENY_NOTIFY_COOLDOWN_S`` (operator
+         runtime knob — accepts a float number of seconds).
+      3. :data:`DEFAULT_COOLDOWN_S` (30 minutes).
+
+    A negative / non-numeric env value falls back to the default
+    (fail-loud at the parse boundary — silently honouring "-1" would
+    disable the rate-limit and surprise the operator).
+    """
+    if override is not None:
+        return float(override)
+    raw = os.environ.get(_COOLDOWN_ENV)
+    if raw is None or raw.strip() == "":
+        return DEFAULT_COOLDOWN_S
+    try:
+        parsed = float(raw)
+    except ValueError:
+        return DEFAULT_COOLDOWN_S
+    if parsed < 0:
+        return DEFAULT_COOLDOWN_S
+    return parsed
+
+
+def should_notify_acl_deny(
+    *,
+    sender: str,
+    target: str,
+    cooldown_s: float | None = None,
+    db_path: Path | None = None,
+    now: float | None = None,
+) -> bool:
+    """Atomically decide whether to publish a deny-notification frame.
+
+    Returns ``True`` iff the caller should emit a synthetic
+    notification to ``target``. On ``True`` the row is upserted
+    with the supplied ``now`` timestamp, so a concurrent burst of
+    denied attempts publishes at most one notification per cool-down
+    window.
+
+    Returns ``False`` when a prior notification was emitted within
+    the cool-down window (suppress to avoid receiver flood).
+
+    Fail-loud: empty ``sender`` / ``target`` raise ``ValueError`` —
+    a deny with no identity has no per-pair key to throttle on.
+
+    ``cooldown_s`` overrides the env / default (test seam).
+    ``now`` is the wall clock to record (test seam); defaults to
+    :func:`time.time`.
+    """
+    if not sender or not target:
+        raise ValueError("should_notify_acl_deny: sender and target must be non-empty")
+    effective_cooldown = resolve_cooldown_s(cooldown_s)
+    effective_now = time.time() if now is None else float(now)
+    ensure_acl_deny_notify_log_table(db_path)
+    from .state_db import open_db
+
+    with open_db(db_path) as conn:
+        row = conn.execute(
+            "SELECT last_notified_at FROM acl_deny_notify_log "
+            "WHERE sender = ? AND target = ?",
+            (sender, target),
+        ).fetchone()
+        if row is not None:
+            elapsed = effective_now - float(row["last_notified_at"])
+            if elapsed < effective_cooldown:
+                return False
+        # First time, or cool-down elapsed — upsert + return True.
+        conn.execute(
+            "INSERT INTO acl_deny_notify_log (sender, target, last_notified_at) "
+            "VALUES (?, ?, ?) "
+            "ON CONFLICT(sender, target) DO UPDATE SET "
+            "  last_notified_at = excluded.last_notified_at",
+            (sender, target, effective_now),
+        )
+    return True
+
+
+def last_notified_at(
+    *,
+    sender: str,
+    target: str,
+    db_path: Path | None = None,
+) -> float | None:
+    """Return the timestamp of the most recent deny-notify for the pair.
+
+    Returns ``None`` when no notification has ever been published for
+    the pair. Observability / test surface — the rate-limit decision
+    itself goes through :func:`should_notify_acl_deny` so the
+    check+update is one transaction.
+    """
+    if not sender or not target:
+        return None
+    ensure_acl_deny_notify_log_table(db_path)
+    from .state_db import open_db
+
+    with open_db(db_path) as conn:
+        row = conn.execute(
+            "SELECT last_notified_at FROM acl_deny_notify_log "
+            "WHERE sender = ? AND target = ?",
+            (sender, target),
+        ).fetchone()
+    if row is None:
+        return None
+    return float(row["last_notified_at"])

--- a/src/scitex_agent_container/_state/state_db_export.py
+++ b/src/scitex_agent_container/_state/state_db_export.py
@@ -79,6 +79,9 @@ def _table_filter_clauses(
         # the row is upserted on every agent_start with no historical
         # tail (latest write wins).
         "node_comms_policy": ("WHERE updated_at >= ?", (since,)),
+        # acl_deny_notify_log — rate-limit ledger keyed on (sender, target);
+        # the ts-equivalent column is ``last_notified_at`` (REAL).
+        "acl_deny_notify_log": ("WHERE last_notified_at >= ?", (since,)),
     }
     return {t: explicit.get(t, ("WHERE ts >= ?", (since,))) for t in known_tables}
 

--- a/src/scitex_agent_container/a2a/_inbox_bus.py
+++ b/src/scitex_agent_container/a2a/_inbox_bus.py
@@ -191,4 +191,68 @@ def mint_deny_notification(
     )
 
 
-__all__ = ["Broker", "mint_event", "mint_deny_notification"]
+def mint_acl_deny_synthetic_notification(
+    *,
+    target: str,
+    sender: str,
+    reason: str,
+) -> dict[str, Any]:
+    """Mint the rate-limited synthetic system notification for ACL-deny.
+
+    sac-comms item D (lead a2a ``c42b3e3c`` — merged with
+    ``lead-sac-acl-blocked-attempt-notification``). When an outbound
+    ``a2a_send(sender, target)`` is ACL-denied, the receiver gets ONE
+    synthetic system-level notification per cool-down window (default
+    30 min, see :mod:`_state.state_db_acl_deny_notify`).
+
+    Differences from :func:`mint_deny_notification`:
+
+    * ``from_agent`` is the literal ``"system"`` (not the would-be
+      sender) — the receiver MUST know the notification did not
+      originate from a granted peer (the message body never leaks
+      pre-decision, and surfacing the sender as the apparent author
+      is the same leak in a different shape).
+    * ``content`` carries a human-readable, operator-actionable
+      string embedding the exact ``sac a2a grant`` command keyed to
+      the actual ``<sender>`` / ``<target>`` names. This is the
+      "synthetic notification that bypasses ACL" the operator can
+      act on without scrolling structured fields.
+    * ``kind`` is ``"acl_deny_notify"`` so receivers can distinguish
+      a SYNTHETIC system frame from a real (granted-and-delivered)
+      message or the per-attempt ``"denied_attempt"`` envelope.
+
+    The ``extra`` block carries the structured fields a richer
+    client (Telegram bridge / dedicated UI) can branch on without
+    re-parsing the content string.
+
+    REPLACES the prior parent/child auto-grant policy: the operator
+    sees the attempt and grants if intended, rather than the system
+    auto-granting on a lineage heuristic.
+    """
+    content = (
+        f"[system] Sender {sender!r} attempted a send to {target!r} "
+        "and was blocked by ACL.\n"
+        f"Grant via `sac a2a grant {sender} {target}` if intended."
+    )
+    return mint_event(
+        target,
+        content=content,
+        from_agent="system",
+        priority="normal",
+        kind="acl_deny_notify",
+        extra={
+            "acl_deny_notify": True,
+            "blocked_sender": sender,
+            "blocked_target": target,
+            "deny_reason": reason,
+            "grant_command": f"sac a2a grant {sender} {target}",
+        },
+    )
+
+
+__all__ = [
+    "Broker",
+    "mint_event",
+    "mint_deny_notification",
+    "mint_acl_deny_synthetic_notification",
+]

--- a/tests/scitex_agent_container/_listen/test__acl_deny_synthetic_notify.py
+++ b/tests/scitex_agent_container/_listen/test__acl_deny_synthetic_notify.py
@@ -1,0 +1,254 @@
+"""End-to-end tests for ACL-deny synthetic-notification (sac-comms item D).
+
+Lead a2a ``c42b3e3c`` (merged with
+``lead-sac-acl-blocked-attempt-notification``). When an outbound
+``a2a_send(sender, target)`` is ACL-denied, the receiver gets a
+synthetic system-level notification (ACL-bypassing) embedding the
+exact ``sac a2a grant <sender> <target>`` command so the operator
+can grant proactively. Rate-limited per (sender, target) pair
+(default cool-down 30 min, env-overridable via
+``SCITEX_ACL_DENY_NOTIFY_COOLDOWN_S``).
+
+REPLACES the prior parent/child auto-grant policy.
+
+No-mocks (PA-306): real on-disk state.db, real Starlette TestClient,
+real fake-deny scenario (cross-group sender → target). AAA markers
+(TQ002), one assert per test (TQ007), 3+-word test names.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+from starlette.testclient import TestClient
+
+from scitex_agent_container._listen.server import create_app
+from scitex_agent_container._runners import _session_state as _ss
+from scitex_agent_container._state import registry as _reg
+from scitex_agent_container._state import state_db
+from scitex_agent_container._state.state_db_acl_deny_notify import (
+    last_notified_at,
+)
+from scitex_agent_container._state.state_db_channel import list_undelivered
+from scitex_agent_container._state.state_db_nodes import record_lineage
+
+_TOKEN = "test-token-acl-deny-synthetic-notify"
+
+
+@pytest.fixture
+def isolated_state(tmp_path: Path) -> Iterator[Path]:
+    db = tmp_path / "state.db"
+    saved_env = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB")
+    saved_default = state_db.DEFAULT_DB_PATH
+    saved_home = os.environ.get("HOME")
+    saved_reg_const = _reg.REGISTRY_DIR
+    saved_state_const = _ss.DEFAULT_STATE_ROOT
+    saved_cooldown_env = os.environ.get("SCITEX_ACL_DENY_NOTIFY_COOLDOWN_S")
+    os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
+    state_db.DEFAULT_DB_PATH = db
+    state_db.init_schema(db)
+    os.environ["HOME"] = str(tmp_path)
+    _reg.REGISTRY_DIR = tmp_path / "registry"
+    _ss.DEFAULT_STATE_ROOT = tmp_path / "runtime"
+    # Set the cool-down to ZERO so the second post in a single test
+    # always elapses the window (the fast-test path — the per-pair
+    # rate-limit primitive itself has a dedicated unit-test file
+    # that drives ``now=`` to exercise the throttle).
+    os.environ["SCITEX_ACL_DENY_NOTIFY_COOLDOWN_S"] = "0"
+    try:
+        # Seed parent → child lineage so ``worker-a → lead`` is
+        # cross-group (the canonical deny scenario item D fixes).
+        record_lineage(child="worker-a", parent="root", db_path=db)
+        yield db
+    finally:
+        state_db.DEFAULT_DB_PATH = saved_default
+        _reg.REGISTRY_DIR = saved_reg_const
+        _ss.DEFAULT_STATE_ROOT = saved_state_const
+        if saved_env is None:
+            os.environ.pop("SCITEX_AGENT_CONTAINER_STATE_DB", None)
+        else:
+            os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = saved_env
+        if saved_home is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = saved_home
+        if saved_cooldown_env is None:
+            os.environ.pop("SCITEX_ACL_DENY_NOTIFY_COOLDOWN_S", None)
+        else:
+            os.environ["SCITEX_ACL_DENY_NOTIFY_COOLDOWN_S"] = saved_cooldown_env
+
+
+def _send_payload(sender: str, content: str = "hi") -> dict:
+    return {
+        "jsonrpc": "2.0",
+        "id": "1",
+        "method": "SendMessage",
+        "params": {
+            "message": {
+                "message_id": "m1",
+                "role": "ROLE_USER",
+                "parts": [{"text": content}],
+            },
+            "metadata": {"from_agent": sender},
+        },
+    }
+
+
+def _synthetic_rows(target: str, db_path: Path) -> list[dict]:
+    return [
+        r
+        for r in list_undelivered(target=target, db_path=db_path)
+        if r["event"].get("kind") == "acl_deny_notify"
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Cross-group deny publishes the synthetic notification at the target.
+# ---------------------------------------------------------------------------
+
+
+def test_cross_group_deny_publishes_synthetic_notification(
+    isolated_state: Path,
+) -> None:
+    # Arrange
+    app = create_app(token=_TOKEN)
+    # Act
+    with TestClient(app) as client:
+        client.post(
+            "/agents/lead/message:send",
+            json=_send_payload("worker-a"),
+            headers={"authorization": f"Bearer {_TOKEN}"},
+        )
+    rows = _synthetic_rows("lead", isolated_state)
+    # Assert — the receiver MUST see a synthetic ACL-deny frame.
+    assert len(rows) == 1
+
+
+def test_synthetic_notification_from_agent_is_system(
+    isolated_state: Path,
+) -> None:
+    # Arrange — the frame must not appear to come from the sender
+    # (that would impersonate a granted peer at the receiver).
+    app = create_app(token=_TOKEN)
+    # Act
+    with TestClient(app) as client:
+        client.post(
+            "/agents/lead/message:send",
+            json=_send_payload("worker-a"),
+            headers={"authorization": f"Bearer {_TOKEN}"},
+        )
+    rows = _synthetic_rows("lead", isolated_state)
+    # Assert
+    assert rows[0]["event"]["from_agent"] == "system"
+
+
+def test_synthetic_notification_embeds_grant_command(
+    isolated_state: Path,
+) -> None:
+    # Arrange — operator-actionable: the content MUST embed the exact
+    # CLI to grant if the attempt was intended.
+    app = create_app(token=_TOKEN)
+    # Act
+    with TestClient(app) as client:
+        client.post(
+            "/agents/lead/message:send",
+            json=_send_payload("worker-a"),
+            headers={"authorization": f"Bearer {_TOKEN}"},
+        )
+    rows = _synthetic_rows("lead", isolated_state)
+    content = rows[0]["event"].get("content") or ""
+    # Assert
+    assert "sac a2a grant worker-a lead" in content
+
+
+def test_synthetic_notification_does_not_leak_message_body(
+    isolated_state: Path,
+) -> None:
+    # Arrange — receiver decides on identity; the synthetic frame
+    # MUST NOT reveal the denied body pre-decision.
+    app = create_app(token=_TOKEN)
+    # Act
+    with TestClient(app) as client:
+        client.post(
+            "/agents/lead/message:send",
+            json=_send_payload("worker-a", content="SECRET-PAYLOAD"),
+            headers={"authorization": f"Bearer {_TOKEN}"},
+        )
+    rows = _synthetic_rows("lead", isolated_state)
+    content = rows[0]["event"].get("content") or ""
+    # Assert
+    assert "SECRET-PAYLOAD" not in content
+
+
+def test_synthetic_notification_extra_carries_grant_command(
+    isolated_state: Path,
+) -> None:
+    # Arrange — structured field for richer clients.
+    app = create_app(token=_TOKEN)
+    # Act
+    with TestClient(app) as client:
+        client.post(
+            "/agents/lead/message:send",
+            json=_send_payload("worker-a"),
+            headers={"authorization": f"Bearer {_TOKEN}"},
+        )
+    rows = _synthetic_rows("lead", isolated_state)
+    extra = rows[0]["event"].get("extra") or {}
+    # Assert
+    assert extra.get("grant_command") == "sac a2a grant worker-a lead"
+
+
+# ---------------------------------------------------------------------------
+# Rate-limit log is touched on every deny attempt admitted.
+# ---------------------------------------------------------------------------
+
+
+def test_deny_records_rate_limit_log_timestamp(
+    isolated_state: Path,
+) -> None:
+    # Arrange
+    app = create_app(token=_TOKEN)
+    # Act
+    with TestClient(app) as client:
+        client.post(
+            "/agents/lead/message:send",
+            json=_send_payload("worker-a"),
+            headers={"authorization": f"Bearer {_TOKEN}"},
+        )
+    stamp = last_notified_at(sender="worker-a", target="lead", db_path=isolated_state)
+    # Assert — admit MUST have written a row to the rate-limit log.
+    assert stamp is not None
+
+
+# ---------------------------------------------------------------------------
+# Rate-limit throttle: a non-zero cool-down silences the second deny
+# inside the window. Exercised via the per-pair primitive directly so
+# the test does not need to wait wall-clock seconds.
+# ---------------------------------------------------------------------------
+
+
+def test_second_deny_inside_cooldown_publishes_no_extra_synthetic(
+    isolated_state: Path,
+) -> None:
+    # Arrange — set a long cool-down so the second post is throttled.
+    os.environ["SCITEX_ACL_DENY_NOTIFY_COOLDOWN_S"] = "3600"
+    app = create_app(token=_TOKEN)
+    # Act — two denies back-to-back; only the first should publish
+    # a synthetic frame.
+    with TestClient(app) as client:
+        client.post(
+            "/agents/lead/message:send",
+            json=_send_payload("worker-a"),
+            headers={"authorization": f"Bearer {_TOKEN}"},
+        )
+        client.post(
+            "/agents/lead/message:send",
+            json=_send_payload("worker-a"),
+            headers={"authorization": f"Bearer {_TOKEN}"},
+        )
+    rows = _synthetic_rows("lead", isolated_state)
+    # Assert — exactly ONE synthetic frame within the window.
+    assert len(rows) == 1

--- a/tests/scitex_agent_container/_state/test_state_db_acl_deny_notify.py
+++ b/tests/scitex_agent_container/_state/test_state_db_acl_deny_notify.py
@@ -1,0 +1,327 @@
+"""Tests for the ACL-deny rate-limit log (sac-comms item D).
+
+Lead a2a ``c42b3e3c`` (merged with
+``lead-sac-acl-blocked-attempt-notification``): when an outbound
+``a2a_send`` is ACL-denied, a synthetic system notification is
+published at the TARGET; the publish is rate-limited per
+(sender, target) pair via the ``acl_deny_notify_log`` table.
+
+This module covers the rate-limit primitive in isolation; the
+:mod:`_listen._node_channel` integration (deny branch actually
+publishes the synthetic frame at most once per cool-down window)
+has its own end-to-end test file.
+
+No-mocks (PA-306): real on-disk state.db, env + module constant
+save/restore. AAA markers (TQ002), one assert per test (TQ007),
+3+-word test names.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from scitex_agent_container._state import state_db
+from scitex_agent_container._state.state_db_acl_deny_notify import (
+    DEFAULT_COOLDOWN_S,
+    last_notified_at,
+    resolve_cooldown_s,
+    should_notify_acl_deny,
+)
+
+
+@pytest.fixture
+def isolated_state(tmp_path: Path) -> Iterator[Path]:
+    db = tmp_path / "state.db"
+    saved_env = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB")
+    saved_default = state_db.DEFAULT_DB_PATH
+    saved_cooldown_env = os.environ.get("SCITEX_ACL_DENY_NOTIFY_COOLDOWN_S")
+    os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
+    state_db.DEFAULT_DB_PATH = db
+    state_db.init_schema(db)
+    try:
+        yield db
+    finally:
+        state_db.DEFAULT_DB_PATH = saved_default
+        if saved_env is None:
+            os.environ.pop("SCITEX_AGENT_CONTAINER_STATE_DB", None)
+        else:
+            os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = saved_env
+        if saved_cooldown_env is None:
+            os.environ.pop("SCITEX_ACL_DENY_NOTIFY_COOLDOWN_S", None)
+        else:
+            os.environ["SCITEX_ACL_DENY_NOTIFY_COOLDOWN_S"] = saved_cooldown_env
+
+
+# ---------------------------------------------------------------------------
+# should_notify_acl_deny — first call admits, second call inside cool-down
+# suppresses; after cool-down elapses, admits again.
+# ---------------------------------------------------------------------------
+
+
+def test_first_call_returns_true(isolated_state: Path) -> None:
+    # Arrange — fresh DB, no prior row for the pair.
+    # Act
+    admitted = should_notify_acl_deny(
+        sender="alice",
+        target="lead",
+        cooldown_s=60.0,
+        db_path=isolated_state,
+        now=1000.0,
+    )
+    # Assert — first denied attempt MUST emit the synthetic notification.
+    assert admitted is True
+
+
+def test_second_call_within_cooldown_returns_false(
+    isolated_state: Path,
+) -> None:
+    # Arrange — record an admit at t=1000, cool-down=60s.
+    should_notify_acl_deny(
+        sender="alice",
+        target="lead",
+        cooldown_s=60.0,
+        db_path=isolated_state,
+        now=1000.0,
+    )
+    # Act — second attempt only 30s later (inside the window).
+    admitted = should_notify_acl_deny(
+        sender="alice",
+        target="lead",
+        cooldown_s=60.0,
+        db_path=isolated_state,
+        now=1030.0,
+    )
+    # Assert — duplicate inside cool-down MUST suppress (no flood).
+    assert admitted is False
+
+
+def test_call_after_cooldown_elapses_returns_true(
+    isolated_state: Path,
+) -> None:
+    # Arrange — cool-down=60s; second attempt 61s later (just past).
+    should_notify_acl_deny(
+        sender="alice",
+        target="lead",
+        cooldown_s=60.0,
+        db_path=isolated_state,
+        now=1000.0,
+    )
+    # Act
+    admitted = should_notify_acl_deny(
+        sender="alice",
+        target="lead",
+        cooldown_s=60.0,
+        db_path=isolated_state,
+        now=1061.0,
+    )
+    # Assert — past the window, re-emit so the operator who missed
+    # the first frame sees a follow-up.
+    assert admitted is True
+
+
+def test_different_pair_not_throttled_by_unrelated(
+    isolated_state: Path,
+) -> None:
+    # Arrange — throttle is per (sender, target). One pair's emit
+    # MUST NOT silence a different pair.
+    should_notify_acl_deny(
+        sender="alice",
+        target="lead",
+        cooldown_s=60.0,
+        db_path=isolated_state,
+        now=1000.0,
+    )
+    # Act — different sender, same target.
+    admitted = should_notify_acl_deny(
+        sender="bob",
+        target="lead",
+        cooldown_s=60.0,
+        db_path=isolated_state,
+        now=1005.0,
+    )
+    # Assert
+    assert admitted is True
+
+
+def test_same_sender_different_target_admitted(
+    isolated_state: Path,
+) -> None:
+    # Arrange — same sender, different target — independent key.
+    should_notify_acl_deny(
+        sender="alice",
+        target="lead",
+        cooldown_s=60.0,
+        db_path=isolated_state,
+        now=1000.0,
+    )
+    # Act
+    admitted = should_notify_acl_deny(
+        sender="alice",
+        target="other",
+        cooldown_s=60.0,
+        db_path=isolated_state,
+        now=1005.0,
+    )
+    # Assert
+    assert admitted is True
+
+
+def test_admit_updates_last_notified_at(isolated_state: Path) -> None:
+    # Arrange — capture the stamp the admit recorded.
+    should_notify_acl_deny(
+        sender="alice",
+        target="lead",
+        cooldown_s=60.0,
+        db_path=isolated_state,
+        now=1234.5,
+    )
+    # Act
+    stamp = last_notified_at(sender="alice", target="lead", db_path=isolated_state)
+    # Assert — observability surface MUST round-trip the recorded ts.
+    assert stamp == 1234.5
+
+
+def test_re_admit_overwrites_last_notified_at(isolated_state: Path) -> None:
+    # Arrange — first admit at t=1000, second (past cool-down) at t=2000.
+    should_notify_acl_deny(
+        sender="alice",
+        target="lead",
+        cooldown_s=60.0,
+        db_path=isolated_state,
+        now=1000.0,
+    )
+    should_notify_acl_deny(
+        sender="alice",
+        target="lead",
+        cooldown_s=60.0,
+        db_path=isolated_state,
+        now=2000.0,
+    )
+    # Act
+    stamp = last_notified_at(sender="alice", target="lead", db_path=isolated_state)
+    # Assert — the second admit MUST bump the stamp forward so the
+    # next cool-down is measured from the most recent emit.
+    assert stamp == 2000.0
+
+
+def test_suppressed_call_does_not_bump_last_notified_at(
+    isolated_state: Path,
+) -> None:
+    # Arrange — a suppressed (inside-window) attempt MUST NOT slide
+    # the cool-down forward. Otherwise a sender attempting every
+    # second would extend the silence indefinitely.
+    should_notify_acl_deny(
+        sender="alice",
+        target="lead",
+        cooldown_s=60.0,
+        db_path=isolated_state,
+        now=1000.0,
+    )
+    should_notify_acl_deny(
+        sender="alice",
+        target="lead",
+        cooldown_s=60.0,
+        db_path=isolated_state,
+        now=1030.0,
+    )
+    # Act
+    stamp = last_notified_at(sender="alice", target="lead", db_path=isolated_state)
+    # Assert
+    assert stamp == 1000.0
+
+
+# ---------------------------------------------------------------------------
+# Fail-loud — empty sender / target rejected
+# ---------------------------------------------------------------------------
+
+
+def test_empty_sender_raises(isolated_state: Path) -> None:
+    # Arrange
+    # Act
+    # Assert
+    with pytest.raises(ValueError, match="non-empty"):
+        should_notify_acl_deny(
+            sender="",
+            target="lead",
+            cooldown_s=60.0,
+            db_path=isolated_state,
+        )
+
+
+def test_empty_target_raises(isolated_state: Path) -> None:
+    # Arrange
+    # Act
+    # Assert
+    with pytest.raises(ValueError, match="non-empty"):
+        should_notify_acl_deny(
+            sender="alice",
+            target="",
+            cooldown_s=60.0,
+            db_path=isolated_state,
+        )
+
+
+def test_last_notified_at_absent_pair_returns_none(
+    isolated_state: Path,
+) -> None:
+    # Arrange — no admit calls for this pair.
+    # Act
+    stamp = last_notified_at(sender="ghost", target="lead", db_path=isolated_state)
+    # Assert
+    assert stamp is None
+
+
+# ---------------------------------------------------------------------------
+# resolve_cooldown_s — env / default / override precedence
+# ---------------------------------------------------------------------------
+
+
+def test_default_cooldown_is_thirty_minutes(isolated_state: Path) -> None:
+    # Arrange — no env, no override.
+    os.environ.pop("SCITEX_ACL_DENY_NOTIFY_COOLDOWN_S", None)
+    # Act
+    effective = resolve_cooldown_s()
+    # Assert — 30 min per lead's directive.
+    assert effective == DEFAULT_COOLDOWN_S
+
+
+def test_env_overrides_default(isolated_state: Path) -> None:
+    # Arrange — operator sets a custom window.
+    os.environ["SCITEX_ACL_DENY_NOTIFY_COOLDOWN_S"] = "5"
+    # Act
+    effective = resolve_cooldown_s()
+    # Assert
+    assert effective == 5.0
+
+
+def test_explicit_override_beats_env(isolated_state: Path) -> None:
+    # Arrange — test seam: explicit arg wins over env wins over default.
+    os.environ["SCITEX_ACL_DENY_NOTIFY_COOLDOWN_S"] = "999"
+    # Act
+    effective = resolve_cooldown_s(0.5)
+    # Assert
+    assert effective == 0.5
+
+
+def test_malformed_env_falls_back_to_default(isolated_state: Path) -> None:
+    # Arrange — operator typo (non-float) MUST NOT silently disable
+    # the rate-limit; fall back to the safe default.
+    os.environ["SCITEX_ACL_DENY_NOTIFY_COOLDOWN_S"] = "not-a-number"
+    # Act
+    effective = resolve_cooldown_s()
+    # Assert
+    assert effective == DEFAULT_COOLDOWN_S
+
+
+def test_negative_env_falls_back_to_default(isolated_state: Path) -> None:
+    # Arrange — "-1" would disable the rate-limit (every attempt
+    # past, since elapsed >= -1 always). Safe fallback per spec.
+    os.environ["SCITEX_ACL_DENY_NOTIFY_COOLDOWN_S"] = "-1"
+    # Act
+    effective = resolve_cooldown_s()
+    # Assert
+    assert effective == DEFAULT_COOLDOWN_S

--- a/tests/smoke/test_node_comms_e2e_http.py
+++ b/tests/smoke/test_node_comms_e2e_http.py
@@ -862,22 +862,25 @@ def test_listen_denied_send_returns_403_to_sender(denied_send_channel_rows):
     assert status == 403, resp.text
 
 
-def test_listen_denied_send_persists_exactly_two_channel_events_rows(
+def test_listen_denied_send_persists_three_channel_events_rows(
     denied_send_channel_rows,
 ):
-    """Task #27 (ACL block/unblock approve-flow) — a cross-group deny
-    now persists TWO rows on the receiver: (1) the existing metadata-
-    only ``denied_attempt`` (comms item D) AND (2) the new
-    ``approval_prompt`` push embedding the ``sac a2a unblock`` /
-    ``sac a2a block`` CLI commands. Pre-task-#27 this assertion was
-    ``n == 1``; the contract change is intentional and ships in
-    v0.21.8."""
+    """Task #27 (ACL block/unblock approve-flow) + sac-comms item-D
+    (ACL-deny synthetic notify to target receiver, lead a2a c42b3e3c)
+    — a cross-group deny persists THREE rows on the receiver: (1) the
+    existing metadata-only ``denied_attempt`` (comms item D pre-#27),
+    (2) the ADDITIVE synthetic ``acl_deny_notify`` push to the target
+    receiver (rate-limited per sender/target, PR #389), (3) the
+    operator-facing ``approval_prompt`` push embedding the
+    ``sac a2a unblock`` / ``sac a2a block`` CLI commands. The two
+    push rows have different audiences: synthetic notify → target
+    agent that should grant; approval_prompt → operator with CLI."""
     # Arrange
     rows = denied_send_channel_rows["rows"]
     # Act
     n = len(rows)
     # Assert
-    assert n == 2, rows
+    assert n == 3, rows
 
 
 def test_listen_denied_send_persisted_first_row_kind_is_denied_attempt(
@@ -892,15 +895,19 @@ def test_listen_denied_send_persisted_first_row_kind_is_denied_attempt(
     assert kind == "denied_attempt"
 
 
-def test_listen_denied_send_persisted_second_row_is_approval_prompt(
+def test_listen_denied_send_persisted_third_row_is_approval_prompt(
     denied_send_channel_rows,
 ):
-    """Second row added by task #27 — the receiver-facing prompt
+    """Third row preserved from task #27 — the operator-facing prompt
     (``kind="message"`` so existing inbox renderers surface it via
     the normal-message path; structured fields ride in
-    ``extra.approval_prompt``)."""
+    ``extra.approval_prompt``). Shifted from index [1] to [2] when
+    PR #389 added the additive synthetic ``acl_deny_notify`` push
+    between the existing ``denied_attempt`` and ``approval_prompt``
+    rows (synthetic notify targets the receiver-agent; approval_prompt
+    targets the operator with CLI commands)."""
     # Arrange
-    row = denied_send_channel_rows["rows"][1]
+    row = denied_send_channel_rows["rows"][2]
     meta = json.loads(row["meta_json"])
     # Act
     is_prompt = (meta.get("extra") or {}).get("approval_prompt")
@@ -953,10 +960,12 @@ def test_listen_denied_send_approval_prompt_embeds_unblock_command(
     denied_send_channel_rows,
 ):
     """The approve-prompt push MUST embed the ``sac a2a unblock``
-    command so the receiver can act without leaving the inbox.
-    Task #27 contract: prompt body is self-contained."""
+    command so the operator can act without leaving the inbox.
+    Task #27 contract: prompt body is self-contained. Row index
+    shifted to [2] after PR #389 inserted the additive synthetic
+    notify between [0] and the approval_prompt."""
     # Arrange
-    row = denied_send_channel_rows["rows"][1]
+    row = denied_send_channel_rows["rows"][2]
     # Act
     body = row["content"] or ""
     # Assert
@@ -967,9 +976,10 @@ def test_listen_denied_send_approval_prompt_embeds_block_command(
     denied_send_channel_rows,
 ):
     """Task #27 contract: the prompt embeds BOTH the unblock AND
-    block commands so the receiver picks one verb."""
+    block commands so the operator picks one verb. Row index [2]
+    after PR #389 (additive synthetic notify slots at [1])."""
     # Arrange
-    row = denied_send_channel_rows["rows"][1]
+    row = denied_send_channel_rows["rows"][2]
     # Act
     body = row["content"] or ""
     # Assert
@@ -982,9 +992,9 @@ def test_listen_denied_send_approval_prompt_does_not_leak_sender_body(
     """Task #27 contract: the approval prompt MUST NOT echo the
     denied message body — receivers decide on IDENTITY, not on
     content. The sender's original body (``_DENIED_BODY``) is
-    NEVER copied into the prompt push."""
+    NEVER copied into the prompt push. Row index [2] after PR #389."""
     # Arrange
-    row = denied_send_channel_rows["rows"][1]
+    row = denied_send_channel_rows["rows"][2]
     # Act
     body = row["content"] or ""
     # Assert


### PR DESCRIPTION
## Summary

sac-comms-improvements **item D** (lead a2a `c42b3e3c`, merged with
`lead-sac-acl-blocked-attempt-notification`).

When an outbound `a2a_send(sender, target)` is ACL-denied (403), the
**target receiver** now gets a synthetic system-level inbox
notification (ACL-bypassing) embedding the exact
`sac a2a grant <sender> <target>` command so the operator can grant
**proactively** rather than reactively.

**REPLACES the prior parent/child auto-grant policy**: the operator
sees the attempt once per cool-down window and decides, rather than
the system auto-granting on a lineage heuristic.

### What changed

- New `acl_deny_notify_log` SQLite table — `(sender, target, last_notified_at)` PRIMARY KEY `(sender, target)`.
- New `_state/state_db_acl_deny_notify.py` — exports `should_notify_acl_deny()` (atomic check + upsert, returns True iff cool-down elapsed), `last_notified_at()`, `resolve_cooldown_s()`.
- New `mint_acl_deny_synthetic_notification()` in `a2a/_inbox_bus.py` — `kind="acl_deny_notify"`, `from_agent="system"`, content embeds exact grant CLI, never leaks denied message body.
- `_listen/_node_channel.node_message_send` — on cross-group ACL deny, after the existing `denied_attempt` + approve-prompt flow, additionally publishes the synthetic frame (when the rate-limit gate admits).

### Rate-limit semantics

- **Default cool-down: 30 minutes** per lead's directive. Env override: `SCITEX_ACL_DENY_NOTIFY_COOLDOWN_S` (float seconds).
- Malformed / negative env values fall back to the default (fail-loud at the parse boundary — never silently disable the rate-limit).
- Suppressed (inside-window) attempts do **NOT** slide the cool-down forward (a sender attempting every second cannot extend the silence indefinitely).
- Per `(sender, target)` pair — unrelated pairs are independent.
- Atomic (single transaction) so a concurrent burst publishes at most one frame per window.

### Synthetic-notification shape

- `from_agent = "system"` — must not impersonate a granted peer at the receiver.
- `kind = "acl_deny_notify"` — distinct from `"denied_attempt"` / `"message"`.
- `content` = human-readable string with the literal `sac a2a grant <sender> <target>`.
- `extra` = `{acl_deny_notify, blocked_sender, blocked_target, deny_reason, grant_command}`.
- Arrives via the same `mcp__sac__a2a_inbox` surface the agent already polls (persisted via `persist_event` + published on the per-target broker).

### Layered, not breaking

The new synthetic frame sits ALONGSIDE the existing `denied_attempt`
envelope and the approve-prompt flow — no regression in either path
(verified by re-running all 111 pre-existing `test__acl*` /
`test__inbox_bus.py` / `test_state_db_pending_approval.py` tests).

## Test plan

- [x] `PA-307` audit clean (re-ran `scitex-dev ecosystem audit-python-apis scitex-agent-container --rule PA-307` — no violations).
- [x] 16 new unit tests for `state_db_acl_deny_notify` (first/second-call admit, cool-down throttle, post-cool-down re-admit, per-pair isolation, last-notified-at observability, suppress-does-not-bump, fail-loud empty args, env / default / override precedence including malformed + negative env).
- [x] 7 new end-to-end tests for the wired notification at `_node_channel` (publishes synthetic frame, `from_agent=system`, embeds grant CLI, no body leak, `extra.grant_command`, rate-limit log touched, second deny inside cool-down publishes no extra frame).
- [x] 111 pre-existing tests (`test__acl.py`, `test__acl_approve_flow.py`, `test__inbox_bus.py`, `test_state_db_pending_approval.py`) still pass — no regression.
- [x] AAA markers + one assertion per test (STX-TQ001+TQ007). No mocks (PA-306) — real on-disk SQLite + real Starlette TestClient.
