### PR TITLE
fix(runtime): inject DIRENV_CONFIG for .envrc loading; revert scitex-todo-specific injections (restore standalone)

### DIFF
--- a/src/scitex_agent_container/runtimes/_apptainer_listen_env.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_listen_env.py
@@ -81,24 +81,20 @@ def listen_env_flags(config) -> list[str]:
     agent_name = getattr(config, "name", "") or ""
     if agent_name:
         flags += ["--env", f"SAC_NAME={agent_name}"]
-        # SCITEX-TODO CREATOR IDENTITY — scitex-todo stamps every card / comment
-        # write with ``$SCITEX_TODO_AGENT`` (falling back to ``$USER`` =
-        # blank/"operator" when unset). An agent whose project ``.envrc`` forgot
-        # the export therefore creates OWNER-LESS cards and trips the
-        # mandatory-creator rule (incident 2026-07-01: scitex-dev's .envrc had
-        # CCT_AGENT_ID but not SCITEX_TODO_AGENT). Inject it DETERMINISTICALLY =
-        # the agent name so card attribution never depends on per-project
-        # ``.envrc`` goodwill. Same empty-name skip as SAC_NAME.
-        flags += ["--env", f"SCITEX_TODO_AGENT={agent_name}"]
 
-    # SCITEX-TODO CANONICAL STORE — pin every agent's scitex-todo store to the
-    # bound shared tasks.yaml. ``~/.scitex/todo`` is bound rw to
-    # ``/home/agent/.scitex/todo`` (see ``_p3a_default_binds``), so an agent
-    # whose ``.envrc`` lacks ``$SCITEX_TODO_TASKS`` otherwise resolves a
-    # different/empty store (project-shadow or the bundled example) and silently
-    # misses its inbox / channel notifications (incident follow-up 2026-07-01).
-    # UNCONDITIONAL — the container path is identical for every agent.
-    flags += ["--env", "SCITEX_TODO_TASKS=/home/agent/.scitex/todo/tasks.yaml"]
+    # DIRENV CONFIG LOCATION — direnv reads its config from
+    # ``$DIRENV_CONFIG/direnv.toml`` (default ``$HOME/.config/direnv``). The sac
+    # base image writes a permissive whitelist to ``/etc/direnv/direnv.toml``
+    # (``prefix = [ "/" ]``) so per-project ``.envrc`` files load without a
+    # manual ``direnv allow`` — but without pointing ``$DIRENV_CONFIG`` at that
+    # path, direnv reads an unwritten ``~/.config/direnv/direnv.toml``, its
+    # loaded ``whitelist.prefix`` stays empty, and EVERY ``.envrc`` is blocked
+    # ("direnv: error .envrc is blocked. Run `direnv allow`"). Empirically
+    # verified 2026-07-01. UNCONDITIONAL — every agent needs the whitelist to
+    # apply. Note: this is a generic, language-agnostic direnv-tooling knob (NOT
+    # coupled to any scitex-* package), so it does not violate the
+    # sac/other-package standalone boundary.
+    flags += ["--env", "DIRENV_CONFIG=/etc/direnv"]
 
     # PERSISTENT TESTMON CACHE — point testmon's data file at the
     # container-side bind destination (see

--- a/tests/scitex_agent_container/runtimes/test__apptainer_listen_env.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_listen_env.py
@@ -226,59 +226,26 @@ def test_listen_env_flags_omits_empty_sac_name(sandboxed_home: Path) -> None:
     assert not any(f.startswith("SAC_NAME=") for f in flags)
 
 
-def test_listen_env_flags_injects_scitex_todo_agent(sandboxed_home: Path) -> None:
-    # Arrange — a config carrying the agent's own name (scitex-dev is the
-    # incident agent whose .envrc lacked the export).
-    config = SimpleNamespace(name="scitex-dev", claude=SimpleNamespace(channels=[]))
-    # Act
-    flags = listen_env_flags(config)
-    # Assert — scitex-todo's creator identity is injected = the agent name, so
-    # cards it creates are attributed to it, not owner-less $USER.
-    assert "SCITEX_TODO_AGENT=scitex-dev" in flags
-
-
-def test_listen_env_flags_scitex_todo_agent_follows_an_env_token(
-    sandboxed_home: Path,
-) -> None:
-    # Arrange — apptainer consumes ``--env KEY=VALUE`` as two argv tokens.
-    config = SimpleNamespace(name="scitex-dev", claude=SimpleNamespace(channels=[]))
-    flags = listen_env_flags(config)
-    # Act
-    idx = flags.index("SCITEX_TODO_AGENT=scitex-dev")
-    # Assert
-    assert flags[idx - 1] == "--env"
-
-
-def test_listen_env_flags_omits_empty_scitex_todo_agent(
-    sandboxed_home: Path,
-) -> None:
-    # Arrange — an empty name must NOT be injected (an empty value would shadow
-    # a real one supplied elsewhere).
-    config = SimpleNamespace(name="", claude=SimpleNamespace(channels=[]))
-    # Act
-    flags = listen_env_flags(config)
-    # Assert
-    assert not any(f.startswith("SCITEX_TODO_AGENT=") for f in flags)
-
-
-def test_listen_env_flags_injects_scitex_todo_tasks_store(
+def test_listen_env_flags_injects_direnv_config_location(
     no_bus_config: SimpleNamespace,
     sandboxed_home: Path,
 ) -> None:
-    # Arrange — the canonical bound store path is identical for every agent.
+    # Arrange — every agent needs direnv's config location pointed at the base
+    # image's whitelist so per-project .envrc files load without manual
+    # `direnv allow`. Generic tooling knob, not coupled to any scitex-* package.
     # Act
     flags = listen_env_flags(no_bus_config)
-    # Assert — the shared tasks.yaml store is pinned so notifications resolve.
-    assert "SCITEX_TODO_TASKS=/home/agent/.scitex/todo/tasks.yaml" in flags
+    # Assert
+    assert "DIRENV_CONFIG=/etc/direnv" in flags
 
 
-def test_listen_env_flags_scitex_todo_tasks_follows_an_env_token(
+def test_listen_env_flags_direnv_config_follows_an_env_token(
     no_bus_config: SimpleNamespace,
     sandboxed_home: Path,
 ) -> None:
     # Arrange — apptainer consumes ``--env KEY=VALUE`` as two argv tokens.
     flags = listen_env_flags(no_bus_config)
     # Act
-    idx = flags.index("SCITEX_TODO_TASKS=/home/agent/.scitex/todo/tasks.yaml")
+    idx = flags.index("DIRENV_CONFIG=/etc/direnv")
     # Assert
     assert flags[idx - 1] == "--env"


### PR DESCRIPTION
## Two coupled fixes

### 1. .envrc doesn't load — root cause empirically confirmed
`direnv` reads its config from `\$DIRENV_CONFIG/direnv.toml` (default `~/.config/direnv`). The base image writes a permissive whitelist to `/etc/direnv/direnv.toml` (`prefix = [ "/" ]`), but with `DIRENV_CONFIG` unset, direnv reads an unwritten `~/.config/direnv/direnv.toml`, its loaded `whitelist.prefix` stays empty, and every `.envrc` is **blocked** (`.envrc is blocked. Run direnv allow`). Verified in my container: `direnv status` shows `whitelist.prefix []`.

Fix: inject `DIRENV_CONFIG=/etc/direnv` unconditionally in `listen_env_flags` so the whitelist applies and per-project `.envrc` loads. **Generic direnv-tooling knob — not coupled to any scitex-* package**, so it does not violate the standalone principle.

### 2. Revert PR #510's scitex-todo-specific injections
PR #510 injected `SCITEX_TODO_AGENT` + `SCITEX_TODO_TASKS` by hardcoding scitex-todo-specific env var names in sac. That made sac **know** scitex-todo, which violates the operator's standalone principle (symmetric with scitex-todo-must-not-know-sac). Reverting those lines.

Fixing direnv (#1) makes them unnecessary anyway: with `.envrc` actually loading, each project's own `.envrc` handles its own tool-specific exports without sac needing to know any of them.

### Tests
14 pass. Removed the 5 scitex-todo-specific tests I added in #510; added 2 DIRENV_CONFIG tests. No mocks.

### Follow-ups
- Notify scitex-todo the fix moved layers (their `.envrc` pattern is back in force once #510 revert deploys).
- Existing `SCITEX_TESTMON_CACHE_ROOT` injection is also scitex-* specific and pre-dates this — a separate cleanup, not scope here.