### PR TITLE
feat(listen): liveness-tick reconciler — emit anomaly on stuck open cards (alarm-engine producer)

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_listen_lifespan.py
+++ b/src/scitex_agent_container/_lifecycle/_listen_lifespan.py
@@ -8,11 +8,12 @@ module line budget) AND the focal point of the silent-bind-hang fix
 The lifespan:
 
   1. ``await`` the one-shot self-peer persistence (app ready);
-  2. launch the three background loops — periodic-drive, GitHub-CI
-     poll, TUI-heartbeat — each honouring its disable env var. Their
-     startup paths now route every blocking ``gh``/``tmux``/FS call
-     through ``_off_loop.run_blocking*`` so none can starve uvicorn's
-     bind (the root cause of the silent fleet-comms outage);
+  2. launch the background loops — periodic-drive, GitHub-CI poll,
+     TUI-heartbeat, liveness-tick reconciler — each honouring its
+     disable env var. Their startup paths route every blocking
+     ``gh``/``tmux``/FS call through ``_off_loop.run_blocking*`` so none
+     can starve uvicorn's bind (the root cause of the silent fleet-comms
+     outage);
   3. launch the fail-loud bind watchdog (``_bind_watchdog``) when a
      port is known, so an up-but-not-serving daemon can NEVER stay
      silent;
@@ -38,6 +39,15 @@ def build_listen_lifespan(*, health_watchdog_port: int | None = None):
     CLI passes the port it hands to ``uvicorn.run``; in-process tests may
     omit it (no watchdog) or pass a real bound port.
     """
+    from .._listen._liveness_tick import (
+        DEFAULT_INTERVAL_S as DEFAULT_LIVENESS_TICK_INTERVAL_S,
+        DEFAULT_RENOTIFY_S as DEFAULT_LIVENESS_TICK_RENOTIFY_S,
+        DEFAULT_STALE_S as DEFAULT_LIVENESS_TICK_STALE_S,
+        ENV_INTERVAL_S as LIVENESS_TICK_ENV_INTERVAL_S,
+        ENV_RENOTIFY_S as LIVENESS_TICK_ENV_RENOTIFY_S,
+        ENV_STALE_S as LIVENESS_TICK_ENV_STALE_S,
+        liveness_tick_reconciler_loop,
+    )
     from ._bind_watchdog import bind_watchdog_loop
     from ._github_ci_poll_loop import (
         DEFAULT_CI_POLL_INTERVAL_S,
@@ -48,6 +58,12 @@ def build_listen_lifespan(*, health_watchdog_port: int | None = None):
         DEFAULT_TUI_HEARTBEAT_INTERVAL_S,
         tui_heartbeat_loop,
     )
+
+    def _env_float(name: str, default: float) -> float:
+        try:
+            return float(os.environ.get(name, default))
+        except (TypeError, ValueError):
+            return default
 
     # Imported lazily inside the helper below to avoid a server↔lifecycle
     # import cycle at module load.
@@ -115,6 +131,30 @@ def build_listen_lifespan(*, health_watchdog_port: int | None = None):
         tui_hb_task = asyncio.create_task(tui_heartbeat_loop(interval_s=_tui_hb_interval))
         app.state.tui_heartbeat_task = tui_hb_task
         tasks.append(tui_hb_task)
+
+        # Liveness-tick reconciler (card sac-card-anchored-stop-reconciler):
+        # deterministic alarm-engine producer — reads cards (truth) vs.
+        # real agent activity and emits an anomaly on the
+        # ``scitex_todo.hooks`` bus when an OPEN, unblocked card's owner is
+        # dead/idle past the stale threshold. Its FS/registry reads route
+        # through ``_off_loop`` so it can never starve the bind. Honour
+        # SAC_LIVENESS_TICK_DISABLED=1 to skip launching.
+        if os.environ.get("SAC_LIVENESS_TICK_DISABLED", "") != "1":
+            lt_task = asyncio.create_task(
+                liveness_tick_reconciler_loop(
+                    interval_s=_env_float(
+                        LIVENESS_TICK_ENV_INTERVAL_S, DEFAULT_LIVENESS_TICK_INTERVAL_S
+                    ),
+                    stale_s=_env_float(
+                        LIVENESS_TICK_ENV_STALE_S, DEFAULT_LIVENESS_TICK_STALE_S
+                    ),
+                    renotify_s=_env_float(
+                        LIVENESS_TICK_ENV_RENOTIFY_S, DEFAULT_LIVENESS_TICK_RENOTIFY_S
+                    ),
+                )
+            )
+            app.state.liveness_tick_task = lt_task
+            tasks.append(lt_task)
 
         # FAIL-LOUD bind watchdog (operator: "when failure occurs, fail
         # loud"). If we know the bind port, probe it shortly after startup

--- a/src/scitex_agent_container/_listen/_liveness_tick.py
+++ b/src/scitex_agent_container/_listen/_liveness_tick.py
@@ -1,0 +1,364 @@
+"""Liveness-tick reconciler: ALARM on a stuck OPEN card (alarm-engine producer).
+
+Card ``sac-card-anchored-stop-reconciler``. PRINCIPLE (operator): do not
+trust agentic flow; harness it deterministically. The scitex-todo CARD
+is the anchor of truth — a card stays OPEN until explicitly resolved.
+This is the deterministic reconciler that runs INSIDE ``sac listen``,
+reads cards (truth) vs. real agent activity, and ALARMS on a mismatch so
+a stuck/crashed agent can never sit silent.
+
+SEPARATION OF CONCERNS (locked with the scitex-todo team): **sac only
+DETECTS and EMITS.** sac does NOT write to the card store. We emit an
+anomaly event on the ``scitex_todo.hooks`` entry-point bus; scitex-todo's
+own consumer (registered separately, on their side) turns it into a card
+record + operator push. Nothing here writes ``tasks.yaml``.
+
+Bind-safety (cards ``sac-listen-self-peer-persist-blocks-bind`` /
+``sac-listen-watchdog-autorestart-alarm``): the only blocking IO — reading
+``tasks.yaml`` + each owner's ``session.jsonl`` + the active-instances
+registry — runs through :func:`_off_loop.run_blocking_or`, so a
+slow/locked read can NEVER starve uvicorn's bind or the running server.
+
+This module is the IO + emit + loop glue; the pure reconcile rule lives
+in :mod:`_liveness_tick_detect` and is re-exported here.
+
+Event shape (locked proposal)::
+
+    {"agent": str, "card_id": str, "reason": str,
+     "severity": str, "ts": float}
+
+``reason`` ∈ {"owner-not-live", "owner-idle"}; ``severity`` scales with
+staleness ("warning" → "critical").
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from datetime import timezone
+from pathlib import Path
+from typing import Any, Callable, Iterable
+
+from ._liveness_tick_detect import (  # re-exported public surface
+    AgentLiveness,
+    StuckCard,
+    find_stuck_cards,
+    open_card_owners,
+)
+
+logger = logging.getLogger(__name__)
+
+# --- env knobs (conservative defaults to avoid false alarms) ----------------
+ENV_DISABLED = "SAC_LIVENESS_TICK_DISABLED"
+ENV_INTERVAL_S = "SAC_LIVENESS_TICK_INTERVAL_S"
+ENV_STALE_S = "SAC_LIVENESS_TICK_STALE_S"
+ENV_RENOTIFY_S = "SAC_LIVENESS_TICK_RENOTIFY_S"
+
+DEFAULT_INTERVAL_S = 120.0
+DEFAULT_STALE_S = 900.0
+DEFAULT_RENOTIFY_S = 3600.0
+
+# The entry-point bus sac emits an anomaly onto. scitex-todo registers
+# its consumer here (separately, on their side); sac is the FIRST
+# producer — until a consumer is registered the emit degrades to a logged
+# line.
+HOOKS_ENTRY_POINT_GROUP = "scitex_todo.hooks"
+
+
+# --- IO resolvers (run OFF the event loop via run_blocking_or) --------------
+
+
+def _default_tasks_path() -> Path:
+    from .._lifecycle._ci_owner import _default_tasks_path as _p
+
+    return _p()
+
+
+def _load_tasks_doc(tasks_path: Path) -> dict:
+    """Read + parse ``tasks.yaml``. Fail-soft: unreadable ⇒ ``{}``."""
+    if not tasks_path.is_file():
+        return {}
+    import yaml
+
+    try:
+        doc = yaml.safe_load(tasks_path.read_text()) or {}
+    except Exception:  # stx-allow: fallback (unreadable tasks store → no cards this tick)
+        return {}
+    return doc if isinstance(doc, dict) else {}
+
+
+def _session_last_active_ts(name: str) -> float | None:
+    """Epoch seconds of ``name``'s session.jsonl last-record, or ``None``.
+
+    Reads the last non-empty JSONL line carrying a ``ts``/``timestamp``
+    via the same parser the SSE tail uses. Fail-soft: a missing /
+    unreadable / tsless session yields ``None`` (unknown)."""
+    from ._tail import _record_ts, _runtime_session_jsonl
+
+    path = _runtime_session_jsonl(name)
+    if not path.is_file():
+        return None
+    import json as _json
+
+    last_ts: float | None = None
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    record = _json.loads(line)
+                except _json.JSONDecodeError:
+                    continue
+                if not isinstance(record, dict):
+                    continue
+                dt = _record_ts(record)
+                if dt is not None:
+                    if dt.tzinfo is None:
+                        dt = dt.replace(tzinfo=timezone.utc)
+                    last_ts = dt.timestamp()
+    except OSError:  # stx-allow: fallback (unreadable session → unknown activity)
+        return None
+    return last_ts
+
+
+def _live_agent_pids() -> dict[str, int]:
+    """Map active-agent name → recorded pid, from the instances registry.
+
+    Reuses the existing ``list_active_instances`` reader (``ended_at IS
+    NULL`` rows) rather than reinventing a liveness store. Fail-soft: any
+    registry hiccup ⇒ ``{}`` (nobody-live this tick — the SAFE direction:
+    a card resolves to ``owner-not-live`` only once it is ALSO stale, so a
+    transient registry blip cannot spam)."""
+    try:
+        from .._state.state_db import list_active_instances
+
+        rows = list_active_instances()
+    except Exception:  # stx-allow: fallback (registry transient → nobody resolved this tick)
+        return {}
+    out: dict[str, int] = {}
+    for row in rows or []:
+        try:
+            name = str(row.get("name", "")).strip()
+            pid = row.get("pid")
+            if name and isinstance(pid, int):
+                out.setdefault(name, pid)  # newest row wins (DESC order)
+        except Exception:  # stx-allow: fallback (one bad row contributes nothing)
+            continue
+    return out
+
+
+def resolve_liveness(owners: Iterable[str]) -> dict[str, AgentLiveness]:
+    """Resolve each owner agent → :class:`AgentLiveness` (BLOCKING — run
+    off-loop). ``is_live`` is "active registry row AND pid alive"; the
+    session timestamp comes from ``session.jsonl``'s last record."""
+    from ._agent_exec_liveness import _pid_alive
+
+    pids = _live_agent_pids()
+    out: dict[str, AgentLiveness] = {}
+    for owner in owners:
+        pid = pids.get(owner)
+        is_live = bool(pid is not None and _pid_alive(pid))
+        last_active = _session_last_active_ts(owner) if is_live else None
+        out[owner] = AgentLiveness(is_live=is_live, last_active_ts=last_active)
+    return out
+
+
+def _resolve_doc_and_liveness(tasks_path: Path) -> tuple[dict, dict[str, AgentLiveness]]:
+    """One blocking unit: load the doc, then resolve liveness for exactly
+    the owners of its OPEN, unblocked cards. Bundled so the loop makes a
+    SINGLE off-loop call per tick."""
+    doc = _load_tasks_doc(tasks_path)
+    owners = open_card_owners(doc)
+    liveness = resolve_liveness(owners) if owners else {}
+    return doc, liveness
+
+
+# --- bus emit (degrade gracefully) ------------------------------------------
+
+
+def _load_hook_consumers() -> list[Callable[[dict], Any]]:
+    """Load every callable registered on the ``scitex_todo.hooks`` group.
+
+    Uses the stdlib selectable ``entry_points`` API. Fail-soft per entry:
+    one un-loadable entry-point contributes nothing. Returns ``[]`` when
+    the group is empty (no consumer registered yet)."""
+    from importlib.metadata import entry_points
+
+    try:
+        eps = entry_points(group=HOOKS_ENTRY_POINT_GROUP)
+    except Exception:  # stx-allow: fallback (metadata read hiccup → no consumers this call)
+        return []
+    consumers: list[Callable[[dict], Any]] = []
+    for ep in eps:
+        try:
+            fn = ep.load()
+        except Exception as exc:  # stx-allow: fallback (one bad entry-point contributes nothing)
+            logger.warning(
+                "liveness_tick: failed to load %s consumer %r: %s",
+                HOOKS_ENTRY_POINT_GROUP,
+                getattr(ep, "name", ep),
+                exc,
+            )
+            continue
+        if callable(fn):
+            consumers.append(fn)
+    return consumers
+
+
+def emit_anomaly(event: dict, consumers: Iterable[Callable[[dict], Any]]) -> int:
+    """Deliver ``event`` to each consumer DEFENSIVELY. Returns the count
+    that accepted it.
+
+    A consumer that raises is logged and skipped — it can NEVER crash the
+    loop. An empty ``consumers`` iterable delivers to nobody and returns 0
+    (the caller logs the once-at-startup "no consumer" line)."""
+    delivered = 0
+    for fn in consumers:
+        try:
+            fn(event)
+            delivered += 1
+        except Exception as exc:  # stx-allow: fallback (a consumer failure must never crash the alarm loop)
+            logger.warning(
+                "liveness_tick: scitex_todo.hooks consumer %r raised on emit "
+                "(%s); continuing — the alarm loop must stay up",
+                getattr(fn, "__name__", fn),
+                exc,
+            )
+    return delivered
+
+
+def _build_event(stuck: StuckCard, now: float) -> dict:
+    return {
+        "agent": stuck.agent,
+        "card_id": stuck.card_id,
+        "reason": stuck.reason,
+        "severity": stuck.severity,
+        "ts": now,
+    }
+
+
+async def liveness_tick_reconciler_loop(
+    *,
+    interval_s: float = DEFAULT_INTERVAL_S,
+    stale_s: float = DEFAULT_STALE_S,
+    renotify_s: float = DEFAULT_RENOTIFY_S,
+    tasks_path: Path | None = None,
+    tasks_doc_source: dict | None = None,
+    liveness_source: dict[str, AgentLiveness] | None = None,
+    consumers_source: "Iterable[Callable[[dict], Any]] | None" = None,
+    now_fn: Callable[[], float] = time.time,
+) -> None:
+    """Long-running task launched by the ``sac listen`` lifespan.
+
+    Each tick: resolve ``tasks.yaml`` + owner liveness OFF the event loop
+    (bind-safe), run the pure :func:`find_stuck_cards` rule, and emit one
+    anomaly event per newly-stuck ``(agent, card_id)`` onto the
+    ``scitex_todo.hooks`` bus. DEDUP: at most one emit per ``(agent,
+    card_id)`` per ``renotify_s`` cooldown (in-memory; the daemon is
+    long-running), so a persistently-stuck card does NOT spam per tick.
+
+    Injection seams (tests): ``tasks_doc_source`` / ``liveness_source``
+    bypass the off-loop FS/registry reads; ``consumers_source`` supplies a
+    real local consumer list instead of the entry-point lookup. Production
+    leaves them ``None``.
+
+    Failure modes mirror ``periodic_drive_loop``: a tick body that raises
+    is logged + retried (the loop must not die); cancellation is honoured
+    at the sleep boundary and re-raised cleanly.
+    """
+    tasks_path = tasks_path if tasks_path is not None else _default_tasks_path()
+    logger.info(
+        "liveness_tick: starting (interval_s=%.1f stale_s=%.1f renotify_s=%.1f)",
+        interval_s,
+        stale_s,
+        renotify_s,
+    )
+
+    # Startup probe: warn ONCE if no consumer is registered yet (sac is the
+    # first producer; scitex-todo registers its consumer separately).
+    if consumers_source is None and not _load_hook_consumers():
+        logger.warning(
+            "liveness_tick: no %s consumer registered — anomalies will be "
+            "DETECTED and logged but not delivered until scitex-todo "
+            "registers its consumer (sac is the first producer on this bus)",
+            HOOKS_ENTRY_POINT_GROUP,
+        )
+
+    last_emit_at: dict[tuple[str, str], float] = {}
+    try:
+        while True:
+            try:
+                if tasks_doc_source is not None or liveness_source is not None:
+                    doc = tasks_doc_source if tasks_doc_source is not None else {}
+                    liveness = liveness_source if liveness_source is not None else {}
+                else:
+                    # DEFENSE IN DEPTH (cards sac-listen-self-peer-persist-
+                    # blocks-bind / sac-listen-watchdog-autorestart-alarm):
+                    # the doc read + session.jsonl reads + registry read are
+                    # blocking FS/SQLite. Run them OFF the event loop with a
+                    # hard timeout so a slow/locked read can never starve
+                    # uvicorn's bind or the running listen server.
+                    from .._lifecycle._off_loop import run_blocking_or
+
+                    doc, liveness = await run_blocking_or(
+                        _resolve_doc_and_liveness,
+                        tasks_path,
+                        default=({}, {}),
+                        op="liveness_tick resolve (tasks.yaml + session/registry FS)",
+                        timeout_s=max(interval_s, 15.0),
+                    )
+
+                now = now_fn()
+                stuck = find_stuck_cards(doc, liveness, now=now, stale_s=stale_s)
+
+                if consumers_source is not None:
+                    consumers = list(consumers_source)
+                else:
+                    consumers = _load_hook_consumers()
+
+                for sc in stuck:
+                    key = (sc.agent, sc.card_id)
+                    prev = last_emit_at.get(key)
+                    if prev is not None and (now - prev) < renotify_s:
+                        continue  # within re-notify cooldown → suppress spam
+                    event = _build_event(sc, now)
+                    logger.warning(
+                        "liveness_tick: ANOMALY agent=%s card=%s reason=%s "
+                        "severity=%s stale_for=%.0fs",
+                        sc.agent,
+                        sc.card_id,
+                        sc.reason,
+                        sc.severity,
+                        sc.stale_for_s,
+                    )
+                    emit_anomaly(event, consumers)
+                    last_emit_at[key] = now
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:  # stx-allow: fallback (loop must not die on a transient FS/registry error)
+                logger.warning("liveness_tick: tick failed (%s); sleeping + retry", exc)
+            await asyncio.sleep(interval_s)
+    except asyncio.CancelledError:
+        logger.info("liveness_tick: cancelled cleanly")
+        raise
+
+
+__all__ = [
+    "AgentLiveness",
+    "DEFAULT_INTERVAL_S",
+    "DEFAULT_RENOTIFY_S",
+    "DEFAULT_STALE_S",
+    "ENV_DISABLED",
+    "ENV_INTERVAL_S",
+    "ENV_RENOTIFY_S",
+    "ENV_STALE_S",
+    "HOOKS_ENTRY_POINT_GROUP",
+    "StuckCard",
+    "emit_anomaly",
+    "find_stuck_cards",
+    "liveness_tick_reconciler_loop",
+    "resolve_liveness",
+]

--- a/src/scitex_agent_container/_listen/_liveness_tick_detect.py
+++ b/src/scitex_agent_container/_listen/_liveness_tick_detect.py
@@ -1,0 +1,210 @@
+"""Pure detection core for the liveness-tick reconciler (no IO, no asyncio).
+
+Card ``sac-card-anchored-stop-reconciler``. Split out of
+``_liveness_tick`` (the loop/IO glue) so the reconcile RULE is
+unit-testable against a real in-memory tasks doc + real liveness inputs,
+mirroring how ``_periodic_drive`` (pure core) is separate from
+``_periodic_drive_loop`` (loop glue).
+
+The rule keeps false positives low: a card fires an anomaly ONLY when it
+is OPEN, has an assignee, declares NO blocker, and its ``last_activity``
+is older than ``stale_s`` — and then ``owner-not-live`` if the owner
+agent is not live, else ``owner-idle`` if the owner is live but its
+session.jsonl last-record is also older than ``stale_s``; otherwise the
+owner is progressing and nothing fires.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+# A card whose ``status`` is one of these is NOT open (terminal/resolved
+# or an intentionally-parked state that already declares why it isn't
+# progressing). ``blocked`` / ``deferred`` / ``coordinating`` are treated
+# as "carries a declared blocker" — the card is parked on purpose, so it
+# must not alarm even with an empty ``blocker`` field.
+TERMINAL_STATUSES = frozenset(
+    {
+        "done",
+        "closed",
+        "cancelled",
+        "canceled",
+        "archived",
+        "wontfix",
+        "resolved",
+        "complete",
+        "completed",
+    }
+)
+PARKED_STATUSES = frozenset({"blocked", "deferred", "coordinating"})
+
+# severity ladder: scale with how far past ``stale_s`` the card drifted.
+_SEVERITY_CRITICAL_MULT = 4.0
+
+
+@dataclass(frozen=True)
+class StuckCard:
+    """A detected anomaly: an OPEN, unblocked, stale card whose owner is
+    not progressing. :func:`find_stuck_cards` returns these; the loop
+    turns each into a ``scitex_todo.hooks`` bus event."""
+
+    agent: str
+    card_id: str
+    reason: str  # "owner-not-live" | "owner-idle"
+    severity: str  # "warning" | "critical"
+    stale_for_s: float
+
+
+@dataclass(frozen=True)
+class AgentLiveness:
+    """Resolved liveness for one owner agent — the input the rule reads.
+
+    ``is_live`` — owner process is alive (registry row + ``_pid_alive``).
+    ``last_active_ts`` — epoch seconds of the owner's session.jsonl
+    last-record, or ``None`` when unknown (no session yet)."""
+
+    is_live: bool
+    last_active_ts: float | None
+
+
+def _parse_iso_ts(value: Any) -> float | None:
+    """Parse an ISO-8601 ``last_activity`` (``...Z`` or offset) to epoch s.
+
+    Returns ``None`` for missing/unparseable values so the rule can treat
+    "no known activity" distinctly from "recently active"."""
+    if not isinstance(value, str) or not value:
+        return None
+    s = value.strip()
+    if s.endswith("Z"):
+        s = s[:-1] + "+00:00"
+    try:
+        dt = datetime.fromisoformat(s)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.timestamp()
+
+
+def _is_open(status: Any) -> bool:
+    """True iff a card's ``status`` is neither terminal nor parked."""
+    s = str(status or "").strip().lower()
+    return bool(s) and s not in TERMINAL_STATUSES and s not in PARKED_STATUSES
+
+
+def _has_blocker(task: dict) -> bool:
+    """True iff the card declares a blocker (top-level ``blocker`` field).
+
+    The card author has stated WHY it isn't progressing, so it must not
+    alarm. A parked ``status`` is handled separately by :func:`_is_open`."""
+    blocker = task.get("blocker")
+    return isinstance(blocker, str) and bool(blocker.strip())
+
+
+def _severity_for(stale_for_s: float, stale_s: float) -> str:
+    """warning until ``_SEVERITY_CRITICAL_MULT × stale_s``, then critical."""
+    if stale_s > 0 and stale_for_s >= stale_s * _SEVERITY_CRITICAL_MULT:
+        return "critical"
+    return "warning"
+
+
+def open_card_owners(tasks_doc: dict) -> set[str]:
+    """Owner agent names of OPEN, unblocked cards — the set whose liveness
+    the loop needs to resolve. Pure over ``tasks_doc``."""
+    owners: set[str] = set()
+    for task in tasks_doc.get("tasks", []) or []:
+        if not isinstance(task, dict) or not _is_open(task.get("status")):
+            continue
+        if _has_blocker(task):
+            continue
+        owner = task.get("assignee") or task.get("agent")
+        if isinstance(owner, str) and owner.strip():
+            owners.add(owner.strip())
+    return owners
+
+
+def find_stuck_cards(
+    tasks_doc: dict,
+    liveness: dict[str, AgentLiveness],
+    now: float,
+    stale_s: float,
+) -> list[StuckCard]:
+    """Pure reconcile rule — NO IO. Return the OPEN cards that are stuck.
+
+    ``tasks_doc`` is a parsed ``tasks.yaml`` (``{"tasks": [...]}``).
+    ``liveness`` maps an owner agent name → its resolved
+    :class:`AgentLiveness`. ``now`` is epoch seconds; ``stale_s`` is the
+    staleness threshold.
+
+    A card contributes an anomaly ONLY when ALL hold:
+      * its ``status`` is OPEN (not terminal, not a parked state);
+      * it has an ``assignee``/``agent`` owner;
+      * it declares NO ``blocker``;
+      * its ``last_activity`` is older than ``stale_s`` (or absent).
+    Then the reason is ``"owner-not-live"`` if the owner is not live, else
+    ``"owner-idle"`` if the owner is live but its session.jsonl
+    last-record is older than ``stale_s``; otherwise the owner is making
+    progress and no anomaly is emitted.
+    """
+    out: list[StuckCard] = []
+    for task in tasks_doc.get("tasks", []) or []:
+        if not isinstance(task, dict):
+            continue
+        if not _is_open(task.get("status")):
+            continue
+        owner = task.get("assignee") or task.get("agent")
+        if not isinstance(owner, str) or not owner.strip():
+            continue
+        owner = owner.strip()
+        if _has_blocker(task):
+            continue
+
+        card_last = _parse_iso_ts(task.get("last_activity"))
+        card_stale_for = (now - card_last) if card_last is not None else float("inf")
+        if card_stale_for < stale_s:
+            continue  # card itself moved recently → progressing
+
+        card_id = str(task.get("id", "")).strip()
+        if not card_id:
+            continue
+
+        live = liveness.get(owner)
+        if live is None or not live.is_live:
+            out.append(
+                StuckCard(
+                    agent=owner,
+                    card_id=card_id,
+                    reason="owner-not-live",
+                    severity=_severity_for(card_stale_for, stale_s),
+                    stale_for_s=card_stale_for,
+                )
+            )
+            continue
+
+        # Owner IS live — anomaly only if its session is ALSO idle past
+        # the threshold (hung). A recent session record ⇒ progressing.
+        sess_last = live.last_active_ts
+        sess_idle_for = (now - sess_last) if sess_last is not None else float("inf")
+        if sess_idle_for >= stale_s:
+            out.append(
+                StuckCard(
+                    agent=owner,
+                    card_id=card_id,
+                    reason="owner-idle",
+                    severity=_severity_for(min(card_stale_for, sess_idle_for), stale_s),
+                    stale_for_s=card_stale_for,
+                )
+            )
+    return out
+
+
+__all__ = [
+    "AgentLiveness",
+    "PARKED_STATUSES",
+    "StuckCard",
+    "TERMINAL_STATUSES",
+    "find_stuck_cards",
+    "open_card_owners",
+]

--- a/tests/scitex_agent_container/_listen/test__liveness_tick.py
+++ b/tests/scitex_agent_container/_listen/test__liveness_tick.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 import asyncio
 import json
 from datetime import datetime, timezone
-from typing import Any
 
 import pytest
 

--- a/tests/scitex_agent_container/_listen/test__liveness_tick.py
+++ b/tests/scitex_agent_container/_listen/test__liveness_tick.py
@@ -1,0 +1,367 @@
+"""Tests for the liveness-tick reconciler loop + graceful bus emit.
+
+Card ``sac-card-anchored-stop-reconciler``. We exercise the asyncio task
+the ``sac listen`` lifespan launches — ``liveness_tick_reconciler_loop``
+— WITHOUT standing up the real Starlette app, by injecting a real
+in-memory tasks doc + real :class:`AgentLiveness` map + a REAL local
+consumer list. No mocks (STX-NM002): the "consumer" is an ordinary
+module-level callable that appends to a list; the throwing consumer is an
+ordinary callable that raises.
+
+The IO resolvers (``_load_tasks_doc`` / ``_session_last_active_ts``) are
+exercised against REAL files under ``tmp_path``.
+
+STX-TQ002 AAA-markers + STX-TQ007 one-assert.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from scitex_agent_container._listen._liveness_tick import (
+    DEFAULT_INTERVAL_S,
+    DEFAULT_RENOTIFY_S,
+    DEFAULT_STALE_S,
+    HOOKS_ENTRY_POINT_GROUP,
+    AgentLiveness,
+    emit_anomaly,
+    liveness_tick_reconciler_loop,
+)
+from scitex_agent_container._listen import _liveness_tick as mod
+
+NOW = 2_000_000.0
+STALE_S = 900.0
+
+
+def _iso(epoch: float) -> str:
+    return (
+        datetime.fromtimestamp(epoch, tz=timezone.utc)
+        .strftime("%Y-%m-%dT%H:%M:%SZ")
+    )
+
+
+def _stuck_doc() -> dict:
+    """A tasks doc with exactly one OPEN, unblocked, stale card."""
+    return {
+        "tasks": [
+            {
+                "id": "card-stuck",
+                "status": "in_progress",
+                "assignee": "agent-x",
+                "last_activity": _iso(NOW - STALE_S - 60.0),
+            }
+        ]
+    }
+
+
+# ===========================================================================
+# constants / wiring
+# ===========================================================================
+
+
+class TestDefaults:
+    def test_default_interval_is_120s(self) -> None:
+        # Arrange
+        constant = DEFAULT_INTERVAL_S
+        # Act
+        observed = constant
+        # Assert
+        assert observed == 120.0
+
+    def test_default_stale_is_900s(self) -> None:
+        # Arrange
+        constant = DEFAULT_STALE_S
+        # Act
+        observed = constant
+        # Assert
+        assert observed == 900.0
+
+    def test_default_renotify_is_3600s(self) -> None:
+        # Arrange
+        constant = DEFAULT_RENOTIFY_S
+        # Act
+        observed = constant
+        # Assert
+        assert observed == 3600.0
+
+    def test_entry_point_group_is_scitex_todo_hooks(self) -> None:
+        # Arrange
+        constant = HOOKS_ENTRY_POINT_GROUP
+        # Act
+        observed = constant
+        # Assert
+        assert observed == "scitex_todo.hooks"
+
+
+# ===========================================================================
+# emit_anomaly — graceful delivery (real callables, no mocks)
+# ===========================================================================
+
+
+class TestEmitAnomaly:
+    def test_event_is_delivered_to_a_real_consumer(self) -> None:
+        # Arrange — a real local consumer that records what it received.
+        received: list[dict] = []
+
+        def consumer(event: dict) -> None:
+            received.append(event)
+
+        event = {
+            "agent": "agent-x",
+            "card_id": "card-1",
+            "reason": "owner-not-live",
+            "severity": "warning",
+            "ts": NOW,
+        }
+        # Act
+        emit_anomaly(event, [consumer])
+        # Assert
+        assert received == [event]
+
+    def test_empty_consumer_list_delivers_to_nobody(self) -> None:
+        # Arrange — no consumer registered (sac is the first producer).
+        # Act
+        delivered = emit_anomaly({"agent": "a"}, [])
+        # Assert — returns 0, does not raise.
+        assert delivered == 0
+
+    def test_throwing_consumer_does_not_propagate(self) -> None:
+        # Arrange — one consumer raises, a later one must still receive.
+        received: list[dict] = []
+
+        def boom(event: dict) -> None:
+            raise RuntimeError("consumer blew up")
+
+        def ok(event: dict) -> None:
+            received.append(event)
+
+        # Act — must NOT raise.
+        delivered = emit_anomaly({"agent": "a"}, [boom, ok])
+        # Assert — the healthy consumer still got it (count == 1).
+        assert delivered == 1
+
+
+# ===========================================================================
+# IO resolvers against REAL files under tmp_path
+# ===========================================================================
+
+
+class TestLoadTasksDoc:
+    def test_reads_a_real_tasks_yaml(self, tmp_path) -> None:
+        # Arrange — write a real YAML file.
+        p = tmp_path / "tasks.yaml"
+        p.write_text("tasks:\n  - id: c1\n    status: pending\n")
+        # Act
+        doc = mod._load_tasks_doc(p)
+        # Assert
+        assert doc["tasks"][0]["id"] == "c1"
+
+    def test_missing_file_degrades_to_empty(self, tmp_path) -> None:
+        # Arrange — path does not exist.
+        # Act
+        doc = mod._load_tasks_doc(tmp_path / "nope.yaml")
+        # Assert
+        assert doc == {}
+
+
+@pytest.fixture
+def home_at_tmp(tmp_path):
+    """Point ``$HOME`` (which the production session-path resolver expands)
+    at a real ``tmp_path`` and restore it on teardown — a real env swap,
+    NOT a monkeypatch of any production internal."""
+    import os
+
+    saved = os.environ.get("HOME")
+    os.environ["HOME"] = str(tmp_path)
+    try:
+        yield tmp_path
+    finally:
+        if saved is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = saved
+
+
+class TestSessionLastActiveTs:
+    def test_returns_last_record_timestamp_from_real_jsonl(
+        self, home_at_tmp
+    ) -> None:
+        # Arrange — a real session.jsonl with two timestamped records under
+        # the redirected $HOME runtime root (no internal function mocked).
+        run_dir = (
+            home_at_tmp / ".scitex" / "agent-container" / "runtime" / "agent-x"
+        )
+        run_dir.mkdir(parents=True)
+        sess = run_dir / "session.jsonl"
+        early = _iso(NOW - 500.0)
+        late = _iso(NOW - 10.0)
+        sess.write_text(
+            json.dumps({"ts": early}) + "\n" + json.dumps({"ts": late}) + "\n"
+        )
+        # Act
+        ts = mod._session_last_active_ts("agent-x")
+        # Assert — the LAST record's timestamp wins.
+        assert ts == pytest.approx(
+            datetime.fromisoformat(late.replace("Z", "+00:00")).timestamp()
+        )
+
+    def test_missing_session_returns_none(self, home_at_tmp) -> None:
+        # Arrange — runtime root exists but no session.jsonl for the agent.
+        target = "ghost-agent"
+        # Act
+        ts = mod._session_last_active_ts(target)
+        # Assert
+        assert ts is None
+
+
+# ===========================================================================
+# loop — drives detection + emit through one tick (injected sources)
+# ===========================================================================
+
+
+async def _run_one_tick(*, consumers, doc, liveness, **kw) -> None:
+    """Spin the loop briefly then cancel — forces ≥1 tick deterministically."""
+    task = asyncio.create_task(
+        liveness_tick_reconciler_loop(
+            interval_s=0.05,
+            stale_s=STALE_S,
+            tasks_doc_source=doc,
+            liveness_source=liveness,
+            consumers_source=consumers,
+            now_fn=lambda: NOW,
+            **kw,
+        )
+    )
+    await asyncio.sleep(0.15)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+@pytest.mark.asyncio
+class TestLoopEmits:
+    async def test_loop_emits_anomaly_for_a_stuck_card(self) -> None:
+        # Arrange — a stuck card + a dead owner + a real consumer list.
+        events: list[dict] = []
+        liveness = {"agent-x": AgentLiveness(is_live=False, last_active_ts=None)}
+        # Act
+        await _run_one_tick(
+            consumers=[events.append], doc=_stuck_doc(), liveness=liveness
+        )
+        # Assert — exactly one anomaly landed.
+        assert len(events) >= 1
+
+    async def test_emitted_event_has_the_locked_shape(self) -> None:
+        # Arrange
+        events: list[dict] = []
+        liveness = {"agent-x": AgentLiveness(is_live=False, last_active_ts=None)}
+        # Act
+        await _run_one_tick(
+            consumers=[events.append], doc=_stuck_doc(), liveness=liveness
+        )
+        # Assert — keys match the locked event shape.
+        assert set(events[0]) == {"agent", "card_id", "reason", "severity", "ts"}
+
+    async def test_emitted_reason_is_owner_not_live(self) -> None:
+        # Arrange
+        events: list[dict] = []
+        liveness = {"agent-x": AgentLiveness(is_live=False, last_active_ts=None)}
+        # Act
+        await _run_one_tick(
+            consumers=[events.append], doc=_stuck_doc(), liveness=liveness
+        )
+        # Assert
+        assert events[0]["reason"] == "owner-not-live"
+
+    async def test_progressing_card_emits_nothing(self) -> None:
+        # Arrange — owner live + session moved 1s ago ⇒ no anomaly.
+        events: list[dict] = []
+        liveness = {"agent-x": AgentLiveness(is_live=True, last_active_ts=NOW - 1.0)}
+        # Act
+        await _run_one_tick(
+            consumers=[events.append], doc=_stuck_doc(), liveness=liveness
+        )
+        # Assert
+        assert events == []
+
+    async def test_throwing_consumer_does_not_kill_the_loop(self) -> None:
+        # Arrange — a throwing consumer FIRST, a recording one SECOND. If the
+        # throw propagated it would crash the loop before the second runs,
+        # so a recorded event proves the loop survived the bad consumer.
+        recorded: list[dict] = []
+
+        def boom(event: dict) -> None:
+            raise RuntimeError("downstream consumer failure")
+
+        liveness = {"agent-x": AgentLiveness(is_live=False, last_active_ts=None)}
+        # Act
+        await _run_one_tick(
+            consumers=[boom, recorded.append], doc=_stuck_doc(), liveness=liveness
+        )
+        # Assert — the healthy consumer still received the anomaly.
+        assert len(recorded) >= 1
+
+
+# ===========================================================================
+# dedup / re-notify cooldown
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_loop_dedups_within_renotify_cooldown() -> None:
+    # Arrange — many ticks at fixed NOW within a long cooldown.
+    events: list[dict] = []
+    liveness = {"agent-x": AgentLiveness(is_live=False, last_active_ts=None)}
+    task = asyncio.create_task(
+        liveness_tick_reconciler_loop(
+            interval_s=0.02,
+            stale_s=STALE_S,
+            renotify_s=10_000.0,  # huge → never re-notify in this test
+            tasks_doc_source=_stuck_doc(),
+            liveness_source=liveness,
+            consumers_source=[events.append],
+            now_fn=lambda: NOW,  # frozen clock → all ticks share one "now"
+        )
+    )
+    # Act — let several ticks run.
+    await asyncio.sleep(0.2)
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+    # Assert — despite many ticks, the (agent, card) fired exactly once.
+    assert len(events) == 1
+
+
+# ===========================================================================
+# cancellation
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_loop_honours_cancellation_cleanly() -> None:
+    # Arrange
+    task = asyncio.create_task(
+        liveness_tick_reconciler_loop(
+            interval_s=0.05,
+            tasks_doc_source={"tasks": []},
+            liveness_source={},
+            consumers_source=[],
+            now_fn=lambda: NOW,
+        )
+    )
+    # Act
+    await asyncio.sleep(0.06)
+    task.cancel()
+    # Assert
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+# EOF

--- a/tests/scitex_agent_container/_listen/test__liveness_tick_detect.py
+++ b/tests/scitex_agent_container/_listen/test__liveness_tick_detect.py
@@ -1,0 +1,281 @@
+"""Tests for the pure reconcile rule of the liveness-tick reconciler.
+
+Card ``sac-card-anchored-stop-reconciler``. ``find_stuck_cards`` is pure
+(no IO, no asyncio), so these tests feed it a REAL in-memory tasks doc +
+REAL :class:`AgentLiveness` inputs and assert the stuck/progressing/
+blocked/not-live branches. No mocks (STX-NM002).
+
+STX-TQ002 AAA-markers + STX-TQ007 one-assert.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from scitex_agent_container._listen._liveness_tick_detect import (
+    AgentLiveness,
+    find_stuck_cards,
+    open_card_owners,
+)
+
+# A fixed "now" so staleness maths is deterministic.
+NOW = 1_000_000.0
+STALE_S = 900.0
+
+
+def _iso(epoch: float) -> str:
+    """ISO-8601 ``...Z`` string for an epoch second (the tasks.yaml shape)."""
+    return (
+        datetime.fromtimestamp(epoch, tz=timezone.utc)
+        .strftime("%Y-%m-%dT%H:%M:%SZ")
+    )
+
+
+def _card(**over) -> dict:
+    """An OPEN card stale past the threshold, with an assignee + no blocker.
+
+    Each test overrides only the field under test, so the baseline is the
+    one that WOULD fire — keeping each case a single-variable change."""
+    base = {
+        "id": "card-x",
+        "status": "in_progress",
+        "assignee": "agent-x",
+        "last_activity": _iso(NOW - STALE_S - 60.0),  # past threshold
+    }
+    base.update(over)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# owner not live → owner-not-live
+# ---------------------------------------------------------------------------
+
+
+class TestOwnerNotLive:
+    def test_dead_owner_of_stale_open_card_is_an_anomaly(self) -> None:
+        # Arrange — owner has no live registry row.
+        doc = {"tasks": [_card()]}
+        liveness = {"agent-x": AgentLiveness(is_live=False, last_active_ts=None)}
+        # Act
+        stuck = find_stuck_cards(doc, liveness, now=NOW, stale_s=STALE_S)
+        # Assert
+        assert [s.reason for s in stuck] == ["owner-not-live"]
+
+    def test_owner_absent_from_liveness_map_is_not_live(self) -> None:
+        # Arrange — no entry at all for the owner ⇒ treated as not live.
+        doc = {"tasks": [_card()]}
+        # Act
+        stuck = find_stuck_cards(doc, {}, now=NOW, stale_s=STALE_S)
+        # Assert
+        assert stuck and stuck[0].reason == "owner-not-live"
+
+    def test_anomaly_carries_the_card_id(self) -> None:
+        # Arrange
+        doc = {"tasks": [_card(id="card-77")]}
+        liveness = {"agent-x": AgentLiveness(is_live=False, last_active_ts=None)}
+        # Act
+        stuck = find_stuck_cards(doc, liveness, now=NOW, stale_s=STALE_S)
+        # Assert
+        assert stuck[0].card_id == "card-77"
+
+
+# ---------------------------------------------------------------------------
+# owner live but session idle → owner-idle
+# ---------------------------------------------------------------------------
+
+
+class TestOwnerIdle:
+    def test_live_owner_with_idle_session_is_an_anomaly(self) -> None:
+        # Arrange — process alive, but session.jsonl last record is stale.
+        doc = {"tasks": [_card()]}
+        liveness = {
+            "agent-x": AgentLiveness(
+                is_live=True, last_active_ts=NOW - STALE_S - 30.0
+            )
+        }
+        # Act
+        stuck = find_stuck_cards(doc, liveness, now=NOW, stale_s=STALE_S)
+        # Assert
+        assert [s.reason for s in stuck] == ["owner-idle"]
+
+    def test_live_owner_with_unknown_session_is_idle(self) -> None:
+        # Arrange — live but no session timestamp known (None) ⇒ idle.
+        doc = {"tasks": [_card()]}
+        liveness = {"agent-x": AgentLiveness(is_live=True, last_active_ts=None)}
+        # Act
+        stuck = find_stuck_cards(doc, liveness, now=NOW, stale_s=STALE_S)
+        # Assert
+        assert stuck and stuck[0].reason == "owner-idle"
+
+
+# ---------------------------------------------------------------------------
+# progressing → no anomaly
+# ---------------------------------------------------------------------------
+
+
+class TestProgressingNoAnomaly:
+    def test_live_owner_with_recent_session_is_progressing(self) -> None:
+        # Arrange — live + session moved 1s ago ⇒ progressing.
+        doc = {"tasks": [_card()]}
+        liveness = {"agent-x": AgentLiveness(is_live=True, last_active_ts=NOW - 1.0)}
+        # Act
+        stuck = find_stuck_cards(doc, liveness, now=NOW, stale_s=STALE_S)
+        # Assert
+        assert stuck == []
+
+    def test_card_with_recent_last_activity_never_fires(self) -> None:
+        # Arrange — card itself moved 1s ago; owner dead is irrelevant.
+        doc = {"tasks": [_card(last_activity=_iso(NOW - 1.0))]}
+        liveness = {"agent-x": AgentLiveness(is_live=False, last_active_ts=None)}
+        # Act
+        stuck = find_stuck_cards(doc, liveness, now=NOW, stale_s=STALE_S)
+        # Assert
+        assert stuck == []
+
+
+# ---------------------------------------------------------------------------
+# declared blocker / parked status / terminal status → no anomaly
+# ---------------------------------------------------------------------------
+
+
+class TestSuppressedByDeclaration:
+    def test_card_with_declared_blocker_is_suppressed(self) -> None:
+        # Arrange — author declared WHY it's parked.
+        doc = {"tasks": [_card(blocker="dependency")]}
+        liveness = {"agent-x": AgentLiveness(is_live=False, last_active_ts=None)}
+        # Act
+        stuck = find_stuck_cards(doc, liveness, now=NOW, stale_s=STALE_S)
+        # Assert
+        assert stuck == []
+
+    def test_blank_blocker_string_does_not_suppress(self) -> None:
+        # Arrange — empty/whitespace blocker is NOT a declared blocker.
+        doc = {"tasks": [_card(blocker="   ")]}
+        liveness = {"agent-x": AgentLiveness(is_live=False, last_active_ts=None)}
+        # Act
+        stuck = find_stuck_cards(doc, liveness, now=NOW, stale_s=STALE_S)
+        # Assert
+        assert stuck and stuck[0].reason == "owner-not-live"
+
+    def test_blocked_status_is_a_parked_state(self) -> None:
+        # Arrange — status=blocked is parked-on-purpose ⇒ not open.
+        doc = {"tasks": [_card(status="blocked")]}
+        liveness = {"agent-x": AgentLiveness(is_live=False, last_active_ts=None)}
+        # Act
+        stuck = find_stuck_cards(doc, liveness, now=NOW, stale_s=STALE_S)
+        # Assert
+        assert stuck == []
+
+    def test_deferred_status_is_a_parked_state(self) -> None:
+        # Arrange
+        doc = {"tasks": [_card(status="deferred")]}
+        liveness = {"agent-x": AgentLiveness(is_live=False, last_active_ts=None)}
+        # Act
+        stuck = find_stuck_cards(doc, liveness, now=NOW, stale_s=STALE_S)
+        # Assert
+        assert stuck == []
+
+    def test_done_status_is_terminal(self) -> None:
+        # Arrange — a resolved card is never open.
+        doc = {"tasks": [_card(status="done")]}
+        liveness = {"agent-x": AgentLiveness(is_live=False, last_active_ts=None)}
+        # Act
+        stuck = find_stuck_cards(doc, liveness, now=NOW, stale_s=STALE_S)
+        # Assert
+        assert stuck == []
+
+
+# ---------------------------------------------------------------------------
+# missing owner / id → skipped
+# ---------------------------------------------------------------------------
+
+
+class TestSkippedRows:
+    def test_card_without_assignee_is_skipped(self) -> None:
+        # Arrange — no owner to alarm against.
+        card = _card()
+        card.pop("assignee")
+        doc = {"tasks": [card]}
+        # Act
+        stuck = find_stuck_cards(doc, {}, now=NOW, stale_s=STALE_S)
+        # Assert
+        assert stuck == []
+
+    def test_agent_key_is_honoured_when_assignee_absent(self) -> None:
+        # Arrange — older cards use ``agent`` rather than ``assignee``.
+        card = _card()
+        card.pop("assignee")
+        card["agent"] = "agent-legacy"
+        doc = {"tasks": [card]}
+        liveness = {"agent-legacy": AgentLiveness(is_live=False, last_active_ts=None)}
+        # Act
+        stuck = find_stuck_cards(doc, liveness, now=NOW, stale_s=STALE_S)
+        # Assert
+        assert stuck and stuck[0].agent == "agent-legacy"
+
+    def test_card_without_id_is_skipped(self) -> None:
+        # Arrange — an id-less row can't be referenced downstream.
+        doc = {"tasks": [_card(id="")]}
+        liveness = {"agent-x": AgentLiveness(is_live=False, last_active_ts=None)}
+        # Act
+        stuck = find_stuck_cards(doc, liveness, now=NOW, stale_s=STALE_S)
+        # Assert
+        assert stuck == []
+
+    def test_non_dict_task_row_is_skipped(self) -> None:
+        # Arrange — a malformed (non-dict) entry must not crash the rule.
+        doc = {"tasks": ["not-a-dict", _card()]}
+        liveness = {"agent-x": AgentLiveness(is_live=False, last_active_ts=None)}
+        # Act
+        stuck = find_stuck_cards(doc, liveness, now=NOW, stale_s=STALE_S)
+        # Assert — the good row still fires; the bad row is ignored.
+        assert len(stuck) == 1
+
+
+# ---------------------------------------------------------------------------
+# severity scaling
+# ---------------------------------------------------------------------------
+
+
+class TestSeverity:
+    def test_just_past_threshold_is_warning(self) -> None:
+        # Arrange — stale by a little over one threshold.
+        doc = {"tasks": [_card(last_activity=_iso(NOW - STALE_S - 10.0))]}
+        liveness = {"agent-x": AgentLiveness(is_live=False, last_active_ts=None)}
+        # Act
+        stuck = find_stuck_cards(doc, liveness, now=NOW, stale_s=STALE_S)
+        # Assert
+        assert stuck[0].severity == "warning"
+
+    def test_far_past_threshold_is_critical(self) -> None:
+        # Arrange — stale by > 4× the threshold.
+        doc = {"tasks": [_card(last_activity=_iso(NOW - STALE_S * 5))]}
+        liveness = {"agent-x": AgentLiveness(is_live=False, last_active_ts=None)}
+        # Act
+        stuck = find_stuck_cards(doc, liveness, now=NOW, stale_s=STALE_S)
+        # Assert
+        assert stuck[0].severity == "critical"
+
+
+# ---------------------------------------------------------------------------
+# open_card_owners (the set the loop resolves liveness for)
+# ---------------------------------------------------------------------------
+
+
+class TestOpenCardOwners:
+    def test_collects_only_open_unblocked_owners(self) -> None:
+        # Arrange — one open+unblocked, one done, one blocked.
+        doc = {
+            "tasks": [
+                _card(id="a", assignee="owner-open"),
+                _card(id="b", status="done", assignee="owner-done"),
+                _card(id="c", blocker="dep", assignee="owner-blocked"),
+            ]
+        }
+        # Act
+        owners = open_card_owners(doc)
+        # Assert
+        assert owners == {"owner-open"}
+
+
+# EOF


### PR DESCRIPTION
## Summary

Card `sac-card-anchored-stop-reconciler`. Adds a deterministic
**liveness-tick reconciler** inside `sac listen` — the first *producer*
on the `scitex_todo.hooks` alarm-engine bus. It reads cards (truth,
`~/.scitex/todo/tasks.yaml`) vs. real agent activity and ALARMS on a
mismatch so a stuck/crashed agent can never sit silent.

**Separation of concerns (locked with scitex-todo):** sac only **DETECTS
and EMITS** — it does NOT write the card store. The anomaly fires on the
entry-point bus; scitex-todo's own consumer (registered separately, on
their side) turns it into a card record + operator push. Nothing here
writes `tasks.yaml`.

### Event shape (locked) + entry-point group

Emitted onto entry-point group **`scitex_todo.hooks`**:

```python
{"agent": str, "card_id": str, "reason": str, "severity": str, "ts": float}
```

- `reason` ∈ `{"owner-not-live", "owner-idle"}`
- `severity` ∈ `{"warning", "critical"}` (critical past 4× the stale threshold)

### Reconcile rule (`find_stuck_cards`, pure / no-IO)

A card fires an anomaly ONLY when it is **OPEN** (status not terminal and
not a parked `blocked`/`deferred`/`coordinating` state), has an
`assignee`/`agent`, declares **no `blocker`**, and its `last_activity` is
older than `stale_s` — then:
- owner agent **not live** (no active-instances row, or pid reaped) → `owner-not-live`;
- owner **live** but its `session.jsonl` last-record is older than `stale_s` → `owner-idle`;
- otherwise (live + recently active) → progressing → no anomaly.

**DEDUP:** at most one emit per `(agent, card_id)` per re-notify cooldown
(in-memory; the daemon is long-running), so a persistently-stuck card
does not spam per tick.

### Bind-safety (preserves the startup hardening)

The loop's only blocking IO — reading `tasks.yaml`, each owner's
`session.jsonl`, and the active-instances registry — routes through
`_off_loop.run_blocking_or`, so it can never starve uvicorn's bind. The
loop is gated by `SAC_LIVENESS_TICK_DISABLED` and registered in
`build_listen_lifespan` exactly like the existing periodic-drive / CI /
TUI / peer-sync loops (append to `tasks`, park on `app.state`, cancel on
teardown). The bind/startup path is otherwise untouched.

### Degrades gracefully

sac is the FIRST producer on this bus — **until scitex-todo registers a
`scitex_todo.hooks` consumer**, anomalies are still DETECTED and logged
at WARNING but delivered to nobody (a single "no consumer registered"
line is logged once at startup). A consumer that raises is caught and
skipped — the alarm loop stays up.

### Config (env, conservative defaults)

| var | default |
| --- | --- |
| `SAC_LIVENESS_TICK_DISABLED` | (off switch) |
| `SAC_LIVENESS_TICK_INTERVAL_S` | 120 |
| `SAC_LIVENESS_TICK_STALE_S` | 900 |
| `SAC_LIVENESS_TICK_RENOTIFY_S` | 3600 |

### Files

- `src/.../_listen/_liveness_tick_detect.py` — pure detection core (`find_stuck_cards`, dataclasses, status/severity helpers).
- `src/.../_listen/_liveness_tick.py` — IO resolvers (off-loop), graceful `scitex_todo.hooks` emit, the async loop. Re-exports the pure surface.
- `src/.../_lifecycle/_listen_lifespan.py` — gated loop registration.
- tests mirror both src files (PS-204 §2).

## Test plan

No mocks (STX-NM002): the detection rule is tested with a REAL in-memory
tasks doc + real `AgentLiveness` inputs; the emit is tested with a REAL
local callable as the consumer list; the IO resolvers run against REAL
files under `tmp_path`.

- [x] `find_stuck_cards`: stuck (not-live), stuck (idle), progressing (live+recent session), suppressed (declared blocker / parked status / terminal status), skipped (no assignee / no id / non-dict row), severity warning↔critical.
- [x] graceful emit: real consumer receives the locked event shape; empty consumer list = no crash (returns 0); throwing consumer = no crash, healthy consumer still receives.
- [x] loop forces the stuck/idle conditions via injected `tasks_doc_source` + `liveness_source` (no mocks) + frozen `now_fn`; asserts owner-not-live emit, progressing → no emit, dedup within cooldown, clean cancellation.
- [x] 37 passed locally: `PYTHONPATH=src python -m pytest tests/scitex_agent_container/_listen/test__liveness_tick{,_detect}.py -q`