### PR TITLE
fix(envrc): drop empty-valued vars from folded .env (fixes Telegram token shadowing)

### DIFF
--- a/src/scitex_agent_container/runtimes/_envrc.py
+++ b/src/scitex_agent_container/runtimes/_envrc.py
@@ -121,10 +121,14 @@ def eval_envrc(envrc: Path, *, base_env: Path | None = None) -> dict[str, str]:
     lines.append("set +a")
     lines.append("env -0")
     loaded = _capture_env("\n".join(lines), cwd)
+    # Drop EMPTY values: a secret line (``export CCT_BOT_TOKEN="$CCT_BOT_TOKEN_X"``)
+    # folds to ``CCT_BOT_TOKEN=`` when its source is unset at fold time, which then
+    # SHADOWS the real value a later layer supplies (the .mcp.json's legacy-spelled
+    # bot token) — an empty short-form made the bridge read "" and 404 (dead poller).
     return {
         key: val
         for key, val in loaded.items()
-        if key not in _SHELL_NOISE and baseline.get(key) != val
+        if key not in _SHELL_NOISE and baseline.get(key) != val and val != ""
     }
 
 
@@ -194,10 +198,14 @@ def eval_envrc_cascade(
     lines.append("set +a")
     lines.append("env -0")
     loaded = _capture_env("\n".join(lines), cwd)
+    # Drop EMPTY values: a secret line (``export CCT_BOT_TOKEN="$CCT_BOT_TOKEN_X"``)
+    # folds to ``CCT_BOT_TOKEN=`` when its source is unset at fold time, which then
+    # SHADOWS the real value a later layer supplies (the .mcp.json's legacy-spelled
+    # bot token) — an empty short-form made the bridge read "" and 404 (dead poller).
     return {
         key: val
         for key, val in loaded.items()
-        if key not in _SHELL_NOISE and baseline.get(key) != val
+        if key not in _SHELL_NOISE and baseline.get(key) != val and val != ""
     }
 
 

--- a/tests/scitex_agent_container/runtimes/test__envrc.py
+++ b/tests/scitex_agent_container/runtimes/test__envrc.py
@@ -199,14 +199,27 @@ def test_secrets_preamble_does_not_leak_source_secret(
     assert "SECRET_TOK" not in out
 
 
-def test_no_preamble_when_var_unset_is_unchanged(
+def test_empty_unresolved_reference_is_dropped(
     tmp_path: Path, secrets_envrc: None
 ) -> None:
-    # Arrange — SAC_SECRETS_ENVRC unset; .envrc references an undefined var.
+    # Arrange — SAC_SECRETS_ENVRC unset; .envrc references an undefined var,
+    # so the export resolves to an empty string.
     os.environ.pop(_SECRETS_VAR, None)
     envrc = tmp_path / ".envrc"
     envrc.write_text('export PUBLIC="$SECRET_TOK"\n', encoding="utf-8")
     # Act
     out = eval_envrc(envrc)
-    # Assert — today's behaviour: the unresolved reference folds empty.
-    assert out.get("PUBLIC") == ""
+    # Assert — an empty value is DROPPED (not folded as ""), so it cannot shadow
+    # a real value a later layer supplies under another spelling.
+    assert "PUBLIC" not in out
+
+
+def test_fold_omits_empty_valued_var(tmp_path: Path) -> None:
+    # Arrange — .envrc exports one real var and one that resolves empty.
+    (tmp_path / ".envrc").write_text(
+        'export REAL=ok\nexport EMPTY="$UNSET_SOURCE"\n', encoding="utf-8"
+    )
+    # Act
+    fold_envrc_into_env(tmp_path)
+    # Assert — the empty var is not written into the folded .env.
+    assert "EMPTY=" not in (tmp_path / ".env").read_text()


### PR DESCRIPTION
## Summary
- The env fold now omits empty-valued variables. A per-agent secret line `export CCT_BOT_TOKEN="$CCT_BOT_TOKEN_X"` folds to `CCT_BOT_TOKEN=` when its source var is unset at fold time; that empty var then **shadows** the real Telegram bot token the agent `.mcp.json` supplies under a different spelling (`CLAUDE_CODE_TELEGRAMMER_TELEGRAM_BOT_TOKEN`, read from the `/run/dev-secrets` bind). The bridge read an empty token → every Bot API call 404'd → dead poller.
- This is the real cause behind "only one agent connects to Telegram": only agents whose token resolved non-empty worked; the rest were empty-shadowed.

## Why this half
The bridge owner is shipping the complementary guard (its env-reader treats an empty value as absent). Either fix alone resolves it; both = defense in depth. This is the fix at the source — sac shouldn't inject an empty secret var that defeats the real one.

## Test plan
- [x] `test_empty_unresolved_reference_is_dropped` — an unresolved/empty export is omitted, not folded as `""` (updated from the prior test that asserted the buggy behavior)
- [x] `test_fold_omits_empty_valued_var` — the folded `.env` doesn't carry an empty var
- [x] Full `test__envrc.py` — 15 passed
- [ ] After merge + the bridge guard: restart a channel agent and confirm its poller comes up on its own per-agent dir