### PR TITLE
fix(a2a): unify agent_send endpoint resolution — end the registry split-brain

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_send.py
+++ b/src/scitex_agent_container/cli_pkg/_send.py
@@ -149,12 +149,24 @@ def send_to_agent(
         raise ValueError("either prompt or key is required")
 
     from .._network.peer import PeerError
-    from .._state.state_db import _resolve_host, list_active_instances
+    from .._state.state_db import _resolve_host
+    from ._send_resolve import resolve_send_endpoint
 
     current_host = _resolve_host(None)
-    rows = list_active_instances()
-    matching = [r for r in rows if r.get("name") == name]
-    if not matching:
+    # Resolve the LIVE endpoint the same way ``a2a_send`` / the listen
+    # forwarder do: active ``instances`` row port first, then the durable
+    # ``port_allocator`` claim that survives a health-monitor restart.
+    # Gating ONLY on the instances row (the old behaviour) caused the
+    # "registry split-brain": a locally-running agent whose row went stale
+    # (supervisor restart via ``runtime.start``, stale-lease clear) showed
+    # ``a2a_port=null`` here even while ``a2a_send`` reached it on the bus.
+    # See :mod:`._send_resolve` for the full root-cause writeup.
+    endpoint = resolve_send_endpoint(name, current_host=current_host)
+    a2a_port = endpoint.a2a_port
+    peer_host = endpoint.host if endpoint.host != current_host else ""
+    if endpoint.row is None and endpoint.source == "none":
+        # No active instances row AND no durable allocator claim → the
+        # agent is genuinely not running anywhere this host can see.
         return {
             "status": "error",
             "error": f"agent {name!r} not running",
@@ -165,19 +177,20 @@ def send_to_agent(
                 current_host=current_host,
             ),
         }
-    row = matching[0]
-    a2a_port = row.get("a2a_port")
-    peer_host = str(row.get("host") or "")
-    if not isinstance(a2a_port, int) or a2a_port <= 0:
+    if a2a_port is None:
+        # A row exists but neither it nor the allocator carries a usable
+        # port (sidecar-disabled spec, or a row written before the port
+        # was resolved). Loud — there is no /v1/turn to reach.
         return {
             "status": "error",
             "error": (
                 f"agent {name!r} has no a2a_port recorded "
-                f"(a2a_port={a2a_port!r}); cannot reach /v1/turn"
+                f"(no active instances-row port and no port_allocator "
+                f"claim); cannot reach /v1/turn"
             ),
             "diagnosis": diagnose_send_failure(
                 name,
-                a2a_port=a2a_port if isinstance(a2a_port, int) else None,
+                a2a_port=None,
                 peer_host=peer_host or current_host,
                 current_host=current_host,
             ),
@@ -262,7 +275,9 @@ def send_to_agent(
             }
         return {"status": "error", "error": msg, "diagnosis": diagnosis}
 
-    metadata: dict[str, Any] = {
+    metadata: dict[
+        str, Any
+    ] = {  # stx-allow: STX-SAC001 (reason: this is the send-reply ``response_metadata`` contract — name+host+url+a2a_port of the turn target — NOT an A2A AgentCard; the v0-field heuristic false-positives on the name+url pair)
         "name": name,
         "host": peer_host or current_host,
         "url": url,

--- a/src/scitex_agent_container/cli_pkg/_send_diagnosis.py
+++ b/src/scitex_agent_container/cli_pkg/_send_diagnosis.py
@@ -76,6 +76,25 @@ def _pid_alive(pid: Any) -> bool | None:
         return False
 
 
+def _has_durable_port_claim(name: str) -> bool:
+    """True iff ``name`` holds a live ``port_allocator`` claim.
+
+    The ``a2a_ports`` claim is written at ``agent_start`` and released
+    only at ``agent_stop`` / ``--force``, so it survives a health-monitor
+    ``runtime.start`` restart that does NOT refresh the ``instances`` row.
+    A live claim therefore means "this agent is running" even when its
+    instances row went stale — the registry split-brain case. Best-effort:
+    any read failure returns ``False`` (the caller then reports the
+    instances-row verdict unchanged, never a fabricated "running").
+    """
+    try:
+        from .._state.port_allocator import get_port
+
+        return get_port(name) is not None
+    except Exception:  # stx-allow: fallback (reason: an unreadable allocator table must not crash the diagnosis nor fabricate liveness — fall back to the instances-row verdict)
+        return False
+
+
 def _port_reachable(
     port: int, *, host: str = "127.0.0.1", timeout: float = 1.0
 ) -> bool:
@@ -147,6 +166,14 @@ def diagnose_send_failure(
     }
 
     # ---- registry / instances row + pid ---------------------------------
+    # ``registry_status`` reflects the SAME live-endpoint sources
+    # ``send_to_agent`` now resolves through (registry split-brain fix):
+    # an active ``instances`` row OR a durable ``port_allocator`` claim.
+    # Without the allocator arm a locally-running agent whose instances
+    # row went stale (health-monitor restart via ``runtime.start``,
+    # stale-lease clear) would still be reported "stopped" here even
+    # though ``send_to_agent`` correctly reaches it — the exact
+    # split-brain symptom this diagnosis is meant to explain, not repeat.
     row: dict[str, Any] | None = None
     try:
         from .._state.state_db import list_active_instances
@@ -154,7 +181,16 @@ def diagnose_send_failure(
         rows = list_active_instances()
         matching = [r for r in rows if r.get("name") == name]
         row = matching[0] if matching else None
-        diagnosis["registry_status"] = "running" if row is not None else "stopped"
+        if row is not None:
+            diagnosis["registry_status"] = "running"
+        elif _has_durable_port_claim(name):
+            # No active row, but a live allocator claim — the agent is
+            # running (a stopped agent releases its claim). Mark it
+            # running and note the source so the operator isn't misled.
+            diagnosis["registry_status"] = "running"
+            diagnosis["registry_source"] = "port_allocator"
+        else:
+            diagnosis["registry_status"] = "stopped"
     except Exception as exc:  # noqa: BLE001 — report loudly, never fake "stopped"
         diagnosis["registry_status"] = f"unreadable: {type(exc).__name__}: {exc}"
 

--- a/src/scitex_agent_container/cli_pkg/_send_resolve.py
+++ b/src/scitex_agent_container/cli_pkg/_send_resolve.py
@@ -1,0 +1,201 @@
+"""Live A2A endpoint resolution for ``send_to_agent`` (registry split-brain fix).
+
+Background — the "registry split-brain" (2026-06-19, figrecipe→beta).
+``agent_send`` (this library) used to resolve a target's A2A endpoint
+SOLELY from the ``instances`` table: it took the active row's
+``a2a_port`` and refused (``status="error"``, ``a2a_port=null``) when no
+active row existed or the row's port was null. ``a2a_send`` (the bus
+transport) resolves through ``sac listen``'s live broker / peer
+registry instead, so it kept reaching a live agent that ``agent_send``
+declared "stopped".
+
+The disagreement is real because the ``instances`` row goes stale while
+the agent keeps running:
+
+  * The ONLY writer of a fresh local row is
+    :func:`_lifecycle._instances.record_local_instance`, reached ONLY via
+    :func:`_lifecycle._start.agent_start`.
+  * The health-monitor's restart callback (``_start.py``) calls
+    ``runtime.start(config)`` DIRECTLY — it never re-runs ``agent_start``,
+    so a crashed/hung TUI agent that the supervisor restarts comes back
+    with its turn-bridge bound on the same port but NO refreshed
+    ``instances`` row.
+  * ``clear_stale_instance_lease`` / a prior stop can end the row.
+
+The DURABLE, restart-surviving source of truth for an agent's bound
+port is the ``a2a_ports`` allocator table (:mod:`_state.port_allocator`):
+written at ``agent_start`` (``resolve_a2a_port`` → ``claim_port``),
+idempotent, released only at ``agent_stop`` / ``--force``. It is the SAME
+port the turn-bridge binds (``_tui_turn_bridge.resolved_a2a_port`` reads
+``config.a2a.port`` which ``resolve_a2a_port`` set from the claim) and the
+SAME source the listen forwarder (``_listen._forward.forward_to_live_runner``),
+the registry-endpoint enricher (``_listen._registry_endpoints``), and the
+peer client (``_network._peer_resolve.resolve_peer_url``) already prefer.
+
+This module makes ``agent_send`` resolve the endpoint the SAME WAY those
+paths do, so the two transports agree on the live endpoint:
+
+  1. Active ``instances`` row (``bound_port`` preferred, legacy
+     ``a2a_port`` fallback) + its ``host`` — the cross-host dispatcher
+     records remote=True rows here, so this stays authoritative for
+     cross-host agents.
+  2. Durable local allocator claim (:func:`_state.port_allocator.get_port`)
+     when the row is missing or carries a null port — the case the
+     health-monitor restart leaves behind for a LOCAL agent.
+
+Resolution is pure-ish (state.db reads only) and fail-soft on read
+errors so the caller still produces its own clear error payload when no
+endpoint resolves anywhere. The caller (``_send.send_to_agent``) keeps
+ALL of its loud liveness gates (pid-dead, sidecar-port-unreachable,
+creds-expired) — this module only fixes WHERE the port comes from, never
+relaxes the "is it actually reachable?" checks.
+"""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+
+class ResolvedEndpoint(NamedTuple):
+    """Where a named agent's live ``/v1/turn`` listens, plus provenance.
+
+    ``a2a_port`` is ``None`` only when NO source (active row port nor
+    durable allocator claim) knows a port — the caller surfaces the same
+    loud "no a2a_port recorded" / "not running" error it always did.
+
+    ``host`` is the agent's host (the active row's ``host`` when a row
+    exists, else the local canonical host for an allocator-only claim).
+
+    ``source`` is provenance for diagnostics / tests:
+      * ``"instance_row"`` — the active ``instances`` row carried a port.
+      * ``"port_allocator"`` — the row was missing or null-port; the
+        durable allocator claim supplied the port (the split-brain fix
+        path).
+      * ``"none"`` — nothing resolved a port.
+
+    ``row`` is the active ``instances`` row dict when one exists (so the
+    caller can keep reusing its ``pid`` / ``host`` for diagnosis without
+    a second query), else ``None``.
+    """
+
+    a2a_port: int | None
+    host: str
+    source: str
+    row: dict | None
+
+
+def _active_row_for(name: str) -> dict | None:
+    """Return the newest active ``instances`` row for ``name``, else None.
+
+    Best-effort: a state.db read failure degrades to ``None`` so the
+    caller falls through to the allocator claim rather than crashing the
+    send. ``list_active_instances`` orders ``started_at DESC`` so the
+    first match is the newest.
+    """
+    try:
+        from .._state.state_db import list_active_instances
+    except Exception:  # pragma: no cover - import guarded only for safety
+        return None
+    try:
+        rows = [r for r in list_active_instances() if r.get("name") == name]
+    except Exception:  # stx-allow: fallback (reason: an unreadable instances table must not crash send; the allocator claim below is the durable resolver and the caller still fails loud if neither knows a port)
+        return None
+    return rows[0] if rows else None
+
+
+def _row_port(row: dict | None) -> int | None:
+    """Extract a positive int port from a row (``bound_port`` preferred).
+
+    Mirrors :func:`_network._peer_resolve._lookup_instance_endpoint` and
+    :func:`_listen._registry_endpoints._instance_endpoint`: prefer the
+    family-tree ``bound_port`` column, fall back to legacy ``a2a_port``.
+    Returns ``None`` for a missing / non-positive value.
+    """
+    if not row:
+        return None
+    port = row.get("bound_port")
+    if port is None:
+        port = row.get("a2a_port")
+    if isinstance(port, bool):  # bool is an int subclass — reject explicitly
+        return None
+    if isinstance(port, int) and port > 0:
+        return port
+    return None
+
+
+def _allocator_port(name: str) -> int | None:
+    """Return the durable allocator claim for ``name``, else None.
+
+    The ``a2a_ports`` table survives a health-monitor ``runtime.start``
+    restart (it is only released at ``agent_stop`` / ``--force``), so it
+    is the source that stays correct when the ``instances`` row went
+    stale. Best-effort: any read failure degrades to ``None``.
+    """
+    try:
+        from .._state.port_allocator import get_port
+
+        port = get_port(name)
+    except Exception:  # stx-allow: fallback (reason: best-effort durable-port lookup — caller fails loud when no source knows a port)
+        return None
+    if isinstance(port, bool):
+        return None
+    return int(port) if isinstance(port, int) and port > 0 else None
+
+
+def resolve_send_endpoint(name: str, *, current_host: str) -> ResolvedEndpoint:
+    """Resolve ``name``'s live ``/v1/turn`` endpoint (split-brain fix).
+
+    Resolution order (matches the listen forwarder + peer resolver, so
+    ``agent_send`` and ``a2a_send`` agree on the live endpoint):
+
+      1. Active ``instances`` row port (``bound_port`` / ``a2a_port``)
+         when present — authoritative, and the only place a cross-host
+         (remote=True) agent's host + port live.
+      2. Durable ``port_allocator`` claim when the row is missing or its
+         port is null — the case a health-monitor restart leaves for a
+         LOCAL agent. Host is the local canonical host.
+
+    ``host`` resolution:
+      * When an active row exists, use its ``host`` (so a cross-host
+        agent still routes via ssh to its peer).
+      * When only an allocator claim exists, the agent ran on THIS host
+        (the local allocator never holds claims for remote agents), so
+        ``host`` is ``current_host``.
+
+    Never raises — read failures degrade to ``a2a_port=None`` and the
+    caller surfaces its own loud "not running" / "no a2a_port" error.
+    """
+    row = _active_row_for(name)
+    row_port = _row_port(row)
+    if row_port is not None:
+        host = str(row.get("host") or "") if row else ""
+        return ResolvedEndpoint(
+            a2a_port=row_port,
+            host=host or current_host,
+            source="instance_row",
+            row=row,
+        )
+
+    # Row missing OR null-port → consult the durable allocator claim. This
+    # is the split-brain fix: a locally-running agent whose instances row
+    # went stale (health-monitor restart, stale-lease clear) still has its
+    # claim here, exactly as the listen forwarder / peer resolver rely on.
+    alloc_port = _allocator_port(name)
+    if alloc_port is not None:
+        # An allocator claim is local by construction (remote agents'
+        # ports live only in their own host's claim table, surfaced to us
+        # via the remote=True instances row handled above). If a stale row
+        # exists with a different (non-local) host we still prefer the
+        # local claim's host: the claim proves a live LOCAL sidecar, which
+        # is what we are about to dispatch to.
+        return ResolvedEndpoint(
+            a2a_port=alloc_port,
+            host=current_host,
+            source="port_allocator",
+            row=row,
+        )
+
+    return ResolvedEndpoint(a2a_port=None, host=current_host, source="none", row=row)
+
+
+__all__ = ["ResolvedEndpoint", "resolve_send_endpoint"]

--- a/tests/scitex_agent_container/cli_pkg/test__send.py
+++ b/tests/scitex_agent_container/cli_pkg/test__send.py
@@ -831,3 +831,93 @@ def test_agent_send_nonblocking_not_running_still_errors(state_db_env):
     result = send_to_agent("ghost", "hi")
     # Assert
     assert result["status"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# Registry split-brain regression (2026-06-19, figrecipe→beta).
+#
+# A locally-running agent whose ``instances`` row went STALE (the
+# health-monitor restart calls ``runtime.start`` directly, never
+# re-running ``agent_start``/``record_local_instance``; the
+# stale-lease sweep also ends rows) used to make ``agent_send`` report
+# ``status=error`` / ``a2a_port=null`` — even though the agent was live
+# and ``a2a_send`` reached it on the bus. The fix resolves the endpoint
+# from the DURABLE ``port_allocator`` claim (released only at stop /
+# --force) when no active instances row carries a port, matching how
+# the listen forwarder + peer resolver already resolve.
+#
+# These tests seed ONLY a real ``a2a_ports`` claim (no instances row)
+# to reproduce the split-brain, and a REAL bound listener so the
+# reachability gate sees a live sidecar — no mocks.
+# ---------------------------------------------------------------------------
+
+
+def _seed_port_claim(name: str, port: int) -> None:
+    """Insert a real durable allocator claim (no instances row)."""
+    from scitex_agent_container._state.port_allocator import claim_port
+
+    claim_port(name, explicit=port)
+
+
+def test_agent_send_reaches_agent_with_only_allocator_claim_nonblocking(
+    state_db_env, fresh_lead_creds_path
+):
+    # Arrange — NO instances row; only a durable allocator claim on a
+    # REAL bound port (the post-restart split-brain state).
+    with _real_listener() as port:
+        _seed_port_claim("beta", port)
+        # Act
+        with _exploding_post_turn():
+            result = send_to_agent("beta", "hi", lead_creds_path=fresh_lead_creds_path)
+    # Assert — dispatched, not the old misleading "agent not running".
+    assert result["status"] == "dispatched"
+
+
+def test_agent_send_allocator_claim_url_uses_claimed_port_blocking(
+    state_db_env, fresh_lead_creds_path
+):
+    # Arrange — NO instances row; only an allocator claim. The blocking
+    # POST must target the CLAIMED port's loopback /v1/turn.
+    _seed_port_claim("beta", 19007)
+    captured: dict = {}
+
+    def fake_post(url, text, *, timeout_s):
+        captured["url"] = url
+        return ("ok", {})
+
+    # Act
+    with _swap_post_turn(fake_post):
+        send_to_agent("beta", "hi", wait=True, lead_creds_path=fresh_lead_creds_path)
+    # Assert
+    assert captured["url"] == "http://127.0.0.1:19007/v1/turn"
+
+
+def test_agent_send_allocator_claim_diagnosis_reports_running(
+    state_db_env, fresh_lead_creds_path
+):
+    # Arrange — only an allocator claim (no row) on a port nothing is
+    # listening on, so the dispatch fails its reachability gate and we
+    # can inspect the attached diagnosis. The agent is RUNNING (the claim
+    # proves it), so the diagnosis must NOT repeat the split-brain lie of
+    # "stopped".
+    import socket as _socket
+
+    s = _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    dead_port = s.getsockname()[1]
+    s.close()
+    _seed_port_claim("beta", dead_port)
+    # Act
+    with _exploding_post_turn():
+        result = send_to_agent("beta", "hi", lead_creds_path=fresh_lead_creds_path)
+    # Assert
+    assert result["diagnosis"]["registry_status"] == "running"
+
+
+def test_agent_send_genuinely_absent_still_reports_not_running(state_db_env):
+    # Arrange — neither a row NOR a claim: the agent is genuinely gone.
+    # The split-brain fix must not paper over a real "not running".
+    # Act
+    result = send_to_agent("ghost", "hi")
+    # Assert
+    assert "not running" in result["error"]

--- a/tests/scitex_agent_container/cli_pkg/test__send_resolve.py
+++ b/tests/scitex_agent_container/cli_pkg/test__send_resolve.py
@@ -1,0 +1,188 @@
+"""Tests for ``scitex_agent_container.cli_pkg._send_resolve``.
+
+The live-endpoint resolver behind the registry split-brain fix.
+``agent_send`` resolves a target's ``/v1/turn`` endpoint through this
+module, which prefers the active ``instances`` row port but falls back
+to the DURABLE ``port_allocator`` claim — the source that stays correct
+when a health-monitor restart (``runtime.start`` directly) leaves the
+``instances`` row stale while the agent keeps running.
+
+Verifies:
+
+* instance-row port wins when present (``source="instance_row"``)
+* allocator claim is used when NO row exists (``source="port_allocator"``)
+* allocator claim is used when the row exists but its port is null
+* a cross-host row's host is preserved (routes to the peer)
+* nothing resolved → ``source="none"`` / ``a2a_port=None``
+* the ``bound_port`` column is preferred over legacy ``a2a_port``
+
+PA-306 / STX-NM002: no ``unittest.mock``, no ``monkeypatch``. State is
+seeded into a REAL temp ``state.db`` via the real ``record_instance_start``
+/ ``claim_port`` helpers. STX-TQ007: one fact per test. STX-TQ002: AAA.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+
+import pytest
+
+from scitex_agent_container.cli_pkg._send_resolve import resolve_send_endpoint
+
+_LOCAL_HOST = "lead-host"
+
+
+@pytest.fixture
+def state_db_env(tmp_path):
+    """Redirect state.db + host to a temp sandbox; reload the module.
+
+    Mirrors ``test__send.py``'s fixture so the resolver reads an empty db
+    unless the test seeds rows / claims itself.
+    """
+    saved_db = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB")
+    saved_host = os.environ.get("SAC_HOST")
+    os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(tmp_path / "state.db")
+    os.environ["SAC_HOST"] = _LOCAL_HOST
+    import scitex_agent_container._state.state_db as _state_db_mod
+
+    importlib.reload(_state_db_mod)
+    try:
+        yield tmp_path
+    finally:
+        if saved_db is None:
+            os.environ.pop("SCITEX_AGENT_CONTAINER_STATE_DB", None)
+        else:
+            os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = saved_db
+        if saved_host is None:
+            os.environ.pop("SAC_HOST", None)
+        else:
+            os.environ["SAC_HOST"] = saved_host
+        importlib.reload(_state_db_mod)
+
+
+def _seed_row(name: str, *, host: str = _LOCAL_HOST, a2a_port=None, bound_port=None):
+    """Insert a real active ``instances`` row."""
+    from scitex_agent_container._state.state_db import record_instance_start
+
+    record_instance_start(
+        name=name, host=host, a2a_port=a2a_port, bound_port=bound_port
+    )
+
+
+def _seed_claim(name: str, port: int) -> None:
+    """Insert a real durable ``a2a_ports`` allocator claim."""
+    from scitex_agent_container._state.port_allocator import claim_port
+
+    claim_port(name, explicit=port)
+
+
+# ---------------------------------------------------------------------------
+# instance-row port wins when present
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_uses_instance_row_port_when_present(state_db_env):
+    # Arrange
+    _seed_row("alpha", a2a_port=12345)
+    # Act
+    ep = resolve_send_endpoint("alpha", current_host=_LOCAL_HOST)
+    # Assert
+    assert ep.a2a_port == 12345
+
+
+def test_resolve_instance_row_source_label(state_db_env):
+    # Arrange
+    _seed_row("alpha", a2a_port=12345)
+    # Act
+    ep = resolve_send_endpoint("alpha", current_host=_LOCAL_HOST)
+    # Assert
+    assert ep.source == "instance_row"
+
+
+def test_resolve_prefers_bound_port_over_legacy_a2a_port(state_db_env):
+    # Arrange — both columns set to different values; bound_port must win.
+    _seed_row("alpha", a2a_port=11111, bound_port=22222)
+    # Act
+    ep = resolve_send_endpoint("alpha", current_host=_LOCAL_HOST)
+    # Assert
+    assert ep.a2a_port == 22222
+
+
+# ---------------------------------------------------------------------------
+# the split-brain fix: allocator claim used when the row is stale/absent
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_falls_back_to_allocator_when_no_row(state_db_env):
+    # Arrange — NO instances row, but a durable allocator claim exists.
+    # This is the health-monitor-restart case: the row was ended but the
+    # claim (released only on stop/--force) survives.
+    _seed_claim("beta", 19007)
+    # Act
+    ep = resolve_send_endpoint("beta", current_host=_LOCAL_HOST)
+    # Assert
+    assert ep.a2a_port == 19007
+
+
+def test_resolve_allocator_fallback_source_label(state_db_env):
+    # Arrange
+    _seed_claim("beta", 19007)
+    # Act
+    ep = resolve_send_endpoint("beta", current_host=_LOCAL_HOST)
+    # Assert
+    assert ep.source == "port_allocator"
+
+
+def test_resolve_allocator_fallback_host_is_local(state_db_env):
+    # Arrange — an allocator claim is local by construction.
+    _seed_claim("beta", 19007)
+    # Act
+    ep = resolve_send_endpoint("beta", current_host=_LOCAL_HOST)
+    # Assert
+    assert ep.host == _LOCAL_HOST
+
+
+def test_resolve_falls_back_to_allocator_when_row_port_is_null(state_db_env):
+    # Arrange — a row exists but carries NO port; the claim supplies it.
+    _seed_row("beta", a2a_port=None)
+    _seed_claim("beta", 19007)
+    # Act
+    ep = resolve_send_endpoint("beta", current_host=_LOCAL_HOST)
+    # Assert
+    assert ep.a2a_port == 19007
+
+
+# ---------------------------------------------------------------------------
+# cross-host row host is preserved
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_cross_host_row_preserves_peer_host(state_db_env):
+    # Arrange — a remote row (different host) carries the peer + port.
+    _seed_row("gamma", host="peer-x", a2a_port=18888)
+    # Act
+    ep = resolve_send_endpoint("gamma", current_host=_LOCAL_HOST)
+    # Assert
+    assert ep.host == "peer-x"
+
+
+# ---------------------------------------------------------------------------
+# nothing resolved → source="none"
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_nothing_known_returns_source_none(state_db_env):
+    # Arrange — no row, no claim.
+    # Act
+    ep = resolve_send_endpoint("ghost", current_host=_LOCAL_HOST)
+    # Assert
+    assert ep.source == "none"
+
+
+def test_resolve_nothing_known_returns_null_port(state_db_env):
+    # Arrange — no row, no claim.
+    # Act
+    ep = resolve_send_endpoint("ghost", current_host=_LOCAL_HOST)
+    # Assert
+    assert ep.a2a_port is None


### PR DESCRIPTION
Fixes the a2a "registry split-brain": `agent_send` resolved a target's endpoint from the **agent-instance registry** (which goes stale — a health-monitor restart re-binds the turn-bridge but never refreshes the instance row via `record_local_instance`), so it refused (`a2a_port=null`/`stopped`) live agents that `a2a_send` (the peers/bus registry) reached fine. Observed live: figrecipe→beta.

## Fix (additive — preserves both sources)
New `cli_pkg/_send_resolve.py::resolve_send_endpoint` resolves via:
1. the active instance-row port + host (**cross-host rows stay authoritative**), then
2. the **durable `port_allocator` claim** as fallback — the exact case a supervisor restart leaves behind.

`send_to_agent` uses it. **All loud liveness gates unchanged** (pid-dead, sidecar-unreachable, creds-expired) — only the port *source* moved. `diagnose_send_failure` now reports `registry_status=running` (+`registry_source`) when only a durable claim exists, instead of repeating the stale "stopped".

## No-drop (operator constraint)
Instance-row resolution kept (branch 1); durable-claim added (branch 2); gates + diagnosis enriched, nothing removed.

## Tests
47 targeted (10 new resolver + 4 split-brain regression + 33 existing); `cli_pkg/`+`_state/` 2494 passed (only the local `sac listen` port-collision artifact fails).

## Known follow-up (separate)
`sac agents list` still derives TUI status from a docker-inspect probe → shows "stopped" for a live TUI agent. Display-surface only; not on the `agent_send` transport path.