### PR TITLE
fix(runtime): inject SAC_NAME into the agent container env

### DIFF
--- a/src/scitex_agent_container/runtimes/_apptainer_listen_env.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_listen_env.py
@@ -71,6 +71,17 @@ def listen_env_flags(config) -> list[str]:
 
     flags: list[str] = ["--env", f"SAC_LISTEN_BASE_URL={listen_base_url()}"]
 
+    # AGENT SELF-NAME — without ``SAC_NAME`` an in-container agent cannot
+    # introspect its own registry row: ``agent_list``/``agent_logs`` return
+    # "not found" and ``agent_spawn`` can't resolve the caller, so parent->child
+    # lineage links go unrecorded (the spawn caller defaults to ``SAC_NAME``,
+    # read via ``_env.getenv("NAME")`` which honours SAC_NAME/SCITEX_AGENT_
+    # CONTAINER_NAME). ``SAC_LISTEN_*`` were injected but this was missed. Skip
+    # an EMPTY name so it can never shadow a value supplied elsewhere.
+    agent_name = getattr(config, "name", "") or ""
+    if agent_name:
+        flags += ["--env", f"SAC_NAME={agent_name}"]
+
     # PERSISTENT TESTMON CACHE — point testmon's data file at the
     # container-side bind destination (see
     # ``_p3a_default_binds._FLEET_DEFAULT_BINDS``: the host's

--- a/tests/scitex_agent_container/runtimes/test__apptainer_listen_env.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_listen_env.py
@@ -188,3 +188,39 @@ def test_listen_env_flags_unions_host_set_dir_with_default(
     assert (
         f"SCITEX_AGENT_CONTAINER_YAML_DIRS={custom}:{host_default}" in flags
     )
+
+
+def test_listen_env_flags_injects_sac_name(sandboxed_home: Path) -> None:
+    # Arrange — a config carrying the agent's own name.
+    config = SimpleNamespace(
+        name="scitex-todo", claude=SimpleNamespace(channels=[])
+    )
+    # Act
+    flags = listen_env_flags(config)
+    # Assert — the self-name is injected so in-container agent_list/logs +
+    # spawn lineage resolve (they read SAC_NAME via _env.getenv("NAME")).
+    assert "SAC_NAME=scitex-todo" in flags
+
+
+def test_listen_env_flags_sac_name_follows_an_env_token(
+    sandboxed_home: Path,
+) -> None:
+    # Arrange — apptainer consumes ``--env KEY=VALUE`` as two argv tokens.
+    config = SimpleNamespace(
+        name="scitex-todo", claude=SimpleNamespace(channels=[])
+    )
+    flags = listen_env_flags(config)
+    # Act
+    idx = flags.index("SAC_NAME=scitex-todo")
+    # Assert
+    assert flags[idx - 1] == "--env"
+
+
+def test_listen_env_flags_omits_empty_sac_name(sandboxed_home: Path) -> None:
+    # Arrange — an empty name must NOT be injected: an empty SAC_NAME would
+    # shadow a value supplied elsewhere and is worse than absent.
+    config = SimpleNamespace(name="", claude=SimpleNamespace(channels=[]))
+    # Act
+    flags = listen_env_flags(config)
+    # Assert
+    assert not any(f.startswith("SAC_NAME=") for f in flags)


### PR DESCRIPTION
## Summary
- Agent containers were injected with `SAC_LISTEN_BASE_URL`/`BEARER` but **not** `SAC_NAME`. So an in-container agent couldn't resolve its own identity: `agent_list`/`agent_logs` returned "not found in registry" and `agent_spawn` couldn't resolve the caller, leaving parent→child lineage unrecorded (the spawn caller defaults to `SAC_NAME`, read via `_env.getenv("NAME")`).
- Inject `SAC_NAME=<config.name>` in `listen_env_flags` alongside the existing listen vars. An empty name is skipped so it can never shadow a value supplied elsewhere (same empty-shadow lesson as the recent envrc fix).

## Why
Verified live: `echo $SAC_NAME` is unset inside a running agent container today (the card's Jun-24 report still holds). Fixes in-container fleet introspection + spawn lineage.

## Test plan
- [x] `SAC_NAME=<name>` injected, preceded by a literal `--env` token (2 tests)
- [x] empty name omitted (1 test)
- [x] full `test__apptainer_listen_env.py`: 12 passed (existing injections unregressed)
- [ ] After merge + redeploy: `echo $SAC_NAME` inside a container resolves; `agent_list`/`agent_logs` work from inside