### PR TITLE
fix(channels): strip server: prefix so dev-channels flag carries the MCP name

### DIFF
--- a/src/scitex_agent_container/runtimes/_apptainer_inner_argv.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_inner_argv.py
@@ -411,7 +411,13 @@ def tui_channel_config(config: "AgentConfig") -> tuple[str | None, str | None]:
     ]
     if not channels:
         return None, None
-    dev_channels = ",".join(sorted(set(channels)))
+    from ._sdk_channels import channel_mcp_name
+
+    # claude resolves each --dangerously-load-development-channels entry to an
+    # MCP server BY NAME; strip the spec's ``server:`` notation prefix so the
+    # flag carries the real name (else "no MCP server configured with that
+    # name" + the channel is silently dropped). SDK parity: _sdk_channels.
+    dev_channels = ",".join(sorted({channel_mcp_name(c) for c in channels}))
     channel_mcp: str | None = None
     if any(c == "server:sac" for c in channels):
         args = ["mcp", "channel", "--name", config.name]

--- a/src/scitex_agent_container/runtimes/_sdk_channels.py
+++ b/src/scitex_agent_container/runtimes/_sdk_channels.py
@@ -195,6 +195,23 @@ def _dedupe_channels(channels: list[str]) -> list[str]:
     return out
 
 
+def channel_mcp_name(channel: str) -> str:
+    """Map a ``spec.claude.channels`` entry to the MCP server name claude
+    resolves the channel against.
+
+    claude's ``--dangerously-load-development-channels`` matches each listed
+    channel to a registered MCP server BY NAME. The spec notation carries a
+    ``server:`` prefix (``server:sac`` / ``server:scitex-todo`` /
+    ``server:claude-code-telegrammer``) that is NOT part of the backing MCP
+    server name (those register as ``sac`` / ``scitex-todo`` /
+    ``claude-code-telegrammer``). Passing the prefixed form verbatim makes
+    claude report ``<channel> · no MCP server configured with that name`` and
+    silently drop the channel — telegram inbound + a2a wake never arrive.
+    Strip the prefix so the flag value is the real MCP name.
+    """
+    return channel.strip().removeprefix("server:")
+
+
 def apply_channels(
     kwargs: dict,
     channels: list[str] | None,
@@ -220,7 +237,8 @@ def apply_channels(
         extra_args = kwargs.setdefault("extra_args", {})
         if isinstance(extra_args, dict):
             extra_args.setdefault(
-                "dangerously-load-development-channels", ",".join(chset)
+                "dangerously-load-development-channels",
+                ",".join(channel_mcp_name(c) for c in chset),
             )
 
     if any(c.strip() == "server:sac" for c in channels):

--- a/tests/scitex_agent_container/runtimes/test__apptainer_build_argv.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_build_argv.py
@@ -493,8 +493,9 @@ def test_tui_channel_config_sets_dev_channels(tmp_path) -> None:
     config = load_config(str(spec))
     # Act
     dev_channels, _ = tui_channel_config(config)
-    # Assert
-    assert dev_channels == "server:sac"
+    # Assert: the MCP server NAME (``server:`` prefix stripped) — claude
+    # resolves a channel to an MCP by that exact name.
+    assert dev_channels == "sac"
 
 
 def test_tui_channel_config_registers_sac_channel_subscriber(tmp_path) -> None:
@@ -541,7 +542,7 @@ def test_build_run_argv_tui_adds_dev_channels_flag(
         config, state_dir=state_dir, sif_path=Path("/img/sac.sif"), tui=True
     )
     # Assert — flag rides in the inner cmd (preflight-wrapped on non-relaxed).
-    assert "--dangerously-load-development-channels server:sac" in " ".join(argv)
+    assert "--dangerously-load-development-channels sac" in " ".join(argv)
 
 
 def test_build_run_argv_tui_injects_channel_subscriber_mcp(

--- a/tests/scitex_agent_container/runtimes/test__sdk_channels.py
+++ b/tests/scitex_agent_container/runtimes/test__sdk_channels.py
@@ -29,6 +29,7 @@ from scitex_agent_container.runtimes._sdk_channels import (
     SacBinaryNotFoundError,
     TelegrammerWakeWiringError,
     apply_channels,
+    channel_mcp_name,
     merge_home_mcp_servers,
     validate_telegrammer_wake_wiring,
 )
@@ -106,6 +107,40 @@ def _devflag(kwargs: dict) -> str | None:
     return kwargs.get("extra_args", {}).get("dangerously-load-development-channels")
 
 
+class TestChannelMcpName:
+    """``channel_mcp_name`` maps a spec ``channels`` entry → MCP server name.
+
+    claude resolves each ``--dangerously-load-development-channels`` entry to
+    a registered MCP server BY NAME, so the ``server:`` notation prefix must
+    be stripped (else "no MCP server configured with that name" + the channel
+    is silently dropped — telegram inbound + a2a wake never arrive).
+    """
+
+    def test_strips_the_server_prefix_to_the_bare_mcp_name(self):
+        # Arrange
+        channel = "server:sac"
+        # Act
+        name = channel_mcp_name(channel)
+        # Assert
+        assert name == "sac"
+
+    def test_passes_through_a_name_that_has_no_prefix(self):
+        # Arrange
+        channel = "claude-code-telegrammer"
+        # Act
+        name = channel_mcp_name(channel)
+        # Assert
+        assert name == "claude-code-telegrammer"
+
+    def test_trims_whitespace_before_stripping_the_prefix(self):
+        # Arrange
+        channel = "  server:scitex-todo  "
+        # Act
+        name = channel_mcp_name(channel)
+        # Assert
+        assert name == "scitex-todo"
+
+
 class TestForeignChannelTurnsOnDevChannels:
     """A non-sac channel must enable dev-channels (the regression guard)."""
 
@@ -114,8 +149,9 @@ class TestForeignChannelTurnsOnDevChannels:
         kwargs: dict = {}
         # Act
         apply_channels(kwargs, ["server:claude-code-telegrammer"], None, "clew")
-        # Assert
-        assert _devflag(kwargs) == "server:claude-code-telegrammer"
+        # Assert: the MCP server NAME (``server:`` prefix stripped) — claude
+        # resolves a channel to an MCP by that exact name.
+        assert _devflag(kwargs) == "claude-code-telegrammer"
 
     def test_telegrammer_channel_does_not_register_sac_mcp(self):
         # Arrange
@@ -208,7 +244,7 @@ class TestSacChannelStillWorks:
         # Act
         apply_channels(kwargs, ["server:sac"], 9999, "lead")
         # Assert
-        assert _devflag(kwargs) == "server:sac"
+        assert _devflag(kwargs) == "sac"
 
     def test_sac_channel_registers_sac_mcp(self, fake_sac_bin):
         # Arrange — SAC_BIN points at a real executable so the resolver
@@ -343,8 +379,9 @@ class TestBothChannelsCoexist:
         apply_channels(
             kwargs, ["server:sac", "server:claude-code-telegrammer"], None, "clew"
         )
-        # Assert: claude needs the full set to render both channels' tags.
-        assert _devflag(kwargs) == "server:sac,server:claude-code-telegrammer"
+        # Assert: the full set, each as the MCP server NAME (``server:``
+        # prefix stripped — claude resolves a channel to an MCP by that name).
+        assert _devflag(kwargs) == "sac,claude-code-telegrammer"
 
     def test_sac_mcp_registered_when_sac_present_among_many(self, fake_sac_bin):
         # Arrange
@@ -366,7 +403,7 @@ class TestDedupeAndNormalization:
         # Act — ``fake_sac_bin`` so the sac sidecar resolver does not raise.
         apply_channels(kwargs, ["server:sac", " server:sac "], None, "lead")
         # Assert
-        assert _devflag(kwargs) == "server:sac"
+        assert _devflag(kwargs) == "sac"
 
 
 class TestNoChannels:


### PR DESCRIPTION
## What

`spec.claude.channels` entries (`server:sac`, `server:scitex-todo`,
`server:claude-code-telegrammer`) were passed **verbatim** to claude's
`--dangerously-load-development-channels`. claude resolves each listed channel
to a registered MCP server **by name**, so it looked for an MCP literally named
`server:sac` — none exists (it registers as `sac`) — logged
`server:sac · no MCP server configured with that name`, and **silently dropped
the channel**.

Observed on a live figrecipe TUI: `sac · ✔ connected · 5 tools` **yet**
`server:sac · no MCP server configured with that name`. Consequence: a2a wake,
telegram inbound, and scitex-todo notifications never reached the session (the
"store fills, no turn appears" silent-failure class) — e.g. a Telegram message
sent to figrecipe was polled + consumed by the telegrammer but never rendered
in the TUI.

## Fix

New `channel_mcp_name()` helper strips the `server:` notation prefix. Both flag
builders use it:
- `tui_channel_config` (TUI / apptainer path)
- `apply_channels` (SDK path)

The inline `sac mcp channel` subscriber trigger **and** the telegrammer-wake
trigger still key on the `server:` notation (unchanged — that is the
spec-facing form). Only the **flag value** changes: `server:sac` → `sac`,
`server:scitex-todo` → `scitex-todo`, etc. — names that match the registered
MCP servers, so claude binds + renders each channel.

## Tests

- `TestChannelMcpName` (new): strip / passthrough-without-prefix / whitespace.
- 6 existing assertions updated from the prefixed value to the resolved MCP
  name (`test__sdk_channels.py` ×4, `test__apptainer_build_argv.py` ×2).
- 72 passed locally across the channel + argv suites.
