### PR TITLE
feat(to_home): fail-loud deep-merge of .mcp.json across the baseline overlay (W1)

### DIFF
--- a/src/scitex_agent_container/runtimes/_mcp_merge.py
+++ b/src/scitex_agent_container/runtimes/_mcp_merge.py
@@ -1,0 +1,50 @@
+"""Fail-loud deep-merge of two `.mcp.json` docs (W1 — operator 2026-06-17).
+
+`runtimes/_to_home.deploy_to_home` is a two-pass overlay (shared baseline
+`_shared/to_home/` → per-agent `to_home/`). For most files the per-agent layer
+full-overwrites the baseline. For `.mcp.json` that is WRONG: it would silently
+drop the baseline's default servers (sac / scitex-todo / claude-code-telegrammer)
+for any agent that ships its own `.mcp.json`.
+
+This module deep-merges the two `mcpServers` maps instead — every agent inherits
+the defaults AND keeps its own servers. A genuine conflict (same server name,
+two different definitions) **fails loud** via :class:`McpMergeConflict`; we never
+silently pick a winner (operator: fail-fast, fail-loud, no silent fallbacks).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class McpMergeConflict(Exception):
+    """A server name is defined two different ways across baseline + agent."""
+
+
+def merge_mcp_json(baseline: dict, overlay: dict) -> dict:
+    """Return ``baseline`` deep-merged with ``overlay``.
+
+    * ``mcpServers`` — union by name. Disjoint names combine; an identical
+      same-name definition is kept once (idempotent); a CONFLICTING same-name
+      definition raises :class:`McpMergeConflict`.
+    * Other top-level keys — ``overlay`` wins where present, else ``baseline``
+      is preserved.
+    """
+    merged: dict[str, Any] = dict(baseline)
+    servers: dict[str, Any] = dict(baseline.get("mcpServers") or {})
+    for name, defn in (overlay.get("mcpServers") or {}).items():
+        if name in servers and servers[name] != defn:
+            raise McpMergeConflict(
+                f"mcpServers['{name}'] is defined differently in the shared "
+                f"baseline and the per-agent .mcp.json — resolve it explicitly "
+                f"(baseline={servers[name]!r}, agent={defn!r})."
+            )
+        servers[name] = defn
+    for key, value in overlay.items():
+        if key != "mcpServers":
+            merged[key] = value
+    merged["mcpServers"] = servers
+    return merged
+
+
+__all__ = ["McpMergeConflict", "merge_mcp_json"]

--- a/src/scitex_agent_container/runtimes/_to_home.py
+++ b/src/scitex_agent_container/runtimes/_to_home.py
@@ -54,6 +54,7 @@ content — see ``_to_home_errors.py`` for context.
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import re
@@ -63,10 +64,12 @@ from datetime import datetime
 from pathlib import Path
 
 from ..config import AgentConfig
+from ._mcp_merge import merge_mcp_json
 from ._symlink_resolve import DanglingToHomeSymlinkError, deref_copy_symlink
 from ._to_home_errors import (
     WorkspaceCLAUDEMarkerError,
     WorkspaceCredentialLeakError,
+    WorkspaceMcpMergeError,
 )
 from ._to_home_text import (
     END_MARKER,
@@ -91,6 +94,13 @@ _interpolate_metadata = interpolate_metadata
 # Files that get marker-protected merge semantics (vs. full overwrite).
 # Marker protection guards against silent data loss on a hand-edited file.
 _MARKER_PROTECTED_BASENAMES = frozenset({"CLAUDE.md", "state.md"})
+
+# Files DEEP-MERGED across the two-pass overlay (vs. full overwrite). The
+# shared baseline ``_shared/to_home/.mcp.json`` carries the default MCP servers
+# (sac / scitex-todo / claude-code-telegrammer); a per-agent ``.mcp.json`` must
+# UNION its servers with that baseline, not replace it (which would silently
+# drop the defaults). Same-name conflict → fail loud. See :func:`_deploy_mcp_merge`.
+_MCP_MERGE_BASENAMES = frozenset({".mcp.json"})
 
 # Files that get chmod 0600 after copy. ``.env`` only by default; the
 # rest preserve source perms via ``shutil.copy2``.
@@ -295,6 +305,8 @@ def _walk_and_apply(
         # Regular file.
         if child.name in _MARKER_PROTECTED_BASENAMES:
             _deploy_marker_protected(child, dst, config=config, rel=rel)
+        elif child.name in _MCP_MERGE_BASENAMES:
+            _deploy_mcp_merge(child, dst, config=config, rel=rel)
         elif child.name in _TIGHT_PERM_BASENAMES:
             _deploy_tight_perm_file(child, dst, config=config, rel=rel)
         else:
@@ -370,6 +382,48 @@ def _deploy_plain_file(
         except UnicodeDecodeError:
             shutil.copy2(src, dst)
     logger.info("to_home: deployed %s -> %s", rel, dst)
+
+
+def _deploy_mcp_merge(
+    src: Path,
+    dst: Path,
+    *,
+    config: AgentConfig | None,
+    rel: Path,
+) -> None:
+    """Deep-merge ``.mcp.json`` with any already-deployed (baseline) copy.
+
+    The two-pass overlay deploys the shared baseline ``.mcp.json`` first, then
+    each agent's own lands here. Full-overwrite would silently drop the
+    baseline's default servers (sac / scitex-todo / claude-code-telegrammer);
+    instead we UNION the ``mcpServers`` (baseline ∪ per-agent) via
+    :func:`_mcp_merge.merge_mcp_json`. Fail-loud (no silent fallback): an
+    unparseable source/destination ``.mcp.json`` raises
+    :class:`WorkspaceMcpMergeError`; a same-name server defined two different
+    ways raises :class:`_mcp_merge.McpMergeConflict`. Both abort the deploy.
+    """
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    _clear_readonly_dst(dst)
+    overlay_text = _read_and_interpolate(src, config)
+    try:
+        overlay_doc = json.loads(overlay_text) if overlay_text.strip() else {}
+    except json.JSONDecodeError as exc:
+        raise WorkspaceMcpMergeError(
+            f"to_home: source {rel} is not valid JSON ({exc})"
+        ) from exc
+    if dst.is_file():
+        existing = dst.read_text()
+        try:
+            base_doc = json.loads(existing) if existing.strip() else {}
+        except json.JSONDecodeError as exc:
+            raise WorkspaceMcpMergeError(
+                f"to_home: existing {dst} is not valid JSON ({exc})"
+            ) from exc
+        merged = merge_mcp_json(base_doc, overlay_doc)
+    else:
+        merged = overlay_doc
+    dst.write_text(json.dumps(merged, indent=2) + "\n")
+    logger.info("to_home: deep-merged .mcp.json %s -> %s", rel, dst)
 
 
 def _deploy_tight_perm_file(

--- a/src/scitex_agent_container/runtimes/_to_home_errors.py
+++ b/src/scitex_agent_container/runtimes/_to_home_errors.py
@@ -40,7 +40,21 @@ class WorkspaceCredentialLeakError(RuntimeError):
     """
 
 
+class WorkspaceMcpMergeError(RuntimeError):
+    """A ``.mcp.json`` under ``to_home/`` could not be deep-merged — refused.
+
+    The two-pass overlay deep-merges the shared baseline ``.mcp.json`` with
+    each agent's own so default servers (sac / scitex-todo /
+    claude-code-telegrammer) and the agent's own both survive. The deploy is
+    hard-aborted (no silent fallback) when a source ``.mcp.json`` is not valid
+    JSON — guessing/overwriting could drop server wiring an agent needs. A
+    genuine same-name server conflict surfaces as ``_mcp_merge.McpMergeConflict``
+    (the operator resolves it explicitly).
+    """
+
+
 __all__ = [
     "WorkspaceCLAUDEMarkerError",
     "WorkspaceCredentialLeakError",
+    "WorkspaceMcpMergeError",
 ]

--- a/tests/scitex_agent_container/runtimes/test__mcp_merge.py
+++ b/tests/scitex_agent_container/runtimes/test__mcp_merge.py
@@ -1,0 +1,87 @@
+"""Tests for the fail-loud `.mcp.json` deep-merge (W1 / operator 2026-06-17).
+
+The shared baseline `_shared/to_home/.mcp.json` must DEEP-MERGE with each
+agent's own `.mcp.json` — union the `mcpServers` so every agent inherits the
+default servers (sac / scitex-todo / claude-code-telegrammer) AND keeps its
+own. Today the to_home deploy FULL-OVERWRITES `.mcp.json`, so a per-agent file
+would silently drop the baseline defaults — exactly the silent-fallback the
+operator forbids.
+
+Contract (fail-fast, fail-loud, no silent fallback):
+  * disjoint server names  → union.
+  * same name, IDENTICAL definition → kept once (idempotent).
+  * same name, DIFFERENT definition → raise `McpMergeConflict` (the operator
+    must resolve it explicitly; never silently pick a winner).
+
+Conventions: one assert / AAA markers (a `pytest.raises` block IS the assert);
+no mocks — pure dict inputs.
+"""
+
+from __future__ import annotations
+
+import pytest
+from scitex_agent_container.runtimes._mcp_merge import (
+    McpMergeConflict,
+    merge_mcp_json,
+)
+
+
+def test_disjoint_servers_are_unioned():
+    # Arrange
+    base = {"mcpServers": {"sac": {"command": "sac"}}}
+    overlay = {"mcpServers": {"todo": {"command": "todo"}}}
+    # Act
+    merged = merge_mcp_json(base, overlay)
+    # Assert
+    assert set(merged["mcpServers"]) == {"sac", "todo"}
+
+
+def test_identical_same_name_server_is_kept_once():
+    # Arrange
+    srv = {"command": "sac", "args": ["mcp", "start"]}
+    base = {"mcpServers": {"sac": srv}}
+    overlay = {"mcpServers": {"sac": dict(srv)}}
+    # Act
+    merged = merge_mcp_json(base, overlay)
+    # Assert
+    assert merged["mcpServers"]["sac"] == srv
+
+
+def test_conflicting_same_name_server_fails_loud():
+    # Arrange — same name, different command → must NOT silently pick one.
+    base = {"mcpServers": {"sac": {"command": "/opt/venv-sac/bin/sac"}}}
+    overlay = {"mcpServers": {"sac": {"command": "/usr/bin/sac"}}}
+    # Act
+    # Assert
+    with pytest.raises(McpMergeConflict):
+        merge_mcp_json(base, overlay)
+
+
+def test_overlay_only_servers_survive_when_baseline_empty():
+    # Arrange
+    base = {"mcpServers": {}}
+    overlay = {"mcpServers": {"todo": {"command": "todo"}}}
+    # Act
+    merged = merge_mcp_json(base, overlay)
+    # Assert
+    assert merged["mcpServers"] == {"todo": {"command": "todo"}}
+
+
+def test_baseline_defaults_survive_an_agents_own_extra_server():
+    # Arrange — the core W1 guarantee: agent's extra server PLUS the defaults.
+    base = {"mcpServers": {"sac": {"command": "sac"}, "todo": {"command": "todo"}}}
+    overlay = {"mcpServers": {"figrecipe": {"command": "fr"}}}
+    # Act
+    merged = merge_mcp_json(base, overlay)
+    # Assert
+    assert set(merged["mcpServers"]) == {"sac", "todo", "figrecipe"}
+
+
+def test_non_mcpservers_keys_are_preserved_from_both():
+    # Arrange — top-level keys other than mcpServers (e.g. a comment) merge too.
+    base = {"mcpServers": {"sac": {"command": "sac"}}, "_note": "baseline"}
+    overlay = {"mcpServers": {"todo": {"command": "todo"}}}
+    # Act
+    merged = merge_mcp_json(base, overlay)
+    # Assert
+    assert merged["_note"] == "baseline"

--- a/tests/scitex_agent_container/runtimes/test__to_home.py
+++ b/tests/scitex_agent_container/runtimes/test__to_home.py
@@ -12,6 +12,7 @@ Env-driven tests use the project-wide ``env_save_restore`` fixture
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import stat
@@ -20,11 +21,13 @@ from pathlib import Path
 import pytest
 
 from scitex_agent_container.config._types import AgentConfig
+from scitex_agent_container.runtimes._mcp_merge import McpMergeConflict
 from scitex_agent_container.runtimes._to_home import (
     END_MARKER,
     DanglingToHomeSymlinkError,
     WorkspaceCLAUDEMarkerError,
     WorkspaceCredentialLeakError,
+    WorkspaceMcpMergeError,
     deploy_to_home,
     materialize_to_home,
     resolve_baseline_to_home_dir,
@@ -696,6 +699,60 @@ def _build_layered(tmp_path: Path) -> tuple[Path, Path, Path]:
     per_agent.mkdir(parents=True, exist_ok=True)
     baseline.mkdir(parents=True, exist_ok=True)
     return spec_dir, per_agent, baseline
+
+
+# ---------------------------------------------------------------------------
+# .mcp.json deep-merge across the two-pass overlay (W1 / operator 2026-06-17)
+# ---------------------------------------------------------------------------
+
+
+def test_mcp_json_two_pass_unions_baseline_and_agent_servers(tmp_path):
+    # Arrange — baseline ships the defaults; the agent ships its own server.
+    spec_dir, per_agent, baseline = _build_layered(tmp_path)
+    (baseline / ".mcp.json").write_text(
+        json.dumps(
+            {"mcpServers": {"sac": {"command": "sac"}, "todo": {"command": "todo"}}}
+        )
+    )
+    (per_agent / ".mcp.json").write_text(
+        json.dumps({"mcpServers": {"figrecipe": {"command": "fr"}}})
+    )
+    home = tmp_path / "home"
+    home.mkdir()
+    # Act
+    materialize_to_home(spec_dir, home)
+    merged = json.loads((home / ".mcp.json").read_text())
+    # Assert
+    assert set(merged["mcpServers"]) == {"sac", "todo", "figrecipe"}
+
+
+def test_mcp_json_conflicting_server_across_layers_fails_loud(tmp_path):
+    # Arrange — same server name, different command in baseline vs agent.
+    spec_dir, per_agent, baseline = _build_layered(tmp_path)
+    (baseline / ".mcp.json").write_text(
+        json.dumps({"mcpServers": {"sac": {"command": "A"}}})
+    )
+    (per_agent / ".mcp.json").write_text(
+        json.dumps({"mcpServers": {"sac": {"command": "B"}}})
+    )
+    home = tmp_path / "home"
+    home.mkdir()
+    # Act
+    # Assert
+    with pytest.raises(McpMergeConflict):
+        materialize_to_home(spec_dir, home)
+
+
+def test_mcp_json_invalid_agent_json_fails_loud(tmp_path):
+    # Arrange — the agent's .mcp.json is not valid JSON.
+    spec_dir, per_agent, _baseline = _build_layered(tmp_path)
+    (per_agent / ".mcp.json").write_text("not json{")
+    home = tmp_path / "home"
+    home.mkdir()
+    # Act
+    # Assert
+    with pytest.raises(WorkspaceMcpMergeError):
+        materialize_to_home(spec_dir, home)
 
 
 class TestResolveBaselineToHomeDir:


### PR DESCRIPTION
## Why (operator 2026-06-17)

Agent MCP defaults should live declaratively in the shared baseline \`_shared/to_home/.mcp.json\` and **deep-merge** with each agent's own \`.mcp.json\` — not be hardcoded. But the two-pass to_home overlay currently **full-overwrites** \`.mcp.json\`, so a per-agent file would **silently drop** the baseline's default servers (sac / scitex-todo / claude-code-telegrammer). That's the silent-fallback the operator forbids.

Owner: proj-scitex-agent-container

## What

- \`runtimes/_mcp_merge.merge_mcp_json\` — union \`mcpServers\` (baseline ∪ per-agent); identical same-name kept once; a **conflicting** same-name definition raises \`McpMergeConflict\`.
- Route \`.mcp.json\` through a new \`_deploy_mcp_merge\` in \`_walk_and_apply\` (deep-merge vs full-overwrite).
- **Fail-loud, no silent fallback**: same-name conflict → \`McpMergeConflict\`; unparseable \`.mcp.json\` → \`WorkspaceMcpMergeError\`. Both abort the deploy.

## Safety

**Backward-compatible**: with no baseline \`.mcp.json\` present (today's state), the agent's file lands unchanged — now also JSON-validated fail-loud. This is the *mechanism* that enables the declarative defaults file + the channel-injection, which land as follow-ups (the baseline file is a dotfiles/data change; channels aren't in \`.mcp.json\`).

## Tests

6 helper unit tests + 3 two-pass integration tests (baseline+agent union; conflict fails loud; bad JSON fails loud); **78 runtimes tests green**; ruff clean.

(Pre-existing PS-140 cross-package-imports-gate staleness is unrelated.)