### PR TITLE
docs(skill): broaden WHEN clause for paraphrased-intent triggering

### DIFF
--- a/src/scitex_agent_container/_skills/scitex-agent-container/SKILL.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/SKILL.md
@@ -2,7 +2,7 @@
 name: scitex-agent-container
 description: |
   [WHAT] Declarative YAML AI-agent lifecycle — define an agent in one `spec.yaml`; `sac agents start` runs it as a long-lived Claude SDK session inside Apptainer, with A2A inbound (`POST /v1/turn`), SSH remote deploy, JSON status.
-  [WHEN] Launching/managing a Claude Code agent or fleet, running one on a remote host, wiring MCP, talking over A2A, or any mention of `sac agents start`, `scitex-agent-container`, `spec.yaml`, fleet head/worker.
+  [WHEN] Launching/managing a Claude Code agent or fleet, running one on a remote host, wiring MCP, talking over A2A, or any mention of `sac agents start`, `scitex-agent-container`, `spec.yaml`, fleet head/worker. Also trigger on paraphrased asks that don't name sac directly: running Claude Code as a persistent background daemon that survives restarts, spinning up an AI agent on a remote server via SSH, or having multiple Claude Code agents message each other.
   [HOW] `pip install scitex-agent-container`, then `sac agents start <name>` or `import scitex_agent_container`.
 tags: [scitex-agent-container]
 primary_interface: cli


### PR DESCRIPTION
## Summary
- A skill-creator review pass on `scitex-agent-container`'s SKILL.md found the `[WHEN]` clause relied on literal keyword-matching (`sac agents start`, `spec.yaml`, etc.) and would likely undertrigger on paraphrased asks that don't name `sac` directly.
- Extend `[WHEN]` to also cover the underlying problem space: running Claude Code as a persistent/background daemon, keeping an agent alive across restarts, spinning up an agent on a remote server via SSH, and multiple Claude Code agents messaging each other.
- Description word count stays within the ~120-word budget (118 words); YAML frontmatter verified to still parse.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` confirms frontmatter still parses
- [x] `scitex-dev ecosystem audit-skills scitex-agent-container` → `SUCC: scitex-agent-container: no skills violations`