### PR TITLE
feat(config): exclude_hooks/exclude_skills — switch off materialized items per agent

### DIFF
--- a/src/scitex_agent_container/config/_loaders.py
+++ b/src/scitex_agent_container/config/_loaders.py
@@ -299,6 +299,8 @@ def load_v3(raw: dict, path: Path) -> AgentConfig:
 
     startup_prompts_raw = spec.get("startup_prompts", []) or []
     startup_prompts = [str(p) for p in startup_prompts_raw if p]
+    exclude_hooks = [str(h) for h in (spec.get("exclude_hooks", []) or []) if h]
+    exclude_skills = [str(s) for s in (spec.get("exclude_skills", []) or []) if s]
 
     kind = str(raw.get("kind", "Agent"))
     proxy_spec = parse_proxy(spec, kind=kind)
@@ -358,6 +360,8 @@ def load_v3(raw: dict, path: Path) -> AgentConfig:
         skills=parse_skills(spec),
         startup_commands=parse_startup_commands(spec),
         startup_prompts=startup_prompts,
+        exclude_hooks=exclude_hooks,
+        exclude_skills=exclude_skills,
         context_management=parse_context_management(spec),
         listen=parse_listen(spec),
         extensions=parse_extensions(spec),

--- a/src/scitex_agent_container/config/_types.py
+++ b/src/scitex_agent_container/config/_types.py
@@ -523,6 +523,12 @@ class AgentConfig:
     # (§3). startup_commands are SHELL commands run BEFORE claude starts;
     # startup_prompts are TEXT fed to claude as the first user message(s).
     startup_prompts: list[str] = field(default_factory=list)
+    # Opt-OUT switches (No-Surprise: see what an agent gets via `sac agents
+    # explain`, then turn specific items off). Each entry is a substring matched
+    # against a materialized hook COMMAND (e.g. "report_to_lead_on_stop" drops
+    # that Stop hook) or a skill @-import path. Empty = nothing excluded.
+    exclude_hooks: list[str] = field(default_factory=list)
+    exclude_skills: list[str] = field(default_factory=list)
     mcp_servers: dict[str, dict] = field(default_factory=dict)
     multiplexer: str = "tmux"  # "tmux" (default) or "screen"
     hosts_spec: HostsSpec = field(default_factory=HostsSpec)

--- a/src/scitex_agent_container/runtimes/claude_md.py
+++ b/src/scitex_agent_container/runtimes/claude_md.py
@@ -309,8 +309,18 @@ def build_skills_lines(config: AgentConfig) -> list[str]:
                 lines.append(f"- {name}: {p}")
         lines.append("")
 
-    _emit_required(config.skills.required)
-    _emit_available(config.skills.available)
+    # Opt-out: drop skills the spec listed in ``exclude_skills`` (substring
+    # match against the skill name) — the operator saw them via
+    # `sac agents explain`, then switched specific ones off.
+    excluded = list(getattr(config, "exclude_skills", []) or [])
+
+    def _keep(names: list[str]) -> list[str]:
+        if not excluded:
+            return names
+        return [n for n in names if not any(p in n for p in excluded)]
+
+    _emit_required(_keep(config.skills.required))
+    _emit_available(_keep(config.skills.available))
     return lines
 
 

--- a/src/scitex_agent_container/runtimes/settings_json.py
+++ b/src/scitex_agent_container/runtimes/settings_json.py
@@ -221,6 +221,44 @@ def _strip_stale_sac_ingest_hooks(hooks: object) -> dict:
     return cleaned
 
 
+def _exclude_hooks(hooks: object, patterns: list[str]) -> dict:
+    """Drop any hook whose command CONTAINS one of ``patterns`` (substring).
+
+    The operator opt-out: after seeing the full materialized hook set via
+    `sac agents explain`, a spec's ``exclude_hooks`` switches specific ones off
+    (e.g. ``report_to_lead_on_stop`` once the lead is retired). A group emptied
+    of all hooks is removed; non-matching hooks and non-hook groups survive.
+    Shares the shape of :func:`_strip_stale_sac_ingest_hooks`.
+    """
+    if not isinstance(hooks, dict):
+        return {}
+    cleaned: dict = {}
+    for ev, groups in hooks.items():
+        if not isinstance(groups, list):
+            cleaned[ev] = groups
+            continue
+        kept_groups: list = []
+        for grp in groups:
+            hk_list = grp.get("hooks") if isinstance(grp, dict) else None
+            if not isinstance(hk_list, list):
+                kept_groups.append(grp)
+                continue
+            kept = [
+                hk
+                for hk in hk_list
+                if not (
+                    isinstance(hk, dict)
+                    and isinstance(hk.get("command"), str)
+                    and any(p in hk["command"] for p in patterns)
+                )
+            ]
+            if kept:
+                kept_groups.append({**grp, "hooks": kept})
+        if kept_groups:
+            cleaned[ev] = kept_groups
+    return cleaned
+
+
 def _mcp_server_names(config: AgentConfig, workdir: str) -> list[str]:
     """Collect MCP server names from config and on-disk .mcp.json."""
     names: set[str] = set()
@@ -441,6 +479,13 @@ def setup_settings_json(
         settings["hooks"] = _merge_hooks_blocks(base_hooks, settings["hooks"])
 
     existing.update(settings)
+
+    # Opt-out: drop hooks the spec listed in ``exclude_hooks`` (No-Surprise —
+    # the operator SAW the full set via `sac agents explain`, then switched
+    # specific ones off). Applied LAST, to the fully-merged hooks.
+    excludes = list(getattr(config, "exclude_hooks", []) or [])
+    if excludes and isinstance(existing.get("hooks"), dict):
+        existing["hooks"] = _exclude_hooks(existing["hooks"], excludes)
 
     settings_path.parent.mkdir(parents=True, exist_ok=True)
     settings_path.write_text(json.dumps(existing, indent=2) + "\n")

--- a/tests/scitex_agent_container/runtimes/test_settings_json.py
+++ b/tests/scitex_agent_container/runtimes/test_settings_json.py
@@ -801,3 +801,34 @@ def test_setup_merge_leaves_single_ingest_command_after_rename():
     assert [h["command"] for g in merged["UserPromptSubmit"] for h in g["hooks"]] == [
         "scitex-agent-container event ingest prompt"
     ]
+
+
+def _hooks_block(*commands: str) -> dict:
+    return {"Stop": [{"matcher": "", "hooks": [{"command": c} for c in commands]}]}
+
+
+def test_exclude_hooks_drops_a_matching_command() -> None:
+    # Arrange — a Stop block with two hooks; exclude one by substring.
+    hooks = _hooks_block("a/report_to_lead_on_stop.sh", "b/keep_me.sh")
+    # Act
+    out = sj_mod._exclude_hooks(hooks, ["report_to_lead"])
+    # Assert
+    assert [h["command"] for g in out["Stop"] for h in g["hooks"]] == ["b/keep_me.sh"]
+
+
+def test_exclude_hooks_keeps_non_matching() -> None:
+    # Arrange
+    hooks = _hooks_block("x/keep_one.sh", "y/keep_two.sh")
+    # Act
+    out = sj_mod._exclude_hooks(hooks, ["telegram"])
+    # Assert
+    assert len(out["Stop"][0]["hooks"]) == 2
+
+
+def test_exclude_hooks_removes_emptied_event() -> None:
+    # Arrange — every hook in the event matches the exclude pattern.
+    hooks = _hooks_block("z/report_to_lead_on_stop.sh")
+    # Act
+    out = sj_mod._exclude_hooks(hooks, ["report_to_lead"])
+    # Assert
+    assert "Stop" not in out


### PR DESCRIPTION
Opt-out half of the visibility work. A spec can now drop specific materialized hooks/skills (substring match): `exclude_hooks: [report_to_lead_on_stop, telegram]`, `exclude_skills: [...]`. Filters the merged hooks last in setup_settings_json + build_skills_lines names. explain reflects it automatically. Concrete use: drop the report-to-lead Stop hook now the lead is retired. Verified 39->29 hooks; tests + audit clean.