### PR TITLE
feat(listen): OAuth single-flight boot gate (kill mass re-login race) + split _agent_exec.py

### DIFF
--- a/src/scitex_agent_container/_listen/_agent_exec.py
+++ b/src/scitex_agent_container/_listen/_agent_exec.py
@@ -1,39 +1,29 @@
-"""Agent prompt/key + start routes for ``sac listen`` (extracted from server.py).
+"""Agent start route for ``sac listen`` (extracted from server.py).
 
-Hosts the claude-execution surface — sending a prompt or interrupt key to
-an agent and starting an agent — plus the claude-binary resolver and the
-SSE streaming helper they depend on:
+Hosts the agent-start surface — POST /agents → :func:`agents_start` — which
+shells the canonical ``sac agents start`` for the named agent, records spawn
+lineage, and probes post-ack liveness. The credential-sensitive boot window is
+serialized through :mod:`._credential_refresh_lock` so concurrent brokered
+background spawns never race the shared OAuth token rotation.
 
-    POST /agents/<name>/send   → :func:`agent_send`
-    POST /agents               → :func:`agents_start`
-
-Split out of :mod:`scitex_agent_container._listen.server` (which grew
-past the per-file line cap). ``server.py`` re-imports the handlers so
-route registration (:func:`_v1_agent_routes`) and the historical
-``from ..._listen.server import agent_send`` import path keep working
-unchanged. No behaviour change — this is a pure extraction of one
-cohesive responsibility (driving the claude binary / starting agents)
-away from the host control-plane wiring that stays in ``server.py``.
+The sibling ``POST /agents/<name>/send`` surface (claude-binary resolver + SSE
+stream) lives in :mod:`._agent_exec_send`; the post-ack liveness probe lives in
+:mod:`._agent_exec_liveness`. Both are re-imported here so server.py's
+historical ``from ._agent_exec import agent_send, _find_claude_binary``
+import path keeps working unchanged.
 """
 
 from __future__ import annotations
 
-import asyncio
-import json as _json
 import os
 import shutil
-import subprocess
-import time
-from pathlib import Path
 
 from starlette.requests import Request
-from starlette.responses import JSONResponse, Response, StreamingResponse
+from starlette.responses import JSONResponse
 
-from .._runners._session_state import read_session_id, state_dir_for
-from ..config import load_config
-from ..config._resolve import resolve_config
 from ._acl import check_spawn, deny_response
-from ._forward import forward_to_live_runner
+from ._agent_exec_liveness import _probe_post_ack_liveness
+from ._agent_exec_send import _find_claude_binary, agent_send
 from ._inline_spec import materialize_inline_spec
 
 __all__ = [
@@ -41,309 +31,6 @@ __all__ = [
     "agent_send",
     "agents_start",
 ]
-
-
-# Layer-3 fail-loud (clew dogfood repro 2026-06-06, lead msg 57f1632a).
-# Grace window the listen waits AFTER `sac agents start <child>` returns
-# rc=0 before it accepts the spawn as "running and healthy". Long enough
-# for the real apptainer instance to come up on a SLURM-allocation host
-# under typical load; short enough that a stillborn instance is caught
-# before the operator's recv path treats SUCC as truth.
-_POST_ACK_LIVENESS_TIMEOUT_S = 5.0
-
-# How often to re-check the apptainer_pid file inside the grace window.
-_POST_ACK_LIVENESS_POLL_INTERVAL_S = 0.1
-
-
-def _pid_alive(pid: int) -> bool:
-    """``kill -0`` style liveness check. Returns False iff pid is reaped.
-
-    ``PermissionError`` means the kernel refused us (e.g. pid owned by
-    another uid), but the process exists — we treat that as alive.
-    Only ``ProcessLookupError`` (and the equivalent ``OSError(ESRCH)``)
-    counts as dead. ``pid <= 0`` is treated as dead defensively (the
-    file may have been written truncated / partial).
-    """
-    if pid <= 0:
-        return False
-    try:
-        os.kill(pid, 0)
-    except ProcessLookupError:
-        return False
-    except PermissionError:
-        return True
-    except OSError:
-        return False
-    return True
-
-
-def _probe_post_ack_liveness(
-    runtime_dir: Path,
-    *,
-    timeout_s: float = _POST_ACK_LIVENESS_TIMEOUT_S,
-    poll_interval_s: float = _POST_ACK_LIVENESS_POLL_INTERVAL_S,
-) -> tuple[str, str] | None:
-    """Return ``None`` if the spawned instance is live by deadline.
-
-    Returns ``(kind, hint)`` tuple on loud failure, suitable for the
-    :func:`_lifecycle._startup_failed.write_marker` ``kind_override``
-    + the operator-facing diagnostic hint:
-
-    * ``"post_ack_no_apptainer_pid"`` — the child subprocess returned
-      0 but never wrote ``<runtime_dir>/apptainer_pid``. The wrapper
-      bypassed the apptainer runtime path entirely (broken config,
-      missing image, runtime mis-resolved, etc.).
-    * ``"post_ack_apptainer_pid_dead"`` — ``apptainer_pid`` was
-      written but the process is dead (or never was alive). The SIF
-      instance came up and immediately exited; ``stderr.log`` in the
-      runtime dir usually has the actual cause.
-
-    Implementation: poll for the file to appear; once it does, check
-    liveness via ``os.kill(pid, 0)``. The check repeats until either
-    deadline OR a non-alive pid is observed, whichever comes first.
-    """
-    if timeout_s <= 0.0:
-        # Test escape hatch: zero/negative timeout skips the probe. The
-        # listen handler honours SAC_LISTEN_POST_ACK_LIVENESS_TIMEOUT_S
-        # to set this from the env so legacy tests that don't simulate
-        # the apptainer-pid write can opt out (the probe's contract is
-        # asserted by the dedicated probe-tests below).
-        return None
-    pid_file = runtime_dir / "apptainer_pid"
-    deadline = time.monotonic() + max(0.0, timeout_s)
-    saw_pid_file = False
-    last_seen_pid: int | None = None
-
-    while True:
-        if pid_file.is_file():
-            saw_pid_file = True
-            try:
-                pid = int(pid_file.read_text(encoding="utf-8").strip())
-            except (OSError, ValueError):
-                pid = -1
-            last_seen_pid = pid
-            if pid > 0 and _pid_alive(pid):
-                return None  # live → happy path
-        if time.monotonic() >= deadline:
-            break
-        time.sleep(poll_interval_s)
-
-    if not saw_pid_file:
-        return (
-            "post_ack_no_apptainer_pid",
-            f"`sac agents start` returned rc=0 but no apptainer_pid "
-            f"file appeared in {runtime_dir} within "
-            f"{timeout_s:.1f}s. The child subprocess bypassed the "
-            "apptainer runtime path (broken wrapper / missing config / "
-            "runtime mis-resolved). Inspect the runtime_dir for any "
-            "stdout/stderr the child captured, and verify the agent's "
-            "spec.apptainer block resolves to a real SIF on disk.",
-        )
-    return (
-        "post_ack_apptainer_pid_dead",
-        f"apptainer_pid={last_seen_pid} in {runtime_dir} was reaped "
-        f"within {timeout_s:.1f}s of the spawn-ack. The SIF instance "
-        "came up and exited silently — check the runtime_dir's "
-        "stderr.log for the apptainer FATAL line. Common causes: "
-        "missing bind source on host, SIF binary missing on host, "
-        "in-SIF entrypoint crashing on a startup-prompt eval.",
-    )
-
-
-def _find_claude_binary() -> str:
-    """Same resolver as send_cmds — bundled SDK copy first, then PATH."""
-    bundled = (
-        "/opt/venv-sac/lib/python3.12/site-packages/claude_agent_sdk/_bundled/claude"
-    )
-    if os.path.isfile(bundled) and os.access(bundled, os.X_OK):
-        return bundled
-    found = shutil.which("claude")
-    if not found:
-        raise RuntimeError("claude binary not found")
-    return found
-
-
-async def agent_send(request: Request) -> Response:
-    """POST /agents/<name>/send.
-
-    Body discriminator (per REQUIREMENT_SUMMARY §4.2):
-        {"type":"prompt","prompt":"...","options":{...}}
-        {"type":"key","key":"ESC"}
-
-    Back-compat (this commit only): a body without ``type`` is treated
-    as ``{type: "prompt", ...}`` so existing callers keep working.
-
-    Routing for ``type: prompt``:
-        1. If the agent has ``spec.a2a.port`` set and its inbound HTTP
-           is reachable, forward the turn into the live in-memory
-           runner inbox.
-        2. Otherwise fall back to ``claude --resume <sid> -p`` —
-           short-lived re-launch against the persisted session.jsonl.
-
-    Routing for ``type: key``:
-        SIGINT the live runner pid (best-effort). ESC / C-c / SIGINT
-        accepted; unknown keys → 400. No live runner → 404.
-    """
-    name = request.path_params["name"]
-    try:
-        body = await request.json()
-    except Exception:  # stx-allow: fallback (reason: malformed JSON → 400 with explanation rather than ASGI 500)
-        return JSONResponse({"error": "body must be JSON"}, status_code=400)
-
-    # Default to prompt when ``type`` is absent — back-compat shim
-    # documented in REQUIREMENT_SUMMARY §4.2.
-    type_ = body.get("type", "prompt")
-    if type_ == "key":
-        key = body.get("key")
-        # Supported: ESC / C-c / SIGINT — all map to SIGINT on the
-        # runner pid, which interrupts the current turn without
-        # killing the agent.
-        if key not in ("ESC", "C-c", "SIGINT"):
-            return JSONResponse(
-                {
-                    "error": (
-                        f"unsupported key={key!r}; expected one of "
-                        "'ESC', 'C-c', 'SIGINT'"
-                    )
-                },
-                status_code=400,
-            )
-        import signal as _signal
-
-        sd = state_dir_for(name)
-        pid_file = sd / "pid"
-        if not pid_file.is_file():
-            return JSONResponse(
-                {"error": f"agent {name!r} has no live session"},
-                status_code=404,
-            )
-        try:
-            pid = int(pid_file.read_text().strip())
-            os.kill(pid, _signal.SIGINT)
-        except (OSError, ValueError) as exc:
-            return JSONResponse({"error": str(exc)}, status_code=500)
-        return JSONResponse(
-            {
-                "name": name,
-                "route": "interrupt",
-                "pid": pid,
-                "signal": "SIGINT",
-            }
-        )
-    if type_ != "prompt":
-        return JSONResponse(
-            {"error": f"unknown type {type_!r}; expected 'prompt' or 'key'"},
-            status_code=400,
-        )
-
-    prompt = body.get("prompt")
-    if not isinstance(prompt, str) or not prompt:
-        return JSONResponse(
-            {"error": "missing or empty 'prompt' string"}, status_code=400
-        )
-
-    try:
-        spec_path = resolve_config(name)
-        cfg = load_config(spec_path)
-    except Exception as exc:
-        return JSONResponse({"error": str(exc)}, status_code=404)
-
-    # 1) Try live-runner route first.
-    options = body.get("options") or {}
-    live = await forward_to_live_runner(cfg, name, prompt, options)
-    if live is not None:
-        return live
-
-    # 2) Fall back to short-lived re-launch.
-    sd = state_dir_for(name)
-    sid = read_session_id(sd)
-    if not sid:
-        return JSONResponse(
-            {"error": f"no session_id recorded for {name!r}"}, status_code=409
-        )
-
-    try:
-        claude_bin = _find_claude_binary()
-    except RuntimeError as exc:
-        return JSONResponse({"error": str(exc)}, status_code=500)
-
-    argv = [claude_bin, "--resume", sid, "-p", prompt]
-    if "model" in options:
-        argv += ["--model", str(options["model"])]
-    if "max_turns" in options:
-        argv += ["--max-turns", str(options["max_turns"])]
-
-    workdir = cfg.expanded_workdir or os.getcwd()
-
-    # SSE branch: client opted in via Accept: text/event-stream. Stream
-    # claude's stdout line-by-line as SSE frames.
-    accept = request.headers.get("accept", "")
-    if "text/event-stream" in accept:
-        argv += ["--output-format", "stream-json", "--include-partial-messages"]
-        return StreamingResponse(
-            _stream_claude(argv, workdir, name, sid),
-            media_type="text/event-stream",
-            headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
-        )
-
-    # Buffered branch (default): run to completion, return one JSON blob.
-    proc = await asyncio.to_thread(
-        subprocess.run,
-        argv,
-        cwd=workdir,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    return JSONResponse(
-        {
-            "name": name,
-            "session_id": sid,
-            "returncode": proc.returncode,
-            "stdout": proc.stdout,
-            "stderr": proc.stderr,
-        }
-    )
-
-
-def _sse_frame(event: str | None, data: str) -> bytes:
-    """Encode one SSE frame. ``event`` is optional; ``data`` is one line."""
-    head = f"event: {event}\n" if event else ""
-    return (head + f"data: {data}\n\n").encode("utf-8")
-
-
-async def _stream_claude(argv: list[str], workdir: str, name: str, sid: str):
-    """Run claude as an async subprocess and yield SSE frames."""
-    try:
-        proc = await asyncio.create_subprocess_exec(
-            *argv,
-            cwd=workdir,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-    except FileNotFoundError as exc:
-        yield _sse_frame("error", _json.dumps({"error": str(exc)}))
-        return
-
-    yield _sse_frame("start", _json.dumps({"name": name, "session_id": sid}))
-
-    assert proc.stdout is not None
-    try:
-        while True:
-            line = await proc.stdout.readline()
-            if not line:
-                break
-            yield _sse_frame(None, line.decode("utf-8", "replace").rstrip("\n"))
-        rc = await proc.wait()
-        yield _sse_frame("done", _json.dumps({"returncode": rc}))
-    except (asyncio.CancelledError, GeneratorExit):
-        if proc.returncode is None:
-            proc.terminate()
-            try:
-                await asyncio.wait_for(proc.wait(), timeout=2.0)
-            except asyncio.TimeoutError:
-                proc.kill()
-        raise
 
 
 async def agents_start(request: Request) -> JSONResponse:
@@ -490,13 +177,21 @@ async def agents_start(request: Request) -> JSONResponse:
     if one_shot:
         inner_argv.append("--one-shot")
     inner_argv.append(name)
-    proc = await asyncio.to_thread(
-        subprocess.run,
+    # Single-flight the OAuth-refresh boot window (card
+    # sac-multi-start-queue-oauth): concurrent brokered background spawns share
+    # ~/.claude/.credentials.json and would race the in-container token
+    # rotation -> the loser's freshly-rotated token is clobbered -> 401 ->
+    # mass re-login. run_brokered_launch serializes background launches through
+    # a blocking flock + bounded refresh-settle; foreground / one-shot bypass
+    # it (single, interactive, long-lived — a fleet-wide lock held that long
+    # would serialize everything for no safety gain).
+    from ._credential_refresh_lock import run_brokered_launch
+
+    proc = await run_brokered_launch(
         inner_argv,
-        capture_output=True,
-        text=True,
-        check=False,
-        env=child_env,
+        child_env,
+        foreground=bool(foreground),
+        one_shot=bool(one_shot),
     )
     if proc.returncode != 0:
         # PR-1 — stillborn agent observability. The subprocess can exit
@@ -592,11 +287,11 @@ async def agents_start(request: Request) -> JSONResponse:
         env_timeout = float(
             os.environ.get(
                 "SAC_LISTEN_POST_ACK_LIVENESS_TIMEOUT_S",
-                str(_POST_ACK_LIVENESS_TIMEOUT_S),
+                str(5.0),
             )
         )
     except ValueError:
-        env_timeout = _POST_ACK_LIVENESS_TIMEOUT_S
+        env_timeout = 5.0
     liveness_failure = _probe_post_ack_liveness(
         runtime_dir,
         timeout_s=env_timeout,

--- a/src/scitex_agent_container/_listen/_agent_exec_liveness.py
+++ b/src/scitex_agent_container/_listen/_agent_exec_liveness.py
@@ -1,0 +1,129 @@
+"""Post-ack liveness probe for brokered spawns (extracted from _agent_exec).
+
+Layer-3 fail-loud (clew dogfood repro 2026-06-06, lead msg 57f1632a): after
+``sac agents start <child>`` returns rc=0, the listen waits a grace window for
+the real apptainer instance to come up before accepting the spawn as healthy —
+a SIF that comes up and dies silently must not be reported as SUCC.
+
+Split out of :mod:`scitex_agent_container._listen._agent_exec` to keep that
+module under the per-file line cap. ``_agent_exec`` re-imports
+``_probe_post_ack_liveness`` so its behavior is unchanged.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+__all__ = [
+    "_POST_ACK_LIVENESS_TIMEOUT_S",
+    "_POST_ACK_LIVENESS_POLL_INTERVAL_S",
+    "_pid_alive",
+    "_probe_post_ack_liveness",
+]
+
+# Grace window the listen waits AFTER `sac agents start <child>` returns rc=0
+# before it accepts the spawn as "running and healthy". Long enough for the
+# real apptainer instance to come up on a SLURM-allocation host under typical
+# load; short enough that a stillborn instance is caught before the operator's
+# recv path treats SUCC as truth.
+_POST_ACK_LIVENESS_TIMEOUT_S = 5.0
+
+# How often to re-check the apptainer_pid file inside the grace window.
+_POST_ACK_LIVENESS_POLL_INTERVAL_S = 0.1
+
+
+def _pid_alive(pid: int) -> bool:
+    """``kill -0`` style liveness check. Returns False iff pid is reaped.
+
+    ``PermissionError`` means the kernel refused us (e.g. pid owned by
+    another uid), but the process exists — we treat that as alive.
+    Only ``ProcessLookupError`` (and the equivalent ``OSError(ESRCH)``)
+    counts as dead. ``pid <= 0`` is treated as dead defensively (the
+    file may have been written truncated / partial).
+    """
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def _probe_post_ack_liveness(
+    runtime_dir: Path,
+    *,
+    timeout_s: float = _POST_ACK_LIVENESS_TIMEOUT_S,
+    poll_interval_s: float = _POST_ACK_LIVENESS_POLL_INTERVAL_S,
+) -> tuple[str, str] | None:
+    """Return ``None`` if the spawned instance is live by deadline.
+
+    Returns ``(kind, hint)`` tuple on loud failure, suitable for the
+    :func:`_lifecycle._startup_failed.write_marker` ``kind_override``
+    + the operator-facing diagnostic hint:
+
+    * ``"post_ack_no_apptainer_pid"`` — the child subprocess returned
+      0 but never wrote ``<runtime_dir>/apptainer_pid``. The wrapper
+      bypassed the apptainer runtime path entirely (broken config,
+      missing image, runtime mis-resolved, etc.).
+    * ``"post_ack_apptainer_pid_dead"`` — ``apptainer_pid`` was
+      written but the process is dead (or never was alive). The SIF
+      instance came up and immediately exited; ``stderr.log`` in the
+      runtime dir usually has the actual cause.
+
+    Implementation: poll for the file to appear; once it does, check
+    liveness via ``os.kill(pid, 0)``. The check repeats until either
+    deadline OR a non-alive pid is observed, whichever comes first.
+    """
+    if timeout_s <= 0.0:
+        # Test escape hatch: zero/negative timeout skips the probe. The
+        # listen handler honours SAC_LISTEN_POST_ACK_LIVENESS_TIMEOUT_S
+        # to set this from the env so legacy tests that don't simulate
+        # the apptainer-pid write can opt out (the probe's contract is
+        # asserted by the dedicated probe-tests below).
+        return None
+    pid_file = runtime_dir / "apptainer_pid"
+    deadline = time.monotonic() + max(0.0, timeout_s)
+    saw_pid_file = False
+    last_seen_pid: int | None = None
+
+    while True:
+        if pid_file.is_file():
+            saw_pid_file = True
+            try:
+                pid = int(pid_file.read_text(encoding="utf-8").strip())
+            except (OSError, ValueError):
+                pid = -1
+            last_seen_pid = pid
+            if pid > 0 and _pid_alive(pid):
+                return None  # live → happy path
+        if time.monotonic() >= deadline:
+            break
+        time.sleep(poll_interval_s)
+
+    if not saw_pid_file:
+        return (
+            "post_ack_no_apptainer_pid",
+            f"`sac agents start` returned rc=0 but no apptainer_pid "
+            f"file appeared in {runtime_dir} within "
+            f"{timeout_s:.1f}s. The child subprocess bypassed the "
+            "apptainer runtime path (broken wrapper / missing config / "
+            "runtime mis-resolved). Inspect the runtime_dir for any "
+            "stdout/stderr the child captured, and verify the agent's "
+            "spec.apptainer block resolves to a real SIF on disk.",
+        )
+    return (
+        "post_ack_apptainer_pid_dead",
+        f"apptainer_pid={last_seen_pid} in {runtime_dir} was reaped "
+        f"within {timeout_s:.1f}s of the spawn-ack. The SIF instance "
+        "came up and exited silently — check the runtime_dir's "
+        "stderr.log for the apptainer FATAL line. Common causes: "
+        "missing bind source on host, SIF binary missing on host, "
+        "in-SIF entrypoint crashing on a startup-prompt eval.",
+    )

--- a/src/scitex_agent_container/_listen/_agent_exec_send.py
+++ b/src/scitex_agent_container/_listen/_agent_exec_send.py
@@ -1,0 +1,227 @@
+"""``POST /agents/<name>/send`` route + claude-binary resolver + SSE stream.
+
+Split out of :mod:`scitex_agent_container._listen._agent_exec` to keep that
+module under the per-file line cap. ``_agent_exec`` re-imports
+``agent_send`` and ``_find_claude_binary`` (server.py imports them from
+``_agent_exec``), so the public import paths are unchanged.
+
+    POST /agents/<name>/send → :func:`agent_send`
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json as _json
+import os
+import shutil
+import subprocess
+
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response, StreamingResponse
+
+from .._runners._session_state import read_session_id, state_dir_for
+from ..config import load_config
+from ..config._resolve import resolve_config
+from ._forward import forward_to_live_runner
+
+__all__ = [
+    "_find_claude_binary",
+    "_sse_frame",
+    "_stream_claude",
+    "agent_send",
+]
+
+
+def _find_claude_binary() -> str:
+    """Same resolver as send_cmds — bundled SDK copy first, then PATH."""
+    bundled = (
+        "/opt/venv-sac/lib/python3.12/site-packages/claude_agent_sdk/_bundled/claude"
+    )
+    if os.path.isfile(bundled) and os.access(bundled, os.X_OK):
+        return bundled
+    found = shutil.which("claude")
+    if not found:
+        raise RuntimeError("claude binary not found")
+    return found
+
+
+async def agent_send(request: Request) -> Response:
+    """POST /agents/<name>/send.
+
+    Body discriminator (per REQUIREMENT_SUMMARY §4.2):
+        {"type":"prompt","prompt":"...","options":{...}}
+        {"type":"key","key":"ESC"}
+
+    Back-compat (this commit only): a body without ``type`` is treated
+    as ``{type: "prompt", ...}`` so existing callers keep working.
+
+    Routing for ``type: prompt``:
+        1. If the agent has ``spec.a2a.port`` set and its inbound HTTP
+           is reachable, forward the turn into the live in-memory
+           runner inbox.
+        2. Otherwise fall back to ``claude --resume <sid> -p`` —
+           short-lived re-launch against the persisted session.jsonl.
+
+    Routing for ``type: key``:
+        SIGINT the live runner pid (best-effort). ESC / C-c / SIGINT
+        accepted; unknown keys → 400. No live runner → 404.
+    """
+    name = request.path_params["name"]
+    try:
+        body = await request.json()
+    except Exception:  # stx-allow: fallback (reason: malformed JSON → 400 with explanation rather than ASGI 500)
+        return JSONResponse({"error": "body must be JSON"}, status_code=400)
+
+    # Default to prompt when ``type`` is absent — back-compat shim
+    # documented in REQUIREMENT_SUMMARY §4.2.
+    type_ = body.get("type", "prompt")
+    if type_ == "key":
+        key = body.get("key")
+        # Supported: ESC / C-c / SIGINT — all map to SIGINT on the
+        # runner pid, which interrupts the current turn without
+        # killing the agent.
+        if key not in ("ESC", "C-c", "SIGINT"):
+            return JSONResponse(
+                {
+                    "error": (
+                        f"unsupported key={key!r}; expected one of "
+                        "'ESC', 'C-c', 'SIGINT'"
+                    )
+                },
+                status_code=400,
+            )
+        import signal as _signal
+
+        sd = state_dir_for(name)
+        pid_file = sd / "pid"
+        if not pid_file.is_file():
+            return JSONResponse(
+                {"error": f"agent {name!r} has no live session"},
+                status_code=404,
+            )
+        try:
+            pid = int(pid_file.read_text().strip())
+            os.kill(pid, _signal.SIGINT)
+        except (OSError, ValueError) as exc:
+            return JSONResponse({"error": str(exc)}, status_code=500)
+        return JSONResponse(
+            {
+                "name": name,
+                "route": "interrupt",
+                "pid": pid,
+                "signal": "SIGINT",
+            }
+        )
+    if type_ != "prompt":
+        return JSONResponse(
+            {"error": f"unknown type {type_!r}; expected 'prompt' or 'key'"},
+            status_code=400,
+        )
+
+    prompt = body.get("prompt")
+    if not isinstance(prompt, str) or not prompt:
+        return JSONResponse(
+            {"error": "missing or empty 'prompt' string"}, status_code=400
+        )
+
+    try:
+        spec_path = resolve_config(name)
+        cfg = load_config(spec_path)
+    except Exception as exc:
+        return JSONResponse({"error": str(exc)}, status_code=404)
+
+    # 1) Try live-runner route first.
+    options = body.get("options") or {}
+    live = await forward_to_live_runner(cfg, name, prompt, options)
+    if live is not None:
+        return live
+
+    # 2) Fall back to short-lived re-launch.
+    sd = state_dir_for(name)
+    sid = read_session_id(sd)
+    if not sid:
+        return JSONResponse(
+            {"error": f"no session_id recorded for {name!r}"}, status_code=409
+        )
+
+    try:
+        claude_bin = _find_claude_binary()
+    except RuntimeError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=500)
+
+    argv = [claude_bin, "--resume", sid, "-p", prompt]
+    if "model" in options:
+        argv += ["--model", str(options["model"])]
+    if "max_turns" in options:
+        argv += ["--max-turns", str(options["max_turns"])]
+
+    workdir = cfg.expanded_workdir or os.getcwd()
+
+    # SSE branch: client opted in via Accept: text/event-stream. Stream
+    # claude's stdout line-by-line as SSE frames.
+    accept = request.headers.get("accept", "")
+    if "text/event-stream" in accept:
+        argv += ["--output-format", "stream-json", "--include-partial-messages"]
+        return StreamingResponse(
+            _stream_claude(argv, workdir, name, sid),
+            media_type="text/event-stream",
+            headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+        )
+
+    # Buffered branch (default): run to completion, return one JSON blob.
+    proc = await asyncio.to_thread(
+        subprocess.run,
+        argv,
+        cwd=workdir,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return JSONResponse(
+        {
+            "name": name,
+            "session_id": sid,
+            "returncode": proc.returncode,
+            "stdout": proc.stdout,
+            "stderr": proc.stderr,
+        }
+    )
+
+
+def _sse_frame(event: str | None, data: str) -> bytes:
+    """Encode one SSE frame. ``event`` is optional; ``data`` is one line."""
+    head = f"event: {event}\n" if event else ""
+    return (head + f"data: {data}\n\n").encode("utf-8")
+
+
+async def _stream_claude(argv: list[str], workdir: str, name: str, sid: str):
+    """Run claude as an async subprocess and yield SSE frames."""
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *argv,
+            cwd=workdir,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+    except FileNotFoundError as exc:
+        yield _sse_frame("error", _json.dumps({"error": str(exc)}))
+        return
+
+    yield _sse_frame("start", _json.dumps({"name": name, "session_id": sid}))
+    assert proc.stdout is not None
+    try:
+        while True:
+            line = await proc.stdout.readline()
+            if not line:
+                break
+            yield _sse_frame(None, line.decode("utf-8", "replace").rstrip("\n"))
+        rc = await proc.wait()
+        yield _sse_frame("done", _json.dumps({"returncode": rc}))
+    except (asyncio.CancelledError, GeneratorExit):
+        if proc.returncode is None:
+            proc.terminate()
+            try:
+                await asyncio.wait_for(proc.wait(), timeout=2.0)
+            except asyncio.TimeoutError:
+                proc.kill()
+        raise

--- a/src/scitex_agent_container/_listen/_credential_refresh_lock.py
+++ b/src/scitex_agent_container/_listen/_credential_refresh_lock.py
@@ -80,9 +80,13 @@ def _read_expires_at_ms() -> int | None:
 def _refresh_imminent(expires_at_ms: int | None, now_ms: float, window_ms: float) -> bool:
     """True iff a boot-time refresh is plausible (token at/near expiry).
 
-    Unknown expiry returns True (serialize defensively)."""
+    Unknown expiry returns False: if we cannot read ``expiresAt`` there is
+    either no OAuth token to rotate (api-key / no-creds setups) or no way to
+    observe a refresh landing, so settling would only delay without
+    coordinating. The flock still serializes the brief launch window in that
+    case; the settle wait engages only when we can actually watch the rotation."""
     if expires_at_ms is None:
-        return True
+        return False
     return (expires_at_ms - now_ms) <= window_ms
 
 

--- a/src/scitex_agent_container/_listen/_credential_refresh_lock.py
+++ b/src/scitex_agent_container/_listen/_credential_refresh_lock.py
@@ -1,0 +1,220 @@
+"""Single-flight boot-window lock for the shared OAuth credential file.
+
+Card sac-multi-start-queue-oauth (2026-06-25). Every agent binds the same
+``~/.claude/.credentials.json`` ``:rw``; the in-container ``claude`` refreshes
+the rotating OAuth token. When many agents boot at once they race that refresh
+and clobber each other's freshly-rotated (single-use) token -> the loser gets a
+401 -> mass re-login.
+
+sac never holds the OAuth token material (it only reads safe metadata such as
+``expiresAt`` — see ``_account/credentials.py``). It can therefore only
+*serialize access*, not perform the refresh. This module serializes the
+credential-sensitive BOOT window across processes with a BLOCKING
+``fcntl.flock(LOCK_EX)`` so only one agent boots through its initial OAuth
+refresh at a time.
+
+Subtlety: a BACKGROUND ``sac agents start`` returns as soon as the container is
+kicked off — BEFORE the in-container ``claude`` has refreshed. So holding the
+lock only for the launch subprocess would not actually cover the refresh. The
+gate therefore holds the lock through a bounded *settle window* after the
+launch, releasing the next waiter as soon as the shared file's ``expiresAt``
+changes (refresh observed) or the timeout elapses. The settle wait is engaged
+only when a refresh is actually imminent (token at/near expiry); a healthy
+far-from-expiry token boots through with just the brief flock.
+
+Mirrors the proven flock pattern in ``_single_instance.py`` but BLOCKING (we
+want to wait our turn, not fail fast) and not port-scoped (one credential file
+for the whole fleet on a host). NOT covered here: the ~1h-later in-flight
+rotation of already-running agents — that needs per-agent snapshots or a
+long-lived broker and is tracked separately.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import fcntl
+import os
+import subprocess
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+_LOCK_NAME = "creds-refresh.lock"
+# Hold the lock at most this long after a launch while waiting for the
+# holder's OAuth refresh to land. Operator-overridable via
+# SAC_CREDS_SETTLE_SECONDS; 0 disables the gate entirely (no serialization).
+_DEFAULT_SETTLE_SECONDS = 20.0
+# Only engage the settle wait when the token expires within this window — a
+# far-from-expiry token will not refresh at boot, so there is nothing to race.
+_DEFAULT_IMMINENT_WINDOW_SECONDS = 300.0
+_POLL_INTERVAL_SECONDS = 0.5
+
+__all__ = [
+    "credential_lock_path",
+    "credential_boot_gate",
+    "gate_settings_from_env",
+    "run_brokered_launch",
+]
+
+
+def credential_lock_path(lock_dir: Path) -> Path:
+    """Return the fleet-wide credential-refresh lock path under ``lock_dir``."""
+    return lock_dir / _LOCK_NAME
+
+
+def _read_expires_at_ms() -> int | None:
+    """Best-effort read of ``claudeAiOauth.expiresAt`` (unix-ms) from the
+    shared credential file. Returns ``None`` when unreadable — the caller
+    treats unknown as "be safe, serialize". Never reads token material."""
+    try:
+        from .._account.credentials import read_credentials_metadata
+
+        meta = read_credentials_metadata()
+        value = meta.get("expiresAt")
+        return int(value) if value is not None else None
+    except Exception:  # stx-allow: fallback (reason: metadata read is advisory; unknown -> serialize)
+        return None
+
+
+def _refresh_imminent(expires_at_ms: int | None, now_ms: float, window_ms: float) -> bool:
+    """True iff a boot-time refresh is plausible (token at/near expiry).
+
+    Unknown expiry returns True (serialize defensively)."""
+    if expires_at_ms is None:
+        return True
+    return (expires_at_ms - now_ms) <= window_ms
+
+
+def gate_settings_from_env() -> tuple[Path, float, float]:
+    """Resolve ``(lock_dir, settle_seconds, imminent_window_seconds)`` from env.
+
+    ``SAC_CREDS_SETTLE_SECONDS`` overrides the settle cap (0 disables the gate).
+    ``SAC_CREDS_REFRESH_IMMINENT_SECONDS`` overrides the imminence window. The
+    lock dir mirrors the listen single-instance lock dir."""
+    from ._single_instance import default_lock_dir
+
+    settle = _env_float("SAC_CREDS_SETTLE_SECONDS", _DEFAULT_SETTLE_SECONDS)
+    window = _env_float(
+        "SAC_CREDS_REFRESH_IMMINENT_SECONDS", _DEFAULT_IMMINENT_WINDOW_SECONDS
+    )
+    return default_lock_dir(), settle, window
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = os.environ.get(name)
+    if raw is None or raw.strip() == "":
+        return default
+    try:
+        return float(raw)
+    except ValueError:  # stx-allow: fallback (reason: a malformed knob must not crash the launch path; fall back to the default)
+        return default
+
+
+@contextmanager
+def credential_boot_gate(
+    *,
+    lock_dir: Path,
+    settle_seconds: float = _DEFAULT_SETTLE_SECONDS,
+    imminent_window_seconds: float = _DEFAULT_IMMINENT_WINDOW_SECONDS,
+) -> Iterator[None]:
+    """Serialize the credential-sensitive boot window across processes.
+
+    Acquires a BLOCKING exclusive flock on ``<lock_dir>/creds-refresh.lock``,
+    runs the wrapped body (the launch), then — only when a refresh was
+    imminent at acquire time — holds the lock until the shared credential
+    file's ``expiresAt`` changes (refresh landed) or ``settle_seconds``
+    elapses, before releasing the next waiter. ``settle_seconds <= 0`` makes
+    the whole gate a no-op (no flock, no wait)."""
+    if settle_seconds <= 0:
+        yield
+        return
+
+    lock_dir.mkdir(parents=True, exist_ok=True)
+    path = credential_lock_path(lock_dir)
+    fd = os.open(str(path), os.O_CREAT | os.O_RDWR, 0o644)
+    fcntl.flock(fd, fcntl.LOCK_EX)  # BLOCKING — wait our turn through the window
+    baseline_expires = _read_expires_at_ms()
+    imminent = _refresh_imminent(
+        baseline_expires, time.time() * 1000.0, imminent_window_seconds * 1000.0
+    )
+    try:
+        os.ftruncate(fd, 0)
+        os.write(fd, f"{os.getpid()}\n".encode("utf-8"))
+        yield
+    finally:
+        if imminent:
+            _wait_for_refresh(baseline_expires, settle_seconds)
+        try:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        except OSError:  # stx-allow: fallback (reason: best-effort; kernel releases on close)
+            pass
+        try:
+            os.close(fd)
+        except OSError:  # stx-allow: fallback (reason: fd already invalid — non-fatal)
+            pass
+
+
+def _wait_for_refresh(baseline_expires_ms: int | None, settle_seconds: float) -> None:
+    """Hold until the shared credential ``expiresAt`` changes or timeout.
+
+    A changed ``expiresAt`` means the holder's in-container ``claude`` rotated
+    the token, so the next waiter will read the fresh value instead of racing
+    it. Polls cheaply; the cap bounds the worst case (e.g. the token was not
+    actually near expiry, or refresh failed)."""
+    deadline = time.monotonic() + settle_seconds
+    while time.monotonic() < deadline:
+        current = _read_expires_at_ms()
+        if (
+            current is not None
+            and baseline_expires_ms is not None
+            and current != baseline_expires_ms
+        ):
+            return
+        time.sleep(_POLL_INTERVAL_SECONDS)
+
+
+def _run_locked(
+    inner_argv: list[str],
+    child_env: dict[str, str],
+) -> "subprocess.CompletedProcess[str]":
+    lock_dir, settle, window = gate_settings_from_env()
+    with credential_boot_gate(
+        lock_dir=lock_dir,
+        settle_seconds=settle,
+        imminent_window_seconds=window,
+    ):
+        return subprocess.run(
+            inner_argv,
+            capture_output=True,
+            text=True,
+            check=False,
+            env=child_env,
+        )
+
+
+async def run_brokered_launch(
+    inner_argv: list[str],
+    child_env: dict[str, str],
+    *,
+    foreground: bool,
+    one_shot: bool,
+) -> "subprocess.CompletedProcess[str]":
+    """Run the brokered ``sac agents start`` subprocess off the event loop.
+
+    Background launches go through :func:`credential_boot_gate` so concurrent
+    brokered spawns serialize through the OAuth-refresh boot window. Foreground
+    / one-shot launches BYPASS the gate: they are single, interactive, and
+    block for the whole session — holding a fleet-wide lock that long would
+    serialize everything for no safety gain (the mass-launch race is the
+    background path)."""
+    if foreground or one_shot:
+        return await asyncio.to_thread(
+            subprocess.run,
+            inner_argv,
+            capture_output=True,
+            text=True,
+            check=False,
+            env=child_env,
+        )
+    return await asyncio.to_thread(_run_locked, inner_argv, child_env)

--- a/tests/scitex_agent_container/_listen/test__credential_refresh_lock.py
+++ b/tests/scitex_agent_container/_listen/test__credential_refresh_lock.py
@@ -1,0 +1,152 @@
+"""Tests for the credential-refresh single-flight boot gate.
+
+Card sac-multi-start-queue-oauth (2026-06-25). The gate serializes the
+OAuth-refresh boot window across concurrent brokered spawns so they don't race
+the shared ~/.claude/.credentials.json token rotation.
+
+Discipline: AAA markers each on their own line; one literal ``assert`` per
+test; real filesystem + real fcntl flock fixtures (``tmp_path`` + threads), no
+mocks.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._listen._credential_refresh_lock import (
+    _refresh_imminent,
+    credential_boot_gate,
+    credential_lock_path,
+    gate_settings_from_env,
+    run_brokered_launch,
+)
+
+
+@pytest.fixture
+def settle_disabled_env():
+    """Set SAC_CREDS_SETTLE_SECONDS=0 on the real environment, restore on exit.
+
+    A yield fixture (not ``monkeypatch``) so the gate reads the real env var
+    exactly as production does."""
+    key = "SAC_CREDS_SETTLE_SECONDS"
+    prev = os.environ.get(key)
+    os.environ[key] = "0"
+    try:
+        yield
+    finally:
+        if prev is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = prev
+
+
+def test_credential_lock_path_is_scoped_under_lock_dir(tmp_path: Path) -> None:
+    # Arrange
+    lock_dir = tmp_path / "runtime"
+    # Act
+    path = credential_lock_path(lock_dir)
+    # Assert
+    assert path == lock_dir / "creds-refresh.lock"
+
+
+def test_refresh_imminent_unknown_expiry_is_false() -> None:
+    # Arrange — unknown expiry: nothing observable to settle on, so the gate
+    # must not block (the flock still serializes the brief launch window).
+    # Act
+    result = _refresh_imminent(None, now_ms=0.0, window_ms=300_000.0)
+    # Assert
+    assert result is False
+
+
+def test_refresh_imminent_far_future_is_false() -> None:
+    # Arrange — token expires well outside the imminence window.
+    # Act
+    result = _refresh_imminent(600_000, now_ms=0.0, window_ms=300_000.0)
+    # Assert
+    assert result is False
+
+
+def test_refresh_imminent_near_expiry_is_true() -> None:
+    # Arrange — token expires inside the imminence window.
+    # Act
+    result = _refresh_imminent(60_000, now_ms=0.0, window_ms=300_000.0)
+    # Assert
+    assert result is True
+
+
+def test_gate_is_noop_when_settle_disabled(tmp_path: Path) -> None:
+    # Arrange — settle_seconds <= 0 disables the gate entirely.
+    lock_dir = tmp_path / "runtime"
+    # Act
+    with credential_boot_gate(lock_dir=lock_dir, settle_seconds=0.0):
+        pass
+    # Assert — no lock file is created when the gate is a no-op.
+    assert not credential_lock_path(lock_dir).exists()
+
+
+def test_gate_serializes_concurrent_holders(tmp_path: Path) -> None:
+    # Arrange — three threads contend for the same lock dir; the flock must
+    # admit only one at a time. imminent_window_seconds=0 avoids the settle
+    # wait when a real (non-expired) cred file is present; the per-body sleep
+    # creates the contention window.
+    lock_dir = tmp_path / "runtime"
+    inside: list[int] = []
+    violations: list[int] = []
+
+    def worker() -> None:
+        with credential_boot_gate(
+            lock_dir=lock_dir, settle_seconds=0.05, imminent_window_seconds=0.0
+        ):
+            inside.append(1)
+            if len(inside) > 1:
+                violations.append(1)
+            time.sleep(0.05)
+            inside.pop()
+
+    threads = [threading.Thread(target=worker) for _ in range(3)]
+    # Act
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    # Assert — never two holders inside the gate simultaneously.
+    assert violations == []
+
+
+def test_gate_settings_from_env_parses_settle_override(settle_disabled_env) -> None:
+    # Arrange — settle_disabled_env sets SAC_CREDS_SETTLE_SECONDS=0 for real.
+    # Act
+    _lock_dir, settle, _window = gate_settings_from_env()
+    # Assert
+    assert settle == 0.0
+
+
+@pytest.mark.asyncio
+async def test_run_brokered_launch_foreground_runs_argv() -> None:
+    # Arrange — foreground bypasses the gate but must still run the argv.
+    argv = [sys.executable, "-c", "import sys; sys.exit(7)"]
+    # Act
+    proc = await run_brokered_launch(
+        argv, dict(os.environ), foreground=True, one_shot=False
+    )
+    # Assert
+    assert proc.returncode == 7
+
+
+@pytest.mark.asyncio
+async def test_run_brokered_launch_background_runs_argv(settle_disabled_env) -> None:
+    # Arrange — settle_disabled_env disables the gate so the background path
+    # just runs the argv (no flock / settle).
+    argv = [sys.executable, "-c", "import sys; sys.exit(5)"]
+    # Act
+    proc = await run_brokered_launch(
+        argv, dict(os.environ), foreground=False, one_shot=False
+    )
+    # Assert
+    assert proc.returncode == 5


### PR DESCRIPTION
## Summary

Half-B of card `sac-multi-start-queue-oauth`: serialize the OAuth-credential refresh **boot window** in the listen server so concurrent brokered spawns don't race the shared token rotation.

**The race:** every agent binds the same `~/.claude/.credentials.json` `:rw`; their in-container `claude` refreshes the rotating, single-use OAuth token. When many boot at once they refresh concurrently, the last writer wins, and the loser's freshly-rotated token is invalidated → 401 → mass re-login. **sac never holds the token material** (only reads `expiresAt`), so it can only *coordinate access*.

**The gate** (`_listen/_credential_refresh_lock.py`): a blocking `fcntl.flock(LOCK_EX)` around the credential-sensitive boot window, plus a bounded *settle* — after a launch, hold the lock until the shared file's `expiresAt` changes (refresh landed) or `SAC_CREDS_SETTLE_SECONDS` (default 20) elapses, so the next waiter reads the rotated token instead of racing it.
- **Background** brokered spawns go through the gate (the mass-launch path).
- **Foreground / one-shot** bypass it (single, interactive, long-lived — a fleet-wide lock held that long would serialize everything for no safety gain).
- **Unknown `expiresAt`** (creds-less / api-key setups) → *not imminent* → no settle (the flock still serializes the brief window); the settle engages only when `expiresAt` is known and near expiry — the actual dangerous window. This also keeps the existing listen tests from blocking.

## Prerequisite refactor (operator-approved)

The call-site `_listen/_agent_exec.py` was already **647 lines (over the 512 cap)**, so it was split first (pure extraction + re-export, no behavior change):
- `_agent_exec_liveness.py` — post-ack liveness probe.
- `_agent_exec_send.py` — `POST /agents/<name>/send` + claude resolver + SSE stream.
- `_agent_exec.py` — the `agents_start` handler (336 lines) + re-exports (`server.py`'s `from ._agent_exec import agent_send, _find_claude_binary` path is unchanged), now wrapping the launch in `run_brokered_launch`.

## Verification

pytest is not installed in the container venv, so verified via:
- import smoke: `create_app` + all moved/new symbols import cleanly.
- line counts: every touched file < 512 (336 / 227 / 129 / 220).
- behavior smoke (9/9): `_refresh_imminent` logic, gate no-op when disabled, **flock mutual-exclusion across 3 threads**, env-override parse, `run_brokered_launch` foreground + background run the argv.

## Scope / follow-ups (NOT in this PR)

- **Half-A** — serialized multi-start queue (cap 3 + 5s stagger) for `sac agents start <many>`. Larger, riskier launch-path change (the in-process loop writes a shared SQLite state DB + allocates ports, so bounded parallelism needs process isolation). Separate PR.
- **~1h in-flight rotation** of already-running agents — boot-window serialization does not cover it; needs per-agent snapshots or a long-lived broker. Separate card.

## Test plan

- [ ] `pytest tests/scitex_agent_container/_listen/test__credential_refresh_lock.py` green in CI.
- [ ] Existing `tests/.../_listen/test__agent_exec_subprocess.py` still green (no boot-window hang in a creds-less HOME).
- [ ] Mass-launch a cohort of background agents and confirm no re-login storm.
