### PR TITLE
feat(listen): C10 card-event a2a-delivery rail + /v1/notify interim endpoint (reach containerized agents)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,6 +169,20 @@ scitex-agent-container = "scitex_agent_container._linter_plugin:get_plugin"
 [project.entry-points."scitex_dev.jobs"]
 scitex-agent-container = "scitex_agent_container._jobs_plugin:provide_jobs"
 
+# C10 — sac's consumer on scitex-todo's shared card-event bus. When
+# scitex-todo's board emits a card-event (commented / created /
+# reassigned / status_changed / completed / committed / pushed /
+# merged), this callable is invoked in the board's process; it resolves
+# the card's owner + collaborators + subscribers and delivers the
+# notification to each via the local ``sac listen`` daemon's
+# ``/v1/notify`` router endpoint — so a CONTAINERIZED owner-agent (whose
+# a2a port is unreachable inbound) still receives it. The consumer
+# filters for the card-event kinds and ignores everything else, incl.
+# sac's OWN liveness-tick anomaly events on the same bus. Bus-only
+# contract: no import of scitex_todo.
+[project.entry-points."scitex_todo.hooks"]
+scitex-agent-container = "scitex_agent_container._listen._card_event_delivery:deliver_card_event"
+
 [project.urls]
 Homepage = "https://github.com/ywatanabe1989/scitex-agent-container"
 Repository = "https://github.com/ywatanabe1989/scitex-agent-container.git"

--- a/src/scitex_agent_container/_listen/_agent_delete.py
+++ b/src/scitex_agent_container/_listen/_agent_delete.py
@@ -1,0 +1,106 @@
+"""``DELETE /agents/<name>`` handler for ``sac listen`` (extracted from server.py).
+
+Hosts the agent-lifecycle DELETE responsibility — stop a running agent
+(SIGTERM), or surface the stillborn / not-found / ACL-deny cases with
+the right status code. Split out of
+:mod:`scitex_agent_container._listen.server` (which grew past the
+per-file line cap). ``server.py`` re-imports :func:`agent_delete` so
+route registration (:func:`_v1_agent_routes`) and the historical
+``from ..._listen.server import agent_delete`` import path keep working
+unchanged. No behaviour change — this is a pure extraction of one
+cohesive responsibility (agent-lifecycle delete), mirroring the existing
+``_node_channel`` / ``_agent_exec`` extractions.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+from .._runners._session_state import state_dir_for
+
+__all__ = ["agent_delete"]
+
+
+async def agent_delete(request: Request) -> JSONResponse:
+    """DELETE /agents/<name> — stop the agent.
+
+    Four cases distinguished by the response code:
+
+      * **200 OK** — agent is live; ``pid`` file present; SIGTERM sent.
+      * **410 Gone** (PR-1) — agent is *stillborn*: a ``STARTUP_FAILED``
+        marker is on disk (set by the POST /agents handler on a
+        non-zero ``sac agents start`` exit). The body carries the
+        failure details so the caller doesn't need to also
+        ``GET .../status``.
+      * **404 Not Found** — agent never existed or was already deleted.
+      * **403 Forbidden** (PR-3) — caller is identified (via
+        ``request.state.authenticated_node``) but lacks lineage-scoped
+        permission to operate on this target. Body shape:
+        ``{"error": "ACL deny", "kind": "acl_deny", "reason": "..."}``
+        — the 5th kind in the wire taxonomy pinned with clew.
+
+    Splitting 410 from 404 is the operator-actionable difference:
+    "never existed" vs. "existed, has been removed". Splitting 403
+    from both is identity-actionable: the agent exists (or doesn't,
+    irrelevant) but the caller can't touch it.
+    """
+    name = request.path_params["name"]
+    # PR-3 — lineage-scoped ACL gate. ``authenticated_node`` is the
+    # resolved per-node identity from NodeAuthMiddleware; ``None``
+    # is the administrative / host-wide bearer (always allowed by
+    # check_lineage_acl). The ACL is enforced BEFORE we touch the
+    # state dir / pid file so a denied caller learns nothing about
+    # whether the target exists (status, marker, runtime files).
+    from ._acl import check_lineage_acl, deny_response
+
+    caller = getattr(request.state, "authenticated_node", None)
+    decision, reason = check_lineage_acl(caller=caller, target=name)
+    if decision == "deny":
+        return deny_response(reason or "lineage ACL deny")
+    sd = state_dir_for(name)
+    pid_file = sd / "pid"
+    if not pid_file.is_file():
+        # PR-1 — distinguish stillborn (have STARTUP_FAILED marker) from
+        # genuinely not-found. Stillborn → 410 Gone + the structured
+        # failure body the operator/orchestrator can branch on without
+        # also hitting GET /agents/<name>/status.
+        #
+        # Wire shape per clew review (#287):
+        #
+        # The "headline" failure fields (status, phase, kind, failed_at,
+        # runtime_dir, remediation_hint) are LIFTED to the top level so a
+        # clew-launcher error renderer can branch / display without
+        # walking into ``details``. ``see_also`` is the host-absolute
+        # path to the on-disk marker so a human / sysadmin can ``cat``
+        # the marker (and the peer ``stdout.log`` / ``stderr.log`` in
+        # the same directory) without recomputing it. The full marker
+        # remains under ``details`` for parity with the marker file
+        # contents (and so an orchestrator can hash it for dedupe).
+        from .._lifecycle._startup_failed import MARKER_FILENAME, read_marker
+
+        marker = read_marker(sd)
+        if marker is not None:
+            runtime_dir = marker.get("runtime_dir", str(sd.resolve()))
+            body: dict[str, Any] = {
+                "name": name,
+                "status": "startup_failed",
+                "kind": marker.get("kind"),
+                "phase": marker.get("phase"),
+                "failed_at": marker.get("failed_at"),
+                "runtime_dir": runtime_dir,
+                "remediation_hint": marker.get("remediation_hint", ""),
+                "see_also": f"{runtime_dir}/{MARKER_FILENAME}",
+                "details": marker,
+            }
+            return JSONResponse(body, status_code=410)
+        return JSONResponse({"error": "no pid file"}, status_code=404)
+    try:
+        pid = int(pid_file.read_text().strip())
+        os.kill(pid, 15)  # SIGTERM
+    except (OSError, ValueError) as exc:
+        return JSONResponse({"error": str(exc)}, status_code=500)
+    return JSONResponse({"name": name, "stopped": True, "pid": pid})

--- a/src/scitex_agent_container/_listen/_card_event_delivery.py
+++ b/src/scitex_agent_container/_listen/_card_event_delivery.py
@@ -1,0 +1,340 @@
+"""C10 — sac's ``scitex_todo.hooks`` consumer: deliver card-events to agents.
+
+The problem this closes
+=======================
+scitex-todo's board emits canonical card-events on the shared
+``scitex_todo.hooks`` entry-point bus (its C5, already deployed): kinds
+``commented`` / ``created`` / ``reassigned`` / ``status_changed`` /
+``completed`` (and C6 adds ``committed`` / ``pushed`` / ``merged``). Each
+event names the card + its owner / collaborators / subscribers.
+
+sac REGISTERS this module's :func:`deliver_card_event` as a consumer in
+that entry-point group (see this repo's ``pyproject.toml``
+``[project.entry-points."scitex_todo.hooks"]``). When scitex-todo emits a
+card-event, this consumer is invoked IN THE EMITTING PROCESS (the board's
+process — the same host that runs ``sac listen``). It resolves the target
+agent(s) from the event and delivers the notification to each.
+
+Why HTTP to ``/v1/notify`` (not an in-process broker call)
+==========================================================
+The a2a inbox :class:`~scitex_agent_container.a2a._inbox_bus.Broker` that
+a containerized agent subscribes to lives inside the ``sac listen``
+daemon's process. This consumer runs in the BOARD's process, which is a
+*different* process — it has no handle to that broker. So delivery goes
+over loopback HTTP to the local ``sac listen`` daemon's ``POST
+/v1/notify`` endpoint (:mod:`._notify`), which then publishes into the
+agent's bus via the router. That endpoint is the ONE delivery seam: a
+containerized agent SUBSCRIBES OUTBOUND to the daemon's SSE stream and
+the daemon PUBLISHES down it, so a direct POST to the agent's own
+``turn_url`` (``Connection refused`` for a container) is never attempted.
+
+The bus is shared in BOTH directions
+=====================================
+sac ITSELF emits anomaly events on ``scitex_todo.hooks`` (the
+liveness-tick producer in :mod:`._liveness_tick`). Those have a
+``reason`` / ``severity`` shape, NOT one of the card-event kinds above.
+:func:`deliver_card_event` FILTERS for the card-event kinds and IGNORES
+everything else (incl. sac's own anomaly events), so the two flows never
+cross-wire.
+
+Degrade gracefully
+===================
+A delivery failure to one agent must NEVER crash the bus dispatch (the
+producer loops over every consumer and a raise would break the chain for
+the rest). Every failure is logged LOUD and swallowed; the function
+returns the count of agents it delivered to.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import urllib.error
+import urllib.request
+from typing import Any, Iterable
+
+logger = logging.getLogger(__name__)
+
+# The card-event kinds this consumer recognises. Anything else — most
+# importantly sac's OWN liveness-tick anomaly events on the same bus, plus
+# any future kind we don't yet handle — is ignored (no-op) so the two
+# flows sharing ``scitex_todo.hooks`` never cross-wire.
+CARD_EVENT_KINDS = frozenset(
+    {
+        "commented",
+        "created",
+        "reassigned",
+        "status_changed",
+        "completed",
+        # C6 git-lifecycle kinds.
+        "committed",
+        "pushed",
+        "merged",
+    }
+)
+
+# Env knobs (same names the rest of the sac client surface reads).
+ENV_BASE_URL = "SAC_LISTEN_BASE_URL"
+ENV_BEARER = "SAC_LISTEN_BEARER"
+ENV_DISABLED = "SAC_CARD_EVENT_DELIVERY_DISABLED"
+
+DEFAULT_BASE_URL = "http://127.0.0.1:7878"
+_NOTIFY_PATH = "/v1/notify"
+_POST_TIMEOUT_S = 5.0
+
+
+def _event_kind(event: dict[str, Any]) -> str | None:
+    """Return the event's kind string, tolerating a couple of spellings.
+
+    The canonical field is ``kind``; some producers label it ``event`` or
+    ``type``. Non-string / absent ⇒ ``None`` (the caller treats that as
+    "unrecognized" and no-ops)."""
+    for key in ("kind", "event", "type"):
+        val = event.get(key)
+        if isinstance(val, str) and val.strip():
+            return val.strip()
+    return None
+
+
+def _coerce_names(value: Any) -> list[str]:
+    """Flatten an owner/collaborators/subscribers field into agent names.
+
+    Accepts a bare string, a list of strings, or a list of dicts carrying
+    a ``name`` / ``agent`` key (defensive against the producer shipping
+    richer member objects). Anything else contributes nothing."""
+    out: list[str] = []
+    if isinstance(value, str):
+        if value.strip():
+            out.append(value.strip())
+        return out
+    if isinstance(value, dict):
+        for key in ("name", "agent"):
+            inner = value.get(key)
+            if isinstance(inner, str) and inner.strip():
+                out.append(inner.strip())
+                break
+        return out
+    if isinstance(value, (list, tuple, set)):
+        for item in value:
+            out.extend(_coerce_names(item))
+    return out
+
+
+def resolve_targets(event: dict[str, Any]) -> list[str]:
+    """Resolve the unique, order-preserving set of target agent names.
+
+    Sources, in priority order (first occurrence wins for dedup):
+
+    * the card OWNER — ``owner`` / ``assignee`` / ``owner_agent`` /
+      ``agent`` (the field the producer uses for "whose card is this");
+    * ``collaborators`` — agents working the card alongside the owner;
+    * ``subscribers`` — agents watching the card.
+
+    Each may be a string, a list of strings, or a list of ``{"name": …}``
+    member dicts (see :func:`_coerce_names`). Self/empty names are
+    dropped. The result drives one ``/v1/notify`` POST per agent."""
+    ordered: list[str] = []
+    for key in ("owner", "assignee", "owner_agent", "agent"):
+        ordered.extend(_coerce_names(event.get(key)))
+    ordered.extend(_coerce_names(event.get("collaborators")))
+    ordered.extend(_coerce_names(event.get("subscribers")))
+
+    seen: set[str] = set()
+    unique: list[str] = []
+    for name in ordered:
+        if name and name not in seen:
+            seen.add(name)
+            unique.append(name)
+    return unique
+
+
+def _render_body(event: dict[str, Any], kind: str) -> str:
+    """Render the notification text a target agent sees.
+
+    Prefers an explicit human-facing field the producer may set
+    (``body`` / ``message`` / ``text`` / ``comment``); otherwise builds a
+    compact one-liner from the kind + card id so the agent always gets an
+    actionable string (never an empty push)."""
+    for key in ("body", "message", "text", "comment"):
+        val = event.get(key)
+        if isinstance(val, str) and val.strip():
+            return val.strip()
+    card_id = event.get("card_id") or event.get("card") or event.get("id")
+    if card_id:
+        return f"scitex-todo: card {card_id} {kind}"
+    return f"scitex-todo: card {kind}"
+
+
+def _resolve_base_url() -> str:
+    base = os.environ.get(ENV_BASE_URL, "").strip()
+    return (base or DEFAULT_BASE_URL).rstrip("/")
+
+
+def _resolve_bearer() -> str | None:
+    """Bearer for the local ``sac listen`` ``/v1/notify`` call.
+
+    ``SAC_LISTEN_BEARER`` env first (what every other sac client reads);
+    fall back to the host token file written by ``sac listen`` at startup.
+    ``None`` only when neither is present — the POST then goes
+    unauthenticated and the daemon answers 401, which surfaces loudly in
+    the per-target log line rather than silently dropping."""
+    env_bearer = os.environ.get(ENV_BEARER, "").strip()
+    if env_bearer:
+        return env_bearer
+    # stx-allow: fallback (reason: token-file read is best-effort; a
+    # missing/unreadable token degrades to an unauthenticated POST that
+    # fails LOUD with 401, never a silent drop.)
+    try:
+        from .tokens import default_token_path, read_token
+
+        return read_token(default_token_path())
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        return None
+
+
+def _post_notify(
+    base_url: str,
+    bearer: str | None,
+    *,
+    agent: str,
+    body: str,
+    card_id: str | None,
+) -> bool:
+    """POST one ``/v1/notify`` to the local daemon. Return True on 2xx.
+
+    Uses stdlib ``urllib`` (no async, no extra deps) since the consumer
+    runs in the producer's synchronous dispatch context. Any transport /
+    HTTP error is logged LOUD and returns False — the caller continues to
+    the next target (one bad delivery must not abort the rest)."""
+    payload = {"agent": agent, "body": body, "from_agent": "scitex-todo"}
+    if card_id:
+        payload["card_id"] = card_id
+    data = json.dumps(payload).encode("utf-8")
+    headers = {"Content-Type": "application/json"}
+    if bearer:
+        headers["Authorization"] = f"Bearer {bearer}"
+    req = urllib.request.Request(
+        f"{base_url}{_NOTIFY_PATH}", data=data, headers=headers, method="POST"
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=_POST_TIMEOUT_S) as resp:
+            status = getattr(resp, "status", None) or resp.getcode()
+            if 200 <= int(status) < 300:
+                return True
+            logger.warning(
+                "card_event_delivery: /v1/notify for agent=%s returned %s",
+                agent,
+                status,
+            )
+            return False
+    except urllib.error.HTTPError as exc:
+        detail = ""
+        try:
+            detail = exc.read().decode("utf-8", "replace")[:300]
+        except Exception:  # stx-allow: fallback (reason: error-body read is diagnostic only)
+            pass
+        logger.warning(
+            "card_event_delivery: /v1/notify for agent=%s failed HTTP %s: %s",
+            agent,
+            exc.code,
+            detail,
+        )
+        return False
+    except (urllib.error.URLError, OSError, ValueError) as exc:
+        logger.warning(
+            "card_event_delivery: /v1/notify for agent=%s failed to reach %s: %s",
+            agent,
+            base_url,
+            exc,
+        )
+        return False
+
+
+def deliver_card_event(event: Any) -> int:
+    """``scitex_todo.hooks`` consumer entry-point — deliver a card-event.
+
+    Registered via ``pyproject.toml``
+    ``[project.entry-points."scitex_todo.hooks"]``. Invoked by
+    scitex-todo's board (and ignored-by-design when sac's own
+    liveness-tick fires on the same bus). Contract:
+
+    1. FILTER: a non-dict event, or one whose kind is not in
+       :data:`CARD_EVENT_KINDS` (e.g. sac's anomaly events), is a
+       no-op — returns ``0``.
+    2. RESOLVE: target agents = owner + collaborators + subscribers
+       (:func:`resolve_targets`).
+    3. DELIVER: POST one ``/v1/notify`` per agent to the local ``sac
+       listen`` daemon, which publishes into each agent's a2a bus so a
+       subscribed (containerized) agent receives it.
+
+    DEGRADE GRACEFULLY: never raises. A per-agent delivery failure is
+    logged LOUD and skipped; the function returns the count of agents
+    it delivered to. (A raise here would break the producer's dispatch
+    loop for every consumer after this one.)
+
+    NO import of ``scitex_todo`` — the contract is bus-only.
+    """
+    try:
+        if os.environ.get(ENV_DISABLED, "") == "1":
+            return 0
+        if not isinstance(event, dict):
+            return 0
+
+        kind = _event_kind(event)
+        if kind is None or kind not in CARD_EVENT_KINDS:
+            # Unrecognized kind — most importantly sac's own liveness-tick
+            # anomaly events (``reason``/``severity`` shape). No-op.
+            return 0
+
+        targets = resolve_targets(event)
+        if not targets:
+            logger.warning(
+                "card_event_delivery: card-event kind=%s named no deliverable "
+                "agent (owner/collaborators/subscribers all empty); skipping",
+                kind,
+            )
+            return 0
+
+        card_id = event.get("card_id") or event.get("card") or event.get("id")
+        card_id = card_id if isinstance(card_id, str) and card_id.strip() else None
+        body = _render_body(event, kind)
+
+        base_url = _resolve_base_url()
+        bearer = _resolve_bearer()
+
+        return _deliver_to_targets(
+            targets, base_url=base_url, bearer=bearer, body=body, card_id=card_id
+        )
+    except Exception as exc:  # stx-allow: fallback (reason: a consumer MUST NOT crash the producer's bus-dispatch loop — log loud and swallow)
+        logger.warning(
+            "card_event_delivery: unexpected failure handling card-event "
+            "(%s); swallowed so the bus dispatch survives",
+            exc,
+        )
+        return 0
+
+
+def _deliver_to_targets(
+    targets: Iterable[str],
+    *,
+    base_url: str,
+    bearer: str | None,
+    body: str,
+    card_id: str | None,
+) -> int:
+    """POST to each target; tolerate per-target failure. Return success count."""
+    delivered = 0
+    for agent in targets:
+        if _post_notify(
+            base_url, bearer, agent=agent, body=body, card_id=card_id
+        ):
+            delivered += 1
+    return delivered
+
+
+__all__ = [
+    "CARD_EVENT_KINDS",
+    "deliver_card_event",
+    "resolve_targets",
+]

--- a/src/scitex_agent_container/_listen/_notify.py
+++ b/src/scitex_agent_container/_listen/_notify.py
@@ -1,0 +1,197 @@
+"""``POST /v1/notify`` — interim card-event delivery to a containerized agent.
+
+Why this exists (scitex-todo escalation, P1)
+=============================================
+scitex-todo's board resolves an agent's ``turn_url`` and does a DIRECT
+HTTP POST to it (``http://<host>:<port>/v1/turn``). For a CONTAINERIZED
+agent that POST gets ``Connection refused [Errno 111]`` — the agent's
+a2a port is NOT reachable inbound from the board's host context.
+
+By contrast, sac's a2a delivery reaches containers because a
+containerized agent SUBSCRIBES OUTBOUND to the central ``sac listen``
+daemon's a2a bus (the SSE stream at ``/agents/<name>/inbox/stream``) and
+the daemon PUBLISHES down that connection — nothing is ever POSTed into
+the container. So fleet notify-delivery to containers MUST go through
+sac's a2a router (the listen daemon's publish-to-bus), never a direct
+POST.
+
+This endpoint is the INTERIM unblock: the board POSTs here (loopback
+``127.0.0.1:7878`` from its host context, same bearer as the rest of the
+``sac listen`` control-plane) INSTEAD of the agent's ``turn_url``. The
+body is published into the named agent's inbox bus via the EXACT same
+:class:`~scitex_agent_container.a2a._inbox_bus.Broker` publish path that
+``/agents/<name>/message:send`` (a2a_send) uses, so it reaches a
+subscribed (containerized) agent.
+
+The full event-driven rail (C10) is :mod:`._card_event_delivery`, which
+registers a ``scitex_todo.hooks`` consumer and calls the same
+:func:`publish_to_agent` helper. This module owns the HTTP seam; that
+one owns the bus-consumer seam. Both deliver through ``publish_to_agent``
+so there is ONE router-publish code path.
+
+Contract (so the board can call it)
+====================================
+``POST /v1/notify``  (bearer-gated by ``BearerAuthMiddleware``)
+
+Request JSON::
+
+    {"agent": "<owner-agent-name>",   # required, non-empty
+     "body": "<notification text>",   # required, non-empty
+     "card_id": "<card id>",          # optional — rides on the envelope
+     "from_agent": "<sender>"}        # optional — defaults to "scitex-todo"
+
+Response ``200``::
+
+    {"agent": "<name>", "msg_id": "<hex>",
+     "delivered_subscriber_count": <int>}
+
+A ``delivered_subscriber_count`` of ``0`` is NOT an error — the event is
+persisted to ``channel_events`` first, so an agent whose container is
+momentarily disconnected receives it on its next ``inbox/stream``
+connect (durability/replay, mirroring ``node_message_send``). The count
+is surfaced so the board has delivery visibility.
+
+Fail-loud (handoff §0): malformed JSON / missing-or-empty ``agent`` /
+missing-or-empty ``body`` → ``400`` with a reason; a persist/publish
+failure → ``500`` with the reason. No silent drops.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+
+from .._state.state_db_channel import persist_event
+from ..a2a._inbox_bus import Broker, mint_event
+
+logger = logging.getLogger(__name__)
+
+# Default sender identity stamped on the envelope when the caller does
+# not supply ``from_agent``. The board (scitex-todo) is the canonical
+# producer for this endpoint.
+DEFAULT_NOTIFY_FROM = "scitex-todo"
+
+__all__ = ["notify", "publish_to_agent"]
+
+
+async def publish_to_agent(
+    broker: Broker,
+    *,
+    agent: str,
+    body: str,
+    from_agent: str | None = None,
+    card_id: str | None = None,
+    kind: str = "message",
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Persist + publish ``body`` into ``agent``'s inbox bus.
+
+    THE single router-publish helper shared by the HTTP endpoint
+    (:func:`notify`) and the C10 entry-point consumer
+    (:mod:`._card_event_delivery`). It mirrors the durability contract
+    of :func:`scitex_agent_container._listen._node_channel.node_message_send`:
+    the event is persisted to ``channel_events`` BEFORE publish so an
+    event addressed to an agent with no live subscriber is not silently
+    dropped — it is replayed on the next ``inbox/stream`` connect. The
+    persisted row id rides on the envelope as ``_row_id`` so the SSE
+    handler stamps it onto the ``id:`` line (the ``Last-Event-ID``
+    cursor).
+
+    ``card_id`` (when given) is threaded into the envelope's ``extra``
+    block so a card-aware consumer can correlate the push back to the
+    originating card without parsing the free-form ``body``.
+
+    Returns ``{"msg_id": str, "delivered_subscriber_count": int}``.
+    Raises on a persist/publish failure (the caller maps it to a loud
+    non-2xx / logged warning).
+    """
+    merged_extra: dict[str, Any] = dict(extra) if extra else {}
+    if card_id:
+        merged_extra.setdefault("card_id", card_id)
+
+    event = mint_event(
+        agent,
+        content=body,
+        from_agent=from_agent or DEFAULT_NOTIFY_FROM,
+        kind=kind,
+        extra=merged_extra or None,
+    )
+    # Durability first (handoff §0): persist BEFORE publish so a
+    # not-yet-connected container still receives the event on reconnect.
+    row_id = persist_event(target=agent, event=event)
+    event["_row_id"] = row_id
+    delivered = await broker.publish(agent, event)
+    return {"msg_id": event["msg_id"], "delivered_subscriber_count": delivered}
+
+
+async def notify(request: Request) -> Response:
+    """``POST /v1/notify`` — see module docstring for the full contract.
+
+    Bearer auth is enforced by :class:`BearerAuthMiddleware` (the route
+    is not in its ``PUBLIC_PATHS``). This handler validates the body
+    shape, then delegates to :func:`publish_to_agent` so the bus-publish
+    path is identical to the C10 rail and to ``a2a_send``.
+    """
+    try:
+        body_json = await request.json()
+    except (ValueError, json.JSONDecodeError) as exc:
+        return JSONResponse(
+            {"error": f"body must be valid JSON: {exc}"}, status_code=400
+        )
+    if not isinstance(body_json, dict):
+        return JSONResponse({"error": "body must be a JSON object"}, status_code=400)
+
+    agent = body_json.get("agent")
+    if not isinstance(agent, str) or not agent.strip():
+        return JSONResponse(
+            {"error": "field 'agent' is required and must be a non-empty string"},
+            status_code=400,
+        )
+    agent = agent.strip()
+
+    text = body_json.get("body")
+    if not isinstance(text, str) or not text.strip():
+        return JSONResponse(
+            {"error": "field 'body' is required and must be a non-empty string"},
+            status_code=400,
+        )
+
+    card_id = body_json.get("card_id")
+    if card_id is not None and not isinstance(card_id, str):
+        return JSONResponse(
+            {"error": "field 'card_id' must be a string when set"},
+            status_code=400,
+        )
+    from_agent = body_json.get("from_agent")
+    if from_agent is not None and not isinstance(from_agent, str):
+        return JSONResponse(
+            {"error": "field 'from_agent' must be a string when set"},
+            status_code=400,
+        )
+
+    broker: Broker = request.app.state.inbox
+    try:
+        result = await publish_to_agent(
+            broker,
+            agent=agent,
+            body=text,
+            from_agent=from_agent,
+            card_id=card_id,
+        )
+    except Exception as exc:  # stx-allow: fallback (reason: a persist/publish failure must be a LOUD 500 with the reason, never a silent drop)
+        logger.warning("notify: publish to %r failed: %s", agent, exc)
+        return JSONResponse(
+            {"error": f"failed to deliver to {agent!r}: {exc}"}, status_code=500
+        )
+
+    return JSONResponse(
+        {
+            "agent": agent,
+            "msg_id": result["msg_id"],
+            "delivered_subscriber_count": result["delivered_subscriber_count"],
+        }
+    )

--- a/src/scitex_agent_container/_listen/server.py
+++ b/src/scitex_agent_container/_listen/server.py
@@ -23,7 +23,6 @@ ADR-0004 (no backward compat).
 
 from __future__ import annotations
 
-import os
 import urllib.error as _urlerror
 import urllib.request as _urlrequest
 from typing import Any
@@ -340,86 +339,12 @@ from ._node_channel import (  # noqa: E402
     node_message_send,
 )
 
-
-async def agent_delete(request: Request) -> JSONResponse:
-    """DELETE /agents/<name> — stop the agent.
-
-    Four cases distinguished by the response code:
-
-      * **200 OK** — agent is live; ``pid`` file present; SIGTERM sent.
-      * **410 Gone** (PR-1) — agent is *stillborn*: a ``STARTUP_FAILED``
-        marker is on disk (set by the POST /agents handler on a
-        non-zero ``sac agents start`` exit). The body carries the
-        failure details so the caller doesn't need to also
-        ``GET .../status``.
-      * **404 Not Found** — agent never existed or was already deleted.
-      * **403 Forbidden** (PR-3) — caller is identified (via
-        ``request.state.authenticated_node``) but lacks lineage-scoped
-        permission to operate on this target. Body shape:
-        ``{"error": "ACL deny", "kind": "acl_deny", "reason": "..."}``
-        — the 5th kind in the wire taxonomy pinned with clew.
-
-    Splitting 410 from 404 is the operator-actionable difference:
-    "never existed" vs. "existed, has been removed". Splitting 403
-    from both is identity-actionable: the agent exists (or doesn't,
-    irrelevant) but the caller can't touch it.
-    """
-    name = request.path_params["name"]
-    # PR-3 — lineage-scoped ACL gate. ``authenticated_node`` is the
-    # resolved per-node identity from NodeAuthMiddleware; ``None``
-    # is the administrative / host-wide bearer (always allowed by
-    # check_lineage_acl). The ACL is enforced BEFORE we touch the
-    # state dir / pid file so a denied caller learns nothing about
-    # whether the target exists (status, marker, runtime files).
-    from ._acl import check_lineage_acl, deny_response
-
-    caller = getattr(request.state, "authenticated_node", None)
-    decision, reason = check_lineage_acl(caller=caller, target=name)
-    if decision == "deny":
-        return deny_response(reason or "lineage ACL deny")
-    sd = state_dir_for(name)
-    pid_file = sd / "pid"
-    if not pid_file.is_file():
-        # PR-1 — distinguish stillborn (have STARTUP_FAILED marker) from
-        # genuinely not-found. Stillborn → 410 Gone + the structured
-        # failure body the operator/orchestrator can branch on without
-        # also hitting GET /agents/<name>/status.
-        #
-        # Wire shape per clew review (#287):
-        #
-        # The "headline" failure fields (status, phase, kind, failed_at,
-        # runtime_dir, remediation_hint) are LIFTED to the top level so a
-        # clew-launcher error renderer can branch / display without
-        # walking into ``details``. ``see_also`` is the host-absolute
-        # path to the on-disk marker so a human / sysadmin can ``cat``
-        # the marker (and the peer ``stdout.log`` / ``stderr.log`` in
-        # the same directory) without recomputing it. The full marker
-        # remains under ``details`` for parity with the marker file
-        # contents (and so an orchestrator can hash it for dedupe).
-        from .._lifecycle._startup_failed import MARKER_FILENAME, read_marker
-
-        marker = read_marker(sd)
-        if marker is not None:
-            runtime_dir = marker.get("runtime_dir", str(sd.resolve()))
-            body: dict[str, Any] = {
-                "name": name,
-                "status": "startup_failed",
-                "kind": marker.get("kind"),
-                "phase": marker.get("phase"),
-                "failed_at": marker.get("failed_at"),
-                "runtime_dir": runtime_dir,
-                "remediation_hint": marker.get("remediation_hint", ""),
-                "see_also": f"{runtime_dir}/{MARKER_FILENAME}",
-                "details": marker,
-            }
-            return JSONResponse(body, status_code=410)
-        return JSONResponse({"error": "no pid file"}, status_code=404)
-    try:
-        pid = int(pid_file.read_text().strip())
-        os.kill(pid, 15)  # SIGTERM
-    except (OSError, ValueError) as exc:
-        return JSONResponse({"error": str(exc)}, status_code=500)
-    return JSONResponse({"name": name, "stopped": True, "pid": pid})
+# ``agent_delete`` (the DELETE /agents/<name> lifecycle handler) was
+# extracted into ``_agent_delete`` (server.py hit the per-file line cap);
+# re-imported here so route registration (:func:`_v1_agent_routes`) and
+# the historical ``from ..._listen.server import agent_delete`` import
+# path keep working unchanged.
+from ._agent_delete import agent_delete  # noqa: E402
 
 
 # --- App factory -----------------------------------------------------------
@@ -507,9 +432,18 @@ def create_app(
     # (rather than the silently-ineffective per-container copy).
     from ._acl_routes import acl_block, acl_grant, acl_unblock
 
+    # Interim card-event delivery (scitex-todo escalation, P1). The board
+    # POSTs here (loopback, host-wide bearer) INSTEAD of a containerized
+    # agent's unreachable ``turn_url``; ``notify`` publishes the body into
+    # the agent's inbox bus via the same router path ``a2a_send`` uses, so
+    # a subscribed (containerized) agent receives it. Bearer-gated by the
+    # ``BearerAuthMiddleware`` below (not in its ``PUBLIC_PATHS``).
+    from ._notify import notify
+
     routes: list[Route] = [
         Route("/v1/health", health, methods=["GET"]),
         Route("/.well-known/agent-card.json", fleet_card_handler, methods=["GET"]),
+        Route("/v1/notify", notify, methods=["POST"]),
         Route("/v1/acl/unblock", acl_unblock, methods=["POST"]),
         Route("/v1/acl/block", acl_block, methods=["POST"]),
         Route("/v1/acl/grant", acl_grant, methods=["POST"]),

--- a/tests/integration/test_listen_notify_delivery.py
+++ b/tests/integration/test_listen_notify_delivery.py
@@ -1,0 +1,256 @@
+"""End-to-end: ``POST /v1/notify`` reaches a real SSE subscriber.
+
+This is the empirical proof for the scitex-todo escalation (P1). A
+CONTAINERIZED agent's ``sac mcp channel`` SUBSCRIBES OUTBOUND to the
+central ``sac listen`` daemon's a2a bus at
+``GET /agents/<name>/inbox/stream`` (SSE); the daemon PUBLISHES down that
+connection. The board cannot POST into the container's own a2a port
+(``Connection refused``), so it POSTs the notification to the daemon's
+``/v1/notify`` instead — and the daemon publishes it onto the bus the
+agent is already subscribed to.
+
+This test boots a REAL ``sac listen`` app on a REAL loopback uvicorn
+socket, opens a REAL SSE subscriber on ``/agents/<name>/inbox/stream``
+(exactly what a containerized agent does), POSTs to ``/v1/notify`` with
+the host bearer, and asserts the subscriber receives the body. If
+delivery did NOT route through the bus, the subscriber would never see
+the event — so a green assertion is the end-to-end guarantee the board
+needs.
+
+No mocks (STX-NM002), mirroring the real-socket style of
+``test_sac_listen_health_probe.py`` /
+``test_listen_startup_sync_no_bind_block.py``:
+
+* the server is a REAL ``uvicorn`` bound to a REAL ephemeral 127.0.0.1
+  port;
+* the subscriber is a REAL ``httpx`` SSE stream over that socket;
+* the publish goes through the REAL ``Broker`` inside the REAL app;
+* the ``state.db`` is a REAL (isolated, tmp_path) SQLite file.
+
+TQ: module docstring states intent (TQ001); AAA markers (TQ002); the
+state.db / bring-up fixtures are FUNCTION scoped (TQ004) and ``yield``
+their resources (TQ005); 3+-word names.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import os
+import socket
+import threading
+import time
+from pathlib import Path
+
+import httpx
+import pytest
+import uvicorn
+
+from scitex_agent_container._listen.server import create_app
+from scitex_agent_container._runners import _session_state as _ss
+from scitex_agent_container._state import registry as _reg
+from scitex_agent_container._state import state_db
+
+HOST_TOKEN = "integration-notify-host-token"
+AGENT = "containerized-worker"
+
+
+# ---------------------------------------------------------------------------
+# Real-socket bring-up (mirrors tests/smoke/_node_comms._run_loopback).
+# ---------------------------------------------------------------------------
+
+
+def _free_port() -> int:
+    """Bind a loopback socket to port 0; return the OS-assigned port."""
+    with contextlib.closing(socket.socket()) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+@pytest.fixture
+def listen_state_db(tmp_path: Path):
+    """Isolated state.db + registry/runtime dirs for the real app.
+
+    Function-scoped (TQ004 — no shared mutable state across tests); sets
+    its env + module constants, ``yield``s the bundle (TQ005), and
+    restores everything on teardown.
+    """
+    saved = {
+        "HOME": os.environ.get("HOME"),
+        "SCITEX_AGENT_CONTAINER_STATE_DB": os.environ.get(
+            "SCITEX_AGENT_CONTAINER_STATE_DB"
+        ),
+        "SCITEX_AGENT_CONTAINER_REGISTRY_DIR": os.environ.get(
+            "SCITEX_AGENT_CONTAINER_REGISTRY_DIR"
+        ),
+        "SCITEX_AGENT_CONTAINER_RUNTIME_DIR": os.environ.get(
+            "SCITEX_AGENT_CONTAINER_RUNTIME_DIR"
+        ),
+    }
+    saved_reg_const = _reg.REGISTRY_DIR
+    saved_state_const = _ss.DEFAULT_STATE_ROOT
+    saved_db_const = state_db.DEFAULT_DB_PATH
+
+    db = tmp_path / "state.db"
+    os.environ["HOME"] = str(tmp_path)
+    os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
+    os.environ["SCITEX_AGENT_CONTAINER_REGISTRY_DIR"] = str(tmp_path / "registry")
+    os.environ["SCITEX_AGENT_CONTAINER_RUNTIME_DIR"] = str(tmp_path / "runtime")
+    state_db.DEFAULT_DB_PATH = db
+    _reg.REGISTRY_DIR = tmp_path / "registry"
+    _ss.DEFAULT_STATE_ROOT = tmp_path / "runtime"
+    state_db.init_schema(db)
+    try:
+        yield {"db": db}
+    finally:
+        state_db.DEFAULT_DB_PATH = saved_db_const
+        _reg.REGISTRY_DIR = saved_reg_const
+        _ss.DEFAULT_STATE_ROOT = saved_state_const
+        for key, val in saved.items():
+            if val is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = val
+
+
+@pytest.fixture
+def live_listen(listen_state_db):
+    """Boot the REAL ``sac listen`` app on a REAL loopback uvicorn port.
+
+    Disables the listen lifespan's background loops (peer-sync, CI poll,
+    TUI heartbeat, liveness-tick, bind-watchdog) so the test stays hermetic
+    and fast; the routes + broker we exercise are unaffected. Function-
+    scoped; ``yield``s the base URL; tears uvicorn down in ``finally``.
+    """
+    loop_disables = {
+        "SAC_LISTEN_STARTUP_SYNC_DISABLED": "1",
+        "SAC_PERIODIC_DRIVE_DISABLED": "1",
+        "SAC_GITHUB_CI_POLLER_DISABLED": "1",
+        "SAC_TUI_HEARTBEAT_DISABLED": "1",
+        "SAC_LIVENESS_TICK_DISABLED": "1",
+        "SAC_LISTEN_BIND_WATCHDOG_DISABLED": "1",
+    }
+    saved_disables = {k: os.environ.get(k) for k in loop_disables}
+    os.environ.update(loop_disables)
+
+    app = create_app(token=HOST_TOKEN, local_host="127.0.0.1")
+    port = _free_port()
+    config = uvicorn.Config(
+        app, host="127.0.0.1", port=port, log_level="warning", ws="none"
+    )
+    server = uvicorn.Server(config)
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+    deadline = time.monotonic() + 5.0
+    while not server.started:
+        if time.monotonic() > deadline:
+            raise RuntimeError("uvicorn loopback did not start in 5s")
+        time.sleep(0.05)
+    try:
+        yield f"http://127.0.0.1:{port}"
+    finally:
+        server.should_exit = True
+        thread.join(timeout=5.0)
+        for k, v in saved_disables.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+async def _subscribe_then_notify(base_url: str, *, body: str, card_id: str) -> dict:
+    """Subscribe to the agent's inbox SSE, POST /v1/notify, return the event.
+
+    Models the containerized agent exactly: the SSE subscription is the
+    OUTBOUND connection from the (would-be) container; the /v1/notify POST
+    is the board's call from the host context. We wait for the SSE
+    comment-frame (proves "subscribed") before posting so there is no race.
+    """
+    ready = asyncio.Event()
+    captured: dict = {}
+
+    async def consume() -> None:
+        async with httpx.AsyncClient(timeout=5.0) as ac:
+            async with ac.stream(
+                "GET",
+                f"{base_url}/agents/{AGENT}/inbox/stream",
+                headers={"authorization": f"Bearer {HOST_TOKEN}"},
+            ) as sse:
+                async for line in sse.aiter_lines():
+                    if line.startswith(":"):
+                        ready.set()
+                        continue
+                    if line.startswith("data:"):
+                        captured["event"] = json.loads(line[len("data:") :].lstrip())
+                        return
+
+    sub = asyncio.create_task(consume())
+    try:
+        await asyncio.wait_for(ready.wait(), timeout=5.0)
+        async with httpx.AsyncClient(timeout=5.0) as ac:
+            resp = await ac.post(
+                f"{base_url}/v1/notify",
+                json={"agent": AGENT, "body": body, "card_id": card_id},
+                headers={"authorization": f"Bearer {HOST_TOKEN}"},
+            )
+        captured["status"] = resp.status_code
+        captured["resp_body"] = resp.json()
+        await asyncio.wait_for(sub, timeout=5.0)
+    finally:
+        if not sub.done():
+            sub.cancel()
+            with contextlib.suppress(BaseException):
+                await sub
+    return captured
+
+
+@pytest.fixture
+def notify_roundtrip(live_listen):
+    """Run one subscribe→/v1/notify→receive round-trip; return the capture.
+
+    Function-scoped; the heavy real-socket round-trip runs once and the
+    one-assert-per-test cases below read its result (no extra sockets).
+    """
+    captured = asyncio.run(
+        _subscribe_then_notify(
+            live_listen, body="card 7 commented by operator", card_id="card-7"
+        )
+    )
+    yield captured
+
+
+def test_notify_post_returns_200(notify_roundtrip) -> None:
+    # Arrange — the round-trip fixture posted to the live /v1/notify.
+    captured = notify_roundtrip
+    # Act
+    status = captured.get("status")
+    # Assert
+    assert status == 200, captured.get("resp_body")
+
+
+def test_notify_reaches_the_outbound_sse_subscriber(notify_roundtrip) -> None:
+    # Arrange — the subscriber modelled a containerized agent's SSE stream.
+    event = notify_roundtrip.get("event", {})
+    # Act
+    content = event.get("content")
+    # Assert — delivery routed through the bus to the real subscriber.
+    assert content == "card 7 commented by operator", notify_roundtrip
+
+
+def test_notify_response_reports_one_delivered_subscriber(notify_roundtrip) -> None:
+    # Arrange — one SSE subscriber was connected when /v1/notify fired.
+    resp_body = notify_roundtrip.get("resp_body", {})
+    # Act
+    count = resp_body.get("delivered_subscriber_count")
+    # Assert
+    assert count == 1, resp_body
+
+
+def test_notify_event_carries_card_id_in_extra(notify_roundtrip) -> None:
+    # Arrange — the board passed card_id so the agent can correlate.
+    event = notify_roundtrip.get("event", {})
+    # Act
+    card_id = (event.get("extra") or {}).get("card_id")
+    # Assert
+    assert card_id == "card-7", event

--- a/tests/scitex_agent_container/_listen/test__agent_delete.py
+++ b/tests/scitex_agent_container/_listen/test__agent_delete.py
@@ -1,0 +1,81 @@
+"""Unit test mirroring ``src/scitex_agent_container/_listen/_agent_delete.py``.
+
+The ``agent_delete`` handler was extracted from ``server.py`` (which hit
+the per-file line cap). The exhaustive wire-shape coverage lives in
+``test_server_startup_failed.py`` / ``test_server_lineage_acl.py`` (which
+drive it through ``create_app``). This file is the PS-204 §2 mirror: it
+asserts the extraction's public surface — the handler is importable from
+its new home AND still serves the ``404`` not-found path through the real
+app over a real ASGI round-trip.
+
+No mocks (STX-NM002): the real Starlette app via the real ``TestClient``
+against a real isolated runtime dir.
+
+TQ: AAA markers (TQ002); 3+-word names; the env fixture is FUNCTION
+scoped (TQ004) and ``yield``s (TQ005).
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+from pathlib import Path
+
+import pytest
+from starlette.testclient import TestClient
+
+from scitex_agent_container._listen._agent_delete import agent_delete
+from scitex_agent_container._listen.server import create_app
+
+TOKEN = "test-agent-delete-token"
+
+
+@pytest.fixture
+def isolated_runtime(tmp_path: Path):
+    """Redirect $HOME + runtime dir into tmp_path so delete touches no real
+    state. Function-scoped (TQ004); ``yield``s after reloading the state
+    module against the redirected env (TQ005); restores on teardown.
+    """
+    import scitex_agent_container._runners._session_state as ss
+
+    saved_home = os.environ.get("HOME")
+    saved_runtime = os.environ.get("SCITEX_AGENT_CONTAINER_RUNTIME_DIR")
+    home = tmp_path / "home"
+    home.mkdir()
+    runtime = tmp_path / "runtime"
+    runtime.mkdir()
+    os.environ["HOME"] = str(home)
+    os.environ["SCITEX_AGENT_CONTAINER_RUNTIME_DIR"] = str(runtime)
+    importlib.reload(ss)
+    try:
+        yield tmp_path
+    finally:
+        os.environ.pop("SCITEX_AGENT_CONTAINER_RUNTIME_DIR", None)
+        if saved_home is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = saved_home
+        if saved_runtime is not None:
+            os.environ["SCITEX_AGENT_CONTAINER_RUNTIME_DIR"] = saved_runtime
+        importlib.reload(ss)
+
+
+def test_agent_delete_is_importable_from_extracted_module() -> None:
+    # Arrange — the extraction must keep the handler importable from its
+    # new home (the route registration imports it from here).
+    handler = agent_delete
+    # Act
+    is_callable = callable(handler)
+    # Assert
+    assert is_callable
+
+
+def test_delete_unknown_agent_returns_404(isolated_runtime) -> None:
+    # Arrange — agent never existed: no pid file, no marker.
+    app = create_app(token=TOKEN)
+    headers = {"authorization": f"Bearer {TOKEN}"}
+    # Act
+    with TestClient(app) as client:
+        response = client.delete("/agents/never-existed-xyz", headers=headers)
+    # Assert
+    assert response.status_code == 404

--- a/tests/scitex_agent_container/_listen/test__card_event_delivery.py
+++ b/tests/scitex_agent_container/_listen/test__card_event_delivery.py
@@ -1,0 +1,253 @@
+"""Unit tests for the C10 ``scitex_todo.hooks`` consumer.
+
+Mirrors ``src/scitex_agent_container/_listen/_card_event_delivery.py``
+(PS-204 §2).
+
+What this proves
+================
+:func:`deliver_card_event` is sac's consumer on scitex-todo's shared
+card-event bus. It MUST:
+
+* FILTER — deliver on a card-event kind; NO-OP on an unrecognized kind,
+  most importantly sac's OWN liveness-tick anomaly events on the same
+  bus (which carry ``reason`` / ``severity``, not a card-event kind). If
+  the two flows cross-wired, sac would POST its own anomalies back into
+  agents' inboxes.
+* RESOLVE — target = card owner + collaborators + subscribers.
+* DELIVER — one ``/v1/notify`` POST per target to the local daemon.
+* DEGRADE — never raise; a per-target failure is logged + skipped.
+
+No mocks (STX-NM002)
+====================
+The filter / resolve logic is asserted on REAL event dicts. The delivery
+half is exercised against a REAL local HTTP server bound to a REAL
+ephemeral loopback port that records the POSTs it receives — we point
+``SAC_LISTEN_BASE_URL`` at it (via a real ``os.environ`` set/restore
+fixture, NOT monkeypatch) and assert the consumer made the right real
+HTTP calls. The graceful-degrade test uses the SAME real server, which
+answers ``500`` for one specific agent name and ``200`` for the rest —
+real per-target failure, nothing about production is rewritten.
+
+TQ: AAA markers (TQ002); 3+-word names; the HTTP-server / env fixtures
+are FUNCTION scoped (TQ004) and ``yield`` their resources (TQ005).
+"""
+
+from __future__ import annotations
+
+import http.server
+import json
+import os
+import threading
+from dataclasses import dataclass, field
+
+import pytest
+
+from scitex_agent_container._listen._card_event_delivery import (
+    deliver_card_event,
+    resolve_targets,
+)
+
+# Agent name the fake daemon is hard-wired to FAIL for (500). Used by the
+# graceful-degrade test to produce a real per-target failure with no mock.
+_FLAKY_AGENT = "flaky-agent"
+
+
+# ---------------------------------------------------------------------------
+# Filter + resolve: pure logic on real event dicts (no IO).
+# ---------------------------------------------------------------------------
+
+
+def test_anomaly_event_is_ignored_no_op() -> None:
+    # Arrange — sac's OWN liveness-tick anomaly shape on the shared bus:
+    # ``reason``/``severity``, NO card-event kind. (If this were delivered,
+    # sac would push its own anomalies into an agent's inbox.)
+    anomaly = {
+        "agent": "worker-x",
+        "card_id": "card-1",
+        "reason": "owner-not-live",
+        "severity": "critical",
+        "ts": 1.0,
+    }
+    # Act
+    delivered = deliver_card_event(anomaly)
+    # Assert — recognised as not-a-card-event → no delivery.
+    assert delivered == 0
+
+
+def test_unknown_kind_is_ignored_no_op() -> None:
+    # Arrange — a kind sac does not handle.
+    event = {"kind": "archived", "owner": "worker-x"}
+    # Act
+    delivered = deliver_card_event(event)
+    # Assert
+    assert delivered == 0
+
+
+def test_non_dict_event_is_ignored_no_op() -> None:
+    # Arrange — a malformed (non-dict) payload on the bus.
+    payload = "not-a-dict"
+    # Act — swallowed, never raises into the producer.
+    delivered = deliver_card_event(payload)
+    # Assert
+    assert delivered == 0
+
+
+def test_resolve_targets_unions_owner_collaborators_subscribers() -> None:
+    # Arrange — the three target sources, with a duplicate to dedup.
+    event = {
+        "kind": "commented",
+        "owner": "alice",
+        "collaborators": ["bob", "alice"],
+        "subscribers": ["carol"],
+    }
+    # Act
+    targets = resolve_targets(event)
+    # Assert — order-preserving union, deduped.
+    assert targets == ["alice", "bob", "carol"]
+
+
+def test_resolve_targets_accepts_member_dicts() -> None:
+    # Arrange — a producer that ships richer member objects.
+    event = {
+        "kind": "reassigned",
+        "assignee": {"name": "dave"},
+        "subscribers": [{"agent": "erin"}],
+    }
+    # Act
+    targets = resolve_targets(event)
+    # Assert
+    assert targets == ["dave", "erin"]
+
+
+# ---------------------------------------------------------------------------
+# Delivery: against a REAL local HTTP server standing in for /v1/notify.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _Daemon:
+    base_url: str
+    posts: list[dict] = field(default_factory=list)
+
+
+@pytest.fixture
+def fake_notify_daemon():
+    """Run a REAL HTTP server that records ``/v1/notify`` POSTs.
+
+    Stands in for the local ``sac listen`` daemon: a real socket on a real
+    ephemeral loopback port. It answers ``500`` when the posted body's
+    ``agent`` equals :data:`_FLAKY_AGENT` and ``200`` otherwise — a real
+    per-target failure path for the graceful-degrade test, with nothing
+    about production rewritten.
+
+    Points ``SAC_LISTEN_BASE_URL`` / ``SAC_LISTEN_BEARER`` at it via a
+    real ``os.environ`` set/restore (NOT monkeypatch). Function-scoped
+    (TQ004); ``yield``s the running daemon handle (TQ005) and tears the
+    server + env down afterwards.
+    """
+    recorder_posts: list[dict] = []
+
+    class _Handler(http.server.BaseHTTPRequestHandler):
+        def do_POST(self):  # noqa: N802 (http.server API)
+            length = int(self.headers.get("Content-Length", 0))
+            raw = self.rfile.read(length) if length else b"{}"
+            try:
+                body = json.loads(raw.decode("utf-8"))
+            except Exception:  # stx-allow: fallback (reason: stub records whatever arrives)
+                body = {"_raw": raw.decode("utf-8", "replace")}
+            recorder_posts.append(
+                {
+                    "path": self.path,
+                    "authorization": self.headers.get("Authorization"),
+                    "body": body,
+                }
+            )
+            fail = isinstance(body, dict) and body.get("agent") == _FLAKY_AGENT
+            payload = b'{"ok": false}' if fail else b'{"ok": true}'
+            self.send_response(500 if fail else 200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def log_message(self, *_args):  # silence default stderr spam
+            return
+
+    server = http.server.HTTPServer(("127.0.0.1", 0), _Handler)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    saved_base = os.environ.get("SAC_LISTEN_BASE_URL")
+    saved_bearer = os.environ.get("SAC_LISTEN_BEARER")
+    os.environ["SAC_LISTEN_BASE_URL"] = f"http://127.0.0.1:{port}"
+    os.environ["SAC_LISTEN_BEARER"] = "test-c10-bearer"
+    try:
+        yield _Daemon(base_url=f"http://127.0.0.1:{port}", posts=recorder_posts)
+    finally:
+        for key, val in (
+            ("SAC_LISTEN_BASE_URL", saved_base),
+            ("SAC_LISTEN_BEARER", saved_bearer),
+        ):
+            if val is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = val
+        server.shutdown()
+        server.server_close()
+
+
+def test_commented_event_delivers_to_owner(fake_notify_daemon) -> None:
+    # Arrange — a real card-event naming one owner agent.
+    event = {"kind": "commented", "owner": "worker-x", "card_id": "card-7"}
+    # Act
+    delivered = deliver_card_event(event)
+    # Assert — exactly one real POST landed at the daemon, addressed to the
+    # owner agent.
+    assert delivered == 1 and fake_notify_daemon.posts[0]["body"]["agent"] == (
+        "worker-x"
+    )
+
+
+def test_delivery_carries_bearer_and_card_id(fake_notify_daemon) -> None:
+    # Arrange
+    event = {"kind": "completed", "owner": "worker-x", "card_id": "card-7"}
+    # Act
+    deliver_card_event(event)
+    post = fake_notify_daemon.posts[0]
+    # Assert — bearer header + card_id threaded onto the /v1/notify body.
+    assert (
+        post["authorization"] == "Bearer test-c10-bearer"
+        and post["body"]["card_id"] == "card-7"
+    )
+
+
+def test_delivery_posts_to_each_unique_target(fake_notify_daemon) -> None:
+    # Arrange — owner + collaborator + subscriber = three unique agents.
+    event = {
+        "kind": "status_changed",
+        "owner": "alice",
+        "collaborators": ["bob"],
+        "subscribers": ["carol"],
+        "card_id": "card-9",
+    }
+    # Act
+    delivered = deliver_card_event(event)
+    agents = sorted(p["body"]["agent"] for p in fake_notify_daemon.posts)
+    # Assert
+    assert delivered == 3 and agents == ["alice", "bob", "carol"]
+
+
+def test_one_bad_target_does_not_abort_the_rest(fake_notify_daemon) -> None:
+    # Arrange — the daemon returns a real 500 for ``_FLAKY_AGENT`` and 200
+    # for the rest, so the first target genuinely fails over the wire.
+    event = {
+        "kind": "commented",
+        "owner": _FLAKY_AGENT,
+        "collaborators": ["bob"],
+        "card_id": "card-9",
+    }
+    # Act — must NOT raise; the healthy target still gets delivered.
+    delivered = deliver_card_event(event)
+    # Assert — one success (bob); the 500 for the flaky owner is swallowed.
+    assert delivered == 1

--- a/tests/scitex_agent_container/_listen/test__notify.py
+++ b/tests/scitex_agent_container/_listen/test__notify.py
@@ -1,0 +1,194 @@
+"""Unit tests for the interim ``POST /v1/notify`` delivery endpoint.
+
+Mirrors ``src/scitex_agent_container/_listen/_notify.py`` (PS-204 §2).
+
+What this proves
+================
+``/v1/notify`` is the interim unblock for the scitex-todo escalation:
+the board POSTs here INSTEAD of a containerized agent's unreachable
+``turn_url``, and the body is published into the agent's a2a inbox bus
+via the SAME :class:`~scitex_agent_container.a2a._inbox_bus.Broker`
+publish path ``a2a_send`` uses — so a subscribed (containerized) agent
+receives it.
+
+No mocks (STX-NM002)
+====================
+* The bus half (:func:`publish_to_agent`) is exercised against a REAL
+  in-process :class:`Broker` with a REAL subscriber: we ``subscribe`` a
+  queue, publish, and assert the exact event lands on that queue. Nothing
+  is mocked.
+* The HTTP half is driven through the REAL Starlette app via the REAL
+  ``TestClient`` (a real ASGI round-trip), against a REAL isolated
+  state.db — bearer gating, body validation, and the persisted
+  ``channel_events`` row are all asserted against real behaviour.
+
+TQ: AAA markers (TQ002); 3+-word names; the state.db fixture is FUNCTION
+scoped (TQ004) and ``yield``s (TQ005).
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+from starlette.testclient import TestClient
+
+from scitex_agent_container._listen._notify import publish_to_agent
+from scitex_agent_container._listen.server import create_app
+from scitex_agent_container._runners import _session_state as _ss
+from scitex_agent_container._state import registry as _reg
+from scitex_agent_container._state import state_db
+from scitex_agent_container._state.state_db_channel import list_undelivered
+from scitex_agent_container.a2a._inbox_bus import Broker
+
+TOKEN = "test-notify-token"
+
+
+@pytest.fixture
+def notify_env(tmp_path: Path):
+    """Isolated state.db + registry so ``/v1/notify`` persists in isolation.
+
+    Function-scoped (TQ004 — no session/module-scoped state mutation) and
+    ``yield``s after acquiring its resources (TQ005). Restores every env
+    var + module constant it overrides.
+    """
+    saved_home = os.environ.get("HOME")
+    saved_db_env = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB")
+    saved_reg_env = os.environ.get("SCITEX_AGENT_CONTAINER_REGISTRY_DIR")
+    saved_run_env = os.environ.get("SCITEX_AGENT_CONTAINER_RUNTIME_DIR")
+    saved_reg_const = _reg.REGISTRY_DIR
+    saved_state_const = _ss.DEFAULT_STATE_ROOT
+    saved_db_const = state_db.DEFAULT_DB_PATH
+
+    db = tmp_path / "state.db"
+    os.environ["HOME"] = str(tmp_path)
+    os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
+    os.environ["SCITEX_AGENT_CONTAINER_REGISTRY_DIR"] = str(tmp_path / "registry")
+    os.environ["SCITEX_AGENT_CONTAINER_RUNTIME_DIR"] = str(tmp_path / "runtime")
+    state_db.DEFAULT_DB_PATH = db
+    _reg.REGISTRY_DIR = tmp_path / "registry"
+    _ss.DEFAULT_STATE_ROOT = tmp_path / "runtime"
+    state_db.init_schema(db)
+
+    try:
+        yield {"db": db, "tmp_path": tmp_path}
+    finally:
+        state_db.DEFAULT_DB_PATH = saved_db_const
+        _reg.REGISTRY_DIR = saved_reg_const
+        _ss.DEFAULT_STATE_ROOT = saved_state_const
+        for k, v in (
+            ("HOME", saved_home),
+            ("SCITEX_AGENT_CONTAINER_STATE_DB", saved_db_env),
+            ("SCITEX_AGENT_CONTAINER_REGISTRY_DIR", saved_reg_env),
+            ("SCITEX_AGENT_CONTAINER_RUNTIME_DIR", saved_run_env),
+        ):
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+# ---------------------------------------------------------------------------
+# Bus half: publish_to_agent against a REAL broker + REAL subscriber.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_publish_reaches_a_real_subscriber(notify_env) -> None:
+    # Arrange — a REAL broker with a REAL subscriber queue for the agent.
+    broker = Broker()
+    queue = await broker.subscribe("worker-x")
+    # Act — publish through the production helper (persist + publish).
+    await publish_to_agent(broker, agent="worker-x", body="card 42 commented")
+    # Assert — the subscriber received the event body verbatim.
+    event = queue.get_nowait()
+    assert event["content"] == "card 42 commented"
+
+
+@pytest.mark.asyncio
+async def test_publish_reports_delivered_subscriber_count(notify_env) -> None:
+    # Arrange — two REAL subscribers on the same agent's bus.
+    broker = Broker()
+    await broker.subscribe("worker-x")
+    await broker.subscribe("worker-x")
+    # Act
+    result = await publish_to_agent(broker, agent="worker-x", body="ping")
+    # Assert — both live subscribers are counted.
+    assert result["delivered_subscriber_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_publish_threads_card_id_into_extra(notify_env) -> None:
+    # Arrange
+    broker = Broker()
+    queue = await broker.subscribe("worker-x")
+    # Act
+    await publish_to_agent(
+        broker, agent="worker-x", body="see card", card_id="card-99"
+    )
+    # Assert — card_id rides under ``extra`` for card-aware consumers.
+    event = queue.get_nowait()
+    assert (event.get("extra") or {}).get("card_id") == "card-99"
+
+
+# ---------------------------------------------------------------------------
+# HTTP half: /v1/notify through the real app over a real ASGI round-trip.
+# ---------------------------------------------------------------------------
+
+
+def test_notify_persists_event_for_replay(notify_env) -> None:
+    # Arrange — real app + real state.db; no subscriber connected yet, so
+    # durability (persist-before-publish) is what carries the event.
+    app = create_app(token=TOKEN, local_host="127.0.0.1")
+    headers = {"authorization": f"Bearer {TOKEN}"}
+    # Act
+    with TestClient(app) as client:
+        resp = client.post(
+            "/v1/notify",
+            json={"agent": "worker-y", "body": "card 7 reassigned"},
+            headers=headers,
+        )
+    rows = list_undelivered(target="worker-y")
+    # Assert — 200 and the body is durably queued for the next connect.
+    assert resp.status_code == 200 and rows[0]["event"]["content"] == (
+        "card 7 reassigned"
+    )
+
+
+def test_notify_requires_bearer_token(notify_env) -> None:
+    # Arrange — same control-plane bearer gate as the rest of 7878.
+    app = create_app(token=TOKEN, local_host="127.0.0.1")
+    # Act — no Authorization header.
+    with TestClient(app) as client:
+        resp = client.post(
+            "/v1/notify", json={"agent": "worker-y", "body": "hi"}
+        )
+    # Assert
+    assert resp.status_code == 401
+
+
+def test_notify_rejects_missing_agent_loudly(notify_env) -> None:
+    # Arrange
+    app = create_app(token=TOKEN, local_host="127.0.0.1")
+    headers = {"authorization": f"Bearer {TOKEN}"}
+    # Act — body present, agent missing.
+    with TestClient(app) as client:
+        resp = client.post("/v1/notify", json={"body": "hi"}, headers=headers)
+    # Assert — fail loud (400), not a silent accept.
+    assert resp.status_code == 400
+
+
+def test_notify_rejects_empty_body_loudly(notify_env) -> None:
+    # Arrange
+    app = create_app(token=TOKEN, local_host="127.0.0.1")
+    headers = {"authorization": f"Bearer {TOKEN}"}
+    # Act — agent present, body blank.
+    with TestClient(app) as client:
+        resp = client.post(
+            "/v1/notify",
+            json={"agent": "worker-y", "body": "   "},
+            headers=headers,
+        )
+    # Assert
+    assert resp.status_code == 400


### PR DESCRIPTION
## Why

Restores the operator's core workflow: commenting on a scitex-todo card must reach the card's owner-AGENT, **including containerized agents**.

scitex-todo's board resolves an agent's `turn_url` and does a DIRECT HTTP POST to it (e.g. `http://ywata-note-win:19015/v1/turn`). For a **containerized** agent that POST gets `Connection refused [Errno 111]` — the agent's a2a port is not reachable inbound from the board's host context. sac's a2a delivery DOES reach containers because a containerized agent **subscribes outbound** to the central `sac listen` daemon's a2a bus (SSE) and the daemon **publishes** down that connection. So fleet notify-delivery to containers must go through sac's a2a router, never a direct POST.

Refs: scitex-todo's escalation + the agreed bus-only `scitex_todo.hooks` contract (C5 producer already deployed; sac's C10 consumer here). The shared bus carries events in BOTH directions — sac itself emits anomaly events on `scitex_todo.hooks` (the just-merged liveness-tick producer, #475) — so the C10 consumer filters for card-event kinds and ignores everything else.

## What

### Deliverable 1 — interim unblock: `POST /v1/notify`
A delivery endpoint on the listen daemon (`127.0.0.1:7878`), bearer-gated by the existing `BearerAuthMiddleware`, accepting JSON `{"agent","body","card_id?","from_agent?"}`. It persists-then-publishes the body into the named agent's inbox `Broker` via the **same router publish path `a2a_send` uses** (`_notify.publish_to_agent`), so a subscribed (containerized) agent receives it. Fail-loud: malformed body → 400; publish failure → 500. The board POSTs here **instead of** the unreachable `turn_url`.

### Deliverable 2 — C10: the event-driven rail
Registers a `scitex_todo.hooks` entry-point → `scitex_agent_container._listen._card_event_delivery:deliver_card_event`. It FILTERS for card-event kinds (`commented` / `created` / `reassigned` / `status_changed` / `completed` + C6 `committed` / `pushed` / `merged`), **ignoring unrecognized kinds incl. sac's own liveness-tick anomaly events** on the same bus, resolves `owner + collaborators + subscribers`, and delivers to each via the local `/v1/notify` endpoint. Degrades gracefully — a per-agent failure is logged and swallowed so the producer's bus dispatch survives. No import of `scitex_todo` (bus-only).

`server.py` hit the per-file line cap, so the `DELETE /agents/<name>` handler was extracted to `_agent_delete.py` (re-exported; no behaviour change) to make room for the `/v1/notify` route.

## For the scitex-todo board (how to call the interim endpoint)

- **Method + path:** `POST http://127.0.0.1:7878/v1/notify` (loopback, from the board's host context)
- **Auth:** `Authorization: Bearer <token>` — same host-wide bearer as the rest of `7878`. Token file: `~/.scitex/agent-container/tokens/listen-<hostname>.token` (print via `sac listen --print-token`); also accepted via `SAC_LISTEN_BEARER`.
- **Body:** `{"agent": "<owner-agent-name>", "body": "<text>", "card_id": "<card id, optional>", "from_agent": "<sender, optional, default scitex-todo>"}`
- **Response 200:** `{"agent","msg_id","delivered_subscriber_count"}`. `delivered_subscriber_count: 0` is **not** an error — the event is persisted first and replayed on the agent's next `inbox/stream` connect (durability), so a momentarily-disconnected container still gets it.

## Test plan (no mocks — STX-NM002)

- [x] `publish_to_agent` against a **real** `Broker` + **real** subscriber (subscribe → publish → assert receipt)
- [x] `/v1/notify` over a **real** bound listen app (`TestClient`): bearer-gating (401), body validation (400), durable persist
- [x] C10 filter on **real** dicts: card-event kind → delivers to owner/collaborators/subscribers; anomaly (liveness shape) + unknown kind → no-op
- [x] C10 graceful-degrade: **real** local HTTP server returns 500 for one target → the other still delivers; never raises
- [x] **End-to-end integration** (`tests/integration/test_listen_notify_delivery.py`): boots a **real** uvicorn on a real loopback port, subscribes a **real** SSE client to `/agents/<name>/inbox/stream` (exactly what a containerized agent does), POSTs `/v1/notify`, asserts the subscriber receives the body + `delivered_subscriber_count == 1`
- [x] Entry-point registration verified from a **clean wheel install** (`entry_points(group="scitex_todo.hooks")` → `ep.load()` resolves; anomaly/unknown filtered; card-event attempts delivery + degrades)
- [x] Existing `_listen` suite: 88 passed (1 unrelated cross-host ssh-shim test flaked on timeout under parallel load; passes in isolation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)