### PR TITLE
feat(runtime): auto-stage .credentials.json + .claude.json into TUI HOME

### DIFF
--- a/src/scitex_agent_container/runtimes/_tui_auth_stage.py
+++ b/src/scitex_agent_container/runtimes/_tui_auth_stage.py
@@ -1,0 +1,166 @@
+"""Auth-staging for the ``runtime: tui`` adapter.
+
+Stages the TWO files the interactive ``claude`` TUI checks on launch
+into a TUI agent's materialised ``$HOME``:
+
+  - ``<home>/.claude/.credentials.json`` — live OAuth token. The TUI
+    reads this on launch via its bundled ``$HOME/.claude/`` path; same
+    file ``claude -p`` reads under ``CLAUDE_CONFIG_DIR``.
+  - ``<home>/.claude.json`` — onboarding state with the ``oauthAccount``
+    block. The interactive TUI reads this to decide whether to skip
+    the login picker. ``claude -p`` does NOT touch this file, which is
+    why the SDK runtime path worked while the TUI hedge stalled on the
+    login picker before this staging existed (lead a2a
+    ``020bd692bfb94c45b28181d58ae9b0e6``, 2026-06-14).
+
+Sources are environment-configurable so a non-default container layout
+can point at an alternative credential / onboarding location without
+a code change. Defaults match the apptainer-runtime convention:
+
+  ``/tmp/sac-claude/.credentials.json`` — the apptainer auth bind point
+  (see ``_apptainer_auth.auth_argv``: the host's ``~/.claude/`` is
+  dir-bound at ``/tmp/sac-claude``, so this file is the host live
+  ``.credentials.json`` from inside the SAC process).
+
+  ``${HOME}/.claude.json`` — the SAC process's own onboarding state
+  (whatever ``claude /login`` wrote to the host user's ``$HOME``).
+  When SAC runs inside apptainer this is the agent-user ``$HOME`` the
+  operator pre-staged the file under.
+
+Fail-loud doctrine: when either source is missing the staging raises
+:class:`TuiAuthStageError` with the exact path AND the remedy
+("set ``SAC_TUI_AUTH_CREDENTIALS_SRC`` or stage the file"). No silent
+fallback to a hardcoded template — a TUI agent that authenticates
+with the wrong identity is worse than one that fails to start.
+
+Symlink semantics: source paths are followed (``cp -Lf``) so a
+sym-linked source resolves to its real target before copy. The
+destination is always a regular file with ``0600`` perms on the
+credentials.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+
+__all__ = [
+    "TuiAuthStageError",
+    "StagedAuth",
+    "stage_tui_auth",
+    "CREDENTIALS_SRC_ENV",
+    "CLAUDE_JSON_SRC_ENV",
+    "DEFAULT_CREDENTIALS_SRC",
+    "DEFAULT_CLAUDE_JSON_SRC_BASENAME",
+]
+
+
+# Environment variable names — public so the operator (and the
+# documentation generator) can refer to them by symbol.
+CREDENTIALS_SRC_ENV = "SAC_TUI_AUTH_CREDENTIALS_SRC"
+CLAUDE_JSON_SRC_ENV = "SAC_TUI_AUTH_CLAUDE_JSON_SRC"
+
+# Default credential source: the apptainer-runtime convention. See
+# ``_apptainer_auth.auth_argv`` — the host's ``~/.claude/`` dir is
+# dir-bound at ``/tmp/sac-claude``, so this path resolves to the host
+# live ``.credentials.json`` from inside an apptainer'd SAC process.
+DEFAULT_CREDENTIALS_SRC = "/tmp/sac-claude/.credentials.json"
+
+# Default onboarding-state source basename, joined under ``$HOME`` at
+# resolve time. The host user's ``~/.claude.json`` is what ``claude
+# /login`` wrote and is the natural per-identity source.
+DEFAULT_CLAUDE_JSON_SRC_BASENAME = ".claude.json"
+
+
+class TuiAuthStageError(RuntimeError):
+    """Raised when a required TUI-auth source is missing.
+
+    Carries the exact source path plus the env var that can override
+    it so the operator's remedy is unambiguous.
+    """
+
+
+@dataclass(frozen=True)
+class StagedAuth:
+    """Paths landed by :func:`stage_tui_auth` (one per source).
+
+    Returned so the caller (the TUI runtime + e2e probes) can log the
+    exact destination paths without re-deriving them.
+    """
+
+    credentials_dst: Path
+    claude_json_dst: Path
+
+
+def _resolve_credentials_src() -> Path:
+    raw = os.environ.get(CREDENTIALS_SRC_ENV, "") or DEFAULT_CREDENTIALS_SRC
+    return Path(raw).expanduser()
+
+
+def _resolve_claude_json_src() -> Path:
+    raw = os.environ.get(CLAUDE_JSON_SRC_ENV, "")
+    if raw:
+        return Path(raw).expanduser()
+    return Path.home() / DEFAULT_CLAUDE_JSON_SRC_BASENAME
+
+
+def _follow_and_copy(src: Path, dst: Path) -> None:
+    """``cp -Lf`` semantics: follow source symlinks, overwrite dst.
+
+    ``shutil.copyfile`` already follows source symlinks by default; we
+    resolve first so the error message in :class:`FileNotFoundError`
+    names the real underlying path when the symlink dangles.
+    """
+    real_src = src.resolve(strict=True)
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    # Remove any existing dst (regular file or symlink) so we never
+    # write THROUGH a symlink the previous run may have left behind.
+    if dst.is_symlink() or dst.exists():
+        dst.unlink()
+    shutil.copyfile(real_src, dst)
+
+
+def stage_tui_auth(home_dir: Path) -> StagedAuth:
+    """Stage the credentials + ``.claude.json`` into ``home_dir``.
+
+    Idempotent: re-running overwrites the destination files. The
+    credentials destination is chmod 0600 after copy (matches the
+    permission the bundled ``claude`` enforces on its own writes).
+
+    Raises :class:`TuiAuthStageError` if either source path is absent
+    on the filesystem. See module docstring for the env-var override
+    contract.
+    """
+    home_dir.mkdir(parents=True, exist_ok=True)
+
+    creds_src = _resolve_credentials_src()
+    if not creds_src.exists():
+        raise TuiAuthStageError(
+            f"TUI auth: credentials source missing at {creds_src}. "
+            f"Set {CREDENTIALS_SRC_ENV} to an existing path or stage the "
+            "file (default expects the apptainer auth bind at "
+            f"{DEFAULT_CREDENTIALS_SRC})."
+        )
+
+    claude_json_src = _resolve_claude_json_src()
+    if not claude_json_src.exists():
+        raise TuiAuthStageError(
+            f"TUI auth: .claude.json source missing at {claude_json_src}. "
+            f"Set {CLAUDE_JSON_SRC_ENV} to an existing path or stage the "
+            "file (default expects ${HOME}/.claude.json — typically "
+            "materialised by `claude /login` on the host)."
+        )
+
+    claude_dir = home_dir / ".claude"
+    claude_dir.mkdir(parents=True, exist_ok=True)
+
+    creds_dst = claude_dir / ".credentials.json"
+    _follow_and_copy(creds_src, creds_dst)
+    creds_dst.chmod(0o600)
+
+    claude_json_dst = home_dir / ".claude.json"
+    _follow_and_copy(claude_json_src, claude_json_dst)
+
+    return StagedAuth(credentials_dst=creds_dst, claude_json_dst=claude_json_dst)

--- a/src/scitex_agent_container/runtimes/tui_session.py
+++ b/src/scitex_agent_container/runtimes/tui_session.py
@@ -62,10 +62,17 @@ from typing import Any
 from .._runners._tmux.tmux import TmuxManager
 from ..config import AgentConfig
 from ._to_home import deploy_to_home
+from ._tui_auth_stage import TuiAuthStageError, stage_tui_auth
 from .base import RuntimeBase
 from .claude_md import setup_claude_md
 
-__all__ = ["TuiSessionRuntime", "session_name_for", "state_dir_for_config"]
+__all__ = [
+    "TuiAuthStageError",
+    "TuiSessionRuntime",
+    "session_name_for",
+    "stage_tui_auth",
+    "state_dir_for_config",
+]
 
 
 _CLAUDE_BIN_DEFAULT = "claude"
@@ -149,8 +156,8 @@ class TuiSessionRuntime(RuntimeBase):
         self._claude_bin = claude_bin
 
     def materialize_workspace(self, config: AgentConfig) -> Path | None:
-        """Materialise per-agent ``to_home/`` + CLAUDE.md into
-        ``<state>/home/`` and return that path.
+        """Materialise per-agent ``to_home/`` + CLAUDE.md + TUI-auth
+        files into ``<state>/home/`` and return that path.
 
         Mirrors ``ClaudeSessionRuntime._materialize_workspace``: writes
         the sac-managed CLAUDE.md skill chain into ``<state>/home/CLAUDE.md``
@@ -159,6 +166,20 @@ class TuiSessionRuntime(RuntimeBase):
         baseline. The result is a self-contained $HOME tree the TUI
         ``claude`` binary will read on launch — same SkillsSpec / MCP
         / hook surface the SDK runtime provides.
+
+        ADDITIONAL TUI-auth staging (lead a2a
+        ``910ff436642948eb85f8b3100204ed9b``, 2026-06-14): the
+        interactive ``claude`` TUI checks TWO files the SDK runner
+        does not — ``$HOME/.claude/.credentials.json`` (live OAuth
+        token) and ``$HOME/.claude.json`` (onboarding state). Before
+        this hook, every ``sac agents start --runtime tui`` agent sat
+        on the login picker because neither file was present in the
+        materialised HOME. :func:`stage_tui_auth` lands both, sourced
+        by default from the apptainer auth bind + ``${HOME}/.claude.json``
+        and overridable via ``SAC_TUI_AUTH_CREDENTIALS_SRC`` /
+        ``SAC_TUI_AUTH_CLAUDE_JSON_SRC``. Fail-loud: a missing source
+        raises :class:`TuiAuthStageError` with a remedy rather than
+        letting the TUI silently stall on the picker.
 
         Returns ``None`` for stub configs lacking the full AgentConfig
         surface (unit-test ``SimpleNamespace`` fixtures); the caller
@@ -170,6 +191,7 @@ class TuiSessionRuntime(RuntimeBase):
         home_dir.mkdir(parents=True, exist_ok=True)
         setup_claude_md(config, str(home_dir))
         deploy_to_home(config, str(home_dir))
+        stage_tui_auth(home_dir)
         return home_dir
 
     def start(

--- a/tests/scitex_agent_container/runtimes/test__tui_auth_stage.py
+++ b/tests/scitex_agent_container/runtimes/test__tui_auth_stage.py
@@ -1,0 +1,387 @@
+"""Tests for ``runtimes._tui_auth_stage.stage_tui_auth``.
+
+Stages the two files the interactive ``claude`` TUI needs into a
+materialised ``$HOME``. Lead a2a ``910ff436642948eb85f8b3100204ed9b``
+(2026-06-14) — the auth-staging recipe proven by the e2e probe baked
+into the runtime so every ``sac agents start`` TUI agent skips the
+login picker automatically.
+
+STX-TQ002 AAA markers, STX-TQ007 one-assert. No mocks; sources are
+real files under ``tmp_path`` and assertions read real files back.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container.runtimes._tui_auth_stage import (
+    CLAUDE_JSON_SRC_ENV,
+    CREDENTIALS_SRC_ENV,
+    TuiAuthStageError,
+    stage_tui_auth,
+)
+
+# ---------------------------------------------------------------------------
+# Shared fixtures — sandbox $HOME + the two source-path env vars so the
+# operator's real ~/.claude.json / /tmp/sac-claude/ is never touched.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(tmp_path: Path):
+    """Save/restore HOME and the two SAC_TUI_AUTH_* env vars."""
+    saved: dict[str, str | None] = {
+        key: os.environ.get(key)
+        for key in ("HOME", CREDENTIALS_SRC_ENV, CLAUDE_JSON_SRC_ENV)
+    }
+    # Point HOME at a fresh dir so the default ${HOME}/.claude.json
+    # source resolves under tmp_path (and is missing by default —
+    # tests that exercise the default must pre-stage it themselves).
+    os.environ["HOME"] = str(tmp_path / "home")
+    (tmp_path / "home").mkdir(parents=True, exist_ok=True)
+    # Unset the env overrides so each test opts in explicitly.
+    os.environ.pop(CREDENTIALS_SRC_ENV, None)
+    os.environ.pop(CLAUDE_JSON_SRC_ENV, None)
+    try:
+        yield
+    finally:
+        for key, value in saved.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+@pytest.fixture
+def creds_src(tmp_path: Path) -> Path:
+    """Stage a real ``.credentials.json`` source with realistic content."""
+    src = tmp_path / "creds-src" / ".credentials.json"
+    src.parent.mkdir(parents=True, exist_ok=True)
+    src.write_text(
+        json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "sk-ant-oat01-test-token",
+                    "refreshToken": "sk-ant-ort01-test-refresh",
+                    "expiresAt": 9999999999999,
+                    "subscriptionType": "max",
+                }
+            }
+        )
+    )
+    return src
+
+
+@pytest.fixture
+def claude_json_src(tmp_path: Path) -> Path:
+    """Stage a real ``.claude.json`` source with the onboarding block."""
+    src = tmp_path / "claude-json-src" / ".claude.json"
+    src.parent.mkdir(parents=True, exist_ok=True)
+    src.write_text(
+        json.dumps(
+            {
+                "hasCompletedOnboarding": True,
+                "lastOnboardingVersion": "2.0.54",
+                "userID": "deadbeef" * 8,
+                "oauthAccount": {
+                    "accountUuid": "11111111-2222-3333-4444-555555555555",
+                    "emailAddress": "test@example.com",
+                    "organizationUuid": "66666666-7777-8888-9999-aaaaaaaaaaaa",
+                    "organizationType": "claude_max",
+                },
+            }
+        )
+    )
+    return src
+
+
+@pytest.fixture
+def home_dir(tmp_path: Path) -> Path:
+    """Materialised HOME root the TUI runtime would pass."""
+    h = tmp_path / "tui-home"
+    h.mkdir(parents=True, exist_ok=True)
+    return h
+
+
+@pytest.fixture
+def staged_via_env(home_dir: Path, creds_src: Path, claude_json_src: Path) -> None:
+    """Stage via env-var overrides — exercises the default code path
+    that the TUI runtime uses (defaults pointing at the host)."""
+    os.environ[CREDENTIALS_SRC_ENV] = str(creds_src)
+    os.environ[CLAUDE_JSON_SRC_ENV] = str(claude_json_src)
+    stage_tui_auth(home_dir)
+
+
+# ---------------------------------------------------------------------------
+# Happy path — both sources present, staging lands the right files.
+# ---------------------------------------------------------------------------
+
+
+class TestStageTuiAuthHappyPath:
+    """Both sources exist; staging lands real files with correct perms."""
+
+    def test_credentials_file_landed_under_dot_claude(
+        self, home_dir: Path, staged_via_env: None
+    ) -> None:
+        # Arrange
+        dst = home_dir / ".claude" / ".credentials.json"
+        # Act
+        present = dst.is_file()
+        # Assert
+        assert present is True
+
+    def test_credentials_file_chmod_0600(
+        self, home_dir: Path, staged_via_env: None
+    ) -> None:
+        # Arrange
+        dst = home_dir / ".claude" / ".credentials.json"
+        # Act
+        mode = stat.S_IMODE(dst.stat().st_mode)
+        # Assert
+        assert mode == 0o600
+
+    def test_credentials_content_matches_source(
+        self,
+        home_dir: Path,
+        creds_src: Path,
+        staged_via_env: None,
+    ) -> None:
+        # Arrange
+        dst = home_dir / ".claude" / ".credentials.json"
+        # Act
+        observed = dst.read_text()
+        # Assert
+        assert observed == creds_src.read_text()
+
+    def test_claude_json_landed_at_home_root(
+        self, home_dir: Path, staged_via_env: None
+    ) -> None:
+        # Arrange
+        dst = home_dir / ".claude.json"
+        # Act
+        present = dst.is_file()
+        # Assert
+        assert present is True
+
+    def test_claude_json_content_matches_source(
+        self,
+        home_dir: Path,
+        claude_json_src: Path,
+        staged_via_env: None,
+    ) -> None:
+        # Arrange
+        dst = home_dir / ".claude.json"
+        # Act
+        observed = json.loads(dst.read_text())
+        expected = json.loads(claude_json_src.read_text())
+        # Assert
+        assert observed == expected
+
+    def test_return_value_names_credentials_destination(
+        self,
+        home_dir: Path,
+        creds_src: Path,
+        claude_json_src: Path,
+    ) -> None:
+        # Arrange
+        os.environ[CREDENTIALS_SRC_ENV] = str(creds_src)
+        os.environ[CLAUDE_JSON_SRC_ENV] = str(claude_json_src)
+        # Act
+        staged = stage_tui_auth(home_dir)
+        # Assert
+        assert staged.credentials_dst == home_dir / ".claude" / ".credentials.json"
+
+    def test_return_value_names_claude_json_destination(
+        self,
+        home_dir: Path,
+        creds_src: Path,
+        claude_json_src: Path,
+    ) -> None:
+        # Arrange
+        os.environ[CREDENTIALS_SRC_ENV] = str(creds_src)
+        os.environ[CLAUDE_JSON_SRC_ENV] = str(claude_json_src)
+        # Act
+        staged = stage_tui_auth(home_dir)
+        # Assert
+        assert staged.claude_json_dst == home_dir / ".claude.json"
+
+
+# ---------------------------------------------------------------------------
+# Fail-loud — missing sources raise TuiAuthStageError.
+# ---------------------------------------------------------------------------
+
+
+class TestStageTuiAuthFailLoud:
+    """Missing source → raise with a remedy. No silent fallback."""
+
+    def test_missing_credentials_source_raises(
+        self,
+        home_dir: Path,
+        claude_json_src: Path,
+        tmp_path: Path,
+    ) -> None:
+        # Arrange
+        os.environ[CREDENTIALS_SRC_ENV] = str(tmp_path / "nope" / ".credentials.json")
+        os.environ[CLAUDE_JSON_SRC_ENV] = str(claude_json_src)
+        # Act / Assert
+        with pytest.raises(TuiAuthStageError, match="credentials source missing"):
+            stage_tui_auth(home_dir)
+
+    def test_missing_claude_json_source_raises(
+        self,
+        home_dir: Path,
+        creds_src: Path,
+        tmp_path: Path,
+    ) -> None:
+        # Arrange
+        os.environ[CREDENTIALS_SRC_ENV] = str(creds_src)
+        os.environ[CLAUDE_JSON_SRC_ENV] = str(tmp_path / "nope" / ".claude.json")
+        # Act / Assert
+        with pytest.raises(TuiAuthStageError, match=".claude.json source missing"):
+            stage_tui_auth(home_dir)
+
+    def test_credentials_error_names_env_var(
+        self,
+        home_dir: Path,
+        claude_json_src: Path,
+        tmp_path: Path,
+    ) -> None:
+        # Arrange
+        os.environ[CREDENTIALS_SRC_ENV] = str(tmp_path / "nope" / ".credentials.json")
+        os.environ[CLAUDE_JSON_SRC_ENV] = str(claude_json_src)
+        # Act
+        with pytest.raises(TuiAuthStageError) as exc_info:
+            stage_tui_auth(home_dir)
+        # Assert — operator's remedy must include the env var to override.
+        assert CREDENTIALS_SRC_ENV in str(exc_info.value)
+
+    def test_claude_json_error_names_env_var(
+        self,
+        home_dir: Path,
+        creds_src: Path,
+        tmp_path: Path,
+    ) -> None:
+        # Arrange
+        os.environ[CREDENTIALS_SRC_ENV] = str(creds_src)
+        os.environ[CLAUDE_JSON_SRC_ENV] = str(tmp_path / "nope" / ".claude.json")
+        # Act
+        with pytest.raises(TuiAuthStageError) as exc_info:
+            stage_tui_auth(home_dir)
+        # Assert
+        assert CLAUDE_JSON_SRC_ENV in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# Defaults — when env not set, falls back to documented paths.
+# ---------------------------------------------------------------------------
+
+
+class TestStageTuiAuthDefaults:
+    """When neither env is set, the defaults resolve correctly."""
+
+    def test_default_claude_json_src_is_under_home(
+        self,
+        home_dir: Path,
+        creds_src: Path,
+        tmp_path: Path,
+    ) -> None:
+        # Arrange — stage a .claude.json at ${HOME}/.claude.json so the
+        # default resolver finds it; only override the credentials env
+        # (the default /tmp/sac-claude/.credentials.json is a real
+        # operator-host path we must not touch from a unit test).
+        os.environ[CREDENTIALS_SRC_ENV] = str(creds_src)
+        host_claude_json = Path(os.environ["HOME"]) / ".claude.json"
+        host_claude_json.write_text(json.dumps({"hasCompletedOnboarding": True}))
+        # Act
+        stage_tui_auth(home_dir)
+        # Assert — destination materialised from the default-resolved source.
+        observed = json.loads((home_dir / ".claude.json").read_text())
+        assert observed == {"hasCompletedOnboarding": True}
+
+
+# ---------------------------------------------------------------------------
+# Symlink semantics — sources are followed (cp -Lf).
+# ---------------------------------------------------------------------------
+
+
+class TestStageTuiAuthSymlinkSources:
+    """``cp -Lf`` semantics: source symlinks resolve to real content."""
+
+    def test_symlinked_credentials_source_resolves_to_target_content(
+        self,
+        home_dir: Path,
+        creds_src: Path,
+        claude_json_src: Path,
+        tmp_path: Path,
+    ) -> None:
+        # Arrange — a symlink at the env-pointed path, target is the real file.
+        link = tmp_path / "creds-link" / ".credentials.json"
+        link.parent.mkdir(parents=True, exist_ok=True)
+        link.symlink_to(creds_src)
+        os.environ[CREDENTIALS_SRC_ENV] = str(link)
+        os.environ[CLAUDE_JSON_SRC_ENV] = str(claude_json_src)
+        # Act
+        stage_tui_auth(home_dir)
+        # Assert — dst is a REGULAR FILE with the symlink target's content.
+        dst = home_dir / ".claude" / ".credentials.json"
+        assert dst.read_text() == creds_src.read_text()
+
+    def test_symlinked_credentials_destination_is_not_a_symlink(
+        self,
+        home_dir: Path,
+        creds_src: Path,
+        claude_json_src: Path,
+        tmp_path: Path,
+    ) -> None:
+        # Arrange — same shape as above.
+        link = tmp_path / "creds-link" / ".credentials.json"
+        link.parent.mkdir(parents=True, exist_ok=True)
+        link.symlink_to(creds_src)
+        os.environ[CREDENTIALS_SRC_ENV] = str(link)
+        os.environ[CLAUDE_JSON_SRC_ENV] = str(claude_json_src)
+        # Act
+        stage_tui_auth(home_dir)
+        # Assert
+        dst = home_dir / ".claude" / ".credentials.json"
+        assert dst.is_symlink() is False
+
+
+# ---------------------------------------------------------------------------
+# Idempotency — re-run overwrites previous staging.
+# ---------------------------------------------------------------------------
+
+
+class TestStageTuiAuthIdempotent:
+    """Re-running the staging overwrites the prior destination."""
+
+    def test_rerun_overwrites_credentials_content(
+        self,
+        home_dir: Path,
+        claude_json_src: Path,
+        tmp_path: Path,
+    ) -> None:
+        # Arrange — two distinct credential sources; stage A then B.
+        creds_a = tmp_path / "a" / ".credentials.json"
+        creds_a.parent.mkdir(parents=True, exist_ok=True)
+        creds_a.write_text('{"version": "A"}')
+        creds_b = tmp_path / "b" / ".credentials.json"
+        creds_b.parent.mkdir(parents=True, exist_ok=True)
+        creds_b.write_text('{"version": "B"}')
+        os.environ[CLAUDE_JSON_SRC_ENV] = str(claude_json_src)
+
+        os.environ[CREDENTIALS_SRC_ENV] = str(creds_a)
+        stage_tui_auth(home_dir)
+        # Act — re-stage with the second source.
+        os.environ[CREDENTIALS_SRC_ENV] = str(creds_b)
+        stage_tui_auth(home_dir)
+        # Assert — destination reflects the LATER source.
+        observed = (home_dir / ".claude" / ".credentials.json").read_text()
+        assert observed == '{"version": "B"}'
+
+
+# EOF

--- a/tests/scitex_agent_container/runtimes/test_tui_session_real_smoke.py
+++ b/tests/scitex_agent_container/runtimes/test_tui_session_real_smoke.py
@@ -47,6 +47,10 @@ from pathlib import Path
 import pytest
 
 from scitex_agent_container.config import load_config
+from scitex_agent_container.runtimes._tui_auth_stage import (
+    CLAUDE_JSON_SRC_ENV,
+    CREDENTIALS_SRC_ENV,
+)
 from scitex_agent_container.runtimes.tui_session import (
     TuiSessionRuntime,
     session_name_for,
@@ -218,6 +222,36 @@ class _SmokeProbes:
     state_home: Path
 
 
+def _stage_fake_auth_sources(
+    tmp_path: Path, env_save_restore_class: object
+) -> tuple[Path, Path]:
+    """Stage realistic-but-fake credentials + .claude.json sources and
+    point the auth-stage env vars at them.
+
+    The TUI runtime now materialises both files into ``<state>/home/``
+    (lead a2a ``910ff436642948eb85f8b3100204ed9b``) so every test that
+    calls ``runtime.start`` needs them present somewhere. For smoke /
+    nonce tests we don't need REAL OAuth tokens — fake files satisfy
+    ``stage_tui_auth``'s existence check and the inner claude TUI then
+    falls back to the login picker (which is what the smoke tests
+    already expect to see anyway).
+    """
+    fake_creds = tmp_path / "fake_creds" / ".credentials.json"
+    fake_creds.parent.mkdir(parents=True, exist_ok=True)
+    fake_creds.write_text(
+        '{"claudeAiOauth": {"accessToken": "fake", "refreshToken": "fake",'
+        ' "expiresAt": 9999999999999, "subscriptionType": "max"}}'
+    )
+    fake_claude_json = tmp_path / "fake_claude_json" / ".claude.json"
+    fake_claude_json.parent.mkdir(parents=True, exist_ok=True)
+    fake_claude_json.write_text(
+        '{"hasCompletedOnboarding": false, "oauthAccount": null}'
+    )
+    env_save_restore_class.set(CREDENTIALS_SRC_ENV, str(fake_creds))
+    env_save_restore_class.set(CLAUDE_JSON_SRC_ENV, str(fake_claude_json))
+    return fake_creds, fake_claude_json
+
+
 @pytest.fixture(scope="class")
 def smoke_probes(request, tmp_path_factory, env_save_restore_class) -> "_SmokeProbes":
     """Drive ONE real tmux + real claude launch and capture every probe
@@ -233,6 +267,7 @@ def smoke_probes(request, tmp_path_factory, env_save_restore_class) -> "_SmokePr
     home_root = tmp_path / "home_root"
     home_root.mkdir()
     env_save_restore_class.set("HOME", str(home_root))
+    _stage_fake_auth_sources(tmp_path, env_save_restore_class)
 
     config = load_config(spec_path)
     runtime = TuiSessionRuntime()
@@ -447,6 +482,7 @@ def nonce_probes(tmp_path_factory, env_save_restore_class) -> "_NonceProbes":
     home_root = tmp_path / "home_root"
     home_root.mkdir()
     env_save_restore_class.set("HOME", str(home_root))
+    _stage_fake_auth_sources(tmp_path, env_save_restore_class)
 
     config = load_config(spec_path)
     runtime = TuiSessionRuntime(claude_bin=_BASH_ECHO_READER)
@@ -512,6 +548,40 @@ class TestTuiRuntimeNonceRoundTrip:
         observed = expected in pane
         # Assert
         assert observed is True
+
+
+# ---------------------------------------------------------------------------
+# Auth-stage materialisation (lead a2a ``910ff436642948eb85f8b3100204ed9b``)
+#
+# The materialise step now lands the two files the interactive TUI
+# checks on launch. The smoke fixture above points the env vars at
+# fake auth so the stage doesn't read host creds; these tests prove
+# the files arrived where the inner ``claude`` will look for them.
+# ---------------------------------------------------------------------------
+
+
+class TestTuiRuntimeAuthStaged:
+    """Step-3 of the 2026-06-14 TUI hedge: ``.claude/.credentials.json``
+    and ``.claude.json`` land in ``<state>/home/`` automatically. Shares
+    the same smoke launch (no extra wall).
+    """
+
+    def test_credentials_file_in_state_home(self, smoke_probes: _SmokeProbes) -> None:
+        # Arrange
+        path = smoke_probes.state_home / ".claude" / ".credentials.json"
+        # Act
+        present = path.is_file()
+        # Assert
+        assert present is True
+
+    def test_claude_json_in_state_home(self, smoke_probes: _SmokeProbes) -> None:
+        # Arrange
+        path = smoke_probes.state_home / ".claude.json"
+        # Act
+        present = path.is_file()
+        # Assert
+        assert present is True
+
 
 
 # EOF


### PR DESCRIPTION
## Summary
- `TuiSessionRuntime.materialize_workspace` now lands `.claude/.credentials.json` (live OAuth) + `.claude.json` (onboarding + oauthAccount) into `<state>/home/` so every `sac agents start --runtime tui` agent authenticates without the login picker.
- Sources default to the apptainer auth bind (`/tmp/sac-claude/.credentials.json`) + `${HOME}/.claude.json`; overridable via `SAC_TUI_AUTH_CREDENTIALS_SRC` / `SAC_TUI_AUTH_CLAUDE_JSON_SRC`.
- Fail-loud: missing source raises `TuiAuthStageError` with the exact path + env var to override. No silent fallback to a hardcoded identity.

## Why
Lead a2a `020bd692` / `910ff436` (2026-06-14): operator's e2e probe caught every TUI agent stalling on the login picker because the interactive `claude` TUI reads onboarding state from `~/.claude.json` (which `claude -p` does not). PR #391 wired tmux + `claude`; this PR closes the auth gap so the fleet can dogfood `runtime: tui`.

## Proof (live, ywata1989@gmail.com)
Scrollback from the e2e probe after pre-staging both files (the recipe this PR bakes into the runtime):

```
╭─── Claude Code v2.1.150 ───
│ Welcome back Yusuke!
│ Opus 4.7 (1M context) · Claude Max ·
│ ywata1989@gmail.com's Organization
│ /tmp/tui-e2e-888fd713/home
╰───
❯
? for shortcuts
```

No login picker — the TUI mounts straight into the input field.

## Tests
- `test__tui_auth_stage.py` — 15 new one-assert unit tests (happy path, fail-loud, defaults, symlink follow, idempotent re-stage).
- `test_tui_session_real_smoke.py` — existing smoke fixture extended to pre-stage fake auth env vars; 2 new `TestTuiRuntimeAuthStaged` one-assert tests confirm both files land in `<state>/home/`. All 14 real-binary tests green on this dev host.

## Test plan
- [x] Unit tests green (`test__tui_auth_stage.py` + `test_tui_session.py`): 36 passed.
- [x] Real-binary smoke green (`test_tui_session_real_smoke.py`): 14 passed.
- [x] Auth-skip proven against live claude 2.1.150 + live OAuth token.
- [ ] CI green (this PR).

## Follow-up (separate PR)
Structural `send_text_and_submit` hardening (`wait_for_input_ready` poll + echo-verify retry) — the operator's e2e probe also caught Ink dropping keystrokes against a freshly-rendered TUI. Code already drafted; lands after this PR so the 3 dogfood agents are unblocked first.

Lead a2a: `910ff436642948eb85f8b3100204ed9b`, `b591f42c4c4944d18c23bf4e8efc6f6b`