### PR TITLE
feat(to_home): propagate host ~/.claude/commands/*.md to agents

### DIFF
--- a/src/scitex_agent_container/runtimes/_host_commands.py
+++ b/src/scitex_agent_container/runtimes/_host_commands.py
@@ -1,0 +1,77 @@
+"""Deploy the operator's host ``~/.claude/commands/*.md`` as an agent baseline.
+
+Claude Code slash commands live in the standard host directory
+``~/.claude/commands/`` (one ``<name>.md`` per command). They are NOT
+visible inside an agent container, whose ``~/.claude/commands/`` only
+carries whatever ``to_home`` materialization deploys. So an operator who
+authors ``/incidence`` etc. on the host sees nothing when running it in an
+agent.
+
+This module closes that gap: at deploy time it resolves the *host* home's
+``~/.claude/commands/`` (``Path("~/.claude/commands").expanduser()`` — never
+a hard-coded username) and copies each ``*.md`` into the agent's
+materialized ``.claude/commands/``. The operator authors a command ONCE in
+the standard host location and it propagates to every agent.
+
+Precedence: host commands are the LOWEST baseline. The materialization
+calls :func:`deploy_host_claude_commands` BEFORE the shared-baseline /
+per-agent ``to_home`` walk, so any per-agent ``to_home/.claude/commands/<x>.md``
+or sac-bundled command of the same name OVERWRITES the host one — matching
+the existing to_home cascade precedence (lower layer first, higher layer
+wins on conflict).
+
+Skip-if-missing: no host ``~/.claude/commands/`` dir → no-op (no error, no
+empty ``commands/`` dir fabricated). Non-``*.md`` entries (e.g.
+``archive-*.tar.gz``) are skipped.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# The standard Claude Code slash-commands dir under the operator's host home.
+# Resolved fresh at deploy time so it always tracks the real host user (no
+# hard-coded username).
+_HOST_COMMANDS_REL = "~/.claude/commands"
+
+
+def host_claude_commands_dir() -> Path | None:
+    """Resolve the host ``~/.claude/commands/`` dir, or ``None`` if absent.
+
+    Returns ``None`` (skip-if-missing) when the directory does not exist, so
+    callers can no-op without fabricating an empty ``commands/`` dir in the
+    agent home.
+    """
+    p = Path(_HOST_COMMANDS_REL).expanduser()
+    return p if p.is_dir() else None
+
+
+def deploy_host_claude_commands(workspace_home: Path) -> None:
+    """Copy host ``~/.claude/commands/*.md`` into ``<workspace_home>/.claude/commands/``.
+
+    Baseline layer: deploy these FIRST (before the shared/per-agent
+    ``to_home`` walk) so a same-name per-agent or bundled command wins.
+
+    Skip-if-missing: no host commands dir → no-op. Only ``*.md`` files are
+    copied (non-``.md`` entries such as ``archive-*.tar.gz`` are skipped).
+    The agent ``commands/`` dir is created only when at least one host
+    command is deployed.
+    """
+    src_dir = host_claude_commands_dir()
+    if src_dir is None:
+        return
+    dst_dir = Path(workspace_home) / ".claude" / "commands"
+    for src in sorted(src_dir.iterdir()):
+        if not src.is_file() or src.suffix != ".md":
+            continue
+        dst_dir.mkdir(parents=True, exist_ok=True)
+        dst = dst_dir / src.name
+        shutil.copy2(src, dst)
+        logger.info("to_home: host command %s -> %s", src.name, dst)
+
+
+__all__ = ["deploy_host_claude_commands", "host_claude_commands_dir"]

--- a/src/scitex_agent_container/runtimes/_to_home.py
+++ b/src/scitex_agent_container/runtimes/_to_home.py
@@ -68,6 +68,7 @@ from pathlib import Path
 
 from ..config import AgentConfig
 from ._envrc import fold_envrc_cascade_into_env, fold_envrc_into_env
+from ._host_commands import deploy_host_claude_commands
 from ._mcp_merge import merge_mcp_json
 from ._symlink_resolve import DanglingToHomeSymlinkError, deref_copy_symlink
 from ._to_home_errors import (
@@ -247,6 +248,10 @@ def materialize_to_home(spec_dir: Path, workspace_home: Path) -> None:
         _stale = workspace_home / _merge_name
         if _stale.is_file():
             _stale.unlink()
+    # Host ~/.claude/commands/*.md — the LOWEST baseline layer. Deploy FIRST so
+    # a same-name shared-baseline / per-agent command overwrites it below.
+    # Skip-if-missing (no host commands dir → no-op).
+    deploy_host_claude_commands(workspace_home)
     if baseline is not None:
         _walk_and_apply(baseline, baseline, workspace_home, config=None)
     if root.is_dir():
@@ -303,6 +308,10 @@ def deploy_to_home(config: AgentConfig, workspace_home: str) -> None:
         _stale = dest / _merge_name
         if _stale.is_file():
             _stale.unlink()
+    # Host ~/.claude/commands/*.md — the LOWEST baseline layer. Deploy FIRST so
+    # a same-name shared-baseline / per-agent command overwrites it below.
+    # Skip-if-missing (no host commands dir → no-op).
+    deploy_host_claude_commands(dest)
     if baseline is not None:
         _walk_and_apply(baseline, baseline, dest, config=config)
     if root is not None:

--- a/tests/scitex_agent_container/runtimes/test__host_commands.py
+++ b/tests/scitex_agent_container/runtimes/test__host_commands.py
@@ -1,0 +1,83 @@
+"""Tests for host ``~/.claude/commands/*.md`` baseline deploy.
+
+The operator authors a Claude Code slash command ONCE in the standard host
+location ``~/.claude/commands/`` and it must propagate into every agent's
+materialized ``.claude/commands/``. Host commands are the LOWEST baseline, so
+a same-name per-agent / bundled command wins.
+
+PA-306 no-mocks: real ``tmp_path`` directories. ``$HOME`` is steered to a fake
+host home via the shared ``env_save_restore`` fixture (no monkeypatch) so
+``Path("~/.claude/commands").expanduser()`` resolves under test control.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scitex_agent_container.runtimes._host_commands import (
+    deploy_host_claude_commands,
+)
+from scitex_agent_container.runtimes._to_home import materialize_to_home
+
+
+def _seed_host_commands(fake_home: Path, env_save_restore) -> Path:
+    """Point ``$HOME`` at ``fake_home`` and create its ``.claude/commands/``."""
+    env_save_restore.set("HOME", str(fake_home))
+    cmds = fake_home / ".claude" / "commands"
+    cmds.mkdir(parents=True, exist_ok=True)
+    return cmds
+
+
+class TestDeployHostClaudeCommands:
+    def test_host_command_lands_in_agent_commands(
+        self, tmp_path, env_save_restore
+    ):
+        # Arrange — a fake host ~/.claude/commands/foo.md.
+        host_cmds = _seed_host_commands(tmp_path / "host_home", env_save_restore)
+        (host_cmds / "foo.md").write_text("# /foo\nrun foo\n")
+        agent_home = tmp_path / "agent_home"
+        # Act
+        deploy_host_claude_commands(agent_home)
+        # Assert
+        landed = agent_home / ".claude" / "commands" / "foo.md"
+        assert landed.read_text() == "# /foo\nrun foo\n"
+
+    def test_skip_if_missing_fabricates_no_commands_dir(
+        self, tmp_path, env_save_restore
+    ):
+        # Arrange — host home with NO .claude/commands/ dir.
+        env_save_restore.set("HOME", str(tmp_path / "bare_host_home"))
+        agent_home = tmp_path / "agent_home"
+        # Act — must be a no-op (no error).
+        deploy_host_claude_commands(agent_home)
+        # Assert — no commands dir fabricated in the agent home.
+        assert not (agent_home / ".claude" / "commands").exists()
+
+    def test_non_md_host_entry_is_skipped(self, tmp_path, env_save_restore):
+        # Arrange — a non-.md archive sits beside no .md files.
+        host_cmds = _seed_host_commands(tmp_path / "host_home", env_save_restore)
+        (host_cmds / "archive-old.tar.gz").write_bytes(b"\x00")
+        agent_home = tmp_path / "agent_home"
+        # Act
+        deploy_host_claude_commands(agent_home)
+        # Assert — the non-.md entry did not land.
+        assert not (
+            agent_home / ".claude" / "commands" / "archive-old.tar.gz"
+        ).exists()
+
+
+class TestHostCommandPrecedenceViaMaterialize:
+    def test_per_agent_command_wins_over_host(self, tmp_path, env_save_restore):
+        # Arrange — host /foo.md AND a per-agent to_home/.claude/commands/foo.md.
+        host_cmds = _seed_host_commands(tmp_path / "host_home", env_save_restore)
+        (host_cmds / "foo.md").write_text("HOST VERSION\n")
+        spec_dir = tmp_path / "spec"
+        per_agent = spec_dir / "to_home" / ".claude" / "commands"
+        per_agent.mkdir(parents=True)
+        (per_agent / "foo.md").write_text("AGENT VERSION\n")
+        agent_home = tmp_path / "agent_home"
+        # Act
+        materialize_to_home(spec_dir, agent_home)
+        # Assert — the per-agent command overwrites the host one.
+        landed = agent_home / ".claude" / "commands" / "foo.md"
+        assert landed.read_text() == "AGENT VERSION\n"


### PR DESCRIPTION
## Summary
- Operator-authored Claude Code slash commands in the standard host
  `~/.claude/commands/` (e.g. `/incidence`, `/constitution`) were invisible
  inside agent containers — the agent's `~/.claude/commands/` only carried what
  `to_home` materialization deployed.
- New focused helper `runtimes/_host_commands.py` resolves the host
  `~/.claude/commands/` (`Path("~/.claude/commands").expanduser()` — no
  hard-coded username) and copies each `*.md` into the agent's materialized
  `.claude/commands/` as the LOWEST baseline layer.
- Wired into both `materialize_to_home` and `deploy_to_home` BEFORE the
  shared-baseline / per-agent walk, so a same-name per-agent or bundled command
  still WINS (matches the existing to_home cascade precedence).
- Skip-if-missing (no host commands dir → no-op, no fabricated dir); non-`.md`
  entries (e.g. `archive-*.tar.gz`) skipped.
- New logic lives in the helper because `_to_home.py` is already over the
  512-line cap; the change to `_to_home.py` is purely additive (import + one
  call site per entrypoint).

## Test plan
New `tests/.../test__host_commands.py` (no mocks; `$HOME` steered to a fake host
home via `env_save_restore`):
- [x] `test_host_command_lands_in_agent_commands` — fake host `foo.md` lands at agent `.claude/commands/foo.md`
- [x] `test_skip_if_missing_fabricates_no_commands_dir` — no host commands dir → no error, no dir fabricated
- [x] `test_per_agent_command_wins_over_host` — per-agent `to_home` command overrides the host one
- [x] Existing to_home suite (95 tests) still green — no regression

Note: full end-to-end verification (a host-authored slash command actually
running inside a LIVE agent) is post-merge + agent restart, since
materialization runs at agent start.