### PR TITLE
fix(image): install pre-commit into system python so git hooks work fleet-wide

### DIFF
--- a/src/scitex_agent_container/containers/apptainer-base.def
+++ b/src/scitex_agent_container/containers/apptainer-base.def
@@ -250,9 +250,21 @@ From: ubuntu:24.04
     make -C /tmp/unix-tree-2.1.3 install PREFIX=/usr/local
     rm -rf /tmp/unix-tree-*
 
-    # ---- 6. uv (Astral) + pipx -----------------------------------------
+    # ---- 6. uv (Astral) + pipx + pre-commit ----------------------------
     UV_INSTALL_DIR=/usr/local/bin curl -LsSf https://astral.sh/uv/install.sh | sh
     python3 -m pip install --no-cache-dir --break-system-packages pipx
+    # pre-commit into SYSTEM python on purpose: every repo's git hook execs
+    # ``INSTALL_PYTHON=/usr/bin/python3 -m pre_commit`` — the interpreter
+    # ``pre-commit install`` bakes into .git/hooks/pre-commit. A module
+    # invocation (``-m pre_commit``), so pipx's isolated venv does NOT
+    # satisfy it; it must import from /usr/bin/python3. Without this, EVERY
+    # repo's commit hook silently dies with ModuleNotFoundError. Same
+    # --break-system-packages exception as pipx above (a lightweight dev
+    # tool the hooks invoke via system python; the heavy scientific stack
+    # still stays in the venv, section 6b). Regression context: this was a
+    # runtime overlay install that the fresh-SIF refresh wiped fleet-wide
+    # (figrecipe 2026-06-28) — pinning it into the image makes it durable.
+    python3 -m pip install --no-cache-dir --break-system-packages pre-commit
 
     # ---- 6a. python convenience symlink -----------------------------
     # Ubuntu 24.04's `python3-is-python3` doesn't ship by default; many
@@ -345,7 +357,7 @@ From: ubuntu:24.04
 %labels
     org.scitex.layer base
     org.scitex.runtime apptainer
-    org.scitex.contains "git gh node npm rustc cargo fd bat eza rg tree jq yq delta gdu sd dust uv pipx mermaid prettier eslint jsonlint apptainer rtk"
+    org.scitex.contains "git gh node npm rustc cargo fd bat eza rg tree jq yq delta gdu sd dust uv pipx pre-commit mermaid prettier eslint jsonlint apptainer rtk"
 
 %help
     scitex-agent-container :base layer.


### PR DESCRIPTION
## Problem
After the overnight container refresh, `/usr/bin/python3 -m pre_commit` → ModuleNotFoundError in refreshed containers, **silently breaking every repo's git pre-commit hook** (the hook bakes `INSTALL_PYTHON=/usr/bin/python3`). Reported by figrecipe (worker-telegrammer) 2026-06-28; likely fleet-wide.

## Root cause
No `.def` ever installed pre-commit into system python (grep-confirmed across base/scitex/proxy). The working state was a **runtime overlay artifact** that the fresh-SIF + fresh-overlay wiped — never durable.

## Fix
Install `pre-commit` into system python in `apptainer-base.def` via `--break-system-packages`, mirroring the existing `pipx` line. A module invocation (`-m pre_commit`) requires it in `/usr/bin/python3` specifically — pipx's isolated venv wouldn't satisfy the baked hook. The heavy scientific stack still stays in `/opt/venv-sac` (section 6b). Also added `pre-commit` to the `org.scitex.contains` label.

## Activation
Base-image change → takes effect on the **next image rebuild** (operator-gated). Bundles with the post-2.30.3-publish rebuild. No per-repo changes needed (existing baked hooks just start working again).

## Test plan
- [ ] Not unit-testable (container recipe). Verify post-rebuild: `/usr/bin/python3 -m pre_commit --version` resolves inside a fresh container, and a repo's `git commit` runs its hooks.