### PR TITLE
feat(envrc): SAC_SECRETS_ENVRC secrets preamble for daemon launches

### DIFF
--- a/src/scitex_agent_container/runtimes/_envrc.py
+++ b/src/scitex_agent_container/runtimes/_envrc.py
@@ -14,6 +14,20 @@ the agent ships neither ``.env`` nor ``.envrc`` the whole flow is skipped.
 Fail-loud: a ``.envrc`` whose bash evaluation exits non-zero raises
 :class:`EnvrcEvalError` and aborts the deploy, rather than launching the agent
 with a half-applied environment.
+
+Secrets preamble (``SAC_SECRETS_ENVRC``): an agent's ``.envrc`` typically does
+``export CCT_BOT_TOKEN="$CCT_BOT_TOKEN_TODO"`` — which only resolves when the
+LAUNCHING process already carries the source secret. The operator's shell does;
+the ``sac-listen`` daemon's does NOT, so a daemon-restarted agent folds an EMPTY
+token. Set ``SAC_SECRETS_ENVRC`` to a colon-separated list of absolute secret
+files (non-existent entries are skipped) and each is sourced (``set -a``) into
+BOTH the baseline AND the loaded shells, BEFORE everything else. Because the
+secret files' own vars then appear in BOTH shells they are NOT in the diff →
+NOT folded into the agent ``.env`` (no leak); but the per-agent ``.envrc``'s
+references now resolve to the real values and, being NEW/CHANGED keys, ARE
+folded. Unset/empty ``SAC_SECRETS_ENVRC`` ⇒ behaviour is exactly as before. A
+secret file that exists but fails to source still raises (fail-loud); only a
+NON-EXISTENT path is skipped (matching the per-layer skip-if-missing posture).
 """
 
 from __future__ import annotations
@@ -31,9 +45,33 @@ logger = logging.getLogger(__name__)
 # ``.env``/``.envrc`` contribution, so excluded from the captured diff.
 _SHELL_NOISE = frozenset({"_", "SHLVL", "PWD", "OLDPWD"})
 
+# Env var naming the secrets-preamble files (colon-separated absolute paths).
+_SECRETS_ENVRC_VAR = "SAC_SECRETS_ENVRC"
+
 
 class EnvrcEvalError(RuntimeError):
     """An agent's ``.envrc`` failed to evaluate (fail-loud; aborts deploy)."""
+
+
+def _secrets_preamble_lines() -> list[str]:
+    """Return ``. <path>`` source lines for the ``SAC_SECRETS_ENVRC`` files.
+
+    Reads the colon-separated absolute paths from ``SAC_SECRETS_ENVRC``,
+    keeps only the entries that currently exist (a non-existent path is
+    skipped — matching the per-layer skip-if-missing posture), and returns
+    one quoted ``. <path>`` line per surviving file. Empty list when the var
+    is unset/empty — so the baseline and loaded scripts are unchanged from
+    pre-preamble behaviour. The same list is spliced into BOTH the baseline
+    and the loaded shell so the secret files' own vars cancel in the diff.
+    """
+    raw = os.environ.get(_SECRETS_ENVRC_VAR, "")
+    lines: list[str] = []
+    for entry in raw.split(":"):
+        if not entry:
+            continue
+        if Path(entry).is_file():
+            lines.append(f". {shlex.quote(entry)}")
+    return lines
 
 
 def _capture_env(script: str, cwd: Path) -> dict[str, str]:
@@ -73,8 +111,10 @@ def eval_envrc(envrc: Path, *, base_env: Path | None = None) -> dict[str, str]:
     Raises :class:`EnvrcEvalError` (wrapping bash stderr) on a non-zero exit.
     """
     cwd = envrc.parent
-    baseline = _capture_env("env -0", cwd)
-    lines = ["set -a"]
+    preamble = _secrets_preamble_lines()
+    baseline_lines = ["set -a", *preamble, "set +a", "env -0"]
+    baseline = _capture_env("\n".join(baseline_lines), cwd)
+    lines = ["set -a", *preamble]
     if base_env is not None and base_env.is_file():
         lines.append(f". {shlex.quote(str(base_env))}")
     lines.append(f". {shlex.quote(str(envrc))}")
@@ -142,8 +182,10 @@ def eval_envrc_cascade(
     if base_env is None and not files:
         return {}
     cwd = files[-1].parent if files else base_env.parent  # type: ignore[union-attr]
-    baseline = _capture_env("env -0", cwd)
-    lines = ["set -a"]
+    preamble = _secrets_preamble_lines()
+    baseline_lines = ["set -a", *preamble, "set +a", "env -0"]
+    baseline = _capture_env("\n".join(baseline_lines), cwd)
+    lines = ["set -a", *preamble]
     if base_env is not None and base_env.is_file():
         lines.append(f". {shlex.quote(str(base_env))}")
     for f in files:

--- a/tests/scitex_agent_container/runtimes/test__envrc.py
+++ b/tests/scitex_agent_container/runtimes/test__envrc.py
@@ -12,6 +12,8 @@ Named ``test__envrc.py`` for the PS-204 §2 orphan-test mirror against
 
 from __future__ import annotations
 
+import os
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
@@ -23,6 +25,21 @@ from scitex_agent_container.runtimes._envrc import (
     fold_envrc_cascade_into_env,
     fold_envrc_into_env,
 )
+
+_SECRETS_VAR = "SAC_SECRETS_ENVRC"
+
+
+@pytest.fixture
+def secrets_envrc() -> Iterator[None]:
+    """Save/restore ``SAC_SECRETS_ENVRC`` so a test may set it freely."""
+    saved = os.environ.get(_SECRETS_VAR)
+    try:
+        yield
+    finally:
+        if saved is None:
+            os.environ.pop(_SECRETS_VAR, None)
+        else:
+            os.environ[_SECRETS_VAR] = saved
 
 
 def test_eval_envrc_captures_exported_var(tmp_path: Path) -> None:
@@ -150,3 +167,46 @@ def test_fold_envrc_cascade_writes_combined_env_file(tmp_path: Path) -> None:
     # Assert — the folded .env carries BOTH sources.
     text = (dest / ".env").read_text()
     assert "FROM_ENV=1" in text and "FROM_LAYER=2" in text
+
+
+def test_secrets_preamble_resolves_referenced_secret(
+    tmp_path: Path, secrets_envrc: None
+) -> None:
+    # Arrange — a secret file in scope; the .envrc references its var.
+    secret = tmp_path / "secret.env"
+    secret.write_text("export SECRET_TOK=abc123\n", encoding="utf-8")
+    os.environ[_SECRETS_VAR] = str(secret)
+    envrc = tmp_path / ".envrc"
+    envrc.write_text('export PUBLIC="$SECRET_TOK"\n', encoding="utf-8")
+    # Act
+    out = eval_envrc(envrc)
+    # Assert — the .envrc reference resolved to the real secret value.
+    assert out.get("PUBLIC") == "abc123"
+
+
+def test_secrets_preamble_does_not_leak_source_secret(
+    tmp_path: Path, secrets_envrc: None
+) -> None:
+    # Arrange — same setup as the resolve test.
+    secret = tmp_path / "secret.env"
+    secret.write_text("export SECRET_TOK=abc123\n", encoding="utf-8")
+    os.environ[_SECRETS_VAR] = str(secret)
+    envrc = tmp_path / ".envrc"
+    envrc.write_text('export PUBLIC="$SECRET_TOK"\n', encoding="utf-8")
+    # Act
+    out = eval_envrc(envrc)
+    # Assert — the source secret var is NOT folded (cancels in the diff).
+    assert "SECRET_TOK" not in out
+
+
+def test_no_preamble_when_var_unset_is_unchanged(
+    tmp_path: Path, secrets_envrc: None
+) -> None:
+    # Arrange — SAC_SECRETS_ENVRC unset; .envrc references an undefined var.
+    os.environ.pop(_SECRETS_VAR, None)
+    envrc = tmp_path / ".envrc"
+    envrc.write_text('export PUBLIC="$SECRET_TOK"\n', encoding="utf-8")
+    # Act
+    out = eval_envrc(envrc)
+    # Assert — today's behaviour: the unresolved reference folds empty.
+    assert out.get("PUBLIC") == ""


### PR DESCRIPTION
## Summary
- Adds an optional **secrets preamble** so an agent's `.envrc` fold resolves secret references (`export CCT_BOT_TOKEN="$CCT_BOT_TOKEN_TODO"`) regardless of who launches the agent — the operator's secrets-sourced shell OR the secrets-less `sac-listen` daemon (the sac-from-sac / agent-managed restart path that today folds an EMPTY token).
- New env var `SAC_SECRETS_ENVRC`: colon-separated absolute secret-file paths. Each existing file is sourced (`set -a`) into **both** the baseline and the loaded shells, **before** everything else, via a shared `_secrets_preamble_lines()` helper used by both `eval_envrc` and `eval_envrc_cascade`.
- Because the secret files are sourced into BOTH shells, their own source vars (e.g. `CCT_BOT_TOKEN_TODO`) cancel in the baseline/loaded diff -> **not folded** into the agent `.env` (no leak). The per-agent `.envrc`'s reference now resolves to the real token and, being a NEW/CHANGED key, **is** folded.
- Unset/empty `SAC_SECRETS_ENVRC` => behaviour is **exactly as before** (regression-guarded). Fail-loud preserved: a secret file that exists but errors still raises `EnvrcEvalError`; only a non-existent path is skipped.
- Module docstring updated to document the contract. File stays at 240 lines (< 512 cap).

## Test plan
New tests in `tests/scitex_agent_container/runtimes/test__envrc.py` (real tmp files, no mocks; one-assert each; env var save/restore fixture):
- [x] `test_secrets_preamble_resolves_referenced_secret` — folded `PUBLIC == "abc123"`
- [x] `test_secrets_preamble_does_not_leak_source_secret` — `SECRET_TOK` absent from fold
- [x] `test_no_preamble_when_var_unset_is_unchanged` — regression guard: reference folds empty
- [x] Full file: `14 passed` (11 existing + 3 new)