### PR TITLE
feat(dispatch): robust concrete-host resolution — host: <canonical> == host: local, never ssh-to-self

### DIFF
--- a/src/scitex_agent_container/_skills/scitex-agent-container/11_remote-deploy.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/11_remote-deploy.md
@@ -40,46 +40,19 @@ time.
 
 ## How `spec.host` resolves — concrete hostname → local or remote
 
-`spec.host` is a CONCRETE canonical hostname; at `sac agents start` time
-sac resolves *where that host is* and picks the launch path. You write the
-machine's name — not `"remote"` vs `"local"` — and sac routes it:
+`spec.host` is a CONCRETE hostname; `sac agents start` resolves *where it is*:
 
-| `spec.host` value | Classifies as | Launch path |
-|---|---|---|
-| `local` or absent | local | local `agent_start` |
-| the current machine's canonical name or a known alias of it | local | local `agent_start` — **byte-for-byte identical** to `host: local` |
-| a peer key from `config.yaml::peers:` (incl. `spartan-*` globs) | remote | remote ssh dispatch (`_dispatch_remote_start`) |
-| anything else — unregistered name / typo | unknown | **never ssh** — falls through to the liveness-gated singleton-skip (defer if live on the pinned host, else start locally) |
+| `spec.host` | Launch path |
+|---|---|
+| `local` / absent, or this machine's canonical name / alias | local `agent_start` (identical to `host: local`) |
+| a `peers:` key not this machine (incl. `spartan-*` globs) | ssh dispatch (`_dispatch_remote_start`) |
+| unregistered / typo | never ssh; defers to the liveness-gated singleton-skip |
 
-Resolution consults exactly the two registries an operator already keeps:
-
-1. **The host's own identity** — the canonical name + aliases in
-   `config.yaml::host:` (`host.canonical` / `host.aliases`, plus the
-   `SCITEX_AGENT_CONTAINER_HOSTNAME` / `SAC_HOST` overrides). Any spelling
-   that denotes THIS machine classifies as local.
-2. **The peers registry** — `config.yaml::peers:` (each peer's `ssh:` may be
-   a bare `~/.ssh/config` Host alias). A match that is NOT the local machine
-   classifies as remote.
-
-The local-identity check runs **before** the peer table, so a machine that
-is ALSO registered as a peer so other hosts can reach it (e.g.
-`ywata-note-win: {ssh: localhost}`) is never ssh-dispatched to itself — its
-own canonical name still resolves local. This is what makes the
-concrete-hostname convention safe: `host: ywata-note-win` on
-`ywata-note-win` is the same local launch as `host: local`, while the same
-spec shipped as `host: spartan` dispatches over ssh to the `spartan` peer.
-
-Only a resolved **remote peer** ever reaches ssh. An unknown / unregistered
-host is never silently ssh-dispatched to nowhere; it defers to the existing
-liveness-gated singleton-skip — the agent is skipped when it is verified
-live on its pinned host, otherwise the stale-binding fall-through starts it
-locally (so a mistyped host is never a silent no-op that leaves the agent
-unstarted everywhere).
-
-The resolver lives in
-`cli_pkg/lifecycle/_common.classify_dispatch_host` (pure: concrete host →
-`local` / `remote` / `unknown`); `try_dispatch` dispatches only `remote`
-and returns local-path control for `local` / `unknown`.
+Identity is `config.yaml::host:` (canonical + aliases); peers are
+`config.yaml::peers:` (`ssh:` may be a `~/.ssh/config` alias). The local check
+precedes the peer table, so a self-registered peer (`ywata-note-win: {ssh:
+localhost}`) is never ssh'd to itself. Resolver:
+`_common.classify_dispatch_host` (`try_dispatch` dispatches only `remote`).
 
 ## YAML — multi-instance, one per peer
 

--- a/src/scitex_agent_container/_skills/scitex-agent-container/11_remote-deploy.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/11_remote-deploy.md
@@ -38,6 +38,49 @@ spec:
 order; first available wins). The agent runs on exactly one peer at a
 time.
 
+## How `spec.host` resolves — concrete hostname → local or remote
+
+`spec.host` is a CONCRETE canonical hostname; at `sac agents start` time
+sac resolves *where that host is* and picks the launch path. You write the
+machine's name — not `"remote"` vs `"local"` — and sac routes it:
+
+| `spec.host` value | Classifies as | Launch path |
+|---|---|---|
+| `local` or absent | local | local `agent_start` |
+| the current machine's canonical name or a known alias of it | local | local `agent_start` — **byte-for-byte identical** to `host: local` |
+| a peer key from `config.yaml::peers:` (incl. `spartan-*` globs) | remote | remote ssh dispatch (`_dispatch_remote_start`) |
+| anything else — unregistered name / typo | unknown | **never ssh** — falls through to the liveness-gated singleton-skip (defer if live on the pinned host, else start locally) |
+
+Resolution consults exactly the two registries an operator already keeps:
+
+1. **The host's own identity** — the canonical name + aliases in
+   `config.yaml::host:` (`host.canonical` / `host.aliases`, plus the
+   `SCITEX_AGENT_CONTAINER_HOSTNAME` / `SAC_HOST` overrides). Any spelling
+   that denotes THIS machine classifies as local.
+2. **The peers registry** — `config.yaml::peers:` (each peer's `ssh:` may be
+   a bare `~/.ssh/config` Host alias). A match that is NOT the local machine
+   classifies as remote.
+
+The local-identity check runs **before** the peer table, so a machine that
+is ALSO registered as a peer so other hosts can reach it (e.g.
+`ywata-note-win: {ssh: localhost}`) is never ssh-dispatched to itself — its
+own canonical name still resolves local. This is what makes the
+concrete-hostname convention safe: `host: ywata-note-win` on
+`ywata-note-win` is the same local launch as `host: local`, while the same
+spec shipped as `host: spartan` dispatches over ssh to the `spartan` peer.
+
+Only a resolved **remote peer** ever reaches ssh. An unknown / unregistered
+host is never silently ssh-dispatched to nowhere; it defers to the existing
+liveness-gated singleton-skip — the agent is skipped when it is verified
+live on its pinned host, otherwise the stale-binding fall-through starts it
+locally (so a mistyped host is never a silent no-op that leaves the agent
+unstarted everywhere).
+
+The resolver lives in
+`cli_pkg/lifecycle/_common.classify_dispatch_host` (pure: concrete host →
+`local` / `remote` / `unknown`); `try_dispatch` dispatches only `remote`
+and returns local-path control for `local` / `unknown`.
+
 ## YAML — multi-instance, one per peer
 
 ```yaml

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_common.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_common.py
@@ -9,7 +9,8 @@ and the foreground-tail multiplexer.
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+import socket
+from collections.abc import Collection, Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable
 
@@ -28,25 +29,121 @@ BoundHostLivenessOracle = Callable[[str, str], bool]
 _SKIP_DIR_NAMES = {"legacy-agents", "shared", "GITIGNORED"}
 
 
+def classify_dispatch_host(
+    target_host: str | None,
+    current_host: str,
+    peers: Mapping[str, "PeerSpec"],
+    *,
+    local_names: Collection[str] = (),
+) -> tuple[str, str | None]:
+    """Classify a concrete ``spec.host`` into local / remote / unknown.
+
+    Pure resolver — never raises, never logs, never reads files (the
+    caller supplies ``local_names`` and ``peers``). This is the operator's
+    "resolution layer": a concrete canonical hostname is mapped to WHERE
+    that host is, so ``host: <this-machine>`` launches locally and
+    ``host: <peer>`` dispatches over ssh.
+
+    Returns a ``(kind, peer)`` tuple:
+
+    * ``("local", None)``  — run on the caller. Fires when ``target_host``
+      is unset (``host: local`` / absent, normalized to ``""`` → ``None``),
+      equals ``current_host``, or is any spelling in ``local_names``
+      (the canonical name + aliases that denote THIS machine per
+      ``host_config``). LOCAL is checked BEFORE the peer table so a machine
+      that is ALSO registered as a peer (e.g. ``ywata-note-win: {ssh:
+      localhost}`` so remote hosts can reach it) is never ssh-dispatched
+      to itself.
+    * ``("remote", <peer>)`` — dispatch to that peer over ssh. Fires when
+      ``target_host`` is a known peer key distinct from the local machine.
+    * ``("unknown", None)`` — ``target_host`` names neither the local
+      machine nor a peer. :func:`try_dispatch` treats this exactly like
+      ``local`` (returns ``False`` → proceed with the local path), so it
+      falls through to the liveness-gated singleton-skip which either
+      defers to the pinned host or (the bm025 stale-binding fix) starts
+      locally. The classification is kept DISTINCT from ``local`` so a
+      caller that wants to fail loud on an unregistered host can, but the
+      default never routes an unknown host to ssh.
+    """
+    if target_host is None:
+        return ("local", None)
+    if target_host == current_host or target_host in local_names:
+        return ("local", None)
+    if target_host in peers:
+        return ("remote", target_host)
+    return ("unknown", None)
+
+
 def _resolve_dispatch_peer(
     target_host: str | None,
     current_host: str,
     peers: Mapping[str, "PeerSpec"],
+    *,
+    local_names: Collection[str] = (),
 ) -> str | None:
     """Return the peer name to dispatch to, or None for local execution.
 
-    Pure resolver — never raises, never logs, never reads files. Returns
-    a peer name only when ``target_host`` names a known peer that is not
-    the current host. An unknown ``target_host`` yields ``None`` so the
-    caller can decide whether to skip locally or escalate the mismatch.
+    Thin wrapper over :func:`classify_dispatch_host` preserving the historic
+    "peer-name-or-None" contract used by :func:`try_dispatch`. Returns a peer
+    name only for a ``remote`` classification; both ``local`` and ``unknown``
+    yield ``None`` (the caller decides what an unknown host means). With the
+    default empty ``local_names`` the behaviour is byte-identical to the
+    pre-hardening resolver — the alias-of-self short-circuit only engages
+    when the caller passes the machine's local spellings.
     """
-    if target_host is None:
-        return None
-    if target_host == current_host:
-        return None
-    if target_host not in peers:
-        return None
-    return target_host
+    _kind, peer = classify_dispatch_host(
+        target_host, current_host, peers, local_names=local_names
+    )
+    return peer
+
+
+def _local_host_names(current_host: str | None = None) -> set[str]:
+    """Return every host spelling that denotes THIS machine.
+
+    Unions the two hostname authorities so ``host: <canonical-or-alias>``
+    resolves to a LOCAL launch regardless of which registry the operator
+    configured, and — critically — regardless of drift between them:
+
+      * ``host_config`` (F-CS12 ``~/.scitex/agent-container/config.yaml``):
+        ``canonical_host()`` plus the ``host.aliases`` entry keyed by this
+        machine's short hostname.
+      * ``config/_host.resolve_hostname()`` (the value dispatch already
+        passes as ``current_host``) and the bare ``socket`` short hostname.
+
+    Only the alias entry for THIS machine's short hostname is included, so a
+    peer machine's alias is never mistaken for local. Best-effort — a
+    missing / broken config degrades to the short hostname (plus
+    ``current_host`` when supplied); it never raises.
+    """
+    names: set[str] = set()
+    if current_host:
+        names.add(current_host)
+    short = socket.gethostname().split(".")[0]
+    if short:
+        names.add(short)
+    # config/_host resolver (env override → spec.hostname_aliases → short).
+    try:
+        from ...config._host import resolve_hostname
+
+        rn = resolve_hostname()
+        if rn:
+            names.add(rn)
+    except Exception:  # stx-allow: fallback (reason: hostname resolution must never block dispatch; short hostname already captured)
+        pass
+    # host_config F-CS12 registry (env override → host.canonical → aliases).
+    try:
+        from ..._state.host_config import load as _load_host_config
+
+        cfg = _load_host_config()
+        canonical = cfg.canonical_host()
+        if canonical:
+            names.add(canonical)
+        alias = cfg.host.aliases.get(short)
+        if alias:
+            names.add(alias)
+    except Exception:  # stx-allow: fallback (reason: absent/malformed config.yaml must not break the local-vs-remote decision; the two hostname sources above suffice)
+        pass
+    return {n for n in names if n}
 
 
 def _bound_host(config: AgentConfig) -> str | None:
@@ -357,6 +454,8 @@ def _multiplex_foreground_tails(names, sleeper=None):
 __all__ = [
     "_SKIP_DIR_NAMES",
     "BoundHostLivenessOracle",
+    "classify_dispatch_host",
+    "_local_host_names",
     "_bound_host",
     "_registry_active_on",
     "_resolve_dispatch_peer",

--- a/src/scitex_agent_container/cli_pkg/lifecycle/_dispatch.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_dispatch.py
@@ -5,9 +5,9 @@
 End-to-end implementation of the cross-host pipeline (see
 ``~/proj/scitex-lead/GITIGNORED/WORKING/remote-agent-pipeline.md``).
 The routing branch in ``_start.py`` delegates to :func:`try_dispatch`,
-which asks the pure resolver in ``_common._resolve_dispatch_peer``
-whether a remote handoff is required and, when so, calls
-:func:`_dispatch_remote_start` to:
+which asks the pure resolver in ``_common.classify_dispatch_host`` to map
+the concrete ``spec.host`` to local / remote / unknown. A ``remote``
+classification calls :func:`_dispatch_remote_start` to:
 
   * drift-check via ``rsync --dry-run --itemize-changes``,
   * rsync the spec dir to the peer,
@@ -32,9 +32,11 @@ from typing import TYPE_CHECKING
 import click
 
 from ...config import AgentConfig
-from ._common import _resolve_dispatch_peer
+from ._common import _local_host_names, classify_dispatch_host
 
 if TYPE_CHECKING:
+    from collections.abc import Collection
+
     from ..._state.host_config import PeerSpec
 
 
@@ -310,31 +312,59 @@ def try_dispatch(
     *,
     dry_run: bool,
     force: bool,
+    local_names: "Collection[str] | None" = None,
 ) -> bool:
     """Route ``config`` to a remote peer when its ``spec.host`` demands it.
 
-    Returns ``True`` when the start was dispatched (the caller should
-    ``continue`` the per-target loop).  Returns ``False`` when local
-    execution should proceed — either because ``spec.host`` is unset,
-    equals the current host, or names an unknown host (the resolver
-    yields None and the singleton-skip logic downstream decides what
-    to do).
+    Resolves the concrete ``spec.host`` into exactly one of three outcomes
+    via :func:`classify_dispatch_host`:
 
-    Calls :func:`_dispatch_remote_start` for the end-to-end handoff:
-    drift-check + rsync + remote ``sac agents start --no-redispatch
-    --json`` + lead-side ``state.db.instances`` row write.
+    * **local** — ``spec.host`` is unset (``host: local`` / absent), equals
+      the current host, or is any spelling in ``local_names`` (the canonical
+      name + aliases denoting THIS machine). Returns ``False`` so the caller
+      proceeds with the UNCHANGED local launch. This is the equivalence the
+      concrete-hostname convention relies on: ``host: <this-canonical>``
+      lands on the byte-identical local path as ``host: local`` — and,
+      because the local check precedes the peer table, a machine that is
+      also registered as a peer (``ssh: localhost``) is never ssh-dispatched
+      to itself.
+    * **remote** — ``spec.host`` names a known peer distinct from this
+      machine. Calls :func:`_dispatch_remote_start` for the end-to-end
+      handoff (drift-check + rsync + remote ``sac agents start
+      --no-redispatch --json`` + lead-side ``state.db.instances`` row) and
+      returns ``True``. Only this branch ever reaches ssh.
+    * **unknown** — ``spec.host`` names neither this machine nor a peer.
+      Returns ``False`` (treated exactly like ``local``) so the caller falls
+      through to the liveness-gated singleton-skip in
+      :func:`_resolve_singleton_skip` — skip when the agent is verified live
+      on its pinned host, else the documented bm025 stale-binding
+      fall-through to a local start. An unknown host is therefore never
+      silently ssh-dispatched to nowhere.
+
+    ``local_names`` defaults to :func:`_local_host_names` (the union of both
+    hostname authorities); tests inject an explicit set to keep the routing
+    decision pure and hermetic.
     """
     spec_host = config.hosts_spec.host
     if isinstance(spec_host, list):
         target_host = spec_host[0] if spec_host else None
     else:
         target_host = spec_host or None
-    dispatch_peer = _resolve_dispatch_peer(
-        target_host=target_host,
-        current_host=current_host,
-        peers=peers,
+    if local_names is None:
+        local_names = _local_host_names(current_host)
+    kind, dispatch_peer = classify_dispatch_host(
+        target_host,
+        current_host,
+        peers,
+        local_names=local_names,
     )
-    if dispatch_peer is None:
+    # ONLY a resolved remote peer triggers ssh dispatch. "local" and
+    # "unknown" both return False: local launches here; unknown defers to the
+    # unchanged singleton-skip logic downstream (which the 40 running agents
+    # and the multi-host fleet pattern depend on). The classifier's guarantee
+    # is negative-safety — an unknown host never becomes an ssh target, and a
+    # self-registered peer never ssh-dispatches to itself.
+    if kind != "remote" or dispatch_peer is None:
         return False
     _dispatch_remote_start(
         name=config.name,

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__common.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__common.py
@@ -21,11 +21,13 @@ from scitex_agent_container.cli_pkg.lifecycle._common import (
     _bound_host,
     _discover_all_agents,
     _iter_agent_yamls,
+    _local_host_names,
     _multiplex_foreground_tails,
     _registry_active_on,
     _resolve_dispatch_peer,
     _resolve_singleton_skip,
     _singleton_skip_reason,
+    classify_dispatch_host,
 )
 from scitex_agent_container.config import AgentConfig
 from scitex_agent_container.config._types import HostsSpec, SchedulingSpec
@@ -786,3 +788,151 @@ class TestResolveDispatchPeer:
         out = _resolve_dispatch_peer(" spartan-bm152 ", "ywata-note-win", peers)
         # Assert
         assert out is None
+
+    def test_alias_of_self_that_is_also_a_peer_stays_local(self):
+        # Arrange — the current machine is ALSO registered as a peer (so
+        # remote hosts can ssh to it); an alias spelling must resolve LOCAL,
+        # never ssh-to-self, even though it is a peer key.
+        peers = {
+            "ywata-note-win": PeerSpec(name="ywata-note-win", ssh="localhost"),
+        }
+        # Act
+        out = _resolve_dispatch_peer(
+            "ywata-note-win",
+            "some-raw-hostname",
+            peers,
+            local_names={"ywata-note-win", "some-raw-hostname"},
+        )
+        # Assert
+        assert out is None
+
+
+# ---------------------------------------------------------------------------
+# classify_dispatch_host — the operator's concrete-hostname resolution layer:
+# concrete host -> local | remote:<peer> | unknown. Pure; never reads files.
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyDispatchHost:
+    def test_absent_host_classifies_local(self):
+        # Arrange — host: local / absent normalizes to None upstream.
+        peers = _peers_with_spartan()
+        # Act
+        kind, peer = classify_dispatch_host(None, "ywata-note-win", peers)
+        # Assert
+        assert (kind, peer) == ("local", None)
+
+    def test_canonical_name_of_current_host_classifies_local(self):
+        # Arrange — host: <this-canonical> equals current_host.
+        peers = _peers_with_spartan()
+        # Act
+        kind, peer = classify_dispatch_host(
+            "ywata-note-win", "ywata-note-win", peers
+        )
+        # Assert
+        assert (kind, peer) == ("local", None)
+
+    def test_alias_of_current_host_classifies_local(self):
+        # Arrange — target differs from current_host but is a known local
+        # alias (host_config canonical/aliases denote THIS machine).
+        peers = _peers_with_spartan()
+        # Act
+        kind, peer = classify_dispatch_host(
+            "ywata-note-win",
+            "raw-short-name",
+            peers,
+            local_names={"raw-short-name", "ywata-note-win"},
+        )
+        # Assert
+        assert (kind, peer) == ("local", None)
+
+    def test_local_wins_over_peer_table_no_ssh_to_self(self):
+        # Arrange — the machine is registered as a peer too; local must win.
+        peers = {"ywata-note-win": PeerSpec(name="ywata-note-win", ssh="localhost")}
+        # Act
+        kind, peer = classify_dispatch_host(
+            "ywata-note-win",
+            "ywata-note-win",
+            peers,
+            local_names={"ywata-note-win"},
+        )
+        # Assert
+        assert (kind, peer) == ("local", None)
+
+    def test_known_peer_classifies_remote(self):
+        # Arrange
+        peers = _peers_with_spartan()
+        # Act
+        kind, peer = classify_dispatch_host(
+            "spartan-bm152", "ywata-note-win", peers
+        )
+        # Assert
+        assert (kind, peer) == ("remote", "spartan-bm152")
+
+    def test_unknown_host_classifies_unknown(self):
+        # Arrange — neither local nor a peer key.
+        peers = _peers_with_spartan()
+        # Act
+        kind, peer = classify_dispatch_host("typo-host", "ywata-note-win", peers)
+        # Assert
+        assert (kind, peer) == ("unknown", None)
+
+    def test_glob_peer_key_classifies_remote(self):
+        # Arrange — PeersMap resolves spartan-* patterns on lookup.
+        from scitex_agent_container._state.host_config import PeersMap
+
+        peers = PeersMap()
+        peers["spartan-*"] = PeerSpec(name="spartan-*", ssh="")
+        # Act
+        kind, peer = classify_dispatch_host(
+            "spartan-bm999", "ywata-note-win", peers
+        )
+        # Assert
+        assert (kind, peer) == ("remote", "spartan-bm999")
+
+
+# ---------------------------------------------------------------------------
+# _local_host_names — impure adapter unioning the two hostname authorities.
+# No-mocks: a real config.yaml fixture via $SCITEX_AGENT_CONTAINER_CONFIG.
+# ---------------------------------------------------------------------------
+
+
+class TestLocalHostNames:
+    def test_includes_current_host_argument(self):
+        # Arrange
+        current = "passed-in-host"
+        # Act
+        names = _local_host_names(current)
+        # Assert
+        assert "passed-in-host" in names
+
+    def test_includes_config_canonical_and_alias(
+        self, tmp_path: Path, env_save_restore
+    ):
+        # Arrange — real config.yaml: canonical name + an alias for the short
+        # hostname this test process actually reports.
+        import socket
+
+        short = socket.gethostname().split(".")[0]
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text(
+            "host:\n"
+            "  canonical: box-canonical\n"
+            "  aliases:\n"
+            f"    {short}: box-alias\n"
+        )
+        env_save_restore.set("SCITEX_AGENT_CONTAINER_CONFIG", str(cfg))
+        # Act
+        names = _local_host_names()
+        # Assert — $SAC_HOST unset, so canonical_host() returns host.canonical.
+        assert "box-canonical" in names
+
+    def test_never_raises_without_config(self, tmp_path: Path, env_save_restore):
+        # Arrange — point at a nonexistent config; must degrade, not raise.
+        env_save_restore.set(
+            "SCITEX_AGENT_CONTAINER_CONFIG", str(tmp_path / "missing.yaml")
+        )
+        # Act
+        names = _local_host_names("host-x")
+        # Assert — still returns the short hostname + the passed current_host.
+        assert "host-x" in names and names

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__dispatch.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__dispatch.py
@@ -21,11 +21,15 @@ from typing import Any
 
 import pytest
 
+from scitex_agent_container._state.host_config import PeerSpec
 from scitex_agent_container.cli_pkg.lifecycle._dispatch import (
     _dispatch_remote_start,
     lookup_remote_peer,
+    try_dispatch,
     try_dispatch_remote,
 )
+from scitex_agent_container.config import AgentConfig
+from scitex_agent_container.config._types import HostsSpec
 
 # ---------------------------------------------------------------------------
 # Shim helpers — dual-behavior rsync (dry-run vs real) plus a fake ssh.
@@ -741,3 +745,141 @@ class TestTryDispatchRemote:
         # Assert
         with pytest.raises(RuntimeError, match="NOT in"):
             _do()
+
+
+# ---------------------------------------------------------------------------
+# try_dispatch — concrete-host routing: local (no ssh) / remote (ssh argv) /
+# unknown (fail loud). local + unknown reach no ssh; the remote path reuses
+# the PATH-shim ssh + rsync (no live network) to assert the constructed argv.
+# ``local_names`` is injected so routing is hermetic (no host_config read).
+# ---------------------------------------------------------------------------
+
+
+def _cfg_host(name: str, host) -> AgentConfig:
+    """AgentConfig carrying a v3 ``spec.host`` pin (str / list / '')."""
+    c = AgentConfig(name=name)
+    c.hosts_spec = HostsSpec(host=host, hosts=[])
+    return c
+
+
+class TestTryDispatchClassification:
+    def test_canonical_host_stays_local_and_skips_ssh(self, shim_bin, capsys):
+        # Arrange — host == this machine; an ssh shim is present to prove it
+        # is never invoked, and a peer map that would NOT rescue the name.
+        _install_ssh_shim(shim_bin, stdout=_OK_JSON, exit=0)
+        cfg = _cfg_host("alpha", "ywata-note-win")
+        peers = {"peer-host": PeerSpec(name="peer-host", ssh="peer-host")}
+        # Act
+        out = try_dispatch(
+            cfg,
+            "ywata-note-win",
+            peers,
+            dry_run=False,
+            force=False,
+            local_names={"ywata-note-win"},
+        )
+        # Assert
+        assert out is False and _ssh_invocations(shim_bin) == []
+
+    def test_alias_of_self_that_is_also_a_peer_stays_local(self, shim_bin, capsys):
+        # Arrange — the machine is ALSO a peer (ssh: localhost); an alias
+        # spelling must resolve local, never ssh-dispatch to itself.
+        _install_ssh_shim(shim_bin, stdout=_OK_JSON, exit=0)
+        cfg = _cfg_host("alpha", "ywata-note-win")
+        peers = {"ywata-note-win": PeerSpec(name="ywata-note-win", ssh="localhost")}
+        # Act
+        out = try_dispatch(
+            cfg,
+            "raw-short-name",
+            peers,
+            dry_run=False,
+            force=False,
+            local_names={"raw-short-name", "ywata-note-win"},
+        )
+        # Assert
+        assert out is False and _ssh_invocations(shim_bin) == []
+
+    def test_absent_host_stays_local(self, shim_bin, capsys):
+        # Arrange — host: local / absent normalizes to '' upstream.
+        _install_ssh_shim(shim_bin, stdout=_OK_JSON, exit=0)
+        cfg = _cfg_host("alpha", "")
+        peers = {"peer-host": PeerSpec(name="peer-host", ssh="peer-host")}
+        # Act
+        out = try_dispatch(
+            cfg,
+            "ywata-note-win",
+            peers,
+            dry_run=False,
+            force=False,
+            local_names={"ywata-note-win"},
+        )
+        # Assert
+        assert out is False and _ssh_invocations(shim_bin) == []
+
+    def test_unknown_host_falls_through_to_local_returning_false(self, capsys):
+        # Arrange — host is a typo: neither this machine nor a peer key. It
+        # must NOT dispatch; try_dispatch returns False so the caller runs the
+        # unchanged singleton-skip logic (skip-if-live-elsewhere, else local).
+        cfg = _cfg_host("alpha", "spartn-gpgpu")
+        peers = {"peer-host": PeerSpec(name="peer-host", ssh="peer-host")}
+        # Act
+        out = try_dispatch(
+            cfg,
+            "ywata-note-win",
+            peers,
+            dry_run=False,
+            force=False,
+            local_names={"ywata-note-win"},
+        )
+        # Assert
+        assert out is False
+
+    def test_unknown_host_never_dispatches_ssh(self, shim_bin, capsys):
+        # Arrange — an ssh shim is present; the unknown path must not touch it
+        # (negative-safety: an unknown host is never routed to ssh).
+        _install_ssh_shim(shim_bin, stdout=_OK_JSON, exit=0)
+        cfg = _cfg_host("alpha", "spartn-gpgpu")
+        peers = {"peer-host": PeerSpec(name="peer-host", ssh="peer-host")}
+        # Act
+        try_dispatch(
+            cfg,
+            "ywata-note-win",
+            peers,
+            dry_run=False,
+            force=False,
+            local_names={"ywata-note-win"},
+        )
+        # Assert
+        assert _ssh_invocations(shim_bin) == []
+
+    def test_known_peer_dispatches_remote_with_expected_ssh_argv(
+        self, spec_dir, shim_bin, state_db, fake_home, env_save_restore, capsys
+    ):
+        # Arrange — host is a known peer distinct from the caller; PATH-shim
+        # rsync (clean first-launch) + ssh (ok JSON) stand in for the network.
+        # _dispatch_remote_start re-loads peers from the on-disk config for
+        # build_ssh_argv, so register peer-host there too (real config.yaml).
+        _write_peer_config(fake_home, env_save_restore, peer="peer-host")
+        _install_rsync_shim(shim_bin, **_RK_OK)
+        _install_ssh_shim(shim_bin, **_SK_OK)
+        cfg = _cfg_host("alpha", "peer-host")
+        peers = {"peer-host": PeerSpec(name="peer-host", ssh="peer-host")}
+        # Act
+        out = try_dispatch(
+            cfg,
+            "ywata-note-win",
+            peers,
+            dry_run=False,
+            force=False,
+            local_names={"ywata-note-win"},
+        )
+        # Assert — dispatched, and the ssh argv runs the peer-side start verb.
+        ssh_calls = _ssh_invocations(shim_bin)
+        assert out is True and ssh_calls[0][-6:] == [
+            "sac",
+            "agents",
+            "start",
+            "alpha",
+            "--no-redispatch",
+            "--json",
+        ]


### PR DESCRIPTION
## Summary

Realizes the operator's **concrete-hostname** model for `spec.host`: a spec names a
canonical machine and `sac agents start` resolves *where that host is* — the current
machine (local launch) or a known peer (remote ssh dispatch). Hardens the resolver so a
bulk rename of specs from `host: local` to `host: <canonical-name>` is safe **by
construction**, not by luck of string equality.

## STEP-1 finding — cross-host dispatch is ALREADY fully wired

`sac agents start <name>` already routes local-vs-remote from `spec.host`:
`_start.py::start` → `_start_single.py::run_single_targets` → `_dispatch.py::try_dispatch`
(single-target path only; bulk/parallel use `--no-redispatch`) → `_dispatch_remote_start`
does rsync + `ssh <peer> sac agents start --no-redispatch --json` (via `build_ssh_argv`,
honoring `~/.ssh` config + `via` ProxyJump + `env_preamble`) + a lead-side
`state.db.instances` row. `host: <peer>` → remote and `host: local`/absent → local
already worked. The gap was the *resolution*, not the dispatch.

## Equivalence answer (gates the 85-spec rename): YES

`host: ywata-note-win` (== canonical) IS dispatched to the LOCAL path identically to
`host: local`, now **by construction**. Proof:

- `config/_parsers/_hosts.py::parse_hosts_spec` normalizes literal `host: local` → `""`;
  `host: ywata-note-win` stays the string.
- `_dispatch.py::try_dispatch` → `_common.classify_dispatch_host`: `""`→None→`local`;
  `ywata-note-win` matches `local_names` (this machine's canonical/alias union) → `local`.
  Both return `("local", …)` → `try_dispatch` returns `False` → the SAME unchanged
  `agent_start` local launch.

Before this PR the equivalence was conditional on `resolve_hostname() == "ywata-note-win"`
exactly, and because `ywata-note-win` is itself a peer key (`ssh: localhost`), any drift
between the two hostname resolvers would send it down the `target_host in peers` branch →
a remote ssh-dispatch to localhost. This PR removes that fragility.

## Change (pure resolution layer, `cli_pkg/lifecycle/_common.py`)

- `classify_dispatch_host(target, current, peers, local_names) -> (local|remote|unknown, peer)`.
  The **local check precedes the peer table** → a self-registered peer is never
  ssh-dispatched to itself.
- `_local_host_names` unions BOTH hostname authorities (host_config canonical + this
  machine's aliases + `resolve_hostname` + short hostname) → `host: <canonical-or-alias>`
  classifies local regardless of resolver drift.
- `try_dispatch` dispatches ONLY a resolved remote peer; `local` and `unknown` both
  return `False` → UNCHANGED local path. An unknown host is never routed to ssh; it
  defers to the existing liveness-gated singleton-skip (skip if live on the pinned host,
  else the documented **bm025** stale-binding fall-through to a local start). The 40
  running agents + the multi-host fleet skip pattern are byte-for-byte unaffected.

`_resolve_dispatch_peer` preserved as a thin delegating wrapper (its 8 tests pass
unchanged). Reuses `host_config` / `build_ssh_argv` / `ssh_control_options` — no new SSH
machinery.

## Tests (no mocks)

`classify_dispatch_host` (local/current/alias/peer/glob-peer/unknown + local-wins-over-peer);
`_local_host_names` vs a real `config.yaml` fixture; `try_dispatch` routing — canonical +
alias + absent stay local (ssh shim never called), unknown falls through to local without
ssh, known-peer dispatches with the expected peer-side ssh argv via PATH-shim ssh/rsync.

Full `cli_pkg/lifecycle/` + `_network/test_peer_dispatch_ledger.py` +
`config/_parsers/test__hosts.py`: **406 passed**. `scitex-dev ecosystem audit-all
scitex-agent-container`: clean (CLI / skills / Python-API / project).

## Docs

`11_remote-deploy.md`: concrete-hostname resolution table + local-wins-over-peer rule.

## Residual (separate decision)

A fail-LOUD error on a truly unknown/typo host was scoped out: it conflicts with the
documented **bm025** fix (unknown + no live row → fall through to local so the agent runs
somewhere rather than hang). Distinguishing "typo" from "real fleet host I don't peer
with" needs a global host registry sac lacks. The classifier returns a distinct `unknown`
so a future policy can opt in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
