### PR TITLE
feat(tui): write heartbeat.json for TUI agents (SDK-runner parity)

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_tui_heartbeat_loop.py
+++ b/src/scitex_agent_container/_lifecycle/_tui_heartbeat_loop.py
@@ -1,0 +1,263 @@
+"""TUI heartbeat writer — first-class liveness parity for ``runtime: tui``.
+
+Operator mandate ("heartbeat must be available in tui as well"): the
+status / observability layer (``agent_status``, ``sac agents list``,
+the board) reads ``heartbeat.json``, which ONLY the SDK runner writes.
+A live TUI agent therefore showed empty ``heartbeat_at`` and status
+``stopped``/gray even while its tmux session was demonstrably alive —
+``TuiSessionRuntime.is_running`` already sees it (tmux session exists
+AND pane-activity within the max-idle window), but that signal never
+reached ``heartbeat.json``.
+
+This module closes that gap with a CENTRALIZED writer in the listen
+server — one async loop, no per-agent sidecar lifecycle to supervise.
+Every tick it:
+
+  1. lists agents whose ``spec.runtime == "tui"`` (the ``agent_lister``
+     seam; production default walks the Registry + on-disk specs);
+  2. for each RUNNING one — its ``tui-<name>`` tmux session exists —
+     reads the session's pane-activity epoch
+     (``TmuxManager.session_activity``);
+  3. writes that agent's ``heartbeat.json`` via the existing
+     :func:`_session_state.write_heartbeat`, stamping ``ts`` with the
+     pane-activity epoch (the SAME liveness signal ``is_running`` keys
+     off) and ``state="running"``.
+
+Sibling of :func:`_github_ci_poll_loop.github_ci_poll_loop`: same
+create-task → sleep-at-boundary → honour-cancellation contract so a
+``sac listen`` SIGTERM doesn't leak the loop.
+
+Resilience (operator: fail-loud, fail-fast, no silent fallbacks):
+
+  * **Per-agent best-effort** — one agent's failure (unresolvable state
+    dir, a tmux probe hiccup) is logged at debug and skipped; it must
+    NOT abort the whole tick (the other live TUI agents still get a
+    fresh beat).
+  * **Per-tick resilience** — a tick-level exception is logged + retried
+    next tick, never fatal.
+  * **Fail-loud on missing tooling** — if ``tmux`` is not installed at
+    all, the loop logs ONE error and disables itself rather than
+    emitting a silent stream of no-ops forever (mirrors the CI poller's
+    ``gh``-missing preflight).
+
+Every collaborator is an injection seam so tests drive the full loop
+deterministically without tmux / a real registry / state-dir IO.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import shutil
+from pathlib import Path
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+# Default cadence. The TUI-alive max-idle window is 300s
+# (``runtimes.tui_session._DEFAULT_MAX_IDLE_S``); beating every ~30s
+# keeps ``heartbeat_at`` comfortably fresh inside that window while
+# costing a handful of cheap ``tmux`` probes per minute. Override via
+# ``SAC_TUI_HEARTBEAT_INTERVAL_S`` at the wiring site.
+DEFAULT_TUI_HEARTBEAT_INTERVAL_S = 30.0
+
+# State written for a live TUI agent. ``running`` mirrors the
+# observability vocabulary the SDK heartbeat uses; the read side
+# (``_session_movement.heartbeat_iso``) only consumes ``ts``, but the
+# field keeps the payload shape consistent for any state-aware consumer.
+_TUI_HEARTBEAT_STATE = "running"
+
+
+def _tmux_available() -> bool:
+    """True iff the ``tmux`` binary is on ``$PATH`` (fail-loud preflight)."""
+    return shutil.which("tmux") is not None
+
+
+def list_tui_agents() -> list[dict]:
+    """Production default for the ``agent_lister`` seam.
+
+    Returns one record per agent whose resolved ``spec.runtime`` is
+    ``"tui"``, each carrying:
+
+      * ``name``      — the agent / spec directory name.
+      * ``state_dir`` — the resolved on-disk state dir (``Path``), or
+        ``None`` when neither the project-scope nor home-scope candidate
+        exists yet. The loop skips ``None`` (nothing to write into).
+
+    No ``pid`` is carried: a TUI agent's real process lives inside the
+    container under tmux and is managed via ``tmux kill-session``, not a
+    host-pid signal (the registry only records the ephemeral, already-dead
+    ``sac agents start`` launcher pid). The heartbeat read side keys off
+    ``ts``, so the loop writes ``pid=0`` rather than a misleading value.
+
+    Sources mirror :func:`cli_pkg._helpers._agent_list.get_agent_list_data`:
+    the runtime Registry first, then specs defined on disk that are not
+    registered. A spec that fails to load contributes nothing (best-effort
+    — one bad YAML never blocks the rest). De-duped by name (registry
+    wins, matching the list command's precedence).
+    """
+    from .._state.registry import Registry
+    from ..config import load_config
+    from ._session_movement import resolve_state_dir
+
+    out: list[dict] = []
+    seen: set[str] = set()
+
+    def _consider(name: str, config_path: str | None) -> None:
+        if not name or name in seen:
+            return
+        if not config_path:
+            return
+        try:
+            cfg = load_config(config_path)
+        except Exception:  # stx-allow: fallback (one bad spec contributes nothing — best-effort enumeration)
+            return
+        if getattr(cfg, "runtime", None) != "tui":
+            return
+        seen.add(name)
+        state_dir = resolve_state_dir(name)
+        if state_dir is None:
+            # Fall back to the runtime's own resolver: a just-started TUI
+            # agent always has its state dir (materialize_workspace made
+            # it), even if the read-side resolver's is-dir probe lost a
+            # race. Best-effort — None stays None if even this fails.
+            try:
+                from ..runtimes.tui_session import state_dir_for_config
+
+                state_dir = state_dir_for_config(cfg)
+            except Exception:  # stx-allow: fallback (resolver import/build may fail in a partial install)
+                state_dir = None
+        out.append({"name": name, "state_dir": state_dir})
+
+    try:
+        for row in Registry().list_all():
+            if not isinstance(row, dict):
+                continue
+            _consider(row.get("name", ""), row.get("config"))
+    except Exception as exc:  # stx-allow: fallback (registry read failure must not blank the on-disk specs below)
+        logger.debug("list_tui_agents: registry enumeration failed: %s", exc)
+
+    # Specs defined on disk but not (yet) in the registry — same source
+    # the list command merges in so an on-disk TUI agent is not missed.
+    try:
+        from ..cli_pkg._helpers._agent_list import _discover_defined_agents
+
+        for name, spec_path in _discover_defined_agents():
+            _consider(name, str(spec_path))
+    except Exception as exc:  # stx-allow: fallback (on-disk discovery is additive; registry rows already captured)
+        logger.debug("list_tui_agents: on-disk spec discovery failed: %s", exc)
+
+    return out
+
+
+def _beat_one(
+    agent: dict,
+    *,
+    session_exists_fn: Callable[[str], bool],
+    activity_fn: Callable[[str], int | None],
+    write_fn: Callable[..., None],
+) -> bool:
+    """Write one TUI agent's heartbeat if its session is live. Best-effort.
+
+    Returns ``True`` iff a heartbeat was written (session exists AND a
+    pane-activity epoch was available), ``False`` otherwise. Never raises
+    — a per-agent failure is logged at debug and swallowed so one bad
+    agent cannot abort the tick.
+    """
+    name = agent.get("name", "")
+    state_dir = agent.get("state_dir")
+    if not name or state_dir is None:
+        return False
+    session_name = f"tui-{name}"
+    try:
+        if not session_exists_fn(session_name):
+            return False
+        activity = activity_fn(session_name)
+        if activity is None:
+            # Session exists but no readable activity stamp — not a live,
+            # responsive TUI (matches is_running's None→False contract).
+            return False
+        write_fn(
+            Path(state_dir),
+            pid=0,
+            state=_TUI_HEARTBEAT_STATE,
+            ts=float(activity),
+        )
+        return True
+    except Exception as exc:  # stx-allow: fallback (per-agent best-effort: one failure must not abort the tick — logged, skipped)
+        logger.debug("tui_heartbeat: beat for %r failed (skipped): %s", name, exc)
+        return False
+
+
+async def tui_heartbeat_loop(
+    *,
+    interval_s: float = DEFAULT_TUI_HEARTBEAT_INTERVAL_S,
+    agent_lister: Any = None,
+    session_exists_fn: Any = None,
+    activity_fn: Any = None,
+    write_fn: Any = None,
+    tmux_check: Any = None,
+) -> None:
+    """Long-running TUI heartbeat-writer task for the listen lifespan.
+
+    Seams (production defaults bound when ``None``): ``agent_lister`` →
+    :func:`list_tui_agents`; ``session_exists_fn`` →
+    :meth:`_runners._tmux.tmux.TmuxManager.exists`; ``activity_fn`` →
+    :meth:`TmuxManager.session_activity`; ``write_fn`` →
+    :func:`_runners._session_state.write_heartbeat`; ``tmux_check`` →
+    :func:`_tmux_available`.
+    """
+    if os.environ.get("SAC_TUI_HEARTBEAT_DISABLED", "") == "1":
+        logger.info("tui_heartbeat_loop: disabled via SAC_TUI_HEARTBEAT_DISABLED")
+        return
+
+    check = tmux_check if tmux_check is not None else _tmux_available
+    if not check():
+        logger.error(
+            "tui_heartbeat_loop: `tmux` is not installed — TUI heartbeat "
+            "writing DISABLED. TUI agents will show empty heartbeat_at on "
+            "this host until tmux is on $PATH. (fail-loud: refusing to run "
+            "a writer that can observe nothing)"
+        )
+        return
+
+    lister = agent_lister if agent_lister is not None else list_tui_agents
+    if session_exists_fn is None or activity_fn is None:
+        from .._runners._tmux.tmux import TmuxManager
+
+        if session_exists_fn is None:
+            session_exists_fn = TmuxManager.exists
+        if activity_fn is None:
+            activity_fn = TmuxManager.session_activity
+    if write_fn is None:
+        from .._runners._session_state import write_heartbeat as write_fn
+
+    logger.info("tui_heartbeat_loop: starting (interval_s=%.1f)", interval_s)
+    try:
+        while True:
+            try:
+                for agent in list(lister()):
+                    _beat_one(
+                        agent,
+                        session_exists_fn=session_exists_fn,
+                        activity_fn=activity_fn,
+                        write_fn=write_fn,
+                    )
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:  # stx-allow: fallback (loop must survive a transient registry/tmux/FS error; logged, retried next tick)
+                logger.warning(
+                    "tui_heartbeat_loop: tick failed (%s); retry next tick", exc
+                )
+            await asyncio.sleep(interval_s)
+    except asyncio.CancelledError:
+        logger.info("tui_heartbeat_loop: cancelled cleanly")
+        raise
+
+
+__all__ = [
+    "DEFAULT_TUI_HEARTBEAT_INTERVAL_S",
+    "list_tui_agents",
+    "tui_heartbeat_loop",
+]

--- a/src/scitex_agent_container/_listen/server.py
+++ b/src/scitex_agent_container/_listen/server.py
@@ -523,6 +523,10 @@ def create_app(*, token: str, local_host: str | None = None) -> Starlette:
         github_ci_poll_loop,
     )
     from .._lifecycle._periodic_drive_loop import periodic_drive_loop
+    from .._lifecycle._tui_heartbeat_loop import (
+        DEFAULT_TUI_HEARTBEAT_INTERVAL_S,
+        tui_heartbeat_loop,
+    )
     from ._self_peer_persistence import persist_self_peers_on_listen_startup
 
     @asynccontextmanager
@@ -555,6 +559,25 @@ def create_app(*, token: str, local_host: str | None = None) -> Starlette:
         )
         app.state.github_ci_poller_task = ci_task
         tasks.append(ci_task)
+        # TUI heartbeat writer (operator: "heartbeat must be available in
+        # tui as well"). Centralized writer so TUI agents get heartbeat.json
+        # parity with the SDK runner and stop showing empty heartbeat_at /
+        # "stopped" while alive. Self-disables (fail-loud) when `tmux` is
+        # missing or SAC_TUI_HEARTBEAT_DISABLED=1, so launch unconditionally.
+        # Cadence override: SAC_TUI_HEARTBEAT_INTERVAL_S.
+        try:
+            _tui_hb_interval = float(
+                _os.environ.get(
+                    "SAC_TUI_HEARTBEAT_INTERVAL_S", DEFAULT_TUI_HEARTBEAT_INTERVAL_S
+                )
+            )
+        except (TypeError, ValueError):
+            _tui_hb_interval = DEFAULT_TUI_HEARTBEAT_INTERVAL_S
+        tui_hb_task = _asyncio.create_task(
+            tui_heartbeat_loop(interval_s=_tui_hb_interval)
+        )
+        app.state.tui_heartbeat_task = tui_hb_task
+        tasks.append(tui_hb_task)
         try:
             yield
         finally:

--- a/src/scitex_agent_container/_runners/_session_state.py
+++ b/src/scitex_agent_container/_runners/_session_state.py
@@ -234,6 +234,7 @@ def write_heartbeat(
     state: str,
     name: str | None = None,
     host: str | None = None,
+    ts: float | None = None,
     db_writer=None,
 ) -> None:
     """Atomically write the heartbeat record to ``heartbeat.json``
@@ -246,6 +247,13 @@ def write_heartbeat(
     accumulated from each ``ResultMessage.usage`` into ``quota.json``.
     This lets the operator see, per agent, how long it has been running
     and how many tokens it has used — straight off the fast-path JSON.
+
+    ``ts`` overrides the recorded heartbeat timestamp (unix seconds);
+    when ``None`` (the SDK-runner default) the current wall-clock is
+    used. The TUI heartbeat writer passes the agent's tmux pane-activity
+    epoch here so ``heartbeat_at`` reflects the SAME liveness signal
+    ``TuiSessionRuntime.is_running`` keys off (rather than the moment
+    the centralized loop happened to observe it).
 
     When the container tmpfs is probeable it also carries
     ``tmp_used_pct`` — the ``/tmp`` fill percentage — so a filling
@@ -264,7 +272,12 @@ def write_heartbeat(
     """
     state_dir.mkdir(parents=True, exist_ok=True)
     now = time.time()
-    payload = {"ts": now, "pid": pid, "state": state}
+    # ``now`` drives the duration-based enrichment (elapsed_s, jsonl
+    # delta-bytes) so those stay honest wall-clock measurements; only
+    # the recorded ``ts`` is overridable so the TUI writer can stamp the
+    # actual pane-activity epoch (the liveness signal it observed).
+    beat_ts = float(ts) if ts is not None else now
+    payload = {"ts": beat_ts, "pid": pid, "state": state}
     payload.update(_heartbeat_usage_fields(state_dir, now))
     payload.update(_tmp_pressure_fields())
     # Operator-requested (feedback_sac_heartbeat_observability):

--- a/tests/scitex_agent_container/_lifecycle/test__tui_heartbeat_loop.py
+++ b/tests/scitex_agent_container/_lifecycle/test__tui_heartbeat_loop.py
@@ -1,0 +1,344 @@
+"""Tests for the centralized TUI heartbeat writer.
+
+Exercises the asyncio task the listen lifespan launches — without real
+tmux / a real registry / state.db — by injecting the ``agent_lister``,
+``session_exists_fn``, ``activity_fn``, ``write_fn`` and ``tmux_check``
+seams. Mirrors test__github_ci_poll_loop.py's create-task → sleep →
+cancel pattern, and writes into real ``tmp_path`` state dirs (no mocks).
+
+STX-TQ002 AAA-markers each on its own line + STX-TQ007 one-assert.
+No mocks/monkeypatch — dependency-injection seams + tmp-dir fixtures.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._lifecycle._session_movement import heartbeat_iso
+from scitex_agent_container._lifecycle._tui_heartbeat_loop import (
+    DEFAULT_TUI_HEARTBEAT_INTERVAL_S,
+    tui_heartbeat_loop,
+)
+
+ISO_8601_UTC_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?\+00:00$")
+
+# Real heartbeat writer under test — the same function the SDK runner
+# uses. Injected as the ``write_fn`` seam so the loop drives the actual
+# atomic write into a tmp state dir (no mock).
+from scitex_agent_container._runners._session_state import write_heartbeat
+
+PINNED_ACTIVITY_TS = 1_750_000_000
+
+
+def _one_tui_agent(state_dir: Path):
+    """Build an ``agent_lister`` seam yielding a single TUI agent."""
+
+    def _lister():
+        return [{"name": "tui-demo", "state_dir": state_dir}]
+
+    return _lister
+
+
+async def _run_one_tick(**kwargs) -> None:
+    """Start the loop, let exactly one tick run, then cancel cleanly."""
+    task = asyncio.create_task(tui_heartbeat_loop(interval_s=0.05, **kwargs))
+    await asyncio.sleep(0.12)
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Core: a live TUI agent gets a valid heartbeat.json (the operator ask).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_loop_writes_heartbeat_json_for_live_tui_agent(tmp_path: Path):
+    # Arrange — a temp state dir + a fresh pane-activity stamp; real writer.
+    state_dir = tmp_path / "tui-demo"
+    state_dir.mkdir()
+    # Act
+    await _run_one_tick(
+        agent_lister=_one_tui_agent(state_dir),
+        session_exists_fn=lambda s: True,
+        activity_fn=lambda s: PINNED_ACTIVITY_TS,
+        write_fn=write_heartbeat,
+        tmux_check=lambda: True,
+    )
+    # Assert
+    assert (state_dir / "heartbeat.json").is_file()
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_json_is_valid_json(tmp_path: Path):
+    # Arrange
+    state_dir = tmp_path / "tui-demo"
+    state_dir.mkdir()
+    # Act
+    await _run_one_tick(
+        agent_lister=_one_tui_agent(state_dir),
+        session_exists_fn=lambda s: True,
+        activity_fn=lambda s: PINNED_ACTIVITY_TS,
+        write_fn=write_heartbeat,
+        tmux_check=lambda: True,
+    )
+    payload = json.loads((state_dir / "heartbeat.json").read_text(encoding="utf-8"))
+    # Assert
+    assert payload["state"] == "running"
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_ts_is_the_pane_activity_epoch(tmp_path: Path):
+    # Arrange — the recorded ts must be the injected pane-activity epoch.
+    state_dir = tmp_path / "tui-demo"
+    state_dir.mkdir()
+    # Act
+    await _run_one_tick(
+        agent_lister=_one_tui_agent(state_dir),
+        session_exists_fn=lambda s: True,
+        activity_fn=lambda s: PINNED_ACTIVITY_TS,
+        write_fn=write_heartbeat,
+        tmux_check=lambda: True,
+    )
+    payload = json.loads((state_dir / "heartbeat.json").read_text(encoding="utf-8"))
+    # Assert
+    assert payload["ts"] == float(PINNED_ACTIVITY_TS)
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_at_renders_as_iso_8601_for_the_read_side(tmp_path: Path):
+    # Arrange — the status read side (heartbeat_iso) must now resolve a
+    # non-empty ISO-8601 stamp for a TUI agent.
+    state_dir = tmp_path / "tui-demo"
+    state_dir.mkdir()
+    # Act
+    await _run_one_tick(
+        agent_lister=_one_tui_agent(state_dir),
+        session_exists_fn=lambda s: True,
+        activity_fn=lambda s: PINNED_ACTIVITY_TS,
+        write_fn=write_heartbeat,
+        tmux_check=lambda: True,
+    )
+    iso = heartbeat_iso(state_dir)
+    # Assert
+    assert ISO_8601_UTC_RE.match(iso) is not None
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_pid_is_zero_for_tui_agent(tmp_path: Path):
+    # Arrange — a TUI agent has no meaningful host pid (managed via
+    # tmux kill-session), so the writer records 0 rather than a stale
+    # launcher pid.
+    state_dir = tmp_path / "tui-demo"
+    state_dir.mkdir()
+    # Act
+    await _run_one_tick(
+        agent_lister=_one_tui_agent(state_dir),
+        session_exists_fn=lambda s: True,
+        activity_fn=lambda s: PINNED_ACTIVITY_TS,
+        write_fn=write_heartbeat,
+        tmux_check=lambda: True,
+    )
+    payload = json.loads((state_dir / "heartbeat.json").read_text(encoding="utf-8"))
+    # Assert
+    assert payload["pid"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Skip cases: no session / no activity → no heartbeat written.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_heartbeat_when_session_absent(tmp_path: Path):
+    # Arrange — agent is listed but its tmux session does not exist.
+    state_dir = tmp_path / "tui-demo"
+    state_dir.mkdir()
+    # Act
+    await _run_one_tick(
+        agent_lister=_one_tui_agent(state_dir),
+        session_exists_fn=lambda s: False,
+        activity_fn=lambda s: PINNED_ACTIVITY_TS,
+        write_fn=write_heartbeat,
+        tmux_check=lambda: True,
+    )
+    # Assert
+    assert not (state_dir / "heartbeat.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_no_heartbeat_when_activity_is_none(tmp_path: Path):
+    # Arrange — session exists but has no readable activity stamp.
+    state_dir = tmp_path / "tui-demo"
+    state_dir.mkdir()
+    # Act
+    await _run_one_tick(
+        agent_lister=_one_tui_agent(state_dir),
+        session_exists_fn=lambda s: True,
+        activity_fn=lambda s: None,
+        write_fn=write_heartbeat,
+        tmux_check=lambda: True,
+    )
+    # Assert
+    assert not (state_dir / "heartbeat.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_probes_the_tui_prefixed_session_name(tmp_path: Path):
+    # Arrange — capture the session name the loop probes; it must be
+    # ``tui-<name>`` (the convention TuiSessionRuntime owns).
+    state_dir = tmp_path / "tui-demo"
+    state_dir.mkdir()
+    probed: list = []
+    # Act
+    await _run_one_tick(
+        agent_lister=_one_tui_agent(state_dir),
+        session_exists_fn=lambda s: probed.append(s) or True,
+        activity_fn=lambda s: PINNED_ACTIVITY_TS,
+        write_fn=write_heartbeat,
+        tmux_check=lambda: True,
+    )
+    # Assert
+    assert "tui-tui-demo" in probed
+
+
+# ---------------------------------------------------------------------------
+# Resilience + lifecycle (mirror the CI poller's contract).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_one_agent_failure_does_not_block_a_second_agent(tmp_path: Path):
+    # Arrange — first agent's write blows up; second must still be written.
+    good_dir = tmp_path / "tui-good"
+    good_dir.mkdir()
+
+    def _lister():
+        return [
+            {"name": "boom", "state_dir": tmp_path / "tui-boom"},
+            {"name": "good", "state_dir": good_dir},
+        ]
+
+    def _write(state_dir, **kwargs):
+        if "boom" in str(state_dir):
+            raise RuntimeError("simulated per-agent write failure")
+        write_heartbeat(state_dir, **kwargs)
+
+    # Act
+    await _run_one_tick(
+        agent_lister=_lister,
+        session_exists_fn=lambda s: True,
+        activity_fn=lambda s: PINNED_ACTIVITY_TS,
+        write_fn=_write,
+        tmux_check=lambda: True,
+    )
+    # Assert
+    assert (good_dir / "heartbeat.json").is_file()
+
+
+@pytest.mark.asyncio
+async def test_loop_disabled_when_tmux_missing_writes_nothing(tmp_path: Path):
+    # Arrange — fail-loud preflight: no tmux → loop returns immediately.
+    state_dir = tmp_path / "tui-demo"
+    state_dir.mkdir()
+    # Act — returns at once (no infinite loop), so await directly.
+    await tui_heartbeat_loop(
+        agent_lister=_one_tui_agent(state_dir),
+        session_exists_fn=lambda s: True,
+        activity_fn=lambda s: PINNED_ACTIVITY_TS,
+        write_fn=write_heartbeat,
+        tmux_check=lambda: False,
+    )
+    # Assert
+    assert not (state_dir / "heartbeat.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_loop_disabled_via_env_var_writes_nothing(tmp_path: Path):
+    # Arrange — explicit env save/restore (no monkeypatch, PA-306).
+    import os as _os
+
+    state_dir = tmp_path / "tui-demo"
+    state_dir.mkdir()
+    key = "SAC_TUI_HEARTBEAT_DISABLED"
+    saved = _os.environ.get(key)
+    _os.environ[key] = "1"
+    # Act
+    try:
+        await tui_heartbeat_loop(
+            agent_lister=_one_tui_agent(state_dir),
+            session_exists_fn=lambda s: True,
+            activity_fn=lambda s: PINNED_ACTIVITY_TS,
+            write_fn=write_heartbeat,
+            tmux_check=lambda: True,
+        )
+    finally:
+        if saved is None:
+            _os.environ.pop(key, None)
+        else:
+            _os.environ[key] = saved
+    # Assert
+    assert not (state_dir / "heartbeat.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_loop_survives_a_tick_exception_then_cancels_cleanly(tmp_path: Path):
+    # Arrange — a lister that raises must NOT kill the loop (logged + retried).
+    def boom():
+        raise RuntimeError("transient registry blip")
+
+    task = asyncio.create_task(
+        tui_heartbeat_loop(
+            interval_s=0.05,
+            agent_lister=boom,
+            session_exists_fn=lambda s: True,
+            activity_fn=lambda s: PINNED_ACTIVITY_TS,
+            write_fn=write_heartbeat,
+            tmux_check=lambda: True,
+        )
+    )
+    # Act — let the failing tick run, then cancel.
+    await asyncio.sleep(0.12)
+    task.cancel()
+    # Assert — the loop swallowed the tick error and stayed alive, so
+    # cancellation (not the RuntimeError) is what surfaces.
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+@pytest.mark.asyncio
+async def test_loop_honours_cancellation_cleanly(tmp_path: Path):
+    # Arrange
+    task = asyncio.create_task(
+        tui_heartbeat_loop(
+            interval_s=0.05,
+            agent_lister=lambda: [],
+            session_exists_fn=lambda s: True,
+            activity_fn=lambda s: PINNED_ACTIVITY_TS,
+            write_fn=write_heartbeat,
+            tmux_check=lambda: True,
+        )
+    )
+    # Act
+    await asyncio.sleep(0.06)
+    task.cancel()
+    # Assert — the finally must re-raise CancelledError, not swallow it.
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+@pytest.mark.asyncio
+async def test_default_interval_is_thirty_seconds():
+    # Arrange — guard the documented cadence default.
+    # Act
+    value = DEFAULT_TUI_HEARTBEAT_INTERVAL_S
+    # Assert
+    assert value == 30.0


### PR DESCRIPTION
## Problem

TUI-mode agents (`spec.runtime: tui`) never wrote `heartbeat.json` — only
the SDK runner did. The status/observability layer reads that file, so a
live TUI agent showed an empty `heartbeat_at` and status **stopped**/gray
in `sac agents status`, `sac agents list`, and the board — even while its
tmux session was demonstrably alive (`TuiSessionRuntime.is_running` already
sees it: session exists + pane-activity within the 300s window).

Operator: *"heartbeat must be available in tui as well."*

## Approach

A **centralized** heartbeat writer in the `sac listen` server — one async
loop, no per-agent sidecar lifecycle to supervise. Every ~30s it:

1. lists agents whose resolved `spec.runtime == "tui"`;
2. for each RUNNING one (its `tui-<name>` tmux session exists) reads the
   pane-activity epoch via `TmuxManager.session_activity`;
3. writes that agent's `heartbeat.json` via the existing
   `write_heartbeat(...)`, stamping `ts` with the pane-activity epoch (the
   **same** signal `is_running` keys off) and `state="running"`.

Structured as a sibling of the CI poll loop: same env-disable check,
fail-loud preflight, lazy seam-binding, per-tick try/except, and
cancellation honoured at the sleep boundary.

## Changes

- **`_lifecycle/_tui_heartbeat_loop.py`** (new): the async loop +
  `list_tui_agents()` production default (walks the Registry + on-disk
  specs, filters `runtime == "tui"`, resolves each `state_dir` the same
  way the read side does). Per-agent best-effort (one failure never aborts
  the tick); fail-loud + self-disable when `tmux` is entirely missing
  (logged once); honours `SAC_TUI_HEARTBEAT_DISABLED` /
  `SAC_TUI_HEARTBEAT_INTERVAL_S`. A TUI agent has no meaningful host pid
  (managed via `tmux kill-session`, not a signal), so the writer records
  `pid=0` rather than a stale launcher pid.
- **`_listen/server.py`**: `create_task(tui_heartbeat_loop(...))` wired
  into the listen lifespan next to `periodic_drive_loop` /
  `github_ci_poll_loop`, matching the existing interval-config +
  cancellation pattern.
- **`_runners/_session_state.py`**: `write_heartbeat` gains an optional
  `ts=` override (defaults to wall-clock — full backward-compat for the
  SDK runner) so the TUI writer records the actual pane-activity epoch.
  Duration-based enrichment (`elapsed_s`, jsonl delta) still uses
  wall-clock; the state.db diary write stays suppressed for the TUI loop
  (JSON-only, no name/host → no surprise rows).

## Tests (scitex doctrine)

DI seams (no mocks/monkeypatch), AAA markers each on its own line, one
assert per test, strict-asyncio. The core test: a live TUI agent gets a
valid `heartbeat.json` whose `ts` is the injected pane-activity epoch and
which `heartbeat_iso` renders as ISO-8601 (injecting the activity-reader +
the agent-lister as functions). Plus: skip when session absent / activity
`None`; probes the `tui-<name>` session; per-agent failure isolation;
tmux-missing + env-var disable; tick-exception survival; clean
cancellation.

Result: new suite **14 passed**; existing `_session_movement` /
`_github_ci_poll_loop` / `_heartbeat_fields` / state.db-heartbeats
**65 passed** (signature change is backward-compatible); listen
`test_server.py` **63 passed** (lifespan wiring exercised via TestClient).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
