### PR TITLE
feat(to_home): deploy curated host skills (ywatanabe, scitex) to agents

### DIFF
--- a/src/scitex_agent_container/runtimes/_host_skills.py
+++ b/src/scitex_agent_container/runtimes/_host_skills.py
@@ -1,0 +1,79 @@
+"""Deploy a curated set of the operator's host ``~/.claude/skills/`` as an agent baseline.
+
+Claude Code dev-rule skills (the ``ywatanabe`` and ``scitex`` skill sets)
+live in the standard host directory ``~/.claude/skills/`` (one ``<name>/``
+dir per skill, each carrying a ``SKILL.md``). They are NOT visible inside an
+agent container, whose ``~/.claude/skills/`` only carries whatever the agent
+materialized for itself — so the operator's general dev-rule skills never load.
+
+This module closes that gap, mirroring :mod:`._host_commands`: at deploy time
+it resolves each curated host skill dir (``Path("~/.claude/skills/<name>").
+expanduser()`` — never a hard-coded username) and symlinks it into the agent's
+materialized ``.claude/skills/<name>``.
+
+Why a curated allowlist: the operator chose exactly the dev-rule skill SETS
+(``ywatanabe`` and ``scitex``) — NOT the tool skills, and explicitly NOT
+``secret`` / ``scitex-lead``. Keep the allowlist tight.
+
+Why symlink (not copy): the host entry ``~/.claude/skills/<name>`` is itself a
+symlink (e.g. ``-> ~/.dotfiles/src/.claude/skills/ywatanabe``); its
+``.resolve()``d real target is bind-visible inside the container (apptainer
+binds the host home at the same path), it matches how the operator's own
+``~/.claude/skills/`` references these (symlinks), and it stays live without
+re-copying. The link is created with the ABSOLUTE resolved target (a relative
+link would break — the agent home sits at a different depth).
+
+Precedence: per-agent / sac-bundled skills WIN. If an agent-side
+``skills/<name>`` already exists, it is left untouched (no clobber).
+
+Skip-if-missing: a curated name absent on the host → no-op for that name (no
+error). No empty ``skills/`` dir is fabricated when nothing is deployed.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# The curated host dev-rule skill SETS the operator chose to propagate into
+# every agent. Deliberately excludes tool skills and ``secret`` /
+# ``scitex-lead``. Resolved fresh at deploy time so each always tracks the real
+# host user (no hard-coded username).
+_DEFAULT_SKILLS: tuple[str, ...] = ("ywatanabe", "scitex")
+
+
+def deploy_host_skills(
+    workspace_home: Path,
+    names: tuple[str, ...] = _DEFAULT_SKILLS,
+) -> None:
+    """Symlink curated host ``~/.claude/skills/<name>`` into ``<workspace_home>/.claude/skills/``.
+
+    For each ``name`` in ``names`` resolve the host skill dir
+    ``~/.claude/skills/<name>`` (itself a symlink) to its real absolute target
+    via ``.resolve()``. When that target exists and is a directory, create a
+    symlink ``<workspace_home>/.claude/skills/<name>`` pointing at the ABSOLUTE
+    resolved target.
+
+    Skip-if-missing: a host skill absent → no-op for that name. No clobber: an
+    existing agent-side ``skills/<name>`` (per-agent / bundled) is left in
+    place. The agent ``skills/`` dir is created only when at least one skill is
+    deployed.
+    """
+    dst_dir = Path(workspace_home) / ".claude" / "skills"
+    for name in names:
+        host_entry = Path(f"~/.claude/skills/{name}").expanduser()
+        target = host_entry.resolve()
+        if not target.is_dir():
+            continue
+        dst = dst_dir / name
+        if dst.exists() or dst.is_symlink():
+            # Per-agent / bundled skill of the same name wins — do not clobber.
+            continue
+        dst_dir.mkdir(parents=True, exist_ok=True)
+        dst.symlink_to(target)
+        logger.info("to_home: host skill %s -> %s", name, target)
+
+
+__all__ = ["deploy_host_skills"]

--- a/src/scitex_agent_container/runtimes/_to_home.py
+++ b/src/scitex_agent_container/runtimes/_to_home.py
@@ -57,20 +57,24 @@ content — see ``_to_home_errors.py`` for context.
 
 from __future__ import annotations
 
-import json
 import logging
 import os
-import re
-import shutil
-import stat
-from datetime import datetime
 from pathlib import Path
 
 from ..config import AgentConfig
 from ._envrc import fold_envrc_cascade_into_env, fold_envrc_into_env
 from ._host_commands import deploy_host_claude_commands
-from ._mcp_merge import merge_mcp_json
+from ._host_skills import deploy_host_skills
 from ._symlink_resolve import DanglingToHomeSymlinkError, deref_copy_symlink
+from ._to_home_deployers import (
+    _clear_readonly_dst,
+    _deploy_marker_protected,
+    _deploy_mcp_merge,
+    _deploy_plain_file,
+    _deploy_tight_perm_file,
+    _deploy_verbatim_secret,
+    _read_and_interpolate,
+)
 from ._to_home_errors import (
     WorkspaceCLAUDEMarkerError,
     WorkspaceCredentialLeakError,
@@ -96,6 +100,12 @@ _validate_marker_invariants = validate_marker_invariants
 _extract_user_tail = extract_user_tail
 _interpolate_env = interpolate_env
 _interpolate_metadata = interpolate_metadata
+
+# Per-entry deploy helpers live in :mod:`_to_home_deployers` (re-imported
+# above). Re-bound here so legacy imports
+# (``from ...runtimes._to_home import _deploy_plain_file``) keep resolving.
+_END_MARKER = END_MARKER
+_split_around_generated_section = split_around_generated_section
 
 
 # Files that get marker-protected merge semantics (vs. full overwrite).
@@ -252,6 +262,9 @@ def materialize_to_home(spec_dir: Path, workspace_home: Path) -> None:
     # a same-name shared-baseline / per-agent command overwrites it below.
     # Skip-if-missing (no host commands dir → no-op).
     deploy_host_claude_commands(workspace_home)
+    # Curated host ~/.claude/skills/<name> (ywatanabe, scitex) — symlinked in.
+    # No-clobber: a per-agent / bundled same-name skill is left untouched.
+    deploy_host_skills(workspace_home)
     if baseline is not None:
         _walk_and_apply(baseline, baseline, workspace_home, config=None)
     if root.is_dir():
@@ -312,6 +325,9 @@ def deploy_to_home(config: AgentConfig, workspace_home: str) -> None:
     # a same-name shared-baseline / per-agent command overwrites it below.
     # Skip-if-missing (no host commands dir → no-op).
     deploy_host_claude_commands(dest)
+    # Curated host ~/.claude/skills/<name> (ywatanabe, scitex) — symlinked in.
+    # No-clobber: a per-agent / bundled same-name skill is left untouched.
+    deploy_host_skills(dest)
     if baseline is not None:
         _walk_and_apply(baseline, baseline, dest, config=config)
     if root is not None:
@@ -435,223 +451,10 @@ def _walk_and_apply(
 
 
 # --- per-entry deploy helpers ----------------------------------------------
-
-
-def _clear_readonly_dst(dst: Path) -> None:
-    """Make an existing ``dst`` overwritable before a copy/write.
-
-    Hooks deployed under ``to_home/`` are commonly mode 0755/read-only
-    (e.g. ``hook_switch_helper.sh``). ``shutil.copy2`` / ``Path.write_text``
-    over a read-only existing destination raise
-    ``PermissionError: [Errno 13]`` — the deploy from #142 hit exactly
-    this. We add the owner-write bit so the in-place overwrite succeeds.
-
-    No-op when ``dst`` doesn't exist or is already writable. Symlinks are
-    left untouched (the symlink path unlinks them instead). Genuinely
-    unexpected ``OSError`` (e.g. EROFS, EPERM on a foreign-owned file) is
-    re-raised so the deploy still crashes loud rather than masking a real
-    permissions problem.
-    """
-    if dst.is_symlink() or not dst.exists():
-        return
-    mode = dst.stat().st_mode
-    if not mode & stat.S_IWUSR:
-        os.chmod(dst, mode | stat.S_IWUSR)
-
-
-# Symlinks are dereference-copied to real content — see
-# :func:`_symlink_resolve.deref_copy_symlink`. The traversal calls it
-# directly; this module re-exports the symbol for callers.
-
-
-def _read_and_interpolate(src: Path, config: AgentConfig | None) -> str:
-    """Read ``src`` as text and apply metadata/env interpolation.
-
-    Interpolation runs only when an ``AgentConfig`` is supplied (i.e. the
-    public ``deploy_to_home`` entrypoint). The lower-level
-    ``materialize_to_home(spec_dir, workspace_home)`` signature copies
-    text verbatim — useful for unit tests and any caller that doesn't
-    have a full AgentConfig in hand.
-    """
-    text = src.read_text()
-    if config is not None and text.strip():
-        text = _interpolate_metadata(text, config)
-        text = _interpolate_env(text)
-    return text
-
-
-def _deploy_plain_file(
-    src: Path,
-    dst: Path,
-    *,
-    config: AgentConfig | None,
-    rel: Path,
-) -> None:
-    """Full overwrite. Uses ``shutil.copy2`` for binary-safe perm preserve
-    when no interpolation is needed; otherwise writes interpolated text."""
-    dst.parent.mkdir(parents=True, exist_ok=True)
-    _clear_readonly_dst(dst)
-    if config is None:
-        shutil.copy2(src, dst)
-    else:
-        # Best-effort interpolation: binary files raise UnicodeDecodeError
-        # on read_text; fall back to byte copy in that case.
-        try:
-            text = _read_and_interpolate(src, config)
-            dst.write_text(text)
-            shutil.copystat(src, dst)
-        except UnicodeDecodeError:
-            shutil.copy2(src, dst)
-    logger.info("to_home: deployed %s -> %s", rel, dst)
-
-
-def _deploy_mcp_merge(
-    src: Path,
-    dst: Path,
-    *,
-    config: AgentConfig | None,
-    rel: Path,
-) -> None:
-    """Deep-merge ``.mcp.json`` with any already-deployed (baseline) copy.
-
-    The two-pass overlay deploys the shared baseline ``.mcp.json`` first, then
-    each agent's own lands here. Full-overwrite would silently drop the
-    baseline's default servers (sac / scitex-todo / claude-code-telegrammer);
-    instead we UNION the ``mcpServers`` (baseline ∪ per-agent) via
-    :func:`_mcp_merge.merge_mcp_json`. Fail-loud (no silent fallback): an
-    unparseable source/destination ``.mcp.json`` raises
-    :class:`WorkspaceMcpMergeError`; a same-name server defined two different
-    ways raises :class:`_mcp_merge.McpMergeConflict`. Both abort the deploy.
-    """
-    dst.parent.mkdir(parents=True, exist_ok=True)
-    _clear_readonly_dst(dst)
-    overlay_text = _read_and_interpolate(src, config)
-    try:
-        overlay_doc = json.loads(overlay_text) if overlay_text.strip() else {}
-    except json.JSONDecodeError as exc:
-        raise WorkspaceMcpMergeError(
-            f"to_home: source {rel} is not valid JSON ({exc})"
-        ) from exc
-    if dst.is_file():
-        existing = dst.read_text()
-        try:
-            base_doc = json.loads(existing) if existing.strip() else {}
-        except json.JSONDecodeError as exc:
-            raise WorkspaceMcpMergeError(
-                f"to_home: existing {dst} is not valid JSON ({exc})"
-            ) from exc
-        merged = merge_mcp_json(base_doc, overlay_doc)
-    else:
-        merged = overlay_doc
-    dst.write_text(json.dumps(merged, indent=2) + "\n")
-    logger.info("to_home: deep-merged .mcp.json %s -> %s", rel, dst)
-
-
-def _deploy_tight_perm_file(
-    src: Path,
-    dst: Path,
-    *,
-    config: AgentConfig | None,
-    rel: Path,
-) -> None:
-    """Full overwrite, then chmod 0600 (e.g. ``.env``)."""
-    text = _read_and_interpolate(src, config)
-    dst.parent.mkdir(parents=True, exist_ok=True)
-    _clear_readonly_dst(dst)
-    if not text.endswith("\n"):
-        text += "\n"
-    dst.write_text(text)
-    try:
-        os.chmod(dst, 0o600)
-    except OSError as exc:  # stx-allow: fallback (reason: filesystem op failure)
-        logger.warning("Failed to chmod 0600 on %s: %s", dst, exc)
-    logger.info("to_home: deployed (0600) %s -> %s", rel, dst)
-
-
-def _deploy_verbatim_secret(src: Path, dst: Path, *, rel: Path) -> None:
-    """Byte-for-byte copy (NO interpolation) + chmod 0600. For ``.envrc``.
-
-    Unlike :func:`_deploy_tight_perm_file`, this NEVER runs ``${...}``
-    interpolation: a ``.envrc`` is a shell script and its own ``${VAR}`` /
-    ``$(...)`` syntax must reach bash intact (sac interpolation would expand
-    it at deploy time and corrupt the script). The file is evaluated later by
-    :func:`_envrc.fold_envrc_into_env`.
-    """
-    dst.parent.mkdir(parents=True, exist_ok=True)
-    _clear_readonly_dst(dst)
-    shutil.copy2(src, dst)
-    try:
-        os.chmod(dst, 0o600)
-    except OSError as exc:  # stx-allow: fallback (reason: filesystem op failure)
-        logger.warning("Failed to chmod 0600 on %s: %s", dst, exc)
-    logger.info("to_home: deployed verbatim (0600) %s -> %s", rel, dst)
-
-
-def _deploy_marker_protected(
-    src: Path,
-    dst: Path,
-    *,
-    config: AgentConfig | None,
-    rel: Path,
-) -> None:
-    """Marker-protected merge for CLAUDE.md / state.md.
-
-    Invariants:
-      - Source wrapped in Start/End markers.
-      - Existing user content past the End marker is preserved.
-      - Malformed existing markers (count != 1 or order swapped)
-        hard-abort with :class:`WorkspaceCLAUDEMarkerError`.
-    """
-    section_content = src.read_text().strip()
-    if not section_content:
-        return
-
-    if config is not None:
-        section_content = _interpolate_metadata(section_content, config)
-
-    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-    start_tag = (
-        f"<!-- Start of scitex-agent-container generated section ({timestamp}) -->"
-    )
-
-    # Strip any embedded sac markers from the source so we don't end up
-    # with nested Start/End pairs after wrapping (defensive scrub for
-    # CLAUDE.md).
-    section_body = re.sub(
-        r"<!--.*?scitex-agent-container.*?-->\n?",
-        "",
-        section_content,
-    ).strip()
-
-    new_content = f"{start_tag}\n{section_body}\n{END_MARKER}\n"
-
-    existing_text = dst.read_text() if dst.exists() else ""
-    # Preserve content AROUND a prior generated section: the ``head`` BEFORE it
-    # (e.g. the setup_claude_md auto agent-section, which uses its OWN marker
-    # style — so the two now compose instead of fatal-ing when the baseline
-    # lives at .claude/CLAUDE.md) and the ``tail`` AFTER it (operator-appended
-    # content). Malformed markers still fail loud inside the split.
-    head, user_tail = split_around_generated_section(existing_text, str(dst))
-
-    body = new_content
-    if user_tail.strip():
-        body = body.rstrip("\n") + user_tail
-        if not body.endswith("\n"):
-            body += "\n"
-    if head.strip():
-        updated = head.rstrip("\n") + "\n\n" + body
-    else:
-        updated = body
-
-    dst.parent.mkdir(parents=True, exist_ok=True)
-    _clear_readonly_dst(dst)
-    dst.write_text(updated)
-    logger.info(
-        "to_home: marker-protected %s -> %s (user tail preserved: %s)",
-        rel,
-        dst,
-        "yes" if user_tail else "no",
-    )
+# Extracted to :mod:`._to_home_deployers` (the file outgrew the line cap);
+# re-imported above and re-exported below so legacy import paths still resolve.
+# Symlinks are dereference-copied to real content via
+# :func:`_symlink_resolve.deref_copy_symlink`, called directly by the traversal.
 
 
 # --- internal helpers ------------------------------------------------------
@@ -666,6 +469,16 @@ def _spec_dir(config: AgentConfig) -> Path | None:
 __all__ = [
     "DanglingToHomeSymlinkError",
     "WorkspaceCLAUDEMarkerError",
+    "WorkspaceMcpMergeError",
+    # Per-entry deploy helpers re-exported from _to_home_deployers for the
+    # legacy ``from ...runtimes._to_home import _deploy_*`` import contract.
+    "_clear_readonly_dst",
+    "_deploy_marker_protected",
+    "_deploy_mcp_merge",
+    "_deploy_plain_file",
+    "_deploy_tight_perm_file",
+    "_deploy_verbatim_secret",
+    "_read_and_interpolate",
     "deploy_to_home",
     "materialize_to_home",
     "resolve_baseline_to_home_dir",

--- a/src/scitex_agent_container/runtimes/_to_home_deployers.py
+++ b/src/scitex_agent_container/runtimes/_to_home_deployers.py
@@ -1,0 +1,263 @@
+"""Per-entry deploy helpers for ``to_home`` materialization.
+
+Extracted from :mod:`._to_home` (which had grown past the line cap), mirroring
+the existing ``_to_home_text`` / ``_to_home_settings`` / ``_to_home_errors``
+extractions. These are the low-level "deploy ONE source entry to ONE
+destination" primitives the traversal in :mod:`._to_home` dispatches to per
+basename class:
+
+  - :func:`_deploy_plain_file` — full overwrite.
+  - :func:`_deploy_mcp_merge` — deep-merge ``.mcp.json`` (baseline ∪ per-agent).
+  - :func:`_deploy_tight_perm_file` — overwrite + chmod 0600 (``.env``).
+  - :func:`_deploy_verbatim_secret` — byte copy, NO interpolation, 0600 (``.envrc``).
+  - :func:`_deploy_marker_protected` — marker-protected merge (CLAUDE.md / state.md).
+
+:mod:`._to_home` re-exports these so legacy import paths
+(``from ...runtimes._to_home import _deploy_plain_file``) keep resolving.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import shutil
+import stat
+from datetime import datetime
+from pathlib import Path
+
+from ..config import AgentConfig
+from ._mcp_merge import merge_mcp_json
+from ._to_home_errors import WorkspaceMcpMergeError
+from ._to_home_text import (
+    END_MARKER,
+    interpolate_env,
+    interpolate_metadata,
+    split_around_generated_section,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _clear_readonly_dst(dst: Path) -> None:
+    """Make an existing ``dst`` overwritable before a copy/write.
+
+    Hooks deployed under ``to_home/`` are commonly mode 0755/read-only
+    (e.g. ``hook_switch_helper.sh``). ``shutil.copy2`` / ``Path.write_text``
+    over a read-only existing destination raise
+    ``PermissionError: [Errno 13]`` — the deploy from #142 hit exactly
+    this. We add the owner-write bit so the in-place overwrite succeeds.
+
+    No-op when ``dst`` doesn't exist or is already writable. Symlinks are
+    left untouched (the symlink path unlinks them instead). Genuinely
+    unexpected ``OSError`` (e.g. EROFS, EPERM on a foreign-owned file) is
+    re-raised so the deploy still crashes loud rather than masking a real
+    permissions problem.
+    """
+    if dst.is_symlink() or not dst.exists():
+        return
+    mode = dst.stat().st_mode
+    if not mode & stat.S_IWUSR:
+        os.chmod(dst, mode | stat.S_IWUSR)
+
+
+def _read_and_interpolate(src: Path, config: AgentConfig | None) -> str:
+    """Read ``src`` as text and apply metadata/env interpolation.
+
+    Interpolation runs only when an ``AgentConfig`` is supplied (i.e. the
+    public ``deploy_to_home`` entrypoint). The lower-level
+    ``materialize_to_home(spec_dir, workspace_home)`` signature copies
+    text verbatim — useful for unit tests and any caller that doesn't
+    have a full AgentConfig in hand.
+    """
+    text = src.read_text()
+    if config is not None and text.strip():
+        text = interpolate_metadata(text, config)
+        text = interpolate_env(text)
+    return text
+
+
+def _deploy_plain_file(
+    src: Path,
+    dst: Path,
+    *,
+    config: AgentConfig | None,
+    rel: Path,
+) -> None:
+    """Full overwrite. Uses ``shutil.copy2`` for binary-safe perm preserve
+    when no interpolation is needed; otherwise writes interpolated text."""
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    _clear_readonly_dst(dst)
+    if config is None:
+        shutil.copy2(src, dst)
+    else:
+        # Best-effort interpolation: binary files raise UnicodeDecodeError
+        # on read_text; fall back to byte copy in that case.
+        try:
+            text = _read_and_interpolate(src, config)
+            dst.write_text(text)
+            shutil.copystat(src, dst)
+        except UnicodeDecodeError:
+            shutil.copy2(src, dst)
+    logger.info("to_home: deployed %s -> %s", rel, dst)
+
+
+def _deploy_mcp_merge(
+    src: Path,
+    dst: Path,
+    *,
+    config: AgentConfig | None,
+    rel: Path,
+) -> None:
+    """Deep-merge ``.mcp.json`` with any already-deployed (baseline) copy.
+
+    The two-pass overlay deploys the shared baseline ``.mcp.json`` first, then
+    each agent's own lands here. Full-overwrite would silently drop the
+    baseline's default servers (sac / scitex-todo / claude-code-telegrammer);
+    instead we UNION the ``mcpServers`` (baseline ∪ per-agent) via
+    :func:`_mcp_merge.merge_mcp_json`. Fail-loud (no silent fallback): an
+    unparseable source/destination ``.mcp.json`` raises
+    :class:`WorkspaceMcpMergeError`; a same-name server defined two different
+    ways raises :class:`_mcp_merge.McpMergeConflict`. Both abort the deploy.
+    """
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    _clear_readonly_dst(dst)
+    overlay_text = _read_and_interpolate(src, config)
+    try:
+        overlay_doc = json.loads(overlay_text) if overlay_text.strip() else {}
+    except json.JSONDecodeError as exc:
+        raise WorkspaceMcpMergeError(
+            f"to_home: source {rel} is not valid JSON ({exc})"
+        ) from exc
+    if dst.is_file():
+        existing = dst.read_text()
+        try:
+            base_doc = json.loads(existing) if existing.strip() else {}
+        except json.JSONDecodeError as exc:
+            raise WorkspaceMcpMergeError(
+                f"to_home: existing {dst} is not valid JSON ({exc})"
+            ) from exc
+        merged = merge_mcp_json(base_doc, overlay_doc)
+    else:
+        merged = overlay_doc
+    dst.write_text(json.dumps(merged, indent=2) + "\n")
+    logger.info("to_home: deep-merged .mcp.json %s -> %s", rel, dst)
+
+
+def _deploy_tight_perm_file(
+    src: Path,
+    dst: Path,
+    *,
+    config: AgentConfig | None,
+    rel: Path,
+) -> None:
+    """Full overwrite, then chmod 0600 (e.g. ``.env``)."""
+    text = _read_and_interpolate(src, config)
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    _clear_readonly_dst(dst)
+    if not text.endswith("\n"):
+        text += "\n"
+    dst.write_text(text)
+    try:
+        os.chmod(dst, 0o600)
+    except OSError as exc:  # stx-allow: fallback (reason: filesystem op failure)
+        logger.warning("Failed to chmod 0600 on %s: %s", dst, exc)
+    logger.info("to_home: deployed (0600) %s -> %s", rel, dst)
+
+
+def _deploy_verbatim_secret(src: Path, dst: Path, *, rel: Path) -> None:
+    """Byte-for-byte copy (NO interpolation) + chmod 0600. For ``.envrc``.
+
+    Unlike :func:`_deploy_tight_perm_file`, this NEVER runs ``${...}``
+    interpolation: a ``.envrc`` is a shell script and its own ``${VAR}`` /
+    ``$(...)`` syntax must reach bash intact (sac interpolation would expand
+    it at deploy time and corrupt the script). The file is evaluated later by
+    :func:`_envrc.fold_envrc_into_env`.
+    """
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    _clear_readonly_dst(dst)
+    shutil.copy2(src, dst)
+    try:
+        os.chmod(dst, 0o600)
+    except OSError as exc:  # stx-allow: fallback (reason: filesystem op failure)
+        logger.warning("Failed to chmod 0600 on %s: %s", dst, exc)
+    logger.info("to_home: deployed verbatim (0600) %s -> %s", rel, dst)
+
+
+def _deploy_marker_protected(
+    src: Path,
+    dst: Path,
+    *,
+    config: AgentConfig | None,
+    rel: Path,
+) -> None:
+    """Marker-protected merge for CLAUDE.md / state.md.
+
+    Invariants:
+      - Source wrapped in Start/End markers.
+      - Existing user content past the End marker is preserved.
+      - Malformed existing markers (count != 1 or order swapped)
+        hard-abort with :class:`WorkspaceCLAUDEMarkerError`.
+    """
+    section_content = src.read_text().strip()
+    if not section_content:
+        return
+
+    if config is not None:
+        section_content = interpolate_metadata(section_content, config)
+
+    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    start_tag = (
+        f"<!-- Start of scitex-agent-container generated section ({timestamp}) -->"
+    )
+
+    # Strip any embedded sac markers from the source so we don't end up
+    # with nested Start/End pairs after wrapping (defensive scrub for
+    # CLAUDE.md).
+    section_body = re.sub(
+        r"<!--.*?scitex-agent-container.*?-->\n?",
+        "",
+        section_content,
+    ).strip()
+
+    new_content = f"{start_tag}\n{section_body}\n{END_MARKER}\n"
+
+    existing_text = dst.read_text() if dst.exists() else ""
+    # Preserve content AROUND a prior generated section: the ``head`` BEFORE it
+    # (e.g. the setup_claude_md auto agent-section, which uses its OWN marker
+    # style — so the two now compose instead of fatal-ing when the baseline
+    # lives at .claude/CLAUDE.md) and the ``tail`` AFTER it (operator-appended
+    # content). Malformed markers still fail loud inside the split.
+    head, user_tail = split_around_generated_section(existing_text, str(dst))
+
+    body = new_content
+    if user_tail.strip():
+        body = body.rstrip("\n") + user_tail
+        if not body.endswith("\n"):
+            body += "\n"
+    if head.strip():
+        updated = head.rstrip("\n") + "\n\n" + body
+    else:
+        updated = body
+
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    _clear_readonly_dst(dst)
+    dst.write_text(updated)
+    logger.info(
+        "to_home: marker-protected %s -> %s (user tail preserved: %s)",
+        rel,
+        dst,
+        "yes" if user_tail else "no",
+    )
+
+
+__all__ = [
+    "_clear_readonly_dst",
+    "_deploy_marker_protected",
+    "_deploy_mcp_merge",
+    "_deploy_plain_file",
+    "_deploy_tight_perm_file",
+    "_deploy_verbatim_secret",
+    "_read_and_interpolate",
+]

--- a/tests/scitex_agent_container/runtimes/test__host_skills.py
+++ b/tests/scitex_agent_container/runtimes/test__host_skills.py
@@ -1,0 +1,84 @@
+"""Tests for the curated host ``~/.claude/skills/<name>`` baseline deploy.
+
+The operator's general dev-rule skill SETS (``ywatanabe`` and ``scitex``) live
+under the standard host ``~/.claude/skills/`` and must propagate into every
+agent's materialized ``.claude/skills/`` so agents load them. They are
+symlinked (not copied) to the host skill's resolved real target. The allowlist
+is curated — tool skills and ``secret`` / ``scitex-lead`` are NOT deployed.
+
+PA-306 no-mocks: real ``tmp_path`` directories. ``$HOME`` is steered to a fake
+host home via the shared ``env_save_restore`` fixture (no monkeypatch) so
+``Path("~/.claude/skills/<name>").expanduser()`` resolves under test control.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scitex_agent_container.runtimes._host_skills import deploy_host_skills
+from scitex_agent_container.runtimes._to_home import materialize_to_home
+
+
+def _seed_host_skill(fake_home: Path, name: str, env_save_restore) -> Path:
+    """Point ``$HOME`` at ``fake_home`` and create its ``.claude/skills/<name>``."""
+    env_save_restore.set("HOME", str(fake_home))
+    skill = fake_home / ".claude" / "skills" / name
+    skill.mkdir(parents=True, exist_ok=True)
+    (skill / "SKILL.md").write_text("# skill\n")
+    return skill
+
+
+class TestDeployHostSkills:
+    def test_curated_host_skill_symlinked_into_agent_skills(
+        self, tmp_path, env_save_restore
+    ):
+        # Arrange — a fake host ~/.claude/skills/ywatanabe/ (in the allowlist).
+        host_skill = _seed_host_skill(
+            tmp_path / "host_home", "ywatanabe", env_save_restore
+        )
+        agent_home = tmp_path / "agent_home"
+        # Act
+        deploy_host_skills(agent_home)
+        # Assert — the agent skill resolves to the host skill dir.
+        landed = agent_home / ".claude" / "skills" / "ywatanabe"
+        assert landed.resolve() == host_skill.resolve()
+
+    def test_name_not_present_on_host_is_not_deployed(
+        self, tmp_path, env_save_restore
+    ):
+        # Arrange — host has only ``ywatanabe``; ``scitex`` is absent.
+        _seed_host_skill(tmp_path / "host_home", "ywatanabe", env_save_restore)
+        agent_home = tmp_path / "agent_home"
+        # Act — default allowlist requests both, but scitex must not be fabricated.
+        deploy_host_skills(agent_home)
+        # Assert — the absent name did not land.
+        assert not (agent_home / ".claude" / "skills" / "scitex").exists()
+
+    def test_skip_if_missing_fabricates_no_skills_dir(
+        self, tmp_path, env_save_restore
+    ):
+        # Arrange — host home with NO .claude/skills/ dir at all.
+        env_save_restore.set("HOME", str(tmp_path / "bare_host_home"))
+        agent_home = tmp_path / "agent_home"
+        # Act — must be a no-op (no error).
+        deploy_host_skills(agent_home)
+        # Assert — no skills dir fabricated in the agent home.
+        assert not (agent_home / ".claude" / "skills").exists()
+
+
+class TestHostSkillNoClobberViaMaterialize:
+    def test_existing_agent_skill_is_not_clobbered(
+        self, tmp_path, env_save_restore
+    ):
+        # Arrange — host ywatanabe AND a per-agent to_home/.claude/skills/ywatanabe.
+        _seed_host_skill(tmp_path / "host_home", "ywatanabe", env_save_restore)
+        spec_dir = tmp_path / "spec"
+        per_agent = spec_dir / "to_home" / ".claude" / "skills" / "ywatanabe"
+        per_agent.mkdir(parents=True)
+        (per_agent / "SKILL.md").write_text("AGENT SKILL\n")
+        agent_home = tmp_path / "agent_home"
+        # Act
+        materialize_to_home(spec_dir, agent_home)
+        # Assert — the per-agent skill content wins (host symlink did not clobber).
+        landed = agent_home / ".claude" / "skills" / "ywatanabe" / "SKILL.md"
+        assert landed.read_text() == "AGENT SKILL\n"


### PR DESCRIPTION
## Summary
- The operator's general dev-rule skill sets (`ywatanabe`, `scitex`) live under the host `~/.claude/skills/` and are NOT visible inside agent containers, so agents never load them (parallel to the just-merged host-commands gap).
- Adds `runtimes/_host_skills.deploy_host_skills`, which for a curated allowlist (`ywatanabe`, `scitex` — deliberately NOT the tool skills, and NOT `secret`/`scitex-lead`) resolves each host `~/.claude/skills/<name>` (itself a symlink) to its real absolute target and symlinks it into the agent's `.claude/skills/<name>`. Skip-if-missing per name; no-clobber (a per-agent/bundled same-name skill wins). Symlink (not copy) — the resolved target is bind-visible in the container and matches how the operator's own `~/.claude/skills/` references these.
- Wired into both to_home entrypoints (`materialize_to_home` + `deploy_to_home`) right beside `deploy_host_claude_commands`.
- Drive-by: `_to_home.py` was already over the 512-line cap on `develop`; extracted the cohesive per-entry deploy helpers into `_to_home_deployers.py` (re-exported to preserve legacy import paths), bringing `_to_home.py` back under cap. No behavior change.

## Test plan
- [x] New `tests/.../runtimes/test__host_skills.py` (no mocks, `$HOME` steered to a tmp host home):
  - `test_curated_host_skill_symlinked_into_agent_skills` — agent skill resolves to the host skill dir
  - `test_name_not_present_on_host_is_not_deployed` — absent allowlist name is not fabricated
  - `test_skip_if_missing_fabricates_no_skills_dir` — no host skills dir → no error, no `skills/` fabricated
  - `test_existing_agent_skill_is_not_clobbered` (via `materialize_to_home`) — per-agent skill wins
- [x] Full `tests/scitex_agent_container/runtimes` suite green: 1070 passed, 20 skipped (incl. all existing `_to_home` tests — refactor preserves the legacy import contract).
- Full end-to-end verification (a host skill actually loading inside a live agent) is post-merge + agent restart.