### PR TITLE
fix(tui): clear stale compose buffer on boot before submitting startup prompt

### DIFF
--- a/src/scitex_agent_container/runtimes/_tui_compose.py
+++ b/src/scitex_agent_container/runtimes/_tui_compose.py
@@ -1,0 +1,313 @@
+"""Pure, fully-injectable compose-buffer primitives for the TUI runtime.
+
+Extracted from :mod:`tui_session` (which re-exports every public name here, so
+existing imports keep working) to keep that module under the line limit and to
+group the unit-testable Ink-TUI compose-buffer logic — no tmux import — in one
+cohesive place. The :class:`TuiSessionRuntime` wires the real tmux callables
+into these functions (``_verify_submitted`` → :func:`verify_submit_by_advancement`,
+``_clear_compose_buffer`` → :func:`clear_compose_buffer`).
+
+Two boot fixes live here:
+
+  * :func:`verify_submit_by_advancement` — the boot Enter-drop fix
+    (sac-tui-enter-drop-on-boot): wait-for-idle + verify-by-advancement so the
+    submit Enter never fires into the busy/initializing window where the Ink
+    TUI silently drops it.
+  * :func:`clear_compose_buffer` — the /compact-burst-on-restart fix
+    (sac-tui-clear-compose-buffer-on-boot): a persistent tmux pane carries
+    stale "compose-pending-unsent" text (external input that accumulated while
+    the pane was busy) ACROSS an agent restart; the boot Enter would otherwise
+    submit that whole stale stack. Clearing the compose buffer at the TOP of
+    startup-prompt injection drops the stale text before the boot submit.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from typing import Callable
+
+__all__ = [
+    "clear_compose_buffer",
+    "verify_submit_by_advancement",
+]
+
+
+def _pane_tail(pane: str, lines: int = 14) -> str:
+    """Last ``lines`` non-empty rows of a captured pane, for loud diagnostics.
+
+    A boot-drain failure logs this so the operator sees the EXACT modal /
+    login-wall / render state that blocked readiness — never a bare
+    "timed out" with no evidence.
+    """
+    rows = [r for r in (pane or "").splitlines() if r.strip()]
+    return "\n".join(rows[-lines:])
+
+
+#: Live compose box = the BOTTOM-MOST ``❯`` row (claude renders it just
+#: above the status bar). Same unsent-text regex as the shared
+#: ``prompts`` detector, but scoped to that one row.
+_COMPOSE_PROMPT_RE = re.compile(r"❯[ \t\xa0]+\S")
+
+#: Keystrokes that EMPTY a (possibly multi-line) pending compose buffer in
+#: Claude Code's Ink TUI WITHOUT submitting it or quitting the process.
+#: EMPIRICALLY verified against a real ``claude`` 2.1.150 TUI
+#: (sac-tui-clear-compose-buffer-on-boot, 2026-06-26): a single ``Escape``
+#: leaves a multi-line buffer intact, but a DOUBLE ``Escape`` clears the whole
+#: buffer in one shot — no per-line counting, no kill-ring side effect, and it
+#: never fires Enter. (``C-u`` also clears, but only ONE line per press — it is
+#: a line-kill, so an N-line stale stack needs N+ presses and leaves a
+#: "Ctrl+Y to paste deleted text" hint; Esc-Esc is the clean single gesture.)
+_COMPOSE_CLEAR_KEYS: tuple[str, ...] = ("Escape", "Escape")
+
+
+def _compose_pending_live(pane: str) -> bool:
+    """True iff the LIVE compose box holds pasted-but-unsent text.
+
+    Scopes the ``compose-pending-unsent`` test to the CURRENT input line
+    (the bottom-most ``❯`` row) instead of the whole pane. A ``❯`` sitting
+    in SCROLLBACK — e.g. a submitted ``❯ 1`` echo or the prior turn's
+    rendered prompt — otherwise makes the shared :func:`prompts.detect`
+    report "still pending" forever, so :func:`verify_submit_by_advancement`
+    never sees the buffer clear and false-alarms (the
+    ``sac-tui-enter-drop-on-boot`` live test, 2026-06-24: scitex-dev booted
+    fine yet the drive logged "stayed UNSENT after 8 attempts"). Text after
+    the live ``❯`` = unsent; an empty live box = submitted / ready.
+    """
+    for row in reversed((pane or "").splitlines()):
+        if "❯" in row:
+            return bool(_COMPOSE_PROMPT_RE.search(row))
+    return False
+
+
+def _pane_is_input_idle(pane: str) -> bool:
+    """True when the pane is safe to submit an Enter into.
+
+    Input-idle = NOT busy (no spinner / "thinking" word / "esc to
+    interrupt" line — reusing :func:`liveness_probe.pane_is_busy`, the
+    fleet's single source of truth for the busy-marker list) AND the
+    compose input is actually present: either claude's idle ready cue
+    (:func:`prompts.is_ready`) OR a pasted-but-unsent buffer
+    (:func:`prompts.detect` == ``compose-pending-unsent``) is on screen.
+
+    The boot Enter-drop (sac-tui-enter-drop-on-boot) is precisely a
+    submit fired while ``pane_is_busy`` is True (Claude initializing /
+    spinner up / MCP mid-reconnect); the Ink TUI eats Enter in that
+    window. Gating every send on this predicate is the structural fix.
+    """
+    # Local imports keep this module free of an import cycle and let the
+    # detectors stay the fleet SSOT (no copy to desync).
+    from .._lifecycle.liveness_probe import pane_is_busy
+    from . import prompts as _prompts
+
+    if pane_is_busy(pane):
+        return False
+    return _prompts.is_ready(pane) or _compose_pending_live(pane)
+
+
+def clear_compose_buffer(
+    name: str,
+    *,
+    capture_fn: Callable[[str], str],
+    send_keys_fn: Callable[[str], None],
+    max_attempts: int = 5,
+    poll_s: float = 0.4,
+    sleep_fn: Callable[[float], None] = time.sleep,
+    time_fn: Callable[[], float] = time.monotonic,
+) -> bool:
+    """Empty any stale pasted-but-unsent text in the live compose box.
+
+    Pure + fully injectable — no tmux import (mirrors
+    :func:`verify_submit_by_advancement`). The fix for
+    /compact-burst-on-restart (card sac-tui-clear-compose-buffer-on-boot):
+    a persistent tmux pane carries EXTERNAL "compose-pending-unsent" input
+    (e.g. a burst of stale ``/compact`` slash-commands the operator typed
+    while the pane was busy) ACROSS an agent restart. If the boot's
+    startup-prompt Enter fires with that stack still in the buffer, the whole
+    stale stack is submitted. Calling this at the TOP of startup-prompt
+    injection (before any paste/submit) drops the stale text first.
+
+    Algorithm:
+
+      1. **Capture once.** If the LIVE compose box is already empty
+         (:func:`_compose_pending_live` False) there is nothing to clear —
+         return ``True`` immediately. This is the COMMON case (a fresh boot
+         with no stale buffer), so the no-op costs one capture and no
+         keystroke.
+      2. Otherwise send the verified CLEAR keystrokes
+         (:data:`_COMPOSE_CLEAR_KEYS` = double ``Escape`` — empties a
+         multi-line buffer without submitting or quitting), then poll
+         ``capture_fn`` until the live box is empty, bounded by
+         ``max_attempts``. Resend the clear keys each attempt (the Ink TUI
+         can drop a keystroke mid-render).
+      3. On success return ``True``; on exhaustion log LOUD (error with the
+         pane tail + ``tmux attach`` hint) and return ``False`` but DO NOT
+         raise — boot must still proceed (same fail-loud-not-fatal posture as
+         the rest of the file). The downstream
+         :func:`verify_submit_by_advancement` is the second safety net.
+    """
+    import logging
+
+    log = logging.getLogger(__name__)
+
+    pane = capture_fn(name)
+    if not _compose_pending_live(pane):
+        # Common case: nothing stale in the live box — no-op.
+        return True
+
+    last_pane = pane
+    for _ in range(max_attempts):
+        for key in _COMPOSE_CLEAR_KEYS:
+            send_keys_fn(key)
+        # Let the clear render, then re-capture and verify the live box is empty.
+        if poll_s > 0:
+            sleep_fn(poll_s)
+        last_pane = capture_fn(name)
+        if not _compose_pending_live(last_pane):
+            return True
+
+    log.error(
+        "TuiSessionRuntime: stale compose buffer for %s did NOT clear after "
+        "%d attempts of %r — the Ink TUI kept dropping the clear keystroke (or "
+        "new text keeps arriving). Boot will proceed (verify_submit_by_advancement "
+        "is the next net), but the boot Enter may submit stale text. Attach to "
+        "inspect/recover: `tmux attach -t %s`. Pane tail:\n%s",
+        name,
+        max_attempts,
+        list(_COMPOSE_CLEAR_KEYS),
+        name,
+        _pane_tail(last_pane),
+    )
+    return False
+
+
+def verify_submit_by_advancement(
+    name: str,
+    *,
+    capture_fn: Callable[[str], str],
+    send_keys_fn: Callable[[str], None],
+    max_resends: int = 8,
+    poll_s: float = 0.6,
+    appear_timeout_s: float = 5.0,
+    idle_wait_s: float = 30.0,
+    sleep_fn: Callable[[float], None] = time.sleep,
+    time_fn: Callable[[], float] = time.monotonic,
+) -> bool:
+    """Submit a pasted compose buffer, waiting for idle and verifying by
+    buffer-advancement. Pure + fully injectable — no tmux import.
+
+    This is the fix for the boot Enter-drop (task
+    ``sac-tui-enter-drop-on-boot``). The OLD ``_verify_submitted`` resent
+    Enter ``max_resends`` times back-to-back with only a fixed ``poll_s``
+    sleep — but on (re)start ALL of those resends fire INSIDE the busy /
+    initializing window (spinner ``Photosynthesizing…`` / ``Working…`` /
+    ``Ruminating…`` up, MCP mid-reconnect), where the Ink TUI silently
+    drops every Enter. The agent then sits with its startup_prompt pasted
+    but unsent.
+
+    Algorithm — wait-for-idle + verify-by-advancement, mirroring the
+    proven emacs-claude-code TUI driver cadence (short text→Enter gap,
+    send-verify by buffer advancement, anti-flicker re-capture):
+
+      1. **Wait for the paste to RENDER** as ``compose-pending-unsent``
+         (``capture_fn`` → :func:`prompts.detect`). A multi-line paste
+         takes a beat. If it never renders within ``appear_timeout_s``
+         the turn was either submitted instantly or there was nothing to
+         submit → return ``True`` (nothing to force).
+      2. For up to ``max_resends`` attempts:
+         a. **Wait for input-idle** (:func:`_pane_is_input_idle`): no
+            spinner AND the compose input present. Bounded by
+            ``idle_wait_s``. While waiting, if the buffer ALREADY advanced
+            (no longer ``compose-pending-unsent``) it was submitted →
+            return ``True``. Do NOT send Enter while busy.
+         b. **Send one Enter** (only once idle + still pending).
+         c. **Verify advancement**: poll a short settle; if the buffer is
+            no longer ``compose-pending-unsent`` the Enter landed →
+            return ``True``.
+         d. Otherwise adaptive back-off (settle grows each attempt) and
+            retry — re-checking idle from scratch so the next Enter again
+            only fires into a non-busy pane.
+      3. On exhaustion → fail LOUD (error log with the pane tail +
+         ``tmux attach`` guidance) and return ``False`` (never a silent
+         give-up).
+
+    Returns ``True`` if the buffer was observed to advance (or never
+    rendered as pending), ``False`` if it stayed pending after all
+    bounded attempts.
+    """
+    import logging
+
+    log = logging.getLogger(__name__)
+
+    def _advanced() -> str:
+        """Capture once; return pane text. Buffer 'advanced' iff the
+        returned text no longer detects as compose-pending-unsent."""
+        return capture_fn(name)
+
+    # Phase 1 — wait for the pasted text to appear as an unsent buffer.
+    appear_deadline = time_fn() + appear_timeout_s
+    saw_pending = False
+    last_pane = ""
+    while time_fn() < appear_deadline:
+        last_pane = _advanced()
+        if _compose_pending_live(last_pane):
+            saw_pending = True
+            break
+        if poll_s > 0:
+            sleep_fn(poll_s)
+    if not saw_pending:
+        return True
+
+    # Phase 2 — bounded resend loop: wait-for-idle, send Enter, verify.
+    for attempt in range(max_resends):
+        # 2a — wait for input-idle (no spinner), bounded by idle_wait_s.
+        # Bail early on advancement (a prior Enter, or the operator,
+        # already submitted) so we never send a stray Enter into the
+        # next, empty prompt.
+        idle_deadline = time_fn() + idle_wait_s
+        idle = False
+        while time_fn() < idle_deadline:
+            last_pane = _advanced()
+            if not _compose_pending_live(last_pane):
+                return True
+            if _pane_is_input_idle(last_pane):
+                idle = True
+                break
+            if poll_s > 0:
+                sleep_fn(poll_s)
+        if not idle:
+            # Still busy after the whole idle window — do NOT blind-fire
+            # Enter (that is the original bug). Loop to the next attempt;
+            # the final failure path below reports loudly if it persists.
+            continue
+
+        # 2b — idle + still pending: send exactly one Enter.
+        send_keys_fn("Enter")
+
+        # 2c — verify advancement with an adaptive settle. Anti-flicker:
+        # re-capture after a short gap; the buffer clears within a frame
+        # or two when the Enter lands.
+        settle = poll_s * (1 + attempt)  # adaptive back-off between attempts
+        verify_deadline = time_fn() + settle
+        while True:
+            if poll_s > 0:
+                sleep_fn(poll_s)
+            last_pane = _advanced()
+            if not _compose_pending_live(last_pane):
+                return True
+            if time_fn() >= verify_deadline:
+                break
+        # 2d — not advanced; loop to next attempt (re-checks idle).
+
+    pane = capture_fn(name)
+    log.error(
+        "TuiSessionRuntime: startup_prompt for %s stayed pasted-but-UNSENT "
+        "after %d wait-for-idle Enter attempts — the Ink TUI keeps dropping "
+        "Enter (or the pane never left BUSY). Attach to inspect/recover: "
+        "`tmux attach -t %s` then press Enter. Pane tail:\n%s",
+        name,
+        max_resends,
+        name,
+        _pane_tail(pane or last_pane),
+    )
+    return False

--- a/src/scitex_agent_container/runtimes/tui_session.py
+++ b/src/scitex_agent_container/runtimes/tui_session.py
@@ -55,13 +55,11 @@ runner picks up whatever ``claude`` version the rebuilt SIF provides.
 
 from __future__ import annotations
 
-import re
 import shlex
 import time
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 
-from .._lifecycle.liveness_probe import pane_is_busy
 from .._runners._tmux.tmux import (
     TmuxManager,
     TuiInputNotReadyError,
@@ -69,6 +67,12 @@ from .._runners._tmux.tmux import (
 from ..config import AgentConfig
 from . import prompts as _prompts
 from ._apptainer_build_argv import build_run_argv
+from ._tui_compose import (
+    _compose_pending_live,
+    _pane_tail,
+    clear_compose_buffer,
+    verify_submit_by_advancement,
+)
 from ._to_home import deploy_to_home
 from ._to_home_overlay import deploy_to_home_overlay, resolve_overlay_upper_home
 from ._tui_auth_stage import TuiAuthStageError
@@ -81,6 +85,7 @@ __all__ = [
     "TuiAuthStageError",
     "TuiInputNotReadyError",
     "TuiSessionRuntime",
+    "clear_compose_buffer",
     "session_name_for",
     "state_dir_for_config",
     "verify_submit_by_advancement",
@@ -107,194 +112,6 @@ _DEFAULT_MAX_IDLE_S = 300.0
 # moment they appear; it returns as soon as claude is up, so this is a
 # CAP, not a fixed block. 240s comfortably covers a cold uv resolve.
 _STARTUP_BOOT_DRAIN_S = 240.0
-
-
-def _pane_tail(pane: str, lines: int = 14) -> str:
-    """Last ``lines`` non-empty rows of a captured pane, for loud diagnostics.
-
-    A boot-drain failure logs this so the operator sees the EXACT modal /
-    login-wall / render state that blocked readiness — never a bare
-    "timed out" with no evidence.
-    """
-    rows = [r for r in (pane or "").splitlines() if r.strip()]
-    return "\n".join(rows[-lines:])
-
-
-#: Live compose box = the BOTTOM-MOST ``❯`` row (claude renders it just
-#: above the status bar). Same unsent-text regex as the shared
-#: ``prompts`` detector, but scoped to that one row.
-_COMPOSE_PROMPT_RE = re.compile(r"❯[ \t\xa0]+\S")
-
-
-def _compose_pending_live(pane: str) -> bool:
-    """True iff the LIVE compose box holds pasted-but-unsent text.
-
-    Scopes the ``compose-pending-unsent`` test to the CURRENT input line
-    (the bottom-most ``❯`` row) instead of the whole pane. A ``❯`` sitting
-    in SCROLLBACK — e.g. a submitted ``❯ 1`` echo or the prior turn's
-    rendered prompt — otherwise makes the shared :func:`prompts.detect`
-    report "still pending" forever, so :func:`verify_submit_by_advancement`
-    never sees the buffer clear and false-alarms (the
-    ``sac-tui-enter-drop-on-boot`` live test, 2026-06-24: scitex-dev booted
-    fine yet the drive logged "stayed UNSENT after 8 attempts"). Text after
-    the live ``❯`` = unsent; an empty live box = submitted / ready.
-    """
-    for row in reversed((pane or "").splitlines()):
-        if "❯" in row:
-            return bool(_COMPOSE_PROMPT_RE.search(row))
-    return False
-
-
-def _pane_is_input_idle(pane: str) -> bool:
-    """True when the pane is safe to submit an Enter into.
-
-    Input-idle = NOT busy (no spinner / "thinking" word / "esc to
-    interrupt" line — reusing :func:`liveness_probe.pane_is_busy`, the
-    fleet's single source of truth for the busy-marker list) AND the
-    compose input is actually present: either claude's idle ready cue
-    (:func:`prompts.is_ready`) OR a pasted-but-unsent buffer
-    (:func:`prompts.detect` == ``compose-pending-unsent``) is on screen.
-
-    The boot Enter-drop (sac-tui-enter-drop-on-boot) is precisely a
-    submit fired while ``pane_is_busy`` is True (Claude initializing /
-    spinner up / MCP mid-reconnect); the Ink TUI eats Enter in that
-    window. Gating every send on this predicate is the structural fix.
-    """
-    if pane_is_busy(pane):
-        return False
-    return _prompts.is_ready(pane) or _compose_pending_live(pane)
-
-
-def verify_submit_by_advancement(
-    name: str,
-    *,
-    capture_fn: Callable[[str], str],
-    send_keys_fn: Callable[[str], None],
-    max_resends: int = 8,
-    poll_s: float = 0.6,
-    appear_timeout_s: float = 5.0,
-    idle_wait_s: float = 30.0,
-    sleep_fn: Callable[[float], None] = time.sleep,
-    time_fn: Callable[[], float] = time.monotonic,
-) -> bool:
-    """Submit a pasted compose buffer, waiting for idle and verifying by
-    buffer-advancement. Pure + fully injectable — no tmux import.
-
-    This is the fix for the boot Enter-drop (task
-    ``sac-tui-enter-drop-on-boot``). The OLD ``_verify_submitted`` resent
-    Enter ``max_resends`` times back-to-back with only a fixed ``poll_s``
-    sleep — but on (re)start ALL of those resends fire INSIDE the busy /
-    initializing window (spinner ``Photosynthesizing…`` / ``Working…`` /
-    ``Ruminating…`` up, MCP mid-reconnect), where the Ink TUI silently
-    drops every Enter. The agent then sits with its startup_prompt pasted
-    but unsent.
-
-    Algorithm — wait-for-idle + verify-by-advancement, mirroring the
-    proven emacs-claude-code TUI driver cadence (short text→Enter gap,
-    send-verify by buffer advancement, anti-flicker re-capture):
-
-      1. **Wait for the paste to RENDER** as ``compose-pending-unsent``
-         (``capture_fn`` → :func:`prompts.detect`). A multi-line paste
-         takes a beat. If it never renders within ``appear_timeout_s``
-         the turn was either submitted instantly or there was nothing to
-         submit → return ``True`` (nothing to force).
-      2. For up to ``max_resends`` attempts:
-         a. **Wait for input-idle** (:func:`_pane_is_input_idle`): no
-            spinner AND the compose input present. Bounded by
-            ``idle_wait_s``. While waiting, if the buffer ALREADY advanced
-            (no longer ``compose-pending-unsent``) it was submitted →
-            return ``True``. Do NOT send Enter while busy.
-         b. **Send one Enter** (only once idle + still pending).
-         c. **Verify advancement**: poll a short settle; if the buffer is
-            no longer ``compose-pending-unsent`` the Enter landed →
-            return ``True``.
-         d. Otherwise adaptive back-off (settle grows each attempt) and
-            retry — re-checking idle from scratch so the next Enter again
-            only fires into a non-busy pane.
-      3. On exhaustion → fail LOUD (error log with the pane tail +
-         ``tmux attach`` guidance) and return ``False`` (never a silent
-         give-up).
-
-    Returns ``True`` if the buffer was observed to advance (or never
-    rendered as pending), ``False`` if it stayed pending after all
-    bounded attempts.
-    """
-    import logging
-
-    log = logging.getLogger(__name__)
-
-    def _advanced() -> str:
-        """Capture once; return pane text. Buffer 'advanced' iff the
-        returned text no longer detects as compose-pending-unsent."""
-        return capture_fn(name)
-
-    # Phase 1 — wait for the pasted text to appear as an unsent buffer.
-    appear_deadline = time_fn() + appear_timeout_s
-    saw_pending = False
-    last_pane = ""
-    while time_fn() < appear_deadline:
-        last_pane = _advanced()
-        if _compose_pending_live(last_pane):
-            saw_pending = True
-            break
-        if poll_s > 0:
-            sleep_fn(poll_s)
-    if not saw_pending:
-        return True
-
-    # Phase 2 — bounded resend loop: wait-for-idle, send Enter, verify.
-    for attempt in range(max_resends):
-        # 2a — wait for input-idle (no spinner), bounded by idle_wait_s.
-        # Bail early on advancement (a prior Enter, or the operator,
-        # already submitted) so we never send a stray Enter into the
-        # next, empty prompt.
-        idle_deadline = time_fn() + idle_wait_s
-        idle = False
-        while time_fn() < idle_deadline:
-            last_pane = _advanced()
-            if not _compose_pending_live(last_pane):
-                return True
-            if _pane_is_input_idle(last_pane):
-                idle = True
-                break
-            if poll_s > 0:
-                sleep_fn(poll_s)
-        if not idle:
-            # Still busy after the whole idle window — do NOT blind-fire
-            # Enter (that is the original bug). Loop to the next attempt;
-            # the final failure path below reports loudly if it persists.
-            continue
-
-        # 2b — idle + still pending: send exactly one Enter.
-        send_keys_fn("Enter")
-
-        # 2c — verify advancement with an adaptive settle. Anti-flicker:
-        # re-capture after a short gap; the buffer clears within a frame
-        # or two when the Enter lands.
-        settle = poll_s * (1 + attempt)  # adaptive back-off between attempts
-        verify_deadline = time_fn() + settle
-        while True:
-            if poll_s > 0:
-                sleep_fn(poll_s)
-            last_pane = _advanced()
-            if not _compose_pending_live(last_pane):
-                return True
-            if time_fn() >= verify_deadline:
-                break
-        # 2d — not advanced; loop to next attempt (re-checks idle).
-
-    pane = capture_fn(name)
-    log.error(
-        "TuiSessionRuntime: startup_prompt for %s stayed pasted-but-UNSENT "
-        "after %d wait-for-idle Enter attempts — the Ink TUI keeps dropping "
-        "Enter (or the pane never left BUSY). Attach to inspect/recover: "
-        "`tmux attach -t %s` then press Enter. Pane tail:\n%s",
-        name,
-        max_resends,
-        name,
-        _pane_tail(pane or last_pane),
-    )
-    return False
 
 
 def session_name_for(config: AgentConfig) -> str:
@@ -732,6 +549,17 @@ class TuiSessionRuntime(RuntimeBase):
              ``send_keys(name, "Enter")`` — operator-recovered each
              stuck agent by attaching tmux and pressing this. Baking
              it in removes the manual rescue.
+
+        Stale-compose fix (2026-06-26, card sac-tui-clear-compose-buffer-on-boot):
+        a persistent tmux pane carries EXTERNAL pasted-but-unsent text (e.g. a
+        burst of stale ``/compact`` slash-commands the operator typed while the
+        pane was busy) ACROSS an agent restart. If we paste + submit the
+        startup prompt with that stack still in the compose box, the boot Enter
+        submits the WHOLE stale stack too (observed: 9× ``/compact`` + a stray
+        ``2``). So BEFORE the per-prompt loop we
+        :meth:`_clear_compose_buffer` — a no-op when the box is already empty
+        (the common case), an empirically-verified double-``Escape`` clear when
+        it is not.
         """
         import logging
 
@@ -740,6 +568,12 @@ class TuiSessionRuntime(RuntimeBase):
         if not prompts:
             return
         name = session_name_for(config)
+        # Drop any stale "compose-pending-unsent" text the persistent pane
+        # carried across the restart, BEFORE the first paste/submit, so the
+        # boot Enter never submits an external stale stack. Fail-loud, never
+        # fatal: a failed clear logs LOUD and boot still proceeds (the
+        # downstream _verify_submitted is the second net).
+        self._clear_compose_buffer(name)
         for index, prompt in enumerate(prompts, start=1):
             if not prompt:
                 continue
@@ -764,6 +598,30 @@ class TuiSessionRuntime(RuntimeBase):
                     name,
                     exc,
                 )
+
+    def _clear_compose_buffer(
+        self,
+        name: str,
+        *,
+        max_attempts: int = 5,
+        poll_s: float = 0.4,
+    ) -> bool:
+        """Clear stale compose-pending text before the boot submit.
+
+        Thin wrapper that wires the real tmux callables into the pure,
+        unit-testable :func:`clear_compose_buffer` (mirrors how
+        :meth:`_verify_submitted` wraps :func:`verify_submit_by_advancement`).
+        See that function's docstring for the no-op-when-empty / double-Escape
+        algorithm (the fix for /compact-burst-on-restart,
+        sac-tui-clear-compose-buffer-on-boot).
+        """
+        return clear_compose_buffer(
+            name,
+            capture_fn=self._mux.capture_content,
+            send_keys_fn=lambda key: self._mux.send_keys(name, key),
+            max_attempts=max_attempts,
+            poll_s=poll_s,
+        )
 
     def _verify_submitted(
         self,

--- a/src/scitex_agent_container/runtimes/tui_session.py
+++ b/src/scitex_agent_container/runtimes/tui_session.py
@@ -85,6 +85,7 @@ __all__ = [
     "TuiAuthStageError",
     "TuiInputNotReadyError",
     "TuiSessionRuntime",
+    "_compose_pending_live",
     "clear_compose_buffer",
     "session_name_for",
     "state_dir_for_config",

--- a/tests/scitex_agent_container/runtimes/test_tui_session_clear_compose.py
+++ b/tests/scitex_agent_container/runtimes/test_tui_session_clear_compose.py
@@ -1,0 +1,280 @@
+"""Regression: /compact-burst-on-restart (sac-tui-clear-compose-buffer-on-boot).
+
+On an agent RESTART the persistent tmux pane can carry a BURST of stale
+"compose-pending-unsent" text (observed live: 9× ``/compact`` + a stray ``2``)
+that EXTERNAL input accumulated in the Ink TUI compose box while the pane was
+busy. The boot's startup-prompt injection used to paste + submit WITHOUT first
+clearing that stale buffer, so the boot Enter submitted the whole stale stack.
+
+The fix (:func:`clear_compose_buffer`) empties the live compose box BEFORE the
+per-prompt paste/submit loop:
+
+  * no-op when the live box is already empty (the COMMON case — one capture,
+    no keystroke);
+  * otherwise send the EMPIRICALLY-verified clear keystrokes (double
+    ``Escape`` — clears a multi-line buffer without submitting or quitting,
+    confirmed against a real claude 2.1.150 TUI, 2026-06-26), then poll until
+    the box is empty, bounded by ``max_attempts``;
+  * fail-loud-not-fatal: on exhaustion log LOUD and return False, never raise
+    (boot must proceed; verify_submit_by_advancement is the second net).
+
+These tests drive the pure function with REAL fake callables (a scripted /
+state-machine ``capture_fn`` + a recording ``send_keys_fn``) — no MagicMock,
+no monkeypatch-as-fixture-param (PA-306). STX-TQ002 AAA each on its own line,
+STX-TQ007 one assertion per test.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+
+from scitex_agent_container.runtimes._tui_compose import (
+    _COMPOSE_CLEAR_KEYS,
+    clear_compose_buffer,
+)
+
+# ── Realistic pane snapshots ────────────────────────────────────────────────
+# Only the load-bearing glyphs matter to _compose_pending_live (the bottom-most
+# ❯ row): text after the live ❯ == pending; an empty live box == cleared.
+
+# A multi-line stale stack sitting unsent in the live compose box — exactly the
+# /compact-burst the operator observed across a restart.
+_STALE_MULTILINE = (
+    "❯\xa0/compact\n"
+    "  /compact\n"
+    "  /compact\n"
+    "  2\n"
+    "  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents\n"
+)
+# Cleared: the live ❯ box is empty (placeholder), ready for the boot paste.
+_CLEARED = (
+    "❯ \n  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents\n"
+)
+
+
+# ── Fakes (real callables, not mocks) ───────────────────────────────────────
+
+
+@dataclass
+class _RecordingSend:
+    """A ``send_keys_fn`` that records every key sent."""
+
+    keys: list[str] = field(default_factory=list)
+
+    def __call__(self, key: str) -> None:
+        self.keys.append(key)
+
+
+@dataclass
+class _ScriptedPane:
+    """A ``capture_fn`` returning a scripted sequence of pane snapshots.
+
+    Each call returns the next snapshot; once exhausted it keeps returning the
+    LAST one (a steady terminal state).
+    """
+
+    snapshots: list[str]
+    captures: int = 0
+
+    def __call__(self, _name: str) -> str:
+        idx = min(self.captures, len(self.snapshots) - 1)
+        self.captures += 1
+        return self.snapshots[idx]
+
+
+class _StaleUntilCleared:
+    """State-machine ``capture_fn``: reports the multi-line stale stack until
+    the paired sender has sent ``release`` full clear-key gestures, then
+    reports the cleared (empty) box.
+
+    Models the real TUI: the stale buffer survives until the clear keystrokes
+    actually LAND; ``release`` lets a test simulate the Ink TUI eating the
+    first N gestures before one finally clears.
+    """
+
+    def __init__(self, sender: _RecordingSend, *, release_after_gestures: int = 1) -> None:
+        self._sender = sender
+        self._release = release_after_gestures
+
+    def __call__(self, _name: str) -> str:
+        # One "gesture" == one full _COMPOSE_CLEAR_KEYS sequence. Count COMPLETE
+        # gestures (a key in the sequence repeats, so counting a single key is
+        # wrong — divide the total sent by the gesture length).
+        gestures = len(self._sender.keys) // len(_COMPOSE_CLEAR_KEYS)
+        return _CLEARED if gestures >= self._release else _STALE_MULTILINE
+
+
+def _no_sleep(_s: float) -> None:
+    return None
+
+
+# ── (a) stale pending buffer -> helper clears it ─────────────────────────────
+
+
+def test_clears_stale_pending_buffer_and_returns_true() -> None:
+    # Arrange — the live box holds a multi-line stale stack; the clear gesture
+    # empties it on the first try.
+    sender = _RecordingSend()
+    capture = _StaleUntilCleared(sender, release_after_gestures=1)
+    # Act
+    ok = clear_compose_buffer(
+        "tui-x",
+        capture_fn=capture,
+        send_keys_fn=sender,
+        max_attempts=5,
+        poll_s=0.0,
+        sleep_fn=_no_sleep,
+    )
+    # Assert — cleared successfully.
+    assert ok is True
+
+
+def test_sends_the_verified_clear_keystrokes_when_buffer_is_stale() -> None:
+    # Arrange — stale multi-line buffer, cleared after one gesture.
+    sender = _RecordingSend()
+    capture = _StaleUntilCleared(sender, release_after_gestures=1)
+    # Act
+    clear_compose_buffer(
+        "tui-x",
+        capture_fn=capture,
+        send_keys_fn=sender,
+        max_attempts=5,
+        poll_s=0.0,
+        sleep_fn=_no_sleep,
+    )
+    # Assert — exactly the empirically-verified clear gesture was sent.
+    assert sender.keys == list(_COMPOSE_CLEAR_KEYS)
+
+
+# ── (b) already-empty buffer -> no-op (no keystroke sent) ────────────────────
+
+
+def test_noop_when_buffer_already_empty_sends_no_keys() -> None:
+    # Arrange — the live box is already empty (the common fresh-boot case).
+    capture = _ScriptedPane([_CLEARED])
+    sender = _RecordingSend()
+    # Act
+    ok = clear_compose_buffer(
+        "tui-x",
+        capture_fn=capture,
+        send_keys_fn=sender,
+        max_attempts=5,
+        poll_s=0.0,
+        sleep_fn=_no_sleep,
+    )
+    # Assert — no-op: cleared (nothing to do) and not a single key sent.
+    assert (ok, sender.keys) == (True, [])
+
+
+def test_noop_captures_only_once_when_already_empty() -> None:
+    # Arrange — already empty: the helper should short-circuit after one read.
+    capture = _ScriptedPane([_CLEARED])
+    sender = _RecordingSend()
+    # Act
+    clear_compose_buffer(
+        "tui-x",
+        capture_fn=capture,
+        send_keys_fn=sender,
+        max_attempts=5,
+        poll_s=0.0,
+        sleep_fn=_no_sleep,
+    )
+    # Assert — exactly one capture, no polling loop entered.
+    assert capture.captures == 1
+
+
+# ── (c) clear never succeeds -> returns False, logs loud, does NOT raise ──────
+
+
+def test_returns_false_when_clear_never_succeeds() -> None:
+    # Arrange — the Ink TUI drops every clear gesture (release impossibly high).
+    sender = _RecordingSend()
+    capture = _StaleUntilCleared(sender, release_after_gestures=999)
+    # Act
+    ok = clear_compose_buffer(
+        "tui-x",
+        capture_fn=capture,
+        send_keys_fn=sender,
+        max_attempts=3,
+        poll_s=0.0,
+        sleep_fn=_no_sleep,
+    )
+    # Assert — bounded give-up returns False (never silently True).
+    assert ok is False
+
+
+def test_bounded_attempts_does_not_exceed_max_attempts() -> None:
+    # Arrange — same never-clearing pane; assert the resend bound holds.
+    sender = _RecordingSend()
+    capture = _StaleUntilCleared(sender, release_after_gestures=999)
+    # Act
+    clear_compose_buffer(
+        "tui-x",
+        capture_fn=capture,
+        send_keys_fn=sender,
+        max_attempts=2,
+        poll_s=0.0,
+        sleep_fn=_no_sleep,
+    )
+    # Assert — one full clear gesture per attempt, never more than the bound.
+    assert sender.keys == list(_COMPOSE_CLEAR_KEYS) * 2
+
+
+def test_logs_loud_on_exhaustion(caplog) -> None:
+    # Arrange — never clears, so the exhaustion path fires.
+    sender = _RecordingSend()
+    capture = _StaleUntilCleared(sender, release_after_gestures=999)
+    # Act
+    with caplog.at_level(logging.ERROR):
+        clear_compose_buffer(
+            "tui-x",
+            capture_fn=capture,
+            send_keys_fn=sender,
+            max_attempts=2,
+            poll_s=0.0,
+            sleep_fn=_no_sleep,
+        )
+    # Assert — a LOUD error was logged (not a silent best-effort return).
+    assert any(r.levelno == logging.ERROR for r in caplog.records)
+
+
+def test_does_not_raise_when_clear_never_succeeds() -> None:
+    # Arrange — never clears; boot must still proceed, so no exception.
+    sender = _RecordingSend()
+    capture = _StaleUntilCleared(sender, release_after_gestures=999)
+    # Act
+    raised = False
+    try:
+        clear_compose_buffer(
+            "tui-x",
+            capture_fn=capture,
+            send_keys_fn=sender,
+            max_attempts=2,
+            poll_s=0.0,
+            sleep_fn=_no_sleep,
+        )
+    except Exception:  # noqa: BLE001 — the whole point is that NOTHING escapes.
+        raised = True
+    # Assert — fail-loud-not-fatal: it returns, never raises.
+    assert raised is False
+
+
+# ── (d) resends across a dropped gesture, then clears ────────────────────────
+
+
+def test_resends_clear_when_first_gesture_is_dropped() -> None:
+    # Arrange — the Ink TUI eats the FIRST clear gesture; the second lands.
+    sender = _RecordingSend()
+    capture = _StaleUntilCleared(sender, release_after_gestures=2)
+    # Act
+    ok = clear_compose_buffer(
+        "tui-x",
+        capture_fn=capture,
+        send_keys_fn=sender,
+        max_attempts=5,
+        poll_s=0.0,
+        sleep_fn=_no_sleep,
+    )
+    # Assert — resent until cleared (two full gestures), then succeeded.
+    assert (ok, sender.keys) == (True, list(_COMPOSE_CLEAR_KEYS) * 2)


### PR DESCRIPTION
## Summary
Fixes **/compact-burst-on-restart** (card `sac-tui-clear-compose-buffer-on-boot`).

On an agent RESTART, a TUI agent's persistent tmux pane carries stale
"compose-pending-unsent" text ACROSS the restart — EXTERNAL input that
accumulated in the Ink TUI compose box while the pane was busy (observed live:
9x `/compact` + a stray `2`). `_inject_startup_prompts` pasted + submitted the
startup prompt WITHOUT first clearing that buffer, so the boot Enter submitted
the whole stale stack along with the boot prompt.

The fix clears the live compose box at the TOP of `_inject_startup_prompts`,
BEFORE the per-prompt paste/submit loop:

- New pure, fully-injectable `clear_compose_buffer()` (mirrors the existing
  `verify_submit_by_advancement` style — no tmux import, unit-testable):
  - no-op when the live compose box is already empty (the COMMON fresh-boot
    case: one capture, no keystroke);
  - else send the verified clear keystrokes, then poll until the box is empty,
    bounded by `max_attempts` (resends each attempt to survive an Ink mid-render
    drop);
  - on exhaustion: log LOUD (error + pane tail + `tmux attach` hint) and return
    `False`, but **DO NOT raise** — boot must proceed (`verify_submit_by_advancement`
    is the second net). Same fail-loud-not-fatal posture as the rest of the file.
- Wired via a thin `_clear_compose_buffer()` runtime method (like `_verify_submitted`
  wraps `verify_submit_by_advancement`).
- Extracted the cohesive pure compose-buffer primitives into a new
  `runtimes/_tui_compose.py`; `tui_session` re-exports them so existing imports
  (and the boot Enter-drop fix `verify_submit_by_advancement`) are unchanged.
  This was needed to land under the repo's per-file line limit.

## Verified clear keystroke (empirical — not guessed)
Tested against a **real `claude` 2.1.150 TUI** in a throwaway tmux session,
pasting a multi-line pending buffer:

| keystroke | result on a MULTI-LINE pending buffer |
|---|---|
| `C-u` | line-kill only — clears ONE line per press; an N-line stack needs N+ presses and leaves a "Ctrl+Y to paste deleted text" hint |
| `Escape` (single) | **does NOT clear** — multi-line buffer stays intact |
| **`Escape` `Escape` (double)** | **clears the WHOLE buffer in one shot, no submit, no quit** ✓ |

Before/after evidence (live capture):
```
### BEFORE Esc Esc (live compose box) ###
❯ stale-aaa\
  stale-bbb\
  stale-ccc
### sending Escape Escape ###
### AFTER Esc Esc ###
0   ← count of stale lines remaining (buffer fully cleared; session still alive)
```
So `_COMPOSE_CLEAR_KEYS = ("Escape", "Escape")`.

## Test plan
- [x] stale multi-line buffer -> helper clears it; asserts the verified clear keystrokes were sent
- [x] already-empty buffer -> no-op (no keystroke sent; exactly one capture)
- [x] clear never succeeds -> returns `False`, logs LOUD, does NOT raise; bounded to `max_attempts`
- [x] resends across a dropped gesture, then clears
- [x] no mocks — scripted/state-machine `capture_fn` + recording `send_keys_fn` (STX-NM002)
- [x] full module run: `test_tui_session_clear_compose.py` (9) + `test_tui_session_verify_advancement.py` (12) + `test_tui_session_startup_prompt_enter.py` (4) = **25 passed** (absolute pytest path)

## Notes for reviewer
- High blast radius: every TUI agent boots through `_inject_startup_prompts`. **Auto-merge NOT enabled** — please review before merge.
- The boot Enter-drop fix (`verify_submit_by_advancement`, `sac-tui-enter-drop-on-boot`) is moved verbatim into `_tui_compose.py` and re-exported — not regressed.
- `tui_session.py` remains over the per-file line limit (1029 lines) as a PRE-EXISTING condition; this PR extracts one cohesive module rather than fully splitting the runtime class (out of scope for this focused fix).