### PR TITLE
feat(runtimes): respect agent to_home/.env and .envrc via apptainer --env-file

### DIFF
--- a/src/scitex_agent_container/runtimes/_apptainer_build_argv.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_build_argv.py
@@ -87,6 +87,24 @@ def build_run_argv(
     home_host.mkdir(parents=True, exist_ok=True)
     argv += ["--bind", f"{home_host}:/home/agent"]
 
+    # Agent-supplied environment file. ``deploy_to_home`` materialises each
+    # agent's ``to_home/.env`` to ``$HOME/.env`` (== ``home_host/.env`` on
+    # the host) BEFORE this argv is built (see TuiSessionRuntime /
+    # ClaudeSessionRuntime: deploy_to_home → build_run_argv). The
+    # materialised file is never auto-loaded into the agent's process, so we
+    # inject it here via apptainer ``--env-file`` — the apptainer-native
+    # mechanism that works for BOTH the relaxed and hardened (preflight-
+    # wrapped) inner commands. Emitted FIRST among env wiring so every
+    # curated ``--env`` below (quota path, state-db, auth, listen, spec.env)
+    # OVERRIDES it: the .env supplies per-agent additions (e.g.
+    # ``CLAUDE_CODE_TELEGRAMMER_TELEGRAM_BOT_TOKEN``), never sac's critical
+    # wiring. Format is plain ``KEY=VALUE`` — apptainer ``--env-file`` is not
+    # a shell, so no ``export`` prefix and no quoting of values. No-op when
+    # the agent ships no ``.env``.
+    env_file = home_host / ".env"
+    if env_file.is_file():
+        argv += ["--env-file", str(env_file)]
+
     # Quota-cache bind (#16) — see module-level docstring in
     # _apptainer_runtime. Bind read-only + advertise the in-container
     # path to the telegrammer bridge so its default-path lookup hits

--- a/src/scitex_agent_container/runtimes/_envrc.py
+++ b/src/scitex_agent_container/runtimes/_envrc.py
@@ -1,0 +1,117 @@
+"""Evaluate an agent's ``to_home/.envrc`` into ``KEY=VALUE`` env pairs.
+
+direnv's ``.envrc`` is a shell script (``export``, ``$(...)``, conditionals,
+``dotenv`` …), so apptainer ``--env-file`` cannot parse it directly. At deploy
+time :func:`_to_home.deploy_to_home` sources it in bash — AFTER the sibling
+``.env`` so the ``.envrc`` can read and override those values — and captures
+the NET environment contribution (vars ADDED or CHANGED vs a baseline shell
+with the same parent env). The result is folded back into the materialised
+``$HOME/.env`` that :func:`_apptainer_build_argv.build_run_argv` injects via
+``--env-file``.
+
+Default behaviour (NOT opt-in): a present ``.envrc`` is always evaluated; when
+the agent ships neither ``.env`` nor ``.envrc`` the whole flow is skipped.
+Fail-loud: a ``.envrc`` whose bash evaluation exits non-zero raises
+:class:`EnvrcEvalError` and aborts the deploy, rather than launching the agent
+with a half-applied environment.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shlex
+import subprocess
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Shell-internal vars that legitimately differ between two otherwise-identical
+# bash invocations (or are set by bash itself) — never part of the
+# ``.env``/``.envrc`` contribution, so excluded from the captured diff.
+_SHELL_NOISE = frozenset({"_", "SHLVL", "PWD", "OLDPWD"})
+
+
+class EnvrcEvalError(RuntimeError):
+    """An agent's ``.envrc`` failed to evaluate (fail-loud; aborts deploy)."""
+
+
+def _capture_env(script: str, cwd: Path) -> dict[str, str]:
+    """Run ``script`` in a clean (no rc/profile) bash and return its env.
+
+    Output is parsed from ``env -0`` (NUL-delimited ``KEY=VALUE``) so values
+    containing newlines or ``=`` survive intact. A non-zero exit raises
+    :class:`EnvrcEvalError` carrying bash's stderr.
+    """
+    proc = subprocess.run(
+        ["bash", "--noprofile", "--norc", "-c", script],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        raise EnvrcEvalError(proc.stderr.strip() or f"bash exited {proc.returncode}")
+    env: dict[str, str] = {}
+    for entry in proc.stdout.split("\0"):
+        if not entry:
+            continue
+        key, sep, val = entry.partition("=")
+        if sep:
+            env[key] = val
+    return env
+
+
+def eval_envrc(envrc: Path, *, base_env: Path | None = None) -> dict[str, str]:
+    """Return the net env vars from sourcing ``base_env`` then ``envrc``.
+
+    Sources (with ``set -a`` so plain ``KEY=VALUE`` assignments export) the
+    optional ``base_env`` (the sibling ``.env``) first, then ``envrc``, and
+    diffs the resulting environment against a baseline shell — returning only
+    the keys the scripts ADDED or CHANGED (shell-internal noise filtered).
+    ``cwd`` is ``envrc``'s directory so relative paths inside it resolve.
+
+    Raises :class:`EnvrcEvalError` (wrapping bash stderr) on a non-zero exit.
+    """
+    cwd = envrc.parent
+    baseline = _capture_env("env -0", cwd)
+    lines = ["set -a"]
+    if base_env is not None and base_env.is_file():
+        lines.append(f". {shlex.quote(str(base_env))}")
+    lines.append(f". {shlex.quote(str(envrc))}")
+    lines.append("set +a")
+    lines.append("env -0")
+    loaded = _capture_env("\n".join(lines), cwd)
+    return {
+        key: val
+        for key, val in loaded.items()
+        if key not in _SHELL_NOISE and baseline.get(key) != val
+    }
+
+
+def fold_envrc_into_env(dest: Path) -> None:
+    """Fold ``dest/.envrc`` (if any) into ``dest/.env`` for ``--env-file``.
+
+    When ``dest/.envrc`` exists, evaluate it (after ``dest/.env`` so it can
+    build on those values) and rewrite ``dest/.env`` with the combined net
+    environment (``chmod 0600``). No-op when there is no ``.envrc`` — a plain
+    ``.env`` is left exactly as materialised. Also a no-op when evaluation
+    yields nothing, so an existing ``.env`` is never blanked.
+    """
+    envrc = dest / ".envrc"
+    if not envrc.is_file():
+        return
+    env_file = dest / ".env"
+    base = env_file if env_file.is_file() else None
+    merged = eval_envrc(envrc, base_env=base)
+    if not merged:
+        return
+    body = "".join(f"{k}={v}\n" for k, v in sorted(merged.items()))
+    env_file.write_text(body)
+    try:
+        os.chmod(env_file, 0o600)
+    except OSError as exc:  # stx-allow: fallback (reason: filesystem op failure)
+        logger.warning("envrc: failed to chmod 0600 on %s: %s", env_file, exc)
+    logger.info("envrc: folded %s into %s (%d vars)", envrc, env_file, len(merged))
+
+
+__all__ = ["EnvrcEvalError", "eval_envrc", "fold_envrc_into_env"]

--- a/src/scitex_agent_container/runtimes/_to_home.py
+++ b/src/scitex_agent_container/runtimes/_to_home.py
@@ -64,6 +64,7 @@ from datetime import datetime
 from pathlib import Path
 
 from ..config import AgentConfig
+from ._envrc import fold_envrc_into_env
 from ._mcp_merge import merge_mcp_json
 from ._symlink_resolve import DanglingToHomeSymlinkError, deref_copy_symlink
 from ._to_home_errors import (
@@ -105,6 +106,12 @@ _MCP_MERGE_BASENAMES = frozenset({".mcp.json"})
 # Files that get chmod 0600 after copy. ``.env`` only by default; the
 # rest preserve source perms via ``shutil.copy2``.
 _TIGHT_PERM_BASENAMES = frozenset({".env"})
+
+# Files copied VERBATIM (no ${...} interpolation) + chmod 0600. ``.envrc`` is a
+# shell script whose own ${VAR} / $(...) syntax must reach bash intact (sac
+# interpolation would expand it at deploy time and corrupt the script); it is
+# evaluated host-side post-deploy by :func:`_envrc.fold_envrc_into_env`.
+_VERBATIM_SECRET_BASENAMES = frozenset({".envrc"})
 
 # Env var: explicit override for the shared/common baseline to_home dir.
 # Absolute path. When unset we fall back to ``<agents_dir>/_shared/to_home``
@@ -206,6 +213,7 @@ def materialize_to_home(spec_dir: Path, workspace_home: Path) -> None:
         _walk_and_apply(baseline, baseline, workspace_home, config=None)
     if root.is_dir():
         _walk_and_apply(root, root, workspace_home, config=None)
+    fold_envrc_into_env(workspace_home)
 
 
 def deploy_to_home(config: AgentConfig, workspace_home: str) -> None:
@@ -240,6 +248,10 @@ def deploy_to_home(config: AgentConfig, workspace_home: str) -> None:
         _walk_and_apply(baseline, baseline, dest, config=config)
     if root is not None:
         _walk_and_apply(root, root, dest, config=config)
+    # .envrc (if present) is a shell script: evaluate it host-side and fold
+    # the result into dest/.env so build_run_argv's --env-file injects it.
+    # No-op when the agent ships no .envrc.
+    fold_envrc_into_env(dest)
 
 
 # --- traversal -------------------------------------------------------------
@@ -309,6 +321,8 @@ def _walk_and_apply(
             _deploy_mcp_merge(child, dst, config=config, rel=rel)
         elif child.name in _TIGHT_PERM_BASENAMES:
             _deploy_tight_perm_file(child, dst, config=config, rel=rel)
+        elif child.name in _VERBATIM_SECRET_BASENAMES:
+            _deploy_verbatim_secret(child, dst, rel=rel)
         else:
             _deploy_plain_file(child, dst, config=config, rel=rel)
 
@@ -445,6 +459,25 @@ def _deploy_tight_perm_file(
     except OSError as exc:  # stx-allow: fallback (reason: filesystem op failure)
         logger.warning("Failed to chmod 0600 on %s: %s", dst, exc)
     logger.info("to_home: deployed (0600) %s -> %s", rel, dst)
+
+
+def _deploy_verbatim_secret(src: Path, dst: Path, *, rel: Path) -> None:
+    """Byte-for-byte copy (NO interpolation) + chmod 0600. For ``.envrc``.
+
+    Unlike :func:`_deploy_tight_perm_file`, this NEVER runs ``${...}``
+    interpolation: a ``.envrc`` is a shell script and its own ``${VAR}`` /
+    ``$(...)`` syntax must reach bash intact (sac interpolation would expand
+    it at deploy time and corrupt the script). The file is evaluated later by
+    :func:`_envrc.fold_envrc_into_env`.
+    """
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    _clear_readonly_dst(dst)
+    shutil.copy2(src, dst)
+    try:
+        os.chmod(dst, 0o600)
+    except OSError as exc:  # stx-allow: fallback (reason: filesystem op failure)
+        logger.warning("Failed to chmod 0600 on %s: %s", dst, exc)
+    logger.info("to_home: deployed verbatim (0600) %s -> %s", rel, dst)
 
 
 def _deploy_marker_protected(

--- a/tests/scitex_agent_container/runtimes/test__apptainer_build_argv.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_build_argv.py
@@ -199,6 +199,55 @@ def test_build_run_argv_tui_inner_is_claude(tui_config, tmp_path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# build_run_argv — to_home/.env injected via --env-file (sac respects .env)
+# ---------------------------------------------------------------------------
+
+
+def test_build_run_argv_injects_env_file_when_present(tui_config, tmp_path) -> None:
+    # Arrange — the $HOME/.env that deploy_to_home materialises, at the host
+    # side of the /home/agent bind (state_dir/home/.env).
+    state_dir = tmp_path / "state"
+    (state_dir / "home").mkdir(parents=True, exist_ok=True)
+    (state_dir / "home" / ".env").write_text(
+        "CLAUDE_CODE_TELEGRAMMER_TELEGRAM_BOT_TOKEN=123:not-a-real-secret\n",
+        encoding="utf-8",
+    )
+    # Act
+    argv = build_run_argv(
+        tui_config, state_dir=state_dir, sif_path=Path("/img/sac.sif"), tui=True
+    )
+    # Assert
+    assert "--env-file" in argv and str(state_dir / "home" / ".env") in argv
+
+
+def test_build_run_argv_omits_env_file_when_absent(tui_config, tmp_path) -> None:
+    # Arrange — no .env materialised under state_dir/home.
+    state_dir = tmp_path / "state"
+    # Act
+    argv = build_run_argv(
+        tui_config, state_dir=state_dir, sif_path=Path("/img/sac.sif"), tui=True
+    )
+    # Assert
+    assert "--env-file" not in argv
+
+
+def test_build_run_argv_env_file_precedes_curated_env(tui_config, tmp_path) -> None:
+    # Arrange — .env present; a curated --env (state-db) must be emitted
+    # AFTER the --env-file so it wins on conflict (precedence by position).
+    state_dir = tmp_path / "state"
+    (state_dir / "home").mkdir(parents=True, exist_ok=True)
+    (state_dir / "home" / ".env").write_text("FOO=bar\n", encoding="utf-8")
+    # Act
+    argv = build_run_argv(
+        tui_config, state_dir=state_dir, sif_path=Path("/img/sac.sif"), tui=True
+    )
+    # Assert
+    assert argv.index("--env-file") < argv.index(
+        "SCITEX_AGENT_CONTAINER_STATE_DB=/state/state.db"
+    )
+
+
+# ---------------------------------------------------------------------------
 # credentials_file_bind — writable single-source-of-truth mount
 # ---------------------------------------------------------------------------
 

--- a/tests/scitex_agent_container/runtimes/test__envrc.py
+++ b/tests/scitex_agent_container/runtimes/test__envrc.py
@@ -1,0 +1,95 @@
+"""Evaluate ``to_home/.envrc`` into env vars for ``--env-file`` injection.
+
+Covers ``_envrc.{eval_envrc, fold_envrc_into_env}``: a direnv-style ``.envrc``
+is a shell script apptainer ``--env-file`` can't parse, so ``deploy_to_home``
+evaluates it host-side (after the sibling ``.env``) and folds the net env into
+the materialised ``.env``. Real bash + tmp files — no mocks (PA-306).
+STX-TQ002 AAA-marker + STX-TQ007 one-assert.
+
+Named ``test__envrc.py`` for the PS-204 §2 orphan-test mirror against
+``src/scitex_agent_container/runtimes/_envrc.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container.runtimes._envrc import (
+    EnvrcEvalError,
+    eval_envrc,
+    fold_envrc_into_env,
+)
+
+
+def test_eval_envrc_captures_exported_var(tmp_path: Path) -> None:
+    # Arrange
+    envrc = tmp_path / ".envrc"
+    envrc.write_text("export FIGRECIPE_FOO=bar\n", encoding="utf-8")
+    # Act
+    out = eval_envrc(envrc)
+    # Assert
+    assert out.get("FIGRECIPE_FOO") == "bar"
+
+
+def test_eval_envrc_evaluates_command_substitution(tmp_path: Path) -> None:
+    # Arrange
+    envrc = tmp_path / ".envrc"
+    envrc.write_text("export COMPUTED=$(printf abc)\n", encoding="utf-8")
+    # Act
+    out = eval_envrc(envrc)
+    # Assert
+    assert out.get("COMPUTED") == "abc"
+
+
+def test_eval_envrc_sees_base_env_first(tmp_path: Path) -> None:
+    # Arrange — .envrc references a var defined in the sibling .env.
+    base = tmp_path / ".env"
+    base.write_text("BASE_TOKEN=xyz\n", encoding="utf-8")
+    envrc = tmp_path / ".envrc"
+    envrc.write_text('export DERIVED="${BASE_TOKEN}-suffix"\n', encoding="utf-8")
+    # Act
+    out = eval_envrc(envrc, base_env=base)
+    # Assert
+    assert out.get("DERIVED") == "xyz-suffix"
+
+
+def test_eval_envrc_raises_on_nonzero_exit(tmp_path: Path) -> None:
+    # Arrange — a .envrc that fails (exit 1).
+    envrc = tmp_path / ".envrc"
+    envrc.write_text("echo boom >&2\nexit 1\n", encoding="utf-8")
+    # Act
+    # Assert
+    with pytest.raises(EnvrcEvalError):
+        eval_envrc(envrc)
+
+
+def test_fold_envrc_writes_combined_env_file(tmp_path: Path) -> None:
+    # Arrange — dest has both .env and .envrc; the .envrc adds a var.
+    (tmp_path / ".env").write_text("FROM_ENV=1\n", encoding="utf-8")
+    (tmp_path / ".envrc").write_text("export FROM_ENVRC=2\n", encoding="utf-8")
+    # Act
+    fold_envrc_into_env(tmp_path)
+    # Assert — the folded .env carries BOTH sources.
+    text = (tmp_path / ".env").read_text()
+    assert "FROM_ENV=1" in text and "FROM_ENVRC=2" in text
+
+
+def test_fold_envrc_noop_when_no_envrc(tmp_path: Path) -> None:
+    # Arrange — only a .env, no .envrc.
+    env_file = tmp_path / ".env"
+    env_file.write_text("ONLY=env\n", encoding="utf-8")
+    # Act
+    fold_envrc_into_env(tmp_path)
+    # Assert — .env left exactly as materialised.
+    assert env_file.read_text() == "ONLY=env\n"
+
+
+def test_fold_envrc_sets_owner_only_perms(tmp_path: Path) -> None:
+    # Arrange
+    (tmp_path / ".envrc").write_text("export SECRET=s\n", encoding="utf-8")
+    # Act
+    fold_envrc_into_env(tmp_path)
+    # Assert — the folded .env is chmod 0600.
+    assert (tmp_path / ".env").stat().st_mode & 0o777 == 0o600

--- a/tests/scitex_agent_container/runtimes/test__to_home.py
+++ b/tests/scitex_agent_container/runtimes/test__to_home.py
@@ -1166,3 +1166,32 @@ class TestNoHostAutoRead:
         assert (
             home / ".claude" / "skills" / "general" / "SKILL.md"
         ).read_text() == "from per-agent\n"
+
+
+# ---------------------------------------------------------------------------
+# .envrc — verbatim deploy + host-side fold into .env (sac respects .envrc)
+# ---------------------------------------------------------------------------
+
+
+def test_deploy_to_home_folds_envrc_into_env(tmp_path: Path) -> None:
+    # Arrange — a to_home carrying a .envrc (direnv shell script).
+    cfg, to_home = _build_cfg(tmp_path)
+    (to_home / ".envrc").write_text("export FOLDED_FROM_ENVRC=yes\n", encoding="utf-8")
+    home = tmp_path / "home"
+    # Act
+    deploy_to_home(cfg, str(home))
+    # Assert — the .envrc was evaluated and folded into $HOME/.env.
+    assert "FOLDED_FROM_ENVRC=yes" in (home / ".env").read_text()
+
+
+def test_deploy_to_home_envrc_deployed_verbatim(tmp_path: Path) -> None:
+    # Arrange — a .envrc whose own ${...} syntax must NOT be sac-interpolated.
+    cfg, to_home = _build_cfg(tmp_path)
+    (to_home / ".envrc").write_text(
+        "export KEEP='${NOT_INTERPOLATED}'\n", encoding="utf-8"
+    )
+    home = tmp_path / "home"
+    # Act
+    deploy_to_home(cfg, str(home))
+    # Assert — the deployed .envrc retains its literal shell ${...} syntax.
+    assert "${NOT_INTERPOLATED}" in (home / ".envrc").read_text()


### PR DESCRIPTION
## What

Make sac respect each agent's `to_home/.env` **and** `to_home/.envrc`, by default, so the agent's process env — and any MCP server it spawns (e.g. `claude-code-telegrammer`) — picks up agent-supplied vars. No-op when the agent ships neither.

## Why

`to_home/.env` was already materialised to `$HOME/.env` (chmod 0600) but **never loaded** into the agent process — `_apptainer_provider.py` even noted the materialised copy "is not consulted". This wires it in.

## How

1. **`.env`** — `build_run_argv` injects the materialised `$HOME/.env` (= `state_dir/home/.env`) via apptainer `--env-file`, emitted **first** so every curated `--env` (auth, listen, state-db, spec.env) overrides it. Works for both relaxed and hardened (preflight-wrapped) inner commands.
2. **`.envrc`** (direnv) — a shell script `--env-file` cannot parse. New `_envrc` module evaluates it host-side at deploy (bash, sourcing the sibling `.env` first so `.envrc` can build on it) and folds the **net** env contribution into `$HOME/.env`. Deployed **verbatim** (no `${...}` interpolation — its shell `${VAR}`/`$(...)` syntax must reach bash intact) at chmod 0600. **Fail-loud**: a non-zero `.envrc` eval raises `EnvrcEvalError` and aborts the deploy.

Precedence (lowest → highest): `.env` → `.envrc` → curated sac `--env`.

## Tests

- `test__apptainer_build_argv.py`: 3 (env-file present / absent / precedes curated env).
- `test__envrc.py`: 7 (export capture, command substitution, base-env precedence, raises-on-failure, fold, no-op, 0600 perms).
- Full regression: **119 passed** across `_envrc` + `to_home` + `to_home_overlay` + `build_argv` + examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
