### PR TITLE
harden(listen): systemd watchdog — Restart=always + health-probe + loud alarm

### DIFF
--- a/scripts/systemd/README.md
+++ b/scripts/systemd/README.md
@@ -24,30 +24,81 @@ operator-started ad-hoc and could be found DOWN with nothing
 restarting it.
 
 ```bash
-# Install the unit (operator copies, then enables)
+# Install BOTH the listen unit and its health watchdog (preferred —
+# copies units + probe script, daemon-reload, enable --now, status):
+scripts/systemd/install-sac-listen.sh
+
+# Or by hand (listen unit only — does NOT install the watchdog):
 cp scripts/systemd/sac-listen.service ~/.config/systemd/user/
 systemctl --user daemon-reload
 systemctl --user enable --now sac-listen.service
 
 # Verify
 systemctl --user status sac-listen.service
+systemctl --user list-timers sac-listen-health.timer
 journalctl --user -u sac-listen.service -n 50
+journalctl --user -u sac-listen-health.service -n 50   # LOUD restart/alarm lines
 
 # Healthcheck (echos the same /v1/health the unit's diagnostic
-# stderr names at boot)
+# stderr names at boot — and the same URL the watchdog probes)
 curl -s http://127.0.0.1:7878/v1/health   # → {"ok":true,"service":"sac-listen","v":1}
 
-# Disable / remove
-systemctl --user disable --now sac-listen.service
-rm ~/.config/systemd/user/sac-listen.service
-systemctl --user daemon-reload
+# Disable / remove (preferred — removes units + watchdog + probe)
+scripts/systemd/install-sac-listen.sh --uninstall
 ```
 
 ### Restart policy + companion guards
 
-* `Type=simple` + `Restart=on-failure` + `RestartSec=5s`. Brief
-  debounce so a launch that always fails (e.g. bad pip upgrade
-  surfaced as ImportError) doesn't hot-loop.
+* `Type=simple` + `Restart=always` + `RestartSec=5s`. Brief debounce
+  so a launch that always fails (e.g. bad pip upgrade surfaced as
+  ImportError) doesn't hot-loop. **Incident 2026-06-26** upgraded this
+  from `Restart=on-failure` to `Restart=always`: a clean 0-exit (e.g.
+  an unexpected SIGTERM that uvicorn turns into a graceful shutdown)
+  was NOT covered by `on-failure`, and that is exactly how the fleet
+  lost a2a comms silently with nothing restarting the listen.
+  `StartLimitIntervalSec=60s` / `StartLimitBurst=5` (in `[Unit]`)
+  rate-limit a permanently-broken launch so it can't spin forever; the
+  health watchdog clears the resulting `failed` state and keeps trying.
+* **Decoupled from agent/lead lifecycle.** The unit declares NO
+  `After=`/`Requires=`/`BindsTo=`/`PartOf=` against any agent or lead
+  unit — only `After=network.target`. Retiring, restarting, or
+  crashing any agent (or the lead) must NEVER take the listen down;
+  it is fleet infrastructure.
+
+### Health watchdog — sac-listen-health.{service,timer}
+
+`Restart=always` only sees a *process exit*. A **wedged** listen
+(process alive, port still bound, but the HTTP server no longer
+answering `/v1/health`) is invisible to systemd — and that silent
+mode is what the 2026-06-26 incident punished the fleet with. The
+companion watchdog closes the gap:
+
+* `sac-listen-health.timer` fires `sac-listen-health.service` every
+  ~30s (`OnBootSec=30s`, `OnUnitActiveSec=30s`).
+* `sac-listen-health.service` (oneshot) runs
+  `sac-listen-health-probe.sh`, which HTTP-probes
+  `http://127.0.0.1:7878/v1/health`. "Up" == *any* HTTP response
+  (incl. a 401/403 under bearer auth); only a transport failure
+  (connection refused / timeout) counts as "down" — the same
+  auth-change-proof liveness contract as
+  `_listen/_restart.py::wait_for_health`.
+* On a down probe the script:
+  1. logs a **LOUD ERROR** to the journal (`journalctl --user -u
+     sac-listen-health`) so the restart is VISIBLE, not silent;
+  2. best-effort emits the anomaly on the operator alarm path
+     (`sac fleet notify blocker`) — this may fail (the listen is the
+     transport for that notify), but is tried so a peer/lead listen or
+     a recovered inbox still surfaces it;
+  3. runs `systemctl --user reset-failed && restart sac-listen.service`
+     (the `reset-failed` clears a tripped `StartLimitBurst` so a
+     transient burst self-heals while a genuine hard-down stays
+     visible).
+* The watchdog is itself decoupled — it does NOT `Requires=`/`After=`
+  the listen (it must run and alarm precisely when the listen is
+  down), and the timer is enabled independently.
+* Tunables via env on the probe: `SAC_LISTEN_HEALTH_URL`,
+  `SAC_LISTEN_UNIT`, `SAC_LISTEN_PROBE_TIMEOUT`, `SAC_LISTEN_NOTIFY`.
+  `--check-only` probes without any side effects (used by tests).
 * The companion `_listen/_single_instance.py` flock guard (task
   #26 sub (1)) ensures `Restart=on-failure` can't double-bind the
   port. The kernel releases the flock on every dirty exit, so the

--- a/scripts/systemd/install-sac-listen.sh
+++ b/scripts/systemd/install-sac-listen.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# install-sac-listen.sh — install the sac listen control-plane unit AND
+# its health watchdog into the systemd-user manager.
+#
+# Installs, into ~/.config/systemd/user/:
+#   sac-listen.service          the control plane (Restart=always)
+#   sac-listen-health.service   the oneshot health probe
+#   sac-listen-health.timer     fires the probe every ~30s
+#   sac-listen-health-probe.sh  the probe script the .service runs
+#
+# Then daemon-reload, enable --now both the listen and the timer, and
+# print status. Idempotent: re-running re-copies the latest unit text
+# and re-enables.
+#
+# Incident 2026-06-26: the listen died with NO unit installed (nothing
+# restarted it) and NO alarm. Running this script is what guarantees a
+# restart + a LOUD alarm on the next failure.
+#
+# Usage:
+#   scripts/systemd/install-sac-listen.sh            # install + enable + status
+#   scripts/systemd/install-sac-listen.sh --uninstall  # disable + remove
+set -euo pipefail
+
+SRC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEST_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
+
+LISTEN_UNIT="sac-listen.service"
+HEALTH_SERVICE="sac-listen-health.service"
+HEALTH_TIMER="sac-listen-health.timer"
+PROBE_SCRIPT="sac-listen-health-probe.sh"
+
+log() { printf '%s\n' "$*" >&2; }
+
+uninstall() {
+  log "# Disabling + removing sac listen units from ${DEST_DIR}"
+  systemctl --user disable --now "$HEALTH_TIMER" >/dev/null 2>&1 || true
+  systemctl --user disable --now "$LISTEN_UNIT" >/dev/null 2>&1 || true
+  rm -f "${DEST_DIR}/${LISTEN_UNIT}" \
+        "${DEST_DIR}/${HEALTH_SERVICE}" \
+        "${DEST_DIR}/${HEALTH_TIMER}" \
+        "${DEST_DIR}/${PROBE_SCRIPT}"
+  systemctl --user daemon-reload
+  log "# Removed. Verify: systemctl --user list-unit-files 'sac-listen*'"
+}
+
+if [ "${1:-}" = "--uninstall" ]; then
+  uninstall
+  exit 0
+fi
+
+if [ "${1:-}" != "" ]; then
+  log "usage: $0 [--uninstall]"
+  exit 2
+fi
+
+mkdir -p "$DEST_DIR"
+
+# 1. Copy the probe script first (the health .service ExecStart points
+#    at the installed copy) and make it executable.
+install -m 0755 "${SRC_DIR}/${PROBE_SCRIPT}" "${DEST_DIR}/${PROBE_SCRIPT}"
+log "# Installed ${DEST_DIR}/${PROBE_SCRIPT}"
+
+# 2. Copy the listen unit and the health timer verbatim.
+install -m 0644 "${SRC_DIR}/${LISTEN_UNIT}" "${DEST_DIR}/${LISTEN_UNIT}"
+install -m 0644 "${SRC_DIR}/${HEALTH_TIMER}" "${DEST_DIR}/${HEALTH_TIMER}"
+log "# Installed ${DEST_DIR}/${LISTEN_UNIT}"
+log "# Installed ${DEST_DIR}/${HEALTH_TIMER}"
+
+# 3. Copy the health .service, rewriting the ExecStart %h-relative path
+#    to the concrete installed probe path. %h works at runtime too, but
+#    pinning the absolute path avoids any ambiguity if XDG_CONFIG_HOME
+#    is non-default.
+sed "s#^ExecStart=.*#ExecStart=${DEST_DIR}/${PROBE_SCRIPT}#" \
+    "${SRC_DIR}/${HEALTH_SERVICE}" > "${DEST_DIR}/${HEALTH_SERVICE}"
+chmod 0644 "${DEST_DIR}/${HEALTH_SERVICE}"
+log "# Installed ${DEST_DIR}/${HEALTH_SERVICE} (ExecStart -> ${DEST_DIR}/${PROBE_SCRIPT})"
+
+# 4. Reload, enable + start both the listen and the watchdog timer.
+systemctl --user daemon-reload
+systemctl --user enable --now "$LISTEN_UNIT"
+systemctl --user enable --now "$HEALTH_TIMER"
+log "# Enabled + started ${LISTEN_UNIT} and ${HEALTH_TIMER}"
+
+# 5. Status for the operator.
+log ""
+log "# ---- status: ${LISTEN_UNIT} ----"
+systemctl --user status "$LISTEN_UNIT" --no-pager || true
+log ""
+log "# ---- timer: ${HEALTH_TIMER} ----"
+systemctl --user list-timers "$HEALTH_TIMER" --no-pager || true
+log ""
+log "# Health endpoint:"
+log "#   curl -s http://127.0.0.1:7878/v1/health"
+log "# Watchdog journal (LOUD restart/alarm lines land here):"
+log "#   journalctl --user -u ${HEALTH_SERVICE} -n 50"

--- a/scripts/systemd/sac-listen-health-probe.sh
+++ b/scripts/systemd/sac-listen-health-probe.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# sac-listen-health-probe.sh — fleet-infrastructure watchdog for the
+# central `sac listen` (a2a + registry control plane, default
+# 127.0.0.1:7878).
+#
+# Incident 2026-06-26: the listen died mid-session with NO auto-restart
+# and NO alarm, so the whole fleet lost agent-to-agent comms SILENTLY.
+# systemd's own Restart=always covers a *process exit*, but a listen
+# that is wedged (process alive, port bound, but the HTTP server no
+# longer answering /v1/health) is invisible to systemd. This probe
+# closes that gap: it HTTP-probes the health endpoint and, on failure,
+#   1. logs a LOUD ERROR (journal, via stderr — the timer unit routes
+#      both streams to `journalctl --user -u sac-listen-health`),
+#   2. restarts `sac-listen.service` (clearing any `failed` state first
+#      so a tripped StartLimit self-heals),
+#   3. best-effort emits the anomaly on the operator alarm path
+#      (`sac fleet notify blocker`) so the restart is VISIBLE, not
+#      silent.
+#
+# Run by `sac-listen-health.timer` every ~30s. Also runnable by hand:
+#
+#   scripts/systemd/sac-listen-health-probe.sh            # probe+heal
+#   scripts/systemd/sac-listen-health-probe.sh --check-only   # probe, no side effects
+#
+# Exit codes:
+#   0  healthy (or, in heal mode, a restart was issued successfully)
+#   1  unhealthy (in --check-only) / restart attempt failed (heal mode)
+#   2  usage error
+#
+# Env overrides (all optional):
+#   SAC_LISTEN_HEALTH_URL   default http://127.0.0.1:7878/v1/health
+#   SAC_LISTEN_UNIT         default sac-listen.service
+#   SAC_LISTEN_PROBE_TIMEOUT  curl --max-time seconds, default 5
+#   SAC_LISTEN_NOTIFY       1 (default) to attempt `sac fleet notify`,
+#                           0 to skip (used by tests / non-lead hosts)
+#
+# No mocks (STX-NM002): the probe talks to a REAL HTTP endpoint over a
+# REAL socket; tests stand up a real local HTTP server and assert the
+# real curl-based classification.
+set -uo pipefail
+
+HEALTH_URL="${SAC_LISTEN_HEALTH_URL:-http://127.0.0.1:7878/v1/health}"
+LISTEN_UNIT="${SAC_LISTEN_UNIT:-sac-listen.service}"
+PROBE_TIMEOUT="${SAC_LISTEN_PROBE_TIMEOUT:-5}"
+NOTIFY_ENABLED="${SAC_LISTEN_NOTIFY:-1}"
+
+CHECK_ONLY=0
+case "${1:-}" in
+  --check-only) CHECK_ONLY=1 ;;
+  "" ) ;;
+  -h|--help)
+    sed -n '2,40p' "$0"
+    exit 0
+    ;;
+  *)
+    echo "usage: $0 [--check-only]" >&2
+    exit 2
+    ;;
+esac
+
+# probe_health URL TIMEOUT -> 0 if the daemon answered with ANY HTTP
+# status (incl. 401/403 under bearer auth — the daemon is up and
+# auth-gating), 1 if the transport failed (connection refused / DNS /
+# timeout). This mirrors the liveness contract in
+# `_listen/_restart.py::wait_for_health`: "got an HTTP response" == up,
+# only a transport failure == down. That is auth-change-proof: a future
+# decision to bearer-gate /v1/health must NOT make the watchdog SIGKILL
+# a live, 401-answering daemon.
+probe_health() {
+  local url="$1" timeout="$2" code
+  # -s silent, -o /dev/null discard body, -w '%{http_code}' print the
+  # numeric status, --max-time bound the whole request. curl exits
+  # non-zero on a transport failure and prints "000" as the code.
+  code="$(curl -s -o /dev/null -w '%{http_code}' --max-time "$timeout" "$url" 2>/dev/null)"
+  local rc=$?
+  if [ "$rc" -ne 0 ]; then
+    return 1
+  fi
+  # "000" == curl reached no HTTP layer (e.g. connection refused that
+  # still returned rc 0 on some curl builds). Treat as down.
+  if [ -z "$code" ] || [ "$code" = "000" ]; then
+    return 1
+  fi
+  return 0
+}
+
+if probe_health "$HEALTH_URL" "$PROBE_TIMEOUT"; then
+  # Quiet on the happy path — a healthy 30s probe should NOT spam the
+  # journal. Operators tail for the LOUD line below.
+  exit 0
+fi
+
+# --- UNHEALTHY ------------------------------------------------------------
+
+ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+if [ "$CHECK_ONLY" -eq 1 ]; then
+  echo "sac-listen-health: UNHEALTHY ${HEALTH_URL} (no HTTP response) at ${ts}" >&2
+  exit 1
+fi
+
+# LOUD ERROR — this is the line that makes a restart VISIBLE in the
+# journal. Prefixed ERROR + the incident reference so a `journalctl`
+# grep finds it.
+echo "ERROR: sac-listen DOWN — ${HEALTH_URL} did not answer (transport failure)." >&2
+echo "ERROR: sac-listen watchdog is RESTARTING ${LISTEN_UNIT} at ${ts}." >&2
+echo "ERROR: incident-class=sac-listen-watchdog-autorestart-alarm; fleet a2a comms were interrupted." >&2
+
+# Best-effort operator alarm. The listen is the transport for
+# `sac fleet notify`, so this MAY fail (the listen is down). We still
+# try: (a) if only the HTTP layer wedged but the inbox path recovers,
+# or (b) if a peer/lead listen on another host receives it. Failure is
+# logged but does NOT change the restart outcome.
+if [ "$NOTIFY_ENABLED" = "1" ] && command -v sac >/dev/null 2>&1; then
+  if sac fleet notify blocker \
+      --from-agent "sac-listen-watchdog" \
+      --summary "sac listen DOWN — watchdog restarting ${LISTEN_UNIT}" \
+      --detail "health probe to ${HEALTH_URL} failed at ${ts}; fleet a2a comms interrupted. Auto-restart in progress." \
+      >/dev/null 2>&1; then
+    echo "sac-listen-health: alarm pushed via 'sac fleet notify blocker'." >&2
+  else
+    echo "WARN: sac-listen-health: 'sac fleet notify blocker' failed (expected if the listen itself is the down transport)." >&2
+  fi
+fi
+
+# Restart. `reset-failed` first so a tripped StartLimitBurst (the unit
+# entered `failed` after 5 restarts/60s) is cleared and `restart` can
+# proceed — otherwise systemd refuses with "start request repeated too
+# quickly".
+restart_rc=0
+if command -v systemctl >/dev/null 2>&1; then
+  systemctl --user reset-failed "$LISTEN_UNIT" >/dev/null 2>&1 || true
+  if systemctl --user restart "$LISTEN_UNIT"; then
+    echo "sac-listen-health: issued 'systemctl --user restart ${LISTEN_UNIT}'." >&2
+  else
+    restart_rc=$?
+    echo "ERROR: sac-listen-health: 'systemctl --user restart ${LISTEN_UNIT}' FAILED (rc=${restart_rc})." >&2
+  fi
+else
+  echo "ERROR: sac-listen-health: systemctl not found; cannot restart ${LISTEN_UNIT}." >&2
+  restart_rc=1
+fi
+
+exit "$restart_rc"

--- a/scripts/systemd/sac-listen-health.service
+++ b/scripts/systemd/sac-listen-health.service
@@ -1,0 +1,30 @@
+[Unit]
+Description=sac listen health watchdog — probe /v1/health, restart + alarm on failure
+Documentation=https://github.com/ywatanabe1989/scitex-agent-container
+# Companion to sac-listen.service. Oneshot probe fired by
+# sac-listen-health.timer every ~30s. DECOUPLED from any agent/lead
+# lifecycle (it is fleet infrastructure). We do NOT bind it to
+# sac-listen.service with Requires=/After= because the probe must run
+# and ALARM even when sac-listen.service is down/failed — that is the
+# whole point. The probe issues its own `systemctl --user restart
+# sac-listen.service`, so a dependency edge would be circular.
+#
+# Incident 2026-06-26: the listen died with no restart and no alarm.
+# This watchdog catches a WEDGED listen (process alive but HTTP no
+# longer answering) that systemd's Restart=always can't see, and makes
+# every restart LOUD.
+
+[Service]
+Type=oneshot
+# %h expands to the user's home; the unit ships at install time with
+# this path so the probe is found regardless of cwd. install-sac-listen.sh
+# rewrites this line to the operator's actual checkout path so the
+# installed unit does not depend on a fixed clone location.
+ExecStart=%h/.config/systemd/user/sac-listen-health-probe.sh
+# Route both streams to the journal so the LOUD ERROR lines from the
+# probe land in `journalctl --user -u sac-listen-health`.
+StandardOutput=journal
+StandardError=journal
+# A wedged-restart cycle should never itself hang the timer; bound the
+# whole probe (curl --max-time is 5s, restart is fast).
+TimeoutStartSec=60s

--- a/scripts/systemd/sac-listen-health.timer
+++ b/scripts/systemd/sac-listen-health.timer
@@ -1,0 +1,20 @@
+[Unit]
+Description=Fire the sac listen health watchdog every ~30s
+Documentation=https://github.com/ywatanabe1989/scitex-agent-container
+# Fleet infrastructure — decoupled from agent/lead lifecycle. See
+# sac-listen-health.service for the rationale.
+
+[Timer]
+# First probe 30s after boot/login so the listen has time to bind, then
+# every 30s thereafter. AccuracySec=5s keeps the cadence tight (the
+# default 1min accuracy would let systemd batch the probe up to a
+# minute late, widening the detection window).
+OnBootSec=30s
+OnUnitActiveSec=30s
+AccuracySec=5s
+# If the machine was asleep/off when a probe was due, fire once on
+# resume rather than skipping silently.
+Persistent=false
+
+[Install]
+WantedBy=timers.target

--- a/scripts/systemd/sac-listen.service
+++ b/scripts/systemd/sac-listen.service
@@ -6,6 +6,26 @@ Documentation=https://github.com/ywatanabe1989/scitex-agent-container
 # default and serves the local agent fleet; ``network.target`` is
 # enough.
 After=network.target
+# DECOUPLE from any agent/lead lifecycle. sac listen is FLEET
+# INFRASTRUCTURE (the a2a + registry control plane). Retiring,
+# restarting, or crashing any individual agent — or the lead — must
+# NEVER take this unit down. We therefore declare NO After=/Requires=/
+# BindsTo=/PartOf= against any agent/lead/scope unit. The only
+# dependency is the network stack above. Incident 2026-06-26: the
+# listen died mid-session with nothing restarting it and the whole
+# fleet lost a2a comms silently; the hardening below (Restart=always +
+# the companion sac-listen-health.timer) closes that gap.
+#
+# Rate-limit the restart loop so a permanently-broken launch (bad pip
+# upgrade -> ImportError on every start) does NOT spin forever burning
+# CPU. If the unit restarts >5 times in 60s systemd gives up and
+# enters `failed`; the companion sac-listen-health.timer then fires
+# its LOUD alarm AND runs `systemctl reset-failed && restart` so a
+# transient burst self-heals while a genuine hard-down stays visible
+# to the operator. (These two keys belong in [Unit] in modern
+# systemd; only legacy systemd honoured them under [Service].)
+StartLimitIntervalSec=60s
+StartLimitBurst=5
 
 [Service]
 Type=simple
@@ -25,11 +45,18 @@ StandardOutput=journal
 StandardError=journal
 
 # Restart policy — the operator task brief: "auto-start on boot and
-# auto-restart on crash, with a healthcheck". The flock-backed
-# single-instance guard (operator task #26 sub (1)) ensures that
-# Restart=on-failure can't double-bind the port; the kernel releases
-# the flock on every dirty exit, so the next start cleanly takes it.
-Restart=on-failure
+# auto-restart on crash, with a healthcheck". Incident 2026-06-26
+# upgraded this from Restart=on-failure to Restart=always: a listen
+# that exits 0 for ANY reason (a clean uvicorn shutdown triggered by
+# an unexpected SIGTERM, a bug that returns 0 on a fatal path, an
+# operator `kill` that the process turns into a graceful exit) must
+# STILL come back. Restart=on-failure does NOT cover a 0-exit, which
+# is exactly how the fleet lost a2a comms silently. Restart=always
+# covers every non-`systemctl stop` exit. The flock-backed
+# single-instance guard (operator task #26 sub (1)) ensures the
+# restart can't double-bind the port; the kernel releases the flock
+# on every dirty exit, so the next start cleanly takes it.
+Restart=always
 # Brief debounce: avoid hot-looping a launch that always fails (e.g.
 # uvicorn import error after a bad pip upgrade). 5s is the same
 # value scitex-orochi's persistent-services use.

--- a/tests/integration/test_sac_listen_health_probe.py
+++ b/tests/integration/test_sac_listen_health_probe.py
@@ -33,7 +33,7 @@ import pytest
 
 # --- locate the shipped scripts -------------------------------------------
 
-_REPO_ROOT = Path(__file__).resolve().parents[3]
+_REPO_ROOT = Path(__file__).resolve().parents[2]
 _SYSTEMD_DIR = _REPO_ROOT / "scripts" / "systemd"
 _PROBE = _SYSTEMD_DIR / "sac-listen-health-probe.sh"
 _INSTALL = _SYSTEMD_DIR / "install-sac-listen.sh"

--- a/tests/scitex_agent_container/scripts/test_sac_listen_health_probe.py
+++ b/tests/scitex_agent_container/scripts/test_sac_listen_health_probe.py
@@ -1,0 +1,328 @@
+"""Behavioural tests for the sac listen health watchdog + its units.
+
+Incident 2026-06-26: the central ``sac listen`` died mid-session with
+NO auto-restart and NO alarm, so the fleet lost a2a comms silently.
+The hardening adds:
+
+* ``scripts/systemd/sac-listen.service`` — ``Restart=always`` decoupled
+  from agent/lead lifecycle.
+* ``scripts/systemd/sac-listen-health-probe.sh`` — HTTP-probes
+  ``/v1/health``; on failure logs a LOUD ERROR, alarms, and restarts.
+* ``scripts/systemd/sac-listen-health.{service,timer}`` — fire the
+  probe every ~30s.
+* ``scripts/systemd/install-sac-listen.sh`` — install path.
+
+No mocks (STX-NM002): the probe is exercised against a REAL local HTTP
+server bound to a REAL ephemeral port over a REAL socket. The "down"
+case points the probe at a closed port (real connection refused). The
+unit-file assertions parse the REAL shipped files. AAA markers (TQ002);
+3+-word test names.
+"""
+
+from __future__ import annotations
+
+import http.server
+import os
+import shutil
+import socket
+import subprocess
+import threading
+from pathlib import Path
+
+import pytest
+
+# --- locate the shipped scripts -------------------------------------------
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SYSTEMD_DIR = _REPO_ROOT / "scripts" / "systemd"
+_PROBE = _SYSTEMD_DIR / "sac-listen-health-probe.sh"
+_INSTALL = _SYSTEMD_DIR / "install-sac-listen.sh"
+_SERVICE = _SYSTEMD_DIR / "sac-listen.service"
+_HEALTH_SERVICE = _SYSTEMD_DIR / "sac-listen-health.service"
+_HEALTH_TIMER = _SYSTEMD_DIR / "sac-listen-health.timer"
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("curl") is None,
+    reason="sac-listen-health-probe.sh requires curl",
+)
+
+
+# --- real-HTTP-server fixture ---------------------------------------------
+
+
+class _QuietHandler(http.server.BaseHTTPRequestHandler):
+    """Answers /v1/health with the real listen health shape; silent log."""
+
+    def do_GET(self):  # noqa: N802 (http.server API)
+        body = b'{"ok": true, "service": "sac-listen", "v": 1}'
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *_args):  # silence the default stderr spam
+        return
+
+
+@pytest.fixture()
+def live_health_server():
+    """Start a real HTTP server on an ephemeral loopback port; yield URL."""
+    server = http.server.HTTPServer(("127.0.0.1", 0), _QuietHandler)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{port}/v1/health"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def _free_port() -> int:
+    """Grab then release a port so nothing is listening on it."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def _run_probe(*args: str, env_extra: dict[str, str] | None = None):
+    env = os.environ.copy()
+    # Never let a test accidentally fire the operator alarm.
+    env["SAC_LISTEN_NOTIFY"] = "0"
+    if env_extra:
+        env.update(env_extra)
+    return subprocess.run(
+        ["bash", str(_PROBE), *args],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def _down_env() -> dict[str, str]:
+    """Env pointing the probe at a real closed port (connection refused)."""
+    return {
+        "SAC_LISTEN_HEALTH_URL": f"http://127.0.0.1:{_free_port()}/v1/health",
+        "SAC_LISTEN_PROBE_TIMEOUT": "2",
+    }
+
+
+# --- probe: check-only classification -------------------------------------
+
+
+def test_check_only_passes_against_live_server(live_health_server):
+    # Arrange
+    env = {"SAC_LISTEN_HEALTH_URL": live_health_server}
+    # Act
+    result = _run_probe("--check-only", env_extra=env)
+    # Assert
+    assert result.returncode == 0
+
+
+def test_check_only_fails_against_dead_port():
+    # Arrange
+    env = _down_env()
+    # Act
+    result = _run_probe("--check-only", env_extra=env)
+    # Assert
+    assert result.returncode == 1
+
+
+def test_check_only_down_logs_unhealthy_line():
+    # Arrange
+    env = _down_env()
+    # Act
+    result = _run_probe("--check-only", env_extra=env)
+    # Assert
+    assert "UNHEALTHY" in result.stderr
+
+
+def test_check_only_healthy_is_quiet(live_health_server):
+    # Arrange
+    env = {"SAC_LISTEN_HEALTH_URL": live_health_server}
+    # Act
+    result = _run_probe("--check-only", env_extra=env)
+    # Assert
+    assert result.stderr.strip() == ""
+
+
+# --- probe: heal-mode loudness (no real systemctl needed) -----------------
+
+
+def test_heal_mode_down_emits_loud_error():
+    # Arrange
+    env = _down_env()
+    env["SAC_LISTEN_UNIT"] = "sac-listen-nonexistent-test.service"
+    # Act
+    result = _run_probe(env_extra=env)
+    # Assert
+    assert "ERROR: sac-listen DOWN" in result.stderr
+
+
+def test_heal_mode_logs_restart_intent():
+    # Arrange
+    env = _down_env()
+    env["SAC_LISTEN_UNIT"] = "sac-listen-nonexistent-test.service"
+    # Act
+    result = _run_probe(env_extra=env)
+    # Assert
+    assert "RESTARTING" in result.stderr
+
+
+def test_heal_mode_healthy_does_not_restart(live_health_server):
+    # Arrange
+    env = {"SAC_LISTEN_HEALTH_URL": live_health_server}
+    # Act
+    result = _run_probe(env_extra=env)
+    # Assert
+    assert result.returncode == 0 and "RESTARTING" not in result.stderr
+
+
+def test_usage_error_on_bad_arg():
+    # Arrange
+    args = ("--bogus",)
+    # Act
+    result = _run_probe(*args)
+    # Assert
+    assert result.returncode == 2
+
+
+# --- probe + install: shell syntax ----------------------------------------
+
+
+def test_probe_script_has_valid_bash_syntax():
+    # Arrange
+    cmd = ["bash", "-n", str(_PROBE)]
+    # Act
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    # Assert
+    assert result.returncode == 0, result.stderr
+
+
+def test_install_script_has_valid_bash_syntax():
+    # Arrange
+    cmd = ["bash", "-n", str(_INSTALL)]
+    # Act
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    # Assert
+    assert result.returncode == 0, result.stderr
+
+
+# --- unit-file lint --------------------------------------------------------
+
+
+def _kv_pairs(text: str) -> dict[str, str]:
+    """Flatten a unit file to last-wins key=value (ignoring comments)."""
+    out: dict[str, str] = {}
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or line.startswith("["):
+            continue
+        if "=" in line:
+            k, _, v = line.partition("=")
+            out[k.strip()] = v.strip()
+    return out
+
+
+def test_listen_unit_restarts_always():
+    # Arrange
+    kv = _kv_pairs(_SERVICE.read_text())
+    # Act
+    restart = kv.get("Restart")
+    # Assert
+    assert restart == "always"
+
+
+def test_listen_unit_has_restart_debounce():
+    # Arrange
+    kv = _kv_pairs(_SERVICE.read_text())
+    # Act
+    restart_sec = kv.get("RestartSec")
+    # Assert
+    assert restart_sec == "5s"
+
+
+def _directive_lines(text: str) -> list[str]:
+    """Non-comment, non-section unit-file lines (the actual directives)."""
+    return [
+        ln.strip()
+        for ln in text.splitlines()
+        if ln.strip()
+        and not ln.strip().startswith("#")
+        and not ln.strip().startswith("[")
+    ]
+
+
+def test_listen_unit_is_decoupled_from_agents():
+    # Arrange
+    lines = _directive_lines(_SERVICE.read_text())
+    # Act — scan only real directives, not the explanatory comments.
+    offenders = [
+        ln
+        for ln in lines
+        if ln.startswith(("Requires=", "BindsTo=", "PartOf="))
+    ]
+    # Assert
+    assert offenders == []
+
+
+def test_listen_unit_only_orders_after_network():
+    # Arrange
+    text = _SERVICE.read_text()
+    # Act
+    afters = [
+        line.split("=", 1)[1].strip()
+        for line in text.splitlines()
+        if line.strip().startswith("After=")
+    ]
+    # Assert
+    assert afters == ["network.target"]
+
+
+def test_health_timer_fires_periodically():
+    # Arrange
+    kv = _kv_pairs(_HEALTH_TIMER.read_text())
+    # Act
+    has_periodic = "OnUnitActiveSec" in kv
+    # Assert
+    assert has_periodic
+
+
+def test_health_service_is_oneshot():
+    # Arrange
+    kv = _kv_pairs(_HEALTH_SERVICE.read_text())
+    # Act
+    service_type = kv.get("Type")
+    # Assert
+    assert service_type == "oneshot"
+
+
+def test_health_service_execstart_names_probe():
+    # Arrange
+    kv = _kv_pairs(_HEALTH_SERVICE.read_text())
+    # Act
+    exec_start = kv.get("ExecStart", "")
+    # Assert
+    assert "sac-listen-health-probe.sh" in exec_start
+
+
+def test_health_units_decoupled_from_listen():
+    # Arrange
+    svc = _HEALTH_SERVICE.read_text()
+    # Act
+    has_hard_dep = "Requires=sac-listen.service" in svc
+    # Assert
+    assert not has_hard_dep
+
+
+def test_probe_script_is_executable():
+    # Arrange
+    mode = _PROBE.stat().st_mode
+    # Act
+    is_exec = bool(mode & 0o111)
+    # Assert
+    assert is_exec, "probe script must be executable"


### PR DESCRIPTION
## Incident
The central `sac listen` (a2a+registry, 7878) died mid-session with NO auto-restart + NO alarm -> silent whole-fleet comms outage. No systemd unit was installed.

## Hardening
- `sac-listen.service`: `Restart=on-failure` -> **`Restart=always`** (on-failure missed clean 0-exit, which is how it died); StartLimit rate-limit; documented decoupling from any agent/lead (only After=network.target).
- `sac-listen-health-probe.sh` + `.service`/`.timer` (~30s): probes /v1/health; on failure logs LOUD ERROR, emits operator alarm (`sac fleet notify blocker`), restarts the unit. Decoupled so it alarms precisely when the listen is down.
- `install-sac-listen.sh` (+`--uninstall`).
- 19 no-mock tests pass; systemd-analyze verify clean.

Card sac-listen-watchdog-autorestart-alarm. NOTE: uses correct /v1/health (flagged that _restart.py polls a non-existent /v1/sac/health — folding into the restart-selfheal PR).