### PR TITLE
fix(tui): fail-loud on expired pinned creds + robust sac channel-MCP path

### DIFF
--- a/src/scitex_agent_container/runtimes/_apptainer_auth.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_auth.py
@@ -179,7 +179,73 @@ def auth_argv(config: AgentConfig, state_dir: Path) -> list[str]:
     return argv
 
 
-def credentials_file_bind(config: AgentConfig) -> list[str]:
+class CredentialExpiredError(RuntimeError):
+    """Raised when ``spec.claude.credentials_file`` resolves to an expired
+    or unverifiable OAuth credential.
+
+    Mirrors :class:`_apptainer_creds.PinnedAccountError`'s fail-loud
+    contract for the EXPLICIT-file path. ``resolve_cred_file`` only
+    expiry-checks the ``spec.claude.account`` branch; the explicit-file
+    branch was not checked, so a pinned ``credentials_file`` whose token
+    had expired was still bound ``:rw`` into the SIF. The in-container
+    ``claude`` then 401'd and exited before rendering, and
+    ``sac agents start`` collapsed to the opaque "runtime.start()
+    returned False / <empty — inner process exited before any output>"
+    failure with no cause (2026-06-17 ``ywatanabe-scitex-ai``). The
+    message names the resolved path and the remedy (``claude /login``
+    then re-snapshot) so the operator's next step is unambiguous.
+    """
+
+
+def _assert_credential_unexpired(
+    src: Path, *, origin: str, now: float | None = None
+) -> None:
+    """Fail loud if ``src`` has no verifiable, in-the-future OAuth expiry.
+
+    Reuses :func:`_account.creds_sync._read_oauth_expiry_seconds` (the
+    same ms→s normaliser the account-pinned resolver and the host
+    snapshot refreshers use) so every credential-freshness check in the
+    codebase agrees. ``now`` is a real-time injection seam for tests;
+    production passes ``None`` → ``time.time()``.
+
+    Raises :class:`CredentialExpiredError` when the file carries no
+    numeric ``claudeAiOauth.expiresAt`` (unverifiable) or that expiry is
+    already in the past (stale). Matches the account-pinned contract: a
+    launch-time-expired PINNED credential is an operator/refresher
+    problem to fix BEFORE launch, not something to bind-and-hope the
+    in-container ~1h refresh rescues — a dead refresh token cannot, which
+    is exactly how the opaque empty-pane failure arises.
+    """
+    import time
+
+    from .._account.creds_sync import _read_oauth_expiry_seconds
+
+    expiry = _read_oauth_expiry_seconds(src)
+    now_ts = now if now is not None else time.time()
+    if expiry is None:
+        raise CredentialExpiredError(
+            f"credentials file {src} ({origin}) has no numeric "
+            "`claudeAiOauth.expiresAt` — refusing to launch with an "
+            "unverifiable token. Fix: `claude /login` to that account on "
+            "this host, then `sac accounts save <account>` (snapshot it) "
+            "or `sac accounts sync-live`, and restart this agent."
+        )
+    if expiry <= now_ts:
+        ago = int(now_ts - expiry)
+        raise CredentialExpiredError(
+            f"credentials file {src} ({origin}) expired {ago}s ago — "
+            "refusing to launch a pinned agent with a stale token. The "
+            "in-container claude would 401 and exit before rendering, "
+            "surfacing only as an empty pane. Fix: `claude /login` to "
+            "that account on this host, then `sac accounts save "
+            "<account>` (or `sac accounts sync-live`), and restart this "
+            "agent."
+        )
+
+
+def credentials_file_bind(
+    config: AgentConfig, *, now: float | None = None
+) -> list[str]:
     """Render the writable file-bind for the agent's credentials file.
 
     Emitted LAST in :func:`_apptainer_build_argv.build_run_argv` (after
@@ -234,6 +300,14 @@ def credentials_file_bind(config: AgentConfig) -> list[str]:
                 "(the agent mounts it writable at $HOME/.claude/"
                 ".credentials.json as its single source of truth)."
             )
+        # Fail loud on an EXPIRED/unverifiable pinned credential BEFORE
+        # binding it into the SIF. The account branch below is already
+        # expiry-checked by ``resolve_cred_file`` (→ PinnedAccountError);
+        # the explicit-file branch was not, so a dead pinned token bound
+        # :rw made the in-container claude 401 and exit, collapsing
+        # ``sac agents start`` into the opaque "runtime.start() returned
+        # False / empty pane" failure (2026-06-17 ywatanabe-scitex-ai).
+        _assert_credential_unexpired(src, origin=src_origin, now=now)
     elif str(getattr(claude_spec, "account", "") or "").strip():
         # Account-pinned auto-resolution (operator+lead 2026-06-15):
         # delegate to the SDK-path resolver so SDK and TUI agree on
@@ -268,4 +342,4 @@ def credentials_file_bind(config: AgentConfig) -> list[str]:
     return ["--bind", f"{src}:{dest}:rw"]
 
 
-__all__ = ["auth_argv", "credentials_file_bind"]
+__all__ = ["CredentialExpiredError", "auth_argv", "credentials_file_bind"]

--- a/src/scitex_agent_container/runtimes/_apptainer_inner_argv.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_inner_argv.py
@@ -292,49 +292,50 @@ def _tui_runner_argv(
     return argv
 
 
-# Absolute path to the bundled ``sac`` console-script inside the base
-# SIF (sac-base.sif as of 2026-06-15). The script is installed under the
-# agent venv (``/opt/venv-agent/bin/sac``), NOT the SDK venv
-# (``/opt/venv-sac/bin/sac`` does not exist — verified by
-# ``ls /opt/venv-{agent,sac}/bin/sac`` in the running SIF).
+# In-SIF resolution of the bundled ``sac`` console-script for the
+# channel-MCP subscriber. The bundled ``claude`` TUI spawns it as an
+# stdio MCP subprocess INSIDE the SIF, so the command must point at
+# sac's REAL in-SIF location — which varies by image build:
 #
-# Why hardcode rather than ``shutil.which("sac")``: this constant is
-# read on the HOST when the SAC runtime builds the apptainer-exec
-# argv. The host's PATH (the SAC runtime inherits
-# ``/opt/venv-sac/bin:...``) does NOT include ``/opt/venv-agent/bin``,
-# so ``shutil.which("sac")`` would fail to find sac on the host even
-# though it exists inside the SIF. The path written here is the
-# IN-SIF absolute path the bundled claude will exec when it spawns
-# the channel-MCP subprocess; that filesystem is the SIF's, not the
-# host's, so the hardcoded SIF path is correct.
+#   * sac-base.sif (current, verified 2026-06-17): /opt/venv-sac/bin/sac
+#   * a prior build:                               /opt/venv-agent/bin/sac
 #
-# Under ``--containall --cleanenv`` the venv bin dir is NOT on PATH,
-# so a bare ``sac`` (as the host SDK path uses) is also unresolvable
-# from an MCP subprocess inside the SIF — the channel sidecar must
-# be invoked by absolute path.
-#
-# Operator override: set ``SAC_BIN_IN_SIF`` in the agent's env (e.g.
-# ``spec.env``) to point at a different in-SIF location if the image
-# is rebuilt with sac installed elsewhere. The constant below is the
-# default for the current sac-base.sif.
-_SAC_BIN_IN_SIF_DEFAULT = "/opt/venv-agent/bin/sac"
+# A single hardcoded path silently broke the channel the moment the SIF
+# layout flipped: claude reported ``server:sac · no MCP server configured
+# with that name`` because the subprocess ``command`` did not exist
+# (2026-06-17 figrecipe/neurovista/todo — the constant had been flipped
+# to ``/opt/venv-agent/bin/sac``, absent from sac-base.sif). The HOST
+# cannot probe the in-SIF filesystem while building the apptainer-exec
+# argv, so resolution is DEFERRED to spawn time: the MCP ``command`` is
+# ``/bin/sh -c <resolver>`` that tries the known venvs + PATH inside the
+# SIF and fails loud if none is executable (see :func:`_sac_channel_mcp_server`).
+# Absolute candidates make it PATH-independent under ``--containall`` /
+# ``--cleanenv`` where the venv bin dir may not be exported.
+
+# Ordered absolute in-SIF candidates (current build first), mirroring the
+# SDK runner's ``_sdk_channels._resolve_sac_binary`` candidate philosophy.
+_SAC_BIN_IN_SIF_CANDIDATES: tuple[str, ...] = (
+    "/opt/venv-sac/bin/sac",
+    "/opt/venv-agent/bin/sac",
+    "/usr/local/bin/sac",
+)
+
+# Back-compat single-path constant + helper. The channel MCP no longer
+# consumes these (it uses the spawn-time resolver below); kept for
+# external imports / single-path callers. Default corrected to the
+# verified current sac-base.sif location.
+_SAC_BIN_IN_SIF_DEFAULT = "/opt/venv-sac/bin/sac"
 
 
 def resolve_sac_bin_in_sif() -> str:
-    """Return the absolute in-SIF path to the ``sac`` console script.
+    """Return a best-effort single in-SIF path to the ``sac`` script.
 
-    Resolves at MCP-config build time on the HOST. Reads the
-    ``SAC_BIN_IN_SIF`` env var override first (operator escape hatch
-    when the SIF is rebuilt with sac in a non-default location); falls
-    back to :data:`_SAC_BIN_IN_SIF_DEFAULT`. NEVER attempts a host-side
-    ``shutil.which`` — the path is INSIDE the SIF; host PATH lookups
-    are noise here (the SAC runtime's PATH typically does not include
-    ``/opt/venv-agent/bin`` so ``which`` would mis-report).
-
-    The default is the verified location for ``sac-base.sif`` as of
-    2026-06-15; see the module-level comment for the verification
-    record. Override via ``SAC_BIN_IN_SIF`` env when the SIF layout
-    changes (this avoids hardcoding-shaped breakage on SIF rebuilds).
+    Honours the ``SAC_BIN_IN_SIF`` env override, else returns
+    :data:`_SAC_BIN_IN_SIF_DEFAULT`. NOTE: the channel-MCP subscriber no
+    longer uses this — it resolves sac at SPAWN time across
+    :data:`_SAC_BIN_IN_SIF_CANDIDATES` (robust to SIF venv layout); see
+    :func:`_sac_channel_mcp_server`. This helper remains for
+    backward-compatible imports and single-path callers.
     """
     override = _os.environ.get("SAC_BIN_IN_SIF", "").strip()
     if override:
@@ -344,9 +345,46 @@ def resolve_sac_bin_in_sif() -> str:
 
 # Backward-compat alias — keep imports of ``_SAC_BIN_IN_SIF`` working
 # (e.g. external skill-doc examples that referenced the legacy constant
-# name). New call sites should call :func:`resolve_sac_bin_in_sif` so
-# the env override takes effect.
+# name). New call sites should call :func:`resolve_sac_bin_in_sif`.
 _SAC_BIN_IN_SIF = _SAC_BIN_IN_SIF_DEFAULT
+
+
+def _sac_channel_mcp_server(channel_args: list[str]) -> dict:
+    """Build the stdio MCP-server spec for the ``sac mcp channel`` sub.
+
+    The ``command`` resolves sac's absolute path INSIDE the SIF at spawn
+    time — trying ``$SAC_BIN`` / ``$SAC_BIN_IN_SIF`` (operator override
+    via ``spec.env``), the known venv locations
+    (:data:`_SAC_BIN_IN_SIF_CANDIDATES`), then ``command -v sac`` — and
+    ``exec``s the first executable, passing ``channel_args`` through
+    unchanged via ``"$@"``. Fails loud (a stderr diagnostic + ``exit
+    127``) when sac is absent, so a missing binary surfaces as a named
+    error rather than the silent ``server:sac · no MCP server configured
+    with that name`` (2026-06-17). Absolute candidates make resolution
+    PATH-independent under ``--containall`` / ``--cleanenv``.
+
+    ``/bin/sh -c <resolver> sac <channel_args...>``: ``"sac"`` becomes
+    ``$0`` and ``channel_args`` become ``"$@"``, so the resolved binary
+    runs ``sac mcp channel --name <agent> [...]`` exactly.
+    """
+    candidates = (
+        '"$SAC_BIN" "$SAC_BIN_IN_SIF" '
+        + " ".join(_SAC_BIN_IN_SIF_CANDIDATES)
+        + ' "$(command -v sac 2>/dev/null)"'
+    )
+    resolver = (
+        f"for c in {candidates}; do "
+        'if [ -n "$c" ] && [ -x "$c" ]; then exec "$c" "$@"; fi; '
+        "done; "
+        ">&2 echo 'sac: binary not found in SIF; channel MCP cannot "
+        "start (set SAC_BIN_IN_SIF in spec.env or rebuild the image "
+        "with sac installed)'; exit 127"
+    )
+    return {
+        "type": "stdio",
+        "command": "/bin/sh",
+        "args": ["-c", resolver, "sac", *channel_args],
+    }
 
 
 def tui_channel_config(config: "AgentConfig") -> tuple[str | None, str | None]:
@@ -381,17 +419,7 @@ def tui_channel_config(config: "AgentConfig") -> tuple[str | None, str | None]:
         port = getattr(a2a_spec, "port", None) if a2a_spec else None
         if isinstance(port, int) and port > 0:
             args += ["--turn-url", f"http://127.0.0.1:{port}/v1/turn"]
-        channel_mcp = json.dumps(
-            {
-                "mcpServers": {
-                    "sac": {
-                        "type": "stdio",
-                        "command": resolve_sac_bin_in_sif(),
-                        "args": args,
-                    }
-                }
-            }
-        )
+        channel_mcp = json.dumps({"mcpServers": {"sac": _sac_channel_mcp_server(args)}})
     return dev_channels, channel_mcp
 
 

--- a/tests/scitex_agent_container/runtimes/test__apptainer_build_argv.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_build_argv.py
@@ -37,7 +37,10 @@ from typing import Iterator
 import pytest
 
 from scitex_agent_container.config import load_config
-from scitex_agent_container.runtimes._apptainer_auth import credentials_file_bind
+from scitex_agent_container.runtimes._apptainer_auth import (
+    CredentialExpiredError,
+    credentials_file_bind,
+)
 from scitex_agent_container.runtimes._apptainer_build_argv import build_run_argv
 from scitex_agent_container.runtimes._apptainer_inner_argv import (
     build_inner_argv,
@@ -209,10 +212,15 @@ def test_credentials_file_bind_empty_when_unset(tui_config) -> None:
 
 
 def test_credentials_file_bind_mounts_designated_file_rw(tmp_path) -> None:
-    # Arrange — a designated credentials file on disk.
+    # Arrange — a designated credentials file on disk carrying a valid,
+    # unexpired OAuth token (the bind now fails loud on a stale or
+    # unverifiable pinned credential — see the expiry tests below).
     creds = tmp_path / "acct" / ".credentials.json"
     creds.parent.mkdir(parents=True, exist_ok=True)
-    creds.write_text("{}", encoding="utf-8")
+    creds.write_text(
+        '{"claudeAiOauth": {"accessToken": "tok", "expiresAt": 9999999999000}}',
+        encoding="utf-8",
+    )
     spec = _write_spec(
         tmp_path,
         _BASE_SPEC.format(extra=f"    credentials_file: {creds}"),
@@ -290,7 +298,8 @@ def test_credentials_file_bind_explicit_file_wins_over_account(
     explicit = tmp_path / "explicit" / ".credentials.json"
     explicit.parent.mkdir(parents=True, exist_ok=True)
     explicit.write_text(
-        '{"claudeAiOauth": {"accessToken": "explicit"}}', encoding="utf-8"
+        '{"claudeAiOauth": {"accessToken": "explicit", "expiresAt": 9999999999000}}',
+        encoding="utf-8",
     )
     spec = _write_spec(
         tmp_path,
@@ -327,6 +336,52 @@ def test_credentials_file_bind_account_pinned_raises_on_missing_snapshot(
     # Act
     # Assert
     with pytest.raises(PinnedAccountError, match=r"nonexistent-account"):
+        credentials_file_bind(config)
+
+
+def test_credentials_file_bind_designated_expired_token_fails_loud(
+    tmp_path: Path,
+) -> None:
+    # Arrange — designate a credentials file whose OAuth token expired in
+    # the past relative to the injected ``now``. Before this guard the
+    # expired file was bound :rw and the in-container claude 401'd and
+    # exited, surfacing only as the opaque empty-pane start failure.
+    creds = tmp_path / "acct" / ".credentials.json"
+    creds.parent.mkdir(parents=True, exist_ok=True)
+    creds.write_text(
+        '{"claudeAiOauth": {"accessToken": "stale", "expiresAt": 1700000000000}}',
+        encoding="utf-8",
+    )
+    spec = _write_spec(
+        tmp_path,
+        _BASE_SPEC.format(extra=f"    credentials_file: {creds}"),
+    )
+    config = load_config(str(spec))
+    # Act — ``now`` (2027) is well after the token's 2023 expiry.
+    # Assert
+    with pytest.raises(CredentialExpiredError, match=r"expired"):
+        credentials_file_bind(config, now=1_800_000_000.0)
+
+
+def test_credentials_file_bind_designated_missing_expiry_fails_loud(
+    tmp_path: Path,
+) -> None:
+    # Arrange — designate a credentials file with no numeric expiresAt;
+    # the token cannot be verified fresh, so the launch must abort loud
+    # rather than bind an unverifiable credential.
+    creds = tmp_path / "acct" / ".credentials.json"
+    creds.parent.mkdir(parents=True, exist_ok=True)
+    creds.write_text(
+        '{"claudeAiOauth": {"accessToken": "no-expiry"}}', encoding="utf-8"
+    )
+    spec = _write_spec(
+        tmp_path,
+        _BASE_SPEC.format(extra=f"    credentials_file: {creds}"),
+    )
+    config = load_config(str(spec))
+    # Act
+    # Assert
+    with pytest.raises(CredentialExpiredError, match=r"unverifiable"):
         credentials_file_bind(config)
 
 
@@ -505,10 +560,13 @@ def test_tui_channel_config_command_is_resolved_sac_path(tmp_path) -> None:
 
 
 def test_build_run_argv_appends_credentials_bind_last(tmp_path) -> None:
-    # Arrange — designated creds + a real spec.
+    # Arrange — designated creds (valid, unexpired) + a real spec.
     creds = tmp_path / "acct" / ".credentials.json"
     creds.parent.mkdir(parents=True, exist_ok=True)
-    creds.write_text("{}", encoding="utf-8")
+    creds.write_text(
+        '{"claudeAiOauth": {"accessToken": "tok", "expiresAt": 9999999999000}}',
+        encoding="utf-8",
+    )
     spec = _write_spec(
         tmp_path,
         _BASE_SPEC.format(extra=f"    credentials_file: {creds}"),

--- a/tests/scitex_agent_container/runtimes/test__apptainer_build_argv.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_build_argv.py
@@ -458,6 +458,24 @@ def test_tui_channel_config_registers_sac_channel_subscriber(tmp_path) -> None:
     assert channel_mcp is not None and "mcp" in channel_mcp and "channel" in channel_mcp
 
 
+def test_tui_channel_config_sac_subscriber_resolves_across_venvs(tmp_path) -> None:
+    # Arrange — a server:sac channel spec.
+    spec = _write_spec(tmp_path, _SPEC_WITH_CHANNEL)
+    config = load_config(str(spec))
+    # Act
+    _, channel_mcp = tui_channel_config(config)
+    # Assert — the subscriber command is a spawn-time /bin/sh resolver
+    # that tries BOTH known venv locations (robust to the SIF layout flip
+    # that silently broke server:sac on 2026-06-17), not a single
+    # hardcoded path that goes stale on the next image rebuild.
+    assert (
+        channel_mcp is not None
+        and '"command": "/bin/sh"' in channel_mcp
+        and "/opt/venv-sac/bin/sac" in channel_mcp
+        and "/opt/venv-agent/bin/sac" in channel_mcp
+    )
+
+
 def test_build_run_argv_tui_adds_dev_channels_flag(
     tmp_path, listen_bearer_token
 ) -> None:
@@ -493,17 +511,18 @@ def test_build_run_argv_tui_injects_channel_subscriber_mcp(
     )
     # Assert — the inline sac-channel subscriber rides on --mcp-config
     # (preflight-wrapped on non-relaxed specs, so check the joined argv).
-    # The command must be the in-SIF absolute path of the `sac` console
-    # script. The default is /opt/venv-agent/bin/sac (verified in
-    # sac-base.sif 2026-06-15; the old /opt/venv-sac/bin/sac hardcode
-    # was wrong — the binary lives under the agent venv, not the SDK
-    # venv). The bare command must NOT be just `sac` (PR #407 silent-
-    # exec-fail class).
+    # The command resolves sac's in-SIF path at SPAWN time via /bin/sh
+    # across the known venv candidates (robust to SIF layout — a single
+    # hardcode silently broke server:sac when sac-base.sif moved it from
+    # /opt/venv-agent to /opt/venv-sac, 2026-06-17). The resolver must
+    # reference the current sac-base.sif location and still drive
+    # `sac ... channel`. A bare `"command": "sac"` would silent-exec-fail
+    # under --containall (PR #407 class); the absolute candidates avoid it.
     joined = " ".join(argv)
-    assert '"command": "/opt/venv-agent/bin/sac"' in joined and '"channel"' in joined
+    assert "/opt/venv-sac/bin/sac" in joined and '"channel"' in joined
 
 
-def test_resolve_sac_bin_in_sif_returns_agent_venv_path() -> None:
+def test_resolve_sac_bin_in_sif_returns_sac_venv_path() -> None:
     # Arrange — no override
     saved = os.environ.pop("SAC_BIN_IN_SIF", None)
     try:
@@ -513,10 +532,11 @@ def test_resolve_sac_bin_in_sif_returns_agent_venv_path() -> None:
         )
 
         path = resolve_sac_bin_in_sif()
-        # Assert — the verified in-SIF default. If someone changes this
-        # they must verify with `ls /opt/venv-agent/bin/sac` inside the
-        # running SIF and update both the constant and this test.
-        assert path == "/opt/venv-agent/bin/sac"
+        # Assert — the verified current sac-base.sif location (2026-06-17:
+        # `ls /opt/venv-{agent,sac}/bin/sac` → only venv-sac exists). The
+        # channel MCP itself resolves across candidates at spawn time;
+        # this single-path helper just must not point at a phantom path.
+        assert path == "/opt/venv-sac/bin/sac"
     finally:
         if saved is not None:
             os.environ["SAC_BIN_IN_SIF"] = saved
@@ -551,12 +571,13 @@ def test_tui_channel_config_command_is_resolved_sac_path(tmp_path) -> None:
     config = load_config(str(spec))
     # Act
     _, channel_mcp = tui_channel_config(config)
-    # Assert — the inline JSON's command is the resolver's value
-    # (defaults to /opt/venv-agent/bin/sac for sac-base.sif). The
-    # legacy /opt/venv-sac/bin/sac would silently fail exec inside
-    # the SIF since the binary does not exist there. ``"" in None``
-    # would TypeError, so the None-check is structurally embedded.
-    assert '"command": "/opt/venv-agent/bin/sac"' in (channel_mcp or "")
+    # Assert — the inline JSON's command is the /bin/sh spawn-time
+    # resolver, NOT a single hardcoded venv path (the
+    # /opt/venv-agent/bin/sac hardcode silently broke server:sac on
+    # 2026-06-17 when sac-base.sif shipped sac under /opt/venv-sac).
+    # The resolver exec's the first executable candidate inside the SIF.
+    # ``"" in None`` would TypeError, so the None-check is embedded.
+    assert '"command": "/bin/sh"' in (channel_mcp or "")
 
 
 def test_build_run_argv_appends_credentials_bind_last(tmp_path) -> None:


### PR DESCRIPTION
## Two TUI fleet-launch bugs, found dogfooding the local fleet (2026-06-17)

Both surfaced bringing up `proj-scitex-dev` / `proj-figrecipe` as `runtime: tui` agents.

### 1. Expired pinned `credentials_file` → opaque "empty pane" failure
`spec.claude.credentials_file` was bound `:rw` into the SIF after only an `is_file()` check — no expiry validation (the `account:` branch already guards via `resolve_cred_file` → `PinnedAccountError`). An expired pinned token whose refresh token is dead (`ywatanabe-scitex-ai`, expired −4h) bound silently; the in-container claude 401'd and exited before rendering, and `sac agents start` collapsed to:

```
Failed to start agent 'proj-scitex-dev': runtime.start() returned False.
  pane tail: <empty — inner process exited before any output>
```

**Fix:** `CredentialExpiredError` + a shared `_assert_credential_unexpired` (reuses `_account.creds_sync._read_oauth_expiry_seconds`); the explicit-file branch now aborts pre-exec naming the path + remedy (`claude /login` then re-snapshot). `now=` test seam.

### 2. sac channel-MCP spawned at a non-existent path → agent deaf to the bus
The TUI channel subscriber spawned `sac mcp channel` via a single hardcoded `_SAC_BIN_IN_SIF_DEFAULT = /opt/venv-agent/bin/sac` — which does **not** exist in the current `sac-base.sif` (sac lives at `/opt/venv-sac/bin/sac`). The `sac` MCP server died on spawn → `server:sac · no MCP server configured with that name` → the agent could not receive a2a-bus channel pushes. The rest of the codebase already uses the correct path (`config/_loaders.py`, image-build/deploy skills); only this resolver was flipped.

**Fix:** defer resolution to spawn time — the channel MCP command is now `/bin/sh -c <resolver> sac <args>` trying `$SAC_BIN`/`$SAC_BIN_IN_SIF` (override), `/opt/venv-{sac,agent}/bin/sac`, `/usr/local/bin/sac`, then `command -v sac`; `exec`s the first executable, fails loud (`exit 127` + stderr) if none. PATH-independent for the absolute candidates under `--containall`. Robust to SIF venv-layout flips; mirrors the SDK runner's `_sdk_channels` candidate philosophy.

### Testing
- `tests/scitex_agent_container/runtimes/` full dir: **850 passed, 14 skipped** (skips = live-binary/tmux/apptainer smoke).
- `scitex-dev ecosystem audit-all scitex-agent-container`: all SUCC.
- New tests: expired + unverifiable pinned cred fail loud; channel MCP command is `/bin/sh` and resolves across both venvs.
- Resolver verified in the real SIF: resolves `/opt/venv-sac/bin/sac`, runs `sac --version`.

### Rollout
No SIF rebuild needed (resolver runs at spawn time against the existing in-SIF sac). After merge: pull `develop` on the host, then `sac agents restart <agent>`. Immediate workaround without this PR: set `SAC_BIN_IN_SIF=/opt/venv-sac/bin/sac` in the agent's `spec.env` — the legacy resolver honors it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
