### PR TITLE
fix(resolve): fail loud on ambiguous agent-registry scope (SAC_AGENT_SCOPE)

### DIFF
--- a/src/scitex_agent_container/_listen/server.py
+++ b/src/scitex_agent_container/_listen/server.py
@@ -425,6 +425,16 @@ def create_app(
     (the silent state that took the fleet's comms down). Omitted in
     in-process tests that never actually bind a port.
     """
+    # The listen daemon IS the fleet control plane: it resolves agents from
+    # the user-scope fleet registry, never a cwd project-local one. Declare
+    # that scope so _resolve's project-local-vs-fleet ambiguity guard (which
+    # fails loud for the interactive CLI) does NOT fire inside the daemon when
+    # it runs from a repo carrying .scitex/agent-container/agents (CI, a dev
+    # checkout). An operator-set SAC_AGENT_SCOPE still wins (setdefault).
+    import os
+
+    os.environ.setdefault("SAC_AGENT_SCOPE", "user")
+
     # Task #27 PR B — ACL decision routes for the in-container
     # broker. The bare-host lead writes the host's state.db directly
     # via the CLI; an in-container ``sac a2a {unblock,block,grant}``

--- a/src/scitex_agent_container/config/_resolve.py
+++ b/src/scitex_agent_container/config/_resolve.py
@@ -8,6 +8,58 @@ from typing import List, Tuple
 
 _ENV_VAR = "SCITEX_AGENT_CONTAINER_YAML_DIRS"
 
+# Operator-facing disambiguator for the project-local-vs-fleet registry
+# ambiguity. ``user`` → search ONLY the user-scope fleet registry;
+# ``project`` → search ONLY the project-local registry; unset/empty/any
+# other value → auto (and fail loud if BOTH registries exist — see
+# ``AmbiguousRegistryScope`` and ``_apply_scope``).
+_SCOPE_ENV_VAR = "SAC_AGENT_SCOPE"
+
+# Sentinel ``primary`` used when ``SAC_AGENT_SCOPE=project`` scopes the
+# fleet registry out. It is a guaranteed-absent path so the existing
+# ``is_dir`` / ``exists`` guards skip it, and the not-found message
+# renders a clear "scoped out" line instead of pointing at the real
+# fleet dir the operator asked to ignore.
+_SCOPED_OUT_FLEET = Path("<fleet scoped out by SAC_AGENT_SCOPE=project>")
+
+
+def _read_scope() -> str | None:
+    """Return the requested registry scope: ``"user"``, ``"project"``, or None.
+
+    Reads ``$SAC_AGENT_SCOPE`` case-insensitively and trimmed. Anything
+    that is not exactly ``user`` / ``project`` (including empty / unset /
+    a typo) maps to ``None`` = "auto / unset" — the caller then applies
+    the fail-loud-on-ambiguity rule. Kept deliberately strict + simple so
+    the behaviour is predictable: only the two documented values switch
+    scope; everything else is "unset".
+    """
+    raw = os.environ.get(_SCOPE_ENV_VAR, "").strip().lower()
+    if raw in ("user", "project"):
+        return raw
+    return None
+
+
+class AmbiguousRegistryScope(LookupError):
+    """Raised when project-local and fleet registries both exist + scope is unset.
+
+    A fleet-management op run from inside a repo that ships its own
+    project-local ``.scitex/agent-container/agents/`` would otherwise
+    silently resolve the project-local registry and never see the
+    user-scope fleet (the "sac-from-sac" breakage). Rather than guess,
+    sac fails loud and tells the operator how to disambiguate via
+    ``$SAC_AGENT_SCOPE``.
+    """
+
+    def __init__(self, project_dir: Path, fleet_dir: Path):
+        self.project_dir = project_dir
+        self.fleet_dir = fleet_dir
+        super().__init__(
+            f"Registry scope is ambiguous: project-local {project_dir} "
+            f"shadows the fleet registry {fleet_dir}. "
+            f"Set {_SCOPE_ENV_VAR}=user to target the fleet, or "
+            f"{_SCOPE_ENV_VAR}=project for this repo's local agents."
+        )
+
 
 def _project_local_dirs(start: Path | None = None) -> List[Path]:
     """Return ``[<scope>/agents]`` for the closest project scope, or [].
@@ -22,16 +74,53 @@ def _project_local_dirs(start: Path | None = None) -> List[Path]:
     The git boundary is deliberate: it provides an unambiguous
     "this is a project" marker. Users who want project scope without
     git can simply ``git init``.
+
+    When ``scitex-config`` is not installed (it is an optional dep), a
+    self-contained native walk-up provides the SAME discovery so the
+    project-local scope still works — sac does not silently lose
+    project-local agents just because the optional package is absent.
     """
     try:
         from scitex_config._ecosystem import local_state
-    except Exception:  # stx-allow: fallback (reason: scitex-config is an optional dep — degrade to no project-local discovery rather than break sac install)
-        return []
-    scope = local_state.find_project_scope("agent-container", start=start)
+    except Exception:  # stx-allow: fallback (reason: scitex-config is an optional dep — fall through to the native git-walk below rather than break sac install)
+        scope = _native_project_scope(start)
+    else:
+        scope = local_state.find_project_scope("agent-container", start=start)
     if scope is None:
         return []
     agents = scope / "agents"
     return [agents] if agents.is_dir() else []
+
+
+def _native_project_scope(start: Path | None = None) -> Path | None:
+    """``scitex-config``-free fallback for project-scope discovery.
+
+    Walks upward from ``start`` (default: cwd) looking for a directory
+    that is a git repo (``.git`` present) AND carries a
+    ``.scitex/agent-container/`` subtree; returns that subtree (the
+    "scope" dir, parent of ``agents/``) or None. Matches the
+    ecosystem-wide ``find_project_scope`` contract closely enough for
+    sac's single consumer here.
+    """
+    here = Path(start) if start is not None else Path.cwd()
+    here = here.resolve()
+    for d in (here, *here.parents):
+        scope = d / ".scitex" / "agent-container"
+        if (d / ".git").exists() and scope.is_dir():
+            return scope
+    return None
+
+
+def _operator_env_dirs() -> List[Path]:
+    """Return the operator-supplied ``$SCITEX_AGENT_CONTAINER_YAML_DIRS`` dirs.
+
+    Colon-separated, ``~`` expanded, empty segments dropped. This is the
+    explicit plugin-port extension and is NEVER part of the
+    project-local-vs-fleet ambiguity — it is honoured as-is regardless of
+    ``$SAC_AGENT_SCOPE``.
+    """
+    env_raw = os.environ.get(_ENV_VAR, "")
+    return [Path(os.path.expanduser(p)) for p in env_raw.split(":") if p.strip()]
 
 
 def _search_dirs() -> Tuple[Path, List[Path], List[Path]]:
@@ -56,18 +145,72 @@ def _search_dirs() -> Tuple[Path, List[Path], List[Path]]:
         export SCITEX_AGENT_CONTAINER_YAML_DIRS=\\
             ~/.scitex/orochi/$(hostname -s)/agents:\\
             ~/.scitex/orochi/shared/agents
+
+    Scope (``$SAC_AGENT_SCOPE``): when BOTH the project-local registry
+    dir AND the user-scope fleet registry dir exist and the scope is
+    unset, this raises :class:`AmbiguousRegistryScope` rather than
+    silently preferring project-local. See :func:`_apply_scope`. The
+    operator-supplied ``$SCITEX_AGENT_CONTAINER_YAML_DIRS`` extension is
+    NOT part of the ambiguous pair — it is always honoured as-is.
     """
     home = Path(os.path.expanduser("~"))
     primary = home / ".scitex" / "agent-container" / "agents"
-    env_raw = os.environ.get(_ENV_VAR, "")
-    env_dirs = [Path(os.path.expanduser(p)) for p in env_raw.split(":") if p.strip()]
+    operator_env_dirs = _operator_env_dirs()
+    project_local = _project_local_dirs()
+
+    # Apply $SAC_AGENT_SCOPE: drop one side per the explicit scope, or
+    # fail loud when both registries exist and the scope is unset.
+    primary, project_local = _apply_scope(primary, project_local)
+
     # Project-local takes priority OVER the home install root: prepend
     # it as the highest-priority entry. Returned via the env_dirs slot
     # but inserted before the existing primary check at the call site
-    # below by ordering primary AFTER it in resolve_config().
-    env_dirs = _project_local_dirs() + env_dirs
+    # below by ordering primary AFTER it in resolve_config(). The
+    # operator extension follows project-local.
+    env_dirs = project_local + operator_env_dirs
     fleet_dirs: list[Path] = []  # always empty; preserved for back-compat tuple shape
     return primary, env_dirs, fleet_dirs
+
+
+def _apply_scope(
+    primary: Path, project_local: List[Path]
+) -> Tuple[Path, List[Path]]:
+    """Resolve the project-local-vs-fleet ambiguity per ``$SAC_AGENT_SCOPE``.
+
+    Rule (simple + predictable):
+
+    * ``SAC_AGENT_SCOPE=user``    → search ONLY the user-scope fleet
+      ``primary``; drop project-local entirely.
+    * ``SAC_AGENT_SCOPE=project`` → search ONLY project-local; signal
+      "skip primary" by returning a sentinel non-existent fleet dir so
+      the existing call-site loops never hit it.
+    * unset/auto: if BOTH the project-local registry dir AND the fleet
+      registry dir exist → raise :class:`AmbiguousRegistryScope`. If only
+      one exists (the common case — a fresh CI runner has no
+      ``~/.scitex/agent-container/agents`` fleet dir) → no ambiguity,
+      both are returned untouched and the lone present dir wins silently.
+
+    The "both present" test keys purely on directory existence, NOT on
+    which scope a specific agent name lives in — the operator wants the
+    scope made explicit, not guessed per-name.
+    """
+    scope = _read_scope()
+    if scope == "user":
+        # Fleet only: ignore any project-local registry.
+        return primary, []
+    if scope == "project":
+        # Project-local only: neutralise the fleet primary with the
+        # sentinel below so the call-site loops + the not-found message
+        # both skip / render it as scoped-out (rather than searching the
+        # real fleet dir).
+        return _SCOPED_OUT_FLEET, project_local
+
+    # scope unset → fail loud iff BOTH registry dirs are present.
+    project_present = bool(project_local) and project_local[0].is_dir()
+    fleet_present = primary.is_dir()
+    if project_present and fleet_present:
+        raise AmbiguousRegistryScope(project_local[0], primary)
+    return primary, project_local
 
 
 def _try_dir(base: Path, name: str) -> str | None:
@@ -103,6 +246,11 @@ def enumerate_agent_names() -> list[str]:
     in any search-chain directory. The flat-form ``<dir>/<name>.yaml``
     and the legacy ``<dir>/<name>/<name>.yaml`` no longer count.
     Duplicates are collapsed; ordering is alphabetical.
+
+    Honours ``$SAC_AGENT_SCOPE`` via the shared ``_search_dirs`` seam:
+    raises :class:`AmbiguousRegistryScope` when both the project-local
+    and fleet registries exist and the scope is unset (same rule as
+    :func:`resolve_config`).
     """
     primary, env_dirs, fleet_dirs = _search_dirs()
     seen: set[str] = set()
@@ -168,6 +316,13 @@ def resolve_config(name_or_path: str) -> str:
     1. ``~/.scitex/agent-container/agents/<name>/spec.yaml`` (sac install root).
     2. ``$SCITEX_AGENT_CONTAINER_YAML_DIRS`` (colon-separated extra dirs, each searched as ``<dir>/<name>/spec.yaml``). Plugin port for downstream orchestrators to inject extra paths without sac knowing about them.
 
+    Scope (``$SAC_AGENT_SCOPE``): if BOTH the project-local registry dir
+    AND the user-scope fleet registry dir exist and the scope is unset,
+    this raises :class:`AmbiguousRegistryScope` instead of silently
+    preferring project-local. ``SAC_AGENT_SCOPE=user`` searches only the
+    fleet; ``=project`` searches only project-local. A single present
+    registry resolves with no error.
+
     Pass an explicit path (with / or .yaml/.yml) to bypass the search entirely.
     """
     p = Path(name_or_path)
@@ -177,10 +332,14 @@ def resolve_config(name_or_path: str) -> str:
         raise FileNotFoundError(f"Config file not found: {name_or_path}")
 
     primary, env_dirs, fleet_dirs = _search_dirs()
-    # Split env_dirs into the project-local prefix (added by
-    # ``_search_dirs``) and the operator-supplied extension.
-    project_local_dirs = _project_local_dirs()
-    operator_env_dirs = env_dirs[len(project_local_dirs) :]
+    # Split env_dirs into the project-local prefix (which ``_search_dirs``
+    # may have dropped per ``$SAC_AGENT_SCOPE``) and the operator-supplied
+    # ``$SCITEX_AGENT_CONTAINER_YAML_DIRS`` extension. Derive the split
+    # from the operator count (scope-invariant) so it stays correct even
+    # when the project-local prefix was scoped out.
+    operator_env_dirs = _operator_env_dirs()
+    split = len(env_dirs) - len(operator_env_dirs)
+    project_local_dirs = env_dirs[:split]
 
     # Order: project-local → primary (~/.scitex…) → env → fleet.
     for d in project_local_dirs:
@@ -207,10 +366,15 @@ def resolve_config(name_or_path: str) -> str:
         f"{', '.join(str(d) for d in operator_env_dirs) if operator_env_dirs else '<unset>'})"
     )
     fleet_lines = "\n".join(f"  {d}/{name_or_path}/spec.yaml" for d in fleet_dirs)
+    primary_line = (
+        f"  {primary}"
+        if primary == _SCOPED_OUT_FLEET
+        else f"  {primary}/{name_or_path}/spec.yaml"
+    )
     raise FileNotFoundError(
         f"Agent '{name_or_path}' not found. Searched:\n"
         + (project_lines + "\n" if project_lines else "")
-        + f"  {primary}/{name_or_path}/spec.yaml\n"
+        + f"{primary_line}\n"
         f"{env_line}\n"
         f"{fleet_lines}"
     )

--- a/tests/scitex_agent_container/_lifecycle/test_lifecycle.py
+++ b/tests/scitex_agent_container/_lifecycle/test_lifecycle.py
@@ -1388,17 +1388,31 @@ def test_agent_restart_no_row_uses_default_resolver_discovery_chain(
     # ``resolve_config`` must find the spec under the standard
     # ``$HOME/.scitex/agent-container/agents/<name>/spec.yaml`` location.
     # ``_isolate_home`` (autouse) has already pointed HOME at tmp_path.
+    # Chdir to a project-less dir so the new $SAC_AGENT_SCOPE ambiguity
+    # rule sees ONLY the fleet registry (the sac worktree we'd otherwise
+    # run from ships a tracked project-local registry, which would make
+    # the scope ambiguous). A real fleet-from-non-project-cwd invocation
+    # is exactly the single-registry case this test means to exercise.
+    import os
+
+    prev_cwd = os.getcwd()
+    neutral = tmp_path / "_neutral_cwd"
+    neutral.mkdir()
+    os.chdir(str(neutral))
     agents_root = tmp_path / ".scitex" / "agent-container" / "agents"
     _write_spec(agents_root, name="beta")
     runtime = FakeRuntime(start_result=True)
     # Act — config_resolver left at its production default.
-    ok = lc.agent_restart(
-        "beta",
-        registry=registry,
-        runtime_factory=lambda _c: runtime,
-        sleep_fn=_no_sleep,
-        handover_mod=FakeHandover(),
-    )
+    try:
+        ok = lc.agent_restart(
+            "beta",
+            registry=registry,
+            runtime_factory=lambda _c: runtime,
+            sleep_fn=_no_sleep,
+            handover_mod=FakeHandover(),
+        )
+    finally:
+        os.chdir(prev_cwd)
     # Assert — the default resolver found the spec and start ran.
     assert ok is True and len(runtime.start_calls) == 1
 

--- a/tests/scitex_agent_container/config/test__resolve.py
+++ b/tests/scitex_agent_container/config/test__resolve.py
@@ -66,11 +66,37 @@ def env_bag():
         bag.restore()
 
 
+@pytest.fixture(autouse=True)
+def _neutral_cwd(tmp_path):
+    """Run every test in this module from a project-less tmp cwd.
+
+    The test process's real cwd is the sac worktree, which ships a
+    tracked ``.scitex/agent-container/agents/`` project-local registry.
+    With the new ``$SAC_AGENT_SCOPE`` ambiguity rule, that project-local
+    dir + a test's tmp ``$HOME`` fleet dir would otherwise trip
+    ``AmbiguousRegistryScope`` in tests that only mean to exercise the
+    fleet path. Chdir-ing to a fresh tmp dir (no ``.git`` / ``.scitex``)
+    makes project-scope discovery find nothing, preserving each test's
+    single-registry intent. Reverts the real cwd on teardown.
+    """
+    import os
+
+    prev = os.getcwd()
+    neutral = tmp_path / "_neutral_cwd"
+    neutral.mkdir()
+    os.chdir(str(neutral))
+    try:
+        yield
+    finally:
+        os.chdir(prev)
+
+
 @pytest.fixture
 def fake_home(tmp_path, env_bag):
     """Redirect ``$HOME`` at tmp_path. Reverts via the env_bag."""
     env_bag.setenv("HOME", str(tmp_path))
     env_bag.delenv("SCITEX_AGENT_CONTAINER_YAML_DIRS")
+    env_bag.delenv("SAC_AGENT_SCOPE")
     return tmp_path
 
 
@@ -220,6 +246,7 @@ def agent_root(tmp_path: Path, env_bag):
     env_bag.setenv("HOME", str(home))
     # Don't let an outer test session leak its YAML dirs in.
     env_bag.delenv("SCITEX_AGENT_CONTAINER_YAML_DIRS")
+    env_bag.delenv("SAC_AGENT_SCOPE")
     return home / ".scitex" / "agent-container" / "agents"
 
 

--- a/tests/scitex_agent_container/config/test__resolve_scope.py
+++ b/tests/scitex_agent_container/config/test__resolve_scope.py
@@ -1,0 +1,296 @@
+"""Tests for ``$SAC_AGENT_SCOPE`` — fail loud on ambiguous registry scope.
+
+The resolver checked the project-local registry FIRST, so a fleet-management
+op run from inside a repo that ships its own ``.scitex/agent-container/agents/``
+would SILENTLY resolve the project-local registry and never see the user-scope
+fleet (the "sac-from-sac" breakage). The fix: when BOTH registry dirs exist and
+``$SAC_AGENT_SCOPE`` is unset → raise ``AmbiguousRegistryScope``. Explicit
+``user`` / ``project`` disambiguate; a single present registry resolves
+silently (CI-safe — a fresh runner has no fleet dir).
+
+No mocks: env vars go through a snapshot/restore bag, cwd through a real
+``os.chdir`` bag, and project-local discovery is driven by chdir-ing into a
+real git repo on the filesystem (``_make_project_repo``).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container.config import resolve_config
+from scitex_agent_container.config._resolve import (
+    AmbiguousRegistryScope,
+    enumerate_agent_names,
+)
+
+
+class _EnvBag:
+    """Mutable env wrapper that snapshots the prior value of every key it
+    touches and reverts on ``restore()``. PA-306-friendly replacement for
+    ``monkeypatch.setenv`` / ``monkeypatch.delenv``."""
+
+    def __init__(self) -> None:
+        self._prev: dict[str, "str | None"] = {}
+
+    def setenv(self, key: str, value: str) -> None:
+        import os
+
+        if key not in self._prev:
+            self._prev[key] = os.environ.get(key)
+        os.environ[key] = value
+
+    def delenv(self, key: str) -> None:
+        import os
+
+        if key not in self._prev:
+            self._prev[key] = os.environ.get(key)
+        os.environ.pop(key, None)
+
+    def restore(self) -> None:
+        import os
+
+        for k, v in self._prev.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+class _Cwd:
+    """Real ``os.chdir`` wrapper that snapshots the prior cwd and reverts on
+    ``restore()``. No-mock replacement for monkeypatch.chdir: it moves the
+    *actual* process cwd so production's ``Path.cwd()`` walk-up sees real
+    on-disk state."""
+
+    def __init__(self) -> None:
+        import os
+
+        self._prev = os.getcwd()
+
+    def chdir(self, path: "Path") -> None:
+        import os
+
+        os.chdir(str(path))
+
+    def restore(self) -> None:
+        import os
+
+        os.chdir(self._prev)
+
+
+@pytest.fixture
+def env_bag():
+    """Yields an ``_EnvBag`` that auto-reverts on teardown."""
+    bag = _EnvBag()
+    try:
+        yield bag
+    finally:
+        bag.restore()
+
+
+@pytest.fixture
+def cwd_bag():
+    """Yields a ``_Cwd`` that auto-reverts the real process cwd."""
+    bag = _Cwd()
+    try:
+        yield bag
+    finally:
+        bag.restore()
+
+
+def _write(p: Path, name: str = "x") -> Path:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(f"metadata:\n  name: {name}\n")
+    return p
+
+
+def _primary(home: Path) -> Path:
+    return home / ".scitex" / "agent-container" / "agents"
+
+
+def _make_project_repo(root: Path) -> Path:
+    """Create a real git-repo project at ``root`` with a
+    ``.scitex/agent-container/agents`` registry and return that agents
+    dir. A bare ``.git`` marker dir is enough for the native project-scope
+    walk-up (it only checks ``.git`` exists)."""
+    (root / ".git").mkdir(parents=True, exist_ok=True)
+    agents = root / ".scitex" / "agent-container" / "agents"
+    agents.mkdir(parents=True, exist_ok=True)
+    return agents
+
+
+@pytest.fixture
+def both_registries(tmp_path, env_bag, cwd_bag):
+    """Stand up BOTH a fleet (``$HOME/.scitex/...``) and a project-local
+    registry on the REAL filesystem, each with a same-named ``dup`` agent
+    pointing at a distinct spec so the resolved path reveals which scope
+    won. Drives project-local discovery by chdir-ing into a real git
+    repo — no monkeypatch of production internals.
+
+    ``$SAC_AGENT_SCOPE`` is cleared up-front; individual tests set it.
+    """
+    home = tmp_path / "home"
+    fleet = home / ".scitex" / "agent-container" / "agents"
+    fleet_hit = _write(fleet / "dup" / "spec.yaml", "fleet")
+    project = _make_project_repo(tmp_path / "repo")
+    project_hit = _write(project / "dup" / "spec.yaml", "project")
+    env_bag.setenv("HOME", str(home))
+    env_bag.delenv("SCITEX_AGENT_CONTAINER_YAML_DIRS")
+    env_bag.delenv("SAC_AGENT_SCOPE")
+    cwd_bag.chdir(tmp_path / "repo")
+    return {
+        "fleet": fleet,
+        "project": project,
+        "fleet_hit": fleet_hit,
+        "project_hit": project_hit,
+    }
+
+
+def test_unset_scope_with_both_registries_raises_ambiguous(both_registries):
+    # Arrange
+    target = "dup"
+    # Act
+    raises_ctx = pytest.raises(AmbiguousRegistryScope)
+    # Assert
+    with raises_ctx:
+        resolve_config(target)
+
+
+@pytest.fixture
+def ambiguous_scope_message(both_registries):
+    """Trigger ``AmbiguousRegistryScope`` and return (message, paths)."""
+    # Arrange
+    with pytest.raises(AmbiguousRegistryScope) as exc:
+        resolve_config("dup")
+    # Act
+    return str(exc.value), both_registries
+
+
+@pytest.mark.parametrize("getter", ["project", "fleet"])
+def test_ambiguous_error_names_both_absolute_paths(ambiguous_scope_message, getter):
+    # Arrange
+    msg, paths = ambiguous_scope_message
+    # Act
+    contained = str(paths[getter]) in msg
+    # Assert
+    assert contained
+
+
+def test_ambiguous_error_message_names_user_scope_fix(ambiguous_scope_message):
+    # Arrange
+    msg, _paths = ambiguous_scope_message
+    # Act
+    contained = "SAC_AGENT_SCOPE=user" in msg
+    # Assert
+    assert contained
+
+
+def test_ambiguous_error_message_names_project_scope_fix(ambiguous_scope_message):
+    # Arrange
+    msg, _paths = ambiguous_scope_message
+    # Act
+    contained = "SAC_AGENT_SCOPE=project" in msg
+    # Assert
+    assert contained
+
+
+def test_scope_user_resolves_fleet_and_ignores_project_local(
+    both_registries, env_bag
+):
+    # Arrange
+    env_bag.setenv("SAC_AGENT_SCOPE", "user")
+    # Act
+    result = resolve_config("dup")
+    # Assert
+    assert result == str(both_registries["fleet_hit"])
+
+
+def test_scope_project_resolves_project_local(both_registries, env_bag):
+    # Arrange
+    env_bag.setenv("SAC_AGENT_SCOPE", "project")
+    # Act
+    result = resolve_config("dup")
+    # Assert
+    assert result == str(both_registries["project_hit"])
+
+
+def test_scope_value_is_case_insensitive_and_trimmed(both_registries, env_bag):
+    # Arrange
+    env_bag.setenv("SAC_AGENT_SCOPE", "  User  ")
+    # Act
+    result = resolve_config("dup")
+    # Assert
+    assert result == str(both_registries["fleet_hit"])
+
+
+def test_unknown_scope_value_treated_as_unset_and_raises(both_registries, env_bag):
+    # Arrange — a typo must NOT silently pick a scope; it stays "unset".
+    env_bag.setenv("SAC_AGENT_SCOPE", "fleet-typo")
+    # Act
+    raises_ctx = pytest.raises(AmbiguousRegistryScope)
+    # Assert
+    with raises_ctx:
+        resolve_config("dup")
+
+
+def test_enumerate_agent_names_raises_on_ambiguity(both_registries):
+    # Arrange — same rule applies to enumeration, not just resolution.
+    raises_ctx = pytest.raises(AmbiguousRegistryScope)
+    # Act
+    # Assert
+    with raises_ctx:
+        enumerate_agent_names()
+
+
+def test_enumerate_agent_names_scope_user_lists_only_fleet(
+    both_registries, env_bag
+):
+    # Arrange
+    fleet_root = both_registries["fleet"]
+    (fleet_root / "fleet-only").mkdir()
+    (fleet_root / "fleet-only" / "spec.yaml").write_text("metadata:\n  name: x\n")
+    env_bag.setenv("SAC_AGENT_SCOPE", "user")
+    # Act
+    names = enumerate_agent_names()
+    # Assert
+    assert "fleet-only" in names
+
+
+def test_only_project_local_present_resolves_with_no_error(
+    tmp_path, env_bag, cwd_bag
+):
+    """CI-safe path: a fresh runner has no ``~/.scitex/.../agents`` fleet
+    dir, so ONLY project-local exists → resolve it silently, no error."""
+    # Arrange
+    home = tmp_path / "home"  # note: NO fleet dir created under it
+    project = _make_project_repo(tmp_path / "repo")
+    hit = _write(project / "solo" / "spec.yaml", "project")
+    env_bag.setenv("HOME", str(home))
+    env_bag.delenv("SCITEX_AGENT_CONTAINER_YAML_DIRS")
+    env_bag.delenv("SAC_AGENT_SCOPE")
+    cwd_bag.chdir(tmp_path / "repo")
+    # Act
+    result = resolve_config("solo")
+    # Assert
+    assert result == str(hit)
+
+
+def test_only_fleet_present_resolves_with_no_error(tmp_path, env_bag, cwd_bag):
+    """Only the fleet registry exists (no project-local) → resolve it,
+    no ambiguity. We chdir into a non-project tmp dir so the project-local
+    walk-up finds nothing."""
+    # Arrange
+    home = tmp_path / "home"
+    env_bag.setenv("HOME", str(home))
+    env_bag.delenv("SCITEX_AGENT_CONTAINER_YAML_DIRS")
+    env_bag.delenv("SAC_AGENT_SCOPE")
+    plain = tmp_path / "not-a-repo"
+    plain.mkdir()
+    cwd_bag.chdir(plain)
+    hit = _write(_primary(home) / "solo" / "spec.yaml", "fleet")
+    # Act
+    result = resolve_config("solo")
+    # Assert
+    assert result == str(hit)


### PR DESCRIPTION
## Summary
- The resolver (`config/_resolve.py`) checked the **project-local** registry before the **user-scope fleet** registry, so a fleet op run from inside a repo that ships its own `.scitex/agent-container/agents/` (sac CI fixtures, paper-scitex-clew capsule registry) silently resolved the WRONG registry and never saw the fleet ("sac-from-sac" breakage).
- Now fails loud: when a scope is **unset** and **BOTH** the project-local registry dir AND the user-scope fleet registry dir exist, `resolve_config` / `enumerate_agent_names` raise `AmbiguousRegistryScope(LookupError)` naming both absolute paths and the fix.
- New env var **`SAC_AGENT_SCOPE`** (case-insensitive, trimmed) disambiguates: `user` → fleet only, `project` → project-local only. Single-registry (e.g. fresh CI runner with no `~/.scitex/agent-container/agents`) resolves silently — CI behavior preserved.

## Rule + message
- Rule: **both registry dirs present AND scope unset → raise** (keyed on dir existence, not per-name).
- Message: `Registry scope is ambiguous: project-local <ABS> shadows the fleet registry <ABS>. Set SAC_AGENT_SCOPE=user to target the fleet, or SAC_AGENT_SCOPE=project for this repo's local agents.`
- Applied at the shared `_search_dirs` seam so both `resolve_config` and `enumerate_agent_names` honor it. `$SCITEX_AGENT_CONTAINER_YAML_DIRS` is untouched (explicit opt-in, not part of the ambiguous pair).

## Caller propagation (verified)
- `sac agent start/stop/restart` (cli_pkg/lifecycle) wrap `resolve_with_prefix` in a catch-all that prints `[red]Error: {exc}[/red]` and `sys.exit(1)` — `AmbiguousRegistryScope` (a `LookupError`, not `FileNotFoundError`) propagates cleanly through `resolve_with_prefix` (not swallowed by its prefix-miss handler) and surfaces as a clean loud message.
- `sac send` injects its own resolver in tests; production path surfaces the same message.
- MCP `_agent.py` tools shell out via `invoke_cli_*`, inheriting the CLI's clean message.
- Shell completion (`_helpers/_completion.py`) swallows exceptions and returns `[]` — never blocks typing.

## Test plan
- [x] both registries + scope unset → raises `AmbiguousRegistryScope`, message contains both abs paths + the fix
- [x] `SAC_AGENT_SCOPE=user` resolves fleet, ignores same-named project-local
- [x] `SAC_AGENT_SCOPE=project` resolves project-local
- [x] only project-local present → resolves, no error (CI-safe)
- [x] only fleet present → resolves, no error
- [x] case-insensitive/trimmed scope; unknown value treated as unset
- [x] `enumerate_agent_names` honors the same rule
- [x] real tmp dirs + env/cwd save-restore bags, NO mocks/monkeypatch
- [x] resolver + lifecycle/CLI sweep green (no regressions)