### PR TITLE
fix: stop stray --fakeroot file creation in project root (root cause)

### DIFF
--- a/src/scitex_agent_container/config/_parsers/_apptainer.py
+++ b/src/scitex_agent_container/config/_parsers/_apptainer.py
@@ -114,6 +114,11 @@ def parse_apptainer(spec: dict):
         def_file=str(raw.get("def_file", "") or ""),
         nv=bool(raw.get("nv", False)),
         rocm=bool(raw.get("rocm", False)),
+        # ``--fakeroot`` (uid 0 inside via userns). Previously dropped by
+        # the parser → the YAML key silently no-op'd. Parse it so the
+        # curated iso-prepend can emit ``--fakeroot`` (always in a valid
+        # position — see _apptainer_iso_flags + _apptainer_argv_guard).
+        fakeroot=bool(raw.get("fakeroot", False)),
         overlay=str(raw.get("overlay", "") or ""),
         overlay_size=str(raw.get("overlay_size", "") or ""),
         overlay_create_if_missing=bool(raw.get("overlay_create_if_missing", True)),

--- a/src/scitex_agent_container/runtimes/_apptainer_argv_guard.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_argv_guard.py
@@ -1,0 +1,151 @@
+"""Fail-loud guard against malformed ``apptainer exec`` flag argv.
+
+Root-cause fix for the stray ``--fakeroot`` file (1 NULL byte) that
+kept appearing in the PROJECT ROOT.
+
+The bug
+-------
+``build_run_argv`` assembles the ``apptainer exec`` flag list from a mix
+of sac-curated flags (``--containall``, ``--home /home/agent``,
+``--fakeroot``, ``--bind …``, ``--overlay …``) and operator-supplied
+``spec.apptainer.raw_args``. apptainer's ``--overlay`` / ``--bind`` /
+``--env-file`` / ``--home`` / ``--workdir`` each take a **required
+value**. When such a flag is emitted with NO value — e.g. an operator
+``raw_args: ["--overlay"]`` followed by sac's own ``--fakeroot``, or a
+``raw_args: ["--bind"]`` — apptainer's CLI parser swallows the NEXT
+token as the missing value. The next token is frequently sac's
+``--fakeroot`` (a no-value flag).
+
+apptainer then treats that swallowed ``--fakeroot`` as a **relative
+overlay/image path** and creates a stub file at it. Because the TUI
+runtime shell-runs the argv with ``cwd = expanded_workdir`` (the PROJECT
+ROOT for the maintainer agent whose workdir *is* the repo), the stub
+lands as ``<repo>/--fakeroot`` — exactly 1 byte, the placeholder header
+apptainer writes for a fresh overlay/output target.
+
+The fix
+-------
+Validate the flag argv (the slice between ``apptainer exec`` and the
+SIF) BEFORE it is ever launched / shell-joined: if a known
+value-taking apptainer flag is immediately followed by another
+``--option`` (so its value is missing), raise :class:`ApptainerArgvError`
+loudly instead of letting apptainer silently create a stray file in the
+project root. No band-aid (we don't delete the file after the fact); we
+refuse to emit an argv that could create it.
+
+Only the curated + raw flag region is checked. The inner command
+(``bash -c "<preflight>\nexec …"`` or the flat relaxed inner argv) sits
+AFTER the SIF and is the container's business, not apptainer's flag
+parser — so it is excluded.
+"""
+
+from __future__ import annotations
+
+# apptainer ``exec`` options that REQUIRE a following value. A subset
+# focused on the ones sac itself emits or operators commonly pass via
+# raw_args; an unknown value-flag not listed here simply isn't guarded
+# (we never want a false positive that blocks a legitimate launch).
+VALUE_TAKING_FLAGS = frozenset(
+    {
+        "--bind",
+        "--overlay",
+        "--env-file",
+        "--home",
+        "--workdir",
+        "--pwd",
+        "--env",
+        "--scratch",
+        "--mount",
+        "--fusemount",
+    }
+)
+
+
+class ApptainerArgvError(ValueError):
+    """Raised when the apptainer flag argv is malformed.
+
+    Specifically: a value-taking flag is missing its value (the next
+    token is another ``--option`` or the flag is last in the region),
+    which would make apptainer swallow the following flag as a relative
+    path and create a stray file in the launch cwd.
+    """
+
+
+def validate_flag_argv(argv: list[str]) -> None:
+    """Fail loud if a value-taking apptainer flag is missing its value.
+
+    Inspects only the flag region between ``apptainer exec`` and the SIF
+    path (first positional that is not consumed as a flag value). Raises
+    :class:`ApptainerArgvError` describing the offending flag + the token
+    that would be wrongly swallowed.
+
+    A no-op for a well-formed argv.
+    """
+    flag_region = _flag_region(argv)
+    i = 0
+    n = len(flag_region)
+    while i < n:
+        token = flag_region[i]
+        if token in VALUE_TAKING_FLAGS:
+            nxt = flag_region[i + 1] if i + 1 < n else None
+            if nxt is None or nxt.startswith("--"):
+                swallowed = nxt if nxt is not None else "<end-of-flags / the SIF>"
+                raise ApptainerArgvError(
+                    f"apptainer flag {token!r} is missing its required value: "
+                    f"the next token is {swallowed!r}. apptainer would swallow "
+                    f"that token as {token}'s value and, if it is a flag like "
+                    "'--fakeroot', create a stray relative file (e.g. "
+                    "'--fakeroot') in the launch cwd / project root. Fix the "
+                    "spec.apptainer.raw_args ordering so every value-taking "
+                    "flag is immediately followed by its value."
+                )
+            # Skip the value so a value that legitimately starts with
+            # '--' (rare, but possible) isn't itself re-checked.
+            i += 2
+            continue
+        i += 1
+
+
+def _flag_region(argv: list[str]) -> list[str]:
+    """Return the apptainer flag tokens between ``exec`` and the SIF.
+
+    The SIF is the first positional NOT consumed as a value-taking
+    flag's argument. Everything from ``apptainer exec`` up to (excluding)
+    that positional is the flag region; the inner command after the SIF
+    is excluded.
+
+    Robust to a leading ``["apptainer", "exec", ...]`` prefix; if the
+    expected prefix is absent we scan the whole list (the guard then
+    simply checks the entire argv, which is still safe).
+    """
+    start = 0
+    if len(argv) >= 2 and argv[0] == "apptainer" and argv[1] == "exec":
+        start = 2
+
+    region: list[str] = []
+    i = start
+    n = len(argv)
+    while i < n:
+        token = argv[i]
+        if token.startswith("--"):
+            region.append(token)
+            if (
+                token in VALUE_TAKING_FLAGS
+                and i + 1 < n
+                and not argv[i + 1].startswith("--")
+            ):
+                # Real (non-flag) value — keep it in-region as the pair so
+                # the validator sees a satisfied flag. A ``--``-prefixed
+                # next token is a MISSING value: leave it for the validator
+                # to flag (do NOT consume it here).
+                region.append(argv[i + 1])
+                i += 2
+                continue
+            i += 1
+            continue
+        # First non-flag, non-value token == the SIF path → flags end.
+        break
+    return region
+
+
+__all__ = ["ApptainerArgvError", "VALUE_TAKING_FLAGS", "validate_flag_argv"]

--- a/src/scitex_agent_container/runtimes/_apptainer_build_argv.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_build_argv.py
@@ -24,6 +24,7 @@ import os
 from pathlib import Path
 
 from ..config import AgentConfig
+from ._apptainer_argv_guard import validate_flag_argv
 from ._apptainer_build import _create_overlay_image
 
 # ----------------------------------------------------------------------
@@ -379,15 +380,13 @@ def build_run_argv(
     # writable at ``$HOME/.claude/.credentials.json``. Emitted LAST among
     # binds (after the overlay-upper-home bind) so the relaxed ``--home``
     # tmpfs / upper-home bind cannot shadow it; last bind to a path wins.
-    #
     # apptainer FILE binds need the in-container destination to pre-exist,
     # so first ensure an empty placeholder at the host path backing the
     # container $HOME (overlay upper-home when relaxed-directory-overlay,
     # else the workspace-home bind). Without it a fresh overlay agent FATALs
     # at boot: "destination doesn't exist in container". The placeholder
     # goes in the bind DESTINATION backing, never to_home (whose
-    # credential-leak guard refuses .credentials.json). No-op when no creds
-    # bind will be emitted.
+    # credential-leak guard refuses .credentials.json). No-op w/o a creds bind.
     from ._apptainer_auth import credentials_file_bind, ensure_credentials_bind_target
 
     creds_bind = credentials_file_bind(config)
@@ -398,6 +397,10 @@ def build_run_argv(
         bind_flags=creds_bind,
     )
     argv += creds_bind
+
+    # Root-cause guard for the stray ``--fakeroot`` file in the project root
+    # (see _apptainer_argv_guard): a value-taking flag missing its value.
+    validate_flag_argv(argv)
 
     argv.append(str(sif_path))
 

--- a/tests/scitex_agent_container/runtimes/test__apptainer_argv_guard.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_argv_guard.py
@@ -1,0 +1,257 @@
+"""Regression tests — the stray ``--fakeroot`` file in the project root.
+
+Operator bug (2026-06-25): a 1-byte (single NULL) file literally named
+``--fakeroot`` kept appearing in the PROJECT ROOT. Root cause: when a
+value-taking apptainer flag (``--overlay`` / ``--bind`` / ``--env-file``
+/ …) is emitted with NO value — e.g. operator ``raw_args: ["--overlay"]``
+directly before sac's own ``--fakeroot`` — apptainer's CLI parser
+swallows the NEXT token (``--fakeroot``) as the missing value and creates
+a relative stub file at it. The TUI runtime shell-runs the argv with
+``cwd = expanded_workdir`` (the project root for the maintainer agent),
+so the stub lands in the repo.
+
+Fix: ``_apptainer_argv_guard.validate_flag_argv`` fails loud (no
+band-aid) when the assembled apptainer flag region has a value-taking
+flag missing its value, BEFORE the argv is ever launched. Wired into
+``build_run_argv`` just before the SIF is appended.
+
+No mocks / no monkeypatch (PA-306/307). Real ``load_config`` on a tmp
+spec for the end-to-end cases; direct argv lists for the unit cases.
+AAA blocks, markers on their own line, one assert per test.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from scitex_agent_container.config import load_config
+from scitex_agent_container.runtimes._apptainer_argv_guard import (
+    ApptainerArgvError,
+    validate_flag_argv,
+)
+from scitex_agent_container.runtimes._apptainer_build_argv import build_run_argv
+
+# ---------------------------------------------------------------------------
+# Fixtures (mirror test__apptainer_build_argv.py — real HOME + bearer token)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _isolate_home(tmp_path: Path) -> Iterator[Path]:
+    # Arrange-side fixture: keep the bearer-token resolver off the real ~.
+    saved = os.environ.get("HOME")
+    os.environ["HOME"] = str(tmp_path)
+    try:
+        yield tmp_path
+    finally:
+        if saved is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = saved
+
+
+@pytest.fixture
+def listen_bearer_token(_isolate_home: Path) -> Path:
+    # Materialise a real listen bearer so build_run_argv's listen-env
+    # guard doesn't turn an argv-shape test into a RuntimeError.
+    token_dir = _isolate_home / ".scitex" / "agent-container" / "tokens"
+    token_dir.mkdir(parents=True, exist_ok=True)
+    token_path = token_dir / f"listen-{socket.gethostname()}.token"
+    token_path.write_text("test-bearer-token-not-a-secret\n", encoding="utf-8")
+    return token_path
+
+
+def _write_spec(tmp_path: Path, raw_args_yaml: str) -> Path:
+    spec_dir = tmp_path / "agents" / "agt"
+    spec_dir.mkdir(parents=True, exist_ok=True)
+    spec = spec_dir / "spec.yaml"
+    spec.write_text(
+        "apiVersion: scitex-agent-container/v3\n"
+        "kind: Agent\n"
+        "metadata:\n"
+        "  labels:\n"
+        "    project: t\n"
+        '    sac-builtin: "off"\n'
+        "spec:\n"
+        "  runtime: tui\n"
+        "  host: local\n"
+        "  workdir: /tmp/agt-work\n"
+        "  apptainer:\n"
+        "    image: /x.sif\n"
+        "    fakeroot: true\n"
+        "    binds: []\n"
+        f"{raw_args_yaml}"
+        "  health:\n"
+        "    enabled: true\n"
+        "    interval: 60\n"
+        "  restart:\n"
+        "    policy: on-failure\n"
+        "    max_retries: 3\n"
+        "  claude:\n"
+        "    model: claude-opus-4-8[1m]\n",
+        encoding="utf-8",
+    )
+    return spec
+
+
+# ---------------------------------------------------------------------------
+# validate_flag_argv — unit cases (direct argv lists)
+# ---------------------------------------------------------------------------
+
+
+def test_valid_fakeroot_argv_passes_without_raising() -> None:
+    # Arrange — a well-formed flag region: --fakeroot sits before the SIF.
+    argv = ["apptainer", "exec", "--containall", "--fakeroot", "/x.sif", "bash"]
+    # Act
+    result = validate_flag_argv(argv)
+    # Assert — a no-op returns None (did not raise).
+    assert result is None
+
+
+def test_overlay_missing_value_swallowing_fakeroot_raises() -> None:
+    # Arrange — operator --overlay with no value, sac --fakeroot next.
+    argv = ["apptainer", "exec", "--overlay", "--fakeroot", "/x.sif", "bash"]
+    # Act
+    run = lambda: validate_flag_argv(argv)
+    # Assert
+    with pytest.raises(ApptainerArgvError):
+        run()
+
+
+def test_bind_missing_value_swallowing_next_flag_raises() -> None:
+    # Arrange — --bind with no value, another flag (--cleanenv) next.
+    argv = ["apptainer", "exec", "--bind", "--cleanenv", "/x.sif", "bash"]
+    # Act
+    run = lambda: validate_flag_argv(argv)
+    # Assert
+    with pytest.raises(ApptainerArgvError):
+        run()
+
+
+def test_error_message_names_the_offending_flag() -> None:
+    # Arrange
+    argv = ["apptainer", "exec", "--overlay", "--fakeroot", "/x.sif"]
+    message = ""
+    try:
+        validate_flag_argv(argv)
+    except ApptainerArgvError as exc:
+        message = str(exc)
+    # Act
+    names_cause = "--overlay" in message
+    # Assert — the diagnostic points at the real cause (--overlay).
+    assert names_cause is True
+
+
+def test_valid_bind_with_value_before_fakeroot_passes() -> None:
+    # Arrange — --bind has its value; --fakeroot is well-positioned.
+    argv = ["apptainer", "exec", "--bind", "/a:/a", "--fakeroot", "/x.sif"]
+    # Act
+    result = validate_flag_argv(argv)
+    # Assert
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# build_run_argv — end-to-end (real spec → guard runs before launch)
+# ---------------------------------------------------------------------------
+
+
+def test_build_run_argv_well_positioned_fakeroot_does_not_raise(
+    tmp_path: Path, listen_bearer_token: Path
+) -> None:
+    # Arrange — operator raw_args puts --fakeroot in a VALID position
+    # (a value-flag --bind with its value comes first).
+    raw = "    raw_args:\n      - --bind\n      - /a:/a\n      - --fakeroot\n"
+    cfg = load_config(str(_write_spec(tmp_path, raw)))
+    # Act
+    argv = build_run_argv(
+        cfg, state_dir=tmp_path / "st", sif_path=tmp_path / "x.sif", tui=True
+    )
+    # Assert — the guard passed; --fakeroot made it into the argv.
+    assert "--fakeroot" in argv
+
+
+def test_build_run_argv_well_positioned_fakeroot_precedes_a_value(
+    tmp_path: Path, listen_bearer_token: Path
+) -> None:
+    # Arrange — same valid raw_args; --bind /a:/a satisfies its value so
+    # --fakeroot is never swallowed.
+    raw = "    raw_args:\n      - --bind\n      - /a:/a\n      - --fakeroot\n"
+    cfg = load_config(str(_write_spec(tmp_path, raw)))
+    argv = build_run_argv(
+        cfg, state_dir=tmp_path / "st", sif_path=tmp_path / "x.sif", tui=True
+    )
+    idx = argv.index("--bind")
+    # Act — the token AFTER the first --bind is its value, not --fakeroot.
+    following = argv[idx + 1]
+    # Assert
+    assert not following.startswith("--")
+
+
+def test_build_run_argv_overlay_no_value_before_fakeroot_raises(
+    tmp_path: Path, listen_bearer_token: Path
+) -> None:
+    # Arrange — operator raw_args declares a bare --overlay (no value);
+    # sac then appends its own --fakeroot right after, reproducing the bug.
+    raw = "    raw_args:\n      - --overlay\n"
+    cfg = load_config(str(_write_spec(tmp_path, raw)))
+    # Act
+    build = lambda: build_run_argv(
+        cfg, state_dir=tmp_path / "st", sif_path=tmp_path / "x.sif", tui=True
+    )
+    # Assert — refused loudly BEFORE any launch / file creation.
+    with pytest.raises(ApptainerArgvError):
+        build()
+
+
+def test_build_run_argv_curated_fakeroot_from_yaml_is_emitted(
+    tmp_path: Path, listen_bearer_token: Path
+) -> None:
+    # Arrange — spec sets apptainer.fakeroot: true (parsed now); no
+    # raw_args. The curated iso-prepend must emit --fakeroot.
+    cfg = load_config(str(_write_spec(tmp_path, "")))
+    # Act
+    argv = build_run_argv(
+        cfg, state_dir=tmp_path / "st", sif_path=tmp_path / "x.sif", tui=True
+    )
+    # Assert — the YAML fakeroot key reached the launch argv.
+    assert "--fakeroot" in argv
+
+
+def test_build_run_argv_no_stray_fakeroot_file_in_cwd(
+    tmp_path: Path, listen_bearer_token: Path, clean_cwd
+) -> None:
+    # Arrange — build a valid fakeroot argv while cwd is a clean dir; the
+    # guard + well-formed argv must not (and cannot, being pure) create a
+    # stray ``--fakeroot`` file in cwd.
+    cfg = load_config(str(_write_spec(tmp_path, "")))
+    build_run_argv(
+        cfg, state_dir=tmp_path / "st", sif_path=tmp_path / "x.sif", tui=True
+    )
+    # Act
+    stray = clean_cwd / "--fakeroot"
+    # Assert
+    assert not stray.exists()
+
+
+@pytest.fixture
+def clean_cwd(tmp_path: Path) -> Iterator[Path]:
+    """chdir into a clean dir for the duration of the test, no monkeypatch.
+
+    A real ``os.chdir`` swap (saved + restored in a yield-fixture) so the
+    no-stray-file assertion runs with cwd pointed at an empty directory —
+    proving the argv assembly never writes ``--fakeroot`` relative to cwd.
+    """
+    clean = tmp_path / "clean-cwd"
+    clean.mkdir()
+    saved = os.getcwd()
+    os.chdir(clean)
+    try:
+        yield clean
+    finally:
+        os.chdir(saved)


### PR DESCRIPTION
## Summary
- A 1-byte (single NULL) file literally named `--fakeroot` kept appearing in the project root. Root cause: `build_run_argv` appends operator `spec.apptainer.raw_args` + the curated `--fakeroot` with no guard that value-taking apptainer flags (`--overlay`/`--bind`/`--env-file`/`--home`/...) actually have a value. A missing value (e.g. operator `raw_args: ["--overlay"]` directly before sac's own `--fakeroot`) makes apptainer's CLI parser swallow the next token as that flag's value and create a relative 1-byte stub at it. The TUI runtime shell-runs the argv with `cwd=expanded_workdir` — the project root for the maintainer agent whose workdir IS the repo — so the stub lands in the repo. Verified: `apptainer exec --overlay` swallows the following `--fakeroot`; the SDK path uses list-form `subprocess.Popen(argv)` and is unaffected (only the TUI shell-join path is exposed).
- Fix (fail-loud, no band-aid): new `runtimes/_apptainer_argv_guard.validate_flag_argv` refuses a flag region where a value-taking flag is missing its value, raising `ApptainerArgvError` BEFORE the argv is launched / shell-joined. Wired into `build_run_argv` just before the SIF is appended.
- Also fixed `config/_parsers/_apptainer.py` silently dropping the `apptainer.fakeroot` YAML key (it never reached the runtime), so the curated `--fakeroot` path works and is covered by the guard.

## Test plan
- [x] `tests/scitex_agent_container/runtimes/test__apptainer_argv_guard.py` (10 tests) — malformed `--overlay`/`--bind` (raise), well-positioned `--fakeroot` (no raise), curated-fakeroot-from-YAML emitted, and no stray `--fakeroot` file in a clean cwd. AAA / one-assert / no mocks / no monkeypatch.
- [x] Existing `test__apptainer_build_argv.py` + `test__apptainer_build_fakeroot.py` (63) still green.
- [x] Existing `config/_parsers/test__apptainer.py` (44) still green.