### PR TITLE
feat(restart): in-container fresh (no-resume) restart via the host bypass

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_restart_client.py
+++ b/src/scitex_agent_container/_lifecycle/_restart_client.py
@@ -176,6 +176,7 @@ def request_restart(
     name: str,
     *,
     caller: str | None = None,
+    fresh: bool = False,
     base_url: str | None = None,
     bearer: str | None = None,
     timeout_s: float = _DEFAULT_TIMEOUT_S,
@@ -192,6 +193,11 @@ def request_restart(
         The requesting agent's identity for the listen-server's
         ``check_lineage_acl`` MANAGE gate. Defaults to ``SAC_NAME`` from
         the container env via :func:`_resolve_caller`.
+    fresh
+        When True, ask the host to start a NEW Claude session
+        (``start --force --fresh``) instead of a plain resuming restart —
+        the deterministic recovery for an agent wedged on a boot prompt
+        whose queued-input buffer returns on every resuming restart.
     base_url
         Override ``SAC_LISTEN_BASE_URL``. Tests pass an in-process
         listen URL; production passes ``None``.
@@ -226,6 +232,10 @@ def request_restart(
     body: dict[str, Any] = {}
     if resolved_caller:
         body["caller"] = resolved_caller
+    # Omitted (default) keeps the byte-identical plain-restart body; set only
+    # when a fresh (no-resume) restart is requested.
+    if fresh:
+        body["fresh"] = True
 
     payload = json.dumps(body).encode("utf-8")
     url = f"{base}/agents/{name}/restart"

--- a/src/scitex_agent_container/_listen/_agent_restart.py
+++ b/src/scitex_agent_container/_listen/_agent_restart.py
@@ -93,6 +93,12 @@ async def agent_restart(request: Request) -> JSONResponse:
     if decision == "deny":
         return deny_response(reason or "lineage ACL deny")
 
+    # ``fresh`` (optional): start a NEW Claude session instead of a resuming
+    # restart — the deterministic recovery for an agent wedged on a boot prompt
+    # whose queued-input buffer returns on every plain restart. Default (absent
+    # / falsey) keeps the byte-identical plain-restart argv below.
+    fresh = bool(body.get("fresh"))
+
     sac_bin = shutil.which("sac") or "sac"
     # ``agents`` (plural) is the canonical group; ``--yes`` skips the
     # interactive guard (this POST IS the confirmation) and ``--json``
@@ -103,7 +109,12 @@ async def agent_restart(request: Request) -> JSONResponse:
     child_env = dict(os.environ)
     child_env.pop("APPTAINER_CONTAINER", None)
     child_env.pop("SINGULARITY_CONTAINER", None)
-    inner_argv = [sac_bin, "agents", "restart", name, "--yes", "--json"]
+    if fresh:
+        # New session, no resume: stop-then-start fresh. ``start`` accepts
+        # --force (stop if running), --fresh (never --continue) and --json.
+        inner_argv = [sac_bin, "agents", "start", name, "--force", "--fresh", "--json"]
+    else:
+        inner_argv = [sac_bin, "agents", "restart", name, "--yes", "--json"]
 
     proc = await asyncio.create_subprocess_exec(
         *inner_argv,

--- a/src/scitex_agent_container/_mcp/_tools/_agent.py
+++ b/src/scitex_agent_container/_mcp/_tools/_agent.py
@@ -212,7 +212,7 @@ def agent_stop(name: str) -> dict[str, Any]:
     return invoke_cli_text(["agents", "stop", name])
 
 
-def agent_restart(name: str) -> dict[str, Any]:
+def agent_restart(name: str, fresh: bool = False) -> dict[str, Any]:
     """Restart an agent (stop + start). Mirrors ``sac agents restart <name>``.
 
     Passes ``--yes`` unconditionally: the CLI refuses an unconfirmed
@@ -231,8 +231,16 @@ def agent_restart(name: str) -> dict[str, Any]:
     The fallback is transparent here: the CLI runs it internally so this
     tool needs no extra wiring; on a bare host (row resolvable) the local
     path runs unchanged.
+
+    ``fresh=True`` brokers a NEW Claude session (``start --force --fresh``)
+    instead of a resuming restart — the deterministic recovery for an agent
+    wedged on a boot prompt whose queued input keeps returning on a plain
+    restart.
     """
-    return invoke_cli_text(["agents", "restart", name, "--yes"])
+    argv = ["agents", "restart", name, "--yes"]
+    if fresh:
+        argv.append("--fresh")
+    return invoke_cli_text(argv)
 
 
 def agent_send(

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_restart.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_restart.py
@@ -119,19 +119,36 @@ def _should_try_host_bypass(exc: Exception) -> bool:
     return True
 
 
-def _restart_via_host_bypass(name: str) -> dict:
+def _restart_via_host_bypass(name: str, fresh: bool = False) -> dict:
     """Broker the restart to the HOST listen and return its JSON envelope.
 
     Mirrors the spawn bypass (``agent_spawn`` → ``request_spawn``): the
     in-SIF client POSTs to ``{SAC_LISTEN_BASE_URL}/agents/<name>/restart``
-    and the host runs ``sac agents restart <name> --yes`` on the bare
-    host (manage-gated by ``check_lineage_acl``). A
-    :class:`RestartRequestError` (transport / 401 / 403 / 5xx) propagates
-    so the CLI's outer ``except`` surfaces it fail-loud.
+    and the host runs ``sac agents restart <name> --yes`` (or, when
+    ``fresh``, ``sac agents start <name> --force --fresh``) on the bare host
+    (manage-gated by ``check_lineage_acl``). A :class:`RestartRequestError`
+    (transport / 401 / 403 / 5xx) propagates so the CLI's outer ``except``
+    surfaces it fail-loud.
     """
     from ..._lifecycle._restart_client import request_restart
 
-    return request_restart(name)
+    return request_restart(name, fresh=fresh)
+
+
+def _bypass_base_url_available() -> bool:
+    """True iff a host-listen base URL resolves (we are an in-container agent).
+
+    The fresh-restart path is bypass-only: it has nothing to broker to on a
+    bare host, so the CLI fails loud there rather than silently doing a
+    resuming restart.
+    """
+    from ..._lifecycle._restart_client import RestartRequestError, _resolve_base_url
+
+    try:
+        _resolve_base_url(None)
+    except RestartRequestError:
+        return False
+    return True
 
 
 @click.command()
@@ -161,7 +178,22 @@ def _restart_via_host_bypass(name: str) -> dict:
         "Required for cross-host dispatch — the lead parses peer stdout."
     ),
 )
-def restart(name: str, dry_run: bool, yes: bool, as_json: bool) -> None:
+@click.option(
+    "--fresh",
+    "fresh",
+    is_flag=True,
+    default=False,
+    help=(
+        "Start a NEW Claude session instead of resuming (brokers "
+        "'start --force --fresh' to the host). The deterministic recovery for "
+        "an agent wedged on a boot prompt whose queued input keeps returning "
+        "on a plain restart. In-container only; on a bare host run "
+        "'sac agents start <name> --force --fresh' directly."
+    ),
+)
+def restart(
+    name: str, dry_run: bool, yes: bool, as_json: bool, fresh: bool
+) -> None:
     """Restart an agent.
 
     Resolves the agent's recorded host first: a row on a remote peer is
@@ -180,6 +212,38 @@ def restart(name: str, dry_run: bool, yes: bool, as_json: bool) -> None:
     if not yes:
         click.echo(f"Refusing to restart agent '{name}' without --yes/-y.", err=True)
         raise SystemExit(2)
+    if fresh:
+        # Fresh restart is the in-container recovery path: broker
+        # ``start --force --fresh`` to the host listen. On a bare host there is
+        # no listen to broker to, so fail loud with the direct command rather
+        # than silently doing a resuming restart (which would re-wedge).
+        if not _bypass_base_url_available():
+            click.echo(
+                f"--fresh restart requires the host bypass (run inside a "
+                f"container). On a bare host run: sac agents start {name} "
+                f"--force --fresh",
+                err=True,
+            )
+            raise SystemExit(1)
+        envelope = _restart_via_host_bypass(name, fresh=True)
+        if as_json:
+            click.echo(
+                _json.dumps(
+                    {
+                        "name": name,
+                        "restarted": envelope.get("returncode") == 0,
+                        "dispatched": False,
+                        "via": "host-listen",
+                        "fresh": True,
+                        "host_response": envelope,
+                    }
+                )
+            )
+        else:
+            console.print(
+                f"[green]Agent '{name}' fresh-restarted via host listen[/green]"
+            )
+        return
     # stx-allow: fallback (reason: config resolution, cross-host ssh dispatch, or
     # agent_restart can raise if the agent is not running or the session cannot be
     # found; an error message + sys.exit(1) is cleaner than an unhandled traceback)

--- a/tests/scitex_agent_container/_lifecycle/test__restart_client.py
+++ b/tests/scitex_agent_container/_lifecycle/test__restart_client.py
@@ -186,6 +186,26 @@ def test_post_body_omits_caller_for_admin_path(listen_env) -> None:
     assert "caller" not in json.loads(captured["body"])
 
 
+def test_post_body_includes_fresh_when_requested(listen_env) -> None:
+    # Arrange
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    opener, captured = _opener_returning(b'{"name":"peer","returncode":0}')
+    # Act
+    request_restart("peer", fresh=True, opener=opener)
+    # Assert — the host learns to start a fresh session.
+    assert json.loads(captured["body"])["fresh"] is True
+
+
+def test_post_body_omits_fresh_by_default(listen_env) -> None:
+    # Arrange
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    opener, captured = _opener_returning(b'{"name":"peer","returncode":0}')
+    # Act
+    request_restart("peer", opener=opener)
+    # Assert — default body stays byte-identical to a plain restart.
+    assert "fresh" not in json.loads(captured["body"])
+
+
 def test_explicit_caller_arg_overrides_sac_name_env(listen_env) -> None:
     # Arrange
     listen_env("LISTEN_BASE_URL", "http://host:9100")

--- a/tests/scitex_agent_container/_mcp/_tools/test__agent_restart.py
+++ b/tests/scitex_agent_container/_mcp/_tools/test__agent_restart.py
@@ -53,6 +53,15 @@ def test_restart_passes_yes_flag() -> None:
     assert captured[0] == ["agents", "restart", "foo", "--yes"]
 
 
+def test_restart_fresh_appends_fresh_flag() -> None:
+    # Arrange
+    with _record_argv() as captured:
+        # Act
+        agent_restart("foo", fresh=True)
+    # Assert — fresh requests a brand-new session via the CLI's --fresh path.
+    assert captured[0] == ["agents", "restart", "foo", "--yes", "--fresh"]
+
+
 def test_stop_does_not_force_yes() -> None:
     # Arrange
     with _record_argv() as captured:

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__restart.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__restart.py
@@ -550,3 +550,68 @@ def test_cross_host_restart_nonjson_stdout_reports_non_json(
     result = runner.invoke(restart, ["zeta", "-y"])
     # Assert
     assert "non-JSON" in result.output
+
+
+# ---------------------------------------------------------------------------
+# --fresh branch: a fresh (no-resume) restart is bypass-only. With the host
+# listen reachable it brokers ``start --force --fresh`` (fresh=True) and never
+# touches the local restart; on a bare host (no listen) it fails LOUD with the
+# direct command rather than silently doing a resuming restart.
+# ---------------------------------------------------------------------------
+
+
+def test_fresh_without_bypass_exits_one():
+    # Arrange — no listen base URL resolvable (bare host).
+    runner = CliRunner()
+    # Act
+    with _swap("_bypass_base_url_available", lambda: False):
+        result = runner.invoke(restart, ["alpha", "-y", "--fresh"])
+    # Assert
+    assert result.exit_code == 1
+
+
+def test_fresh_without_bypass_reports_direct_start_command():
+    # Arrange
+    runner = CliRunner()
+    # Act
+    with _swap("_bypass_base_url_available", lambda: False):
+        result = runner.invoke(restart, ["alpha", "-y", "--fresh"])
+    # Assert — fail loud with the deterministic bare-host command.
+    assert "start alpha --force --fresh" in result.output
+
+
+def test_fresh_with_bypass_brokers_fresh_true():
+    # Arrange — bypass available; record the brokered (name, fresh).
+    calls: list[tuple[str, bool]] = []
+
+    def _rec(name, fresh=False):
+        calls.append((name, fresh))
+        return {"returncode": 0}
+
+    runner = CliRunner()
+    # Act
+    with (
+        _swap("_bypass_base_url_available", lambda: True),
+        _swap("_restart_via_host_bypass", _rec),
+    ):
+        runner.invoke(restart, ["alpha", "-y", "--fresh"])
+    # Assert
+    assert calls == [("alpha", True)]
+
+
+def test_fresh_does_not_call_local_agent_restart():
+    # Arrange — fresh is bypass-only; the local restart must NOT run.
+    called: list[str] = []
+    runner = CliRunner()
+    # Act
+    with (
+        _swap("_bypass_base_url_available", lambda: True),
+        _swap(
+            "_restart_via_host_bypass",
+            lambda name, fresh=False: {"returncode": 0},
+        ),
+        _swap("agent_restart", lambda name: called.append(name)),
+    ):
+        runner.invoke(restart, ["alpha", "-y", "--fresh"])
+    # Assert
+    assert called == []


### PR DESCRIPTION
## Summary
- A channel agent can wedge on a TUI boot prompt whose queued-input buffer returns on every plain (resuming) restart, so its MCP servers (e.g. the Telegram poller) never launch. The deterministic recovery — a brand-new Claude session (`start --force --fresh`) — already exists, but an in-container agent could only trigger a *plain* restart through the host bypass.
- This threads an optional `fresh` through the whole bypass chain: MCP `agent_restart(fresh=True)` → restart CLI `--fresh` → `request_restart(fresh=)` → listen handler → `start --force --fresh` on the host.
- **Additive / low-risk:** the default path is byte-identical to a plain restart (`if fresh:` only runs when set). Fresh is **bypass-only** — on a bare host the CLI fails LOUD with the direct `start --force --fresh` command rather than silently doing a resuming restart.

## Why
Found while closing the Telegram per-agent incident: two agents (scitex-hub, scitex-todo) are config-correct but their pollers won't launch because a plain restart re-resumes the wedged session. `--fresh` is the deterministic cure; this makes it reachable from inside a container (autonomous wedged-agent recovery).

## Test plan
- [x] `request_restart` payload carries `fresh` only when set (2 tests)
- [x] MCP `agent_restart(fresh=True)` appends `--fresh` (1 test)
- [x] restart CLI: fresh+no-bypass → exit 1 with the direct command; fresh+bypass → brokers `fresh=True` and skips local restart (4 tests)
- [x] full affected suites: 51 passed (existing default-path tests unchanged)
- [ ] End-to-end live activation needs the listen daemon redeployed+restarted, then `agent_restart(<agent>, fresh=True)` → poller launches — a deploy-time follow-up