### PR TITLE
feat(image): consume scitex-container 0.3.0 atomic build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,13 @@ dependencies = [
     # v0.3.0 was the release that split public from ecosystem-internal
     # and exposed both surfaces — that is our hard minimum.
     "scitex-config>=0.3.0",
-    "scitex-container>=0.1.0",
+    # 0.3.0 floor: sac's source-bundled ``sac image build`` delegates to
+    # scitex-container's atomic ``build(...)`` (timestamped SIF + stable
+    # symlink swap; failed build leaves the prior image intact). That API
+    # — ``cwd`` (build context independent of ``output_dir``),
+    # ``image_name``, ``retain``, Path return — landed in 0.3.0. See
+    # cli_pkg/_image_source_build.py::_default_container_build.
+    "scitex-container>=0.3.0",
     "scitex-logging>=0.1.5",
     "scitex-ssh>=1.0.0",
     # A2A protocol surface — Phase 1 SDK adoption (see GITIGNORED/A2A_MIGRATION.md).

--- a/src/scitex_agent_container/cli_pkg/_image_source_build.py
+++ b/src/scitex_agent_container/cli_pkg/_image_source_build.py
@@ -25,25 +25,35 @@ copy of the package root. This module owns that staging step:
 
     build_layer_from_source(layer, def_path, pkg_root, output_dir, ...)
         -> stages a build context under output_dir/sac-<layer>/build-context/
-        -> runs ``apptainer build`` with cwd=staging_dir
-        -> returns the path to the built SIF (or sandbox dir)
+        -> delegates to ``scitex_container.build`` with cwd=staging_dir
+        -> returns the stable boot symlink of the built SIF (or the sandbox dir)
 
-The scitex_container.apptainer.build helper does not expose a ``cwd``
-parameter and locates .def files by name via its own search heuristic, so
-the source-bundled build path bypasses it and shells out to ``apptainer``
-directly. The backend abstraction in image_group.py is preserved for the
-non-build verbs (sandbox / update / freeze / list / status / snapshot)
-which manage already-built SIFs.
+scitex-container 0.3.0 exposes an atomic ``build(...)`` that accepts a
+``cwd`` (build context, independent of ``output_dir``), a ``def_path``
+(so out-of-tree callers whose recipes ship inside their own wheel bypass
+``find_containers_dir``), and an ``image_name``. It builds to a
+timestamped ``<output_dir>/<image_name>/<image_name>-<ts>.sif`` and then
+atomically swaps two stable symlinks — the INNER boot path
+``<output_dir>/<image_name>/<image_name>.sif`` and the TOP-level
+``<output_dir>/<image_name>.sif`` (which resolves a layered .def's
+``From: ./<image_name>.sif``). A failed build never touches the live
+symlinks, so the prior image stays intact — no more in-place overwrite.
+sac now delegates to that helper rather than shelling ``apptainer build
+--force`` itself; the source-bundled staging (this module) still owns the
+build-context prep so the .def's relative ``%files`` +
+``From: ./sac-base.sif`` resolve. The backend abstraction in
+image_group.py is preserved for the non-build verbs (sandbox / update /
+freeze / list / status / snapshot) which manage already-built SIFs.
 
 Testability follows the same save/restore pattern as ``image_group``'s
-``_load_apptainer`` hook: ``_apptainer_build_runner`` is a module-level
-callable that tests reassign to a real (no MagicMock) recording fake.
+``_load_apptainer`` hook: ``_container_build`` is a module-level callable
+that tests reassign to a real (no MagicMock) recording fake, so the unit
+tests never shell a real apptainer.
 """
 
 from __future__ import annotations
 
 import shutil
-import subprocess
 from pathlib import Path
 from typing import Callable
 
@@ -256,69 +266,53 @@ def stage_build_context(
 # ---------------------------------------------------------------------------
 
 
-def _default_apptainer_build_runner(
-    output_path: Path,
-    staged_def: Path,
+def _default_container_build(
     *,
+    def_path: Path,
+    output_dir: Path,
     cwd: Path,
+    image_name: str,
     sandbox: bool,
     force: bool,
-) -> int:
-    """Default runner — shells out to ``apptainer build``.
+) -> Path:
+    """Default builder — delegates to scitex-container's atomic ``build``.
 
-    Returns the apptainer exit code (0 on success). Sandbox builds use
-    ``--fakeroot`` (apptainer's sandbox-from-def path requires it on
-    rootless installs).
+    scitex-container 0.3.0 builds to a timestamped
+    ``<output_dir>/<image_name>/<image_name>-<ts>.sif`` and then swaps
+    two stable symlinks all-at-once (the INNER boot path
+    ``<output_dir>/<image_name>/<image_name>.sif`` and the TOP-level
+    ``<output_dir>/<image_name>.sif`` that a layered .def's
+    ``From: ./<image_name>.sif`` resolves against). A failed build leaves
+    the prior live image + symlinks untouched — atomic, rollback-safe.
 
-    SIF builds prefer ``--fakeroot`` when the user already has
-    ``/etc/subuid`` + ``/etc/subgid`` mappings (the lead's hand-built
-    SIF on 2026-06-05 used this path), and fall back to ``sudo
-    apptainer build`` only when no mappings exist. The sudo fallback
-    works on an interactive shell but fails silently in headless /
-    detached / no-tty contexts (sudo prompts for a password) — which
-    is exactly what bit the lead's ``sac image build`` invocation
-    earlier today. The fakeroot probe lives in
-    :mod:`runtimes._apptainer_build` so both the lifecycle build and
-    this CLI build agree on the heuristic.
+    ``cwd`` is the staged build context (independent of ``output_dir``),
+    so the .def's relative ``%files scitex-agent-container-src ...`` and
+    ``From: ./sac-base.sif`` (staged into ``cwd`` by
+    :func:`stage_build_context`) resolve at build time. ``retain`` is
+    omitted so scitex-container uses its config-resolved retention
+    default. Returns the resolved timestamped SIF (SIF build) or the
+    sandbox directory (sandbox build).
     """
-    # Local import — runtimes/_apptainer_build pulls config etc. and
-    # we don't want to pay that cost on the cold ``sac image`` startup
-    # path until the actual build runs.
-    from ..runtimes._apptainer_build import _should_use_fakeroot_for_build
+    # Local import — scitex-container pulls its own deps and we don't
+    # want to pay that cost on the cold ``sac image`` startup path until
+    # the actual build runs.
+    from scitex_container import build as _sc_build
 
-    if sandbox:
-        argv = [
-            "apptainer",
-            "build",
-            "--sandbox",
-            "--fakeroot",
-        ]
-        if force:
-            argv.append("--force")
-        argv += [str(output_path), str(staged_def)]
-    elif _should_use_fakeroot_for_build():
-        # Rootless user-namespace build — no sudo prompt. This is the
-        # path the lead's hand-built SIF used today.
-        argv = ["apptainer", "build", "--fakeroot"]
-        if force:
-            argv.append("--force")
-        argv += [str(output_path), str(staged_def)]
-    else:
-        # No subuid mappings: fall back to sudo. Works interactively;
-        # FAILS in headless contexts (silent password prompt).
-        argv = ["sudo", "apptainer", "build"]
-        if force:
-            argv.append("--force")
-        argv += [str(output_path), str(staged_def)]
-
-    result = subprocess.run(argv, cwd=str(cwd))
-    return result.returncode
+    return _sc_build(
+        def_path=def_path,
+        output_dir=output_dir,
+        cwd=cwd,
+        image_name=image_name,
+        sandbox=sandbox,
+        force=force,
+    )
 
 
 # Module-level overridable reference — same swap-and-restore pattern as
 # image_group._load_apptainer. Tests reassign this to a real recording
-# callable (no MagicMock).
-_apptainer_build_runner: Callable[..., int] = _default_apptainer_build_runner
+# callable (no MagicMock) so the unit suite never shells a real apptainer
+# or imports scitex-container.
+_container_build: Callable[..., Path] = _default_container_build
 
 
 def build_layer_from_source(
@@ -333,16 +327,20 @@ def build_layer_from_source(
 ) -> Path:
     """Build a sac SIF (or sandbox) from a .def that bundles its own source.
 
-    Stages a build context under ``output_dir/sac-<layer>/build-context/``,
-    invokes ``apptainer build`` with cwd set to that staging dir (so the
-    .def's relative ``%files scitex-agent-container-src ...`` resolves to
-    the bundled source copy), and returns the path of the built artefact.
+    Stages a build context under ``output_dir/sac-<layer>/build-context/``
+    (so the .def's relative ``%files scitex-agent-container-src ...``
+    resolves to the bundled source copy, and a layered .def's
+    ``From: ./sac-base.sif`` resolves to the symlinked prerequisite SIF),
+    then delegates to :func:`scitex_container.build` with that staging dir
+    as the build context (``cwd``). The build is atomic: it lands a
+    timestamped SIF and swaps stable symlinks all-at-once, leaving the
+    prior image intact on failure.
 
     Parameters
     ----------
     layer : str
-        Layer name (``base`` / ``scitex`` / ``proxy``). Used to name the
-        per-layer artefact dir and the output filename.
+        Layer name (``base`` / ``scitex`` / ``proxy``). Maps to the
+        ``sac-<layer>`` image name (per-image subdir + artefact stem).
     def_path : Path
         Source .def file. Copied (not modified) into the staging dir.
     pkg_root : Path
@@ -350,30 +348,37 @@ def build_layer_from_source(
         ``scitex-agent-container-src/``.
     output_dir : Path
         Containers dir (typically ``~/.scitex/agent-container/containers``).
-        The per-layer subdir is created here.
+        scitex-container lands the artefact under
+        ``<output_dir>/sac-<layer>/`` and publishes the stable
+        ``<output_dir>/sac-<layer>/sac-<layer>.sif`` boot symlink.
     sandbox : bool
         If True, build a writable sandbox directory rather than a SIF.
     force : bool
-        Pass ``--force`` to apptainer (overwrite existing artefact).
+        Force a rebuild even when the recipe hash is unchanged.
     bootstrap_sif : Path | None
         Optional prerequisite SIF for a layered .def. Forwarded to
         :func:`stage_build_context` which symlinks it into the staging
-        dir so the .def's ``Bootstrap: localimage`` / ``From: ./<name>.
-        sif`` line resolves at build time. ``None`` for top-of-stack
-        defs (``base``, ``proxy``). Required for ``scitex`` (bootstraps
-        off ``sac-base.sif``); omitting it produces a half-staged
-        context and apptainer FATAL's on "no such file or directory".
+        dir under its own name so the .def's ``Bootstrap: localimage`` /
+        ``From: ./<name>.sif`` line resolves against the build context
+        (``cwd``) at build time. ``None`` for top-of-stack defs
+        (``base``, ``proxy``). Required for ``scitex`` (bootstraps off
+        ``sac-base.sif``); omitting it produces a half-staged context
+        and apptainer FATAL's on "no such file or directory".
 
     Returns
     -------
     Path
-        Path to the built ``.sif`` (or sandbox dir).
+        For a SIF build, the STABLE inner boot symlink
+        (``<output_dir>/sac-<layer>/sac-<layer>.sif``) — what callers
+        (and downstream layers' ``bootstrap_sif``) resolve against,
+        unchanged from the pre-atomic layout. For a sandbox build, the
+        sandbox directory (``<output_dir>/sac-<layer>/sac-<layer>.sandbox``).
 
     Raises
     ------
     RuntimeError
-        If the apptainer subprocess exits non-zero. The build context
-        is left in place for post-mortem inspection.
+        Propagated from :func:`scitex_container.build` if the underlying
+        apptainer build fails. The live image + symlinks are left intact.
     FileNotFoundError
         Propagated from :func:`stage_build_context` if inputs are missing.
     """
@@ -385,28 +390,76 @@ def build_layer_from_source(
         pkg_root, def_path, staging_dir, bootstrap_sif=bootstrap_sif
     )
 
-    output_path = artifact_dir / (
-        f"sac-{layer}.sandbox" if sandbox else f"sac-{layer}.sif"
-    )
-
-    rc = _apptainer_build_runner(
-        output_path,
-        staged_def,
+    image_name = f"sac-{layer}"
+    result = _container_build(
+        def_path=staged_def,
+        output_dir=output_dir,
         cwd=staging_dir,
+        image_name=image_name,
         sandbox=sandbox,
         force=force,
     )
-    if rc != 0:
-        raise RuntimeError(
-            f"apptainer build failed (rc={rc}) for layer={layer} "
-            f"def={staged_def} cwd={staging_dir}"
+
+    if sandbox:
+        # Sandbox: scitex-container returns the sandbox dir itself
+        # (<artifact_dir>/<image_name>.sandbox); no symlink layer.
+        return Path(result)
+    # SIF: scitex-container returns the RESOLVED timestamped real SIF.
+    # Callers (and the next layer's bootstrap_sif) want the STABLE inner
+    # boot symlink, which is layout-invariant across rebuilds.
+    return artifact_dir / f"{image_name}.sif"
+
+
+class BootstrapSifMissing(FileNotFoundError):
+    """Raised when a layered build's prerequisite SIF is absent.
+
+    Carries the fail-loud remediation text the CLI surfaces verbatim, so
+    the layer→prerequisite policy lives with the source-build path rather
+    than inline in the ``sac image build`` command.
+    """
+
+
+def resolve_bootstrap_sif(layer: str, output_dir: Path) -> Path | None:
+    """Return the prerequisite SIF a layered ``.def`` bootstraps off.
+
+    Layered .defs (currently only ``scitex``) start ``From: ./sac-base.sif``
+    — a path RELATIVE to the build-context dir. The prerequisite is the
+    prior layer's STABLE inner boot symlink,
+    ``<output_dir>/sac-base/sac-base.sif`` (a symlink to the live
+    timestamped SIF under scitex-container 0.3.0's atomic layout).
+    :func:`build_layer_from_source` symlinks it into the staging dir so
+    apptainer's relative ``From:`` resolves at build time.
+
+    Returns ``None`` for top-of-stack layers (``base``) which bootstrap
+    off a registry image, not a prior SIF.
+
+    Raises
+    ------
+    BootstrapSifMissing
+        When a layered build is requested but the prerequisite SIF has not
+        been built. Fails loud BEFORE staging so apptainer never FATAL's
+        on a half-staged context (the 2026-06-07 cohort-A rebuild stall).
+        The exception message names the missing path AND the remediation
+        command.
+    """
+    if layer != "scitex":
+        return None
+    bootstrap_sif = output_dir / "sac-base" / "sac-base.sif"
+    if not bootstrap_sif.is_file():
+        raise BootstrapSifMissing(
+            f"scitex layer requires a built sac-base.sif at "
+            f"{bootstrap_sif}; build the base layer first:\n"
+            f"  $ sac image build base -y\n"
+            f"then retry `sac image build scitex -y`."
         )
-    return output_path
+    return bootstrap_sif
 
 
 __all__ = [
     "stage_build_context",
     "build_layer_from_source",
-    "_default_apptainer_build_runner",
-    "_apptainer_build_runner",
+    "resolve_bootstrap_sif",
+    "BootstrapSifMissing",
+    "_default_container_build",
+    "_container_build",
 ]

--- a/src/scitex_agent_container/cli_pkg/image_group.py
+++ b/src/scitex_agent_container/cli_pkg/image_group.py
@@ -160,11 +160,13 @@ def image_build(layer: str, sandbox: bool, dry_run: bool, yes: bool) -> None:
       $ sac image build --sandbox      # writable sandbox dir
     """
     out_dir = _ensure_containers_dir()
-    # Existing artefact warning — operators forget that `sac image
-    # build` overwrites the SIF in place. Surface the target path
-    # (and its current size + mtime, if any) BEFORE the
-    # refuse-without-yes gate so a `-y` re-invocation knows what it's
-    # about to clobber.
+    # Existing-artefact notice. A SIF rebuild is now ATOMIC (delegated to
+    # scitex-container's ``build``): it lands a fresh timestamped SIF and
+    # swaps the stable ``sac-<layer>.sif`` boot symlink all-at-once, so on
+    # success the live image is replaced but on failure the prior one is
+    # left intact (no in-place clobber). A sandbox rebuild is still in
+    # place. ``existing`` is the stable inner boot symlink for SIFs;
+    # ``.stat()`` follows it to the live timestamped target.
     artifact_dir = out_dir / f"sac-{layer}"
     existing = artifact_dir / (
         f"sac-{layer}.sandbox" if sandbox else f"sac-{layer}.sif"
@@ -177,9 +179,10 @@ def image_build(layer: str, sandbox: bool, dry_run: bool, yes: bool) -> None:
             timespec="seconds"
         )
         kind = "sandbox dir" if sandbox else "SIF"
+        verb = "overwritten" if sandbox else "replaced (atomic swap)"
         click.echo(
             f"⚠  Existing {kind} at {existing} "
-            f"({size_mb:.0f} MB, built {mtime}) will be overwritten.",
+            f"({size_mb:.0f} MB, built {mtime}) will be {verb}.",
             err=True,
         )
 
@@ -202,42 +205,25 @@ def image_build(layer: str, sandbox: bool, dry_run: bool, yes: bool) -> None:
     # /opt/scitex-agent-container-src, which gets there via a %files
     # copy of a sibling directory next to the .def at build time. The
     # staging helper (cli_pkg/_image_source_build.py) creates that
-    # sibling copy under <out>/sac-<layer>/build-context/ and runs
-    # ``apptainer build`` with cwd set there so the .def's relative
-    # %files path resolves correctly.
-    #
-    # We bypass scitex-container's build helper for this path because
-    # it doesn't expose a ``cwd`` parameter — without cwd control,
-    # apptainer would resolve the .def's relative %files against
-    # whatever directory the operator happened to ``sac image build``
-    # from, which is not predictable. The non-build verbs (sandbox,
-    # update, freeze, list, status, snapshot) still delegate to the
-    # scitex-container backend since they operate on already-built
-    # SIFs and don't need build-context staging.
+    # sibling copy under <out>/sac-<layer>/build-context/, then delegates
+    # to scitex-container 0.3.0's atomic ``build`` with ``cwd`` set to
+    # that staging dir so the .def's relative %files + ``From: ./sac-
+    # base.sif`` resolve. ``build`` lands a timestamped SIF and swaps the
+    # stable ``sac-<layer>.sif`` boot symlink all-at-once — a failed
+    # build leaves the prior image intact (atomic, rollback-safe). The
+    # non-build verbs (sandbox, update, freeze, list, status, snapshot)
+    # also delegate to the scitex-container backend.
     pkg_root = _RECIPES_DIR.parent
 
-    # Layered .defs (currently: ``scitex``) bootstrap off a prior
-    # layer's SIF via ``Bootstrap: localimage`` / ``From: ./<name>.sif``
-    # — the .def references the SIF as a sibling of itself in the
-    # build-context dir. Resolve the prerequisite SIF path here so
-    # build_layer_from_source can symlink it into the staging dir, and
-    # FAIL LOUD when the prerequisite is missing rather than letting
-    # apptainer FATAL on a half-staged context (the 2026-06-07 cohort-
-    # A rebuild stall: ``sac image build scitex`` ran without the
-    # freshly-built sac-base.sif staged → apptainer FATAL "no such
-    # file or directory" mid-build).
-    bootstrap_sif: Path | None = None
-    if layer == "scitex":
-        bootstrap_sif = out_dir / "sac-base" / "sac-base.sif"
-        if not bootstrap_sif.is_file():
-            click.echo(
-                f"error: scitex layer requires a built sac-base.sif at "
-                f"{bootstrap_sif}; build the base layer first:\n"
-                f"  $ sac image build base -y\n"
-                f"then retry `sac image build scitex -y`.",
-                err=True,
-            )
-            sys.exit(1)
+    # Layered .defs (currently: ``scitex``) bootstrap off a prior layer's
+    # SIF (``From: ./sac-base.sif``). Resolve the prerequisite here — the
+    # helper FAILS LOUD when it is missing so apptainer never FATAL's on a
+    # half-staged context (the 2026-06-07 cohort-A rebuild stall).
+    try:
+        bootstrap_sif = _image_source_build.resolve_bootstrap_sif(layer, out_dir)
+    except _image_source_build.BootstrapSifMissing as exc:
+        click.echo(f"error: {exc}", err=True)
+        sys.exit(1)
 
     try:
         output = _build_layer_from_source(

--- a/tests/scitex_agent_container/cli_pkg/test__image_source_build.py
+++ b/tests/scitex_agent_container/cli_pkg/test__image_source_build.py
@@ -6,7 +6,9 @@ satisfy PS-204 §2 orphan-test-file: every test file must mirror a
 single src file):
 
   - ``stage_build_context`` / ``build_layer_from_source`` /
-    ``_default_apptainer_build_runner`` — unit coverage of the helper.
+    ``resolve_bootstrap_sif`` — unit coverage of the helper. The build
+    delegates to scitex-container's atomic ``build`` via the module-level
+    ``_container_build`` seam (swapped for a real recording fake).
   - Shipped .def contract — every apptainer-*.def in the package's
     ``containers/`` dir must declare the bundled-source ``%files``
     entry, install sac from ``/opt/scitex-agent-container-src``, and
@@ -40,7 +42,6 @@ import pytest
 import scitex_agent_container
 from scitex_agent_container.cli_pkg import _image_source_build as isb
 from scitex_agent_container.cli_pkg.image_group import _LAYERS, _RECIPES_DIR
-from scitex_agent_container.runtimes import _apptainer_build as build_mod
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -86,37 +87,26 @@ def fake_def(tmp_path: Path) -> Path:
 
 
 @contextmanager
-def _use_apptainer_runner(runner_fn) -> Iterator[list[tuple]]:
-    """Swap ``_image_source_build._apptainer_build_runner`` for a real fake."""
+def _use_container_build(build_fn) -> Iterator[list[tuple]]:
+    """Swap ``_image_source_build._container_build`` for a real fake.
+
+    ``_container_build`` is the seam that delegates to scitex-container's
+    atomic ``build``; swapping it lets the unit tests exercise the
+    staging + mapping without importing scitex-container or shelling a
+    real apptainer. No MagicMock — a hand-rolled recording callable.
+    """
     calls: list[tuple] = []
 
     def _recording(*a, **kw):
         calls.append((a, kw))
-        return runner_fn(*a, **kw)
+        return build_fn(*a, **kw)
 
-    saved = isb._apptainer_build_runner
-    isb._apptainer_build_runner = _recording  # type: ignore[assignment]
+    saved = isb._container_build
+    isb._container_build = _recording  # type: ignore[assignment]
     try:
         yield calls
     finally:
-        isb._apptainer_build_runner = saved  # type: ignore[assignment]
-
-
-@contextmanager
-def _force_fakeroot_probe(value: bool) -> Iterator[None]:
-    """Swap ``runtimes._apptainer_build._should_use_fakeroot_for_build``.
-
-    The runner imports the probe lazily on each call, so swapping the
-    module attribute deterministically controls which SIF-build branch
-    the runner takes regardless of the host's actual ``/etc/subuid``
-    state. No MagicMock — a plain ``lambda`` returning the desired value.
-    """
-    saved = build_mod._should_use_fakeroot_for_build
-    build_mod._should_use_fakeroot_for_build = lambda: value  # type: ignore[assignment]
-    try:
-        yield
-    finally:
-        build_mod._should_use_fakeroot_for_build = saved  # type: ignore[assignment]
+        isb._container_build = saved  # type: ignore[assignment]
 
 
 # ---------------------------------------------------------------------------
@@ -449,13 +439,28 @@ def test_stage_build_context_preserves_staging_dir_when_bootstrap_sif_missing(
 # ---------------------------------------------------------------------------
 
 
-def test_build_layer_from_source_invokes_runner_with_staging_cwd(
+def _stub_build_result(*_a, output_dir, image_name, sandbox, **_kw) -> Path:
+    """A fake ``_container_build`` that mimics scitex-container's returns.
+
+    SIF build → the resolved timestamped real SIF
+    (``<output_dir>/<image_name>/<image_name>-<ts>.sif``). Sandbox build →
+    the sandbox dir. ``build_layer_from_source`` derives the STABLE inner
+    boot symlink from ``output_dir`` + ``image_name`` itself, so the exact
+    timestamp here is irrelevant to what the helper returns.
+    """
+    image_dir = Path(output_dir) / image_name
+    if sandbox:
+        return image_dir / f"{image_name}.sandbox"
+    return image_dir / f"{image_name}-20260702T000000Z.sif"
+
+
+def test_build_layer_from_source_invokes_build_with_staging_cwd(
     tmp_path, fake_pkg_root, fake_def
 ):
     # Arrange
     out_dir = tmp_path / "out"
     # Act
-    with _use_apptainer_runner(lambda *a, **kw: 0) as calls:
+    with _use_container_build(_stub_build_result) as calls:
         isb.build_layer_from_source(
             layer="base",
             def_path=fake_def,
@@ -468,13 +473,79 @@ def test_build_layer_from_source_invokes_runner_with_staging_cwd(
     assert kwargs["cwd"] == expected_cwd and expected_cwd.is_dir()
 
 
-def test_build_layer_from_source_writes_output_into_layer_dir(
+def test_build_layer_from_source_maps_output_dir_and_image_name(
     tmp_path, fake_pkg_root, fake_def
 ):
-    # Arrange
+    # Arrange — the containers output dir maps straight to ``output_dir``;
+    # the layer maps to ``image_name`` (``sac-<layer>``) so scitex-
+    # container lands the artefact under ``<output_dir>/sac-<layer>/``.
     out_dir = tmp_path / "out"
     # Act
-    with _use_apptainer_runner(lambda *a, **kw: 0):
+    with _use_container_build(_stub_build_result) as calls:
+        isb.build_layer_from_source(
+            layer="base",
+            def_path=fake_def,
+            pkg_root=fake_pkg_root,
+            output_dir=out_dir,
+        )
+    # Assert
+    kwargs = calls[0][1]
+    assert kwargs["output_dir"] == out_dir and kwargs["image_name"] == "sac-base"
+
+
+def test_build_layer_from_source_passes_staged_def_and_force(
+    tmp_path, fake_pkg_root, fake_def
+):
+    # Arrange — ``def_path`` is the STAGED copy (in the build-context
+    # dir), not the source .def, so scitex-container resolves relative
+    # ``%files`` against the same staging dir it uses as ``cwd``.
+    out_dir = tmp_path / "out"
+    # Act
+    with _use_container_build(_stub_build_result) as calls:
+        isb.build_layer_from_source(
+            layer="base",
+            def_path=fake_def,
+            pkg_root=fake_pkg_root,
+            output_dir=out_dir,
+            force=True,
+        )
+    # Assert
+    kwargs = calls[0][1]
+    staged_def = out_dir / "sac-base" / "build-context" / "apptainer-base.def"
+    assert (
+        kwargs["def_path"] == staged_def
+        and kwargs["force"] is True
+        and kwargs["sandbox"] is False
+    )
+
+
+def test_build_layer_from_source_omits_retain_for_config_default(
+    tmp_path, fake_pkg_root, fake_def
+):
+    # Arrange — sac does not pin ``retain``; scitex-container falls back
+    # to the image config's retention default (keeps N previous + live).
+    out_dir = tmp_path / "out"
+    # Act
+    with _use_container_build(_stub_build_result) as calls:
+        isb.build_layer_from_source(
+            layer="base",
+            def_path=fake_def,
+            pkg_root=fake_pkg_root,
+            output_dir=out_dir,
+        )
+    # Assert
+    assert "retain" not in calls[0][1]
+
+
+def test_build_layer_from_source_returns_stable_inner_boot_symlink(
+    tmp_path, fake_pkg_root, fake_def
+):
+    # Arrange — build() returns a timestamped real SIF; the helper must
+    # return the STABLE inner boot symlink (layout-invariant across
+    # rebuilds), which callers + the next layer's bootstrap resolve.
+    out_dir = tmp_path / "out"
+    # Act
+    with _use_container_build(_stub_build_result):
         result = isb.build_layer_from_source(
             layer="base",
             def_path=fake_def,
@@ -485,13 +556,13 @@ def test_build_layer_from_source_writes_output_into_layer_dir(
     assert result == out_dir / "sac-base" / "sac-base.sif"
 
 
-def test_build_layer_from_source_sandbox_writes_sandbox_path(
+def test_build_layer_from_source_sandbox_returns_sandbox_path(
     tmp_path, fake_pkg_root, fake_def
 ):
     # Arrange
     out_dir = tmp_path / "out"
     # Act
-    with _use_apptainer_runner(lambda *a, **kw: 0):
+    with _use_container_build(_stub_build_result):
         result = isb.build_layer_from_source(
             layer="base",
             def_path=fake_def,
@@ -503,15 +574,20 @@ def test_build_layer_from_source_sandbox_writes_sandbox_path(
     assert result == out_dir / "sac-base" / "sac-base.sandbox"
 
 
-def test_build_layer_from_source_raises_RuntimeError_on_nonzero_exit(
+def test_build_layer_from_source_propagates_runtime_error(
     tmp_path, fake_pkg_root, fake_def
 ):
-    # Arrange
+    # Arrange — scitex-container's ``build`` raises RuntimeError on a
+    # failed apptainer build; the helper must let it propagate (the live
+    # image + symlinks are left intact by the atomic build).
     out_dir = tmp_path / "out"
+
+    def _raising(*_a, **_kw):
+        raise RuntimeError("apptainer build failed; see build log")
 
     # Act
     def _call():
-        with _use_apptainer_runner(lambda *a, **kw: 7):
+        with _use_container_build(_raising):
             isb.build_layer_from_source(
                 layer="base",
                 def_path=fake_def,
@@ -520,23 +596,25 @@ def test_build_layer_from_source_raises_RuntimeError_on_nonzero_exit(
             )
 
     # Assert
-    with pytest.raises(RuntimeError, match=r"apptainer build failed.*rc=7"):
+    with pytest.raises(RuntimeError, match=r"apptainer build failed"):
         _call()
 
 
 def test_build_layer_from_source_stages_source_at_known_relative_name(
     tmp_path, fake_pkg_root, fake_def
 ):
-    # Arrange — runner records cwd; we then check the staged tree on disk.
+    # Arrange — build() records cwd; we then check the staged tree on disk.
     out_dir = tmp_path / "out"
     seen_cwds: list[Path] = []
 
-    def _runner(*_a, cwd, **_kw):
+    def _record_cwd(*_a, cwd, output_dir, image_name, sandbox, **_kw):
         seen_cwds.append(cwd)
-        return 0
+        return _stub_build_result(
+            output_dir=output_dir, image_name=image_name, sandbox=sandbox
+        )
 
     # Act
-    with _use_apptainer_runner(_runner):
+    with _use_container_build(_record_cwd):
         isb.build_layer_from_source(
             layer="base",
             def_path=fake_def,
@@ -558,16 +636,18 @@ def test_build_layer_from_source_forwards_bootstrap_sif_to_staging(
     tmp_path, fake_pkg_root, fake_def
 ):
     # Arrange — pin that the public builder forwards ``bootstrap_sif``
-    # through to ``stage_build_context`` so the staged context for a
-    # layered .def actually carries the prerequisite SIF. Without this,
-    # apptainer would FATAL on a half-staged context (the 2026-06-07
-    # cohort-A rebuild stall).
+    # through to ``stage_build_context`` so the staged context (== the
+    # ``cwd`` build context) for a layered .def carries the prerequisite
+    # SIF. Without this, apptainer would FATAL on a half-staged context
+    # (the 2026-06-07 cohort-A rebuild stall). This is exactly how the
+    # layered ``From: ./sac-base.sif`` resolves: the symlink lives in the
+    # ``cwd`` staging dir scitex-container's ``build`` runs against.
     out_dir = tmp_path / "out"
     fake_base_sif = tmp_path / "sac-base.sif"
     fake_base_sif.write_bytes(b"fake SIF")
 
     # Act
-    with _use_apptainer_runner(lambda *a, **kw: 0):
+    with _use_container_build(_stub_build_result):
         isb.build_layer_from_source(
             layer="scitex",
             def_path=fake_def,
@@ -584,117 +664,48 @@ def test_build_layer_from_source_forwards_bootstrap_sif_to_staging(
 
 
 # ---------------------------------------------------------------------------
-# _default_apptainer_build_runner — argv shape (no real apptainer call)
+# resolve_bootstrap_sif — layer → prerequisite SIF policy
 # ---------------------------------------------------------------------------
 
 
-def test_default_runner_sif_argv_uses_sudo_when_subuid_absent(tmp_path):
-    # Arrange — fakeroot probe forced False (no /etc/subuid mapping for
-    # this user) so the runner takes the sudo fallback branch. Swap
-    # subprocess.run for a real recording callable.
-    seen: dict = {}
-
-    class _FakeResult:
-        returncode = 0
-
-    def _fake_run(argv, cwd=None):
-        seen["argv"] = list(argv)
-        seen["cwd"] = cwd
-        return _FakeResult()
-
-    saved = isb.subprocess.run
-    isb.subprocess.run = _fake_run  # type: ignore[assignment]
-    try:
-        # Act
-        with _force_fakeroot_probe(False):
-            rc = isb._default_apptainer_build_runner(
-                output_path=tmp_path / "x.sif",
-                staged_def=tmp_path / "x.def",
-                cwd=tmp_path,
-                sandbox=False,
-                force=True,
-            )
-    finally:
-        isb.subprocess.run = saved  # type: ignore[assignment]
-    # Assert
-    assert (
-        rc == 0
-        and seen["argv"][:3] == ["sudo", "apptainer", "build"]
-        and "--force" in seen["argv"]
-        and "--fakeroot" not in seen["argv"]
-        and str(tmp_path / "x.sif") in seen["argv"]
-        and str(tmp_path / "x.def") in seen["argv"]
-        and seen["cwd"] == str(tmp_path)
-    )
-
-
-def test_default_runner_sif_argv_uses_fakeroot_when_subuid_present(
-    tmp_path: Path, subprocess_shim
-):
-    """Lead's hand-built SIF on 2026-06-05 used the rootless fakeroot
-    path because /etc/subuid had a mapping; ``sac image build`` had
-    been falling back to sudo (silent password prompt in headless
-    contexts). Real PATH-installed ``apptainer`` shim records argv;
-    the production runner shells out via the real ``subprocess.run``
-    and the shim writes the argv to a log we read back. No MagicMock.
-    """
-    # Arrange — install a recording apptainer shim, force the probe True.
-    subprocess_shim.install("apptainer", exit=0)
+def test_resolve_bootstrap_sif_base_returns_none(tmp_path):
+    # Arrange — top-of-stack ``base`` has no prerequisite SIF.
+    out_dir = tmp_path / "out"
     # Act
-    with _force_fakeroot_probe(True):
-        rc = isb._default_apptainer_build_runner(
-            output_path=tmp_path / "x.sif",
-            staged_def=tmp_path / "x.def",
-            cwd=tmp_path,
-            sandbox=False,
-            force=True,
-        )
-    argv = subprocess_shim.argv_for("apptainer")
-    # Assert — argv carries --fakeroot, no sudo, and the build target.
-    assert (
-        rc == 0
-        and argv is not None
-        and argv[0] == "build"
-        and "--fakeroot" in argv
-        and "sudo" not in argv
-        and "--force" in argv
-        and str(tmp_path / "x.sif") in argv
-        and str(tmp_path / "x.def") in argv
-    )
+    result = isb.resolve_bootstrap_sif("base", out_dir)
+    # Assert
+    assert result is None
 
 
-def test_default_runner_sandbox_argv_uses_fakeroot_and_no_sudo(tmp_path):
-    # Arrange
-    seen: dict = {}
+def test_resolve_bootstrap_sif_scitex_returns_inner_base_boot_symlink(tmp_path):
+    # Arrange — under 0.3.0's atomic layout the prerequisite is the STABLE
+    # inner boot symlink ``<out>/sac-base/sac-base.sif`` (a symlink to the
+    # live timestamped SIF). ``is_file()`` follows it, so a valid symlink
+    # resolves. Model that: a real timestamped SIF + a symlink to it.
+    out_dir = tmp_path / "out"
+    base_dir = out_dir / "sac-base"
+    base_dir.mkdir(parents=True)
+    real_sif = base_dir / "sac-base-20260702T000000Z.sif"
+    real_sif.write_bytes(b"fake base SIF")
+    inner = base_dir / "sac-base.sif"
+    inner.symlink_to(real_sif.name)
+    # Act
+    result = isb.resolve_bootstrap_sif("scitex", out_dir)
+    # Assert
+    assert result == inner
 
-    class _FakeResult:
-        returncode = 0
 
-    def _fake_run(argv, cwd=None):
-        seen["argv"] = list(argv)
-        return _FakeResult()
+def test_resolve_bootstrap_sif_scitex_raises_when_base_missing(tmp_path):
+    # Arrange — scitex requested but sac-base.sif was never built.
+    out_dir = tmp_path / "out"
 
-    saved = isb.subprocess.run
-    isb.subprocess.run = _fake_run  # type: ignore[assignment]
-    try:
-        # Act
-        isb._default_apptainer_build_runner(
-            output_path=tmp_path / "sb",
-            staged_def=tmp_path / "x.def",
-            cwd=tmp_path,
-            sandbox=True,
-            force=False,
-        )
-    finally:
-        isb.subprocess.run = saved  # type: ignore[assignment]
-    # Assert — sandbox path does NOT prepend sudo, DOES include --fakeroot
-    assert (
-        seen["argv"][0] == "apptainer"
-        and "--sandbox" in seen["argv"]
-        and "--fakeroot" in seen["argv"]
-        and "sudo" not in seen["argv"]
-        and "--force" not in seen["argv"]  # force=False
-    )
+    # Act
+    def _call():
+        return isb.resolve_bootstrap_sif("scitex", out_dir)
+
+    # Assert
+    with pytest.raises(isb.BootstrapSifMissing, match=r"sac image build base"):
+        _call()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Replace sac's hand-rolled `apptainer build --force` (in-place overwrite of the live SIF, no atomicity/rollback) with a delegation to **scitex-container 0.3.0**'s atomic `build()`. It builds to a timestamped `<out>/<name>/<name>-<ts>.sif` and swaps the stable boot symlinks all-at-once, so a **failed build leaves the prior image intact**.
- All build-context staging is preserved (source copy next to the `.def` for `%files`; prerequisite SIF symlinked into the staging dir for a layered `From: ./sac-base.sif`).
- Card: `sac-consume-scitex-container-atomic-build-20260702`.

## What changed
- **`cli_pkg/_image_source_build.py`** — the `build_layer_from_source(...)` staging is unchanged; the hand-rolled `apptainer build` subprocess seam (`_apptainer_build_runner`) is replaced by a `_container_build` seam whose default (`_default_container_build`) calls:
  ```python
  scitex_container.build(
      def_path=<staged .def in build-context>,
      output_dir=<containers dir where the SIF lands>,
      cwd=<staging dir>,          # %files + From: ./sac-base.sif resolve here
      image_name=f"sac-{layer}",  # → <out>/sac-<layer>/sac-<layer>-<ts>.sif
      sandbox=<bool>,
      force=True,
      # retain omitted → scitex-container config default (N previous + live)
  )
  ```
  Returns the **stable inner boot symlink** `<out>/sac-<layer>/sac-<layer>.sif` (SIF) or the sandbox dir — layout-invariant across rebuilds, so zero agent-spec churn. The layer→prerequisite-SIF policy is extracted into `resolve_bootstrap_sif(...)` (+ `BootstrapSifMissing`).
- **`cli_pkg/image_group.py`** — `image_build(...)` comments/warning updated from "overwrites in place" to atomic build+swap; uses `resolve_bootstrap_sif`. The `bootstrap_sif = <out>/sac-base/sac-base.sif` path is **unchanged** and still resolves: under 0.3.0 that inner path is now a symlink to the live timestamped SIF, and `is_file()`/`.stat()` follow symlinks.
- **`pyproject.toml`** — `scitex-container` floor bumped `>=0.1.0` → `>=0.3.0` (the `cwd` / `image_name` / `retain` / Path-return API).
- **tests** — the old `apptainer build` argv assertions are replaced with `_container_build` kwargs-mapping tests + `resolve_bootstrap_sif` coverage, all via hand-rolled module-level seams (no mocks/monkeypatch).

## Verification
- Isolated venv with `scitex-container==0.3.0`: confirmed `from scitex_container import build`, signature carries `cwd`/`image_name`/`retain`, returns `Path`, and the exact kwargs sac passes `bind()` cleanly for both SIF and sandbox. Confirmed the atomic layout publishes INNER `<out>/<name>/<name>.sif` + TOP `<out>/<name>.sif` symlinks (the latter resolves a layered `From: ./sac-base.sif`).
- `test__image_source_build.py` + `test_image_group.py`: **all pass** (86 collected, exit 0) under `/opt/venv-sac/bin/python -m pytest`.
- A real end-to-end apptainer build is not runnable in this environment (gated); relied on the unit seams + the isolated import-signature/bind check.

## Test plan
- [ ] CI green (scitex-dev audit + full suite)
- [ ] On a host with apptainer + a built `sac-base.sif`: `sac image build base -y` then `sac image build scitex -y` — confirm the timestamped SIF + stable `sac-<layer>.sif` symlink land, and a forced failure leaves the prior image intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)