### PR TITLE
fix(to_home): force-overwrite read-only command files on deploy (un-bricks restart)

### DIFF
--- a/src/scitex_agent_container/runtimes/_host_commands.py
+++ b/src/scitex_agent_container/runtimes/_host_commands.py
@@ -50,6 +50,23 @@ def host_claude_commands_dir() -> Path | None:
     return p if p.is_dir() else None
 
 
+def _copy_force_overwrite(src: Path, dst: Path) -> None:
+    """``shutil.copy2`` that can overwrite a read-only destination.
+
+    ``copy2`` opens ``dst`` for writing and raises ``PermissionError`` when it
+    already exists read-only — and it copies the source mode back afterwards,
+    so a 0444 source leaves a 0444 destination that makes the NEXT deploy fail.
+    A stale read-only command file thus aborts the deploy and leaves the agent
+    DOWN on restart (observed 2026-07-01: a 0444 ``update-docs.md``). Grant
+    owner-write before the copy (so it can overwrite) and after (so the next
+    deploy can too).
+    """
+    if dst.exists():
+        dst.chmod(dst.stat().st_mode | 0o200)
+    shutil.copy2(src, dst)
+    dst.chmod(dst.stat().st_mode | 0o200)
+
+
 def deploy_host_claude_commands(workspace_home: Path) -> None:
     """Copy host ``~/.claude/commands/*.md`` into ``<workspace_home>/.claude/commands/``.
 
@@ -70,7 +87,7 @@ def deploy_host_claude_commands(workspace_home: Path) -> None:
             continue
         dst_dir.mkdir(parents=True, exist_ok=True)
         dst = dst_dir / src.name
-        shutil.copy2(src, dst)
+        _copy_force_overwrite(src, dst)
         logger.info("to_home: host command %s -> %s", src.name, dst)
 
 

--- a/tests/scitex_agent_container/runtimes/test__host_commands.py
+++ b/tests/scitex_agent_container/runtimes/test__host_commands.py
@@ -42,6 +42,22 @@ class TestDeployHostClaudeCommands:
         landed = agent_home / ".claude" / "commands" / "foo.md"
         assert landed.read_text() == "# /foo\nrun foo\n"
 
+    def test_overwrites_read_only_destination(self, tmp_path, env_save_restore):
+        # Arrange — deploy once, then make the landed file read-only (0444) and
+        # change the host source (mirrors a 0444 source mode preserved across
+        # deploys, which aborted a restart and left the agent DOWN).
+        host_cmds = _seed_host_commands(tmp_path / "host_home", env_save_restore)
+        (host_cmds / "foo.md").write_text("v1\n")
+        agent_home = tmp_path / "agent_home"
+        deploy_host_claude_commands(agent_home)
+        landed = agent_home / ".claude" / "commands" / "foo.md"
+        landed.chmod(0o444)
+        (host_cmds / "foo.md").write_text("v2\n")
+        # Act — must overwrite the read-only destination, not raise.
+        deploy_host_claude_commands(agent_home)
+        # Assert
+        assert landed.read_text() == "v2\n"
+
     def test_skip_if_missing_fabricates_no_commands_dir(
         self, tmp_path, env_save_restore
     ):


### PR DESCRIPTION
## Summary
- `deploy_host_claude_commands` used `shutil.copy2`, which raises `PermissionError` overwriting a read-only destination AND copies the source mode back — so a `0444` source leaves a `0444` destination that fails the NEXT deploy.
- A stale read-only command file (`0444 update-docs.md`, hit live 2026-07-01) aborted to_home materialization mid-restart and left scitex-hub DOWN (stop succeeded, start failed).
- Fix: grant owner-write before and after the copy so the deploy always succeeds and the destination stays overwritable.

## Test plan
- [x] `test_overwrites_read_only_destination` — deploy over a `0444` landed file succeeds and updates content
- [x] Full `test__host_commands.py` — 5 passed