### PR TITLE
harden(listen): self-healing `sac listen restart` + `status` verb + /v1/health probe fix

### DIFF
--- a/src/scitex_agent_container/_listen/_port_holder.py
+++ b/src/scitex_agent_container/_listen/_port_holder.py
@@ -1,0 +1,272 @@
+"""Port-holder discovery + self-heal for the ``sac listen`` restart.
+
+The incident this serves (card ``sac-listen-restart-selfheal-cli``,
+2026-06-26): a wedged ``sac listen`` remnant was still **bound to the
+port** but never answered HTTP — ``curl`` hung forever. The flock
+pidfile only names the *tracked* daemon; this remnant was UNtracked
+(or the operator had already ``rm``-ed the pidfile), so the recovery
+needs a pidfile-independent way to find and kill whatever holds the
+port. That manual surgery was ``lsof``/``pkill``/``setsid`` by hand —
+this module is its deterministic codification.
+
+Responsibilities (all pure-stdlib + external-tool, NO new dep):
+
+1. :func:`port_is_bound` — a socket TCP-connect probe. The *trigger*:
+   "is anything holding this port right now?" A half-dead uvicorn that
+   accepts the connection but never replies still shows as bound here.
+
+2. :func:`port_holder_pids` — resolve the holding PID(s) via
+   ``lsof`` → ``ss`` → ``fuser`` (whichever is installed). Empty list
+   when no tool finds a holder, so the caller can fail loud rather
+   than guess.
+
+3. :func:`clear_wedged_port_holders` — the self-heal: probe, resolve,
+   force-kill, re-probe; loud :class:`PortHealResult.error` if the
+   port stays held.
+
+4. :func:`diagnose_unhealthy` — name the REAL cause when a relaunched
+   daemon is not serving (``port still held by PID X`` vs
+   ``bind failed``).
+
+The process-termination primitive (``terminate_fn``) and ``sleep_fn``
+are passed in by the caller (``_restart``) rather than imported, to
+avoid a circular dependency and keep the SIGTERM→SIGKILL escalation +
+its test seams owned by ``_restart``. The two discovery seams
+(``_probe_bound`` / ``_resolve_pids``) live here and are swapped via a
+save/restore context manager in tests (PA-306 / STX-NM001-003 — no
+MagicMock).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import socket
+import subprocess
+from dataclasses import dataclass
+from typing import Callable
+
+__all__ = [
+    "PortHealResult",
+    "clear_wedged_port_holders",
+    "diagnose_unhealthy",
+    "port_holder_pids",
+    "port_is_bound",
+]
+
+# Test seam — mirrors ``_restart._run_subprocess``.
+_run_subprocess: Callable[..., subprocess.CompletedProcess] = subprocess.run
+
+
+def port_is_bound(host: str, port: int, *, timeout: float = 1.0) -> bool:
+    """Return ``True`` iff *something* is listening on ``host:port``.
+
+    A pure-socket TCP connect — no dependency, no external tool. A
+    wedged remnant that accepts the connection but never answers HTTP
+    still shows up here as "bound". ``127.0.0.1`` is substituted for a
+    wildcard ``0.0.0.0`` / ``::`` bind so an all-interfaces listener is
+    still detected on loopback. Refused / timeout → ``False``.
+    """
+    probe_host = "127.0.0.1" if host in ("", "0.0.0.0", "::") else host
+    try:
+        with socket.create_connection((probe_host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+_LSOF_PID_RE = re.compile(r"^p(\d+)$")
+_SS_PID_RE = re.compile(r"pid=(\d+)")
+
+
+def port_holder_pids(port: int) -> list[int]:
+    """Return the PIDs of processes LISTENING on TCP ``port``.
+
+    Tries ``lsof`` first (most precise: filters to LISTEN), then ``ss``
+    and finally ``fuser``. An absent tool (``FileNotFoundError``) or a
+    non-zero / error exit advances to the next. Empty list when no tool
+    finds a holder. The own-PID is never included.
+    """
+    self_pid = os.getpid()
+    for finder in (_lsof_pids, _ss_pids, _fuser_pids):
+        try:
+            pids = finder(port)
+        except (FileNotFoundError, OSError, subprocess.SubprocessError):
+            continue
+        found = sorted({p for p in pids if p > 0 and p != self_pid})
+        if found:
+            return found
+    return []
+
+
+def _lsof_pids(port: int) -> list[int]:
+    """``lsof -nP -iTCP:<port> -sTCP:LISTEN -Fp`` → listening PIDs.
+
+    ``-F p`` machine-readable output emits one ``p<pid>`` line per
+    holder. ``-sTCP:LISTEN`` avoids grabbing a transient client socket
+    on the same port number.
+    """
+    proc = _run_subprocess(
+        ["lsof", "-nP", f"-iTCP:{port}", "-sTCP:LISTEN", "-Fp"],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=5.0,
+    )
+    pids: list[int] = []
+    for line in (proc.stdout or "").splitlines():
+        m = _LSOF_PID_RE.match(line.strip())
+        if m:
+            pids.append(int(m.group(1)))
+    return pids
+
+
+def _ss_pids(port: int) -> list[int]:
+    """``ss -ltnpH 'sport = :<port>'`` → listening PIDs.
+
+    The ``users:(("proc",pid=1234,fd=7))`` column carries the PID; we
+    extract every ``pid=<n>``.
+    """
+    proc = _run_subprocess(
+        ["ss", "-ltnpH", f"sport = :{port}"],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=5.0,
+    )
+    return [int(m) for m in _SS_PID_RE.findall(proc.stdout or "")]
+
+
+def _fuser_pids(port: int) -> list[int]:
+    """``fuser <port>/tcp`` → PIDs (last-resort, coarsest).
+
+    Output is ``<port>/tcp:   <pid> <pid> ...`` — the PIDs follow the
+    colon, and the ``<port>/tcp:`` prefix carries the port number which
+    must NOT be mistaken for a PID. We take only the text AFTER the
+    last colon on each line and parse bare integers there. Lines with
+    no colon (rare/odd builds) are parsed whole. Prints to stdout
+    (newer builds) or stderr; we read both. Coarser than ``lsof``/``ss``
+    (no LISTEN vs ESTABLISHED distinction) so it is tried last.
+    """
+    proc = _run_subprocess(
+        ["fuser", f"{port}/tcp"],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=5.0,
+    )
+    pids: list[int] = []
+    for line in (f"{proc.stdout or ''}\n{proc.stderr or ''}").splitlines():
+        after = line.rsplit(":", 1)[-1] if ":" in line else line
+        pids.extend(int(tok) for tok in re.findall(r"\d+", after))
+    return pids
+
+
+# Discovery seams — swapped on THIS module in tests so the self-heal
+# can be driven without a real listener (and so a test never probes /
+# kills the live central listen on the dev host's 7878).
+_probe_bound: Callable[[str, int], bool] = port_is_bound
+_resolve_pids: Callable[[int], list[int]] = port_holder_pids
+
+
+@dataclass(frozen=True)
+class PortHealResult:
+    """Outcome of the wedged-port-holder self-heal step.
+
+    ``killed`` is the PID(s) force-killed off the port. ``error`` is
+    non-empty ONLY when the port is still bound but we could neither
+    name a holder nor free it — a loud, actionable failure rather than
+    a silent relaunch into ``EADDRINUSE``.
+    """
+
+    killed: tuple[int, ...] = ()
+    error: str = ""
+
+
+def clear_wedged_port_holders(
+    *,
+    host: str,
+    port: int,
+    grace_secs: float,
+    force: bool,
+    terminate_fn: Callable[..., bool],
+    sleep_fn: Callable[[float], None],
+    poll_interval: float,
+) -> PortHealResult:
+    """Free the port from an UNtracked wedged remnant ("curl hangs").
+
+    Called AFTER the pidfile-tracked daemon is stopped. Socket-probe
+    the port; if free, no-op. If bound, resolve the holding PID(s) and
+    force-kill each via ``terminate_fn`` (``force`` → SIGKILL, else
+    TERM→KILL), then re-probe. A still-bound port — or a bound port
+    with no resolvable holder — returns a LOUD
+    :attr:`PortHealResult.error` so the caller fails loud instead of
+    relaunching into ``EADDRINUSE``. Pure-logic + injected seams;
+    never raises.
+    """
+    if not _probe_bound(host, port):
+        return PortHealResult()
+
+    holders = _resolve_pids(port)
+    if not holders:
+        return PortHealResult(
+            error=(
+                f"port {port} is still held but no holding PID could be "
+                f"resolved (no lsof/ss/fuser, or it lists no PID). "
+                f"Refusing to relaunch into EADDRINUSE — inspect with "
+                f"`sudo lsof -iTCP:{port} -sTCP:LISTEN`."
+            )
+        )
+
+    killed: list[int] = []
+    for pid in holders:
+        terminate_fn(pid, grace_secs=grace_secs, force_kill=force)
+        killed.append(pid)
+
+    sleep_fn(poll_interval)  # let the kernel reap the socket, then re-probe
+    if _probe_bound(host, port):
+        survivors = _resolve_pids(port) or killed
+        survivor_str = ", ".join(str(p) for p in survivors)
+        return PortHealResult(
+            killed=tuple(killed),
+            error=(
+                f"port {port} still held by PID {survivor_str} after "
+                f"force-kill — the holder is unkillable from this user "
+                f"(zombie / different uid / uninterruptible). Inspect "
+                f"manually; may need `sudo kill -9 {survivor_str}`."
+            ),
+        )
+    return PortHealResult(killed=tuple(killed))
+
+
+def diagnose_unhealthy(
+    *, host: str, port: int, deadline_secs: float, health_path: str
+) -> str:
+    """Name the REAL reason a freshly-relaunched daemon is not healthy.
+
+    A restart that can't bring the daemon up must fail loud with the
+    actual cause, not a generic "did not respond". Probe the port:
+
+    * Port IS bound but health never answered → up-but-not-serving (a
+      holder wedged on the socket). This is the exact state
+      ``_lifecycle/_bind_watchdog.py`` (PR #469) alarms on from inside
+      the daemon; we name the holding PID(s) for one-``kill`` recovery.
+    * Port is NOT bound → the relaunched ``sac listen`` never bound
+      (startup crash / bind failed). Point at the listen log.
+    """
+    if _probe_bound(host, port):
+        holders = _resolve_pids(port)
+        who = ", ".join(str(p) for p in holders) if holders else "unknown"
+        return (
+            f"ERROR: port {port} still held by PID {who} but {health_path} "
+            f"never answered within {deadline_secs}s — the daemon is UP but "
+            f"NOT SERVING (wedged on the socket). This is the silent-outage "
+            f"mode `_lifecycle/_bind_watchdog.py` alarms on. Retry "
+            f"`sac listen restart --force` to SIGKILL PID {who}."
+        )
+    return (
+        f"ERROR: bind failed — nothing is listening on {host}:{port} after "
+        f"relaunch and {health_path} never answered within {deadline_secs}s. "
+        f"The new `sac listen` did not bind (startup crash / port grab race). "
+        f"Check the listen log for the bind error."
+    )

--- a/src/scitex_agent_container/_listen/_restart.py
+++ b/src/scitex_agent_container/_listen/_restart.py
@@ -12,27 +12,36 @@ Codifies the manual SIGTERM-hang recovery dance documented in
 4. Clear the stale pidfile (after verifying via ``kill -0`` that the
    named PID is actually dead — protects against killing a recycled
    PID).
-5. Relaunch. If a systemd-user unit exists AND is enabled, prefer
+5. **Self-heal a wedged port holder** (incident 2026-06-26, card
+   ``sac-listen-restart-selfheal-cli``): after the pidfile path, if
+   the port is STILL bound by an UNtracked remnant (a half-dead
+   uvicorn that ``curl`` hangs on; pidfile may already be ``rm``-ed),
+   discover + force-kill the holder. See :mod:`._port_holder` and
+   :func:`clear_wedged_port_holders` for the mechanism — this codifies
+   the manual ``pkill``/``setsid`` recovery.
+6. Relaunch. If a systemd-user unit exists AND is enabled, prefer
    ``systemctl --user daemon-reload && systemctl --user restart
    sac-listen`` (handles a changed unit file). Otherwise direct
    ``sac listen`` subprocess spawn.
-6. Verify on ``/v1/sac/health`` with a bounded poll loop. Fail loud
-   if the new daemon doesn't come up.
+7. Verify on ``/v1/health`` with a bounded poll loop. **Fail loud**
+   if the daemon doesn't come up — the error names the REAL cause
+   (``port still held by PID X`` / ``bind failed``), not a generic
+   "did not respond". Aligns with ``_lifecycle/_bind_watchdog.py``
+   (PR #469), which logs the same fail-loud ERROR for an
+   up-but-not-serving daemon — both close the silent-outage door from
+   opposite ends.
 
 Design calls locked by lead (msg ``c3cbf269f74c41e28ab37bb1e4be5cee``):
+(a) bind resolution mirrors ``sac listen`` (caller passes host+port;
+this module is bind-agnostic); (b) prefer systemd — ``daemon-reload``
+before ``restart``; (c) loud WARN on SIGKILL escalation, silent on
+clean TERM; (d) no ``sac dev systemd restart`` abstraction — strictly
+under ``sac listen restart``.
 
-  (a) Bind resolution mirrors ``sac listen`` — caller passes the
-      host+port that ``sac listen`` would resolve to; this module is
-      bind-agnostic.
-  (b) Prefer systemd — ``daemon-reload`` before ``restart`` so a
-      changed unit file picks up.
-  (c) Loud WARN on SIGKILL escalation — silent on clean TERM.
-  (d) No ``sac dev systemd restart`` abstraction — strictly under
-      ``sac listen restart``.
-
-Pure-logic module — no click. Tests swap the module-level injection
-points (``_kill``, ``_sleep``, ``_run_subprocess``, ``_http_get``)
-via a save/restore context manager, no MagicMock.
+Pure-logic module — no click. Tests swap the module-level seams
+(``_kill``, ``_sleep``, ``_run_subprocess``, ``_http_get``) here, and
+the port-holder seams on :mod:`._port_holder`, via a save/restore
+context manager, no MagicMock.
 """
 
 from __future__ import annotations
@@ -45,6 +54,14 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable
 
+from ._port_holder import (
+    PortHealResult,
+    clear_wedged_port_holders,
+    diagnose_unhealthy,
+    port_holder_pids,
+    port_is_bound,
+)
+
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
@@ -53,6 +70,15 @@ DEFAULT_GRACE_SECS: float = 10.0
 _POLL_INTERVAL_SECS: float = 0.2
 _HEALTH_POLL_INTERVAL_SECS: float = 0.5
 DEFAULT_HEALTH_DEADLINE_SECS: float = 30.0
+
+# The ONLY registered liveness route. ``_listen.server`` registers the
+# ``health`` handler at ``/v1/health`` (see its routing table) — there
+# is no ``/v1/sac/health`` route. The probe previously hit the latter
+# and only "worked" because ``wait_for_health`` treats any HTTP
+# response (incl. the 404) as alive; the URL was wrong + brittle.
+# Single source of truth so the probe + the bind-watchdog
+# (``_lifecycle/_bind_watchdog.py``) and tests can't drift.
+HEALTH_PATH: str = "/v1/health"
 
 DEFAULT_SYSTEMD_UNIT_PATH: Path = (
     Path.home() / ".config" / "systemd" / "user" / "sac-listen.service"
@@ -73,23 +99,12 @@ _run_subprocess: Callable[..., subprocess.CompletedProcess] = subprocess.run
 def _default_http_get(url: str, timeout: float) -> int:
     """Return the HTTP status for a GET, or -1 if the server is *down*.
 
-    Uses stdlib ``urllib`` rather than ``httpx`` to keep the restart
-    path dep-light — if uvicorn binds the port, urllib reaches it.
-
-    Critically, an HTTP error *response* (401/403/404/5xx) is NOT a
-    failure for liveness purposes — it PROVES a daemon is bound and
-    answering. ``urllib`` raises :class:`~urllib.error.HTTPError`
-    (a subclass of ``URLError``) for any 4xx/5xx and carries the real
-    status code on ``.code`` — so we surface that code rather than
-    collapsing it to ``-1``. Only a genuine transport failure
-    (connection refused / DNS / timeout — a bare ``URLError`` with no
-    status, or ``OSError``) means "down" and returns ``-1``.
-
-    This is the fix for the bearer-auth false-negative
-    (card ``sac-listen-restart-healthcheck-bearer``): when
-    ``BearerAuthMiddleware`` gates the endpoint, the probe's
-    unauthenticated GET gets a 401 — which used to be swallowed as
-    ``-1`` and read as "daemon down", SIGKILLing a healthy daemon.
+    Stdlib ``urllib`` (dep-light). An HTTP error *response*
+    (401/403/404/5xx) is NOT a failure — it PROVES a daemon is bound
+    and answering, so we surface the real ``.code`` rather than
+    collapse it to ``-1`` (the bearer-auth false-negative fix, PR #463,
+    card ``sac-listen-restart-healthcheck-bearer``). Only a transport
+    failure (refused / DNS / timeout) returns ``-1``.
     """
     import urllib.error
     import urllib.request
@@ -123,6 +138,10 @@ class RestartResult:
     pre-state / health / which relaunch path / error message.
     The CLI verb surfaces ``escalated_to_sigkill`` as a LOUD WARN
     per design call (c).
+
+    ``port_holders_killed`` records any UNtracked PID(s) the self-heal
+    force-killed off the port (the wedged-remnant / "curl hangs"
+    case) — empty when only the pidfile-tracked daemon was stopped.
     """
 
     ok: bool
@@ -132,6 +151,7 @@ class RestartResult:
     health_ok: bool
     took_systemd_path: bool
     error: str = ""
+    port_holders_killed: tuple[int, ...] = ()
 
 
 # ---------------------------------------------------------------------------
@@ -142,20 +162,16 @@ class RestartResult:
 def pidfile_path(port: int, lock_dir: Path) -> Path:
     """Mirror ``_single_instance._pid_file_path`` (port-scoped).
 
-    Re-derived rather than imported to keep cli_pkg independent of
-    the single-instance private API. Shape ``<lock_dir>/listen-<port>.pid``
-    is the stable on-disk contract.
+    Re-derived (not imported) to keep cli_pkg independent of the
+    single-instance private API. ``<lock_dir>/listen-<port>.pid`` is
+    the stable on-disk contract.
     """
     return lock_dir / f"listen-{port}.pid"
 
 
 def read_pid_from_file(pid_file: Path) -> int | None:
-    """Read the PID from ``pid_file``, or return ``None`` on absence /
-    malformed / empty.
-
-    Robust to a partially-written file and a stale pidfile from an
-    earlier sac version that may carry junk.
-    """
+    """Read the PID from ``pid_file``, or ``None`` on absent / malformed
+    / empty (robust to a partial write or junk from an older sac)."""
     try:
         content = pid_file.read_text(encoding="utf-8").strip()
     except (FileNotFoundError, OSError):
@@ -170,11 +186,10 @@ def read_pid_from_file(pid_file: Path) -> int | None:
 
 
 def pid_alive(pid: int) -> bool:
-    """Return ``True`` iff a process with this PID currently exists.
+    """Return ``True`` iff a process with this PID exists.
 
-    ``os.kill(pid, 0)`` is the canonical liveness probe.
-    ``PermissionError`` means the PID is owned by another user —
-    still alive from the perspective of "is the slot taken".
+    ``os.kill(pid, 0)`` is the canonical liveness probe;
+    ``PermissionError`` (other-user PID) still counts as alive.
     """
     try:
         _kill(pid, 0)
@@ -199,9 +214,9 @@ def _terminate_then_kill(
     """Send SIGTERM, poll for exit up to ``grace_secs``, escalate to
     SIGKILL on timeout.
 
-    Returns ``True`` iff SIGKILL escalation was used (CLI surfaces
-    as LOUD WARN per design call (c)). Caller MUST verify the PID is
-    actually dead before clearing the pidfile.
+    Returns ``True`` iff SIGKILL escalation was used (CLI surfaces as
+    LOUD WARN per (c)). Caller MUST verify the PID is dead before
+    clearing the pidfile.
 
     ``force_kill=True`` skips the TERM step. CLI exposes as
     ``--force`` for an operator who already knows the daemon hangs.
@@ -245,10 +260,9 @@ def systemd_unit_is_active(
     """Return ``True`` iff a ``sac-listen.service`` user unit is
     installed AND enabled.
 
-    Two-step check (file presence + ``systemctl --user is-enabled``)
-    so we don't try to ``restart`` a unit that was copied in but
-    never enabled — falls through to direct-spawn instead of
-    surfacing a confusing systemd error.
+    Two-step (file presence + ``systemctl --user is-enabled``) so we
+    don't ``restart`` a copied-but-never-enabled unit — falls through
+    to direct-spawn instead of a confusing systemd error.
     """
     if not unit_path.is_file():
         return False
@@ -276,7 +290,7 @@ def wait_for_health(
     port: int,
     deadline_secs: float,
 ) -> bool:
-    """Poll ``http://<host>:<port>/v1/sac/health`` until the daemon is
+    """Poll ``http://<host>:<port>/v1/health`` until the daemon is
     *alive* or the deadline elapses.
 
     "Alive" means the daemon answered with *any* HTTP status — a 200
@@ -286,19 +300,16 @@ def wait_for_health(
     failure (connection refused / timeout), which ``_http_get``
     reports as ``-1``.
 
-    Rationale (card ``sac-listen-restart-healthcheck-bearer``): a
-    restart must NEVER SIGKILL + abort against a daemon that is
+    Rationale (card ``sac-listen-restart-healthcheck-bearer``, PR #463):
+    a restart must NEVER SIGKILL + abort against a daemon that is
     demonstrably answering. Gating liveness on ``status == 200`` made
     a later bearer-auth change re-classify a live, 401-answering
     daemon as "down" — a fail-quiet that destroyed a healthy process.
-    Treating "got an HTTP response" as alive is auth-change-proof
-    (fail-loud / no-surprise).
-
-    Endpoint shape fixed by ``_listen.server.health`` (returns
-    ``{"ok": true, "service": "sac-listen", "v": 1}`` on the
-    unauthenticated ``/v1/health`` route).
+    Treating "got an HTTP response" as alive is auth-change-proof.
+    ``HEALTH_PATH`` (``/v1/health``) is the only route ``server.py``
+    registers.
     """
-    url = f"http://{host}:{port}/v1/sac/health"
+    url = f"http://{host}:{port}{HEALTH_PATH}"
     elapsed = 0.0
     while elapsed < deadline_secs:
         status = _http_get(url, timeout=2.0)
@@ -330,10 +341,8 @@ def restart_listen(
 ) -> RestartResult:
     """Execute the full stop-clean-relaunch sequence.
 
-    ``host``/``port`` mirror ``sac listen``'s bind resolution per
-    design call (a) — the CLI verb resolves them from the
-    group-level ``--bind``. ``lock_dir`` matches
-    ``_single_instance.default_lock_dir()`` in production. Never
+    ``host``/``port`` mirror ``sac listen``'s bind resolution per (a);
+    ``lock_dir`` matches ``_single_instance.default_lock_dir()``. Never
     raises — every failure populates ``RestartResult.error``.
     """
     pid_file = pidfile_path(port, lock_dir)
@@ -342,6 +351,22 @@ def restart_listen(
     prior_alive = prior_pid is not None and pid_alive(prior_pid)
 
     escalated = False
+    port_holders_killed: tuple[int, ...] = ()
+
+    def _fail(*, error: str, took_systemd_path: bool = False) -> RestartResult:
+        """Failure result capturing pre-state + self-heal progress so
+        far. De-dupes the early-return branches below."""
+        return RestartResult(
+            ok=False,
+            escalated_to_sigkill=escalated,
+            had_prior_pidfile=had_prior_pidfile,
+            prior_pid_alive=prior_alive,
+            health_ok=False,
+            took_systemd_path=took_systemd_path,
+            error=error,
+            port_holders_killed=port_holders_killed,
+        )
+
     if prior_pid is not None and prior_alive:
         escalated = _terminate_then_kill(
             prior_pid, grace_secs=grace_secs, force_kill=force
@@ -351,32 +376,35 @@ def restart_listen(
         # rather than clear the lock + let a second daemon start beside.
         _sleep(_POLL_INTERVAL_SECS)
         if pid_alive(prior_pid):
-            return RestartResult(
-                ok=False,
-                escalated_to_sigkill=escalated,
-                had_prior_pidfile=had_prior_pidfile,
-                prior_pid_alive=prior_alive,
-                health_ok=False,
-                took_systemd_path=False,
+            return _fail(
                 error=(
                     f"PID {prior_pid} survived SIGKILL — refusing to "
                     f"clear pidfile or relaunch. Inspect manually "
                     f"(zombie/uninterruptible state)."
-                ),
+                )
             )
 
     try:
         pid_file.unlink(missing_ok=True)
     except OSError as exc:
-        return RestartResult(
-            ok=False,
-            escalated_to_sigkill=escalated,
-            had_prior_pidfile=had_prior_pidfile,
-            prior_pid_alive=prior_alive,
-            health_ok=False,
-            took_systemd_path=False,
-            error=f"failed to clear stale pidfile {pid_file}: {exc!r}",
-        )
+        return _fail(error=f"failed to clear stale pidfile {pid_file}: {exc!r}")
+
+    # Self-heal a WEDGED port holder the pidfile never named (the
+    # "curl hangs forever" remnant) before relaunch so the new daemon
+    # doesn't hit EADDRINUSE. terminate/sleep are passed in so the
+    # escalation seams stay owned here (and avoid a circular import).
+    heal = clear_wedged_port_holders(
+        host=host,
+        port=port,
+        grace_secs=grace_secs,
+        force=force,
+        terminate_fn=_terminate_then_kill,
+        sleep_fn=_sleep,
+        poll_interval=_POLL_INTERVAL_SECS,
+    )
+    port_holders_killed = heal.killed
+    if heal.error:
+        return _fail(error=heal.error)
 
     use_systemd = systemd_unit_is_active(systemd_unit_path)
     if use_systemd:
@@ -392,24 +420,14 @@ def restart_listen(
                 timeout=15.0,
             ).returncode
         except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
-            return RestartResult(
-                ok=False,
-                escalated_to_sigkill=escalated,
-                had_prior_pidfile=had_prior_pidfile,
-                prior_pid_alive=prior_alive,
-                health_ok=False,
-                took_systemd_path=True,
+            return _fail(
                 error=f"systemctl restart failed: {exc!r}",
+                took_systemd_path=True,
             )
         if rc != 0:
-            return RestartResult(
-                ok=False,
-                escalated_to_sigkill=escalated,
-                had_prior_pidfile=had_prior_pidfile,
-                prior_pid_alive=prior_alive,
-                health_ok=False,
-                took_systemd_path=True,
+            return _fail(
                 error=f"systemctl restart exited rc={rc}",
+                took_systemd_path=True,
             )
     else:
         argv = sac_listen_argv or ["sac", "listen"]
@@ -425,15 +443,7 @@ def restart_listen(
             # EXPECTED — the spawned daemon never exits.
             pass
         except (FileNotFoundError, OSError) as exc:
-            return RestartResult(
-                ok=False,
-                escalated_to_sigkill=escalated,
-                had_prior_pidfile=had_prior_pidfile,
-                prior_pid_alive=prior_alive,
-                health_ok=False,
-                took_systemd_path=False,
-                error=f"direct spawn failed: {exc!r}",
-            )
+            return _fail(error=f"direct spawn failed: {exc!r}")
 
     health_ok = wait_for_health(
         host=host, port=port, deadline_secs=health_deadline_secs
@@ -445,12 +455,17 @@ def restart_listen(
         prior_pid_alive=prior_alive,
         health_ok=health_ok,
         took_systemd_path=use_systemd,
-        error=""
-        if health_ok
-        else (
-            f"daemon did not respond 200 on /v1/sac/health within "
-            f"{health_deadline_secs}s"
+        error=(
+            ""
+            if health_ok
+            else diagnose_unhealthy(
+                host=host,
+                port=port,
+                deadline_secs=health_deadline_secs,
+                health_path=HEALTH_PATH,
+            )
         ),
+        port_holders_killed=port_holders_killed,
     )
 
 
@@ -476,10 +491,16 @@ __all__ = [
     "DEFAULT_GRACE_SECS",
     "DEFAULT_HEALTH_DEADLINE_SECS",
     "DEFAULT_SYSTEMD_UNIT_PATH",
+    "HEALTH_PATH",
+    "PortHealResult",
     "RestartResult",
+    "clear_wedged_port_holders",
+    "diagnose_unhealthy",
     "format_escalation_warning",
     "pid_alive",
     "pidfile_path",
+    "port_holder_pids",
+    "port_is_bound",
     "read_pid_from_file",
     "restart_listen",
     "systemd_unit_is_active",

--- a/src/scitex_agent_container/_listen/_status_report.py
+++ b/src/scitex_agent_container/_listen/_status_report.py
@@ -1,0 +1,100 @@
+"""``sac listen status`` report — probe + render (card
+``sac-listen-restart-selfheal-cli``).
+
+One-command diagnosis of the listen daemon: running/down, bound
+address, pidfile + its PID liveness, and a live health probe. Kept out
+of ``cli_pkg/listen_cmds`` so the click verb stays a thin wrapper and
+this logic is unit-testable without a CliRunner.
+
+``http_get`` / ``port_is_bound`` are passed in by the caller (the CLI
+resolves them from ``_restart`` / ``_port_holder``) so tests drive the
+probe with recorded fakes — no real socket, no MagicMock.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable
+
+__all__ = [
+    "build_status_payload",
+    "render_status_lines",
+]
+
+
+def build_status_payload(
+    *,
+    host: str,
+    port: int,
+    pid_file: Path,
+    pidfile_pid: int | None,
+    pidfile_pid_alive: bool,
+    health_path: str,
+    http_get: Callable[[str, float], int],
+    port_is_bound: Callable[[str, int], bool],
+) -> dict:
+    """Probe the daemon and return a machine-readable status dict.
+
+    ``running`` uses auth-change-proof liveness (mirrors
+    ``_restart.wait_for_health``): ANY HTTP response (incl. a 401 from
+    the bearer gate) proves it is serving; only ``-1`` (transport
+    failure) is "down". ``port_bound`` separates "wedged" (bound but
+    not answering) from "fully down" (not even bound).
+    """
+    port_bound = port_is_bound(host, port)
+    health_url = f"http://{host}:{port}{health_path}"
+    health_status = http_get(health_url, 2.0)
+    serving = health_status > 0
+    return {
+        "bind": f"{host}:{port}",
+        "running": serving,
+        "port_bound": port_bound,
+        "pidfile": str(pid_file),
+        "pidfile_pid": pidfile_pid,
+        "pidfile_pid_alive": pidfile_pid_alive,
+        "health_url": health_url,
+        "health_status": health_status,
+    }
+
+
+def render_status_lines(payload: dict) -> list[str]:
+    """Render the human-readable report from a status payload.
+
+    Returns a list of lines (the CLI echoes them). The headline names
+    the three distinct states explicitly — UP / WEDGED / DOWN — so the
+    operator can tell "bound but not serving" (needs ``restart
+    --force``) from "fully down" (needs ``restart``) at a glance.
+    """
+    serving = bool(payload["running"])
+    port_bound = bool(payload["port_bound"])
+    health_status = payload["health_status"]
+    pidfile_pid = payload["pidfile_pid"]
+
+    if serving:
+        state = "UP (serving)"
+    elif port_bound:
+        state = "WEDGED (port bound but not serving)"
+    else:
+        state = "DOWN"
+
+    lines = [
+        f"sac listen: {state}",
+        f"  bind:           {payload['bind']}",
+        f"  port bound:     {'yes' if port_bound else 'no'}",
+        f"  pidfile:        {payload['pidfile']}",
+    ]
+    if pidfile_pid is None:
+        lines.append("  pidfile PID:    <none/stale-empty>")
+    else:
+        liveness = (
+            "alive" if payload["pidfile_pid_alive"] else "DEAD (stale pidfile)"
+        )
+        lines.append(f"  pidfile PID:    {pidfile_pid} ({liveness})")
+    probe = f"HTTP {health_status}" if health_status > 0 else "no response (down)"
+    lines.append(f"  health probe:   {payload['health_url']} -> {probe}")
+    if not serving:
+        lines.append(
+            "  hint: run `sac listen restart` (add --force if a wedged "
+            "remnant holds the port)."
+        )
+    return lines

--- a/src/scitex_agent_container/_skills/scitex-agent-container/10_cli.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/10_cli.md
@@ -50,16 +50,22 @@ Reads `session_id` from the per-agent state dir and shells out to `claude --resu
 ## sac listen (HTTP/JSON control plane)
 
 ```bash
-sac listen                                # Boot the local /v1/sac/ server (loopback only by default)
+sac listen                                # Boot the local control-plane server (loopback only by default)
 sac listen --bind 127.0.0.1:7878          # Custom bind
 sac listen --print-token                  # Echo the bearer token & exit
+sac listen status                         # One-shot health report (UP/WEDGED/DOWN); exit 1 if not serving
+sac listen status --json                  # Machine-readable status envelope
+sac listen restart                        # Self-healing stop-clean-relaunch (clears stale pidfile, force-kills wedged port holder)
+sac listen restart --force                # SIGKILL the daemon + any wedged port holder immediately
 ```
 
-When running, exposes (bearer-token authenticated):
+`restart` is the deterministic incident-recovery verb: it clears a stale pidfile, force-kills an untracked remnant still holding the port (the "curl hangs forever" case), then relaunches and health-probes — failing loud (non-zero, `ERROR:` naming the real cause) if the daemon can't be brought up. `status` is the one-command diagnosis.
+
+When running, exposes (bearer-token authenticated, except the public health route):
 
 | Route | Purpose |
 |---|---|
-| `GET  /v1/sac/health` | Liveness; public |
+| `GET  /v1/health` | Liveness; public (unauthenticated) |
 | `GET  /agents` | List local registry |
 | `GET  /agents/<name>/status` | Spec path, workdir, session_id |
 | `GET  /agents/<name>/card` | A2A-compatible AgentCard |

--- a/src/scitex_agent_container/cli_pkg/listen_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/listen_cmds.py
@@ -306,7 +306,9 @@ def _do_start_listen(
 
     click.echo(f"# sac listen v1 → {host}:{port}", err=True)
     click.echo(f"# token file: {tok_path}", err=True)
-    click.echo(f"# health: curl http://{host}:{port}/v1/sac/health", err=True)
+    # The ONLY registered liveness route is /v1/health (server.py); the
+    # old /v1/sac/health string here was a non-route that 404'd.
+    click.echo(f"# health: curl http://{host}:{port}/v1/health", err=True)
     click.echo(f"# pidfile: {lock_handle.pid_file}", err=True)
 
     # ADR-0014 Stage 1 — register the host's operator identity into
@@ -360,18 +362,31 @@ def _do_start_listen(
 )
 @click.pass_context
 def listen_restart(ctx: click.Context, grace_secs: float, force: bool) -> None:
-    """Atomically stop, clean, and relaunch the sac listen daemon.
+    """Atomically stop, self-heal, and relaunch the sac listen daemon.
 
-    Codifies the SIGTERM-hang lockfile recovery sequence documented at
-    ``scripts/systemd/README.md`` (PR #294). Mirrors ``sac listen``'s
-    own bind resolution: ``sac listen restart`` with no args restarts
-    the same daemon ``sac listen`` with no args would start.
+    Deterministic incident recovery (card
+    ``sac-listen-restart-selfheal-cli``) — codifies the manual
+    ``rm`` pidfile / ``pkill`` wedged remnant / ``setsid sac listen`` /
+    ``curl`` dance into one verb. It clears a STALE pidfile (pointing
+    at a dead/recycled PID), FORCE-KILLS a wedged process still holding
+    the port (the "curl hangs forever" case — even one the pidfile
+    never named), then starts and health-probes. No manual shell
+    surgery is ever needed.
+
+    FAIL LOUD: if the daemon can't be brought up within the health
+    deadline, exits NON-ZERO with an ``ERROR:`` line naming the REAL
+    cause (``port still held by PID X`` / ``bind failed``), not a
+    generic "did not respond".
+
+    Mirrors ``sac listen``'s own bind resolution: ``sac listen
+    restart`` with no args restarts the same daemon ``sac listen``
+    with no args would start.
 
     \b
     Example:
         sac listen restart                  # 10s grace, then SIGKILL
         sac listen restart --grace-secs 30  # longer TERM window
-        sac listen restart --force          # skip TERM, kill immediately
+        sac listen restart --force          # SIGKILL daemon + port holder
     """
     from .._listen._restart import (
         format_escalation_warning,
@@ -399,10 +414,83 @@ def listen_restart(ctx: click.Context, grace_secs: float, force: bool) -> None:
     if result.escalated_to_sigkill:
         click.echo(format_escalation_warning(grace_secs), err=True)
 
+    # Surface any wedged port holder we force-killed so the operator has
+    # a paper trail of the self-heal (the codified pkill).
+    if result.port_holders_killed:
+        pids = ", ".join(str(p) for p in result.port_holders_killed)
+        click.echo(
+            f"# self-heal: force-killed wedged port holder(s) PID {pids} "
+            f"off {host}:{port}",
+            err=True,
+        )
+
     if not result.ok:
         raise click.ClickException(
-            result.error or "sac listen restart failed (unknown reason)"
+            result.error or "ERROR: sac listen restart failed (unknown reason)"
         )
 
     msg = f"# sac listen restarted ({'systemd' if result.took_systemd_path else 'direct'}) → {host}:{port}"
     click.echo(msg, err=True)
+
+
+@listen.command(name="status")
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Emit a machine-readable JSON status envelope.",
+)
+@click.pass_context
+def listen_status(ctx: click.Context, as_json: bool) -> None:
+    """Report the sac listen daemon's health in one command.
+
+    One-command diagnosis (card ``sac-listen-restart-selfheal-cli``):
+    running/down, bound address, pidfile + its PID liveness, and a live
+    health-probe result. Exits ``0`` when serving, ``1`` when down or
+    wedged — usable interactively and as a scriptable liveness gate.
+
+    \b
+    Example:
+        sac listen status            # human-readable report
+        sac listen status --json     # JSON envelope for scripts
+    """
+    import json as _json
+
+    from .._listen._restart import (
+        HEALTH_PATH,
+        pid_alive,
+        pidfile_path,
+        port_is_bound,
+        read_pid_from_file,
+    )
+    from .._listen._restart import _http_get as _probe_http
+    from .._listen._single_instance import default_lock_dir
+    from .._listen._status_report import (
+        build_status_payload,
+        render_status_lines,
+    )
+
+    host, port = _split_bind(ctx.obj["bind"])
+    pid_file = pidfile_path(port, default_lock_dir())
+    pidfile_pid = read_pid_from_file(pid_file)
+
+    payload = build_status_payload(
+        host=host,
+        port=port,
+        pid_file=pid_file,
+        pidfile_pid=pidfile_pid,
+        pidfile_pid_alive=pidfile_pid is not None and pid_alive(pidfile_pid),
+        health_path=HEALTH_PATH,
+        http_get=_probe_http,
+        port_is_bound=port_is_bound,
+    )
+
+    if as_json:
+        click.echo(_json.dumps(payload))
+    else:
+        for line in render_status_lines(payload):
+            click.echo(line)
+
+    if not payload["running"]:
+        ctx.exit(1)

--- a/tests/scitex_agent_container/_listen/test__port_holder.py
+++ b/tests/scitex_agent_container/_listen/test__port_holder.py
@@ -1,0 +1,306 @@
+"""Tests for ``_listen/_port_holder.py`` — port-holder discovery +
+self-heal (card ``sac-listen-restart-selfheal-cli``).
+
+No-mocks discipline (PA-306 / STX-NM001-003): the external-tool seam
+(``_run_subprocess``) and the discovery seams (``_probe_bound`` /
+``_resolve_pids``) are swapped via a hand-rolled save/restore context
+manager. The socket probe is exercised against a REAL loopback
+``http.server`` / a real closed port — no MagicMock.
+
+AAA + >=3-word names + one assert per test (STX-TQ002 / PA-307).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from contextlib import contextmanager
+from typing import Iterator
+
+from scitex_agent_container._listen import _port_holder as ph
+
+
+@contextmanager
+def _swap(name: str, value) -> Iterator[None]:
+    saved = getattr(ph, name)
+    setattr(ph, name, value)
+    try:
+        yield
+    finally:
+        setattr(ph, name, saved)
+
+
+def _no_sleep(_secs: float) -> None:
+    """No-op sleep seam."""
+
+
+def _completed(stdout: str = "", stderr: str = "", rc: int = 0):
+    return subprocess.CompletedProcess(
+        args=[], returncode=rc, stdout=stdout, stderr=stderr
+    )
+
+
+class _TermRecorder:
+    """Records (pid, force_kill) for each terminate call, returns escalated."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[int, bool]] = []
+
+    def __call__(self, pid: int, *, grace_secs: float, force_kill: bool) -> bool:
+        self.calls.append((pid, force_kill))
+        return force_kill
+
+
+# ---------------------------------------------------------------------------
+# port_is_bound — real loopback server (bound) + real closed port (free)
+# ---------------------------------------------------------------------------
+
+
+def test_port_is_bound_true_for_live_loopback_server() -> None:
+    # Arrange — a real TCP server bound on an ephemeral loopback port.
+    import http.server
+    import threading
+
+    class _Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802
+            self.send_response(200)
+            self.end_headers()
+
+        def log_message(self, *_a):
+            return
+
+    server = http.server.HTTPServer(("127.0.0.1", 0), _Handler)
+    _host, port = server.server_address
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    # Act
+    try:
+        bound = ph.port_is_bound("127.0.0.1", port, timeout=1.0)
+    finally:
+        server.shutdown()
+        thread.join(timeout=2.0)
+    # Assert
+    assert bound is True
+
+
+def test_port_is_bound_false_for_closed_port() -> None:
+    # Arrange — port 1 on loopback is not bound (connection refused).
+    # Act
+    bound = ph.port_is_bound("127.0.0.1", 1, timeout=0.2)
+    # Assert
+    assert bound is False
+
+
+# ---------------------------------------------------------------------------
+# port_holder_pids — lsof / ss / fuser parsing + fallback chain
+# ---------------------------------------------------------------------------
+
+
+def test_lsof_branch_parses_pid_lines() -> None:
+    # Arrange — lsof -Fp emits one ``p<pid>`` line per holder.
+    def _run(argv, **_kw):
+        return _completed(stdout="p4242\nf7\n") if argv[0] == "lsof" else _completed()
+
+    # Act
+    with _swap("_run_subprocess", _run):
+        pids = ph.port_holder_pids(7878)
+    # Assert
+    assert pids == [4242]
+
+
+def test_falls_back_to_ss_when_lsof_missing() -> None:
+    # Arrange — lsof raises FileNotFoundError; ss returns a pid= column.
+    def _run(argv, **_kw):
+        if argv[0] == "lsof":
+            raise FileNotFoundError("lsof: not found")
+        if argv[0] == "ss":
+            return _completed(
+                stdout='LISTEN 0 128 *:7878 *:* users:(("uv",pid=5151,fd=7))\n'
+            )
+        return _completed()
+
+    # Act
+    with _swap("_run_subprocess", _run):
+        pids = ph.port_holder_pids(7878)
+    # Assert
+    assert pids == [5151]
+
+
+def test_falls_back_to_fuser_when_lsof_and_ss_empty() -> None:
+    # Arrange — lsof + ss yield nothing; fuser prints a bare PID.
+    def _run(argv, **_kw):
+        if argv[0] == "fuser":
+            return _completed(stdout="", stderr="7878/tcp:        6262\n")
+        return _completed()
+
+    # Act
+    with _swap("_run_subprocess", _run):
+        pids = ph.port_holder_pids(7878)
+    # Assert
+    assert pids == [6262]
+
+
+def test_returns_empty_when_no_tool_finds_holder() -> None:
+    # Arrange — every tool returns nothing.
+    with _swap("_run_subprocess", lambda *_a, **_kw: _completed()):
+        # Act
+        pids = ph.port_holder_pids(7878)
+    # Assert
+    assert pids == []
+
+
+def test_own_pid_is_excluded_from_holders() -> None:
+    # Arrange — lsof reports THIS process's PID; it must be filtered.
+    import os
+
+    def _run(argv, **_kw):
+        if argv[0] == "lsof":
+            return _completed(stdout=f"p{os.getpid()}\n")
+        return _completed()
+
+    # Act
+    with _swap("_run_subprocess", _run):
+        pids = ph.port_holder_pids(7878)
+    # Assert
+    assert pids == []
+
+
+# ---------------------------------------------------------------------------
+# clear_wedged_port_holders — the self-heal
+# ---------------------------------------------------------------------------
+
+
+def test_no_op_when_port_not_bound() -> None:
+    # Arrange — port is free; heal must do nothing.
+    term = _TermRecorder()
+    with (
+        _swap("_probe_bound", lambda _h, _p: False),
+        _swap("_resolve_pids", lambda _p: [4242]),
+    ):
+        # Act
+        result = ph.clear_wedged_port_holders(
+            host="127.0.0.1",
+            port=7878,
+            grace_secs=1.0,
+            force=True,
+            terminate_fn=term,
+            sleep_fn=_no_sleep,
+            poll_interval=0.01,
+        )
+    # Assert
+    assert result.killed == () and term.calls == []
+
+
+def test_force_kills_holder_then_frees_port() -> None:
+    # Arrange — bound before, free after the kill.
+    term = _TermRecorder()
+    states = iter([True, False])
+    with (
+        _swap("_probe_bound", lambda _h, _p: next(states, False)),
+        _swap("_resolve_pids", lambda _p: [4242]),
+    ):
+        # Act
+        result = ph.clear_wedged_port_holders(
+            host="127.0.0.1",
+            port=7878,
+            grace_secs=1.0,
+            force=True,
+            terminate_fn=term,
+            sleep_fn=_no_sleep,
+            poll_interval=0.01,
+        )
+    # Assert — the remnant was killed and recorded.
+    assert result.killed == (4242,) and result.error == ""
+
+
+def test_loud_error_when_no_pid_resolves_but_bound() -> None:
+    # Arrange — bound but no holder PID found.
+    term = _TermRecorder()
+    with (
+        _swap("_probe_bound", lambda _h, _p: True),
+        _swap("_resolve_pids", lambda _p: []),
+    ):
+        # Act
+        result = ph.clear_wedged_port_holders(
+            host="127.0.0.1",
+            port=7878,
+            grace_secs=1.0,
+            force=True,
+            terminate_fn=term,
+            sleep_fn=_no_sleep,
+            poll_interval=0.01,
+        )
+    # Assert
+    assert "no holding PID could be resolved" in result.error
+
+
+def test_loud_error_when_holder_survives_kill() -> None:
+    # Arrange — port stays bound even after the kill (unkillable).
+    term = _TermRecorder()
+    with (
+        _swap("_probe_bound", lambda _h, _p: True),
+        _swap("_resolve_pids", lambda _p: [4242]),
+    ):
+        # Act
+        result = ph.clear_wedged_port_holders(
+            host="127.0.0.1",
+            port=7878,
+            grace_secs=1.0,
+            force=True,
+            terminate_fn=term,
+            sleep_fn=_no_sleep,
+            poll_interval=0.01,
+        )
+    # Assert
+    assert "still held by PID 4242" in result.error
+
+
+def test_without_force_uses_term_escalation_not_immediate_kill() -> None:
+    # Arrange — force=False must pass force_kill=False to the terminator.
+    term = _TermRecorder()
+    states = iter([True, False])
+    with (
+        _swap("_probe_bound", lambda _h, _p: next(states, False)),
+        _swap("_resolve_pids", lambda _p: [4242]),
+    ):
+        # Act
+        ph.clear_wedged_port_holders(
+            host="127.0.0.1",
+            port=7878,
+            grace_secs=1.0,
+            force=False,
+            terminate_fn=term,
+            sleep_fn=_no_sleep,
+            poll_interval=0.01,
+        )
+    # Assert
+    assert term.calls == [(4242, False)]
+
+
+# ---------------------------------------------------------------------------
+# diagnose_unhealthy — names the REAL cause
+# ---------------------------------------------------------------------------
+
+
+def test_diagnose_names_wedged_pid_when_port_bound() -> None:
+    # Arrange — port bound but not serving → up-but-not-serving.
+    with (
+        _swap("_probe_bound", lambda _h, _p: True),
+        _swap("_resolve_pids", lambda _p: [7171]),
+    ):
+        # Act
+        msg = ph.diagnose_unhealthy(
+            host="127.0.0.1", port=7878, deadline_secs=30.0, health_path="/v1/health"
+        )
+    # Assert
+    assert "NOT SERVING" in msg and "7171" in msg
+
+
+def test_diagnose_reports_bind_failed_when_port_free() -> None:
+    # Arrange — nothing bound after relaunch → bind failed.
+    with _swap("_probe_bound", lambda _h, _p: False):
+        # Act
+        msg = ph.diagnose_unhealthy(
+            host="127.0.0.1", port=7878, deadline_secs=30.0, health_path="/v1/health"
+        )
+    # Assert
+    assert "bind failed" in msg

--- a/tests/scitex_agent_container/_listen/test__restart.py
+++ b/tests/scitex_agent_container/_listen/test__restart.py
@@ -17,6 +17,9 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Iterator
 
+import pytest
+
+from scitex_agent_container._listen import _port_holder as ph_mod
 from scitex_agent_container._listen import _restart as restart_mod
 from scitex_agent_container._listen._restart import (
     format_escalation_warning,
@@ -42,6 +45,43 @@ def _swap(name: str, value) -> Iterator[None]:
         yield
     finally:
         setattr(restart_mod, name, saved)
+
+
+@contextmanager
+def _swap_ph(name: str, value) -> Iterator[None]:
+    """Replace a ``_port_holder.<name>`` seam for the block. The
+    discovery seams (``_probe_bound`` / ``_resolve_pids``) live on
+    ``_port_holder``, not ``_restart``.
+    """
+    saved = getattr(ph_mod, name)
+    setattr(ph_mod, name, value)
+    try:
+        yield
+    finally:
+        setattr(ph_mod, name, saved)
+
+
+@pytest.fixture(autouse=True)
+def _neutralize_port_seams() -> Iterator[None]:
+    """Make the wedged-port-holder self-heal a hard no-op by default.
+
+    SAFETY: the real ``port_is_bound`` does a live socket connect, and
+    on a dev host the central ``sac listen`` is actually bound on 7878.
+    Without this guard a ``restart_listen(port=7878)`` test would probe
+    the real port, find it held, and FORCE-KILL the live fleet listen
+    as a test side effect. Defaulting the probe to "not bound" keeps
+    every test hermetic; the dedicated self-heal tests override these
+    two seams inside their own ``with`` block.
+    """
+    saved_bound = ph_mod._probe_bound
+    saved_holders = ph_mod._resolve_pids
+    ph_mod._probe_bound = lambda _host, _port: False
+    ph_mod._resolve_pids = lambda _port: []
+    try:
+        yield
+    finally:
+        ph_mod._probe_bound = saved_bound
+        ph_mod._resolve_pids = saved_holders
 
 
 def _no_sleep(_secs: float) -> None:
@@ -506,8 +546,20 @@ def test_wait_for_health_polls_correct_url() -> None:
     # Act
     with _swap("_http_get", http), _swap("_sleep", _no_sleep):
         wait_for_health(host="127.0.0.1", port=7878, deadline_secs=5.0)
+    # Assert — the ONLY registered liveness route is /v1/health, NOT
+    # the previously-probed /v1/sac/health (latent-bug fix, card
+    # sac-listen-restart-selfheal-cli).
+    assert http.calls[0][0] == "http://127.0.0.1:7878/v1/health"
+
+
+def test_wait_for_health_does_not_poll_v1_sac_health() -> None:
+    # Arrange — guard against regressing back to the unregistered route.
+    http = _HttpRecorder(statuses=[200])
+    # Act
+    with _swap("_http_get", http), _swap("_sleep", _no_sleep):
+        wait_for_health(host="127.0.0.1", port=7878, deadline_secs=5.0)
     # Assert
-    assert http.calls[0][0] == "http://127.0.0.1:7878/v1/sac/health"
+    assert "/v1/sac/health" not in http.calls[0][0]
 
 
 # ---------------------------------------------------------------------------
@@ -565,7 +617,8 @@ def test_failed_health_check_sets_ok_false(tmp_path: Path) -> None:
 
 
 def test_failed_health_check_carries_error_message(tmp_path: Path) -> None:
-    # Arrange
+    # Arrange — health never answers AND the port is not bound (default
+    # neutralized seam) → the "bind failed" fail-loud branch fires.
     kill = _KillRecorder(alive_script=[False])
     subproc = _SubprocessRecorder(returncodes=[0])
     http = _HttpRecorder(statuses=[-1])
@@ -584,8 +637,8 @@ def test_failed_health_check_carries_error_message(tmp_path: Path) -> None:
             systemd_unit_path=tmp_path / "absent.service",
             sac_listen_argv=["echo", "stub"],
         )
-    # Assert
-    assert "/v1/sac/health" in result.error
+    # Assert — loud, names the real cause (bind failed) + the right route.
+    assert "ERROR: bind failed" in result.error and "/v1/health" in result.error
 
 
 # ---------------------------------------------------------------------------
@@ -898,7 +951,7 @@ def test_cli_listen_restart_failure_exits_nonzero_with_error(tmp_path: Path) -> 
             prior_pid_alive=False,
             health_ok=False,
             took_systemd_path=False,
-            error="daemon did not respond 200 on /v1/sac/health within 30s",
+            error="ERROR: bind failed — nothing is listening on 127.0.0.1:7878",
         )
 
     runner = CliRunner()
@@ -909,5 +962,228 @@ def test_cli_listen_restart_failure_exits_nonzero_with_error(tmp_path: Path) -> 
         result = runner.invoke(listen_grp, ["restart"])
     finally:
         restart_mod_alias.restart_listen = saved  # type: ignore[assignment]
+    # Assert — non-zero exit + the loud ERROR cause surfaces to stderr.
+    assert result.exit_code != 0 and "ERROR: bind failed" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Self-heal: wedged port holder ("curl hangs forever") force-killed
+# (card sac-listen-restart-selfheal-cli). The pidfile is gone / names a
+# dead PID, but an UNtracked remnant still holds the port. restart must
+# discover + kill it, then start — no manual rm/pkill/setsid.
+# ---------------------------------------------------------------------------
+
+
+def test_restart_force_kills_untracked_port_holder(tmp_path: Path) -> None:
+    # Arrange — NO pidfile (operator already rm-ed it), but the port is
+    # still bound by a remnant PID 4242. force=True → SIGKILL it.
+    kill = _KillRecorder(alive_script=[False])
+    subproc = _SubprocessRecorder(returncodes=[0])
+    http = _HttpRecorder(statuses=[200])
+    # Port is bound BEFORE the kill, free AFTER (two probes per heal call).
+    bound_states = iter([True, False])
+
+    def _bound(_host: str, _port: int) -> bool:
+        return next(bound_states, False)
+
+    # Act
+    with (
+        _swap("_kill", kill),
+        _swap("_sleep", _no_sleep),
+        _swap("_run_subprocess", subproc),
+        _swap("_http_get", http),
+        _swap_ph("_probe_bound", _bound),
+        _swap_ph("_resolve_pids", lambda _port: [4242]),
+    ):
+        result = restart_listen(
+            host="127.0.0.1",
+            port=7878,
+            lock_dir=tmp_path,
+            force=True,
+            systemd_unit_path=tmp_path / "absent.service",
+            sac_listen_argv=["echo", "stub"],
+        )
+    # Assert — the remnant PID was force-killed off the port.
+    assert result.port_holders_killed == (4242,)
+
+
+def test_restart_with_wedged_holder_sends_sigkill_to_remnant(tmp_path: Path) -> None:
+    # Arrange — wedged remnant on the port; force=True must SIGKILL it
+    # (the "curl hangs forever" recovery, no manual pkill).
+    kill = _KillRecorder(alive_script=[False])
+    subproc = _SubprocessRecorder(returncodes=[0])
+    http = _HttpRecorder(statuses=[200])
+    bound_states = iter([True, False])
+
+    def _bound(_host: str, _port: int) -> bool:
+        return next(bound_states, False)
+
+    # Act
+    with (
+        _swap("_kill", kill),
+        _swap("_sleep", _no_sleep),
+        _swap("_run_subprocess", subproc),
+        _swap("_http_get", http),
+        _swap_ph("_probe_bound", _bound),
+        _swap_ph("_resolve_pids", lambda _port: [4242]),
+    ):
+        restart_listen(
+            host="127.0.0.1",
+            port=7878,
+            lock_dir=tmp_path,
+            force=True,
+            systemd_unit_path=tmp_path / "absent.service",
+            sac_listen_argv=["echo", "stub"],
+        )
+    # Assert — SIGKILL (9) was delivered to the remnant PID 4242.
+    assert (4242, signal.SIGKILL) in kill.calls
+
+
+def test_restart_succeeds_after_clearing_wedged_holder(tmp_path: Path) -> None:
+    # Arrange — remnant killed, port freed, relaunch answers health.
+    kill = _KillRecorder(alive_script=[False])
+    subproc = _SubprocessRecorder(returncodes=[0])
+    http = _HttpRecorder(statuses=[200])
+    bound_states = iter([True, False])
+
+    def _bound(_host: str, _port: int) -> bool:
+        return next(bound_states, False)
+
+    # Act
+    with (
+        _swap("_kill", kill),
+        _swap("_sleep", _no_sleep),
+        _swap("_run_subprocess", subproc),
+        _swap("_http_get", http),
+        _swap_ph("_probe_bound", _bound),
+        _swap_ph("_resolve_pids", lambda _port: [4242]),
+    ):
+        result = restart_listen(
+            host="127.0.0.1",
+            port=7878,
+            lock_dir=tmp_path,
+            force=True,
+            systemd_unit_path=tmp_path / "absent.service",
+            sac_listen_argv=["echo", "stub"],
+        )
     # Assert
-    assert result.exit_code != 0 and "/v1/sac/health" in result.output
+    assert result.ok is True
+
+
+def test_restart_fails_loud_when_holder_unkillable(tmp_path: Path) -> None:
+    # Arrange — port stays bound even AFTER the force-kill (holder is a
+    # different uid / zombie). Must fail loud naming the surviving PID,
+    # NOT relaunch into EADDRINUSE.
+    kill = _KillRecorder(alive_script=[False])
+    subproc = _SubprocessRecorder(returncodes=[0])
+    http = _HttpRecorder(statuses=[200])
+
+    # Act
+    with (
+        _swap("_kill", kill),
+        _swap("_sleep", _no_sleep),
+        _swap("_run_subprocess", subproc),
+        _swap("_http_get", http),
+        _swap_ph("_probe_bound", lambda _host, _port: True),  # never frees
+        _swap_ph("_resolve_pids", lambda _port: [4242]),
+    ):
+        result = restart_listen(
+            host="127.0.0.1",
+            port=7878,
+            lock_dir=tmp_path,
+            force=True,
+            systemd_unit_path=tmp_path / "absent.service",
+            sac_listen_argv=["echo", "stub"],
+        )
+    # Assert — loud, non-empty error naming the surviving PID + port.
+    assert result.ok is False and "still held by PID 4242" in result.error
+
+
+def test_restart_fails_loud_when_port_held_but_no_pid_found(tmp_path: Path) -> None:
+    # Arrange — port is bound but NO holder PID resolves (no
+    # lsof/ss/fuser). Must NOT relaunch into EADDRINUSE; fail loud.
+    kill = _KillRecorder(alive_script=[False])
+    subproc = _SubprocessRecorder(returncodes=[0])
+    http = _HttpRecorder(statuses=[200])
+
+    # Act
+    with (
+        _swap("_kill", kill),
+        _swap("_sleep", _no_sleep),
+        _swap("_run_subprocess", subproc),
+        _swap("_http_get", http),
+        _swap_ph("_probe_bound", lambda _host, _port: True),
+        _swap_ph("_resolve_pids", lambda _port: []),  # nothing resolves
+    ):
+        result = restart_listen(
+            host="127.0.0.1",
+            port=7878,
+            lock_dir=tmp_path,
+            force=True,
+            systemd_unit_path=tmp_path / "absent.service",
+            sac_listen_argv=["echo", "stub"],
+        )
+    # Assert
+    assert result.ok is False and "no holding PID could be resolved" in result.error
+
+
+def test_restart_does_not_kill_when_port_free(tmp_path: Path) -> None:
+    # Arrange — nothing holds the port (clean restart). The self-heal
+    # must be a no-op: no holders recorded as killed.
+    kill = _KillRecorder(alive_script=[False])
+    subproc = _SubprocessRecorder(returncodes=[0])
+    http = _HttpRecorder(statuses=[200])
+
+    # Act
+    with (
+        _swap("_kill", kill),
+        _swap("_sleep", _no_sleep),
+        _swap("_run_subprocess", subproc),
+        _swap("_http_get", http),
+        _swap_ph("_probe_bound", lambda _host, _port: False),
+        _swap_ph("_resolve_pids", lambda _port: [9999]),  # would-be, unused
+    ):
+        result = restart_listen(
+            host="127.0.0.1",
+            port=7878,
+            lock_dir=tmp_path,
+            systemd_unit_path=tmp_path / "absent.service",
+            sac_listen_argv=["echo", "stub"],
+        )
+    # Assert
+    assert result.port_holders_killed == ()
+
+
+def test_unhealthy_with_bound_port_names_wedged_pid(tmp_path: Path) -> None:
+    # Arrange — relaunch happens, port comes up bound, but health never
+    # answers (up-but-not-serving). The fail-loud cause must name the
+    # wedged PID, aligning with _lifecycle/_bind_watchdog.py.
+    kill = _KillRecorder(alive_script=[False])
+    subproc = _SubprocessRecorder(returncodes=[0])
+    http = _HttpRecorder(statuses=[-1, -1])
+    # First two probes (the heal step) say not-bound so we relaunch;
+    # the post-relaunch diagnosis probe says bound (wedged).
+    bound_states = iter([False, True, True])
+
+    def _bound(_host: str, _port: int) -> bool:
+        return next(bound_states, True)
+
+    # Act
+    with (
+        _swap("_kill", kill),
+        _swap("_sleep", _no_sleep),
+        _swap("_run_subprocess", subproc),
+        _swap("_http_get", http),
+        _swap_ph("_probe_bound", _bound),
+        _swap_ph("_resolve_pids", lambda _port: [7171]),
+    ):
+        result = restart_listen(
+            host="127.0.0.1",
+            port=7878,
+            lock_dir=tmp_path,
+            health_deadline_secs=0.5,
+            systemd_unit_path=tmp_path / "absent.service",
+            sac_listen_argv=["echo", "stub"],
+        )
+    # Assert — loud "UP but NOT SERVING" cause naming the wedged PID.
+    assert "NOT SERVING" in result.error and "7171" in result.error

--- a/tests/scitex_agent_container/_listen/test__restart_bearer_auth.py
+++ b/tests/scitex_agent_container/_listen/test__restart_bearer_auth.py
@@ -25,6 +25,9 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Iterator
 
+import pytest
+
+from scitex_agent_container._listen import _port_holder as ph_mod
 from scitex_agent_container._listen import _restart as restart_mod
 from scitex_agent_container._listen._restart import restart_listen
 
@@ -38,6 +41,24 @@ def _swap(name: str, value) -> Iterator[None]:
         yield
     finally:
         setattr(restart_mod, name, saved)
+
+
+@pytest.fixture(autouse=True)
+def _neutralize_port_seams() -> Iterator[None]:
+    """Default the wedged-port-holder self-heal to a no-op (see the
+    twin fixture in ``test__restart.py``): the real socket probe would
+    otherwise find + force-kill the live central listen on 7878. The
+    discovery seams live on ``_port_holder``.
+    """
+    saved_bound = ph_mod._probe_bound
+    saved_holders = ph_mod._resolve_pids
+    ph_mod._probe_bound = lambda _host, _port: False
+    ph_mod._resolve_pids = lambda _port: []
+    try:
+        yield
+    finally:
+        ph_mod._probe_bound = saved_bound
+        ph_mod._resolve_pids = saved_holders
 
 
 def _no_sleep(_secs: float) -> None:

--- a/tests/scitex_agent_container/_listen/test__status_report.py
+++ b/tests/scitex_agent_container/_listen/test__status_report.py
@@ -1,0 +1,142 @@
+"""Tests for ``_listen/_status_report.py`` — ``sac listen status``
+probe + render (card ``sac-listen-restart-selfheal-cli``).
+
+No-mocks (PA-306): ``http_get`` / ``port_is_bound`` are plain
+callables passed in, so a small recorded fake drives each state. No
+MagicMock, no monkeypatch.
+
+AAA + >=3-word names + one assert per test (STX-TQ002 / PA-307).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scitex_agent_container._listen._status_report import (
+    build_status_payload,
+    render_status_lines,
+)
+
+
+def _payload(
+    *,
+    http_status: int,
+    bound: bool,
+    pidfile_pid: int | None = 12345,
+    pidfile_pid_alive: bool = True,
+    pid_file: Path = Path("/run/listen-7878.pid"),
+) -> dict:
+    return build_status_payload(
+        host="127.0.0.1",
+        port=7878,
+        pid_file=pid_file,
+        pidfile_pid=pidfile_pid,
+        pidfile_pid_alive=pidfile_pid_alive,
+        health_path="/v1/health",
+        http_get=lambda _url, _t: http_status,
+        port_is_bound=lambda _h, _p: bound,
+    )
+
+
+# ---------------------------------------------------------------------------
+# build_status_payload — liveness classification
+# ---------------------------------------------------------------------------
+
+
+def test_running_true_on_http_200() -> None:
+    # Arrange
+    # Act
+    payload = _payload(http_status=200, bound=True)
+    # Assert
+    assert payload["running"] is True
+
+
+def test_running_true_on_http_401_under_bearer_auth() -> None:
+    # Arrange — a 401 proves the daemon answered (auth-change-proof).
+    # Act
+    payload = _payload(http_status=401, bound=True)
+    # Assert
+    assert payload["running"] is True
+
+
+def test_running_false_on_transport_failure() -> None:
+    # Arrange — -1 means connection refused / timeout → down.
+    # Act
+    payload = _payload(http_status=-1, bound=False)
+    # Assert
+    assert payload["running"] is False
+
+
+def test_payload_probes_v1_health_url() -> None:
+    # Arrange
+    # Act
+    payload = _payload(http_status=200, bound=True)
+    # Assert
+    assert payload["health_url"] == "http://127.0.0.1:7878/v1/health"
+
+
+def test_payload_reports_bind_address() -> None:
+    # Arrange
+    # Act
+    payload = _payload(http_status=200, bound=True)
+    # Assert
+    assert payload["bind"] == "127.0.0.1:7878"
+
+
+# ---------------------------------------------------------------------------
+# render_status_lines — UP / WEDGED / DOWN headline
+# ---------------------------------------------------------------------------
+
+
+def test_render_headline_up_when_serving() -> None:
+    # Arrange
+    payload = _payload(http_status=200, bound=True)
+    # Act
+    lines = render_status_lines(payload)
+    # Assert
+    assert "UP (serving)" in lines[0]
+
+
+def test_render_headline_wedged_when_bound_but_not_serving() -> None:
+    # Arrange — port bound but health does not answer (the wedged case).
+    payload = _payload(http_status=-1, bound=True)
+    # Act
+    lines = render_status_lines(payload)
+    # Assert
+    assert "WEDGED" in lines[0]
+
+
+def test_render_headline_down_when_not_bound() -> None:
+    # Arrange
+    payload = _payload(http_status=-1, bound=False)
+    # Act
+    lines = render_status_lines(payload)
+    # Assert
+    assert "DOWN" in lines[0]
+
+
+def test_render_marks_dead_pidfile_pid() -> None:
+    # Arrange — pidfile names a PID that is no longer alive (stale).
+    payload = _payload(http_status=-1, bound=False, pidfile_pid_alive=False)
+    # Act
+    text = "\n".join(render_status_lines(payload))
+    # Assert
+    assert "DEAD (stale pidfile)" in text
+
+
+def test_render_emits_restart_hint_when_down() -> None:
+    # Arrange
+    payload = _payload(http_status=-1, bound=False)
+    # Act
+    text = "\n".join(render_status_lines(payload))
+    # Assert
+    assert "sac listen restart" in text
+
+
+def test_render_no_hint_when_serving() -> None:
+    # Arrange
+    payload = _payload(http_status=200, bound=True)
+    # Act
+    text = "\n".join(render_status_lines(payload))
+    # Assert
+    assert "hint:" not in text


### PR DESCRIPTION
## Summary
Deterministic incident recovery for a dead/wedged central `sac listen` (card `sac-listen-restart-selfheal-cli`). The 2026-06-26 incident needed manual `rm` pidfile / `pkill` wedged remnant / `setsid sac listen` / `curl`. This makes it one verb, fail-loud.

- **`sac listen restart` self-heals**: clears a stale pidfile (dead/recycled PID) AND force-kills an *untracked* remnant still holding the port — the "curl hangs forever" case the flock pidfile never named — via a socket probe + `lsof`/`ss`/`fuser` PID discovery, *before* relaunch (never starts into `EADDRINUSE`). `--force` SIGKILLs both the daemon and the port holder.
- **`sac listen status`** (new, + `--json`): one-command diagnosis — UP / WEDGED / DOWN, bound address, pidfile + its PID liveness, live health probe; exits non-zero when not serving.
- **FAIL LOUD**: a restart that can't bring the daemon up exits non-zero with an `ERROR:` line naming the real cause (`port still held by PID X` vs `bind failed`), not a generic "did not respond". Aligns with / references `_lifecycle/_bind_watchdog.py` (#469).
- **Latent bug fix**: the post-relaunch health probe hit the unregistered `/v1/sac/health`; the only liveness route `server.py` registers is `/v1/health`. Keeps #463's behavior (any HTTP status >0 = alive, incl. 401 under bearer auth).
- Extracted port-holder discovery/heal into `_listen/_port_holder.py` and the status report into `_listen/_status_report.py` to keep modules focused and under the 512-line limit.

## Test plan
- [x] `tests/.../_listen/` full dir: **586 passed**
- [x] new no-mock tests (real loopback socket / `http.server`): stale-pidfile cleared; untracked remnant force-killed then restart succeeds; `status` reports up vs down/wedged; restart failure exits non-zero with loud `ERROR:`; probe hits `/v1/health` (and asserts it is NOT `/v1/sac/health`)
- [x] empirically verified against the LIVE listen: `sac listen status` → `UP (serving)`, `http://127.0.0.1:7878/v1/health -> HTTP 200`, exit 0 (read-only; live daemon untouched)
- [ ] maintainer review (no auto-merge)

Note: this branch is off `develop`; #469's `_bind_watchdog.py` is referenced in comments/errors but not imported, so it lands cleanly regardless of #469 merge order.