### PR TITLE
fix(agents): render the proven developer shape for `sac agents create --template full`

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_create.py
+++ b/src/scitex_agent_container/cli_pkg/_create.py
@@ -15,10 +15,20 @@ Two templates ship out of the box:
     ``examples/agents/minimal-agent/``. Three blocks: ``apptainer.image``,
     ``claude.model``, ``claude.flags``. Use as the starting point for new
     agents you'll customise yourself.
-  * ``full`` — full-fat spec mirroring
-    ``examples/agents/full-agent/`` (sans the inline tutorial comments).
-    Use when you want every knob present so you can delete what you
-    don't need rather than look up what's available.
+  * ``full`` — the PROVEN developer shape the fleet's live dev agents
+    use (card sac-agents-new-template-stale, operator 2026-06-25:
+    "very general, just developer like existing ones"). NOT a bare
+    knob-tour: it renders a ready-to-run project-maintainer agent —
+    runtime: tui, relaxed + persistent directory overlay,
+    full-home reach at the canonical path, the fleet push channels
+    (``server:sac`` + ``server:scitex-todo`` + telegrammer),
+    ``SCITEX_TODO_AGENT_ID`` wired to the agent, an editable install of
+    the agent's own repo, a generic "Start or continue." kick, opus
+    model, and metadata.labels. Parameterised by ``{name}`` (the agent
+    == project) and ``{home}`` (the operator's home, filled at render
+    time so the whole-home bind + workdir are absolute yet
+    operator-agnostic). Edit the labels + prompt for the real mission;
+    delete blocks you don't need.
 
 The CLI refuses to overwrite an existing ``spec.yaml`` unless ``--force``
 is passed — protects the "60 stale ``*-quality`` specs already pending
@@ -105,52 +115,119 @@ spec:
 
 
 _FULL_TEMPLATE = """\
-# {name} — fresh v3 spec scaffolded by ``sac agents create --template full``.
+# {name} — fresh v3 DEVELOPER spec scaffolded by ``sac agents create --template full``.
 #
-# Every field below validates against the live v3 schema. Delete blocks
-# you don't need rather than chase the spec reference for what's
-# available.
+# This is the PROVEN developer shape the fleet's live dev agents use
+# (card sac-agents-new-template-stale; operator 2026-06-25: "very
+# general, just developer like existing ones") — a ready-to-run
+# project-maintainer agent, NOT a bare skeleton. It ships:
+#   * runtime: tui                interactive in-apptainer Claude TUI
+#   * relaxed + directory overlay persistent per-agent $HOME / installs
+#   * full host reach at the canonical path (so ~/proj/... paths match)
+#   * fleet push channels         server:sac + server:scitex-todo + telegrammer
+#   * SCITEX_TODO_AGENT_ID        todo-store writes attribute to THIS agent
+#   * editable install of the agent's own repo (live dev loop)
+#   * a generic "Start or continue." kick + metadata.labels + opus model
+# Every field validates against the live v3 schema. Edit the labels + the
+# startup prompt for the agent's real mission; delete blocks you don't need.
 
 apiVersion: scitex-agent-container/v3
 kind: Agent
 
 metadata:
   labels:
-    role: worker
+    role: project-maintainer
     team: scitex
+    project: {name}
+    purpose: {name}-maintainer
     description: |
-      {name} — fresh v3 agent. Replace this description and the
-      startup prompt with your agent's actual mission.
-    function: scaffolded
-    capabilities: scaffolded
-    skills: ""
+      {name} developer agent — maintains the {name} repo. Replace this
+      description and the startup prompt below with the agent's real mission.
+    capabilities: develop, test, review, release
     cardinality: singleton
 
 spec:
-  runtime: apptainer
+  runtime: tui
   host: local
-  workdir: ~/proj/{name}
 
+  # The in-container --pwd. The repo is bound at this SAME absolute path
+  # below, so host and container agree (editable install, git, tooling).
+  workdir: {home}/proj/{name}
+
+  # to_home/ sibling — mirrored into the container $HOME (overlay upper
+  # home under relaxed mode). Put CLAUDE.md / .mcp.json / .claude/ there.
   to_home: ./to_home
 
   python-venv: auto
 
   apptainer:
-    image: ~/.scitex/agent-container/containers/sac-scitex.sif
-    binds: []
-    relaxed: false
+    # sac-base.sif = the minimal layer; the agent editable-installs its
+    # own stack into the overlay below. Swap to sac-scitex.sif to start
+    # from the full pre-baked scitex stack instead.
+    image: ~/.scitex/agent-container/containers/sac-base.sif
+
+    # Relaxed isolation — the dev agent shares the operator's identity and
+    # host tree (the fleet dev default). Pairs with the raw_args below,
+    # which re-declare the namespace + canonical HOME the overlay needs.
+    relaxed: true
+
+    # Persistent per-agent directory overlay: package installs, caches and
+    # $HOME state survive restarts while the base SIF stays immutable. sac
+    # auto-creates the overlay dir and materialises to_home/ into its upper
+    # home on first start.
+    overlay: ~/.scitex/agent-container/containers/overlays/{name}/
+
+    # Full host reach at the CANONICAL path (source ~ is expanded by sac;
+    # the destination must be absolute). Narrow this to specific project
+    # trees for a capsule-style agent.
+    binds:
+      - {home}:{home}:rw
+
+    # Per-agent env. SCITEX_TODO_AGENT_ID makes scitex-todo writes
+    # attribute to THIS agent. (sac AUTO-injects
+    # SCITEX_AGENT_CONTAINER_STATE_DB + binds the per-agent state dir, so
+    # the state DB needs no manual entry here.)
+    env:
+      SCITEX_TODO_AGENT_ID: {name}
+
+    # Relaxed mode skips sac's curated isolation prepend, so re-declare the
+    # user namespace, filesystem isolation, and the canonical container HOME
+    # that the overlay upper home is materialised under.
+    raw_args:
+      - --userns
+      - --containall
+      - --home=/home/agent
 
   claude:
-    model: sonnet
+    model: opus[1m]
     flags:
       - --dangerously-skip-permissions
     session: continue
     auto_accept: true
 
+    # Fleet push channels: sac control bus + shared scitex-todo store + the
+    # Telegram bridge (operator DMs wake the agent). server:sac is also
+    # auto-injected by the loader; listed here for visibility.
+    channels:
+      - server:sac
+      - server:scitex-todo
+      - server:claude-code-telegrammer
+
+    # Pin this agent to a dedicated account by uncommenting and pointing at
+    # that account's LIVE .credentials.json (else the shared host OAuth is
+    # forwarded automatically).
+    # credentials_file: ~/.scitex/agent-container/accounts/<ACCOUNT>/.credentials.json
+
+  # Editable-install the agent's own repo so imports resolve to the live
+  # working tree (edit -> test without reinstall). The `|| true` keeps
+  # startup resilient when the repo has no installable package yet.
+  startup_commands:
+    - command: 'uv pip install -e {home}/proj/{name} --quiet || true'
+
+  # Generic self-resume kick — the agent picks up its board / last state.
+  # Replace with the agent's real first mission.
   startup_prompts:
-    - |
-      You are {name}. Replace this prompt with your agent's actual
-      mission. Reply READY when initialized.
+    - Start or continue.
 
   health:
     enabled: true
@@ -398,7 +475,12 @@ def create(
         )
 
     template = _TEMPLATES[kind]
-    body = template.format(name=name)
+    # ``{home}`` is filled from the operator's home so the full template's
+    # whole-home bind + workdir are ABSOLUTE (apptainer bind targets can't
+    # be ``~``/``$VAR``) yet still operator-agnostic — mirrors sac's own
+    # "full host reach" hint (`- {home}:{home}:rw`). The minimal template
+    # has no ``{home}`` token; the surplus kwarg is harmless.
+    body = template.format(name=name, home=str(Path.home()))
 
     agent_dir.mkdir(parents=True, exist_ok=True)
     spec_path.write_text(body)

--- a/tests/scitex_agent_container/cli_pkg/test__create.py
+++ b/tests/scitex_agent_container/cli_pkg/test__create.py
@@ -61,6 +61,130 @@ def test_create_full_template_passes_v3_validator(tmp_path: Path) -> None:
     assert errors == []
 
 
+# ---------------------------------------------------------------------------
+# `full` template = the PROVEN developer shape (card
+# sac-agents-new-template-stale; operator 2026-06-25 "very general, just
+# developer like existing ones"). It must render a READY dev agent, not the
+# stale generic skeleton (runtime apptainer, model sonnet, binds [],
+# placeholder prompt, NO overlay / SCITEX_TODO_AGENT_ID / channels /
+# editable-install / dev labels). These tests pin every load-bearing field
+# the card flagged as missing — they FAIL against the old template.
+# ---------------------------------------------------------------------------
+
+
+def _render_full(tmp_path: Path, name: str = "proj-x") -> dict:
+    """Render the inline ``full`` template for ``name``; return the parsed doc."""
+    runner = CliRunner()
+    base = tmp_path / "agents"
+    runner.invoke(create_cmd, [name, "--base-dir", str(base), "--template", "full"])
+    return yaml.safe_load((base / name / "spec.yaml").read_text())
+
+
+def test_full_template_runtime_is_tui(tmp_path: Path) -> None:
+    # Arrange
+    doc = _render_full(tmp_path)
+    # Act
+    spec = doc["spec"]
+    # Assert — interactive TUI dev agent, not the stale generic apptainer shape.
+    assert spec["runtime"] == "tui"
+
+
+def test_full_template_is_relaxed(tmp_path: Path) -> None:
+    # Arrange
+    doc = _render_full(tmp_path)
+    # Act
+    relaxed = doc["spec"]["apptainer"]["relaxed"]
+    # Assert — relaxed isolation (dev agent shares the operator's host tree).
+    assert relaxed is True
+
+
+def test_full_template_declares_directory_overlay(tmp_path: Path) -> None:
+    # Arrange
+    doc = _render_full(tmp_path)
+    # Act
+    overlay = doc["spec"]["apptainer"]["overlay"]
+    # Assert — persistent per-agent overlay (MISSING on the stale template).
+    assert overlay.endswith("/overlays/proj-x/")
+
+
+def test_full_template_wires_scitex_todo_agent_id(tmp_path: Path) -> None:
+    # Arrange
+    doc = _render_full(tmp_path)
+    # Act
+    env = doc["spec"]["apptainer"]["env"]
+    # Assert — todo-store writes attribute to THIS agent (MISSING before).
+    assert env["SCITEX_TODO_AGENT_ID"] == "proj-x"
+
+
+def test_full_template_lists_the_three_fleet_channels(tmp_path: Path) -> None:
+    # Arrange
+    doc = _render_full(tmp_path)
+    # Act
+    channels = doc["spec"]["claude"]["channels"]
+    # Assert — sac + scitex-todo + telegrammer push channels (all MISSING before).
+    assert channels == [
+        "server:sac",
+        "server:scitex-todo",
+        "server:claude-code-telegrammer",
+    ]
+
+
+def test_full_template_editable_installs_the_repo(tmp_path: Path) -> None:
+    # Arrange
+    doc = _render_full(tmp_path)
+    # Act
+    cmds = " ".join(sc.get("command", "") for sc in doc["spec"]["startup_commands"])
+    # Assert — the dev loop editable-installs the agent's own repo (MISSING before).
+    assert "pip install -e" in cmds
+
+
+def test_full_template_kick_is_start_or_continue(tmp_path: Path) -> None:
+    # Arrange
+    doc = _render_full(tmp_path)
+    # Act
+    prompts = doc["spec"]["startup_prompts"]
+    # Assert — a real self-resume kick, not a "replace this / READY" placeholder.
+    assert prompts == ["Start or continue."]
+
+
+def test_full_template_has_developer_metadata_labels(tmp_path: Path) -> None:
+    # Arrange
+    doc = _render_full(tmp_path)
+    # Act
+    role = doc["metadata"]["labels"]["role"]
+    # Assert — developer role labels present (stale template was a bare 'worker').
+    assert role == "project-maintainer"
+
+
+def test_full_template_full_home_bind_at_canonical_path(tmp_path: Path) -> None:
+    # Arrange
+    doc = _render_full(tmp_path)
+    home = str(Path.home())
+    # Act
+    binds = doc["spec"]["apptainer"]["binds"]
+    # Assert — full host reach at the canonical path (was binds: [] on the stale one).
+    assert f"{home}:{home}:rw" in binds
+
+
+def test_full_template_model_is_opus(tmp_path: Path) -> None:
+    # Arrange
+    doc = _render_full(tmp_path)
+    # Act
+    model = doc["spec"]["claude"]["model"]
+    # Assert — opus (dev workhorse), not the stale 'sonnet'.
+    assert model.startswith("opus")
+
+
+def test_full_template_workdir_under_home_matches_agent(tmp_path: Path) -> None:
+    # Arrange
+    doc = _render_full(tmp_path)
+    home = str(Path.home())
+    # Act
+    workdir = doc["spec"]["workdir"]
+    # Assert — --pwd is the repo path, bound rw above (host==container).
+    assert workdir == f"{home}/proj/proj-x"
+
+
 def test_create_default_template_is_minimal(tmp_path: Path) -> None:
     # Arrange
     runner = CliRunner()


### PR DESCRIPTION
## What

Fixes card `sac-agents-new-template-stale` [P2]. `sac agents create --template full`
rendered a **generic skeleton**, not "a developer like existing ones", so the operator
had to hand-write specs (e.g. figrecipe) from the proven shape.

## What the `full` template was missing (vs the proven dev shape)

| field | stale `full` | proven dev shape (now) |
|---|---|---|
| runtime | `apptainer` | `tui` (interactive in-apptainer TUI) |
| isolation | `relaxed: false` | `relaxed: true` |
| overlay | (none) | persistent per-agent directory overlay |
| host reach | `binds: []` | full home at canonical path `- {home}:{home}:rw` |
| todo attribution | (none) | `apptainer.env: SCITEX_TODO_AGENT_ID: {name}` |
| push channels | (none) | `server:sac` + `server:scitex-todo` + `server:claude-code-telegrammer` |
| editable install | (none) | `startup_commands: uv pip install -e {home}/proj/{name}` |
| startup prompt | placeholder ("You are NAME... Reply READY") | `Start or continue.` |
| labels | bare `role: worker` | `role: project-maintainer` + project/purpose/... |
| model | `sonnet` | `opus[1m]` |

## How

- Rewrote `_FULL_TEMPLATE` in `cli_pkg/_create.py` to the proven, ready-to-run developer
  shape, parameterised by `{name}` (agent == project) and `{home}`.
- `{home}` is filled from the operator's home **at render time** (`Path.home()`) so the
  whole-home bind + `workdir` are absolute — apptainer bind targets can't be `~`/`$VAR` —
  yet stay operator-agnostic. Mirrors sac's own "full host reach" validation hint
  (`- {home}:{home}:rw`).
- Prefers first-class fields (`apptainer.overlay`, `apptainer.env`, `binds` — all expand
  `~` or take the value verbatim); `raw_args` only carries the relaxed namespace flags
  (`--userns --containall --home=/home/agent`).
- **Not hardcoded to one agent** — it is a reusable developer template keyed on `{name}`.

Kept general per the operator ask ("very general, just developer like existing ones").
`SCITEX_AGENT_CONTAINER_STATE_DB` is **auto-injected** by sac (`build_run_argv` binds the
per-agent state dir + sets the env), so the state DB needs no manual template entry.

## Tests

- Adds 11 field-presence tests (real fs via `tmp_path`, no mocks) pinning each flagged
  field — they fail against the old template.
- `validate_config` on the rendered spec == `[]` (clean); minimal template unaffected.
- `test__create.py`: **46/46 green**.
- `scitex-dev ecosystem audit-all scitex-agent-container`: no violations on the touched
  surface.

## Out of scope

The card's 2026-07-02 comment about `SAC_PLACEHOLDER_*` **over-replacement** is a separate
bug in the **dir-template** fill path (and the offending `_template_generalist` lives in
the operator's agents root, outside this repo), not the inline `full` template fixed here.
