### PR TITLE
feat(config): default generic startup_prompt when a spec omits it

### DIFF
--- a/src/scitex_agent_container/config/_loaders.py
+++ b/src/scitex_agent_container/config/_loaders.py
@@ -29,6 +29,17 @@ from ._parsers import (
 )
 from ._types import AgentConfig, HostsSpec
 
+# Generic boot-kick used when a spec omits ``startup_prompts``. Role/ID live in
+# the auto-generated $HOME/.claude/CLAUDE.md and the task lives on the agent's
+# scitex-todo card slice, so the boot prompt only needs a generic kick — per-spec
+# restatement of scope/task is the anti-pattern (operator, 2026-06-25). Bare +
+# period (no colon) so it also parses plain in YAML without >-/quotes.
+DEFAULT_STARTUP_PROMPT = (
+    "Start or continue. Scan your scitex-todo card slice, resume any in-flight "
+    "or assigned work (hold idle if none), then report readiness. Follow "
+    "CLAUDE.md + your skills; don't restate, don't invent scope."
+)
+
 # Default workdir layout: sac's own state root. Per-agent runtime state
 # (CLAUDE.md, .mcp.json, .claude/) lives at
 # ``~/.scitex/agent-container/runtime/workspaces/<effective-id>/``. External
@@ -299,6 +310,9 @@ def load_v3(raw: dict, path: Path) -> AgentConfig:
 
     startup_prompts_raw = spec.get("startup_prompts", []) or []
     startup_prompts = [str(p) for p in startup_prompts_raw if p]
+    if not startup_prompts:
+        # DRY default: specs omit startup_prompts and inherit the generic kick.
+        startup_prompts = [DEFAULT_STARTUP_PROMPT]
     exclude_hooks = [str(h) for h in (spec.get("exclude_hooks", []) or []) if h]
     exclude_skills = [str(s) for s in (spec.get("exclude_skills", []) or []) if s]
 

--- a/tests/scitex_agent_container/config/test__loaders.py
+++ b/tests/scitex_agent_container/config/test__loaders.py
@@ -20,6 +20,7 @@ import yaml
 
 from scitex_agent_container.config import load_config
 from scitex_agent_container.config._loaders import (
+    DEFAULT_STARTUP_PROMPT,
     _parse_env_files,
     _resolve_python_venv,
     _resolve_venv,
@@ -525,6 +526,24 @@ def test_load_config_no_warn_for_short_startup_kick(tmp_path: Path):
         load_config(p)
     # Assert
     assert not any("startup_prompts" in str(w.message) for w in rec)
+
+
+def test_load_config_defaults_startup_prompt_when_omitted(tmp_path: Path):
+    # Arrange — a spec with NO startup_prompts inherits the generic sac default.
+    p = _v3_yaml(tmp_path, "nodefault", {})
+    # Act
+    cfg = load_config(p)
+    # Assert
+    assert cfg.startup_prompts == [DEFAULT_STARTUP_PROMPT]
+
+
+def test_load_config_keeps_explicit_startup_prompt_over_default(tmp_path: Path):
+    # Arrange — an explicit startup_prompts must NOT be replaced by the default.
+    p = _v3_yaml(tmp_path, "explicit", {"startup_prompts": ["my own kick"]})
+    # Act
+    cfg = load_config(p)
+    # Assert
+    assert cfg.startup_prompts == ["my own kick"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

`load_config` now injects a generic **default `startup_prompts`** when a spec omits it (`config/_loaders.py`):

> Start or continue. Scan your scitex-todo card slice, resume any in-flight or assigned work (hold idle if none), then report readiness. Follow CLAUDE.md + your skills; don't restate, don't invent scope.

## Why

Per-spec `startup_prompts` that restate role/scope/task are the anti-pattern — role/ID come from the auto-generated `CLAUDE.md` and the task from the agent's scitex-todo card slice. With this default, specs can omit `startup_prompts` entirely (DRY/SSoT). Explicit prompts are preserved unchanged.

## Tests

2 new loader tests (default-when-omitted, explicit-preserved). Full `test__loaders.py`: **51 passed**.

Follow-up: drop the now-redundant per-spec `startup_prompts` from agent specs (they already match this text).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
