### PR TITLE
fix(create): emit empty to_home/.mcp.json for generated agents

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_create.py
+++ b/src/scitex_agent_container/cli_pkg/_create.py
@@ -240,6 +240,18 @@ def create(
     agent_dir.mkdir(parents=True, exist_ok=True)
     spec_path.write_text(body)
 
+    # Emit an empty ``to_home/.mcp.json`` to match the proven spec shape
+    # (figrecipe/scitex-todo). The .mcp.json deep-merge cascade expects a
+    # per-agent file present even when empty; without it a generated agent
+    # diverges from the proven shape and a hand-added file is dropped on the
+    # next regen (the retired gen_ecosystem_dev_specs.sh bug, now folded into
+    # this CLI). Create-if-absent so an existing custom .mcp.json is never
+    # clobbered.
+    mcp_path = agent_dir / "to_home" / ".mcp.json"
+    if not mcp_path.exists():
+        mcp_path.parent.mkdir(parents=True, exist_ok=True)
+        mcp_path.write_text('{\n  "mcpServers": {}\n}\n')
+
     print(
         f"Wrote {spec_path} (template={template}, group={resolved_group}, "
         f"install={'yes' if _has_package(resolved_workdir) else 'no'}, "

--- a/tests/scitex_agent_container/cli_pkg/test__create.py
+++ b/tests/scitex_agent_container/cli_pkg/test__create.py
@@ -36,6 +36,49 @@ def test_create_writes_spec_yaml_at_target(tmp_path: Path) -> None:
     assert _spec(base, "dev-x").is_file()
 
 
+def test_create_emits_empty_to_home_mcp_json(tmp_path: Path) -> None:
+    # Arrange
+    runner = CliRunner()
+    base = tmp_path / "agents"
+    # Act
+    runner.invoke(
+        create_cmd, ["dev-mcp", "--template", "developer", "--base-dir", str(base)]
+    )
+    # Assert — the proven spec shape includes a per-agent to_home/.mcp.json.
+    assert (base / "dev-mcp" / "to_home" / ".mcp.json").is_file()
+
+
+def test_create_to_home_mcp_json_has_empty_servers(tmp_path: Path) -> None:
+    # Arrange
+    import json
+
+    runner = CliRunner()
+    base = tmp_path / "agents"
+    # Act
+    runner.invoke(
+        create_cmd, ["dev-mcp2", "--template", "developer", "--base-dir", str(base)]
+    )
+    doc = json.loads((base / "dev-mcp2" / "to_home" / ".mcp.json").read_text())
+    # Assert — empty mcpServers (proven figrecipe shape), not a dropped file.
+    assert doc == {"mcpServers": {}}
+
+
+def test_create_does_not_clobber_existing_mcp_json(tmp_path: Path) -> None:
+    # Arrange — a pre-existing custom .mcp.json must survive (create-if-absent).
+    runner = CliRunner()
+    base = tmp_path / "agents"
+    mcp = base / "dev-keep" / "to_home" / ".mcp.json"
+    mcp.parent.mkdir(parents=True, exist_ok=True)
+    mcp.write_text('{"mcpServers": {"custom": {}}}')
+    # Act
+    runner.invoke(
+        create_cmd,
+        ["dev-keep", "--template", "developer", "--base-dir", str(base), "--force"],
+    )
+    # Assert — the custom file is untouched.
+    assert "custom" in mcp.read_text()
+
+
 def test_create_developer_passes_v3_validator(tmp_path: Path) -> None:
     # Arrange
     runner = CliRunner()


### PR DESCRIPTION
## Summary
- `sac agents create` rendered only `spec.yaml`, omitting the empty `to_home/.mcp.json` the proven figrecipe/scitex-todo spec shape includes. Generated developer/scientist agents diverged from the proven shape, and a hand-added file got dropped on every regen.
- This is the retired `gen_ecosystem_dev_specs.sh` bug (the card's script was folded into this CLI; the gap moved here). Emit `{"mcpServers": {}}` per agent — create-if-absent so a custom `.mcp.json` is never clobbered.

## Why
The `_developer`/`_scientist` templates contain only `spec.yaml`, and the CLI renders only that — so the empty `.mcp.json` was never emitted. dotfiles hand-added it to 60 generated specs; the next regen would drop them again. Resolves card `sac-gen-ecosystem-dev-specs-missing-mcp-json`.

## Test plan
- [x] generated agent has `to_home/.mcp.json` (1 test)
- [x] content is `{"mcpServers": {}}` (1 test)
- [x] an existing custom `.mcp.json` is NOT clobbered (1 test, create-if-absent)
- [x] full `test__create.py`: 20 passed