### PR TITLE
fix(tui): accept v2.1.150 ready state in wait_until_input_ready (unblocks scitex-arm capsule)

### DIFF
--- a/src/scitex_agent_container/runtimes/tui_session.py
+++ b/src/scitex_agent_container/runtimes/tui_session.py
@@ -737,7 +737,13 @@ class TuiSessionRuntime(RuntimeBase):
         send_keys_fn = self._mux.send_keys
         while time.monotonic() < deadline:
             last_pane = self._mux.capture_content(name)
-            if marker in last_pane:
+            # Claude Code v2.1.150 dropped the "? for shortcuts" idle marker; its
+            # ready state shows the "bypass permissions" status bar instead (input
+            # live behind the first-launch welcome box). Accept is_ready() too —
+            # mirroring _drain_at_boot — so prompt injection is not blocked by an
+            # outdated marker (paper-scitex-clew handoff 2026-06-20: agent idled
+            # at a live input, "drained 0 modals").
+            if marker in last_pane or _prompts.is_ready(last_pane):
                 return True
             handled = _prompts.detect_and_respond(
                 last_pane, accepted, send_keys_fn=lambda key: send_keys_fn(name, key)

--- a/tests/scitex_agent_container/runtimes/test_tui_session_v2_ready_marker.py
+++ b/tests/scitex_agent_container/runtimes/test_tui_session_v2_ready_marker.py
@@ -1,0 +1,80 @@
+"""Regression: wait_until_input_ready accepts the Claude Code v2.1.150 ready state.
+
+paper-scitex-clew handoff (2026-06-20): the scitex-arm capsule agent idled at a
+LIVE input behind the first-launch welcome box — `wait_until_input_ready` waited
+on the legacy ``? for shortcuts`` marker, which v2.1.150 no longer prints (its
+idle state shows the ``bypass permissions`` status bar instead). The drain timed
+out ("drained 0 modals") and the startup prompt was never injected.
+
+Fix: accept ``is_ready()`` (the maintained ready check) too, mirroring
+``_drain_at_boot``. Real in-memory MultiplexerProtocol — no mocks (PA-306).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from scitex_agent_container.runtimes.tui_session import (
+    TuiInputNotReadyError,
+    TuiSessionRuntime,
+)
+
+# Actual idle pane captured from a live agent (ywata-note-win, 2026-06-20):
+# welcome box + live input (❯) + "bypass permissions" status bar, and crucially
+# NO "? for shortcuts" marker.
+_V2_READY_PANE = (
+    "╭─── Claude Code v2.1.150 ───╮\n"
+    "│      Welcome back Yusuke!  │  What's new\n"
+    "╰────────────────────────────╯\n"
+    "❯ \n"
+    "  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents\n"
+)
+_BOOTING_PANE = "uv pip install -e .[all,dev]\nResolving dependencies ..."
+
+
+@dataclass
+class _Config:
+    name: str
+
+
+class _PaneMux:
+    """Minimal real MultiplexerProtocol surface used by wait_until_input_ready:
+    a single always-present session returning a fixed pane. Not a mock — a real
+    object implementing exactly the methods the runtime calls."""
+
+    def __init__(self, pane: str) -> None:
+        self._pane = pane
+        self.sent: list[str] = []
+
+    def exists(self, name: str) -> bool:
+        return True
+
+    def capture_content(self, name: str) -> str:
+        return self._pane
+
+    def send_keys(self, name: str, key: str) -> None:
+        self.sent.append(key)
+
+
+def test_wait_until_input_ready_accepts_v2_1_150_bypass_permissions_state():
+    # Arrange
+    runtime = TuiSessionRuntime(multiplexer=_PaneMux(_V2_READY_PANE))
+    config = _Config(name="capsule")
+    # Act
+    ready = runtime.wait_until_input_ready(config, timeout_s=1.0, poll_s=0.0)
+    # Assert
+    assert ready is True
+
+
+def test_wait_until_input_ready_still_times_out_when_not_ready():
+    # Arrange
+    runtime = TuiSessionRuntime(multiplexer=_PaneMux(_BOOTING_PANE))
+    config = _Config(name="boot")
+    # Act
+    caught = False
+    try:
+        runtime.wait_until_input_ready(config, timeout_s=0.2, poll_s=0.0)
+    except TuiInputNotReadyError:
+        caught = True
+    # Assert
+    assert caught is True


### PR DESCRIPTION
## Item 1 — paper-scitex-clew handoff (2026-06-20)

The scitex-arm capsule agent **idled at a live input** behind Claude Code v2.1.150's first-launch welcome box, blocking the killer-experiment.

## Root cause (confirmed from a live captured pane, ywata-note-win)
`wait_until_input_ready` waited **only** on the legacy `? for shortcuts` marker. v2.1.150 **no longer prints it** — the idle/ready state shows the `⏵⏵ bypass permissions on` status bar (input `❯` live, welcome box as scrollback above). So the drain timed out ("drained 0 modals") and the startup prompt was never injected. *(The handoff guessed the welcome box was a blocking modal; the capture showed the input was actually live — the marker check was the bug.)*

## Fix
`wait_until_input_ready` now accepts `is_ready()` (the maintained ready check = bypass-permissions status) in addition to the legacy marker — **mirroring `_drain_at_boot`, which already did**. One line in `runtimes/tui_session.py`.

## Test
New regression `test_tui_session_v2_ready_marker.py` drives the runtime with the **real captured v2.1.150 pane** (no mocks): asserts ready-detection on bypass-permissions, and that a still-booting pane still times out. 51 prompts/TUI tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)