### PR TITLE
feat(channel): account-pinned TUI auto cred bind (P0 #5)

### DIFF
--- a/src/scitex_agent_container/runtimes/_tui_auth_stage.py
+++ b/src/scitex_agent_container/runtimes/_tui_auth_stage.py
@@ -208,6 +208,24 @@ def _resolve_pinned_account_credentials(
     Defensive against stub AgentConfig surfaces used in unit tests —
     a missing ``claude.account`` attribute degrades silently to
     "unpinned" without raising.
+
+    P0 #5 (2026-06-15): the snapshot root is resolved through
+    :func:`_state.account_store._store_path` so the SciTeX-config
+    CWD cascade (project-scope ``<repo>/.scitex/agent-container/accounts/``
+    wins over user-scope ``${HOME}/.scitex/agent-container/accounts/``)
+    is honoured — the SAME resolver the apptainer-runtime SDK path uses
+    via :func:`_apptainer_creds.resolve_cred_file`. Multi-host: each
+    host resolves its own LOCAL snapshot; no copy between hosts. This
+    is the "canonical single-source" model the operator's lead-learnings
+    skill #29 describes — symlink/dir-bind only, server-managed.
+
+    Caveat (carried over from :mod:`_apptainer_auth`): a single-file
+    bind on the snapshot path can be orphaned by host-side atomic-rename
+    refresh writers. The TUI staging path COPIES the snapshot into the
+    materialised ``$HOME`` rather than bind-mounting it, so the orphan
+    concern does not apply here — but a re-stage on token expiry is
+    required for long-lived TUI sessions (handled by the same
+    ``stage_tui_auth`` call on restart).
     """
     acct = ""
     try:
@@ -216,14 +234,13 @@ def _resolve_pinned_account_credentials(
         acct = ""
     if not acct:
         return None
-    snapshot = (
-        Path.home()
-        / ".scitex"
-        / "agent-container"
-        / "accounts"
-        / acct
-        / ".credentials.json"
-    )
+    # Local import keeps the module-level cost down (account_store
+    # pulls scitex_config at import) and matches the same lazy-import
+    # idiom used in ``_apptainer_creds.resolve_cred_file``.
+    from .._state.account_store import _store_path
+
+    store = _store_path(None, Path.home())
+    snapshot = store / acct / ".credentials.json"
     return snapshot if snapshot.is_file() else None
 
 

--- a/tests/scitex_agent_container/runtimes/test__tui_auth_stage.py
+++ b/tests/scitex_agent_container/runtimes/test__tui_auth_stage.py
@@ -744,14 +744,14 @@ class TestStageTuiAuthAccountStoreCwdCascade:
         tmp_path: Path,
         home_dir: Path,
         claude_json_src: Path,
-        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         # Arrange — materialise a real git-rooted project-scope account
         # store under tmp_path/repo/. Walk-up detection requires .git/.
         # The user-scope store also contains an obviously-wrong snapshot
         # so that a regression (hardcoded HOME resolution) would surface
         # immediately in the assertion: only the project-scope token can
-        # produce the expected accessToken string.
+        # produce the expected accessToken string. PA-306: real
+        # os.chdir() with save/restore (no monkeypatch).
         acct = "scitex-todo"
         repo = tmp_path / "repo"
         (repo / ".git").mkdir(parents=True)
@@ -774,7 +774,6 @@ class TestStageTuiAuthAccountStoreCwdCascade:
                 }
             )
         )
-        # User-scope decoy (would win under the buggy hardcoded path).
         user_snap = (
             Path(os.environ["HOME"])
             / ".scitex"
@@ -795,10 +794,14 @@ class TestStageTuiAuthAccountStoreCwdCascade:
             )
         )
         os.environ[CLAUDE_JSON_SRC_ENV] = str(claude_json_src)
-        monkeypatch.chdir(repo)
+        saved_cwd = os.getcwd()
+        os.chdir(repo)
         config = _StubConfig(claude=_StubClaude(account=acct))
-        # Act
-        stage_tui_auth(home_dir, config=config)
+        try:
+            # Act
+            stage_tui_auth(home_dir, config=config)
+        finally:
+            os.chdir(saved_cwd)
         # Assert — project-scope snapshot won the cascade.
         observed = json.loads((home_dir / ".claude" / ".credentials.json").read_text())
         assert (
@@ -811,12 +814,10 @@ class TestStageTuiAuthAccountStoreCwdCascade:
         tmp_path: Path,
         home_dir: Path,
         claude_json_src: Path,
-        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         # Arrange — CWD is a git repo BUT no project-scope account store
-        # exists; cascade must fall back to user-scope. The host has its
-        # own ``~/.scitex/agent-container/accounts/<acct>/`` (the
-        # per-host canonical default).
+        # exists; cascade must fall back to user-scope. PA-306: real
+        # os.chdir() with save/restore (no monkeypatch).
         acct = "scitex-todo"
         repo = tmp_path / "repo"
         (repo / ".git").mkdir(parents=True)
@@ -840,10 +841,14 @@ class TestStageTuiAuthAccountStoreCwdCascade:
             )
         )
         os.environ[CLAUDE_JSON_SRC_ENV] = str(claude_json_src)
-        monkeypatch.chdir(repo)
+        saved_cwd = os.getcwd()
+        os.chdir(repo)
         config = _StubConfig(claude=_StubClaude(account=acct))
-        # Act
-        stage_tui_auth(home_dir, config=config)
+        try:
+            # Act
+            stage_tui_auth(home_dir, config=config)
+        finally:
+            os.chdir(saved_cwd)
         # Assert
         observed = json.loads((home_dir / ".claude" / ".credentials.json").read_text())
         assert (

--- a/tests/scitex_agent_container/runtimes/test__tui_auth_stage.py
+++ b/tests/scitex_agent_container/runtimes/test__tui_auth_stage.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import json
 import os
 import stat
+from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
@@ -574,9 +575,6 @@ class TestStageTuiAuthSettingsPreserveExisting:
 # agent on a host failed because the default container-bind path
 # /tmp/sac-claude does not exist outside apptainer.
 # ---------------------------------------------------------------------------
-
-
-from dataclasses import dataclass
 
 
 @dataclass

--- a/tests/scitex_agent_container/runtimes/test__tui_auth_stage.py
+++ b/tests/scitex_agent_container/runtimes/test__tui_auth_stage.py
@@ -720,4 +720,138 @@ class TestStageTuiAuthHostFallbackChain:
             do_stage(home_dir, config=None)
 
 
+# ---------------------------------------------------------------------------
+# P0 #5 (2026-06-15): TUI auto cred bind for account-pinned agents must
+# honour the SciTeX-config local_state CWD cascade — the same resolver
+# the apptainer-runtime SDK path uses via ``_account_store._store_path``.
+#
+# Previously :func:`_resolve_pinned_account_credentials` hardcoded the
+# snapshot path at ``${HOME}/.scitex/agent-container/accounts/<acct>/``,
+# bypassing project-scope ``<repo>/.scitex/agent-container/accounts/``.
+# This broke account-pinned TUI agents whose host snapshot lived in the
+# project-scope store (the canonical SciTeX layout the SDK path already
+# honours). Multi-host model: each host resolves its own local snapshot;
+# no copy between hosts — CWD cascade is host-local by construction.
+# ---------------------------------------------------------------------------
+
+
+class TestStageTuiAuthAccountStoreCwdCascade:
+    """``spec.claude.account`` snapshot resolution must walk the
+    SciTeX-config CWD cascade so a project-scope account store
+    (``<repo>/.scitex/agent-container/accounts/<acct>/``) wins over the
+    user-scope default."""
+
+    def test_project_scope_account_snapshot_wins_over_user_scope(
+        self,
+        tmp_path: Path,
+        home_dir: Path,
+        claude_json_src: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Arrange — materialise a real git-rooted project-scope account
+        # store under tmp_path/repo/. Walk-up detection requires .git/.
+        # The user-scope store also contains an obviously-wrong snapshot
+        # so that a regression (hardcoded HOME resolution) would surface
+        # immediately in the assertion: only the project-scope token can
+        # produce the expected accessToken string.
+        acct = "scitex-todo"
+        repo = tmp_path / "repo"
+        (repo / ".git").mkdir(parents=True)
+        proj_snap = (
+            repo
+            / ".scitex"
+            / "agent-container"
+            / "accounts"
+            / acct
+            / ".credentials.json"
+        )
+        proj_snap.parent.mkdir(parents=True, exist_ok=True)
+        proj_snap.write_text(
+            json.dumps(
+                {
+                    "claudeAiOauth": {
+                        "accessToken": "sk-ant-oat01-project-scope-snapshot",
+                        "expiresAt": 9999999999999,
+                    }
+                }
+            )
+        )
+        # User-scope decoy (would win under the buggy hardcoded path).
+        user_snap = (
+            Path(os.environ["HOME"])
+            / ".scitex"
+            / "agent-container"
+            / "accounts"
+            / acct
+            / ".credentials.json"
+        )
+        user_snap.parent.mkdir(parents=True, exist_ok=True)
+        user_snap.write_text(
+            json.dumps(
+                {
+                    "claudeAiOauth": {
+                        "accessToken": "sk-ant-oat01-WRONG-user-scope-decoy",
+                        "expiresAt": 9999999999999,
+                    }
+                }
+            )
+        )
+        os.environ[CLAUDE_JSON_SRC_ENV] = str(claude_json_src)
+        monkeypatch.chdir(repo)
+        config = _StubConfig(claude=_StubClaude(account=acct))
+        # Act
+        stage_tui_auth(home_dir, config=config)
+        # Assert — project-scope snapshot won the cascade.
+        observed = json.loads((home_dir / ".claude" / ".credentials.json").read_text())
+        assert (
+            observed["claudeAiOauth"]["accessToken"]
+            == "sk-ant-oat01-project-scope-snapshot"
+        )
+
+    def test_user_scope_snapshot_used_when_no_project_scope(
+        self,
+        tmp_path: Path,
+        home_dir: Path,
+        claude_json_src: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Arrange — CWD is a git repo BUT no project-scope account store
+        # exists; cascade must fall back to user-scope. The host has its
+        # own ``~/.scitex/agent-container/accounts/<acct>/`` (the
+        # per-host canonical default).
+        acct = "scitex-todo"
+        repo = tmp_path / "repo"
+        (repo / ".git").mkdir(parents=True)
+        user_snap = (
+            Path(os.environ["HOME"])
+            / ".scitex"
+            / "agent-container"
+            / "accounts"
+            / acct
+            / ".credentials.json"
+        )
+        user_snap.parent.mkdir(parents=True, exist_ok=True)
+        user_snap.write_text(
+            json.dumps(
+                {
+                    "claudeAiOauth": {
+                        "accessToken": "sk-ant-oat01-user-scope-snapshot",
+                        "expiresAt": 9999999999999,
+                    }
+                }
+            )
+        )
+        os.environ[CLAUDE_JSON_SRC_ENV] = str(claude_json_src)
+        monkeypatch.chdir(repo)
+        config = _StubConfig(claude=_StubClaude(account=acct))
+        # Act
+        stage_tui_auth(home_dir, config=config)
+        # Assert
+        observed = json.loads((home_dir / ".claude" / ".credentials.json").read_text())
+        assert (
+            observed["claudeAiOauth"]["accessToken"]
+            == "sk-ant-oat01-user-scope-snapshot"
+        )
+
+
 # EOF


### PR DESCRIPTION
## Summary
- Bug class: account-pinned TUI agents (`spec.claude.account: <acct>`) silently fail to auto-bind their per-host credential snapshot when the snapshot lives in the project-scope SciTeX-config store (`<repo>/.scitex/agent-container/accounts/<acct>/`). The TUI auth-staging resolver hardcoded `${HOME}/.scitex/...`, bypassing the CWD cascade the apptainer-runtime SDK path already uses via `_apptainer_creds.resolve_cred_file`.
- Fix shape: extend `_resolve_pinned_account_credentials` in `runtimes/_tui_auth_stage.py` to delegate snapshot-root resolution to `_state.account_store._store_path(None, Path.home())` — the SAME helper the SDK path uses. Both runtimes now share a single source of truth for "where is account `<acct>` on this host?". No new spec field is needed; account-pinned TUI agents now resolve their snapshot automatically without a manual `SAC_TUI_AUTH_CREDENTIALS_SRC` override.

## Multi-host story
Per lead-learnings/29 the canonical single-source model is preserved:
- Each host resolves its own LOCAL snapshot — NO COPY between hosts.
- `_store_path` walks `<cwd-or-marker>/.scitex/agent-container/accounts/` first (project-scope wins), then falls to `$SCITEX_DIR/agent-container/accounts/` (user scope).
- A pinned agent on host A reads host A's local snapshot; host B reads host B's. The shared spec stays declarative ("account: scitex-todo"), each host materialises its own cred path.

## `credentials_file:` parity
The explicit operator override path was — and remains — `SAC_TUI_AUTH_CREDENTIALS_SRC`, which still wins above account-pinned auto-resolution (see `_resolve_credentials_src` priority order). This PR brings the auto-resolution path to feature parity so operators no longer need the manual override for account-pinned TUI agents.

## Test plan
- [x] New `TestStageTuiAuthAccountStoreCwdCascade` class with two tests:
  - `test_project_scope_account_snapshot_wins_over_user_scope` — RED pre-fix (user-scope decoy wins), GREEN post-fix.
  - `test_user_scope_snapshot_used_when_no_project_scope` — fall-through to user scope works.
- [x] Full `tests/scitex_agent_container/runtimes/` suite — **780 passed** (excluding `test_tui_session_real_smoke.py` per below).
- [x] `ruff check` clean on changed files (`_tui_auth_stage.py` + `test__tui_auth_stage.py`).
- [x] Existing `TestStageTuiAuthPinnedAccountSnapshot` + `TestStageTuiAuthHostFallbackChain` tests still pass — semantics for "missing snapshot falls to chain" is preserved.

## Caveat
The apptainer atomic-rename / orphan-bind concern (`_apptainer_auth.py:107-120`) does NOT apply to the TUI staging path because TUI **copies** the snapshot into the materialised `$HOME` rather than bind-mounting it. A re-stage on token expiry is required for long-lived TUI sessions — handled by the same `stage_tui_auth` call on restart. The docstring on `_resolve_pinned_account_credentials` documents this explicitly.

## Pre-existing audit-failing tests
`tests/scitex_agent_container/runtimes/test_tui_session_real_smoke.py` errors with `TuiAuthStageError: hasCompletedOnboarding=False` — this is a host-environment issue (the dev container's `~/.claude.json` lacks `hasCompletedOnboarding: true`), NOT a regression from this PR. Not addressed here.
