### PR TITLE
fix(runtime): TUI send_turn uses bare send_text_and_submit (echo-verify false-failed)

### DIFF
--- a/src/scitex_agent_container/runtimes/tui_session.py
+++ b/src/scitex_agent_container/runtimes/tui_session.py
@@ -527,19 +527,18 @@ class TuiSessionRuntime(RuntimeBase):
             # an input-ready marker (the modal drain has no work
             # to do anyway). Real-binary callers always wait.
             self.wait_until_input_ready(config)
-        # Structural fix for the Ink-drop race (lead a2a
-        # ``910ff436642948eb85f8b3100204ed9b`` / ``b591f42c4c4944d18``,
-        # 2026-06-14). ``send_text_and_submit_verified`` polls
-        # capture-pane for the echo of ``text`` before committing
-        # Enter and re-sends on silent drops — defeats the React/Ink
-        # renderer race where keystrokes arriving mid-frame are
-        # eaten without trace. The plain ``send_text_and_submit``
-        # path is retained on TmuxManager / MultiplexerProtocol for
-        # the salvaged ``claude_code._run_startup_commands`` (which
-        # talks to its own UI state machine), but the runtime's
-        # turn delivery uses the verified primitive so each agent
-        # turn either lands or fails loud (TuiKeystrokeDropError).
-        self._mux.send_text_and_submit_verified(name, text)
+        # Bare send (lead a2a c6707941, 2026-06-14): operator's
+        # diagnostic on the live host proved `tmux send-keys <text>`
+        # + `tmux send-keys Enter` reaches the claude TUI input
+        # field and submits cleanly every time. The verified
+        # variant's echo-detection (substring match on Ink-rendered
+        # capture-pane glyphs) was raising TuiKeystrokeDropError
+        # despite the keystrokes landing — net effect was a 60s
+        # `sac agents send` timeout despite a working pipeline.
+        # Switch the default back to the bare primitive (the same
+        # one claude_code._run_startup_commands uses against
+        # startup_prompts).
+        self._mux.send_text_and_submit(name, text)
         return True
 
     def wait_until_input_ready(


### PR DESCRIPTION
Lead a2a c6707941 (2026-06-14) — host diagnostic isolated the turn-delivery wedge:

[A] `tmux send-keys -t SESS "hello-manual-test"` → pane shows `❯ hello-manual-test`. Reaches input.
[B] `tmux send-keys -t SESS Enter` → claude responds on Claude Max. Submits cleanly.
[C] `runtime.send_turn()` with verified primitive → 60s timeout.

The verified primitive's substring match against Ink-rendered capture-pane glyphs was missing the echo, retrying max times, raising `TuiKeystrokeDropError` despite keystrokes landing.

## Fix
`TuiSessionRuntime.send_turn` calls bare `send_text_and_submit` (the proven primitive `claude_code._run_startup_commands` uses). The verified variant remains for future Ink-drop instrumentation but is no longer on the hot path.

## Tests
25 LOCAL tui_session tests green. GitHub Actions still infra-broken (account quota); admin-merge per lead a2a 083ce634.

This is the LAST blocker between TUI auth and end-to-end turn delivery. Post-merge canary on a throwaway TUI agent expected to: drain modals → input prompt → `sac agents send` types + Enters → claude responds.