### PR TITLE
feat(agents-list): active-only + compact by default; -v paths, --all ghosts

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_helpers/_agent_list.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers/_agent_list.py
@@ -427,15 +427,58 @@ def print_agent_list_json(
     click.echo(json_mod.dumps(data, indent=2))
 
 
+def _is_ghost_row(row: dict) -> bool:
+    """True for a dead registry entry: a LOCAL agent whose spec file is gone.
+
+    Operator 2026-06-17: ``sac agents list`` should show only active agents
+    by default. Stale ``instances`` rows (e.g. left by a pytest run whose
+    tmp spec dir was cleaned) surface as ``status="unknown"`` with a
+    ``"File not found"`` validation error — pure noise. They are hidden by
+    default and revealed with ``--all``.
+
+    Safety: only a LOCAL spec-missing row is a ghost. A REMOTE agent's spec
+    lives on its own host (a local "File not found" says nothing about it),
+    and a remote liveness-probe timeout also reports ``status="unknown"`` —
+    neither must be hidden, or the fleet view would erase live peers. An
+    on-disk spec that merely fails SCHEMA validation (``status="invalid"``)
+    also stays visible so the operator can see and fix it.
+    """
+    host = row.get("host") or "local"
+    if host not in ("local", ""):
+        return False
+    errors = row.get("validation_errors") or []
+    return any("File not found" in str(e) for e in errors)
+
+
 def print_agent_list(
     registry: Registry,
     capability: str | None = None,
     machine: str | None = None,
+    *,
+    verbose: bool = False,
+    show_all: bool = False,
 ) -> None:
-    """Print a rich table of all registered agents."""
+    """Print a rich table of all registered agents.
+
+    By default shows only active agents (dead spec-missing registry ghosts
+    are hidden — see :func:`_is_ghost_row`) and omits the full spec ``Path``
+    column (it folds every row to 10+ lines). ``show_all=True`` includes the
+    ghosts; ``verbose=True`` adds the ``Path`` column back.
+    """
     data = get_agent_list_data(registry, capability=capability, machine=machine)
     if not data:
         console.print("[dim]No agents found (registry empty, no specs on disk).[/dim]")
+        return
+
+    hidden = 0
+    if not show_all:
+        kept = [r for r in data if not _is_ghost_row(r)]
+        hidden = len(data) - len(kept)
+        data = kept
+    if not data:
+        console.print(
+            "[dim]No active agents (all hidden as stale; --all to show).[/dim]"
+        )
         return
 
     table = Table(title="Agents")
@@ -448,8 +491,16 @@ def print_agent_list(
     table.add_column("Host")
     # Account labels (e.g. ``<name> (<email>)``) can be long; fold within
     # the cell rather than stealing width from the name column.
-    table.add_column("Account", overflow="fold")
-    table.add_column("Path", overflow="fold")
+    # Account folds the long ``<name> (<email>)`` label to ~5 lines; show the
+    # short account name only by default (no_wrap), full label in --verbose.
+    if verbose:
+        table.add_column("Account", overflow="fold")
+    else:
+        table.add_column("Account", no_wrap=True, overflow="ellipsis")
+    # ``Path`` (full spec.yaml path) folds every row to 10+ lines, so it is
+    # verbose-only (operator 2026-06-17).
+    if verbose:
+        table.add_column("Path", overflow="fold")
     table.add_column("Started")
     cmap = {
         "running": "green",
@@ -470,17 +521,28 @@ def print_agent_list(
         )
         started = row["started_at"] if row["started_at"] not in ("-", "?") else "—"
         account_cell = row.get("account") or "—"
-        table.add_row(
+        # Drop the ``(email)`` parenthetical in the default (compact) view so
+        # the row stays one line; --verbose keeps the full ``name (email)``.
+        if not verbose and " (" in account_cell:
+            account_cell = account_cell.split(" (", 1)[0]
+        cells = [
             row["name"],
             f"[{col}]{row['status']}[/{col}]",
             yaml_cell,
             host_cell,
             account_cell,
-            row.get("path") or "—",
-            started,
-        )
+        ]
+        if verbose:
+            cells.append(row.get("path") or "—")
+        cells.append(started)
+        table.add_row(*cells)
 
     console.print(table)
+    if hidden:
+        console.print(
+            f"[dim]({hidden} stale/ghost agent(s) hidden — --all to show, "
+            "-v for paths)[/dim]"
+        )
     # Full error text follows the table so the operator can copy-paste.
     for row in data:
         if row.get("validation_errors"):

--- a/src/scitex_agent_container/cli_pkg/status_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/status_cmds.py
@@ -137,6 +137,23 @@ def _format_claude_account_block(meta: dict) -> list[str]:
     help="Fleet view: filter by machine label.",
 )
 @click.option(
+    "--verbose",
+    "-v",
+    "verbose",
+    is_flag=True,
+    default=False,
+    help="Fleet view: add the full spec.yaml Path column (off by default — "
+    "it folds every row to 10+ lines).",
+)
+@click.option(
+    "--all",
+    "show_all",
+    is_flag=True,
+    default=False,
+    help="Fleet view: include stale/ghost agents (dead registry entries whose "
+    "spec file is gone). Hidden by default.",
+)
+@click.option(
     "--snapshot",
     "with_snapshot",
     is_flag=True,
@@ -170,6 +187,8 @@ def status(
     terse: bool,
     capability: str | None,
     machine: str | None,
+    verbose: bool,
+    show_all: bool,
     with_snapshot: bool,
     with_priority: bool,
     with_workdir_audit: bool,
@@ -321,7 +340,13 @@ def status(
                 )
             )
         else:
-            print_agent_list(registry, capability=capability, machine=machine)
+            print_agent_list(
+                registry,
+                capability=capability,
+                machine=machine,
+                verbose=verbose,
+                show_all=show_all,
+            )
 
 
 @click.command(name="check-health")

--- a/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list.py
+++ b/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list.py
@@ -697,3 +697,64 @@ def test_remote_row_is_never_a_ghost_even_if_spec_missing_locally():
     result = _al._is_ghost_row(row)
     # Assert
     assert result is False
+
+
+# ---------------------------------------------------------------------------
+# print_agent_list — active-only / verbose / --all rendering (operator 2026-06-17)
+# ---------------------------------------------------------------------------
+
+
+def test_print_agent_list_hides_ghost_and_shows_hidden_footer(capsys, tmp_path):
+    # Arrange — a real agent + a ghost (registry entry whose spec file is gone).
+    good = _write_valid_spec(tmp_path / "good")
+    registry = _FakeRegistry(
+        [
+            {"name": "good", "config": str(good), "screen": "s", "started_at": "ts"},
+            {"name": "deadrow", "config": str(tmp_path / "gone" / "spec.yaml")},
+        ]
+    )
+    # Act — default view.
+    with _swap_discover(_no_discover), _swap_probe(lambda cfg: True):
+        print_agent_list(registry)
+    # Assert — ghost row hidden + footer shown ("deadrow" avoids collision
+    # with the footer's own "stale/ghost" wording).
+    out = capsys.readouterr().out
+    assert "deadrow" not in out and "hidden" in out
+
+
+def test_print_agent_list_show_all_includes_ghost(capsys, tmp_path):
+    # Arrange
+    registry = _FakeRegistry(
+        [{"name": "ghost", "config": str(tmp_path / "gone" / "spec.yaml")}]
+    )
+    # Act
+    with _swap_discover(_no_discover), _swap_probe(lambda cfg: True):
+        print_agent_list(registry, show_all=True)
+    # Assert
+    assert "ghost" in capsys.readouterr().out
+
+
+def test_print_agent_list_verbose_adds_path_column(capsys, tmp_path):
+    # Arrange
+    good = _write_valid_spec(tmp_path / "good")
+    registry = _FakeRegistry(
+        [{"name": "good", "config": str(good), "screen": "s", "started_at": "ts"}]
+    )
+    # Act
+    with _swap_discover(_no_discover), _swap_probe(lambda cfg: True):
+        print_agent_list(registry, verbose=True)
+    # Assert — the Path header appears only in verbose mode.
+    assert "Path" in capsys.readouterr().out
+
+
+def test_print_agent_list_default_omits_path_column(capsys, tmp_path):
+    # Arrange
+    good = _write_valid_spec(tmp_path / "good")
+    registry = _FakeRegistry(
+        [{"name": "good", "config": str(good), "screen": "s", "started_at": "ts"}]
+    )
+    # Act
+    with _swap_discover(_no_discover), _swap_probe(lambda cfg: True):
+        print_agent_list(registry)
+    # Assert
+    assert "Path" not in capsys.readouterr().out

--- a/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list.py
+++ b/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list.py
@@ -641,3 +641,59 @@ def test_safe_account_for_returns_string_on_none_config():
     result = _al._safe_account_for(cfg)
     # Assert
     assert isinstance(result, str) and result
+
+
+# ---------------------------------------------------------------------------
+# _is_ghost_row — dead-registry-entry filter (operator 2026-06-17:
+# `sac agents list` should show only active agents by default).
+# ---------------------------------------------------------------------------
+
+
+def test_local_row_with_file_not_found_is_a_ghost():
+    # Arrange — a stale local registry entry whose spec was deleted (e.g. a
+    # pytest-temp dir cleaned up after the run).
+    row = {
+        "host": "local",
+        "validation_errors": [
+            "File not found: /tmp/pytest-.../agents/archive-target/spec.yaml"
+        ],
+    }
+    # Act
+    result = _al._is_ghost_row(row)
+    # Assert
+    assert result is True
+
+
+def test_local_row_with_valid_spec_is_not_a_ghost():
+    # Arrange — a real defined agent (no validation errors).
+    row = {"host": "local", "validation_errors": []}
+    # Act
+    result = _al._is_ghost_row(row)
+    # Assert
+    assert result is False
+
+
+def test_invalid_schema_row_is_not_a_ghost():
+    # Arrange — a real on-disk spec that fails schema validation must STAY
+    # visible (operator needs to see + fix it); only a MISSING file is a ghost.
+    row = {
+        "host": "local",
+        "validation_errors": ["kind must be one of ['Agent', 'AgentProxy'], got None"],
+    }
+    # Act
+    result = _al._is_ghost_row(row)
+    # Assert
+    assert result is False
+
+
+def test_remote_row_is_never_a_ghost_even_if_spec_missing_locally():
+    # Arrange — a remote agent's spec lives on its own host; a local
+    # "File not found" must NOT hide it (it would erase the fleet view).
+    row = {
+        "host": "spartan-bm159",
+        "validation_errors": ["File not found: /home/.../spec.yaml"],
+    }
+    # Act
+    result = _al._is_ghost_row(row)
+    # Assert
+    assert result is False


### PR DESCRIPTION
## Why (operator 2026-06-17)
`sac agents list` was unreadable: the full spec.yaml **Path** column folded every row to 10+ lines, and stale **pytest-temp registry ghosts** (`status=unknown`, "File not found") polluted the view.

Owner: proj-scitex-agent-container

## What
- **Active-only by default**: hide dead registry ghosts (`_is_ghost_row` — a *local* agent whose spec file is gone). `--all` shows them; footer reports hidden count.
- **No Path by default**: `-v/--verbose` adds the Path column back.
- **Compact Account**: short name by default (no_wrap), full `name (email)` under `-v`.

## Safety (what stays visible)
Remote agents (spec lives on their host), remote liveness-timeout `unknown` rows, and on-disk **schema-invalid** specs (e.g. `self`) all stay visible — only a *local spec-missing* row is a ghost. So the fleet view never erases live peers and broken specs still surface for fixing.

## Result
One line per row, active agents only. Before: ~10 lines/row × 13 rows incl. 3 ghosts. After: 9 clean rows + "(3 stale hidden)".

## Tests
4 new ghost-filter tests (local-missing=ghost; valid/schema-invalid/remote=not-ghost); 77 list+status tests green; ruff clean.