### PR TITLE
feat(cli): sac agents new instantiates _template_* dir-templates with SAC_PLACEHOLDER fills

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_new.py
+++ b/src/scitex_agent_container/cli_pkg/_new.py
@@ -32,6 +32,13 @@ from pathlib import Path
 
 import click
 
+from ._new_dir_template import (
+    DirTemplateError,
+    discover_dir_templates,
+    instantiate_dir_template,
+    parse_set_pairs,
+)
+
 # Agent names follow the dir-as-SSoT convention: lowercase letters,
 # digits, dashes, underscores. Slashes / dots would write outside the
 # base dir or shadow YAML extension suffixes. Mirrors the constraints
@@ -165,12 +172,21 @@ _TEMPLATES = {
 
 
 def _default_base_dir() -> Path:
-    """Return ``~/.scitex/agent-container/agents`` (sac's primary root).
+    """Return sac's primary agents root (the resolver's ``primary`` base).
 
-    Resolved lazily so the CLI can be imported without touching the
-    filesystem (matters for cold-start budget + tab-completion).
+    Reuses :func:`scitex_agent_container.config._resolve._search_dirs`
+    so there is a single source of truth for "where agents live" — the
+    dir-template discovery scans this same root. Resolved lazily so the
+    CLI can be imported without touching the filesystem (matters for
+    cold-start budget + tab-completion).
     """
-    return Path.home() / ".scitex" / "agent-container" / "agents"
+    try:
+        from ..config._resolve import _search_dirs
+
+        primary, _env, _fleet = _search_dirs()
+        return primary
+    except Exception:  # stx-allow: fallback (reason: resolver import is best-effort; hardcoded default keeps `sac agents new` working if config pkg shifts)
+        return Path.home() / ".scitex" / "agent-container" / "agents"
 
 
 @click.command(name="new")
@@ -178,13 +194,47 @@ def _default_base_dir() -> Path:
 @click.option(
     "--template",
     "template_name",
-    type=click.Choice(sorted(_TEMPLATES), case_sensitive=False),
+    type=str,
     default="minimal",
     show_default=True,
     help=(
-        "Template preset to scaffold. 'minimal' = bare-minimum spec "
-        "(image + model). 'full' = annotated v3 spec with every "
-        "common block pre-filled."
+        "Template to scaffold. Inline presets: 'minimal' = bare-minimum "
+        "spec (image + model); 'full' = annotated v3 spec. Plus any "
+        "DIR-template discovered under the agents root as "
+        "``_template_<kind>/`` (the choice is the <kind> suffix, e.g. "
+        "'python_developer'). Discovery is dynamic — drop a new "
+        "``_template_foo/`` dir in and 'foo' just works."
+    ),
+)
+@click.option(
+    "--project",
+    "project",
+    type=str,
+    default=None,
+    help=(
+        "Fill the ``SAC_PLACEHOLDER_PROJECT`` token in dir-templates. "
+        "Required if the chosen dir-template carries that token."
+    ),
+)
+@click.option(
+    "--agent-id",
+    "agent_id",
+    type=str,
+    default=None,
+    help=(
+        "Fill the ``SAC_PLACEHOLDER_AGENT_ID`` token in dir-templates. "
+        "Defaults to <name> when omitted."
+    ),
+)
+@click.option(
+    "--set",
+    "set_pairs",
+    type=str,
+    multiple=True,
+    metavar="KEY=VALUE",
+    help=(
+        "Fill an arbitrary ``SAC_PLACEHOLDER_<KEY>`` token by exact name "
+        "(KEY is upper-cased). Repeatable, e.g. --set EXTRA=val."
     ),
 )
 @click.option(
@@ -193,9 +243,9 @@ def _default_base_dir() -> Path:
     type=click.Path(file_okay=False, path_type=Path),
     default=None,
     help=(
-        "Parent directory under which ``<name>/spec.yaml`` is written. "
-        "Default: ~/.scitex/agent-container/agents/ (sac's primary "
-        "agents root, matches the resolver search-chain entry #1)."
+        "Parent directory under which ``<name>/spec.yaml`` is written "
+        "AND scanned for ``_template_*`` dir-templates. Default: sac's "
+        "primary agents root (resolver search-chain entry #1)."
     ),
 )
 @click.option(
@@ -207,19 +257,32 @@ def _default_base_dir() -> Path:
         "re-runs cannot clobber a customised spec."
     ),
 )
-def new(name: str, template_name: str, base_dir: Path | None, force: bool) -> None:
+def new(
+    name: str,
+    template_name: str,
+    project: str | None,
+    agent_id: str | None,
+    set_pairs: tuple[str, ...],
+    base_dir: Path | None,
+    force: bool,
+) -> None:
     """Scaffold a fresh v3 ``spec.yaml`` for a new agent.
 
-    Writes ``<base-dir>/<name>/spec.yaml`` (plus an empty ``to_home/``
-    sibling) from the chosen template. The template is guaranteed to
-    pass ``validate_config`` without operator edits.
+    Writes ``<base-dir>/<name>/spec.yaml`` (plus a ``to_home/`` sibling)
+    from the chosen template. Inline templates (``minimal``/``full``)
+    render a string; DIR-templates (``_template_<kind>/`` under the
+    agents root) are copied wholesale and have their
+    ``SAC_PLACEHOLDER_*`` tokens filled from ``--project``/``--agent-id``/
+    ``--set``. Any surviving placeholder fails the command loud and
+    removes the partial output.
 
     Examples:
 
     \b
         sac agents new my-agent
         sac agents new my-agent --template full
-        sac agents new my-agent --base-dir ./agents --force
+        sac agents new dev1 --template python_developer --project myproj
+        sac agents new r1 --template researcher --project p --set TEAM=x
     """
     if not _is_valid_agent_name(name):
         raise click.UsageError(
@@ -231,13 +294,51 @@ def new(name: str, template_name: str, base_dir: Path | None, force: bool) -> No
     agent_dir = base / name
     spec_path = agent_dir / "spec.yaml"
 
+    kind = template_name.lower()
+    dir_templates = discover_dir_templates(base)
+
+    # Dispatch: dir-template kind wins over inline names ONLY if it does
+    # not collide with the reserved inline names; a same-named inline
+    # preset always refers to the string template (operator can't shadow
+    # 'minimal'/'full' with a dir).
+    is_inline = kind in _TEMPLATES
+    is_dir = kind in dir_templates and not is_inline
+
+    if not is_inline and not is_dir:
+        choices = sorted(set(_TEMPLATES) | set(dir_templates))
+        raise click.UsageError(
+            f"Unknown template {template_name!r}. Available: "
+            f"{', '.join(choices)} "
+            f"(scanned {base} for _template_* dirs)."
+        )
+
+    if is_dir:
+        try:
+            extra = parse_set_pairs(set_pairs)
+            instantiate_dir_template(
+                dir_templates[kind],
+                agent_dir,
+                project=project,
+                agent_id=agent_id if agent_id is not None else name,
+                extra=extra,
+                force=force,
+            )
+        except DirTemplateError as exc:
+            raise click.ClickException(str(exc)) from exc
+        print(
+            f"Wrote {agent_dir} (template={kind}, dir-template).",
+            file=sys.stderr,
+            flush=True,
+        )
+        return
+
     if spec_path.exists() and not force:
         raise click.ClickException(
             f"Refusing to overwrite existing spec at {spec_path}. "
             "Re-run with --force to replace, or pick a different name."
         )
 
-    template = _TEMPLATES[template_name.lower()]
+    template = _TEMPLATES[kind]
     body = template.format(name=name)
 
     agent_dir.mkdir(parents=True, exist_ok=True)
@@ -250,7 +351,7 @@ def new(name: str, template_name: str, base_dir: Path | None, force: bool) -> No
     to_home.mkdir(parents=True, exist_ok=True)
 
     print(
-        f"Wrote {spec_path} (template={template_name}).",
+        f"Wrote {spec_path} (template={kind}).",
         file=sys.stderr,
         flush=True,
     )

--- a/src/scitex_agent_container/cli_pkg/_new_dir_template.py
+++ b/src/scitex_agent_container/cli_pkg/_new_dir_template.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Directory-template support for ``sac agents new``.
+
+Beyond the two inline string templates (``minimal`` / ``full``), the
+operator ships *directory* templates that live in the agents root,
+named ``_template_<kind>/`` (e.g. ``_template_python_developer/``,
+``_template_researcher/``, ``_template_generalist/``). Each is a real
+directory carrying ``spec.yaml`` + ``to_home/`` and whatever else the
+kind needs, with literal placeholder tokens of the form
+``SAC_PLACEHOLDER_<NAME>`` baked into the files (workdir paths, install
+targets, labels, STATE_DB names, …).
+
+``sac agents new <name> --template <kind>`` instantiates such a template
+by *copying the whole tree* to ``<base-dir>/<name>/`` and substituting
+the placeholder tokens. The substitution is fail-loud: if ANY
+``SAC_PLACEHOLDER_*`` token survives, the partial output directory is
+removed and a non-zero error is raised naming every unfilled token, the
+file(s)/line(s) it appears in, and the flag that would fill it.
+
+Discovery is dynamic: dropping a new ``_template_foo/`` dir into the
+agents root surfaces ``foo`` as a ``--template`` choice with NO code
+change here.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List
+
+# Literal token shape baked into the dir-templates. The trailing name is
+# captured so we can report exactly which placeholders are unfilled and
+# hint at the matching CLI flag.
+_PLACEHOLDER_PREFIX = "SAC_PLACEHOLDER_"
+_PLACEHOLDER_RE = re.compile(r"SAC_PLACEHOLDER_[A-Z0-9_]+")
+
+# Dir-template directories carry this prefix; the suffix becomes the
+# ``--template`` choice (``_template_python_developer`` → ``python_developer``).
+_DIR_TEMPLATE_PREFIX = "_template_"
+
+
+class DirTemplateError(Exception):
+    """Raised when a dir-template cannot be instantiated cleanly.
+
+    Carries a human-readable message already formatted for stderr; the
+    CLI converts it into a ``click.ClickException`` so the exit code is
+    non-zero.
+    """
+
+
+def discover_dir_templates(agents_root: Path) -> Dict[str, Path]:
+    """Return ``{kind: dir}`` for every ``_template_*`` subdir of ``agents_root``.
+
+    The map key is the suffix after ``_template_`` (the ``--template``
+    choice); the value is the absolute directory path. Discovery is
+    dynamic — a directory dropped in afterwards is found with no code
+    change. Missing / non-dir roots yield an empty map (callers fall
+    back to the inline templates only).
+    """
+    out: Dict[str, Path] = {}
+    if not agents_root.is_dir():
+        return out
+    for sub in sorted(agents_root.iterdir()):
+        if not sub.is_dir():
+            continue
+        if not sub.name.startswith(_DIR_TEMPLATE_PREFIX):
+            continue
+        kind = sub.name[len(_DIR_TEMPLATE_PREFIX) :]
+        if not kind:
+            continue
+        out[kind] = sub
+    return out
+
+
+def _flag_hint(token: str) -> str:
+    """Return the CLI flag that fills ``token`` (an exact ``SAC_PLACEHOLDER_*``).
+
+    ``SAC_PLACEHOLDER_PROJECT`` → ``--project``;
+    ``SAC_PLACEHOLDER_AGENT_ID`` → ``--agent-id``;
+    anything else → ``--set <SUFFIX>=...``.
+    """
+    suffix = token[len(_PLACEHOLDER_PREFIX) :]
+    if suffix == "PROJECT":
+        return "--project <value>"
+    if suffix == "AGENT_ID":
+        return "--agent-id <value>"
+    return f"--set {suffix}=<value>"
+
+
+def _build_substitutions(
+    project: str | None,
+    agent_id: str,
+    extra: Dict[str, str],
+) -> Dict[str, str]:
+    """Map full placeholder tokens → fill values.
+
+    ``--project``/``--agent-id`` are sugar for the two well-known tokens;
+    ``--set KEY=VALUE`` fills ``SAC_PLACEHOLDER_<KEY>`` by exact name.
+    ``project`` may be ``None`` (operator omitted ``--project``); the
+    token is simply not in the map, so the post-scan reports it as
+    unfilled with a clear hint.
+    """
+    subs: Dict[str, str] = {}
+    if project is not None:
+        subs[_PLACEHOLDER_PREFIX + "PROJECT"] = project
+    subs[_PLACEHOLDER_PREFIX + "AGENT_ID"] = agent_id
+    for key, value in extra.items():
+        subs[_PLACEHOLDER_PREFIX + key] = value
+    return subs
+
+
+def parse_set_pairs(pairs: tuple[str, ...]) -> Dict[str, str]:
+    """Parse repeatable ``--set KEY=VALUE`` into ``{KEY: VALUE}``.
+
+    KEY is upper-cased so ``--set extra=v`` fills ``SAC_PLACEHOLDER_EXTRA``
+    (the tokens are upper-case by convention). A pair without ``=`` is a
+    usage error.
+    """
+    out: Dict[str, str] = {}
+    for pair in pairs:
+        if "=" not in pair:
+            raise DirTemplateError(
+                f"--set expects KEY=VALUE, got {pair!r} (no '=')."
+            )
+        key, value = pair.split("=", 1)
+        key = key.strip().upper()
+        if not key:
+            raise DirTemplateError(f"--set expects a non-empty KEY, got {pair!r}.")
+        out[key] = value
+    return out
+
+
+@dataclass
+class _Remaining:
+    token: str
+    rel_path: str
+    lineno: int
+
+
+def _scan_remaining(agent_dir: Path) -> List[_Remaining]:
+    """Return every surviving ``SAC_PLACEHOLDER_*`` occurrence under ``agent_dir``.
+
+    Walks all regular files; binary / undecodable files are skipped (the
+    templates are text). Reports file-relative path + 1-based line number
+    so the error can point the operator at the exact spot.
+    """
+    out: List[_Remaining] = []
+    for path in sorted(agent_dir.rglob("*")):
+        if not path.is_file():
+            continue
+        try:
+            text = path.read_text()
+        except (UnicodeDecodeError, OSError):
+            continue
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            for match in _PLACEHOLDER_RE.findall(line):
+                out.append(
+                    _Remaining(
+                        token=match,
+                        rel_path=str(path.relative_to(agent_dir)),
+                        lineno=lineno,
+                    )
+                )
+    return out
+
+
+def _format_remaining_error(remaining: List[_Remaining]) -> str:
+    """Build the fail-loud message naming each unfilled token + a fill hint."""
+    by_token: Dict[str, List[_Remaining]] = {}
+    for item in remaining:
+        by_token.setdefault(item.token, []).append(item)
+
+    lines = [
+        "Unfilled placeholder token(s) remain after substitution — "
+        "refusing to leave a half-written agent.",
+    ]
+    for token in sorted(by_token):
+        locations = ", ".join(
+            f"{r.rel_path}:{r.lineno}" for r in by_token[token]
+        )
+        lines.append(f"  {token}")
+        lines.append(f"    at: {locations}")
+        lines.append(f"    fill with: {_flag_hint(token)}")
+    return "\n".join(lines)
+
+
+def _apply_substitutions(agent_dir: Path, subs: Dict[str, str]) -> None:
+    """Substitute every known token across all text files under ``agent_dir``."""
+    for path in sorted(agent_dir.rglob("*")):
+        if not path.is_file():
+            continue
+        try:
+            text = path.read_text()
+        except (UnicodeDecodeError, OSError):
+            continue
+        new_text = text
+        for token, value in subs.items():
+            new_text = new_text.replace(token, value)
+        if new_text != text:
+            path.write_text(new_text)
+
+
+def instantiate_dir_template(
+    template_dir: Path,
+    agent_dir: Path,
+    *,
+    project: str | None,
+    agent_id: str,
+    extra: Dict[str, str],
+    force: bool,
+) -> None:
+    """Copy ``template_dir`` → ``agent_dir`` and fill placeholder tokens.
+
+    Fail-loud contract: on ANY surviving ``SAC_PLACEHOLDER_*`` token the
+    freshly-created ``agent_dir`` is removed (so no half-written agent is
+    left behind) and :class:`DirTemplateError` is raised with a message
+    naming each unfilled token, its location(s), and the fill flag.
+
+    ``force`` controls whether an existing ``agent_dir`` is replaced.
+    """
+    spec_path = agent_dir / "spec.yaml"
+    if spec_path.exists() and not force:
+        raise DirTemplateError(
+            f"Refusing to overwrite existing spec at {spec_path}. "
+            "Re-run with --force to replace, or pick a different name."
+        )
+
+    # Track whether we created the dir so cleanup only removes our own
+    # output (never a pre-existing dir the operator passed via --force).
+    pre_existing = agent_dir.exists()
+    if pre_existing and force:
+        shutil.rmtree(agent_dir)
+
+    shutil.copytree(template_dir, agent_dir)
+
+    subs = _build_substitutions(project, agent_id, extra)
+    _apply_substitutions(agent_dir, subs)
+
+    remaining = _scan_remaining(agent_dir)
+    if remaining:
+        # Remove the partial output so a failed run leaves nothing behind.
+        shutil.rmtree(agent_dir, ignore_errors=True)
+        raise DirTemplateError(_format_remaining_error(remaining))
+
+
+__all__ = [
+    "DirTemplateError",
+    "discover_dir_templates",
+    "instantiate_dir_template",
+    "parse_set_pairs",
+]

--- a/tests/scitex_agent_container/cli_pkg/test__new.py
+++ b/tests/scitex_agent_container/cli_pkg/test__new.py
@@ -147,3 +147,248 @@ def test_new_rejects_invalid_agent_name(tmp_path: Path) -> None:
     result = runner.invoke(new_cmd, ["bad/name", "--base-dir", str(base)])
     # Assert
     assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# Dir-template instantiation (`_template_<kind>/` + SAC_PLACEHOLDER fills).
+# ---------------------------------------------------------------------------
+
+# A valid-once-filled minimal spec carrying placeholder tokens. After
+# --project / --agent-id substitution the result must pass validate_config.
+_DEMO_SPEC = """\
+# SAC_PLACEHOLDER_AGENT_ID — demo dir-template.
+apiVersion: scitex-agent-container/v3
+kind: Agent
+
+metadata:
+  labels:
+    role: worker
+    groups: [demo]
+    description: SAC_PLACEHOLDER_PROJECT agent SAC_PLACEHOLDER_AGENT_ID.
+
+spec:
+  runtime: apptainer
+  host: local
+  workdir: ~/proj/SAC_PLACEHOLDER_PROJECT/SAC_PLACEHOLDER_AGENT_ID
+
+  apptainer:
+    image: ~/.scitex/agent-container/containers/sac-base.sif
+    binds: []
+
+  claude:
+    model: haiku
+    flags:
+      - --dangerously-skip-permissions
+
+  health:
+    enabled: true
+    interval: 60
+
+  restart:
+    policy: on-failure
+    max_retries: 3
+# EOF
+"""
+
+
+def _make_demo_template(base: Path, *, extra_token: str | None = None) -> Path:
+    """Create a fake ``_template_demo/`` dir under ``base`` and return it.
+
+    Carries SAC_PLACEHOLDER_PROJECT / SAC_PLACEHOLDER_AGENT_ID in
+    spec.yaml + a token inside to_home/ so substitution coverage spans
+    the whole tree. ``extra_token`` (e.g. "EXTRA") injects a custom
+    ``SAC_PLACEHOLDER_<EXTRA>`` into to_home/.
+    """
+    tdir = base / "_template_demo"
+    (tdir / "to_home").mkdir(parents=True)
+    (tdir / "spec.yaml").write_text(_DEMO_SPEC)
+    home_body = "agent=SAC_PLACEHOLDER_AGENT_ID project=SAC_PLACEHOLDER_PROJECT\n"
+    if extra_token is not None:
+        home_body += f"extra=SAC_PLACEHOLDER_{extra_token}\n"
+    (tdir / "to_home" / "CLAUDE.md").write_text(home_body)
+    return tdir
+
+
+def _no_placeholder_remains(agent_dir: Path) -> bool:
+    """True iff no ``SAC_PLACEHOLDER_*`` token survives anywhere in tree."""
+    for path in agent_dir.rglob("*"):
+        if path.is_file() and "SAC_PLACEHOLDER_" in path.read_text():
+            return False
+    return True
+
+
+def _invoke_demo(
+    runner: CliRunner, base: Path, name: str, *extra_args: str
+) -> object:
+    """Instantiate the demo dir-template under ``base`` and return result."""
+    return runner.invoke(
+        new_cmd,
+        [name, "--base-dir", str(base), "--template", "demo", *extra_args],
+    )
+
+
+def test_new_dir_template_instantiation_exits_zero(tmp_path: Path) -> None:
+    # Arrange
+    runner = CliRunner()
+    base = tmp_path / "agents"
+    _make_demo_template(base)
+    # Act
+    result = _invoke_demo(
+        runner, base, "demo1", "--project", "myproj", "--agent-id", "demo1"
+    )
+    # Assert
+    assert result.exit_code == 0
+
+
+def test_new_dir_template_writes_spec_yaml(tmp_path: Path) -> None:
+    # Arrange
+    runner = CliRunner()
+    base = tmp_path / "agents"
+    _make_demo_template(base)
+    # Act
+    _invoke_demo(runner, base, "demo1", "--project", "myproj")
+    # Assert
+    assert (base / "demo1" / "spec.yaml").is_file()
+
+
+def test_new_dir_template_leaves_no_placeholder(tmp_path: Path) -> None:
+    # Arrange
+    runner = CliRunner()
+    base = tmp_path / "agents"
+    _make_demo_template(base)
+    # Act
+    _invoke_demo(runner, base, "demo1", "--project", "myproj")
+    # Assert
+    assert _no_placeholder_remains(base / "demo1")
+
+
+def test_new_dir_template_filled_spec_validates(tmp_path: Path) -> None:
+    # Arrange
+    runner = CliRunner()
+    base = tmp_path / "agents"
+    _make_demo_template(base)
+    # Act
+    _invoke_demo(runner, base, "demo1", "--project", "myproj")
+    errors = validate_config(base / "demo1" / "spec.yaml")
+    # Assert
+    assert errors == []
+
+
+def test_new_dir_template_copies_to_home_tree(tmp_path: Path) -> None:
+    # Arrange
+    runner = CliRunner()
+    base = tmp_path / "agents"
+    _make_demo_template(base)
+    # Act
+    runner.invoke(
+        new_cmd,
+        ["d2", "--base-dir", str(base), "--template", "demo", "--project", "p"],
+    )
+    home = (base / "d2" / "to_home" / "CLAUDE.md").read_text()
+    # Assert — to_home/ copied AND its placeholder substituted (agent-id default).
+    assert "agent=d2 project=p" in home
+
+
+def test_new_dir_template_agent_id_defaults_to_name(tmp_path: Path) -> None:
+    # Arrange
+    runner = CliRunner()
+    base = tmp_path / "agents"
+    _make_demo_template(base)
+    # Act — omit --agent-id; it must default to <name>.
+    runner.invoke(
+        new_cmd,
+        ["nameddefault", "--base-dir", str(base), "--template", "demo", "--project", "p"],
+    )
+    text = (base / "nameddefault" / "to_home" / "CLAUDE.md").read_text()
+    # Assert
+    assert "agent=nameddefault" in text
+
+
+def test_new_dir_template_missing_placeholder_exits_nonzero(tmp_path: Path) -> None:
+    # Arrange — omit --project so SAC_PLACEHOLDER_PROJECT cannot be filled.
+    runner = CliRunner()
+    base = tmp_path / "agents"
+    _make_demo_template(base)
+    # Act
+    result = _invoke_demo(runner, base, "partial")
+    # Assert
+    assert result.exit_code != 0
+
+
+def test_new_dir_template_missing_placeholder_names_token(tmp_path: Path) -> None:
+    # Arrange
+    runner = CliRunner()
+    base = tmp_path / "agents"
+    _make_demo_template(base)
+    # Act
+    result = _invoke_demo(runner, base, "partial")
+    # Assert — error must name the exact unfilled token.
+    assert "SAC_PLACEHOLDER_PROJECT" in result.output
+
+
+def test_new_dir_template_missing_placeholder_leaves_no_output(tmp_path: Path) -> None:
+    # Arrange
+    runner = CliRunner()
+    base = tmp_path / "agents"
+    _make_demo_template(base)
+    # Act
+    _invoke_demo(runner, base, "partial")
+    # Assert — partial output removed; no half-written agent.
+    assert not (base / "partial").exists()
+
+
+def test_new_dir_template_set_exits_zero(tmp_path: Path) -> None:
+    # Arrange — demo carries a custom SAC_PLACEHOLDER_EXTRA token.
+    runner = CliRunner()
+    base = tmp_path / "agents"
+    _make_demo_template(base, extra_token="EXTRA")
+    # Act
+    result = _invoke_demo(
+        runner, base, "withextra", "--project", "p", "--set", "EXTRA=val"
+    )
+    # Assert
+    assert result.exit_code == 0
+
+
+def test_new_dir_template_set_fills_custom_token(tmp_path: Path) -> None:
+    # Arrange
+    runner = CliRunner()
+    base = tmp_path / "agents"
+    _make_demo_template(base, extra_token="EXTRA")
+    # Act
+    _invoke_demo(runner, base, "withextra", "--project", "p", "--set", "EXTRA=val")
+    text = (base / "withextra" / "to_home" / "CLAUDE.md").read_text()
+    # Assert
+    assert "extra=val" in text
+
+
+def test_new_dir_template_discovery_is_dynamic(tmp_path: Path) -> None:
+    # Arrange — a brand-new _template_demo/ dir with NO code change must
+    # be accepted as a --template choice.
+    runner = CliRunner()
+    base = tmp_path / "agents"
+    _make_demo_template(base)
+    # Act
+    result = runner.invoke(
+        new_cmd,
+        ["dyn", "--base-dir", str(base), "--template", "demo", "--project", "p"],
+    )
+    # Assert
+    assert result.exit_code == 0
+
+
+def test_new_inline_minimal_still_works_with_dir_templates_present(
+    tmp_path: Path,
+) -> None:
+    # Arrange — dir-template present, but inline 'minimal' must still render
+    # the string template (not be shadowed).
+    runner = CliRunner()
+    base = tmp_path / "agents"
+    _make_demo_template(base)
+    # Act
+    runner.invoke(
+        new_cmd, ["inl", "--base-dir", str(base), "--template", "minimal"]
+    )
+    errors = validate_config(base / "inl" / "spec.yaml")
+    # Assert
+    assert errors == []


### PR DESCRIPTION
## Summary
- `sac agents new <name> --template <kind>` now instantiates DIRECTORY templates (`_template_<kind>/` under the agents root) in addition to the existing inline `minimal`/`full` string presets.
- Discovery is dynamic: every `_template_*` subdir of the base-dir is scanned at invocation and its suffix becomes a `--template` choice (e.g. `_template_python_developer/` -> `python_developer`). Dropping a new `_template_foo/` dir works with NO code change.
- Instantiation copies the whole template tree to `<base-dir>/<name>/` (spec.yaml + to_home/ + anything else) and substitutes `SAC_PLACEHOLDER_*` tokens via `--project` (PROJECT), `--agent-id` (AGENT_ID, defaults to `<name>`), and repeatable `--set KEY=VALUE` (any `SAC_PLACEHOLDER_<KEY>`).
- Fail-loud: after substitution every written file is scanned; any surviving `SAC_PLACEHOLDER_*` removes the partial output dir and exits non-zero, naming each unfilled token, its file:line, and the flag that fills it.
- Dir-template logic lives in a sibling module `_new_dir_template.py` to keep both files under 512 lines.

## Design notes
- `--template` changed from a static `click.Choice` to a free string validated inside the command, because dir-template discovery depends on `--base-dir` (only known at invocation). Unknown kinds raise a `UsageError` listing all available choices (inline + discovered).
- Inline `minimal`/`full` always win over a same-named dir (operator can't shadow the reserved presets); all other kinds resolve to dir-templates.
- `--base-dir` now doubles as the discovery scan root; its default reuses the resolver's `primary` base (`_search_dirs()`), keeping a single source of truth for "where agents live".
- `sac agents create` left untouched.

## Test plan
- [x] `_template_demo` instantiation with `--project X --agent-id Y` -> dir exists, no `SAC_PLACEHOLDER_*` remains, validates.
- [x] `--agent-id` defaults to `<name>` when omitted; to_home/ tree copied + substituted.
- [x] missing `--project` -> exit non-zero, error names `SAC_PLACEHOLDER_PROJECT`, no half-written output.
- [x] inline `--template minimal` / `--template full` still validate with a dir-template present.
- [x] `--set EXTRA=val` fills `SAC_PLACEHOLDER_EXTRA`.
- [x] dynamic discovery (new dir, no code change).
- All 24 tests in `tests/scitex_agent_container/cli_pkg/test__new.py` pass.