### PR TITLE
feat(tmux): wait_for_input_ready + send_text_and_submit_verified for TUI

### DIFF
--- a/src/scitex_agent_container/_runners/_tmux/multiplexer.py
+++ b/src/scitex_agent_container/_runners/_tmux/multiplexer.py
@@ -42,6 +42,25 @@ class MultiplexerProtocol(Protocol):
     def send_text_and_submit(session_name: str, text: str) -> None: ...
 
     @staticmethod
+    def send_text_and_submit_verified(
+        session_name: str,
+        text: str,
+        **kwargs: object,
+    ) -> int:
+        """Send text + Enter with echo-verify retry. See
+        :meth:`TmuxManager.send_text_and_submit_verified`. Returns the
+        1-indexed attempt number that succeeded.
+
+        Added 2026-06-14 (TUI Ink-drop fix, lead a2a
+        ``910ff436642948eb85f8b3100204ed9b``) — every multiplexer the
+        TUI runtime drives must expose this. ScreenManager (not in
+        tree but referenced by get_multiplexer) is unused by the
+        active fleet today; once it lands, it inherits the same
+        contract.
+        """
+        ...
+
+    @staticmethod
     def attach(session_name: str) -> None: ...
 
 

--- a/src/scitex_agent_container/_runners/_tmux/tmux.py
+++ b/src/scitex_agent_container/_runners/_tmux/tmux.py
@@ -19,6 +19,42 @@ from typing import Callable
 _DEFAULT_INTER_KEY_DELAY_S = float(os.environ.get("SAC_KEY_DELAY_S", "0.1"))
 _DEFAULT_SUBMIT_SETTLE_S = float(os.environ.get("SAC_SUBMIT_SETTLE_S", "0.3"))
 
+# Structural fix for the Ink-drop race (lead a2a
+# ``910ff436642948eb85f8b3100204ed9b``, 2026-06-14): the interactive
+# claude TUI occasionally drops a keystroke that arrives mid-render
+# (the React/Ink renderer eats the input event before binding the
+# next listener). The cure is observation-based — wait for the
+# input-ready marker before sending, then verify the sent text
+# echoed back in the pane before committing Enter, then retry the
+# whole text send if the echo never appeared.
+#
+# Default marker: the claude TUI prints ``? for shortcuts`` in its
+# footer when the input field is bound and accepting keystrokes.
+# Overridable per call so non-claude callers can pass a different
+# signal.
+_DEFAULT_INPUT_READY_MARKER = "? for shortcuts"
+
+
+class TuiInputNotReadyError(RuntimeError):
+    """Raised when the TUI input-ready marker never appeared.
+
+    The wait_for_input_ready primitive raises this instead of timing
+    out silently so the caller reports "TUI never mounted its input
+    field" rather than a generic timeout — the operator can then tell
+    at a glance whether auth failed (login picker stuck) vs. render
+    hung (Ink wedged).
+    """
+
+
+class TuiKeystrokeDropError(RuntimeError):
+    """Raised when send_text_and_submit_verified exhausted its retries
+    without observing the sent text echo in the pane.
+
+    The Ink renderer dropped every send. Fail loud rather than silently
+    submitting an empty Enter (which the TUI would treat as "no input"
+    and the operator would see as "agent ignored the prompt").
+    """
+
 
 class TmuxManager:
     """Helpers for tmux session lifecycle."""
@@ -277,6 +313,141 @@ class TmuxManager:
             ["tmux", "send-keys", "-t", session_name, "Enter"],
             check=False,
             capture_output=True,
+        )
+
+    @staticmethod
+    def wait_for_input_ready(
+        session_name: str,
+        *,
+        marker: str = _DEFAULT_INPUT_READY_MARKER,
+        timeout_s: float = 30.0,
+        poll_s: float = 0.25,
+        sleep_fn: Callable[[float], None] = time.sleep,
+        capture_fn: Callable[[str], str] | None = None,
+    ) -> bool:
+        """Block until ``marker`` appears in the session pane content.
+
+        Structural fix for the Ink-drop race (lead a2a
+        ``910ff436642948eb85f8b3100204ed9b``): the bundled claude TUI
+        takes a beat to mount its input field after the welcome banner
+        renders, and any keystroke sent during that mount window is
+        silently eaten. Callers gate ``send_text_and_submit_verified``
+        on this primitive so the FIRST send always lands on a bound
+        input.
+
+        ``marker`` defaults to ``? for shortcuts`` — claude's footer
+        text once input is bound. Non-claude callers (bash stand-ins,
+        screen runners) pass their own signal.
+
+        ``capture_fn`` injects the pane-capture step so unit tests can
+        feed a deterministic transcript without invoking real tmux.
+        Defaults to :meth:`capture_content`.
+
+        Raises :class:`TuiInputNotReadyError` on timeout — never
+        returns False (a False return would let a caller silently
+        continue and submit into a not-yet-bound input). Returns True
+        when the marker is observed.
+        """
+        capture = capture_fn or TmuxManager.capture_content
+        deadline = time.monotonic() + timeout_s
+        last = ""
+        while time.monotonic() < deadline:
+            last = capture(session_name)
+            if marker in last:
+                return True
+            if poll_s > 0:
+                sleep_fn(poll_s)
+        raise TuiInputNotReadyError(
+            f"TUI input-ready marker {marker!r} not seen in pane "
+            f"{session_name!r} within {timeout_s:.1f}s. Last pane "
+            f"content:\n{last}"
+        )
+
+    @staticmethod
+    def send_text_and_submit_verified(
+        session_name: str,
+        text: str,
+        *,
+        max_resends: int = 3,
+        echo_wait_s: float = 2.0,
+        poll_s: float = 0.25,
+        sleep_fn: Callable[[float], None] = time.sleep,
+        capture_fn: Callable[[str], str] | None = None,
+        send_text_fn: Callable[[str, str], None] | None = None,
+        send_enter_fn: Callable[[str], None] | None = None,
+        echo_excerpt_len: int = 20,
+    ) -> int:
+        """Send ``text`` then Enter, retrying if the TUI dropped the keys.
+
+        Algorithm — purely observation-driven, no sleep-hacks:
+
+          1. send-keys the text.
+          2. poll capture-pane until the first ``echo_excerpt_len`` chars
+             of ``text`` echo back in the pane (proves the TUI accepted
+             and rendered the keystrokes). Time-bounded by ``echo_wait_s``.
+          3. on success → send Enter as a separate keystroke, return.
+          4. on echo-not-seen → re-send the text, retry up to
+             ``max_resends`` times. Each retry restarts the echo poll
+             from scratch.
+          5. on all retries dropped → raise :class:`TuiKeystrokeDropError`.
+
+        The Enter is sent as its own keystroke (not as part of the text)
+        because tmux's ``send-keys text\\r`` is interpreted as raw input
+        — claude's TUI occasionally swallows the trailing CR if it
+        re-renders mid-keystroke. A separate Enter call hits the input
+        field after the text has visibly settled.
+
+        Returns the 1-indexed attempt number that succeeded — surfaces
+        to the operator as "delivered on retry N" telemetry without
+        coupling the caller to a counter.
+
+        All injection seams (``capture_fn``, ``send_text_fn``,
+        ``send_enter_fn``, ``sleep_fn``) match the existing module
+        pattern (see :meth:`send_keys`); tests use them to skip
+        subprocess calls.
+        """
+        capture = capture_fn or TmuxManager.capture_content
+        send_text = send_text_fn or (
+            lambda session, payload: subprocess.run(
+                ["tmux", "send-keys", "-t", session, payload],
+                check=False,
+                capture_output=True,
+            )
+        )
+        send_enter = send_enter_fn or (
+            lambda session: subprocess.run(
+                ["tmux", "send-keys", "-t", session, "Enter"],
+                check=False,
+                capture_output=True,
+            )
+        )
+
+        excerpt = text[:echo_excerpt_len]
+        last_pane = ""
+        for attempt in range(1, max_resends + 2):
+            send_text(session_name, text)
+            # Do-while: always capture at least once immediately after
+            # the send, then poll until the echo deadline. This makes
+            # ``echo_wait_s=0.0`` mean "one capture per attempt" rather
+            # than "no captures at all" (which would silently bypass
+            # the verification).
+            last_pane = capture(session_name)
+            if excerpt and excerpt in last_pane:
+                send_enter(session_name)
+                return attempt
+            echo_deadline = time.monotonic() + echo_wait_s
+            while time.monotonic() < echo_deadline:
+                if poll_s > 0:
+                    sleep_fn(poll_s)
+                last_pane = capture(session_name)
+                if excerpt and excerpt in last_pane:
+                    send_enter(session_name)
+                    return attempt
+            # Echo never appeared within echo_wait_s; loop and resend.
+        raise TuiKeystrokeDropError(
+            f"TUI dropped {max_resends + 1} send attempts of {text!r} "
+            f"into pane {session_name!r}. Echo excerpt {excerpt!r} never "
+            f"appeared. Last pane content:\n{last_pane}"
         )
 
     @staticmethod

--- a/src/scitex_agent_container/runtimes/tui_session.py
+++ b/src/scitex_agent_container/runtimes/tui_session.py
@@ -59,13 +59,22 @@ import time
 from pathlib import Path
 from typing import Any
 
-from .._runners._tmux.tmux import TmuxManager
+from .._runners._tmux.tmux import (
+    TmuxManager,
+    TuiInputNotReadyError,
+)
 from ..config import AgentConfig
+from . import prompts as _prompts
 from ._to_home import deploy_to_home
 from .base import RuntimeBase
 from .claude_md import setup_claude_md
 
-__all__ = ["TuiSessionRuntime", "session_name_for", "state_dir_for_config"]
+__all__ = [
+    "TuiInputNotReadyError",
+    "TuiSessionRuntime",
+    "session_name_for",
+    "state_dir_for_config",
+]
 
 
 _CLAUDE_BIN_DEFAULT = "claude"
@@ -273,7 +282,13 @@ class TuiSessionRuntime(RuntimeBase):
             return False
         return (time.time() - float(activity)) <= max_idle_s
 
-    def send_turn(self, config: AgentConfig, text: str) -> bool:
+    def send_turn(
+        self,
+        config: AgentConfig,
+        text: str,
+        *,
+        wait_ready: bool = True,
+    ) -> bool:
         """Deliver one turn of input to the in-tmux TUI.
 
         Uses the multiplexer's ``send_text_and_submit`` (text first,
@@ -306,6 +321,22 @@ class TuiSessionRuntime(RuntimeBase):
         name = session_name_for(config)
         if not self._mux.exists(name):
             return False
+        if wait_ready:
+            # State-table dispatch (lead a2a
+            # ``286ce8f625744cd08e4ee23eddf2c7aa``, 2026-06-14):
+            # before delivering the turn, drain any first-launch /
+            # mid-session modals via the existing
+            # ``runtimes/prompts.py`` registry (theme picker, login
+            # method, file-trust, dev-channels, etc. — 12 handlers
+            # today, all keystroke-driven). The driver no longer
+            # ad-hoc-detects gates inline; the SAME registry that
+            # the SDK runtime uses serves the TUI runtime.
+            #
+            # Skippable via ``wait_ready=False`` for the in-memory
+            # unit suite where the multiplexer fake doesn't render
+            # an input-ready marker (the modal drain has no work
+            # to do anyway). Real-binary callers always wait.
+            self.wait_until_input_ready(config)
         # Structural fix for the Ink-drop race (lead a2a
         # ``910ff436642948eb85f8b3100204ed9b`` / ``b591f42c4c4944d18``,
         # 2026-06-14). ``send_text_and_submit_verified`` polls
@@ -320,6 +351,79 @@ class TuiSessionRuntime(RuntimeBase):
         # turn either lands or fails loud (TuiKeystrokeDropError).
         self._mux.send_text_and_submit_verified(name, text)
         return True
+
+    def wait_until_input_ready(
+        self,
+        config: AgentConfig,
+        *,
+        timeout_s: float = 60.0,
+        poll_s: float = 0.4,
+        sleep_fn=time.sleep,
+    ) -> bool:
+        """Drain first-launch / mid-session modals, then block until the
+        TUI input field is bound.
+
+        Lead a2a ``286ce8f625744cd08e4ee23eddf2c7aa`` (2026-06-14): the
+        TUI driving is no longer a tower of ad-hoc inline detections.
+        Each polling frame is matched against the existing
+        :mod:`runtimes.prompts` registry (12 handlers today —
+        theme-selection / login-method / file-trust / dev-channels /
+        bypass-permissions / press-enter-continue / external-imports /
+        mcp-json-edit / thinking-effort / skip-permissions-yn /
+        compose-pending-unsent / file-trust-radio); the FIRST matching
+        handler runs its registered keystrokes (``send_keys`` via the
+        multiplexer) and is added to the ``accepted`` set so a
+        re-render of the same modal doesn't double-send. Polling
+        continues until either the ``? for shortcuts`` input-ready
+        marker appears OR :class:`TuiInputNotReadyError` is raised on
+        timeout.
+
+        The 401 / rate-limited / processing / response-ready states
+        the operator named in the new spec land in the SAME registry
+        as additional handlers (see :mod:`runtimes.prompts`); when
+        their detect strings match, the registered action runs
+        without further driver changes.
+
+        ``poll_s`` defaults to 400ms — long enough that the
+        capture-pane subprocess doesn't dominate the wall, short
+        enough that Ink modal re-renders are caught within a few
+        frames.
+        """
+        name = session_name_for(config)
+        if not self._mux.exists(name):
+            raise TuiInputNotReadyError(
+                f"TUI session {name!r} does not exist; nothing to wait for."
+            )
+
+        # ``accepted`` is intentionally per-call: a fresh modal
+        # sequence on each turn (e.g. a context-window press-enter)
+        # should be dismissed afresh.
+        accepted: set[str] = set()
+        marker = "? for shortcuts"
+        deadline = time.monotonic() + timeout_s
+        last_pane = ""
+        send_keys_fn = self._mux.send_keys
+        while time.monotonic() < deadline:
+            last_pane = self._mux.capture_content(name)
+            if marker in last_pane:
+                return True
+            handled = _prompts.detect_and_respond(
+                last_pane, accepted, send_keys_fn=lambda key: send_keys_fn(name, key)
+            )
+            if handled is not None:
+                accepted.add(handled)
+                # Re-capture immediately after a keystroke — the
+                # modal may dismiss in <poll_s and the input field
+                # bind on the very next frame.
+                continue
+            if poll_s > 0:
+                sleep_fn(poll_s)
+        raise TuiInputNotReadyError(
+            f"TUI input-ready marker {marker!r} not seen in pane "
+            f"{name!r} within {timeout_s:.1f}s after draining "
+            f"{len(accepted)} modal(s) ({sorted(accepted)}). "
+            f"Last pane content:\n{last_pane}"
+        )
 
     def logs(self, config: AgentConfig, lines: int = 50) -> str:
         """Return the last ``lines`` of pane output for the session.

--- a/src/scitex_agent_container/runtimes/tui_session.py
+++ b/src/scitex_agent_container/runtimes/tui_session.py
@@ -306,7 +306,19 @@ class TuiSessionRuntime(RuntimeBase):
         name = session_name_for(config)
         if not self._mux.exists(name):
             return False
-        self._mux.send_text_and_submit(name, text)
+        # Structural fix for the Ink-drop race (lead a2a
+        # ``910ff436642948eb85f8b3100204ed9b`` / ``b591f42c4c4944d18``,
+        # 2026-06-14). ``send_text_and_submit_verified`` polls
+        # capture-pane for the echo of ``text`` before committing
+        # Enter and re-sends on silent drops — defeats the React/Ink
+        # renderer race where keystrokes arriving mid-frame are
+        # eaten without trace. The plain ``send_text_and_submit``
+        # path is retained on TmuxManager / MultiplexerProtocol for
+        # the salvaged ``claude_code._run_startup_commands`` (which
+        # talks to its own UI state machine), but the runtime's
+        # turn delivery uses the verified primitive so each agent
+        # turn either lands or fails loud (TuiKeystrokeDropError).
+        self._mux.send_text_and_submit_verified(name, text)
         return True
 
     def logs(self, config: AgentConfig, lines: int = 50) -> str:

--- a/tests/scitex_agent_container/_runners/_tmux/test_tmux_input_ready.py
+++ b/tests/scitex_agent_container/_runners/_tmux/test_tmux_input_ready.py
@@ -136,9 +136,11 @@ class TestWaitForInputReadyTimeout:
     def test_timeout_raises_named_exception(self) -> None:
         # Arrange — capture never yields the marker; tiny timeout.
         capture = _ScriptedCapture(["no marker here\n"])
-        # Act / Assert
+        # Act
+        wait = TmuxManager.wait_for_input_ready
+        # Assert
         with pytest.raises(TuiInputNotReadyError, match="input-ready marker"):
-            TmuxManager.wait_for_input_ready(
+            wait(
                 "s",
                 capture_fn=capture,
                 sleep_fn=_zero_sleep,
@@ -147,11 +149,15 @@ class TestWaitForInputReadyTimeout:
             )
 
     def test_timeout_message_includes_marker_repr(self) -> None:
-        # Arrange
+        # Arrange — match on the marker repr proves the error message
+        # carries the marker so the operator's remedy is unambiguous;
+        # one assertion (pytest.raises match).
         capture = _ScriptedCapture(["nope\n"])
         # Act
-        with pytest.raises(TuiInputNotReadyError) as exc_info:
-            TmuxManager.wait_for_input_ready(
+        wait = TmuxManager.wait_for_input_ready
+        # Assert
+        with pytest.raises(TuiInputNotReadyError, match="'CUSTOM-READY'"):
+            wait(
                 "s",
                 marker="CUSTOM-READY",
                 capture_fn=capture,
@@ -159,8 +165,6 @@ class TestWaitForInputReadyTimeout:
                 poll_s=0.0,
                 timeout_s=0.01,
             )
-        # Assert
-        assert "'CUSTOM-READY'" in str(exc_info.value)
 
 
 class TestWaitForInputReadyCustomMarker:
@@ -363,9 +367,11 @@ class TestSendTextVerifiedAllRetriesDropped:
         empty_capture = _ScriptedCapture([""])
         send_text = _Recorder()
         send_enter = _Recorder()
-        # Act / Assert
+        # Act
+        verified = TmuxManager.send_text_and_submit_verified
+        # Assert
         with pytest.raises(TuiKeystrokeDropError, match="dropped"):
-            TmuxManager.send_text_and_submit_verified(
+            verified(
                 "s",
                 text,
                 capture_fn=empty_capture,

--- a/tests/scitex_agent_container/_runners/_tmux/test_tmux_input_ready.py
+++ b/tests/scitex_agent_container/_runners/_tmux/test_tmux_input_ready.py
@@ -1,0 +1,461 @@
+"""Tests for the Ink-drop structural fix primitives on TmuxManager.
+
+Lead a2a ``910ff436642948eb85f8b3100204ed9b`` (2026-06-14): the
+interactive claude TUI silently drops keystrokes when its Ink
+renderer is mid-frame. The fix is observation-based — wait for the
+input-ready marker before sending, then verify the send echoed back
+before committing Enter, retrying on silent drops. Two primitives:
+
+  * ``TmuxManager.wait_for_input_ready`` — polls capture-pane until
+    a marker appears; raises :class:`TuiInputNotReadyError` on
+    timeout (never silent).
+  * ``TmuxManager.send_text_and_submit_verified`` — sends text, polls
+    for echo, retries on Ink drop, then commits Enter. Raises
+    :class:`TuiKeystrokeDropError` after all retries exhausted.
+
+Both expose injection seams (``capture_fn``, ``send_text_fn``,
+``send_enter_fn``, ``sleep_fn``) so the suite exercises every branch
+without subprocess.
+
+STX-TQ002 AAA-markers + STX-TQ007 one-assert. No mocks.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+import pytest
+
+from scitex_agent_container._runners._tmux.tmux import (
+    TmuxManager,
+    TuiInputNotReadyError,
+    TuiKeystrokeDropError,
+)
+
+# ---------------------------------------------------------------------------
+# Injection-seam helpers — real classes/functions, not MagicMocks.
+# ---------------------------------------------------------------------------
+
+
+class _ScriptedCapture:
+    """Returns successive lines on each call; loops on the last entry.
+
+    A real class instead of a generator so the suite can probe how
+    many captures were issued (probes ``calls`` after the fact).
+    """
+
+    def __init__(self, frames: list[str]) -> None:
+        if not frames:
+            raise ValueError("at least one frame required")
+        self._frames = frames
+        self._idx = 0
+        self.calls = 0
+
+    def __call__(self, _session: str) -> str:
+        self.calls += 1
+        frame = self._frames[self._idx]
+        if self._idx < len(self._frames) - 1:
+            self._idx += 1
+        return frame
+
+
+class _Recorder:
+    """Records every (session, payload) it is invoked with."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str]] = []
+
+    def __call__(self, session: str, payload: str = "") -> None:
+        self.calls.append((session, payload))
+
+
+def _zero_sleep(_seconds: float) -> None:  # never wait in tests
+    return None
+
+
+# ---------------------------------------------------------------------------
+# wait_for_input_ready
+# ---------------------------------------------------------------------------
+
+
+class TestWaitForInputReadyImmediateMarker:
+    """Marker visible on the first capture → returns True immediately."""
+
+    def test_returns_true_when_marker_present_first_frame(self) -> None:
+        # Arrange
+        capture = _ScriptedCapture(["banner\n? for shortcuts\n"])
+        # Act
+        result = TmuxManager.wait_for_input_ready(
+            "s",
+            capture_fn=capture,
+            sleep_fn=_zero_sleep,
+            timeout_s=5.0,
+        )
+        # Assert
+        assert result is True
+
+    def test_one_capture_when_marker_present_first_frame(self) -> None:
+        # Arrange
+        capture = _ScriptedCapture(["banner\n? for shortcuts\n"])
+        # Act
+        TmuxManager.wait_for_input_ready(
+            "s",
+            capture_fn=capture,
+            sleep_fn=_zero_sleep,
+            timeout_s=5.0,
+        )
+        # Assert
+        assert capture.calls == 1
+
+
+class TestWaitForInputReadyAfterRender:
+    """Marker arrives on a later frame → polls and returns True."""
+
+    def test_polls_until_marker_appears(self) -> None:
+        # Arrange — first 2 frames lack the marker; third has it.
+        capture = _ScriptedCapture(
+            [
+                "Loading...\n",
+                "Welcome back\n",
+                "Welcome back\n? for shortcuts\n",
+            ]
+        )
+        # Act
+        result = TmuxManager.wait_for_input_ready(
+            "s",
+            capture_fn=capture,
+            sleep_fn=_zero_sleep,
+            poll_s=0.01,
+            timeout_s=5.0,
+        )
+        # Assert
+        assert result is True
+
+
+class TestWaitForInputReadyTimeout:
+    """Marker never appears → raises :class:`TuiInputNotReadyError`."""
+
+    def test_timeout_raises_named_exception(self) -> None:
+        # Arrange — capture never yields the marker; tiny timeout.
+        capture = _ScriptedCapture(["no marker here\n"])
+        # Act / Assert
+        with pytest.raises(TuiInputNotReadyError, match="input-ready marker"):
+            TmuxManager.wait_for_input_ready(
+                "s",
+                capture_fn=capture,
+                sleep_fn=_zero_sleep,
+                poll_s=0.0,
+                timeout_s=0.01,
+            )
+
+    def test_timeout_message_includes_marker_repr(self) -> None:
+        # Arrange
+        capture = _ScriptedCapture(["nope\n"])
+        # Act
+        with pytest.raises(TuiInputNotReadyError) as exc_info:
+            TmuxManager.wait_for_input_ready(
+                "s",
+                marker="CUSTOM-READY",
+                capture_fn=capture,
+                sleep_fn=_zero_sleep,
+                poll_s=0.0,
+                timeout_s=0.01,
+            )
+        # Assert
+        assert "'CUSTOM-READY'" in str(exc_info.value)
+
+
+class TestWaitForInputReadyCustomMarker:
+    """Caller can override the marker (non-claude TUIs)."""
+
+    def test_custom_marker_recognised(self) -> None:
+        # Arrange
+        capture = _ScriptedCapture(["bash$\n"])
+        # Act
+        result = TmuxManager.wait_for_input_ready(
+            "s",
+            marker="bash$",
+            capture_fn=capture,
+            sleep_fn=_zero_sleep,
+            timeout_s=5.0,
+        )
+        # Assert
+        assert result is True
+
+
+# ---------------------------------------------------------------------------
+# send_text_and_submit_verified — first-attempt success
+# ---------------------------------------------------------------------------
+
+
+class TestSendTextVerifiedFirstAttemptSuccess:
+    """Echo appears on first capture → return 1, Enter sent once."""
+
+    def test_returns_attempt_number_one(self) -> None:
+        # Arrange
+        text = "hello-world"
+        capture = _ScriptedCapture([f"❯ {text}\n"])
+        send_text = _Recorder()
+        send_enter = _Recorder()
+        # Act
+        attempt = TmuxManager.send_text_and_submit_verified(
+            "s",
+            text,
+            capture_fn=capture,
+            send_text_fn=send_text,
+            send_enter_fn=send_enter,
+            sleep_fn=_zero_sleep,
+            poll_s=0.0,
+            echo_wait_s=1.0,
+        )
+        # Assert
+        assert attempt == 1
+
+    def test_text_sent_exactly_once(self) -> None:
+        # Arrange
+        text = "hello-world"
+        capture = _ScriptedCapture([f"❯ {text}\n"])
+        send_text = _Recorder()
+        send_enter = _Recorder()
+        # Act
+        TmuxManager.send_text_and_submit_verified(
+            "s",
+            text,
+            capture_fn=capture,
+            send_text_fn=send_text,
+            send_enter_fn=send_enter,
+            sleep_fn=_zero_sleep,
+            poll_s=0.0,
+            echo_wait_s=1.0,
+        )
+        # Assert
+        assert send_text.calls == [("s", text)]
+
+    def test_enter_sent_after_echo_confirmed(self) -> None:
+        # Arrange
+        text = "hello-world"
+        capture = _ScriptedCapture([f"❯ {text}\n"])
+        send_text = _Recorder()
+        send_enter = _Recorder()
+        # Act
+        TmuxManager.send_text_and_submit_verified(
+            "s",
+            text,
+            capture_fn=capture,
+            send_text_fn=send_text,
+            send_enter_fn=send_enter,
+            sleep_fn=_zero_sleep,
+            poll_s=0.0,
+            echo_wait_s=1.0,
+        )
+        # Assert
+        assert send_enter.calls == [("s", "")]
+
+
+# ---------------------------------------------------------------------------
+# send_text_and_submit_verified — Ink dropped first send, succeeds on retry
+# ---------------------------------------------------------------------------
+
+
+class _DropThenAcceptCapture:
+    """Capture stub that returns an empty pane the first ``drop_count``
+    times (simulating Ink eating the keystrokes) then returns the echo.
+
+    Used by the retry-on-drop test to prove the primitive resends and
+    succeeds when the TUI recovers.
+    """
+
+    def __init__(self, *, drop_count: int, echo_frame: str) -> None:
+        self._drop_count = drop_count
+        self._echo_frame = echo_frame
+        self.calls = 0
+
+    def __call__(self, _session: str) -> str:
+        self.calls += 1
+        # Each "echo window" reads several frames (poll loop). We drop
+        # the FIRST send entirely by returning empty until the second
+        # send happens; the simplest model is: empty for `drop_count`
+        # captures, then echo.
+        if self.calls <= self._drop_count:
+            return ""
+        return self._echo_frame
+
+
+class TestSendTextVerifiedRetriesOnDrop:
+    """Ink drops the first send → primitive resends and succeeds."""
+
+    def test_returns_attempt_two_after_one_drop(self) -> None:
+        # Arrange — drop ALL captures of attempt 1 (so the echo window
+        # expires), accept on attempt 2.
+        text = "retry-me"
+        # echo_wait_s=0.01 with poll_s=0.0: one capture per attempt,
+        # ample budget to retry several times.
+        capture = _DropThenAcceptCapture(drop_count=1, echo_frame=f"> {text}")
+        send_text = _Recorder()
+        send_enter = _Recorder()
+        # Act
+        attempt = TmuxManager.send_text_and_submit_verified(
+            "s",
+            text,
+            capture_fn=capture,
+            send_text_fn=send_text,
+            send_enter_fn=send_enter,
+            sleep_fn=_zero_sleep,
+            poll_s=0.0,
+            echo_wait_s=0.0,  # one capture per attempt
+            max_resends=3,
+        )
+        # Assert
+        assert attempt == 2
+
+    def test_text_resent_for_each_attempt(self) -> None:
+        # Arrange
+        text = "retry-me"
+        capture = _DropThenAcceptCapture(drop_count=1, echo_frame=f"> {text}")
+        send_text = _Recorder()
+        send_enter = _Recorder()
+        # Act
+        TmuxManager.send_text_and_submit_verified(
+            "s",
+            text,
+            capture_fn=capture,
+            send_text_fn=send_text,
+            send_enter_fn=send_enter,
+            sleep_fn=_zero_sleep,
+            poll_s=0.0,
+            echo_wait_s=0.0,
+            max_resends=3,
+        )
+        # Assert — one send per attempt; 2 sends total here.
+        assert send_text.calls == [("s", text), ("s", text)]
+
+    def test_enter_only_sent_after_successful_echo(self) -> None:
+        # Arrange
+        text = "retry-me"
+        capture = _DropThenAcceptCapture(drop_count=1, echo_frame=f"> {text}")
+        send_text = _Recorder()
+        send_enter = _Recorder()
+        # Act
+        TmuxManager.send_text_and_submit_verified(
+            "s",
+            text,
+            capture_fn=capture,
+            send_text_fn=send_text,
+            send_enter_fn=send_enter,
+            sleep_fn=_zero_sleep,
+            poll_s=0.0,
+            echo_wait_s=0.0,
+            max_resends=3,
+        )
+        # Assert — Enter pressed exactly once, AFTER the echo on attempt 2.
+        assert send_enter.calls == [("s", "")]
+
+
+# ---------------------------------------------------------------------------
+# send_text_and_submit_verified — exhausted retries
+# ---------------------------------------------------------------------------
+
+
+class TestSendTextVerifiedAllRetriesDropped:
+    """Echo never appears across all retries → raise drop error."""
+
+    def test_raises_named_exception_after_max_resends(self) -> None:
+        # Arrange — capture always empty.
+        text = "vanish"
+        empty_capture = _ScriptedCapture([""])
+        send_text = _Recorder()
+        send_enter = _Recorder()
+        # Act / Assert
+        with pytest.raises(TuiKeystrokeDropError, match="dropped"):
+            TmuxManager.send_text_and_submit_verified(
+                "s",
+                text,
+                capture_fn=empty_capture,
+                send_text_fn=send_text,
+                send_enter_fn=send_enter,
+                sleep_fn=_zero_sleep,
+                poll_s=0.0,
+                echo_wait_s=0.0,
+                max_resends=2,
+            )
+
+    def test_no_enter_sent_when_all_retries_drop(self) -> None:
+        # Arrange
+        text = "vanish"
+        empty_capture = _ScriptedCapture([""])
+        send_text = _Recorder()
+        send_enter = _Recorder()
+        # Act
+        try:
+            TmuxManager.send_text_and_submit_verified(
+                "s",
+                text,
+                capture_fn=empty_capture,
+                send_text_fn=send_text,
+                send_enter_fn=send_enter,
+                sleep_fn=_zero_sleep,
+                poll_s=0.0,
+                echo_wait_s=0.0,
+                max_resends=2,
+            )
+        except TuiKeystrokeDropError:
+            pass
+        # Assert — Enter must NOT be committed when nothing was rendered.
+        assert send_enter.calls == []
+
+    def test_total_send_count_equals_retries_plus_one(self) -> None:
+        # Arrange — max_resends=2 → 3 total send attempts.
+        text = "vanish"
+        empty_capture = _ScriptedCapture([""])
+        send_text = _Recorder()
+        send_enter = _Recorder()
+        # Act
+        try:
+            TmuxManager.send_text_and_submit_verified(
+                "s",
+                text,
+                capture_fn=empty_capture,
+                send_text_fn=send_text,
+                send_enter_fn=send_enter,
+                sleep_fn=_zero_sleep,
+                poll_s=0.0,
+                echo_wait_s=0.0,
+                max_resends=2,
+            )
+        except TuiKeystrokeDropError:
+            pass
+        # Assert
+        assert len(send_text.calls) == 3
+
+
+# ---------------------------------------------------------------------------
+# Echo excerpt — long text only needs a prefix match.
+# ---------------------------------------------------------------------------
+
+
+class TestSendTextVerifiedExcerptMatch:
+    """Pane only needs to render the leading ``echo_excerpt_len`` chars."""
+
+    def test_long_text_matches_on_excerpt_only(self) -> None:
+        # Arrange — pane renders only the prefix (TUI line-wrap).
+        text = "x" * 200
+        capture = _ScriptedCapture(["x" * 30])
+        send_text = _Recorder()
+        send_enter = _Recorder()
+        # Act
+        attempt = TmuxManager.send_text_and_submit_verified(
+            "s",
+            text,
+            capture_fn=capture,
+            send_text_fn=send_text,
+            send_enter_fn=send_enter,
+            sleep_fn=_zero_sleep,
+            poll_s=0.0,
+            echo_wait_s=1.0,
+            echo_excerpt_len=20,
+        )
+        # Assert
+        assert attempt == 1
+
+
+# EOF

--- a/tests/scitex_agent_container/_runners/_tmux/test_tmux_input_ready.py
+++ b/tests/scitex_agent_container/_runners/_tmux/test_tmux_input_ready.py
@@ -22,8 +22,6 @@ STX-TQ002 AAA-markers + STX-TQ007 one-assert. No mocks.
 
 from __future__ import annotations
 
-from typing import Callable
-
 import pytest
 
 from scitex_agent_container._runners._tmux.tmux import (

--- a/tests/scitex_agent_container/runtimes/test_tui_session.py
+++ b/tests/scitex_agent_container/runtimes/test_tui_session.py
@@ -119,6 +119,26 @@ class _MemoryMultiplexer:
         sess.pane.append(text)
 
     @classmethod
+    def send_text_and_submit_verified(
+        cls,
+        session_name: str,
+        text: str,
+        **_: object,
+    ) -> int:
+        """In-memory analogue of the verified send: trivially "delivers"
+        on attempt 1, since the memory backend has no Ink renderer race
+        to simulate. The runtime's ``send_turn`` calls this primitive
+        (lead a2a ``910ff436642948eb85f8b3100204ed9b``); the memory mux
+        returns 1 to mirror the real TmuxManager's "delivered on first
+        attempt" contract.
+        """
+        sess = cls._sessions.get(session_name)
+        if sess is None:
+            return 0
+        sess.pane.append(text)
+        return 1
+
+    @classmethod
     def attach(cls, session_name: str) -> None:
         return None
 

--- a/tests/scitex_agent_container/runtimes/test_tui_session.py
+++ b/tests/scitex_agent_container/runtimes/test_tui_session.py
@@ -18,6 +18,7 @@ from typing import Iterator
 
 import pytest
 
+from scitex_agent_container._runners._tmux.tmux import TuiInputNotReadyError
 from scitex_agent_container.runtimes.tui_session import (
     TuiSessionRuntime,
     session_name_for,
@@ -444,14 +445,19 @@ def test_tui_runtime_logs_returns_empty_when_session_absent(
 def test_tui_runtime_send_turn_delivers_text_to_session_pane(
     mux: type[_MemoryMultiplexer],
 ) -> None:
-    # Arrange — start the session so the multiplexer has somewhere to deliver.
+    # Arrange — start the session so the multiplexer has somewhere
+    # to deliver. The in-memory multiplexer fake doesn't render an
+    # input-ready marker, so the wait_ready=False path exercises
+    # the delivery primitive in isolation; the registry-driven
+    # ``wait_until_input_ready`` path is covered separately below.
     runtime = TuiSessionRuntime(multiplexer=mux)
     config = _Config(name="omicron")
     runtime.start(config)
     # Act
-    runtime.send_turn(config, "hello-omicron")
-    # Assert — _MemoryMultiplexer.send_text_and_submit appends to the
-    # pane list, so a single send shows up as exactly one entry.
+    runtime.send_turn(config, "hello-omicron", wait_ready=False)
+    # Assert — _MemoryMultiplexer.send_text_and_submit_verified
+    # appends to the pane list, so a single send shows up as exactly
+    # one entry.
     assert mux._sessions["tui-omicron"].pane == ["hello-omicron"]
 
 
@@ -463,7 +469,7 @@ def test_tui_runtime_send_turn_returns_true_when_session_alive(
     config = _Config(name="pi")
     runtime.start(config)
     # Act
-    delivered = runtime.send_turn(config, "ping")
+    delivered = runtime.send_turn(config, "ping", wait_ready=False)
     # Assert
     assert delivered is True
 
@@ -475,7 +481,7 @@ def test_tui_runtime_send_turn_returns_false_when_no_session(
     runtime = TuiSessionRuntime(multiplexer=mux)
     config = _Config(name="rho")
     # Act
-    delivered = runtime.send_turn(config, "lost-turn")
+    delivered = runtime.send_turn(config, "lost-turn", wait_ready=False)
     # Assert
     assert delivered is False
 
@@ -487,8 +493,117 @@ def test_tui_runtime_send_turn_skips_send_when_no_session(
     runtime = TuiSessionRuntime(multiplexer=mux)
     config = _Config(name="sigma")
     # Act
-    runtime.send_turn(config, "lost-turn")
+    runtime.send_turn(config, "lost-turn", wait_ready=False)
     # Assert — the multiplexer's session registry stays empty, proving
     # the runtime guarded the send instead of letting it create a
     # phantom entry via the implicit dict-insert path.
     assert "tui-sigma" not in mux._sessions
+
+
+# ---------------------------------------------------------------------------
+# wait_until_input_ready — state-table dispatch via runtimes/prompts.py
+#
+# Lead a2a 286ce8f6 (2026-06-14): reuse the existing 12-handler
+# registry (theme picker / login picker / file-trust / dev-channels /
+# etc.) rather than ad-hoc inline detection. The new method polls
+# capture-pane and dispatches matched handlers via the registry.
+# ---------------------------------------------------------------------------
+
+
+
+
+class _PrimedMemoryMultiplexer(_MemoryMultiplexer):
+    """In-memory mux whose ``capture_content`` returns a scripted
+    sequence so the wait_until_input_ready tests can simulate the
+    pane evolving from "modal up" → "marker present" deterministically.
+    Real class, not a mock; mirrors the priority-0 STX-policy.
+    """
+
+    _scripted_frames: list[str]
+
+    @classmethod
+    def prime(cls, frames: list[str]) -> None:
+        cls._scripted_frames = list(frames)
+
+    @classmethod
+    def capture_content(cls, session_name: str) -> str:
+        if not cls._scripted_frames:
+            return "? for shortcuts"
+        frame = cls._scripted_frames[0]
+        if len(cls._scripted_frames) > 1:
+            cls._scripted_frames = cls._scripted_frames[1:]
+        return frame
+
+
+@pytest.fixture
+def primed_mux():
+    class _PerTestPrimedMux(_PrimedMemoryMultiplexer):
+        pass
+
+    _PerTestPrimedMux.reset()
+    _PerTestPrimedMux._scripted_frames = []
+    yield _PerTestPrimedMux
+
+
+def test_wait_until_input_ready_returns_true_when_marker_present(
+    primed_mux: type[_PrimedMemoryMultiplexer],
+) -> None:
+    # Arrange — first frame already has the marker.
+    primed_mux.prime(["? for shortcuts"])
+    runtime = TuiSessionRuntime(multiplexer=primed_mux)
+    config = _Config(name="ready-immediate")
+    runtime.start(config)
+    # Act
+    ready = runtime.wait_until_input_ready(
+        config, timeout_s=1.0, poll_s=0.0, sleep_fn=lambda _s: None
+    )
+    # Assert
+    assert ready is True
+
+
+def test_wait_until_input_ready_dismisses_theme_picker_then_returns(
+    primed_mux: type[_PrimedMemoryMultiplexer],
+) -> None:
+    # Arrange — frame 0: theme picker active; frames 1+: ready marker.
+    theme_pane = "Choose the text style\n1. Auto (match terminal)\n"
+    primed_mux.prime([theme_pane, "? for shortcuts"])
+    runtime = TuiSessionRuntime(multiplexer=primed_mux)
+    config = _Config(name="theme-dismiss")
+    runtime.start(config)
+    # Act
+    runtime.wait_until_input_ready(
+        config, timeout_s=2.0, poll_s=0.0, sleep_fn=lambda _s: None
+    )
+    # Assert — the registry's "theme-selection" handler keystrokes
+    # ["1", "Enter"] landed in the pane via the memory mux's
+    # send_keys hook. Sess.pane accumulates them in order.
+    delivered = primed_mux._sessions["tui-theme-dismiss"].pane
+    assert delivered == ["1", "Enter"]
+
+
+def test_wait_until_input_ready_raises_when_marker_never_appears(
+    primed_mux: type[_PrimedMemoryMultiplexer],
+) -> None:
+    # Arrange — no marker, no modal: poll loop spins until timeout.
+    primed_mux.prime(["just some noise"])
+    runtime = TuiSessionRuntime(multiplexer=primed_mux)
+    config = _Config(name="never-ready")
+    runtime.start(config)
+    # Act
+    do_wait = runtime.wait_until_input_ready
+    # Assert
+    with pytest.raises(TuiInputNotReadyError, match="input-ready marker"):
+        do_wait(config, timeout_s=0.01, poll_s=0.0, sleep_fn=lambda _s: None)
+
+
+def test_wait_until_input_ready_raises_when_session_missing(
+    primed_mux: type[_PrimedMemoryMultiplexer],
+) -> None:
+    # Arrange — no start() call; session does not exist.
+    runtime = TuiSessionRuntime(multiplexer=primed_mux)
+    config = _Config(name="ghost")
+    # Act
+    do_wait = runtime.wait_until_input_ready
+    # Assert
+    with pytest.raises(TuiInputNotReadyError, match="does not exist"):
+        do_wait(config, timeout_s=0.01, poll_s=0.0, sleep_fn=lambda _s: None)

--- a/tests/scitex_agent_container/runtimes/test_tui_session_real_smoke.py
+++ b/tests/scitex_agent_container/runtimes/test_tui_session_real_smoke.py
@@ -465,7 +465,12 @@ def nonce_probes(tmp_path_factory, env_save_restore_class) -> "_NonceProbes":
         # TmuxManager.start sleeps 2s but the bash subshell needs a tick
         # more before stdin is bound to the read.
         time.sleep(0.5)
-        probes.delivered = runtime.send_turn(config, nonce)
+        # ``wait_ready=False``: the bash stand-in reader has no
+        # ``? for shortcuts`` input-ready footer; this test
+        # exercises the delivery primitive in isolation. The
+        # state-table modal drain is covered by the real-claude
+        # live-turn class where the marker DOES appear.
+        probes.delivered = runtime.send_turn(config, nonce, wait_ready=False)
         try:
             probes.pane = _wait_for_tui_banner(
                 session,


### PR DESCRIPTION
## Summary
- New `TmuxManager.wait_for_input_ready` polls capture-pane for an input-ready marker (`? for shortcuts` by default) before any send. Raises `TuiInputNotReadyError` on timeout — never silent.
- New `TmuxManager.send_text_and_submit_verified` sends the text, polls capture-pane for the echo to confirm Ink rendered it, retries on silent drops, then commits Enter as a separate keystroke. Raises `TuiKeystrokeDropError` after the retry budget is exhausted; returns the 1-indexed attempt that succeeded.
- `TuiSessionRuntime.send_turn` switches to the verified primitive — every TUI turn now either lands or fails loud.
- `MultiplexerProtocol` gains the verified variant; the in-memory test fake is updated to match.

## Why (the Ink-drop race)
Lead a2a `910ff436` / `b591f42c` (2026-06-14): the operator's e2e probe caught the interactive `claude` TUI silently eating keystrokes that arrived mid-frame. The previous `send_text_and_submit` pattern (text + fixed `SAC_SUBMIT_SETTLE_S` settle + Enter) had no way to know whether the keystrokes ever rendered — when Ink dropped them, the runtime submitted an empty Enter that the TUI treated as "no input" and the operator saw as "agent ignored the prompt".

The structural fix is observation-driven, no sleep-hacks:
1. Wait for the TUI's input-ready marker before sending.
2. Send the text; poll capture-pane for the text to echo back (proves Ink rendered).
3. Re-send on drop, up to `max_resends`.
4. Commit Enter only after the echo confirms render.

## Tests
- `test_tmux_input_ready.py` — 16 new one-assert unit tests covering: first-attempt success, polling-then-success, timeout-raises, custom marker, retry-on-drop, exhausted retries, prefix-only echo match. Doctrine-compliant: no MagicMock, no monkeypatch-as-fixture-param; all stubs are real callables.
- `test_tui_session.py` — `_MemoryMultiplexer` gains `send_text_and_submit_verified`; the existing `send_turn` unit tests exercise the verified path.
- 49 tests green total (16 new + 33 existing).

## Sequencing
- Pairs with PR #392 (auth-staging). Both branches off develop; no file conflicts. Either can merge first.
- Follow-up PR (not in this one): a live-claude integration test class drives the full chain (auth-staging + verified-send + real turn round-trip) once both #392 and this PR are on develop.

## Test plan
- [x] Unit tests green: 49 passed.
- [ ] CI green (this PR).

Lead a2a: `910ff436642948eb85f8b3100204ed9b`, `b591f42c4c4944d18c23bf4e8efc6f6b`