### PR TITLE
feat(spec): spec.claude.effort wires --effort + settings.effortLevel (P0 task #12)

### DIFF
--- a/src/scitex_agent_container/config/_apptainer_types.py
+++ b/src/scitex_agent_container/config/_apptainer_types.py
@@ -1,0 +1,131 @@
+"""Dataclass for ``spec.apptainer`` (F-CS18).
+
+Extracted from :mod:`._types` to keep that parent module under the
+512-line per-file cap. Re-exported from :mod:`._types` so existing
+``from scitex_agent_container.config._types import ApptainerSpec``
+imports continue to resolve unchanged.
+
+Apptainer reads OCI images natively (``apptainer build sif
+docker://...``), so for the no-extras case ``spec.image`` alone is
+enough — sac just ``apptainer build``s the SIF and runs it. For
+HPC-specific layering (extra pip packages, system libs, env vars),
+the operator can either:
+
+  * declare ``spec.apptainer.post`` — sac synthesises a ``.def`` with
+    ``Bootstrap: docker`` + ``%post`` + ``%environment`` and builds
+    from it.
+  * declare ``spec.apptainer.def_file`` — sac runs ``apptainer build``
+    against the operator's hand-written ``.def`` (full control).
+
+All fields are optional; an ``apptainer:`` block with no fields set
+is equivalent to none at all.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class ApptainerSpec:
+    """Apptainer-specific image-build extensions (F-CS18)."""
+
+    # v3-realign: apptainer-engine-scoped knobs promoted from top-level.
+    image: str = ""
+    """SIF path or docker:// URL — promoted from top-level spec.image (§3).
+    Empty = fall back to the default sac-scitex SIF."""
+
+    binds: list[str] = field(default_factory=list)
+    """Bind mounts as ``host:container[:mode]`` strings — promoted from
+    top-level spec.mounts (§3)."""
+
+    env: dict[str, str] = field(default_factory=dict)
+    """Env vars exported into the container — promoted from top-level
+    spec.env (§3)."""
+
+    raw_args: list[str] = field(default_factory=list)
+    """v3 escape hatch (§1 invariant): appended verbatim to the
+    ``apptainer exec`` argv after all curated args. Lets operators bolt
+    on flags sac doesn't model."""
+
+    container_workdir: str = "/work"
+    """Path inside the container where ``spec.workdir`` gets bind-mounted
+    (and where the runner's ``--pwd`` lands). Default ``/work``.
+    Override when the SIF expects a different mount point (e.g. a
+    pre-baked ``WORKDIR`` in the .def file)."""
+
+    post: str = ""
+    """Shell snippet run inside the SIF build (apptainer's `%post`).
+    Lines are concatenated verbatim. Empty = no extension."""
+
+    environment: dict = field(default_factory=dict)
+    """Env vars baked into the SIF (apptainer's `%environment`). Same
+    shape as ``spec.env`` — KEY: VALUE pairs."""
+
+    def_file: str = ""
+    """Path to a hand-authored ``.def`` file (apptainer's native
+    build language). Mutually exclusive with `post`/`environment`:
+    when set, sac uses this file verbatim and ignores `post`."""
+
+    nv: bool = False
+    """Forward host NVIDIA driver/libs into the container (apptainer's
+    ``--nv``). Required for CUDA workloads on GPU nodes; harmless on
+    CPU-only hosts but only set when needed."""
+
+    rocm: bool = False
+    """Forward host AMD ROCm libs (apptainer's ``--rocm``). Mutually
+    exclusive with ``nv`` in practice (no host has both)."""
+
+    overlay: str = ""
+    """Writable apptainer overlay image (``--overlay <file>``). Empty =
+    no overlay (tmpfs writable layer). Non-absolute paths resolve
+    against ``spec.workdir``. See ``docs/isolation.md`` §7."""
+
+    overlay_size: str = ""
+    """When set together with ``overlay``, sac auto-creates the overlay
+    image with the given size if it doesn't exist before launching.
+    Accepts apptainer-style sizes with units M/MB/G/GB only (e.g.
+    ``"5G"``, ``"500M"``, ``"1024MB"``). K/KB are explicitly rejected —
+    apptainer's ``overlay create --size`` takes integer MB so sub-MB
+    granularity makes no sense. Empty = no auto-create (default;
+    missing overlay raises FileNotFoundError at launch with a clear
+    message). See ``docs/isolation.md`` §7."""
+
+    overlay_create_if_missing: bool = True
+    """When True (default) AND ``overlay_size`` is set AND the overlay
+    path does not exist, sac runs ``apptainer overlay create --size
+    <MB> <path>`` before launching. When False, sac never creates
+    overlays even if size is given (operator must pre-create — sac
+    raises FileNotFoundError instead). See ``docs/isolation.md`` §7."""
+
+    tmpfs_size: str = "2G"
+    """Minimum free-space guarantee for the container's ``/tmp`` (and
+    ``/var/tmp``). A ``--containall`` apptainer container otherwise gets
+    a 64 MB session tmpfs at ``/tmp`` — too small for the full test
+    suite, coverage XML generation, or pytest fixtures with file IO,
+    which fill it mid-run with "No space left on device".
+
+    sac emits ``--workdir <state_dir>/tmp-scratch`` to relocate ``/tmp``
+    onto the host filesystem (capacity >> 64 MB) and verifies that
+    filesystem has at least this many bytes free before launch, failing
+    loud otherwise. Accepts apptainer-style sizes with units M/MB/G/GB
+    only (e.g. ``"2G"``, ``"512M"``, ``"2048MB"``); K/KB rejected.
+
+    NOT a hard cap — an unprivileged apptainer user cannot mount a
+    size-capped tmpfs (``--mount type=tmpfs`` is unsupported), so the
+    contract is "at least this much room", backed by host disk. Set to
+    ``""`` to opt out entirely (legacy 64 MB tmpfs). See
+    ``runtimes/_apptainer_tmpfs.py``."""
+
+    relaxed: bool = False
+    """Opt out of sac's hardened defaults (auto-prepended
+    ``--containall``/``--cleanenv``/``--writable-tmpfs``/``--home``).
+    See ``docs/isolation.md``."""
+
+    fakeroot: bool = False
+    """Apptainer ``--fakeroot`` — uid 0 inside via user-namespace
+    remapping; operator uid on host. Pairs with the D5 preflight's
+    ``/proc/self/uid_map`` detection (see ``docs/isolation.md``)."""
+
+
+__all__ = ["ApptainerSpec"]

--- a/src/scitex_agent_container/config/_autonomous_validation.py
+++ b/src/scitex_agent_container/config/_autonomous_validation.py
@@ -1,0 +1,61 @@
+"""Validation for ``spec.autonomous`` (F-CS3 phase 1).
+
+Extracted from :mod:`._validation` to keep that parent module under
+the 512-line per-file cap. Mirrors the existing
+``_acl_validation`` / ``_provider_validation`` split pattern: a
+single ``validate_autonomous(spec) -> list[str]`` entry that the
+parent calls and concatenates into its own error list.
+
+The autonomous block authors the drive-until-done contract:
+
+  * ``drive_until``       — non-empty marker string the runner watches
+                            each assistant turn for.
+  * ``max_turns``         — int > 0 cap on conversation length.
+  * ``idle_kick_after_s`` — int > 0 idle deadline before a kick is
+                            posted.
+  * ``kick_text``         — string posted on idle timeout.
+  * ``enabled``           — bool gate; runner ignores the block when
+                            False.
+"""
+
+from __future__ import annotations
+
+
+def validate_autonomous(spec: dict) -> list[str]:
+    """Return shape errors for ``spec.autonomous`` (empty when valid).
+
+    Absent block → no errors (the spec is optional). Non-dict block →
+    one error. A dict block is field-by-field type-checked; positive
+    integer constraints applied to ``max_turns`` + ``idle_kick_after_s``.
+    """
+    errors: list[str] = []
+    autonomous = spec.get("autonomous")
+    if autonomous is None:
+        return errors
+    if not isinstance(autonomous, dict):
+        errors.append(
+            f"spec.autonomous must be a mapping; got {type(autonomous).__name__}"
+        )
+        return errors
+    drive_until = autonomous.get("drive_until")
+    if drive_until is not None and not isinstance(drive_until, str):
+        errors.append("spec.autonomous.drive_until must be a string")
+    elif drive_until == "":
+        errors.append("spec.autonomous.drive_until must be non-empty")
+    for fld in ("max_turns", "idle_kick_after_s"):
+        val = autonomous.get(fld)
+        if val is not None:
+            if not isinstance(val, int) or isinstance(val, bool):
+                errors.append(f"spec.autonomous.{fld} must be an integer")
+            elif val <= 0:
+                errors.append(f"spec.autonomous.{fld} must be > 0")
+    kick = autonomous.get("kick_text")
+    if kick is not None and not isinstance(kick, str):
+        errors.append("spec.autonomous.kick_text must be a string")
+    enabled = autonomous.get("enabled")
+    if enabled is not None and not isinstance(enabled, bool):
+        errors.append("spec.autonomous.enabled must be a boolean")
+    return errors
+
+
+__all__ = ["validate_autonomous"]

--- a/src/scitex_agent_container/config/_parsers/_claude.py
+++ b/src/scitex_agent_container/config/_parsers/_claude.py
@@ -82,8 +82,16 @@ def parse_claude(spec: dict) -> ClaudeSpec:
     raw_options = raw.get("raw_options", {}) or {}
     if not isinstance(raw_options, dict):
         raw_options = {}
+    # Reasoning-effort knob (operator directive 2026-06-15). The
+    # validator restricts the accepted value set ("low"/"medium"/"high"/
+    # "xhigh"/"max"); the parser only coerces shape (non-string → empty
+    # so the unvalidated path can't crash the runner). Empty = no
+    # override — runtime uses claude's own default.
+    effort_raw = raw.get("effort", "")
+    effort = str(effort_raw) if isinstance(effort_raw, str) else ""
     return ClaudeSpec(
         model=str(raw.get("model", "") or ""),
+        effort=effort,
         channels=raw.get("channels", []) or [],
         flags=raw.get("flags", []) or [],
         session=session,

--- a/src/scitex_agent_container/config/_types.py
+++ b/src/scitex_agent_container/config/_types.py
@@ -32,6 +32,14 @@ class ClaudeSpec:
     # v3-realign: model lives under spec.claude.model (promoted from
     # top-level spec.model — §3). Empty = runtime default.
     model: str = ""
+    # Reasoning-effort knob. One of "" (no override — claude's own
+    # default) | "low" | "medium" | "high" | "xhigh" | "max". The
+    # bundled claude binary (2.1.150 in sac-base SIF) reads it from
+    # ``--effort <level>``; the SDK reads it from settings.json
+    # ``effortLevel``. Operator directive 2026-06-15: fleet-wide knob
+    # so every agent can run at effort=max. Validation lives in
+    # ``config._validation`` (same source-of-truth as the model field).
+    effort: str = ""
     channels: list[str] = field(default_factory=list)
     flags: list[str] = field(default_factory=list)
     # v3 escape hatch (§1 invariant): splat ``**raw_options`` into
@@ -133,120 +141,12 @@ class WatchdogSpec:
 # (consume these fields in _runners.claude_session) lands in phase 2.
 # An ``enabled`` row authored under the schema before phase 2 ships
 # is harmless — the runner just ignores it for now.
-# F-CS18 — apptainer-specific extension hook.
-#
-# Apptainer reads OCI images natively (`apptainer build sif docker://...`),
-# so for the no-extras case spec.image alone is enough — sac just
-# `apptainer build`s the SIF and runs it. For HPC-specific layering
-# (extra pip packages, system libs, env vars), the operator can either:
-#
-#   * declare `spec.apptainer.post` — sac synthesises a `.def` with
-#     `Bootstrap: docker` + `%post` + `%environment` and builds from it.
-#   * declare `spec.apptainer.def_file` — sac runs `apptainer build`
-#     against the operator's hand-written `.def` (full control).
-#
-# All fields are optional; an `apptainer:` block with no fields set is
-# equivalent to none at all.
-@dataclass
-class ApptainerSpec:
-    """Apptainer-specific image-build extensions (F-CS18)."""
-
-    # v3-realign: apptainer-engine-scoped knobs promoted from top-level.
-    image: str = ""
-    """SIF path or docker:// URL — promoted from top-level spec.image (§3).
-    Empty = fall back to the default sac-scitex SIF."""
-
-    binds: list[str] = field(default_factory=list)
-    """Bind mounts as ``host:container[:mode]`` strings — promoted from
-    top-level spec.mounts (§3)."""
-
-    env: dict[str, str] = field(default_factory=dict)
-    """Env vars exported into the container — promoted from top-level
-    spec.env (§3)."""
-
-    raw_args: list[str] = field(default_factory=list)
-    """v3 escape hatch (§1 invariant): appended verbatim to the
-    ``apptainer exec`` argv after all curated args. Lets operators bolt
-    on flags sac doesn't model."""
-
-    container_workdir: str = "/work"
-    """Path inside the container where ``spec.workdir`` gets bind-mounted
-    (and where the runner's ``--pwd`` lands). Default ``/work``.
-    Override when the SIF expects a different mount point (e.g. a
-    pre-baked ``WORKDIR`` in the .def file)."""
-
-    post: str = ""
-    """Shell snippet run inside the SIF build (apptainer's `%post`).
-    Lines are concatenated verbatim. Empty = no extension."""
-
-    environment: dict = field(default_factory=dict)
-    """Env vars baked into the SIF (apptainer's `%environment`). Same
-    shape as ``spec.env`` — KEY: VALUE pairs."""
-
-    def_file: str = ""
-    """Path to a hand-authored ``.def`` file (apptainer's native
-    build language). Mutually exclusive with `post`/`environment`:
-    when set, sac uses this file verbatim and ignores `post`."""
-
-    nv: bool = False
-    """Forward host NVIDIA driver/libs into the container (apptainer's
-    ``--nv``). Required for CUDA workloads on GPU nodes; harmless on
-    CPU-only hosts but only set when needed."""
-
-    rocm: bool = False
-    """Forward host AMD ROCm libs (apptainer's ``--rocm``). Mutually
-    exclusive with ``nv`` in practice (no host has both)."""
-
-    overlay: str = ""
-    """Writable apptainer overlay image (``--overlay <file>``). Empty =
-    no overlay (tmpfs writable layer). Non-absolute paths resolve
-    against ``spec.workdir``. See ``docs/isolation.md`` §7."""
-
-    overlay_size: str = ""
-    """When set together with ``overlay``, sac auto-creates the overlay
-    image with the given size if it doesn't exist before launching.
-    Accepts apptainer-style sizes with units M/MB/G/GB only (e.g.
-    ``"5G"``, ``"500M"``, ``"1024MB"``). K/KB are explicitly rejected —
-    apptainer's ``overlay create --size`` takes integer MB so sub-MB
-    granularity makes no sense. Empty = no auto-create (default;
-    missing overlay raises FileNotFoundError at launch with a clear
-    message). See ``docs/isolation.md`` §7."""
-
-    overlay_create_if_missing: bool = True
-    """When True (default) AND ``overlay_size`` is set AND the overlay
-    path does not exist, sac runs ``apptainer overlay create --size
-    <MB> <path>`` before launching. When False, sac never creates
-    overlays even if size is given (operator must pre-create — sac
-    raises FileNotFoundError instead). See ``docs/isolation.md`` §7."""
-
-    tmpfs_size: str = "2G"
-    """Minimum free-space guarantee for the container's ``/tmp`` (and
-    ``/var/tmp``). A ``--containall`` apptainer container otherwise gets
-    a 64 MB session tmpfs at ``/tmp`` — too small for the full test
-    suite, coverage XML generation, or pytest fixtures with file IO,
-    which fill it mid-run with "No space left on device".
-
-    sac emits ``--workdir <state_dir>/tmp-scratch`` to relocate ``/tmp``
-    onto the host filesystem (capacity >> 64 MB) and verifies that
-    filesystem has at least this many bytes free before launch, failing
-    loud otherwise. Accepts apptainer-style sizes with units M/MB/G/GB
-    only (e.g. ``"2G"``, ``"512M"``, ``"2048MB"``); K/KB rejected.
-
-    NOT a hard cap — an unprivileged apptainer user cannot mount a
-    size-capped tmpfs (``--mount type=tmpfs`` is unsupported), so the
-    contract is "at least this much room", backed by host disk. Set to
-    ``""`` to opt out entirely (legacy 64 MB tmpfs). See
-    ``runtimes/_apptainer_tmpfs.py``."""
-
-    relaxed: bool = False
-    """Opt out of sac's hardened defaults (auto-prepended
-    ``--containall``/``--cleanenv``/``--writable-tmpfs``/``--home``).
-    See ``docs/isolation.md``."""
-
-    fakeroot: bool = False
-    """Apptainer ``--fakeroot`` — uid 0 inside via user-namespace
-    remapping; operator uid on host. Pairs with the D5 preflight's
-    ``/proc/self/uid_map`` detection (see ``docs/isolation.md``)."""
+# F-CS18 — apptainer-specific extension hook. ``ApptainerSpec`` is
+# defined in a sibling module to keep this file under the per-file
+# line cap (it carries ~100 lines of inline docstring-heavy fields).
+# Re-exported here so existing imports of
+# ``config._types.ApptainerSpec`` resolve unchanged.
+from ._apptainer_types import ApptainerSpec  # noqa: E402,F401
 
 
 @dataclass

--- a/src/scitex_agent_container/config/_validation.py
+++ b/src/scitex_agent_container/config/_validation.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import yaml
 
 from ._acl_validation import validate_phase3_acl
+from ._autonomous_validation import validate_autonomous
 from ._provider_validation import provider_is_active, validate_provider
 
 # Accepted shapes for ``spec.model`` (F-CS7).
@@ -72,6 +73,14 @@ _VALID_KINDS = frozenset({"Agent", "AgentProxy"})
 # and ``"apptainer"`` are accepted as back-compat and mapped to
 # ``"claude-agent-sdk"`` at dispatch — see ``_lifecycle/_runtime_select``.
 _VALID_RUNTIMES = frozenset({"claude-agent-sdk", "tui", "apptainer", ""})
+
+# Reasoning-effort levels accepted by the bundled claude binary
+# (2.1.150 in sac-base SIF — verified by ``claude --help``: --effort
+# <level>). The SDK reads the same set from settings.json
+# ``effortLevel``. Operator directive 2026-06-15 surfaces this knob
+# fleet-wide so every agent can run at effort=max. Empty / missing =
+# no override (claude's own default applies).
+_VALID_EFFORTS = frozenset({"low", "medium", "high", "xhigh", "max"})
 
 
 _SDK_IMAGE = "scitex-agent-container:scitex"
@@ -299,6 +308,27 @@ def validate_raw(raw: dict, path: str) -> list[str]:
                     "field accepts the provider's own model id instead.)"
                 )
 
+        # spec.claude.effort — reasoning-effort knob (operator directive
+        # 2026-06-15). Restricted to the documented level set so typos
+        # surface at yaml-validate time instead of as an opaque
+        # "unknown level" failure inside claude. Empty / missing is
+        # allowed (no override; claude's own default applies).
+        effort = claude_block.get("effort")
+        if effort is not None:
+            if not isinstance(effort, str):
+                errors.append(
+                    f"spec.claude.effort must be a string, got {type(effort).__name__}"
+                )
+            elif effort and effort not in _VALID_EFFORTS:
+                errors.append(
+                    f"spec.claude.effort '{effort}' is not an accepted "
+                    f"level. Use one of {sorted(_VALID_EFFORTS)} or "
+                    "leave empty for claude's own default. The bundled "
+                    "claude binary (2.1.150) accepts these via "
+                    "--effort <level>; the SDK reads the same from "
+                    "settings.json effortLevel."
+                )
+
         # spec.claude.provider + spec.claude.account are mutually
         # exclusive — an API-key backend needs no OAuth. Declaring both
         # is a config error (the runtime would otherwise have to guess
@@ -407,33 +437,10 @@ def validate_raw(raw: dict, path: str) -> list[str]:
                     f"got {type(hosts_val).__name__}"
                 )
 
-        # spec.autonomous (F-CS3 phase 1) — drive-until-done.
-        autonomous = spec.get("autonomous")
-        if autonomous is not None:
-            if not isinstance(autonomous, dict):
-                errors.append(
-                    "spec.autonomous must be a mapping; got "
-                    f"{type(autonomous).__name__}"
-                )
-            else:
-                drive_until = autonomous.get("drive_until")
-                if drive_until is not None and not isinstance(drive_until, str):
-                    errors.append("spec.autonomous.drive_until must be a string")
-                elif drive_until == "":
-                    errors.append("spec.autonomous.drive_until must be non-empty")
-                for fld in ("max_turns", "idle_kick_after_s"):
-                    val = autonomous.get(fld)
-                    if val is not None:
-                        if not isinstance(val, int) or isinstance(val, bool):
-                            errors.append(f"spec.autonomous.{fld} must be an integer")
-                        elif val <= 0:
-                            errors.append(f"spec.autonomous.{fld} must be > 0")
-                kick = autonomous.get("kick_text")
-                if kick is not None and not isinstance(kick, str):
-                    errors.append("spec.autonomous.kick_text must be a string")
-                enabled = autonomous.get("enabled")
-                if enabled is not None and not isinstance(enabled, bool):
-                    errors.append("spec.autonomous.enabled must be a boolean")
+        # spec.autonomous (F-CS3 phase 1) — drive-until-done. Field-by-
+        # field shape check lives in the sibling module to keep this
+        # file under the per-file cap.
+        errors.extend(validate_autonomous(spec))
 
         # kind: AgentProxy coupling rules.
         #

--- a/src/scitex_agent_container/runtimes/_apptainer_inner_argv.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_inner_argv.py
@@ -264,6 +264,14 @@ def _tui_runner_argv(
         model = str(getattr(config, "model", "") or "").strip()
     if model:
         argv += ["--model", model]
+    # spec.claude.effort → --effort <level> (operator directive
+    # 2026-06-15). Bundled claude 2.1.150 supports the flag — verified
+    # against ``claude --help`` in the sac-base SIF. Empty = omit the
+    # flag (claude uses its own default). Validator restricts the
+    # accepted level set.
+    effort = str(getattr(claude_spec, "effort", "") or "").strip()
+    if effort:
+        argv += ["--effort", effort]
     mcp_values = [v for v in (mcp_config, channel_mcp) if v]
     if mcp_values:
         argv += ["--mcp-config", *mcp_values]

--- a/src/scitex_agent_container/runtimes/settings_json.py
+++ b/src/scitex_agent_container/runtimes/settings_json.py
@@ -45,6 +45,10 @@ _MANAGED_KEYS = frozenset(
         "enabledMcpjsonServers",
         "hooks",
         "statusLine",
+        # spec.claude.effort → settings.effortLevel (operator directive
+        # 2026-06-15). SDK reads it from settings.json; the validator
+        # in config._validation restricts the accepted level set.
+        "effortLevel",
     }
 )
 
@@ -216,6 +220,14 @@ def setup_settings_json(config: AgentConfig, workdir: str) -> None:
 
     if _needs_skip_permissions(config):
         settings["skipDangerousModePermissionPrompt"] = True
+
+    # spec.claude.effort → settings.effortLevel (operator directive
+    # 2026-06-15). When set, the SDK runner reads the level and runs
+    # at that reasoning effort. Empty / missing = no override (SDK
+    # uses its own default). Validator restricts the accepted set.
+    effort = str(getattr(config.claude, "effort", "") or "").strip()
+    if effort:
+        settings["effortLevel"] = effort
 
     if _needs_dev_channels(config):
         settings["enableAllProjectMcpServers"] = True

--- a/tests/scitex_agent_container/config/_parsers/test__claude.py
+++ b/tests/scitex_agent_container/config/_parsers/test__claude.py
@@ -34,6 +34,7 @@ from scitex_agent_container.config._parsers._claude import parse_claude
     ("attr", "expected"),
     [
         ("model", ""),
+        ("effort", ""),
         ("channels", []),
         ("flags", []),
         ("session", "continue"),

--- a/tests/scitex_agent_container/config/test__effort.py
+++ b/tests/scitex_agent_container/config/test__effort.py
@@ -32,7 +32,8 @@ from scitex_agent_container.config._validation import validate_raw
 
 
 def test_claude_spec_default_effort_is_empty_string():
-    # Arrange / Act
+    # Arrange
+    # Act
     spec = ClaudeSpec()
     # Assert
     assert spec.effort == ""

--- a/tests/scitex_agent_container/config/test__effort.py
+++ b/tests/scitex_agent_container/config/test__effort.py
@@ -1,0 +1,199 @@
+"""Tests for ``spec.claude.effort`` parsing + validation.
+
+Mirrors the model-field plumbing (see ``test__validation.py`` and
+``_parsers/test__claude.py``). The bundled claude binary (2.1.150 in the
+sac-base SIF) supports ``--effort <level>`` with values
+``low / medium / high / xhigh / max``; the SDK uses settings.json
+``effortLevel``. Operator directive 2026-06-15: surface this knob fleet-
+wide so every agent can run at effort=max.
+
+The parser plumbs the YAML field through to ``ClaudeSpec.effort``;
+the validator enforces the documented value set. Empty / missing means
+"no override" — the runtime uses the claude binary's own default.
+
+TQ cleanup: module docstring summarises intent (TQ001); every test
+carries AAA markers (TQ002); descriptive names spell out the verified
+behaviour (TQ003); each test asserts exactly one fact (TQ007). Error
+tests use ``pytest.raises(match=...)`` or list-membership checks per
+fleet doctrine.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scitex_agent_container.config._parsers._claude import parse_claude
+from scitex_agent_container.config._types import ClaudeSpec
+from scitex_agent_container.config._validation import validate_raw
+
+# ---------------------------------------------------------------------------
+# ClaudeSpec default
+# ---------------------------------------------------------------------------
+
+
+def test_claude_spec_default_effort_is_empty_string():
+    # Arrange / Act
+    spec = ClaudeSpec()
+    # Assert
+    assert spec.effort == ""
+
+
+# ---------------------------------------------------------------------------
+# parse_claude — pass-through
+# ---------------------------------------------------------------------------
+
+
+def test_parse_claude_missing_block_yields_empty_effort():
+    # Arrange
+    raw: dict = {}
+    # Act
+    result = parse_claude(raw)
+    # Assert
+    assert result.effort == ""
+
+
+def test_parse_claude_missing_effort_key_yields_empty_effort():
+    # Arrange
+    raw = {"claude": {"model": "opus"}}
+    # Act
+    result = parse_claude(raw)
+    # Assert
+    assert result.effort == ""
+
+
+@pytest.mark.parametrize("level", ["low", "medium", "high", "xhigh", "max"])
+def test_parse_claude_accepts_documented_levels(level):
+    # Arrange
+    raw = {"claude": {"effort": level}}
+    # Act
+    result = parse_claude(raw)
+    # Assert
+    assert result.effort == level
+
+
+def test_parse_claude_coerces_non_string_to_empty():
+    # Arrange — defensive: unvalidated path must not crash the runner.
+    raw = {"claude": {"effort": 42}}
+    # Act
+    result = parse_claude(raw)
+    # Assert
+    assert result.effort == ""
+
+
+def test_parse_claude_explicit_none_yields_empty_effort():
+    # Arrange
+    raw = {"claude": {"effort": None}}
+    # Act
+    result = parse_claude(raw)
+    # Assert
+    assert result.effort == ""
+
+
+# ---------------------------------------------------------------------------
+# validate_raw — accepts documented values
+# ---------------------------------------------------------------------------
+
+_BASE = {
+    "apiVersion": "scitex-agent-container/v3",
+    "kind": "Agent",
+    "spec": {"runtime": "apptainer"},
+}
+
+
+def _spec_with_effort(effort):
+    return {
+        **_BASE,
+        "spec": {**_BASE["spec"], "claude": {"effort": effort}},
+    }
+
+
+@pytest.mark.parametrize("level", ["low", "medium", "high", "xhigh", "max"])
+def test_validate_accepts_documented_effort_levels(level):
+    # Arrange
+    raw = _spec_with_effort(level)
+    # Act
+    errors = validate_raw(raw, path="<test>")
+    # Assert
+    assert not [e for e in errors if "spec.claude.effort" in e]
+
+
+def test_validate_accepts_missing_effort():
+    # Arrange
+    raw = _BASE
+    # Act
+    errors = validate_raw(raw, path="<test>")
+    # Assert
+    assert not [e for e in errors if "spec.claude.effort" in e]
+
+
+def test_validate_accepts_empty_effort():
+    # Arrange
+    raw = _spec_with_effort("")
+    # Act
+    errors = validate_raw(raw, path="<test>")
+    # Assert
+    assert not [e for e in errors if "spec.claude.effort" in e]
+
+
+# ---------------------------------------------------------------------------
+# validate_raw — rejects unknown / mistyped values
+# ---------------------------------------------------------------------------
+
+_INVALID_EFFORTS = [
+    "extreme",  # not in the documented set
+    "MAX",  # claude expects lowercase
+    "ultra",
+    "0",
+    "highest",
+]
+
+
+@pytest.mark.parametrize("level", _INVALID_EFFORTS)
+def test_validate_rejects_unknown_effort_value(level):
+    # Arrange
+    raw = _spec_with_effort(level)
+    # Act
+    errors = validate_raw(raw, path="<test>")
+    # Assert
+    assert [e for e in errors if "spec.claude.effort" in e]
+
+
+@pytest.mark.parametrize("level", _INVALID_EFFORTS)
+def test_validate_rejection_echoes_offending_value(level):
+    # Arrange
+    raw = _spec_with_effort(level)
+    # Act
+    errors = validate_raw(raw, path="<test>")
+    bad = [e for e in errors if "spec.claude.effort" in e]
+    # Assert
+    assert level in bad[0]
+
+
+@pytest.mark.parametrize("level", _INVALID_EFFORTS)
+def test_validate_rejection_lists_canonical_levels(level):
+    # Arrange
+    raw = _spec_with_effort(level)
+    # Act
+    errors = validate_raw(raw, path="<test>")
+    bad = [e for e in errors if "spec.claude.effort" in e]
+    # Assert
+    assert "max" in bad[0] and "low" in bad[0]
+
+
+def test_validate_rejects_non_string_effort():
+    # Arrange
+    raw = _spec_with_effort(42)
+    # Act
+    errors = validate_raw(raw, path="<test>")
+    # Assert
+    assert [e for e in errors if "spec.claude.effort" in e]
+
+
+def test_validate_non_string_effort_message_calls_out_type():
+    # Arrange
+    raw = _spec_with_effort(42)
+    # Act
+    errors = validate_raw(raw, path="<test>")
+    bad = [e for e in errors if "spec.claude.effort" in e]
+    # Assert
+    assert "string" in bad[0].lower()

--- a/tests/scitex_agent_container/runtimes/test__effort_wiring.py
+++ b/tests/scitex_agent_container/runtimes/test__effort_wiring.py
@@ -108,7 +108,8 @@ def test_settings_json_writes_effort_level_when_set(tmp_path, level):
 
 
 def test_managed_keys_includes_effort_level():
-    # Arrange / Act
+    # Arrange
+    # Act
     has_key = "effortLevel" in _MANAGED_KEYS
     # Assert
     assert has_key

--- a/tests/scitex_agent_container/runtimes/test__effort_wiring.py
+++ b/tests/scitex_agent_container/runtimes/test__effort_wiring.py
@@ -1,0 +1,142 @@
+"""Tests for ``spec.claude.effort`` → runner argv + settings.json wiring.
+
+Two carriers:
+  * TUI runner — passes ``--effort <level>`` to the bundled ``claude``
+    binary (2.1.150 in sac-base SIF supports the flag).
+  * SDK runner — materialises ``effortLevel: <level>`` into the agent's
+    ``.claude/settings.local.json`` (the SDK reads it from there).
+
+Operator directive 2026-06-15: surface this knob fleet-wide so every
+agent can run at effort=max. Empty / missing means "no override".
+
+TQ cleanup: docstring (TQ001), AAA markers (TQ002), descriptive names
+(TQ003), one assertion per test (TQ007), no monkeypatch parameter
+(env save/restore where needed).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container.config import AgentConfig
+from scitex_agent_container.config._types import ClaudeSpec
+from scitex_agent_container.runtimes._apptainer_inner_argv import _tui_runner_argv
+from scitex_agent_container.runtimes.settings_json import (
+    _MANAGED_KEYS,
+    cleanup_settings_json,
+    setup_settings_json,
+)
+
+
+def _settings_path(workdir) -> Path:
+    return Path(workdir) / ".claude" / "settings.local.json"
+
+
+# ---------------------------------------------------------------------------
+# TUI runner: --effort wiring
+# ---------------------------------------------------------------------------
+
+
+def test_tui_runner_omits_effort_flag_when_unset():
+    # Arrange
+    cfg = AgentConfig(name="t", claude=ClaudeSpec(effort=""))
+    # Act
+    argv = _tui_runner_argv(cfg)
+    # Assert
+    assert "--effort" not in argv
+
+
+@pytest.mark.parametrize("level", ["low", "medium", "high", "xhigh", "max"])
+def test_tui_runner_emits_effort_flag_when_set(level):
+    # Arrange
+    cfg = AgentConfig(name="t", claude=ClaudeSpec(effort=level))
+    # Act
+    argv = _tui_runner_argv(cfg)
+    # Assert
+    assert "--effort" in argv
+
+
+@pytest.mark.parametrize("level", ["low", "medium", "high", "xhigh", "max"])
+def test_tui_runner_effort_value_follows_flag(level):
+    # Arrange
+    cfg = AgentConfig(name="t", claude=ClaudeSpec(effort=level))
+    # Act
+    argv = _tui_runner_argv(cfg)
+    # Assert
+    assert argv[argv.index("--effort") + 1] == level
+
+
+def test_tui_runner_effort_appears_alongside_model_flag():
+    # Arrange — both knobs set; both must reach the binary.
+    cfg = AgentConfig(
+        name="t",
+        claude=ClaudeSpec(model="opus", effort="max"),
+    )
+    # Act
+    argv = _tui_runner_argv(cfg)
+    # Assert
+    assert "--model" in argv and "--effort" in argv
+
+
+# ---------------------------------------------------------------------------
+# SDK settings.json: effortLevel wiring
+# ---------------------------------------------------------------------------
+
+
+def test_settings_json_omits_effort_level_when_unset(tmp_path):
+    # Arrange
+    cfg = AgentConfig(name="t", claude=ClaudeSpec(effort=""))
+    # Act
+    setup_settings_json(cfg, str(tmp_path))
+    data = json.loads(_settings_path(tmp_path).read_text())
+    # Assert
+    assert "effortLevel" not in data
+
+
+@pytest.mark.parametrize("level", ["low", "medium", "high", "xhigh", "max"])
+def test_settings_json_writes_effort_level_when_set(tmp_path, level):
+    # Arrange
+    cfg = AgentConfig(name="t", claude=ClaudeSpec(effort=level))
+    # Act
+    setup_settings_json(cfg, str(tmp_path))
+    data = json.loads(_settings_path(tmp_path).read_text())
+    # Assert
+    assert data["effortLevel"] == level
+
+
+def test_managed_keys_includes_effort_level():
+    # Arrange / Act
+    has_key = "effortLevel" in _MANAGED_KEYS
+    # Assert
+    assert has_key
+
+
+def test_cleanup_removes_effort_level(tmp_path):
+    # Arrange
+    cfg = AgentConfig(name="t", claude=ClaudeSpec(effort="max"))
+    setup_settings_json(cfg, str(tmp_path))
+    # Act
+    cleanup_settings_json(cfg, str(tmp_path))
+    # Assert
+    remaining = (
+        json.loads(_settings_path(tmp_path).read_text())
+        if _settings_path(tmp_path).exists()
+        else {}
+    )
+    assert "effortLevel" not in remaining
+
+
+def test_cleanup_preserves_user_keys_alongside_effort(tmp_path):
+    # Arrange
+    sp = _settings_path(tmp_path)
+    sp.parent.mkdir(parents=True, exist_ok=True)
+    sp.write_text(json.dumps({"userCustomKey": "keep"}))
+    cfg = AgentConfig(name="t", claude=ClaudeSpec(effort="max"))
+    setup_settings_json(cfg, str(tmp_path))
+    # Act
+    cleanup_settings_json(cfg, str(tmp_path))
+    # Assert
+    assert json.loads(sp.read_text()) == {"userCustomKey": "keep"}


### PR DESCRIPTION
## Summary

Operator+lead 2026-06-15: add fleet-wide support for claude's ``--effort <level>`` flag and settings ``effortLevel`` so agents can run at effort=max (opus 4.8[1m] + effort max).

## Verification

In-SIF claude **2.1.150** supports ``--effort`` (verified via ``--help``):

```
--effort <level>   Effort level for the current session (low, medium, high, xhigh, max)
```

No SIF bump required.

## Change shape

Three wire-up points:

1. **``ClaudeSpec.effort`` field** (``config/_types.py`` + ``config/_parsers/_claude.py`` + ``config/_validation.py``). Validates one of ``low/medium/high/xhigh/max``; empty/None = no override (claude's own default).
2. **TUI runner**: ``runtimes/_apptainer_inner_argv._tui_runner_argv`` adds ``--effort <effort>`` next to ``--model`` when set.
3. **SDK settings**: ``runtimes/settings_json`` includes ``effortLevel: <effort>`` in the materialised settings.local.json (the SDK runner's equivalent of the CLI flag).

## Refactor (file-size cap)

- Extracted ``ApptainerSpec`` to new ``config/_apptainer_types.py``.
- Extracted autonomous-runtime validation to new ``config/_autonomous_validation.py``.

Both keep ``config/_types.py`` and ``config/_validation.py`` under the 512-line per-file cap after the effort additions. Public imports preserved via re-exports.

## Test plan

- [x] ``pytest tests/scitex_agent_container/config/test__effort.py tests/scitex_agent_container/runtimes/test__effort_wiring.py tests/scitex_agent_container/config/_parsers/test__claude.py`` — **92 pass**.
- [x] ``ruff check`` clean on all changed/new files.
- [ ] Operator updates per-agent specs to set ``spec.claude.effort: max`` (or relies on ``_base/spec.yaml`` default in dotfiles).

## Out of scope (operator handles)

- ``_base/spec.yaml`` default ``effort: max`` (lives in operator's dotfiles tree, not this repo).
- Individual non-opus model adjustments (fable / haiku / deepseek — operator updates per-agent).
- ``max_tokens`` cap lift — investigated but not bundled here; opening a sibling decision when operator confirms the desired cap for effort=max.

Refs: operator+lead a2a 2026-06-15 ("opus4.8 + effort max fleet-wide").