### PR TITLE
fix(image): add texlive-plain-generic + texlive-lang-english to scitex def (soul.sty drift; unblocks neurovista compile)

### DIFF
--- a/src/scitex_agent_container/containers/apptainer-scitex.def
+++ b/src/scitex_agent_container/containers/apptainer-scitex.def
@@ -177,10 +177,19 @@ From: ./sac-base.sif
     #     by tcolorbox / pgfplots / pgfplotstable / tikz. Listed EXPLICITLY:
     #     under --no-install-recommends it is not reliably pulled via
     #     latex-extra, and the manuscript footprint uses tikz/pgfplots.
+    #   texlive-plain-generic                   — ships soul.sty + soul-ori.sty,
+    #     REQUIRED by manuscripts using \usepackage{soul}. Without it the live
+    #     image fails `! LaTeX Error: File 'soul-ori.sty' not found` mid-compile
+    #     (neurovista drift). Listed EXPLICITLY: not pulled under
+    #     --no-install-recommends.
+    #   texlive-lang-english                    — English hyphenation patterns
+    #     (correct line breaking for English-language manuscripts).
     apt-get update
     apt-get install -y --no-install-recommends \
         texlive-latex-base texlive-latex-recommended texlive-latex-extra \
         texlive-pictures \
+        texlive-plain-generic \
+        texlive-lang-english \
         texlive-bibtex-extra biber \
         texlive-fonts-recommended texlive-fonts-extra \
         texlive-science texlive-publishers \


### PR DESCRIPTION
## Summary
- The `:scitex` section-3 "Manuscript LaTeX toolchain" `apt-get install --no-install-recommends` set was missing `soul.sty` / `soul-ori.sty`, so in-container `latexmk` fails `! LaTeX Error: File 'soul-ori.sty' not found` on manuscripts using `\usepackage{soul}` (neurovista compile).
- Adds two packages to the curated texlive set (no other changes):
  - `texlive-plain-generic` — ships `soul.sty` + `soul-ori.sty`
  - `texlive-lang-english` — English hyphenation patterns
- Inline comment added explaining each. All existing packages + structure and the fail-loud `pdflatex --version` / `latexmk --version` checks are untouched.

## Context
Stopgap to unblock the neurovista manuscript compile now. The full leaf-provider cutover (which deletes this hardcoded block in favor of `scitex-dev ecosystem system-deps install`) supersedes it later — but right now this block is the SSoT, so it carries these two.

## Test plan
- [ ] CI green (def-only change; no `.py`/test edits)
- [ ] On next SIF rebuild: in-container `kpsewhich soul.sty` resolves and `\usepackage{soul}` manuscript (neurovista) compiles via `latexmk`