### PR TITLE
fix(lifecycle): propagate --yes consent through the in-SIF spawn broker

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_in_sif_broker.py
+++ b/src/scitex_agent_container/_lifecycle/_in_sif_broker.py
@@ -126,6 +126,7 @@ def broker_start_to_host(
     opener: Callable | None = None,
     foreground: bool = False,
     one_shot: bool = False,
+    assume_yes: bool = False,
 ) -> dict:
     """POST a spawn request to the host-side ``sac listen``; FAIL LOUD on error.
 
@@ -170,6 +171,16 @@ def broker_start_to_host(
         Optional ``urllib.request.urlopen``-shaped callable. The
         in-SIF integration tests pass a fake opener so the wire shape
         is exercised without an actual network round-trip.
+    assume_yes
+        Forwarded to :func:`_lifecycle._spawn_client.request_spawn` as
+        ``assume_yes`` (wire field ``assume_yes: true``). Bug fix
+        (2026-07-05, paper-scitex-clew report): the host's ``/agents``
+        handler re-runs the same interactive refuse-without-``--yes``
+        gate the ORIGINAL in-SIF caller's ``-y`` already satisfied —
+        without threading this through, that consent never reached the
+        host subprocess and every brokered start refused itself. See
+        :func:`_lifecycle._spawn_client.request_spawn`'s docstring for
+        the full contract.
 
     Returns
     -------
@@ -204,6 +215,7 @@ def broker_start_to_host(
             opener=opener,
             foreground=foreground,
             one_shot=one_shot,
+            assume_yes=assume_yes,
         )
     except SpawnRequestError as exc:
         # Re-throw under the broker's own error type so the integration
@@ -227,6 +239,7 @@ def maybe_broker_in_sif_spawn(
     opener: Callable | None = None,
     foreground: bool = False,
     one_shot: bool = False,
+    assume_yes: bool = False,
 ) -> bool:
     """Single-call broker chokepoint for the in-SIF redirect in agent_start.
 
@@ -268,6 +281,18 @@ def maybe_broker_in_sif_spawn(
     + return rc=0 immediately) and the post-ack liveness probe sees a
     still-alive Popen pid, returning SUCC while the capsule dies
     silently later.
+
+    ``assume_yes``: propagate the caller's own ``-y``/``--yes`` consent
+    through to the host's ``/agents`` handler (bug fix 2026-07-05,
+    paper-scitex-clew report). The host handler shells a fresh
+    ``sac agents start <name>`` subprocess that re-runs the SAME
+    interactive refuse-without-``--yes`` gate the caller already
+    satisfied at the top of this call chain; without this field that
+    consent never reached the host subprocess and the brokered start
+    ALWAYS refused itself with "refusing to start ... without
+    --yes/-y", even when ``-y`` was explicitly given. See
+    :func:`broker_start_to_host` / :func:`_lifecycle._spawn_client.
+    request_spawn` for the full wire contract.
     """
     if dry_run or not is_in_sif():
         return False
@@ -277,6 +302,7 @@ def maybe_broker_in_sif_spawn(
         opener=opener,
         foreground=foreground,
         one_shot=one_shot,
+        assume_yes=assume_yes,
     )
     rc = result.get("returncode") if isinstance(result, dict) else None
     if rc != 0:

--- a/src/scitex_agent_container/_lifecycle/_spawn_client.py
+++ b/src/scitex_agent_container/_lifecycle/_spawn_client.py
@@ -245,6 +245,7 @@ def request_spawn(
     opener: Callable | None = None,
     foreground: bool = False,
     one_shot: bool = False,
+    assume_yes: bool = False,
 ) -> dict:
     """POST a spawn request to the host listen server; FAIL LOUD on error.
 
@@ -295,6 +296,21 @@ def request_spawn(
         the capsule runs one SDK turn (its ``startup_prompts``) and
         exits. Pairs naturally with ``foreground=True`` for the
         cohort capsule shape.
+    assume_yes
+        Forwarded as ``assume_yes: true`` in the POST body when set.
+        Bug fix (2026-07-05, reported by paper-scitex-clew): the host's
+        ``/agents`` handler shells a fresh ``sac agents start <name>``
+        subprocess, which re-runs the SAME interactive
+        refuse-without-``--yes`` gate (``cli_pkg/lifecycle/
+        _start_single.py::should_preview_and_require_yes``) that the
+        ORIGINAL in-SIF caller's own ``-y`` already satisfied. Before
+        this field existed there was no way for that consent to reach
+        the host subprocess, so a brokered ``sac agents start <name>
+        -y`` run from inside a container ALWAYS hit "refusing to start
+        ... without --yes/-y" even though ``-y`` was explicitly passed
+        at the top of the call chain. This does NOT weaken the
+        human-at-a-TTY default-refuse safety net — it only lets the
+        brokered/automated path assert consent that was already given.
 
     Returns
     -------
@@ -332,6 +348,11 @@ def request_spawn(
         body["foreground"] = True
     if one_shot:
         body["one_shot"] = True
+    # Consent-propagation fix (2026-07-05, paper-scitex-clew report): only
+    # emit the key when truthy, same back-compat rationale as foreground/
+    # one_shot above — pre-fix brokers simply ignore an absent field.
+    if assume_yes:
+        body["assume_yes"] = True
 
     payload = json.dumps(body).encode("utf-8")
     url = f"{base}/agents"

--- a/src/scitex_agent_container/_lifecycle/_start.py
+++ b/src/scitex_agent_container/_lifecycle/_start.py
@@ -62,6 +62,7 @@ def agent_start(
     no_preflight: bool = False,
     foreground: bool = False,
     one_shot: bool = False,
+    assume_yes: bool = False,
     strict_drift: bool | None = None,
     runtime_factory: Optional[Callable[[AgentConfig], Any]] = None,
     sleep_fn: Callable[[float], None] = time.sleep,
@@ -83,6 +84,20 @@ def agent_start(
         foreground: Run the runtime in the foreground.
         one_shot: Run the startup prompts once and exit; requires
             ``spec.startup_prompts`` to be non-empty.
+        assume_yes: The CLI caller's own ``-y``/``--yes`` consent,
+            propagated to the in-SIF broker (bug fix 2026-07-05,
+            paper-scitex-clew report). When ``agent_start`` is invoked
+            from inside an apptainer SIF, the spawn is brokered to the
+            host's ``sac listen`` (see :func:`_in_sif_broker.
+            maybe_broker_in_sif_spawn`), which shells a FRESH
+            ``sac agents start <name>`` on the bare host — a subprocess
+            that re-runs the same interactive refuse-without-``--yes``
+            gate the ORIGINAL caller already satisfied. Without
+            threading this through, that consent never reached the host
+            subprocess and every brokered start refused itself even
+            though ``-y`` was explicitly passed at the CLI. Ignored on
+            the non-SIF (direct) path — it has no interactive gate of
+            its own to satisfy.
         strict_drift: Escalate a drifted spec-source git repo from a
             loud warning to a hard block (raise before launch). ``None``
             (default) reads ``SAC_STRICT_DRIFT`` / ``--strict-drift`` is
@@ -124,6 +139,7 @@ def agent_start(
         opener=in_sif_opener,
         foreground=foreground,
         one_shot=one_shot,
+        assume_yes=assume_yes,
     ):
         return True
 

--- a/src/scitex_agent_container/_listen/_agent_exec.py
+++ b/src/scitex_agent_container/_listen/_agent_exec.py
@@ -103,6 +103,28 @@ async def agents_start(request: Request) -> JSONResponse:
             {"error": "'one_shot' must be a boolean if present"},
             status_code=400,
         )
+    # Consent-propagation bug fix (2026-07-05, reported by
+    # paper-scitex-clew): the ``sac agents start <name>`` subprocess this
+    # handler shells below re-runs the SAME interactive
+    # refuse-without-``--yes`` gate (``cli_pkg/lifecycle/_start_single.py::
+    # should_preview_and_require_yes``) that the ORIGINAL in-SIF caller's
+    # own ``-y`` already satisfied. Without this field, that consent never
+    # reached this subprocess and every brokered start refused itself with
+    # "refusing to start ... without --yes/-y" even though ``-y`` was
+    # explicitly passed at the top of the call chain. Threaded through to
+    # the inner argv (``--yes``) AND the child env
+    # (``SAC_ASSUME_YES=1`` below) — belt-and-suspenders, since the env
+    # var is also the documented escape valve for callers that can't
+    # thread ``assume_yes`` through every layer. FAIL-LOUD invariant
+    # preserved: an ABSENT field means no consent was given, so the
+    # subprocess still hits the human-at-a-TTY default-refuse gate
+    # exactly as before this fix.
+    assume_yes = body.get("assume_yes", False)
+    if not isinstance(assume_yes, bool):
+        return JSONResponse(
+            {"error": "'assume_yes' must be a boolean if present"},
+            status_code=400,
+        )
     decision, reason = check_spawn(caller=caller)
     if decision == "deny":
         return deny_response(reason or "spawn denied")
@@ -167,6 +189,15 @@ async def agents_start(request: Request) -> JSONResponse:
     child_env = dict(os.environ)
     child_env.pop("APPTAINER_CONTAINER", None)
     child_env.pop("SINGULARITY_CONTAINER", None)
+    # Consent-propagation fix (2026-07-05, paper-scitex-clew report): set
+    # the env-var escape valve in ADDITION to the --yes flag below so the
+    # inner subprocess's refuse-without-``--yes`` gate
+    # (``should_preview_and_require_yes`` in cli_pkg/lifecycle/
+    # _start_single.py) sees consent even if some intermediate wrapper
+    # strips CLI flags. Absent when assume_yes is False — the default
+    # refuse-without-consent behaviour is completely unchanged.
+    if assume_yes:
+        child_env["SAC_ASSUME_YES"] = "1"
     # PR-α: propagate --foreground / --one-shot to the inner argv per the
     # body fields validated above. Order matches the click signature on
     # `sac agents start` (flags before/after positional name are
@@ -176,6 +207,8 @@ async def agents_start(request: Request) -> JSONResponse:
         inner_argv.append("--foreground")
     if one_shot:
         inner_argv.append("--one-shot")
+    if assume_yes:
+        inner_argv.append("--yes")
     inner_argv.append(name)
     # Single-flight the OAuth-refresh boot window (card
     # sac-multi-start-queue-oauth): concurrent brokered background spawns share

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_start_single.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_start_single.py
@@ -11,6 +11,7 @@ delegates the per-target loop here. Mirrors the existing sibling
 from __future__ import annotations
 
 import json as _json
+import os
 import sys
 import traceback
 from contextlib import nullcontext
@@ -95,7 +96,23 @@ def run_single_targets(
     (``render_plan_summary``: identity, spec path, runtime/image,
     workdir + backed-by-bind check, model). Either way the refusal
     without ``--yes``/``-y`` is unchanged.
+
+    ``SAC_ASSUME_YES=1`` env-var fallback (bug fix 2026-07-05,
+    paper-scitex-clew report): OR'd into ``yes`` here — the ONE place
+    in this module where ``yes`` is finally resolved before the
+    refuse-without-``--yes`` gate fires and before the value is
+    forwarded into ``agent_start``. This is the escape valve for
+    callers that cannot easily thread ``assume_yes`` through every
+    layer (e.g. an operator wiring up a bespoke launcher): the host's
+    ``/agents`` handler (``_listen/_agent_exec.py``) sets this env var
+    on the brokered subprocess's environment when the original in-SIF
+    caller's ``assume_yes`` body field was true, so a brokered
+    ``sac agents start <name> -y`` no longer refuses itself on the
+    host side. Does NOT weaken the human-at-a-TTY default-refuse
+    safety net — a real interactive operator invocation never has
+    this env var set.
     """
+    effective_yes = yes or os.environ.get("SAC_ASSUME_YES") == "1"
 
     def _emit_json(payload: dict) -> None:
         click.echo(_json.dumps(payload, ensure_ascii=False))
@@ -210,7 +227,7 @@ def run_single_targets(
                 # supervisor / spawn-broker / scripts (non-tty, or --yes/
                 # foreground/one-shot/broker-self) launch without refusal.
                 if should_preview_and_require_yes(
-                    yes=yes,
+                    yes=effective_yes,
                     dry_run=dry_run,
                     as_json=as_json,
                     foreground=foreground,
@@ -265,6 +282,7 @@ def run_single_targets(
                     resume_id_override=resume_id,
                     foreground=foreground,
                     one_shot=one_shot,
+                    assume_yes=effective_yes,
                     strict_drift=strict_drift,
                 )
                 if as_json:

--- a/tests/scitex_agent_container/_lifecycle/test__in_sif_broker.py
+++ b/tests/scitex_agent_container/_lifecycle/test__in_sif_broker.py
@@ -313,6 +313,41 @@ def test_broker_forwards_one_shot_to_body(listen_env) -> None:
     assert json.loads(captured["body"])["one_shot"] is True
 
 
+def test_broker_forwards_assume_yes_to_body(listen_env) -> None:
+    # Arrange — consent-propagation fix (2026-07-05, paper-scitex-clew report).
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    opener, captured = _opener_returning(b'{"name":"c","returncode":0}')
+    # Act
+    broker_start_to_host("child", opener=opener, assume_yes=True)
+    # Assert
+    assert json.loads(captured["body"])["assume_yes"] is True
+
+
+def test_broker_omits_assume_yes_when_default_false(listen_env) -> None:
+    # Arrange — regression guard: default (no consent given) is unchanged.
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    opener, captured = _opener_returning(b'{"name":"c","returncode":0}')
+    # Act
+    broker_start_to_host("child", opener=opener)
+    # Assert
+    assert "assume_yes" not in json.loads(captured["body"])
+
+
+def test_maybe_broker_in_sif_forwards_assume_yes_to_body(sif_env, listen_env) -> None:
+    # Arrange — flip is_in_sif() to True so the chokepoint actually brokers.
+    from scitex_agent_container._lifecycle._in_sif_broker import (
+        maybe_broker_in_sif_spawn,
+    )
+
+    sif_env("/path/to/parent.sif", key="APPTAINER_CONTAINER")
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    opener, captured = _opener_returning(b'{"name":"c","returncode":0}')
+    # Act
+    maybe_broker_in_sif_spawn("child", dry_run=False, opener=opener, assume_yes=True)
+    # Assert
+    assert json.loads(captured["body"])["assume_yes"] is True
+
+
 def test_maybe_broker_in_sif_forwards_foreground_to_body(sif_env, listen_env) -> None:
     # Arrange — flip is_in_sif() to True so the chokepoint actually
     # brokers (rather than returning False for the bare-host path).
@@ -487,6 +522,29 @@ def test_agent_start_in_sif_raises_when_listen_url_missing(
         raised_msg = str(exc)
     # Assert — fail-loud names the missing env var so the operator can fix.
     assert "SAC_LISTEN_BASE_URL" in raised_msg
+
+
+def test_agent_start_forwards_assume_yes_to_broker_body(
+    isolated_state, sif_env, listen_env, tmp_path
+) -> None:
+    # Arrange — consent-propagation fix (2026-07-05, paper-scitex-clew
+    # report): agent_start's own assume_yes kwarg must reach the wire.
+    sif_env("/path/to/agent.sif", key="APPTAINER_CONTAINER")
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    spec = _write_spec(tmp_path / "yaml", "capsule-child")
+    opener, captured = _opener_returning(b'{"name":"capsule-child","returncode":0}')
+    # Act
+    agent_start(
+        str(spec),
+        registry=Registry(registry_dir=tmp_path / "reg"),
+        runtime_factory=lambda _c: _RuntimeRecorder(),
+        handover_mod=_FakeHandover(),
+        sleep_fn=lambda _s: None,
+        in_sif_opener=opener,
+        assume_yes=True,
+    )
+    # Assert
+    assert json.loads(captured["body"])["assume_yes"] is True
 
 
 def test_agent_start_not_in_sif_uses_local_runtime(

--- a/tests/scitex_agent_container/_lifecycle/test__spawn_client.py
+++ b/tests/scitex_agent_container/_lifecycle/test__spawn_client.py
@@ -291,6 +291,36 @@ def test_body_omits_foreground_and_one_shot_when_default_false(
     assert "foreground" not in body and "one_shot" not in body
 
 
+# ---------------------------------------------------------------------------
+# Consent-propagation fix (2026-07-05, paper-scitex-clew report): the host's
+# ``/agents`` handler shells a FRESH ``sac agents start <name>`` subprocess
+# that re-runs the interactive refuse-without-``--yes`` gate. request_spawn
+# emits an ``assume_yes`` body field only when truthy — same back-compat
+# rationale as ``foreground``/``one_shot`` above.
+# ---------------------------------------------------------------------------
+
+
+def test_body_includes_assume_yes_true_when_requested(listen_env) -> None:
+    # Arrange
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    opener, captured = _opener_returning(b'{"name":"c","returncode":0}')
+    # Act
+    request_spawn("c", assume_yes=True, opener=opener)
+    # Assert
+    assert json.loads(captured["body"])["assume_yes"] is True
+
+
+def test_body_omits_assume_yes_when_default_false(listen_env) -> None:
+    # Arrange — default kwargs absent on the call.
+    listen_env("LISTEN_BASE_URL", "http://host:9100")
+    opener, captured = _opener_returning(b'{"name":"c","returncode":0}')
+    # Act
+    request_spawn("c", opener=opener)
+    # Assert — key must be ABSENT (not present-but-false), matching the
+    # wire shape of pre-fix brokers.
+    assert "assume_yes" not in json.loads(captured["body"])
+
+
 def test_bearer_token_attached_as_authorization_header(listen_env) -> None:
     # Arrange
     listen_env("LISTEN_BASE_URL", "http://host:9100")

--- a/tests/scitex_agent_container/_listen/test__agent_exec_subprocess.py
+++ b/tests/scitex_agent_container/_listen/test__agent_exec_subprocess.py
@@ -572,6 +572,123 @@ def test_agents_start_no_flags_back_compat_inner_argv_unchanged(
     assert recorded == ["agents", "start", "back-compat-child"]
 
 
+# ---------------------------------------------------------------------------
+# Consent-propagation fix (2026-07-05, reported by paper-scitex-clew): the
+# ``assume_yes`` body field lets the in-SIF caller's own ``-y`` reach the
+# subprocess this handler shells, so the inner ``sac agents start <name>``
+# does not hit the refuse-without-``--yes`` gate a second time. Mirrors the
+# foreground/one_shot argv-propagation tests above exactly.
+# ---------------------------------------------------------------------------
+
+
+def test_agents_start_propagates_assume_yes_to_inner_argv(
+    isolated_listen_env, env_save_restore, tmp_path: Path
+) -> None:
+    """``assume_yes: true`` body field → inner argv carries ``--yes``."""
+    # Arrange
+    import json
+
+    bin_dir = tmp_path / "sac_bin_yes_argv"
+    bin_dir.mkdir()
+    argv_log = _install_argv_recording_sac_shim(bin_dir)
+    env_save_restore.set("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
+    env_save_restore.set("SAC_LISTEN_POST_ACK_LIVENESS_TIMEOUT_S", "0")
+    app = create_app(token=_TOKEN)
+    # Act
+    with TestClient(app) as client:
+        client.post(
+            "/agents",
+            json={"name": "cohort-child", "assume_yes": True},
+            headers={"authorization": f"Bearer {_TOKEN}"},
+        )
+    recorded = json.loads(argv_log.read_text().splitlines()[-1])
+    # Assert
+    assert "--yes" in recorded
+
+
+def test_agents_start_sets_sac_assume_yes_env_for_child(
+    isolated_listen_env, env_save_restore, tmp_path: Path
+) -> None:
+    """``assume_yes: true`` ALSO sets ``SAC_ASSUME_YES=1`` on the child env.
+
+    Belt-and-suspenders escape valve (requirement 5 of the bug fix):
+    even if some intermediate wrapper strips the ``--yes`` CLI flag,
+    the env var still lets the inner refuse-without-``--yes`` gate see
+    consent.
+    """
+    # Arrange
+    import json
+
+    bin_dir = tmp_path / "sac_env_yes_shim_bin"
+    bin_dir.mkdir()
+    env_log = bin_dir / "sac.assume_yes_env.jsonl"
+    script = bin_dir / "sac"
+    script.write_text(
+        f"#!{__import__('sys').executable}\n"
+        "import json, os\n"
+        f"with open({json.dumps(str(env_log))}, 'a') as fh:\n"
+        "    fh.write(json.dumps({'SAC_ASSUME_YES': os.environ.get('SAC_ASSUME_YES')}) + '\\n')\n"
+        "import sys; sys.exit(0)\n"
+    )
+    script.chmod(0o755)
+    env_save_restore.set("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
+    env_save_restore.set("SAC_LISTEN_POST_ACK_LIVENESS_TIMEOUT_S", "0")
+    app = create_app(token=_TOKEN)
+    # Act
+    with TestClient(app) as client:
+        client.post(
+            "/agents",
+            json={"name": "broker-child", "assume_yes": True},
+            headers={"authorization": f"Bearer {_TOKEN}"},
+        )
+    recorded = json.loads(env_log.read_text().splitlines()[-1])
+    # Assert
+    assert recorded["SAC_ASSUME_YES"] == "1"
+
+
+def test_agents_start_no_assume_yes_back_compat_inner_argv_unchanged(
+    isolated_listen_env, env_save_restore, tmp_path: Path
+) -> None:
+    """Body without ``assume_yes`` → inner argv keeps the pre-fix shape."""
+    # Arrange
+    import json
+
+    bin_dir = tmp_path / "sac_bin_no_yes_argv"
+    bin_dir.mkdir()
+    argv_log = _install_argv_recording_sac_shim(bin_dir)
+    env_save_restore.set("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
+    env_save_restore.set("SAC_LISTEN_POST_ACK_LIVENESS_TIMEOUT_S", "0")
+    app = create_app(token=_TOKEN)
+    # Act
+    with TestClient(app) as client:
+        client.post(
+            "/agents",
+            json={"name": "back-compat-child"},
+            headers={"authorization": f"Bearer {_TOKEN}"},
+        )
+    recorded = json.loads(argv_log.read_text().splitlines()[-1])
+    # Assert
+    assert recorded == ["agents", "start", "back-compat-child"]
+
+
+def test_agents_start_rejects_non_bool_assume_yes(
+    isolated_listen_env, env_save_restore, tmp_path: Path
+) -> None:
+    """``assume_yes: "yes"`` → 400, never silently coerced."""
+    # Arrange
+    env_save_restore.set("SAC_LISTEN_POST_ACK_LIVENESS_TIMEOUT_S", "0")
+    app = create_app(token=_TOKEN)
+    # Act
+    with TestClient(app) as client:
+        resp = client.post(
+            "/agents",
+            json={"name": "x", "assume_yes": "yes"},
+            headers={"authorization": f"Bearer {_TOKEN}"},
+        )
+    # Assert
+    assert resp.status_code == 400
+
+
 def test_agents_start_rejects_non_bool_foreground(
     isolated_listen_env, env_save_restore, tmp_path: Path
 ) -> None:

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__start_single_assume_yes.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__start_single_assume_yes.py
@@ -31,7 +31,6 @@ from typing import Any, Iterator
 import pytest
 
 from scitex_agent_container._state import state_db
-from scitex_agent_container._state.registry import Registry
 from scitex_agent_container.cli_pkg.lifecycle._start_single import (
     run_single_targets,
 )

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__start_single_assume_yes.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__start_single_assume_yes.py
@@ -1,0 +1,279 @@
+"""``run_single_targets`` — assume_yes / ``SAC_ASSUME_YES`` propagation.
+
+Bug fix (2026-07-05, reported by paper-scitex-clew): ``sac agents start
+<name> -y`` invoked INSIDE an apptainer SIF is brokered to the host's
+``sac listen`` via :func:`_lifecycle._in_sif_broker.maybe_broker_in_sif_spawn`
+→ :func:`_lifecycle._spawn_client.request_spawn`. Before this fix, the
+POST body carried no consent field at all, so the host's re-shelled
+``sac agents start <name>`` subprocess ALWAYS hit
+``should_preview_and_require_yes``'s refusal, even though ``-y`` was
+given at the top of the call chain.
+
+This module pins the IN-SIF caller's half of the fix:
+:func:`run_single_targets` must fold ``yes`` (CLI ``-y``/``--yes``) OR
+``SAC_ASSUME_YES=1`` into a single ``effective_yes`` value and forward it
+to :func:`agent_start` as ``assume_yes``, which the in-SIF broker then
+puts on the wire as the POST body's ``assume_yes`` field.
+
+NO MOCKS — real spec.yaml on disk + the injectable ``opener`` seam on
+the in-SIF broker (mirrors ``test__in_sif_broker.py`` and
+``test__spawn_client.py``). Each test: AAA markers (TQ002), one
+assertion (TQ007), 3+-word name.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Iterator
+
+import pytest
+
+from scitex_agent_container._state import state_db
+from scitex_agent_container._state.registry import Registry
+from scitex_agent_container.cli_pkg.lifecycle._start_single import (
+    run_single_targets,
+)
+
+# ---------------------------------------------------------------------------
+# Env fixtures — in-SIF markers, listen base URL, and SAC_ASSUME_YES.
+# ---------------------------------------------------------------------------
+
+_SIF_KEYS = ("APPTAINER_CONTAINER", "SINGULARITY_CONTAINER")
+_LISTEN_KEYS = (
+    "SAC_LISTEN_BASE_URL",
+    "SCITEX_AGENT_CONTAINER_LISTEN_BASE_URL",
+    "SAC_LISTEN_BEARER",
+    "SCITEX_AGENT_CONTAINER_LISTEN_BEARER",
+    "SAC_NAME",
+    "SCITEX_AGENT_CONTAINER_NAME",
+    "SAC_ASSUME_YES",
+)
+
+
+@pytest.fixture
+def broker_env() -> Iterator[Any]:
+    """Yield a setter for the in-SIF + listen + SAC_ASSUME_YES env vars."""
+    keys = _SIF_KEYS + _LISTEN_KEYS
+    saved = {k: os.environ.get(k) for k in keys}
+    for k in keys:
+        os.environ.pop(k, None)
+
+    def _set(key: str, value: str | None) -> None:
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
+
+    try:
+        yield _set
+    finally:
+        for k, prev in saved.items():
+            if prev is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = prev
+
+
+@pytest.fixture
+def isolated_state(tmp_path: Path) -> Iterator[Path]:
+    """Real isolated state.db + runtime dir + HOME (mirrors test__in_sif_broker)."""
+    db = tmp_path / "state.db"
+    runtime_dir = tmp_path / "runtime"
+    home = tmp_path / "home"
+    home.mkdir()
+    keys = {
+        "SCITEX_AGENT_CONTAINER_STATE_DB": str(db),
+        "SCITEX_AGENT_CONTAINER_RUNTIME_DIR": str(runtime_dir),
+        "HOME": str(home),
+        "SCITEX_DIR": str(home / ".scitex"),
+    }
+    saved = {k: os.environ.get(k) for k in keys}
+    saved_default = state_db.DEFAULT_DB_PATH
+    os.environ.update(keys)
+    state_db.DEFAULT_DB_PATH = db
+    state_db.init_schema(db)
+    try:
+        yield db
+    finally:
+        state_db.DEFAULT_DB_PATH = saved_default
+        for k, prev in saved.items():
+            if prev is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = prev
+
+
+def _write_spec(yaml_root: Path, name: str) -> Path:
+    agent_dir = yaml_root / name
+    agent_dir.mkdir(parents=True)
+    spec = agent_dir / "spec.yaml"
+    spec.write_text(
+        "apiVersion: scitex-agent-container/v3\n"
+        "kind: Agent\n"
+        "spec:\n"
+        "  runtime: apptainer\n"
+        "  host: local\n"
+        f"  workdir: {yaml_root / (name + '-work')}\n"
+        "  apptainer:\n    image: /x.sif\n    binds: []\n"
+        "  restart:\n    policy: on-failure\n    max_retries: 3\n"
+        "  claude:\n"
+        "    model: sonnet\n"
+        "  health:\n"
+        "    enabled: false\n"
+        "    interval: 60\n"
+    )
+    return spec
+
+
+def _start_loopback_listen():
+    """Start a real loopback HTTP server recording the /agents POST body.
+
+    Returns (base_url, captured) where captured['body'] is populated
+    after the first POST. A real server (not an injected opener) is
+    used here because ``run_single_targets`` does not expose an
+    ``in_sif_opener`` seam of its own — only ``agent_start`` does, and
+    ``run_single_targets`` calls it without one (production shape).
+    """
+    import http.server
+    import threading
+
+    captured: dict = {}
+
+    class _Handler(http.server.BaseHTTPRequestHandler):
+        def do_POST(self):  # noqa: N802
+            length = int(self.headers.get("Content-Length", "0"))
+            raw = self.rfile.read(length)
+            captured["body"] = raw
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(
+                json.dumps({"name": "capsule-child", "returncode": 0}).encode()
+            )
+
+        def log_message(self, *_args):  # silence test noise
+            return
+
+    server = http.server.HTTPServer(("127.0.0.1", 0), _Handler)
+    host, port = server.server_address
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return f"http://{host}:{port}", captured, server, thread
+
+
+def test_yes_flag_forwards_assume_yes_true_to_broker_body(
+    isolated_state, broker_env, tmp_path: Path
+) -> None:
+    """``-y``/``--yes`` on the CLI must reach the host's POST body."""
+    # Arrange — in-SIF + a real loopback listen server.
+    broker_env("APPTAINER_CONTAINER", "/path/to/agent.sif")
+    base_url, captured, server, thread = _start_loopback_listen()
+    broker_env("SAC_LISTEN_BASE_URL", base_url)
+    spec = _write_spec(tmp_path / "yaml", "capsule-child")
+    try:
+        # Act
+        run_single_targets(
+            [str(spec)],
+            no_preflight=True,
+            force=False,
+            resume_id=None,
+            session_mode=None,
+            dry_run=False,
+            as_json=True,
+            foreground=False,
+            one_shot=False,
+            strict_drift=False,
+            no_redispatch=True,
+            multi_foreground=False,
+            preflight_runner=lambda: None,
+            yes=True,
+        )
+    finally:
+        server.shutdown()
+        thread.join(timeout=2.0)
+    # Assert — the POST body the host received carries assume_yes: true.
+    body = json.loads(captured["body"])
+    assert body.get("assume_yes") is True
+
+
+def test_sac_assume_yes_env_forwards_assume_yes_true_to_broker_body(
+    isolated_state, broker_env, tmp_path: Path
+) -> None:
+    """``SAC_ASSUME_YES=1`` alone (no ``-y``) must ALSO reach the POST body.
+
+    This is the escape-valve fallback (requirement 5 of the bug fix):
+    callers that cannot easily thread ``assume_yes`` through every
+    layer set the env var instead.
+    """
+    # Arrange — in-SIF + real loopback listen; --yes NOT passed.
+    broker_env("APPTAINER_CONTAINER", "/path/to/agent.sif")
+    base_url, captured, server, thread = _start_loopback_listen()
+    broker_env("SAC_LISTEN_BASE_URL", base_url)
+    broker_env("SAC_ASSUME_YES", "1")
+    spec = _write_spec(tmp_path / "yaml", "capsule-child")
+    try:
+        # Act
+        run_single_targets(
+            [str(spec)],
+            no_preflight=True,
+            force=False,
+            resume_id=None,
+            session_mode=None,
+            dry_run=False,
+            as_json=True,
+            foreground=False,
+            one_shot=False,
+            strict_drift=False,
+            no_redispatch=True,
+            multi_foreground=False,
+            preflight_runner=lambda: None,
+            yes=False,
+        )
+    finally:
+        server.shutdown()
+        thread.join(timeout=2.0)
+    # Assert
+    body = json.loads(captured["body"])
+    assert body.get("assume_yes") is True
+
+
+def test_no_yes_and_no_env_omits_assume_yes_from_broker_body(
+    isolated_state, broker_env, tmp_path: Path
+) -> None:
+    """Regression guard — the default (no consent given) is unchanged.
+
+    Neither ``--yes`` nor ``SAC_ASSUME_YES`` is set: the wire body must
+    NOT carry ``assume_yes`` at all (back-compat with pre-fix brokers,
+    same convention as ``foreground``/``one_shot``).
+    """
+    # Arrange
+    broker_env("APPTAINER_CONTAINER", "/path/to/agent.sif")
+    base_url, captured, server, thread = _start_loopback_listen()
+    broker_env("SAC_LISTEN_BASE_URL", base_url)
+    spec = _write_spec(tmp_path / "yaml", "capsule-child")
+    try:
+        # Act
+        run_single_targets(
+            [str(spec)],
+            no_preflight=True,
+            force=False,
+            resume_id=None,
+            session_mode=None,
+            dry_run=False,
+            as_json=True,
+            foreground=False,
+            one_shot=False,
+            strict_drift=False,
+            no_redispatch=True,
+            multi_foreground=False,
+            preflight_runner=lambda: None,
+            yes=False,
+        )
+    finally:
+        server.shutdown()
+        thread.join(timeout=2.0)
+    # Assert
+    body = json.loads(captured["body"])
+    assert "assume_yes" not in body


### PR DESCRIPTION
## Bug

Reported by paper-scitex-clew (currently blocked by it): `sac agents start <name> -y` run from INSIDE a running apptainer SIF is brokered through the host-side `sac listen` daemon (`_lifecycle/_in_sif_broker.py` → `_lifecycle/_spawn_client.py::request_spawn`). That RPC's JSON POST body had no yes/assume-yes field at all. The host's `/agents` POST handler (`_listen/_agent_exec.py::agents_start`) shells a FRESH `sac agents start <name>` subprocess, which re-runs the SAME interactive refuse-without-`--yes` gate (`cli_pkg/lifecycle/_start_single.py::should_preview_and_require_yes`) — but the original caller's `-y` never reached that subprocess. Result: a brokered `sac agents start <name> -y` from inside a container ALWAYS hit "refusing to start ... without --yes/-y", even though `-y` was explicitly passed at the top of the call chain.

## Fix

Thread `assume_yes` end-to-end, mirroring how `foreground`/`one_shot` are already propagated:

1. `_lifecycle/_spawn_client.py::request_spawn` — new `assume_yes: bool = False` param; emitted in the POST body only when truthy (`{"assume_yes": true}`), same back-compat convention as `foreground`/`one_shot`.
2. `_lifecycle/_in_sif_broker.py::broker_start_to_host` / `maybe_broker_in_sif_spawn` — thread the same parameter through to `request_spawn`.
3. `_lifecycle/_start.py::agent_start` — new `assume_yes: bool = False` param, forwarded to `maybe_broker_in_sif_spawn`.
4. `cli_pkg/lifecycle/_start_single.py::run_single_targets` — folds the CLI's own `yes` flag into `effective_yes = yes or os.environ.get("SAC_ASSUME_YES") == "1"`, used for both the interactive refuse gate and the `agent_start(..., assume_yes=effective_yes)` call.
5. `_listen/_agent_exec.py::agents_start` (the host-side handler) — validates `assume_yes` (400 if non-bool), and when true, both appends `--yes` to the inner `sac agents start` argv AND sets `SAC_ASSUME_YES=1` on the child subprocess's env (belt-and-suspenders).

### `SAC_ASSUME_YES=1` escape valve

Requirement 5 of the fix: an env-var fallback, OR'd in wherever `yes` is finally resolved on the host side (`run_single_targets`'s `effective_yes`). This lets callers that can't easily thread `assume_yes` through every layer set the env var instead — and it's exactly what the host handler sets on the brokered subprocess's environment.

### What is NOT changed

The human-at-a-TTY default-refuse safety net (`should_preview_and_require_yes`) is untouched — it still refuses an interactive operator launch without `--yes`. This fix only gives the brokered/automated path a legitimate way to assert consent that was already given via `-y` at the top of the call chain.

## Test plan

- [x] `request_spawn` includes `assume_yes` in the POST body when set, omits it when default false (`tests/scitex_agent_container/_lifecycle/test__spawn_client.py`)
- [x] `broker_start_to_host` / `maybe_broker_in_sif_spawn` / `agent_start` forward `assume_yes` end to end (`tests/scitex_agent_container/_lifecycle/test__in_sif_broker.py`)
- [x] Host-side handler honors `assume_yes` (appends `--yes` to inner argv, sets `SAC_ASSUME_YES=1` on child env, rejects non-bool with 400, back-compat argv unchanged when absent) (`tests/scitex_agent_container/_listen/test__agent_exec_subprocess.py`)
- [x] `run_single_targets` folds CLI `--yes` OR `SAC_ASSUME_YES=1` into the value forwarded to `agent_start`/the broker POST body; the no-consent default is unchanged (`tests/scitex_agent_container/cli_pkg/lifecycle/test__start_single_assume_yes.py`, new file)
- [x] Existing refuse-without-yes gate behavior unchanged (`tests/scitex_agent_container/cli_pkg/lifecycle/test__start_confirm_gate.py` — all still green)
- [x] Full targeted suite: `83 passed` (`/opt/venv-sac/bin/python -m pytest .../test__spawn_client.py .../test__in_sif_broker.py .../test__agent_exec_subprocess.py .../test__start_single_assume_yes.py .../test__start_confirm_gate.py -q`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)