### PR TITLE
fix(agents): templates emit metadata.labels.groups list (multi-group), not scalar group

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_create.py
+++ b/src/scitex_agent_container/cli_pkg/_create.py
@@ -16,7 +16,7 @@ overlay, opus, generic boot kick) and differ on only:
 
   axis              developer            scientist
   ----------------- -------------------- ----------------------------------
-  group             developer            scientist
+  groups (list)     [developer]          [scientist]
   purpose suffix    -maintainer          -research
 
 Two blocks are AUTO-detected at create time, regardless of template:

--- a/src/scitex_agent_container/cli_pkg/_create_templates/_developer/spec.yaml
+++ b/src/scitex_agent_container/cli_pkg/_create_templates/_developer/spec.yaml
@@ -15,7 +15,8 @@ metadata:
     project: {{ NAME }}
     purpose: {{ NAME }}-maintainer
     role: project-maintainer
-    group: {{ GROUP }}
+    groups:
+      - {{ GROUP }}
     cardinality: singleton
 
 spec:

--- a/src/scitex_agent_container/cli_pkg/_create_templates/_scientist/spec.yaml
+++ b/src/scitex_agent_container/cli_pkg/_create_templates/_scientist/spec.yaml
@@ -15,7 +15,8 @@ metadata:
     project: {{ NAME }}
     purpose: {{ NAME }}-research
     role: project-maintainer
-    group: {{ GROUP }}
+    groups:
+      - {{ GROUP }}
     cardinality: singleton
 
 spec:

--- a/tests/scitex_agent_container/cli_pkg/test__create.py
+++ b/tests/scitex_agent_container/cli_pkg/test__create.py
@@ -66,7 +66,7 @@ def test_create_developer_group_label(tmp_path: Path) -> None:
     # Act
     parsed = yaml.safe_load(_spec(base, "dev-grp").read_text())
     # Assert — developer template defaults to the developer group.
-    assert parsed["metadata"]["labels"]["group"] == "developer"
+    assert parsed["metadata"]["labels"]["groups"] == ["developer"]
 
 
 def test_create_developer_purpose_suffix(tmp_path: Path) -> None:
@@ -88,7 +88,7 @@ def test_create_scientist_group_label(tmp_path: Path) -> None:
     # Act
     parsed = yaml.safe_load(_spec(base, "sci-grp").read_text())
     # Assert — scientist template defaults to the scientist group.
-    assert parsed["metadata"]["labels"]["group"] == "scientist"
+    assert parsed["metadata"]["labels"]["groups"] == ["scientist"]
 
 
 def test_create_scientist_purpose_suffix(tmp_path: Path) -> None:
@@ -113,7 +113,7 @@ def test_create_group_override(tmp_path: Path) -> None:
     # Act
     parsed = yaml.safe_load(_spec(base, "grp-ovr").read_text())
     # Assert — explicit --group wins over the template default.
-    assert parsed["metadata"]["labels"]["group"] == "platform"
+    assert parsed["metadata"]["labels"]["groups"] == ["platform"]
 
 
 def test_create_install_block_present_when_package(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Group membership moves from a SCALAR `metadata.labels.group: <g>` to a LIST `metadata.labels.groups: [<g>, ...]` so an agent can belong to multiple groups.
- The `_developer`/`_scientist` template skeletons now emit the YAML list form (`groups:\n  - {{ GROUP }}`); the CLI still resolves a single group (template default or `--group` override) and fills it as a one-element list.
- Updated the `_create.py` docstring axis table and the create tests (`groups == ["developer"]` / `["scientist"]` / `["platform"]`).

## Scope
- This is the EMIT side only. The resolver that READS the list and meshes agents on any shared group is tracked separately on card `sac-group-based-acl` — not touched here.

## Test plan
- [x] `pytest tests/scitex_agent_container/cli_pkg/test__create.py` — 17 passed (incl. live `validate_config` v3-validator checks).