### PR TITLE
feat(agents): attach verb + loud duplicate-session guard on start

### DIFF
--- a/src/scitex_agent_container/cli_pkg/agent_group.py
+++ b/src/scitex_agent_container/cli_pkg/agent_group.py
@@ -20,6 +20,7 @@ from .agents_prune_claude import archive_claude_bloat as _archive_claude_bloat_i
 from .build_cmds import check as _check_impl
 from .info_cmds import find as _find_impl
 from .info_cmds import tail_session as _tail_impl
+from .lifecycle import attach as _attach_impl
 from .lifecycle import delete as _delete_impl
 from .lifecycle import forget as _forget_impl
 from .lifecycle import restart as _restart_impl
@@ -51,7 +52,7 @@ class _AgentsGroup(HelpRecursiveGroup):
             "Lifecycle",
             ["new", "start", "stop", "restart", "delete", "forget", "spawn-from-here"],
         ),
-        ("Interact", ["send"]),
+        ("Interact", ["send", "attach"]),
         ("Inspect", ["list", "status", "health", "tail", "recall"]),
         ("Preflight", ["check"]),
         ("Discovery", ["find"]),
@@ -97,6 +98,8 @@ agent_group.add_command(_rebind(_find_impl, "find"))
 agent_group.add_command(_rebind(_recall_impl, "recall"))
 agent_group.add_command(_rebind(_check_impl, "check"))
 agent_group.add_command(_rebind(_send_impl, "send"))
+# `attach` — hand the terminal to a running agent's TUI (tmux) session.
+agent_group.add_command(_rebind(_attach_impl, "attach"))
 # `explain` — render the FULL effective launch plan (mounts, --pwd, env,
 # skills, prompts) WITHOUT launching, so the caller sees exactly what
 # `start` will do (No-Surprise). Already named; no _rebind needed.

--- a/src/scitex_agent_container/cli_pkg/lifecycle/__init__.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/__init__.py
@@ -11,6 +11,7 @@ that file outgrew the 512-line project limit. The public surface
     )
 """
 
+from ._attach import attach
 from ._cleanup import cleanup
 from ._delete import delete
 from ._forget import forget
@@ -18,4 +19,4 @@ from ._restart import restart
 from ._start import start
 from ._stop import stop
 
-__all__ = ["start", "stop", "restart", "delete", "forget", "cleanup"]
+__all__ = ["start", "stop", "restart", "delete", "forget", "cleanup", "attach"]

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_attach.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_attach.py
@@ -1,0 +1,74 @@
+"""``sac agents attach <name>`` — attach your terminal to a running agent.
+
+The TUI runtime holds each agent's interactive ``claude`` process in a
+DETACHED tmux session named by :func:`session_name_for` (currently
+``tui-<name>``). This verb resolves that session and hands your terminal to
+``tmux attach`` (via ``execvp``) so you can watch and drive the live agent;
+detach again with the usual tmux keys (``Ctrl-b d``).
+
+Fail-loud: if the agent has no running session, print a red notice with the
+next step (``sac agents start <name>``) and exit non-zero — never silently
+drop into an empty tmux.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+
+import click
+
+from .._helpers._completion import agent_name_complete
+from .._helpers._console import system_msg
+
+
+def _session_for(name: str) -> tuple[str, str]:
+    """Resolve ``(agent_name, tmux_session)`` for ``name``.
+
+    Prefers the canonical name + session from the loaded spec; falls back to
+    the raw name (``tui-<name>``) when the spec can't be resolved, so attach
+    still works for an agent whose spec moved.
+    """
+    try:
+        from ...config import load_config
+        from ...config._resolve import resolve_with_prefix
+        from ...runtimes.tui_session import session_name_for
+
+        config = load_config(resolve_with_prefix(name))
+        return config.name, session_name_for(config)
+    except Exception:  # stx-allow: fallback (best-effort spec resolution)
+        return name, f"tui-{name}"
+
+
+@click.command()
+@click.argument("name", shell_complete=agent_name_complete)
+def attach(name: str) -> None:
+    """Attach your terminal to a running agent's TUI (tmux) session.
+
+    \b
+    Example:
+      $ sac agents attach neurovista     # Ctrl-b d to detach
+    """
+    agent, session = _session_for(name)
+
+    try:
+        exists = (
+            subprocess.run(
+                ["tmux", "has-session", "-t", session],
+                capture_output=True,
+                text=True,
+            ).returncode
+            == 0
+        )
+    except FileNotFoundError:  # stx-allow: fallback (tmux absent → no session)
+        exists = False
+    if not exists:
+        system_msg(
+            f"no running session '{session}' for agent '{agent}'. "
+            f"Start it first: `sac agents start {agent}`.",
+            style="red",
+        )
+        raise SystemExit(1)
+
+    # Hand the terminal to tmux (replaces this process; detach with Ctrl-b d).
+    os.execvp("tmux", ["tmux", "attach", "-t", session])

--- a/src/scitex_agent_container/runtimes/tui_session.py
+++ b/src/scitex_agent_container/runtimes/tui_session.py
@@ -364,6 +364,25 @@ class TuiSessionRuntime(RuntimeBase):
         """
         del no_preflight, foreground, one_shot
         name = session_name_for(config)
+        # Duplicate-session guard: starting an agent whose tmux session already
+        # exists used to fall through to ``tmux new-session`` (which errors
+        # "duplicate session: <name>" in plain text) and then paste the boot
+        # prompt into the ALREADY-running pane (the Ink-drops-Enter mess). Detect
+        # it up front, say so LOUDLY (red), and — outside --force/--dry-run —
+        # no-op idempotently instead of relaunching over a live session. Shown in
+        # --dry-run too (emitted before the dry-run branch below).
+        if self._mux.exists(name) and not force:
+            from ..cli_pkg._helpers._console import system_msg
+
+            system_msg(
+                f"duplicate session '{name}' — agent already running. "
+                f"Attach: `sac agents attach {config.name}` "
+                f"(or `tmux attach -t {name}`). "
+                f"Relaunch: `sac agents restart {config.name}`.",
+                style="red",
+            )
+            if not dry_run:
+                return True
         if force and self._mux.exists(name):
             self._mux.stop(name)
         self.materialize_workspace(config)

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__attach.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__attach.py
@@ -1,0 +1,35 @@
+"""Tests for ``sac agents attach`` (cli_pkg/lifecycle/_attach.py).
+
+``attach`` resolves an agent's tmux session and hands the terminal to
+``tmux attach``. When no session exists it must fail loud (non-zero exit +
+a red notice pointing at ``sac agents start``) rather than dropping into an
+empty tmux. We exercise the no-session path (real ``tmux has-session`` on a
+name that cannot be running, or tmux absent — both resolve to "no session").
+
+STX-NM002: no mocks/monkeypatch. STX-TQ002/TQ007: AAA markers, one fact/test.
+"""
+
+from __future__ import annotations
+
+from click.testing import CliRunner
+
+from scitex_agent_container.cli_pkg.lifecycle._attach import attach
+
+
+def test_attach_no_session_exits_nonzero() -> None:
+    # Arrange
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(attach, ["zzz-not-a-running-agent-zzz"])
+    # Assert
+    assert result.exit_code != 0
+
+
+def test_session_for_falls_back_to_tui_prefix_for_unknown_name() -> None:
+    # Arrange
+    from scitex_agent_container.cli_pkg.lifecycle._attach import _session_for
+
+    # Act
+    _, session = _session_for("zzz-not-a-real-spec-zzz")
+    # Assert
+    assert session == "tui-zzz-not-a-real-spec-zzz"


### PR DESCRIPTION
Two `sac agents` UX fixes the operator hit while driving the fleet.

1. **`sac agents attach <name>`** (new verb) — hands your terminal to a running agent's tmux TUI session (`execvp tmux attach`). Fail-loud (red + non-zero) when there's no session, pointing at `sac agents start`. Previously the only way in was raw `tmux attach -t tui-<name>`.

2. **duplicate-session guard on `start`** — starting an agent whose tmux session already exists used to fall through to `tmux new-session` (raw `duplicate session: <name>` leak) and paste the boot prompt into the live pane. Now it's detected up front, warned LOUDLY in red, and outside `--force`/`--dry-run` no-ops idempotently. Shown in `--dry-run` too.

Tests: `test__attach` (no-session exit + name fallback); tui_session + agent_group + main suites green (73 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)