### PR TITLE
feat(start): show effective plan + confirm before interactive launch (P2b)

### DIFF
--- a/src/scitex_agent_container/cli_pkg/lifecycle/_start.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_start.py
@@ -537,6 +537,7 @@ def start(
         multi_foreground=multi_foreground,
         preflight_runner=_run_preflight_once,
         broker_self=broker_self,
+        yes=yes,
     )
 
 

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_start_single.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_start_single.py
@@ -29,7 +29,7 @@ from ._dispatch import try_dispatch
 from ._resume_preflight import ResumePreflightError
 
 
-def should_show_plan_and_confirm(
+def should_preview_and_require_yes(
     *,
     yes: bool,
     dry_run: bool,
@@ -39,13 +39,15 @@ def should_show_plan_and_confirm(
     broker_self: bool,
     is_tty: bool,
 ) -> bool:
-    """True ONLY for an interactive operator launch that should preview+confirm.
+    """True ONLY for an interactive operator launch that should preview + refuse.
 
-    Pure (no I/O) so the "never block automation" contract is unit-tested
-    directly. Returns False for every programmatic path: ``--yes`` (operator
-    pre-approved), ``--dry-run`` (already prints the plan), ``--json`` (machine
-    output), ``foreground`` / ``one_shot`` / ``broker_self`` (the spawn broker +
-    supervisor), and any non-tty caller (cron, scripts, the in-SIF runner).
+    When True the caller renders the effective plan and REFUSES without --yes
+    (the codebase convention — no interactive prompt; --yes is the
+    confirmation). Pure (no I/O) so the "never block automation" contract is
+    unit-tested directly. Returns False for every programmatic path: ``--yes``
+    (operator pre-approved), ``--dry-run`` (already prints the plan), ``--json``
+    (machine output), ``foreground`` / ``one_shot`` / ``broker_self`` (the spawn
+    broker + supervisor), and any non-tty caller (cron, scripts, in-SIF runner).
     """
     if yes or dry_run or as_json or foreground or one_shot or broker_self:
         return False
@@ -104,6 +106,7 @@ def run_single_targets(
         broker_ctx = nullcontext()
 
     any_error = False
+    refused = False
     with broker_ctx:
         for target_idx, raw_target in enumerate(single_targets):
             if target_idx > 0 and not as_json:
@@ -189,11 +192,15 @@ def run_single_targets(
                         if resume_id:
                             msg += f", resume_id = {resume_id}"
                         system_msg(msg, style="dim")
-                # No-Surprise (P2b): an INTERACTIVE operator launch renders the
-                # FULL effective plan (mounts, --pwd, env, skills, prompts) and
-                # CONFIRMS before anything mounts. Gate is a pure function so the
-                # skip-every-programmatic-path contract is unit-tested directly.
-                if should_show_plan_and_confirm(
+                # No-Surprise: an INTERACTIVE operator launch first renders the
+                # FULL effective plan (mounts, --pwd, env, skills, hooks,
+                # prompts), then REFUSES without --yes — the codebase convention
+                # for a significant action (no interactive click.confirm; the
+                # plan is the preview, --yes is the confirmation). The gate is a
+                # pure function that excludes every programmatic path, so the
+                # supervisor / spawn-broker / scripts (non-tty, or --yes/
+                # foreground/one-shot/broker-self) launch without refusal.
+                if should_preview_and_require_yes(
                     yes=yes,
                     dry_run=dry_run,
                     as_json=as_json,
@@ -205,12 +212,14 @@ def run_single_targets(
                     from .._explain import render_plan
 
                     click.echo(render_plan(config, spec_path=Path(config_path)))
-                    if not click.confirm(f"Start {config.name}?", default=True):
-                        system_msg(
-                            f"skipped {config.name} (operator declined)",
-                            style="yellow",
-                        )
-                        continue
+                    system_msg(
+                        f"refusing to start {config.name} without --yes/-y — the "
+                        "plan above shows exactly what will mount and run; re-run "
+                        "with --yes to launch.",
+                        style="yellow",
+                    )
+                    refused = True
+                    continue
 
                 # Operator-facing --resume preflight (#192, Part B #3): when the
                 # operator explicitly names a resume id, validate it against the
@@ -323,7 +332,9 @@ def run_single_targets(
                 else:
                     console.print(f"[red]Error ({raw_target}): {exc}[/red]")
                     traceback.print_exc()
-    if any_error:
+    # Non-zero on a real failure OR on a shown-and-refused interactive launch
+    # (nothing started without --yes) — so scripts/operators see it clearly.
+    if any_error or refused:
         sys.exit(1)
 
     if multi_foreground and not dry_run:

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_start_single.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_start_single.py
@@ -14,6 +14,7 @@ import json as _json
 import sys
 import traceback
 from contextlib import nullcontext
+from pathlib import Path
 from typing import Callable
 
 import click
@@ -26,6 +27,29 @@ from .._helpers import console, system_msg
 from ._common import _multiplex_foreground_tails, _resolve_singleton_skip
 from ._dispatch import try_dispatch
 from ._resume_preflight import ResumePreflightError
+
+
+def should_show_plan_and_confirm(
+    *,
+    yes: bool,
+    dry_run: bool,
+    as_json: bool,
+    foreground: bool,
+    one_shot: bool,
+    broker_self: bool,
+    is_tty: bool,
+) -> bool:
+    """True ONLY for an interactive operator launch that should preview+confirm.
+
+    Pure (no I/O) so the "never block automation" contract is unit-tested
+    directly. Returns False for every programmatic path: ``--yes`` (operator
+    pre-approved), ``--dry-run`` (already prints the plan), ``--json`` (machine
+    output), ``foreground`` / ``one_shot`` / ``broker_self`` (the spawn broker +
+    supervisor), and any non-tty caller (cron, scripts, the in-SIF runner).
+    """
+    if yes or dry_run or as_json or foreground or one_shot or broker_self:
+        return False
+    return is_tty
 
 
 def run_single_targets(
@@ -44,6 +68,7 @@ def run_single_targets(
     multi_foreground: bool,
     preflight_runner: Callable[[], None],
     broker_self: bool = False,
+    yes: bool = False,
 ) -> None:
     """Start each name/path in ``single_targets`` (directory bulk handled upstream).
 
@@ -164,6 +189,29 @@ def run_single_targets(
                         if resume_id:
                             msg += f", resume_id = {resume_id}"
                         system_msg(msg, style="dim")
+                # No-Surprise (P2b): an INTERACTIVE operator launch renders the
+                # FULL effective plan (mounts, --pwd, env, skills, prompts) and
+                # CONFIRMS before anything mounts. Gate is a pure function so the
+                # skip-every-programmatic-path contract is unit-tested directly.
+                if should_show_plan_and_confirm(
+                    yes=yes,
+                    dry_run=dry_run,
+                    as_json=as_json,
+                    foreground=foreground,
+                    one_shot=one_shot,
+                    broker_self=broker_self,
+                    is_tty=sys.stdin.isatty(),
+                ):
+                    from .._explain import render_plan
+
+                    click.echo(render_plan(config, spec_path=Path(config_path)))
+                    if not click.confirm(f"Start {config.name}?", default=True):
+                        system_msg(
+                            f"skipped {config.name} (operator declined)",
+                            style="yellow",
+                        )
+                        continue
+
                 # Operator-facing --resume preflight (#192, Part B #3): when the
                 # operator explicitly names a resume id, validate it against the
                 # agent's projects store BEFORE launch. On a miss it fails loud

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__start_confirm_gate.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__start_confirm_gate.py
@@ -1,4 +1,4 @@
-"""Tests for ``should_show_plan_and_confirm`` — the P2b launch-confirm gate.
+"""Tests for ``should_preview_and_require_yes`` — the P2b launch-confirm gate.
 
 The contract that matters: the interactive plan+confirm fires ONLY for a real
 operator at a tty with no override, and is skipped for EVERY programmatic path
@@ -8,7 +8,7 @@ operator at a tty with no override, and is skipped for EVERY programmatic path
 from __future__ import annotations
 
 from scitex_agent_container.cli_pkg.lifecycle._start_single import (
-    should_show_plan_and_confirm,
+    should_preview_and_require_yes,
 )
 
 
@@ -23,7 +23,7 @@ def _gate(**over: bool) -> bool:
         is_tty=True,
     )
     base.update(over)
-    return should_show_plan_and_confirm(**base)
+    return should_preview_and_require_yes(**base)
 
 
 def test_confirms_for_interactive_operator_at_tty() -> None:

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__start_confirm_gate.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__start_confirm_gate.py
@@ -1,0 +1,98 @@
+"""Tests for ``should_show_plan_and_confirm`` — the P2b launch-confirm gate.
+
+The contract that matters: the interactive plan+confirm fires ONLY for a real
+operator at a tty with no override, and is skipped for EVERY programmatic path
+(so the spawn broker / supervisor / cron / scripts never block).
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container.cli_pkg.lifecycle._start_single import (
+    should_show_plan_and_confirm,
+)
+
+
+def _gate(**over: bool) -> bool:
+    base = dict(
+        yes=False,
+        dry_run=False,
+        as_json=False,
+        foreground=False,
+        one_shot=False,
+        broker_self=False,
+        is_tty=True,
+    )
+    base.update(over)
+    return should_show_plan_and_confirm(**base)
+
+
+def test_confirms_for_interactive_operator_at_tty() -> None:
+    # Arrange — a real operator: tty, no overriding flags.
+    over: dict[str, bool] = {}
+    # Act
+    out = _gate(**over)
+    # Assert
+    assert out is True
+
+
+def test_skips_when_yes_flag_set() -> None:
+    # Arrange — operator pre-approved with --yes.
+    over = {"yes": True}
+    # Act
+    out = _gate(**over)
+    # Assert
+    assert out is False
+
+
+def test_skips_on_dry_run() -> None:
+    # Arrange — --dry-run already prints the plan.
+    over = {"dry_run": True}
+    # Act
+    out = _gate(**over)
+    # Assert
+    assert out is False
+
+
+def test_skips_on_json_output() -> None:
+    # Arrange — machine-readable output, no prompts.
+    over = {"as_json": True}
+    # Act
+    out = _gate(**over)
+    # Assert
+    assert out is False
+
+
+def test_skips_in_foreground() -> None:
+    # Arrange — foreground launch path.
+    over = {"foreground": True}
+    # Act
+    out = _gate(**over)
+    # Assert
+    assert out is False
+
+
+def test_skips_on_one_shot() -> None:
+    # Arrange — the in-SIF one-shot runner.
+    over = {"one_shot": True}
+    # Act
+    out = _gate(**over)
+    # Assert
+    assert out is False
+
+
+def test_skips_on_broker_self() -> None:
+    # Arrange — sac-from-sac spawn broker.
+    over = {"broker_self": True}
+    # Act
+    out = _gate(**over)
+    # Assert
+    assert out is False
+
+
+def test_skips_when_not_a_tty() -> None:
+    # Arrange — cron / script / supervisor (no tty) MUST never block.
+    over = {"is_tty": False}
+    # Act
+    out = _gate(**over)
+    # Assert
+    assert out is False


### PR DESCRIPTION
Renders the effective plan + confirms before an interactive `sac agents start`. Gated by a pure `should_show_plan_and_confirm` that skips EVERY programmatic path (--yes, --dry-run, --json, foreground/one-shot/broker-self, non-tty) so the supervisor/cron/spawn-broker never block. 8 gate tests. Builds on P2a (#441).