### PR TITLE
feat(acl): group-based a2a ACL + developer-group full authority

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_spawn_gate.py
+++ b/src/scitex_agent_container/_lifecycle/_spawn_gate.py
@@ -60,9 +60,14 @@ def persist_acl_policy(config: Any, db_path: Path | None = None) -> None:
     so ``read_comms_policy`` always finds a row for any started agent.
     """
     from .._state.state_db_nodes import record_comms_policy
+    from ..config._group_resolver import group_from_labels
 
     comms = config.comms
     lineage = config.lineage
+    # Named group (operator 2026-06-25): metadata.labels.group, else
+    # role-derived (developer-ish roles → "developer"). Persisted here so
+    # the ACL check can read it by node name at send/spawn/manage time.
+    group_name = group_from_labels(getattr(config, "labels", None))
     record_comms_policy(
         name=config.name,
         outbound_siblings=comms.outbound.siblings,
@@ -71,6 +76,7 @@ def persist_acl_policy(config: Any, db_path: Path | None = None) -> None:
         inbound_parent=comms.inbound.parent,
         lineage_group=lineage.group,
         may_spawn=lineage.may_spawn,
+        group_name=group_name,
         db_path=db_path,
     )
 

--- a/src/scitex_agent_container/_listen/_acl.py
+++ b/src/scitex_agent_container/_listen/_acl.py
@@ -42,8 +42,10 @@ from starlette.types import ASGIApp, Receive, Scope, Send
 from .._state.state_db_nodes import (
     derive_group,
     has_grant,
+    is_developer,
     read_comms_policy,
     resolve_node_token,
+    same_named_group,
     sender_target_relationship,
     spawn_allowed,
 )
@@ -81,6 +83,10 @@ def check_lineage_acl(
       * ``caller == target`` — self-management. A SAC agent
         managing its OWN runtime (e.g. ``sac agents status`` on
         itself) is always allowed regardless of lineage.
+      * ``caller`` is in the ``developer`` group (operator
+        2026-06-25) — full agent-CRUD authority over ANY target,
+        independent of lineage. See
+        :func:`_state.state_db_nodes.is_developer`.
       * ``target ∈ descendants_of(caller)`` — caller is a
         transitive ancestor; lineage-scoped operation permitted.
       * Otherwise — deny with a structured reason naming the
@@ -100,6 +106,13 @@ def check_lineage_acl(
         return ("allow", None)
     if caller == target:
         return ("allow", None)
+    # Developer group full authority (operator 2026-06-25): a caller in
+    # the ``developer`` group may manage ANY agent (stop / restart /
+    # delete / status / tail), not just its lineage descendants. Checked
+    # before the descendant walk so developer-group CRUD never depends on
+    # a lineage edge to the target.
+    if is_developer(name=caller, db_path=db_path):
+        return ("allow", None)
     from .._state._lineage import descendants_of
 
     descendants = descendants_of(name=caller, db_path=db_path)
@@ -110,8 +123,9 @@ def check_lineage_acl(
         (
             f"lineage ACL deny: caller {caller!r} has no lineage edge "
             f"to target {target!r}. Permitted operations are self "
-            "(caller == target) or any transitive descendant via the "
-            "lineage table."
+            "(caller == target), any transitive descendant via the "
+            "lineage table, or any target when the caller is in the "
+            "developer group."
         ),
     )
 
@@ -199,7 +213,16 @@ def check_send_acl(
     2. **Cross-group is denied by default.** The effective sender
        (authenticated_node, or claimed_from_agent for an
        administrative caller) must share a group with the target.
-       Same-name (self-send) is trivially allowed.
+       Same-name (self-send) is trivially allowed. Two group notions
+       are honoured, either of which permits the send:
+
+         * the lineage-derived group mesh (parent↔child / sibling↔
+           sibling) via :func:`_state.state_db_nodes.derive_group`, and
+         * the NAMED group (operator 2026-06-25): sender and target
+           resolve to the same non-empty ``metadata.labels.group`` /
+           role-derived group via
+           :func:`_state.state_db_nodes.same_named_group`.
+
     3. **Explicit cross-group grants flip a deny to allow** — see
        :func:`_state.state_db_nodes.grant_send`.
     4. The empty-sender case (no authenticated node AND no claimed
@@ -268,6 +291,17 @@ def check_send_acl(
 
     sender_group = derive_group(name=sender, db_path=db_path)
     if target in sender_group:
+        return ("allow", None)
+
+    # Named-group mesh (operator 2026-06-25): a send is allowed when
+    # sender and target resolve to the SAME non-empty NAMED group
+    # (``metadata.labels.group`` / role-derived). This is the
+    # "group-mesh by default" that replaces "per-pair grant by default"
+    # for grouped fleets — e.g. every ``developer``-group agent may
+    # address every other ``developer``-group agent with no per-pair
+    # grant. Additive: an ungrouped fleet shares no named group and
+    # falls through to the explicit-grant check below, unchanged.
+    if same_named_group(sender=sender, target=target, db_path=db_path):
         return ("allow", None)
 
     if has_grant(sender=sender, target=target, db_path=db_path):
@@ -371,9 +405,26 @@ def check_spawn(
     as :func:`check_send_acl` so the listen-server handler can branch
     uniformly.
 
-    Current policy: root-only spawn. ``caller=None`` is the
-    administrative / human-operator path (allowed).
+    Policy:
+
+      * ``caller=None`` — administrative / human-operator path (allowed
+        by :func:`spawn_allowed`).
+      * **Developer group full authority (operator 2026-06-25)** — a
+        caller whose resolved NAMED group is ``developer`` may spawn
+        regardless of the root-only default. Checked BEFORE the
+        root-only gate so a developer child (non-root) is still allowed.
+      * Otherwise the default root-only policy (a node with no lineage
+        parent may spawn; a child may not).
+
+    The developer bypass deliberately does NOT override a per-spec
+    ``spec.lineage.may_spawn=false`` deny by *not consulting it*: a
+    developer caller is granted authority by the group policy here. A
+    deployment that needs an agent which still cannot spawn should keep
+    it out of the developer group (and rely on the root-only +
+    ``may_spawn`` gates in :func:`spawn_allowed`).
     """
+    if caller and is_developer(name=caller, db_path=db_path):
+        return ("allow", None)
     allowed, reason = spawn_allowed(caller=caller, db_path=db_path)
     if allowed:
         return ("allow", None)

--- a/src/scitex_agent_container/_state/state_db.py
+++ b/src/scitex_agent_container/_state/state_db.py
@@ -52,6 +52,7 @@ from .state_db_migrations import (
     migrate_instance_heartbeats_add_seq,
     migrate_instances_add_family_tree_cols,
     migrate_legacy_heartbeats,
+    migrate_node_comms_policy_add_group_name,
 )
 
 DEFAULT_DB_PATH = Path(
@@ -313,6 +314,12 @@ CREATE INDEX IF NOT EXISTS idx_comms_nodes_host ON comms_nodes(host);
 -- Defaults match the dataclass defaults (everything "allow", may_spawn=1,
 -- lineage_group=""), so absence of a row is byte-equivalent to the
 -- pre-Phase-3 group-default ACL.
+-- ``group_name`` (operator 2026-06-25): the agent's NAMED group, resolved
+-- at agent_start from metadata.labels.group (else role-derived; the
+-- developer-ish roles default to 'developer'). Read at ACL-check time so
+-- a same-named-group send is allowed (full mesh within a group) and the
+-- 'developer' group gets full agent-CRUD authority. Default '' (ungrouped)
+-- keeps absence byte-equivalent to the pre-group-name behaviour.
 CREATE TABLE IF NOT EXISTS node_comms_policy (
     name              TEXT PRIMARY KEY,
     outbound_siblings TEXT NOT NULL DEFAULT 'allow',
@@ -321,6 +328,7 @@ CREATE TABLE IF NOT EXISTS node_comms_policy (
     inbound_parent    TEXT NOT NULL DEFAULT 'allow',
     lineage_group     TEXT NOT NULL DEFAULT '',
     may_spawn         INTEGER NOT NULL DEFAULT 1,
+    group_name        TEXT NOT NULL DEFAULT '',
     updated_at        REAL NOT NULL
 );
 """
@@ -425,6 +433,10 @@ def init_schema(db_path: Path | None = None) -> Path:
         # DB (with the family-tree columns) but is a no-op on an
         # existing one; the migration ADD COLUMNs them onto a pre-cols DB.
         migrate_instances_add_family_tree_cols(conn)
+        # Same idempotent ADD COLUMN for the group-based-ACL ``group_name``
+        # column on a pre-existing ``node_comms_policy`` (operator
+        # 2026-06-25). No-op on a fresh DB (DDL already has the column).
+        migrate_node_comms_policy_add_group_name(conn)
         conn.executescript(_SCHEMA_ATTEMPTS)
         conn.executescript(_SCHEMA_DIARY)
         # Task #27 — ACL block/unblock flow tables. Both CREATE TABLE

--- a/src/scitex_agent_container/_state/state_db_acl_policy.py
+++ b/src/scitex_agent_container/_state/state_db_acl_policy.py
@@ -83,6 +83,10 @@ DEFAULT_COMMS_POLICY: dict[str, Any] = {
     "inbound_parent": "allow",
     "lineage_group": "",
     "may_spawn": True,
+    # Group-based ACL (operator 2026-06-25): the agent's NAMED group.
+    # "" (ungrouped) is the default; absence is byte-equivalent to the
+    # pre-group-name behaviour (same-group allow needs a non-empty match).
+    "group_name": "",
 }
 
 
@@ -95,6 +99,7 @@ def record_comms_policy(
     inbound_parent: str = "allow",
     lineage_group: str = "",
     may_spawn: bool = True,
+    group_name: str = "",
     db_path: Path | None = None,
 ) -> None:
     """Upsert the Phase-3 per-spec ACL policy for ``name``.
@@ -111,32 +116,28 @@ def record_comms_policy(
         raise ValueError("record_comms_policy: name must be non-empty")
     if outbound_siblings not in ("allow", "deny"):
         raise ValueError(
-            f"outbound_siblings must be 'allow' or 'deny', got "
-            f"{outbound_siblings!r}"
+            f"outbound_siblings must be 'allow' or 'deny', got {outbound_siblings!r}"
         )
     if outbound_parent not in ("allow", "deny"):
         raise ValueError(
-            f"outbound_parent must be 'allow' or 'deny', got "
-            f"{outbound_parent!r}"
+            f"outbound_parent must be 'allow' or 'deny', got {outbound_parent!r}"
         )
     if inbound_siblings not in ("allow", "deny"):
         raise ValueError(
-            f"inbound_siblings must be 'allow' or 'deny', got "
-            f"{inbound_siblings!r}"
+            f"inbound_siblings must be 'allow' or 'deny', got {inbound_siblings!r}"
         )
     if inbound_parent not in ("allow", "deny"):
         raise ValueError(
-            f"inbound_parent must be 'allow' or 'deny', got "
-            f"{inbound_parent!r}"
+            f"inbound_parent must be 'allow' or 'deny', got {inbound_parent!r}"
         )
     if lineage_group not in ("", "solitary"):
         raise ValueError(
             f"lineage_group must be '' or 'solitary', got {lineage_group!r}"
         )
     if not isinstance(may_spawn, bool):
-        raise ValueError(
-            f"may_spawn must be a bool, got {type(may_spawn).__name__}"
-        )
+        raise ValueError(f"may_spawn must be a bool, got {type(may_spawn).__name__}")
+    if not isinstance(group_name, str):
+        raise ValueError(f"group_name must be a str, got {type(group_name).__name__}")
     from .state_db import open_db
 
     now = time.time()
@@ -145,8 +146,8 @@ def record_comms_policy(
             "INSERT INTO node_comms_policy ("
             "name, outbound_siblings, outbound_parent, "
             "inbound_siblings, inbound_parent, lineage_group, "
-            "may_spawn, updated_at"
-            ") VALUES (?, ?, ?, ?, ?, ?, ?, ?) "
+            "may_spawn, group_name, updated_at"
+            ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) "
             "ON CONFLICT(name) DO UPDATE SET "
             "outbound_siblings=excluded.outbound_siblings, "
             "outbound_parent=excluded.outbound_parent, "
@@ -154,6 +155,7 @@ def record_comms_policy(
             "inbound_parent=excluded.inbound_parent, "
             "lineage_group=excluded.lineage_group, "
             "may_spawn=excluded.may_spawn, "
+            "group_name=excluded.group_name, "
             "updated_at=excluded.updated_at",
             (
                 name,
@@ -163,6 +165,7 @@ def record_comms_policy(
                 inbound_parent,
                 lineage_group,
                 1 if may_spawn else 0,
+                group_name.strip(),
                 now,
             ),
         )
@@ -186,7 +189,8 @@ def read_comms_policy(
     with open_db(db_path) as conn:
         row = conn.execute(
             "SELECT outbound_siblings, outbound_parent, "
-            "inbound_siblings, inbound_parent, lineage_group, may_spawn "
+            "inbound_siblings, inbound_parent, lineage_group, may_spawn, "
+            "group_name "
             "FROM node_comms_policy WHERE name = ?",
             (name,),
         ).fetchone()
@@ -199,6 +203,7 @@ def read_comms_policy(
         "inbound_parent": str(row["inbound_parent"]),
         "lineage_group": str(row["lineage_group"]),
         "may_spawn": bool(row["may_spawn"]),
+        "group_name": str(row["group_name"]),
     }
 
 
@@ -235,12 +240,8 @@ def sender_target_relationship(
         target_parent_row = conn.execute(
             "SELECT parent_name FROM lineage WHERE child_name = ?", (target,)
         ).fetchone()
-    sender_parent = (
-        str(sender_parent_row["parent_name"]) if sender_parent_row else None
-    )
-    target_parent = (
-        str(target_parent_row["parent_name"]) if target_parent_row else None
-    )
+    sender_parent = str(sender_parent_row["parent_name"]) if sender_parent_row else None
+    target_parent = str(target_parent_row["parent_name"]) if target_parent_row else None
     if sender_parent == target:
         return "parent"
     if target_parent == sender:

--- a/src/scitex_agent_container/_state/state_db_migrations.py
+++ b/src/scitex_agent_container/_state/state_db_migrations.py
@@ -15,6 +15,9 @@ every :func:`state_db.init_schema`.
   * :func:`migrate_instances_add_family_tree_cols` — ADD COLUMN the
     sac-agent-spawn family-tree columns (``bound_port``, ``remote``,
     ``spawned_by``) onto a pre-existing ``instances`` table.
+  * :func:`migrate_node_comms_policy_add_group_name` — ADD COLUMN the
+    ``group_name`` column (group-based ACL, operator 2026-06-25) onto a
+    pre-existing ``node_comms_policy`` table.
 """
 
 from __future__ import annotations
@@ -137,3 +140,39 @@ def migrate_instances_add_family_tree_cols(conn: sqlite3.Connection) -> None:
         conn.execute("ALTER TABLE instances ADD COLUMN remote INTEGER DEFAULT 0")
     if "spawned_by" not in cols:
         conn.execute("ALTER TABLE instances ADD COLUMN spawned_by TEXT")
+
+
+def migrate_node_comms_policy_add_group_name(conn: sqlite3.Connection) -> None:
+    """ADD the ``group_name`` column to ``node_comms_policy``.
+
+    Group-based ACL (operator 2026-06-25): the per-agent NAMED group,
+    resolved at ``agent_start`` from ``metadata.labels.group`` (else
+    role-derived). A fresh DB gets the column from the ``CREATE TABLE``
+    DDL in :mod:`state_db`; this migration is for an EXISTING
+    ``node_comms_policy`` table created before the column existed.
+
+    ``ALTER TABLE ... ADD COLUMN`` with a ``DEFAULT ''`` backfills every
+    pre-existing row to "ungrouped", which is byte-equivalent to the
+    pre-group-name behaviour (the ACL same-group allow requires a
+    NON-EMPTY match).
+
+    Detection: ``node_comms_policy`` exists AND lacks ``group_name``.
+    Idempotent: a no-op once the column is present (or the table is
+    absent).
+    """
+    existing = {
+        r[0]
+        for r in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+    }
+    if "node_comms_policy" not in existing:
+        return
+    cols = {
+        r[1] for r in conn.execute("PRAGMA table_info(node_comms_policy)").fetchall()
+    }
+    if "group_name" in cols:
+        return
+    conn.execute(
+        "ALTER TABLE node_comms_policy ADD COLUMN group_name TEXT NOT NULL DEFAULT ''"
+    )

--- a/src/scitex_agent_container/_state/state_db_nodes.py
+++ b/src/scitex_agent_container/_state/state_db_nodes.py
@@ -57,6 +57,7 @@ __all__ = [
     "derive_group",
     "grant_send",
     "has_grant",
+    "is_developer",
     "is_local_node",
     "list_comms_grants",
     "list_comms_nodes",
@@ -67,9 +68,11 @@ __all__ = [
     "record_comms_policy",
     "record_lineage",
     "register_comms_node",
+    "resolve_group_name",
     "resolve_node_host",
     "resolve_node_token",
     "revoke_send",
+    "same_named_group",
     "sender_target_relationship",
     "spawn_allowed",
     "unregister_comms_node",
@@ -259,6 +262,72 @@ def derive_group(
         for r in sibling_rows:
             group.add(str(r["child_name"]))
         return group
+
+
+# ---------------------------------------------------------------------------
+# named groups (operator 2026-06-25) — a SECOND grouping axis layered on
+# top of the lineage-derived group mesh above. The group NAME is resolved
+# at agent_start from ``metadata.labels.group`` (else role-derived) and
+# persisted in ``node_comms_policy.group_name``; these readers apply it at
+# ACL-check time. Pure DB reads — the resolver itself is in
+# :mod:`scitex_agent_container.config._group_resolver`.
+# ---------------------------------------------------------------------------
+
+
+def resolve_group_name(
+    *,
+    name: str,
+    db_path: Path | None = None,
+) -> str:
+    """Return ``name``'s persisted NAMED group, or ``""`` if ungrouped.
+
+    Reads ``node_comms_policy.group_name`` (written at ``agent_start``
+    from the resolved ``metadata.labels.group`` / role default). An
+    agent with no policy row, or a row with an empty ``group_name``,
+    is "ungrouped" and shares a named group with no one.
+    """
+    if not name:
+        return ""
+    policy = read_comms_policy(name=name, db_path=db_path)
+    return str(policy.get("group_name", "") or "")
+
+
+def same_named_group(
+    *,
+    sender: str,
+    target: str,
+    db_path: Path | None = None,
+) -> bool:
+    """Return ``True`` iff ``sender`` and ``target`` share a NAMED group.
+
+    Both groups must be NON-EMPTY and equal. Two ungrouped agents
+    (empty group) do NOT match — that keeps absence byte-equivalent to
+    the pre-group-name behaviour (an ungrouped fleet falls through to
+    the lineage-mesh + explicit-grant ACL exactly as before).
+    """
+    sender_group = resolve_group_name(name=sender, db_path=db_path)
+    if not sender_group:
+        return False
+    target_group = resolve_group_name(name=target, db_path=db_path)
+    return target_group == sender_group
+
+
+def is_developer(
+    *,
+    name: str,
+    db_path: Path | None = None,
+) -> bool:
+    """Return ``True`` iff ``name``'s resolved NAMED group is ``developer``.
+
+    The developer group has FULL AUTHORITY (operator 2026-06-25):
+    members may CRUD agents (spawn / start / stop / restart / delete)
+    and CRUD the ACL (grant / revoke). The spawn + lineage ACL gates
+    consult this to short-circuit their default (root-only / lineage-
+    descendant) checks.
+    """
+    from ..config._group_resolver import is_developer_group
+
+    return is_developer_group(resolve_group_name(name=name, db_path=db_path))
 
 
 # ---------------------------------------------------------------------------

--- a/src/scitex_agent_container/config/_group_resolver.py
+++ b/src/scitex_agent_container/config/_group_resolver.py
@@ -1,0 +1,144 @@
+"""Named-group resolver for the group-based a2a ACL (operator 2026-06-25).
+
+A SECOND grouping axis layered on top of the existing lineage-derived
+group mesh (:func:`scitex_agent_container._state.state_db_nodes.derive_group`):
+
+  * Each agent has a NAMED group. Source of truth is the spec label
+    ``metadata.labels.group``.
+  * When the ``group`` label is ABSENT, the group is *derived from the
+    role* (``metadata.labels.role`` / ``CLAUDE_AGENT_ROLE``): the
+    developer-ish roles — ``project-maintainer`` / ``maintainer`` /
+    ``dev-agent`` / ``contributor`` (and their project-suffixed forms,
+    e.g. ``contributor-figrecipe``) — resolve to the group
+    :data:`DEVELOPER_GROUP`. So every existing dev agent joins
+    ``developer`` with NO spec edit; an explicit ``labels.group``
+    always overrides the role default.
+  * Anything else (no group label, non-developer / absent role) →
+    the empty string ``""`` — "ungrouped". An ungrouped agent never
+    shares a NAMED group with anyone (the ACL same-group allow is
+    gated on a non-empty match), so absence is byte-equivalent to the
+    pre-existing behaviour.
+
+This module is PURE (no DB, no I/O) — string in, string out — so it is
+trivially testable without fixtures. The persistence half (writing the
+resolved group into ``node_comms_policy`` at ``agent_start`` and reading
+it back at ACL-check time) lives in
+:mod:`scitex_agent_container._state.state_db_acl_policy` /
+:mod:`scitex_agent_container._state.state_db_nodes`.
+
+The developer-role set deliberately mirrors the long-lived-coordinator
+set in :mod:`._session_continuity` (the same ``project-maintainer`` /
+``maintainer`` / ``dev-agent`` / ``contributor`` strings the operator
+named), but is kept SEPARATE: continuity is "does this role keep its
+conversation across restarts", group-authority is "does this role
+belong to the developer group". The two policies happen to overlap
+today but answer different questions and must be free to diverge.
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "DEVELOPER_GROUP",
+    "group_from_labels",
+    "is_developer_group",
+    "resolve_group",
+]
+
+
+# The single privileged group name. Members get full agent-CRUD +
+# ACL-CRUD authority (see :func:`._listen._acl.check_spawn` /
+# ``check_lineage_acl``).
+DEVELOPER_GROUP = "developer"
+
+
+# Exact role strings (case-insensitive) that default to the developer
+# group when no explicit ``labels.group`` is set. Operator-specified
+# 2026-06-25.
+_DEVELOPER_ROLES: frozenset[str] = frozenset(
+    {
+        "project-maintainer",
+        "maintainer",
+        "dev-agent",
+        "contributor",
+    }
+)
+
+# Role PREFIXES that also map to the developer group even when the role
+# is project-suffixed — e.g. ``contributor-figrecipe``,
+# ``dev-agent-clew``, ``maintainer-scitex``. Mirrors the
+# project-suffix convention the continuity resolver already honours.
+_DEVELOPER_ROLE_PREFIXES: tuple[str, ...] = (
+    "project-maintainer-",
+    "maintainer-",
+    "dev-agent-",
+    "contributor-",
+)
+
+
+def _role_is_developer(role: str | None) -> bool:
+    """Return True iff ``role`` is a developer-ish role.
+
+    Case-insensitive, whitespace-trimmed. Matches the exact role set
+    or any project-suffixed prefix. ``None`` / empty → False.
+    """
+    if not role:
+        return False
+    norm = str(role).strip().lower()
+    if not norm:
+        return False
+    if norm in _DEVELOPER_ROLES:
+        return True
+    return norm.startswith(_DEVELOPER_ROLE_PREFIXES)
+
+
+def resolve_group(*, group_label: str | None, role: str | None) -> str:
+    """Resolve an agent's NAMED group from its group label + role.
+
+    Precedence (operator 2026-06-25):
+
+      1. An explicit, non-empty ``group_label`` wins verbatim
+         (whitespace-trimmed) — the operator can name ANY group, not
+         just ``developer``.
+      2. Otherwise, if ``role`` is developer-ish, the group is
+         :data:`DEVELOPER_GROUP`.
+      3. Otherwise, the empty string ``""`` (ungrouped).
+
+    Returns a plain ``str`` (never ``None``). An empty return means
+    "no named group" — the ACL same-group allow is gated on a
+    NON-EMPTY match, so an ungrouped agent shares a named group with
+    no one (absence is a no-op, fully backward-compatible).
+    """
+    if group_label is not None:
+        trimmed = str(group_label).strip()
+        if trimmed:
+            return trimmed
+    if _role_is_developer(role):
+        return DEVELOPER_GROUP
+    return ""
+
+
+def group_from_labels(labels: dict[str, str] | None) -> str:
+    """Resolve the named group from a spec's ``metadata.labels`` dict.
+
+    Convenience wrapper over :func:`resolve_group` that pulls the
+    ``group`` and ``role`` keys out of the labels mapping. A missing /
+    ``None`` labels dict yields ``""`` (ungrouped).
+    """
+    if not labels:
+        return ""
+    return resolve_group(
+        group_label=labels.get("group"),
+        role=labels.get("role"),
+    )
+
+
+def is_developer_group(group: str | None) -> bool:
+    """Return True iff ``group`` is the privileged developer group.
+
+    Case-insensitive on the resolved group name. ``None`` / empty →
+    False. Used by the spawn / lineage ACL gates to grant the
+    developer group full agent-CRUD authority.
+    """
+    if not group:
+        return False
+    return str(group).strip().lower() == DEVELOPER_GROUP

--- a/tests/scitex_agent_container/_listen/test__acl_group.py
+++ b/tests/scitex_agent_container/_listen/test__acl_group.py
@@ -1,0 +1,204 @@
+"""Group-based a2a ACL + developer-group authority (operator 2026-06-25).
+
+The ACL-enforcement half of the group feature, exercised at the
+:mod:`scitex_agent_container._listen._acl` decision functions:
+
+* ``check_send_acl`` — a send between two members of the SAME named
+  group is allowed (full mesh) even with NO lineage edge and NO grant;
+  a cross-group send (different groups, no lineage, no grant) is denied;
+  an explicit grant still flips that cross-group deny to allow
+  (backward-compatible).
+* ``check_spawn`` — a developer-group caller may spawn even though it is
+  a (non-root) child, bypassing the root-only default; a non-developer
+  child is still denied.
+* ``check_lineage_acl`` — a developer-group caller may manage ANY agent
+  (stop / restart / delete / status / tail), not just its lineage
+  descendants; a non-developer caller with no lineage edge is denied.
+
+Groups are seeded via ``record_comms_policy(group_name=...)`` — the same
+row ``agent_start`` writes from the resolved spec label. No mocks: real
+on-disk SQLite via the yield-based ``db_path`` env override.
+
+AAA (each marker on its own line), one assertion per test.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._listen._acl import (
+    check_lineage_acl,
+    check_send_acl,
+    check_spawn,
+)
+from scitex_agent_container._state import state_db
+from scitex_agent_container._state.state_db_nodes import (
+    grant_send,
+    record_comms_policy,
+    record_lineage,
+)
+
+
+@pytest.fixture
+def db_path(tmp_path: Path):
+    # Arrange
+    db = tmp_path / "state.db"
+    saved_env = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB")
+    saved_default = state_db.DEFAULT_DB_PATH
+    os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
+    state_db.DEFAULT_DB_PATH = db
+    state_db.init_schema(db)
+    try:
+        yield db
+    finally:
+        state_db.DEFAULT_DB_PATH = saved_default
+        if saved_env is None:
+            os.environ.pop("SCITEX_AGENT_CONTAINER_STATE_DB", None)
+        else:
+            os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = saved_env
+
+
+# ---------------------------------------------------------------------------
+# check_send_acl — named-group mesh
+# ---------------------------------------------------------------------------
+
+
+def test_send_allowed_within_same_named_group(db_path: Path) -> None:
+    """Same named group, no lineage edge, no grant → allow (full mesh)."""
+    # Arrange
+    record_comms_policy(name="alice", group_name="developer", db_path=db_path)
+    record_comms_policy(name="bob", group_name="developer", db_path=db_path)
+    # Act
+    decision, _reason = check_send_acl(
+        authenticated_node="alice",
+        claimed_from_agent="alice",
+        target="bob",
+        db_path=db_path,
+    )
+    # Assert
+    assert decision == "allow"
+
+
+def test_send_denied_cross_group_without_grant(db_path: Path) -> None:
+    """Different named groups, no lineage, no grant → deny."""
+    # Arrange
+    record_comms_policy(name="alice", group_name="developer", db_path=db_path)
+    record_comms_policy(name="carol", group_name="analysts", db_path=db_path)
+    # Act
+    decision, _reason = check_send_acl(
+        authenticated_node="alice",
+        claimed_from_agent="alice",
+        target="carol",
+        db_path=db_path,
+    )
+    # Assert
+    assert decision == "deny"
+
+
+def test_cross_group_deny_carries_cross_group_reason(db_path: Path) -> None:
+    # Arrange
+    record_comms_policy(name="alice", group_name="developer", db_path=db_path)
+    record_comms_policy(name="carol", group_name="analysts", db_path=db_path)
+    # Act
+    _decision, reason = check_send_acl(
+        authenticated_node="alice",
+        claimed_from_agent="alice",
+        target="carol",
+        db_path=db_path,
+    )
+    # Assert
+    assert reason is not None and "cross-group" in reason
+
+
+def test_send_allowed_cross_group_with_explicit_grant(db_path: Path) -> None:
+    """An explicit grant still flips a cross-group deny to allow."""
+    # Arrange
+    record_comms_policy(name="alice", group_name="developer", db_path=db_path)
+    record_comms_policy(name="carol", group_name="analysts", db_path=db_path)
+    grant_send(sender="alice", target="carol", db_path=db_path)
+    # Act
+    decision, _reason = check_send_acl(
+        authenticated_node="alice",
+        claimed_from_agent="alice",
+        target="carol",
+        db_path=db_path,
+    )
+    # Assert
+    assert decision == "allow"
+
+
+def test_ungrouped_pair_still_denied_without_grant(db_path: Path) -> None:
+    """Two ungrouped agents do not share a named group → legacy deny."""
+    # Arrange — no group_name on either; unrelated lineage families.
+    record_lineage(child="x", parent="root-x", db_path=db_path)
+    record_lineage(child="y", parent="root-y", db_path=db_path)
+    # Act
+    decision, _reason = check_send_acl(
+        authenticated_node="x",
+        claimed_from_agent="x",
+        target="y",
+        db_path=db_path,
+    )
+    # Assert
+    assert decision == "deny"
+
+
+# ---------------------------------------------------------------------------
+# check_spawn — developer-group full authority
+# ---------------------------------------------------------------------------
+
+
+def test_developer_child_may_spawn(db_path: Path) -> None:
+    """A developer-group caller may spawn even as a (non-root) child."""
+    # Arrange
+    record_lineage(child="dev-1", parent="root", db_path=db_path)
+    record_comms_policy(name="dev-1", group_name="developer", db_path=db_path)
+    # Act
+    decision, _reason = check_spawn(caller="dev-1", db_path=db_path)
+    # Assert
+    assert decision == "allow"
+
+
+def test_non_developer_child_still_denied_spawn(db_path: Path) -> None:
+    """Backward-compatible: a non-developer child is still root-only denied."""
+    # Arrange
+    record_lineage(child="worker-a", parent="root", db_path=db_path)
+    record_comms_policy(name="worker-a", group_name="analysts", db_path=db_path)
+    # Act
+    decision, _reason = check_spawn(caller="worker-a", db_path=db_path)
+    # Assert
+    assert decision == "deny"
+
+
+# ---------------------------------------------------------------------------
+# check_lineage_acl — developer-group full agent-CRUD authority
+# ---------------------------------------------------------------------------
+
+
+def test_developer_may_manage_unrelated_agent(db_path: Path) -> None:
+    """Developer-group caller manages a target with NO lineage edge."""
+    # Arrange
+    record_comms_policy(name="dev-1", group_name="developer", db_path=db_path)
+    record_lineage(child="victim", parent="someone-else", db_path=db_path)
+    # Act
+    decision, _reason = check_lineage_acl(
+        caller="dev-1", target="victim", db_path=db_path
+    )
+    # Assert
+    assert decision == "allow"
+
+
+def test_non_developer_cannot_manage_unrelated_agent(db_path: Path) -> None:
+    """Backward-compatible: non-developer with no lineage edge → deny."""
+    # Arrange
+    record_comms_policy(name="worker-a", group_name="analysts", db_path=db_path)
+    record_lineage(child="victim", parent="someone-else", db_path=db_path)
+    # Act
+    decision, _reason = check_lineage_acl(
+        caller="worker-a", target="victim", db_path=db_path
+    )
+    # Assert
+    assert decision == "deny"

--- a/tests/scitex_agent_container/_state/test_state_db_nodes_group.py
+++ b/tests/scitex_agent_container/_state/test_state_db_nodes_group.py
@@ -1,0 +1,182 @@
+"""Named-group persistence + readers (group-based a2a ACL, 2026-06-25).
+
+Covers the state-DB half of the group ACL:
+
+* ``record_comms_policy`` persists ``group_name`` and ``read_comms_policy``
+  round-trips it (default ``""`` when absent).
+* ``resolve_group_name`` returns the persisted group / ``""``.
+* ``same_named_group`` is True only for two NON-EMPTY equal groups.
+* ``is_developer`` recognises a developer-group member.
+
+AAA (each marker on its own line), one assertion per test, no mocks —
+real on-disk SQLite via the yield-based ``db_path`` env override.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._state import state_db
+from scitex_agent_container._state.state_db_nodes import (
+    is_developer,
+    read_comms_policy,
+    record_comms_policy,
+    resolve_group_name,
+    same_named_group,
+)
+
+
+@pytest.fixture
+def db_path(tmp_path: Path):
+    # Arrange
+    db = tmp_path / "state.db"
+    saved_env = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB")
+    saved_default = state_db.DEFAULT_DB_PATH
+    os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
+    state_db.DEFAULT_DB_PATH = db
+    state_db.init_schema(db)
+    try:
+        yield db
+    finally:
+        state_db.DEFAULT_DB_PATH = saved_default
+        if saved_env is None:
+            os.environ.pop("SCITEX_AGENT_CONTAINER_STATE_DB", None)
+        else:
+            os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = saved_env
+
+
+# ---------------------------------------------------------------------------
+# record / read round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_read_comms_policy_group_name_defaults_empty(db_path: Path) -> None:
+    """A node with no policy row reports the ungrouped default."""
+    # Arrange — no record_comms_policy call.
+    # Act
+    policy = read_comms_policy(name="never-recorded", db_path=db_path)
+    # Assert
+    assert policy["group_name"] == ""
+
+
+def test_record_comms_policy_persists_group_name(db_path: Path) -> None:
+    # Arrange
+    record_comms_policy(name="alice", group_name="developer", db_path=db_path)
+    # Act
+    policy = read_comms_policy(name="alice", db_path=db_path)
+    # Assert
+    assert policy["group_name"] == "developer"
+
+
+def test_record_comms_policy_group_name_is_trimmed(db_path: Path) -> None:
+    # Arrange
+    record_comms_policy(name="alice", group_name="  analysts  ", db_path=db_path)
+    # Act
+    policy = read_comms_policy(name="alice", db_path=db_path)
+    # Assert
+    assert policy["group_name"] == "analysts"
+
+
+def test_record_comms_policy_group_name_upsert_refreshes(db_path: Path) -> None:
+    """A re-record (e.g. a restart after a spec edit) updates the group."""
+    # Arrange
+    record_comms_policy(name="alice", group_name="analysts", db_path=db_path)
+    record_comms_policy(name="alice", group_name="developer", db_path=db_path)
+    # Act
+    policy = read_comms_policy(name="alice", db_path=db_path)
+    # Assert
+    assert policy["group_name"] == "developer"
+
+
+def test_record_comms_policy_rejects_non_str_group_name(db_path: Path) -> None:
+    # Arrange
+    bad_group = 123
+    # Act
+    raises = pytest.raises(ValueError)
+    # Assert
+    with raises:
+        record_comms_policy(name="alice", group_name=bad_group, db_path=db_path)
+
+
+# ---------------------------------------------------------------------------
+# resolve_group_name
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_group_name_returns_persisted_group(db_path: Path) -> None:
+    # Arrange
+    record_comms_policy(name="alice", group_name="developer", db_path=db_path)
+    # Act
+    group = resolve_group_name(name="alice", db_path=db_path)
+    # Assert
+    assert group == "developer"
+
+
+def test_resolve_group_name_unknown_node_is_empty(db_path: Path) -> None:
+    # Arrange — no row.
+    # Act
+    group = resolve_group_name(name="ghost", db_path=db_path)
+    # Assert
+    assert group == ""
+
+
+# ---------------------------------------------------------------------------
+# same_named_group
+# ---------------------------------------------------------------------------
+
+
+def test_same_named_group_true_for_equal_nonempty(db_path: Path) -> None:
+    # Arrange
+    record_comms_policy(name="alice", group_name="developer", db_path=db_path)
+    record_comms_policy(name="bob", group_name="developer", db_path=db_path)
+    # Act
+    result = same_named_group(sender="alice", target="bob", db_path=db_path)
+    # Assert
+    assert result is True
+
+
+def test_same_named_group_false_for_different_groups(db_path: Path) -> None:
+    # Arrange
+    record_comms_policy(name="alice", group_name="developer", db_path=db_path)
+    record_comms_policy(name="bob", group_name="analysts", db_path=db_path)
+    # Act
+    result = same_named_group(sender="alice", target="bob", db_path=db_path)
+    # Assert
+    assert result is False
+
+
+def test_same_named_group_false_when_both_ungrouped(db_path: Path) -> None:
+    """Two ungrouped agents must NOT match — absence is a no-op."""
+    # Arrange — neither has a group_name.
+    record_comms_policy(name="alice", db_path=db_path)
+    record_comms_policy(name="bob", db_path=db_path)
+    # Act
+    result = same_named_group(sender="alice", target="bob", db_path=db_path)
+    # Assert
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# is_developer
+# ---------------------------------------------------------------------------
+
+
+def test_is_developer_true_for_developer_group_member(db_path: Path) -> None:
+    # Arrange
+    record_comms_policy(name="alice", group_name="developer", db_path=db_path)
+    # Act
+    result = is_developer(name="alice", db_path=db_path)
+    # Assert
+    assert result is True
+
+
+def test_is_developer_false_for_other_group_member(db_path: Path) -> None:
+    # Arrange
+    record_comms_policy(name="alice", group_name="analysts", db_path=db_path)
+    # Act
+    result = is_developer(name="alice", db_path=db_path)
+    # Assert
+    assert result is False

--- a/tests/scitex_agent_container/config/test__group_resolver.py
+++ b/tests/scitex_agent_container/config/test__group_resolver.py
@@ -1,0 +1,175 @@
+"""Named-group resolver (group-based a2a ACL, operator 2026-06-25).
+
+Pure string-in / string-out resolution — no DB, no fixtures. Covers:
+
+* An explicit ``metadata.labels.group`` wins verbatim.
+* An absent group label derives the group from the role: the
+  developer-ish roles (project-maintainer / maintainer / dev-agent /
+  contributor, and project-suffixed forms) default to ``developer``.
+* Anything else → ``""`` (ungrouped).
+* :func:`group_from_labels` reads the ``group`` / ``role`` keys.
+* :func:`is_developer_group` recognises the privileged group.
+
+AAA, one assertion per test, no mocks.
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container.config._group_resolver import (
+    DEVELOPER_GROUP,
+    group_from_labels,
+    is_developer_group,
+    resolve_group,
+)
+
+
+def test_explicit_group_label_wins_over_role() -> None:
+    # Arrange
+    label = "analysts"
+    # Act
+    group = resolve_group(group_label=label, role="contributor")
+    # Assert
+    assert group == "analysts"
+
+
+def test_explicit_group_label_is_whitespace_trimmed() -> None:
+    # Arrange
+    label = "  analysts  "
+    # Act
+    group = resolve_group(group_label=label, role=None)
+    # Assert
+    assert group == "analysts"
+
+
+def test_role_project_maintainer_derives_developer_group() -> None:
+    # Arrange
+    role = "project-maintainer"
+    # Act
+    group = resolve_group(group_label=None, role=role)
+    # Assert
+    assert group == DEVELOPER_GROUP
+
+
+def test_role_maintainer_derives_developer_group() -> None:
+    # Arrange
+    role = "maintainer"
+    # Act
+    group = resolve_group(group_label=None, role=role)
+    # Assert
+    assert group == DEVELOPER_GROUP
+
+
+def test_role_dev_agent_derives_developer_group() -> None:
+    # Arrange
+    role = "dev-agent"
+    # Act
+    group = resolve_group(group_label=None, role=role)
+    # Assert
+    assert group == DEVELOPER_GROUP
+
+
+def test_role_contributor_derives_developer_group() -> None:
+    # Arrange
+    role = "contributor"
+    # Act
+    group = resolve_group(group_label=None, role=role)
+    # Assert
+    assert group == DEVELOPER_GROUP
+
+
+def test_project_suffixed_contributor_role_derives_developer_group() -> None:
+    # Arrange
+    role = "contributor-figrecipe"
+    # Act
+    group = resolve_group(group_label=None, role=role)
+    # Assert
+    assert group == DEVELOPER_GROUP
+
+
+def test_role_match_is_case_insensitive() -> None:
+    # Arrange
+    role = "Project-Maintainer"
+    # Act
+    group = resolve_group(group_label=None, role=role)
+    # Assert
+    assert group == DEVELOPER_GROUP
+
+
+def test_non_developer_role_is_ungrouped() -> None:
+    # Arrange
+    role = "experiment-capsule"
+    # Act
+    group = resolve_group(group_label=None, role=role)
+    # Assert
+    assert group == ""
+
+
+def test_empty_group_label_falls_through_to_role() -> None:
+    # Arrange
+    label = "   "
+    # Act
+    group = resolve_group(group_label=label, role="contributor")
+    # Assert
+    assert group == DEVELOPER_GROUP
+
+
+def test_no_group_and_no_role_is_ungrouped() -> None:
+    # Arrange
+    # Act
+    group = resolve_group(group_label=None, role=None)
+    # Assert
+    assert group == ""
+
+
+def test_group_from_labels_reads_explicit_group_key() -> None:
+    # Arrange
+    labels = {"group": "analysts", "role": "contributor"}
+    # Act
+    group = group_from_labels(labels)
+    # Assert
+    assert group == "analysts"
+
+
+def test_group_from_labels_derives_from_role_key() -> None:
+    # Arrange
+    labels = {"role": "dev-agent"}
+    # Act
+    group = group_from_labels(labels)
+    # Assert
+    assert group == DEVELOPER_GROUP
+
+
+def test_group_from_labels_none_is_ungrouped() -> None:
+    # Arrange
+    labels = None
+    # Act
+    group = group_from_labels(labels)
+    # Assert
+    assert group == ""
+
+
+def test_is_developer_group_true_for_developer() -> None:
+    # Arrange
+    group = "developer"
+    # Act
+    result = is_developer_group(group)
+    # Assert
+    assert result is True
+
+
+def test_is_developer_group_false_for_other_group() -> None:
+    # Arrange
+    group = "analysts"
+    # Act
+    result = is_developer_group(group)
+    # Assert
+    assert result is False
+
+
+def test_is_developer_group_false_for_empty() -> None:
+    # Arrange
+    group = ""
+    # Act
+    result = is_developer_group(group)
+    # Assert
+    assert result is False


### PR DESCRIPTION
## Summary

Implements group-based a2a ACL + developer-group full authority (operator design, 2026-06-25), layered additively on top of the existing lineage-derived group mesh — fully backward-compatible.

## What changed

- **Group resolver** (`config/_group_resolver.py`, new): an agent's NAMED group is `metadata.labels.group`; when absent, it is derived from `metadata.labels.role` — the developer-ish roles (`project-maintainer` / `maintainer` / `dev-agent` / `contributor`, incl. project-suffixed forms like `contributor-figrecipe`) default to the `developer` group. Existing dev agents join `developer` with **no spec edit**; an explicit `labels.group` overrides. Pure, no I/O.
- **Persistence**: new `node_comms_policy.group_name` column (DDL + idempotent `ADD COLUMN` migration). Written at `agent_start` from the resolved label via `persist_acl_policy`, so the ACL check can read it by node name.
- **a2a send ACL** (`check_send_acl`): a send is allowed when sender and target share a **non-empty named group** (full mesh within a group), in addition to the lineage mesh and explicit grants. Cross-group default-deny + deny-notify and all existing grants are unchanged.
- **Developer-group full authority**: a `developer`-group caller bypasses the root-only spawn gate (`check_spawn`) and the lineage-descendant gate (`check_lineage_acl`), so it may CRUD any agent (spawn/start/stop/restart/delete + status/tail). ACL-CRUD (`grant_send`/`revoke_send`) was already ungated by caller, so developers retain it unchanged.

## Tests

No mocks (real on-disk SQLite, yield-based env fixtures); AAA markers each on their own line; one assert per test. New coverage: same-group allowed; cross-group denied without grant; cross-group allowed **with** grant; role-derived default group; developer may spawn as a child + manage unrelated agents.

- 38 new tests pass (`test__group_resolver.py`, `test_state_db_nodes_group.py`, `test__acl_group.py`).
- 116 existing ACL / spawn / policy / phase3 tests still green (no regressions).
- `scitex-dev ecosystem audit-all` — 0 violations.

## Backward compatibility

An ungrouped fleet (no `labels.group`, non-developer/absent role) resolves to the empty group and shares a named group with no one, so behaviour is byte-equivalent to before: the lineage mesh + explicit-grant ACL and the root-only / lineage-descendant gates apply unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
