### PR TITLE
fix(spawn): forward SCITEX_AGENT_CONTAINER_YAML_DIRS into agent containers

### DIFF
--- a/src/scitex_agent_container/runtimes/_apptainer_listen_env.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_listen_env.py
@@ -37,18 +37,40 @@ logger = logging.getLogger(__name__)
 
 
 def listen_env_flags(config) -> list[str]:
-    """Return the ``--env SAC_LISTEN_*`` flags for ``apptainer exec``.
+    """Return the ``--env`` flags ``apptainer exec`` needs for the bus.
 
-    Pure except for reading the host token file and config; raises
-    ``RuntimeError`` when a ``server:sac`` spec has no resolvable bearer.
+    Forwards the bus-listen URL + bearer (``SAC_LISTEN_*``) and, when set
+    on the host, the agent-spec search path
+    (``SCITEX_AGENT_CONTAINER_YAML_DIRS``) so an in-container ``sac agents
+    start <peer>`` resolves specs at the SAME path the operator uses on
+    the host. Without this forward the in-container sac only searches
+    ``~/.scitex/agent-container/agents`` + the repo-local dir (the env var
+    is unset inside the container), so the spec-bearing spawn path fails
+    with ``Agent '<name>' not found ... (env
+    $SCITEX_AGENT_CONTAINER_YAML_DIRS: <unset>)`` even though the specs
+    are visible in-container via the host-home bind.
+
+    Pure except for reading the host token file, config, and host env;
+    raises ``RuntimeError`` when a ``server:sac`` spec has no resolvable
+    bearer.
     """
     # Local imports keep these resolvable even if a formatter strips
     # module-level unused imports during a refactor, and avoid a circular
     # import with the runtime module that calls this helper.
+    import os
+
     from .._listen._config import listen_base_url
     from ._apptainer_build import _listen_token_path, _read_listen_bearer
 
     flags: list[str] = ["--env", f"SAC_LISTEN_BASE_URL={listen_base_url()}"]
+
+    # Forward the host's agent-spec search path so the in-container sac
+    # resolves peer specs at the operator's path. Only inject when the
+    # host has it set+non-empty — otherwise leave the in-container default
+    # search order untouched (no empty ``--env`` that would shadow it).
+    spec_dirs = os.environ.get("SCITEX_AGENT_CONTAINER_YAML_DIRS", "").strip()
+    if spec_dirs:
+        flags += ["--env", f"SCITEX_AGENT_CONTAINER_YAML_DIRS={spec_dirs}"]
 
     claude_spec = getattr(config, "claude", None)
     channels = list(getattr(claude_spec, "channels", None) or [])

--- a/tests/scitex_agent_container/runtimes/test__apptainer_runtime.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_runtime.py
@@ -2169,6 +2169,123 @@ def test_config_listen_host_propagates_to_env(tmp_path: Path, env_save_restore) 
 
 
 # ---------------------------------------------------------------------------
+# Spec-dir forwarding — SCITEX_AGENT_CONTAINER_YAML_DIRS must be forwarded
+# from the host env into the spawned container so an in-container
+# ``sac agents start <peer>`` resolves peer specs at the operator's path
+# (else the spec-bearing spawn path fails with "Agent not found ... (env
+# $SCITEX_AGENT_CONTAINER_YAML_DIRS: <unset>)"). Unset/empty on the host
+# must NOT inject the flag (leave the in-container default search order).
+# ---------------------------------------------------------------------------
+
+
+def test_spec_dirs_forwarded_when_set_on_host(
+    tmp_path: Path, env_save_restore
+) -> None:
+    # Arrange — host has the agent-spec search path exported.
+    spec_path = "/home/ywatanabe/.dotfiles/src/.scitex/agent-container/agents"
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_YAML_DIRS", spec_path)
+    rt = ApptainerContainerRuntime()
+    cfg = _config(tmp_path / "wd")
+    # Act
+    argv = rt.build_run_argv(
+        cfg, state_dir=tmp_path / "state", sif_path=tmp_path / "x.sif"
+    )
+    # Assert — the value is forwarded verbatim as an --env pair.
+    assert _env_pairs(argv).get("SCITEX_AGENT_CONTAINER_YAML_DIRS") == spec_path
+
+
+def test_spec_dirs_forwarded_preserves_colon_separated_list(
+    tmp_path: Path, env_save_restore
+) -> None:
+    # Arrange — colon-separated multi-dir path must round-trip intact.
+    spec_path = "/host/a/agents:/host/b/agents"
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_YAML_DIRS", spec_path)
+    rt = ApptainerContainerRuntime()
+    cfg = _config(tmp_path / "wd")
+    # Act
+    argv = rt.build_run_argv(
+        cfg, state_dir=tmp_path / "state", sif_path=tmp_path / "x.sif"
+    )
+    # Assert
+    assert _env_pairs(argv).get("SCITEX_AGENT_CONTAINER_YAML_DIRS") == spec_path
+
+
+def test_spec_dirs_not_forwarded_when_unset_on_host(
+    tmp_path: Path, env_save_restore
+) -> None:
+    # Arrange — host does NOT have the env var (delete any inherited one).
+    env_save_restore.delete("SCITEX_AGENT_CONTAINER_YAML_DIRS")
+    rt = ApptainerContainerRuntime()
+    cfg = _config(tmp_path / "wd")
+    # Act
+    argv = rt.build_run_argv(
+        cfg, state_dir=tmp_path / "state", sif_path=tmp_path / "x.sif"
+    )
+    # Assert — no flag injected → in-container default search order kept.
+    assert "SCITEX_AGENT_CONTAINER_YAML_DIRS" not in _env_pairs(argv)
+
+
+def test_spec_dirs_not_forwarded_when_empty_on_host(
+    tmp_path: Path, env_save_restore
+) -> None:
+    # Arrange — set to empty/whitespace; must be treated as unset, not
+    # injected as an empty --env that would shadow the default order.
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_YAML_DIRS", "   ")
+    rt = ApptainerContainerRuntime()
+    cfg = _config(tmp_path / "wd")
+    # Act
+    argv = rt.build_run_argv(
+        cfg, state_dir=tmp_path / "state", sif_path=tmp_path / "x.sif"
+    )
+    # Assert
+    assert "SCITEX_AGENT_CONTAINER_YAML_DIRS" not in _env_pairs(argv)
+
+
+def test_listen_env_flags_forwards_spec_dirs_value(env_save_restore) -> None:
+    # Arrange — exercise the helper directly (unit seam, no container).
+    from scitex_agent_container.runtimes._apptainer_listen_env import (
+        listen_env_flags,
+    )
+
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_YAML_DIRS", "/host/agents")
+    cfg = _config(Path("/tmp/wd"))
+    # Act
+    flags = listen_env_flags(cfg)
+    # Assert — the value rides in the flag list.
+    assert "SCITEX_AGENT_CONTAINER_YAML_DIRS=/host/agents" in flags
+
+
+def test_listen_env_flags_spec_dirs_pair_is_contiguous(env_save_restore) -> None:
+    # Arrange — the value must be preceded by its --env flag so apptainer
+    # parses it as one env pair, not a bare positional.
+    from scitex_agent_container.runtimes._apptainer_listen_env import (
+        listen_env_flags,
+    )
+
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_YAML_DIRS", "/host/agents")
+    cfg = _config(Path("/tmp/wd"))
+    # Act
+    flags = listen_env_flags(cfg)
+    # Assert
+    idx = flags.index("SCITEX_AGENT_CONTAINER_YAML_DIRS=/host/agents")
+    assert flags[idx - 1] == "--env"
+
+
+def test_listen_env_flags_omits_spec_dirs_when_unset(env_save_restore) -> None:
+    # Arrange
+    from scitex_agent_container.runtimes._apptainer_listen_env import (
+        listen_env_flags,
+    )
+
+    env_save_restore.delete("SCITEX_AGENT_CONTAINER_YAML_DIRS")
+    cfg = _config(Path("/tmp/wd"))
+    # Act
+    flags = listen_env_flags(cfg)
+    # Assert — no spec-dir value anywhere in the flag list.
+    assert not any("SCITEX_AGENT_CONTAINER_YAML_DIRS" in f for f in flags)
+
+
+# ---------------------------------------------------------------------------
 # Bus-auth bearer injection (FIX 1) — SAC_LISTEN_BEARER must be injected
 # into EVERY apptainer spec (including relaxed:true), read from the host
 # token file the listen server writes. Missing token → BASE_URL only +


### PR DESCRIPTION
## Summary
- Fixes the `agent_start` half of the in-container spawn bug: an agent that shells `sac agents start <peer>` from inside a container could not resolve the peer's `spec.yaml` because `$SCITEX_AGENT_CONTAINER_YAML_DIRS` is unset inside the container. sac only searched `~/.scitex/agent-container/agents` + the repo-local dir and failed with `Agent '<name>' not found ... (env $SCITEX_AGENT_CONTAINER_YAML_DIRS: <unset>)`, even though the host specs are visible in-container via the home bind.
- Forwards the host's `SCITEX_AGENT_CONTAINER_YAML_DIRS` into the spawned container's `--env` list, alongside the existing `SAC_LISTEN_*` forwarding in `listen_env_flags` (`src/scitex_agent_container/runtimes/_apptainer_listen_env.py`). Injected only when set + non-empty on the host; empty/unset is left untouched so the in-container default search order is preserved.
- Does not touch `SAC_LISTEN_BASE_URL` / `SAC_LISTEN_BEARER` or the spawn client — the spawn-bearer half already landed via #470.

## Test plan
- [x] `test_spec_dirs_forwarded_when_set_on_host` — value forwarded as `--env` pair end-to-end through `build_run_argv`.
- [x] `test_spec_dirs_forwarded_preserves_colon_separated_list` — colon-separated multi-dir path round-trips intact.
- [x] `test_spec_dirs_not_forwarded_when_unset_on_host` — no flag when host env unset.
- [x] `test_spec_dirs_not_forwarded_when_empty_on_host` — whitespace-only treated as unset.
- [x] `test_listen_env_flags_forwards_spec_dirs_value` / `_pair_is_contiguous` / `_omits_spec_dirs_when_unset` — unit-level helper assertions.
- [x] No mocks (STX-NM002); real `env_save_restore` fixture drives the host env.
- [x] Full `test__apptainer_runtime.py` module green (178 passed), including the 18 existing `SAC_LISTEN_*` / bearer tests (no regressions).

Card: sac-agent-cannot-spawn-agents-listen-7878-unreachable-20260625 (the agent_start / spec-dir half).