### PR TITLE
feat(config): builtin sac mcp + channel for every agent

### DIFF
--- a/src/scitex_agent_container/config/_loaders.py
+++ b/src/scitex_agent_container/config/_loaders.py
@@ -290,6 +290,25 @@ def load_v3(raw: dict, path: Path) -> AgentConfig:
     if not comms_spec.a2a.listen:
         a2a_spec = type(a2a_spec)(host=a2a_spec.host, port=None)
 
+    # Builtin sac control plane (operator directive 2026-06-16): EVERY agent
+    # gets the sac MCP tools server + the ``server:sac`` push channel so it can
+    # communicate (a2a / lineage). Without both, agents can't talk to each other
+    # or the lead. Injected by default; opt out per agent with the label
+    # ``sac-builtin: "off"``. Idempotent: skips if already declared (the spec's
+    # own entry/channel wins). Real wiring still happens downstream — apply_channels
+    # (SDK) / tui_channel_config (TUI) for the channel; the .mcp.json / options
+    # merge for the tools server.
+    _sac_optout = str(labels.get("sac-builtin", "")).strip().lower()
+    if _sac_optout not in ("off", "false", "0", "no"):
+        if "server:sac" not in {c.strip() for c in claude_spec.channels}:
+            claude_spec.channels.append("server:sac")
+        if "scitex-agent-container" not in mcp_servers:
+            mcp_servers["scitex-agent-container"] = {
+                "type": "stdio",
+                "command": "/opt/venv-sac/bin/sac",
+                "args": ["mcp", "start"],
+            }
+
     return AgentConfig(
         name=name,
         runtime=str(spec.get("runtime") or "tui"),

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -171,10 +171,11 @@ class TestLoadFullConfig:
     def test_full_loads_claude_channels(self, full_loaded_config):
         # Arrange
         config = full_loaded_config
-        # Act
+        # Act — server:sac is the builtin control-plane channel auto-injected
+        # by load_config for every agent (operator directive 2026-06-16).
         value = config.claude.channels
         # Assert
-        assert value == ["plugin:telegram@claude-plugins-official"]
+        assert value == ["plugin:telegram@claude-plugins-official", "server:sac"]
 
     def test_full_loads_claude_session(self, full_loaded_config):
         # Arrange

--- a/tests/scitex_agent_container/config/test__loaders.py
+++ b/tests/scitex_agent_container/config/test__loaders.py
@@ -576,3 +576,47 @@ def test_load_config_lineage_may_spawn_false_round_trips(tmp_path: Path) -> None
     cfg = load_config(p)
     # Assert
     assert cfg.lineage.may_spawn is False
+
+
+# ---------------------------------------------------------------------------
+# Builtin sac control plane (mcp + channel) — operator directive 2026-06-16
+# ---------------------------------------------------------------------------
+
+
+def test_load_config_injects_sac_channel_by_default(tmp_path: Path) -> None:
+    # Arrange
+    p = _v3_yaml(tmp_path, "sac-chan", {})
+    # Act
+    cfg = load_config(p)
+    # Assert
+    assert "server:sac" in cfg.claude.channels
+
+
+def test_load_config_injects_sac_mcp_server_by_default(tmp_path: Path) -> None:
+    # Arrange
+    p = _v3_yaml(tmp_path, "sac-mcp", {})
+    # Act
+    cfg = load_config(p)
+    # Assert
+    assert "scitex-agent-container" in cfg.mcp_servers
+
+
+def test_load_config_sac_builtin_optout_label_skips_channel(tmp_path: Path) -> None:
+    # Arrange
+    body = {
+        "apiVersion": "scitex-agent-container/v3",
+        "kind": "Agent",
+        "metadata": {"labels": {"sac-builtin": "off"}},
+        "spec": {
+            "runtime": "apptainer",
+            "workdir": str(tmp_path / "wd"),
+            "apptainer": {"image": "x.sif"},
+        },
+    }
+    p = tmp_path / "sac-off" / "spec.yaml"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(yaml.safe_dump(body))
+    # Act
+    cfg = load_config(p)
+    # Assert
+    assert "server:sac" not in cfg.claude.channels

--- a/tests/scitex_agent_container/runtimes/test__apptainer_build_argv.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_build_argv.py
@@ -108,6 +108,7 @@ kind: Agent
 metadata:
   labels:
     project: t
+    sac-builtin: "off"
 spec:
   runtime: tui
   workdir: /tmp/agt-work


### PR DESCRIPTION
## Why
Operator directive (2026-06-16): a SAC agent cannot communicate (a2a / lineage / lead) without sac. Today sac is hand-declared per agent — `scitex-agent-container` in `to_home/.mcp.json` + `server:sac` in `spec.claude.channels` — so it's boilerplate that agents can forget. Make it a **builtin**.

## What
`load_config` now injects, for every agent (unless already declared):
- the **`server:sac` push channel** (`claude.channels`) — receive a2a/bus events;
- the **`scitex-agent-container` MCP tools server** (`/opt/venv-sac/bin/sac mcp start`) — send/query via `agent_*`/`db_*`.

Idempotent (the spec's own entry/channel wins). **Opt out** per agent with `metadata.labels: { sac-builtin: "off" }`. Both runtimes pick it up downstream (SDK `apply_channels`, TUI `tui_channel_config`; the mcp merge for the tools server). SAC stays neutral — this is sac providing its OWN engine surface, not project knowledge.

## Tests
- 3 new loader tests: default channel injected, default mcp injected, opt-out label skips.
- Updated 2 exact-assertion tests for the new builtin (integration `test_full_loads_claude_channels`; the `_BASE_SPEC` argv unit fixture opts out to preserve its no-channel intent).
- Verified locally: config (468) + integration config (85) + runtime channel/mcp (129) all green. Full matrix on CI (broker tests need a live broker not present locally).

## Note
Injecting `server:sac` makes the bus bearer required at launch (existing fail-loud check in `_apptainer_listen_env`) — intended: sac is necessary infra. Agents that genuinely shouldn't have it use the opt-out label.