### PR TITLE
fix(to_home): skip deploy when dst already resolves to source (SameFileError on agent restart)

### DIFF
--- a/src/scitex_agent_container/runtimes/_host_commands.py
+++ b/src/scitex_agent_container/runtimes/_host_commands.py
@@ -60,7 +60,19 @@ def _copy_force_overwrite(src: Path, dst: Path) -> None:
     DOWN on restart (observed 2026-07-01: a 0444 ``update-docs.md``). Grant
     owner-write before the copy (so it can overwrite) and after (so the next
     deploy can too).
+
+    Same-file skip: when ``dst`` already resolves to ``src`` (a prior "linked
+    host file" symlink, a hardlink, or a bind), the copy is a no-op — and
+    ``copy2`` raises ``SameFileError`` while ``chmod`` would FOLLOW the link and
+    mutate the shared host source. Skip cleanly. (INCIDENT 2026-07-02:
+    ``sac agents start/restart neurovista`` on ``~/.claude/commands/autonomous.md``,
+    whose dst was a symlink back to the host source.)
     """
+    try:
+        if dst.exists() and src.samefile(dst):
+            return
+    except OSError:  # stx-allow: fallback (unreadable/broken dst → proceed with the copy)
+        pass
     if dst.exists():
         dst.chmod(dst.stat().st_mode | 0o200)
     shutil.copy2(src, dst)

--- a/src/scitex_agent_container/runtimes/_to_home_deployers.py
+++ b/src/scitex_agent_container/runtimes/_to_home_deployers.py
@@ -78,6 +78,20 @@ def _read_and_interpolate(src: Path, config: AgentConfig | None) -> str:
     return text
 
 
+def _dst_resolves_to_source(src: Path, dst: Path) -> bool:
+    """True when ``dst`` already refers to the SAME file as ``src``.
+
+    Happens when a prior deploy materialized this entry as a "linked host
+    file" (a symlink into ``~/.claude``), or via a hardlink/bind.
+    ``Path.samefile`` follows symlinks and compares device+inode; a missing
+    or broken ``dst`` returns ``False`` so the deploy proceeds normally.
+    """
+    try:
+        return dst.exists() and src.samefile(dst)
+    except OSError:  # stx-allow: fallback (unreadable/broken dst → treat as not-same, let deploy proceed)
+        return False
+
+
 def _deploy_plain_file(
     src: Path,
     dst: Path,
@@ -88,6 +102,15 @@ def _deploy_plain_file(
     """Full overwrite. Uses ``shutil.copy2`` for binary-safe perm preserve
     when no interpolation is needed; otherwise writes interpolated text."""
     dst.parent.mkdir(parents=True, exist_ok=True)
+    # If dst ALREADY resolves to src (a prior "linked host file" symlink, a
+    # hardlink, or a bind), the copy is a no-op — and worse, writing/interpolating
+    # would follow the link and CORRUPT the shared host source. Skip cleanly;
+    # ``shutil.copy2`` would otherwise raise ``SameFileError``. (INCIDENT
+    # 2026-07-02: ``sac agents restart neurovista`` failed on
+    # ``~/.claude/commands/autonomous.md`` — dst was a symlink back to src.)
+    if _dst_resolves_to_source(src, dst):
+        logger.info("to_home: %s already resolves to source; skip", rel)
+        return
     _clear_readonly_dst(dst)
     if config is None:
         shutil.copy2(src, dst)

--- a/tests/scitex_agent_container/runtimes/test__host_commands.py
+++ b/tests/scitex_agent_container/runtimes/test__host_commands.py
@@ -42,6 +42,23 @@ class TestDeployHostClaudeCommands:
         landed = agent_home / ".claude" / "commands" / "foo.md"
         assert landed.read_text() == "# /foo\nrun foo\n"
 
+    def test_symlink_back_to_host_source_is_skipped_not_corrupted(
+        self, tmp_path, env_save_restore
+    ):
+        # Arrange — the agent dst is a symlink back to the host source (a prior
+        # "linked host file"); deploying must not copy the file onto itself.
+        host_cmds = _seed_host_commands(tmp_path / "host_home", env_save_restore)
+        src = host_cmds / "autonomous.md"
+        src.write_text("HOST-CONTENT")
+        agent_home = tmp_path / "agent_home"
+        dst = agent_home / ".claude" / "commands" / "autonomous.md"
+        dst.parent.mkdir(parents=True)
+        dst.symlink_to(src)
+        # Act — must NOT raise SameFileError nor write through the link.
+        deploy_host_claude_commands(agent_home)
+        # Assert
+        assert src.read_text() == "HOST-CONTENT"
+
     def test_overwrites_read_only_destination(self, tmp_path, env_save_restore):
         # Arrange — deploy once, then make the landed file read-only (0444) and
         # change the host source (mirrors a 0444 source mode preserved across

--- a/tests/scitex_agent_container/runtimes/test__to_home_deployers.py
+++ b/tests/scitex_agent_container/runtimes/test__to_home_deployers.py
@@ -1,0 +1,73 @@
+"""Tests for ``_to_home_deployers`` — the same-file (linked-host-file) guard.
+
+No mocks: real files + real symlinks under ``tmp_path``. AAA-marked, one
+assert per test.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scitex_agent_container.runtimes._to_home_deployers import (
+    _deploy_plain_file,
+    _dst_resolves_to_source,
+)
+
+
+class TestDstResolvesToSource:
+    def test_true_when_dst_symlinks_to_source(self, tmp_path) -> None:
+        # Arrange
+        src = tmp_path / "s.md"
+        src.write_text("x")
+        dst = tmp_path / "d.md"
+        dst.symlink_to(src)
+        # Act
+        result = _dst_resolves_to_source(src, dst)
+        # Assert
+        assert result is True
+
+    def test_false_for_two_distinct_files(self, tmp_path) -> None:
+        # Arrange
+        src = tmp_path / "s.md"
+        src.write_text("x")
+        dst = tmp_path / "d.md"
+        dst.write_text("y")
+        # Act
+        result = _dst_resolves_to_source(src, dst)
+        # Assert
+        assert result is False
+
+    def test_false_when_dst_missing(self, tmp_path) -> None:
+        # Arrange
+        src = tmp_path / "s.md"
+        src.write_text("x")
+        dst = tmp_path / "does-not-exist.md"
+        # Act
+        result = _dst_resolves_to_source(src, dst)
+        # Assert
+        assert result is False
+
+
+class TestDeployPlainFileSameFileGuard:
+    def test_symlink_back_to_source_does_not_corrupt_source(self, tmp_path) -> None:
+        # Arrange — dst is a "linked host file" symlink back to src.
+        src = tmp_path / "autonomous.md"
+        src.write_text("HOST-CONTENT")
+        dst = tmp_path / "home" / "autonomous.md"
+        dst.parent.mkdir(parents=True)
+        dst.symlink_to(src)
+        # Act — must NOT raise SameFileError, must NOT write through the link.
+        _deploy_plain_file(src, dst, config=None, rel=Path("commands/autonomous.md"))
+        # Assert
+        assert src.read_text() == "HOST-CONTENT"
+
+    def test_distinct_dst_is_still_overwritten(self, tmp_path) -> None:
+        # Arrange — a normal (non-linked) dst still gets the full overwrite.
+        src = tmp_path / "src.md"
+        src.write_text("NEW")
+        dst = tmp_path / "dst.md"
+        dst.write_text("OLD")
+        # Act
+        _deploy_plain_file(src, dst, config=None, rel=Path("commands/x.md"))
+        # Assert
+        assert dst.read_text() == "NEW"


### PR DESCRIPTION
## Summary
`sac agents restart <agent>` could fail with `shutil.SameFileError` during the `~/.claude` → agent-home materialization. When a prior deploy left an entry as a **"linked host file"** (a symlink back into `~/.claude`), `_deploy_plain_file`'s `shutil.copy2` follows the symlink, sees `src == dst`, and raises. Worse, the interpolation branch would have written **through** the link and corrupted the shared host source.

- **Repro (2026-07-02):** `sac agents restart neurovista -y` → `PosixPath('~/.claude/commands/autonomous.md') and PosixPath('.../runtime/neurovista/home/.claude/commands/autonomous.md') are the same file`. Confirmed the dst was a symlink → the host source (same device+inode when followed).
- **Fix:** guard `_deploy_plain_file` — if `dst` already resolves to `src` (samefile: a prior link, hardlink, or bind), skip cleanly. Idempotent + prevents host-source corruption.

## Test plan
- [x] `test__to_home_deployers.py` — 5 tests, no mocks (real files + real symlinks under `tmp_path`): guard True for symlink-to-src / False for distinct / False for missing dst; `_deploy_plain_file` with a symlink-back-to-src does NOT raise or corrupt the source; a distinct dst is still overwritten. Green.

## Deploy / immediate unblock
Once merged + the host checkout pulled, `sac agents restart` handles linked entries cleanly. Immediate unblock without waiting: remove the offending symlink (`rm .../runtime/<agent>/home/.claude/commands/autonomous.md`) and retry — the deploy re-materializes it.