### PR TITLE
fix(test): green develop — update stale expectations (restart --yes + settings cascade)

### DIFF
--- a/tests/scitex_agent_container/_mcp/_tools/test___init__.py
+++ b/tests/scitex_agent_container/_mcp/_tools/test___init__.py
@@ -237,7 +237,7 @@ def test_agent_restart_with_name_dispatches_text_argv():
         # Act
         _agent.agent_restart("x")
     # Assert
-    assert captured[-1] == ("text", ["agents", "restart", "x"])
+    assert captured[-1] == ("text", ["agents", "restart", "x", "--yes"])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scitex_agent_container/runtimes/test__to_home_overlay.py
+++ b/tests/scitex_agent_container/runtimes/test__to_home_overlay.py
@@ -185,20 +185,21 @@ class TestDeployToHomeOverlay:
         assert (dest / ".bashrc").read_text() == "export FROM_TO_HOME=1\n"
 
     def test_settings_file_lands_under_claude(self, deployed_overlay):
-        # Arrange
+        # Arrange — the cascade normalizes to the USER-scope name
+        # settings.json (ADR-0018); the overlay home IS the container $HOME.
         _, dest = deployed_overlay
         # Act
         # Assert
-        assert (dest / ".claude" / "settings.local.json").is_file()
+        assert (dest / ".claude" / "settings.json").is_file()
 
     def test_settings_relpath_matches_in_container_path(self, deployed_overlay):
         # Arrange — relative path under upper must match the in-container
-        # /home/agent/.claude/settings.local.json the SDK loads via --settings.
+        # /home/agent/.claude/settings.json the TUI loads at USER scope.
         overlay, dest = deployed_overlay
         # Act
-        rel = (dest / ".claude" / "settings.local.json").relative_to(overlay / "upper")
+        rel = (dest / ".claude" / "settings.json").relative_to(overlay / "upper")
         # Assert
-        assert str(rel) == "home/agent/.claude/settings.local.json"
+        assert str(rel) == "home/agent/.claude/settings.json"
 
     def test_creates_upper_home_dir_when_overlay_absent(self, tmp_path):
         # Arrange — overlay dir doesn't exist yet (apptainer creates upper/


### PR DESCRIPTION
Develop CI went red after `2d9405e7` (config cascade + MCP restart --yes), which landed directly on develop. Two pre-existing tests still asserted the old behaviour:

1. `test___init__::test_agent_restart_with_name_dispatches_text_argv` — expected restart argv without `--yes`; the MCP wrapper now passes `--yes` (an MCP call has no TTY to confirm).
2. `test__to_home_overlay::test_settings_file_lands_under_claude` (+ relpath) — expected `settings.local.json`; the layered cascade (ADR-0018) normalizes the overlay `$HOME` settings to `settings.json` at user scope.

Test-only changes. Both files green locally (68 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)