### PR TITLE
feat(listen): restart a peer agent from inside a container via host listen

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_restart_client.py
+++ b/src/scitex_agent_container/_lifecycle/_restart_client.py
@@ -1,0 +1,295 @@
+"""In-container HTTP client for the host-side restart-proxy endpoint.
+
+The restart sibling of :mod:`._spawn_client`. Lets an agent running
+INSIDE an apptainer container ask the host's ``sac listen`` to restart
+a peer agent on the bare host. ``sac agents restart <name>`` resolves
+a peer by its LOCAL registry row + local ``state.db`` — from inside a
+SIF that lookup fails ("Agent not found in registry"), so the restart
+must be brokered to the host the same way spawn is.
+
+Transport contract
+------------------
+
+Endpoint: ``POST {SAC_LISTEN_BASE_URL}/agents/{name}/restart``.
+
+Auth: ``Authorization: Bearer {SAC_LISTEN_BEARER}`` — same credential
+the spawn bypass uses (env-injected by the apptainer runtime, with a
+fallback to the on-disk host token file). Missing
+``SAC_LISTEN_BASE_URL`` raises :class:`RestartRequestError` (fail loud
+— there is no useful default).
+
+Body::
+
+    {"caller": "<requesting-agent>"}   # auto-resolved from SAC_NAME
+
+The server's ``agent_restart`` handler runs
+:func:`._listen._acl.check_lineage_acl` (the MANAGE gate) BEFORE any
+runtime work. On allow it shells ``sac agents restart <name> --yes
+--json`` on the bare host. On deny it returns 403 with an ACL reason;
+we surface that verbatim as :class:`RestartRequestError` (status=403)
+so the caller fails LOUD rather than swallowing the deny.
+
+Stdlib-only on purpose — mirrors :mod:`._spawn_client`: ``urllib``
+(no ``httpx``) + an injectable ``opener`` callable for tests.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Callable
+from urllib import error as urlerror
+from urllib import request as urlrequest
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["RestartRequestError", "request_restart"]
+
+_DEFAULT_TIMEOUT_S = 60.0
+
+
+class RestartRequestError(RuntimeError):
+    """Raised when the host-side restart POST cannot be completed.
+
+    Carries the structured failure info (``status`` + ``body``) so the
+    caller (CLI / MCP tool / log line) can show *why* the restart failed
+    without re-parsing a free-text message. Mirrors
+    :class:`._spawn_client.SpawnRequestError`:
+
+    * a 403 ACL deny is an ERROR — never silently swallowed; the
+      server's reason is forwarded verbatim in ``body``,
+    * a transport error (host listen unreachable) is an ERROR — never
+      converted to "ok with empty result",
+    * a missing ``SAC_LISTEN_BASE_URL`` is an ERROR — the container is
+      misconfigured.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status: int | None = None,
+        body: Any = None,
+    ) -> None:
+        super().__init__(message)
+        self.status = status
+        self.body = body
+
+
+def _resolve_base_url(explicit: str | None) -> str:
+    """Return the listen-server base URL or raise loudly.
+
+    Resolution order: explicit argument → ``SAC_LISTEN_BASE_URL`` (via
+    :func:`_env.getenv` so the long-form alias also works). Trailing
+    slash is stripped so callers can safely concatenate the path.
+    """
+    if explicit:
+        return explicit.rstrip("/")
+    from .._env import getenv
+
+    raw = (getenv("LISTEN_BASE_URL", "") or "").strip()
+    if not raw:
+        raise RestartRequestError(
+            "restart request requires SAC_LISTEN_BASE_URL (the host-stable "
+            "`sac listen` URL injected into the container by the apptainer "
+            "runtime). Got empty/unset."
+        )
+    return raw.rstrip("/")
+
+
+def _resolve_bearer(explicit: str | None) -> str | None:
+    """Return the listen-server bearer token, or ``None`` if unset.
+
+    Identical resolution to :func:`._spawn_client._resolve_bearer`:
+    explicit arg → ``SAC_LISTEN_BEARER`` env → the on-disk host token
+    file. An absent bearer is NOT fatal (the listen may run with bearer
+    auth disabled); the server enforces its own auth contract.
+    """
+    if explicit is not None:
+        return explicit or None
+    from .._env import getenv
+
+    tok = (getenv("LISTEN_BEARER", "") or "").strip()
+    if tok:
+        return tok
+    from .._listen.tokens import default_token_path, read_token
+
+    return read_token(default_token_path())
+
+
+def _resolve_caller(explicit: str | None) -> str | None:
+    """Return the requesting agent's identity, or ``None`` for admin.
+
+    Reuses the spawn caller rule: read ``SAC_NAME`` from the container
+    env (via :func:`._spawn_gate.resolve_spawn_caller`). An empty string
+    normalises to ``None`` (administrative / operator path).
+    """
+    if explicit is not None:
+        return explicit or None
+    from ._spawn_gate import resolve_spawn_caller
+
+    return resolve_spawn_caller()
+
+
+def _parse_body(raw: bytes) -> Any:
+    """Return JSON-parsed body or raw text fallback."""
+    if not raw:
+        return None
+    try:
+        return json.loads(raw)
+    except ValueError:
+        # stx-allow: fallback (reason: non-JSON body surfaced verbatim to
+        # the caller via RestartRequestError.body — never silently dropped
+        # or converted into a fake success).
+        return raw.decode("utf-8", errors="replace")
+
+
+def _http_error_message(name: str, status: int, parsed: Any) -> str:
+    """Build a status-aware error message for a non-2xx listen response.
+
+    A 401/403 means the request REACHED the listen but was refused on
+    credentials/ACL — surface that explicitly so the operator fixes the
+    token or the manage authority, not "cannot reach / timed out".
+    """
+    if status == 401:
+        return (
+            f"restart of {name!r} rejected: listen returned HTTP 401 "
+            f"(auth/bearer) — the restart POST reached the host listen but "
+            f"the bearer token was missing or invalid. Ensure "
+            f"SAC_LISTEN_BEARER is injected, or that the host token file is "
+            f"readable from inside the container. Server said: {parsed!r}"
+        )
+    if status == 403:
+        return (
+            f"restart of {name!r} rejected: listen returned HTTP 403 "
+            f"(auth/acl) — the bearer authenticated but the listen's "
+            f"check_lineage_acl MANAGE gate denied this caller. Server "
+            f"said: {parsed!r}"
+        )
+    return (
+        f"restart of {name!r} rejected: listen returned HTTP "
+        f"{status} ({parsed!r})"
+    )
+
+
+def request_restart(
+    name: str,
+    *,
+    caller: str | None = None,
+    base_url: str | None = None,
+    bearer: str | None = None,
+    timeout_s: float = _DEFAULT_TIMEOUT_S,
+    opener: Callable | None = None,
+) -> dict:
+    """POST a restart request to the host listen server; FAIL LOUD on error.
+
+    Parameters
+    ----------
+    name
+        The agent to restart (must be registered / resolvable on the
+        host — the restart runs on the bare host where its row lives).
+    caller
+        The requesting agent's identity for the listen-server's
+        ``check_lineage_acl`` MANAGE gate. Defaults to ``SAC_NAME`` from
+        the container env via :func:`_resolve_caller`.
+    base_url
+        Override ``SAC_LISTEN_BASE_URL``. Tests pass an in-process
+        listen URL; production passes ``None``.
+    bearer
+        Override ``SAC_LISTEN_BEARER``. Tests pass an explicit value or
+        ``""`` to force the unauthenticated branch.
+    timeout_s
+        Per-request HTTP timeout (seconds). Defaults to 60 — a restart
+        does a stop + settle + start on the host, longer than a spawn.
+    opener
+        Optional ``urllib.request.urlopen``-shaped callable for tests.
+
+    Returns
+    -------
+    dict
+        The server's parsed JSON body on 2xx — the ``agent_restart``
+        handler returns ``{name, returncode, stdout, stderr}``.
+
+    Raises
+    ------
+    RestartRequestError
+        On missing base URL, transport failure, non-2xx HTTP status
+        (including 403 ACL deny), or a malformed (non-object) body.
+    """
+    if not isinstance(name, str) or not name:
+        raise RestartRequestError("name must be a non-empty string")
+
+    base = _resolve_base_url(base_url)
+    tok = _resolve_bearer(bearer)
+    resolved_caller = _resolve_caller(caller)
+
+    body: dict[str, Any] = {}
+    if resolved_caller:
+        body["caller"] = resolved_caller
+
+    payload = json.dumps(body).encode("utf-8")
+    url = f"{base}/agents/{name}/restart"
+    headers = {"Content-Type": "application/json", "Accept": "application/json"}
+    if tok:
+        headers["Authorization"] = f"Bearer {tok}"
+
+    req = urlrequest.Request(url, data=payload, method="POST", headers=headers)
+    opener_fn = opener if opener is not None else urlrequest.urlopen
+
+    try:
+        with opener_fn(req, timeout=timeout_s) as resp:
+            raw = resp.read()
+            status = int(getattr(resp, "status", 200))
+    except urlerror.HTTPError as exc:
+        # A real HTTP response arrived — the listen is REACHABLE. Read the
+        # body so the caller sees the server's reason verbatim (the ACL
+        # deny / auth error carry it).
+        raw_body = b""
+        try:
+            raw_body = exc.read() or b""
+        except Exception:  # stx-allow: defensive — body read on a half-closed HTTPError stream may itself fail; we already have status + URL.  # noqa: BLE001
+            pass
+        parsed = _parse_body(raw_body)
+        logger.warning(
+            "restart_client: POST %s returned HTTP %s body=%r",
+            url,
+            exc.code,
+            parsed,
+        )
+        raise RestartRequestError(
+            _http_error_message(name, exc.code, parsed),
+            status=exc.code,
+            body=parsed,
+        ) from exc
+    except (urlerror.URLError, OSError, ValueError) as exc:
+        # No HTTP exchange happened — connection refused / DNS / timeout.
+        # A 401/403 is NOT routed here (HTTPError is caught above first),
+        # so an authenticated-but-rejected request never gets misreported
+        # as 'cannot reach / timed out'.
+        logger.warning("restart_client: POST %s transport error: %s", url, exc)
+        raise RestartRequestError(
+            f"restart of {name!r} failed: cannot reach listen at {base!r} ({exc})"
+        ) from exc
+
+    parsed = _parse_body(raw)
+    if status < 200 or status >= 300:
+        logger.warning(
+            "restart_client: POST %s returned HTTP %s body=%r",
+            url,
+            status,
+            parsed,
+        )
+        raise RestartRequestError(
+            _http_error_message(name, status, parsed),
+            status=status,
+            body=parsed,
+        )
+
+    if not isinstance(parsed, dict):
+        raise RestartRequestError(
+            f"restart of {name!r} succeeded transport-wise but the listen "
+            f"response was not a JSON object: {parsed!r}",
+            status=status,
+            body=parsed,
+        )
+    return parsed

--- a/src/scitex_agent_container/_listen/_acl.py
+++ b/src/scitex_agent_container/_listen/_acl.py
@@ -91,6 +91,13 @@ def check_lineage_acl(
         :func:`_state.state_db_nodes.is_developer`.
       * ``target ∈ descendants_of(caller)`` — caller is a
         transitive ancestor; lineage-scoped operation permitted.
+      * ``groups_mesh(caller, target)`` (operator 2026-06-29
+        "agents manage agents") — caller and target BOTH resolve
+        into the standard fleet mesh (developer / researcher /
+        generalist). Manage authority is granted across these
+        groups with no lineage edge and no per-pair grant, exactly
+        as :func:`check_send_acl` meshes sends. A non-mesh group
+        (isolated solver) stays unmanageable cross-group.
       * Otherwise — deny with a structured reason naming the
         caller, the target, and the fact that no lineage edge
         connects them.
@@ -120,14 +127,31 @@ def check_lineage_acl(
     descendants = descendants_of(name=caller, db_path=db_path)
     if target in descendants:
         return ("allow", None)
+    # Standard-fleet manage mesh (operator 2026-06-29: "agents manage
+    # agents"). This BROADENS manage authority beyond lineage: a caller
+    # may also manage (stop / restart / delete / status / tail) a target
+    # when BOTH resolve into the standard group mesh (developer /
+    # researcher / generalist) — exactly the cross-group predicate
+    # ``check_send_acl`` uses for sends. So a researcher (e.g. neurovista)
+    # may restart a developer peer (e.g. scitex-todo) with no lineage edge
+    # and no per-pair grant. A non-mesh group (e.g. an isolated solver)
+    # is NOT meshed and stays unmanageable cross-group, preserving the
+    # solid isolation scientific rigor requires.
+    if groups_mesh(
+        resolve_group_name(name=caller, db_path=db_path),
+        resolve_group_name(name=target, db_path=db_path),
+    ):
+        return ("allow", None)
     return (
         "deny",
         (
             f"lineage ACL deny: caller {caller!r} has no lineage edge "
             f"to target {target!r}. Permitted operations are self "
             "(caller == target), any transitive descendant via the "
-            "lineage table, or any target when the caller is in the "
-            "developer group."
+            "lineage table, any target when the caller is in the "
+            "developer group, or any target when caller and target "
+            "both belong to the standard fleet mesh (developer / "
+            "researcher / generalist)."
         ),
     )
 

--- a/src/scitex_agent_container/_listen/_agent_restart.py
+++ b/src/scitex_agent_container/_listen/_agent_restart.py
@@ -1,0 +1,130 @@
+"""``POST /agents/<name>/restart`` handler for ``sac listen``.
+
+The container-side mirror of the spawn bypass (:mod:`._agent_exec`
+``agents_start``), but for the *restart* lifecycle verb: an agent
+running INSIDE a SIF cannot resolve a peer's LOCAL registry row +
+local ``state.db`` (``sac agents restart`` hard-fails with "not found
+in registry" from inside the container). This handler lets the
+container ask the HOST listen to run the restart on the bare host —
+where the registry row, the agent's runtime dir, and that node's
+``sac listen`` token actually live.
+
+Shape mirrors ``agents_start`` exactly:
+
+  * resolve the caller identity from ``request.state.authenticated_node``
+    (the per-node bearer resolved by :class:`._acl.NodeAuthMiddleware`)
+    with a body-``caller`` fallback for the host-bearer / admin path,
+  * run :func:`._acl.check_lineage_acl` (the MANAGE gate — self /
+    lineage-descendant / developer-group / standard-fleet mesh) BEFORE
+    any runtime work; deny → 403 with the ACL reason verbatim,
+  * on allow, shell the canonical ``sac agents restart <name> --yes
+    --json`` on the bare host (same host-shell path ``agents_start``
+    uses for ``sac agents start``) and return its rc + stdout + stderr
+    as JSON. A non-zero rc is surfaced as 502 (the gate passed but the
+    bare-host restart itself failed), never swallowed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import shutil
+
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+from ._acl import check_lineage_acl, deny_response
+
+__all__ = ["agent_restart"]
+
+
+async def agent_restart(request: Request) -> JSONResponse:
+    """POST /agents/<name>/restart — restart the named agent on the host.
+
+    The container-side mirror of the spawn bypass: the in-SIF
+    :mod:`._lifecycle._restart_client` POSTs here so the restart runs
+    on the bare host (where the registry row + runtime dir live)
+    instead of failing "not found in registry" inside the container.
+
+    Identity + ACL (mirrors ``agents_start`` / ``agent_delete``):
+
+      * ``request.state.authenticated_node`` is the resolved per-node
+        identity from :class:`._acl.NodeAuthMiddleware`; ``None`` is
+        the host-wide bearer (administrative / operator path — always
+        allowed by :func:`check_lineage_acl`).
+      * When the host-wide bearer is used, an optional body ``caller``
+        field carries the requesting node's name (same self-claimed
+        caveat as ``agents_start``'s ``caller``) so the manage gate can
+        still apply the standard-fleet mesh for an admin-forwarded
+        request. A per-node bearer always wins over the body claim.
+      * :func:`check_lineage_acl` is the MANAGE gate: self /
+        lineage-descendant / developer-group / standard-fleet mesh.
+        Deny → 403 + ``{"error","kind":"acl_deny","reason"}``.
+
+    On allow, shell ``sac agents restart <name> --yes --json`` on the
+    bare host and return its rc + stdout + stderr. rc != 0 → 502.
+    """
+    name = request.path_params["name"]
+
+    # Body is optional (the client may POST an empty body when it relies
+    # on a per-node bearer for identity). A malformed body is tolerated:
+    # the per-node bearer is the authoritative identity source.
+    try:
+        body = await request.json()
+    except Exception:  # stx-allow: fallback (reason: empty/malformed body → no caller claim; identity falls back to the per-node bearer below)
+        body = {}
+    if not isinstance(body, dict):
+        body = {}
+    claimed_caller = body.get("caller")
+    if claimed_caller is not None and not isinstance(claimed_caller, str):
+        return JSONResponse(
+            {"error": "'caller' must be a string if present"}, status_code=400
+        )
+
+    # Resolve the effective caller for the MANAGE gate. A per-node bearer
+    # (authenticated_node) is the authoritative, unspoofable identity; the
+    # body ``caller`` claim is only consulted on the host-wide bearer path
+    # (authenticated_node is None) so an administrative forwarder can name
+    # the on-behalf-of node for the standard-fleet mesh.
+    authenticated = getattr(request.state, "authenticated_node", None)
+    caller = authenticated if authenticated is not None else claimed_caller
+
+    decision, reason = check_lineage_acl(caller=caller, target=name)
+    if decision == "deny":
+        return deny_response(reason or "lineage ACL deny")
+
+    sac_bin = shutil.which("sac") or "sac"
+    # ``agents`` (plural) is the canonical group; ``--yes`` skips the
+    # interactive guard (this POST IS the confirmation) and ``--json``
+    # gives a parseable envelope — exactly the argv ``agent_restart`` MCP
+    # tool + cross-host dispatch already run. Strip the in-SIF env markers
+    # so a listen running inside a parent SIF doesn't re-broker the child
+    # restart back to itself (same recursion guard as ``agents_start``).
+    child_env = dict(os.environ)
+    child_env.pop("APPTAINER_CONTAINER", None)
+    child_env.pop("SINGULARITY_CONTAINER", None)
+    inner_argv = [sac_bin, "agents", "restart", name, "--yes", "--json"]
+
+    proc = await asyncio.create_subprocess_exec(
+        *inner_argv,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        env=child_env,
+    )
+    out, err = await proc.communicate()
+    stdout = out.decode("utf-8", errors="replace") if out else ""
+    stderr = err.decode("utf-8", errors="replace") if err else ""
+    returncode = proc.returncode if proc.returncode is not None else -1
+
+    payload = {
+        "name": name,
+        "returncode": returncode,
+        "stdout": stdout,
+        "stderr": stderr,
+    }
+    if returncode != 0:
+        # The gate passed but the bare-host restart itself failed (e.g.
+        # the agent has no registry row AND no resolvable spec). Surface
+        # it as 502 with the rc + stderr — never a fake success.
+        return JSONResponse(payload, status_code=502)
+    return JSONResponse(payload, status_code=200)

--- a/src/scitex_agent_container/_listen/server.py
+++ b/src/scitex_agent_container/_listen/server.py
@@ -346,6 +346,13 @@ from ._node_channel import (  # noqa: E402
 # path keep working unchanged.
 from ._agent_delete import agent_delete  # noqa: E402
 
+# ``agent_restart`` (POST /agents/<name>/restart) is the container-side
+# mirror of the spawn bypass: an in-SIF agent cannot resolve a peer's
+# LOCAL registry row, so it POSTs here and the HOST listen runs the
+# restart on the bare host (manage-gated by check_lineage_acl). Lives in
+# its own module to keep server.py under the per-file line cap.
+from ._agent_restart import agent_restart  # noqa: E402
+
 
 # --- App factory -----------------------------------------------------------
 
@@ -363,6 +370,7 @@ def _v1_agent_routes(prefix: str) -> list[Route]:
         Route(f"{prefix}/{{name}}/status", agent_status, methods=["GET"]),
         Route(f"{prefix}/{{name}}/tail", agent_tail, methods=["GET"]),
         Route(f"{prefix}/{{name}}/send", agent_send, methods=["POST"]),
+        Route(f"{prefix}/{{name}}/restart", agent_restart, methods=["POST"]),
         # WI-3 — node-identity-keyed inbox endpoints.
         Route(
             f"{prefix}/{{name}}/message:send",

--- a/src/scitex_agent_container/_mcp/_tools/_agent.py
+++ b/src/scitex_agent_container/_mcp/_tools/_agent.py
@@ -221,6 +221,16 @@ def agent_restart(name: str) -> dict[str, Any]:
     failed with "Refusing to restart ... without --yes/-y." (no-surprise:
     the documented MCP surface must actually work, not dead-end on an
     interactive guard that can never be satisfied over MCP).
+
+    Host bypass (operator 2026-06-29 "agents manage agents"): when this
+    tool runs INSIDE a container, the target peer's registry row lives on
+    the bare host and is unresolvable locally — the underlying CLI then
+    falls back to brokering the restart to the HOST listen
+    (``POST {SAC_LISTEN_BASE_URL}/agents/<name>/restart``, manage-gated by
+    ``check_lineage_acl``), exactly like ``agent_spawn`` brokers a spawn.
+    The fallback is transparent here: the CLI runs it internally so this
+    tool needs no extra wiring; on a bare host (row resolvable) the local
+    path runs unchanged.
     """
     return invoke_cli_text(["agents", "restart", name, "--yes"])
 

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_restart.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_restart.py
@@ -95,6 +95,45 @@ def _dispatch_remote_restart(peer: str, row: dict, peers: dict, name: str) -> di
     return envelope if isinstance(envelope, dict) else {}
 
 
+def _should_try_host_bypass(exc: Exception) -> bool:
+    """Return True iff a LOCAL restart failure should fall back to the host.
+
+    The fallback fires only when BOTH hold:
+
+      * the failure is the "not found in registry" local-resolution miss
+        (an in-SIF agent cannot see a peer's bare-host registry row), and
+      * ``SAC_LISTEN_BASE_URL`` is set (we are a container with the host
+        listen reachable — the spawn bypass's precondition).
+
+    Any other RuntimeError (a real restart fault on a resolvable agent)
+    propagates unchanged so the bare-host operator path is untouched.
+    """
+    from ..._lifecycle._restart_client import RestartRequestError, _resolve_base_url
+
+    if "not found in registry" not in str(exc):
+        return False
+    try:
+        _resolve_base_url(None)
+    except RestartRequestError:
+        return False
+    return True
+
+
+def _restart_via_host_bypass(name: str) -> dict:
+    """Broker the restart to the HOST listen and return its JSON envelope.
+
+    Mirrors the spawn bypass (``agent_spawn`` → ``request_spawn``): the
+    in-SIF client POSTs to ``{SAC_LISTEN_BASE_URL}/agents/<name>/restart``
+    and the host runs ``sac agents restart <name> --yes`` on the bare
+    host (manage-gated by ``check_lineage_acl``). A
+    :class:`RestartRequestError` (transport / 401 / 403 / 5xx) propagates
+    so the CLI's outer ``except`` surfaces it fail-loud.
+    """
+    from ..._lifecycle._restart_client import request_restart
+
+    return request_restart(name)
+
+
 @click.command()
 @click.argument("name", shell_complete=agent_name_complete)
 @click.option(
@@ -180,7 +219,38 @@ def restart(name: str, dry_run: bool, yes: bool, as_json: bool) -> None:
             return
 
         # Local restart (row on this host, or no row — spec fallback).
-        agent_restart(name)
+        # When that LOCAL resolution fails (no registry row AND no
+        # resolvable spec) AND we are inside a container with the host
+        # listen reachable (SAC_LISTEN_BASE_URL injected), broker the
+        # restart to the HOST listen — exactly like the spawn bypass.
+        # This is what lets an in-SIF agent restart a peer whose registry
+        # row lives on the bare host (it is unresolvable from inside the
+        # container). The bare-host operator keeps the local path (the row
+        # IS resolvable there, so the bypass never fires).
+        try:
+            agent_restart(name)
+        except RuntimeError as exc:
+            if not _should_try_host_bypass(exc):
+                raise
+            envelope = _restart_via_host_bypass(name)
+            if as_json:
+                click.echo(
+                    _json.dumps(
+                        {
+                            "name": name,
+                            "restarted": envelope.get("returncode") == 0,
+                            "dispatched": False,
+                            "via": "host-listen",
+                            "host_response": envelope,
+                        }
+                    )
+                )
+            else:
+                console.print(
+                    f"[green]Agent '{name}' restarted via host listen[/green]"
+                )
+                console.print(_json.dumps(envelope))
+            return
         if as_json:
             click.echo(
                 _json.dumps({"name": name, "restarted": True, "dispatched": False})

--- a/tests/scitex_agent_container/_lifecycle/test__restart_client.py
+++ b/tests/scitex_agent_container/_lifecycle/test__restart_client.py
@@ -1,0 +1,332 @@
+"""Tests for the in-container restart-proxy HTTP client.
+
+The restart sibling of :mod:`test__spawn_client`. Same no-mocks
+pattern: the production module exposes an injectable ``opener`` callable
+that defaults to ``urllib.request.urlopen``; tests pass a hand-rolled
+opener returning a ``urllib.response``-shaped object. No
+``monkeypatch.setattr`` on production internals.
+
+Each test: AAA markers (TQ002), one assertion (TQ007), 3+-word name.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+from typing import Iterator
+from urllib import error as urlerror
+
+import pytest
+
+from scitex_agent_container._lifecycle._restart_client import (
+    RestartRequestError,
+    request_restart,
+)
+
+
+class _FakeResp:
+    """A real callable response object matching the urllib contract."""
+
+    def __init__(self, body: bytes, status: int = 200) -> None:
+        self._body = body
+        self.status = status
+
+    def __enter__(self) -> "_FakeResp":
+        return self
+
+    def __exit__(self, *args: object) -> bool:
+        return False
+
+    def read(self) -> bytes:
+        return self._body
+
+
+def _opener_returning(body: bytes, status: int = 200):
+    """Build (opener, captured) — the opener records each call."""
+    captured: dict = {}
+
+    def opener(req, timeout=None):
+        captured["url"] = req.full_url
+        captured["method"] = req.get_method()
+        captured["body"] = req.data
+        captured["headers"] = {k.lower(): v for k, v in dict(req.headers).items()}
+        captured["timeout"] = timeout
+        return _FakeResp(body, status)
+
+    return opener, captured
+
+
+def _opener_raising(exc: Exception):
+    def opener(req, timeout=None):
+        raise exc
+
+    return opener
+
+
+_LISTEN_KEYS = (
+    "SAC_LISTEN_BASE_URL",
+    "SCITEX_AGENT_CONTAINER_LISTEN_BASE_URL",
+    "SAC_LISTEN_BEARER",
+    "SCITEX_AGENT_CONTAINER_LISTEN_BEARER",
+    "SAC_NAME",
+    "SCITEX_AGENT_CONTAINER_NAME",
+)
+
+
+@pytest.fixture
+def listen_env(tmp_path) -> Iterator[callable]:
+    """Yield a setter; clears + restores both prefixes for every key.
+
+    HOME is redirected to a clean ``tmp_path`` so the bearer file
+    fallback reads from an isolated, empty tokens dir.
+    """
+    saved = {k: os.environ.get(k) for k in _LISTEN_KEYS}
+    saved_home = os.environ.get("HOME")
+    for k in _LISTEN_KEYS:
+        os.environ.pop(k, None)
+    os.environ["HOME"] = str(tmp_path)
+
+    def _set(suffix: str, value: str | None) -> None:
+        long_form = f"SCITEX_AGENT_CONTAINER_{suffix}"
+        short_form = f"SAC_{suffix}"
+        os.environ.pop(long_form, None)
+        if value is None:
+            os.environ.pop(short_form, None)
+        else:
+            os.environ[short_form] = value
+
+    try:
+        yield _set
+    finally:
+        for k in _LISTEN_KEYS:
+            os.environ.pop(k, None)
+        for k, prev in saved.items():
+            if prev is not None:
+                os.environ[k] = prev
+        if saved_home is not None:
+            os.environ["HOME"] = saved_home
+        else:
+            os.environ.pop("HOME", None)
+
+
+# ---------------------------------------------------------------------------
+# Missing base URL — fail loud
+# ---------------------------------------------------------------------------
+
+
+def test_missing_base_url_raises_restart_request_error(listen_env) -> None:
+    # Arrange — listen_env yields with both base-url envs cleared.
+    captured_message = ""
+    # Act
+    try:
+        request_restart("peer", opener=lambda req, timeout=None: None)
+    except RestartRequestError as exc:
+        captured_message = str(exc)
+    # Assert
+    assert "SAC_LISTEN_BASE_URL" in captured_message
+
+
+def test_empty_name_raises_restart_request_error(listen_env) -> None:
+    # Arrange
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    raised = False
+    # Act
+    try:
+        request_restart("", opener=lambda req, timeout=None: None)
+    except RestartRequestError:
+        raised = True
+    # Assert
+    assert raised is True
+
+
+# ---------------------------------------------------------------------------
+# Happy path — POST shape
+# ---------------------------------------------------------------------------
+
+
+def test_post_targets_restart_route_on_base_url(listen_env) -> None:
+    # Arrange — trailing slash on the base URL must be stripped.
+    listen_env("LISTEN_BASE_URL", "http://host:9100/")
+    opener, captured = _opener_returning(b'{"name":"peer","returncode":0}')
+    # Act
+    request_restart("peer", opener=opener)
+    # Assert
+    assert captured["url"] == "http://host:9100/agents/peer/restart"
+
+
+def test_post_uses_http_post_method(listen_env) -> None:
+    # Arrange
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    opener, captured = _opener_returning(b'{"name":"peer","returncode":0}')
+    # Act
+    request_restart("peer", opener=opener)
+    # Assert
+    assert captured["method"] == "POST"
+
+
+def test_post_body_defaults_caller_from_sac_name_env(listen_env) -> None:
+    # Arrange — SAC_NAME present → resolved as caller automatically.
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    listen_env("NAME", "neurovista")
+    opener, captured = _opener_returning(b'{"name":"peer","returncode":0}')
+    # Act
+    request_restart("peer", opener=opener)
+    # Assert
+    assert json.loads(captured["body"])["caller"] == "neurovista"
+
+
+def test_post_body_omits_caller_for_admin_path(listen_env) -> None:
+    # Arrange — no SAC_NAME → admin path; the field is omitted entirely.
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    opener, captured = _opener_returning(b'{"name":"peer","returncode":0}')
+    # Act
+    request_restart("peer", opener=opener)
+    # Assert
+    assert "caller" not in json.loads(captured["body"])
+
+
+def test_explicit_caller_arg_overrides_sac_name_env(listen_env) -> None:
+    # Arrange
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    listen_env("NAME", "env-caller")
+    opener, captured = _opener_returning(b'{"name":"peer","returncode":0}')
+    # Act
+    request_restart("peer", caller="arg-caller", opener=opener)
+    # Assert
+    assert json.loads(captured["body"])["caller"] == "arg-caller"
+
+
+def test_bearer_token_attached_as_authorization_header(listen_env) -> None:
+    # Arrange
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    listen_env("LISTEN_BEARER", "tok-abc")
+    opener, captured = _opener_returning(b'{"name":"peer","returncode":0}')
+    # Act
+    request_restart("peer", opener=opener)
+    # Assert
+    assert captured["headers"].get("authorization") == "Bearer tok-abc"
+
+
+def test_no_authorization_header_when_bearer_unset(listen_env) -> None:
+    # Arrange — no bearer in env, none passed, no on-disk token file.
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    opener, captured = _opener_returning(b'{"name":"peer","returncode":0}')
+    # Act
+    request_restart("peer", opener=opener)
+    # Assert
+    assert "authorization" not in captured["headers"]
+
+
+def test_success_returns_parsed_response_dict(listen_env) -> None:
+    # Arrange
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    body = json.dumps(
+        {"name": "peer", "returncode": 0, "stdout": "ok", "stderr": ""}
+    ).encode()
+    opener, _ = _opener_returning(body)
+    # Act
+    out = request_restart("peer", opener=opener)
+    # Assert
+    assert out["returncode"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Failure modes — fail loud, never swallowed
+# ---------------------------------------------------------------------------
+
+
+def test_acl_403_deny_raises_with_status_403(listen_env) -> None:
+    # Arrange — server returns the ACL deny payload from deny_response().
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    deny_body = json.dumps(
+        {"error": "ACL deny", "reason": "lineage ACL deny: caller has no edge"}
+    ).encode()
+    opener = _opener_raising(
+        urlerror.HTTPError(
+            "http://host:9100/agents/peer/restart",
+            403,
+            "Forbidden",
+            {},
+            io.BytesIO(deny_body),
+        )
+    )
+    captured_status = None
+    # Act
+    try:
+        request_restart("peer", opener=opener)
+    except RestartRequestError as exc:
+        captured_status = exc.status
+    # Assert
+    assert captured_status == 403
+
+
+def test_acl_403_deny_preserves_server_reason_in_body(listen_env) -> None:
+    # Arrange
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    deny_body = json.dumps(
+        {"error": "ACL deny", "reason": "lineage ACL deny"}
+    ).encode()
+    opener = _opener_raising(
+        urlerror.HTTPError(
+            "http://host:9100/agents/peer/restart",
+            403,
+            "Forbidden",
+            {},
+            io.BytesIO(deny_body),
+        )
+    )
+    captured_body = None
+    # Act
+    try:
+        request_restart("peer", opener=opener)
+    except RestartRequestError as exc:
+        captured_body = exc.body
+    # Assert
+    assert captured_body == {"error": "ACL deny", "reason": "lineage ACL deny"}
+
+
+def test_server_500_raises_restart_request_error(listen_env) -> None:
+    # Arrange
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    opener = _opener_raising(
+        urlerror.HTTPError(
+            "http://host:9100/agents/peer/restart", 500, "boom", {}, io.BytesIO(b"")
+        )
+    )
+    captured_status = None
+    # Act
+    try:
+        request_restart("peer", opener=opener)
+    except RestartRequestError as exc:
+        captured_status = exc.status
+    # Assert
+    assert captured_status == 500
+
+
+def test_transport_error_keeps_status_none(listen_env) -> None:
+    # Arrange — listen unreachable (connection refused etc.).
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    opener = _opener_raising(urlerror.URLError("connection refused"))
+    captured_status: object = "UNSET"
+    # Act
+    try:
+        request_restart("peer", opener=opener)
+    except RestartRequestError as exc:
+        captured_status = exc.status
+    # Assert — no HTTP exchange happened, so status stays None.
+    assert captured_status is None
+
+
+def test_non_dict_2xx_body_raises_restart_request_error(listen_env) -> None:
+    # Arrange — server returns a JSON array instead of an object.
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    opener, _ = _opener_returning(b"[1,2,3]", status=200)
+    raised = False
+    # Act
+    try:
+        request_restart("peer", opener=opener)
+    except RestartRequestError:
+        raised = True
+    # Assert
+    assert raised is True

--- a/tests/scitex_agent_container/_listen/test__acl_group.py
+++ b/tests/scitex_agent_container/_listen/test__acl_group.py
@@ -288,3 +288,44 @@ def test_non_developer_cannot_manage_unrelated_agent(db_path: Path) -> None:
     )
     # Assert
     assert decision == "deny"
+
+
+# ---------------------------------------------------------------------------
+# check_lineage_acl — standard-fleet MANAGE mesh (operator 2026-06-29
+# "agents manage agents"). A caller may manage a target when BOTH resolve
+# into the developer / researcher / generalist mesh, with no lineage edge
+# and no per-pair grant. This is what lets a researcher restart a developer
+# peer via the host listen bypass.
+# ---------------------------------------------------------------------------
+
+
+def test_researcher_may_manage_developer_target_via_mesh(db_path: Path) -> None:
+    """Researcher → developer, no lineage, no grant → allow (manage mesh)."""
+    # Arrange — neurovista (researcher) restarts scitex-todo (developer).
+    record_comms_policy(name="neurovista", group_name="researcher", db_path=db_path)
+    record_comms_policy(name="scitex-todo", group_name="developer", db_path=db_path)
+    # Act
+    decision, _reason = check_lineage_acl(
+        caller="neurovista", target="scitex-todo", db_path=db_path
+    )
+    # Assert
+    assert decision == "allow"
+
+
+def test_mesh_caller_cannot_manage_isolated_solver_target(db_path: Path) -> None:
+    """A non-mesh target (isolated solver) stays unmanageable cross-group.
+
+    Uses a RESEARCHER caller (not developer): the developer group has
+    full agent-CRUD authority over ANY target regardless of mesh, so the
+    isolation must be probed by a mesh-but-non-developer caller.
+    """
+    # Arrange — researcher caller, solver target (outside the mesh).
+    record_comms_policy(name="res-1", group_name="researcher", db_path=db_path)
+    record_comms_policy(name="solver-1", group_name="solver", db_path=db_path)
+    record_lineage(child="solver-1", parent="someone-else", db_path=db_path)
+    # Act
+    decision, _reason = check_lineage_acl(
+        caller="res-1", target="solver-1", db_path=db_path
+    )
+    # Assert
+    assert decision == "deny"

--- a/tests/scitex_agent_container/_listen/test_server_restart_route.py
+++ b/tests/scitex_agent_container/_listen/test_server_restart_route.py
@@ -1,0 +1,134 @@
+"""Wired tests for the POST /agents/<name>/restart route ACL gate.
+
+The container-side restart bypass (mirror of the spawn bypass) routes
+through the real Starlette ``TestClient`` + a per-node bearer mapping,
+exactly like :mod:`test_server_lineage_acl` does for DELETE / tail:
+
+  * a non-host-bearer caller with no lineage edge AND no group mesh to
+    ``<name>`` lands on 403 + ``kind="acl_deny"``;
+  * a host-bearer caller (admin) is NOT blocked by the gate (it shells
+    the bare-host restart, which fails to resolve the ghost agent — but
+    the ACL gate is not the failure cause).
+
+These assert the gate is wired on the new route; the host-shell leg
+(``sac agents restart``) is exercised separately by the CLI tests.
+
+No mocks (PA-306); AAA + one assert (PA-307). Node tokens seeded via
+:func:`mint_node_token` (the real persistence path the server reads).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+from starlette.testclient import TestClient
+
+from scitex_agent_container._listen.server import create_app
+from scitex_agent_container._state.state_db_nodes import (
+    mint_node_token,
+    record_comms_policy,
+)
+
+HOST_TOKEN = "test-host-bearer"
+
+
+@pytest.fixture
+def isolated_env(tmp_path: Path, env_save_restore):
+    home = tmp_path / "home"
+    home.mkdir()
+    runtime = tmp_path / "runtime"
+    runtime.mkdir()
+    yaml_dir = home / ".scitex" / "agent-container" / "agents"
+    yaml_dir.mkdir(parents=True, exist_ok=True)
+    state_db_path = tmp_path / "state.db"
+    env_save_restore.set("HOME", str(home))
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_RUNTIME_DIR", str(runtime))
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_YAML_DIRS", str(yaml_dir))
+    env_save_restore.set("SCITEX_AGENT_CONTAINER_STATE_DB", str(state_db_path))
+    import importlib
+
+    import scitex_agent_container._runners._session_state as ss
+
+    importlib.reload(ss)
+    yield tmp_path
+    os.environ.pop("SCITEX_AGENT_CONTAINER_RUNTIME_DIR", None)
+    os.environ.pop("SCITEX_AGENT_CONTAINER_YAML_DIRS", None)
+    os.environ.pop("SCITEX_AGENT_CONTAINER_STATE_DB", None)
+    os.environ.pop("HOME", None)
+    importlib.reload(ss)
+
+
+@pytest.fixture
+def client(isolated_env):
+    app = create_app(token=HOST_TOKEN)
+    with TestClient(app) as c:
+        yield c
+
+
+def _node_headers(name: str) -> dict[str, str]:
+    token = mint_node_token(name=name)
+    return {"authorization": f"Bearer {token}"}
+
+
+def _host_headers() -> dict[str, str]:
+    return {"authorization": f"Bearer {HOST_TOKEN}"}
+
+
+# ---------------------------------------------------------------------------
+# restart — non-host bearer w/ no lineage / no mesh → 403 acl_deny
+# ---------------------------------------------------------------------------
+
+
+def test_restart_unrelated_caller_returns_403(client, isolated_env):
+    # Arrange — alice has no lineage edge and no group mesh to the target.
+    headers = _node_headers("alice")
+    # Act
+    response = client.post("/agents/unrelated-target/restart", headers=headers)
+    # Assert
+    assert response.status_code == 403
+
+
+def test_restart_unrelated_caller_body_has_kind_acl_deny(client, isolated_env):
+    # Arrange
+    headers = _node_headers("alice")
+    # Act
+    response = client.post("/agents/unrelated-target-2/restart", headers=headers)
+    body = json.loads(response.content)
+    # Assert
+    assert body["kind"] == "acl_deny"
+
+
+# ---------------------------------------------------------------------------
+# restart — host bearer (admin) is NOT blocked by the ACL gate
+# ---------------------------------------------------------------------------
+
+
+def test_restart_with_host_bearer_does_not_403(client, isolated_env):
+    # Arrange — host bearer is the admin path; the gate must allow even
+    # though the ghost agent has no row (the bare-host shell will fail,
+    # but NOT with a 403 from the ACL gate).
+    # Act
+    response = client.post("/agents/ghost/restart", headers=_host_headers())
+    # Assert
+    assert response.status_code != 403
+
+
+# ---------------------------------------------------------------------------
+# restart — standard-fleet mesh: a researcher may manage a developer peer
+# ---------------------------------------------------------------------------
+
+
+def test_restart_researcher_to_developer_not_403(client, isolated_env):
+    # Arrange — neurovista (researcher) restarts scitex-todo (developer):
+    # the manage mesh allows it with no lineage edge. The target has no
+    # row so the bare-host shell fails, but NOT via a 403 ACL deny.
+    record_comms_policy(name="neurovista", group_name="researcher")
+    record_comms_policy(name="scitex-todo", group_name="developer")
+    headers = _node_headers("neurovista")
+    # Act
+    response = client.post("/agents/scitex-todo/restart", headers=headers)
+    # Assert
+    assert response.status_code != 403


### PR DESCRIPTION
## Summary

Lets an agent running INSIDE a container restart a peer agent via the HOST `sac listen` — exactly like `spawn` already works. Today `sac agents restart <name>` resolves a peer by a LOCAL registry row + local `state.db`, so from a container it fails with "Agent not found in registry". This mirrors the existing spawn bypass at every step.

- **Server** — `POST /agents/{name}/restart` (`_listen/_agent_restart.py`, registered in `server.py`). Resolves the caller from `request.state.authenticated_node` (per-node bearer; body `caller` fallback on the host-bearer/admin path), runs `check_lineage_acl` (the MANAGE gate) BEFORE any work, and on allow shells `sac agents restart <name> --yes --json` on the bare host (same host-shell pattern `agents_start` uses for start). Deny → 403 with the ACL reason verbatim; non-zero rc → 502; fail-loud JSON throughout.
- **Container client** — `request_restart(...)` / `RestartRequestError` (`_lifecycle/_restart_client.py`), stdlib `urllib`, caller auto-resolved from `SAC_NAME`, bearer + base-url resolution (env → host token file) mirroring `_spawn_client`. POSTs to `{SAC_LISTEN_BASE_URL}/agents/{name}/restart`. Fail-loud on missing env / transport / 401 / 403 / 5xx / non-object body.
- **CLI + MCP fallback** — `sac agents restart` (`cli_pkg/lifecycle/_restart.py`) catches the local "not found in registry" miss and, when `SAC_LISTEN_BASE_URL` is set, brokers the restart to the host via `request_restart` (prints the host response). The local path is unchanged when the registry row IS resolvable (bare-host operator usage). The MCP `agent_restart` tool runs the same CLI via the runner, so it inherits the bypass with no extra wiring.
- **Manage-ACL mesh** — `check_lineage_acl` now also allows a caller to manage a target when BOTH resolve into the standard fleet mesh (developer / researcher / generalist) via `groups_mesh(resolve_group_name(caller), resolve_group_name(target))`, exactly as `check_send_acl` does for sends. This lets a researcher (neurovista) restart a developer peer (scitex-todo) with no lineage edge and no per-pair grant. A non-mesh group (isolated solver) stays unmanageable cross-group (operator 2026-06-29 "agents manage agents").

This unblocks "a container agent restarts a peer with no operator involvement" — neurovista will test by restarting scitex-todo.

## Test plan
- [x] `request_restart` client: POST shape (route/method/caller/bearer), 403 → `RestartRequestError(status=403)` with server reason in `.body`, missing `SAC_LISTEN_BASE_URL` → fail-loud, transport error keeps `status=None`, non-object 2xx body → error. (injected opener, no mocks)
- [x] ACL: a researcher manages a developer target via the mesh (`check_lineage_acl` allow); a researcher → isolated solver target is denied.
- [x] Server route: `POST /agents/{name}/restart` hits the ACL gate — denied per-node caller → 403 `kind=acl_deny`; host bearer + mesh caller → not 403.
- [x] `PYTHONPATH=src /opt/venv-sac/bin/python -m pytest <new files> -q` → 35 passed; existing `test__restart.py` / `test_server_lineage_acl.py` still green.