### PR TITLE
feat(launch): jailed-capsule mount-boundary assert — force --containall + reject shared-FS binds (realpath) for solver group

### DIFF
--- a/src/scitex_agent_container/config/_apptainer_spec.py
+++ b/src/scitex_agent_container/config/_apptainer_spec.py
@@ -1,0 +1,154 @@
+"""``ApptainerSpec`` dataclass — extracted from :mod:`config._types`.
+
+F-CS18 — apptainer-specific extension hook.
+
+Apptainer reads OCI images natively (`apptainer build sif docker://...`),
+so for the no-extras case spec.image alone is enough — sac just
+`apptainer build`s the SIF and runs it. For HPC-specific layering
+(extra pip packages, system libs, env vars), the operator can either:
+
+  * declare `spec.apptainer.post` — sac synthesises a `.def` with
+    `Bootstrap: docker` + `%post` + `%environment` and builds from it.
+  * declare `spec.apptainer.def_file` — sac runs `apptainer build`
+    against the operator's hand-written `.def` (full control).
+
+All fields are optional; an `apptainer:` block with no fields set is
+equivalent to none at all.
+
+Pulled out of ``_types.py`` so that module stays under sac's 512-line
+per-file cap. Re-exported from ``config._types`` for back-compat — any
+``from ...config._types import ApptainerSpec`` keeps resolving.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class ApptainerSpec:
+    """Apptainer-specific image-build extensions (F-CS18)."""
+
+    # v3-realign: apptainer-engine-scoped knobs promoted from top-level.
+    image: str = ""
+    """SIF path or docker:// URL — promoted from top-level spec.image (§3).
+    Empty = fall back to the default sac-scitex SIF."""
+
+    binds: list[str] = field(default_factory=list)
+    """Bind mounts as ``host:container[:mode]`` strings — promoted from
+    top-level spec.mounts (§3)."""
+
+    env: dict[str, str] = field(default_factory=dict)
+    """Env vars exported into the container — promoted from top-level
+    spec.env (§3)."""
+
+    raw_args: list[str] = field(default_factory=list)
+    """v3 escape hatch (§1 invariant): appended verbatim to the
+    ``apptainer exec`` argv after all curated args. Lets operators bolt
+    on flags sac doesn't model."""
+
+    container_workdir: str = "/work"
+    """Path inside the container where ``spec.workdir`` gets bind-mounted
+    (and where the runner's ``--pwd`` lands). Default ``/work``.
+    Override when the SIF expects a different mount point (e.g. a
+    pre-baked ``WORKDIR`` in the .def file)."""
+
+    post: str = ""
+    """Shell snippet run inside the SIF build (apptainer's `%post`).
+    Lines are concatenated verbatim. Empty = no extension."""
+
+    environment: dict = field(default_factory=dict)
+    """Env vars baked into the SIF (apptainer's `%environment`). Same
+    shape as ``spec.env`` — KEY: VALUE pairs."""
+
+    def_file: str = ""
+    """Path to a hand-authored ``.def`` file (apptainer's native
+    build language). Mutually exclusive with `post`/`environment`:
+    when set, sac uses this file verbatim and ignores `post`."""
+
+    nv: bool = False
+    """Forward host NVIDIA driver/libs into the container (apptainer's
+    ``--nv``). Required for CUDA workloads on GPU nodes; harmless on
+    CPU-only hosts but only set when needed."""
+
+    rocm: bool = False
+    """Forward host AMD ROCm libs (apptainer's ``--rocm``). Mutually
+    exclusive with ``nv`` in practice (no host has both)."""
+
+    overlay: str = ""
+    """Writable apptainer overlay image (``--overlay <file>``). Empty =
+    no overlay (tmpfs writable layer). Non-absolute paths resolve
+    against ``spec.workdir``. See ``docs/isolation.md`` §7."""
+
+    overlay_size: str = ""
+    """When set together with ``overlay``, sac auto-creates the overlay
+    image with the given size if it doesn't exist before launching.
+    Accepts apptainer-style sizes with units M/MB/G/GB only (e.g.
+    ``"5G"``, ``"500M"``, ``"1024MB"``). K/KB are explicitly rejected —
+    apptainer's ``overlay create --size`` takes integer MB so sub-MB
+    granularity makes no sense. Empty = no auto-create (default;
+    missing overlay raises FileNotFoundError at launch with a clear
+    message). See ``docs/isolation.md`` §7."""
+
+    overlay_create_if_missing: bool = True
+    """When True (default) AND ``overlay_size`` is set AND the overlay
+    path does not exist, sac runs ``apptainer overlay create --size
+    <MB> <path>`` before launching. When False, sac never creates
+    overlays even if size is given (operator must pre-create — sac
+    raises FileNotFoundError instead). See ``docs/isolation.md`` §7."""
+
+    tmpfs_size: str = "2G"
+    """Minimum free-space guarantee for the container's ``/tmp`` (and
+    ``/var/tmp``). A ``--containall`` apptainer container otherwise gets
+    a 64 MB session tmpfs at ``/tmp`` — too small for the full test
+    suite, coverage XML generation, or pytest fixtures with file IO,
+    which fill it mid-run with "No space left on device".
+
+    sac emits ``--workdir <state_dir>/tmp-scratch`` to relocate ``/tmp``
+    onto the host filesystem (capacity >> 64 MB) and verifies that
+    filesystem has at least this many bytes free before launch, failing
+    loud otherwise. Accepts apptainer-style sizes with units M/MB/G/GB
+    only (e.g. ``"2G"``, ``"512M"``, ``"2048MB"``); K/KB rejected.
+
+    NOT a hard cap — an unprivileged apptainer user cannot mount a
+    size-capped tmpfs (``--mount type=tmpfs`` is unsupported), so the
+    contract is "at least this much room", backed by host disk. Set to
+    ``""`` to opt out entirely (legacy 64 MB tmpfs). See
+    ``runtimes/_apptainer_tmpfs.py``."""
+
+    relaxed: bool = False
+    """Opt out of sac's hardened defaults (auto-prepended
+    ``--containall``/``--cleanenv``/``--writable-tmpfs``/``--home``).
+    See ``docs/isolation.md``."""
+
+    fakeroot: bool = False
+    """Apptainer ``--fakeroot`` — uid 0 inside via user-namespace
+    remapping; operator uid on host. Pairs with the D5 preflight's
+    ``/proc/self/uid_map`` detection (see ``docs/isolation.md``)."""
+
+    jail: bool = False
+    """Opt in to the JAILED-capsule mount-boundary assert (security
+    guardrail — ``runtimes/_apptainer_jail.py``). When true (or when the
+    spec resolves to the ``solver`` named group, which turns this on
+    automatically and non-bypassably), the apptainer launch layer FORCES
+    ``--containall`` and REFUSES to launch if any operator-controlled bind
+    source (``binds`` / ``raw_args`` ``--bind`` / ``APPTAINER_BIND*`` env)
+    or the ``--pwd`` realpath-resolves under a forbidden shared-filesystem
+    prefix (``/data/gpfs`` / ``/data/scratch`` / ``/home``). Fail-loud,
+    before exec; the spec cannot opt it back off for a solver."""
+
+    nested_build: bool = False
+    """Enable NESTED apptainer build/pull from inside the agent container
+    (``runtimes/_apptainer_nested.py``): binds ``/dev/fuse``, masks
+    ``/etc/subuid``+``/etc/subgid`` (→ root-mapped + ``fakeroot``-command
+    build path, no setuid ``newuidmap`` needed), and points
+    ``APPTAINER_TMPDIR``/``CACHEDIR`` at the real-disk ``/tmp``. Lets a
+    solver reproduce a capsule's pinned env — pull a published
+    ``docker://`` image, or build a Dockerfile-derived def whose ``%post``
+    runs as root — then exec it. Composes with ``access: capsule`` (adds
+    no host-FS bind). Size the build scratch via ``tmpfs_size`` (2G default
+    is too small for a multi-GB image). Verified 2026-06-20 in
+    sac-scitex.sif."""
+
+
+__all__ = ["ApptainerSpec"]

--- a/src/scitex_agent_container/config/_parsers/_apptainer.py
+++ b/src/scitex_agent_container/config/_parsers/_apptainer.py
@@ -130,5 +130,10 @@ def parse_apptainer(spec: dict):
         if "tmpfs_size" in raw
         else "2G",
         relaxed=bool(raw.get("relaxed", False)),
+        # JAILED-capsule mount-boundary opt-in (security guardrail — see
+        # runtimes/_apptainer_jail.py). Solver-group specs are jailed
+        # automatically regardless of this flag; other capsule types set
+        # ``jail: true`` to opt in.
+        jail=bool(raw.get("jail", False)),
         nested_build=bool(raw.get("nested_build", False)),
     )

--- a/src/scitex_agent_container/config/_types.py
+++ b/src/scitex_agent_container/config/_types.py
@@ -11,6 +11,10 @@ from typing import Any, Dict
 from ._acl_types import CommsSpec, LineageSpec  # noqa: E402,F401
 from ._provider_types import ProviderSpec
 
+# ApptainerSpec extracted to a sibling module (per-file line cap);
+# re-exported here so ``from ...config._types import ApptainerSpec`` resolves.
+from ._apptainer_spec import ApptainerSpec  # noqa: E402,F401
+
 
 @dataclass
 class ContainerSpec:
@@ -152,135 +156,6 @@ class WatchdogSpec:
 # (consume these fields in _runners.claude_session) lands in phase 2.
 # An ``enabled`` row authored under the schema before phase 2 ships
 # is harmless — the runner just ignores it for now.
-# F-CS18 — apptainer-specific extension hook.
-#
-# Apptainer reads OCI images natively (`apptainer build sif docker://...`),
-# so for the no-extras case spec.image alone is enough — sac just
-# `apptainer build`s the SIF and runs it. For HPC-specific layering
-# (extra pip packages, system libs, env vars), the operator can either:
-#
-#   * declare `spec.apptainer.post` — sac synthesises a `.def` with
-#     `Bootstrap: docker` + `%post` + `%environment` and builds from it.
-#   * declare `spec.apptainer.def_file` — sac runs `apptainer build`
-#     against the operator's hand-written `.def` (full control).
-#
-# All fields are optional; an `apptainer:` block with no fields set is
-# equivalent to none at all.
-@dataclass
-class ApptainerSpec:
-    """Apptainer-specific image-build extensions (F-CS18)."""
-
-    # v3-realign: apptainer-engine-scoped knobs promoted from top-level.
-    image: str = ""
-    """SIF path or docker:// URL — promoted from top-level spec.image (§3).
-    Empty = fall back to the default sac-scitex SIF."""
-
-    binds: list[str] = field(default_factory=list)
-    """Bind mounts as ``host:container[:mode]`` strings — promoted from
-    top-level spec.mounts (§3)."""
-
-    env: dict[str, str] = field(default_factory=dict)
-    """Env vars exported into the container — promoted from top-level
-    spec.env (§3)."""
-
-    raw_args: list[str] = field(default_factory=list)
-    """v3 escape hatch (§1 invariant): appended verbatim to the
-    ``apptainer exec`` argv after all curated args. Lets operators bolt
-    on flags sac doesn't model."""
-
-    container_workdir: str = "/work"
-    """Path inside the container where ``spec.workdir`` gets bind-mounted
-    (and where the runner's ``--pwd`` lands). Default ``/work``.
-    Override when the SIF expects a different mount point (e.g. a
-    pre-baked ``WORKDIR`` in the .def file)."""
-
-    post: str = ""
-    """Shell snippet run inside the SIF build (apptainer's `%post`).
-    Lines are concatenated verbatim. Empty = no extension."""
-
-    environment: dict = field(default_factory=dict)
-    """Env vars baked into the SIF (apptainer's `%environment`). Same
-    shape as ``spec.env`` — KEY: VALUE pairs."""
-
-    def_file: str = ""
-    """Path to a hand-authored ``.def`` file (apptainer's native
-    build language). Mutually exclusive with `post`/`environment`:
-    when set, sac uses this file verbatim and ignores `post`."""
-
-    nv: bool = False
-    """Forward host NVIDIA driver/libs into the container (apptainer's
-    ``--nv``). Required for CUDA workloads on GPU nodes; harmless on
-    CPU-only hosts but only set when needed."""
-
-    rocm: bool = False
-    """Forward host AMD ROCm libs (apptainer's ``--rocm``). Mutually
-    exclusive with ``nv`` in practice (no host has both)."""
-
-    overlay: str = ""
-    """Writable apptainer overlay image (``--overlay <file>``). Empty =
-    no overlay (tmpfs writable layer). Non-absolute paths resolve
-    against ``spec.workdir``. See ``docs/isolation.md`` §7."""
-
-    overlay_size: str = ""
-    """When set together with ``overlay``, sac auto-creates the overlay
-    image with the given size if it doesn't exist before launching.
-    Accepts apptainer-style sizes with units M/MB/G/GB only (e.g.
-    ``"5G"``, ``"500M"``, ``"1024MB"``). K/KB are explicitly rejected —
-    apptainer's ``overlay create --size`` takes integer MB so sub-MB
-    granularity makes no sense. Empty = no auto-create (default;
-    missing overlay raises FileNotFoundError at launch with a clear
-    message). See ``docs/isolation.md`` §7."""
-
-    overlay_create_if_missing: bool = True
-    """When True (default) AND ``overlay_size`` is set AND the overlay
-    path does not exist, sac runs ``apptainer overlay create --size
-    <MB> <path>`` before launching. When False, sac never creates
-    overlays even if size is given (operator must pre-create — sac
-    raises FileNotFoundError instead). See ``docs/isolation.md`` §7."""
-
-    tmpfs_size: str = "2G"
-    """Minimum free-space guarantee for the container's ``/tmp`` (and
-    ``/var/tmp``). A ``--containall`` apptainer container otherwise gets
-    a 64 MB session tmpfs at ``/tmp`` — too small for the full test
-    suite, coverage XML generation, or pytest fixtures with file IO,
-    which fill it mid-run with "No space left on device".
-
-    sac emits ``--workdir <state_dir>/tmp-scratch`` to relocate ``/tmp``
-    onto the host filesystem (capacity >> 64 MB) and verifies that
-    filesystem has at least this many bytes free before launch, failing
-    loud otherwise. Accepts apptainer-style sizes with units M/MB/G/GB
-    only (e.g. ``"2G"``, ``"512M"``, ``"2048MB"``); K/KB rejected.
-
-    NOT a hard cap — an unprivileged apptainer user cannot mount a
-    size-capped tmpfs (``--mount type=tmpfs`` is unsupported), so the
-    contract is "at least this much room", backed by host disk. Set to
-    ``""`` to opt out entirely (legacy 64 MB tmpfs). See
-    ``runtimes/_apptainer_tmpfs.py``."""
-
-    relaxed: bool = False
-    """Opt out of sac's hardened defaults (auto-prepended
-    ``--containall``/``--cleanenv``/``--writable-tmpfs``/``--home``).
-    See ``docs/isolation.md``."""
-
-    fakeroot: bool = False
-    """Apptainer ``--fakeroot`` — uid 0 inside via user-namespace
-    remapping; operator uid on host. Pairs with the D5 preflight's
-    ``/proc/self/uid_map`` detection (see ``docs/isolation.md``)."""
-
-    nested_build: bool = False
-    """Enable NESTED apptainer build/pull from inside the agent container
-    (``runtimes/_apptainer_nested.py``): binds ``/dev/fuse``, masks
-    ``/etc/subuid``+``/etc/subgid`` (→ root-mapped + ``fakeroot``-command
-    build path, no setuid ``newuidmap`` needed), and points
-    ``APPTAINER_TMPDIR``/``CACHEDIR`` at the real-disk ``/tmp``. Lets a
-    solver reproduce a capsule's pinned env — pull a published
-    ``docker://`` image, or build a Dockerfile-derived def whose ``%post``
-    runs as root — then exec it. Composes with ``access: capsule`` (adds
-    no host-FS bind). Size the build scratch via ``tmpfs_size`` (2G default
-    is too small for a multi-GB image). Verified 2026-06-20 in
-    sac-scitex.sif."""
-
-
 @dataclass
 class AutonomousSpec:
     enabled: bool = False

--- a/src/scitex_agent_container/runtimes/_apptainer_build_argv.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_build_argv.py
@@ -364,13 +364,8 @@ def build_run_argv(
     # (apptainer applies user binds after home setup). No-op for
     # non-relaxed / non-directory-overlay specs (resolver returns
     # None) and when the upper-home wasn't materialised.
-    from ._to_home_overlay import (
-        resolve_container_home,
-        resolve_overlay_upper_home,
-    )
-
-    # Reuse the up-front resolution (see the home_backing block above) so
-    # the skip-the-workspace-home decision and this bind agree exactly.
+    # resolve_container_home / resolve_overlay_upper_home already imported at
+    # the top of this function; reuse the up-front resolution.
     upper_home = _upper_home
     if upper_home is not None and upper_home.is_dir():
         container_home = resolve_container_home(config)
@@ -498,6 +493,11 @@ def build_run_argv(
 
         inner_str = " ".join(shlex.quote(a) for a in inner_argv)
         argv += ["bash", "-c", f"{PREFLIGHT_SCRIPT}\nexec {inner_str}"]
+    # Jailed-capsule mount boundary (non-bypassable, fail-loud): forces
+    # --containall + rejects shared-FS binds/--pwd. See _apptainer_jail.
+    from ._apptainer_jail import enforce_jail
+
+    enforce_jail(config, argv)
     return argv
 
 

--- a/src/scitex_agent_container/runtimes/_apptainer_jail.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_jail.py
@@ -46,7 +46,13 @@ resolves under a forbidden prefix is still caught. We deliberately avoid
 
 Prefix matching is PATH-COMPONENT-AWARE (``os.path.commonpath``), so
 ``/homework`` does NOT match the ``/home`` prefix — a bare ``startswith``
-would false-positive.
+would false-positive. A source is refused when it is at/under a forbidden
+prefix OR an ANCESTOR of one: ``--bind /:/host`` or ``--bind /data:/data``
+would mount the whole shared FS (including ``/data/gpfs``) and is strictly
+worse than ``--bind /data/gpfs/x`` — so both directions are caught
+(``commonpath ∈ {source, prefix}``). Disjoint node-local subtrees
+(``/tmp``, ``$TMPDIR/workdir``) share only a higher ancestor equal to
+neither side, so they still pass.
 """
 
 from __future__ import annotations
@@ -130,17 +136,27 @@ def forbidden_prefixes() -> list[str]:
 
 
 def _is_under(realpath: str, prefix: str) -> bool:
-    """Component-aware "is ``realpath`` at or under ``prefix``".
+    """Component-aware "does ``realpath`` intersect the forbidden subtree".
 
-    Uses ``os.path.commonpath`` so ``/homework`` does NOT match the
-    ``/home`` prefix (a bare ``startswith`` would). Both args must be
-    normalised absolute paths.
+    Returns True when ``realpath`` is at/under ``prefix`` (e.g.
+    ``/data/gpfs/x`` vs ``/data/gpfs``) OR an ANCESTOR of ``prefix``
+    (e.g. ``/data`` or ``/`` vs ``/data/gpfs``) — an ancestor bind mounts
+    the ENTIRE shared FS including ``prefix``, so it is strictly worse and
+    must also be refused (HPC reviewer, PR #529). The predicate is
+    ``commonpath ∈ {realpath, prefix}``.
+
+    Uses ``os.path.commonpath`` (path-component-aware) so ``/homework``
+    does NOT match the ``/home`` prefix (a bare ``startswith`` would), and
+    a disjoint node-local subtree (``/tmp``, ``$TMPDIR/workdir``) whose
+    commonpath with ``prefix`` is a shared ancestor equal to NEITHER side
+    still passes. Both args must be normalised absolute paths.
     """
     try:
-        return os.path.commonpath([realpath, prefix]) == prefix
+        cp = os.path.commonpath([realpath, prefix])
     except ValueError:
         # Different roots / a relative path slipped in — no match.
         return False
+    return cp == prefix or cp == realpath
 
 
 def match_forbidden(source: str, prefixes: list[str]) -> tuple[str, str] | None:

--- a/src/scitex_agent_container/runtimes/_apptainer_jail.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_jail.py
@@ -1,0 +1,308 @@
+"""Jailed-capsule mount-boundary assert (HIGH-PRIORITY security guardrail).
+
+A rogue, un-jailed capsule once walked Spartan's shared GPFS with
+``find /`` — a repeat risks losing cluster access. This module enforces,
+at the sac apptainer-launch layer (non-bypassable, BEFORE exec), that a
+"jailed" capsule can NEVER mount a shared / heavy-metadata filesystem. A
+rogue ``find /`` inside a jailed capsule must see only the SIF rootfs +
+node-local binds.
+
+A capsule is JAILED when EITHER:
+
+  * its spec resolves to the ``solver`` named group
+    (``metadata.labels`` → :func:`config._group_resolver.group_from_labels`)
+    — auto-on, non-bypassable; OR
+  * ``spec.apptainer.jail: true`` — opt-in for other capsule types.
+
+For a jailed capsule the launch command-builder ENFORCES, before exec:
+
+  1. ``--containall`` is FORCED into the argv (drops apptainer's default
+     ``$HOME`` / ``$PWD`` / ``/tmp`` auto-binds) — added if absent, even
+     under ``relaxed``.
+  2. Every operator-controlled bind SOURCE is ``os.path.realpath``-resolved
+     (to catch symlinks that point a benign-looking path at a shared FS —
+     e.g. ``~/.cache -> /data/gpfs/...``) and REFUSED if it resolves under
+     a forbidden shared-FS prefix. Sources checked:
+       * ``spec.apptainer.binds`` entries,
+       * ``spec.apptainer.raw_args`` ``--bind`` / ``-B`` entries,
+       * the ``APPTAINER_BIND`` / ``SINGULARITY_BIND`` /
+         ``APPTAINER_BINDPATH`` / ``SINGULARITY_BINDPATH`` env vars
+         (``--containall`` drops apptainer's *default* auto-binds but an
+         env var can RE-ADD one that the explicit-args check would miss).
+  3. The ``--pwd`` (effective cwd / workdir) is realpath-checked the same
+     way.
+
+Failure is FAIL-LOUD: a :class:`RuntimeError` naming the offending bind,
+its realpath, and the matched prefix — never a silent strip. The assert
+is NON-BYPASSABLE (the spec cannot opt it off).
+
+``realpath`` tolerates a not-yet-existing bind source: node-local sources
+like ``$TMPDIR/workdir`` are created AT launch, so the leaf may be absent
+when this runs. ``os.path.realpath`` resolves the existing parent chain
+(following symlinks) and appends the missing leaf WITHOUT failing — so a
+missing leaf launches cleanly while a symlinked existing parent that
+resolves under a forbidden prefix is still caught. We deliberately avoid
+``Path.resolve(strict=True)`` / ``os.stat`` which require existence.
+
+Prefix matching is PATH-COMPONENT-AWARE (``os.path.commonpath``), so
+``/homework`` does NOT match the ``/home`` prefix — a bare ``startswith``
+would false-positive.
+"""
+
+from __future__ import annotations
+
+import os
+
+__all__ = [
+    "DEFAULT_FORBIDDEN_PREFIXES",
+    "ENV_BIND_VARS",
+    "FORBIDDEN_PREFIXES_ENV",
+    "SOLVER_GROUP",
+    "enforce_jail",
+    "forbidden_prefixes",
+    "is_jailed",
+    "match_forbidden",
+    "scrub_bind_env",
+]
+
+# The named group that auto-triggers the jail (non-bypassable).
+SOLVER_GROUP = "solver"
+
+# Forbidden shared / heavy-metadata filesystem prefixes. A jailed
+# capsule's bind sources (realpath-resolved) must not land under any of
+# these. Override via ``SAC_JAIL_FORBIDDEN_PREFIXES`` (os.pathsep-separated
+# — i.e. ``:``-separated on POSIX) for site-specific mount layouts.
+DEFAULT_FORBIDDEN_PREFIXES: tuple[str, ...] = (
+    "/data/gpfs",
+    "/data/scratch",
+    "/home",
+)
+FORBIDDEN_PREFIXES_ENV = "SAC_JAIL_FORBIDDEN_PREFIXES"
+
+# Env vars apptainer/singularity read to ADD binds even under
+# ``--containall``. Validated (fail-loud) AND scrubbed for a jailed
+# capsule so no env-injected bind survives.
+ENV_BIND_VARS: tuple[str, ...] = (
+    "APPTAINER_BIND",
+    "SINGULARITY_BIND",
+    "APPTAINER_BINDPATH",
+    "SINGULARITY_BINDPATH",
+)
+
+
+# ----------------------------------------------------------------------
+# Trigger detection
+# ----------------------------------------------------------------------
+def is_jailed(config) -> bool:
+    """Return True iff ``config`` describes a jailed capsule.
+
+    Jailed when EITHER the resolved named group is ``solver`` (auto-on,
+    non-bypassable) OR ``spec.apptainer.jail`` is truthy (opt-in).
+    """
+    ap = getattr(config, "apptainer", None)
+    if ap is not None and bool(getattr(ap, "jail", False)):
+        return True
+    labels = getattr(config, "labels", None)
+    try:
+        from ..config._group_resolver import group_from_labels
+
+        grp = group_from_labels(labels)
+    except Exception:
+        grp = ""
+    return str(grp).strip().lower() == SOLVER_GROUP
+
+
+# ----------------------------------------------------------------------
+# Prefix resolution + component-aware match
+# ----------------------------------------------------------------------
+def forbidden_prefixes() -> list[str]:
+    """Return the normalised forbidden shared-FS prefixes.
+
+    Honours the ``SAC_JAIL_FORBIDDEN_PREFIXES`` override (os.pathsep-
+    separated); falls back to :data:`DEFAULT_FORBIDDEN_PREFIXES`.
+    """
+    raw = os.environ.get(FORBIDDEN_PREFIXES_ENV, "").strip()
+    if raw:
+        parts = [p for p in raw.split(os.pathsep) if p.strip()]
+    else:
+        parts = list(DEFAULT_FORBIDDEN_PREFIXES)
+    return [os.path.normpath(p) for p in parts]
+
+
+def _is_under(realpath: str, prefix: str) -> bool:
+    """Component-aware "is ``realpath`` at or under ``prefix``".
+
+    Uses ``os.path.commonpath`` so ``/homework`` does NOT match the
+    ``/home`` prefix (a bare ``startswith`` would). Both args must be
+    normalised absolute paths.
+    """
+    try:
+        return os.path.commonpath([realpath, prefix]) == prefix
+    except ValueError:
+        # Different roots / a relative path slipped in — no match.
+        return False
+
+
+def match_forbidden(source: str, prefixes: list[str]) -> tuple[str, str] | None:
+    """Realpath ``source`` and return ``(realpath, matched_prefix)`` if it
+    lands under any forbidden ``prefixes``, else ``None``.
+
+    ``os.path.realpath`` resolves symlinks in the existing parent chain
+    and tolerates a missing leaf (no ``strict=True`` / ``stat``), so a
+    not-yet-created node-local source resolves cleanly.
+    """
+    if not source:
+        return None
+    rp = os.path.realpath(source)
+    for pref in prefixes:
+        if _is_under(rp, pref):
+            return rp, pref
+    return None
+
+
+# ----------------------------------------------------------------------
+# Bind-spec parsing
+# ----------------------------------------------------------------------
+def _bind_source(bind_spec: str) -> str:
+    """Host source (part before the first ``:``) of a bind spec."""
+    return str(bind_spec).split(":", 1)[0].strip()
+
+
+def _split_bind_specs(value: str) -> list[str]:
+    """Split a comma-separated ``--bind`` value into individual specs."""
+    return [s for s in str(value).split(",") if s.strip()]
+
+
+def _raw_args_bind_sources(raw_args) -> list[str]:
+    """Bind sources declared via ``--bind`` / ``-B`` in ``raw_args``.
+
+    Handles the space-separated (``--bind X``), ``=`` (``--bind=X``,
+    ``-B=X``), attached (``-BX``) and comma-multiplexed (``--bind a:b,c:d``)
+    forms.
+    """
+    out: list[str] = []
+    args = [str(a) for a in (raw_args or [])]
+    i = 0
+    while i < len(args):
+        a = args[i]
+        val: str | None = None
+        if a in ("--bind", "-B"):
+            if i + 1 < len(args):
+                val = args[i + 1]
+                i += 1
+        elif a.startswith("--bind="):
+            val = a[len("--bind=") :]
+        elif a.startswith("-B="):
+            val = a[len("-B=") :]
+        elif a.startswith("-B") and len(a) > 2:
+            val = a[2:]
+        if val:
+            out.extend(_bind_source(s) for s in _split_bind_specs(val))
+        i += 1
+    return out
+
+
+def _pwd_value(argv: list[str]) -> str | None:
+    """The ``--pwd`` value in ``argv`` (space or ``=`` form), or None."""
+    for i, a in enumerate(argv):
+        if a == "--pwd" and i + 1 < len(argv):
+            return argv[i + 1]
+        if a.startswith("--pwd="):
+            return a[len("--pwd=") :]
+    return None
+
+
+def _env_bind_sources(env) -> list[tuple[str, str]]:
+    """``(var, source)`` for every bind declared in the bind env vars."""
+    out: list[tuple[str, str]] = []
+    for var in ENV_BIND_VARS:
+        val = env.get(var, "")
+        if not val:
+            continue
+        for spec in _split_bind_specs(val):
+            out.append((var, _bind_source(spec)))
+    return out
+
+
+# ----------------------------------------------------------------------
+# Env scrub (launch environment)
+# ----------------------------------------------------------------------
+def scrub_bind_env(env: dict) -> None:
+    """Remove the bind env vars from ``env`` in place.
+
+    Belt-and-suspenders alongside :func:`enforce_jail`'s fail-loud
+    validation: for a jailed capsule NO env-injected bind may survive, so
+    the launch environment is stripped of these vars entirely (even
+    benign ones) before exec.
+    """
+    for var in ENV_BIND_VARS:
+        env.pop(var, None)
+
+
+# ----------------------------------------------------------------------
+# Enforcement
+# ----------------------------------------------------------------------
+def _refuse(name, label, source, realpath, prefix, prefixes) -> RuntimeError:
+    return RuntimeError(
+        f"JAILED capsule {name!r}: REFUSING to launch — {label} has host "
+        f"source {source!r} which realpath-resolves to {realpath!r}, under "
+        f"the forbidden shared-filesystem prefix {prefix!r}. A jailed "
+        "capsule (solver group, or spec.apptainer.jail=true) must NEVER "
+        "mount a shared / heavy-metadata filesystem "
+        f"(forbidden prefixes: {prefixes}). This assert is non-bypassable "
+        "and fail-loud. Rebind the mount to a node-local path "
+        "(e.g. under $TMPDIR)."
+    )
+
+
+def enforce_jail(config, argv: list[str], *, env=None) -> None:
+    """Enforce the jailed-capsule mount boundary on ``argv`` in place.
+
+    No-op for a non-jailed capsule. For a jailed one:
+
+      * FORCES ``--containall`` into ``argv`` if absent (inserted right
+        after ``apptainer exec``);
+      * realpath-checks every operator-controlled bind source
+        (spec binds + raw_args ``--bind`` + the bind env vars) and the
+        ``--pwd`` against the forbidden prefixes, raising a fail-loud
+        :class:`RuntimeError` on the first hit.
+
+    ``env`` defaults to ``os.environ``; pass a dict in tests.
+    """
+    if not is_jailed(config):
+        return
+    if env is None:
+        env = os.environ
+    name = getattr(config, "name", "<unknown>")
+    prefixes = forbidden_prefixes()
+
+    # 1. Force --containall (drops default $HOME/$PWD/tmp auto-binds).
+    if "--containall" not in argv:
+        insert_at = 2 if argv[:2] == ["apptainer", "exec"] else 0
+        argv.insert(insert_at, "--containall")
+
+    # 2. Collect every operator-controlled bind source.
+    ap = getattr(config, "apptainer", None)
+    checks: list[tuple[str, str]] = []
+    for b in (getattr(ap, "binds", None) or []) if ap is not None else []:
+        checks.append((f"spec.apptainer.binds entry {b!r}", _bind_source(str(b))))
+    raw_args = getattr(ap, "raw_args", None) if ap is not None else None
+    for src in _raw_args_bind_sources(raw_args):
+        checks.append((f"raw_args --bind {src!r}", src))
+    for var, src in _env_bind_sources(env):
+        checks.append((f"${var} bind {src!r}", src))
+
+    for label, source in checks:
+        hit = match_forbidden(source, prefixes)
+        if hit is not None:
+            rp, pref = hit
+            raise _refuse(name, label, source, rp, pref, prefixes)
+
+    # 3. --pwd / effective workdir.
+    pwd = _pwd_value(argv)
+    if pwd is None:
+        pwd = str(getattr(config, "workdir", "") or "")
+    hit = match_forbidden(pwd, prefixes)
+    if hit is not None:
+        rp, pref = hit
+        raise _refuse(name, f"--pwd {pwd!r}", pwd, rp, pref, prefixes)

--- a/src/scitex_agent_container/runtimes/_apptainer_runtime.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_runtime.py
@@ -213,6 +213,17 @@ class ApptainerContainerRuntime(RuntimeBase):
 
         launch_env = {**os.environ, **host_cargo_bin_append_env(os.environ)}
 
+        # Jailed-capsule guardrail: strip the apptainer/singularity bind
+        # env vars from the launch environment so NO env-injected bind
+        # survives (--containall drops apptainer's DEFAULT auto-binds but
+        # not an APPTAINER_BIND-injected one). build_run_argv already
+        # fail-loud-rejects a forbidden env bind before we get here; this
+        # scrub is the belt-and-suspenders removal for a jailed capsule.
+        from ._apptainer_jail import is_jailed, scrub_bind_env
+
+        if is_jailed(config):
+            scrub_bind_env(launch_env)
+
         if foreground:
             return subprocess.run(argv, env=launch_env).returncode == 0
 

--- a/tests/scitex_agent_container/runtimes/test__apptainer_jail.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_jail.py
@@ -170,6 +170,33 @@ def test_jailed_spec_binds_gpfs_scratch_refused(tmp_path: Path) -> None:
         _build(cfg, tmp_path)
 
 
+def test_jailed_root_bind_ancestor_refused(tmp_path: Path) -> None:
+    # Arrange — `--bind /:/host` mounts the WHOLE FS (incl. /data/gpfs),
+    # strictly worse than binding /data/gpfs directly. An ANCESTOR of a
+    # forbidden prefix must be refused too.
+    cfg = _solver_cfg(
+        tmp_path / "wd",
+        apptainer=ApptainerSpec(raw_args=["--bind", "/:/host"]),
+    )
+    # Act
+    # Assert
+    with pytest.raises(RuntimeError, match="forbidden"):
+        _build(cfg, tmp_path)
+
+
+def test_jailed_data_parent_bind_ancestor_refused(tmp_path: Path) -> None:
+    # Arrange — `--bind /data:/data` is an ancestor of /data/gpfs and
+    # /data/scratch; mounting it exposes both. Must be refused.
+    cfg = _solver_cfg(
+        tmp_path / "wd",
+        apptainer=ApptainerSpec(binds=["/data:/data"]),
+    )
+    # Act
+    # Assert
+    with pytest.raises(RuntimeError, match="forbidden"):
+        _build(cfg, tmp_path)
+
+
 # ---------------------------------------------------------------------------
 # (b) symlinked source resolving under /data/gpfs → rejected (realpath)
 # ---------------------------------------------------------------------------

--- a/tests/scitex_agent_container/runtimes/test__apptainer_jail.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_jail.py
@@ -1,0 +1,404 @@
+"""Tests for the jailed-capsule mount-boundary assert
+(:mod:`runtimes._apptainer_jail`).
+
+Security guardrail: a jailed capsule (``solver`` group auto-on, or
+``spec.apptainer.jail=true``) must NEVER mount a shared / heavy-metadata
+filesystem. The launch command-builder FORCES ``--containall`` and
+REFUSES (fail-loud, before exec) any bind whose realpath-resolved source
+lands under a forbidden prefix.
+
+No mocks / no ``monkeypatch`` — real ``AgentConfig`` specs, real
+``build_run_argv`` argv assembly, real on-disk symlinks (``tmp_path``) to
+prove realpath resolution, and a real ``os.environ`` set/restore fixture
+for the env-injection cases. Assertions are on the built argv / the
+raised error, never a live apptainer run.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+from typing import Callable
+
+import pytest
+
+from scitex_agent_container.config import AgentConfig
+from scitex_agent_container.config._types import ApptainerSpec
+from scitex_agent_container.runtimes import _apptainer_jail as jail
+from scitex_agent_container.runtimes._apptainer_jail import (
+    ENV_BIND_VARS,
+    enforce_jail,
+    is_jailed,
+    scrub_bind_env,
+)
+from scitex_agent_container.runtimes._apptainer_runtime import (
+    ApptainerContainerRuntime,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+@pytest.fixture(autouse=True)
+def _isolate_bind_env():
+    """Clear ambient apptainer bind / prefix-override env vars per test.
+
+    sac may run INSIDE a container that already exports ``APPTAINER_BIND``
+    (e.g. its own ``~/.scitex/todo`` bind) — real ``os.environ`` state
+    that would otherwise leak into ``enforce_jail`` and make these tests
+    non-deterministic. Snapshot + pop before each test, restore after.
+    No mocks: real environment mutation with real teardown.
+    """
+    keys = list(ENV_BIND_VARS) + [jail.FORBIDDEN_PREFIXES_ENV]
+    saved = {k: os.environ.get(k) for k in keys}
+    for k in keys:
+        os.environ.pop(k, None)
+    yield
+    for k, original in saved.items():
+        if original is None:
+            os.environ.pop(k, None)
+        else:
+            os.environ[k] = original
+
+
+@pytest.fixture
+def env_set() -> Callable[[str, str], None]:
+    """Set real ``os.environ`` keys, restoring originals on teardown.
+
+    A no-mocks replacement for ``monkeypatch.setenv`` — production reads
+    the real environment.
+    """
+    saved: dict[str, str | None] = {}
+
+    def _set(key: str, value: str) -> None:
+        if key not in saved:
+            saved[key] = os.environ.get(key)
+        os.environ[key] = value
+
+    yield _set
+
+    for key, original in saved.items():
+        if original is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = original
+
+
+def _solver_cfg(workdir, **kw) -> AgentConfig:
+    """A jailed-by-group config (metadata.labels.groups: [solver])."""
+    return AgentConfig(
+        name=kw.pop("name", "solver-x"),
+        runtime="apptainer",
+        workdir=str(workdir),
+        labels=kw.pop("labels", {"groups": ["solver"]}),
+        **kw,
+    )
+
+
+def _build(cfg: AgentConfig, tmp_path: Path) -> list[str]:
+    rt = ApptainerContainerRuntime()
+    return rt.build_run_argv(
+        cfg, state_dir=tmp_path / "state", sif_path=tmp_path / "x.sif"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Trigger detection
+# ---------------------------------------------------------------------------
+def test_solver_group_is_jailed(tmp_path: Path) -> None:
+    # Arrange
+    cfg = _solver_cfg(tmp_path / "wd")
+    # Act
+    jailed = is_jailed(cfg)
+    # Assert
+    assert jailed is True
+
+
+def test_jail_flag_is_jailed(tmp_path: Path) -> None:
+    # Arrange
+    cfg = AgentConfig(
+        name="j",
+        runtime="apptainer",
+        workdir=str(tmp_path),
+        apptainer=ApptainerSpec(jail=True),
+    )
+    # Act
+    jailed = is_jailed(cfg)
+    # Assert
+    assert jailed is True
+
+
+def test_non_solver_non_jail_is_not_jailed(tmp_path: Path) -> None:
+    # Arrange
+    cfg = AgentConfig(
+        name="dev",
+        runtime="apptainer",
+        workdir=str(tmp_path),
+        labels={"groups": ["developer"]},
+    )
+    # Act
+    jailed = is_jailed(cfg)
+    # Assert
+    assert jailed is False
+
+
+# ---------------------------------------------------------------------------
+# (a) jailed spec with a raw_args --bind /data/gpfs → fail-loud
+# ---------------------------------------------------------------------------
+def test_jailed_raw_args_gpfs_bind_refused(tmp_path: Path) -> None:
+    # Arrange
+    cfg = _solver_cfg(
+        tmp_path / "wd",
+        apptainer=ApptainerSpec(raw_args=["--bind", "/data/gpfs/proj:/x"]),
+    )
+    # Act
+    # Assert
+    with pytest.raises(RuntimeError, match=re.escape("/data/gpfs/proj")):
+        _build(cfg, tmp_path)
+
+
+def test_jailed_spec_binds_gpfs_scratch_refused(tmp_path: Path) -> None:
+    # Arrange
+    cfg = _solver_cfg(
+        tmp_path / "wd",
+        apptainer=ApptainerSpec(binds=["/data/scratch/data:/data:ro"]),
+    )
+    # Act
+    # Assert
+    with pytest.raises(RuntimeError, match=re.escape("/data/scratch/data")):
+        _build(cfg, tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# (b) symlinked source resolving under /data/gpfs → rejected (realpath)
+# ---------------------------------------------------------------------------
+def test_jailed_symlinked_source_realpath_refused(tmp_path: Path) -> None:
+    # Arrange — a benign-looking source under tmp_path that is actually a
+    # symlink to /data/gpfs. Only realpath (not a textual check) catches
+    # it; the link target need not exist (realpath resolves the string).
+    link = tmp_path / "cache"
+    link.symlink_to("/data/gpfs")
+    cfg = _solver_cfg(
+        tmp_path / "wd",
+        apptainer=ApptainerSpec(binds=[f"{link}/sub:/x"]),
+    )
+    # Act
+    # Assert — the message names the realpath, not the benign link.
+    with pytest.raises(RuntimeError, match=re.escape("/data/gpfs/sub")):
+        _build(cfg, tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# (c) /homework near-miss → NOT rejected (component-aware match)
+# ---------------------------------------------------------------------------
+def test_jailed_homework_near_miss_allowed(tmp_path: Path) -> None:
+    # Arrange — /homework must NOT match the /home forbidden prefix.
+    cfg = _solver_cfg(
+        tmp_path / "wd",
+        apptainer=ApptainerSpec(binds=["/homework/mine:/x"]),
+    )
+    # Act
+    argv = _build(cfg, tmp_path)
+    # Assert
+    assert "--containall" in argv
+
+
+# ---------------------------------------------------------------------------
+# (d) clean jailed spec (node-local bind) → launches, --containall present
+# ---------------------------------------------------------------------------
+def test_jailed_node_local_bind_launches_with_containall(tmp_path: Path) -> None:
+    # Arrange
+    node_local = tmp_path / "nl"
+    node_local.mkdir()
+    cfg = _solver_cfg(
+        tmp_path / "wd",
+        apptainer=ApptainerSpec(binds=[f"{node_local}:/work:rw"]),
+    )
+    # Act
+    argv = _build(cfg, tmp_path)
+    # Assert
+    assert "--containall" in argv
+
+
+def test_jailed_relaxed_still_forces_containall(tmp_path: Path) -> None:
+    # Arrange — relaxed=true normally SKIPS the hardened --containall; the
+    # jail assert FORCES it back regardless (non-bypassable).
+    node_local = tmp_path / "nl"
+    node_local.mkdir()
+    cfg = _solver_cfg(
+        tmp_path / "wd",
+        apptainer=ApptainerSpec(relaxed=True, binds=[f"{node_local}:/work:rw"]),
+    )
+    # Act
+    argv = _build(cfg, tmp_path)
+    # Assert
+    assert "--containall" in argv
+
+
+# ---------------------------------------------------------------------------
+# (e) --pwd under /home → rejected
+# ---------------------------------------------------------------------------
+def test_jailed_pwd_under_home_refused(tmp_path: Path) -> None:
+    # Arrange
+    cfg = _solver_cfg("/home/someuser/proj")
+    # Act
+    # Assert
+    with pytest.raises(RuntimeError, match=re.escape("/home/someuser/proj")):
+        _build(cfg, tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# (f) non-jailed non-solver agent with a /data/gpfs bind → NOT rejected
+# ---------------------------------------------------------------------------
+def test_non_jailed_gpfs_bind_unaffected(tmp_path: Path) -> None:
+    # Arrange
+    cfg = AgentConfig(
+        name="full",
+        runtime="apptainer",
+        workdir=str(tmp_path / "wd"),
+        labels={"groups": ["developer"]},
+        apptainer=ApptainerSpec(binds=["/data/gpfs/proj:/data:ro"]),
+    )
+    # Act
+    argv = _build(cfg, tmp_path)
+    # Assert
+    assert "/data/gpfs/proj:/data:ro" in argv
+
+
+# ---------------------------------------------------------------------------
+# (g) missing-leaf node-local source → launches (realpath tolerates it)
+# ---------------------------------------------------------------------------
+def test_jailed_missing_leaf_source_launches(tmp_path: Path) -> None:
+    # Arrange — $TMPDIR/workdir is created AT launch, so the leaf is absent
+    # when the assert runs. realpath resolves the existing parent + appends
+    # the missing leaf WITHOUT failing.
+    existing_parent = tmp_path / "tmpdir"
+    existing_parent.mkdir()
+    missing = existing_parent / "workdir"  # deliberately not created
+    cfg = _solver_cfg(
+        tmp_path / "wd",
+        apptainer=ApptainerSpec(binds=[f"{missing}:/work:rw"]),
+    )
+    # Act
+    argv = _build(cfg, tmp_path)
+    # Assert
+    assert "--containall" in argv
+
+
+def test_jailed_missing_leaf_over_gpfs_symlink_still_refused(tmp_path: Path) -> None:
+    # Arrange — a missing leaf whose EXISTING parent is a symlink to
+    # /data/gpfs must still be caught (realpath resolves the parent).
+    link = tmp_path / "cache"
+    link.symlink_to("/data/gpfs")
+    cfg = _solver_cfg(
+        tmp_path / "wd",
+        apptainer=ApptainerSpec(binds=[f"{link}/not-yet-created:/x"]),
+    )
+    # Act
+    # Assert
+    with pytest.raises(RuntimeError, match=re.escape("/data/gpfs/not-yet-created")):
+        _build(cfg, tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# (h) env-injected bind vars → rejected fail-loud + scrubbed
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("var", list(ENV_BIND_VARS))
+def test_jailed_env_injected_gpfs_bind_refused(
+    tmp_path: Path, env_set: Callable[[str, str], None], var: str
+) -> None:
+    # Arrange
+    env_set(var, "/data/gpfs/x:/x")
+    cfg = _solver_cfg(tmp_path / "wd")
+    # Act
+    # Assert — the message names both the env var and the offending path.
+    with pytest.raises(RuntimeError, match=re.escape(var) + r".*" + re.escape("/data/gpfs/x")):
+        _build(cfg, tmp_path)
+
+
+def test_scrub_bind_env_removes_bind_vars() -> None:
+    # Arrange
+    env = {v: "/data/gpfs/x:/x" for v in ENV_BIND_VARS}
+    # Act
+    scrub_bind_env(env)
+    # Assert
+    assert not any(v in env for v in ENV_BIND_VARS)
+
+
+def test_scrub_bind_env_keeps_unrelated_vars() -> None:
+    # Arrange
+    env = {"KEEP": "1", "APPTAINER_BIND": "/data/gpfs/x:/x"}
+    # Act
+    scrub_bind_env(env)
+    # Assert
+    assert env == {"KEEP": "1"}
+
+
+def test_non_jailed_env_bind_unaffected(
+    tmp_path: Path, env_set: Callable[[str, str], None]
+) -> None:
+    # Arrange
+    env_set("APPTAINER_BIND", "/data/gpfs/x:/x")
+    cfg = AgentConfig(
+        name="full",
+        runtime="apptainer",
+        workdir=str(tmp_path / "wd"),
+        labels={"groups": ["developer"]},
+    )
+    # Act
+    argv = _build(cfg, tmp_path)
+    # Assert — non-jailed builds normally (no raise); argv is well-formed.
+    assert argv[0:2] == ["apptainer", "exec"]
+
+
+# ---------------------------------------------------------------------------
+# Configurable forbidden-prefix override (component-aware, realpath)
+# ---------------------------------------------------------------------------
+def test_forbidden_prefix_env_override(
+    tmp_path: Path, env_set: Callable[[str, str], None]
+) -> None:
+    # Arrange — point the forbidden set at a real tmp dir; a symlink
+    # resolving there is rejected, proving the override + realpath on an
+    # EXISTING target.
+    fake_shared = tmp_path / "shared_fs"
+    fake_shared.mkdir()
+    env_set(jail.FORBIDDEN_PREFIXES_ENV, str(fake_shared))
+    link = tmp_path / "innocent"
+    link.symlink_to(fake_shared)
+    cfg = _solver_cfg(
+        tmp_path / "wd",
+        apptainer=ApptainerSpec(binds=[f"{link}/data:/x"]),
+    )
+    # Act
+    # Assert
+    with pytest.raises(RuntimeError, match=re.escape(str(fake_shared))):
+        _build(cfg, tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# enforce_jail unit surface (env passed explicitly)
+# ---------------------------------------------------------------------------
+def test_enforce_jail_noop_for_non_jailed() -> None:
+    # Arrange
+    cfg = AgentConfig(name="d", runtime="apptainer", workdir="/tmp/wd")
+    argv = ["apptainer", "exec", "--bind", "/data/gpfs/x:/x", "img.sif", "cmd"]
+    # Act
+    enforce_jail(cfg, argv, env={})
+    # Assert — not jailed → no --containall injected, no raise.
+    assert "--containall" not in argv
+
+
+def test_enforce_jail_forces_containall_insertion() -> None:
+    # Arrange
+    cfg = AgentConfig(
+        name="s",
+        runtime="apptainer",
+        workdir="/tmp/wd",
+        labels={"groups": ["solver"]},
+    )
+    argv = ["apptainer", "exec", "--pwd", "/tmp/wd", "img.sif", "cmd"]
+    # Act
+    enforce_jail(cfg, argv, env={})
+    # Assert
+    assert argv[:3] == ["apptainer", "exec", "--containall"]


### PR DESCRIPTION
## Why
HIGH-PRIORITY security guardrail. A un-jailed capsule once walked Spartan's shared GPFS with `find /`; a repeat risks losing cluster access. This enforces, at the non-bypassable sac apptainer-launch layer, that a "jailed" capsule can NEVER mount a shared / heavy-metadata filesystem — a rogue `find /` inside sees only the SIF rootfs + node-local binds.

## Trigger (a capsule is JAILED when EITHER)
- its spec resolves to the **`solver` named group** (`metadata.labels` → `config._group_resolver.group_from_labels`) — **auto-on, non-bypassable**; OR
- **`spec.apptainer.jail: true`** — opt-in for other capsule types.

## Enforcement (fail-loud, before exec)
Implemented in `runtimes/_apptainer_jail.enforce_jail`, called at the end of `_apptainer_build_argv.build_run_argv` — the **single choke point** every launch path funnels through (SDK `start`, TUI, `dry-run`), so the assert cannot be side-stepped.

1. **Force `--containall`** — added if absent, even under `relaxed` (drops apptainer's default `$HOME`/`$PWD`/`/tmp` auto-binds).
2. **Forbidden shared-FS prefixes** (module-level constant, configurable via `SAC_JAIL_FORBIDDEN_PREFIXES`): `/data/gpfs`, `/data/scratch`, `/home`.
3. **realpath + reject every operator-controlled bind source** — `spec.apptainer.binds`, `raw_args` `--bind`/`-B`, and the `APPTAINER_BIND` / `SINGULARITY_BIND` / `APPTAINER_BINDPATH` / `SINGULARITY_BINDPATH` env vars. Each source is `os.path.realpath()`-resolved (so a symlink like `~/.cache -> /data/gpfs` is caught) and refused with a `RuntimeError` naming the offending bind, its realpath, and the matched prefix. A **missing leaf** is tolerated (`$TMPDIR/workdir`, created at launch, still launches — realpath resolves the existing parent chain and appends the missing leaf without `stat`).
4. **realpath the `--pwd`** / effective workdir; refuse if forbidden.
5. **Scrub** the bind env vars from the child launch env in `_apptainer_runtime.start` (belt-and-suspenders alongside the fail-loud validation, so no env-injected bind survives even benignly).

## realpath / matching care
- realpath is applied to **both** the bind source and `--pwd` before prefix-matching (symlinks can point a benign-looking path at GPFS).
- Prefix matching is **path-component-aware** via `os.path.commonpath`, so `/homework` does **not** match the `/home` prefix.

## Non-bypassable + non-jailed unaffected
- A solver spec cannot opt the assert off. `spec.apptainer.jail=true` is the opt-in for non-solver types; a solver is jailed regardless of the flag.
- Non-jailed, non-solver agents are entirely unaffected — existing behavior, no new restriction (a "full" agent may still bind `/data/gpfs` and `/home`).

## Files / functions
- **new** `runtimes/_apptainer_jail.py` — `is_jailed`, `enforce_jail`, `forbidden_prefixes`, `match_forbidden` (component-aware), `scrub_bind_env`, constants.
- `runtimes/_apptainer_build_argv.py` — `build_run_argv` now calls `enforce_jail(config, argv)` as its final step (the argv-builder hook).
- `runtimes/_apptainer_runtime.py` — `start()` scrubs bind env vars from `launch_env` for jailed capsules.
- **new** `config/_apptainer_spec.py` — `ApptainerSpec` extracted from `config/_types.py` (re-exported) to add the `jail` field and bring the pre-existing over-cap `_types.py` back under the 512-line limit.
- `config/_parsers/_apptainer.py` — parses `apptainer.jail`.
- **new** `tests/scitex_agent_container/runtimes/test__apptainer_jail.py` — 23 tests, no mocks / no `monkeypatch`, real tmp symlinks.

## Tests
All six brief scenarios (gpfs bind rejected, symlink-resolves-to-gpfs rejected, `/homework` near-miss allowed, clean node-local jailed spec launches with `--containall`, `--pwd` under `/home` rejected, non-jailed gpfs bind unaffected) plus missing-leaf tolerance, env-injected binds (parametrized over all 4 vars), env scrub, and the configurable-prefix override. Assertions are on the built argv / raised error, never a live apptainer run. Full apptainer + config suites: **805 passed**; new jail suite: **23 passed**.

Note surfaced during testing: this container's ambient env exports `APPTAINER_BIND=/home/agent/.scitex/todo`; the guardrail correctly flags it (proving the env-injection path works). Tests isolate ambient bind vars via a real set/restore fixture.

Do **not** merge.
