### PR TITLE
feat(tui): A2A wake-on-push parity — host-side /v1/turn → tmux bridge

### DIFF
--- a/src/scitex_agent_container/runtimes/_tui_turn_bridge.py
+++ b/src/scitex_agent_container/runtimes/_tui_turn_bridge.py
@@ -208,7 +208,7 @@ def build_server(
     return _TurnBridgeServer((host, port), on_turn, agent_name)
 
 
-def serve(
+def serve(  # pragma: no cover - integration entry: installs main-thread-only signal handlers + blocks in serve_forever; the server logic is unit-tested via build_server, the full serve path is exercised end-to-end
     *, host: str, port: int, on_turn: Callable[[str], None], agent_name: str
 ) -> None:
     """Run the bridge server until the process is signalled. Blocking."""
@@ -233,18 +233,24 @@ def serve(
 # ---------------------------------------------------------------------------
 # Subprocess entry point
 # ---------------------------------------------------------------------------
-def _build_on_turn(config: AgentConfig) -> Callable[[str], None]:
+def _build_on_turn(
+    config: AgentConfig, *, runtime: Any | None = None
+) -> Callable[[str], None]:
     """Inject callback that drives one TUI turn via the tmux PTY.
 
-    Reuses :meth:`TuiSessionRuntime.send_turn` so the bridge inherits the
-    same modal-drain + input-ready gating an operator ``sac agents send``
-    gets. Raises when the session is gone so the handler answers 502 (the
-    channel subscriber's ``raise_for_status`` then surfaces it loud rather
-    than pretending the wake landed).
+    Calls :meth:`TuiSessionRuntime.send_turn` with ``wait_ready=False``
+    (see the inline note). Raises when the session is gone so the handler
+    answers 502 (the channel subscriber's ``raise_for_status`` then
+    surfaces it loud rather than pretending the wake landed). ``runtime``
+    is a test seam — production constructs the real
+    :class:`TuiSessionRuntime`.
     """
-    from .tui_session import TuiSessionRuntime
+    if (
+        runtime is None
+    ):  # pragma: no cover - trivial default-construct of the real runtime
+        from .tui_session import TuiSessionRuntime
 
-    runtime = TuiSessionRuntime()
+        runtime = TuiSessionRuntime()
 
     def on_turn(text: str) -> None:
         # ``wait_ready=False`` → the bare send_text_and_submit primitive
@@ -267,7 +273,9 @@ def _build_on_turn(config: AgentConfig) -> Callable[[str], None]:
     return on_turn
 
 
-def main(argv: list[str] | None = None) -> int:
+def main(
+    argv: list[str] | None = None,
+) -> int:  # pragma: no cover - subprocess entry: parses args, loads the spec, and blocks in serve(); exercised end-to-end (the launcher spawns it), not unit
     parser = argparse.ArgumentParser(prog="tui-turn-bridge")
     parser.add_argument("--config-path", required=True)
     parser.add_argument("--port", type=int, required=True)

--- a/src/scitex_agent_container/runtimes/_tui_turn_bridge.py
+++ b/src/scitex_agent_container/runtimes/_tui_turn_bridge.py
@@ -1,0 +1,409 @@
+"""Host-side A2A ``/v1/turn`` → tmux bridge for ``runtime: tui`` agents.
+
+Closes the wake-on-push gap that left interactive TUI agents reachable on
+the ``sac listen`` bus (via the ``sac mcp channel`` subscriber) but unable
+to ACT on a pushed message while idle.
+
+Background (2026-06-17). The SDK runtime serves a ``/v1/turn`` HTTP
+endpoint from its in-SIF runner (``_runners/_session_http.py``); the
+channel subscriber's wake primitive (``_mcp/_channel_wake._wake_turn``)
+POSTs each qualifying bus event there so an IDLE agent is DRIVEN to
+process it immediately. The TUI runtime runs interactive ``claude`` in
+tmux — no in-process HTTP server — so that wake POST hit a dead port
+(``[Errno 110] Connection timed out``) and the message only landed as a
+``notifications/claude/channel`` MCP notification, which (per channel.py)
+"cannot wake an idle session". Net effect: a TUI agent received nothing
+actionable until some unrelated next turn.
+
+This module gives TUI agents the SAME turn endpoint, host-side (where the
+tmux PTY lives — the in-SIF subscriber POSTs to ``127.0.0.1:<port>`` and
+apptainer shares the host net namespace). On ``POST /v1/turn`` it injects
+the ``text`` into the agent's tmux session via
+:meth:`TuiSessionRuntime.send_turn` — the exact delivery path an operator
+``sac agents send`` uses — and returns ``200`` as soon as the keystrokes
+are delivered (the driven turn runs asynchronously in the TUI; its own
+Stop hook PUSHes any completion report back, same as the SDK path).
+
+Wire format mirrors ``_session_http`` so ``_wake_turn`` and A2A clients
+work unchanged:
+
+    POST /v1/turn                      (bare — the port identifies the agent)
+    POST /agents/<name>/turn           (canonical sac namespace)
+    POST /agents/<name>/send           (A2A v1 alias)
+    Content-Type: application/json
+    {"text": "...", "from_agent": "<peer>"?, "dispatch_id": "<id>"?}
+
+    200 {"text": "", "delivered": true, "mode": "tui-tmux-inject", "agent": "<name>"}
+    400 {"error": "missing or empty 'text' field"}        # schema mismatch, loud
+    404 {"error": "..."}                                  # unknown route / wrong agent
+    502 {"error": "tui inject failed: ..."}               # session gone / input wedged
+
+Lifecycle mirrors :mod:`a2a_sidecar`: :func:`start_turn_bridge` spawns the
+server as a detached subprocess (so it outlives the ``sac agents start``
+process, like the tmux session it serves), writing a PID file + log under
+the agent's per-host state dir; :func:`stop_turn_bridge` SIGTERMs it.
+Both are best-effort — a failed bridge must never block agent start/stop.
+Bound to ``127.0.0.1`` (the wake POST is loopback; the bind is the
+security boundary, matching the SDK runner which does not auth /v1/turn).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import signal
+import subprocess
+import sys
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any, Callable
+
+from ..config import AgentConfig
+
+log = logging.getLogger(__name__)
+
+PID_FILENAME = "tui-turn-bridge.pid"
+LOG_FILENAME = "tui-turn-bridge.log"
+MODULE_PATH = "scitex_agent_container.runtimes._tui_turn_bridge"
+DEFAULT_HOST = "127.0.0.1"
+
+
+# ---------------------------------------------------------------------------
+# Port + routing helpers
+# ---------------------------------------------------------------------------
+def resolved_a2a_port(config: AgentConfig) -> int | None:
+    """Return the agent's resolved a2a port as a positive int, else None.
+
+    By the time the runtime starts, ``sac agents start`` has resolved a
+    ``spec.a2a.port: auto`` to a concrete int (the SAME value threaded
+    into the channel subscriber's ``--turn-url`` — see
+    ``_apptainer_inner_argv.tui_channel_config``), so the bridge binds the
+    port the subscriber will POST to. Returns None when a2a is unset or
+    still unresolved (caller no-ops — no endpoint to serve).
+    """
+    a2a = getattr(config, "a2a", None)
+    port = getattr(a2a, "port", None) if a2a is not None else None
+    if isinstance(port, bool):  # bool is an int subclass — reject explicitly
+        return None
+    if isinstance(port, int) and port > 0:
+        return port
+    return None
+
+
+def is_turn_route(path: str, agent_name: str) -> bool:
+    """True iff ``path`` is a turn-delivery route for ``agent_name``.
+
+    Accepts the bare ``/v1/turn`` (the port already identifies the agent)
+    and the named ``/agents/<agent_name>/{turn,send}`` aliases. A named
+    route for a DIFFERENT agent is rejected (the caller returns 404) so a
+    misrouted POST fails loud rather than landing in the wrong session.
+    """
+    clean = path.split("?", 1)[0].rstrip("/")
+    if clean == "/v1/turn":
+        return True
+    if agent_name and clean in (
+        f"/agents/{agent_name}/turn",
+        f"/agents/{agent_name}/send",
+    ):
+        return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# HTTP server
+# ---------------------------------------------------------------------------
+class _TurnBridgeServer(ThreadingHTTPServer):
+    """Threading HTTP server carrying the agent name + inject callback.
+
+    ``daemon_threads`` so a SIGTERM tears the server down without waiting
+    on an in-flight inject thread (the keystrokes are already delivered;
+    the driven turn lives in the TUI, not here).
+    """
+
+    daemon_threads = True
+    allow_reuse_address = True
+
+    def __init__(
+        self,
+        server_address: tuple[str, int],
+        on_turn: Callable[[str], None],
+        agent_name: str,
+    ) -> None:
+        super().__init__(server_address, _TurnBridgeHandler)
+        self.on_turn = on_turn
+        self.agent_name = agent_name
+
+
+class _TurnBridgeHandler(BaseHTTPRequestHandler):
+    """One route family: turn delivery + a health probe."""
+
+    # Silence the default stderr access log — the bridge log file is for
+    # our own diagnostics, not one line per loopback POST.
+    def log_message(self, format: str, *args: Any) -> None:  # noqa: A002,D401
+        return
+
+    def _srv(self) -> _TurnBridgeServer:
+        # Real narrowing (PA-306 no-mocks): ``self.server`` IS a
+        # _TurnBridgeServer at runtime; assert it so type-checkers see the
+        # ``on_turn`` / ``agent_name`` attributes without a class-level
+        # annotation override Pyright rejects as variance-incompatible.
+        srv = self.server
+        assert isinstance(srv, _TurnBridgeServer)
+        return srv
+
+    def _respond(self, code: int, obj: dict) -> None:
+        body = json.dumps(obj).encode("utf-8")
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self) -> None:  # noqa: N802 (stdlib handler contract)
+        if self.path.split("?", 1)[0].rstrip("/") == "/health":
+            self._respond(200, {"status": "ok", "agent": self._srv().agent_name})
+            return
+        self._respond(404, {"error": f"no GET route {self.path!r}"})
+
+    def do_POST(self) -> None:  # noqa: N802 (stdlib handler contract)
+        srv = self._srv()
+        # Drain the request body FIRST (even on a route miss) so a 404
+        # never leaves an unread body on the socket.
+        length = int(self.headers.get("Content-Length", 0) or 0)
+        raw = self.rfile.read(length) if length > 0 else b""
+        if not is_turn_route(self.path, srv.agent_name):
+            self._respond(404, {"error": f"no turn route {self.path!r}"})
+            return
+        try:
+            body = json.loads(raw or b"{}")
+        except ValueError as exc:
+            self._respond(400, {"error": f"bad JSON: {exc}"})
+            return
+        text = body.get("text") if isinstance(body, dict) else None
+        if not isinstance(text, str) or not text.strip():
+            self._respond(400, {"error": "missing or empty 'text' field"})
+            return
+        try:
+            srv.on_turn(text)
+        except Exception as exc:  # stx-allow: fallback (reason: surface inject failure as 502 instead of crashing the bridge; the wake POST's raise_for_status then propagates it loud to the channel subscriber)
+            self._respond(502, {"error": f"tui inject failed: {exc}"})
+            return
+        self._respond(
+            200,
+            {
+                "text": "",
+                "delivered": True,
+                "mode": "tui-tmux-inject",
+                "agent": srv.agent_name,
+            },
+        )
+
+
+def build_server(
+    *, host: str, port: int, on_turn: Callable[[str], None], agent_name: str
+) -> _TurnBridgeServer:
+    """Construct (but do not run) the bridge server. Test seam."""
+    return _TurnBridgeServer((host, port), on_turn, agent_name)
+
+
+def serve(
+    *, host: str, port: int, on_turn: Callable[[str], None], agent_name: str
+) -> None:
+    """Run the bridge server until the process is signalled. Blocking."""
+    server = build_server(host=host, port=port, on_turn=on_turn, agent_name=agent_name)
+
+    def _graceful(*_a: Any) -> None:
+        # serve_forever() runs in the main thread here; shutdown() must be
+        # called from another thread, so the signal handler spawns one.
+        import threading
+
+        threading.Thread(target=server.shutdown, daemon=True).start()
+
+    signal.signal(signal.SIGTERM, _graceful)
+    signal.signal(signal.SIGINT, _graceful)
+    log.info("tui-turn-bridge: serving %s on %s:%d", agent_name, host, port)
+    try:
+        server.serve_forever()
+    finally:
+        server.server_close()
+
+
+# ---------------------------------------------------------------------------
+# Subprocess entry point
+# ---------------------------------------------------------------------------
+def _build_on_turn(config: AgentConfig) -> Callable[[str], None]:
+    """Inject callback that drives one TUI turn via the tmux PTY.
+
+    Reuses :meth:`TuiSessionRuntime.send_turn` so the bridge inherits the
+    same modal-drain + input-ready gating an operator ``sac agents send``
+    gets. Raises when the session is gone so the handler answers 502 (the
+    channel subscriber's ``raise_for_status`` then surfaces it loud rather
+    than pretending the wake landed).
+    """
+    from .tui_session import TuiSessionRuntime
+
+    runtime = TuiSessionRuntime()
+
+    def on_turn(text: str) -> None:
+        # ``wait_ready=False`` → the bare send_text_and_submit primitive
+        # (text + Enter), the operator-confirmed delivery path
+        # (``send_turn`` itself defaults to it for that reason). The full
+        # ``wait_until_input_ready`` drain blocks up to 60s polling for a
+        # "? for shortcuts" marker that an autonomous agent's idle pane may
+        # never render — fatal for a wake POST. First-launch modals are
+        # already drained by ``start()._drain_at_boot``; a live wake into
+        # an idle ❯ needs no drain. claude queues keystrokes typed mid-turn
+        # and submits them when the input rebinds, so a wake during an
+        # active turn is not dropped.
+        delivered = runtime.send_turn(config, text, wait_ready=False)
+        if not delivered:
+            raise RuntimeError(
+                f"TUI session for agent {config.name!r} does not exist; "
+                "cannot deliver the pushed turn."
+            )
+
+    return on_turn
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="tui-turn-bridge")
+    parser.add_argument("--config-path", required=True)
+    parser.add_argument("--port", type=int, required=True)
+    parser.add_argument("--host", default=DEFAULT_HOST)
+    args = parser.parse_args(argv)
+
+    from ..config import load_config
+
+    config = load_config(args.config_path)
+    serve(
+        host=args.host,
+        port=args.port,
+        on_turn=_build_on_turn(config),
+        agent_name=config.name,
+    )
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Launcher / lifecycle (mirrors a2a_sidecar)
+# ---------------------------------------------------------------------------
+def _state_dir(config: AgentConfig) -> Path:
+    from .tui_session import state_dir_for_config
+
+    return state_dir_for_config(config)
+
+
+def _pid_path(config: AgentConfig) -> Path:
+    return _state_dir(config) / PID_FILENAME
+
+
+def start_turn_bridge(
+    config: AgentConfig,
+    *,
+    spawn: Callable[..., Any] = subprocess.Popen,
+    host: str = DEFAULT_HOST,
+) -> int | None:
+    """Spawn the detached turn bridge for ``config``; return its PID or None.
+
+    No-op (returns None) when the agent declares no resolved ``a2a.port``
+    — without an a2a port the channel subscriber has no ``--turn-url`` to
+    POST to, so there is nothing to serve. Best-effort: a spawn failure is
+    logged and swallowed (a dead bridge must not block agent start). The
+    ``spawn`` seam lets tests assert the argv without a real subprocess.
+    """
+    port = resolved_a2a_port(config)
+    if port is None:
+        return None
+    config_path = str(getattr(config, "config_path", "") or "")
+    if not config_path:
+        log.warning(
+            "tui-turn-bridge: agent %r has no config_path; cannot start bridge",
+            getattr(config, "name", "?"),
+        )
+        return None
+    state_dir = _state_dir(config)
+    state_dir.mkdir(parents=True, exist_ok=True)
+    argv = [
+        sys.executable,
+        "-m",
+        MODULE_PATH,
+        "--config-path",
+        config_path,
+        "--port",
+        str(port),
+        "--host",
+        host,
+    ]
+    try:
+        log_fh = open(state_dir / LOG_FILENAME, "ab")
+        proc = spawn(
+            argv,
+            stdout=log_fh,
+            stderr=log_fh,
+            stdin=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+    except Exception as exc:  # stx-allow: fallback (reason: best-effort sidecar — a spawn failure must not wedge agent start; logged for the operator)
+        log.warning("tui-turn-bridge: failed to spawn for %r: %s", config.name, exc)
+        return None
+    pid = getattr(proc, "pid", None)
+    if isinstance(pid, int):
+        _pid_path(config).write_text(str(pid), encoding="utf-8")
+    log.info(
+        "tui-turn-bridge: started for %s on %s:%d (pid=%s)",
+        config.name,
+        host,
+        port,
+        pid,
+    )
+    return pid
+
+
+def stop_turn_bridge(config: AgentConfig) -> bool:
+    """SIGTERM the bridge recorded in the PID file; return True if one was.
+
+    No-op (returns False) when no PID file exists. The PID file is the
+    source of truth and is removed regardless of whether the process was
+    still alive, so a stop()->start() cycle never reuses a stale PID.
+    """
+    pid_path = _pid_path(config)
+    if not pid_path.is_file():
+        return False
+    stopped = False
+    try:
+        pid = int(pid_path.read_text(encoding="utf-8").strip())
+    except (
+        OSError,
+        ValueError,
+    ):  # stx-allow: fallback (reason: an unreadable/corrupt PID file is treated as "already stopped"; we still unlink it below so the next start is clean)
+        pid = -1
+    if pid > 0:
+        try:
+            os.kill(pid, signal.SIGTERM)
+            stopped = True
+        except ProcessLookupError:
+            stopped = False
+        except OSError as exc:  # stx-allow: fallback (reason: a permission/ESRCH error still means "not our live process"; log + treat as stopped so cleanup proceeds)
+            log.warning("tui-turn-bridge: SIGTERM pid %d failed: %s", pid, exc)
+    try:
+        pid_path.unlink()
+    except OSError:  # stx-allow: fallback (reason: unlink race is harmless — the file is gone either way)
+        pass
+    return stopped
+
+
+if __name__ == "__main__":  # pragma: no cover -- exercised as a subprocess
+    raise SystemExit(main())
+
+
+__all__ = [
+    "resolved_a2a_port",
+    "is_turn_route",
+    "build_server",
+    "serve",
+    "main",
+    "start_turn_bridge",
+    "stop_turn_bridge",
+]

--- a/src/scitex_agent_container/runtimes/tui_session.py
+++ b/src/scitex_agent_container/runtimes/tui_session.py
@@ -164,6 +164,8 @@ class TuiSessionRuntime(RuntimeBase):
         multiplexer: Any | None = None,
         claude_bin: str = _CLAUDE_BIN_DEFAULT,
         command_builder: Any | None = None,
+        turn_bridge_start: Any | None = None,
+        turn_bridge_stop: Any | None = None,
     ) -> None:
         # Default to the real TmuxManager; tests pass an in-memory
         # MultiplexerProtocol fake. No mocks — the fake is a real
@@ -178,6 +180,15 @@ class TuiSessionRuntime(RuntimeBase):
         # returns a deterministic argv so the tmux-dispatch glue runs
         # without a real apptainer/SIF. Default = :meth:`_default_argv`.
         self._command_builder = command_builder or self._default_argv
+        # Injection seams for the A2A turn bridge — ``(config) -> Any``.
+        # The bridge gives a TUI agent the same ``/v1/turn`` endpoint the
+        # SDK runner serves, so a bus-pushed message WAKES the idle TUI
+        # (see :mod:`_tui_turn_bridge`). ``None`` → resolve the real
+        # launcher lazily at call time (avoids an import cycle:
+        # ``_tui_turn_bridge`` imports this module). Tests inject recording
+        # fakes so start()/stop() never spawn a real subprocess.
+        self._turn_bridge_start = turn_bridge_start
+        self._turn_bridge_stop = turn_bridge_stop
 
     def _default_argv(self, config: AgentConfig) -> list[str] | None:
         """Resolve the SIF and render the ``apptainer exec ... claude``
@@ -364,7 +375,57 @@ class TuiSessionRuntime(RuntimeBase):
             # flipped TUI agent sits at an empty ❯ — operator-facing
             # regression. Best-effort: failure logs + continues.
             self._inject_startup_prompts(config)
+        if started:
+            # A2A wake-on-push parity: give the interactive TUI the same
+            # ``/v1/turn`` endpoint the SDK runner serves so a bus-pushed
+            # message (the ``sac mcp channel`` subscriber's wake POST)
+            # DRIVES a turn in the idle TUI instead of timing out on a dead
+            # port. Best-effort — a failed bridge must not fail the start.
+            self._maybe_start_turn_bridge(config)
         return started
+
+    def _maybe_start_turn_bridge(self, config: AgentConfig) -> None:
+        """Start the A2A turn bridge (best-effort; lazy default seam).
+
+        Resolves the real launcher lazily to avoid the import cycle
+        (:mod:`_tui_turn_bridge` imports this module). Tests inject a
+        recording ``turn_bridge_start`` so no subprocess is spawned. A
+        no-op for agents without a resolved ``a2a.port`` (the launcher
+        itself returns None — see :func:`_tui_turn_bridge.start_turn_bridge`).
+        """
+        import logging
+
+        fn = self._turn_bridge_start
+        if fn is None:
+            from ._tui_turn_bridge import start_turn_bridge
+
+            fn = start_turn_bridge
+        try:
+            fn(config)
+        except Exception as exc:  # stx-allow: fallback (reason: a bridge spawn failure must never wedge agent start — the agent still runs, only wake-on-push is degraded; logged for the operator)
+            logging.getLogger(__name__).warning(
+                "TuiSessionRuntime: A2A turn bridge failed to start for %s: %s",
+                getattr(config, "name", "?"),
+                exc,
+            )
+
+    def _maybe_stop_turn_bridge(self, config: AgentConfig) -> None:
+        """Stop the A2A turn bridge (best-effort; lazy default seam)."""
+        import logging
+
+        fn = self._turn_bridge_stop
+        if fn is None:
+            from ._tui_turn_bridge import stop_turn_bridge
+
+            fn = stop_turn_bridge
+        try:
+            fn(config)
+        except Exception as exc:  # stx-allow: fallback (reason: bridge teardown is best-effort; a failure must not block stop())
+            logging.getLogger(__name__).warning(
+                "TuiSessionRuntime: A2A turn bridge failed to stop for %s: %s",
+                getattr(config, "name", "?"),
+                exc,
+            )
 
     def _inject_startup_prompts(self, config: AgentConfig) -> None:
         """Feed spec.startup_prompts as the first user turn(s).
@@ -429,6 +490,9 @@ class TuiSessionRuntime(RuntimeBase):
         ``TmuxManager.stop`` semantics so the supervisor's
         ``stop()->start()`` cycle remains idempotent).
         """
+        # Tear down the A2A turn bridge first so it stops accepting wake
+        # POSTs before the tmux session it injects into goes away.
+        self._maybe_stop_turn_bridge(config)
         name = session_name_for(config)
         return bool(self._mux.stop(name))
 

--- a/tests/scitex_agent_container/runtimes/test__tui_turn_bridge.py
+++ b/tests/scitex_agent_container/runtimes/test__tui_turn_bridge.py
@@ -18,6 +18,7 @@ assert + STX-TQ003 descriptive names.
 from __future__ import annotations
 
 import json
+import subprocess
 import threading
 import urllib.error
 import urllib.request
@@ -28,6 +29,11 @@ from typing import Callable, Iterator
 import pytest
 
 from scitex_agent_container.runtimes import _tui_turn_bridge as bridge
+
+# A realistic resolved a2a port + a fake PID for the bridge tests
+# (PEP 515 separators satisfy STX-NL001).
+_PORT = 19_007
+_PID = 4_242
 
 
 # ---------------------------------------------------------------------------
@@ -65,11 +71,11 @@ def test_is_turn_route_rejects_named_route_for_other_agent() -> None:
 # ---------------------------------------------------------------------------
 def test_resolved_a2a_port_returns_int_when_resolved() -> None:
     # Arrange
-    config = SimpleNamespace(a2a=SimpleNamespace(port=19007))
+    config = SimpleNamespace(a2a=SimpleNamespace(port=_PORT))
     # Act
     port = bridge.resolved_a2a_port(config)
     # Assert
-    assert port == 19007
+    assert port == _PORT
 
 
 def test_resolved_a2a_port_none_when_port_is_auto_string() -> None:
@@ -238,10 +244,10 @@ def test_start_turn_bridge_passes_resolved_port_to_spawn(
 
     def fake_spawn(argv, **kwargs):
         recorded["argv"] = list(argv)
-        return SimpleNamespace(pid=4242)
+        return SimpleNamespace(pid=_PID)
 
     config = SimpleNamespace(
-        a2a=SimpleNamespace(port=19007), name="figrecipe", config_path=str(spec)
+        a2a=SimpleNamespace(port=_PORT), name="figrecipe", config_path=str(spec)
     )
     # Act
     bridge.start_turn_bridge(config, spawn=fake_spawn)
@@ -256,14 +262,14 @@ def test_start_turn_bridge_returns_spawned_pid(
     spec = tmp_path / "spec.yaml"
     spec.write_text("apiVersion: scitex-agent-container/v3\n", encoding="utf-8")
     config = SimpleNamespace(
-        a2a=SimpleNamespace(port=19007), name="figrecipe", config_path=str(spec)
+        a2a=SimpleNamespace(port=_PORT), name="figrecipe", config_path=str(spec)
     )
     # Act
     pid = bridge.start_turn_bridge(
-        config, spawn=lambda argv, **kw: SimpleNamespace(pid=4242)
+        config, spawn=lambda argv, **kw: SimpleNamespace(pid=_PID)
     )
     # Assert
-    assert pid == 4242
+    assert pid == _PID
 
 
 def test_stop_turn_bridge_noop_when_no_pid_file(
@@ -271,9 +277,76 @@ def test_stop_turn_bridge_noop_when_no_pid_file(
 ) -> None:
     # Arrange — no bridge was ever started for this agent.
     config = SimpleNamespace(
-        a2a=SimpleNamespace(port=19007), name="never-started", config_path=""
+        a2a=SimpleNamespace(port=_PORT), name="never-started", config_path=""
     )
     # Act
     stopped = bridge.stop_turn_bridge(config)
     # Assert
     assert stopped is False
+
+
+# ---------------------------------------------------------------------------
+# _build_on_turn — the inject callback (runtime DI seam, no tmux)
+# ---------------------------------------------------------------------------
+def test_build_on_turn_passes_text_and_wait_ready_false() -> None:
+    # Arrange — a recording runtime whose send_turn reports delivered.
+    seen: list = []
+
+    def fake_send_turn(config, text, wait_ready):
+        seen.append((text, wait_ready))
+        return True
+
+    runtime = SimpleNamespace(send_turn=fake_send_turn)
+    on_turn = bridge._build_on_turn(SimpleNamespace(name="a"), runtime=runtime)
+    # Act
+    on_turn("wake up")
+    # Assert
+    assert seen == [("wake up", False)]
+
+
+def test_build_on_turn_raises_when_session_absent() -> None:
+    # Arrange — send_turn reports the session does not exist (returns False).
+    runtime = SimpleNamespace(send_turn=lambda config, text, wait_ready: False)
+    on_turn = bridge._build_on_turn(SimpleNamespace(name="ghost"), runtime=runtime)
+    # Act
+    # Assert
+    with pytest.raises(RuntimeError):
+        on_turn("wake up")
+
+
+# ---------------------------------------------------------------------------
+# Launcher — spawn-failure + real SIGTERM teardown
+# ---------------------------------------------------------------------------
+def test_start_turn_bridge_returns_none_on_spawn_failure(
+    tmp_path: Path, isolated_home: Path
+) -> None:
+    # Arrange — spawn raises; the launcher must swallow it and return None.
+    spec = tmp_path / "spec.yaml"
+    spec.write_text("apiVersion: scitex-agent-container/v3\n", encoding="utf-8")
+
+    def raising_spawn(argv, **kwargs):
+        raise OSError("exec failed")
+
+    config = SimpleNamespace(
+        a2a=SimpleNamespace(port=_PORT), name="boom", config_path=str(spec)
+    )
+    # Act
+    pid = bridge.start_turn_bridge(config, spawn=raising_spawn)
+    # Assert
+    assert pid is None
+
+
+def test_stop_turn_bridge_sigterms_recorded_pid(isolated_home: Path) -> None:
+    # Arrange — a REAL short-lived process whose PID is recorded as the bridge.
+    proc = subprocess.Popen(["sleep", "30"])
+    config = SimpleNamespace(
+        a2a=SimpleNamespace(port=_PORT), name="kill-me", config_path=""
+    )
+    pid_path = bridge._pid_path(config)
+    pid_path.parent.mkdir(parents=True, exist_ok=True)
+    pid_path.write_text(str(proc.pid), encoding="utf-8")
+    # Act
+    stopped = bridge.stop_turn_bridge(config)
+    # Assert
+    assert stopped is True
+    proc.wait(timeout=5)

--- a/tests/scitex_agent_container/runtimes/test__tui_turn_bridge.py
+++ b/tests/scitex_agent_container/runtimes/test__tui_turn_bridge.py
@@ -1,0 +1,279 @@
+"""Tests for the TUI A2A turn bridge (``runtimes._tui_turn_bridge``).
+
+The bridge gives a ``runtime: tui`` agent the same ``/v1/turn`` endpoint
+the SDK runner serves, so a bus-pushed message (the ``sac mcp channel``
+subscriber's wake POST) DRIVES a turn in the idle TUI instead of timing
+out on a dead port.
+
+Real seams only (PA-306 no-mocks): the HTTP routes run against a REAL
+``ThreadingHTTPServer`` on an ephemeral port, exercised by a REAL urllib
+client; a recording ``on_turn`` callable stands in for the tmux inject.
+The launcher is driven through a real ``spawn`` recorder (a plain
+function), not a mock.
+
+STX-TQ002 AAA markers (each on its own line) + STX-TQ007 one observable
+assert + STX-TQ003 descriptive names.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import urllib.error
+import urllib.request
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Callable, Iterator
+
+import pytest
+
+from scitex_agent_container.runtimes import _tui_turn_bridge as bridge
+
+
+# ---------------------------------------------------------------------------
+# is_turn_route
+# ---------------------------------------------------------------------------
+def test_is_turn_route_accepts_bare_v1_turn() -> None:
+    # Arrange
+    path = "/v1/turn"
+    # Act
+    accepted = bridge.is_turn_route(path, "figrecipe")
+    # Assert
+    assert accepted is True
+
+
+def test_is_turn_route_accepts_named_turn_for_this_agent() -> None:
+    # Arrange
+    path = "/agents/figrecipe/turn"
+    # Act
+    accepted = bridge.is_turn_route(path, "figrecipe")
+    # Assert
+    assert accepted is True
+
+
+def test_is_turn_route_rejects_named_route_for_other_agent() -> None:
+    # Arrange
+    path = "/agents/someone-else/turn"
+    # Act
+    accepted = bridge.is_turn_route(path, "figrecipe")
+    # Assert
+    assert accepted is False
+
+
+# ---------------------------------------------------------------------------
+# resolved_a2a_port
+# ---------------------------------------------------------------------------
+def test_resolved_a2a_port_returns_int_when_resolved() -> None:
+    # Arrange
+    config = SimpleNamespace(a2a=SimpleNamespace(port=19007))
+    # Act
+    port = bridge.resolved_a2a_port(config)
+    # Assert
+    assert port == 19007
+
+
+def test_resolved_a2a_port_none_when_port_is_auto_string() -> None:
+    # Arrange
+    config = SimpleNamespace(a2a=SimpleNamespace(port="auto"))
+    # Act
+    port = bridge.resolved_a2a_port(config)
+    # Assert
+    assert port is None
+
+
+# ---------------------------------------------------------------------------
+# HTTP server — real ThreadingHTTPServer on an ephemeral port
+# ---------------------------------------------------------------------------
+@pytest.fixture
+def bridge_factory() -> Iterator[Callable[..., int]]:
+    """Start real bridge servers on ephemeral ports; tear them all down."""
+    servers = []
+    threads = []
+
+    def start(on_turn: Callable[[str], None], agent_name: str = "figrecipe") -> int:
+        server = bridge.build_server(
+            host="127.0.0.1", port=0, on_turn=on_turn, agent_name=agent_name
+        )
+        port = server.server_address[1]
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        servers.append(server)
+        threads.append(thread)
+        return int(port)
+
+    yield start
+    for server in servers:
+        server.shutdown()
+        server.server_close()
+    for thread in threads:
+        thread.join(timeout=5)
+
+
+def _post(port: int, path: str, body: dict | None) -> tuple[int, dict]:
+    data = json.dumps(body).encode("utf-8") if body is not None else b""
+    req = urllib.request.Request(
+        f"http://127.0.0.1:{port}{path}",
+        data=data,
+        method="POST",
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            return resp.status, json.loads(resp.read() or b"{}")
+    except urllib.error.HTTPError as exc:
+        return exc.code, json.loads(exc.read() or b"{}")
+
+
+def test_post_v1_turn_delivers_text_to_on_turn(bridge_factory) -> None:
+    # Arrange
+    received: list[str] = []
+    port = bridge_factory(received.append)
+    # Act
+    _post(port, "/v1/turn", {"text": "hello fleet"})
+    # Assert
+    assert received == ["hello fleet"]
+
+
+def test_post_v1_turn_returns_200_delivered_true(bridge_factory) -> None:
+    # Arrange
+    port = bridge_factory(lambda text: None)
+    # Act
+    status, body = _post(port, "/v1/turn", {"text": "hi there"})
+    # Assert
+    assert status == 200 and body.get("delivered") is True
+
+
+def test_post_named_turn_route_delivers_for_this_agent(bridge_factory) -> None:
+    # Arrange
+    received: list[str] = []
+    port = bridge_factory(received.append, agent_name="figrecipe")
+    # Act
+    _post(port, "/agents/figrecipe/turn", {"text": "named route"})
+    # Assert
+    assert received == ["named route"]
+
+
+def test_post_missing_text_field_returns_400(bridge_factory) -> None:
+    # Arrange
+    port = bridge_factory(lambda text: None)
+    # Act
+    status, _body = _post(port, "/v1/turn", {"no_text_here": "x"})
+    # Assert
+    assert status == 400
+
+
+def test_post_inject_failure_returns_502(bridge_factory) -> None:
+    # Arrange
+    def raise_session_gone(text: str) -> None:
+        raise RuntimeError("session gone")
+
+    port = bridge_factory(raise_session_gone)
+    # Act
+    status, _body = _post(port, "/v1/turn", {"text": "wake up"})
+    # Assert
+    assert status == 502
+
+
+def test_post_unknown_route_returns_404(bridge_factory) -> None:
+    # Arrange
+    port = bridge_factory(lambda text: None)
+    # Act
+    status, _body = _post(port, "/not/a/turn", {"text": "hi"})
+    # Assert
+    assert status == 404
+
+
+def test_health_get_returns_200(bridge_factory) -> None:
+    # Arrange
+    port = bridge_factory(lambda text: None)
+    # Act
+    with urllib.request.urlopen(f"http://127.0.0.1:{port}/health", timeout=5) as resp:
+        status = resp.status
+    # Assert
+    assert status == 200
+
+
+# ---------------------------------------------------------------------------
+# Launcher — real spawn recorder, real PID file
+# ---------------------------------------------------------------------------
+@pytest.fixture
+def isolated_home(tmp_path: Path) -> Iterator[Path]:
+    """Redirect HOME so the bridge's state-dir writes stay in the sandbox."""
+    import os
+
+    saved = os.environ.get("HOME")
+    os.environ["HOME"] = str(tmp_path)
+    try:
+        yield tmp_path
+    finally:
+        if saved is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = saved
+
+
+def test_start_turn_bridge_noop_without_resolved_port(tmp_path: Path) -> None:
+    # Arrange — an unresolved 'auto' port; spawn must never be invoked.
+    def must_not_spawn(*_a, **_k):
+        raise AssertionError("spawn must not run without a resolved a2a port")
+
+    config = SimpleNamespace(
+        a2a=SimpleNamespace(port="auto"),
+        name="figrecipe",
+        config_path=str(tmp_path / "spec.yaml"),
+    )
+    # Act
+    pid = bridge.start_turn_bridge(config, spawn=must_not_spawn)
+    # Assert
+    assert pid is None
+
+
+def test_start_turn_bridge_passes_resolved_port_to_spawn(
+    tmp_path: Path, isolated_home: Path
+) -> None:
+    # Arrange — a resolved port + config_path; record the spawn argv.
+    spec = tmp_path / "spec.yaml"
+    spec.write_text("apiVersion: scitex-agent-container/v3\n", encoding="utf-8")
+    recorded: dict = {}
+
+    def fake_spawn(argv, **kwargs):
+        recorded["argv"] = list(argv)
+        return SimpleNamespace(pid=4242)
+
+    config = SimpleNamespace(
+        a2a=SimpleNamespace(port=19007), name="figrecipe", config_path=str(spec)
+    )
+    # Act
+    bridge.start_turn_bridge(config, spawn=fake_spawn)
+    # Assert
+    assert "19007" in recorded["argv"]
+
+
+def test_start_turn_bridge_returns_spawned_pid(
+    tmp_path: Path, isolated_home: Path
+) -> None:
+    # Arrange
+    spec = tmp_path / "spec.yaml"
+    spec.write_text("apiVersion: scitex-agent-container/v3\n", encoding="utf-8")
+    config = SimpleNamespace(
+        a2a=SimpleNamespace(port=19007), name="figrecipe", config_path=str(spec)
+    )
+    # Act
+    pid = bridge.start_turn_bridge(
+        config, spawn=lambda argv, **kw: SimpleNamespace(pid=4242)
+    )
+    # Assert
+    assert pid == 4242
+
+
+def test_stop_turn_bridge_noop_when_no_pid_file(
+    tmp_path: Path, isolated_home: Path
+) -> None:
+    # Arrange — no bridge was ever started for this agent.
+    config = SimpleNamespace(
+        a2a=SimpleNamespace(port=19007), name="never-started", config_path=""
+    )
+    # Act
+    stopped = bridge.stop_turn_bridge(config)
+    # Assert
+    assert stopped is False

--- a/tests/scitex_agent_container/runtimes/test_tui_session.py
+++ b/tests/scitex_agent_container/runtimes/test_tui_session.py
@@ -289,6 +289,48 @@ def test_tui_runtime_stop_invokes_turn_bridge_stop_seam(
     assert stopped == [config]
 
 
+def test_tui_runtime_start_swallows_turn_bridge_failure(
+    mux: type[_MemoryMultiplexer],
+) -> None:
+    # Arrange — a bridge-start seam that raises must NOT fail the start
+    # (wake-on-push is best-effort; the agent still runs).
+    def raise_bridge(config: object) -> None:
+        raise RuntimeError("bridge spawn failed")
+
+    runtime = TuiSessionRuntime(
+        multiplexer=mux,
+        command_builder=_fake_builder,
+        turn_bridge_start=raise_bridge,
+        turn_bridge_stop=lambda config: None,
+    )
+    config = _Config(name="bridge-boom")
+    # Act
+    ok = runtime.start(config)
+    # Assert
+    assert ok is True
+
+
+def test_tui_runtime_stop_swallows_turn_bridge_failure(
+    mux: type[_MemoryMultiplexer],
+) -> None:
+    # Arrange — a bridge-stop seam that raises must NOT block stop().
+    def raise_bridge(config: object) -> None:
+        raise RuntimeError("bridge teardown failed")
+
+    runtime = TuiSessionRuntime(
+        multiplexer=mux,
+        command_builder=_fake_builder,
+        turn_bridge_start=lambda config: None,
+        turn_bridge_stop=raise_bridge,
+    )
+    config = _Config(name="bridge-boom-stop")
+    runtime.start(config)
+    # Act
+    stopped = runtime.stop(config)
+    # Assert
+    assert stopped is True
+
+
 def test_tui_runtime_start_invokes_claude_binary_in_session(
     mux: type[_MemoryMultiplexer],
 ) -> None:

--- a/tests/scitex_agent_container/runtimes/test_tui_session.py
+++ b/tests/scitex_agent_container/runtimes/test_tui_session.py
@@ -251,6 +251,44 @@ def test_tui_runtime_start_returns_true_on_success(
     assert ok is True
 
 
+def test_tui_runtime_start_invokes_turn_bridge_seam(
+    mux: type[_MemoryMultiplexer],
+) -> None:
+    # Arrange — record the config handed to the injected bridge-start seam
+    # (so start() wires A2A wake-on-push without spawning a real subprocess).
+    started: list = []
+    runtime = TuiSessionRuntime(
+        multiplexer=mux,
+        command_builder=_fake_builder,
+        turn_bridge_start=started.append,
+        turn_bridge_stop=lambda config: None,
+    )
+    config = _Config(name="bridge-start")
+    # Act
+    runtime.start(config)
+    # Assert
+    assert started == [config]
+
+
+def test_tui_runtime_stop_invokes_turn_bridge_stop_seam(
+    mux: type[_MemoryMultiplexer],
+) -> None:
+    # Arrange
+    stopped: list = []
+    runtime = TuiSessionRuntime(
+        multiplexer=mux,
+        command_builder=_fake_builder,
+        turn_bridge_start=lambda config: None,
+        turn_bridge_stop=stopped.append,
+    )
+    config = _Config(name="bridge-stop")
+    runtime.start(config)
+    # Act
+    runtime.stop(config)
+    # Assert
+    assert stopped == [config]
+
+
 def test_tui_runtime_start_invokes_claude_binary_in_session(
     mux: type[_MemoryMultiplexer],
 ) -> None:


### PR DESCRIPTION
## A2A wake-on-push parity for `runtime: tui` agents

TUI agents already connect to `sac listen` via the same `sac mcp channel` MCP as the SDK (receiving works). But the **wake** half was missing: `_mcp/_channel_wake._wake_turn` POSTs each qualifying bus event to the agent's own `/v1/turn` to DRIVE an idle session — the **SDK runner serves that endpoint in-process, the TUI served nothing**, so the wake POST hit a dead port (`[Errno 110] Connection timed out`) and an idle TUI agent never acted on a pushed message (it only got an MCP `notifications/claude/channel`, which per channel.py "cannot wake an idle session"). This also broke `sac agents send` for local TUI agents (same turn-endpoint path).

### Fix — a host-side `/v1/turn` → tmux bridge
New `runtimes/_tui_turn_bridge.py`: a small `http.server` (dependency-free) bound to `127.0.0.1:<a2a.port>` that, on `POST /v1/turn` (+ `/agents/<name>/{turn,send}`, `GET /health`), injects the `text` into the agent's tmux session via `TuiSessionRuntime.send_turn(..., wait_ready=False)` — the operator-confirmed bare-send path — and returns `200` immediately. The wake POST's body shape matches `_session_http` so `_wake_turn` and A2A clients work unchanged. Bound to loopback (the wake POST is in-SIF→host over the shared net ns; the bind is the security boundary, matching the SDK runner which doesn't auth `/v1/turn`).

Lifecycle mirrors `a2a_sidecar`: spawned as a detached subprocess in `TuiSessionRuntime.start()` (PID file + log under the per-agent state dir), SIGTERM'd in `stop()`. Wired via injection seams (`turn_bridge_start`/`turn_bridge_stop`) so unit tests never spawn a subprocess. Best-effort — a bridge failure never blocks agent start/stop.

```
sender → sac listen (bus) → /inbox/stream (SSE) → sac mcp channel → POST /v1/turn → tmux inject → idle TUI agent WAKES & acts
```

### Verified end-to-end against the live `proj-figrecipe`
Ran the real bridge on a spare port pointed at the running figrecipe, POSTed a turn, and the **idle agent woke and replied** (`BRIDGE-OK-5567`); the bridge answered `{"delivered": true, "mode": "tui-tmux-inject"}`.

### Testing
- `tests/.../runtimes/test__tui_turn_bridge.py` — 16 tests: routing (`/v1/turn`, named, 404), validation (400/502), `/health`, `resolved_a2a_port`, launcher argv/PID/no-op. Real `ThreadingHTTPServer` + real urllib client + recording callables (no mocks).
- `test_tui_session.py` — 2 new seam tests: `start()` invokes the bridge-start seam, `stop()` invokes the bridge-stop seam.
- Full `tests/.../runtimes/` dir + `scitex-dev ecosystem audit-all scitex-agent-container`: green.

### Rollout
No SIF rebuild (the bridge runs host-side). After merge: pull `develop`, `sac agents restart <agent>`. Then a bus push wakes an idle TUI agent, and `sac agents send` reaches it too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
