### PR TITLE
feat(image): bake rtk into the base SIF (activate the token-saver hook in agents)

### DIFF
--- a/src/scitex_agent_container/containers/apptainer-base.def
+++ b/src/scitex_agent_container/containers/apptainer-base.def
@@ -312,7 +312,24 @@ From: ubuntu:24.04
             /usr/local/bin/claude
     fi
 
-    # ---- 7. RTK (deferred — repo not yet public) -----------------------
+    # ---- 7. rtk — Rust Token Killer (the operator's token-saving proxy) -
+    # rtk rewrites dev commands through a token-optimizing CLI proxy. The
+    # operator's ~/.claude/settings.json already wires the rtk
+    # command-rewrite hook, but it silently no-ops in agents unless `rtk`
+    # is on PATH — the host build lands in the operator's ~/.cargo/bin,
+    # which is NOT on the container PATH. Bake rtk into the image so EVERY
+    # agent has it (base + the scitex layer that bootstraps from base).
+    #
+    # Built from source with the toolchain from section 4; the binary
+    # lands in $CARGO_HOME/bin (/opt/cargo/bin, already on PATH). PINNED to
+    # a release tag for reproducible rebuilds — the same drift-avoidance as
+    # the bundled sac source (never a moving @main). `--git` targets the
+    # operator's repo, avoiding the unrelated crates.io `rtk`
+    # (name collision: reachingforthejack/rtk).
+    cargo install --git https://github.com/rtk-ai/rtk --tag v0.38.0 rtk
+    rm -rf /opt/cargo/registry /opt/cargo/git
+    # Fail loud if the build did not produce a working binary.
+    /opt/cargo/bin/rtk --version
 
 %environment
     export LANG=en_US.UTF-8
@@ -328,7 +345,7 @@ From: ubuntu:24.04
 %labels
     org.scitex.layer base
     org.scitex.runtime apptainer
-    org.scitex.contains "git gh node npm rustc cargo fd bat eza rg tree jq yq delta gdu sd dust uv pipx mermaid prettier eslint jsonlint apptainer"
+    org.scitex.contains "git gh node npm rustc cargo fd bat eza rg tree jq yq delta gdu sd dust uv pipx mermaid prettier eslint jsonlint apptainer rtk"
 
 %help
     scitex-agent-container :base layer.


### PR DESCRIPTION
## Summary

Bake **rtk** (Rust Token Killer — the operator's token-saving CLI proxy) into the base SIF so every agent has it.

`apptainer-base.def` section 7 was a deferred placeholder (`# RTK (deferred — repo not yet public)`). The repo (`github.com/rtk-ai/rtk`) is **public now**, so this builds rtk from source with the Rust toolchain already in the image and lands the binary in `/opt/cargo/bin` (already on PATH).

**Why this matters:** the operator's `~/.claude/settings.json` already wires the rtk command-rewrite hook, but it silently no-ops in agents because the host build lives in the operator's `~/.cargo/bin`, which is **not** on the container PATH (the container carries `/opt/cargo/bin`). Putting rtk on the image PATH activates the already-configured hook for every agent.

- One place: `sac-scitex.sif` bootstraps `From: ./sac-base.sif`, so the scitex layer inherits rtk automatically.
- **Pinned** to release tag `v0.38.0` (not a moving `@main`) — same drift-avoidance the base image uses for the bundled sac source.
- `--git` targets the operator's repo, avoiding the unrelated crates.io `rtk` (name collision with reachingforthejack/rtk).
- Fail-loud `rtk --version` verify after install.
- Added `rtk` to the `org.scitex.contains` image label.

This supersedes the runtime-symlink approach (a band-aid that would have needed editing the over-cap TUI boot path) — the image install is the deterministic fix.

## Verification

The build runs on Spartan CI (we don't pay for GitHub runners). Locally confirmed: rtk repo is public, tag `v0.38.0` exists, and the binary it produces runs (`rtk 0.38.0`, `rtk gain` responds — the correct Token Killer, not the crates.io collision).

## Test plan

- [ ] base image build on Spartan succeeds (cargo install + `rtk --version` verify passes).
- [ ] In a freshly built agent, `command -v rtk` resolves and the rewrite hook activates (commands show as `rtk ...`).
