### PR TITLE
fix(a2a): completion reports + reactions deliver but never wake a turn

### DIFF
--- a/src/scitex_agent_container/_mcp/_channel_wake.py
+++ b/src/scitex_agent_container/_mcp/_channel_wake.py
@@ -32,12 +32,22 @@ def _should_wake_turn(event: dict[str, Any]) -> bool:
       content for the agent to act on; driving a turn on every ack would
       burn a turn (and tokens) per receipt and could ping-pong with the
       auto-ack side-effect.
+    - **infra kinds** (``kind`` in ``completion`` / ``reaction``): a
+      completion report is the END of a request the requester already made
+      — it informs, it is not a new request. Waking a turn on it restarts
+      the cycle: two peers each finish a turn, each Stop hook pushes a
+      completion report that wakes the other, and they ping-pong forever
+      emitting "Holding" (observed 2026-06-24, neurovista ⇆ scitex-writer).
+      Reactions are structural receipts too. Both still DELIVER as a
+      ``<channel>`` notification — they just do not DRIVE a fresh turn.
     - **empty content**: nothing to feed the SDK as turn input.
 
     The notification push (the ``<channel>`` tag) still fires for these in
     the no-wake path — only the turn-driving wake is gated here.
     """
     if event.get("ack"):
+        return False
+    if event.get("kind") in ("completion", "reaction"):
         return False
     content = event.get("content")
     return isinstance(content, str) and content.strip() != ""

--- a/tests/scitex_agent_container/_mcp/test_channel.py
+++ b/tests/scitex_agent_container/_mcp/test_channel.py
@@ -1308,6 +1308,42 @@ def test_should_wake_turn_false_for_empty_content():
     assert decision is False
 
 
+def test_should_wake_turn_false_for_completion_report():
+    """A completion report informs the requester that work it already asked
+    for is done — it is not a new request. Waking a turn on it restarts the
+    cycle and two peers ping-pong forever (neurovista ⇆ scitex-writer,
+    2026-06-24). It must DELIVER but not DRIVE a turn."""
+    # Arrange
+    from scitex_agent_container._mcp.channel import _should_wake_turn
+
+    event = {
+        "from_agent": "bob",
+        "content": '{"agent": "bob", "status": "success"}',
+        "msg_id": "m1",
+        "kind": "completion",
+    }
+    # Act
+    decision = _should_wake_turn(event)
+    # Assert
+    assert decision is False
+
+
+def test_should_wake_turn_false_for_reaction_receipt():
+    # Arrange
+    from scitex_agent_container._mcp.channel import _should_wake_turn
+
+    event = {
+        "from_agent": "bob",
+        "content": "👀",
+        "msg_id": "m1",
+        "kind": "reaction",
+    }
+    # Act
+    decision = _should_wake_turn(event)
+    # Assert
+    assert decision is False
+
+
 def test_wake_text_frames_content_with_source_and_msg_id():
     # Arrange
     from scitex_agent_container._mcp.channel import _wake_text


### PR DESCRIPTION
**Bug (observed 2026-06-24):** two peer agents (`neurovista` ⇄ `scitex-writer`) ping-ponged forever, both just emitting "Holding" and burning tokens.

**Cause:** when a turn finishes, the Stop hook pushes a *completion report* to the requester. That report has non-empty content and no `ack` flag, so `_should_wake_turn` returned True → it **drove a fresh turn** on the other agent → which finished → reported back → loop. The same `dispatch_id`s recurred (it was redelivery/re-wake, not a heartbeat).

**Fix:** `_should_wake_turn` now also skips `kind in (completion, reaction)`. These are receipts of work the requester already asked for — not new requests. They still **deliver** as a `<channel>` notification; they just don't **drive** a turn. The `kind` marker already rides the envelope (`build_completion_report` sets `kind=completion`; `mint_event` propagates it), so no new plumbing.

Tests: 2 new cases (completion + reaction → no wake); channel suite green (65 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)