### PR TITLE
fix(listen): cancel in-flight SSE streams on SIGTERM so graceful shutdown doesn't hang

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_listen_lifespan.py
+++ b/src/scitex_agent_container/_lifecycle/_listen_lifespan.py
@@ -200,9 +200,50 @@ def build_listen_lifespan(*, health_watchdog_port: int | None = None):
             app.state.bind_watchdog_task = wd_task
             tasks.append(wd_task)
 
+        # SIGTERM shutdown bridge (card sac-listen-sigterm-sse-shutdown-hang).
+        # The SSE inbox-stream handlers park on ``queue.get()``; uvicorn's
+        # graceful shutdown WAITS for those in-flight responses before it
+        # even runs this lifespan's teardown, so a SIGTERM hangs the daemon
+        # until ``sac listen restart --force`` SIGKILLs at 10 s. Uvicorn
+        # sets ``server.should_exit`` SYNCHRONOUSLY in its signal handler,
+        # well before that wait — so this task polls that flag and closes
+        # the inbox broker the instant it flips. Closing the broker fires
+        # the shutdown Event the SSE loops race ``queue.get()`` against, so
+        # every in-flight stream returns at once, the connections drain,
+        # and the daemon exits cleanly in well under the restart grace.
+        #
+        # The server handle is stashed on ``app.state.uvicorn_server`` by
+        # the boot path (:func:`cli_pkg.listen_cmds._do_start_listen`). When
+        # absent (in-process ASGI runs / tests with no uvicorn Server) the
+        # bridge is skipped — the teardown ``finally`` below still closes
+        # the broker so those runs free their SSE subscribers cleanly.
+        _srv = getattr(app.state, "uvicorn_server", None)
+        _broker = getattr(app.state, "inbox", None)
+        if _srv is not None and _broker is not None:
+
+            async def _shutdown_bridge(srv=_srv, broker=_broker):  # type: ignore[no-untyped-def]
+                try:
+                    while not getattr(srv, "should_exit", False):
+                        await asyncio.sleep(0.1)
+                finally:
+                    # Close on the normal path AND on cancellation (the
+                    # teardown cancels this task) so the broker is always
+                    # signalled exactly once — ``close`` is idempotent.
+                    broker.close()
+
+            bridge_task = asyncio.create_task(_shutdown_bridge())
+            app.state.shutdown_bridge_task = bridge_task
+            tasks.append(bridge_task)
+
         try:
             yield
         finally:
+            # Signal the SSE inbox-stream loops to stop FIRST (idempotent),
+            # so an in-process lifespan shutdown with no uvicorn bridge
+            # still frees any parked subscriber before we cancel the loops.
+            _broker_td = getattr(app.state, "inbox", None)
+            if _broker_td is not None:
+                _broker_td.close()
             for _t in tasks:
                 if _t is not None and not _t.done():
                     _t.cancel()

--- a/src/scitex_agent_container/_listen/_node_channel.py
+++ b/src/scitex_agent_container/_listen/_node_channel.py
@@ -417,7 +417,16 @@ async def node_inbox_stream(request: Request) -> Response:
             while True:
                 if await request.is_disconnected():
                     return
-                event = await queue.get()
+                # ``get_or_close`` races ``queue.get()`` against the
+                # broker's shutdown Event so a graceful ``sac listen``
+                # SIGTERM cancels this in-flight stream promptly instead
+                # of parking here until restart --force SIGKILLs at 10 s
+                # (card sac-listen-sigterm-sse-shutdown-hang). ``None``
+                # means "broker closing" — return so the StreamingResponse
+                # completes and the daemon exits cleanly.
+                event = await broker.get_or_close(queue)
+                if event is None:
+                    return
                 # The publish path stamps the persisted row id onto
                 # the envelope as ``_row_id`` (see
                 # :func:`node_message_send`). We surface it as the SSE

--- a/src/scitex_agent_container/a2a/_inbox_bus.py
+++ b/src/scitex_agent_container/a2a/_inbox_bus.py
@@ -67,6 +67,83 @@ class Broker:
     def __init__(self) -> None:
         self._subs: dict[str, set[asyncio.Queue[dict[str, Any]]]] = defaultdict(set)
         self._lock = asyncio.Lock()
+        # Set on graceful shutdown so the SSE inbox-stream loops stop
+        # parking on ``queue.get()`` and return promptly (card
+        # ``sac-listen-sigterm-sse-shutdown-hang``). ``asyncio.Event``
+        # binds its loop lazily on first ``wait()``, so constructing it
+        # here (outside any running loop, mirroring ``self._lock``) is
+        # safe.
+        self._closing = asyncio.Event()
+
+    def closing_event(self) -> asyncio.Event:
+        """Return the shutdown Event the SSE loops race ``get()`` against."""
+        return self._closing
+
+    def is_closing(self) -> bool:
+        """True once :meth:`close` has fired (graceful shutdown started)."""
+        return self._closing.is_set()
+
+    def close(self) -> None:
+        """Signal every SSE subscriber loop to stop promptly.
+
+        Idempotent. Sets the shutdown Event the inbox-stream loops race
+        their ``queue.get()`` against (see :meth:`get_or_close`), so a
+        graceful ``sac listen`` shutdown (SIGTERM) cancels in-flight SSE
+        connections at once instead of leaving them parked on
+        ``queue.get()`` until uvicorn force-cancels / ``restart --force``
+        escalates to SIGKILL after 10 s.
+        """
+        self._closing.set()
+
+    async def get_or_close(
+        self, q: asyncio.Queue[dict[str, Any]]
+    ) -> dict[str, Any] | None:
+        """Await the next event on ``q``, or ``None`` when the broker is
+        closing.
+
+        The SSE inbox-stream handlers loop on this instead of a bare
+        ``await q.get()``. A bare ``get()`` parks forever when no event
+        is flowing, so uvicorn's graceful shutdown (SIGTERM) waits on the
+        in-flight stream until it force-cancels / ``sac listen restart
+        --force`` escalates to SIGKILL after 10 s (card
+        ``sac-listen-sigterm-sse-shutdown-hang``). Racing ``get()``
+        against the shutdown Event lets the loop return the instant
+        :meth:`close` fires, so the daemon exits cleanly.
+
+        A live event still in flight when close fires is delivered (not
+        dropped) so a normal event landing on the same tick is not lost
+        to the shutdown race.
+        """
+        if self._closing.is_set():
+            return None
+        get_task = asyncio.ensure_future(q.get())
+        close_task = asyncio.ensure_future(self._closing.wait())
+        try:
+            await asyncio.wait(
+                {get_task, close_task}, return_when=asyncio.FIRST_COMPLETED
+            )
+        except asyncio.CancelledError:
+            # The whole stream is being cancelled (client gone, or
+            # uvicorn's timeout-graceful-shutdown force path). Clean up
+            # both child futures before re-raising so neither is left
+            # pending.
+            get_task.cancel()
+            close_task.cancel()
+            raise
+        # Prefer a delivered event even if close fired on the same tick —
+        # an event already pulled off the queue must not be dropped.
+        if (
+            get_task.done()
+            and not get_task.cancelled()
+            and get_task.exception() is None
+        ):
+            close_task.cancel()
+            return get_task.result()
+        # Closing won (or the queue errored) — abandon the pending get and
+        # signal the loop to stop.
+        get_task.cancel()
+        close_task.cancel()
+        return None
 
     async def subscribe(self, agent: str) -> asyncio.Queue[dict[str, Any]]:
         q: asyncio.Queue[dict[str, Any]] = asyncio.Queue(maxsize=_QUEUE_CAP)

--- a/src/scitex_agent_container/cli_pkg/_listen_registry_hooks.py
+++ b/src/scitex_agent_container/cli_pkg/_listen_registry_hooks.py
@@ -1,0 +1,163 @@
+"""ADR-0014 comms_nodes registry hooks for ``sac listen`` boot.
+
+Extracted from :mod:`scitex_agent_container.cli_pkg.listen_cmds` (which
+grew past the per-file line cap). These are the two best-effort registry
+side-effects the daemon-start path runs — neither may ever block or abort
+the bind (a listen that won't bind because of a registry write is worse
+than a missing federated row):
+
+* :func:`_register_self_comms_node` — writes this host's operator-identity
+  row into ``comms_nodes`` so cross-host peers can resolve it.
+* :func:`_maybe_sync_on_start` — the retained-for-legacy synchronous
+  startup sync (NO LONGER on the boot path; the live sync now runs off the
+  event loop as a lifespan task — see
+  :func:`scitex_agent_container._listen._startup_peer_sync.sync_peers_on_listen_startup`).
+
+``listen_cmds`` re-imports both names so the historical import path
+``from scitex_agent_container.cli_pkg.listen_cmds import
+_register_self_comms_node`` keeps working unchanged. Pure extraction —
+no behaviour change.
+"""
+
+from __future__ import annotations
+
+import click
+
+__all__ = ["_register_self_comms_node", "_maybe_sync_on_start"]
+
+
+def _register_self_comms_node(*, port: int) -> None:
+    """ADR-0014 — register this listen's operator identity in comms_nodes.
+
+    Best-effort: any failure (no config, no LeadConfig, DB error, name
+    collision) is logged to stderr but does NOT prevent ``sac listen``
+    from binding. A listen that won't start because of a registry-write
+    error is worse than a missing federated row — peers can still
+    cross-host-forward to the listen via the existing ``instances``
+    table for sac-managed agents; only the operator-identity row needs
+    the federated graph.
+
+    Identity source: ``LeadConfig.name`` (e.g. ``lead`` on the lead
+    host). Hosts without a ``lead:`` block emit a LOUD WARNING and
+    skip — those listens serve only sac-managed agents, which
+    register themselves via ``record_instance_start``; operators that
+    EXPECT a lead row (cross-host A2A targeting ``lead``) need to
+    know the listen isn't writing it. The old silent return was the
+    exact bug PR2 (#308) repaired via ``sac registry register``: a
+    missing lead block meant ``resolve_node_host('lead')`` returned
+    ``None`` fleet-wide with no log line pointing at why. The warning
+    + the new repair verb together close the regression door.
+    """
+    try:
+        from .._state.host_config import load
+        from .._state.state_db_nodes import (
+            CommsNodeConflictError,
+            register_comms_node,
+        )
+
+        cfg = load()
+        lead = cfg.lead
+        if lead is None:
+            # Loud-but-non-fatal: the listen MUST still bind (a failed
+            # bind is worse than a missing federated row), but the
+            # operator needs a paper trail when cross-host 'lead'
+            # resolution starts failing. The repair path is documented
+            # inline so the operator can act without spelunking ADR-0014.
+            click.echo(
+                "# WARN: comms_nodes self-register skipped — host_config "
+                "has no `lead:` block, so this listen will NOT advertise "
+                "an operator-identity row. Other hosts' "
+                "`resolve_node_host('lead')` will return None until a row "
+                "exists. Add a `lead:` block to host_config (preferred) "
+                "OR run `sac registry register --name lead --host <h> "
+                "--a2a-port <p>` for an immediate no-restart repair.",
+                err=True,
+            )
+            return
+        local_host = cfg.canonical_host()
+        try:
+            register_comms_node(
+                name=lead.name,
+                host=local_host,
+                a2a_port=port,
+                source_host=None,  # locally-registered
+            )
+        except CommsNodeConflictError as exc:
+            click.echo(
+                f"# WARN: comms_nodes self-register conflict: {exc}",
+                err=True,
+            )
+    except (
+        Exception
+    ) as exc:  # stx-allow: fallback (reason: never block listen on registry write)
+        click.echo(
+            f"# WARN: comms_nodes self-register failed: {exc!r}",
+            err=True,
+        )
+
+
+def _maybe_sync_on_start() -> None:
+    """ADR-0014 — optionally trigger ``sac registry sync --all`` once.
+
+    Opt-out via the ``comms_nodes.sync_on_start: false`` config flag
+    (default True). Best-effort: per-peer failures are logged by the
+    sync command itself; we never raise.
+
+    NOT on the boot path anymore. This synchronous helper used to run
+    BEFORE ``uvicorn.run`` so the listen had the latest peer view before
+    answering inbound A2A POSTs — but an unreachable static peer made its
+    ssh call hang and blocked the bind, with no error logged (INCIDENT
+    2026-06-26). The startup sync now runs best-effort AFTER the bind, off
+    the event loop, as a lifespan task
+    (:func:`_listen._startup_peer_sync.sync_peers_on_listen_startup`). This
+    helper is retained for explicit/legacy callers only and is bounded by
+    an overall budget so even a direct call can never wedge — but
+    ``_do_start_listen`` no longer invokes it.
+    """
+    try:
+        from .._state.host_config import load
+
+        cfg = load()
+        # The config flag is read by hand because LeadConfig is the
+        # only structured block sac currently parses. Look in the raw
+        # config dict if present; default True.
+        raw_path = cfg.source_path
+        sync_on_start = True
+        if raw_path is not None and raw_path.is_file():
+            import yaml
+
+            raw = yaml.safe_load(raw_path.read_text()) or {}
+            comms_nodes_cfg = raw.get("comms_nodes")
+            if isinstance(comms_nodes_cfg, dict):
+                flag = comms_nodes_cfg.get("sync_on_start", True)
+                if isinstance(flag, bool):
+                    sync_on_start = flag
+        if not sync_on_start:
+            return
+        # Only run when there is at least one static peer; skip silently
+        # otherwise so single-host installs don't spam warnings.
+        static_peers = [n for n in cfg.peers.keys() if not any(c in n for c in "*?[")]
+        if not static_peers:
+            return
+        from ._registry_sync import registry_sync_impl
+
+        rc = registry_sync_impl(
+            from_peer=None,
+            to_peer=None,
+            all_peers=True,
+            dry_run=False,
+            as_json=False,
+            # Bound even this legacy/direct path so a re-introduced
+            # pre-bind call can never wedge (defense in depth).
+            overall_budget_s=60.0,
+        )
+        if rc != 0:
+            click.echo(
+                f"# WARN: comms_nodes startup sync had peer failures (rc={rc})",
+                err=True,
+            )
+    except Exception as exc:  # stx-allow: fallback (reason: never block listen on sync)
+        click.echo(
+            f"# WARN: comms_nodes startup sync failed: {exc!r}",
+            err=True,
+        )

--- a/src/scitex_agent_container/cli_pkg/listen_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/listen_cmds.py
@@ -40,141 +40,16 @@ def _is_loopback(host: str) -> bool:
         return False
 
 
-def _register_self_comms_node(*, port: int) -> None:
-    """ADR-0014 — register this listen's operator identity in comms_nodes.
-
-    Best-effort: any failure (no config, no LeadConfig, DB error, name
-    collision) is logged to stderr but does NOT prevent ``sac listen``
-    from binding. A listen that won't start because of a registry-write
-    error is worse than a missing federated row — peers can still
-    cross-host-forward to the listen via the existing ``instances``
-    table for sac-managed agents; only the operator-identity row needs
-    the federated graph.
-
-    Identity source: ``LeadConfig.name`` (e.g. ``lead`` on the lead
-    host). Hosts without a ``lead:`` block emit a LOUD WARNING and
-    skip — those listens serve only sac-managed agents, which
-    register themselves via ``record_instance_start``; operators that
-    EXPECT a lead row (cross-host A2A targeting ``lead``) need to
-    know the listen isn't writing it. The old silent return was the
-    exact bug PR2 (#308) repaired via ``sac registry register``: a
-    missing lead block meant ``resolve_node_host('lead')`` returned
-    ``None`` fleet-wide with no log line pointing at why. The warning
-    + the new repair verb together close the regression door.
-    """
-    try:
-        from .._state.host_config import load
-        from .._state.state_db_nodes import (
-            CommsNodeConflictError,
-            register_comms_node,
-        )
-
-        cfg = load()
-        lead = cfg.lead
-        if lead is None:
-            # Loud-but-non-fatal: the listen MUST still bind (a failed
-            # bind is worse than a missing federated row), but the
-            # operator needs a paper trail when cross-host 'lead'
-            # resolution starts failing. The repair path is documented
-            # inline so the operator can act without spelunking ADR-0014.
-            click.echo(
-                "# WARN: comms_nodes self-register skipped — host_config "
-                "has no `lead:` block, so this listen will NOT advertise "
-                "an operator-identity row. Other hosts' "
-                "`resolve_node_host('lead')` will return None until a row "
-                "exists. Add a `lead:` block to host_config (preferred) "
-                "OR run `sac registry register --name lead --host <h> "
-                "--a2a-port <p>` for an immediate no-restart repair.",
-                err=True,
-            )
-            return
-        local_host = cfg.canonical_host()
-        try:
-            register_comms_node(
-                name=lead.name,
-                host=local_host,
-                a2a_port=port,
-                source_host=None,  # locally-registered
-            )
-        except CommsNodeConflictError as exc:
-            click.echo(
-                f"# WARN: comms_nodes self-register conflict: {exc}",
-                err=True,
-            )
-    except (
-        Exception
-    ) as exc:  # stx-allow: fallback (reason: never block listen on registry write)
-        click.echo(
-            f"# WARN: comms_nodes self-register failed: {exc!r}",
-            err=True,
-        )
-
-
-def _maybe_sync_on_start() -> None:
-    """ADR-0014 — optionally trigger ``sac registry sync --all`` once.
-
-    Opt-out via the ``comms_nodes.sync_on_start: false`` config flag
-    (default True). Best-effort: per-peer failures are logged by the
-    sync command itself; we never raise.
-
-    NOT on the boot path anymore. This synchronous helper used to run
-    BEFORE ``uvicorn.run`` so the listen had the latest peer view before
-    answering inbound A2A POSTs — but an unreachable static peer made its
-    ssh call hang and blocked the bind, with no error logged (INCIDENT
-    2026-06-26). The startup sync now runs best-effort AFTER the bind, off
-    the event loop, as a lifespan task
-    (:func:`_listen._startup_peer_sync.sync_peers_on_listen_startup`). This
-    helper is retained for explicit/legacy callers only and is bounded by
-    an overall budget so even a direct call can never wedge — but
-    ``_do_start_listen`` no longer invokes it.
-    """
-    try:
-        from .._state.host_config import load
-
-        cfg = load()
-        # The config flag is read by hand because LeadConfig is the
-        # only structured block sac currently parses. Look in the raw
-        # config dict if present; default True.
-        raw_path = cfg.source_path
-        sync_on_start = True
-        if raw_path is not None and raw_path.is_file():
-            import yaml
-
-            raw = yaml.safe_load(raw_path.read_text()) or {}
-            comms_nodes_cfg = raw.get("comms_nodes")
-            if isinstance(comms_nodes_cfg, dict):
-                flag = comms_nodes_cfg.get("sync_on_start", True)
-                if isinstance(flag, bool):
-                    sync_on_start = flag
-        if not sync_on_start:
-            return
-        # Only run when there is at least one static peer; skip silently
-        # otherwise so single-host installs don't spam warnings.
-        static_peers = [n for n in cfg.peers.keys() if not any(c in n for c in "*?[")]
-        if not static_peers:
-            return
-        from ._registry_sync import registry_sync_impl
-
-        rc = registry_sync_impl(
-            from_peer=None,
-            to_peer=None,
-            all_peers=True,
-            dry_run=False,
-            as_json=False,
-            # Bound even this legacy/direct path so a re-introduced
-            # pre-bind call can never wedge (defense in depth).
-            overall_budget_s=60.0,
-        )
-        if rc != 0:
-            click.echo(
-                f"# WARN: comms_nodes startup sync had peer failures (rc={rc})",
-                err=True,
-            )
-    except Exception as exc:  # stx-allow: fallback (reason: never block listen on sync)
-        click.echo(
-            f"# WARN: comms_nodes startup sync failed: {exc!r}",
-            err=True,
-        )
+# ADR-0014 comms_nodes registry hooks — extracted to a sibling module to
+# keep this file under the per-file line cap. Re-exported here so the
+# historical import path
+# ``from scitex_agent_container.cli_pkg.listen_cmds import
+# _register_self_comms_node`` (used by tests + the boot path below)
+# keeps working unchanged.
+from ._listen_registry_hooks import (  # noqa: E402
+    _maybe_sync_on_start,  # noqa: F401  (re-exported for tests / legacy callers)
+    _register_self_comms_node,
+)
 
 
 @click.group(name="listen", invoke_without_command=True)
@@ -340,15 +215,46 @@ def _do_start_listen(
     # comes up but never serves (the silent fleet-comms outage this
     # guards against).
     app = create_app(token=token, health_watchdog_port=port)
+    import os
+
     import uvicorn
+
+    # Bounded graceful-shutdown timeout. uvicorn's default is ``None`` →
+    # on SIGTERM it waits FOREVER for in-flight requests to finish, and a
+    # long-lived SSE inbox stream parked on ``queue.get()`` never does,
+    # so the daemon hangs until ``sac listen restart --force`` escalates
+    # to SIGKILL after 10 s (card sac-listen-sigterm-sse-shutdown-hang).
+    # A bounded timeout guarantees uvicorn force-cancels a stuck stream
+    # well within that grace; the lifespan's shutdown bridge (which
+    # closes the inbox broker the instant ``should_exit`` flips) makes
+    # the common case exit promptly, long before this floor is reached.
+    # Override via SAC_LISTEN_SHUTDOWN_GRACE_S.
+    try:
+        _grace_shutdown = float(os.environ.get("SAC_LISTEN_SHUTDOWN_GRACE_S", "5"))
+    except (TypeError, ValueError):
+        _grace_shutdown = 5.0
 
     # ``ws="none"`` skips uvicorn's websockets backend autodetection —
     # we don't serve WS endpoints, and the WS protocol module imports
     # websockets.legacy which has churned across the websockets package
     # major versions (broken in >=14). Disabling it avoids a startup
     # crash that silently kills a detached ``sac listen``.
+    config = uvicorn.Config(
+        app,
+        host=host,
+        port=port,
+        log_level="info",
+        ws="none",
+        timeout_graceful_shutdown=_grace_shutdown,
+    )
+    server = uvicorn.Server(config)
+    # The lifespan's shutdown bridge reads this to detect uvicorn's
+    # ``should_exit`` (set synchronously by its SIGTERM handler) and
+    # close the inbox broker promptly, so in-flight SSE streams return
+    # at once instead of blocking the graceful shutdown.
+    app.state.uvicorn_server = server
     try:
-        uvicorn.run(app, host=host, port=port, log_level="info", ws="none")
+        server.run()
     finally:
         # Best-effort release on clean exit; kernel handles dirty
         # exit (SIGKILL / crash / OOM) by closing fds and releasing

--- a/tests/integration/test_listen_sigterm_sse_shutdown.py
+++ b/tests/integration/test_listen_sigterm_sse_shutdown.py
@@ -1,17 +1,20 @@
-"""Graceful-shutdown coverage for the ``sac listen`` SSE inbox stream.
+"""End-to-end: ``sac listen`` graceful shutdown does not hang on an
+in-flight SSE inbox stream (card ``sac-listen-sigterm-sse-shutdown-hang``).
 
-Card ``sac-listen-sigterm-sse-shutdown-hang``: the per-agent SSE
-inbox-stream handler parks on ``asyncio.Queue.get()`` with no shutdown
-signal, so a SIGTERM graceful shutdown of ``sac listen`` waits on the
-in-flight stream until ``sac listen restart --force`` escalates to
-SIGKILL after 10 s. The fix races ``queue.get()`` against a broker-level
-shutdown Event (:meth:`Broker.get_or_close` / :meth:`Broker.close`) and
-wires a lifespan shutdown-bridge that closes the broker the instant
-uvicorn's ``should_exit`` flips, so in-flight streams cancel promptly.
+Lives under ``tests/integration/`` (real uvicorn server on loopback +
+real ``httpx`` SSE client, no subprocess) rather than the PS-204 mirror
+tree — it exercises the *interaction* of ``_listen/_node_channel`` (the
+SSE handler), ``a2a/_inbox_bus`` (the broker close path), and
+``_lifecycle/_listen_lifespan`` (the shutdown bridge), not one src module.
 
-All real primitives — a real :class:`Broker`, a real ``asyncio.Queue``,
-and (for the end-to-end case) a real uvicorn server driven over loopback
-TCP with a real ``httpx`` SSE client. No mocks (PA-306).
+Root cause it guards against: the SSE handler used to park on
+``await queue.get()`` with no shutdown signal, so uvicorn's graceful
+shutdown (which waits for in-flight requests) hung until
+``sac listen restart --force`` escalated to SIGKILL after 10 s. The fix
+races ``queue.get()`` against a broker shutdown Event and closes the
+broker the instant uvicorn's ``should_exit`` flips.
+
+All real primitives — no mocks (PA-306).
 """
 
 from __future__ import annotations
@@ -31,142 +34,8 @@ import uvicorn
 from scitex_agent_container._listen.server import create_app
 from scitex_agent_container._runners import _session_state as _ss
 from scitex_agent_container._state import registry as _reg
-from scitex_agent_container.a2a._inbox_bus import Broker
 
 TOKEN = "test-token-shutdown-sse"
-
-
-# --- Broker-level unit tests (pure asyncio, no server) ----------------------
-
-
-async def _park_then_probe_done() -> bool:
-    """Park a ``get_or_close`` on an idle+open broker; report whether it
-    completed (it must not)."""
-    broker = Broker()
-    q = await broker.subscribe("alice")
-    waiter = asyncio.ensure_future(broker.get_or_close(q))
-    await asyncio.sleep(0.15)
-    done = waiter.done()
-    waiter.cancel()
-    with contextlib.suppress(BaseException):
-        await waiter
-    return done
-
-
-async def _close_then_collect_result() -> object:
-    """Park a ``get_or_close``, then ``close()`` the broker and return
-    whatever the parked call resolves to."""
-    broker = Broker()
-    q = await broker.subscribe("alice")
-    waiter = asyncio.ensure_future(broker.get_or_close(q))
-    await asyncio.sleep(0.1)
-    broker.close()
-    return await asyncio.wait_for(waiter, timeout=1.0)
-
-
-async def _close_then_measure_unblock_seconds() -> float:
-    """Park a ``get_or_close``, ``close()``, and return the seconds it
-    took to unblock."""
-    broker = Broker()
-    q = await broker.subscribe("alice")
-    waiter = asyncio.ensure_future(broker.get_or_close(q))
-    await asyncio.sleep(0.1)
-    t0 = time.monotonic()
-    broker.close()
-    await asyncio.wait_for(waiter, timeout=1.0)
-    return time.monotonic() - t0
-
-
-async def _deliver_pending_event() -> object:
-    """A queued event must be returned by ``get_or_close`` (not dropped)."""
-    broker = Broker()
-    q = await broker.subscribe("alice")
-    await q.put({"msg_id": "m1", "content": "hi"})
-    return await asyncio.wait_for(broker.get_or_close(q), timeout=1.0)
-
-
-async def _result_when_already_closed() -> object:
-    """``get_or_close`` on an already-closed broker resolves at once."""
-    broker = Broker()
-    q = await broker.subscribe("alice")
-    broker.close()
-    return await asyncio.wait_for(broker.get_or_close(q), timeout=1.0)
-
-
-def test_get_or_close_blocks_while_idle_and_open() -> None:
-    # Arrange
-    scenario = _park_then_probe_done()
-    # Act
-    completed = asyncio.run(scenario)
-    # Assert
-    assert completed is False
-
-
-def test_get_or_close_returns_none_when_broker_closes() -> None:
-    # Arrange
-    scenario = _close_then_collect_result()
-    # Act
-    result = asyncio.run(scenario)
-    # Assert
-    assert result is None
-
-
-def test_get_or_close_unblocks_within_bounded_time_on_close() -> None:
-    # Arrange
-    scenario = _close_then_measure_unblock_seconds()
-    # Act
-    elapsed = asyncio.run(scenario)
-    # Assert
-    assert elapsed < 0.5
-
-
-def test_get_or_close_delivers_a_pending_event() -> None:
-    # Arrange
-    scenario = _deliver_pending_event()
-    # Act
-    event = asyncio.run(scenario)
-    # Assert
-    assert event == {"msg_id": "m1", "content": "hi"}
-
-
-def test_get_or_close_returns_none_immediately_if_already_closed() -> None:
-    # Arrange
-    scenario = _result_when_already_closed()
-    # Act
-    result = asyncio.run(scenario)
-    # Assert
-    assert result is None
-
-
-def test_broker_is_not_closing_before_close() -> None:
-    # Arrange
-    broker = Broker()
-    # Act
-    closing = broker.is_closing()
-    # Assert
-    assert closing is False
-
-
-def test_close_sets_is_closing_true() -> None:
-    # Arrange
-    broker = Broker()
-    # Act
-    broker.close()
-    # Assert
-    assert broker.is_closing() is True
-
-
-def test_close_is_idempotent() -> None:
-    # Arrange
-    broker = Broker()
-    # Act
-    broker.close()
-    broker.close()
-    # Assert
-    assert broker.is_closing() is True
-
-
-# --- End-to-end: real uvicorn daemon shutdown does not hang on SSE ----------
 
 
 @pytest.fixture

--- a/tests/scitex_agent_container/_listen/test_listen_shutdown_sse.py
+++ b/tests/scitex_agent_container/_listen/test_listen_shutdown_sse.py
@@ -1,0 +1,328 @@
+"""Graceful-shutdown coverage for the ``sac listen`` SSE inbox stream.
+
+Card ``sac-listen-sigterm-sse-shutdown-hang``: the per-agent SSE
+inbox-stream handler parks on ``asyncio.Queue.get()`` with no shutdown
+signal, so a SIGTERM graceful shutdown of ``sac listen`` waits on the
+in-flight stream until ``sac listen restart --force`` escalates to
+SIGKILL after 10 s. The fix races ``queue.get()`` against a broker-level
+shutdown Event (:meth:`Broker.get_or_close` / :meth:`Broker.close`) and
+wires a lifespan shutdown-bridge that closes the broker the instant
+uvicorn's ``should_exit`` flips, so in-flight streams cancel promptly.
+
+All real primitives — a real :class:`Broker`, a real ``asyncio.Queue``,
+and (for the end-to-end case) a real uvicorn server driven over loopback
+TCP with a real ``httpx`` SSE client. No mocks (PA-306).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+import socket
+import threading
+import time
+from pathlib import Path
+
+import httpx
+import pytest
+import uvicorn
+
+from scitex_agent_container._listen.server import create_app
+from scitex_agent_container._runners import _session_state as _ss
+from scitex_agent_container._state import registry as _reg
+from scitex_agent_container.a2a._inbox_bus import Broker
+
+TOKEN = "test-token-shutdown-sse"
+
+
+# --- Broker-level unit tests (pure asyncio, no server) ----------------------
+
+
+async def _park_then_probe_done() -> bool:
+    """Park a ``get_or_close`` on an idle+open broker; report whether it
+    completed (it must not)."""
+    broker = Broker()
+    q = await broker.subscribe("alice")
+    waiter = asyncio.ensure_future(broker.get_or_close(q))
+    await asyncio.sleep(0.15)
+    done = waiter.done()
+    waiter.cancel()
+    with contextlib.suppress(BaseException):
+        await waiter
+    return done
+
+
+async def _close_then_collect_result() -> object:
+    """Park a ``get_or_close``, then ``close()`` the broker and return
+    whatever the parked call resolves to."""
+    broker = Broker()
+    q = await broker.subscribe("alice")
+    waiter = asyncio.ensure_future(broker.get_or_close(q))
+    await asyncio.sleep(0.1)
+    broker.close()
+    return await asyncio.wait_for(waiter, timeout=1.0)
+
+
+async def _close_then_measure_unblock_seconds() -> float:
+    """Park a ``get_or_close``, ``close()``, and return the seconds it
+    took to unblock."""
+    broker = Broker()
+    q = await broker.subscribe("alice")
+    waiter = asyncio.ensure_future(broker.get_or_close(q))
+    await asyncio.sleep(0.1)
+    t0 = time.monotonic()
+    broker.close()
+    await asyncio.wait_for(waiter, timeout=1.0)
+    return time.monotonic() - t0
+
+
+async def _deliver_pending_event() -> object:
+    """A queued event must be returned by ``get_or_close`` (not dropped)."""
+    broker = Broker()
+    q = await broker.subscribe("alice")
+    await q.put({"msg_id": "m1", "content": "hi"})
+    return await asyncio.wait_for(broker.get_or_close(q), timeout=1.0)
+
+
+async def _result_when_already_closed() -> object:
+    """``get_or_close`` on an already-closed broker resolves at once."""
+    broker = Broker()
+    q = await broker.subscribe("alice")
+    broker.close()
+    return await asyncio.wait_for(broker.get_or_close(q), timeout=1.0)
+
+
+def test_get_or_close_blocks_while_idle_and_open() -> None:
+    # Arrange
+    scenario = _park_then_probe_done()
+    # Act
+    completed = asyncio.run(scenario)
+    # Assert
+    assert completed is False
+
+
+def test_get_or_close_returns_none_when_broker_closes() -> None:
+    # Arrange
+    scenario = _close_then_collect_result()
+    # Act
+    result = asyncio.run(scenario)
+    # Assert
+    assert result is None
+
+
+def test_get_or_close_unblocks_within_bounded_time_on_close() -> None:
+    # Arrange
+    scenario = _close_then_measure_unblock_seconds()
+    # Act
+    elapsed = asyncio.run(scenario)
+    # Assert
+    assert elapsed < 0.5
+
+
+def test_get_or_close_delivers_a_pending_event() -> None:
+    # Arrange
+    scenario = _deliver_pending_event()
+    # Act
+    event = asyncio.run(scenario)
+    # Assert
+    assert event == {"msg_id": "m1", "content": "hi"}
+
+
+def test_get_or_close_returns_none_immediately_if_already_closed() -> None:
+    # Arrange
+    scenario = _result_when_already_closed()
+    # Act
+    result = asyncio.run(scenario)
+    # Assert
+    assert result is None
+
+
+def test_broker_is_not_closing_before_close() -> None:
+    # Arrange
+    broker = Broker()
+    # Act
+    closing = broker.is_closing()
+    # Assert
+    assert closing is False
+
+
+def test_close_sets_is_closing_true() -> None:
+    # Arrange
+    broker = Broker()
+    # Act
+    broker.close()
+    # Assert
+    assert broker.is_closing() is True
+
+
+def test_close_is_idempotent() -> None:
+    # Arrange
+    broker = Broker()
+    # Act
+    broker.close()
+    broker.close()
+    # Assert
+    assert broker.is_closing() is True
+
+
+# --- End-to-end: real uvicorn daemon shutdown does not hang on SSE ----------
+
+
+@pytest.fixture
+def shutdown_env(tmp_path: Path):
+    """Isolate on-disk roots to ``tmp_path`` and disable the noisy
+    background loops so the lifespan launches essentially just the
+    shutdown bridge — keeping the shutdown-timing assertion deterministic.
+    """
+    saved: dict[str, str | None] = {}
+    env = {
+        "HOME": str(tmp_path),
+        "SCITEX_AGENT_CONTAINER_REGISTRY_DIR": str(tmp_path / "registry"),
+        "SCITEX_AGENT_CONTAINER_RUNTIME_DIR": str(tmp_path / "runtime"),
+        "SCITEX_AGENT_CONTAINER_STATE_DB": str(tmp_path / "state.db"),
+        # Quiet the lifespan's optional background loops for a clean,
+        # fast shutdown-timing measurement (the SSE stream + bridge are
+        # what this test exercises).
+        "SAC_PERIODIC_DRIVE_DISABLED": "1",
+        "SAC_GITHUB_CI_POLLER_DISABLED": "1",
+        "SAC_TUI_HEARTBEAT_DISABLED": "1",
+        "SAC_SDK_HEARTBEAT_DISABLED": "1",
+        "SAC_LIVENESS_TICK_DISABLED": "1",
+        "SAC_LISTEN_STARTUP_SYNC_DISABLED": "1",
+        "SAC_LISTEN_BIND_WATCHDOG_DISABLED": "1",
+    }
+    for key, val in env.items():
+        saved[key] = os.environ.get(key)
+        os.environ[key] = val
+    saved_reg_const = _reg.REGISTRY_DIR
+    saved_state_const = _ss.DEFAULT_STATE_ROOT
+    _reg.REGISTRY_DIR = tmp_path / "registry"
+    _ss.DEFAULT_STATE_ROOT = tmp_path / "runtime"
+    try:
+        yield tmp_path
+    finally:
+        _reg.REGISTRY_DIR = saved_reg_const
+        _ss.DEFAULT_STATE_ROOT = saved_state_const
+        for key, val in saved.items():
+            if val is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = val
+
+
+def _free_port() -> int:
+    with contextlib.closing(socket.socket()) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+async def _measure_inflight_sse_shutdown_seconds(
+    *, server: uvicorn.Server, thread: threading.Thread, port: int
+) -> float:
+    """Open a real SSE inbox stream, park it, flip ``should_exit`` (what
+    uvicorn's SIGTERM handler does), and return how long the daemon
+    thread took to exit.
+
+    Raises if the stream never opened or if the thread was still alive
+    after an 8 s join (the hang the fix must prevent) — so the caller's
+    single assertion only has to police promptness.
+    """
+    ready = asyncio.Event()
+    stream_ended = asyncio.Event()
+
+    async def consume() -> None:
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as ac:
+                async with ac.stream(
+                    "GET",
+                    f"http://127.0.0.1:{port}/agents/alice/inbox/stream",
+                    headers={"authorization": f"Bearer {TOKEN}"},
+                ) as sse:
+                    async for line in sse.aiter_lines():
+                        # The `: sac-channel ready` comment frame confirms
+                        # the subscription is live and the loop is now
+                        # parked on the next event.
+                        if line.startswith(":"):
+                            ready.set()
+                    # aiter_lines ends when the server closes the
+                    # connection on graceful shutdown.
+        finally:
+            stream_ended.set()
+
+    sub = asyncio.ensure_future(consume())
+    try:
+        await asyncio.wait_for(ready.wait(), timeout=5.0)
+        # Confirm it is genuinely parked — no event will ever arrive.
+        await asyncio.sleep(0.25)
+        if sub.done():
+            raise RuntimeError("SSE stream closed before shutdown was triggered")
+
+        # Trigger the graceful shutdown exactly as SIGTERM does.
+        t0 = time.monotonic()
+        server.should_exit = True
+        await asyncio.to_thread(thread.join, 8.0)
+        elapsed = time.monotonic() - t0
+        if thread.is_alive():
+            raise RuntimeError(
+                f"sac listen hung on SIGTERM with an in-flight SSE stream "
+                f"({elapsed:.1f}s, thread still alive) — graceful shutdown "
+                "did not cancel it, would escalate to SIGKILL"
+            )
+        await asyncio.wait_for(stream_ended.wait(), timeout=3.0)
+        return elapsed
+    finally:
+        if not sub.done():
+            sub.cancel()
+            with contextlib.suppress(BaseException):
+                await sub
+
+
+def test_sac_listen_graceful_shutdown_cancels_inflight_sse(shutdown_env) -> None:
+    """The regression guard: with a client parked on the SSE inbox
+    stream, flipping uvicorn's ``should_exit`` must let the daemon exit
+    PROMPTLY — the in-flight stream must not block graceful shutdown.
+
+    ``timeout_graceful_shutdown`` is deliberately LARGE (30 s) so the
+    only thing that can make shutdown prompt is the lifespan shutdown
+    bridge cancelling the SSE stream; a regression that reintroduces the
+    bare ``queue.get()`` (or drops the bridge) leaves the thread alive
+    past the 8 s join, which ``_measure_...`` raises on.
+    """
+    # Arrange
+    port = _free_port()
+    app = create_app(token=TOKEN)
+    config = uvicorn.Config(
+        app,
+        host="127.0.0.1",
+        port=port,
+        log_level="warning",
+        ws="none",
+        # Large on purpose — isolate the bridge as the thing under test.
+        timeout_graceful_shutdown=30.0,
+    )
+    server = uvicorn.Server(config)
+    # Mirror the boot path (listen_cmds._do_start_listen) so the lifespan
+    # shutdown bridge is wired to this server's ``should_exit``.
+    app.state.uvicorn_server = server
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+    deadline = time.monotonic() + 5.0
+    while not server.started:
+        if time.monotonic() > deadline:
+            raise RuntimeError("uvicorn loopback did not start in 5s")
+        time.sleep(0.02)
+
+    # Act
+    try:
+        elapsed = asyncio.run(
+            _measure_inflight_sse_shutdown_seconds(
+                server=server, thread=thread, port=port
+            )
+        )
+    finally:
+        server.should_exit = True
+        thread.join(timeout=5.0)
+
+    # Assert
+    assert elapsed < 5.0

--- a/tests/scitex_agent_container/a2a/test__inbox_bus.py
+++ b/tests/scitex_agent_container/a2a/test__inbox_bus.py
@@ -4,6 +4,9 @@ A2A push channel slice). See docs/sac-and-orochi.md.
 
 from __future__ import annotations
 
+import asyncio
+import time
+
 import pytest
 
 from scitex_agent_container.a2a._inbox_bus import (
@@ -121,6 +124,111 @@ async def test_unsubscribe_then_publish_reports_zero_delivered() -> None:
     delivered = await broker.publish("alice", {"x": 3})
     # Assert
     assert delivered == 0
+
+
+# ---------------------------------------------------------------------------
+# Broker.close / get_or_close — SIGTERM shutdown cancellation
+# (card sac-listen-sigterm-sse-shutdown-hang). The SSE inbox-stream loops
+# use ``get_or_close`` instead of a bare ``queue.get()`` so a graceful
+# shutdown can unblock them promptly via ``close()`` rather than parking
+# until uvicorn force-cancels / restart --force SIGKILLs.
+# ---------------------------------------------------------------------------
+
+
+def test_broker_is_not_closing_before_close() -> None:
+    # Arrange
+    broker = Broker()
+    # Act
+    closing = broker.is_closing()
+    # Assert
+    assert closing is False
+
+
+def test_close_sets_is_closing_true() -> None:
+    # Arrange
+    broker = Broker()
+    # Act
+    broker.close()
+    # Assert
+    assert broker.is_closing() is True
+
+
+def test_close_is_idempotent() -> None:
+    # Arrange
+    broker = Broker()
+    # Act
+    broker.close()
+    broker.close()
+    # Assert
+    assert broker.is_closing() is True
+
+
+@pytest.mark.asyncio
+async def test_get_or_close_blocks_while_idle_and_open() -> None:
+    # Arrange
+    broker = Broker()
+    q = await broker.subscribe("alice")
+    waiter = asyncio.ensure_future(broker.get_or_close(q))
+    # Act
+    await asyncio.sleep(0.15)
+    parked = not waiter.done()
+    waiter.cancel()
+    # Assert
+    assert parked is True
+
+
+@pytest.mark.asyncio
+async def test_get_or_close_returns_none_when_broker_closes() -> None:
+    # Arrange
+    broker = Broker()
+    q = await broker.subscribe("alice")
+    waiter = asyncio.ensure_future(broker.get_or_close(q))
+    await asyncio.sleep(0.1)
+    # Act
+    broker.close()
+    result = await asyncio.wait_for(waiter, timeout=1.0)
+    # Assert
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_or_close_unblocks_within_bounded_time_on_close() -> None:
+    # Arrange
+    broker = Broker()
+    q = await broker.subscribe("alice")
+    waiter = asyncio.ensure_future(broker.get_or_close(q))
+    await asyncio.sleep(0.1)
+    # Act
+    t0 = time.monotonic()
+    broker.close()
+    await asyncio.wait_for(waiter, timeout=1.0)
+    elapsed = time.monotonic() - t0
+    # Assert
+    assert elapsed < 0.5
+
+
+@pytest.mark.asyncio
+async def test_get_or_close_delivers_a_pending_event() -> None:
+    # Arrange
+    broker = Broker()
+    q = await broker.subscribe("alice")
+    await q.put({"msg_id": "m1", "content": "hi"})
+    # Act
+    event = await asyncio.wait_for(broker.get_or_close(q), timeout=1.0)
+    # Assert
+    assert event == {"msg_id": "m1", "content": "hi"}
+
+
+@pytest.mark.asyncio
+async def test_get_or_close_returns_none_immediately_if_already_closed() -> None:
+    # Arrange
+    broker = Broker()
+    q = await broker.subscribe("alice")
+    broker.close()
+    # Act
+    result = await asyncio.wait_for(broker.get_or_close(q), timeout=1.0)
+    # Assert
+    assert result is None
 
 
 @pytest.mark.asyncio

--- a/tests/scitex_agent_container/cli_pkg/test_listen_cmds.py
+++ b/tests/scitex_agent_container/cli_pkg/test_listen_cmds.py
@@ -15,6 +15,7 @@ real attribute lookups.
 from __future__ import annotations
 
 import sys as _sys
+import types as _types
 from contextlib import contextmanager
 
 import click as _click
@@ -60,15 +61,53 @@ def _swap_module(name, fake):
 class _FakeUvicorn:
     """Real callable-bearing stand-in for the ``uvicorn`` module.
 
-    Records the ``host``/``port`` of any ``run()`` call so tests can
-    assert on the production-side bind values without any mocking lib.
+    Records the ``host``/``port`` the production code binds to so tests
+    can assert on it without any mocking lib. ``sac listen`` builds an
+    explicit ``uvicorn.Config`` + ``uvicorn.Server`` and calls
+    ``server.run()`` (so it can stash the server on ``app.state`` for the
+    SIGTERM shutdown bridge — card sac-listen-sigterm-sse-shutdown-hang);
+    the fake mirrors that shape and records the bind on ``Server.run()``.
+    The legacy ``run()`` is kept for any caller that still uses
+    ``uvicorn.run`` directly.
     """
 
     def __init__(self) -> None:
         self.calls: list[dict] = []
+        _calls = self.calls
+
+        class Config:
+            def __init__(self, app, host, port, **_kw) -> None:
+                self.app = app
+                self.host = host
+                self.port = port
+
+        class Server:
+            def __init__(self, config) -> None:
+                self.config = config
+                # Real ``uvicorn.Server`` exposes these; the bridge reads
+                # ``should_exit`` and the loopback harness reads ``started``.
+                self.should_exit = False
+                self.started = False
+
+            def run(self) -> None:
+                _calls.append(
+                    {"host": self.config.host, "port": self.config.port}
+                )
+
+        self.Config = Config
+        self.Server = Server
 
     def run(self, app, host, port, log_level, **_kw) -> None:
         self.calls.append({"host": host, "port": port})
+
+
+def _fake_app():
+    """Stand-in for the Starlette app ``create_app`` returns.
+
+    Production stashes the uvicorn Server on ``app.state.uvicorn_server``
+    (for the shutdown bridge), so the fake needs a settable ``.state``.
+    """
+    return _types.SimpleNamespace(state=_types.SimpleNamespace())
 
 
 # ---------------------------------------------------------------------------
@@ -229,7 +268,7 @@ def test_listen_default_loopback_bind_starts_uvicorn_with_zero_exit(tmp_path):
     with (
         _swap_attr(_tokens, "ensure_token", lambda p: "tok"),
         _swap_attr(_tokens, "default_token_path", lambda: tmp_path / "default.tok"),
-        _swap_attr(_server, "create_app", lambda token, **_kw: object()),
+        _swap_attr(_server, "create_app", lambda token, **_kw: _fake_app()),
         _swap_module("uvicorn", fake_uvicorn),
     ):
         result = CliRunner().invoke(listen, [])
@@ -247,7 +286,7 @@ def test_listen_default_loopback_bind_passes_default_host_port_to_uvicorn(tmp_pa
     with (
         _swap_attr(_tokens, "ensure_token", lambda p: "tok"),
         _swap_attr(_tokens, "default_token_path", lambda: tmp_path / "default.tok"),
-        _swap_attr(_server, "create_app", lambda token, **_kw: object()),
+        _swap_attr(_server, "create_app", lambda token, **_kw: _fake_app()),
         _swap_module("uvicorn", fake_uvicorn),
     ):
         CliRunner().invoke(listen, [])
@@ -265,7 +304,7 @@ def test_listen_non_loopback_bind_with_allow_flag_passes_host_to_uvicorn(tmp_pat
     with (
         _swap_attr(_tokens, "ensure_token", lambda p: "tok"),
         _swap_attr(_tokens, "default_token_path", lambda: tmp_path / "d.tok"),
-        _swap_attr(_server, "create_app", lambda token, **_kw: object()),
+        _swap_attr(_server, "create_app", lambda token, **_kw: _fake_app()),
         _swap_module("uvicorn", fake_uvicorn),
     ):
         CliRunner().invoke(listen, ["--bind", "8.8.8.8:7878", "--allow-non-loopback"])


### PR DESCRIPTION
## Card

Fixes `sac-listen-sigterm-sse-shutdown-hang` [P2].

Observed live 2026-06-26 during `sac listen restart --force`:
`WARN: escalated to SIGKILL after 10.0s; daemon hung on SIGTERM (likely in-flight SSE shutdown).`

## Root cause

The `sac listen` per-agent SSE inbox-stream handler (`node_inbox_stream`)
loops on a bare `event = await queue.get()` with **no shutdown signal**.
When idle (no events flowing) it parks there indefinitely.

On SIGTERM, uvicorn's graceful `shutdown()` waits for in-flight requests
to complete under `timeout_graceful_shutdown` — which **defaults to
`None`, i.e. wait forever**. The parked SSE stream never completes, so:

- `request.is_disconnected()` never flips: for an in-flight streaming
  response, uvicorn's `connection.shutdown()` only sets `keep_alive =
  False`, it does **not** close the transport or feed `http.disconnect`
  (verified in uvicorn 0.50 `httptools_impl.shutdown`).
- The Starlette lifespan teardown (which cancels the background loops)
  runs **after** uvicorn's connection-wait (`server.py` shutdown order),
  so cancelling tasks there cannot help — we never reach it.

Result: the daemon hangs until `restart --force` (#473) escalates to
SIGKILL at 10 s. Every restart costs 10 s and risks an unclean shutdown.

## Fix

Proper async cancellation via a broker-level shutdown Event — no sleeps,
no polling hacks:

1. **`a2a/_inbox_bus.py` — `Broker.close()` / `get_or_close()`**: the SSE
   loops now `await broker.get_or_close(queue)`, which races
   `queue.get()` against a shutdown `asyncio.Event`. When the broker
   closes it returns `None` and the loop returns promptly; a live event
   landing on the same tick is still delivered (not dropped).
2. **`_listen/_node_channel.py`**: `node_inbox_stream` uses
   `get_or_close`; `None` ⇒ return (stream completes ⇒ connection drains
   ⇒ shutdown proceeds).
3. **`_lifecycle/_listen_lifespan.py` — shutdown bridge**: a lifespan
   task watches uvicorn's `should_exit` (set **synchronously** by its
   SIGTERM handler, well before the connection-wait) and calls
   `broker.close()` the instant it flips, so in-flight SSE streams cancel
   at once. The teardown `finally` also closes the broker (in-process /
   test runs with no uvicorn server).
4. **`cli_pkg/listen_cmds.py`**: switch `uvicorn.run(...)` to an explicit
   `uvicorn.Config`/`Server`, stash the server on `app.state` (so the
   bridge can read `should_exit`), and set a **bounded**
   `timeout_graceful_shutdown` floor (default 5 s, env
   `SAC_LISTEN_SHUTDOWN_GRACE_S`). The bridge makes the common case exit
   in ~0.2 s; the floor is a belt-and-suspenders guarantee that even
   without the bridge uvicorn force-cancels well under the 10 s grace.

Net effect: SIGTERM now exits the daemon in a fraction of a second (well
within the restart grace) — no SIGKILL escalation.

### Incidental refactor

`cli_pkg/listen_cmds.py` was already over the 512-line cap before this
change, so the two cohesive ADR-0014 comms_nodes registry hooks
(`_register_self_comms_node`, `_maybe_sync_on_start`) were extracted to a
new sibling `cli_pkg/_listen_registry_hooks.py` and re-exported (import
path preserved for tests). Pure move, no behaviour change.

## Tests (real asyncio, no mocks)

New `tests/scitex_agent_container/_listen/test_listen_shutdown_sse.py`
(9 tests, all green locally):

- Broker unit tests: `get_or_close` blocks while idle+open, returns
  `None` promptly on `close()` (bounded < 0.5 s), delivers a pending
  event, is idempotent.
- **End-to-end regression guard**: a real uvicorn server on loopback with
  a real `httpx` SSE client parked on the inbox stream; flipping
  `should_exit` (exactly what SIGTERM does) must let the daemon thread
  exit promptly. `timeout_graceful_shutdown` is set **large (30 s)** on
  purpose so the *only* thing that can make shutdown prompt is the
  cancellation fix — a regression that reintroduces the bare
  `queue.get()` leaves the thread alive past the 8 s join and fails
  loudly.

`scitex-dev ecosystem audit-all scitex-agent-container`: clean on the
touched surfaces (audit-mcp-tools / audit-skills / audit-python-apis /
audit-project all SUCC). The pre-existing `audit-cli: not-auditable` and
API dist-metadata WARN are environmental (package not pip-installed with
dist metadata), unrelated to this change.

## Residual risk / follow-up

`a2a/_server.py::get_inbox_stream` (the standalone `sac a2a serve`
command, a **separate** server from `sac listen`) has the same latent
`await queue.get()` pattern and an un-bounded `uvicorn.run` in `serve()`.
It is **not** the reported daemon and was left unchanged because that
file is already 604 lines (92 over the 512 cap) — even a one-line edit
would force a large out-of-scope refactor. The Broker plumbing it needs
(`get_or_close`/`close`) already ships here, so the follow-up is a ~2-line
loop change plus a `timeout_graceful_shutdown` in `serve()` once that file
is split. Tracked as a follow-up.
