### PR TITLE
fix(spawn): authenticate spawn POST + surface 401 as auth error, not 'unreachable'

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_spawn_client.py
+++ b/src/scitex_agent_container/_lifecycle/_spawn_client.py
@@ -122,18 +122,55 @@ def _resolve_base_url(explicit: str | None) -> str:
 def _resolve_bearer(explicit: str | None) -> str | None:
     """Return the listen-server bearer token, or ``None`` if unset.
 
+    Resolution order:
+
+    1. ``explicit`` argument (tests pass a value, or ``""`` to force the
+       unauthenticated branch).
+    2. ``SAC_LISTEN_BEARER`` env var — injected by the apptainer runtime
+       (:mod:`runtimes._apptainer_listen_env`) for agents whose spec
+       registers the ``server:sac`` channel.
+    3. The host bearer **token file** at
+       ``~/.scitex/agent-container/tokens/listen-<host>.token`` — the
+       same credential the listen server validates against
+       (:func:`_listen.tokens.default_token_path`). This fallback is
+       what makes :func:`request_spawn` authenticate even when the
+       spawning agent's spec did NOT include ``server:sac`` (so the
+       runtime injected only ``SAC_LISTEN_BASE_URL``, not the bearer).
+       Without it, the spawn POST goes out unauthenticated and the
+       listen server rejects it with 401 — the bug this resolver path
+       closes (card sac-agent-cannot-spawn-agents-listen-7878-...).
+
     Unlike ``SAC_LISTEN_BASE_URL``, an absent bearer is NOT fatal here:
     the listen server may have been started with bearer auth disabled,
-    in which case the request still goes through. The server enforces
-    its own auth contract; we just forward whatever credential the
-    runtime injected.
+    in which case the request still goes through unauthenticated. The
+    server enforces its own auth contract; we just forward whatever
+    credential we can resolve.
     """
     if explicit is not None:
         return explicit or None
     from .._env import getenv
 
     raw = getenv("LISTEN_BEARER", "") or ""
-    return raw.strip() or None
+    tok = raw.strip()
+    if tok:
+        return tok
+    # Env unset/empty — fall back to the on-disk host token file, the
+    # same path the listen server reads its accepted token from. The
+    # bind that exposes ``~/.scitex/agent-container`` into the container
+    # makes this readable from inside the SIF.
+    return _read_bearer_token_file()
+
+
+def _read_bearer_token_file() -> str | None:
+    """Return the host listen bearer from its token file, or ``None``.
+
+    Never raises — a missing/unreadable token file yields ``None`` so
+    the caller proceeds (and the server's 401 then surfaces as a clear
+    auth error via :func:`request_spawn`).
+    """
+    from .._listen.tokens import default_token_path, read_token
+
+    return read_token(default_token_path())
 
 
 def _resolve_caller(explicit: str | None) -> str | None:
@@ -163,6 +200,37 @@ def _parse_body(raw: bytes) -> Any:
         # to the caller via SpawnRequestError.body — never silently
         # dropped or converted into a fake success).
         return raw.decode("utf-8", errors="replace")
+
+
+def _http_error_message(child_name: str, status: int, parsed: Any) -> str:
+    """Build a status-aware error message for a non-2xx listen response.
+
+    A 401/403 means the request REACHED the listen but was refused on
+    credentials — surface that as an explicit ``auth/bearer`` problem so
+    the operator fixes the token, NOT as 'cannot reach / timed out'
+    (the misreport this card fixes). 401 = missing/invalid bearer; 403 =
+    valid bearer but the ACL gate denied the caller. Every other non-2xx
+    keeps the generic 'rejected: HTTP <code>' shape.
+    """
+    if status == 401:
+        return (
+            f"spawn of {child_name!r} rejected: listen returned HTTP 401 "
+            f"(auth/bearer) — the spawn POST reached the host listen but "
+            f"the bearer token was missing or invalid. Ensure "
+            f"SAC_LISTEN_BEARER is injected, or that the host token file "
+            f"~/.scitex/agent-container/tokens/listen-<host>.token is "
+            f"readable from inside the container. Server said: {parsed!r}"
+        )
+    if status == 403:
+        return (
+            f"spawn of {child_name!r} rejected: listen returned HTTP 403 "
+            f"(auth/acl) — the bearer authenticated but the listen's "
+            f"check_spawn ACL denied this caller. Server said: {parsed!r}"
+        )
+    return (
+        f"spawn of {child_name!r} rejected: listen returned HTTP "
+        f"{status} ({parsed!r})"
+    )
 
 
 def request_spawn(
@@ -279,8 +347,9 @@ def request_spawn(
             raw = resp.read()
             status = int(getattr(resp, "status", 200))
     except urlerror.HTTPError as exc:
-        # Non-2xx — read the body if any so the caller sees the
-        # server's reason verbatim (ACL deny carries it).
+        # A real HTTP response arrived — the listen is REACHABLE, this is
+        # NOT a transport failure. Read the body so the caller sees the
+        # server's reason verbatim (ACL deny / auth error carry it).
         raw_body = b""
         try:
             raw_body = exc.read() or b""
@@ -294,12 +363,16 @@ def request_spawn(
             parsed,
         )
         raise SpawnRequestError(
-            f"spawn of {child_name!r} rejected: listen returned HTTP "
-            f"{exc.code} ({parsed!r})",
+            _http_error_message(child_name, exc.code, parsed),
             status=exc.code,
             body=parsed,
         ) from exc
     except (urlerror.URLError, OSError, ValueError) as exc:
+        # No HTTP exchange happened — connection refused / DNS / timeout.
+        # This (and only this) is a genuine "unreachable" condition. A
+        # 401/403 is NOT routed here: ``HTTPError`` (a URLError subclass)
+        # is caught above first, so an authenticated-but-rejected request
+        # never gets misreported as 'cannot reach / timed out'.
         logger.warning("spawn_client: POST %s transport error: %s", url, exc)
         raise SpawnRequestError(
             f"spawn of {child_name!r} failed: cannot reach listen at {base!r} ({exc})"
@@ -317,8 +390,7 @@ def request_spawn(
             parsed,
         )
         raise SpawnRequestError(
-            f"spawn of {child_name!r} rejected: listen returned HTTP "
-            f"{status} ({parsed!r})",
+            _http_error_message(child_name, status, parsed),
             status=status,
             body=parsed,
         )

--- a/tests/scitex_agent_container/_lifecycle/test__spawn_client.py
+++ b/tests/scitex_agent_container/_lifecycle/test__spawn_client.py
@@ -91,17 +91,27 @@ _LISTEN_KEYS = (
 
 
 @pytest.fixture
-def listen_env() -> Iterator[callable]:
+def listen_env(tmp_path) -> Iterator[callable]:
     """Yield a setter; clears + restores both prefixes for every key.
 
     Tests call ``set("LISTEN_BASE_URL", "http://h:9100")`` etc. — the
     SAC_ short form is written so :func:`_env.getenv` resolves it.
+
+    HOME is also redirected to a clean ``tmp_path`` for the duration of
+    the test (saved + restored), so the bearer file-fallback in
+    :func:`_resolve_bearer` reads from an isolated, empty tokens dir —
+    never the operator's real
+    ``~/.scitex/agent-container/tokens/listen-<host>.token``. Tests that
+    want the file-fallback to fire write the token under
+    ``tmp_path/.scitex/agent-container/tokens/`` themselves.
     """
     saved = {k: os.environ.get(k) for k in _LISTEN_KEYS}
+    saved_home = os.environ.get("HOME")
     # Always start from a clean slate so a stray export in the operator's
     # shell can't make a "must fail" test silently pass.
     for k in _LISTEN_KEYS:
         os.environ.pop(k, None)
+    os.environ["HOME"] = str(tmp_path)
 
     def _set(suffix: str, value: str | None) -> None:
         long_form = f"SCITEX_AGENT_CONTAINER_{suffix}"
@@ -121,6 +131,10 @@ def listen_env() -> Iterator[callable]:
         for k, prev in saved.items():
             if prev is not None:
                 os.environ[k] = prev
+        if saved_home is not None:
+            os.environ["HOME"] = saved_home
+        else:
+            os.environ.pop("HOME", None)
 
 
 # ---------------------------------------------------------------------------
@@ -289,7 +303,9 @@ def test_bearer_token_attached_as_authorization_header(listen_env) -> None:
 
 
 def test_no_authorization_header_when_bearer_unset(listen_env) -> None:
-    # Arrange — no bearer in env, none passed explicitly.
+    # Arrange — no bearer in env, none passed explicitly, AND no on-disk
+    # token file (listen_env redirects HOME to a clean tmp dir): the
+    # file-fallback finds nothing, so the request goes out unauthenticated.
     listen_env("LISTEN_BASE_URL", "http://host:9100")
     opener, captured = _opener_returning(b'{"name":"c","returncode":0}')
     # Act
@@ -439,3 +455,143 @@ def test_explicit_base_url_arg_overrides_env(listen_env) -> None:
     request_spawn("c", base_url="http://arg-host:9100", opener=opener)
     # Assert
     assert captured["url"] == "http://arg-host:9100/agents"
+
+
+# ---------------------------------------------------------------------------
+# Bearer file-fallback (card sac-agent-cannot-spawn-agents-listen-7878-...):
+# when SAC_LISTEN_BEARER is unset (the spawning agent's spec lacked the
+# server:sac channel so the runtime injected only the base URL), the spawn
+# POST must still authenticate by reading the host token file the listen
+# server validates against. Real bytes on disk, no mocks.
+# ---------------------------------------------------------------------------
+
+
+def _write_host_token_file(home, token: str) -> None:
+    """Write a real listen token file under ``home`` for the local host."""
+    from scitex_agent_container._listen.tokens import default_token_path
+
+    path = default_token_path(home=home)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(token, encoding="utf-8")
+
+
+def test_bearer_falls_back_to_host_token_file_when_env_unset(
+    listen_env, tmp_path
+) -> None:
+    # Arrange — no bearer env; a real token file exists under the
+    # (tmp) HOME the listen_env fixture redirected to.
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    _write_host_token_file(tmp_path, "file-tok-xyz")
+    opener, captured = _opener_returning(b'{"name":"c","returncode":0}')
+    # Act
+    request_spawn("c", opener=opener)
+    # Assert — the on-disk token authenticates the spawn POST.
+    assert captured["headers"].get("authorization") == "Bearer file-tok-xyz"
+
+
+def test_env_bearer_takes_precedence_over_token_file(listen_env, tmp_path) -> None:
+    # Arrange — both the env var and the file are present; env wins.
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    listen_env("LISTEN_BEARER", "env-tok")
+    _write_host_token_file(tmp_path, "file-tok")
+    opener, captured = _opener_returning(b'{"name":"c","returncode":0}')
+    # Act
+    request_spawn("c", opener=opener)
+    # Assert
+    assert captured["headers"].get("authorization") == "Bearer env-tok"
+
+
+# ---------------------------------------------------------------------------
+# 401 is REACHABLE-but-rejected, NOT 'unreachable / timed out' (the core
+# misreport this card fixes). Mirrors #463's real-loopback transport test:
+# a genuine TCP server that always 401s — no mock/monkeypatch.
+# ---------------------------------------------------------------------------
+
+
+def test_real_loopback_401_surfaces_auth_error_not_unreachable(listen_env) -> None:
+    # Arrange — a real loopback HTTP server that always 401s, exactly like
+    # the bearer-auth gate when no/invalid token is presented.
+    import http.server
+    import threading
+
+    class _Handler(http.server.BaseHTTPRequestHandler):
+        def do_POST(self):  # noqa: N802
+            self.send_response(401)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(b'{"error":"missing bearer token"}')
+
+        def log_message(self, *_args):  # silence test noise
+            return
+
+    server = http.server.HTTPServer(("127.0.0.1", 0), _Handler)
+    host, port = server.server_address
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    listen_env("LISTEN_BASE_URL", f"http://{host}:{port}")
+    message = ""
+    # Act — default opener (real urllib round-trip), no injected fake.
+    try:
+        request_spawn("c", bearer="", timeout_s=2.0)
+    except SpawnRequestError as exc:
+        message = str(exc)
+    finally:
+        server.shutdown()
+        thread.join(timeout=2.0)
+    # Assert — a reachable 401 reads as an auth/bearer problem, never as
+    # 'cannot reach' (the bug). The word 'auth' anchors the new message.
+    assert "auth" in message and "cannot reach" not in message
+
+
+def test_real_loopback_401_carries_status_401(listen_env) -> None:
+    # Arrange — same real 401 server; the structured status must be 401.
+    import http.server
+    import threading
+
+    class _Handler(http.server.BaseHTTPRequestHandler):
+        def do_POST(self):  # noqa: N802
+            self.send_response(401)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(b'{"error":"missing bearer token"}')
+
+        def log_message(self, *_args):
+            return
+
+    server = http.server.HTTPServer(("127.0.0.1", 0), _Handler)
+    host, port = server.server_address
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    listen_env("LISTEN_BASE_URL", f"http://{host}:{port}")
+    status: object = "UNSET"
+    # Act
+    try:
+        request_spawn("c", bearer="", timeout_s=2.0)
+    except SpawnRequestError as exc:
+        status = exc.status
+    finally:
+        server.shutdown()
+        thread.join(timeout=2.0)
+    # Assert
+    assert status == 401
+
+
+def test_real_connection_failure_surfaces_unreachable(listen_env) -> None:
+    # Arrange — bind a loopback socket, grab its port, then close it so
+    # the port is (almost certainly) refused: a GENUINE transport failure,
+    # which MUST read as 'cannot reach' (unlike the 401 above).
+    import socket
+
+    probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    probe.bind(("127.0.0.1", 0))
+    _h, dead_port = probe.getsockname()
+    probe.close()
+    listen_env("LISTEN_BASE_URL", f"http://127.0.0.1:{dead_port}")
+    message = ""
+    # Act — default opener; the connection is refused.
+    try:
+        request_spawn("c", bearer="", timeout_s=2.0)
+    except SpawnRequestError as exc:
+        message = str(exc)
+    # Assert — only a real transport failure says 'cannot reach'.
+    assert "cannot reach listen" in message


### PR DESCRIPTION
## Summary

`agent_spawn` from inside a container POSTs to the host listen at `http://127.0.0.1:7878/agents`. The listen is reachable (a loopback `curl` returns **401** in milliseconds — alive, bearer-gated), but the spawn client reported the failure as `cannot reach listen ... timed out`. Same false-negative class as the #463 listen-restart health-check bug (a 401 read as "down").

Root causes + fixes in `_lifecycle/_spawn_client.py`:

1. **Bearer not sent.** When the spawning agent's spec lacked the `server:sac` channel, the apptainer runtime injected only `SAC_LISTEN_BASE_URL`, not `SAC_LISTEN_BEARER`, so the POST went out unauthenticated → 401. `_resolve_bearer` now falls back to the on-disk host token file `~/.scitex/agent-container/tokens/listen-<host>.token` (the same credential the listen server validates against) when the env var is unset.

2. **401/403 misreported as transport failure.** A 401/403 now produces an explicit `auth/bearer` (401) / `auth/acl` (403) error message. Only a genuine transport failure (connection refused / DNS / timeout) says `cannot reach listen`. `HTTPError` is a `URLError` subclass and is caught first, so a reachable 401 is never routed to the transport-error branch.

The misreporting line fixed: `_spawn_client.py` — the `except (URLError, OSError, ValueError)` branch raising `... cannot reach listen at {base!r} ...`, which a 401 must never reach.

`SAC_LISTEN_BASE_URL` is left at loopback `127.0.0.1:7878` (correct + reachable; the hostname interface is loopback-only-bind refused — not regressed).

## Test plan

No mocks (STX-NM002); real loopback `http.server` like #463's `test__restart_bearer_auth.py`.

- [x] spawn POST attaches `Authorization: Bearer <token>` from the host token file when env is unset
- [x] env bearer takes precedence over the token file
- [x] a real loopback 401 surfaces an `auth` error, NOT `cannot reach`
- [x] a real loopback 401 carries `status == 401`
- [x] a real refused port surfaces `cannot reach listen`
- [x] full `test__spawn_client.py` (28 passed) + `test__in_sif_broker.py` / `test__in_sif_http_client.py` (34 passed) — no regression

No auto-merge — maintainer reviews.