### PR TITLE
fix(apptainer): scrub legacy scitex-todo env vars from the launch environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- **fix(apptainer): scrub legacy scitex-todo env vars from the launch
+  environment** — INCIDENT 2026-07-05 (reported convergently by
+  claude-code-telegrammer and scitex-dev): apptainer passes the FULL
+  ambient environment of whatever host process invokes it into the
+  container, so a stale pre-0.7.30 `SCITEX_TODO_AGENT` /
+  `SCITEX_TODO_TASKS` export left in an operator's launching shell
+  leaked straight through and tripped scitex-todo's old-var-present
+  hard-reject on the MCP write path, even though neither `.mcp.json`
+  nor `spec.yaml` ever named the legacy var. Adds
+  `_apptainer_host_env.scrub_legacy_env` (reusing the single
+  `_to_home_text.LEGACY_RENAMED_ENV_VARS` denylist already used by the
+  materialized-file guard) and applies it at BOTH exec sites —
+  `_apptainer_runtime.py`'s SDK-Popen `launch_env` construction and
+  `_runners/_tmux/tmux.py`'s `TmuxManager.start` (which previously
+  inherited the full ambient env implicitly, with no `env=` kwarg at
+  all). Also adds a defense-in-depth `unset` step, regenerated fresh
+  every boot in `_apptainer_inner_argv.build_inner_argv` (no image
+  rebuild required), for launch paths that bypass sac's Python env
+  construction entirely (e.g. a raw `apptainer instance start`).
+  Extensible: a future var rename only needs one new entry in
+  `LEGACY_RENAMED_ENV_VARS`.
+
 ## [0.21.11] — 2026-06-09
 
 PATCH release. Re-cut of v0.21.10's accounts-list redesign after the

--- a/src/scitex_agent_container/_runners/_tmux/tmux.py
+++ b/src/scitex_agent_container/_runners/_tmux/tmux.py
@@ -159,7 +159,21 @@ class TmuxManager:
             for key, value in effective_session_env.items():
                 argv += ["-e", f"{key}={value}"]
         argv += ["bash", "-c", shell_script]
-        subprocess.run(argv, check=False)
+
+        # ``subprocess.run`` with no ``env=`` kwarg inherits THIS process's
+        # full ambient environment into the tmux pane — the same
+        # full-ambient-env passthrough class that leaks a stale legacy
+        # var (e.g. SCITEX_TODO_AGENT, left over from before the
+        # scitex-todo 0.7.30 rename) straight through into the eventual
+        # ``exec apptainer ...`` inside the pane (INCIDENT 2026-07-05).
+        # Explicitly scrub the denylisted names from the inherited base
+        # before handing it to tmux, matching the SDK-Popen exec site in
+        # ``_apptainer_runtime.py``. The ``-e KEY=VAL`` overrides above
+        # (cargo-bin append etc.) still layer on top via tmux itself.
+        from ...runtimes._apptainer_host_env import scrub_legacy_env
+
+        launch_env = scrub_legacy_env(os.environ)
+        subprocess.run(argv, check=False, env=launch_env)
 
         time.sleep(2)
         return TmuxManager.exists(session_name)

--- a/src/scitex_agent_container/runtimes/_apptainer_host_env.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_host_env.py
@@ -23,6 +23,17 @@ ADDITIONS (never mutates ``os.environ`` itself) so the exec sites
 (:mod:`_apptainer_runtime` SDK-Popen path and :mod:`tui_session` tmux
 path) can merge them into the env they hand to the ``apptainer``
 process.
+
+It also carries the mirror-image SUBTRACTION helper,
+:func:`scrub_legacy_env` — apptainer passes the FULL ambient
+environment of whatever host process invokes it into the container
+(the exact same passthrough class that motivates
+``APPTAINER_APPEND_PATH`` above), so a stale legacy env var left over
+in the launching shell (e.g. ``SCITEX_TODO_AGENT`` from before the
+scitex-todo 0.7.30 rename) leaks straight through regardless of what
+sac's own ``--env=`` list or to_home materialization says (INCIDENT
+2026-07-05). Both exec sites must pop the same denylist from the env
+dict they hand to the ``apptainer``/``tmux`` subprocess before exec.
 """
 
 from __future__ import annotations
@@ -30,9 +41,21 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Mapping
 
+from ._to_home_text import LEGACY_RENAMED_ENV_VARS
+
+#: Denylist of legacy-renamed env var names that must never survive into
+#: an apptainer launch environment, however they got into the calling
+#: process's ambient env. Single source of truth shared with the
+#: materialized-file guard in :mod:`_to_home_text` — a future rename only
+#: needs one new entry in :data:`_to_home_text.LEGACY_RENAMED_ENV_VARS`,
+#: not a fresh audit of every exec site.
+LEGACY_ENV_DENYLIST = LEGACY_RENAMED_ENV_VARS
+
 __all__ = [
     "APPTAINER_APPEND_PATH_ENV",
+    "LEGACY_ENV_DENYLIST",
     "host_cargo_bin_append_env",
+    "scrub_legacy_env",
 ]
 
 #: The apptainer runtime directive var. Apptainer strips the
@@ -76,3 +99,24 @@ def host_cargo_bin_append_env(base_env: Mapping[str, str]) -> dict[str, str]:
     else:
         value = cargo_bin_str
     return {APPTAINER_APPEND_PATH_ENV: value}
+
+
+def scrub_legacy_env(env: Mapping[str, str]) -> dict[str, str]:
+    """Return a copy of ``env`` with :data:`LEGACY_ENV_DENYLIST` removed.
+
+    Pure — does NOT mutate ``env`` (mirrors :func:`host_cargo_bin_append_env`'s
+    no-mutation contract). Call this at the SAME point each exec site builds
+    the environment dict it hands to the ``apptainer``/``tmux`` subprocess,
+    so a legacy var present in the calling shell's ambient ``os.environ``
+    (however it got there) cannot physically survive into the container —
+    regardless of what sac's own ``--env=`` list or to_home materialization
+    says (INCIDENT 2026-07-05: apptainer's default full-ambient-env
+    passthrough leaked a stale ``SCITEX_TODO_AGENT`` straight through,
+    tripping scitex-todo's old-var-present hard-reject).
+
+    A future scitex-todo (or other) env-var rename only needs one new
+    entry added to :data:`_to_home_text.LEGACY_RENAMED_ENV_VARS` — this
+    function and every exec site that calls it pick the new name up for
+    free, no per-site audit required.
+    """
+    return {k: v for k, v in env.items() if k not in LEGACY_ENV_DENYLIST}

--- a/src/scitex_agent_container/runtimes/_apptainer_inner_argv.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_inner_argv.py
@@ -26,6 +26,7 @@ from ._apptainer_inner_argv_tui import (  # noqa: F401 (re-export)
     tui_channel_config,
     tui_channel_plan,
 )
+from ._to_home_text import LEGACY_RENAMED_ENV_VARS
 
 if TYPE_CHECKING:
     from ..config import AgentConfig
@@ -79,6 +80,24 @@ _GIT_ENV_ALIAS_STEPS: list[str] = [
     '[ -n "${SAC_GIT_SSH_COMMAND:-}" ] && export GIT_SSH_COMMAND="$SAC_GIT_SSH_COMMAND"',
 ]
 
+# Defense-in-depth (belt-and-suspenders) — INCIDENT 2026-07-05: apptainer's
+# full-ambient-env passthrough can leak a stale legacy env var (e.g. a
+# pre-scitex-todo-0.7.30-rename ``SCITEX_TODO_AGENT`` export) straight
+# through into the container from whatever shell/process invoked
+# ``apptainer exec`` / ``instance start``, even when sac's own Python-side
+# env construction has already been scrubbed (see
+# ``_apptainer_host_env.scrub_legacy_env``, applied at both exec sites).
+# This step runs FIRST, inside the container, regenerated fresh every boot
+# from this same builder — no ``.def``/image rebuild required — so a leak
+# that bypassed sac's Python env construction entirely (e.g. an operator
+# running raw ``apptainer instance start`` directly) is still caught before
+# ``exec``ing the actual runner. Single source of truth: the same
+# :data:`_to_home_text.LEGACY_RENAMED_ENV_VARS` frozenset the materialized-
+# file guard and the process-env scrub both read.
+_LEGACY_ENV_UNSET_STEPS: list[str] = [
+    "unset " + " ".join(sorted(LEGACY_RENAMED_ENV_VARS)),
+]
+
 
 def _format_shell_steps(cmds: list) -> list[str]:
     # list[StartupCommand] -> shell statement list. `set -e` so any
@@ -112,9 +131,12 @@ def build_inner_argv(
     """Return the apptainer-inner argv. Dispatches on ``config.kind``.
 
     The argv is now ALWAYS wrapped in
-    ``[/bin/bash, -lc, "<git-env-alias>; [set -e; <cmd1>; sleep N; <cmd2>;]
-    exec <tini ...>"]`` — never returned bare. The first steps are the
-    fixed, unconditional :data:`_GIT_ENV_ALIAS_STEPS` (see there); when
+    ``[/bin/bash, -lc, "<legacy-env-unset>; <git-env-alias>;
+    [set -e; <cmd1>; sleep N; <cmd2>;] exec <tini ...>"]`` — never returned
+    bare. The very first step is the fixed, unconditional
+    :data:`_LEGACY_ENV_UNSET_STEPS` (defense-in-depth against a leaked
+    legacy env var surviving apptainer's ambient-env passthrough — see
+    there), then :data:`_GIT_ENV_ALIAS_STEPS` (see there); when
     ``spec.startup_commands`` is also non-empty those follow next, run as
     container-internal shell BEFORE the claude SDK process starts. ``exec``
     replaces bash with tini, keeping PID 1 clean. NOT a claude prompt — see
@@ -155,10 +177,16 @@ def build_inner_argv(
         )
 
     startup_cmds = list(getattr(config, "startup_commands", []) or [])
-    # Alias step is unconditional (every agent gets it); startup_cmds steps
-    # follow it when present. This means shell_steps is NEVER empty, so the
-    # bash -lc wrap now ALWAYS happens — see docstring.
-    shell_steps = _GIT_ENV_ALIAS_STEPS + _format_shell_steps(startup_cmds)
+    # Legacy-env unset + git-alias steps are unconditional (every agent gets
+    # them); startup_cmds steps follow when present. This means shell_steps
+    # is NEVER empty, so the bash -lc wrap now ALWAYS happens — see
+    # docstring. The unset step runs FIRST so no later step can observe a
+    # leaked legacy var.
+    shell_steps = (
+        _LEGACY_ENV_UNSET_STEPS
+        + _GIT_ENV_ALIAS_STEPS
+        + _format_shell_steps(startup_cmds)
+    )
 
     quoted_runner = " ".join(shlex.quote(p) for p in runner_tail)
     inline = "; ".join(shell_steps + [f"exec {quoted_runner}"])

--- a/src/scitex_agent_container/runtimes/_apptainer_runtime.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_runtime.py
@@ -209,9 +209,16 @@ class ApptainerContainerRuntime(RuntimeBase):
         # container var and ``--env PATH=...`` would clobber PATH). Lets
         # host-only cargo CLIs (e.g. rtk) resolve inside the container.
         # Skip-if-missing + append-not-clobber live in the pure helper.
-        from ._apptainer_host_env import host_cargo_bin_append_env
+        from ._apptainer_host_env import host_cargo_bin_append_env, scrub_legacy_env
 
-        launch_env = {**os.environ, **host_cargo_bin_append_env(os.environ)}
+        # scrub_legacy_env strips stale pre-rename env vars (e.g.
+        # SCITEX_TODO_AGENT) that apptainer's full-ambient-env passthrough
+        # would otherwise leak straight into the container from whatever
+        # shell launched this sac process (INCIDENT 2026-07-05) — applied
+        # BEFORE exec so no such leak ever reaches the ``apptainer`` argv.
+        launch_env = scrub_legacy_env(
+            {**os.environ, **host_cargo_bin_append_env(os.environ)}
+        )
 
         # Jailed-capsule guardrail: strip the apptainer/singularity bind
         # env vars from the launch environment so NO env-injected bind

--- a/src/scitex_agent_container/runtimes/_to_home_text.py
+++ b/src/scitex_agent_container/runtimes/_to_home_text.py
@@ -20,6 +20,33 @@ from ._to_home_errors import WorkspaceCLAUDEMarkerError
 END_MARKER = "<!-- End of scitex-agent-container generated section -->"
 START_MARKER_PREFIX = "<!-- Start of scitex-agent-container generated section"
 
+# Legacy pre-0.7.30 scitex-todo env var names, renamed to the ``_ID`` /
+# ``_YAML_SHARED`` forms. Single source of truth for TWO independent guards:
+#
+#   (a) never bake these into materialized to_home files (this module's
+#       ``_RUNTIME_ONLY_VARS``, below); and
+#   (b) never let a stale value of these survive into the apptainer LAUNCH
+#       ENVIRONMENT (:func:`_apptainer_host_env.scrub_legacy_env`).
+#
+# INCIDENT (2026-07-05, reported convergently by claude-code-telegrammer and
+# scitex-dev): apptainer passes the FULL ambient environment of whatever
+# host shell/process invokes ``apptainer exec`` / ``instance start`` into
+# the container (the same passthrough class documented in
+# ``_apptainer_host_env.py``'s ``APPTAINERENV_APPEND_PATH`` mechanism). A
+# stale ``SCITEX_TODO_AGENT`` export left in an operator's launching shell
+# (from before the 0.7.30 rename) leaked straight through into containers
+# even though neither ``.mcp.json`` nor ``spec.yaml`` ever named it —
+# tripping scitex-todo's strict "old var present -> hard reject" MCP
+# write-path check. This module's guard (a) only ever protected
+# MATERIALIZED FILES; it never touched the live process environment handed
+# to the ``apptainer`` subprocess, which is exactly what broke.
+LEGACY_RENAMED_ENV_VARS = frozenset(
+    {
+        "SCITEX_TODO_AGENT",
+        "SCITEX_TODO_TASKS",
+    }
+)
+
 # Per-agent IDENTITY vars that must NEVER be baked at deploy time.
 #
 # WHY (INCIDENT 2026-07-02, card
@@ -47,8 +74,7 @@ _RUNTIME_ONLY_VARS = frozenset(
         # Legacy pre-0.7.30 names — kept as a GUARD only (never injected by
         # sac anymore): a stale deployer shell exporting the old names must
         # still not bake them into materialized files.
-        "SCITEX_TODO_AGENT",
-        "SCITEX_TODO_TASKS",
+        *LEGACY_RENAMED_ENV_VARS,
         "SAC_NAME",
         "CLAUDE_AGENT_ID",
         "CLAUDE_AGENT_ROLE",

--- a/tests/scitex_agent_container/_runners/_tmux/test_tmux_start_legacy_env_scrub.py
+++ b/tests/scitex_agent_container/_runners/_tmux/test_tmux_start_legacy_env_scrub.py
@@ -1,0 +1,78 @@
+"""``TmuxManager.start`` must never leak a legacy scitex-todo env var
+into the tmux pane environment (INCIDENT 2026-07-05).
+
+``subprocess.run(argv, check=False)`` with no ``env=`` kwarg inherits
+the CALLING process's full ambient environment into the tmux pane —
+the same full-ambient-env-passthrough class documented for the
+SDK-Popen exec site in ``runtimes/_apptainer_runtime.py``. A stale
+``SCITEX_TODO_AGENT`` export left in this test process's env (as a
+stand-in for an operator's launching shell that never migrated off
+the pre-scitex-todo-0.7.30 name) must be scrubbed before the tmux
+pane's shell writes its own ``env`` snapshot — production already
+writes that snapshot to ``/tmp/sac-tui-env-<session>.txt`` right
+before ``exec``ing the real command (lead a2a 4303f855), which this
+test reads back as ground truth instead of inspecting the Python-side
+dict sac builds.
+
+Real ``tmux`` binary + real ``subprocess.run`` — no mocks. Skips when
+``tmux`` is not on PATH (matches ``test_tmux_session_activity.py``).
+
+STX-TQ002 AAA markers + STX-TQ007 one-assert.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import time
+import uuid
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from scitex_agent_container._runners._tmux.tmux import TmuxManager
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("tmux") is None,
+    reason="tmux binary not on PATH",
+)
+
+
+@pytest.fixture
+def stale_legacy_env() -> Iterator[None]:
+    """Set a stale pre-rename ``SCITEX_TODO_AGENT`` in THIS process's
+    ambient env (what ``subprocess.run`` inherits absent ``env=``),
+    auto-restoring afterwards."""
+    prev = os.environ.get("SCITEX_TODO_AGENT")
+    os.environ["SCITEX_TODO_AGENT"] = "stale-legacy-value"
+    try:
+        yield
+    finally:
+        if prev is None:
+            os.environ.pop("SCITEX_TODO_AGENT", None)
+        else:
+            os.environ["SCITEX_TODO_AGENT"] = prev
+
+
+def test_start_scrubs_legacy_env_from_tmux_pane(
+    tmp_path: Path, stale_legacy_env: None
+) -> None:
+    # Arrange
+    session_name = f"tui-test-legacy-scrub-{uuid.uuid4().hex[:8]}"
+    workdir = tmp_path / "wd"
+    workdir.mkdir()
+    snapshot_path = Path(f"/tmp/sac-tui-env-{session_name}.txt")
+    try:
+        # Act — a plain (non-apptainer) command; production writes the
+        # env snapshot unconditionally before ``exec``ing it.
+        TmuxManager.start(session_name, "sleep 5", str(workdir))
+        deadline = time.time() + 5
+        while not snapshot_path.exists() and time.time() < deadline:
+            time.sleep(0.1)
+        dumped = snapshot_path.read_text() if snapshot_path.exists() else ""
+        # Assert
+        assert "SCITEX_TODO_AGENT=" not in dumped
+    finally:
+        TmuxManager.stop(session_name)
+        snapshot_path.unlink(missing_ok=True)

--- a/tests/scitex_agent_container/runtimes/test__apptainer_host_env.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_host_env.py
@@ -28,7 +28,9 @@ import pytest
 
 from scitex_agent_container.runtimes._apptainer_host_env import (
     APPTAINER_APPEND_PATH_ENV,
+    LEGACY_ENV_DENYLIST,
     host_cargo_bin_append_env,
+    scrub_legacy_env,
 )
 
 
@@ -79,3 +81,42 @@ def test_preexisting_directive_is_appended_after_colon(fake_home: Path) -> None:
     result = host_cargo_bin_append_env(base_env)
     # Assert
     assert result[APPTAINER_APPEND_PATH_ENV] == f"/opt/extra/bin:{cargo_bin}"
+
+
+# ----------------------------------------------------------------------
+# scrub_legacy_env — INCIDENT 2026-07-05 (apptainer ambient-env passthrough
+# leaking stale pre-rename scitex-todo env vars into containers).
+# ----------------------------------------------------------------------
+def test_scrub_legacy_env_removes_denylisted_keys() -> None:
+    """Every :data:`LEGACY_ENV_DENYLIST` key is stripped from the output,
+    even when it is present in the base env passed in (simulating a
+    stale export surviving in the launching shell's ambient env)."""
+    # Arrange
+    base_env = {name: "stale-value" for name in LEGACY_ENV_DENYLIST}
+    base_env["UNRELATED_VAR"] = "keep-me"
+    # Act
+    result = scrub_legacy_env(base_env)
+    # Assert
+    assert not (set(result) & LEGACY_ENV_DENYLIST)
+
+
+def test_scrub_legacy_env_keeps_unrelated_keys() -> None:
+    """Non-denylisted keys survive the scrub untouched."""
+    # Arrange
+    base_env = {"SCITEX_TODO_AGENT_ID": "proj-x", "PATH": "/usr/bin"}
+    # Act
+    result = scrub_legacy_env(base_env)
+    # Assert
+    assert result == base_env
+
+
+def test_scrub_legacy_env_does_not_mutate_input() -> None:
+    """Pure function — the caller's dict (often a live ``os.environ`` copy)
+    must be left untouched; only the returned copy is scrubbed."""
+    # Arrange
+    base_env = {"SCITEX_TODO_AGENT": "stale", "PATH": "/usr/bin"}
+    original = dict(base_env)
+    # Act
+    scrub_legacy_env(base_env)
+    # Assert
+    assert base_env == original

--- a/tests/scitex_agent_container/runtimes/test__apptainer_inner_argv.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_inner_argv.py
@@ -24,6 +24,7 @@ from scitex_agent_container.config._types import (
 )
 from scitex_agent_container.runtimes._apptainer_inner_argv import (
     _GIT_ENV_ALIAS_STEPS,
+    _LEGACY_ENV_UNSET_STEPS,
     _SUPERVISOR_RESTART_FLOOR,
     _agent_runner_argv,
     _format_shell_steps,
@@ -32,6 +33,7 @@ from scitex_agent_container.runtimes._apptainer_inner_argv import (
     _resolve_restart_backoff_s,
     build_inner_argv,
 )
+from scitex_agent_container.runtimes._to_home_text import LEGACY_RENAMED_ENV_VARS
 
 
 def _mk_cfg(**kwargs):
@@ -279,6 +281,72 @@ def test_git_alias_mirrors_value_when_source_var_set():
     )
     # Assert
     assert result.stdout == "Test Author"
+
+
+# ---------------------------------------------------------------------------
+# Defense-in-depth legacy-env unset (INCIDENT 2026-07-05) — a stale legacy
+# scitex-todo env var (e.g. SCITEX_TODO_AGENT) must be unset FIRST, inside
+# the container, before anything else runs, regardless of whether sac's own
+# process-env scrub (``_apptainer_host_env.scrub_legacy_env``) caught it
+# upstream. See ``_LEGACY_ENV_UNSET_STEPS``.
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_env_unset_step_names_every_denylisted_var():
+    # Arrange
+    joined = "; ".join(_LEGACY_ENV_UNSET_STEPS)
+    # Act
+    missing = [name for name in LEGACY_RENAMED_ENV_VARS if name not in joined]
+    # Assert — every legacy-renamed var is named in the unset step.
+    assert missing == []
+
+
+def test_empty_startup_commands_argv_contains_legacy_unset_step():
+    # Arrange — an agent with NO startup_commands still gets the unset
+    # step baked into its wrapper.
+    cfg = _mk_cfg()
+    # Act
+    argv = build_inner_argv(cfg)
+    # Assert
+    assert "unset " in argv[2]
+
+
+def test_legacy_env_unset_precedes_git_alias():
+    # Arrange — the unset step must run BEFORE the git alias (and
+    # everything else) so no later step can observe a leaked var.
+    cfg = _mk_cfg()
+    # Act
+    argv = build_inner_argv(cfg)
+    # Assert
+    assert argv[2].index("unset ") < argv[2].index("SAC_GIT_AUTHOR_NAME")
+
+
+def test_legacy_env_unset_precedes_exec():
+    # Arrange
+    cfg = _mk_cfg()
+    # Act
+    argv = build_inner_argv(cfg)
+    # Assert
+    assert argv[2].index("unset ") < argv[2].index("exec ")
+
+
+def test_legacy_env_unset_step_real_bash_execution_strips_var():
+    # Arrange — real bash execution (no mocks): a stale legacy var IS
+    # present in the child env, proving the generated snippet actually
+    # removes it rather than merely looking plausible as a string.
+    env = dict(os.environ)
+    env["SCITEX_TODO_AGENT"] = "stale-legacy-value"
+    script = "; ".join(_LEGACY_ENV_UNSET_STEPS) + "; env"
+    # Act
+    result = subprocess.run(
+        ["/bin/bash", "-c", script],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    # Assert
+    assert "SCITEX_TODO_AGENT=" not in result.stdout
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scitex_agent_container/runtimes/test__apptainer_runtime.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_runtime.py
@@ -1519,6 +1519,62 @@ def test_start_force_overrides_stale_pid_and_starts(
     assert ok is True
 
 
+# ---------------------------------------------------------------------------
+# Legacy env scrub at the launch-env construction site (INCIDENT
+# 2026-07-05) — apptainer's full-ambient-env passthrough must never
+# carry a stale legacy scitex-todo var (e.g. SCITEX_TODO_AGENT, renamed
+# to SCITEX_TODO_AGENT_ID at 0.7.30) from the launching shell into the
+# ``apptainer`` subprocess this runtime execs.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def apptainer_env_dump_on_path(subprocess_shim) -> Path:
+    """Like ``apptainer_on_path`` but the fake binary also dumps its own
+    ``os.environ`` (JSON) to a file — lets a test assert on exactly what
+    the REAL launch environment looked like when ``apptainer`` execs,
+    rather than inspecting the Python-side dict sac built."""
+    bin_dir = subprocess_shim._bin
+    script = bin_dir / "apptainer"
+    env_dump = bin_dir / "apptainer.env.json"
+    body = (
+        f"#!{sys.executable}\n"
+        "import json, os, sys\n"
+        f"with open({_q(str(env_dump))}, 'w') as fh:\n"
+        "    json.dump(dict(os.environ), fh)\n"
+        "sys.exit(0)\n"
+    )
+    script.write_text(body)
+    script.chmod(0o755)
+    return env_dump
+
+
+def test_start_foreground_scrubs_legacy_env_from_apptainer_launch(
+    state_root: Path,
+    tmp_path: Path,
+    apptainer_env_dump_on_path: Path,
+    env_save_restore,
+) -> None:
+    """A stale ``SCITEX_TODO_AGENT`` export present in this test process's
+    ambient env (simulating a launching operator shell that never
+    migrated off the pre-0.7.30 name) must NOT reach the ``apptainer``
+    subprocess env, even though nothing in sac's own ``--env=``
+    construction ever names it."""
+    # Arrange
+    env_save_restore.set("SCITEX_TODO_AGENT", "stale-legacy-value")
+    sif = tmp_path / "ready.sif"
+    sif.write_bytes(b"\x00")
+    rt = ApptainerContainerRuntime()
+    cfg = _config(tmp_path / "wd", image=str(sif))
+    # Act
+    rt.start(cfg, foreground=True)
+    # Assert
+    import json as _json
+
+    dumped_env = _json.loads(apptainer_env_dump_on_path.read_text())
+    assert "SCITEX_TODO_AGENT" not in dumped_env
+
+
 def test_is_running_false_when_no_pid_file(state_root: Path, tmp_path: Path) -> None:
     # Arrange
     rt = ApptainerContainerRuntime()

--- a/tests/scitex_agent_container/runtimes/test__to_home_text.py
+++ b/tests/scitex_agent_container/runtimes/test__to_home_text.py
@@ -14,7 +14,10 @@ STX-TQ002 / TQ007: AAA markers per test, one fact per test.
 
 from __future__ import annotations
 
-from scitex_agent_container.runtimes._to_home_text import interpolate_env
+from scitex_agent_container.runtimes._to_home_text import (
+    LEGACY_RENAMED_ENV_VARS,
+    interpolate_env,
+)
 
 
 # interpolate_env — per-agent identity stays literal
@@ -77,3 +80,34 @@ def test_interpolate_env_leaves_unset_non_identity_var_literal(env_save_restore)
     out = interpolate_env("v=${SAC_TEST_DEFINITELY_UNSET_VAR}")
     # Assert
     assert out == "v=${SAC_TEST_DEFINITELY_UNSET_VAR}"
+
+
+# LEGACY_RENAMED_ENV_VARS — single source of truth shared with
+# _apptainer_host_env.scrub_legacy_env and _apptainer_inner_argv's
+# defense-in-depth unset step (INCIDENT 2026-07-05).
+def test_legacy_renamed_env_vars_contains_scitex_todo_agent():
+    # Arrange
+    names = LEGACY_RENAMED_ENV_VARS
+    # Act
+    present = "SCITEX_TODO_AGENT" in names
+    # Assert
+    assert present
+
+
+def test_legacy_renamed_env_vars_contains_scitex_todo_tasks():
+    # Arrange
+    names = LEGACY_RENAMED_ENV_VARS
+    # Act
+    present = "SCITEX_TODO_TASKS" in names
+    # Assert
+    assert present
+
+
+def test_legacy_renamed_env_vars_is_exactly_two_names():
+    # Arrange — future renames add here deliberately, not by accident
+    # growing the set.
+    names = LEGACY_RENAMED_ENV_VARS
+    # Act
+    expected = {"SCITEX_TODO_AGENT", "SCITEX_TODO_TASKS"}
+    # Assert
+    assert names == expected


### PR DESCRIPTION
## Incident

Reported convergently by two peer agents, `claude-code-telegrammer` and
`scitex-dev`: agent containers were seeing the LEGACY env var
`SCITEX_TODO_AGENT` present in their process environment alongside the
current `SCITEX_TODO_AGENT_ID`, even though:

1. `/home/agent/.mcp.json` in these containers only forwards
   `SCITEX_TODO_AGENT_ID`.
2. Their `spec.yaml` only sets `--env=SCITEX_TODO_AGENT_ID=<name>`,
   nothing named `SCITEX_TODO_AGENT`.
3. `src/scitex_agent_container/runtimes/_to_home_text.py` already lists
   `SCITEX_TODO_AGENT` in `_RUNTIME_ONLY_VARS` as a "Legacy pre-0.7.30
   name — kept as a GUARD only (never injected by sac anymore)".
4. Yet `/proc/1/environ` inside affected containers showed BOTH vars
   baked into the apptainer instance's env snapshot at container-start
   time.

Net effect: scitex-todo's MCP write path (`add_task` / `update_task` /
`comment_task`) does a strict "old var present → hard reject" check
regardless of whether old and new values agree, so the leaked legacy
var broke writes fleet-wide.

I searched the shared `scitex-todo` task store for an existing
`incident-sac-apptainer-ambient-env-leak-20260705`-style card (by
`id_prefix` and by keyword across the `scitex-dev` / `scitex-todo`
scopes) and did not find one — either it hasn't landed yet or lives
under a different id. Happy to cross-link once it surfaces.

## Root cause

Apptainer, by default, passes the FULL environment of whatever
host shell/process invokes `apptainer exec` / `instance start` into
the container — NOT just sac's explicit `--env=` list. This repo
already relies on and documents exactly this passthrough class
elsewhere (`_apptainer_host_env.py`'s `APPTAINERENV_APPEND_PATH`
mechanism, whose docstring says "This works even under
`--containall`"). So a stale `SCITEX_TODO_AGENT` export left over in
an operator's launching shell (from before the scitex-todo 0.7.30
rename) leaked straight through into every container launched from
that shell, regardless of what sac's own `--env=` list or to_home
materialization said. The existing `_to_home_text.py` guard only ever
stopped the value from being baked into on-disk template files
(`.mcp.json`, `CLAUDE.md`) — it never touched the *live
process-environment* handed to the `apptainer` subprocess.

## Fix

- **Single source of truth**: extracted the legacy-name denylist out
  of `_to_home_text.py`'s `_RUNTIME_ONLY_VARS` into a standalone
  `LEGACY_RENAMED_ENV_VARS = {"SCITEX_TODO_AGENT", "SCITEX_TODO_TASKS"}`
  (`_to_home_text.py:24-42`). `_RUNTIME_ONLY_VARS` now composes it in,
  so the materialized-file guard is unchanged behaviourally.
  (`SAC_NAME` / `CLAUDE_AGENT_ID` / `CLAUDE_AGENT_ROLE` stay out of
  this denylist — those are per-agent-identity vars that must stay
  literal `${VAR}` at deploy time for a *different* reason, not
  renamed-legacy vars that must never leak; scoped per the task's
  instruction to read that comment carefully.)

- **`_apptainer_host_env.py`** (`runtimes/_apptainer_host_env.py`):
  added `LEGACY_ENV_DENYLIST` (= `LEGACY_RENAMED_ENV_VARS`) and a pure
  `scrub_legacy_env(env) -> dict` that returns a copy of `env` with the
  denylisted keys removed — the mirror-image of the existing
  `host_cargo_bin_append_env` (an addition helper) in the same module.

- **Exec site 1 — SDK-Popen path**
  (`runtimes/_apptainer_runtime.py`, the `start()` method): the
  `launch_env` construction now wraps in `scrub_legacy_env(...)`:
  ```python
  launch_env = scrub_legacy_env(
      {**os.environ, **host_cargo_bin_append_env(os.environ)}
  )
  ```

- **Exec site 2 — tmux/TUI path**
  (`_runners/_tmux/tmux.py`, `TmuxManager.start`): this call site was
  actually **worse** — `subprocess.run(argv, check=False)` passed NO
  `env=` kwarg at all, so it silently inherited the full ambient
  environment of the sac process into the tmux pane, in addition to
  the explicit `-e KEY=VAL` overrides. Now builds an explicit
  `launch_env = scrub_legacy_env(os.environ)` and passes it via
  `env=launch_env`.

- **Defense-in-depth (belt-and-suspenders)**
  (`runtimes/_apptainer_inner_argv.py`, `build_inner_argv`): added
  `_LEGACY_ENV_UNSET_STEPS`, an `unset SCITEX_TODO_AGENT
  SCITEX_TODO_TASKS` shell step that now runs FIRST, before even the
  `SAC_GIT_*` alias steps, inside the container's `bash -lc` wrapper.
  This wrapper is regenerated fresh on every `sac agents start` — no
  `.def`/image rebuild needed — so a leak that bypasses sac's Python
  env construction entirely (e.g. an operator running raw `apptainer
  instance start` directly) is still caught before `exec`ing the real
  runner.

This generalizes the same pattern already used by
`_apptainer_jail.py`'s `scrub_bind_env` (strip disallowed env vars
from the launch environment before exec, belt-and-suspenders alongside
a fail-loud check). A future scitex-todo (or other) env-var rename
only needs one new entry in `LEGACY_RENAMED_ENV_VARS` — every exec
site and the in-container defense pick it up automatically, no fresh
audit required.

## Files changed

- `src/scitex_agent_container/runtimes/_to_home_text.py` — new
  `LEGACY_RENAMED_ENV_VARS` constant; `_RUNTIME_ONLY_VARS` composes it.
- `src/scitex_agent_container/runtimes/_apptainer_host_env.py` — new
  `LEGACY_ENV_DENYLIST` + `scrub_legacy_env()`.
- `src/scitex_agent_container/runtimes/_apptainer_runtime.py` —
  scrub applied at the SDK-Popen `launch_env` construction.
- `src/scitex_agent_container/_runners/_tmux/tmux.py` — scrub applied
  + explicit `env=` now passed to `subprocess.run` for `tmux
  new-session` (previously implicit/none).
- `src/scitex_agent_container/runtimes/_apptainer_inner_argv.py` —
  new `_LEGACY_ENV_UNSET_STEPS`, prepended first in
  `build_inner_argv`'s shell wrapper.
- `CHANGELOG.md` — Unreleased entry.
- Tests (new/updated):
  - `tests/scitex_agent_container/runtimes/test__apptainer_host_env.py`
    — `scrub_legacy_env` unit coverage (removes denylisted keys, keeps
    others, does not mutate input).
  - `tests/scitex_agent_container/runtimes/test__to_home_text.py` —
    `LEGACY_RENAMED_ENV_VARS` content/shape lock.
  - `tests/scitex_agent_container/runtimes/test__apptainer_inner_argv.py`
    — `_LEGACY_ENV_UNSET_STEPS` content, ordering (before git-alias,
    before `exec`), and a real-bash-execution proof it actually strips
    the var.
  - `tests/scitex_agent_container/runtimes/test__apptainer_runtime.py`
    — new `apptainer_env_dump_on_path` fixture + test:
    `rt.start(cfg, foreground=True)` with a stale `SCITEX_TODO_AGENT`
    in the test process's ambient env; asserts the REAL subprocess env
    (dumped by the fake `apptainer` binary) does not contain it.
  - `tests/scitex_agent_container/_runners/_tmux/test_tmux_start_legacy_env_scrub.py`
    (new file) — real `tmux` binary + real `subprocess.run`;
    `TmuxManager.start` with a stale `SCITEX_TODO_AGENT` in the test
    process's env; reads back production's own env-snapshot-before-exec
    file (`/tmp/sac-tui-env-<session>.txt`) and asserts the var is
    absent. Skips when `tmux` is not on `$PATH` (matches existing
    `test_tmux_session_activity.py` convention).

## Test plan

Ran with an absolute interpreter path against this worktree's source
(`PYTHONPATH=<worktree>/src /opt/venv-sac/bin/pytest ...` since the
installed venv package is a separate non-editable copy):

- [x] `tests/scitex_agent_container/runtimes/test__apptainer_host_env.py`
- [x] `tests/scitex_agent_container/runtimes/test__to_home_text.py`
- [x] `tests/scitex_agent_container/runtimes/test__apptainer_inner_argv.py`
- [x] `tests/scitex_agent_container/runtimes/test__apptainer_runtime.py` (179 passed)
- [x] `tests/scitex_agent_container/_runners/_tmux/test_tmux_start_legacy_env_scrub.py` (real tmux)
- [x] Full sweep: `tests/scitex_agent_container/runtimes/` +
      `tests/scitex_agent_container/_runners/` — **1686 passed, 1
      failed, 20 skipped**. The 1 failure
      (`test_claude_session.py::test_state_dir_for_default_root_is_under_user_home`)
      is a **pre-existing, order-dependent flake unrelated to this
      diff** — it passes cleanly in isolation, and none of this PR's
      changed files touch `_session_state.py` or state-root
      resolution. Confirmed by re-running
      `tests/scitex_agent_container/_runners/test_claude_session.py`
      alone (exit 0, all green).

Not merging this myself per instructions.
