### PR TITLE
feat(runtime): inject UV_PROJECT_ENVIRONMENT into agent container env

### DIFF
--- a/src/scitex_agent_container/runtimes/_apptainer_listen_env.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_listen_env.py
@@ -96,6 +96,21 @@ def listen_env_flags(config) -> list[str]:
     # sac/other-package standalone boundary.
     flags += ["--env", "DIRENV_CONFIG=/etc/direnv"]
 
+    # UV DEFAULT VENV — force ``uv``'s project venv to the container-only
+    # boot-built path ``/uvwork/venv-agent`` so any ad-hoc ``uv run`` /
+    # ``uv pip install`` / ``uv sync`` an agent runs WITHOUT an explicit
+    # ``--python`` resolves there instead of defaulting to ``./.venv`` inside
+    # the shared ``~/proj/<agent>`` host<->container bind. A container-created
+    # ``./.venv`` uses the container python (``/opt/python3.12``) whose
+    # ``pyvenv.cfg home=`` then DANGLES on the host (no ``/opt/python3.12``
+    # host-side), breaking host ``uv``/``sac`` — INCIDENT 2026-07-02:
+    # ``~/proj/neurovista/.venv`` broke host tooling exactly this way. The
+    # shared ``~/proj/<agent>/.venv`` stays reserved for the host's own
+    # python. UNCONDITIONAL — every agent's uv must default to the
+    # container-only venv. Generic uv-tooling knob, not coupled to any
+    # scitex-* package.
+    flags += ["--env", "UV_PROJECT_ENVIRONMENT=/uvwork/venv-agent"]
+
     # PERSISTENT TESTMON CACHE — point testmon's data file at the
     # container-side bind destination (see
     # ``_p3a_default_binds._FLEET_DEFAULT_BINDS``: the host's

--- a/tests/scitex_agent_container/runtimes/test__apptainer_listen_env.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_listen_env.py
@@ -249,3 +249,28 @@ def test_listen_env_flags_direnv_config_follows_an_env_token(
     idx = flags.index("DIRENV_CONFIG=/etc/direnv")
     # Assert
     assert flags[idx - 1] == "--env"
+
+
+def test_listen_env_flags_injects_uv_project_environment(
+    no_bus_config: SimpleNamespace,
+    sandboxed_home: Path,
+) -> None:
+    # Arrange — every agent's uv must default to the container-only venv
+    # ``/uvwork/venv-agent`` so ad-hoc uv commands never create ``./.venv``
+    # in the shared ``~/proj/<agent>`` bind (INCIDENT 2026-07-02).
+    # Act
+    flags = listen_env_flags(no_bus_config)
+    # Assert
+    assert "UV_PROJECT_ENVIRONMENT=/uvwork/venv-agent" in flags
+
+
+def test_listen_env_flags_uv_project_environment_follows_an_env_token(
+    no_bus_config: SimpleNamespace,
+    sandboxed_home: Path,
+) -> None:
+    # Arrange — apptainer consumes ``--env KEY=VALUE`` as two argv tokens.
+    flags = listen_env_flags(no_bus_config)
+    # Act
+    idx = flags.index("UV_PROJECT_ENVIRONMENT=/uvwork/venv-agent")
+    # Assert
+    assert flags[idx - 1] == "--env"


### PR DESCRIPTION
## Summary
- Inject `UV_PROJECT_ENVIRONMENT=/uvwork/venv-agent` as an apptainer `--env` flag in `listen_env_flags`, alongside the existing `DIRENV_CONFIG` injection.
- This forces any ad-hoc `uv run` / `uv pip install` / `uv sync` an agent runs (without an explicit `--python`) to resolve to the container-only boot-built venv `/uvwork/venv-agent`, instead of defaulting to `./.venv` inside the shared `~/proj/<agent>` host<->container bind.

## Why
A container-created `./.venv` uses the container python (`/opt/python3.12`), whose `pyvenv.cfg home=` then DANGLES on the host (no `/opt/python3.12` host-side), breaking host `uv`/`sac`. INCIDENT 2026-07-02: `~/proj/neurovista/.venv` broke host tooling exactly this way. The shared `~/proj/<agent>/.venv` stays reserved for the host's own python. Injection is UNCONDITIONAL — every agent's uv must default to the container-only venv.

## Test plan
- [x] `test_listen_env_flags_injects_uv_project_environment` — asserts `UV_PROJECT_ENVIRONMENT=/uvwork/venv-agent` in flags
- [x] `test_listen_env_flags_uv_project_environment_follows_an_env_token` — asserts it is preceded by a literal `--env`
- [x] Full file suite: 16 passed (2 new + 14 existing regression checks)