### PR TITLE
fix(a2a): tag sac's own daemon messages with sender "daemon" (bracket form)

### DIFF
--- a/src/scitex_agent_container/_mcp/_channel_reaction_ack.py
+++ b/src/scitex_agent_container/_mcp/_channel_reaction_ack.py
@@ -47,6 +47,7 @@ import os
 from typing import Any
 
 from .._env import getenv as _sac_env
+from ..a2a._inbox_bus import DAEMON_SENDER
 
 log = logging.getLogger(__name__)
 
@@ -165,10 +166,11 @@ def should_emit_reaction_ack(event: dict[str, Any]) -> bool:
     * the event is itself a structural reaction
       (``kind == "reaction"``) — belt-and-suspenders so a future
       regression in marker handling cannot start a 👀-on-👀 cycle;
-    * the event is a system / synthetic notification
-      (``from_agent == "system"`` or ``kind`` in the synthetic-only
-      allow-list) — reacting to a system notification would post a
-      reaction back to ``system`` which the sender never sees and
+    * the event is a daemon / synthetic notification
+      (``from_agent`` is a bare ``"system"`` or the canonical daemon
+      sender :data:`DAEMON_SENDER`, or ``kind`` in the synthetic-only
+      allow-list) — reacting to a daemon notification would post a
+      reaction back to a non-agent sender the daemon never reads and
       pollutes the dispatch ledger.
 
     The dispatch-id threading is OPTIONAL — a sender that did not
@@ -186,7 +188,7 @@ def should_emit_reaction_ack(event: dict[str, Any]) -> bool:
         return False
     if kind in {"denied_attempt", "acl_deny_notify"}:
         return False
-    if event.get("from_agent") == "system":
+    if event.get("from_agent") in ("system", DAEMON_SENDER):
         return False
     return True
 

--- a/src/scitex_agent_container/a2a/_inbox_bus.py
+++ b/src/scitex_agent_container/a2a/_inbox_bus.py
@@ -40,6 +40,26 @@ from typing import Any
 # drop oldest than block the publisher's HTTP handler.
 _QUEUE_CAP = 64
 
+# Canonical ``from_agent`` (sender) value for messages sac's OWN
+# daemon originates — as opposed to an agent's a2a reasoning, which
+# keeps its own ``from_agent``.
+#
+# Operator directive (2026-07-05, bracket form): the channel tag an
+# agent sees renders as ``<- <source> [<sender>]`` where ``source``
+# stays the CLEAN, unsuffixed channel name (sac's channel identity,
+# e.g. ``sac``) and the SENDER (bracket) says whether the frame came
+# from the daemon or a peer agent. ``_build_notification`` projects
+# the event's ``from_agent`` into ``meta.source`` (the bracket), so a
+# sac daemon frame with ``from_agent=DAEMON_SENDER`` renders as
+# ``<- sac [daemon]`` and an agent frame renders ``<- sac [<agent>]``.
+#
+# This tag is applied ONLY to messages sac itself originates as the
+# daemon with no sender-supplied source. A message that already
+# carries a sender's ``from_agent`` (agent a2a) or another channel's
+# tag passes through UNCHANGED — sac never re-tags those, and the
+# source is never suffixed.
+DAEMON_SENDER = "daemon"
+
 
 class Broker:
     """In-memory pub/sub keyed by agent name."""
@@ -207,11 +227,14 @@ def mint_acl_deny_synthetic_notification(
 
     Differences from :func:`mint_deny_notification`:
 
-    * ``from_agent`` is the literal ``"system"`` (not the would-be
-      sender) — the receiver MUST know the notification did not
-      originate from a granted peer (the message body never leaks
-      pre-decision, and surfacing the sender as the apparent author
-      is the same leak in a different shape).
+    * ``from_agent`` is the canonical daemon sender
+      :data:`DAEMON_SENDER` (``"daemon"``, not the would-be sender) —
+      the receiver MUST know the notification did not originate from a
+      granted peer (the message body never leaks pre-decision, and
+      surfacing the sender as the apparent author is the same leak in a
+      different shape). Rendered in the channel bracket as
+      ``<- sac [daemon]`` so the receiver distinguishes this SAC daemon
+      frame from an agent-authored message.
     * ``content`` carries a human-readable, operator-actionable
       string embedding the exact ``sac a2a grant`` command keyed to
       the actual ``<sender>`` / ``<target>`` names. This is the
@@ -237,7 +260,7 @@ def mint_acl_deny_synthetic_notification(
     return mint_event(
         target,
         content=content,
-        from_agent="system",
+        from_agent=DAEMON_SENDER,
         priority="normal",
         kind="acl_deny_notify",
         extra={
@@ -251,6 +274,7 @@ def mint_acl_deny_synthetic_notification(
 
 
 __all__ = [
+    "DAEMON_SENDER",
     "Broker",
     "mint_event",
     "mint_deny_notification",

--- a/tests/scitex_agent_container/_listen/test__acl_deny_synthetic_notify.py
+++ b/tests/scitex_agent_container/_listen/test__acl_deny_synthetic_notify.py
@@ -127,11 +127,16 @@ def test_cross_group_deny_publishes_synthetic_notification(
     assert len(rows) == 1
 
 
-def test_synthetic_notification_from_agent_is_system(
+def test_synthetic_notification_sender_is_daemon(
     isolated_state: Path,
 ) -> None:
     # Arrange — the frame must not appear to come from the sender
-    # (that would impersonate a granted peer at the receiver).
+    # (that would impersonate a granted peer at the receiver). As a sac
+    # daemon-originated frame it carries sender ``from_agent="daemon"``
+    # so the receiving agent's channel tag renders ``<- sac [daemon]``
+    # (operator directive 2026-07-05, bracket form).
+    from scitex_agent_container.a2a._inbox_bus import DAEMON_SENDER
+
     app = create_app(token=_TOKEN)
     # Act
     with TestClient(app) as client:
@@ -142,7 +147,26 @@ def test_synthetic_notification_from_agent_is_system(
         )
     rows = _synthetic_rows("lead", isolated_state)
     # Assert
-    assert rows[0]["event"]["from_agent"] == "system"
+    assert rows[0]["event"]["from_agent"] == DAEMON_SENDER
+
+
+def test_synthetic_notification_sender_literal_is_daemon(
+    isolated_state: Path,
+) -> None:
+    # Arrange — pin the literal wire value so a rename of the constant
+    # can't silently drift the on-the-wire sender the operator's bracket
+    # convention depends on. No package-suffixed source token.
+    app = create_app(token=_TOKEN)
+    # Act
+    with TestClient(app) as client:
+        client.post(
+            "/agents/lead/message:send",
+            json=_send_payload("worker-a"),
+            headers={"authorization": f"Bearer {_TOKEN}"},
+        )
+    rows = _synthetic_rows("lead", isolated_state)
+    # Assert
+    assert rows[0]["event"]["from_agent"] == "daemon"
 
 
 def test_synthetic_notification_embeds_grant_command(

--- a/tests/scitex_agent_container/_mcp/test__channel_reaction_ack.py
+++ b/tests/scitex_agent_container/_mcp/test__channel_reaction_ack.py
@@ -130,6 +130,19 @@ def test_should_emit_reaction_ack_false_on_system_sender():
     assert decision is False
 
 
+def test_should_emit_reaction_ack_false_on_daemon_sender():
+    # Arrange — the canonical daemon sender (operator directive
+    # 2026-07-05, bracket form) must be treated exactly like the bare
+    # 'system' sender: no reaction back to a non-agent sender.
+    from scitex_agent_container.a2a._inbox_bus import DAEMON_SENDER
+
+    event = {"from_agent": DAEMON_SENDER, "kind": "acl_deny_notify"}
+    # Act
+    decision = should_emit_reaction_ack(event)
+    # Assert
+    assert decision is False
+
+
 # ---------------------------------------------------------------------------
 # (2) Env-driven config
 # ---------------------------------------------------------------------------

--- a/tests/scitex_agent_container/a2a/test__inbox_bus.py
+++ b/tests/scitex_agent_container/a2a/test__inbox_bus.py
@@ -7,7 +7,9 @@ from __future__ import annotations
 import pytest
 
 from scitex_agent_container.a2a._inbox_bus import (
+    DAEMON_SENDER,
     Broker,
+    mint_acl_deny_synthetic_notification,
     mint_deny_notification,
     mint_event,
 )
@@ -458,3 +460,84 @@ def test_mint_deny_notification_includes_timestamp() -> None:
     ts = event.get("ts")
     # Assert
     assert isinstance(ts, float) and ts > 0
+
+
+# ---------------------------------------------------------------------------
+# DAEMON_SENDER — canonical ``from_agent`` (sender) value for messages sac's
+# OWN daemon originates (operator directive 2026-07-05, bracket form). The
+# channel tag renders ``<- <clean-source> [<sender>]``; a daemon frame's
+# sender is ``"daemon"`` (renders ``<- sac [daemon]``). The source stays the
+# clean, UNSUFFIXED channel name — no ``*-system`` token. Sender-supplied
+# sources (agent a2a from_agent, other channels' tags) MUST pass through
+# unchanged.
+# ---------------------------------------------------------------------------
+
+
+def test_daemon_sender_constant_value() -> None:
+    # Arrange — pin the exact wire literal the operator's bracket
+    # convention depends on.
+    expected = "daemon"
+    # Act
+    actual = DAEMON_SENDER
+    # Assert
+    assert actual == expected
+
+
+def test_acl_deny_synthetic_uses_daemon_sender() -> None:
+    # Arrange — a sac-originated daemon notification (no sender-supplied
+    # source) must be tagged with the canonical daemon sender.
+    event = mint_acl_deny_synthetic_notification(
+        target="alice", sender="mallory", reason="cross-group"
+    )
+    # Act
+    from_agent = event["from_agent"]
+    # Assert
+    assert from_agent == DAEMON_SENDER
+
+
+def test_acl_deny_synthetic_is_not_bare_system() -> None:
+    # Arrange — regression guard: the old bare ``"system"`` tag must no
+    # longer appear on sac's own daemon messages.
+    event = mint_acl_deny_synthetic_notification(
+        target="alice", sender="mallory", reason="cross-group"
+    )
+    # Act
+    from_agent = event["from_agent"]
+    # Assert
+    assert from_agent != "system"
+
+
+def test_daemon_sender_is_not_package_suffixed() -> None:
+    # Arrange — regression guard: the sender must NOT be a package-
+    # suffixed ``*-system`` token; the source stays clean and the
+    # bracket carries the plain ``daemon`` sender.
+    event = mint_acl_deny_synthetic_notification(
+        target="alice", sender="mallory", reason="cross-group"
+    )
+    # Act
+    from_agent = event["from_agent"]
+    # Assert
+    assert not from_agent.endswith("-system")
+
+
+def test_mint_event_passes_through_sender_supplied_source_unchanged() -> None:
+    # Arrange — a message that arrives WITH a sender-supplied source
+    # (e.g. another channel's tag such as scitex-todo's) must be
+    # delivered with THAT source unchanged; sac only applies its own
+    # daemon sender to messages it originates with no sender-supplied
+    # source.
+    event = mint_event("alice", content="hi", from_agent="scitex-todo-system")
+    # Act
+    from_agent = event["from_agent"]
+    # Assert
+    assert from_agent == "scitex-todo-system"
+
+
+def test_mint_event_does_not_override_agent_sender_with_daemon() -> None:
+    # Arrange — an agent's own a2a ``from_agent`` must never be re-tagged
+    # to the daemon sender; it keeps its agent identity in the bracket.
+    event = mint_event("alice", content="hi", from_agent="worker-b")
+    # Act
+    from_agent = event["from_agent"]
+    # Assert
+    assert from_agent == "worker-b"


### PR DESCRIPTION
## What

sac's OWN daemon-originated channel messages now carry the canonical sender `from_agent = "daemon"` instead of the bare literal `"system"`, implementing the operator's **bracket form** (2026-07-05).

## Rendering (investigation finding)

`_mcp/channel.py::_build_notification` projects the bus event's `from_agent` into `meta["source"]`, which the client renders in the channel-tag bracket. The outer `source` is the clean MCP channel identity (`sac`). So:

- sac daemon frame → `from_agent="daemon"` → `<- sac [daemon]`
- agent frame → `from_agent=<agent-id>` → `<- sac [<agent-id>]`

The source is the clean, **unsuffixed** channel name — no `*-system` token anywhere.

## Change

- New canonical constant `DAEMON_SENDER = "daemon"` in `a2a/_inbox_bus.py`.
- `mint_acl_deny_synthetic_notification` (the sole sac-daemon message that hardcoded its sender, `_inbox_bus.py`) now uses `DAEMON_SENDER` — was the bare `"system"`.
- `_mcp/_channel_reaction_ack.py::should_emit_reaction_ack` treats `DAEMON_SENDER` as non-reactable (alongside the legacy bare `"system"`), so no reaction is posted back to a non-agent sender.

## Pass-through preserved

A sender-supplied `from_agent` (agent a2a, or another channel's tag such as scitex-todo's `scitex-todo-system`) is delivered **unchanged** — sac only applies the daemon sender to messages it originates with no sender-supplied source.

## Out of scope (untouched)

The `_listen/_notify.py` `DEFAULT_NOTIFY_FROM = "scitex-todo"` card-wake default is **left as-is** (separate scitex-todo card-wake decoupling effort).

## Tests

`test__inbox_bus.py`: constant value + literal, synthetic uses `DAEMON_SENDER`, not bare `"system"`, not package-suffixed, `mint_event` pass-through of agent + other-channel sources. `test__acl_deny_synthetic_notify.py`: end-to-end synthetic frame sender = `daemon`. `test__channel_reaction_ack.py`: reaction-ack guard on daemon sender. 80 passed (`PYTHONPATH=<worktree>/src`, interpreter `/opt/venv-sac/bin/python3`). `scitex-dev ecosystem audit-all` clean except one pre-existing unrelated audit-cli §4 version-line item (CLI untouched).