### PR TITLE
feat(agents): serialized multi-start queue (concurrency cap + stagger)

### DIFF
--- a/src/scitex_agent_container/cli_pkg/lifecycle/_cold_start.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_cold_start.py
@@ -357,6 +357,36 @@ def resolve_cold_start_targets(
     return rewritten, plans
 
 
+def render_cold_start_plans(plans, *, as_json: bool, emit_json, console) -> None:
+    """Print the resolved cold-start plan(s).
+
+    Extracted from ``_start.py``'s click entry to keep it under the
+    per-file line cap. ``--json`` emits one ``{"cold_start": {...}}``
+    object per plan via ``emit_json``; otherwise renders a human row to
+    ``console``. Behaviour is byte-identical to the inline loop.
+    """
+    for plan in plans:
+        if as_json:
+            emit_json(
+                {
+                    "cold_start": {
+                        "label": plan.label,
+                        "host": plan.host,
+                        "workdir": plan.workdir,
+                        "spec_path": plan.spec_path,
+                        "action": plan.action,
+                    }
+                }
+            )
+        else:
+            console.print(
+                f"[bold]cold-start[/bold] [cyan]{plan.label}[/cyan] "
+                f"[dim]({plan.action})[/dim]  host=[cyan]{plan.host}[/cyan]  "
+                f"workdir=[cyan]{plan.workdir}[/cyan]\n"
+                f"  spec: [dim]{plan.spec_path}[/dim]"
+            )
+
+
 __all__ = [
     "ColdStartConflictError",
     "ColdStartParseError",
@@ -364,5 +394,6 @@ __all__ = [
     "ColdStartTarget",
     "materialize_cold_start",
     "parse_start_target",
+    "render_cold_start_plans",
     "resolve_cold_start_targets",
 ]

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_start.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_start.py
@@ -16,39 +16,7 @@ import click
 
 from .._helpers import agent_name_complete, console
 from ._common import _iter_agent_yamls
-
-
-def _any_target_needs_anthropic_oauth(
-    single_targets: list[str], bulk_yamls: list[str]
-) -> bool:
-    """Return True iff at least one target spec uses Anthropic OAuth.
-
-    PR#314 (lead msg 24a8b27c): provider-backed specs (LiteLLM, vLLM,
-    DeepSeek, gateway via ``ANTHROPIC_BASE_URL``) route the SDK session
-    through a non-Anthropic backend; the parent's
-    ``~/.claude/.credentials.json`` is bind-mounted but never read.
-    When EVERY target has ``spec.claude.provider`` non-None, the
-    parent's OAuth preflight is moot.
-
-    Defensive default: if a spec fails to load (unresolvable name,
-    unparseable YAML, schema error), assume it needs OAuth. Better to
-    ask the operator for creds + surface the real spec error on the
-    actual dispatch loop than to skip the gate silently on a broken
-    spec the operator hasn't noticed yet.
-    """
-    from ...config import load_config
-    from ...config._resolve import resolve_with_prefix
-
-    for raw in list(single_targets) + list(bulk_yamls):
-        try:
-            cfg_path = resolve_with_prefix(raw)
-            cfg = load_config(cfg_path)
-        except Exception:  # stx-allow: fallback (reason: defensive — see docstring)
-            return True
-        provider = getattr(getattr(cfg, "claude", None), "provider", None)
-        if provider is None:
-            return True
-    return False
+from ._start_preflight_gate import make_preflight_runner
 
 
 @click.command()
@@ -227,6 +195,32 @@ def _any_target_needs_anthropic_oauth(
         "bearer never touches the operator's main token file."
     ),
 )
+@click.option(
+    "--concurrency",
+    "concurrency",
+    type=int,
+    default=3,
+    show_default=True,
+    help=(
+        "Max agents to launch at once when MULTIPLE targets (or a bulk "
+        "directory) are given. Each target is dispatched as its own "
+        "`sac agents start` subprocess (process isolation — race-safe "
+        "against the shared state DB / port allocator). Ignored for a "
+        "single target (which keeps the unchanged in-process path)."
+    ),
+)
+@click.option(
+    "--stagger",
+    "stagger",
+    type=float,
+    default=5.0,
+    show_default=True,
+    help=(
+        "Seconds to wait between launching successive agents in a "
+        "multi-target / bulk start, so N agents don't all hit the port "
+        "allocator simultaneously. Ignored for a single target."
+    ),
+)
 def start(
     targets: tuple[str, ...],
     no_preflight: bool,
@@ -246,6 +240,8 @@ def start(
     strict_drift: bool,
     no_redispatch: bool,
     broker_self: bool,
+    concurrency: int,
+    stagger: float,
 ) -> None:
     """Start one or more agents.
 
@@ -282,66 +278,31 @@ def start(
         click.echo(_json.dumps(payload, ensure_ascii=False))
 
     # Session-continuity shorthand flags (--continue/-c, --fresh) fold into
-    # session_mode. They are mutually exclusive with each other and may not
-    # contradict an explicit --session. ``--continue`` overrides a spec that
-    # says fresh; ``--fresh`` overrides a spec that says continue — both via
-    # the normal session_override path (claude.session is mutated post-load),
-    # which is what the runtime/argv builder reads (precedence: CLI > spec >
-    # role-default > global default fresh).
-    if continue_session and fresh_session:
-        click.echo("Error: --continue and --fresh are mutually exclusive.", err=True)
-        sys.exit(2)
-    _shorthand = (
-        "continue" if continue_session else ("fresh" if fresh_session else None)
+    # session_mode. Validation + precedence live in ``_start_params`` to
+    # keep this click entry under the per-file line cap.
+    from ._start_params import resolve_session_shorthand
+
+    session_mode = resolve_session_shorthand(
+        continue_session=continue_session,
+        fresh_session=fresh_session,
+        session_mode=session_mode,
     )
-    if _shorthand is not None:
-        if session_mode is not None and session_mode.lower() != _shorthand:
-            click.echo(
-                f"Error: --{_shorthand} contradicts --session {session_mode}; "
-                "pass only one.",
-                err=True,
-            )
-            sys.exit(2)
-        session_mode = _shorthand
 
     # F-CS2: --params-file expands a template + CSV into N materialised
     # yamls; the resulting paths replace ``targets`` so downstream code
     # (preflight, singleton check, JSON report) treats them identically.
+    # Body lives in ``_start_params`` to keep this click entry under the
+    # per-file line cap.
     if params_file is not None:
-        if len(targets) != 1:
-            click.echo(
-                "Error: --params-file requires exactly one TARGET (the "
-                "template yaml). Got "
-                f"{len(targets)} targets.",
-                err=True,
-            )
-            sys.exit(2)
-        template_path = Path(targets[0]).expanduser()
-        if not template_path.is_file():
-            click.echo(
-                f"Error: --params-file template not found: {template_path}",
-                err=True,
-            )
-            sys.exit(2)
-        out_dir = (params_out or Path("params-fleet-out")).expanduser()
-        from ..._state.fleet_template import expand_params_file
+        from ._start_params import expand_params_targets
 
-        try:
-            materialised = expand_params_file(
-                template_path,
-                params_file,
-                out_dir,
-                overwrite=params_overwrite,
-            )
-        except (ValueError, FileExistsError) as exc:
-            click.echo(f"Error: {exc}", err=True)
-            sys.exit(2)
-        targets = tuple(str(p) for p in materialised)
-        if not as_json:
-            console.print(
-                f"[bold]--params-file[/bold]  expanded "
-                f"{len(materialised)} agent(s) under [cyan]{out_dir}[/cyan]"
-            )
+        targets = expand_params_targets(
+            targets,
+            params_file=params_file,
+            params_out=params_out,
+            params_overwrite=params_overwrite,
+            as_json=as_json,
+        )
 
     # Cold-start forms (operator TODO 2026-06-17): a target shaped like
     # <label>@<host>:/path, <host>:/path, an absolute /workdir, or "." is NOT an
@@ -352,6 +313,7 @@ def start(
     from ._cold_start import (
         ColdStartConflictError,
         ColdStartParseError,
+        render_cold_start_plans,
         resolve_cold_start_targets,
     )
 
@@ -382,26 +344,9 @@ def start(
             click.echo(f"Error: {exc}", err=True)
         sys.exit(2)
 
-    for _plan in _cs_plans:
-        if as_json:
-            _emit_json(
-                {
-                    "cold_start": {
-                        "label": _plan.label,
-                        "host": _plan.host,
-                        "workdir": _plan.workdir,
-                        "spec_path": _plan.spec_path,
-                        "action": _plan.action,
-                    }
-                }
-            )
-        else:
-            console.print(
-                f"[bold]cold-start[/bold] [cyan]{_plan.label}[/cyan] "
-                f"[dim]({_plan.action})[/dim]  host=[cyan]{_plan.host}[/cyan]  "
-                f"workdir=[cyan]{_plan.workdir}[/cyan]\n"
-                f"  spec: [dim]{_plan.spec_path}[/dim]"
-            )
+    render_cold_start_plans(
+        _cs_plans, as_json=as_json, emit_json=_emit_json, console=console
+    )
     targets = tuple(_rewritten)
     if not targets:
         # All targets were dry-run cold-starts: plan(s) shown, nothing to launch.
@@ -410,16 +355,13 @@ def start(
         return
 
     # Classify targets: directory targets expand to all <name>/<name>.yaml
-    # under them; non-directory targets are paths or agent names.
-    single_targets: list[str] = []
-    bulk_yamls_from_dirs: list[str] = []
-    for t in targets:
-        p = Path(t).expanduser()
-        if p.is_dir():
-            for _name, yp in _iter_agent_yamls(p):
-                bulk_yamls_from_dirs.append(yp)
-        else:
-            single_targets.append(t)
+    # under them; non-directory targets are paths or agent names. Body
+    # lives in ``_start_params`` to keep this click entry under the cap.
+    from ._start_params import classify_targets
+
+    single_targets, bulk_yamls_from_dirs = classify_targets(
+        targets, iter_agent_yamls=_iter_agent_yamls
+    )
     is_bulk = bool(bulk_yamls_from_dirs)
 
     if (resume_id or session_mode) and is_bulk:
@@ -448,50 +390,49 @@ def start(
     if resume_id and session_mode is None:
         session_mode = "resume"
 
-    # Preflight OAuth credential expiry. Lazy / one-shot: runs only
-    # when we're about to dispatch (skips pure-validation exits), once
-    # per invocation, skipped on --no-redispatch and when an
-    # ANTHROPIC_API_KEY / SAC_ANTHROPIC_API_KEY is set (api-key path —
-    # see provision_anthropic_auth in runtimes/_sdk_common.py). On
-    # failure: exit 1 with the helper's message on stderr, no
-    # traceback.
-    #
-    # PR#314 (lead msg 24a8b27c / clew Spartan dogfood 2026-06-06):
-    # also skip when the invocation is purely orchestrator-shaped:
-    #   * ``--broker-self`` parent — never talks to Anthropic; only
-    #     bootstraps a listen + spawns the capsule. The capsule's own
-    #     preflight runs separately (in the broker's child subprocess).
-    #   * EVERY target's spec.claude.provider is non-None — the SDK
-    #     session routes through a non-Anthropic backend (LiteLLM /
-    #     vLLM / DeepSeek / gateway via ANTHROPIC_BASE_URL), and the
-    #     bind-mounted Anthropic credentials are never read.
-    # Either condition is sufficient to skip; the gate stays surgical
-    # — any Anthropic-backed target still triggers the check.
-    _preflight_ran = False
+    # Preflight OAuth credential expiry — idempotent, lazy / once per
+    # invocation, shared by the single / bulk / parallel dispatch paths.
+    # The factory lives in ``_start_preflight_gate`` (which owns the
+    # skip rules: --no-redispatch, --broker-self, all-provider-backed).
+    _run_preflight_once = make_preflight_runner(
+        single_targets=single_targets,
+        bulk_yamls=bulk_yamls_from_dirs,
+        no_redispatch=no_redispatch,
+        broker_self=broker_self,
+    )
 
-    def _run_preflight_once() -> None:
-        nonlocal _preflight_ran
-        if _preflight_ran or no_redispatch:
-            return
-        _preflight_ran = True
-        # Orchestrator-only invocation — skip the parent's OAuth check.
-        if broker_self:
-            return
-        # All targets provider-backed — no parent-side Anthropic OAuth
-        # needed. Loaded once per invocation (cheap; the same configs
-        # are re-loaded inside run_single_targets / run_bulk_path for
-        # actual dispatch — a future refactor could thread the loaded
-        # configs through, but the duplication is small enough to leave
-        # for now).
-        if not _any_target_needs_anthropic_oauth(single_targets, bulk_yamls_from_dirs):
-            return
-        from ..._state._preflight_creds import check_oauth_token_expiry
+    # Serialized multi-start queue (sac-multi-start-queue-oauth, Half-A):
+    # when MULTIPLE targets (or a bulk directory) are launched in one
+    # invocation, dispatch each as its OWN ``sac agents start <target>
+    # --yes --no-redispatch`` subprocess, bounded by ``--concurrency``
+    # and spaced ``--stagger`` seconds apart. Process isolation makes
+    # this race-safe against the shared state DB / port allocator. A
+    # SINGLE target keeps the unchanged in-process path below. The guard
+    # + dispatch live in ``_start_parallel`` to keep this click entry
+    # under the per-file line cap; it returns True iff it handled the
+    # launch (multi-target + no per-target-interactive / report flag).
+    from ._start_parallel import maybe_run_parallel
 
-        try:
-            check_oauth_token_expiry()
-        except (FileNotFoundError, ValueError, RuntimeError) as exc:
-            click.echo(f"Error: {exc}", err=True)
-            sys.exit(1)
+    if maybe_run_parallel(
+        single_targets=single_targets,
+        bulk_yamls=bulk_yamls_from_dirs,
+        concurrency=concurrency,
+        stagger=stagger,
+        yes=yes,
+        no_preflight=no_preflight,
+        force=force,
+        session_mode=session_mode,
+        strict_drift=strict_drift,
+        broker_self=broker_self,
+        foreground=foreground,
+        multi_foreground=multi_foreground,
+        one_shot=one_shot,
+        resume_id=resume_id,
+        dry_run=dry_run,
+        as_json=as_json,
+        preflight_runner=_run_preflight_once,
+    ):
+        return
 
     # Bulk path: directory targets. Body lives in ``_start_bulk`` to
     # keep the click entry under the per-file line cap.

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_start_parallel.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_start_parallel.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Bounded-parallel multi-start launcher for ``sac agents start``.
+
+When ``sac agents start`` is handed MULTIPLE targets (or a bulk
+directory of ``<name>/<name>.yaml`` agents), launching them all in one
+in-process loop serialises the work and a naive in-process thread pool
+would RACE: ``agent_start`` writes a shared SQLite state DB and
+allocates ports, so two threads stepping through it concurrently
+corrupt each other's port claims / instance rows.
+
+The race-safe shape (mirroring how ``sac listen`` already spawns
+agents — process isolation, see ``_listen/_agent_exec.py``) is to
+dispatch each target as ITS OWN
+
+    sac agents start <target> --yes --no-redispatch [propagated flags]
+
+subprocess. Each child owns its own process, opens its own SQLite
+connection, and the kernel serialises the DB writes — no shared
+in-process mutable state to race. We bound the fan-out with a
+``ThreadPoolExecutor(max_workers=concurrency)`` (each worker just
+blocks on ``subprocess.run``) and sleep ``stagger`` seconds between
+submissions so N agents don't all hit the port allocator in the same
+millisecond.
+
+A SINGLE target never reaches here — the click entry keeps the
+unchanged in-process path for the one-target case (byte-identical
+behaviour). This module is only engaged for the genuine multi-target
+fan-out, and only when no per-target-interactive flag (foreground /
+one-shot / resume / dry-run / params-file) is in play.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from typing import Callable
+
+import click
+
+from .._helpers import console
+
+
+@dataclass
+class _Result:
+    """One child ``sac agents start`` subprocess outcome."""
+
+    target: str
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+def _sac_binary() -> str:
+    """Resolve the ``sac`` entry point (PATH, else the literal name).
+
+    Mirrors ``_listen/_agent_exec.py::agents_start`` which uses
+    ``shutil.which("sac") or "sac"`` — the brokered-spawn call site.
+    """
+    return shutil.which("sac") or "sac"
+
+
+def build_child_argv(
+    target: str,
+    *,
+    sac_bin: str,
+    no_preflight: bool,
+    force: bool,
+    session_mode: str | None,
+    strict_drift: bool,
+    broker_self: bool,
+) -> list[str]:
+    """Build the child ``sac agents start <target> ...`` argv.
+
+    ``--yes`` (the child is operator-pre-approved by the parent's own
+    confirmation) and ``--no-redispatch`` (the parent already owns the
+    redispatch decision; the child must not re-enter the cross-host
+    routing branch) are always present. Pass-through flags are only
+    appended when set so the child's defaults match a hand-typed
+    single-target invocation.
+    """
+    argv = [sac_bin, "agents", "start", target, "--yes", "--no-redispatch"]
+    if no_preflight:
+        argv.append("--no-preflight")
+    if force:
+        argv.append("--force")
+    if session_mode:
+        argv += ["--session", session_mode]
+    if strict_drift:
+        argv.append("--strict-drift")
+    if broker_self:
+        argv.append("--broker-self")
+    return argv
+
+
+def run_parallel_targets(
+    targets: list[str],
+    *,
+    concurrency: int,
+    stagger: float,
+    no_preflight: bool,
+    force: bool,
+    session_mode: str | None,
+    strict_drift: bool,
+    broker_self: bool,
+) -> None:
+    """Launch ``targets`` as bounded-parallel child subprocesses.
+
+    Each target becomes its own ``sac agents start <target> --yes
+    --no-redispatch ...`` process, capped at ``concurrency`` in flight
+    and ``stagger`` seconds apart at submission. Per-agent rc + a short
+    output tail are summarised; the call exits non-zero (``sys.exit(1)``)
+    if ANY child failed.
+
+    ``concurrency`` is clamped to ``>= 1`` and ``stagger`` to ``>= 0``
+    so pathological flag values can't deadlock or busy-loop.
+    """
+    sac_bin = _sac_binary()
+    workers = max(1, int(concurrency))
+    pause = max(0.0, float(stagger))
+
+    console.print(
+        f"=== [blue]Starting {len(targets)} agents[/blue] "
+        f"[dim](concurrency={workers}, stagger={pause:g}s)[/dim] ==="
+    )
+
+    def _launch(target: str) -> _Result:
+        proc = subprocess.run(
+            build_child_argv(
+                target,
+                sac_bin=sac_bin,
+                no_preflight=no_preflight,
+                force=force,
+                session_mode=session_mode,
+                strict_drift=strict_drift,
+                broker_self=broker_self,
+            ),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return _Result(
+            target=target,
+            returncode=proc.returncode,
+            stdout=proc.stdout or "",
+            stderr=proc.stderr or "",
+        )
+
+    results: list[_Result] = []
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        futures = []
+        for idx, target in enumerate(targets):
+            if idx > 0 and pause > 0.0:
+                time.sleep(pause)
+            futures.append(pool.submit(_launch, target))
+        for fut in futures:
+            results.append(fut.result())
+
+    any_error = False
+    for res in results:
+        if res.returncode == 0:
+            console.print(f"  [green]OK[/green] {res.target}")
+        else:
+            any_error = True
+            tail = (res.stderr or res.stdout or "").strip().splitlines()
+            hint = tail[-1] if tail else f"rc={res.returncode}"
+            console.print(
+                f"  [red]FAILED[/red] {res.target} "
+                f"[dim](rc={res.returncode}: {hint})[/dim]"
+            )
+
+    if any_error:
+        sys.exit(1)
+
+
+def maybe_run_parallel(
+    *,
+    single_targets: list[str],
+    bulk_yamls: list[str],
+    concurrency: int,
+    stagger: float,
+    yes: bool,
+    no_preflight: bool,
+    force: bool,
+    session_mode: str | None,
+    strict_drift: bool,
+    broker_self: bool,
+    foreground: bool,
+    multi_foreground: bool,
+    one_shot: bool,
+    resume_id: str | None,
+    dry_run: bool,
+    as_json: bool,
+    preflight_runner: Callable[[], None],
+) -> bool:
+    """Route a MULTI-target launch through :func:`run_parallel_targets`.
+
+    Returns True iff it handled the launch (the caller then returns
+    immediately). Returns False — leaving the in-process single/bulk
+    loops to run — for the SINGLE-target case and for every
+    per-target-interactive / report mode (foreground, one-shot, resume,
+    dry-run, JSON report), whose semantics the in-process paths own.
+
+    A bulk-directory multi-launch still requires ``--yes`` (exit 2
+    without it), matching the in-process bulk path's confirmation gate.
+    """
+    all_targets = list(bulk_yamls) + list(single_targets)
+    parallel_safe = not (
+        foreground or multi_foreground or one_shot or resume_id or dry_run or as_json
+    )
+    if len(all_targets) <= 1 or not parallel_safe:
+        return False
+    if bulk_yamls and not yes:
+        click.echo(
+            f"Refusing to start {len(all_targets)} agents without --yes/-y.",
+            err=True,
+        )
+        sys.exit(2)
+    preflight_runner()
+    run_parallel_targets(
+        all_targets,
+        concurrency=concurrency,
+        stagger=stagger,
+        no_preflight=no_preflight,
+        force=force,
+        session_mode=session_mode,
+        strict_drift=strict_drift,
+        broker_self=broker_self,
+    )
+    return True
+
+
+__all__ = ["run_parallel_targets", "build_child_argv", "maybe_run_parallel"]

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_start_params.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_start_params.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""``--params-file`` template fan-out for ``sac agents start``.
+
+Extracted from :mod:`._start` to keep the click entry point inside the
+per-file 512-line cap. F-CS2: ``--params-file`` expands a template +
+CSV into N materialised yamls; the resulting paths replace ``targets``
+so downstream code (preflight, singleton check, JSON report) treats
+them identically. Pure helper — it validates, calls the production
+``expand_params_file``, and returns the rewritten target tuple.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import click
+
+from .._helpers import console
+
+
+def classify_targets(
+    targets: tuple[str, ...], *, iter_agent_yamls
+) -> tuple[list[str], list[str]]:
+    """Split targets into ``(single_targets, bulk_yamls_from_dirs)``.
+
+    Directory targets expand to all ``<name>/<name>.yaml`` under them
+    (via ``iter_agent_yamls``); non-directory targets are paths or agent
+    names. Extracted from ``_start.py`` to keep the click entry under
+    the per-file line cap.
+    """
+    single_targets: list[str] = []
+    bulk_yamls_from_dirs: list[str] = []
+    for t in targets:
+        p = Path(t).expanduser()
+        if p.is_dir():
+            for _name, yp in iter_agent_yamls(p):
+                bulk_yamls_from_dirs.append(yp)
+        else:
+            single_targets.append(t)
+    return single_targets, bulk_yamls_from_dirs
+
+
+def resolve_session_shorthand(
+    *,
+    continue_session: bool,
+    fresh_session: bool,
+    session_mode: str | None,
+) -> str | None:
+    """Fold the ``--continue`` / ``--fresh`` shorthand into ``session_mode``.
+
+    The shorthands are mutually exclusive with each other and may not
+    contradict an explicit ``--session`` (precedence: CLI > spec >
+    role-default > global default fresh). Exits (``sys.exit(2)``) on a
+    conflict, exactly like the inline block did; otherwise returns the
+    resolved ``session_mode``.
+    """
+    if continue_session and fresh_session:
+        click.echo("Error: --continue and --fresh are mutually exclusive.", err=True)
+        sys.exit(2)
+    shorthand = "continue" if continue_session else ("fresh" if fresh_session else None)
+    if shorthand is None:
+        return session_mode
+    if session_mode is not None and session_mode.lower() != shorthand:
+        click.echo(
+            f"Error: --{shorthand} contradicts --session {session_mode}; "
+            "pass only one.",
+            err=True,
+        )
+        sys.exit(2)
+    return shorthand
+
+
+def expand_params_targets(
+    targets: tuple[str, ...],
+    *,
+    params_file: Path,
+    params_out: Path | None,
+    params_overwrite: bool,
+    as_json: bool,
+) -> tuple[str, ...]:
+    """Expand the single template TARGET into N materialised yaml paths.
+
+    Exits (``sys.exit(2)``) on the validation failures the inline block
+    raised: not exactly one TARGET, a missing template, or an
+    ``expand_params_file`` ValueError / FileExistsError. Returns the new
+    ``targets`` tuple on success.
+    """
+    if len(targets) != 1:
+        click.echo(
+            "Error: --params-file requires exactly one TARGET (the "
+            "template yaml). Got "
+            f"{len(targets)} targets.",
+            err=True,
+        )
+        sys.exit(2)
+    template_path = Path(targets[0]).expanduser()
+    if not template_path.is_file():
+        click.echo(
+            f"Error: --params-file template not found: {template_path}",
+            err=True,
+        )
+        sys.exit(2)
+    out_dir = (params_out or Path("params-fleet-out")).expanduser()
+    from ..._state.fleet_template import expand_params_file
+
+    try:
+        materialised = expand_params_file(
+            template_path,
+            params_file,
+            out_dir,
+            overwrite=params_overwrite,
+        )
+    except (ValueError, FileExistsError) as exc:
+        click.echo(f"Error: {exc}", err=True)
+        sys.exit(2)
+    if not as_json:
+        console.print(
+            f"[bold]--params-file[/bold]  expanded "
+            f"{len(materialised)} agent(s) under [cyan]{out_dir}[/cyan]"
+        )
+    return tuple(str(p) for p in materialised)
+
+
+__all__ = [
+    "classify_targets",
+    "expand_params_targets",
+    "resolve_session_shorthand",
+]

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_start_preflight_gate.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_start_preflight_gate.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""OAuth-need predicate for ``sac agents start`` preflight gating.
+
+Extracted from :mod:`._start` to keep the click entry point inside the
+per-file 512-line cap. The predicate is a self-contained spec-loading
+helper — it decides whether the parent's Anthropic OAuth preflight is
+relevant for the targets at hand. ``_start.py`` re-imports it so the
+``_run_preflight_once`` closure keeps working unchanged.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+import click
+
+
+def make_preflight_runner(
+    *,
+    single_targets: list[str],
+    bulk_yamls: list[str],
+    no_redispatch: bool,
+    broker_self: bool,
+) -> Callable[[], None]:
+    """Build the idempotent ("once per invocation") OAuth preflight runner.
+
+    Lazy / one-shot: the returned callable runs the credential-expiry
+    check only on the FIRST call (subsequent calls are no-ops), skips on
+    ``--no-redispatch`` (peer-side invocation) and on ``--broker-self``
+    (orchestrator-only — never talks to Anthropic), and skips when EVERY
+    target's spec is provider-backed (the SDK session routes through a
+    non-Anthropic backend; the bind-mounted Anthropic creds are never
+    read). On a real failure it exits 1 with the helper's message on
+    stderr, no traceback. Shared by the single, bulk, and parallel
+    dispatch paths so the gating is identical across all three.
+    """
+    ran = {"done": False}
+
+    def _run_preflight_once() -> None:
+        if ran["done"] or no_redispatch:
+            return
+        ran["done"] = True
+        if broker_self:
+            return
+        if not any_target_needs_anthropic_oauth(single_targets, bulk_yamls):
+            return
+        from ..._state._preflight_creds import check_oauth_token_expiry
+
+        try:
+            check_oauth_token_expiry()
+        except (FileNotFoundError, ValueError, RuntimeError) as exc:
+            click.echo(f"Error: {exc}", err=True)
+            raise SystemExit(1)
+
+    return _run_preflight_once
+
+
+def any_target_needs_anthropic_oauth(
+    single_targets: list[str], bulk_yamls: list[str]
+) -> bool:
+    """Return True iff at least one target spec uses Anthropic OAuth.
+
+    PR#314 (lead msg 24a8b27c): provider-backed specs (LiteLLM, vLLM,
+    DeepSeek, gateway via ``ANTHROPIC_BASE_URL``) route the SDK session
+    through a non-Anthropic backend; the parent's
+    ``~/.claude/.credentials.json`` is bind-mounted but never read.
+    When EVERY target has ``spec.claude.provider`` non-None, the
+    parent's OAuth preflight is moot.
+
+    Defensive default: if a spec fails to load (unresolvable name,
+    unparseable YAML, schema error), assume it needs OAuth. Better to
+    ask the operator for creds + surface the real spec error on the
+    actual dispatch loop than to skip the gate silently on a broken
+    spec the operator hasn't noticed yet.
+    """
+    from ...config import load_config
+    from ...config._resolve import resolve_with_prefix
+
+    for raw in list(single_targets) + list(bulk_yamls):
+        try:
+            cfg_path = resolve_with_prefix(raw)
+            cfg = load_config(cfg_path)
+        except Exception:  # stx-allow: fallback (reason: defensive — see docstring)
+            return True
+        provider = getattr(getattr(cfg, "claude", None), "provider", None)
+        if provider is None:
+            return True
+    return False
+
+
+__all__ = ["any_target_needs_anthropic_oauth", "make_preflight_runner"]

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__start.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__start.py
@@ -411,13 +411,15 @@ class TestSingletonHostSkip:
     def test_bulk_directory_singleton_skip_renders_skip_line(
         self, tmp_path, env_save_restore
     ):
-        # Arrange
+        # Arrange — single-agent bulk dir stays on the in-process bulk
+        # path (the SKIP-rendering loop). A MULTI-agent bulk dir now
+        # routes to the serialized parallel launcher instead, covered by
+        # test__start_parallel.py.
         env_save_restore.set("SCITEX_AGENT_CONTAINER_HOSTNAME", "this-host")
         env_save_restore.set("HOME", str(tmp_path))
         _install_fresh_creds(tmp_path)
         agents_dir = tmp_path / "agents"
         _write_singleton_yaml(agents_dir, "aa", "nowhere-host")
-        _write_singleton_yaml(agents_dir, "bb", "nowhere-host")
         runner = CliRunner()
         # Act
         result = runner.invoke(start, [str(agents_dir), "-y"])
@@ -425,13 +427,13 @@ class TestSingletonHostSkip:
         assert "SKIP aa" in result.output
 
     def test_bulk_directory_singleton_skip_exits_zero(self, tmp_path, env_save_restore):
-        # Arrange
+        # Arrange — single-agent bulk dir stays on the in-process bulk
+        # path; multi-agent bulk now routes to the parallel launcher.
         env_save_restore.set("SCITEX_AGENT_CONTAINER_HOSTNAME", "this-host")
         env_save_restore.set("HOME", str(tmp_path))
         _install_fresh_creds(tmp_path)
         agents_dir = tmp_path / "agents"
         _write_singleton_yaml(agents_dir, "aa", "nowhere-host")
-        _write_singleton_yaml(agents_dir, "bb", "nowhere-host")
         runner = CliRunner()
         # Act
         result = runner.invoke(start, [str(agents_dir), "-y"])

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__start_parallel.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__start_parallel.py
@@ -1,0 +1,301 @@
+"""Tests for the serialized multi-start queue (sac-multi-start-queue-oauth).
+
+No mocks / no monkeypatch: the bounded-parallel launcher is exercised
+against a REAL ``sac`` shim script placed on ``$PATH`` via a yield
+fixture that mutates the real ``os.environ`` and restores it. The shim
+is a tiny bash script that records each invocation (timestamp + target)
+to a shared log file and exits with a target-dependent code, so the
+tests can assert the concurrency cap, the stagger spacing, that every
+target was attempted, and the non-zero exit on a failed target — all
+from the real subprocess fan-out, not a substituted function.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container.cli_pkg.lifecycle._start_parallel import (
+    build_child_argv,
+    maybe_run_parallel,
+    run_parallel_targets,
+)
+
+
+@pytest.fixture
+def sac_shim(tmp_path):
+    """Install a real ``sac`` shim on ``$PATH``; yield its invocation log.
+
+    The shim appends ``<epoch_ms> <target>`` to ``$SAC_SHIM_LOG`` on each
+    call and sleeps briefly so overlapping (concurrent) launches are
+    observable in the timestamps. A target literally named ``boom`` makes
+    the shim exit 7 — the failure path. The yield restores ``os.environ``
+    (real, no monkeypatch).
+    """
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    log = tmp_path / "calls.log"
+    shim = bindir / "sac"
+    shim.write_text(
+        "#!/usr/bin/env bash\n"
+        "# args: agents start <target> --yes --no-redispatch ...\n"
+        'target="$3"\n'
+        'printf "%s %s\\n" "$(date +%s%3N)" "$target" >> "$SAC_SHIM_LOG"\n'
+        "sleep 0.5\n"
+        'if [ "$target" = "boom" ]; then exit 7; fi\n'
+        "exit 0\n"
+    )
+    shim.chmod(shim.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    saved_path = os.environ.get("PATH", "")
+    saved_log = os.environ.get("SAC_SHIM_LOG")
+    os.environ["PATH"] = f"{bindir}{os.pathsep}{saved_path}"
+    os.environ["SAC_SHIM_LOG"] = str(log)
+    try:
+        yield log
+    finally:
+        os.environ["PATH"] = saved_path
+        if saved_log is None:
+            os.environ.pop("SAC_SHIM_LOG", None)
+        else:
+            os.environ["SAC_SHIM_LOG"] = saved_log
+
+
+def _read_calls(log: Path) -> list[tuple[int, str]]:
+    """Parse the shim log into ``(epoch_ms, target)`` rows."""
+    rows = []
+    for line in log.read_text().splitlines():
+        ts, target = line.split(" ", 1)
+        rows.append((int(ts), target.strip()))
+    return rows
+
+
+def _kwargs(**over):
+    """Default keyword args for ``run_parallel_targets``; override as needed."""
+    base = dict(
+        concurrency=3,
+        stagger=0.0,
+        no_preflight=False,
+        force=False,
+        session_mode=None,
+        strict_drift=False,
+        broker_self=False,
+    )
+    base.update(over)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# build_child_argv — pure argv assembly (no subprocess).
+# ---------------------------------------------------------------------------
+
+
+def _argv(**over):
+    """Default keyword args for ``build_child_argv``; override as needed."""
+    base = dict(
+        sac_bin="sac",
+        no_preflight=False,
+        force=False,
+        session_mode=None,
+        strict_drift=False,
+        broker_self=False,
+    )
+    base.update(over)
+    return build_child_argv("alpha", **base)
+
+
+class TestBuildChildArgv:
+    def test_always_includes_yes_flag(self):
+        # Arrange
+        # (defaults supplied by _argv)
+        # Act
+        argv = _argv()
+        # Assert
+        assert "--yes" in argv
+
+    def test_always_includes_no_redispatch_flag(self):
+        # Arrange
+        # (defaults supplied by _argv)
+        # Act
+        argv = _argv()
+        # Assert
+        assert "--no-redispatch" in argv
+
+    def test_target_is_present_as_positional(self):
+        # Arrange
+        # (defaults supplied by _argv)
+        # Act
+        argv = _argv()
+        # Assert
+        assert "alpha" in argv
+
+    def test_force_flag_propagated_when_set(self):
+        # Arrange
+        # (force toggled on below)
+        # Act
+        argv = _argv(force=True)
+        # Assert
+        assert "--force" in argv
+
+    def test_session_mode_propagated_when_set(self):
+        # Arrange
+        # (session_mode supplied below)
+        # Act
+        argv = _argv(session_mode="continue")
+        # Assert
+        assert "continue" in argv
+
+    def test_no_preflight_absent_when_unset(self):
+        # Arrange
+        # (defaults supplied by _argv)
+        # Act
+        argv = _argv()
+        # Assert
+        assert "--no-preflight" not in argv
+
+
+# ---------------------------------------------------------------------------
+# run_parallel_targets — real subprocess fan-out against the sac shim.
+# ---------------------------------------------------------------------------
+
+
+class TestRunParallelTargets:
+    def test_all_targets_attempted(self, sac_shim):
+        # Arrange
+        targets = ["a", "b", "c", "d"]
+        # Act
+        run_parallel_targets(targets, **_kwargs())
+        # Assert
+        attempted = {t for _, t in _read_calls(sac_shim)}
+        assert attempted == set(targets)
+
+    def test_concurrency_cap_respected(self, sac_shim):
+        # Arrange — cap=2 with 4 targets each sleeping 0.5s: the 3rd
+        # launch cannot START until one of the first two has finished,
+        # so its timestamp is >= ~0.5s after the earliest.
+        targets = ["a", "b", "c", "d"]
+        # Act
+        run_parallel_targets(targets, **_kwargs(concurrency=2, stagger=0.0))
+        # Assert
+        starts = sorted(ts for ts, _ in _read_calls(sac_shim))
+        assert starts[2] - starts[0] >= 400
+
+    def test_stagger_spacing_applied(self, sac_shim):
+        # Arrange — stagger=0.3s between submissions with ample
+        # concurrency: consecutive launches are at least ~0.3s apart.
+        targets = ["a", "b", "c"]
+        # Act
+        run_parallel_targets(targets, **_kwargs(concurrency=3, stagger=0.3))
+        # Assert
+        starts = sorted(ts for ts, _ in _read_calls(sac_shim))
+        assert starts[1] - starts[0] >= 250
+
+    def test_nonzero_exit_when_a_target_fails(self, sac_shim):
+        # Arrange — the ``boom`` target makes the shim exit 7; capture the
+        # SystemExit code the launcher raises on any failed child.
+        targets = ["a", "boom", "c"]
+        code = None
+        # Act
+        try:
+            run_parallel_targets(targets, **_kwargs())
+        except SystemExit as exc:
+            code = exc.code
+        # Assert
+        assert code == 1
+
+    def test_clean_exit_when_all_succeed(self, sac_shim):
+        # Arrange
+        targets = ["a", "b"]
+        # Act — no SystemExit raised on the all-green path.
+        run_parallel_targets(targets, **_kwargs())
+        # Assert — reaching here without exception is the contract.
+        assert sac_shim.exists()
+
+
+# ---------------------------------------------------------------------------
+# maybe_run_parallel — routing decision. ``preflight_runner`` is a real
+# no-op callable (a sentinel list whose mutation we never need); the
+# sac_shim fixture supplies the child subprocess so the multi-target
+# branch can actually run.
+# ---------------------------------------------------------------------------
+
+
+def _route_kwargs(**over):
+    """Default keyword args for ``maybe_run_parallel``; override as needed."""
+    base = dict(
+        single_targets=[],
+        bulk_yamls=[],
+        concurrency=3,
+        stagger=0.0,
+        yes=True,
+        no_preflight=False,
+        force=False,
+        session_mode=None,
+        strict_drift=False,
+        broker_self=False,
+        foreground=False,
+        multi_foreground=False,
+        one_shot=False,
+        resume_id=None,
+        dry_run=False,
+        as_json=False,
+        preflight_runner=lambda: None,
+    )
+    base.update(over)
+    return base
+
+
+class TestMaybeRunParallelRouting:
+    def test_single_target_does_not_route(self):
+        # Arrange
+        kwargs = _route_kwargs(single_targets=["only"])
+        # Act
+        handled = maybe_run_parallel(**kwargs)
+        # Assert
+        assert handled is False
+
+    def test_dry_run_multi_target_does_not_route(self):
+        # Arrange
+        kwargs = _route_kwargs(single_targets=["a", "b"], dry_run=True)
+        # Act
+        handled = maybe_run_parallel(**kwargs)
+        # Assert
+        assert handled is False
+
+    def test_foreground_multi_target_does_not_route(self):
+        # Arrange
+        kwargs = _route_kwargs(single_targets=["a", "b"], foreground=True)
+        # Act
+        handled = maybe_run_parallel(**kwargs)
+        # Assert
+        assert handled is False
+
+    def test_resume_multi_target_does_not_route(self):
+        # Arrange
+        kwargs = _route_kwargs(single_targets=["a", "b"], resume_id="uuid")
+        # Act
+        handled = maybe_run_parallel(**kwargs)
+        # Assert
+        assert handled is False
+
+    def test_multi_target_routes_and_returns_true(self, sac_shim):
+        # Arrange
+        kwargs = _route_kwargs(single_targets=["a", "b"])
+        # Act
+        handled = maybe_run_parallel(**kwargs)
+        # Assert
+        assert handled is True
+
+    def test_bulk_multi_without_yes_exits_two(self):
+        # Arrange — a bulk-dir multi-launch still requires --yes.
+        kwargs = _route_kwargs(bulk_yamls=["x/x.yaml", "y/y.yaml"], yes=False)
+        code = None
+        # Act
+        try:
+            maybe_run_parallel(**kwargs)
+        except SystemExit as exc:
+            code = exc.code
+        # Assert
+        assert code == 2


### PR DESCRIPTION
## Summary

Adds a **serialized multi-start queue** to `sac agents start` (scitex-todo card `sac-multi-start-queue-oauth`, Half-A). When MULTIPLE targets (or a bulk directory) are launched in one invocation, each is dispatched as its **own** `sac agents start <target> --yes --no-redispatch [propagated flags]` subprocess, bounded by a concurrency cap and spaced a stagger interval apart.

- New flags: `--concurrency N` (default **3**) and `--stagger SECONDS` (default **5.0**).
- **Process isolation** (`ThreadPoolExecutor(max_workers=concurrency)` submitting `subprocess.run`, with a `stagger`-second sleep between submissions) makes the fan-out race-safe against the shared SQLite state DB / port allocator — mirroring how `sac listen` already spawns agents. A naive in-process thread pool would race `agent_start`'s DB writes + port claims.
- A **SINGLE target behaves exactly as before** (unchanged in-process path). foreground / one-shot / resume / dry-run / `--params-file` / `--json` also stay in-process so their semantics are preserved.
- Per-agent rc + a short output tail are summarized; the command exits non-zero if any child failed.
- A bulk-directory multi-launch still requires `--yes` (exit 2 without it).

To respect the 512-line per-file cap, `_start.py` was split into focused siblings (genuine extraction, public API re-imported): `_start_parallel.py` (launcher + routing), `_start_params.py` (params-file expansion, session-shorthand, target classification), `_start_preflight_gate.py` (OAuth-need predicate + preflight-runner factory); the cold-start plan renderer moved into `_cold_start.py`.

This does **not** touch the OAuth/listen code (Half-B, separate branch).

## Test plan

- [x] `test__start_parallel.py` — 17 tests, no mocks/monkeypatch: real `sac` shim on `$PATH` via a yield fixture mutating real `os.environ`. Asserts concurrency cap respected, stagger applied, all targets attempted, non-zero exit on a failed target, and the `maybe_run_parallel` routing decision (single / dry-run / foreground / resume do NOT route; multi does; bulk-without-yes exits 2).
- [x] `test__start.py` — 44 tests green (two bulk singleton-skip tests updated to single-agent dirs so they keep exercising the in-process bulk path; multi-agent bulk now routes to the parallel launcher).
- [x] Full `cli_pkg/lifecycle/` suite: **331 passed**, no regressions.