### PR TITLE
feat(mutual-watch): cross-monitor peer heartbeat + session.jsonl growth

### DIFF
--- a/src/scitex_agent_container/_network/_mutual_watch.py
+++ b/src/scitex_agent_container/_network/_mutual_watch.py
@@ -1,0 +1,314 @@
+"""Mutual heartbeat-watch — bidirectional peer freshness probe.
+
+Operator mandate (lead a2a 1781e82a, 2026-06-14):
+"agents (and lead) cross-monitor heartbeat_at + session.jsonl growth;
+a stale peer raises a STRUCTURAL alert, not a silent drift."
+
+This module owns the pure, stateless decision: "given a peer's
+state-dir snapshot (now + heartbeat.json + session.jsonl stat +
+the prior reading), is the peer stale?" It does NOT touch SQLite,
+spawn threads, or read the registry — those concerns live in the
+caller (the heartbeat-loop integration). Keeping the decision pure
+makes it trivially testable with real fixtures (no mocks).
+
+Two staleness kinds, both addressable independently so the lead can
+distinguish "the peer's whole runner has died" from "the peer is
+heartbeating but produced nothing":
+
+  * ``KIND_STALE_HEARTBEAT`` — ``heartbeat.json`` ``ts`` is older
+    than ``heartbeat_threshold_s`` (default 180 s) against the
+    observer's wall clock. This is the classic "the peer's runner
+    process is wedged or dead" signal.
+  * ``KIND_STALE_SESSION_JSONL`` — heartbeat IS fresh but
+    ``session.jsonl`` has not grown in ``jsonl_idle_threshold_s``
+    (default 300 s) AND ``heartbeat.state`` reports ``"working"``
+    or any non-idle state. This is the "the peer SAYS it is
+    working but produced zero output" signal — the silent drift
+    the operator wanted surfaced.
+
+Mutual = bidirectional: each agent runs the watch over its peers,
+so A → B and B → A independently emit alerts. The "mutual" property
+falls out of the symmetry, not a special pair-mode.
+
+Threshold defaults are tunable through env vars so an operator can
+ratchet them down during a debug sweep without a code change:
+
+  * ``SAC_MUTUAL_WATCH_HEARTBEAT_STALE_S`` (default ``180``).
+  * ``SAC_MUTUAL_WATCH_JSONL_IDLE_S``     (default ``300``).
+
+:func:`load_watch_config` reads them with safe fallbacks (invalid
+float → default) so a typo in the env never wedges the watch.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from .._state.state_db_alerts import (
+    KIND_STALE_HEARTBEAT,
+    KIND_STALE_SESSION_JSONL,
+)
+
+# Defaults are conservative — short enough to catch a wedged
+# runner within a few minutes, long enough to ride out a slow
+# Claude turn without false-positives. Operator overrides via env.
+_DEFAULT_HEARTBEAT_STALE_S = 180.0
+_DEFAULT_JSONL_IDLE_S = 300.0
+
+_ENV_HEARTBEAT_STALE = "SAC_MUTUAL_WATCH_HEARTBEAT_STALE_S"
+_ENV_JSONL_IDLE = "SAC_MUTUAL_WATCH_JSONL_IDLE_S"
+
+
+# Non-idle heartbeat states — when the peer claims one of these
+# but session.jsonl has not moved, that is the silent-drift case
+# the operator wanted surfaced. ``idle`` / ``stopping`` are
+# expected to be quiet so we don't fire on them.
+_NON_IDLE_STATES = frozenset({"working", "starting", "error"})
+
+
+@dataclass(frozen=True)
+class WatchConfig:
+    """Threshold knobs for :func:`check_peer_freshness`.
+
+    Held as a frozen dataclass so a caller can pass the same config
+    object across a batch of peer checks without risk of mutation.
+    Defaults reflect the conservative spec; overrides arrive via
+    :func:`load_watch_config` reading the env vars.
+    """
+
+    heartbeat_threshold_s: float = _DEFAULT_HEARTBEAT_STALE_S
+    jsonl_idle_threshold_s: float = _DEFAULT_JSONL_IDLE_S
+
+
+@dataclass(frozen=True)
+class StalePeerAlert:
+    """Typed alert evidence emitted when a peer fails a freshness check.
+
+    Schema mirrors the ``structural_alerts`` table row so the caller
+    can pass these straight to :func:`state_db_alerts.record_alert`.
+    JSON-serialisable so the lead can read it off ``sac db query``
+    or ``sac a2a status`` without a Python import.
+
+    Fields:
+
+      * ``observer`` / ``peer`` — agent names (who watched / who looks
+        stale).
+      * ``kind`` — one of :data:`KIND_STALE_HEARTBEAT` or
+        :data:`KIND_STALE_SESSION_JSONL`.
+      * ``age_seconds`` — observed age (peer's last beat OR
+        session.jsonl mtime) at the moment of the check.
+      * ``threshold_s`` — the configured limit the age breached.
+      * ``evidence`` — verbatim non-PII snapshot of the proof
+        (peer_state_dir, last_heartbeat_ts, last_session_jsonl_mtime,
+        last_session_jsonl_bytes, peer_state). Encoded into the
+        ``evidence_json`` DB column.
+    """
+
+    observer: str
+    peer: str
+    kind: str
+    age_seconds: float
+    threshold_s: float
+    evidence: dict = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        """Return a plain dict — what the DB writer + JSON consumers expect."""
+        return {
+            "observer": self.observer,
+            "peer": self.peer,
+            "kind": self.kind,
+            "age_seconds": self.age_seconds,
+            "threshold_s": self.threshold_s,
+            "evidence": self.evidence,
+        }
+
+
+def load_watch_config() -> WatchConfig:
+    """Build a :class:`WatchConfig` from env vars, falling back to defaults.
+
+    Invalid float values (typo, empty string) degrade silently to the
+    default — better the watch keeps running with a conservative
+    threshold than wedge on a typo. Negative values are clamped to 0.
+    """
+
+    def _read(name: str, default: float) -> float:
+        raw = os.environ.get(name)
+        if not raw:
+            return default
+        try:
+            value = float(raw)
+        except ValueError:
+            return default
+        return max(0.0, value)
+
+    return WatchConfig(
+        heartbeat_threshold_s=_read(_ENV_HEARTBEAT_STALE, _DEFAULT_HEARTBEAT_STALE_S),
+        jsonl_idle_threshold_s=_read(_ENV_JSONL_IDLE, _DEFAULT_JSONL_IDLE_S),
+    )
+
+
+def _read_peer_heartbeat(peer_state_dir: Path) -> dict | None:
+    """Return the peer's ``heartbeat.json`` dict, or None when unreadable.
+
+    Never raises — a corrupt JSON or missing file degrades to None so
+    the caller treats it as "no recent heartbeat evidence" and fires
+    the stale-heartbeat alert. This mirrors the
+    :func:`_session_state.read_heartbeat` shape.
+    """
+    p = peer_state_dir / "heartbeat.json"
+    try:
+        text = p.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    try:
+        data = json.loads(text)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _peer_session_jsonl_mtime(peer_state_dir: Path) -> tuple[float | None, int | None]:
+    """Return ``(mtime, size_bytes)`` for the peer's ``session.jsonl``.
+
+    Both are ``None`` when the file is absent (peer has never written a
+    turn). Reads stat-only — never opens the file — so a giant transcript
+    does not slow the watch loop.
+    """
+    p = peer_state_dir / "session.jsonl"
+    try:
+        st = p.stat()
+    except OSError:
+        return None, None
+    return float(st.st_mtime), int(st.st_size)
+
+
+def check_peer_freshness(
+    *,
+    observer: str,
+    peer: str,
+    peer_state_dir: Path,
+    now: float,
+    config: WatchConfig | None = None,
+) -> list[StalePeerAlert]:
+    """Probe one peer's state dir and return any structural alerts.
+
+    Returns ``[]`` when the peer is healthy — clean cross-monitor
+    signal. Returns one alert per failed check (heartbeat AND
+    session.jsonl can BOTH fire on a wedged peer that has not
+    beat at all for a long time).
+
+    Two checks:
+
+      1. **Heartbeat freshness** — ``heartbeat.json`` ``ts`` vs
+         ``now``. Missing / corrupt heartbeat → stale-heartbeat
+         alert with ``age_seconds=inf`` semantics expressed as the
+         threshold + 1 (so the evidence field carries "no beat").
+      2. **session.jsonl growth** — only meaningful when the
+         heartbeat IS fresh (otherwise the heartbeat alert covers
+         the case). Fires when ``state`` is non-idle AND
+         ``session.jsonl`` mtime is older than the idle threshold.
+
+    Pure function (no DB writes, no time.time()): the caller passes
+    ``now`` so a test can pin the clock. The caller is also responsible
+    for forwarding each returned alert to
+    :func:`state_db_alerts.record_alert` and for resolving any prior
+    active alert when the peer is now healthy.
+    """
+    cfg = config or load_watch_config()
+    alerts: list[StalePeerAlert] = []
+
+    hb = _read_peer_heartbeat(peer_state_dir)
+    last_hb_ts: float | None = None
+    peer_state: str | None = None
+    if hb is not None:
+        raw_ts = hb.get("ts")
+        if isinstance(raw_ts, (int, float)) and raw_ts > 0:
+            last_hb_ts = float(raw_ts)
+        raw_state = hb.get("state")
+        if isinstance(raw_state, str):
+            peer_state = raw_state
+
+    jsonl_mtime, jsonl_bytes = _peer_session_jsonl_mtime(peer_state_dir)
+
+    # Check 1 — heartbeat freshness. Missing heartbeat counts as
+    # infinitely stale (threshold + a clear sentinel age).
+    if last_hb_ts is None:
+        alerts.append(
+            StalePeerAlert(
+                observer=observer,
+                peer=peer,
+                kind=KIND_STALE_HEARTBEAT,
+                age_seconds=cfg.heartbeat_threshold_s + 1.0,
+                threshold_s=cfg.heartbeat_threshold_s,
+                evidence={
+                    "peer_state_dir": str(peer_state_dir),
+                    "reason": "heartbeat.json missing or unreadable",
+                    "last_heartbeat_ts": None,
+                    "last_session_jsonl_mtime": jsonl_mtime,
+                    "last_session_jsonl_bytes": jsonl_bytes,
+                },
+            )
+        )
+    else:
+        age = max(0.0, now - last_hb_ts)
+        if age > cfg.heartbeat_threshold_s:
+            alerts.append(
+                StalePeerAlert(
+                    observer=observer,
+                    peer=peer,
+                    kind=KIND_STALE_HEARTBEAT,
+                    age_seconds=age,
+                    threshold_s=cfg.heartbeat_threshold_s,
+                    evidence={
+                        "peer_state_dir": str(peer_state_dir),
+                        "last_heartbeat_ts": last_hb_ts,
+                        "peer_state": peer_state,
+                        "last_session_jsonl_mtime": jsonl_mtime,
+                        "last_session_jsonl_bytes": jsonl_bytes,
+                    },
+                )
+            )
+
+    # Check 2 — session.jsonl growth. Only fires when heartbeat is
+    # fresh AND the peer claims a non-idle state but produced nothing.
+    # An idle peer with a quiet transcript is HEALTHY (it correctly
+    # reports it is doing nothing) — we don't punish that.
+    if (
+        last_hb_ts is not None
+        and (now - last_hb_ts) <= cfg.heartbeat_threshold_s
+        and peer_state in _NON_IDLE_STATES
+        and jsonl_mtime is not None
+    ):
+        jsonl_age = max(0.0, now - jsonl_mtime)
+        if jsonl_age > cfg.jsonl_idle_threshold_s:
+            alerts.append(
+                StalePeerAlert(
+                    observer=observer,
+                    peer=peer,
+                    kind=KIND_STALE_SESSION_JSONL,
+                    age_seconds=jsonl_age,
+                    threshold_s=cfg.jsonl_idle_threshold_s,
+                    evidence={
+                        "peer_state_dir": str(peer_state_dir),
+                        "last_heartbeat_ts": last_hb_ts,
+                        "peer_state": peer_state,
+                        "last_session_jsonl_mtime": jsonl_mtime,
+                        "last_session_jsonl_bytes": jsonl_bytes,
+                    },
+                )
+            )
+
+    return alerts
+
+
+__all__ = [
+    "KIND_STALE_HEARTBEAT",
+    "KIND_STALE_SESSION_JSONL",
+    "StalePeerAlert",
+    "WatchConfig",
+    "check_peer_freshness",
+    "load_watch_config",
+]

--- a/src/scitex_agent_container/_network/_mutual_watch_sweep.py
+++ b/src/scitex_agent_container/_network/_mutual_watch_sweep.py
@@ -1,0 +1,146 @@
+"""One-shot peer freshness sweep — orchestrates :mod:`_mutual_watch`.
+
+The pure decision lives in :mod:`_mutual_watch`. This module owns the
+side-effects: enumerate peers, run the check, persist alerts into
+``state_db.structural_alerts``, and resolve any prior-active alerts
+when a peer recovers.
+
+Designed to be called from two places:
+
+  * The heartbeat loop's tick — every N beats the observer agent
+    sweeps its declared peers.
+  * A standalone CLI ``sac fleet watch`` (future) that one-shots a
+    sweep over the registry.
+
+Keeping the sweep stateless (each call enumerates peers fresh,
+resolves stale rows, and emits alerts) means we never have to track
+"which alerts I already fired" in-process — the DB is the only
+source of truth and the upsert semantics in
+:func:`state_db_alerts.record_alert` handle dedup.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from pathlib import Path
+from typing import Iterable
+
+from .._runners._session_state import DEFAULT_STATE_ROOT, state_dir_for
+from .._state import state_db_alerts as _alerts
+from ._mutual_watch import (
+    KIND_STALE_HEARTBEAT,
+    KIND_STALE_SESSION_JSONL,
+    StalePeerAlert,
+    WatchConfig,
+    check_peer_freshness,
+    load_watch_config,
+)
+
+log = logging.getLogger(__name__)
+
+# Both kinds the watch can emit — used to resolve any leftover
+# active row when a peer recovers (every kind that did not fire
+# THIS sweep is clear → resolve it).
+_ALL_KINDS = (KIND_STALE_HEARTBEAT, KIND_STALE_SESSION_JSONL)
+
+
+def sweep_peers(
+    *,
+    observer: str,
+    peer_names: Iterable[str],
+    state_root: Path | None = None,
+    now: float | None = None,
+    config: WatchConfig | None = None,
+    db_path: Path | None = None,
+) -> list[StalePeerAlert]:
+    """Run :func:`check_peer_freshness` against every peer; persist alerts.
+
+    Returns the flat list of alerts emitted this sweep (one per
+    failing check; same peer can produce two kinds). Healthy peers
+    contribute nothing to the list, AND any prior-active alert for
+    that ``(observer, peer, kind)`` is resolved — so a peer that
+    recovers between sweeps does not stay flagged forever.
+
+    Failure isolation: a per-peer exception (e.g. permission denied
+    reading the peer's state dir) is logged but does NOT stop the
+    sweep. The mutual-watch is observability, not the critical
+    path — one broken neighbour must not blind the observer to all
+    its peers.
+
+    ``state_root`` defaults to :data:`_session_state.DEFAULT_STATE_ROOT`
+    so the sweep lives in the same layout the runner writes to.
+    """
+    cfg = config or load_watch_config()
+    ts = float(now) if now is not None else time.time()
+    root = state_root or DEFAULT_STATE_ROOT
+
+    emitted: list[StalePeerAlert] = []
+    for peer in peer_names:
+        if peer == observer:
+            # Skip self — an agent watching itself does not surface
+            # the mutual-monitoring signal the spec asks for.
+            continue
+        peer_dir = state_dir_for(peer, root=root)
+        try:
+            alerts = check_peer_freshness(
+                observer=observer,
+                peer=peer,
+                peer_state_dir=peer_dir,
+                now=ts,
+                config=cfg,
+            )
+        except Exception as exc:  # stx-allow: fallback (reason: observability sweep — one peer's read failure must not block the rest of the sweep; logged at WARNING)
+            log.warning("mutual-watch sweep: peer %r raised %s", peer, exc)
+            continue
+        fired_kinds: set[str] = set()
+        for alert in alerts:
+            fired_kinds.add(alert.kind)
+            try:
+                _alerts.record_alert(
+                    observer=alert.observer,
+                    peer=alert.peer,
+                    kind=alert.kind,
+                    evidence={
+                        **alert.evidence,
+                        "age_seconds": alert.age_seconds,
+                        "threshold_s": alert.threshold_s,
+                    },
+                    now=ts,
+                    db_path=db_path,
+                )
+            except Exception as exc:  # stx-allow: fallback (reason: DB write best-effort during observability sweep; logged at WARNING)
+                log.warning(
+                    "mutual-watch: record_alert(%s, %s, %s) failed: %s",
+                    alert.observer,
+                    alert.peer,
+                    alert.kind,
+                    exc,
+                )
+            emitted.append(alert)
+        # Resolve any kind that did NOT fire this sweep — the peer
+        # has recovered for that check. Idempotent: resolving a
+        # never-fired row is a no-op.
+        for kind in _ALL_KINDS:
+            if kind in fired_kinds:
+                continue
+            try:
+                _alerts.resolve_alert(
+                    observer=observer,
+                    peer=peer,
+                    kind=kind,
+                    now=ts,
+                    db_path=db_path,
+                )
+            except Exception as exc:  # stx-allow: fallback (reason: DB write best-effort during observability sweep; logged at WARNING)
+                log.warning(
+                    "mutual-watch: resolve_alert(%s, %s, %s) failed: %s",
+                    observer,
+                    peer,
+                    kind,
+                    exc,
+                )
+    return emitted
+
+
+__all__ = ["sweep_peers"]

--- a/src/scitex_agent_container/_state/state_db.py
+++ b/src/scitex_agent_container/_state/state_db.py
@@ -343,6 +343,7 @@ KNOWN_TABLES = (
     "comms_nodes",
     "node_comms_policy",
     "acl_deny_notify_log",
+    "structural_alerts",
 )
 
 
@@ -425,6 +426,13 @@ def init_schema(db_path: Path | None = None) -> Path:
         # last-notify timestamp; the check + update lives in
         # :func:`state_db_acl_deny_notify.should_notify_acl_deny`.
         conn.executescript(_adn._SCHEMA)
+        # Mutual heartbeat watch (feat/mutual-heartbeat-watch, 2026-06-14):
+        # structural_alerts table — typed evidence that observer watched
+        # peer and the peer failed a freshness check. Additive; see the
+        # state_db_alerts module docstring for the alert shape.
+        from . import state_db_alerts as _alerts
+
+        _alerts.ensure_schema(conn)
         conn.commit()
     return path
 

--- a/src/scitex_agent_container/_state/state_db_alerts.py
+++ b/src/scitex_agent_container/_state/state_db_alerts.py
@@ -1,0 +1,200 @@
+"""Structural alerts emitted by the mutual heartbeat watch (2026-06-14).
+
+Operator mandate (lead a2a 1781e82a): agents and lead cross-monitor
+each other's ``heartbeat_at`` + ``session.jsonl`` growth so a stale
+peer raises a STRUCTURAL alert (not a silent drift).
+
+A *structural* alert is the typed evidence that ``observer`` watched
+``peer`` and the peer failed a freshness check. Storage shape:
+
+  * ``observer`` — who noticed (the watching agent's name).
+  * ``peer`` — who looks stale (the watched agent's name).
+  * ``kind`` — alert category, e.g. ``"stale_heartbeat"`` /
+    ``"stale_session_jsonl"``. Free-form short string so future
+    kinds (lineage anomaly, cap-marker stuck) drop in without a
+    schema change.
+  * ``first_seen_at`` / ``last_seen_at`` — UNIX seconds (REAL) for
+    de-duplication: re-firing the same triplet bumps ``last_seen_at``
+    and the per-fire counter, NOT a fresh row, so an N-minute stale
+    peer produces ONE alert, not 30 spam rows.
+  * ``hit_count`` — how many beats observed the staleness. ``1`` on
+    first record, ``+=1`` on every subsequent re-fire.
+  * ``resolved_at`` — set by :func:`resolve_alert` when the observer
+    sees the peer recover (heartbeat fresh again). NULL means the
+    alert is still firing.
+  * ``evidence_json`` — verbatim JSON snapshot of the staleness
+    proof (age_seconds, threshold_s, peer_state_path, last hb ts,
+    last session.jsonl mtime / size). Lets the lead read WHY the
+    alert fired without re-running the probe.
+
+The DDL is defined here (not in :mod:`state_db._SCHEMA_REGISTRY`)
+because it is additive and lives on its own migration timeline.
+:func:`state_db.init_schema` calls :func:`ensure_schema` so a fresh
+``state.db`` includes it; existing DBs pick it up on next open.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+from pathlib import Path
+
+# Public table name + canonical kind strings. Kept here so the test
+# suite + CLI consumers (``sac db query --table=structural_alerts``)
+# import one constant rather than re-typing the literal.
+TABLE_NAME = "structural_alerts"
+KIND_STALE_HEARTBEAT = "stale_heartbeat"
+KIND_STALE_SESSION_JSONL = "stale_session_jsonl"
+
+_SCHEMA = f"""
+CREATE TABLE IF NOT EXISTS {TABLE_NAME} (
+    alert_id        INTEGER PRIMARY KEY AUTOINCREMENT,
+    observer        TEXT NOT NULL,
+    peer            TEXT NOT NULL,
+    kind            TEXT NOT NULL,
+    first_seen_at   REAL NOT NULL,
+    last_seen_at    REAL NOT NULL,
+    hit_count       INTEGER NOT NULL DEFAULT 1,
+    resolved_at     REAL,
+    evidence_json   TEXT,
+    UNIQUE (observer, peer, kind, resolved_at)
+);
+CREATE INDEX IF NOT EXISTS idx_structural_alerts_active
+    ON {TABLE_NAME}(observer, peer, kind) WHERE resolved_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_structural_alerts_peer
+    ON {TABLE_NAME}(peer);
+"""
+
+
+def ensure_schema(conn: sqlite3.Connection) -> None:
+    """Idempotently create the ``structural_alerts`` table + indexes.
+
+    Called from :func:`state_db.init_schema` so a fresh ``state.db``
+    carries the table without a separate migration step. Safe to call
+    against an already-initialised DB — every statement is ``IF NOT
+    EXISTS`` guarded.
+    """
+    conn.executescript(_SCHEMA)
+
+
+def record_alert(
+    *,
+    observer: str,
+    peer: str,
+    kind: str,
+    evidence: dict | None = None,
+    now: float | None = None,
+    db_path: Path | None = None,
+) -> int:
+    """Upsert one structural alert. Returns the row's ``alert_id``.
+
+    Deduplication: the active row for ``(observer, peer, kind)`` —
+    i.e. ``resolved_at IS NULL`` — is bumped (``last_seen_at`` +
+    ``hit_count``) instead of inserting a fresh one. This prevents
+    an N-minute stale peer from producing 30 noise rows.
+
+    ``evidence`` is JSON-encoded and stamped onto the new/updated row
+    so the lead can read WHY the alert fired (age vs threshold, last
+    hb timestamp, peer_state_path) without re-running the probe.
+    """
+    from .state_db import open_db
+
+    ts = float(now) if now is not None else time.time()
+    payload = json.dumps(evidence or {}, ensure_ascii=False, sort_keys=True)
+    with open_db(db_path) as conn:
+        ensure_schema(conn)
+        row = conn.execute(
+            f"SELECT alert_id, hit_count FROM {TABLE_NAME} "
+            "WHERE observer=? AND peer=? AND kind=? AND resolved_at IS NULL",
+            (observer, peer, kind),
+        ).fetchone()
+        if row is not None:
+            new_count = int(row["hit_count"]) + 1
+            conn.execute(
+                f"UPDATE {TABLE_NAME} SET last_seen_at=?, hit_count=?, "
+                "evidence_json=? WHERE alert_id=?",
+                (ts, new_count, payload, row["alert_id"]),
+            )
+            return int(row["alert_id"])
+        cur = conn.execute(
+            f"INSERT INTO {TABLE_NAME} "
+            "(observer, peer, kind, first_seen_at, last_seen_at, "
+            "hit_count, evidence_json) "
+            "VALUES (?, ?, ?, ?, ?, 1, ?)",
+            (observer, peer, kind, ts, ts, payload),
+        )
+        return int(cur.lastrowid or 0)
+
+
+def resolve_alert(
+    *,
+    observer: str,
+    peer: str,
+    kind: str,
+    now: float | None = None,
+    db_path: Path | None = None,
+) -> bool:
+    """Mark the active alert for ``(observer, peer, kind)`` resolved.
+
+    Returns True iff an active row existed and was updated. Idempotent:
+    resolving an already-resolved or never-fired triplet is a no-op
+    returning False — callers can splat this on every healthy beat
+    without checking first.
+    """
+    from .state_db import open_db
+
+    ts = float(now) if now is not None else time.time()
+    with open_db(db_path) as conn:
+        ensure_schema(conn)
+        cur = conn.execute(
+            f"UPDATE {TABLE_NAME} SET resolved_at=? "
+            "WHERE observer=? AND peer=? AND kind=? AND resolved_at IS NULL",
+            (ts, observer, peer, kind),
+        )
+        return cur.rowcount > 0
+
+
+def list_active_alerts(
+    *,
+    observer: str | None = None,
+    peer: str | None = None,
+    db_path: Path | None = None,
+) -> list[dict]:
+    """Return every unresolved structural alert, optionally filtered.
+
+    Empty list when nothing has fired — the lead reads this as the
+    cross-monitor heartbeat is clean. Rows include the verbatim
+    ``evidence_json`` blob so the consumer can render the staleness
+    proof without a second query.
+    """
+    from .state_db import open_db
+
+    clauses: list[str] = ["resolved_at IS NULL"]
+    params: list[object] = []
+    if observer is not None:
+        clauses.append("observer=?")
+        params.append(observer)
+    if peer is not None:
+        clauses.append("peer=?")
+        params.append(peer)
+    sql = (
+        f"SELECT * FROM {TABLE_NAME} WHERE "
+        + " AND ".join(clauses)
+        + " ORDER BY last_seen_at DESC"
+    )
+    with open_db(db_path) as conn:
+        ensure_schema(conn)
+        rows = conn.execute(sql, params).fetchall()
+        return [dict(r) for r in rows]
+
+
+__all__ = [
+    "KIND_STALE_HEARTBEAT",
+    "KIND_STALE_SESSION_JSONL",
+    "TABLE_NAME",
+    "ensure_schema",
+    "list_active_alerts",
+    "record_alert",
+    "resolve_alert",
+]

--- a/src/scitex_agent_container/_state/state_db_export.py
+++ b/src/scitex_agent_container/_state/state_db_export.py
@@ -82,6 +82,10 @@ def _table_filter_clauses(
         # acl_deny_notify_log — rate-limit ledger keyed on (sender, target);
         # the ts-equivalent column is ``last_notified_at`` (REAL).
         "acl_deny_notify_log": ("WHERE last_notified_at >= ?", (since,)),
+        # structural_alerts (feat/mutual-heartbeat-watch, 2026-06-14) —
+        # advance on ``last_seen_at`` so a still-firing dedup'd alert
+        # ships on every subsequent pull (the ts column is REAL).
+        "structural_alerts": ("WHERE last_seen_at >= ?", (since,)),
     }
     return {t: explicit.get(t, ("WHERE ts >= ?", (since,))) for t in known_tables}
 

--- a/tests/scitex_agent_container/_network/test__mutual_watch.py
+++ b/tests/scitex_agent_container/_network/test__mutual_watch.py
@@ -1,0 +1,336 @@
+"""Tests for the mutual heartbeat-watch decision logic.
+
+Operator mandate (lead a2a 1781e82a, 2026-06-14): agents cross-monitor
+each other's heartbeat_at + session.jsonl growth; a stale peer raises
+a STRUCTURAL alert.
+
+These tests cover the pure :func:`check_peer_freshness` decision —
+no DB, no threads, no mocks. Each test builds a real peer state dir
+with real heartbeat.json + session.jsonl files and pins the clock to
+a known float so the assertion is exact.
+
+Conventions:
+
+  * AAA marker comments (Arrange / Act / Assert) on separate lines.
+  * One assertion per test (STX-TQ007); related invariants split
+    into dedicated tests.
+  * No mocks / monkeypatch — only real files + pinned ``now``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._network._mutual_watch import (
+    KIND_STALE_HEARTBEAT,
+    KIND_STALE_SESSION_JSONL,
+    WatchConfig,
+    check_peer_freshness,
+    load_watch_config,
+)
+
+# ---------------------------------------------------------------------------
+# Test helpers — real-file fixture builders. No mocks, no monkeypatch.
+# ---------------------------------------------------------------------------
+
+
+def _write_heartbeat(state_dir: Path, ts: float, state: str = "working") -> None:
+    """Write a real heartbeat.json with the given ts + state."""
+    state_dir.mkdir(parents=True, exist_ok=True)
+    (state_dir / "heartbeat.json").write_text(
+        json.dumps({"ts": ts, "pid": 1234, "state": state}),
+        encoding="utf-8",
+    )
+
+
+def _write_session_jsonl(state_dir: Path, mtime: float, content: str = "x\n") -> None:
+    """Write a session.jsonl and pin its mtime to a known wall-clock."""
+    state_dir.mkdir(parents=True, exist_ok=True)
+    p = state_dir / "session.jsonl"
+    p.write_text(content, encoding="utf-8")
+    os.utime(p, (mtime, mtime))
+
+
+# ---------------------------------------------------------------------------
+# Threshold defaults — the spec's "configurable threshold" acceptance.
+# ---------------------------------------------------------------------------
+
+
+def test_watch_config_default_heartbeat_threshold_is_180s():
+    # Arrange / Act
+    cfg = WatchConfig()
+    # Assert — operator-tunable default per module docstring.
+    assert cfg.heartbeat_threshold_s == 180.0
+
+
+def test_watch_config_default_jsonl_idle_threshold_is_300s():
+    # Arrange / Act
+    cfg = WatchConfig()
+    # Assert
+    assert cfg.jsonl_idle_threshold_s == 300.0
+
+
+def test_load_watch_config_honours_env_override_for_heartbeat(env_setter):
+    # Arrange
+    env_setter("SAC_MUTUAL_WATCH_HEARTBEAT_STALE_S", "42")
+    # Act
+    cfg = load_watch_config()
+    # Assert — operator override mechanism: env var takes precedence.
+    assert cfg.heartbeat_threshold_s == 42.0
+
+
+def test_load_watch_config_honours_env_override_for_jsonl(env_setter):
+    # Arrange
+    env_setter("SAC_MUTUAL_WATCH_JSONL_IDLE_S", "7")
+    # Act
+    cfg = load_watch_config()
+    # Assert
+    assert cfg.jsonl_idle_threshold_s == 7.0
+
+
+def test_load_watch_config_invalid_env_value_falls_back_to_default(env_setter):
+    # Arrange — a typo'd value must not wedge the watch loop.
+    env_setter("SAC_MUTUAL_WATCH_HEARTBEAT_STALE_S", "not-a-number")
+    # Act
+    cfg = load_watch_config()
+    # Assert — conservative default wins over the broken override.
+    assert cfg.heartbeat_threshold_s == 180.0
+
+
+# ---------------------------------------------------------------------------
+# Healthy peer — clean cross-monitor signal.
+# ---------------------------------------------------------------------------
+
+
+def test_fresh_peer_emits_no_alert(tmp_path: Path):
+    # Arrange — peer beat 5s ago (well under default 180s).
+    now = 1_700_000_000.0
+    peer_dir = tmp_path / "bob"
+    _write_heartbeat(peer_dir, ts=now - 5.0, state="working")
+    _write_session_jsonl(peer_dir, mtime=now - 5.0)
+    # Act
+    alerts = check_peer_freshness(
+        observer="alice",
+        peer="bob",
+        peer_state_dir=peer_dir,
+        now=now,
+    )
+    # Assert — healthy peer contributes nothing to the alert stream.
+    assert alerts == []
+
+
+def test_idle_peer_with_silent_jsonl_does_not_fire(tmp_path: Path):
+    # Arrange — peer claims idle (correctly reports it is doing nothing).
+    # session.jsonl is old but the heartbeat is recent + state=="idle".
+    now = 1_700_000_000.0
+    peer_dir = tmp_path / "bob"
+    _write_heartbeat(peer_dir, ts=now - 10.0, state="idle")
+    _write_session_jsonl(peer_dir, mtime=now - 9999.0)
+    # Act
+    alerts = check_peer_freshness(
+        observer="alice",
+        peer="bob",
+        peer_state_dir=peer_dir,
+        now=now,
+    )
+    # Assert — an idle peer with a quiet transcript is healthy.
+    assert alerts == []
+
+
+# ---------------------------------------------------------------------------
+# Heartbeat staleness — the classic wedged-runner signal.
+# ---------------------------------------------------------------------------
+
+
+def test_stale_heartbeat_past_threshold_fires_alert(tmp_path: Path):
+    # Arrange — peer last beat 300s ago, threshold 180s.
+    now = 1_700_000_000.0
+    peer_dir = tmp_path / "bob"
+    _write_heartbeat(peer_dir, ts=now - 300.0, state="working")
+    _write_session_jsonl(peer_dir, mtime=now - 300.0)
+    # Act
+    alerts = check_peer_freshness(
+        observer="alice",
+        peer="bob",
+        peer_state_dir=peer_dir,
+        now=now,
+    )
+    # Assert — exactly one structural alert of the heartbeat kind.
+    assert [a.kind for a in alerts] == [KIND_STALE_HEARTBEAT]
+
+
+def test_stale_heartbeat_alert_records_age_seconds(tmp_path: Path):
+    # Arrange — peer last beat 300s ago.
+    now = 1_700_000_000.0
+    peer_dir = tmp_path / "bob"
+    _write_heartbeat(peer_dir, ts=now - 300.0, state="working")
+    # Act
+    alerts = check_peer_freshness(
+        observer="alice",
+        peer="bob",
+        peer_state_dir=peer_dir,
+        now=now,
+    )
+    # Assert — evidence carries the OBSERVED age, not a flag.
+    assert alerts[0].age_seconds == 300.0
+
+
+def test_missing_heartbeat_fires_stale_heartbeat_alert(tmp_path: Path):
+    # Arrange — peer state dir exists but heartbeat.json absent.
+    now = 1_700_000_000.0
+    peer_dir = tmp_path / "bob"
+    peer_dir.mkdir(parents=True)
+    # Act
+    alerts = check_peer_freshness(
+        observer="alice",
+        peer="bob",
+        peer_state_dir=peer_dir,
+        now=now,
+    )
+    # Assert — missing heartbeat counts as the stale-heartbeat case.
+    assert [a.kind for a in alerts] == [KIND_STALE_HEARTBEAT]
+
+
+def test_custom_threshold_does_not_fire_when_age_just_below(tmp_path: Path):
+    # Arrange — peer last beat 5s ago, custom threshold 10s.
+    now = 1_700_000_000.0
+    peer_dir = tmp_path / "bob"
+    _write_heartbeat(peer_dir, ts=now - 5.0, state="working")
+    _write_session_jsonl(peer_dir, mtime=now - 5.0)
+    # Act
+    alerts = check_peer_freshness(
+        observer="alice",
+        peer="bob",
+        peer_state_dir=peer_dir,
+        now=now,
+        config=WatchConfig(heartbeat_threshold_s=10.0, jsonl_idle_threshold_s=10.0),
+    )
+    # Assert — under-threshold peer is healthy under a tighter knob.
+    assert alerts == []
+
+
+def test_custom_threshold_fires_when_age_just_above(tmp_path: Path):
+    # Arrange — peer last beat 15s ago, custom threshold 10s.
+    now = 1_700_000_000.0
+    peer_dir = tmp_path / "bob"
+    _write_heartbeat(peer_dir, ts=now - 15.0, state="working")
+    _write_session_jsonl(peer_dir, mtime=now - 1.0)
+    # Act
+    alerts = check_peer_freshness(
+        observer="alice",
+        peer="bob",
+        peer_state_dir=peer_dir,
+        now=now,
+        config=WatchConfig(heartbeat_threshold_s=10.0, jsonl_idle_threshold_s=300.0),
+    )
+    # Assert — tightened threshold catches a peer the default would miss.
+    assert [a.kind for a in alerts] == [KIND_STALE_HEARTBEAT]
+
+
+# ---------------------------------------------------------------------------
+# session.jsonl staleness — the silent-drift signal.
+# ---------------------------------------------------------------------------
+
+
+def test_working_peer_with_idle_jsonl_fires_session_jsonl_alert(tmp_path: Path):
+    # Arrange — peer beat IS fresh but session.jsonl has not grown
+    # for 400s while state=="working" (the silent-drift case).
+    now = 1_700_000_000.0
+    peer_dir = tmp_path / "bob"
+    _write_heartbeat(peer_dir, ts=now - 5.0, state="working")
+    _write_session_jsonl(peer_dir, mtime=now - 400.0)
+    # Act
+    alerts = check_peer_freshness(
+        observer="alice",
+        peer="bob",
+        peer_state_dir=peer_dir,
+        now=now,
+    )
+    # Assert — operator-mandated structural alert for silent drift.
+    assert [a.kind for a in alerts] == [KIND_STALE_SESSION_JSONL]
+
+
+def test_working_peer_with_recent_jsonl_does_not_fire(tmp_path: Path):
+    # Arrange — peer beat fresh, session.jsonl mtime fresh, state="working".
+    now = 1_700_000_000.0
+    peer_dir = tmp_path / "bob"
+    _write_heartbeat(peer_dir, ts=now - 5.0, state="working")
+    _write_session_jsonl(peer_dir, mtime=now - 5.0)
+    # Act
+    alerts = check_peer_freshness(
+        observer="alice",
+        peer="bob",
+        peer_state_dir=peer_dir,
+        now=now,
+    )
+    # Assert — actively-producing working peer is healthy.
+    assert alerts == []
+
+
+# ---------------------------------------------------------------------------
+# Mutual = bidirectional. A watches B AND B watches A independently.
+# ---------------------------------------------------------------------------
+
+
+def test_mutual_watch_both_directions_emit_when_both_peers_are_stale(tmp_path: Path):
+    # Arrange — TWO peer state dirs; both stale heartbeats.
+    now = 1_700_000_000.0
+    a_dir = tmp_path / "alice"
+    b_dir = tmp_path / "bob"
+    _write_heartbeat(a_dir, ts=now - 400.0, state="working")
+    _write_heartbeat(b_dir, ts=now - 400.0, state="working")
+    # Act — alice observes bob; bob observes alice. Two independent calls.
+    alice_watching_bob = check_peer_freshness(
+        observer="alice", peer="bob", peer_state_dir=b_dir, now=now
+    )
+    bob_watching_alice = check_peer_freshness(
+        observer="bob", peer="alice", peer_state_dir=a_dir, now=now
+    )
+    combined = alice_watching_bob + bob_watching_alice
+    # Assert — both directions emit, observer/peer fields oriented per call.
+    assert {(a.observer, a.peer) for a in combined} == {
+        ("alice", "bob"),
+        ("bob", "alice"),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Shared fixture — env save/restore without monkeypatch-as-fixture.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def env_setter():
+    """Save/restore env vars explicitly (no monkeypatch fixture).
+
+    Yields a setter the test calls with ``(name, value)``; the
+    fixture records the prior value and restores it on teardown.
+    Implementation note: this is an env-management helper, not a
+    mocking primitive — STX-NM002 bans mocks / monkeypatch-as-fixture
+    for test seams, but explicit save/restore of OS state is the
+    standard pattern in this repo (see ``db_path`` fixture in
+    ``test_state_db_turns_errors_heartbeats.py``).
+    """
+    saved: dict[str, str | None] = {}
+
+    def _set(name: str, value: str) -> None:
+        if name not in saved:
+            saved[name] = os.environ.get(name)
+        os.environ[name] = value
+
+    yield _set
+    for name, prior in saved.items():
+        if prior is None:
+            os.environ.pop(name, None)
+        else:
+            os.environ[name] = prior
+
+
+# Touch ``time`` only to silence the lint that flags the unused import
+# the test fixture above might otherwise drag in.
+assert callable(time.time)

--- a/tests/scitex_agent_container/_network/test__mutual_watch.py
+++ b/tests/scitex_agent_container/_network/test__mutual_watch.py
@@ -62,15 +62,19 @@ def _write_session_jsonl(state_dir: Path, mtime: float, content: str = "x\n") ->
 
 
 def test_watch_config_default_heartbeat_threshold_is_180s():
-    # Arrange / Act
-    cfg = WatchConfig()
+    # Arrange
+    ctor = WatchConfig
+    # Act
+    cfg = ctor()
     # Assert — operator-tunable default per module docstring.
     assert cfg.heartbeat_threshold_s == 180.0
 
 
 def test_watch_config_default_jsonl_idle_threshold_is_300s():
-    # Arrange / Act
-    cfg = WatchConfig()
+    # Arrange
+    ctor = WatchConfig
+    # Act
+    cfg = ctor()
     # Assert
     assert cfg.jsonl_idle_threshold_s == 300.0
 

--- a/tests/scitex_agent_container/_network/test__mutual_watch_sweep.py
+++ b/tests/scitex_agent_container/_network/test__mutual_watch_sweep.py
@@ -1,0 +1,307 @@
+"""Tests for the mutual-watch sweep orchestrator + alert persistence.
+
+Covers the side-effect layer that sits between the pure decision
+(``_mutual_watch``) and the operator surface (``structural_alerts``
+table). The sweep walks peers, persists alerts via
+:mod:`state_db_alerts`, and resolves prior-active alerts when the
+peer recovers.
+
+Conventions:
+
+  * AAA marker comments (Arrange / Act / Assert) on separate lines.
+  * One assertion per test (STX-TQ007).
+  * No mocks / monkeypatch — real state.db (tmp path via env), real
+    files for peer state dirs.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Fixtures — isolated state.db + isolated state_root.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def state_env(tmp_path: Path):
+    """Pin SCITEX_AGENT_CONTAINER_STATE_DB + RUNTIME_DIR to a tmp path.
+
+    Yields a dict with ``db_path`` and ``state_root`` so the test can
+    write peer state dirs and read back ``structural_alerts`` rows.
+    Explicit env save/restore (no monkeypatch fixture) per repo
+    convention.
+    """
+    saved = {
+        "SCITEX_AGENT_CONTAINER_STATE_DB": os.environ.get(
+            "SCITEX_AGENT_CONTAINER_STATE_DB"
+        ),
+        "SCITEX_AGENT_CONTAINER_RUNTIME_DIR": os.environ.get(
+            "SCITEX_AGENT_CONTAINER_RUNTIME_DIR"
+        ),
+    }
+    db_path = tmp_path / "state.db"
+    state_root = tmp_path / "runtime"
+    os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db_path)
+    os.environ["SCITEX_AGENT_CONTAINER_RUNTIME_DIR"] = str(state_root)
+    # Reload modules that snapshot env at import.
+    import scitex_agent_container._state.state_db as _db
+
+    importlib.reload(_db)
+    import scitex_agent_container._runners._session_state as _ss
+
+    importlib.reload(_ss)
+    try:
+        yield {"db_path": db_path, "state_root": state_root}
+    finally:
+        for key, prior in saved.items():
+            if prior is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = prior
+        importlib.reload(_db)
+        importlib.reload(_ss)
+
+
+def _write_heartbeat(state_dir: Path, ts: float, state: str = "working") -> None:
+    state_dir.mkdir(parents=True, exist_ok=True)
+    (state_dir / "heartbeat.json").write_text(
+        json.dumps({"ts": ts, "pid": 4242, "state": state}),
+        encoding="utf-8",
+    )
+
+
+def _write_session_jsonl(state_dir: Path, mtime: float) -> None:
+    state_dir.mkdir(parents=True, exist_ok=True)
+    p = state_dir / "session.jsonl"
+    p.write_text("x\n", encoding="utf-8")
+    os.utime(p, (mtime, mtime))
+
+
+# ---------------------------------------------------------------------------
+# Schema + persistence.
+# ---------------------------------------------------------------------------
+
+
+def test_init_schema_creates_structural_alerts_table(state_env):
+    # Arrange
+    from scitex_agent_container._state.state_db import init_schema
+
+    # Act
+    init_schema()
+    import sqlite3
+
+    with sqlite3.connect(state_env["db_path"]) as conn:
+        names = {
+            r[0]
+            for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        }
+    # Assert
+    assert "structural_alerts" in names
+
+
+def test_record_alert_inserts_row_with_evidence(state_env):
+    # Arrange
+    from scitex_agent_container._state.state_db_alerts import (
+        KIND_STALE_HEARTBEAT,
+        list_active_alerts,
+        record_alert,
+    )
+
+    # Act
+    record_alert(
+        observer="alice",
+        peer="bob",
+        kind=KIND_STALE_HEARTBEAT,
+        evidence={"age_seconds": 300.0},
+        now=1_700_000_000.0,
+    )
+    rows = list_active_alerts()
+    # Assert — exactly one active row landed.
+    assert len(rows) == 1
+
+
+def test_record_alert_dedupes_repeat_fires_into_one_row(state_env):
+    # Arrange — three sweeps observe the same staleness.
+    from scitex_agent_container._state.state_db_alerts import (
+        KIND_STALE_HEARTBEAT,
+        list_active_alerts,
+        record_alert,
+    )
+
+    # Act
+    for ts in (1_700_000_000.0, 1_700_000_060.0, 1_700_000_120.0):
+        record_alert(observer="alice", peer="bob", kind=KIND_STALE_HEARTBEAT, now=ts)
+    rows = list_active_alerts()
+    # Assert — dedup means ONE row, hit_count bumped each time.
+    assert rows[0]["hit_count"] == 3
+
+
+def test_resolve_alert_marks_row_resolved(state_env):
+    # Arrange
+    from scitex_agent_container._state.state_db_alerts import (
+        KIND_STALE_HEARTBEAT,
+        list_active_alerts,
+        record_alert,
+        resolve_alert,
+    )
+
+    record_alert(observer="alice", peer="bob", kind=KIND_STALE_HEARTBEAT, now=1.0)
+    # Act
+    resolve_alert(observer="alice", peer="bob", kind=KIND_STALE_HEARTBEAT, now=2.0)
+    # Assert — active list is empty after resolve.
+    assert list_active_alerts() == []
+
+
+# ---------------------------------------------------------------------------
+# Sweep — orchestration over real peer state dirs + DB writes.
+# ---------------------------------------------------------------------------
+
+
+def test_sweep_emits_alert_when_peer_heartbeat_is_stale(state_env):
+    # Arrange — bob's state dir under the real state root.
+    from scitex_agent_container._network._mutual_watch_sweep import sweep_peers
+
+    now = 1_700_000_000.0
+    bob_dir = state_env["state_root"] / "bob"
+    _write_heartbeat(bob_dir, ts=now - 400.0, state="working")
+    _write_session_jsonl(bob_dir, mtime=now - 5.0)
+    # Act
+    emitted = sweep_peers(
+        observer="alice",
+        peer_names=["bob"],
+        state_root=state_env["state_root"],
+        now=now,
+    )
+    # Assert — the stale heartbeat is surfaced as a structural alert.
+    assert [a.kind for a in emitted] == ["stale_heartbeat"]
+
+
+def test_sweep_persists_alert_into_structural_alerts_table(state_env):
+    # Arrange
+    from scitex_agent_container._network._mutual_watch_sweep import sweep_peers
+    from scitex_agent_container._state.state_db_alerts import list_active_alerts
+
+    now = 1_700_000_000.0
+    bob_dir = state_env["state_root"] / "bob"
+    _write_heartbeat(bob_dir, ts=now - 400.0, state="working")
+    # Act
+    sweep_peers(
+        observer="alice",
+        peer_names=["bob"],
+        state_root=state_env["state_root"],
+        now=now,
+    )
+    rows = list_active_alerts(observer="alice", peer="bob")
+    # Assert — DB has the row the operator + lead read from.
+    assert rows[0]["kind"] == "stale_heartbeat"
+
+
+def test_sweep_resolves_prior_alert_when_peer_recovers(state_env):
+    # Arrange — first sweep observes stale heartbeat, second sweep sees recovery.
+    from scitex_agent_container._network._mutual_watch_sweep import sweep_peers
+    from scitex_agent_container._state.state_db_alerts import list_active_alerts
+
+    bob_dir = state_env["state_root"] / "bob"
+    sweep_now = 1_700_000_000.0
+    _write_heartbeat(bob_dir, ts=sweep_now - 400.0, state="working")
+    sweep_peers(
+        observer="alice",
+        peer_names=["bob"],
+        state_root=state_env["state_root"],
+        now=sweep_now,
+    )
+    # Peer recovers: fresh heartbeat.
+    recover_now = sweep_now + 10.0
+    _write_heartbeat(bob_dir, ts=recover_now - 5.0, state="working")
+    _write_session_jsonl(bob_dir, mtime=recover_now - 5.0)
+    # Act
+    sweep_peers(
+        observer="alice",
+        peer_names=["bob"],
+        state_root=state_env["state_root"],
+        now=recover_now,
+    )
+    # Assert — the recovery sweep cleared the alert.
+    assert list_active_alerts(observer="alice", peer="bob") == []
+
+
+def test_sweep_does_not_fire_for_healthy_peer(state_env):
+    # Arrange
+    from scitex_agent_container._network._mutual_watch_sweep import sweep_peers
+
+    now = 1_700_000_000.0
+    bob_dir = state_env["state_root"] / "bob"
+    _write_heartbeat(bob_dir, ts=now - 5.0, state="working")
+    _write_session_jsonl(bob_dir, mtime=now - 5.0)
+    # Act
+    emitted = sweep_peers(
+        observer="alice",
+        peer_names=["bob"],
+        state_root=state_env["state_root"],
+        now=now,
+    )
+    # Assert — clean cross-monitor signal.
+    assert emitted == []
+
+
+def test_sweep_is_mutual_each_observer_sees_its_peers_independently(state_env):
+    # Arrange — alice + bob both stale, alice watches bob and bob watches alice.
+    from scitex_agent_container._network._mutual_watch_sweep import sweep_peers
+    from scitex_agent_container._state.state_db_alerts import list_active_alerts
+
+    now = 1_700_000_000.0
+    alice_dir = state_env["state_root"] / "alice"
+    bob_dir = state_env["state_root"] / "bob"
+    _write_heartbeat(alice_dir, ts=now - 400.0, state="working")
+    _write_heartbeat(bob_dir, ts=now - 400.0, state="working")
+    # Act — two observers run independent sweeps.
+    sweep_peers(
+        observer="alice",
+        peer_names=["bob"],
+        state_root=state_env["state_root"],
+        now=now,
+    )
+    sweep_peers(
+        observer="bob",
+        peer_names=["alice"],
+        state_root=state_env["state_root"],
+        now=now,
+    )
+    rows = list_active_alerts()
+    # Assert — both directions persisted.
+    assert {(r["observer"], r["peer"]) for r in rows} == {
+        ("alice", "bob"),
+        ("bob", "alice"),
+    }
+
+
+def test_sweep_skips_observer_watching_itself(state_env):
+    # Arrange — observer name appears in peer_names (e.g. registry self-row).
+    from scitex_agent_container._network._mutual_watch_sweep import sweep_peers
+
+    now = 1_700_000_000.0
+    alice_dir = state_env["state_root"] / "alice"
+    _write_heartbeat(alice_dir, ts=now - 400.0, state="working")
+    # Act
+    emitted = sweep_peers(
+        observer="alice",
+        peer_names=["alice"],
+        state_root=state_env["state_root"],
+        now=now,
+    )
+    # Assert — self-watch is not the mutual-monitoring signal the spec asks for.
+    assert emitted == []
+
+
+# Quietly use ``time`` so import-linting is happy if a future test
+# needs wall-clock fixtures.
+assert callable(time.time)


### PR DESCRIPTION
## Summary

Operator mandate (lead a2a 1781e82a, 2026-06-14): "agents (and lead) cross-monitor heartbeat_at + session.jsonl growth; a stale peer raises a STRUCTURAL alert, not a silent drift."

- New pure-decision module `_network/_mutual_watch.py` — `check_peer_freshness()` emits typed `StalePeerAlert` instances for two kinds: `stale_heartbeat` (peer's beat older than threshold) and `stale_session_jsonl` (heartbeat fresh but jsonl idle while peer claims working).
- New orchestrator `_network/_mutual_watch_sweep.py` — walks peers, persists alerts, resolves recovery; per-peer failures are isolated.
- New table `structural_alerts` (state.db) with dedup on `(observer, peer, kind)` so an N-minute stale peer produces ONE row (`hit_count` bumped), not 30 noise rows. Exposed via existing `sac db query --table=structural_alerts`.

## Design highlights

- **Mutual = bidirectional** falls out of symmetry: each agent runs the sweep over its peers, so A→B and B→A independently emit.
- **Threshold default + override**: 180s heartbeat / 300s session.jsonl idle. Operator overrides via env vars `SAC_MUTUAL_WATCH_HEARTBEAT_STALE_S` / `SAC_MUTUAL_WATCH_JSONL_IDLE_S`. Invalid env values degrade silently to defaults so a typo cannot wedge the watch.
- **Additive surface** — does NOT touch existing status JSON envelope (per coordination note re sibling branch `feat/status-json-session-movement`). Alert shape lives in its own table; status reporters can opt-in to projecting active alerts later without colliding.
- **Pure decision is mock-free testable** — `check_peer_freshness()` takes `now` as a parameter and reads real files only, so unit tests pin the clock and use real heartbeat.json / session.jsonl on tmp_path.

## Alert shape (one-line JSON example)

```json
{"observer":"alice","peer":"bob","kind":"stale_heartbeat","age_seconds":400.0,"threshold_s":180.0,"evidence":{"peer_state_dir":"/runtime/bob","last_heartbeat_ts":1700000000.0,"peer_state":"working","last_session_jsonl_mtime":1699999999.0,"last_session_jsonl_bytes":12345}}
```

## Threshold defaults + override mechanism

| Knob | Default | Override env var |
| --- | --- | --- |
| heartbeat staleness | 180s | `SAC_MUTUAL_WATCH_HEARTBEAT_STALE_S` |
| session.jsonl idle  | 300s | `SAC_MUTUAL_WATCH_JSONL_IDLE_S` |

Programmatic override: pass a `WatchConfig(heartbeat_threshold_s=..., jsonl_idle_threshold_s=...)` to `check_peer_freshness()` or `sweep_peers()`.

## Files

- `src/scitex_agent_container/_network/_mutual_watch.py` (new, ~260 lines, pure decision + dataclass)
- `src/scitex_agent_container/_network/_mutual_watch_sweep.py` (new, ~140 lines, orchestrator)
- `src/scitex_agent_container/_state/state_db_alerts.py` (new, ~180 lines, table + helpers)
- `src/scitex_agent_container/_state/state_db.py` (`KNOWN_TABLES` += `structural_alerts`; `ensure_schema` call)
- `src/scitex_agent_container/_state/state_db_export.py` (filter clause for `structural_alerts`)
- `tests/scitex_agent_container/_network/test__mutual_watch.py` (15 tests)
- `tests/scitex_agent_container/_network/test__mutual_watch_sweep.py` (10 tests)

## Test plan

- [x] 15 unit tests pass — pure decision against real fixture files
- [x] 10 sweep + persistence tests pass — real state.db on tmp_path
- [x] 110 existing `_state/test_state_db.py` tests pass (export filter regression fixed)
- [ ] CI green