### PR TITLE
feat(image): bake a manuscript LaTeX toolchain into the scitex SAC image

### DIFF
--- a/src/scitex_agent_container/containers/apptainer-scitex.def
+++ b/src/scitex_agent_container/containers/apptainer-scitex.def
@@ -9,6 +9,7 @@
 #   - black, flake8, ipython, ipdb, pytest, pytest-cov
 #   - claude-agent-sdk (the runner's API; bundles its own claude binary)
 #   - scitex[all] (scientific stack)
+#   - a curated manuscript LaTeX toolchain (latex / latexmk / biber)
 #   - scitex-agent-container (sac CLI + runner module)
 #
 # Build:
@@ -145,6 +146,48 @@ From: ./sac-base.sif
             /opt/scitex-agent-container-src
     fi
 
+    # ---- 3. Manuscript LaTeX toolchain ---------------------------------
+    # Paper agents (paper-scitex-clew / paper-neurovista / paper-ripple-wm
+    # / neurovista) compile manuscripts in-container, but the SAC image
+    # shipped NO LaTeX engine — pdflatex/latexmk/lualatex/xelatex were all
+    # missing, and the nested texlive container can't mount because the
+    # unprivileged user-namespace has no /dev/fuse. Decision (operator,
+    # card sac-image-latex-manuscript): bake a CURATED native TeX Live set
+    # here in the :scitex layer (NOT full texlive — too big; NOT enabling
+    # fuse — fragile). LaTeX is a manuscript/scientific concern, so it
+    # belongs on the scientific layer, not the lean :base.
+    #
+    # Curated package set (Ubuntu 24.04 noble apt, --no-install-recommends
+    # to avoid pulling the multi-GB full-texlive recommends chain):
+    #   texlive-latex-base/-recommended/-extra — the LaTeX core + the
+    #     common class/package set most manuscripts use.
+    #   texlive-bibtex-extra + biber           — bibliography backends
+    #     (biber is biblatex's engine; bibtex-extra carries the styles).
+    #   texlive-fonts-recommended/-extra        — font packages many
+    #     journal classes hard-require at \documentclass load.
+    #   texlive-science                         — amsmath/siunitx/physics
+    #     /algorithms etc. (math + science macros).
+    #   texlive-publishers                      — ships elsarticle and a
+    #     large set of journal document classes (Elsevier, IEEE, etc.).
+    #   texlive-luatex + texlive-xetex          — lualatex/xelatex engines
+    #     (unicode + system-font manuscripts).
+    #   latexmk                                 — the build driver that
+    #     resolves the latex/bibtex/biber re-run loop automatically.
+    apt-get update
+    apt-get install -y --no-install-recommends \
+        texlive-latex-base texlive-latex-recommended texlive-latex-extra \
+        texlive-bibtex-extra biber \
+        texlive-fonts-recommended texlive-fonts-extra \
+        texlive-science texlive-publishers \
+        texlive-luatex texlive-xetex \
+        latexmk
+    rm -rf /var/lib/apt/lists/*
+    # Fail loud if the engine or build driver did not land — a SIF that
+    # silently ships without pdflatex/latexmk would re-park every paper
+    # agent's compile lane exactly as before.
+    pdflatex --version
+    latexmk --version
+
 %environment
     export PATH=/opt/venv-sac/bin:$PATH
     export VIRTUAL_ENV=/opt/venv-sac
@@ -156,9 +199,11 @@ From: ./sac-base.sif
     org.scitex.layer scitex
     org.scitex.runtime apptainer
     org.scitex.from scitex-agent-container:base
-    org.scitex.contains "scitex[all] claude-agent-sdk scitex-agent-container ffmpeg portaudio black flake8 ipython pytest"
+    org.scitex.contains "scitex[all] claude-agent-sdk scitex-agent-container ffmpeg portaudio black flake8 ipython pytest latex latexmk biber"
 
 %help
     scitex-agent-container :scitex layer (sac default image).
-    Layered on :base; adds scitex scientific stack, claude SDK, sac itself.
+    Layered on :base; adds scitex scientific stack, claude SDK, sac
+    itself, and a curated manuscript LaTeX toolchain (pdflatex /
+    lualatex / xelatex / latexmk / biber).
     Default entry point: python -m scitex_agent_container._runners.claude_session

--- a/src/scitex_agent_container/containers/apptainer-scitex.def
+++ b/src/scitex_agent_container/containers/apptainer-scitex.def
@@ -173,9 +173,14 @@ From: ./sac-base.sif
     #     (unicode + system-font manuscripts).
     #   latexmk                                 — the build driver that
     #     resolves the latex/bibtex/biber re-run loop automatically.
+    #   texlive-pictures                        — pgf/tikz core, REQUIRED
+    #     by tcolorbox / pgfplots / pgfplotstable / tikz. Listed EXPLICITLY:
+    #     under --no-install-recommends it is not reliably pulled via
+    #     latex-extra, and the manuscript footprint uses tikz/pgfplots.
     apt-get update
     apt-get install -y --no-install-recommends \
         texlive-latex-base texlive-latex-recommended texlive-latex-extra \
+        texlive-pictures \
         texlive-bibtex-extra biber \
         texlive-fonts-recommended texlive-fonts-extra \
         texlive-science texlive-publishers \

--- a/src/scitex_agent_container/containers/apptainer-scitex.def
+++ b/src/scitex_agent_container/containers/apptainer-scitex.def
@@ -188,6 +188,15 @@ From: ./sac-base.sif
     pdflatex --version
     latexmk --version
 
+    # ---- 4. System-python invariant (paper-agent .venv base) -----------
+    # Paper agents migrating onto this image keep a per-agent uv .venv whose
+    # base interpreter resolves to the system python3 (3.12 on noble),
+    # inherited unchanged from :base. Assert it survived this layer's
+    # %post so a future edit here cannot silently break the interpreter the
+    # paper venvs depend on (regression neurovista hit when a venv pointed
+    # at a removed path). No new python is installed — this is a guard.
+    /usr/bin/python3 --version
+
 %environment
     export PATH=/opt/venv-sac/bin:$PATH
     export VIRTUAL_ENV=/opt/venv-sac


### PR DESCRIPTION
## Problem

Paper agents cannot compile manuscripts in-container: the SAC apptainer
image ships **no LaTeX engine** (pdflatex/latexmk/lualatex/xelatex all
missing), and the nested texlive container can't mount because the
unprivileged user-namespace has no `/dev/fuse`. (card `sac-image-latex-manuscript`, P1)

## Decision (already made by operator)

Bake a **curated** LaTeX toolchain natively into the image — NOT full
texlive (too big), NOT enabling fuse (fragile band-aid).

## What this PR does

Adds a new `%post` section **3. Manuscript LaTeX toolchain** to
`apptainer-scitex.def` (the scientific layer), not `apptainer-base.def`.
LaTeX is a manuscript/scientific concern, so it belongs on the :scitex
layer by Separation of Concerns; :base stays lean.

Package set (Ubuntu 24.04 noble apt, `--no-install-recommends`):

```
texlive-latex-base texlive-latex-recommended texlive-latex-extra
texlive-bibtex-extra biber
texlive-fonts-recommended texlive-fonts-extra
texlive-science texlive-publishers   # publishers ships elsarticle + journal classes
texlive-luatex texlive-xetex
latexmk
```

- `rm -rf /var/lib/apt/lists/*` after install (matches base.def's apt cleanup).
- Fail-loud verify: `pdflatex --version` + `latexmk --version`.
- Updated `%labels org.scitex.contains` and `%help` + header comment to mention latex/latexmk/biber.
- File is 209 lines — well under the 512-line hook cap.

## REQUIRED FOLLOW-UP (different repo/owner — NOT in this PR)

The four paper agents all pin **`sac-base.sif`** in their spec.yaml:

- `paper-scitex-clew`, `paper-neurovista`, `paper-ripple-wm`, `neurovista`
  (`spec.image: .../containers/sac-base.sif`, confirmed via `rg`)

LaTeX is added to the **:scitex** layer, so these agents will **NOT**
receive LaTeX until their `spec.image` is switched to **`sac-scitex.sif`**.
That is a dotfiles change in the operator's repo and is intentionally
left out of this PR.

## Verification honesty

The SIF cannot be built here (real build runs on Spartan CI). Verification
done: the `.def` is syntactically sound, the section matches house style
(numbered comment block + fail-loud verify, same as base.def's gdu/rtk
sections), and the package names are the canonical stable noble texlive
names. The actual `pdflatex --version` / `latexmk --version` gate runs at
SIF build time on CI.