### PR TITLE
feat(preflight): fail-fast guard against $HOME clobbering operator dotfiles

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_start.py
+++ b/src/scitex_agent_container/_lifecycle/_start.py
@@ -213,6 +213,14 @@ def agent_start(
         agent_name=config.name,
     )
 
+    # Data-safety invariant (UNCONDITIONAL — not gated by ``no_preflight``):
+    # refuse specs whose $HOME resolves onto an operator-writable host bind,
+    # which would let the agent's home writes clobber the operator's real
+    # dotfiles. See :mod:`..runtimes._home_isolation_guard`.
+    from ..runtimes._home_isolation_guard import assert_home_not_operator_writable
+
+    assert_home_not_operator_writable(config)
+
     runtime_factory = runtime_factory or _get_runtime
     runtime = runtime_factory(config)
 

--- a/src/scitex_agent_container/runtimes/_home_isolation_guard.py
+++ b/src/scitex_agent_container/runtimes/_home_isolation_guard.py
@@ -1,0 +1,82 @@
+"""Host-side fail-fast: refuse specs whose ``$HOME`` is operator-writable.
+
+The agent's canonical ``$HOME`` (``/home/agent``) is overlay/tmpfs-backed and
+per-agent, which is precisely what stops Claude Code + shell writes
+(``~/.claude/.credentials.json``, session transcripts, ``~/.bash_history``,
+``~/.config``, caches) from CLOBBERING the operator's REAL dotfiles. A
+``relaxed: true`` spec can move ``$HOME`` via ``--home`` in ``raw_args`` onto a
+real host directory that is ALSO bind-mounted read-write — then the agent's
+home writes overwrite the operator's files. The in-container preflight
+(:mod:`._apptainer_preflight`) is bypassed by relaxed specs and runs too late.
+This guard runs on the host BEFORE the container spawns and rejects that class
+of spec.
+"""
+
+from __future__ import annotations
+
+from pathlib import PurePosixPath
+
+from ..config import AgentConfig
+from ._to_home_overlay import resolve_container_home
+
+__all__ = ["assert_home_not_operator_writable"]
+
+
+def _iter_operator_bind_specs(config: AgentConfig) -> list[str]:
+    """Bind specs the OPERATOR declared: ``apptainer.binds`` + ``raw_args``
+    ``--bind``/``-B`` values. sac's own default binds are added later in
+    build_argv and are intentionally NOT considered here.
+    """
+    ap = getattr(config, "apptainer", None)
+    if ap is None:
+        return []
+    specs: list[str] = list(getattr(ap, "binds", None) or [])
+    raw = list(getattr(ap, "raw_args", None) or [])
+    i = 0
+    while i < len(raw):
+        arg = str(raw[i])
+        value: str | None = None
+        if arg in ("--bind", "-B"):
+            if i + 1 < len(raw):
+                value = str(raw[i + 1])
+                i += 1
+        elif arg.startswith("--bind="):
+            value = arg[len("--bind=") :]
+        elif arg.startswith("-B="):
+            value = arg[len("-B=") :]
+        if value:
+            # A single --bind value may carry several comma-separated specs.
+            specs.extend(part for part in value.split(",") if part)
+        i += 1
+    return specs
+
+
+def _parse_bind(spec: str) -> tuple[str, str]:
+    """Return ``(dst, mode)`` for a ``src[:dst[:mode]]`` bind. A missing mode
+    is ``rw`` (apptainer's default); a bare ``src`` binds ``src:src`` rw.
+    """
+    parts = spec.split(":")
+    if len(parts) == 1:
+        return parts[0], "rw"
+    dst = parts[1]
+    mode = parts[2] if len(parts) >= 3 and parts[2] else "rw"
+    return dst, mode
+
+
+def assert_home_not_operator_writable(config: AgentConfig) -> None:
+    """Raise if the resolved container ``$HOME`` equals or is a subpath of any
+    operator-declared read-write bind destination — the dotfile-clobber vector.
+    """
+    home = PurePosixPath(resolve_container_home(config))
+    for spec in _iter_operator_bind_specs(config):
+        dst, mode = _parse_bind(spec)
+        if mode.startswith("ro"):
+            continue
+        dst_p = PurePosixPath(dst)
+        if home == dst_p or dst_p in home.parents:
+            raise RuntimeError(
+                f"ERROR[sac-home-guard]: agent $HOME={home} is served by "
+                f"operator read-write bind '{spec}' — writes to the agent home "
+                f"would CLOBBER real host files at {dst}. Use the canonical "
+                f"overlay-backed /home/agent, or bind that path read-only (:ro)."
+            )

--- a/tests/scitex_agent_container/runtimes/test_home_isolation_guard.py
+++ b/tests/scitex_agent_container/runtimes/test_home_isolation_guard.py
@@ -1,0 +1,77 @@
+"""Guard: refuse specs whose $HOME is served by an operator-writable bind."""
+
+import pytest
+
+from scitex_agent_container.config import AgentConfig
+from scitex_agent_container.config._types import ApptainerSpec
+from scitex_agent_container.runtimes._home_isolation_guard import (
+    assert_home_not_operator_writable,
+)
+
+
+def _config(*, binds=None, raw_args=None):
+    return AgentConfig(
+        name="test-agent",
+        apptainer=ApptainerSpec(binds=binds or [], raw_args=raw_args or []),
+    )
+
+
+def test_canonical_home_with_whole_home_rw_bind_passes():
+    # Arrange: $HOME=/home/agent (default), not under the rw /home/ywatanabe bind.
+    config = _config(binds=["/home/ywatanabe:/home/ywatanabe:rw"])
+    # Act
+    result = assert_home_not_operator_writable(config)
+    # Assert
+    assert result is None
+
+
+def test_ro_identity_bind_under_home_passes():
+    # Arrange: a read-only mount into the agent home cannot clobber anything.
+    config = _config(binds=["/home/ywatanabe/.ssh:/home/agent/.ssh:ro"])
+    # Act
+    result = assert_home_not_operator_writable(config)
+    # Assert
+    assert result is None
+
+
+def test_home_moved_onto_rw_bind_raises():
+    # Arrange
+    config = _config(
+        binds=["/home/ywatanabe:/home/ywatanabe:rw"],
+        raw_args=["--home", "/home/ywatanabe"],
+    )
+    # Act
+    guard = assert_home_not_operator_writable
+    # Assert
+    with pytest.raises(RuntimeError):
+        guard(config)
+
+
+def test_home_under_ancestor_rw_bind_raises():
+    # Arrange
+    config = _config(
+        binds=["/home/ywatanabe:/home/ywatanabe:rw"],
+        raw_args=["--home", "/home/ywatanabe/sub"],
+    )
+    # Act
+    guard = assert_home_not_operator_writable
+    # Assert
+    with pytest.raises(RuntimeError):
+        guard(config)
+
+
+def test_rw_bind_via_raw_args_bind_flag_raises():
+    # Arrange: bind declared through raw_args with no explicit mode defaults to rw.
+    config = _config(
+        raw_args=[
+            "--home",
+            "/home/ywatanabe",
+            "--bind",
+            "/home/ywatanabe:/home/ywatanabe",
+        ],
+    )
+    # Act
+    guard = assert_home_not_operator_writable
+    # Assert
+    with pytest.raises(RuntimeError):
+        guard(config)


### PR DESCRIPTION
## Why
The agent's canonical `$HOME=/home/agent` is overlay/tmpfs-backed and per-agent — that isolation is what stops the agent's Claude Code + shell writes (`~/.claude/.credentials.json`, session transcripts, `~/.bash_history`, `~/.config`, caches, git config) from **clobbering the operator's real dotfiles**. A `relaxed: true` spec can move `$HOME` via `--home` in `raw_args` onto a real host directory that is also bind-mounted read-write, defeating the isolation. The existing in-container preflight (`_apptainer_preflight.py`, asserts `$HOME == /home/agent`) is **bypassed by relaxed specs** and runs inside the container (too late).

## What
A host-side, fail-fast, fail-loud guard in `agent_start`, run **before** the container spawns and **unconditionally** (not gated by `--no-preflight`, since this is a data-safety invariant, not a liveness check).

**Invariant:** refuse launch if the resolved container `$HOME` (`resolve_container_home`) **equals or is a subpath of** the destination of any *operator-declared* `:rw` bind (from `apptainer.binds` or `raw_args --bind`). sac's own default binds and `:ro` identity mounts are excluded.

- Passes every current spec (neurovista etc. keep `$HOME=/home/agent`, which is never under the rw whole-home bind). Verified: no `--home` in the repo points anywhere but `/home/agent`, so zero false positives.
- Refuses e.g. `--home /home/ywatanabe` + `/home/ywatanabe:/home/ywatanabe:rw` with a message naming the offending bind and home.

## Files
- `runtimes/_home_isolation_guard.py` — new, pure function `assert_home_not_operator_writable(config)`.
- `_lifecycle/_start.py` — wired in after the existing telegrammer-wiring validator.
- `tests/scitex_agent_container/runtimes/test_home_isolation_guard.py` — 5 tests (2 pass-paths, 3 clobber-refusals incl. raw_args `--bind`), no mocks, all green.

## Note
Stacked on `fix/remove-stray-fakeroot-junk` (the develop CI-unblock PR). Once that merges, this PR's diff reduces to just the guard.

## Test plan
- [ ] New guard tests green in CI
- [ ] Full matrix green