### PR TITLE
fix: in-container agent_start spec resolution via host home bind

### DIFF
--- a/src/scitex_agent_container/runtimes/_apptainer_listen_env.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_listen_env.py
@@ -39,25 +39,32 @@ logger = logging.getLogger(__name__)
 def listen_env_flags(config) -> list[str]:
     """Return the ``--env`` flags ``apptainer exec`` needs for the bus.
 
-    Forwards the bus-listen URL + bearer (``SAC_LISTEN_*``) and, when set
-    on the host, the agent-spec search path
+    Forwards the bus-listen URL + bearer (``SAC_LISTEN_*``) and ALWAYS
+    injects the agent-spec search path
     (``SCITEX_AGENT_CONTAINER_YAML_DIRS``) so an in-container ``sac agents
     start <peer>`` resolves specs at the SAME path the operator uses on
-    the host. Without this forward the in-container sac only searches
-    ``~/.scitex/agent-container/agents`` + the repo-local dir (the env var
-    is unset inside the container), so the spec-bearing spawn path fails
-    with ``Agent '<name>' not found ... (env
+    the host. The injected value is the union of any host-set
+    ``SCITEX_AGENT_CONTAINER_YAML_DIRS`` (pass-through, order preserved)
+    and the host's canonical user-scope agents dir
+    (``~/.scitex/agent-container/agents`` expanded against the HOST home
+    at launch time). That host dir is bind-visible in-container because
+    apptainer binds the invoking host's ``$HOME`` at the same path, yet
+    the in-container ``$HOME`` is a DIFFERENT, empty home — so the
+    in-container sac's default user-scope search finds zero specs unless
+    we point it back at the host home explicitly. Without this the
+    spec-bearing spawn path fails with ``Agent '<name>' not found ... (env
     $SCITEX_AGENT_CONTAINER_YAML_DIRS: <unset>)`` even though the specs
     are visible in-container via the host-home bind.
 
-    Pure except for reading the host token file, config, and host env;
-    raises ``RuntimeError`` when a ``server:sac`` spec has no resolvable
-    bearer.
+    Pure except for reading the host token file, config, host env, and
+    host home; raises ``RuntimeError`` when a ``server:sac`` spec has no
+    resolvable bearer.
     """
     # Local imports keep these resolvable even if a formatter strips
     # module-level unused imports during a refactor, and avoid a circular
     # import with the runtime module that calls this helper.
     import os
+    from pathlib import Path
 
     from .._listen._config import listen_base_url
     from ._apptainer_build import _listen_token_path, _read_listen_bearer
@@ -98,13 +105,29 @@ def listen_env_flags(config) -> list[str]:
         "SCITEX_GENAI_BASE_URL=http://127.0.0.1:4000/v1",
     ]
 
-    # Forward the host's agent-spec search path so the in-container sac
-    # resolves peer specs at the operator's path. Only inject when the
-    # host has it set+non-empty — otherwise leave the in-container default
-    # search order untouched (no empty ``--env`` that would shadow it).
-    spec_dirs = os.environ.get("SCITEX_AGENT_CONTAINER_YAML_DIRS", "").strip()
-    if spec_dirs:
-        flags += ["--env", f"SCITEX_AGENT_CONTAINER_YAML_DIRS={spec_dirs}"]
+    # ALWAYS inject the agent-spec search path so the in-container sac
+    # resolves peer specs even when the launching env has nothing set.
+    # The in-container ``$HOME`` is a different, empty home than the
+    # host's, so its default user-scope search
+    # (``~/.scitex/agent-container/agents`` under the CONTAINER home)
+    # finds zero specs. apptainer binds the host ``$HOME`` at the same
+    # path, so the HOST-side expansion below is bind-visible in-container.
+    # Union: any host-set value (pass-through, order preserved) followed
+    # by the host user-scope agents dir if not already present. The suffix
+    # ``.scitex/agent-container/agents`` matches ``config/_resolve.py``'s
+    # ``_search_dirs`` ``primary`` so the two stay in sync. Do NOT hardcode
+    # a username — ``expanduser`` resolves the invoking host's home.
+    host_default = str(
+        Path("~/.scitex/agent-container/agents").expanduser()
+    )
+    spec_dirs_raw = os.environ.get("SCITEX_AGENT_CONTAINER_YAML_DIRS", "")
+    spec_dirs: list[str] = [p for p in spec_dirs_raw.split(":") if p.strip()]
+    if host_default not in spec_dirs:
+        spec_dirs.append(host_default)
+    flags += [
+        "--env",
+        f"SCITEX_AGENT_CONTAINER_YAML_DIRS={':'.join(spec_dirs)}",
+    ]
 
     claude_spec = getattr(config, "claude", None)
     channels = list(getattr(claude_spec, "channels", None) or [])

--- a/tests/scitex_agent_container/runtimes/test__apptainer_listen_env.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_listen_env.py
@@ -141,3 +141,50 @@ def test_listen_env_flags_injects_no_genai_api_key(
     assert not any(
         "GENAI_API_KEY" in f or "QWEN_API_KEY" in f for f in flags
     )
+
+
+@pytest.fixture
+def cleared_spec_dirs() -> Iterator[None]:
+    """Yield with ``$SCITEX_AGENT_CONTAINER_YAML_DIRS`` UNSET, restored after."""
+    prev = os.environ.get("SCITEX_AGENT_CONTAINER_YAML_DIRS")
+    os.environ.pop("SCITEX_AGENT_CONTAINER_YAML_DIRS", None)
+    try:
+        yield
+    finally:
+        if prev is not None:
+            os.environ["SCITEX_AGENT_CONTAINER_YAML_DIRS"] = prev
+
+
+def test_listen_env_flags_injects_host_default_spec_dir_when_env_unset(
+    no_bus_config: SimpleNamespace,
+    sandboxed_home: Path,
+    cleared_spec_dirs: None,
+) -> None:
+    # Arrange — host env var is unset; sandboxed $HOME roots the default.
+    host_default = str(
+        (sandboxed_home / ".scitex" / "agent-container" / "agents")
+    )
+    # Act
+    flags = listen_env_flags(no_bus_config)
+    # Assert — a YAML_DIRS --env is emitted whose value holds the host default.
+    assert any(
+        f == f"SCITEX_AGENT_CONTAINER_YAML_DIRS={host_default}" for f in flags
+    )
+
+
+def test_listen_env_flags_unions_host_set_dir_with_default(
+    no_bus_config: SimpleNamespace,
+    sandboxed_home: Path,
+    cleared_spec_dirs: None,
+) -> None:
+    # Arrange — host sets a custom dir; the default rooted at sandboxed $HOME
+    # must be unioned after it with no duplicate.
+    custom = str(sandboxed_home / "custom-agents")
+    os.environ["SCITEX_AGENT_CONTAINER_YAML_DIRS"] = custom
+    host_default = str(sandboxed_home / ".scitex" / "agent-container" / "agents")
+    # Act
+    flags = listen_env_flags(no_bus_config)
+    # Assert — the emitted value contains BOTH the host-set dir and default.
+    assert (
+        f"SCITEX_AGENT_CONTAINER_YAML_DIRS={custom}:{host_default}" in flags
+    )

--- a/tests/scitex_agent_container/runtimes/test__apptainer_runtime.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_runtime.py
@@ -2169,16 +2169,26 @@ def test_config_listen_host_propagates_to_env(tmp_path: Path, env_save_restore) 
 
 
 # ---------------------------------------------------------------------------
-# Spec-dir forwarding — SCITEX_AGENT_CONTAINER_YAML_DIRS must be forwarded
-# from the host env into the spawned container so an in-container
-# ``sac agents start <peer>`` resolves peer specs at the operator's path
-# (else the spec-bearing spawn path fails with "Agent not found ... (env
-# $SCITEX_AGENT_CONTAINER_YAML_DIRS: <unset>)"). Unset/empty on the host
-# must NOT inject the flag (leave the in-container default search order).
+# Spec-dir injection — SCITEX_AGENT_CONTAINER_YAML_DIRS is ALWAYS injected
+# into the spawned container so an in-container ``sac agents start <peer>``
+# resolves peer specs (else the spawn path fails with "Agent not found ...
+# (env $SCITEX_AGENT_CONTAINER_YAML_DIRS: <unset>)"). The injected value is
+# the union of any host-set value (pass-through, order preserved) and the
+# host's canonical user-scope agents dir (``~/.scitex/agent-container/agents``
+# expanded against the HOST home) — bind-visible in-container because
+# apptainer binds the host ``$HOME`` at the same path, while the in-container
+# ``$HOME`` is a different, empty home whose default search finds no specs.
 # ---------------------------------------------------------------------------
 
 
-def test_spec_dirs_forwarded_when_set_on_host(
+def _host_default_agents_dir() -> str:
+    # The canonical user-scope agents dir, expanded against the HOST home —
+    # matches ``config/_resolve.py``'s ``_search_dirs`` primary so the two
+    # stay in sync.
+    return str(Path("~/.scitex/agent-container/agents").expanduser())
+
+
+def test_spec_dirs_union_host_value_then_default_when_set_on_host(
     tmp_path: Path, env_save_restore
 ) -> None:
     # Arrange — host has the agent-spec search path exported.
@@ -2190,11 +2200,13 @@ def test_spec_dirs_forwarded_when_set_on_host(
     argv = rt.build_run_argv(
         cfg, state_dir=tmp_path / "state", sif_path=tmp_path / "x.sif"
     )
-    # Assert — the value is forwarded verbatim as an --env pair.
-    assert _env_pairs(argv).get("SCITEX_AGENT_CONTAINER_YAML_DIRS") == spec_path
+    # Assert — host value first, host default appended (union).
+    assert _env_pairs(argv).get("SCITEX_AGENT_CONTAINER_YAML_DIRS") == (
+        f"{spec_path}:{_host_default_agents_dir()}"
+    )
 
 
-def test_spec_dirs_forwarded_preserves_colon_separated_list(
+def test_spec_dirs_preserves_colon_list_then_appends_default(
     tmp_path: Path, env_save_restore
 ) -> None:
     # Arrange — colon-separated multi-dir path must round-trip intact.
@@ -2206,11 +2218,13 @@ def test_spec_dirs_forwarded_preserves_colon_separated_list(
     argv = rt.build_run_argv(
         cfg, state_dir=tmp_path / "state", sif_path=tmp_path / "x.sif"
     )
-    # Assert
-    assert _env_pairs(argv).get("SCITEX_AGENT_CONTAINER_YAML_DIRS") == spec_path
+    # Assert — list preserved in order, host default appended.
+    assert _env_pairs(argv).get("SCITEX_AGENT_CONTAINER_YAML_DIRS") == (
+        f"{spec_path}:{_host_default_agents_dir()}"
+    )
 
 
-def test_spec_dirs_not_forwarded_when_unset_on_host(
+def test_spec_dirs_defaults_to_host_agents_dir_when_unset_on_host(
     tmp_path: Path, env_save_restore
 ) -> None:
     # Arrange — host does NOT have the env var (delete any inherited one).
@@ -2221,15 +2235,17 @@ def test_spec_dirs_not_forwarded_when_unset_on_host(
     argv = rt.build_run_argv(
         cfg, state_dir=tmp_path / "state", sif_path=tmp_path / "x.sif"
     )
-    # Assert — no flag injected → in-container default search order kept.
-    assert "SCITEX_AGENT_CONTAINER_YAML_DIRS" not in _env_pairs(argv)
+    # Assert — the host default is injected so in-container resolution works.
+    assert (
+        _env_pairs(argv).get("SCITEX_AGENT_CONTAINER_YAML_DIRS")
+        == _host_default_agents_dir()
+    )
 
 
-def test_spec_dirs_not_forwarded_when_empty_on_host(
+def test_spec_dirs_empty_host_value_yields_default_only(
     tmp_path: Path, env_save_restore
 ) -> None:
-    # Arrange — set to empty/whitespace; must be treated as unset, not
-    # injected as an empty --env that would shadow the default order.
+    # Arrange — empty/whitespace host value is dropped, default still injected.
     env_save_restore.set("SCITEX_AGENT_CONTAINER_YAML_DIRS", "   ")
     rt = ApptainerContainerRuntime()
     cfg = _config(tmp_path / "wd")
@@ -2237,11 +2253,16 @@ def test_spec_dirs_not_forwarded_when_empty_on_host(
     argv = rt.build_run_argv(
         cfg, state_dir=tmp_path / "state", sif_path=tmp_path / "x.sif"
     )
-    # Assert
-    assert "SCITEX_AGENT_CONTAINER_YAML_DIRS" not in _env_pairs(argv)
+    # Assert — whitespace-only entry filtered, only the default remains.
+    assert (
+        _env_pairs(argv).get("SCITEX_AGENT_CONTAINER_YAML_DIRS")
+        == _host_default_agents_dir()
+    )
 
 
-def test_listen_env_flags_forwards_spec_dirs_value(env_save_restore) -> None:
+def test_listen_env_flags_unions_spec_dirs_value_with_default(
+    env_save_restore,
+) -> None:
     # Arrange — exercise the helper directly (unit seam, no container).
     from scitex_agent_container.runtimes._apptainer_listen_env import (
         listen_env_flags,
@@ -2251,8 +2272,11 @@ def test_listen_env_flags_forwards_spec_dirs_value(env_save_restore) -> None:
     cfg = _config(Path("/tmp/wd"))
     # Act
     flags = listen_env_flags(cfg)
-    # Assert — the value rides in the flag list.
-    assert "SCITEX_AGENT_CONTAINER_YAML_DIRS=/host/agents" in flags
+    # Assert — the host value rides first, host default appended.
+    assert (
+        "SCITEX_AGENT_CONTAINER_YAML_DIRS=/host/agents:"
+        f"{_host_default_agents_dir()}"
+    ) in flags
 
 
 def test_listen_env_flags_spec_dirs_pair_is_contiguous(env_save_restore) -> None:
@@ -2266,12 +2290,17 @@ def test_listen_env_flags_spec_dirs_pair_is_contiguous(env_save_restore) -> None
     cfg = _config(Path("/tmp/wd"))
     # Act
     flags = listen_env_flags(cfg)
+    value = (
+        "SCITEX_AGENT_CONTAINER_YAML_DIRS=/host/agents:"
+        f"{_host_default_agents_dir()}"
+    )
     # Assert
-    idx = flags.index("SCITEX_AGENT_CONTAINER_YAML_DIRS=/host/agents")
-    assert flags[idx - 1] == "--env"
+    assert flags[flags.index(value) - 1] == "--env"
 
 
-def test_listen_env_flags_omits_spec_dirs_when_unset(env_save_restore) -> None:
+def test_listen_env_flags_injects_default_spec_dir_when_unset(
+    env_save_restore,
+) -> None:
     # Arrange
     from scitex_agent_container.runtimes._apptainer_listen_env import (
         listen_env_flags,
@@ -2281,8 +2310,10 @@ def test_listen_env_flags_omits_spec_dirs_when_unset(env_save_restore) -> None:
     cfg = _config(Path("/tmp/wd"))
     # Act
     flags = listen_env_flags(cfg)
-    # Assert — no spec-dir value anywhere in the flag list.
-    assert not any("SCITEX_AGENT_CONTAINER_YAML_DIRS" in f for f in flags)
+    # Assert — the host default is injected even with nothing set.
+    assert (
+        f"SCITEX_AGENT_CONTAINER_YAML_DIRS={_host_default_agents_dir()}" in flags
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Second, independent half of card `sac-agent-cannot-spawn-agents-listen-7878-unreachable` (the spawn-client/bearer half merged in #470).

A containerized agent running `sac agents start <peer>` could not resolve peer specs, failing with `Agent '<name>' not found ... (env $SCITEX_AGENT_CONTAINER_YAML_DIRS: <unset>)`. Root cause (empirically verified in a live container on ywata-note-win): the in-container `$HOME=/home/agent` is a different, empty home than the host's, so the in-container sac's default user-scope search finds zero specs. apptainer auto-binds the invoking host's `$HOME` at the same path, so the canonical specs at `~/.scitex/agent-container/agents` ARE bind-visible — but sac never looked there.

`listen_env_flags` now ALWAYS injects `SCITEX_AGENT_CONTAINER_YAML_DIRS` as the union of:
- any host-set value (pass-through, order preserved — no regression of the existing forward), then
- the host's canonical user-scope agents dir (`~/.scitex/agent-container/agents` expanded HOST-side at launch; bind-visible in-container). No hardcoded username — `expanduser` resolves the invoking host's home. Suffix matches `config/_resolve.py` `_search_dirs` `primary`.

## Test plan
- [x] `test_listen_env_flags_injects_host_default_spec_dir_when_env_unset` — host env unset still emits the host default
- [x] `test_listen_env_flags_unions_host_set_dir_with_default` — host-set dir + default unioned, no duplicate
- [x] existing 7 tests in the file unregressed
- [x] `python -m pytest tests/scitex_agent_container/runtimes/test__apptainer_listen_env.py -x -q` → 9 passed