### PR TITLE
feat(launch): bind the host emacs-claude-code handoff dir into agents (read-only)

### DIFF
--- a/src/scitex_agent_container/runtimes/_p3a_default_binds.py
+++ b/src/scitex_agent_container/runtimes/_p3a_default_binds.py
@@ -104,6 +104,20 @@ _FLEET_DEFAULT_BINDS: tuple[str, ...] = (
     # canonical install. If a future SIF reintroduces a second venv
     # prefix, add its bind ONLY after confirming the destination dir
     # exists in that SIF.
+    #
+    # Operator handoff path (card sac-bind-host-tmp-emacs-handoff) — under
+    # ``--containall`` the host ``/tmp`` is isolated, so agents cannot read
+    # the UI debug + screenshot context the operator hands over at
+    # ``/tmp/emacs-claude-code/`` (``Element_Debug_Info_*.txt`` etc.), and
+    # ``ssh ywata-note-win`` from inside the container is refused. Bind the
+    # handoff dir READ-ONLY so an agent reads the file at the SAME path the
+    # operator names, with no manual copy-into-home step. Destination is a
+    # ``/tmp`` tmpfs path (writable under --containall), so apptainer's
+    # bind-dest auto-create cannot lose the overlay race the HAZARD above
+    # describes. ``default_binds_for_host`` skips it silently on hosts/times
+    # where the source dir does not exist (remote hosts, fresh boot before
+    # emacs writes) — no FATAL, no surprise mount.
+    "/tmp/emacs-claude-code:/tmp/emacs-claude-code:ro",
 )
 
 

--- a/tests/scitex_agent_container/runtimes/test__p3a_default_binds.py
+++ b/tests/scitex_agent_container/runtimes/test__p3a_default_binds.py
@@ -322,3 +322,23 @@ def test_default_binds_for_host_returns_absolute_host_paths_only(
     assert all(
         not src.startswith("~") and Path(src).is_absolute() for src in host_sources
     )
+
+
+# ---------------------------------------------------------------------------
+# Operator handoff bind (card sac-bind-host-tmp-emacs-handoff) — under
+# --containall the host /tmp is isolated, so agents need the emacs-claude-code
+# handoff dir bound read-only to read the operator's UI debug / screenshot
+# context. Skip-if-missing is covered by the host-existence-gate tests above.
+# ---------------------------------------------------------------------------
+
+
+def test_fleet_defaults_include_emacs_handoff_bind_read_only() -> None:
+    # Arrange — read the static fleet-default tuple directly.
+    from scitex_agent_container.runtimes._p3a_default_binds import (
+        _FLEET_DEFAULT_BINDS,
+    )
+
+    # Act
+    handoff = [b for b in _FLEET_DEFAULT_BINDS if "emacs-claude-code" in b]
+    # Assert — bound at the same host path, read-only.
+    assert handoff == ["/tmp/emacs-claude-code:/tmp/emacs-claude-code:ro"]


### PR DESCRIPTION
Binds the host `/tmp/emacs-claude-code` handoff dir **read-only** into every agent via the fleet-default binds, so agents can read the operator's UI debug + screenshot context (`Element_Debug_Info_*.txt`) at the same path the operator names.

Today this is unreadable: under `--containall` the host `/tmp` is isolated, and `ssh` from inside the container is refused (hit live 3x while handing over board-UI context). The cleanest fix is one entry in `_FLEET_DEFAULT_BINDS` — no per-spec edits, every agent gets it.

- Read-only (agents only read handoffs).
- `default_binds_for_host` skip-if-missing → no-op on remote hosts and fresh boots (no FATAL).
- `/tmp` tmpfs destination → avoids the overlay-race bind-dest FATAL the removed venv-agent bind caused.
- Out of scope: clipboard images in `/tmp` root (not the handoff dir) — drop them in `emacs-claude-code/` or home.

Test added (asserts the entry is present + read-only); 17 pass. Card `sac-bind-host-tmp-emacs-handoff`.

Note: binds apply at launch, so already-running agents pick this up on their next restart.
