### PR TITLE
feat(env): rename injected SCITEX_TODO_AGENT → SCITEX_TODO_AGENT_ID (+ TASKS → TASKS_YAML_SHARED) for scitex-todo 0.7.30 lockstep

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,5 +1,5 @@
 export CCT_AGENT_ID="scitex-agent-container"
 export CCT_BOT_TOKEN="$CCT_BOT_TOKEN_SAC"
 
-# SciTeX Todo
-export SCITEX_TODO_AGENT="scitex-agent-container"
+# SciTeX Todo (>= 0.7.30 identity var name)
+export SCITEX_TODO_AGENT_ID="scitex-agent-container"

--- a/src/scitex_agent_container/_lifecycle/_ci_owner.py
+++ b/src/scitex_agent_container/_lifecycle/_ci_owner.py
@@ -34,7 +34,7 @@ def _default_agents_dir() -> Path:
 
 
 def _default_tasks_path() -> Path:
-    env = os.environ.get("SCITEX_TODO_TASKS")
+    env = os.environ.get("SCITEX_TODO_TASKS_YAML_SHARED")
     if env:
         return Path(env).expanduser()
     return Path.home() / ".scitex" / "todo" / "tasks.yaml"

--- a/src/scitex_agent_container/_mcp/_tools/_agent.py
+++ b/src/scitex_agent_container/_mcp/_tools/_agent.py
@@ -311,7 +311,7 @@ def agent_create(
 
     Writes ``<name>/spec.yaml`` from the developer/scientist skeleton,
     filling identity (name -> project / workdir / overlay / state-db /
-    SCITEX_TODO_AGENT) and auto-detecting the editable-install block
+    SCITEX_TODO_AGENT_ID) and auto-detecting the editable-install block
     (workdir ships a package) and the per-agent Telegram bot
     (``telegram_token`` file present). ``start=True`` launches the agent
     afterwards. The developer group is authorized to CRUD agents."""

--- a/src/scitex_agent_container/cli_pkg/_create.py
+++ b/src/scitex_agent_container/cli_pkg/_create.py
@@ -196,7 +196,7 @@ def create(
 
     Writes ``<base-dir>/<name>/spec.yaml`` from the matching underscore-agent
     skeleton, filling identity (name -> project / workdir / overlay /
-    state-db / SCITEX_TODO_AGENT) and auto-detecting the editable-install and
+    state-db / SCITEX_TODO_AGENT_ID) and auto-detecting the editable-install and
     Telegram-bot blocks.
 
     Examples:

--- a/src/scitex_agent_container/cli_pkg/_create_templates/_developer/spec.yaml
+++ b/src/scitex_agent_container/cli_pkg/_create_templates/_developer/spec.yaml
@@ -45,7 +45,7 @@ spec:
       - --env
       - SCITEX_AGENT_CONTAINER_STATE_DB=/state/{{ NAME }}/state.db
       - --env
-      - SCITEX_TODO_AGENT={{ NAME }}
+      - SCITEX_TODO_AGENT_ID={{ NAME }}
       - --env
       - GIT_AUTHOR_NAME=Yusuke Watanabe
       - --env

--- a/src/scitex_agent_container/cli_pkg/_create_templates/_scientist/spec.yaml
+++ b/src/scitex_agent_container/cli_pkg/_create_templates/_scientist/spec.yaml
@@ -45,7 +45,7 @@ spec:
       - --env
       - SCITEX_AGENT_CONTAINER_STATE_DB=/state/{{ NAME }}/state.db
       - --env
-      - SCITEX_TODO_AGENT={{ NAME }}
+      - SCITEX_TODO_AGENT_ID={{ NAME }}
       - --env
       - GIT_AUTHOR_NAME=Yusuke Watanabe
       - --env

--- a/src/scitex_agent_container/runtimes/_to_home_text.py
+++ b/src/scitex_agent_container/runtimes/_to_home_text.py
@@ -41,6 +41,12 @@ START_MARKER_PREFIX = "<!-- Start of scitex-agent-container generated section"
 # ``CCT_ALLOWED_USERS`` / ``CCT_STATE_DIR`` and any future ``CCT_*`` var.
 _RUNTIME_ONLY_VARS = frozenset(
     {
+        # scitex-todo >= 0.7.30 names
+        "SCITEX_TODO_AGENT_ID",
+        "SCITEX_TODO_TASKS_YAML_SHARED",
+        # Legacy pre-0.7.30 names — kept as a GUARD only (never injected by
+        # sac anymore): a stale deployer shell exporting the old names must
+        # still not bake them into materialized files.
         "SCITEX_TODO_AGENT",
         "SCITEX_TODO_TASKS",
         "SAC_NAME",

--- a/tests/scitex_agent_container/runtimes/test__to_home_text.py
+++ b/tests/scitex_agent_container/runtimes/test__to_home_text.py
@@ -27,9 +27,22 @@ def test_interpolate_env_keeps_cct_agent_id_literal_even_when_set(env_save_resto
     assert out == "id=${CCT_AGENT_ID}"
 
 
-def test_interpolate_env_keeps_scitex_todo_agent_literal_even_when_set(
+def test_interpolate_env_keeps_scitex_todo_agent_id_literal_even_when_set(
     env_save_restore,
 ):
+    # Arrange
+    env_save_restore.set("SCITEX_TODO_AGENT_ID", "agent:scitex-agent-container")
+    # Act
+    out = interpolate_env("agent=${SCITEX_TODO_AGENT_ID}")
+    # Assert
+    assert out == "agent=${SCITEX_TODO_AGENT_ID}"
+
+
+def test_interpolate_env_keeps_legacy_scitex_todo_agent_literal_even_when_set(
+    env_save_restore,
+):
+    # Legacy pre-0.7.30 name kept as a guard: a stale deployer shell must
+    # still not bake it into materialized files.
     # Arrange
     env_save_restore.set("SCITEX_TODO_AGENT", "agent:scitex-agent-container")
     # Act


### PR DESCRIPTION
## Why

scitex-todo **0.7.30** renames its env vars and **fail-louds when the OLD names are present**:

- `SCITEX_TODO_AGENT` → `SCITEX_TODO_AGENT_ID` (per-agent identity)
- `SCITEX_TODO_TASKS` → `SCITEX_TODO_TASKS_YAML_SHARED` (shared tasks.yaml store override)

sac injects the identity var per-agent, so the injected KEY must flip. Values are unchanged (still the agent name / tasks.yaml path).

## Injection sites changed

| File | Change |
|---|---|
| `src/scitex_agent_container/cli_pkg/_create_templates/_developer/spec.yaml` | apptainer `--env SCITEX_TODO_AGENT={{ NAME }}` → `SCITEX_TODO_AGENT_ID={{ NAME }}` (per-agent identity injection) |
| `src/scitex_agent_container/cli_pkg/_create_templates/_scientist/spec.yaml` | same injection rename |
| `src/scitex_agent_container/_lifecycle/_ci_owner.py` | `_default_tasks_path()` now reads `SCITEX_TODO_TASKS_YAML_SHARED` (was `SCITEX_TODO_TASKS`) |
| `.envrc` | this repo's own direnv identity export → `SCITEX_TODO_AGENT_ID` |
| `src/scitex_agent_container/runtimes/_to_home_text.py` | `_RUNTIME_ONLY_VARS` deploy-time bake guard: NEW names added; OLD names retained **as guard only** (a stale deployer shell exporting the old names must still not get baked into materialized files — they are never injected) |
| `src/scitex_agent_container/_mcp/_tools/_agent.py` | docstring mention updated |
| `src/scitex_agent_container/cli_pkg/_create.py` | docstring mention updated |
| `tests/scitex_agent_container/runtimes/test__to_home_text.py` | identity-literal test renamed to `SCITEX_TODO_AGENT_ID` + new legacy-guard test for the retained old name |

Not touched (out of this repo, by design): `_shared/to_home/.mcp.json` (dotfiles) and agent `spec.yaml` files under `~/.scitex/agent-container/agents/`.

## Tests

- `tests/scitex_agent_container/runtimes/test__to_home_text.py` — 6 passed (against worktree src; the new-name test correctly fails against the pre-change installed package, confirming it is a real regression guard)
- `tests/scitex_agent_container/_lifecycle/test__ci_owner.py` — 7 passed (uses explicit `tasks_path` seams, unaffected by the env rename)
- Full `tests/scitex_agent_container/_lifecycle/` — passed

## ⚠️ Deploy note — 0.7.30 LOCKSTEP ONLY

Merge/deploy this **only as part of the scitex-todo 0.7.30 lockstep** (SIF rebake to scitex-todo 0.7.30 + fleet restart):

- Merged alone against a 0.7.29 SIF: agents get `SCITEX_TODO_AGENT_ID` which old scitex-todo ignores → identity lost.
- 0.7.30 SIF alone without this PR: sac still injects the OLD name → 0.7.30 fail-louds.

Existing per-agent `spec.yaml` files on hosts still carry the old `--env SCITEX_TODO_AGENT=...` line; those are regenerated/edited outside this repo and must flip in the same lockstep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
