### PR TITLE
feat(launch): generic SAC_GIT_* -> GIT_* env alias in the container shell wrapper (values-agnostic; source stays direnv/.envrc-owned)

### DIFF
--- a/src/scitex_agent_container/runtimes/_apptainer_inner_argv.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_inner_argv.py
@@ -4,18 +4,31 @@ Factored out of ``_apptainer_runtime.py`` so adding new ``kind``
 dispatch branches doesn't push the parent module past the 512-line
 cap. Each builder returns the full ``[tini, --, python3, -m, MODULE,
 *args]`` list for one ``kind``.
+
+The interactive-TUI argv/channel-plan helpers (``_tui_runner_argv``,
+``tui_channel_plan``, ``tui_channel_config``, ``resolve_sac_bin_in_sif``,
+``_home_has_resumable_conversation``, ...) live in
+``_apptainer_inner_argv_tui`` (split out 2026-07-05 to stay under the
+512-line cap) and are re-imported below so every existing
+``from scitex_agent_container.runtimes._apptainer_inner_argv import X``
+keeps working unchanged.
 """
 
 from __future__ import annotations
 
-import json
-import os as _os
 import shlex
 from typing import TYPE_CHECKING
 
+from ._apptainer_inner_argv_tui import (  # noqa: F401 (re-export)
+    _home_has_resumable_conversation,
+    _tui_runner_argv,
+    resolve_sac_bin_in_sif,
+    tui_channel_config,
+    tui_channel_plan,
+)
+
 if TYPE_CHECKING:
     from ..config import AgentConfig
-    from ._sdk_channels import ChannelPlan
 
 # Runner-module dispatch by ``config.kind``. Kept here so the parent
 # orchestrator doesn't need to know either runner's module path.
@@ -40,6 +53,31 @@ _TINI_PREFIX = ["/usr/bin/tini", "-s", "--", "python3", "-m"]
 # ``max_retries`` raises the cap above this floor. Auth failures stay
 # terminal regardless (the supervisor short-circuits them).
 _SUPERVISOR_RESTART_FLOOR = 3
+
+
+# Generic, values-agnostic env alias — always prepended as the FIRST
+# shell step (see build_inner_argv), regardless of whether the agent
+# declares any spec.startup_commands. This does not know or care where
+# SAC_GIT_* came from: a project's own ``.envrc`` (direnv ``source_up`` to
+# e.g. ``~/proj/.envrc``) is the actual current source, entirely outside
+# this module's concern. It only mirrors whichever of the 5 SAC_GIT_* vars
+# are ALREADY present in the shell env (by whatever means, once direnv has
+# fired via the login shell's /etc/bash.bashrc hook) onto the literal
+# ``GIT_*`` names git itself reads — because git has no concept of a
+# ``SAC_`` prefix, while the operator wants the canonical/introspectable
+# source-of-truth names to carry it (``printenv | grep SAC_`` shows every
+# sac-relevant var in one shot). ``${VAR:-}`` + ``-n`` guards make an unset
+# SAC_GIT_* a silent no-op — it never overwrites an already-correct GIT_*
+# with an empty string. These lines run BEFORE any ``set -e`` that
+# _format_shell_steps below may emit, so a false ``[ -n ... ]`` (unset var)
+# never aborts the launch.
+_GIT_ENV_ALIAS_STEPS: list[str] = [
+    '[ -n "${SAC_GIT_AUTHOR_NAME:-}" ] && export GIT_AUTHOR_NAME="$SAC_GIT_AUTHOR_NAME"',
+    '[ -n "${SAC_GIT_AUTHOR_EMAIL:-}" ] && export GIT_AUTHOR_EMAIL="$SAC_GIT_AUTHOR_EMAIL"',
+    '[ -n "${SAC_GIT_COMMITTER_NAME:-}" ] && export GIT_COMMITTER_NAME="$SAC_GIT_COMMITTER_NAME"',
+    '[ -n "${SAC_GIT_COMMITTER_EMAIL:-}" ] && export GIT_COMMITTER_EMAIL="$SAC_GIT_COMMITTER_EMAIL"',
+    '[ -n "${SAC_GIT_SSH_COMMAND:-}" ] && export GIT_SSH_COMMAND="$SAC_GIT_SSH_COMMAND"',
+]
 
 
 def _format_shell_steps(cmds: list) -> list[str]:
@@ -73,11 +111,14 @@ def build_inner_argv(
 ) -> list[str]:
     """Return the apptainer-inner argv. Dispatches on ``config.kind``.
 
-    When ``spec.startup_commands`` is non-empty, the argv is wrapped
-    in ``[/bin/bash, -lc, "set -e; <cmd1>; sleep N; <cmd2>; exec <tini ...>"]``
-    so the commands run as container-internal shell BEFORE the claude
-    SDK process starts. ``exec`` replaces bash with tini, keeping PID 1
-    clean. NOT a claude prompt — see ``spec.startup_prompts``.
+    The argv is now ALWAYS wrapped in
+    ``[/bin/bash, -lc, "<git-env-alias>; [set -e; <cmd1>; sleep N; <cmd2>;]
+    exec <tini ...>"]`` — never returned bare. The first steps are the
+    fixed, unconditional :data:`_GIT_ENV_ALIAS_STEPS` (see there); when
+    ``spec.startup_commands`` is also non-empty those follow next, run as
+    container-internal shell BEFORE the claude SDK process starts. ``exec``
+    replaces bash with tini, keeping PID 1 clean. NOT a claude prompt — see
+    ``spec.startup_prompts``.
 
     ``tui=True`` selects the interactive ``claude`` TUI as the inner
     process instead of the ``python -m`` SDK session runner (see
@@ -114,9 +155,10 @@ def build_inner_argv(
         )
 
     startup_cmds = list(getattr(config, "startup_commands", []) or [])
-    shell_steps = _format_shell_steps(startup_cmds)
-    if not shell_steps:
-        return runner_tail
+    # Alias step is unconditional (every agent gets it); startup_cmds steps
+    # follow it when present. This means shell_steps is NEVER empty, so the
+    # bash -lc wrap now ALWAYS happens — see docstring.
+    shell_steps = _GIT_ENV_ALIAS_STEPS + _format_shell_steps(startup_cmds)
 
     quoted_runner = " ".join(shlex.quote(p) for p in runner_tail)
     inline = "; ".join(shell_steps + [f"exec {quoted_runner}"])
@@ -225,332 +267,6 @@ def _agent_runner_argv(config: "AgentConfig", *, one_shot: bool) -> list[str]:
             auto.kick_text,
         ]
     return runner_argv
-
-
-_CLAUDE_TUI_BIN = "claude"
-
-
-def _home_has_resumable_conversation(config: "AgentConfig"):
-    """Return ``(has_conversation, home_path)`` for the agent's container $HOME.
-
-    Interactive ``claude -c`` (continue) with NO prior conversation prints
-    ``No conversation found to continue`` and **exits** — which kills the tmux
-    PTY at boot, so the boot-drain only ever sees a vanished session (the exact
-    failure that cost a 240 s misdiagnosis as "login wall"). Continue-mode must
-    therefore be gated on a transcript actually existing.
-
-    Resolves the SAME host dir that backs the container ``$HOME`` in
-    :func:`_apptainer_build_argv.build_run_argv` — the overlay upper-home for a
-    relaxed-directory-overlay agent, else the workspace-home bind — and checks
-    for any ``.claude/projects/*/*.jsonl`` transcript. Lazy imports keep this
-    free of an import cycle with ``tui_session`` / ``_to_home_overlay``.
-    """
-    from pathlib import Path
-
-    from ._to_home_overlay import resolve_overlay_upper_home
-
-    upper = resolve_overlay_upper_home(config)
-    if upper is not None and upper.is_dir():
-        home = upper
-    else:
-        from .tui_session import state_dir_for_config
-
-        home = state_dir_for_config(config) / "home"
-    projects = Path(home) / ".claude" / "projects"
-    has = projects.is_dir() and any(projects.glob("*/*.jsonl"))
-    return has, home
-
-
-def _tui_runner_argv(
-    config: "AgentConfig",
-    *,
-    mcp_config: str | None = None,
-    channel_mcp: str | None = None,
-    dev_channels: str | None = None,
-    settings: str | None = None,
-) -> list[str]:
-    """Argv for the interactive ``claude`` TUI (``spec.runtime: tui``).
-
-    The inner process is the bundled ``claude`` binary running its
-    interactive Ink TUI — the tmux PTY the caller wraps this argv in is
-    what gives it a terminal. Threads the declarative spec surface:
-
-      * ``spec.claude.model``  → ``--model <name>`` (when set).
-      * ``spec.claude.flags``  → appended verbatim (e.g.
-        ``--dangerously-skip-permissions``).
-
-    Settings/hooks: the interactive ``claude`` reads hooks/settings from
-    ``$HOME/.claude/settings.json`` at USER scope (and project-scope
-    ``<cwd>/.claude/settings{,.local}.json``). It does NOT read a
-    ``$HOME/.claude/settings.local.json`` — there is no ``.local.json`` at
-    user scope. So the skip-permissions key + SAC channel hooks + the
-    ``_shared`` baseline honest-grounding Stop gate / lint PostToolUse are
-    materialised into ``$HOME/.claude/settings.json``
-    (``setup_settings_json(..., filename="settings.json")``) and discovered
-    automatically — no flag needed. The caller still passes the in-container
-    path as ``settings`` and we add ``--settings <path>`` as belt-and-
-    suspenders / SDK parity, but for the interactive TUI that flag is a no-op
-    (it replaces discovery and only applies to print/SDK mode — see
-    ``_sdk_common.build_sdk_options`` and skill ``25_claude-setup-delivery``).
-    The earlier bug — the suite materialised under ``settings.local.json`` at
-    ``$HOME`` — left it INERT: the TUI hit live "Do you want to proceed?"
-    prompts AND reached DONE with an empty clew DAG because the Stop gate
-    never fired (paper-scitex-clew solver run 2026-06-20).
-
-    MCP servers: the interactive ``claude`` auto-discovers ``.mcp.json``
-    from the PROJECT ROOT (its cwd, ``--pwd``), NOT from ``$HOME`` like
-    the SDK runner. So when to_home materialised a ``$HOME/.mcp.json``,
-    the caller passes its in-container path as ``mcp_config`` and we add
-    ``--mcp-config <path>`` so the TUI loads those servers (figrecipe /
-    scitex-agent-container / scitex-todo …). Without this the TUI shows
-    "No MCP servers configured".
-
-    Channels (SDK parity — see ``runtimes._sdk_channels.apply_channels``):
-    ``spec.claude.channels`` drives two flags. ``dev_channels`` →
-    ``--dangerously-load-development-channels <set>`` (any channel).
-    ``channel_mcp`` → an inline ``--mcp-config`` JSON registering the
-    ``sac mcp channel`` stdio subscriber (``server:sac`` only) so the TUI
-    actually receives a2a-bus pushes — the interactive ``claude`` has no
-    ``--channels`` flag, so the subscriber must be injected as an MCP
-    server (the bus-auth env from ``listen_env_flags`` lets it connect).
-    Each mcp config rides on its OWN ``--mcp-config`` flag (P0 fix
-    2026-06-15): claude's ``<configs...>`` syntax claims it accepts
-    multiple space-separated values after one flag, but the binary
-    silently drops everything past the first — the operator-facing
-    symptom was the TUI complaining "no MCP server configured with that
-    name" even though the values were passed. Repeated flags match the
-    SDK runtime's pattern and are observably loaded.
-
-    No tini wrapper: the TUI is the foreground interactive process in the
-    tmux pane; apptainer + tmux own signal delivery. ``startup_commands``
-    wrapping (``build_inner_argv``) still ``exec``s this as the tail.
-    """
-    argv: list[str] = [_CLAUDE_TUI_BIN]
-    claude_spec = getattr(config, "claude", None)
-    model = str(getattr(claude_spec, "model", "") or "").strip()
-    if not model:
-        model = str(getattr(config, "model", "") or "").strip()
-    if model:
-        argv += ["--model", model]
-    # Session continuity: append ``-c`` (continue) ONLY when the resolved
-    # session mode is ``continue``. ``config.claude.session`` is already fully
-    # resolved (CLI override > explicit spec > role-default > global ``fresh``)
-    # by the loader/CLI before this builder runs — we only translate it to the
-    # flag here. Experiment capsules (no coordinator role → ``fresh``) run
-    # hermetic; coordinator roles keep continuity.
-    from ..config._session_continuity import wants_continue
-
-    if wants_continue(getattr(claude_spec, "session", None)):
-        has_history, home = _home_has_resumable_conversation(config)
-        if has_history:
-            argv.append("-c")
-        else:
-            import logging
-
-            logging.getLogger(__name__).warning(
-                "TuiSessionRuntime: agent %r is continue-mode but its "
-                "container-home %s holds NO prior conversation transcript — "
-                "OMITTING `-c` and starting a FRESH session this boot. Reason: "
-                "interactive `claude -c` with no history prints 'No conversation "
-                "found to continue' and EXITS, silently killing the tmux session "
-                "during boot-drain (misdiagnosed as a login wall). The session "
-                "becomes resumable once this first boot writes a transcript. If "
-                "this recurs EVERY boot the home is not persisting across "
-                "restarts — check the overlay-upper bind / to_home materialisation.",
-                getattr(config, "name", "?"),
-                home,
-            )
-    # One ``--mcp-config`` per value (P0 fix 2026-06-15, operator-reported):
-    # ``claude --help`` documents ``--mcp-config <configs...>`` as accepting
-    # multiple space-separated values after a single flag, but the real
-    # binary silently drops every value past the first. Symptom on the
-    # failing fleet (figrecipe / todo / neurovista): the TUI pane showed
-    # ``server:claude-code-telegrammer,server:sac · no MCP server
-    # configured with that name`` even though the workspace ``.mcp.json``
-    # path AND the inline ``sac mcp channel`` JSON were both passed.
-    # Emitting one flag per value matches the SDK runtime's repeated-
-    # flag pattern and is observably loaded by the TUI.
-    if mcp_config:
-        argv += ["--mcp-config", mcp_config]
-    if channel_mcp:
-        argv += ["--mcp-config", channel_mcp]
-    # Explicit settings/hooks load (belt-and-suspenders / SDK parity). The
-    # interactive TUI actually loads these via USER-scope discovery of
-    # ``$HOME/.claude/settings.json`` — this ``--settings`` is a no-op for it
-    # (it only takes effect in print/SDK mode), but harmless and kept for
-    # parity. Emitted before the verbatim ``spec.claude.flags`` so an operator
-    # who hand-passes their own ``--settings`` still wins (claude takes the
-    # last occurrence).
-    if settings:
-        argv += ["--settings", settings]
-    if dev_channels:
-        # --dangerously-load-development-channels is REPEATABLE — claude wants
-        # one occurrence per channel (the ``server:<mcp>`` entry, prefix kept).
-        # A comma-joined value is read as ONE channel entry → "no MCP server
-        # configured with that name", losing every channel. dev_channels
-        # arrives comma-joined; split it and emit one flag per channel.
-        for _channel in dev_channels.split(","):
-            argv += ["--dangerously-load-development-channels", _channel]
-    for flag in list(getattr(claude_spec, "flags", []) or []):
-        flag = str(flag).strip()
-        if flag:
-            argv.append(flag)
-    return argv
-
-
-# In-SIF resolution of the bundled ``sac`` console-script for the
-# channel-MCP subscriber. The bundled ``claude`` TUI spawns it as an
-# stdio MCP subprocess INSIDE the SIF, so the command must point at
-# sac's REAL in-SIF location — which varies by image build:
-#
-#   * sac-base.sif (current, verified 2026-06-17): /opt/venv-sac/bin/sac
-#   * a prior build:                               /opt/venv-agent/bin/sac
-#
-# A single hardcoded path silently broke the channel the moment the SIF
-# layout flipped: claude reported ``server:sac · no MCP server configured
-# with that name`` because the subprocess ``command`` did not exist
-# (2026-06-17 figrecipe/neurovista/todo — the constant had been flipped
-# to ``/opt/venv-agent/bin/sac``, absent from sac-base.sif). The HOST
-# cannot probe the in-SIF filesystem while building the apptainer-exec
-# argv, so resolution is DEFERRED to spawn time: the MCP ``command`` is
-# ``/bin/sh -c <resolver>`` that tries the known venvs + PATH inside the
-# SIF and fails loud if none is executable (see :func:`_sac_channel_mcp_server`).
-# Absolute candidates make it PATH-independent under ``--containall`` /
-# ``--cleanenv`` where the venv bin dir may not be exported.
-
-# Ordered absolute in-SIF candidates (current build first), mirroring the
-# SDK runner's ``_sdk_channels._resolve_sac_binary`` candidate philosophy.
-_SAC_BIN_IN_SIF_CANDIDATES: tuple[str, ...] = (
-    "/opt/venv-sac/bin/sac",
-    "/opt/venv-agent/bin/sac",
-    "/usr/local/bin/sac",
-)
-
-# Back-compat single-path constant + helper. The channel MCP no longer
-# consumes these (it uses the spawn-time resolver below); kept for
-# external imports / single-path callers. Default corrected to the
-# verified current sac-base.sif location.
-_SAC_BIN_IN_SIF_DEFAULT = "/opt/venv-sac/bin/sac"
-
-
-def resolve_sac_bin_in_sif() -> str:
-    """Return a best-effort single in-SIF path to the ``sac`` script.
-
-    Honours the ``SAC_BIN_IN_SIF`` env override, else returns
-    :data:`_SAC_BIN_IN_SIF_DEFAULT`. NOTE: the channel-MCP subscriber no
-    longer uses this — it resolves sac at SPAWN time across
-    :data:`_SAC_BIN_IN_SIF_CANDIDATES` (robust to SIF venv layout); see
-    :func:`_sac_channel_mcp_server`. This helper remains for
-    backward-compatible imports and single-path callers.
-    """
-    override = _os.environ.get("SAC_BIN_IN_SIF", "").strip()
-    if override:
-        return override
-    return _SAC_BIN_IN_SIF_DEFAULT
-
-
-# Backward-compat alias — keep imports of ``_SAC_BIN_IN_SIF`` working
-# (e.g. external skill-doc examples that referenced the legacy constant
-# name). New call sites should call :func:`resolve_sac_bin_in_sif`.
-_SAC_BIN_IN_SIF = _SAC_BIN_IN_SIF_DEFAULT
-
-
-def _sac_channel_mcp_server(channel_args: list[str]) -> dict:
-    """Build the stdio MCP-server spec for the ``sac mcp channel`` sub.
-
-    The ``command`` resolves sac's absolute path INSIDE the SIF at spawn
-    time — trying ``$SAC_BIN`` / ``$SAC_BIN_IN_SIF`` (operator override
-    via ``spec.env``), the known venv locations
-    (:data:`_SAC_BIN_IN_SIF_CANDIDATES`), then ``command -v sac`` — and
-    ``exec``s the first executable, passing ``channel_args`` through
-    unchanged via ``"$@"``. Fails loud (a stderr diagnostic + ``exit
-    127``) when sac is absent, so a missing binary surfaces as a named
-    error rather than the silent ``server:sac · no MCP server configured
-    with that name`` (2026-06-17). Absolute candidates make resolution
-    PATH-independent under ``--containall`` / ``--cleanenv``.
-
-    ``/bin/sh -c <resolver> sac <channel_args...>``: ``"sac"`` becomes
-    ``$0`` and ``channel_args`` become ``"$@"``, so the resolved binary
-    runs ``sac mcp channel --name <agent> [...]`` exactly.
-    """
-    candidates = (
-        '"$SAC_BIN" "$SAC_BIN_IN_SIF" '
-        + " ".join(_SAC_BIN_IN_SIF_CANDIDATES)
-        + ' "$(command -v sac 2>/dev/null)"'
-    )
-    resolver = (
-        f"for c in {candidates}; do "
-        'if [ -n "$c" ] && [ -x "$c" ]; then exec "$c" "$@"; fi; '
-        "done; "
-        ">&2 echo 'sac: binary not found in SIF; channel MCP cannot "
-        "start (set SAC_BIN_IN_SIF in spec.env or rebuild the image "
-        "with sac installed)'; exit 127"
-    )
-    return {
-        "type": "stdio",
-        "command": "/bin/sh",
-        "args": ["-c", resolver, "sac", *channel_args],
-    }
-
-
-def tui_channel_plan(config: "AgentConfig") -> "ChannelPlan":
-    """Compute the shared :class:`ChannelPlan` for a TUI agent from its config.
-
-    The bridge from the TUI's config-shaped inputs (``spec.claude.channels``,
-    the resolved ``spec.a2a.port``, the agent name) to the runtime-agnostic
-    ``_sdk_channels.compute_channel_plan``. Both :func:`tui_channel_config`
-    (the inner ``--mcp-config`` / ``--dangerously-load-development-channels``)
-    and ``build_run_argv`` (the telegrammer wake ``--env``) call this, so the
-    TUI wires the SAME channel decisions as the SDK ``apply_channels`` path —
-    no drift.
-    """
-    from ._sdk_channels import compute_channel_plan
-
-    claude_spec = getattr(config, "claude", None)
-    channels = [
-        str(c).strip()
-        for c in (getattr(claude_spec, "channels", []) or [])
-        if str(c).strip()
-    ]
-    a2a_spec = getattr(config, "a2a", None)
-    raw_port = getattr(a2a_spec, "port", None) if a2a_spec else None
-    a2a_port = raw_port if isinstance(raw_port, int) and raw_port > 0 else None
-    return compute_channel_plan(channels, a2a_port, config.name)
-
-
-def tui_channel_config(config: "AgentConfig") -> tuple[str | None, str | None]:
-    """Resolve ``spec.claude.channels`` into TUI channel flags.
-
-    Returns ``(dev_channels, channel_mcp_json)`` — SDK parity with
-    :func:`runtimes._sdk_channels.apply_channels`:
-
-      * ``dev_channels`` — comma-joined channel set for
-        ``--dangerously-load-development-channels`` (fires for ANY
-        channel entry), or ``None`` when no channels are declared.
-      * ``channel_mcp_json`` — inline ``--mcp-config`` JSON registering
-        the ``sac mcp channel --name <agent>`` stdio subscriber under
-        ``mcpServers.sac`` (``server:sac`` ONLY), or ``None``. The
-        subscriber's ``--listen-url`` defaults to ``$SAC_LISTEN_BASE_URL``
-        (already forwarded by ``listen_env_flags``); when the a2a port is
-        resolved it also gets ``--turn-url`` for the WAKE path.
-    """
-    plan = tui_channel_plan(config)
-    if not plan.channels:
-        return None, None
-    # One --dangerously-load flag per channel (the emission loop in
-    # _tui_runner_argv splits this comma-joined value) — the SAME set the SDK
-    # comma-joins into extra_args, so the two runtimes never disagree.
-    dev_channels = ",".join(plan.channels)
-    channel_mcp: str | None = None
-    if plan.sac_sidecar_args is not None:
-        channel_mcp = json.dumps(
-            {
-                "mcpServers": {
-                    "sac": _sac_channel_mcp_server(list(plan.sac_sidecar_args))
-                }
-            }
-        )
-    return dev_channels, channel_mcp
 
 
 def _proxy_runner_argv(config: "AgentConfig") -> list[str]:

--- a/src/scitex_agent_container/runtimes/_apptainer_inner_argv_tui.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_inner_argv_tui.py
@@ -1,0 +1,354 @@
+"""Interactive ``claude`` TUI argv + channel-plan helpers.
+
+Split out of ``_apptainer_inner_argv.py`` (2026-07-05) to keep that
+orchestrator under the repo's 512-line cap — this module is the
+cohesive "everything about the interactive TUI inner process" half;
+the `kind: Agent` / `kind: AgentProxy` SDK-runner dispatch and the
+shell-wrapper (``build_inner_argv``) stay in the parent module. Every
+symbol here is still importable as
+``scitex_agent_container.runtimes._apptainer_inner_argv.<name>`` — the
+parent module re-imports them for back-compat with existing callers.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..config import AgentConfig
+    from ._sdk_channels import ChannelPlan
+
+_CLAUDE_TUI_BIN = "claude"
+
+
+def _home_has_resumable_conversation(config: "AgentConfig"):
+    """Return ``(has_conversation, home_path)`` for the agent's container $HOME.
+
+    Interactive ``claude -c`` (continue) with NO prior conversation prints
+    ``No conversation found to continue`` and **exits** — which kills the tmux
+    PTY at boot, so the boot-drain only ever sees a vanished session (the exact
+    failure that cost a 240 s misdiagnosis as "login wall"). Continue-mode must
+    therefore be gated on a transcript actually existing.
+
+    Resolves the SAME host dir that backs the container ``$HOME`` in
+    :func:`_apptainer_build_argv.build_run_argv` — the overlay upper-home for a
+    relaxed-directory-overlay agent, else the workspace-home bind — and checks
+    for any ``.claude/projects/*/*.jsonl`` transcript. Lazy imports keep this
+    free of an import cycle with ``tui_session`` / ``_to_home_overlay``.
+    """
+    from pathlib import Path
+
+    from ._to_home_overlay import resolve_overlay_upper_home
+
+    upper = resolve_overlay_upper_home(config)
+    if upper is not None and upper.is_dir():
+        home = upper
+    else:
+        from .tui_session import state_dir_for_config
+
+        home = state_dir_for_config(config) / "home"
+    projects = Path(home) / ".claude" / "projects"
+    has = projects.is_dir() and any(projects.glob("*/*.jsonl"))
+    return has, home
+
+
+def _tui_runner_argv(
+    config: "AgentConfig",
+    *,
+    mcp_config: str | None = None,
+    channel_mcp: str | None = None,
+    dev_channels: str | None = None,
+    settings: str | None = None,
+) -> list[str]:
+    """Argv for the interactive ``claude`` TUI (``spec.runtime: tui``).
+
+    The inner process is the bundled ``claude`` binary running its
+    interactive Ink TUI — the tmux PTY the caller wraps this argv in is
+    what gives it a terminal. Threads the declarative spec surface:
+
+      * ``spec.claude.model``  → ``--model <name>`` (when set).
+      * ``spec.claude.flags``  → appended verbatim (e.g.
+        ``--dangerously-skip-permissions``).
+
+    Settings/hooks: the interactive ``claude`` reads hooks/settings from
+    ``$HOME/.claude/settings.json`` at USER scope (and project-scope
+    ``<cwd>/.claude/settings{,.local}.json``). It does NOT read a
+    ``$HOME/.claude/settings.local.json`` — there is no ``.local.json`` at
+    user scope. So the skip-permissions key + SAC channel hooks + the
+    ``_shared`` baseline honest-grounding Stop gate / lint PostToolUse are
+    materialised into ``$HOME/.claude/settings.json``
+    (``setup_settings_json(..., filename="settings.json")``) and discovered
+    automatically — no flag needed. The caller still passes the in-container
+    path as ``settings`` and we add ``--settings <path>`` as belt-and-
+    suspenders / SDK parity, but for the interactive TUI that flag is a no-op
+    (it replaces discovery and only applies to print/SDK mode — see
+    ``_sdk_common.build_sdk_options`` and skill ``25_claude-setup-delivery``).
+    The earlier bug — the suite materialised under ``settings.local.json`` at
+    ``$HOME`` — left it INERT: the TUI hit live "Do you want to proceed?"
+    prompts AND reached DONE with an empty clew DAG because the Stop gate
+    never fired (paper-scitex-clew solver run 2026-06-20).
+
+    MCP servers: the interactive ``claude`` auto-discovers ``.mcp.json``
+    from the PROJECT ROOT (its cwd, ``--pwd``), NOT from ``$HOME`` like
+    the SDK runner. So when to_home materialised a ``$HOME/.mcp.json``,
+    the caller passes its in-container path as ``mcp_config`` and we add
+    ``--mcp-config <path>`` so the TUI loads those servers (figrecipe /
+    scitex-agent-container / scitex-todo …). Without this the TUI shows
+    "No MCP servers configured".
+
+    Channels (SDK parity — see ``runtimes._sdk_channels.apply_channels``):
+    ``spec.claude.channels`` drives two flags. ``dev_channels`` →
+    ``--dangerously-load-development-channels <set>`` (any channel).
+    ``channel_mcp`` → an inline ``--mcp-config`` JSON registering the
+    ``sac mcp channel`` stdio subscriber (``server:sac`` only) so the TUI
+    actually receives a2a-bus pushes — the interactive ``claude`` has no
+    ``--channels`` flag, so the subscriber must be injected as an MCP
+    server (the bus-auth env from ``listen_env_flags`` lets it connect).
+    Each mcp config rides on its OWN ``--mcp-config`` flag (P0 fix
+    2026-06-15): claude's ``<configs...>`` syntax claims it accepts
+    multiple space-separated values after one flag, but the binary
+    silently drops everything past the first — the operator-facing
+    symptom was the TUI complaining "no MCP server configured with that
+    name" even though the values were passed. Repeated flags match the
+    SDK runtime's pattern and are observably loaded.
+
+    No tini wrapper: the TUI is the foreground interactive process in the
+    tmux pane; apptainer + tmux own signal delivery. ``startup_commands``
+    wrapping (``build_inner_argv``) still ``exec``s this as the tail.
+    """
+    argv: list[str] = [_CLAUDE_TUI_BIN]
+    claude_spec = getattr(config, "claude", None)
+    model = str(getattr(claude_spec, "model", "") or "").strip()
+    if not model:
+        model = str(getattr(config, "model", "") or "").strip()
+    if model:
+        argv += ["--model", model]
+    # Session continuity: append ``-c`` (continue) ONLY when the resolved
+    # session mode is ``continue``. ``config.claude.session`` is already fully
+    # resolved (CLI override > explicit spec > role-default > global ``fresh``)
+    # by the loader/CLI before this builder runs — we only translate it to the
+    # flag here. Experiment capsules (no coordinator role → ``fresh``) run
+    # hermetic; coordinator roles keep continuity.
+    from ..config._session_continuity import wants_continue
+
+    if wants_continue(getattr(claude_spec, "session", None)):
+        has_history, home = _home_has_resumable_conversation(config)
+        if has_history:
+            argv.append("-c")
+        else:
+            import logging
+
+            logging.getLogger(__name__).warning(
+                "TuiSessionRuntime: agent %r is continue-mode but its "
+                "container-home %s holds NO prior conversation transcript — "
+                "OMITTING `-c` and starting a FRESH session this boot. Reason: "
+                "interactive `claude -c` with no history prints 'No conversation "
+                "found to continue' and EXITS, silently killing the tmux session "
+                "during boot-drain (misdiagnosed as a login wall). The session "
+                "becomes resumable once this first boot writes a transcript. If "
+                "this recurs EVERY boot the home is not persisting across "
+                "restarts — check the overlay-upper bind / to_home materialisation.",
+                getattr(config, "name", "?"),
+                home,
+            )
+    # One ``--mcp-config`` per value (P0 fix 2026-06-15, operator-reported):
+    # ``claude --help`` documents ``--mcp-config <configs...>`` as accepting
+    # multiple space-separated values after a single flag, but the real
+    # binary silently drops every value past the first. Symptom on the
+    # failing fleet (figrecipe / todo / neurovista): the TUI pane showed
+    # ``server:claude-code-telegrammer,server:sac · no MCP server
+    # configured with that name`` even though the workspace ``.mcp.json``
+    # path AND the inline ``sac mcp channel`` JSON were both passed.
+    # Emitting one flag per value matches the SDK runtime's repeated-
+    # flag pattern and is observably loaded by the TUI.
+    if mcp_config:
+        argv += ["--mcp-config", mcp_config]
+    if channel_mcp:
+        argv += ["--mcp-config", channel_mcp]
+    # Explicit settings/hooks load (belt-and-suspenders / SDK parity). The
+    # interactive TUI actually loads these via USER-scope discovery of
+    # ``$HOME/.claude/settings.json`` — this ``--settings`` is a no-op for it
+    # (it only takes effect in print/SDK mode), but harmless and kept for
+    # parity. Emitted before the verbatim ``spec.claude.flags`` so an operator
+    # who hand-passes their own ``--settings`` still wins (claude takes the
+    # last occurrence).
+    if settings:
+        argv += ["--settings", settings]
+    if dev_channels:
+        # --dangerously-load-development-channels is REPEATABLE — claude wants
+        # one occurrence per channel (the ``server:<mcp>`` entry, prefix kept).
+        # A comma-joined value is read as ONE channel entry → "no MCP server
+        # configured with that name", losing every channel. dev_channels
+        # arrives comma-joined; split it and emit one flag per channel.
+        for _channel in dev_channels.split(","):
+            argv += ["--dangerously-load-development-channels", _channel]
+    for flag in list(getattr(claude_spec, "flags", []) or []):
+        flag = str(flag).strip()
+        if flag:
+            argv.append(flag)
+    return argv
+
+
+# In-SIF resolution of the bundled ``sac`` console-script for the
+# channel-MCP subscriber. The bundled ``claude`` TUI spawns it as an
+# stdio MCP subprocess INSIDE the SIF, so the command must point at
+# sac's REAL in-SIF location — which varies by image build:
+#
+#   * sac-base.sif (current, verified 2026-06-17): /opt/venv-sac/bin/sac
+#   * a prior build:                               /opt/venv-agent/bin/sac
+#
+# A single hardcoded path silently broke the channel the moment the SIF
+# layout flipped: claude reported ``server:sac · no MCP server configured
+# with that name`` because the subprocess ``command`` did not exist
+# (2026-06-17 figrecipe/neurovista/todo — the constant had been flipped
+# to ``/opt/venv-agent/bin/sac``, absent from sac-base.sif). The HOST
+# cannot probe the in-SIF filesystem while building the apptainer-exec
+# argv, so resolution is DEFERRED to spawn time: the MCP ``command`` is
+# ``/bin/sh -c <resolver>`` that tries the known venvs + PATH inside the
+# SIF and fails loud if none is executable (see :func:`_sac_channel_mcp_server`).
+# Absolute candidates make it PATH-independent under ``--containall`` /
+# ``--cleanenv`` where the venv bin dir may not be exported.
+
+# Ordered absolute in-SIF candidates (current build first), mirroring the
+# SDK runner's ``_sdk_channels._resolve_sac_binary`` candidate philosophy.
+_SAC_BIN_IN_SIF_CANDIDATES: tuple[str, ...] = (
+    "/opt/venv-sac/bin/sac",
+    "/opt/venv-agent/bin/sac",
+    "/usr/local/bin/sac",
+)
+
+# Back-compat single-path constant + helper. The channel MCP no longer
+# consumes these (it uses the spawn-time resolver below); kept for
+# external imports / single-path callers. Default corrected to the
+# verified current sac-base.sif location.
+_SAC_BIN_IN_SIF_DEFAULT = "/opt/venv-sac/bin/sac"
+
+
+def resolve_sac_bin_in_sif() -> str:
+    """Return a best-effort single in-SIF path to the ``sac`` script.
+
+    Honours the ``SAC_BIN_IN_SIF`` env override, else returns
+    :data:`_SAC_BIN_IN_SIF_DEFAULT`. NOTE: the channel-MCP subscriber no
+    longer uses this — it resolves sac at SPAWN time across
+    :data:`_SAC_BIN_IN_SIF_CANDIDATES` (robust to SIF venv layout); see
+    :func:`_sac_channel_mcp_server`. This helper remains for
+    backward-compatible imports and single-path callers.
+    """
+    import os as _os
+
+    override = _os.environ.get("SAC_BIN_IN_SIF", "").strip()
+    if override:
+        return override
+    return _SAC_BIN_IN_SIF_DEFAULT
+
+
+# Backward-compat alias — keep imports of ``_SAC_BIN_IN_SIF`` working
+# (e.g. external skill-doc examples that referenced the legacy constant
+# name). New call sites should call :func:`resolve_sac_bin_in_sif`.
+_SAC_BIN_IN_SIF = _SAC_BIN_IN_SIF_DEFAULT
+
+
+def _sac_channel_mcp_server(channel_args: list[str]) -> dict:
+    """Build the stdio MCP-server spec for the ``sac mcp channel`` sub.
+
+    The ``command`` resolves sac's absolute path INSIDE the SIF at spawn
+    time — trying ``$SAC_BIN`` / ``$SAC_BIN_IN_SIF`` (operator override
+    via ``spec.env``), the known venv locations
+    (:data:`_SAC_BIN_IN_SIF_CANDIDATES`), then ``command -v sac`` — and
+    ``exec``s the first executable, passing ``channel_args`` through
+    unchanged via ``"$@"``. Fails loud (a stderr diagnostic + ``exit
+    127``) when sac is absent, so a missing binary surfaces as a named
+    error rather than the silent ``server:sac · no MCP server configured
+    with that name`` (2026-06-17). Absolute candidates make resolution
+    PATH-independent under ``--containall`` / ``--cleanenv``.
+
+    ``/bin/sh -c <resolver> sac <channel_args...>``: ``"sac"`` becomes
+    ``$0`` and ``channel_args`` become ``"$@"``, so the resolved binary
+    runs ``sac mcp channel --name <agent> [...]`` exactly.
+    """
+    candidates = (
+        '"$SAC_BIN" "$SAC_BIN_IN_SIF" '
+        + " ".join(_SAC_BIN_IN_SIF_CANDIDATES)
+        + ' "$(command -v sac 2>/dev/null)"'
+    )
+    resolver = (
+        f"for c in {candidates}; do "
+        'if [ -n "$c" ] && [ -x "$c" ]; then exec "$c" "$@"; fi; '
+        "done; "
+        ">&2 echo 'sac: binary not found in SIF; channel MCP cannot "
+        "start (set SAC_BIN_IN_SIF in spec.env or rebuild the image "
+        "with sac installed)'; exit 127"
+    )
+    return {
+        "type": "stdio",
+        "command": "/bin/sh",
+        "args": ["-c", resolver, "sac", *channel_args],
+    }
+
+
+def tui_channel_plan(config: "AgentConfig") -> "ChannelPlan":
+    """Compute the shared :class:`ChannelPlan` for a TUI agent from its config.
+
+    The bridge from the TUI's config-shaped inputs (``spec.claude.channels``,
+    the resolved ``spec.a2a.port``, the agent name) to the runtime-agnostic
+    ``_sdk_channels.compute_channel_plan``. Both :func:`tui_channel_config`
+    (the inner ``--mcp-config`` / ``--dangerously-load-development-channels``)
+    and ``build_run_argv`` (the telegrammer wake ``--env``) call this, so the
+    TUI wires the SAME channel decisions as the SDK ``apply_channels`` path —
+    no drift.
+    """
+    from ._sdk_channels import compute_channel_plan
+
+    claude_spec = getattr(config, "claude", None)
+    channels = [
+        str(c).strip()
+        for c in (getattr(claude_spec, "channels", []) or [])
+        if str(c).strip()
+    ]
+    a2a_spec = getattr(config, "a2a", None)
+    raw_port = getattr(a2a_spec, "port", None) if a2a_spec else None
+    a2a_port = raw_port if isinstance(raw_port, int) and raw_port > 0 else None
+    return compute_channel_plan(channels, a2a_port, config.name)
+
+
+def tui_channel_config(config: "AgentConfig") -> tuple[str | None, str | None]:
+    """Resolve ``spec.claude.channels`` into TUI channel flags.
+
+    Returns ``(dev_channels, channel_mcp_json)`` — SDK parity with
+    :func:`runtimes._sdk_channels.apply_channels`:
+
+      * ``dev_channels`` — comma-joined channel set for
+        ``--dangerously-load-development-channels`` (fires for ANY
+        channel entry), or ``None`` when no channels are declared.
+      * ``channel_mcp_json`` — inline ``--mcp-config`` JSON registering
+        the ``sac mcp channel --name <agent>`` stdio subscriber under
+        ``mcpServers.sac`` (``server:sac`` ONLY), or ``None``. The
+        subscriber's ``--listen-url`` defaults to ``$SAC_LISTEN_BASE_URL``
+        (already forwarded by ``listen_env_flags``); when the a2a port is
+        resolved it also gets ``--turn-url`` for the WAKE path.
+    """
+    plan = tui_channel_plan(config)
+    if not plan.channels:
+        return None, None
+    # One --dangerously-load flag per channel (the emission loop in
+    # _tui_runner_argv splits this comma-joined value) — the SAME set the SDK
+    # comma-joins into extra_args, so the two runtimes never disagree.
+    dev_channels = ",".join(plan.channels)
+    channel_mcp: str | None = None
+    if plan.sac_sidecar_args is not None:
+        channel_mcp = json.dumps(
+            {
+                "mcpServers": {
+                    "sac": _sac_channel_mcp_server(list(plan.sac_sidecar_args))
+                }
+            }
+        )
+    return dev_channels, channel_mcp
+
+
+__all__ = [
+    "resolve_sac_bin_in_sif",
+    "tui_channel_config",
+    "tui_channel_plan",
+]

--- a/tests/scitex_agent_container/runtimes/test__apptainer_build_argv.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_build_argv.py
@@ -30,6 +30,7 @@ to keep the mirror 1:1.
 from __future__ import annotations
 
 import os
+import shlex
 import socket
 from pathlib import Path
 from typing import Iterator
@@ -140,6 +141,19 @@ def tui_config(tmp_path):
     return load_config(str(spec))
 
 
+def _effective_inner_argv(inner: list[str]) -> list[str]:
+    """Token-list of the actual ``claude`` invocation.
+
+    ``build_inner_argv`` now ALWAYS wraps the runner argv in
+    ``/bin/bash -lc <inline>`` (the unconditional SAC_GIT_* env alias
+    step — see ``_apptainer_inner_argv._GIT_ENV_ALIAS_STEPS``), so the
+    literal inner command is shell-quoted text after ``exec `` inside
+    ``inner[2]`` rather than being ``inner`` itself.
+    """
+    exec_part = inner[2].split("exec ", 1)[1]
+    return shlex.split(exec_part)
+
+
 # ---------------------------------------------------------------------------
 # build_inner_argv(tui=True) — interactive claude as the inner process
 # ---------------------------------------------------------------------------
@@ -148,7 +162,7 @@ def tui_config(tmp_path):
 def test_tui_inner_argv_runs_claude_binary(tui_config) -> None:
     # Arrange — config from the tui_config fixture.
     # Act
-    inner = build_inner_argv(tui_config, tui=True)
+    inner = _effective_inner_argv(build_inner_argv(tui_config, tui=True))
     # Assert — the inner command is the interactive claude TUI.
     assert inner[0] == "claude"
 
@@ -156,7 +170,7 @@ def test_tui_inner_argv_runs_claude_binary(tui_config) -> None:
 def test_tui_inner_argv_threads_model_flag(tui_config) -> None:
     # Arrange — config from the tui_config fixture.
     # Act
-    inner = build_inner_argv(tui_config, tui=True)
+    inner = _effective_inner_argv(build_inner_argv(tui_config, tui=True))
     # Assert
     assert "--model" in inner and "claude-opus-4-8[1m]" in inner
 
@@ -164,7 +178,7 @@ def test_tui_inner_argv_threads_model_flag(tui_config) -> None:
 def test_tui_inner_argv_appends_spec_flags(tui_config) -> None:
     # Arrange — config from the tui_config fixture.
     # Act
-    inner = build_inner_argv(tui_config, tui=True)
+    inner = _effective_inner_argv(build_inner_argv(tui_config, tui=True))
     # Assert
     assert "--dangerously-skip-permissions" in inner
 

--- a/tests/scitex_agent_container/runtimes/test__apptainer_inner_argv.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_inner_argv.py
@@ -1,13 +1,18 @@
 """Tests for ``runtimes/_apptainer_inner_argv.py``.
 
-Covers the startup_commands shell-exec wrapper and the absence of
-the legacy --mission fallback. See commit message
+Covers the startup_commands shell-exec wrapper, the absence of the
+legacy --mission fallback, and the unconditional SAC_GIT_* -> GIT_*
+env-alias step (see commit message
+``feat(launch): generic SAC_GIT_* -> GIT_* env alias in the container
+shell wrapper``). See also commit message
 ``feat(startup_commands): execute as container shell``.
 """
 
 from __future__ import annotations
 
+import os
 import shutil
+import subprocess
 from pathlib import Path
 
 from scitex_agent_container.config import AgentConfig
@@ -18,6 +23,7 @@ from scitex_agent_container.config._types import (
     StartupCommand,
 )
 from scitex_agent_container.runtimes._apptainer_inner_argv import (
+    _GIT_ENV_ALIAS_STEPS,
     _SUPERVISOR_RESTART_FLOOR,
     _agent_runner_argv,
     _format_shell_steps,
@@ -37,13 +43,34 @@ def _mk_cfg(**kwargs):
 # ---------------------------------------------------------------------------
 
 
-def test_startup_commands_empty_returns_plain_tini_argv():
+def test_startup_commands_empty_still_wraps_in_bash():
+    # Arrange — EMPTY startup_commands. Before the SAC_GIT_* alias step
+    # existed this returned the bare tini argv unwrapped; now the alias
+    # is unconditional, so every agent (even one with no startup_commands
+    # at all) gets the bash -lc wrapper.
+    cfg = _mk_cfg()
+    # Act
+    argv = build_inner_argv(cfg)
+    # Assert
+    assert argv[0] == "/bin/bash"
+
+
+def test_startup_commands_empty_still_passes_dash_lc():
     # Arrange
     cfg = _mk_cfg()
     # Act
     argv = build_inner_argv(cfg)
     # Assert
-    assert argv[0] == "/usr/bin/tini"
+    assert argv[1] == "-lc"
+
+
+def test_startup_commands_empty_still_execs_tini():
+    # Arrange
+    cfg = _mk_cfg()
+    # Act
+    argv = build_inner_argv(cfg)
+    # Assert
+    assert "exec /usr/bin/tini" in argv[2]
 
 
 def test_single_startup_command_wraps_in_bash():
@@ -64,13 +91,16 @@ def test_single_startup_command_passes_dash_lc():
     assert argv[1] == "-lc"
 
 
-def test_single_startup_command_emits_set_e_first():
-    # Arrange
+def test_single_startup_command_emits_set_e_after_git_alias():
+    # Arrange — the fixed SAC_GIT_* alias steps are now unconditionally
+    # prepended, so "set -e" (from _format_shell_steps) is no longer the
+    # very first thing in the inline script; it still directly precedes
+    # the user's own startup command.
     cfg = _mk_cfg(startup_commands=[StartupCommand(command="pip install foo")])
     # Act
     argv = build_inner_argv(cfg)
     # Assert
-    assert argv[2].startswith("set -e;")
+    assert "; set -e; pip install foo;" in argv[2]
 
 
 def test_single_startup_command_emits_exec_then_tini():
@@ -107,12 +137,13 @@ def test_startup_command_delay_emits_sleep_n():
 
 
 def test_empty_command_string_is_filtered_out():
-    # Arrange
+    # Arrange — the blank command contributes NO shell step of its own,
+    # but the wrap still happens (the unconditional git-alias step).
     cfg = _mk_cfg(startup_commands=[StartupCommand(command="")])
     # Act
     argv = build_inner_argv(cfg)
     # Assert
-    assert argv[0] == "/usr/bin/tini"
+    assert "exec /usr/bin/tini" in argv[2]
 
 
 def test_shlex_quote_protects_paths_with_spaces():
@@ -129,6 +160,125 @@ def test_shlex_quote_protects_paths_with_spaces():
     # here since a2a is unset, but shlex.quote is exercised on every
     # element).
     assert "/bin/bash" in argv
+
+
+# ---------------------------------------------------------------------------
+# SAC_GIT_* -> GIT_* env alias: generic, values-agnostic, always present.
+# git itself only reads the literal GIT_* names; the alias mirrors whichever
+# SAC_GIT_* vars are already in the shell env (source: each project's own
+# .envrc via direnv source_up — entirely outside this module's concern) onto
+# them. See _GIT_ENV_ALIAS_STEPS.
+# ---------------------------------------------------------------------------
+
+_EXPECTED_GIT_ALIAS_MAPPINGS = (
+    ("SAC_GIT_AUTHOR_NAME", "GIT_AUTHOR_NAME"),
+    ("SAC_GIT_AUTHOR_EMAIL", "GIT_AUTHOR_EMAIL"),
+    ("SAC_GIT_COMMITTER_NAME", "GIT_COMMITTER_NAME"),
+    ("SAC_GIT_COMMITTER_EMAIL", "GIT_COMMITTER_EMAIL"),
+    ("SAC_GIT_SSH_COMMAND", "GIT_SSH_COMMAND"),
+)
+
+
+def test_git_alias_step_count_is_exactly_five():
+    # Arrange — one guarded export per mapping, no more, no less.
+    steps = _GIT_ENV_ALIAS_STEPS
+    # Act
+    count = len(steps)
+    # Assert
+    assert count == 5
+
+
+def test_git_alias_steps_contain_all_five_mappings():
+    # Arrange
+    joined = "; ".join(_GIT_ENV_ALIAS_STEPS)
+    expected = [
+        f'[ -n "${{{src}:-}}" ] && export {dst}="${src}"'
+        for src, dst in _EXPECTED_GIT_ALIAS_MAPPINGS
+    ]
+    # Act
+    missing = [line for line in expected if line not in joined]
+    # Assert — every SAC_GIT_* -> GIT_* mapping is present verbatim.
+    assert missing == []
+
+
+def test_empty_startup_commands_argv_contains_git_alias_steps():
+    # Arrange — an agent with NO startup_commands at all still gets the
+    # alias baked into its wrapper.
+    cfg = _mk_cfg()
+    # Act
+    argv = build_inner_argv(cfg)
+    # Assert
+    assert "SAC_GIT_AUTHOR_NAME" in argv[2]
+
+
+def test_git_alias_precedes_exec_in_empty_startup_commands_case():
+    # Arrange
+    cfg = _mk_cfg()
+    # Act
+    argv = build_inner_argv(cfg)
+    # Assert — alias runs before the tini exec, not after.
+    assert argv[2].index("SAC_GIT_AUTHOR_NAME") < argv[2].index("exec ")
+
+
+def test_git_alias_precedes_custom_startup_command():
+    # Arrange — an agent WITH its own startup_commands still gets the
+    # alias step prepended BEFORE its own steps.
+    cfg = _mk_cfg(startup_commands=[StartupCommand(command="echo custom-step")])
+    # Act
+    argv = build_inner_argv(cfg)
+    # Assert
+    assert argv[2].index("SAC_GIT_AUTHOR_NAME") < argv[2].index("echo custom-step")
+
+
+def test_git_alias_runs_before_set_e_from_startup_commands():
+    # Arrange — the alias lines must run BEFORE any `set -e` emitted for
+    # startup_commands, so a false `[ -n ... ]` (unset SAC_GIT_*) never
+    # aborts the launch under set -e.
+    cfg = _mk_cfg(startup_commands=[StartupCommand(command="echo custom-step")])
+    # Act
+    argv = build_inner_argv(cfg)
+    # Assert
+    assert argv[2].index("SAC_GIT_AUTHOR_NAME") < argv[2].index("set -e")
+
+
+def test_git_alias_is_noop_shell_when_source_vars_unset():
+    # Arrange — real bash execution (no mocks): clear every SAC_GIT_*/GIT_*
+    # from the env, run the exact generated alias snippet, then dump env.
+    env = {
+        k: v
+        for k, v in os.environ.items()
+        if not k.startswith("SAC_GIT_") and not k.startswith("GIT_")
+    }
+    script = "; ".join(_GIT_ENV_ALIAS_STEPS) + "; env"
+    # Act
+    result = subprocess.run(
+        ["/bin/bash", "-c", script],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    # Assert — no GIT_* leaked into the child env; silent no-op.
+    assert "GIT_AUTHOR_NAME" not in result.stdout
+
+
+def test_git_alias_mirrors_value_when_source_var_set():
+    # Arrange — real bash execution proving the mechanism end-to-end.
+    env = dict(os.environ)
+    env["SAC_GIT_AUTHOR_NAME"] = "Test Author"
+    script = (
+        "; ".join(_GIT_ENV_ALIAS_STEPS) + '; printf "%s" "$GIT_AUTHOR_NAME"'
+    )
+    # Act
+    result = subprocess.run(
+        ["/bin/bash", "-c", script],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    # Assert
+    assert result.stdout == "Test Author"
 
 
 # ---------------------------------------------------------------------------
@@ -353,13 +503,31 @@ def _tui_argv(session: str) -> list[str]:
     return build_inner_argv(cfg, tui=True)
 
 
+def _exec_tail_tokens(argv: list[str]) -> list[str]:
+    """Tokenize the ``exec <runner...>`` tail of a bash -lc wrapped argv.
+
+    ``build_inner_argv`` now ALWAYS wraps in ``/bin/bash -lc <inline>``
+    (unconditional SAC_GIT_* alias step), so the actual runner argv
+    (e.g. ``claude --model haiku -c``) is embedded as shell-quoted text
+    inside ``argv[2]`` rather than being ``argv`` itself. Token-splitting
+    the ``exec`` tail (instead of a raw substring check) avoids false
+    matches against unrelated ``-c``-containing text elsewhere in the
+    alias/startup-command steps.
+    """
+    import shlex as _shlex
+
+    inline = argv[2]
+    exec_part = inline.split("exec ", 1)[1]
+    return _shlex.split(exec_part)
+
+
 def test_tui_session_fresh_omits_continue_flag():
     # Arrange — fresh is the default mode; an experiment trial must start
     # an independent session.
     # Act
     argv = _tui_argv("fresh")
     # Assert
-    assert "-c" not in argv
+    assert "-c" not in _exec_tail_tokens(argv)
 
 
 def test_tui_session_continue_with_history_appends_continue_flag():
@@ -380,7 +548,7 @@ def test_tui_session_continue_with_history_appends_continue_flag():
     finally:
         shutil.rmtree(Path(home) / ".claude", ignore_errors=True)
     # Assert
-    assert "-c" in argv
+    assert "-c" in _exec_tail_tokens(argv)
 
 
 def test_tui_session_continue_without_history_omits_continue_flag():
@@ -397,7 +565,7 @@ def test_tui_session_continue_without_history_omits_continue_flag():
     # Act
     argv = build_inner_argv(cfg, tui=True)
     # Assert
-    assert "-c" not in argv
+    assert "-c" not in _exec_tail_tokens(argv)
 
 
 def test_tui_session_resume_omits_continue_flag():
@@ -405,7 +573,7 @@ def test_tui_session_resume_omits_continue_flag():
     # Act
     argv = _tui_argv("resume")
     # Assert
-    assert "-c" not in argv
+    assert "-c" not in _exec_tail_tokens(argv)
 
 
 def test_tui_session_new_session_alias_omits_continue_flag():
@@ -415,7 +583,7 @@ def test_tui_session_new_session_alias_omits_continue_flag():
     # Act
     argv = _tui_argv("new-session")
     # Assert
-    assert "-c" not in argv
+    assert "-c" not in _exec_tail_tokens(argv)
 
 
 def test_tui_inner_argv_default_claudespec_is_fresh_no_continue_flag():
@@ -425,4 +593,4 @@ def test_tui_inner_argv_default_claudespec_is_fresh_no_continue_flag():
     # Act
     argv = build_inner_argv(cfg, tui=True)
     # Assert
-    assert "-c" not in argv
+    assert "-c" not in _exec_tail_tokens(argv)

--- a/tests/scitex_agent_container/runtimes/test__apptainer_inner_argv_mcp.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_inner_argv_mcp.py
@@ -23,11 +23,29 @@ STX-TQ002 AAA-marker + STX-TQ007 one-assert + PA-306 no-mock-fixtures.
 
 from __future__ import annotations
 
+import shlex
 from dataclasses import dataclass, field
 
 from scitex_agent_container.runtimes._apptainer_inner_argv import (
     build_inner_argv,
 )
+
+
+def _effective_argv(argv: list[str]) -> list[str]:
+    """Token-list of the actual runner invocation.
+
+    ``build_inner_argv`` now ALWAYS wraps the runner argv in
+    ``/bin/bash -lc <inline>`` (the unconditional SAC_GIT_* env alias
+    step, see ``_apptainer_inner_argv._GIT_ENV_ALIAS_STEPS``), so the
+    literal runner argv (e.g. ``claude --mcp-config ...``) is embedded
+    as shell-quoted text after ``exec `` inside ``argv[2]`` rather than
+    being ``argv`` itself. Token-splitting that tail recovers the same
+    flat list these tests asserted against before the wrap became
+    unconditional.
+    """
+    inline = argv[2]
+    exec_part = inline.split("exec ", 1)[1]
+    return shlex.split(exec_part)
 
 
 @dataclass
@@ -76,6 +94,7 @@ def test_tui_runner_emits_one_mcp_config_flag_per_value() -> None:
         tui_mcp_config="/home/agent/.mcp.json",
         tui_channel_mcp='{"mcpServers":{"sac":{}}}',
     )
+    argv = _effective_argv(argv)
     # Assert — exactly two ``--mcp-config`` flags (one per value), not
     # one flag with two space-separated values (the operator-reported
     # silent-drop shape).
@@ -92,6 +111,7 @@ def test_tui_runner_each_mcp_config_value_immediately_follows_its_flag() -> None
         tui_mcp_config="/home/agent/.mcp.json",
         tui_channel_mcp='{"mcpServers":{"sac":{}}}',
     )
+    argv = _effective_argv(argv)
     # Assert — each value sits adjacent to its OWN ``--mcp-config``.
     # The buggy shape would put both behind a single flag and the second
     # would be unreachable via this lookup (returns only one entry).
@@ -112,6 +132,7 @@ def test_tui_runner_single_mcp_config_value_still_emits_one_flag() -> None:
         tui_mcp_config="/home/agent/.mcp.json",
         tui_channel_mcp=None,
     )
+    argv = _effective_argv(argv)
     # Assert
     assert _count_flag_occurrences(argv, "--mcp-config") == 1
 
@@ -126,6 +147,7 @@ def test_tui_runner_only_channel_mcp_still_emits_one_flag() -> None:
         tui_mcp_config=None,
         tui_channel_mcp='{"mcpServers":{"sac":{}}}',
     )
+    argv = _effective_argv(argv)
     # Assert
     assert _count_flag_occurrences(argv, "--mcp-config") == 1
 
@@ -140,6 +162,7 @@ def test_tui_runner_no_mcp_config_emits_no_flag() -> None:
         tui_mcp_config=None,
         tui_channel_mcp=None,
     )
+    argv = _effective_argv(argv)
     # Assert
     assert _count_flag_occurrences(argv, "--mcp-config") == 0
 
@@ -157,6 +180,7 @@ def test_tui_runner_mcp_config_value_is_not_a_joined_pair() -> None:
         tui_mcp_config="/home/agent/.mcp.json",
         tui_channel_mcp='{"mcpServers":{"sac":{}}}',
     )
+    argv = _effective_argv(argv)
     # Assert — no single argv element contains BOTH the path and the
     # JSON (the smoking-gun of the joined-string regression).
     joined_entries = [

--- a/tests/scitex_agent_container/runtimes/test__apptainer_preflight.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_preflight.py
@@ -31,6 +31,21 @@ def _inner_after_sif(argv: list[str], sif: Path) -> list[str]:
     return argv[argv.index(str(sif)) + 1 :]
 
 
+def _unwrap_git_alias_shell(tokens: list[str]) -> list[str]:
+    """Peel the unconditional ``/bin/bash -lc "<git-alias>; exec <inner>"``
+    wrapper (see ``_apptainer_inner_argv._GIT_ENV_ALIAS_STEPS``) if present.
+
+    Every agent's inner argv is now wrapped in this alias shell regardless
+    of ``startup_commands``/``relaxed``, so both the "relaxed" (no D2
+    preflight) and the D2-wrapped tricky-quoting fixtures need one more
+    unwrap step than before that step existed.
+    """
+    if len(tokens) >= 3 and tokens[0] == "/bin/bash" and tokens[1] == "-lc":
+        _, _, exec_line = tokens[2].rpartition("; exec ")
+        return shlex.split(exec_line)
+    return tokens
+
+
 # ---------------------------------------------------------------------------
 # Fixtures: default-wrapped invocation (preflight active)
 # ---------------------------------------------------------------------------
@@ -140,7 +155,7 @@ def test_preflight_relaxed_inner_starts_with_tini(
     # Arrange
     _argv, inner = relaxed_argv
     # Act
-    first = inner[0]
+    first = _unwrap_git_alias_shell(inner)[0]
     # Assert
     assert first == "/usr/bin/tini"
 
@@ -191,7 +206,10 @@ def tricky_inner(tmp_path: Path) -> list[str]:
 def tricky_exec_argv(tricky_inner: list[str]) -> list[str]:
     script = tricky_inner[2]
     _, _, exec_line = script.rpartition("\nexec ")
-    return shlex.split(exec_line)
+    # The D2 preflight's own exec line is itself the unconditional
+    # ``/bin/bash -lc "<git-alias>; exec <inner>"`` wrapper — one more
+    # unwrap is needed to reach the actual tini/mission invocation.
+    return _unwrap_git_alias_shell(shlex.split(exec_line))
 
 
 def test_preflight_quoting_wraps_with_bash_dash_c(tricky_inner: list[str]) -> None:

--- a/tests/scitex_agent_container/runtimes/test__apptainer_runtime.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_runtime.py
@@ -161,16 +161,29 @@ def _proxy_config(workdir: Path, **kw) -> AgentConfig:
 
 
 def _extract_inner_argv(argv: list[str]) -> list[str]:
-    """Unwrap the D2 ``bash -c "<preflight>\\nexec <inner>"`` wrapper.
+    """Unwrap the D2 ``bash -c "<preflight>\\nexec <inner>"`` wrapper
+    and/or the container-shell ``/bin/bash -lc "<alias/startup>; exec
+    <inner>"`` wrapper (UNCONDITIONAL since the SAC_GIT_* env-alias step
+    was added — see ``_apptainer_inner_argv._GIT_ENV_ALIAS_STEPS`` — so
+    every agent's inner argv is now shell-wrapped, not just those with
+    ``startup_commands``).
 
-    When ``apptainer.relaxed=true`` no wrapper is present and the inner
-    argv lives flat in ``argv``.
+    The two wrappers NEST — the D2 preflight's ``exec`` line is itself
+    ``exec /bin/bash -lc '<git-alias>; exec <runner...>'`` (one shell
+    string, single-quoted) — so a single non-recursive unwrap only peels
+    the outer layer, leaving the inner ``/bin/bash -lc`` triplet
+    unresolved. Recurse until the ``/usr/bin/tini`` marker (or a flat
+    ``apptainer.relaxed=true`` argv with no wrapper at all) is reached.
     """
     for i, a in enumerate(argv):
         if a == "bash" and i + 2 < len(argv) and argv[i + 1] == "-c":
             script = argv[i + 2]
             _, _, exec_line = script.rpartition("\nexec ")
-            return shlex.split(exec_line)
+            return _extract_inner_argv(shlex.split(exec_line))
+        if a == "/bin/bash" and i + 2 < len(argv) and argv[i + 1] == "-lc":
+            script = argv[i + 2]
+            _, _, exec_line = script.rpartition("; exec ")
+            return _extract_inner_argv(shlex.split(exec_line))
         if a == "/usr/bin/tini":
             return argv[i:]
     return []


### PR DESCRIPTION
## Summary

- Adds a **generic, values-agnostic** alias step to the container-side shell wrapper built by `build_inner_argv()` (`src/scitex_agent_container/runtimes/_apptainer_inner_argv.py`): if `SAC_GIT_AUTHOR_NAME` / `SAC_GIT_AUTHOR_EMAIL` / `SAC_GIT_COMMITTER_NAME` / `SAC_GIT_COMMITTER_EMAIL` / `SAC_GIT_SSH_COMMAND` are present in the shell env at that point, it also exports each one under git's own literal `GIT_*` name — because `git` itself only reads the unprefixed names, while the operator wants the canonical, introspectable source-of-truth vars to carry the `SAC_` prefix (`printenv | grep SAC_` shows every sac-relevant var in one shot).
- This step is **values-agnostic**: it does not read any file and does not know or care where `SAC_GIT_*` came from. The actual source is, and remains, each project's own `.envrc` (direnv's `source_up` to e.g. `~/proj/.envrc`) — entirely outside this PR's concern. No `.envrc`, `spec.yaml`, or `.def` file is touched.
- The alias step is unconditional — it now applies to **every** agent, even ones with empty `startup_commands` (previously the whole `bash -lc` wrap was skipped in that case and the runner ran bare). `${VAR:-}` + `-n` guards make an unset `SAC_GIT_*` a silent no-op — it never overwrites an already-correct `GIT_*` with an empty string, and (since the alias runs before any `set -e` that `_format_shell_steps` may emit) a false guard never aborts the launch.
- **Timing**: this runs in the container shell (`bash -lc`, a login shell) AFTER direnv's `/etc/bash.bashrc` hook has already fired, and BEFORE the runner/claude process execs — so it sees whatever `SAC_GIT_*` a project's `.envrc` set. Apptainer's `%environment` was considered and rejected: it's baked into the image and established before the container's user command (this bash wrapper) even runs, so it can never see values direnv sets later. No `.def` file is touched.
- **Host-side only**: takes effect for every agent on its next restart; no image rebuild required.

### Incidental refactor (kept minimal, tests green)
`_apptainer_inner_argv.py` was already at 599 lines (over the repo's 512-line cap) before this change; adding the alias pushed it further over and tripped the line-limit hook. Split the cohesive interactive-TUI argv/channel-plan helpers (`_tui_runner_argv`, `tui_channel_plan`, `tui_channel_config`, `resolve_sac_bin_in_sif`, `_home_has_resumable_conversation`, ...) into a new `_apptainer_inner_argv_tui.py` — pure extraction, no behavior change, every existing import path re-exported unchanged. Both files are now well under the cap (314 / 354 lines).

### Test-suite ripple (unavoidable consequence of "always wrap")
Making the wrap unconditional means `build_inner_argv`'s bare-argv contract changes for every caller (the runner argv is now shell-quoted text after `exec` inside the wrapped script, not the literal returned list). Updated the affected assertions across `test__apptainer_inner_argv.py`, `test__apptainer_inner_argv_mcp.py`, `test__apptainer_build_argv.py`, and `test__apptainer_runtime.py` (mostly to tokenize the exec-tail instead of indexing the raw list), and made `test__apptainer_runtime.py`'s `_extract_inner_argv` unwrap helper **recursive** since the D2 preflight wrapper's own `exec` line is itself this new `/bin/bash -lc` wrapper (nested, not flat).

## Test plan

- [x] `pytest tests/scitex_agent_container/runtimes/test__apptainer_inner_argv.py` — includes new dedicated tests: (a) empty `startup_commands` still wraps in `bash -lc` with the alias present, (b) alias precedes an agent's own `startup_commands` steps, (c) alias runs before `set -e` (never aborts launch), (d) exact 5 `SAC_GIT_*` → `GIT_*` mappings present verbatim, (e) real-bash-subprocess proof the alias is a silent no-op when unset and mirrors the value when set (no mocks).
- [x] `pytest tests/scitex_agent_container/runtimes/` (whole directory, 1196 tests) — 1175 passed, 20 skipped, 1 failed. The 1 failure (`test__sdk_channels.py::TestTelegrammerWakeDiagnostics::test_no_log_when_channel_not_requested`) is a **pre-existing environment issue** in this dev container (the `sac` console script genuinely isn't installed at `/opt/venv-agent/bin/sac` here) — confirmed unrelated to this diff (no file in the failing stack trace was touched by this PR).
- [x] Confirmed both `.py` files are under the 512-line cap (314 / 354 lines).

Not merging — operator-directed review only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
