### PR TITLE
harden(listen): startup peer-sync must not block uvicorn bind (background + timeout)

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_listen_lifespan.py
+++ b/src/scitex_agent_container/_lifecycle/_listen_lifespan.py
@@ -60,6 +60,23 @@ def build_listen_lifespan(*, health_watchdog_port: int | None = None):
         await persist_self_peers_on_listen_startup()
         tasks: list = []
 
+        # Best-effort ``comms_nodes`` peer-sync — launched HERE (after the
+        # bind, off the event loop) rather than synchronously before
+        # ``uvicorn.run``. The pre-bind synchronous sync was the live
+        # silent-bind-hang vector (INCIDENT 2026-06-26): one powered-off
+        # static peer made its un-timed ssh call hang, blocking boot before
+        # 7878 ever bound, with no error logged. As a backgrounded task that
+        # dispatches the blocking ssh sweep via ``asyncio.to_thread`` and
+        # bounds it, it can never block the bind. Honour
+        # SAC_LISTEN_STARTUP_SYNC_DISABLED=1 to skip launching (test
+        # harnesses / single-host installs that opt out at the env level).
+        if os.environ.get("SAC_LISTEN_STARTUP_SYNC_DISABLED", "") != "1":
+            from .._listen._startup_peer_sync import sync_peers_on_listen_startup
+
+            sync_task = asyncio.create_task(sync_peers_on_listen_startup())
+            app.state.startup_peer_sync_task = sync_task
+            tasks.append(sync_task)
+
         # Periodic-drive listen-loop (lead a2a 7916f486, 2026-06-14).
         # Honour SAC_PERIODIC_DRIVE_DISABLED=1 to skip launching.
         if os.environ.get("SAC_PERIODIC_DRIVE_DISABLED", "") != "1":

--- a/src/scitex_agent_container/_listen/_startup_peer_sync.py
+++ b/src/scitex_agent_container/_listen/_startup_peer_sync.py
@@ -1,0 +1,177 @@
+"""Best-effort ``comms_nodes`` peer-sync at ``sac listen`` startup —
+launched AFTER uvicorn binds, off the event loop.
+
+Why this module exists (INCIDENT 2026-06-26)
+--------------------------------------------
+``sac listen`` used to run a SYNCHRONOUS ``sac registry sync --all`` over
+ssh to every static peer (``cli_pkg.listen_cmds._maybe_sync_on_start``)
+*before* ``uvicorn.run`` was ever reached. That sync had no overall
+timeout, so a single powered-off peer made the ssh call HANG, blocking
+boot before the bind — port 7878 never bound, with NO error logged, and
+the whole fleet lost agent-to-agent comms. PR #469's bind-watchdog could
+not catch this: the watchdog lives inside ``create_app``, which runs
+*after* the pre-bind sync.
+
+The fix
+-------
+The bind must be impossible to block. uvicorn binds 7878 FIRST; the
+peer-sync runs best-effort AFTER the server is serving, as a lifespan
+task — exactly the pattern PR #469 used to background self-peer
+persistence and the three startup loops.
+
+Because :func:`cli_pkg._registry_sync.registry_sync_impl` is blocking ssh
+(``subprocess.run``), not async, it is dispatched OFF the event loop via
+``asyncio.to_thread`` and bounded by an overall ``wait_for`` — so even if
+every per-peer ssh somehow wedged past its own ``ConnectTimeout`` /
+``timeout=`` guard, it can never occupy the loop thread or block uvicorn's
+bind.
+
+Best-effort + fail-loud
+-----------------------
+Every failure mode (no config, opt-out, no static peers, per-peer ssh
+failure, overall timeout) is logged and the listen keeps serving. A
+timeout or peer failure emits a LOUD ``warning`` naming the cause — never
+a silent hang, never a silent swallow.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Overall wall-clock ceiling for the whole post-bind peer sweep. The sweep
+# is already bounded per-peer (``_registry_sync._PEER_SSH_TIMEOUT_S``) and
+# given the same value as an internal budget; this outer ``wait_for`` is the
+# last line of defence so the lifespan task itself can never hang the
+# teardown. Generous: a healthy multi-peer sweep finishes in well under this.
+DEFAULT_STARTUP_SYNC_TIMEOUT_S = 60.0
+
+
+def _read_sync_on_start_flag(cfg) -> bool:
+    """Return the ``comms_nodes.sync_on_start`` flag (default True).
+
+    The flag is read by hand from the raw config dict because
+    :class:`host_config.Config` only structures the blocks sac parses
+    natively. Any read error degrades to True (the historical default) —
+    a best-effort sync that runs is strictly safer than one silently
+    skipped because the YAML had an unrelated quirk.
+    """
+    raw_path = getattr(cfg, "source_path", None)
+    if raw_path is None or not raw_path.is_file():
+        return True
+    try:
+        import yaml
+
+        raw = yaml.safe_load(raw_path.read_text()) or {}
+    except Exception:  # stx-allow: fallback (reason: a malformed/unreadable config must not crash listen startup; default to the historical sync-on-start=True.)
+        return True
+    comms_nodes_cfg = raw.get("comms_nodes")
+    if isinstance(comms_nodes_cfg, dict):
+        flag = comms_nodes_cfg.get("sync_on_start", True)
+        if isinstance(flag, bool):
+            return flag
+    return True
+
+
+def _run_registry_sync_all(*, budget_s: float) -> int:
+    """Blocking helper: run the all-peers registry sync once.
+
+    Imported lazily and called via ``asyncio.to_thread`` so its blocking
+    ssh ``subprocess.run`` calls never touch the event-loop thread.
+    ``budget_s`` is forwarded as the sweep's internal overall budget so an
+    unreachable peer is skipped fast even inside the thread.
+    """
+    from ..cli_pkg._registry_sync import registry_sync_impl
+
+    return registry_sync_impl(
+        from_peer=None,
+        to_peer=None,
+        all_peers=True,
+        dry_run=False,
+        as_json=False,
+        overall_budget_s=budget_s,
+    )
+
+
+async def sync_peers_on_listen_startup(
+    *, timeout_s: float = DEFAULT_STARTUP_SYNC_TIMEOUT_S
+) -> None:
+    """Lifespan task: best-effort ``comms_nodes`` sync AFTER the bind.
+
+    Mirrors the synchronous pre-bind logic that lived in
+    ``cli_pkg.listen_cmds._maybe_sync_on_start`` — read the
+    ``comms_nodes.sync_on_start`` opt-out, skip silently when there are no
+    static peers (single-host installs) — but runs OFF the event loop and
+    bounded so it can NEVER block uvicorn's bind.
+
+    Never raises: a discovery/import/timeout failure logs at ``warning``
+    and the listen keeps serving. PRESERVES INTENT — the peer-registry sync
+    still happens (best-effort, after bind); it is not deleted.
+    """
+    try:
+        from .._state.host_config import load
+
+        cfg = load()
+        if not _read_sync_on_start_flag(cfg):
+            return
+        # Only run when there is at least one static (non-glob) peer; skip
+        # silently otherwise so single-host installs don't spam warnings.
+        static_peers = [n for n in cfg.peers.keys() if not any(c in n for c in "*?[")]
+        if not static_peers:
+            return
+    except Exception as exc:  # stx-allow: fallback (reason: a config-read crash must not block listen startup; degrade to no startup sync.)
+        logger.warning(
+            "startup peer-sync: config read failed (%r); skipping sync, "
+            "listen continues serving",
+            exc,
+        )
+        return
+
+    # Reserve a slice of the overall timeout for the in-thread sweep so the
+    # outer ``wait_for`` is the hard backstop, not the primary limiter.
+    sweep_budget = max(1.0, timeout_s - 1.0)
+    try:
+        rc = await asyncio.wait_for(
+            asyncio.to_thread(_run_registry_sync_all, budget_s=sweep_budget),
+            timeout=timeout_s,
+        )
+    except asyncio.CancelledError:
+        raise
+    except asyncio.TimeoutError:
+        # FAIL LOUD: the sweep exceeded its budget. The bind is unaffected
+        # (this runs after it), but the operator must know the federated
+        # graph may be stale — an unreachable peer is the usual cause.
+        logger.warning(
+            "startup peer-sync: all-peers comms_nodes sync exceeded %.0fs and "
+            "was abandoned (an unreachable/stalled static peer is the usual "
+            "cause). The listen IS serving; the federated peer view may be "
+            "stale until the next sync. Check `comms_nodes.peers` reachability.",
+            timeout_s,
+        )
+        return
+    except Exception as exc:  # stx-allow: fallback (reason: never block/kill the listen on a startup-sync error; log loud and keep serving.)
+        logger.warning(
+            "startup peer-sync: all-peers comms_nodes sync failed (%r); listen "
+            "continues serving with the pre-sync peer view",
+            exc,
+        )
+        return
+
+    if rc != 0:
+        # Per-peer failures already logged their own loud [FAIL] lines via
+        # the sync's text report; summarise here so the cause is visible in
+        # the listen's own log stream too.
+        logger.warning(
+            "startup peer-sync: comms_nodes sync completed with peer "
+            "failures (rc=%d) — see the per-peer [FAIL] lines above. The "
+            "listen IS serving; unreachable peers were skipped, not retried.",
+            rc,
+        )
+
+
+__all__ = [
+    "DEFAULT_STARTUP_SYNC_TIMEOUT_S",
+    "sync_peers_on_listen_startup",
+]

--- a/src/scitex_agent_container/cli_pkg/_registry_sync.py
+++ b/src/scitex_agent_container/cli_pkg/_registry_sync.py
@@ -36,6 +36,23 @@ import click
 
 from .._state.host_config import Config, build_ssh_argv, load
 
+# Hard per-peer ssh wall-clock ceiling. ``build_ssh_argv`` already pins
+# ``ConnectTimeout`` so the TCP handshake to a dead host fails fast, but a
+# peer that accepts the connection and then stalls (or a wedged ProxyJump
+# middle-hop) could otherwise keep ``subprocess.run`` blocked forever — the
+# exact hang that, on the pre-bind startup path, took the whole fleet's
+# comms down with no error logged (INCIDENT 2026-06-26). We pass ``timeout=``
+# to every ssh ``subprocess.run`` and a tighter ``ConnectTimeout`` override so
+# an unreachable/stalled peer is converted into a loud, fast per-peer FAIL
+# instead of an indefinite wedge.
+_PEER_SSH_TIMEOUT_S = 15.0
+_PEER_SSH_CONNECT_TIMEOUT_S = 5
+
+# ssh option overriding the probe-friendly default ConnectTimeout=10 baked
+# into ``build_ssh_argv`` with a tighter value for the sync path, so a
+# powered-off peer fails its TCP connect in ~5s rather than ~10s.
+_SSH_TIGHT_CONNECT_OPTS = ["-o", f"ConnectTimeout={_PEER_SSH_CONNECT_TIMEOUT_S}"]
+
 
 @dataclass
 class SyncResult:
@@ -89,7 +106,9 @@ def _stamp_source_host(payload: dict[str, Any], source_host: str) -> dict[str, A
 def _pull_from(peer: str, cfg: Config, *, dry_run: bool) -> SyncResult:
     """Pull comms_nodes from ``peer`` and import locally."""
     remote_argv = ["sac", "db", "export", "--tables", "comms_nodes"]
-    ssh_argv = build_ssh_argv(peer, remote_argv, cfg.peers)
+    ssh_argv = build_ssh_argv(
+        peer, remote_argv, cfg.peers, extra_opts=_SSH_TIGHT_CONNECT_OPTS
+    )
     if dry_run:
         click.echo(
             f"[dry-run] pull comms_nodes from {peer!r}: "
@@ -97,7 +116,23 @@ def _pull_from(peer: str, cfg: Config, *, dry_run: bool) -> SyncResult:
             err=True,
         )
         return SyncResult(peer=peer, direction="pull", ok=True, inserted={})
-    proc = subprocess.run(ssh_argv, capture_output=True, text=True)
+    try:
+        proc = subprocess.run(
+            ssh_argv, capture_output=True, text=True, timeout=_PEER_SSH_TIMEOUT_S
+        )
+    except subprocess.TimeoutExpired:
+        # Skip-unreachable-and-WARN: an unreachable/stalled peer must
+        # fail fast and loud, never wedge the caller. Naming the peer +
+        # the budget makes the WARN actionable.
+        return SyncResult(
+            peer=peer,
+            direction="pull",
+            ok=False,
+            error=(
+                f"ssh timed out after {_PEER_SSH_TIMEOUT_S:.0f}s "
+                f"(peer unreachable or stalled) — skipped"
+            ),
+        )
     if proc.returncode != 0:
         return SyncResult(
             peer=peer,
@@ -147,7 +182,9 @@ def _pull_from(peer: str, cfg: Config, *, dry_run: bool) -> SyncResult:
 def _push_to(peer: str, cfg: Config, *, dry_run: bool) -> SyncResult:
     """Export locally and pipe to ``ssh peer -- sac db import -``."""
     remote_argv = ["sac", "db", "import", "-"]
-    ssh_argv = build_ssh_argv(peer, remote_argv, cfg.peers)
+    ssh_argv = build_ssh_argv(
+        peer, remote_argv, cfg.peers, extra_opts=_SSH_TIGHT_CONNECT_OPTS
+    )
     if dry_run:
         click.echo(
             f"[dry-run] push comms_nodes to {peer!r}: "
@@ -158,12 +195,26 @@ def _push_to(peer: str, cfg: Config, *, dry_run: bool) -> SyncResult:
     from .._state.state_db import export_state
 
     payload = export_state(tables=["comms_nodes"])
-    proc = subprocess.run(
-        ssh_argv,
-        input=json.dumps(payload),
-        capture_output=True,
-        text=True,
-    )
+    try:
+        proc = subprocess.run(
+            ssh_argv,
+            input=json.dumps(payload),
+            capture_output=True,
+            text=True,
+            timeout=_PEER_SSH_TIMEOUT_S,
+        )
+    except subprocess.TimeoutExpired:
+        # Skip-unreachable-and-WARN (see _pull_from): a stalled push must
+        # never block the caller; fail fast and name the peer + budget.
+        return SyncResult(
+            peer=peer,
+            direction="push",
+            ok=False,
+            error=(
+                f"ssh timed out after {_PEER_SSH_TIMEOUT_S:.0f}s "
+                f"(peer unreachable or stalled) — skipped"
+            ),
+        )
     if proc.returncode != 0:
         return SyncResult(
             peer=peer,
@@ -215,6 +266,7 @@ def registry_sync_impl(
     all_peers: bool,
     dry_run: bool,
     as_json: bool,
+    overall_budget_s: float | None = None,
 ) -> int:
     """Click-decoupled core. Returns the intended process exit code.
 
@@ -226,6 +278,13 @@ def registry_sync_impl(
       static peer. Per-peer errors do not abort; the exit code is
       non-zero iff any peer failed.
     * No mode flags → :class:`click.UsageError`.
+
+    ``overall_budget_s`` (``--all`` only) caps the wall-clock the whole
+    sweep may spend. Each peer is already bounded by ``_PEER_SSH_TIMEOUT_S``;
+    this is the second guard so a config with many unreachable peers cannot
+    accumulate into a long block. Once the budget is exhausted, every
+    remaining peer is skipped with a loud per-peer WARN (named + reason)
+    rather than attempted. ``None`` (the CLI default) means unbounded.
     """
     if not (from_peer or to_peer or all_peers):
         raise click.UsageError(
@@ -244,9 +303,32 @@ def registry_sync_impl(
                 err=True,
             )
             return 0
+        import time as _time
+
+        deadline = (
+            None if overall_budget_s is None else _time.monotonic() + overall_budget_s
+        )
+
+        def _budget_skip(pname: str, direction: str) -> SyncResult:
+            return SyncResult(
+                peer=pname,
+                direction=direction,
+                ok=False,
+                error=(
+                    f"overall sync budget ({overall_budget_s:.0f}s) exhausted "
+                    f"before reaching this peer — skipped"
+                ),
+            )
+
         for pname in static:
+            if deadline is not None and _time.monotonic() >= deadline:
+                results.append(_budget_skip(pname, "pull"))
+                continue
             results.append(_pull_from(pname, cfg, dry_run=dry_run))
         for pname in static:
+            if deadline is not None and _time.monotonic() >= deadline:
+                results.append(_budget_skip(pname, "push"))
+                continue
             results.append(_push_to(pname, cfg, dry_run=dry_run))
     else:
         if from_peer:

--- a/src/scitex_agent_container/cli_pkg/listen_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/listen_cmds.py
@@ -111,17 +111,22 @@ def _register_self_comms_node(*, port: int) -> None:
 
 
 def _maybe_sync_on_start() -> None:
-    """ADR-0014 — optionally trigger ``sac registry sync --all`` once at start.
+    """ADR-0014 — optionally trigger ``sac registry sync --all`` once.
 
     Opt-out via the ``comms_nodes.sync_on_start: false`` config flag
     (default True). Best-effort: per-peer failures are logged by the
     sync command itself; we never raise.
 
-    The sync is synchronous so the listen has the latest peer view
-    before it starts answering inbound A2A POSTs — that's the closure
-    on the bidirectionality bug: a Spartan listen that just came up
-    will already know where ``lead`` lives before the first agent on
-    Spartan tries to send to it.
+    NOT on the boot path anymore. This synchronous helper used to run
+    BEFORE ``uvicorn.run`` so the listen had the latest peer view before
+    answering inbound A2A POSTs — but an unreachable static peer made its
+    ssh call hang and blocked the bind, with no error logged (INCIDENT
+    2026-06-26). The startup sync now runs best-effort AFTER the bind, off
+    the event loop, as a lifespan task
+    (:func:`_listen._startup_peer_sync.sync_peers_on_listen_startup`). This
+    helper is retained for explicit/legacy callers only and is bounded by
+    an overall budget so even a direct call can never wedge — but
+    ``_do_start_listen`` no longer invokes it.
     """
     try:
         from .._state.host_config import load
@@ -156,6 +161,9 @@ def _maybe_sync_on_start() -> None:
             all_peers=True,
             dry_run=False,
             as_json=False,
+            # Bound even this legacy/direct path so a re-introduced
+            # pre-bind call can never wedge (defense in depth).
+            overall_budget_s=60.0,
         )
         if rc != 0:
             click.echo(
@@ -317,7 +325,15 @@ def _do_start_listen(
     # (a listen that won't bind because of a registry write is worse
     # than a missing federated row).
     _register_self_comms_node(port=port)
-    _maybe_sync_on_start()
+    # NOTE: the ``comms_nodes`` peer-sync used to run SYNCHRONOUSLY HERE,
+    # before ``uvicorn.run``. That was the live silent-bind-hang vector
+    # (INCIDENT 2026-06-26): a single powered-off static peer made its
+    # un-timed ssh call hang, blocking boot before 7878 ever bound, with no
+    # error logged — the whole fleet lost agent-to-agent comms. The sync now
+    # runs best-effort AFTER the bind, off the event loop, as a lifespan
+    # task (``_listen._startup_peer_sync.sync_peers_on_listen_startup``, wired
+    # in ``_lifecycle._listen_lifespan``). The bind must be impossible to
+    # block; nothing that can hang may run on this pre-bind path.
 
     # Pass the bind port so the lifespan's fail-loud watchdog can probe
     # 127.0.0.1:<port>/v1/health after startup and scream if the daemon

--- a/tests/integration/test_listen_startup_sync_no_bind_block.py
+++ b/tests/integration/test_listen_startup_sync_no_bind_block.py
@@ -1,0 +1,316 @@
+"""Regression: an unreachable static peer must NOT block the ``sac listen`` bind.
+
+INCIDENT 2026-06-26
+===================
+The central ``sac listen`` daemon silently failed to serve — the process
+was alive but port 7878 was never bound (curl returned 000), with NO error
+logged → the whole fleet lost agent-to-agent comms.
+
+Root cause (this vector): ``cli_pkg.listen_cmds._maybe_sync_on_start`` ran a
+SYNCHRONOUS ``sac registry sync --all`` over ssh to every static peer
+(``comms_nodes.peers``) BEFORE ``uvicorn.run`` was reached. That sync had no
+overall timeout, so a single powered-off peer made the ssh call HANG, blocking
+boot before the bind. PR #469's bind-watchdog could not catch this — it lives
+inside ``create_app``, which runs *after* the pre-bind sync.
+
+The fix proven here
+===================
+1. The blocking peer-sync no longer runs on the pre-bind path. It runs
+   best-effort AFTER the bind, off the event loop, as a lifespan task
+   (``_listen._startup_peer_sync.sync_peers_on_listen_startup``).
+2. Defense in depth: each per-peer ssh has a hard ``ConnectTimeout`` + an
+   overall ``subprocess.run(timeout=...)``, and the ``--all`` sweep honours an
+   overall budget — so even a re-introduced pre-bind call fails fast.
+
+No mocks (STX-NM002)
+====================
+These tests exercise REAL behaviour:
+
+* The "unreachable peer" is a REAL ssh subprocess dialing a routable-but-dead
+  address — ``192.0.2.1`` (RFC 5737 TEST-NET-1, guaranteed never routable). The
+  kernel/ssh ``ConnectTimeout`` makes the connect fail fast; nothing is mocked.
+* The bind is a REAL ephemeral TCP socket (``socket.socket().bind``), standing
+  in for the port uvicorn owns, asserted to stay bound across the sync.
+
+The whole point is timing: a hang would never return; we assert the sync
+RETURNS within a wall-clock bound far below an infinite block.
+
+TQ: module docstring states intent (TQ001); each test asserts exactly one fact
+(TQ007); the shared (slow, real-ssh) work is computed once per scenario in a
+fixture so the single-assert split costs no extra ssh round-trips.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import socket
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+import yaml
+
+# A routable-but-dead address: RFC 5737 TEST-NET-1. Packets to it are dropped
+# (never refused-fast, never routed), so an ssh connect can ONLY terminate via
+# ``ConnectTimeout`` — the realistic "host powered off" condition, with zero
+# dependence on any external service being up or down.
+_DEAD_PEER_SSH = "192.0.2.1"
+
+# Hard ceiling for "did it hang?". The per-peer ssh ConnectTimeout is 5s and
+# the overall sweep budget we pass is small; a correct implementation returns
+# in well under this. An un-timed (buggy) sync would block effectively forever,
+# so any value comfortably above one ConnectTimeout but far below "forever"
+# proves the fix. We give generous headroom for slow CI while still being a
+# decisive hang-vs-return discriminator.
+_MAX_WALLCLOCK_S = 45.0
+
+
+@pytest.fixture(scope="module")
+def dead_peer_env(tmp_path_factory: pytest.TempPathFactory):
+    """Real config.yaml whose only static peer is the dead TEST-NET-1 host.
+
+    Module-scoped on purpose: the heavy work that depends on this (a REAL ssh
+    connect to a dead host, bounded only by ConnectTimeout) is slow, so we set
+    up the env ONCE and let the per-scenario fixtures below run their single
+    ssh sweep once each — keeping the one-assert-per-test split (TQ007) from
+    multiplying real connect-timeout waits. Env + state.db are saved and
+    restored by hand because pytest's ``monkeypatch`` / the repo's
+    ``env_save_restore`` are function-scoped.
+
+    Also pins state.db so the sync's import side has a real, isolated DB to
+    write to (it won't, since the peer is unreachable, but the code path must
+    have a valid target).
+    """
+    import os
+
+    tmp = tmp_path_factory.mktemp("dead_peer_env")
+    cfg = tmp / "config.yaml"
+    cfg.write_text(
+        yaml.safe_dump(
+            {
+                "host": {"canonical": "test-local"},
+                "peers": {
+                    # Single static peer, pointed at the dead address. No
+                    # ``via`` hops — we want to exercise the direct ssh path.
+                    "deadpeer": {"ssh": _DEAD_PEER_SSH},
+                },
+            }
+        )
+    )
+    db = tmp / "state.db"
+
+    saved = {
+        k: os.environ.get(k)
+        for k in ("SCITEX_AGENT_CONTAINER_CONFIG", "SCITEX_AGENT_CONTAINER_STATE_DB")
+    }
+    os.environ["SCITEX_AGENT_CONTAINER_CONFIG"] = str(cfg)
+    os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
+    import scitex_agent_container._state.state_db as _state_db_mod
+
+    importlib.reload(_state_db_mod)
+    try:
+        yield tmp
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        importlib.reload(_state_db_mod)
+
+
+def _bind_ephemeral_socket() -> socket.socket:
+    """Bind+listen on a real ephemeral 127.0.0.1 port (stands in for uvicorn)."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    s.bind(("127.0.0.1", 0))
+    s.listen(8)
+    return s
+
+
+# ---------------------------------------------------------------------------
+# Defense-in-depth: the synchronous all-peers sync returns fast on a dead peer.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _SyncOutcome:
+    rc: int
+    elapsed_s: float
+    output: str
+
+
+@pytest.fixture(scope="module")
+def sync_all_outcome(dead_peer_env: Path) -> _SyncOutcome:
+    """Run the all-peers sync ONCE against the dead peer; capture the outcome.
+
+    Module-scoped so the single real-ssh round-trip is shared by every
+    assertion below — the one-assert-per-test split (TQ007) adds no extra
+    connect-timeout waits. Output is captured via ``redirect_std*`` into a
+    buffer (not ``capsys``, which is function-scoped) so the sync's loud
+    ``click.echo(..., err=True)`` [FAIL] line is observable at module scope.
+    """
+    import contextlib
+    import io
+
+    from scitex_agent_container.cli_pkg._registry_sync import registry_sync_impl
+
+    buf_out, buf_err = io.StringIO(), io.StringIO()
+    start = time.monotonic()
+    with contextlib.redirect_stdout(buf_out), contextlib.redirect_stderr(buf_err):
+        rc = registry_sync_impl(
+            from_peer=None,
+            to_peer=None,
+            all_peers=True,
+            dry_run=False,
+            as_json=False,
+            overall_budget_s=_MAX_WALLCLOCK_S,
+        )
+    elapsed = time.monotonic() - start
+    return _SyncOutcome(
+        rc=rc, elapsed_s=elapsed, output=buf_err.getvalue() + buf_out.getvalue()
+    )
+
+
+def test_registry_sync_all_returns_instead_of_hanging_on_unreachable_peer(
+    sync_all_outcome: _SyncOutcome,
+) -> None:
+    # Arrange — the fixture wrote the dead-peer config + pinned state.db.
+    # Act — the fixture ran the real-ssh all-peers sync once, timing it.
+    elapsed_s = sync_all_outcome.elapsed_s
+    # Assert — it RETURNED well within the ceiling. A pre-fix un-timed sync
+    # would block here forever.
+    assert elapsed_s < _MAX_WALLCLOCK_S, (
+        f"all-peers sync took {sync_all_outcome.elapsed_s:.1f}s against an "
+        f"unreachable peer — it hung instead of failing fast "
+        f"(ceiling {_MAX_WALLCLOCK_S:.0f}s)."
+    )
+
+
+def test_registry_sync_all_reports_unreachable_peer_as_failure(
+    sync_all_outcome: _SyncOutcome,
+) -> None:
+    # Arrange — the fixture wrote the dead-peer config + pinned state.db.
+    # Act — the fixture ran the real-ssh all-peers sync once.
+    rc = sync_all_outcome.rc
+    # Assert — non-zero rc: an unreachable peer is surfaced as a failure, not a
+    # false success that silently swallows the lost sync.
+    assert rc != 0, (
+        "sync against an unreachable peer returned rc=0 (false success) — an "
+        "unreachable peer must be surfaced as a failure, not silently swallowed."
+    )
+
+
+def test_registry_sync_all_names_unreachable_peer_in_loud_failure_line(
+    sync_all_outcome: _SyncOutcome,
+) -> None:
+    # Arrange — the fixture wrote the dead-peer config + captured sync output.
+    # Act — read the captured stderr/stdout from the single real-ssh sweep.
+    output = sync_all_outcome.output
+    # Assert — FAIL LOUD: the dead peer is named in a [FAIL] line so the
+    # operator can act, rather than the failure being silent.
+    has_named_fail = "deadpeer" in output and "FAIL" in output
+    assert has_named_fail, (
+        "the unreachable peer was not named in a loud [FAIL] line; failures "
+        f"must be surfaced, not swallowed. Output was:\n{sync_all_outcome.output}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Primary fix: the post-bind startup-sync task completes while a real bound
+# socket (the uvicorn stand-in) stays bound — i.e. the sync can never block it.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _PostBindOutcome:
+    elapsed_s: float
+    bound_port: int
+
+
+@pytest.fixture
+def post_bind_sync_outcome(dead_peer_env: Path) -> _PostBindOutcome:
+    """Bind a REAL socket, then drive the actual post-bind sync coroutine once.
+
+    Mirrors uvicorn owning the port BEFORE the best-effort sync runs. The
+    socket stays bound for the duration so the assertions below can probe it.
+    """
+    from scitex_agent_container._listen._startup_peer_sync import (
+        sync_peers_on_listen_startup,
+    )
+
+    sock = _bind_ephemeral_socket()
+    bound_port = sock.getsockname()[1]
+    try:
+
+        async def _drive() -> None:
+            # The real coroutine the lifespan schedules. It dispatches the
+            # blocking ssh sweep via asyncio.to_thread and is bounded; the
+            # outer wait_for here is the test's own hang-detector.
+            await asyncio.wait_for(
+                sync_peers_on_listen_startup(timeout_s=_MAX_WALLCLOCK_S),
+                timeout=_MAX_WALLCLOCK_S,
+            )
+
+        start = time.monotonic()
+        # Never raises on best-effort failure; must simply RETURN.
+        asyncio.run(_drive())
+        elapsed = time.monotonic() - start
+
+        # Capture whether the bind is still held WHILE the socket is open — a
+        # fresh bind to the same port must fail (port already in use).
+        port_still_bound = False
+        probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            probe.bind(("127.0.0.1", bound_port))
+        except OSError:
+            port_still_bound = True
+        finally:
+            probe.close()
+    finally:
+        sock.close()
+
+    if not port_still_bound:
+        pytest.fail(
+            "the ephemeral bind was lost during the sync — the sync disturbed "
+            "the bound port, which it must never do."
+        )
+    return _PostBindOutcome(elapsed_s=elapsed, bound_port=bound_port)
+
+
+def test_post_bind_startup_sync_returns_within_budget_on_unreachable_peer(
+    post_bind_sync_outcome: _PostBindOutcome,
+) -> None:
+    # Arrange — the fixture bound a real ephemeral socket (uvicorn stand-in).
+    # Act — the fixture drove the real post-bind sync coroutine once, timing it.
+    elapsed_s = post_bind_sync_outcome.elapsed_s
+    # Assert — the post-bind sync returned within budget; on the old path this
+    # same work ran BEFORE the bind and would have blocked it forever.
+    assert elapsed_s < _MAX_WALLCLOCK_S, (
+        f"post-bind startup sync took {post_bind_sync_outcome.elapsed_s:.1f}s "
+        f"against an unreachable peer — it would have blocked uvicorn's bind on "
+        f"the old path."
+    )
+
+
+def test_startup_sync_is_not_invoked_on_the_pre_bind_path(dead_peer_env: Path) -> None:
+    # Arrange — guard the structural invariant the incident turned on: the
+    # daemon-start path must reach the bind WITHOUT first running the blocking
+    # peer-sync. We assert the pre-bind helper no longer calls the synchronous
+    # sync, so a powered-off peer can never wedge boot before ``uvicorn.run``.
+    import inspect
+
+    from scitex_agent_container.cli_pkg import listen_cmds
+
+    # Act
+    src = inspect.getsource(listen_cmds._do_start_listen)
+
+    # Assert — the synchronous pre-bind sync call is gone from the start path.
+    assert "_maybe_sync_on_start()" not in src, (
+        "_do_start_listen still calls the synchronous _maybe_sync_on_start() "
+        "before uvicorn.run — that is the exact pre-bind hang vector "
+        "(INCIDENT 2026-06-26). The peer-sync must run AFTER the bind, off the "
+        "event loop, via the lifespan task."
+    )

--- a/tests/integration/test_listen_startup_sync_no_bind_block.py
+++ b/tests/integration/test_listen_startup_sync_no_bind_block.py
@@ -67,7 +67,7 @@ _DEAD_PEER_SSH = "192.0.2.1"
 _MAX_WALLCLOCK_S = 45.0
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def dead_peer_env(tmp_path_factory: pytest.TempPathFactory):
     """Real config.yaml whose only static peer is the dead TEST-NET-1 host.
 
@@ -142,7 +142,7 @@ class _SyncOutcome:
     output: str
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def sync_all_outcome(dead_peer_env: Path) -> _SyncOutcome:
     """Run the all-peers sync ONCE against the dead peer; capture the outcome.
 
@@ -231,7 +231,7 @@ class _PostBindOutcome:
 
 
 @pytest.fixture
-def post_bind_sync_outcome(dead_peer_env: Path) -> _PostBindOutcome:
+def post_bind_sync_outcome(dead_peer_env: Path):
     """Bind a REAL socket, then drive the actual post-bind sync coroutine once.
 
     Mirrors uvicorn owning the port BEFORE the best-effort sync runs. The
@@ -277,7 +277,7 @@ def post_bind_sync_outcome(dead_peer_env: Path) -> _PostBindOutcome:
             "the ephemeral bind was lost during the sync — the sync disturbed "
             "the bound port, which it must never do."
         )
-    return _PostBindOutcome(elapsed_s=elapsed, bound_port=bound_port)
+    yield _PostBindOutcome(elapsed_s=elapsed, bound_port=bound_port)
 
 
 def test_post_bind_startup_sync_returns_within_budget_on_unreachable_peer(


### PR DESCRIPTION
## Summary

Fixes the remaining live vector behind INCIDENT 2026-06-26 (todo card `sac-listen-startup-sync-hangs`): the central `sac listen` was alive but never bound 7878 (curl 000), with NO error logged, so the whole fleet lost agent-to-agent comms.

**Root cause (this vector):** `_do_start_listen` ran a SYNCHRONOUS `registry_sync_impl(all_peers=True)` over SSH to every static peer (`comms_nodes.peers`) BEFORE `uvicorn.run`. With no overall timeout, a single powered-off peer made the SSH call HANG, blocking boot before the bind. PR #469's in-app bind-watchdog cannot catch this — that watchdog lives inside `create_app`, which runs *after* the pre-bind sync. The host `comms_nodes.sync_on_start: false` flag only mitigated the non-default path.

## Fix — the bind must be impossible to block

- **Primary:** the peer-sync no longer runs on the pre-bind path. It runs best-effort **after** the bind, **off the event loop**, as a lifespan task (`_listen._startup_peer_sync.sync_peers_on_listen_startup`), dispatching the blocking SSH sweep via `asyncio.to_thread` + a bounded `wait_for` — mirroring the exact pattern #469 used to background self-peer persistence and the startup loops.
- **Defense in depth:** per-peer SSH gets a tight `ConnectTimeout=5` **and** an overall `subprocess.run(timeout=15)`; the `--all` sweep honours an overall budget; the legacy `_maybe_sync_on_start` (no longer on the boot path, kept for the two existing direct-call tests) is bounded too — so even a re-introduced pre-bind call fails fast, never wedges.
- **Fail loud:** an unreachable/skipped peer emits a WARN naming the peer + reason (`[FAIL] pull deadpeer: ssh timed out ...`); never a silent hang, never a silent swallow.
- **Preserves intent:** the `comms_nodes` peer-registry sync still happens (best-effort, after bind), gated by the same `comms_nodes.sync_on_start` opt-out.

## Files

- `src/scitex_agent_container/cli_pkg/listen_cmds.py` — drop the synchronous pre-bind `_maybe_sync_on_start()` call; document why nothing that can hang may run pre-bind.
- `src/scitex_agent_container/_listen/_startup_peer_sync.py` (new) — async post-bind hook; runs the blocking sweep off-loop, bounded, fail-loud.
- `src/scitex_agent_container/_lifecycle/_listen_lifespan.py` — launch the hook as a backgrounded lifespan task (cancelled cleanly on teardown; `SAC_LISTEN_STARTUP_SYNC_DISABLED=1` opt-out).
- `src/scitex_agent_container/cli_pkg/_registry_sync.py` — per-peer SSH `timeout` + tighter `ConnectTimeout`, overall sweep budget, skip-unreachable-and-WARN.
- `tests/integration/test_listen_startup_sync_no_bind_block.py` (new) — regression.

## How the test forces the unreachable-peer condition without mocks (STX-NM002)

It points a real static peer at a **routable-but-dead** address — `192.0.2.1` (RFC 5737 TEST-NET-1, guaranteed never routable) — and drives the **real** ssh sync. The kernel/ssh `ConnectTimeout` makes the connect fail fast; nothing is mocked. It then asserts:

1. `registry_sync_impl(all_peers=True)` **returns within budget** instead of hanging, and names the dead peer in a loud `[FAIL]` line (a pre-fix un-timed sync would block forever — the test's wall-clock ceiling is the hang-vs-return discriminator).
2. The **real** post-bind coroutine completes while a **real ephemeral `socket.bind()`** (the uvicorn stand-in) stays bound — proving the sync can never disturb/block the bind.
3. Structural guard: `_do_start_listen` no longer calls the synchronous sync on the pre-bind path.

## Test plan

- [x] `tests/integration/test_listen_startup_sync_no_bind_block.py` — 5 passed (real ssh to dead IP + real socket).
- [x] `tests/scitex_agent_container/cli_pkg/test__registry_sync.py` + `test_listen_cmds_comms_nodes.py` — 24 passed (no regressions on the touched modules).
- [x] Full `tests/scitex_agent_container/_lifecycle` + `_listen` suites — 1062 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)