### PR TITLE
test(config): fix-forward develop red — expect builtin sac mcp on minimal spec

### DIFF
--- a/tests/integration/test_config_v2.py
+++ b/tests/integration/test_config_v2.py
@@ -307,13 +307,21 @@ class TestMinimalV3RuntimeWorkspace:
         # Assert
         assert value == "~/.scitex/agent-container/runtime/agents/test-agent"
 
-    def test_v1_minimal_mcp_servers_empty(self, v1_minimal_loaded_config):
+    def test_v1_minimal_mcp_servers_has_builtin_sac(self, v1_minimal_loaded_config):
+        """Builtin control plane (#415): a minimal spec with no MCP servers of
+        its own still gets exactly the sac tools server injected by default."""
         # Arrange
         config = v1_minimal_loaded_config
         # Act
         value = config.mcp_servers
         # Assert
-        assert value == {}
+        assert value == {
+            "scitex-agent-container": {
+                "type": "stdio",
+                "command": "/opt/venv-sac/bin/sac",
+                "args": ["mcp", "start"],
+            }
+        }
 
 
 @pytest.fixture


### PR DESCRIPTION
## Fix-forward: develop pytest matrix red after #415

PR #415 (`feat(config): builtin sac mcp + channel for every agent`) injects the sac control-plane MCP server (`scitex-agent-container`) into **every** agent by default (operator directive 2026-06-16: every sac agent must have sac MCP + channel to communicate).

The integration test `test_v1_minimal_mcp_servers_empty` still asserted an **empty** `mcp_servers` map for a bare v3 spec. After #415 merged, the full pytest matrix went red on develop:

```
tests/integration/test_config_v2.py::TestMinimalV3RuntimeWorkspace::test_v1_minimal_mcp_servers_empty
  AssertionError: assert {'scitex-agent-container': {...'type': 'stdio'}} == {}
```

Same single failure on py3.11 / py3.12 / py3.13 (run [27594820834](https://github.com/ywatanabe1989/scitex-agent-container/actions/runs/27594820834)).

### Change
Update the test to assert the **new invariant**: a minimal spec with no servers of its own gets exactly the builtin sac tools server. Renamed `test_v1_minimal_mcp_servers_empty` → `test_v1_minimal_mcp_servers_has_builtin_sac`.

### Verification
`PYTHONPATH=src .venv/bin/python -m pytest tests/integration/test_config_v2.py tests/scitex_agent_container/config/test__loaders.py` → **79 passed**. Swept the rest of the suite for other exact `mcp_servers ==`/`channels ==` assertions; the only other matches are CLI-arg namespace tests, unaffected by the loader injection.