### PR TITLE
release: sync main with develop (resolved content; disjoint-history needs operator merge)

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,10 +1,26 @@
-name: cla
+name: CLA Assistant
+
+# Two trigger paths:
+#   1. PRs from contributors           → CLAssistant action checks signature.
+#                                         allowlist already short-circuits to
+#                                         success for `bot*` and the repo
+#                                         owner, so owner PRs land instantly.
+#   2. Direct pushes / tag pushes      → owner-bypass job posts a synthetic
+#      by the repo owner                  `CLAssistant=success` status on the
+#                                         SHA so the release pipeline's
+#                                         sync-main step (a direct ref PATCH)
+#                                         doesn't get rejected by main's
+#                                         branch-protection rule that requires
+#                                         CLAssistant. Operator-direct: 2026-06-04.
 
 on:
   issue_comment:
     types: [created]
   pull_request_target:
     types: [opened, closed, synchronize]
+  push:
+    branches: [main, develop]
+    tags: ['v*']
 
 permissions:
   actions: write
@@ -13,25 +29,36 @@ permissions:
   statuses: write
 
 jobs:
+  owner-bypass:
+    # Fires only for direct pushes by the repo owner. PR events keep
+    # going through the full CLAssistant action below.
+    if: github.event_name == 'push' && github.actor == 'ywatanabe1989'
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+    steps:
+      - name: Mark CLAssistant=success on this SHA (owner-allowlisted direct push)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          gh api "repos/${REPO}/statuses/${SHA}" \
+            -f state=success \
+            -f context=CLAssistant \
+            -f description="Owner-triggered direct push (CLA bypass per repo allowlist)"
+
   CLAssistant:
+    # PR / comment path — unchanged from the pre-2026-06-04 workflow.
+    if: github.event_name != 'push'
     runs-on: ubuntu-latest
     steps:
       - name: CLA Assistant
         uses: contributor-assistant/github-action@v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # PS-168 §1 (workflow-secret-env-prefix): per-package secrets in
-          # .github/workflows/ must carry the SCITEX_AGENT_CONTAINER_ prefix.
-          # GITHUB_TOKEN above is the GitHub-builtin (cross-cutting, allow-
-          # listed); GH_PERSONAL_ACCESS_TOKEN is a repo-set secret the CLA
-          # assistant needs for writing to the cla-signatures branch on behalf
-          # of external contributors, so it MUST carry the package prefix.
-          # The repo secret must be added under the prefixed name in GitHub
-          # Settings → Secrets → Actions for this workflow to function for
-          # non-allow-listed contributors; ywatanabe1989's own PRs are
-          # allow-listed below and never exercise this token, so a missing
-          # secret is recoverable without breaking maintainer flow.
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.SCITEX_AGENT_CONTAINER_GH_PERSONAL_ACCESS_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
         with:
           path-to-signatures: "signatures/cla.json"
           path-to-document: "https://github.com/ywatanabe1989/scitex-agent-container/blob/main/CLA.md"


### PR DESCRIPTION
## Summary

Resolved-content branch for the blocked release sync **PR #265 "release: sync main with develop"** (base `main`, head `develop`, currently `CONFLICTING`/`DIRTY`).

**Do NOT merge via the GitHub button.** This PR will still display as conflicting — see "Why #265 is conflicting" below. It is provided as a tested, resolved-content artifact for operator review of the final merge mechanic.

## Root cause: disjoint histories (not a content clash)

`origin/main` and `origin/develop` have **no merge base** (the merge-base of the two branches is empty). develop's root commit is an **orphaned squash** (`367ef03a`, "Merge PR #284", 2026-06-01) with zero parents; `main` retains full history from `cf6ef67a` (2026-04-07). Because there is no common ancestor, git/GitHub treat *every* file as a conflict (PR #265 shows +78219/-2301 across 459 files), even though content-wise **develop = main + ~78k lines of new work**.

Of main's commits, only **3 postdate develop's orphan root** (i.e. are genuine main-only changes a plain "take develop" would drop):

| Commit | Subject | Disposition |
|---|---|---|
| `552d416d` | ci(cla): owner-bypass for direct pushes (closes sync-main wedge) | **PRESERVED** (this branch) |
| `caead7e3` | ci(cla): point cla.yml secret at GH_PERSONAL_ACCESS_TOKEN (PS-168) | **PRESERVED** (this branch) |
| `4be3777a` | chore(ci): L1-L5 CI-speedup (#354) — adds pr-ci.yml/release-ci.yml | **flagged, not carried** (see below) |

The other ~1477 main commits all predate 2026-06-01 — they are the pre-orphan shared lineage that develop squashed away.

## What this branch is

`origin/develop` (HEAD `389eff10`) **+ exactly one file**: `.github/workflows/cla.yml` restored to main's version. That CLA file is load-bearing for releases:
- **owner-bypass job** posts a synthetic `CLAssistant=success` status on owner direct pushes/tags so the release sync-main step is not rejected by main's branch-protection rule. Dropping it re-introduces the exact wedge that blocks releases.
- secret pinned to `GH_PERSONAL_ACCESS_TOKEN` — the name that exists on `main` (the sync target).

The diff of this branch against develop is `.github/workflows/cla.yml` only.

## Main-only changes deliberately NOT carried (operator decision)

- **`pr-ci.yml` + `release-ci.yml`** (`4be3777a`, #354): main's newer *consolidated* CI. Left out because develop already ships equivalent *separate* workflows (`pytest-matrix`, `import-smoke`, `scitex-dev-quality-audit`). Shipping both would double-run import-smoke/pytest-matrix on every push+PR. **Recommend** applying the consolidation as its own follow-up PR onto develop, not folding it into a release sync.
- **`_account/claude_usage_parsers.py`** (`e0b6e922`, quota hotfix): superseded by develop's `claude_usage.py`, which already implements the 2026-05-28+ `five_hour`/`seven_day` utilization schema. No functional loss.

## Why this PR also shows "conflicting", and recommended merge mechanic

This branch shares no ancestor with `main` either, so the GitHub merge UI will show the same disjoint-history conflict. The fix is a **history decision**, not more tree-resolution. Recommended options for the operator:

1. **Adopt develop's content as the new main** (matches the orphan-history reality): after review, merge this branch into main with `--allow-unrelated-histories` resolving in this branch's favor (`-X theirs`), or reset main's tree to this branch's tree via a single sync commit. One step; main content becomes identical to this branch.
2. If main's *full pre-2026-06-01 history* must be retained on main, merge with `--allow-unrelated-histories` and keep main's version only for the three flagged main-only paths (already reconciled here except the CI consolidation).

Either way, the content target is this branch's tree.

## Validation (repo `.venv`, Python 3.11)

- `tests/develop/test_audit.py` — **1 passed** (audit-skills/python-apis clean; the only project-audit error was an untracked local `--fakeroot` junk file, not in git, absent in CI)
- `tests/scitex_agent_container/config` — **514 passed**
- `tests/scitex_agent_container/runtimes` — **982 passed, 14 skipped**

Supersedes the content intent of #265; leave #265 open or close in favor of this once a merge mechanic is chosen.
