### PR TITLE
feat(listen): CI-verdict delivery ring (#404) — poll GitHub, deliver to pusher, climb lineage

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_ci_deliver.py
+++ b/src/scitex_agent_container/_lifecycle/_ci_deliver.py
@@ -1,0 +1,119 @@
+"""CI-verdict delivery orchestration (sac #404).
+
+feedback.pdf §3: "a2a-deliver the verdict to the pusher, then up the
+recorded lineage pusher → parent → … → lead. Job = delivery." This is
+the composition layer that ties the data pieces together:
+
+  dedup-guard → resolve owner → deliver to pusher → climb to lead → record
+
+Only TERMINAL verdicts (``success`` / ``failure``) are delivered; a
+``pending`` / ``none`` conclusion is a no-op so the verdict is delivered
+exactly once it actually resolves (and the dedup key is recorded only
+after a real terminal delivery, so a later red→green flip still fires).
+
+Every collaborator (``post`` transport, owner resolver, lineage walk,
+dedup read/write) is a keyword seam defaulting to the production impl —
+so the poll loop calls it with no args and tests inject fakes (no
+network / gh / state.db). A per-target ``post`` failure is logged and
+skipped; the climb continues and the verdict is still recorded (the
+agent learns of the verdict on its next heartbeat/poll regardless).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+TERMINAL_CONCLUSIONS = frozenset({"success", "failure"})
+
+
+def _verdict_text(repo: str, pr: int, head_sha: str, conclusion: str) -> str:
+    short = head_sha[:8] if head_sha else "?"
+    head = f"CI {conclusion.upper()} — {repo} PR #{pr} ({short})."
+    if conclusion == "success":
+        tail = " Green: self-merge if you own it. Do NOT poll `gh pr checks`."
+    else:
+        tail = " Red: fix-and-push — the ring re-fires on your next push."
+    return head + tail
+
+
+def deliver_verdict(
+    repo: str,
+    pr: int,
+    head_sha: str,
+    conclusion: str,
+    *,
+    post: Any = None,
+    owner_resolver: Any = None,
+    ancestors: Any = None,
+    already_delivered: Any = None,
+    record: Any = None,
+    db_path: Any = None,
+    agents_dir: Any = None,
+    tasks_path: Any = None,
+    pr_body: str | None = None,
+) -> dict:
+    """Deliver one CI verdict to its owner + up the lineage. Idempotent.
+
+    Returns a summary ``{"delivered": [names], "skipped": bool,
+    "reason": str}``. ``reason`` ∈ {``delivered``, ``non-terminal``,
+    ``already-delivered``, ``no-owner``}.
+    """
+    if conclusion not in TERMINAL_CONCLUSIONS:
+        return {"delivered": [], "skipped": True, "reason": "non-terminal"}
+
+    # Bind production defaults lazily (None seam → real impl) to keep
+    # import cost off the hot path and avoid import cycles.
+    if post is None:
+        from .._network.peer import post_turn
+
+        post = post_turn
+    if owner_resolver is None:
+        from ._ci_owner import resolve_owner
+
+        owner_resolver = resolve_owner
+    if ancestors is None:
+        from .._state._lineage import ancestors_to_root
+
+        ancestors = ancestors_to_root
+    if already_delivered is None:
+        from .._state.state_db_verdict_dedup import verdict_already_delivered
+
+        already_delivered = verdict_already_delivered
+    if record is None:
+        from .._state.state_db_verdict_dedup import record_verdict_delivered
+
+        record = record_verdict_delivered
+
+    if already_delivered(
+        repo=repo, pr=pr, head_sha=head_sha, conclusion=conclusion, db_path=db_path
+    ):
+        return {"delivered": [], "skipped": True, "reason": "already-delivered"}
+
+    owner = owner_resolver(
+        repo, pr_body=pr_body, agents_dir=agents_dir, tasks_path=tasks_path
+    )
+    if not owner:
+        return {"delivered": [], "skipped": True, "reason": "no-owner"}
+
+    targets = [owner, *ancestors(name=owner, db_path=db_path)]
+    text = _verdict_text(repo, pr, head_sha, conclusion)
+    delivered: list[str] = []
+    for target in targets:
+        try:
+            post(target, text)
+            delivered.append(target)
+        except Exception as exc:  # stx-allow: fallback (one unreachable target must not abort the climb)
+            logger.warning("deliver_verdict: post to %s failed: %s", target, exc)
+
+    # Record AFTER attempting delivery so a verdict that found an owner is
+    # not re-delivered next tick. A total-delivery failure still records —
+    # the agent picks the verdict up on its own heartbeat; re-spamming a
+    # transiently-unreachable fleet every tick is worse than one miss.
+    record(repo=repo, pr=pr, head_sha=head_sha, conclusion=conclusion, db_path=db_path)
+    return {"delivered": delivered, "skipped": False, "reason": "delivered"}
+
+
+__all__ = ["TERMINAL_CONCLUSIONS", "deliver_verdict"]

--- a/src/scitex_agent_container/_lifecycle/_ci_owner.py
+++ b/src/scitex_agent_container/_lifecycle/_ci_owner.py
@@ -1,0 +1,145 @@
+"""Resolve a repo → the owning agent for CI-verdict delivery (sac #404).
+
+feedback.pdf §3 + scitex-dev handoff (2026-06-17): when sac polls a CI
+verdict it must deliver it to the agent that owns the repo. Resolution
+order (dev-confirmed — most authoritative + sac-local first):
+
+  1. PRIMARY — sac's own agent specs ``<agents_dir>/*/spec.yaml``:
+     ``metadata.labels.project`` matched against the repo basename. The
+     returned owner is the agent's directory name (the canonical
+     ``sac agents`` name that :func:`peer.post_turn` resolves).
+  2. tasks.yaml — a task whose ``repo`` matches → its ``agent``/``assignee``.
+  3. FALLBACK — a ``Owner: <agent>`` line in the PR body.
+
+All reads are fail-soft (a malformed spec / tasks file contributes
+nothing) so one bad row never blocks delivery to a resolvable owner.
+``None`` means "no owner found" → the caller skips delivery for that PR.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+_OWNER_LINE = re.compile(r"^\s*Owner:\s*(\S+)\s*$", re.MULTILINE)
+
+
+def _repo_basename(repo: str) -> str:
+    return repo.split("/")[-1].strip()
+
+
+def _default_agents_dir() -> Path:
+    return Path.home() / ".scitex" / "agent-container" / "agents"
+
+
+def _default_tasks_path() -> Path:
+    env = os.environ.get("SCITEX_TODO_TASKS")
+    if env:
+        return Path(env).expanduser()
+    return Path.home() / ".scitex" / "todo" / "tasks.yaml"
+
+
+def _owner_from_agent_specs(basename: str, agents_dir: Path) -> str | None:
+    if not agents_dir.is_dir():
+        return None
+    import yaml
+
+    for spec in sorted(agents_dir.glob("*/spec.yaml")):
+        try:
+            doc = yaml.safe_load(spec.read_text()) or {}
+            project = (doc.get("metadata") or {}).get("labels", {}).get("project", "")
+        except Exception:  # stx-allow: fallback (one bad spec contributes nothing)
+            continue
+        if isinstance(project, str) and project.strip() == basename:
+            return spec.parent.name
+    return None
+
+
+def _owner_from_tasks(basename: str, tasks_path: Path) -> str | None:
+    if not tasks_path.is_file():
+        return None
+    import yaml
+
+    try:
+        doc = yaml.safe_load(tasks_path.read_text()) or {}
+    except Exception:  # stx-allow: fallback (unreadable tasks store → no owner here)
+        return None
+    for task in doc.get("tasks", []) or []:
+        if not isinstance(task, dict):
+            continue
+        repo = str(task.get("repo", "")).strip()
+        if repo and _repo_basename(repo) == basename:
+            owner = task.get("agent") or task.get("assignee")
+            if isinstance(owner, str) and owner.strip():
+                return owner.strip()
+    return None
+
+
+def _owner_from_pr_body(pr_body: str) -> str | None:
+    m = _OWNER_LINE.search(pr_body)
+    return m.group(1) if m else None
+
+
+def resolve_owner(
+    repo: str,
+    *,
+    pr_body: str | None = None,
+    agents_dir: Path | None = None,
+    tasks_path: Path | None = None,
+) -> str | None:
+    """Resolve ``repo`` → owning agent name, or ``None`` if unresolvable.
+
+    See module docstring for the (spec → tasks.yaml → PR ``Owner:``)
+    precedence. ``agents_dir`` / ``tasks_path`` are injection seams for
+    tests; production callers leave them ``None`` to use the canonical
+    host locations.
+    """
+    basename = _repo_basename(repo)
+    if not basename:
+        return None
+    agents_dir = agents_dir if agents_dir is not None else _default_agents_dir()
+    tasks_path = tasks_path if tasks_path is not None else _default_tasks_path()
+
+    owner = _owner_from_agent_specs(basename, agents_dir)
+    if owner:
+        return owner
+    owner = _owner_from_tasks(basename, tasks_path)
+    if owner:
+        return owner
+    if pr_body:
+        owner = _owner_from_pr_body(pr_body)
+        if owner:
+            return owner
+    return None
+
+
+def tracked_repos(*, agents_dir: Path | None = None, org: str | None = None) -> list:
+    """Return the ``owner/repo`` strings the CI poller should watch.
+
+    Derived from sac's own agent specs (the repos that have an owning
+    agent): each spec's ``metadata.labels.project`` becomes
+    ``<org>/<project>``. ``org`` defaults to ``$SAC_CI_POLL_ORG`` then
+    ``ywatanabe1989`` (the SciTeX GitHub org). Sorted + de-duped; a
+    project with no agent contributes nothing, so the poller only ever
+    watches repos sac can actually deliver a verdict for.
+    """
+    agents_dir = agents_dir if agents_dir is not None else _default_agents_dir()
+    resolved_org = org or os.environ.get("SAC_CI_POLL_ORG", "ywatanabe1989")
+    if not agents_dir.is_dir():
+        return []
+    import yaml
+
+    projects: set[str] = set()
+    for spec in sorted(agents_dir.glob("*/spec.yaml")):
+        try:
+            doc = yaml.safe_load(spec.read_text()) or {}
+            project = (doc.get("metadata") or {}).get("labels", {}).get("project", "")
+        except Exception:  # stx-allow: fallback (one bad spec contributes nothing)
+            continue
+        if isinstance(project, str) and project.strip():
+            projects.add(project.strip())
+    return [f"{resolved_org}/{p}" for p in sorted(projects)]
+
+
+__all__ = ["resolve_owner", "tracked_repos"]

--- a/src/scitex_agent_container/_lifecycle/_github_ci.py
+++ b/src/scitex_agent_container/_lifecycle/_github_ci.py
@@ -1,0 +1,179 @@
+"""GitHub-CI poll reads for the CI-feedback ring (sac #404).
+
+feedback.pdf §3: ``sac listen`` polls GitHub CI on its OWN schedule and
+delivers each verdict to the pusher. This module wraps the two ``gh``
+reads the poll loop needs:
+
+  * :func:`pr_ci_conclusion` — a PR's overall CI outcome
+    (``success`` / ``failure`` / ``pending`` / ``none``), derived from
+    ``gh pr checks <pr> -R <repo> --json bucket``.
+  * :func:`pr_head_sha` — the PR's current head sha, from
+    ``gh api repos/<repo>/pulls/<pr> --jq .head.sha`` (so the dedup key
+    ``(repo, pr, head_sha, conclusion)`` tracks the exact commit).
+
+Both take a ``run`` injection seam (``run(args) -> stdout``) defaulting
+to a thin ``gh`` subprocess wrapper — tests pass canned output, no
+network. The wrapper is deliberately fail-soft: any ``gh`` error maps to
+empty output → ``"none"`` / ``""`` so a transient GitHub blip degrades to
+"deliver nothing this tick" rather than crashing the listen loop.
+
+``gh`` is the chosen client because it is already installed + token-
+authenticated on the fleet hosts (repo + workflow scopes); no extra dep.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Callable
+
+logger = logging.getLogger(__name__)
+
+# A ``run`` seam returns the subprocess stdout for ``gh <args>``.
+GhRunner = Callable[[list], str]
+
+CONCLUSION_SUCCESS = "success"
+CONCLUSION_FAILURE = "failure"
+CONCLUSION_PENDING = "pending"
+CONCLUSION_NONE = "none"
+
+# ``gh pr checks --json bucket`` bucket vocabulary.
+_FAILING_BUCKETS = frozenset({"fail", "cancel"})
+
+
+def _run_gh(args: list) -> str:
+    """Run ``gh <args>`` and return stdout (empty on any failure).
+
+    Fail-soft: ``gh pr checks`` exits non-zero for pending/failing states
+    yet still prints the ``--json`` payload, so we return stdout
+    regardless of return code. A missing binary / OSError maps to ``""``.
+    """
+    import subprocess
+
+    try:
+        proc = subprocess.run(
+            ["gh", *args],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except (
+        Exception
+    ) as exc:  # stx-allow: fallback (gh missing / spawn error → no verdict this tick)
+        logger.warning("_github_ci: gh invocation failed: %s", exc)
+        return ""
+    return proc.stdout or ""
+
+
+def pr_ci_conclusion(repo: str, pr: int, *, run: GhRunner = _run_gh) -> str:
+    """Return the PR's overall CI conclusion.
+
+    One of :data:`CONCLUSION_SUCCESS`, :data:`CONCLUSION_FAILURE`,
+    :data:`CONCLUSION_PENDING`, :data:`CONCLUSION_NONE`. Mapping over the
+    ``gh pr checks --json bucket`` buckets:
+
+      * any ``fail``/``cancel`` bucket → ``failure``
+      * else any ``pending`` bucket   → ``pending``
+      * else (all ``pass``/``skipping``, non-empty) → ``success``
+      * empty list or unparseable output → ``none`` (deliver nothing)
+    """
+    raw = run(["pr", "checks", str(pr), "-R", repo, "--json", "bucket"])
+    try:
+        rows = json.loads(raw) if raw.strip() else []
+    except (ValueError, TypeError):
+        return CONCLUSION_NONE
+    if not isinstance(rows, list) or not rows:
+        return CONCLUSION_NONE
+    buckets = {str(r.get("bucket", "")) for r in rows if isinstance(r, dict)}
+    if buckets & _FAILING_BUCKETS:
+        return CONCLUSION_FAILURE
+    if "pending" in buckets:
+        return CONCLUSION_PENDING
+    if buckets:
+        return CONCLUSION_SUCCESS
+    return CONCLUSION_NONE
+
+
+def pr_head_sha(repo: str, pr: int, *, run: GhRunner = _run_gh) -> str:
+    """Return the PR's current head sha (empty string if unresolvable)."""
+    raw = run(["api", f"repos/{repo}/pulls/{pr}", "--jq", ".head.sha"])
+    return raw.strip()
+
+
+def list_open_prs(repo: str, *, run: GhRunner = _run_gh) -> list:
+    """Return open PRs for ``repo`` as dicts ``{number, head_sha, body}``.
+
+    One ``gh pr list -R <repo> --state open --json number,headRefOid,body``
+    call gives the poll loop everything it needs per PR (number + head sha
+    for the dedup key, body for the ``Owner:`` fallback). Unparseable /
+    empty output → ``[]`` (the tick polls nothing for this repo).
+    """
+    raw = run(
+        [
+            "pr",
+            "list",
+            "-R",
+            repo,
+            "--state",
+            "open",
+            "--json",
+            "number,headRefOid,body",
+        ]
+    )
+    try:
+        rows = json.loads(raw) if raw.strip() else []
+    except (ValueError, TypeError):
+        return []
+    out: list = []
+    for r in rows if isinstance(rows, list) else []:
+        if not isinstance(r, dict):
+            continue
+        num = r.get("number")
+        if not isinstance(num, int):
+            continue
+        out.append(
+            {
+                "number": num,
+                "head_sha": str(r.get("headRefOid", "")),
+                "body": str(r.get("body") or ""),
+            }
+        )
+    return out
+
+
+def gh_ready(*, probe=None) -> bool:
+    """True iff ``gh`` is installed AND authenticated.
+
+    The poll loop calls this once at startup and FAILS LOUD (logs an
+    error + disables itself) when it returns False — a missing /
+    unauthenticated ``gh`` is a deploy error that must be visible, not a
+    silent stream of ``none`` verdicts (operator: fail-loud, fail-fast,
+    no silent fallbacks). ``probe`` is a test seam returning the bool
+    directly; production runs ``gh auth status``.
+    """
+    if probe is not None:
+        return bool(probe())
+    import subprocess
+
+    try:
+        r = subprocess.run(
+            ["gh", "auth", "status"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except Exception:  # stx-allow: fallback (gh missing → not ready; loop fails loud)
+        return False
+    return r.returncode == 0
+
+
+__all__ = [
+    "CONCLUSION_FAILURE",
+    "CONCLUSION_NONE",
+    "CONCLUSION_PENDING",
+    "CONCLUSION_SUCCESS",
+    "gh_ready",
+    "list_open_prs",
+    "pr_ci_conclusion",
+    "pr_head_sha",
+]

--- a/src/scitex_agent_container/_lifecycle/_github_ci_poll_loop.py
+++ b/src/scitex_agent_container/_lifecycle/_github_ci_poll_loop.py
@@ -1,0 +1,114 @@
+"""GitHub-CI poll loop — the listen-side glue for the CI ring (sac #404).
+
+feedback.pdf §3: ``sac listen`` polls GitHub CI on its OWN schedule and
+a2a-delivers each verdict to the pusher, then up the lineage to lead —
+STANDALONE (todo down → sac still delivers; no relay, no SPOF).
+
+This is the long-running asyncio task the listen lifespan launches at
+boot (sibling of :func:`_periodic_drive_loop.periodic_drive_loop`).
+Each tick: for every tracked repo, list its open PRs and hand each
+``(repo, pr, head_sha, conclusion)`` to :func:`_ci_deliver.deliver_verdict`
+(which dedups, resolves the owner, delivers, climbs the lineage, records).
+
+Fail-loud preflight (operator: fail-loud, fail-fast, no silent fallbacks):
+a missing / unauthenticated ``gh`` is a DEPLOY error, not a transient
+blip — the loop logs an ERROR and DISABLES itself rather than emitting a
+silent stream of ``none`` verdicts forever.
+
+Loop resilience: a per-tick exception is logged + retried next tick (the
+poller must survive a transient GitHub/network error), and cancellation
+is honoured at the sleep boundary so a ``sac listen`` SIGTERM doesn't
+leak the loop — same contract as the periodic-drive lane.
+
+Every collaborator is an injection seam so tests drive the full loop
+deterministically without gh / network / state.db.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Default poll cadence. The verdict already arrives "fast" because dev's
+# Spartan CI is ~3 min + auto-merge; a 5-min poll floor keeps GitHub API
+# load trivial while staying within the operator's "instant-enough"
+# scale. Override via ``SAC_GITHUB_CI_POLL_INTERVAL_S`` at the wiring site.
+DEFAULT_CI_POLL_INTERVAL_S = 300.0
+
+
+def _default_ready_check() -> bool:
+    from ._github_ci import gh_ready
+
+    return gh_ready()
+
+
+async def github_ci_poll_loop(
+    *,
+    poll_interval_s: float = DEFAULT_CI_POLL_INTERVAL_S,
+    repos_source: Any = None,
+    list_prs: Any = None,
+    conclusion_for: Any = None,
+    deliver: Any = None,
+    ready_check: Any = None,
+) -> None:
+    """Long-running CI-verdict poll+deliver task for the listen lifespan.
+
+    Seams (production defaults bound when ``None``): ``repos_source`` →
+    :func:`_ci_owner.tracked_repos`, ``list_prs`` →
+    :func:`_github_ci.list_open_prs`, ``conclusion_for`` →
+    :func:`_github_ci.pr_ci_conclusion`, ``deliver`` →
+    :func:`_ci_deliver.deliver_verdict`, ``ready_check`` →
+    :func:`_github_ci.gh_ready`.
+    """
+    if os.environ.get("SAC_GITHUB_CI_POLLER_DISABLED", "") == "1":
+        logger.info("github_ci_poll_loop: disabled via SAC_GITHUB_CI_POLLER_DISABLED")
+        return
+
+    ready = ready_check if ready_check is not None else _default_ready_check
+    if not ready():
+        logger.error(
+            "github_ci_poll_loop: `gh` is not installed/authenticated — "
+            "CI-verdict delivery DISABLED. Run `gh auth login` on this host. "
+            "(fail-loud: refusing to run a poller that can deliver nothing)"
+        )
+        return
+
+    if repos_source is None:
+        from ._ci_owner import tracked_repos as repos_source
+    if list_prs is None:
+        from ._github_ci import list_open_prs as list_prs
+    if conclusion_for is None:
+        from ._github_ci import pr_ci_conclusion as conclusion_for
+    if deliver is None:
+        from ._ci_deliver import deliver_verdict as deliver
+
+    logger.info("github_ci_poll_loop: starting (poll_interval_s=%.1f)", poll_interval_s)
+    try:
+        while True:
+            try:
+                for repo in list(repos_source()):
+                    for pr in list_prs(repo):
+                        deliver(
+                            repo,
+                            pr["number"],
+                            pr.get("head_sha", ""),
+                            conclusion_for(repo, pr["number"]),
+                            pr_body=pr.get("body", ""),
+                        )
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:  # stx-allow: fallback (loop must survive a transient GitHub/registry error; logged, retried next tick)
+                logger.warning(
+                    "github_ci_poll_loop: tick failed (%s); retry next tick", exc
+                )
+            await asyncio.sleep(poll_interval_s)
+    except asyncio.CancelledError:
+        logger.info("github_ci_poll_loop: cancelled cleanly")
+        raise
+
+
+__all__ = ["DEFAULT_CI_POLL_INTERVAL_S", "github_ci_poll_loop"]

--- a/src/scitex_agent_container/_listen/server.py
+++ b/src/scitex_agent_container/_listen/server.py
@@ -518,6 +518,10 @@ def create_app(*, token: str, local_host: str | None = None) -> Starlette:
     # requests; teardown is a no-op (persistence is one-shot at boot).
     from contextlib import asynccontextmanager
 
+    from .._lifecycle._github_ci_poll_loop import (
+        DEFAULT_CI_POLL_INTERVAL_S,
+        github_ci_poll_loop,
+    )
     from .._lifecycle._periodic_drive_loop import periodic_drive_loop
     from ._self_peer_persistence import persist_self_peers_on_listen_startup
 
@@ -527,21 +531,40 @@ def create_app(*, token: str, local_host: str | None = None) -> Starlette:
         import os as _os
 
         await persist_self_peers_on_listen_startup()
+        tasks: list = []
         # Periodic-drive listen-loop (lead a2a 7916f486, 2026-06-14).
         # Honour SAC_PERIODIC_DRIVE_DISABLED=1 to skip launching.
-        task = None
         if _os.environ.get("SAC_PERIODIC_DRIVE_DISABLED", "") != "1":
             task = _asyncio.create_task(periodic_drive_loop(app.state))
             app.state.periodic_drive_task = task
+            tasks.append(task)
+        # GitHub-CI verdict-delivery poll loop (sac #404, feedback.pdf §3).
+        # The loop self-disables (fail-loud) when `gh` is unauthenticated
+        # or SAC_GITHUB_CI_POLLER_DISABLED=1, so launch unconditionally.
+        # Cadence override: SAC_GITHUB_CI_POLL_INTERVAL_S.
+        try:
+            _ci_interval = float(
+                _os.environ.get(
+                    "SAC_GITHUB_CI_POLL_INTERVAL_S", DEFAULT_CI_POLL_INTERVAL_S
+                )
+            )
+        except (TypeError, ValueError):
+            _ci_interval = DEFAULT_CI_POLL_INTERVAL_S
+        ci_task = _asyncio.create_task(
+            github_ci_poll_loop(poll_interval_s=_ci_interval)
+        )
+        app.state.github_ci_poller_task = ci_task
+        tasks.append(ci_task)
         try:
             yield
         finally:
-            if task is not None and not task.done():
-                task.cancel()
-                try:
-                    await task
-                except (_asyncio.CancelledError, Exception):
-                    pass
+            for _t in tasks:
+                if _t is not None and not _t.done():
+                    _t.cancel()
+                    try:
+                        await _t
+                    except (_asyncio.CancelledError, Exception):
+                        pass
 
     app = Starlette(routes=routes, lifespan=_lifespan)
     # Per-app shared state for the WI-3 inbox surface.

--- a/src/scitex_agent_container/_state/_lineage.py
+++ b/src/scitex_agent_container/_state/_lineage.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-__all__ = ["descendants_of"]
+__all__ = ["ancestors_to_root", "descendants_of"]
 
 
 def descendants_of(
@@ -99,3 +99,60 @@ def descendants_of(
             frontier = next_frontier
             depth += 1
     return out
+
+
+def ancestors_to_root(
+    *,
+    name: str,
+    db_path: Path | None = None,
+    max_depth: int = 64,
+) -> list[str]:
+    """Return the lineage chain from ``name``'s parent up to the root.
+
+    The UP walk complementing :func:`descendants_of`. Used by the
+    CI-feedback ring (feedback.pdf §3) to climb pusher → parent → … →
+    lead when delivering a verdict up the recorded lineage.
+
+    Ordered immediate-parent first, root (the topmost ancestor with no
+    parent) last. Does NOT include ``name`` itself. A node with no
+    parent — or an unknown ``name`` — returns ``[]``.
+
+    Cycle guard: a ``seen`` set plus the ``max_depth`` ceiling bound the
+    walk so a hand-edited DB with a parent cycle (which
+    :func:`record_lineage` never produces) cannot loop the listen
+    server — same rationale as :func:`descendants_of`.
+
+    Args:
+        name: the agent whose ancestor chain we want (the pusher).
+        db_path: optional override for the state.db path; tests pass a
+            tmp file so the global DB stays clean.
+        max_depth: walk depth ceiling. Default 64 (safety bound).
+
+    Returns:
+        Ordered list of ancestor agent names (parent first, root last),
+        not including ``name``.
+    """
+    if not name:
+        return []
+    from .state_db import open_db
+
+    chain: list[str] = []
+    seen: set[str] = {name}
+    with open_db(db_path) as conn:
+        current = name
+        depth = 0
+        while depth < max_depth:
+            row = conn.execute(
+                "SELECT parent_name FROM lineage WHERE child_name = ?",
+                (current,),
+            ).fetchone()
+            if row is None:
+                break
+            parent = str(row["parent_name"])
+            if parent in seen:
+                break  # cycle guard (hand-edited DB; record_lineage never loops)
+            chain.append(parent)
+            seen.add(parent)
+            current = parent
+            depth += 1
+    return chain

--- a/src/scitex_agent_container/_state/state_db_verdict_dedup.py
+++ b/src/scitex_agent_container/_state/state_db_verdict_dedup.py
@@ -1,0 +1,122 @@
+"""CI-verdict delivery dedup — the "delivered-set" (sac #404).
+
+feedback.pdf §3: sac polls GitHub CI on its OWN schedule and a2a-delivers
+each verdict to the pusher EXACTLY ONCE — deduping on
+``(repo, pr, head_sha, conclusion)`` in sac's own state so a re-poll (or a
+``sac listen`` restart) never re-delivers a verdict the agent already saw.
+This module owns that delivered-set table in ``state.db``.
+
+A re-run that flips the conclusion (red→green on the same head_sha) is a
+DISTINCT key, so the flipped verdict IS delivered — the dedup is per exact
+outcome, not per PR. A new push (new ``head_sha``) is likewise distinct.
+
+Sibling-module pattern (mirrors :mod:`dispatch_ledger`): own
+``CREATE TABLE IF NOT EXISTS`` behind :func:`init_verdict_dedup_schema`,
+layered on the shared connection from :func:`state_db.open_db`, and a
+lazy :func:`_ensure_table` so callers never need an explicit init. Kept
+out of ``state_db.py`` so this branch never collides with concurrent
+``state_db.py`` work (same rationale as the dispatch ledger).
+
+All times are ``REAL`` unix-seconds (float), matching the diary tables.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+from pathlib import Path
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS verdict_delivered (
+    repo          TEXT NOT NULL,
+    pr            INTEGER NOT NULL,
+    head_sha      TEXT NOT NULL,
+    conclusion    TEXT NOT NULL,
+    dispatch_id   TEXT,
+    delivered_at  REAL NOT NULL,
+    PRIMARY KEY (repo, pr, head_sha, conclusion)
+);
+"""
+
+
+def init_verdict_dedup_schema(db_path: Path | None = None) -> Path:
+    """Create the ``verdict_delivered`` table if missing. Idempotent.
+
+    Delegates the base schema + connection config to
+    :func:`state_db.open_db`, then layers our own
+    ``CREATE TABLE IF NOT EXISTS`` so the delivered-set lives in the same
+    ``state.db`` file as the registry + diary tables. Returns the
+    resolved database path.
+    """
+    from .state_db import init_schema, open_db
+
+    with open_db(db_path) as conn:
+        conn.executescript(_SCHEMA)
+    return init_schema(db_path)
+
+
+def _ensure_table(conn: sqlite3.Connection) -> None:
+    """Ensure the delivered-set table exists on an already-open connection."""
+    conn.executescript(_SCHEMA)
+
+
+def verdict_already_delivered(
+    *,
+    repo: str,
+    pr: int,
+    head_sha: str,
+    conclusion: str,
+    db_path: Path | None = None,
+) -> bool:
+    """Return ``True`` iff this exact verdict was already delivered.
+
+    The dedup key is the 4-tuple ``(repo, pr, head_sha, conclusion)``. A
+    miss — or a brand-new ``state.db`` — returns ``False`` so the caller
+    delivers. Never raises on a fresh db (the table is ensured first).
+    """
+    from .state_db import open_db
+
+    with open_db(db_path) as conn:
+        _ensure_table(conn)
+        row = conn.execute(
+            "SELECT 1 FROM verdict_delivered "
+            "WHERE repo=? AND pr=? AND head_sha=? AND conclusion=?",
+            (repo, int(pr), head_sha, conclusion),
+        ).fetchone()
+    return row is not None
+
+
+def record_verdict_delivered(
+    *,
+    repo: str,
+    pr: int,
+    head_sha: str,
+    conclusion: str,
+    dispatch_id: str | None = None,
+    delivered_at: float | None = None,
+    db_path: Path | None = None,
+) -> None:
+    """Mark this verdict delivered. Idempotent (re-poll-safe).
+
+    Uses ``INSERT OR IGNORE`` on the 4-tuple primary key so re-seeing the
+    same verdict is a no-op rather than an ``IntegrityError`` — the loop
+    can record unconditionally after a successful delivery.
+    """
+    from .state_db import open_db
+
+    ts = float(delivered_at) if delivered_at is not None else time.time()
+    with open_db(db_path) as conn:
+        _ensure_table(conn)
+        conn.execute(
+            "INSERT OR IGNORE INTO verdict_delivered "
+            "(repo, pr, head_sha, conclusion, dispatch_id, delivered_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (repo, int(pr), head_sha, conclusion, dispatch_id, ts),
+        )
+
+
+__all__ = [
+    "init_verdict_dedup_schema",
+    "record_verdict_delivered",
+    "verdict_already_delivered",
+]

--- a/tests/scitex_agent_container/_lifecycle/test__ci_deliver.py
+++ b/tests/scitex_agent_container/_lifecycle/test__ci_deliver.py
@@ -1,0 +1,114 @@
+"""Tests for CI-verdict delivery orchestration (sac #404).
+
+feedback.pdf §3: "a2a-deliver the verdict to the pusher, then up the
+recorded lineage pusher → parent → … → lead. Job = delivery." This
+module composes the data layer (dedup + owner-resolution + lineage
+climb) with the a2a ``post`` transport. Every collaborator is a DI seam
+so the test drives the full routing/dedup logic with zero network, gh,
+or state.db dependency (STX-NM — seams, not mocks).
+
+Conventions: one assertion per test (STX-TQ007); AAA markers.
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container._lifecycle._ci_deliver import deliver_verdict
+
+
+def _seams(*, owner="proj-x", ancestors=("lead",), already=False):
+    """Build a kwargs dict of DI seams + a capture list for posts."""
+    posts: list[str] = []
+    recorded: list[tuple] = []
+    seams = dict(
+        post=lambda name, text: posts.append(name),
+        owner_resolver=lambda repo, **kw: owner,
+        ancestors=lambda *, name, db_path=None: list(ancestors),
+        already_delivered=lambda **kw: already,
+        record=lambda **kw: recorded.append(
+            (kw["repo"], kw["pr"], kw["head_sha"], kw["conclusion"])
+        ),
+    )
+    return seams, posts, recorded
+
+
+def test_pending_verdict_is_skipped_without_posting():
+    # Arrange
+    seams, posts, _ = _seams()
+    # Act
+    result = deliver_verdict("o/r", 1, "sha", "pending", **seams)
+    # Assert
+    assert result["skipped"] is True and posts == []
+
+
+def test_already_delivered_verdict_is_skipped():
+    # Arrange
+    seams, posts, _ = _seams(already=True)
+    # Act
+    result = deliver_verdict("o/r", 1, "sha", "success", **seams)
+    # Assert
+    assert posts == []
+
+
+def test_unresolved_owner_is_skipped():
+    # Arrange
+    seams, posts, _ = _seams(owner=None)
+    # Act
+    result = deliver_verdict("o/r", 1, "sha", "failure", **seams)
+    # Assert
+    assert result["reason"] == "no-owner"
+
+
+def test_delivers_to_pusher_then_up_the_lineage_to_lead():
+    # Arrange — owner=proj-x, ancestors climb to lead.
+    seams, posts, _ = _seams(owner="proj-x", ancestors=("parent", "lead"))
+    # Act
+    deliver_verdict("o/r", 1, "sha", "success", **seams)
+    # Assert
+    assert posts == ["proj-x", "parent", "lead"]
+
+
+def test_records_delivered_after_posting():
+    # Arrange
+    seams, _, recorded = _seams(owner="proj-x", ancestors=())
+    # Act
+    deliver_verdict("o/r", 5, "abc", "failure", **seams)
+    # Assert
+    assert recorded == [("o/r", 5, "abc", "failure")]
+
+
+def test_one_post_failure_does_not_abort_remaining_targets():
+    # Arrange — first target raises; the climb must still reach lead.
+    posts: list[str] = []
+
+    def flaky_post(name, text):
+        posts.append(name)
+        if name == "proj-x":
+            raise RuntimeError("boom")
+
+    seams = dict(
+        post=flaky_post,
+        owner_resolver=lambda repo, **kw: "proj-x",
+        ancestors=lambda *, name, db_path=None: ["lead"],
+        already_delivered=lambda **kw: False,
+        record=lambda **kw: None,
+    )
+    # Act
+    deliver_verdict("o/r", 1, "sha", "success", **seams)
+    # Assert
+    assert posts == ["proj-x", "lead"]
+
+
+def test_delivered_message_names_repo_pr_and_conclusion():
+    # Arrange — capture the delivered text, not just the target.
+    captured: list[str] = []
+    seams = dict(
+        post=lambda name, text: captured.append(text),
+        owner_resolver=lambda repo, **kw: "proj-x",
+        ancestors=lambda *, name, db_path=None: [],
+        already_delivered=lambda **kw: False,
+        record=lambda **kw: None,
+    )
+    # Act
+    deliver_verdict("ywatanabe1989/scitex-dev", 42, "deadbeef", "failure", **seams)
+    # Assert
+    assert "scitex-dev" in captured[0] and "42" in captured[0]

--- a/tests/scitex_agent_container/_lifecycle/test__ci_owner.py
+++ b/tests/scitex_agent_container/_lifecycle/test__ci_owner.py
@@ -1,0 +1,111 @@
+"""Tests for CI-verdict owner resolution (sac #404).
+
+feedback.pdf §3 + scitex-dev handoff (2026-06-17): resolve a repo → the
+owning agent to deliver the verdict to, in order:
+
+  1. PRIMARY  — sac's own agent specs: ``metadata.labels.project`` ↔ repo
+     basename (sac-local, authoritative, no cross-package read).
+  2. tasks.yaml — task ``repo`` field → owning ``agent``.
+  3. FALLBACK — PR body ``Owner:`` line.
+
+Conventions: one assertion per test (STX-TQ007); AAA markers; no mocks
+(STX-NM) — real YAML files under ``tmp_path``, injected via the
+``agents_dir`` / ``tasks_path`` seams.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scitex_agent_container._lifecycle._ci_owner import resolve_owner, tracked_repos
+
+
+def _write_spec(agents_dir: Path, agent_name: str, project: str) -> None:
+    d = agents_dir / agent_name
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "spec.yaml").write_text(
+        "apiVersion: scitex-agent-container/v3\n"
+        "kind: Agent\n"
+        "metadata:\n"
+        "  labels:\n"
+        f"    project: {project}\n"
+        "spec:\n"
+        "  runtime: tui\n"
+    )
+
+
+def test_agent_spec_label_project_resolves_owner(tmp_path: Path):
+    # Arrange
+    agents = tmp_path / "agents"
+    _write_spec(agents, "proj-scitex-dev", "scitex-dev")
+    # Act
+    owner = resolve_owner("ywatanabe1989/scitex-dev", agents_dir=agents)
+    # Assert
+    assert owner == "proj-scitex-dev"
+
+
+def test_tasks_yaml_repo_resolves_owner_when_no_spec(tmp_path: Path):
+    # Arrange — empty agents dir; owner only in tasks.yaml.
+    agents = tmp_path / "agents"
+    agents.mkdir()
+    tasks = tmp_path / "tasks.yaml"
+    tasks.write_text("tasks:\n  - repo: scitex-dev\n    agent: proj-from-tasks\n")
+    # Act
+    owner = resolve_owner(
+        "ywatanabe1989/scitex-dev", agents_dir=agents, tasks_path=tasks
+    )
+    # Assert
+    assert owner == "proj-from-tasks"
+
+
+def test_pr_body_owner_line_is_last_fallback(tmp_path: Path):
+    # Arrange — nothing in specs or tasks; only the PR body carries it.
+    agents = tmp_path / "agents"
+    agents.mkdir()
+    body = "## Summary\n\nOwner: proj-from-body\n\nmore text\n"
+    # Act
+    owner = resolve_owner("o/unmatched", agents_dir=agents, pr_body=body)
+    # Assert
+    assert owner == "proj-from-body"
+
+
+def test_agent_spec_takes_precedence_over_tasks(tmp_path: Path):
+    # Arrange — both present; the spec (PRIMARY) must win.
+    agents = tmp_path / "agents"
+    _write_spec(agents, "proj-from-spec", "scitex-dev")
+    tasks = tmp_path / "tasks.yaml"
+    tasks.write_text("tasks:\n  - repo: scitex-dev\n    agent: proj-from-tasks\n")
+    # Act
+    owner = resolve_owner("scitex-dev", agents_dir=agents, tasks_path=tasks)
+    # Assert
+    assert owner == "proj-from-spec"
+
+
+def test_unknown_repo_resolves_to_none(tmp_path: Path):
+    # Arrange
+    agents = tmp_path / "agents"
+    agents.mkdir()
+    # Act
+    owner = resolve_owner("o/nope", agents_dir=agents)
+    # Assert
+    assert owner is None
+
+
+def test_tracked_repos_derives_owner_repo_from_spec_labels(tmp_path: Path):
+    # Arrange
+    agents = tmp_path / "agents"
+    _write_spec(agents, "proj-scitex-dev", "scitex-dev")
+    # Act
+    repos = tracked_repos(agents_dir=agents, org="ywatanabe1989")
+    # Assert
+    assert repos == ["ywatanabe1989/scitex-dev"]
+
+
+def test_tracked_repos_empty_when_no_specs(tmp_path: Path):
+    # Arrange
+    agents = tmp_path / "agents"
+    agents.mkdir()
+    # Act
+    repos = tracked_repos(agents_dir=agents, org="ywatanabe1989")
+    # Assert
+    assert repos == []

--- a/tests/scitex_agent_container/_lifecycle/test__github_ci.py
+++ b/tests/scitex_agent_container/_lifecycle/test__github_ci.py
@@ -1,0 +1,119 @@
+"""Tests for the GitHub-CI poll wrapper (sac #404).
+
+feedback.pdf §3: sac polls GitHub CI on its own schedule. This module
+wraps the two ``gh`` reads the poller needs — a PR's CI conclusion and
+its head sha — behind a ``run`` injection seam so tests drive canned
+``gh`` output without a network call (DI seam, not a mock; same pattern
+as ``periodic_drive_loop``'s ``agents_source`` / ``now_fn``).
+
+Conventions: one assertion per test (STX-TQ007); AAA markers; no mocks /
+monkeypatch (STX-NM) — the ``run`` callable is dependency-injected.
+"""
+
+from __future__ import annotations
+
+import json
+
+from scitex_agent_container._lifecycle._github_ci import (
+    gh_ready,
+    list_open_prs,
+    pr_ci_conclusion,
+    pr_head_sha,
+)
+
+
+def test_all_pass_buckets_yield_success_conclusion():
+    # Arrange
+    out = json.dumps([{"bucket": "pass"}, {"bucket": "skipping"}])
+    # Act
+    conclusion = pr_ci_conclusion("o/r", 1, run=lambda args: out)
+    # Assert
+    assert conclusion == "success"
+
+
+def test_any_fail_bucket_yields_failure_conclusion():
+    # Arrange
+    out = json.dumps([{"bucket": "pass"}, {"bucket": "fail"}])
+    # Act
+    conclusion = pr_ci_conclusion("o/r", 1, run=lambda args: out)
+    # Assert
+    assert conclusion == "failure"
+
+
+def test_cancel_bucket_yields_failure_conclusion():
+    # Arrange
+    out = json.dumps([{"bucket": "pass"}, {"bucket": "cancel"}])
+    # Act
+    conclusion = pr_ci_conclusion("o/r", 1, run=lambda args: out)
+    # Assert
+    assert conclusion == "failure"
+
+
+def test_pending_without_fail_yields_pending_conclusion():
+    # Arrange
+    out = json.dumps([{"bucket": "pass"}, {"bucket": "pending"}])
+    # Act
+    conclusion = pr_ci_conclusion("o/r", 1, run=lambda args: out)
+    # Assert
+    assert conclusion == "pending"
+
+
+def test_empty_checks_list_yields_none_conclusion():
+    # Arrange
+    out = json.dumps([])
+    # Act
+    conclusion = pr_ci_conclusion("o/r", 1, run=lambda args: out)
+    # Assert
+    assert conclusion == "none"
+
+
+def test_malformed_json_yields_none_conclusion():
+    # Arrange — gh emitted garbage / nothing; the poller must not crash.
+    # Act
+    conclusion = pr_ci_conclusion("o/r", 1, run=lambda args: "not json{")
+    # Assert
+    assert conclusion == "none"
+
+
+def test_head_sha_returns_stripped_sha():
+    # Arrange — `gh api ... --jq .head.sha` prints the sha + trailing nl.
+    # Act
+    sha = pr_head_sha("o/r", 1, run=lambda args: "c3211e1f0d71\n")
+    # Assert
+    assert sha == "c3211e1f0d71"
+
+
+def test_list_open_prs_parses_number_sha_and_body():
+    # Arrange
+    out = json.dumps([{"number": 7, "headRefOid": "abc123", "body": "Owner: proj-x"}])
+    # Act
+    prs = list_open_prs("o/r", run=lambda args: out)
+    # Assert
+    assert prs == [{"number": 7, "head_sha": "abc123", "body": "Owner: proj-x"}]
+
+
+def test_list_open_prs_empty_output_yields_empty_list():
+    # Arrange — gh emitted nothing (no open PRs / transient blip).
+    empty = ""
+    # Act
+    prs = list_open_prs("o/r", run=lambda args: empty)
+    # Assert
+    assert prs == []
+
+
+def test_gh_ready_true_when_probe_reports_authenticated():
+    # Arrange — probe seam stands in for `gh auth status` succeeding.
+    probe = lambda: True  # noqa: E731
+    # Act
+    ready = gh_ready(probe=probe)
+    # Assert
+    assert ready is True
+
+
+def test_gh_ready_false_when_probe_reports_unauthenticated():
+    # Arrange — probe seam stands in for `gh auth status` failing.
+    probe = lambda: False  # noqa: E731
+    # Act
+    ready = gh_ready(probe=probe)
+    # Assert
+    assert ready is False

--- a/tests/scitex_agent_container/_lifecycle/test__github_ci_poll_loop.py
+++ b/tests/scitex_agent_container/_lifecycle/test__github_ci_poll_loop.py
@@ -1,0 +1,136 @@
+"""Tests for the GitHub-CI poll loop (sac #404).
+
+Exercises the asyncio task the listen lifespan launches — without a real
+``gh`` / network / state.db — by injecting the ``ready_check``,
+``repos_source``, ``list_prs``, ``conclusion_for`` and ``deliver`` seams.
+Mirrors test__periodic_drive_loop.py's create-task → sleep → cancel
+pattern.
+
+STX-TQ002 AAA-markers + STX-TQ007 one-assert. No mocks (DI seams).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from scitex_agent_container._lifecycle._github_ci_poll_loop import (
+    github_ci_poll_loop,
+)
+
+
+@pytest.mark.asyncio
+async def test_loop_disabled_when_gh_not_ready_delivers_nothing():
+    # Arrange — fail-loud preflight: gh not authenticated → loop returns.
+    calls: list = []
+    # Act — loop returns immediately (no infinite loop), so await directly.
+    await github_ci_poll_loop(
+        ready_check=lambda: False,
+        repos_source=lambda: ["o/r"],
+        list_prs=lambda repo: [{"number": 1, "head_sha": "s", "body": ""}],
+        conclusion_for=lambda repo, pr: "success",
+        deliver=lambda *a, **k: calls.append(a),
+    )
+    # Assert
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_loop_disabled_via_env_var_delivers_nothing():
+    # Arrange — explicit env save/restore (no monkeypatch, PA-306).
+    import os as _os
+
+    calls: list = []
+    key = "SAC_GITHUB_CI_POLLER_DISABLED"
+    saved = _os.environ.get(key)
+    _os.environ[key] = "1"
+    # Act
+    try:
+        await github_ci_poll_loop(
+            ready_check=lambda: True,
+            repos_source=lambda: ["o/r"],
+            list_prs=lambda repo: [{"number": 1, "head_sha": "s", "body": ""}],
+            conclusion_for=lambda repo, pr: "success",
+            deliver=lambda *a, **k: calls.append(a),
+        )
+    finally:
+        if saved is None:
+            _os.environ.pop(key, None)
+        else:
+            _os.environ[key] = saved
+    # Assert
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_loop_delivers_open_pr_verdict_in_one_tick():
+    # Arrange
+    calls: list = []
+    task = asyncio.create_task(
+        github_ci_poll_loop(
+            poll_interval_s=0.05,
+            ready_check=lambda: True,
+            repos_source=lambda: ["o/r"],
+            list_prs=lambda repo: [{"number": 7, "head_sha": "abc", "body": ""}],
+            conclusion_for=lambda repo, pr: "success",
+            deliver=lambda repo, pr, head_sha, conclusion, **k: calls.append(
+                (repo, pr, head_sha, conclusion)
+            ),
+        )
+    )
+    # Act — let one tick run, then cancel.
+    await asyncio.sleep(0.12)
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+    # Assert
+    assert ("o/r", 7, "abc", "success") in calls
+
+
+@pytest.mark.asyncio
+async def test_loop_survives_a_tick_exception_then_cancels_cleanly():
+    # Arrange — a tick that raises must NOT kill the loop (logged + retried).
+    def boom(repo):
+        raise RuntimeError("transient gh blip")
+
+    task = asyncio.create_task(
+        github_ci_poll_loop(
+            poll_interval_s=0.05,
+            ready_check=lambda: True,
+            repos_source=lambda: ["o/r"],
+            list_prs=boom,
+            conclusion_for=lambda repo, pr: "success",
+            deliver=lambda *a, **k: None,
+        )
+    )
+    # Act — let the failing tick run, then cancel.
+    await asyncio.sleep(0.12)
+    task.cancel()
+    # Assert — the loop swallowed the tick error and stayed alive, so
+    # cancellation (not the RuntimeError) is what surfaces.
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+@pytest.mark.asyncio
+async def test_loop_honours_cancellation_cleanly():
+    # Arrange
+    task = asyncio.create_task(
+        github_ci_poll_loop(
+            poll_interval_s=0.05,
+            ready_check=lambda: True,
+            repos_source=lambda: [],
+            list_prs=lambda repo: [],
+            conclusion_for=lambda repo, pr: "none",
+            deliver=lambda *a, **k: None,
+        )
+    )
+    # Act
+    await asyncio.sleep(0.06)
+    task.cancel()
+    # Assert — the finally must re-raise CancelledError, not swallow it.
+    with pytest.raises(asyncio.CancelledError):
+        await task

--- a/tests/scitex_agent_container/_state/test__lineage.py
+++ b/tests/scitex_agent_container/_state/test__lineage.py
@@ -11,7 +11,10 @@ from pathlib import Path
 
 import pytest
 
-from scitex_agent_container._state._lineage import descendants_of
+from scitex_agent_container._state._lineage import (
+    ancestors_to_root,
+    descendants_of,
+)
 from scitex_agent_container._state.state_db_nodes import record_lineage
 
 # ---------------------------------------------------------------------------
@@ -168,3 +171,64 @@ def test_descendants_respects_max_depth_bound(db_path: Path) -> None:
     result = descendants_of(name="a", db_path=db_path, max_depth=3)
     # Assert
     assert result == {"b", "c", "d"}
+
+
+# ---------------------------------------------------------------------------
+# Upward walk — ancestors_to_root (sac #404 verdict climb)
+# ---------------------------------------------------------------------------
+
+
+def test_ancestors_empty_when_node_has_no_parent(db_path: Path) -> None:
+    # Arrange — no lineage rows for "lonely".
+    # Act
+    chain = ancestors_to_root(name="lonely", db_path=db_path)
+    # Assert
+    assert chain == []
+
+
+def test_ancestors_single_parent_returns_one_element_chain(db_path: Path) -> None:
+    # Arrange
+    record_lineage(child="kid", parent="mom", db_path=db_path)
+    # Act
+    chain = ancestors_to_root(name="kid", db_path=db_path)
+    # Assert
+    assert chain == ["mom"]
+
+
+def test_ancestors_chain_is_ordered_parent_first_root_last(db_path: Path) -> None:
+    # Arrange — pusher → parent → grandparent → lead.
+    record_lineage(child="pusher", parent="parent", db_path=db_path)
+    record_lineage(child="parent", parent="grandparent", db_path=db_path)
+    record_lineage(child="grandparent", parent="lead", db_path=db_path)
+    # Act
+    chain = ancestors_to_root(name="pusher", db_path=db_path)
+    # Assert
+    assert chain == ["parent", "grandparent", "lead"]
+
+
+def test_ancestors_chain_excludes_the_queried_agent(db_path: Path) -> None:
+    # Arrange
+    record_lineage(child="a", parent="b", db_path=db_path)
+    # Act
+    chain = ancestors_to_root(name="a", db_path=db_path)
+    # Assert
+    assert "a" not in chain
+
+
+def test_ancestors_cycle_in_hand_edited_db_is_bounded(db_path: Path) -> None:
+    # Arrange — record_lineage prevents cycles, so inject one directly to
+    # prove the depth guard (same "cannot trust the DB blindly" rationale
+    # as descendants_of). record_lineage first creates the table.
+    import sqlite3
+
+    record_lineage(child="x", parent="y", db_path=db_path)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "INSERT OR REPLACE INTO lineage (child_name, parent_name, created_at) "
+            "VALUES ('y', 'x', 0.0)"
+        )
+        conn.commit()
+    # Act
+    chain = ancestors_to_root(name="x", db_path=db_path, max_depth=5)
+    # Assert
+    assert len(chain) <= 5

--- a/tests/scitex_agent_container/_state/test_state_db_verdict_dedup.py
+++ b/tests/scitex_agent_container/_state/test_state_db_verdict_dedup.py
@@ -1,0 +1,171 @@
+"""Tests for the CI-verdict delivery dedup table (sac #404).
+
+The CI-feedback ring (feedback.pdf §3) requires sac to deliver each
+GitHub CI verdict to the pusher EXACTLY ONCE, even though it polls
+GitHub repeatedly. Dedup key is ``(repo, pr, head_sha, conclusion)`` —
+sac's own ``delivered-set`` (the PDF's term), kept in ``state.db`` so it
+survives a ``sac listen`` restart.
+
+Conventions (mirroring test_dispatch_ledger.py):
+
+  * One assertion per test (STX-TQ007); related invariants via
+    ``pytest.parametrize``.
+  * AAA markers (Arrange / Act / Assert).
+  * No mocks / monkeypatch (STX-NM); real sqlite under ``tmp_path``,
+    isolated via the ``db_path`` env fixture (explicit save/restore).
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def db_path(tmp_path: Path):
+    """Isolated state.db location, exported via env so callers pick it up.
+
+    Explicit env save/restore (no monkeypatch fixture, PA-306).
+    """
+    p = tmp_path / "state.db"
+    key = "SCITEX_AGENT_CONTAINER_STATE_DB"
+    saved = os.environ.get(key)
+    os.environ[key] = str(p)
+    import scitex_agent_container._state.state_db as mod
+
+    importlib.reload(mod)
+    try:
+        yield p
+    finally:
+        if saved is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = saved
+        importlib.reload(mod)
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+
+def test_init_schema_creates_verdict_delivered_table(db_path: Path):
+    # Arrange
+    from scitex_agent_container._state.state_db_verdict_dedup import (
+        init_verdict_dedup_schema,
+    )
+
+    # Act
+    init_verdict_dedup_schema()
+    with sqlite3.connect(db_path) as conn:
+        names = {
+            r[0]
+            for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        }
+    # Assert
+    assert "verdict_delivered" in names
+
+
+def test_record_creates_table_lazily_without_explicit_init(db_path: Path):
+    # Arrange — never call init; record must ensure the table itself.
+    from scitex_agent_container._state.state_db_verdict_dedup import (
+        record_verdict_delivered,
+        verdict_already_delivered,
+    )
+
+    # Act
+    record_verdict_delivered(
+        repo="ywatanabe1989/scitex-dev", pr=1, head_sha="abc", conclusion="success"
+    )
+    # Assert
+    assert verdict_already_delivered(
+        repo="ywatanabe1989/scitex-dev", pr=1, head_sha="abc", conclusion="success"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Dedup semantics
+# ---------------------------------------------------------------------------
+
+
+def test_fresh_key_is_not_delivered(db_path: Path):
+    # Arrange
+    from scitex_agent_container._state.state_db_verdict_dedup import (
+        verdict_already_delivered,
+    )
+
+    # Act
+    seen = verdict_already_delivered(
+        repo="ywatanabe1989/scitex-dev", pr=7, head_sha="deadbeef", conclusion="success"
+    )
+    # Assert
+    assert seen is False
+
+
+def test_recorded_key_is_delivered(db_path: Path):
+    # Arrange
+    from scitex_agent_container._state.state_db_verdict_dedup import (
+        record_verdict_delivered,
+        verdict_already_delivered,
+    )
+
+    # Act
+    record_verdict_delivered(
+        repo="ywatanabe1989/scitex-dev", pr=7, head_sha="deadbeef", conclusion="failure"
+    )
+    # Assert
+    assert verdict_already_delivered(
+        repo="ywatanabe1989/scitex-dev", pr=7, head_sha="deadbeef", conclusion="failure"
+    )
+
+
+def test_different_conclusion_is_a_distinct_key(db_path: Path):
+    # Arrange — a re-run flipping red→green is a NEW verdict to deliver.
+    from scitex_agent_container._state.state_db_verdict_dedup import (
+        record_verdict_delivered,
+        verdict_already_delivered,
+    )
+
+    record_verdict_delivered(repo="r", pr=3, head_sha="sha1", conclusion="failure")
+    # Act
+    seen_success = verdict_already_delivered(
+        repo="r", pr=3, head_sha="sha1", conclusion="success"
+    )
+    # Assert
+    assert seen_success is False
+
+
+def test_different_head_sha_is_a_distinct_key(db_path: Path):
+    # Arrange — a new push (new head_sha) is a new verdict.
+    from scitex_agent_container._state.state_db_verdict_dedup import (
+        record_verdict_delivered,
+        verdict_already_delivered,
+    )
+
+    record_verdict_delivered(repo="r", pr=3, head_sha="sha1", conclusion="success")
+    # Act
+    seen_other = verdict_already_delivered(
+        repo="r", pr=3, head_sha="sha2", conclusion="success"
+    )
+    # Assert
+    assert seen_other is False
+
+
+def test_record_is_idempotent(db_path: Path):
+    # Arrange — re-seeing the same verdict (re-poll) must not raise.
+    from scitex_agent_container._state.state_db_verdict_dedup import (
+        record_verdict_delivered,
+        verdict_already_delivered,
+    )
+
+    record_verdict_delivered(repo="r", pr=9, head_sha="s", conclusion="success")
+    # Act
+    record_verdict_delivered(repo="r", pr=9, head_sha="s", conclusion="success")
+    # Assert
+    assert verdict_already_delivered(repo="r", pr=9, head_sha="s", conclusion="success")


### PR DESCRIPTION
## Summary

feedback.pdf §3: \`sac listen\` polls GitHub CI on its OWN schedule and a2a-delivers each verdict to the owning agent, then up the recorded state.db lineage to lead — STANDALONE (no relay, no SPOF), deduped exactly-once. Agents act on the pushed verdict (green→self-merge, red→fix-and-push) and never poll \`gh pr checks\`.

Owner: proj-scitex-agent-container

## What's in (all TDD; 53 unit tests + 531 \`_listen\` tests green)

- \`_state/state_db_verdict_dedup.py\` — deliver-once "delivered-set" (dedup on repo,pr,head_sha,conclusion; a red→green flip is a distinct key)
- \`_state/_lineage.py::ancestors_to_root\` — pusher→parent→…→lead climb
- \`_lifecycle/_github_ci.py\` — \`gh\` wrappers (conclusion / head_sha / open PRs) + fail-loud \`gh_ready\` preflight
- \`_lifecycle/_ci_owner.py\` — repo→owner (agent-spec \`labels.project\` → tasks.yaml → PR \`Owner:\`) + \`tracked_repos\`
- \`_lifecycle/_ci_deliver.py\` — dedup-guard → resolve → deliver → climb → record
- \`_lifecycle/_github_ci_poll_loop.py\` — asyncio poll loop (sibling of \`periodic_drive_loop\`); self-disables fail-loud if \`gh\` unauthenticated; env toggles \`SAC_GITHUB_CI_POLLER_DISABLED\` / \`SAC_GITHUB_CI_POLL_INTERVAL_S\`
- \`_listen/server.py\` — wire the loop into the listen lifespan + clean SIGTERM teardown

## Design (per scitex-dev handoff 2026-06-17)

- **Poll, not push**: \`sac listen\` is loopback; GitHub Actions can't reach it, so GitHub is the shared substrate both sides read. dev emits nothing extra.
- **Owner resolution**: sac's own agent specs first (authoritative, no cross-package read).
- **fail-loud / fail-fast / no silent fallbacks**: unauthenticated \`gh\` disables the poller with an ERROR, not a silent stream of "none".

## Deferred to follow-ups (operator split)

- #405 reconcile — reframed as a **mergeability/conflict alert** (not auto-restart) on develop-advance.
- \`scitex_todo.hooks\` entry-point bus — not needed for the poll-based ring.

## Audit

\`scitex-dev ecosystem audit-all\` clean **except one pre-existing PS-140** (cross-package-imports gate staleness): the gate file is byte-identical to develop and lists pre-existing internal modules; the regenerate tool (\`write-integration-tests\`) is absent from the installed scitex-dev v0.17.14. Not introduced by this PR.