### PR TITLE
fix(runtime): TUI HOME/CLAUDE_CONFIG_DIR via tmux -e + post-launch env-verify (unblocks TUI auth)

### DIFF
--- a/src/scitex_agent_container/_runners/_tmux/tmux.py
+++ b/src/scitex_agent_container/_runners/_tmux/tmux.py
@@ -76,6 +76,7 @@ class TmuxManager:
         workdir: str,
         env_exports: str = "",
         venv: str = "",
+        session_env: dict[str, str] | None = None,
     ) -> bool:
         """Launch a command inside a new detached tmux session.
 
@@ -83,8 +84,22 @@ class TmuxManager:
             session_name: Name for the tmux session.
             command: Shell command to execute.
             workdir: Working directory for the command.
-            env_exports: Newline-separated export statements to prepend.
+            env_exports: Newline-separated export statements to prepend
+                to the shell script (legacy belt-and-suspenders path —
+                see :param:`session_env` for the structural fix).
             venv: Path to virtualenv to activate before running command.
+            session_env: Mapping of env vars passed via ``tmux
+                new-session -e KEY=VAL`` so the values land on the
+                session itself and propagate to every pane / child
+                process IRRESPECTIVE of whether a login shell init
+                file would overwrite a same-named export inside the
+                script. This is the operator-mandated path for HOME +
+                CLAUDE_CONFIG_DIR on the TUI runtime (lead a2a
+                ``8f910ea7e78e4e0b959ce087376e542b``, 2026-06-14:
+                live agents launched without HOME pointing at the
+                staged $STATE/home dropped to interactive OAuth login
+                because the inner ``claude`` read the operator's
+                real ``~/.claude/`` instead of the staged one).
 
         Returns:
             True if the tmux session was created successfully.
@@ -108,20 +123,17 @@ class TmuxManager:
         )
 
         Path(workdir).mkdir(parents=True, exist_ok=True)
-        subprocess.run(
-            [
-                "tmux",
-                "new-session",
-                "-d",
-                "-s",
-                session_name,
-                "bash",
-                "-l",
-                "-c",
-                shell_script,
-            ],
-            check=False,
-        )
+        # Build argv with optional ``-e KEY=VAL`` pairs first; bash
+        # without ``-l`` so login init files cannot overwrite the
+        # tmux-side env. The script's belt-and-suspenders exports
+        # stay as a no-cost defense for any consumer that still
+        # passes env_exports without session_env.
+        argv: list[str] = ["tmux", "new-session", "-d", "-s", session_name]
+        if session_env:
+            for key, value in session_env.items():
+                argv += ["-e", f"{key}={value}"]
+        argv += ["bash", "-c", shell_script]
+        subprocess.run(argv, check=False)
 
         time.sleep(2)
         return TmuxManager.exists(session_name)

--- a/src/scitex_agent_container/runtimes/_tui_auth_stage.py
+++ b/src/scitex_agent_container/runtimes/_tui_auth_stage.py
@@ -255,6 +255,118 @@ def _resolve_settings_json_src() -> Path | None:
     return host_settings if host_settings.is_file() else None
 
 
+def _assert_credentials_usable(dst: Path, *, source: Path) -> None:
+    """Post-copy sanity check on the staged credentials file.
+
+    Lead a2a ``3b85d17b3a2f492fac55fad7f94aa73e`` (2026-06-14): the
+    three live host-side TUI agents stalled at the OAuth login URL
+    screen because a silently-broken or expired credentials file
+    was staged — the TUI rejected it and fell to interactive OAuth.
+    Now we sanity-check the destination after copy and FAIL LOUD
+    with a remedy. No silent broken stage.
+
+    Asserts:
+      - file is non-empty and parses as JSON.
+      - ``claudeAiOauth.accessToken`` is a non-empty string.
+      - ``claudeAiOauth.expiresAt`` is a numeric ms-since-epoch in
+        the future (TUI rejects expired tokens).
+    """
+    import time
+
+    if not dst.is_file() or dst.stat().st_size == 0:
+        raise TuiAuthStageError(
+            f"TUI auth: staged credentials at {dst} is missing or empty "
+            f"(source was {source}). Re-stage by running "
+            "`sac accounts save <acct>` on the credential-holding host "
+            "or `sac accounts sync-live`."
+        )
+    try:
+        payload = json.loads(dst.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise TuiAuthStageError(
+            f"TUI auth: staged credentials at {dst} did not parse as "
+            f"JSON ({exc}). Source was {source}. First 200 bytes:\n"
+            f"{dst.read_bytes()[:200]!r}"
+        ) from exc
+    oauth = payload.get("claudeAiOauth") if isinstance(payload, dict) else None
+    if not isinstance(oauth, dict):
+        raise TuiAuthStageError(
+            f"TUI auth: staged credentials at {dst} has no "
+            f"`claudeAiOauth` block (source was {source}). The TUI "
+            "needs the full OAuth payload — re-stage via "
+            "`claude /login` to the target account then "
+            "`sac accounts sync-live`."
+        )
+    access = oauth.get("accessToken")
+    if not isinstance(access, str) or not access:
+        raise TuiAuthStageError(
+            f"TUI auth: staged credentials at {dst} has empty "
+            f"`claudeAiOauth.accessToken` (source was {source}). "
+            "Re-stage the credential via `claude /login`."
+        )
+    expires_at = oauth.get("expiresAt")
+    now_ms = time.time() * 1000.0
+    if not isinstance(expires_at, (int, float)) or expires_at <= now_ms:
+        raise TuiAuthStageError(
+            f"TUI auth: staged credentials at {dst} are expired "
+            f"(expiresAt={expires_at!r}, now_ms={int(now_ms)}). "
+            f"Source was {source}. Refresh via `sac accounts "
+            "sync-live` (operator) or `claude /login` then re-stage."
+        )
+
+
+def _assert_claude_json_oauth_ready(dst: Path, *, source: Path) -> None:
+    """Post-copy sanity check on the staged onboarding state.
+
+    The bundled TUI shows the OAuth login screen even when the
+    credentials file is valid IF ``hasCompletedOnboarding`` is not
+    ``True`` OR ``oauthAccount`` is null/absent. Operator host
+    .claude.json sometimes lacks these fields (SDK-only flow never
+    wrote them). FAIL LOUD with the missing-field name so the
+    operator's remedy is unambiguous.
+    """
+    if not dst.is_file() or dst.stat().st_size == 0:
+        raise TuiAuthStageError(
+            f"TUI auth: staged .claude.json at {dst} is missing or "
+            f"empty (source was {source})."
+        )
+    try:
+        payload = json.loads(dst.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise TuiAuthStageError(
+            f"TUI auth: staged .claude.json at {dst} did not parse "
+            f"as JSON ({exc}). Source was {source}."
+        ) from exc
+    if not isinstance(payload, dict):
+        raise TuiAuthStageError(
+            f"TUI auth: staged .claude.json at {dst} is not a JSON "
+            f"object (got {type(payload).__name__}). Source was {source}."
+        )
+    if payload.get("hasCompletedOnboarding") is not True:
+        raise TuiAuthStageError(
+            f"TUI auth: staged .claude.json at {dst} has "
+            f"hasCompletedOnboarding={payload.get('hasCompletedOnboarding')!r}; "
+            "the TUI will show the OAuth/login flow regardless of "
+            "credentials. Source was {source}. Stage a .claude.json "
+            "that has `hasCompletedOnboarding: true` AND a non-null "
+            "`oauthAccount` block (typically materialised by `claude "
+            "/login` on the host that holds the OAuth account)."
+        )
+    oauth_account = payload.get("oauthAccount")
+    if not isinstance(oauth_account, dict) or not oauth_account:
+        raise TuiAuthStageError(
+            f"TUI auth: staged .claude.json at {dst} has empty/missing "
+            f"`oauthAccount` (got {oauth_account!r}); the TUI will "
+            f"show the OAuth login URL. Source was {source}. The "
+            "field must include `accountUuid` + `emailAddress` + "
+            "`organizationUuid` + `organizationType` — typically "
+            "materialised by `claude /login` on the host. Set "
+            f"{CLAUDE_JSON_SRC_ENV} to a .claude.json that has those "
+            "fields, or run `claude /login` to the target account "
+            "and re-stage."
+        )
+
+
 def _follow_and_copy(src: Path, dst: Path) -> None:
     """``cp -Lf`` semantics: follow source symlinks, overwrite dst.
 
@@ -333,9 +445,11 @@ def stage_tui_auth(
     creds_dst = claude_dir / ".credentials.json"
     _follow_and_copy(creds_src, creds_dst)
     creds_dst.chmod(0o600)
+    _assert_credentials_usable(creds_dst, source=creds_src)
 
     claude_json_dst = home_dir / ".claude.json"
     _follow_and_copy(claude_json_src, claude_json_dst)
+    _assert_claude_json_oauth_ready(claude_json_dst, source=claude_json_src)
 
     settings_json_dst = claude_dir / "settings.json"
     if not settings_json_dst.exists():

--- a/src/scitex_agent_container/runtimes/tui_session.py
+++ b/src/scitex_agent_container/runtimes/tui_session.py
@@ -136,6 +136,139 @@ def state_dir_for_config(config: AgentConfig) -> Path:
     return _runner.state_dir_for(config.name, root=root)
 
 
+def _verify_tui_process_env(
+    *,
+    session_name: str,
+    expected_home: str,
+    expected_claude_config_dir: str,
+    settle_s: float = 1.5,
+) -> None:
+    """Assert the inner ``claude`` process has the staged HOME +
+    CLAUDE_CONFIG_DIR set in its environ.
+
+    Lead a2a ``7a453a2a7ce0464ba67fd4b0c1d525fb`` (2026-06-14): when
+    the staged env did not stick on the inner ``claude`` process,
+    the operator saw the agent silently sit at the OAuth login URL
+    screen for hours — the only signal was a manual `tmux capture-
+    pane`. This helper closes that gap by reading
+    ``/proc/<claude-pid>/environ`` post-launch and FAILING LOUD via
+    :class:`TuiAuthStageError` when the values are missing /
+    mismatched. The SAC start path then surfaces a structural error
+    instead of stranding the operator at OAuth.
+
+    Best-effort: when ``ps`` / ``/proc`` cannot resolve the claude
+    PID (BSD host, container with PID-namespace isolation), we log
+    a one-line warning and return — the structural-alerts table
+    catches the boot-drain timeout that follows. We never silently
+    pass a wrong env.
+    """
+    import logging
+    import subprocess
+    import time as _time
+
+    if settle_s > 0:
+        _time.sleep(settle_s)
+
+    pid = _find_claude_pid_under_session(session_name)
+    if pid is None:
+        logging.getLogger(__name__).warning(
+            "TuiSessionRuntime: could not locate claude PID under "
+            "tmux session %s; skipping environ verification.",
+            session_name,
+        )
+        return
+
+    try:
+        environ_raw = Path(f"/proc/{pid}/environ").read_bytes()
+    except (FileNotFoundError, PermissionError) as exc:
+        logging.getLogger(__name__).warning(
+            "TuiSessionRuntime: cannot read /proc/%s/environ for "
+            "TUI env verification (%s); skipping.",
+            pid,
+            exc,
+        )
+        return
+
+    env: dict[str, str] = {}
+    for entry in environ_raw.split(b"\0"):
+        if not entry or b"=" not in entry:
+            continue
+        key_b, value_b = entry.split(b"=", 1)
+        env[key_b.decode("utf-8", errors="replace")] = value_b.decode(
+            "utf-8", errors="replace"
+        )
+
+    observed_home = env.get("HOME", "")
+    observed_config_dir = env.get("CLAUDE_CONFIG_DIR", "")
+    if (
+        observed_home != expected_home
+        or observed_config_dir != expected_claude_config_dir
+    ):
+        # Late import to dodge a circular dep (the auth-stage module
+        # already imports name_for / state_dir helpers from this one
+        # via ``stage_tui_auth``'s caller).
+        from ._tui_auth_stage import TuiAuthStageError
+
+        raise TuiAuthStageError(
+            "TUI auth: inner claude process is NOT using the staged "
+            "HOME. Operator-symptom: TUI parks at the OAuth login URL "
+            "screen because claude reads the host ~/.claude/ instead "
+            "of the staged <state>/home/.claude/. Diagnostic: "
+            f"observed HOME={observed_home!r} / "
+            f"CLAUDE_CONFIG_DIR={observed_config_dir!r}; expected "
+            f"HOME={expected_home!r} / "
+            f"CLAUDE_CONFIG_DIR={expected_claude_config_dir!r}. "
+            f"Pid={pid}, session={session_name!r}. Common root: "
+            "the launcher shell sourced login init files that "
+            "overwrote HOME (mitigation: TmuxManager now passes the "
+            "env via `tmux new-session -e` and drops the bash `-l` "
+            "flag — this error indicates the mitigation regressed)."
+        )
+    _ = subprocess  # keep import resolved for type-checkers / linters
+
+
+def _find_claude_pid_under_session(session_name: str) -> int | None:
+    """Walk ``ps -eo pid,ppid,comm`` for a ``claude`` process whose
+    parent chain rises through the tmux server. Returns ``None`` when
+    the host's ``ps`` lacks the columns we expect (BSD-style) or no
+    matching process is running yet.
+    """
+    import subprocess
+
+    try:
+        result = subprocess.run(
+            ["ps", "-eo", "pid,ppid,comm"], capture_output=True, text=True
+        )
+    except (FileNotFoundError, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    parent: dict[int, tuple[int, str]] = {}
+    for line in result.stdout.splitlines()[1:]:
+        parts = line.split(None, 2)
+        if len(parts) < 3:
+            continue
+        try:
+            pid = int(parts[0])
+            ppid = int(parts[1])
+        except ValueError:
+            continue
+        parent[pid] = (ppid, parts[2])
+    for pid, (_ppid, comm) in parent.items():
+        if comm != "claude" and not comm.startswith("claude"):
+            continue
+        cursor = pid
+        for _ in range(10):
+            ppid, _ = parent.get(cursor, (0, ""))
+            ancestor = parent.get(ppid)
+            if ancestor is None:
+                break
+            if "tmux" in ancestor[1] or "tmux" in str(parent.get(ppid, ("", ""))[1]):
+                return pid
+            cursor = ppid
+    return None
+
+
 class TuiSessionRuntime(RuntimeBase):
     """Interactive tmux-backed Claude TUI runtime.
 
@@ -275,18 +408,40 @@ class TuiSessionRuntime(RuntimeBase):
             or "/tmp"
         )
         env_exports = ""
+        session_env: dict[str, str] = {}
         if home_dir is not None:
             env_exports = (
                 f"export HOME={home_dir}\nexport CLAUDE_CONFIG_DIR={home_dir}/.claude\n"
             )
+            # Structural fix (lead a2a 8f910ea7, 2026-06-14): live
+            # host agents launched with `bash -l` which re-sourced
+            # login init files that reset HOME to the operator's
+            # real home; the inner `claude` then read the operator's
+            # `~/.claude/` instead of the staged `<state>/home/.claude/`
+            # and fell to interactive OAuth. Pass HOME +
+            # CLAUDE_CONFIG_DIR via tmux `new-session -e KEY=VAL`
+            # (and TmuxManager drops the bash `-l` flag) so the
+            # staged values can no longer be overwritten.
+            session_env = {
+                "HOME": str(home_dir),
+                "CLAUDE_CONFIG_DIR": f"{home_dir}/.claude",
+                "CLAUDE_DISABLE_AUTO_UPDATE": "1",
+            }
         started = bool(
             self._mux.start(
                 session_name=name,
                 command=self._claude_bin,
                 workdir=str(workdir),
                 env_exports=env_exports,
+                session_env=session_env or None,
             )
         )
+        if started and home_dir is not None:
+            _verify_tui_process_env(
+                session_name=name,
+                expected_home=str(home_dir),
+                expected_claude_config_dir=f"{home_dir}/.claude",
+            )
         if started and drain_pickers_at_boot:
             # URGENT (lead a2a 278159b5, 2026-06-14): drain the
             # picker registry AT BOOT so the supervisor + downstream

--- a/tests/scitex_agent_container/runtimes/test__tui_auth_stage.py
+++ b/tests/scitex_agent_container/runtimes/test__tui_auth_stage.py
@@ -331,12 +331,26 @@ class TestStageTuiAuthDefaults:
         # operator-host path we must not touch from a unit test).
         os.environ[CREDENTIALS_SRC_ENV] = str(creds_src)
         host_claude_json = Path(os.environ["HOME"]) / ".claude.json"
-        host_claude_json.write_text(json.dumps({"hasCompletedOnboarding": True}))
+        # Stage a fully-formed .claude.json — hasCompletedOnboarding=true
+        # AND a non-empty oauthAccount, because the post-2026-06-14
+        # fail-loud validators require both (a TUI staged with a partial
+        # .claude.json would fall back to interactive OAuth at runtime).
+        host_claude_json.write_text(
+            json.dumps(
+                {
+                    "hasCompletedOnboarding": True,
+                    "oauthAccount": {
+                        "accountUuid": "host-acct-uuid",
+                        "emailAddress": "host@example.com",
+                    },
+                }
+            )
+        )
         # Act
         stage_tui_auth(home_dir)
         # Assert — destination materialised from the default-resolved source.
         observed = json.loads((home_dir / ".claude.json").read_text())
-        assert observed == {"hasCompletedOnboarding": True}
+        assert observed["hasCompletedOnboarding"] is True
 
 
 # ---------------------------------------------------------------------------
@@ -400,13 +414,36 @@ class TestStageTuiAuthIdempotent:
         claude_json_src: Path,
         tmp_path: Path,
     ) -> None:
-        # Arrange — two distinct credential sources; stage A then B.
+        # Arrange — two distinct credential sources; both must satisfy
+        # the post-2026-06-14 fail-loud validators (non-empty oauth +
+        # future expiresAt). Tags differentiate which one was staged.
+        far_future = 9999999999999
+        token_a = "sk-ant-oat01-A" + "0" * 80
+        token_b = "sk-ant-oat01-B" + "1" * 80
         creds_a = tmp_path / "a" / ".credentials.json"
         creds_a.parent.mkdir(parents=True, exist_ok=True)
-        creds_a.write_text('{"version": "A"}')
+        creds_a.write_text(
+            json.dumps(
+                {
+                    "claudeAiOauth": {
+                        "accessToken": token_a,
+                        "expiresAt": far_future,
+                    }
+                }
+            )
+        )
         creds_b = tmp_path / "b" / ".credentials.json"
         creds_b.parent.mkdir(parents=True, exist_ok=True)
-        creds_b.write_text('{"version": "B"}')
+        creds_b.write_text(
+            json.dumps(
+                {
+                    "claudeAiOauth": {
+                        "accessToken": token_b,
+                        "expiresAt": far_future,
+                    }
+                }
+            )
+        )
         os.environ[CLAUDE_JSON_SRC_ENV] = str(claude_json_src)
 
         os.environ[CREDENTIALS_SRC_ENV] = str(creds_a)
@@ -414,9 +451,9 @@ class TestStageTuiAuthIdempotent:
         # Act — re-stage with the second source.
         os.environ[CREDENTIALS_SRC_ENV] = str(creds_b)
         stage_tui_auth(home_dir)
-        # Assert — destination reflects the LATER source.
-        observed = (home_dir / ".claude" / ".credentials.json").read_text()
-        assert observed == '{"version": "B"}'
+        # Assert — destination reflects the LATER source (token B).
+        observed = json.loads((home_dir / ".claude" / ".credentials.json").read_text())
+        assert observed["claudeAiOauth"]["accessToken"] == token_b
 
 
 # ---------------------------------------------------------------------------
@@ -579,14 +616,28 @@ class TestStageTuiAuthPinnedAccountSnapshot:
             / ".credentials.json"
         )
         snapshot.parent.mkdir(parents=True, exist_ok=True)
-        snapshot.write_text('{"version": "pinned-snapshot"}')
+        # Snapshot content must satisfy the fail-loud validators
+        # (claudeAiOauth.accessToken + future expiresAt) — the
+        # snapshot stores the realistic OAuth payload.
+        snapshot.write_text(
+            json.dumps(
+                {
+                    "claudeAiOauth": {
+                        "accessToken": "sk-ant-oat01-pinned-snapshot",
+                        "expiresAt": 9999999999999,
+                    }
+                }
+            )
+        )
         os.environ[CLAUDE_JSON_SRC_ENV] = str(claude_json_src)
         config = _StubConfig(claude=_StubClaude(account=acct))
         # Act
         stage_tui_auth(home_dir, config=config)
         # Assert — destination reflects the snapshot, not the chain default.
-        observed = (home_dir / ".claude" / ".credentials.json").read_text()
-        assert observed == '{"version": "pinned-snapshot"}'
+        observed = json.loads((home_dir / ".claude" / ".credentials.json").read_text())
+        assert (
+            observed["claudeAiOauth"]["accessToken"] == "sk-ant-oat01-pinned-snapshot"
+        )
 
     def test_pinned_account_with_missing_snapshot_falls_to_chain(
         self,
@@ -627,7 +678,18 @@ class TestStageTuiAuthHostFallbackChain:
         # bind, which exists and would short-circuit the test.
         host_creds = Path(os.environ["HOME"]) / ".claude" / ".credentials.json"
         host_creds.parent.mkdir(parents=True, exist_ok=True)
-        host_creds.write_text('{"version": "host-live"}')
+        # Host-live content must satisfy the fail-loud validators
+        # (claudeAiOauth.accessToken + future expiresAt).
+        host_creds.write_text(
+            json.dumps(
+                {
+                    "claudeAiOauth": {
+                        "accessToken": "sk-ant-oat01-host-live",
+                        "expiresAt": 9999999999999,
+                    }
+                }
+            )
+        )
         os.environ[CLAUDE_JSON_SRC_ENV] = str(claude_json_src)
         os.environ[CREDENTIALS_FALLBACK_CHAIN_ENV] = (
             f"/nope-container-bind/.credentials.json:{host_creds}"
@@ -635,8 +697,8 @@ class TestStageTuiAuthHostFallbackChain:
         # Act — config=None means unpinned; chain falls to host_live.
         stage_tui_auth(home_dir, config=None)
         # Assert
-        observed = (home_dir / ".claude" / ".credentials.json").read_text()
-        assert observed == '{"version": "host-live"}'
+        observed = json.loads((home_dir / ".claude" / ".credentials.json").read_text())
+        assert observed["claudeAiOauth"]["accessToken"] == "sk-ant-oat01-host-live"
 
     def test_error_lists_all_tried_paths_when_chain_exhausted(
         self,

--- a/tests/scitex_agent_container/runtimes/test_tui_session.py
+++ b/tests/scitex_agent_container/runtimes/test_tui_session.py
@@ -72,7 +72,13 @@ class _MemoryMultiplexer:
         workdir: str,
         env_exports: str = "",
         venv: str = "",
+        session_env: dict[str, str] | None = None,
     ) -> bool:
+        # ``session_env`` is the structural fix added 2026-06-14 (lead
+        # a2a 8f910ea7) so the in-memory mux mirrors the real
+        # TmuxManager signature; the fake doesn't actually plumb it
+        # anywhere — capturing the kwarg is enough for the runtime
+        # unit suite to exercise the dispatcher.
         cls._sessions[session_name] = _MemorySession(
             name=session_name,
             command=command,


### PR DESCRIPTION
## URGENT — 6/15 SDK cutoff blocker

Lead a2a 8f910ea7 / 7a453a2a (2026-06-14): 3 live host-side TUI agents (neurovista / paper-scitex-clew / ripple-wm) launched cleanly per PR #393/#398 but the inner `claude` process parked at the OAuth login URL screen — silently — for hours. Root cause: `bash -l` re-sourced login init files that reset HOME after our shell script's `export HOME=<state>/home` ran. The inner `claude` then read the operator's real `~/.claude/` (no usable creds in the OAuth schema the TUI expects) and fell to interactive OAuth.

## Fix (4 structural layers)
1. `TmuxManager.start` accepts `session_env` passed via `tmux new-session -e KEY=VAL` — tmux sets the env on the session itself; children inherit irrespective of shell init.
2. `TmuxManager.start` drops `bash -l` (uses `bash -c`) so login init files can't run.
3. `TuiSessionRuntime.start` builds `session_env = {HOME, CLAUDE_CONFIG_DIR, CLAUDE_DISABLE_AUTO_UPDATE}` and passes it. Legacy `env_exports` belt-and-suspenders stays.
4. New `_verify_tui_process_env` helper reads `/proc/<claude-pid>/environ`, asserts HOME + CLAUDE_CONFIG_DIR match. Raises loud `TuiAuthStageError` on mismatch — SAC catches the silent-OAuth class immediately, never strands the operator at the login URL.

Defense-in-depth (per lead): stage_tui_auth post-copy validators (`_assert_credentials_usable` + `_assert_claude_json_oauth_ready`) FAIL LOUD on missing claudeAiOauth.accessToken / expired tokens / missing oauthAccount / hasCompletedOnboarding≠true.

## Tests
65 LOCAL tests green (test_tui_session 25 + test__tui_auth_stage 24 + test_tmux_input_ready 16). Test fixtures updated to realistic OAuth payloads; in-memory `_MemoryMultiplexer.start` accepts the new `session_env` kwarg.

## CI status
GitHub Actions is infra-broken account-wide (account-level startup_failure, exhausted runner quota; dev #188 confirmed the same). Per lead's admin-merge authorization (a2a 083ce634), this lands on LOCAL-only green via `gh pr merge --admin --squash`.

## Verification protocol
After merge: operator pulls, flips ONE agent's spec back to `runtime: tui`, `sac agents start`, then `tr '\0' '\n' </proc/<claude-pid>/environ | grep -E 'HOME|CLAUDE_CONFIG_DIR'` should show the state home, AND the tmux pane should reach the input prompt (no OAuth URL). If clean, all three flip; if not, stay on SDK bridge.