### PR TITLE
feat(versions): sac versions --json for fleet drift-report

### DIFF
--- a/src/scitex_agent_container/_drift/__init__.py
+++ b/src/scitex_agent_container/_drift/__init__.py
@@ -24,6 +24,11 @@ from ._local import (
     warn_if_spec_source_drifted,
 )
 from ._status import DriftState, DriftStatus
+from .versions import (
+    collect_versions,
+    discover_base_sifs,
+    record_overlay_manifest,
+)
 
 __all__ = [
     "DriftState",
@@ -33,7 +38,10 @@ __all__ = [
     "check_fleet_drift",
     "check_peer_drift",
     "check_spec_source_drift",
+    "collect_versions",
+    "discover_base_sifs",
     "drift_warning_lines",
+    "record_overlay_manifest",
     "spec_source_repo",
     "warn_if_spec_source_drifted",
 ]

--- a/src/scitex_agent_container/_drift/versions.py
+++ b/src/scitex_agent_container/_drift/versions.py
@@ -1,0 +1,465 @@
+"""scitex-* version introspection across the image layers sac owns.
+
+scitex-dev's ``ecosystem check-versions`` reports scitex-* package
+versions across 6 layers (PyPI, GitHub, both hosts' venvs, CI, editable)
+but cannot see the 2 layers only sac owns:
+
+* **base-image** — the shared ``/opt/venv-sac`` venv baked into each base
+  SIF (``sac-base`` / ``sac-scitex``). One set per base image, ``agent="*"``.
+* **agent-overlay** — the scitex-* packages an individual agent's writable
+  overlay *adds or overrides* vs its base venv. Usually empty — most agents
+  run straight on the shared base venv, so their overlay upper carries no
+  extra site-packages.
+
+This module exposes both as a flat list of rows so scitex-dev's drift
+aggregator can fold sac's 2 layers in with the other 6. Each row::
+
+    {agent, layer, image, package, version, source}
+
+* ``layer``  ∈ {"base-image", "agent-overlay"}
+* ``image``  — the base SIF name on EVERY row (disambiguates multiple base
+  images and maps agent → base).
+* ``source`` ∈ {"manifest", "live"} — "manifest" reads a baked version
+  manifest (near-zero cost, the routine path); "live" is produced by an
+  actual ``pip list`` / site-packages scan (ground truth).
+
+sac emits RAW base + overlay rows; it does NOT compute the "effective"
+(overlay-else-base) view — that derivation is the aggregator's job.
+
+Resilience doctrine (mirrors :mod:`._local`): never raise. A missing
+apptainer binary, an unbuilt SIF, an unreadable overlay — all degrade to
+"skip that image / agent", never a crash. ``sac versions --json --live``
+must always emit valid JSON.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+from pathlib import Path
+from typing import Iterable
+
+logger = logging.getLogger(__name__)
+
+# Path of the baked manifest INSIDE a base SIF, written by the apptainer
+# ``.def`` ``%post`` step (``containers/apptainer-*.def``). Read via
+# ``apptainer exec <sif> cat <this>`` — near-zero cost vs a full pip list.
+BAKED_MANIFEST_PATH = "/opt/scitex-versions.json"
+
+# The venv every sac SIF ships its Python stack in (see apptainer-*.def:
+# ``python3 -m venv /opt/venv-sac``).
+DEFAULT_VENV = "/opt/venv-sac"
+
+# Base image assumed when an agent's spec leaves ``apptainer.image`` empty
+# (ApptainerSpec.image docstring: "Empty = fall back to the default
+# sac-scitex SIF").
+DEFAULT_BASE_IMAGE = "sac-scitex"
+
+# Per-agent overlay manifest filename, recorded next to the overlay dir at
+# overlay-setup time (see :func:`record_overlay_manifest`).
+OVERLAY_MANIFEST_NAME = "scitex-overlay-versions.json"
+
+# Apptainer directory overlays keep the writable layer under ``upper/``.
+_OVERLAY_UPPER = "upper"
+
+# Overridable so a caller / test can point at a different runtime binary.
+_APPTAINER_BIN = "apptainer"
+_EXEC_TIMEOUT_S = 30
+
+LAYER_BASE = "base-image"
+LAYER_OVERLAY = "agent-overlay"
+SOURCE_MANIFEST = "manifest"
+SOURCE_LIVE = "live"
+
+
+# ---------------------------------------------------------------------------
+# scitex-* filtering + normalisation (pure helpers)
+# ---------------------------------------------------------------------------
+def is_scitex_package(name: str) -> bool:
+    """True for ``scitex`` and any ``scitex-*`` / ``scitex_*`` dist name."""
+    n = (name or "").strip().lower().replace("_", "-")
+    return n == "scitex" or n.startswith("scitex-")
+
+
+def _canonical(name: str) -> str:
+    return (name or "").strip().lower().replace("_", "-")
+
+
+def normalize_pkg_list(raw) -> list[dict]:
+    """Normalise a ``pip list --format=json`` list (or a baked manifest)
+    down to a sorted ``[{"package", "version"}]`` of scitex-* rows only.
+
+    Accepts either pip's ``[{"name", "version"}, ...]`` shape or a plain
+    ``{name: version}`` mapping (tolerant of hand-written manifests).
+    """
+    if isinstance(raw, dict):
+        items: Iterable = ({"name": k, "version": v} for k, v in raw.items())
+    else:
+        items = raw or []
+    out: dict[str, str] = {}
+    for row in items:
+        try:
+            name = str(row["name"])
+            version = str(row["version"])
+        except (KeyError, TypeError):
+            continue
+        if is_scitex_package(name):
+            out[_canonical(name)] = version
+    return [{"package": p, "version": out[p]} for p in sorted(out)]
+
+
+def _pkg_map(rows: list[dict]) -> dict[str, str]:
+    return {r["package"]: r["version"] for r in rows}
+
+
+def overlay_adds(overlay_pkgs: list[dict], base_map: dict[str, str]) -> list[dict]:
+    """Rows in ``overlay_pkgs`` that ADD or OVERRIDE vs ``base_map``.
+
+    A row survives when its ``(package, version)`` is absent from the base
+    set OR present at a different version — i.e. the overlay genuinely
+    changed it. Packages the overlay carries identically to base are
+    dropped (no drift to report).
+    """
+    return [r for r in overlay_pkgs if base_map.get(r["package"]) != r["version"]]
+
+
+# ---------------------------------------------------------------------------
+# apptainer exec seam (real subprocess; PATH-driven so tests use a shim)
+# ---------------------------------------------------------------------------
+def _apptainer_exec(sif, inner_argv: list[str], *, timeout: int = _EXEC_TIMEOUT_S):
+    """Run ``apptainer exec <sif> <inner...>``; return CompletedProcess or None.
+
+    Real subprocess — no mocks. PATH resolves the ``apptainer`` binary; tests
+    install a fake ``apptainer`` on PATH. Never raises: a missing binary,
+    timeout, or OS error degrades to ``None`` (the caller treats that the
+    same as "could not read").
+    """
+    try:
+        return subprocess.run(
+            [_APPTAINER_BIN, "exec", str(sif), *inner_argv],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        logger.debug("apptainer exec failed for %s: %s", sif, exc)
+        return None
+
+
+def _parse_json_stdout(cp) -> list[dict] | None:
+    if cp is None or cp.returncode != 0 or not (cp.stdout or "").strip():
+        return None
+    try:
+        return normalize_pkg_list(json.loads(cp.stdout))
+    except json.JSONDecodeError:
+        return None
+
+
+def read_base_manifest(sif) -> list[dict] | None:
+    """Near-zero-cost read of the baked ``/opt/scitex-versions.json``.
+
+    Returns the scitex-* rows, or ``None`` when the manifest is absent
+    (older images not yet rebuilt) so the caller falls back to live.
+    """
+    return _parse_json_stdout(_apptainer_exec(sif, ["cat", BAKED_MANIFEST_PATH]))
+
+
+def read_base_live(sif, venv: str = DEFAULT_VENV) -> list[dict] | None:
+    """Ground-truth read via ``<venv>/bin/pip list --format=json`` in the SIF."""
+    return _parse_json_stdout(
+        _apptainer_exec(sif, [f"{venv}/bin/pip", "list", "--format=json"])
+    )
+
+
+# ---------------------------------------------------------------------------
+# base-image layer
+# ---------------------------------------------------------------------------
+def default_containers_dir() -> Path:
+    """sac's built-artifact dir (SSoT: ``cli_pkg.image_group._CONTAINERS_DIR``)."""
+    return Path.home() / ".scitex" / "agent-container" / "containers"
+
+
+def discover_base_sifs(containers_dir=None) -> list[tuple[str, Path]]:
+    """Discover base SIFs as sorted ``(image_name, sif_path)`` tuples.
+
+    Mirrors ``sac image list`` discovery. The atomic builder lands, for each
+    layer, BOTH a top-level ``<containers>/sac-<layer>.sif`` symlink (what a
+    layered ``.def``'s ``From: ./sac-base.sif`` and the ``sac create``
+    template resolve against) AND a nested ``<containers>/sac-<layer>/
+    sac-<layer>.sif`` boot symlink, both pointing at the same timestamped
+    target. We glob both, key by the SIF stem (e.g. ``"sac-base"``,
+    ``"sac-scitex"``), and emit ONE entry per name — the top-level symlink
+    wins so we return the canonical path agents reference. Falls back to any
+    ``*.sif`` inside a per-layer subdir when no stable symlink exists.
+    """
+    root = Path(containers_dir) if containers_dir else default_containers_dir()
+    if not root.is_dir():
+        return []
+    found: dict[str, Path] = {}
+    # 1. Top-level symlinks (canonical, agent-referenced) win.
+    for sif in sorted(root.glob("*.sif")):
+        found.setdefault(sif.stem, sif)
+    # 2. Nested per-layer dirs fill in anything not already seen.
+    for sub in sorted(p for p in root.iterdir() if p.is_dir()):
+        stable = sub / f"{sub.name}.sif"
+        if stable.exists():
+            found.setdefault(sub.name, stable)
+            continue
+        others = sorted(sub.glob("*.sif"))
+        if others:
+            found.setdefault(sub.name, others[0])
+    return [(name, found[name]) for name in sorted(found)]
+
+
+def base_image_rows(containers_dir=None, *, live: bool = False):
+    """Return ``(rows, base_maps)`` for the base-image layer.
+
+    ``base_maps[image_name] = {package: version}`` is fed to the overlay
+    diff so agent-overlay rows only show genuine adds/overrides.
+
+    When ``live`` is False the routine manifest path is tried first
+    (source="manifest") and falls back to a live ``pip list`` per image.
+    ``live=True`` forces the ground-truth pip-list read (source="live") —
+    the path that produces real output on images not yet rebuilt with the
+    baked manifest.
+    """
+    rows: list[dict] = []
+    base_maps: dict[str, dict] = {}
+    for name, sif in discover_base_sifs(containers_dir):
+        pkgs = None
+        source = SOURCE_LIVE
+        if not live:
+            pkgs = read_base_manifest(sif)
+            if pkgs is not None:
+                source = SOURCE_MANIFEST
+        if pkgs is None:
+            pkgs = read_base_live(sif)
+            source = SOURCE_LIVE
+        if pkgs is None:
+            logger.warning(
+                "versions: could not read scitex-* versions from base image "
+                "%s (%s) — apptainer missing or SIF unbuilt?",
+                name,
+                sif,
+            )
+            base_maps[name] = {}
+            continue
+        base_maps[name] = _pkg_map(pkgs)
+        for row in pkgs:
+            rows.append(
+                {
+                    "agent": "*",
+                    "layer": LAYER_BASE,
+                    "image": name,
+                    "package": row["package"],
+                    "version": row["version"],
+                    "source": source,
+                }
+            )
+    return rows, base_maps
+
+
+# ---------------------------------------------------------------------------
+# agent-overlay layer
+# ---------------------------------------------------------------------------
+def agent_base_image_name(config, default: str = DEFAULT_BASE_IMAGE) -> str:
+    """Map an ``AgentConfig`` to the base SIF *name* it runs on.
+
+    ``apptainer.image`` may be empty (→ default), a path
+    (``/x/sac-base.sif`` → ``sac-base``), or a ``docker://`` ref
+    (``docker://org/sac-scitex:tag`` → ``sac-scitex``).
+    """
+    ap = getattr(config, "apptainer", None)
+    image = (getattr(ap, "image", "") or "").strip() if ap is not None else ""
+    if not image:
+        return default
+    ref = image.split("://", 1)[-1]
+    stem = Path(ref).name
+    for suffix in (".sif", ".sandbox"):
+        if stem.endswith(suffix):
+            stem = stem[: -len(suffix)]
+    stem = stem.split(":", 1)[0]  # strip a docker tag
+    return stem or default
+
+
+def _overlay_dir(config) -> Path | None:
+    """Resolve the agent's directory-form overlay path, or None.
+
+    Reuses ``runtimes._to_home_overlay._resolve_overlay_dir`` (the exact
+    resolver the launch path uses) so there is no second source of truth
+    for "where is this agent's overlay".
+    """
+    from ..runtimes._to_home_overlay import _resolve_overlay_dir
+
+    return _resolve_overlay_dir(config)
+
+
+def _overlay_venv_root(overlay_dir: Path) -> Path:
+    """Host-side path where writes to ``/opt/venv-sac`` land in the overlay."""
+    return overlay_dir / _OVERLAY_UPPER / DEFAULT_VENV.lstrip("/")
+
+
+def _overlay_manifest_path(overlay_dir: Path) -> Path:
+    return overlay_dir / OVERLAY_MANIFEST_NAME
+
+
+def scan_venv_scitex(venv_root: Path) -> list[dict]:
+    """Scan a host-visible venv dir for scitex-* ``*.dist-info``.
+
+    Reads ``<venv_root>/lib/python*/site-packages/*.dist-info`` directory
+    names (``<Name>-<Version>.dist-info``) — no subprocess, since an agent's
+    overlay upperdir is a plain host directory. Returns ``[]`` when the venv
+    root is absent (the common case: agents share the read-only base venv,
+    so their overlay upper carries no ``/opt/venv-sac``).
+    """
+    if not venv_root.is_dir():
+        return []
+    out: dict[str, str] = {}
+    for site in venv_root.glob("lib/python*/site-packages"):
+        for dist_info in site.glob("*.dist-info"):
+            stem = dist_info.name[: -len(".dist-info")]
+            name, _, version = stem.rpartition("-")
+            if name and version and is_scitex_package(name):
+                out[_canonical(name)] = version
+    return [{"package": p, "version": out[p]} for p in sorted(out)]
+
+
+def _read_overlay_pkgs(overlay_dir: Path, *, live: bool) -> tuple[list[dict], str]:
+    """Return ``(overlay_scitex_pkgs, source)`` for one agent's overlay."""
+    if not live:
+        manifest = _overlay_manifest_path(overlay_dir)
+        if manifest.is_file():
+            try:
+                return (
+                    normalize_pkg_list(json.loads(manifest.read_text())),
+                    SOURCE_MANIFEST,
+                )
+            except (OSError, json.JSONDecodeError) as exc:
+                logger.debug("versions: bad overlay manifest %s: %s", manifest, exc)
+    return scan_venv_scitex(_overlay_venv_root(overlay_dir)), SOURCE_LIVE
+
+
+def agent_overlay_rows(agent_configs, base_maps, *, live: bool = False) -> list[dict]:
+    """Overlay rows for ``agent_configs`` (iterable of ``(name, config)``).
+
+    Emits ONLY the scitex-* packages an agent's overlay adds or overrides
+    vs the base image it runs on. Agents with no overlay, or whose overlay
+    matches base, contribute no rows.
+    """
+    rows: list[dict] = []
+    for name, config in agent_configs:
+        try:
+            overlay_dir = _overlay_dir(config)
+        except Exception as exc:  # stx-allow: fallback (reason: never crash the sweep on one agent's malformed spec)
+            logger.debug("versions: overlay resolve failed for %s: %s", name, exc)
+            continue
+        if overlay_dir is None:
+            continue
+        image = agent_base_image_name(config)
+        overlay_pkgs, source = _read_overlay_pkgs(overlay_dir, live=live)
+        for row in overlay_adds(overlay_pkgs, base_maps.get(image, {})):
+            rows.append(
+                {
+                    "agent": name,
+                    "layer": LAYER_OVERLAY,
+                    "image": image,
+                    "package": row["package"],
+                    "version": row["version"],
+                    "source": source,
+                }
+            )
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# record side — per-agent overlay manifest (near-zero manifest path forward)
+# ---------------------------------------------------------------------------
+def record_overlay_manifest(config) -> Path | None:
+    """Record the overlay's scitex-* set to ``<overlay>/<manifest>``.
+
+    Wired into the overlay-setup path (``runtimes._to_home_overlay
+    .deploy_to_home_overlay``) so a later ``sac versions`` reads it as
+    ``source="manifest"`` instead of re-scanning. Captures whatever the
+    overlay venv holds at record time (empty for a fresh overlay). Returns
+    the written path or ``None``; best-effort, never raises.
+    """
+    try:
+        overlay_dir = _overlay_dir(config)
+        if overlay_dir is None:
+            return None
+        pkgs = scan_venv_scitex(_overlay_venv_root(overlay_dir))
+        overlay_dir.mkdir(parents=True, exist_ok=True)
+        path = _overlay_manifest_path(overlay_dir)
+        path.write_text(json.dumps(pkgs, indent=2))
+        return path
+    except Exception as exc:  # stx-allow: fallback (reason: provenance recording must never break a launch)
+        logger.debug("versions: record_overlay_manifest failed: %s", exc)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# top-level assembly
+# ---------------------------------------------------------------------------
+def _load_agent_configs() -> list[tuple[str, object]]:
+    """Enumerate every discoverable agent as ``(name, AgentConfig)``.
+
+    Best-effort: a spec that fails to load is skipped (logged at debug),
+    never fatal — the sweep must survive one malformed agent.
+    """
+    from ..config import load_config, resolve_config
+    from ..config._resolve import enumerate_agent_names
+
+    out: list[tuple[str, object]] = []
+    try:
+        names = enumerate_agent_names()
+    except Exception as exc:  # stx-allow: fallback (reason: an ambiguous/missing registry yields zero agents, not a crash)
+        logger.debug("versions: enumerate_agent_names failed: %s", exc)
+        return out
+    for name in names:
+        try:
+            out.append((name, load_config(resolve_config(name))))
+        except Exception as exc:  # stx-allow: fallback (reason: skip one bad spec, keep sweeping)
+            logger.debug("versions: skip agent %s (config load failed): %s", name, exc)
+    return out
+
+
+def collect_versions(
+    *, live: bool = False, containers_dir=None, agent_configs=None
+) -> list[dict]:
+    """The flat ``[{agent, layer, image, package, version, source}]`` list.
+
+    ``live`` forces ground-truth pip-list / venv-scan reads (source="live").
+    ``containers_dir`` / ``agent_configs`` are injectable seams for tests;
+    production leaves them ``None`` (real containers dir + real registry).
+    """
+    rows, base_maps = base_image_rows(containers_dir, live=live)
+    if agent_configs is None:
+        agent_configs = _load_agent_configs()
+    rows.extend(agent_overlay_rows(agent_configs, base_maps, live=live))
+    return rows
+
+
+__all__ = [
+    "BAKED_MANIFEST_PATH",
+    "DEFAULT_BASE_IMAGE",
+    "DEFAULT_VENV",
+    "LAYER_BASE",
+    "LAYER_OVERLAY",
+    "OVERLAY_MANIFEST_NAME",
+    "SOURCE_LIVE",
+    "SOURCE_MANIFEST",
+    "agent_base_image_name",
+    "agent_overlay_rows",
+    "base_image_rows",
+    "collect_versions",
+    "discover_base_sifs",
+    "is_scitex_package",
+    "normalize_pkg_list",
+    "overlay_adds",
+    "read_base_live",
+    "read_base_manifest",
+    "record_overlay_manifest",
+    "scan_venv_scitex",
+]

--- a/src/scitex_agent_container/cli_pkg/_main.py
+++ b/src/scitex_agent_container/cli_pkg/_main.py
@@ -48,7 +48,7 @@ COMMAND_CATEGORIES = [
     ("Build & Install", ["image", "installation"]),
     ("Diagnostics", ["doctor"]),
     ("Remote testing", ["pytest"]),
-    ("Introspection", ["mcp", "list-python-apis", "skills"]),
+    ("Introspection", ["mcp", "list-python-apis", "skills", "versions"]),
     ("Developer", ["dev"]),
 ]
 
@@ -90,6 +90,10 @@ class _MainGroup(LazyGroup):
         # Top-level standalone
         "list-python-apis": f"{_PKG}.info_cmds:list_python_apis",
         "installation": f"{_PKG}.installation_group:install_group",
+        # scitex-* version introspection across sac's base + overlay layers
+        # (drift-report aggregation surface for scitex-dev ecosystem
+        # check-versions — the 2 layers only sac can see).
+        "versions": f"{_PKG}.versions_cmds:versions",
     }
 
     # Tracks whether scitex_dev._cli._completion has been attached.

--- a/src/scitex_agent_container/cli_pkg/versions_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/versions_cmds.py
@@ -1,0 +1,100 @@
+"""``sac versions`` — scitex-* versions across the layers sac owns.
+
+scitex-dev's ``ecosystem check-versions`` reports scitex-* versions across
+6 layers (PyPI, GitHub, both hosts' venvs, CI, editable) but cannot see the
+2 layers only sac owns: the shared base-image venv and the per-agent overlay
+venvs. This verb exposes those as a flat JSON list so scitex-dev's drift
+aggregator can fold all 8 together.
+
+Contract — a flat list of ``{agent, layer, image, package, version, source}``:
+  * ``layer``  ∈ {"base-image", "agent-overlay"}
+  * base-image rows: ``agent="*"``, one set per base SIF; ``image`` = the SIF
+    name (e.g. "sac-base", "sac-scitex").
+  * agent-overlay rows: ``agent=<name>``, ONLY the scitex-* packages the
+    agent's overlay adds/overrides vs its base (usually empty); ``image`` =
+    the base SIF that agent runs on.
+  * ``source`` ∈ {"manifest", "live"}.
+
+sac emits RAW base + overlay rows; scitex-dev's aggregator derives the
+"effective" (overlay-else-base) view.
+"""
+
+from __future__ import annotations
+
+import json as _json
+
+import click
+
+from .._drift.versions import LAYER_BASE, collect_versions
+
+# Column order for the optional human-readable table.
+_COLUMNS = ("agent", "layer", "image", "package", "version", "source")
+
+
+def _render_table(rows: list[dict]) -> str:
+    """Render rows as a fixed-width table (nice-to-have; --json is canonical)."""
+    if not rows:
+        return "(no scitex-* versions discovered)"
+    widths = {
+        col: max(len(col), *(len(str(r.get(col, ""))) for r in rows))
+        for col in _COLUMNS
+    }
+    header = "  ".join(col.upper().ljust(widths[col]) for col in _COLUMNS)
+    sep = "  ".join("-" * widths[col] for col in _COLUMNS)
+    lines = [header, sep]
+    for r in rows:
+        lines.append(
+            "  ".join(str(r.get(col, "")).ljust(widths[col]) for col in _COLUMNS)
+        )
+    return "\n".join(lines)
+
+
+@click.command("versions")
+@click.option(
+    "--json/--table",
+    "as_json",
+    default=True,
+    help="Emit the flat JSON list (default, the LOCKED contract) or a "
+    "human-readable table.",
+)
+@click.option(
+    "--live",
+    is_flag=True,
+    default=False,
+    help="Force ground-truth reads (exec `pip list` per base SIF, scan each "
+    "overlay venv) instead of the near-zero baked-manifest path. This is "
+    "what produces real output on images not yet rebuilt with the manifest.",
+)
+@click.option(
+    "--containers-dir",
+    default=None,
+    help="Override the base-image containers dir "
+    "(default: ~/.scitex/agent-container/containers). Mainly for testing.",
+)
+@click.option(
+    "--base-only",
+    is_flag=True,
+    default=False,
+    help="Emit only the base-image layer (skip per-agent overlay enumeration).",
+)
+def versions(as_json, live, containers_dir, base_only):
+    """Report scitex-* package versions for sac's base + overlay layers.
+
+    \b
+    Examples:
+      $ sac versions --json                 # baked-manifest path (routine)
+      $ sac versions --json --live          # ground-truth exec pip-list
+      $ sac versions --table                # human-readable
+    """
+    rows = collect_versions(
+        live=live,
+        containers_dir=containers_dir,
+        agent_configs=[] if base_only else None,
+    )
+    if as_json:
+        click.echo(_json.dumps(rows, indent=2))
+    else:
+        click.echo(_render_table(rows))
+
+
+__all__ = ["versions", "LAYER_BASE"]

--- a/src/scitex_agent_container/containers/apptainer-base.def
+++ b/src/scitex_agent_container/containers/apptainer-base.def
@@ -372,6 +372,21 @@ From: ubuntu:24.04
     # Fail loud if the build did not produce a working binary.
     /opt/cargo/bin/rtk --version
 
+    # ---- 8. Bake the scitex-* version manifest (`sac versions`) --------
+    # `sac versions --json` reads this baked manifest (source="manifest",
+    # near-zero cost — a `cat`, not a full `pip list`) so scitex-dev's
+    # ecosystem drift aggregator can see the base-image venv layer cheaply.
+    # The verb falls back to a live `apptainer exec <sif> pip list` when
+    # this file is absent (older images not yet rebuilt), so shipping it is
+    # purely additive. Filtered to the scitex-* ecosystem packages; written
+    # in pip's own `--format=json` shape so the reader parses both paths
+    # identically. Pure pipe + `python -c` (dash-safe — apptainer %post runs
+    # under /bin/sh, which has no bash process substitution).
+    /opt/venv-sac/bin/pip list --format=json \
+        | /opt/venv-sac/bin/python -c 'import json,sys; rows=[r for r in json.load(sys.stdin) if str(r.get("name","")).lower().replace("_","-").split("-")[0]=="scitex"]; json.dump(sorted(rows,key=lambda r:str(r.get("name","")).lower()), sys.stdout, indent=2)' \
+        > /opt/scitex-versions.json
+    cat /opt/scitex-versions.json
+
 %environment
     export LANG=en_US.UTF-8
     export LC_ALL=en_US.UTF-8

--- a/src/scitex_agent_container/containers/apptainer-scitex.def
+++ b/src/scitex_agent_container/containers/apptainer-scitex.def
@@ -253,6 +253,21 @@ EOF
     # at a removed path). No new python is installed — this is a guard.
     /usr/bin/python3 --version
 
+    # ---- 6. Bake the scitex-* version manifest (`sac versions`) --------
+    # `sac versions --json` reads this baked manifest (source="manifest",
+    # near-zero cost — a `cat`, not a full `pip list`) so scitex-dev's
+    # ecosystem drift aggregator can see the base-image venv layer cheaply.
+    # The verb falls back to a live `apptainer exec <sif> pip list` when
+    # this file is absent (older images), so shipping it is purely additive.
+    # This layer's scitex[all] + scitex-dev/-writer/-audio/-cv make the
+    # manifest much richer than :base. Filtered to scitex-* and written in
+    # pip's `--format=json` shape. Pure pipe + `python -c` (dash-safe — no
+    # bash process substitution under /bin/sh).
+    /opt/venv-sac/bin/pip list --format=json \
+        | /opt/venv-sac/bin/python -c 'import json,sys; rows=[r for r in json.load(sys.stdin) if str(r.get("name","")).lower().replace("_","-").split("-")[0]=="scitex"]; json.dump(sorted(rows,key=lambda r:str(r.get("name","")).lower()), sys.stdout, indent=2)' \
+        > /opt/scitex-versions.json
+    cat /opt/scitex-versions.json
+
 %environment
     export PATH=/opt/venv-sac/bin:$PATH
     export VIRTUAL_ENV=/opt/venv-sac

--- a/src/scitex_agent_container/runtimes/_to_home_overlay.py
+++ b/src/scitex_agent_container/runtimes/_to_home_overlay.py
@@ -148,6 +148,16 @@ def deploy_to_home_overlay(config: AgentConfig) -> Path | None:
     dest.mkdir(parents=True, exist_ok=True)
     deploy_to_home(config, str(dest))
     logger.info("to_home: mirrored into overlay upper home %s", dest)
+    # Record the overlay's scitex-* package delta as a version manifest so a
+    # later ``sac versions`` reads it cheaply (source="manifest") instead of
+    # re-scanning the overlay venv. Best-effort provenance side-effect — a
+    # failure here must never affect the launch.
+    try:
+        from .._drift.versions import record_overlay_manifest
+
+        record_overlay_manifest(config)
+    except Exception:  # stx-allow: fallback (reason: version-manifest recording is best-effort; never break a launch)
+        logger.debug("to_home: overlay version-manifest recording skipped", exc_info=True)
     return dest
 
 

--- a/tests/scitex_agent_container/_drift/test_versions.py
+++ b/tests/scitex_agent_container/_drift/test_versions.py
@@ -1,0 +1,405 @@
+"""Tests for scitex-* version introspection across sac's image layers.
+
+PA-306: no mocks. The base-image exec path runs a REAL fake ``apptainer``
+binary installed on PATH (a self-contained Python script that branches on
+argv exactly like the real one would — ``cat <manifest>`` vs
+``pip list --format=json``), so production code hits the real
+``subprocess.run`` + real PATH lookup. The overlay + filesystem paths run
+against real temp directories (fake venv dist-info dirs, real overlay
+uppers) — no patched imports.
+
+Each test: AAA markers (TQ002), one assertion (TQ007), 3+-word name (TQ003).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from scitex_agent_container._drift import versions as V
+
+# A pip `list --format=json` payload mixing scitex-* and non-scitex rows.
+_PIP_LIST = json.dumps(
+    [
+        {"name": "scitex", "version": "2.11.0"},
+        {"name": "scitex-io", "version": "1.2.3"},
+        {"name": "scitex_plt", "version": "0.9.0"},
+        {"name": "numpy", "version": "2.0.0"},
+        {"name": "click", "version": "8.1.7"},
+    ]
+)
+
+# A baked manifest (already scitex-filtered, pip's own shape).
+_MANIFEST = json.dumps(
+    [
+        {"name": "scitex", "version": "9.9.9"},
+        {"name": "scitex-io", "version": "9.9.9"},
+    ]
+)
+
+
+def _install_fake_apptainer(
+    bin_dir: Path,
+    env,
+    *,
+    piplist: str = _PIP_LIST,
+    manifest: str = _MANIFEST,
+    manifest_stems: tuple[str, ...] = (),
+) -> None:
+    """Install a branching fake ``apptainer`` on PATH.
+
+    ``manifest_stems`` names the SIF stems whose ``cat <manifest>`` succeeds;
+    any other stem's ``cat`` exits 1 (manifest absent → live fallback).
+    ``pip list --format=json`` always returns ``piplist``.
+    """
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    script = bin_dir / "apptainer"
+    body = (
+        f"#!{sys.executable}\n"
+        "import os, sys\n"
+        "argv = sys.argv[1:]\n"
+        "sif = argv[1] if len(argv) > 1 else ''\n"
+        "inner = argv[2:]\n"
+        "stem = os.path.basename(sif)\n"
+        "stem = stem[:-4] if stem.endswith('.sif') else stem\n"
+        f"manifest_stems = {list(manifest_stems)!r}\n"
+        "if inner[:1] == ['cat'] and inner and inner[-1].endswith('scitex-versions.json'):\n"
+        "    if stem in manifest_stems:\n"
+        f"        sys.stdout.write({manifest!r}); sys.exit(0)\n"
+        "    sys.stderr.write('cat: no such file\\n'); sys.exit(1)\n"
+        "if 'list' in inner and '--format=json' in inner:\n"
+        f"    sys.stdout.write({piplist!r}); sys.exit(0)\n"
+        "sys.exit(2)\n"
+    )
+    script.write_text(body)
+    script.chmod(0o755)
+    env.set("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
+
+
+def _make_venv_dist_info(venv_root: Path, pkgs: dict[str, str]) -> None:
+    """Create ``<venv>/lib/python3.12/site-packages/<Name>-<Version>.dist-info``."""
+    site = venv_root / "lib" / "python3.12" / "site-packages"
+    site.mkdir(parents=True, exist_ok=True)
+    for name, version in pkgs.items():
+        (site / f"{name}-{version}.dist-info").mkdir()
+
+
+def _fake_config(overlay_dir: Path, image: str = "") -> SimpleNamespace:
+    ap = SimpleNamespace(overlay=str(overlay_dir), raw_args=[], image=image)
+    return SimpleNamespace(apptainer=ap, workdir=str(overlay_dir.parent))
+
+
+# ---------------------------------------------------------------------------
+# pure helpers: scitex filter + normalisation + overlay diff
+# ---------------------------------------------------------------------------
+def test_is_scitex_matches_core_and_dashed():
+    # Arrange
+    names = ["scitex", "scitex-io", "scitex_plt"]
+    # Act
+    results = [V.is_scitex_package(n) for n in names]
+    # Assert
+    assert results == [True, True, True]
+
+
+def test_is_scitex_rejects_non_ecosystem():
+    # Arrange
+    non_ecosystem = ["numpy", "scitexfoo", ""]
+    # Act
+    results = [V.is_scitex_package(n) for n in non_ecosystem]
+    # Assert
+    assert not any(results)
+
+
+def test_normalize_filters_to_scitex_only():
+    # Arrange
+    raw = json.loads(_PIP_LIST)
+    # Act
+    rows = V.normalize_pkg_list(raw)
+    # Assert
+    assert rows == [
+        {"package": "scitex", "version": "2.11.0"},
+        {"package": "scitex-io", "version": "1.2.3"},
+        {"package": "scitex-plt", "version": "0.9.0"},
+    ]
+
+
+def test_normalize_accepts_mapping_shape():
+    # Arrange
+    raw = {"scitex-io": "1.0.0", "numpy": "2.0.0"}
+    # Act
+    rows = V.normalize_pkg_list(raw)
+    # Assert
+    assert rows == [{"package": "scitex-io", "version": "1.0.0"}]
+
+
+def test_overlay_adds_keeps_only_adds_and_overrides():
+    # Arrange
+    base = {"scitex-io": "1.0.0", "scitex": "2.0.0"}
+    overlay = [
+        {"package": "scitex-io", "version": "9.9.9"},  # override
+        {"package": "scitex", "version": "2.0.0"},  # identical → dropped
+        {"package": "scitex-cv", "version": "0.5.0"},  # add
+    ]
+    # Act
+    kept = V.overlay_adds(overlay, base)
+    # Assert
+    assert kept == [
+        {"package": "scitex-io", "version": "9.9.9"},
+        {"package": "scitex-cv", "version": "0.5.0"},
+    ]
+
+
+# ---------------------------------------------------------------------------
+# agent → base image name mapping
+# ---------------------------------------------------------------------------
+def test_base_image_name_defaults_when_empty():
+    # Arrange
+    cfg = _fake_config(Path("/x/overlay"), image="")
+    # Act
+    name = V.agent_base_image_name(cfg)
+    # Assert
+    assert name == "sac-scitex"
+
+
+def test_base_image_name_from_sif_path():
+    # Arrange
+    cfg = _fake_config(Path("/x/overlay"), image="/opt/containers/sac-base.sif")
+    # Act
+    name = V.agent_base_image_name(cfg)
+    # Assert
+    assert name == "sac-base"
+
+
+def test_base_image_name_strips_docker_tag():
+    # Arrange
+    cfg = _fake_config(Path("/x/overlay"), image="docker://org/sac-scitex:v2")
+    # Act
+    name = V.agent_base_image_name(cfg)
+    # Assert
+    assert name == "sac-scitex"
+
+
+# ---------------------------------------------------------------------------
+# base SIF discovery (top-level + nested symlinks, deduped)
+# ---------------------------------------------------------------------------
+def test_discover_finds_toplevel_and_nested(tmp_path: Path):
+    # Arrange
+    (tmp_path / "sac-base.sif").write_text("")  # top-level symlink form
+    nested = tmp_path / "sac-scitex"
+    nested.mkdir()
+    (nested / "sac-scitex.sif").write_text("")  # nested boot symlink form
+    # Act
+    found = V.discover_base_sifs(tmp_path)
+    # Assert
+    assert [name for name, _ in found] == ["sac-base", "sac-scitex"]
+
+
+def test_discover_empty_dir_returns_empty(tmp_path: Path):
+    # Arrange
+    missing = tmp_path / "missing"
+    # Act
+    found = V.discover_base_sifs(missing)
+    # Assert
+    assert found == []
+
+
+# ---------------------------------------------------------------------------
+# base-image rows via the real fake-apptainer exec seam
+# ---------------------------------------------------------------------------
+def test_base_rows_prefer_manifest_source(tmp_path: Path, env_save_restore):
+    # Arrange
+    (tmp_path / "sac-base.sif").write_text("")
+    _install_fake_apptainer(
+        tmp_path / "bin", env_save_restore, manifest_stems=("sac-base",)
+    )
+    # Act
+    rows, base_maps = V.base_image_rows(tmp_path)
+    # Assert
+    assert all(r["source"] == "manifest" for r in rows) and base_maps["sac-base"] == {
+        "scitex": "9.9.9",
+        "scitex-io": "9.9.9",
+    }
+
+
+def test_base_rows_fall_back_to_live(tmp_path: Path, env_save_restore):
+    # Arrange — no stem has a manifest, so cat fails → live pip list.
+    (tmp_path / "sac-base.sif").write_text("")
+    _install_fake_apptainer(tmp_path / "bin", env_save_restore, manifest_stems=())
+    # Act
+    rows, _ = V.base_image_rows(tmp_path)
+    # Assert
+    assert rows and all(r["source"] == "live" for r in rows)
+
+
+def test_base_rows_live_flag_forces_live(tmp_path: Path, env_save_restore):
+    # Arrange — manifest IS present but --live must bypass it.
+    (tmp_path / "sac-base.sif").write_text("")
+    _install_fake_apptainer(
+        tmp_path / "bin", env_save_restore, manifest_stems=("sac-base",)
+    )
+    # Act
+    rows, _ = V.base_image_rows(tmp_path, live=True)
+    # Assert
+    assert rows and all(r["source"] == "live" for r in rows)
+
+
+def test_base_rows_carry_full_contract_shape(tmp_path: Path, env_save_restore):
+    # Arrange
+    (tmp_path / "sac-base.sif").write_text("")
+    _install_fake_apptainer(tmp_path / "bin", env_save_restore, manifest_stems=())
+    # Act
+    rows, _ = V.base_image_rows(tmp_path)
+    # Assert
+    assert all(
+        set(r) == {"agent", "layer", "image", "package", "version", "source"}
+        and r["agent"] == "*"
+        and r["layer"] == "base-image"
+        and r["image"] == "sac-base"
+        for r in rows
+    )
+
+
+# ---------------------------------------------------------------------------
+# overlay venv scan + overlay rows
+# ---------------------------------------------------------------------------
+def test_scan_venv_returns_scitex_dist_info(tmp_path: Path):
+    # Arrange
+    _make_venv_dist_info(
+        tmp_path, {"scitex_io": "1.2.3", "numpy": "2.0.0", "scitex": "2.11.0"}
+    )
+    # Act
+    rows = V.scan_venv_scitex(tmp_path)
+    # Assert
+    assert rows == [
+        {"package": "scitex", "version": "2.11.0"},
+        {"package": "scitex-io", "version": "1.2.3"},
+    ]
+
+
+def test_scan_venv_missing_root_is_empty(tmp_path: Path):
+    # Arrange
+    absent = tmp_path / "nope"
+    # Act
+    rows = V.scan_venv_scitex(absent)
+    # Assert
+    assert rows == []
+
+
+def test_overlay_rows_emit_only_adds_and_overrides(tmp_path: Path):
+    # Arrange — overlay venv adds scitex-cv, overrides scitex-io, matches scitex.
+    overlay = tmp_path / "overlays" / "worker"
+    _make_venv_dist_info(
+        overlay / "upper" / "opt" / "venv-sac",
+        {"scitex_io": "9.9.9", "scitex": "2.0.0", "scitex_cv": "0.5.0"},
+    )
+    base_maps = {"sac-scitex": {"scitex-io": "1.0.0", "scitex": "2.0.0"}}
+    cfg = _fake_config(overlay)
+    # Act
+    rows = V.agent_overlay_rows([("worker", cfg)], base_maps, live=True)
+    # Assert
+    assert sorted((r["package"], r["version"]) for r in rows) == [
+        ("scitex-cv", "0.5.0"),
+        ("scitex-io", "9.9.9"),
+    ]
+
+
+def test_overlay_rows_shape_and_source_live(tmp_path: Path):
+    # Arrange
+    overlay = tmp_path / "overlays" / "worker"
+    _make_venv_dist_info(
+        overlay / "upper" / "opt" / "venv-sac", {"scitex_cv": "0.5.0"}
+    )
+    cfg = _fake_config(overlay, image="/c/sac-base.sif")
+    # Act
+    rows = V.agent_overlay_rows([("worker", cfg)], {}, live=True)
+    # Assert
+    assert rows == [
+        {
+            "agent": "worker",
+            "layer": "agent-overlay",
+            "image": "sac-base",
+            "package": "scitex-cv",
+            "version": "0.5.0",
+            "source": "live",
+        }
+    ]
+
+
+def test_overlay_rows_prefer_manifest_source(tmp_path: Path):
+    # Arrange — a recorded overlay manifest should be read as source=manifest.
+    overlay = tmp_path / "overlays" / "worker"
+    overlay.mkdir(parents=True)
+    (overlay / "scitex-overlay-versions.json").write_text(
+        json.dumps([{"name": "scitex-cv", "version": "0.7.0"}])
+    )
+    cfg = _fake_config(overlay)
+    # Act
+    rows = V.agent_overlay_rows([("worker", cfg)], {}, live=False)
+    # Assert
+    assert rows[0]["source"] == "manifest" and rows[0]["version"] == "0.7.0"
+
+
+def test_overlay_rows_no_overlay_yields_nothing(tmp_path: Path):
+    # Arrange — config with no overlay declared.
+    cfg = SimpleNamespace(
+        apptainer=SimpleNamespace(overlay="", raw_args=[], image=""),
+        workdir=str(tmp_path),
+    )
+    # Act
+    rows = V.agent_overlay_rows([("worker", cfg)], {}, live=True)
+    # Assert
+    assert rows == []
+
+
+# ---------------------------------------------------------------------------
+# record side + top-level assembly
+# ---------------------------------------------------------------------------
+def test_record_overlay_manifest_writes_scitex_set(tmp_path: Path):
+    # Arrange
+    overlay = tmp_path / "overlays" / "worker"
+    _make_venv_dist_info(
+        overlay / "upper" / "opt" / "venv-sac", {"scitex_cv": "0.5.0"}
+    )
+    cfg = _fake_config(overlay)
+    # Act
+    path = V.record_overlay_manifest(cfg)
+    # Assert
+    assert json.loads(Path(path).read_text()) == [
+        {"package": "scitex-cv", "version": "0.5.0"}
+    ]
+
+
+def test_collect_versions_combines_base_and_overlay(tmp_path: Path, env_save_restore):
+    # Arrange
+    (tmp_path / "sac-scitex.sif").write_text("")
+    _install_fake_apptainer(tmp_path / "bin", env_save_restore, manifest_stems=())
+    overlay = tmp_path / "overlays" / "worker"
+    _make_venv_dist_info(
+        overlay / "upper" / "opt" / "venv-sac", {"scitex_cv": "0.5.0"}
+    )
+    cfg = _fake_config(overlay, image="/c/sac-scitex.sif")
+    # Act
+    rows = V.collect_versions(
+        live=True, containers_dir=tmp_path, agent_configs=[("worker", cfg)]
+    )
+    # Assert — flat list carries both layers, every row the 6-key contract.
+    layers = {r["layer"] for r in rows}
+    assert layers == {"base-image", "agent-overlay"} and all(
+        set(r) == {"agent", "layer", "image", "package", "version", "source"}
+        for r in rows
+    )
+
+
+def test_collect_versions_base_only_when_no_agents(tmp_path: Path, env_save_restore):
+    # Arrange
+    (tmp_path / "sac-base.sif").write_text("")
+    _install_fake_apptainer(tmp_path / "bin", env_save_restore, manifest_stems=())
+    # Act
+    rows = V.collect_versions(live=True, containers_dir=tmp_path, agent_configs=[])
+    # Assert
+    assert rows and {r["layer"] for r in rows} == {"base-image"}

--- a/tests/scitex_agent_container/_drift/test_versions.py
+++ b/tests/scitex_agent_container/_drift/test_versions.py
@@ -19,8 +19,6 @@ import sys
 from pathlib import Path
 from types import SimpleNamespace
 
-import pytest
-
 from scitex_agent_container._drift import versions as V
 
 # A pip `list --format=json` payload mixing scitex-* and non-scitex rows.

--- a/tests/scitex_agent_container/cli_pkg/test_versions_cmds.py
+++ b/tests/scitex_agent_container/cli_pkg/test_versions_cmds.py
@@ -1,0 +1,121 @@
+"""CLI tests for ``sac versions`` (scitex-* version introspection).
+
+PA-306: no mocks. ``CliRunner`` drives the real click command; the
+base-image exec path runs a REAL fake ``apptainer`` binary on PATH (a
+self-contained Python script branching on argv) against a real temp
+containers dir. ``--base-only`` keeps the test off the live agent registry.
+
+Each test: AAA markers (TQ002), one assertion (TQ007), 3+-word name (TQ003).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from scitex_agent_container.cli_pkg import main
+from scitex_agent_container.cli_pkg.versions_cmds import versions
+
+_PIP_LIST = json.dumps(
+    [
+        {"name": "scitex", "version": "2.11.0"},
+        {"name": "scitex-io", "version": "1.2.3"},
+        {"name": "numpy", "version": "2.0.0"},
+    ]
+)
+
+
+def _install_fake_apptainer(bin_dir: Path, env) -> None:
+    """Fake ``apptainer`` whose ``pip list --format=json`` returns _PIP_LIST.
+
+    ``cat <manifest>`` always exits 1 (no baked manifest) so the verb takes
+    the live fallback — the shippable-today path.
+    """
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    script = bin_dir / "apptainer"
+    body = (
+        f"#!{sys.executable}\n"
+        "import sys\n"
+        "inner = sys.argv[3:]\n"
+        "if 'list' in inner and '--format=json' in inner:\n"
+        f"    sys.stdout.write({_PIP_LIST!r}); sys.exit(0)\n"
+        "sys.exit(1)\n"
+    )
+    script.write_text(body)
+    script.chmod(0o755)
+    env.set("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
+
+
+@pytest.fixture
+def containers_dir(tmp_path: Path, env_save_restore) -> Path:
+    """A real containers dir with one base SIF + a fake apptainer on PATH."""
+    (tmp_path / "sac-base.sif").write_text("")
+    _install_fake_apptainer(tmp_path / "_bin", env_save_restore)
+    return tmp_path
+
+
+def test_json_emits_flat_contract_rows(containers_dir: Path):
+    # Arrange
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(
+        versions, ["--json", "--live", "--base-only", "--containers-dir", str(containers_dir)]
+    )
+    rows = json.loads(result.output)
+    # Assert
+    assert all(
+        set(r) == {"agent", "layer", "image", "package", "version", "source"}
+        for r in rows
+    )
+
+
+def test_json_base_rows_are_scitex_only(containers_dir: Path):
+    # Arrange
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(
+        versions, ["--live", "--base-only", "--containers-dir", str(containers_dir)]
+    )
+    packages = {r["package"] for r in json.loads(result.output)}
+    # Assert
+    assert packages == {"scitex", "scitex-io"}
+
+
+def test_live_flag_tags_source_live(containers_dir: Path):
+    # Arrange
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(
+        versions, ["--live", "--base-only", "--containers-dir", str(containers_dir)]
+    )
+    sources = {r["source"] for r in json.loads(result.output)}
+    # Assert
+    assert sources == {"live"}
+
+
+def test_table_output_shows_headers(containers_dir: Path):
+    # Arrange
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(
+        versions, ["--table", "--live", "--base-only", "--containers-dir", str(containers_dir)]
+    )
+    # Assert
+    assert "PACKAGE" in result.output and "base-image" in result.output
+
+
+def test_versions_registered_on_main_group(containers_dir: Path):
+    # Arrange
+    runner = CliRunner()
+    # Act — resolve through the top-level LazyGroup, proving registration.
+    result = runner.invoke(
+        main,
+        ["versions", "--live", "--base-only", "--containers-dir", str(containers_dir)],
+    )
+    # Assert
+    assert result.exit_code == 0 and json.loads(result.output)


### PR DESCRIPTION
## What

New `sac versions --json` verb exposing the 2 image layers only sac can
see — the shared **base-image** venv and per-agent **overlay** venvs — as a
flat JSON list for scitex-dev's fleet drift-report aggregator. scitex-dev's
`ecosystem check-versions` already covers the other 6 layers (PyPI, GitHub,
both hosts' venvs, CI, editable); this closes the 2-layer gap so it can fold all 8.

**LOCKED contract** — flat list of `{agent, layer, image, package, version, source}`:
- `layer` in {`base-image`, `agent-overlay`}
- base-image rows: `agent="*"`, one set per base SIF; `image` = SIF name (e.g. `sac-base`, `sac-scitex`)
- agent-overlay rows: `agent=<name>`, ONLY the scitex-* packages the overlay ADDS/OVERRIDES vs its base (usually empty — agents share the base venv); `image` = the base SIF that agent runs on
- `source` in {`manifest`, `live`}
- sac emits RAW base + overlay rows; the aggregator derives the "effective" (overlay-else-base) view.

## How
- **`_drift/versions.py`** — collection: discover base SIFs (top-level + nested symlinks, deduped), manifest-else-live per image, agent enumeration to base-image mapping, overlay venv scan + adds/overrides diff. Resilient (never raises; missing apptainer/SIF degrades to skip).
- **`cli_pkg/versions_cmds.py`** — `sac versions`: `--json` (default, the contract), `--live`, `--table`, `--base-only`, `--containers-dir`. Registered via LazyGroup in `_main.py` (Introspection).
- **Manifest baking** — a `%post` step in both `apptainer-base.def` + `apptainer-scitex.def` bakes `/opt/scitex-versions.json` (scitex-* pip freeze) at build so the routine read is `source="manifest"` (a `cat`, near-zero vs `pip list`). Additive; effective on next build, nothing rebuilt now.
- **Overlay record hook** — best-effort `record_overlay_manifest()` wired into `runtimes/_to_home_overlay.deploy_to_home_overlay`, never affects a launch.

## Shippable TODAY (no rebuild)
`sac versions --json --live` runs `apptainer exec <sif> /opt/venv-sac/bin/pip list --format=json` per discovered base SIF — real output now, before any rebuild. The baked-manifest path activates on next build.

## Base-image discovery
Reuses `sac image list` conventions: base SIFs under `~/.scitex/agent-container/containers/` as both top-level `sac-<layer>.sif` symlinks and nested `sac-<layer>/sac-<layer>.sif`. Agent to base via `AgentConfig.apptainer.image` (empty → default `sac-scitex`). Overlay upper venv at `<overlay>/upper/opt/venv-sac`.

## Tests
28 new tests, real (no mocks): a self-contained fake `apptainer` on PATH (branches on argv) drives the exec path; real temp venvs/overlays drive the filesystem paths. `_drift/test_versions.py` + `cli_pkg/test_versions_cmds.py` mirror the new src modules (PS-204). All 28 green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
