### PR TITLE
fix(start): fail loud on runtime.start() failure + split _start.py

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_start.py
+++ b/src/scitex_agent_container/_lifecycle/_start.py
@@ -6,7 +6,6 @@ Extracted from the former monolithic ``lifecycle.py`` (split for the
 
 from __future__ import annotations
 
-import sys
 import threading
 import time
 import traceback
@@ -22,156 +21,17 @@ from ._instances import record_local_instance as _record_local_instance
 from ._runtime_select import _get_runtime
 from ._session_reset import _clear_persisted_session_id
 from ._spawn_gate import enforce_spawn_gate, persist_acl_policy
+
+# Re-exported from _start_preflight for back-compat: callers/tests import these
+# pre-flight helpers from _start. _resolve_strict_drift is used only transitively
+# (by _check_spec_source_drift_at_launch) but stays re-exported here.
+from ._start_preflight import (  # noqa: F401
+    _check_spec_source_drift_at_launch,
+    _resolve_strict_drift,
+    _rotate_to_healthy_account,
+    _verify_real_liveness,
+)
 from .health import health_monitor
-
-
-def _verify_real_liveness(
-    config: AgentConfig,
-    runtime,
-    *,
-    instances_oracle: Callable[[], list[dict]] | None = None,
-) -> bool:
-    """Return True iff the agent is *demonstrably* running on this host.
-
-    The pre-fix call site treated ``registry.exists(name) and
-    runtime.is_running(config)`` as the already-running signal. Both
-    are necessary but not sufficient:
-
-      * ``registry.exists`` is a JSON file on disk — a forced ``rm``,
-        a stale entry from a prior boot, or a crash-during-write leaves
-        the file behind even though no agent is running.
-      * ``runtime.is_running`` checks the per-runtime PID file with
-        ``os.kill(pid, 0)`` — on a Linux PID-wraparound the same pid
-        can belong to a completely unrelated process and the probe
-        returns True.
-
-    Either of those false positives causes the no-op branch in
-    :func:`agent_start` to swallow a real start request silently and
-    return rc=0. The cross-host ``instances`` table is the third
-    independent signal — it is written by ``record_local_instance``
-    inside the *real* start path and removed by ``agent_stop`` /
-    ``cleanup_stale``. We require an active row before treating the
-    agent as already-running. If the row is absent, the registry/PID
-    pair is inconsistent → fall through to a real start instead of
-    the silent no-op.
-
-    The ``instances_oracle`` seam is the no-mocks knob for tests; it
-    defaults to a host-unfiltered :func:`state_db.list_active_instances`
-    call (we want ANY active row for the name, not just rows on the
-    current host — handover may have moved it).
-    """
-    if instances_oracle is None:
-        from .._state.state_db import list_active_instances as _default
-
-        def instances_oracle():  # type: ignore[no-redef]
-            # Explicit host=None so the call is unambiguous and the
-            # fixture-isolated test reads through the same module.
-            return _default(host=None)
-
-    try:
-        rows = instances_oracle()
-    except Exception:
-        # stx-allow: fallback (reason: a missing/locked state.db must
-        # not block the start path; degrade to "no liveness evidence"
-        # which causes the caller to launch fresh rather than silently
-        # no-op)
-        return False
-    for row in rows or ():
-        if row.get("name") == config.name:
-            return True
-    return False
-
-
-def _resolve_strict_drift(strict_drift: bool | None) -> bool:
-    """Resolve effective strict-drift mode (arg wins, else env).
-
-    ``strict_drift=True/False`` from ``--strict-drift`` takes priority.
-    ``None`` falls back to ``SAC_STRICT_DRIFT`` (``1``/``true``/``yes``
-    → strict). Read through the sac env helper so either prefix works.
-    """
-    if strict_drift is not None:
-        return strict_drift
-    from .._env import getenv as _sac_env
-
-    raw = (_sac_env("STRICT_DRIFT", "") or "").strip().lower()
-    return raw in ("1", "true", "yes", "on")
-
-
-def _rotate_to_healthy_account(
-    config: AgentConfig,
-    *,
-    log_stream: Any = None,
-) -> None:
-    """Rotate ``config.claude.account`` to a healthy stored account.
-
-    CREDS-PHASE1 wiring. Only acts on PINNED agents
-    (``spec.claude.account`` non-empty). For an unpinned agent the
-    runtime continues to bind the host's live ``.credentials.json``
-    untouched.
-
-    On a pinned agent:
-
-    * If the pinned snapshot is healthy → no-op (config unchanged).
-    * If the pinned snapshot is EXPIRED/ABSENT but another stored
-      account has a fresh snapshot → ``config.claude.account`` is
-      mutated to that account and a one-line rotation notice is
-      printed to ``log_stream`` (default ``sys.stderr``). The runtime
-      then binds that account's snapshot ``:rw`` directly via
-      :func:`runtimes._apptainer_creds.resolve_cred_file` (operator
-      #15 — the prior boot-copy path was the root cause of the
-      2026-06-01 fleet outage; refreshes now write back to the
-      snapshot itself, never expiring).
-    * If NOTHING is healthy → :class:`_creds.NoHealthyAccountError`
-      propagates (fail loud, no silent stale-token launch). Agent is
-      NOT started.
-
-    See :mod:`scitex_agent_container._creds._pick_healthy` for the
-    health model — non-expired snapshot = healthy. Cap-induced 429s
-    still surface from claude in-turn; the picker only avoids
-    known-stale auth at boot.
-    """
-    pinned = getattr(getattr(config, "claude", None), "account", "") or ""
-    if not pinned:
-        return  # unpinned agent — host live OAuth, untouched.
-
-    from .._creds import pick_healthy_account
-
-    picked = pick_healthy_account(pinned)
-    if picked == pinned:
-        return  # pinned is healthy — no rotation, no log line.
-
-    config.claude.account = picked
-    stream = log_stream if log_stream is not None else sys.stderr
-    print(
-        f"[sac:creds] agent '{config.name}' rotated account: "
-        f"{pinned!r} -> {picked!r} (pinned snapshot unhealthy; "
-        f"rotated to the first healthy stored account)",
-        file=stream,
-    )
-
-
-def _check_spec_source_drift_at_launch(
-    config_path: str, agent_name: str, strict_drift: bool | None
-) -> None:
-    """Run the launch-time drift check; warn loud (or block if strict).
-
-    Fully guarded: the underlying check never raises except the
-    deliberate strict-mode :class:`SpecSourceDriftError`. We let that
-    propagate (the CLI / caller turns it into a non-zero exit); any
-    other unexpected failure here is swallowed so a launch is never
-    crashed by the drift guard.
-    """
-    from .._drift import SpecSourceDriftError, warn_if_spec_source_drifted
-
-    strict = _resolve_strict_drift(strict_drift)
-    try:
-        warn_if_spec_source_drifted(config_path, agent=agent_name, strict=strict)
-    except SpecSourceDriftError:
-        # Deliberate strict-mode block — propagate so the caller exits
-        # non-zero. This is the ONE thing this guard is allowed to raise.
-        raise
-    except Exception:  # stx-allow: fallback (reason: the drift guard must NEVER crash a launch; any unexpected error degrades to "no check ran" and the agent proceeds)
-        traceback.print_exc()
 
 
 def agent_start(
@@ -496,7 +356,28 @@ def agent_start(
         start_kw["one_shot"] = True
     success = runtime.start(config, **start_kw)
     if not success:
-        raise RuntimeError(f"Failed to start agent '{config.name}'")
+        # Fail loud: a bare False from runtime.start() must not become a
+        # cause-less "Failed to start". Capture the agent's tmux pane (the
+        # inner apptainer/claude output) + whether a session exists, so the
+        # real boot failure — boot-drain timeout, auth, a broken in-container
+        # login shell, an immediate claude exit — is visible, not swallowed.
+        diag = ""
+        try:
+            from .._runners._tmux.tmux import TmuxManager
+            from ..runtimes.tui_session import session_name_for
+
+            _sess = session_name_for(config)
+            _pane = TmuxManager.capture_logs(_sess, lines=60).rstrip()
+            diag = (
+                f" (tmux session_exists={TmuxManager.exists(_sess)})\n"
+                f"  pane tail:\n{_pane or '<empty — inner process exited before any output>'}"
+            )
+        except Exception:  # stx-allow: fallback (reason: diagnostics must never mask the real start failure — degrade to no pane)
+            diag = " (no pane diagnostics available)"
+        raise RuntimeError(
+            f"Failed to start agent '{config.name}': runtime.start() returned "
+            f"False.{diag}"
+        )
 
     # Register
     registry.add(

--- a/src/scitex_agent_container/_lifecycle/_start_preflight.py
+++ b/src/scitex_agent_container/_lifecycle/_start_preflight.py
@@ -1,0 +1,163 @@
+"""Pre-flight helpers for ``agent_start`` — liveness, account rotation,
+strict-drift resolution, and launch-time spec-source drift.
+
+Extracted from ``_start.py`` (split for the 512-line module limit).
+``_start.agent_start`` imports these; behaviour is unchanged.
+"""
+
+from __future__ import annotations
+
+import sys
+import traceback
+from typing import Any, Callable
+
+from ..config import AgentConfig
+
+
+def _verify_real_liveness(
+    config: AgentConfig,
+    runtime,
+    *,
+    instances_oracle: Callable[[], list[dict]] | None = None,
+) -> bool:
+    """Return True iff the agent is *demonstrably* running on this host.
+
+    The pre-fix call site treated ``registry.exists(name) and
+    runtime.is_running(config)`` as the already-running signal. Both
+    are necessary but not sufficient:
+
+      * ``registry.exists`` is a JSON file on disk — a forced ``rm``,
+        a stale entry from a prior boot, or a crash-during-write leaves
+        the file behind even though no agent is running.
+      * ``runtime.is_running`` checks the per-runtime PID file with
+        ``os.kill(pid, 0)`` — on a Linux PID-wraparound the same pid
+        can belong to a completely unrelated process and the probe
+        returns True.
+
+    Either of those false positives causes the no-op branch in
+    :func:`agent_start` to swallow a real start request silently and
+    return rc=0. The cross-host ``instances`` table is the third
+    independent signal — it is written by ``record_local_instance``
+    inside the *real* start path and removed by ``agent_stop`` /
+    ``cleanup_stale``. We require an active row before treating the
+    agent as already-running. If the row is absent, the registry/PID
+    pair is inconsistent → fall through to a real start instead of
+    the silent no-op.
+
+    The ``instances_oracle`` seam is the no-mocks knob for tests; it
+    defaults to a host-unfiltered :func:`state_db.list_active_instances`
+    call (we want ANY active row for the name, not just rows on the
+    current host — handover may have moved it).
+    """
+    if instances_oracle is None:
+        from .._state.state_db import list_active_instances as _default
+
+        def instances_oracle():  # type: ignore[no-redef]
+            # Explicit host=None so the call is unambiguous and the
+            # fixture-isolated test reads through the same module.
+            return _default(host=None)
+
+    try:
+        rows = instances_oracle()
+    except Exception:
+        # stx-allow: fallback (reason: a missing/locked state.db must
+        # not block the start path; degrade to "no liveness evidence"
+        # which causes the caller to launch fresh rather than silently
+        # no-op)
+        return False
+    for row in rows or ():
+        if row.get("name") == config.name:
+            return True
+    return False
+
+
+def _resolve_strict_drift(strict_drift: bool | None) -> bool:
+    """Resolve effective strict-drift mode (arg wins, else env).
+
+    ``strict_drift=True/False`` from ``--strict-drift`` takes priority.
+    ``None`` falls back to ``SAC_STRICT_DRIFT`` (``1``/``true``/``yes``
+    → strict). Read through the sac env helper so either prefix works.
+    """
+    if strict_drift is not None:
+        return strict_drift
+    from .._env import getenv as _sac_env
+
+    raw = (_sac_env("STRICT_DRIFT", "") or "").strip().lower()
+    return raw in ("1", "true", "yes", "on")
+
+
+def _rotate_to_healthy_account(
+    config: AgentConfig,
+    *,
+    log_stream: Any = None,
+) -> None:
+    """Rotate ``config.claude.account`` to a healthy stored account.
+
+    CREDS-PHASE1 wiring. Only acts on PINNED agents
+    (``spec.claude.account`` non-empty). For an unpinned agent the
+    runtime continues to bind the host's live ``.credentials.json``
+    untouched.
+
+    On a pinned agent:
+
+    * If the pinned snapshot is healthy → no-op (config unchanged).
+    * If the pinned snapshot is EXPIRED/ABSENT but another stored
+      account has a fresh snapshot → ``config.claude.account`` is
+      mutated to that account and a one-line rotation notice is
+      printed to ``log_stream`` (default ``sys.stderr``). The runtime
+      then binds that account's snapshot ``:rw`` directly via
+      :func:`runtimes._apptainer_creds.resolve_cred_file` (operator
+      #15 — the prior boot-copy path was the root cause of the
+      2026-06-01 fleet outage; refreshes now write back to the
+      snapshot itself, never expiring).
+    * If NOTHING is healthy → :class:`_creds.NoHealthyAccountError`
+      propagates (fail loud, no silent stale-token launch). Agent is
+      NOT started.
+
+    See :mod:`scitex_agent_container._creds._pick_healthy` for the
+    health model — non-expired snapshot = healthy. Cap-induced 429s
+    still surface from claude in-turn; the picker only avoids
+    known-stale auth at boot.
+    """
+    pinned = getattr(getattr(config, "claude", None), "account", "") or ""
+    if not pinned:
+        return  # unpinned agent — host live OAuth, untouched.
+
+    from .._creds import pick_healthy_account
+
+    picked = pick_healthy_account(pinned)
+    if picked == pinned:
+        return  # pinned is healthy — no rotation, no log line.
+
+    config.claude.account = picked
+    stream = log_stream if log_stream is not None else sys.stderr
+    print(
+        f"[sac:creds] agent '{config.name}' rotated account: "
+        f"{pinned!r} -> {picked!r} (pinned snapshot unhealthy; "
+        f"rotated to the first healthy stored account)",
+        file=stream,
+    )
+
+
+def _check_spec_source_drift_at_launch(
+    config_path: str, agent_name: str, strict_drift: bool | None
+) -> None:
+    """Run the launch-time drift check; warn loud (or block if strict).
+
+    Fully guarded: the underlying check never raises except the
+    deliberate strict-mode :class:`SpecSourceDriftError`. We let that
+    propagate (the CLI / caller turns it into a non-zero exit); any
+    other unexpected failure here is swallowed so a launch is never
+    crashed by the drift guard.
+    """
+    from .._drift import SpecSourceDriftError, warn_if_spec_source_drifted
+
+    strict = _resolve_strict_drift(strict_drift)
+    try:
+        warn_if_spec_source_drifted(config_path, agent=agent_name, strict=strict)
+    except SpecSourceDriftError:
+        # Deliberate strict-mode block — propagate so the caller exits
+        # non-zero. This is the ONE thing this guard is allowed to raise.
+        raise
+    except Exception:  # stx-allow: fallback (reason: the drift guard must NEVER crash a launch; any unexpected error degrades to "no check ran" and the agent proceeds)
+        traceback.print_exc()


### PR DESCRIPTION
## Why
Operator directive (fail loud, fail fast, no silent feedback). A neutral smoke agent that validated 0 errors and materialized `to_home` correctly still failed to boot — and `agent_start` raised a **cause-less** `RuntimeError("Failed to start agent")`: no underlying reason, no log, no tmux pane. The real boot failure (boot-drain timeout, auth, a broken in-container login shell, an immediate `claude` exit) was swallowed.

## What
- **Fail loud:** on `runtime.start() == False`, `agent_start` now captures the agent's tmux pane (`TmuxManager.capture_logs`) + `session_exists` and raises a descriptive `RuntimeError` instead of a bare one. Diagnostics are best-effort (never mask the failure).
- **Refactor (512-line limit):** `_start.py` was 544 lines. Extracted the four pre-flight helpers (`_verify_real_liveness`, `_resolve_strict_drift`, `_rotate_to_healthy_account`, `_check_spec_source_drift_at_launch`) into `_start_preflight.py`; `_start.py` re-exports them for back-compat (callers/tests import them from `_start`). Now 425 / 163 lines.

## Verify
- `_lifecycle` tests collect clean (456 items — imports resolve after the split).
- `test__start_drift.py` + `test__start_spawn_acl.py` pass (12). 
- Full `_lifecycle` suite not run to completion locally (the broker tests `test__broker_self.py` hang without a live broker on this host — environmental, not from this change); CI runs the full matrix.

## Note
A likely root cause the smoke test surfaced for the boot failure itself (separate from this fix): the in-SIF login shell hits `~/.bash_profile: /home/ywatanabe/.local/bin/env: No such file or directory`. With this fix, that will now be visible in the raised error's pane tail.