### PR TITLE
fix(to_home): compose marker-merge + feat(explain): show materialized hooks/sections

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_explain.py
+++ b/src/scitex_agent_container/cli_pkg/_explain.py
@@ -105,6 +105,69 @@ def _pwd_is_backed(pwd: str, binds: list[tuple[str, str, str]]) -> bool:
     return False
 
 
+def _hook_label(command: str) -> str:
+    """Readable name for a hook command: the script basename, else the command."""
+    if not command:
+        return command
+    first = command.split()[0]
+    if "/" in first:
+        return first.rsplit("/", 1)[-1]
+    return command[:48]
+
+
+def _materialized_hooks_and_sections(
+    config: AgentConfig,
+) -> tuple[dict[str, list[str]], list[str]]:
+    """Effective hooks + CLAUDE.md section titles the agent will actually get.
+
+    Runs the EXACT production materializers (setup_claude_md → deploy_to_home →
+    setup_settings_json) into a THROWAWAY directory and reads the result back —
+    so the shown set is ground truth (the same merge ``start`` does), with no
+    drift and no writes to the agent's real home. The temp dir is always
+    removed.
+    """
+    import json as _json
+    import shutil
+    import tempfile
+
+    from ..runtimes._to_home import deploy_to_home
+    from ..runtimes.claude_md import setup_claude_md
+    from ..runtimes.settings_json import setup_settings_json
+
+    tmp = tempfile.mkdtemp(prefix="sac-explain-")
+    try:
+        setup_claude_md(config, tmp)
+        deploy_to_home(config, tmp)
+        setup_settings_json(config, tmp, filename="settings.json")
+        claude_dir = Path(tmp) / ".claude"
+
+        hooks: dict[str, list[str]] = {}
+        settings_path = claude_dir / "settings.json"
+        if settings_path.is_file():
+            data = _json.loads(settings_path.read_text())
+            for event, blocks in (data.get("hooks") or {}).items():
+                names = [
+                    _hook_label(h.get("command", ""))
+                    for blk in blocks
+                    for h in blk.get("hooks", [])
+                ]
+                if names:
+                    hooks[event] = names
+
+        sections: list[str] = []
+        claude_md = claude_dir / "CLAUDE.md"
+        if claude_md.is_file():
+            for raw in claude_md.read_text().splitlines():
+                line = raw.strip()
+                if line.startswith("## "):
+                    sections.append(line[3:].strip())
+                elif line.startswith("# ") and not line.startswith("## "):
+                    sections.append(f"{line[2:].strip()} (title)")
+        return hooks, sections
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
 def render_plan(config: AgentConfig, *, spec_path: Path | None = None) -> str:
     """Return the human-readable effective launch plan for ``config``."""
     argv = _argv_for(config)
@@ -179,6 +242,26 @@ def render_plan(config: AgentConfig, *, spec_path: Path | None = None) -> str:
             lines.append(
                 f"  [{idx}] {len(n)} chars / {n.count(chr(10)) + 1} lines{tag}"
             )
+
+    # Hooks + instruction sections that materialize into the agent's $HOME —
+    # the part that used to be invisible. Read back from a throwaway
+    # materialization using the EXACT production materializers (ground truth,
+    # no drift, no writes to the real home). Best-effort: never crash explain.
+    try:
+        hooks, sections = _materialized_hooks_and_sections(config)
+        if hooks:
+            total = sum(len(v) for v in hooks.values())
+            lines.append("")
+            lines.append(f"Hooks (materialized, {total} total):")
+            for event, names in hooks.items():
+                lines.append(f"  {event} ({len(names)}): {', '.join(names)}")
+        if sections:
+            lines.append("")
+            lines.append("Instruction sections ($HOME/.claude/CLAUDE.md):")
+            for title in sections:
+                lines.append(f"  • {title}")
+    except Exception:  # stx-allow: fallback (explain is best-effort; never crash)
+        pass
 
     return "\n".join(lines)
 

--- a/src/scitex_agent_container/runtimes/_to_home.py
+++ b/src/scitex_agent_container/runtimes/_to_home.py
@@ -80,6 +80,7 @@ from ._to_home_text import (
     extract_user_tail,
     interpolate_env,
     interpolate_metadata,
+    split_around_generated_section,
     validate_marker_invariants,
 )
 
@@ -538,21 +539,22 @@ def _deploy_marker_protected(
     new_content = f"{start_tag}\n{section_body}\n{END_MARKER}\n"
 
     existing_text = dst.read_text() if dst.exists() else ""
-    if existing_text.strip():
-        _validate_marker_invariants(existing_text, str(dst))
+    # Preserve content AROUND a prior generated section: the ``head`` BEFORE it
+    # (e.g. the setup_claude_md auto agent-section, which uses its OWN marker
+    # style — so the two now compose instead of fatal-ing when the baseline
+    # lives at .claude/CLAUDE.md) and the ``tail`` AFTER it (operator-appended
+    # content). Malformed markers still fail loud inside the split.
+    head, user_tail = split_around_generated_section(existing_text, str(dst))
 
-    user_tail = _extract_user_tail(dst)
-
-    if END_MARKER not in new_content:
-        # Shouldn't happen — we just wrote END_MARKER — but keep the
-        # safety net so the contract is explicit.
-        updated = new_content
-    elif user_tail:
-        updated = new_content.rstrip("\n") + user_tail
-        if not updated.endswith("\n"):
-            updated += "\n"
+    body = new_content
+    if user_tail.strip():
+        body = body.rstrip("\n") + user_tail
+        if not body.endswith("\n"):
+            body += "\n"
+    if head.strip():
+        updated = head.rstrip("\n") + "\n\n" + body
     else:
-        updated = new_content
+        updated = body
 
     dst.parent.mkdir(parents=True, exist_ok=True)
     _clear_readonly_dst(dst)

--- a/src/scitex_agent_container/runtimes/_to_home_text.py
+++ b/src/scitex_agent_container/runtimes/_to_home_text.py
@@ -39,6 +39,34 @@ def validate_marker_invariants(text: str, source_name: str) -> None:
         )
 
 
+def split_around_generated_section(text: str, source_name: str) -> tuple[str, str]:
+    """Split ``text`` into ``(head, tail)`` around the sac generated section.
+
+    * ``head`` — everything BEFORE the Start marker, preserved verbatim. When
+      the file has NO generated section yet (0 markers) the ENTIRE content is
+      the head: a file that already holds OTHER content — e.g. the
+      ``setup_claude_md`` auto agent-section (which uses its own
+      ``<!-- agent-container:start/end -->`` marker style), or operator-authored
+      text — composes cleanly instead of fatal-ing. This is what lets the
+      baseline live at ``.claude/CLAUDE.md`` next to the auto section.
+    * ``tail`` — everything AFTER the End marker (preserved operator content).
+
+    Malformed markers (duplicate or swapped Start/End) still fail loud via
+    :func:`validate_marker_invariants`.
+    """
+    if not text.strip():
+        return "", ""
+    start_count = text.count(START_MARKER_PREFIX)
+    end_count = text.count(END_MARKER)
+    if start_count == 0 and end_count == 0:
+        head = text if text.endswith("\n") else text + "\n"
+        return head, ""
+    validate_marker_invariants(text, source_name)  # fatals on malformed
+    start = text.find(START_MARKER_PREFIX)
+    end = text.find(END_MARKER) + len(END_MARKER)
+    return text[:start], text[end:]
+
+
 def extract_user_tail(workspace_path: Path) -> str:
     """Return content past the End marker in an existing workspace file.
 

--- a/tests/scitex_agent_container/runtimes/test__to_home_marker_compose.py
+++ b/tests/scitex_agent_container/runtimes/test__to_home_marker_compose.py
@@ -1,0 +1,82 @@
+"""Regression tests for the marker-merge compose fix.
+
+Before the fix, deploying the baseline CLAUDE.md into a file that already held
+the ``setup_claude_md`` auto agent-section (a DIFFERENT marker style, hence
+zero *deploy* markers) raised WorkspaceCLAUDEMarkerError and refused to deploy —
+breaking the ``.claude/CLAUDE.md`` layout AND live agent materialization. The
+merge now PRESERVES that content as a head and appends the generated section.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scitex_agent_container.runtimes._to_home import _deploy_marker_protected
+from scitex_agent_container.runtimes._to_home_errors import (
+    WorkspaceCLAUDEMarkerError,
+)
+from scitex_agent_container.runtimes._to_home_text import (
+    END_MARKER,
+    START_MARKER_PREFIX,
+    split_around_generated_section,
+)
+
+_AUTO_SECTION = (
+    '<!-- agent-container:start id="x" -->\n## Agent: x\n'
+    '<!-- agent-container:end id="x" -->\n'
+)
+
+
+def _gen(body: str = "GEN") -> str:
+    return f"{START_MARKER_PREFIX} (t) -->\n{body}\n{END_MARKER}\n"
+
+
+def test_split_no_deploy_markers_keeps_all_as_head() -> None:
+    # Arrange — a file with the auto agent-section but NO deploy markers.
+    text = _AUTO_SECTION
+    # Act
+    out = split_around_generated_section(text, "<t>")
+    # Assert
+    assert out == (text, "")
+
+
+def test_split_extracts_head_before_generated_section() -> None:
+    # Arrange — operator head + a generated section + tail.
+    text = "HEAD\n" + _gen() + "TAIL\n"
+    # Act
+    head, _tail = split_around_generated_section(text, "<t>")
+    # Assert
+    assert head == "HEAD\n"
+
+
+def test_split_extracts_tail_after_generated_section() -> None:
+    # Arrange
+    text = "HEAD\n" + _gen() + "TAIL\n"
+    # Act
+    _head, tail = split_around_generated_section(text, "<t>")
+    # Assert — everything after the End marker, verbatim (the newline included).
+    assert tail == "\nTAIL\n"
+
+
+def test_split_malformed_duplicate_markers_fails_loud() -> None:
+    # Arrange — two End markers (corruption).
+    text = _gen() + END_MARKER + "\n"
+    # Act
+    ctx = pytest.raises(WorkspaceCLAUDEMarkerError)
+    # Assert
+    with ctx:
+        split_around_generated_section(text, "<t>")
+
+
+def test_deploy_composes_with_existing_auto_section(tmp_path) -> None:
+    # Arrange — target already holds the auto agent-section (the live case);
+    # source is the baseline CLAUDE.md being deployed over it.
+    src = tmp_path / "CLAUDE.md"
+    src.write_text("# Baseline\nsafety rules\n")
+    dst = tmp_path / "out" / "CLAUDE.md"
+    dst.parent.mkdir()
+    dst.write_text(_AUTO_SECTION)
+    # Act — must NOT raise; composes instead.
+    _deploy_marker_protected(src, dst, config=None, rel=tmp_path)
+    # Assert — the pre-existing auto-section survived alongside the new section.
+    assert "## Agent: x" in dst.read_text()


### PR DESCRIPTION
Two related changes:

1. **Root-cause fix** — the CLAUDE.md marker-merge fatal-ed when the target already held the auto agent-section (different marker style). It now composes (preserves head + tail). This unbreaks the `.claude/CLAUDE.md` layout AND live agent materialization (a restart was about to FATAL). 5 regression tests.

2. **Visibility** — `sac agents explain` now shows the previously-hidden hooks (28 PreToolUse, …) + CLAUDE.md instruction sections, read back from a throwaway materialization (ground truth, no drift). Secrets stay redacted.

Full runtimes suite green (989).