### PR TITLE
feat(runtimes): inject SCITEX_GENAI_BASE_URL for host-tunneled qwen

### DIFF
--- a/src/scitex_agent_container/runtimes/_apptainer_listen_env.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_listen_env.py
@@ -81,6 +81,23 @@ def listen_env_flags(config) -> list[str]:
         "SCITEX_TESTMON_CACHE_ROOT=/home/agent/.cache/scitex-testmon",
     ]
 
+    # HOST-TUNNELED QWEN FALLBACK — point the scitex-genai client at the
+    # host-side ssh tunnel to Spartan-hosted qwen. ``127.0.0.1:4000`` is
+    # reachable from EVERY agent container because apptainer shares the
+    # host network namespace, so no per-container port forward is needed.
+    # ``SCITEX_GENAI_BASE_URL`` is a namespaced FALLBACK that scitex-genai
+    # consults ONLY on its self-hosted / unknown-model path — it is
+    # deliberately NOT ``OPENAI_BASE_URL`` (which the openai SDK auto-reads
+    # and would misroute real ``gpt-*`` traffic to this local qwen tunnel).
+    # Only the base URL is injected here; the qwen API key is gated on a
+    # separate operator security decision and is intentionally NOT set.
+    # UNCONDITIONAL (same as the base URL + testmon cache above): a base
+    # URL with no key is harmless to agents that never hit the fallback.
+    flags += [
+        "--env",
+        "SCITEX_GENAI_BASE_URL=http://127.0.0.1:4000/v1",
+    ]
+
     # Forward the host's agent-spec search path so the in-container sac
     # resolves peer specs at the operator's path. Only inject when the
     # host has it set+non-empty — otherwise leave the in-container default

--- a/tests/scitex_agent_container/runtimes/test__apptainer_listen_env.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_listen_env.py
@@ -90,3 +90,54 @@ def test_listen_env_flags_still_injects_base_url(
     flags = listen_env_flags(no_bus_config)
     # Assert — the pre-existing base-URL injection is unregressed.
     assert any(f.startswith("SAC_LISTEN_BASE_URL=") for f in flags)
+
+
+def test_listen_env_flags_still_injects_testmon_cache_root(
+    no_bus_config: SimpleNamespace,
+    sandboxed_home: Path,
+) -> None:
+    # Arrange — fixtures supply an empty-channel config + sandboxed $HOME.
+    # Act
+    flags = listen_env_flags(no_bus_config)
+    # Assert — the testmon-cache injection is unregressed.
+    assert (
+        "SCITEX_TESTMON_CACHE_ROOT=/home/agent/.cache/scitex-testmon" in flags
+    )
+
+
+def test_listen_env_flags_injects_genai_base_url(
+    no_bus_config: SimpleNamespace,
+    sandboxed_home: Path,
+) -> None:
+    # Arrange — fixtures supply an empty-channel config + sandboxed $HOME.
+    # Act
+    flags = listen_env_flags(no_bus_config)
+    # Assert — the host-tunneled qwen fallback base URL is injected.
+    assert "SCITEX_GENAI_BASE_URL=http://127.0.0.1:4000/v1" in flags
+
+
+def test_listen_env_flags_genai_base_url_follows_an_env_token(
+    no_bus_config: SimpleNamespace,
+    sandboxed_home: Path,
+) -> None:
+    # Arrange — apptainer consumes ``--env KEY=VALUE`` as two argv tokens;
+    # the genai base URL must be preceded by a literal ``--env`` flag.
+    flags = listen_env_flags(no_bus_config)
+    # Act
+    idx = flags.index("SCITEX_GENAI_BASE_URL=http://127.0.0.1:4000/v1")
+    # Assert
+    assert flags[idx - 1] == "--env"
+
+
+def test_listen_env_flags_injects_no_genai_api_key(
+    no_bus_config: SimpleNamespace,
+    sandboxed_home: Path,
+) -> None:
+    # Arrange — only the base URL half is injected here; the qwen API key
+    # is gated on a separate operator security decision and must NOT leak.
+    # Act
+    flags = listen_env_flags(no_bus_config)
+    # Assert — no genai/qwen API-key env var is present.
+    assert not any(
+        "GENAI_API_KEY" in f or "QWEN_API_KEY" in f for f in flags
+    )


### PR DESCRIPTION
## Summary
- Inject `SCITEX_GENAI_BASE_URL=http://127.0.0.1:4000/v1` unconditionally from `listen_env_flags(config)`, via the same `--env`-token-then-`KEY=VALUE` pattern used for `SAC_LISTEN_BASE_URL` and `SCITEX_TESTMON_CACHE_ROOT`.
- This points scitex-genai's self-hosted / unknown-model **fallback** path at the host-side ssh tunnel to Spartan-hosted qwen. `127.0.0.1:4000` is reachable from every agent container because apptainer shares the host network namespace.
- Deliberately uses the namespaced `SCITEX_GENAI_BASE_URL` rather than `OPENAI_BASE_URL` — the latter is auto-read by the openai SDK and would misroute real `gpt-*` traffic to the local qwen tunnel.
- **Only the base URL is injected. No API key.** The qwen API key is gated on a separate operator security decision; this PR is the harmless base_url half only.

## Test plan
- [x] Extended `tests/scitex_agent_container/runtimes/test__apptainer_listen_env.py` with real (mock-free) tests asserting:
  - `SCITEX_GENAI_BASE_URL=http://127.0.0.1:4000/v1` is present and preceded by a literal `--env` token.
  - No `*GENAI_API_KEY*` / `*QWEN_API_KEY*` env var is injected.
  - `SAC_LISTEN_BASE_URL` and `SCITEX_TESTMON_CACHE_ROOT` injections are unregressed.
- [x] `PYTHONPATH=src /opt/venv-sac/bin/python -m pytest tests/scitex_agent_container/runtimes/test__apptainer_listen_env.py -q` → 7 passed.