### PR TITLE
fix(tui): scope boot-submit verify to the live input box (follow-up to #448)

### DIFF
--- a/src/scitex_agent_container/runtimes/tui_session.py
+++ b/src/scitex_agent_container/runtimes/tui_session.py
@@ -55,6 +55,7 @@ runner picks up whatever ``claude`` version the rebuilt SIF provides.
 
 from __future__ import annotations
 
+import re
 import shlex
 import time
 from pathlib import Path
@@ -119,11 +120,29 @@ def _pane_tail(pane: str, lines: int = 14) -> str:
     return "\n".join(rows[-lines:])
 
 
-# The ``prompts.detect`` name for a pasted-but-unsent compose buffer
-# (``❯ <text>`` still on the input line). Re-use the existing detector —
-# do not fork the regex. Buffer "advancement" = this name NO LONGER
-# matching (the text was submitted and the input line cleared).
-_COMPOSE_PENDING = "compose-pending-unsent"
+#: Live compose box = the BOTTOM-MOST ``❯`` row (claude renders it just
+#: above the status bar). Same unsent-text regex as the shared
+#: ``prompts`` detector, but scoped to that one row.
+_COMPOSE_PROMPT_RE = re.compile(r"❯[ \t\xa0]+\S")
+
+
+def _compose_pending_live(pane: str) -> bool:
+    """True iff the LIVE compose box holds pasted-but-unsent text.
+
+    Scopes the ``compose-pending-unsent`` test to the CURRENT input line
+    (the bottom-most ``❯`` row) instead of the whole pane. A ``❯`` sitting
+    in SCROLLBACK — e.g. a submitted ``❯ 1`` echo or the prior turn's
+    rendered prompt — otherwise makes the shared :func:`prompts.detect`
+    report "still pending" forever, so :func:`verify_submit_by_advancement`
+    never sees the buffer clear and false-alarms (the
+    ``sac-tui-enter-drop-on-boot`` live test, 2026-06-24: scitex-dev booted
+    fine yet the drive logged "stayed UNSENT after 8 attempts"). Text after
+    the live ``❯`` = unsent; an empty live box = submitted / ready.
+    """
+    for row in reversed((pane or "").splitlines()):
+        if "❯" in row:
+            return bool(_COMPOSE_PROMPT_RE.search(row))
+    return False
 
 
 def _pane_is_input_idle(pane: str) -> bool:
@@ -143,7 +162,7 @@ def _pane_is_input_idle(pane: str) -> bool:
     """
     if pane_is_busy(pane):
         return False
-    return _prompts.is_ready(pane) or _prompts.detect(pane) == _COMPOSE_PENDING
+    return _prompts.is_ready(pane) or _compose_pending_live(pane)
 
 
 def verify_submit_by_advancement(
@@ -215,7 +234,7 @@ def verify_submit_by_advancement(
     last_pane = ""
     while time_fn() < appear_deadline:
         last_pane = _advanced()
-        if _prompts.detect(last_pane) == _COMPOSE_PENDING:
+        if _compose_pending_live(last_pane):
             saw_pending = True
             break
         if poll_s > 0:
@@ -233,7 +252,7 @@ def verify_submit_by_advancement(
         idle = False
         while time_fn() < idle_deadline:
             last_pane = _advanced()
-            if _prompts.detect(last_pane) != _COMPOSE_PENDING:
+            if not _compose_pending_live(last_pane):
                 return True
             if _pane_is_input_idle(last_pane):
                 idle = True
@@ -258,7 +277,7 @@ def verify_submit_by_advancement(
             if poll_s > 0:
                 sleep_fn(poll_s)
             last_pane = _advanced()
-            if _prompts.detect(last_pane) != _COMPOSE_PENDING:
+            if not _compose_pending_live(last_pane):
                 return True
             if time_fn() >= verify_deadline:
                 break

--- a/tests/scitex_agent_container/runtimes/test_tui_session_verify_advancement.py
+++ b/tests/scitex_agent_container/runtimes/test_tui_session_verify_advancement.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 from scitex_agent_container.runtimes.tui_session import (
+    _compose_pending_live,
     verify_submit_by_advancement,
 )
 
@@ -60,6 +61,18 @@ _CLEARED = (
 )
 # Never anything pending (e.g. instant submit / nothing to force).
 _EMPTY_PROMPT = "❯ \n  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents\n"
+
+# Submitted, but a prior "❯ …" line lingers in SCROLLBACK (e.g. a "❯ 1"
+# echo or the previous turn's rendered prompt). The LIVE box (bottom-most
+# ❯) is empty, so this is NOT pending. The OLD whole-pane detector matched
+# the scrollback ❯ and false-reported "still pending" forever — the
+# sac-tui-enter-drop-on-boot live regression (scitex-dev, 2026-06-24).
+_CLEARED_WITH_SCROLLBACK_PROMPT = (
+    "❯\xa0go work\n"
+    "● Working on it.\n"
+    "❯ \n"
+    "  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents\n"
+)
 
 
 # ── Fakes (real callables, not mocks) ───────────────────────────────────────
@@ -353,3 +366,49 @@ def test_returns_true_when_buffer_advances_before_any_enter() -> None:
     )
     # Assert — detected advancement, returned True, sent no stray Enter.
     assert (ok, sender.keys) == (True, [])
+
+
+# ── (h) regression: a scrollback "❯ …" must not mask a cleared live box ──────
+
+
+def test_compose_pending_live_ignores_scrollback_prompt() -> None:
+    # Arrange — live box empty, but a "❯ …" line remains in scrollback.
+    pane = _CLEARED_WITH_SCROLLBACK_PROMPT
+    # Act
+    pending = _compose_pending_live(pane)
+    # Assert — the live (bottom-most) box is empty, so NOT pending.
+    assert pending is False
+
+
+def test_compose_pending_live_flags_live_unsent_text() -> None:
+    # Arrange — the live (bottom-most) ❯ holds unsent text.
+    pane = _IDLE_WITH_PENDING
+    # Act
+    pending = _compose_pending_live(pane)
+    # Assert
+    assert pending is True
+
+
+def test_advancement_detected_despite_scrollback_prompt() -> None:
+    # Arrange — after the Enter lands the live box clears, but a prior
+    # "❯ …" line lingers in SCROLLBACK. The old whole-pane detector kept
+    # reading "pending" forever and false-failed; the live-box check sees
+    # the submission (the sac-tui-enter-drop-on-boot live fix, 2026-06-24).
+    sender = _RecordingSend()
+    capture = _PendingUntilEnter(
+        sender, cleared=_CLEARED_WITH_SCROLLBACK_PROMPT, release_after=1
+    )
+    # Act
+    ok = verify_submit_by_advancement(
+        "tui-x",
+        capture_fn=capture,
+        send_keys_fn=sender,
+        max_resends=4,
+        poll_s=0.0,
+        appear_timeout_s=5.0,
+        idle_wait_s=5.0,
+        sleep_fn=_no_sleep,
+        time_fn=_FakeClock(step=0.1),
+    )
+    # Assert — submission recognized despite the scrollback ❯.
+    assert ok is True


### PR DESCRIPTION
fix(tui): scope boot-submit verify to the live input box (no false-alarm)

Follow-up to #448. The wait-for-idle + verify-by-advancement boot-submit
landed, but its compose-pending check scanned the WHOLE pane, so a prompt
marker lingering in SCROLLBACK (e.g. a submitted "1" echo) made it read
"still pending" forever — it false-alarmed ("startup_prompt stayed
pasted-but-UNSENT") even when the prompt HAD submitted (scitex-dev live
restart 2026-06-24: the agent booted fine, the drive logged a false fail).

- _compose_pending_live: scope the pending / advancement check to the
  LIVE input box (bottom-most prompt line) instead of the whole buffer.
- 3 regression tests incl. the scrollback case (fail pre-fix, pass after).

Live-verified: scitex-dev restarts clean, no false-alarm. Full runtimes +
tmux suite green (1064 passed). Task: sac-tui-enter-drop-on-boot.
