### PR TITLE
fix(channels): unify SDK+TUI channel wiring + wire the TUI telegrammer wake

### DIFF
--- a/src/scitex_agent_container/runtimes/_apptainer_build_argv.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_build_argv.py
@@ -276,6 +276,19 @@ def build_run_argv(
 
     argv += listen_env_flags(config)
 
+    # TUI parity with the SDK's telegrammer wake (apply_channels →
+    # _wire_telegrammer_wake): inject CLAUDE_CODE_TELEGRAMMER_TURN_URL so an
+    # inbound Telegram message POSTs to the agent's /v1/turn and wakes an idle
+    # session. The TUI telegrammer inherits the container env (same path as its
+    # bot token via --env-file), so forward the SAME shared-plan wake URL here.
+    # Without it an idle TUI agent never wakes on Telegram (the SDK↔TUI drift).
+    if tui:
+        from ._apptainer_inner_argv import tui_channel_plan
+
+        _wake_url = tui_channel_plan(config).telegrammer_turn_url
+        if _wake_url:
+            argv += ["--env", f"CLAUDE_CODE_TELEGRAMMER_TURN_URL={_wake_url}"]
+
     # v3-realign: spec.apptainer.raw_args (§1 escape-hatch invariant) —
     # appended verbatim after all curated args, before the SIF +
     # inner command. Lets operators bolt on flags sac doesn't model

--- a/src/scitex_agent_container/runtimes/_apptainer_inner_argv.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_inner_argv.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ..config import AgentConfig
+    from ._sdk_channels import ChannelPlan
 
 # Runner-module dispatch by ``config.kind``. Kept here so the parent
 # orchestrator doesn't need to know either runner's module path.
@@ -284,7 +285,13 @@ def _tui_runner_argv(
     if channel_mcp:
         argv += ["--mcp-config", channel_mcp]
     if dev_channels:
-        argv += ["--dangerously-load-development-channels", dev_channels]
+        # --dangerously-load-development-channels is REPEATABLE — claude wants
+        # one occurrence per channel (the ``server:<mcp>`` entry, prefix kept).
+        # A comma-joined value is read as ONE channel entry → "no MCP server
+        # configured with that name", losing every channel. dev_channels
+        # arrives comma-joined; split it and emit one flag per channel.
+        for _channel in dev_channels.split(","):
+            argv += ["--dangerously-load-development-channels", _channel]
     for flag in list(getattr(claude_spec, "flags", []) or []):
         flag = str(flag).strip()
         if flag:
@@ -387,6 +394,31 @@ def _sac_channel_mcp_server(channel_args: list[str]) -> dict:
     }
 
 
+def tui_channel_plan(config: "AgentConfig") -> "ChannelPlan":
+    """Compute the shared :class:`ChannelPlan` for a TUI agent from its config.
+
+    The bridge from the TUI's config-shaped inputs (``spec.claude.channels``,
+    the resolved ``spec.a2a.port``, the agent name) to the runtime-agnostic
+    ``_sdk_channels.compute_channel_plan``. Both :func:`tui_channel_config`
+    (the inner ``--mcp-config`` / ``--dangerously-load-development-channels``)
+    and ``build_run_argv`` (the telegrammer wake ``--env``) call this, so the
+    TUI wires the SAME channel decisions as the SDK ``apply_channels`` path —
+    no drift.
+    """
+    from ._sdk_channels import compute_channel_plan
+
+    claude_spec = getattr(config, "claude", None)
+    channels = [
+        str(c).strip()
+        for c in (getattr(claude_spec, "channels", []) or [])
+        if str(c).strip()
+    ]
+    a2a_spec = getattr(config, "a2a", None)
+    raw_port = getattr(a2a_spec, "port", None) if a2a_spec else None
+    a2a_port = raw_port if isinstance(raw_port, int) and raw_port > 0 else None
+    return compute_channel_plan(channels, a2a_port, config.name)
+
+
 def tui_channel_config(config: "AgentConfig") -> tuple[str | None, str | None]:
     """Resolve ``spec.claude.channels`` into TUI channel flags.
 
@@ -403,29 +435,22 @@ def tui_channel_config(config: "AgentConfig") -> tuple[str | None, str | None]:
         (already forwarded by ``listen_env_flags``); when the a2a port is
         resolved it also gets ``--turn-url`` for the WAKE path.
     """
-    claude_spec = getattr(config, "claude", None)
-    channels = [
-        str(c).strip()
-        for c in (getattr(claude_spec, "channels", []) or [])
-        if str(c).strip()
-    ]
-    if not channels:
+    plan = tui_channel_plan(config)
+    if not plan.channels:
         return None, None
-    from ._sdk_channels import channel_mcp_name
-
-    # claude resolves each --dangerously-load-development-channels entry to an
-    # MCP server BY NAME; strip the spec's ``server:`` notation prefix so the
-    # flag carries the real name (else "no MCP server configured with that
-    # name" + the channel is silently dropped). SDK parity: _sdk_channels.
-    dev_channels = ",".join(sorted({channel_mcp_name(c) for c in channels}))
+    # One --dangerously-load flag per channel (the emission loop in
+    # _tui_runner_argv splits this comma-joined value) — the SAME set the SDK
+    # comma-joins into extra_args, so the two runtimes never disagree.
+    dev_channels = ",".join(plan.channels)
     channel_mcp: str | None = None
-    if any(c == "server:sac" for c in channels):
-        args = ["mcp", "channel", "--name", config.name]
-        a2a_spec = getattr(config, "a2a", None)
-        port = getattr(a2a_spec, "port", None) if a2a_spec else None
-        if isinstance(port, int) and port > 0:
-            args += ["--turn-url", f"http://127.0.0.1:{port}/v1/turn"]
-        channel_mcp = json.dumps({"mcpServers": {"sac": _sac_channel_mcp_server(args)}})
+    if plan.sac_sidecar_args is not None:
+        channel_mcp = json.dumps(
+            {
+                "mcpServers": {
+                    "sac": _sac_channel_mcp_server(list(plan.sac_sidecar_args))
+                }
+            }
+        )
     return dev_channels, channel_mcp
 
 

--- a/src/scitex_agent_container/runtimes/_sdk_channels.py
+++ b/src/scitex_agent_container/runtimes/_sdk_channels.py
@@ -46,6 +46,7 @@ import json as _json
 import logging as _logging
 import os as _os
 import shutil as _shutil
+from dataclasses import dataclass
 from pathlib import Path as _Path
 
 _log = _logging.getLogger(__name__)
@@ -195,21 +196,60 @@ def _dedupe_channels(channels: list[str]) -> list[str]:
     return out
 
 
-def channel_mcp_name(channel: str) -> str:
-    """Map a ``spec.claude.channels`` entry to the MCP server name claude
-    resolves the channel against.
+@dataclass(frozen=True)
+class ChannelPlan:
+    """Runtime-agnostic channel-wiring decisions for one agent.
 
-    claude's ``--dangerously-load-development-channels`` matches each listed
-    channel to a registered MCP server BY NAME. The spec notation carries a
-    ``server:`` prefix (``server:sac`` / ``server:scitex-todo`` /
-    ``server:claude-code-telegrammer``) that is NOT part of the backing MCP
-    server name (those register as ``sac`` / ``scitex-todo`` /
-    ``claude-code-telegrammer``). Passing the prefixed form verbatim makes
-    claude report ``<channel> · no MCP server configured with that name`` and
-    silently drop the channel — telegram inbound + a2a wake never arrive.
-    Strip the prefix so the flag value is the real MCP name.
+    Computed once by :func:`compute_channel_plan`, then applied by each
+    runtime through its own thin adapter — the SDK to ``ClaudeAgentOptions``
+    kwargs (``mcp_servers`` / ``extra_args``), the TUI to the ``apptainer
+    exec`` argv (``--mcp-config`` / ``--dangerously-load-development-channels``
+    / ``--env``). Centralising the DECISIONS here keeps the two channel-wiring
+    paths from drifting; the apply mechanism is the only per-runtime diff.
     """
-    return channel.strip().removeprefix("server:")
+
+    channels: tuple[str, ...]
+    sac_sidecar_args: tuple[str, ...] | None
+    telegrammer_turn_url: str | None
+
+
+def compute_channel_plan(
+    channels: list[str] | None,
+    a2a_port: int | None,
+    agent_name: str,
+) -> ChannelPlan:
+    """Resolve ``spec.claude.channels`` into the shared channel-wiring plan.
+
+    Pure — no I/O, no kwargs/argv mutation. Both runtimes wire the SAME
+    ``channels`` set (the SDK comma-joins them into the single
+    ``--dangerously-load-development-channels`` ``extra_args`` value; the TUI
+    emits one flag per entry), so they never disagree on WHICH channels load.
+
+      * ``sac_sidecar_args`` — the ``sac mcp channel`` argv (+ ``--turn-url``
+        once an a2a port is resolved), present only when ``server:sac`` is
+        requested. The SDK wraps it with sac's resolved abs path; the TUI with
+        an in-SIF ``/bin/sh`` resolver — that wrapping is the only diff.
+      * ``telegrammer_turn_url`` — the loopback ``/v1/turn`` the standalone
+        telegrammer POSTs inbound to (wake-on-push), present only when the
+        telegrammer channel is requested AND an a2a port is resolved.
+    """
+    chset = _dedupe_channels(channels or [])
+    sac_sidecar_args: tuple[str, ...] | None = None
+    if any(c.strip() == "server:sac" for c in (channels or [])):
+        args = ["mcp", "channel", "--name", agent_name]
+        if a2a_port is not None:
+            args += ["--turn-url", f"http://127.0.0.1:{int(a2a_port)}/v1/turn"]
+        sac_sidecar_args = tuple(args)
+    telegrammer_turn_url: str | None = None
+    if a2a_port is not None and any(
+        c.strip() == _TELEGRAMMER_CHANNEL for c in (channels or [])
+    ):
+        telegrammer_turn_url = f"http://127.0.0.1:{int(a2a_port)}/v1/turn"
+    return ChannelPlan(
+        channels=tuple(chset),
+        sac_sidecar_args=sac_sidecar_args,
+        telegrammer_turn_url=telegrammer_turn_url,
+    )
 
 
 def apply_channels(
@@ -232,39 +272,29 @@ def apply_channels(
     if not channels:
         return
 
-    chset = _dedupe_channels(channels)
-    if chset:
+    plan = compute_channel_plan(channels, a2a_port, agent_name)
+    if plan.channels:
         extra_args = kwargs.setdefault("extra_args", {})
         if isinstance(extra_args, dict):
             extra_args.setdefault(
                 "dangerously-load-development-channels",
-                ",".join(channel_mcp_name(c) for c in chset),
+                ",".join(plan.channels),
             )
 
-    if any(c.strip() == "server:sac" for c in channels):
+    if plan.sac_sidecar_args is not None:
         mcps = kwargs.setdefault("mcp_servers", {})
         if isinstance(mcps, dict) and "sac" not in mcps:
-            # Sidecar subscribes to the BUS inbox (`sac listen`), resolved
-            # from SAC_LISTEN_BASE_URL — NOT the a2a port. a2a_port is the
-            # WAKE path (WI-1): passed as --turn-url so a received bus event
-            # POSTs to the agent's own loopback /v1/turn to wake an idle
-            # session (push ≡ Telegram).
-            sidecar_args = ["mcp", "channel", "--name", agent_name]
-            if a2a_port is not None:
-                sidecar_args += [
-                    "--turn-url",
-                    f"http://127.0.0.1:{int(a2a_port)}/v1/turn",
-                ]
             # Resolve `sac` to an absolute path so the SDK subprocess can
             # spawn the channel adapter regardless of its PATH. A bare
-            # ``"sac"`` command silently fails exec when the SDK's PATH
-            # does not contain the agent venv's bin dir — exactly the bug
-            # that left this agent's a2a inbox unsubscribed for hours on
-            # 2026-06-15 (see ``_resolve_sac_binary`` docstring).
+            # ``"sac"`` command silently fails exec when the SDK's PATH does
+            # not contain the agent venv's bin dir — exactly the bug that
+            # left this agent's a2a inbox unsubscribed for hours on
+            # 2026-06-15 (see ``_resolve_sac_binary``). The sidecar argv
+            # (+ --turn-url) is the shared decision from compute_channel_plan.
             mcps["sac"] = {
                 "type": "stdio",
                 "command": _resolve_sac_binary(),
-                "args": sidecar_args,
+                "args": list(plan.sac_sidecar_args),
             }
 
     _wire_telegrammer_wake(kwargs, channels, a2a_port)

--- a/tests/scitex_agent_container/runtimes/test__apptainer_build_argv.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_build_argv.py
@@ -479,6 +479,24 @@ spec:
 """
 
 
+_SPEC_WITH_TELEGRAMMER_AND_PORT = """\
+apiVersion: scitex-agent-container/v3
+kind: Agent
+metadata:
+  labels:
+    project: t
+spec:
+  runtime: tui
+  workdir: /tmp/agt-work
+  claude:
+    model: sonnet
+    channels:
+      - server:claude-code-telegrammer
+  a2a:
+    port: 19007
+"""
+
+
 def test_tui_channel_config_none_when_no_channels(tui_config) -> None:
     # Arrange — tui_config has no channels.
     # Act
@@ -493,9 +511,8 @@ def test_tui_channel_config_sets_dev_channels(tmp_path) -> None:
     config = load_config(str(spec))
     # Act
     dev_channels, _ = tui_channel_config(config)
-    # Assert: the MCP server NAME (``server:`` prefix stripped) — claude
-    # resolves a channel to an MCP by that exact name.
-    assert dev_channels == "sac"
+    # Assert
+    assert dev_channels == "server:sac"
 
 
 def test_tui_channel_config_registers_sac_channel_subscriber(tmp_path) -> None:
@@ -542,7 +559,31 @@ def test_build_run_argv_tui_adds_dev_channels_flag(
         config, state_dir=state_dir, sif_path=Path("/img/sac.sif"), tui=True
     )
     # Assert — flag rides in the inner cmd (preflight-wrapped on non-relaxed).
-    assert "--dangerously-load-development-channels sac" in " ".join(argv)
+    assert "--dangerously-load-development-channels server:sac" in " ".join(argv)
+
+
+def test_build_run_argv_tui_wires_telegrammer_wake_env(
+    tmp_path, listen_bearer_token
+) -> None:
+    # Arrange — a TUI agent requesting its own telegrammer channel with a
+    # resolved a2a port (as resolve_a2a_port sets at agent_start). SDK parity:
+    # the SDK injects the wake via mcp_servers; the TUI forwards it as a
+    # container --env the telegrammer inherits (same path as its bot token via
+    # --env-file), so an inbound message POSTs to /v1/turn and wakes an idle
+    # session — the SDK<->TUI drift this closes.
+    spec = _write_spec(tmp_path, _SPEC_WITH_TELEGRAMMER_AND_PORT)
+    config = load_config(str(spec))
+    state_dir = tmp_path / "state"
+    (state_dir / "home").mkdir(parents=True)
+    # Act
+    argv = build_run_argv(
+        config, state_dir=state_dir, sif_path=Path("/img/sac.sif"), tui=True
+    )
+    # Assert
+    assert (
+        "--env CLAUDE_CODE_TELEGRAMMER_TURN_URL=http://127.0.0.1:19007/v1/turn"
+        in " ".join(argv)
+    )
 
 
 def test_build_run_argv_tui_injects_channel_subscriber_mcp(

--- a/tests/scitex_agent_container/runtimes/test__sdk_channels.py
+++ b/tests/scitex_agent_container/runtimes/test__sdk_channels.py
@@ -29,7 +29,7 @@ from scitex_agent_container.runtimes._sdk_channels import (
     SacBinaryNotFoundError,
     TelegrammerWakeWiringError,
     apply_channels,
-    channel_mcp_name,
+    compute_channel_plan,
     merge_home_mcp_servers,
     validate_telegrammer_wake_wiring,
 )
@@ -107,38 +107,48 @@ def _devflag(kwargs: dict) -> str | None:
     return kwargs.get("extra_args", {}).get("dangerously-load-development-channels")
 
 
-class TestChannelMcpName:
-    """``channel_mcp_name`` maps a spec ``channels`` entry → MCP server name.
+class TestComputeChannelPlan:
+    """The shared plan both runtimes apply (SDK -> kwargs, TUI -> argv): one
+    source of truth for the channel set, sac sidecar, and telegrammer wake."""
 
-    claude resolves each ``--dangerously-load-development-channels`` entry to
-    a registered MCP server BY NAME, so the ``server:`` notation prefix must
-    be stripped (else "no MCP server configured with that name" + the channel
-    is silently dropped — telegram inbound + a2a wake never arrive).
-    """
-
-    def test_strips_the_server_prefix_to_the_bare_mcp_name(self):
+    def test_telegrammer_channel_with_port_yields_wake_url(self):
         # Arrange
-        channel = "server:sac"
+        channels = ["server:claude-code-telegrammer"]
         # Act
-        name = channel_mcp_name(channel)
+        plan = compute_channel_plan(channels, 700, "clew")
         # Assert
-        assert name == "sac"
+        assert plan.telegrammer_turn_url == "http://127.0.0.1:700/v1/turn"
 
-    def test_passes_through_a_name_that_has_no_prefix(self):
+    def test_telegrammer_channel_without_port_yields_no_wake(self):
         # Arrange
-        channel = "claude-code-telegrammer"
+        channels = ["server:claude-code-telegrammer"]
         # Act
-        name = channel_mcp_name(channel)
+        plan = compute_channel_plan(channels, None, "clew")
         # Assert
-        assert name == "claude-code-telegrammer"
+        assert plan.telegrammer_turn_url is None
 
-    def test_trims_whitespace_before_stripping_the_prefix(self):
+    def test_sac_channel_yields_sidecar_args_with_turn_url(self):
         # Arrange
-        channel = "  server:scitex-todo  "
+        channels = ["server:sac"]
         # Act
-        name = channel_mcp_name(channel)
+        plan = compute_channel_plan(channels, 701, "lead")
         # Assert
-        assert name == "scitex-todo"
+        assert plan.sac_sidecar_args == (
+            "mcp",
+            "channel",
+            "--name",
+            "lead",
+            "--turn-url",
+            "http://127.0.0.1:701/v1/turn",
+        )
+
+    def test_channels_are_the_shared_deduped_set(self):
+        # Arrange
+        channels = ["server:sac", "server:scitex-todo", "server:sac"]
+        # Act
+        plan = compute_channel_plan(channels, None, "lead")
+        # Assert
+        assert plan.channels == ("server:sac", "server:scitex-todo")
 
 
 class TestForeignChannelTurnsOnDevChannels:
@@ -149,9 +159,8 @@ class TestForeignChannelTurnsOnDevChannels:
         kwargs: dict = {}
         # Act
         apply_channels(kwargs, ["server:claude-code-telegrammer"], None, "clew")
-        # Assert: the MCP server NAME (``server:`` prefix stripped) — claude
-        # resolves a channel to an MCP by that exact name.
-        assert _devflag(kwargs) == "claude-code-telegrammer"
+        # Assert
+        assert _devflag(kwargs) == "server:claude-code-telegrammer"
 
     def test_telegrammer_channel_does_not_register_sac_mcp(self):
         # Arrange
@@ -244,7 +253,7 @@ class TestSacChannelStillWorks:
         # Act
         apply_channels(kwargs, ["server:sac"], 9999, "lead")
         # Assert
-        assert _devflag(kwargs) == "sac"
+        assert _devflag(kwargs) == "server:sac"
 
     def test_sac_channel_registers_sac_mcp(self, fake_sac_bin):
         # Arrange — SAC_BIN points at a real executable so the resolver
@@ -379,9 +388,8 @@ class TestBothChannelsCoexist:
         apply_channels(
             kwargs, ["server:sac", "server:claude-code-telegrammer"], None, "clew"
         )
-        # Assert: the full set, each as the MCP server NAME (``server:``
-        # prefix stripped — claude resolves a channel to an MCP by that name).
-        assert _devflag(kwargs) == "sac,claude-code-telegrammer"
+        # Assert: claude needs the full set to render both channels' tags.
+        assert _devflag(kwargs) == "server:sac,server:claude-code-telegrammer"
 
     def test_sac_mcp_registered_when_sac_present_among_many(self, fake_sac_bin):
         # Arrange
@@ -403,7 +411,7 @@ class TestDedupeAndNormalization:
         # Act — ``fake_sac_bin`` so the sac sidecar resolver does not raise.
         apply_channels(kwargs, ["server:sac", " server:sac "], None, "lead")
         # Assert
-        assert _devflag(kwargs) == "sac"
+        assert _devflag(kwargs) == "server:sac"
 
 
 class TestNoChannels:


### PR DESCRIPTION
> ⚠️ **Supersedes the already-merged #427** ("strip `server:`"). That PR
> stripped `server:` to bare names in `apply_channels` — silently changing the
> SDK's dev-channels — and never wired the telegrammer wake. This PR reverts
> that approach: it **restores `server:`** and unifies both runtimes on one
> shared plan. (The user confirmed `server:` is required and the SDK telegram
> path worked, so the bare-name strip was the wrong half.)

## What

The SDK (`apply_channels`) and TUI (`tui_channel_config`) had **drifted** into
two partial channel-wiring implementations. The TUI omitted the telegrammer
**wake-on-push** entirely, so an idle TUI agent never woke on inbound Telegram
— while the SDK did (`apply_channels → _wire_telegrammer_wake`). That's why
telegram worked under `runtime: claude-agent-sdk` but not `runtime: tui`.

(The TUI also previously emitted `--dangerously-load-development-channels` as a
single comma-joined value; it now emits one flag per channel.)

## Fix — shared component, minimal per-runtime apply

`compute_channel_plan(channels, a2a_port, agent_name) → ChannelPlan` is the
single source of truth for the channel **decisions**:
- the channel set (`server:`-prefixed, deduped),
- the `sac mcp channel` sidecar argv (+ `--turn-url`),
- the telegrammer wake URL (`…/v1/turn`).

Each runtime keeps only a thin **apply** adapter (the sole difference):
- **SDK** `apply_channels`: plan → `ClaudeAgentOptions` kwargs (`mcp_servers` /
  `extra_args`). **Byte-identical behavior — no regression.**
- **TUI** `tui_channel_config` + `build_run_argv`: plan → argv. dev-channels
  one `--dangerously-load-development-channels` flag per channel (`server:`
  kept); sac sidecar via inline `--mcp-config`; **telegrammer wake forwarded as
  a container `--env`** the telegrammer inherits (same path as its bot token
  via `--env-file`).

No port reorder needed — `resolve_a2a_port` already mutates `config.a2a.port`
before the argv build.

## Tests

- `TestComputeChannelPlan` (×4): the shared plan's wake URL / sac sidecar /
  channel set.
- `test_build_run_argv_tui_wires_telegrammer_wake_env`: the TUI wake `--env`.
- **The full SDK suite (`test__sdk_channels.py`) stays 100% green — the
  no-regression guard.**
- 108 passed across the channel + argv suites.
