### PR TITLE
feat(status): surface session.jsonl bytes + last_write + heartbeat_at in status --json

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_session_movement.py
+++ b/src/scitex_agent_container/_lifecycle/_session_movement.py
@@ -1,0 +1,172 @@
+"""Surface session.jsonl movement next to per-agent status JSON.
+
+Operator mandate (lead a2a 1781e82a, 2026-06-14): the lead's
+kick-cycle needs an objective MOVEMENT signal embedded directly in
+``sac agents status --json`` so the supervisor can read "is this
+agent actually producing?" without scraping ``heartbeat.json`` /
+``session.jsonl`` out of band.
+
+The session.jsonl bytes + last write mtime are already written into
+``heartbeat.json`` every beat (see ``_runners._heartbeat_fields``).
+This module promotes those signals — plus the heartbeat ts itself —
+to top-level fields on the per-agent status payload so consumers can
+key off three stable names:
+
+  * ``session_jsonl_bytes`` (int)           — current file size.
+  * ``session_jsonl_last_write`` (ISO-8601) — mtime, RFC 3339 UTC.
+  * ``heartbeat_at`` (ISO-8601)             — last heartbeat ts.
+
+Missing data is reported as ``(0, "")`` / empty string — explicit,
+not ``None``/``null`` — so JSON consumers can drop the key check
+and treat zero-bytes / empty-iso as the canonical "no signal yet".
+
+Why a dedicated helper (and not just splatting ``heartbeat.json``
+keys)? The heartbeat record is the WRITER's view, formatted for
+the heartbeat loop's own bookkeeping (delta bytes, seconds-since-
+last-beat). The status JSON envelope is the READER's view —
+operators and downstream watchers want the simplest possible
+"how big and when last touched" pair, decoupled from heartbeat
+cadence and from any future change in the heartbeat payload shape.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Tuple
+
+__all__ = [
+    "resolve_state_dir",
+    "session_jsonl_movement",
+    "heartbeat_iso",
+    "status_movement_fields",
+]
+
+
+def resolve_state_dir(name: str) -> Path | None:
+    """Resolve the on-disk state dir for ``name`` (or ``None`` if not found).
+
+    Mirrors the resolution that ``_state._meta.transcript._read_sdk_session_state``
+    uses on the read side: project-local scope first (matches
+    ``runtimes.claude_session._project_runtime_root`` on the write
+    side), then the default ``~/.scitex/agent-container/runtime/<name>``
+    fallback.
+
+    Returns ``None`` when neither candidate exists on disk so callers
+    can collapse that to the all-defaults shape without an explicit
+    is-dir check at every call site.
+    """
+    if not name:
+        return None
+    candidates: list[Path] = []
+    try:
+        from scitex_config._ecosystem import local_state
+
+        scope = local_state.find_project_scope("agent-container")
+    except Exception:  # stx-allow: fallback (reason: scitex-config is optional; degrade to home-scope state dir)
+        scope = None
+    if scope is not None:
+        candidates.append(scope / "runtime" / name)
+    try:
+        from .._runners import claude_session as _runner
+
+        candidates.append(_runner.state_dir_for(name))
+    except Exception:  # stx-allow: fallback (reason: runner module import may fail in partial installs — home-scope candidate alone is enough)
+        pass
+    for candidate in candidates:
+        try:
+            if candidate.is_dir():
+                return candidate
+        except OSError:
+            continue
+    return None
+
+
+def session_jsonl_movement(state_dir: Path | str) -> Tuple[int, str]:
+    """Return ``(bytes, last_write_iso)`` for ``<state_dir>/session.jsonl``.
+
+    ``bytes`` is the current file size in bytes. ``last_write_iso`` is
+    the file's mtime as an ISO-8601 UTC timestamp (``YYYY-MM-DDTHH:MM:SS+00:00``).
+
+    Missing / unreadable file → ``(0, "")``. Explicit empty string —
+    NOT ``None``/``null`` — so callers serialising into JSON don't
+    have to special-case missing-data per field.
+
+    Best-effort: every IO failure (permission-denied, race with
+    rotate, etc.) degrades to ``(0, "")`` so the status command
+    never crashes on a movement-probe hiccup.
+    """
+    if not state_dir:
+        return 0, ""
+    path = Path(state_dir) / "session.jsonl"
+    try:
+        st = path.stat()
+    except OSError:
+        return 0, ""
+    size = int(getattr(st, "st_size", 0) or 0)
+    try:
+        iso = (
+            datetime.fromtimestamp(st.st_mtime, tz=timezone.utc).isoformat()
+            if st.st_mtime
+            else ""
+        )
+    except (OSError, OverflowError, ValueError):
+        iso = ""
+    return size, iso
+
+
+def heartbeat_iso(state_dir: Path | str) -> str:
+    """Return the last heartbeat ts as ISO-8601, or ``""`` if absent.
+
+    Reads ``<state_dir>/heartbeat.json`` and converts the ``ts``
+    (unix seconds, as written by ``_session_state.write_heartbeat``)
+    to an RFC-3339 UTC string. Best-effort: any read or decode
+    failure degrades to the empty string so the status command
+    never crashes on a heartbeat-probe hiccup.
+
+    Returns an empty string (NOT ``None``) so JSON consumers can
+    treat the field as "always present, never null".
+    """
+    if not state_dir:
+        return ""
+    path = Path(state_dir) / "heartbeat.json"
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+    if not text:
+        return ""
+    import json as _json
+
+    try:
+        payload = _json.loads(text)
+    except (ValueError, TypeError):
+        return ""
+    ts = payload.get("ts") if isinstance(payload, dict) else None
+    if not isinstance(ts, (int, float)) or ts <= 0:
+        return ""
+    try:
+        return datetime.fromtimestamp(float(ts), tz=timezone.utc).isoformat()
+    except (OSError, OverflowError, ValueError):
+        return ""
+
+
+def status_movement_fields(state_dir: Path | str | None) -> dict:
+    """Build the three-key status JSON envelope additive block.
+
+    Returns a dict with ``session_jsonl_bytes``, ``session_jsonl_last_write``,
+    and ``heartbeat_at`` populated from the agent's state dir. All
+    three keys are always present — missing data renders as ``0`` or
+    ``""`` so the schema stays stable across the registered / not-yet-
+    started / running transitions.
+
+    ``state_dir=None`` (no resolvable state dir, e.g. cross-host
+    instance) yields the all-defaults shape — same three keys with
+    the explicit empty values.
+    """
+    bytes_, last_write = session_jsonl_movement(state_dir or "")
+    return {
+        "session_jsonl_bytes": int(bytes_),
+        "session_jsonl_last_write": last_write,
+        "heartbeat_at": heartbeat_iso(state_dir or ""),
+    }

--- a/src/scitex_agent_container/_lifecycle/_status.py
+++ b/src/scitex_agent_container/_lifecycle/_status.py
@@ -224,6 +224,32 @@ def agent_status(
         # Never let metadata collection break status.
         pass
 
+    # Operator mandate (lead a2a 1781e82a, 2026-06-14): surface
+    # ``session_jsonl_bytes`` / ``session_jsonl_last_write`` /
+    # ``heartbeat_at`` at the TOP level of the status JSON so the
+    # kick-cycle can read MOVEMENT objectively without scraping
+    # ``heartbeat.json`` or walking the SDK ``sdk_session`` block.
+    # All three keys are always present; missing-data renders as
+    # ``0`` / ``""`` (explicit empty values, NOT null) so consumers
+    # never need a key-existence check.
+    # stx-allow: fallback (reason: a state-dir read failure should never break
+    # the status command — degrade to the explicit empty shape)
+    try:
+        from ._session_movement import resolve_state_dir, status_movement_fields
+
+        state_dir = resolve_state_dir(name)
+        movement = status_movement_fields(state_dir)
+    except Exception:  # stx-allow: fallback (reason: catch-all safety net — see inline comment for context)
+        movement = {
+            "session_jsonl_bytes": 0,
+            "session_jsonl_last_write": "",
+            "heartbeat_at": "",
+        }
+    for k, v in movement.items():
+        # Don't overwrite a field that a prior enrich step already set —
+        # the additive contract says NEW keys, not "always replaces".
+        result.setdefault(k, v)
+
     return result
 
 

--- a/src/scitex_agent_container/cli_pkg/_helpers/_agent_list.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers/_agent_list.py
@@ -60,6 +60,36 @@ def _safe_account_for(cfg) -> str:
         return "unknown"
 
 
+def _movement_fields(name: str) -> dict:
+    """Return the three movement keys for ``name`` (always all-present).
+
+    Operator mandate (lead a2a 1781e82a, 2026-06-14): the fleet view's
+    per-agent rows must carry the same ``session_jsonl_bytes`` /
+    ``session_jsonl_last_write`` / ``heartbeat_at`` trio that the
+    per-agent ``agent_status`` payload exposes, so a single fleet
+    ``--json`` read answers "is each agent producing?".
+
+    Tolerant: any state-dir resolution / IO failure degrades to the
+    all-defaults shape (zero bytes + empty ISO strings) so the list
+    command never crashes on a movement-probe hiccup.
+    """
+    # stx-allow: fallback (reason: list output must never crash on a
+    # state-dir probe hiccup; explicit empty-values shape is the right UX.)
+    try:
+        from ..._lifecycle._session_movement import (
+            resolve_state_dir,
+            status_movement_fields,
+        )
+
+        return status_movement_fields(resolve_state_dir(name))
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        return {
+            "session_jsonl_bytes": 0,
+            "session_jsonl_last_write": "",
+            "heartbeat_at": "",
+        }
+
+
 def _probe_local(cfg) -> bool | None:
     """Probe an agent's liveness via ContainerRuntime.
 
@@ -273,6 +303,13 @@ def get_agent_list_data(
             # Agents sharing one label share one server-side rate limit.
             "account": _safe_account_for(cfg),
         }
+        # Operator mandate (lead a2a 1781e82a, 2026-06-14): surface
+        # session.jsonl movement + last heartbeat at the per-row level
+        # of ``sac agents status --json`` so the kick-cycle reads
+        # MOVEMENT without scraping the SDK heartbeat.json out of band.
+        # All three keys are always present; missing-data renders as
+        # ``0`` / ``""``.
+        row.update(_movement_fields(name))
         if errors:
             row["validation_errors"] = errors
         if liveness_unknown:
@@ -334,6 +371,7 @@ def get_agent_list_data(
             "a2a_port": _safe_port_for(name),
             "account": _safe_account_for(cfg),
         }
+        row.update(_movement_fields(name))
         if errors:
             row["validation_errors"] = errors
         if labels:

--- a/src/scitex_agent_container/terse.py
+++ b/src/scitex_agent_container/terse.py
@@ -90,6 +90,13 @@ TERSE_STATUS_FIELDS: tuple[str, ...] = (
     "skills_loaded",
     "hostname_canonical",
     "machine",
+    # ---- Operator-mandated MOVEMENT trio (lead a2a 1781e82a, 2026-06-14) ---
+    # Lets the lead's kick-cycle read "is this agent producing?" in one
+    # pass without scraping ``heartbeat.json`` out of band. Always
+    # present in the source payload (``0`` / ``""`` when no state dir).
+    "session_jsonl_bytes",
+    "session_jsonl_last_write",
+    "heartbeat_at",
 )
 
 # Whitelist used by ``scitex-agent-container take-snapshot --json --terse``.

--- a/tests/integration/test_status_json.py
+++ b/tests/integration/test_status_json.py
@@ -816,13 +816,16 @@ def test_terse_projected_size_stays_under_4kb(
     assert len(json.dumps(projected)) < 4096
 
 
-def test_terse_whitelist_pins_34_field_contract() -> None:
-    # Arrange
+def test_terse_whitelist_pins_37_field_contract() -> None:
+    # Arrange — bumped from 34 → 37 when the operator-mandated
+    # MOVEMENT trio (session_jsonl_bytes / session_jsonl_last_write /
+    # heartbeat_at) joined the terse whitelist (lead a2a 1781e82a,
+    # 2026-06-14). Re-pin so a future schema drift is caught.
     from scitex_agent_container.terse import TERSE_STATUS_FIELDS
 
     # Act — import.
     # Assert
-    assert len(TERSE_STATUS_FIELDS) == 34
+    assert len(TERSE_STATUS_FIELDS) == 37
 
 
 def test_terse_projection_covers_whitelist_on_representative_snapshot(

--- a/tests/scitex_agent_container/_lifecycle/test__session_movement.py
+++ b/tests/scitex_agent_container/_lifecycle/test__session_movement.py
@@ -1,0 +1,309 @@
+"""Tests for ``_lifecycle._session_movement``.
+
+Covers the helper used by ``sac agents status --json`` to surface
+``session_jsonl_bytes`` + ``session_jsonl_last_write`` + ``heartbeat_at``
+as top-level keys per the operator mandate (lead a2a 1781e82a,
+2026-06-14). Real ``tmp_path`` directories, no mocks. AAA markers
+on separate lines. One assertion per test (STX-TQ007).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import time
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._lifecycle._session_movement import (
+    heartbeat_iso,
+    resolve_state_dir,
+    session_jsonl_movement,
+    status_movement_fields,
+)
+
+ISO_8601_UTC_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?\+00:00$")
+
+
+# ---------------------------------------------------------------------------
+# session_jsonl_movement
+# ---------------------------------------------------------------------------
+
+
+def test_session_jsonl_movement_returns_zero_bytes_when_missing(tmp_path: Path):
+    # Arrange
+    state_dir = tmp_path / "fresh"
+    state_dir.mkdir()
+    # Act
+    bytes_, _last_write = session_jsonl_movement(state_dir)
+    # Assert
+    assert bytes_ == 0
+
+
+def test_session_jsonl_movement_returns_empty_iso_when_missing(tmp_path: Path):
+    # Arrange
+    state_dir = tmp_path / "fresh"
+    state_dir.mkdir()
+    # Act
+    _bytes, last_write = session_jsonl_movement(state_dir)
+    # Assert
+    assert last_write == ""
+
+
+def test_session_jsonl_movement_returns_real_bytes(tmp_path: Path):
+    # Arrange
+    state_dir = tmp_path / "live"
+    state_dir.mkdir()
+    payload = b'{"type":"user","text":"hi"}\n{"type":"assistant","text":"yo"}\n'
+    (state_dir / "session.jsonl").write_bytes(payload)
+    # Act
+    bytes_, _last_write = session_jsonl_movement(state_dir)
+    # Assert
+    assert bytes_ == len(payload)
+
+
+def test_session_jsonl_movement_returns_iso_8601_utc_mtime(tmp_path: Path):
+    # Arrange
+    state_dir = tmp_path / "live"
+    state_dir.mkdir()
+    jsonl = state_dir / "session.jsonl"
+    jsonl.write_text("{}\n", encoding="utf-8")
+    # Pin mtime to a known unix-ts so we can assert the format AND the value.
+    pinned = 1_750_000_000.0
+    os.utime(jsonl, (pinned, pinned))
+    # Act
+    _bytes, last_write = session_jsonl_movement(state_dir)
+    # Assert
+    assert ISO_8601_UTC_RE.match(last_write) is not None
+
+
+def test_session_jsonl_movement_iso_matches_actual_mtime(tmp_path: Path):
+    # Arrange — pin mtime to a known unix-ts and convert via the same
+    # tz-aware path the helper uses (utc) so the test is deterministic.
+    from datetime import datetime, timezone
+
+    state_dir = tmp_path / "live"
+    state_dir.mkdir()
+    jsonl = state_dir / "session.jsonl"
+    jsonl.write_text("{}\n", encoding="utf-8")
+    pinned = 1_750_000_000.0
+    os.utime(jsonl, (pinned, pinned))
+    expected = datetime.fromtimestamp(pinned, tz=timezone.utc).isoformat()
+    # Act
+    _bytes, last_write = session_jsonl_movement(state_dir)
+    # Assert
+    assert last_write == expected
+
+
+def test_session_jsonl_movement_empty_path_returns_zero(tmp_path: Path):
+    # Arrange
+    state_dir = ""
+    # Act
+    bytes_, _last_write = session_jsonl_movement(state_dir)
+    # Assert
+    assert bytes_ == 0
+
+
+def test_session_jsonl_movement_missing_state_dir_returns_empty_iso(tmp_path: Path):
+    # Arrange — state_dir does not exist at all.
+    state_dir = tmp_path / "ghost"
+    # Act
+    _bytes, last_write = session_jsonl_movement(state_dir)
+    # Assert
+    assert last_write == ""
+
+
+# ---------------------------------------------------------------------------
+# heartbeat_iso
+# ---------------------------------------------------------------------------
+
+
+def test_heartbeat_iso_returns_empty_when_missing(tmp_path: Path):
+    # Arrange
+    state_dir = tmp_path / "fresh"
+    state_dir.mkdir()
+    # Act
+    iso = heartbeat_iso(state_dir)
+    # Assert
+    assert iso == ""
+
+
+def test_heartbeat_iso_returns_iso_8601_for_valid_payload(tmp_path: Path):
+    # Arrange
+    state_dir = tmp_path / "live"
+    state_dir.mkdir()
+    (state_dir / "heartbeat.json").write_text(
+        json.dumps({"ts": 1_750_000_000.0, "pid": 1, "state": "idle"}),
+        encoding="utf-8",
+    )
+    # Act
+    iso = heartbeat_iso(state_dir)
+    # Assert
+    assert ISO_8601_UTC_RE.match(iso) is not None
+
+
+def test_heartbeat_iso_value_matches_expected(tmp_path: Path):
+    # Arrange
+    from datetime import datetime, timezone
+
+    state_dir = tmp_path / "live"
+    state_dir.mkdir()
+    pinned = 1_750_000_000.0
+    (state_dir / "heartbeat.json").write_text(
+        json.dumps({"ts": pinned, "pid": 1, "state": "idle"}),
+        encoding="utf-8",
+    )
+    expected = datetime.fromtimestamp(pinned, tz=timezone.utc).isoformat()
+    # Act
+    iso = heartbeat_iso(state_dir)
+    # Assert
+    assert iso == expected
+
+
+def test_heartbeat_iso_returns_empty_on_corrupt_json(tmp_path: Path):
+    # Arrange
+    state_dir = tmp_path / "live"
+    state_dir.mkdir()
+    (state_dir / "heartbeat.json").write_text("not-json{", encoding="utf-8")
+    # Act
+    iso = heartbeat_iso(state_dir)
+    # Assert
+    assert iso == ""
+
+
+def test_heartbeat_iso_returns_empty_when_ts_missing(tmp_path: Path):
+    # Arrange
+    state_dir = tmp_path / "live"
+    state_dir.mkdir()
+    (state_dir / "heartbeat.json").write_text(
+        json.dumps({"pid": 1, "state": "idle"}),
+        encoding="utf-8",
+    )
+    # Act
+    iso = heartbeat_iso(state_dir)
+    # Assert
+    assert iso == ""
+
+
+# ---------------------------------------------------------------------------
+# status_movement_fields
+# ---------------------------------------------------------------------------
+
+
+def test_status_movement_fields_none_state_dir_returns_all_three_keys():
+    # Arrange — no resolvable state dir at all.
+    # Act
+    fields = status_movement_fields(None)
+    # Assert
+    assert set(fields) == {
+        "session_jsonl_bytes",
+        "session_jsonl_last_write",
+        "heartbeat_at",
+    }
+
+
+def test_status_movement_fields_none_state_dir_bytes_is_zero():
+    # Arrange
+    # Act
+    fields = status_movement_fields(None)
+    # Assert
+    assert fields["session_jsonl_bytes"] == 0
+
+
+def test_status_movement_fields_none_state_dir_last_write_is_empty():
+    # Arrange
+    # Act
+    fields = status_movement_fields(None)
+    # Assert
+    assert fields["session_jsonl_last_write"] == ""
+
+
+def test_status_movement_fields_none_state_dir_heartbeat_at_is_empty():
+    # Arrange
+    # Act
+    fields = status_movement_fields(None)
+    # Assert
+    assert fields["heartbeat_at"] == ""
+
+
+def test_status_movement_fields_populated_for_live_state_dir(tmp_path: Path):
+    # Arrange
+    state_dir = tmp_path / "live"
+    state_dir.mkdir()
+    (state_dir / "session.jsonl").write_text("hello\n", encoding="utf-8")
+    (state_dir / "heartbeat.json").write_text(
+        json.dumps({"ts": time.time(), "pid": 1, "state": "idle"}),
+        encoding="utf-8",
+    )
+    # Act
+    fields = status_movement_fields(state_dir)
+    # Assert
+    assert fields["session_jsonl_bytes"] == len(b"hello\n")
+
+
+def test_status_movement_fields_live_state_dir_heartbeat_is_iso(tmp_path: Path):
+    # Arrange
+    state_dir = tmp_path / "live"
+    state_dir.mkdir()
+    (state_dir / "heartbeat.json").write_text(
+        json.dumps({"ts": 1_750_000_000.0, "pid": 1, "state": "working"}),
+        encoding="utf-8",
+    )
+    # Act
+    fields = status_movement_fields(state_dir)
+    # Assert
+    assert ISO_8601_UTC_RE.match(fields["heartbeat_at"]) is not None
+
+
+# ---------------------------------------------------------------------------
+# resolve_state_dir
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_runtime_root(tmp_path: Path, env_save_restore):
+    """Redirect the default runtime root to ``tmp_path/runtime`` via env var
+    and reload the ``_session_state`` module so its module-level
+    ``DEFAULT_STATE_ROOT`` picks up the new value. Real reload, no monkeypatch.
+    """
+    import importlib
+
+    runtime_root = tmp_path / "runtime"
+    runtime_root.mkdir()
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_RUNTIME_DIR", str(runtime_root))
+    import scitex_agent_container._runners._session_state as _ss
+
+    importlib.reload(_ss)
+    return runtime_root
+
+
+def test_resolve_state_dir_returns_none_when_empty_name():
+    # Arrange
+    # Act
+    resolved = resolve_state_dir("")
+    # Assert
+    assert resolved is None
+
+
+def test_resolve_state_dir_finds_home_scope_when_dir_present(
+    isolated_runtime_root: Path,
+):
+    # Arrange
+    name = "movement-test-agent"
+    (isolated_runtime_root / name).mkdir()
+    # Act
+    resolved = resolve_state_dir(name)
+    # Assert
+    assert resolved == isolated_runtime_root / name
+
+
+def test_resolve_state_dir_returns_none_when_no_candidate_exists(
+    isolated_runtime_root: Path,
+):
+    # Arrange — no per-agent dir was created.
+    # Act
+    resolved = resolve_state_dir("never-created-agent")
+    # Assert
+    assert resolved is None

--- a/tests/scitex_agent_container/_lifecycle/test__status_movement.py
+++ b/tests/scitex_agent_container/_lifecycle/test__status_movement.py
@@ -1,0 +1,221 @@
+"""Tests for the session-movement fields on ``agent_status`` payload.
+
+Operator mandate (lead a2a 1781e82a, 2026-06-14): the per-agent
+``sac agents status <name> --json`` envelope must carry
+``session_jsonl_bytes`` / ``session_jsonl_last_write`` / ``heartbeat_at``
+as top-level keys so the kick-cycle reads MOVEMENT directly.
+
+Real registry / real config / real ``ClaudeSessionRuntime`` (no
+container running → ``is_running=False``); no mocks. AAA markers on
+separate lines; one assertion per test (STX-TQ007).
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def isolated_runtime(tmp_path: Path, env_save_restore):
+    """Redirect the runtime root + reload ``_session_state`` so the
+    helper's ``state_dir_for(name)`` lookup lands inside ``tmp_path``.
+    """
+    root = tmp_path / "runtime"
+    root.mkdir()
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_RUNTIME_DIR", str(root))
+    import scitex_agent_container._runners._session_state as _ss
+
+    importlib.reload(_ss)
+    return root
+
+
+@pytest.fixture
+def isolated_registry(tmp_path: Path):
+    """Real ``Registry`` rooted in ``tmp_path/reg``."""
+    from scitex_agent_container._state.registry import Registry
+
+    return Registry(registry_dir=tmp_path / "reg")
+
+
+def _write_valid_spec(parent: Path, name: str) -> Path:
+    agent_dir = parent / name
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    spec = agent_dir / "spec.yaml"
+    spec.write_text(
+        "apiVersion: scitex-agent-container/v3\n"
+        "kind: Agent\n"
+        "metadata: {}\n"
+        "spec:\n"
+        "  runtime: apptainer\n"
+    )
+    return spec
+
+
+def test_status_payload_includes_session_jsonl_bytes_key(
+    tmp_path: Path, isolated_runtime: Path, isolated_registry
+):
+    # Arrange
+    from scitex_agent_container._lifecycle._status import agent_status
+
+    spec = _write_valid_spec(tmp_path, "alpha")
+    isolated_registry.add("alpha", str(spec), "cld-alpha")
+    # Act
+    result = agent_status("alpha", registry=isolated_registry)
+    # Assert
+    assert "session_jsonl_bytes" in result
+
+
+def test_status_payload_includes_session_jsonl_last_write_key(
+    tmp_path: Path, isolated_runtime: Path, isolated_registry
+):
+    # Arrange
+    from scitex_agent_container._lifecycle._status import agent_status
+
+    spec = _write_valid_spec(tmp_path, "alpha")
+    isolated_registry.add("alpha", str(spec), "cld-alpha")
+    # Act
+    result = agent_status("alpha", registry=isolated_registry)
+    # Assert
+    assert "session_jsonl_last_write" in result
+
+
+def test_status_payload_includes_heartbeat_at_key(
+    tmp_path: Path, isolated_runtime: Path, isolated_registry
+):
+    # Arrange
+    from scitex_agent_container._lifecycle._status import agent_status
+
+    spec = _write_valid_spec(tmp_path, "alpha")
+    isolated_registry.add("alpha", str(spec), "cld-alpha")
+    # Act
+    result = agent_status("alpha", registry=isolated_registry)
+    # Assert
+    assert "heartbeat_at" in result
+
+
+def test_status_payload_session_jsonl_bytes_zero_when_no_state_dir(
+    tmp_path: Path, isolated_runtime: Path, isolated_registry
+):
+    # Arrange — no state dir was materialised under ``isolated_runtime``.
+    from scitex_agent_container._lifecycle._status import agent_status
+
+    spec = _write_valid_spec(tmp_path, "alpha")
+    isolated_registry.add("alpha", str(spec), "cld-alpha")
+    # Act
+    result = agent_status("alpha", registry=isolated_registry)
+    # Assert
+    assert result["session_jsonl_bytes"] == 0
+
+
+def test_status_payload_session_jsonl_last_write_empty_when_no_state_dir(
+    tmp_path: Path, isolated_runtime: Path, isolated_registry
+):
+    # Arrange
+    from scitex_agent_container._lifecycle._status import agent_status
+
+    spec = _write_valid_spec(tmp_path, "alpha")
+    isolated_registry.add("alpha", str(spec), "cld-alpha")
+    # Act
+    result = agent_status("alpha", registry=isolated_registry)
+    # Assert
+    assert result["session_jsonl_last_write"] == ""
+
+
+def test_status_payload_heartbeat_at_empty_when_no_state_dir(
+    tmp_path: Path, isolated_runtime: Path, isolated_registry
+):
+    # Arrange
+    from scitex_agent_container._lifecycle._status import agent_status
+
+    spec = _write_valid_spec(tmp_path, "alpha")
+    isolated_registry.add("alpha", str(spec), "cld-alpha")
+    # Act
+    result = agent_status("alpha", registry=isolated_registry)
+    # Assert
+    assert result["heartbeat_at"] == ""
+
+
+def test_status_payload_session_jsonl_bytes_matches_real_file_size(
+    tmp_path: Path, isolated_runtime: Path, isolated_registry
+):
+    # Arrange — state dir + real session.jsonl + heartbeat.json on disk.
+    from scitex_agent_container._lifecycle._status import agent_status
+
+    spec = _write_valid_spec(tmp_path, "live")
+    isolated_registry.add("live", str(spec), "cld-live")
+    state_dir = isolated_runtime / "live"
+    state_dir.mkdir()
+    payload = b'{"type":"assistant","text":"alive"}\n'
+    (state_dir / "session.jsonl").write_bytes(payload)
+    (state_dir / "heartbeat.json").write_text(
+        json.dumps({"ts": time.time(), "pid": 1, "state": "idle"}),
+        encoding="utf-8",
+    )
+    # Act
+    result = agent_status("live", registry=isolated_registry)
+    # Assert
+    assert result["session_jsonl_bytes"] == len(payload)
+
+
+def test_status_payload_heartbeat_at_non_empty_when_heartbeat_present(
+    tmp_path: Path, isolated_runtime: Path, isolated_registry
+):
+    # Arrange
+    from scitex_agent_container._lifecycle._status import agent_status
+
+    spec = _write_valid_spec(tmp_path, "live2")
+    isolated_registry.add("live2", str(spec), "cld-live2")
+    state_dir = isolated_runtime / "live2"
+    state_dir.mkdir()
+    (state_dir / "heartbeat.json").write_text(
+        json.dumps({"ts": 1_750_000_000.0, "pid": 1, "state": "working"}),
+        encoding="utf-8",
+    )
+    # Act
+    result = agent_status("live2", registry=isolated_registry)
+    # Assert
+    assert result["heartbeat_at"] != ""
+
+
+def test_status_payload_session_jsonl_last_write_iso_format_when_file_present(
+    tmp_path: Path, isolated_runtime: Path, isolated_registry
+):
+    # Arrange
+    import re
+
+    from scitex_agent_container._lifecycle._status import agent_status
+
+    spec = _write_valid_spec(tmp_path, "live3")
+    isolated_registry.add("live3", str(spec), "cld-live3")
+    state_dir = isolated_runtime / "live3"
+    state_dir.mkdir()
+    jsonl = state_dir / "session.jsonl"
+    jsonl.write_text("{}\n", encoding="utf-8")
+    pinned = 1_750_000_000.0
+    os.utime(jsonl, (pinned, pinned))
+    iso_re = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?\+00:00$")
+    # Act
+    result = agent_status("live3", registry=isolated_registry)
+    # Assert
+    assert iso_re.match(result["session_jsonl_last_write"]) is not None
+
+
+def test_status_payload_existing_keys_remain_after_movement_enrichment(
+    tmp_path: Path, isolated_runtime: Path, isolated_registry
+):
+    # Arrange — additive contract: legacy fields like name / status /
+    # hooks_configured must still be present alongside the new keys.
+    from scitex_agent_container._lifecycle._status import agent_status
+
+    spec = _write_valid_spec(tmp_path, "compat")
+    isolated_registry.add("compat", str(spec), "cld-compat")
+    # Act
+    result = agent_status("compat", registry=isolated_registry)
+    # Assert
+    assert set(("name", "status", "hooks_configured", "listen")) <= set(result)

--- a/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list_movement.py
+++ b/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list_movement.py
@@ -1,0 +1,262 @@
+"""Tests for the session-movement fields on ``get_agent_list_data`` rows.
+
+Operator mandate (lead a2a 1781e82a, 2026-06-14): each per-agent
+row in the ``sac agents status --json`` fleet view must carry
+``session_jsonl_bytes`` / ``session_jsonl_last_write`` / ``heartbeat_at``
+as top-level keys so the kick-cycle can read MOVEMENT without
+scraping ``heartbeat.json`` out of band.
+
+Real ``tmp_path`` directories, no mocks; AAA markers on separate
+lines; one assertion per test (STX-TQ007).
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def isolated_runtime(tmp_path: Path, env_save_restore):
+    """Redirect the runtime root + reload ``_session_state`` so
+    ``DEFAULT_STATE_ROOT`` picks up the redirected value. Real reload,
+    no monkeypatch.
+    """
+    root = tmp_path / "runtime"
+    root.mkdir()
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_RUNTIME_DIR", str(root))
+    import scitex_agent_container._runners._session_state as _ss
+
+    importlib.reload(_ss)
+    return root
+
+
+class _FakeRegistry:
+    """Hand-rolled stand-in for ``Registry`` — same shape, no MagicMock."""
+
+    def __init__(self, entries: list[dict]) -> None:
+        self._entries = entries
+
+    def list_all(self) -> list[dict]:
+        return list(self._entries)
+
+
+def _write_valid_spec(dir_: Path) -> Path:
+    dir_.mkdir(parents=True, exist_ok=True)
+    spec = dir_ / "spec.yaml"
+    spec.write_text(
+        "apiVersion: scitex-agent-container/v3\n"
+        "kind: Agent\n"
+        "metadata: {}\n"
+        "spec:\n"
+        "  runtime: apptainer\n"
+    )
+    return spec
+
+
+def _no_discover() -> list[tuple[str, Path]]:
+    return []
+
+
+def _entry(name: str, spec: Path) -> dict:
+    return {
+        "name": name,
+        "screen": f"cld-{name}",
+        "started_at": "2026-06-14T00:00:00Z",
+        "config": str(spec),
+    }
+
+
+def _registered_row(rows: list[dict], name: str) -> dict:
+    return next(r for r in rows if r["name"] == name)
+
+
+def test_row_includes_session_jsonl_bytes_key_when_no_state_dir(
+    tmp_path: Path, isolated_runtime: Path
+):
+    # Arrange
+    import scitex_agent_container.cli_pkg._helpers._agent_list as _al
+
+    spec = _write_valid_spec(tmp_path / "alpha")
+    registry = _FakeRegistry([_entry("alpha", spec)])
+    saved = _al._discover_defined_agents
+    _al._discover_defined_agents = _no_discover  # type: ignore[assignment]
+    try:
+        # Act
+        rows = _al.get_agent_list_data(registry)
+    finally:
+        _al._discover_defined_agents = saved  # type: ignore[assignment]
+    # Assert
+    assert "session_jsonl_bytes" in _registered_row(rows, "alpha")
+
+
+def test_row_includes_session_jsonl_last_write_key_when_no_state_dir(
+    tmp_path: Path, isolated_runtime: Path
+):
+    # Arrange
+    import scitex_agent_container.cli_pkg._helpers._agent_list as _al
+
+    spec = _write_valid_spec(tmp_path / "alpha")
+    registry = _FakeRegistry([_entry("alpha", spec)])
+    saved = _al._discover_defined_agents
+    _al._discover_defined_agents = _no_discover  # type: ignore[assignment]
+    try:
+        # Act
+        rows = _al.get_agent_list_data(registry)
+    finally:
+        _al._discover_defined_agents = saved  # type: ignore[assignment]
+    # Assert
+    assert "session_jsonl_last_write" in _registered_row(rows, "alpha")
+
+
+def test_row_includes_heartbeat_at_key_when_no_state_dir(
+    tmp_path: Path, isolated_runtime: Path
+):
+    # Arrange
+    import scitex_agent_container.cli_pkg._helpers._agent_list as _al
+
+    spec = _write_valid_spec(tmp_path / "alpha")
+    registry = _FakeRegistry([_entry("alpha", spec)])
+    saved = _al._discover_defined_agents
+    _al._discover_defined_agents = _no_discover  # type: ignore[assignment]
+    try:
+        # Act
+        rows = _al.get_agent_list_data(registry)
+    finally:
+        _al._discover_defined_agents = saved  # type: ignore[assignment]
+    # Assert
+    assert "heartbeat_at" in _registered_row(rows, "alpha")
+
+
+def test_row_session_jsonl_bytes_is_zero_when_no_state_dir(
+    tmp_path: Path, isolated_runtime: Path
+):
+    # Arrange
+    import scitex_agent_container.cli_pkg._helpers._agent_list as _al
+
+    spec = _write_valid_spec(tmp_path / "alpha")
+    registry = _FakeRegistry([_entry("alpha", spec)])
+    saved = _al._discover_defined_agents
+    _al._discover_defined_agents = _no_discover  # type: ignore[assignment]
+    try:
+        # Act
+        rows = _al.get_agent_list_data(registry)
+    finally:
+        _al._discover_defined_agents = saved  # type: ignore[assignment]
+    # Assert
+    assert _registered_row(rows, "alpha")["session_jsonl_bytes"] == 0
+
+
+def test_row_session_jsonl_last_write_is_empty_when_no_state_dir(
+    tmp_path: Path, isolated_runtime: Path
+):
+    # Arrange
+    import scitex_agent_container.cli_pkg._helpers._agent_list as _al
+
+    spec = _write_valid_spec(tmp_path / "alpha")
+    registry = _FakeRegistry([_entry("alpha", spec)])
+    saved = _al._discover_defined_agents
+    _al._discover_defined_agents = _no_discover  # type: ignore[assignment]
+    try:
+        # Act
+        rows = _al.get_agent_list_data(registry)
+    finally:
+        _al._discover_defined_agents = saved  # type: ignore[assignment]
+    # Assert
+    assert _registered_row(rows, "alpha")["session_jsonl_last_write"] == ""
+
+
+def test_row_heartbeat_at_is_empty_when_no_state_dir(
+    tmp_path: Path, isolated_runtime: Path
+):
+    # Arrange
+    import scitex_agent_container.cli_pkg._helpers._agent_list as _al
+
+    spec = _write_valid_spec(tmp_path / "alpha")
+    registry = _FakeRegistry([_entry("alpha", spec)])
+    saved = _al._discover_defined_agents
+    _al._discover_defined_agents = _no_discover  # type: ignore[assignment]
+    try:
+        # Act
+        rows = _al.get_agent_list_data(registry)
+    finally:
+        _al._discover_defined_agents = saved  # type: ignore[assignment]
+    # Assert
+    assert _registered_row(rows, "alpha")["heartbeat_at"] == ""
+
+
+def test_row_session_jsonl_bytes_matches_file_size_when_state_dir_present(
+    tmp_path: Path, isolated_runtime: Path
+):
+    # Arrange — materialise a state dir with a real session.jsonl + heartbeat.
+    import scitex_agent_container.cli_pkg._helpers._agent_list as _al
+
+    spec = _write_valid_spec(tmp_path / "live")
+    state_dir = isolated_runtime / "live"
+    state_dir.mkdir()
+    payload = b'{"type":"assistant","text":"ok"}\n'
+    (state_dir / "session.jsonl").write_bytes(payload)
+    (state_dir / "heartbeat.json").write_text(
+        json.dumps({"ts": time.time(), "pid": 1, "state": "idle"}),
+        encoding="utf-8",
+    )
+    registry = _FakeRegistry([_entry("live", spec)])
+    saved = _al._discover_defined_agents
+    _al._discover_defined_agents = _no_discover  # type: ignore[assignment]
+    try:
+        # Act
+        rows = _al.get_agent_list_data(registry)
+    finally:
+        _al._discover_defined_agents = saved  # type: ignore[assignment]
+    # Assert
+    assert _registered_row(rows, "live")["session_jsonl_bytes"] == len(payload)
+
+
+def test_row_heartbeat_at_is_non_empty_when_state_dir_present(
+    tmp_path: Path, isolated_runtime: Path
+):
+    # Arrange
+    import scitex_agent_container.cli_pkg._helpers._agent_list as _al
+
+    spec = _write_valid_spec(tmp_path / "live2")
+    state_dir = isolated_runtime / "live2"
+    state_dir.mkdir()
+    (state_dir / "heartbeat.json").write_text(
+        json.dumps({"ts": 1_750_000_000.0, "pid": 1, "state": "working"}),
+        encoding="utf-8",
+    )
+    registry = _FakeRegistry([_entry("live2", spec)])
+    saved = _al._discover_defined_agents
+    _al._discover_defined_agents = _no_discover  # type: ignore[assignment]
+    try:
+        # Act
+        rows = _al.get_agent_list_data(registry)
+    finally:
+        _al._discover_defined_agents = saved  # type: ignore[assignment]
+    # Assert
+    assert _registered_row(rows, "live2")["heartbeat_at"] != ""
+
+
+def test_row_existing_keys_remain_after_movement_enrichment(
+    tmp_path: Path, isolated_runtime: Path
+):
+    # Arrange — existing-key backward-compat: name/status/path must
+    # still appear next to the new movement keys (additive contract).
+    import scitex_agent_container.cli_pkg._helpers._agent_list as _al
+
+    spec = _write_valid_spec(tmp_path / "compat")
+    registry = _FakeRegistry([_entry("compat", spec)])
+    saved = _al._discover_defined_agents
+    _al._discover_defined_agents = _no_discover  # type: ignore[assignment]
+    try:
+        # Act
+        rows = _al.get_agent_list_data(registry)
+    finally:
+        _al._discover_defined_agents = saved  # type: ignore[assignment]
+    row = _registered_row(rows, "compat")
+    # Assert
+    assert set(("name", "status", "path", "account")) <= set(row)


### PR DESCRIPTION
## Summary

Per operator mandate (lead a2a `1781e82a`, 2026-06-14), the per-agent
status JSON envelope now carries three new TOP-LEVEL keys so the
lead's kick-cycle reads MOVEMENT objectively in one read — no need
to scrape `heartbeat.json` or walk the `sdk_session` block out of
band:

- `session_jsonl_bytes` (int) — current size of `<state_dir>/session.jsonl`
- `session_jsonl_last_write` (ISO-8601 UTC) — file mtime
- `heartbeat_at` (ISO-8601 UTC) — last heartbeat ts

All three are **additive**, **always present** (missing data = `0` / `""`, explicit empties, never `null`), and wired into both:

- `agent_status(name)` — per-agent payload (`sac agents status <name> --json`)
- `get_agent_list_data(...)` — fleet rows (`sac agents status --json`)
- the `--terse` whitelist projection

### Example

```json
{
  "name": "demo-agent",
  "status": "stopped",
  "session_jsonl_bytes": 108,
  "session_jsonl_last_write": "2026-06-14T09:22:34.964268+00:00",
  "heartbeat_at": "2026-06-14T09:22:34.971140+00:00"
}
```

### Files

- **NEW** `src/scitex_agent_container/_lifecycle/_session_movement.py` — helper (state-dir resolver + jsonl/heartbeat reader)
- `src/scitex_agent_container/_lifecycle/_status.py` — promote movement trio into `agent_status` result
- `src/scitex_agent_container/cli_pkg/_helpers/_agent_list.py` — same trio on every fleet row (registered + defined-only)
- `src/scitex_agent_container/terse.py` — add the trio to `TERSE_STATUS_FIELDS`
- `tests/scitex_agent_container/_lifecycle/test__session_movement.py` — 21 helper unit tests
- `tests/scitex_agent_container/_lifecycle/test__status_movement.py` — 10 per-agent envelope tests
- `tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list_movement.py` — 9 fleet-row tests
- `tests/integration/test_status_json.py` — bump terse-whitelist pin 34 → 37

### Coordination

Sibling work on `feat/comm-reaction-ack` / `feat/mutual-heartbeat-watch`
is concurrently in flight. This PR keeps the agents-status JSON envelope
**purely additive** (no rename, no removal) so it merges cleanly with
either of those branches.

## Test plan

- [x] 40 new unit tests pass (`test__session_movement.py` + `test__status_movement.py` + `test__agent_list_movement.py`)
- [x] Existing `tests/scitex_agent_container/cli_pkg/test_status_cmds.py` (42), `_helpers/test__agent_list.py` (31), and `_lifecycle/test_lifecycle.py` (78) all still pass — 151/151
- [x] Existing `tests/integration/test_status_json.py` (129 tests) — terse-pin updated to 37 to match the new whitelist
- [ ] CI green on PR