### PR TITLE
feat(channel): credentials_file_bind auto-resolves account → rw single-file bind (canonical no-copy)

### DIFF
--- a/src/scitex_agent_container/runtimes/_apptainer_auth.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_auth.py
@@ -180,39 +180,86 @@ def auth_argv(config: AgentConfig, state_dir: Path) -> list[str]:
 
 
 def credentials_file_bind(config: AgentConfig) -> list[str]:
-    """Render the writable file-bind for ``spec.claude.credentials_file``.
+    """Render the writable file-bind for the agent's credentials file.
 
     Emitted LAST in :func:`_apptainer_build_argv.build_run_argv` (after
     the overlay-upper-home bind) so a relaxed ``--home`` tmpfs or
     ``--bind <upper>:/home/agent`` cannot shadow the credentials file —
     user binds apply in order and the last bind to a path wins.
 
-    Binds the designated host file ``rw`` at ``<container_home>/.claude/
-    .credentials.json`` so the in-container ``claude`` reads AND
-    refreshes that single file directly (single source of truth). No-op
-    when the field is unset, the file is missing, or a provider override
-    is active (API-key backend → no OAuth file).
+    Source resolution (first hit wins):
+
+      1. Explicit ``spec.claude.credentials_file`` — operator-pinned
+         host path. Wins for any agent that designates it.
+      2. ``spec.claude.account`` — per-host snapshot resolved via the
+         SAC account-store CWD cascade (same path the SDK runtime uses
+         through :func:`_apptainer_creds.resolve_cred_file`). This is
+         the canonical single-source model (operator 2026-06-15,
+         lead-learnings/29): each host writable-binds its OWN local
+         snapshot; NO COPY between hosts; the snapshot dir is
+         server-managed. A pinned-account TUI agent gets this bind
+         AUTOMATICALLY without any manual ``credentials_file:`` line.
+      3. Neither set or a provider backend is active → no bind.
+
+    Binds the resolved host file ``rw`` at ``<container_home>/.claude/
+    .credentials.json`` so the in-container ``claude`` (both SDK and
+    TUI variants) reads AND refreshes that single file directly. The
+    SAME path the interactive ``claude`` auto-discovers when no
+    ``$CLAUDE_CONFIG_DIR`` redirect is set — operator-confirmed working
+    shape (figrecipe + scitex-todo manual test 2026-06-15).
 
     Caveat: a single-file bind is on the file's inode. An in-container
-    refresh that rewrites in-place persists to the source; one that does
-    tmp+rename orphans the bind (the source keeps the pre-rename token).
-    The designated file should therefore NOT be a path concurrently
-    atomic-renamed by host-side ``sac accounts``/watch-live tooling — it
-    is the agent's private, operator-rotated credentials file.
+    refresh that rewrites in-place persists to the source; one that
+    does tmp+rename orphans the bind (the source keeps the pre-rename
+    token). For account-pinned mode the snapshot dir is owned by
+    sac-account tooling that the operator controls; coordinate writers
+    accordingly. For explicit ``credentials_file:`` the path SHOULD
+    NOT be one concurrently atomic-renamed by host-side
+    ``sac accounts``/watch-live tooling — it is the agent's private,
+    operator-rotated credentials file.
     """
     if provider_active(config):
         return []
     claude_spec = getattr(config, "claude", None)
     designated = str(getattr(claude_spec, "credentials_file", "") or "").strip()
-    if not designated:
+    src: Path | None = None
+    src_origin = ""
+    if designated:
+        src = Path(designated).expanduser()
+        src_origin = f"spec.claude.credentials_file={designated!r}"
+        if not src.is_file():
+            raise FileNotFoundError(
+                f"spec.claude.credentials_file points at {src}, which is "
+                "not a file. Designate an existing .credentials.json "
+                "(the agent mounts it writable at $HOME/.claude/"
+                ".credentials.json as its single source of truth)."
+            )
+    elif str(getattr(claude_spec, "account", "") or "").strip():
+        # Account-pinned auto-resolution (operator+lead 2026-06-15):
+        # delegate to the SDK-path resolver so SDK and TUI agree on
+        # snapshot location (CWD cascade via ``_store_path``). Raises
+        # :class:`PinnedAccountError` when the snapshot is absent or
+        # expired — the canonical fail-loud contract.
+        from pathlib import Path as _Path
+
+        # Import lazily so the absence of a snapshot doesn't impact
+        # unpinned/provider-backed callers, and to break import cycles
+        # with ``_apptainer_creds`` (which itself imports from this
+        # module's siblings).
+        from ._apptainer_creds import resolve_cred_file
+
+        # state_dir is unused by ``resolve_cred_file`` for the pinned
+        # branch — pass a sentinel that satisfies the signature.
+        src = resolve_cred_file(config, _Path("/dev/null"))
+        src_origin = (
+            f"spec.claude.account={getattr(claude_spec, 'account', '')!r} → {src}"
+        )
+    if src is None:
         return []
-    src = Path(designated).expanduser()
     if not src.is_file():
         raise FileNotFoundError(
-            f"spec.claude.credentials_file points at {src}, which is not "
-            "a file. Designate an existing .credentials.json (the agent "
-            "mounts it writable at $HOME/.claude/.credentials.json as its "
-            "single source of truth)."
+            f"resolved credentials path {src} ({src_origin}) is not a "
+            "file. Refusing to launch with an unverifiable credential."
         )
     from ._to_home_overlay import resolve_container_home
 

--- a/tests/scitex_agent_container/runtimes/test__apptainer_build_argv.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_build_argv.py
@@ -240,6 +240,95 @@ def test_credentials_file_bind_missing_file_fails_loud(tmp_path) -> None:
         credentials_file_bind(config)
 
 
+def test_credentials_file_bind_resolves_account_when_no_explicit_file(
+    tmp_path: Path, _isolate_home: Path
+) -> None:
+    # Arrange — write a real snapshot at the user-scope account-store path,
+    # then declare ``spec.claude.account`` (no explicit ``credentials_file:``).
+    # ``_isolate_home`` redirects ``HOME`` so the store lands inside
+    # ``tmp_path`` and ``_store_path`` resolves to it. Multi-host
+    # canonical-single-source model (operator+lead 2026-06-15,
+    # lead-learnings/29): each host writable-binds its OWN local
+    # snapshot — no copy between hosts.
+    acct = "scitex-todo"
+    store = _isolate_home / ".scitex" / "agent-container" / "accounts" / acct
+    store.mkdir(parents=True, exist_ok=True)
+    snap = store / ".credentials.json"
+    snap.write_text(
+        '{"claudeAiOauth": {"accessToken": "tok", "expiresAt": 9999999999000}}',
+        encoding="utf-8",
+    )
+    spec = _write_spec(
+        tmp_path,
+        _BASE_SPEC.format(extra=f"    account: {acct}"),
+    )
+    config = load_config(str(spec))
+    # Act
+    flags = credentials_file_bind(config)
+    # Assert — single-file rw bind onto the canonical container creds path,
+    # source = the per-host snapshot. NO copy, NO CLAUDE_CONFIG_DIR redirect.
+    assert flags == [
+        "--bind",
+        f"{snap}:/home/agent/.claude/.credentials.json:rw",
+    ]
+
+
+def test_credentials_file_bind_explicit_file_wins_over_account(
+    tmp_path: Path, _isolate_home: Path
+) -> None:
+    # Arrange — both ``account:`` and ``credentials_file:`` set. Explicit
+    # wins (operator override always trumps auto-resolution).
+    acct = "scitex-todo"
+    store = _isolate_home / ".scitex" / "agent-container" / "accounts" / acct
+    store.mkdir(parents=True, exist_ok=True)
+    snap = store / ".credentials.json"
+    snap.write_text(
+        '{"claudeAiOauth": {"accessToken": "snap", "expiresAt": 9999999999000}}',
+        encoding="utf-8",
+    )
+    explicit = tmp_path / "explicit" / ".credentials.json"
+    explicit.parent.mkdir(parents=True, exist_ok=True)
+    explicit.write_text(
+        '{"claudeAiOauth": {"accessToken": "explicit"}}', encoding="utf-8"
+    )
+    spec = _write_spec(
+        tmp_path,
+        _BASE_SPEC.format(
+            extra=f"    account: {acct}\n    credentials_file: {explicit}"
+        ),
+    )
+    config = load_config(str(spec))
+    # Act
+    flags = credentials_file_bind(config)
+    # Assert — explicit file path is the source.
+    assert flags == [
+        "--bind",
+        f"{explicit}:/home/agent/.claude/.credentials.json:rw",
+    ]
+
+
+def test_credentials_file_bind_account_pinned_raises_on_missing_snapshot(
+    tmp_path: Path, _isolate_home: Path
+) -> None:
+    # Arrange — ``account:`` set but NO snapshot at the resolver's path.
+    # ``resolve_cred_file`` is the canonical fail-loud point; verify the
+    # exception propagates so ``sac agents start`` aborts at config-build
+    # time (not silently launches with an unverifiable credential).
+    from scitex_agent_container.runtimes._apptainer_creds import (
+        PinnedAccountError,
+    )
+
+    spec = _write_spec(
+        tmp_path,
+        _BASE_SPEC.format(extra="    account: nonexistent-account"),
+    )
+    config = load_config(str(spec))
+    # Act
+    # Assert
+    with pytest.raises(PinnedAccountError, match=r"nonexistent-account"):
+        credentials_file_bind(config)
+
+
 def test_build_run_argv_tui_adds_mcp_config_when_home_has_mcp_json(
     tui_config, tmp_path
 ) -> None:


### PR DESCRIPTION
## Summary

Followup to PR #409. Operator+lead 2026-06-15 directive: pinned-account TUI agents must use a **writable mount to the per-host snapshot** — not a copy into the materialised \$HOME. The canonical single-source model per lead-learnings/29 forbids copies (each host writable-binds its own local snapshot; the snapshot dir is server-managed).

PR #409 fixed the legacy stage_tui_auth copy path so account-pinned worked on develop pre-#408. PR #408 removed that copy path. This PR brings the post-#408 bind path to canonical-single-source parity so the fleet TUI migration uses the no-copy model end-to-end.

## Change shape

``runtimes/_apptainer_auth.credentials_file_bind`` resolution order:

1. **Explicit ``spec.claude.credentials_file``** — operator-pinned host path. Wins for any agent that designates it.
2. **``spec.claude.account``** — per-host snapshot resolved via ``_apptainer_creds.resolve_cred_file`` (the same SDK-runtime resolver, which walks ``_state.account_store._store_path``'s CWD cascade: project-scope ``<repo>/.scitex/agent-container/accounts/`` wins over user-scope ``\$HOME/.scitex/...``). Each host writable-binds its OWN local snapshot. No copy between hosts. The snapshot dir is server-managed.
3. **Neither set** (or a provider backend is active) → no bind (unchanged).

The bound path is ``<container_home>/.claude/.credentials.json`` (figrecipe shape — operator-confirmed working). The interactive TUI claude auto-discovers this path; the SDK runner reads it via ``CLAUDE_CONFIG_DIR``. Both runtimes now agree on a single source of truth without needing the legacy ``/tmp/sac-claude`` dir-bind for the pinned-account branch.

## Fail-loud

Missing snapshot OR expired/unverifiable token → ``PinnedAccountError`` raised at config-build time (canonical guard already in ``resolve_cred_file``). ``sac agents start`` aborts instead of silently launching with a bad credential.

## Multi-host story

Per lead-learnings/29:

- Each host has its OWN local snapshot via the CWD cascade (no copy between hosts).
- Operators manage the snapshot dir directly (e.g. ``sac account save`` on the credential-holding host).
- Concurrent atomic-rename writers on the snapshot path orphan single-file binds (the inode-bind class). For per-account snapshots the writers are sac-account tooling the operator controls; coordinate accordingly. The risk is documented in the function docstring.

## Test plan

- [x] ``pytest tests/scitex_agent_container/runtimes/test__apptainer_build_argv.py`` — 23 pass (3 new + 20 existing).
- [x] ``ruff check`` clean on changed files.
- [ ] Operator verifies after restart that a TUI agent with only ``spec.claude.account: <acct>`` (no ``credentials_file:`` line) gets ``/proc/<claude>/mountinfo`` showing a writable bind from the host snapshot to ``/home/agent/.claude/.credentials.json``.

## Out of scope / followup

- Remove the legacy ``/tmp/sac-claude`` dir-bind logic from ``auth_argv`` for the pinned-account branch (currently dead-but-still-emits for account-pinned post-this-PR; a sibling cleanup PR).
- Two-refresher hazard (scitex-todo + figrecipe both resolving to scitex-ai) — design decision pending operator+lead.

Refs: operator+lead a2a 2026-06-15 ("コピーはまずい・ライタブルマウントでシングルソース"), lead-learnings/29 canonical single-source.