### PR TITLE
feat(acl): add `privileged` group to host_exec eligibility + management mesh

### DIFF
--- a/src/scitex_agent_container/_listen/_host_exec.py
+++ b/src/scitex_agent_container/_listen/_host_exec.py
@@ -16,8 +16,9 @@ FLOW:
    ``agents_start``/``agent_restart`` handlers).
 3. GROUP GATE: resolve the caller's group via
    ``resolve_group_name`` and refuse with 403 unless it is one of
-   ``ELIGIBLE_GROUPS`` (developer, researcher). The operator explicitly scoped
-   arbitrary host-exec to these two groups (2026-07-01 Q1a).
+   ``ELIGIBLE_GROUPS`` (developer, researcher, privileged). The operator
+   explicitly scoped arbitrary host-exec to developer + researcher
+   (2026-07-01 Q1a) and added ``privileged`` on 2026-07-02.
 4. Execute ``subprocess.run(argv, ...)`` — no shell, argv list only. Capture
    stdout/stderr, honour an optional timeout, return exit_code + duration.
 5. Audit log every invocation as one JSONL line to
@@ -46,9 +47,14 @@ from starlette.responses import JSONResponse
 
 from ._acl import deny_response, resolve_group_name
 
-# Operator-scoped groups (2026-07-01 Q1a + researcher). Members of these groups
-# are permitted to broker arbitrary commands as the operator's uid on the host.
-ELIGIBLE_GROUPS: frozenset[str] = frozenset({"developer", "researcher"})
+# Operator-scoped groups (2026-07-01 Q1a + researcher; ``privileged`` added
+# 2026-07-02 per operator request). Members of these groups are permitted to
+# broker arbitrary commands as the operator's uid on the host. The
+# ``privileged`` group (grant / dotfiles / claude-code-telegrammer) was added
+# so those agents can run host ops and manage the fleet flexibly.
+ELIGIBLE_GROUPS: frozenset[str] = frozenset(
+    {"developer", "researcher", "privileged"}
+)
 
 # Structured audit log — one JSONL entry per invocation. Path is fixed (matches
 # the other runtime logs). Test seam: monkeypatch ``_audit_log_path``.

--- a/src/scitex_agent_container/config/_group_resolver.py
+++ b/src/scitex_agent_container/config/_group_resolver.py
@@ -48,6 +48,7 @@ __all__ = [
     "DEVELOPER_GROUP",
     "GENERALIST_GROUP",
     "MESH_GROUPS",
+    "PRIVILEGED_GROUP",
     "RESEARCHER_GROUP",
     "group_from_labels",
     "groups_mesh",
@@ -68,12 +69,23 @@ DEVELOPER_GROUP = "developer"
 RESEARCHER_GROUP = "researcher"
 GENERALIST_GROUP = "generalist"
 
+# The privileged group (operator 2026-07-02): grant / dotfiles /
+# claude-code-telegrammer. Like ``developer`` it may broker arbitrary
+# host-exec (see :data:`._listen._host_exec.ELIGIBLE_GROUPS`) and, by being
+# a MESH group below, may manage agents across groups (start / restart /
+# stop / delete / status / tail via :func:`._listen._acl.check_lineage_acl`)
+# with no lineage edge and no per-pair grant — "work flexibly".
+PRIVILEGED_GROUP = "privileged"
 
-# Cross-group mesh (operator 2026-06-27): the three STANDARD fleet groups
-# coordinate with each other in all directions — a ``developer`` may
-# address a ``researcher`` may address a ``generalist``, no per-pair grant
-# needed. This is "fleet-mesh by default" for the standard groups, the
-# layer above the same-named-group mesh.
+
+# Cross-group mesh (operator 2026-06-27; ``privileged`` added 2026-07-02):
+# the STANDARD fleet groups coordinate with each other in all directions —
+# a ``developer`` may address a ``researcher`` may address a ``generalist``
+# may address a ``privileged``, no per-pair grant needed. This is
+# "fleet-mesh by default" for the standard groups, the layer above the
+# same-named-group mesh. Being a mesh group is ALSO what lets ``privileged``
+# manage agents across groups (start / restart / stop / delete / status /
+# tail) via :func:`._listen._acl.check_lineage_acl`.
 #
 # A group OUTSIDE this set does NOT mesh: e.g. a paper-scitex-clew solver
 # in an isolated group (and/or ``lineage_group='solitary'`` + per-spec
@@ -81,7 +93,7 @@ GENERALIST_GROUP = "generalist"
 # preserving the solid isolation scientific rigor requires. To mesh a new
 # group, add its name here (single-line edit, zero schema change).
 MESH_GROUPS: frozenset[str] = frozenset(
-    {DEVELOPER_GROUP, RESEARCHER_GROUP, GENERALIST_GROUP}
+    {DEVELOPER_GROUP, RESEARCHER_GROUP, GENERALIST_GROUP, PRIVILEGED_GROUP}
 )
 
 

--- a/tests/scitex_agent_container/_listen/test__host_exec.py
+++ b/tests/scitex_agent_container/_listen/test__host_exec.py
@@ -188,9 +188,41 @@ def test_host_exec_allows_the_researcher_group():
     assert resp.status_code == 200
 
 
+def test_host_exec_allows_the_privileged_group():
+    # Arrange — privileged is eligible per operator scope (2026-07-02).
+    req = _FakeRequest({"argv": ["true"]}, authenticated_node="a-privileged")
+    # Act
+    resp = _run(
+        host_exec(
+            req,
+            group_resolver=lambda name: "privileged",
+            audit_writer=_noop_audit,
+        )
+    )
+    # Assert
+    assert resp.status_code == 200
+
+
+def test_host_exec_denies_unlabeled_privileged_style_caller_helpfully():
+    # Arrange — an agent that has NOT been labeled into the privileged group
+    # resolves to the ungrouped "" (or any non-eligible group) and is refused
+    # with a structured 403 that names the eligible groups.
+    req = _FakeRequest({"argv": ["true"]}, authenticated_node="unlabeled-agent")
+    # Act
+    resp = _run(
+        host_exec(
+            req,
+            group_resolver=lambda name: "",
+            audit_writer=_noop_audit,
+        )
+    )
+    # Assert
+    assert resp.status_code == 403
+
+
 def test_host_exec_eligible_groups_set_matches_operator_scope():
     # Arrange
-    expected = frozenset({"developer", "researcher"})
+    expected = frozenset({"developer", "researcher", "privileged"})
     # Act
     actual = ELIGIBLE_GROUPS
     # Assert

--- a/tests/scitex_agent_container/config/test__group_resolver.py
+++ b/tests/scitex_agent_container/config/test__group_resolver.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 from scitex_agent_container.config._group_resolver import (
     DEVELOPER_GROUP,
     GENERALIST_GROUP,
+    PRIVILEGED_GROUP,
     RESEARCHER_GROUP,
     group_from_labels,
     groups_mesh,
@@ -314,5 +315,45 @@ def test_groups_mesh_false_when_one_side_is_ungrouped() -> None:
     # Arrange
     # Act
     result = groups_mesh(RESEARCHER_GROUP, "")
+    # Assert
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# privileged group (operator 2026-07-02): host-exec eligible + mesh member so
+# it can manage agents across groups
+# ---------------------------------------------------------------------------
+
+
+def test_is_mesh_group_true_for_privileged() -> None:
+    # Arrange
+    group = PRIVILEGED_GROUP
+    # Act
+    result = is_mesh_group(group)
+    # Assert
+    assert result is True
+
+
+def test_groups_mesh_true_privileged_manages_developer() -> None:
+    # Arrange — privileged meshes with the standard fleet, so a privileged
+    # caller may manage (start / restart / …) a developer target cross-group.
+    # Act
+    result = groups_mesh(PRIVILEGED_GROUP, DEVELOPER_GROUP)
+    # Assert
+    assert result is True
+
+
+def test_groups_mesh_true_privileged_manages_researcher() -> None:
+    # Arrange
+    # Act
+    result = groups_mesh(PRIVILEGED_GROUP, RESEARCHER_GROUP)
+    # Assert
+    assert result is True
+
+
+def test_groups_mesh_false_privileged_against_non_mesh_group() -> None:
+    # Arrange — an isolated solver stays unmanageable even by privileged.
+    # Act
+    result = groups_mesh(PRIVILEGED_GROUP, "solver")
     # Assert
     assert result is False


### PR DESCRIPTION
## Summary
Adds a new named agent group **`privileged`** (grant / dotfiles / claude-code-telegrammer) that sac recognizes for two capabilities:

- **Arbitrary host-exec** — `privileged` joins `developer` + `researcher` in `ELIGIBLE_GROUPS`, so its members may broker any command via `POST /v1/host_exec`.
- **Cross-group management** — `privileged` is added to `MESH_GROUPS` (`_group_resolver.py`), so a privileged caller may (re)start / stop / delete / status / tail agents across groups with no lineage edge and no per-pair grant, via `check_lineage_acl`'s `groups_mesh` predicate. It also meshes for a2a sends both ways.

## Exact changes
- `src/scitex_agent_container/_listen/_host_exec.py`
  - `ELIGIBLE_GROUPS`: `{"developer", "researcher"}` → `{"developer", "researcher", "privileged"}`
  - Module docstring (group-gate step) + the `ELIGIBLE_GROUPS` comment updated to cite the 2026-07-02 operator addition alongside the 2026-07-01 scoping.
- `src/scitex_agent_container/config/_group_resolver.py`
  - New `PRIVILEGED_GROUP = "privileged"` constant (+ `__all__` entry).
  - `MESH_GROUPS` now includes `PRIVILEGED_GROUP`.
  - Mesh comment updated to note privileged and that mesh membership is what grants cross-group management.
- Tests (mirror the existing developer/researcher cases, no mocks, absolute-path pytest):
  - `tests/.../_listen/test__host_exec.py`: privileged passes the group gate (200); an unlabeled caller (group `""`) is denied with a structured 403; eligible-set assertion updated to include privileged.
  - `tests/.../config/test__group_resolver.py`: `is_mesh_group("privileged")` true; `groups_mesh(privileged, developer/researcher)` true; `groups_mesh(privileged, "solver")` false (isolation preserved).

## Management mesh: found + updated (not deferred)
The management mesh is `MESH_GROUPS` in `_group_resolver.py`, consumed by `check_lineage_acl` (agent stop/restart/delete/status/tail) and `check_send_acl` via `groups_mesh`. Adding `privileged` there gives it the requested flexible cross-group management with a single-line, zero-schema-change edit.

## Scope note
This is only the sac CODE that *recognizes* `privileged`. The actual agent spec labels (`groups: [privileged]` on grant / dotfiles / claude-code-telegrammer) are applied separately by the dotfiles agent.

## DEPLOY NOTE
`ELIGIBLE_GROUPS` is read by the running `sac listen` daemon. This change only takes effect **after the daemon is restarted on the merged code** (operator action) — do not assume host-exec eligibility for `privileged` is live at merge time.

## Test plan
- [x] `test__host_exec.py` — privileged allow, unlabeled deny, eligible-set assertion (23 passed)
- [x] `test__group_resolver.py` — privileged mesh predicates (all passed)
- [x] `test__acl_group.py` + `test__acl_check_lineage.py` — no regressions (27 passed)
- [ ] Operator: restart `sac listen` on merged develop so `ELIGIBLE_GROUPS` change is live