### PR TITLE
feat(tui): claude exec inside apptainer SIF + MCP/cred-leak fixes (P0 2026-06-15)

### DIFF
--- a/docs/adr/0009-claude-setup-delivery-to-home-first.md
+++ b/docs/adr/0009-claude-setup-delivery-to-home-first.md
@@ -60,7 +60,7 @@ host bind or a host auto-read.
 
 ### Symlink resolution — definition is the sole source of truth
 
-Materialize walks **both** the global `_base/to_home/` and the per-agent
+Materialize walks **both** the global `_shared/to_home/` and the per-agent
 `to_home/` and copies their content into the container `$HOME`
 (`/home/agent`). The rule for symlinks:
 
@@ -77,7 +77,7 @@ Materialize walks **both** the global `_base/to_home/` and the per-agent
   `~/.claude/skills` (and no `~/.claude/skills` fallback). The only way
   host content enters the container is via an **explicit** symlink the
   operator places under `to_home/` — e.g.
-  `_base/to_home/.claude/skills -> ~/.claude/skills` — which the walk
+  `_shared/to_home/.claude/skills -> ~/.claude/skills` — which the walk
   resolves to real content at deploy time. That is explicit-pass, and it
   is intended.
 - **No "keep literal symlink" / warn-and-keep / naming-convention

--- a/src/scitex_agent_container/_baseline_assets/claude_worktree_hooks/README.md
+++ b/src/scitex_agent_container/_baseline_assets/claude_worktree_hooks/README.md
@@ -32,13 +32,13 @@ prevention and cleanup meet in the same tree.
 
 1. Copy `worktree_create.py` and `worktree_remove.py` to the baseline:
 
-       <agents_dir>/_base/to_home/.claude/hooks/claude_worktree_hooks/
+       <agents_dir>/_shared/to_home/.claude/hooks/claude_worktree_hooks/
 
    The runtime's `_to_home.py` materializes that tree into every
    agent's `$HOME/.claude/hooks/claude_worktree_hooks/` on each start.
 
 2. Merge the `hooks` block from `settings.local.json.fragment.json`
-   into `<agents_dir>/_base/to_home/.claude/settings.local.json`
+   into `<agents_dir>/_shared/to_home/.claude/settings.local.json`
    (under the top-level `hooks` key). The fragment's `_comment_*`
    string carries the source-of-truth audit trail and should be
    preserved.

--- a/src/scitex_agent_container/_lifecycle/_runtime_select.py
+++ b/src/scitex_agent_container/_lifecycle/_runtime_select.py
@@ -33,8 +33,10 @@ def _get_runtime(config: AgentConfig):
     """Return the runtime adapter for the config's launch mode.
 
     Branches on ``config.runtime`` (the launch-mode selector).
-    Back-compat: an empty string or the legacy ``"apptainer"`` value
-    (the old container-engine selector) maps to ``"claude-agent-sdk"``
+    Default: an empty / unset ``runtime`` selects the interactive
+    in-apptainer ``tui`` runtime (operator directive 2026-06-15).
+    Back-compat: the legacy ``"apptainer"`` value (the old
+    container-engine selector) maps to ``"claude-agent-sdk"``
     SILENTLY. The deprecation log for ``runtime='apptainer'`` fires
     at the actual start path
     (:func:`_lifecycle._start.start_agent`) — not here, because
@@ -48,19 +50,23 @@ def _get_runtime(config: AgentConfig):
     something, not on every read.
     """
     runtime = config.runtime or ""
-    if runtime in ("", "apptainer", "claude-agent-sdk"):
-        from ..runtimes.claude_session import ClaudeSessionRuntime
-
-        return ClaudeSessionRuntime()
-    if runtime == "tui":
+    # TUI is the default launch mode (operator directive 2026-06-15,
+    # post the SDK-pool cutoff): empty / unset → interactive in-apptainer
+    # TUI. Explicit legacy values still map to the headless SDK runner so
+    # existing SDK specs are untouched.
+    if runtime in ("", "tui"):
         from ..runtimes.tui_session import TuiSessionRuntime
 
         return TuiSessionRuntime()
+    if runtime in ("apptainer", "claude-agent-sdk"):
+        from ..runtimes.claude_session import ClaudeSessionRuntime
+
+        return ClaudeSessionRuntime()
     raise ValueError(
         f"Unsupported runtime: {runtime!r}. "
-        "spec.runtime must be 'claude-agent-sdk' (default), 'tui' "
-        "(June-15 SDK-pool-cutoff pivot), or the back-compat "
-        "'apptainer' / '' (mapped to 'claude-agent-sdk' at dispatch)."
+        "spec.runtime must be 'tui' (default, interactive in-apptainer "
+        "TUI), 'claude-agent-sdk' (headless SDK runner), or the "
+        "back-compat 'apptainer' (mapped to 'claude-agent-sdk')."
     )
 
 

--- a/src/scitex_agent_container/_skills/scitex-agent-container/01_config-v3.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/01_config-v3.md
@@ -105,7 +105,7 @@ Every path under `to_home/` lands at the same relative path under
 `$HOME`. `CLAUDE.md` / `state.md` get a marker-protected merge; `.env`
 gets mode 0600; everything else is a full overwrite. `${VAR}` and
 `${metadata.name}` are interpolated in text files. A shared baseline
-`to_home/` (`<agents_dir>/_base/to_home`, override `$SAC_TO_HOME_BASELINE`)
+`to_home/` (`<agents_dir>/_shared/to_home`, override `$SAC_TO_HOME_BASELINE`)
 is applied first; the per-agent `to_home/` overlays on top.
 
 | Source | Destination | Mode | Semantics |

--- a/src/scitex_agent_container/_skills/scitex-agent-container/25_claude-setup-delivery.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/25_claude-setup-delivery.md
@@ -55,7 +55,7 @@ content (see "Symlink resolution" below), never via a host auto-read.
 
 ### Scope / non-goals
 
-SAC guarantees this model only: per-agent `to_home` + the `_base` baseline, with
+SAC guarantees this model only: per-agent `to_home` + the `_shared` baseline, with
 `ro`-binds for secrets/skills. Bolder patterns — a pooled **shared `to_home`**, or
 binding the **host `$HOME`** directly — are possible via raw escape hatches but
 are explicitly **out of scope** (operator's own risk). Keeps the guarantee crisp.
@@ -84,7 +84,7 @@ agents/<name>/to_home/
                        resolved to real content — see below)
 ```
 
-A shared baseline (`<agents_dir>/_base/to_home/`, or `$SAC_TO_HOME_BASELINE`)
+A shared baseline (`<agents_dir>/_shared/to_home/`, or `$SAC_TO_HOME_BASELINE`)
 is applied first; the per-agent `to_home/` overlays on top (per-agent wins).
 See `runtimes/_to_home.py` and ADR-0006 for the per-entry semantics. **This
 is general** — `to_home` is not a `.claude` delivery mechanism, it is a `$HOME`
@@ -95,7 +95,7 @@ delivery mechanism.
 The definition is the **sole source of truth**; the runtime **never auto-reads
 host state**. Materialization enforces this at the symlink level:
 
-- **Every** symlink under `_base/to_home/` and per-agent `to_home/` is
+- **Every** symlink under `_shared/to_home/` and per-agent `to_home/` is
   **dereference-copied**: the target resolves to real content (a file or whole
   tree, nested symlinks dereferenced too) and lands at the destination. The
   container `$HOME` holds only real, self-contained files — closed to apptainer
@@ -106,7 +106,7 @@ host state**. Materialization enforces this at the symlink level:
 - **No** keep-literal / warn-and-keep / naming behavior and **no** unconditional
   host `~/.claude/skills` auto-read. Host content enters only via an
   **explicit** `to_home/` symlink — e.g.
-  `_base/to_home/.claude/skills -> ~/.claude/skills` — resolved at deploy time
+  `_shared/to_home/.claude/skills -> ~/.claude/skills` — resolved at deploy time
   (explicit-pass). Applies to skills, hooks, `.env`, etc. An in-container
   literal symlink is made via `startup_commands`.
 

--- a/src/scitex_agent_container/_skills/scitex-agent-container/29_progress-reporting-to-lead.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/29_progress-reporting-to-lead.md
@@ -1,7 +1,7 @@
 ---
 description: |
   [TOPIC] Push progress reports to the lead's a2a inbox at every milestone, so fleet coordination stops requiring polls.
-  [DETAILS] sac agents send `mcp__sac__a2a_send(target='lead', ...)` push updates on PR open/merge/close, BLOCKED, DONE, or any significant context change. The lead reads its inbox to coordinate the fleet without reading every agent's `agent_logs` / `gh` state by hand. Speak/Telegram are for the OPERATOR; a2a push is for the LEAD. Both happen at milestones — not exclusive channels. Includes the KIND vocabulary, when-to / when-not-to thresholds, the one-time per-agent ACL grant the lead has to issue (`sac a2a grant --sender <name> --target lead`), and pointers to the companion Stop-hook reminder shipped via the dotfiles `_base/to_home/` overlay.
+  [DETAILS] sac agents send `mcp__sac__a2a_send(target='lead', ...)` push updates on PR open/merge/close, BLOCKED, DONE, or any significant context change. The lead reads its inbox to coordinate the fleet without reading every agent's `agent_logs` / `gh` state by hand. Speak/Telegram are for the OPERATOR; a2a push is for the LEAD. Both happen at milestones — not exclusive channels. Includes the KIND vocabulary, when-to / when-not-to thresholds, the one-time per-agent ACL grant the lead has to issue (`sac a2a grant --sender <name> --target lead`), and pointers to the companion Stop-hook reminder shipped via the dotfiles `_shared/to_home/` overlay.
 tags: [scitex-agent-container-progress-reporting-to-lead]
 ---
 
@@ -87,7 +87,7 @@ ACL-based send restrictions are not currently enforced in sac (verified 2026-05-
 
 ## Companion Stop-hook reminder
 
-A turn-end reminder hook ships via the dotfiles `_base/to_home/` overlay at `~/.claude/hooks/stop/report_to_lead_on_stop.{sh,md}`. The shell shim emits a stderr nudge at every Stop; the `.md` is the agent-facing protocol crib pointing right back to this skill. The hook is gated on `SCITEX_AGENT_CONTAINER_NAME` so non-sac sessions (including the lead session itself) do not inherit the reminder.
+A turn-end reminder hook ships via the dotfiles `_shared/to_home/` overlay at `~/.claude/hooks/stop/report_to_lead_on_stop.{sh,md}`. The shell shim emits a stderr nudge at every Stop; the `.md` is the agent-facing protocol crib pointing right back to this skill. The hook is gated on `SCITEX_AGENT_CONTAINER_NAME` so non-sac sessions (including the lead session itself) do not inherit the reminder.
 
 ## Cross-references
 

--- a/src/scitex_agent_container/_skills/scitex-agent-container/30_responsiveness-background-work.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/30_responsiveness-background-work.md
@@ -13,7 +13,7 @@ tags: [scitex-agent-container-responsiveness-background-work, telegram-latency, 
 > **Structural enforcement**: a pre-tool-use hook
 > ``~/.claude/hooks/pre-tool-use/force_background_bash.sh`` (shipped
 > under ``examples/agents/full-agent/to_home/.claude/hooks/`` and
-> deployed fleet-wide via the ``agents/_base/to_home/`` overlay)
+> deployed fleet-wide via the ``agents/_shared/to_home/`` overlay)
 > BLOCKS any unbounded foreground Bash with a WHY message that
 > explains the relaunch routes. This skill explains the rationale;
 > the hook is the wall. If the hook blocks you, the relaunch

--- a/src/scitex_agent_container/_skills/scitex-agent-container/41_claude-worktree-relocation.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/41_claude-worktree-relocation.md
@@ -46,11 +46,11 @@ diagnostics.
 1. Copy both `worktree_create.py` and `worktree_remove.py` into the
    baseline to_home tree:
 
-       <agents_dir>/_base/to_home/.claude/hooks/claude_worktree_hooks/
+       <agents_dir>/_shared/to_home/.claude/hooks/claude_worktree_hooks/
 
 2. Merge the `hooks` block from
    `settings.local.json.fragment.json` into
-   `<agents_dir>/_base/to_home/.claude/settings.local.json` (under the
+   `<agents_dir>/_shared/to_home/.claude/settings.local.json` (under the
    top-level `hooks` key). Preserve the `_comment_worktree_hooks`
    string — it carries the source-of-truth audit trail.
 
@@ -83,7 +83,7 @@ silent schema drift would break the relocation.
 
 The hook scripts are canonical, version-controlled, regression-tested
 implementations of a fleet-wide policy. Shipping them here (instead of
-ad-hoc in the operator's dotfiles `_base/to_home/`) means:
+ad-hoc in the operator's dotfiles `_shared/to_home/`) means:
 
 * The implementation has an audit trail (commit history + PR review).
 * The hook contract is pinned by tests, not by the operator's memory.

--- a/src/scitex_agent_container/_walk_exclusions.py
+++ b/src/scitex_agent_container/_walk_exclusions.py
@@ -9,7 +9,7 @@ Two on-start walkers in SAC enumerate large trees synchronously:
   ``to_home`` symlink-dereference step. ``shutil.copytree(...,
   symlinks=False)`` copies the whole resolved target tree into the
   container overlay; a baseline symlink like
-  ``_base/to_home/.claude/skills -> ~/.claude/skills`` transitively
+  ``_shared/to_home/.claude/skills -> ~/.claude/skills`` transitively
   pulls in anything reachable under that target.
 
 Both walkers used to descend into ``worktrees/`` subtrees, which are

--- a/src/scitex_agent_container/config/_loaders.py
+++ b/src/scitex_agent_container/config/_loaders.py
@@ -292,7 +292,7 @@ def load_v3(raw: dict, path: Path) -> AgentConfig:
 
     return AgentConfig(
         name=name,
-        runtime=str(spec.get("runtime") or "apptainer"),
+        runtime=str(spec.get("runtime") or "tui"),
         image=apptainer_spec.image,
         model=model,
         workdir=workdir,

--- a/src/scitex_agent_container/config/_parsers/_claude.py
+++ b/src/scitex_agent_container/config/_parsers/_claude.py
@@ -91,6 +91,7 @@ def parse_claude(spec: dict) -> ClaudeSpec:
         resume_id=str(raw.get("resume_id", "") or ""),
         auto_accept=raw.get("auto_accept", True),
         account=str(raw.get("account", "") or ""),
+        credentials_file=str(raw.get("credentials_file", "") or ""),
         provider=_parse_provider(raw),
         raw_options=dict(raw_options),
     )

--- a/src/scitex_agent_container/config/_types.py
+++ b/src/scitex_agent_container/config/_types.py
@@ -66,6 +66,28 @@ class ClaudeSpec:
     # move a pinned agent (that is the point of pinning), and changing
     # this field requires ``sac agent restart`` to re-copy the snapshot.
     account: str = ""
+    # Explicit credentials-file designation (host path to a
+    # ``.credentials.json``). When set, the runtime BIND-MOUNTS that
+    # exact file WRITABLE at the in-container
+    # ``$HOME/.claude/.credentials.json`` — single source of truth, no
+    # copy. The in-container ``claude`` reads/refreshes that file
+    # directly, so an OAuth refresh persists straight back to the
+    # designated file and never desyncs from / corrupts a shared
+    # ``~/.claude/.credentials.json``. Designating different files for
+    # different agents is how multiple accounts run side by side
+    # (rotate by pointing agents at different credential files).
+    #
+    # Precedence: when set, this file-mount REPLACES the account /
+    # host dir-bind auth path (no ``CLAUDE_CONFIG_DIR`` redirect) — the
+    # designated file IS the agent's credentials. Mutually exclusive
+    # with ``provider`` (an API-key backend needs no OAuth file).
+    #
+    # Caveat (documented in ``_apptainer_auth``): a single-file bind is
+    # on the file's inode; a host-side atomic tmp+rename on the source
+    # orphans the bind. In-container ``claude`` refresh that writes
+    # in-place is safe; designate a path NOT concurrently atomic-renamed
+    # by host-side ``sac accounts``/watch-live tooling.
+    credentials_file: str = ""
     # Vendor-agnostic backend override (see :class:`ProviderSpec`).
     # When set, the SDK session runs against an Anthropic-SDK-compatible
     # backend (DeepSeek, a gateway, ...) on an API key instead of
@@ -417,7 +439,10 @@ class AgentConfig:
     """Parsed agent configuration from a YAML definition file."""
 
     name: str
-    runtime: str = "apptainer"
+    # Launch-mode selector. Default ``"tui"`` (interactive in-apptainer
+    # TUI — operator directive 2026-06-15). ``"claude-agent-sdk"`` =
+    # headless SDK runner; legacy ``"apptainer"`` maps to the SDK runner.
+    runtime: str = "tui"
     # Top-level container image. Empty = use the default sac-scitex SIF.
     # (`spec.dockerfile` was dropped 2026-05-13 with the docker ripout.)
     image: str = ""

--- a/src/scitex_agent_container/config/_validation.py
+++ b/src/scitex_agent_container/config/_validation.py
@@ -237,9 +237,9 @@ def validate_raw(raw: dict, path: str) -> list[str]:
         if runtime and runtime not in _VALID_RUNTIMES:
             errors.append(
                 f"spec.runtime must be one of {sorted(_VALID_RUNTIMES)} "
-                f"(got '{runtime}'). 'claude-agent-sdk' (default) =  "
-                "headless SDK runner; 'tui' = tmux-backed interactive "
-                "Claude TUI; 'apptainer' / '' = back-compat for the "
+                f"(got '{runtime}'). 'tui' (default, '' maps here) = "
+                "interactive in-apptainer Claude TUI; 'claude-agent-sdk' "
+                "= headless SDK runner; 'apptainer' = back-compat for the "
                 "pre-2026-06-13 container-engine field, mapped to "
                 "'claude-agent-sdk' at dispatch."
             )

--- a/src/scitex_agent_container/runtimes/_apptainer_auth.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_auth.py
@@ -49,6 +49,25 @@ def auth_argv(config: AgentConfig, state_dir: Path) -> list[str]:
 
     argv: list[str] = []
 
+    # Designated credentials file (spec.claude.credentials_file): the
+    # operator names ONE host ``.credentials.json`` to mount writable at
+    # the in-container ``$HOME/.claude/.credentials.json`` (single source
+    # of truth — see :func:`credentials_file_bind`, emitted last in
+    # build_run_argv so the relaxed ``--home`` tmpfs / overlay-upper bind
+    # cannot shadow it). When designated we SKIP the account/host
+    # dir-bind + ``CLAUDE_CONFIG_DIR`` redirect entirely: the file IS the
+    # agent's credentials at its default ``$HOME`` location. Still forward
+    # the pay-per-token env below (harmless; the OAuth file wins for
+    # Pro/Max).
+    claude_spec = getattr(config, "claude", None)
+    designated = str(getattr(claude_spec, "credentials_file", "") or "").strip()
+    if designated:
+        for auth_env in ("ANTHROPIC_API_KEY", "SAC_ANTHROPIC_API_KEY"):
+            val = os.environ.get(auth_env)
+            if val:
+                argv += ["--env", f"{auth_env}={val}"]
+        return argv
+
     # Forward Anthropic auth (mirrors container.py). Order matters:
     # see runtimes/_sdk_common.py:provision_anthropic_auth — when
     # `~/.claude/.credentials.json` exists (Pro/Max OAuth flow), the
@@ -160,4 +179,46 @@ def auth_argv(config: AgentConfig, state_dir: Path) -> list[str]:
     return argv
 
 
-__all__ = ["auth_argv"]
+def credentials_file_bind(config: AgentConfig) -> list[str]:
+    """Render the writable file-bind for ``spec.claude.credentials_file``.
+
+    Emitted LAST in :func:`_apptainer_build_argv.build_run_argv` (after
+    the overlay-upper-home bind) so a relaxed ``--home`` tmpfs or
+    ``--bind <upper>:/home/agent`` cannot shadow the credentials file —
+    user binds apply in order and the last bind to a path wins.
+
+    Binds the designated host file ``rw`` at ``<container_home>/.claude/
+    .credentials.json`` so the in-container ``claude`` reads AND
+    refreshes that single file directly (single source of truth). No-op
+    when the field is unset, the file is missing, or a provider override
+    is active (API-key backend → no OAuth file).
+
+    Caveat: a single-file bind is on the file's inode. An in-container
+    refresh that rewrites in-place persists to the source; one that does
+    tmp+rename orphans the bind (the source keeps the pre-rename token).
+    The designated file should therefore NOT be a path concurrently
+    atomic-renamed by host-side ``sac accounts``/watch-live tooling — it
+    is the agent's private, operator-rotated credentials file.
+    """
+    if provider_active(config):
+        return []
+    claude_spec = getattr(config, "claude", None)
+    designated = str(getattr(claude_spec, "credentials_file", "") or "").strip()
+    if not designated:
+        return []
+    src = Path(designated).expanduser()
+    if not src.is_file():
+        raise FileNotFoundError(
+            f"spec.claude.credentials_file points at {src}, which is not "
+            "a file. Designate an existing .credentials.json (the agent "
+            "mounts it writable at $HOME/.claude/.credentials.json as its "
+            "single source of truth)."
+        )
+    from ._to_home_overlay import resolve_container_home
+
+    container_home = resolve_container_home(config).rstrip("/")
+    dest = f"{container_home}/.claude/.credentials.json"
+    return ["--bind", f"{src}:{dest}:rw"]
+
+
+__all__ = ["auth_argv", "credentials_file_bind"]

--- a/src/scitex_agent_container/runtimes/_apptainer_build_argv.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_build_argv.py
@@ -54,6 +54,7 @@ def build_run_argv(
     sif_path: Path,
     runner_argv: list[str] | None = None,
     one_shot: bool = False,
+    tui: bool = False,
 ) -> list[str]:
     """Render the ``apptainer exec`` argv.
 
@@ -62,6 +63,12 @@ def build_run_argv(
     :func:`_apptainer_inner_argv.build_inner_argv` when the caller
     doesn't pre-build a ``runner_argv``; it mirrors the legacy
     ``self._one_shot`` flag the class method threaded through.
+
+    ``tui=True`` swaps the inner command from the ``python -m`` SDK
+    session runner to the interactive ``claude`` TUI (same isolation /
+    binds / overlay / auth / to_home as the SDK path — only the inner
+    process differs). The caller (``TuiSessionRuntime``) launches the
+    returned argv inside a tmux PTY rather than backgrounding it.
     """
     # Hardened isolation by default — see _apptainer_iso_flags for the
     # per-flag skip logic (relaxed opt-out, operator-declared raw_args,
@@ -286,6 +293,14 @@ def build_run_argv(
         container_home = resolve_container_home(config)
         argv += ["--bind", f"{upper_home}:{container_home}"]
 
+    # Designated credentials file (spec.claude.credentials_file) — bound
+    # writable at ``$HOME/.claude/.credentials.json``. Emitted LAST among
+    # binds (after the overlay-upper-home bind) so the relaxed ``--home``
+    # tmpfs / upper-home bind cannot shadow it; last bind to a path wins.
+    from ._apptainer_auth import credentials_file_bind
+
+    argv += credentials_file_bind(config)
+
     argv.append(str(sif_path))
 
     # Inner command (tini-supervised runner). Dispatched on
@@ -298,8 +313,36 @@ def build_run_argv(
     # auto-removes module-level unused imports during refactors.
     from ._apptainer_inner_argv import RUNNER_MODULE_PROXY, build_inner_argv
 
+    # TUI MCP wiring: the interactive ``claude`` auto-discovers
+    # ``.mcp.json`` from its cwd (the project root), NOT from ``$HOME``
+    # like the SDK runner. When to_home materialised a ``$HOME/.mcp.json``
+    # (workspace-home bind or overlay-upper), pass its in-container path
+    # via ``--mcp-config`` so the TUI actually loads those servers.
+    tui_mcp_config: str | None = None
+    tui_channel_mcp: str | None = None
+    tui_dev_channels: str | None = None
+    if tui:
+        ch = resolve_container_home(config).rstrip("/")
+        has_mcp = (home_host / ".mcp.json").is_file() or (
+            upper_home is not None and (upper_home / ".mcp.json").is_file()
+        )
+        if has_mcp:
+            tui_mcp_config = f"{ch}/.mcp.json"
+        # SDK-parity channels: spec.claude.channels → dev-channels flag +
+        # an inline ``sac mcp channel`` subscriber MCP (server:sac only).
+        from ._apptainer_inner_argv import tui_channel_config
+
+        tui_dev_channels, tui_channel_mcp = tui_channel_config(config)
+
     if runner_argv is None:
-        inner_argv = build_inner_argv(config, one_shot=one_shot)
+        inner_argv = build_inner_argv(
+            config,
+            one_shot=one_shot,
+            tui=tui,
+            tui_mcp_config=tui_mcp_config,
+            tui_channel_mcp=tui_channel_mcp,
+            tui_dev_channels=tui_dev_channels,
+        )
     else:
         kind = getattr(config, "kind", "Agent")
         module = RUNNER_MODULE_PROXY if kind == "AgentProxy" else RUNNER_MODULE

--- a/src/scitex_agent_container/runtimes/_apptainer_inner_argv.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_inner_argv.py
@@ -9,6 +9,7 @@ cap. Each builder returns the full ``[tini, --, python3, -m, MODULE,
 from __future__ import annotations
 
 import json
+import os as _os
 import shlex
 from typing import TYPE_CHECKING
 
@@ -275,11 +276,61 @@ def _tui_runner_argv(
     return argv
 
 
-# Absolute path to the bundled ``sac`` binary inside the base SIF. Under
-# ``--containall --cleanenv`` the venv bin dir is NOT on PATH, so a bare
-# ``sac`` (as the SDK path uses) is unresolvable from an MCP subprocess —
-# the channel sidecar must be invoked by absolute path.
-_SAC_BIN_IN_SIF = "/opt/venv-sac/bin/sac"
+# Absolute path to the bundled ``sac`` console-script inside the base
+# SIF (sac-base.sif as of 2026-06-15). The script is installed under the
+# agent venv (``/opt/venv-agent/bin/sac``), NOT the SDK venv
+# (``/opt/venv-sac/bin/sac`` does not exist — verified by
+# ``ls /opt/venv-{agent,sac}/bin/sac`` in the running SIF).
+#
+# Why hardcode rather than ``shutil.which("sac")``: this constant is
+# read on the HOST when the SAC runtime builds the apptainer-exec
+# argv. The host's PATH (the SAC runtime inherits
+# ``/opt/venv-sac/bin:...``) does NOT include ``/opt/venv-agent/bin``,
+# so ``shutil.which("sac")`` would fail to find sac on the host even
+# though it exists inside the SIF. The path written here is the
+# IN-SIF absolute path the bundled claude will exec when it spawns
+# the channel-MCP subprocess; that filesystem is the SIF's, not the
+# host's, so the hardcoded SIF path is correct.
+#
+# Under ``--containall --cleanenv`` the venv bin dir is NOT on PATH,
+# so a bare ``sac`` (as the host SDK path uses) is also unresolvable
+# from an MCP subprocess inside the SIF — the channel sidecar must
+# be invoked by absolute path.
+#
+# Operator override: set ``SAC_BIN_IN_SIF`` in the agent's env (e.g.
+# ``spec.env``) to point at a different in-SIF location if the image
+# is rebuilt with sac installed elsewhere. The constant below is the
+# default for the current sac-base.sif.
+_SAC_BIN_IN_SIF_DEFAULT = "/opt/venv-agent/bin/sac"
+
+
+def resolve_sac_bin_in_sif() -> str:
+    """Return the absolute in-SIF path to the ``sac`` console script.
+
+    Resolves at MCP-config build time on the HOST. Reads the
+    ``SAC_BIN_IN_SIF`` env var override first (operator escape hatch
+    when the SIF is rebuilt with sac in a non-default location); falls
+    back to :data:`_SAC_BIN_IN_SIF_DEFAULT`. NEVER attempts a host-side
+    ``shutil.which`` — the path is INSIDE the SIF; host PATH lookups
+    are noise here (the SAC runtime's PATH typically does not include
+    ``/opt/venv-agent/bin`` so ``which`` would mis-report).
+
+    The default is the verified location for ``sac-base.sif`` as of
+    2026-06-15; see the module-level comment for the verification
+    record. Override via ``SAC_BIN_IN_SIF`` env when the SIF layout
+    changes (this avoids hardcoding-shaped breakage on SIF rebuilds).
+    """
+    override = _os.environ.get("SAC_BIN_IN_SIF", "").strip()
+    if override:
+        return override
+    return _SAC_BIN_IN_SIF_DEFAULT
+
+
+# Backward-compat alias — keep imports of ``_SAC_BIN_IN_SIF`` working
+# (e.g. external skill-doc examples that referenced the legacy constant
+# name). New call sites should call :func:`resolve_sac_bin_in_sif` so
+# the env override takes effect.
+_SAC_BIN_IN_SIF = _SAC_BIN_IN_SIF_DEFAULT
 
 
 def tui_channel_config(config: "AgentConfig") -> tuple[str | None, str | None]:
@@ -319,7 +370,7 @@ def tui_channel_config(config: "AgentConfig") -> tuple[str | None, str | None]:
                 "mcpServers": {
                     "sac": {
                         "type": "stdio",
-                        "command": _SAC_BIN_IN_SIF,
+                        "command": resolve_sac_bin_in_sif(),
                         "args": args,
                     }
                 }

--- a/src/scitex_agent_container/runtimes/_apptainer_inner_argv.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_inner_argv.py
@@ -8,6 +8,7 @@ cap. Each builder returns the full ``[tini, --, python3, -m, MODULE,
 
 from __future__ import annotations
 
+import json
 import shlex
 from typing import TYPE_CHECKING
 
@@ -58,7 +59,15 @@ def _format_shell_steps(cmds: list) -> list[str]:
     return steps
 
 
-def build_inner_argv(config: "AgentConfig", *, one_shot: bool = False) -> list[str]:
+def build_inner_argv(
+    config: "AgentConfig",
+    *,
+    one_shot: bool = False,
+    tui: bool = False,
+    tui_mcp_config: str | None = None,
+    tui_channel_mcp: str | None = None,
+    tui_dev_channels: str | None = None,
+) -> list[str]:
     """Return the apptainer-inner argv. Dispatches on ``config.kind``.
 
     When ``spec.startup_commands`` is non-empty, the argv is wrapped
@@ -66,9 +75,22 @@ def build_inner_argv(config: "AgentConfig", *, one_shot: bool = False) -> list[s
     so the commands run as container-internal shell BEFORE the claude
     SDK process starts. ``exec`` replaces bash with tini, keeping PID 1
     clean. NOT a claude prompt — see ``spec.startup_prompts``.
+
+    ``tui=True`` selects the interactive ``claude`` TUI as the inner
+    process instead of the ``python -m`` SDK session runner (see
+    :func:`_tui_runner_argv`). The startup_commands wrapper still
+    applies, so container-internal bootstrap (uv venv, symlinks, ...)
+    runs before ``exec claude`` identically to the SDK path.
     """
     kind = getattr(config, "kind", "Agent")
-    if kind == "AgentProxy":
+    if tui:
+        runner_tail = _tui_runner_argv(
+            config,
+            mcp_config=tui_mcp_config,
+            channel_mcp=tui_channel_mcp,
+            dev_channels=tui_dev_channels,
+        )
+    elif kind == "AgentProxy":
         runner_tail = _TINI_PREFIX + [RUNNER_MODULE_PROXY] + _proxy_runner_argv(config)
     else:
         runner_tail = (
@@ -189,6 +211,121 @@ def _agent_runner_argv(config: "AgentConfig", *, one_shot: bool) -> list[str]:
             auto.kick_text,
         ]
     return runner_argv
+
+
+_CLAUDE_TUI_BIN = "claude"
+
+
+def _tui_runner_argv(
+    config: "AgentConfig",
+    *,
+    mcp_config: str | None = None,
+    channel_mcp: str | None = None,
+    dev_channels: str | None = None,
+) -> list[str]:
+    """Argv for the interactive ``claude`` TUI (``spec.runtime: tui``).
+
+    The inner process is the bundled ``claude`` binary running its
+    interactive Ink TUI — the tmux PTY the caller wraps this argv in is
+    what gives it a terminal. Threads the declarative spec surface:
+
+      * ``spec.claude.model``  → ``--model <name>`` (when set).
+      * ``spec.claude.flags``  → appended verbatim (e.g.
+        ``--dangerously-skip-permissions``).
+
+    MCP servers: the interactive ``claude`` auto-discovers ``.mcp.json``
+    from the PROJECT ROOT (its cwd, ``--pwd``), NOT from ``$HOME`` like
+    the SDK runner. So when to_home materialised a ``$HOME/.mcp.json``,
+    the caller passes its in-container path as ``mcp_config`` and we add
+    ``--mcp-config <path>`` so the TUI loads those servers (figrecipe /
+    scitex-agent-container / scitex-todo …). Without this the TUI shows
+    "No MCP servers configured".
+
+    Channels (SDK parity — see ``runtimes._sdk_channels.apply_channels``):
+    ``spec.claude.channels`` drives two flags. ``dev_channels`` →
+    ``--dangerously-load-development-channels <set>`` (any channel).
+    ``channel_mcp`` → an inline ``--mcp-config`` JSON registering the
+    ``sac mcp channel`` stdio subscriber (``server:sac`` only) so the TUI
+    actually receives a2a-bus pushes — the interactive ``claude`` has no
+    ``--channels`` flag, so the subscriber must be injected as an MCP
+    server (the bus-auth env from ``listen_env_flags`` lets it connect).
+    Both mcp configs ride on ONE ``--mcp-config`` (it takes
+    space-separated file/JSON values).
+
+    No tini wrapper: the TUI is the foreground interactive process in the
+    tmux pane; apptainer + tmux own signal delivery. ``startup_commands``
+    wrapping (``build_inner_argv``) still ``exec``s this as the tail.
+    """
+    argv: list[str] = [_CLAUDE_TUI_BIN]
+    claude_spec = getattr(config, "claude", None)
+    model = str(getattr(claude_spec, "model", "") or "").strip()
+    if not model:
+        model = str(getattr(config, "model", "") or "").strip()
+    if model:
+        argv += ["--model", model]
+    mcp_values = [v for v in (mcp_config, channel_mcp) if v]
+    if mcp_values:
+        argv += ["--mcp-config", *mcp_values]
+    if dev_channels:
+        argv += ["--dangerously-load-development-channels", dev_channels]
+    for flag in list(getattr(claude_spec, "flags", []) or []):
+        flag = str(flag).strip()
+        if flag:
+            argv.append(flag)
+    return argv
+
+
+# Absolute path to the bundled ``sac`` binary inside the base SIF. Under
+# ``--containall --cleanenv`` the venv bin dir is NOT on PATH, so a bare
+# ``sac`` (as the SDK path uses) is unresolvable from an MCP subprocess —
+# the channel sidecar must be invoked by absolute path.
+_SAC_BIN_IN_SIF = "/opt/venv-sac/bin/sac"
+
+
+def tui_channel_config(config: "AgentConfig") -> tuple[str | None, str | None]:
+    """Resolve ``spec.claude.channels`` into TUI channel flags.
+
+    Returns ``(dev_channels, channel_mcp_json)`` — SDK parity with
+    :func:`runtimes._sdk_channels.apply_channels`:
+
+      * ``dev_channels`` — comma-joined channel set for
+        ``--dangerously-load-development-channels`` (fires for ANY
+        channel entry), or ``None`` when no channels are declared.
+      * ``channel_mcp_json`` — inline ``--mcp-config`` JSON registering
+        the ``sac mcp channel --name <agent>`` stdio subscriber under
+        ``mcpServers.sac`` (``server:sac`` ONLY), or ``None``. The
+        subscriber's ``--listen-url`` defaults to ``$SAC_LISTEN_BASE_URL``
+        (already forwarded by ``listen_env_flags``); when the a2a port is
+        resolved it also gets ``--turn-url`` for the WAKE path.
+    """
+    claude_spec = getattr(config, "claude", None)
+    channels = [
+        str(c).strip()
+        for c in (getattr(claude_spec, "channels", []) or [])
+        if str(c).strip()
+    ]
+    if not channels:
+        return None, None
+    dev_channels = ",".join(sorted(set(channels)))
+    channel_mcp: str | None = None
+    if any(c == "server:sac" for c in channels):
+        args = ["mcp", "channel", "--name", config.name]
+        a2a_spec = getattr(config, "a2a", None)
+        port = getattr(a2a_spec, "port", None) if a2a_spec else None
+        if isinstance(port, int) and port > 0:
+            args += ["--turn-url", f"http://127.0.0.1:{port}/v1/turn"]
+        channel_mcp = json.dumps(
+            {
+                "mcpServers": {
+                    "sac": {
+                        "type": "stdio",
+                        "command": _SAC_BIN_IN_SIF,
+                        "args": args,
+                    }
+                }
+            }
+        )
+    return dev_channels, channel_mcp
 
 
 def _proxy_runner_argv(config: "AgentConfig") -> list[str]:

--- a/src/scitex_agent_container/runtimes/_p3a_default_binds.py
+++ b/src/scitex_agent_container/runtimes/_p3a_default_binds.py
@@ -9,7 +9,7 @@ Two classes of fleet-wide bind live here today:
   ``feedback_scitex_todo_single_shared_store``
   (lead-learnings/22, P3a unlock). Lead a2a
   ``214dd26d3fd24e088c75a34329895fa4``. This module is the SOLE
-  source of the bind — no fleet ``_base/spec.yaml`` carries an
+  source of the bind — no fleet ``_shared/spec.yaml`` carries an
   explicit ``~/.scitex/todo:`` line (lead audit 2026-06-13 a2a
   ``f33cbc78c2074594b513439d93748810``), so the helper here is what
   every sac-launched agent picks up at boot.

--- a/src/scitex_agent_container/runtimes/_symlink_resolve.py
+++ b/src/scitex_agent_container/runtimes/_symlink_resolve.py
@@ -12,7 +12,7 @@ filesystem layout.
 
 A symlink under ``to_home/`` is the operator's *explicit* opt-in to
 pull host content into the definition (e.g.
-``_base/to_home/.claude/skills -> ~/.claude/skills``). That is
+``_shared/to_home/.claude/skills -> ~/.claude/skills``). That is
 explicit-pass, which is fine; the link is resolved to real content at
 deploy time. A symlink whose target cannot be resolved (dangling) is a
 real defect in the definition and hard-aborts the deploy via
@@ -58,7 +58,7 @@ def deref_copy_symlink(src: Path, dst: Path) -> None:
     the ``ignore`` callable handed to ``shutil.copytree`` — most
     importantly ``worktrees/`` directories anywhere in the resolved
     tree. Without this, a baseline symlink like
-    ``_base/to_home/.claude/skills -> ~/.claude/skills`` would
+    ``_shared/to_home/.claude/skills -> ~/.claude/skills`` would
     transitively pull every git worktree nested under the host's
     ``~/.claude/`` into the container overlay at start time — one of
     the two SAC-side walkers behind the original F-CS8 outage class

--- a/src/scitex_agent_container/runtimes/_to_home.py
+++ b/src/scitex_agent_container/runtimes/_to_home.py
@@ -38,30 +38,18 @@ No fragmented "leaf-vs-mirror" distinction — every path under
 Missing ``to_home/`` dir → silent no-op (specs without one just don't
 get materialization).
 
-Baseline layer (shared/common to_home)
---------------------------------------
-Common hooks/settings shared by every agent live in ONE place instead
-of being copied into every agent's ``to_home/``. Materialization is a
-two-pass overlay:
+Baseline layer (shared/common to_home): two-pass overlay applies the
+shared baseline first (resolved via :func:`resolve_baseline_to_home_dir`
+— ``$SAC_TO_HOME_BASELINE`` override or ``<agents_dir>/_shared/to_home/``
+sibling), then the per-agent ``to_home/`` on top. Per-agent files win
+on conflict. Absent baseline → behaves as before, fully backward
+compatible.
 
-  1. Apply the COMMON baseline ``to_home/`` first.
-  2. Apply the per-agent ``<spec_dir>/to_home/`` ON TOP.
-
-Per-agent files therefore win on conflict (overlay semantics) — they
-re-run the same per-entry deploy helpers over whatever the baseline
-laid down (full overwrite, marker-protected re-wrap, symlink
-dereference-copy).
-
-Baseline location (see :func:`resolve_baseline_to_home_dir`):
-
-  - ``$SAC_TO_HOME_BASELINE`` — explicit override (absolute dir), or
-  - ``<agents_dir>/_shared/to_home/`` — a sibling ``_shared`` dir under
-    the agents root (agents live at ``<agents_dir>/<name>/``, so the
-    agents root is the spec dir's parent). ``_base`` is accepted as a
-    backward-compat fallback.
-
-Absent baseline dir → behaves exactly as before (no baseline = current
-behavior; fully backward compatible).
+Credential-leak guard (2026-06-15, lead-reported): a ``.credentials.json``
+under ``to_home/`` aborts the deploy with
+:class:`WorkspaceCredentialLeakError`. Credentials are operator-rotated
+runtime state from the auth-stage rw bind, never static workspace
+content — see ``_to_home_errors.py`` for context.
 """
 
 from __future__ import annotations
@@ -76,73 +64,28 @@ from pathlib import Path
 
 from ..config import AgentConfig
 from ._symlink_resolve import DanglingToHomeSymlinkError, deref_copy_symlink
+from ._to_home_errors import (
+    WorkspaceCLAUDEMarkerError,
+    WorkspaceCredentialLeakError,
+)
+from ._to_home_text import (
+    END_MARKER,
+    extract_user_tail,
+    interpolate_env,
+    interpolate_metadata,
+    validate_marker_invariants,
+)
 
 logger = logging.getLogger(__name__)
 
-END_MARKER = "<!-- End of scitex-agent-container generated section -->"
-START_MARKER_PREFIX = "<!-- Start of scitex-agent-container generated section"
-
-
-class WorkspaceCLAUDEMarkerError(RuntimeError):
-    """Existing workspace marker-protected file has malformed markers.
-
-    The deploy is hard-aborted on this error rather than silently
-    overwriting or guessing — preserving user content past the End
-    marker is a safety contract and any ambiguity in marker placement
-    could destroy work.
-    """
-
-
-def _validate_marker_invariants(text: str, source_name: str) -> None:
-    """Hard-fail if Start/End markers are missing or malformed."""
-    start_count = text.count(START_MARKER_PREFIX)
-    end_count = text.count(END_MARKER)
-    if start_count != 1 or end_count != 1:
-        raise WorkspaceCLAUDEMarkerError(
-            f"{source_name}: expected exactly 1 Start marker and 1 End "
-            f"marker, found Start={start_count} End={end_count}. "
-            "Refusing to deploy to avoid data loss. Restore the markers "
-            "manually before retrying."
-        )
-    if text.find(START_MARKER_PREFIX) > text.find(END_MARKER):
-        raise WorkspaceCLAUDEMarkerError(
-            f"{source_name}: Start marker appears AFTER End marker. "
-            "This indicates a corrupted file. Refusing to deploy."
-        )
-
-
-def _extract_user_tail(workspace_path: Path) -> str:
-    if not workspace_path.exists():
-        return ""
-    try:
-        existing = workspace_path.read_text()
-    except OSError:  # stx-allow: fallback (reason: file system operation failure)
-        return ""
-    idx = existing.rfind(END_MARKER)
-    if idx == -1:
-        return ""
-    return existing[idx + len(END_MARKER) :]
-
-
-def _interpolate_env(text: str) -> str:
-    return re.sub(
-        r"\$\{(\w+)\}",
-        lambda m: os.environ.get(m.group(1), m.group(0)),
-        text,
-    )
-
-
-def _interpolate_metadata(text: str, config: AgentConfig) -> str:
-    def _replace(m: re.Match) -> str:
-        key = m.group(1)
-        if key == "metadata.name":
-            return config.name
-        if key.startswith("metadata.labels."):
-            label = key[len("metadata.labels.") :]
-            return config.labels.get(label) or m.group(0)
-        return m.group(0)
-
-    return re.sub(r"\$\{([^}]+)\}", _replace, text)
+# Marker constants + text helpers re-exported for legacy import paths
+# (e.g. tests doing ``from ...runtimes._to_home import END_MARKER``).
+# Implementations live in :mod:`_to_home_text` per the 2026-06-15
+# extraction (see GITIGNORED/REFACTORING.md when present).
+_validate_marker_invariants = validate_marker_invariants
+_extract_user_tail = extract_user_tail
+_interpolate_env = interpolate_env
+_interpolate_metadata = interpolate_metadata
 
 
 # Files that get marker-protected merge semantics (vs. full overwrite).
@@ -243,6 +186,11 @@ def materialize_to_home(spec_dir: Path, workspace_home: Path) -> None:
     root = spec_dir / "to_home"
     if baseline is None and not root.is_dir():
         return
+    # Credential-leak guard runs BEFORE any deploy (both layers).
+    if baseline is not None:
+        _scan_for_credential_leak(baseline)
+    if root.is_dir():
+        _scan_for_credential_leak(root)
     workspace_home.mkdir(parents=True, exist_ok=True)
     if baseline is not None:
         _walk_and_apply(baseline, baseline, workspace_home, config=None)
@@ -271,6 +219,11 @@ def deploy_to_home(config: AgentConfig, workspace_home: str) -> None:
     baseline = resolve_baseline_to_home_dir(_spec_dir(config))
     if root is None and baseline is None:
         return
+    # Credential-leak guard runs BEFORE any deploy (both layers).
+    if baseline is not None:
+        _scan_for_credential_leak(baseline)
+    if root is not None:
+        _scan_for_credential_leak(root)
     dest = Path(workspace_home)
     dest.mkdir(parents=True, exist_ok=True)
     if baseline is not None:
@@ -280,6 +233,26 @@ def deploy_to_home(config: AgentConfig, workspace_home: str) -> None:
 
 
 # --- traversal -------------------------------------------------------------
+
+
+def _scan_for_credential_leak(src_root: Path) -> None:
+    """Raise :class:`WorkspaceCredentialLeakError` on first
+    ``.credentials.json`` found at any depth under ``src_root``.
+
+    Runs BEFORE any deploy so a rejected tree cannot land partial
+    sibling content next to a leaked credential. See the error class
+    docstring for the lead-reported incident this guards against.
+    """
+    if not src_root.is_dir():
+        return
+    for leak in src_root.rglob(".credentials.json"):
+        rel = leak.relative_to(src_root)
+        raise WorkspaceCredentialLeakError(
+            f"to_home/ contains a .credentials.json at {rel} — refused. "
+            "Credentials must come from the auth-stage rw bind, not "
+            f"a static workspace copy. Remove {leak} and rely on "
+            "spec.claude.account or spec.claude.credentials_file."
+        )
 
 
 def _walk_and_apply(
@@ -295,6 +268,11 @@ def _walk_and_apply(
     messages can report a path relative to the spec. ``config`` is
     optional: when present, text-file interpolation (``${metadata.*}``
     and ``${ENV_VAR}``) runs over CLAUDE.md / state.md / .env / .mcp.json.
+
+    The caller (``materialize_to_home`` / ``deploy_to_home``) runs
+    :func:`_scan_for_credential_leak` first so a leaked
+    ``.credentials.json`` aborts the deploy before any sibling
+    content lands.
     """
     for child in sorted(src_dir.iterdir()):
         rel = child.relative_to(src_root)

--- a/src/scitex_agent_container/runtimes/_to_home.py
+++ b/src/scitex_agent_container/runtimes/_to_home.py
@@ -55,9 +55,10 @@ dereference-copy).
 Baseline location (see :func:`resolve_baseline_to_home_dir`):
 
   - ``$SAC_TO_HOME_BASELINE`` — explicit override (absolute dir), or
-  - ``<agents_dir>/_base/to_home/`` — a sibling ``_base`` dir under the
-    agents root (agents live at ``<agents_dir>/<name>/``, so the agents
-    root is the spec dir's parent).
+  - ``<agents_dir>/_shared/to_home/`` — a sibling ``_shared`` dir under
+    the agents root (agents live at ``<agents_dir>/<name>/``, so the
+    agents root is the spec dir's parent). ``_base`` is accepted as a
+    backward-compat fallback.
 
 Absent baseline dir → behaves exactly as before (no baseline = current
 behavior; fully backward compatible).
@@ -153,13 +154,17 @@ _MARKER_PROTECTED_BASENAMES = frozenset({"CLAUDE.md", "state.md"})
 _TIGHT_PERM_BASENAMES = frozenset({".env"})
 
 # Env var: explicit override for the shared/common baseline to_home dir.
-# Absolute path. When unset we fall back to ``<agents_dir>/_base/to_home``.
+# Absolute path. When unset we fall back to ``<agents_dir>/_shared/to_home``
+# (or the legacy ``_base`` sibling).
 _BASELINE_ENV_VAR = "SAC_TO_HOME_BASELINE"
 
-# Name of the sibling dir (under the agents root) that holds the common
+# Names of the sibling dir (under the agents root) that holds the common
 # baseline. Agents live at ``<agents_dir>/<name>/``, so the agents root
-# is the spec dir's parent and the baseline is ``<parent>/_base/to_home``.
-_BASELINE_DIR_NAME = "_base"
+# is the spec dir's parent and the baseline is ``<parent>/_shared/to_home``.
+# ``_shared`` is the current name; ``_base`` is retained as a
+# backward-compat fallback for hosts/fleets not yet renamed (first match
+# under the agents root wins, in declared order).
+_BASELINE_DIR_NAMES = ("_shared", "_base")
 
 
 # --- public API ------------------------------------------------------------
@@ -196,8 +201,9 @@ def resolve_baseline_to_home_dir(spec_dir: Path | None) -> Path | None:
 
     Resolution order:
       1. ``$SAC_TO_HOME_BASELINE`` (absolute dir) — explicit override.
-      2. ``<agents_dir>/_base/to_home`` — a sibling ``_base`` dir under
-         the agents root. Agents live at ``<agents_dir>/<name>/``, so the
+      2. ``<agents_dir>/_shared/to_home`` — a sibling ``_shared`` dir
+         under the agents root (``_base`` accepted as a backward-compat
+         fallback). Agents live at ``<agents_dir>/<name>/``, so the
          agents root is ``spec_dir.parent``.
 
     Returns ``None`` when no baseline dir can be resolved (no baseline =
@@ -209,8 +215,11 @@ def resolve_baseline_to_home_dir(spec_dir: Path | None) -> Path | None:
         return p if p.is_dir() else None
     if spec_dir is None:
         return None
-    p = spec_dir.parent / _BASELINE_DIR_NAME / "to_home"
-    return p if p.is_dir() else None
+    for name in _BASELINE_DIR_NAMES:
+        p = spec_dir.parent / name / "to_home"
+        if p.is_dir():
+            return p
+    return None
 
 
 def materialize_to_home(spec_dir: Path, workspace_home: Path) -> None:

--- a/src/scitex_agent_container/runtimes/_to_home_errors.py
+++ b/src/scitex_agent_container/runtimes/_to_home_errors.py
@@ -1,0 +1,46 @@
+"""Error classes for the to_home/ materialization pipeline.
+
+Extracted from :mod:`_to_home` to keep that module under the 512-line
+file-size cap (2026-06-15: adding ``WorkspaceCredentialLeakError`` for
+P0 task #6 pushed the file over). Both classes remain re-exported from
+``_to_home`` for backward compatibility — existing imports
+``from ...runtimes._to_home import WorkspaceCLAUDEMarkerError`` keep
+working.
+
+Co-locating the two error classes in one tiny module is intentional:
+they both signal a deploy-time refusal (operator-fix required, not a
+runtime fault), and grouping them keeps the file count modest while
+still respecting the line-cap doctrine.
+"""
+
+from __future__ import annotations
+
+
+class WorkspaceCLAUDEMarkerError(RuntimeError):
+    """Existing workspace marker-protected file has malformed markers.
+
+    The deploy is hard-aborted on this error rather than silently
+    overwriting or guessing — preserving user content past the End
+    marker is a safety contract and any ambiguity in marker placement
+    could destroy work.
+    """
+
+
+class WorkspaceCredentialLeakError(RuntimeError):
+    """``to_home/`` contains a ``.credentials.json`` — refused.
+
+    Credentials are operator-rotated runtime state from the auth-stage
+    rw bind, NEVER static workspace content. Lead-reported 2026-06-15:
+    an expired ``.credentials.json`` under
+    ``proj-scitex-todo/to_home/.claude/`` masked the bind and the
+    agent OAuth-spun on a stale token. The guard is hard-loud (no
+    silent skip) so the operator sees the offending source path and
+    removes it; the deploy fails BEFORE any sibling files land so an
+    aborted run cannot land partial state next to the leaked credential.
+    """
+
+
+__all__ = [
+    "WorkspaceCLAUDEMarkerError",
+    "WorkspaceCredentialLeakError",
+]

--- a/src/scitex_agent_container/runtimes/_to_home_text.py
+++ b/src/scitex_agent_container/runtimes/_to_home_text.py
@@ -1,0 +1,97 @@
+"""Text helpers for the to_home/ materialization pipeline.
+
+Extracted from :mod:`_to_home` to keep that module under the 512-line
+file-size cap (2026-06-15 — see ``GITIGNORED/REFACTORING.md``).
+Contains the marker constants, marker-invariant validator, user-tail
+extractor, and ``${VAR}`` / ``${metadata.*}`` interpolators used by
+:func:`_deploy_marker_protected` and :func:`_deploy_plain_file` in
+the orchestrator module.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+from ..config import AgentConfig
+from ._to_home_errors import WorkspaceCLAUDEMarkerError
+
+END_MARKER = "<!-- End of scitex-agent-container generated section -->"
+START_MARKER_PREFIX = "<!-- Start of scitex-agent-container generated section"
+
+
+def validate_marker_invariants(text: str, source_name: str) -> None:
+    """Hard-fail if Start/End markers are missing or malformed."""
+    start_count = text.count(START_MARKER_PREFIX)
+    end_count = text.count(END_MARKER)
+    if start_count != 1 or end_count != 1:
+        raise WorkspaceCLAUDEMarkerError(
+            f"{source_name}: expected exactly 1 Start marker and 1 End "
+            f"marker, found Start={start_count} End={end_count}. "
+            "Refusing to deploy to avoid data loss. Restore the markers "
+            "manually before retrying."
+        )
+    if text.find(START_MARKER_PREFIX) > text.find(END_MARKER):
+        raise WorkspaceCLAUDEMarkerError(
+            f"{source_name}: Start marker appears AFTER End marker. "
+            "This indicates a corrupted file. Refusing to deploy."
+        )
+
+
+def extract_user_tail(workspace_path: Path) -> str:
+    """Return content past the End marker in an existing workspace file.
+
+    Empty string when the file is missing, unreadable, or has no End
+    marker. Used to preserve user-appended content across a re-deploy
+    of marker-protected files (CLAUDE.md / state.md).
+    """
+    if not workspace_path.exists():
+        return ""
+    try:
+        existing = workspace_path.read_text()
+    except OSError:  # stx-allow: fallback (reason: file system operation failure)
+        return ""
+    idx = existing.rfind(END_MARKER)
+    if idx == -1:
+        return ""
+    return existing[idx + len(END_MARKER) :]
+
+
+def interpolate_env(text: str) -> str:
+    """Substitute ``${VAR}`` with ``os.environ[VAR]``, leaving unknown
+    refs untouched (so an unset env var becomes a visible artefact
+    rather than silently collapsing to empty string).
+    """
+    return re.sub(
+        r"\$\{(\w+)\}",
+        lambda m: os.environ.get(m.group(1), m.group(0)),
+        text,
+    )
+
+
+def interpolate_metadata(text: str, config: AgentConfig) -> str:
+    """Substitute ``${metadata.name}`` and ``${metadata.labels.<k>}``
+    against ``config``. Unknown keys pass through unchanged.
+    """
+
+    def _replace(m: re.Match) -> str:
+        key = m.group(1)
+        if key == "metadata.name":
+            return config.name
+        if key.startswith("metadata.labels."):
+            label = key[len("metadata.labels.") :]
+            return config.labels.get(label) or m.group(0)
+        return m.group(0)
+
+    return re.sub(r"\$\{([^}]+)\}", _replace, text)
+
+
+__all__ = [
+    "END_MARKER",
+    "START_MARKER_PREFIX",
+    "extract_user_tail",
+    "interpolate_env",
+    "interpolate_metadata",
+    "validate_marker_invariants",
+]

--- a/src/scitex_agent_container/runtimes/claude_md.py
+++ b/src/scitex_agent_container/runtimes/claude_md.py
@@ -348,7 +348,7 @@ def setup_claude_md(config: AgentConfig, workdir: str) -> None:
     lines.append(
         f'- Default scope for scitex-todo writes: `scope="agent:{agent_env_id}"`.'
     )
-    lines.append("- See `_base/to_home/CLAUDE.md` for the full convention.")
+    lines.append("- See `_shared/to_home/CLAUDE.md` for the full convention.")
     lines.append(f'<!-- agent-container:end id="{agent_id}" -->')
 
     section = "\n".join(lines)

--- a/src/scitex_agent_container/runtimes/tui_session.py
+++ b/src/scitex_agent_container/runtimes/tui_session.py
@@ -55,6 +55,7 @@ runner picks up whatever ``claude`` version the rebuilt SIF provides.
 
 from __future__ import annotations
 
+import shlex
 import time
 from pathlib import Path
 from typing import Any
@@ -65,8 +66,10 @@ from .._runners._tmux.tmux import (
 )
 from ..config import AgentConfig
 from . import prompts as _prompts
+from ._apptainer_build_argv import build_run_argv
 from ._to_home import deploy_to_home
-from ._tui_auth_stage import TuiAuthStageError, stage_tui_auth
+from ._to_home_overlay import deploy_to_home_overlay, resolve_overlay_upper_home
+from ._tui_auth_stage import TuiAuthStageError
 from .base import RuntimeBase
 from .claude_md import setup_claude_md
 from .onboarding import ensure_project_onboarding
@@ -76,7 +79,6 @@ __all__ = [
     "TuiInputNotReadyError",
     "TuiSessionRuntime",
     "session_name_for",
-    "stage_tui_auth",
     "state_dir_for_config",
 ]
 
@@ -93,6 +95,14 @@ _REQUIRED_CONFIG_ATTRS = ("expanded_workdir", "skills", "claude", "env", "labels
 # so a custom health policy in spec.health can tune it without a
 # code change.
 _DEFAULT_MAX_IDLE_S = 300.0
+
+# Boot-drain window when ``spec.startup_commands`` delay ``exec claude``
+# (e.g. an in-container ``uv pip install`` that runs for minutes before
+# the TUI launches). The drain polls through the bootstrap and dismisses
+# claude's first-run modals (bypass-permissions / trust / theme) the
+# moment they appear; it returns as soon as claude is up, so this is a
+# CAP, not a fixed block. 240s comfortably covers a cold uv resolve.
+_STARTUP_BOOT_DRAIN_S = 240.0
 
 
 def session_name_for(config: AgentConfig) -> str:
@@ -136,92 +146,6 @@ def state_dir_for_config(config: AgentConfig) -> Path:
     return _runner.state_dir_for(config.name, root=root)
 
 
-def _verify_tui_process_env(
-    *,
-    session_name: str,
-    expected_home: str,
-    expected_claude_config_dir: str,
-    settle_s: float = 1.5,
-) -> None:
-    """Assert the staged HOME + CLAUDE_CONFIG_DIR reached the inner
-    shell that ``exec``'d ``claude`` by reading a SESSION-SCOPED env
-    snapshot file written by the launch script.
-
-    Lead a2a ``4303f855a2184614954077e0ff466ad8`` (2026-06-14): the
-    previous ``/proc/<pid>/environ`` + ``ps`` walk version was not
-    session-scoped — it returned the FIRST claude-under-any-tmux on
-    the host, which on the operator's machine matched HIS own
-    interactive claude (HOME=/home/ywatanabe). The verify raised
-    spuriously while the actual TUI agent's env was fine.
-
-    New design (decoupled from PID hunting): TmuxManager.start writes
-    ``env > /tmp/sac-tui-env-<session_name>.txt`` IMMEDIATELY before
-    ``exec claude`` so the file captures the exact env passed to the
-    final ``exec``. We read that file and assert HOME +
-    CLAUDE_CONFIG_DIR. Cannot mis-attribute — the file name embeds
-    the session.
-
-    Best-effort: when the file is absent (very slow tmux startup,
-    container with no /tmp write, or the operator pulled this PR but
-    didn't restart sac with the new code), log a one-line warning
-    and return. Structural-alerts boot-drain timeout catches the
-    downstream symptom.
-    """
-    import logging
-    import time as _time
-
-    snapshot_path = Path(f"/tmp/sac-tui-env-{session_name}.txt")
-    deadline = _time.monotonic() + max(settle_s, 0.5)
-    while _time.monotonic() < deadline:
-        if snapshot_path.is_file() and snapshot_path.stat().st_size > 0:
-            break
-        _time.sleep(0.1)
-
-    if not snapshot_path.is_file() or snapshot_path.stat().st_size == 0:
-        logging.getLogger(__name__).warning(
-            "TuiSessionRuntime: env-snapshot %s missing/empty; "
-            "skipping env verification (boot-drain timeout will "
-            "catch downstream symptoms).",
-            snapshot_path,
-        )
-        return
-
-    env: dict[str, str] = {}
-    for line in snapshot_path.read_text(
-        encoding="utf-8", errors="replace"
-    ).splitlines():
-        if "=" not in line:
-            continue
-        key, value = line.split("=", 1)
-        env[key] = value
-
-    observed_home = env.get("HOME", "")
-    observed_config_dir = env.get("CLAUDE_CONFIG_DIR", "")
-    if (
-        observed_home != expected_home
-        or observed_config_dir != expected_claude_config_dir
-    ):
-        from ._tui_auth_stage import TuiAuthStageError
-
-        raise TuiAuthStageError(
-            "TUI auth: env snapshot at exec-claude time does NOT "
-            "match the staged values. Operator-symptom: TUI parks "
-            "at the OAuth login URL screen because claude reads the "
-            "host ~/.claude/ instead of the staged <state>/home/.claude/. "
-            "Diagnostic: "
-            f"observed HOME={observed_home!r} / "
-            f"CLAUDE_CONFIG_DIR={observed_config_dir!r}; expected "
-            f"HOME={expected_home!r} / "
-            f"CLAUDE_CONFIG_DIR={expected_claude_config_dir!r}. "
-            f"Snapshot file: {snapshot_path}, session={session_name!r}. "
-            "Common roots: stale sac install (operator did `git pull` "
-            "but the installed sac is from PyPI — run `pip install "
-            "-e ~/proj/scitex-agent-container` to use develop) OR a "
-            "shell init file resetting HOME after the exports OR the "
-            "tmux version doesn't support `-e KEY=VAL` (needs >=3.2)."
-        )
-
-
 class TuiSessionRuntime(RuntimeBase):
     """Interactive tmux-backed Claude TUI runtime.
 
@@ -239,6 +163,7 @@ class TuiSessionRuntime(RuntimeBase):
         self,
         multiplexer: Any | None = None,
         claude_bin: str = _CLAUDE_BIN_DEFAULT,
+        command_builder: Any | None = None,
     ) -> None:
         # Default to the real TmuxManager; tests pass an in-memory
         # MultiplexerProtocol fake. No mocks — the fake is a real
@@ -246,36 +171,63 @@ class TuiSessionRuntime(RuntimeBase):
         # satisfies, just backed by a dict instead of subprocess.
         self._mux = multiplexer if multiplexer is not None else TmuxManager
         self._claude_bin = claude_bin
+        # Injection seam (mirrors ``multiplexer`` + ClaudeSessionRuntime's
+        # ``container_runtime_for``): ``(config) -> list[str] | None`` —
+        # the ``apptainer exec ... claude`` argv to launch in tmux, or
+        # ``None`` when no SIF could be resolved. Tests inject a fake that
+        # returns a deterministic argv so the tmux-dispatch glue runs
+        # without a real apptainer/SIF. Default = :meth:`_default_argv`.
+        self._command_builder = command_builder or self._default_argv
+
+    def _default_argv(self, config: AgentConfig) -> list[str] | None:
+        """Resolve the SIF and render the ``apptainer exec ... claude``
+        argv (``tui=True``) — the production launch command.
+
+        Returns ``None`` when no SIF resolves (e.g. apptainer absent);
+        :meth:`start` turns that into a fail-loud error on a real run.
+        Reuses ``ApptainerContainerRuntime`` so SIF resolution / build /
+        the missing-apptainer diagnostic stay identical to the SDK path.
+        """
+        from ._apptainer_runtime import ApptainerContainerRuntime
+
+        container_rt = ApptainerContainerRuntime()
+        sif_path = container_rt.resolve_sif(config)
+        if sif_path is None:
+            return None
+        state_dir = state_dir_for_config(config)
+        return build_run_argv(config, state_dir=state_dir, sif_path=sif_path, tui=True)
 
     def materialize_workspace(self, config: AgentConfig) -> Path | None:
-        """Materialise per-agent ``to_home/`` + CLAUDE.md + TUI-auth
-        files into ``<state>/home/`` and return that path.
+        """Materialise per-agent ``to_home/`` + CLAUDE.md into the
+        container ``$HOME`` and return the host-side ``<state>/home/`` path.
 
-        Mirrors ``ClaudeSessionRuntime._materialize_workspace``: writes
-        the sac-managed CLAUDE.md skill chain into ``<state>/home/CLAUDE.md``
-        and overlays the per-agent ``to_home/`` (.mcp.json, .env,
-        .claude/{hooks,skills,settings.json}) on top of the shared
-        baseline. The result is a self-contained $HOME tree the TUI
-        ``claude`` binary will read on launch — same SkillsSpec / MCP
-        / hook surface the SDK runtime provides.
+        Mirrors ``ClaudeSessionRuntime._setup_workspace`` EXACTLY so the
+        in-apptainer TUI gets the same $HOME surface as the SDK path:
 
-        ADDITIONAL TUI-auth staging (lead a2a
-        ``910ff436642948eb85f8b3100204ed9b``, 2026-06-14): the
-        interactive ``claude`` TUI checks TWO files the SDK runner
-        does not — ``$HOME/.claude/.credentials.json`` (live OAuth
-        token) and ``$HOME/.claude.json`` (onboarding state). Before
-        this hook, every ``sac agents start --runtime tui`` agent sat
-        on the login picker because neither file was present in the
-        materialised HOME. :func:`stage_tui_auth` lands both, sourced
-        by default from the apptainer auth bind + ``${HOME}/.claude.json``
-        and overridable via ``SAC_TUI_AUTH_CREDENTIALS_SRC`` /
-        ``SAC_TUI_AUTH_CLAUDE_JSON_SRC``. Fail-loud: a missing source
-        raises :class:`TuiAuthStageError` with a remedy rather than
-        letting the TUI silently stall on the picker.
+          * ``setup_claude_md`` writes the sac-managed CLAUDE.md skill
+            chain into ``<state>/home/CLAUDE.md``.
+          * ``deploy_to_home`` overlays the shared ``_shared/to_home``
+            baseline + per-agent ``to_home/`` (.mcp.json, .env,
+            .claude/{hooks,skills,settings.json}) into ``<state>/home/``
+            (the host dir bound at ``/home/agent``).
+          * ``deploy_to_home_overlay`` mirrors the SAME tree into the
+            overlay upper-home for relaxed ``--home``/``--overlay`` specs
+            (where the workspace-home bind is shadowed). No-op otherwise.
+
+        Credentials are NOT staged here: the in-apptainer TUI receives
+        them via the writable file-bind ``spec.claude.credentials_file``
+        (or the account/host dir-bind) emitted in ``build_run_argv`` —
+        single source of truth, no copy to desync.
+
+        ``ensure_project_onboarding`` pre-seeds the per-workspace entry
+        in ``$HOME/.claude.json`` so the TUI skips the workspace-trust
+        wizard; it is written into BOTH the workspace-home and (when
+        present) the overlay upper-home so it lands regardless of which
+        home-delivery mode the spec uses.
 
         Returns ``None`` for stub configs lacking the full AgentConfig
         surface (unit-test ``SimpleNamespace`` fixtures); the caller
-        treats that as "skip materialise, run with bare $HOME".
+        treats that as "skip materialise".
         """
         if not all(hasattr(config, a) for a in _REQUIRED_CONFIG_ATTRS):
             return None
@@ -283,32 +235,20 @@ class TuiSessionRuntime(RuntimeBase):
         home_dir.mkdir(parents=True, exist_ok=True)
         setup_claude_md(config, str(home_dir))
         deploy_to_home(config, str(home_dir))
-        # Pass config so the resolver can consult spec.claude.account
-        # for the per-account snapshot path on host starts (lead a2a
-        # 1781e82a, 2026-06-14).
-        stage_tui_auth(home_dir, config=config)
-        # Pre-seed the projects entry so the TUI skips the per-workspace
-        # onboarding wizard (theme picker / dev-channels approval) on
-        # first launch. Without this, the dogfood (2026-06-14) caught
-        # the bundled ``claude`` showing "Choose the text style" before
-        # mounting its input field — which would wedge ``send_turn``
-        # against a modal overlay. ``ensure_project_onboarding`` is the
-        # same primitive the SDK runtime uses (see
-        # ``_runners/_tmux/claude_code.py``); calling it here gives the
-        # TUI runtime parity with the SDK path on workspace onboarding.
-        # The seed must use the SAME workdir the tmux session is
-        # launched in (see ``start()`` below). Both call sites use
-        # ``expanded_workdir`` so a tilde-prefixed default resolves
-        # to an absolute path before mkdir/cd/seed; a mismatch
-        # (e.g. seeding ``expanded_workdir`` while claude runs in
-        # raw ``workdir``) would leave the picker live against the
-        # actual cwd. Single source of truth.
+        # Relaxed ``--home``/directory-overlay specs shadow the
+        # workspace-home bind; mirror the same to_home tree into the
+        # overlay upper-home so it reaches the container $HOME. No-op for
+        # non-overlay specs (the workspace-home bind suffices).
+        deploy_to_home_overlay(config)
         workdir = (
             getattr(config, "expanded_workdir", "")
             or getattr(config, "workdir", "")
             or "/tmp"
         )
         ensure_project_onboarding(workdir, home=home_dir)
+        upper_home = resolve_overlay_upper_home(config)
+        if upper_home is not None and upper_home.is_dir():
+            ensure_project_onboarding(workdir, home=upper_home)
         return home_dir
 
     def start(
@@ -322,80 +262,78 @@ class TuiSessionRuntime(RuntimeBase):
         inject_startup_prompts: bool = True,
         boot_drain_timeout_s: float = 30.0,
     ) -> bool:
-        """Launch ``claude`` inside a detached tmux session sac owns.
+        """Launch the interactive ``claude`` TUI **inside apptainer**,
+        held open by a detached tmux session sac owns.
 
-        Materialises the per-agent ``to_home/`` + CLAUDE.md into
-        ``<state>/home/`` before launching tmux, then exports
-        ``HOME=<state>/home`` + ``CLAUDE_CONFIG_DIR=<state>/home/.claude``
-        into the tmux session so the in-tmux ``claude`` TUI sees the
-        agent's skills, MCP servers, hooks, and settings.json — same
-        surface the SDK runtime provides via apptainer bind-mount.
+        Parity with ``ClaudeSessionRuntime`` (the SDK runtime): the
+        agent runs in the SIF with the SAME isolation, binds, overlay,
+        auth, and to_home delivery — assembled by
+        :func:`_apptainer_build_argv.build_run_argv` with ``tui=True``.
+        The only differences from the SDK path are (1) the inner process
+        is the interactive ``claude`` TUI instead of the ``python -m``
+        session runner, and (2) tmux wraps the ``apptainer exec`` so the
+        TUI gets a PTY and survives operator detach. tmux is a PTY
+        holder only — it never runs ``claude`` on the host.
 
-        ``force=True`` stops any existing session for this agent
-        before starting (the same idempotent-restart contract the
-        supervisor relies on). ``dry_run=True`` materialises the
-        workspace but skips the actual ``tmux new-session`` — lets
-        the operator verify the rendered tree without spawning a
-        process. ``foreground`` is ignored (a tmux session whose
-        whole point is detachment has no meaningful foreground mode
-        — same convention as the screen runner).
+        ``force=True`` stops any existing session before starting
+        (idempotent-restart contract). ``dry_run=True`` materialises the
+        workspace + writes the rendered argv to
+        ``<state>/apptainer_run.argv.txt`` but skips ``tmux new-session``.
+        ``foreground`` / ``no_preflight`` are accepted for RuntimeBase
+        parity; a detached-by-design tmux session has no foreground mode.
         """
+        del no_preflight, foreground
         name = session_name_for(config)
         if force and self._mux.exists(name):
             self._mux.stop(name)
-        home_dir = self.materialize_workspace(config)
+        self.materialize_workspace(config)
+
+        from .._lifecycle._runtime_select import warn_if_legacy_apptainer_runtime
+
+        warn_if_legacy_apptainer_runtime(config)
+
+        # Render the ``apptainer exec ... claude`` argv via the injection
+        # seam (default :meth:`_default_argv` resolves the SIF + calls
+        # build_run_argv(tui=True); tests inject a deterministic fake).
+        argv = self._command_builder(config)
+        if argv is None:
+            import shutil as _shutil
+
+            if _shutil.which("apptainer") is None and not dry_run:
+                raise TuiAuthStageError(
+                    "apptainer binary not found on $PATH — the TUI runtime "
+                    "runs claude INSIDE apptainer (parity with the SDK "
+                    "runtime). Install apptainer, or run on a host that has "
+                    "it. (Legacy host-tmux TUI is retired.)"
+                )
+            return False
+
         if dry_run:
+            state_dir = state_dir_for_config(config)
+            state_dir.mkdir(parents=True, exist_ok=True)
+            (state_dir / "apptainer_run.argv.txt").write_text("\n".join(argv) + "\n")
             return True
-        # Use expanded_workdir so a tilde-prefixed default (the
-        # AgentConfig default ``~/.scitex/agent-container/runtime/agents/<name>``)
-        # resolves to an absolute path. The raw ``config.workdir``
-        # may still carry the literal ``~`` — passed straight to
-        # ``Path(...).mkdir`` it materialises a directory NAMED ``~``
-        # under the launching cwd, and the shell ``cd '~/.scitex/...'``
-        # (single-quoted, so no tilde expansion) lands in a bogus
-        # path. Both observed in the 2026-06-14 dogfood, which then
-        # broke the per-workspace onboarding seed below because the
-        # picker fired against a different workdir than the seed.
+
+        # tmux runs ``exec <command>`` in a bash -c; pass the apptainer
+        # argv shell-quoted so the PTY wraps ``apptainer exec ... claude``.
+        # No HOME/CLAUDE_CONFIG_DIR session env: the container sets its
+        # own $HOME (=/home/agent) and the host-side tmux shell's env is
+        # irrelevant to the in-SIF process. The host workdir is only the
+        # tmux launch cwd — the agent's real cwd is ``--pwd`` inside the SIF.
         workdir = (
             getattr(config, "expanded_workdir", "")
             or getattr(config, "workdir", "")
             or "/tmp"
         )
-        env_exports = ""
-        session_env: dict[str, str] = {}
-        if home_dir is not None:
-            env_exports = (
-                f"export HOME={home_dir}\nexport CLAUDE_CONFIG_DIR={home_dir}/.claude\n"
-            )
-            # Structural fix (lead a2a 8f910ea7, 2026-06-14): live
-            # host agents launched with `bash -l` which re-sourced
-            # login init files that reset HOME to the operator's
-            # real home; the inner `claude` then read the operator's
-            # `~/.claude/` instead of the staged `<state>/home/.claude/`
-            # and fell to interactive OAuth. Pass HOME +
-            # CLAUDE_CONFIG_DIR via tmux `new-session -e KEY=VAL`
-            # (and TmuxManager drops the bash `-l` flag) so the
-            # staged values can no longer be overwritten.
-            session_env = {
-                "HOME": str(home_dir),
-                "CLAUDE_CONFIG_DIR": f"{home_dir}/.claude",
-                "CLAUDE_DISABLE_AUTO_UPDATE": "1",
-            }
+        command = " ".join(shlex.quote(a) for a in argv)
         started = bool(
             self._mux.start(
                 session_name=name,
-                command=self._claude_bin,
+                command=command,
                 workdir=str(workdir),
-                env_exports=env_exports,
-                session_env=session_env or None,
+                session_env={"CLAUDE_DISABLE_AUTO_UPDATE": "1"},
             )
         )
-        if started and home_dir is not None:
-            _verify_tui_process_env(
-                session_name=name,
-                expected_home=str(home_dir),
-                expected_claude_config_dir=f"{home_dir}/.claude",
-            )
         if started and drain_pickers_at_boot:
             # URGENT (lead a2a 278159b5, 2026-06-14): drain the
             # picker registry AT BOOT so the supervisor + downstream
@@ -406,17 +344,19 @@ class TuiSessionRuntime(RuntimeBase):
             # out. Failure here MUST NOT fail the start (supervisor
             # restart loop would oscillate); log + let the send_turn
             # retry on its own hook.
-            try:
-                self.wait_until_input_ready(config, timeout_s=boot_drain_timeout_s)
-            except TuiInputNotReadyError as exc:  # stx-allow: fallback (reason: boot-drain best-effort; send_turn retries — operator escalation 2026-06-14)
-                import logging
-
-                logging.getLogger(__name__).warning(
-                    "TuiSessionRuntime.start: boot-drain timed out "
-                    "for %s; send_turn will retry. Last error: %s",
-                    name,
-                    exc,
-                )
+            #
+            # Adaptive window (2026-06-15): when ``startup_commands``
+            # delay ``exec claude`` (e.g. an in-container uv install of
+            # minutes), a fixed 30s drain expires BEFORE claude renders
+            # its first modal — the bypass-permissions / trust picker
+            # then sits forever because nothing re-drains it at boot.
+            # Stretch the window to cover the bootstrap; the drain
+            # returns as soon as claude is up (it does NOT block the
+            # full window — see ``_drain_at_boot``).
+            effective_timeout = boot_drain_timeout_s
+            if list(getattr(config, "startup_commands", []) or []):
+                effective_timeout = max(boot_drain_timeout_s, _STARTUP_BOOT_DRAIN_S)
+            self._drain_at_boot(config, timeout_s=effective_timeout)
         if started and inject_startup_prompts:
             # Boot-mission injection (lead a2a 4973264a, 2026-06-14):
             # parity with SDK runtime — feed spec.startup_prompts to
@@ -586,6 +526,68 @@ class TuiSessionRuntime(RuntimeBase):
         # startup_prompts).
         self._mux.send_text_and_submit(name, text)
         return True
+
+    def _drain_at_boot(
+        self,
+        config: AgentConfig,
+        *,
+        timeout_s: float,
+        poll_s: float = 0.5,
+    ) -> bool:
+        """Dismiss claude's first-run modals at boot; return as soon as
+        the TUI is up — NOT when it goes idle.
+
+        Differs from :meth:`wait_until_input_ready` (the send_turn drain,
+        which waits for the ``? for shortcuts`` idle marker) on two
+        boot-specific realities:
+
+          * ``startup_commands`` can delay ``exec claude`` by minutes —
+            the loop just keeps polling (nothing in the install log
+            matches a modal) until claude finally renders its first
+            screen. The caller passes a window wide enough to cover the
+            bootstrap (:data:`_STARTUP_BOOT_DRAIN_S`).
+          * an autonomous agent with ``startup_prompts`` goes STRAIGHT to
+            work once the modals clear, so the idle marker may never
+            show. Exit on the marker OR :func:`prompts.is_ready` (claude
+            launched with no blocking ``Enter to confirm`` modal),
+            whichever first — so start() never blocks the full window
+            after the bypass/trust picker is dismissed.
+
+        Best-effort: never raises. A timeout just means the modal will be
+        re-drained by the next :meth:`send_turn`. Returns True iff a
+        ready signal was observed within the window.
+        """
+        name = session_name_for(config)
+        if not self._mux.exists(name):
+            return False
+        accepted: set[str] = set()
+        marker = "? for shortcuts"
+        deadline = time.monotonic() + timeout_s
+        send_keys_fn = self._mux.send_keys
+        while time.monotonic() < deadline:
+            pane = self._mux.capture_content(name)
+            if marker in pane or _prompts.is_ready(pane):
+                return True
+            handled = _prompts.detect_and_respond(
+                pane, accepted, send_keys_fn=lambda key: send_keys_fn(name, key)
+            )
+            if handled is not None:
+                accepted.add(handled)
+                continue
+            if poll_s > 0:
+                time.sleep(poll_s)
+        import logging
+
+        logging.getLogger(__name__).warning(
+            "TuiSessionRuntime: boot-drain window (%.0fs) elapsed for %s "
+            "without a ready signal (drained %d modal(s): %s); send_turn "
+            "will re-drain.",
+            timeout_s,
+            name,
+            len(accepted),
+            sorted(accepted),
+        )
+        return False
 
     def wait_until_input_ready(
         self,

--- a/tests/examples/test_force_background_bash_hook.py
+++ b/tests/examples/test_force_background_bash_hook.py
@@ -7,7 +7,7 @@ operator Telegram. Enforcement is a pre-tool-use hook — structural,
 not behavioural — so an agent CANNOT accidentally run an unbounded
 foreground Bash and queue the operator behind it.
 
-Canonical policy (mirrors the lead's _base/to_home copy, dotfiles
+Canonical policy (mirrors the lead's _shared/to_home copy, dotfiles
 commit ac582483):
 
   Allow foreground ONLY if BOUNDED:
@@ -23,7 +23,7 @@ commit ac582483):
   Escape: ``CC_ALLOW_FOREGROUND_HEAVY=1``.
 
 The hook ships in the example agent template so future agents inherit
-it; the lead's identical-policy copy in dotfiles ``_base/to_home`` is
+it; the lead's identical-policy copy in dotfiles ``_shared/to_home`` is
 the fleet rollout surface.
 
 Each test asserts a single observable invariant. AAA layout. No mocks.

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -121,7 +121,9 @@ class TestLoadMinimalConfig:
         config = minimal_loaded_config
         # Act
         runtime = config.runtime
-        # Assert
+        # Assert — MINIMAL_CONFIG explicitly pins runtime: apptainer.
+        # (The default-when-omitted is tui — see
+        # test_v3_spec_structure.test_runtime_defaults_to_tui_when_omitted.)
         assert runtime == "apptainer"
 
     def test_minimal_defaults_model_to_sonnet(self, minimal_loaded_config):

--- a/tests/integration/test_templates_v3_valid.py
+++ b/tests/integration/test_templates_v3_valid.py
@@ -34,13 +34,16 @@ def test_example_spec_name_matches_directory_name(spec):
     sorted(EXAMPLES_DIR.glob("*/spec.yaml")),
     ids=lambda p: p.parent.name,
 )
-def test_example_spec_runtime_defaults_to_apptainer(spec):
+def test_example_spec_runtime_is_apptainer(spec):
     # Arrange
     from scitex_agent_container.config import load_config
 
     # Act
     cfg = load_config(str(spec))
-    # Assert
+    # Assert — every example spec EXPLICITLY pins runtime: apptainer
+    # (incl. the proxy/provider examples, which need the SDK path, not
+    # the interactive TUI). The DEFAULT-when-omitted is tui — covered in
+    # test_v3_spec_structure.test_runtime_defaults_to_tui_when_omitted.
     assert cfg.runtime == "apptainer"
 
 

--- a/tests/integration/test_v3_spec_structure.py
+++ b/tests/integration/test_v3_spec_structure.py
@@ -72,6 +72,14 @@ class TestCrossCuttingTopLevel:
         # Assert
         assert cfg.runtime == "apptainer"
 
+    def test_runtime_defaults_to_tui_when_omitted(self, tmp_path):
+        # Arrange — a spec that does NOT declare runtime.
+        spec = _write_spec(tmp_path, {"workdir": "/tmp/agent-x"})
+        # Act
+        cfg = load_config(str(spec))
+        # Assert — TUI is the default launch mode (operator directive 2026-06-15).
+        assert cfg.runtime == "tui"
+
     def test_workdir_value_round_trips(self, tmp_path):
         # Arrange
         spec = _write_spec(

--- a/tests/scitex_agent_container/_lifecycle/test__runtime_select.py
+++ b/tests/scitex_agent_container/_lifecycle/test__runtime_select.py
@@ -2,9 +2,9 @@
 
 Operator directive 12870 (lead a2a ``b58dd5d3b4d640d2a7f31f16c710e839``):
 ``spec.runtime`` is repurposed from container-engine selector to
-LAUNCH-MODE selector. ``claude-agent-sdk`` (default) → the SDK runner;
-``tui`` → the new tmux-backed TUI runner. Legacy ``apptainer`` / ``""``
-values are accepted for back-compat and map to ``claude-agent-sdk``
+LAUNCH-MODE selector. ``tui`` (the DEFAULT since 2026-06-15; ``""`` /
+unset maps here) → the in-apptainer TUI runner; ``claude-agent-sdk`` →
+the headless SDK runner. Legacy ``apptainer`` maps to ``claude-agent-sdk``
 with a one-line deprecation log.
 
 STX-TQ002 AAA + STX-TQ007 one-assert. No mocks — uses a tiny stub
@@ -40,13 +40,13 @@ def test_get_runtime_returns_claude_session_for_claude_agent_sdk():
     assert isinstance(rt, ClaudeSessionRuntime)
 
 
-def test_get_runtime_returns_claude_session_for_empty_runtime():
-    # Arrange — historical default; existing specs may omit the field.
+def test_get_runtime_returns_tui_session_for_empty_runtime():
+    # Arrange — empty / unset is the DEFAULT and now maps to TUI.
     config = SimpleNamespace(name="alpha", runtime="")
     # Act
     rt = _get_runtime(config)
     # Assert
-    assert isinstance(rt, ClaudeSessionRuntime)
+    assert isinstance(rt, TuiSessionRuntime)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scitex_agent_container/_lifecycle/test_lifecycle.py
+++ b/tests/scitex_agent_container/_lifecycle/test_lifecycle.py
@@ -212,7 +212,8 @@ def _no_sleep(_seconds: float) -> None:
 
 
 def test_get_runtime_apptainer_returns_claude_session_runtime() -> None:
-    # Arrange
+    # Arrange — legacy ``"apptainer"`` (the pre-2026-06-13 container-engine
+    # selector) is back-compat-mapped to the headless SDK runner.
     cfg = AgentConfig(name="x", runtime="apptainer")
     # Act
     rt = lc._get_runtime(cfg)
@@ -222,15 +223,21 @@ def test_get_runtime_apptainer_returns_claude_session_runtime() -> None:
     assert isinstance(rt, ClaudeSessionRuntime)
 
 
-def test_get_runtime_empty_runtime_treated_as_apptainer() -> None:
-    # Arrange: explicit empty string runtime falls through to apptainer.
+def test_get_runtime_empty_runtime_defaults_to_tui() -> None:
+    # Arrange — operator directive 2026-06-15: post the SDK-pool cutoff, an
+    # empty / unset ``spec.runtime`` selects the interactive in-apptainer
+    # TUI runtime (the new default). Previously empty → ClaudeSessionRuntime;
+    # the contract flipped when ``spec.runtime`` was repurposed from
+    # container-engine selector to launch-mode selector (directive 12870 +
+    # lead a2a ``b58dd5d3``). Pin the new default here so a future
+    # accidental flip-back is caught.
     cfg = AgentConfig(name="x", runtime="")
     # Act
     rt = lc._get_runtime(cfg)
     # Assert
-    from scitex_agent_container.runtimes.claude_session import ClaudeSessionRuntime
+    from scitex_agent_container.runtimes.tui_session import TuiSessionRuntime
 
-    assert isinstance(rt, ClaudeSessionRuntime)
+    assert isinstance(rt, TuiSessionRuntime)
 
 
 def test_get_runtime_unsupported_runtime_raises() -> None:

--- a/tests/scitex_agent_container/runtimes/test__apptainer_build_argv.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_build_argv.py
@@ -15,13 +15,24 @@ runtime) instead of on the host via tmux:
     tmpfs cannot shadow it.
 
 Real AgentConfig via ``load_config`` on a tmp spec — no mocks.
-STX-TQ002 AAA-marker + STX-TQ007 one-assert.
+STX-TQ002 AAA-marker + STX-TQ007 one-assert + PA-306 no-mock-fixtures.
+
+The file is named ``test__apptainer_build_argv.py`` to satisfy the
+PS-204 §2 orphan-test mirror rule against
+``src/scitex_agent_container/runtimes/_apptainer_build_argv.py`` (the
+production entry-point under test). The companion helpers tested here
+(``_apptainer_auth.credentials_file_bind`` and
+``_apptainer_inner_argv.{build_inner_argv,tui_channel_config,
+resolve_sac_bin_in_sif}``) are exercised through ``build_run_argv``
+to keep the mirror 1:1.
 """
 
 from __future__ import annotations
 
 import os
+import socket
 from pathlib import Path
+from typing import Iterator
 
 import pytest
 
@@ -32,6 +43,55 @@ from scitex_agent_container.runtimes._apptainer_inner_argv import (
     build_inner_argv,
     tui_channel_config,
 )
+
+
+@pytest.fixture
+def _isolate_home(tmp_path: Path) -> Iterator[Path]:
+    """Redirect ``HOME`` (and ``Path.home``) to a per-test tmp dir.
+
+    The bearer-token resolver (``_apptainer_build._listen_token_path`` →
+    ``_listen.tokens.default_token_path``) anchors on ``Path.home()``. By
+    sliding ``HOME`` to ``tmp_path`` we keep the materialised token file
+    contained inside the test and never touch the developer's real
+    ``~/.scitex/agent-container/tokens/`` tree.
+    """
+    saved = os.environ.get("HOME")
+    os.environ["HOME"] = str(tmp_path)
+    try:
+        yield tmp_path
+    finally:
+        if saved is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = saved
+
+
+@pytest.fixture
+def listen_bearer_token(_isolate_home: Path) -> Path:
+    """Materialise a real ``sac listen`` bearer token at the resolver path.
+
+    Tests that exercise ``build_run_argv`` against a spec whose
+    ``spec.claude.channels`` includes ``server:sac`` would otherwise hit
+    the fail-loud guard in
+    ``_apptainer_listen_env.listen_env_flags`` — that guard exists to
+    refuse launches whose in-container channel adapter can never
+    authenticate to ``sac listen``. CI hosts have no token file, so the
+    guard turns an argv-shape test into a RuntimeError. This fixture
+    writes a real (non-empty) token to the resolver-computed path so the
+    guard sees a usable bearer and ``build_run_argv`` proceeds.
+
+    The path layout mirrors the production resolver
+    (``_listen.tokens.default_token_path``): ``$HOME/.scitex/agent-
+    container/tokens/listen-<hostname>.token``. We use ``socket.
+    gethostname()`` here so a CI runner rename does not desync the
+    fixture from the resolver.
+    """
+    home = _isolate_home
+    token_dir = home / ".scitex" / "agent-container" / "tokens"
+    token_dir.mkdir(parents=True, exist_ok=True)
+    token_path = token_dir / f"listen-{socket.gethostname()}.token"
+    token_path.write_text("test-bearer-token-not-a-secret\n", encoding="utf-8")
+    return token_path
 
 
 def _write_spec(tmp_path: Path, body: str) -> Path:
@@ -253,8 +313,13 @@ def test_tui_channel_config_registers_sac_channel_subscriber(tmp_path) -> None:
     assert channel_mcp is not None and "mcp" in channel_mcp and "channel" in channel_mcp
 
 
-def test_build_run_argv_tui_adds_dev_channels_flag(tmp_path) -> None:
-    # Arrange
+def test_build_run_argv_tui_adds_dev_channels_flag(
+    tmp_path, listen_bearer_token
+) -> None:
+    # Arrange — ``listen_bearer_token`` materialises a real bearer at the
+    # resolver path so the ``server:sac`` channel guard
+    # (``_apptainer_listen_env.listen_env_flags``) does not refuse the
+    # launch on a CI host that has never run ``sac listen``.
     spec = _write_spec(tmp_path, _SPEC_WITH_CHANNEL)
     config = load_config(str(spec))
     state_dir = tmp_path / "state"
@@ -267,8 +332,12 @@ def test_build_run_argv_tui_adds_dev_channels_flag(tmp_path) -> None:
     assert "--dangerously-load-development-channels server:sac" in " ".join(argv)
 
 
-def test_build_run_argv_tui_injects_channel_subscriber_mcp(tmp_path) -> None:
-    # Arrange
+def test_build_run_argv_tui_injects_channel_subscriber_mcp(
+    tmp_path, listen_bearer_token
+) -> None:
+    # Arrange — ``listen_bearer_token`` materialises a real bearer at the
+    # resolver path so the ``server:sac`` channel guard does not refuse
+    # this launch on a CI host that has never run ``sac listen``.
     spec = _write_spec(tmp_path, _SPEC_WITH_CHANNEL)
     config = load_config(str(spec))
     state_dir = tmp_path / "state"
@@ -308,15 +377,25 @@ def test_resolve_sac_bin_in_sif_returns_agent_venv_path() -> None:
             os.environ["SAC_BIN_IN_SIF"] = saved
 
 
-def test_resolve_sac_bin_in_sif_honours_env_override(monkeypatch) -> None:
-    # Arrange — operator escape hatch for rebuilt SIFs.
-    monkeypatch.setenv("SAC_BIN_IN_SIF", "/custom/path/to/sac")
-    # Act
-    from scitex_agent_container.runtimes._apptainer_inner_argv import (
-        resolve_sac_bin_in_sif,
-    )
+def test_resolve_sac_bin_in_sif_honours_env_override() -> None:
+    # Arrange — operator escape hatch for rebuilt SIFs. ``monkeypatch``
+    # is forbidden by the PA-306 §3 no-mocks rule, so save/restore the
+    # env var directly on ``os.environ`` (real state mutation, not a
+    # pytest fixture wrapper).
+    saved = os.environ.get("SAC_BIN_IN_SIF")
+    os.environ["SAC_BIN_IN_SIF"] = "/custom/path/to/sac"
+    try:
+        # Act
+        from scitex_agent_container.runtimes._apptainer_inner_argv import (
+            resolve_sac_bin_in_sif,
+        )
 
-    path = resolve_sac_bin_in_sif()
+        path = resolve_sac_bin_in_sif()
+    finally:
+        if saved is None:
+            os.environ.pop("SAC_BIN_IN_SIF", None)
+        else:
+            os.environ["SAC_BIN_IN_SIF"] = saved
     # Assert
     assert path == "/custom/path/to/sac"
 

--- a/tests/scitex_agent_container/runtimes/test__symlink_resolve.py
+++ b/tests/scitex_agent_container/runtimes/test__symlink_resolve.py
@@ -8,7 +8,7 @@ to real content at the destination — is exercised here along with the
 2026-06-04 F-CS8 fix: ``worktrees/`` subtrees inside the resolved
 target are EXCLUDED from the copy via :func:`_walk_exclusions.copytree_ignore`.
 Without this, a baseline symlink like
-``_base/to_home/.claude/skills -> ~/.claude/skills`` would
+``_shared/to_home/.claude/skills -> ~/.claude/skills`` would
 transitively pull every git worktree nested under the host
 ``~/.claude/`` into the container overlay at start time.
 """

--- a/tests/scitex_agent_container/runtimes/test__to_home.py
+++ b/tests/scitex_agent_container/runtimes/test__to_home.py
@@ -24,6 +24,7 @@ from scitex_agent_container.runtimes._to_home import (
     END_MARKER,
     DanglingToHomeSymlinkError,
     WorkspaceCLAUDEMarkerError,
+    WorkspaceCredentialLeakError,
     deploy_to_home,
     materialize_to_home,
     resolve_baseline_to_home_dir,
@@ -163,6 +164,102 @@ class TestMaterializeToHomeBasics:
         materialize_to_home(spec_dir, home)
         # Assert
         assert home.is_dir()
+
+
+class TestCredentialLeakGuard:
+    """``to_home/`` must never carry a ``.credentials.json``.
+
+    Lead-reported 2026-06-15: an EXPIRED ``.credentials.json`` was
+    committed under ``proj-scitex-todo/to_home/.claude/.credentials.json``
+    and re-deployed every ``sac agents start``. Credentials are
+    operator-rotated runtime state, not workspace bootstrap content —
+    they must come from the auth-stage rw bind, not a static copy.
+    Letting a static cred file land in ``$HOME/.claude/.credentials.json``
+    masks a missing bind: the agent appears to authenticate but uses
+    a stale token, then 401s opaquely at the next refresh.
+
+    The guard is loud (raises :class:`WorkspaceCredentialLeakError`)
+    rather than silent-skip so the operator sees the offending path
+    and fixes the source.
+    """
+
+    def test_credentials_json_at_to_home_root_raises(self, tmp_path):
+        # Arrange
+        spec_dir = tmp_path / "spec"
+        (spec_dir / "to_home").mkdir(parents=True)
+        (spec_dir / "to_home" / ".credentials.json").write_text('{"x":1}\n')
+        home = tmp_path / "home"
+        # Act + Assert
+        with pytest.raises(WorkspaceCredentialLeakError) as exc_info:
+            materialize_to_home(spec_dir, home)
+        assert ".credentials.json" in str(exc_info.value)
+
+    def test_credentials_json_under_dot_claude_raises(self, tmp_path):
+        # Arrange — the lead-reported leak shape.
+        spec_dir = tmp_path / "spec"
+        (spec_dir / "to_home" / ".claude").mkdir(parents=True)
+        (spec_dir / "to_home" / ".claude" / ".credentials.json").write_text(
+            '{"oauthAccount":"old"}\n'
+        )
+        home = tmp_path / "home"
+        # Act + Assert
+        with pytest.raises(WorkspaceCredentialLeakError) as exc_info:
+            materialize_to_home(spec_dir, home)
+        assert ".credentials.json" in str(exc_info.value)
+
+    def test_credentials_json_at_arbitrary_depth_raises(self, tmp_path):
+        # Arrange — guard fires regardless of nesting.
+        spec_dir = tmp_path / "spec"
+        deep = spec_dir / "to_home" / "a" / "b" / "c"
+        deep.mkdir(parents=True)
+        (deep / ".credentials.json").write_text("{}\n")
+        home = tmp_path / "home"
+        # Act + Assert
+        with pytest.raises(WorkspaceCredentialLeakError):
+            materialize_to_home(spec_dir, home)
+
+    def test_other_dotfiles_in_claude_dir_pass(self, tmp_path):
+        # Arrange — settings.json, mcp.json etc. under .claude/ are fine,
+        # only `.credentials.json` is forbidden.
+        spec_dir = tmp_path / "spec"
+        (spec_dir / "to_home" / ".claude").mkdir(parents=True)
+        (spec_dir / "to_home" / ".claude" / "settings.json").write_text("{}\n")
+        home = tmp_path / "home"
+        # Act
+        materialize_to_home(spec_dir, home)
+        # Assert
+        assert (home / ".claude" / "settings.json").is_file()
+
+    def test_error_message_names_the_offending_path(self, tmp_path):
+        # Arrange
+        spec_dir = tmp_path / "spec"
+        (spec_dir / "to_home" / ".claude").mkdir(parents=True)
+        leak = spec_dir / "to_home" / ".claude" / ".credentials.json"
+        leak.write_text("{}\n")
+        home = tmp_path / "home"
+        # Act + Assert
+        with pytest.raises(WorkspaceCredentialLeakError) as exc_info:
+            materialize_to_home(spec_dir, home)
+        # The message must point the operator at the offending source so
+        # they can `rm` it. Relative path (from to_home/) is enough.
+        msg = str(exc_info.value)
+        assert ".claude/.credentials.json" in msg
+
+    def test_no_partial_destination_on_reject(self, tmp_path):
+        # Arrange — leak + other content; guard must fire BEFORE any deploy.
+        spec_dir = tmp_path / "spec"
+        (spec_dir / "to_home" / ".claude").mkdir(parents=True)
+        (spec_dir / "to_home" / ".claude" / ".credentials.json").write_text("{}")
+        # Sibling content that would otherwise deploy:
+        (spec_dir / "to_home" / "innocent.txt").write_text("hi")
+        home = tmp_path / "home"
+        # Act + Assert
+        with pytest.raises(WorkspaceCredentialLeakError):
+            materialize_to_home(spec_dir, home)
+        # The destination home dir is created but the deploy was rejected
+        # before any file landed (or it MAY contain partial content — the
+        # important contract is no .credentials.json was copied).
+        assert not (home / ".claude" / ".credentials.json").exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scitex_agent_container/runtimes/test__to_home.py
+++ b/tests/scitex_agent_container/runtimes/test__to_home.py
@@ -189,10 +189,12 @@ class TestCredentialLeakGuard:
         (spec_dir / "to_home").mkdir(parents=True)
         (spec_dir / "to_home" / ".credentials.json").write_text('{"x":1}\n')
         home = tmp_path / "home"
-        # Act + Assert
-        with pytest.raises(WorkspaceCredentialLeakError) as exc_info:
+        # Act
+        # Assert — `match=` pins the relative-path text so the audit
+        # sees one assertion (TQ007) with AAA markers on their own
+        # lines (TQ002).
+        with pytest.raises(WorkspaceCredentialLeakError, match=r"\.credentials\.json"):
             materialize_to_home(spec_dir, home)
-        assert ".credentials.json" in str(exc_info.value)
 
     def test_credentials_json_under_dot_claude_raises(self, tmp_path):
         # Arrange — the lead-reported leak shape.
@@ -202,10 +204,12 @@ class TestCredentialLeakGuard:
             '{"oauthAccount":"old"}\n'
         )
         home = tmp_path / "home"
-        # Act + Assert
-        with pytest.raises(WorkspaceCredentialLeakError) as exc_info:
+        # Act
+        # Assert
+        with pytest.raises(
+            WorkspaceCredentialLeakError, match=r"\.claude/\.credentials\.json"
+        ):
             materialize_to_home(spec_dir, home)
-        assert ".credentials.json" in str(exc_info.value)
 
     def test_credentials_json_at_arbitrary_depth_raises(self, tmp_path):
         # Arrange — guard fires regardless of nesting.
@@ -214,7 +218,8 @@ class TestCredentialLeakGuard:
         deep.mkdir(parents=True)
         (deep / ".credentials.json").write_text("{}\n")
         home = tmp_path / "home"
-        # Act + Assert
+        # Act
+        # Assert
         with pytest.raises(WorkspaceCredentialLeakError):
             materialize_to_home(spec_dir, home)
 
@@ -237,29 +242,30 @@ class TestCredentialLeakGuard:
         leak = spec_dir / "to_home" / ".claude" / ".credentials.json"
         leak.write_text("{}\n")
         home = tmp_path / "home"
-        # Act + Assert
-        with pytest.raises(WorkspaceCredentialLeakError) as exc_info:
+        # Act
+        # Assert — the operator-visible relative path must appear in
+        # the message so `rm` is one step away.
+        with pytest.raises(
+            WorkspaceCredentialLeakError, match=r"\.claude/\.credentials\.json"
+        ):
             materialize_to_home(spec_dir, home)
-        # The message must point the operator at the offending source so
-        # they can `rm` it. Relative path (from to_home/) is enough.
-        msg = str(exc_info.value)
-        assert ".claude/.credentials.json" in msg
 
     def test_no_partial_destination_on_reject(self, tmp_path):
-        # Arrange — leak + other content; guard must fire BEFORE any deploy.
+        # Arrange — leak + other content; guard fires BEFORE any deploy.
         spec_dir = tmp_path / "spec"
         (spec_dir / "to_home" / ".claude").mkdir(parents=True)
         (spec_dir / "to_home" / ".claude" / ".credentials.json").write_text("{}")
-        # Sibling content that would otherwise deploy:
         (spec_dir / "to_home" / "innocent.txt").write_text("hi")
         home = tmp_path / "home"
-        # Act + Assert
-        with pytest.raises(WorkspaceCredentialLeakError):
+        try:
             materialize_to_home(spec_dir, home)
-        # The destination home dir is created but the deploy was rejected
-        # before any file landed (or it MAY contain partial content — the
-        # important contract is no .credentials.json was copied).
-        assert not (home / ".claude" / ".credentials.json").exists()
+        except WorkspaceCredentialLeakError:
+            pass
+        # Act
+        leaked = home / ".claude" / ".credentials.json"
+        # Assert — the destination must NOT carry the leaked file even
+        # though the guard fired during a deploy that touched siblings.
+        assert not leaked.exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scitex_agent_container/runtimes/test__to_home.py
+++ b/tests/scitex_agent_container/runtimes/test__to_home.py
@@ -576,7 +576,7 @@ class TestDeployToHomeFromConfig:
 # Layout under tmp_path:
 #   agents/<name>/spec.yaml   ← spec dir
 #   agents/<name>/to_home/    ← per-agent layer (overlay, wins on conflict)
-#   agents/_base/to_home/     ← shared baseline (applied first)
+#   agents/_shared/to_home/   ← shared baseline (applied first)
 # ---------------------------------------------------------------------------
 
 
@@ -589,7 +589,7 @@ def _build_layered(tmp_path: Path) -> tuple[Path, Path, Path]:
     agents_root = tmp_path / "agents"
     spec_dir = agents_root / "test-agent"
     per_agent = spec_dir / "to_home"
-    baseline = agents_root / "_base" / "to_home"
+    baseline = agents_root / "_shared" / "to_home"
     per_agent.mkdir(parents=True, exist_ok=True)
     baseline.mkdir(parents=True, exist_ok=True)
     return spec_dir, per_agent, baseline
@@ -605,13 +605,38 @@ class TestResolveBaselineToHomeDir:
         assert resolved == baseline
 
     def test_returns_none_when_no_base_dir_present(self, tmp_path):
-        # Arrange — spec dir without a sibling _base/to_home.
+        # Arrange — spec dir without a sibling _shared/to_home.
         spec_dir = tmp_path / "agents" / "lonely-agent"
         spec_dir.mkdir(parents=True)
         # Act
         resolved = resolve_baseline_to_home_dir(spec_dir)
         # Assert
         assert resolved is None
+
+    def test_resolves_legacy_base_dir_as_fallback(self, tmp_path):
+        # Arrange — only the legacy ``_base`` sibling exists.
+        agents_root = tmp_path / "agents"
+        spec_dir = agents_root / "test-agent"
+        spec_dir.mkdir(parents=True)
+        legacy = agents_root / "_base" / "to_home"
+        legacy.mkdir(parents=True)
+        # Act
+        resolved = resolve_baseline_to_home_dir(spec_dir)
+        # Assert
+        assert resolved == legacy
+
+    def test_shared_dir_wins_over_legacy_base_dir(self, tmp_path):
+        # Arrange — both ``_shared`` and legacy ``_base`` siblings exist.
+        agents_root = tmp_path / "agents"
+        spec_dir = agents_root / "test-agent"
+        spec_dir.mkdir(parents=True)
+        shared = agents_root / "_shared" / "to_home"
+        shared.mkdir(parents=True)
+        (agents_root / "_base" / "to_home").mkdir(parents=True)
+        # Act
+        resolved = resolve_baseline_to_home_dir(spec_dir)
+        # Assert
+        assert resolved == shared
 
     def test_returns_none_when_spec_dir_is_none(self):
         # Arrange — no spec dir, no env override.
@@ -688,7 +713,7 @@ class TestMaterializeBaselineOverlay:
         assert (home / "agent_only.txt").read_text() == "agent\n"
 
     def test_absent_baseline_is_unchanged_current_behavior(self, tmp_path):
-        # Arrange — no _base/ sibling at all; only a per-agent to_home.
+        # Arrange — no _shared/ sibling at all; only a per-agent to_home.
         # (Matches the historical single-layer layout.)
         spec_dir = tmp_path / "spec"
         (spec_dir / "to_home").mkdir(parents=True)
@@ -704,7 +729,7 @@ class TestMaterializeBaselineOverlay:
         agents_root = tmp_path / "agents"
         spec_dir = agents_root / "test-agent"
         spec_dir.mkdir(parents=True)
-        baseline = agents_root / "_base" / "to_home"
+        baseline = agents_root / "_shared" / "to_home"
         baseline.mkdir(parents=True)
         (baseline / "common.txt").write_text("shared\n")
         home = tmp_path / "home"
@@ -720,7 +745,7 @@ class TestDeployBaselineFromConfig:
         agents_root = tmp_path / "agents"
         spec_dir = agents_root / "test-agent"
         (spec_dir / "to_home").mkdir(parents=True)
-        baseline = agents_root / "_base" / "to_home"
+        baseline = agents_root / "_shared" / "to_home"
         baseline.mkdir(parents=True)
         (baseline / ".bashrc").write_text("export BASE=1\n")
         cfg = AgentConfig(name="test-agent")
@@ -738,7 +763,7 @@ class TestDeployBaselineFromConfig:
         spec_dir = agents_root / "test-agent"
         per_agent = spec_dir / "to_home"
         per_agent.mkdir(parents=True)
-        baseline = agents_root / "_base" / "to_home"
+        baseline = agents_root / "_shared" / "to_home"
         baseline.mkdir(parents=True)
         (baseline / "shared.txt").write_text("from baseline\n")
         (per_agent / "shared.txt").write_text("from agent\n")
@@ -871,7 +896,7 @@ class TestReadOnlyDestinationOverwrite:
 # ---------------------------------------------------------------------------
 # Isolation: the delivery path NEVER auto-reads host state. Host content
 # enters ONLY via an EXPLICIT symlink the operator places under to_home/
-# (e.g. ``_base/to_home/.claude/skills -> ~/.claude/skills``), which the
+# (e.g. ``_shared/to_home/.claude/skills -> ~/.claude/skills``), which the
 # materialize walk resolves to real content. The old unconditional host
 # ``~/.claude/skills`` auto-read is gone — these tests lock that.
 # ---------------------------------------------------------------------------
@@ -951,7 +976,7 @@ class TestNoHostAutoRead:
         agents_root = tmp_path / "agents"
         base_skill = (
             agents_root
-            / "_base"
+            / "_shared"
             / "to_home"
             / ".claude"
             / "skills"

--- a/tests/scitex_agent_container/runtimes/test_prompts.py
+++ b/tests/scitex_agent_container/runtimes/test_prompts.py
@@ -294,6 +294,54 @@ def test_detect_and_respond_skips_accepted_returns_none():
     assert result is None
 
 
+# Verbatim pane captured from a live in-apptainer TUI agent (2026-06-15)
+# sitting on the bypass-permissions picker — guards the real screen
+# format, not just the minimal synthetic anchors above.
+_LIVE_BYPASS_PANE = """\
+  WARNING: Claude Code running in Bypass Permissions mode
+
+  In Bypass Permissions mode, Claude Code will not ask for your approval before running
+   potentially dangerous commands.
+
+  By proceeding, you accept all responsibility for actions taken while running in
+  Bypass Permissions mode.
+
+  https://code.claude.com/docs/en/security
+
+  ❯ 1. No, exit
+    2. Yes, I accept
+
+  Enter to confirm · Esc to cancel
+"""
+
+
+def test_detect_and_respond_handles_live_bypass_pane():
+    # Arrange
+    sent: list[str] = []
+    # Act
+    result = detect_and_respond(_LIVE_BYPASS_PANE, set(), lambda k: sent.append(k))
+    # Assert
+    assert result == "bypass-permissions"
+
+
+def test_live_bypass_pane_sends_two_then_enter():
+    # Arrange
+    sent: list[str] = []
+    # Act
+    detect_and_respond(_LIVE_BYPASS_PANE, set(), lambda k: sent.append(k))
+    # Assert
+    assert sent == ["2", "Enter"]
+
+
+def test_live_bypass_pane_is_not_ready_while_modal_up():
+    # Arrange — the bypass modal carries "Enter to confirm".
+    pane = _LIVE_BYPASS_PANE
+    # Act
+    ready = is_ready(pane)
+    # Assert — must NOT report ready while a blocking modal is showing.
+    assert ready is False
+
+
 def test_detect_and_respond_skips_accepted_sends_nothing():
     # Arrange
     sent: list[str] = []

--- a/tests/scitex_agent_container/runtimes/test_tui_apptainer_argv.py
+++ b/tests/scitex_agent_container/runtimes/test_tui_apptainer_argv.py
@@ -330,9 +330,9 @@ def test_tui_channel_config_command_is_resolved_sac_path(tmp_path) -> None:
     # Assert — the inline JSON's command is the resolver's value
     # (defaults to /opt/venv-agent/bin/sac for sac-base.sif). The
     # legacy /opt/venv-sac/bin/sac would silently fail exec inside
-    # the SIF since the binary does not exist there.
-    assert channel_mcp is not None
-    assert '"command": "/opt/venv-agent/bin/sac"' in channel_mcp
+    # the SIF since the binary does not exist there. ``"" in None``
+    # would TypeError, so the None-check is structurally embedded.
+    assert '"command": "/opt/venv-agent/bin/sac"' in (channel_mcp or "")
 
 
 def test_build_run_argv_appends_credentials_bind_last(tmp_path) -> None:

--- a/tests/scitex_agent_container/runtimes/test_tui_apptainer_argv.py
+++ b/tests/scitex_agent_container/runtimes/test_tui_apptainer_argv.py
@@ -1,0 +1,305 @@
+"""In-apptainer TUI runtime — argv assembly + credential-file mount.
+
+Covers the 2026-06-15 pivot where ``spec.runtime: tui`` runs the
+interactive ``claude`` TUI INSIDE apptainer (parity with the SDK
+runtime) instead of on the host via tmux:
+
+  * ``build_inner_argv(config, tui=True)`` → interactive ``claude``
+    (model + flags) as the inner process, not the ``python -m`` runner.
+  * ``build_run_argv(config, tui=True)`` → a full ``apptainer exec ...``
+    argv whose inner command is ``claude``.
+  * ``credentials_file_bind`` → the designated ``spec.claude.
+    credentials_file`` is bind-mounted WRITABLE at the container
+    ``$HOME/.claude/.credentials.json`` (single source of truth), and
+    emitted AFTER the sif path's preceding binds so a relaxed ``--home``
+    tmpfs cannot shadow it.
+
+Real AgentConfig via ``load_config`` on a tmp spec — no mocks.
+STX-TQ002 AAA-marker + STX-TQ007 one-assert.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container.config import load_config
+from scitex_agent_container.runtimes._apptainer_auth import credentials_file_bind
+from scitex_agent_container.runtimes._apptainer_build_argv import build_run_argv
+from scitex_agent_container.runtimes._apptainer_inner_argv import (
+    build_inner_argv,
+    tui_channel_config,
+)
+
+
+def _write_spec(tmp_path: Path, body: str) -> Path:
+    spec_dir = tmp_path / "agents" / "agt"
+    spec_dir.mkdir(parents=True, exist_ok=True)
+    spec = spec_dir / "spec.yaml"
+    spec.write_text(body, encoding="utf-8")
+    return spec
+
+
+_BASE_SPEC = """\
+apiVersion: scitex-agent-container/v3
+kind: Agent
+metadata:
+  labels:
+    project: t
+spec:
+  runtime: tui
+  workdir: /tmp/agt-work
+  claude:
+    model: claude-opus-4-8[1m]
+    flags:
+      - --dangerously-skip-permissions
+{extra}
+"""
+
+
+@pytest.fixture
+def tui_config(tmp_path):
+    spec = _write_spec(tmp_path, _BASE_SPEC.format(extra=""))
+    return load_config(str(spec))
+
+
+# ---------------------------------------------------------------------------
+# build_inner_argv(tui=True) — interactive claude as the inner process
+# ---------------------------------------------------------------------------
+
+
+def test_tui_inner_argv_runs_claude_binary(tui_config) -> None:
+    # Arrange — config from the tui_config fixture.
+    # Act
+    inner = build_inner_argv(tui_config, tui=True)
+    # Assert — the inner command is the interactive claude TUI.
+    assert inner[0] == "claude"
+
+
+def test_tui_inner_argv_threads_model_flag(tui_config) -> None:
+    # Arrange — config from the tui_config fixture.
+    # Act
+    inner = build_inner_argv(tui_config, tui=True)
+    # Assert
+    assert "--model" in inner and "claude-opus-4-8[1m]" in inner
+
+
+def test_tui_inner_argv_appends_spec_flags(tui_config) -> None:
+    # Arrange — config from the tui_config fixture.
+    # Act
+    inner = build_inner_argv(tui_config, tui=True)
+    # Assert
+    assert "--dangerously-skip-permissions" in inner
+
+
+def test_tui_inner_argv_is_not_the_python_runner(tui_config) -> None:
+    # Arrange — config from the tui_config fixture.
+    # Act
+    inner = build_inner_argv(tui_config, tui=True)
+    # Assert — never dispatches the SDK session runner module.
+    assert not any("claude_session" in part for part in inner)
+
+
+# ---------------------------------------------------------------------------
+# build_run_argv(tui=True) — full apptainer exec wrapping claude
+# ---------------------------------------------------------------------------
+
+
+def test_build_run_argv_tui_is_apptainer_exec(tui_config, tmp_path) -> None:
+    # Arrange — config from the tui_config fixture.
+    # Act
+    argv = build_run_argv(
+        tui_config,
+        state_dir=tmp_path / "state",
+        sif_path=Path("/img/sac.sif"),
+        tui=True,
+    )
+    # Assert
+    assert argv[:2] == ["apptainer", "exec"]
+
+
+def test_build_run_argv_tui_inner_is_claude(tui_config, tmp_path) -> None:
+    # Arrange — config from the tui_config fixture.
+    # Act
+    argv = build_run_argv(
+        tui_config,
+        state_dir=tmp_path / "state",
+        sif_path=Path("/img/sac.sif"),
+        tui=True,
+    )
+    # Assert — the inner command is the interactive claude TUI (wrapped
+    # by the preflight ``exec`` on non-relaxed specs).
+    assert "claude --model" in " ".join(argv)
+
+
+# ---------------------------------------------------------------------------
+# credentials_file_bind — writable single-source-of-truth mount
+# ---------------------------------------------------------------------------
+
+
+def test_credentials_file_bind_empty_when_unset(tui_config) -> None:
+    # Arrange — config from the tui_config fixture (no credentials_file).
+    # Act
+    flags = credentials_file_bind(tui_config)
+    # Assert
+    assert flags == []
+
+
+def test_credentials_file_bind_mounts_designated_file_rw(tmp_path) -> None:
+    # Arrange — a designated credentials file on disk.
+    creds = tmp_path / "acct" / ".credentials.json"
+    creds.parent.mkdir(parents=True, exist_ok=True)
+    creds.write_text("{}", encoding="utf-8")
+    spec = _write_spec(
+        tmp_path,
+        _BASE_SPEC.format(extra=f"    credentials_file: {creds}"),
+    )
+    config = load_config(str(spec))
+    # Act
+    flags = credentials_file_bind(config)
+    # Assert — writable bind onto the canonical container creds path.
+    assert flags == [
+        "--bind",
+        f"{creds}:/home/agent/.claude/.credentials.json:rw",
+    ]
+
+
+def test_credentials_file_bind_missing_file_fails_loud(tmp_path) -> None:
+    # Arrange — designate a path that does not exist.
+    spec = _write_spec(
+        tmp_path,
+        _BASE_SPEC.format(extra=f"    credentials_file: {tmp_path / 'nope.json'}"),
+    )
+    config = load_config(str(spec))
+    # Act
+    raises = pytest.raises(FileNotFoundError)
+    # Assert
+    with raises:
+        credentials_file_bind(config)
+
+
+def test_build_run_argv_tui_adds_mcp_config_when_home_has_mcp_json(
+    tui_config, tmp_path
+) -> None:
+    # Arrange — materialise a $HOME/.mcp.json under the state dir.
+    state_dir = tmp_path / "state"
+    (state_dir / "home").mkdir(parents=True)
+    (state_dir / "home" / ".mcp.json").write_text("{}", encoding="utf-8")
+    # Act
+    argv = build_run_argv(
+        tui_config, state_dir=state_dir, sif_path=Path("/img/sac.sif"), tui=True
+    )
+    # Assert — the TUI is pointed at the in-container .mcp.json.
+    assert "--mcp-config /home/agent/.mcp.json" in " ".join(argv)
+
+
+def test_build_run_argv_tui_omits_mcp_config_when_no_mcp_json(
+    tui_config, tmp_path
+) -> None:
+    # Arrange — state dir with a home but NO .mcp.json.
+    state_dir = tmp_path / "state"
+    (state_dir / "home").mkdir(parents=True)
+    # Act
+    argv = build_run_argv(
+        tui_config, state_dir=state_dir, sif_path=Path("/img/sac.sif"), tui=True
+    )
+    # Assert
+    assert "--mcp-config" not in argv
+
+
+_SPEC_WITH_CHANNEL = """\
+apiVersion: scitex-agent-container/v3
+kind: Agent
+metadata:
+  labels:
+    project: t
+spec:
+  runtime: tui
+  workdir: /tmp/agt-work
+  claude:
+    model: sonnet
+    channels:
+      - server:sac
+"""
+
+
+def test_tui_channel_config_none_when_no_channels(tui_config) -> None:
+    # Arrange — tui_config has no channels.
+    # Act
+    dev_channels, channel_mcp = tui_channel_config(tui_config)
+    # Assert
+    assert (dev_channels, channel_mcp) == (None, None)
+
+
+def test_tui_channel_config_sets_dev_channels(tmp_path) -> None:
+    # Arrange
+    spec = _write_spec(tmp_path, _SPEC_WITH_CHANNEL)
+    config = load_config(str(spec))
+    # Act
+    dev_channels, _ = tui_channel_config(config)
+    # Assert
+    assert dev_channels == "server:sac"
+
+
+def test_tui_channel_config_registers_sac_channel_subscriber(tmp_path) -> None:
+    # Arrange
+    spec = _write_spec(tmp_path, _SPEC_WITH_CHANNEL)
+    config = load_config(str(spec))
+    # Act
+    _, channel_mcp = tui_channel_config(config)
+    # Assert — inline MCP JSON registers the absolute-path sac channel sub.
+    assert channel_mcp is not None and "mcp" in channel_mcp and "channel" in channel_mcp
+
+
+def test_build_run_argv_tui_adds_dev_channels_flag(tmp_path) -> None:
+    # Arrange
+    spec = _write_spec(tmp_path, _SPEC_WITH_CHANNEL)
+    config = load_config(str(spec))
+    state_dir = tmp_path / "state"
+    (state_dir / "home").mkdir(parents=True)
+    # Act
+    argv = build_run_argv(
+        config, state_dir=state_dir, sif_path=Path("/img/sac.sif"), tui=True
+    )
+    # Assert — flag rides in the inner cmd (preflight-wrapped on non-relaxed).
+    assert "--dangerously-load-development-channels server:sac" in " ".join(argv)
+
+
+def test_build_run_argv_tui_injects_channel_subscriber_mcp(tmp_path) -> None:
+    # Arrange
+    spec = _write_spec(tmp_path, _SPEC_WITH_CHANNEL)
+    config = load_config(str(spec))
+    state_dir = tmp_path / "state"
+    (state_dir / "home").mkdir(parents=True)
+    # Act
+    argv = build_run_argv(
+        config, state_dir=state_dir, sif_path=Path("/img/sac.sif"), tui=True
+    )
+    # Assert — the inline sac-channel subscriber rides on --mcp-config
+    # (preflight-wrapped on non-relaxed specs, so check the joined argv).
+    joined = " ".join(argv)
+    assert '"command": "/opt/venv-sac/bin/sac"' in joined and '"channel"' in joined
+
+
+def test_build_run_argv_appends_credentials_bind_last(tmp_path) -> None:
+    # Arrange — designated creds + a real spec.
+    creds = tmp_path / "acct" / ".credentials.json"
+    creds.parent.mkdir(parents=True, exist_ok=True)
+    creds.write_text("{}", encoding="utf-8")
+    spec = _write_spec(
+        tmp_path,
+        _BASE_SPEC.format(extra=f"    credentials_file: {creds}"),
+    )
+    config = load_config(str(spec))
+    # Act
+    argv = build_run_argv(
+        config,
+        state_dir=tmp_path / "state",
+        sif_path=Path("/img/sac.sif"),
+        tui=True,
+    )
+    # Assert — the creds bind sits immediately before the sif path so no
+    # later home bind can shadow it.
+    sif_idx = argv.index("/img/sac.sif")
+    assert argv[sif_idx - 1] == f"{creds}:/home/agent/.claude/.credentials.json:rw"

--- a/tests/scitex_agent_container/runtimes/test_tui_apptainer_argv.py
+++ b/tests/scitex_agent_container/runtimes/test_tui_apptainer_argv.py
@@ -20,6 +20,7 @@ STX-TQ002 AAA-marker + STX-TQ007 one-assert.
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
@@ -278,8 +279,60 @@ def test_build_run_argv_tui_injects_channel_subscriber_mcp(tmp_path) -> None:
     )
     # Assert — the inline sac-channel subscriber rides on --mcp-config
     # (preflight-wrapped on non-relaxed specs, so check the joined argv).
+    # The command must be the in-SIF absolute path of the `sac` console
+    # script. The default is /opt/venv-agent/bin/sac (verified in
+    # sac-base.sif 2026-06-15; the old /opt/venv-sac/bin/sac hardcode
+    # was wrong — the binary lives under the agent venv, not the SDK
+    # venv). The bare command must NOT be just `sac` (PR #407 silent-
+    # exec-fail class).
     joined = " ".join(argv)
-    assert '"command": "/opt/venv-sac/bin/sac"' in joined and '"channel"' in joined
+    assert '"command": "/opt/venv-agent/bin/sac"' in joined and '"channel"' in joined
+
+
+def test_resolve_sac_bin_in_sif_returns_agent_venv_path() -> None:
+    # Arrange — no override
+    saved = os.environ.pop("SAC_BIN_IN_SIF", None)
+    try:
+        # Act
+        from scitex_agent_container.runtimes._apptainer_inner_argv import (
+            resolve_sac_bin_in_sif,
+        )
+
+        path = resolve_sac_bin_in_sif()
+        # Assert — the verified in-SIF default. If someone changes this
+        # they must verify with `ls /opt/venv-agent/bin/sac` inside the
+        # running SIF and update both the constant and this test.
+        assert path == "/opt/venv-agent/bin/sac"
+    finally:
+        if saved is not None:
+            os.environ["SAC_BIN_IN_SIF"] = saved
+
+
+def test_resolve_sac_bin_in_sif_honours_env_override(monkeypatch) -> None:
+    # Arrange — operator escape hatch for rebuilt SIFs.
+    monkeypatch.setenv("SAC_BIN_IN_SIF", "/custom/path/to/sac")
+    # Act
+    from scitex_agent_container.runtimes._apptainer_inner_argv import (
+        resolve_sac_bin_in_sif,
+    )
+
+    path = resolve_sac_bin_in_sif()
+    # Assert
+    assert path == "/custom/path/to/sac"
+
+
+def test_tui_channel_config_command_is_resolved_sac_path(tmp_path) -> None:
+    # Arrange
+    spec = _write_spec(tmp_path, _SPEC_WITH_CHANNEL)
+    config = load_config(str(spec))
+    # Act
+    _, channel_mcp = tui_channel_config(config)
+    # Assert — the inline JSON's command is the resolver's value
+    # (defaults to /opt/venv-agent/bin/sac for sac-base.sif). The
+    # legacy /opt/venv-sac/bin/sac would silently fail exec inside
+    # the SIF since the binary does not exist there.
+    assert channel_mcp is not None
+    assert '"command": "/opt/venv-agent/bin/sac"' in channel_mcp
 
 
 def test_build_run_argv_appends_credentials_bind_last(tmp_path) -> None:

--- a/tests/scitex_agent_container/runtimes/test_tui_session.py
+++ b/tests/scitex_agent_container/runtimes/test_tui_session.py
@@ -181,6 +181,18 @@ class _Config:
     workdir: str = "/tmp"
 
 
+# Deterministic stand-in for the ``apptainer exec ... claude`` argv the
+# production ``_default_argv`` resolves. Injected via ``command_builder``
+# so the tmux-dispatch glue runs without a real apptainer/SIF on the CI
+# runner — the realistic argv is exercised by the build_run_argv suite +
+# the in-apptainer dry-run smoke. Ends in ``claude`` (the inner TUI).
+_FAKE_ARGV = ["apptainer", "exec", "img.sif", "claude"]
+
+
+def _fake_builder(config: _Config) -> list[str]:
+    return list(_FAKE_ARGV)
+
+
 @pytest.fixture
 def mux() -> Iterator[type[_MemoryMultiplexer]]:
     """Per-test fresh in-memory multiplexer class.
@@ -219,7 +231,7 @@ def test_tui_runtime_start_creates_named_session(
     mux: type[_MemoryMultiplexer],
 ) -> None:
     # Arrange
-    runtime = TuiSessionRuntime(multiplexer=mux)
+    runtime = TuiSessionRuntime(multiplexer=mux, command_builder=_fake_builder)
     config = _Config(name="beta", workdir="/tmp/beta")
     # Act
     runtime.start(config)
@@ -231,7 +243,7 @@ def test_tui_runtime_start_returns_true_on_success(
     mux: type[_MemoryMultiplexer],
 ) -> None:
     # Arrange
-    runtime = TuiSessionRuntime(multiplexer=mux)
+    runtime = TuiSessionRuntime(multiplexer=mux, command_builder=_fake_builder)
     config = _Config(name="gamma")
     # Act
     ok = runtime.start(config)
@@ -243,19 +255,19 @@ def test_tui_runtime_start_invokes_claude_binary_in_session(
     mux: type[_MemoryMultiplexer],
 ) -> None:
     # Arrange
-    runtime = TuiSessionRuntime(multiplexer=mux, claude_bin="/usr/local/bin/claude")
+    runtime = TuiSessionRuntime(multiplexer=mux, command_builder=_fake_builder)
     config = _Config(name="delta")
     # Act
     runtime.start(config)
     # Assert
-    assert mux._sessions["tui-delta"].command == "/usr/local/bin/claude"
+    assert mux._sessions["tui-delta"].command == "apptainer exec img.sif claude"
 
 
 def test_tui_runtime_start_force_stops_existing_session_first(
     mux: type[_MemoryMultiplexer],
 ) -> None:
     # Arrange
-    runtime = TuiSessionRuntime(multiplexer=mux)
+    runtime = TuiSessionRuntime(multiplexer=mux, command_builder=_fake_builder)
     config = _Config(name="epsilon")
     runtime.start(config)
     pre_stop_calls = sum(1 for _ in mux._stop_log)
@@ -269,7 +281,7 @@ def test_tui_runtime_start_dry_run_does_not_create_session(
     mux: type[_MemoryMultiplexer],
 ) -> None:
     # Arrange
-    runtime = TuiSessionRuntime(multiplexer=mux)
+    runtime = TuiSessionRuntime(multiplexer=mux, command_builder=_fake_builder)
     config = _Config(name="zeta")
     # Act
     runtime.start(config, dry_run=True)
@@ -281,7 +293,7 @@ def test_tui_runtime_start_dry_run_returns_true(
     mux: type[_MemoryMultiplexer],
 ) -> None:
     # Arrange
-    runtime = TuiSessionRuntime(multiplexer=mux)
+    runtime = TuiSessionRuntime(multiplexer=mux, command_builder=_fake_builder)
     config = _Config(name="eta")
     # Act
     ok = runtime.start(config, dry_run=True)
@@ -298,7 +310,7 @@ def test_tui_runtime_stop_kills_named_session(
     mux: type[_MemoryMultiplexer],
 ) -> None:
     # Arrange
-    runtime = TuiSessionRuntime(multiplexer=mux)
+    runtime = TuiSessionRuntime(multiplexer=mux, command_builder=_fake_builder)
     config = _Config(name="theta")
     runtime.start(config)
     # Act
@@ -311,7 +323,7 @@ def test_tui_runtime_stop_returns_true_when_session_existed(
     mux: type[_MemoryMultiplexer],
 ) -> None:
     # Arrange
-    runtime = TuiSessionRuntime(multiplexer=mux)
+    runtime = TuiSessionRuntime(multiplexer=mux, command_builder=_fake_builder)
     config = _Config(name="iota")
     runtime.start(config)
     # Act
@@ -324,7 +336,7 @@ def test_tui_runtime_stop_returns_false_when_no_session(
     mux: type[_MemoryMultiplexer],
 ) -> None:
     # Arrange
-    runtime = TuiSessionRuntime(multiplexer=mux)
+    runtime = TuiSessionRuntime(multiplexer=mux, command_builder=_fake_builder)
     config = _Config(name="kappa")
     # Act
     ok = runtime.stop(config)
@@ -341,7 +353,7 @@ def test_tui_runtime_is_running_true_when_session_active(
     mux: type[_MemoryMultiplexer],
 ) -> None:
     # Arrange
-    runtime = TuiSessionRuntime(multiplexer=mux)
+    runtime = TuiSessionRuntime(multiplexer=mux, command_builder=_fake_builder)
     config = _Config(name="lambda")
     runtime.start(config)
     # Act
@@ -354,7 +366,7 @@ def test_tui_runtime_is_running_false_when_session_absent(
     mux: type[_MemoryMultiplexer],
 ) -> None:
     # Arrange
-    runtime = TuiSessionRuntime(multiplexer=mux)
+    runtime = TuiSessionRuntime(multiplexer=mux, command_builder=_fake_builder)
     config = _Config(name="mu")
     # Act
     alive = runtime.is_running(config)
@@ -371,7 +383,7 @@ def test_tui_runtime_is_running_false_when_activity_stale_beyond_window(
     mux: type[_MemoryMultiplexer],
 ) -> None:
     # Arrange — start session, then back-date activity beyond default window.
-    runtime = TuiSessionRuntime(multiplexer=mux)
+    runtime = TuiSessionRuntime(multiplexer=mux, command_builder=_fake_builder)
     config = _Config(name="nu-stale")
     runtime.start(config)
     mux._sessions["tui-nu-stale"].activity_at = time.time() - 9_999.0
@@ -385,7 +397,7 @@ def test_tui_runtime_is_running_respects_max_idle_s_override(
     mux: type[_MemoryMultiplexer],
 ) -> None:
     # Arrange — back-date activity 100s; tighten window to 50s.
-    runtime = TuiSessionRuntime(multiplexer=mux)
+    runtime = TuiSessionRuntime(multiplexer=mux, command_builder=_fake_builder)
     config = _Config(name="xi-tight")
     runtime.start(config)
     mux._sessions["tui-xi-tight"].activity_at = time.time() - 100.0
@@ -401,7 +413,7 @@ def test_tui_runtime_is_running_false_when_session_activity_unavailable(
     # Arrange — a legacy multiplexer fake that lacks session_activity
     # (returns None) must NOT be silently treated as "alive". The probe
     # has to fail loud to "not responsive" so the supervisor restarts.
-    runtime = TuiSessionRuntime(multiplexer=mux)
+    runtime = TuiSessionRuntime(multiplexer=mux, command_builder=_fake_builder)
     config = _Config(name="omicron-legacy")
     runtime.start(config)
 
@@ -426,20 +438,20 @@ def test_tui_runtime_logs_returns_captured_pane_text(
     mux: type[_MemoryMultiplexer],
 ) -> None:
     # Arrange
-    runtime = TuiSessionRuntime(multiplexer=mux, claude_bin="claude-foo")
+    runtime = TuiSessionRuntime(multiplexer=mux, command_builder=_fake_builder)
     config = _Config(name="nu", workdir="/data/nu")
     runtime.start(config)
     # Act
     text = runtime.logs(config, lines=10)
     # Assert
-    assert text == "<pane lines=10>claude-foo@/data/nu"
+    assert text == "<pane lines=10>apptainer exec img.sif claude@/data/nu"
 
 
 def test_tui_runtime_logs_returns_empty_when_session_absent(
     mux: type[_MemoryMultiplexer],
 ) -> None:
     # Arrange
-    runtime = TuiSessionRuntime(multiplexer=mux)
+    runtime = TuiSessionRuntime(multiplexer=mux, command_builder=_fake_builder)
     config = _Config(name="xi")
     # Act
     text = runtime.logs(config)
@@ -460,7 +472,7 @@ def test_tui_runtime_send_turn_delivers_text_to_session_pane(
     # input-ready marker, so the wait_ready=False path exercises
     # the delivery primitive in isolation; the registry-driven
     # ``wait_until_input_ready`` path is covered separately below.
-    runtime = TuiSessionRuntime(multiplexer=mux)
+    runtime = TuiSessionRuntime(multiplexer=mux, command_builder=_fake_builder)
     config = _Config(name="omicron")
     runtime.start(config)
     # Act
@@ -475,7 +487,7 @@ def test_tui_runtime_send_turn_returns_true_when_session_alive(
     mux: type[_MemoryMultiplexer],
 ) -> None:
     # Arrange
-    runtime = TuiSessionRuntime(multiplexer=mux)
+    runtime = TuiSessionRuntime(multiplexer=mux, command_builder=_fake_builder)
     config = _Config(name="pi")
     runtime.start(config)
     # Act
@@ -488,7 +500,7 @@ def test_tui_runtime_send_turn_returns_false_when_no_session(
     mux: type[_MemoryMultiplexer],
 ) -> None:
     # Arrange — no start() call; session does not exist.
-    runtime = TuiSessionRuntime(multiplexer=mux)
+    runtime = TuiSessionRuntime(multiplexer=mux, command_builder=_fake_builder)
     config = _Config(name="rho")
     # Act
     delivered = runtime.send_turn(config, "lost-turn", wait_ready=False)
@@ -500,7 +512,7 @@ def test_tui_runtime_send_turn_skips_send_when_no_session(
     mux: type[_MemoryMultiplexer],
 ) -> None:
     # Arrange — no start() call.
-    runtime = TuiSessionRuntime(multiplexer=mux)
+    runtime = TuiSessionRuntime(multiplexer=mux, command_builder=_fake_builder)
     config = _Config(name="sigma")
     # Act
     runtime.send_turn(config, "lost-turn", wait_ready=False)
@@ -558,7 +570,7 @@ def test_wait_until_input_ready_returns_true_when_marker_present(
 ) -> None:
     # Arrange — first frame already has the marker.
     primed_mux.prime(["? for shortcuts"])
-    runtime = TuiSessionRuntime(multiplexer=primed_mux)
+    runtime = TuiSessionRuntime(multiplexer=primed_mux, command_builder=_fake_builder)
     config = _Config(name="ready-immediate")
     # ``drain_pickers_at_boot=False`` so the start path doesn't
     # consume the primed frame queue — the test wants the queue
@@ -578,7 +590,7 @@ def test_wait_until_input_ready_dismisses_theme_picker_then_returns(
     # Arrange — frame 0: theme picker active; frames 1+: ready marker.
     theme_pane = "Choose the text style\n1. Auto (match terminal)\n"
     primed_mux.prime([theme_pane, "? for shortcuts"])
-    runtime = TuiSessionRuntime(multiplexer=primed_mux)
+    runtime = TuiSessionRuntime(multiplexer=primed_mux, command_builder=_fake_builder)
     config = _Config(name="theme-dismiss")
     runtime.start(config, drain_pickers_at_boot=False)
     # Act
@@ -597,7 +609,7 @@ def test_wait_until_input_ready_raises_when_marker_never_appears(
 ) -> None:
     # Arrange — no marker, no modal: poll loop spins until timeout.
     primed_mux.prime(["just some noise"])
-    runtime = TuiSessionRuntime(multiplexer=primed_mux)
+    runtime = TuiSessionRuntime(multiplexer=primed_mux, command_builder=_fake_builder)
     config = _Config(name="never-ready")
     # Skip boot-drain so start() doesn't itself eat 30s + then
     # propagate the absent-marker timeout through this test.
@@ -613,10 +625,78 @@ def test_wait_until_input_ready_raises_when_session_missing(
     primed_mux: type[_PrimedMemoryMultiplexer],
 ) -> None:
     # Arrange — no start() call; session does not exist.
-    runtime = TuiSessionRuntime(multiplexer=primed_mux)
+    runtime = TuiSessionRuntime(multiplexer=primed_mux, command_builder=_fake_builder)
     config = _Config(name="ghost")
     # Act
     do_wait = runtime.wait_until_input_ready
     # Assert
     with pytest.raises(TuiInputNotReadyError, match="does not exist"):
         do_wait(config, timeout_s=0.01, poll_s=0.0, sleep_fn=lambda _s: None)
+
+
+# ---------------------------------------------------------------------------
+# _drain_at_boot — dismiss first-run modals through a delayed claude start
+# ---------------------------------------------------------------------------
+
+# A bypass-permissions modal frame, then the launched (busy/idle) footer.
+_BYPASS_FRAME = (
+    "WARNING: Claude Code running in Bypass Permissions mode\n"
+    "  1. No, exit\n  2. Yes, I accept\nEnter to confirm · Esc to cancel"
+)
+_LAUNCHED_FRAME = "✽ Propagating…\n❯\n⏵⏵ bypass permissions on (shift+tab to cycle)"
+
+
+def test_drain_at_boot_returns_true_when_marker_present(
+    primed_mux: type[_PrimedMemoryMultiplexer],
+) -> None:
+    # Arrange — claude already idle at the input field.
+    primed_mux.prime(["? for shortcuts"])
+    runtime = TuiSessionRuntime(multiplexer=primed_mux, command_builder=_fake_builder)
+    config = _Config(name="boot-ready")
+    runtime.start(config, drain_pickers_at_boot=False)
+    # Act
+    ready = runtime._drain_at_boot(config, timeout_s=1.0, poll_s=0.0)
+    # Assert
+    assert ready is True
+
+
+def test_drain_at_boot_dismisses_bypass_then_exits_on_is_ready(
+    primed_mux: type[_PrimedMemoryMultiplexer],
+) -> None:
+    # Arrange — frame 0: bypass modal; frame 1+: launched footer (is_ready).
+    primed_mux.prime([_BYPASS_FRAME, _LAUNCHED_FRAME])
+    runtime = TuiSessionRuntime(multiplexer=primed_mux, command_builder=_fake_builder)
+    config = _Config(name="boot-bypass")
+    runtime.start(config, drain_pickers_at_boot=False)
+    # Act
+    runtime._drain_at_boot(config, timeout_s=2.0, poll_s=0.0)
+    # Assert — the bypass handler's keystrokes ["2", "Enter"] landed.
+    assert primed_mux._sessions["tui-boot-bypass"].pane == ["2", "Enter"]
+
+
+def test_drain_at_boot_returns_true_after_dismissing_bypass(
+    primed_mux: type[_PrimedMemoryMultiplexer],
+) -> None:
+    # Arrange — modal then launched footer.
+    primed_mux.prime([_BYPASS_FRAME, _LAUNCHED_FRAME])
+    runtime = TuiSessionRuntime(multiplexer=primed_mux, command_builder=_fake_builder)
+    config = _Config(name="boot-bypass-ok")
+    runtime.start(config, drain_pickers_at_boot=False)
+    # Act
+    ready = runtime._drain_at_boot(config, timeout_s=2.0, poll_s=0.0)
+    # Assert
+    assert ready is True
+
+
+def test_drain_at_boot_returns_false_on_timeout(
+    primed_mux: type[_PrimedMemoryMultiplexer],
+) -> None:
+    # Arrange — only noise; no modal, no ready signal (claude still booting).
+    primed_mux.prime(["uv: Preparing packages... (56/169)"])
+    runtime = TuiSessionRuntime(multiplexer=primed_mux, command_builder=_fake_builder)
+    config = _Config(name="boot-slow")
+    runtime.start(config, drain_pickers_at_boot=False)
+    # Act
+    ready = runtime._drain_at_boot(config, timeout_s=0.01, poll_s=0.0)
+    # Assert — best-effort: never raises, just reports not-ready.
+    assert ready is False

--- a/tests/scitex_agent_container/runtimes/test_tui_session_real_smoke.py
+++ b/tests/scitex_agent_container/runtimes/test_tui_session_real_smoke.py
@@ -67,7 +67,24 @@ from scitex_agent_container.runtimes.tui_session import (
 _TMUX_BIN = shutil.which("tmux")
 _CLAUDE_BIN = shutil.which("claude")
 
+# RETIRED MODEL (2026-06-15 in-apptainer TUI pivot): this harness asserts
+# the legacy host-tmux behaviour — a real ``claude`` process running on
+# the HOST with ``HOME=<state>/home`` (probed via ``/proc/<pid>/environ``)
+# and credentials COPIED into ``<state>/home``. The TUI runtime now runs
+# ``claude`` INSIDE apptainer (parity with the SDK runtime): there is no
+# host claude process to probe, the in-container ``$HOME`` is
+# ``/home/agent``, and credentials are bind-mounted (not copied). These
+# premises are gone, so the module is skipped rather than asserting a
+# retired path. FOLLOW-UP: rewrite as a true in-apptainer smoke that boots
+# the SIF and probes inside the container (needs a built SIF + valid
+# creds). The dispatch glue is covered hermetically in test_tui_session.py
+# (via the ``command_builder`` seak) and the argv assembly in the
+# build_run_argv suite.
 pytestmark = [
+    pytest.mark.skip(
+        reason="retired host-tmux TUI model — TUI now runs inside apptainer; "
+        "rewrite as in-apptainer smoke (needs built SIF + creds)"
+    ),
     pytest.mark.skipif(_TMUX_BIN is None, reason="tmux binary not on PATH"),
     pytest.mark.skipif(_CLAUDE_BIN is None, reason="claude binary not on PATH"),
     # The whole module spawns real processes and waits seconds for the
@@ -586,7 +603,6 @@ class TestTuiRuntimeAuthStaged:
         present = path.is_file()
         # Assert
         assert present is True
-
 
 
 # EOF


### PR DESCRIPTION
## Summary
- TUI runtime now spawns interactive ``claude`` INSIDE the apptainer SIF (parity with SDK runner), instead of on the host. Predecessor session WIP (preserved via stash + checkpoint commit).
- Fix the channel-MCP sac binary path: was hardcoded to ``/opt/venv-sac/bin/sac`` (does not exist in sac-base.sif), corrected to ``/opt/venv-agent/bin/sac`` + ``SAC_BIN_IN_SIF`` env override for future SIF layout changes.
- Guard against credential leak in ``to_home/``: a ``.credentials.json`` under ``to_home/`` now hard-aborts the deploy with ``WorkspaceCredentialLeakError`` so stale tokens cannot mask a missing auth-stage bind.

This is **PR #1 of 2** for lead's P0 TUI-runtime directive (2026-06-15). PR #2 will land #5: ``spec.claude.account`` auto-creating the rw cred bind on ``sac agents start`` (parity with ``credentials_file``). Operator's interim workaround (manually pinning ``credentials_file: <snapshot-path>``) is fine for now.

## Lead-reported bugs addressed

1. **TUI host-exec** (operator confirmed via ``/proc/<claude_pid>/environ`` — no ``SINGULARITY_CONTAINER``, parent=tmux only). Fix: rebuild the TUI's tmux command via ``build_run_argv(tui=True)`` so the inner process is ``apptainer exec sac-base.sif claude``. Predecessor session had this largely landed; checkpoint commit captures + commits the recovered WIP.

2. **MCP-load gap** — scitex-todo TUI loaded only 2 of 4 declared MCPs. Root cause: the inline ``--mcp-config`` JSON ``tui_channel_config`` emits referenced ``/opt/venv-sac/bin/sac``, which does not exist in the SIF. Fix: ``_apptainer_inner_argv.py`` now uses ``resolve_sac_bin_in_sif()`` defaulting to ``/opt/venv-agent/bin/sac`` (verified via ``ls`` inside the running SIF).

3. **to_home credential leak** — expired ``.credentials.json`` committed under ``proj-scitex-todo/to_home/.claude/`` was re-deployed every ``sac agents start``, masking the auth-stage bind and OAuth-spinning the agent on a stale token. Fix: pre-deploy scan in ``_to_home._scan_for_credential_leak`` raises ``WorkspaceCredentialLeakError`` on first ``.credentials.json`` at any depth.

## Out of scope (deferred to next PR)
- **#5 ``spec.claude.account`` auto rw cred bind**: pinned-account agents currently get a dir-bind at ``/tmp/sac-claude`` + ``CLAUDE_CONFIG_DIR`` redirect (legacy SDK shape). Lead asks to unify with ``credentials_file_bind`` (single-file rw bind at ``$HOME/.claude/.credentials.json``) so account-pinned TUI agents don't need a manual ``credentials_file`` line.
- **#7 two-refresher hazard**: scitex-todo + figrecipe both resolve to scitex-ai; need dedicated account per agent OR canonical-single-source design before running both TUI agents concurrently. Spec/design decision; coordinated separately.

## Refactor note (size cap)
``_to_home.py`` would have exceeded the 512-line file cap after adding the leak guard. Followed the GITIGNORED/REFACTORING.md protocol and extracted:
- ``_to_home_errors.py`` (error classes — ``WorkspaceCLAUDEMarkerError``, ``WorkspaceCredentialLeakError``).
- ``_to_home_text.py`` (marker constants + interpolation helpers — ``END_MARKER``, ``validate_marker_invariants``, ``extract_user_tail``, ``interpolate_env``, ``interpolate_metadata``).
The legacy private-name aliases (``_validate_marker_invariants`` etc.) remain in ``_to_home.py`` for any external consumer that imported them.

## Test plan
- [x] ``pytest tests/scitex_agent_container/runtimes/test_tui_apptainer_argv.py`` — 14 pass, 1 pre-existing bearer-token fixture failure (unrelated to this change).
- [x] ``pytest tests/scitex_agent_container/runtimes/test__to_home.py`` — 69 pass (6 new credential-leak guard tests + 63 existing).
- [x] ``ruff check`` — clean across changed + new files.
- [ ] Operator verifies post-merge that figrecipe + scitex-todo both load all 4 declared MCPs (``mcp__scitex-agent-container__*`` + ``mcp__scitex-todo__*`` tools appear).
- [ ] Operator verifies post-merge that committing ``.credentials.json`` under ``to_home/`` now aborts ``sac agents start`` with ``WorkspaceCredentialLeakError``.

Refs: P0 TUI runtime fix (operator 6/15 cutoff), lead a2a 2026-06-15.