### PR TITLE
feat(container): bump claude CLI to 2.1.198 (fable[1m]) via decoupled npm install

### DIFF
--- a/src/scitex_agent_container/containers/apptainer-base.def
+++ b/src/scitex_agent_container/containers/apptainer-base.def
@@ -172,13 +172,21 @@ From: ubuntu:24.04
         @typescript-eslint/parser \
         @typescript-eslint/eslint-plugin \
         jsonlint \
-        @mermaid-js/mermaid-cli
+        @mermaid-js/mermaid-cli \
+        @anthropic-ai/claude-code@2.1.198
 
-    # ---- 3a. Claude Code CLI — bundled with claude-agent-sdk -------
-    # No separate install needed: pip install claude-agent-sdk bundles
-    # the matching CLI binary under _bundled/claude (see
-    # claude-agent-sdk-python README). We symlink it onto PATH in
-    # section 6b after the venv is built.
+    # ---- 3a. Claude Code CLI — decoupled from the SDK bundle -------
+    # 2026-07-02: the SDK-bundled CLI is stuck at 2.1.191 even on the
+    # latest claude-agent-sdk (0.2.110), and the operator needs 2.1.198
+    # to unlock the `fable[1m]` model. So the PATH `claude` binary is now
+    # DECOUPLED from the SDK: we install the standalone
+    # `@anthropic-ai/claude-code@2.1.198` npm package (added to the
+    # `npm install -g` list above; npm prefix is /opt/npm-global, so it
+    # lands at /opt/npm-global/bin/claude) and repoint /usr/local/bin/claude
+    # at THAT in section 6b — the SDK stays pinned at 0.2.110 purely for
+    # the Python runtime. NOTE: this is a deliberate CLI/SDK version
+    # mismatch (2.1.198 CLI vs the SDK's own 2.1.191 bundle); see section
+    # 6b for the caveat about SDK/claude-session agents.
     npx puppeteer browsers install chrome-headless-shell || true
 
     rm -rf /var/lib/apt/lists/*
@@ -285,10 +293,13 @@ From: ubuntu:24.04
     # since-fixed 2.1.139 startup hang on `GET /v1/mcp_servers`; the
     # SDK has rolled forward across the affected window and the
     # currently shipping pair is the one the lead's hand-built SIF
-    # uses today. The SDK bundles its CLI under `_bundled/claude`, so
-    # pinning the Python version also pins the binary — no separate
-    # `claude` install needed (see Anthropic's claude-agent-sdk-python
-    # README).
+    # uses today. The SDK bundles its CLI under `_bundled/claude`, but
+    # as of 2026-07-02 that bundle is STALE at 2.1.191 even on 0.2.110,
+    # so we no longer surface it on PATH — the PATH `claude` binary is
+    # the standalone npm `@anthropic-ai/claude-code@2.1.198` install
+    # instead (see section 3a and the repoint below in this section).
+    # The SDK pin (0.2.110) is kept ONLY for the Python runtime that
+    # scitex-agent-container's runner imports.
     #
     # sac itself is installed from /opt/scitex-agent-container-src/ —
     # the package's OWN source tree, copied in by the %files section
@@ -315,13 +326,18 @@ From: ubuntu:24.04
         "scitex-todo[mcp]>=0.3.0" \
         /opt/scitex-agent-container-src
 
-    # Surface the SDK's bundled claude CLI on PATH so humans can
-    # `apptainer shell` and run `claude` interactively, and so that
-    # subprocess_cli's bundled-fallback path resolves the same binary
-    # the SDK uses programmatically.
-    if [ -x /opt/venv-sac/lib/python3.12/site-packages/claude_agent_sdk/_bundled/claude ]; then
-        ln -sf /opt/venv-sac/lib/python3.12/site-packages/claude_agent_sdk/_bundled/claude \
-            /usr/local/bin/claude
+    # Surface the standalone npm-installed claude CLI (2.1.198) on PATH,
+    # DECOUPLED from the SDK's stale 2.1.191 bundle (2026-07-02). This is
+    # what humans get on `apptainer shell` and what TUI agents
+    # (runtime: tui) invoke via `command -v claude` — so they get
+    # 2.1.198 and the `fable[1m]` model. CAVEAT: this is a CLI/SDK
+    # version mismatch. SDK/claude-session agents may still invoke the
+    # SDK's OWN bundled binary (2.1.191) depending on how
+    # subprocess_cli resolves the executable, rather than this PATH
+    # symlink — that path is NOT yet validated on a rebuilt SIF and
+    # needs a smoke-test before fleet-wide rollout.
+    if [ -x /opt/npm-global/bin/claude ]; then
+        ln -sf /opt/npm-global/bin/claude /usr/local/bin/claude
     fi
 
     # ---- 7. rtk — Rust Token Killer (the operator's token-saving proxy) -
@@ -348,8 +364,12 @@ From: ubuntu:24.04
     export LC_ALL=en_US.UTF-8
     # /opt/venv-sac/bin first so the runner uses the SAC-shipped python
     # (with scitex-agent-container + claude-agent-sdk preinstalled).
-    # /root/.local/bin holds the install.sh-installed `claude` binary
-    # (preferred over npm package — see %post note).
+    # The PATH `claude` resolves to /usr/local/bin/claude, which section
+    # 6b symlinks at the standalone npm `@anthropic-ai/claude-code@2.1.198`
+    # binary (/opt/npm-global/bin/claude) — DECOUPLED from the SDK's stale
+    # 2.1.191 bundle (2026-07-02, for `fable[1m]`). No `claude` lands in
+    # /opt/venv-sac/bin or /root/.local/bin (the latter holds only uv), so
+    # those earlier entries do NOT shadow the 2.1.198 symlink.
     export PATH=/opt/venv-sac/bin:/root/.local/bin:/opt/cargo/bin:/opt/npm-global/bin:/usr/local/bin:$PATH
     export RUSTUP_HOME=/opt/rust
     export CARGO_HOME=/opt/cargo


### PR DESCRIPTION
## Summary

The container's PATH `claude` CLI was stuck at **2.1.191** because it came from the `claude-agent-sdk` bundle (`_bundled/claude`). The operator needs **2.1.198** to unlock the `fable[1m]` model. The latest SDK (0.2.110) STILL bundles 2.1.191, so this PR **decouples** the CLI binary from the SDK:

- Install the standalone `@anthropic-ai/claude-code@2.1.198` npm package (npm prefix `/opt/npm-global` -> `/opt/npm-global/bin/claude`).
- Repoint `/usr/local/bin/claude` at the npm binary instead of the SDK's `_bundled/claude` (guarded by `[ -x /opt/npm-global/bin/claude ]`, mirroring the prior guard).
- **SDK pin `claude-agent-sdk==0.2.110` is UNTOUCHED** — kept purely for the Python runtime that sac's runner imports.
- Stale comments updated (sections 3a, 6b, `%environment`) with a dated note (2026-07-02) explaining the decoupled design.

File: `src/scitex_agent_container/containers/apptainer-base.def` (builds sac-base.sif). `apptainer-scitex.def` does NOT symlink the bundled claude (base owns the symlink), so no change needed there.

## Exact lines changed
- **npm globals list**: added `@anthropic-ai/claude-code@2.1.198` to the `npm install -g` list.
- **Symlink repoint (section 6b)**:
  - before: `ln -sf /opt/venv-sac/lib/python3.12/site-packages/claude_agent_sdk/_bundled/claude /usr/local/bin/claude`
  - after:  `ln -sf /opt/npm-global/bin/claude /usr/local/bin/claude` (guarded by `[ -x /opt/npm-global/bin/claude ]`)
- **Comments**: section 3a header + note, section 6b SDK note, and `%environment` PATH comment rewritten to describe the decoupling and dated 2026-07-02.

Net: `1 file changed, 39 insertions(+), 19 deletions(-)`.

## Important nuance / caveats
- **CLI/SDK version mismatch (deliberate):** claude 2.1.198 CLI + claude-agent-sdk 0.2.110 (whose own bundle is 2.1.191).
  - **TUI agents (`runtime: tui`)** invoke the PATH `claude` (`command -v claude` -> `/usr/local/bin/claude` -> 2.1.198), so they get `fable[1m]`.
  - **SDK / claude-session agents** may still invoke the SDK's OWN bundled binary (2.1.191) depending on how `subprocess_cli` resolves the executable, rather than the PATH symlink. **This is NOT yet validated** and needs a smoke-test on a rebuilt SIF before fleet-wide rollout.
- **PATH-precedence check:** `/opt/venv-sac/bin` and `/root/.local/bin` precede `/opt/npm-global/bin`/`/usr/local/bin` in `%environment` PATH, but NO `claude` binary lands in either (the latter holds only `uv`), so they do NOT shadow the 2.1.198 symlink. The stale `%environment` comment claiming an "install.sh-installed claude" in `/root/.local/bin` (which never existed) was corrected.
- **This PR does NOT rebuild the SIF** — that's a separate heavy/host step. It only changes the `.def`.

## Test plan
- [ ] Rebuild sac-base.sif from this `.def`.
- [ ] `apptainer shell` -> `claude --version` reports **2.1.198**.
- [ ] Confirm `/usr/local/bin/claude` -> `/opt/npm-global/bin/claude` and `command -v claude` resolves there.
- [ ] Smoke-test a TUI agent gets `fable[1m]`.
- [ ] Smoke-test an SDK/claude-session agent: confirm which binary it actually invokes (validate the mismatch caveat above) before fleet-wide rollout.
