### PR TITLE
feat(binds): host scitex_agent_container overlay at /opt/venv-agent (P0 fleet-tui standardisation 1/3)

### DIFF
--- a/src/scitex_agent_container/runtimes/_p3a_default_binds.py
+++ b/src/scitex_agent_container/runtimes/_p3a_default_binds.py
@@ -83,6 +83,33 @@ _FLEET_DEFAULT_BINDS: tuple[str, ...] = (
     # either updates the entry or drops it after the SIF refresh.
     "~/proj/scitex-agent-container/src/scitex_agent_container"
     ":/opt/venv-sac/lib/python3.12/site-packages/scitex_agent_container:ro",
+    # 2026-06-15 (operator+lead a2a fleet-tui-standardisation) — bind
+    # the SAME host source over the AGENT venv's package install path
+    # too. The bundled SIFs ship an editable install whose ``.pth``
+    # points at ``/work/.worktrees/wt-tui-auth-stage/src`` (a path
+    # that only exists inside the agent-container repo's own /work);
+    # for OTHER agents (research agents whose /work is a different
+    # repo) the editable target is absent and python falls through to
+    # the stub at ``/opt/venv-agent/lib/.../scitex_agent_container/``
+    # which carries only ``_bundled/`` and ``cron/`` (no
+    # ``__init__.py``) — so ``import scitex_agent_container`` from the
+    # ``sac`` console-script fails outright on those agents and
+    # ``server:sac`` shows ✘ failed in ``/mcp``, breaking inbound wake.
+    #
+    # The fix: overlay the host source at the venv-agent install path
+    # so every agent (fleet-wide) gets a working ``sac`` regardless of
+    # what ``/work`` happens to be on that host. The SIF stub's tiny
+    # ``_bundled/`` and ``cron/`` contents (a stray pyproject.toml,
+    # README.md, post-merge-pull.sh) are intentionally shadowed —
+    # they are install-time artefacts that runtime code does not read.
+    #
+    # Removable: drop once the SIF def is re-baked with a proper
+    # non-worktree-pointing install (operator task 3 of the fleet-tui
+    # standardisation directive). The skip-if-missing filter in
+    # ``default_binds_for_host`` makes this a no-op on hosts that lack
+    # the canonical repo path.
+    "~/proj/scitex-agent-container/src/scitex_agent_container"
+    ":/opt/venv-agent/lib/python3.12/site-packages/scitex_agent_container:ro",
 )
 
 

--- a/tests/scitex_agent_container/runtimes/test__p3a_default_binds.py
+++ b/tests/scitex_agent_container/runtimes/test__p3a_default_binds.py
@@ -224,6 +224,95 @@ def test_apply_default_binds_lets_explicit_spec_override_sac_overlay(
 
 
 # ---------------------------------------------------------------------------
+# 2026-06-15 venv-agent overlay — host scitex_agent_container -> agent venv
+# (operator+lead fleet-tui standardisation; companion to the venv-sac
+# overlay above; removable once the SIF def is re-baked without the
+# worktree-pointing editable install).
+# ---------------------------------------------------------------------------
+
+
+def test_default_binds_returns_venv_agent_overlay_when_host_repo_exists(
+    fake_home: Path,
+) -> None:
+    # Arrange — synthesise the canonical host repo path under the
+    # sandboxed $HOME so the helper picks it up.
+    sac_src = (
+        fake_home / "proj" / "scitex-agent-container" / "src" / "scitex_agent_container"
+    )
+    sac_src.mkdir(parents=True)
+    # Act
+    binds = default_binds_for_host()
+    # Assert — destination is the AGENT venv's install path (the second
+    # in-SIF site-packages location that the bundled `sac` console-
+    # script's interpreter actually loads from).
+    assert any(
+        ":/opt/venv-agent/lib/python3.12/site-packages/scitex_agent_container:ro" in b
+        for b in binds
+    )
+
+
+def test_default_binds_skips_venv_agent_overlay_when_host_repo_missing(
+    fake_home: Path,
+) -> None:
+    # Arrange — fake_home has no canonical repo subtree.
+    # Act
+    binds = default_binds_for_host()
+    # Assert
+    assert not any(
+        "/opt/venv-agent/lib/python3.12/site-packages/scitex_agent_container" in b
+        for b in binds
+    )
+
+
+def test_apply_default_binds_lets_explicit_spec_override_venv_agent_overlay(
+    fake_home: Path,
+) -> None:
+    # Arrange — operator pins a custom host source for the venv-agent
+    # destination; the spec entry MUST win.
+    sac_src = (
+        fake_home / "proj" / "scitex-agent-container" / "src" / "scitex_agent_container"
+    )
+    sac_src.mkdir(parents=True)
+    custom_override = (
+        "/opt/local-sac-src"
+        ":/opt/venv-agent/lib/python3.12/site-packages/scitex_agent_container:rw"
+    )
+    spec_binds = [custom_override]
+    # Act
+    result = apply_default_binds(spec_binds)
+    # Assert
+    agent_entries = [
+        b
+        for b in result
+        if "/opt/venv-agent/lib/python3.12/site-packages/scitex_agent_container" in b
+    ]
+    assert agent_entries == [custom_override]
+
+
+def test_both_venv_overlays_present_when_host_repo_exists(fake_home: Path) -> None:
+    # Arrange — sanity check: both SDK-venv and agent-venv overlays
+    # are emitted together so the SAME host source feeds BOTH
+    # in-SIF install locations (parity for both ``claude`` paths and
+    # the ``sac`` console-script path).
+    sac_src = (
+        fake_home / "proj" / "scitex-agent-container" / "src" / "scitex_agent_container"
+    )
+    sac_src.mkdir(parents=True)
+    # Act
+    binds = default_binds_for_host()
+    venv_sac_present = any(
+        "/opt/venv-sac/lib/python3.12/site-packages/scitex_agent_container" in b
+        for b in binds
+    )
+    venv_agent_present = any(
+        "/opt/venv-agent/lib/python3.12/site-packages/scitex_agent_container" in b
+        for b in binds
+    )
+    # Assert
+    assert venv_sac_present and venv_agent_present
+
+
+# ---------------------------------------------------------------------------
 # 2026-06-13 literal-~ regression guard (lead a2a 8db5081b8aed)
 #
 # apptainer's ``--bind`` does NOT expand ``~`` — it treats the leading


### PR DESCRIPTION
## Summary

Operator+lead 2026-06-15 (fleet TUI standardisation, task 1 of 3): bind the host's editable ``scitex_agent_container`` source over ``/opt/venv-agent/lib/python3.12/site-packages/scitex_agent_container`` so the bundled ``sac`` console-script imports working code on EVERY agent (not just the agent-container repo itself).

## Root cause

The bundled ``sac-base.sif`` ships an editable install whose ``.pth`` points at ``/work/.worktrees/wt-tui-auth-stage/src``. That path only exists inside the agent-container repo's own ``/work``; for OTHER agents (research agents whose ``/work`` is a different repo) the editable target is absent and ``import scitex_agent_container`` from ``/opt/venv-agent/bin/sac`` falls through to a stub at ``/opt/venv-agent/lib/.../scitex_agent_container/`` that has ``_bundled/`` + ``cron/`` only — NO ``__init__.py``. ``sac`` crashes on import and ``server:sac`` shows ✘ failed in ``/mcp``, breaking inbound wake fleet-wide.

Verified in MY container:

```
$ ls /opt/venv-agent/lib/python3.12/site-packages/scitex_agent_container/
_bundled  cron        # no __init__.py
$ cat /opt/venv-agent/lib/python3.12/site-packages/_editable_impl_scitex_agent_container.pth
/work/.worktrees/wt-tui-auth-stage/src
```

## Change shape

Adds a second entry to ``_FLEET_DEFAULT_BINDS`` in ``runtimes/_p3a_default_binds.py`` — same host source as the existing 2026-06-13 SAC overlay, targeting the venv-agent install path instead of venv-sac. Skip-if-missing filter still applies (no bind on hosts without the canonical repo checkout). Existing per-agent ``spec.apptainer.binds`` overrides still win via de-dup-by-destination.

The SIF stub's tiny ``_bundled/`` + ``cron/`` contents (``pyproject.toml``, ``README.md``, ``post-merge-pull.sh``) are intentionally shadowed by the overlay — install-time artefacts that runtime code does not read.

## Test plan

- [x] ``pytest tests/scitex_agent_container/runtimes/test__p3a_default_binds.py`` — 17 pass (4 new for venv-agent overlay + 13 existing).
- [x] ``ruff check`` clean.
- [ ] Operator updates host ``sac`` (so the new default-bind code generates the apptainer cmd) and restarts research 3 agents (neurovista / clew / ripple-wm) to verify ``/mcp`` now shows ``server:sac`` ✔ and inbound wake delivers.

## Removable

Drop this bind once the SIF def is re-baked with a proper non-worktree-pointing install (task 3 of the fleet TUI standardisation directive).

Refs: operator+lead a2a 2026-06-15 ("host-sac bind, immediate fix"), lead-learnings #29 (canonical single-source).