### PR TITLE
fix(listen): sac listen restart health-check no longer false-negatives under bearer auth

### DIFF
--- a/src/scitex_agent_container/_listen/_restart.py
+++ b/src/scitex_agent_container/_listen/_restart.py
@@ -71,10 +71,25 @@ _run_subprocess: Callable[..., subprocess.CompletedProcess] = subprocess.run
 
 
 def _default_http_get(url: str, timeout: float) -> int:
-    """Return the HTTP status for a GET, or -1 on any error.
+    """Return the HTTP status for a GET, or -1 if the server is *down*.
 
     Uses stdlib ``urllib`` rather than ``httpx`` to keep the restart
     path dep-light — if uvicorn binds the port, urllib reaches it.
+
+    Critically, an HTTP error *response* (401/403/404/5xx) is NOT a
+    failure for liveness purposes — it PROVES a daemon is bound and
+    answering. ``urllib`` raises :class:`~urllib.error.HTTPError`
+    (a subclass of ``URLError``) for any 4xx/5xx and carries the real
+    status code on ``.code`` — so we surface that code rather than
+    collapsing it to ``-1``. Only a genuine transport failure
+    (connection refused / DNS / timeout — a bare ``URLError`` with no
+    status, or ``OSError``) means "down" and returns ``-1``.
+
+    This is the fix for the bearer-auth false-negative
+    (card ``sac-listen-restart-healthcheck-bearer``): when
+    ``BearerAuthMiddleware`` gates the endpoint, the probe's
+    unauthenticated GET gets a 401 — which used to be swallowed as
+    ``-1`` and read as "daemon down", SIGKILLing a healthy daemon.
     """
     import urllib.error
     import urllib.request
@@ -83,7 +98,12 @@ def _default_http_get(url: str, timeout: float) -> int:
         req = urllib.request.Request(url, method="GET")
         with urllib.request.urlopen(req, timeout=timeout) as resp:
             return int(resp.status)
-    except (urllib.error.URLError, urllib.error.HTTPError, OSError):
+    except urllib.error.HTTPError as exc:
+        # 4xx/5xx — the daemon answered. Surface the real status so the
+        # liveness predicate can see "alive but auth-gated" (401/403).
+        return int(exc.code)
+    except (urllib.error.URLError, OSError):
+        # Transport-level failure (refused / timeout / DNS) — down.
         return -1
 
 
@@ -256,17 +276,36 @@ def wait_for_health(
     port: int,
     deadline_secs: float,
 ) -> bool:
-    """Poll ``http://<host>:<port>/v1/sac/health`` until 200 or deadline.
+    """Poll ``http://<host>:<port>/v1/sac/health`` until the daemon is
+    *alive* or the deadline elapses.
 
-    Endpoint shape fixed by ``_listen.server.health`` (route
-    ``/v1/sac/health``, returns ``{"ok": true, "service":
-    "sac-listen", "v": 1}``).
+    "Alive" means the daemon answered with *any* HTTP status — a 200
+    from the unauthenticated health route, but ALSO a 401/403 from
+    :class:`~_listen.auth.BearerAuthMiddleware` (the daemon is up and
+    auth-gating) or even a 404. The only "down" signal is a transport
+    failure (connection refused / timeout), which ``_http_get``
+    reports as ``-1``.
+
+    Rationale (card ``sac-listen-restart-healthcheck-bearer``): a
+    restart must NEVER SIGKILL + abort against a daemon that is
+    demonstrably answering. Gating liveness on ``status == 200`` made
+    a later bearer-auth change re-classify a live, 401-answering
+    daemon as "down" — a fail-quiet that destroyed a healthy process.
+    Treating "got an HTTP response" as alive is auth-change-proof
+    (fail-loud / no-surprise).
+
+    Endpoint shape fixed by ``_listen.server.health`` (returns
+    ``{"ok": true, "service": "sac-listen", "v": 1}`` on the
+    unauthenticated ``/v1/health`` route).
     """
     url = f"http://{host}:{port}/v1/sac/health"
     elapsed = 0.0
     while elapsed < deadline_secs:
         status = _http_get(url, timeout=2.0)
-        if status == 200:
+        # Any HTTP response (positive status) proves the daemon is
+        # bound and answering — incl. 401/403 under bearer auth.
+        # Only ``-1`` (transport failure) means "not up yet".
+        if status > 0:
             return True
         _sleep(_HEALTH_POLL_INTERVAL_SECS)
         elapsed += _HEALTH_POLL_INTERVAL_SECS

--- a/tests/scitex_agent_container/_listen/test__restart.py
+++ b/tests/scitex_agent_container/_listen/test__restart.py
@@ -478,14 +478,26 @@ def test_wait_for_health_returns_true_on_first_200() -> None:
     assert result is True
 
 
-def test_wait_for_health_returns_false_when_never_200() -> None:
-    # Arrange
-    http = _HttpRecorder(statuses=[503, -1, 502])
+def test_wait_for_health_returns_false_when_transport_fails() -> None:
+    # Arrange — every probe is a transport failure (refused/timeout),
+    # i.e. ``-1``: the only signal that means the daemon is truly down.
+    http = _HttpRecorder(statuses=[-1, -1, -1])
     # Act
     with _swap("_http_get", http), _swap("_sleep", _no_sleep):
         result = wait_for_health(host="127.0.0.1", port=7878, deadline_secs=1.0)
     # Assert
     assert result is False
+
+
+def test_wait_for_health_returns_true_on_401_under_bearer_auth() -> None:
+    # Arrange — bearer-auth gate answers the unauthenticated probe with
+    # 401: the daemon is ALIVE (it answered), so liveness must pass.
+    http = _HttpRecorder(statuses=[401])
+    # Act
+    with _swap("_http_get", http), _swap("_sleep", _no_sleep):
+        result = wait_for_health(host="127.0.0.1", port=7878, deadline_secs=5.0)
+    # Assert
+    assert result is True
 
 
 def test_wait_for_health_polls_correct_url() -> None:

--- a/tests/scitex_agent_container/_listen/test__restart_bearer_auth.py
+++ b/tests/scitex_agent_container/_listen/test__restart_bearer_auth.py
@@ -1,0 +1,192 @@
+"""Regression tests for the bearer-auth health-probe false-negative.
+
+Card ``sac-listen-restart-healthcheck-bearer`` (P1): a bearer-auth
+merge began gating the listen health endpoint, so the restart's
+unauthenticated post-relaunch probe got a 401 — which the probe used
+to read as "daemon down", SIGKILLing + aborting against a daemon that
+was demonstrably ALIVE (it answered 401).
+
+The fix: ``_default_http_get`` surfaces the real HTTP status from an
+``HTTPError`` (401/403/404/5xx) instead of collapsing it to ``-1``,
+and ``wait_for_health`` treats *any* HTTP response (positive status)
+as "alive" — only a transport failure (``-1``) means "down".
+
+PA-306 + STX-NM001-003 compliant: no MagicMock / no monkeypatch. The
+module-level seams are swapped via a hand-rolled save/restore context
+manager; the transport test uses a REAL loopback ``http.server``.
+
+AAA + >=3-word names + one assert per test (STX-TQ002 / PA-307).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+from scitex_agent_container._listen import _restart as restart_mod
+from scitex_agent_container._listen._restart import restart_listen
+
+
+@contextmanager
+def _swap(name: str, value) -> Iterator[None]:
+    """Replace ``restart_mod.<name>`` for the duration of the block."""
+    saved = getattr(restart_mod, name)
+    setattr(restart_mod, name, value)
+    try:
+        yield
+    finally:
+        setattr(restart_mod, name, saved)
+
+
+def _no_sleep(_secs: float) -> None:
+    """Recorded fake: no-op sleep, makes the poll loop instant."""
+
+
+class _KillRecorder:
+    """Hand-rolled fake for ``os.kill`` — kill(pid, 0) reports the pid
+    dead so the relaunch path proceeds to the health probe.
+    """
+
+    def __init__(self, *, alive_script: list[bool]) -> None:
+        self.calls: list[tuple[int, int]] = []
+        self._script = list(alive_script)
+        self._last_alive = alive_script[-1] if alive_script else False
+
+    def __call__(self, pid: int, sig: int) -> None:
+        self.calls.append((pid, sig))
+        if sig == 0:
+            if self._script:
+                alive = self._script.pop(0)
+                self._last_alive = alive
+            else:
+                alive = self._last_alive
+            if not alive:
+                raise ProcessLookupError(pid)
+
+
+class _SubprocessRecorder:
+    """Hand-rolled fake for ``subprocess.run`` — records argv + rc."""
+
+    def __init__(self, *, returncodes: list[int] | None = None) -> None:
+        self.calls: list[list[str]] = []
+        self._rcs = list(returncodes) if returncodes else []
+
+    def __call__(self, *args, **kwargs):
+        argv = list(args[0]) if args else list(kwargs.get("args", []))
+        self.calls.append(argv)
+        rc = self._rcs.pop(0) if self._rcs else 0
+        return subprocess.CompletedProcess(
+            args=argv, returncode=rc, stdout="", stderr=""
+        )
+
+
+class _HttpRecorder:
+    """Hand-rolled fake for the http-get seam — scripted statuses."""
+
+    def __init__(self, *, statuses: list[int]) -> None:
+        self.calls: list[tuple[str, float]] = []
+        self._statuses = list(statuses)
+
+    def __call__(self, url: str, timeout: float) -> int:
+        self.calls.append((url, timeout))
+        if not self._statuses:
+            return -1
+        return self._statuses.pop(0)
+
+
+# ---------------------------------------------------------------------------
+# Full restart flow — a 401-answering relaunch is "up", not aborted.
+# ---------------------------------------------------------------------------
+
+
+def test_restart_treats_401_relaunch_as_ok(tmp_path: Path) -> None:
+    # Arrange — relaunched daemon answers the unauthenticated probe with
+    # 401 (bearer-auth gate). It is ALIVE, so restart must report ok.
+    pid_file = tmp_path / "listen-7878.pid"
+    pid_file.write_text("12345\n")
+    kill = _KillRecorder(alive_script=[False])
+    subproc = _SubprocessRecorder(returncodes=[0])
+    http = _HttpRecorder(statuses=[401])
+    # Act
+    with (
+        _swap("_kill", kill),
+        _swap("_sleep", _no_sleep),
+        _swap("_run_subprocess", subproc),
+        _swap("_http_get", http),
+    ):
+        result = restart_listen(
+            host="127.0.0.1",
+            port=7878,
+            lock_dir=tmp_path,
+            health_deadline_secs=0.5,
+            systemd_unit_path=tmp_path / "absent.service",
+            sac_listen_argv=["echo", "stub"],
+        )
+    # Assert — 401 = alive = restart succeeded (no false-negative abort).
+    assert result.ok is True
+
+
+def test_restart_401_carries_no_error_message(tmp_path: Path) -> None:
+    # Arrange — same 401-answering relaunch; the error field must be
+    # empty (a 401 is liveness, not a failure to surface to the operator).
+    pid_file = tmp_path / "listen-7878.pid"
+    pid_file.write_text("12345\n")
+    kill = _KillRecorder(alive_script=[False])
+    subproc = _SubprocessRecorder(returncodes=[0])
+    http = _HttpRecorder(statuses=[401])
+    # Act
+    with (
+        _swap("_kill", kill),
+        _swap("_sleep", _no_sleep),
+        _swap("_run_subprocess", subproc),
+        _swap("_http_get", http),
+    ):
+        result = restart_listen(
+            host="127.0.0.1",
+            port=7878,
+            lock_dir=tmp_path,
+            health_deadline_secs=0.5,
+            systemd_unit_path=tmp_path / "absent.service",
+            sac_listen_argv=["echo", "stub"],
+        )
+    # Assert
+    assert result.error == ""
+
+
+# ---------------------------------------------------------------------------
+# Transport layer — a real 401-serving loopback server, no mocks.
+# ---------------------------------------------------------------------------
+
+
+def test_default_http_get_returns_401_status_not_minus_one() -> None:
+    # Arrange — a real loopback HTTP server that always 401s, mirroring
+    # the bearer-auth gate. No mock/monkeypatch: a genuine TCP server.
+    import http.server
+    import threading
+
+    class _Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802
+            self.send_response(401)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(b'{"error":"missing bearer token"}')
+
+        def log_message(self, *_args):  # silence test noise
+            return
+
+    server = http.server.HTTPServer(("127.0.0.1", 0), _Handler)
+    host, port = server.server_address
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    # Act
+    try:
+        status = restart_mod._default_http_get(
+            f"http://{host}:{port}/v1/sac/health", timeout=2.0
+        )
+    finally:
+        server.shutdown()
+        thread.join(timeout=2.0)
+    # Assert — the real 401 status surfaces, never collapsed to -1.
+    assert status == 401


### PR DESCRIPTION
## Root cause

Card `sac-listen-restart-healthcheck-bearer` (P1). The `sac listen restart` post-relaunch health probe lives in `src/scitex_agent_container/_listen/_restart.py`:

- `_default_http_get` (was line ~73) caught `urllib.error.HTTPError` (a subclass of `URLError`) and **collapsed every HTTP error response to `-1`**, throwing away the real status code.
- `wait_for_health` (was line ~269) only treated `status == 200` as "alive".

After the `BearerAuthMiddleware` merge (`_listen/auth.py`) gated the endpoint behind a bearer token, the probe's **unauthenticated** GET gets a `401 {"error":"missing bearer token"}`. That 401 was swallowed to `-1`, read as "daemon down", so restart reported `daemon did not respond 200 on /v1/sac/health within 30.0s`, SIGKILLed the old daemon, and aborted — even though the relaunched daemon was demonstrably **alive** (it answered 401). This made the canonical recovery path (`scripts/systemd/README.md`) unreliable and triggered false "hub down" panic (observed live 2026-06-25).

## Fix chosen (option a + robustness predicate)

A 401 PROVES the daemon answered. The robustness fix is auth-change-proof, so I made the probe's liveness predicate treat **any HTTP response (positive status) as "up"**:

- `_default_http_get` now surfaces the real status from `HTTPError.code` (401/403/404/5xx); only a true transport failure (`URLError`/`OSError` — refused/timeout/DNS) returns `-1`.
- `wait_for_health` returns `True` on any `status > 0`; only `-1` means "down".

This is fail-loud / no-surprise: a restart can never again SIGKILL + abort against a daemon that is answering, regardless of future auth changes. (I did not change the auth gate itself — keeping the bearer intent intact — only the probe's interpretation of a response.)

## Regression tests (no mocks, no monkeypatch)

- `tests/.../test__restart_bearer_auth.py` (new sibling — keeps the big test file under the limit):
  - `test_default_http_get_returns_401_status_not_minus_one` — a **real loopback `http.server`** that always 401s; asserts the status surfaces as `401`, not `-1`.
  - `test_restart_treats_401_relaunch_as_ok` — full `restart_listen` flow where the relaunch answers 401; asserts `result.ok is True`.
  - `test_restart_401_carries_no_error_message` — asserts `result.error == ""`.
- `test__restart.py` — added `test_wait_for_health_returns_true_on_401_under_bearer_auth`; reworked the old `..._never_200` test to `..._transport_fails` (pure `-1`) to match the corrected semantics.

All 42 tests in the two files pass.

## Test plan
- [x] `python -m pytest tests/scitex_agent_container/_listen/test__restart.py test__restart_bearer_auth.py -q` -> 42 passed