### PR TITLE
fix(cron): make post-merge-pull remote-agnostic (origin/develop)

### DIFF
--- a/src/scitex_agent_container/cron/post-merge-pull.sh
+++ b/src/scitex_agent_container/cron/post-merge-pull.sh
@@ -1,8 +1,13 @@
 #!/usr/bin/env bash
-# post-merge-pull.sh — pull every scitex-* in-tree clone from gitea:develop.
+# post-merge-pull.sh — fast-forward every scitex-* in-tree clone from its
+# tracked upstream (origin/develop on the fleet checkouts).
 #
-# Designed to run under cron once a minute on each fleet host.
+# Designed to run under cron once a minute on each fleet host so the host
+# checkouts stay current and nobody has to pull by hand.
 # Scope: ~/proj/<repo> only.  ~/forks/ and workspace clones are skipped.
+# Remote-agnostic: uses each branch's configured upstream — no hardcoded
+# remote name or URL.  Only ever touches a checkout that is on `develop`
+# with a clean working tree; feature-branch / dirty checkouts are left alone.
 #
 # Usage:
 #   crontab: * * * * * ~/.scitex/agent-container/runtime/cron/post-merge-pull.sh \
@@ -29,15 +34,17 @@ if ! flock -n 9; then
 fi
 
 # ---------------------------------------------------------------------------
-# Repo list: canonical name → gitea remote URL
+# Repo allowlist: canonical scitex repo names.  Each resolves to ~/proj/<name>
+# and is pulled via its tracked upstream (origin/develop) — no remote URL is
+# hardcoded here.  A name whose dir is absent is skipped.
 # ---------------------------------------------------------------------------
-declare -A GITEA_URLS=(
-    ["scitex-agent-container"]="git@git.scitex.ai:ywatanabe1989/scitex-agent-container.git"
-    ["scitex-orochi"]="git@git.scitex.ai:ywatanabe1989/scitex-orochi.git"
-    ["scitex-resource"]="git@git.scitex.ai:ywatanabe1989/scitex-resource.git"
-    ["scitex-ssh"]="git@git.scitex.ai:ywatanabe1989/scitex-ssh.git"
-    ["scitex-hpc"]="git@git.scitex.ai:ywatanabe1989/scitex-hpc.git"
-    ["scitex"]="git@git.scitex.ai:ywatanabe1989/scitex.git"
+REPOS=(
+    "scitex-agent-container"
+    "scitex-orochi"
+    "scitex-resource"
+    "scitex-ssh"
+    "scitex-hpc"
+    "scitex"
 )
 
 _pull_repo() {
@@ -49,6 +56,21 @@ _pull_repo() {
         return 0
     }
 
+    # Must be an actual git repo.
+    if ! git -C "${repo_path}" rev-parse --git-dir &>/dev/null; then
+        _info "SKIP ${name}: not a git repository at ${repo_path}"
+        return 0
+    fi
+
+    # Only ever touch a checkout that is on develop — never disturb a
+    # feature-branch checkout.
+    local branch
+    branch="$(git -C "${repo_path}" rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+    if [[ "${branch}" != "develop" ]]; then
+        _info "SKIP ${name}: on '${branch}', not 'develop'"
+        return 0
+    fi
+
     # Skip repos with uncommitted local changes (contributor workspace guard).
     local dirty
     dirty="$(git -C "${repo_path}" status --porcelain 2>/dev/null || true)"
@@ -57,37 +79,25 @@ _pull_repo() {
         return 0
     fi
 
-    # Ensure gitea remote exists (idempotent).
-    local gitea_url="${GITEA_URLS[${name}]}"
-    if ! git -C "${repo_path}" remote get-url gitea &>/dev/null; then
-        git -C "${repo_path}" remote add gitea "${gitea_url}"
-        _info "Added remote 'gitea' → ${gitea_url} for ${name}"
-    fi
-
-    # Fetch + ff-only pull from gitea develop.
-    if ! git -C "${repo_path}" fetch gitea develop 2>>"${LOG_FILE}"; then
-        _warn "FAIL ${name}: fetch gitea develop failed"
-        return 0
-    fi
-
+    # Fast-forward only, via the branch's configured upstream (origin/develop).
     local before_sha after_sha
     before_sha="$(git -C "${repo_path}" rev-parse HEAD)"
 
-    if ! git -C "${repo_path}" pull --ff-only gitea develop 2>>"${LOG_FILE}"; then
-        _warn "FAIL ${name}: pull --ff-only failed (non-fast-forward?)"
+    if ! git -C "${repo_path}" pull --ff-only 2>>"${LOG_FILE}"; then
+        _warn "FAIL ${name}: pull --ff-only failed (non-fast-forward or no upstream?)"
         return 0
     fi
 
     after_sha="$(git -C "${repo_path}" rev-parse HEAD)"
     if [[ "${before_sha}" == "${after_sha}" ]]; then
-        _info "OK ${name}: already at $(echo "${after_sha}" | head -c 12) (no new commits)"
+        _info "OK ${name}: already at ${after_sha:0:12} (no new commits)"
     else
         _info "OK ${name}: ${before_sha:0:12} → ${after_sha:0:12}"
     fi
 }
 
 _info "--- post-merge-pull start (host=${HOST}) ---"
-for repo_name in "${!GITEA_URLS[@]}"; do
+for repo_name in "${REPOS[@]}"; do
     _pull_repo "${repo_name}"
 done
 _info "--- post-merge-pull done ---"

--- a/tests/scitex_agent_container/cli_pkg/test_installation_group.py
+++ b/tests/scitex_agent_container/cli_pkg/test_installation_group.py
@@ -382,49 +382,75 @@ def test_boot_dry_run_mentions_pip_install_plan(
 # ---------------------------------------------------------------------------
 
 
-def _make_repo(path: Path, name: str) -> Path:
-    """Create a bare upstream and a clone with 'gitea' remote."""
+_GIT_ENV = {
+    "GIT_AUTHOR_NAME": "test",
+    "GIT_AUTHOR_EMAIL": "t@t",
+    "GIT_COMMITTER_NAME": "test",
+    "GIT_COMMITTER_EMAIL": "t@t",
+}
+
+
+def _git(clone: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "-C", str(clone), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+        env={**os.environ, **_GIT_ENV},
+    )
+
+
+def _make_repo(path: Path, name: str, *, branch: str = "develop") -> Path:
+    """Create a bare upstream on `develop` plus a clone tracking it.
+
+    The clone is checked out on ``branch`` with origin/develop as the
+    tracked upstream — exactly the fleet layout the cron script targets
+    (remote-agnostic: the remote is named ``origin``, not ``gitea``).
+    """
     upstream = path / f"{name}-upstream"
     clone = path / "proj" / name
     upstream.mkdir(parents=True)
-    clone.mkdir(parents=True)
 
     subprocess.run(
-        ["git", "init", "--bare", str(upstream)], check=True, capture_output=True
-    )
-    subprocess.run(["git", "init", str(clone)], check=True, capture_output=True)
-    subprocess.run(
-        ["git", "-C", str(clone), "remote", "add", "gitea", str(upstream)],
+        ["git", "init", "--bare", "-b", "develop", str(upstream)],
         check=True,
         capture_output=True,
     )
-    (clone / "README.md").write_text("hello")
+    # Seed the upstream develop branch via a throwaway clone.
+    seed = path / f"{name}-seed"
     subprocess.run(
-        ["git", "-C", str(clone), "add", "."], check=True, capture_output=True
+        ["git", "clone", str(upstream), str(seed)], check=True, capture_output=True
     )
+    _git(seed, "checkout", "-b", "develop")
+    (seed / "README.md").write_text("hello")
+    _git(seed, "add", ".")
+    _git(seed, "commit", "-m", "init")
+    _git(seed, "push", "-u", "origin", "develop")
+
+    # The fleet checkout: origin = upstream, on develop tracking it.
     subprocess.run(
-        ["git", "-C", str(clone), "commit", "--allow-empty", "-m", "init"],
-        check=True,
-        capture_output=True,
-        env={
-            **os.environ,
-            "GIT_AUTHOR_NAME": "test",
-            "GIT_AUTHOR_EMAIL": "t@t",
-            "GIT_COMMITTER_NAME": "test",
-            "GIT_COMMITTER_EMAIL": "t@t",
-        },
+        ["git", "clone", str(upstream), str(clone)], check=True, capture_output=True
     )
-    subprocess.run(
-        ["git", "-C", str(clone), "push", "gitea", "HEAD:develop"],
-        check=True,
-        capture_output=True,
-    )
+    _git(clone, "checkout", "develop")
+    if branch != "develop":
+        _git(clone, "checkout", "-b", branch)
     return clone
+
+
+def _advance_upstream(path: Path, name: str) -> None:
+    """Push a new develop commit upstream so the clone can fast-forward."""
+    upstream = path / f"{name}-upstream"
+    seed = path / f"{name}-seed"
+    (seed / "more.txt").write_text("more")
+    _git(seed, "add", ".")
+    _git(seed, "commit", "-m", "second")
+    _git(seed, "push", "origin", "develop")
+    _ = upstream  # upstream already wired via origin
 
 
 def _post_merge_pull_script() -> Path:
     return (
-        Path(__file__).parent.parent
+        Path(__file__).parents[3]
         / "src"
         / "scitex_agent_container"
         / "cron"
@@ -440,45 +466,100 @@ def post_merge_pull_script() -> Path:
     return script
 
 
+def _run_script(script: Path, home: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", str(script)],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "HOME": str(home)},
+    )
+
+
+def _log_text(home: Path) -> str:
+    log_dir = home / ".scitex" / "agent-container" / "runtime" / "logs"
+    return "\n".join(p.read_text() for p in log_dir.glob("post-merge-pull.*.log"))
+
+
+_REPO = "scitex-agent-container"
+
+
 @pytest.mark.integration
 class TestPostMergePullScript:
     """Real bash + real git — no mocks anywhere."""
 
-    def test_script_pulls_clean_repo_returns_zero(
-        self, tmp_path, post_merge_pull_script
-    ):
+    # -- clean develop checkout: fast-forwards from tracked upstream --------
+
+    @pytest.fixture
+    def clean_develop_run(self, tmp_path, post_merge_pull_script):
+        clone = _make_repo(tmp_path, _REPO)
+        before = _git(clone, "rev-parse", "HEAD").stdout.strip()
+        _advance_upstream(tmp_path, _REPO)
+        result = _run_script(post_merge_pull_script, tmp_path)
+        after = _git(clone, "rev-parse", "HEAD").stdout.strip()
+        return result, before, after
+
+    def test_clean_develop_returns_zero(self, clean_develop_run):
         # Arrange
-        _make_repo(tmp_path, "scitex-agent-container")
-        log_dir = tmp_path / ".scitex" / "orochi" / "shared" / "logs"
-        log_dir.mkdir(parents=True)
-        env = {**os.environ, "HOME": str(tmp_path)}
         # Act
-        result = subprocess.run(
-            ["bash", str(post_merge_pull_script)],
-            capture_output=True,
-            text=True,
-            env=env,
-        )
+        result, _before, _after = clean_develop_run
         # Assert
         assert result.returncode == 0
 
-    def test_script_skips_dirty_repo_with_warn(self, tmp_path, post_merge_pull_script):
+    def test_clean_develop_fast_forwards_to_upstream(self, clean_develop_run):
         # Arrange
-        clone = _make_repo(tmp_path, "scitex-agent-container")
-        (clone / "dirty.txt").write_text("unsaved")
-        subprocess.run(
-            ["git", "-C", str(clone), "add", "dirty.txt"], capture_output=True
-        )
-        log_dir = tmp_path / ".scitex" / "orochi" / "shared" / "logs"
-        log_dir.mkdir(parents=True)
-        env = {**os.environ, "HOME": str(tmp_path)}
         # Act
-        subprocess.run(
-            ["bash", str(post_merge_pull_script)],
-            capture_output=True,
-            text=True,
-            env=env,
-        )
+        _result, before, after = clean_develop_run
         # Assert
-        log_files = list(log_dir.glob("post-merge-pull.*.log"))
-        assert log_files
+        assert after != before
+
+    # -- feature-branch checkout: never touched ----------------------------
+
+    @pytest.fixture
+    def feature_branch_run(self, tmp_path, post_merge_pull_script):
+        clone = _make_repo(tmp_path, _REPO, branch="feat/wip")
+        before = _git(clone, "rev-parse", "HEAD").stdout.strip()
+        _advance_upstream(tmp_path, _REPO)
+        result = _run_script(post_merge_pull_script, tmp_path)
+        after = _git(clone, "rev-parse", "HEAD").stdout.strip()
+        return result, before, after, _log_text(tmp_path)
+
+    def test_feature_branch_head_unchanged(self, feature_branch_run):
+        # Arrange
+        # Act
+        _result, before, after, _log = feature_branch_run
+        # Assert
+        assert after == before
+
+    def test_feature_branch_logs_skip(self, feature_branch_run):
+        # Arrange
+        # Act
+        _result, _before, _after, log = feature_branch_run
+        # Assert
+        assert "not 'develop'" in log
+
+    # -- dirty develop checkout: skipped with a warning --------------------
+
+    @pytest.fixture
+    def dirty_develop_run(self, tmp_path, post_merge_pull_script):
+        clone = _make_repo(tmp_path, _REPO)
+        before = _git(clone, "rev-parse", "HEAD").stdout.strip()
+        (clone / "dirty.txt").write_text("unsaved")
+        _git(clone, "add", "dirty.txt")
+        _advance_upstream(tmp_path, _REPO)
+        result = _run_script(post_merge_pull_script, tmp_path)
+        after = _git(clone, "rev-parse", "HEAD").stdout.strip()
+        return result, before, after, _log_text(tmp_path)
+
+    def test_dirty_develop_head_unchanged(self, dirty_develop_run):
+        # Arrange
+        # Act
+        _result, before, after, _log = dirty_develop_run
+        # Assert
+        assert after == before
+
+    def test_dirty_develop_logs_uncommitted_warning(self, dirty_develop_run):
+        # Arrange
+        # Act
+        _result, _before, _after, log = dirty_develop_run
+        # Assert
+        assert "uncommitted changes" in log


### PR DESCRIPTION
## Summary
`cron/post-merge-pull.sh` (the every-minute fleet auto-pull) hardcoded a `gitea` remote: a `GITEA_URLS` map + `git remote add gitea ...` + `git pull --ff-only gitea develop`. Fleet checkouts use `origin`=GitHub with **no** `gitea` remote, so every run died with `fatal: 'gitea' does not appear to be a git repository` -- hosts never auto-updated and people pulled by hand.

- Dropped `GITEA_URLS` and **all** gitea-specific logic (`remote add`, `fetch gitea develop`, `pull --ff-only gitea develop`).
- Kept an explicit repo-NAME allowlist (scitex-agent-container, scitex-orochi, scitex-resource, scitex-ssh, scitex-hpc, scitex), each resolved as `~/proj/<name>`; absent dirs skipped.
- Per repo: act only if it is a git repo **on `develop`** with a **clean** tree, then `git -C <repo> pull --ff-only` with **no explicit remote/branch** (uses the tracked upstream = origin/develop). Feature-branch checkouts are SKIPped with an info log; never disturbed. Before/after SHA logging kept.
- Unchanged: `flock` single-instance lock, dirty-skip guard, `--ff-only` only, `LOG_DIR` under `~/.scitex/agent-container/runtime/logs`, `set -euo pipefail`, ts info/warn helpers. Header + inline comments now reference origin/develop (tracked upstream).

## How I verified
- `bash -n` clean.
- `shellcheck` not installed on this host (`command -v shellcheck` -> none), so not run.
- Fixed the existing integration harness in `tests/.../cli_pkg/test_installation_group.py` -- its script path was wrong (`tests/.../src/...`), so the old tests silently **skipped**. Now builds real `develop`-checkout clones with a tracked upstream (real bash + real git, no mocks):
  - `test_clean_develop_returns_zero` / `test_clean_develop_fast_forwards_to_upstream` -- ff-pull via tracked upstream
  - `test_feature_branch_head_unchanged` / `test_feature_branch_logs_skip` -- feature branch left alone
  - `test_dirty_develop_head_unchanged` / `test_dirty_develop_logs_uncommitted_warning` -- dirty tree skipped with warn
  - **`6 passed in 18.43s`** (`-m integration`).

## Scheduling note
This PR only fixes the script. Wiring it into cron (the crontab line + deploying to `~/.scitex/agent-container/runtime/cron/`) is a **separate dotfiles/host step**, not part of this change.
