### PR TITLE
feat(tui): DB-backed outbound completion reports (SDK-parity, sac-core)

### DIFF
--- a/src/scitex_agent_container/_state/inbound_ledger.py
+++ b/src/scitex_agent_container/_state/inbound_ledger.py
@@ -1,0 +1,236 @@
+"""Inbound dispatch ledger — one row per INBOUND dispatch awaiting a
+completion report (2026-06-18).
+
+The receiver-side mirror of :mod:`dispatch_ledger` (which is the SENDER's
+outbound record). It exists for the ``runtime: tui`` push-feedback loop:
+a TUI agent has no in-process turn envelope, so the requester identity
+(``from_agent`` + ``dispatch_id``) of a bus-pushed wake cannot ride the
+tmux-injected text from the host-side bridge through to the in-container
+``Stop`` hook that reports completion. This SQLite table is that bridge —
+the SAME ``state.db`` is bound into the container (``/state/<name>``), so
+the host-side writer and the in-container reader share it (WAL +
+``busy_timeout`` from :func:`state_db.open_db` make the cross-process
+access safe).
+
+Lifecycle of one row:
+
+  * ``pending``   — the bridge recorded a requester-bearing inbound wake
+    (:func:`record_inbound`); the turn is queued/running in the TUI.
+  * ``reporting`` — the Stop hook atomically CLAIMED the oldest pending
+    row (:func:`claim_oldest_pending`) to push its completion. The claim
+    is a single ``UPDATE`` so two concurrent Stop hooks (or a retry)
+    cannot double-report the same dispatch.
+  * ``reported`` / ``failed`` — terminal, set by :func:`mark_reported`
+    after the completion push to the requester succeeds / fails loud.
+
+FIFO by ``ts`` + sequential TUI turn processing keeps the dispatch↔turn
+correlation correct: the Nth ``Stop`` claims the Nth recorded dispatch.
+
+Sibling-module rationale (carried from :mod:`dispatch_ledger`): the table
++ its ``CREATE TABLE IF NOT EXISTS`` live here behind
+:func:`init_inbound_schema`, layered on top of ``state_db`` via
+``open_db``, so this feature never edits the same lines as a concurrent
+``state_db.py`` restructure.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+from pathlib import Path
+from typing import Any, Optional
+
+# Row lifecycle. ``record_inbound`` always writes ``pending``; the Stop
+# hook claims to ``reporting`` then settles to ``reported`` / ``failed``.
+STATUS_PENDING = "pending"
+STATUS_REPORTING = "reporting"
+STATUS_REPORTED = "reported"
+STATUS_FAILED = "failed"
+VALID_STATUSES = (STATUS_PENDING, STATUS_REPORTING, STATUS_REPORTED, STATUS_FAILED)
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS inbound_dispatches (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    agent        TEXT NOT NULL,
+    from_agent   TEXT NOT NULL,
+    dispatch_id  TEXT,
+    status       TEXT NOT NULL DEFAULT 'pending',
+    ts           REAL NOT NULL,
+    reported_ts  REAL
+);
+CREATE INDEX IF NOT EXISTS idx_inbound_agent_status_ts
+    ON inbound_dispatches(agent, status, ts);
+"""
+
+__all__ = [
+    "STATUS_PENDING",
+    "STATUS_REPORTING",
+    "STATUS_REPORTED",
+    "STATUS_FAILED",
+    "VALID_STATUSES",
+    "init_inbound_schema",
+    "record_inbound",
+    "claim_oldest_pending",
+    "mark_reported",
+    "list_inbound",
+]
+
+
+def init_inbound_schema(db_path: Path | None = None) -> Path:
+    """Create the ``inbound_dispatches`` table if missing. Idempotent.
+
+    Returns the resolved database path. Mirrors
+    :func:`dispatch_ledger.init_ledger_schema`: delegates base schema +
+    connection config to :func:`state_db.open_db`, then layers our own
+    ``CREATE TABLE IF NOT EXISTS``.
+    """
+    from .state_db import init_schema, open_db
+
+    with open_db(db_path) as conn:
+        conn.executescript(_SCHEMA)
+    return init_schema(db_path)
+
+
+def _ensure_table(conn: sqlite3.Connection) -> None:
+    """Ensure the inbound table exists on an already-open connection."""
+    conn.executescript(_SCHEMA)
+
+
+def record_inbound(
+    *,
+    agent: str,
+    from_agent: str,
+    dispatch_id: Optional[str] = None,
+    ts: float | None = None,
+    db_path: Path | None = None,
+) -> int:
+    """Insert one ``pending`` inbound-dispatch row; return its ``id``.
+
+    Called by the bridge when an inbound wake carries a ``from_agent``
+    (the peer to report back to). A wake with no requester is NOT recorded
+    by the caller — there is nobody to report to. ``ts`` is a real-time
+    injection seam for tests.
+    """
+    if not agent or not from_agent:
+        raise ValueError("record_inbound requires non-empty agent + from_agent")
+    row_ts = float(ts) if ts is not None else time.time()
+    from .state_db import open_db
+
+    with open_db(db_path) as conn:
+        _ensure_table(conn)
+        cur = conn.execute(
+            """
+            INSERT INTO inbound_dispatches (agent, from_agent, dispatch_id, status, ts)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (agent, from_agent, dispatch_id, STATUS_PENDING, row_ts),
+        )
+        # lastrowid is always set after a successful single-row INSERT;
+        # the ``or 0`` only satisfies the int|None type and never fires.
+        return int(cur.lastrowid or 0)
+
+
+def claim_oldest_pending(
+    *,
+    agent: str,
+    db_path: Path | None = None,
+) -> dict[str, Any] | None:
+    """Atomically claim the OLDEST ``pending`` row for ``agent``.
+
+    Flips exactly one row ``pending → reporting`` inside a single
+    ``BEGIN IMMEDIATE`` transaction and returns it (as a dict), or
+    ``None`` when the agent has no pending dispatch (the common no-op —
+    most turns have no requester). The atomic claim means two concurrent
+    ``Stop`` hooks (or a hook retry) can never push the same completion
+    twice. The caller settles the claimed row via :func:`mark_reported`.
+    """
+    from .state_db import open_db
+
+    with open_db(db_path) as conn:
+        _ensure_table(conn)
+        conn.row_factory = sqlite3.Row
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            row = conn.execute(
+                """
+                SELECT * FROM inbound_dispatches
+                WHERE agent = ? AND status = ?
+                ORDER BY ts ASC, id ASC
+                LIMIT 1
+                """,
+                (agent, STATUS_PENDING),
+            ).fetchone()
+            if row is None:
+                conn.execute("COMMIT")
+                return None
+            conn.execute(
+                "UPDATE inbound_dispatches SET status = ? WHERE id = ?",
+                (STATUS_REPORTING, row["id"]),
+            )
+            conn.execute("COMMIT")
+        except Exception:
+            conn.execute("ROLLBACK")
+            raise
+        claimed = dict(row)
+        claimed["status"] = STATUS_REPORTING
+        return claimed
+
+
+def mark_reported(
+    row_id: int,
+    *,
+    status: str = STATUS_REPORTED,
+    reported_ts: float | None = None,
+    db_path: Path | None = None,
+) -> bool:
+    """Settle a claimed row to a terminal status. Returns True iff matched.
+
+    ``status`` must be ``reported`` (push succeeded) or ``failed`` (push
+    raised) — an unknown value raises rather than writing an unqueryable
+    status (fail loudly, never silently).
+    """
+    if status not in (STATUS_REPORTED, STATUS_FAILED):
+        raise ValueError(
+            f"mark_reported status must be {STATUS_REPORTED!r} or "
+            f"{STATUS_FAILED!r}, got {status!r}"
+        )
+    row_ts = float(reported_ts) if reported_ts is not None else time.time()
+    from .state_db import open_db
+
+    with open_db(db_path) as conn:
+        _ensure_table(conn)
+        cur = conn.execute(
+            "UPDATE inbound_dispatches SET status = ?, reported_ts = ? WHERE id = ?",
+            (status, row_ts, row_id),
+        )
+        return cur.rowcount > 0
+
+
+def list_inbound(
+    *,
+    agent: str | None = None,
+    status: str | None = None,
+    limit: int = 100,
+    db_path: Path | None = None,
+) -> list[dict[str, Any]]:
+    """Return inbound rows (newest first) — observability / tests."""
+    from .state_db import open_db
+
+    clauses: list[str] = []
+    params: list[Any] = []
+    if agent:
+        clauses.append("agent = ?")
+        params.append(agent)
+    if status:
+        clauses.append("status = ?")
+        params.append(status)
+    where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
+    params.append(int(limit))
+    with open_db(db_path) as conn:
+        _ensure_table(conn)
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute(
+            f"SELECT * FROM inbound_dispatches{where} ORDER BY ts DESC, id DESC LIMIT ?",
+            params,
+        ).fetchall()
+        return [dict(r) for r in rows]

--- a/src/scitex_agent_container/runtimes/_tui_outbound.py
+++ b/src/scitex_agent_container/runtimes/_tui_outbound.py
@@ -1,0 +1,283 @@
+"""Outbound completion-report plumbing for ``runtime: tui`` agents (DB-backed).
+
+INBOUND wakes are delivered by :mod:`_tui_turn_bridge`; this is the
+SYMMETRIC outbound half — the dispatch-correlated completion report a TUI
+agent owes its requester, at SDK parity with
+:func:`_runners._session_completion.push_completion`
+(``{agent, dispatch_id, status, summary}`` over the bus, persisted to
+``channel_events``, closing the sender's dispatch-ledger row).
+
+A TUI has no in-process turn envelope, so the requester identity
+(``from_agent`` + ``dispatch_id``) cannot ride the tmux-injected text, and
+the pane gives no reliable turn-complete signal. So:
+
+* the bridge RECORDS each requester-bearing inbound wake into the
+  DB-backed inbound ledger (:mod:`_state.inbound_ledger` — the receiver
+  mirror of the sender's :mod:`_state.dispatch_ledger`), via
+  :func:`record_dispatch`;
+* on claude's NATIVE ``Stop`` (a reliable turn-complete signal), a Stop
+  hook calls :func:`flush_one_completion`, which atomically CLAIMS the
+  oldest pending inbound, pulls the reply summary from the transcript
+  claude hands the hook, and pushes the completion to the requester.
+
+The SAME ``state.db`` is bound into the container at ``/state/<name>``, so
+the host-side bridge writer and the in-container hook reader share it
+(``open_db`` WAL + ``busy_timeout`` make the cross-process access safe).
+This is the sac SQLite state DB doing what it is for — durable, ACID,
+queryable communication state — not an ad-hoc side file.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Optional
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "record_dispatch",
+    "summarize_transcript",
+    "flush_one_completion",
+    "main",
+]
+
+
+def record_dispatch(
+    *,
+    db_path: Path,
+    agent: str,
+    from_agent: str,
+    dispatch_id: Optional[str] = None,
+) -> int | None:
+    """Record a requester-bearing inbound wake into the inbound ledger.
+
+    No-op (returns ``None``) when ``from_agent`` is empty — an operator
+    ``sac agents send`` without a peer, or a boot turn, has nobody to
+    report back to. Returns the ledger row id otherwise. Called by the
+    bridge with the agent's host-side ``state.db`` path.
+    """
+    if not from_agent:
+        return None
+    from .._state.inbound_ledger import record_inbound
+
+    return record_inbound(
+        db_path=db_path,
+        agent=agent,
+        from_agent=from_agent,
+        dispatch_id=dispatch_id,
+    )
+
+
+def summarize_transcript(
+    transcript_path: Path,
+    *,
+    cap: int = 2_000,
+) -> tuple[str, str]:
+    """Return ``(status, summary)`` from a claude session transcript.
+
+    Reads the JSONL transcript claude hands the Stop hook and returns the
+    LAST assistant text block as the summary (bounded to ``cap`` chars —
+    the full text stays in the transcript). ``status`` is ``"success"``
+    when an assistant reply is found and ``"unknown"`` otherwise — NEVER a
+    fabricated success. Tolerant of schema drift: unparseable lines are
+    skipped; several known assistant-content shapes are accepted.
+    """
+    from .._runners._session_completion import STATUS_SUCCESS, STATUS_UNKNOWN
+
+    path = Path(transcript_path)
+    if not path.is_file():
+        return STATUS_UNKNOWN, ""
+    last_text = ""
+    try:
+        raw_lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:  # stx-allow: fallback (reason: unreadable transcript → unknown status with no summary, never crash the Stop hook)
+        return STATUS_UNKNOWN, ""
+    for ln in raw_lines:
+        ln = ln.strip()
+        if not ln:
+            continue
+        try:
+            rec = json.loads(ln)
+        except json.JSONDecodeError:
+            continue
+        text = _assistant_text(rec)
+        if text:
+            last_text = text
+    if not last_text:
+        return STATUS_UNKNOWN, ""
+    if len(last_text) > cap:
+        last_text = last_text[:cap] + "…"
+    return STATUS_SUCCESS, last_text
+
+
+def _assistant_text(rec: Any) -> str:
+    """Extract assistant text from one transcript record, else ''.
+
+    Accepts the common claude transcript shapes:
+      * ``{"type"|"role": "assistant", "message": {"content": [...]}}``
+      * ``{"role": "assistant", "content": [...]|"..."}``
+    Content blocks may be ``{"type": "text", "text": "..."}`` or bare
+    strings. Anything else yields '' (skipped).
+    """
+    if not isinstance(rec, dict):
+        return ""
+    role = rec.get("role") or rec.get("type")
+    if role != "assistant":
+        return ""
+    message = rec.get("message")
+    content = (
+        message.get("content") if isinstance(message, dict) else rec.get("content")
+    )
+    if isinstance(content, str):
+        return content.strip()
+    if not isinstance(content, list):
+        return ""
+    parts: list[str] = []
+    for block in content:
+        if isinstance(block, str):
+            parts.append(block)
+        elif isinstance(block, dict) and block.get("type") == "text":
+            t = block.get("text")
+            if isinstance(t, str):
+                parts.append(t)
+    return "\n".join(p for p in parts if p).strip()
+
+
+def flush_one_completion(
+    *,
+    db_path: Path,
+    agent: str,
+    transcript_path: Path | None,
+    listen_url: str,
+    bearer: Optional[str],
+    push_fn: Any = None,
+) -> bool:
+    """Claim the oldest pending inbound for ``agent`` and push its report.
+
+    Returns ``True`` when a dispatch was claimed and a push attempted,
+    ``False`` when none was pending (the common no-op — most turns have no
+    requester). The claim is atomic (:func:`inbound_ledger.claim_oldest_pending`),
+    so a Stop-hook retry or two concurrent hooks never double-report. On a
+    push failure the row is settled ``failed`` and the error re-raised so
+    the Stop hook surfaces it loudly; on success it is settled ``reported``.
+
+    ``push_fn`` is a test seam ``(*, agent, requester, report, listen_url,
+    bearer, dispatch_id) -> Any``; production uses
+    :func:`_session_completion.push_completion` via ``asyncio.run``.
+    """
+    from .._state.inbound_ledger import (
+        STATUS_FAILED,
+        STATUS_REPORTED,
+        claim_oldest_pending,
+        mark_reported,
+    )
+
+    claimed = claim_oldest_pending(agent=agent, db_path=db_path)
+    if claimed is None:
+        return False
+    row_id = int(claimed["id"])
+    requester = str(claimed.get("from_agent") or "").strip()
+    dispatch_id = claimed.get("dispatch_id")
+    did = dispatch_id if isinstance(dispatch_id, str) and dispatch_id else None
+
+    from .._runners._session_completion import build_completion_report
+
+    status, summary = summarize_transcript(
+        Path(transcript_path) if transcript_path else Path("/nonexistent")
+    )
+    report = build_completion_report(
+        agent=agent, dispatch_id=did, status=status, summary_text=summary
+    )
+
+    if (
+        push_fn is None
+    ):  # pragma: no cover - production wires the real async push (asyncio.run + network); unit tests inject push_fn, the e2e path exercises this
+        import asyncio
+
+        from .._runners._session_completion import push_completion
+
+        def _push(**kw: Any) -> Any:
+            return asyncio.run(push_completion(**kw))
+
+        push_fn = _push
+
+    try:
+        push_fn(
+            agent=agent,
+            requester=requester,
+            report=report,
+            listen_url=listen_url,
+            bearer=bearer,
+            dispatch_id=did,
+        )
+    except Exception:
+        mark_reported(row_id, status=STATUS_FAILED, db_path=db_path)
+        raise
+    mark_reported(row_id, status=STATUS_REPORTED, db_path=db_path)
+    log.info(
+        "tui-outbound: completion report pushed to %s (dispatch_id=%s, status=%s)",
+        requester,
+        did,
+        status,
+    )
+    return True
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Stop-hook entrypoint: report the just-completed turn's completion.
+
+    Invoked by the agent's in-container ``Stop`` hook, which pipes claude's
+    Stop payload JSON on stdin. Resolves the agent name, ``state.db``,
+    bus URL and bearer from the in-container env the runtime injects
+    (``SCITEX_AGENT_CONTAINER_AGENT`` / ``…_STATE_DB`` /
+    ``SAC_LISTEN_BASE_URL`` / ``SAC_LISTEN_BEARER``), reads
+    ``transcript_path`` from stdin for the reply summary, and flushes the
+    OLDEST pending inbound dispatch (one per ``Stop`` = one completed turn).
+
+    Returns 0 always — a Stop hook must NOT wedge the agent's turn loop. A
+    missing context (non-sac session) or an empty queue is a clean no-op;
+    a delivery failure is logged loud (and the ledger row is marked
+    ``failed`` by :func:`flush_one_completion`) but still exits 0.
+    """
+    import os
+    import sys
+
+    del argv
+    transcript_path: Path | None = None
+    try:
+        raw = sys.stdin.read()
+    except Exception:  # stx-allow: fallback (reason: no/closed stdin → summary degrades to unknown, never crash the hook)
+        raw = ""
+    if raw.strip():
+        try:
+            payload = json.loads(raw)
+            tp = payload.get("transcript_path") if isinstance(payload, dict) else None
+            if isinstance(tp, str) and tp:
+                transcript_path = Path(tp)
+        except json.JSONDecodeError:
+            transcript_path = None
+
+    agent = os.environ.get("SCITEX_AGENT_CONTAINER_AGENT", "").strip()
+    db_path_s = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB", "").strip()
+    listen_url = os.environ.get("SAC_LISTEN_BASE_URL", "").strip()
+    bearer = os.environ.get("SAC_LISTEN_BEARER", "").strip() or None
+    if not agent or not db_path_s or not listen_url:
+        # Not a wired sac TUI agent context (or no bus) — nothing to report.
+        return 0
+    try:
+        flush_one_completion(
+            db_path=Path(db_path_s),
+            agent=agent,
+            transcript_path=transcript_path,
+            listen_url=listen_url,
+            bearer=bearer,
+        )
+    except Exception as exc:  # stx-allow: fallback (reason: a completion-push failure must not wedge the agent's turn loop; the row is already marked failed + this logs loud — the requester can fall back to the agent's logs)
+        log.warning("tui-outbound: completion flush failed: %s", exc)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover -- exercised as a Stop-hook subprocess
+    raise SystemExit(main())

--- a/src/scitex_agent_container/runtimes/_tui_turn_bridge.py
+++ b/src/scitex_agent_container/runtimes/_tui_turn_bridge.py
@@ -128,7 +128,7 @@ class _TurnBridgeServer(ThreadingHTTPServer):
     def __init__(
         self,
         server_address: tuple[str, int],
-        on_turn: Callable[[str], None],
+        on_turn: Callable[..., None],
         agent_name: str,
     ) -> None:
         super().__init__(server_address, _TurnBridgeHandler)
@@ -185,8 +185,16 @@ class _TurnBridgeHandler(BaseHTTPRequestHandler):
         if not isinstance(text, str) or not text.strip():
             self._respond(400, {"error": "missing or empty 'text' field"})
             return
+        # Requester identity (optional) — the peer that dispatched this
+        # wake. Threaded to on_turn so the inbound is recorded in the
+        # ledger for the Stop-hook completion report (SDK parity). Absent
+        # for an operator send / boot turn → no report is owed.
+        raw_from = body.get("from_agent") if isinstance(body, dict) else None
+        raw_did = body.get("dispatch_id") if isinstance(body, dict) else None
+        from_agent = raw_from if isinstance(raw_from, str) and raw_from else None
+        dispatch_id = raw_did if isinstance(raw_did, str) and raw_did else None
         try:
-            srv.on_turn(text)
+            srv.on_turn(text, from_agent=from_agent, dispatch_id=dispatch_id)
         except Exception as exc:  # stx-allow: fallback (reason: surface inject failure as 502 instead of crashing the bridge; the wake POST's raise_for_status then propagates it loud to the channel subscriber)
             self._respond(502, {"error": f"tui inject failed: {exc}"})
             return
@@ -202,14 +210,14 @@ class _TurnBridgeHandler(BaseHTTPRequestHandler):
 
 
 def build_server(
-    *, host: str, port: int, on_turn: Callable[[str], None], agent_name: str
+    *, host: str, port: int, on_turn: Callable[..., None], agent_name: str
 ) -> _TurnBridgeServer:
     """Construct (but do not run) the bridge server. Test seam."""
     return _TurnBridgeServer((host, port), on_turn, agent_name)
 
 
 def serve(  # pragma: no cover - integration entry: installs main-thread-only signal handlers + blocks in serve_forever; the server logic is unit-tested via build_server, the full serve path is exercised end-to-end
-    *, host: str, port: int, on_turn: Callable[[str], None], agent_name: str
+    *, host: str, port: int, on_turn: Callable[..., None], agent_name: str
 ) -> None:
     """Run the bridge server until the process is signalled. Blocking."""
     server = build_server(host=host, port=port, on_turn=on_turn, agent_name=agent_name)
@@ -235,7 +243,7 @@ def serve(  # pragma: no cover - integration entry: installs main-thread-only si
 # ---------------------------------------------------------------------------
 def _build_on_turn(
     config: AgentConfig, *, runtime: Any | None = None
-) -> Callable[[str], None]:
+) -> Callable[..., None]:
     """Inject callback that drives one TUI turn via the tmux PTY.
 
     Calls :meth:`TuiSessionRuntime.send_turn` with ``wait_ready=False``
@@ -244,6 +252,14 @@ def _build_on_turn(
     surfaces it loud rather than pretending the wake landed). ``runtime``
     is a test seam — production constructs the real
     :class:`TuiSessionRuntime`.
+
+    When the wake carries a ``from_agent`` (the dispatching peer), the
+    inbound is RECORDED into the DB-backed inbound ledger BEFORE the
+    inject, so the agent's ``Stop`` hook can push a dispatch-correlated
+    completion report back to that requester (SDK-parity outbound — see
+    :mod:`_tui_outbound`). Recording is best-effort: a ledger-write
+    failure logs but never blocks delivering the turn (the agent still
+    wakes; only the auto-report is lost).
     """
     if (
         runtime is None
@@ -252,7 +268,29 @@ def _build_on_turn(
 
         runtime = TuiSessionRuntime()
 
-    def on_turn(text: str) -> None:
+    def on_turn(
+        text: str,
+        *,
+        from_agent: str | None = None,
+        dispatch_id: str | None = None,
+    ) -> None:
+        if from_agent:
+            try:
+                from ._tui_outbound import record_dispatch
+                from .tui_session import state_dir_for_config
+
+                record_dispatch(
+                    db_path=state_dir_for_config(config) / "state.db",
+                    agent=config.name,
+                    from_agent=from_agent,
+                    dispatch_id=dispatch_id,
+                )
+            except Exception as exc:  # stx-allow: fallback (reason: a ledger-write failure must not block delivering the wake — the agent still processes the turn; only the auto-completion-report is lost, logged for the operator)
+                logging.getLogger(__name__).warning(
+                    "tui-outbound: failed to record inbound dispatch for %s: %s",
+                    config.name,
+                    exc,
+                )
         # ``wait_ready=False`` → the bare send_text_and_submit primitive
         # (text + Enter), the operator-confirmed delivery path
         # (``send_turn`` itself defaults to it for that reason). The full

--- a/tests/scitex_agent_container/_state/test_inbound_ledger.py
+++ b/tests/scitex_agent_container/_state/test_inbound_ledger.py
@@ -1,0 +1,109 @@
+"""Tests for the receiver-side inbound dispatch ledger
+(``_state.inbound_ledger``) — the DB-backed bridge that carries a TUI
+wake's requester identity from the host-side turn-bridge to the
+in-container Stop hook that reports completion.
+
+Real SQLite (a tmp ``state.db`` path, no mocks). Covers the
+pending→reporting→reported lifecycle, FIFO claim order, the atomic
+single-claim guarantee, and fail-loud validation. STX-TQ002 AAA markers
++ STX-TQ007 one assert + STX-TQ003 descriptive names.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._state import inbound_ledger as ledger
+
+
+def test_record_inbound_inserts_a_pending_row(tmp_path: Path) -> None:
+    # Arrange
+    db = tmp_path / "state.db"
+    # Act
+    ledger.record_inbound(
+        db_path=db, agent="figrecipe", from_agent="lead", dispatch_id="d1"
+    )
+    # Assert
+    rows = ledger.list_inbound(agent="figrecipe", db_path=db)
+    assert len(rows) == 1 and rows[0]["status"] == ledger.STATUS_PENDING
+
+
+def test_record_inbound_rejects_empty_from_agent(tmp_path: Path) -> None:
+    # Arrange
+    db = tmp_path / "state.db"
+    # Act
+    # Assert
+    with pytest.raises(ValueError):
+        ledger.record_inbound(db_path=db, agent="figrecipe", from_agent="")
+
+
+def test_claim_oldest_pending_returns_the_fifo_oldest(tmp_path: Path) -> None:
+    # Arrange — two dispatches, oldest first by ts.
+    db = tmp_path / "state.db"
+    ledger.record_inbound(
+        db_path=db, agent="a", from_agent="lead", dispatch_id="old", ts=100.0
+    )
+    ledger.record_inbound(
+        db_path=db, agent="a", from_agent="peer", dispatch_id="new", ts=200.0
+    )
+    # Act
+    claimed = ledger.claim_oldest_pending(agent="a", db_path=db)
+    # Assert
+    assert claimed is not None and claimed["dispatch_id"] == "old"
+
+
+def test_claim_oldest_pending_flips_row_to_reporting(tmp_path: Path) -> None:
+    # Arrange
+    db = tmp_path / "state.db"
+    ledger.record_inbound(db_path=db, agent="a", from_agent="lead", dispatch_id="d1")
+    # Act
+    claimed = ledger.claim_oldest_pending(agent="a", db_path=db)
+    # Assert
+    assert claimed is not None and claimed["status"] == ledger.STATUS_REPORTING
+
+
+def test_claim_oldest_pending_none_when_queue_empty(tmp_path: Path) -> None:
+    # Arrange
+    db = tmp_path / "state.db"
+    # Act
+    claimed = ledger.claim_oldest_pending(agent="a", db_path=db)
+    # Assert
+    assert claimed is None
+
+
+def test_claim_is_atomic_so_one_row_is_claimed_once(tmp_path: Path) -> None:
+    # Arrange — a single pending row, claimed once already.
+    db = tmp_path / "state.db"
+    ledger.record_inbound(db_path=db, agent="a", from_agent="lead", dispatch_id="d1")
+    ledger.claim_oldest_pending(agent="a", db_path=db)
+    # Act — a second claim finds nothing pending (no double-report).
+    second = ledger.claim_oldest_pending(agent="a", db_path=db)
+    # Assert
+    assert second is None
+
+
+def test_mark_reported_settles_a_claimed_row(tmp_path: Path) -> None:
+    # Arrange
+    db = tmp_path / "state.db"
+    row_id = ledger.record_inbound(
+        db_path=db, agent="a", from_agent="lead", dispatch_id="d1"
+    )
+    ledger.claim_oldest_pending(agent="a", db_path=db)
+    # Act
+    settled = ledger.mark_reported(row_id, status=ledger.STATUS_REPORTED, db_path=db)
+    # Assert
+    assert settled is True
+
+
+def test_mark_reported_rejects_a_non_terminal_status(tmp_path: Path) -> None:
+    # Arrange
+    db = tmp_path / "state.db"
+    row_id = ledger.record_inbound(
+        db_path=db, agent="a", from_agent="lead", dispatch_id="d1"
+    )
+    # Act
+    # Assert
+    with pytest.raises(ValueError):
+        ledger.mark_reported(row_id, status="pending", db_path=db)

--- a/tests/scitex_agent_container/runtimes/test__tui_outbound.py
+++ b/tests/scitex_agent_container/runtimes/test__tui_outbound.py
@@ -1,0 +1,241 @@
+"""Tests for the TUI outbound completion plumbing (``runtimes._tui_outbound``).
+
+The symmetric outbound half of the TUI a2a loop: record a requester-bearing
+inbound (DB), summarise the reply from the transcript, and push a
+dispatch-correlated completion report to the requester (SDK parity).
+
+Real seams (no mocks): a tmp ``state.db`` for the inbound ledger, a real
+JSONL transcript file for summary extraction, and a recording ``push_fn``
+in place of the network push. STX-TQ002 AAA + STX-TQ007 one assert +
+STX-TQ003 descriptive names.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scitex_agent_container._state import inbound_ledger as ledger
+from scitex_agent_container.runtimes import _tui_outbound as outbound
+
+
+def _write_transcript(path: Path, *records: dict) -> None:
+    path.write_text("\n".join(json.dumps(r) for r in records) + "\n", encoding="utf-8")
+
+
+def test_record_dispatch_noop_without_from_agent(tmp_path: Path) -> None:
+    # Arrange
+    db = tmp_path / "state.db"
+    # Act
+    row_id = outbound.record_dispatch(
+        db_path=db, agent="a", from_agent="", dispatch_id="d1"
+    )
+    # Assert
+    assert row_id is None
+
+
+def test_record_dispatch_records_pending_inbound(tmp_path: Path) -> None:
+    # Arrange
+    db = tmp_path / "state.db"
+    # Act
+    outbound.record_dispatch(db_path=db, agent="a", from_agent="lead", dispatch_id="d1")
+    # Assert
+    assert len(ledger.list_inbound(agent="a", db_path=db)) == 1
+
+
+def test_summarize_transcript_returns_last_assistant_text(tmp_path: Path) -> None:
+    # Arrange
+    transcript = tmp_path / "t.jsonl"
+    _write_transcript(
+        transcript,
+        {"type": "user", "message": {"content": "hi"}},
+        {
+            "type": "assistant",
+            "message": {"content": [{"type": "text", "text": "first"}]},
+        },
+        {
+            "type": "assistant",
+            "message": {"content": [{"type": "text", "text": "ACK-OK"}]},
+        },
+    )
+    # Act
+    status, summary = outbound.summarize_transcript(transcript)
+    # Assert
+    assert (status, summary) == ("success", "ACK-OK")
+
+
+def test_summarize_transcript_unknown_when_no_assistant_reply(tmp_path: Path) -> None:
+    # Arrange
+    transcript = tmp_path / "t.jsonl"
+    _write_transcript(transcript, {"type": "user", "message": {"content": "hi"}})
+    # Act
+    status, _summary = outbound.summarize_transcript(transcript)
+    # Assert
+    assert status == "unknown"
+
+
+def test_flush_one_completion_false_when_queue_empty(tmp_path: Path) -> None:
+    # Arrange — nothing recorded.
+    db = tmp_path / "state.db"
+    # Act
+    flushed = outbound.flush_one_completion(
+        db_path=db,
+        agent="a",
+        transcript_path=None,
+        listen_url="http://127.0.0.1:7878",
+        bearer=None,
+        push_fn=lambda **_kw: None,
+    )
+    # Assert
+    assert flushed is False
+
+
+def test_flush_one_completion_pushes_to_requester(tmp_path: Path) -> None:
+    # Arrange — one queued dispatch + a transcript with a reply.
+    db = tmp_path / "state.db"
+    outbound.record_dispatch(db_path=db, agent="a", from_agent="lead", dispatch_id="d1")
+    transcript = tmp_path / "t.jsonl"
+    _write_transcript(
+        transcript,
+        {
+            "type": "assistant",
+            "message": {"content": [{"type": "text", "text": "done"}]},
+        },
+    )
+    captured: dict[str, Any] = {}
+
+    def push(**kw: Any) -> None:
+        captured.update(kw)
+
+    # Act
+    outbound.flush_one_completion(
+        db_path=db,
+        agent="a",
+        transcript_path=transcript,
+        listen_url="http://127.0.0.1:7878",
+        bearer="tok",
+        push_fn=push,
+    )
+    # Assert
+    assert captured["requester"] == "lead"
+
+
+def test_flush_one_completion_marks_reported_on_success(tmp_path: Path) -> None:
+    # Arrange
+    db = tmp_path / "state.db"
+    outbound.record_dispatch(db_path=db, agent="a", from_agent="lead", dispatch_id="d1")
+    # Act
+    outbound.flush_one_completion(
+        db_path=db,
+        agent="a",
+        transcript_path=None,
+        listen_url="http://127.0.0.1:7878",
+        bearer=None,
+        push_fn=lambda **_kw: None,
+    )
+    # Assert
+    rows = ledger.list_inbound(agent="a", db_path=db)
+    assert rows[0]["status"] == ledger.STATUS_REPORTED
+
+
+def test_flush_one_completion_marks_failed_and_raises_on_push_error(
+    tmp_path: Path,
+) -> None:
+    # Arrange — a push that fails loud (no live subscriber).
+    db = tmp_path / "state.db"
+    outbound.record_dispatch(db_path=db, agent="a", from_agent="lead", dispatch_id="d1")
+
+    def boom(**_kw: Any) -> None:
+        raise RuntimeError("no live subscriber")
+
+    # Act
+    # Assert
+    with pytest.raises(RuntimeError):
+        outbound.flush_one_completion(
+            db_path=db,
+            agent="a",
+            transcript_path=None,
+            listen_url="http://127.0.0.1:7878",
+            bearer=None,
+            push_fn=boom,
+        )
+
+
+def test_summarize_transcript_unknown_when_file_absent(tmp_path: Path) -> None:
+    # Arrange
+    missing = tmp_path / "nope.jsonl"
+    # Act
+    status, summary = outbound.summarize_transcript(missing)
+    # Assert
+    assert (status, summary) == ("unknown", "")
+
+
+def test_summarize_transcript_truncates_to_cap(tmp_path: Path) -> None:
+    # Arrange — an assistant reply longer than the cap.
+    transcript = tmp_path / "t.jsonl"
+    _write_transcript(
+        transcript,
+        {
+            "type": "assistant",
+            "message": {"content": [{"type": "text", "text": "x" * 50}]},
+        },
+    )
+    # Act
+    _status, summary = outbound.summarize_transcript(transcript, cap=10)
+    # Assert
+    assert summary == "x" * 10 + "…"
+
+
+def _run_main_with(env: dict[str, str], stdin_text: str) -> int:
+    """Invoke ``outbound.main`` with a real (restored) env + stdin — no mocks."""
+    import io
+    import os
+    import sys
+
+    keys = (
+        "SCITEX_AGENT_CONTAINER_AGENT",
+        "SCITEX_AGENT_CONTAINER_STATE_DB",
+        "SAC_LISTEN_BASE_URL",
+        "SAC_LISTEN_BEARER",
+    )
+    saved = {k: os.environ.get(k) for k in keys}
+    saved_stdin = sys.stdin
+    for k in keys:
+        os.environ.pop(k, None)
+    for k, v in env.items():
+        os.environ[k] = v
+    sys.stdin = io.StringIO(stdin_text)
+    try:
+        return outbound.main([])
+    finally:
+        sys.stdin = saved_stdin
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+def test_main_returns_zero_when_queue_empty(tmp_path: Path) -> None:
+    # Arrange — wired env, empty ledger, a transcript path on stdin.
+    db = tmp_path / "state.db"
+    env = {
+        "SCITEX_AGENT_CONTAINER_AGENT": "a",
+        "SCITEX_AGENT_CONTAINER_STATE_DB": str(db),
+        "SAC_LISTEN_BASE_URL": "http://127.0.0.1:7878",
+    }
+    # Act
+    rc = _run_main_with(env, json.dumps({"transcript_path": str(tmp_path / "x.jsonl")}))
+    # Assert
+    assert rc == 0
+
+
+def test_main_noop_when_agent_env_absent(tmp_path: Path) -> None:
+    # Arrange — no sac agent env → main cannot resolve context.
+    # Act
+    rc = _run_main_with({}, "{}")
+    # Assert
+    assert rc == 0

--- a/tests/scitex_agent_container/runtimes/test__tui_turn_bridge.py
+++ b/tests/scitex_agent_container/runtimes/test__tui_turn_bridge.py
@@ -96,7 +96,7 @@ def bridge_factory() -> Iterator[Callable[..., int]]:
     servers = []
     threads = []
 
-    def start(on_turn: Callable[[str], None], agent_name: str = "figrecipe") -> int:
+    def start(on_turn: Callable[..., None], agent_name: str = "figrecipe") -> int:
         server = bridge.build_server(
             host="127.0.0.1", port=0, on_turn=on_turn, agent_name=agent_name
         )
@@ -133,7 +133,7 @@ def _post(port: int, path: str, body: dict | None) -> tuple[int, dict]:
 def test_post_v1_turn_delivers_text_to_on_turn(bridge_factory) -> None:
     # Arrange
     received: list[str] = []
-    port = bridge_factory(received.append)
+    port = bridge_factory(lambda text, **_kw: received.append(text))
     # Act
     _post(port, "/v1/turn", {"text": "hello fleet"})
     # Assert
@@ -142,7 +142,7 @@ def test_post_v1_turn_delivers_text_to_on_turn(bridge_factory) -> None:
 
 def test_post_v1_turn_returns_200_delivered_true(bridge_factory) -> None:
     # Arrange
-    port = bridge_factory(lambda text: None)
+    port = bridge_factory(lambda text, **_kw: None)
     # Act
     status, body = _post(port, "/v1/turn", {"text": "hi there"})
     # Assert
@@ -152,16 +152,37 @@ def test_post_v1_turn_returns_200_delivered_true(bridge_factory) -> None:
 def test_post_named_turn_route_delivers_for_this_agent(bridge_factory) -> None:
     # Arrange
     received: list[str] = []
-    port = bridge_factory(received.append, agent_name="figrecipe")
+    port = bridge_factory(
+        lambda text, **_kw: received.append(text), agent_name="figrecipe"
+    )
     # Act
     _post(port, "/agents/figrecipe/turn", {"text": "named route"})
     # Assert
     assert received == ["named route"]
 
 
+def test_post_threads_requester_identity_to_on_turn(bridge_factory) -> None:
+    # Arrange — capture the requester kwargs the handler forwards.
+    seen: dict = {}
+
+    def rec(text: str, *, from_agent=None, dispatch_id=None) -> None:
+        seen["from_agent"] = from_agent
+        seen["dispatch_id"] = dispatch_id
+
+    port = bridge_factory(rec)
+    # Act
+    _post(
+        port,
+        "/v1/turn",
+        {"text": "hi", "from_agent": "lead", "dispatch_id": "d1"},
+    )
+    # Assert
+    assert seen == {"from_agent": "lead", "dispatch_id": "d1"}
+
+
 def test_post_missing_text_field_returns_400(bridge_factory) -> None:
     # Arrange
-    port = bridge_factory(lambda text: None)
+    port = bridge_factory(lambda text, **_kw: None)
     # Act
     status, _body = _post(port, "/v1/turn", {"no_text_here": "x"})
     # Assert
@@ -170,7 +191,7 @@ def test_post_missing_text_field_returns_400(bridge_factory) -> None:
 
 def test_post_inject_failure_returns_502(bridge_factory) -> None:
     # Arrange
-    def raise_session_gone(text: str) -> None:
+    def raise_session_gone(text: str, **_kw: object) -> None:
         raise RuntimeError("session gone")
 
     port = bridge_factory(raise_session_gone)
@@ -182,7 +203,7 @@ def test_post_inject_failure_returns_502(bridge_factory) -> None:
 
 def test_post_unknown_route_returns_404(bridge_factory) -> None:
     # Arrange
-    port = bridge_factory(lambda text: None)
+    port = bridge_factory(lambda text, **_kw: None)
     # Act
     status, _body = _post(port, "/not/a/turn", {"text": "hi"})
     # Assert
@@ -191,7 +212,7 @@ def test_post_unknown_route_returns_404(bridge_factory) -> None:
 
 def test_health_get_returns_200(bridge_factory) -> None:
     # Arrange
-    port = bridge_factory(lambda text: None)
+    port = bridge_factory(lambda text, **_kw: None)
     # Act
     with urllib.request.urlopen(f"http://127.0.0.1:{port}/health", timeout=5) as resp:
         status = resp.status


### PR DESCRIPTION
## DB-backed outbound completion reports for `runtime: tui` (SDK parity) — sac-core half

Closes the symmetric **outbound** half of the TUI a2a loop. Inbound (#423) wakes an idle TUI agent; this makes it owe its requester the same **dispatch-correlated completion report** the SDK sends automatically (`{agent, dispatch_id, status, summary}` via `push_completion`).

### Why the DB (not a side file)
A TUI has no in-process turn envelope, so a bus-pushed wake's requester identity (`from_agent` + `dispatch_id`) can't ride the tmux-injected text from the **host-side** bridge to the **in-container** Stop hook. We carry it through the sac **SQLite state DB** — the bound `state.db` is visible host-side *and* in-container at `/state/<name>`, and `open_db`'s WAL + `busy_timeout=30000` make the cross-process access safe. This is the sac state DB doing what it's for: durable, ACID, queryable comms state.

### What landed
- **`_state/inbound_ledger.py`** (new) — the receiver-side mirror of the sender's `dispatch_ledger`. An `inbound_dispatches` table (sibling-module + own `CREATE TABLE IF NOT EXISTS`, layered on `open_db`). `record_inbound` (pending) / **atomic** `claim_oldest_pending` (pending→reporting in one `BEGIN IMMEDIATE`, so no double-report) / `mark_reported` (reported|failed) / `list_inbound`. FIFO by `ts` + sequential TUI turn processing keeps the dispatch↔turn correlation correct.
- **`runtimes/_tui_outbound.py`** (new) — `record_dispatch` (bridge writes), `summarize_transcript` (reply pulled from the transcript claude hands the Stop hook), `flush_one_completion` (claim → `build_completion_report` → **reuse `_session_completion.push_completion`** → mark reported/failed), and a `main()` Stop-hook entrypoint (reads the hook's stdin + in-container env).
- **`runtimes/_tui_turn_bridge.py`** — `on_turn` now threads `from_agent`/`dispatch_id` and records the inbound (best-effort — never blocks the wake) before injecting.

### SDK route is untouched + parallel
Only TUI files + one new table changed; `push_completion`/`build_completion_report` are **reused, never modified**. `runtime: claude-agent-sdk` (incl. qwen3.x via `spec.claude.provider`) is unchanged — `_runtime_select` keeps `tui` and `claude-agent-sdk` as two parallel launch modes sharing the same DB-backed comms primitives.

### Testing
- New: 8 `inbound_ledger` tests (lifecycle, FIFO, atomic single-claim, fail-loud validation), 11 `_tui_outbound` tests (record/summarize/flush via a recording `push_fn`, reported/failed settle, `main` no-ops), 1 bridge requester-threading test.
- Patch coverage ~84–87% on all three modules (clears codecov/patch 80%).
- Full `runtimes/` + `_state/` regression: **1905 passed, 17 skipped**. Ecosystem audit: SUCC.

### Other half (separate, dotfiles)
A thin `stop/completion_push_on_stop.sh` hook + one `settings.local.json` line in the to_home baseline, invoking `python -m …_tui_outbound`. Lands next, focused on figrecipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
