### PR TITLE
fix(runtime): drain picker registry at TUI boot — unblocks 3 stuck research agents

### DIFF
--- a/src/scitex_agent_container/runtimes/tui_session.py
+++ b/src/scitex_agent_container/runtimes/tui_session.py
@@ -232,6 +232,8 @@ class TuiSessionRuntime(RuntimeBase):
         force: bool = False,
         dry_run: bool = False,
         foreground: bool = False,
+        drain_pickers_at_boot: bool = True,
+        boot_drain_timeout_s: float = 30.0,
     ) -> bool:
         """Launch ``claude`` inside a detached tmux session sac owns.
 
@@ -277,7 +279,7 @@ class TuiSessionRuntime(RuntimeBase):
             env_exports = (
                 f"export HOME={home_dir}\nexport CLAUDE_CONFIG_DIR={home_dir}/.claude\n"
             )
-        return bool(
+        started = bool(
             self._mux.start(
                 session_name=name,
                 command=self._claude_bin,
@@ -285,6 +287,28 @@ class TuiSessionRuntime(RuntimeBase):
                 env_exports=env_exports,
             )
         )
+        if started and drain_pickers_at_boot:
+            # URGENT (lead a2a 278159b5, 2026-06-14): drain the
+            # picker registry AT BOOT so the supervisor + downstream
+            # send paths land on a TUI already at the input field.
+            # Wiring drain into send_turn alone was lazy — the
+            # supervisor never calls send_turn during boot, so the
+            # picker sat up and every `sac agents send` then timed
+            # out. Failure here MUST NOT fail the start (supervisor
+            # restart loop would oscillate); log + let the send_turn
+            # retry on its own hook.
+            try:
+                self.wait_until_input_ready(config, timeout_s=boot_drain_timeout_s)
+            except TuiInputNotReadyError as exc:  # stx-allow: fallback (reason: boot-drain best-effort; send_turn retries — operator escalation 2026-06-14)
+                import logging
+
+                logging.getLogger(__name__).warning(
+                    "TuiSessionRuntime.start: boot-drain timed out "
+                    "for %s; send_turn will retry. Last error: %s",
+                    name,
+                    exc,
+                )
+        return started
 
     def stop(self, config: AgentConfig) -> bool:
         """Kill the tmux session sac owns for this agent.

--- a/tests/scitex_agent_container/runtimes/test_tui_session.py
+++ b/tests/scitex_agent_container/runtimes/test_tui_session.py
@@ -94,7 +94,11 @@ class _MemoryMultiplexer:
         sess = cls._sessions.get(session_name)
         if sess is None:
             return ""
-        return "\n".join(sess.pane)
+        # Append the input-ready marker so the runtime's boot-drain
+        # (post-2026-06-14 lead a2a 278159b5) short-circuits in the
+        # in-memory unit suite. The fake doesn't render first-launch
+        # modals; the drain has no work to do and must not block.
+        return "\n".join(sess.pane) + "\n? for shortcuts"
 
     @classmethod
     def capture_logs(cls, session_name: str, lines: int = 50) -> str:
@@ -510,8 +514,6 @@ def test_tui_runtime_send_turn_skips_send_when_no_session(
 # ---------------------------------------------------------------------------
 
 
-
-
 class _PrimedMemoryMultiplexer(_MemoryMultiplexer):
     """In-memory mux whose ``capture_content`` returns a scripted
     sequence so the wait_until_input_ready tests can simulate the
@@ -552,7 +554,10 @@ def test_wait_until_input_ready_returns_true_when_marker_present(
     primed_mux.prime(["? for shortcuts"])
     runtime = TuiSessionRuntime(multiplexer=primed_mux)
     config = _Config(name="ready-immediate")
-    runtime.start(config)
+    # ``drain_pickers_at_boot=False`` so the start path doesn't
+    # consume the primed frame queue — the test wants the queue
+    # intact for its own direct wait_until_input_ready call below.
+    runtime.start(config, drain_pickers_at_boot=False)
     # Act
     ready = runtime.wait_until_input_ready(
         config, timeout_s=1.0, poll_s=0.0, sleep_fn=lambda _s: None
@@ -569,7 +574,7 @@ def test_wait_until_input_ready_dismisses_theme_picker_then_returns(
     primed_mux.prime([theme_pane, "? for shortcuts"])
     runtime = TuiSessionRuntime(multiplexer=primed_mux)
     config = _Config(name="theme-dismiss")
-    runtime.start(config)
+    runtime.start(config, drain_pickers_at_boot=False)
     # Act
     runtime.wait_until_input_ready(
         config, timeout_s=2.0, poll_s=0.0, sleep_fn=lambda _s: None
@@ -588,7 +593,9 @@ def test_wait_until_input_ready_raises_when_marker_never_appears(
     primed_mux.prime(["just some noise"])
     runtime = TuiSessionRuntime(multiplexer=primed_mux)
     config = _Config(name="never-ready")
-    runtime.start(config)
+    # Skip boot-drain so start() doesn't itself eat 30s + then
+    # propagate the absent-marker timeout through this test.
+    runtime.start(config, drain_pickers_at_boot=False)
     # Act
     do_wait = runtime.wait_until_input_ready
     # Assert


### PR DESCRIPTION
## URGENT — operator-facing TUI gate

Lead a2a `278159b5d3b7401d9752fb82ffdc64ba` (2026-06-14): the three live host-side TUI agents (neurovista / paper-scitex-clew / ripple-wm) idle at the theme picker after restart onto PR #393 because the picker drain was wired into `send_turn` only — supervisor never calls send_turn during boot, so the modal sits up; every subsequent `sac agents send` times out at 60s.

## Fix
`TuiSessionRuntime.start()` now calls `wait_until_input_ready` immediately after the tmux + claude launch returns success. By the time `start()` exits the TUI is at the input-ready footer; every downstream send path (a2a sidecar, `sac agents send`, supervisor restart) just works.

Two new kwargs on `start()`:
- `drain_pickers_at_boot: bool = True` — production default; in-memory unit suite passes False for tests that probe drain directly.
- `boot_drain_timeout_s: float = 30.0` — generous for first-frame render, short enough that supervisor restart doesn't oscillate.

Drain failure is **logged-and-swallowed**, not raised: supervisor restart loop must not oscillate on a transient render delay; the next `send_turn` retries via its own `wait_until_input_ready` hook.

## Tests
65 tests pass in 1.07s (was 60s on first iteration because the no-marker test hung — fixed by routing the 3 primed-mux tests to `drain_pickers_at_boot=False`). In-memory `_MemoryMultiplexer.capture_content` fake now appends the `? for shortcuts` marker so the default boot-drain short-circuits in tests.

## After merge
Operator pulls develop + `sac agents restart neurovista paper-scitex-clew ripple-wm` ONCE; subsequent `sac agents send` delivers.

Lead a2a: `278159b5d3b7401d9752fb82ffdc64ba`