### PR TITLE
feat(agents): sac agents create + developer/scientist templates + MCP agent_create

### DIFF
--- a/src/scitex_agent_container/_mcp/_tools/_agent.py
+++ b/src/scitex_agent_container/_mcp/_tools/_agent.py
@@ -280,6 +280,35 @@ def agent_send(
     )
 
 
+def agent_create(
+    name: str,
+    template: str = "developer",
+    workdir: str | None = None,
+    telegram_token: str | None = None,
+    group: str | None = None,
+    start: bool = False,
+) -> dict[str, Any]:
+    """Create a proven-shape agent spec from a template. Mirrors
+    ``sac agents create <name> --template developer|scientist``.
+
+    Writes ``<name>/spec.yaml`` from the developer/scientist skeleton,
+    filling identity (name -> project / workdir / overlay / state-db /
+    SCITEX_TODO_AGENT) and auto-detecting the editable-install block
+    (workdir ships a package) and the per-agent Telegram bot
+    (``telegram_token`` file present). ``start=True`` launches the agent
+    afterwards. The developer group is authorized to CRUD agents."""
+    argv = ["agents", "create", name, "--template", template]
+    if workdir:
+        argv += ["--workdir", workdir]
+    if telegram_token:
+        argv += ["--telegram-token", telegram_token]
+    if group:
+        argv += ["--group", group]
+    if start:
+        argv += ["--start"]
+    return invoke_cli_text(argv)
+
+
 def register_agent_tools(mcp) -> None:
     """Attach ``@mcp.tool()`` to every public function in this module."""
     for fn in (
@@ -290,6 +319,7 @@ def register_agent_tools(mcp) -> None:
         agent_find,
         agent_check,
         agent_recall,
+        agent_create,
         agent_start,
         agent_spawn,
         agent_stop,
@@ -307,6 +337,7 @@ __all__ = [
     "agent_find",
     "agent_check",
     "agent_recall",
+    "agent_create",
     "agent_start",
     "agent_spawn",
     "agent_stop",

--- a/src/scitex_agent_container/cli_pkg/_create.py
+++ b/src/scitex_agent_container/cli_pkg/_create.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""``sac agents create NAME`` — stamp a proven-shape developer/scientist agent.
+
+Card sac-templated-agent-create (2026-06-25). Folds the two prototype
+shell stampers (``scripts/agents/new_agent_spec.sh`` +
+``scripts/gen_ecosystem_dev_specs.sh``) into one reproducible CLI so
+agents can create agents without hand-written specs or one-off scripts —
+the CLI is the SSoT.
+
+Two templates ship as underscore-agent skeletons under
+``_create_templates/`` (``_developer`` / ``_scientist``), modeled on the
+proven ``figrecipe`` (developer) and ``paper-scitex-clew`` (scientist)
+shapes. They share one TUI core (sac-base.sif, full-home bind, directory
+overlay, opus, generic boot kick) and differ on only:
+
+  axis              developer            scientist
+  ----------------- -------------------- ----------------------------------
+  group             developer            scientist
+  purpose suffix    -maintainer          -research
+
+Two blocks are AUTO-detected at create time, regardless of template:
+
+  * editable install — emitted iff the workdir ships ``pyproject.toml``
+    or ``setup.py`` (paper repos ship none -> no install).
+  * per-agent Telegram bot — emitted iff a bot-token file is present
+    (``--telegram-token F`` or the default
+    ``<secrets>/telegram_<name>_bot.txt``).
+
+Only MINIMAL identity overrides are exposed (name / workdir / group /
+telegram-token). Deeper changes = edit the generated spec.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+import click
+
+from ._new import _default_base_dir, _is_valid_agent_name
+
+_TEMPLATE_DIR = Path(__file__).parent / "_create_templates"
+_DEFAULT_PROJ_ROOT = "/home/ywatanabe/proj"
+_DEFAULT_SECRETS_DIR = "/home/ywatanabe/.bash.d/secrets/access_tokens"
+_TEMPLATES = ("developer", "scientist")
+
+# Whole-line ``# >>>name`` / ``# <<<name`` markers wrap each optional block
+# in the skeletons. ``_apply_block`` either drops just the markers (keep) or
+# drops the markers AND the lines between them (omit).
+_TOKEN_RE = re.compile(r"\{\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*\}\}")
+
+
+def _apply_block(text: str, name: str, keep: bool) -> str:
+    """Resolve one ``# >>>name`` … ``# <<<name`` region.
+
+    ``keep=True`` strips only the two marker lines and leaves the content;
+    ``keep=False`` removes the markers and everything between them.
+    """
+    open_marker = f"# >>>{name}"
+    close_marker = f"# <<<{name}"
+    out: list[str] = []
+    skipping = False
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped == open_marker:
+            skipping = not keep
+            continue
+        if stripped == close_marker:
+            skipping = False
+            continue
+        if skipping:
+            continue
+        out.append(line)
+    body = "\n".join(out)
+    return body + "\n" if text.endswith("\n") else body
+
+
+def _render_tokens(text: str, mapping: dict[str, str]) -> str:
+    """Substitute ``{{ TOKEN }}`` occurrences (whitespace-tolerant)."""
+
+    def _sub(match: "re.Match[str]") -> str:
+        key = match.group(1)
+        if key not in mapping:
+            raise KeyError(f"template token {key!r} not provided")
+        return str(mapping[key])
+
+    return _TOKEN_RE.sub(_sub, text)
+
+
+def _has_package(workdir: str) -> bool:
+    """True iff ``workdir`` ships an installable Python package."""
+    base = Path(workdir)
+    return (base / "pyproject.toml").is_file() or (base / "setup.py").is_file()
+
+
+def render_spec(
+    name: str,
+    template: str,
+    workdir: str,
+    group: str,
+    token_path: str,
+    telegram: bool,
+) -> str:
+    """Render the final ``spec.yaml`` text for one agent from a skeleton.
+
+    Pure function (no filesystem writes) so tests can assert the rendered
+    shape directly. ``telegram`` decides both the bind region and the
+    telegrammer channel; the editable-install region is auto-detected from
+    ``workdir``.
+    """
+    skeleton = (_TEMPLATE_DIR / f"_{template}" / "spec.yaml").read_text()
+    body = _apply_block(skeleton, "install", _has_package(workdir))
+    body = _apply_block(body, "telegram", telegram)
+    body = _apply_block(body, "tg_channel", telegram)
+    return _render_tokens(
+        body,
+        {
+            "NAME": name,
+            "WORKDIR": workdir,
+            "GROUP": group,
+            "TELEGRAM_TOKEN": token_path,
+        },
+    )
+
+
+@click.command(name="create")
+@click.argument("name", type=str)
+@click.option(
+    "--template",
+    "template",
+    type=click.Choice(_TEMPLATES, case_sensitive=False),
+    default="developer",
+    show_default=True,
+    help="Proven-shape preset: 'developer' (package maintainer) or "
+    "'scientist' (paper / research agent).",
+)
+@click.option(
+    "--workdir",
+    "workdir",
+    type=str,
+    default=None,
+    help="Canonical project path (the --pwd). Default: "
+    "/home/ywatanabe/proj/<name>.",
+)
+@click.option(
+    "--telegram-token",
+    "telegram_token",
+    type=str,
+    default=None,
+    help="Path to the per-agent Telegram bot-token file. Wires the bot iff "
+    "the file exists. Default probe: "
+    "<secrets>/telegram_<name>_bot.txt.",
+)
+@click.option(
+    "--group",
+    "group",
+    type=str,
+    default=None,
+    help="Override the group label. Default: the template name "
+    "(developer/scientist).",
+)
+@click.option(
+    "--base-dir",
+    "base_dir",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=None,
+    help="Parent dir under which <name>/spec.yaml is written. Default: "
+    "~/.scitex/agent-container/agents/.",
+)
+@click.option(
+    "--force",
+    is_flag=True,
+    default=False,
+    help="Overwrite an existing spec.yaml (off by default).",
+)
+@click.option(
+    "--start",
+    is_flag=True,
+    default=False,
+    help="Run `sac agents start <name>` after writing the spec.",
+)
+def create(
+    name: str,
+    template: str,
+    workdir: str | None,
+    telegram_token: str | None,
+    group: str | None,
+    base_dir: Path | None,
+    force: bool,
+    start: bool,
+) -> None:
+    """Stamp a proven-shape developer/scientist agent spec.
+
+    Writes ``<base-dir>/<name>/spec.yaml`` from the matching underscore-agent
+    skeleton, filling identity (name -> project / workdir / overlay /
+    state-db / SCITEX_TODO_AGENT) and auto-detecting the editable-install and
+    Telegram-bot blocks.
+
+    Examples:
+
+    \b
+        sac agents create scitex-io --template developer
+        sac agents create paper-ripple-wm --template scientist \\
+            --workdir /home/ywatanabe/proj/ripple-wm
+    """
+    template = template.lower()
+    if not _is_valid_agent_name(name):
+        raise click.UsageError(
+            f"Invalid agent name {name!r}. Use lowercase letters, "
+            "digits, '-', and '_' only (dir-as-SSoT convention)."
+        )
+
+    resolved_workdir = workdir or f"{_DEFAULT_PROJ_ROOT}/{name}"
+    resolved_group = group or template
+    secrets_dir = os.environ.get("SAC_TG_SECRETS_DIR", _DEFAULT_SECRETS_DIR)
+    token_path = telegram_token or f"{secrets_dir}/telegram_{name}_bot.txt"
+    telegram = Path(token_path).is_file()
+
+    body = render_spec(
+        name=name,
+        template=template,
+        workdir=resolved_workdir,
+        group=resolved_group,
+        token_path=token_path,
+        telegram=telegram,
+    )
+
+    base = base_dir if base_dir is not None else _default_base_dir()
+    agent_dir = base / name
+    spec_path = agent_dir / "spec.yaml"
+    if spec_path.exists() and not force:
+        raise click.ClickException(
+            f"Refusing to overwrite existing spec at {spec_path}. "
+            "Re-run with --force to replace, or pick a different name."
+        )
+
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    spec_path.write_text(body)
+
+    print(
+        f"Wrote {spec_path} (template={template}, group={resolved_group}, "
+        f"install={'yes' if _has_package(resolved_workdir) else 'no'}, "
+        f"telegram={'yes' if telegram else 'no'}).",
+        file=sys.stderr,
+        flush=True,
+    )
+
+    if start:
+        import subprocess
+
+        subprocess.run(["sac", "agents", "start", name], check=False)
+
+
+__all__ = ["create", "render_spec"]

--- a/src/scitex_agent_container/cli_pkg/_create_templates/_developer/spec.yaml
+++ b/src/scitex_agent_container/cli_pkg/_create_templates/_developer/spec.yaml
@@ -1,0 +1,92 @@
+# {{ NAME }} — sac developer agent for {{ WORKDIR }}.
+# Stamped by `sac agents create --template developer` from this skeleton.
+# Proven TUI shape; developer group. WRITE to its own repo via topic-branch -> PR.
+#
+# This file is the template SSoT (an underscore agent, skipped by the loader).
+# The CLI fills the double-brace placeholders below and toggles the
+# install / telegram comment regions by auto-detection (editable install iff the workdir ships a package;
+# per-agent Telegram bot iff a token file is present). Deeper changes = edit the
+# generated spec.
+
+apiVersion: scitex-agent-container/v3
+kind: Agent
+metadata:
+  labels:
+    project: {{ NAME }}
+    purpose: {{ NAME }}-maintainer
+    role: project-maintainer
+    group: {{ GROUP }}
+    cardinality: singleton
+
+spec:
+  runtime: tui
+  host: local
+  workdir: {{ WORKDIR }}
+
+  apptainer:
+    image: /home/ywatanabe/.scitex/agent-container/containers/sac-base.sif
+    relaxed: true
+    binds:
+      - /home/ywatanabe:/home/ywatanabe:rw
+      - /home/ywatanabe/.ssh:/home/agent/.ssh:ro
+      - /home/ywatanabe/.config/gh:/home/agent/.config/gh:ro
+      # >>>telegram
+      - /home/ywatanabe/.bun/bin/bun:/usr/local/bin/bun:ro
+      - {{ TELEGRAM_TOKEN }}:/run/dev-secrets/bot-token:ro
+      # <<<telegram
+    raw_args:
+      - --userns
+      - --containall
+      - --home
+      - /home/agent
+      - --overlay
+      - /home/ywatanabe/.scitex/agent-container/containers/overlays/{{ NAME }}/
+      - --env
+      - SCITEX_AGENT_CONTAINER_STATE_DB=/state/{{ NAME }}/state.db
+      - --env
+      - SCITEX_TODO_AGENT={{ NAME }}
+      - --env
+      - GIT_AUTHOR_NAME=Yusuke Watanabe
+      - --env
+      - GIT_AUTHOR_EMAIL=ywatanabe@scitex.ai
+      - --env
+      - GIT_COMMITTER_NAME=Yusuke Watanabe
+      - --env
+      - GIT_COMMITTER_EMAIL=ywatanabe@scitex.ai
+      - --env
+      - GIT_SSH_COMMAND=ssh -o ControlMaster=no -o ControlPath=none
+
+  claude:
+    model: claude-opus-4-8[1m]
+    credentials_file: /home/ywatanabe/.claude/.credentials.json
+    flags:
+      - --dangerously-skip-permissions
+    channels:
+      - server:sac
+      - server:scitex-todo
+      # >>>tg_channel
+      - server:claude-code-telegrammer
+      # <<<tg_channel
+
+  a2a:
+    port: auto
+
+  startup_commands:
+    - command: rm -rf $HOME/proj 2>/dev/null; ln -sfn /home/ywatanabe/proj $HOME/proj
+    - command: 'mkdir -p /uvwork/tmp /uvwork/bin && export TMPDIR=/uvwork/tmp UV_INSTALL_DIR=/uvwork/bin UV_CACHE_DIR=/uvwork/uvcache PATH=/uvwork/bin:$PATH && { [ -x /uvwork/bin/uv ] || curl -LsSf https://astral.sh/uv/install.sh | env TMPDIR=/uvwork/tmp UV_INSTALL_DIR=/uvwork/bin sh; }'
+      # >>>install
+    - command: '[ -x /uvwork/venv-agent/bin/python ] || { export TMPDIR=/uvwork/tmp UV_CACHE_DIR=/uvwork/uvcache PATH=/uvwork/bin:$PATH && cd {{ WORKDIR }} && uv venv /uvwork/venv-agent --python python3 && uv pip install --python /uvwork/venv-agent/bin/python -e .; }'
+      # <<<install
+
+  startup_prompts:
+    - Start or continue. Scan your scitex-todo card slice, resume any in-flight
+      or assigned work (hold idle if none), then report readiness. Follow
+      CLAUDE.md + your skills; don't restate, don't invent scope.
+
+  health:
+    enabled: true
+    interval: 60
+
+  restart:
+    policy: on-failure
+    max_retries: 3

--- a/src/scitex_agent_container/cli_pkg/_create_templates/_scientist/spec.yaml
+++ b/src/scitex_agent_container/cli_pkg/_create_templates/_scientist/spec.yaml
@@ -1,0 +1,92 @@
+# {{ NAME }} — sac scientist agent for {{ WORKDIR }}.
+# Stamped by `sac agents create --template scientist` from this skeleton.
+# Proven TUI shape; scientist group. WRITE to its own repo via topic-branch -> PR.
+#
+# This file is the template SSoT (an underscore agent, skipped by the loader).
+# The CLI fills the double-brace placeholders below and toggles the
+# install / telegram comment regions by auto-detection: editable install iff the workdir ships a package
+# (paper repos ship none, so they get no install); per-agent Telegram bot iff a
+# token file is present. Deeper changes = edit the generated spec.
+
+apiVersion: scitex-agent-container/v3
+kind: Agent
+metadata:
+  labels:
+    project: {{ NAME }}
+    purpose: {{ NAME }}-research
+    role: project-maintainer
+    group: {{ GROUP }}
+    cardinality: singleton
+
+spec:
+  runtime: tui
+  host: local
+  workdir: {{ WORKDIR }}
+
+  apptainer:
+    image: /home/ywatanabe/.scitex/agent-container/containers/sac-base.sif
+    relaxed: true
+    binds:
+      - /home/ywatanabe:/home/ywatanabe:rw
+      - /home/ywatanabe/.ssh:/home/agent/.ssh:ro
+      - /home/ywatanabe/.config/gh:/home/agent/.config/gh:ro
+      # >>>telegram
+      - /home/ywatanabe/.bun/bin/bun:/usr/local/bin/bun:ro
+      - {{ TELEGRAM_TOKEN }}:/run/dev-secrets/bot-token:ro
+      # <<<telegram
+    raw_args:
+      - --userns
+      - --containall
+      - --home
+      - /home/agent
+      - --overlay
+      - /home/ywatanabe/.scitex/agent-container/containers/overlays/{{ NAME }}/
+      - --env
+      - SCITEX_AGENT_CONTAINER_STATE_DB=/state/{{ NAME }}/state.db
+      - --env
+      - SCITEX_TODO_AGENT={{ NAME }}
+      - --env
+      - GIT_AUTHOR_NAME=Yusuke Watanabe
+      - --env
+      - GIT_AUTHOR_EMAIL=ywatanabe@scitex.ai
+      - --env
+      - GIT_COMMITTER_NAME=Yusuke Watanabe
+      - --env
+      - GIT_COMMITTER_EMAIL=ywatanabe@scitex.ai
+      - --env
+      - GIT_SSH_COMMAND=ssh -o ControlMaster=no -o ControlPath=none
+
+  claude:
+    model: claude-opus-4-8[1m]
+    credentials_file: /home/ywatanabe/.claude/.credentials.json
+    flags:
+      - --dangerously-skip-permissions
+    channels:
+      - server:sac
+      - server:scitex-todo
+      # >>>tg_channel
+      - server:claude-code-telegrammer
+      # <<<tg_channel
+
+  a2a:
+    port: auto
+
+  startup_commands:
+    - command: rm -rf $HOME/proj 2>/dev/null; ln -sfn /home/ywatanabe/proj $HOME/proj
+    - command: 'mkdir -p /uvwork/tmp /uvwork/bin && export TMPDIR=/uvwork/tmp UV_INSTALL_DIR=/uvwork/bin UV_CACHE_DIR=/uvwork/uvcache PATH=/uvwork/bin:$PATH && { [ -x /uvwork/bin/uv ] || curl -LsSf https://astral.sh/uv/install.sh | env TMPDIR=/uvwork/tmp UV_INSTALL_DIR=/uvwork/bin sh; }'
+      # >>>install
+    - command: '[ -x /uvwork/venv-agent/bin/python ] || { export TMPDIR=/uvwork/tmp UV_CACHE_DIR=/uvwork/uvcache PATH=/uvwork/bin:$PATH && cd {{ WORKDIR }} && uv venv /uvwork/venv-agent --python python3 && uv pip install --python /uvwork/venv-agent/bin/python -e .; }'
+      # <<<install
+
+  startup_prompts:
+    - Start or continue. Scan your scitex-todo card slice, resume any in-flight
+      or assigned work (hold idle if none), then report readiness. Follow
+      CLAUDE.md + your skills; don't restate, don't invent scope.
+
+  health:
+    enabled: true
+    interval: 60
+
+  restart:
+    policy: on-failure
+    max_retries: 3

--- a/src/scitex_agent_container/cli_pkg/agent_group.py
+++ b/src/scitex_agent_container/cli_pkg/agent_group.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import click
 
 from ._agent_prune_claude import prune_claude as _prune_claude_impl
+from ._create import create as _create_impl
 from ._explain import explain as _explain_impl
 from ._helpers import HelpRecursiveGroup
 from ._new import new as _new_impl
@@ -50,7 +51,7 @@ class _AgentsGroup(HelpRecursiveGroup):
     COMMAND_CATEGORIES = [
         (
             "Lifecycle",
-            ["new", "start", "stop", "restart", "delete", "forget", "spawn-from-here"],
+            ["new", "create", "start", "stop", "restart", "delete", "forget", "spawn-from-here"],
         ),
         ("Interact", ["send", "attach"]),
         ("Inspect", ["list", "status", "health", "tail", "recall"]),
@@ -71,6 +72,12 @@ def agent_group() -> None:
 # sac-fresh-agent-specs, 2026-06-13). Placed FIRST in the lifecycle
 # block — authoring precedes start/stop.
 agent_group.add_command(_rebind(_new_impl, "new"))
+# `create` stamps a proven-shape developer/scientist agent from the
+# underscore-agent skeletons (card sac-templated-agent-create, 2026-06-25)
+# — folds the retired new_agent_spec.sh / gen_ecosystem_dev_specs.sh
+# stampers. `new` is the bare scaffold; `create` is the opinionated,
+# auto-detecting proven shape.
+agent_group.add_command(_rebind(_create_impl, "create"))
 agent_group.add_command(_rebind(_start_impl, "start"))
 agent_group.add_command(_rebind(_stop_impl, "stop"))
 agent_group.add_command(_rebind(_restart_impl, "restart"))

--- a/tests/scitex_agent_container/cli_pkg/test__create.py
+++ b/tests/scitex_agent_container/cli_pkg/test__create.py
@@ -1,0 +1,247 @@
+"""Tests for ``sac agents create`` — stamp a proven-shape agent spec.
+
+Card sac-templated-agent-create (2026-06-25). Folds the retired
+``new_agent_spec.sh`` / ``gen_ecosystem_dev_specs.sh`` stampers into one
+CLI. The developer/scientist skeletons must render to a v3-clean spec
+that the live validator accepts, with the editable-install and Telegram
+blocks toggled by auto-detection.
+
+Discipline: AAA markers each on their own line; one literal ``assert``
+per test; real filesystem fixtures (``tmp_path``), no mocks.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+from click.testing import CliRunner
+
+from scitex_agent_container.cli_pkg._create import create as create_cmd
+from scitex_agent_container.cli_pkg._create import render_spec
+from scitex_agent_container.config._validation import validate_config
+
+
+def _spec(base: Path, name: str) -> Path:
+    return base / name / "spec.yaml"
+
+
+def test_create_writes_spec_yaml_at_target(tmp_path: Path) -> None:
+    # Arrange
+    runner = CliRunner()
+    base = tmp_path / "agents"
+    # Act
+    runner.invoke(create_cmd, ["dev-x", "--template", "developer", "--base-dir", str(base)])
+    # Assert
+    assert _spec(base, "dev-x").is_file()
+
+
+def test_create_developer_passes_v3_validator(tmp_path: Path) -> None:
+    # Arrange
+    runner = CliRunner()
+    base = tmp_path / "agents"
+    # Act
+    runner.invoke(create_cmd, ["dev-val", "--template", "developer", "--base-dir", str(base)])
+    errors = validate_config(_spec(base, "dev-val"))
+    # Assert — rendered developer spec must satisfy the live validator.
+    assert errors == []
+
+
+def test_create_scientist_passes_v3_validator(tmp_path: Path) -> None:
+    # Arrange
+    runner = CliRunner()
+    base = tmp_path / "agents"
+    # Act
+    runner.invoke(create_cmd, ["sci-val", "--template", "scientist", "--base-dir", str(base)])
+    errors = validate_config(_spec(base, "sci-val"))
+    # Assert
+    assert errors == []
+
+
+def test_create_developer_group_label(tmp_path: Path) -> None:
+    # Arrange
+    runner = CliRunner()
+    base = tmp_path / "agents"
+    runner.invoke(create_cmd, ["dev-grp", "--template", "developer", "--base-dir", str(base)])
+    # Act
+    parsed = yaml.safe_load(_spec(base, "dev-grp").read_text())
+    # Assert — developer template defaults to the developer group.
+    assert parsed["metadata"]["labels"]["group"] == "developer"
+
+
+def test_create_developer_purpose_suffix(tmp_path: Path) -> None:
+    # Arrange
+    runner = CliRunner()
+    base = tmp_path / "agents"
+    runner.invoke(create_cmd, ["dev-pur", "--template", "developer", "--base-dir", str(base)])
+    # Act
+    parsed = yaml.safe_load(_spec(base, "dev-pur").read_text())
+    # Assert — developer purpose is the maintainer suffix.
+    assert parsed["metadata"]["labels"]["purpose"] == "dev-pur-maintainer"
+
+
+def test_create_scientist_group_label(tmp_path: Path) -> None:
+    # Arrange
+    runner = CliRunner()
+    base = tmp_path / "agents"
+    runner.invoke(create_cmd, ["sci-grp", "--template", "scientist", "--base-dir", str(base)])
+    # Act
+    parsed = yaml.safe_load(_spec(base, "sci-grp").read_text())
+    # Assert — scientist template defaults to the scientist group.
+    assert parsed["metadata"]["labels"]["group"] == "scientist"
+
+
+def test_create_scientist_purpose_suffix(tmp_path: Path) -> None:
+    # Arrange
+    runner = CliRunner()
+    base = tmp_path / "agents"
+    runner.invoke(create_cmd, ["sci-pur", "--template", "scientist", "--base-dir", str(base)])
+    # Act
+    parsed = yaml.safe_load(_spec(base, "sci-pur").read_text())
+    # Assert — scientist purpose is the research suffix.
+    assert parsed["metadata"]["labels"]["purpose"] == "sci-pur-research"
+
+
+def test_create_group_override(tmp_path: Path) -> None:
+    # Arrange
+    runner = CliRunner()
+    base = tmp_path / "agents"
+    runner.invoke(
+        create_cmd,
+        ["grp-ovr", "--template", "developer", "--group", "platform", "--base-dir", str(base)],
+    )
+    # Act
+    parsed = yaml.safe_load(_spec(base, "grp-ovr").read_text())
+    # Assert — explicit --group wins over the template default.
+    assert parsed["metadata"]["labels"]["group"] == "platform"
+
+
+def test_create_install_block_present_when_package(tmp_path: Path) -> None:
+    # Arrange — a workdir that ships a package triggers the editable install.
+    runner = CliRunner()
+    base = tmp_path / "agents"
+    workdir = tmp_path / "pkg"
+    workdir.mkdir()
+    (workdir / "pyproject.toml").write_text("[project]\nname='x'\n")
+    # Act
+    runner.invoke(
+        create_cmd,
+        ["pkg-agent", "--template", "developer", "--workdir", str(workdir), "--base-dir", str(base)],
+    )
+    text = _spec(base, "pkg-agent").read_text()
+    # Assert — editable install command is emitted for a packaged workdir.
+    assert "uv pip install --python /uvwork/venv-agent/bin/python -e ." in text
+
+
+def test_create_install_block_absent_when_no_package(tmp_path: Path) -> None:
+    # Arrange — an empty workdir ships no package.
+    runner = CliRunner()
+    base = tmp_path / "agents"
+    workdir = tmp_path / "nopkg"
+    workdir.mkdir()
+    # Act
+    runner.invoke(
+        create_cmd,
+        ["nopkg-agent", "--template", "developer", "--workdir", str(workdir), "--base-dir", str(base)],
+    )
+    text = _spec(base, "nopkg-agent").read_text()
+    # Assert — no editable install line when the workdir has no package.
+    assert "uv pip install --python /uvwork/venv-agent/bin/python -e ." not in text
+
+
+def test_create_telegram_block_present_with_token(tmp_path: Path) -> None:
+    # Arrange — an existing token file wires the per-agent bot.
+    runner = CliRunner()
+    base = tmp_path / "agents"
+    token = tmp_path / "bot-token.txt"
+    token.write_text("123:abc\n")
+    # Act
+    runner.invoke(
+        create_cmd,
+        ["tg-agent", "--template", "scientist", "--telegram-token", str(token), "--base-dir", str(base)],
+    )
+    parsed = yaml.safe_load(_spec(base, "tg-agent").read_text())
+    # Assert — the telegrammer channel is wired when a token file exists.
+    assert "server:claude-code-telegrammer" in parsed["spec"]["claude"]["channels"]
+
+
+def test_create_telegram_block_absent_without_token(tmp_path: Path) -> None:
+    # Arrange — no token file -> no bot wiring (unique name avoids the
+    # default probe path matching a real secret).
+    runner = CliRunner()
+    base = tmp_path / "agents"
+    # Act
+    runner.invoke(
+        create_cmd,
+        ["sci-notg-xyz", "--template", "scientist", "--base-dir", str(base)],
+    )
+    parsed = yaml.safe_load(_spec(base, "sci-notg-xyz").read_text())
+    # Assert — no telegrammer channel without a token file.
+    assert "server:claude-code-telegrammer" not in parsed["spec"]["claude"]["channels"]
+
+
+def test_create_render_leaves_no_unresolved_markers(tmp_path: Path) -> None:
+    # Arrange — render directly so sentinel handling is exercised in isolation.
+    rendered = render_spec(
+        name="marker-x",
+        template="developer",
+        workdir=str(tmp_path),
+        group="developer",
+        token_path=str(tmp_path / "tok"),
+        telegram=False,
+    )
+    # Act
+    leftover = ">>>" in rendered or "<<<" in rendered or "{{" in rendered
+    # Assert — every sentinel + token is resolved in the output.
+    assert leftover is False
+
+
+def test_create_refuses_to_overwrite_existing_spec(tmp_path: Path) -> None:
+    # Arrange
+    runner = CliRunner()
+    base = tmp_path / "agents"
+    (base / "dupe").mkdir(parents=True)
+    _spec(base, "dupe").write_text("# pre-existing\n")
+    # Act
+    result = runner.invoke(create_cmd, ["dupe", "--template", "developer", "--base-dir", str(base)])
+    # Assert — non-zero exit so accidental clobber is impossible without --force.
+    assert result.exit_code != 0
+
+
+def test_create_force_overwrites_existing_spec(tmp_path: Path) -> None:
+    # Arrange
+    runner = CliRunner()
+    base = tmp_path / "agents"
+    (base / "dupe2").mkdir(parents=True)
+    _spec(base, "dupe2").write_text("# stale\n")
+    # Act
+    runner.invoke(
+        create_cmd, ["dupe2", "--template", "developer", "--base-dir", str(base), "--force"]
+    )
+    text = _spec(base, "dupe2").read_text()
+    # Assert — fresh template replaces the stale stub.
+    assert "scitex-agent-container/v3" in text
+
+
+def test_create_rejects_invalid_agent_name(tmp_path: Path) -> None:
+    # Arrange — names with slashes would write outside the base dir.
+    runner = CliRunner()
+    base = tmp_path / "agents"
+    # Act
+    result = runner.invoke(
+        create_cmd, ["bad/name", "--template", "developer", "--base-dir", str(base)]
+    )
+    # Assert
+    assert result.exit_code != 0
+
+
+def test_create_rejects_unknown_template(tmp_path: Path) -> None:
+    # Arrange
+    runner = CliRunner()
+    base = tmp_path / "agents"
+    # Act
+    result = runner.invoke(
+        create_cmd, ["whoops", "--template", "nope", "--base-dir", str(base)]
+    )
+    # Assert — Click's Choice raises UsageError (exit code 2).
+    assert result.exit_code != 0


### PR DESCRIPTION
## Summary

Folds the two prototype shell stampers into one reproducible CLI so agents can create agents without hand-written specs — **the CLI is the SSoT** (card `sac-templated-agent-create`).

- **Template skeletons** as underscore-agents: `cli_pkg/_create_templates/_developer/spec.yaml` + `_scientist/spec.yaml`, modeled on the proven `figrecipe` (developer) and `paper-scitex-clew` (scientist) shapes. Double-brace identity tokens (`NAME`/`WORKDIR`/`GROUP`/`TELEGRAM_TOKEN`); two optional blocks wrapped in `# >>>name` / `# <<<name` sentinels.
- **`sac agents create NAME --template developer|scientist`** `[--workdir P] [--telegram-token F] [--group G] [--base-dir D] [--force] [--start]`. Fills identity (name → project / workdir / overlay / state-db / `SCITEX_TODO_AGENT`) and **auto-detects**:
  - editable install — emitted iff the workdir ships `pyproject.toml`/`setup.py` (paper repos get none),
  - per-agent Telegram bot — emitted iff a bot-token file is present.
  Registered in the `agents` **Lifecycle** group, next to `new`.
- **MCP `agent_create`** mirroring the CLI (developer group already authorized to CRUD agents) — added to the register loop + `__all__`.
- **Tests**: `tests/scitex_agent_container/cli_pkg/test__create.py` — 17 tests, AAA markers, real `tmp_path` fixtures, no mocks. Covers validator-clean render for both templates, group/purpose labels, install + telegram toggling, overwrite guard, name/template rejection.

## Prototype scripts

`scripts/agents/new_agent_spec.sh` and `scripts/gen_ecosystem_dev_specs.sh` were **untracked** working-tree files (never committed), so they do not appear in this diff. Their logic is folded into the CLI; the files were archived on disk to `scripts/.old/2026-06-25/`. Bulk ecosystem stamping is now a loop over the primitive:

```bash
for p in $(scitex-dev ecosystem list ...); do sac agents create "$p" --template developer; done
```

## Verification

`sac agents new` and the full pytest harness were unavailable in the container venv (no pytest installed), so the suite was validated via two direct smoke scripts against the live `validate_config`:

- render: both templates validate clean (`errors == []`); install/telegram blocks toggle correctly; all identity tokens + sentinels resolved (16/16).
- CLI/MCP: `create` registered in the group; `agent_create` present in module + `__all__`; CLI writes + refuses overwrite + rejects bad name/template (8/8).

## Test plan

- [ ] `pytest tests/scitex_agent_container/cli_pkg/test__create.py` green in CI (matrix has pytest).
- [ ] `sac agents create scitex-io --template developer` writes a validator-clean spec.
- [ ] `sac agents create paper-x --template scientist --telegram-token <file>` wires the bun bot + telegrammer channel.
