### PR TITLE
fix(tui): wait-for-idle + verify-by-advancement on boot Enter submit

### DIFF
--- a/src/scitex_agent_container/runtimes/tui_session.py
+++ b/src/scitex_agent_container/runtimes/tui_session.py
@@ -58,8 +58,9 @@ from __future__ import annotations
 import shlex
 import time
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
+from .._lifecycle.liveness_probe import pane_is_busy
 from .._runners._tmux.tmux import (
     TmuxManager,
     TuiInputNotReadyError,
@@ -81,6 +82,7 @@ __all__ = [
     "TuiSessionRuntime",
     "session_name_for",
     "state_dir_for_config",
+    "verify_submit_by_advancement",
 ]
 
 
@@ -115,6 +117,165 @@ def _pane_tail(pane: str, lines: int = 14) -> str:
     """
     rows = [r for r in (pane or "").splitlines() if r.strip()]
     return "\n".join(rows[-lines:])
+
+
+# The ``prompts.detect`` name for a pasted-but-unsent compose buffer
+# (``❯ <text>`` still on the input line). Re-use the existing detector —
+# do not fork the regex. Buffer "advancement" = this name NO LONGER
+# matching (the text was submitted and the input line cleared).
+_COMPOSE_PENDING = "compose-pending-unsent"
+
+
+def _pane_is_input_idle(pane: str) -> bool:
+    """True when the pane is safe to submit an Enter into.
+
+    Input-idle = NOT busy (no spinner / "thinking" word / "esc to
+    interrupt" line — reusing :func:`liveness_probe.pane_is_busy`, the
+    fleet's single source of truth for the busy-marker list) AND the
+    compose input is actually present: either claude's idle ready cue
+    (:func:`prompts.is_ready`) OR a pasted-but-unsent buffer
+    (:func:`prompts.detect` == ``compose-pending-unsent``) is on screen.
+
+    The boot Enter-drop (sac-tui-enter-drop-on-boot) is precisely a
+    submit fired while ``pane_is_busy`` is True (Claude initializing /
+    spinner up / MCP mid-reconnect); the Ink TUI eats Enter in that
+    window. Gating every send on this predicate is the structural fix.
+    """
+    if pane_is_busy(pane):
+        return False
+    return _prompts.is_ready(pane) or _prompts.detect(pane) == _COMPOSE_PENDING
+
+
+def verify_submit_by_advancement(
+    name: str,
+    *,
+    capture_fn: Callable[[str], str],
+    send_keys_fn: Callable[[str], None],
+    max_resends: int = 8,
+    poll_s: float = 0.6,
+    appear_timeout_s: float = 5.0,
+    idle_wait_s: float = 30.0,
+    sleep_fn: Callable[[float], None] = time.sleep,
+    time_fn: Callable[[], float] = time.monotonic,
+) -> bool:
+    """Submit a pasted compose buffer, waiting for idle and verifying by
+    buffer-advancement. Pure + fully injectable — no tmux import.
+
+    This is the fix for the boot Enter-drop (task
+    ``sac-tui-enter-drop-on-boot``). The OLD ``_verify_submitted`` resent
+    Enter ``max_resends`` times back-to-back with only a fixed ``poll_s``
+    sleep — but on (re)start ALL of those resends fire INSIDE the busy /
+    initializing window (spinner ``Photosynthesizing…`` / ``Working…`` /
+    ``Ruminating…`` up, MCP mid-reconnect), where the Ink TUI silently
+    drops every Enter. The agent then sits with its startup_prompt pasted
+    but unsent.
+
+    Algorithm — wait-for-idle + verify-by-advancement, mirroring the
+    proven emacs-claude-code TUI driver cadence (short text→Enter gap,
+    send-verify by buffer advancement, anti-flicker re-capture):
+
+      1. **Wait for the paste to RENDER** as ``compose-pending-unsent``
+         (``capture_fn`` → :func:`prompts.detect`). A multi-line paste
+         takes a beat. If it never renders within ``appear_timeout_s``
+         the turn was either submitted instantly or there was nothing to
+         submit → return ``True`` (nothing to force).
+      2. For up to ``max_resends`` attempts:
+         a. **Wait for input-idle** (:func:`_pane_is_input_idle`): no
+            spinner AND the compose input present. Bounded by
+            ``idle_wait_s``. While waiting, if the buffer ALREADY advanced
+            (no longer ``compose-pending-unsent``) it was submitted →
+            return ``True``. Do NOT send Enter while busy.
+         b. **Send one Enter** (only once idle + still pending).
+         c. **Verify advancement**: poll a short settle; if the buffer is
+            no longer ``compose-pending-unsent`` the Enter landed →
+            return ``True``.
+         d. Otherwise adaptive back-off (settle grows each attempt) and
+            retry — re-checking idle from scratch so the next Enter again
+            only fires into a non-busy pane.
+      3. On exhaustion → fail LOUD (error log with the pane tail +
+         ``tmux attach`` guidance) and return ``False`` (never a silent
+         give-up).
+
+    Returns ``True`` if the buffer was observed to advance (or never
+    rendered as pending), ``False`` if it stayed pending after all
+    bounded attempts.
+    """
+    import logging
+
+    log = logging.getLogger(__name__)
+
+    def _advanced() -> str:
+        """Capture once; return pane text. Buffer 'advanced' iff the
+        returned text no longer detects as compose-pending-unsent."""
+        return capture_fn(name)
+
+    # Phase 1 — wait for the pasted text to appear as an unsent buffer.
+    appear_deadline = time_fn() + appear_timeout_s
+    saw_pending = False
+    last_pane = ""
+    while time_fn() < appear_deadline:
+        last_pane = _advanced()
+        if _prompts.detect(last_pane) == _COMPOSE_PENDING:
+            saw_pending = True
+            break
+        if poll_s > 0:
+            sleep_fn(poll_s)
+    if not saw_pending:
+        return True
+
+    # Phase 2 — bounded resend loop: wait-for-idle, send Enter, verify.
+    for attempt in range(max_resends):
+        # 2a — wait for input-idle (no spinner), bounded by idle_wait_s.
+        # Bail early on advancement (a prior Enter, or the operator,
+        # already submitted) so we never send a stray Enter into the
+        # next, empty prompt.
+        idle_deadline = time_fn() + idle_wait_s
+        idle = False
+        while time_fn() < idle_deadline:
+            last_pane = _advanced()
+            if _prompts.detect(last_pane) != _COMPOSE_PENDING:
+                return True
+            if _pane_is_input_idle(last_pane):
+                idle = True
+                break
+            if poll_s > 0:
+                sleep_fn(poll_s)
+        if not idle:
+            # Still busy after the whole idle window — do NOT blind-fire
+            # Enter (that is the original bug). Loop to the next attempt;
+            # the final failure path below reports loudly if it persists.
+            continue
+
+        # 2b — idle + still pending: send exactly one Enter.
+        send_keys_fn("Enter")
+
+        # 2c — verify advancement with an adaptive settle. Anti-flicker:
+        # re-capture after a short gap; the buffer clears within a frame
+        # or two when the Enter lands.
+        settle = poll_s * (1 + attempt)  # adaptive back-off between attempts
+        verify_deadline = time_fn() + settle
+        while True:
+            if poll_s > 0:
+                sleep_fn(poll_s)
+            last_pane = _advanced()
+            if _prompts.detect(last_pane) != _COMPOSE_PENDING:
+                return True
+            if time_fn() >= verify_deadline:
+                break
+        # 2d — not advanced; loop to next attempt (re-checks idle).
+
+    pane = capture_fn(name)
+    log.error(
+        "TuiSessionRuntime: startup_prompt for %s stayed pasted-but-UNSENT "
+        "after %d wait-for-idle Enter attempts — the Ink TUI keeps dropping "
+        "Enter (or the pane never left BUSY). Attach to inspect/recover: "
+        "`tmux attach -t %s` then press Enter. Pane tail:\n%s",
+        name,
+        max_resends,
+        name,
+        _pane_tail(pane or last_pane),
+    )
+    return False
 
 
 def session_name_for(config: AgentConfig) -> str:
@@ -592,63 +753,26 @@ class TuiSessionRuntime(RuntimeBase):
         max_resends: int = 8,
         poll_s: float = 0.6,
         appear_timeout_s: float = 5.0,
+        idle_wait_s: float = 30.0,
     ) -> bool:
-        """Verify a just-pasted turn was SUBMITTED; resend Enter until it is.
+        """Verify a just-pasted turn was SUBMITTED; resend Enter once idle.
 
-        Two-phase, advancement-driven (the fix the emacs-claude-code TUI
-        driver validated — see ``ecc-send-verification.el``):
-
-          1. **Wait for the paste to RENDER** as an unsent compose buffer
-             (``❯ [Pasted text …]`` → ``prompts.detect == compose-pending-
-             unsent``). A multi-line paste takes a beat to appear; the OLD
-             single early check could run BEFORE it rendered, see the empty
-             prompt, and false-pass ``submitted`` — so no Enter ever reached
-             the composed buffer and the startup_prompt sat unsent forever
-             (proj-scitex-dev 2026-06-23, figrecipe/todo/neurovista earlier).
-          2. **Resend Enter until it CLEARS.** Once we have positively SEEN
-             the pending buffer, a plain Enter submits it; the Ink TUI can
-             still eat one during a re-render, so retry up to ``max_resends``.
-
-        If the buffer never renders as pending within ``appear_timeout_s``
-        (submitted instantly, or nothing to submit) we return True — there is
-        nothing to force. Fail LOUD with the pane tail if it stays pending.
+        Thin wrapper that wires the real tmux callables into the pure,
+        unit-testable :func:`verify_submit_by_advancement` loop. See that
+        function's docstring for the wait-for-idle + verify-by-advancement
+        algorithm (the fix for the boot Enter-drop: the OLD loop fired all
+        ``max_resends`` Enters back-to-back INSIDE the busy/initializing
+        window, where the Ink TUI drops every one — sac-tui-enter-drop-on-boot).
         """
-        import logging
-
-        log = logging.getLogger(__name__)
-
-        # Phase 1 — wait for the pasted text to appear as an unsent buffer.
-        appear_deadline = time.monotonic() + appear_timeout_s
-        saw_pending = False
-        while time.monotonic() < appear_deadline:
-            if _prompts.detect(self._mux.capture_content(name)) == (
-                "compose-pending-unsent"
-            ):
-                saw_pending = True
-                break
-            time.sleep(poll_s)
-        if not saw_pending:
-            return True
-
-        # Phase 2 — the buffer IS pending; resend Enter until it clears.
-        for _ in range(max_resends):
-            self._mux.send_keys(name, "Enter")
-            time.sleep(poll_s)
-            if _prompts.detect(self._mux.capture_content(name)) != (
-                "compose-pending-unsent"
-            ):
-                return True
-        pane = self._mux.capture_content(name)
-        log.error(
-            "TuiSessionRuntime: startup_prompt for %s stayed pasted-but-UNSENT "
-            "after %d Enter resends — the Ink TUI is dropping Enter. Attach: "
-            "`tmux attach -t %s`. Pane tail:\n%s",
+        return verify_submit_by_advancement(
             name,
-            max_resends,
-            name,
-            _pane_tail(pane),
+            capture_fn=self._mux.capture_content,
+            send_keys_fn=lambda key: self._mux.send_keys(name, key),
+            max_resends=max_resends,
+            poll_s=poll_s,
+            appear_timeout_s=appear_timeout_s,
+            idle_wait_s=idle_wait_s,
         )
-        return False
 
     def stop(self, config: AgentConfig) -> bool:
         """Kill the tmux session sac owns for this agent.

--- a/tests/scitex_agent_container/runtimes/test_tui_session_verify_advancement.py
+++ b/tests/scitex_agent_container/runtimes/test_tui_session_verify_advancement.py
@@ -1,0 +1,355 @@
+"""Regression: the boot Enter-drop (sac-tui-enter-drop-on-boot).
+
+On every agent (re)start the boot ``startup_prompt`` was pasted into the
+Claude-Code TUI but never submitted: the submit-Enter fired while Claude
+was still BUSY / initializing (spinner ``Photosynthesizing…`` / ``Working…``
+/ ``Ruminating…`` up, MCP mid-reconnect), and the Ink TUI silently drops
+Enter in that window. The OLD ``_verify_submitted`` resent Enter up to 8x
+back-to-back — but every one of those resends landed INSIDE the same busy
+window, so all 8 dropped and the agent sat idle with its mission pasted
+but unsent.
+
+The fix (:func:`verify_submit_by_advancement`) replaces the blind resend
+with **wait-for-idle + verify-by-advancement**:
+
+  * never send Enter while the pane shows a spinner (gate on
+    :func:`liveness_probe.pane_is_busy`, the fleet's SSOT busy detector);
+  * after sending, verify SUBMISSION by buffer advancement — the
+    ``❯ <text>`` compose buffer cleared (``prompts.detect`` no longer
+    ``compose-pending-unsent``);
+  * bounded attempts, then a fail-loud error with the pane tail.
+
+These tests drive the pure function with REAL fake callables (a scripted
+``capture_fn`` + a recording ``send_keys_fn``) — no MagicMock, no
+monkeypatch-as-fixture-param (PA-306). STX-TQ002 AAA each on its own line,
+STX-TQ007 one assertion per test.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from scitex_agent_container.runtimes.tui_session import (
+    verify_submit_by_advancement,
+)
+
+# ── Realistic pane snapshots ────────────────────────────────────────────────
+# Distilled from live captures (ywata-note-win, 2026-06-20/23). Only the
+# load-bearing glyphs matter to the detectors:
+#   * busy        -> contains a DEFAULT_BUSY_MARKER ("Working…" / "esc to
+#                    interrupt"); pane_is_busy() True.
+#   * pending     -> "❯\xa0<text>" (NBSP gap, as Claude's Ink TUI renders a
+#                    paste); prompts.detect() == "compose-pending-unsent".
+#   * cleared     -> empty "❯ " prompt + "bypass permissions" status bar;
+#                    NOT pending, and is_ready() True.
+
+# Busy AND the paste already sitting in the compose buffer: a submit here
+# would be dropped, so the loop must WAIT (not send Enter).
+_BUSY_WITH_PENDING = (
+    "❯\xa0go work\n  ✻ Photosynthesizing… (Working…  esc to interrupt)\n"
+)
+# Idle, paste still pending: this is the only state where Enter should fire.
+_IDLE_WITH_PENDING = (
+    "❯\xa0go work\n  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents\n"
+)
+# Submitted: the compose line cleared, agent is now at a fresh idle prompt.
+_CLEARED = (
+    "● Working on it.\n"
+    "❯ \n"
+    "  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents\n"
+)
+# Never anything pending (e.g. instant submit / nothing to force).
+_EMPTY_PROMPT = "❯ \n  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents\n"
+
+
+# ── Fakes (real callables, not mocks) ───────────────────────────────────────
+
+
+@dataclass
+class _ScriptedPane:
+    """A ``capture_fn`` that returns a scripted sequence of pane snapshots.
+
+    Each call returns the next snapshot; once the script is exhausted it
+    keeps returning the LAST one (a steady terminal state). Records the
+    number of captures so a test can correlate captures with sends.
+    """
+
+    snapshots: list[str]
+    captures: int = 0
+
+    def __call__(self, _name: str) -> str:
+        idx = min(self.captures, len(self.snapshots) - 1)
+        self.captures += 1
+        return self.snapshots[idx]
+
+
+@dataclass
+class _RecordingSend:
+    """A ``send_keys_fn`` that records every key sent."""
+
+    keys: list[str] = field(default_factory=list)
+
+    def __call__(self, key: str) -> None:
+        self.keys.append(key)
+
+
+class _PendingUntilEnter:
+    """State-machine ``capture_fn``: stays at ``pending`` until ``release``
+    Enters have been recorded by the paired sender, then reports ``cleared``.
+
+    Models the real TUI: the buffer is pasted-but-unsent until an Enter
+    actually LANDS; the ``release`` knob lets a test simulate the Ink TUI
+    eating the first N Enters (drop) before one finally submits.
+    """
+
+    def __init__(
+        self,
+        sender: _RecordingSend,
+        *,
+        pending: str = _IDLE_WITH_PENDING,
+        cleared: str = _CLEARED,
+        release_after: int = 1,
+    ) -> None:
+        self._sender = sender
+        self._pending = pending
+        self._cleared = cleared
+        self._release_after = release_after
+
+    def __call__(self, _name: str) -> str:
+        enters = self._sender.keys.count("Enter")
+        return self._cleared if enters >= self._release_after else self._pending
+
+
+class _BusyThenIdleThenCleared:
+    """State-machine ``capture_fn``: BUSY (with paste pending) for the first
+    ``busy_captures`` reads, then idle-with-pending, then — once one Enter has
+    landed — cleared.
+
+    Mirrors a real (re)start: the spinner is up while Claude initializes
+    (paste already on the input line), so the loop must WAIT; the moment the
+    spinner clears, the single Enter submits.
+    """
+
+    def __init__(self, sender: _RecordingSend, *, busy_captures: int = 1) -> None:
+        self._sender = sender
+        self._busy_captures = busy_captures
+        self._reads = 0
+
+    def __call__(self, _name: str) -> str:
+        if self._sender.keys.count("Enter") >= 1:
+            return _CLEARED
+        self._reads += 1
+        if self._reads <= self._busy_captures:
+            return _BUSY_WITH_PENDING
+        return _IDLE_WITH_PENDING
+
+
+def _no_sleep(_s: float) -> None:
+    return None
+
+
+class _FakeClock:
+    """Monotonic clock that advances by a fixed step on every read.
+
+    Lets idle/verify deadlines expire deterministically without real
+    waits — every ``time_fn()`` call ticks forward, so a bounded loop
+    always terminates.
+    """
+
+    def __init__(self, step: float = 0.1) -> None:
+        self._t = 0.0
+        self._step = step
+
+    def __call__(self) -> float:
+        now = self._t
+        self._t += self._step
+        return now
+
+
+# ── (a) waits while busy: no Enter sent during a spinner ─────────────────────
+
+
+def test_does_not_send_enter_while_pane_is_busy() -> None:
+    # Arrange — pane is busy (spinner up) with the paste pending the whole
+    # time; the idle window expires without ever going idle.
+    capture = _ScriptedPane([_BUSY_WITH_PENDING])
+    sender = _RecordingSend()
+    # Act — bounded so the busy idle-wait elapses across attempts.
+    verify_submit_by_advancement(
+        "tui-x",
+        capture_fn=capture,
+        send_keys_fn=sender,
+        max_resends=2,
+        poll_s=0.0,
+        appear_timeout_s=5.0,
+        idle_wait_s=0.3,
+        sleep_fn=_no_sleep,
+        time_fn=_FakeClock(step=0.1),
+    )
+    # Assert — not a single Enter was sent into the busy window.
+    assert sender.keys == []
+
+
+# ── (b) sends Enter once idle + pending ──────────────────────────────────────
+
+
+def test_sends_enter_once_pane_is_idle_with_pending_buffer() -> None:
+    # Arrange — BUSY (paste pending) for the first frames, then idle; the
+    # single Enter that fires once idle clears the buffer.
+    sender = _RecordingSend()
+    capture = _BusyThenIdleThenCleared(sender, busy_captures=2)
+    # Act
+    ok = verify_submit_by_advancement(
+        "tui-x",
+        capture_fn=capture,
+        send_keys_fn=sender,
+        max_resends=3,
+        poll_s=0.0,
+        appear_timeout_s=5.0,
+        idle_wait_s=5.0,
+        sleep_fn=_no_sleep,
+        time_fn=_FakeClock(step=0.1),
+    )
+    # Assert — exactly one Enter was sent (once idle), and it submitted.
+    assert (ok, sender.keys) == (True, ["Enter"])
+
+
+# ── (c) detects buffer advancement = submitted = stop ────────────────────────
+
+
+def test_returns_true_and_stops_when_buffer_advances_after_enter() -> None:
+    # Arrange — idle+pending immediately; a single Enter clears the buffer.
+    sender = _RecordingSend()
+    capture = _PendingUntilEnter(sender, release_after=1)
+    # Act
+    ok = verify_submit_by_advancement(
+        "tui-x",
+        capture_fn=capture,
+        send_keys_fn=sender,
+        max_resends=8,
+        poll_s=0.0,
+        appear_timeout_s=5.0,
+        idle_wait_s=5.0,
+        sleep_fn=_no_sleep,
+        time_fn=_FakeClock(step=0.1),
+    )
+    # Assert — submission verified by advancement; loop stopped after 1 Enter.
+    assert (ok, len(sender.keys)) == (True, 1)
+
+
+# ── (d) resends when not advanced and now idle ───────────────────────────────
+
+
+def test_resends_enter_when_first_is_dropped_then_idle_again() -> None:
+    # Arrange — the Ink TUI eats the FIRST Enter (buffer stays pending);
+    # the second Enter lands. Pane is idle throughout (no spinner), so the
+    # difference from the busy case is purely the drop-then-resend.
+    sender = _RecordingSend()
+    capture = _PendingUntilEnter(sender, release_after=2)
+    # Act
+    ok = verify_submit_by_advancement(
+        "tui-x",
+        capture_fn=capture,
+        send_keys_fn=sender,
+        max_resends=8,
+        poll_s=0.0,
+        appear_timeout_s=5.0,
+        idle_wait_s=5.0,
+        sleep_fn=_no_sleep,
+        time_fn=_FakeClock(step=0.1),
+    )
+    # Assert — it resent until the buffer advanced (2 Enters), then stopped.
+    assert (ok, sender.keys) == (True, ["Enter", "Enter"])
+
+
+# ── (e) bounded attempts then fail-loud ──────────────────────────────────────
+
+
+def test_fails_loud_and_returns_false_when_buffer_never_advances() -> None:
+    # Arrange — idle+pending but Enter NEVER clears the buffer (release set
+    # impossibly high): the Ink TUI drops every send.
+    sender = _RecordingSend()
+    capture = _PendingUntilEnter(sender, release_after=999)
+    # Act
+    ok = verify_submit_by_advancement(
+        "tui-x",
+        capture_fn=capture,
+        send_keys_fn=sender,
+        max_resends=4,
+        poll_s=0.0,
+        appear_timeout_s=5.0,
+        idle_wait_s=5.0,
+        sleep_fn=_no_sleep,
+        time_fn=_FakeClock(step=0.1),
+    )
+    # Assert — bounded to max_resends attempts, then a fail-loud False.
+    assert (ok, sender.keys.count("Enter")) == (False, 4)
+
+
+def test_bounded_attempts_does_not_exceed_max_resends() -> None:
+    # Arrange — same never-advancing pane, a different cap.
+    sender = _RecordingSend()
+    capture = _PendingUntilEnter(sender, release_after=999)
+    # Act
+    verify_submit_by_advancement(
+        "tui-x",
+        capture_fn=capture,
+        send_keys_fn=sender,
+        max_resends=2,
+        poll_s=0.0,
+        appear_timeout_s=5.0,
+        idle_wait_s=5.0,
+        sleep_fn=_no_sleep,
+        time_fn=_FakeClock(step=0.1),
+    )
+    # Assert — never sends more Enters than the bound allows.
+    assert sender.keys.count("Enter") == 2
+
+
+# ── nothing-to-submit short-circuit ─────────────────────────────────────────
+
+
+def test_returns_true_without_sending_when_nothing_pending() -> None:
+    # Arrange — the paste never renders as a pending buffer (submitted
+    # instantly, or there was nothing to force).
+    capture = _ScriptedPane([_EMPTY_PROMPT])
+    sender = _RecordingSend()
+    # Act
+    ok = verify_submit_by_advancement(
+        "tui-x",
+        capture_fn=capture,
+        send_keys_fn=sender,
+        max_resends=8,
+        poll_s=0.0,
+        appear_timeout_s=0.3,
+        idle_wait_s=5.0,
+        sleep_fn=_no_sleep,
+        time_fn=_FakeClock(step=0.1),
+    )
+    # Assert — nothing to force: True, and no Enter sent.
+    assert (ok, sender.keys) == (True, [])
+
+
+# ── bails on advancement during the idle-wait (operator submitted) ──────────
+
+
+def test_returns_true_when_buffer_advances_before_any_enter() -> None:
+    # Arrange — pending appears, then clears on its own (e.g. the operator
+    # pressed Enter, or a prior turn submitted) BEFORE the loop sends Enter.
+    snapshots = [_IDLE_WITH_PENDING, _CLEARED]
+    capture = _ScriptedPane(snapshots)
+    sender = _RecordingSend()
+    # Act
+    ok = verify_submit_by_advancement(
+        "tui-x",
+        capture_fn=capture,
+        send_keys_fn=sender,
+        max_resends=8,
+        poll_s=0.0,
+        appear_timeout_s=5.0,
+        idle_wait_s=5.0,
+        sleep_fn=_no_sleep,
+        time_fn=_FakeClock(step=0.1),
+    )
+    # Assert — detected advancement, returned True, sent no stray Enter.
+    assert (ok, sender.keys) == (True, [])


### PR DESCRIPTION
## P1: TUI Enter-drop on boot (`sac-tui-enter-drop-on-boot`)

### The bug
On every agent (re)start the boot `startup_prompt` was pasted into the Claude-Code TUI but **never submitted**. The submit-Enter fired while Claude was still **BUSY / initializing** (spinner `Photosynthesizing…` / `Working…` / `Ruminating…` up, MCP mid-reconnect), and the Ink TUI silently **drops Enter** in that window. The old `_verify_submitted` then resent Enter up to 8× — but all 8 resends landed inside the **same busy window**, so every one dropped and the agent sat idle with its mission pasted-but-unsent.

### The fix: wait-for-idle + verify-by-advancement
Replaced the blind resend with a new pure, fully-injectable `verify_submit_by_advancement()`:

1. **Never send Enter while busy.** Every send is gated on `liveness_probe.pane_is_busy` — the fleet's single source of truth for the busy-marker list. No new spinner-word list was forked.
2. **Send exactly one Enter once input-idle** AND the compose buffer is still pending (`prompts.detect == compose-pending-unsent`, or `prompts.is_ready` — both existing detectors reused).
3. **Verify submission by buffer advancement** (the `❯ <text>` compose line cleared), with an adaptive settle between attempts. Bails early if the buffer advanced on its own (operator / prior Enter).
4. **Bounded attempts, then fail-loud** — error log with the pane tail + `tmux attach` recovery guidance. Never a silent give-up.

`_verify_submitted` is now a thin wrapper that wires the real tmux callables into the pure loop, so the send/verify logic is **unit-testable without tmux** via injected `capture_fn` / `send_keys_fn` / `sleep_fn` / `time_fn` seams (real fakes, no mocks/monkeypatch — sac test doctrine).

### Reused vs added (SSOT)
- **Reused (no duplication):** `pane_is_busy` + `DEFAULT_BUSY_MARKERS` (`_lifecycle/liveness_probe.py`); `prompts.detect` / `prompts.is_ready` (`runtimes/prompts.py`).
- **Added:** `_pane_is_input_idle` predicate + `verify_submit_by_advancement` (exported in `__all__`).

### Tests
8 new tests in `test_tui_session_verify_advancement.py` driven by real fake callables:
- (a) waits while busy — **no Enter sent during a spinner**
- (b) sends Enter once idle + pending
- (c) advancement = submitted = stop
- (d) resend when the first Enter is dropped, then idle again
- (e) bounded attempts then fail-loud
- plus nothing-to-submit and advance-before-send short-circuits

Full regression sweep green: **208 passed** across `runtimes` (tui_session, startup_prompt_enter, v2_ready_marker, verify_advancement, prompts), all `_runners/_tmux` (incl. real-tmux smoke), `_lifecycle/liveness_probe`, `_state/_meta/pane`.

### Honest scope note
A TUI-timing fix cannot be fully live-verified from a subagent. The **unit tests prove** the send/verify state machine: it does not send Enter while the pane is busy, sends once idle+pending, stops on verified advancement, resends a dropped Enter once idle again, and fails loud after bounded attempts. What still needs a **live agent-restart** to confirm end-to-end is that the real Claude-Code Ink TUI's busy/idle glyphs match the reused detectors across the boot window (they are the same markers `liveness_probe` and `prompts` already use in production).

### CI caveats (infra/CLA, not this code)
- The scitex self-hosted Spartan runner currently throws transient GPFS `set_output` errors (fast-fails on audit / py3.11).
- CLA-Assistant gate.
- These are infra/CLA, not code issues.
