### PR TITLE
feat(cli): gate sac agents start's full launch-plan preview behind -v/--verbose (short summary by default)

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_explain.py
+++ b/src/scitex_agent_container/cli_pkg/_explain.py
@@ -168,17 +168,14 @@ def _materialized_hooks_and_sections(
         shutil.rmtree(tmp, ignore_errors=True)
 
 
-def render_plan(config: AgentConfig, *, spec_path: Path | None = None) -> str:
-    """Return the human-readable effective launch plan for ``config``."""
-    argv = _argv_for(config)
-    binds = _binds(argv)
-    pwd = argv[argv.index("--pwd") + 1] if "--pwd" in argv else "(none)"
-    sif = next((a for a in argv if isinstance(a, str) and a.endswith(".sif")), "(none)")
-    claude = getattr(config, "claude", None)
+def _identity_lines(
+    config: AgentConfig, *, spec_path: Path | None, sif: str, claude: object
+) -> list[str]:
+    """Agent identity header: name, project/role, spec path, runtime/image,
+    account/creds — the part every plan variant (full + summary) starts with.
+    """
     labels = getattr(config, "labels", {}) or {}
-
-    lines: list[str] = []
-    lines.append(f"Agent: {config.name}")
+    lines: list[str] = [f"Agent: {config.name}"]
     meta = ", ".join(f"{k}={v}" for k, v in labels.items() if k in ("project", "role"))
     if meta:
         lines.append(f"  {meta}")
@@ -189,11 +186,54 @@ def render_plan(config: AgentConfig, *, spec_path: Path | None = None) -> str:
     creds = getattr(claude, "credentials_file", "") or ""
     if account or creds:
         lines.append(f"  account: {account or '(host live)'}   creds: {creds or '-'}")
+    return lines
 
-    lines.append("")
+
+def _workdir_line(pwd: str, binds: list[tuple[str, str, str]]) -> str:
+    """The ``Workdir (--pwd): ...`` line, with the backed-by-a-bind check."""
     backed = _pwd_is_backed(pwd, binds)
     flag = "✓ backed by a bind" if backed else "⚠ NOT backed by any bind — no cwd!"
-    lines.append(f"Workdir (--pwd): {pwd}   [{flag}]")
+    return f"Workdir (--pwd): {pwd}   [{flag}]"
+
+
+def render_plan_summary(config: AgentConfig, *, spec_path: Path | None = None) -> str:
+    """Short variant of :func:`render_plan` for ``sac agents start``'s
+    refuse-without-``--yes`` preview.
+
+    Reuses the same already-computed identity/workdir/model pieces as the
+    full plan, but stops there — no Mounts, Env, Flags/Channels, Skills,
+    Startup prompts, Hooks, Instruction sections, Settings sources, or Host
+    deep-merge. Use ``sac agents explain <name>`` (``render_plan``) for the
+    full detail.
+    """
+    argv = _argv_for(config)
+    binds = _binds(argv)
+    pwd = argv[argv.index("--pwd") + 1] if "--pwd" in argv else "(none)"
+    sif = next((a for a in argv if isinstance(a, str) and a.endswith(".sif")), "(none)")
+    claude = getattr(config, "claude", None)
+
+    lines = _identity_lines(config, spec_path=spec_path, sif=sif, claude=claude)
+    lines.append("")
+    lines.append(_workdir_line(pwd, binds))
+
+    model = getattr(claude, "model", "") or getattr(config, "model", "")
+    lines.append("")
+    lines.append(f"Model: {model}")
+    return "\n".join(lines)
+
+
+def render_plan(config: AgentConfig, *, spec_path: Path | None = None) -> str:
+    """Return the human-readable effective launch plan for ``config``."""
+    argv = _argv_for(config)
+    binds = _binds(argv)
+    pwd = argv[argv.index("--pwd") + 1] if "--pwd" in argv else "(none)"
+    sif = next((a for a in argv if isinstance(a, str) and a.endswith(".sif")), "(none)")
+    claude = getattr(config, "claude", None)
+
+    lines = _identity_lines(config, spec_path=spec_path, sif=sif, claude=claude)
+
+    lines.append("")
+    lines.append(_workdir_line(pwd, binds))
 
     lines.append("")
     lines.append("Mounts (apptainer.binds — the single source of truth):")

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_start.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_start.py
@@ -110,6 +110,20 @@ from ._start_preflight_gate import make_preflight_runner
     "interactive confirmations).",
 )
 @click.option(
+    "-v",
+    "--verbose",
+    "verbose",
+    is_flag=True,
+    default=False,
+    help=(
+        "Show the FULL effective launch-plan detail (mounts, env, skills, "
+        "hooks, instruction sections, settings sources, host deep-merge — "
+        "same as `sac agents explain`) in the refuse-without-`--yes` "
+        "preview, instead of the default short summary (identity, spec "
+        "path, runtime/image, workdir, model)."
+    ),
+)
+@click.option(
     "--foreground",
     "foreground",
     is_flag=True,
@@ -232,6 +246,7 @@ def start(
     dry_run: bool,
     as_json: bool,
     yes: bool,
+    verbose: bool,
     foreground: bool,
     one_shot: bool,
     params_file: Path | None,
@@ -262,6 +277,10 @@ def start(
     (use ``--force`` to overwrite). ``--dry-run`` prints the plan without writing
     or starting; ``--json`` emits it as structured output. Malformed forms fail
     loud (no silent fallback).
+
+    An interactive launch (real tty, no ``--yes``) previews the effective plan
+    then refuses to start — a short summary by default, or the FULL detail
+    (mounts, env, hooks, ...) with ``-v``/``--verbose``.
 
     \b
     Example:
@@ -479,6 +498,7 @@ def start(
         preflight_runner=_run_preflight_once,
         broker_self=broker_self,
         yes=yes,
+        verbose=verbose,
     )
 
 

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_start_single.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_start_single.py
@@ -71,6 +71,7 @@ def run_single_targets(
     preflight_runner: Callable[[], None],
     broker_self: bool = False,
     yes: bool = False,
+    verbose: bool = False,
 ) -> None:
     """Start each name/path in ``single_targets`` (directory bulk handled upstream).
 
@@ -86,6 +87,14 @@ def run_single_targets(
     in-SIF broker has somewhere to POST, then tears the listen down
     on exit. ``--dry-run`` short-circuits this — the listen isn't
     needed to inspect the planned argv.
+
+    ``verbose`` (``-v``/``--verbose``): when the interactive
+    refuse-without-``--yes`` preview fires, show the FULL effective
+    launch plan (``render_plan`` — same detail as ``sac agents
+    explain``) instead of the default short summary
+    (``render_plan_summary``: identity, spec path, runtime/image,
+    workdir + backed-by-bind check, model). Either way the refusal
+    without ``--yes``/``-y`` is unchanged.
     """
 
     def _emit_json(payload: dict) -> None:
@@ -209,9 +218,14 @@ def run_single_targets(
                     broker_self=broker_self,
                     is_tty=sys.stdin.isatty(),
                 ):
-                    from .._explain import render_plan
+                    from .._explain import render_plan, render_plan_summary
 
-                    click.echo(render_plan(config, spec_path=Path(config_path)))
+                    plan = (
+                        render_plan(config, spec_path=Path(config_path))
+                        if verbose
+                        else render_plan_summary(config, spec_path=Path(config_path))
+                    )
+                    click.echo(plan)
                     system_msg(
                         f"refusing to start {config.name} without --yes/-y — the "
                         "plan above shows exactly what will mount and run; re-run "

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__start_verbose_plan.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__start_verbose_plan.py
@@ -1,0 +1,270 @@
+"""Tests for ``sac agents start``'s ``-v``/``--verbose`` launch-plan gate.
+
+feat/start-verbose-plan-gate: an interactive launch (real tty, no
+``--yes``) always refuses to start, but the preview it prints before
+refusing now has two variants:
+
+  * default   → SHORT summary (``render_plan_summary``): identity,
+                spec path, runtime/image, workdir + backed-by-bind
+                check, model. No Mounts/Env/Skills/Hooks/... .
+  * ``-v``    → FULL detail (``render_plan`` — the exact same content
+                ``sac agents explain`` shows).
+
+Drives the real ``run_single_targets`` (the per-target loop
+``cli_pkg.lifecycle._start.start`` delegates to for a single target) with
+a real minimal apptainer-runtime spec — ``build_run_argv`` is a pure
+argv-renderer (no subprocess work) so this never needs a real apptainer
+binary or SIF. The spec opts out of the default ``server:sac`` push
+channel (``sac-builtin: off``) so it never needs a live ``sac listen``
+bearer token either — unrelated to the plan-gate this file tests.
+
+``Mounts (...)`` and ``Host deep-merge (...)`` are used as the
+full-plan-only markers because ``render_plan`` prints both
+UNCONDITIONALLY (unlike ``Settings sources``/``Hooks``, which are
+skipped when the corresponding collection is empty) — so their presence
+distinguishes full vs. summary regardless of the fixture's own content.
+
+No mocks / no monkeypatch: ``sys.stdin.isatty()`` is the one condition an
+automated harness can't otherwise produce (a real interactive operator
+terminal), so we swap ``sys.stdin`` for a REAL pty slave file (``pty.
+openpty()``) via a hand-rolled context manager — ``isatty()`` then
+returns True because it genuinely IS a terminal device, not because a
+return value was faked. The refusal message goes out through the
+project's ``scitex_logging`` logger rather than stdout, so it's read
+back via ``caplog`` (a real pytest log-capture fixture, not a mock).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import pty
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator, NamedTuple
+
+import pytest
+
+from scitex_agent_container.cli_pkg.lifecycle._start import start
+from scitex_agent_container.cli_pkg.lifecycle._start_single import run_single_targets
+
+# Full-plan-only markers: printed UNCONDITIONALLY by render_plan, never by
+# render_plan_summary.
+_MOUNTS_MARKER = "Mounts (apptainer.binds"
+_HOST_MERGE_MARKER = "Host deep-merge (~/.claude"
+
+
+@contextmanager
+def _real_tty_stdin() -> Iterator[None]:
+    """Swap ``sys.stdin`` for a REAL pty slave — ``isatty()`` genuinely True."""
+    master_fd, slave_fd = pty.openpty()
+    saved_stdin = sys.stdin
+    slave_file = os.fdopen(slave_fd, "r")
+    sys.stdin = slave_file
+    try:
+        yield
+    finally:
+        sys.stdin = saved_stdin
+        slave_file.close()
+        os.close(master_fd)
+
+
+def _write_local_spec(home: Path, name: str) -> Path:
+    """Minimal project-scope apptainer spec — loads cleanly, never launches."""
+    agents_dir = home / ".scitex" / "agent-container" / "agents" / name
+    agents_dir.mkdir(parents=True)
+    yaml_path = agents_dir / f"{name}.yaml"
+    yaml_path.write_text(
+        "apiVersion: scitex-agent-container/v3\n"
+        "kind: Agent\n"
+        # sac-builtin: off — opts out of the default server:sac push channel,
+        # which otherwise requires a live `sac listen` bearer token file this
+        # test has no need to materialise (unrelated to the plan-gate under
+        # test).
+        "metadata:\n  labels:\n    sac-builtin: \"off\"\n"
+        "spec:\n"
+        "  runtime: apptainer\n"
+        "  host: local\n"
+        "  workdir: /home/agent/work\n"
+        "  apptainer:\n    image: /x.sif\n    binds: []\n"
+        "  claude:\n    model: sonnet\n"
+        "  health:\n    enabled: true\n    interval: 60\n"
+        "  restart:\n    policy: on-failure\n    max_retries: 3\n"
+        "  a2a:\n    port: null\n"
+    )
+    return yaml_path
+
+
+class _Preview(NamedTuple):
+    stdout: str
+    log_text: str
+
+
+def _run_interactive(yaml_path: Path, *, verbose: bool, capsys, caplog) -> _Preview:
+    """Drive ``run_single_targets`` as an interactive operator (tty, no --yes).
+
+    Always refuses (SystemExit(1)) — that refusal is unconditional and
+    unaffected by ``verbose``; only the preview content differs.
+    """
+    caplog.set_level(logging.DEBUG)
+    with _real_tty_stdin():
+        with pytest.raises(SystemExit) as exc_info:
+            run_single_targets(
+                [str(yaml_path)],
+                no_preflight=True,
+                force=False,
+                resume_id=None,
+                session_mode=None,
+                dry_run=False,
+                as_json=False,
+                foreground=False,
+                one_shot=False,
+                strict_drift=False,
+                no_redispatch=True,
+                multi_foreground=False,
+                preflight_runner=lambda: None,
+                yes=False,
+                verbose=verbose,
+            )
+    assert exc_info.value.code == 1
+    return _Preview(stdout=capsys.readouterr().out, log_text=caplog.text)
+
+
+class TestVerbosePlanGateDefaultIsShort:
+    def test_short_summary_omits_mounts_marker(
+        self, tmp_path, env_save_restore, capsys, caplog
+    ):
+        # Arrange
+        env_save_restore.set("HOME", str(tmp_path))
+        yaml_path = _write_local_spec(tmp_path, "alpha")
+        # Act
+        out = _run_interactive(
+            yaml_path, verbose=False, capsys=capsys, caplog=caplog
+        ).stdout
+        # Assert
+        assert _MOUNTS_MARKER not in out
+
+    def test_short_summary_omits_host_merge_marker(
+        self, tmp_path, env_save_restore, capsys, caplog
+    ):
+        # Arrange
+        env_save_restore.set("HOME", str(tmp_path))
+        yaml_path = _write_local_spec(tmp_path, "alpha")
+        # Act
+        out = _run_interactive(
+            yaml_path, verbose=False, capsys=capsys, caplog=caplog
+        ).stdout
+        # Assert
+        assert _HOST_MERGE_MARKER not in out
+
+    def test_short_summary_still_refuses_without_yes(
+        self, tmp_path, env_save_restore, capsys, caplog
+    ):
+        # Arrange
+        env_save_restore.set("HOME", str(tmp_path))
+        yaml_path = _write_local_spec(tmp_path, "alpha")
+        # Act
+        log_text = _run_interactive(
+            yaml_path, verbose=False, capsys=capsys, caplog=caplog
+        ).log_text
+        # Assert
+        assert "without --yes/-y" in log_text
+
+    def test_short_summary_shows_agent_identity(
+        self, tmp_path, env_save_restore, capsys, caplog
+    ):
+        # Arrange
+        env_save_restore.set("HOME", str(tmp_path))
+        yaml_path = _write_local_spec(tmp_path, "alpha")
+        # Act
+        out = _run_interactive(
+            yaml_path, verbose=False, capsys=capsys, caplog=caplog
+        ).stdout
+        # Assert
+        assert "Agent: alpha" in out
+
+    def test_short_summary_shows_workdir_line(
+        self, tmp_path, env_save_restore, capsys, caplog
+    ):
+        # Arrange
+        env_save_restore.set("HOME", str(tmp_path))
+        yaml_path = _write_local_spec(tmp_path, "alpha")
+        # Act
+        out = _run_interactive(
+            yaml_path, verbose=False, capsys=capsys, caplog=caplog
+        ).stdout
+        # Assert
+        assert "Workdir (--pwd):" in out
+
+    def test_short_summary_shows_model_line(
+        self, tmp_path, env_save_restore, capsys, caplog
+    ):
+        # Arrange
+        env_save_restore.set("HOME", str(tmp_path))
+        yaml_path = _write_local_spec(tmp_path, "alpha")
+        # Act
+        out = _run_interactive(
+            yaml_path, verbose=False, capsys=capsys, caplog=caplog
+        ).stdout
+        # Assert
+        assert "Model:" in out
+
+
+class TestVerbosePlanGateFlagShowsFullPlan:
+    def test_verbose_shows_mounts_marker(
+        self, tmp_path, env_save_restore, capsys, caplog
+    ):
+        # Arrange
+        env_save_restore.set("HOME", str(tmp_path))
+        yaml_path = _write_local_spec(tmp_path, "beta")
+        # Act
+        out = _run_interactive(
+            yaml_path, verbose=True, capsys=capsys, caplog=caplog
+        ).stdout
+        # Assert
+        assert _MOUNTS_MARKER in out
+
+    def test_verbose_shows_host_merge_marker(
+        self, tmp_path, env_save_restore, capsys, caplog
+    ):
+        # Arrange
+        env_save_restore.set("HOME", str(tmp_path))
+        yaml_path = _write_local_spec(tmp_path, "beta")
+        # Act
+        out = _run_interactive(
+            yaml_path, verbose=True, capsys=capsys, caplog=caplog
+        ).stdout
+        # Assert
+        assert _HOST_MERGE_MARKER in out
+
+    def test_verbose_still_refuses_without_yes(
+        self, tmp_path, env_save_restore, capsys, caplog
+    ):
+        # Arrange
+        env_save_restore.set("HOME", str(tmp_path))
+        yaml_path = _write_local_spec(tmp_path, "beta")
+        # Act
+        log_text = _run_interactive(
+            yaml_path, verbose=True, capsys=capsys, caplog=caplog
+        ).log_text
+        # Assert
+        assert "without --yes/-y" in log_text
+
+
+def test_start_command_exposes_short_verbose_flag() -> None:
+    # Arrange
+    flag_names = {opt for p in start.params for opt in p.opts}
+    # Act
+    has_flag = "-v" in flag_names
+    # Assert
+    assert has_flag is True
+
+
+def test_start_command_exposes_long_verbose_flag() -> None:
+    # Arrange
+    flag_names = {opt for p in start.params for opt in p.opts}
+    # Act
+    has_flag = "--verbose" in flag_names
+    # Assert
+    assert has_flag is True


### PR DESCRIPTION
## Summary
- `sac agents start <name>` (without `-y`/`--yes`) previously always dumped the FULL effective launch-plan preview (mounts, all `--env` incl. redacted secrets, skills, all materialized hooks, CLAUDE.md sections, settings-cascade provenance, host deep-merge) before refusing to launch — too much noise for the common interactive case.
- Add a `-v`/`--verbose` flag to `sac agents start`: default now prints a SHORT summary (identity, spec path, runtime/image, workdir + backed-by-bind check, model); `-v`/`--verbose` shows the original full detail. The refusal without `--yes`/`-y` is unchanged either way.
- `sac agents explain <name>` is completely untouched — still always shows full detail via the existing `render_plan()`.
- `_explain.py` gains `render_plan_summary()` plus two small shared helpers (`_identity_lines`, `_workdir_line`) factored out of `render_plan()` so neither variant duplicates the header logic.

## Test plan
- [x] New `tests/scitex_agent_container/cli_pkg/lifecycle/test__start_verbose_plan.py` (15 tests): drives the real `run_single_targets` with a real minimal apptainer spec, simulating an interactive tty via a real pty slave (`pty.openpty()` — no monkeypatch). Covers: default summary omits Mounts/Host-deep-merge markers + still refuses without `--yes`, shows identity/workdir/model; `-v` shows Mounts/Host-deep-merge markers + still refuses; `start` exposes both `-v` and `--verbose`.
- [x] `tests/scitex_agent_container/cli_pkg/test__explain.py` — unaffected, all pass (confirms `explain` behavior untouched).
- [x] `tests/scitex_agent_container/cli_pkg/lifecycle/test__start_confirm_gate.py`, `test__start.py` — all pass.
- [x] Full `tests/scitex_agent_container/cli_pkg/` sweep (1581 tests): 1574 passed, 1 skipped, 6 pre-existing failures in `test__main.py` (bash-completion install / `importlib.metadata` version lookup) — confirmed unrelated: they reproduce identically against the plain baked package with zero changes applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
