### PR TITLE
feat(comms): structural reaction-ack so sender detects comm-miss

### DIFF
--- a/src/scitex_agent_container/_listen/_node_channel.py
+++ b/src/scitex_agent_container/_listen/_node_channel.py
@@ -267,6 +267,17 @@ async def node_message_send(request: Request) -> Response:
             status_code=400,
         )
 
+    # ``extra`` rides under metadata so structured side-channels (e.g.
+    # the structural reaction-ack's ``reacted_dispatch_id``) survive the
+    # publish path intact. A non-dict ``extra`` is dropped silently —
+    # this is a permissive forwarder, not a schema validator, and the
+    # consumers (reaction-ack updater, custom handlers) defensively
+    # check shape before reading. Empty dicts are also dropped to keep
+    # the persisted event row compact.
+    extra_meta = sac_meta.get("extra")
+    if not isinstance(extra_meta, dict) or not extra_meta:
+        extra_meta = None
+
     event = mint_event(
         name,
         content=text,
@@ -278,6 +289,7 @@ async def node_message_send(request: Request) -> Response:
         ack=bool(sac_meta.get("ack", False)),
         dispatch_id=sac_meta.get("dispatch_id"),
         kind=kind_meta,
+        extra=extra_meta,
     )
 
     # Implicit registration — handoff §4 "A2A compliance without a

--- a/src/scitex_agent_container/_mcp/_channel_post_deliver.py
+++ b/src/scitex_agent_container/_mcp/_channel_post_deliver.py
@@ -1,0 +1,125 @@
+"""sac channel adapter — post-delivery receipts dispatcher.
+
+Extracted from :mod:`scitex_agent_container._mcp.channel` to keep the
+receive-side adapter under the module line-size budget after the
+structural reaction-ack joined the contentless auto-ack as a second
+post-delivery side-effect.
+
+Both receipts share the same shape on the caller's side:
+
+* They run AFTER successful delivery (notification push or wake-on-turn).
+* They are best-effort — a failed receipt MUST NOT block delivery or
+  kill the long-lived SSE consumer. Every failure logs loudly (warning)
+  but never re-raises.
+* They share the per-sender sliding-window rate cap so any loop or
+  storm self-terminates with the same budget.
+
+This module owns the single entry point
+:func:`run_post_deliver_receipts` so :mod:`channel` has one call site
+instead of two large gated blocks (and re-passes the line ceiling).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from ._channel_auto_ack import (
+    _auto_ack_enabled,
+    _auto_ack_rate_allow,
+    _post_auto_ack,
+    _should_auto_ack,
+)
+from ._channel_reaction_ack import (
+    post_reaction_ack,
+    reaction_ack_enabled,
+    should_emit_reaction_ack,
+)
+
+log = logging.getLogger(__name__)
+
+__all__ = ["run_post_deliver_receipts"]
+
+
+async def run_post_deliver_receipts(
+    event: dict[str, Any],
+    *,
+    agent_name: str | None,
+    listen_url: str | None,
+    bearer: str | None,
+) -> None:
+    """Run every post-delivery receipt side-effect for ``event``.
+
+    Order:
+
+    1. **Stage-2 auto-ack** (contentless ``ack=True`` envelope) — the
+       legacy receipt. The sender-side noise filter typically drops it
+       before the wire so this is a no-op on the wire today, but the
+       loop-guard / rate-cap / env gate are still honoured for
+       symmetry and forward-compat.
+    2. **Structural reaction-ack** (``kind="reaction"`` envelope with
+       a non-empty 👀 marker) — the operator's "comm-miss detectable"
+       signal (lead a2a 1781e82a, 2026-06-14). Unlike the auto-ack,
+       this carries a visible marker so the empty-ack filter does NOT
+       suppress it, and threads the original ``dispatch_id`` so the
+       sender's adapter marks the matching dispatch row REACTED.
+
+    Both gated calls share the per-sender sliding-window rate cap
+    (``_auto_ack_rate_allow``) — a runaway sender that overruns the
+    budget is denied BOTH receipts at once, so a structural-ack storm
+    cannot mask an auto-ack loop or vice versa.
+
+    Caller-side preconditions: ``agent_name`` and ``listen_url`` must
+    be set for either receipt to fire (the channel adapter only runs
+    receipts when it knows where to post them). Both are passed
+    through verbatim — no validation here; the env-gate / loop-guard
+    short-circuit on the missing-config case.
+    """
+    if agent_name is None or listen_url is None:
+        return
+    if not _auto_ack_enabled() and not reaction_ack_enabled():
+        return
+
+    sender = event.get("from_agent")
+
+    # Stage-2 contentless auto-ack (legacy).
+    if (
+        _auto_ack_enabled()
+        and _should_auto_ack(event)
+        and isinstance(sender, str)
+        and _auto_ack_rate_allow(sender)
+    ):
+        try:
+            await _post_auto_ack(
+                event,
+                agent_name=agent_name,
+                listen_url=listen_url,
+                bearer=bearer,
+            )
+        except Exception as exc:  # stx-allow: fallback (reason: best-effort auto-ack; a failed receipt must not block injection or kill the SSE consumer — logged loudly, never silent)
+            log.warning(
+                "sac channel: auto-ack to %r failed: %s",
+                sender,
+                exc,
+            )
+
+    # Structural reaction-ack — the comm-miss-detectable signal.
+    if (
+        reaction_ack_enabled()
+        and should_emit_reaction_ack(event)
+        and isinstance(sender, str)
+        and _auto_ack_rate_allow(sender)
+    ):
+        try:
+            await post_reaction_ack(
+                event,
+                agent_name=agent_name,
+                listen_url=listen_url,
+                bearer=bearer,
+            )
+        except Exception as exc:  # stx-allow: fallback (reason: best-effort reaction-ack; a failed receipt must not block injection or kill the SSE consumer — logged loudly, never silent)
+            log.warning(
+                "sac channel: reaction-ack to %r failed: %s",
+                sender,
+                exc,
+            )

--- a/src/scitex_agent_container/_mcp/_channel_reaction_ack.py
+++ b/src/scitex_agent_container/_mcp/_channel_reaction_ack.py
@@ -1,0 +1,272 @@
+"""sac channel adapter — structural reaction-ack subsystem.
+
+Operator mandate (lead a2a ``1781e82a``, 2026-06-14):
+
+    "when an agent receives an a2a/telegram directive, it auto-reacts
+    (👀/✓) so the sender KNOWS it landed — absence of the reaction =
+    comm miss, detectable."
+
+The existing :mod:`._channel_auto_ack` path emits a CONTENTLESS ack
+that the sender-side empty-ack noise filter
+(:mod:`._channel_ack_filter`) intentionally drops BEFORE it leaves the
+outbound queue. That filter is the operator's "no contentless acks on
+the wire" contract; it cannot be relaxed without re-introducing the
+ack ping-pong noise.
+
+This module adds a parallel, **structural** reaction-ack that DOES
+reach the wire:
+
+* Content is a non-empty marker (``👀`` by default — configurable via
+  ``SAC_REACTION_ACK_MARKER``) so the empty-ack filter does NOT match.
+* ``kind="reaction"`` so the sender's receive-side can recognise the
+  envelope and update the dispatch ledger (mark ``reacted``) instead
+  of just letting the marker land in the inbox as a regular message.
+* Carries ``extra.reacted_dispatch_id`` (the SENDER's dispatch-ledger
+  id, threaded through the original inbound event's ``dispatch_id``
+  field) so the sender can mark the exact outbound row REACTED
+  without a fuzzy text match.
+
+The receive-side hook lives in
+:mod:`._channel_reaction_ack`: :func:`should_emit_reaction_ack` is the
+loop-guard predicate (never react to a reaction; never react if there
+is no identifiable original sender), and :func:`post_reaction_ack`
+posts the marker back to the sender's inbox.
+
+Loop guards mirror the auto-ack path (event ``kind`` and ``ack`` flag
+exclusions), with one extra exclusion for ``kind="reaction"`` itself
+so a future regression cannot trigger a 👀-on-👀 cycle. There is also
+a per-sender sliding-window rate cap (reusing the auto-ack rate cap's
+env knobs — same rule applies: the structural ack is best-effort,
+NEVER blocks delivery, and any failure is logged loudly).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+from .._env import getenv as _sac_env
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "DEFAULT_REACTION_MARKER",
+    "absorb_reaction_ack",
+    "is_reaction_event",
+    "post_reaction_ack",
+    "reaction_ack_enabled",
+    "reaction_ack_marker",
+    "should_emit_reaction_ack",
+]
+
+
+def is_reaction_event(event: dict[str, Any]) -> bool:
+    """Return True iff ``event`` is a structural reaction-ack envelope.
+
+    Single source of truth for the predicate ``kind == "reaction"`` so
+    callers don't sprinkle the string literal across multiple modules.
+    """
+    return event.get("kind") == "reaction"
+
+
+def absorb_reaction_ack(event: dict[str, Any]) -> bool:
+    """Update the dispatch ledger if ``event`` carries a structural reaction.
+
+    The sender-side companion to :func:`post_reaction_ack`: when a
+    ``kind="reaction"`` event lands on THIS agent's inbox, it is the
+    receiver's 👀 receipt to one of OUR previous outbound dispatches.
+    Mark the matching dispatch row ``STATUS_REACTED`` so the operator
+    (and the ``sac a2a comm-miss`` surface) can see the receipt
+    landed.
+
+    Returns ``True`` iff a ledger row was updated. Best-effort: a
+    write failure is logged but never re-raised — losing
+    observability must not break the SSE consumer. A reaction
+    without a ``reacted_dispatch_id`` in ``extra`` (legacy senders /
+    senders that never minted a ledger row) is a no-op and returns
+    ``False``; this is deliberate, not silent: there is simply no
+    row to update.
+    """
+    if not is_reaction_event(event):
+        return False
+    extra = event.get("extra")
+    if not isinstance(extra, dict):
+        return False
+    did = extra.get("reacted_dispatch_id")
+    if not isinstance(did, str) or not did:
+        return False
+    try:
+        from .._state.dispatch_ledger import mark_dispatch_reacted
+    except Exception as exc:  # stx-allow: fallback (reason: optional state subsystem may fail to import in slim test environments)
+        log.warning("sac channel: dispatch_ledger import failed: %s", exc)
+        return False
+    try:
+        return mark_dispatch_reacted(did)
+    except Exception as exc:  # stx-allow: fallback (reason: ledger is observability; a write failure must not break the SSE consumer — logged loudly, never silent)
+        log.warning(
+            "sac channel: mark_dispatch_reacted(%r) failed: %s",
+            did,
+            exc,
+        )
+        return False
+
+
+# Default visible marker. Unicode "eyes" — the same emoji the lead's
+# Telegram doctrine uses to acknowledge a received directive. Operators
+# can pick a different marker (e.g. "✓") via env override. Multi-char
+# strings are passed through verbatim so a workflow that wants
+# "👀 seen" works without code changes.
+DEFAULT_REACTION_MARKER = "\N{EYES}"
+
+
+def reaction_ack_enabled() -> bool:
+    """Whether the receive-side adapter emits a structural reaction-ack
+    on every inbound bus event injection.
+
+    Default ON. Disable with ``SAC_REACTION_ACK=0`` (also accepts
+    ``false`` / ``no`` / ``off``, case-insensitive). The ``SAC_*`` prefix
+    matches the rest of the channel env knobs so a single sac listen
+    process toggles both halves of the receipt machinery from the same
+    env scope.
+    """
+    raw = os.environ.get("SAC_REACTION_ACK")
+    if raw is None:
+        return True
+    return raw.strip().lower() not in ("0", "false", "no", "off")
+
+
+def reaction_ack_marker() -> str:
+    """The content string the structural reaction-ack posts back.
+
+    Reads ``SAC_REACTION_ACK_MARKER`` (also via the sac-env prefix
+    fallback). Empty / whitespace-only overrides revert to
+    :data:`DEFAULT_REACTION_MARKER` — an empty marker would be the very
+    contentless ack the noise filter is designed to drop, so we
+    refuse it loudly (via the silent default) rather than emit a
+    suppressed-then-dropped pair.
+    """
+    raw = _sac_env("REACTION_ACK_MARKER", DEFAULT_REACTION_MARKER)
+    if raw is None or not raw.strip():
+        return DEFAULT_REACTION_MARKER
+    return raw
+
+
+def should_emit_reaction_ack(event: dict[str, Any]) -> bool:
+    """Loop-guard for the structural reaction-ack side-effect.
+
+    Skip when:
+
+    * the event has no identifiable original sender
+      (``from_agent`` missing/empty) — there is nowhere to send the
+      reaction;
+    * the event is itself a contentless ack (``ack`` flag truthy) —
+      no point reacting to a delivery receipt;
+    * the event is itself a structural reaction
+      (``kind == "reaction"``) — belt-and-suspenders so a future
+      regression in marker handling cannot start a 👀-on-👀 cycle;
+    * the event is a system / synthetic notification
+      (``from_agent == "system"`` or ``kind`` in the synthetic-only
+      allow-list) — reacting to a system notification would post a
+      reaction back to ``system`` which the sender never sees and
+      pollutes the dispatch ledger.
+
+    The dispatch-id threading is OPTIONAL — a sender that did not
+    mint a ledger row still benefits from the receipt landing in
+    their inbox (and the receive-side updater simply no-ops when
+    the dispatch row is absent). So we do NOT require
+    ``event['dispatch_id']`` to be present.
+    """
+    if not event.get("from_agent"):
+        return False
+    if event.get("ack"):
+        return False
+    kind = event.get("kind")
+    if kind == "reaction":
+        return False
+    if kind in {"denied_attempt", "acl_deny_notify"}:
+        return False
+    if event.get("from_agent") == "system":
+        return False
+    return True
+
+
+async def post_reaction_ack(
+    event: dict[str, Any],
+    *,
+    agent_name: str,
+    listen_url: str,
+    bearer: str | None,
+) -> None:
+    """POST a structural ``kind=reaction`` envelope back to the sender.
+
+    Reuses the exact ``/agents/<sender>/message:send`` HTTP path the
+    auto-ack and ``a2a_*`` tool surface use, with three distinguishing
+    metadata fields:
+
+    * ``kind="reaction"`` — receiver-side recognises this so the
+      sender's adapter can route to the ledger updater rather than
+      surface it as a normal inbox message.
+    * ``ack=True`` — preserves the auto-ack subsystem's loop-guard
+      (so the existing receive-side ``_should_auto_ack`` will not
+      auto-ack the reaction in turn).
+    * ``extra.reacted_dispatch_id`` — the SENDER's dispatch-ledger id
+      threaded through the original inbound event. Omitted when the
+      sender did not mint a ledger row (legacy clients).
+
+    Content is the configured marker (``👀`` by default), which is
+    non-empty so the sender-side empty-ack noise filter does NOT
+    suppress it — that's the whole point of this code path: a
+    STRUCTURAL receipt that survives the wire.
+
+    Best-effort: the caller logs any exception but never re-raises,
+    so a flaky receipt cannot block delivery or kill the SSE
+    consumer.
+    """
+    import uuid as _uuid
+
+    import httpx
+
+    target = event["from_agent"]
+    marker = reaction_ack_marker()
+    metadata: dict[str, Any] = {
+        "from_agent": agent_name,
+        "ack": True,
+        "kind": "reaction",
+    }
+    msg_id = event.get("msg_id")
+    if msg_id:
+        metadata["in_reply_to"] = msg_id
+    conversation_id = event.get("conversation_id")
+    if conversation_id:
+        metadata["conversation_id"] = conversation_id
+    extra: dict[str, Any] = {}
+    dispatch_id = event.get("dispatch_id")
+    if dispatch_id:
+        extra["reacted_dispatch_id"] = dispatch_id
+    if extra:
+        metadata["extra"] = extra
+    payload = {
+        "jsonrpc": "2.0",
+        "id": _uuid.uuid4().hex,
+        "method": "SendMessage",
+        "params": {
+            "message": {
+                "message_id": _uuid.uuid4().hex,
+                "role": "ROLE_USER",
+                "parts": [{"text": marker}],
+            },
+            "metadata": metadata,
+        },
+    }
+    base = listen_url.rstrip("/")
+    headers = {"Content-Type": "application/json"}
+    if bearer:
+        headers["Authorization"] = f"Bearer {bearer}"
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        resp = await client.post(
+            f"{base}/agents/{target}/message:send",
+            json=payload,
+            headers=headers,
+        )
+        resp.raise_for_status()

--- a/src/scitex_agent_container/_mcp/channel.py
+++ b/src/scitex_agent_container/_mcp/channel.py
@@ -70,6 +70,14 @@ from ._channel_auto_ack import (  # noqa: E402,F401
     _post_auto_ack,
     _should_auto_ack,
 )
+from ._channel_post_deliver import run_post_deliver_receipts  # noqa: E402
+from ._channel_reaction_ack import (  # noqa: E402,F401
+    absorb_reaction_ack,
+    is_reaction_event,
+    post_reaction_ack,
+    reaction_ack_enabled,
+    should_emit_reaction_ack,
+)
 from ._channel_self_register import (  # noqa: E402
     refresh_node as _refresh_comms_node,
 )
@@ -240,9 +248,24 @@ async def _push_channel_event(
     The auto-ack is a best-effort side-effect: it runs only *after* delivery
     and its failure is logged loudly but never re-raised, so a flaky receipt
     can neither block delivery nor kill the long-lived SSE consumer.
+
+    **Reaction-ack ABSORPTION (sender-side)** — a ``kind="reaction"``
+    event is the receiver's structural 👀 receipt to one of OUR previous
+    sends. It is absorbed (dispatch ledger updated to ``STATUS_REACTED``)
+    and NOT injected into the running session — receipts are a wire
+    signal, not a user-visible message. See ``_channel_reaction_ack``.
     """
     from mcp.shared.message import SessionMessage
     from mcp.types import JSONRPCMessage, JSONRPCNotification
+
+    # Sender-side absorption: a structural reaction-ack updates the
+    # dispatch ledger and is then suppressed from session injection.
+    # The event is still buffered into ``_recent`` so a2a_inbox callers
+    # can audit that the receipt landed.
+    if is_reaction_event(event):
+        _recent.append(event)
+        absorb_reaction_ack(event)
+        return
 
     # Buffer for a2a_reply / a2a_ack lookups by msg_id.
     _recent.append(event)
@@ -269,30 +292,16 @@ async def _push_channel_event(
         )
         await session.send_message(SessionMessage(msg))
 
-    # Stage-2 receipt: auto-ack AFTER successful delivery. Best-effort —
-    # never let an ack failure propagate past this point.
-    if (
-        agent_name is not None
-        and listen_url is not None
-        and _auto_ack_enabled()
-        and _should_auto_ack(event)
-        # _should_auto_ack guarantees a truthy ``from_agent`` above, so the
-        # short-circuit makes this index safe; the cap is the last gate.
-        and _auto_ack_rate_allow(event["from_agent"])
-    ):
-        try:
-            await _post_auto_ack(
-                event,
-                agent_name=agent_name,
-                listen_url=listen_url,
-                bearer=bearer,
-            )
-        except Exception as exc:  # stx-allow: fallback (reason: best-effort auto-ack; a failed receipt must not block injection or kill the SSE consumer — logged loudly, never silent)
-            log.warning(
-                "sac channel: auto-ack to %r failed: %s",
-                event.get("from_agent"),
-                exc,
-            )
+    # Post-delivery receipts: contentless auto-ack (legacy noise-filtered
+    # path) + structural reaction-ack (the comm-miss-detectable signal,
+    # lead a2a 1781e82a). Both are best-effort and share the per-sender
+    # rate cap; see ``_channel_post_deliver.run_post_deliver_receipts``.
+    await run_post_deliver_receipts(
+        event,
+        agent_name=agent_name,
+        listen_url=listen_url,
+        bearer=bearer,
+    )
 
 
 async def _serve(

--- a/src/scitex_agent_container/_state/dispatch_ledger.py
+++ b/src/scitex_agent_container/_state/dispatch_ledger.py
@@ -53,9 +53,23 @@ _TEXT_SUMMARY_LIMIT = 500
 # fails loudly instead of silently writing an unqueryable status.
 STATUS_SENT = "sent"
 STATUS_DELIVERED = "delivered"
+# STATUS_REACTED — the receiver's channel adapter posted a structural
+# reaction ack back to the sender (👀 marker). Distinct from
+# ``delivered`` (which is the listen-server publish HTTP 200 — does NOT
+# prove the recipient's adapter actually picked up the event). REACTED
+# is the operator's "comm-miss detectable" signal: absence of a reacted
+# row within the SLO = the recipient never injected the message.
+# See ``feat/comm-reaction-ack`` PR and lead a2a 1781e82a (2026-06-14).
+STATUS_REACTED = "reacted"
 STATUS_TIMEOUT = "timeout"
 STATUS_FAILED = "failed"
-VALID_STATUSES = (STATUS_SENT, STATUS_DELIVERED, STATUS_TIMEOUT, STATUS_FAILED)
+VALID_STATUSES = (
+    STATUS_SENT,
+    STATUS_DELIVERED,
+    STATUS_REACTED,
+    STATUS_TIMEOUT,
+    STATUS_FAILED,
+)
 
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS dispatches (
@@ -191,6 +205,84 @@ def update_dispatch_status(
         return cur.rowcount > 0
 
 
+def mark_dispatch_reacted(
+    dispatch_id: str,
+    *,
+    db_path: Path | None = None,
+) -> bool:
+    """Mark a dispatch as REACTED (receiver injected, structural ack received).
+
+    Thin convenience wrapper over :func:`update_dispatch_status` that
+    pins the status to :data:`STATUS_REACTED`. Used by the sender-side
+    channel adapter when it receives a ``kind="reaction"`` envelope
+    whose ``extra.reacted_dispatch_id`` matches an outbound row.
+
+    Idempotent at the SQL layer (a second call simply re-writes the
+    same status). Returns ``True`` iff a row matched — a ``False``
+    result is the audit signal that the reaction landed for a
+    dispatch this sender never minted (out-of-order replay, wrong
+    sender, or stale ledger).
+    """
+    return update_dispatch_status(dispatch_id, STATUS_REACTED, db_path=db_path)
+
+
+def list_unreacted_dispatches(
+    *,
+    older_than_s: float,
+    from_agent: str | None = None,
+    to_agent: str | None = None,
+    db_path: Path | None = None,
+) -> list[dict]:
+    """Return dispatches the receiver has not REACTED to within the SLO.
+
+    "Comm-miss detection" surface (lead a2a 1781e82a, 2026-06-14):
+    structural reaction-ack means the SENDER can poll this helper and
+    see exactly which outbound messages never produced a 👀 from the
+    recipient's channel adapter. Absence of a reaction past
+    ``older_than_s`` seconds = the recipient never injected the
+    message (their adapter is down, disconnected, or wedged).
+
+    Filters:
+
+    * ``older_than_s`` (REQUIRED) — only rows with ``ts <= now -
+      older_than_s`` are returned. A freshly-minted dispatch that has
+      simply not had time to be REACTED yet is NOT a miss; the SLO is
+      the operator's choice (e.g. 30s for interactive, 5min for
+      batch).
+    * ``from_agent`` / ``to_agent`` — narrow to one sender / receiver
+      pair when the caller cares about a specific peer.
+
+    The query excludes terminal-failure rows (``failed``, ``timeout``)
+    — those are *already* known not to have landed and would just be
+    noise in a comm-miss dashboard. ``reacted`` rows are also
+    excluded (they're the success case). Result: ``sent`` and
+    ``delivered`` rows older than the SLO with no reaction.
+    """
+    cutoff = time.time() - float(older_than_s)
+    clauses: list[str] = [
+        "status IN (?, ?)",
+        "ts <= ?",
+    ]
+    params: list[object] = [STATUS_SENT, STATUS_DELIVERED, cutoff]
+    if from_agent is not None:
+        clauses.append("from_agent = ?")
+        params.append(from_agent)
+    if to_agent is not None:
+        clauses.append("to_agent = ?")
+        params.append(to_agent)
+    where = " WHERE " + " AND ".join(clauses)
+
+    from .state_db import open_db
+
+    with open_db(db_path) as conn:
+        _ensure_table(conn)
+        rows = conn.execute(
+            f"SELECT * FROM dispatches{where} ORDER BY ts DESC",
+            tuple(params),
+        ).fetchall()
+        return [dict(r) for r in rows]
+
+
 def list_dispatches(
     *,
     from_agent: str | None = None,
@@ -246,11 +338,14 @@ def list_dispatches(
 __all__ = [
     "STATUS_DELIVERED",
     "STATUS_FAILED",
+    "STATUS_REACTED",
     "STATUS_SENT",
     "STATUS_TIMEOUT",
     "VALID_STATUSES",
     "init_ledger_schema",
     "list_dispatches",
+    "list_unreacted_dispatches",
+    "mark_dispatch_reacted",
     "new_dispatch_id",
     "record_dispatch",
     "update_dispatch_status",

--- a/tests/scitex_agent_container/_listen/test__node_channel.py
+++ b/tests/scitex_agent_container/_listen/test__node_channel.py
@@ -190,3 +190,70 @@ def test_non_string_kind_400_names_metadata_field(kind_env) -> None:
     err = resp.json().get("error", "")
     # Assert
     assert "metadata.kind" in err
+
+
+# ---------------------------------------------------------------------------
+# ``extra`` forwarding (feat/comm-reaction-ack, 2026-06-14).
+#
+# Structural reaction-ack rides ``params.metadata.extra.reacted_dispatch_id``
+# through the receive route. The receiver must persist the extra block on
+# the channel_events row so the sender's adapter can absorb the
+# dispatch_id and mark the ledger row REACTED. Without this forwarding the
+# whole reaction-ack contract collapses to "we sent 👀 to a void".
+# ---------------------------------------------------------------------------
+
+
+def test_extra_dict_round_trips_onto_event(kind_env) -> None:
+    # Arrange
+    app = create_app(token=TOKEN, local_host="127.0.0.1")
+    headers = {"authorization": f"Bearer {TOKEN}"}
+    body = {
+        "jsonrpc": "2.0",
+        "id": "1",
+        "method": "message/send",
+        "params": {
+            "message": {
+                "message_id": "m1",
+                "role": "ROLE_USER",
+                "parts": [{"text": "ping"}],
+            },
+            "metadata": {
+                "from_agent": "alice",
+                "kind": "reaction",
+                "extra": {"reacted_dispatch_id": "did-abc"},
+            },
+        },
+    }
+    # Act
+    with TestClient(app) as client:
+        client.post("/agents/lead/message:send", json=body, headers=headers)
+    rows = list_undelivered(target="lead")
+    extra = rows[0]["event"].get("extra") or {}
+    # Assert
+    assert extra.get("reacted_dispatch_id") == "did-abc"
+
+
+def test_empty_extra_does_not_land_on_event(kind_env) -> None:
+    # Arrange — an empty ``extra`` dict is morally absent; the receiver
+    # MUST keep the persisted envelope compact (no empty placeholder key).
+    app = create_app(token=TOKEN, local_host="127.0.0.1")
+    headers = {"authorization": f"Bearer {TOKEN}"}
+    body = {
+        "jsonrpc": "2.0",
+        "id": "1",
+        "method": "message/send",
+        "params": {
+            "message": {
+                "message_id": "m1",
+                "role": "ROLE_USER",
+                "parts": [{"text": "ping"}],
+            },
+            "metadata": {"from_agent": "alice", "extra": {}},
+        },
+    }
+    # Act
+    with TestClient(app) as client:
+        client.post("/agents/lead/message:send", json=body, headers=headers)
+    rows = list_undelivered(target="lead")
+    # Assert
+    assert "extra" not in rows[0]["event"]

--- a/tests/scitex_agent_container/_mcp/test__channel_post_deliver.py
+++ b/tests/scitex_agent_container/_mcp/test__channel_post_deliver.py
@@ -1,0 +1,138 @@
+"""Tests for the post-delivery receipts dispatcher
+(``_mcp._channel_post_deliver``).
+
+The dispatcher composes the two receipt side-effects (legacy
+contentless auto-ack + structural reaction-ack) and is the single
+call site channel.py uses after every successful delivery. These
+tests pin:
+
+* the missing-config short-circuit (no agent_name / listen_url → no
+  side-effects, no crashes — the wake-only path takes this branch);
+* both receipts disabled together → early exit (no httpx import on
+  the hot path);
+* one POST when only the reaction-ack is allowed (the legacy
+  auto-ack is empty-content and gets filtered at the sender).
+
+Real ``_FakeListenServer``; no mocks / no monkeypatch on production.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+from typing import Any
+
+import pytest
+import pytest_asyncio
+
+pytest.importorskip("mcp.types")
+
+from scitex_agent_container._mcp._channel_post_deliver import (  # noqa: E402
+    run_post_deliver_receipts,
+)
+from tests.scitex_agent_container._mcp.test__channel_tools import (  # noqa: E402
+    _FakeListenServer,
+)
+
+
+@pytest_asyncio.fixture
+async def fake_listen():
+    server = _FakeListenServer()
+    await server.start()
+    try:
+        yield server
+    finally:
+        await server.stop()
+
+
+@contextlib.contextmanager
+def _env(name: str, value: str | None):
+    sentinel = object()
+    prior: Any = os.environ.get(name, sentinel)
+    if value is None:
+        os.environ.pop(name, None)
+    else:
+        os.environ[name] = value
+    try:
+        yield
+    finally:
+        if prior is sentinel:
+            os.environ.pop(name, None)
+        else:
+            os.environ[name] = prior
+
+
+@pytest.mark.asyncio
+async def test_run_post_deliver_noop_without_agent_name(fake_listen):
+    # Arrange — no ``agent_name`` means there is no sender identity to
+    # post FROM; the dispatcher must early-exit cleanly.
+    event = {"from_agent": "bob", "content": "hi", "msg_id": "m1"}
+    # Act
+    await run_post_deliver_receipts(
+        event,
+        agent_name=None,
+        listen_url=fake_listen.base_url,
+        bearer=None,
+    )
+    # Assert
+    assert fake_listen.posts == []
+
+
+@pytest.mark.asyncio
+async def test_run_post_deliver_noop_without_listen_url(fake_listen):
+    # Arrange — no ``listen_url`` means we don't know WHERE to POST;
+    # early-exit cleanly.
+    event = {"from_agent": "bob", "content": "hi", "msg_id": "m1"}
+    # Act
+    await run_post_deliver_receipts(
+        event,
+        agent_name="alice",
+        listen_url=None,
+        bearer=None,
+    )
+    # Assert
+    assert fake_listen.posts == []
+
+
+@pytest.mark.asyncio
+async def test_run_post_deliver_noop_when_both_receipts_disabled(fake_listen):
+    # Arrange — both env knobs off; zero POSTs reach the listen even
+    # though config is otherwise valid.
+    event = {"from_agent": "bob", "content": "hi", "msg_id": "m1"}
+    # Act
+    with _env("SAC_CHANNEL_AUTO_ACK", "0"), _env("SAC_REACTION_ACK", "0"):
+        await run_post_deliver_receipts(
+            event,
+            agent_name="alice",
+            listen_url=fake_listen.base_url,
+            bearer=None,
+        )
+    # Assert
+    assert fake_listen.posts == []
+
+
+@pytest.mark.asyncio
+async def test_run_post_deliver_only_reaction_posts_when_auto_ack_disabled(
+    fake_listen,
+):
+    # Arrange — auto-ack off, reaction-ack default-on. Only the
+    # structural 👀 reaches the wire.
+    event = {"from_agent": "bob", "content": "hi", "msg_id": "m1"}
+    # Act
+    with _env("SAC_CHANNEL_AUTO_ACK", "0"), _env("SAC_REACTION_ACK", None):
+        await run_post_deliver_receipts(
+            event,
+            agent_name="alice",
+            listen_url=fake_listen.base_url,
+            bearer=None,
+        )
+    # Assert — exactly one structural reaction POST landed.
+    reaction_posts = [
+        payload
+        for _path, payload in fake_listen.posts
+        if (
+            isinstance(payload, dict)
+            and payload.get("params", {}).get("metadata", {}).get("kind") == "reaction"
+        )
+    ]
+    assert len(reaction_posts) == 1

--- a/tests/scitex_agent_container/_mcp/test__channel_reaction_ack.py
+++ b/tests/scitex_agent_container/_mcp/test__channel_reaction_ack.py
@@ -1,0 +1,488 @@
+"""Tests for the sac channel structural reaction-ack subsystem
+(``_mcp._channel_reaction_ack``, ``feat/comm-reaction-ack``).
+
+Three surfaces are covered, no mocks / monkeypatch on production:
+
+1. Pure predicates — :func:`should_emit_reaction_ack` and
+   :func:`is_reaction_event`. Structural, no I/O.
+
+2. Receive-side emit — :func:`post_reaction_ack` posts a non-empty
+   ``kind="reaction"`` envelope back to the sender's listen URL. Uses
+   the real ``_FakeListenServer`` from
+   ``tests/.../_mcp/test__channel_tools.py`` (asyncio.start_server +
+   real httpx — no mocks).
+
+3. Sender-side absorption — :func:`absorb_reaction_ack` walks the
+   envelope and flips the dispatch-ledger row to ``STATUS_REACTED``.
+   Real sqlite under ``tmp_path`` via the same env-fixture pattern
+   the ledger tests use.
+
+Operator mandate (lead a2a ``1781e82a``, 2026-06-14): structural
+reaction so absence = comm miss, detectable.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+import pytest_asyncio
+
+pytest.importorskip("mcp.types")
+
+from scitex_agent_container._mcp._channel_reaction_ack import (  # noqa: E402
+    DEFAULT_REACTION_MARKER,
+    absorb_reaction_ack,
+    is_reaction_event,
+    post_reaction_ack,
+    reaction_ack_enabled,
+    reaction_ack_marker,
+    should_emit_reaction_ack,
+)
+
+# Reuse the real HTTP fake from the sibling test module — same shape
+# as test__channel_ack_filter does. No mocks.
+from tests.scitex_agent_container._mcp.test__channel_tools import (  # noqa: E402
+    _FakeListenServer,
+)
+
+# ---------------------------------------------------------------------------
+# (1) Pure predicates
+# ---------------------------------------------------------------------------
+
+
+def test_is_reaction_event_true_when_kind_is_reaction():
+    # Arrange
+    event = {"kind": "reaction", "from_agent": "bob"}
+    # Act
+    decision = is_reaction_event(event)
+    # Assert
+    assert decision is True
+
+
+def test_is_reaction_event_false_on_normal_message():
+    # Arrange
+    event = {"kind": "message", "from_agent": "bob"}
+    # Act
+    decision = is_reaction_event(event)
+    # Assert
+    assert decision is False
+
+
+def test_should_emit_reaction_ack_true_for_normal_message():
+    # Arrange
+    event = {"from_agent": "bob", "content": "hello"}
+    # Act
+    decision = should_emit_reaction_ack(event)
+    # Assert
+    assert decision is True
+
+
+def test_should_emit_reaction_ack_false_when_no_sender():
+    # Arrange — no ``from_agent`` means nowhere to post the receipt.
+    event: dict[str, Any] = {"content": "hello"}
+    # Act
+    decision = should_emit_reaction_ack(event)
+    # Assert
+    assert decision is False
+
+
+def test_should_emit_reaction_ack_false_on_ack_marker():
+    # Arrange — a stage-2 auto-ack must not trigger a reaction (would
+    # double-stamp the same delivery).
+    event = {"from_agent": "bob", "ack": True}
+    # Act
+    decision = should_emit_reaction_ack(event)
+    # Assert
+    assert decision is False
+
+
+def test_should_emit_reaction_ack_false_on_reaction_event():
+    # Arrange — 👀-on-👀 is the loop we are guarding against.
+    event = {"from_agent": "bob", "kind": "reaction", "content": "\N{EYES}"}
+    # Act
+    decision = should_emit_reaction_ack(event)
+    # Assert
+    assert decision is False
+
+
+def test_should_emit_reaction_ack_false_on_denied_attempt():
+    # Arrange — denied_attempt is a structured notification; reacting
+    # would post back to the would-be sender and pollute the ledger.
+    event = {"from_agent": "carol", "kind": "denied_attempt"}
+    # Act
+    decision = should_emit_reaction_ack(event)
+    # Assert
+    assert decision is False
+
+
+def test_should_emit_reaction_ack_false_on_system_sender():
+    # Arrange — system notifications must never be reacted to (the
+    # 'system' sender has no inbox we should write to).
+    event = {"from_agent": "system", "kind": "acl_deny_notify"}
+    # Act
+    decision = should_emit_reaction_ack(event)
+    # Assert
+    assert decision is False
+
+
+# ---------------------------------------------------------------------------
+# (2) Env-driven config
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def env_setter():
+    """Save/restore env keys per test — no monkeypatch on production."""
+    saved: dict[str, str | None] = {}
+
+    def _set(key: str, value: str | None) -> None:
+        if key not in saved:
+            saved[key] = os.environ.get(key)
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
+
+    try:
+        yield _set
+    finally:
+        for k, prev in saved.items():
+            if prev is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = prev
+
+
+def test_reaction_ack_enabled_default_is_true(env_setter):
+    # Arrange — clear env so default applies.
+    env_setter("SAC_REACTION_ACK", None)
+    # Act
+    decision = reaction_ack_enabled()
+    # Assert
+    assert decision is True
+
+
+def test_reaction_ack_disabled_when_env_zero(env_setter):
+    # Arrange
+    env_setter("SAC_REACTION_ACK", "0")
+    # Act
+    decision = reaction_ack_enabled()
+    # Assert
+    assert decision is False
+
+
+def test_reaction_ack_marker_default_is_eyes(env_setter):
+    # Arrange — clear env so default applies (both keys).
+    env_setter("SAC_REACTION_ACK_MARKER", None)
+    env_setter("SCITEX_AGENT_CONTAINER_REACTION_ACK_MARKER", None)
+    # Act
+    marker = reaction_ack_marker()
+    # Assert
+    assert marker == DEFAULT_REACTION_MARKER
+
+
+def test_reaction_ack_marker_empty_override_falls_back(env_setter):
+    # Arrange — an empty marker would re-trigger the empty-ack filter;
+    # the helper must reject it silently and use the default.
+    env_setter("SAC_REACTION_ACK_MARKER", "   ")
+    # Act
+    marker = reaction_ack_marker()
+    # Assert
+    assert marker == DEFAULT_REACTION_MARKER
+
+
+# ---------------------------------------------------------------------------
+# (3) Receive-side emit — real HTTP fake.
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def fake_listen():
+    server = _FakeListenServer()
+    await server.start()
+    try:
+        yield server
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_post_reaction_ack_emits_a_post_to_sender(fake_listen):
+    # Arrange — alice receives a message from bob; she reacts back.
+    event = {"from_agent": "bob", "msg_id": "m1", "content": "hello"}
+    # Act
+    await post_reaction_ack(
+        event,
+        agent_name="alice",
+        listen_url=fake_listen.base_url,
+        bearer=None,
+    )
+    paths = [p for p, _ in fake_listen.posts]
+    # Assert
+    assert "/agents/bob/message:send" in paths
+
+
+@pytest.mark.asyncio
+async def test_post_reaction_ack_payload_carries_marker_text(fake_listen):
+    # Arrange
+    event = {"from_agent": "bob", "msg_id": "m1", "content": "hello"}
+    # Act
+    await post_reaction_ack(
+        event,
+        agent_name="alice",
+        listen_url=fake_listen.base_url,
+        bearer=None,
+    )
+    payload = fake_listen.posts[0][1]
+    text = payload["params"]["message"]["parts"][0]["text"]
+    # Assert — content is the non-empty marker that survives the
+    # sender-side empty-ack filter.
+    assert text == DEFAULT_REACTION_MARKER
+
+
+@pytest.mark.asyncio
+async def test_post_reaction_ack_payload_carries_kind_reaction(fake_listen):
+    # Arrange
+    event = {"from_agent": "bob", "msg_id": "m1", "content": "hello"}
+    # Act
+    await post_reaction_ack(
+        event,
+        agent_name="alice",
+        listen_url=fake_listen.base_url,
+        bearer=None,
+    )
+    metadata = fake_listen.posts[0][1]["params"]["metadata"]
+    # Assert
+    assert metadata.get("kind") == "reaction"
+
+
+@pytest.mark.asyncio
+async def test_post_reaction_ack_threads_dispatch_id_into_extra(fake_listen):
+    # Arrange — the inbound event carries the SENDER's dispatch_id so
+    # the reaction can pin the exact ledger row.
+    event = {
+        "from_agent": "bob",
+        "msg_id": "m1",
+        "content": "hi",
+        "dispatch_id": "did-abc",
+    }
+    # Act
+    await post_reaction_ack(
+        event,
+        agent_name="alice",
+        listen_url=fake_listen.base_url,
+        bearer=None,
+    )
+    metadata = fake_listen.posts[0][1]["params"]["metadata"]
+    extra = metadata.get("extra") or {}
+    # Assert
+    assert extra.get("reacted_dispatch_id") == "did-abc"
+
+
+@pytest.mark.asyncio
+async def test_post_reaction_ack_marks_envelope_with_ack_loop_guard(fake_listen):
+    # Arrange — the legacy auto-ack subsystem refuses to ack an event
+    # with ``ack=True``; setting it on the reaction preserves that
+    # guard against the auto-ack path re-firing on the receipt.
+    event = {"from_agent": "bob", "msg_id": "m1", "content": "hi"}
+    # Act
+    await post_reaction_ack(
+        event,
+        agent_name="alice",
+        listen_url=fake_listen.base_url,
+        bearer=None,
+    )
+    metadata = fake_listen.posts[0][1]["params"]["metadata"]
+    # Assert
+    assert metadata.get("ack") is True
+
+
+# ---------------------------------------------------------------------------
+# (4) Sender-side absorption — flips the ledger row to REACTED.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def db_path(tmp_path: Path):
+    # Arrange — isolated state.db via env, mirroring the ledger tests.
+    p = tmp_path / "state.db"
+    key = "SCITEX_AGENT_CONTAINER_STATE_DB"
+    saved = os.environ.get(key)
+    os.environ[key] = str(p)
+    import scitex_agent_container._state.state_db as mod
+
+    importlib.reload(mod)
+    try:
+        yield p
+    finally:
+        if saved is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = saved
+        importlib.reload(mod)
+
+
+def test_absorb_reaction_ack_flips_ledger_to_reacted(db_path: Path):
+    # Arrange — record a dispatch, simulate the receiver's 👀 landing.
+    from scitex_agent_container._state.dispatch_ledger import (
+        STATUS_REACTED,
+        list_dispatches,
+        record_dispatch,
+    )
+
+    did = record_dispatch(from_agent="alice", to_agent="bob", text="hi")
+    event = {
+        "from_agent": "bob",
+        "kind": "reaction",
+        "content": DEFAULT_REACTION_MARKER,
+        "extra": {"reacted_dispatch_id": did},
+    }
+    # Act
+    absorb_reaction_ack(event)
+    rows = list_dispatches()
+    # Assert
+    assert rows[0]["status"] == STATUS_REACTED
+
+
+def test_absorb_reaction_ack_returns_true_on_match(db_path: Path):
+    # Arrange
+    from scitex_agent_container._state.dispatch_ledger import record_dispatch
+
+    did = record_dispatch(from_agent="alice", to_agent="bob", text="hi")
+    event = {
+        "from_agent": "bob",
+        "kind": "reaction",
+        "extra": {"reacted_dispatch_id": did},
+    }
+    # Act
+    matched = absorb_reaction_ack(event)
+    # Assert
+    assert matched is True
+
+
+def test_absorb_reaction_ack_returns_false_on_non_reaction_event(db_path: Path):
+    # Arrange — a regular inbound message should never touch the
+    # ledger. Returning False is the audit signal.
+    event = {
+        "from_agent": "bob",
+        "content": "hi",
+        "extra": {"reacted_dispatch_id": "did-x"},
+    }
+    # Act
+    matched = absorb_reaction_ack(event)
+    # Assert
+    assert matched is False
+
+
+def test_absorb_reaction_ack_returns_false_without_dispatch_id(db_path: Path):
+    # Arrange — legacy senders that never minted a ledger row are
+    # not a failure; they're a no-op (deliberate, not silent).
+    event: dict[str, Any] = {"from_agent": "bob", "kind": "reaction"}
+    # Act
+    matched = absorb_reaction_ack(event)
+    # Assert
+    assert matched is False
+
+
+def test_absorb_reaction_ack_is_idempotent_on_double_delivery(db_path: Path):
+    # Arrange — a retried receipt must not corrupt the row.
+    from scitex_agent_container._state.dispatch_ledger import (
+        STATUS_REACTED,
+        list_dispatches,
+        record_dispatch,
+    )
+
+    did = record_dispatch(from_agent="alice", to_agent="bob", text="hi")
+    event = {
+        "from_agent": "bob",
+        "kind": "reaction",
+        "extra": {"reacted_dispatch_id": did},
+    }
+    absorb_reaction_ack(event)
+    # Act — second delivery.
+    absorb_reaction_ack(event)
+    rows = list_dispatches()
+    # Assert — row is still REACTED, no schema corruption, single row.
+    assert rows[0]["status"] == STATUS_REACTED
+
+
+# ---------------------------------------------------------------------------
+# (5) Comm-miss detectability — sender notices an absent reaction.
+# ---------------------------------------------------------------------------
+
+
+def test_comm_miss_detected_when_receipt_never_lands(db_path: Path):
+    # Arrange — sender records a dispatch but the receiver never
+    # reacts (their adapter is down).
+    import time
+
+    from scitex_agent_container._state.dispatch_ledger import (
+        list_unreacted_dispatches,
+        record_dispatch,
+    )
+
+    record_dispatch(
+        from_agent="alice",
+        to_agent="bob",
+        text="hi",
+        ts=time.time() - 60.0,
+    )
+    # Act
+    rows = list_unreacted_dispatches(older_than_s=30.0, from_agent="alice")
+    # Assert — the comm miss is visible.
+    assert len(rows) == 1
+
+
+def test_comm_miss_cleared_after_reaction_lands(db_path: Path):
+    # Arrange — same dispatch, but the receipt landed via absorption.
+    import time
+
+    from scitex_agent_container._state.dispatch_ledger import (
+        list_unreacted_dispatches,
+        record_dispatch,
+    )
+
+    did = record_dispatch(
+        from_agent="alice",
+        to_agent="bob",
+        text="hi",
+        ts=time.time() - 60.0,
+    )
+    event = {
+        "from_agent": "bob",
+        "kind": "reaction",
+        "extra": {"reacted_dispatch_id": did},
+    }
+    absorb_reaction_ack(event)
+    # Act
+    rows = list_unreacted_dispatches(older_than_s=30.0, from_agent="alice")
+    # Assert — no miss; the reaction landed.
+    assert rows == []
+
+
+# ---------------------------------------------------------------------------
+# (6) Payload shape sanity — the outbound envelope mirrors the
+# operator's wire contract (JSON-RPC SendMessage with sac metadata).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_post_reaction_ack_envelope_is_json_rpc_send_message(fake_listen):
+    # Arrange
+    event = {"from_agent": "bob", "msg_id": "m1", "content": "hi"}
+    # Act
+    await post_reaction_ack(
+        event,
+        agent_name="alice",
+        listen_url=fake_listen.base_url,
+        bearer=None,
+    )
+    payload = fake_listen.posts[0][1]
+    serialised = json.dumps(payload)  # round-trips; envelope is JSON.
+    # Assert — minimal sanity: the method is SendMessage.
+    assert "SendMessage" in serialised

--- a/tests/scitex_agent_container/_mcp/test_channel.py
+++ b/tests/scitex_agent_container/_mcp/test_channel.py
@@ -990,14 +990,43 @@ async def test_push_channel_event_still_injects_notification(fake_listen):
     assert len(session.sent) == 1
 
 
+def _contentless_ack_posts(fake_listen) -> list:
+    """Filter the fake listen's posts down to contentless legacy acks.
+
+    A "contentless ack" carries ``metadata.ack=True`` AND an empty (or
+    missing) text body. The structural reaction-ack
+    (``feat/comm-reaction-ack``) is excluded from this filter — it
+    carries a non-empty 👀 marker so the sender-side noise filter
+    deliberately lets it pass.
+    """
+    out = []
+    for path, payload in fake_listen.posts:
+        if not isinstance(payload, dict):
+            continue
+        params = payload.get("params") or {}
+        metadata = params.get("metadata") or {}
+        if not metadata.get("ack"):
+            continue
+        message = params.get("message") or {}
+        parts = message.get("parts") or []
+        text = ""
+        if isinstance(parts, list) and parts and isinstance(parts[0], dict):
+            text = parts[0].get("text", "") or ""
+        if isinstance(text, str) and text.strip() == "":
+            out.append((path, payload))
+    return out
+
+
 @pytest.mark.asyncio
 async def test_push_channel_event_auto_ack_is_suppressed_at_sender(fake_listen):
     """Operator contract: the stage-2 read-receipt auto-ack is contentless
     (empty body + ``metadata.ack=True``), so the sender-side noise filter
-    drops it BEFORE it leaves the outbound queue. The wire stays quiet —
-    the receive-side ``_should_auto_ack`` guard remains as belt-and-
-    suspenders. Pre-filter behaviour (a POST to ``/agents/bob/message:send``)
-    is replaced by zero POSTs."""
+    drops it BEFORE it leaves the outbound queue. The wire stays quiet for
+    contentless acks — the structural reaction-ack
+    (``feat/comm-reaction-ack``) carries a 👀 marker and is the operator's
+    comm-miss-detectable signal; it is NOT suppressed (and is asserted
+    elsewhere). Pre-filter contentless behaviour (a POST to
+    ``/agents/bob/message:send``) is replaced by zero contentless POSTs."""
     # Arrange
     from scitex_agent_container._mcp.channel import _push_channel_event
 
@@ -1011,8 +1040,9 @@ async def test_push_channel_event_auto_ack_is_suppressed_at_sender(fake_listen):
         listen_url=fake_listen.base_url,
         bearer=None,
     )
-    # Assert — no auto-ack reached the listen.
-    assert fake_listen.posts == []
+    # Assert — no CONTENTLESS auto-ack reached the listen. The structural
+    # reaction-ack (non-empty 👀 marker) is a separate, intentional signal.
+    assert _contentless_ack_posts(fake_listen) == []
 
 
 @pytest.mark.asyncio
@@ -1058,19 +1088,24 @@ async def test_push_channel_event_does_not_auto_ack_an_ack(fake_listen):
 
 
 @pytest.mark.asyncio
-async def test_two_adapters_emit_zero_acks_under_sender_side_filter(fake_listen):
+async def test_two_adapters_emit_zero_contentless_acks_under_sender_side_filter(
+    fake_listen,
+):
     """End-to-end ping-pong cannot start under the sender-side filter: A's
-    would-be auto-ack to B is dropped at A before it reaches the wire, so
-    there is nothing for B's adapter to bounce back. Pre-filter behaviour
-    (exactly one ack on the wire) is replaced by zero acks on the wire.
-    Replaces ``test_two_adapters_do_not_ping_pong_to_a_fixed_point`` —
-    the loop terminates one hop earlier."""
+    would-be CONTENTLESS auto-ack to B is dropped at A before it reaches
+    the wire, so there is nothing for B's adapter to bounce back.
+    Pre-filter behaviour (exactly one contentless ack on the wire) is
+    replaced by zero contentless acks on the wire. The structural
+    reaction-ack (``feat/comm-reaction-ack``) is a separate, intentional
+    signal carrying a 👀 marker — it DOES reach the wire so the sender can
+    detect comm-miss; the receive-side loop-guard on ``kind="reaction"``
+    prevents the ping-pong (covered by the e2e module)."""
     # Arrange
     from scitex_agent_container._mcp.channel import _push_channel_event
 
     session_a = _CapturingSession()
     inbound_to_a = {"from_agent": "bob", "content": "hi", "msg_id": "m1"}
-    # Act — A receives B's message; the auto-ack is suppressed at A.
+    # Act — A receives B's message; the contentless ack is suppressed at A.
     await _push_channel_event(
         session_a,
         inbound_to_a,
@@ -1078,18 +1113,23 @@ async def test_two_adapters_emit_zero_acks_under_sender_side_filter(fake_listen)
         listen_url=fake_listen.base_url,
         bearer=None,
     )
-    # Assert — no ack reached the wire.
-    assert fake_listen.posts == []
+    # Assert — no CONTENTLESS ack reached the wire.
+    assert _contentless_ack_posts(fake_listen) == []
 
 
 @pytest.mark.asyncio
-async def test_auto_ack_disabled_via_env_emits_no_post(fake_listen):
+async def test_auto_ack_disabled_via_env_emits_no_contentless_post(fake_listen):
+    """Disabling the legacy contentless auto-ack via env: no contentless
+    POST reaches the wire. The structural reaction-ack
+    (``feat/comm-reaction-ack``) is gated by a SEPARATE env knob
+    (``SAC_REACTION_ACK``) and remains on by default — the operator's
+    comm-miss-detectable signal is intentional and asserted elsewhere."""
     # Arrange
     from scitex_agent_container._mcp.channel import _push_channel_event
 
     session = _CapturingSession()
     event = {"from_agent": "bob", "content": "hi", "msg_id": "m1"}
-    # Act
+    # Act — auto-ack OFF; reaction-ack default (ON).
     with _env("SAC_CHANNEL_AUTO_ACK", "0"):
         await _push_channel_event(
             session,
@@ -1098,8 +1138,8 @@ async def test_auto_ack_disabled_via_env_emits_no_post(fake_listen):
             listen_url=fake_listen.base_url,
             bearer=None,
         )
-    # Assert — injection happened, but no auto-ack POST.
-    assert fake_listen.posts == []
+    # Assert — injection happened, but no contentless auto-ack POST.
+    assert _contentless_ack_posts(fake_listen) == []
 
 
 @pytest.mark.asyncio

--- a/tests/scitex_agent_container/_mcp/test_channel_reaction_ack_e2e.py
+++ b/tests/scitex_agent_container/_mcp/test_channel_reaction_ack_e2e.py
@@ -34,7 +34,6 @@ import pytest_asyncio
 
 pytest.importorskip("mcp.types")
 
-from scitex_agent_container._mcp import channel as channel_mod  # noqa: E402
 from scitex_agent_container._mcp.channel import _recent  # noqa: E402
 
 # Reuse the test_channel FakeListen (real SSE + JSON over asyncio TCP).

--- a/tests/scitex_agent_container/_mcp/test_channel_reaction_ack_e2e.py
+++ b/tests/scitex_agent_container/_mcp/test_channel_reaction_ack_e2e.py
@@ -1,0 +1,342 @@
+"""End-to-end tests for the structural reaction-ack receive-side hook
+(``feat/comm-reaction-ack``, lead a2a 1781e82a, 2026-06-14).
+
+Two flows:
+
+1. **Emit on inbound** — when ``_push_channel_event`` injects a
+   normal inbound event, it ALSO posts a structural ``kind=reaction``
+   envelope back to the sender (so the SENDER can detect comm-miss
+   via absence). Verified end-to-end against the real
+   ``_FakeListenServer`` from ``test_channel.py`` (asyncio TCP +
+   real httpx — no mocks).
+
+2. **Absorb on inbound** — when a ``kind=reaction`` event arrives
+   at THIS agent (we previously sent a message; the receiver now
+   reacts), ``_push_channel_event`` updates the dispatch ledger and
+   skips session injection (receipts are not user-visible
+   messages). The receive-side adapter does NOT re-react to a
+   reaction (no 👀-on-👀 loop).
+
+Conventions: AAA markers, one assert per test (STX-TQ007); no mocks
+/ no monkeypatch on production internals.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+import pytest_asyncio
+
+pytest.importorskip("mcp.types")
+
+from scitex_agent_container._mcp import channel as channel_mod  # noqa: E402
+from scitex_agent_container._mcp.channel import _recent  # noqa: E402
+
+# Reuse the test_channel FakeListen (real SSE + JSON over asyncio TCP).
+from tests.scitex_agent_container._mcp.test_channel import (  # noqa: E402
+    _CapturingSession,
+    _FakeListenServer,
+)
+
+
+@pytest_asyncio.fixture
+async def fake_listen():
+    server = _FakeListenServer()
+    await server.start()
+    try:
+        yield server
+    finally:
+        await server.stop()
+
+
+@pytest.fixture(autouse=True)
+def _clear_recent_ring():
+    _recent.clear()
+    yield
+    _recent.clear()
+
+
+@contextlib.contextmanager
+def _env(name: str, value: str | None):
+    """Real os.environ save/restore (no monkeypatch on production)."""
+    sentinel = object()
+    prior: Any = os.environ.get(name, sentinel)
+    if value is None:
+        os.environ.pop(name, None)
+    else:
+        os.environ[name] = value
+    try:
+        yield
+    finally:
+        if prior is sentinel:
+            os.environ.pop(name, None)
+        else:
+            os.environ[name] = prior
+
+
+@pytest.fixture
+def db_path(tmp_path: Path):
+    """Isolated state.db for dispatch-ledger writes during absorption."""
+    p = tmp_path / "state.db"
+    key = "SCITEX_AGENT_CONTAINER_STATE_DB"
+    saved = os.environ.get(key)
+    os.environ[key] = str(p)
+    import scitex_agent_container._state.state_db as mod
+
+    importlib.reload(mod)
+    try:
+        yield p
+    finally:
+        if saved is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = saved
+        importlib.reload(mod)
+
+
+# ---------------------------------------------------------------------------
+# (1) Emit on inbound normal message — the SENDER's wire signal.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_inbound_message_triggers_reaction_post(fake_listen):
+    """A normal inbound message from bob makes alice post a 👀 back."""
+    # Arrange
+    from scitex_agent_container._mcp.channel import _push_channel_event
+
+    session = _CapturingSession()
+    event = {"from_agent": "bob", "content": "hi", "msg_id": "m1"}
+    # Act
+    await _push_channel_event(
+        session,
+        event,
+        agent_name="alice",
+        listen_url=fake_listen.base_url,
+        bearer=None,
+    )
+    paths = [p for p, _ in fake_listen.posts]
+    # Assert — at least one POST landed at bob's inbox path
+    # (the structural reaction; the legacy contentless auto-ack is
+    # suppressed by the empty-ack noise filter, so this POST IS
+    # the structural reaction).
+    assert "/agents/bob/message:send" in paths
+
+
+@pytest.mark.asyncio
+async def test_reaction_post_body_carries_eyes_marker(fake_listen):
+    """The reaction's content is the non-empty eyes marker — that's
+    what survives the sender-side empty-ack filter."""
+    # Arrange
+    from scitex_agent_container._mcp.channel import _push_channel_event
+
+    session = _CapturingSession()
+    event = {"from_agent": "bob", "content": "hi", "msg_id": "m1"}
+    # Act
+    await _push_channel_event(
+        session,
+        event,
+        agent_name="alice",
+        listen_url=fake_listen.base_url,
+        bearer=None,
+    )
+    # Find the reaction POST (kind=reaction in metadata).
+    reaction_posts = [
+        payload
+        for _path, payload in fake_listen.posts
+        if (
+            isinstance(payload, dict)
+            and payload.get("params", {}).get("metadata", {}).get("kind") == "reaction"
+        )
+    ]
+    text = reaction_posts[0]["params"]["message"]["parts"][0]["text"]
+    # Assert
+    assert text == "\N{EYES}"
+
+
+@pytest.mark.asyncio
+async def test_reaction_post_threads_dispatch_id(fake_listen):
+    """The sender minted a ``dispatch_id`` on the original; the
+    reaction must thread it back so the sender's adapter can pin the
+    exact ledger row."""
+    # Arrange
+    from scitex_agent_container._mcp.channel import _push_channel_event
+
+    session = _CapturingSession()
+    event = {
+        "from_agent": "bob",
+        "content": "hi",
+        "msg_id": "m1",
+        "dispatch_id": "did-abc",
+    }
+    # Act
+    await _push_channel_event(
+        session,
+        event,
+        agent_name="alice",
+        listen_url=fake_listen.base_url,
+        bearer=None,
+    )
+    reaction_posts = [
+        payload
+        for _path, payload in fake_listen.posts
+        if (
+            isinstance(payload, dict)
+            and payload.get("params", {}).get("metadata", {}).get("kind") == "reaction"
+        )
+    ]
+    extra = reaction_posts[0]["params"]["metadata"].get("extra") or {}
+    # Assert
+    assert extra.get("reacted_dispatch_id") == "did-abc"
+
+
+@pytest.mark.asyncio
+async def test_reaction_post_skipped_when_env_disables_reaction_ack(fake_listen):
+    """``SAC_REACTION_ACK=0`` turns the structural receipt off; no
+    reaction POSTs reach the listen (verifies the env gate is wired)."""
+    # Arrange
+    from scitex_agent_container._mcp.channel import _push_channel_event
+
+    session = _CapturingSession()
+    event = {"from_agent": "bob", "content": "hi", "msg_id": "m1"}
+    # Act
+    with _env("SAC_REACTION_ACK", "0"):
+        await _push_channel_event(
+            session,
+            event,
+            agent_name="alice",
+            listen_url=fake_listen.base_url,
+            bearer=None,
+        )
+    reaction_paths = [
+        path
+        for path, payload in fake_listen.posts
+        if isinstance(payload, dict)
+        and payload.get("params", {}).get("metadata", {}).get("kind") == "reaction"
+    ]
+    # Assert
+    assert reaction_paths == []
+
+
+# ---------------------------------------------------------------------------
+# (2) Absorb on inbound reaction — the SENDER's side.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_inbound_reaction_skips_session_injection(fake_listen):
+    """A ``kind=reaction`` event MUST NOT land as a notifications/claude/
+    channel push — it's a wire signal, not a user-visible message."""
+    # Arrange
+    from scitex_agent_container._mcp.channel import _push_channel_event
+
+    session = _CapturingSession()
+    event = {
+        "from_agent": "bob",
+        "kind": "reaction",
+        "content": "\N{EYES}",
+        "extra": {"reacted_dispatch_id": "did-x"},
+    }
+    # Act
+    await _push_channel_event(
+        session,
+        event,
+        agent_name="alice",
+        listen_url=fake_listen.base_url,
+        bearer=None,
+    )
+    # Assert — the session received NO notification for the reaction.
+    assert session.sent == []
+
+
+@pytest.mark.asyncio
+async def test_inbound_reaction_does_not_post_reaction_back(fake_listen):
+    """Loop-guard: ``_push_channel_event`` must not 👀-back a 👀.
+    Zero POSTs are made when an inbound event is a reaction."""
+    # Arrange
+    from scitex_agent_container._mcp.channel import _push_channel_event
+
+    session = _CapturingSession()
+    event = {
+        "from_agent": "bob",
+        "kind": "reaction",
+        "content": "\N{EYES}",
+        "extra": {"reacted_dispatch_id": "did-x"},
+    }
+    # Act
+    await _push_channel_event(
+        session,
+        event,
+        agent_name="alice",
+        listen_url=fake_listen.base_url,
+        bearer=None,
+    )
+    # Assert
+    assert fake_listen.posts == []
+
+
+@pytest.mark.asyncio
+async def test_inbound_reaction_updates_dispatch_ledger(fake_listen, db_path: Path):
+    """End-to-end: alice previously sent a message, bob's adapter posts
+    a structural reaction back; alice's adapter absorbs it and the
+    ledger row flips to REACTED."""
+    # Arrange
+    from scitex_agent_container._mcp.channel import _push_channel_event
+    from scitex_agent_container._state.dispatch_ledger import (
+        STATUS_REACTED,
+        list_dispatches,
+        record_dispatch,
+    )
+
+    did = record_dispatch(from_agent="alice", to_agent="bob", text="hi")
+    session = _CapturingSession()
+    event = {
+        "from_agent": "bob",
+        "kind": "reaction",
+        "content": "\N{EYES}",
+        "extra": {"reacted_dispatch_id": did},
+    }
+    # Act
+    await _push_channel_event(
+        session,
+        event,
+        agent_name="alice",
+        listen_url=fake_listen.base_url,
+        bearer=None,
+    )
+    rows = list_dispatches()
+    # Assert
+    assert rows[0]["status"] == STATUS_REACTED
+
+
+@pytest.mark.asyncio
+async def test_inbound_reaction_still_lands_in_recent_ring(fake_listen):
+    """Even though the reaction is suppressed from session injection,
+    it is buffered into ``_recent`` so a2a_inbox callers can AUDIT
+    that the receipt landed (debug surface)."""
+    # Arrange
+    from scitex_agent_container._mcp.channel import _push_channel_event
+
+    session = _CapturingSession()
+    event = {
+        "from_agent": "bob",
+        "kind": "reaction",
+        "content": "\N{EYES}",
+        "msg_id": "react-1",
+    }
+    # Act
+    await _push_channel_event(
+        session,
+        event,
+        agent_name="alice",
+        listen_url=fake_listen.base_url,
+        bearer=None,
+    )
+    buffered = [e for e in _recent if e.get("msg_id") == "react-1"]
+    # Assert
+    assert len(buffered) == 1

--- a/tests/scitex_agent_container/_state/test_dispatch_ledger_reaction.py
+++ b/tests/scitex_agent_container/_state/test_dispatch_ledger_reaction.py
@@ -1,0 +1,259 @@
+"""Tests for the dispatch-ledger reaction-ack additions
+(``feat/comm-reaction-ack``, 2026-06-14).
+
+Operator mandate (lead a2a ``1781e82a``): "absence of the reaction
+= comm miss, detectable". This module covers the persistence half:
+
+* :data:`STATUS_REACTED` is registered as a valid lifecycle status —
+  ``record_dispatch`` does not reject it and ``mark_dispatch_reacted``
+  writes it durably.
+* :func:`mark_dispatch_reacted` is the thin wrapper the sender's
+  channel adapter calls when a structural 👀 receipt arrives. It is
+  idempotent (a second call leaves the row at REACTED).
+* :func:`list_unreacted_dispatches` returns the rows older than the
+  SLO that have NOT been REACTED — the comm-miss surface. Terminal
+  statuses (``reacted``, ``failed``, ``timeout``) are excluded.
+
+Conventions: AAA markers, one assertion per test (STX-TQ007), no
+mocks / no monkeypatch (real sqlite via the ``db_path`` env fixture).
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def db_path(tmp_path: Path):
+    # Arrange — isolated state.db, exported via env so the ledger picks
+    # it up. Explicit save/restore (no monkeypatch on production code).
+    p = tmp_path / "state.db"
+    key = "SCITEX_AGENT_CONTAINER_STATE_DB"
+    saved = os.environ.get(key)
+    os.environ[key] = str(p)
+    import scitex_agent_container._state.state_db as mod
+
+    importlib.reload(mod)
+    try:
+        yield p
+    finally:
+        if saved is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = saved
+        importlib.reload(mod)
+
+
+# ---------------------------------------------------------------------------
+# STATUS_REACTED is a registered lifecycle status.
+# ---------------------------------------------------------------------------
+
+
+def test_status_reacted_is_registered_as_valid():
+    # Arrange
+    from scitex_agent_container._state.dispatch_ledger import (
+        STATUS_REACTED,
+        VALID_STATUSES,
+    )
+
+    # Act
+    is_valid = STATUS_REACTED in VALID_STATUSES
+    # Assert
+    assert is_valid is True
+
+
+def test_record_dispatch_accepts_status_reacted(db_path: Path):
+    # Arrange
+    from scitex_agent_container._state.dispatch_ledger import (
+        STATUS_REACTED,
+        list_dispatches,
+        record_dispatch,
+    )
+
+    # Act
+    record_dispatch(
+        from_agent="alice",
+        to_agent="bob",
+        text="hi",
+        status=STATUS_REACTED,
+    )
+    rows = list_dispatches()
+    # Assert
+    assert rows[0]["status"] == STATUS_REACTED
+
+
+# ---------------------------------------------------------------------------
+# mark_dispatch_reacted — writes STATUS_REACTED on an existing row.
+# ---------------------------------------------------------------------------
+
+
+def test_mark_dispatch_reacted_flips_status_to_reacted(db_path: Path):
+    # Arrange
+    from scitex_agent_container._state.dispatch_ledger import (
+        STATUS_REACTED,
+        list_dispatches,
+        mark_dispatch_reacted,
+        record_dispatch,
+    )
+
+    did = record_dispatch(from_agent="a", to_agent="b", text="hi")
+    # Act
+    mark_dispatch_reacted(did)
+    rows = list_dispatches()
+    # Assert
+    assert rows[0]["status"] == STATUS_REACTED
+
+
+def test_mark_dispatch_reacted_returns_true_on_match(db_path: Path):
+    # Arrange
+    from scitex_agent_container._state.dispatch_ledger import (
+        mark_dispatch_reacted,
+        record_dispatch,
+    )
+
+    did = record_dispatch(from_agent="a", to_agent="b", text="hi")
+    # Act
+    matched = mark_dispatch_reacted(did)
+    # Assert
+    assert matched is True
+
+
+def test_mark_dispatch_reacted_returns_false_on_unknown_id(db_path: Path):
+    # Arrange — a reaction lands for a dispatch this sender never
+    # minted (out-of-order replay, wrong sender, stale ledger). The
+    # return value is the audit signal.
+    from scitex_agent_container._state.dispatch_ledger import (
+        mark_dispatch_reacted,
+    )
+
+    # Act
+    matched = mark_dispatch_reacted("nonexistent-dispatch-id")
+    # Assert
+    assert matched is False
+
+
+def test_mark_dispatch_reacted_is_idempotent(db_path: Path):
+    # Arrange — a duplicate receipt (network retry) must not corrupt
+    # the row. The second call still writes REACTED on REACTED.
+    from scitex_agent_container._state.dispatch_ledger import (
+        STATUS_REACTED,
+        list_dispatches,
+        mark_dispatch_reacted,
+        record_dispatch,
+    )
+
+    did = record_dispatch(from_agent="a", to_agent="b", text="hi")
+    mark_dispatch_reacted(did)
+    # Act
+    mark_dispatch_reacted(did)
+    rows = list_dispatches()
+    # Assert
+    assert rows[0]["status"] == STATUS_REACTED
+
+
+# ---------------------------------------------------------------------------
+# list_unreacted_dispatches — the comm-miss surface.
+# ---------------------------------------------------------------------------
+
+
+def test_list_unreacted_includes_old_sent_rows(db_path: Path):
+    # Arrange — a dispatch minted 60s ago, never REACTED.
+    from scitex_agent_container._state.dispatch_ledger import (
+        list_unreacted_dispatches,
+        record_dispatch,
+    )
+
+    record_dispatch(
+        from_agent="a",
+        to_agent="b",
+        text="hi",
+        ts=time.time() - 60.0,
+    )
+    # Act — SLO is 30s, so the 60s-old row IS overdue.
+    rows = list_unreacted_dispatches(older_than_s=30.0)
+    # Assert
+    assert len(rows) == 1
+
+
+def test_list_unreacted_excludes_fresh_rows_under_slo(db_path: Path):
+    # Arrange — a dispatch minted 5s ago is NOT a miss; the receiver
+    # has not had time to react yet.
+    from scitex_agent_container._state.dispatch_ledger import (
+        list_unreacted_dispatches,
+        record_dispatch,
+    )
+
+    record_dispatch(
+        from_agent="a",
+        to_agent="b",
+        text="hi",
+        ts=time.time() - 5.0,
+    )
+    # Act
+    rows = list_unreacted_dispatches(older_than_s=30.0)
+    # Assert
+    assert rows == []
+
+
+def test_list_unreacted_excludes_reacted_rows(db_path: Path):
+    # Arrange — REACTED is success; it must never appear as a miss.
+    from scitex_agent_container._state.dispatch_ledger import (
+        list_unreacted_dispatches,
+        mark_dispatch_reacted,
+        record_dispatch,
+    )
+
+    did = record_dispatch(
+        from_agent="a",
+        to_agent="b",
+        text="hi",
+        ts=time.time() - 60.0,
+    )
+    mark_dispatch_reacted(did)
+    # Act
+    rows = list_unreacted_dispatches(older_than_s=30.0)
+    # Assert
+    assert rows == []
+
+
+def test_list_unreacted_excludes_failed_rows(db_path: Path):
+    # Arrange — failed rows are ALREADY known not to have landed;
+    # surfacing them in comm-miss is noise.
+    from scitex_agent_container._state.dispatch_ledger import (
+        STATUS_FAILED,
+        list_unreacted_dispatches,
+        record_dispatch,
+    )
+
+    record_dispatch(
+        from_agent="a",
+        to_agent="b",
+        text="hi",
+        status=STATUS_FAILED,
+        ts=time.time() - 60.0,
+    )
+    # Act
+    rows = list_unreacted_dispatches(older_than_s=30.0)
+    # Assert
+    assert rows == []
+
+
+def test_list_unreacted_narrows_by_to_agent(db_path: Path):
+    # Arrange — two stale rows, one to bob, one to carol. Filter to
+    # bob only.
+    from scitex_agent_container._state.dispatch_ledger import (
+        list_unreacted_dispatches,
+        record_dispatch,
+    )
+
+    record_dispatch(from_agent="a", to_agent="bob", text="hi", ts=time.time() - 60.0)
+    record_dispatch(from_agent="a", to_agent="carol", text="hi", ts=time.time() - 60.0)
+    # Act
+    rows = list_unreacted_dispatches(older_than_s=30.0, to_agent="bob")
+    # Assert
+    assert len(rows) == 1


### PR DESCRIPTION
## Summary

Operator mandate (lead a2a `1781e82a`, 2026-06-14): "when an agent receives an a2a/telegram directive, it auto-reacts (eyes/check) so the sender KNOWS it landed — absence of the reaction = comm miss, detectable."

The legacy stage-2 auto-ack is contentless and the sender-side noise filter drops it before the wire, so the SENDER currently has no durable signal that a delivery actually landed in the recipient's session. This PR adds a parallel STRUCTURAL receipt that DOES reach the wire.

### What lands

- **\`_mcp/_channel_reaction_ack.py\`** — posts a \`kind=\"reaction\"\` envelope with a non-empty 👀 marker back to the sender, threading the original \`dispatch_id\` through \`metadata.extra.reacted_dispatch_id\`. Loop guards skip reactions / acks / system synthetics; env gates \`SAC_REACTION_ACK\` (default on) and \`SAC_REACTION_ACK_MARKER\` (default 👀).
- **\`_mcp/_channel_post_deliver.py\`** — composes the legacy auto-ack + structural reaction-ack as a single post-delivery dispatcher (extracted from \`channel.py\` to stay under the module size cap; reuses the existing per-sender rate cap).
- **\`_mcp/channel.py\`** — sender-side absorption: a \`kind=\"reaction\"\` event updates the dispatch ledger to \`STATUS_REACTED\` and skips session injection (receipts are a wire signal, not a user-visible message).
- **\`_state/dispatch_ledger.py\`** — \`STATUS_REACTED\` lifecycle status, \`mark_dispatch_reacted\` writer, \`list_unreacted_dispatches(older_than_s=...)\` query — the comm-miss surface.
- **\`_listen/_node_channel.py\`** — forwards \`metadata.extra\` through the publish path so the \`reacted_dispatch_id\` survives the receiver → publish → sender SSE round-trip intact.

### Tests (51 new, no mocks / no monkeypatch on production)

- \`test_dispatch_ledger_reaction.py\` — STATUS_REACTED registration, mark idempotency, comm-miss filtering by SLO/agent (11 tests).
- \`test__channel_reaction_ack.py\` — predicates, env knobs, real \`asyncio.start_server\` HTTP fake, payload sanity, absorption + ledger flip + comm-miss detectability (25 tests).
- \`test_channel_reaction_ack_e2e.py\` — end-to-end through \`_push_channel_event\`: emit on inbound, absorb on reaction, no session injection for receipts, no 👀-on-👀 loop, env gate, dispatch ledger updated (8 tests).
- \`test__channel_post_deliver.py\` — dispatcher composition + early exits (4 tests).
- \`test__node_channel.py\` — \`extra\` forwarding round-trips through the real Starlette app and persists onto channel_events (2 tests added; 7 total).

Three existing \`test_channel.py\` assertions were updated to filter on contentless acks only (the OLD \"no posts on the wire\" contract); the structural reaction now does reach the wire by design, and that intentional new POST is asserted in the dedicated e2e module.

## Test plan

- [ ] CI green on the new test files (\`test_dispatch_ledger_reaction.py\`, \`test__channel_reaction_ack.py\`, \`test_channel_reaction_ack_e2e.py\`, \`test__channel_post_deliver.py\`).
- [ ] CI green on the touched existing tests (\`test_channel.py\`, \`test__node_channel.py\`).
- [ ] Locally: 207 tests across the impacted suites pass in ~72s.
- [ ] Manual: SAC_REACTION_ACK=0 disables the receipt; default behaviour emits exactly one structural \`kind=reaction\` POST per inbound non-ack message.