### PR TITLE
fix(cron): auto-pull every ~/proj/scitex-* repo (incident sac-auto-pull-broken-manual-pulls)

### DIFF
--- a/src/scitex_agent_container/cron/post-merge-pull.sh
+++ b/src/scitex_agent_container/cron/post-merge-pull.sh
@@ -4,27 +4,54 @@
 #
 # Designed to run under cron once a minute on each fleet host so the host
 # checkouts stay current and nobody has to pull by hand.
-# Scope: ~/proj/<repo> only.  ~/forks/ and workspace clones are skipped.
+#
+# Discovery (fixes the stale-checkout incident, card
+# sac-auto-pull-broken-manual-pulls-20260630): every directory matching
+# ~/proj/scitex  and  ~/proj/scitex-*  is considered — NOT a hand-maintained
+# allowlist. A hardcoded list silently omitted repos (scitex-dev, scitex-todo,
+# …) so they went stale while merged PRs sat unpulled; glob discovery keeps
+# the sweep complete as the fleet grows. Non-git dirs (tarballs, `*.worktrees`
+# container dirs), feature-branch checkouts and dirty trees are filtered out by
+# the per-repo guards below, so the wide glob is safe.
+#
 # Remote-agnostic: uses each branch's configured upstream — no hardcoded
-# remote name or URL.  Only ever touches a checkout that is on `develop`
-# with a clean working tree; feature-branch / dirty checkouts are left alone.
+# remote name or URL.  Only ever fast-forwards a checkout that is on `develop`
+# with a clean working tree; feature-branch / dirty / ahead / diverged
+# checkouts are left untouched (never clobbers unpushed local work).
+#
+# Fail-loud but resilient: one problem repo never aborts the sweep. A repo
+# that is behind its upstream but cannot be fast-forwarded (missing upstream,
+# unreachable remote, racing ff) is logged as a WARN and makes the whole run
+# exit non-zero, so the failure is visible in cron's log rather than silently
+# skipped-and-forgotten. Expected non-actionable states (ahead / diverged /
+# dirty / not-on-develop) are logged but do not fail the run.
 #
 # Usage:
 #   crontab: * * * * * ~/.scitex/agent-container/runtime/cron/post-merge-pull.sh \
 #              >> ~/.scitex/agent-container/runtime/logs/post-merge-pull.$(hostname -s).cron.log 2>&1
 
 set -euo pipefail
+shopt -s nullglob
 
 HOST="$(hostname -s)"
-LOG_DIR="${HOME}/.scitex/agent-container/runtime/logs"
+PROJ_DIR="${HOME}/proj"
+RUNTIME_DIR="${HOME}/.scitex/agent-container/runtime"
+LOG_DIR="${RUNTIME_DIR}/logs"
 LOG_FILE="${LOG_DIR}/post-merge-pull.${HOST}.log"
-LOCK_FILE="/tmp/post-merge-pull.${HOST}.lock"
+# Lock lives under HOME (per-host, per-user) rather than a shared /tmp path so
+# concurrent users on a multi-tenant host — and hermetic test runs with an
+# isolated $HOME — never collide on a single global lock.
+LOCK_FILE="${RUNTIME_DIR}/post-merge-pull.${HOST}.lock"
 
 mkdir -p "${LOG_DIR}"
 
 _ts() { date '+%Y-%m-%dT%H:%M:%S'; }
 _info() { echo "$(_ts) [INFO] $*" | tee -a "${LOG_FILE}"; }
 _warn() { echo "$(_ts) [WARN] $*" | tee -a "${LOG_FILE}" >&2; }
+
+# Repos that were behind but could not be fast-forwarded (real failures).
+SWEEP_FAILURES=()
+_record_failure() { SWEEP_FAILURES+=("$1"); }
 
 # Acquire exclusive lock — abort if another run is still active.
 exec 9>"${LOCK_FILE}"
@@ -34,31 +61,28 @@ if ! flock -n 9; then
 fi
 
 # ---------------------------------------------------------------------------
-# Repo allowlist: canonical scitex repo names.  Each resolves to ~/proj/<name>
-# and is pulled via its tracked upstream (origin/develop) — no remote URL is
-# hardcoded here.  A name whose dir is absent is skipped.
+# Repo discovery: every ~/proj/scitex and ~/proj/scitex-* directory. The wide
+# net is deliberate — the per-repo guards in _pull_repo (must be a git repo,
+# on develop, clean, with a tracked upstream) filter out everything that
+# should not be touched, so no hand-maintained allowlist can drift stale.
 # ---------------------------------------------------------------------------
-REPOS=(
-    "scitex-agent-container"
-    "scitex-orochi"
-    "scitex-resource"
-    "scitex-ssh"
-    "scitex-hpc"
-    "scitex"
-)
+_discover_repos() {
+    [[ -d "${PROJ_DIR}" ]] || return 0
+    local d
+    for d in "${PROJ_DIR}"/scitex "${PROJ_DIR}"/scitex-*; do
+        [[ -d "${d}" ]] || continue
+        printf '%s\n' "${d}"
+    done
+}
 
 _pull_repo() {
-    local name="$1"
-    local repo_path="${HOME}/proj/${name}"
+    local repo_path="$1"
+    local name
+    name="$(basename "${repo_path}")"
 
-    [[ -d "${repo_path}" ]] || {
-        _info "SKIP ${name}: not found at ${repo_path}"
-        return 0
-    }
-
-    # Must be an actual git repo.
+    # Must be an actual git repo (skips tarballs, `*.worktrees` container dirs).
     if ! git -C "${repo_path}" rev-parse --git-dir &>/dev/null; then
-        _info "SKIP ${name}: not a git repository at ${repo_path}"
+        _info "SKIP ${name}: not a git repository"
         return 0
     fi
 
@@ -79,25 +103,69 @@ _pull_repo() {
         return 0
     fi
 
-    # Fast-forward only, via the branch's configured upstream (origin/develop).
-    local before_sha after_sha
-    before_sha="$(git -C "${repo_path}" rev-parse HEAD)"
+    # Resolve the branch's tracked upstream (e.g. origin/develop). No upstream
+    # means this checkout is not wired for auto-pull — log loudly so it is not
+    # silently forgotten, but it is a config state, not a run failure.
+    local upstream
+    upstream="$(git -C "${repo_path}" rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || true)"
+    if [[ -z "${upstream}" ]]; then
+        _warn "SKIP ${name}: no upstream configured for 'develop'"
+        return 0
+    fi
+    local remote="${upstream%%/*}"
 
-    if ! git -C "${repo_path}" pull --ff-only 2>>"${LOG_FILE}"; then
-        _warn "FAIL ${name}: pull --ff-only failed (non-fast-forward or no upstream?)"
+    # Refresh remote refs. A failed fetch (unreachable remote) on a checkout we
+    # are meant to keep current IS a real failure — flag it.
+    if ! git -C "${repo_path}" fetch --quiet "${remote}" 2>>"${LOG_FILE}"; then
+        _warn "FAIL ${name}: git fetch ${remote} failed (unreachable remote?)"
+        _record_failure "${name}"
         return 0
     fi
 
-    after_sha="$(git -C "${repo_path}" rev-parse HEAD)"
-    if [[ "${before_sha}" == "${after_sha}" ]]; then
-        _info "OK ${name}: already at ${after_sha:0:12} (no new commits)"
-    else
-        _info "OK ${name}: ${before_sha:0:12} → ${after_sha:0:12}"
+    local local_sha remote_sha base
+    local_sha="$(git -C "${repo_path}" rev-parse HEAD)"
+    remote_sha="$(git -C "${repo_path}" rev-parse "${upstream}")"
+    base="$(git -C "${repo_path}" merge-base HEAD "${upstream}" 2>/dev/null || true)"
+
+    if [[ "${local_sha}" == "${remote_sha}" ]]; then
+        _info "OK ${name}: already at ${local_sha:0:12} (no new commits)"
+        return 0
     fi
+
+    if [[ "${base}" == "${remote_sha}" ]]; then
+        # Local is ahead of upstream — unpushed local commits. Never clobber.
+        _info "SKIP ${name}: local is ahead of ${upstream} (unpushed commits) — not pulling"
+        return 0
+    fi
+
+    if [[ "${base}" != "${local_sha}" ]]; then
+        # Neither ancestor of the other — histories diverged. Needs a human;
+        # ff-only would fail, so leave it and surface it loudly.
+        _warn "SKIP ${name}: diverged from ${upstream} — manual reconcile needed"
+        return 0
+    fi
+
+    # base == local_sha and local != remote  ⇒  strictly behind ⇒ fast-forward.
+    if git -C "${repo_path}" merge --ff-only "${upstream}" >>"${LOG_FILE}" 2>&1; then
+        _info "OK ${name}: ${local_sha:0:12} → ${remote_sha:0:12}"
+    else
+        _warn "FAIL ${name}: fast-forward to ${upstream} failed"
+        _record_failure "${name}"
+    fi
+    return 0
 }
 
-_info "--- post-merge-pull start (host=${HOST}) ---"
-for repo_name in "${REPOS[@]}"; do
-    _pull_repo "${repo_name}"
-done
-_info "--- post-merge-pull done ---"
+_info "--- post-merge-pull start (host=${HOST}, proj=${PROJ_DIR}) ---"
+
+_repo_count=0
+while IFS= read -r repo_path; do
+    [[ -n "${repo_path}" ]] || continue
+    _repo_count=$((_repo_count + 1))
+    _pull_repo "${repo_path}"
+done < <(_discover_repos)
+
+if [[ ${#SWEEP_FAILURES[@]} -gt 0 ]]; then
+    _warn "--- post-merge-pull done: ${#SWEEP_FAILURES[@]}/${_repo_count} repo(s) FAILED to pull: ${SWEEP_FAILURES[*]} ---"
+    exit 1
+fi
+_info "--- post-merge-pull done: ${_repo_count} repo(s) checked, all clear ---"

--- a/tests/scitex_agent_container/cli_pkg/test_installation_group.py
+++ b/tests/scitex_agent_container/cli_pkg/test_installation_group.py
@@ -563,3 +563,149 @@ class TestPostMergePullScript:
         _result, _before, _after, log = dirty_develop_run
         # Assert
         assert "uncommitted changes" in log
+
+
+def _local_commit(clone: Path) -> None:
+    """Add an unpushed local commit so the checkout is *ahead* of upstream."""
+    (clone / "unpushed.txt").write_text("local work")
+    _git(clone, "add", "unpushed.txt")
+    _git(clone, "commit", "-m", "local unpushed")
+
+
+def _break_remote(clone: Path, dead_path: Path) -> None:
+    """Point origin at a nonexistent path so ``git fetch`` fails hard."""
+    _git(clone, "remote", "set-url", "origin", str(dead_path))
+
+
+@pytest.mark.integration
+class TestPostMergePullDiscoveryAndResilience:
+    """Regression coverage for the auto-pull incident (card
+    sac-auto-pull-broken-manual-pulls-20260630): repo discovery must not be a
+    hand-maintained allowlist, and one broken repo must not silently abort or
+    corrupt the sweep. Real bash + real git — no mocks anywhere.
+    """
+
+    # -- discovery is glob-based, not a hand-maintained allowlist ----------
+    # The incident's smoking gun: scitex-dev went stale because it was absent
+    # from the old hardcoded REPOS list. Any ~/proj/scitex-* develop checkout
+    # must now be discovered and fast-forwarded.
+
+    @pytest.fixture
+    def offlist_repo_run(self, tmp_path, post_merge_pull_script):
+        # "scitex-dev" was NOT in the legacy hardcoded allowlist.
+        clone = _make_repo(tmp_path, "scitex-dev")
+        before = _git(clone, "rev-parse", "HEAD").stdout.strip()
+        _advance_upstream(tmp_path, "scitex-dev")
+        result = _run_script(post_merge_pull_script, tmp_path)
+        after = _git(clone, "rev-parse", "HEAD").stdout.strip()
+        return result, before, after
+
+    def test_offlist_repo_is_discovered_and_fast_forwarded(self, offlist_repo_run):
+        # Arrange
+        # Act
+        _result, before, after = offlist_repo_run
+        # Assert — the whole point of the fix: no allowlist gap.
+        assert after != before
+
+    def test_offlist_repo_run_returns_zero(self, offlist_repo_run):
+        # Arrange
+        # Act
+        result, _before, _after = offlist_repo_run
+        # Assert
+        assert result.returncode == 0
+
+    # -- ahead checkout: unpushed local commits are never clobbered --------
+
+    @pytest.fixture
+    def ahead_develop_run(self, tmp_path, post_merge_pull_script):
+        clone = _make_repo(tmp_path, "scitex-ahead")
+        _local_commit(clone)  # local is now ahead of origin/develop
+        before = _git(clone, "rev-parse", "HEAD").stdout.strip()
+        result = _run_script(post_merge_pull_script, tmp_path)
+        after = _git(clone, "rev-parse", "HEAD").stdout.strip()
+        return result, before, after, _log_text(tmp_path)
+
+    def test_ahead_checkout_head_unchanged(self, ahead_develop_run):
+        # Arrange
+        # Act
+        _result, before, after, _log = ahead_develop_run
+        # Assert
+        assert after == before
+
+    def test_ahead_checkout_logs_ahead_skip(self, ahead_develop_run):
+        # Arrange
+        # Act
+        _result, _before, _after, log = ahead_develop_run
+        # Assert
+        assert "ahead" in log
+
+    def test_ahead_checkout_run_returns_zero(self, ahead_develop_run):
+        # Arrange — ahead is an expected state, not a run failure.
+        # Act
+        result, _before, _after, _log = ahead_develop_run
+        # Assert
+        assert result.returncode == 0
+
+    # -- behind checkout with unreachable upstream: fail loud --------------
+
+    @pytest.fixture
+    def unreachable_upstream_run(self, tmp_path, post_merge_pull_script):
+        clone = _make_repo(tmp_path, "scitex-broken")
+        before = _git(clone, "rev-parse", "HEAD").stdout.strip()
+        _advance_upstream(tmp_path, "scitex-broken")  # now behind
+        _break_remote(clone, tmp_path / "does-not-exist")
+        result = _run_script(post_merge_pull_script, tmp_path)
+        after = _git(clone, "rev-parse", "HEAD").stdout.strip()
+        return result, before, after, _log_text(tmp_path)
+
+    def test_unreachable_upstream_exits_nonzero(self, unreachable_upstream_run):
+        # Arrange — a repo that can't be pulled must fail loud, not vanish.
+        # Act
+        result, _before, _after, _log = unreachable_upstream_run
+        # Assert
+        assert result.returncode != 0
+
+    def test_unreachable_upstream_logs_fail(self, unreachable_upstream_run):
+        # Arrange
+        # Act
+        _result, _before, _after, log = unreachable_upstream_run
+        # Assert
+        assert "FAIL" in log
+
+    def test_unreachable_upstream_head_unchanged(self, unreachable_upstream_run):
+        # Arrange — a failed fetch must never move HEAD.
+        # Act
+        _result, before, after, _log = unreachable_upstream_run
+        # Assert
+        assert after == before
+
+    # -- one broken repo must not abort the rest of the sweep --------------
+
+    @pytest.fixture
+    def mixed_sweep_run(self, tmp_path, post_merge_pull_script):
+        good = _make_repo(tmp_path, "scitex-good")
+        good_before = _git(good, "rev-parse", "HEAD").stdout.strip()
+        _advance_upstream(tmp_path, "scitex-good")  # good is behind -> should FF
+
+        bad = _make_repo(tmp_path, "scitex-bad")
+        _advance_upstream(tmp_path, "scitex-bad")  # bad is behind
+        _break_remote(bad, tmp_path / "nowhere")  # ...but can't fetch
+
+        result = _run_script(post_merge_pull_script, tmp_path)
+        good_after = _git(good, "rev-parse", "HEAD").stdout.strip()
+        return result, good_before, good_after
+
+    def test_sweep_fast_forwards_good_repo_despite_bad_one(self, mixed_sweep_run):
+        # Arrange — the healthy repo must still be pulled even though another
+        # repo in the same sweep failed.
+        # Act
+        _result, good_before, good_after = mixed_sweep_run
+        # Assert
+        assert good_after != good_before
+
+    def test_sweep_still_reports_failure_exit_code(self, mixed_sweep_run):
+        # Arrange — the failure of the bad repo is still surfaced overall.
+        # Act
+        result, _good_before, _good_after = mixed_sweep_run
+        # Assert
+        assert result.returncode != 0


### PR DESCRIPTION
## Incident

Fixes card `sac-auto-pull-broken-manual-pulls-20260630` [P2].

Agents kept having to ask the operator to `git pull` (a constitution
violation — pull belongs in the agent's automated delivery loop) because
the per-minute host-checkout auto-pull
(`src/scitex_agent_container/cron/post-merge-pull.sh`) never kept every
`~/proj/scitex-*` repo current. Hit live twice today: merged PRs stayed
behind on sac `develop`, and the sac venv's `scitex-dev` was stale.

## The three documented breaks — status

1. **Hardcoded `gitea` remote** (`git pull gitea develop` on checkouts
   whose only remote is `origin=github`). Already fixed in `145c63ac`
   (remote-agnostic, tracked upstream). This PR preserves and hardens it:
   the remote is derived from the branch's `@{u}`, never named literally
   (`rg gitea` → 0 hits).
2. **Not deployed** to `~/.scitex/agent-container/runtime/cron/`. Handled
   in code by `sac install boot` → `_deploy_cron_script`, which copies
   the bundled script to exactly the path `_cron_line()` points at.
3. **Not scheduled** (absent from the crontab). Handled in code by
   `sac installation setup-cron`, which writes that cron line
   idempotently.

Breaks 2 and 3 are resolved **in code**; the remaining piece is the
one-time **host-side activation** (`sac install boot` +
`sac installation setup-cron`) — the "host-only" step the card calls out.
On this host neither has run yet (no crontab entry, no deployed script),
so the automation should be activated on each fleet host after merge.

## The live root cause this PR fixes

Even with breaks 1–3 addressed, the script pulled a **hand-maintained
6-repo allowlist** (`scitex-agent-container, scitex-orochi,
scitex-resource, scitex-ssh, scitex-hpc, scitex`). It silently omitted
`scitex-dev`, `scitex-todo`, and ~25 other `develop` checkouts present on
this host — which is exactly why `scitex-dev` went stale and merged PRs
sat unpulled today. A hardcoded list cannot keep up with a growing fleet.

## Changes to `post-merge-pull.sh`

- **Glob discovery** of every `~/proj/scitex` and `~/proj/scitex-*`
  directory — no allowlist to drift stale.
- **Safe per-repo guards** on the wide net: must be a git repo (skips
  tarballs and `*.worktrees` container dirs), on `develop`, clean tree,
  with a tracked upstream. Unpushed work is never clobbered — **ahead**
  and **diverged** checkouts are left untouched.
- **Precise classification** via `fetch` + `merge-base`:
  up-to-date / behind→ff / ahead→skip / diverged→warn / no-upstream→warn.
- **Fail loud but resilient**: a repo that is behind yet cannot fetch or
  fast-forward is logged as `FAIL` and makes the run exit non-zero — so
  it is visible in cron's log, not silently skipped-and-forgotten — but
  one bad repo never aborts the sweep (failures collected in an array and
  summarized at the end). Expected states (ahead / diverged / dirty /
  not-on-develop) are logged but do not fail the run.
- Moved the lock from a shared `/tmp` path to under `$HOME` so
  multi-tenant hosts and hermetic test runs never collide on one lock.

## Tests (real bash + real git, no mocks)

New coverage in `test_installation_group.py`
(`TestPostMergePullDiscoveryAndResilience`), each using a temp bare
upstream + clone fixture:

- an **off-allowlist** repo (`scitex-dev`) is discovered and
  fast-forwarded (the regression that caused the incident);
- an **ahead** checkout with unpushed commits is never clobbered and is
  logged as an ahead-skip;
- an **unreachable upstream** on a behind repo fails loud (non-zero exit,
  `FAIL` logged, HEAD unchanged);
- one **broken** repo does not stop a healthy repo from fast-forwarding,
  while the run still reports a non-zero exit.

All 41 tests in the file pass (`/opt/venv-sac/bin/python3 -m pytest`,
`PYTHONPATH=<worktree>/src`, 39.6s). The existing
`TestPostMergePullScript` cases (clean/feature/dirty) remain green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
