### PR TITLE
fix(hooks): fail-loud guard for non-CLA-allowlisted commit authors

### DIFF
--- a/src/scitex_agent_container/_baseline_assets/git_identity_hooks/.gitignore
+++ b/src/scitex_agent_container/_baseline_assets/git_identity_hooks/.gitignore
@@ -1,0 +1,4 @@
+# Runtime block-audit log written by enforce_commit_author_allowlist.sh on
+# each BLOCK (its LOG_PATH = <hook-dir>/.<script>.log). A pure runtime
+# artifact -- never committed; the self-test / pytest suite generates it.
+.enforce_commit_author_allowlist.sh.log

--- a/src/scitex_agent_container/_baseline_assets/git_identity_hooks/README.md
+++ b/src/scitex_agent_container/_baseline_assets/git_identity_hooks/README.md
@@ -1,0 +1,108 @@
+# Git-identity guard hooks (CLA-author allowlist)
+
+Canonical, version-controlled, tested source for the PreToolUse Bash
+hook that keeps a non-CLA-allowlisted commit author from silently
+reaching CI. Sibling in spirit to `../claude_worktree_hooks/`: the
+authoritative copy lives here in the package and is **propagated** into
+the fleet baseline that `runtimes/_to_home.py` materializes into every
+agent's `$HOME/.claude/`.
+
+## Why
+
+Evidenced incident (scitex-hpc, 2026-07-05): an agent's PR went fully
+GREEN on real CI (audit / docs / import-smoke / pytest 3.11-3.13) but
+the **required `CLAssistant` check FAILED** and blocked the merge. The
+commits were authored `agent@scitex-hpc`, which maps to no GitHub
+account, and the CLA allowlist (`bot*`, `ywatanabe1989`) rejected it.
+Force-push is hook-blocked, so the only remedy was re-creating the whole
+tree as a fresh commit authored by the allowlisted identity
+(`ywatanabe@scitex.ai` = `ywatanabe1989`) on a NEW branch — pure,
+avoidable rework, discovered only AFTER a full CI cycle.
+
+Root cause: the container's git author is meant to default to the
+allowlisted `Yusuke Watanabe <ywatanabe@scitex.ai>`, pinned through
+`SAC_GIT_AUTHOR_EMAIL` (direnv `.envrc`) → `GIT_AUTHOR_EMAIL` (the
+apptainer alias step in `runtimes/_apptainer_inner_argv.py`). That pin
+can **silently** fail — direnv never fired / the var is empty, so
+`GIT_AUTHOR_EMAIL` is unset and git synthesizes `user@hostname`; or a
+prompt-level `git config user.email` override moves the author away.
+Nothing caught it until CLAssistant, after CI.
+
+> This exact silent failure was reproduced live while building this
+> hook: a fresh `scitex-agent-container` worktree resolved its author to
+> `proj-scitex-agent-container <agent@scitex-agent-container>`
+> (`GIT_AUTHOR_EMAIL` unset, a non-allowlisted local `user.email`). The
+> guard blocks that at commit time.
+
+## What
+
+- `enforce_commit_author_allowlist.sh` — PreToolUse Bash hook. On
+  `git commit` / `git push` it resolves the **effective** author email
+  and **BLOCKS (exit 2)** when it is not allowlisted, with a message
+  that (a) tells the agent to fix identity BEFORE pushing, and (b)
+  explicitly distinguishes "wrong local identity" from "the CLAssistant
+  bot itself errored". Read-only git (status/log/add), non-git,
+  non-Bash, and not-in-a-repo all pass through untouched.
+- `settings.local.json.fragment.json` — the PreToolUse wiring snippet to
+  merge into the baseline `settings.json` (see below).
+
+### Allowlist (case-insensitive email match)
+
+| kind          | value                                     | maps to           |
+| ------------- | ----------------------------------------- | ----------------- |
+| built-in exact | `ywatanabe@scitex.ai`                    | GitHub `ywatanabe1989` |
+| built-in glob  | `*[bot]@users.noreply.github.com`        | `bot*` authors    |
+| env extension  | `CC_CLA_ALLOWED_EMAILS="a@x,b@y"`         | LLEmacs / others  |
+
+The default is intentionally tight: the container's ONLY intended author
+is `ywatanabe@scitex.ai`, so ANY deviation (`agent@<host>`, a synthesized
+`user@hostname`, a stray override) is the bug the hook exists to catch.
+For a rare non-default-but-allowlisted identity, extend via
+`CC_CLA_ALLOWED_EMAILS` rather than loosening the default. Operator-
+supervised bypass: `CC_ALLOW_CLA_AUTHOR=1` or an inline
+`# hook-bypass: cla-author` marker.
+
+## How to deploy fleet-wide
+
+The hook only FIRES once it is in the materialized baseline. The package
+copy here is the source of truth; propagate it exactly like
+`claude_worktree_hooks`:
+
+1. Copy the script to the shared baseline pre-tool-use dir:
+
+       <agents_dir>/_shared/to_home/.claude/hooks/pre-tool-use/enforce_commit_author_allowlist.sh
+
+   (In this fleet that is
+   `~/.dotfiles/src/.scitex/agent-container/agents/_shared/to_home/.claude/hooks/pre-tool-use/`.)
+   `runtimes/_to_home.py` materializes that tree into every agent's
+   `$HOME/.claude/hooks/pre-tool-use/` on each start — no SIF rebuild.
+
+2. Merge the `PreToolUse` `Bash`-matcher entry from
+   `settings.local.json.fragment.json` into the baseline
+   `<agents_dir>/_shared/to_home/.claude/settings.json` `hooks` block
+   (append it to the existing `Bash` matcher's `hooks` list, next to
+   `deny_commit_push_on_main_develop.sh`).
+
+3. Restart agents (or wait for the next natural restart). Claude Code
+   re-reads `~/.claude/settings.json` on each session boot.
+
+## Verification
+
+- `bash enforce_commit_author_allowlist.sh --self-test` — drives the
+  hook against real ephemeral git repos (allowlisted vs non-allowlisted
+  authors, inline `--author` / `GIT_AUTHOR_EMAIL=` / `-c user.email=`
+  overrides, push-range author scan, env extension, both bypasses,
+  read-only/non-git/non-Bash pass-through). Exit 0 iff all pass.
+- Regression suite:
+  `tests/scitex_agent_container/_baseline_assets/git_identity_hooks/`
+  drives the same scenarios from pytest (no mocks, real repos).
+
+## Provisioning side (defense in depth)
+
+This hook is the fail-loud backstop. The upstream pin still belongs to
+direnv: `~/proj/.envrc` exports `SAC_GIT_AUTHOR_EMAIL=ywatanabe@scitex.ai`
+(+ name/committer), and `runtimes/_apptainer_inner_argv.py`
+(`_GIT_ENV_ALIAS_STEPS`) mirrors `SAC_GIT_*` → `GIT_*`. If a host is
+found where that pin does not land (as reproduced above), fix the direnv
+allow / `.envrc` sourcing on that host so `GIT_AUTHOR_EMAIL` is set at
+launch — the hook then never has to fire.

--- a/src/scitex_agent_container/_baseline_assets/git_identity_hooks/enforce_commit_author_allowlist.sh
+++ b/src/scitex_agent_container/_baseline_assets/git_identity_hooks/enforce_commit_author_allowlist.sh
@@ -1,0 +1,487 @@
+#!/bin/bash
+# -*- coding: utf-8 -*-
+# Timestamp: "2026-07-06 (proj-scitex-agent-container)"
+# File: ~/.claude/hooks/pre-tool-use/enforce_commit_author_allowlist.sh
+#
+# Description: PreToolUse hook for Bash. On `git commit` / `git push`,
+# resolves the EFFECTIVE commit-author email and BLOCKS (exit 2) when it
+# is not on the CLA allowlist, with an actionable, in-place fix so the
+# identity is corrected BEFORE the push — never after CI.
+#
+# WHY (evidenced incident, scitex-hpc 2026-07-05)
+# ------------------------------------------------
+# An agent's PR went fully GREEN on real CI (audit / docs / import-smoke /
+# pytest 3.11-3.13) but the REQUIRED `CLAssistant` check FAILED and blocked
+# the merge: the commits were authored `agent@scitex-hpc`, which maps to no
+# GitHub account, and the CLA allowlist rejected it. Force-push is
+# hook-blocked, so the ONLY remedy was re-creating the whole tree as a fresh
+# commit authored by the allowlisted identity on a NEW branch — pure,
+# avoidable rework discovered only AFTER a full CI cycle.
+#
+# Root cause: the container's git author is meant to default to the
+# CLA-allowlisted `Yusuke Watanabe <ywatanabe@scitex.ai>` (= GitHub
+# `ywatanabe1989`), pinned via `SAC_GIT_AUTHOR_EMAIL` (direnv `.envrc`) ->
+# `GIT_AUTHOR_EMAIL` (apptainer alias step). That pin can silently fail
+# (direnv never fired / var empty), leaving `GIT_AUTHOR_EMAIL` unset so git
+# synthesizes `user@hostname`; or a prompt-level `git config user.email`
+# override moves the author away. Nothing caught it until CLAssistant, after
+# CI. This hook is the fail-loud backstop that catches it at commit/push
+# time, in-place.
+#
+# The CLA maps AUTHOR -> GitHub account by email. The container's ONLY
+# intended author is the allowlisted `ywatanabe@scitex.ai`; ANY deviation
+# (`agent@<host>`, a synthesized `user@hostname`, a stray override) is the
+# bug. So the default allowlist is intentionally tight; extend it for the
+# rare non-default-but-allowlisted identity (LLEmacs / a bot) via the env
+# var below rather than loosening the default.
+#
+# Policy:
+#   - `git commit`, effective author NOT allowlisted             -> BLOCK
+#   - `git push`, ANY unpushed commit's author NOT allowlisted   -> BLOCK
+#   - author IS allowlisted (exact / glob / env-extension)       -> allow
+#   - read-only / non-commit-push git (status, log, add, ...)    -> allow
+#   - non-git / non-Bash / not-in-a-repo                         -> allow
+#
+# Allowlist (case-insensitive email match):
+#   - built-in exact:  ywatanabe@scitex.ai   (= GitHub ywatanabe1989)
+#   - built-in glob:   *[bot]@users.noreply.github.com   (bot* authors)
+#   - env extension:   CC_CLA_ALLOWED_EMAILS="a@x,b@y"   (comma/space list)
+#
+# Detection of `git -C <path>` mirrors the sibling git hooks so a command
+# issued from one cwd that mutates ANOTHER repo is judged against the repo
+# it actually touches.
+#
+# Bypass (rare -- operator-supervised):
+#   - Inline marker:  `# hook-bypass: cla-author`
+#   - Env variable:   CC_ALLOW_CLA_AUTHOR=1
+
+set -u
+
+THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOG_PATH="$THIS_DIR/.$(basename "$0").log"
+
+# ------------------------------------------------------------------
+# Self-test
+# ------------------------------------------------------------------
+if [[ "${1:-}" == "--self-test" ]]; then
+    echo "=== Self-test: $(basename "$0") ==="
+    pass=0
+    fail=0
+
+    # Deterministic: the hook resolves `git var GIT_AUTHOR_IDENT`, which
+    # honours GIT_AUTHOR_EMAIL from the ENV over repo config. Unset the
+    # inherited identity/extension vars so each case controls its own.
+    unset GIT_AUTHOR_EMAIL GIT_AUTHOR_NAME GIT_COMMITTER_EMAIL \
+        GIT_COMMITTER_NAME CC_CLA_ALLOWED_EMAILS CC_ALLOW_CLA_AUTHOR 2>/dev/null || true
+
+    tmpdir=$(mktemp -d)
+    trap 'rm -rf "$tmpdir"' EXIT
+
+    good_repo="$tmpdir/good"     # config author = allowlisted
+    bad_repo="$tmpdir/bad"       # config author = NOT allowlisted
+    (
+        mkdir -p "$good_repo" && cd "$good_repo" || exit
+        git init -q -b feature/x
+        git config user.email "ywatanabe@scitex.ai"
+        git config user.name "Yusuke Watanabe"
+        git commit --allow-empty -q -m seed
+
+        mkdir -p "$bad_repo" && cd "$bad_repo" || exit
+        git init -q -b feature/x
+        git config user.email "agent@scitex-hpc"
+        git config user.name "agent"
+        git commit --allow-empty -q -m seed
+    ) >/dev/null 2>&1
+
+    run() {
+        local desc="$1" cmd="$2" cwd="$3" want="$4" envset="${5:-}" rc json
+        json=$(printf '{"tool_name":"Bash","tool_input":{"command":%s},"cwd":%s}' \
+            "$(printf '%s' "$cmd" | python3 -c 'import sys,json;print(json.dumps(sys.stdin.read()))')" \
+            "$(printf '%s' "$cwd" | python3 -c 'import sys,json;print(json.dumps(sys.stdin.read()))')")
+        if [[ -n "$envset" ]]; then
+            printf '%s' "$json" | env $envset "$0" >/dev/null 2>&1
+        else
+            printf '%s' "$json" | "$0" >/dev/null 2>&1
+        fi
+        rc=$?
+        if [[ "$rc" == "$want" ]]; then
+            echo "  PASS ($rc) $desc"
+            pass=$((pass + 1))
+        else
+            echo "  FAIL got $rc want $want: $desc -- cmd: $cmd"
+            fail=$((fail + 1))
+        fi
+    }
+
+    # --- commit: allowlisted config author -> ALLOW ---
+    run "commit good-config author" "git commit -m x" "$good_repo" 0
+    run "commit good, -C form" "git -C $good_repo commit -m x" "$tmpdir" 0
+
+    # --- commit: non-allowlisted config author -> BLOCK ---
+    run "commit bad-config author" "git commit -m x" "$bad_repo" 2
+    run "commit bad, -am" "git commit -am x" "$bad_repo" 2
+    run "commit bad, add && commit" "git add -A && git commit -m x" "$bad_repo" 2
+    run "commit bad, -C form" "git -C $bad_repo commit -m x" "$tmpdir" 2
+
+    # --- inline overrides win, respected by the guard ---
+    run "bad repo but GIT_AUTHOR_EMAIL=good inline" \
+        "GIT_AUTHOR_EMAIL=ywatanabe@scitex.ai git commit -m x" "$bad_repo" 0
+    run "good repo but --author=bad inline" \
+        "git commit -m x --author='Nobody <nobody@nowhere.invalid>'" "$good_repo" 2
+    run "bad repo but -c user.email=good inline" \
+        "git -c user.email=ywatanabe@scitex.ai commit -m x" "$bad_repo" 0
+
+    # --- push: judges the authors of the unpushed commits ---
+    run "push bad-author commit" "git push origin feature/x" "$bad_repo" 2
+    run "push good-author commit" "git push origin feature/x" "$good_repo" 0
+
+    # --- env extension allowlists an extra identity ---
+    run "commit bad author, extended via env" "git commit -m x" "$bad_repo" 0 \
+        "CC_CLA_ALLOWED_EMAILS=agent@scitex-hpc"
+
+    # --- bypasses ---
+    run "marker bypass" "git commit -m x # hook-bypass: cla-author" "$bad_repo" 0
+    run "env bypass" "git commit -m x" "$bad_repo" 0 "CC_ALLOW_CLA_AUTHOR=1"
+
+    # --- non-commit/push git in a bad repo -> ALLOW (read-only) ---
+    run "status in bad repo" "git status" "$bad_repo" 0
+    run "log in bad repo" "git log --oneline" "$bad_repo" 0
+    run "add in bad repo" "git add -A" "$bad_repo" 0
+
+    # --- non-git / non-repo / non-Bash -> ALLOW ---
+    run "non-git command" "ls -la" "$bad_repo" 0
+    run "commit outside any repo" "git commit -m x" "$tmpdir" 0
+    rc=0
+    echo '{"tool_name":"Edit","tool_input":{}}' | "$0" >/dev/null 2>&1 || rc=$?
+    if [[ "$rc" == "0" ]]; then
+        echo "  PASS (0) non-Bash tool"
+        pass=$((pass + 1))
+    else
+        echo "  FAIL got $rc want 0: non-Bash tool"
+        fail=$((fail + 1))
+    fi
+
+    # --- quoted git token in an rg pattern must NOT trip the gate ---
+    run "quoted git commit in rg pattern" \
+        "rg -N 'git commit|git push' $tmpdir" "$good_repo" 0
+
+    echo "pass=$pass fail=$fail"
+    [[ $fail -eq 0 ]] && exit 0 || exit 1
+fi
+
+# ------------------------------------------------------------------
+# Enablement switch (project-switch helper, like the sibling hooks)
+# ------------------------------------------------------------------
+HELPER_SCRIPT="$(dirname "$THIS_DIR")/project-switch/hook_switch_helper.sh"
+if [[ -f "$HELPER_SCRIPT" ]]; then
+    # shellcheck source=/dev/null
+    source "$HELPER_SCRIPT"
+    if declare -f check_hook_enabled_or_exit >/dev/null 2>&1; then
+        check_hook_enabled_or_exit "$(basename "$0")"
+    fi
+fi
+
+# ------------------------------------------------------------------
+# Env-var escape
+# ------------------------------------------------------------------
+[[ "${CC_ALLOW_CLA_AUTHOR:-}" == "1" ]] && exit 0
+
+# ------------------------------------------------------------------
+# Read input; string-marker bypass
+# ------------------------------------------------------------------
+INPUT="$(cat)"
+printf '%s' "$INPUT" | grep -qF 'hook-bypass: cla-author' && exit 0
+
+# ------------------------------------------------------------------
+# Main decision. The Python body is captured via a QUOTED heredoc so it
+# may contain arbitrary single/double quotes (the block message + git
+# fix commands need both); it is passed to `python3 -c`. INPUT arrives on
+# stdin, LOG_PATH via the environment.
+# ------------------------------------------------------------------
+PYCODE=$(cat <<'PYEOF'
+import json, sys, re, os, shlex, subprocess, fnmatch
+
+
+def sh(*args):
+    try:
+        r = subprocess.run(list(args), capture_output=True, text=True)
+        return r.returncode, r.stdout.strip(), r.stderr.strip()
+    except Exception:
+        return 1, "", ""
+
+
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+if d.get("tool_name", "") != "Bash":
+    sys.exit(0)
+cmd = (d.get("tool_input", {}) or {}).get("command", "") or ""
+cwd = d.get("cwd", "") or ""
+if not cmd or not cwd or not os.path.isdir(cwd):
+    sys.exit(0)
+
+
+# Quote-aware split: a `git commit` token inside a quoted rg/grep pattern
+# must NOT trip the gate. Mirrors the sibling git hooks.
+def _split_top_level(s):
+    segs, buf, i, n, q = [], [], 0, len(s), None
+    while i < n:
+        c = s[i]
+        if q:
+            buf.append(c)
+            if c == q:
+                q = None
+            i += 1
+            continue
+        if c == "'" or c == '"':
+            q = c
+            buf.append(c)
+            i += 1
+            continue
+        if c == "&" and i + 1 < n and s[i + 1] == "&":
+            segs.append("".join(buf)); buf = []; i += 2; continue
+        if c == "|" and i + 1 < n and s[i + 1] == "|":
+            segs.append("".join(buf)); buf = []; i += 2; continue
+        if c == "|" or c == ";":
+            segs.append("".join(buf)); buf = []; i += 1; continue
+        buf.append(c)
+        i += 1
+    segs.append("".join(buf))
+    return segs
+
+
+def _git_subcmd_and_C(seg):
+    """(subcommand, git_C_target) if the segment's first real command is
+    git, else (None, None)."""
+    try:
+        toks = shlex.split(seg, posix=True)
+    except ValueError:
+        toks = seg.split()
+    i = 0
+    while i < len(toks):
+        t = toks[i]
+        if "=" in t and not t.startswith("-"):
+            i += 1
+            continue
+        if t in ("sudo", "env", "nice", "time", "command"):
+            i += 1
+            continue
+        break
+    if i >= len(toks) or not (toks[i] == "git" or toks[i].endswith("/git")):
+        return None, None
+    rest = toks[i + 1:]
+    target = None
+    j = 0
+    while j < len(rest):
+        t = rest[j]
+        if t == "-C" and j + 1 < len(rest):
+            target = rest[j + 1]; j += 2; continue
+        if t.startswith("-C") and len(t) > 2:
+            target = t[2:]; j += 1; continue
+        if t == "-c" and j + 1 < len(rest):
+            j += 2
+            continue
+        if t.startswith("-"):
+            j += 1
+            continue
+        return t, target
+    return None, target
+
+
+mode_commit = False
+mode_push = False
+git_c = None
+for seg in _split_top_level(cmd):
+    sub, tgt = _git_subcmd_and_C(seg)
+    if sub == "commit":
+        mode_commit = True
+        if tgt and not git_c:
+            git_c = tgt
+    elif sub == "push":
+        mode_push = True
+        if tgt and not git_c:
+            git_c = tgt
+if not (mode_commit or mode_push):
+    sys.exit(0)
+
+# Resolve the target repo (honour `git -C <path>`).
+repo = git_c or cwd
+if repo and not os.path.isabs(repo):
+    repo = os.path.join(cwd, repo)
+repo = os.path.expanduser(repo)
+if not os.path.isdir(repo):
+    repo = cwd
+if sh("git", "-C", repo, "rev-parse", "--git-dir")[0] != 0:
+    sys.exit(0)
+
+# Allowlist (case-insensitive).
+ALLOWED_EXACT = {"ywatanabe@scitex.ai"}
+ALLOWED_GLOBS = ["*[[]bot[]]@users.noreply.github.com"]
+for e in re.split(r"[,\s]+", os.environ.get("CC_CLA_ALLOWED_EMAILS", "")):
+    e = e.strip().lower()
+    if e:
+        ALLOWED_EXACT.add(e)
+
+
+def allowed(email):
+    e = (email or "").strip().lower()
+    if not e:
+        return False
+    if e in ALLOWED_EXACT:
+        return True
+    return any(fnmatch.fnmatch(e, g) for g in ALLOWED_GLOBS)
+
+
+def email_of(ident):
+    m = re.search(r"<([^>]*)>", ident or "")
+    return m.group(1).strip() if m else ""
+
+
+# authors :: list of (email, source)
+authors = []
+
+# Inline overrides (mirror git's resolution precedence).
+inline_email, inline_src = None, None
+m = re.search(r'''(?:^|[\s;&|(])GIT_AUTHOR_EMAIL=("[^"]*"|'[^']*'|\S+)''', cmd)
+if m:
+    inline_email = m.group(1).strip("\"'")
+    inline_src = "inline GIT_AUTHOR_EMAIL="
+m = re.search(r'''-c\s+user\.email=("[^"]*"|'[^']*'|\S+)''', cmd)
+if m:
+    inline_email = m.group(1).strip("\"'")
+    inline_src = "inline -c user.email="
+if mode_commit:
+    m = re.search(r'''--author[=\s]+("[^"]*"|'[^']*'|\S+)''', cmd)
+    if m:
+        val = m.group(1).strip("\"'")
+        em = email_of(val) or (val if "@" in val else "")
+        if em:
+            inline_email = em
+            inline_src = "inline --author flag"
+
+if mode_commit:
+    if inline_email:
+        authors.append((inline_email, inline_src))
+    else:
+        ident = sh("git", "-C", repo, "var", "GIT_AUTHOR_IDENT")[1]
+        env_ae = os.environ.get("GIT_AUTHOR_EMAIL", "").strip()
+        cfg_ae = sh("git", "-C", repo, "config", "user.email")[1].strip()
+        if env_ae:
+            src = "GIT_AUTHOR_EMAIL env"
+        elif cfg_ae:
+            src = "user.email config"
+        else:
+            src = "git default (no identity set -> synthesized user@hostname)"
+        authors.append((email_of(ident), src))
+
+if mode_push:
+    # Authors of the commits this push would publish: prefer the tracked
+    # upstream range; else exclude known integration refs; else HEAD.
+    emails = []
+    rc, up, _ = sh("git", "-C", repo, "rev-parse", "--abbrev-ref",
+                   "--symbolic-full-name", "@{upstream}")
+    if rc == 0 and up:
+        rc, out, _ = sh("git", "-C", repo, "log", "--format=%ae", up + "..HEAD")
+        emails = [x for x in out.splitlines() if x.strip()] if rc == 0 else []
+    else:
+        excludes = []
+        for ref in ("origin/develop", "origin/main", "origin/master"):
+            if sh("git", "-C", repo, "rev-parse", "--verify", "--quiet", ref)[0] == 0:
+                excludes.append("^" + ref)
+        if excludes:
+            rc, out, _ = sh("git", "-C", repo, "log", "--format=%ae", "HEAD", *excludes)
+            emails = [x for x in out.splitlines() if x.strip()] if rc == 0 else []
+        else:
+            rc, out, _ = sh("git", "-C", repo, "log", "-1", "--format=%ae", "HEAD")
+            emails = [out.strip()] if rc == 0 and out.strip() else []
+    seen = set()
+    for em in emails:
+        if em not in seen:
+            seen.add(em)
+            authors.append((em, "pushed commit author"))
+
+violations = [(em, src) for (em, src) in authors if not allowed(em)]
+if not violations:
+    sys.exit(0)
+
+# Block + log.
+log_path = os.environ.get("LOG_PATH", "")
+if log_path:
+    try:
+        import datetime
+        ts = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        with open(log_path, "a") as fh:
+            fh.write("[%s] BLOCK cla-author :: repo=%s :: %s :: %s\n"
+                     % (ts, repo, [v[0] for v in violations], cmd))
+    except Exception:
+        pass
+
+bad_email = violations[0][0] or "<empty>"
+bad_src = violations[0][1]
+
+if bad_src.startswith("GIT_AUTHOR_EMAIL env") or bad_src.startswith("inline GIT_AUTHOR_EMAIL"):
+    fix = (
+        "A GIT_AUTHOR_EMAIL is set to a NON-allowlisted value (it beats\n"
+        "  git config). Re-point it, then re-create the commit:\n"
+        "    export GIT_AUTHOR_EMAIL=ywatanabe@scitex.ai\n"
+        "    export GIT_AUTHOR_NAME='Yusuke Watanabe'\n"
+        "    git -C %s commit --amend --reset-author --no-edit" % repo
+    )
+elif "pushed commit author" in bad_src:
+    fix = (
+        "One or more commits you are pushing are authored by a\n"
+        "  non-allowlisted identity. Fix identity, then rewrite them\n"
+        "  (topic branch only -- never a shared branch):\n"
+        "    git -C %s config user.email ywatanabe@scitex.ai\n"
+        "    git -C %s config user.name  'Yusuke Watanabe'\n"
+        "    # last commit:\n"
+        "    git -C %s commit --amend --reset-author --no-edit\n"
+        "    # or a range: git -C %s rebase --exec \\\n"
+        "        'git commit --amend --reset-author --no-edit' <base>" % (repo, repo, repo, repo)
+    )
+else:
+    fix = (
+        "Set the CLA-allowlisted identity, then re-create the commit:\n"
+        "    git -C %s config user.email ywatanabe@scitex.ai\n"
+        "    git -C %s config user.name  'Yusuke Watanabe'\n"
+        "    git -C %s commit --amend --reset-author --no-edit   # if already committed"
+        % (repo, repo, repo)
+    )
+
+msg = (
+    "BLOCKED by enforce_commit_author_allowlist.sh: commit author\n"
+    "'%s' is NOT CLA-allowlisted (source: %s).\n"
+    "\n"
+    ">>> This is a LOCAL IDENTITY problem -- NOT a failure of the CLAssistant\n"
+    ">>> bot. The bot is fine; your commit author simply maps to no allowlisted\n"
+    ">>> GitHub account.\n"
+    "\n"
+    "The required 'CLAssistant' check maps each commit author to a GitHub\n"
+    "account via an allowlist (bot*, ywatanabe1989 -> ywatanabe@scitex.ai). An\n"
+    "author that maps to no allowlisted account makes CLAssistant FAIL and\n"
+    "BLOCK THE MERGE -- and it only surfaces AFTER CI has already gone green.\n"
+    "Because force-push is hook-blocked, the sole remedy then is re-creating\n"
+    "the tree on a new branch (avoidable rework -- incident: scitex-hpc\n"
+    "2026-07-05). Fix it HERE, before pushing.\n"
+    "\n"
+    "FIX\n"
+    "---\n"
+    "  %s\n"
+    "\n"
+    "If '%s' is a DIFFERENT but legitimately allowlisted identity\n"
+    "(e.g. LLEmacs / a bot), extend the allowlist instead:\n"
+    "  export CC_CLA_ALLOWED_EMAILS='%s'\n"
+    "Bypass (operator-supervised only): append '# hook-bypass: cla-author'\n"
+    % (bad_email, bad_src, fix, bad_email, bad_email)
+)
+
+sys.stderr.write(msg)
+sys.exit(2)
+PYEOF
+)
+
+printf '%s' "$INPUT" | LOG_PATH="$LOG_PATH" python3 -c "$PYCODE"
+exit $?
+
+# EOF

--- a/src/scitex_agent_container/_baseline_assets/git_identity_hooks/settings.local.json.fragment.json
+++ b/src/scitex_agent_container/_baseline_assets/git_identity_hooks/settings.local.json.fragment.json
@@ -1,0 +1,17 @@
+{
+  "_comment_cla_author_hook": "PreToolUse Bash-matcher wiring for enforce_commit_author_allowlist.sh. APPEND the single hook entry below into the EXISTING `PreToolUse` `Bash` matcher's `hooks` list in the baseline <agents_dir>/_shared/to_home/.claude/settings.json (next to deny_commit_push_on_main_develop.sh) -- do NOT add a second Bash matcher block. Script body lives next to this fragment (src/scitex_agent_container/_baseline_assets/git_identity_hooks/) and must be deployed to $HOME/.claude/hooks/pre-tool-use/enforce_commit_author_allowlist.sh via to_home materialization. Rationale + incident (scitex-hpc 2026-07-05, CLAssistant blocked a green PR authored agent@scitex-hpc) are documented in the sibling README.md. The hook is a plain bash script (matches the other pre-tool-use git guards); it is NOT pinned to a venv interpreter -- it shells out to `python3` on PATH internally, consistent with enforce_git_dash_C.sh / deny_commit_push_on_main_develop.sh.",
+
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/pre-tool-use/enforce_commit_author_allowlist.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/integration/git_identity_hooks/conftest.py
+++ b/tests/integration/git_identity_hooks/conftest.py
@@ -2,8 +2,14 @@
 
 Drives the real ``enforce_commit_author_allowlist.sh`` shell hook against
 real ephemeral git repos (no mocks, no patches) — the fleet rule for hook
-tests. The script is resolved by package-relative path so a refactor of
-the asset location is caught at collection time, not at spawn time.
+tests. The script is a ``.sh`` asset with no ``.py`` source counterpart,
+so — like the ``_real.py`` integration pattern (see
+``02_package/06_project-structure-tests.md``) — these tests live under
+``tests/integration/`` to stay OUT of PS-204's ``tests/<pkg>/`` mirror
+scope while ``pytest tests/`` still collects and runs them.
+
+The hook is resolved by repo-relative path so a refactor of the asset
+location is caught at collection time, not at spawn time.
 """
 
 from __future__ import annotations
@@ -17,7 +23,7 @@ from typing import Iterator
 import pytest
 
 HOOK_DIR = (
-    Path(__file__).resolve().parents[4]
+    Path(__file__).resolve().parents[3]
     / "src"
     / "scitex_agent_container"
     / "_baseline_assets"

--- a/tests/integration/git_identity_hooks/test_enforce_commit_author_allowlist.py
+++ b/tests/integration/git_identity_hooks/test_enforce_commit_author_allowlist.py
@@ -6,6 +6,10 @@ its commits were authored ``agent@scitex-hpc``, mapping to no allowlisted
 GitHub account). These tests drive the real shell hook against real
 ephemeral git repos — no mocks — and assert the block/allow decision plus
 the shape of the actionable message.
+
+Located under ``tests/integration/`` (not ``tests/<pkg>/``) because the
+hook is a ``.sh`` asset with no ``.py`` source to mirror; PS-204 only
+scans the ``tests/<pkg>/`` mirror tree.
 """
 
 from __future__ import annotations

--- a/tests/scitex_agent_container/_baseline_assets/git_identity_hooks/conftest.py
+++ b/tests/scitex_agent_container/_baseline_assets/git_identity_hooks/conftest.py
@@ -1,0 +1,94 @@
+"""Shared fixtures for the git_identity_hooks tests.
+
+Drives the real ``enforce_commit_author_allowlist.sh`` shell hook against
+real ephemeral git repos (no mocks, no patches) — the fleet rule for hook
+tests. The script is resolved by package-relative path so a refactor of
+the asset location is caught at collection time, not at spawn time.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+HOOK_DIR = (
+    Path(__file__).resolve().parents[4]
+    / "src"
+    / "scitex_agent_container"
+    / "_baseline_assets"
+    / "git_identity_hooks"
+)
+HOOK_SCRIPT = HOOK_DIR / "enforce_commit_author_allowlist.sh"
+
+ALLOWLISTED_EMAIL = "ywatanabe@scitex.ai"
+ALLOWLISTED_NAME = "Yusuke Watanabe"
+NON_ALLOWLISTED_EMAIL = "agent@scitex-hpc"
+
+# Identity/allowlist env vars that would make the hook's resolution
+# non-deterministic; scrubbed from every hook invocation so each test
+# controls its own inputs via repo config / command / explicit env.
+_SCRUB = (
+    "GIT_AUTHOR_EMAIL",
+    "GIT_AUTHOR_NAME",
+    "GIT_COMMITTER_EMAIL",
+    "GIT_COMMITTER_NAME",
+    "CC_CLA_ALLOWED_EMAILS",
+    "CC_ALLOW_CLA_AUTHOR",
+)
+
+
+def _clean_env(extra: dict | None = None) -> dict:
+    env = {k: v for k, v in os.environ.items() if k not in _SCRUB}
+    if extra:
+        env.update(extra)
+    return env
+
+
+def _git(cwd: Path, *args: str) -> str:
+    res = subprocess.run(
+        ["git", "-C", str(cwd), *args],
+        capture_output=True,
+        text=True,
+        check=True,
+        env=_clean_env(),
+    )
+    return res.stdout.strip()
+
+
+def _make_repo(path: Path, email: str, name: str = "someone") -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    _git(path, "init", "-q", "--initial-branch=feature/x")
+    _git(path, "config", "user.email", email)
+    _git(path, "config", "user.name", name)
+    _git(path, "commit", "--allow-empty", "-q", "-m", "seed")
+    return path
+
+
+def run_hook(
+    command: str, cwd: Path, extra_env: dict | None = None
+) -> subprocess.CompletedProcess:
+    """Invoke the hook with a Bash-tool PreToolUse payload; return the
+    completed process so tests assert on returncode/stderr directly."""
+    payload = {"tool_name": "Bash", "tool_input": {"command": command}, "cwd": str(cwd)}
+    return subprocess.run(
+        ["bash", str(HOOK_SCRIPT)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        env=_clean_env(extra_env),
+    )
+
+
+@pytest.fixture
+def good_repo(tmp_path: Path) -> Iterator[Path]:
+    yield _make_repo(tmp_path / "good", ALLOWLISTED_EMAIL, ALLOWLISTED_NAME)
+
+
+@pytest.fixture
+def bad_repo(tmp_path: Path) -> Iterator[Path]:
+    yield _make_repo(tmp_path / "bad", NON_ALLOWLISTED_EMAIL, "agent")

--- a/tests/scitex_agent_container/_baseline_assets/git_identity_hooks/test_enforce_commit_author_allowlist.py
+++ b/tests/scitex_agent_container/_baseline_assets/git_identity_hooks/test_enforce_commit_author_allowlist.py
@@ -1,0 +1,266 @@
+"""Regression tests for ``enforce_commit_author_allowlist.sh``.
+
+The hook is the fail-loud backstop for the CLA-author failure class
+(incident scitex-hpc 2026-07-05: a green PR blocked by CLAssistant because
+its commits were authored ``agent@scitex-hpc``, mapping to no allowlisted
+GitHub account). These tests drive the real shell hook against real
+ephemeral git repos — no mocks — and assert the block/allow decision plus
+the shape of the actionable message.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from .conftest import (
+    ALLOWLISTED_EMAIL,
+    HOOK_SCRIPT,
+    NON_ALLOWLISTED_EMAIL,
+    run_hook,
+)
+
+
+# --- result fixtures (run the hook once; each test asserts one thing) --
+
+
+@pytest.fixture
+def self_test_result():
+    return subprocess.run(
+        ["bash", str(HOOK_SCRIPT), "--self-test"], capture_output=True, text=True
+    )
+
+
+@pytest.fixture
+def commit_bad_result(bad_repo):
+    return run_hook("git commit -m x", bad_repo)
+
+
+@pytest.fixture
+def ambient_env_result(bad_repo):
+    return run_hook(
+        "git commit -m x", bad_repo, extra_env={"GIT_AUTHOR_EMAIL": "stray@nowhere.invalid"}
+    )
+
+
+# --- asset presence ---------------------------------------------------
+
+
+def test_hook_script_file_exists():
+    # Arrange
+    script = HOOK_SCRIPT
+    # Act
+    present = script.is_file()
+    # Assert
+    assert present, f"missing hook: {script}"
+
+
+def test_hook_script_is_executable():
+    # Arrange
+    script = HOOK_SCRIPT
+    # Act
+    mode = script.stat().st_mode
+    # Assert
+    assert mode & 0o111, "hook is not executable"
+
+
+# --- the script's own self-test (broadest built-in coverage) ----------
+
+
+def test_self_test_exits_zero(self_test_result):
+    # Arrange
+    res = self_test_result
+    # Act
+    rc = res.returncode
+    # Assert
+    assert rc == 0, res.stdout + res.stderr
+
+
+def test_self_test_reports_no_failures(self_test_result):
+    # Arrange
+    res = self_test_result
+    # Act
+    out = res.stdout
+    # Assert
+    assert "fail=0" in out
+
+
+# --- commit: allow / block --------------------------------------------
+
+
+def test_commit_allowlisted_author_is_allowed(good_repo):
+    # Arrange
+    cmd = "git commit -m x"
+    # Act
+    res = run_hook(cmd, good_repo)
+    # Assert
+    assert res.returncode == 0, res.stderr
+
+
+def test_commit_non_allowlisted_author_is_blocked(commit_bad_result):
+    # Arrange
+    res = commit_bad_result
+    # Act
+    rc = res.returncode
+    # Assert
+    assert rc == 2
+
+
+def test_commit_block_message_names_the_bad_email(commit_bad_result):
+    # Arrange
+    res = commit_bad_result
+    # Act
+    stderr = res.stderr
+    # Assert
+    assert NON_ALLOWLISTED_EMAIL in stderr
+
+
+def test_commit_block_message_distinguishes_from_cla_bot_error(commit_bad_result):
+    # Arrange
+    res = commit_bad_result
+    # Act
+    stderr = res.stderr
+    # Assert
+    assert "NOT a failure of the CLAssistant" in stderr
+
+
+def test_commit_block_message_gives_config_fix(commit_bad_result):
+    # Arrange
+    res = commit_bad_result
+    # Act
+    stderr = res.stderr
+    # Assert
+    assert "config user.email ywatanabe@scitex.ai" in stderr
+
+
+def test_commit_blocked_when_targeted_via_git_dash_c(bad_repo, tmp_path):
+    # Arrange
+    cmd = f"git -C {bad_repo} commit -m x"
+    # Act
+    res = run_hook(cmd, tmp_path)
+    # Assert
+    assert res.returncode == 2
+
+
+def test_commit_blocked_in_chained_add_then_commit(bad_repo):
+    # Arrange
+    cmd = "git add -A && git commit -m x"
+    # Act
+    res = run_hook(cmd, bad_repo)
+    # Assert
+    assert res.returncode == 2
+
+
+# --- inline identity overrides (mirror git precedence) ----------------
+
+
+def test_inline_author_email_env_overrides_bad_config(bad_repo):
+    # Arrange
+    cmd = f"GIT_AUTHOR_EMAIL={ALLOWLISTED_EMAIL} git commit -m x"
+    # Act
+    res = run_hook(cmd, bad_repo)
+    # Assert
+    assert res.returncode == 0, res.stderr
+
+
+def test_inline_bad_author_flag_blocked_in_good_repo(good_repo):
+    # Arrange
+    cmd = "git commit -m x --author='Nobody <nobody@nowhere.invalid>'"
+    # Act
+    res = run_hook(cmd, good_repo)
+    # Assert
+    assert res.returncode == 2
+
+
+def test_ambient_bad_author_email_env_is_blocked(ambient_env_result):
+    # Arrange
+    res = ambient_env_result
+    # Act
+    rc = res.returncode
+    # Assert
+    assert rc == 2
+
+
+def test_ambient_bad_author_email_message_points_at_env(ambient_env_result):
+    # Arrange
+    res = ambient_env_result
+    # Act
+    stderr = res.stderr
+    # Assert
+    assert "GIT_AUTHOR_EMAIL" in stderr
+
+
+# --- push: judges the unpushed commits' authors -----------------------
+
+
+def test_push_with_bad_author_commit_is_blocked(bad_repo):
+    # Arrange
+    cmd = "git push origin feature/x"
+    # Act
+    res = run_hook(cmd, bad_repo)
+    # Assert
+    assert res.returncode == 2
+
+
+def test_push_with_good_author_commit_is_allowed(good_repo):
+    # Arrange
+    cmd = "git push origin feature/x"
+    # Act
+    res = run_hook(cmd, good_repo)
+    # Assert
+    assert res.returncode == 0, res.stderr
+
+
+# --- allowlist extension + bypasses -----------------------------------
+
+
+def test_env_extension_allowlists_extra_email(bad_repo):
+    # Arrange
+    extra = {"CC_CLA_ALLOWED_EMAILS": NON_ALLOWLISTED_EMAIL}
+    # Act
+    res = run_hook("git commit -m x", bad_repo, extra_env=extra)
+    # Assert
+    assert res.returncode == 0, res.stderr
+
+
+def test_inline_marker_bypasses_the_guard(bad_repo):
+    # Arrange
+    cmd = "git commit -m x # hook-bypass: cla-author"
+    # Act
+    res = run_hook(cmd, bad_repo)
+    # Assert
+    assert res.returncode == 0
+
+
+def test_env_var_bypasses_the_guard(bad_repo):
+    # Arrange
+    extra = {"CC_ALLOW_CLA_AUTHOR": "1"}
+    # Act
+    res = run_hook("git commit -m x", bad_repo, extra_env=extra)
+    # Assert
+    assert res.returncode == 0
+
+
+# --- pass-through: read-only / non-git / non-Bash ---------------------
+
+
+@pytest.mark.parametrize("cmd", ["git status", "git log --oneline", "git add -A", "ls -la"])
+def test_readonly_and_non_git_commands_pass_through(bad_repo, cmd):
+    # Arrange
+    command = cmd
+    # Act
+    res = run_hook(command, bad_repo)
+    # Assert
+    assert res.returncode == 0
+
+
+def test_non_bash_tool_invocation_passes_through():
+    # Arrange
+    payload = '{"tool_name":"Edit","tool_input":{}}'
+    # Act
+    res = subprocess.run(
+        ["bash", str(HOOK_SCRIPT)], input=payload, capture_output=True, text=True
+    )
+    # Assert
+    assert res.returncode == 0


### PR DESCRIPTION
## Problem — an evidenced, recurring failure class

An agent's PR can go **fully green on CI** (audit / docs / import-smoke /
pytest 3.11–3.13) yet be **blocked from merge** by the *required*
`CLAssistant` check — because the commits were authored by an identity
that maps to no GitHub account and is not on the CLA allowlist
(`bot*`, `ywatanabe1989`). Evidenced on **scitex-hpc, 2026-07-05**:
commits authored `agent@scitex-hpc` → CLAssistant failed → merge blocked
**after** a full CI cycle. Force-push is hook-blocked, so the only remedy
was re-creating the whole tree as a fresh commit on a new branch —
avoidable rework.

**This bug reproduced live while building this PR.** A fresh
`scitex-agent-container` worktree resolved its author to
`proj-scitex-agent-container <agent@scitex-agent-container>`
(`GIT_AUTHOR_EMAIL` **unset**, a non-allowlisted local `user.email`) — i.e.
the provisioning identity pin silently did not reach this container.

## Where the identity is set (investigation)

- **Values**: `~/proj/.envrc` (direnv, fleet ancestor) exports
  `SAC_GIT_AUTHOR_EMAIL=ywatanabe@scitex.ai` (+ name / committer). By
  design the `.envrc` states identity is owned by direnv, *not*
  force-injected by sac launch code.
- **Mirror**: `src/scitex_agent_container/runtimes/_apptainer_inner_argv.py`
  `_GIT_ENV_ALIAS_STEPS` maps `SAC_GIT_*` → `GIT_AUTHOR_*` / `GIT_COMMITTER_*`
  as the first shell step of every container launch — **only when the
  `SAC_GIT_*` var is non-empty**. If direnv never fired (var empty),
  `GIT_AUTHOR_EMAIL` stays unset and git synthesizes `user@hostname`, or a
  stray `git config user.email` wins. Nothing caught it until CLAssistant.

## The fix — a fail-loud, in-place guard

`enforce_commit_author_allowlist.sh` — a **PreToolUse Bash** hook. On
`git commit` / `git push` it resolves the **effective** author email and
**BLOCKS (exit 2)** when it is not CLA-allowlisted, with a message that:

- fixes identity **before** the push (no post-CI force-push rework),
- **explicitly distinguishes** a wrong *local identity* from a
  *CLAssistant-bot error*,
- gives a **source-specific fix** (env `GIT_AUTHOR_EMAIL` vs `user.email`
  config vs synthesized default; `--amend --reset-author` for commits
  already made).

Resolution mirrors git's own precedence: inline `--author=` /
`GIT_AUTHOR_EMAIL=` / `-c user.email=` → `git var GIT_AUTHOR_IDENT` (env
→ config). On `git push` it scans the authors of the unpushed commits
(`@{upstream}..HEAD`, else excluding `origin/{develop,main,master}`, else
`HEAD`). Allowlist: built-in `ywatanabe@scitex.ai` +
`*[bot]@users.noreply.github.com`, extensible via
`CC_CLA_ALLOWED_EMAILS`; bypass via `CC_ALLOW_CLA_AUTHOR=1` or an inline
`# hook-bypass: cla-author`. Read-only git, non-git, non-Bash, and
not-in-a-repo all pass through.

## Where it landed

The operative home for pre-tool-use git guards is the **dotfiles**
`_shared/to_home/.claude/hooks/pre-tool-use/` (materialized into every
container by `runtimes/_to_home.py`). Following the `claude_worktree_hooks`
precedent, the **canonical, version-controlled, tested source** is
vendored here in the package:

```
src/scitex_agent_container/_baseline_assets/git_identity_hooks/
  ├── enforce_commit_author_allowlist.sh      # the guard
  ├── README.md                                # why + deploy steps
  ├── settings.local.json.fragment.json        # PreToolUse wiring snippet
  └── .gitignore                               # ignores the runtime block-log
tests/scitex_agent_container/_baseline_assets/git_identity_hooks/
  └── test_enforce_commit_author_allowlist.py  # 25 tests, real repos
```

**Operator / dotfiles-owner — one-step propagation to make it fire fleet-wide**
(identical to `claude_worktree_hooks`):

1. Copy the script to
   `~/.dotfiles/src/.scitex/agent-container/agents/_shared/to_home/.claude/hooks/pre-tool-use/enforce_commit_author_allowlist.sh`
   (keep it `chmod +x`).
2. Append this entry to the existing `PreToolUse` **Bash** matcher's
   `hooks` list in
   `~/.dotfiles/src/.scitex/agent-container/agents/_shared/to_home/.claude/settings.json`
   (next to `deny_commit_push_on_main_develop.sh`):
   ```json
   { "type": "command", "command": "$HOME/.claude/hooks/pre-tool-use/enforce_commit_author_allowlist.sh" }
   ```
3. Agents pick it up on next restart (`_to_home.py` re-materializes; no
   SIF rebuild).

I did not commit into `~/.dotfiles` from this worktree: it is a separate
repo on an unrelated in-progress topic branch, and this task is one
PR against `scitex-agent-container` develop.

## Provisioning-pin option (not taken — operator's call)

I deliberately did **not** hardcode the identity into
`_apptainer_inner_argv.py`: the `.envrc` documents that direnv, not sac
launch code, owns identity values, and the guard already catches *every*
failure path (missing env, bad config, `--author`, synthesized default).
If preferred, the direnv-firing gap that produced the live repro (this
container's `GIT_AUTHOR_EMAIL` unset) can be fixed at the direnv/`.envrc`
layer, or a design-respecting launch-time **warning** (no hardcoded
identity) can be added — happy to follow up either way.

## Test evidence

- Hook self-test: **21/21 pass** (`bash enforce_commit_author_allowlist.sh --self-test`).
- Regression suite: **25/25 pass**
  (`/opt/venv-sac/bin/python3 -m pytest .../git_identity_hooks/`, real
  ephemeral repos, no mocks): allow allowlisted commit; block
  `agent@scitex-hpc`; `git -C` retarget; chained `add && commit`; inline
  `--author` / `GIT_AUTHOR_EMAIL=` / `-c user.email=`; ambient bad env;
  push author-scan (block/allow); env-extension; both bypasses; read-only
  / non-git / non-Bash pass-through; message-shape assertions.
- `scitex-dev ecosystem audit-all scitex-agent-container`: clean on all
  touched surfaces (mcp-tools / skills / python-apis / project all
  `SUCC`; the lone `audit-cli: not-auditable` is a pre-existing meta-state
  unrelated to this change, which adds no CLI).
- This PR's own commit is authored `Yusuke Watanabe <ywatanabe@scitex.ai>`
  (allowlisted) so it does not hit the bug it fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
