### PR TITLE
feat(binds): bind host /tmp read-only at /tmp/host (operator handoff)

### DIFF
--- a/src/scitex_agent_container/runtimes/_p3a_default_binds.py
+++ b/src/scitex_agent_container/runtimes/_p3a_default_binds.py
@@ -118,6 +118,20 @@ _FLEET_DEFAULT_BINDS: tuple[str, ...] = (
     # where the source dir does not exist (remote hosts, fresh boot before
     # emacs writes) — no FATAL, no surprise mount.
     "/tmp/emacs-claude-code:/tmp/emacs-claude-code:ro",
+    # GENERAL HOST-/tmp HANDOFF — generalise the narrow emacs entry above
+    # into an operator->agent file-handoff channel: anything the operator
+    # drops in host ``/tmp`` becomes readable in-container at
+    # ``/tmp/host/...``. READ-ONLY because host ``/tmp`` holds other
+    # processes' tempfiles + live sockets — an agent must NEVER clobber it.
+    # Destination ``/tmp/host`` is a SUBPATH under the container's writable
+    # ``/tmp`` tmpfs (writable under --containall), so apptainer's bind-dest
+    # auto-create cannot lose the overlay race the HAZARD above describes
+    # (same reasoning as the emacs entry). Host ``/tmp`` ALWAYS exists, so
+    # this default always applies. Do NOT bind over ``/tmp`` ITSELF — that
+    # would clobber the container's relocated scratch, the ``/tmp/sac-claude``
+    # credentials bind, and the nested-apptainer cache; mounting at the
+    # ``/tmp/host`` subpath sits harmlessly inside the tmpfs.
+    "/tmp:/tmp/host:ro",
     # PERSISTENT TESTMON CACHE — survive the fresh-git-worktree churn the
     # develop-pin hook forces. Every commit lands in a NEW worktree, so a
     # worktree-local ``.testmondata`` is always cold and pytest re-runs the

--- a/tests/scitex_agent_container/runtimes/test__p3a_default_binds.py
+++ b/tests/scitex_agent_container/runtimes/test__p3a_default_binds.py
@@ -117,12 +117,16 @@ def test_apply_default_binds_lets_explicit_spec_entry_override_default(
 def test_apply_default_binds_returns_spec_only_when_host_dir_missing(
     fake_home: Path,
 ) -> None:
-    # Arrange
+    # Arrange: sandboxed $HOME has no ~/.scitex/todo so the home-relative
+    # todo default is gated out. Host-absolute defaults (the always-present
+    # ``/tmp`` -> ``/tmp/host`` handoff) ignore the $HOME swap, so we assert
+    # on the home-relative slice the gate actually governs.
     spec_binds = ["~/proj:/home/agent/proj:ro"]
     # Act
     result = apply_default_binds(spec_binds)
+    home_relative = [b for b in result if "/home/agent/" in b]
     # Assert
-    assert result == spec_binds
+    assert home_relative == spec_binds
 
 
 def test_apply_default_binds_handles_empty_spec_binds(fake_home: Path) -> None:
@@ -342,6 +346,30 @@ def test_fleet_defaults_include_emacs_handoff_bind_read_only() -> None:
     handoff = [b for b in _FLEET_DEFAULT_BINDS if "emacs-claude-code" in b]
     # Assert — bound at the same host path, read-only.
     assert handoff == ["/tmp/emacs-claude-code:/tmp/emacs-claude-code:ro"]
+
+
+# ---------------------------------------------------------------------------
+# General host-/tmp handoff bind — host ``/tmp`` bound READ-ONLY at the
+# container subpath ``/tmp/host`` so anything the operator drops in host
+# ``/tmp`` is readable in-container at ``/tmp/host/...`` (generalises the
+# narrow emacs handoff above). ``ro`` because host ``/tmp`` carries other
+# processes' tempfiles + live sockets; the destination is a subpath under the
+# container's writable ``/tmp`` tmpfs so bind-dest auto-create is race-safe.
+# ---------------------------------------------------------------------------
+
+
+def test_fleet_defaults_include_host_tmp_handoff_bind_read_only() -> None:
+    # Arrange — read the static fleet-default tuple directly.
+    from scitex_agent_container.runtimes._p3a_default_binds import (
+        _FLEET_DEFAULT_BINDS,
+    )
+
+    # Act — filter by the container-side destination ``/tmp/host``.
+    host_tmp = [
+        b for b in _FLEET_DEFAULT_BINDS if b.split(":", 2)[1:2] == ["/tmp/host"]
+    ]
+    # Assert — host /tmp bound read-only at the /tmp/host subpath.
+    assert host_tmp == ["/tmp:/tmp/host:ro"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add a fleet-wide default bind mounting the host's `/tmp` **read-only** at the in-container subpath `/tmp/host`, generalising the narrow `/tmp/emacs-claude-code` handoff into a general operator->agent file-handoff channel (anything dropped in host `/tmp` becomes readable at `/tmp/host/...`).
- `ro` because host `/tmp` carries other processes' tempfiles + live sockets — an agent must never clobber it. Destination is a subpath under the container's writable `/tmp` tmpfs, so apptainer bind-dest auto-create is race-safe (same reasoning as the emacs entry). Does **not** bind over `/tmp` itself (would clobber relocated scratch / `/tmp/sac-claude` creds / nested-apptainer cache).
- Additive: the existing `/tmp/emacs-claude-code:/tmp/emacs-claude-code:ro` entry is kept unchanged (operator tooling names that exact same-path; `/tmp/host` does not preserve same-path).
- Drive-by fix: `test_apply_default_binds_returns_spec_only_when_host_dir_missing` was a pre-existing host-dependent flaky assertion — it asserted exact equality, but real host-absolute defaults (`/tmp/emacs-claude-code`, now `/tmp/host`) leak through the `$HOME`-sandboxed gate. Narrowed it to assert on the home-relative slice the host-existence gate actually governs.

## Test plan
- [x] `pytest tests/scitex_agent_container/runtimes/test__p3a_default_binds.py` — 19 passed (incl. new `test_fleet_defaults_include_host_tmp_handoff_bind_read_only`).
- [x] Confirmed the equality-assert test was already failing on `develop` on this host (`/tmp/emacs-claude-code` exists) before this change — the narrowing fixes a pre-existing flake, not a regression.