### PR TITLE
fix(resolve): registry-scope ambiguity is per-name, not per-directory

### DIFF
--- a/src/scitex_agent_container/config/_resolve.py
+++ b/src/scitex_agent_container/config/_resolve.py
@@ -50,11 +50,17 @@ class AmbiguousRegistryScope(LookupError):
     ``$SAC_AGENT_SCOPE``.
     """
 
-    def __init__(self, project_dir: Path, fleet_dir: Path):
+    def __init__(self, project_dir: Path, fleet_dir: Path, name: str | None = None):
         self.project_dir = project_dir
         self.fleet_dir = fleet_dir
+        self.name = name
+        lead = (
+            f"agent {name!r} exists in BOTH registries: "
+            if name
+            else "Registry scope is ambiguous: "
+        )
         super().__init__(
-            f"Registry scope is ambiguous: project-local {project_dir} "
+            f"{lead}project-local {project_dir} "
             f"shadows the fleet registry {fleet_dir}. "
             f"Set {_SCOPE_ENV_VAR}=user to target the fleet, or "
             f"{_SCOPE_ENV_VAR}=project for this repo's local agents."
@@ -146,12 +152,12 @@ def _search_dirs() -> Tuple[Path, List[Path], List[Path]]:
             ~/.scitex/orochi/$(hostname -s)/agents:\\
             ~/.scitex/orochi/shared/agents
 
-    Scope (``$SAC_AGENT_SCOPE``): when BOTH the project-local registry
-    dir AND the user-scope fleet registry dir exist and the scope is
-    unset, this raises :class:`AmbiguousRegistryScope` rather than
-    silently preferring project-local. See :func:`_apply_scope`. The
-    operator-supplied ``$SCITEX_AGENT_CONTAINER_YAML_DIRS`` extension is
-    NOT part of the ambiguous pair — it is always honoured as-is.
+    Scope (``$SAC_AGENT_SCOPE``): ``user`` searches only the fleet,
+    ``project`` only the project-local. When unset, BOTH are returned and
+    :func:`resolve_config` raises :class:`AmbiguousRegistryScope` ONLY for
+    an agent name that resolves in BOTH registries (a real collision) —
+    not merely because both registry dirs exist. The operator-supplied
+    ``$SCITEX_AGENT_CONTAINER_YAML_DIRS`` extension is always honoured.
     """
     home = Path(os.path.expanduser("~"))
     primary = home / ".scitex" / "agent-container" / "agents"
@@ -184,15 +190,13 @@ def _apply_scope(
     * ``SAC_AGENT_SCOPE=project`` → search ONLY project-local; signal
       "skip primary" by returning a sentinel non-existent fleet dir so
       the existing call-site loops never hit it.
-    * unset/auto: if BOTH the project-local registry dir AND the fleet
-      registry dir exist → raise :class:`AmbiguousRegistryScope`. If only
-      one exists (the common case — a fresh CI runner has no
-      ``~/.scitex/agent-container/agents`` fleet dir) → no ambiguity,
-      both are returned untouched and the lone present dir wins silently.
-
-    The "both present" test keys purely on directory existence, NOT on
-    which scope a specific agent name lives in — the operator wants the
-    scope made explicit, not guessed per-name.
+    * unset/auto: return BOTH untouched. The ambiguity check is
+      deferred to :func:`resolve_config`, which raises
+      :class:`AmbiguousRegistryScope` ONLY when the SAME agent name
+      resolves in both registries (a real collision) — NOT merely
+      because both registry DIRS exist. So an unrelated project-local
+      registry (e.g. the sac repo's ``sdk-test``/``self`` test fixtures)
+      never blocks a fleet-only agent like ``sac agents start <fleet>``.
     """
     scope = _read_scope()
     if scope == "user":
@@ -205,11 +209,8 @@ def _apply_scope(
         # real fleet dir).
         return _SCOPED_OUT_FLEET, project_local
 
-    # scope unset → fail loud iff BOTH registry dirs are present.
-    project_present = bool(project_local) and project_local[0].is_dir()
-    fleet_present = primary.is_dir()
-    if project_present and fleet_present:
-        raise AmbiguousRegistryScope(project_local[0], primary)
+    # scope unset → return both; per-name ambiguity is decided in
+    # resolve_config (raise only when the requested name is in both).
     return primary, project_local
 
 
@@ -316,12 +317,13 @@ def resolve_config(name_or_path: str) -> str:
     1. ``~/.scitex/agent-container/agents/<name>/spec.yaml`` (sac install root).
     2. ``$SCITEX_AGENT_CONTAINER_YAML_DIRS`` (colon-separated extra dirs, each searched as ``<dir>/<name>/spec.yaml``). Plugin port for downstream orchestrators to inject extra paths without sac knowing about them.
 
-    Scope (``$SAC_AGENT_SCOPE``): if BOTH the project-local registry dir
-    AND the user-scope fleet registry dir exist and the scope is unset,
-    this raises :class:`AmbiguousRegistryScope` instead of silently
-    preferring project-local. ``SAC_AGENT_SCOPE=user`` searches only the
-    fleet; ``=project`` searches only project-local. A single present
-    registry resolves with no error.
+    Scope (``$SAC_AGENT_SCOPE``): if the requested NAME resolves in BOTH a
+    project-local registry AND the fleet and the scope is unset, this
+    raises :class:`AmbiguousRegistryScope` (a real collision) instead of
+    silently preferring project-local. A name present in only one registry
+    resolves with no error, even when both registry dirs exist.
+    ``SAC_AGENT_SCOPE=user`` searches only the fleet; ``=project`` only
+    project-local.
 
     Pass an explicit path (with / or .yaml/.yml) to bypass the search entirely.
     """
@@ -341,14 +343,31 @@ def resolve_config(name_or_path: str) -> str:
     split = len(env_dirs) - len(operator_env_dirs)
     project_local_dirs = env_dirs[:split]
 
-    # Order: project-local → primary (~/.scitex…) → env → fleet.
+    # Per-name scope ambiguity (operator 2026-06-29): raise ONLY when the
+    # SAME agent name resolves in BOTH a project-local registry AND the
+    # fleet, with no explicit $SAC_AGENT_SCOPE. A name present in only ONE
+    # registry resolves with no error even when both registry DIRS exist —
+    # so an unrelated project-local registry (e.g. the sac repo's
+    # sdk-test/self test fixtures) never blocks a fleet-only agent like
+    # `sac agents start <fleet-agent>`. When it IS a real collision, the
+    # message lets the operator pick (=project for this repo's local one,
+    # =user for the fleet).
+    proj_hit = None
     for d in project_local_dirs:
-        hit = _try_dir(d, name_or_path)
-        if hit:
-            return hit
-    hit = _try_dir(primary, name_or_path)
-    if hit:
-        return hit
+        proj_hit = _try_dir(d, name_or_path)
+        if proj_hit:
+            break
+    fleet_hit = _try_dir(primary, name_or_path)
+    if proj_hit and fleet_hit and _read_scope() is None:
+        raise AmbiguousRegistryScope(
+            Path(proj_hit).parent.parent, primary, name=name_or_path
+        )
+
+    # Resolution order: project-local → primary (~/.scitex…) → env → fleet.
+    if proj_hit:
+        return proj_hit
+    if fleet_hit:
+        return fleet_hit
     for d in operator_env_dirs:
         hit = _try_dir(d, name_or_path)
         if hit:

--- a/tests/scitex_agent_container/config/test__resolve_scope.py
+++ b/tests/scitex_agent_container/config/test__resolve_scope.py
@@ -3,10 +3,12 @@
 The resolver checked the project-local registry FIRST, so a fleet-management
 op run from inside a repo that ships its own ``.scitex/agent-container/agents/``
 would SILENTLY resolve the project-local registry and never see the user-scope
-fleet (the "sac-from-sac" breakage). The fix: when BOTH registry dirs exist and
-``$SAC_AGENT_SCOPE`` is unset → raise ``AmbiguousRegistryScope``. Explicit
-``user`` / ``project`` disambiguate; a single present registry resolves
-silently (CI-safe — a fresh runner has no fleet dir).
+fleet (the "sac-from-sac" breakage). The fix (per-name, operator 2026-06-29):
+``resolve_config`` raises ``AmbiguousRegistryScope`` ONLY when the requested
+NAME resolves in BOTH registries (a real collision). A name in only one
+registry resolves with no error, even when both registry DIRS exist — so an
+unrelated project-local registry (the sac repo's test fixtures) never blocks a
+fleet-only agent. Explicit ``user`` / ``project`` disambiguate.
 
 No mocks: env vars go through a snapshot/restore bag, cwd through a real
 ``os.chdir`` bag, and project-local discovery is driven by chdir-ing into a
@@ -235,13 +237,47 @@ def test_unknown_scope_value_treated_as_unset_and_raises(both_registries, env_ba
         resolve_config("dup")
 
 
-def test_enumerate_agent_names_raises_on_ambiguity(both_registries):
-    # Arrange — same rule applies to enumeration, not just resolution.
-    raises_ctx = pytest.raises(AmbiguousRegistryScope)
+def test_enumerate_agent_names_lists_both_when_unset(both_registries):
+    # Arrange — enumeration does NOT raise on the per-name rule; it unions
+    # both registries (a name present in both is deduped). Only
+    # resolve_config of a genuinely COLLIDING name fails loud.
     # Act
+    names = enumerate_agent_names()
     # Assert
-    with raises_ctx:
-        enumerate_agent_names()
+    assert "dup" in names
+
+
+def test_ambiguous_error_names_the_colliding_agent(ambiguous_scope_message):
+    # Arrange
+    msg, _paths = ambiguous_scope_message
+    # Act
+    contained = "dup" in msg
+    # Assert
+    assert contained
+
+
+def test_fleet_only_name_resolves_despite_project_local_registry(both_registries):
+    # Arrange — both registry DIRS exist, but this name is ONLY in the
+    # fleet (the operator's real case: `sac agents start <fleet-agent>`
+    # from inside the sac repo, whose project-local registry holds
+    # unrelated fixtures). Must resolve, NOT raise.
+    fleet = both_registries["fleet"]
+    hit = _write(fleet / "fleet-solo" / "spec.yaml", "fleet")
+    # Act
+    result = resolve_config("fleet-solo")
+    # Assert
+    assert result == str(hit)
+
+
+def test_project_only_name_resolves_despite_fleet_registry(both_registries):
+    # Arrange — both registry DIRS exist, but this name is ONLY in the
+    # project-local registry → resolve it (project-local default), no raise.
+    project = both_registries["project"]
+    hit = _write(project / "proj-solo" / "spec.yaml", "project")
+    # Act
+    result = resolve_config("proj-solo")
+    # Assert
+    assert result == str(hit)
 
 
 def test_enumerate_agent_names_scope_user_lists_only_fleet(


### PR DESCRIPTION
## Problem
`sac agents start <fleet-agent>` run from inside the sac repo failed with `AmbiguousRegistryScope` — because the repo ships a tiny test-fixture registry (`.scitex/agent-container/agents/` = `sdk-test` + `self`), and the previous guard raised whenever **both registry directories existed**, regardless of whether the requested agent actually collided. So a fleet-only agent (`scitex-seizure-metrics`) was blocked by unrelated fixtures.

## Fix (operator-directed, per-name)
`resolve_config` now raises `AmbiguousRegistryScope` **only when the requested NAME resolves in both** the project-local registry and the fleet (a real collision). A name present in only one registry resolves cleanly, even when both registry dirs exist. `_apply_scope` no longer raises on mere dir-existence; the explicit `SAC_AGENT_SCOPE=user|project` overrides are unchanged. The error message now names the colliding agent and offers project-local (in-repo default) vs fleet.

## Test plan
- [x] `test__resolve_scope.py`: collision-name still raises; **new** — fleet-only name resolves despite a project-local registry; project-only name resolves; enumerate unions both (no raise); error names the agent; scope=user/project unchanged.
- [x] Re-ran the listen-server tests that the previous (dir-existence) guard broke — all green.
- [x] 66 passed locally.