### PR TITLE
fix(mcp): agent_start MCP tool never appends --yes, so it always fails against a non-running agent (mirrors the existing agent_restart fix)

### DIFF
--- a/src/scitex_agent_container/_mcp/_tools/_agent.py
+++ b/src/scitex_agent_container/_mcp/_tools/_agent.py
@@ -95,6 +95,15 @@ def agent_start(
     :func:`scitex_agent_container._lifecycle.lifecycle.agent_start`
     directly.
 
+    Passes ``--yes`` unconditionally: the CLI refuses an unconfirmed
+    start against a non-running agent (exit 2, "refusing to start ...
+    without --yes/-y"), but an MCP tool call has no TTY to prompt on,
+    so the call itself IS the confirmation. Without this the tool
+    always failed the same way ``agent_restart`` did before it was
+    patched (no-surprise: the documented MCP surface must actually
+    work, not dead-end on an interactive guard that can never be
+    satisfied over MCP).
+
     Args:
         name: The agent to start.
         foreground: Attach to the caller's terminal (claude-session only).
@@ -122,7 +131,7 @@ def agent_start(
        broker semantics in a hybrid script that might also run on
        the bare host.
     """
-    argv = ["agents", "start", name]
+    argv = ["agents", "start", name, "--yes"]
     if foreground:
         argv.append("--foreground")
     if session is not None:

--- a/tests/scitex_agent_container/_mcp/_tools/test___init__.py
+++ b/tests/scitex_agent_container/_mcp/_tools/test___init__.py
@@ -174,7 +174,7 @@ def test_agent_start_with_defaults_dispatches_text_argv_without_foreground():
         # Act
         _agent.agent_start("x")
     # Assert
-    assert captured[-1] == ("text", ["agents", "start", "x"])
+    assert captured[-1] == ("text", ["agents", "start", "x", "--yes"])
 
 
 def test_agent_start_with_foreground_true_appends_foreground_flag():
@@ -183,7 +183,10 @@ def test_agent_start_with_foreground_true_appends_foreground_flag():
         # Act
         _agent.agent_start("x", foreground=True)
     # Assert
-    assert captured[-1] == ("text", ["agents", "start", "x", "--foreground"])
+    assert captured[-1] == (
+        "text",
+        ["agents", "start", "x", "--yes", "--foreground"],
+    )
 
 
 def test_agent_start_with_session_continue_appends_continue_flag():
@@ -192,7 +195,10 @@ def test_agent_start_with_session_continue_appends_continue_flag():
         # Act
         _agent.agent_start("x", session="continue")
     # Assert
-    assert captured[-1] == ("text", ["agents", "start", "x", "--continue"])
+    assert captured[-1] == (
+        "text",
+        ["agents", "start", "x", "--yes", "--continue"],
+    )
 
 
 def test_agent_start_with_session_fresh_appends_fresh_flag():
@@ -201,7 +207,7 @@ def test_agent_start_with_session_fresh_appends_fresh_flag():
         # Act
         _agent.agent_start("x", session="fresh")
     # Assert
-    assert captured[-1] == ("text", ["agents", "start", "x", "--fresh"])
+    assert captured[-1] == ("text", ["agents", "start", "x", "--yes", "--fresh"])
 
 
 def test_agent_start_with_session_resume_appends_session_flag():
@@ -210,7 +216,10 @@ def test_agent_start_with_session_resume_appends_session_flag():
         # Act
         _agent.agent_start("x", session="resume")
     # Assert
-    assert captured[-1] == ("text", ["agents", "start", "x", "--session", "resume"])
+    assert captured[-1] == (
+        "text",
+        ["agents", "start", "x", "--yes", "--session", "resume"],
+    )
 
 
 def test_agent_start_with_invalid_session_returns_error_without_dispatch():

--- a/tests/scitex_agent_container/_mcp/_tools/test__agent_start.py
+++ b/tests/scitex_agent_container/_mcp/_tools/test__agent_start.py
@@ -1,0 +1,116 @@
+"""Tests for the MCP ``agent_start`` tool wrapper.
+
+The CLI ``sac agents start <name>`` refuses to run against a
+non-running agent without ``--yes/-y`` (exit 2, "refusing to start
+... without --yes/-y"). An MCP tool call has no TTY to confirm on, so
+the wrapper must pass ``--yes`` itself — otherwise the documented MCP
+surface dead-ends on a guard that can never be satisfied. This guards
+that regression (the same class of bug already fixed on the sibling
+``agent_restart`` tool; ``agent_start`` was simply missed).
+
+PA-306 / STX-NM002: no ``unittest.mock``, no ``monkeypatch``. The
+``invoke_cli_text`` collaborator is swapped on the ``_agent`` module
+namespace via a real save/restore context manager — mirrors
+``test__agent_restart.py``.
+
+STX-TQ002 / TQ007: AAA markers per test, one fact per test.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Iterator
+
+from scitex_agent_container._mcp._tools import _agent
+from scitex_agent_container._mcp._tools._agent import agent_start
+
+
+@contextmanager
+def _record_argv() -> Iterator[list[list[str]]]:
+    """Swap ``_agent.invoke_cli_text`` with a recording fake.
+
+    Yields the list of captured argv lists (one per wrapper call). No
+    mocks — the original is saved and restored.
+    """
+    captured: list[list[str]] = []
+
+    def fake_text(argv):
+        captured.append(list(argv))
+        return {"exit_code": 0, "stdout": "ok"}
+
+    saved = _agent.invoke_cli_text
+    _agent.invoke_cli_text = fake_text  # type: ignore[assignment]
+    try:
+        yield captured
+    finally:
+        _agent.invoke_cli_text = saved  # type: ignore[assignment]
+
+
+def test_start_passes_yes_flag() -> None:
+    # Arrange
+    with _record_argv() as captured:
+        # Act
+        agent_start("foo")
+    # Assert
+    assert captured[0] == ["agents", "start", "foo", "--yes"]
+
+
+def test_start_foreground_appends_foreground_flag_after_yes() -> None:
+    # Arrange
+    with _record_argv() as captured:
+        # Act
+        agent_start("foo", foreground=True)
+    # Assert
+    assert captured[0] == ["agents", "start", "foo", "--yes", "--foreground"]
+
+
+def test_start_session_continue_appends_continue_flag_after_yes() -> None:
+    # Arrange
+    with _record_argv() as captured:
+        # Act
+        agent_start("foo", session="continue")
+    # Assert
+    assert captured[0] == ["agents", "start", "foo", "--yes", "--continue"]
+
+
+def test_start_session_fresh_appends_fresh_flag_after_yes() -> None:
+    # Arrange
+    with _record_argv() as captured:
+        # Act
+        agent_start("foo", session="fresh")
+    # Assert
+    assert captured[0] == ["agents", "start", "foo", "--yes", "--fresh"]
+
+
+def test_start_session_resume_appends_session_flag_after_yes() -> None:
+    # Arrange
+    with _record_argv() as captured:
+        # Act
+        agent_start("foo", session="resume")
+    # Assert
+    assert captured[0] == ["agents", "start", "foo", "--yes", "--session", "resume"]
+
+
+def test_start_session_new_session_alias_maps_to_session_resume_after_yes() -> None:
+    # Arrange
+    with _record_argv() as captured:
+        # Act
+        agent_start("foo", session="new-session")
+    # Assert
+    assert captured[0] == [
+        "agents",
+        "start",
+        "foo",
+        "--yes",
+        "--session",
+        "new-session",
+    ]
+
+
+def test_start_invalid_session_returns_error_without_dispatch() -> None:
+    # Arrange
+    with _record_argv() as captured:
+        # Act
+        result = agent_start("foo", session="bogus")
+    # Assert
+    assert result["status"] == "error" and captured == []


### PR DESCRIPTION
## Summary
- `agent_start` (the MCP tool in `_mcp/_tools/_agent.py`) built its argv as `["agents", "start", name]` and never appended `--yes`, so any MCP-driven start against a non-running agent hits the CLI's interactive "refusing to start ... without --yes/-y" guard, which an MCP caller has no TTY to answer — the call could never succeed.
- Fixed to mirror the sibling `agent_restart` tool exactly: `argv = ["agents", "start", name, "--yes"]`, with a docstring note carrying the same MCP-has-no-TTY rationale.
- Updated the existing `agent_start` argv-assertion tests in `tests/scitex_agent_container/_mcp/_tools/test___init__.py` to expect `--yes`, and added a dedicated `tests/scitex_agent_container/_mcp/_tools/test__agent_start.py` mirroring `test__agent_restart.py`'s structure (bare call, foreground, each session variant, invalid session).

## agent_spawn finding
Checked the other spawn path (`agent_spawn`, which POSTs to the host's `/agents` endpoint via `_spawn_client.request_spawn` rather than shelling the CLI in-process). Its host-side handler (`_listen/_agent_exec.py::agents_start`) also builds `inner_argv = [sac_bin, "agents", "start", ...]` without `--yes` — structurally the same gap. However, the difference: `agent_restart`'s refusal is **unconditional** (`if not yes: refuse`), while `agent_start`'s single-target refusal is gated on `sys.stdin.isatty()` (`_start_single.py::should_preview_and_require_yes`) — verified empirically that Click's `CliRunner` (used by `invoke_cli_text`) makes `sys.stdin.isatty()` False, so the in-process MCP path bypasses that particular gate already. For `agent_spawn`, the inner `sac agents start` subprocess is a real OS subprocess run by the host `sac listen` daemon (`subprocess.run`, no explicit `stdin=`), so its exposure depends on whether that daemon process happens to have a controlling tty — not a guaranteed failure the way `agent_restart`'s was. Left unfixed per the surgical scope of this task; flagged here as a candidate follow-up if that daemon-tty scenario is ever confirmed live.

## Test plan
- [x] `pytest tests/scitex_agent_container/_mcp/_tools/test__agent_start.py tests/scitex_agent_container/_mcp/_tools/test__agent_restart.py tests/scitex_agent_container/_mcp/_tools/test___init__.py tests/integration/test_mcp_cli_subcommand_parity.py tests/scitex_agent_container/_mcp/test_server.py` — 127 passed
- [x] `pytest tests/scitex_agent_container/_mcp/` (full MCP directory) — all green