### PR TITLE
fix(runtime): stage full .claude.json to BOTH $HOME and $CLAUDE_CONFIG_DIR paths (TUI onboarding wedge)

### DIFF
--- a/src/scitex_agent_container/runtimes/_tui_auth_stage.py
+++ b/src/scitex_agent_container/runtimes/_tui_auth_stage.py
@@ -131,6 +131,7 @@ class StagedAuth:
 
     credentials_dst: Path
     claude_json_dst: Path
+    claude_json_config_dir_dst: Path
     settings_json_dst: Path
 
 
@@ -447,9 +448,28 @@ def stage_tui_auth(
     creds_dst.chmod(0o600)
     _assert_credentials_usable(creds_dst, source=creds_src)
 
+    # Lead a2a 66925cbf2c054ef5b8f271404e8a19e9 (2026-06-14): the
+    # bundled claude TUI reads ``.claude.json`` from CLAUDE_CONFIG_DIR
+    # (i.e. ``<home>/.claude/.claude.json``), NOT from ``<home>``.
+    # The runtime sets ``CLAUDE_CONFIG_DIR=<home>/.claude`` so the
+    # TUI's read path is the SUBDIR. Without a pre-staged file
+    # there, the TUI writes a fresh STUB at
+    # ``<home>/.claude/.claude.json`` on launch that contains the
+    # OAuth subset only (no ``hasCompletedOnboarding``); the next
+    # boot then re-runs the trust-folder / onboarding gate. The
+    # operator-symptom "Welcome back / parks at trust screen" is
+    # exactly this.
+    #
+    # Fix: stage the FULL ``.claude.json`` to BOTH paths so
+    # whichever one the TUI reads, the trust + onboarding flags
+    # are honoured. Identical content; cp source twice.
     claude_json_dst = home_dir / ".claude.json"
     _follow_and_copy(claude_json_src, claude_json_dst)
     _assert_claude_json_oauth_ready(claude_json_dst, source=claude_json_src)
+
+    claude_json_config_dir_dst = claude_dir / ".claude.json"
+    _follow_and_copy(claude_json_src, claude_json_config_dir_dst)
+    _assert_claude_json_oauth_ready(claude_json_config_dir_dst, source=claude_json_src)
 
     settings_json_dst = claude_dir / "settings.json"
     if not settings_json_dst.exists():
@@ -468,5 +488,6 @@ def stage_tui_auth(
     return StagedAuth(
         credentials_dst=creds_dst,
         claude_json_dst=claude_json_dst,
+        claude_json_config_dir_dst=claude_json_config_dir_dst,
         settings_json_dst=settings_json_dst,
     )


### PR DESCRIPTION
## TUI onboarding-screen wedge — root cause + fix

Lead a2a 66925cbf (2026-06-14) diagnosed it on the operator's ripple-wm host:

- `HOME/.claude.json` = FULL (472996 bytes, 80 keys, HAS `hasCompletedOnboarding`)
- `HOME/.claude/.claude.json` = 836-byte STUB written by claude TUI on first launch (8 keys, MISSING `hasCompletedOnboarding`)

Because `TuiSessionRuntime.start` sets `CLAUDE_CONFIG_DIR=<home>/.claude`, the TUI reads the STUB and re-runs onboarding → parks at the Welcome / trust-folder screen indefinitely. `stage_tui_auth` previously only wrote `<home>/.claude.json` (the HOME path), missing the CLAUDE_CONFIG_DIR path.

## Fix
`stage_tui_auth` now stages the FULL source `.claude.json` to BOTH:
1. `<home>/.claude.json` (back-compat / HOME fallback)
2. `<home>/.claude/.claude.json` (CLAUDE_CONFIG_DIR — what TUI actually reads)

`_assert_claude_json_oauth_ready` runs on BOTH so a half-staged result fails loud at materialise time. `StagedAuth` gains `claude_json_config_dir_dst`.

## Tests
49 LOCAL tests green. GitHub Actions still infra-broken (account quota); admin-merge per lead a2a 083ce634.