### PR TITLE
fix(acl): resolve named group from plural metadata.labels.groups list

### DIFF
--- a/src/scitex_agent_container/config/_group_resolver.py
+++ b/src/scitex_agent_container/config/_group_resolver.py
@@ -3,9 +3,16 @@
 A SECOND grouping axis layered on top of the existing lineage-derived
 group mesh (:func:`scitex_agent_container._state.state_db_nodes.derive_group`):
 
-  * Each agent has a NAMED group. Source of truth is the spec label
-    ``metadata.labels.group``.
-  * When the ``group`` label is ABSENT, the group is *derived from the
+  * Each agent has a NAMED group. Source of truth is the spec
+    ``metadata.labels``. The convention is the PLURAL list form
+    ``groups: [<name>]`` — every agent ``spec.yaml`` and the operator's
+    templates author the named group as a one-element list, e.g.
+    ``groups: [researcher]``; the FIRST non-empty element is the named
+    group. The SINGULAR string ``group: <name>`` is also accepted (and
+    WINS over the plural list when both are present), for hand-written
+    specs that prefer a scalar.
+  * When NEITHER ``group`` nor ``groups`` is present, the group is
+    *derived from the
     role* (``metadata.labels.role`` / ``CLAUDE_AGENT_ROLE``): the
     developer-ish roles — ``project-maintainer`` / ``maintainer`` /
     ``dev-agent`` / ``contributor`` (and their project-suffixed forms,
@@ -144,17 +151,58 @@ def resolve_group(*, group_label: str | None, role: str | None) -> str:
     return ""
 
 
-def group_from_labels(labels: dict[str, str] | None) -> str:
+def _first_named_group(labels: dict) -> str | None:
+    """Pull the operative named-group string out of a ``labels`` dict.
+
+    Honours the two authored forms, SINGULAR-string-wins:
+
+      1. ``labels["group"]`` (a string) — wins verbatim when present and
+         non-empty (whitespace-trimmed).
+      2. else the FIRST non-empty element of ``labels["groups"]`` (a
+         list) — the spec convention (``groups: [researcher]``).
+
+    Returns the chosen group string, or ``None`` when neither form
+    yields a non-empty value. Defensive: ``groups`` may be absent, a
+    non-list (e.g. a bare string or other scalar), or empty/all-blank —
+    any of those is treated as "absent" and falls through to ``None``.
+    """
+    singular = labels.get("group")
+    if singular is not None:
+        trimmed = str(singular).strip()
+        if trimmed:
+            return trimmed
+    plural = labels.get("groups")
+    if isinstance(plural, (list, tuple)):
+        for item in plural:
+            if item is None:
+                continue
+            trimmed = str(item).strip()
+            if trimmed:
+                return trimmed
+    return None
+
+
+def group_from_labels(labels: dict | None) -> str:
     """Resolve the named group from a spec's ``metadata.labels`` dict.
 
-    Convenience wrapper over :func:`resolve_group` that pulls the
-    ``group`` and ``role`` keys out of the labels mapping. A missing /
-    ``None`` labels dict yields ``""`` (ungrouped).
+    Convenience wrapper over :func:`resolve_group`. Precedence:
+
+      1. SINGULAR ``labels["group"]`` (string) wins when non-empty.
+      2. else the FIRST non-empty element of the PLURAL
+         ``labels["groups"]`` list — the spec convention
+         (``groups: [researcher]``).
+      3. else role-derivation via :func:`resolve_group` (a
+         developer-ish ``labels["role"]`` → :data:`DEVELOPER_GROUP`).
+      4. else ``""`` (ungrouped).
+
+    A missing / ``None`` labels dict yields ``""`` (ungrouped). The
+    plural ``groups`` key is read defensively (absent / non-list /
+    empty are all treated as "absent" — see :func:`_first_named_group`).
     """
     if not labels:
         return ""
     return resolve_group(
-        group_label=labels.get("group"),
+        group_label=_first_named_group(labels),
         role=labels.get("role"),
     )
 

--- a/tests/scitex_agent_container/config/test__group_resolver.py
+++ b/tests/scitex_agent_container/config/test__group_resolver.py
@@ -7,7 +7,9 @@ Pure string-in / string-out resolution — no DB, no fixtures. Covers:
   developer-ish roles (project-maintainer / maintainer / dev-agent /
   contributor, and project-suffixed forms) default to ``developer``.
 * Anything else → ``""`` (ungrouped).
-* :func:`group_from_labels` reads the ``group`` / ``role`` keys.
+* :func:`group_from_labels` reads the PLURAL ``groups`` list (spec
+  convention, first non-empty element wins), the SINGULAR ``group``
+  string (wins over the list), or falls back to the ``role`` key.
 * :func:`is_developer_group` recognises the privileged group.
 
 AAA, one assertion per test, no mocks.
@@ -150,6 +152,87 @@ def test_group_from_labels_none_is_ungrouped() -> None:
     group = group_from_labels(labels)
     # Assert
     assert group == ""
+
+
+def test_group_from_labels_reads_plural_groups_researcher() -> None:
+    # Arrange
+    labels = {"groups": ["researcher"]}
+    # Act
+    group = group_from_labels(labels)
+    # Assert
+    assert group == "researcher"
+
+
+def test_group_from_labels_reads_plural_groups_generalist() -> None:
+    # Arrange
+    labels = {"groups": ["generalist"]}
+    # Act
+    group = group_from_labels(labels)
+    # Assert
+    assert group == "generalist"
+
+
+def test_group_from_labels_singular_group_still_works() -> None:
+    # Arrange
+    labels = {"group": "developer"}
+    # Act
+    group = group_from_labels(labels)
+    # Assert
+    assert group == "developer"
+
+
+def test_group_from_labels_singular_wins_over_plural() -> None:
+    # Arrange
+    labels = {"group": "developer", "groups": ["researcher"]}
+    # Act
+    group = group_from_labels(labels)
+    # Assert
+    assert group == "developer"
+
+
+def test_group_from_labels_empty_plural_falls_back_to_role() -> None:
+    # Arrange
+    labels = {"groups": [], "role": "dev-agent"}
+    # Act
+    group = group_from_labels(labels)
+    # Assert
+    assert group == DEVELOPER_GROUP
+
+
+def test_group_from_labels_empty_plural_no_role_is_ungrouped() -> None:
+    # Arrange
+    labels = {"groups": []}
+    # Act
+    group = group_from_labels(labels)
+    # Assert
+    assert group == ""
+
+
+def test_group_from_labels_plural_beats_role() -> None:
+    # Arrange
+    labels = {"groups": ["scientist"], "role": "project-maintainer"}
+    # Act
+    group = group_from_labels(labels)
+    # Assert
+    assert group == "scientist"
+
+
+def test_group_from_labels_first_nonempty_plural_element_wins() -> None:
+    # Arrange
+    labels = {"groups": ["  ", "researcher", "generalist"]}
+    # Act
+    group = group_from_labels(labels)
+    # Assert
+    assert group == "researcher"
+
+
+def test_group_from_labels_non_list_plural_falls_back_to_role() -> None:
+    # Arrange
+    labels = {"groups": "researcher", "role": "dev-agent"}
+    # Act
+    group = group_from_labels(labels)
+    # Assert
+    assert group == DEVELOPER_GROUP
 
 
 def test_is_developer_group_true_for_developer() -> None:


### PR DESCRIPTION
## Summary
- `config/_group_resolver.py:group_from_labels` read only the SINGULAR `group` key, but every agent `spec.yaml` and the operator's templates author the named group as a PLURAL list under `metadata.labels` (`groups: [researcher]`). Nothing in the codebase read `groups` (plural), so those labels were silently ignored — researcher/generalist agents fell back to role-derivation (`project-maintainer` -> `developer`) and never joined their named group, defeating the just-merged cross-group ACL mesh.
- The fix honors both forms via a `_first_named_group` helper, with precedence:
  1. singular `labels["group"]` (string) wins when present and non-empty (trimmed);
  2. else the FIRST non-empty element of `labels["groups"]` (list) — the spec convention;
  3. else role-derivation (existing `_role_is_developer` -> `developer`);
  4. else `""` (ungrouped).
- `groups` is read defensively: absent, non-list (bare string/scalar), or empty/all-blank are all treated as "absent" and fall through. `resolve_group(*, group_label, role)` signature is unchanged — the plural handling lives in `group_from_labels` before it calls `resolve_group`. Module docstring updated to document `groups: [<name>]` (plural list) as the convention with `group:` (singular string) also accepted.

## Labels parser/loader
No parser change was required. Verified the label reaches the resolver end-to-end: `config/_loaders.py:224` does `labels = metadata.get("labels", {}) or {}` and passes it through verbatim at line ~365 (`labels=labels`) into `AgentConfig.labels`. The raw dict (including the `groups` list value) is preserved — no parser under `config/_parsers/` touches/normalizes it. `_lifecycle/_spawn_gate.py:70` then calls `group_from_labels(config.labels)` at agent_start, so the fix bites the live ACL.

## Test plan
- [x] `group_from_labels({"groups": ["researcher"]})` == "researcher"
- [x] `group_from_labels({"groups": ["generalist"]})` == "generalist"
- [x] `group_from_labels({"group": "developer"})` == "developer" (singular still works)
- [x] singular wins over plural when both present
- [x] `{"groups": [], "role": "dev-agent"}` -> "developer"; `{"groups": []}` -> ""
- [x] `{"groups": ["scientist"], "role": "project-maintainer"}` == "scientist" (plural beats role)
- [x] first non-empty plural element wins; non-list `groups` falls back to role
- [x] `PYTHONPATH=src /opt/venv-sac/bin/python -m pytest tests/.../config/test__group_resolver.py tests/.../_listen/test__acl_group.py -q` -> 46 passed