### PR TITLE
fix(runtimes): fresh-agent boot reliability — onboarding gate, cred-bind target, turn-bridge lifecycle

### DIFF
--- a/src/scitex_agent_container/runtimes/_apptainer_auth.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_auth.py
@@ -342,4 +342,123 @@ def credentials_file_bind(
     return ["--bind", f"{src}:{dest}:rw"]
 
 
-__all__ = ["CredentialExpiredError", "auth_argv", "credentials_file_bind"]
+def ensure_credentials_bind_target(
+    config: AgentConfig,
+    *,
+    home_host: Path,
+    overlay_upper_home: Path | None = None,
+    bind_flags: list[str] | None = None,
+) -> Path | None:
+    """Pre-create the host-side placeholder for the credentials file-bind.
+
+    apptainer FILE binds require the in-container destination to ALREADY
+    EXIST on the underlying filesystem — a fresh directory-overlay agent
+    otherwise FATALs at boot with::
+
+        mount … /home/agent/.claude/.credentials.json … destination doesn't
+        exist in container
+
+    The destination of :func:`credentials_file_bind` is
+    ``<container_home>/.claude/.credentials.json``. The host filesystem
+    backing that container ``$HOME`` is the overlay upper-home for relaxed
+    directory-overlay specs (bound OVER ``--home`` in
+    :func:`_apptainer_build_argv.build_run_argv`), else the workspace-home
+    dir (``<state>/home``, bound at ``/home/agent``). This ensures an empty
+    0-byte ``.claude/.credentials.json`` exists at that host path so the
+    ``:rw`` bind lands; the bind then SHADOWS this placeholder with the real
+    operator credential — the placeholder's contents never matter.
+
+    CRITICAL — placement: the placeholder is written into the overlay
+    upper-home / workspace-home (the bind DESTINATION backing), NEVER into
+    ``to_home/``. The to_home credential-leak guard
+    (:func:`_to_home._scan_for_credential_leak`) REFUSES any
+    ``.credentials.json`` under ``to_home/`` — and rightly so: credentials
+    are runtime bind state, not static workspace content. These two homes
+    are deploy destinations, outside that guard's scan roots.
+
+    ``bind_flags`` is the ALREADY-RESOLVED output of
+    :func:`credentials_file_bind` — the caller passes it so the source
+    resolution (and its fail-loud expiry check) runs only once per launch.
+    When ``None`` we resolve it ourselves (the convenience path used by
+    runtimes that don't pre-compute it). The in-container destination is
+    parsed from the bind so the host placeholder mirrors the EXACT path
+    apptainer will mount onto (``.claude/.credentials.json`` under $HOME).
+
+    No-op (returns ``None``) when no credentials bind will be emitted
+    (no ``spec.claude.credentials_file`` / ``account``, or a provider
+    backend is active) — there is no file-bind target to satisfy. Returns
+    the placeholder path it ensured, otherwise.
+
+    Best-effort on the placeholder write itself: a failure here must not
+    block launch (the bind may still succeed if the target exists for
+    another reason), so an OSError is swallowed after logging.
+    """
+    flags = bind_flags if bind_flags is not None else credentials_file_bind(config)
+    if not flags:
+        return None
+    # flags == ["--bind", "<src>:<container_home>/.claude/.credentials.json:rw"]
+    from ._to_home_overlay import resolve_container_home
+
+    container_home = resolve_container_home(config).rstrip("/")
+    # Relative path of the bind target under the container $HOME, derived
+    # from the emitted destination so the placeholder mirrors it exactly.
+    dest_in_container = _bind_destination(flags)
+    rel = ".claude/.credentials.json"
+    if dest_in_container and dest_in_container.startswith(container_home + "/"):
+        rel = dest_in_container[len(container_home) + 1 :]
+    # Host dir backing the container $HOME: overlay upper-home (relaxed
+    # directory-overlay) wins; else the workspace-home bind.
+    backing = (
+        overlay_upper_home
+        if overlay_upper_home is not None and overlay_upper_home.is_dir()
+        else home_host
+    )
+    placeholder = backing / rel
+    try:
+        placeholder.parent.mkdir(parents=True, exist_ok=True)
+        if not placeholder.exists():
+            placeholder.touch()
+    except OSError as exc:  # stx-allow: fallback (reason: a placeholder-create failure must not block launch — the bind may still land if the target exists for another reason; logged for the operator)
+        import logging
+
+        logging.getLogger(__name__).warning(
+            "credentials bind-target placeholder %s could not be created "
+            "(container_home=%s): %s",
+            placeholder,
+            container_home,
+            exc,
+        )
+        return None
+    return placeholder
+
+
+def _bind_destination(bind_flags: list[str]) -> str:
+    """Extract the in-container destination path from a ``--bind`` flag pair.
+
+    ``["--bind", "<src>:<dst>:rw"]`` → ``"<dst>"``. The source path may
+    itself contain ``:`` only on exotic filesystems; apptainer bind specs
+    are ``src:dst[:opts]`` and our emitted dst + opts are fixed, so we take
+    the destination as the second colon-field from the spec's tail. Returns
+    ``""`` when the shape is unrecognised (the caller falls back to the
+    canonical ``.claude/.credentials.json`` relative path).
+    """
+    if len(bind_flags) < 2:
+        return ""
+    spec = bind_flags[1]
+    # Strip a trailing ``:rw`` / ``:ro`` mount-option, then the dst is the
+    # last colon-field of what remains (src may be absolute with no colon).
+    body = spec
+    for opt in (":rw", ":ro"):
+        if body.endswith(opt):
+            body = body[: -len(opt)]
+            break
+    parts = body.rsplit(":", 1)
+    return parts[1] if len(parts) == 2 else ""
+
+
+__all__ = [
+    "CredentialExpiredError",
+    "auth_argv",
+    "credentials_file_bind",
+    "ensure_credentials_bind_target",
+]

--- a/src/scitex_agent_container/runtimes/_apptainer_build_argv.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_build_argv.py
@@ -315,9 +315,25 @@ def build_run_argv(
     # writable at ``$HOME/.claude/.credentials.json``. Emitted LAST among
     # binds (after the overlay-upper-home bind) so the relaxed ``--home``
     # tmpfs / upper-home bind cannot shadow it; last bind to a path wins.
-    from ._apptainer_auth import credentials_file_bind
+    #
+    # apptainer FILE binds need the in-container destination to pre-exist,
+    # so first ensure an empty placeholder at the host path backing the
+    # container $HOME (overlay upper-home when relaxed-directory-overlay,
+    # else the workspace-home bind). Without it a fresh overlay agent FATALs
+    # at boot: "destination doesn't exist in container". The placeholder
+    # goes in the bind DESTINATION backing, never to_home (whose
+    # credential-leak guard refuses .credentials.json). No-op when no creds
+    # bind will be emitted.
+    from ._apptainer_auth import credentials_file_bind, ensure_credentials_bind_target
 
-    argv += credentials_file_bind(config)
+    creds_bind = credentials_file_bind(config)
+    ensure_credentials_bind_target(
+        config,
+        home_host=home_host,
+        overlay_upper_home=upper_home,
+        bind_flags=creds_bind,
+    )
+    argv += creds_bind
 
     argv.append(str(sif_path))
 

--- a/src/scitex_agent_container/runtimes/_tui_turn_bridge.py
+++ b/src/scitex_agent_container/runtimes/_tui_turn_bridge.py
@@ -358,10 +358,25 @@ def start_turn_bridge(
     POST to, so there is nothing to serve. Best-effort: a spawn failure is
     logged and swallowed (a dead bridge must not block agent start). The
     ``spawn`` seam lets tests assert the argv without a real subprocess.
+
+    Pre-existing-bridge teardown (2026-06-19 a2a mis-route fix): a restart
+    that does NOT route through :meth:`TuiSessionRuntime.stop` (e.g. the
+    supervisor's stale-lease path, or a flip that changes ``a2a.port``)
+    can leave the agent's PREVIOUS bridge process alive on the old port.
+    Writing the new PID over the pidfile would orphan it permanently — the
+    stale bridge keeps its old port bound, and a later fresh agent that
+    inherits that port collides and mis-routes traffic into the stale
+    bridge's tmux. So we ALWAYS :func:`stop_turn_bridge` first, making the
+    one-bridge-per-agent invariant hold regardless of how we got here.
     """
     port = resolved_a2a_port(config)
     if port is None:
         return None
+    # Deterministically tear down any prior bridge for THIS agent before we
+    # spawn (and overwrite the pidfile). The pidfile is keyed by the agent's
+    # per-host state dir, so this reliably kills the agent's own previous
+    # bridge — even one left on a now-stale port by a port-changing restart.
+    stop_turn_bridge(config)
     config_path = str(getattr(config, "config_path", "") or "")
     if not config_path:
         log.warning(

--- a/src/scitex_agent_container/runtimes/onboarding.py
+++ b/src/scitex_agent_container/runtimes/onboarding.py
@@ -1,21 +1,38 @@
-"""Pre-seed ~/.claude.json projects entry to skip per-workspace onboarding.
+"""Pre-seed ~/.claude.json to skip Claude Code's first-run onboarding.
 
-When Claude Code launches in a workspace it has never seen before, it shows
-interactive prompts (theme selection, login method, dev-channels approval).
-For fleet agents these prompts block startup and require a human click.
+When Claude Code launches it gates on two independent onboarding layers:
 
-This module pre-populates the ``projects[<workdir>]`` entry in
-``~/.claude.json`` with the minimal fields that signal "onboarding complete",
-so Claude Code skips the ceremony and reaches the working prompt immediately.
+  * **Global first-run** (top-level ``hasCompletedOnboarding``). On a FRESH
+    ``~/.claude.json`` this key is absent, so Claude runs its first-run
+    onboarding wizard — which includes the OAuth LOGIN screen — and IGNORES
+    an otherwise-valid bound credential. A fresh fleet agent then sits on the
+    login prompt forever (verified live: figrecipe↔beta a2a demo, 2026-06-19).
+  * **Per-workspace** (``projects[<workdir>].hasCompletedProjectOnboarding``).
+    A workspace Claude has never seen shows the theme / trust / dev-channels
+    prompts.
+
+For fleet agents BOTH prompts block startup and require a human click. This
+module pre-populates both layers so Claude skips the ceremony and reaches the
+working prompt immediately on a valid credential.
 
 Only the safe, non-secret fields are written:
-  - ``hasCompletedProjectOnboarding``: true — suppresses the wizard
-  - ``hasTrustDialogAccepted``: true — suppresses trust prompt
-  - ``allowedTools``, ``mcpContextUris``, etc.: empty — safe defaults
 
-Token / credential fields are never touched by this module.
+  Top-level (global first-run gate — see :data:`_TOP_LEVEL_SEED`):
+    - ``hasCompletedOnboarding``: true — suppresses the first-run wizard
+      (and its OAuth login screen) so a bound credential is honoured
+    - ``theme``: a default — Claude otherwise prompts to pick one
+    - ``numStartups``: a small positive int — signals "not a first launch"
 
-See: ywatanabe1989/todo#396
+  Per-workspace (see :data:`_ONBOARDING_SEED`):
+    - ``hasCompletedProjectOnboarding``: true — suppresses the wizard
+    - ``hasTrustDialogAccepted``: true — suppresses trust prompt
+    - ``allowedTools``, ``mcpContextUris``, etc.: empty — safe defaults
+
+Every seed is idempotent: an existing value is NEVER overwritten (only an
+absent or falsy-completion gate flag is forced true). Token / credential
+fields are never touched by this module.
+
+See: ywatanabe1989/todo#396 ; fresh-agent boot reliability (2026-06-19).
 """
 
 from __future__ import annotations
@@ -44,23 +61,71 @@ _ONBOARDING_SEED: dict = {
     "lastGracefulShutdown": False,
 }
 
+# Top-level keys that gate Claude Code's GLOBAL first-run onboarding (the
+# wizard that includes the OAuth login screen). On a fresh ``~/.claude.json``
+# these are absent and Claude runs first-run onboarding, ignoring a bound
+# credential. Seeding them (idempotently — never clobbering an operator's own
+# value) makes a fresh agent boot straight onto its credential.
+#   - ``hasCompletedOnboarding``: the headline gate.
+#   - ``theme``: Claude prompts for a theme on first run; "dark" is a safe,
+#     conventional default (it never overrides an existing choice).
+#   - ``numStartups``: Claude treats 0/absent as a first launch; a small
+#     positive int signals "already launched" without faking a large count.
+_TOP_LEVEL_SEED: dict = {
+    "hasCompletedOnboarding": True,
+    "theme": "dark",
+    "numStartups": 1,
+}
+
+
+def _apply_top_level_seed(data: dict) -> bool:
+    """Seed the GLOBAL first-run gate keys into ``data`` (idempotent).
+
+    Sets each :data:`_TOP_LEVEL_SEED` key only when ABSENT, so an operator's
+    own ``theme`` / ``numStartups`` is never clobbered. ``hasCompletedOnboarding``
+    is additionally forced true when present-but-falsy (a stale ``false`` left
+    by a half-finished first run would still re-trigger the OAuth login wizard,
+    exactly the failure this guards against).
+
+    Returns True iff ``data`` was mutated (so the caller knows a write is owed).
+    """
+    changed = False
+    for key, value in _TOP_LEVEL_SEED.items():
+        if key not in data:
+            data[key] = value
+            changed = True
+    if not data.get("hasCompletedOnboarding"):
+        data["hasCompletedOnboarding"] = True
+        changed = True
+    return changed
+
 
 def ensure_project_onboarding(
     workdir: str,
     home: Path | None = None,
 ) -> bool:
-    """Ensure ``~/.claude.json`` has a complete projects entry for ``workdir``.
+    """Ensure ``~/.claude.json`` clears Claude Code's onboarding gates.
 
-    If the entry already exists and ``hasCompletedProjectOnboarding`` is True,
-    this is a no-op. Otherwise the seed fields are merged into the entry
-    (existing keys are preserved so we don't clobber live session stats).
+    Seeds two independent layers (see the module docstring), both idempotent:
+
+      1. **Global first-run** — top-level ``hasCompletedOnboarding`` (+ ``theme``,
+         ``numStartups``) via :func:`_apply_top_level_seed`. Without this a fresh
+         agent runs Claude's first-run wizard (OAuth login screen) and ignores a
+         valid bound credential. Applied UNCONDITIONALLY, even when the
+         per-workspace entry is already complete — a workspace can be trusted
+         while the global gate is still missing.
+      2. **Per-workspace** — the ``projects[<workdir>]`` entry. A no-op when that
+         entry already has ``hasCompletedProjectOnboarding`` true; otherwise the
+         seed fields are merged in (existing keys preserved so live session
+         stats are not clobbered).
 
     Args:
         workdir: Absolute path to the agent's working directory.
         home: Override for the home directory. Defaults to ``Path.home()``.
 
     Returns:
-        True if the entry was created or updated; False if already complete.
+        True if EITHER layer was created or updated; False if both were already
+        complete (nothing written).
 
     Never raises — errors are logged and the function returns False so
     callers can continue without crashing.
@@ -84,22 +149,30 @@ def ensure_project_onboarding(
                 logger.warning("cannot read %s: %s", claude_json_path, exc)
                 return False
 
+        # Global first-run gate — independent of the per-workspace entry, so a
+        # fresh ``~/.claude.json`` that lacks ``hasCompletedOnboarding`` is
+        # always fixed (even if the workspace happens to be pre-trusted).
+        top_changed = _apply_top_level_seed(data)
+
         projects: dict = data.setdefault("projects", {})
         entry = projects.get(workdir_key, {})
 
+        project_changed = False
         if entry.get("hasCompletedProjectOnboarding"):
             logger.debug("onboarding already seeded for %s", workdir_key)
+        else:
+            # Merge seed into existing entry (preserve live stats already there)
+            for key, value in _ONBOARDING_SEED.items():
+                entry.setdefault(key, value)
+            # Force the critical gate fields true even if entry had them False
+            entry["hasCompletedProjectOnboarding"] = True
+            entry["hasTrustDialogAccepted"] = True
+            entry["hasClaudeMdExternalIncludesApproved"] = True
+            projects[workdir_key] = entry
+            project_changed = True
+
+        if not (top_changed or project_changed):
             return False
-
-        # Merge seed into existing entry (preserve any live stats already there)
-        for key, value in _ONBOARDING_SEED.items():
-            entry.setdefault(key, value)
-        # Ensure the critical gate fields are set even if entry had them as False
-        entry["hasCompletedProjectOnboarding"] = True
-        entry["hasTrustDialogAccepted"] = True
-        entry["hasClaudeMdExternalIncludesApproved"] = True
-
-        projects[workdir_key] = entry
 
         # Write atomically: temp file + rename
         tmp_path = claude_json_path.with_suffix(".json.tmp")

--- a/tests/scitex_agent_container/runtimes/test__apptainer_build_argv.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_build_argv.py
@@ -40,6 +40,7 @@ from scitex_agent_container.config import load_config
 from scitex_agent_container.runtimes._apptainer_auth import (
     CredentialExpiredError,
     credentials_file_bind,
+    ensure_credentials_bind_target,
 )
 from scitex_agent_container.runtimes._apptainer_build_argv import build_run_argv
 from scitex_agent_container.runtimes._apptainer_inner_argv import (
@@ -653,3 +654,139 @@ def test_build_run_argv_appends_credentials_bind_last(tmp_path) -> None:
     # later home bind can shadow it.
     sif_idx = argv.index("/img/sac.sif")
     assert argv[sif_idx - 1] == f"{creds}:/home/agent/.claude/.credentials.json:rw"
+
+
+# ---------------------------------------------------------------------------
+# ensure_credentials_bind_target — apptainer file-bind needs a pre-existing
+# destination (fresh-agent boot FATAL fix)
+# ---------------------------------------------------------------------------
+
+
+def _valid_creds_file(tmp_path: Path) -> Path:
+    creds = tmp_path / "acct" / ".credentials.json"
+    creds.parent.mkdir(parents=True, exist_ok=True)
+    creds.write_text(
+        '{"claudeAiOauth": {"accessToken": "tok", "expiresAt": 9999999999000}}',
+        encoding="utf-8",
+    )
+    return creds
+
+
+def test_ensure_bind_target_noop_when_no_credentials(tui_config, tmp_path) -> None:
+    # Arrange — config has no credentials_file / account (the tui_config
+    # fixture); no bind will be emitted, so nothing to pre-create.
+    home_host = tmp_path / "home"
+    home_host.mkdir()
+    # Act
+    result = ensure_credentials_bind_target(tui_config, home_host=home_host)
+    # Assert
+    assert result is None
+
+
+def test_ensure_bind_target_creates_placeholder_in_workspace_home(tmp_path) -> None:
+    # Arrange — designated creds, default (non-overlay) spec → the container
+    # $HOME is backed by the workspace-home bind.
+    creds = _valid_creds_file(tmp_path)
+    spec = _write_spec(
+        tmp_path, _BASE_SPEC.format(extra=f"    credentials_file: {creds}")
+    )
+    config = load_config(str(spec))
+    home_host = tmp_path / "state" / "home"
+    home_host.mkdir(parents=True)
+    # Act
+    placeholder = ensure_credentials_bind_target(config, home_host=home_host)
+    # Assert — an empty placeholder now exists at the workspace-home path.
+    assert placeholder == home_host / ".claude" / ".credentials.json"
+
+
+def test_ensure_bind_target_placeholder_is_a_real_file_on_disk(tmp_path) -> None:
+    # Arrange
+    creds = _valid_creds_file(tmp_path)
+    spec = _write_spec(
+        tmp_path, _BASE_SPEC.format(extra=f"    credentials_file: {creds}")
+    )
+    config = load_config(str(spec))
+    home_host = tmp_path / "state" / "home"
+    home_host.mkdir(parents=True)
+    # Act
+    ensure_credentials_bind_target(config, home_host=home_host)
+    # Assert — apptainer's file-bind destination now pre-exists.
+    assert (home_host / ".claude" / ".credentials.json").is_file()
+
+
+def test_ensure_bind_target_prefers_overlay_upper_home(tmp_path) -> None:
+    # Arrange — a relaxed directory-overlay spec: the container $HOME is the
+    # overlay upper-home (bound OVER --home), NOT the workspace-home. The
+    # placeholder MUST land in the upper-home so the bind destination exists.
+    creds = _valid_creds_file(tmp_path)
+    spec = _write_spec(
+        tmp_path, _BASE_SPEC.format(extra=f"    credentials_file: {creds}")
+    )
+    config = load_config(str(spec))
+    home_host = tmp_path / "state" / "home"
+    home_host.mkdir(parents=True)
+    upper_home = tmp_path / "overlay" / "upper" / "home" / "agent"
+    upper_home.mkdir(parents=True)
+    # Act
+    placeholder = ensure_credentials_bind_target(
+        config, home_host=home_host, overlay_upper_home=upper_home
+    )
+    # Assert — placeholder is under the overlay upper-home, not workspace-home.
+    assert placeholder == upper_home / ".claude" / ".credentials.json"
+
+
+def test_ensure_bind_target_falls_back_to_workspace_home_when_upper_absent(
+    tmp_path,
+) -> None:
+    # Arrange — an overlay_upper_home that does NOT exist on disk (e.g. an
+    # .img overlay we cannot write into): the helper must fall back to the
+    # workspace-home bind rather than create an upper-home that won't be used.
+    creds = _valid_creds_file(tmp_path)
+    spec = _write_spec(
+        tmp_path, _BASE_SPEC.format(extra=f"    credentials_file: {creds}")
+    )
+    config = load_config(str(spec))
+    home_host = tmp_path / "state" / "home"
+    home_host.mkdir(parents=True)
+    missing_upper = tmp_path / "no-such-upper"  # never created
+    # Act
+    placeholder = ensure_credentials_bind_target(
+        config, home_host=home_host, overlay_upper_home=missing_upper
+    )
+    # Assert
+    assert placeholder == home_host / ".claude" / ".credentials.json"
+
+
+def test_ensure_bind_target_does_not_overwrite_existing_placeholder(tmp_path) -> None:
+    # Arrange — a placeholder that already carries content (e.g. a prior
+    # boot's real credential); the helper must leave it untouched (the bind
+    # shadows it anyway, and we never want to truncate a real file).
+    creds = _valid_creds_file(tmp_path)
+    spec = _write_spec(
+        tmp_path, _BASE_SPEC.format(extra=f"    credentials_file: {creds}")
+    )
+    config = load_config(str(spec))
+    home_host = tmp_path / "state" / "home"
+    (home_host / ".claude").mkdir(parents=True)
+    existing = home_host / ".claude" / ".credentials.json"
+    existing.write_text("PRIOR", encoding="utf-8")
+    # Act
+    ensure_credentials_bind_target(config, home_host=home_host)
+    # Assert
+    assert existing.read_text(encoding="utf-8") == "PRIOR"
+
+
+def test_build_run_argv_precreates_credentials_bind_target(tmp_path) -> None:
+    # Arrange — full build with designated creds; the host placeholder must
+    # exist AFTER build so the emitted file-bind destination pre-exists (the
+    # fresh-overlay-agent boot FATAL this fix closes).
+    creds = _valid_creds_file(tmp_path)
+    spec = _write_spec(
+        tmp_path, _BASE_SPEC.format(extra=f"    credentials_file: {creds}")
+    )
+    config = load_config(str(spec))
+    state_dir = tmp_path / "state"
+    # Act
+    build_run_argv(config, state_dir=state_dir, sif_path=Path("/img/sac.sif"), tui=True)
+    # Assert — placeholder at the workspace-home backing the /home/agent bind.
+    assert (state_dir / "home" / ".claude" / ".credentials.json").is_file()

--- a/tests/scitex_agent_container/runtimes/test__tui_turn_bridge.py
+++ b/tests/scitex_agent_container/runtimes/test__tui_turn_bridge.py
@@ -371,3 +371,50 @@ def test_stop_turn_bridge_sigterms_recorded_pid(isolated_home: Path) -> None:
     # Assert
     assert stopped is True
     proc.wait(timeout=5)
+
+
+# ---------------------------------------------------------------------------
+# start_turn_bridge — pre-existing-bridge teardown (a2a mis-route fix)
+# ---------------------------------------------------------------------------
+def test_start_turn_bridge_kills_preexisting_bridge_before_spawn(
+    tmp_path: Path, isolated_home: Path
+) -> None:
+    # Arrange — a REAL prior bridge process recorded in the agent's pidfile
+    # (the orphan a port-changing restart would otherwise leave alive), plus
+    # a recording spawn for the NEW bridge so no second subprocess is created.
+    spec = tmp_path / "spec.yaml"
+    spec.write_text("apiVersion: scitex-agent-container/v3\n", encoding="utf-8")
+    config = SimpleNamespace(
+        a2a=SimpleNamespace(port=_PORT), name="restart-me", config_path=str(spec)
+    )
+    prior = subprocess.Popen(["sleep", "30"])
+    pid_path = bridge._pid_path(config)
+    pid_path.parent.mkdir(parents=True, exist_ok=True)
+    pid_path.write_text(str(prior.pid), encoding="utf-8")
+    # Act — start must SIGTERM the prior bridge before spawning the new one.
+    bridge.start_turn_bridge(config, spawn=lambda argv, **kw: SimpleNamespace(pid=_PID))
+    # Assert — the prior process received SIGTERM and exited.
+    assert prior.wait(timeout=5) is not None
+    # (defensive: make sure we never leak the helper if the assert above changes)
+    if prior.poll() is None:  # pragma: no cover
+        prior.kill()
+
+
+def test_start_turn_bridge_records_new_pid_over_prior(
+    tmp_path: Path, isolated_home: Path
+) -> None:
+    # Arrange — a stale pidfile pointing at an already-dead PID; the new
+    # start must overwrite it with the freshly-spawned bridge's PID (never
+    # leave the orphaned/stale value behind).
+    spec = tmp_path / "spec.yaml"
+    spec.write_text("apiVersion: scitex-agent-container/v3\n", encoding="utf-8")
+    config = SimpleNamespace(
+        a2a=SimpleNamespace(port=_PORT), name="repid-me", config_path=str(spec)
+    )
+    pid_path = bridge._pid_path(config)
+    pid_path.parent.mkdir(parents=True, exist_ok=True)
+    pid_path.write_text("999999", encoding="utf-8")  # dead/stale PID
+    # Act
+    bridge.start_turn_bridge(config, spawn=lambda argv, **kw: SimpleNamespace(pid=_PID))
+    # Assert — pidfile now holds the new bridge's PID.
+    assert pid_path.read_text(encoding="utf-8").strip() == str(_PID)

--- a/tests/scitex_agent_container/runtimes/test_onboarding.py
+++ b/tests/scitex_agent_container/runtimes/test_onboarding.py
@@ -23,6 +23,7 @@ import pytest
 
 from scitex_agent_container.runtimes.onboarding import (
     _ONBOARDING_SEED,
+    _TOP_LEVEL_SEED,
     ensure_project_onboarding,
 )
 
@@ -144,6 +145,105 @@ class TestEnsureProjectOnboardingFreshInstall:
         ensure_project_onboarding(str(missing), home=tmp_path)
         # Assert
         assert str(missing) in _load(tmp_path)["projects"]
+
+
+# ---------------------------------------------------------------------------
+# Global first-run gate (top-level hasCompletedOnboarding) — fix #1
+# ---------------------------------------------------------------------------
+
+
+class TestTopLevelOnboardingGate:
+    """The headline fresh-agent boot fix: a fresh ``~/.claude.json`` must come
+    out with the global first-run gate seeded so Claude honours a bound
+    credential instead of running its OAuth-login first-run wizard.
+    """
+
+    @pytest.mark.parametrize("seed_key", list(_TOP_LEVEL_SEED.keys()))
+    def test_fresh_install_populates_every_top_level_seed_field(
+        self, tmp_path, workdir, seed_key
+    ):
+        # Arrange
+        ensure_project_onboarding(str(workdir), home=tmp_path)
+        # Act
+        present = seed_key in _load(tmp_path)
+        # Assert
+        assert present
+
+    def test_fresh_install_sets_has_completed_onboarding_true(self, tmp_path, workdir):
+        # Arrange
+        ensure_project_onboarding(str(workdir), home=tmp_path)
+        # Act
+        value = _load(tmp_path)["hasCompletedOnboarding"]
+        # Assert
+        assert value is True
+
+    def test_top_level_gate_seeded_even_when_workspace_already_complete(
+        self, tmp_path, workdir
+    ):
+        # Arrange — a file whose per-workspace entry is already onboarded but
+        # which lacks the GLOBAL gate (the exact fresh-agent shape: a trusted
+        # workspace pre-seed without hasCompletedOnboarding).
+        key = str(workdir.resolve())
+        (tmp_path / ".claude.json").write_text(
+            json.dumps({"projects": {key: {"hasCompletedProjectOnboarding": True}}})
+        )
+        # Act
+        ensure_project_onboarding(str(workdir), home=tmp_path)
+        # Assert — the global gate is added despite the project no-op.
+        assert _load(tmp_path)["hasCompletedOnboarding"] is True
+
+    def test_missing_global_gate_returns_true_even_when_workspace_complete(
+        self, tmp_path, workdir
+    ):
+        # Arrange — same shape as above; the return value must report that a
+        # write happened (the global gate was seeded).
+        key = str(workdir.resolve())
+        (tmp_path / ".claude.json").write_text(
+            json.dumps({"projects": {key: {"hasCompletedProjectOnboarding": True}}})
+        )
+        # Act
+        result = ensure_project_onboarding(str(workdir), home=tmp_path)
+        # Assert
+        assert result is True
+
+    def test_falsy_has_completed_onboarding_is_forced_true(self, tmp_path, workdir):
+        # Arrange — a stale ``false`` left by a half-finished first run would
+        # still re-trigger the login wizard; it must be forced true.
+        (tmp_path / ".claude.json").write_text(
+            json.dumps({"hasCompletedOnboarding": False})
+        )
+        # Act
+        ensure_project_onboarding(str(workdir), home=tmp_path)
+        # Assert
+        assert _load(tmp_path)["hasCompletedOnboarding"] is True
+
+    @pytest.mark.parametrize(
+        "field,operator_value",
+        [
+            ("theme", "light"),
+            ("numStartups", 42),
+        ],
+    )
+    def test_existing_top_level_value_is_never_clobbered(
+        self, tmp_path, workdir, field, operator_value
+    ):
+        # Arrange — operator already chose a theme / has a real startup count.
+        (tmp_path / ".claude.json").write_text(json.dumps({field: operator_value}))
+        # Act
+        ensure_project_onboarding(str(workdir), home=tmp_path)
+        # Assert — the seed must not overwrite the existing value.
+        assert _load(tmp_path)[field] == operator_value
+
+    def test_fully_complete_file_is_a_noop_returning_false(self, tmp_path, workdir):
+        # Arrange — both layers already complete: nothing left to seed.
+        key = str(workdir.resolve())
+        doc = {"hasCompletedOnboarding": True, "theme": "dark", "numStartups": 5}
+        doc["projects"] = {key: {"hasCompletedProjectOnboarding": True}}
+        (tmp_path / ".claude.json").write_text(json.dumps(doc))
+        # Act
+        result = ensure_project_onboarding(str(workdir), home=tmp_path)
+        # Assert
+        assert result is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Makes a FRESH sac agent boot + participate in a2a reliably. Each fix was diagnosed live (figrecipe↔beta a2a demo) and is unit/argv-tested.

## Fixes
1. **Onboarding gate (headline)** — `onboarding.py`: seed top-level `hasCompletedOnboarding` (+ theme/numStartups) so a fresh agent's `.claude.json` doesn't trigger claude's first-run OAuth-login wizard while a valid credential sits unused. Idempotent; lands in workspace-home + overlay-upper-home.
2. **Cred-bind target pre-creation** — `_apptainer_auth.py`: pre-create the 0-byte placeholder backing `$HOME/.claude/.credentials.json` (overlay-upper for relaxed-overlay specs, else `<state>/home`) so the `:rw` file-bind lands instead of FATAL-ing. Never written into `to_home/` (the leak guard refuses it).
3. **Turn-bridge lifecycle** — `_tui_turn_bridge.py`: `start_turn_bridge` always stops the agent's prior bridge first, so a restart that changes a2a port can't orphan the old bridge (the a2a mis-route root cause).

## Tests
- 4 touched modules: 141 passed. Full `runtimes/`: 918 passed, 14 skipped (real-apptainer smoke). 
- `_lifecycle/` shows 8 `test__broker_self.py` failures — local-env `sac listen` port-collision artifact, unrelated to this diff (no broker/listen logic touched).

Follow-up (separate PR): dev-agent full-bind default + `spec.access` capsule knob; agent-instance vs a2a-peers registry unification.