### PR TITLE
fix(a2a): `sac a2a list` fails loud, never a raw traceback (unblocks todo CI)

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_a2a_list_fetch.py
+++ b/src/scitex_agent_container/cli_pkg/_a2a_list_fetch.py
@@ -1,0 +1,90 @@
+"""Fetch + parse the `/agents` registry for ``sac a2a list`` — fail-loud, no traceback.
+
+scitex-dev handoff (2026-06-17): on the Spartan runner host (bm159, fresh env,
+``~/.local/bin/sac``) ``sac a2a list --json`` exited 1 with an unhandled
+TRACEBACK, so scitex-todo's ``/fleet/mesh`` view (which shells out to it) 500'd
+and blocked CI. Root cause: the inline request in ``a2a_group.a2a_list`` only
+caught ``urllib.error.URLError`` — a socket timeout (``TimeoutError``) on a
+loaded runner, or a non-JSON body, escaped as a raw traceback.
+
+This module extracts the network + parse step behind a DI ``opener`` seam so it
+is unit-testable without a real server, and maps EVERY failure mode
+(connection refused / DNS / HTTP error / timeout / OS error / non-JSON / odd
+shape) to a single :class:`A2aListError`. The caller turns that into one clean
+``SystemExit`` line — fail-loud, no silent fallback, and never a raw traceback
+that breaks a machine-readable caller.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from typing import Any, Callable
+
+
+class A2aListError(Exception):
+    """Clean, message-carrying failure for ``sac a2a list`` (→ ``SystemExit``)."""
+
+
+def parse_agents_response(raw: Any) -> list:
+    """Parse a ``/agents`` response body into the agents list. Fail-loud.
+
+    Accepts ``bytes`` or ``str``. Raises :class:`A2aListError` on a non-JSON
+    body, a non-object payload, or an ``agents`` field that is not a list —
+    so a 502 HTML page / truncated body / schema drift fails with a clear
+    message instead of a downstream ``KeyError``/``JSONDecodeError`` traceback.
+    """
+    text = raw.decode() if isinstance(raw, (bytes, bytearray)) else raw
+    try:
+        payload = json.loads(text)
+    except (ValueError, TypeError) as exc:  # JSONDecodeError ⊂ ValueError
+        raise A2aListError(
+            f"listen returned a non-JSON /agents body ({type(exc).__name__}: {exc})"
+        ) from exc
+    if not isinstance(payload, dict):
+        raise A2aListError(
+            f"listen returned a non-object /agents body ({type(payload).__name__})"
+        )
+    agents = payload.get("agents", [])
+    if not isinstance(agents, list):
+        raise A2aListError(
+            f"listen /agents 'agents' field is not a list ({type(agents).__name__})"
+        )
+    return agents
+
+
+def fetch_agents(
+    url: str,
+    token: str,
+    *,
+    opener: Callable[..., Any] | None = None,
+    timeout: float = 6.0,
+) -> list:
+    """``GET <url>/agents`` with the bearer token; return the agents list.
+
+    Maps every reach/read failure — ``URLError`` (incl. ``HTTPError``),
+    ``TimeoutError``/``socket.timeout``, and any other ``OSError`` — to
+    :class:`A2aListError`, then delegates body parsing to
+    :func:`parse_agents_response` (which fail-louds on bad JSON/shape). The
+    result: ``sac a2a list`` never emits a raw traceback on a degraded host.
+
+    ``opener`` is a DI seam (default :func:`urllib.request.urlopen`) so the
+    error mapping is unit-testable with no real network.
+    """
+    opener = opener or urllib.request.urlopen
+    req = urllib.request.Request(url.rstrip("/") + "/agents")
+    req.add_header("Authorization", f"Bearer {token}")
+    try:
+        with opener(req, timeout=timeout) as resp:
+            raw = resp.read()
+    except urllib.error.URLError as exc:
+        raise A2aListError(f"cannot reach listen at {url}: {exc}") from exc
+    except (TimeoutError, OSError) as exc:  # socket.timeout, conn reset, ...
+        raise A2aListError(
+            f"listen at {url} did not respond ({type(exc).__name__}: {exc})"
+        ) from exc
+    return parse_agents_response(raw)
+
+
+__all__ = ["A2aListError", "fetch_agents", "parse_agents_response"]

--- a/src/scitex_agent_container/cli_pkg/a2a_group.py
+++ b/src/scitex_agent_container/cli_pkg/a2a_group.py
@@ -484,10 +484,7 @@ def a2a_grants(as_json: bool) -> None:
     "--url",
     "base_url",
     default=None,
-    help=(
-        "Listen base URL. Default: $SAC_LISTEN_BASE_URL or "
-        "http://127.0.0.1:7878."
-    ),
+    help=("Listen base URL. Default: $SAC_LISTEN_BASE_URL or http://127.0.0.1:7878."),
 )
 def a2a_list(as_json: bool, base_url: str | None) -> None:
     """List every peer registered on the local ``sac listen`` (the a2a registry).
@@ -509,9 +506,7 @@ def a2a_list(as_json: bool, base_url: str | None) -> None:
 
     from .._listen.tokens import default_token_path, read_token
 
-    url = base_url or os.environ.get(
-        "SAC_LISTEN_BASE_URL", "http://127.0.0.1:7878"
-    )
+    url = base_url or os.environ.get("SAC_LISTEN_BASE_URL", "http://127.0.0.1:7878")
     token = os.environ.get("SAC_LISTEN_BEARER")
     if not token:
         token = read_token(default_token_path())
@@ -522,17 +517,18 @@ def a2a_list(as_json: bool, base_url: str | None) -> None:
             "Is `sac listen` running on this host?"
         )
 
-    req = urllib.request.Request(url.rstrip("/") + "/agents")
-    req.add_header("Authorization", f"Bearer {token}")
-    try:
-        with urllib.request.urlopen(req, timeout=6.0) as resp:
-            payload = json.loads(resp.read().decode())
-    except urllib.error.URLError as exc:
-        raise SystemExit(
-            f"sac a2a list: cannot reach listen at {url}: {exc}"
-        ) from exc
+    # Fail-loud, no raw traceback: fetch_agents maps every reach/read/parse
+    # failure (URLError, socket timeout, OSError, non-JSON / odd body) to one
+    # clean A2aListError. The inline version only caught URLError, so a socket
+    # timeout on a loaded runner or a non-JSON body crashed UNHANDLED and broke
+    # callers shelling out to `sac a2a list --json` (scitex-dev 2026-06-17:
+    # Spartan runner bm159 → todo /fleet/mesh 500'd → CI blocked).
+    from ._a2a_list_fetch import A2aListError, fetch_agents
 
-    agents = payload.get("agents", [])
+    try:
+        agents = fetch_agents(url, token)
+    except A2aListError as exc:
+        raise SystemExit(f"sac a2a list: {exc}") from exc
     if as_json:
         click.echo(json.dumps(agents, ensure_ascii=False))
         return

--- a/tests/scitex_agent_container/cli_pkg/test__a2a_list_fetch.py
+++ b/tests/scitex_agent_container/cli_pkg/test__a2a_list_fetch.py
@@ -1,0 +1,142 @@
+"""Tests for `sac a2a list`'s fetch+parse — fail-loud, never a raw traceback.
+
+Regression: on a fresh / loaded runner host (scitex-dev handoff 2026-06-17,
+Spartan bm159) `sac a2a list --json` exited 1 with a TRACEBACK — the inline
+request only caught ``urllib.error.URLError``, so a socket timeout
+(``TimeoutError``) or a non-JSON body (``json.JSONDecodeError``) crashed
+unhandled, breaking callers that shell out to it (todo's `/fleet/mesh`).
+Every failure mode must map to a clean ``A2aListError`` (→ one-line SystemExit).
+
+Conventions: one assert per test (STX-TQ007 — a ``pytest.raises`` block IS
+the one assertion); AAA markers (STX-TQ002); no mocks (STX-NM) — the opener
+is dependency-injected (a plain callable seam).
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+
+import pytest
+from scitex_agent_container.cli_pkg._a2a_list_fetch import (
+    A2aListError,
+    fetch_agents,
+    parse_agents_response,
+)
+
+
+class _FakeResp:
+    """Minimal context-manager stand-in for an http response."""
+
+    def __init__(self, body: bytes) -> None:
+        self._body = body
+
+    def __enter__(self) -> "_FakeResp":
+        return self
+
+    def __exit__(self, *_a: object) -> bool:
+        return False
+
+    def read(self) -> bytes:
+        return self._body
+
+
+def _opener_returning(body: bytes):
+    def _open(req, timeout=None):  # noqa: ANN001
+        return _FakeResp(body)
+
+    return _open
+
+
+def _opener_raising(exc: BaseException):
+    def _open(req, timeout=None):  # noqa: ANN001
+        raise exc
+
+    return _open
+
+
+# --- parse_agents_response ---------------------------------------------------
+
+
+def test_parse_valid_body_returns_agents_list():
+    # Arrange
+    body = json.dumps({"agents": [{"name": "a"}]}).encode()
+    # Act
+    agents = parse_agents_response(body)
+    # Assert
+    assert agents == [{"name": "a"}]
+
+
+def test_parse_missing_agents_key_returns_empty_list():
+    # Arrange
+    body = json.dumps({}).encode()
+    # Act
+    agents = parse_agents_response(body)
+    # Assert
+    assert agents == []
+
+
+def test_parse_non_json_body_raises_a2a_list_error():
+    # Arrange
+    body = b"<html>502 Bad Gateway</html>"
+    # Act
+    # Assert
+    with pytest.raises(A2aListError):
+        parse_agents_response(body)
+
+
+def test_parse_non_object_json_raises_a2a_list_error():
+    # Arrange — a bare array is not the expected {"agents": [...]} object.
+    body = json.dumps([1, 2, 3]).encode()
+    # Act
+    # Assert
+    with pytest.raises(A2aListError):
+        parse_agents_response(body)
+
+
+# --- fetch_agents (injected opener) ------------------------------------------
+
+
+def test_fetch_returns_agents_on_valid_response():
+    # Arrange
+    body = json.dumps({"agents": [{"name": "lead"}]}).encode()
+    # Act
+    agents = fetch_agents("http://x:7878", "tok", opener=_opener_returning(body))
+    # Assert
+    assert agents == [{"name": "lead"}]
+
+
+def test_fetch_maps_socket_timeout_to_a2a_list_error():
+    # Arrange — the bug: TimeoutError was NOT caught by `except URLError`.
+    opener = _opener_raising(TimeoutError("timed out"))
+    # Act
+    # Assert
+    with pytest.raises(A2aListError):
+        fetch_agents("http://x:7878", "tok", opener=opener)
+
+
+def test_fetch_maps_urlerror_to_a2a_list_error():
+    # Arrange — connection refused / DNS failure.
+    opener = _opener_raising(urllib.error.URLError("conn refused"))
+    # Act
+    # Assert
+    with pytest.raises(A2aListError):
+        fetch_agents("http://x:7878", "tok", opener=opener)
+
+
+def test_fetch_maps_oserror_to_a2a_list_error():
+    # Arrange — generic socket / OS error mid-read.
+    opener = _opener_raising(OSError("reset by peer"))
+    # Act
+    # Assert
+    with pytest.raises(A2aListError):
+        fetch_agents("http://x:7878", "tok", opener=opener)
+
+
+def test_fetch_maps_bad_json_response_to_a2a_list_error():
+    # Arrange — listen reachable but returns garbage.
+    opener = _opener_returning(b"not json{")
+    # Act
+    # Assert
+    with pytest.raises(A2aListError):
+        fetch_agents("http://x:7878", "tok", opener=opener)

--- a/tests/scitex_agent_container/cli_pkg/test_a2a_group.py
+++ b/tests/scitex_agent_container/cli_pkg/test_a2a_group.py
@@ -377,6 +377,31 @@ def test_serve_rejects_missing_yaml_path(tmp_path: Path) -> None:
     assert res.exit_code != 0
 
 
+def test_a2a_list_fails_loud_when_listen_unreachable() -> None:
+    # Arrange -- bearer present (passes the token gate), but listen points at a
+    # dead port. a2a_list must FAIL LOUD (clean exit), not a raw traceback
+    # (scitex-dev 2026-06-17: a timeout/non-JSON on the runner crashed unhandled
+    # and 500'd todo's mesh view). Explicit env save/restore (no monkeypatch).
+    saved_url = os.environ.get("SAC_LISTEN_BASE_URL")
+    saved_tok = os.environ.get("SAC_LISTEN_BEARER")
+    os.environ["SAC_LISTEN_BASE_URL"] = "http://127.0.0.1:1"
+    os.environ["SAC_LISTEN_BEARER"] = "test-token"
+    # Act
+    try:
+        res = CliRunner().invoke(a2a, ["list", "--json"])
+    finally:
+        for _key, _saved in (
+            ("SAC_LISTEN_BASE_URL", saved_url),
+            ("SAC_LISTEN_BEARER", saved_tok),
+        ):
+            if _saved is None:
+                os.environ.pop(_key, None)
+            else:
+                os.environ[_key] = _saved
+    # Assert
+    assert res.exit_code != 0
+
+
 # ---------------------------------------------------------------------------
 # a2a_serve -- live subprocess smoke (mirrors tests/e2e pattern)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

scitex-dev handoff (2026-06-17): on the Spartan runner (bm159, fresh env, \`~/.local/bin/sac\`), \`sac a2a list --json\` exited 1 with an **unhandled traceback** → scitex-todo's \`/fleet/mesh\` (which shells out to it) **500'd → blocked #208 CI**.

Owner: proj-scitex-agent-container

## Root cause

\`a2a_list\`'s inline request caught only \`urllib.error.URLError\`. A **socket timeout** (\`TimeoutError\`) on a loaded runner, or a **non-JSON body**, escaped unhandled → raw traceback → non-zero exit with garbage on stdout, breaking machine-readable callers.

## Fix

Extract fetch+parse into \`cli_pkg/_a2a_list_fetch.py\` (DI \`opener\` seam) that maps **every** reach/read/parse failure — \`URLError\`/\`HTTPError\`, \`TimeoutError\`/\`socket.timeout\`, \`OSError\`, non-JSON, odd shape — to one \`A2aListError\` → a single clean \`SystemExit\` line. **Fail-loud, no silent fallback, never a raw traceback.** Mirrors the already-robust handling at \`a2a_group.py:218\`.

## Tests

- 9 new unit tests (\`test__a2a_list_fetch.py\`) — timeout/URLError/OSError/non-JSON/odd-shape → \`A2aListError\`; valid → list.
- 52 a2a CLI tests green; ruff clean.

(Note: pre-existing PS-140 cross-package-imports-gate staleness on this repo is unrelated to this PR.)