### PR TITLE
fix(listen): run host_exec subprocess off the event loop (long commands starved the daemon)

### DIFF
--- a/src/scitex_agent_container/_listen/_host_exec.py
+++ b/src/scitex_agent_container/_listen/_host_exec.py
@@ -33,6 +33,7 @@ downstream consumers pass user input.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import subprocess
@@ -195,7 +196,16 @@ async def host_exec(
     exit_code = -1
     exec_error: str | None = None
     try:
-        completed = subprocess.run(
+        # Dispatch the blocking subprocess OFF the event loop. Running
+        # subprocess.run() directly in this async handler blocks the SINGLE
+        # uvicorn event loop for the command's whole lifetime — a long
+        # host_exec (e.g. a ~13-min `sac image build`) then starves EVERY
+        # other endpoint (a2a, health, spawn), the exact "agents can't reach
+        # sac" outage (INCIDENT 2026-07-02). asyncio.to_thread keeps the loop
+        # free to serve other requests concurrently; subprocess.TimeoutExpired
+        # raised inside the thread still propagates through the await.
+        completed = await asyncio.to_thread(
+            subprocess.run,
             argv,
             cwd=cwd_raw,
             timeout=timeout_s,

--- a/tests/scitex_agent_container/_listen/test__host_exec.py
+++ b/tests/scitex_agent_container/_listen/test__host_exec.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import time
 import types
 from typing import Any
 
@@ -292,3 +293,23 @@ def test_host_exec_audit_entry_records_argv():
     _run(host_exec(req, group_resolver=_dev_resolver, audit_writer=entries.append))
     # Assert
     assert entries[0]["argv"] == ["echo", "audit"]
+
+
+def test_host_exec_does_not_block_the_event_loop():
+    # Arrange — two ~0.3s execs; off-loop dispatch lets them overlap, while
+    # a subprocess.run on the event loop would serialize them to ~0.6s.
+    req_a = _FakeRequest({"argv": ["sleep", "0.3"]}, authenticated_node="dev")
+    req_b = _FakeRequest({"argv": ["sleep", "0.3"]}, authenticated_node="dev")
+
+    async def _both() -> float:
+        start = time.monotonic()
+        await asyncio.gather(
+            host_exec(req_a, group_resolver=_dev_resolver, audit_writer=_noop_audit),
+            host_exec(req_b, group_resolver=_dev_resolver, audit_writer=_noop_audit),
+        )
+        return time.monotonic() - start
+
+    # Act
+    elapsed = _run(_both())
+    # Assert
+    assert elapsed < 0.5


### PR DESCRIPTION
## Summary
**Fleet-comms outage fix.** While an agent ran `sac image build scitex` (~13 min) through the new `/v1/host_exec` bypass, the whole fleet lost contact with sac — a2a, health, and spawn all hung. Root cause: the `host_exec` handler called `subprocess.run()` **directly in the async handler**, blocking the single uvicorn event loop for the command's entire lifetime, so no other endpoint could be served.

- Dispatch the subprocess via `asyncio.to_thread` so the event loop stays free to serve concurrent requests. `subprocess.TimeoutExpired` still propagates through the `await`, so the existing timeout path is unchanged.
- Regression test: two ~0.3s execs now overlap (~0.3s wall) instead of serializing (~0.6s), proving the handler yields the loop.

## Why it matters
The bypass is designed to run *long* host commands (image builds). Without off-loop dispatch, every long host_exec is a fleet-wide comms outage. This makes the bypass safe for its intended use.

## Test plan
- [x] `test__host_exec.py` — 21 tests green (20 existing + 1 new concurrency proof), no mocks/monkeypatch, AAA + one-assert.
- [ ] Deploy: needs the running daemon restarted after merge to take effect (the live daemon still has the blocking handler until then).