### PR TITLE
fix(mcp): agent_create references nonexistent developer/scientist templates (post-#534); rename sac agents new -> create

### DIFF
--- a/src/scitex_agent_container/_mcp/_tools/_agent.py
+++ b/src/scitex_agent_container/_mcp/_tools/_agent.py
@@ -309,29 +309,34 @@ def agent_send(
 
 def agent_create(
     name: str,
-    template: str = "developer",
+    template: str = "python_developer",
     project: str | None = None,
     start: bool = False,
 ) -> dict[str, Any]:
     """Create a proven-shape agent spec from a template. Mirrors
-    ``sac agents new <name> --template developer|scientist --project <p>``.
+    ``sac agents create <name> --template python_developer|researcher|generalist
+    --project <p>``.
 
-    ``create`` was folded into ``new``'s dir-template system
-    (``_template_developer`` / ``_template_scientist`` — card
-    refactor/consolidate-create-into-new-templates): the underscore-agent
-    skeleton is copied wholesale and its ``SAC_PLACEHOLDER_PROJECT`` /
-    ``SAC_PLACEHOLDER_AGENT_ID`` tokens filled from ``project`` (defaults
-    to ``name``) and ``name`` respectively. The old auto-detected
-    editable-install toggle is gone — the install step is now
-    unconditional in the template (delete it by hand if the target repo
-    ships no Python package); likewise there is no per-agent Telegram
-    bot-token wiring — add ``server:claude-code-telegrammer`` + a
-    per-project ``.envrc`` by hand after creation. ``start=True`` launches
-    the agent afterwards. The developer group is authorized to CRUD
-    agents."""
+    ``create`` was folded into ``new``'s dir-template system (card
+    refactor/consolidate-create-into-new-templates), and ``new`` was in
+    turn renamed to ``create`` (CRUD naming, reusing the vacated verb).
+    There is no ``developer``/``scientist`` template — those were the
+    planned-then-dropped names; the fleet's PROVEN dir-templates already
+    cover the same ground: use ``python_developer`` for a developer-role
+    agent and ``researcher`` for a research-role agent (``generalist`` for
+    anything else). The underscore-agent skeleton is copied wholesale and
+    its ``SAC_PLACEHOLDER_PROJECT`` / ``SAC_PLACEHOLDER_AGENT_ID`` tokens
+    filled from ``project`` (defaults to ``name``) and ``name``
+    respectively. The old auto-detected editable-install toggle is gone —
+    the install step is now unconditional in the template (delete it by
+    hand if the target repo ships no Python package); likewise there is no
+    per-agent Telegram bot-token wiring — add
+    ``server:claude-code-telegrammer`` + a per-project ``.envrc`` by hand
+    after creation. ``start=True`` launches the agent afterwards. The
+    developer group is authorized to CRUD agents."""
     argv = [
         "agents",
-        "new",
+        "create",
         name,
         "--template",
         template,

--- a/src/scitex_agent_container/cli_pkg/_create.py
+++ b/src/scitex_agent_container/cli_pkg/_create.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""``sac agents new NAME`` — scaffold a fresh v3 agent spec.
+"""``sac agents create NAME`` — scaffold a fresh v3 agent spec.
 
 Card sac-fresh-agent-specs (2026-06-13). "Author fresh specs from a
 clean template, not in-place repair" — operators get a v3-clean
@@ -23,6 +23,14 @@ Two templates ship out of the box:
 The CLI refuses to overwrite an existing ``spec.yaml`` unless ``--force``
 is passed — protects the "60 stale ``*-quality`` specs already pending
 uncommitted" scenario the card calls out.
+
+Named ``create`` (renamed from ``new``, card
+refactor/consolidate-create-into-new-templates): CRUD naming
+(Create/Read/Update/Delete) lines up with the existing ``delete``
+verb. The old narrow ``sac agents create`` (auto-detected
+editable-install toggle, marker-block machinery) was retired in the
+same card and folded into this command's dir-template system, which
+freed the ``create`` name back up.
 """
 
 from __future__ import annotations
@@ -58,7 +66,7 @@ def _is_valid_agent_name(name: str) -> bool:
 
 
 _MINIMAL_TEMPLATE = """\
-# {name} — fresh v3 spec scaffolded by ``sac agents new``.
+# {name} — fresh v3 spec scaffolded by ``sac agents create``.
 #
 # This is the minimal shape — every field the validator REQUIRES (no hidden
 # defaults): placement, workdir, image + binds, model, health, restart. Add
@@ -97,7 +105,7 @@ spec:
 
 
 _FULL_TEMPLATE = """\
-# {name} — fresh v3 spec scaffolded by ``sac agents new --template full``.
+# {name} — fresh v3 spec scaffolded by ``sac agents create --template full``.
 #
 # Every field below validates against the live v3 schema. Delete blocks
 # you don't need rather than chase the spec reference for what's
@@ -185,7 +193,7 @@ def _default_base_dir() -> Path:
 
         primary, _env, _fleet = _search_dirs()
         return primary
-    except Exception:  # stx-allow: fallback (reason: resolver import is best-effort; hardcoded default keeps `sac agents new` working if config pkg shifts)
+    except Exception:  # stx-allow: fallback (reason: resolver import is best-effort; hardcoded default keeps `sac agents create` working if config pkg shifts)
         return Path.home() / ".scitex" / "agent-container" / "agents"
 
 
@@ -195,8 +203,8 @@ def _extract_base_dir_arg(raw_args: list[str]) -> Path | None:
     ``--help`` is an eager click option: its callback prints help and
     exits before non-eager options (like ``--base-dir``) are parsed into
     ``ctx.params``. Scanning the raw args directly (stashed by
-    :meth:`_NewCommand.parse_args`) lets the dynamic help epilog honor an
-    explicit ``--base-dir`` regardless of where ``--help`` falls in the
+    :meth:`_CreateCommand.parse_args`) lets the dynamic help epilog honor
+    an explicit ``--base-dir`` regardless of where ``--help`` falls in the
     invocation.
     """
     for i, arg in enumerate(raw_args):
@@ -207,8 +215,8 @@ def _extract_base_dir_arg(raw_args: list[str]) -> Path | None:
     return None
 
 
-class _NewCommand(click.Command):
-    """``new`` with a live-scanned template list in its ``--help`` output.
+class _CreateCommand(click.Command):
+    """``create`` with a live-scanned template list in its ``--help`` output.
 
     The ``--template`` option's static ``help=`` text cannot name the
     current ``_template_*`` set — dir-templates are dropped into the
@@ -221,12 +229,12 @@ class _NewCommand(click.Command):
         # Stash the raw args so format_epilog can recover --base-dir even
         # when --help (eager) exits before --base-dir (non-eager) would
         # otherwise be parsed into ctx.params.
-        ctx.meta["_new_raw_args"] = list(args)
+        ctx.meta["_create_raw_args"] = list(args)
         return super().parse_args(ctx, args)
 
     def format_epilog(self, ctx: click.Context, formatter: click.HelpFormatter) -> None:
         super().format_epilog(ctx, formatter)
-        raw_args = ctx.meta.get("_new_raw_args", [])
+        raw_args = ctx.meta.get("_create_raw_args", [])
         base = _extract_base_dir_arg(raw_args) or _default_base_dir()
         dir_templates = sorted(discover_dir_templates(base))
         with formatter.section("Available templates (live-scanned)"):
@@ -243,7 +251,7 @@ class _NewCommand(click.Command):
                 )
 
 
-@click.command(name="new", cls=_NewCommand)
+@click.command(name="create", cls=_CreateCommand)
 @click.argument("name", type=str)
 @click.option(
     "--template",
@@ -254,7 +262,7 @@ class _NewCommand(click.Command):
     help=(
         "Template kind: 'minimal'/'full' (built-in) or any "
         "_template_<kind>/ dir under the agents root. Run "
-        "`sac agents new --help` to see the CURRENT live list."
+        "`sac agents create --help` to see the CURRENT live list."
     ),
 )
 @click.option(
@@ -308,7 +316,7 @@ class _NewCommand(click.Command):
         "re-runs cannot clobber a customised spec."
     ),
 )
-def new(
+def create(
     name: str,
     template_name: str,
     project: str | None,
@@ -330,10 +338,10 @@ def new(
     Examples:
 
     \b
-        sac agents new my-agent
-        sac agents new my-agent --template full
-        sac agents new dev1 --template python_developer --project myproj
-        sac agents new r1 --template researcher --project p --set TEAM=x
+        sac agents create my-agent
+        sac agents create my-agent --template full
+        sac agents create dev1 --template python_developer --project myproj
+        sac agents create r1 --template researcher --project p --set TEAM=x
     """
     if not _is_valid_agent_name(name):
         raise click.UsageError(
@@ -408,4 +416,4 @@ def new(
     )
 
 
-__all__ = ["new"]
+__all__ = ["create"]

--- a/src/scitex_agent_container/cli_pkg/_new_dir_template.py
+++ b/src/scitex_agent_container/cli_pkg/_new_dir_template.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""Directory-template support for ``sac agents new``.
+"""Directory-template support for ``sac agents create``.
 
 Beyond the two inline string templates (``minimal`` / ``full``), the
 operator ships *directory* templates that live in the agents root,
@@ -11,7 +11,7 @@ kind needs, with literal placeholder tokens of the form
 ``SAC_PLACEHOLDER_<NAME>`` baked into the files (workdir paths, install
 targets, labels, STATE_DB names, …).
 
-``sac agents new <name> --template <kind>`` instantiates such a template
+``sac agents create <name> --template <kind>`` instantiates such a template
 by *copying the whole tree* to ``<base-dir>/<name>/`` and substituting
 the placeholder tokens. The substitution is fail-loud: if ANY
 ``SAC_PLACEHOLDER_*`` token survives, the partial output directory is

--- a/src/scitex_agent_container/cli_pkg/agent_group.py
+++ b/src/scitex_agent_container/cli_pkg/agent_group.py
@@ -15,7 +15,7 @@ import click
 from ._agent_prune_claude import prune_claude as _prune_claude_impl
 from ._explain import explain as _explain_impl
 from ._helpers import HelpRecursiveGroup
-from ._new import new as _new_impl
+from ._create import create as _create_impl
 from .agents_prune_claude import archive_claude_bloat as _archive_claude_bloat_impl
 from .build_cmds import check as _check_impl
 from .info_cmds import find as _find_impl
@@ -50,7 +50,7 @@ class _AgentsGroup(HelpRecursiveGroup):
     COMMAND_CATEGORIES = [
         (
             "Lifecycle",
-            ["new", "start", "stop", "restart", "delete", "forget", "spawn-from-here"],
+            ["create", "start", "stop", "restart", "delete", "forget", "spawn-from-here"],
         ),
         ("Interact", ["send", "attach"]),
         ("Inspect", ["list", "status", "health", "tail", "recall"]),
@@ -67,16 +67,20 @@ def agent_group() -> None:
 
 
 # Lifecycle verbs
-# `new` scaffolds a fresh v3 spec.yaml + to_home/ skeleton (card
+# `create` scaffolds a fresh v3 spec.yaml + to_home/ skeleton (card
 # sac-fresh-agent-specs, 2026-06-13). Placed FIRST in the lifecycle
 # block — authoring precedes start/stop.
-agent_group.add_command(_rebind(_new_impl, "new"))
-# `create` (card sac-templated-agent-create, 2026-06-25) was folded into
-# `new`'s dir-template system as `_template_developer/` / `_template_scientist/`
-# (card refactor/consolidate-create-into-new-templates) — the auto-detect /
-# marker-block machinery is retired in favor of the plain, unconditional
-# convention the other dir-templates already use. Use
-# `sac agents new <name> --template developer|scientist --project <p>`.
+#
+# This command was named `new` until card
+# refactor/consolidate-create-into-new-templates: the OLD, narrower
+# `sac agents create` (auto-detect / marker-block machinery, card
+# sac-templated-agent-create 2026-06-25) was folded into `new`'s
+# dir-template system, which freed the `create` name back up — `new`
+# was then renamed to `create` for CRUD-consistent naming (the CLI
+# already has `delete`). Use
+# `sac agents create <name> --template python_developer|researcher|generalist
+# --project <p>`.
+agent_group.add_command(_rebind(_create_impl, "create"))
 agent_group.add_command(_rebind(_start_impl, "start"))
 agent_group.add_command(_rebind(_stop_impl, "stop"))
 agent_group.add_command(_rebind(_restart_impl, "restart"))

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_cold_start.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_cold_start.py
@@ -24,7 +24,7 @@ import re
 from dataclasses import dataclass
 from pathlib import Path
 
-# Agent-name charset (mirrors cli_pkg._new validation): lowercase letters,
+# Agent-name charset (mirrors cli_pkg._create validation): lowercase letters,
 # digits, hyphen, underscore; must start with a letter.
 _VALID_LABEL = re.compile(r"^[a-z][a-z0-9_-]*$")
 
@@ -36,7 +36,7 @@ _VALID_LABEL = re.compile(r"^[a-z][a-z0-9_-]*$")
 # (``local`` = the caller's host; dispatch runs remote when it names a peer).
 _COLD_START_SPEC = """\
 # {label} — cold-started by `sac start` ({stamp_note}).
-# Standardized TUI spec; edit freely or `sac agents new` for the full tour.
+# Standardized TUI spec; edit freely or `sac agents create` for the full tour.
 apiVersion: scitex-agent-container/v3
 kind: Agent
 metadata:

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__start.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__start.py
@@ -915,7 +915,7 @@ class TestColdStart:
         # Act
         CliRunner().invoke(start, [str(work), "--dry-run"])
         # Assert — dry-run must not materialize into the real agents root.
-        from scitex_agent_container.cli_pkg._new import _default_base_dir
+        from scitex_agent_container.cli_pkg._create import _default_base_dir
 
         assert not (_default_base_dir() / "figdemo-unique-xyz").exists()
 

--- a/tests/scitex_agent_container/cli_pkg/test__create.py
+++ b/tests/scitex_agent_container/cli_pkg/test__create.py
@@ -1,9 +1,14 @@
-"""Tests for ``sac agents new`` — scaffold a fresh v3 spec.yaml.
+"""Tests for ``sac agents create`` — scaffold a fresh v3 spec.yaml.
 
 Card sac-fresh-agent-specs (2026-06-13). Authoring policy is "fresh
-template, not in-place repair": the operator runs ``sac agents new
+template, not in-place repair": the operator runs ``sac agents create
 <name>`` and gets a v3-clean spec.yaml + to_home/ skeleton next to it,
 ready to edit. The validator must accept the output as-is.
+
+Renamed from ``new`` to ``create`` (card
+refactor/consolidate-create-into-new-templates) — CRUD-consistent
+naming now that the old, narrower ``create`` command was folded into
+this one's dir-template system, freeing the name back up.
 
 Discipline: AAA markers each on their own line; one literal ``assert``
 per test; real filesystem fixtures (``tmp_path``), no mocks.
@@ -16,51 +21,51 @@ from pathlib import Path
 import yaml
 from click.testing import CliRunner
 
-from scitex_agent_container.cli_pkg._new import new as new_cmd
+from scitex_agent_container.cli_pkg._create import create as create_cmd
 from scitex_agent_container.config._validation import validate_config
 
 
-def test_new_writes_spec_yaml_at_target(tmp_path: Path) -> None:
+def test_create_writes_spec_yaml_at_target(tmp_path: Path) -> None:
     # Arrange
     runner = CliRunner()
     base = tmp_path / "agents"
     # Act
-    runner.invoke(new_cmd, ["my-agent", "--base-dir", str(base)])
+    runner.invoke(create_cmd, ["my-agent", "--base-dir", str(base)])
     # Assert
     assert (base / "my-agent" / "spec.yaml").is_file()
 
 
-def test_new_minimal_template_passes_v3_validator(tmp_path: Path) -> None:
+def test_create_minimal_template_passes_v3_validator(tmp_path: Path) -> None:
     # Arrange
     runner = CliRunner()
     base = tmp_path / "agents"
     # Act
     runner.invoke(
-        new_cmd, ["fresh-agent", "--base-dir", str(base), "--template", "minimal"]
+        create_cmd, ["fresh-agent", "--base-dir", str(base), "--template", "minimal"]
     )
     errors = validate_config(base / "fresh-agent" / "spec.yaml")
     # Assert — fresh template must satisfy the live validator (zero errors).
     assert errors == []
 
 
-def test_new_full_template_passes_v3_validator(tmp_path: Path) -> None:
+def test_create_full_template_passes_v3_validator(tmp_path: Path) -> None:
     # Arrange
     runner = CliRunner()
     base = tmp_path / "agents"
     # Act
     runner.invoke(
-        new_cmd, ["full-fresh", "--base-dir", str(base), "--template", "full"]
+        create_cmd, ["full-fresh", "--base-dir", str(base), "--template", "full"]
     )
     errors = validate_config(base / "full-fresh" / "spec.yaml")
     # Assert
     assert errors == []
 
 
-def test_new_default_template_is_minimal(tmp_path: Path) -> None:
+def test_create_default_template_is_minimal(tmp_path: Path) -> None:
     # Arrange
     runner = CliRunner()
     base = tmp_path / "agents"
-    runner.invoke(new_cmd, ["defaulty", "--base-dir", str(base)])
+    runner.invoke(create_cmd, ["defaulty", "--base-dir", str(base)])
     # Act — parse the spec YAML to inspect the rendered config keys, NOT
     # the prose docstring (the comment legitimately MENTIONS the field
     # name as an "add this if you need it" pointer).
@@ -69,82 +74,82 @@ def test_new_default_template_is_minimal(tmp_path: Path) -> None:
     assert "startup_prompts" not in parsed.get("spec", {})
 
 
-def test_new_creates_to_home_skeleton(tmp_path: Path) -> None:
+def test_create_creates_to_home_skeleton(tmp_path: Path) -> None:
     # Arrange
     runner = CliRunner()
     base = tmp_path / "agents"
     # Act
-    runner.invoke(new_cmd, ["agent-x", "--base-dir", str(base)])
+    runner.invoke(create_cmd, ["agent-x", "--base-dir", str(base)])
     # Assert — to_home/ exists as a sibling of spec.yaml so the runtime
     # auto-discovers it (spec-reference §to_home).
     assert (base / "agent-x" / "to_home").is_dir()
 
 
-def test_new_refuses_to_overwrite_existing_spec(tmp_path: Path) -> None:
+def test_create_refuses_to_overwrite_existing_spec(tmp_path: Path) -> None:
     # Arrange
     runner = CliRunner()
     base = tmp_path / "agents"
     (base / "dupe").mkdir(parents=True)
     (base / "dupe" / "spec.yaml").write_text("# pre-existing\n")
     # Act
-    result = runner.invoke(new_cmd, ["dupe", "--base-dir", str(base)])
+    result = runner.invoke(create_cmd, ["dupe", "--base-dir", str(base)])
     # Assert — non-zero exit so accidental clobber is impossible without --force.
     assert result.exit_code != 0
 
 
-def test_new_force_overwrites_existing_spec(tmp_path: Path) -> None:
+def test_create_force_overwrites_existing_spec(tmp_path: Path) -> None:
     # Arrange
     runner = CliRunner()
     base = tmp_path / "agents"
     (base / "dupe2").mkdir(parents=True)
     (base / "dupe2" / "spec.yaml").write_text("# stale\n")
     # Act
-    runner.invoke(new_cmd, ["dupe2", "--base-dir", str(base), "--force"])
+    runner.invoke(create_cmd, ["dupe2", "--base-dir", str(base), "--force"])
     text = (base / "dupe2" / "spec.yaml").read_text()
     # Assert — fresh template replaces the stale stub (apiVersion line is canonical).
     assert "scitex-agent-container/v3" in text
 
 
-def test_new_rejects_unknown_template(tmp_path: Path) -> None:
+def test_create_rejects_unknown_template(tmp_path: Path) -> None:
     # Arrange
     runner = CliRunner()
     base = tmp_path / "agents"
     # Act
     result = runner.invoke(
-        new_cmd, ["bad", "--base-dir", str(base), "--template", "nope"]
+        create_cmd, ["bad", "--base-dir", str(base), "--template", "nope"]
     )
     # Assert — Click's Choice raises UsageError (exit code 2).
     assert result.exit_code != 0
 
 
-def test_new_emits_canonical_apiversion_header(tmp_path: Path) -> None:
+def test_create_emits_canonical_apiversion_header(tmp_path: Path) -> None:
     # Arrange
     runner = CliRunner()
     base = tmp_path / "agents"
     # Act
-    runner.invoke(new_cmd, ["headered", "--base-dir", str(base)])
+    runner.invoke(create_cmd, ["headered", "--base-dir", str(base)])
     first_lines = (base / "headered" / "spec.yaml").read_text().splitlines()[:10]
     # Assert — apiVersion appears in the file head (no buried boilerplate).
     assert any("apiVersion: scitex-agent-container/v3" in line for line in first_lines)
 
 
-def test_new_template_kind_is_agent_not_agentproxy(tmp_path: Path) -> None:
+def test_create_template_kind_is_agent_not_agentproxy(tmp_path: Path) -> None:
     # Arrange
     runner = CliRunner()
     base = tmp_path / "agents"
     # Act
-    runner.invoke(new_cmd, ["kindly", "--base-dir", str(base)])
+    runner.invoke(create_cmd, ["kindly", "--base-dir", str(base)])
     text = (base / "kindly" / "spec.yaml").read_text()
     # Assert — default scaffold is the common case (SDK runner).
     assert "kind: Agent" in text
 
 
-def test_new_rejects_invalid_agent_name(tmp_path: Path) -> None:
+def test_create_rejects_invalid_agent_name(tmp_path: Path) -> None:
     # Arrange — names with slashes would write outside the base dir.
     runner = CliRunner()
     base = tmp_path / "agents"
     # Act
-    result = runner.invoke(new_cmd, ["bad/name", "--base-dir", str(base)])
+    result = runner.invoke(create_cmd, ["bad/name", "--base-dir", str(base)])
     # Assert
     assert result.exit_code != 0
 
@@ -222,12 +227,12 @@ def _invoke_demo(
 ) -> object:
     """Instantiate the demo dir-template under ``base`` and return result."""
     return runner.invoke(
-        new_cmd,
+        create_cmd,
         [name, "--base-dir", str(base), "--template", "demo", *extra_args],
     )
 
 
-def test_new_dir_template_instantiation_exits_zero(tmp_path: Path) -> None:
+def test_create_dir_template_instantiation_exits_zero(tmp_path: Path) -> None:
     # Arrange
     runner = CliRunner()
     base = tmp_path / "agents"
@@ -240,7 +245,7 @@ def test_new_dir_template_instantiation_exits_zero(tmp_path: Path) -> None:
     assert result.exit_code == 0
 
 
-def test_new_dir_template_writes_spec_yaml(tmp_path: Path) -> None:
+def test_create_dir_template_writes_spec_yaml(tmp_path: Path) -> None:
     # Arrange
     runner = CliRunner()
     base = tmp_path / "agents"
@@ -251,7 +256,7 @@ def test_new_dir_template_writes_spec_yaml(tmp_path: Path) -> None:
     assert (base / "demo1" / "spec.yaml").is_file()
 
 
-def test_new_dir_template_leaves_no_placeholder(tmp_path: Path) -> None:
+def test_create_dir_template_leaves_no_placeholder(tmp_path: Path) -> None:
     # Arrange
     runner = CliRunner()
     base = tmp_path / "agents"
@@ -262,7 +267,7 @@ def test_new_dir_template_leaves_no_placeholder(tmp_path: Path) -> None:
     assert _no_placeholder_remains(base / "demo1")
 
 
-def test_new_dir_template_filled_spec_validates(tmp_path: Path) -> None:
+def test_create_dir_template_filled_spec_validates(tmp_path: Path) -> None:
     # Arrange
     runner = CliRunner()
     base = tmp_path / "agents"
@@ -274,14 +279,14 @@ def test_new_dir_template_filled_spec_validates(tmp_path: Path) -> None:
     assert errors == []
 
 
-def test_new_dir_template_copies_to_home_tree(tmp_path: Path) -> None:
+def test_create_dir_template_copies_to_home_tree(tmp_path: Path) -> None:
     # Arrange
     runner = CliRunner()
     base = tmp_path / "agents"
     _make_demo_template(base)
     # Act
     runner.invoke(
-        new_cmd,
+        create_cmd,
         ["d2", "--base-dir", str(base), "--template", "demo", "--project", "p"],
     )
     home = (base / "d2" / "to_home" / "CLAUDE.md").read_text()
@@ -289,14 +294,14 @@ def test_new_dir_template_copies_to_home_tree(tmp_path: Path) -> None:
     assert "agent=d2 project=p" in home
 
 
-def test_new_dir_template_agent_id_defaults_to_name(tmp_path: Path) -> None:
+def test_create_dir_template_agent_id_defaults_to_name(tmp_path: Path) -> None:
     # Arrange
     runner = CliRunner()
     base = tmp_path / "agents"
     _make_demo_template(base)
     # Act — omit --agent-id; it must default to <name>.
     runner.invoke(
-        new_cmd,
+        create_cmd,
         ["nameddefault", "--base-dir", str(base), "--template", "demo", "--project", "p"],
     )
     text = (base / "nameddefault" / "to_home" / "CLAUDE.md").read_text()
@@ -304,7 +309,7 @@ def test_new_dir_template_agent_id_defaults_to_name(tmp_path: Path) -> None:
     assert "agent=nameddefault" in text
 
 
-def test_new_dir_template_missing_placeholder_exits_nonzero(tmp_path: Path) -> None:
+def test_create_dir_template_missing_placeholder_exits_nonzero(tmp_path: Path) -> None:
     # Arrange — omit --project so SAC_PLACEHOLDER_PROJECT cannot be filled.
     runner = CliRunner()
     base = tmp_path / "agents"
@@ -315,7 +320,7 @@ def test_new_dir_template_missing_placeholder_exits_nonzero(tmp_path: Path) -> N
     assert result.exit_code != 0
 
 
-def test_new_dir_template_missing_placeholder_names_token(tmp_path: Path) -> None:
+def test_create_dir_template_missing_placeholder_names_token(tmp_path: Path) -> None:
     # Arrange
     runner = CliRunner()
     base = tmp_path / "agents"
@@ -326,7 +331,7 @@ def test_new_dir_template_missing_placeholder_names_token(tmp_path: Path) -> Non
     assert "SAC_PLACEHOLDER_PROJECT" in result.output
 
 
-def test_new_dir_template_missing_placeholder_leaves_no_output(tmp_path: Path) -> None:
+def test_create_dir_template_missing_placeholder_leaves_no_output(tmp_path: Path) -> None:
     # Arrange
     runner = CliRunner()
     base = tmp_path / "agents"
@@ -337,7 +342,7 @@ def test_new_dir_template_missing_placeholder_leaves_no_output(tmp_path: Path) -
     assert not (base / "partial").exists()
 
 
-def test_new_dir_template_set_exits_zero(tmp_path: Path) -> None:
+def test_create_dir_template_set_exits_zero(tmp_path: Path) -> None:
     # Arrange — demo carries a custom SAC_PLACEHOLDER_EXTRA token.
     runner = CliRunner()
     base = tmp_path / "agents"
@@ -350,7 +355,7 @@ def test_new_dir_template_set_exits_zero(tmp_path: Path) -> None:
     assert result.exit_code == 0
 
 
-def test_new_dir_template_set_fills_custom_token(tmp_path: Path) -> None:
+def test_create_dir_template_set_fills_custom_token(tmp_path: Path) -> None:
     # Arrange
     runner = CliRunner()
     base = tmp_path / "agents"
@@ -362,7 +367,7 @@ def test_new_dir_template_set_fills_custom_token(tmp_path: Path) -> None:
     assert "extra=val" in text
 
 
-def test_new_dir_template_discovery_is_dynamic(tmp_path: Path) -> None:
+def test_create_dir_template_discovery_is_dynamic(tmp_path: Path) -> None:
     # Arrange — a brand-new _template_demo/ dir with NO code change must
     # be accepted as a --template choice.
     runner = CliRunner()
@@ -370,14 +375,14 @@ def test_new_dir_template_discovery_is_dynamic(tmp_path: Path) -> None:
     _make_demo_template(base)
     # Act
     result = runner.invoke(
-        new_cmd,
+        create_cmd,
         ["dyn", "--base-dir", str(base), "--template", "demo", "--project", "p"],
     )
     # Assert
     assert result.exit_code == 0
 
 
-def test_new_inline_minimal_still_works_with_dir_templates_present(
+def test_create_inline_minimal_still_works_with_dir_templates_present(
     tmp_path: Path,
 ) -> None:
     # Arrange — dir-template present, but inline 'minimal' must still render
@@ -387,7 +392,7 @@ def test_new_inline_minimal_still_works_with_dir_templates_present(
     _make_demo_template(base)
     # Act
     runner.invoke(
-        new_cmd, ["inl", "--base-dir", str(base), "--template", "minimal"]
+        create_cmd, ["inl", "--base-dir", str(base), "--template", "minimal"]
     )
     errors = validate_config(base / "inl" / "spec.yaml")
     # Assert
@@ -395,13 +400,16 @@ def test_new_inline_minimal_still_works_with_dir_templates_present(
 
 
 # ---------------------------------------------------------------------------
-# `create` consolidation — developer/scientist are now `_template_*` dirs
-# (card refactor/consolidate-create-into-new-templates), not a separate
-# `sac agents create` command. These fixtures mirror the SHAPE of the real
-# `_template_developer` / `_template_scientist` dirs shipped in the operator's
-# agents root (outside this repo, like `_template_researcher`) — same
-# SAC_PLACEHOLDER_PROJECT / SAC_PLACEHOLDER_AGENT_ID tokens, groups, and
-# purpose suffix — so the mechanism + shape is covered hermetically in CI.
+# Old-`create` consolidation — the retired, narrower `sac agents create`
+# (auto-detect / marker-block machinery, card sac-templated-agent-create
+# 2026-06-25) was folded into the dir-template system rather than kept as
+# a separate command (card refactor/consolidate-create-into-new-templates).
+# `developer`/`scientist` below are SYNTHETIC demo fixtures exercising the
+# generic `_template_<kind>/` mechanism hermetically in CI — they do NOT
+# mirror any real shipped template. The fleet's actual dir-templates are
+# `_template_python_developer` / `_template_researcher` / `_template_generalist`
+# (operator's agents root, outside this repo); there is no
+# `_template_developer` / `_template_scientist` and there never will be.
 # ---------------------------------------------------------------------------
 
 _DEVELOPER_DEMO_SPEC = """\
@@ -474,28 +482,28 @@ def _write_dir_template(base: Path, kind: str, body: str) -> Path:
     return tdir
 
 
-def test_new_developer_template_leaves_no_placeholder(tmp_path: Path) -> None:
+def test_create_developer_template_leaves_no_placeholder(tmp_path: Path) -> None:
     # Arrange
     runner = CliRunner()
     base = tmp_path / "agents"
     _write_dir_template(base, "developer", _DEVELOPER_DEMO_SPEC)
     # Act
     runner.invoke(
-        new_cmd,
+        create_cmd,
         ["dev1", "--base-dir", str(base), "--template", "developer", "--project", "myproj"],
     )
     # Assert
     assert _no_placeholder_remains(base / "dev1")
 
 
-def test_new_developer_template_validates(tmp_path: Path) -> None:
+def test_create_developer_template_validates(tmp_path: Path) -> None:
     # Arrange
     runner = CliRunner()
     base = tmp_path / "agents"
     _write_dir_template(base, "developer", _DEVELOPER_DEMO_SPEC)
     # Act
     runner.invoke(
-        new_cmd,
+        create_cmd,
         ["dev2", "--base-dir", str(base), "--template", "developer", "--project", "myproj"],
     )
     errors = validate_config(base / "dev2" / "spec.yaml")
@@ -503,14 +511,14 @@ def test_new_developer_template_validates(tmp_path: Path) -> None:
     assert errors == []
 
 
-def test_new_developer_template_group_label(tmp_path: Path) -> None:
+def test_create_developer_template_group_label(tmp_path: Path) -> None:
     # Arrange
     runner = CliRunner()
     base = tmp_path / "agents"
     _write_dir_template(base, "developer", _DEVELOPER_DEMO_SPEC)
     # Act
     runner.invoke(
-        new_cmd,
+        create_cmd,
         ["dev3", "--base-dir", str(base), "--template", "developer", "--project", "myproj"],
     )
     parsed = yaml.safe_load((base / "dev3" / "spec.yaml").read_text())
@@ -518,28 +526,28 @@ def test_new_developer_template_group_label(tmp_path: Path) -> None:
     assert parsed["metadata"]["labels"]["groups"] == ["developer"]
 
 
-def test_new_scientist_template_leaves_no_placeholder(tmp_path: Path) -> None:
+def test_create_scientist_template_leaves_no_placeholder(tmp_path: Path) -> None:
     # Arrange
     runner = CliRunner()
     base = tmp_path / "agents"
     _write_dir_template(base, "scientist", _SCIENTIST_DEMO_SPEC)
     # Act
     runner.invoke(
-        new_cmd,
+        create_cmd,
         ["sci1", "--base-dir", str(base), "--template", "scientist", "--project", "paperx"],
     )
     # Assert
     assert _no_placeholder_remains(base / "sci1")
 
 
-def test_new_scientist_template_validates(tmp_path: Path) -> None:
+def test_create_scientist_template_validates(tmp_path: Path) -> None:
     # Arrange
     runner = CliRunner()
     base = tmp_path / "agents"
     _write_dir_template(base, "scientist", _SCIENTIST_DEMO_SPEC)
     # Act
     runner.invoke(
-        new_cmd,
+        create_cmd,
         ["sci2", "--base-dir", str(base), "--template", "scientist", "--project", "paperx"],
     )
     errors = validate_config(base / "sci2" / "spec.yaml")
@@ -547,14 +555,14 @@ def test_new_scientist_template_validates(tmp_path: Path) -> None:
     assert errors == []
 
 
-def test_new_scientist_template_group_label(tmp_path: Path) -> None:
+def test_create_scientist_template_group_label(tmp_path: Path) -> None:
     # Arrange
     runner = CliRunner()
     base = tmp_path / "agents"
     _write_dir_template(base, "scientist", _SCIENTIST_DEMO_SPEC)
     # Act
     runner.invoke(
-        new_cmd,
+        create_cmd,
         ["sci3", "--base-dir", str(base), "--template", "scientist", "--project", "paperx"],
     )
     parsed = yaml.safe_load((base / "sci3" / "spec.yaml").read_text())
@@ -562,14 +570,14 @@ def test_new_scientist_template_group_label(tmp_path: Path) -> None:
     assert parsed["metadata"]["labels"]["groups"] == ["scientist"]
 
 
-def test_new_scientist_template_purpose_suffix(tmp_path: Path) -> None:
+def test_create_scientist_template_purpose_suffix(tmp_path: Path) -> None:
     # Arrange
     runner = CliRunner()
     base = tmp_path / "agents"
     _write_dir_template(base, "scientist", _SCIENTIST_DEMO_SPEC)
     # Act
     runner.invoke(
-        new_cmd,
+        create_cmd,
         ["sci4", "--base-dir", str(base), "--template", "scientist", "--project", "paperx"],
     )
     parsed = yaml.safe_load((base / "sci4" / "spec.yaml").read_text())
@@ -582,39 +590,39 @@ def test_new_scientist_template_purpose_suffix(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_new_help_lists_live_dir_templates(tmp_path: Path) -> None:
+def test_create_help_lists_live_dir_templates(tmp_path: Path) -> None:
     # Arrange — a brand-new throwaway dir-template with NO code change must
     # surface in --help, proving the list is live-scanned, not hardcoded.
     runner = CliRunner()
     base = tmp_path / "agents"
     _write_dir_template(base, "zzz_test", _DEVELOPER_DEMO_SPEC)
     # Act
-    result = runner.invoke(new_cmd, ["--base-dir", str(base), "--help"])
+    result = runner.invoke(create_cmd, ["--base-dir", str(base), "--help"])
     # Assert
     assert "zzz_test" in result.output
 
 
-def test_new_help_lists_inline_templates(tmp_path: Path) -> None:
+def test_create_help_lists_inline_templates(tmp_path: Path) -> None:
     # Arrange
     runner = CliRunner()
     base = tmp_path / "agents"
     # Act
-    result = runner.invoke(new_cmd, ["--base-dir", str(base), "--help"])
+    result = runner.invoke(create_cmd, ["--base-dir", str(base), "--help"])
     # Assert — built-in presets are always listed alongside any dir-templates.
     assert "minimal" in result.output and "full" in result.output
 
 
-def test_new_help_omits_dir_template_absent_from_root(tmp_path: Path) -> None:
+def test_create_help_omits_dir_template_absent_from_root(tmp_path: Path) -> None:
     # Arrange — an EMPTY agents root: no _template_* dirs exist.
     runner = CliRunner()
     base = tmp_path / "agents"
     # Act
-    result = runner.invoke(new_cmd, ["--base-dir", str(base), "--help"])
+    result = runner.invoke(create_cmd, ["--base-dir", str(base), "--help"])
     # Assert — nothing invented; the live scan reports none found.
     assert "none found" in result.output
 
 
-def test_new_rejects_unknown_template_still_lists_choices(tmp_path: Path) -> None:
+def test_create_rejects_unknown_template_still_lists_choices(tmp_path: Path) -> None:
     # Arrange — regression check: an unknown --template still fails loud
     # and names the valid choices (unaffected by the --help epilog change).
     runner = CliRunner()
@@ -622,7 +630,7 @@ def test_new_rejects_unknown_template_still_lists_choices(tmp_path: Path) -> Non
     _write_dir_template(base, "developer", _DEVELOPER_DEMO_SPEC)
     # Act
     result = runner.invoke(
-        new_cmd, ["whoops", "--base-dir", str(base), "--template", "nope"]
+        create_cmd, ["whoops", "--base-dir", str(base), "--template", "nope"]
     )
     # Assert
     assert "developer" in result.output and result.exit_code != 0

--- a/tests/scitex_agent_container/cli_pkg/test_agent_group.py
+++ b/tests/scitex_agent_container/cli_pkg/test_agent_group.py
@@ -46,20 +46,30 @@ def test_agents_status_and_list_share_same_callback() -> None:
     assert same_callback
 
 
-def test_agents_create_command_is_removed() -> None:
-    # Arrange — `create` was folded into `new --template developer|scientist`
-    # (card refactor/consolidate-create-into-new-templates); the standalone
-    # command must no longer be registered.
+def test_agents_new_command_name_is_retired() -> None:
+    # Arrange — the old, narrower `create` was folded into `new`'s
+    # dir-template system (card refactor/consolidate-create-into-new-templates),
+    # and `new` was then renamed to `create` for CRUD-consistent naming
+    # (the CLI already has `delete`). The `new` name is no longer registered.
     # Act
-    is_registered = "create" in agent_group.commands
+    is_registered = "new" in agent_group.commands
     # Assert
     assert is_registered is False
 
 
-def test_agents_help_does_not_list_create() -> None:
+def test_agents_create_command_is_registered() -> None:
+    # Arrange — `create` now names the unified dir-template-aware command
+    # (formerly `new`); the vacated old-`create` name was reused.
+    # Act
+    is_registered = "create" in agent_group.commands
+    # Assert
+    assert is_registered is True
+
+
+def test_agents_help_lists_create_under_lifecycle() -> None:
     # Arrange
     runner = CliRunner()
     # Act
     result = runner.invoke(agent_group, ["--help"])
-    # Assert — the Lifecycle section no longer names `create`.
-    assert "create" not in result.output
+    # Assert — the Lifecycle section names `create` (renamed from `new`).
+    assert "create" in result.output


### PR DESCRIPTION
## Summary
- Fixes a **live regression on `develop`** introduced by #534 (merged before its follow-up fix could land): the `agent_create` MCP tool's `template` param defaulted to / documented `developer`/`scientist`, but those dir-templates were never shipped — the operator decided the fleet's proven `_template_python_developer` / `_template_researcher` already cover the same ground, so no new templates were added. Calling `agent_create` with those values hit the CLI's fail-loud "Unknown template" error. Now defaults to / documents the real choices: `python_developer`, `researcher`, `generalist`.
- Renames the CLI command `sac agents new` -> `sac agents create` (operator's explicit CRUD-naming request): the old narrow `create` was retired in #534, freeing the name back up, and the CLI already has `delete`. Renamed `cli_pkg/_new.py` -> `_create.py`, updated `agent_group.py` registration, `agent_create`'s argv (now literally matches the CLI verb it shells: `["agents", "create", ...]`), and every docstring/help-text/example referencing `sac agents new`.

## Test plan
- [x] `tests/scitex_agent_container/cli_pkg/test__create.py` (renamed from `test__new.py`) — 35 passed
- [x] `tests/scitex_agent_container/cli_pkg/test_agent_group.py` — 6 passed (updated the two tests that asserted `create` was absent — it's now the renamed `new`)
- [x] `tests/scitex_agent_container/_mcp/` (full suite) — 389 passed
- [x] `tests/scitex_agent_container/cli_pkg/lifecycle/test__start.py` — 44 passed (updated one stale import path)
- [x] `tests/scitex_agent_container/cli_pkg/lifecycle/test__cold_start.py` + `test__cold_start_materialize.py` — 33 passed
- [x] Manual: `sac agents --help` lists `create` under Lifecycle; `sac agents create --help` renders correctly with the corrected examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)