### PR TITLE
feat(acl): mesh developer/researcher/generalist groups in all directions

### DIFF
--- a/src/scitex_agent_container/_listen/_acl.py
+++ b/src/scitex_agent_container/_listen/_acl.py
@@ -39,11 +39,13 @@ from typing import Literal
 from starlette.responses import JSONResponse
 from starlette.types import ASGIApp, Receive, Scope, Send
 
+from ..config._group_resolver import groups_mesh
 from .._state.state_db_nodes import (
     derive_group,
     has_grant,
     is_developer,
     read_comms_policy,
+    resolve_group_name,
     resolve_node_token,
     same_named_group,
     sender_target_relationship,
@@ -302,6 +304,21 @@ def check_send_acl(
     # grant. Additive: an ungrouped fleet shares no named group and
     # falls through to the explicit-grant check below, unchanged.
     if same_named_group(sender=sender, target=target, db_path=db_path):
+        return ("allow", None)
+
+    # Cross-group mesh (operator 2026-06-27): the three STANDARD fleet
+    # groups — developer / researcher / generalist — coordinate in all
+    # directions with NO per-pair grant. Evaluated AFTER the phase-3
+    # per-spec deny (so a solver's ``inbound.siblings=deny`` /
+    # ``lineage_group='solitary'`` isolation still wins) and AFTER the
+    # same-named-group mesh, but BEFORE the explicit-grant fallthrough.
+    # An agent in a non-mesh group (e.g. an isolated solver group) is
+    # NOT meshed and falls through to the grant check below, preserving
+    # the solid isolation scientific rigor requires.
+    if groups_mesh(
+        resolve_group_name(name=sender, db_path=db_path),
+        resolve_group_name(name=target, db_path=db_path),
+    ):
         return ("allow", None)
 
     if has_grant(sender=sender, target=target, db_path=db_path):

--- a/src/scitex_agent_container/config/_group_resolver.py
+++ b/src/scitex_agent_container/config/_group_resolver.py
@@ -39,8 +39,13 @@ from __future__ import annotations
 
 __all__ = [
     "DEVELOPER_GROUP",
+    "GENERALIST_GROUP",
+    "MESH_GROUPS",
+    "RESEARCHER_GROUP",
     "group_from_labels",
+    "groups_mesh",
     "is_developer_group",
+    "is_mesh_group",
     "resolve_group",
 ]
 
@@ -49,6 +54,28 @@ __all__ = [
 # ACL-CRUD authority (see :func:`._listen._acl.check_spawn` /
 # ``check_lineage_acl``).
 DEVELOPER_GROUP = "developer"
+
+# The other two standard fleet groups. They carry NO extra authority
+# (unlike ``developer``); they exist so a researcher / generalist agent
+# resolves to a stable named group for the cross-group mesh below.
+RESEARCHER_GROUP = "researcher"
+GENERALIST_GROUP = "generalist"
+
+
+# Cross-group mesh (operator 2026-06-27): the three STANDARD fleet groups
+# coordinate with each other in all directions — a ``developer`` may
+# address a ``researcher`` may address a ``generalist``, no per-pair grant
+# needed. This is "fleet-mesh by default" for the standard groups, the
+# layer above the same-named-group mesh.
+#
+# A group OUTSIDE this set does NOT mesh: e.g. a paper-scitex-clew solver
+# in an isolated group (and/or ``lineage_group='solitary'`` + per-spec
+# ``inbound.siblings=deny``) falls through to the explicit-grant ACL,
+# preserving the solid isolation scientific rigor requires. To mesh a new
+# group, add its name here (single-line edit, zero schema change).
+MESH_GROUPS: frozenset[str] = frozenset(
+    {DEVELOPER_GROUP, RESEARCHER_GROUP, GENERALIST_GROUP}
+)
 
 
 # Exact role strings (case-insensitive) that default to the developer
@@ -142,3 +169,28 @@ def is_developer_group(group: str | None) -> bool:
     if not group:
         return False
     return str(group).strip().lower() == DEVELOPER_GROUP
+
+
+def is_mesh_group(group: str | None) -> bool:
+    """Return True iff ``group`` is one of the standard mesh groups.
+
+    Case-insensitive on the resolved group name. ``None`` / empty →
+    False. Members of :data:`MESH_GROUPS` coordinate with members of any
+    other mesh group (see :func:`groups_mesh`); a group outside the set
+    does not mesh and stays isolated.
+    """
+    if not group:
+        return False
+    return str(group).strip().lower() in MESH_GROUPS
+
+
+def groups_mesh(group_a: str | None, group_b: str | None) -> bool:
+    """Return True iff ``group_a`` and ``group_b`` both mesh.
+
+    The cross-group allow predicate: a send is meshed when BOTH the
+    sender's and the target's resolved named groups are standard mesh
+    groups (:data:`MESH_GROUPS`). Either side being ungrouped, or in a
+    non-mesh group (e.g. an isolated solver group), returns False — the
+    send then falls through to the explicit-grant ACL.
+    """
+    return is_mesh_group(group_a) and is_mesh_group(group_b)

--- a/tests/scitex_agent_container/_listen/test__acl_group.py
+++ b/tests/scitex_agent_container/_listen/test__acl_group.py
@@ -147,6 +147,92 @@ def test_ungrouped_pair_still_denied_without_grant(db_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# check_send_acl — cross-group mesh among {developer, researcher, generalist}
+# (operator 2026-06-27)
+# ---------------------------------------------------------------------------
+
+
+def test_send_allowed_developer_to_researcher(db_path: Path) -> None:
+    """Cross-group mesh: developer → researcher, no grant → allow."""
+    # Arrange
+    record_comms_policy(name="dev-1", group_name="developer", db_path=db_path)
+    record_comms_policy(name="res-1", group_name="researcher", db_path=db_path)
+    # Act
+    decision, _reason = check_send_acl(
+        authenticated_node="dev-1",
+        claimed_from_agent="dev-1",
+        target="res-1",
+        db_path=db_path,
+    )
+    # Assert
+    assert decision == "allow"
+
+
+def test_send_allowed_researcher_to_generalist(db_path: Path) -> None:
+    """Cross-group mesh: researcher → generalist, no grant → allow."""
+    # Arrange
+    record_comms_policy(name="res-1", group_name="researcher", db_path=db_path)
+    record_comms_policy(name="gen-1", group_name="generalist", db_path=db_path)
+    # Act
+    decision, _reason = check_send_acl(
+        authenticated_node="res-1",
+        claimed_from_agent="res-1",
+        target="gen-1",
+        db_path=db_path,
+    )
+    # Assert
+    assert decision == "allow"
+
+
+def test_send_allowed_generalist_to_developer_all_directions(db_path: Path) -> None:
+    """Mesh is bidirectional: generalist → developer, no grant → allow."""
+    # Arrange
+    record_comms_policy(name="gen-1", group_name="generalist", db_path=db_path)
+    record_comms_policy(name="dev-1", group_name="developer", db_path=db_path)
+    # Act
+    decision, _reason = check_send_acl(
+        authenticated_node="gen-1",
+        claimed_from_agent="gen-1",
+        target="dev-1",
+        db_path=db_path,
+    )
+    # Assert
+    assert decision == "allow"
+
+
+def test_send_denied_mesh_group_to_isolated_solver(db_path: Path) -> None:
+    """A non-mesh group (solver) stays isolated: developer → solver → deny."""
+    # Arrange
+    record_comms_policy(name="dev-1", group_name="developer", db_path=db_path)
+    record_comms_policy(name="solver-1", group_name="solver", db_path=db_path)
+    # Act
+    decision, _reason = check_send_acl(
+        authenticated_node="dev-1",
+        claimed_from_agent="dev-1",
+        target="solver-1",
+        db_path=db_path,
+    )
+    # Assert
+    assert decision == "deny"
+
+
+def test_send_denied_isolated_solver_to_mesh_group(db_path: Path) -> None:
+    """Isolation holds in both directions: solver → researcher → deny."""
+    # Arrange
+    record_comms_policy(name="solver-1", group_name="solver", db_path=db_path)
+    record_comms_policy(name="res-1", group_name="researcher", db_path=db_path)
+    # Act
+    decision, _reason = check_send_acl(
+        authenticated_node="solver-1",
+        claimed_from_agent="solver-1",
+        target="res-1",
+        db_path=db_path,
+    )
+    # Assert
+    assert decision == "deny"
+
+
+# ---------------------------------------------------------------------------
 # check_spawn — developer-group full authority
 # ---------------------------------------------------------------------------
 

--- a/tests/scitex_agent_container/config/test__group_resolver.py
+++ b/tests/scitex_agent_container/config/test__group_resolver.py
@@ -17,8 +17,12 @@ from __future__ import annotations
 
 from scitex_agent_container.config._group_resolver import (
     DEVELOPER_GROUP,
+    GENERALIST_GROUP,
+    RESEARCHER_GROUP,
     group_from_labels,
+    groups_mesh,
     is_developer_group,
+    is_mesh_group,
     resolve_group,
 )
 
@@ -171,5 +175,61 @@ def test_is_developer_group_false_for_empty() -> None:
     group = ""
     # Act
     result = is_developer_group(group)
+    # Assert
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# cross-group mesh predicates (operator 2026-06-27)
+# ---------------------------------------------------------------------------
+
+
+def test_is_mesh_group_true_for_researcher() -> None:
+    # Arrange
+    group = RESEARCHER_GROUP
+    # Act
+    result = is_mesh_group(group)
+    # Assert
+    assert result is True
+
+
+def test_is_mesh_group_true_for_generalist() -> None:
+    # Arrange
+    group = GENERALIST_GROUP
+    # Act
+    result = is_mesh_group(group)
+    # Assert
+    assert result is True
+
+
+def test_is_mesh_group_false_for_solver() -> None:
+    # Arrange
+    group = "solver"
+    # Act
+    result = is_mesh_group(group)
+    # Assert
+    assert result is False
+
+
+def test_groups_mesh_true_across_standard_groups() -> None:
+    # Arrange
+    # Act
+    result = groups_mesh(DEVELOPER_GROUP, RESEARCHER_GROUP)
+    # Assert
+    assert result is True
+
+
+def test_groups_mesh_false_when_one_side_is_non_mesh() -> None:
+    # Arrange
+    # Act
+    result = groups_mesh(DEVELOPER_GROUP, "solver")
+    # Assert
+    assert result is False
+
+
+def test_groups_mesh_false_when_one_side_is_ungrouped() -> None:
+    # Arrange
+    # Act
+    result = groups_mesh(RESEARCHER_GROUP, "")
     # Assert
     assert result is False


### PR DESCRIPTION
## Summary
- The three standard fleet groups — **developer / researcher / generalist** — now coordinate cross-group with **no per-pair grant** (operator 2026-06-27, "mesh in all directions").
- A group **outside** the mesh set (e.g. isolated paper-scitex-clew **solvers**) is NOT meshed — it falls through to the explicit-grant ACL, preserving the solid isolation scientific rigor requires.
- `sac`-from-`sac` spawn already passes `check_spawn` (developer-group + root authority); this PR closes the a2a-coordination half.

## Change
- `config/_group_resolver.py`: `MESH_GROUPS = {developer, researcher, generalist}` + pure `is_mesh_group` / `groups_mesh` predicates (string-in/string-out, no DB).
- `_listen/_acl.py`: `check_send_acl` allows a cross-mesh send **after** the phase-3 per-spec deny (so a solver's `inbound.siblings=deny` / `lineage_group='solitary'` isolation still wins) and **before** the explicit-grant fallthrough. Reuses the already-exported `resolve_group_name` reader — no edit to the over-cap `state_db_nodes.py`.

## Test plan
- [x] `test__group_resolver.py` — 6 new: `is_mesh_group` (researcher/generalist true, solver false), `groups_mesh` (cross-standard true, non-mesh/ungrouped false).
- [x] `test__acl_group.py` — 5 new: developer→researcher, researcher→generalist, generalist→developer (all-directions allow); developer→solver, solver→researcher (isolation deny).
- [x] 37 passed (incl. all pre-existing group/ACL tests; existing `analysts` cross-group deny unaffected).