### PR TITLE
chore(containers): bump claude-agent-sdk 0.2.87 -> 0.2.110

### DIFF
--- a/src/scitex_agent_container/containers/apptainer-base.def
+++ b/src/scitex_agent_container/containers/apptainer-base.def
@@ -311,7 +311,7 @@ From: ubuntu:24.04
     # pyyaml, ruamel-yaml) are already SAC-transitive via the runner
     # plumbing, so the [mcp] extra adds just fastmcp.
     uv pip install --python /opt/venv-sac/bin/python \
-        "claude-agent-sdk==0.2.87" \
+        "claude-agent-sdk==0.2.110" \
         "scitex-todo[mcp]>=0.3.0" \
         /opt/scitex-agent-container-src
 

--- a/src/scitex_agent_container/containers/apptainer-scitex.def
+++ b/src/scitex_agent_container/containers/apptainer-scitex.def
@@ -127,7 +127,7 @@ From: ./sac-base.sif
             black flake8 \
             ipython ipdb \
             pytest pytest-cov \
-            "claude-agent-sdk==0.2.87" \
+            "claude-agent-sdk==0.2.110" \
             "scitex[all]" \
             xarray
         uv pip install --python /opt/venv-sac/bin/python \
@@ -157,7 +157,7 @@ From: ./sac-base.sif
             black flake8 \
             ipython ipdb \
             pytest pytest-cov \
-            "claude-agent-sdk==0.2.87" \
+            "claude-agent-sdk==0.2.110" \
             "scitex[all]" \
             xarray
         /opt/venv-sac/bin/pip install --no-cache-dir \


### PR DESCRIPTION
Operator request 2026-07-01. Bumps the three pin locations across apptainer-base.def + apptainer-scitex.def (both build branches). Dotfiles def already updated separately.