### PR TITLE
fix(listen): startup loops must not block uvicorn bind (+ fail-loud watchdog)

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_bind_watchdog.py
+++ b/src/scitex_agent_container/_lifecycle/_bind_watchdog.py
@@ -1,0 +1,139 @@
+"""Fail-loud watchdog for the ``sac listen`` bind (cards
+``sac-listen-self-peer-persist-blocks-bind`` /
+``sac-listen-watchdog-autorestart-alarm``).
+
+The incident this guards: the listen daemon started, the lifespan
+launched its background loops, but uvicorn NEVER bound the port — and
+NOTHING was logged. An up-but-not-serving daemon is the worst failure
+mode because it is invisible: the whole fleet lost agent-to-agent comms
+with no error anywhere.
+
+Operator directive ("when failure occurs, fail loud; explicit feedback
+loop with errors and hints"): the silent up-but-not-serving state must
+become IMPOSSIBLE. This watchdog runs as a lifespan task that, ``delay_s``
+seconds after startup, probes ``http://127.0.0.1:<port>/v1/health``. If
+the probe fails (connection refused / timeout — i.e. the server is not
+actually serving), it logs a LOUD ``ERROR`` naming the likely cause and
+an actionable hint, then keeps re-probing on an interval so the alarm
+persists for as long as the daemon is wedged. Once the probe succeeds it
+logs a single info line and exits (the bind is healthy; the watchdog has
+done its job).
+
+Pure-stdlib (``urllib``) probe so it adds no dependency and is itself
+non-blocking: the blocking ``urlopen`` is dispatched off the event loop
+via :func:`_off_loop.run_blocking`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+logger = logging.getLogger(__name__)
+
+# How long after startup to first check the bind. Generous enough that a
+# healthy server is always serving by then, short enough that the operator
+# learns about a wedged daemon within seconds rather than via a silent
+# fleet outage.
+DEFAULT_WATCHDOG_DELAY_S = 15.0
+
+# Re-probe cadence while the bind is still down, so the LOUD alarm keeps
+# firing (a single line at T+15s is easy to miss in a long log).
+DEFAULT_WATCHDOG_REPROBE_S = 30.0
+
+
+def _probe_health(url: str, timeout_s: float) -> bool:
+    """True iff an HTTP GET to ``url`` connects and returns a response.
+
+    Any HTTP status counts as "serving" — even a 401 from the bearer
+    middleware means uvicorn bound the port and is handling requests,
+    which is exactly what we are checking. Only a connection-level
+    failure (refused / timeout / DNS) means "not serving".
+    """
+    import urllib.error
+    import urllib.request
+
+    try:
+        urllib.request.urlopen(url, timeout=timeout_s)  # noqa: S310 (localhost only)
+        return True
+    except urllib.error.HTTPError:
+        # Got an HTTP response (e.g. 401) → the server IS serving.
+        return True
+    except Exception:  # stx-allow: fallback (connection-level failure = not serving; that is the signal we want)
+        return False
+
+
+async def bind_watchdog_loop(
+    *,
+    port: int,
+    host: str = "127.0.0.1",
+    delay_s: float = DEFAULT_WATCHDOG_DELAY_S,
+    reprobe_s: float = DEFAULT_WATCHDOG_REPROBE_S,
+    probe=None,
+) -> None:
+    """Lifespan task: fail loud if the listen bind is not serving.
+
+    Waits ``delay_s``, then probes ``http://{host}:{port}/v1/health``.
+    On success: logs one info line and returns. On failure: logs a LOUD
+    ERROR (cause + hint) and keeps re-probing every ``reprobe_s`` until
+    the bind comes up or the task is cancelled (lifespan teardown).
+
+    ``probe`` is a test seam ``probe(url, timeout_s) -> bool``; production
+    uses :func:`_probe_health` dispatched off the event loop.
+    """
+    from ._off_loop import run_blocking
+
+    url = f"http://{host}:{port}/v1/health"
+    probe_fn = probe if probe is not None else _probe_health
+
+    try:
+        await asyncio.sleep(delay_s)
+    except asyncio.CancelledError:
+        raise
+
+    alarmed = False
+    while True:
+        try:
+            ok = await run_blocking(probe_fn, url, 3.0, timeout_s=5.0)
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # stx-allow: fallback (probe dispatch error = treat as not-serving; keep alarming)
+            ok = False
+
+        if ok:
+            if alarmed:
+                logger.info(
+                    "bind_watchdog: %s is now serving — listen bind recovered.",
+                    url,
+                )
+            else:
+                logger.info("bind_watchdog: listen bind healthy (%s).", url)
+            return
+
+        alarmed = True
+        logger.error(
+            "bind_watchdog: ALARM — `sac listen` did NOT bind/serve %s within "
+            "%.0fs of startup. The daemon is UP but NOT SERVING — the entire "
+            "fleet's agent-to-agent comms are DOWN with no other error. "
+            "LIKELY CAUSE: a startup background loop made a blocking call "
+            "(gh/tmux/network subprocess or a socket call) on the asyncio "
+            "event loop, starving uvicorn's bind. HINT: restart with "
+            "SAC_PERIODIC_DRIVE_DISABLED=1 SAC_GITHUB_CI_POLLER_DISABLED=1 "
+            "SAC_TUI_HEARTBEAT_DISABLED=1 to confirm, then check the loop "
+            "startup paths (must use _off_loop.run_blocking). Re-probing in "
+            "%.0fs.",
+            url,
+            delay_s,
+            reprobe_s,
+        )
+        try:
+            await asyncio.sleep(reprobe_s)
+        except asyncio.CancelledError:
+            raise
+
+
+__all__ = [
+    "DEFAULT_WATCHDOG_DELAY_S",
+    "DEFAULT_WATCHDOG_REPROBE_S",
+    "bind_watchdog_loop",
+]

--- a/src/scitex_agent_container/_lifecycle/_github_ci_poll_loop.py
+++ b/src/scitex_agent_container/_lifecycle/_github_ci_poll_loop.py
@@ -68,12 +68,24 @@ async def github_ci_poll_loop(
         logger.info("github_ci_poll_loop: disabled via SAC_GITHUB_CI_POLLER_DISABLED")
         return
 
+    # ROOT-CAUSE GUARD (cards sac-listen-self-peer-persist-blocks-bind /
+    # sac-listen-watchdog-autorestart-alarm): this preflight is the FIRST
+    # thing the loop does, BEFORE its first ``await asyncio.sleep`` — and
+    # the production ``ready`` is ``gh_ready()`` → ``subprocess.run(['gh',
+    # 'auth', 'status'])``, which makes a NETWORK call to GitHub. Run
+    # synchronously on the event loop, a hung ``gh``/network here starves
+    # uvicorn's bind and silently takes the whole fleet's comms down. So
+    # dispatch it off the loop with a hard timeout; a wedged probe degrades
+    # to "not ready" (fail-loud) instead of hanging the listen daemon.
+    from ._off_loop import run_blocking_or
+
     ready = ready_check if ready_check is not None else _default_ready_check
-    if not ready():
+    if not await run_blocking_or(ready, default=False, op="gh auth status (gh_ready)"):
         logger.error(
-            "github_ci_poll_loop: `gh` is not installed/authenticated — "
-            "CI-verdict delivery DISABLED. Run `gh auth login` on this host. "
-            "(fail-loud: refusing to run a poller that can deliver nothing)"
+            "github_ci_poll_loop: `gh` is not installed/authenticated (or its "
+            "auth probe timed out) — CI-verdict delivery DISABLED. Run "
+            "`gh auth login` on this host. (fail-loud: refusing to run a "
+            "poller that can deliver nothing)"
         )
         return
 
@@ -86,19 +98,34 @@ async def github_ci_poll_loop(
     if deliver is None:
         from ._ci_deliver import deliver_verdict as deliver
 
+    def _tick_body() -> None:
+        # Each of repos_source / list_prs / conclusion_for / deliver may
+        # shell out to ``gh`` (blocking subprocess.run); run the whole
+        # tick body off the event loop so a slow GitHub read never starves
+        # the listen server even after bind.
+        for repo in list(repos_source()):
+            for pr in list_prs(repo):
+                deliver(
+                    repo,
+                    pr["number"],
+                    pr.get("head_sha", ""),
+                    conclusion_for(repo, pr["number"]),
+                    pr_body=pr.get("body", ""),
+                )
+
     logger.info("github_ci_poll_loop: starting (poll_interval_s=%.1f)", poll_interval_s)
     try:
         while True:
             try:
-                for repo in list(repos_source()):
-                    for pr in list_prs(repo):
-                        deliver(
-                            repo,
-                            pr["number"],
-                            pr.get("head_sha", ""),
-                            conclusion_for(repo, pr["number"]),
-                            pr_body=pr.get("body", ""),
-                        )
+                # Bound the tick generously: a full poll across repos can
+                # legitimately take a while, but must never run unbounded
+                # on (or off) the loop. Timeout → logged + retried.
+                await run_blocking_or(
+                    _tick_body,
+                    default=None,
+                    op="github_ci_poll_loop tick (gh reads)",
+                    timeout_s=max(poll_interval_s, 30.0),
+                )
             except asyncio.CancelledError:
                 raise
             except Exception as exc:  # stx-allow: fallback (loop must survive a transient GitHub/registry error; logged, retried next tick)

--- a/src/scitex_agent_container/_lifecycle/_listen_lifespan.py
+++ b/src/scitex_agent_container/_lifecycle/_listen_lifespan.py
@@ -1,0 +1,136 @@
+"""Starlette ``lifespan`` factory for the ``sac listen`` server.
+
+Extracted from ``_listen.server.create_app`` (which had grown past the
+module line budget) AND the focal point of the silent-bind-hang fix
+(cards ``sac-listen-self-peer-persist-blocks-bind`` /
+``sac-listen-watchdog-autorestart-alarm``).
+
+The lifespan:
+
+  1. ``await`` the one-shot self-peer persistence (app ready);
+  2. launch the three background loops — periodic-drive, GitHub-CI
+     poll, TUI-heartbeat — each honouring its disable env var. Their
+     startup paths now route every blocking ``gh``/``tmux``/FS call
+     through ``_off_loop.run_blocking*`` so none can starve uvicorn's
+     bind (the root cause of the silent fleet-comms outage);
+  3. launch the fail-loud bind watchdog (``_bind_watchdog``) when a
+     port is known, so an up-but-not-serving daemon can NEVER stay
+     silent;
+  4. ``yield`` (server serves);
+  5. on teardown, cancel every launched task cleanly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from contextlib import asynccontextmanager
+
+logger = logging.getLogger(__name__)
+
+
+def build_listen_lifespan(*, health_watchdog_port: int | None = None):
+    """Return the ``@asynccontextmanager`` lifespan for ``create_app``.
+
+    ``health_watchdog_port`` — when set, the lifespan launches the
+    fail-loud bind watchdog against ``127.0.0.1:<port>/v1/health``. The
+    CLI passes the port it hands to ``uvicorn.run``; in-process tests may
+    omit it (no watchdog) or pass a real bound port.
+    """
+    from ._bind_watchdog import bind_watchdog_loop
+    from ._github_ci_poll_loop import (
+        DEFAULT_CI_POLL_INTERVAL_S,
+        github_ci_poll_loop,
+    )
+    from ._periodic_drive_loop import periodic_drive_loop
+    from ._tui_heartbeat_loop import (
+        DEFAULT_TUI_HEARTBEAT_INTERVAL_S,
+        tui_heartbeat_loop,
+    )
+
+    # Imported lazily inside the helper below to avoid a server↔lifecycle
+    # import cycle at module load.
+    @asynccontextmanager
+    async def _lifespan(app):  # type: ignore[no-untyped-def]
+        from .._listen._self_peer_persistence import (
+            persist_self_peers_on_listen_startup,
+        )
+
+        await persist_self_peers_on_listen_startup()
+        tasks: list = []
+
+        # Periodic-drive listen-loop (lead a2a 7916f486, 2026-06-14).
+        # Honour SAC_PERIODIC_DRIVE_DISABLED=1 to skip launching.
+        if os.environ.get("SAC_PERIODIC_DRIVE_DISABLED", "") != "1":
+            task = asyncio.create_task(periodic_drive_loop(app.state))
+            app.state.periodic_drive_task = task
+            tasks.append(task)
+
+        # GitHub-CI verdict-delivery poll loop (sac #404, feedback.pdf §3).
+        # Self-disables (fail-loud) when `gh` is unauthenticated or
+        # SAC_GITHUB_CI_POLLER_DISABLED=1, so launch unconditionally.
+        # Cadence override: SAC_GITHUB_CI_POLL_INTERVAL_S.
+        try:
+            _ci_interval = float(
+                os.environ.get(
+                    "SAC_GITHUB_CI_POLL_INTERVAL_S", DEFAULT_CI_POLL_INTERVAL_S
+                )
+            )
+        except (TypeError, ValueError):
+            _ci_interval = DEFAULT_CI_POLL_INTERVAL_S
+        ci_task = asyncio.create_task(github_ci_poll_loop(poll_interval_s=_ci_interval))
+        app.state.github_ci_poller_task = ci_task
+        tasks.append(ci_task)
+
+        # TUI heartbeat writer (operator: "heartbeat must be available in
+        # tui as well"). Self-disables (fail-loud) when `tmux` is missing
+        # or SAC_TUI_HEARTBEAT_DISABLED=1, so launch unconditionally.
+        # Cadence override: SAC_TUI_HEARTBEAT_INTERVAL_S.
+        try:
+            _tui_hb_interval = float(
+                os.environ.get(
+                    "SAC_TUI_HEARTBEAT_INTERVAL_S", DEFAULT_TUI_HEARTBEAT_INTERVAL_S
+                )
+            )
+        except (TypeError, ValueError):
+            _tui_hb_interval = DEFAULT_TUI_HEARTBEAT_INTERVAL_S
+        tui_hb_task = asyncio.create_task(tui_heartbeat_loop(interval_s=_tui_hb_interval))
+        app.state.tui_heartbeat_task = tui_hb_task
+        tasks.append(tui_hb_task)
+
+        # FAIL-LOUD bind watchdog (operator: "when failure occurs, fail
+        # loud"). If we know the bind port, probe it shortly after startup
+        # and scream an ERROR if the daemon is up-but-not-serving — the
+        # exact silent state that took the fleet's comms down. Disable via
+        # SAC_LISTEN_BIND_WATCHDOG_DISABLED=1 (e.g. odd test harnesses).
+        if (
+            health_watchdog_port is not None
+            and os.environ.get("SAC_LISTEN_BIND_WATCHDOG_DISABLED", "") != "1"
+        ):
+            try:
+                _wd_delay = float(os.environ.get("SAC_LISTEN_BIND_WATCHDOG_DELAY_S", ""))
+            except (TypeError, ValueError):
+                _wd_delay = None
+            wd_kwargs = {"port": int(health_watchdog_port)}
+            if _wd_delay is not None:
+                wd_kwargs["delay_s"] = _wd_delay
+            wd_task = asyncio.create_task(bind_watchdog_loop(**wd_kwargs))
+            app.state.bind_watchdog_task = wd_task
+            tasks.append(wd_task)
+
+        try:
+            yield
+        finally:
+            for _t in tasks:
+                if _t is not None and not _t.done():
+                    _t.cancel()
+                    try:
+                        await _t
+                    except (asyncio.CancelledError, Exception):  # stx-allow: fallback (teardown best-effort; a loop's final exception must not block shutdown)
+                        pass
+
+    return _lifespan
+
+
+__all__ = ["build_listen_lifespan"]

--- a/src/scitex_agent_container/_lifecycle/_off_loop.py
+++ b/src/scitex_agent_container/_lifecycle/_off_loop.py
@@ -1,0 +1,110 @@
+"""Run blocking calls OFF the asyncio event loop, with a hard timeout.
+
+Root-cause guard for the silent ``sac listen`` bind hang (cards
+``sac-listen-self-peer-persist-blocks-bind`` /
+``sac-listen-watchdog-autorestart-alarm``):
+
+The listen lifespan launches its background loops via ``create_task``
+*before* uvicorn binds the port. Each loop's coroutine body runs its
+synchronous preflight (``gh auth status``, ``tmux`` probes, a registry
+walk) BEFORE its first ``await``. A synchronous ``subprocess.run`` /
+socket call on those code paths runs ON the event loop thread — so a
+hung ``gh``/``tmux``/network call starves uvicorn's own bind (which is
+also a loop task), and the daemon comes up but never serves, with NO
+error logged. A full silent fleet-comms outage.
+
+This helper makes that class of bug impossible: every blocking call a
+loop makes goes through :func:`run_blocking`, which (1) dispatches the
+call to a thread via ``run_in_executor`` so it never occupies the loop
+thread, and (2) wraps it in ``asyncio.wait_for`` so a wedged call can
+never hang forever — it raises :class:`asyncio.TimeoutError` after
+``timeout_s`` and the caller logs + degrades instead of blocking the
+fleet.
+
+Fail-loud (operator: "when failure occurs, fail loud"): a timeout is
+returned to the caller as an explicit exception (or, via
+:func:`run_blocking_or`, a sentinel default + a logged ERROR naming the
+op), never silently swallowed into an indistinguishable success.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Callable, TypeVar
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+# Default ceiling for any single off-loop blocking call made from a
+# listen background loop. A healthy ``gh``/``tmux`` probe returns in well
+# under a second; this generous floor only ever fires on a genuinely
+# wedged call (dead network, hung child) — exactly the case that used to
+# take the whole fleet's comms down.
+DEFAULT_BLOCKING_TIMEOUT_S = 5.0
+
+
+async def run_blocking(
+    fn: Callable[..., T],
+    *args: Any,
+    timeout_s: float = DEFAULT_BLOCKING_TIMEOUT_S,
+    **kwargs: Any,
+) -> T:
+    """Run a blocking ``fn(*args, **kwargs)`` off the loop, bounded.
+
+    The call is dispatched to the default thread-pool executor so it
+    never occupies the event-loop thread, and bounded by ``timeout_s``
+    via :func:`asyncio.wait_for`. Raises :class:`asyncio.TimeoutError`
+    if the call does not finish in time (the underlying thread is left
+    to finish/abandon — we do NOT join it, so a wedged child can never
+    block the loop). Any exception ``fn`` raises propagates unchanged.
+    """
+    loop = asyncio.get_running_loop()
+
+    def _call() -> T:
+        return fn(*args, **kwargs)
+
+    return await asyncio.wait_for(
+        loop.run_in_executor(None, _call), timeout=timeout_s
+    )
+
+
+async def run_blocking_or(
+    fn: Callable[..., T],
+    *args: Any,
+    default: T,
+    op: str,
+    timeout_s: float = DEFAULT_BLOCKING_TIMEOUT_S,
+    **kwargs: Any,
+) -> T:
+    """Like :func:`run_blocking` but degrade to ``default`` on timeout/error.
+
+    A timeout or an exception from ``fn`` is logged at ERROR (fail-loud:
+    the message names ``op`` and, for a timeout, the ceiling that fired)
+    and ``default`` is returned, so a single wedged probe degrades that
+    tick rather than wedging the loop. ``op`` is a short human label for
+    the operation (e.g. ``"gh auth status"``).
+    """
+    try:
+        return await run_blocking(fn, *args, timeout_s=timeout_s, **kwargs)
+    except asyncio.TimeoutError:
+        logger.error(
+            "off_loop: %s exceeded %.1fs and was abandoned (it was about to "
+            "block the listen event loop / uvicorn bind). Degrading this "
+            "call to its safe default. Hint: a hung subprocess "
+            "(gh/tmux/network) or unresponsive host is the usual cause.",
+            op,
+            timeout_s,
+        )
+        return default
+    except Exception as exc:  # stx-allow: fallback (off-loop probe failure degrades this call, never wedges the loop)
+        logger.warning("off_loop: %s failed (%s); degrading to default", op, exc)
+        return default
+
+
+__all__ = [
+    "DEFAULT_BLOCKING_TIMEOUT_S",
+    "run_blocking",
+    "run_blocking_or",
+]

--- a/src/scitex_agent_container/_lifecycle/_periodic_drive_loop.py
+++ b/src/scitex_agent_container/_lifecycle/_periodic_drive_loop.py
@@ -148,8 +148,23 @@ async def periodic_drive_loop(
                 if agents_source is not None:
                     agents = list(agents_source)
                 else:
+                    # DEFENSE IN DEPTH (cards sac-listen-self-peer-persist-
+                    # blocks-bind / sac-listen-watchdog-autorestart-alarm):
+                    # ``_agents_from_registry`` reads the registry + walks
+                    # on-disk specs (``resolve_config``/``load_config`` —
+                    # blocking FS, possibly git). Run it off the event loop
+                    # with a hard timeout so a slow/locked FS read can never
+                    # starve uvicorn's bind or the running listen server.
+                    from ._off_loop import run_blocking_or
+
                     registry = getattr(app_state, "registry", None)
-                    agents = _agents_from_registry(registry)
+                    agents = await run_blocking_or(
+                        _agents_from_registry,
+                        registry,
+                        default=[],
+                        op="periodic_drive_loop agent resolve (registry/spec FS)",
+                        timeout_s=max(tick_interval_s, 15.0),
+                    )
 
                 # Fold the loop-local last_emit_at memory into each
                 # state so the sweep's rate-limit reads the right

--- a/src/scitex_agent_container/_lifecycle/_tui_heartbeat_loop.py
+++ b/src/scitex_agent_container/_lifecycle/_tui_heartbeat_loop.py
@@ -212,8 +212,17 @@ async def tui_heartbeat_loop(
         logger.info("tui_heartbeat_loop: disabled via SAC_TUI_HEARTBEAT_DISABLED")
         return
 
+    # ROOT-CAUSE GUARD (cards sac-listen-self-peer-persist-blocks-bind /
+    # sac-listen-watchdog-autorestart-alarm): like the CI poller, this
+    # preflight and the per-tick body run BEFORE/around the first
+    # ``await`` and shell out to ``tmux`` (blocking subprocess.run) plus a
+    # registry walk. On the event loop, a hung ``tmux`` here starves
+    # uvicorn's bind. Run every blocking step off the loop with a hard
+    # timeout so a wedged probe degrades that step instead of the daemon.
+    from ._off_loop import run_blocking_or
+
     check = tmux_check if tmux_check is not None else _tmux_available
-    if not check():
+    if not await run_blocking_or(check, default=False, op="tmux preflight (which tmux)"):
         logger.error(
             "tui_heartbeat_loop: `tmux` is not installed — TUI heartbeat "
             "writing DISABLED. TUI agents will show empty heartbeat_at on "
@@ -233,17 +242,29 @@ async def tui_heartbeat_loop(
     if write_fn is None:
         from .._runners._session_state import write_heartbeat as write_fn
 
+    def _tick_body() -> None:
+        # ``lister()`` walks the registry + on-disk specs and each
+        # ``_beat_one`` probes ``tmux`` (blocking subprocess.run); run the
+        # whole tick off the event loop so a slow/hung probe never starves
+        # the listen server even after bind.
+        for agent in list(lister()):
+            _beat_one(
+                agent,
+                session_exists_fn=session_exists_fn,
+                activity_fn=activity_fn,
+                write_fn=write_fn,
+            )
+
     logger.info("tui_heartbeat_loop: starting (interval_s=%.1f)", interval_s)
     try:
         while True:
             try:
-                for agent in list(lister()):
-                    _beat_one(
-                        agent,
-                        session_exists_fn=session_exists_fn,
-                        activity_fn=activity_fn,
-                        write_fn=write_fn,
-                    )
+                await run_blocking_or(
+                    _tick_body,
+                    default=None,
+                    op="tui_heartbeat_loop tick (tmux probes)",
+                    timeout_s=max(interval_s, 15.0),
+                )
             except asyncio.CancelledError:
                 raise
             except Exception as exc:  # stx-allow: fallback (loop must survive a transient registry/tmux/FS error; logged, retried next tick)

--- a/src/scitex_agent_container/_listen/server.py
+++ b/src/scitex_agent_container/_listen/server.py
@@ -458,7 +458,12 @@ def _v1_agent_routes(prefix: str) -> list[Route]:
     ]
 
 
-def create_app(*, token: str, local_host: str | None = None) -> Starlette:
+def create_app(
+    *,
+    token: str,
+    local_host: str | None = None,
+    health_watchdog_port: int | None = None,
+) -> Starlette:
     """Build the Starlette app with bearer auth (ADR-0004 — ``/agents`` only).
 
     WI-3 wires a per-app :class:`Broker` + :class:`NodeRegistry` so
@@ -487,6 +492,13 @@ def create_app(*, token: str, local_host: str | None = None) -> Starlette:
     :func:`state_db._resolve_host` (env + config + hostname chain).
     Passing the value explicitly matters for in-process multi-host
     tests where the env is shared.
+
+    ``health_watchdog_port`` — when set (the CLI passes the port it
+    hands to ``uvicorn.run``), the lifespan launches a fail-loud bind
+    watchdog that probes ``127.0.0.1:<port>/v1/health`` shortly after
+    startup and logs a LOUD ERROR if the daemon is up-but-not-serving
+    (the silent state that took the fleet's comms down). Omitted in
+    in-process tests that never actually bind a port.
     """
     # Task #27 PR B — ACL decision routes for the in-container
     # broker. The bare-host lead writes the host's state.db directly
@@ -511,85 +523,19 @@ def create_app(*, token: str, local_host: str | None = None) -> Starlette:
     # effort (every failure logs and continues — startup MUST proceed).
     #
     # Starlette dropped the legacy ``on_startup=`` kwarg in favour of
-    # the ``lifespan`` async-context-manager API, so the persistence
-    # call goes inside an ``@asynccontextmanager`` adapter. The
-    # adapter awaits the persistence helper before yielding (= app
-    # ready), then yields control back so the server starts handling
-    # requests; teardown is a no-op (persistence is one-shot at boot).
-    from contextlib import asynccontextmanager
+    # the ``lifespan`` async-context-manager API. The lifespan — which
+    # awaits self-peer persistence, launches the three background loops
+    # (now off-loop-hardened so none can block the bind) and the
+    # fail-loud bind watchdog, then cancels them on teardown — lives in
+    # ``_lifecycle._listen_lifespan`` (extracted to keep this module
+    # under its line budget AND because it is the focal point of the
+    # silent-bind-hang fix).
+    from .._lifecycle._listen_lifespan import build_listen_lifespan
 
-    from .._lifecycle._github_ci_poll_loop import (
-        DEFAULT_CI_POLL_INTERVAL_S,
-        github_ci_poll_loop,
+    app = Starlette(
+        routes=routes,
+        lifespan=build_listen_lifespan(health_watchdog_port=health_watchdog_port),
     )
-    from .._lifecycle._periodic_drive_loop import periodic_drive_loop
-    from .._lifecycle._tui_heartbeat_loop import (
-        DEFAULT_TUI_HEARTBEAT_INTERVAL_S,
-        tui_heartbeat_loop,
-    )
-    from ._self_peer_persistence import persist_self_peers_on_listen_startup
-
-    @asynccontextmanager
-    async def _lifespan(app):  # type: ignore[no-untyped-def]
-        import asyncio as _asyncio
-        import os as _os
-
-        await persist_self_peers_on_listen_startup()
-        tasks: list = []
-        # Periodic-drive listen-loop (lead a2a 7916f486, 2026-06-14).
-        # Honour SAC_PERIODIC_DRIVE_DISABLED=1 to skip launching.
-        if _os.environ.get("SAC_PERIODIC_DRIVE_DISABLED", "") != "1":
-            task = _asyncio.create_task(periodic_drive_loop(app.state))
-            app.state.periodic_drive_task = task
-            tasks.append(task)
-        # GitHub-CI verdict-delivery poll loop (sac #404, feedback.pdf §3).
-        # The loop self-disables (fail-loud) when `gh` is unauthenticated
-        # or SAC_GITHUB_CI_POLLER_DISABLED=1, so launch unconditionally.
-        # Cadence override: SAC_GITHUB_CI_POLL_INTERVAL_S.
-        try:
-            _ci_interval = float(
-                _os.environ.get(
-                    "SAC_GITHUB_CI_POLL_INTERVAL_S", DEFAULT_CI_POLL_INTERVAL_S
-                )
-            )
-        except (TypeError, ValueError):
-            _ci_interval = DEFAULT_CI_POLL_INTERVAL_S
-        ci_task = _asyncio.create_task(
-            github_ci_poll_loop(poll_interval_s=_ci_interval)
-        )
-        app.state.github_ci_poller_task = ci_task
-        tasks.append(ci_task)
-        # TUI heartbeat writer (operator: "heartbeat must be available in
-        # tui as well"). Centralized writer so TUI agents get heartbeat.json
-        # parity with the SDK runner and stop showing empty heartbeat_at /
-        # "stopped" while alive. Self-disables (fail-loud) when `tmux` is
-        # missing or SAC_TUI_HEARTBEAT_DISABLED=1, so launch unconditionally.
-        # Cadence override: SAC_TUI_HEARTBEAT_INTERVAL_S.
-        try:
-            _tui_hb_interval = float(
-                _os.environ.get(
-                    "SAC_TUI_HEARTBEAT_INTERVAL_S", DEFAULT_TUI_HEARTBEAT_INTERVAL_S
-                )
-            )
-        except (TypeError, ValueError):
-            _tui_hb_interval = DEFAULT_TUI_HEARTBEAT_INTERVAL_S
-        tui_hb_task = _asyncio.create_task(
-            tui_heartbeat_loop(interval_s=_tui_hb_interval)
-        )
-        app.state.tui_heartbeat_task = tui_hb_task
-        tasks.append(tui_hb_task)
-        try:
-            yield
-        finally:
-            for _t in tasks:
-                if _t is not None and not _t.done():
-                    _t.cancel()
-                    try:
-                        await _t
-                    except (_asyncio.CancelledError, Exception):
-                        pass
-
-    app = Starlette(routes=routes, lifespan=_lifespan)
     # Per-app shared state for the WI-3 inbox surface.
     app.state.inbox = Broker()
     app.state.nodes = NodeRegistry()

--- a/src/scitex_agent_container/cli_pkg/listen_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/listen_cmds.py
@@ -317,7 +317,11 @@ def _do_start_listen(
     _register_self_comms_node(port=port)
     _maybe_sync_on_start()
 
-    app = create_app(token=token)
+    # Pass the bind port so the lifespan's fail-loud watchdog can probe
+    # 127.0.0.1:<port>/v1/health after startup and scream if the daemon
+    # comes up but never serves (the silent fleet-comms outage this
+    # guards against).
+    app = create_app(token=token, health_watchdog_port=port)
     import uvicorn
 
     # ``ws="none"`` skips uvicorn's websockets backend autodetection —

--- a/tests/scitex_agent_container/cli_pkg/test_listen_cmds.py
+++ b/tests/scitex_agent_container/cli_pkg/test_listen_cmds.py
@@ -229,7 +229,7 @@ def test_listen_default_loopback_bind_starts_uvicorn_with_zero_exit(tmp_path):
     with (
         _swap_attr(_tokens, "ensure_token", lambda p: "tok"),
         _swap_attr(_tokens, "default_token_path", lambda: tmp_path / "default.tok"),
-        _swap_attr(_server, "create_app", lambda token: object()),
+        _swap_attr(_server, "create_app", lambda token, **_kw: object()),
         _swap_module("uvicorn", fake_uvicorn),
     ):
         result = CliRunner().invoke(listen, [])
@@ -247,7 +247,7 @@ def test_listen_default_loopback_bind_passes_default_host_port_to_uvicorn(tmp_pa
     with (
         _swap_attr(_tokens, "ensure_token", lambda p: "tok"),
         _swap_attr(_tokens, "default_token_path", lambda: tmp_path / "default.tok"),
-        _swap_attr(_server, "create_app", lambda token: object()),
+        _swap_attr(_server, "create_app", lambda token, **_kw: object()),
         _swap_module("uvicorn", fake_uvicorn),
     ):
         CliRunner().invoke(listen, [])
@@ -265,7 +265,7 @@ def test_listen_non_loopback_bind_with_allow_flag_passes_host_to_uvicorn(tmp_pat
     with (
         _swap_attr(_tokens, "ensure_token", lambda p: "tok"),
         _swap_attr(_tokens, "default_token_path", lambda: tmp_path / "d.tok"),
-        _swap_attr(_server, "create_app", lambda token: object()),
+        _swap_attr(_server, "create_app", lambda token, **_kw: object()),
         _swap_module("uvicorn", fake_uvicorn),
     ):
         CliRunner().invoke(listen, ["--bind", "8.8.8.8:7878", "--allow-non-loopback"])


### PR DESCRIPTION
## Incident
Central `sac listen` (a2a+registry, 7878) started but never bound -> whole-fleet comms outage, **silent**. Root cause: a startup background loop ran a **blocking subprocess on the asyncio event loop**, starving uvicorn's bind. Disabling all 3 loops -> binds.

## Fix
- `_off_loop.py`: loops can't block the bind (bind first, loops after).
- `_bind_watchdog.py`: **fail-loud** ERROR if not serving within N s.
- `_listen_lifespan.py`: lifespan extracted from server.py.
- per-loop hardening.

## Verified
Patched listen binds (401) with ALL loops ENABLED; old code hung (000). Tests follow-up (worker rate-limited); empirically verified live.

Card sac-listen-self-peer-persist-blocks-bind.