### PR TITLE
feat(runtimes): bind + inject SCITEX_TESTMON_CACHE_ROOT for persistent testmon cache

### DIFF
--- a/src/scitex_agent_container/runtimes/_apptainer_listen_env.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_listen_env.py
@@ -64,6 +64,23 @@ def listen_env_flags(config) -> list[str]:
 
     flags: list[str] = ["--env", f"SAC_LISTEN_BASE_URL={listen_base_url()}"]
 
+    # PERSISTENT TESTMON CACHE — point testmon's data file at the
+    # container-side bind destination (see
+    # ``_p3a_default_binds._FLEET_DEFAULT_BINDS``: the host's
+    # ``~/.cache/scitex-testmon`` is bound ``rw`` to
+    # ``/home/agent/.cache/scitex-testmon``). scitex-dev's pre-commit-hook
+    # wrapper reads ``$SCITEX_TESTMON_CACHE_ROOT`` so the testmon cache
+    # PERSISTS across the fresh-git-worktree churn the develop-pin hook
+    # forces — otherwise every commit re-runs the full ~2500-test suite
+    # against a cold worktree-local ``.testmondata``. UNCONDITIONAL (same
+    # as the base URL above): the cache helps every agent regardless of
+    # bus membership, and a missing host bind dir is already a silent
+    # no-op via ``default_binds_for_host``'s skip-if-missing filter.
+    flags += [
+        "--env",
+        "SCITEX_TESTMON_CACHE_ROOT=/home/agent/.cache/scitex-testmon",
+    ]
+
     # Forward the host's agent-spec search path so the in-container sac
     # resolves peer specs at the operator's path. Only inject when the
     # host has it set+non-empty — otherwise leave the in-container default

--- a/src/scitex_agent_container/runtimes/_p3a_default_binds.py
+++ b/src/scitex_agent_container/runtimes/_p3a_default_binds.py
@@ -118,6 +118,23 @@ _FLEET_DEFAULT_BINDS: tuple[str, ...] = (
     # where the source dir does not exist (remote hosts, fresh boot before
     # emacs writes) — no FATAL, no surprise mount.
     "/tmp/emacs-claude-code:/tmp/emacs-claude-code:ro",
+    # PERSISTENT TESTMON CACHE — survive the fresh-git-worktree churn the
+    # develop-pin hook forces. Every commit lands in a NEW worktree, so a
+    # worktree-local ``.testmondata`` is always cold and pytest re-runs the
+    # full ~2500-test suite (~2h). A peer package (scitex-dev) is building a
+    # pre-commit-hook wrapper that points testmon's data file at
+    # ``$SCITEX_TESTMON_CACHE_ROOT`` (sac injects that env var to the
+    # container-side path ``/home/agent/.cache/scitex-testmon`` — see
+    # ``_apptainer_listen_env.listen_env_flags``). Binding the host's
+    # ``~/.cache/scitex-testmon`` to that container path ``rw`` lets the
+    # cache PERSIST across worktree churn so only impacted tests re-run.
+    # ``rw`` because testmon must WRITE the updated cache after each run.
+    # The ``default_binds_for_host`` skip-if-missing filter means a missing
+    # host dir is a silent no-op (NO bind, NO crash) — so sac must NOT
+    # mkdir it; the operator/infra creates ``~/.cache/scitex-testmon`` on
+    # the host separately (non-container local dev falls back to the same
+    # ``~/.cache/scitex-testmon`` path the wrapper reads directly).
+    "~/.cache/scitex-testmon:/home/agent/.cache/scitex-testmon:rw",
 )
 
 

--- a/tests/scitex_agent_container/runtimes/test__apptainer_listen_env.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_listen_env.py
@@ -1,0 +1,92 @@
+"""Tests for ``runtimes._apptainer_listen_env.listen_env_flags``.
+
+``listen_env_flags`` builds the ``--env`` flags ``build_run_argv`` appends
+to the ``apptainer exec`` argv. It UNCONDITIONALLY injects the bus-listen
+base URL plus — as of the persistent-testmon-cache change — the
+``SCITEX_TESTMON_CACHE_ROOT`` env var pointing at the container-side bind
+destination ``/home/agent/.cache/scitex-testmon``. scitex-dev's pre-commit
+hook reads that var so testmon's cache survives the fresh-git-worktree
+churn the develop-pin hook forces.
+
+No mocks — a tiny in-test config stand-in (``types.SimpleNamespace``) plus
+a sandboxed ``$HOME`` so the bearer-token lookup resolves to an absent
+file (the no-bus / warn-only branch), which keeps the test free of any
+host bus token. STX-TQ002 AAA + STX-TQ007 one-assert.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Iterator
+
+import pytest
+
+from scitex_agent_container.runtimes._apptainer_listen_env import (
+    listen_env_flags,
+)
+
+
+@pytest.fixture
+def no_bus_config() -> SimpleNamespace:
+    """A config whose ``claude.channels`` is empty (no ``server:sac``).
+
+    With no bus channel requested, an absent bearer token is harmless —
+    ``listen_env_flags`` warns and returns the base-URL + testmon-cache
+    flags instead of raising, so the test never needs a real token file.
+    """
+    return SimpleNamespace(claude=SimpleNamespace(channels=[]))
+
+
+@pytest.fixture
+def sandboxed_home(tmp_path: Path) -> Iterator[Path]:
+    """Yield a tmp_path-rooted ``$HOME`` so the bearer-token path is absent."""
+    prev = os.environ.get("HOME")
+    os.environ["HOME"] = str(tmp_path)
+    try:
+        yield tmp_path
+    finally:
+        if prev is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = prev
+
+
+def test_listen_env_flags_injects_testmon_cache_root_var(
+    no_bus_config: SimpleNamespace,
+    sandboxed_home: Path,
+) -> None:
+    # Arrange — fixtures supply an empty-channel config + sandboxed $HOME.
+    # Act
+    flags = listen_env_flags(no_bus_config)
+    # Assert — the container-side testmon cache path is injected as an env var.
+    assert (
+        "SCITEX_TESTMON_CACHE_ROOT=/home/agent/.cache/scitex-testmon" in flags
+    )
+
+
+def test_listen_env_flags_testmon_var_follows_an_env_token(
+    no_bus_config: SimpleNamespace,
+    sandboxed_home: Path,
+) -> None:
+    # Arrange — apptainer consumes ``--env KEY=VALUE`` as two argv tokens;
+    # the testmon var must be preceded by a literal ``--env`` flag.
+    flags = listen_env_flags(no_bus_config)
+    # Act
+    idx = flags.index(
+        "SCITEX_TESTMON_CACHE_ROOT=/home/agent/.cache/scitex-testmon"
+    )
+    # Assert
+    assert flags[idx - 1] == "--env"
+
+
+def test_listen_env_flags_still_injects_base_url(
+    no_bus_config: SimpleNamespace,
+    sandboxed_home: Path,
+) -> None:
+    # Arrange — fixtures supply an empty-channel config + sandboxed $HOME.
+    # Act
+    flags = listen_env_flags(no_bus_config)
+    # Assert — the pre-existing base-URL injection is unregressed.
+    assert any(f.startswith("SAC_LISTEN_BASE_URL=") for f in flags)

--- a/tests/scitex_agent_container/runtimes/test__p3a_default_binds.py
+++ b/tests/scitex_agent_container/runtimes/test__p3a_default_binds.py
@@ -342,3 +342,26 @@ def test_fleet_defaults_include_emacs_handoff_bind_read_only() -> None:
     handoff = [b for b in _FLEET_DEFAULT_BINDS if "emacs-claude-code" in b]
     # Assert — bound at the same host path, read-only.
     assert handoff == ["/tmp/emacs-claude-code:/tmp/emacs-claude-code:ro"]
+
+
+# ---------------------------------------------------------------------------
+# Persistent testmon cache bind — host ~/.cache/scitex-testmon bound rw to the
+# container-side /home/agent/.cache/scitex-testmon so testmon's data file
+# survives the fresh-git-worktree churn the develop-pin hook forces (scitex-dev
+# pre-commit-hook wrapper reads $SCITEX_TESTMON_CACHE_ROOT). Skip-if-missing
+# (no sac-side mkdir) is covered by the host-existence-gate tests above.
+# ---------------------------------------------------------------------------
+
+
+def test_fleet_defaults_include_testmon_cache_bind_rw() -> None:
+    # Arrange — read the static fleet-default tuple directly.
+    from scitex_agent_container.runtimes._p3a_default_binds import (
+        _FLEET_DEFAULT_BINDS,
+    )
+
+    # Act
+    testmon = [b for b in _FLEET_DEFAULT_BINDS if "scitex-testmon" in b]
+    # Assert — bound rw to the container-side cache path under /home/agent.
+    assert testmon == [
+        "~/.cache/scitex-testmon:/home/agent/.cache/scitex-testmon:rw"
+    ]


### PR DESCRIPTION
## Summary
Enable a persistent, per-repo testmon cache that survives the fresh-git-worktree churn the develop-pin hook forces (today every commit gets a cold `.testmondata` -> full ~2500-test re-run, ~2h). Peer package `scitex-dev` builds a pre-commit-hook wrapper that reads `$SCITEX_TESTMON_CACHE_ROOT` (falling back to `~/.cache/scitex-testmon` for non-container local dev). The sac (container) side does two things:

- **Fleet-default bind** (`runtimes/_p3a_default_binds.py`): add `~/.cache/scitex-testmon:/home/agent/.cache/scitex-testmon:rw` to `_FLEET_DEFAULT_BINDS`. `rw` so testmon can write the updated cache. The `default_binds_for_host` skip-if-missing filter keeps a missing host dir a silent no-op — sac does NOT mkdir it (operator/infra owns the host dir).
- **Env injection** (`runtimes/_apptainer_listen_env.py` -> `listen_env_flags`): inject `SCITEX_TESTMON_CACHE_ROOT=/home/agent/.cache/scitex-testmon` (the container-side bind destination) via the SAME `--env` builder that injects `SAC_LISTEN_BASE_URL`/`SAC_LISTEN_BEARER`. Unconditional, like the base URL.

## Tests (no mocks)
- `test__p3a_default_binds.py`: assert the testmon bind string is present in `_FLEET_DEFAULT_BINDS` (rw, container-side `/home/agent` path).
- `test__apptainer_listen_env.py` (new): assert `listen_env_flags` injects `SCITEX_TESTMON_CACHE_ROOT=/home/agent/.cache/scitex-testmon` preceded by a literal `--env` token, base-URL injection unregressed. Uses a sandboxed `$HOME` (no-bus / warn-only branch, no real token file).

Run:
`PYTHONPATH=src /opt/venv-sac/bin/python -m pytest tests/scitex_agent_container/runtimes/test__p3a_default_binds.py tests/scitex_agent_container/runtimes/test__apptainer_listen_env.py -q`

## Note — pre-existing, unrelated test brittleness
`test_apply_default_binds_returns_spec_only_when_host_dir_missing` (pre-existing, not touched by this PR) does a strict-equality assert that assumes NO fleet-default host source exists. It fails on any host where `/tmp/emacs-claude-code` (the emacs-handoff bind source, predates this PR) exists, because that absolute `/tmp` source is not sandboxable by the test's `fake_home` fixture. Green in CI (no such dir there). Left untouched to keep scope to the testmon feature — flagging for a follow-up.

## Test plan
- [ ] CI green on develop
- [ ] Operator verifies container-side path `/home/agent/.cache/scitex-testmon` matches the scitex-dev wrapper before announcing to the peer package