### PR TITLE
feat(containers): add tmux + ncurses-term to apptainer-base.def (TUI hedge unblock)

### DIFF
--- a/src/scitex_agent_container/containers/apptainer-base.def
+++ b/src/scitex_agent_container/containers/apptainer-base.def
@@ -84,6 +84,7 @@ From: ubuntu:24.04
         nano jq \
         fd-find ripgrep bat eza \
         git-delta \
+        tmux ncurses-term \
         tini
     locale-gen en_US.UTF-8
 


### PR DESCRIPTION
## Summary

Add `tmux` + `ncurses-term` to the canonical `apptainer-base.def` apt-install step so the in-flight TUI runtime hedge (PR #385, branch `feat/tui-runtime-e2e-integration`) can actually launch end-to-end against the 2026-06-15 SDK-subscription cutoff.

Without this, `TuiSessionRuntime.start()` fails at the first `tmux new-session -d` because the multiplexer binary the runtime targets is not in the SIF.

## Substance

Two packages, both Ubuntu `noble/main`, both `--no-install-recommends` clean (~3-4 MB combined):

- `tmux` — THE missing multiplexer. The TUI runtime spawns `claude` inside a tmux session (so the agent survives terminal detaches; risk 1 of the TUI-stability A2A lead a2a `c8edc13b`).
- `ncurses-term` — extended terminfo database (`xterm-256color`, `screen-256color`, `tmux-256color`). The TUI's Ink/React renderer needs the right `TERM` capability or it falls back to a degraded mode that drops colour + ASCII-only boxes.

Other tools `claude` TUI uses are already in `base.def`:
- `locales` + `locale-gen en_US.UTF-8` (lines 81 + 88) → UTF-8 encoding parity.
- `less` (line 82) → claude's built-in pager.
- `procps`, `lsof`, `strace` (line 82) → diagnostic.

`script` / `util-linux` not added — claude TUI doesn't shell out to it.

## Why merge separately (def-only PR)

Lead's directive (a2a `9ed896c9`): land the canonical SIF source on develop NOW so the next SIF rebuild reads from a merged tree, not an unmerged branch. The TUI runtime integration itself stays on its own branch (`feat/tui-runtime-e2e-integration`, commit `509a6de1`) until the step-3 acceptance gate (real-agent e2e turn) is met.

## After-merge

Lead rebuilds the base SIF on ywata-note-win (~30 min base+scitex), smoke-tests `apptainer exec <sif> tmux -V` + `claude --version`, then proj-scitex-agent-container restarts onto the rebuilt SIF and resumes step 2 (real tmux + real claude smoke) → step 3 (real agent e2e turn).

## Test plan

- [ ] CI green (pytest-matrix only exercises the .def file as a static asset; no functional change to Python code).
- [ ] After merge: `sac image build base` on a clean host produces a SIF containing `tmux` (≥3.4 from noble) and `ncurses-term`.
- [ ] After SIF rebuild + agent restart: `tmux -V` returns inside a sac-launched container, unblocking the TUI runtime e2e gate.
