### PR TITLE
test+log(to_home): lock verbatim .claude/skills materialization + boot-log effective skills

### DIFF
--- a/src/scitex_agent_container/runtimes/_skills_boot_log.py
+++ b/src/scitex_agent_container/runtimes/_skills_boot_log.py
@@ -1,0 +1,62 @@
+"""Boot-time diagnostic: log the effective skills materialized into the agent home.
+
+Pure diagnostic (operator requirement, 2026-07-03). sac's ONLY job re skills is
+to materialize ``to_home/.claude/skills/`` VERBATIM into the in-container
+``$HOME/.claude/skills/`` (= ``/home/agent/.claude/skills/``) — the ``@``-imports
+live in each agent's OWN ``to_home/.claude/CLAUDE.md`` (author-controlled), never
+in sac. After :func:`._to_home.deploy_to_home` runs, the agent home holds exactly
+what was staged: the per-agent ``to_home/.claude/skills/`` subtree (copied by
+``_to_home._walk_and_apply``'s recursive ``iterdir``) plus any curated host skill
+sets symlinked in by ``_host_skills.deploy_host_skills``.
+
+Listing that set at INFO on start makes a degraded / empty skill set visible
+rather than silently absent — e.g. a ``skills: [scitexification]`` cohort can
+confirm ``scitexification`` is present in ``$HOME/.claude/skills/``. Never
+raises; a diagnostic must not abort a start.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from ..config import AgentConfig
+
+logger = logging.getLogger(__name__)
+
+
+def log_effective_skills(config: AgentConfig, home_dir: str | Path) -> None:
+    """Log (INFO) the skill dirs present under ``<home_dir>/.claude/skills``.
+
+    Each immediate child directory is listed by name; a child that lacks a
+    top-level ``SKILL.md`` is annotated ``(no SKILL.md)`` so a malformed or
+    set-style entry is still visible. A broken symlink is annotated
+    ``(unreadable)``. Absent skills dir → ``0 skills``. Never raises.
+    """
+    skills_dir = Path(home_dir) / ".claude" / "skills"
+    name = getattr(config, "name", "?")
+    if not skills_dir.is_dir():
+        logger.info(
+            "skills: agent %s — no %s (0 skills materialized)", name, skills_dir
+        )
+        return
+    entries: list[str] = []
+    for child in sorted(skills_dir.iterdir()):
+        try:
+            if not child.is_dir():
+                continue
+        except OSError:  # stx-allow: fallback (broken symlink → report as such)
+            entries.append(f"{child.name}(unreadable)")
+            continue
+        has_skill_md = (child / "SKILL.md").is_file()
+        entries.append(child.name if has_skill_md else f"{child.name}(no SKILL.md)")
+    logger.info(
+        "skills: agent %s — %d skill dir(s) under %s: %s",
+        name,
+        len(entries),
+        skills_dir,
+        ", ".join(entries) or "(none)",
+    )
+
+
+__all__ = ["log_effective_skills"]

--- a/src/scitex_agent_container/runtimes/_tui_workspace.py
+++ b/src/scitex_agent_container/runtimes/_tui_workspace.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from ..config import AgentConfig
+from ._skills_boot_log import log_effective_skills
 from ._to_home import deploy_to_home
 from ._to_home_overlay import deploy_to_home_overlay, resolve_overlay_upper_home
 from .claude_md import setup_claude_md
@@ -77,6 +78,7 @@ def materialize_workspace(
     home_dir.mkdir(parents=True, exist_ok=True)
     setup_claude_md(config, str(home_dir))
     deploy_to_home(config, str(home_dir))
+    log_effective_skills(config, home_dir)
     ensure_global_settings_json()
     setup_settings_json(config, str(home_dir), filename="settings.json")
     deploy_to_home_overlay(config)

--- a/src/scitex_agent_container/runtimes/claude_session.py
+++ b/src/scitex_agent_container/runtimes/claude_session.py
@@ -24,6 +24,7 @@ import sys
 from pathlib import Path
 
 from ..config import AgentConfig
+from ._skills_boot_log import log_effective_skills
 from ._to_home import deploy_to_home
 from .base import RuntimeBase
 from .claude_md import cleanup_claude_md, setup_claude_md
@@ -60,6 +61,7 @@ def _materialize_home_layouts(config: AgentConfig, home_dir: str) -> None:
             "Refusing to start with stale config."
         )
     deploy_to_home(config, home_dir)
+    log_effective_skills(config, home_dir)
 
 
 # F-CS8 — silent SDK failure on heavy workdir/.claude/ trees.

--- a/tests/scitex_agent_container/runtimes/test__skills_boot_log.py
+++ b/tests/scitex_agent_container/runtimes/test__skills_boot_log.py
@@ -1,0 +1,60 @@
+"""Tests for the boot-time effective-skills diagnostic log.
+
+PA-306 no-mocks: real ``AgentConfig`` + real ``tmp_path`` skill dirs, real
+``caplog``. The log is a pure diagnostic — it must list the materialized skill
+dir names at INFO and never raise.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from scitex_agent_container.config._types import AgentConfig
+from scitex_agent_container.runtimes._skills_boot_log import log_effective_skills
+
+_LOGGER = "scitex_agent_container.runtimes._skills_boot_log"
+
+
+def test_logs_present_skill_names(tmp_path, caplog):
+    # Arrange
+    sk = tmp_path / ".claude" / "skills" / "scitexification"
+    sk.mkdir(parents=True)
+    (sk / "SKILL.md").write_text("---\nname: scitexification\n---\n")
+    cfg = AgentConfig(name="solver-1")
+    # Act
+    with caplog.at_level(logging.INFO, logger=_LOGGER):
+        log_effective_skills(cfg, tmp_path)
+    # Assert
+    assert any("scitexification" in r.getMessage() for r in caplog.records)
+
+
+def test_absent_skills_dir_logs_zero(tmp_path, caplog):
+    # Arrange — no .claude/skills/ at all.
+    cfg = AgentConfig(name="empty-agent")
+    # Act
+    with caplog.at_level(logging.INFO, logger=_LOGGER):
+        log_effective_skills(cfg, tmp_path)
+    # Assert
+    assert any("0 skills" in r.getMessage() for r in caplog.records)
+
+
+def test_dir_without_skill_md_is_annotated(tmp_path, caplog):
+    # Arrange — a skill dir missing its SKILL.md.
+    (tmp_path / ".claude" / "skills" / "half").mkdir(parents=True)
+    cfg = AgentConfig(name="a")
+    # Act
+    with caplog.at_level(logging.INFO, logger=_LOGGER):
+        log_effective_skills(cfg, tmp_path)
+    # Assert
+    assert any("no SKILL.md" in r.getMessage() for r in caplog.records)
+
+
+def test_never_raises_on_missing_home(tmp_path, caplog):
+    # Arrange — a home dir that does not exist at all.
+    cfg = AgentConfig(name="a")
+    # Act — a diagnostic must not abort a start; reaching the assert proves
+    # no exception was raised for a nonexistent home.
+    with caplog.at_level(logging.INFO, logger=_LOGGER):
+        log_effective_skills(cfg, tmp_path / "does-not-exist")
+    # Assert
+    assert any("0 skills" in r.getMessage() for r in caplog.records)

--- a/tests/scitex_agent_container/runtimes/test__to_home.py
+++ b/tests/scitex_agent_container/runtimes/test__to_home.py
@@ -168,6 +168,61 @@ class TestMaterializeToHomeBasics:
         assert home.is_dir()
 
 
+class TestSkillsSubtreeMaterialization:
+    """LOCK: ``to_home/.claude/skills/`` is materialized VERBATIM and DEEPLY.
+
+    sac's only skills job is to copy the whole ``.claude/skills/`` subtree into
+    the agent home; ``@``-imports live in each agent's OWN
+    ``to_home/.claude/CLAUDE.md`` (author-controlled), never in sac. A
+    paper-scitex-clew solver's ``@skills/<name>/SKILL.md`` import resolves
+    in-container ONLY if ``_walk_and_apply`` recurses into
+    ``.claude/skills/<name>/`` and copies ``SKILL.md`` byte-for-byte. These
+    tests guard that dependency (a regression here silently breaks their run).
+    """
+
+    def test_skill_md_lands_verbatim(self, tmp_path):
+        # Arrange — a staged skill dir with a SKILL.md.
+        spec_dir = tmp_path / "spec"
+        sk = spec_dir / "to_home" / ".claude" / "skills" / "scitexification"
+        sk.mkdir(parents=True)
+        body = "---\nname: scitexification\n---\nDo the thing.\n"
+        (sk / "SKILL.md").write_text(body)
+        home = tmp_path / "home"
+        # Act
+        materialize_to_home(spec_dir, home)
+        # Assert — byte-for-byte, at the in-home relative path.
+        landed = home / ".claude" / "skills" / "scitexification" / "SKILL.md"
+        assert landed.read_text() == body
+
+    def test_nested_skill_resource_is_preserved(self, tmp_path):
+        # Arrange — a resource nested BELOW the skill dir (deep recursion).
+        spec_dir = tmp_path / "spec"
+        sk = spec_dir / "to_home" / ".claude" / "skills" / "foo"
+        (sk / "references").mkdir(parents=True)
+        (sk / "SKILL.md").write_text("---\nname: foo\n---\n")
+        (sk / "references" / "table.md").write_text("row\n")
+        home = tmp_path / "home"
+        # Act
+        materialize_to_home(spec_dir, home)
+        # Assert
+        nested = home / ".claude" / "skills" / "foo" / "references" / "table.md"
+        assert nested.read_text() == "row\n"
+
+    def test_multiple_skill_dirs_all_materialize(self, tmp_path):
+        # Arrange
+        spec_dir = tmp_path / "spec"
+        root = spec_dir / "to_home" / ".claude" / "skills"
+        for nm in ("alpha", "beta"):
+            (root / nm).mkdir(parents=True)
+            (root / nm / "SKILL.md").write_text(f"---\nname: {nm}\n---\n")
+        home = tmp_path / "home"
+        # Act
+        materialize_to_home(spec_dir, home)
+        # Assert — both staged skills landed (host-curated extras allowed).
+        got = {p.parent.name for p in (home / ".claude" / "skills").rglob("SKILL.md")}
+        assert {"alpha", "beta"} <= got
+
+
 class TestCredentialLeakGuard:
     """``to_home/`` must never carry a ``.credentials.json``.
 


### PR DESCRIPTION
## What / why

sac's ONLY skills responsibility is to materialize the agent's `to_home/.claude/` subtree **verbatim** into the in-container `$HOME/.claude/` (= `/home/agent/.claude/`). The `@`-imports live in each agent's OWN `to_home/.claude/CLAUDE.md` (author-controlled) — never in sac. So no `spec.skills` honoring, no `@`-import emission, no name-resolution belongs in sac.

**Answer to the gating question:** the to_home deployer **already** materializes `.claude/skills/` verbatim and deeply — **no deployer fix needed.** `runtimes/_to_home.py::_walk_and_apply` recurses on directory children via `iterdir` (dirs → `mkdir` + recurse), and `SKILL.md` is in none of the special-basename sets (`_MARKER_PROTECTED`/`_MCP_MERGE`/`_TIGHT_PERM`/`_VERBATIM_SECRET`/`_CASCADE_DEPLOYED`), so it falls through to `_deploy_plain_file` = byte-for-byte copy. Verified empirically: a fixture `to_home/.claude/skills/scitexification/SKILL.md` (plus a nested resource) lands intact at `home/.claude/skills/scitexification/SKILL.md`.

**=> paper-scitex-clew needs ZERO sac code change for skills to materialize.** Their solver `@skills/<name>/SKILL.md` imports resolve in-container today. (They still need Spartan on a sac build that includes this branch only if they want the new boot-log diagnostic; the materialization itself works on current sac.)

## Changes (tiny, additive)

1. **Regression tests** (`tests/.../test__to_home.py::TestSkillsSubtreeMaterialization`) locking verbatim + deep materialization: staged skill dir → home verbatim, nested resource preserved, multiple skill dirs all land. Guards paper-scitex-clew's dependency against a future selective-copy regression.
2. **Boot-log diagnostic** — new `runtimes/_skills_boot_log.py::log_effective_skills(config, home_dir)`, called from both start paths right after `deploy_to_home`: the SDK path (`claude_session._materialize_home_layouts`) and the TUI path (`_tui_workspace.materialize_workspace`). Logs (INFO) the skill dir names under `$HOME/.claude/skills` so a degraded/empty set is visible at start, never silent. Never raises. Covered by `tests/.../test__skills_boot_log.py`.

No change to `_to_home.py` (already at the 512-line cap) or to `claude_md.py`'s skills emission.

## Tests
`PYTHONPATH=src pytest test__skills_boot_log.py test__to_home.py test_claude_session.py` → **129 passed** (7 new).

Do NOT merge yet — coordinator gates.