### PR TITLE
fix(runtimes): never bake per-agent identity vars in interpolate_env

### DIFF
--- a/src/scitex_agent_container/runtimes/_to_home_text.py
+++ b/src/scitex_agent_container/runtimes/_to_home_text.py
@@ -20,6 +20,44 @@ from ._to_home_errors import WorkspaceCLAUDEMarkerError
 END_MARKER = "<!-- End of scitex-agent-container generated section -->"
 START_MARKER_PREFIX = "<!-- Start of scitex-agent-container generated section"
 
+# Per-agent IDENTITY vars that must NEVER be baked at deploy time.
+#
+# WHY (INCIDENT 2026-07-02, card
+# sac-mcp-json-per-agent-identity-not-ambient-env-...): ``interpolate_env``
+# runs host-side inside the ``sac agents start`` process, so it substitutes
+# ``${VAR}`` from the LAUNCHING SHELL's ``os.environ``. Running
+# ``sac agents start neurovista`` from the sac repo dir (whose ``.envrc``
+# exports ``CCT_AGENT_ID=scitex-agent-container`` + that bot's token) baked
+# ``CCT_AGENT_ID=scitex-agent-container`` and the wrong bot token into
+# neurovista's materialized ``.mcp.json`` — neurovista's telegrammer then
+# attached with the wrong identity.
+#
+# Per-agent identity must ALWAYS come from the agent's OWN runtime env (its
+# ``.envrc`` via direnv, working since the ``DIRENV_CONFIG`` fix), never from
+# whatever directory ``sac agents start`` was typed in. So we leave these
+# refs as literal ``${VAR}`` placeholders for RUNTIME expansion, and we keep
+# secrets (bot tokens) out of materialized files on disk. The ``CCT_`` prefix
+# rule below covers ``CCT_AGENT_ID`` / ``CCT_BOT_TOKEN`` /
+# ``CCT_ALLOWED_USERS`` / ``CCT_STATE_DIR`` and any future ``CCT_*`` var.
+_RUNTIME_ONLY_VARS = frozenset(
+    {
+        "SCITEX_TODO_AGENT",
+        "SCITEX_TODO_TASKS",
+        "SAC_NAME",
+        "CLAUDE_AGENT_ID",
+        "CLAUDE_AGENT_ROLE",
+    }
+)
+
+
+def _is_runtime_only_var(name: str) -> bool:
+    """True when ``name`` is per-agent identity → keep as ``${VAR}`` literal.
+
+    Any ``CCT_*`` var is runtime-only (identity + telegram secrets), plus the
+    explicit members of :data:`_RUNTIME_ONLY_VARS`.
+    """
+    return name.startswith("CCT_") or name in _RUNTIME_ONLY_VARS
+
 
 def validate_marker_invariants(text: str, source_name: str) -> None:
     """Hard-fail if Start/End markers are missing or malformed."""
@@ -90,12 +128,22 @@ def interpolate_env(text: str) -> str:
     """Substitute ``${VAR}`` with ``os.environ[VAR]``, leaving unknown
     refs untouched (so an unset env var becomes a visible artefact
     rather than silently collapsing to empty string).
+
+    Per-agent IDENTITY vars (see :data:`_RUNTIME_ONLY_VARS` and the
+    ``CCT_`` prefix rule) are NEVER substituted here — they stay as literal
+    ``${VAR}`` for RUNTIME expansion from the agent's own env, regardless of
+    whether they happen to be present in the deployer's ``os.environ``. This
+    is the fix for the 2026-07-02 wrong-identity incident (see the module
+    header on ``_RUNTIME_ONLY_VARS``).
     """
-    return re.sub(
-        r"\$\{(\w+)\}",
-        lambda m: os.environ.get(m.group(1), m.group(0)),
-        text,
-    )
+
+    def _replace(m: re.Match) -> str:
+        name = m.group(1)
+        if _is_runtime_only_var(name):
+            return m.group(0)  # keep ${VAR} literal for runtime expansion
+        return os.environ.get(name, m.group(0))
+
+    return re.sub(r"\$\{(\w+)\}", _replace, text)
 
 
 def interpolate_metadata(text: str, config: AgentConfig) -> str:

--- a/tests/scitex_agent_container/runtimes/test__to_home_text.py
+++ b/tests/scitex_agent_container/runtimes/test__to_home_text.py
@@ -1,0 +1,66 @@
+"""Tests for the to_home/ text interpolators.
+
+Focus: ``interpolate_env`` must NEVER bake per-agent IDENTITY vars at
+deploy time — they stay as literal ``${VAR}`` placeholders for RUNTIME
+expansion from the agent's own env (INCIDENT 2026-07-02, card
+sac-mcp-json-per-agent-identity-not-ambient-env). Non-identity vars are
+still substituted from ``os.environ`` (regression guard against
+over-denylisting).
+
+STX-NM002: no mocks/monkeypatch — env mutated via the ``env_save_restore``
+fixture (auto-reverts on teardown).
+STX-TQ002 / TQ007: AAA markers per test, one fact per test.
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container.runtimes._to_home_text import interpolate_env
+
+
+# interpolate_env — per-agent identity stays literal
+def test_interpolate_env_keeps_cct_agent_id_literal_even_when_set(env_save_restore):
+    # Arrange
+    env_save_restore.set("CCT_AGENT_ID", "scitex-agent-container")
+    # Act
+    out = interpolate_env("id=${CCT_AGENT_ID}")
+    # Assert
+    assert out == "id=${CCT_AGENT_ID}"
+
+
+def test_interpolate_env_keeps_scitex_todo_agent_literal_even_when_set(
+    env_save_restore,
+):
+    # Arrange
+    env_save_restore.set("SCITEX_TODO_AGENT", "agent:scitex-agent-container")
+    # Act
+    out = interpolate_env("agent=${SCITEX_TODO_AGENT}")
+    # Assert
+    assert out == "agent=${SCITEX_TODO_AGENT}"
+
+
+def test_interpolate_env_keeps_cct_bot_token_literal_even_when_set(env_save_restore):
+    # Arrange
+    env_save_restore.set("CCT_BOT_TOKEN", "123:wrong-token")
+    # Act
+    out = interpolate_env("token=${CCT_BOT_TOKEN}")
+    # Assert
+    assert out == "token=${CCT_BOT_TOKEN}"
+
+
+# interpolate_env — non-identity vars still substitute (regression)
+def test_interpolate_env_substitutes_non_identity_var(env_save_restore):
+    # Arrange
+    env_save_restore.set("SAC_TEST_NON_IDENTITY_VAR", "expanded-value")
+    # Act
+    out = interpolate_env("v=${SAC_TEST_NON_IDENTITY_VAR}")
+    # Assert
+    assert out == "v=expanded-value"
+
+
+def test_interpolate_env_leaves_unset_non_identity_var_literal(env_save_restore):
+    # Arrange
+    env_save_restore.delete("SAC_TEST_DEFINITELY_UNSET_VAR")
+    # Act
+    out = interpolate_env("v=${SAC_TEST_DEFINITELY_UNSET_VAR}")
+    # Assert
+    assert out == "v=${SAC_TEST_DEFINITELY_UNSET_VAR}"


### PR DESCRIPTION
## Summary
- `interpolate_env` runs host-side inside the `sac agents start` process, so it substituted `${VAR}` from the **launching shell's** `os.environ`. Running `sac agents start neurovista` from the sac repo dir (whose `.envrc` exports `CCT_AGENT_ID` + that bot's token) baked the wrong identity/token into neurovista's materialized `.mcp.json` (INCIDENT 2026-07-02, card `sac-mcp-json-per-agent-identity-not-ambient-env`). neurovista's telegrammer then attached with the wrong identity.
- Fix (option B): `interpolate_env` now NEVER substitutes per-agent IDENTITY vars — they stay as literal `${VAR}` placeholders for RUNTIME expansion from the agent's own env (its `.envrc` via direnv). Denylist: `_RUNTIME_ONLY_VARS` = {`SCITEX_TODO_AGENT`, `SCITEX_TODO_TASKS`, `SAC_NAME`, `CLAUDE_AGENT_ID`, `CLAUDE_AGENT_ROLE`} plus any `CCT_*` var (covers `CCT_AGENT_ID`/`CCT_BOT_TOKEN`/`CCT_ALLOWED_USERS`/`CCT_STATE_DIR`).
- Also keeps telegram bot tokens out of materialized files on disk.
- `interpolate_metadata` is untouched (uses `config`, not `os.environ`).

## Test plan
- [x] New `tests/scitex_agent_container/runtimes/test__to_home_text.py` (5 tests, no monkeypatch — uses the shared `env_save_restore` fixture): identity vars stay literal even when set; non-identity var still substitutes; unset non-identity var stays literal. All pass.
- [x] Existing `test__to_home.py` + `test__to_home_deployers.py` — 80 passed, no regressions.