### PR TITLE
feat(cli): sac agents refresh-acl — re-publish fleet ACL/group policy without relaunch

### DIFF
--- a/src/scitex_agent_container/cli_pkg/agent_group.py
+++ b/src/scitex_agent_container/cli_pkg/agent_group.py
@@ -58,7 +58,7 @@ class _AgentsGroup(HelpRecursiveGroup):
         ("Preflight", ["check"]),
         ("Discovery", ["find"]),
         ("Account", ["accounts"]),
-        ("Maintenance", ["prune-claude", "archive-claude-bloat"]),
+        ("Maintenance", ["prune-claude", "archive-claude-bloat", "refresh-acl"]),
     ]
 
 
@@ -120,5 +120,13 @@ agent_group.add_command(_rebind(_prune_claude_impl, "prune-claude"))
 # ``prune-claude`` (the narrower, dry-run-first, two-bucket scheme):
 # this command is the wide audit-driven button.
 agent_group.add_command(_rebind(_archive_claude_bloat_impl, "archive-claude-bloat"))
+# `refresh-acl` — re-publish every fleet agent's ACL/group policy from
+# its CURRENT on-disk spec into node_comms_policy, with NO agent
+# relaunch. The operator's post-restart activation step after a group-
+# model change: `systemctl --user restart sac-listen && sac agents
+# refresh-acl` brings the new group mesh live without a fleet relaunch.
+from .refresh_acl import refresh_acl as _refresh_acl_impl  # noqa: E402
+
+agent_group.add_command(_refresh_acl_impl)
 
 __all__ = ["agent_group"]

--- a/src/scitex_agent_container/cli_pkg/refresh_acl.py
+++ b/src/scitex_agent_container/cli_pkg/refresh_acl.py
@@ -1,0 +1,174 @@
+"""``sac agents refresh-acl`` — re-publish every fleet agent's ACL /
+group policy FROM ITS CURRENT SPEC, with NO agent relaunch.
+
+Why this exists
+---------------
+Each agent's named group + comms policy is persisted into the
+``node_comms_policy`` DB table at *its own* agent-start, by
+:func:`scitex_agent_container._lifecycle._spawn_gate.persist_acl_policy`.
+The ACL reads those persisted values. So when the group model changes
+(a new group resolver, or edited ``groups:`` labels in specs), the
+change does NOT take effect for already-running agents until each one
+restarts — even after the listen server restarts. Relaunching the whole
+fleet is heavy (loses sessions, burns API credit).
+
+This command is the lightweight activation step: it re-resolves and
+re-writes every fleet agent's group policy from the authoritative
+on-disk spec, with no agent relaunch. The operator's post-restart
+sequence is::
+
+    systemctl --user restart sac-listen && sac agents refresh-acl
+
+Behaviour
+---------
+* Enumerates every fleet agent spec by globbing the USER-SCOPE fleet
+  registry directly: ``~/.scitex/agent-container/agents/*/spec.yaml``
+  (skipping dirs starting with ``_`` — ``_shared``, ``_template_*``).
+  It does NOT route through the cwd-sensitive resolver — the glob is
+  deterministic regardless of cwd.
+* For each spec: reads the CURRENTLY persisted ``group_name``, then
+  ``load_config`` + ``persist_acl_policy`` re-resolves + re-writes the
+  policy, then reads the NEW ``group_name`` and prints a per-agent diff.
+* Idempotent + safe — it only refreshes the DB from on-disk specs;
+  running it twice is a no-op on the second run.
+* ``--dry-run`` shows the diff WITHOUT writing (the new group is
+  previewed with the pure :func:`group_from_labels` resolver).
+* Fails loud (non-zero exit) if the registry dir is missing or any spec
+  fails to load — but keeps going for the rest, collecting + reporting
+  every error at the end.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import click
+
+from ._helpers import console
+
+# Env override for the user-scope fleet registry dir. Mirrors the
+# ``SCITEX_AGENT_CONTAINER_STATE_DB`` override used by the state DB: it
+# lets the command be pointed at an isolated on-disk registry (tests /
+# a non-default install root) without touching the production default.
+_REGISTRY_ENV = "SCITEX_AGENT_CONTAINER_AGENTS_DIR"
+
+
+def _fleet_registry_dir() -> Path:
+    """Return the user-scope fleet registry dir (``…/agents``).
+
+    Honours the ``SCITEX_AGENT_CONTAINER_AGENTS_DIR`` env override; falls
+    back to the canonical ``~/.scitex/agent-container/agents``. Globbed
+    directly (NOT via the cwd-sensitive config resolver) so the command
+    is deterministic regardless of the caller's cwd.
+    """
+    override = os.environ.get(_REGISTRY_ENV)
+    if override:
+        return Path(override).expanduser()
+    return Path("~/.scitex/agent-container/agents").expanduser()
+
+
+def _fleet_spec_paths(registry: Path) -> list[Path]:
+    """Return every ``<name>/spec.yaml`` under ``registry``.
+
+    Skips registry subdirs whose name starts with ``_`` (``_shared``,
+    ``_template_*``) — those are scaffolding, not real fleet agents.
+    """
+    out: list[Path] = []
+    for spec in sorted(registry.glob("*/spec.yaml")):
+        if spec.parent.name.startswith("_"):
+            continue
+        out.append(spec)
+    return out
+
+
+@click.command(name="refresh-acl")
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Show the group diff WITHOUT writing to the DB.",
+)
+def refresh_acl(dry_run: bool) -> None:
+    """Re-publish every fleet agent's ACL / group policy from its spec.
+
+    Re-resolves each agent's NAMED group from its authoritative on-disk
+    ``spec.yaml`` and re-writes ``node_comms_policy`` — WITHOUT relaunching
+    any agent. Run it after a group-model change (e.g. ``systemctl --user
+    restart sac-listen``) to bring the new group mesh live with no fleet
+    relaunch.
+
+    \b
+    Example:
+      $ sac agents refresh-acl
+      $ sac agents refresh-acl --dry-run
+    """
+    from .._lifecycle._spawn_gate import persist_acl_policy
+    from .._state.state_db_nodes import read_comms_policy
+    from ..config import load_config
+    from ..config._group_resolver import group_from_labels
+
+    registry = _fleet_registry_dir()
+    if not registry.is_dir():
+        raise click.ClickException(
+            f"Fleet registry dir not found: {registry}. Expected the "
+            "user-scope agents registry at "
+            "~/.scitex/agent-container/agents/. Nothing to refresh."
+        )
+
+    specs = _fleet_spec_paths(registry)
+    if not specs:
+        console.print(
+            f"[yellow]No fleet agent specs under {registry} "
+            "(only _shared/_template dirs, or empty). Nothing to "
+            "refresh.[/yellow]"
+        )
+        return
+
+    refreshed = 0
+    changed = 0
+    errors: list[tuple[Path, str]] = []
+
+    for spec in specs:
+        # stx-allow: fallback (reason: a single malformed/foreign spec.yaml
+        # must NOT abort the rest of the fleet refresh — collect the error,
+        # report it at the end, and exit non-zero. See errors[] below.)
+        try:
+            config = load_config(spec)
+        except Exception as exc:  # stx-allow: fallback (reason: see above)
+            errors.append((spec, str(exc)))
+            console.print(f"[red]FAILED[/red] {spec}: {exc}")
+            continue
+
+        name = config.name
+        old_group = read_comms_policy(name=name)["group_name"]
+
+        if dry_run:
+            new_group = group_from_labels(getattr(config, "labels", None))
+        else:
+            persist_acl_policy(config)
+            new_group = read_comms_policy(name=name)["group_name"]
+
+        refreshed += 1
+        old_disp = old_group or "(none)"
+        new_disp = new_group or "(none)"
+        if old_group == new_group:
+            console.print(f"{name}: {old_disp} (unchanged)")
+        else:
+            changed += 1
+            console.print(f"{name}: {old_disp} -> {new_disp}")
+
+    mode = "would refresh" if dry_run else "refreshed"
+    console.print(
+        f"\n[bold]{refreshed} {mode}, {changed} changed"
+        f"{', ' + str(len(errors)) + ' failed' if errors else ''}.[/bold]"
+    )
+    if errors:
+        console.print(
+            f"[red]{len(errors)} spec(s) failed to load — "
+            "fix the named file(s) above and re-run.[/red]"
+        )
+        raise SystemExit(1)
+
+
+__all__ = ["refresh_acl"]

--- a/tests/scitex_agent_container/cli_pkg/test_refresh_acl.py
+++ b/tests/scitex_agent_container/cli_pkg/test_refresh_acl.py
@@ -1,0 +1,214 @@
+"""``sac agents refresh-acl`` — re-publish fleet ACL/group policy from
+specs without an agent relaunch.
+
+Real on-disk fixtures only (no mocks): a tmp fleet registry of v3
+``spec.yaml`` files + a tmp ``state.db``, both wired via env overrides
+(``SCITEX_AGENT_CONTAINER_STATE_DB`` and
+``SCITEX_AGENT_CONTAINER_AGENTS_DIR``) in yield-based fixtures — the
+pattern from ``tests/scitex_agent_container/_listen/test__acl_group.py``.
+The command is exercised end-to-end through its real Click entrypoint
+against those real on-disk files.
+
+AAA (each marker on its own line), one assertion per test.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+import yaml as _yaml
+from click.testing import CliRunner
+
+from scitex_agent_container._state import state_db
+from scitex_agent_container._state.state_db_nodes import (
+    read_comms_policy,
+    record_comms_policy,
+)
+from scitex_agent_container.cli_pkg import refresh_acl as refresh_acl_mod
+from scitex_agent_container.cli_pkg.refresh_acl import refresh_acl
+
+
+@pytest.fixture
+def db_path(tmp_path: Path):
+    # Arrange — isolated on-disk state.db via the env override.
+    db = tmp_path / "state.db"
+    saved_env = os.environ.get("SCITEX_AGENT_CONTAINER_STATE_DB")
+    saved_default = state_db.DEFAULT_DB_PATH
+    os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = str(db)
+    state_db.DEFAULT_DB_PATH = db
+    state_db.init_schema(db)
+    try:
+        yield db
+    finally:
+        state_db.DEFAULT_DB_PATH = saved_default
+        if saved_env is None:
+            os.environ.pop("SCITEX_AGENT_CONTAINER_STATE_DB", None)
+        else:
+            os.environ["SCITEX_AGENT_CONTAINER_STATE_DB"] = saved_env
+
+
+_REQUIRED_SCAFFOLD: dict = {
+    "host": "local",
+    "runtime": "apptainer",
+    "claude": {"model": "claude-opus-4-8[1m]"},
+    "apptainer": {"image": "/opt/sac/scitex.sif", "binds": []},
+    "health": {"enabled": True, "interval": 60},
+    "restart": {"policy": "on-failure", "max_retries": 3},
+}
+
+
+def _write_spec(registry: Path, name: str, labels: dict | None) -> Path:
+    """Write a dir-as-SSoT v3 ``<name>/spec.yaml`` under ``registry``."""
+    agent_dir = registry / name
+    agent_dir.mkdir(parents=True)
+    spec_body = dict(_REQUIRED_SCAFFOLD)
+    spec_body["workdir"] = f"~/.scitex/agent-container/runtime/agents/{name}"
+    metadata = {"labels": labels} if labels is not None else {}
+    spec_path = agent_dir / "spec.yaml"
+    spec_path.write_text(
+        _yaml.safe_dump(
+            {
+                "apiVersion": "scitex-agent-container/v3",
+                "kind": "Agent",
+                "metadata": metadata,
+                "spec": spec_body,
+            }
+        )
+    )
+    return spec_path
+
+
+@pytest.fixture
+def registry(tmp_path: Path):
+    # Arrange — a tmp fleet registry the command globs directly, wired via
+    # the SCITEX_AGENT_CONTAINER_AGENTS_DIR env override (yield-based; the
+    # value is popped/restored on teardown).
+    reg = tmp_path / "agents"
+    reg.mkdir()
+    env_key = refresh_acl_mod._REGISTRY_ENV
+    saved = os.environ.get(env_key)
+    os.environ[env_key] = str(reg)
+    try:
+        yield reg
+    finally:
+        if saved is None:
+            os.environ.pop(env_key, None)
+        else:
+            os.environ[env_key] = saved
+
+
+def test_refresh_writes_resolved_group_for_stale_agent(db_path, registry):
+    """A spec with groups:[researcher] whose persisted group is stale →
+    after the command read_comms_policy returns ``researcher``."""
+    # Arrange — spec says researcher; DB still holds the stale developer.
+    _write_spec(registry, "alice", {"groups": ["researcher"]})
+    record_comms_policy(name="alice", group_name="developer", db_path=db_path)
+    # Act
+    CliRunner().invoke(refresh_acl, [], catch_exceptions=False)
+    # Assert
+    assert read_comms_policy(name="alice")["group_name"] == "researcher"
+
+
+def test_diff_output_shows_the_change(db_path, registry):
+    """The printed per-agent diff shows old -> new for a changed group."""
+    # Arrange
+    _write_spec(registry, "alice", {"groups": ["researcher"]})
+    record_comms_policy(name="alice", group_name="developer", db_path=db_path)
+    # Act
+    result = CliRunner().invoke(refresh_acl, [], catch_exceptions=False)
+    # Assert
+    assert "alice: developer -> researcher" in result.output
+
+
+def test_unchanged_agent_marked_unchanged(db_path, registry):
+    """An agent already at its resolved group prints ``(unchanged)``."""
+    # Arrange
+    _write_spec(registry, "alice", {"groups": ["researcher"]})
+    record_comms_policy(name="alice", group_name="researcher", db_path=db_path)
+    # Act
+    result = CliRunner().invoke(refresh_acl, [], catch_exceptions=False)
+    # Assert
+    assert "(unchanged)" in result.output
+
+
+def test_dry_run_does_not_mutate_the_db(db_path, registry):
+    """--dry-run shows the diff WITHOUT writing — DB stays stale."""
+    # Arrange
+    _write_spec(registry, "alice", {"groups": ["researcher"]})
+    record_comms_policy(name="alice", group_name="developer", db_path=db_path)
+    # Act
+    CliRunner().invoke(refresh_acl, ["--dry-run"], catch_exceptions=False)
+    # Assert
+    assert read_comms_policy(name="alice")["group_name"] == "developer"
+
+
+def test_dry_run_still_previews_the_new_group(db_path, registry):
+    """--dry-run previews the would-be group in the diff output."""
+    # Arrange
+    _write_spec(registry, "alice", {"groups": ["researcher"]})
+    record_comms_policy(name="alice", group_name="developer", db_path=db_path)
+    # Act
+    result = CliRunner().invoke(refresh_acl, ["--dry-run"], catch_exceptions=False)
+    # Assert
+    assert "alice: developer -> researcher" in result.output
+
+
+def test_underscore_dirs_are_skipped(db_path, registry):
+    """``_shared`` / ``_template_*`` dirs are NOT treated as fleet agents."""
+    # Arrange — a real agent plus two underscore scaffolding dirs.
+    _write_spec(registry, "alice", {"groups": ["researcher"]})
+    _write_spec(registry, "_shared", {"groups": ["researcher"]})
+    _write_spec(registry, "_template_dev", {"groups": ["developer"]})
+    # Act
+    result = CliRunner().invoke(refresh_acl, [], catch_exceptions=False)
+    # Assert
+    assert "_shared" not in result.output and "_template_dev" not in result.output
+
+
+def test_malformed_spec_reported_with_nonzero_exit(db_path, registry):
+    """A malformed spec is reported + non-zero exit, but the others still
+    refresh."""
+    # Arrange — one good agent, one spec.yaml that fails validation.
+    _write_spec(registry, "alice", {"groups": ["researcher"]})
+    bad_dir = registry / "broken"
+    bad_dir.mkdir()
+    (bad_dir / "spec.yaml").write_text("this: is: not: a: valid: v3 spec\n")
+    # Act
+    result = CliRunner().invoke(refresh_acl, [], catch_exceptions=False)
+    # Assert
+    assert result.exit_code == 1
+
+
+def test_malformed_spec_does_not_abort_the_others(db_path, registry):
+    """The good agent is still refreshed despite the sibling failure."""
+    # Arrange
+    _write_spec(registry, "alice", {"groups": ["researcher"]})
+    record_comms_policy(name="alice", group_name="developer", db_path=db_path)
+    bad_dir = registry / "broken"
+    bad_dir.mkdir()
+    (bad_dir / "spec.yaml").write_text("this: is: not: a: valid: v3 spec\n")
+    # Act
+    CliRunner().invoke(refresh_acl, [], catch_exceptions=False)
+    # Assert
+    assert read_comms_policy(name="alice")["group_name"] == "researcher"
+
+
+def test_missing_registry_dir_fails_loud(db_path, tmp_path):
+    """A missing registry dir is an actionable non-zero failure."""
+    # Arrange — point the env override at a path that does not exist.
+    missing = tmp_path / "nope" / "agents"
+    env_key = refresh_acl_mod._REGISTRY_ENV
+    saved = os.environ.get(env_key)
+    os.environ[env_key] = str(missing)
+    try:
+        # Act
+        result = CliRunner().invoke(refresh_acl, [], catch_exceptions=False)
+    finally:
+        if saved is None:
+            os.environ.pop(env_key, None)
+        else:
+            os.environ[env_key] = saved
+    # Assert
+    assert result.exit_code != 0


### PR DESCRIPTION
## Summary
- New `sac agents refresh-acl` command re-publishes every fleet agent's ACL/group policy into `node_comms_policy` FROM ITS CURRENT on-disk spec, with NO agent relaunch — the operator's lightweight post-restart activation step after a group-model change.
- Globs the USER-SCOPE fleet registry directly (`~/.scitex/agent-container/agents/*/spec.yaml`, skipping `_shared` / `_template_*`), so it is deterministic regardless of cwd. For each spec it reads the current persisted `group_name`, runs `load_config` + `persist_acl_policy`, then reads the new `group_name` and prints a per-agent `name: <old> -> <new>` diff (or `(unchanged)`), with a count summary.
- Idempotent + fail-loud: missing registry or any spec that fails to load → non-zero exit (the failing file is named), but the rest still refresh. `--dry-run` previews the would-be group via the pure `group_from_labels` resolver without touching the DB.

Activation: `systemctl --user restart sac-listen && sac agents refresh-acl` brings the new group mesh live with no fleet relaunch.

## Why
Each agent's named group + comms policy is persisted at *its own* agent-start by `persist_acl_policy` in `_lifecycle/_spawn_gate.py`. A group-model change (new resolver / edited `groups:` labels) therefore does NOT take effect for an already-running agent until it restarts — even after the listen server restarts. Relaunching the whole fleet is heavy (lost sessions, burned API credit). This command refreshes the DB from the authoritative specs instead.

## Implementation notes
- `_fleet_registry_dir()` honours a `SCITEX_AGENT_CONTAINER_AGENTS_DIR` env override (mirrors the `SCITEX_AGENT_CONTAINER_STATE_DB` state-db override) so the registry can be redirected for an isolated install root / tests — no `monkeypatch`.
- Wired into the `sac agents` group under the Maintenance category, matching the established `_rebind`/click pattern.

## Test plan
- [x] `tests/scitex_agent_container/cli_pkg/test_refresh_acl.py` — 9 real on-disk tests (tmp registry + tmp state.db via env overrides, no mocks): stale spec → `read_comms_policy` returns the resolved group; diff shows the change; `(unchanged)` path; `--dry-run` does NOT mutate the DB but still previews; `_shared`/`_template_*` skipped; malformed spec → reported + non-zero exit but others still refresh; missing registry fails loud. All 9 pass.