### PR TITLE
fix(systemd): resolve sac's absolute path into the installed listen unit

### DIFF
--- a/scripts/systemd/install-sac-listen.sh
+++ b/scripts/systemd/install-sac-listen.sh
@@ -86,6 +86,45 @@ apply_secrets_envrc() {
   log "# SAC_SECRETS_ENVRC=${value} -> baked into ${unit}"
 }
 
+# Resolve the absolute path to the `sac` binary to bake into the
+# installed listen unit's ExecStart. WHY: systemd-user services do NOT
+# inherit the operator's interactive shell PATH (no .bashrc/.bash_profile/
+# venv-activation) — only the login-manager's default PATH. `sac` is
+# typically installed into a per-project venv (e.g.
+# .venv/bin/sac), which is never on that default PATH, so the repo
+# template's generic `ExecStart=/usr/bin/env sac listen` resolves to
+# nothing and the unit fails with exit 127 on first start (confirmed
+# live 2026-07-05: an installed-but-never-started unit failed exactly
+# this way on first install).
+#   - Operator override: if SAC_BIN is already exported when the
+#     installer runs, use it verbatim (mirrors the SAC_SECRETS_ENVRC
+#     override in secrets_envrc_value above).
+#   - Default: `command -v sac`, resolved in the INSTALLER's own shell
+#     context — which, unlike systemd-user, DOES see the operator's
+#     activated venv/PATH when this script is run interactively.
+# UNLIKE secrets_envrc_value (which silently omits its line when
+# nothing is found), this function FAILS LOUD: a listen unit with no
+# resolvable sac binary must never be installed, since that guarantees
+# a silent, unannounced exit-127 restart loop with no useful signal.
+resolve_sac_bin() {
+  if [ -n "${SAC_BIN:-}" ]; then
+    printf '%s' "$SAC_BIN"
+    return 0
+  fi
+  local resolved
+  resolved="$(command -v sac || true)"
+  if [ -z "$resolved" ]; then
+    log "ERROR: sac not found on PATH — activate the venv this script" \
+        "should run from (e.g. 'source .venv/bin/activate'), or pass" \
+        "SAC_BIN=<absolute-path-to-sac> explicitly. Refusing to install" \
+        "a listen unit with an unresolvable ExecStart (systemd-user does" \
+        "not inherit your interactive shell PATH, so guessing here would" \
+        "just move the exit-127 failure from install-time to boot-time)."
+    exit 1
+  fi
+  printf '%s' "$resolved"
+}
+
 uninstall() {
   log "# Disabling + removing sac listen units from ${DEST_DIR}"
   systemctl --user disable --now "$HEALTH_TIMER" >/dev/null 2>&1 || true
@@ -110,15 +149,30 @@ fi
 
 mkdir -p "$DEST_DIR"
 
+# 0. Resolve SAC_BIN FIRST, before installing/enabling anything. This is
+#    a fail-loud step (see resolve_sac_bin above): an unresolvable sac
+#    must abort the whole install, not land a broken unit that only
+#    fails once systemd tries to start it.
+SAC_BIN="$(resolve_sac_bin)"
+log "# SAC_BIN=${SAC_BIN} -> will be baked into ${LISTEN_UNIT}'s ExecStart"
+
 # 1. Copy the probe script first (the health .service ExecStart points
 #    at the installed copy) and make it executable.
 install -m 0755 "${SRC_DIR}/${PROBE_SCRIPT}" "${DEST_DIR}/${PROBE_SCRIPT}"
 log "# Installed ${DEST_DIR}/${PROBE_SCRIPT}"
 
-# 2. Copy the listen unit and the health timer verbatim.
-install -m 0644 "${SRC_DIR}/${LISTEN_UNIT}" "${DEST_DIR}/${LISTEN_UNIT}"
+# 2. Copy the listen unit, rewriting the ExecStart line to the resolved
+#    absolute SAC_BIN path (systemd-user does not inherit the
+#    interactive shell PATH that `/usr/bin/env sac` in the repo
+#    template relies on — see resolve_sac_bin's comment above). Same
+#    sed-stream-rewrite technique as the health .service step below;
+#    the repo template itself is left untouched (only the INSTALLED
+#    copy gets the concrete path). The health timer copies verbatim.
+sed "s#^ExecStart=.*#ExecStart=${SAC_BIN} listen#" \
+    "${SRC_DIR}/${LISTEN_UNIT}" > "${DEST_DIR}/${LISTEN_UNIT}"
+chmod 0644 "${DEST_DIR}/${LISTEN_UNIT}"
 install -m 0644 "${SRC_DIR}/${HEALTH_TIMER}" "${DEST_DIR}/${HEALTH_TIMER}"
-log "# Installed ${DEST_DIR}/${LISTEN_UNIT}"
+log "# Installed ${DEST_DIR}/${LISTEN_UNIT} (ExecStart -> ${SAC_BIN} listen)"
 log "# Installed ${DEST_DIR}/${HEALTH_TIMER}"
 
 # 2b. Bake SAC_SECRETS_ENVRC into the installed listen unit so the daemon


### PR DESCRIPTION
## Summary

- **Bug (found live 2026-07-05, first-ever install of this existing-but-never-installed unit):** `sac-listen.service`'s `ExecStart=/usr/bin/env sac listen` relies on `sac` resolving via PATH at systemd-user service-start time. systemd-user does **not** inherit the operator's interactive shell PATH (no `.bashrc`/venv-activation), so the unit failed with exit 127 ("command not found") on first start. The host's actual `sac` binary lives in a per-project venv (`.venv/bin/sac`), never on systemd-user's default PATH. The coordinator hand-patched the already-installed unit's `ExecStart` to an absolute path as an emergency live fix.
- **Fix (source + installer, so future installs on any host get it right):**
  - Added `resolve_sac_bin()` to `scripts/systemd/install-sac-listen.sh`, mirroring `secrets_envrc_value()`'s override-then-default shape: honors an `SAC_BIN` env var override, else resolves via `command -v sac` in the installer's own shell context. Unlike `secrets_envrc_value` (which silently omits its line when nothing resolves), `resolve_sac_bin` **fails loud** — prints an actionable error ("sac not found on PATH — activate the venv this script should run from, or pass SAC_BIN=<path> explicitly") and exits 1, so a broken unit is never installed in the first place.
  - The installer now resolves `SAC_BIN` first (before any install/enable step), then rewrites the **installed copy's** `ExecStart` line via the same `sed`-stream-rewrite technique already used for the health-probe service's `ExecStart` (`sed "s#^ExecStart=.*#ExecStart=${SAC_BIN} listen#" ... > installed-copy`). The repo's own `sac-listen.service` template is untouched — still the generic `/usr/bin/env sac listen` form — matching how `apply_secrets_envrc` and the health-service rewrite already only touch the installed copy.

## Changes

- `scripts/systemd/install-sac-listen.sh`
  - New `resolve_sac_bin()` function (after `apply_secrets_envrc`, before `uninstall()`).
  - New step 0 in the main flow: `SAC_BIN="$(resolve_sac_bin)"` runs before any install/enable, so a missing `sac` aborts the whole install cleanly (relies on `set -euo pipefail`, verified — see below).
  - Step 2 changed from a plain `install -m 0644` copy of `sac-listen.service` to a `sed`-stream rewrite + `chmod 0644`, exactly like the existing health-service step.
  - Expanded inline comments explaining the systemd-user PATH-inheritance gap.
- `scripts/systemd/sac-listen.service` — **unchanged** (repo template intentionally keeps the generic form).

## Verification

This repo has no existing pytest/test-shell-script harness for `scripts/systemd/*` (confirmed via `find` — no test files reference these scripts), so verification here is manual, run directly against the actual files:

1. **Syntax**: `bash -n scripts/systemd/install-sac-listen.sh` → exits 0, no errors.

2. **sed-rewrite correctness** (ran the exact sed used in the script against the real template with a fake `SAC_BIN`):
   ```
   $ SAC_BIN=/fake/path/to/sac
   $ sed "s#^ExecStart=.*#ExecStart=${SAC_BIN} listen#" scripts/systemd/sac-listen.service > /tmp/out.service
   $ diff scripts/systemd/sac-listen.service /tmp/out.service
   38c38
   < ExecStart=/usr/bin/env sac listen
   ---
   > ExecStart=/fake/path/to/sac listen
   ```
   Only the `ExecStart` line changes; every other line (Restart=always, StartLimitBurst, TimeoutStopSec, etc.) is untouched.

3. **Fail-loud path** (extracted the function logic and ran it with `PATH` stripped of `sac` and no `SAC_BIN` set):
   ```
   $ bash -c '... resolve_sac_bin ...; PATH=/nonexistent_bin_dir resolve_sac_bin; echo "unreachable"'
   ERROR: sac not found on PATH — activate the venv...
   $ echo "outer exit: $?"
   outer exit: 1
   ```
   The "unreachable" echo never printed — confirms the error path exits before returning a usable value.

4. **`set -e` propagation through `SAC_BIN="$(resolve_sac_bin)"`** (the actual pattern used in the script, not just the bare function call — command substitution runs the function in a subshell, so this needed explicit confirmation):
   ```
   $ bash -c 'set -euo pipefail; ...; PATH=/nonexistent_bin_dir; SAC_BIN="$(resolve_sac_bin)"; echo "REACHED THIS LINE (should not happen): SAC_BIN=$SAC_BIN"'
   ERROR: sac not found
   $ echo "outer exit: $?"
   outer exit: 1
   ```
   Confirms the script aborts cleanly at the assignment — the "REACHED" line never printed.

5. **Ecosystem audit**: ran `scitex-dev ecosystem audit-all scitex-agent-container` against this worktree. One violation reported (§4: root `--help` doesn't show the package version) — pre-existing and unrelated to this change (this PR only touches a systemd install script, not the CLI entrypoint). No new violations introduced.

I did **not** run the actual installer against this host's live systemd-user (per instructions — the coordinator's emergency hand-patch on this host's already-installed unit stays as-is for now).

## Follow-up (not part of this PR)

Once this merges, re-running `scripts/systemd/install-sac-listen.sh` on the host where the emergency hand-patch was applied will reconcile the live installed unit with this proper fail-loud/`SAC_BIN`-resolved shape (replacing the manually-patched `ExecStart` with one produced by the installer itself). This is an operational step for a follow-up, not done in this PR.
