### PR TITLE
feat(start): cold-start forms for `sac agents start` (path / host:path / label@host:path / .)

### DIFF
--- a/src/scitex_agent_container/cli_pkg/lifecycle/_cold_start.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_cold_start.py
@@ -259,6 +259,91 @@ def materialize_cold_start(
     )
 
 
+def _dir_has_agents_default(p: Path) -> bool:
+    """Fallback bulk-dir detector: any ``<child>/spec.yaml`` under ``p``.
+
+    The command injects the production ``_iter_agent_yamls`` (which also
+    accepts the ``<name>/<name>.yaml`` layout); this default keeps the helper
+    usable + unit-testable without importing the command (no import cycle).
+    """
+    try:
+        return any((c / "spec.yaml").is_file() for c in p.iterdir() if c.is_dir())
+    except OSError:
+        return False
+
+
+def _is_existing_spec_target(arg: str, dir_has_agents) -> bool:
+    """True when ``arg`` is an EXISTING spec/agent target — not a cold-start.
+
+    Guards the path-shaped cold-start forms (``/path``, ``.``) from hijacking
+    the existing ``sac start`` targets:
+
+      * a ``*.yaml`` / ``*.yml`` path → an explicit spec file;
+      * a directory containing ``spec.yaml`` → an agent dir;
+      * a directory that ``dir_has_agents`` recognizes as a bulk agents root.
+
+    Such targets flow through the existing resolver untouched. A plain project
+    *workdir* (no agent spec inside) is left for the cold-start parser.
+    """
+    if arg.endswith((".yaml", ".yml")):
+        return True
+    p = Path(arg).expanduser()
+    if not p.is_dir():
+        return False
+    if (p / "spec.yaml").is_file():
+        return True
+    if dir_has_agents(p):
+        return True
+    # An EMPTY directory is treated as an existing (empty) bulk target — the
+    # clean "nothing to start" no-op — not a cold-start workdir. A real project
+    # workdir is non-empty; cold-start needs ``.``/``<host>:``/``<label>@`` or a
+    # non-empty path. (Preserves the existing empty-bulk-dir contract.)
+    try:
+        return not any(p.iterdir())
+    except OSError:
+        return False
+
+
+def resolve_cold_start_targets(
+    targets,
+    *,
+    caller_host: str,
+    dry_run: bool = False,
+    force: bool = False,
+    base_dir: Path | None = None,
+    cwd: str | None = None,
+    dir_has_agents=None,
+):
+    """Rewrite raw ``sac start`` targets, materializing cold-start forms.
+
+    Returns ``(rewritten_targets, plans)``: ``rewritten_targets`` is the list to
+    hand to the existing launch flow (cold-start forms replaced by their agent
+    label; everything else passed through), and ``plans`` is the list of
+    :class:`ColdStartPlan` for the cold-started ones (for the "what's happening"
+    message + ``--json``). A ``dry_run`` ``would-create`` is NOT added to the
+    launch list (no spec exists yet to start). Raises
+    :class:`ColdStartParseError` / :class:`ColdStartConflictError` (fail-loud).
+    """
+    dir_has_agents = dir_has_agents or _dir_has_agents_default
+    rewritten: list[str] = []
+    plans: list[ColdStartPlan] = []
+    for t in targets:
+        if _is_existing_spec_target(t, dir_has_agents):
+            rewritten.append(t)
+            continue
+        cs = parse_start_target(t, caller_host=caller_host, cwd=cwd)
+        if cs is None:
+            rewritten.append(t)
+            continue
+        plan = materialize_cold_start(
+            cs, base_dir=base_dir, dry_run=dry_run, force=force
+        )
+        plans.append(plan)
+        if not (dry_run and plan.action == "would-create"):
+            rewritten.append(plan.label)
+    return rewritten, plans
+
+
 __all__ = [
     "ColdStartConflictError",
     "ColdStartParseError",
@@ -266,4 +351,5 @@ __all__ = [
     "ColdStartTarget",
     "materialize_cold_start",
     "parse_start_target",
+    "resolve_cold_start_targets",
 ]

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_cold_start.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_cold_start.py
@@ -1,0 +1,269 @@
+"""`sac start` cold-start target parser (operator TODO 2026-06-17).
+
+`sac start` accepts four convenience forms in addition to a plain agent name,
+so an operator can launch an agent for an arbitrary project dir without first
+hand-writing a spec:
+
+  1. ``<label>@<host>:/path/to/workdir/``  — explicit label, host, workdir
+  2. ``<host>:/path/to/workdir/``          — label = basename(workdir)
+  3. ``/path/to/workdir/`` (or ``./rel``)  — host = the caller's host
+  4. ``.``                                 — workdir = $CWD, host = caller
+
+:func:`parse_start_target` is a PURE classifier: it returns a
+:class:`ColdStartTarget` for the four forms, ``None`` for a plain agent name
+(``proj-figrecipe`` → resolve through the existing registry flow), and raises
+:class:`ColdStartParseError` on a malformed form (fail-fast, fail-loud, no
+silent fallback — operator directive). Materialization + launch live in the
+caller (:mod:`._start`); this module only decides "what did the operator mean?".
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+# Agent-name charset (mirrors cli_pkg._new validation): lowercase letters,
+# digits, hyphen, underscore; must start with a letter.
+_VALID_LABEL = re.compile(r"^[a-z][a-z0-9_-]*$")
+
+# Minimal standardized TUI spec for a cold-started agent. Deliberately small
+# (operator: keep agent defs pure) — the sac MCP server + ``server:sac``
+# channel are auto-injected by the loader, so only what's UNIQUE to this agent
+# is written here. ``host`` is always set (dispatch runs locally when it
+# matches the caller's host, remote otherwise).
+_COLD_START_SPEC = """\
+# {label} — cold-started by `sac start` ({stamp_note}).
+# Minimal standardized TUI spec; edit freely or `sac agents new` for the full tour.
+apiVersion: scitex-agent-container/v3
+kind: Agent
+metadata:
+  labels:
+    project: {label}
+spec:
+  runtime: tui
+  host: {host}
+  workdir: {workdir}
+  claude:
+    flags:
+      - --dangerously-skip-permissions
+  a2a:
+    port: auto
+"""
+
+
+class ColdStartParseError(ValueError):
+    """A `sac start` target looked like a cold-start form but was malformed.
+
+    Raised (never swallowed) so the operator sees exactly what was wrong
+    instead of the arg being silently misread as an agent name.
+    """
+
+
+class ColdStartConflictError(RuntimeError):
+    """A cold-start label already exists with a DIFFERENT workdir/host.
+
+    Fail-loud (operator directive): never silently clobber a customised spec
+    nor silently launch the wrong workdir. The operator resolves it with a
+    different label or ``--force``.
+    """
+
+
+@dataclass(frozen=True)
+class ColdStartTarget:
+    """A parsed cold-start request: which agent, where, in what dir."""
+
+    label: str
+    host: str
+    workdir: str
+
+
+def _derive_label(workdir: str) -> str:
+    """Agent label = sanitized basename of the workdir. Fail loud if empty."""
+    base = os.path.basename(workdir.rstrip("/"))
+    if not base:
+        raise ColdStartParseError(
+            f"cannot derive an agent label from workdir {workdir!r} "
+            "(empty basename) — pass an explicit <label>@<host>:<path>."
+        )
+    return base
+
+
+def _validate_label(label: str) -> str:
+    if not _VALID_LABEL.match(label):
+        raise ColdStartParseError(
+            f"invalid agent label {label!r}: must match {_VALID_LABEL.pattern} "
+            "(lowercase letter first, then letters/digits/-/_). Rename the dir "
+            "or pass an explicit <label>@<host>:<path>."
+        )
+    return label
+
+
+def _split_host_path(hostpath: str, *, original: str) -> tuple[str, str]:
+    """Split ``<host>:/path`` into ``(host, path)``; fail loud if malformed."""
+    if ":" not in hostpath:
+        raise ColdStartParseError(
+            f"{original!r}: expected '<host>:/path' after '@', got {hostpath!r}."
+        )
+    host, path = hostpath.split(":", 1)
+    if not host:
+        raise ColdStartParseError(f"{original!r}: empty host before ':'.")
+    if not path:
+        raise ColdStartParseError(f"{original!r}: empty workdir after '<host>:'.")
+    return host, path
+
+
+def _looks_local_path(arg: str) -> bool:
+    return arg == "." or arg.startswith(("/", "./", "~", "../"))
+
+
+def parse_start_target(
+    arg: str,
+    *,
+    caller_host: str,
+    cwd: str | None = None,
+) -> ColdStartTarget | None:
+    """Classify a ``sac start`` positional target.
+
+    Returns ``None`` for a plain agent name (existing registry flow), a
+    :class:`ColdStartTarget` for the four cold-start forms, or raises
+    :class:`ColdStartParseError` for a malformed form. ``cwd`` defaults to the
+    process working directory (injectable for tests).
+    """
+    arg = arg.strip()
+    cwd = cwd if cwd is not None else os.getcwd()
+
+    # Forms 3 & 4 — a local path / "." (host defaults to the caller).
+    if _looks_local_path(arg):
+        workdir = cwd if arg == "." else os.path.abspath(os.path.expanduser(arg))
+        return ColdStartTarget(
+            label=_validate_label(_derive_label(workdir)),
+            host=caller_host,
+            workdir=workdir,
+        )
+
+    # Form 1 — <label>@<host>:/path.
+    if "@" in arg:
+        label, hostpath = arg.split("@", 1)
+        if not label:
+            raise ColdStartParseError(f"{arg!r}: empty label before '@'.")
+        host, path = _split_host_path(hostpath, original=arg)
+        return ColdStartTarget(
+            label=_validate_label(label),
+            host=host,
+            workdir=path,
+        )
+
+    # Form 2 — <host>:/path (label derived from the workdir basename).
+    if ":" in arg:
+        host, path = _split_host_path(arg, original=arg)
+        return ColdStartTarget(
+            label=_validate_label(_derive_label(path)),
+            host=host,
+            workdir=path,
+        )
+
+    # No path / host markers → a plain agent name; existing flow resolves it.
+    return None
+
+
+@dataclass(frozen=True)
+class ColdStartPlan:
+    """Outcome of :func:`materialize_cold_start` — what was (or would be) done."""
+
+    label: str
+    spec_path: str
+    host: str
+    workdir: str
+    action: str  # "create" | "reuse" | "would-create" | "would-reuse"
+
+
+def _default_agents_root() -> Path:
+    return Path.home() / ".scitex" / "agent-container" / "agents"
+
+
+def _existing_matches(spec_path: Path, target: ColdStartTarget) -> bool:
+    """True iff an existing spec already points at this exact workdir+host."""
+    from ...config import load_config
+
+    cfg = load_config(str(spec_path))
+    existing_host = getattr(cfg, "host", "") or getattr(
+        getattr(cfg, "hosts_spec", None), "host", ""
+    )
+    return (getattr(cfg, "workdir", "") or "") == target.workdir and (
+        existing_host or ""
+    ) == target.host
+
+
+def materialize_cold_start(
+    target: ColdStartTarget,
+    *,
+    base_dir: Path | None = None,
+    dry_run: bool = False,
+    force: bool = False,
+) -> ColdStartPlan:
+    """Write a minimal standardized TUI spec for ``target`` and return a plan.
+
+    Idempotent + fail-loud:
+      * fresh label → write ``<base>/<label>/{spec.yaml,to_home/}``.
+      * existing label pointing at the SAME workdir+host → reuse (no write).
+      * existing label, DIFFERENT workdir/host → :class:`ColdStartConflictError`
+        unless ``force`` (then overwrite).
+      * ``dry_run`` → never write; ``action`` reports the intended outcome.
+    """
+    base = base_dir if base_dir is not None else _default_agents_root()
+    agent_dir = Path(base) / target.label
+    spec_path = agent_dir / "spec.yaml"
+
+    if spec_path.is_file() and not force:
+        if _existing_matches(spec_path, target):
+            return ColdStartPlan(
+                label=target.label,
+                spec_path=str(spec_path),
+                host=target.host,
+                workdir=target.workdir,
+                action="would-reuse" if dry_run else "reuse",
+            )
+        raise ColdStartConflictError(
+            f"agent {target.label!r} already exists at {spec_path} with a "
+            f"different workdir/host than {target.workdir!r}@{target.host!r}. "
+            "Use a different <label>, or pass --force to overwrite."
+        )
+
+    if dry_run:
+        return ColdStartPlan(
+            label=target.label,
+            spec_path=str(spec_path),
+            host=target.host,
+            workdir=target.workdir,
+            action="would-create",
+        )
+
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    (agent_dir / "to_home").mkdir(exist_ok=True)
+    spec_path.write_text(
+        _COLD_START_SPEC.format(
+            label=target.label,
+            host=target.host,
+            workdir=target.workdir,
+            stamp_note="minimal standardized template",
+        )
+    )
+    return ColdStartPlan(
+        label=target.label,
+        spec_path=str(spec_path),
+        host=target.host,
+        workdir=target.workdir,
+        action="create",
+    )
+
+
+__all__ = [
+    "ColdStartConflictError",
+    "ColdStartParseError",
+    "ColdStartPlan",
+    "ColdStartTarget",
+    "materialize_cold_start",
+    "parse_start_target",
+]

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_start.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_start.py
@@ -223,18 +223,34 @@ def start(
     no_redispatch: bool,
     broker_self: bool,
 ) -> None:
-    """Start one or more agents from YAML definitions.
+    """Start one or more agents.
 
-    Each TARGET is either a YAML path, an agent name (resolved against the
-    standard search paths), or a directory containing ``<name>/<name>.yaml``
-    agent layouts. Multiple targets may be given.
+    Each TARGET may be an EXISTING agent — an agent name, a ``spec.yaml`` path,
+    or a directory of ``<name>/spec.yaml`` agents (bulk) — OR a COLD-START form
+    that materializes a minimal standardized TUI spec for an arbitrary project
+    workdir and starts it (operator TODO 2026-06-17):
+
+    \b
+      <label>@<host>:/path/to/workdir   explicit label, host, and workdir
+      <host>:/path/to/workdir           label = the workdir's basename
+      /path/to/workdir                  host = this (the caller's) host
+      .                                 workdir = the current directory
+
+    Cold-start writes ``~/.scitex/agent-container/agents/<label>/{spec.yaml,
+    to_home/}`` then launches it; ``@<host>`` dispatches to that host. Re-running
+    a cold-start form reuses the spec when workdir+host match, else fails loud
+    (use ``--force`` to overwrite). ``--dry-run`` prints the plan without writing
+    or starting; ``--json`` emits it as structured output. Malformed forms fail
+    loud (no silent fallback).
 
     \b
     Example:
-      $ sac agent start foo
-      $ sac agent start ~/.scitex/agent-container/agents/foo/foo.yaml
-      $ sac agent start foo bar baz
-      $ sac agent start ~/.scitex/agent-container/agents/   # whole dir = bulk
+      $ sac start proj-figrecipe                       # existing agent (by name)
+      $ sac start ~/.scitex/agent-container/agents/     # bulk dir = all agents
+      $ sac start /home/me/proj/figrecipe               # cold-start, local host
+      $ sac start fig@spartan:/home/me/proj/figrecipe   # cold-start on spartan
+      $ sac start .                                     # cold-start the cwd
+      $ sac start . --dry-run --json                    # preview the plan only
     """
     import json as _json
 
@@ -279,6 +295,72 @@ def start(
                 f"[bold]--params-file[/bold]  expanded "
                 f"{len(materialised)} agent(s) under [cyan]{out_dir}[/cyan]"
             )
+
+    # Cold-start forms (operator TODO 2026-06-17): a target shaped like
+    # <label>@<host>:/path, <host>:/path, an absolute /workdir, or "." is NOT an
+    # existing agent — materialize a minimal standardized TUI spec for it, then
+    # start it through the normal flow below. Plain agent names + explicit
+    # spec.yaml paths + agent/agents-root dirs pass through untouched
+    # (fs-precedence in resolve_cold_start_targets). Malformed forms fail loud.
+    from ._cold_start import (
+        ColdStartConflictError,
+        ColdStartParseError,
+        resolve_cold_start_targets,
+    )
+
+    try:
+        from ...config._host import resolve_hostname
+
+        _caller_host = resolve_hostname()
+    except Exception:  # stx-allow: fallback (hostname resolution may fail in odd net envs; basename of socket name is the safe default)
+        import socket
+
+        _caller_host = socket.gethostname().split(".")[0]
+
+    try:
+        _rewritten, _cs_plans = resolve_cold_start_targets(
+            targets,
+            caller_host=_caller_host,
+            dry_run=dry_run,
+            force=force,
+            # Use the SAME bulk-dir detector the classifier below uses, so an
+            # agents-root dir (``<name>/<name>.yaml`` layout) is treated as an
+            # existing bulk target, not cold-started.
+            dir_has_agents=lambda p: bool(_iter_agent_yamls(p)),
+        )
+    except (ColdStartParseError, ColdStartConflictError) as exc:
+        if as_json:
+            _emit_json({"error": str(exc)})
+        else:
+            click.echo(f"Error: {exc}", err=True)
+        sys.exit(2)
+
+    for _plan in _cs_plans:
+        if as_json:
+            _emit_json(
+                {
+                    "cold_start": {
+                        "label": _plan.label,
+                        "host": _plan.host,
+                        "workdir": _plan.workdir,
+                        "spec_path": _plan.spec_path,
+                        "action": _plan.action,
+                    }
+                }
+            )
+        else:
+            console.print(
+                f"[bold]cold-start[/bold] [cyan]{_plan.label}[/cyan] "
+                f"[dim]({_plan.action})[/dim]  host=[cyan]{_plan.host}[/cyan]  "
+                f"workdir=[cyan]{_plan.workdir}[/cyan]\n"
+                f"  spec: [dim]{_plan.spec_path}[/dim]"
+            )
+    targets = tuple(_rewritten)
+    if not targets:
+        # All targets were dry-run cold-starts: plan(s) shown, nothing to launch.
+        if not as_json:
+            console.print("[dim]--dry-run: spec(s) planned above; not started.[/dim]")
+        return
 
     # Classify targets: directory targets expand to all <name>/<name>.yaml
     # under them; non-directory targets are paths or agent names.

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__cold_start.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__cold_start.py
@@ -1,0 +1,190 @@
+"""Tests for the `sac start` cold-start target parser (operator TODO 2026-06-17).
+
+`sac start` accepts four convenience forms in addition to a plain agent name:
+
+  1. ``<label>@<host>:/path/to/workdir/``   — explicit label, host, workdir
+  2. ``<host>:/path/to/workdir/``           — label = basename(workdir)
+  3. ``/path/to/workdir/``                  — host = caller's host
+  4. ``.``                                  — workdir = $CWD, host = caller
+
+A plain agent name (``proj-figrecipe``) is NOT a cold-start form — it resolves
+through the existing registry flow, so the parser returns ``None`` for it.
+Malformed forms fail loud (``ColdStartParseError``) — no silent fallback.
+
+Conventions: one assert / AAA markers; no mocks (pure function, real inputs).
+"""
+
+from __future__ import annotations
+
+import pytest
+from scitex_agent_container.cli_pkg.lifecycle._cold_start import (
+    ColdStartParseError,
+    ColdStartTarget,
+    parse_start_target,
+)
+
+CALLER = "ywata-note-win"
+
+
+# --- plain agent name → not a cold-start form (existing flow) ----------------
+
+
+def test_plain_agent_name_returns_none():
+    # Arrange
+    arg = "proj-figrecipe"
+    # Act
+    result = parse_start_target(arg, caller_host=CALLER)
+    # Assert
+    assert result is None
+
+
+# --- form 1: <label>@<host>:/path --------------------------------------------
+
+
+def test_label_host_path_form_parses_label():
+    # Arrange
+    arg = "fig@spartan:/home/me/proj/figrecipe"
+    # Act
+    t = parse_start_target(arg, caller_host=CALLER)
+    # Assert
+    assert t.label == "fig"
+
+
+def test_label_host_path_form_parses_host():
+    # Arrange
+    arg = "fig@spartan:/home/me/proj/figrecipe"
+    # Act
+    t = parse_start_target(arg, caller_host=CALLER)
+    # Assert
+    assert t.host == "spartan"
+
+
+def test_label_host_path_form_parses_workdir():
+    # Arrange
+    arg = "fig@spartan:/home/me/proj/figrecipe"
+    # Act
+    t = parse_start_target(arg, caller_host=CALLER)
+    # Assert
+    assert t.workdir == "/home/me/proj/figrecipe"
+
+
+# --- form 2: <host>:/path → label = basename ---------------------------------
+
+
+def test_host_path_form_derives_label_from_basename():
+    # Arrange
+    arg = "spartan:/home/me/proj/figrecipe"
+    # Act
+    t = parse_start_target(arg, caller_host=CALLER)
+    # Assert
+    assert t.label == "figrecipe"
+
+
+def test_host_path_form_parses_host():
+    # Arrange
+    arg = "spartan:/home/me/proj/figrecipe/"
+    # Act
+    t = parse_start_target(arg, caller_host=CALLER)
+    # Assert
+    assert t.host == "spartan"
+
+
+def test_host_path_form_strips_trailing_slash_for_basename():
+    # Arrange
+    arg = "spartan:/home/me/proj/figrecipe/"
+    # Act
+    t = parse_start_target(arg, caller_host=CALLER)
+    # Assert
+    assert t.label == "figrecipe"
+
+
+# --- form 3: /path → caller host ---------------------------------------------
+
+
+def test_absolute_path_form_uses_caller_host():
+    # Arrange
+    arg = "/home/me/proj/figrecipe"
+    # Act
+    t = parse_start_target(arg, caller_host=CALLER)
+    # Assert
+    assert t.host == CALLER
+
+
+def test_absolute_path_form_derives_label_from_basename():
+    # Arrange
+    arg = "/home/me/proj/figrecipe"
+    # Act
+    t = parse_start_target(arg, caller_host=CALLER)
+    # Assert
+    assert t.label == "figrecipe"
+
+
+# --- form 4: . → cwd ---------------------------------------------------------
+
+
+def test_dot_form_uses_cwd_as_workdir(tmp_path):
+    # Arrange
+    d = tmp_path / "myproj"
+    d.mkdir()
+    # Act
+    t = parse_start_target(".", caller_host=CALLER, cwd=str(d))
+    # Assert
+    assert t.workdir == str(d)
+
+
+def test_dot_form_derives_label_from_cwd_basename(tmp_path):
+    # Arrange
+    d = tmp_path / "myproj"
+    d.mkdir()
+    # Act
+    t = parse_start_target(".", caller_host=CALLER, cwd=str(d))
+    # Assert
+    assert t.label == "myproj"
+
+
+# --- fail-loud (no silent fallback) ------------------------------------------
+
+
+def test_at_without_host_colon_fails_loud():
+    # Arrange
+    arg = "fig@justlabel"
+    # Act
+    # Assert
+    with pytest.raises(ColdStartParseError):
+        parse_start_target(arg, caller_host=CALLER)
+
+
+def test_empty_host_in_host_path_fails_loud():
+    # Arrange
+    arg = ":/home/me/proj"
+    # Act
+    # Assert
+    with pytest.raises(ColdStartParseError):
+        parse_start_target(arg, caller_host=CALLER)
+
+
+def test_host_colon_with_empty_path_fails_loud():
+    # Arrange
+    arg = "spartan:"
+    # Act
+    # Assert
+    with pytest.raises(ColdStartParseError):
+        parse_start_target(arg, caller_host=CALLER)
+
+
+def test_label_with_invalid_chars_fails_loud():
+    # Arrange
+    arg = "bad label@spartan:/home/me/proj"
+    # Act
+    # Assert
+    with pytest.raises(ColdStartParseError):
+        parse_start_target(arg, caller_host=CALLER)
+
+
+def test_returns_cold_start_target_type():
+    # Arrange
+    arg = "/home/me/proj/x"
+    # Act
+    t = parse_start_target(arg, caller_host=CALLER)
+    # Assert
+    assert isinstance(t, ColdStartTarget)

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__cold_start_materialize.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__cold_start_materialize.py
@@ -144,3 +144,88 @@ def test_dry_run_reports_would_create_action(tmp_path):
     plan = materialize_cold_start(t, base_dir=tmp_path / "agents", dry_run=True)
     # Assert
     assert plan.action == "would-create"
+
+
+# ---------------------------------------------------------------------------
+# resolve_cold_start_targets — the sac-start orchestration (fs-precedence)
+# ---------------------------------------------------------------------------
+
+from scitex_agent_container.cli_pkg.lifecycle._cold_start import (  # noqa: E402
+    resolve_cold_start_targets,
+)
+
+
+def test_plain_agent_name_passes_through_unchanged(tmp_path):
+    # Arrange
+    targets = ["proj-figrecipe"]
+    # Act
+    rewritten, plans = resolve_cold_start_targets(
+        targets, caller_host="h", base_dir=tmp_path / "agents"
+    )
+    # Assert
+    assert rewritten == ["proj-figrecipe"] and plans == []
+
+
+def test_existing_spec_yaml_path_passes_through(tmp_path):
+    # Arrange — an explicit spec.yaml path must NOT be cold-started.
+    spec = tmp_path / "foo" / "spec.yaml"
+    spec.parent.mkdir(parents=True)
+    spec.write_text("apiVersion: scitex-agent-container/v3\nkind: Agent\nspec: {}\n")
+    # Act
+    rewritten, plans = resolve_cold_start_targets(
+        [str(spec)], caller_host="h", base_dir=tmp_path / "agents"
+    )
+    # Assert
+    assert rewritten == [str(spec)] and plans == []
+
+
+def test_agents_root_dir_passes_through_for_bulk(tmp_path):
+    # Arrange — a dir with <name>/spec.yaml children = existing bulk target.
+    root = tmp_path / "agents_root"
+    (root / "a").mkdir(parents=True)
+    (root / "a" / "spec.yaml").write_text("kind: Agent\n")
+    # Act
+    rewritten, plans = resolve_cold_start_targets(
+        [str(root)], caller_host="h", base_dir=tmp_path / "agents"
+    )
+    # Assert
+    assert rewritten == [str(root)] and plans == []
+
+
+def test_workdir_path_is_cold_started_to_its_label(tmp_path):
+    # Arrange — a plain project workdir (no spec inside) → cold-start.
+    work = tmp_path / "myproj"
+    work.mkdir()
+    (work / "README.md").write_text("x")  # non-empty → a real workdir
+    # Act
+    rewritten, plans = resolve_cold_start_targets(
+        [str(work)], caller_host="h", base_dir=tmp_path / "agents"
+    )
+    # Assert
+    assert rewritten == ["myproj"]
+
+
+def test_workdir_cold_start_records_a_plan(tmp_path):
+    # Arrange
+    work = tmp_path / "myproj"
+    work.mkdir()
+    (work / "README.md").write_text("x")  # non-empty → a real workdir
+    # Act
+    rewritten, plans = resolve_cold_start_targets(
+        [str(work)], caller_host="h", base_dir=tmp_path / "agents"
+    )
+    # Assert
+    assert plans[0].label == "myproj" and plans[0].action == "create"
+
+
+def test_dry_run_would_create_is_not_added_to_launch_list(tmp_path):
+    # Arrange
+    work = tmp_path / "myproj"
+    work.mkdir()
+    (work / "README.md").write_text("x")  # non-empty → a real workdir
+    # Act
+    rewritten, plans = resolve_cold_start_targets(
+        [str(work)], caller_host="h", base_dir=tmp_path / "agents", dry_run=True
+    )
+    # Assert
+    assert rewritten == [] and plans[0].action == "would-create"

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__cold_start_materialize.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__cold_start_materialize.py
@@ -1,0 +1,146 @@
+"""Tests for cold-start spec materialization (operator TODO 2026-06-17).
+
+``materialize_cold_start`` turns a parsed :class:`ColdStartTarget` into a real
+``<agents-root>/<label>/{spec.yaml,to_home/}`` (minimal standardized TUI spec)
+and returns a plan, so ``sac start`` can then launch it through the existing
+flow. Contract:
+
+  * fresh label  → writes a v3-valid TUI spec (action="create").
+  * existing label, SAME workdir+host → reuse, no overwrite (action="reuse").
+  * existing label, DIFFERENT workdir/host → fail loud unless ``force``.
+  * ``dry_run`` → never writes; reports the intended action.
+
+Conventions: one assert / AAA markers; no mocks (real YAML under tmp_path,
+exercised through the production ``load_config`` / ``validate_config``).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container.cli_pkg.lifecycle._cold_start import (
+    ColdStartConflictError,
+    ColdStartTarget,
+    materialize_cold_start,
+)
+
+
+def _target(tmp_path: Path, label="figrecipe", host="ywata-note-win"):
+    return ColdStartTarget(label=label, host=host, workdir=str(tmp_path / "work"))
+
+
+def test_fresh_label_writes_spec_yaml(tmp_path):
+    # Arrange
+    t = _target(tmp_path)
+    # Act
+    plan = materialize_cold_start(t, base_dir=tmp_path / "agents")
+    # Assert
+    assert Path(plan.spec_path).is_file()
+
+
+def test_fresh_label_action_is_create(tmp_path):
+    # Arrange
+    t = _target(tmp_path)
+    # Act
+    plan = materialize_cold_start(t, base_dir=tmp_path / "agents")
+    # Assert
+    assert plan.action == "create"
+
+
+def test_written_spec_is_v3_valid(tmp_path):
+    # Arrange
+    import scitex_agent_container as sac
+
+    t = _target(tmp_path)
+    # Act
+    plan = materialize_cold_start(t, base_dir=tmp_path / "agents")
+    errors = sac.validate_config(plan.spec_path)
+    # Assert
+    assert errors == []
+
+
+def test_written_spec_is_tui_runtime(tmp_path):
+    # Arrange
+    from scitex_agent_container.config import load_config
+
+    t = _target(tmp_path)
+    # Act
+    plan = materialize_cold_start(t, base_dir=tmp_path / "agents")
+    cfg = load_config(plan.spec_path)
+    # Assert
+    assert cfg.runtime == "tui"
+
+
+def test_written_spec_has_the_workdir(tmp_path):
+    # Arrange
+    from scitex_agent_container.config import load_config
+
+    t = _target(tmp_path)
+    # Act
+    plan = materialize_cold_start(t, base_dir=tmp_path / "agents")
+    cfg = load_config(plan.spec_path)
+    # Assert
+    assert cfg.workdir == str(tmp_path / "work")
+
+
+def test_creates_to_home_dir(tmp_path):
+    # Arrange
+    t = _target(tmp_path)
+    # Act
+    materialize_cold_start(t, base_dir=tmp_path / "agents")
+    # Assert
+    assert (tmp_path / "agents" / "figrecipe" / "to_home").is_dir()
+
+
+def test_existing_label_same_target_is_reused(tmp_path):
+    # Arrange — materialize once, then again with the identical target.
+    t = _target(tmp_path)
+    materialize_cold_start(t, base_dir=tmp_path / "agents")
+    # Act
+    plan = materialize_cold_start(t, base_dir=tmp_path / "agents")
+    # Assert
+    assert plan.action == "reuse"
+
+
+def test_existing_label_different_workdir_fails_loud(tmp_path):
+    # Arrange — same label, different workdir → must not silently clobber.
+    materialize_cold_start(_target(tmp_path), base_dir=tmp_path / "agents")
+    other = ColdStartTarget(
+        label="figrecipe", host="ywata-note-win", workdir=str(tmp_path / "OTHER")
+    )
+    # Act
+    # Assert
+    with pytest.raises(ColdStartConflictError):
+        materialize_cold_start(other, base_dir=tmp_path / "agents")
+
+
+def test_existing_label_different_workdir_force_overwrites(tmp_path):
+    # Arrange
+    materialize_cold_start(_target(tmp_path), base_dir=tmp_path / "agents")
+    other = ColdStartTarget(
+        label="figrecipe", host="ywata-note-win", workdir=str(tmp_path / "OTHER")
+    )
+    # Act
+    plan = materialize_cold_start(other, base_dir=tmp_path / "agents", force=True)
+    # Assert
+    assert plan.action == "create"
+
+
+def test_dry_run_does_not_write_spec(tmp_path):
+    # Arrange
+    t = _target(tmp_path)
+    # Act
+    plan = materialize_cold_start(t, base_dir=tmp_path / "agents", dry_run=True)
+    # Assert
+    assert not Path(plan.spec_path).exists()
+
+
+def test_dry_run_reports_would_create_action(tmp_path):
+    # Arrange
+    t = _target(tmp_path)
+    # Act
+    plan = materialize_cold_start(t, base_dir=tmp_path / "agents", dry_run=True)
+    # Assert
+    assert plan.action == "would-create"

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__start.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__start.py
@@ -825,3 +825,61 @@ def test_start_command_exposes_strict_drift_flag():
     has_flag = "--strict-drift" in flag_names
     # Assert
     assert has_flag is True
+
+
+# ---------------------------------------------------------------------------
+# Cold-start forms (operator TODO 2026-06-17) — sac (agents) start <path|host>.
+# All use --dry-run so nothing launches or is written to the real agents root.
+# ---------------------------------------------------------------------------
+
+
+class TestColdStart:
+    def test_local_workdir_dry_run_prints_plan_and_exits_zero(self, tmp_path):
+        # Arrange — a non-empty project workdir (not an agents root).
+        work = tmp_path / "figdemo"
+        work.mkdir()
+        (work / "README.md").write_text("x")
+        # Act
+        result = CliRunner().invoke(start, [str(work), "--dry-run"])
+        # Assert
+        assert result.exit_code == 0
+
+    def test_local_workdir_dry_run_names_the_derived_label(self, tmp_path):
+        # Arrange
+        work = tmp_path / "figdemo"
+        work.mkdir()
+        (work / "README.md").write_text("x")
+        # Act
+        result = CliRunner().invoke(start, [str(work), "--dry-run"])
+        # Assert
+        assert "figdemo" in result.output
+
+    def test_local_workdir_dry_run_does_not_write_spec(self, tmp_path):
+        # Arrange
+        work = tmp_path / "figdemo-unique-xyz"
+        work.mkdir()
+        (work / "README.md").write_text("x")
+        # Act
+        CliRunner().invoke(start, [str(work), "--dry-run"])
+        # Assert — dry-run must not materialize into the real agents root.
+        from scitex_agent_container.cli_pkg._new import _default_base_dir
+
+        assert not (_default_base_dir() / "figdemo-unique-xyz").exists()
+
+    def test_json_dry_run_emits_cold_start_payload(self, tmp_path):
+        # Arrange
+        work = tmp_path / "figdemo"
+        work.mkdir()
+        (work / "README.md").write_text("x")
+        # Act
+        result = CliRunner().invoke(start, [str(work), "--dry-run", "--json"])
+        # Assert
+        assert "cold_start" in result.output
+
+    def test_malformed_form_fails_loud_exit_two(self):
+        # Arrange
+        arg = "fig@nohost"
+        # Act
+        result = CliRunner().invoke(start, [arg, "--dry-run"])
+        # Assert
+        assert result.exit_code == 2


### PR DESCRIPTION
## Why (operator TODO 2026-06-17)
Launch an agent for an arbitrary project workdir without hand-writing a spec.

Owner: proj-scitex-agent-container

## Forms (`sac agents start <TARGET>`)
| Form | label | host | workdir |
|------|-------|------|---------|
| `<label>@<host>:/path` | `<label>` | `<host>` | `/path` |
| `<host>:/path` | basename(path) | `<host>` | `/path` |
| `/path` (non-empty workdir) | basename | caller | `/path` |
| `.` | basename(cwd) | caller | cwd |

A plain name / `spec.yaml` path / bulk agents-dir / empty dir → **existing flow, untouched** (fs-precedence). Cold-start forms **materialize** `~/.scitex/agent-container/agents/<label>/{spec.yaml,to_home/}` (minimal standardized **TUI** spec) then launch via the existing path; `@host` rides the existing `spec.host` dispatch.

## Behaviour
- **Fail-loud, no silent fallback**: malformed form → `ColdStartParseError` (exit 2); existing label with different workdir/host → `ColdStartConflictError` (use `--force`).
- **Idempotent**: re-running a form with matching workdir+host reuses the spec.
- **`--dry-run`** prints the plan (no write/launch); **`--json`** emits it structured; explicit per-agent "cold-start … (action) host=… workdir=…" line; improved `start --help`.

## Note on `sac start`
Bare `sac start` remains the deprecated rename-redirect to `sac agents start` (CLI noun-verb convention unchanged). The forms work under the canonical **`sac agents start`** / `sac agent start`.

## Tests
38 new (parser 16, materialize+resolve 17, command 5); full lifecycle suite green; ruff clean. Caught + fixed a bulk-dir-detection regression via e2e before commit.

## Audit
`scitex-dev audit-all` is **SUCC on cli / skills / python-apis / mcp**; the lone `ERRO` is the **pre-existing repo-wide PS-140** (stale `tests/integration/test_cross_package_imports.py` gate) — not introduced here (same error on #417/#420), and the regen tool (`write-integration-tests`) is absent from the installed scitex-dev. Escalated to scitex-dev separately.