### PR TITLE
feat(session-candidates): preview trailing messages instead of first message

### DIFF
--- a/src/scitex_agent_container/_runners/_session_candidates.py
+++ b/src/scitex_agent_container/_runners/_session_candidates.py
@@ -34,6 +34,12 @@ __all__ = [
     "format_candidates",
 ]
 
+#: Sensible tail-like default for the trailing-messages preview when the
+#: caller (CLI ``-n``/``--tail-lines``) omits it — a couple of lines reads
+#: better than a single message in the existing one-line-per-candidate list
+#: format (sac-session-candidates-tail-preview).
+DEFAULT_TAIL_LINES = 2
+
 
 @dataclass(frozen=True)
 class SessionCandidate:
@@ -42,12 +48,17 @@ class SessionCandidate:
     ``session_id`` is the ``.jsonl`` stem (the uuid a ``--resume`` takes).
     ``mtime`` is the file's last-modified unix time (newest = most recently
     active). ``first_message`` is a short snippet of the first user prompt
-    (empty when the transcript has no parseable user turn).
+    (empty when the transcript has no parseable user turn) — kept for
+    callers that still want "how did this conversation start". The
+    default-DISPLAYED preview is ``last_messages`` (the trailing N
+    messages, more identifying for "what was I last doing" when choosing a
+    session to resume — sac-session-candidates-tail-preview).
     """
 
     session_id: str
     mtime: float
     first_message: str
+    last_messages: str = ""
 
     @property
     def mtime_iso(self) -> str:
@@ -141,11 +152,91 @@ def _extract_user_text(rec: dict) -> str:
     return ""
 
 
+def _extract_message_text(rec: dict) -> str:
+    """Pull message text out of one transcript record, else ''.
+
+    Like :func:`_extract_user_text` but accepts BOTH ``user`` and
+    ``assistant`` turns — the tail preview wants "what was said last in
+    this conversation" regardless of who said it, unlike the first-message
+    snippet which specifically anchors on the operator's opening prompt.
+    Returns the text prefixed with ``"<role>: "`` so a multi-line preview
+    stays legible about who said what.
+    """
+    if not isinstance(rec, dict):
+        return ""
+    role = rec.get("type") or rec.get("role")
+    if role not in ("user", "assistant"):
+        return ""
+    message = rec.get("message")
+    content = (
+        message.get("content") if isinstance(message, dict) else rec.get("content")
+    )
+    if isinstance(content, str):
+        text = content
+    elif isinstance(content, list):
+        parts: list[str] = []
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "text":
+                parts.append(str(block.get("text", "")))
+            elif isinstance(block, str):
+                parts.append(block)
+        text = " ".join(parts)
+    else:
+        text = ""
+    text = " ".join(text.split())
+    if not text:
+        return ""
+    return f"{role}: {text}"
+
+
+def _last_messages(
+    jsonl_path: Path,
+    *,
+    n: int = DEFAULT_TAIL_LINES,
+    max_chars: int = 120,
+) -> str:
+    """Return a snippet of the last ``n`` messages in a transcript.
+
+    Mirrors :func:`_first_user_message`'s parsing + per-message
+    char-truncation convention, but scans the ``.jsonl`` BACKWARD from the
+    end and pulls text from both user and assistant turns (the trailing
+    exchange is what "what was I last doing" needs, not just the
+    operator's own last prompt). Each matched message is truncated to
+    ``max_chars`` and the (up to) ``n`` snippets are joined with ``" | "``,
+    oldest-first, so the result stays a single line in the existing
+    one-line-per-candidate list format. Best-effort: any IO / parse
+    failure yields an empty string, same as the first-message extractor.
+    """
+    if n <= 0:
+        return ""
+    try:
+        with jsonl_path.open(encoding="utf-8", errors="replace") as fh:
+            lines = fh.readlines()
+    except OSError:
+        return ""
+    snippets: list[str] = []
+    for line in reversed(lines):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rec = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        text = _extract_message_text(rec)
+        if text:
+            snippets.append(text[:max_chars])
+            if len(snippets) >= n:
+                break
+    return " | ".join(reversed(snippets))
+
+
 def list_session_candidates(
     workdir: str,
     *,
     home: Path | None = None,
     limit: int = 10,
+    tail_lines: int = DEFAULT_TAIL_LINES,
 ) -> list[SessionCandidate]:
     """Return resumable conversations for ``workdir``, newest first.
 
@@ -154,6 +245,12 @@ def list_session_candidates(
     descending (most recently active first). Empty list when the projects
     dir is absent or holds no transcripts — the caller then knows there is
     genuinely nothing to resume.
+
+    ``tail_lines`` controls how many TRAILING messages are captured into
+    each candidate's ``last_messages`` preview (the default DISPLAYED
+    snippet — see :func:`format_candidates`); pass ``0`` to skip tail
+    extraction entirely. ``first_message`` is always computed too, for
+    callers still relying on it.
     """
     proj = _project_dir(workdir, home=home)
     if not proj.is_dir():
@@ -177,6 +274,7 @@ def list_session_candidates(
                 session_id=p.stem,
                 mtime=mtime,
                 first_message=_first_user_message(p),
+                last_messages=_last_messages(p, n=tail_lines),
             )
         )
     return out
@@ -185,14 +283,19 @@ def list_session_candidates(
 def format_candidates(candidates: list[SessionCandidate]) -> str:
     """Render candidates as a human-readable, copy-pasteable list.
 
-    Each line: ``  <session_id>  (<iso-mtime>)  <first-message snippet>``.
-    Returns a sentinel line when there are no candidates so the caller's
-    message is never an empty block.
+    Each line: ``  <session_id>  (<iso-mtime>)  <last-messages preview>``.
+    The preview shows the TRAILING messages of the transcript (what the
+    conversation was last doing — more identifying than the opening
+    prompt when choosing which session to resume,
+    sac-session-candidates-tail-preview) rather than the first-message
+    snippet. Returns a sentinel line when there are no candidates so the
+    caller's message is never an empty block.
     """
     if not candidates:
         return "  (no resumable conversations found in the projects store)"
     lines = [
-        f"  {c.session_id}  ({c.mtime_iso})  {c.first_message}".rstrip()
+        f"  {c.session_id}  ({c.mtime_iso})  "
+        f"{c.last_messages or c.first_message}".rstrip()
         for c in candidates
     ]
     return "\n".join(lines)

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_resume_preflight.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_resume_preflight.py
@@ -71,6 +71,7 @@ def preflight_resume_id(
     resume_id: str,
     *,
     is_remote: bool = False,
+    tail_lines: int | None = None,
 ) -> None:
     """Validate an explicit ``--resume`` id; fail loud + informative on miss.
 
@@ -92,10 +93,21 @@ def preflight_resume_id(
 
     ``is_remote`` lets the caller skip the local-store assertion for
     cross-host agents (their conversations are not on this host).
+
+    ``tail_lines`` (CLI ``-n``/``--tail-lines``, ``sac-session-candidates-
+    tail-preview``): how many TRAILING messages of each candidate's
+    transcript to preview in the listing below — more identifying than
+    the opening prompt when picking which conversation to resume. ``None``
+    (the default) defers to :data:`_session_candidates.DEFAULT_TAIL_LINES`.
     """
     from ..._runners._session_candidates import (
+        DEFAULT_TAIL_LINES,
         format_candidates,
         list_session_candidates,
+    )
+
+    effective_tail_lines = (
+        DEFAULT_TAIL_LINES if tail_lines is None else tail_lines
     )
 
     if is_remote:
@@ -128,7 +140,9 @@ def preflight_resume_id(
     from pathlib import Path as _Path
 
     workdir = str(_Path(config.workdir).expanduser())
-    candidates = list_session_candidates(workdir, home=home)
+    candidates = list_session_candidates(
+        workdir, home=home, tail_lines=effective_tail_lines
+    )
     if any(c.session_id == resume_id for c in candidates):
         return  # valid choice — proceed to launch.
 

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_start.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_start.py
@@ -50,6 +50,11 @@ from ._start_preflight_gate import make_preflight_runner
     "and overrides the YAML's claude.session / claude.resume_id.",
 )
 @click.option(
+    "-n", "--tail-lines", "tail_lines", type=int, default=None,
+    help="Trailing transcript messages to preview per resumable session "
+    "on a stale --resume (sac-session-candidates-tail-preview).",
+)
+@click.option(
     "--session",
     "session_mode",
     type=click.Choice(
@@ -257,6 +262,7 @@ def start(
     broker_self: bool,
     concurrency: int,
     stagger: float,
+    tail_lines: int | None,
 ) -> None:
     """Start one or more agents.
 
@@ -499,6 +505,7 @@ def start(
         broker_self=broker_self,
         yes=yes,
         verbose=verbose,
+        tail_lines=tail_lines,
     )
 
 

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_start_single.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_start_single.py
@@ -72,6 +72,7 @@ def run_single_targets(
     broker_self: bool = False,
     yes: bool = False,
     verbose: bool = False,
+    tail_lines: int | None = None,
 ) -> None:
     """Start each name/path in ``single_targets`` (directory bulk handled upstream).
 
@@ -95,6 +96,12 @@ def run_single_targets(
     (``render_plan_summary``: identity, spec path, runtime/image,
     workdir + backed-by-bind check, model). Either way the refusal
     without ``--yes``/``-y`` is unchanged.
+
+    ``tail_lines`` (``-n``/``--tail-lines``): forwarded to the
+    ``--resume`` preflight's candidate listing — how many trailing
+    transcript messages to preview per resumable conversation
+    (sac-session-candidates-tail-preview). ``None`` defers to the
+    module default.
     """
 
     def _emit_json(payload: dict) -> None:
@@ -255,7 +262,12 @@ def run_single_targets(
                         else (spec_host or None)
                     )
                     is_remote = bool(target_host) and target_host != current_host
-                    preflight_resume_id(config, resume_id, is_remote=is_remote)
+                    preflight_resume_id(
+                        config,
+                        resume_id,
+                        is_remote=is_remote,
+                        tail_lines=tail_lines,
+                    )
                 agent_start(
                     config_path,
                     no_preflight=no_preflight,

--- a/tests/scitex_agent_container/_runners/test__session_candidates.py
+++ b/tests/scitex_agent_container/_runners/test__session_candidates.py
@@ -5,7 +5,10 @@ SELECTABLE: list the conversations actually available for the agent so a
 ``--resume <chosen>`` is an informed choice rather than a silent fresh
 start. These tests prove ``list_session_candidates`` reads the SDK's
 ``$HOME/.claude/projects/<encoded-cwd>/*.jsonl`` store and returns
-structured candidates newest-first with a first-message snippet.
+structured candidates newest-first, with a TRAILING-messages preview
+(``last_messages``, the default DISPLAYED snippet — more identifying for
+"what was I last doing" than the opening prompt, sac-session-candidates-
+tail-preview) alongside the first-message snippet kept for back-compat.
 
 No-mocks: real on-disk ``.jsonl`` transcripts under a tmp ``$HOME``.
 Conforms to STX-TQ002 (AAA markers), STX-TQ003 (descriptive names),
@@ -32,8 +35,14 @@ def _write_transcript(
     session_id: str,
     *,
     first_user_text: str = "do the thing",
+    extra_messages: list[tuple[str, str]] | None = None,
 ) -> Path:
-    """Create a fake SDK transcript .jsonl under the encoded projects dir."""
+    """Create a fake SDK transcript .jsonl under the encoded projects dir.
+
+    ``extra_messages`` is a list of ``(role, text)`` pairs appended after
+    the opening user/assistant exchange, letting tests build a longer
+    transcript to exercise the trailing-messages (tail) preview.
+    """
     proj = home / ".claude" / "projects" / encode_claude_project(workdir)
     proj.mkdir(parents=True, exist_ok=True)
     p = proj / f"{session_id}.jsonl"
@@ -41,6 +50,8 @@ def _write_transcript(
         json.dumps({"type": "user", "message": {"content": first_user_text}}),
         json.dumps({"type": "assistant", "message": {"content": "ok"}}),
     ]
+    for role, text in extra_messages or []:
+        lines.append(json.dumps({"type": role, "message": {"content": text}}))
     p.write_text("\n".join(lines) + "\n", encoding="utf-8")
     return p
 
@@ -124,6 +135,56 @@ class TestListSessionCandidates:
         # Assert
         assert len(candidates) == 1
 
+    def test_last_messages_defaults_to_trailing_two(self, tmp_path: Path) -> None:
+        # Arrange — opening exchange + a later exchange; default tail is 2.
+        home = tmp_path / "home"
+        _write_transcript(
+            home,
+            "/work",
+            "uuid-aaa",
+            first_user_text="do the thing",
+            extra_messages=[
+                ("user", "actually do the other thing"),
+                ("assistant", "done, the other thing is fixed"),
+            ],
+        )
+        # Act
+        candidates = list_session_candidates("/work", home=home)
+        # Assert — the trailing two messages, not the opening prompt.
+        assert candidates[0].last_messages == (
+            "user: actually do the other thing | "
+            "assistant: done, the other thing is fixed"
+        )
+
+    def test_tail_lines_controls_preview_message_count(self, tmp_path: Path) -> None:
+        # Arrange
+        home = tmp_path / "home"
+        _write_transcript(
+            home,
+            "/work",
+            "uuid-aaa",
+            first_user_text="do the thing",
+            extra_messages=[
+                ("user", "actually do the other thing"),
+                ("assistant", "done, the other thing is fixed"),
+            ],
+        )
+        # Act
+        candidates = list_session_candidates("/work", home=home, tail_lines=1)
+        # Assert — only the very last message.
+        assert candidates[0].last_messages == "assistant: done, the other thing is fixed"
+
+    def test_first_message_still_populated_for_back_compat(
+        self, tmp_path: Path
+    ) -> None:
+        # Arrange
+        home = tmp_path / "home"
+        _write_transcript(home, "/work", "uuid-aaa", first_user_text="resume me please")
+        # Act
+        candidates = list_session_candidates("/work", home=home)
+        # Assert — existing callers of first_message are unaffected.
+        assert candidates[0].first_message == "resume me please"
+
 
 # ---------------------------------------------------------------------------
 # format_candidates
@@ -148,3 +209,35 @@ class TestFormatCandidates:
         rendered = format_candidates(candidates)
         # Assert
         assert "uuid-zzz" in rendered
+
+    def test_renders_trailing_reply_in_listing(self, tmp_path: Path) -> None:
+        # Arrange — opening prompt differs from the trailing exchange.
+        home = tmp_path / "home"
+        _write_transcript(
+            home,
+            "/work",
+            "uuid-zzz",
+            first_user_text="the opening prompt",
+            extra_messages=[("assistant", "the trailing reply")],
+        )
+        candidates = list_session_candidates("/work", home=home)
+        # Act
+        rendered = format_candidates(candidates)
+        # Assert — the tail preview is shown.
+        assert "the trailing reply" in rendered
+
+    def test_does_not_render_opening_prompt_in_listing(self, tmp_path: Path) -> None:
+        # Arrange — opening prompt differs from the trailing exchange.
+        home = tmp_path / "home"
+        _write_transcript(
+            home,
+            "/work",
+            "uuid-zzz",
+            first_user_text="the opening prompt",
+            extra_messages=[("assistant", "the trailing reply")],
+        )
+        candidates = list_session_candidates("/work", home=home)
+        # Act
+        rendered = format_candidates(candidates)
+        # Assert — the opening prompt is no longer the default preview.
+        assert "the opening prompt" not in rendered

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__resume_preflight.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__resume_preflight.py
@@ -162,6 +162,40 @@ class TestPreflightResumeId:
         # Assert
         assert result is None
 
+    def test_error_lists_trailing_message_not_opening_prompt(
+        self, runtime_root: Path
+    ) -> None:
+        # Arrange — a transcript whose LAST message differs from the
+        # opening one; the informative listing should show the tail
+        # (sac-session-candidates-tail-preview), not "prior work".
+        cfg = _FakeConfig("clew", "/home/agent/work")
+        p = _seed_conversation(runtime_root, "clew", "/home/agent/work", "uuid-live")
+        with p.open("a", encoding="utf-8") as fh:
+            fh.write(
+                json.dumps(
+                    {"type": "assistant", "message": {"content": "final reply"}}
+                )
+                + "\n"
+            )
+        # Act
+        ctx = pytest.raises(ResumePreflightError, match="final reply")
+        # Assert
+        with ctx:
+            preflight_resume_id(cfg, "uuid-gone")
+
+    def test_tail_lines_zero_falls_back_to_first_message(
+        self, runtime_root: Path
+    ) -> None:
+        # Arrange — with tail_lines=0 no trailing preview is captured, so
+        # the listing falls back to the first-message snippet.
+        cfg = _FakeConfig("clew", "/home/agent/work")
+        _seed_conversation(runtime_root, "clew", "/home/agent/work", "uuid-live")
+        # Act
+        ctx = pytest.raises(ResumePreflightError, match="prior work")
+        # Assert
+        with ctx:
+            preflight_resume_id(cfg, "uuid-gone", tail_lines=0)
+
     def test_full_access_keys_store_on_canonical_workdir_not_alias(
         self, runtime_root: Path
     ) -> None:


### PR DESCRIPTION
## Summary
- Resumable-session listings (the `sac agents start --resume <uuid>` preflight, and the autonomous dead-session recovery path) now default to previewing the LAST N transcript messages per candidate instead of the opening prompt — more identifying for "what was I last doing" when picking which conversation to resume.
- Adds a `-n`/`--tail-lines` option on `sac agents start` (default 2 trailing messages), threaded through `run_single_targets` -> `preflight_resume_id` -> `list_session_candidates`.
- `first_message` / `_first_user_message` are kept unchanged for existing callers; `format_candidates` now renders `last_messages` (falling back to `first_message` if empty, e.g. `tail_lines=0`).

Card: `sac-session-candidates-tail-preview`

## Changes
- `src/scitex_agent_container/_runners/_session_candidates.py`: new `_extract_message_text`, `_last_messages`, `DEFAULT_TAIL_LINES`; `SessionCandidate.last_messages` field; `list_session_candidates(..., tail_lines=...)`; `format_candidates` renders the tail preview.
- `src/scitex_agent_container/cli_pkg/lifecycle/_resume_preflight.py`: `preflight_resume_id(..., tail_lines=...)`.
- `src/scitex_agent_container/cli_pkg/lifecycle/_start_single.py`: `run_single_targets(..., tail_lines=...)` forwards to the preflight.
- `src/scitex_agent_container/cli_pkg/lifecycle/_start.py`: new `-n`/`--tail-lines` click option on `sac agents start`.
- Tests: `tests/scitex_agent_container/_runners/test__session_candidates.py`, `tests/scitex_agent_container/cli_pkg/lifecycle/test__resume_preflight.py`.

## Test plan
- [x] `pytest tests/scitex_agent_container/_runners tests/scitex_agent_container/cli_pkg/lifecycle -q` — 851 passed
- [x] `scitex-dev ecosystem audit-all scitex-agent-container` — one pre-existing, unrelated §4 finding (root `--help` missing version line); not introduced by this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)