### PR TITLE
fix(channel): resolve sac binary to absolute path so MCP sidecar can spawn (P1a)

### DIFF
--- a/src/scitex_agent_container/runtimes/_sdk_channels.py
+++ b/src/scitex_agent_container/runtimes/_sdk_channels.py
@@ -45,9 +45,80 @@ from __future__ import annotations
 import json as _json
 import logging as _logging
 import os as _os
+import shutil as _shutil
 from pathlib import Path as _Path
 
 _log = _logging.getLogger(__name__)
+
+
+class SacBinaryNotFoundError(RuntimeError):
+    """The ``sac`` console script could not be resolved for the SDK to spawn.
+
+    Raised at MCP-config build time (inside ``apply_channels``) when the
+    operator requests ``server:sac`` but no executable ``sac`` exists on
+    PATH and no override is set. Letting the MCP config carry an
+    unresolvable bare ``sac`` command makes the SDK fail to spawn the
+    channel adapter SILENTLY — the agent then has no a2a inbox consumer
+    and lead/peer messages accumulate undelivered (smoke-tested
+    2026-06-15 on proj-scitex-agent-container: ``sac`` lived at
+    ``/opt/venv-agent/bin/sac`` while the SDK's PATH was
+    ``/opt/venv-sac/bin:...``, so the MCP child exec'd ``sac`` not found
+    and the inbox queued silently for hours). Failing loudly here makes
+    the misconfig visible at agent start, not three lead messages later.
+    """
+
+
+# Operator escape hatch: explicit absolute path overrides PATH lookup.
+# Set in env when ``sac`` is installed somewhere PATH does not see.
+SAC_BIN_ENV = "SAC_BIN"
+
+
+def _resolve_sac_binary() -> str:
+    """Return an absolute, executable path to the ``sac`` console script.
+
+    Resolution order (first hit wins):
+
+      1. ``$SAC_BIN`` env override — must point at an existing executable
+         file (raises ``SacBinaryNotFoundError`` when set but unusable, so
+         a typo'd override is loud rather than silently falling back to
+         the PATH search).
+      2. ``shutil.which("sac")`` — standard PATH lookup. Works on any host
+         that ships ``sac`` in its PATH (developer workstations, CI).
+      3. Known container candidate ``/opt/venv-agent/bin/sac`` — the SAC
+         agent-image install location. The SDK runner's PATH does not
+         include this directory (it inherits the SAC runtime's PATH which
+         is ``/opt/venv-sac/bin:...``), so the PATH search above misses
+         it; explicit candidate fixes the spawn for the in-container case.
+
+    Raises ``SacBinaryNotFoundError`` when no candidate resolves.
+    """
+    override = _os.environ.get(SAC_BIN_ENV)
+    if override:
+        if _Path(override).is_file() and _os.access(override, _os.X_OK):
+            return override
+        raise SacBinaryNotFoundError(
+            f"{SAC_BIN_ENV}={override!r} is set but the path is not an "
+            f"executable file. Fix the env or unset it to fall back to "
+            f"PATH lookup."
+        )
+
+    found = _shutil.which("sac")
+    if found:
+        return found
+
+    for candidate in ("/opt/venv-agent/bin/sac",):
+        if _Path(candidate).is_file() and _os.access(candidate, _os.X_OK):
+            return candidate
+
+    raise SacBinaryNotFoundError(
+        "Cannot resolve the `sac` console script: not on PATH and not at "
+        "any known candidate location (/opt/venv-agent/bin/sac). The MCP "
+        "sidecar config would carry a bare `sac` command that fails exec "
+        "silently in the SDK subprocess — the agent's a2a inbox would "
+        "have no consumer and lead messages would queue undelivered. "
+        f"Fix: install `sac` on PATH, or set ${SAC_BIN_ENV} to its "
+        "absolute path."
+    )
 
 
 def merge_home_mcp_servers(mcp_servers: dict) -> dict:
@@ -166,9 +237,15 @@ def apply_channels(
                     "--turn-url",
                     f"http://127.0.0.1:{int(a2a_port)}/v1/turn",
                 ]
+            # Resolve `sac` to an absolute path so the SDK subprocess can
+            # spawn the channel adapter regardless of its PATH. A bare
+            # ``"sac"`` command silently fails exec when the SDK's PATH
+            # does not contain the agent venv's bin dir — exactly the bug
+            # that left this agent's a2a inbox unsubscribed for hours on
+            # 2026-06-15 (see ``_resolve_sac_binary`` docstring).
             mcps["sac"] = {
                 "type": "stdio",
-                "command": "sac",
+                "command": _resolve_sac_binary(),
                 "args": sidecar_args,
             }
 

--- a/tests/scitex_agent_container/runtimes/test__sdk_channels.py
+++ b/tests/scitex_agent_container/runtimes/test__sdk_channels.py
@@ -285,7 +285,9 @@ class TestSacBinaryResolution:
         # Arrange — wipe PATH and $SAC_BIN so no candidate resolves; the
         # resolver still checks /opt/venv-agent/bin/sac as a last resort,
         # so we exercise the raise only when that path is absent on the
-        # test host (the case for CI/dev boxes).
+        # test host (the case for CI/dev boxes). ``match=`` pins the
+        # message-content contract (operator sees "sac" in the text) so
+        # one assertion covers both raise + content (STX-TQ007).
         import os.path as _osp
 
         if _osp.isfile("/opt/venv-agent/bin/sac"):
@@ -299,76 +301,33 @@ class TestSacBinaryResolution:
         os.environ["PATH"] = str(tmp_path)  # empty dir → no `sac`
         kwargs: dict = {}
         try:
-            # Act + Assert
-            with pytest.raises(SacBinaryNotFoundError):
-                apply_channels(kwargs, ["server:sac"], 9999, "lead")
-        finally:
-            os.environ["PATH"] = saved_path
-            if saved_sac_bin is not None:
-                os.environ[SAC_BIN_ENV] = saved_sac_bin
-
-    def test_unresolvable_sac_message_names_sac(self, tmp_path):
-        # Arrange — same setup as the raise-loudly sibling; this test
-        # pins the message-content contract (operator sees "sac" in the
-        # text) so a future refactor of the message can't accidentally
-        # drop the name.
-        import os.path as _osp
-
-        if _osp.isfile("/opt/venv-agent/bin/sac"):
-            pytest.skip(
-                "/opt/venv-agent/bin/sac exists on this host; resolver "
-                "would not raise. Skipping the message-content pin."
-            )
-        saved_sac_bin = os.environ.pop(SAC_BIN_ENV, None)
-        saved_path = os.environ.get("PATH", "")
-        os.environ["PATH"] = str(tmp_path)
-        kwargs: dict = {}
-        try:
             # Act
-            with pytest.raises(SacBinaryNotFoundError) as exc_info:
+            # Assert
+            with pytest.raises(SacBinaryNotFoundError, match=r"(?i)sac"):
                 apply_channels(kwargs, ["server:sac"], 9999, "lead")
         finally:
             os.environ["PATH"] = saved_path
             if saved_sac_bin is not None:
                 os.environ[SAC_BIN_ENV] = saved_sac_bin
-        # Assert
-        assert "sac" in str(exc_info.value).lower()
 
     def test_sac_bin_pointing_at_nonexistent_path_raises(self, tmp_path):
-        # Arrange — typo'd override must fail loudly, never silently
-        # fall back to PATH lookup (an operator typo would mask the
-        # override and the wrong binary would get spawned).
-        saved_sac_bin = os.environ.get(SAC_BIN_ENV)
-        os.environ[SAC_BIN_ENV] = str(tmp_path / "does-not-exist")
-        kwargs: dict = {}
-        try:
-            # Act + Assert
-            with pytest.raises(SacBinaryNotFoundError):
-                apply_channels(kwargs, ["server:sac"], 9999, "lead")
-        finally:
-            if saved_sac_bin is None:
-                os.environ.pop(SAC_BIN_ENV, None)
-            else:
-                os.environ[SAC_BIN_ENV] = saved_sac_bin
-
-    def test_sac_bin_typo_message_names_env_var(self, tmp_path):
-        # Arrange — sibling to the raise test; pins that the error
-        # message names the SAC_BIN_ENV env var so the operator sees
-        # which variable they need to fix.
+        # Arrange — typo'd override must fail loudly and the message
+        # MUST name the SAC_BIN_ENV env var so the operator sees which
+        # variable to fix. ``match=SAC_BIN_ENV`` pins both contracts in
+        # one assertion (STX-TQ007).
         saved_sac_bin = os.environ.get(SAC_BIN_ENV)
         os.environ[SAC_BIN_ENV] = str(tmp_path / "does-not-exist")
         kwargs: dict = {}
         try:
             # Act
-            with pytest.raises(SacBinaryNotFoundError) as exc_info:
+            # Assert
+            with pytest.raises(SacBinaryNotFoundError, match=SAC_BIN_ENV):
                 apply_channels(kwargs, ["server:sac"], 9999, "lead")
         finally:
             if saved_sac_bin is None:
                 os.environ.pop(SAC_BIN_ENV, None)
             else:
                 os.environ[SAC_BIN_ENV] = saved_sac_bin
-        # Assert
-        assert SAC_BIN_ENV in str(exc_info.value)
 
 
 class TestBothChannelsCoexist:

--- a/tests/scitex_agent_container/runtimes/test__sdk_channels.py
+++ b/tests/scitex_agent_container/runtimes/test__sdk_channels.py
@@ -282,11 +282,10 @@ class TestSacBinaryResolution:
                 os.environ[SAC_BIN_ENV] = saved_sac_bin
 
     def test_unresolvable_sac_raises_loudly(self, tmp_path):
-        # Arrange — wipe PATH and $SAC_BIN so no candidate resolves; also
-        # forbid the in-container fallback path by pointing $PATH at an
-        # empty dir (the resolver still checks /opt/venv-agent/bin/sac as
-        # a last resort, so we exercise the raise only when that path is
-        # absent on the test host — which is the case for CI/dev boxes).
+        # Arrange — wipe PATH and $SAC_BIN so no candidate resolves; the
+        # resolver still checks /opt/venv-agent/bin/sac as a last resort,
+        # so we exercise the raise only when that path is absent on the
+        # test host (the case for CI/dev boxes).
         import os.path as _osp
 
         if _osp.isfile("/opt/venv-agent/bin/sac"):
@@ -298,34 +297,78 @@ class TestSacBinaryResolution:
         saved_sac_bin = os.environ.pop(SAC_BIN_ENV, None)
         saved_path = os.environ.get("PATH", "")
         os.environ["PATH"] = str(tmp_path)  # empty dir → no `sac`
+        kwargs: dict = {}
         try:
-            kwargs: dict = {}
             # Act + Assert
-            with pytest.raises(SacBinaryNotFoundError) as exc_info:
+            with pytest.raises(SacBinaryNotFoundError):
                 apply_channels(kwargs, ["server:sac"], 9999, "lead")
-            assert "sac" in str(exc_info.value).lower()
         finally:
             os.environ["PATH"] = saved_path
             if saved_sac_bin is not None:
                 os.environ[SAC_BIN_ENV] = saved_sac_bin
 
-    def test_sac_bin_pointing_at_nonexistent_path_raises(self, tmp_path):
-        # Arrange — typo'd override must fail loudly, never silently fall
-        # back to PATH lookup (otherwise an operator typo silently masks
-        # the override and the wrong binary gets spawned).
-        saved_sac_bin = os.environ.get(SAC_BIN_ENV)
-        os.environ[SAC_BIN_ENV] = str(tmp_path / "does-not-exist")
+    def test_unresolvable_sac_message_names_sac(self, tmp_path):
+        # Arrange — same setup as the raise-loudly sibling; this test
+        # pins the message-content contract (operator sees "sac" in the
+        # text) so a future refactor of the message can't accidentally
+        # drop the name.
+        import os.path as _osp
+
+        if _osp.isfile("/opt/venv-agent/bin/sac"):
+            pytest.skip(
+                "/opt/venv-agent/bin/sac exists on this host; resolver "
+                "would not raise. Skipping the message-content pin."
+            )
+        saved_sac_bin = os.environ.pop(SAC_BIN_ENV, None)
+        saved_path = os.environ.get("PATH", "")
+        os.environ["PATH"] = str(tmp_path)
+        kwargs: dict = {}
         try:
-            kwargs: dict = {}
-            # Act + Assert
+            # Act
             with pytest.raises(SacBinaryNotFoundError) as exc_info:
                 apply_channels(kwargs, ["server:sac"], 9999, "lead")
-            assert SAC_BIN_ENV in str(exc_info.value)
+        finally:
+            os.environ["PATH"] = saved_path
+            if saved_sac_bin is not None:
+                os.environ[SAC_BIN_ENV] = saved_sac_bin
+        # Assert
+        assert "sac" in str(exc_info.value).lower()
+
+    def test_sac_bin_pointing_at_nonexistent_path_raises(self, tmp_path):
+        # Arrange — typo'd override must fail loudly, never silently
+        # fall back to PATH lookup (an operator typo would mask the
+        # override and the wrong binary would get spawned).
+        saved_sac_bin = os.environ.get(SAC_BIN_ENV)
+        os.environ[SAC_BIN_ENV] = str(tmp_path / "does-not-exist")
+        kwargs: dict = {}
+        try:
+            # Act + Assert
+            with pytest.raises(SacBinaryNotFoundError):
+                apply_channels(kwargs, ["server:sac"], 9999, "lead")
         finally:
             if saved_sac_bin is None:
                 os.environ.pop(SAC_BIN_ENV, None)
             else:
                 os.environ[SAC_BIN_ENV] = saved_sac_bin
+
+    def test_sac_bin_typo_message_names_env_var(self, tmp_path):
+        # Arrange — sibling to the raise test; pins that the error
+        # message names the SAC_BIN_ENV env var so the operator sees
+        # which variable they need to fix.
+        saved_sac_bin = os.environ.get(SAC_BIN_ENV)
+        os.environ[SAC_BIN_ENV] = str(tmp_path / "does-not-exist")
+        kwargs: dict = {}
+        try:
+            # Act
+            with pytest.raises(SacBinaryNotFoundError) as exc_info:
+                apply_channels(kwargs, ["server:sac"], 9999, "lead")
+        finally:
+            if saved_sac_bin is None:
+                os.environ.pop(SAC_BIN_ENV, None)
+            else:
+                os.environ[SAC_BIN_ENV] = saved_sac_bin
+        # Assert
+        assert SAC_BIN_ENV in str(exc_info.value)
 
 
 class TestBothChannelsCoexist:

--- a/tests/scitex_agent_container/runtimes/test__sdk_channels.py
+++ b/tests/scitex_agent_container/runtimes/test__sdk_channels.py
@@ -25,11 +25,34 @@ import os
 import pytest
 
 from scitex_agent_container.runtimes._sdk_channels import (
+    SAC_BIN_ENV,
+    SacBinaryNotFoundError,
     TelegrammerWakeWiringError,
     apply_channels,
     merge_home_mcp_servers,
     validate_telegrammer_wake_wiring,
 )
+
+
+@pytest.fixture
+def fake_sac_bin(tmp_path):
+    """Materialize an executable fake ``sac`` script and point ``$SAC_BIN``
+    at it. Yields the absolute path so tests can assert on the exact value.
+
+    Yield-based save/restore of ``$SAC_BIN`` (PA-306: no monkeypatch).
+    """
+    fake = tmp_path / "sac"
+    fake.write_text("#!/bin/sh\nexit 0\n")
+    fake.chmod(0o755)
+    saved = os.environ.get(SAC_BIN_ENV)
+    os.environ[SAC_BIN_ENV] = str(fake)
+    try:
+        yield str(fake)
+    finally:
+        if saved is None:
+            os.environ.pop(SAC_BIN_ENV, None)
+        else:
+            os.environ[SAC_BIN_ENV] = saved
 
 
 @pytest.fixture
@@ -153,10 +176,11 @@ class TestTelegrammerWakeWiring:
             "http://operator.example/v1/turn"
         )
 
-    def test_no_injection_without_telegrammer_channel(self):
+    def test_no_injection_without_telegrammer_channel(self, fake_sac_bin):
         # Arrange
         kwargs = self._kwargs_with_telegrammer_mcp()
-        # Act — channel not requested, only the MCP entry present
+        # Act — channel not requested, only the MCP entry present.
+        # ``fake_sac_bin`` so the sac sidecar resolver does not raise.
         apply_channels(kwargs, ["server:sac"], 19007, "clew")
         # Assert
         env = kwargs["mcp_servers"]["claude-code-telegrammer"]["env"]
@@ -172,9 +196,13 @@ class TestTelegrammerWakeWiring:
 
 
 class TestSacChannelStillWorks:
-    """``server:sac`` keeps both the dev flag and the sidecar registration."""
+    """``server:sac`` keeps both the dev flag and the sidecar registration.
 
-    def test_sac_channel_sets_dev_flag(self):
+    All tests here depend on ``fake_sac_bin`` so the binary resolver returns
+    a deterministic absolute path instead of raising SacBinaryNotFoundError.
+    """
+
+    def test_sac_channel_sets_dev_flag(self, fake_sac_bin):
         # Arrange
         kwargs: dict = {}
         # Act
@@ -182,15 +210,16 @@ class TestSacChannelStillWorks:
         # Assert
         assert _devflag(kwargs) == "server:sac"
 
-    def test_sac_channel_registers_sac_mcp(self):
-        # Arrange
+    def test_sac_channel_registers_sac_mcp(self, fake_sac_bin):
+        # Arrange — SAC_BIN points at a real executable so the resolver
+        # returns a deterministic absolute path (see fake_sac_bin fixture).
         kwargs: dict = {}
         # Act
         apply_channels(kwargs, ["server:sac"], 9999, "lead")
         # Assert
-        assert kwargs["mcp_servers"]["sac"]["command"] == "sac"
+        assert kwargs["mcp_servers"]["sac"]["command"] == fake_sac_bin
 
-    def test_sac_sidecar_carries_turn_url_for_wake(self):
+    def test_sac_sidecar_carries_turn_url_for_wake(self, fake_sac_bin):
         # Arrange
         kwargs: dict = {}
         # Act
@@ -199,7 +228,7 @@ class TestSacChannelStillWorks:
         args = kwargs["mcp_servers"]["sac"]["args"]
         assert args[args.index("--turn-url") + 1] == "http://127.0.0.1:9999/v1/turn"
 
-    def test_sac_sidecar_omits_turn_url_when_no_a2a_port(self):
+    def test_sac_sidecar_omits_turn_url_when_no_a2a_port(self, fake_sac_bin):
         # Arrange
         kwargs: dict = {}
         # Act
@@ -208,10 +237,105 @@ class TestSacChannelStillWorks:
         assert "--turn-url" not in kwargs["mcp_servers"]["sac"]["args"]
 
 
-class TestBothChannelsCoexist:
-    """An agent can request both its own channel AND the sac bus channel."""
+class TestSacBinaryResolution:
+    """``server:sac`` must spawn ``sac`` via an absolute, executable path —
+    a bare ``"sac"`` command in the MCP config fails exec silently when the
+    SDK subprocess's PATH does not contain the agent venv's bin dir, and
+    the a2a inbox then has no consumer (smoke-tested 2026-06-15 on
+    proj-scitex-agent-container; lead messages queued undelivered for
+    hours). This contract is the loud-fail guard."""
 
-    def test_dev_flag_lists_both_channels_comma_joined(self):
+    def test_sac_bin_env_override_is_honoured(self, fake_sac_bin):
+        # Arrange — fake_sac_bin already sets $SAC_BIN to the fake script
+        kwargs: dict = {}
+        # Act
+        apply_channels(kwargs, ["server:sac"], 9999, "lead")
+        # Assert
+        assert kwargs["mcp_servers"]["sac"]["command"] == fake_sac_bin
+
+    def test_command_is_absolute_path(self, fake_sac_bin):
+        # Arrange
+        kwargs: dict = {}
+        # Act
+        apply_channels(kwargs, ["server:sac"], 9999, "lead")
+        # Assert
+        cmd = kwargs["mcp_servers"]["sac"]["command"]
+        assert os.path.isabs(cmd), f"command must be absolute path: {cmd!r}"
+
+    def test_resolves_via_path_when_no_env_override(self, tmp_path):
+        # Arrange — drop $SAC_BIN, install fake `sac` on PATH only
+        fake = tmp_path / "sac"
+        fake.write_text("#!/bin/sh\nexit 0\n")
+        fake.chmod(0o755)
+        saved_sac_bin = os.environ.pop(SAC_BIN_ENV, None)
+        saved_path = os.environ.get("PATH", "")
+        os.environ["PATH"] = str(tmp_path)
+        try:
+            kwargs: dict = {}
+            # Act
+            apply_channels(kwargs, ["server:sac"], 9999, "lead")
+            # Assert
+            assert kwargs["mcp_servers"]["sac"]["command"] == str(fake)
+        finally:
+            os.environ["PATH"] = saved_path
+            if saved_sac_bin is not None:
+                os.environ[SAC_BIN_ENV] = saved_sac_bin
+
+    def test_unresolvable_sac_raises_loudly(self, tmp_path):
+        # Arrange — wipe PATH and $SAC_BIN so no candidate resolves; also
+        # forbid the in-container fallback path by pointing $PATH at an
+        # empty dir (the resolver still checks /opt/venv-agent/bin/sac as
+        # a last resort, so we exercise the raise only when that path is
+        # absent on the test host — which is the case for CI/dev boxes).
+        import os.path as _osp
+
+        if _osp.isfile("/opt/venv-agent/bin/sac"):
+            pytest.skip(
+                "/opt/venv-agent/bin/sac exists on this host; resolver "
+                "will find it via the candidate fallback. Test cannot "
+                "drive the unresolvable branch without further isolation."
+            )
+        saved_sac_bin = os.environ.pop(SAC_BIN_ENV, None)
+        saved_path = os.environ.get("PATH", "")
+        os.environ["PATH"] = str(tmp_path)  # empty dir → no `sac`
+        try:
+            kwargs: dict = {}
+            # Act + Assert
+            with pytest.raises(SacBinaryNotFoundError) as exc_info:
+                apply_channels(kwargs, ["server:sac"], 9999, "lead")
+            assert "sac" in str(exc_info.value).lower()
+        finally:
+            os.environ["PATH"] = saved_path
+            if saved_sac_bin is not None:
+                os.environ[SAC_BIN_ENV] = saved_sac_bin
+
+    def test_sac_bin_pointing_at_nonexistent_path_raises(self, tmp_path):
+        # Arrange — typo'd override must fail loudly, never silently fall
+        # back to PATH lookup (otherwise an operator typo silently masks
+        # the override and the wrong binary gets spawned).
+        saved_sac_bin = os.environ.get(SAC_BIN_ENV)
+        os.environ[SAC_BIN_ENV] = str(tmp_path / "does-not-exist")
+        try:
+            kwargs: dict = {}
+            # Act + Assert
+            with pytest.raises(SacBinaryNotFoundError) as exc_info:
+                apply_channels(kwargs, ["server:sac"], 9999, "lead")
+            assert SAC_BIN_ENV in str(exc_info.value)
+        finally:
+            if saved_sac_bin is None:
+                os.environ.pop(SAC_BIN_ENV, None)
+            else:
+                os.environ[SAC_BIN_ENV] = saved_sac_bin
+
+
+class TestBothChannelsCoexist:
+    """An agent can request both its own channel AND the sac bus channel.
+
+    Depends on ``fake_sac_bin`` because the sac sidecar registration goes
+    through the absolute-path resolver.
+    """
+
+    def test_dev_flag_lists_both_channels_comma_joined(self, fake_sac_bin):
         # Arrange
         kwargs: dict = {}
         # Act
@@ -221,7 +345,7 @@ class TestBothChannelsCoexist:
         # Assert: claude needs the full set to render both channels' tags.
         assert _devflag(kwargs) == "server:sac,server:claude-code-telegrammer"
 
-    def test_sac_mcp_registered_when_sac_present_among_many(self):
+    def test_sac_mcp_registered_when_sac_present_among_many(self, fake_sac_bin):
         # Arrange
         kwargs: dict = {}
         # Act
@@ -235,10 +359,10 @@ class TestBothChannelsCoexist:
 class TestDedupeAndNormalization:
     """Whitespace + duplicate channel entries are normalized."""
 
-    def test_duplicate_channels_collapse_in_dev_flag(self):
+    def test_duplicate_channels_collapse_in_dev_flag(self, fake_sac_bin):
         # Arrange
         kwargs: dict = {}
-        # Act
+        # Act — ``fake_sac_bin`` so the sac sidecar resolver does not raise.
         apply_channels(kwargs, ["server:sac", " server:sac "], None, "lead")
         # Assert
         assert _devflag(kwargs) == "server:sac"

--- a/tests/scitex_agent_container/runtimes/test__sdk_channels.py
+++ b/tests/scitex_agent_container/runtimes/test__sdk_channels.py
@@ -281,21 +281,20 @@ class TestSacBinaryResolution:
             if saved_sac_bin is not None:
                 os.environ[SAC_BIN_ENV] = saved_sac_bin
 
+    @pytest.mark.skipif(
+        os.path.isfile("/opt/venv-agent/bin/sac"),
+        reason=(
+            "/opt/venv-agent/bin/sac exists on this host; resolver will "
+            "find it via the candidate fallback. Test cannot drive the "
+            "unresolvable branch without further isolation."
+        ),
+    )
     def test_unresolvable_sac_raises_loudly(self, tmp_path):
         # Arrange — wipe PATH and $SAC_BIN so no candidate resolves; the
         # resolver still checks /opt/venv-agent/bin/sac as a last resort,
         # so we exercise the raise only when that path is absent on the
         # test host (the case for CI/dev boxes). ``match=`` pins the
-        # message-content contract (operator sees "sac" in the text) so
-        # one assertion covers both raise + content (STX-TQ007).
-        import os.path as _osp
-
-        if _osp.isfile("/opt/venv-agent/bin/sac"):
-            pytest.skip(
-                "/opt/venv-agent/bin/sac exists on this host; resolver "
-                "will find it via the candidate fallback. Test cannot "
-                "drive the unresolvable branch without further isolation."
-            )
+        # message-content contract (one assertion = STX-TQ007 clean).
         saved_sac_bin = os.environ.pop(SAC_BIN_ENV, None)
         saved_path = os.environ.get("PATH", "")
         os.environ["PATH"] = str(tmp_path)  # empty dir → no `sac`

--- a/tests/scitex_agent_container/runtimes/test__sdk_common.py
+++ b/tests/scitex_agent_container/runtimes/test__sdk_common.py
@@ -893,7 +893,19 @@ class TestChannelSidecar:
     """
 
     @pytest.fixture
-    def _sac_channel_opts(self, sdk_env: _Env, tmp_path):
+    def _fake_sac_bin(self, sdk_env: _Env, tmp_path):
+        """Materialize an executable fake ``sac`` and point ``$SAC_BIN`` at it
+        so ``apply_channels``' binary resolver returns a deterministic
+        absolute path instead of raising ``SacBinaryNotFoundError``. Yields
+        the absolute path so assertions can pin the exact value."""
+        fake = tmp_path / "sac"
+        fake.write_text("#!/bin/sh\nexit 0\n")
+        fake.chmod(0o755)
+        sdk_env.setenv("SAC_BIN", str(fake))
+        return str(fake)
+
+    @pytest.fixture
+    def _sac_channel_opts(self, sdk_env: _Env, tmp_path, _fake_sac_bin):
         # Arrange: a VALID cred file present so auth needs no env mutation.
         _write_valid_cred(sdk_env, tmp_path)
         sdk_env.delenv("ANTHROPIC_API_KEY")
@@ -907,13 +919,13 @@ class TestChannelSidecar:
         )
         return opts
 
-    def test_registers_sac_stdio_mcp(self, _sac_channel_opts):
+    def test_registers_sac_stdio_mcp(self, _sac_channel_opts, _fake_sac_bin):
         # Arrange
         servers = _sac_channel_opts.mcp_servers  # type: ignore[operator]
         # Act
         sac = servers.get("sac")
-        # Assert
-        assert sac is not None and sac["command"] == "sac"
+        # Assert — resolver wires the SAC_BIN-overridden absolute path
+        assert sac is not None and sac["command"] == _fake_sac_bin
 
     def test_sidecar_args_subscribe_to_named_agent_inbox(self, _sac_channel_opts):
         # Arrange
@@ -963,8 +975,12 @@ class TestChannelSidecar:
         # Assert
         assert listen_url is None or listen_url == os.environ.get("SAC_LISTEN_BASE_URL")
 
-    def test_no_error_when_a2a_port_absent(self, sdk_env: _Env, tmp_path):
+    def test_no_error_when_a2a_port_absent(
+        self, sdk_env: _Env, tmp_path, _fake_sac_bin
+    ):
         # Arrange: valid cred present; channels set but NO _a2a_port threaded.
+        # ``_fake_sac_bin`` provides $SAC_BIN so the binary resolver does not
+        # raise SacBinaryNotFoundError on test hosts that lack ``sac`` on PATH.
         _write_valid_cred(sdk_env, tmp_path)
         sdk_env.delenv("ANTHROPIC_API_KEY")
         sdk_env.delenv(_SAC_KEY)


### PR DESCRIPTION
## Summary
- Resolve the `sac` console script to an absolute path before wiring it into the SDK MCP config (was a bare `"command": "sac"` that the SDK subprocess could not exec when its PATH did not contain the agent venv's bin dir).
- Loud-fail with `SacBinaryNotFoundError` when no candidate resolves — the silent exec-fail class is exactly the failure mode this PR closes.
- This is **PR #1 of 2** for lead's P1 a2a-unify directive (2026-06-15). PR #2 will delete `sac peer post-turn` and migrate callers to MCP a2a (larger refactor).

## Why now
Smoke-tested 2026-06-15 on `proj-scitex-agent-container`:
- `pgrep -af 'sac mcp channel'` returned no process despite the MCP config wiring it.
- `which sac` failed in the SDK process env (PATH = `/opt/venv-sac/bin:...`, but `sac` lives at `/opt/venv-agent/bin/sac`).
- Manual SSE drain of `http://127.0.0.1:7878/agents/proj-scitex-agent-container/inbox/stream` delivered 2 queued lead messages including today's orientation — confirming the inbox had been holding messages with no consumer for hours.

Lead's exact words: *"your a2a inbox is currently NOT subscribed — diagnose and fix your own listen/channel adapter as part of (1)."*

## Resolution order
`_resolve_sac_binary()` (in `runtimes/_sdk_channels.py`):
1. `$SAC_BIN` env override — must point at an executable file; typo'd override raises (no silent fallback).
2. `shutil.which("sac")` — standard PATH lookup for developer hosts / CI.
3. Known container candidate `/opt/venv-agent/bin/sac` — the SAC agent-image install location.

If none resolve: `SacBinaryNotFoundError` with the explicit fix path.

## Test plan
- [x] `pytest tests/scitex_agent_container/runtimes/test__sdk_channels.py` — 39 passed, 1 skipped (skip is the unresolvable-sac branch, intentionally guarded against the in-container `/opt/venv-agent/bin/sac` fallback).
- [x] `pytest tests/scitex_agent_container/runtimes/` — 782 passed, 1 skipped, 14 errors. The 14 errors are pre-existing `TuiAuthStageError` in `test_tui_session_real_smoke.py` (missing `hasCompletedOnboarding=true` fixture), unrelated to this change.
- [ ] Operator verifies after restart that the in-container `pgrep -af 'sac mcp channel'` shows a live process and lead a2a delivery is back.

## Out of scope (deferred to PR #2)
- Delete `sac peer post-turn` CLI command + helpers.
- Migrate ~12 src files / ~9 test files from `peer.post_turn()` / `_send_turn_to_remote_peer()` to the MCP `a2a_send` tool.
- Optional: add `validate_sac_channel_wiring()` preflight in `_lifecycle/_start.py` mirroring `validate_telegrammer_wake_wiring` (the runtime-side loud-fail in `_resolve_sac_binary` already covers the case, but a host-side preflight catches the misconfig before agent boot).

Refs: P1 a2a-unify (self-fix portion); lead a2a 2026-06-15.