### PR TITLE
feat(to_home): aggregate resolved skills into CLAUDE.md at deploy time

### DIFF
--- a/src/scitex_agent_container/runtimes/_to_home.py
+++ b/src/scitex_agent_container/runtimes/_to_home.py
@@ -72,6 +72,7 @@ from ._to_home_errors import (
     WorkspaceCredentialLeakError,
     WorkspaceMcpMergeError,
 )
+from ._to_home_skills import aggregate_skills_into_claudemd
 from ._to_home_text import (
     END_MARKER,
     extract_user_tail,
@@ -220,6 +221,10 @@ def materialize_to_home(spec_dir: Path, workspace_home: Path) -> None:
     if root.is_dir():
         _walk_and_apply(root, root, workspace_home, config=None)
     fold_envrc_into_env(workspace_home)
+    # Inline the agent's now-materialized skills into CLAUDE.md (forceful,
+    # idempotent) so they are always in context regardless of @-import /
+    # skill-chaining reliability. See _to_home_skills for the rationale.
+    aggregate_skills_into_claudemd(workspace_home)
 
 
 def deploy_to_home(config: AgentConfig, workspace_home: str) -> None:
@@ -268,6 +273,10 @@ def deploy_to_home(config: AgentConfig, workspace_home: str) -> None:
     # the result into dest/.env so build_run_argv's --env-file injects it.
     # No-op when the agent ships no .envrc.
     fold_envrc_into_env(dest)
+    # Inline the agent's now-materialized skills into CLAUDE.md (forceful,
+    # idempotent) so they are always in context regardless of @-import /
+    # skill-chaining reliability. See _to_home_skills for the rationale.
+    aggregate_skills_into_claudemd(dest)
 
 
 # --- traversal -------------------------------------------------------------
@@ -574,6 +583,7 @@ def _spec_dir(config: AgentConfig) -> Path | None:
 __all__ = [
     "DanglingToHomeSymlinkError",
     "WorkspaceCLAUDEMarkerError",
+    "aggregate_skills_into_claudemd",
     "deploy_to_home",
     "materialize_to_home",
     "resolve_baseline_to_home_dir",

--- a/src/scitex_agent_container/runtimes/_to_home_skills.py
+++ b/src/scitex_agent_container/runtimes/_to_home_skills.py
@@ -1,0 +1,221 @@
+"""Aggregate an agent's resolved skills content into its CLAUDE.md.
+
+Operator guarantee (2026-06-20, routed via paper-scitex-clew handoff item 5):
+skill-chaining (skills that reference other skills) and ``startup_prompts``
+are both unreliable triggers, so the strongest enforcement is to inline the
+agent's actual skill content into its ``CLAUDE.md`` at deploy time — CLAUDE.md
+is always-on context that the harness loads every turn.
+
+This module is called from :func:`_to_home.deploy_to_home` (and the overlay
+twin) AFTER ``to_home`` materialization, so the skills the agent will actually
+see — the real ``*.md`` files under ``<workspace_home>/.claude/skills/`` (v3:
+skills are materialized there, not bind-mounted; see skill
+``25_claude-setup-delivery``) — are already on disk.
+
+The aggregated content is wrapped between idempotent markers::
+
+    <!-- sac:skills:start -->
+    ...inlined skill bodies...
+    <!-- sac:skills:end -->
+
+Re-deploys REPLACE the block cleanly: the writer strips any existing
+``sac:skills`` block first, then appends a fresh one. This stays correct even
+though ``CLAUDE.md`` is *also* marker-protected by
+:func:`_to_home._deploy_marker_protected` (whose ``Start/End`` section is a
+separate, independently-managed marker pair): the strip-then-append keeps
+exactly one skills block no matter how the user-tail carries it forward.
+
+Extracted into its own module (vs. folding into ``_to_home.py``, already at
+the ~512-line file ceiling) per the repo's sibling-module convention.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Idempotent skills-aggregation markers. Distinct from the CLAUDE.md
+# Start/End generated-section markers in _to_home_text.py.
+SKILLS_START_MARKER = "<!-- sac:skills:start -->"
+SKILLS_END_MARKER = "<!-- sac:skills:end -->"
+
+# Subtrees we never treat as skill content.
+_SKIP_DIRS = frozenset({"__pycache__", "GITIGNORED", ".git"})
+
+# CLAUDE.md basenames Claude Code reads, relative to the workspace home.
+# Both are honoured: the root file is the SAC convention (see
+# 25_claude-setup-delivery), and ``.claude/CLAUDE.md`` is the SDK's own
+# user-memory path. We aggregate into whichever already exist; if NEITHER
+# exists but skills do, we create the root one (the canonical target).
+_CLAUDE_MD_RELPATHS = ("CLAUDE.md", ".claude/CLAUDE.md")
+
+
+def _iter_skill_files(skills_dir: Path) -> list[Path]:
+    """Return every ``*.md`` skill leaf under ``skills_dir`` (sorted).
+
+    Skips hidden / generated subtrees. The top-level ``SKILL.md`` index is
+    included like any other leaf so its routing content is inlined too.
+    """
+    if not skills_dir.is_dir():
+        return []
+    out: list[Path] = []
+    for md in sorted(skills_dir.rglob("*.md")):
+        rel_parts = md.relative_to(skills_dir).parts[:-1]
+        if any(p in _SKIP_DIRS or p.startswith(".") for p in rel_parts):
+            continue
+        out.append(md)
+    return out
+
+
+def _build_skills_block(skills_dir: Path) -> str | None:
+    """Render the marker-wrapped aggregated skills block, or None.
+
+    Returns ``None`` when there are no skill files to inline (caller then
+    only strips any stale block, never appends an empty one).
+    """
+    files = _iter_skill_files(skills_dir)
+    if not files:
+        return None
+
+    parts: list[str] = [
+        SKILLS_START_MARKER,
+        "",
+        "# Aggregated skills (auto-injected by scitex-agent-container)",
+        "",
+        "The skill content below is inlined from "
+        "`~/.claude/skills/` at deploy time so it is ALWAYS in context — "
+        "do not rely on `@`-import or skill-chaining to load it.",
+        "",
+    ]
+    for md in files:
+        rel = md.relative_to(skills_dir)
+        try:
+            body = md.read_text(encoding="utf-8").strip()
+        except OSError as exc:
+            logger.warning("skills-aggregate: skip unreadable %s (%s)", md, exc)
+            continue
+        parts.append(f"## skill: {rel}")
+        parts.append("")
+        parts.append(body)
+        parts.append("")
+    parts.append(SKILLS_END_MARKER)
+    return "\n".join(parts).rstrip("\n") + "\n"
+
+
+def _strip_existing_block(text: str) -> str:
+    """Remove any existing ``sac:skills`` block from ``text``.
+
+    Tolerant of a missing end marker (truncates from start marker to EOF) so
+    a half-written prior block never duplicates. No markers → returns
+    ``text`` unchanged.
+    """
+    start = text.find(SKILLS_START_MARKER)
+    if start == -1:
+        return text
+    prefix = text[:start]
+    end = text.find(SKILLS_END_MARKER, start)
+    if end == -1:
+        # Malformed/truncated: drop everything from the start marker on.
+        suffix = ""
+    else:
+        suffix = text[end + len(SKILLS_END_MARKER) :]
+    prefix = prefix.rstrip("\n")
+    suffix = suffix.lstrip("\n")
+    if prefix and suffix:
+        joined = f"{prefix}\n{suffix}"
+    else:
+        joined = prefix or suffix
+    if not joined:
+        return ""
+    return joined.rstrip("\n") + "\n"
+
+
+def _apply_to_file(claude_md: Path, block: str) -> None:
+    """Write ``block`` into ``claude_md`` (strip-then-append; idempotent)."""
+    existing = claude_md.read_text(encoding="utf-8") if claude_md.is_file() else ""
+    stripped = _strip_existing_block(existing)
+    if stripped and not stripped.endswith("\n"):
+        stripped += "\n"
+    sep = "\n" if stripped.strip() else ""
+    new_text = f"{stripped}{sep}{block}"
+    claude_md.parent.mkdir(parents=True, exist_ok=True)
+    # CLAUDE.md may have been written read-only by a prior step; clear it.
+    if claude_md.exists():
+        import os
+        import stat
+
+        mode = claude_md.stat().st_mode
+        if not mode & stat.S_IWUSR:
+            os.chmod(claude_md, mode | stat.S_IWUSR)
+    claude_md.write_text(new_text, encoding="utf-8")
+
+
+def aggregate_skills_into_claudemd(workspace_home: Path) -> list[Path]:
+    """Inline ``<workspace_home>/.claude/skills/`` content into CLAUDE.md.
+
+    Forceful + idempotent: on every call the ``sac:skills`` block in each
+    target CLAUDE.md is replaced with a freshly-rendered one. Targets every
+    CLAUDE.md in :data:`_CLAUDE_MD_RELPATHS` that already exists; if none
+    exists but skills are present, the root ``CLAUDE.md`` is created.
+
+    No-op (returns ``[]``) when there are no skill files — but a stale block
+    in an existing CLAUDE.md is still stripped so removing the last skill
+    cleans up after itself.
+
+    Returns the list of CLAUDE.md paths that were written.
+    """
+    skills_dir = workspace_home / ".claude" / "skills"
+    block = _build_skills_block(skills_dir)
+
+    targets = [
+        workspace_home / rel
+        for rel in _CLAUDE_MD_RELPATHS
+        if (workspace_home / rel).is_file()
+    ]
+
+    if block is None:
+        # No skills: only clean up an existing block, never create a file.
+        written: list[Path] = []
+        for tgt in targets:
+            before = tgt.read_text(encoding="utf-8")
+            after = _strip_existing_block(before)
+            if after != before:
+                _write_plain(tgt, after)
+                written.append(tgt)
+        return written
+
+    if not targets:
+        # Skills exist but no CLAUDE.md yet — create the canonical root one.
+        targets = [workspace_home / _CLAUDE_MD_RELPATHS[0]]
+
+    written = []
+    for tgt in targets:
+        _apply_to_file(tgt, block)
+        written.append(tgt)
+        logger.info(
+            "skills-aggregate: inlined %d skill file(s) into %s",
+            len(_iter_skill_files(skills_dir)),
+            tgt,
+        )
+    return written
+
+
+def _write_plain(claude_md: Path, text: str) -> None:
+    """Write ``text`` clearing a read-only bit first (no block logic)."""
+    import os
+    import stat
+
+    if claude_md.exists():
+        mode = claude_md.stat().st_mode
+        if not mode & stat.S_IWUSR:
+            os.chmod(claude_md, mode | stat.S_IWUSR)
+    claude_md.write_text(text, encoding="utf-8")
+
+
+__all__ = [
+    "SKILLS_END_MARKER",
+    "SKILLS_START_MARKER",
+    "aggregate_skills_into_claudemd",
+]

--- a/tests/scitex_agent_container/runtimes/test__to_home_skills.py
+++ b/tests/scitex_agent_container/runtimes/test__to_home_skills.py
@@ -1,0 +1,355 @@
+"""Tests for deploy-time skills→CLAUDE.md aggregation (handoff item 5).
+
+The agent's resolved skills (the real ``*.md`` files materialized under
+``<workspace_home>/.claude/skills/``) are inlined into CLAUDE.md between
+idempotent ``sac:skills`` markers so they are always in context — the
+operator's "guarantee" against unreliable ``@``-import / skill-chaining.
+
+No mocks: real files on ``tmp_path`` and the real ``materialize_to_home`` /
+``deploy_to_home`` entrypoints (PA-306). AAA markers throughout.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container.config._types import AgentConfig
+from scitex_agent_container.runtimes._to_home import (
+    deploy_to_home,
+    materialize_to_home,
+)
+from scitex_agent_container.runtimes._to_home_skills import (
+    SKILLS_END_MARKER,
+    SKILLS_START_MARKER,
+    aggregate_skills_into_claudemd,
+)
+
+# ---------------------------------------------------------------------------
+# Builders
+# ---------------------------------------------------------------------------
+
+
+def _home_with_skills(
+    tmp_path: Path,
+    skills: dict[str, str],
+    *,
+    claude_md: str | None = None,
+) -> Path:
+    """Build a workspace home with ``.claude/skills/<name>`` files.
+
+    ``skills`` maps a relative path (under ``.claude/skills/``) to its body.
+    ``claude_md`` (when given) seeds ``<home>/CLAUDE.md``.
+    """
+    home = tmp_path / "home"
+    skills_dir = home / ".claude" / "skills"
+    skills_dir.mkdir(parents=True, exist_ok=True)
+    for rel, body in skills.items():
+        leaf = skills_dir / rel
+        leaf.parent.mkdir(parents=True, exist_ok=True)
+        leaf.write_text(body, encoding="utf-8")
+    if claude_md is not None:
+        (home / "CLAUDE.md").write_text(claude_md, encoding="utf-8")
+    return home
+
+
+# ---------------------------------------------------------------------------
+# aggregate_skills_into_claudemd — core behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestAggregateBasics:
+    def test_inlines_skill_body(self, tmp_path):
+        # Arrange
+        home = _home_with_skills(
+            tmp_path, {"s1.md": "# S1\nskill one body"}, claude_md="# Agent\n"
+        )
+        # Act
+        aggregate_skills_into_claudemd(home)
+        # Assert
+        assert "skill one body" in (home / "CLAUDE.md").read_text()
+
+    def test_emits_start_marker(self, tmp_path):
+        # Arrange
+        home = _home_with_skills(tmp_path, {"s1.md": "body"}, claude_md="# Agent\n")
+        # Act
+        aggregate_skills_into_claudemd(home)
+        # Assert
+        assert SKILLS_START_MARKER in (home / "CLAUDE.md").read_text()
+
+    def test_emits_end_marker(self, tmp_path):
+        # Arrange
+        home = _home_with_skills(tmp_path, {"s1.md": "body"}, claude_md="# Agent\n")
+        # Act
+        aggregate_skills_into_claudemd(home)
+        # Assert
+        assert SKILLS_END_MARKER in (home / "CLAUDE.md").read_text()
+
+    def test_preserves_existing_claude_md_content(self, tmp_path):
+        # Arrange
+        home = _home_with_skills(
+            tmp_path, {"s1.md": "body"}, claude_md="# Agent\nmission text\n"
+        )
+        # Act
+        aggregate_skills_into_claudemd(home)
+        # Assert
+        assert "mission text" in (home / "CLAUDE.md").read_text()
+
+    def test_inlines_multiple_skill_bodies(self, tmp_path):
+        # Arrange
+        home = _home_with_skills(
+            tmp_path,
+            {"a.md": "alpha body", "b.md": "beta body"},
+            claude_md="# Agent\n",
+        )
+        # Act
+        aggregate_skills_into_claudemd(home)
+        text = (home / "CLAUDE.md").read_text()
+        # Assert
+        assert "alpha body" in text and "beta body" in text
+
+    def test_includes_nested_skill(self, tmp_path):
+        # Arrange
+        home = _home_with_skills(
+            tmp_path,
+            {"sub/nested.md": "nested body"},
+            claude_md="# Agent\n",
+        )
+        # Act
+        aggregate_skills_into_claudemd(home)
+        # Assert
+        assert "nested body" in (home / "CLAUDE.md").read_text()
+
+    def test_returns_written_path(self, tmp_path):
+        # Arrange
+        home = _home_with_skills(tmp_path, {"s1.md": "body"}, claude_md="# Agent\n")
+        # Act
+        written = aggregate_skills_into_claudemd(home)
+        # Assert
+        assert home / "CLAUDE.md" in written
+
+
+class TestAggregateNoSkills:
+    def test_no_skills_no_claude_md_is_noop(self, tmp_path):
+        # Arrange
+        home = tmp_path / "home"
+        (home / ".claude" / "skills").mkdir(parents=True)
+        # Act
+        written = aggregate_skills_into_claudemd(home)
+        # Assert
+        assert written == []
+
+    def test_no_skills_does_not_create_claude_md(self, tmp_path):
+        # Arrange
+        home = tmp_path / "home"
+        (home / ".claude" / "skills").mkdir(parents=True)
+        # Act
+        aggregate_skills_into_claudemd(home)
+        # Assert
+        assert not (home / "CLAUDE.md").exists()
+
+    def test_removing_last_skill_strips_block(self, tmp_path):
+        # Arrange
+        home = _home_with_skills(tmp_path, {"s1.md": "body"}, claude_md="# Agent\n")
+        aggregate_skills_into_claudemd(home)
+        (home / ".claude" / "skills" / "s1.md").unlink()
+        # Act
+        aggregate_skills_into_claudemd(home)
+        # Assert
+        assert SKILLS_START_MARKER not in (home / "CLAUDE.md").read_text()
+
+    def test_removing_last_skill_keeps_user_content(self, tmp_path):
+        # Arrange
+        home = _home_with_skills(
+            tmp_path, {"s1.md": "body"}, claude_md="# Agent\nkeep mission\n"
+        )
+        aggregate_skills_into_claudemd(home)
+        (home / ".claude" / "skills" / "s1.md").unlink()
+        # Act
+        aggregate_skills_into_claudemd(home)
+        # Assert
+        assert "keep mission" in (home / "CLAUDE.md").read_text()
+
+
+class TestAggregateCreatesClaudeMd:
+    def test_creates_root_claude_md_when_absent(self, tmp_path):
+        # Arrange — skills present, no CLAUDE.md anywhere.
+        home = _home_with_skills(tmp_path, {"s1.md": "body"})
+        # Act
+        aggregate_skills_into_claudemd(home)
+        # Assert
+        assert (home / "CLAUDE.md").is_file()
+
+    def test_created_claude_md_has_skill_body(self, tmp_path):
+        # Arrange
+        home = _home_with_skills(tmp_path, {"s1.md": "fresh body"})
+        # Act
+        aggregate_skills_into_claudemd(home)
+        # Assert
+        assert "fresh body" in (home / "CLAUDE.md").read_text()
+
+
+class TestAggregateIdempotent:
+    def test_second_run_keeps_single_block(self, tmp_path):
+        # Arrange
+        home = _home_with_skills(tmp_path, {"s1.md": "body"}, claude_md="# Agent\n")
+        aggregate_skills_into_claudemd(home)
+        # Act
+        aggregate_skills_into_claudemd(home)
+        # Assert
+        assert (home / "CLAUDE.md").read_text().count(SKILLS_START_MARKER) == 1
+
+    def test_second_run_byte_identical(self, tmp_path):
+        # Arrange
+        home = _home_with_skills(tmp_path, {"s1.md": "body"}, claude_md="# Agent\n")
+        aggregate_skills_into_claudemd(home)
+        first = (home / "CLAUDE.md").read_text()
+        # Act
+        aggregate_skills_into_claudemd(home)
+        # Assert
+        assert (home / "CLAUDE.md").read_text() == first
+
+    def test_changed_skill_is_refreshed(self, tmp_path):
+        # Arrange
+        home = _home_with_skills(tmp_path, {"s1.md": "old body"}, claude_md="# Agent\n")
+        aggregate_skills_into_claudemd(home)
+        (home / ".claude" / "skills" / "s1.md").write_text("new body")
+        # Act
+        aggregate_skills_into_claudemd(home)
+        text = (home / "CLAUDE.md").read_text()
+        # Assert
+        assert "new body" in text and "old body" not in text
+
+    def test_changed_skill_keeps_single_block(self, tmp_path):
+        # Arrange
+        home = _home_with_skills(tmp_path, {"s1.md": "old body"}, claude_md="# Agent\n")
+        aggregate_skills_into_claudemd(home)
+        (home / ".claude" / "skills" / "s1.md").write_text("new body")
+        # Act
+        aggregate_skills_into_claudemd(home)
+        # Assert
+        assert (home / "CLAUDE.md").read_text().count(SKILLS_START_MARKER) == 1
+
+
+class TestAggregateTargetsBothClaudeMd:
+    def test_aggregates_into_dot_claude_claude_md(self, tmp_path):
+        # Arrange — only .claude/CLAUDE.md exists (SDK user-memory path).
+        home = _home_with_skills(tmp_path, {"s1.md": "body"})
+        nested = home / ".claude" / "CLAUDE.md"
+        nested.write_text("# nested agent\n")
+        # Act
+        aggregate_skills_into_claudemd(home)
+        # Assert
+        assert SKILLS_START_MARKER in nested.read_text()
+
+    def test_aggregates_into_both_when_both_exist(self, tmp_path):
+        # Arrange
+        home = _home_with_skills(tmp_path, {"s1.md": "body"}, claude_md="# root\n")
+        (home / ".claude" / "CLAUDE.md").write_text("# nested\n")
+        # Act
+        aggregate_skills_into_claudemd(home)
+        # Assert
+        assert SKILLS_START_MARKER in (home / ".claude" / "CLAUDE.md").read_text()
+
+
+# ---------------------------------------------------------------------------
+# Integration via the real deploy entrypoints (marker-protection coexistence)
+# ---------------------------------------------------------------------------
+
+
+def _spec_with_skills(tmp_path: Path) -> Path:
+    """Build a spec dir whose to_home/ has CLAUDE.md + .claude/skills."""
+    spec = tmp_path / "spec"
+    th = spec / "to_home"
+    (th / ".claude" / "skills").mkdir(parents=True)
+    (th / "CLAUDE.md").write_text("## Doctrine\nBe helpful.\n")
+    (th / ".claude" / "skills" / "SKILL.md").write_text("# index")
+    (th / ".claude" / "skills" / "s1.md").write_text("# S1\ndeploy skill body")
+    return spec
+
+
+class TestMaterializeIntegration:
+    def test_materialize_inlines_skill(self, tmp_path):
+        # Arrange
+        spec = _spec_with_skills(tmp_path)
+        home = tmp_path / "home"
+        # Act
+        materialize_to_home(spec, home)
+        # Assert
+        assert "deploy skill body" in (home / "CLAUDE.md").read_text()
+
+    def test_materialize_keeps_generated_section(self, tmp_path):
+        # Arrange
+        spec = _spec_with_skills(tmp_path)
+        home = tmp_path / "home"
+        # Act
+        materialize_to_home(spec, home)
+        # Assert
+        assert "Be helpful." in (home / "CLAUDE.md").read_text()
+
+    def test_redeploy_keeps_single_skills_block(self, tmp_path):
+        # Arrange
+        spec = _spec_with_skills(tmp_path)
+        home = tmp_path / "home"
+        materialize_to_home(spec, home)
+        # Act — re-deploy (marker-protect carries the prior block forward).
+        materialize_to_home(spec, home)
+        # Assert
+        assert (home / "CLAUDE.md").read_text().count(SKILLS_START_MARKER) == 1
+
+    def test_redeploy_preserves_user_tail_and_block(self, tmp_path):
+        # Arrange
+        spec = _spec_with_skills(tmp_path)
+        home = tmp_path / "home"
+        materialize_to_home(spec, home)
+        dst = home / "CLAUDE.md"
+        dst.write_text(dst.read_text() + "\n### usernote\nkeepme\n")
+        # Act
+        materialize_to_home(spec, home)
+        # Assert
+        assert "keepme" in dst.read_text()
+
+    def test_redeploy_user_tail_keeps_single_block(self, tmp_path):
+        # Arrange
+        spec = _spec_with_skills(tmp_path)
+        home = tmp_path / "home"
+        materialize_to_home(spec, home)
+        dst = home / "CLAUDE.md"
+        dst.write_text(dst.read_text() + "\n### usernote\nkeepme\n")
+        # Act
+        materialize_to_home(spec, home)
+        # Assert
+        assert dst.read_text().count(SKILLS_START_MARKER) == 1
+
+
+class TestDeployToHomeIntegration:
+    def _cfg(self, tmp_path: Path) -> tuple[AgentConfig, Path]:
+        spec = _spec_with_skills(tmp_path)
+        cfg = AgentConfig(name="skills-agent")
+        cfg.config_path = str(spec / "spec.yaml")
+        cfg.to_home = ""
+        return cfg, spec
+
+    def test_deploy_inlines_skill(self, tmp_path):
+        # Arrange
+        cfg, _spec = self._cfg(tmp_path)
+        home = tmp_path / "home"
+        # Act
+        deploy_to_home(cfg, str(home))
+        # Assert
+        assert "deploy skill body" in (home / "CLAUDE.md").read_text()
+
+    def test_deploy_is_idempotent(self, tmp_path):
+        # Arrange
+        cfg, _spec = self._cfg(tmp_path)
+        home = tmp_path / "home"
+        deploy_to_home(cfg, str(home))
+        first = (home / "CLAUDE.md").read_text()
+        # Act
+        deploy_to_home(cfg, str(home))
+        # Assert
+        assert (home / "CLAUDE.md").read_text() == first
+
+
+# EOF


### PR DESCRIPTION
## Summary

Implements the operator's "guarantee" (paper-scitex-clew handoff item 5):
because `@`-import and skill-chaining are unreliable triggers, sac now
**forcefully inlines an agent's resolved skill content into its CLAUDE.md at
deploy time**, between idempotent markers, so the skills are always in
context (CLAUDE.md is loaded every turn).

## What changed

- **`runtimes/_to_home_skills.py`** (new) — `aggregate_skills_into_claudemd(workspace_home)`:
  - Reads the agent's now-materialized `*.md` skills under
    `<workspace_home>/.claude/skills/`. (In v3 `spec.skills` is removed and
    skills are *materialized* into the workspace home via `to_home`, not
    bind-mounted — so post-materialization these files ARE the agent's
    resolved skills.)
  - Inlines them into CLAUDE.md wrapped in
    `<!-- sac:skills:start -->` … `<!-- sac:skills:end -->`.
  - **Forceful + idempotent**: each deploy strips any existing block and
    re-renders. This stays correct even though CLAUDE.md is *also*
    marker-protected by `_deploy_marker_protected` (a separate Start/End
    generated-section pair): strip-then-append keeps exactly one skills block
    regardless of how the user-tail carries it forward across re-deploys.
  - No skills → no-op (but a stale block in an existing CLAUDE.md is still
    cleaned up, so removing the last skill self-cleans). Skills present but no
    CLAUDE.md → the canonical root `CLAUDE.md` is created. Targets both
    `CLAUDE.md` and `.claude/CLAUDE.md` when present.
- **`runtimes/_to_home.py`** — `deploy_to_home` and `materialize_to_home`
  call the aggregator after to_home materialization + `fold_envrc_into_env`.
  The overlay twin (`deploy_to_home_overlay`) inherits it. Sibling-module
  split keeps `_to_home.py` near its line ceiling (mirrors `_to_home_text` /
  `_to_home_overlay`).

## Tests (no mocks)

- 26 new tests in `test__to_home_skills.py` — real files on `tmp_path`, real
  `materialize_to_home` / `deploy_to_home` entrypoints. Cover: inlining
  (single/multiple/nested), marker emission, content preservation,
  idempotency (byte-identical re-run, changed-skill refresh, single-block),
  removal cleanup, create-when-absent, both-CLAUDE.md targeting, and
  **marker-protection coexistence across re-deploys + user-tail**.
- AAA `# Arrange`/`# Act`/`# Assert`; one assertion per test.
- No regression: existing to_home suites (93 pass), full runtimes suite
  (976 passed, 14 pre-existing skips).

## Note on the legacy `SkillsSpec`

`config._types.SkillsSpec` (`required`/`available`/`injection_mode="at-import"`)
is parsed but **unconsumed** in the deploy path — the v3 docs confirm
`spec.skills` was removed and at-import was never wired. This PR deliberately
sources skills from the materialized `.claude/skills/` tree (the v3 reality),
not from that vestigial spec field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)