### PR TITLE
fix(envrc): drop runtime-only/legacy identity vars from folded .env (stops SCITEX_TODO_AGENT write-outage)

### DIFF
--- a/src/scitex_agent_container/runtimes/_envrc.py
+++ b/src/scitex_agent_container/runtimes/_envrc.py
@@ -38,6 +38,8 @@ import shlex
 import subprocess
 from pathlib import Path
 
+from ._to_home_text import _is_legacy_identity_var
+
 logger = logging.getLogger(__name__)
 
 # Shell-internal vars that legitimately differ between two otherwise-identical
@@ -121,14 +123,41 @@ def eval_envrc(envrc: Path, *, base_env: Path | None = None) -> dict[str, str]:
     lines.append("set +a")
     lines.append("env -0")
     loaded = _capture_env("\n".join(lines), cwd)
-    # Drop EMPTY values: a secret line (``export CCT_BOT_TOKEN="$CCT_BOT_TOKEN_X"``)
-    # folds to ``CCT_BOT_TOKEN=`` when its source is unset at fold time, which then
-    # SHADOWS the real value a later layer supplies (the .mcp.json's legacy-spelled
-    # bot token) — an empty short-form made the bridge read "" and 404 (dead poller).
+    return _folded_env(loaded, baseline)
+
+
+def _folded_env(
+    loaded: dict[str, str], baseline: dict[str, str]
+) -> dict[str, str]:
+    """Filter a captured ``loaded`` env down to the net ``.env`` contribution.
+
+    Applied identically by :func:`eval_envrc` and :func:`eval_envrc_cascade`.
+    A key is kept only when it is NOT shell noise, was ADDED or CHANGED vs the
+    ``baseline`` shell, has a non-empty value, and is NOT a deprecated identity
+    alias.
+
+    * **Empty values** are dropped: a secret line
+      (``export CCT_BOT_TOKEN="$CCT_BOT_TOKEN_X"``) folds to ``CCT_BOT_TOKEN=``
+      when its source is unset at fold time, which then SHADOWS the real value
+      a later layer supplies — an empty short-form made the telegram bridge
+      read "" and 404 (dead poller).
+    * **Legacy identity aliases** (:func:`_is_legacy_identity_var`) are dropped
+      so a stale ``SCITEX_TODO_AGENT`` that once landed in ``dest/.env`` cannot
+      SELF-PERPETUATE: the fold sources ``dest/.env`` as its base, so any such
+      orphan var (set by no cascade ``.envrc``) re-enters the diff and is
+      re-baked every deploy — and scitex-todo's MCP now HARD-REJECTS any call
+      when ``SCITEX_TODO_AGENT`` is present (INCIDENT 2026-07-05/06 write-
+      outage). The current ``_ID`` identity vars are deliberately NOT dropped:
+      the ``.env`` is the container ``--env-file`` and the materialized
+      ``.mcp.json`` expands ``${SCITEX_TODO_AGENT_ID}`` from it.
+    """
     return {
         key: val
         for key, val in loaded.items()
-        if key not in _SHELL_NOISE and baseline.get(key) != val and val != ""
+        if key not in _SHELL_NOISE
+        and baseline.get(key) != val
+        and val != ""
+        and not _is_legacy_identity_var(key)
     }
 
 
@@ -198,15 +227,7 @@ def eval_envrc_cascade(
     lines.append("set +a")
     lines.append("env -0")
     loaded = _capture_env("\n".join(lines), cwd)
-    # Drop EMPTY values: a secret line (``export CCT_BOT_TOKEN="$CCT_BOT_TOKEN_X"``)
-    # folds to ``CCT_BOT_TOKEN=`` when its source is unset at fold time, which then
-    # SHADOWS the real value a later layer supplies (the .mcp.json's legacy-spelled
-    # bot token) — an empty short-form made the bridge read "" and 404 (dead poller).
-    return {
-        key: val
-        for key, val in loaded.items()
-        if key not in _SHELL_NOISE and baseline.get(key) != val and val != ""
-    }
+    return _folded_env(loaded, baseline)
 
 
 def fold_envrc_cascade_into_env(dest: Path, envrcs: "list[Path | None]") -> None:

--- a/src/scitex_agent_container/runtimes/_to_home_text.py
+++ b/src/scitex_agent_container/runtimes/_to_home_text.py
@@ -61,21 +61,57 @@ START_MARKER_PREFIX = "<!-- Start of scitex-agent-container generated section"
 # scitex-todo and claude-code-telegrammer have both shipped templates using
 # ``${RUNTIME:VAR}`` for their identity vars — that migration + removal is a
 # separate follow-up PR.
-_RUNTIME_ONLY_VARS = frozenset(
+# Legacy pre-0.7.30 identity ALIASES — deprecated names that a downstream
+# consumer now HARD-REJECTS if present. scitex-todo's MCP server refuses any
+# call when ``SCITEX_TODO_AGENT`` is set ("was renamed to
+# ``SCITEX_TODO_AGENT_ID``; unset the old var"), so a stale copy of one of
+# these baked into a materialized/folded ``.env`` is not merely redundant like
+# the current ``_ID`` names — it is FATAL to the consumer (live write-outage,
+# INCIDENT 2026-07-05/06). Kept as its OWN named subset (unioned into
+# :data:`_RUNTIME_ONLY_VARS` below, so the name list is defined ONCE) precisely
+# so the ``.env``-fold guard in :mod:`_envrc` can drop ONLY these legacy
+# aliases while the CURRENT identity vars (``SCITEX_TODO_AGENT_ID`` / ``CCT_*``
+# / ``SAC_NAME``) legitimately REMAIN in the ``--env-file`` the container needs
+# at runtime (the materialized ``.mcp.json`` expands ``${SCITEX_TODO_AGENT_ID}``
+# from that container env). Dropping the current vars from the fold too would
+# strip the agent's live identity — a second outage — so the fold must NOT use
+# the broad :func:`_is_runtime_only_var`.
+_LEGACY_IDENTITY_VARS = frozenset(
     {
-        # scitex-todo >= 0.7.30 names
-        "SCITEX_TODO_AGENT_ID",
-        "SCITEX_TODO_TASKS_YAML_SHARED",
-        # Legacy pre-0.7.30 names — kept as a GUARD only (never injected by
-        # sac anymore): a stale deployer shell exporting the old names must
-        # still not bake them into materialized files.
         "SCITEX_TODO_AGENT",
         "SCITEX_TODO_TASKS",
-        "SAC_NAME",
-        "CLAUDE_AGENT_ID",
-        "CLAUDE_AGENT_ROLE",
     }
 )
+
+_RUNTIME_ONLY_VARS = (
+    frozenset(
+        {
+            # scitex-todo >= 0.7.30 names
+            "SCITEX_TODO_AGENT_ID",
+            "SCITEX_TODO_TASKS_YAML_SHARED",
+            "SAC_NAME",
+            "CLAUDE_AGENT_ID",
+            "CLAUDE_AGENT_ROLE",
+        }
+    )
+    # Legacy pre-0.7.30 names — kept as a GUARD only (never injected by sac
+    # anymore): a stale deployer shell exporting the old names must still not
+    # bake them into materialized files.
+    | _LEGACY_IDENTITY_VARS
+)
+
+
+def _is_legacy_identity_var(name: str) -> bool:
+    """True when ``name`` is a DEPRECATED identity alias the downstream
+    consumer hard-rejects → must be DROPPED from a folded ``.env``.
+
+    Narrower than :func:`_is_runtime_only_var` on purpose: the ``.env`` fold
+    (:func:`_envrc.eval_envrc` / :func:`_envrc.eval_envrc_cascade`) produces
+    the container's ``--env-file``, so the CURRENT identity vars must survive
+    there — only the fatal legacy aliases in :data:`_LEGACY_IDENTITY_VARS` are
+    stripped. See that constant's comment.
+    """
+    return name in _LEGACY_IDENTITY_VARS
 
 
 def _is_runtime_only_var(name: str) -> bool:

--- a/tests/scitex_agent_container/runtimes/test__envrc.py
+++ b/tests/scitex_agent_container/runtimes/test__envrc.py
@@ -223,3 +223,61 @@ def test_fold_omits_empty_valued_var(tmp_path: Path) -> None:
     fold_envrc_into_env(tmp_path)
     # Assert — the empty var is not written into the folded .env.
     assert "EMPTY=" not in (tmp_path / ".env").read_text()
+
+
+def test_cascade_drops_legacy_identity_alias_from_base_env(
+    tmp_path: Path, secrets_envrc: None
+) -> None:
+    # Arrange — a stale legacy alias (SCITEX_TODO_AGENT) already sits in the
+    # base .env (as it does for the affected agents); the .envrc sets only the
+    # current _ID name. This mirrors the self-perpetuating-loop that keeps the
+    # legacy var alive across deploys.
+    os.environ.pop(_SECRETS_VAR, None)
+    base = tmp_path / ".env"
+    base.write_text(
+        "SCITEX_TODO_AGENT=someagent\nSCITEX_TODO_AGENT_ID=someagent\n",
+        encoding="utf-8",
+    )
+    envrc = tmp_path / ".envrc"
+    envrc.write_text('export SCITEX_TODO_AGENT_ID="someagent"\n', encoding="utf-8")
+    # Act — the real fold path used in production (base .env sourced as base_env).
+    out = eval_envrc_cascade([envrc], base_env=base)
+    # Assert — the deprecated alias is dropped (scitex-todo MCP hard-rejects it).
+    assert "SCITEX_TODO_AGENT" not in out
+
+
+def test_cascade_keeps_current_id_var_from_base_env(
+    tmp_path: Path, secrets_envrc: None
+) -> None:
+    # Arrange — same setup as the drop test.
+    os.environ.pop(_SECRETS_VAR, None)
+    base = tmp_path / ".env"
+    base.write_text(
+        "SCITEX_TODO_AGENT=someagent\nSCITEX_TODO_AGENT_ID=someagent\n",
+        encoding="utf-8",
+    )
+    envrc = tmp_path / ".envrc"
+    envrc.write_text('export SCITEX_TODO_AGENT_ID="someagent"\n', encoding="utf-8")
+    # Act
+    out = eval_envrc_cascade([envrc], base_env=base)
+    # Assert — the CURRENT identity var survives (container --env-file needs it).
+    assert out.get("SCITEX_TODO_AGENT_ID") == "someagent"
+
+
+def test_fold_cascade_rewrites_env_without_legacy_alias(
+    tmp_path: Path, secrets_envrc: None
+) -> None:
+    # Arrange — a stale legacy alias in the materialised .env; the real
+    # fold_envrc_cascade_into_env rewrites the file in place.
+    os.environ.pop(_SECRETS_VAR, None)
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "SCITEX_TODO_AGENT=someagent\nSCITEX_TODO_AGENT_ID=someagent\n",
+        encoding="utf-8",
+    )
+    envrc = tmp_path / ".envrc"
+    envrc.write_text('export SCITEX_TODO_AGENT_ID="someagent"\n', encoding="utf-8")
+    # Act
+    fold_envrc_cascade_into_env(tmp_path, [envrc])
+    # Assert — the rewritten .env no longer carries the fatal legacy alias.
+    assert "SCITEX_TODO_AGENT=" not in env_file.read_text()


### PR DESCRIPTION
## Live write-outage — root cause and fix

Multiple agents (`claude-code-telegrammer`, `scitex-dev`, `scitex-todo`,
`neurovista`) carry the legacy `SCITEX_TODO_AGENT=<self>` var in their
materialized `.env`, alongside the current `SCITEX_TODO_AGENT_ID=<self>`.
scitex-todo's MCP server now HARD-REJECTS any call when `SCITEX_TODO_AGENT`
is present, so every scitex-todo MCP write from these agents fails.

### Root cause (deterministic, proven — no dotfiles change needed)

Reproduced the **real** `eval_envrc_cascade` for `claude-code-telegrammer`
with the actual `SAC_SECRETS_ENVRC` preamble the `sac-listen` daemon sources:

| case | base `.env` | folded output |
|---|---|---|
| A | contains stale `SCITEX_TODO_AGENT` | **survives** |
| B | without it | absent |
| C | no base, cascade + preamble only | absent |

So **no shell/dotfiles/secret/`.envrc` file sets `SCITEX_TODO_AGENT`** — the
preamble files are sourced into BOTH the baseline and loaded shells so they
cancel in the diff, and the cascade `.envrc` files only set the `_ID` name.
The legacy var is a **self-perpetuating loop**: the fold sources `dest/.env`
as `base_env` in the loaded-but-not-baseline shell, so a stale
`SCITEX_TODO_AGENT` (originally baked by an older sac/`.envrc`, set by no
current cascade layer) re-enters the diff and is re-baked on every deploy.
No dotfiles patch is required.

### Fix (sac-side defense-in-depth)

Guard the `.env` fold so deprecated identity aliases can never survive:

- `_to_home_text.py`: factor the legacy alias names into a single named
  `_LEGACY_IDENTITY_VARS` subset (`SCITEX_TODO_AGENT`, `SCITEX_TODO_TASKS`),
  unioned into `_RUNTIME_ONLY_VARS` (no name duplication), and add
  `_is_legacy_identity_var`.
- `_envrc.py`: both fold paths (`eval_envrc`, `eval_envrc_cascade`) now share
  a `_folded_env` filter that drops legacy identity aliases.

**Why not the broad `_is_runtime_only_var`:** the materialized `.env` IS the
container `--env-file`, and the materialized `.mcp.json` expands
`${SCITEX_TODO_AGENT_ID}` from that container env (the in-container `.envrc`
is empty). Dropping the CURRENT `_ID`/`CCT_*` vars would strip the agent's
live identity — a second outage. Only the fatal legacy aliases are dropped;
`SCITEX_TODO_AGENT_ID` deliberately survives.

### Tests

Three regression tests using the **real** fold functions (no mocks): a base
`.env` carrying `SCITEX_TODO_AGENT` folds WITHOUT it while
`SCITEX_TODO_AGENT_ID` survives. `test__envrc.py` 18 passed,
`test__to_home_text.py` 10 passed.

### Operational follow-up

Affected agents (`claude-code-telegrammer`, `scitex-dev`, `scitex-todo`,
`neurovista`) each need a **redeploy + restart** to clear the already-baked
`.env` — this fix stops the re-bake on the next deploy but does not rewrite
an existing materialized `.env` in place until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
