### PR TITLE
chore(quota-watch): default log under ~/.scitex/agent-container/logs

### DIFF
--- a/src/scitex_agent_container/_account/quota_watch.py
+++ b/src/scitex_agent_container/_account/quota_watch.py
@@ -26,7 +26,9 @@ logger = logging.getLogger(__name__)
 DEFAULT_THRESHOLD = 80.0  # rotate when usage exceeds this %
 DEFAULT_INTERVAL = 300  # check every 5 minutes
 SURVIVAL_THRESHOLD = 50.0  # warn in survival mode when usage exceeds this %
-_DEFAULT_LOG_PATH = Path.home() / ".scitex" / "logs" / "quota-watch.log"
+_DEFAULT_LOG_PATH = (
+    Path.home() / ".scitex" / "agent-container" / "logs" / "quota-watch.log"
+)
 
 
 def _select_next_account(
@@ -259,7 +261,7 @@ def run_loop(
         store_dir: Override for account store directory.
         home:      Override for home directory.
         daemon:    If True, double-fork into background before looping.
-        log_path:  Log file path used when daemon=True (default: ~/.scitex/logs/quota-watch.log).
+        log_path:  Log file path used when daemon=True (default: ~/.scitex/agent-container/logs/quota-watch.log).
     """
     if daemon:
         _log = log_path or _DEFAULT_LOG_PATH

--- a/tests/scitex_agent_container/_account/test_quota_watch.py
+++ b/tests/scitex_agent_container/_account/test_quota_watch.py
@@ -22,6 +22,7 @@ import pytest
 
 import scitex_agent_container._account.quota_watch as qw_mod
 from scitex_agent_container._account.quota_watch import (
+    _DEFAULT_LOG_PATH,
     _select_next_account,
     check_and_rotate,
 )
@@ -468,3 +469,12 @@ def test_survival_mode_check_exception_message_quotes_exception_text(tmp_path):
         result = qw_mod.survival_mode_check(home=home)
     # Assert
     assert "boom from fetch_usage" in result["message"]
+
+
+def test_default_log_path_lives_under_agent_container():
+    # Arrange
+    expected_suffix = Path("agent-container") / "logs" / "quota-watch.log"
+    # Act
+    actual_suffix = Path(*_DEFAULT_LOG_PATH.parts[-3:])
+    # Assert
+    assert actual_suffix == expected_suffix


### PR DESCRIPTION
## Summary
- The quota-watch daemon's default log path was `~/.scitex/logs/quota-watch.log`, missing the `agent-container/` segment. Root-level `~/.scitex/` files get quarantined into `~/.scitex/_violation/` per the operator convention; every other sac log path already nests under `~/.scitex/agent-container/`.
- Repoint `_DEFAULT_LOG_PATH` to `~/.scitex/agent-container/logs/quota-watch.log` and update the matching docstring. The existing `_daemonize` already `mkdir(parents=True, exist_ok=True)`s the log dir, so the new nested dir is created on demand.
- Source default only — no on-disk log files are migrated or touched.

## Test plan
- [x] `pytest tests/scitex_agent_container/_account/test_quota_watch.py -q` → 31 passed
- [x] New one-assert test `test_default_log_path_lives_under_agent_container` verifies the default path tail is `agent-container/logs/quota-watch.log`