### PR TITLE
feat(reconciler): Notification-hook records a card blocker when an agent waits for input

### DIFF
--- a/src/scitex_agent_container/_state/notification_blocker.py
+++ b/src/scitex_agent_container/_state/notification_blocker.py
@@ -1,0 +1,207 @@
+"""Record a card blocker when a Claude Code ``Notification`` hook fires.
+
+Claude Code emits a ``Notification`` hook event whenever it is waiting for
+input or permission (matcher types ``permission_prompt`` / ``idle_prompt`` /
+``auth_success`` / ``elicitation_dialog``). When that happens, the agent is
+*blocked on the operator* but typically says nothing — the operator only
+discovers it by opening the terminal (the live failure that motivated
+``sac-card-anchored-stop-reconciler``: a maintainer sat blocked at a "Submit
+answers" prompt unnoticed).
+
+This module is the deterministic backstop: given the notification payload, it
+resolves the agent's most-recently-active ``in_progress`` task card and stamps
+it ``status=blocked`` / ``blocker=operator-decision`` plus a comment carrying
+the notification message — so the board shows the block immediately.
+
+Design rules
+------------
+- **No ``import scitex_todo``.** The shared task store is mutated ONLY through
+  the installed ``scitex-todo`` CLI (``list-tasks`` / ``update`` / ``comment``).
+- **Fail-loud, no-surprise.** If the agent owns zero ``in_progress`` cards we
+  write nothing to a card and emit a loud agent-level log line instead of
+  silently guessing.
+- **Dedup.** The per-agent event ring (:mod:`event_log`) records each
+  notification; a repeat ``(agent, card, message-hash)`` seen recently is not
+  re-commented.
+- **Never raise.** A hook handler must not crash the host agent.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import subprocess
+from typing import Any
+
+from .event_log import append_event, read_recent
+
+logger = logging.getLogger(__name__)
+
+# How many recent ring events to scan when checking for a duplicate
+# notification (keeps dedup O(window), simple, and bounded).
+_DEDUP_WINDOW = 50
+# The verified scitex-todo blocker enum value for "waiting on the operator to
+# decide" — confirmed against scitex_todo._model.VALID_BLOCKERS and the
+# board's ``--blocking-me`` predicate (status=blocked AND
+# blocker=operator-decision). NOT the card's loose wording.
+_BLOCKER_OPERATOR_DECISION = "operator-decision"
+
+
+def _notification_message(payload: dict[str, Any]) -> str:
+    """Extract the human-readable notification text from the hook payload."""
+    for key in ("message", "notification", "body", "title"):
+        val = payload.get(key)
+        if isinstance(val, str) and val.strip():
+            return val.strip()
+    return "Claude Code is waiting for input"
+
+
+def _message_hash(message: str) -> str:
+    """Short stable hash of the notification message for dedup."""
+    return hashlib.sha256(message.encode("utf-8", "replace")).hexdigest()[:16]
+
+
+def _run_todo(args: list[str]) -> subprocess.CompletedProcess[str]:
+    """Run the ``scitex-todo`` CLI; never raises (returns the result)."""
+    return subprocess.run(  # noqa: S603,S607 — trusted CLI, fixed argv
+        ["scitex-todo", *args],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+
+def _most_recent_in_progress(agent: str) -> dict[str, Any] | None:
+    """Return the agent's most-recently-active ``in_progress`` card, or None.
+
+    Reads the shared store via ``scitex-todo list-tasks --agent <agent>
+    --status in_progress --json`` and picks the row with the latest
+    ``last_activity`` (falling back to list order when absent).
+    """
+    import json
+
+    proc = _run_todo(
+        ["list-tasks", "--agent", agent, "--status", "in_progress", "--json"]
+    )
+    if proc.returncode != 0:
+        logger.warning(
+            "scitex-todo list-tasks failed for agent %s (rc=%s): %s",
+            agent,
+            proc.returncode,
+            proc.stderr.strip()[:300],
+        )
+        return None
+    try:
+        rows = json.loads(proc.stdout or "[]")
+    except json.JSONDecodeError:
+        logger.warning("scitex-todo list-tasks returned non-JSON for %s", agent)
+        return None
+    if not isinstance(rows, list) or not rows:
+        return None
+    rows = [r for r in rows if isinstance(r, dict) and r.get("id")]
+    if not rows:
+        return None
+    rows.sort(key=lambda r: str(r.get("last_activity") or ""), reverse=True)
+    return rows[0]
+
+
+def _already_recorded(agent: str, card_id: str, msg_hash: str) -> bool:
+    """True if this (agent, card, message-hash) notification was seen recently."""
+    for ev in read_recent(agent, limit=_DEDUP_WINDOW):
+        if (
+            ev.get("kind") == "notification"
+            and ev.get("card_id") == card_id
+            and ev.get("message_hash") == msg_hash
+        ):
+            return True
+    return False
+
+
+def handle_notification(agent: str, payload: dict[str, Any]) -> None:
+    """Record the operator-decision blocker on the agent's active card.
+
+    Fail-loud on zero cards; dedup on repeat; never raises.
+    """
+    # stx-allow: fallback (reason: hook handler must never crash the host
+    # agent; any failure resolving the store / running the CLI is logged and
+    # swallowed so the tool call is not aborted)
+    try:
+        message = _notification_message(payload)
+        msg_hash = _message_hash(message)
+
+        card = _most_recent_in_progress(agent)
+        if card is None:
+            # Fail-loud / no-surprise: do NOT silently pick a card.
+            logger.warning(
+                "Notification hook fired for agent %s but it owns no "
+                "in_progress card — nothing recorded (message: %s)",
+                agent,
+                message[:200],
+            )
+            # Still ring the event so the agent's heartbeat reflects the
+            # notification (no card_id — nothing to dedup against a card).
+            append_event(
+                agent,
+                "notification",
+                {"message": message, "message_hash": msg_hash, "card_id": ""},
+            )
+            return
+
+        card_id = str(card["id"])
+
+        if _already_recorded(agent, card_id, msg_hash):
+            logger.info(
+                "Notification for agent %s card %s already recorded "
+                "(dedup) — skipping re-comment",
+                agent,
+                card_id,
+            )
+            return
+
+        # Set the blocker + status on the card.
+        upd = _run_todo(
+            [
+                "update",
+                card_id,
+                "--status",
+                "blocked",
+                "--blocker",
+                _BLOCKER_OPERATOR_DECISION,
+            ]
+        )
+        if upd.returncode != 0:
+            logger.warning(
+                "scitex-todo update failed for card %s (rc=%s): %s",
+                card_id,
+                upd.returncode,
+                upd.stderr.strip()[:300],
+            )
+
+        # Carry the notification message as a comment on the card.
+        comment_text = f"[notification] agent waiting for input: {message}"
+        cmt = _run_todo(["comment", card_id, comment_text, "--author", f"agent:{agent}"])
+        if cmt.returncode != 0:
+            logger.warning(
+                "scitex-todo comment failed for card %s (rc=%s): %s",
+                card_id,
+                cmt.returncode,
+                cmt.stderr.strip()[:300],
+            )
+
+        # TODO(sac-card-anchored-stop-reconciler): emit a dedicated scitex-todo
+        # ``needs-decision`` bus event KIND here so downstream push (phone /
+        # telegram / email) can subscribe to the decision-needed signal
+        # directly. That is a scitex-todo-side change; for now the comment
+        # write above already emits a card-message bus event, which suffices
+        # for this increment.
+
+        # Record in the per-agent ring LAST so a future identical notification
+        # dedups against this one.
+        append_event(
+            agent,
+            "notification",
+            {"message": message, "message_hash": msg_hash, "card_id": card_id},
+        )
+    except Exception:  # stx-allow: fallback (reason: catch-all — hook handler must never crash the host agent)
+        logger.warning("notification_blocker.handle_notification failed", exc_info=True)

--- a/src/scitex_agent_container/cli_pkg/hook_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/hook_cmds.py
@@ -54,7 +54,7 @@ def _resolve_agent(flag: str) -> str:
 @click.argument(
     "kind",
     type=click.Choice(
-        ["pretool", "posttool", "prompt", "stop", "other"],
+        ["pretool", "posttool", "prompt", "stop", "notification", "other"],
         case_sensitive=False,
     ),
 )
@@ -81,7 +81,15 @@ def hook_event(kind: str, agent_flag: str) -> None:
         except Exception:  # stx-allow: fallback (reason: catch-all safety net — see inline comment for context)
             payload = {"raw": raw[:500]}
         agent = _resolve_agent(agent_flag)
-        append_event(agent, kind.lower(), payload)
+        kind_lc = kind.lower()
+        if kind_lc == "notification":
+            # The notification handler owns its own event-ring write (with a
+            # card_id for dedup), so we do NOT also append a bare event here.
+            from .._state.notification_blocker import handle_notification
+
+            handle_notification(agent, payload)
+        else:
+            append_event(agent, kind_lc, payload)
     except Exception:  # stx-allow: fallback (reason: catch-all safety net — see inline comment for context)
         # Hooks must never break the host; swallow all failures.
         pass

--- a/src/scitex_agent_container/runtimes/_hooks_config.py
+++ b/src/scitex_agent_container/runtimes/_hooks_config.py
@@ -1,0 +1,89 @@
+"""Static Claude Code hook-wiring SAC injects into every agent.
+
+``_HOOKS_CONFIG`` is pushed into each spawned agent's settings file (via
+:func:`scitex_agent_container.runtimes.settings_json.setup_settings_json`) so
+the agent's Claude Code lifecycle events flow into SAC's per-agent event
+ring-buffer (``~/.scitex/agent-container/runtime/events/<agent>.jsonl``,
+consumed by ``event_log.summarize()`` which feeds the Orochi dashboard rows).
+
+Each entry routes a Claude Code hook event to
+``scitex-agent-container event ingest <kind>`` (see
+:mod:`scitex_agent_container.cli_pkg.hook_cmds`).
+
+Extracted from ``settings_json.py`` to keep that orchestrator under the
+512-line cap and to give the hook wiring a single cohesive home.
+"""
+
+from __future__ import annotations
+
+# Hook config pushed into every spawned agent's settings file so
+# PreToolUse / PostToolUse / UserPromptSubmit / Stop / Notification events
+# flow into the per-agent event ring-buffer. Without the first four, the
+# dashboard's Last tool / Last MCP / Last action rows render as dashes
+# (scitex-orochi todo#59).
+_HOOKS_CONFIG = {
+    "PreToolUse": [
+        {
+            "matcher": "",
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": "scitex-agent-container event ingest pretool",
+                }
+            ],
+        }
+    ],
+    "PostToolUse": [
+        {
+            "matcher": "",
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": "scitex-agent-container event ingest posttool",
+                }
+            ],
+        }
+    ],
+    "UserPromptSubmit": [
+        {
+            "matcher": "",
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": "scitex-agent-container event ingest prompt",
+                }
+            ],
+        }
+    ],
+    "Stop": [
+        {
+            "matcher": "",
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": "scitex-agent-container event ingest stop",
+                }
+            ],
+        }
+    ],
+    # Notification fires when Claude Code is waiting for input / permission
+    # (matcher types: permission_prompt, idle_prompt, auth_success,
+    # elicitation_dialog). The ingest handler records the blocker on the
+    # agent's active in_progress card so the board shows the agent is stuck
+    # even if the agent itself never speaks up (sac-card-anchored-stop-
+    # reconciler — the live failure: a maintainer sat blocked at a "Submit
+    # answers" prompt and the operator only found it via the terminal).
+    "Notification": [
+        {
+            "matcher": "",
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": "scitex-agent-container event ingest notification",
+                }
+            ],
+        }
+    ],
+}
+
+__all__ = ["_HOOKS_CONFIG"]

--- a/src/scitex_agent_container/runtimes/settings_json.py
+++ b/src/scitex_agent_container/runtimes/settings_json.py
@@ -56,6 +56,12 @@ from pathlib import Path
 
 from ..config import AgentConfig
 
+# Hook config pushed into every spawned agent's settings file so
+# PreToolUse / PostToolUse / UserPromptSubmit / Stop / Notification events
+# flow into the per-agent event ring-buffer. Extracted into ``_hooks_config``
+# to keep this orchestrator under the 512-line cap (scitex-orochi todo#59).
+from ._hooks_config import _HOOKS_CONFIG
+
 logger = logging.getLogger(__name__)
 
 # Keys managed by this module — cleanup removes exactly these.
@@ -68,59 +74,6 @@ _MANAGED_KEYS = frozenset(
         "statusLine",
     }
 )
-
-# Hook config pushed into every spawned agent's settings file so
-# PreToolUse / PostToolUse / UserPromptSubmit / Stop events flow into
-# the per-agent event ring-buffer (~/.scitex/agent-container/runtime/events/
-# <agent>.jsonl). Consumed by event_log.summarize() which feeds the
-# Orochi dashboard's Last tool / Last MCP / Last action rows. Without
-# this wiring those rows render as dashes (scitex-orochi todo#59).
-_HOOKS_CONFIG = {
-    "PreToolUse": [
-        {
-            "matcher": "",
-            "hooks": [
-                {
-                    "type": "command",
-                    "command": "scitex-agent-container event ingest pretool",
-                }
-            ],
-        }
-    ],
-    "PostToolUse": [
-        {
-            "matcher": "",
-            "hooks": [
-                {
-                    "type": "command",
-                    "command": "scitex-agent-container event ingest posttool",
-                }
-            ],
-        }
-    ],
-    "UserPromptSubmit": [
-        {
-            "matcher": "",
-            "hooks": [
-                {
-                    "type": "command",
-                    "command": "scitex-agent-container event ingest prompt",
-                }
-            ],
-        }
-    ],
-    "Stop": [
-        {
-            "matcher": "",
-            "hooks": [
-                {
-                    "type": "command",
-                    "command": "scitex-agent-container event ingest stop",
-                }
-            ],
-        }
-    ],
-}
 
 
 def _load_settings_dict(path: Path) -> dict:

--- a/tests/scitex_agent_container/_state/test_notification_blocker.py
+++ b/tests/scitex_agent_container/_state/test_notification_blocker.py
@@ -1,0 +1,141 @@
+"""Tests for ``_state.notification_blocker`` — card blocker on Notification.
+
+No-mocks. Every test exercises real production code against a REAL temporary
+``tasks.yaml`` mutated through the installed ``scitex-todo`` CLI:
+
+* ``$SCITEX_TODO_TASKS`` points the CLI at a per-test temp store.
+* ``$SCITEX_DIR`` + cwd-outside-a-repo route the event ring-buffer to
+  ``tmp_path`` (user scope), so dedup uses a real on-disk JSONL.
+* ``handle_notification`` runs the real ``scitex-todo list-tasks / update /
+  comment`` subprocesses — no patches, no monkeypatch.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._state.notification_blocker import handle_notification
+
+_AGENT = "agent:nbtest"
+
+
+def _scitex_todo(store: Path, args: list[str]) -> subprocess.CompletedProcess[str]:
+    env = {**os.environ, "SCITEX_TODO_TASKS": str(store)}
+    return subprocess.run(
+        ["scitex-todo", *args],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+        timeout=60,
+    )
+
+
+def _card(store: Path, card_id: str) -> dict:
+    proc = _scitex_todo(store, ["list-tasks", "--json"])
+    rows = json.loads(proc.stdout or "[]")
+    return next(r for r in rows if r.get("id") == card_id)
+
+
+@pytest.fixture
+def todo_store(tmp_path: Path, env_save_restore):
+    """A real temp tasks.yaml + event ring routed to ``tmp_path``.
+
+    Yields the store path; cleans env / cwd on teardown.
+    """
+    store = tmp_path / "tasks.yaml"
+    env_save_restore.set("SCITEX_TODO_TASKS", str(store))
+    env_save_restore.set("SCITEX_DIR", str(tmp_path / "scitex_home"))
+    env_save_restore.delete("SCITEX_AGENT_CONTAINER_AGENT")
+    env_save_restore.delete("CLAUDE_AGENT_ID")
+    saved_cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        yield store
+    finally:
+        os.chdir(saved_cwd)
+
+
+@pytest.fixture
+def one_in_progress_card(todo_store: Path):
+    """Seed exactly one in_progress card owned by ``_AGENT``."""
+    _scitex_todo(
+        todo_store,
+        ["add", "card-1", "Active card", "--status", "in_progress",
+         "--agent", _AGENT, "-y"],
+    )
+    return todo_store
+
+
+# ---------------------------------------------------------------------------
+# Happy path — one in_progress card
+# ---------------------------------------------------------------------------
+
+
+def test_handler_sets_operator_decision_blocker(one_in_progress_card: Path):
+    # Arrange
+    payload = {"message": "Submit answers to continue"}
+    # Act
+    handle_notification(_AGENT, payload)
+    # Assert
+    assert _card(one_in_progress_card, "card-1")["blocker"] == "operator-decision"
+
+
+def test_handler_sets_status_blocked(one_in_progress_card: Path):
+    # Arrange
+    payload = {"message": "Submit answers to continue"}
+    # Act
+    handle_notification(_AGENT, payload)
+    # Assert
+    assert _card(one_in_progress_card, "card-1")["status"] == "blocked"
+
+
+def test_handler_adds_comment_carrying_message(one_in_progress_card: Path):
+    # Arrange
+    payload = {"message": "Submit answers to continue"}
+    # Act
+    handle_notification(_AGENT, payload)
+    comments = _card(one_in_progress_card, "card-1").get("comments", [])
+    # Assert
+    assert any("Submit answers to continue" in str(c) for c in comments)
+
+
+def test_handler_dedups_repeat_notification(one_in_progress_card: Path):
+    # Arrange
+    payload = {"message": "Submit answers to continue"}
+    handle_notification(_AGENT, payload)
+    # Act
+    handle_notification(_AGENT, payload)
+    comments = _card(one_in_progress_card, "card-1").get("comments", [])
+    # Assert
+    assert len(comments) == 1
+
+
+# ---------------------------------------------------------------------------
+# Zero-card fail-loud path
+# ---------------------------------------------------------------------------
+
+
+def test_zero_card_writes_no_card(todo_store: Path):
+    # Arrange
+    payload = {"message": "Submit answers to continue"}
+    # Act
+    handle_notification(_AGENT, payload)
+    rows = json.loads(_scitex_todo(todo_store, ["list-tasks", "--json"]).stdout or "[]")
+    # Assert
+    assert rows == []
+
+
+def test_zero_card_logs_loud_warning(todo_store: Path, caplog):
+    # Arrange
+    payload = {"message": "Submit answers to continue"}
+    # Act
+    with caplog.at_level("WARNING"):
+        handle_notification(_AGENT, payload)
+    # Assert
+    assert "owns no in_progress card" in caplog.text

--- a/tests/scitex_agent_container/cli_pkg/test_hook_cmds.py
+++ b/tests/scitex_agent_container/cli_pkg/test_hook_cmds.py
@@ -256,6 +256,45 @@ def test_hook_event_via_subprocess_stdin_pipe(tmp_path: Path, env_save_restore):
     assert completed.returncode == 0
 
 
+def test_hook_event_notification_routes_to_blocker(
+    tmp_path: Path, env_save_restore
+):
+    """The ``notification`` kind routes through the blocker handler, which
+    stamps the agent's in_progress card blocked=operator-decision."""
+    # Arrange
+    store = tmp_path / "tasks.yaml"
+    env_save_restore.set("SCITEX_TODO_TASKS", str(store))
+    env_save_restore.set("SCITEX_DIR", str(tmp_path / "scitex_home"))
+    env_save_restore.delete("SCITEX_AGENT_CONTAINER_AGENT")
+    env_save_restore.delete("CLAUDE_AGENT_ID")
+    env = {**os.environ}
+    subprocess.run(
+        ["scitex-todo", "add", "c1", "Card", "--status", "in_progress",
+         "--agent", "nbagent", "-y"],
+        env=env, capture_output=True, text=True, check=False, timeout=60,
+    )
+    saved_cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        # Act
+        CliRunner().invoke(
+            hook_event,
+            ["notification", "--agent", "nbagent"],
+            input=json.dumps({"message": "Submit answers"}),
+        )
+        rows = json.loads(
+            subprocess.run(
+                ["scitex-todo", "list-tasks", "--json"],
+                env=env, capture_output=True, text=True, check=False, timeout=60,
+            ).stdout
+            or "[]"
+        )
+    finally:
+        os.chdir(saved_cwd)
+    # Assert
+    assert rows[0]["blocker"] == "operator-decision"
+
+
 def test_hook_event_subprocess_writes_real_log(
     tmp_path: Path,
 ):

--- a/tests/scitex_agent_container/runtimes/test_settings_json.py
+++ b/tests/scitex_agent_container/runtimes/test_settings_json.py
@@ -45,6 +45,20 @@ def test_hooks_always_injected_when_settings_written(tmp_path):
     assert data["hooks"] == _HOOKS_CONFIG
 
 
+def test_hooks_config_has_notification_entry_wired_to_ingest():
+    """The Notification hook deploys an ``event ingest notification`` command.
+
+    Records a card blocker when an agent waits for input
+    (sac-card-anchored-stop-reconciler).
+    """
+    # Arrange
+    notification_groups = _HOOKS_CONFIG["Notification"]
+    # Act
+    command = notification_groups[0]["hooks"][0]["command"]
+    # Assert
+    assert command == "scitex-agent-container event ingest notification"
+
+
 @pytest.mark.parametrize(
     "kind,subcommand",
     [
@@ -52,6 +66,7 @@ def test_hooks_always_injected_when_settings_written(tmp_path):
         ("PostToolUse", "posttool"),
         ("UserPromptSubmit", "prompt"),
         ("Stop", "stop"),
+        ("Notification", "notification"),
     ],
 )
 def test_hook_kind_maps_to_ingest_command(tmp_path, kind, subcommand):
@@ -66,7 +81,8 @@ def test_hook_kind_maps_to_ingest_command(tmp_path, kind, subcommand):
 
 
 @pytest.mark.parametrize(
-    "kind", ["PreToolUse", "PostToolUse", "UserPromptSubmit", "Stop"]
+    "kind",
+    ["PreToolUse", "PostToolUse", "UserPromptSubmit", "Stop", "Notification"],
 )
 def test_hook_command_has_no_control_chars(tmp_path, kind):
     """Regression: a stray backspace (\\x08) once sat INSIDE every hook command


### PR DESCRIPTION
## Summary
First, SAC-side-only layer of `sac-card-anchored-stop-reconciler`. Installs a per-agent Claude Code **`Notification`** hook (fires when Claude waits for input / permission) that deterministically records the blocker on the agent's active task card — so the board shows a stuck agent immediately even if the agent stays silent. The live failure this fixes: the maintainer agent sat blocked at a "Submit answers" prompt and the operator only found it by opening the terminal.

## What changed
- **`runtimes/_hooks_config.py`** (new): `_HOOKS_CONFIG` extracted out of `settings_json.py` (which was already over the 512-line cap) and given a `Notification` entry wired to `scitex-agent-container event ingest notification`. `settings_json` re-exports it, so the public API + the existing `setup_settings_json` deploy path are unchanged. The hook installs into every agent's `.claude/settings.json`.
- **`cli_pkg/hook_cmds.py`**: `notification` added to the event-kind choice list and routed to the new handler (other kinds keep the bare `append_event` path).
- **`_state/notification_blocker.py`** (new): resolves the agent's most-recently-active `in_progress` card via the **scitex-todo CLI** (`list-tasks --agent <agent> --status in_progress --json`, picks latest `last_activity`) — no `import scitex_todo`. Sets `status=blocked` / `blocker=operator-decision` (the verified enum value behind the board's `--blocking-me` predicate) and adds a comment carrying the notification message. **Fail-loud**: zero in_progress cards → no card write, a loud agent-level warning. **Dedup**: per-agent event ring on `(agent, card, message-hash)`.

A `# TODO` marks where a dedicated scitex-todo `needs-decision` bus-event KIND would be emitted (separate scitex-todo-side change; the comment write already emits a card-message event, which suffices here).

## Out of scope (not built)
Lineage climb, phone/telegram/email push, the Stop-hook + reconciler-tick layers, done-on-merge, and any scitex-todo-repo change.

## Verification
- `Notification` confirmed as the real Claude Code hook event (waits-for-input/permission; matcher types permission_prompt / idle_prompt / auth_success / elicitation_dialog; payload carries `message` + `session_id`) via the claude-code-official skill.
- `operator-decision` confirmed against `scitex_todo._model.VALID_BLOCKERS` and the board predicate.
- End-to-end against a real temp `tasks.yaml` via the installed CLI: card flips to blocked/operator-decision with the message as a comment.

## Test plan
- [x] `_HOOKS_CONFIG` contains a `Notification` entry wired to the ingest command
- [x] handler sets blocker + comment given a real temp store with one in_progress card owned by the agent
- [x] zero-card case writes no card but logs loud
- [x] dedup skips re-commenting a repeat notification
- [x] all files < 512 lines; no mocks / no monkeypatch (real tmp store + scitex-todo CLI)
- [x] 94 tests pass

Note: do NOT enable auto-merge — this installs a hook fleet-wide; maintainer review requested.