### PR TITLE
fix(mcp): .mcp.json merge — per-agent overrides shared baseline (deep-merge + warning)

### DIFF
--- a/src/scitex_agent_container/runtimes/_mcp_merge.py
+++ b/src/scitex_agent_container/runtimes/_mcp_merge.py
@@ -1,4 +1,4 @@
-"""Fail-loud deep-merge of two `.mcp.json` docs (W1 — operator 2026-06-17).
+"""Deep-merge of two `.mcp.json` docs with per-agent precedence.
 
 `runtimes/_to_home.deploy_to_home` is a two-pass overlay (shared baseline
 `_shared/to_home/` → per-agent `to_home/`). For most files the per-agent layer
@@ -6,40 +6,73 @@ full-overwrites the baseline. For `.mcp.json` that is WRONG: it would silently
 drop the baseline's default servers (sac / scitex-todo / claude-code-telegrammer)
 for any agent that ships its own `.mcp.json`.
 
-This module deep-merges the two `mcpServers` maps instead — every agent inherits
-the defaults AND keeps its own servers. A genuine conflict (same server name,
-two different definitions) **fails loud** via :class:`McpMergeConflict`; we never
-silently pick a winner (operator: fail-fast, fail-loud, no silent fallbacks).
+So we DEEP-MERGE the two `mcpServers` maps: disjoint names combine, and a
+same-name server is recursively merged with the **per-agent (overlay) value
+winning** on any leaf conflict (operator 2026-07-02: a per-agent override of a
+baseline server — e.g. claude-code-telegrammer with per-agent identity — is a
+legitimate, common need; a fail-loud exception was too strict). A genuine
+override is not fatal: it is LOGGED at WARNING (visible, not fail-loud), matching
+the rest of the to_home cascade ("higher layer wins on conflict").
 """
 
 from __future__ import annotations
 
+import logging
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 
 class McpMergeConflict(Exception):
-    """A server name is defined two different ways across baseline + agent."""
+    """Deprecated: retained for import compatibility only.
+
+    No longer raised — a same-name server override now deep-merges with the
+    per-agent (overlay) value winning, logging a WARNING instead of aborting.
+    """
+
+
+def _deep_merge(base: Any, overlay: Any, *, name: str, path: str) -> Any:
+    """Recursively merge ``overlay`` onto ``base``; overlay wins on leaf conflicts.
+
+    A differing leaf (overlay overrides a non-equal base value) is logged at
+    WARNING so a per-agent override of the shared baseline stays visible.
+    """
+    if isinstance(base, dict) and isinstance(overlay, dict):
+        out = dict(base)
+        for key, value in overlay.items():
+            if key in base:
+                child = f"{path}.{key}" if path else key
+                out[key] = _deep_merge(base[key], value, name=name, path=child)
+            else:
+                out[key] = value
+        return out
+    if base != overlay:
+        logger.warning(
+            "mcpServers['%s'].%s: per-agent overrides shared baseline (%r -> %r)",
+            name,
+            path or "(root)",
+            base,
+            overlay,
+        )
+    return overlay
 
 
 def merge_mcp_json(baseline: dict, overlay: dict) -> dict:
-    """Return ``baseline`` deep-merged with ``overlay``.
+    """Return ``baseline`` deep-merged with ``overlay`` (per-agent precedence).
 
-    * ``mcpServers`` — union by name. Disjoint names combine; an identical
-      same-name definition is kept once (idempotent); a CONFLICTING same-name
-      definition raises :class:`McpMergeConflict`.
+    * ``mcpServers`` — union by name; a same-name server is deep-merged with the
+      overlay (per-agent) winning on leaf conflicts. A differing leaf is
+      WARNING-logged, never fatal.
     * Other top-level keys — ``overlay`` wins where present, else ``baseline``
       is preserved.
     """
     merged: dict[str, Any] = dict(baseline)
     servers: dict[str, Any] = dict(baseline.get("mcpServers") or {})
     for name, defn in (overlay.get("mcpServers") or {}).items():
-        if name in servers and servers[name] != defn:
-            raise McpMergeConflict(
-                f"mcpServers['{name}'] is defined differently in the shared "
-                f"baseline and the per-agent .mcp.json — resolve it explicitly "
-                f"(baseline={servers[name]!r}, agent={defn!r})."
-            )
-        servers[name] = defn
+        if name in servers:
+            servers[name] = _deep_merge(servers[name], defn, name=name, path="")
+        else:
+            servers[name] = defn
     for key, value in overlay.items():
         if key != "mcpServers":
             merged[key] = value

--- a/tests/scitex_agent_container/runtimes/test__mcp_merge.py
+++ b/tests/scitex_agent_container/runtimes/test__mcp_merge.py
@@ -1,29 +1,24 @@
-"""Tests for the fail-loud `.mcp.json` deep-merge (W1 / operator 2026-06-17).
+"""Tests for the `.mcp.json` deep-merge with per-agent precedence.
 
 The shared baseline `_shared/to_home/.mcp.json` must DEEP-MERGE with each
 agent's own `.mcp.json` — union the `mcpServers` so every agent inherits the
 default servers (sac / scitex-todo / claude-code-telegrammer) AND keeps its
-own. Today the to_home deploy FULL-OVERWRITES `.mcp.json`, so a per-agent file
-would silently drop the baseline defaults — exactly the silent-fallback the
-operator forbids.
+own. A plain full-overwrite would silently drop the baseline defaults.
 
-Contract (fail-fast, fail-loud, no silent fallback):
+Contract (operator 2026-07-02 — per-agent precedence, warn-not-fatal):
   * disjoint server names  → union.
   * same name, IDENTICAL definition → kept once (idempotent).
-  * same name, DIFFERENT definition → raise `McpMergeConflict` (the operator
-    must resolve it explicitly; never silently pick a winner).
+  * same name, DIFFERENT definition → recursively DEEP-MERGE with the per-agent
+    (overlay) value winning on leaf conflicts; a genuine override is LOGGED at
+    WARNING (visible, not fatal).
 
-Conventions: one assert / AAA markers (a `pytest.raises` block IS the assert);
-no mocks — pure dict inputs.
+Conventions: one assert / AAA markers; no mocks — pure dict inputs (`caplog`
+is a real log capture, not a mock).
 """
 
 from __future__ import annotations
 
-import pytest
-from scitex_agent_container.runtimes._mcp_merge import (
-    McpMergeConflict,
-    merge_mcp_json,
-)
+from scitex_agent_container.runtimes._mcp_merge import merge_mcp_json
 
 
 def test_disjoint_servers_are_unioned():
@@ -47,14 +42,38 @@ def test_identical_same_name_server_is_kept_once():
     assert merged["mcpServers"]["sac"] == srv
 
 
-def test_conflicting_same_name_server_fails_loud():
-    # Arrange — same name, different command → must NOT silently pick one.
+def test_conflicting_same_name_server_per_agent_wins():
+    # Arrange — same name, different command → per-agent (overlay) wins.
     base = {"mcpServers": {"sac": {"command": "/opt/venv-sac/bin/sac"}}}
     overlay = {"mcpServers": {"sac": {"command": "/usr/bin/sac"}}}
     # Act
+    merged = merge_mcp_json(base, overlay)
     # Assert
-    with pytest.raises(McpMergeConflict):
+    assert merged["mcpServers"]["sac"]["command"] == "/usr/bin/sac"
+
+
+def test_same_name_server_env_deep_merges_per_agent_wins():
+    # Arrange — overlay overrides one env key; baseline's other env key survives.
+    base = {"mcpServers": {"cct": {"env": {"CCT_AGENT_ID": "sac", "KEEP": "yes"}}}}
+    overlay = {"mcpServers": {"cct": {"env": {"CCT_AGENT_ID": "neurovista"}}}}
+    # Act
+    merged = merge_mcp_json(base, overlay)
+    # Assert
+    assert merged["mcpServers"]["cct"]["env"] == {
+        "CCT_AGENT_ID": "neurovista",
+        "KEEP": "yes",
+    }
+
+
+def test_conflicting_same_name_server_logs_warning(caplog):
+    # Arrange — a genuine override should be visible (WARNING), not silent.
+    base = {"mcpServers": {"sac": {"command": "/opt/venv-sac/bin/sac"}}}
+    overlay = {"mcpServers": {"sac": {"command": "/usr/bin/sac"}}}
+    # Act
+    with caplog.at_level("WARNING"):
         merge_mcp_json(base, overlay)
+    # Assert
+    assert "per-agent overrides shared baseline" in caplog.text
 
 
 def test_overlay_only_servers_survive_when_baseline_empty():

--- a/tests/scitex_agent_container/runtimes/test__to_home.py
+++ b/tests/scitex_agent_container/runtimes/test__to_home.py
@@ -21,7 +21,6 @@ from pathlib import Path
 import pytest
 
 from scitex_agent_container.config._types import AgentConfig
-from scitex_agent_container.runtimes._mcp_merge import McpMergeConflict
 from scitex_agent_container.runtimes._to_home import (
     END_MARKER,
     DanglingToHomeSymlinkError,
@@ -726,7 +725,7 @@ def test_mcp_json_two_pass_unions_baseline_and_agent_servers(tmp_path):
     assert set(merged["mcpServers"]) == {"sac", "todo", "figrecipe"}
 
 
-def test_mcp_json_conflicting_server_across_layers_fails_loud(tmp_path):
+def test_mcp_json_conflicting_server_across_layers_per_agent_wins(tmp_path):
     # Arrange — same server name, different command in baseline vs agent.
     spec_dir, per_agent, baseline = _build_layered(tmp_path)
     (baseline / ".mcp.json").write_text(
@@ -738,9 +737,10 @@ def test_mcp_json_conflicting_server_across_layers_fails_loud(tmp_path):
     home = tmp_path / "home"
     home.mkdir()
     # Act
+    materialize_to_home(spec_dir, home)
+    merged = json.loads((home / ".mcp.json").read_text())
     # Assert
-    with pytest.raises(McpMergeConflict):
-        materialize_to_home(spec_dir, home)
+    assert merged["mcpServers"]["sac"]["command"] == "B"
 
 
 def test_mcp_json_invalid_agent_json_fails_loud(tmp_path):


### PR DESCRIPTION
## Summary
`merge_mcp_json` fail-loud-raised `McpMergeConflict` when a same-name `mcpServer` was defined differently in the shared baseline vs a per-agent `.mcp.json`. That blocked a **legitimate** need — a per-agent override of a baseline server (e.g. `claude-code-telegrammer` with per-agent identity) — and it's inconsistent with the rest of the to_home cascade ("higher layer wins on conflict").

Operator decision (2026-07-02):
- **Per-agent wins**, via recursive **deep-merge** (overlay leaf keys override baseline; baseline-only keys preserved — so an override of just `env.CCT_AGENT_ID` keeps the baseline `command`/`args`).
- A genuine override is a **WARNING** (visible), not a fatal exception.
- `McpMergeConflict` kept for import compatibility, no longer raised.

## Test plan
- [x] `test__mcp_merge.py` — deep-merge + per-agent-wins + env-deep-merge + `caplog` warning assertion (8 tests, no mocks).
- [x] `test__to_home.py` — flipped the deploy-level `fails_loud` test to `per_agent_wins`; dropped the unused `McpMergeConflict` import. Full `_to_home` + `_mcp_merge` suites green.

## Context
Part of the 2026-07-02 telegrammer/identity cluster: card `sac-mcp-merge-per-agent-deepmerge-warning-20260702`. Complements `sac-mcp-json-per-agent-identity-not-ambient-env-20260702` (baseline shouldn't be contaminated in the first place).