### PR TITLE
fix(security): redact secrets in on-disk apptainer argv snapshots

### DIFF
--- a/src/scitex_agent_container/_state/_meta/secrets.py
+++ b/src/scitex_agent_container/_state/_meta/secrets.py
@@ -4,6 +4,16 @@ Extracted from ``agent_meta.py`` to keep that module under the 512-line
 hook ceiling. ``agent_meta`` re-exports ``_SECRET_PATTERNS`` and
 ``_redact_secrets`` so existing callers (including tests using
 ``agent_meta._redact_secrets``) continue to work unchanged.
+
+Also home to :func:`_redact_env_entry` (+ its ``_SECRET_ENV`` key-name
+regex) — the ``KEY=value`` argv-element redactor originally written
+for ``cli_pkg._explain``'s console plan-preview. Centralised here
+(rather than left in ``cli_pkg``) so runtime modules that must redact
+an on-disk argv/env record (``_apptainer_runtime.py``,
+``tui_session.py`` — see card ``sac-argv-token-plaintext``) can reuse
+the exact same secret-name matching without a ``runtimes`` →
+``cli_pkg`` import (which would invert the package's dependency
+direction). ``cli_pkg._explain`` re-exports both names for back-compat.
 """
 
 from __future__ import annotations
@@ -30,3 +40,28 @@ def _redact_secrets(text: str) -> str:
         else:
             s = pat.sub("***REDACTED***", s)
     return s
+
+
+# Matches a secret-shaped env-var KEY (not its value) — deliberately
+# generic so it covers any ``*_API_KEY`` / ``*_TOKEN`` / ``*_BEARER`` /
+# ``*_KEY`` / ``*_CREDENTIAL`` / ``*_SECRET`` / ``*_PASSWORD`` name, not
+# just ``SAC_ANTHROPIC_API_KEY`` (the incident var).
+_SECRET_ENV = re.compile(
+    r"(SECRET|TOKEN|BEARER|PASSWORD|API_KEY|_KEY|CREDENTIAL)", re.IGNORECASE
+)
+
+
+def _redact_env_entry(entry: str) -> str:
+    """Mask the VALUE of a secret-named ``KEY=value`` argv/env entry.
+
+    Never touches entries that aren't ``KEY=value`` shaped (plain flags
+    like ``--bind`` or ``--env`` pass through untouched) and never
+    touches a non-secret-named key (e.g. ``CLAUDE_AGENT_ID=...``). Used
+    both for the human-facing ``sac agents explain`` plan preview and
+    for on-disk argv/plan snapshots (``apptainer_run.argv.txt``) so the
+    two surfaces apply IDENTICAL redaction and never drift.
+    """
+    key, sep, val = entry.partition("=")
+    if sep and val and _SECRET_ENV.search(key):
+        return f"{key}=<redacted: {len(val)} chars>"
+    return entry

--- a/src/scitex_agent_container/cli_pkg/_explain.py
+++ b/src/scitex_agent_container/cli_pkg/_explain.py
@@ -10,11 +10,12 @@ reality. Resolution honours the project-over-user cascade (a repo's
 
 from __future__ import annotations
 
-import re
 from pathlib import Path
 
 import click
 
+from .._state._meta.secrets import _redact_env_entry as _redact
+from .._state._meta.secrets import _SECRET_ENV  # noqa: F401 (re-exported, back-compat)
 from ..config import AgentConfig, load_config
 
 
@@ -57,19 +58,6 @@ def _binds(argv: list[str]) -> list[tuple[str, str, str]]:
             mode = parts[2] if len(parts) > 2 else "rw"
             out.append((src, dst, mode))
     return out
-
-
-_SECRET_ENV = re.compile(
-    r"(SECRET|TOKEN|BEARER|PASSWORD|API_KEY|_KEY|CREDENTIAL)", re.IGNORECASE
-)
-
-
-def _redact(entry: str) -> str:
-    """Mask the VALUE of a secret-named env var — never echo a key/token."""
-    key, sep, val = entry.partition("=")
-    if sep and val and _SECRET_ENV.search(key):
-        return f"{key}=<redacted: {len(val)} chars>"
-    return entry
 
 
 def _envs(argv: list[str]) -> list[str]:

--- a/src/scitex_agent_container/runtimes/_apptainer_argv_record.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_argv_record.py
@@ -1,0 +1,45 @@
+"""On-disk argv/plan snapshot writer — REDACTED, never raw (card
+``sac-argv-token-plaintext``, security finding 2026-05-24).
+
+Both the apptainer and TUI dry-run paths persist the resolved launch
+``argv`` to ``<state_dir>/apptainer_run.argv.txt`` for debugging /
+``sac agents explain`` parity. Before this module existed, that write
+embedded secret env values (``SAC_ANTHROPIC_API_KEY=<real token>``,
+``SAC_LISTEN_BEARER=<real bearer>``, ...) in PLAINTEXT on disk — the
+console-facing plan preview (``cli_pkg._explain.render_plan``) already
+redacted the same values before printing, but the FILE write bypassed
+that treatment entirely.
+
+:func:`write_redacted_argv` is the single write path both runtimes now
+share: every argv element shaped like ``KEY=value`` with a
+secret-looking ``KEY`` (see ``_state._meta.secrets._SECRET_ENV`` —
+``*_API_KEY`` / ``*_TOKEN`` / ``*_BEARER`` / ``*_KEY`` / ``*_SECRET`` /
+``*_PASSWORD`` / ``*_CREDENTIAL``) gets its value masked; plain flags
+(``--bind``, ``--env``, ...) and non-secret ``KEY=value`` pairs
+(``CLAUDE_AGENT_ID=...``) pass through untouched — identical behaviour
+to the console preview, so the two surfaces never drift apart.
+
+The real (unredacted) argv is untouched — it's what actually reaches
+the ``apptainer``/``tmux`` subprocess; only the ON-DISK RECORD is
+masked. The file is also chmod'd 0600 belt-and-suspenders (the
+directory/file should already be per-agent-private, but a stray
+world/group-readable state dir must not turn a masked-at-write-time
+file into the only thing standing between a secret and a co-tenant).
+"""
+
+from __future__ import annotations
+
+import stat
+from pathlib import Path
+
+from .._state._meta.secrets import _redact_env_entry
+
+
+def write_redacted_argv(path: Path, argv: list[str]) -> None:
+    """Write ``argv`` to ``path``, one element per line, secrets masked."""
+    redacted = [_redact_env_entry(a) for a in argv]
+    path.write_text("\n".join(redacted) + "\n")
+    try:
+        path.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 0600 — owner rw only
+    except OSError:  # stx-allow: fallback (best-effort hardening only)
+        pass

--- a/src/scitex_agent_container/runtimes/_apptainer_runtime.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_runtime.py
@@ -67,6 +67,7 @@ from ._apptainer_build_argv import (  # noqa: F401
 from ._apptainer_build_argv import (
     build_run_argv as _build_run_argv_impl,
 )
+from ._apptainer_argv_record import write_redacted_argv as _write_redacted_argv
 from .base import RuntimeBase
 
 DEFAULT_SIF_NAME = "scitex-agent-container.sif"
@@ -200,7 +201,7 @@ class ApptainerContainerRuntime(RuntimeBase):
 
         argv = self.build_run_argv(config, state_dir=state_dir, sif_path=sif_path)
         if dry_run:
-            (state_dir / "apptainer_run.argv.txt").write_text("\n".join(argv) + "\n")
+            _write_redacted_argv(state_dir / "apptainer_run.argv.txt", argv)
             return True
 
         # Append the host ``~/.cargo/bin`` to the CONTAINER PATH via

--- a/src/scitex_agent_container/runtimes/tui_session.py
+++ b/src/scitex_agent_container/runtimes/tui_session.py
@@ -275,9 +275,11 @@ class TuiSessionRuntime(StartupPromptInjectorMixin, TurnBridgeSeamMixin, Runtime
             return False
 
         if dry_run:
+            from ._apptainer_argv_record import write_redacted_argv
+
             state_dir = state_dir_for_config(config)
             state_dir.mkdir(parents=True, exist_ok=True)
-            (state_dir / "apptainer_run.argv.txt").write_text("\n".join(argv) + "\n")
+            write_redacted_argv(state_dir / "apptainer_run.argv.txt", argv)
             return True
 
         # The host workdir is only the tmux launch cwd — the agent's real cwd is

--- a/tests/scitex_agent_container/runtimes/test__apptainer_runtime.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_runtime.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import importlib
 import os
 import shlex
+import stat
 import subprocess
 import sys
 import time
@@ -1428,6 +1429,151 @@ def test_start_dry_run_argv_file_begins_with_apptainer(
     # Assert
     argv_file = rt._state_dir(cfg) / "apptainer_run.argv.txt"
     assert argv_file.read_text().splitlines()[0] == "apptainer"
+
+
+def test_start_dry_run_argv_file_omits_the_raw_secret(
+    state_root: Path,
+    tmp_path: Path,
+    apptainer_on_path: Path,
+    env_save_restore,
+) -> None:
+    # Arrange — security regression test for card
+    # ``sac-argv-token-plaintext`` (found 2026-05-24): the dry-run argv
+    # file used to embed ``SAC_ANTHROPIC_API_KEY`` in PLAINTEXT because
+    # the write bypassed the console-preview's redaction. A fake token
+    # in the host env must never appear verbatim in the on-disk file.
+    env_save_restore.set("SAC_ANTHROPIC_API_KEY", "sk-ant-oat01-supersecrettoken")
+    sif = tmp_path / "ready.sif"
+    sif.write_bytes(b"\x00")
+    rt = ApptainerContainerRuntime()
+    cfg = _config(tmp_path / "wd", image=str(sif))
+
+    # Act
+    rt.start(cfg, dry_run=True)
+
+    # Assert — the raw secret never hits disk.
+    argv_file = rt._state_dir(cfg) / "apptainer_run.argv.txt"
+    assert "sk-ant-oat01-supersecrettoken" not in argv_file.read_text()
+
+
+def test_start_dry_run_argv_file_carries_the_redacted_marker(
+    state_root: Path,
+    tmp_path: Path,
+    apptainer_on_path: Path,
+    env_save_restore,
+) -> None:
+    # Arrange — same incident as above: the redacted placeholder (the
+    # same shape ``sac agents explain`` prints to the console) must
+    # replace the raw value rather than the key vanishing entirely.
+    env_save_restore.set("SAC_ANTHROPIC_API_KEY", "sk-ant-oat01-supersecrettoken")
+    sif = tmp_path / "ready.sif"
+    sif.write_bytes(b"\x00")
+    rt = ApptainerContainerRuntime()
+    cfg = _config(tmp_path / "wd", image=str(sif))
+
+    # Act
+    rt.start(cfg, dry_run=True)
+
+    # Assert
+    argv_file = rt._state_dir(cfg) / "apptainer_run.argv.txt"
+    assert "SAC_ANTHROPIC_API_KEY=<redacted:" in argv_file.read_text()
+
+
+def test_start_dry_run_argv_file_is_owner_only_readable(
+    state_root: Path,
+    tmp_path: Path,
+    apptainer_on_path: Path,
+    env_save_restore,
+) -> None:
+    # Arrange — belt-and-suspenders: even a redacted-at-rest file should
+    # not be group/world readable (card ``sac-argv-token-plaintext``
+    # follow-up on runtime-dir permissions).
+    env_save_restore.set("SAC_ANTHROPIC_API_KEY", "sk-ant-oat01-supersecrettoken")
+    sif = tmp_path / "ready.sif"
+    sif.write_bytes(b"\x00")
+    rt = ApptainerContainerRuntime()
+    cfg = _config(tmp_path / "wd", image=str(sif))
+
+    # Act
+    rt.start(cfg, dry_run=True)
+
+    # Assert
+    argv_file = rt._state_dir(cfg) / "apptainer_run.argv.txt"
+    assert stat.S_IMODE(argv_file.stat().st_mode) == 0o600
+
+
+def test_start_dry_run_argv_file_leaves_non_secret_env_untouched(
+    state_root: Path,
+    tmp_path: Path,
+    apptainer_on_path: Path,
+) -> None:
+    # Arrange — the redaction must be scoped to secret-named keys; an
+    # ordinary env entry (e.g. the always-emitted state-db path) must
+    # still be readable verbatim for debugging.
+    sif = tmp_path / "ready.sif"
+    sif.write_bytes(b"\x00")
+    rt = ApptainerContainerRuntime()
+    cfg = _config(tmp_path / "wd", image=str(sif))
+
+    # Act
+    rt.start(cfg, dry_run=True)
+
+    # Assert
+    argv_file = rt._state_dir(cfg) / "apptainer_run.argv.txt"
+    assert "SCITEX_AGENT_CONTAINER_STATE_DB=/state/state.db" in argv_file.read_text()
+
+
+def test_build_run_argv_still_carries_the_real_secret_for_the_subprocess(
+    state_root: Path,
+    tmp_path: Path,
+    env_save_restore,
+) -> None:
+    # Arrange — the fix must ONLY touch the on-disk dry-run record; the
+    # real argv the runtime hands to the actual ``apptainer exec``
+    # subprocess must still carry the real secret value, or the SDK
+    # inside the container would never authenticate. Exercises the
+    # real (unmocked) ``build_run_argv`` the runtime launches with.
+    env_save_restore.set("SAC_ANTHROPIC_API_KEY", "sk-ant-oat01-supersecrettoken")
+    sif = tmp_path / "ready.sif"
+    sif.write_bytes(b"\x00")
+    rt = ApptainerContainerRuntime()
+    cfg = _config(tmp_path / "wd", image=str(sif))
+
+    # Act
+    argv = rt.build_run_argv(cfg, state_dir=rt._state_dir(cfg), sif_path=sif)
+
+    # Assert
+    assert "SAC_ANTHROPIC_API_KEY=sk-ant-oat01-supersecrettoken" in argv
+
+
+def test_start_background_apptainer_subprocess_receives_the_real_secret(
+    state_root: Path,
+    tmp_path: Path,
+    apptainer_on_path: Path,
+    subprocess_shim,
+    env_save_restore,
+) -> None:
+    # Arrange — end-to-end confirmation (real subprocess, no Popen
+    # mocking): a real launch's ``apptainer exec`` child process must
+    # still receive the real secret in its argv, even though the
+    # on-disk dry-run record never would. ``apptainer_on_path`` installs
+    # a fake ``apptainer`` binary that logs its own received argv.
+    env_save_restore.set("SAC_ANTHROPIC_API_KEY", "sk-ant-oat01-supersecrettoken")
+    sif = tmp_path / "ready.sif"
+    sif.write_bytes(b"\x00")
+    rt = ApptainerContainerRuntime()
+    cfg = _config(tmp_path / "wd", image=str(sif))
+
+    # Act
+    rt.start(cfg)
+    for _ in range(50):
+        if subprocess_shim.call_count("apptainer") > 0:
+            break
+        time.sleep(0.1)
+
+    # Assert
+    received = subprocess_shim.argv_for("apptainer") or []
+    assert "SAC_ANTHROPIC_API_KEY=sk-ant-oat01-supersecrettoken" in received
 
 
 def test_start_background_returns_true(


### PR DESCRIPTION
## Summary

Security fix for card `sac-argv-token-plaintext` (found 2026-05-24, still unfixed until this PR).

**The finding**: the per-agent launch record `apptainer_run.argv.txt` (written by the `--dry-run` code path of both the apptainer runtime and the TUI runtime) contained `SAC_ANTHROPIC_API_KEY` — and any other secret-shaped env var (`SAC_LISTEN_BEARER`, etc.) — in **plaintext on disk**. The console-facing `sac agents explain` plan preview already redacted these values before printing (`cli_pkg/_explain.py`'s `_redact`), but the on-disk write bypassed that treatment entirely.

**Write sites found and fixed** (both, not just the one named in the original report):
1. `runtimes/_apptainer_runtime.py:203` — `ApptainerContainerRuntime.start(..., dry_run=True)`.
2. `runtimes/tui_session.py:280` — the TUI runtime's `dry_run=True` path (same `apptainer_run.argv.txt` filename, separate write site — same bug, not previously covered by the card).

I also checked the `STARTUP_FAILED` marker write path (`_lifecycle/_startup_failed.py`, fed by `_listen/_agent_exec.py`'s `proc.stdout`/`proc.stderr`) since the task description mentioned a live incident with a `stdout_tail` field showing plan text. That marker only ever captures whatever `sac agents start`'s own subprocess printed to stdout — and the refuse-without-`--yes` preview it can print (`render_plan_summary`) intentionally omits the Env section entirely, while the full preview (`render_plan`, `--verbose`) already redacts via `_redact` before `click.echo`. So no additional unredacted write site exists there; nothing else needed fixing.

## Fix

- Extracted the `KEY=value` redactor (+ its `_SECRET_ENV` key-name regex) out of `cli_pkg/_explain.py` into `_state/_meta/secrets.py` as `_redact_env_entry`, generalizing it beyond the single incident var to any `*_API_KEY` / `*_TOKEN` / `*_BEARER` / `*_KEY` / `*_SECRET` / `*_PASSWORD` / `*_CREDENTIAL`-shaped key. This is the same regex `cli_pkg/_explain.py` already used for the console preview — centralizing it avoids a `runtimes` → `cli_pkg` import (which would have inverted the package's dependency direction) and guarantees the console preview and the on-disk record can never drift apart.
- Added `runtimes/_apptainer_argv_record.py::write_redacted_argv(path, argv)` — the single write path both runtimes now share. Each argv element shaped like `KEY=value` with a secret-looking key gets its value masked (`KEY=<redacted: N chars>`); plain flags (`--bind`, `--env`, ...) and non-secret `KEY=value` pairs pass through untouched. The file is also `chmod`'d `0600` (owner-only) as belt-and-suspenders hardening.
- `_apptainer_runtime.py` and `tui_session.py` both call this helper instead of a raw `write_text`.
- The **real** (unredacted) argv handed to the actual `apptainer exec` / `tmux` subprocess is untouched — verified by a dedicated test that calls the real `build_run_argv` directly and by an end-to-end test using a real subprocess fake-binary that logs its own received argv.

## Runtime-dir permission follow-up

Checked: the state dir itself is created with the process's default umask (no explicit mode), so on a shared/multi-tenant host it could in principle be group/world-readable even though the file's own content is now redacted. Added the `chmod 0600` on the argv file itself as defense-in-depth (belt-and-suspenders per the card's guidance); did not change the directory's mode since that's a broader change outside this fix's blast radius — flagging it here in case the operator wants a follow-up card for `<state_dir>` itself.

## Test plan

- [x] 6 new regression tests in `tests/scitex_agent_container/runtimes/test__apptainer_runtime.py`:
  - raw secret never appears in the dry-run argv file
  - redacted marker (`SAC_ANTHROPIC_API_KEY=<redacted: N chars>`) is present
  - the argv file is `0600`
  - non-secret env entries (e.g. `SCITEX_AGENT_CONTAINER_STATE_DB=...`) are left untouched
  - `build_run_argv` (the real, unmocked function) still returns the real secret value
  - a real subprocess (fake `apptainer` binary logging its own argv) still receives the real secret
- [x] Full file: `tests/scitex_agent_container/runtimes/test__apptainer_runtime.py` — 184 passed
- [x] `test__explain.py`, `_state/_meta/test_secrets.py`, `_state/test_agent_meta.py`, `runtimes/test_tui_session.py` — 124 passed, 3 skipped (pre-existing skips, back-compat imports still resolve)
- [x] Full repo suite — 8189 passed, 64 skipped, 16 failed. All 16 failures are pre-existing/environmental (missing `sac` binary on `$PATH`, package not `pip`-installed so `importlib.metadata` lookups fail, sandbox `HOME`/timeout artifacts) and confirmed to have zero references to any file this PR touches.
- [x] `scitex-dev ecosystem audit-all scitex-agent-container` — one pre-existing violation (§4: root `--help` missing the version line), unrelated to this change (no root CLI help text touched here).

Card reference: `sac-argv-token-plaintext`.