### PR TITLE
fix(lifecycle): correct sac agents list liveness + SDK-agent heartbeat loop

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_listen_lifespan.py
+++ b/src/scitex_agent_container/_lifecycle/_listen_lifespan.py
@@ -54,6 +54,10 @@ def build_listen_lifespan(*, health_watchdog_port: int | None = None):
         github_ci_poll_loop,
     )
     from ._periodic_drive_loop import periodic_drive_loop
+    from ._sdk_heartbeat_loop import (
+        DEFAULT_SDK_HEARTBEAT_INTERVAL_S,
+        sdk_heartbeat_loop,
+    )
     from ._tui_heartbeat_loop import (
         DEFAULT_TUI_HEARTBEAT_INTERVAL_S,
         tui_heartbeat_loop,
@@ -131,6 +135,26 @@ def build_listen_lifespan(*, health_watchdog_port: int | None = None):
         tui_hb_task = asyncio.create_task(tui_heartbeat_loop(interval_s=_tui_hb_interval))
         app.state.tui_heartbeat_task = tui_hb_task
         tasks.append(tui_hb_task)
+
+        # SDK/claude-session heartbeat writer (fix
+        # liveness-live-agents-read-stopped): parity with the TUI writer
+        # for the non-TUI runtimes, so a running-but-quiet SDK agent's
+        # host-side ``heartbeat_at`` stays fresh instead of freezing at
+        # its start time. Self-disables via SAC_SDK_HEARTBEAT_DISABLED=1.
+        # Cadence override: SAC_SDK_HEARTBEAT_INTERVAL_S.
+        try:
+            _sdk_hb_interval = float(
+                os.environ.get(
+                    "SAC_SDK_HEARTBEAT_INTERVAL_S", DEFAULT_SDK_HEARTBEAT_INTERVAL_S
+                )
+            )
+        except (TypeError, ValueError):
+            _sdk_hb_interval = DEFAULT_SDK_HEARTBEAT_INTERVAL_S
+        sdk_hb_task = asyncio.create_task(
+            sdk_heartbeat_loop(interval_s=_sdk_hb_interval)
+        )
+        app.state.sdk_heartbeat_task = sdk_hb_task
+        tasks.append(sdk_hb_task)
 
         # Liveness-tick reconciler (card sac-card-anchored-stop-reconciler):
         # deterministic alarm-engine producer — reads cards (truth) vs.

--- a/src/scitex_agent_container/_lifecycle/_sdk_heartbeat_loop.py
+++ b/src/scitex_agent_container/_lifecycle/_sdk_heartbeat_loop.py
@@ -1,0 +1,232 @@
+"""SDK / claude-session heartbeat writer — liveness parity for the
+non-TUI runtimes.
+
+The TUI runtime has a centralized ``tui_heartbeat_loop`` that keeps a
+quiet-but-live ``runtime: tui`` agent's ``heartbeat.json`` fresh (so it
+reads "running" and shows a moving ``heartbeat_at``). The headless
+``runtime: claude-agent-sdk`` runner writes its OWN heartbeat from
+INSIDE the container — but only while its conversation loop is actively
+ticking; if that in-container loop is not observable from the host (a
+detached / reparented runner, or a beat that lands on the container's
+own tmpfs rather than the host ``/state`` bind), the host-side
+``heartbeat_at`` freezes at the last start time even though the agent is
+provably alive.
+
+This module closes that gap the SAME way ``tui_heartbeat_loop`` does for
+TUI agents: a CENTRALIZED async loop in the listen server that, every
+tick,
+
+  1. lists agents whose resolved ``spec.runtime`` selects a non-TUI
+     (SDK / claude-session) runtime;
+  2. for each one whose DECLARED runtime reports ``is_running`` True
+     (the same probe ``sac agents status`` / ``sac agents list`` use —
+     :func:`_lifecycle._runtime_select._get_runtime`);
+  3. writes a FRESH ``heartbeat.json`` beat via the existing
+     :func:`_session_state.write_heartbeat`, stamping ``ts`` with the
+     current wall clock (a live agent's host-side liveness signal), so
+     ``heartbeat_at`` moves for a running SDK agent that isn't itself
+     landing host-visible beats.
+
+Sibling of :func:`_tui_heartbeat_loop.tui_heartbeat_loop`: same
+create-task → tick → honour-cancellation contract, same per-agent /
+per-tick best-effort resilience, same injection seams so tests drive the
+loop deterministically without a real runtime / registry / state-dir IO.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from pathlib import Path
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+# Default cadence. The SDK ``health.interval`` default is 300s; beating
+# every ~30s keeps ``heartbeat_at`` comfortably fresh inside that window.
+# Override via ``SAC_SDK_HEARTBEAT_INTERVAL_S`` at the wiring site.
+DEFAULT_SDK_HEARTBEAT_INTERVAL_S = 30.0
+
+# Runtimes handled by the TUI loop, NOT here (avoid double-beating a TUI
+# agent — the TUI loop stamps the pane-activity epoch, this loop would
+# clobber it with wall clock).
+_TUI_RUNTIMES = frozenset({"", "tui"})
+
+# State written for a live SDK agent. ``running`` mirrors the
+# observability vocabulary the TUI/SDK heartbeat use; the read side
+# (``_session_movement.heartbeat_iso``) only consumes ``ts``.
+_SDK_HEARTBEAT_STATE = "running"
+
+
+def list_sdk_agents() -> list[dict]:
+    """Production default for the ``agent_lister`` seam.
+
+    Returns one record per agent whose resolved ``spec.runtime`` selects
+    a NON-TUI runtime (``claude-agent-sdk`` and the back-compat
+    ``apptainer`` alias), each carrying:
+
+      * ``name``      — the agent / spec directory name.
+      * ``config``    — the loaded :class:`AgentConfig` (the liveness
+        probe needs it to select the declared runtime).
+      * ``state_dir`` — the resolved on-disk state dir (``Path``), or
+        ``None`` when neither the project-scope nor home-scope candidate
+        exists yet. The loop skips ``None`` (nothing to write into).
+
+    Sources mirror :func:`_tui_heartbeat_loop.list_tui_agents`: the
+    runtime Registry first, then specs defined on disk that are not
+    registered. A spec that fails to load contributes nothing
+    (best-effort). De-duped by name (registry wins).
+    """
+    from ..config import load_config
+    from ._session_movement import resolve_state_dir
+
+    out: list[dict] = []
+    seen: set[str] = set()
+
+    def _consider(name: str, config_path: str | None) -> None:
+        if not name or name in seen:
+            return
+        if not config_path:
+            return
+        try:
+            cfg = load_config(config_path)
+        except Exception:  # stx-allow: fallback (one bad spec contributes nothing — best-effort enumeration)
+            return
+        runtime = getattr(cfg, "runtime", None) or ""
+        if runtime in _TUI_RUNTIMES:
+            return  # TUI agents are handled by tui_heartbeat_loop
+        seen.add(name)
+        state_dir = resolve_state_dir(name)
+        out.append({"name": name, "config": cfg, "state_dir": state_dir})
+
+    try:
+        from .._state.registry import Registry
+
+        for row in Registry().list_all():
+            if not isinstance(row, dict):
+                continue
+            _consider(row.get("name", ""), row.get("config"))
+    except Exception as exc:  # stx-allow: fallback (registry read failure must not blank the on-disk specs below)
+        logger.debug("list_sdk_agents: registry enumeration failed: %s", exc)
+
+    try:
+        from ..cli_pkg._helpers._agent_list import _discover_defined_agents
+
+        for name, spec_path in _discover_defined_agents():
+            _consider(name, str(spec_path))
+    except Exception as exc:  # stx-allow: fallback (on-disk discovery is additive; registry rows already captured)
+        logger.debug("list_sdk_agents: on-disk spec discovery failed: %s", exc)
+
+    return out
+
+
+def _beat_one(
+    agent: dict,
+    *,
+    is_running_fn: Callable[[Any], bool | None],
+    write_fn: Callable[..., None],
+    now_fn: Callable[[], float] = time.time,
+) -> bool:
+    """Write one SDK agent's heartbeat if its declared runtime reports it
+    running. Best-effort — never raises.
+
+    Returns ``True`` iff a heartbeat was written (runtime reported the
+    agent alive AND a state dir exists), ``False`` otherwise. A per-agent
+    failure is logged at debug and swallowed so one bad agent cannot
+    abort the tick.
+    """
+    name = agent.get("name", "")
+    config = agent.get("config")
+    state_dir = agent.get("state_dir")
+    if not name or config is None or state_dir is None:
+        return False
+    try:
+        if not is_running_fn(config):
+            return False
+        write_fn(
+            Path(state_dir),
+            pid=0,
+            state=_SDK_HEARTBEAT_STATE,
+            ts=float(now_fn()),
+        )
+        return True
+    except Exception as exc:  # stx-allow: fallback (per-agent best-effort: one failure must not abort the tick — logged, skipped)
+        logger.debug("sdk_heartbeat: beat for %r failed (skipped): %s", name, exc)
+        return False
+
+
+def _default_is_running(config: Any) -> bool | None:
+    """Production default for the ``is_running_fn`` seam: probe the
+    agent's DECLARED runtime (the same selection ``sac agents status`` /
+    ``sac agents list`` use) so a running SDK agent is recognised
+    identically across all three surfaces.
+    """
+    from ._runtime_select import _get_runtime
+
+    return _get_runtime(config).is_running(config)
+
+
+async def sdk_heartbeat_loop(
+    *,
+    interval_s: float = DEFAULT_SDK_HEARTBEAT_INTERVAL_S,
+    agent_lister: Any = None,
+    is_running_fn: Any = None,
+    write_fn: Any = None,
+) -> None:
+    """Long-running SDK/claude-session heartbeat-writer task for the
+    listen lifespan.
+
+    Seams (production defaults bound when ``None``): ``agent_lister`` →
+    :func:`list_sdk_agents`; ``is_running_fn`` → :func:`_default_is_running`
+    (declared-runtime probe); ``write_fn`` →
+    :func:`_runners._session_state.write_heartbeat`.
+    """
+    if os.environ.get("SAC_SDK_HEARTBEAT_DISABLED", "") == "1":
+        logger.info("sdk_heartbeat_loop: disabled via SAC_SDK_HEARTBEAT_DISABLED")
+        return
+
+    # ROOT-CAUSE GUARD (mirrors tui_heartbeat_loop): the per-tick body
+    # walks the registry + on-disk specs and probes each agent's runtime
+    # (tmux / kill / FS reads). On the event loop a hung probe would
+    # starve uvicorn's bind, so run the whole tick off the loop with a
+    # hard timeout.
+    from ._off_loop import run_blocking_or
+
+    lister = agent_lister if agent_lister is not None else list_sdk_agents
+    probe = is_running_fn if is_running_fn is not None else _default_is_running
+    if write_fn is None:
+        from .._runners._session_state import write_heartbeat as write_fn
+
+    def _tick_body() -> None:
+        for agent in list(lister()):
+            _beat_one(agent, is_running_fn=probe, write_fn=write_fn)
+
+    logger.info("sdk_heartbeat_loop: starting (interval_s=%.1f)", interval_s)
+    try:
+        while True:
+            try:
+                await run_blocking_or(
+                    _tick_body,
+                    default=None,
+                    op="sdk_heartbeat_loop tick (runtime probes)",
+                    timeout_s=max(interval_s, 15.0),
+                )
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:  # stx-allow: fallback (loop must survive a transient registry/runtime/FS error; logged, retried next tick)
+                logger.warning(
+                    "sdk_heartbeat_loop: tick failed (%s); retry next tick", exc
+                )
+            await asyncio.sleep(interval_s)
+    except asyncio.CancelledError:
+        logger.info("sdk_heartbeat_loop: cancelled cleanly")
+        raise
+
+
+__all__ = [
+    "DEFAULT_SDK_HEARTBEAT_INTERVAL_S",
+    "list_sdk_agents",
+    "sdk_heartbeat_loop",
+]

--- a/src/scitex_agent_container/cli_pkg/_helpers/_agent_list.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers/_agent_list.py
@@ -1,15 +1,17 @@
-"""Agent-list assembly + presentation (JSON + rich-table)."""
+"""Agent-list DATA ASSEMBLY (probes, labels, movement, discovery).
+
+The READER-facing presentation (JSON dump + rich-table) lives in the
+sibling :mod:`_agent_list_render` (split for the 512-line per-file cap);
+its public names — ``print_agent_list`` / ``print_agent_list_json`` /
+``_is_ghost_row`` / ``_extract_damaged_fields`` — are re-exported at the
+bottom of this module so existing ``from ._agent_list import ...``
+importers are unchanged.
+"""
 
 from __future__ import annotations
 
-import json as json_mod
-
-import click
-from rich.table import Table
-
 from ..._state.registry import Registry
 from ...config import load_config
-from ._console import console
 
 
 def _safe_port_for(name: str) -> int | None:
@@ -91,25 +93,34 @@ def _movement_fields(name: str) -> dict:
 
 
 def _probe_local(cfg) -> bool | None:
-    """Probe an agent's liveness via ContainerRuntime.
+    """Probe an agent's liveness via its DECLARED runtime adapter.
 
-    F-CS17 stage 3b: replaces the legacy ``_probe_remote`` /
-    ``_detect_multiplexer`` machinery. Sac is a container wrapper —
-    liveness is whatever ``docker inspect`` reports for the
-    container_id sidecar in the agent's state dir. Cross-host
-    liveness moved to F-CS12's ``sac --on <peer> agent status``
-    pattern; the local helper here NEVER does its own ssh.
+    Must select the SAME runtime ``agent_status`` uses
+    (:func:`_lifecycle._runtime_select._get_runtime`, which branches on
+    ``spec.runtime``) — NOT a hardcoded ``ClaudeSessionRuntime``. That
+    hardcode was the root cause of "live agent reads stopped" (fix
+    ``liveness-live-agents-read-stopped``): the DEFAULT runtime is
+    ``tui``, whose liveness is the ``tui-<name>`` tmux session's
+    pane-activity (``TuiSessionRuntime.is_running``). Probing a live TUI
+    agent through ``ClaudeSessionRuntime`` instead reached
+    ``ApptainerContainerRuntime.is_running`` → ``os.kill(read_pid, 0)``,
+    but a TUI agent NEVER writes an ``apptainer_pid`` file (it launches
+    via tmux, not ``subprocess.Popen`` with a pidfile), so ``_read_pid``
+    returned ``None`` → ``is_running`` returned ``False`` → status
+    "stopped" for a provably-running agent. Routing through
+    ``_get_runtime`` makes ``sac agents list`` agree with
+    ``sac agents status``.
 
     Returns None on exception (e.g. malformed config) so the caller
     surfaces ``status='unknown'`` rather than crashing the list.
     """
-    # stx-allow: fallback (reason: container engine may be missing or
-    # state-dir may not exist for an agent that never ran; either case
-    # maps to liveness_unknown rather than a hard error.)
+    # stx-allow: fallback (reason: runtime may be missing or state-dir may
+    # not exist for an agent that never ran; either case maps to
+    # liveness_unknown rather than a hard error.)
     try:
-        from ...runtimes.claude_session import ClaudeSessionRuntime
+        from ..._lifecycle._runtime_select import _get_runtime
 
-        return ClaudeSessionRuntime().is_running(cfg)
+        return _get_runtime(cfg).is_running(cfg)
     except Exception:  # stx-allow: fallback (reason: catch-all safety net — see inline comment for context)
         return None
 
@@ -417,156 +428,13 @@ def _discover_defined_agents() -> "list[tuple[str, Path]]":  # noqa: F821
     return pairs
 
 
-def print_agent_list_json(
-    registry: Registry,
-    capability: str | None = None,
-    machine: str | None = None,
-) -> None:
-    """Print agent list as JSON."""
-    data = get_agent_list_data(registry, capability=capability, machine=machine)
-    click.echo(json_mod.dumps(data, indent=2))
+# Presentation layer lives in the sibling ``_agent_list_render`` module
+# (512-line cap split). Re-exported here so ``from ._agent_list import
+# print_agent_list`` and the ``_helpers/__init__`` lazy map keep resolving.
+from ._agent_list_render import (  # noqa: E402,F401
+    _extract_damaged_fields,
+    _is_ghost_row,
+    print_agent_list,
+    print_agent_list_json,
+)
 
-
-def _is_ghost_row(row: dict) -> bool:
-    """True for a dead registry entry: a LOCAL agent whose spec file is gone.
-
-    Operator 2026-06-17: ``sac agents list`` should show only active agents
-    by default. Stale ``instances`` rows (e.g. left by a pytest run whose
-    tmp spec dir was cleaned) surface as ``status="unknown"`` with a
-    ``"File not found"`` validation error — pure noise. They are hidden by
-    default and revealed with ``--all``.
-
-    Safety: only a LOCAL spec-missing row is a ghost. A REMOTE agent's spec
-    lives on its own host (a local "File not found" says nothing about it),
-    and a remote liveness-probe timeout also reports ``status="unknown"`` —
-    neither must be hidden, or the fleet view would erase live peers. An
-    on-disk spec that merely fails SCHEMA validation (``status="invalid"``)
-    also stays visible so the operator can see and fix it.
-    """
-    host = row.get("host") or "local"
-    if host not in ("local", ""):
-        return False
-    errors = row.get("validation_errors") or []
-    return any("File not found" in str(e) for e in errors)
-
-
-def print_agent_list(
-    registry: Registry,
-    capability: str | None = None,
-    machine: str | None = None,
-    *,
-    verbose: bool = False,
-    show_all: bool = False,
-) -> None:
-    """Print a rich table of all registered agents.
-
-    By default shows only active agents (dead spec-missing registry ghosts
-    are hidden — see :func:`_is_ghost_row`) and omits the full spec ``Path``
-    column (it folds every row to 10+ lines). ``show_all=True`` includes the
-    ghosts; ``verbose=True`` adds the ``Path`` column back.
-    """
-    data = get_agent_list_data(registry, capability=capability, machine=machine)
-    if not data:
-        console.print("[dim]No agents found (registry empty, no specs on disk).[/dim]")
-        return
-
-    hidden = 0
-    if not show_all:
-        kept = [r for r in data if not _is_ghost_row(r)]
-        hidden = len(data) - len(kept)
-        data = kept
-    if not data:
-        console.print(
-            "[dim]No active agents (all hidden as stale; --all to show).[/dim]"
-        )
-        return
-
-    table = Table(title="Agents")
-    # ``no_wrap`` keeps the agent name (the primary identifier) intact:
-    # rich shrinks the fold-able Account/Path columns instead of
-    # ellipsising the name when the terminal is narrow.
-    table.add_column("Name", style="bold", no_wrap=True)
-    table.add_column("Status")
-    table.add_column("YAML")
-    table.add_column("Host")
-    # Account labels (e.g. ``<name> (<email>)``) can be long; fold within
-    # the cell rather than stealing width from the name column.
-    # Account folds the long ``<name> (<email>)`` label to ~5 lines; show the
-    # short account name only by default (no_wrap), full label in --verbose.
-    if verbose:
-        table.add_column("Account", overflow="fold")
-    else:
-        table.add_column("Account", no_wrap=True, overflow="ellipsis")
-    # ``Path`` (full spec.yaml path) folds every row to 10+ lines, so it is
-    # verbose-only (operator 2026-06-17).
-    if verbose:
-        table.add_column("Path", overflow="fold")
-    table.add_column("Started")
-    cmap = {
-        "running": "green",
-        "stopped": "red",
-        "defined": "yellow",
-        "invalid": "bold red",
-        "unknown": "dim",
-    }
-    for row in data:
-        col = cmap.get(row["status"], "white")
-        host = row.get("host") or "local"
-        host_cell = host if host in ("local", "") else f"[cyan]{host}[/cyan]"
-        errors = row.get("validation_errors") or []
-        yaml_cell = (
-            f"[bold red]✗ {', '.join(_extract_damaged_fields(errors)) or 'errors'}[/bold red]"
-            if errors
-            else "[green]✓[/green]"
-        )
-        started = row["started_at"] if row["started_at"] not in ("-", "?") else "—"
-        account_cell = row.get("account") or "—"
-        # Drop the ``(email)`` parenthetical in the default (compact) view so
-        # the row stays one line; --verbose keeps the full ``name (email)``.
-        if not verbose and " (" in account_cell:
-            account_cell = account_cell.split(" (", 1)[0]
-        cells = [
-            row["name"],
-            f"[{col}]{row['status']}[/{col}]",
-            yaml_cell,
-            host_cell,
-            account_cell,
-        ]
-        if verbose:
-            cells.append(row.get("path") or "—")
-        cells.append(started)
-        table.add_row(*cells)
-
-    console.print(table)
-    if hidden:
-        console.print(
-            f"[dim]({hidden} stale/ghost agent(s) hidden — --all to show, "
-            "-v for paths)[/dim]"
-        )
-    # Full error text follows the table so the operator can copy-paste.
-    for row in data:
-        if row.get("validation_errors"):
-            console.print(f"[bold red]✗ {row['name']}[/bold red] validation errors:")
-            for err in row["validation_errors"]:
-                console.print(f"    [red]- {err}[/red]")
-
-
-def _extract_damaged_fields(errors: list[str]) -> list[str]:
-    """Pull `spec.<field>` / top-level field names out of validator
-    error strings so the YAML column can show *which* keys are broken
-    without dumping the full error message into a narrow cell.
-    """
-    import re as _re
-
-    fields: list[str] = []
-    seen: set[str] = set()
-    pat = _re.compile(r"(spec\.[a-zA-Z_][a-zA-Z_0-9.]*|metadata\.[a-zA-Z_]+)")
-    for err in errors:
-        for m in pat.findall(err):
-            if m not in seen:
-                seen.add(m)
-                fields.append(m)
-    # Cap the column width.
-    if len(fields) > 4:
-        fields = fields[:3] + [f"+{len(fields) - 3} more"]
-    return fields

--- a/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_render.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers/_agent_list_render.py
@@ -1,0 +1,184 @@
+"""Agent-list presentation (JSON + rich-table).
+
+Extracted from ``_agent_list.py`` (which had grown past the 512-line
+per-file cap) so the DATA-ASSEMBLY layer (``get_agent_list_data`` and its
+probe/label helpers) stays in ``_agent_list.py`` while the READER-facing
+rendering lives here. ``_agent_list`` re-exports these names so existing
+``from ._agent_list import print_agent_list`` importers are unchanged.
+"""
+
+from __future__ import annotations
+
+import json as json_mod
+
+import click
+from rich.table import Table
+
+from ..._state.registry import Registry
+from ._console import console
+
+__all__ = [
+    "print_agent_list_json",
+    "print_agent_list",
+    "_is_ghost_row",
+    "_extract_damaged_fields",
+]
+
+
+def print_agent_list_json(
+    registry: Registry,
+    capability: str | None = None,
+    machine: str | None = None,
+) -> None:
+    """Print agent list as JSON."""
+    from ._agent_list import get_agent_list_data
+
+    data = get_agent_list_data(registry, capability=capability, machine=machine)
+    click.echo(json_mod.dumps(data, indent=2))
+
+
+def _is_ghost_row(row: dict) -> bool:
+    """True for a dead registry entry: a LOCAL agent whose spec file is gone.
+
+    Operator 2026-06-17: ``sac agents list`` should show only active agents
+    by default. Stale ``instances`` rows (e.g. left by a pytest run whose
+    tmp spec dir was cleaned) surface as ``status="unknown"`` with a
+    ``"File not found"`` validation error — pure noise. They are hidden by
+    default and revealed with ``--all``.
+
+    Safety: only a LOCAL spec-missing row is a ghost. A REMOTE agent's spec
+    lives on its own host (a local "File not found" says nothing about it),
+    and a remote liveness-probe timeout also reports ``status="unknown"`` —
+    neither must be hidden, or the fleet view would erase live peers. An
+    on-disk spec that merely fails SCHEMA validation (``status="invalid"``)
+    also stays visible so the operator can see and fix it.
+    """
+    host = row.get("host") or "local"
+    if host not in ("local", ""):
+        return False
+    errors = row.get("validation_errors") or []
+    return any("File not found" in str(e) for e in errors)
+
+
+def print_agent_list(
+    registry: Registry,
+    capability: str | None = None,
+    machine: str | None = None,
+    *,
+    verbose: bool = False,
+    show_all: bool = False,
+) -> None:
+    """Print a rich table of all registered agents.
+
+    By default shows only active agents (dead spec-missing registry ghosts
+    are hidden — see :func:`_is_ghost_row`) and omits the full spec ``Path``
+    column (it folds every row to 10+ lines). ``show_all=True`` includes the
+    ghosts; ``verbose=True`` adds the ``Path`` column back.
+    """
+    from ._agent_list import get_agent_list_data
+
+    data = get_agent_list_data(registry, capability=capability, machine=machine)
+    if not data:
+        console.print("[dim]No agents found (registry empty, no specs on disk).[/dim]")
+        return
+
+    hidden = 0
+    if not show_all:
+        kept = [r for r in data if not _is_ghost_row(r)]
+        hidden = len(data) - len(kept)
+        data = kept
+    if not data:
+        console.print(
+            "[dim]No active agents (all hidden as stale; --all to show).[/dim]"
+        )
+        return
+
+    table = Table(title="Agents")
+    # ``no_wrap`` keeps the agent name (the primary identifier) intact:
+    # rich shrinks the fold-able Account/Path columns instead of
+    # ellipsising the name when the terminal is narrow.
+    table.add_column("Name", style="bold", no_wrap=True)
+    table.add_column("Status")
+    table.add_column("YAML")
+    table.add_column("Host")
+    # Account labels (e.g. ``<name> (<email>)``) can be long; fold within
+    # the cell rather than stealing width from the name column.
+    # Account folds the long ``<name> (<email>)`` label to ~5 lines; show the
+    # short account name only by default (no_wrap), full label in --verbose.
+    if verbose:
+        table.add_column("Account", overflow="fold")
+    else:
+        table.add_column("Account", no_wrap=True, overflow="ellipsis")
+    # ``Path`` (full spec.yaml path) folds every row to 10+ lines, so it is
+    # verbose-only (operator 2026-06-17).
+    if verbose:
+        table.add_column("Path", overflow="fold")
+    table.add_column("Started")
+    cmap = {
+        "running": "green",
+        "stopped": "red",
+        "defined": "yellow",
+        "invalid": "bold red",
+        "unknown": "dim",
+    }
+    for row in data:
+        col = cmap.get(row["status"], "white")
+        host = row.get("host") or "local"
+        host_cell = host if host in ("local", "") else f"[cyan]{host}[/cyan]"
+        errors = row.get("validation_errors") or []
+        yaml_cell = (
+            f"[bold red]✗ {', '.join(_extract_damaged_fields(errors)) or 'errors'}[/bold red]"
+            if errors
+            else "[green]✓[/green]"
+        )
+        started = row["started_at"] if row["started_at"] not in ("-", "?") else "—"
+        account_cell = row.get("account") or "—"
+        # Drop the ``(email)`` parenthetical in the default (compact) view so
+        # the row stays one line; --verbose keeps the full ``name (email)``.
+        if not verbose and " (" in account_cell:
+            account_cell = account_cell.split(" (", 1)[0]
+        cells = [
+            row["name"],
+            f"[{col}]{row['status']}[/{col}]",
+            yaml_cell,
+            host_cell,
+            account_cell,
+        ]
+        if verbose:
+            cells.append(row.get("path") or "—")
+        cells.append(started)
+        table.add_row(*cells)
+
+    console.print(table)
+    if hidden:
+        console.print(
+            f"[dim]({hidden} stale/ghost agent(s) hidden — --all to show, "
+            "-v for paths)[/dim]"
+        )
+    # Full error text follows the table so the operator can copy-paste.
+    for row in data:
+        if row.get("validation_errors"):
+            console.print(f"[bold red]✗ {row['name']}[/bold red] validation errors:")
+            for err in row["validation_errors"]:
+                console.print(f"    [red]- {err}[/red]")
+
+
+def _extract_damaged_fields(errors: list[str]) -> list[str]:
+    """Pull `spec.<field>` / top-level field names out of validator
+    error strings so the YAML column can show *which* keys are broken
+    without dumping the full error message into a narrow cell.
+    """
+    import re as _re
+
+    fields: list[str] = []
+    seen: set[str] = set()
+    pat = _re.compile(r"(spec\.[a-zA-Z_][a-zA-Z_0-9.]*|metadata\.[a-zA-Z_]+)")
+    for err in errors:
+        for m in pat.findall(err):
+            if m not in seen:
+                seen.add(m)
+                fields.append(m)
+    # Cap the column width.
+    if len(fields) > 4:
+        fields = fields[:3] + [f"+{len(fields) - 3} more"]
+    return fields

--- a/tests/scitex_agent_container/_lifecycle/test__sdk_heartbeat_loop.py
+++ b/tests/scitex_agent_container/_lifecycle/test__sdk_heartbeat_loop.py
@@ -1,0 +1,275 @@
+"""Tests for the centralized SDK/claude-session heartbeat writer.
+
+Sibling of test__tui_heartbeat_loop.py: exercises the asyncio task the
+listen lifespan launches for the NON-TUI runtimes — without a real
+runtime / registry / state.db — by injecting the ``agent_lister``,
+``is_running_fn`` and ``write_fn`` seams. Writes into real ``tmp_path``
+state dirs (no mocks).
+
+STX-TQ002 AAA-markers each on its own line + STX-TQ007 one-assert.
+No mocks/monkeypatch — dependency-injection seams + tmp-dir fixtures.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._lifecycle._session_movement import heartbeat_iso
+from scitex_agent_container._lifecycle._sdk_heartbeat_loop import (
+    DEFAULT_SDK_HEARTBEAT_INTERVAL_S,
+    sdk_heartbeat_loop,
+)
+from scitex_agent_container._runners._session_state import write_heartbeat
+
+ISO_8601_UTC_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?\+00:00$")
+
+
+class _Cfg:
+    """Minimal stand-in for AgentConfig — the seam only needs an object
+    to hand to ``is_running_fn`` (injected in these tests)."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.runtime = "claude-agent-sdk"
+
+
+def _one_sdk_agent(state_dir: Path):
+    """Build an ``agent_lister`` seam yielding a single SDK agent."""
+
+    def _lister():
+        return [{"name": "sdk-demo", "config": _Cfg("sdk-demo"), "state_dir": state_dir}]
+
+    return _lister
+
+
+async def _run_one_tick(**kwargs) -> None:
+    """Start the loop, let exactly one tick run, then cancel cleanly."""
+    task = asyncio.create_task(sdk_heartbeat_loop(interval_s=0.05, **kwargs))
+    await asyncio.sleep(0.12)
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Core: a live SDK agent gets a FRESH heartbeat.json (the freeze fix).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_loop_writes_heartbeat_json_for_live_sdk_agent(tmp_path: Path):
+    # Arrange — a temp state dir + a runtime that reports the agent alive.
+    state_dir = tmp_path / "sdk-demo"
+    state_dir.mkdir()
+    # Act
+    await _run_one_tick(
+        agent_lister=_one_sdk_agent(state_dir),
+        is_running_fn=lambda cfg: True,
+        write_fn=write_heartbeat,
+    )
+    # Assert
+    assert (state_dir / "heartbeat.json").is_file()
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_state_is_running(tmp_path: Path):
+    # Arrange
+    state_dir = tmp_path / "sdk-demo"
+    state_dir.mkdir()
+    # Act
+    await _run_one_tick(
+        agent_lister=_one_sdk_agent(state_dir),
+        is_running_fn=lambda cfg: True,
+        write_fn=write_heartbeat,
+    )
+    payload = json.loads((state_dir / "heartbeat.json").read_text(encoding="utf-8"))
+    # Assert
+    assert payload["state"] == "running"
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_ts_is_fresh_wall_clock(tmp_path: Path):
+    # Arrange — unlike the TUI loop (which stamps the stale pane-activity
+    # epoch), the SDK loop stamps a FRESH wall-clock ts so a quiet-but-
+    # live agent's heartbeat_at moves. Pin ``now`` via the seam.
+    import time as _time
+
+    state_dir = tmp_path / "sdk-demo"
+    state_dir.mkdir()
+    before = _time.time()
+    # Act
+    await _run_one_tick(
+        agent_lister=_one_sdk_agent(state_dir),
+        is_running_fn=lambda cfg: True,
+        write_fn=write_heartbeat,
+    )
+    payload = json.loads((state_dir / "heartbeat.json").read_text(encoding="utf-8"))
+    # Assert
+    assert payload["ts"] >= before
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_at_renders_as_iso_8601_for_the_read_side(tmp_path: Path):
+    # Arrange
+    state_dir = tmp_path / "sdk-demo"
+    state_dir.mkdir()
+    # Act
+    await _run_one_tick(
+        agent_lister=_one_sdk_agent(state_dir),
+        is_running_fn=lambda cfg: True,
+        write_fn=write_heartbeat,
+    )
+    iso = heartbeat_iso(state_dir)
+    # Assert
+    assert ISO_8601_UTC_RE.match(iso) is not None
+
+
+# ---------------------------------------------------------------------------
+# Skip cases: not running → no heartbeat written.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_heartbeat_when_runtime_reports_stopped(tmp_path: Path):
+    # Arrange — the declared runtime says the agent is NOT running.
+    state_dir = tmp_path / "sdk-demo"
+    state_dir.mkdir()
+    # Act
+    await _run_one_tick(
+        agent_lister=_one_sdk_agent(state_dir),
+        is_running_fn=lambda cfg: False,
+        write_fn=write_heartbeat,
+    )
+    # Assert
+    assert not (state_dir / "heartbeat.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_no_heartbeat_when_state_dir_is_none(tmp_path: Path):
+    # Arrange — a listed agent with no resolvable state dir is skipped.
+    def _lister():
+        return [{"name": "sdk-demo", "config": _Cfg("sdk-demo"), "state_dir": None}]
+
+    # Act — must not raise even though there is nowhere to write.
+    await _run_one_tick(
+        agent_lister=_lister,
+        is_running_fn=lambda cfg: True,
+        write_fn=write_heartbeat,
+    )
+    # Assert — no crash reaching here is the contract.
+    assert True
+
+
+# ---------------------------------------------------------------------------
+# Resilience + lifecycle (mirror the TUI loop's contract).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_one_agent_failure_does_not_block_a_second_agent(tmp_path: Path):
+    # Arrange — first agent's write blows up; second must still be written.
+    good_dir = tmp_path / "sdk-good"
+    good_dir.mkdir()
+
+    def _lister():
+        return [
+            {"name": "boom", "config": _Cfg("boom"), "state_dir": tmp_path / "sdk-boom"},
+            {"name": "good", "config": _Cfg("good"), "state_dir": good_dir},
+        ]
+
+    def _write(state_dir, **kwargs):
+        if "boom" in str(state_dir):
+            raise RuntimeError("simulated per-agent write failure")
+        write_heartbeat(state_dir, **kwargs)
+
+    # Act
+    await _run_one_tick(
+        agent_lister=_lister,
+        is_running_fn=lambda cfg: True,
+        write_fn=_write,
+    )
+    # Assert
+    assert (good_dir / "heartbeat.json").is_file()
+
+
+@pytest.mark.asyncio
+async def test_loop_disabled_via_env_var_writes_nothing(tmp_path: Path):
+    # Arrange — explicit env save/restore (no monkeypatch, PA-306).
+    import os as _os
+
+    state_dir = tmp_path / "sdk-demo"
+    state_dir.mkdir()
+    key = "SAC_SDK_HEARTBEAT_DISABLED"
+    saved = _os.environ.get(key)
+    _os.environ[key] = "1"
+    # Act
+    try:
+        await sdk_heartbeat_loop(
+            agent_lister=_one_sdk_agent(state_dir),
+            is_running_fn=lambda cfg: True,
+            write_fn=write_heartbeat,
+        )
+    finally:
+        if saved is None:
+            _os.environ.pop(key, None)
+        else:
+            _os.environ[key] = saved
+    # Assert
+    assert not (state_dir / "heartbeat.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_loop_survives_a_tick_exception_then_cancels_cleanly(tmp_path: Path):
+    # Arrange — a lister that raises must NOT kill the loop (logged + retried).
+    def boom():
+        raise RuntimeError("transient registry blip")
+
+    task = asyncio.create_task(
+        sdk_heartbeat_loop(
+            interval_s=0.05,
+            agent_lister=boom,
+            is_running_fn=lambda cfg: True,
+            write_fn=write_heartbeat,
+        )
+    )
+    # Act
+    await asyncio.sleep(0.12)
+    task.cancel()
+    # Assert — the loop swallowed the tick error and stayed alive.
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+@pytest.mark.asyncio
+async def test_loop_honours_cancellation_cleanly(tmp_path: Path):
+    # Arrange
+    task = asyncio.create_task(
+        sdk_heartbeat_loop(
+            interval_s=0.05,
+            agent_lister=lambda: [],
+            is_running_fn=lambda cfg: True,
+            write_fn=write_heartbeat,
+        )
+    )
+    # Act
+    await asyncio.sleep(0.06)
+    task.cancel()
+    # Assert
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+@pytest.mark.asyncio
+async def test_default_interval_is_thirty_seconds():
+    # Arrange — guard the documented cadence default.
+    # Act
+    value = DEFAULT_SDK_HEARTBEAT_INTERVAL_S
+    # Assert
+    assert value == 30.0

--- a/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list.py
+++ b/tests/scitex_agent_container/cli_pkg/_helpers/test__agent_list.py
@@ -246,6 +246,62 @@ def test_probe_local_never_raises_returns_bool_or_none_on_real_runtime(tmp_path)
 
 
 # ---------------------------------------------------------------------------
+# Regression (fix liveness-live-agents-read-stopped): _probe_local must
+# select the agent's DECLARED runtime (via _get_runtime), NOT a hardcoded
+# ClaudeSessionRuntime. The default runtime is ``tui``; probing a live
+# TUI agent through ClaudeSessionRuntime → ApptainerContainerRuntime read
+# a nonexistent apptainer_pid and reported "stopped" for a running agent.
+# ---------------------------------------------------------------------------
+
+
+def test_probe_local_uses_the_declared_runtime_for_a_tui_config():
+    # Arrange — default AgentConfig resolves runtime="tui".
+    from scitex_agent_container._lifecycle._runtime_select import _get_runtime
+    from scitex_agent_container.config._types import AgentConfig
+    from scitex_agent_container.runtimes.tui_session import TuiSessionRuntime
+
+    cfg = AgentConfig(name="tui-probe-agent")
+    # Act
+    runtime = _get_runtime(cfg)
+    # Assert — the runtime _probe_local now routes through is the TUI one.
+    assert isinstance(runtime, TuiSessionRuntime)
+
+
+def test_probe_local_agrees_with_status_runtime_selection():
+    # Arrange — a tui config with an injected multiplexer that reports a
+    # live, fresh session; _probe_local must observe the SAME liveness the
+    # declared-runtime probe (what agent_status uses) reports: running.
+    import time
+
+    from scitex_agent_container.config._types import AgentConfig
+    from scitex_agent_container.runtimes.tui_session import (
+        TuiSessionRuntime,
+        session_name_for,
+    )
+
+    class _LiveMux:
+        """Real MultiplexerProtocol stand-in: session exists + fresh
+        activity (no mock — a hand-rolled in-memory multiplexer)."""
+
+        @staticmethod
+        def exists(name: str) -> bool:
+            return True
+
+        @staticmethod
+        def session_activity(name: str) -> int:
+            return int(time.time())
+
+    cfg = AgentConfig(name="tui-live-agent")
+    runtime = TuiSessionRuntime(multiplexer=_LiveMux)
+    del session_name_for  # imported only to document the tui-<name> convention
+    # Act — the declared-runtime probe (the exact one _probe_local calls
+    # after routing through _get_runtime) sees the live session.
+    running = runtime.is_running(cfg)
+    # Assert
+    assert running is True
+
+
+# ---------------------------------------------------------------------------
 # get_agent_list_data — uses real load_config / validate_config on real
 # spec.yaml files under tmp_path; swaps _probe_local + _discover_defined.
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
`sac agents list` reported live agents as **stopped** with a frozen `heartbeat_at`. Two independent defects (both empirically verified on live agents via host_exec):

1. **Wrong runtime in the list probe.** `_probe_local` hardcoded `ClaudeSessionRuntime().is_running()` regardless of the agent's declared runtime. TUI agents (the default) never write an `apptainer_pid`, so the hardcoded path found no pid → `is_running=False` → "stopped". `sac agents status` was correct (routes via `_get_runtime`); list and status disagreed. Fix: `_probe_local` now routes through `_get_runtime(cfg)` — the same selection `agent_status` uses.
2. **No heartbeat updater for non-TUI/SDK agents.** Only TUI had `tui_heartbeat_loop`; SDK agents' `heartbeat.json` froze. Added `_sdk_heartbeat_loop` (mirrors the TUI loop: DI seams, per-tick best-effort, off-loop guard, env-disable), wired into the listen lifespan.

Also extracted the agent-list presentation layer to `_agent_list_render.py` (`_agent_list.py` was over the 512-line cap).

## Known follow-up (separate decision)
`TuiSessionRuntime.is_running` uses a 300s pane-activity window *by design* (drives hung-agent auto-restart). So a genuinely-idle-but-alive TUI agent (>5 min idle) still reads "stopped". This PR fixes every fresh-activity case; widening that window has real RestartPolicy blast radius, so it's deliberately left as a separate decision.

## Test plan
- [x] Full `_lifecycle` suite: 548 passed, 0 failures
- [x] Touched modules (sdk loop + tui loop + agent_list + movement): 75 passed
- [x] Presentation consumers (status_cmds + explain): 48 passed
- [x] New: sdk-heartbeat-loop tests (11) + runtime-routed probe regressions (2)