### PR TITLE
fix(launch): fail-loud debuggable agent launch — boot-stderr feedback, rename hint, idempotent .mcp.json deploy

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_start.py
+++ b/src/scitex_agent_container/_lifecycle/_start.py
@@ -34,6 +34,23 @@ from ._start_preflight import (  # noqa: F401
 from .health import health_monitor
 
 
+def _format_boot_stderr_section(log: Path) -> str:
+    """Formatted 'inner stderr' diagnostic section for a failed TUI start.
+
+    B->A feedback / no silent fallback: ``TuiSessionRuntime`` redirects the
+    inner ``apptainer exec … claude`` STDERR — where apptainer's FATAL mount
+    errors and an immediate claude exit land — to ``<state>/boot.stderr.log``
+    (``log``), which SURVIVES the tmux pane's death. Return its tail so a boot
+    failure is the LOUD cause in the raised error, never a cause-less
+    ``<empty>`` pane fallback. Empty/absent-log safe; never raises.
+    """
+    tail = ""
+    if log.is_file():
+        tail = log.read_text(errors="replace")[-4_000:].rstrip()
+    body = tail or "<no stderr captured — runtime never launched the process>"
+    return f"  inner stderr ({log}):\n{body}\n"
+
+
 def agent_start(
     config_path: str,
     registry: Registry | None = None,
@@ -364,13 +381,18 @@ def agent_start(
         diag = ""
         try:
             from .._runners._tmux.tmux import TmuxManager
-            from ..runtimes.tui_session import session_name_for
+            from ..runtimes.tui_session import (
+                session_name_for,
+                state_dir_for_config,
+            )
 
             _sess = session_name_for(config)
             _pane = TmuxManager.capture_logs(_sess, lines=60).rstrip()
+            _boot_log = state_dir_for_config(config) / "boot.stderr.log"
             diag = (
                 f" (tmux session_exists={TmuxManager.exists(_sess)})\n"
-                f"  pane tail:\n{_pane or '<empty — inner process exited before any output>'}"
+                f"{_format_boot_stderr_section(_boot_log)}"
+                f"  pane tail:\n{_pane or '<empty>'}"
             )
         except Exception:  # stx-allow: fallback (reason: diagnostics must never mask the real start failure — degrade to no pane)
             diag = " (no pane diagnostics available)"

--- a/src/scitex_agent_container/cli_pkg/_main.py
+++ b/src/scitex_agent_container/cli_pkg/_main.py
@@ -270,16 +270,16 @@ class _MainGroup(LazyGroup):
     # stale scripts persist indefinitely; hard errors force the fix.
     LAZY_RENAMED = {
         # Lifecycle
-        "start": (f"{_PKG}.lifecycle:start", "sac agent start"),
-        "stop": (f"{_PKG}.lifecycle:stop", "sac agent stop"),
-        "restart": (f"{_PKG}.lifecycle:restart", "sac agent restart"),
-        "validate": (f"{_PKG}.build_cmds:validate", "sac agent validate"),
-        "check": (f"{_PKG}.build_cmds:check", "sac agent check"),
+        "start": (f"{_PKG}.lifecycle:start", "sac agents start"),
+        "stop": (f"{_PKG}.lifecycle:stop", "sac agents stop"),
+        "restart": (f"{_PKG}.lifecycle:restart", "sac agents restart"),
+        "validate": (f"{_PKG}.build_cmds:validate", "sac agents validate"),
+        "check": (f"{_PKG}.build_cmds:check", "sac agents check"),
         # Status / introspection
-        "show-status": (f"{_PKG}.status_cmds:status", "sac agent status"),
-        "check-health": (f"{_PKG}.status_cmds:health", "sac agent health"),
-        "find": (f"{_PKG}.info_cmds:find", "sac agent find"),
-        "recall": (f"{_PKG}.recall_cmds:recall", "sac agent recall"),
+        "show-status": (f"{_PKG}.status_cmds:status", "sac agents status"),
+        "check-health": (f"{_PKG}.status_cmds:health", "sac agents health"),
+        "find": (f"{_PKG}.info_cmds:find", "sac agents find"),
+        "recall": (f"{_PKG}.recall_cmds:recall", "sac agents recall"),
         # Quota — accounts is a top-level noun (the credential store is
         # fleet-wide, not agent-scoped).
         "watch-quota": (
@@ -370,8 +370,8 @@ def main(ctx: click.Context, help_recursive: bool, as_json: bool) -> None:
 
     \b
     Example:
-      $ sac agent start orchestrator                                      # by name
-      $ sac agent start ~/.scitex/agent-container/agents/orchestrator/spec.yaml   # by path
+      $ sac agents start orchestrator                                      # by name
+      $ sac agents start ~/.scitex/agent-container/agents/orchestrator/spec.yaml   # by path
     """
     ctx.ensure_object(dict)
     if as_json:
@@ -389,7 +389,7 @@ def cli_entry_point() -> None:
     Click's group parser normally consumes ``--on`` during ``main``'s
     own arg parsing, but the flag has to be honoured BEFORE the
     subcommand is dispatched: ``sac --on spartan agent list`` must
-    run ``sac agent list`` on spartan, not locally. Pre-process
+    run ``sac agents list`` on spartan, not locally. Pre-process
     ``sys.argv`` here, dispatch via host_group.dispatch_remote when
     the flag is present, and fall through to plain ``main()``
     otherwise.

--- a/src/scitex_agent_container/runtimes/_to_home.py
+++ b/src/scitex_agent_container/runtimes/_to_home.py
@@ -209,6 +209,12 @@ def materialize_to_home(spec_dir: Path, workspace_home: Path) -> None:
     if root.is_dir():
         _scan_for_credential_leak(root)
     workspace_home.mkdir(parents=True, exist_ok=True)
+    # Idempotency (see deploy_to_home): re-derive deep-merged files fresh so a
+    # changed per-agent definition never false-conflicts with a stale copy.
+    for _merge_name in _MCP_MERGE_BASENAMES:
+        _stale = workspace_home / _merge_name
+        if _stale.is_file():
+            _stale.unlink()
     if baseline is not None:
         _walk_and_apply(baseline, baseline, workspace_home, config=None)
     if root.is_dir():
@@ -244,6 +250,16 @@ def deploy_to_home(config: AgentConfig, workspace_home: str) -> None:
         _scan_for_credential_leak(root)
     dest = Path(workspace_home)
     dest.mkdir(parents=True, exist_ok=True)
+    # Idempotency: re-derive the deep-merged .mcp.json FRESH each deploy. Drop
+    # any prior-deploy copy first so a CHANGED per-agent definition (e.g. an
+    # updated telegrammer command/path) re-deploys cleanly, instead of
+    # false-conflicting (McpMergeConflict) against last deploy's stale result
+    # in _deploy_mcp_merge. No data loss — the file is regenerated below from
+    # baseline ∪ per-agent.
+    for _merge_name in _MCP_MERGE_BASENAMES:
+        _stale = dest / _merge_name
+        if _stale.is_file():
+            _stale.unlink()
     if baseline is not None:
         _walk_and_apply(baseline, baseline, dest, config=config)
     if root is not None:

--- a/src/scitex_agent_container/runtimes/tui_session.py
+++ b/src/scitex_agent_container/runtimes/tui_session.py
@@ -336,7 +336,21 @@ class TuiSessionRuntime(RuntimeBase):
             or getattr(config, "workdir", "")
             or "/tmp"
         )
-        command = " ".join(shlex.quote(a) for a in argv)
+        # B->A feedback (fail-fast / fail-loud / no silent fallback): the inner
+        # ``apptainer exec … claude`` renders its TUI to the tmux PANE (stdout),
+        # but its STDERR — where apptainer's FATAL mount errors and an immediate
+        # claude exit land — would otherwise die with the pane, leaving the
+        # launcher only a cause-less "<empty>" pane tail. Redirect that stderr
+        # to a DURABLE per-agent log from t=0 (no pipe-pane race) so
+        # ``agent_start`` (``_read_boot_stderr_section``) surfaces the real boot
+        # failure. ``2>`` truncates per start. No mkdir here: deploy_to_home
+        # already created ``<state>/home`` (so ``<state>/`` exists), and keeping
+        # this seam free of real-FS writes lets the unit suite record the
+        # command via a fake mux without polluting ``~/.scitex``.
+        boot_stderr_log = state_dir_for_config(config) / "boot.stderr.log"
+        command = " ".join(shlex.quote(a) for a in argv) + (
+            f" 2> {shlex.quote(str(boot_stderr_log))}"
+        )
         started = bool(
             self._mux.start(
                 session_name=name,

--- a/tests/scitex_agent_container/_lifecycle/test__start_boot_stderr.py
+++ b/tests/scitex_agent_container/_lifecycle/test__start_boot_stderr.py
@@ -1,0 +1,34 @@
+"""``_format_boot_stderr_section`` — surface the captured inner-boot stderr.
+
+Mirror for ``_lifecycle/_start.py`` boot-failure diagnostics: ``TuiSessionRuntime``
+redirects the inner ``apptainer exec … claude`` STDERR to
+``<state>/boot.stderr.log`` (B->A feedback), and a failed ``agent_start``
+surfaces its tail LOUDLY instead of a silent "<empty>" pane. The formatter is
+a pure function over a ``Path`` — real tmp files, no mocks (PA-306).
+STX-TQ002 AAA-marker + STX-TQ007 one-assert.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scitex_agent_container._lifecycle._start import _format_boot_stderr_section
+
+
+def test_format_boot_stderr_section_surfaces_captured_fatal(tmp_path: Path) -> None:
+    # Arrange — a boot.stderr.log holding the real apptainer FATAL.
+    log = tmp_path / "boot.stderr.log"
+    log.write_text("FATAL: container creation failed: mount error\n", encoding="utf-8")
+    # Act
+    section = _format_boot_stderr_section(log)
+    # Assert
+    assert "FATAL: container creation failed" in section
+
+
+def test_format_boot_stderr_section_marks_absent_log(tmp_path: Path) -> None:
+    # Arrange — no log file (the inner process never launched).
+    log = tmp_path / "boot.stderr.log"
+    # Act
+    section = _format_boot_stderr_section(log)
+    # Assert
+    assert "<no stderr captured" in section

--- a/tests/scitex_agent_container/cli_pkg/_helpers/test__groups.py
+++ b/tests/scitex_agent_container/cli_pkg/_helpers/test__groups.py
@@ -162,7 +162,7 @@ TOP_LEVEL_REDIRECTS = [
     # (argv, new_path_substring_in_stderr, test_id)
     pytest.param(["clean-registry"], "sac db clean", id="clean-registry"),
     pytest.param(["probe-network"], "sac host probe-hub", id="probe-network"),
-    pytest.param(["start", "any-name"], "sac agent start", id="start-alias"),
+    pytest.param(["start", "any-name"], "sac agents start", id="start-alias"),
     pytest.param(["registry", "clean"], "sac db clean", id="registry-clean-subcommand"),
 ]
 

--- a/tests/scitex_agent_container/runtimes/test__to_home.py
+++ b/tests/scitex_agent_container/runtimes/test__to_home.py
@@ -1195,3 +1195,27 @@ def test_deploy_to_home_envrc_deployed_verbatim(tmp_path: Path) -> None:
     deploy_to_home(cfg, str(home))
     # Assert — the deployed .envrc retains its literal shell ${...} syntax.
     assert "${NOT_INTERPOLATED}" in (home / ".envrc").read_text()
+
+
+# ---------------------------------------------------------------------------
+# .mcp.json deep-merge idempotency — a CHANGED per-agent definition must
+# re-deploy cleanly (no false McpMergeConflict vs last deploy's stale result).
+# ---------------------------------------------------------------------------
+
+
+def test_deploy_to_home_remerges_changed_mcp_json_without_conflict(
+    tmp_path: Path,
+) -> None:
+    # Arrange — deploy a per-agent .mcp.json once, then CHANGE it (the
+    # figrecipe scenario: an updated telegrammer command).
+    cfg, to_home = _build_cfg(tmp_path)
+    mcp = to_home / ".mcp.json"
+    mcp.write_text('{"mcpServers": {"x": {"command": "old"}}}', encoding="utf-8")
+    home = tmp_path / "home"
+    deploy_to_home(cfg, str(home))
+    mcp.write_text('{"mcpServers": {"x": {"command": "new"}}}', encoding="utf-8")
+    # Act — redeploy with the changed definition (must NOT McpMergeConflict).
+    deploy_to_home(cfg, str(home))
+    # Assert — the deployed .mcp.json reflects the NEW definition (re-derived).
+    deployed = json.loads((home / ".mcp.json").read_text())
+    assert deployed["mcpServers"]["x"]["command"] == "new"

--- a/tests/scitex_agent_container/runtimes/test_tui_session.py
+++ b/tests/scitex_agent_container/runtimes/test_tui_session.py
@@ -340,7 +340,10 @@ def test_tui_runtime_start_invokes_claude_binary_in_session(
     # Act
     runtime.start(config)
     # Assert
-    assert mux._sessions["tui-delta"].command == "apptainer exec img.sif claude"
+    assert (
+        mux._sessions["tui-delta"].command.split(" 2> ", 1)[0]
+        == "apptainer exec img.sif claude"
+    )
 
 
 def test_tui_runtime_start_force_stops_existing_session_first(
@@ -524,7 +527,9 @@ def test_tui_runtime_logs_returns_captured_pane_text(
     # Act
     text = runtime.logs(config, lines=10)
     # Assert
-    assert text == "<pane lines=10>apptainer exec img.sif claude@/data/nu"
+    assert text.startswith(
+        "<pane lines=10>apptainer exec img.sif claude 2> "
+    ) and text.endswith("/boot.stderr.log@/data/nu")
 
 
 def test_tui_runtime_logs_returns_empty_when_session_absent(


### PR DESCRIPTION
## What

Four launch-reliability fixes for `sac agents start`, all embodying **fail-fast / fail-loud / no-silent-fallback / A→B→A feedback**. Motivated by a real debugging session where a figrecipe TUI boot died **silently** (`<empty — inner process exited before any output>`) and it took a manual `2>`-redirect to find the actual `apptainer: FATAL` cause.

## Fixes

1. **B→A boot feedback** (`tui_session.py`, `_start.py`) — the TUI runtime redirects the inner `apptainer exec … claude` **stderr → `<state>/boot.stderr.log`** (survives the tmux pane's death). On a failed `agent_start`, `_format_boot_stderr_section` surfaces its tail, so a `FATAL` mount error or an immediate claude exit is the **loud** cause, never the cause-less `<empty>` pane fallback. No mkdir/extra FS writes in the launch seam (deploy already created the state dir).

2. **Correct rename hint** (`_main.py`) — the legacy top-level redirects (`sac start`, `sac stop`, …) pointed users at `sac agent <verb>` (singular), but the group is `agents`. Every hint now points at the valid `sac agents <verb>`.

3. **Idempotent `.mcp.json` deploy** (`_to_home.py`) — `deploy_to_home` / `materialize_to_home` re-derive the deep-merged `.mcp.json` **fresh** each deploy (drop the prior copy first). A **changed** per-agent definition (e.g. an updated telegrammer command) now re-deploys cleanly instead of false-conflicting (`McpMergeConflict`) against last deploy's stale result.

## Tests

- `test__start_boot_stderr.py` (new): `_format_boot_stderr_section` surfaces a captured FATAL; marks an absent log.
- `test__to_home.py`: `.mcp.json` re-merge idempotency (deploy → change → redeploy, no conflict).
- `test_tui_session.py`: 2 existing asserts updated for the appended stderr redirect.
- Full `_lifecycle` + `_main` + `runtime` suites green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
