### PR TITLE
fix(runtime): auto-inject SCITEX_TODO_AGENT per agent (owner-less cards)

### DIFF
--- a/src/scitex_agent_container/runtimes/_apptainer_listen_env.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_listen_env.py
@@ -91,6 +91,15 @@ def listen_env_flags(config) -> list[str]:
         # ``.envrc`` goodwill. Same empty-name skip as SAC_NAME.
         flags += ["--env", f"SCITEX_TODO_AGENT={agent_name}"]
 
+    # SCITEX-TODO CANONICAL STORE — pin every agent's scitex-todo store to the
+    # bound shared tasks.yaml. ``~/.scitex/todo`` is bound rw to
+    # ``/home/agent/.scitex/todo`` (see ``_p3a_default_binds``), so an agent
+    # whose ``.envrc`` lacks ``$SCITEX_TODO_TASKS`` otherwise resolves a
+    # different/empty store (project-shadow or the bundled example) and silently
+    # misses its inbox / channel notifications (incident follow-up 2026-07-01).
+    # UNCONDITIONAL — the container path is identical for every agent.
+    flags += ["--env", "SCITEX_TODO_TASKS=/home/agent/.scitex/todo/tasks.yaml"]
+
     # PERSISTENT TESTMON CACHE — point testmon's data file at the
     # container-side bind destination (see
     # ``_p3a_default_binds._FLEET_DEFAULT_BINDS``: the host's

--- a/src/scitex_agent_container/runtimes/_apptainer_listen_env.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_listen_env.py
@@ -81,6 +81,15 @@ def listen_env_flags(config) -> list[str]:
     agent_name = getattr(config, "name", "") or ""
     if agent_name:
         flags += ["--env", f"SAC_NAME={agent_name}"]
+        # SCITEX-TODO CREATOR IDENTITY — scitex-todo stamps every card / comment
+        # write with ``$SCITEX_TODO_AGENT`` (falling back to ``$USER`` =
+        # blank/"operator" when unset). An agent whose project ``.envrc`` forgot
+        # the export therefore creates OWNER-LESS cards and trips the
+        # mandatory-creator rule (incident 2026-07-01: scitex-dev's .envrc had
+        # CCT_AGENT_ID but not SCITEX_TODO_AGENT). Inject it DETERMINISTICALLY =
+        # the agent name so card attribution never depends on per-project
+        # ``.envrc`` goodwill. Same empty-name skip as SAC_NAME.
+        flags += ["--env", f"SCITEX_TODO_AGENT={agent_name}"]
 
     # PERSISTENT TESTMON CACHE — point testmon's data file at the
     # container-side bind destination (see

--- a/tests/scitex_agent_container/runtimes/test__apptainer_listen_env.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_listen_env.py
@@ -259,3 +259,26 @@ def test_listen_env_flags_omits_empty_scitex_todo_agent(
     flags = listen_env_flags(config)
     # Assert
     assert not any(f.startswith("SCITEX_TODO_AGENT=") for f in flags)
+
+
+def test_listen_env_flags_injects_scitex_todo_tasks_store(
+    no_bus_config: SimpleNamespace,
+    sandboxed_home: Path,
+) -> None:
+    # Arrange — the canonical bound store path is identical for every agent.
+    # Act
+    flags = listen_env_flags(no_bus_config)
+    # Assert — the shared tasks.yaml store is pinned so notifications resolve.
+    assert "SCITEX_TODO_TASKS=/home/agent/.scitex/todo/tasks.yaml" in flags
+
+
+def test_listen_env_flags_scitex_todo_tasks_follows_an_env_token(
+    no_bus_config: SimpleNamespace,
+    sandboxed_home: Path,
+) -> None:
+    # Arrange — apptainer consumes ``--env KEY=VALUE`` as two argv tokens.
+    flags = listen_env_flags(no_bus_config)
+    # Act
+    idx = flags.index("SCITEX_TODO_TASKS=/home/agent/.scitex/todo/tasks.yaml")
+    # Assert
+    assert flags[idx - 1] == "--env"

--- a/tests/scitex_agent_container/runtimes/test__apptainer_listen_env.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_listen_env.py
@@ -224,3 +224,38 @@ def test_listen_env_flags_omits_empty_sac_name(sandboxed_home: Path) -> None:
     flags = listen_env_flags(config)
     # Assert
     assert not any(f.startswith("SAC_NAME=") for f in flags)
+
+
+def test_listen_env_flags_injects_scitex_todo_agent(sandboxed_home: Path) -> None:
+    # Arrange — a config carrying the agent's own name (scitex-dev is the
+    # incident agent whose .envrc lacked the export).
+    config = SimpleNamespace(name="scitex-dev", claude=SimpleNamespace(channels=[]))
+    # Act
+    flags = listen_env_flags(config)
+    # Assert — scitex-todo's creator identity is injected = the agent name, so
+    # cards it creates are attributed to it, not owner-less $USER.
+    assert "SCITEX_TODO_AGENT=scitex-dev" in flags
+
+
+def test_listen_env_flags_scitex_todo_agent_follows_an_env_token(
+    sandboxed_home: Path,
+) -> None:
+    # Arrange — apptainer consumes ``--env KEY=VALUE`` as two argv tokens.
+    config = SimpleNamespace(name="scitex-dev", claude=SimpleNamespace(channels=[]))
+    flags = listen_env_flags(config)
+    # Act
+    idx = flags.index("SCITEX_TODO_AGENT=scitex-dev")
+    # Assert
+    assert flags[idx - 1] == "--env"
+
+
+def test_listen_env_flags_omits_empty_scitex_todo_agent(
+    sandboxed_home: Path,
+) -> None:
+    # Arrange — an empty name must NOT be injected (an empty value would shadow
+    # a real one supplied elsewhere).
+    config = SimpleNamespace(name="", claude=SimpleNamespace(channels=[]))
+    # Act
+    flags = listen_env_flags(config)
+    # Assert
+    assert not any(f.startswith("SCITEX_TODO_AGENT=") for f in flags)


### PR DESCRIPTION
## Why (incident 2026-07-01)
scitex-dev created **owner-less** scitex-todo cards. Root cause: scitex-todo stamps every card/comment write with `\$SCITEX_TODO_AGENT` (falling back to `\$USER` = blank/"operator" when unset), and that var was set only by each **project's `.envrc`**. scitex-dev's `.envrc` exported `CCT_AGENT_ID` (Telegram) but **not** `SCITEX_TODO_AGENT`, so its writes fell back to `\$USER` and tripped the mandatory-creator rule. Card attribution depended on per-project `.envrc` goodwill, and one that forgot broke it.

## Fix (deterministic, no goodwill)
Inject `SCITEX_TODO_AGENT=<agent-name>` in `listen_env_flags` right beside the existing `SAC_NAME` injection (same empty-name skip). Now **every** agent's cards are attributed to it, with no dependence on a project `.envrc` remembering the export.

- Value = the agent's own name (sac already knows it; same source as `SAC_NAME`).
- Additive + empty-guarded — cannot shadow a real value; agents that already set it via `.envrc`/`raw_args` get the identical value.
- Takes effect on each agent's **next restart** (env is injected at container launch).

## Files
- `runtimes/_apptainer_listen_env.py` — one `--env SCITEX_TODO_AGENT=<name>` line beside `SAC_NAME`.
- `tests/.../test__apptainer_listen_env.py` — 3 tests mirroring the `SAC_NAME` tests (inject / follows-`--env` / omit-empty). 15/15 green.

## Note
This makes the per-project `.envrc SCITEX_TODO_AGENT` export redundant fleet-wide. Broadcasting the "restart to pick it up" note to agents.

## Test plan
- [ ] CI green