### PR TITLE
feat(send): full tmux key passthrough in sac agents send (arrows/Enter/Tab/any key)

### DIFF
--- a/src/scitex_agent_container/_listen/_agent_exec.py
+++ b/src/scitex_agent_container/_listen/_agent_exec.py
@@ -1,19 +1,18 @@
-"""Agent prompt/key + start routes for ``sac listen`` (extracted from server.py).
+"""Agent prompt/key send route for ``sac listen`` (extracted from server.py).
 
-Hosts the claude-execution surface — sending a prompt or interrupt key to
-an agent and starting an agent — plus the claude-binary resolver and the
-SSE streaming helper they depend on:
+Hosts the claude-execution surface — sending a prompt or a key to an
+agent — plus the claude-binary resolver and the SSE streaming helper
+they depend on:
 
     POST /agents/<name>/send   → :func:`agent_send`
-    POST /agents               → :func:`agents_start`
 
-Split out of :mod:`scitex_agent_container._listen.server` (which grew
-past the per-file line cap). ``server.py`` re-imports the handlers so
-route registration (:func:`_v1_agent_routes`) and the historical
-``from ..._listen.server import agent_send`` import path keep working
-unchanged. No behaviour change — this is a pure extraction of one
-cohesive responsibility (driving the claude binary / starting agents)
-away from the host control-plane wiring that stays in ``server.py``.
+The ``type: key`` branch is delegated to :mod:`._agent_exec_keys`
+(cancel-keys → SIGINT, every other named key / sequence → tmux
+send-keys). The ``POST /agents`` spawn route lives in
+:mod:`._agent_start` and is re-exported here so ``server.py``'s route
+registration (:func:`_v1_agent_routes`) and the historical
+``from ..._listen.server import agent_send`` / ``agents_start`` import
+paths keep working unchanged.
 """
 
 from __future__ import annotations
@@ -23,8 +22,6 @@ import json as _json
 import os
 import shutil
 import subprocess
-import time
-from pathlib import Path
 
 from starlette.requests import Request
 from starlette.responses import JSONResponse, Response, StreamingResponse
@@ -32,122 +29,15 @@ from starlette.responses import JSONResponse, Response, StreamingResponse
 from .._runners._session_state import read_session_id, state_dir_for
 from ..config import load_config
 from ..config._resolve import resolve_config
-from ._acl import check_spawn, deny_response
+from ._agent_exec_keys import _handle_key_send
+from ._agent_start import agents_start
 from ._forward import forward_to_live_runner
-from ._inline_spec import materialize_inline_spec
 
 __all__ = [
     "_find_claude_binary",
     "agent_send",
     "agents_start",
 ]
-
-
-# Layer-3 fail-loud (clew dogfood repro 2026-06-06, lead msg 57f1632a).
-# Grace window the listen waits AFTER `sac agents start <child>` returns
-# rc=0 before it accepts the spawn as "running and healthy". Long enough
-# for the real apptainer instance to come up on a SLURM-allocation host
-# under typical load; short enough that a stillborn instance is caught
-# before the operator's recv path treats SUCC as truth.
-_POST_ACK_LIVENESS_TIMEOUT_S = 5.0
-
-# How often to re-check the apptainer_pid file inside the grace window.
-_POST_ACK_LIVENESS_POLL_INTERVAL_S = 0.1
-
-
-def _pid_alive(pid: int) -> bool:
-    """``kill -0`` style liveness check. Returns False iff pid is reaped.
-
-    ``PermissionError`` means the kernel refused us (e.g. pid owned by
-    another uid), but the process exists — we treat that as alive.
-    Only ``ProcessLookupError`` (and the equivalent ``OSError(ESRCH)``)
-    counts as dead. ``pid <= 0`` is treated as dead defensively (the
-    file may have been written truncated / partial).
-    """
-    if pid <= 0:
-        return False
-    try:
-        os.kill(pid, 0)
-    except ProcessLookupError:
-        return False
-    except PermissionError:
-        return True
-    except OSError:
-        return False
-    return True
-
-
-def _probe_post_ack_liveness(
-    runtime_dir: Path,
-    *,
-    timeout_s: float = _POST_ACK_LIVENESS_TIMEOUT_S,
-    poll_interval_s: float = _POST_ACK_LIVENESS_POLL_INTERVAL_S,
-) -> tuple[str, str] | None:
-    """Return ``None`` if the spawned instance is live by deadline.
-
-    Returns ``(kind, hint)`` tuple on loud failure, suitable for the
-    :func:`_lifecycle._startup_failed.write_marker` ``kind_override``
-    + the operator-facing diagnostic hint:
-
-    * ``"post_ack_no_apptainer_pid"`` — the child subprocess returned
-      0 but never wrote ``<runtime_dir>/apptainer_pid``. The wrapper
-      bypassed the apptainer runtime path entirely (broken config,
-      missing image, runtime mis-resolved, etc.).
-    * ``"post_ack_apptainer_pid_dead"`` — ``apptainer_pid`` was
-      written but the process is dead (or never was alive). The SIF
-      instance came up and immediately exited; ``stderr.log`` in the
-      runtime dir usually has the actual cause.
-
-    Implementation: poll for the file to appear; once it does, check
-    liveness via ``os.kill(pid, 0)``. The check repeats until either
-    deadline OR a non-alive pid is observed, whichever comes first.
-    """
-    if timeout_s <= 0.0:
-        # Test escape hatch: zero/negative timeout skips the probe. The
-        # listen handler honours SAC_LISTEN_POST_ACK_LIVENESS_TIMEOUT_S
-        # to set this from the env so legacy tests that don't simulate
-        # the apptainer-pid write can opt out (the probe's contract is
-        # asserted by the dedicated probe-tests below).
-        return None
-    pid_file = runtime_dir / "apptainer_pid"
-    deadline = time.monotonic() + max(0.0, timeout_s)
-    saw_pid_file = False
-    last_seen_pid: int | None = None
-
-    while True:
-        if pid_file.is_file():
-            saw_pid_file = True
-            try:
-                pid = int(pid_file.read_text(encoding="utf-8").strip())
-            except (OSError, ValueError):
-                pid = -1
-            last_seen_pid = pid
-            if pid > 0 and _pid_alive(pid):
-                return None  # live → happy path
-        if time.monotonic() >= deadline:
-            break
-        time.sleep(poll_interval_s)
-
-    if not saw_pid_file:
-        return (
-            "post_ack_no_apptainer_pid",
-            f"`sac agents start` returned rc=0 but no apptainer_pid "
-            f"file appeared in {runtime_dir} within "
-            f"{timeout_s:.1f}s. The child subprocess bypassed the "
-            "apptainer runtime path (broken wrapper / missing config / "
-            "runtime mis-resolved). Inspect the runtime_dir for any "
-            "stdout/stderr the child captured, and verify the agent's "
-            "spec.apptainer block resolves to a real SIF on disk.",
-        )
-    return (
-        "post_ack_apptainer_pid_dead",
-        f"apptainer_pid={last_seen_pid} in {runtime_dir} was reaped "
-        f"within {timeout_s:.1f}s of the spawn-ack. The SIF instance "
-        "came up and exited silently — check the runtime_dir's "
-        "stderr.log for the apptainer FATAL line. Common causes: "
-        "missing bind source on host, SIF binary missing on host, "
-        "in-SIF entrypoint crashing on a startup-prompt eval.",
-    )
 
 
 def _find_claude_binary() -> str:
@@ -181,8 +71,11 @@ async def agent_send(request: Request) -> Response:
            short-lived re-launch against the persisted session.jsonl.
 
     Routing for ``type: key``:
-        SIGINT the live runner pid (best-effort). ESC / C-c / SIGINT
-        accepted; unknown keys → 400. No live runner → 404.
+        Cancel keys (ESC / C-c / SIGINT) SIGINT the live runner pid
+        (best-effort) to interrupt the turn. Every OTHER named key or
+        key sequence (Enter, Up, Down, Tab, digits, …) is delivered to
+        the agent's tmux session via send-keys. Unknown key names →
+        400 with the valid set listed; no live runner → 404.
     """
     name = request.path_params["name"]
     try:
@@ -194,42 +87,7 @@ async def agent_send(request: Request) -> Response:
     # documented in REQUIREMENT_SUMMARY §4.2.
     type_ = body.get("type", "prompt")
     if type_ == "key":
-        key = body.get("key")
-        # Supported: ESC / C-c / SIGINT — all map to SIGINT on the
-        # runner pid, which interrupts the current turn without
-        # killing the agent.
-        if key not in ("ESC", "C-c", "SIGINT"):
-            return JSONResponse(
-                {
-                    "error": (
-                        f"unsupported key={key!r}; expected one of "
-                        "'ESC', 'C-c', 'SIGINT'"
-                    )
-                },
-                status_code=400,
-            )
-        import signal as _signal
-
-        sd = state_dir_for(name)
-        pid_file = sd / "pid"
-        if not pid_file.is_file():
-            return JSONResponse(
-                {"error": f"agent {name!r} has no live session"},
-                status_code=404,
-            )
-        try:
-            pid = int(pid_file.read_text().strip())
-            os.kill(pid, _signal.SIGINT)
-        except (OSError, ValueError) as exc:
-            return JSONResponse({"error": str(exc)}, status_code=500)
-        return JSONResponse(
-            {
-                "name": name,
-                "route": "interrupt",
-                "pid": pid,
-                "signal": "SIGINT",
-            }
-        )
+        return _handle_key_send(name, body)
     if type_ != "prompt":
         return JSONResponse(
             {"error": f"unknown type {type_!r}; expected 'prompt' or 'key'"},
@@ -345,297 +203,3 @@ async def _stream_claude(argv: list[str], workdir: str, name: str, sid: str):
                 proc.kill()
         raise
 
-
-async def agents_start(request: Request) -> JSONResponse:
-    """POST /agents — start one or more agents.
-
-    Body shapes:
-
-        # Start a pre-registered spec (existing on disk):
-        {"name": "<existing-spec-name>", "caller": "<sender-name>"}
-
-        # Register-and-start an ad-hoc spec in one call:
-        {
-            "name": "<name>",
-            "caller": "<sender-name>",
-            "spec": {"apiVersion": "scitex-agent-container/v3",
-                     "kind": "Agent",
-                     "spec": {...}},
-            "overwrite": false   # optional; default false → 409 on clash
-        }
-
-    WI-2 spawn-permission gate (limited scope per lead 2026-05-20):
-    the optional ``caller`` field carries the spawning node's name
-    (same self-claimed-identity caveat as ``message:send``'s
-    ``metadata.from_agent``). The gate is **root-only** today —
-    a node with no parent in the ``lineage`` table may spawn; a
-    child gets a clear 403. ``caller`` omitted = administrative /
-    human-operator path → allowed.
-
-    On allow, the parent → child edge is recorded in ``lineage``
-    so the new agent inherits the spawner's group.
-    """
-    try:
-        body = await request.json()
-    except (
-        Exception
-    ):  # stx-allow: fallback (reason: malformed JSON → 400 instead of 500)
-        return JSONResponse({"error": "body must be JSON"}, status_code=400)
-    name = body.get("name")
-    if not isinstance(name, str) or not name:
-        return JSONResponse(
-            {"error": "missing or empty 'name' string"}, status_code=400
-        )
-
-    # WI-2 spawn-permission gate.
-    caller = body.get("caller")
-    if caller is not None and not isinstance(caller, str):
-        return JSONResponse(
-            {"error": "'caller' must be a string if present"}, status_code=400
-        )
-
-    # PR-α (lead msg d96a468c 2026-06-06): cohort one-shot diagnostic.
-    # When the parent's ``sac agents start`` carried --foreground /
-    # --one-shot, the spawn client (_lifecycle/_spawn_client.py) emits
-    # these as body fields. Propagate to the inner argv so the host's
-    # apptainer runtime takes the foreground/one-shot branch
-    # (subprocess.run blocks until the capsule exits) — the capsule's
-    # actual exit code + stderr then flow up into STARTUP_FAILED on
-    # crash, instead of the background branch's "Popen + rc=0
-    # immediately" lie. Each flag is independent + back-compat absent
-    # (default False → no flag, pre-α behaviour).
-    foreground = body.get("foreground", False)
-    if not isinstance(foreground, bool):
-        return JSONResponse(
-            {"error": "'foreground' must be a boolean if present"},
-            status_code=400,
-        )
-    one_shot = body.get("one_shot", False)
-    if not isinstance(one_shot, bool):
-        return JSONResponse(
-            {"error": "'one_shot' must be a boolean if present"},
-            status_code=400,
-        )
-    decision, reason = check_spawn(caller=caller)
-    if decision == "deny":
-        return deny_response(reason or "spawn denied")
-
-    inline_spec = body.get("spec")
-    if inline_spec is not None:
-        # PR-2 — pass ``caller`` through so the bind translate can
-        # look up the parent agent's host-side bind map and rewrite
-        # in-SIF ``/work/...`` sources before the PR-1 preflight
-        # runs. Caller absent → translate disabled, preflight
-        # enforces directly (the operator/admin path).
-        err = materialize_inline_spec(
-            name,
-            inline_spec,
-            overwrite=bool(body.get("overwrite")),
-            caller=caller,
-        )
-        if err is not None:
-            return err
-
-    # Record lineage on allowed-spawn so the new child inherits the
-    # caller's group. ``caller=None`` → no lineage record (admin /
-    # operator path; the new agent starts as a root).
-    if caller:
-        from .._state.state_db_nodes import record_lineage as _record_lineage
-
-        try:
-            _record_lineage(child=name, parent=caller)
-        except ValueError as exc:
-            # Idempotent same-parent re-record is fine; a re-parent
-            # to a different caller is loudly rejected.
-            return JSONResponse({"error": str(exc)}, status_code=409)
-
-    sac_bin = shutil.which("sac") or "sac"
-    # ``agents`` (plural) is the canonical command group; the singular
-    # ``agent`` form was removed in the F-CS13 rename and the host CLI
-    # no longer exposes it (verified 2026-06-01 by the SAC-from-SAC
-    # live test: the singular form returned "Error: No such command
-    # 'agent'." with rc=2, breaking every brokered spawn from inside
-    # a SIF). Using the canonical plural is what every other CLI
-    # call site already does — see ``cli_pkg/fleet_group.py``
-    # ``[remote_sac, "agents", "start", name]``.
-    from datetime import datetime, timezone
-
-    started_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-    # --broker-self recursive re-entry fix (clew dogfood repro
-    # 2026-06-06, lead msg d8f61055): when the listen runs inside a
-    # parent SAC's SIF on a SLURM allocation, this handler's child
-    # `sac agents start` inherits APPTAINER_CONTAINER /
-    # SINGULARITY_CONTAINER from the listen's env. That makes
-    # is_in_sif() return True in the child, which re-enters
-    # maybe_broker_in_sif_spawn → tries to broker the spawn to
-    # *this same listen* → recursive InSifBrokerError loop.
-    #
-    # The listen IS the host-side spawn boundary: the child should
-    # take the bare-host path (direct apptainer-exec the sibling
-    # SIF), not pretend it is still inside a parent SIF. Strip the
-    # in-SIF env markers so is_in_sif() returns False on the child.
-    # No other downstream sac code reads these env vars except the
-    # broker probe, so the strip is safe; apptainer ITSELF re-sets
-    # APPTAINER_CONTAINER inside the child SIF it execs.
-    child_env = dict(os.environ)
-    child_env.pop("APPTAINER_CONTAINER", None)
-    child_env.pop("SINGULARITY_CONTAINER", None)
-    # PR-α: propagate --foreground / --one-shot to the inner argv per the
-    # body fields validated above. Order matches the click signature on
-    # `sac agents start` (flags before/after positional name are
-    # equivalent, but keep the positional last for the canonical shape).
-    inner_argv = [sac_bin, "agents", "start"]
-    if foreground:
-        inner_argv.append("--foreground")
-    if one_shot:
-        inner_argv.append("--one-shot")
-    inner_argv.append(name)
-    proc = await asyncio.to_thread(
-        subprocess.run,
-        inner_argv,
-        capture_output=True,
-        text=True,
-        check=False,
-        env=child_env,
-    )
-    if proc.returncode != 0:
-        # PR-1 — stillborn agent observability. The subprocess can exit
-        # non-zero for many reasons, including apptainer FATAL on a bind
-        # source the host can't see (the clew capsule case). Write a
-        # ``runtime_dir/STARTUP_FAILED`` marker so:
-        #   * a subsequent ``DELETE`` returns 410 Gone with the failure
-        #     payload instead of 404 "no pid file",
-        #   * ``GET .../status`` can surface ``status="startup_failed"``
-        #     instead of vacuous registry-only fields,
-        #   * future fleet-GC automation can drop the stillborn cleanly.
-        # The marker write is best-effort: a write failure (e.g. /state
-        # filesystem RO) MUST NOT shadow the underlying spawn failure.
-        # stx-allow: fallback (reason: marker is observability metadata
-        # only; failing here would only obscure the real start failure)
-        try:
-            from .._lifecycle._startup_failed import write_marker
-            from .._runners._session_state import state_dir_for
-
-            runtime_dir = state_dir_for(name)
-            write_marker(
-                runtime_dir,
-                started_at=started_at,
-                phase="container_creation",
-                exit_code=proc.returncode,
-                stdout=proc.stdout,
-                stderr=proc.stderr,
-            )
-        except Exception:  # stx-allow: fallback (reason: see inline comment)
-            pass
-
-        return JSONResponse(
-            {
-                "name": name,
-                "returncode": proc.returncode,
-                "stdout": proc.stdout,
-                "stderr": proc.stderr,
-            },
-            status_code=502,
-        )
-
-    # Layer-3 fail-loud (clew dogfood repro 2026-06-06, lead msg
-    # 57f1632a): `sac agents start <child>` returning rc=0 was being
-    # treated as "instance is running and healthy", but the apptainer
-    # exec the child spawned can die SILENTLY post-ack — empty
-    # stdout.log, dead apptainer_pid, no fresh STARTUP_FAILED marker.
-    # The "SUCC: started" body of this 200 response lied.
-    #
-    # Probe the runtime_dir for liveness: wait up to
-    # ``_POST_ACK_LIVENESS_TIMEOUT_S`` for ``apptainer_pid`` to appear
-    # AND for that pid to still be alive (``kill -0``). Three loud
-    # failure modes:
-    #
-    #   * apptainer_pid never appears within the grace → the child
-    #     subprocess returned 0 without invoking the apptainer
-    #     runtime path (broken wrapper, missing config, etc.).
-    #     kind = "post_ack_no_apptainer_pid"
-    #   * apptainer_pid appears but the pid is dead by the time we
-    #     check → the SIF instance came up and immediately died.
-    #     kind = "post_ack_apptainer_pid_dead"
-    #   * apptainer_pid was alive at grace-deadline → return 200/SUCC
-    #     (the existing happy path).
-    #
-    # Loud failures write a fresh STARTUP_FAILED with the new kind
-    # AND downgrade the response to 502 so the operator-side recv
-    # path can show a real diagnostic instead of a misleading SUCC.
-    #
-    # PR-α: skip the probe when foreground=True. The inner subprocess
-    # already blocked (apptainer runtime's foreground branch is
-    # subprocess.run, not Popen) and explicitly does NOT write
-    # apptainer_pid — the probe would always report
-    # post_ack_no_apptainer_pid on a successful one-shot run. The real
-    # signal is the inner rc captured above; rc!=0 already wrote
-    # STARTUP_FAILED with stderr_tail (the cohort one-shot diagnostic).
-    if foreground:
-        return JSONResponse(
-            {
-                "name": name,
-                "returncode": proc.returncode,
-                "stdout": proc.stdout,
-                "stderr": proc.stderr,
-            },
-            status_code=200,
-        )
-    from .._lifecycle._startup_failed import write_marker
-    from .._runners._session_state import state_dir_for
-
-    runtime_dir = state_dir_for(name)
-    # Test escape hatch: ``SAC_LISTEN_POST_ACK_LIVENESS_TIMEOUT_S`` env
-    # var lets the suite skip / shorten the probe (≤0 → skip entirely).
-    # Production callers leave it unset and get the default 5s grace.
-    try:
-        env_timeout = float(
-            os.environ.get(
-                "SAC_LISTEN_POST_ACK_LIVENESS_TIMEOUT_S",
-                str(_POST_ACK_LIVENESS_TIMEOUT_S),
-            )
-        )
-    except ValueError:
-        env_timeout = _POST_ACK_LIVENESS_TIMEOUT_S
-    liveness_failure = _probe_post_ack_liveness(
-        runtime_dir,
-        timeout_s=env_timeout,
-    )
-    if liveness_failure is not None:
-        kind, hint = liveness_failure
-        # stx-allow: fallback (reason: marker write is observability;
-        # a write failure here must not shadow the underlying
-        # post-ack-died signal that the listen is about to return)
-        try:
-            write_marker(
-                runtime_dir,
-                started_at=started_at,
-                phase="post_ack_liveness",
-                exit_code=0,
-                stdout=proc.stdout or "",
-                stderr=(proc.stderr or "")
-                + f"\n\n[listen post-ack liveness probe] {kind}: {hint}\n",
-                kind_override=kind,
-            )
-        except Exception:  # stx-allow: fallback (reason: see inline comment)
-            pass
-        return JSONResponse(
-            {
-                "name": name,
-                "returncode": proc.returncode,
-                "stdout": proc.stdout,
-                "stderr": proc.stderr,
-                "post_ack_liveness": {"kind": kind, "hint": hint},
-            },
-            status_code=502,
-        )
-
-    return JSONResponse(
-        {
-            "name": name,
-            "returncode": proc.returncode,
-            "stdout": proc.stdout,
-            "stderr": proc.stderr,
-        },
-        status_code=200,
-    )

--- a/src/scitex_agent_container/_listen/_agent_exec_keys.py
+++ b/src/scitex_agent_container/_listen/_agent_exec_keys.py
@@ -1,0 +1,160 @@
+"""``type: key`` handler for ``POST /agents/<name>/send`` (listen).
+
+Split out of :mod:`._agent_exec` (which is at its per-file line cap) so
+the key-passthrough logic lives in one cohesive place. Two routes:
+
+  * cancel keys (ESC / C-c / SIGINT) → SIGINT the runner pid, which
+    interrupts the current turn without killing the agent. This is the
+    historical behaviour, preserved verbatim.
+  * every OTHER named key / sequence (Enter, Up, Down, Tab, digits, …)
+    → ``tmux send-keys`` into the agent's live tmux session so the
+    keystroke lands in the TUI exactly as if typed.
+
+Validation against the tmux key vocabulary (:mod:`..._runners._tmux._keys`)
+fails loud with the valid set listed; nothing is half-delivered.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Callable, Tuple
+
+from starlette.responses import JSONResponse, Response
+
+from .._runners._session_state import state_dir_for
+from .._runners._tmux._keys import (
+    UnknownKeyError,
+    parse_key_sequence,
+    validate_keys,
+)
+
+__all__ = ["_handle_key_send", "_CANCEL_KEYS"]
+
+# Cancel keys keep their historical interrupt semantics — SIGINT the
+# runner pid rather than typing the literal key into the TUI.
+_CANCEL_KEYS = frozenset({"ESC", "C-c", "SIGINT"})
+
+# Injection seam: resolve ``name`` → ``(session_name, mux)`` where mux
+# exposes ``exists(session)`` + ``send_keys(session, *keys)``. The
+# default goes through the real config + multiplexer; tests pass a
+# recording fake so the send-keys branch is exercised without a live
+# tmux session (mirrors the existing tmux-test injection pattern).
+MuxResolver = Callable[[str], Tuple[str, object]]
+
+
+def _default_mux_resolver(name: str) -> Tuple[str, object]:
+    """Resolve ``name`` to its tmux ``(screen_name, multiplexer)``."""
+    from ..config import load_config
+    from ..config._resolve import resolve_config
+    from .._runners._tmux.multiplexer import get_multiplexer
+
+    spec_path = resolve_config(name)
+    cfg = load_config(spec_path)
+    return cfg.screen_name, get_multiplexer(cfg)
+
+
+def _interrupt_pid(name: str) -> Response:
+    """SIGINT the agent's recorded runner pid (cancel the current turn)."""
+    import signal as _signal
+
+    sd = state_dir_for(name)
+    pid_file = sd / "pid"
+    if not pid_file.is_file():
+        return JSONResponse(
+            {"error": f"agent {name!r} has no live session"},
+            status_code=404,
+        )
+    try:
+        pid = int(pid_file.read_text().strip())
+        os.kill(pid, _signal.SIGINT)
+    except (OSError, ValueError) as exc:
+        return JSONResponse({"error": str(exc)}, status_code=500)
+    return JSONResponse(
+        {
+            "name": name,
+            "route": "interrupt",
+            "pid": pid,
+            "signal": "SIGINT",
+        }
+    )
+
+
+def _send_keys_to_session(
+    name: str,
+    tmux_keys: list[str],
+    *,
+    mux_resolver: MuxResolver = _default_mux_resolver,
+) -> Response:
+    """Deliver validated tmux key names into the agent's tmux session.
+
+    Resolves the agent's ``screen_name`` (its tmux session) + its
+    multiplexer via ``mux_resolver`` and routes the keys through the
+    multiplexer's ``send_keys`` — the same primitive the TUI runner
+    uses. Loud 404 when the spec cannot be resolved (unknown agent) or
+    there is no live tmux session.
+    """
+    try:
+        session, mux = mux_resolver(name)
+    except Exception as exc:  # stx-allow: fallback (reason: unknown agent → 404 with reason, not ASGI 500)
+        return JSONResponse({"error": str(exc)}, status_code=404)
+
+    if not mux.exists(session):  # type: ignore[attr-defined]
+        return JSONResponse(
+            {
+                "error": (
+                    f"agent {name!r} has no live tmux session {session!r}"
+                )
+            },
+            status_code=404,
+        )
+    mux.send_keys(session, *tmux_keys)  # type: ignore[attr-defined]
+    return JSONResponse(
+        {
+            "name": name,
+            "route": "send-keys",
+            "session": session,
+            "keys": tmux_keys,
+        }
+    )
+
+
+def _handle_key_send(
+    name: str,
+    body: dict,
+    *,
+    mux_resolver: MuxResolver = _default_mux_resolver,
+) -> Response:
+    """Route a ``type: key`` body to SIGINT (cancel) or tmux send-keys.
+
+    Body shapes:
+        {"type":"key","key":"ESC"}             → SIGINT (cancel turn)
+        {"type":"key","key":"Enter"}           → send-keys "Enter"
+        {"type":"key","key":"1"}               → send-keys "1"
+        {"type":"key","keys":"Up Up Enter"}    → send-keys Up Up Enter
+
+    A single cancel ``key`` keeps the historical interrupt path. Any
+    other ``key`` or any ``keys`` sequence is validated against the
+    tmux vocabulary and delivered to the agent's tmux session.
+    Unknown names → 400 with the valid set listed (no partial send).
+    """
+    key = body.get("key")
+    keys = body.get("keys")
+
+    if isinstance(key, str) and key in _CANCEL_KEYS and keys is None:
+        return _interrupt_pid(name)
+
+    if isinstance(keys, str):
+        tokens = parse_key_sequence(keys)
+    elif isinstance(key, str):
+        tokens = [key]
+    else:
+        return JSONResponse(
+            {"error": "key send requires a 'key' or 'keys' string"},
+            status_code=400,
+        )
+
+    try:
+        tmux_keys = validate_keys(tokens)
+    except (UnknownKeyError, ValueError) as exc:
+        return JSONResponse({"error": str(exc)}, status_code=400)
+    return _send_keys_to_session(name, tmux_keys, mux_resolver=mux_resolver)

--- a/src/scitex_agent_container/_listen/_agent_start.py
+++ b/src/scitex_agent_container/_listen/_agent_start.py
@@ -1,0 +1,430 @@
+"""``POST /agents`` spawn route + post-ack liveness probe (listen).
+
+Extracted from :mod:`._agent_exec` (which grew past the per-file line
+cap) so the spawn surface lives in one cohesive module. ``_agent_exec``
+re-exports :func:`agents_start` so ``server.py``'s route registration
+and historical import paths keep working unchanged. No behaviour change
+— a pure extraction of the agent-start responsibility away from the
+prompt/key send surface.
+
+    POST /agents               → :func:`agents_start`
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+from ._acl import check_spawn, deny_response
+from ._inline_spec import materialize_inline_spec
+
+__all__ = ["agents_start"]
+
+
+# Layer-3 fail-loud (clew dogfood repro 2026-06-06, lead msg 57f1632a).
+# Grace window the listen waits AFTER `sac agents start <child>` returns
+# rc=0 before it accepts the spawn as "running and healthy". Long enough
+# for the real apptainer instance to come up on a SLURM-allocation host
+# under typical load; short enough that a stillborn instance is caught
+# before the operator's recv path treats SUCC as truth.
+_POST_ACK_LIVENESS_TIMEOUT_S = 5.0
+
+# How often to re-check the apptainer_pid file inside the grace window.
+_POST_ACK_LIVENESS_POLL_INTERVAL_S = 0.1
+
+
+def _pid_alive(pid: int) -> bool:
+    """``kill -0`` style liveness check. Returns False iff pid is reaped.
+
+    ``PermissionError`` means the kernel refused us (e.g. pid owned by
+    another uid), but the process exists — we treat that as alive.
+    Only ``ProcessLookupError`` (and the equivalent ``OSError(ESRCH)``)
+    counts as dead. ``pid <= 0`` is treated as dead defensively (the
+    file may have been written truncated / partial).
+    """
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def _probe_post_ack_liveness(
+    runtime_dir: Path,
+    *,
+    timeout_s: float = _POST_ACK_LIVENESS_TIMEOUT_S,
+    poll_interval_s: float = _POST_ACK_LIVENESS_POLL_INTERVAL_S,
+) -> tuple[str, str] | None:
+    """Return ``None`` if the spawned instance is live by deadline.
+
+    Returns ``(kind, hint)`` tuple on loud failure, suitable for the
+    :func:`_lifecycle._startup_failed.write_marker` ``kind_override``
+    + the operator-facing diagnostic hint:
+
+    * ``"post_ack_no_apptainer_pid"`` — the child subprocess returned
+      0 but never wrote ``<runtime_dir>/apptainer_pid``. The wrapper
+      bypassed the apptainer runtime path entirely (broken config,
+      missing image, runtime mis-resolved, etc.).
+    * ``"post_ack_apptainer_pid_dead"`` — ``apptainer_pid`` was
+      written but the process is dead (or never was alive). The SIF
+      instance came up and immediately exited; ``stderr.log`` in the
+      runtime dir usually has the actual cause.
+
+    Implementation: poll for the file to appear; once it does, check
+    liveness via ``os.kill(pid, 0)``. The check repeats until either
+    deadline OR a non-alive pid is observed, whichever comes first.
+    """
+    if timeout_s <= 0.0:
+        # Test escape hatch: zero/negative timeout skips the probe. The
+        # listen handler honours SAC_LISTEN_POST_ACK_LIVENESS_TIMEOUT_S
+        # to set this from the env so legacy tests that don't simulate
+        # the apptainer-pid write can opt out (the probe's contract is
+        # asserted by the dedicated probe-tests below).
+        return None
+    pid_file = runtime_dir / "apptainer_pid"
+    deadline = time.monotonic() + max(0.0, timeout_s)
+    saw_pid_file = False
+    last_seen_pid: int | None = None
+
+    while True:
+        if pid_file.is_file():
+            saw_pid_file = True
+            try:
+                pid = int(pid_file.read_text(encoding="utf-8").strip())
+            except (OSError, ValueError):
+                pid = -1
+            last_seen_pid = pid
+            if pid > 0 and _pid_alive(pid):
+                return None  # live → happy path
+        if time.monotonic() >= deadline:
+            break
+        time.sleep(poll_interval_s)
+
+    if not saw_pid_file:
+        return (
+            "post_ack_no_apptainer_pid",
+            f"`sac agents start` returned rc=0 but no apptainer_pid "
+            f"file appeared in {runtime_dir} within "
+            f"{timeout_s:.1f}s. The child subprocess bypassed the "
+            "apptainer runtime path (broken wrapper / missing config / "
+            "runtime mis-resolved). Inspect the runtime_dir for any "
+            "stdout/stderr the child captured, and verify the agent's "
+            "spec.apptainer block resolves to a real SIF on disk.",
+        )
+    return (
+        "post_ack_apptainer_pid_dead",
+        f"apptainer_pid={last_seen_pid} in {runtime_dir} was reaped "
+        f"within {timeout_s:.1f}s of the spawn-ack. The SIF instance "
+        "came up and exited silently — check the runtime_dir's "
+        "stderr.log for the apptainer FATAL line. Common causes: "
+        "missing bind source on host, SIF binary missing on host, "
+        "in-SIF entrypoint crashing on a startup-prompt eval.",
+    )
+
+
+async def agents_start(request: Request) -> JSONResponse:
+    """POST /agents — start one or more agents.
+
+    Body shapes:
+
+        # Start a pre-registered spec (existing on disk):
+        {"name": "<existing-spec-name>", "caller": "<sender-name>"}
+
+        # Register-and-start an ad-hoc spec in one call:
+        {
+            "name": "<name>",
+            "caller": "<sender-name>",
+            "spec": {"apiVersion": "scitex-agent-container/v3",
+                     "kind": "Agent",
+                     "spec": {...}},
+            "overwrite": false   # optional; default false → 409 on clash
+        }
+
+    WI-2 spawn-permission gate (limited scope per lead 2026-05-20):
+    the optional ``caller`` field carries the spawning node's name
+    (same self-claimed-identity caveat as ``message:send``'s
+    ``metadata.from_agent``). The gate is **root-only** today —
+    a node with no parent in the ``lineage`` table may spawn; a
+    child gets a clear 403. ``caller`` omitted = administrative /
+    human-operator path → allowed.
+
+    On allow, the parent → child edge is recorded in ``lineage``
+    so the new agent inherits the spawner's group.
+    """
+    try:
+        body = await request.json()
+    except (
+        Exception
+    ):  # stx-allow: fallback (reason: malformed JSON → 400 instead of 500)
+        return JSONResponse({"error": "body must be JSON"}, status_code=400)
+    name = body.get("name")
+    if not isinstance(name, str) or not name:
+        return JSONResponse(
+            {"error": "missing or empty 'name' string"}, status_code=400
+        )
+
+    # WI-2 spawn-permission gate.
+    caller = body.get("caller")
+    if caller is not None and not isinstance(caller, str):
+        return JSONResponse(
+            {"error": "'caller' must be a string if present"}, status_code=400
+        )
+
+    # PR-α (lead msg d96a468c 2026-06-06): cohort one-shot diagnostic.
+    # When the parent's ``sac agents start`` carried --foreground /
+    # --one-shot, the spawn client (_lifecycle/_spawn_client.py) emits
+    # these as body fields. Propagate to the inner argv so the host's
+    # apptainer runtime takes the foreground/one-shot branch
+    # (subprocess.run blocks until the capsule exits) — the capsule's
+    # actual exit code + stderr then flow up into STARTUP_FAILED on
+    # crash, instead of the background branch's "Popen + rc=0
+    # immediately" lie. Each flag is independent + back-compat absent
+    # (default False → no flag, pre-α behaviour).
+    foreground = body.get("foreground", False)
+    if not isinstance(foreground, bool):
+        return JSONResponse(
+            {"error": "'foreground' must be a boolean if present"},
+            status_code=400,
+        )
+    one_shot = body.get("one_shot", False)
+    if not isinstance(one_shot, bool):
+        return JSONResponse(
+            {"error": "'one_shot' must be a boolean if present"},
+            status_code=400,
+        )
+    decision, reason = check_spawn(caller=caller)
+    if decision == "deny":
+        return deny_response(reason or "spawn denied")
+
+    inline_spec = body.get("spec")
+    if inline_spec is not None:
+        # PR-2 — pass ``caller`` through so the bind translate can
+        # look up the parent agent's host-side bind map and rewrite
+        # in-SIF ``/work/...`` sources before the PR-1 preflight
+        # runs. Caller absent → translate disabled, preflight
+        # enforces directly (the operator/admin path).
+        err = materialize_inline_spec(
+            name,
+            inline_spec,
+            overwrite=bool(body.get("overwrite")),
+            caller=caller,
+        )
+        if err is not None:
+            return err
+
+    # Record lineage on allowed-spawn so the new child inherits the
+    # caller's group. ``caller=None`` → no lineage record (admin /
+    # operator path; the new agent starts as a root).
+    if caller:
+        from .._state.state_db_nodes import record_lineage as _record_lineage
+
+        try:
+            _record_lineage(child=name, parent=caller)
+        except ValueError as exc:
+            # Idempotent same-parent re-record is fine; a re-parent
+            # to a different caller is loudly rejected.
+            return JSONResponse({"error": str(exc)}, status_code=409)
+
+    sac_bin = shutil.which("sac") or "sac"
+    # ``agents`` (plural) is the canonical command group; the singular
+    # ``agent`` form was removed in the F-CS13 rename and the host CLI
+    # no longer exposes it (verified 2026-06-01 by the SAC-from-SAC
+    # live test: the singular form returned "Error: No such command
+    # 'agent'." with rc=2, breaking every brokered spawn from inside
+    # a SIF). Using the canonical plural is what every other CLI
+    # call site already does — see ``cli_pkg/fleet_group.py``
+    # ``[remote_sac, "agents", "start", name]``.
+    from datetime import datetime, timezone
+
+    started_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    # --broker-self recursive re-entry fix (clew dogfood repro
+    # 2026-06-06, lead msg d8f61055): when the listen runs inside a
+    # parent SAC's SIF on a SLURM allocation, this handler's child
+    # `sac agents start` inherits APPTAINER_CONTAINER /
+    # SINGULARITY_CONTAINER from the listen's env. That makes
+    # is_in_sif() return True in the child, which re-enters
+    # maybe_broker_in_sif_spawn → tries to broker the spawn to
+    # *this same listen* → recursive InSifBrokerError loop.
+    #
+    # The listen IS the host-side spawn boundary: the child should
+    # take the bare-host path (direct apptainer-exec the sibling
+    # SIF), not pretend it is still inside a parent SIF. Strip the
+    # in-SIF env markers so is_in_sif() returns False on the child.
+    # No other downstream sac code reads these env vars except the
+    # broker probe, so the strip is safe; apptainer ITSELF re-sets
+    # APPTAINER_CONTAINER inside the child SIF it execs.
+    child_env = dict(os.environ)
+    child_env.pop("APPTAINER_CONTAINER", None)
+    child_env.pop("SINGULARITY_CONTAINER", None)
+    # PR-α: propagate --foreground / --one-shot to the inner argv per the
+    # body fields validated above. Order matches the click signature on
+    # `sac agents start` (flags before/after positional name are
+    # equivalent, but keep the positional last for the canonical shape).
+    inner_argv = [sac_bin, "agents", "start"]
+    if foreground:
+        inner_argv.append("--foreground")
+    if one_shot:
+        inner_argv.append("--one-shot")
+    inner_argv.append(name)
+    proc = await asyncio.to_thread(
+        subprocess.run,
+        inner_argv,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=child_env,
+    )
+    if proc.returncode != 0:
+        # PR-1 — stillborn agent observability. The subprocess can exit
+        # non-zero for many reasons, including apptainer FATAL on a bind
+        # source the host can't see (the clew capsule case). Write a
+        # ``runtime_dir/STARTUP_FAILED`` marker so:
+        #   * a subsequent ``DELETE`` returns 410 Gone with the failure
+        #     payload instead of 404 "no pid file",
+        #   * ``GET .../status`` can surface ``status="startup_failed"``
+        #     instead of vacuous registry-only fields,
+        #   * future fleet-GC automation can drop the stillborn cleanly.
+        # The marker write is best-effort: a write failure (e.g. /state
+        # filesystem RO) MUST NOT shadow the underlying spawn failure.
+        # stx-allow: fallback (reason: marker is observability metadata
+        # only; failing here would only obscure the real start failure)
+        try:
+            from .._lifecycle._startup_failed import write_marker
+            from .._runners._session_state import state_dir_for
+
+            runtime_dir = state_dir_for(name)
+            write_marker(
+                runtime_dir,
+                started_at=started_at,
+                phase="container_creation",
+                exit_code=proc.returncode,
+                stdout=proc.stdout,
+                stderr=proc.stderr,
+            )
+        except Exception:  # stx-allow: fallback (reason: see inline comment)
+            pass
+
+        return JSONResponse(
+            {
+                "name": name,
+                "returncode": proc.returncode,
+                "stdout": proc.stdout,
+                "stderr": proc.stderr,
+            },
+            status_code=502,
+        )
+
+    # Layer-3 fail-loud (clew dogfood repro 2026-06-06, lead msg
+    # 57f1632a): `sac agents start <child>` returning rc=0 was being
+    # treated as "instance is running and healthy", but the apptainer
+    # exec the child spawned can die SILENTLY post-ack — empty
+    # stdout.log, dead apptainer_pid, no fresh STARTUP_FAILED marker.
+    # The "SUCC: started" body of this 200 response lied.
+    #
+    # Probe the runtime_dir for liveness: wait up to
+    # ``_POST_ACK_LIVENESS_TIMEOUT_S`` for ``apptainer_pid`` to appear
+    # AND for that pid to still be alive (``kill -0``). Three loud
+    # failure modes:
+    #
+    #   * apptainer_pid never appears within the grace → the child
+    #     subprocess returned 0 without invoking the apptainer
+    #     runtime path (broken wrapper, missing config, etc.).
+    #     kind = "post_ack_no_apptainer_pid"
+    #   * apptainer_pid appears but the pid is dead by the time we
+    #     check → the SIF instance came up and immediately died.
+    #     kind = "post_ack_apptainer_pid_dead"
+    #   * apptainer_pid was alive at grace-deadline → return 200/SUCC
+    #     (the existing happy path).
+    #
+    # Loud failures write a fresh STARTUP_FAILED with the new kind
+    # AND downgrade the response to 502 so the operator-side recv
+    # path can show a real diagnostic instead of a misleading SUCC.
+    #
+    # PR-α: skip the probe when foreground=True. The inner subprocess
+    # already blocked (apptainer runtime's foreground branch is
+    # subprocess.run, not Popen) and explicitly does NOT write
+    # apptainer_pid — the probe would always report
+    # post_ack_no_apptainer_pid on a successful one-shot run. The real
+    # signal is the inner rc captured above; rc!=0 already wrote
+    # STARTUP_FAILED with stderr_tail (the cohort one-shot diagnostic).
+    if foreground:
+        return JSONResponse(
+            {
+                "name": name,
+                "returncode": proc.returncode,
+                "stdout": proc.stdout,
+                "stderr": proc.stderr,
+            },
+            status_code=200,
+        )
+    from .._lifecycle._startup_failed import write_marker
+    from .._runners._session_state import state_dir_for
+
+    runtime_dir = state_dir_for(name)
+    # Test escape hatch: ``SAC_LISTEN_POST_ACK_LIVENESS_TIMEOUT_S`` env
+    # var lets the suite skip / shorten the probe (≤0 → skip entirely).
+    # Production callers leave it unset and get the default 5s grace.
+    try:
+        env_timeout = float(
+            os.environ.get(
+                "SAC_LISTEN_POST_ACK_LIVENESS_TIMEOUT_S",
+                str(_POST_ACK_LIVENESS_TIMEOUT_S),
+            )
+        )
+    except ValueError:
+        env_timeout = _POST_ACK_LIVENESS_TIMEOUT_S
+    liveness_failure = _probe_post_ack_liveness(
+        runtime_dir,
+        timeout_s=env_timeout,
+    )
+    if liveness_failure is not None:
+        kind, hint = liveness_failure
+        # stx-allow: fallback (reason: marker write is observability;
+        # a write failure here must not shadow the underlying
+        # post-ack-died signal that the listen is about to return)
+        try:
+            write_marker(
+                runtime_dir,
+                started_at=started_at,
+                phase="post_ack_liveness",
+                exit_code=0,
+                stdout=proc.stdout or "",
+                stderr=(proc.stderr or "")
+                + f"\n\n[listen post-ack liveness probe] {kind}: {hint}\n",
+                kind_override=kind,
+            )
+        except Exception:  # stx-allow: fallback (reason: see inline comment)
+            pass
+        return JSONResponse(
+            {
+                "name": name,
+                "returncode": proc.returncode,
+                "stdout": proc.stdout,
+                "stderr": proc.stderr,
+                "post_ack_liveness": {"kind": kind, "hint": hint},
+            },
+            status_code=502,
+        )
+
+    return JSONResponse(
+        {
+            "name": name,
+            "returncode": proc.returncode,
+            "stdout": proc.stdout,
+            "stderr": proc.stderr,
+        },
+        status_code=200,
+    )

--- a/src/scitex_agent_container/_mcp/_tools/_agent.py
+++ b/src/scitex_agent_container/_mcp/_tools/_agent.py
@@ -230,6 +230,7 @@ def agent_send(
     prompt: str | None = None,
     timeout_seconds: int = 120,
     key: str | None = None,
+    keys: str | None = None,
     model: str | None = None,
     max_turns: int | None = None,
     wait: bool = False,
@@ -264,8 +265,19 @@ def agent_send(
       * ``"creds-expired"`` — lead/peer OAuth token expired
       * ``"timeout"`` — (``wait=True``) no response in ``timeout_seconds``
 
-    ``prompt`` and ``key`` are mutually exclusive; passing both raises
-    ``ValueError`` (surfaced to the MCP host as a tool-input error).
+    ``prompt`` / ``key`` / ``keys`` are mutually exclusive; passing more
+    than one raises ``ValueError`` (surfaced to the MCP host as a
+    tool-input error).
+
+    Key passthrough (``key`` / ``keys``) mirrors the CLI ``sac agents
+    send --key/--keys``: cancel keys (ESC / C-c / SIGINT) interrupt the
+    turn via SIGINT; every other tmux key name (Enter, Up, Down, Left,
+    Right, Tab, BTab, digits, …) or whitespace-separated ``keys``
+    sequence is delivered to the agent's LOCAL tmux session via
+    send-keys. Returns ``status="ok"`` with ``route="send-keys"`` /
+    ``"interrupt"`` on success, or ``status="error"`` for an unknown key
+    name, a missing tmux session, or a cross-host agent (key passthrough
+    only reaches a local session).
     """
     from ...cli_pkg._send import send_to_agent
 
@@ -273,6 +285,7 @@ def agent_send(
         name,
         prompt=prompt,
         key=key,
+        keys=keys,
         timeout_seconds=timeout_seconds,
         model=model,
         max_turns=max_turns,

--- a/src/scitex_agent_container/_runners/_tmux/_keys.py
+++ b/src/scitex_agent_container/_runners/_tmux/_keys.py
@@ -1,0 +1,193 @@
+"""Named-key vocabulary for tmux ``send-keys`` passthrough.
+
+``sac agents send <agent> --key <NAME>`` (and ``--keys "<NAME> <NAME>
+..."``) routes the full key vocabulary tmux understands into the
+agent's live tmux session, so arrows / Enter / Tab / digits land in
+the TUI exactly as if typed at the keyboard. Delivery is already
+``tmux send-keys`` underneath (see
+:meth:`...tmux.TmuxManager.send_keys`); this module is the single
+source of truth for *which* names are accepted and rejects anything
+else fail-loud with the valid set listed (no surprise key silently
+swallowed).
+
+Two kinds of token reach :func:`validate_key`:
+
+  * a NAMED key — one of the tmux keyword names below (``Enter``,
+    ``Up``, ``BTab``, ``C-c``, ``M-x`` …). These pass through to
+    ``send-keys`` verbatim; tmux itself interprets the keyword.
+  * a LITERAL single character — a digit / letter / punctuation
+    (``"1"``, ``"a"``, ``"/"``). tmux send-keys treats a non-keyword
+    argument as raw input, so a single printable char is delivered
+    as-is. We accept any single printable character so the operator
+    can send ``1`` / ``2`` to a radio selector or ``y`` to a y/n
+    prompt.
+
+Anything else (an unknown multi-char word like ``"Retrun"``, an empty
+string) is rejected by :func:`validate_key` raising
+:class:`UnknownKeyError`, whose message lists the full named set so
+the caller can self-correct.
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "NAMED_KEYS",
+    "UnknownKeyError",
+    "validate_key",
+    "validate_keys",
+    "parse_key_sequence",
+]
+
+
+# The named keys tmux ``send-keys`` understands as keyword arguments.
+# Mirrors the vocabulary in tmux(1) "KEY BINDINGS" / "send-keys": the
+# named special keys plus the C-/M- modifier prefixes. Held as a frozen
+# set so the validation is a single O(1) membership test and the set
+# cannot be mutated at runtime.
+_SPECIAL_NAMES: frozenset[str] = frozenset(
+    {
+        # Submit / whitespace.
+        "Enter",
+        "Tab",
+        "BTab",  # back-tab (Shift-Tab)
+        "Space",
+        # Editing.
+        "BSpace",  # backspace
+        "DC",  # delete-character (forward delete)
+        "IC",  # insert-character
+        "Escape",
+        # Navigation.
+        "Up",
+        "Down",
+        "Left",
+        "Right",
+        "Home",
+        "End",
+        "PageUp",
+        "PPage",  # alias tmux accepts for PageUp
+        "PageDown",
+        "NPage",  # alias tmux accepts for PageDown
+        # Function keys F1..F12.
+        "F1",
+        "F2",
+        "F3",
+        "F4",
+        "F5",
+        "F6",
+        "F7",
+        "F8",
+        "F9",
+        "F10",
+        "F11",
+        "F12",
+    }
+)
+
+# Aliases the operator may type that map onto a canonical tmux name.
+# ``ESC`` and ``C-c`` are the historical cancel-key spellings; keep
+# them working so the existing vocabulary is a strict superset.
+_ALIASES: dict[str, str] = {
+    "ESC": "Escape",
+}
+
+# Public view of the accepted named keys (canonical names + aliases),
+# used for the fail-loud error message.
+NAMED_KEYS: frozenset[str] = _SPECIAL_NAMES | frozenset(_ALIASES)
+
+
+class UnknownKeyError(ValueError):
+    """Raised when a key name is neither a known tmux keyword nor a
+    single literal printable character.
+
+    Subclasses :class:`ValueError` so the CLI (``click``) and the MCP
+    layer surface it as an input error. The message always lists the
+    valid named set so the caller can self-correct without guessing.
+    """
+
+
+def _is_literal_char(token: str) -> bool:
+    """Return True for a single printable character (digit / letter /
+    punctuation) tmux delivers as raw input.
+
+    A single printable char is the literal-passthrough case: ``"1"``,
+    ``"a"``, ``"/"``. Whitespace is excluded — ``Space`` /
+    ``Enter`` / ``Tab`` are the named-key spellings for those.
+    """
+    return len(token) == 1 and token.isprintable() and not token.isspace()
+
+
+def _modifier_key(token: str) -> bool:
+    """Return True for a ``C-<x>`` / ``M-<x>`` / ``S-<x>`` modifier combo.
+
+    tmux accepts control (``C-``), meta/alt (``M-``) and shift
+    (``S-``) prefixes on a single following character or a named key
+    (e.g. ``C-c``, ``M-x``, ``C-Left``, ``S-Up``). We accept the
+    prefix when the remainder is itself a single literal char or a
+    known special name, so the full modifier vocabulary is reachable
+    without hand-enumerating every combination.
+    """
+    for prefix in ("C-", "M-", "S-"):
+        if token.startswith(prefix) and len(token) > len(prefix):
+            rest = token[len(prefix) :]
+            if _is_literal_char(rest) or rest in _SPECIAL_NAMES:
+                return True
+    return False
+
+
+def validate_key(token: str) -> str:
+    """Validate one key token and return the tmux ``send-keys`` argument.
+
+    Accepts, in order:
+
+      * an alias (``ESC`` → ``Escape``) — returns the canonical name;
+      * a known special name (``Enter``, ``Up``, ``BTab`` …) verbatim;
+      * a ``C-``/``M-``/``S-`` modifier combo (``C-c``, ``M-x``) verbatim;
+      * a single printable literal char (``"1"``, ``"a"``) verbatim.
+
+    Raises:
+        UnknownKeyError: when ``token`` matches none of the above. The
+            message lists the accepted named set so the caller can fix
+            the call without guessing.
+    """
+    if token in _ALIASES:
+        return _ALIASES[token]
+    if token in _SPECIAL_NAMES:
+        return token
+    if _modifier_key(token):
+        return token
+    if _is_literal_char(token):
+        return token
+    raise UnknownKeyError(
+        f"unsupported key {token!r}. Accepted: a single printable "
+        f"character (e.g. '1', 'a', '/'), a C-/M-/S- modifier combo "
+        f"(e.g. 'C-c', 'M-x'), or one of the named keys "
+        f"{sorted(NAMED_KEYS)}."
+    )
+
+
+def validate_keys(tokens: list[str]) -> list[str]:
+    """Validate a list of key tokens, returning the tmux arguments.
+
+    Fails loud on the FIRST invalid token (no partial send): the whole
+    sequence is rejected so the operator never gets a half-delivered
+    key stream. Returns the validated/canonicalised tokens in order.
+
+    Raises:
+        UnknownKeyError: on the first unrecognised token.
+        ValueError: when ``tokens`` is empty (nothing to send).
+    """
+    if not tokens:
+        raise ValueError("no keys to send (empty sequence)")
+    return [validate_key(t) for t in tokens]
+
+
+def parse_key_sequence(spec: str) -> list[str]:
+    """Split a whitespace-separated ``--keys`` spec into tokens.
+
+    ``"Up Up Enter"`` → ``["Up", "Up", "Enter"]``. Whitespace-only
+    input yields an empty list (the caller / :func:`validate_keys`
+    then rejects it loud). This is deliberately simple — a single
+    literal *space* is the named key ``Space``, so there is no need to
+    preserve embedded spaces as data.
+    """
+    return spec.split()

--- a/src/scitex_agent_container/cli_pkg/_send.py
+++ b/src/scitex_agent_container/cli_pkg/_send.py
@@ -78,6 +78,7 @@ def send_to_agent(
     prompt: str | None = None,
     *,
     key: str | None = None,
+    keys: str | None = None,
     timeout_seconds: int = 120,
     model: str | None = None,
     max_turns: int | None = None,
@@ -139,20 +140,29 @@ def send_to_agent(
             never read.
 
     Raises:
-        ValueError: When ``prompt`` and ``key`` are both passed (or
-            both omitted). The MCP layer surfaces this as a tool
-            validation error.
+        ValueError: When more than one of ``prompt`` / ``key`` / ``keys``
+            is passed (or all are omitted). The MCP layer surfaces this
+            as a tool validation error.
     """
-    if prompt and key:
-        raise ValueError("prompt and key are mutually exclusive")
-    if not prompt and not key:
-        raise ValueError("either prompt or key is required")
+    _key_modes = [v for v in (prompt, key, keys) if v]
+    if len(_key_modes) > 1:
+        raise ValueError("prompt, key and keys are mutually exclusive")
+    if not _key_modes:
+        raise ValueError("one of prompt, key or keys is required")
 
     from .._network.peer import PeerError
     from .._state.state_db import _resolve_host
     from ._send_resolve import resolve_send_endpoint
 
     current_host = _resolve_host(None)
+
+    # Key passthrough is tmux-based (NOT /v1/turn), so it does not need a
+    # bound a2a_port. Handle it before the A2A endpoint resolution. Cancel
+    # keys (ESC / C-c / SIGINT) keep the local SIGINT semantics; every
+    # other named key / sequence is delivered to the agent's tmux session.
+    if key is not None or keys is not None:
+        return _dispatch_keys(name, key=key, keys=keys, current_host=current_host)
+
     # Resolve the LIVE endpoint the same way ``a2a_send`` / the listen
     # forwarder do: active ``instances`` row port first, then the durable
     # ``port_allocator`` claim that survives a health-monitor restart.
@@ -199,18 +209,6 @@ def send_to_agent(
         url = f"ssh://{peer_host}:{a2a_port}/v1/turn"
     else:
         url = f"http://127.0.0.1:{a2a_port}/v1/turn"
-
-    if key:
-        # Key-passthrough isn't wired into /v1/turn yet; the CLI handles
-        # ESC via os.kill(SIGINT) on a local pid file. Surfacing this
-        # as a loud error is the no-silent-fallback choice.
-        return {
-            "status": "error",
-            "error": (
-                f"key={key!r} dispatch not supported via send_to_agent; "
-                "use the CLI's local SIGINT path (`sac agents send --key`)"
-            ),
-        }
 
     text = prompt or ""
     metadata_extras: dict[str, Any] = {}
@@ -290,6 +288,112 @@ def send_to_agent(
         "status": "ok",
         "response_text": reply,
         "response_metadata": metadata,
+    }
+
+
+def _dispatch_keys(
+    name: str,
+    *,
+    key: str | None,
+    keys: str | None,
+    current_host: str,
+) -> dict[str, Any]:
+    """Deliver ``key`` / ``keys`` to ``name`` and return a structured dict.
+
+    Mirrors the CLI ``sac agents send --key/--keys`` passthrough for the
+    MCP ``agent_send`` tool. Routing:
+
+      * a single cancel key (ESC / C-c / SIGINT) → SIGINT the local
+        runner pid (interrupt the turn), same as the CLI;
+      * every other named key / sequence → validate against the tmux
+        vocabulary and ``send-keys`` it into the agent's LOCAL tmux
+        session.
+
+    Key delivery is tmux-based, so it only works for an agent running on
+    THIS host. A cross-host agent returns a loud error directing the
+    caller to run the send on the peer (no silent mis-target).
+
+    Returns:
+        ``{"status": "ok", "route": "send-keys"|"interrupt", ...}`` on
+        success; ``{"status": "error", "error": ...}`` on an unknown key,
+        a missing tmux session, a dead/absent pid, or a cross-host agent.
+    """
+    import os
+    import signal as _signal
+
+    from .._runners._session_state import state_dir_for
+    from .._runners._tmux._keys import (
+        UnknownKeyError,
+        parse_key_sequence,
+        validate_keys,
+    )
+    from .._state.state_db import list_active_instances
+
+    _cancel = {"ESC", "C-c", "SIGINT"}
+
+    # Refuse to mis-target a cross-host agent — keys go to the local
+    # tmux session only.
+    rows = list_active_instances()
+    matching = [
+        r
+        for r in rows
+        if r.get("name") == name and str(r.get("host") or "") == current_host
+    ]
+    if not matching:
+        return {
+            "status": "error",
+            "error": (
+                f"agent {name!r} is not running locally on {current_host!r}; "
+                "key passthrough is tmux-based and only reaches a local "
+                "session. Run `sac agents send` on the host where the agent "
+                "runs."
+            ),
+        }
+
+    if key is not None and key in _cancel and keys is None:
+        state_dir = state_dir_for(name)
+        pid_file = state_dir / "pid"
+        if not pid_file.is_file():
+            return {
+                "status": "error",
+                "error": f"agent {name!r} has no pid file at {pid_file}",
+            }
+        try:
+            pid = int(pid_file.read_text().strip())
+            os.kill(pid, _signal.SIGINT)
+        except (OSError, ValueError) as exc:
+            return {"status": "error", "error": str(exc)}
+        return {"status": "ok", "route": "interrupt", "pid": pid, "signal": "SIGINT"}
+
+    tokens = parse_key_sequence(keys) if keys is not None else [key or ""]
+    try:
+        tmux_keys = validate_keys(tokens)
+    except (UnknownKeyError, ValueError) as exc:
+        return {"status": "error", "error": str(exc)}
+
+    from .._runners._tmux.multiplexer import get_multiplexer
+    from ..config import load_config
+    from ..config._resolve import resolve_config
+
+    try:
+        cfg = load_config(resolve_config(name))
+    except Exception as exc:  # stx-allow: fallback (reason: unknown agent → structured error, not a traceback through MCP transport)
+        return {"status": "error", "error": str(exc)}
+    mux = get_multiplexer(cfg)
+    if not mux.exists(cfg.screen_name):
+        return {
+            "status": "error",
+            "error": (
+                f"agent {name!r} has no live tmux session {cfg.screen_name!r}"
+            ),
+        }
+    mux.send_keys(cfg.screen_name, *tmux_keys)
+    return {
+        "status": "ok",
+        "route": "send-keys",
+        "agent": name,
+        "session": cfg.screen_name,
+        "keys": tmux_keys,
     }
 
 

--- a/src/scitex_agent_container/cli_pkg/send_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/send_cmds.py
@@ -28,6 +28,7 @@ import sys
 import click
 
 from .._runners._session_state import read_session_id, state_dir_for
+from .._runners._tmux.multiplexer import get_multiplexer
 from ..config import load_config
 from ..config._resolve import resolve_config
 from ._helpers import agent_name_complete
@@ -213,6 +214,86 @@ def _find_claude_binary() -> str:
     )
 
 
+# Cancel keys keep their historical interrupt semantics: instead of
+# being typed into the TUI they SIGINT the runner pid, cancelling the
+# current turn. Every OTHER key goes through tmux send-keys.
+_CANCEL_KEYS = frozenset({"ESC", "C-c", "SIGINT"})
+
+
+def _interrupt_via_sigint(name: str) -> None:
+    """SIGINT the agent's recorded runner pid (cancel the current turn).
+
+    The historical ESC / C-c / SIGINT semantics: cancel the turn rather
+    than typing the literal key into the TUI. Fails loud when no pid
+    file exists (agent not running) or the kill fails.
+    """
+    import signal as _signal
+
+    state_dir = state_dir_for(name)
+    pid_file = state_dir / "pid"
+    if not pid_file.is_file():
+        raise click.ClickException(
+            f"No pid file at {pid_file} — agent {name!r} not running."
+        )
+    try:
+        pid = int(pid_file.read_text().strip())
+        os.kill(pid, _signal.SIGINT)
+    except (OSError, ValueError) as exc:
+        raise click.ClickException(str(exc)) from exc
+    click.echo(f"# interrupt {name}: SIGINT → pid={pid}", err=True)
+
+
+def _send_keys_to_session(name: str, tmux_keys: list[str]) -> None:
+    """Deliver validated tmux key names into the agent's tmux session.
+
+    Resolves the agent's ``screen_name`` (its tmux session) from its
+    config and routes the keys through the configured multiplexer's
+    ``send_keys`` — the SAME send-keys primitive the TUI runner uses,
+    so Enter / arrows / Tab / digits land in the live TUI.
+    """
+    spec_path = resolve_config(name)
+    cfg = load_config(spec_path)
+    mux = get_multiplexer(cfg)
+    if not mux.exists(cfg.screen_name):
+        raise click.ClickException(
+            f"No tmux session {cfg.screen_name!r} for agent {name!r} "
+            "— is it running under the tmux/TUI runtime?"
+        )
+    mux.send_keys(cfg.screen_name, *tmux_keys)
+    click.echo(
+        f"# keys {name}: {' '.join(tmux_keys)} → tmux {cfg.screen_name}",
+        err=True,
+    )
+
+
+def _deliver_keys(name: str, *, key: str | None, keys: str | None) -> None:
+    """Route ``--key`` / ``--keys`` to SIGINT (cancel) or tmux send-keys.
+
+    A single ``--key`` that is one of :data:`_CANCEL_KEYS` keeps the
+    historical interrupt path (SIGINT the runner pid). Everything else
+    — a non-cancel ``--key`` or any ``--keys`` sequence — is validated
+    against the tmux key vocabulary and delivered to the agent's tmux
+    session. Validation fails loud (lists the valid set) BEFORE any
+    partial send.
+    """
+    from .._runners._tmux._keys import (
+        UnknownKeyError,
+        parse_key_sequence,
+        validate_keys,
+    )
+
+    if key is not None and key in _CANCEL_KEYS:
+        _interrupt_via_sigint(name)
+        return
+
+    tokens = [key] if key is not None else parse_key_sequence(keys or "")
+    try:
+        tmux_keys = validate_keys(tokens)
+    except (UnknownKeyError, ValueError) as exc:
+        raise click.UsageError(str(exc)) from exc
+    _send_keys_to_session(name, tmux_keys)
+
+
 @click.command(name="send")
 @click.argument("name", shell_complete=agent_name_complete)
 @click.argument("prompt", required=False)
@@ -231,8 +312,21 @@ def _find_claude_binary() -> str:
     "--key",
     default=None,
     help=(
-        "Send a control key instead of a prompt (tmux-style, e.g. ``ESC``, "
-        "``C-c``). Mutually exclusive with PROMPT."
+        "Send one key instead of a prompt (tmux-style, e.g. ``Enter``, "
+        "``Up``, ``Tab``, ``1``, ``ESC``, ``C-c``). Cancel keys "
+        "(ESC / C-c / SIGINT) interrupt the turn; every other key is "
+        "delivered to the agent's tmux session. Mutually exclusive with "
+        "PROMPT and --keys."
+    ),
+)
+@click.option(
+    "--keys",
+    "keys",
+    default=None,
+    help=(
+        "Send a whitespace-separated SEQUENCE of keys to the agent's "
+        'tmux session (e.g. ``--keys "Up Up Enter"`` or ``--keys "2 '
+        'Enter"``). Mutually exclusive with PROMPT and --key.'
     ),
 )
 @click.option(
@@ -248,25 +342,37 @@ def send(
     model: str | None,
     max_turns: int | None,
     key: str | None,
+    keys: str | None,
     no_stream: bool,
     forward: tuple[str, ...],
 ) -> None:
-    """Send a follow-up PROMPT (or control key) to an agent's existing
+    """Send a follow-up PROMPT (or key/keys) to an agent's existing
     Claude session.
 
     \b
     Examples:
       sac agent send coverage-runner "now bump the threshold to 95%"
       sac agent send coverage-runner --key ESC
+      sac agent send coverage-runner --key Enter
+      sac agent send coverage-runner --keys "Up Up Enter"
       sac agent send coverage-runner -- --model opus --max-turns 3 "..."
+
+    ``--key`` / ``--keys`` deliver tmux key names (Enter, Up, Down,
+    Left, Right, Tab, BTab, Space, Home, End, PageUp, PageDown,
+    Escape, C-c, …) plus literal chars/digits straight into the
+    agent's tmux session. The cancel keys (ESC / C-c / SIGINT) instead
+    interrupt the current turn via SIGINT.
 
     Anything after a literal ``--`` is forwarded verbatim to ``claude``
     (the raw escape hatch documented in SAC_OROCHI_SCOPES.md §1).
     """
-    if key and prompt:
-        raise click.UsageError("--key is mutually exclusive with PROMPT.")
-    if not key and not prompt:
-        raise click.UsageError("Either PROMPT or --key is required.")
+    _passed = [v for v in (prompt, key, keys) if v]
+    if len(_passed) > 1:
+        raise click.UsageError(
+            "PROMPT, --key and --keys are mutually exclusive."
+        )
+    if not _passed:
+        raise click.UsageError("Either PROMPT, --key or --keys is required.")
 
     # PR-3 — in-SIF auto-fallback. When inside an apptainer SIF and
     # sending a PROMPT (the ``--key`` SIGINT path needs local pid
@@ -277,7 +383,7 @@ def send(
     # follow the same Checkpoint 2 contract as the other in-SIF verbs.
     from .._lifecycle._in_sif_broker import is_in_sif
 
-    if is_in_sif() and prompt and not key:
+    if is_in_sif() and prompt and not key and not keys:
         _send_via_host_listen(
             name=name,
             prompt=prompt,
@@ -285,28 +391,8 @@ def send(
             max_turns=max_turns,
         )
         return  # noreturn — _send_via_host_listen sys.exits
-    if key:
-        # ESC / C-c → SIGINT to the runner pid. Other keys are reserved
-        # for a future tty-bridge implementation.
-        if key not in ("ESC", "C-c", "SIGINT"):
-            raise click.UsageError(
-                f"--key {key!r} not supported. Only ESC / C-c / SIGINT are "
-                "wired (cancel current turn). Use a prompt otherwise."
-            )
-        import signal as _signal
-
-        state_dir = state_dir_for(name)
-        pid_file = state_dir / "pid"
-        if not pid_file.is_file():
-            raise click.ClickException(
-                f"No pid file at {pid_file} — agent {name!r} not running."
-            )
-        try:
-            pid = int(pid_file.read_text().strip())
-            os.kill(pid, _signal.SIGINT)
-        except (OSError, ValueError) as exc:
-            raise click.ClickException(str(exc)) from exc
-        click.echo(f"# interrupt {name}: SIGINT → pid={pid}", err=True)
+    if key or keys:
+        _deliver_keys(name, key=key, keys=keys)
         return
 
     # Cross-host: when the agent's active state.db.instances row lives

--- a/tests/scitex_agent_container/_listen/test_agent_exec_keys.py
+++ b/tests/scitex_agent_container/_listen/test_agent_exec_keys.py
@@ -1,0 +1,194 @@
+"""Tests for the ``type: key`` listen handler (``_listen._agent_exec_keys``).
+
+``POST /agents/<name>/send`` with ``{"type":"key", ...}`` routes:
+  * cancel keys (ESC / C-c / SIGINT) → SIGINT the runner pid;
+  * any other named key / sequence → tmux send-keys to the session.
+
+These tests exercise the send-keys branch through the ``mux_resolver``
+injection seam (a recording fake mux — no live tmux, no monkeypatch)
+plus the validation / discrimination branches. The cancel-key branch's
+delegation is asserted by proving it does NOT consult the mux resolver.
+
+STX-TQ002 AAA-markers + STX-TQ007 one-assert. No mocks.
+"""
+
+from __future__ import annotations
+
+import json
+
+from scitex_agent_container._listen._agent_exec_keys import _handle_key_send
+
+
+class _RecordingMux:
+    """Fake multiplexer recording every ``send_keys`` it receives.
+
+    ``exists`` returns a configurable verdict so the no-session 404
+    branch is reachable; ``send_keys`` records ``(session, keys)``.
+    """
+
+    def __init__(self, *, session_exists: bool = True) -> None:
+        self._exists = session_exists
+        self.sent: list[tuple[str, tuple[str, ...]]] = []
+
+    def exists(self, session: str) -> bool:
+        return self._exists
+
+    def send_keys(self, session: str, *keys: str) -> None:
+        self.sent.append((session, keys))
+
+
+def _make_resolver(session: str, mux: _RecordingMux):
+    """Return a ``mux_resolver`` yielding the given session + mux."""
+
+    def _resolve(_name: str) -> tuple[str, object]:
+        return session, mux
+
+    return _resolve
+
+
+def _body(response) -> dict:
+    """Decode a JSONResponse body to a dict."""
+    return json.loads(bytes(response.body).decode("utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# send-keys branch — single named key
+# ---------------------------------------------------------------------------
+
+
+class TestNamedKeyGoesToSendKeys:
+    """A non-cancel named key is delivered via tmux send-keys."""
+
+    def test_enter_routed_to_send_keys(self) -> None:
+        # Arrange
+        mux = _RecordingMux()
+        resolver = _make_resolver("cld-foo", mux)
+        # Act
+        _handle_key_send("foo", {"key": "Enter"}, mux_resolver=resolver)
+        # Assert
+        assert mux.sent == [("cld-foo", ("Enter",))]
+
+    def test_response_route_is_send_keys(self) -> None:
+        # Arrange
+        mux = _RecordingMux()
+        resolver = _make_resolver("cld-foo", mux)
+        # Act
+        resp = _handle_key_send("foo", {"key": "Enter"}, mux_resolver=resolver)
+        # Assert
+        assert _body(resp)["route"] == "send-keys"
+
+    def test_digit_routed_to_send_keys(self) -> None:
+        # Arrange
+        mux = _RecordingMux()
+        resolver = _make_resolver("cld-foo", mux)
+        # Act
+        _handle_key_send("foo", {"key": "2"}, mux_resolver=resolver)
+        # Assert
+        assert mux.sent == [("cld-foo", ("2",))]
+
+
+# ---------------------------------------------------------------------------
+# send-keys branch — sequence
+# ---------------------------------------------------------------------------
+
+
+class TestKeySequenceGoesToSendKeys:
+    """A ``keys`` sequence is split, validated and sent in order."""
+
+    def test_sequence_sent_in_order(self) -> None:
+        # Arrange
+        mux = _RecordingMux()
+        resolver = _make_resolver("cld-foo", mux)
+        # Act
+        _handle_key_send(
+            "foo", {"keys": "Up Up Enter"}, mux_resolver=resolver
+        )
+        # Assert
+        assert mux.sent == [("cld-foo", ("Up", "Up", "Enter"))]
+
+    def test_esc_alias_in_sequence_canonicalised(self) -> None:
+        # Arrange
+        mux = _RecordingMux()
+        resolver = _make_resolver("cld-foo", mux)
+        # Act
+        _handle_key_send("foo", {"keys": "ESC Enter"}, mux_resolver=resolver)
+        # Assert
+        assert mux.sent == [("cld-foo", ("Escape", "Enter"))]
+
+
+# ---------------------------------------------------------------------------
+# cancel-key branch — does NOT consult the mux resolver
+# ---------------------------------------------------------------------------
+
+
+class TestCancelKeyDoesNotSendKeys:
+    """ESC takes the interrupt path; the mux resolver is untouched."""
+
+    def test_esc_never_calls_send_keys(self) -> None:
+        # Arrange — a resolver that explodes proves it is never called.
+        def _boom(_name: str):
+            raise AssertionError("resolver must not be consulted for ESC")
+
+        # Act
+        resp = _handle_key_send("foo", {"key": "ESC"}, mux_resolver=_boom)
+        # Assert — interrupt path returns 404 (no live pid in test env),
+        # NOT an AssertionError from the resolver.
+        assert resp.status_code in (404, 500)
+
+
+# ---------------------------------------------------------------------------
+# validation / discrimination
+# ---------------------------------------------------------------------------
+
+
+class TestUnknownKeyRejected:
+    """An unknown key name is rejected 400 before any send."""
+
+    def test_unknown_key_returns_400(self) -> None:
+        # Arrange
+        mux = _RecordingMux()
+        resolver = _make_resolver("cld-foo", mux)
+        # Act
+        resp = _handle_key_send(
+            "foo", {"key": "Retrun"}, mux_resolver=resolver
+        )
+        # Assert
+        assert resp.status_code == 400
+
+    def test_unknown_key_does_not_send(self) -> None:
+        # Arrange
+        mux = _RecordingMux()
+        resolver = _make_resolver("cld-foo", mux)
+        # Act
+        _handle_key_send("foo", {"key": "Retrun"}, mux_resolver=resolver)
+        # Assert
+        assert mux.sent == []
+
+
+class TestMissingKeyRejected:
+    """A body with neither key nor keys is rejected 400."""
+
+    def test_empty_body_returns_400(self) -> None:
+        # Arrange
+        mux = _RecordingMux()
+        resolver = _make_resolver("cld-foo", mux)
+        # Act
+        resp = _handle_key_send("foo", {}, mux_resolver=resolver)
+        # Assert
+        assert resp.status_code == 400
+
+
+class TestNoLiveSession:
+    """A non-existent tmux session yields a loud 404."""
+
+    def test_missing_session_returns_404(self) -> None:
+        # Arrange
+        mux = _RecordingMux(session_exists=False)
+        resolver = _make_resolver("cld-foo", mux)
+        # Act
+        resp = _handle_key_send("foo", {"key": "Enter"}, mux_resolver=resolver)
+        # Assert
+        assert resp.status_code == 404
+
+
+# EOF

--- a/tests/scitex_agent_container/_runners/_tmux/test_keys.py
+++ b/tests/scitex_agent_container/_runners/_tmux/test_keys.py
@@ -1,0 +1,268 @@
+"""Tests for the tmux named-key vocabulary (``_runners._tmux._keys``).
+
+``sac agents send --key/--keys`` validates every key name against this
+module before routing it to ``tmux send-keys``. The contract:
+
+  * named tmux keys (Enter, Up, BTab, …) pass through verbatim;
+  * the ``ESC`` alias canonicalises to ``Escape``;
+  * ``C-``/``M-``/``S-`` modifier combos pass through;
+  * single printable literal chars (digits / letters / punctuation)
+    pass through as raw input;
+  * everything else is rejected fail-loud with the valid set listed.
+
+STX-TQ002 AAA-markers + STX-TQ007 one-assert. No mocks.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scitex_agent_container._runners._tmux._keys import (
+    NAMED_KEYS,
+    UnknownKeyError,
+    parse_key_sequence,
+    validate_key,
+    validate_keys,
+)
+
+# ---------------------------------------------------------------------------
+# validate_key — named keys
+# ---------------------------------------------------------------------------
+
+
+class TestValidateKeyNamed:
+    """Known tmux keyword names pass through verbatim."""
+
+    def test_enter_passes_through(self) -> None:
+        # Arrange
+        token = "Enter"
+        # Act
+        result = validate_key(token)
+        # Assert
+        assert result == "Enter"
+
+    def test_up_arrow_passes_through(self) -> None:
+        # Arrange
+        token = "Up"
+        # Act
+        result = validate_key(token)
+        # Assert
+        assert result == "Up"
+
+    def test_btab_passes_through(self) -> None:
+        # Arrange
+        token = "BTab"
+        # Act
+        result = validate_key(token)
+        # Assert
+        assert result == "BTab"
+
+
+class TestValidateKeyAlias:
+    """The ESC alias canonicalises to the tmux ``Escape`` keyword."""
+
+    def test_esc_maps_to_escape(self) -> None:
+        # Arrange
+        token = "ESC"
+        # Act
+        result = validate_key(token)
+        # Assert
+        assert result == "Escape"
+
+
+# ---------------------------------------------------------------------------
+# validate_key — modifier combos
+# ---------------------------------------------------------------------------
+
+
+class TestValidateKeyModifier:
+    """``C-``/``M-``/``S-`` combos pass through verbatim."""
+
+    def test_ctrl_c_passes_through(self) -> None:
+        # Arrange
+        token = "C-c"
+        # Act
+        result = validate_key(token)
+        # Assert
+        assert result == "C-c"
+
+    def test_meta_x_passes_through(self) -> None:
+        # Arrange
+        token = "M-x"
+        # Act
+        result = validate_key(token)
+        # Assert
+        assert result == "M-x"
+
+    def test_ctrl_named_key_passes_through(self) -> None:
+        # Arrange
+        token = "C-Left"
+        # Act
+        result = validate_key(token)
+        # Assert
+        assert result == "C-Left"
+
+
+# ---------------------------------------------------------------------------
+# validate_key — literal characters
+# ---------------------------------------------------------------------------
+
+
+class TestValidateKeyLiteral:
+    """Single printable chars pass through as raw input."""
+
+    def test_digit_passes_through(self) -> None:
+        # Arrange
+        token = "1"
+        # Act
+        result = validate_key(token)
+        # Assert
+        assert result == "1"
+
+    def test_letter_passes_through(self) -> None:
+        # Arrange
+        token = "y"
+        # Act
+        result = validate_key(token)
+        # Assert
+        assert result == "y"
+
+    def test_punctuation_passes_through(self) -> None:
+        # Arrange
+        token = "/"
+        # Act
+        result = validate_key(token)
+        # Assert
+        assert result == "/"
+
+
+# ---------------------------------------------------------------------------
+# validate_key — rejection
+# ---------------------------------------------------------------------------
+
+
+class TestValidateKeyRejection:
+    """Unknown names raise fail-loud with the valid set listed."""
+
+    def test_unknown_word_raises(self) -> None:
+        # Arrange
+        token = "Retrun"
+        # Act
+        call = lambda: validate_key(token)
+        # Assert
+        with pytest.raises(UnknownKeyError, match="unsupported key"):
+            call()
+
+    def test_error_lists_a_named_key(self) -> None:
+        # Arrange
+        token = "Retrun"
+        # Act
+        call = lambda: validate_key(token)
+        # Assert
+        with pytest.raises(UnknownKeyError, match="Enter"):
+            call()
+
+    def test_empty_string_raises(self) -> None:
+        # Arrange
+        token = ""
+        # Act
+        call = lambda: validate_key(token)
+        # Assert
+        with pytest.raises(UnknownKeyError):
+            call()
+
+
+# ---------------------------------------------------------------------------
+# validate_keys — sequences
+# ---------------------------------------------------------------------------
+
+
+class TestValidateKeysSequence:
+    """A whole sequence validates in order; first bad token fails loud."""
+
+    def test_valid_sequence_returns_all(self) -> None:
+        # Arrange
+        tokens = ["Up", "Up", "Enter"]
+        # Act
+        result = validate_keys(tokens)
+        # Assert
+        assert result == ["Up", "Up", "Enter"]
+
+    def test_alias_in_sequence_canonicalised(self) -> None:
+        # Arrange
+        tokens = ["ESC", "Enter"]
+        # Act
+        result = validate_keys(tokens)
+        # Assert
+        assert result == ["Escape", "Enter"]
+
+    def test_first_bad_token_raises(self) -> None:
+        # Arrange
+        tokens = ["Up", "Nope", "Enter"]
+        # Act
+        call = lambda: validate_keys(tokens)
+        # Assert
+        with pytest.raises(UnknownKeyError):
+            call()
+
+    def test_empty_sequence_raises_value_error(self) -> None:
+        # Arrange
+        tokens: list[str] = []
+        # Act
+        call = lambda: validate_keys(tokens)
+        # Assert
+        with pytest.raises(ValueError, match="empty sequence"):
+            call()
+
+
+# ---------------------------------------------------------------------------
+# parse_key_sequence
+# ---------------------------------------------------------------------------
+
+
+class TestParseKeySequence:
+    """Whitespace-separated spec splits into tokens."""
+
+    def test_splits_on_whitespace(self) -> None:
+        # Arrange
+        spec = "Up Up Enter"
+        # Act
+        result = parse_key_sequence(spec)
+        # Assert
+        assert result == ["Up", "Up", "Enter"]
+
+    def test_blank_yields_empty_list(self) -> None:
+        # Arrange
+        spec = "   "
+        # Act
+        result = parse_key_sequence(spec)
+        # Assert
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# NAMED_KEYS export
+# ---------------------------------------------------------------------------
+
+
+class TestNamedKeysExport:
+    """The public vocabulary carries the documented names."""
+
+    def test_includes_arrow_keys(self) -> None:
+        # Arrange
+        arrows = {"Up", "Down", "Left", "Right"}
+        # Act
+        present = arrows <= NAMED_KEYS
+        # Assert
+        assert present is True
+
+    def test_includes_esc_alias(self) -> None:
+        # Arrange
+        alias = "ESC"
+        # Act
+        present = alias in NAMED_KEYS
+        # Assert
+        assert present is True
+
+
+# EOF

--- a/tests/scitex_agent_container/cli_pkg/test__send_keys.py
+++ b/tests/scitex_agent_container/cli_pkg/test__send_keys.py
@@ -1,0 +1,264 @@
+"""Tests for the key-passthrough path of ``_send.send_to_agent``.
+
+The MCP ``agent_send`` tool mirrors the CLI ``sac agents send
+--key/--keys`` by passing ``key`` / ``keys`` to
+:func:`scitex_agent_container.cli_pkg._send.send_to_agent`. Routing:
+
+  * cancel keys (ESC / C-c / SIGINT) → SIGINT the local runner pid;
+  * any other named key / sequence → tmux send-keys to the LOCAL
+    session;
+  * a cross-host / not-running-locally agent → loud error (key
+    passthrough is local-tmux only);
+  * an unknown key name → loud error.
+
+PA-306 / STX-NM002: no ``unittest.mock``, no ``monkeypatch``. Real
+collaborators are swapped at the module namespace via save/restore
+context managers; env mutations follow the same pattern.
+
+STX-TQ002 AAA-markers + STX-TQ007 one-assert.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+import scitex_agent_container._runners._tmux.multiplexer as _mux_mod
+from scitex_agent_container.cli_pkg._send import send_to_agent
+
+
+@pytest.fixture
+def state_db_env(tmp_path: Path) -> Iterator[Path]:
+    """Isolate ``state.db`` + pin host to ``lead-host`` for the test."""
+    saved_db = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB")
+    saved_host = os.environ.get("SAC_HOST")
+    os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(tmp_path / "state.db")
+    os.environ["SAC_HOST"] = "lead-host"
+    import scitex_agent_container._state.state_db as _state_db_mod
+
+    importlib.reload(_state_db_mod)
+    try:
+        yield tmp_path
+    finally:
+        if saved_db is None:
+            os.environ.pop("SCITEX_AGENT_CONTAINER_STATE_DB", None)
+        else:
+            os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = saved_db
+        if saved_host is None:
+            os.environ.pop("SAC_HOST", None)
+        else:
+            os.environ["SAC_HOST"] = saved_host
+        importlib.reload(_state_db_mod)
+
+
+def _seed_local(name: str, *, a2a_port: int = 12345, pid: int = 4242) -> None:
+    """Record an active instance row on the current (lead) host."""
+    from scitex_agent_container._state.state_db import record_instance_start
+
+    record_instance_start(
+        name=name, host="lead-host", pid=pid, a2a_port=a2a_port
+    )
+
+
+def _seed_remote(name: str, *, peer: str = "peer-host", a2a_port: int = 1) -> None:
+    """Record an active instance row on a peer host."""
+    from scitex_agent_container._state.state_db import record_instance_start
+
+    record_instance_start(name=name, host=peer, a2a_port=a2a_port)
+
+
+class _RecordingMux:
+    """Fake multiplexer recording ``send_keys``; session present."""
+
+    sent: list[tuple[str, tuple[str, ...]]] = []
+
+    @staticmethod
+    def exists(session: str) -> bool:
+        return True
+
+    @classmethod
+    def send_keys(cls, session: str, *keys: str) -> None:
+        cls.sent.append((session, keys))
+
+
+@contextmanager
+def _swap_mux_and_config(session: str):
+    """Swap ``get_multiplexer`` + config resolvers so the send-keys path
+    runs against a fresh recording fake with a known ``screen_name``.
+
+    Returns the fresh recording mux class so the test can probe ``sent``.
+    """
+    import scitex_agent_container.cli_pkg._send as _send_mod  # noqa: F401
+
+    class _Mux(_RecordingMux):
+        sent: list[tuple[str, tuple[str, ...]]] = []
+
+    class _Cfg:
+        screen_name = session
+
+    saved_get = _mux_mod.get_multiplexer
+    import scitex_agent_container.config as _config_mod
+    import scitex_agent_container.config._resolve as _resolve_mod
+
+    saved_resolve = _resolve_mod.resolve_config
+    saved_load = _config_mod.load_config
+    _mux_mod.get_multiplexer = lambda cfg: _Mux  # type: ignore[assignment]
+    _resolve_mod.resolve_config = lambda name: "spec.yaml"  # type: ignore[assignment]
+    _config_mod.load_config = lambda path: _Cfg()  # type: ignore[assignment]
+    try:
+        yield _Mux
+    finally:
+        _mux_mod.get_multiplexer = saved_get  # type: ignore[assignment]
+        _resolve_mod.resolve_config = saved_resolve  # type: ignore[assignment]
+        _config_mod.load_config = saved_load  # type: ignore[assignment]
+
+
+# ---------------------------------------------------------------------------
+# send-keys delivery (local agent)
+# ---------------------------------------------------------------------------
+
+
+class TestNamedKeyDelivered:
+    """A non-cancel named key reaches the local tmux session."""
+
+    def test_enter_sent_to_session(self, state_db_env) -> None:
+        # Arrange
+        _seed_local("alpha")
+        # Act
+        with _swap_mux_and_config("cld-alpha") as mux:
+            send_to_agent("alpha", key="Enter")
+        # Assert
+        assert mux.sent == [("cld-alpha", ("Enter",))]
+
+    def test_status_ok_route_send_keys(self, state_db_env) -> None:
+        # Arrange
+        _seed_local("alpha")
+        # Act
+        with _swap_mux_and_config("cld-alpha"):
+            result = send_to_agent("alpha", key="2")
+        # Assert
+        assert result["route"] == "send-keys"
+
+
+class TestKeySequenceDelivered:
+    """A ``keys`` sequence is split, validated and sent in order."""
+
+    def test_sequence_sent_in_order(self, state_db_env) -> None:
+        # Arrange
+        _seed_local("alpha")
+        # Act
+        with _swap_mux_and_config("cld-alpha") as mux:
+            send_to_agent("alpha", keys="Up Up Enter")
+        # Assert
+        assert mux.sent == [("cld-alpha", ("Up", "Up", "Enter"))]
+
+
+# ---------------------------------------------------------------------------
+# cancel key → SIGINT
+# ---------------------------------------------------------------------------
+
+
+class TestCancelKeyInterrupts:
+    """ESC routes to the SIGINT interrupt path, returning route=interrupt."""
+
+    def test_esc_returns_interrupt_route(self, state_db_env) -> None:
+        # Arrange — a real short-lived child handles SIGINT (NOT the test
+        # process), and its pid is the one the interrupt path targets.
+        import subprocess
+        import sys
+
+        child = subprocess.Popen(
+            [sys.executable, "-c", "import signal,time\n"
+             "signal.signal(signal.SIGINT, lambda *a: None)\n"
+             "time.sleep(30)"]
+        )
+        _seed_local("alpha", pid=child.pid)
+        sd = state_db_env / "runtime" / "alpha"
+        sd.mkdir(parents=True)
+        (sd / "pid").write_text(str(child.pid))
+        saved = os.environ.get("SCITEX_AGENT_CONTAINER_RUNTIME_DIR")
+        os.environ["SCITEX_AGENT_CONTAINER_RUNTIME_DIR"] = str(
+            state_db_env / "runtime"
+        )
+        import scitex_agent_container._runners._session_state as _ss
+
+        importlib.reload(_ss)
+        # Act
+        try:
+            result = send_to_agent("alpha", key="ESC")
+        finally:
+            child.kill()
+            child.wait()
+            if saved is None:
+                os.environ.pop("SCITEX_AGENT_CONTAINER_RUNTIME_DIR", None)
+            else:
+                os.environ["SCITEX_AGENT_CONTAINER_RUNTIME_DIR"] = saved
+            importlib.reload(_ss)
+        # Assert
+        assert result["route"] == "interrupt"
+
+
+# ---------------------------------------------------------------------------
+# error surfaces
+# ---------------------------------------------------------------------------
+
+
+class TestUnknownKeyError:
+    """An unknown key name returns a structured error (no send)."""
+
+    def test_unknown_key_status_error(self, state_db_env) -> None:
+        # Arrange
+        _seed_local("alpha")
+        # Act
+        with _swap_mux_and_config("cld-alpha"):
+            result = send_to_agent("alpha", key="Bogus")
+        # Assert
+        assert result["status"] == "error"
+
+
+class TestCrossHostRejected:
+    """A key to a remote-only agent is refused loud (local-tmux only)."""
+
+    def test_remote_agent_status_error(self, state_db_env) -> None:
+        # Arrange — only a peer-host row exists.
+        _seed_remote("beta")
+        # Act
+        result = send_to_agent("beta", key="Enter")
+        # Assert
+        assert result["status"] == "error"
+
+    def test_remote_agent_error_mentions_local(self, state_db_env) -> None:
+        # Arrange
+        _seed_remote("beta")
+        # Act
+        result = send_to_agent("beta", key="Enter")
+        # Assert
+        assert "local" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# mutual exclusion
+# ---------------------------------------------------------------------------
+
+
+class TestMutualExclusion:
+    """prompt / key / keys are mutually exclusive."""
+
+    def test_key_and_keys_raises(self, state_db_env) -> None:
+        # Arrange
+        raised: Exception | None = None
+        # Act
+        try:
+            send_to_agent("alpha", key="Enter", keys="Up Down")
+        except ValueError as exc:
+            raised = exc
+        # Assert
+        assert isinstance(raised, ValueError)
+
+
+# EOF

--- a/tests/scitex_agent_container/cli_pkg/test_send_cmds.py
+++ b/tests/scitex_agent_container/cli_pkg/test_send_cmds.py
@@ -176,7 +176,7 @@ def test_invocation_without_prompt_or_key_reports_requirement_in_output(
     # Act
     result = runner.invoke(send, ["alpha"])
     # Assert
-    assert "Either PROMPT or --key is required" in result.output
+    assert "Either PROMPT, --key or --keys is required" in result.output
 
 
 def test_invocation_with_both_prompt_and_key_exits_nonzero(isolated_env):
@@ -248,8 +248,8 @@ def test_key_esc_delivers_sigint_to_recorded_pid(alpha_with_pid, field, expected
 def test_key_unsupported_exits_nonzero(isolated_env):
     # Arrange
     runner = CliRunner()
-    # Act
-    result = runner.invoke(send, ["alpha", "--key", "F12"])
+    # Act — ``Bogus`` is neither a tmux keyword nor a single literal char.
+    result = runner.invoke(send, ["alpha", "--key", "Bogus"])
     # Assert
     assert result.exit_code != 0
 
@@ -258,9 +258,9 @@ def test_key_unsupported_reports_not_supported(isolated_env):
     # Arrange
     runner = CliRunner()
     # Act
-    result = runner.invoke(send, ["alpha", "--key", "F12"])
+    result = runner.invoke(send, ["alpha", "--key", "Bogus"])
     # Assert
-    assert "not supported" in result.output
+    assert "unsupported key" in result.output
 
 
 def test_key_esc_without_pid_file_exits_nonzero(isolated_env):
@@ -339,6 +339,89 @@ def test_missing_session_id_reports_no_session_recorded(
     result = invoke()
     # Assert
     assert "No session_id recorded" in result.output
+
+
+# ---------------------------------------------------------------------------
+# --key / --keys: tmux send-keys passthrough (non-cancel keys)
+# ---------------------------------------------------------------------------
+
+
+class _RecordingMux:
+    """Fake multiplexer recording ``send_keys`` calls; session present."""
+
+    sent: list[tuple[str, tuple[str, ...]]] = []
+
+    @staticmethod
+    def exists(session: str) -> bool:
+        return True
+
+    @classmethod
+    def send_keys(cls, session: str, *keys: str) -> None:
+        cls.sent.append((session, keys))
+
+
+@contextmanager
+def _swap_recording_mux() -> Iterator[type]:
+    """Swap ``get_multiplexer`` to yield a fresh recording fake."""
+
+    class _Mux(_RecordingMux):
+        sent: list[tuple[str, tuple[str, ...]]] = []
+
+    saved = send_mod.get_multiplexer
+    send_mod.get_multiplexer = lambda cfg: _Mux  # type: ignore[assignment]
+    try:
+        yield _Mux
+    finally:
+        send_mod.get_multiplexer = saved  # type: ignore[assignment]
+
+
+def test_key_enter_delivered_to_tmux_session(isolated_env):
+    # Arrange
+    runner = CliRunner()
+    # Act
+    with _swap_recording_mux() as mux:
+        result = runner.invoke(send, ["alpha", "--key", "Enter"])
+    # Assert
+    assert mux.sent == [("alpha", ("Enter",))]
+
+
+def test_key_enter_exits_zero(isolated_env):
+    # Arrange
+    runner = CliRunner()
+    # Act
+    with _swap_recording_mux():
+        result = runner.invoke(send, ["alpha", "--key", "Enter"])
+    # Assert
+    assert result.exit_code == 0, result.output
+
+
+def test_keys_sequence_delivered_in_order(isolated_env):
+    # Arrange
+    runner = CliRunner()
+    # Act
+    with _swap_recording_mux() as mux:
+        runner.invoke(send, ["alpha", "--keys", "Up Up Enter"])
+    # Assert
+    assert mux.sent == [("alpha", ("Up", "Up", "Enter"))]
+
+
+def test_key_digit_delivered_to_tmux_session(isolated_env):
+    # Arrange
+    runner = CliRunner()
+    # Act
+    with _swap_recording_mux() as mux:
+        runner.invoke(send, ["alpha", "--key", "2"])
+    # Assert
+    assert mux.sent == [("alpha", ("2",))]
+
+
+def test_prompt_and_keys_mutually_exclusive(isolated_env):
+    # Arrange
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(send, ["alpha", "hi", "--keys", "Enter"])
+    # Assert
+    assert result.exit_code != 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
`sac agents send <agent> --key <NAME>` previously rejected everything except ESC / C-c / SIGINT. Delivery is tmux `send-keys` underneath, so the full key vocabulary was already available — just not exposed. This wires it through end to end.

- New `_runners/_tmux/_keys.py`: single source of truth for the name->tmux mapping + validation. Accepts named tmux keys (Enter, Up, Down, Left, Right, Tab, BTab, Space, Home, End, PageUp/PPage, PageDown/NPage, Escape, BSpace, DC, IC, F1-F12), `C-`/`M-`/`S-` modifier combos, the `ESC`->`Escape` alias, and any single literal char/digit. Unknown names fail loud with the valid set listed.
- CLI (`cli_pkg/send_cmds.py`): `--key <NAME>` now delivers to the agent's tmux session (`screen_name`); added `--keys "<NAME> <NAME> ..."` for a sequence. Cancel keys (ESC / C-c / SIGINT) keep the SIGINT-the-runner-pid interrupt path. The text-prompt path is unchanged.
- Listen `type:key` handler: extracted to new `_listen/_agent_exec_keys.py` — cancel keys -> SIGINT, every other named key/sequence -> tmux send-keys; unknown -> 400, no live session -> 404.
- MCP `agent_send` (`cli_pkg/_send.send_to_agent`): added `key`/`keys` passthrough. Local-tmux only — a cross-host agent is refused loud (no mis-target).
- Refactor: split the over-cap `_listen/_agent_exec.py` — the `agents_start` spawn route + post-ack liveness probe moved to `_agent_start.py` (re-exported, no behaviour change).

## Test plan
- [x] `_runners/_tmux/test_keys.py` — vocabulary: named keys, alias, modifier combos, literals, rejection, sequences.
- [x] `_listen/test_agent_exec_keys.py` — send-keys routing, cancel-key discrimination, 400/404 surfaces (recording-fake mux, no monkeypatch).
- [x] `cli_pkg/test_send_cmds.py` — `--key`/`--keys` delivery + mutual exclusion (updated F12-now-valid + new-message assertions).
- [x] `cli_pkg/test__send_keys.py` — `send_to_agent` key path: local delivery, cancel SIGINT (real child proc), cross-host refusal, unknown-key error.
- 82 passed across the touched suites; AAA, one-assert, no mocks/monkeypatch.