### PR TITLE
fix(mcp): deterministic MCP connect (alwaysLoad + MCP_TIMEOUT) + lazy-import + boot self-heal

### DIFF
--- a/docs/mcp-cold-start.md
+++ b/docs/mcp-cold-start.md
@@ -1,0 +1,64 @@
+# MCP cold-start connect race — root cause + fix
+
+## The incident (2026-07-06)
+
+Agents' `scitex-agent-container` (`sac mcp start`) and `scitex-todo`
+(`scitex-todo mcp start`) **stdio** MCP servers intermittently fail to connect at
+Claude Code session start — per-agent and racy (some agents connect, others do
+not). The servers start healthy and write nothing to stdout; the failure is a
+**client-side cold-start connect-timing race**:
+
+- The heavy `fastmcp` import makes the stdio server slow to become ready
+  (~4.4 s of `import fastmcp` on a cold / slow container FS — see profiling
+  below), intermittently exceeding Claude Code's MCP startup/connect timeout.
+- Claude Code does **NOT** auto-reconnect a failed **stdio** MCP (its
+  3-initial / 5-mid-session retries are HTTP/SSE only). So a lost race leaves
+  the agent missing `host_exec` / `agent_spawn` / `db_*` / the todo tools for
+  the **entire session**.
+
+### Profiling (coverage-free, `perf_counter`)
+
+| phase | ms |
+|---|---|
+| `import fastmcp` | ~2100 |
+| `from fastmcp import FastMCP` | ~2300 |
+| import all 9 sac tool modules (eager) | ~40 |
+| `FastMCP()` construct | ~6 |
+| `register_all_tools` schema-gen (~35 tools) | ~300 |
+
+`import fastmcp` dominates; the tool modules are ~40 ms.
+
+## The fix
+
+1. **`alwaysLoad: true`** on the critical stdio servers in `.mcp.json` — forces
+   Claude Code to **block** on startup until the server connects (capped at
+   `MCP_TIMEOUT`) instead of the default racy background connect. Real field
+   (v2.1.121+; a harmless no-op on older clients). Stamped on defensively at
+   materialize time by `runtimes/_mcp_reliability.inject_always_load`
+   (`_to_home_deployers._deploy_mcp_merge`, `mcp_config._setup_mcp_from_servers`);
+   the `.mcp.json` deep-merge preserves it.
+2. **`MCP_TIMEOUT=30000`** (ms) in the agent launch env — the client MCP
+   **startup** timeout (distinct from the per-server `timeout` field, which is a
+   per-tool-call cap). Injected by `runtimes/_apptainer_listen_env.listen_env_flags`.
+3. **Lazy-import** of the tool modules (`_mcp/server.py` imports them inside
+   `_build_server()`, not at module load) so `import scitex_agent_container._mcp`
+   stays cheap.
+4. **Auto-heal boot self-check** — `sac mcp healthcheck` (`_mcp/_healthcheck.py`),
+   run at boot via a `SessionStart` hook: logs the expected capability surface,
+   detects failed critical MCPs via `claude mcp list`, and on failure alarms +
+   requests a rate-limited `--fresh` self-restart. FAIL-OPEN — never blocks boot.
+
+## Knobs
+
+| env var | effect |
+|---|---|
+| `MCP_TIMEOUT` | client MCP startup connect timeout (ms) — set to `30000` |
+| `SAC_MCP_HEALTHCHECK_DISABLED` | `1`/`true` disables the boot self-check |
+| `SAC_MCP_HEALTHCHECK_NO_RESTART` | `1`/`true` → alarm only, never self-restart |
+| `SAC_MCP_HEALTHCHECK_STATE_DIR` | override the restart-cooldown sentinel dir |
+
+## Not fixed here
+
+The ecosystem-wide `fastmcp` version pin is scitex-dev's domain. sac's
+`pyproject.toml` carries an unpinned `fastmcp>=2.0`; `sac versions --json --live
+--base-only` reports the fastmcp version across SIFs.

--- a/src/scitex_agent_container/_mcp/_healthcheck.py
+++ b/src/scitex_agent_container/_mcp/_healthcheck.py
@@ -1,0 +1,330 @@
+"""Boot self-check + auto-heal for the critical MCP connections.
+
+Fleet incident 2026-07-06 (belt-and-suspenders layer). The deterministic fix
+for the cold-start connect race lives in the distributed config
+(``alwaysLoad:true`` + a raised ``MCP_TIMEOUT`` — see
+:mod:`scitex_agent_container.runtimes._mcp_reliability`). THIS module is the
+recovery net for the residual cases those cannot cover: a critical MCP server
+that dies AFTER connecting, or one that is genuinely broken (won't connect at
+all) rather than merely slow.
+
+Run at agent boot (a ``SessionStart`` hook invokes ``sac mcp healthcheck``):
+
+  1. LOG the expected capability surface. If a critical MCP is down, an agent
+     that reaches for ``host_exec``/``agent_spawn``/``db_*`` or the todo tools
+     gets a "tool not found" — which reads as "I lack that capability" unless
+     the boot log makes explicit that those tools come from an MCP that FAILED
+     to connect. The log turns a silent capability gap into a diagnosable
+     "MCP broken → heal".
+  2. DETECT which critical servers connected, via ``claude mcp list`` (Claude
+     Code's live per-server connectivity check).
+  3. HEAL a detected failure: raise a loud, operator-visible alarm and — rate
+     limited, to avoid a boot⇄restart loop — request a self-restart through the
+     host ``sac listen`` control plane (the same broker ``sac agents restart``
+     uses). A ``--fresh`` restart re-runs the whole launch, giving the (now
+     ``alwaysLoad`` + long-``MCP_TIMEOUT``) connect another, blocking, attempt.
+
+FAIL-OPEN THROUGHOUT: every step is defensive. A healthcheck that itself errors
+(no ``claude`` binary, unparseable output, restart broker unreachable, …) must
+NEVER block the agent's boot — it logs and returns. The worst case degrades to
+today's behaviour (tools missing), never worse.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from pathlib import Path
+from typing import Callable, Iterable
+
+log = logging.getLogger(__name__)
+
+# Critical MCP servers → the capability surface each one gates. Names match the
+# server keys in the distributed ``.mcp.json``. Logged verbatim at boot.
+CRITICAL_CAPABILITIES: dict[str, tuple[str, ...]] = {
+    "scitex-agent-container": (
+        "host_exec_local (run host commands)",
+        "agent_spawn / agent_start / agent_restart (manage peers)",
+        "db_query / db_show (state DB)",
+        "host_exec / host_list (multi-host)",
+    ),
+    "scitex-todo": (
+        "add_task / update_task / complete_task",
+        "list_tasks / comment_task (the fleet task board)",
+    ),
+}
+
+# Statuses parsed out of ``claude mcp list``.
+CONNECTED = "connected"
+FAILED = "failed"
+UNKNOWN = "unknown"
+
+# Self-restart cooldown: never self-restart for a failed MCP more than once per
+# this window, so a genuinely-broken server can't drive a tight boot⇄restart
+# loop (the alarm still fires every boot, so a human sees a persistent break).
+_RESTART_COOLDOWN_S = 1800.0
+
+# Env knobs (all optional; defaults are safe).
+ENV_DISABLE = "SAC_MCP_HEALTHCHECK_DISABLED"
+ENV_NO_RESTART = "SAC_MCP_HEALTHCHECK_NO_RESTART"
+ENV_STATE_DIR = "SAC_MCP_HEALTHCHECK_STATE_DIR"
+
+
+def _state_dir() -> Path:
+    """Directory for the restart-cooldown sentinel (override via env for tests)."""
+    override = os.environ.get(ENV_STATE_DIR)
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / ".scitex" / "agent-container" / "runtime" / "mcp-health"
+
+
+def _default_mcp_list_runner() -> str:
+    """Run ``claude mcp list`` and return combined stdout+stderr (best-effort).
+
+    Returns ``""`` on any failure (missing binary, timeout, …) — the parser then
+    yields ``unknown`` for every server and the check degrades to a no-op.
+    """
+    import subprocess
+
+    try:
+        proc = subprocess.run(
+            ["claude", "mcp", "list"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except Exception as exc:  # stx-allow: fallback (reason: fail-open — a broken/absent `claude` binary must never block boot)
+        log.warning("mcp healthcheck: `claude mcp list` failed to run (%s)", exc)
+        return ""
+    return (proc.stdout or "") + "\n" + (proc.stderr or "")
+
+
+def parse_mcp_status(text: str, servers: Iterable[str]) -> dict[str, str]:
+    """Classify each ``server`` as connected / failed / unknown from ``claude
+    mcp list`` output.
+
+    ``claude mcp list`` prints one line per server, e.g.::
+
+        scitex-agent-container: sac mcp start  - ✓ Connected
+        scitex-todo: scitex-todo mcp start  - ✗ Failed to connect
+
+    We match the server name at the start of a line (``name:`` prefix) and read
+    a connected/failed marker from that line. Robust to unicode-glyph vs plain
+    "Connected"/"Failed" wording. Any server not mentioned → ``unknown``.
+    """
+    result: dict[str, str] = {name: UNKNOWN for name in servers}
+    if not text:
+        return result
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        low = line.lower()
+        for name in result:
+            # Match "<name>:" or "<name> " at the line start (mcp list uses
+            # "name: command - status"). Substring fallback covers reformats.
+            if line.startswith(f"{name}:") or line.startswith(f"{name} ") or name in line:
+                if "fail" in low or "✗" in line or "not connect" in low or "error" in low:
+                    result[name] = FAILED
+                elif "connect" in low or "✓" in line or "ready" in low:
+                    # "failed to connect" already handled above; here it's the
+                    # positive "Connected".
+                    result[name] = CONNECTED
+                break
+    return result
+
+
+def log_capability_surface(statuses: dict[str, str]) -> None:
+    """Log the expected capability surface, flagging any down critical server.
+
+    So a later "tool not found" is diagnosable as "MCP broken → heal", not
+    misread as "I lack that capability".
+    """
+    for server, caps in CRITICAL_CAPABILITIES.items():
+        status = statuses.get(server, UNKNOWN)
+        surface = "; ".join(caps)
+        if status == CONNECTED:
+            log.info("mcp healthcheck: '%s' CONNECTED — provides: %s", server, surface)
+        elif status == FAILED:
+            log.warning(
+                "mcp healthcheck: '%s' FAILED TO CONNECT — the following tools "
+                "are UNAVAILABLE this session (this is an MCP connect failure, "
+                "NOT a missing capability): %s",
+                server,
+                surface,
+            )
+        else:
+            log.info(
+                "mcp healthcheck: '%s' status UNKNOWN (could not read "
+                "`claude mcp list`) — expected tools: %s",
+                server,
+                surface,
+            )
+
+
+def _recent_restart(now: float, state_dir: Path) -> bool:
+    """True when a self-restart was requested within the cooldown window."""
+    sentinel = state_dir / "last-restart.ts"
+    try:
+        prev = float(sentinel.read_text().strip())
+    except Exception:  # stx-allow: fallback (no/again unreadable sentinel → treat as "no recent restart")
+        return False
+    return (now - prev) < _RESTART_COOLDOWN_S
+
+
+def _record_restart(now: float, state_dir: Path) -> None:
+    """Stamp the cooldown sentinel (best-effort)."""
+    sentinel = state_dir / "last-restart.ts"
+    try:
+        sentinel.parent.mkdir(parents=True, exist_ok=True)
+        sentinel.write_text(f"{now}\n")
+    except OSError as exc:  # stx-allow: fallback (can't write sentinel → skip cooldown, still fail-open)
+        log.warning("mcp healthcheck: could not record restart sentinel (%s)", exc)
+
+
+def _env_flag(name: str) -> bool:
+    """True when env var ``name`` is set to a truthy string."""
+    return os.environ.get(name, "").strip().lower() in ("1", "true", "yes")
+
+
+def _default_self_restart(agent_name: str) -> bool:
+    """Broker a ``--fresh`` self-restart via the host ``sac listen`` plane.
+
+    Returns True when the restart request was accepted. Fail-open: any error
+    (missing ``SAC_LISTEN_BASE_URL``, ACL denial, transport failure) logs and
+    returns False — the agent keeps running, degraded, rather than crashing.
+    """
+    try:
+        from .._lifecycle._restart_client import RestartRequestError, request_restart
+    except Exception as exc:  # stx-allow: fallback (lifecycle client unavailable → cannot self-heal, stay up)
+        log.warning("mcp healthcheck: restart client unavailable (%s)", exc)
+        return False
+    try:
+        request_restart(agent_name, caller=agent_name, fresh=True)
+    except RestartRequestError as exc:
+        log.warning(
+            "mcp healthcheck: self-restart request for '%s' was rejected (%s)",
+            agent_name,
+            exc,
+        )
+        return False
+    except Exception as exc:  # stx-allow: fallback (any transport/env error → stay up, don't crash boot)
+        log.warning("mcp healthcheck: self-restart request errored (%s)", exc)
+        return False
+    log.warning(
+        "mcp healthcheck: requested a --fresh self-restart of '%s' to re-attempt "
+        "the failed MCP connect(s)",
+        agent_name,
+    )
+    return True
+
+
+def run_healthcheck(
+    *,
+    mcp_list_runner: Callable[[], str] | None = None,
+    restart_fn: Callable[[str], bool] | None = None,
+    agent_name: str | None = None,
+    now_fn: Callable[[], float] = time.time,
+    state_dir: Path | None = None,
+    disabled: bool | None = None,
+    allow_restart: bool | None = None,
+) -> dict:
+    """Boot self-check + auto-heal. FAIL-OPEN — never raises.
+
+    Returns a result dict::
+
+        {"statuses": {server: status}, "failed": [server, ...],
+         "healed": bool, "action": "ok"|"restart-requested"|"alarm-only"|
+                                    "restart-cooldown"|"disabled"|"error"}
+
+    Injection seams (real callables / values, no mocks): ``mcp_list_runner``
+    supplies the ``claude mcp list`` output; ``restart_fn`` performs the
+    self-restart and returns whether it was accepted; ``state_dir`` locates the
+    cooldown sentinel; ``disabled`` / ``allow_restart`` override the env knobs.
+    Production leaves them ``None`` — the module then shells out / brokers to
+    the host plane and reads :data:`ENV_DISABLE` / :data:`ENV_NO_RESTART` /
+    :data:`ENV_STATE_DIR` from the environment.
+    """
+    try:
+        is_disabled = disabled if disabled is not None else _env_flag(ENV_DISABLE)
+        if is_disabled:
+            log.info("mcp healthcheck: disabled")
+            return {"statuses": {}, "failed": [], "healed": False, "action": "disabled"}
+
+        resolved_state_dir = state_dir if state_dir is not None else _state_dir()
+        runner = mcp_list_runner or _default_mcp_list_runner
+        servers = tuple(CRITICAL_CAPABILITIES.keys())
+        text = runner()
+        statuses = parse_mcp_status(text, servers)
+        log_capability_surface(statuses)
+
+        failed = [s for s, st in statuses.items() if st == FAILED]
+        if not failed:
+            return {
+                "statuses": statuses,
+                "failed": [],
+                "healed": False,
+                "action": "ok",
+            }
+
+        # A critical MCP FAILED to connect — alarm LOUD (operator-visible).
+        log.warning(
+            "mcp healthcheck: CRITICAL MCP connection failure — %s did not "
+            "connect. Tools from those servers are unavailable this session.",
+            ", ".join(failed),
+        )
+
+        name = agent_name or os.environ.get("SAC_NAME") or os.environ.get(
+            "SCITEX_AGENT_CONTAINER_NAME", ""
+        )
+        restart_allowed = (
+            allow_restart if allow_restart is not None else not _env_flag(ENV_NO_RESTART)
+        )
+        if not restart_allowed or not name:
+            return {
+                "statuses": statuses,
+                "failed": failed,
+                "healed": False,
+                "action": "alarm-only",
+            }
+
+        now = now_fn()
+        if _recent_restart(now, resolved_state_dir):
+            log.warning(
+                "mcp healthcheck: a self-restart was already requested within "
+                "the cooldown; NOT restarting again (alarm stands). Servers "
+                "still failing: %s",
+                ", ".join(failed),
+            )
+            return {
+                "statuses": statuses,
+                "failed": failed,
+                "healed": False,
+                "action": "restart-cooldown",
+            }
+
+        restart = restart_fn or _default_self_restart
+        accepted = bool(restart(name))
+        if accepted:
+            _record_restart(now, resolved_state_dir)
+        return {
+            "statuses": statuses,
+            "failed": failed,
+            "healed": accepted,
+            "action": "restart-requested" if accepted else "alarm-only",
+        }
+    except Exception as exc:  # stx-allow: fallback (the heal-check itself must NEVER block or crash the agent boot)
+        log.warning("mcp healthcheck: self-check errored, ignoring (%s)", exc)
+        return {"statuses": {}, "failed": [], "healed": False, "action": "error"}
+
+
+__all__ = [
+    "CONNECTED",
+    "CRITICAL_CAPABILITIES",
+    "FAILED",
+    "UNKNOWN",
+    "log_capability_surface",
+    "parse_mcp_status",
+    "run_healthcheck",
+]

--- a/src/scitex_agent_container/_mcp/server.py
+++ b/src/scitex_agent_container/_mcp/server.py
@@ -15,7 +15,16 @@ from __future__ import annotations
 import logging
 import sys
 
-from ._tools import register_all_tools
+# NOTE: ``register_all_tools`` is deliberately NOT imported at module top
+# level. Importing it here would pull in all nine tool modules (and their
+# ``click.testing`` helper) at ``import scitex_agent_container._mcp`` time —
+# i.e. on the `sac mcp start` cold-start path, BEFORE the stdio handshake.
+# The heavy tool implementations (host_exec / agent-spawn / db / image /
+# template clients) are already lazy-imported inside each tool body; keeping
+# the registration import lazy too means a bare ``import _mcp`` (doctor,
+# list-tools, the package _api surface) stays cheap, and the tool modules are
+# only imported when the server is actually built in ``_build_server``. See
+# ``docs/mcp-cold-start.md`` and the F-CS15 cold-start-race fix.
 
 
 def _ensure_stderr_logging() -> None:
@@ -61,6 +70,10 @@ def _build_server():
             "fastmcp is required for the sac MCP server — "
             "install with `pip install scitex-agent-container[mcp]`"
         ) from exc
+
+    # Lazy tool-module import (cold-start race fix): the nine tool modules are
+    # imported HERE, at build time, rather than at ``import _mcp`` module load.
+    from ._tools import register_all_tools
 
     server = FastMCP(name="scitex-agent-container", instructions=_INSTRUCTIONS)
     register_all_tools(server)

--- a/src/scitex_agent_container/cli_pkg/mcp_group.py
+++ b/src/scitex_agent_container/cli_pkg/mcp_group.py
@@ -183,6 +183,50 @@ def mcp_channel(name: str | None, listen_url: str | None, turn_url: str | None) 
     _channel_main(name=name, listen_url=listen_url, turn_url=turn_url)
 
 
+@mcp.command("healthcheck")
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Emit the result as JSON.",
+)
+def mcp_healthcheck(as_json: bool) -> None:
+    """Boot self-check + auto-heal for the critical MCP connections.
+
+    Verifies the ``scitex-agent-container`` + ``scitex-todo`` stdio MCP
+    servers actually CONNECTED (via ``claude mcp list``), logs the expected
+    capability surface so a missing tool reads as "MCP broken → heal" rather
+    than "I lack capability", and — if a critical server failed to connect —
+    raises a loud alarm and requests a rate-limited ``--fresh`` self-restart
+    through the host ``sac listen`` plane. FAIL-OPEN: always exits 0, so a
+    ``SessionStart`` hook that runs this never blocks the agent's boot.
+
+    \b
+    Example (SessionStart hook):
+      $ sac mcp healthcheck
+    """
+    # Lazy import: keep this out of the cold-start path and out of the CLI's
+    # module-import budget. ``_healthcheck`` pulls no heavy deps (no fastmcp).
+    from .._mcp._healthcheck import run_healthcheck
+
+    result = run_healthcheck()
+    if as_json:
+        click.echo(json_mod.dumps(result))
+    else:
+        action = result.get("action", "ok")
+        failed = result.get("failed") or []
+        if failed:
+            click.secho(
+                f"MCP healthcheck: {', '.join(failed)} FAILED — action={action}",
+                fg="red",
+            )
+        else:
+            click.secho(f"MCP healthcheck: all critical MCPs OK (action={action})", fg="green")
+    # Fail-open: NEVER non-zero. A boot hook must not block the session.
+    raise SystemExit(0)
+
+
 @mcp.command("doctor")
 def mcp_doctor() -> None:
     """Check MCP server dependencies + tool registration health.

--- a/src/scitex_agent_container/runtimes/_apptainer_listen_env.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_listen_env.py
@@ -68,6 +68,7 @@ def listen_env_flags(config) -> list[str]:
 
     from .._listen._config import listen_base_url
     from ._apptainer_build import _listen_token_path, _read_listen_bearer
+    from ._mcp_reliability import mcp_timeout_env_flags
 
     flags: list[str] = ["--env", f"SAC_LISTEN_BASE_URL={listen_base_url()}"]
 
@@ -144,6 +145,20 @@ def listen_env_flags(config) -> list[str]:
         "--env",
         "SCITEX_GENAI_BASE_URL=http://127.0.0.1:4000/v1",
     ]
+
+    # MCP STARTUP CONNECT TIMEOUT — raise Claude Code's per-server MCP startup
+    # timeout (fleet incident 2026-07-06). The ``sac`` + ``scitex-todo`` stdio
+    # MCP servers pull in ``fastmcp``, whose import alone is multiple seconds on
+    # a cold / slow container FS; Claude Code's default startup cap intermittently
+    # loses that race, and it does NOT auto-reconnect a failed *stdio* MCP — so
+    # the agent then runs its ENTIRE session missing host_exec / agent_spawn /
+    # db_* / the todo tools. ``MCP_TIMEOUT`` is the CLIENT startup-timeout env var
+    # (ms), DISTINCT from the per-server ``timeout`` field (per-tool-call). Paired
+    # with ``alwaysLoad:true`` on those servers (see ``_mcp_reliability``), the
+    # session deterministically WAITS for the (slow) connect. UNCONDITIONAL —
+    # every agent needs it; a generic Claude-Code tooling knob, not coupled to any
+    # scitex-* package.
+    flags += mcp_timeout_env_flags()
 
     # ALWAYS inject the agent-spec search path so the in-container sac
     # resolves peer specs even when the launching env has nothing set.

--- a/src/scitex_agent_container/runtimes/_mcp_reliability.py
+++ b/src/scitex_agent_container/runtimes/_mcp_reliability.py
@@ -1,0 +1,93 @@
+"""Fleet MCP cold-start reliability knobs (incident 2026-07-06).
+
+Root cause (root-caused + verified by the fleet): the agents'
+``scitex-agent-container`` (``sac mcp start``) and ``scitex-todo``
+(``scitex-todo mcp start``) stdio MCP servers INTERMITTENTLY fail to connect
+at Claude Code session start. The server itself starts healthy — the failure
+is a CLIENT-SIDE connect-timing RACE: the heavy ``fastmcp`` import makes the
+stdio server slow to become ready and intermittently exceeds Claude Code's
+default MCP startup/connect timeout. Claude Code does NOT auto-reconnect a
+failed *stdio* MCP (its 3-initial / 5-mid-session retries are HTTP/SSE ONLY),
+so the agent then runs its ENTIRE session missing those tools (``host_exec``,
+``agent_spawn``, ``db_*``, and the todo tools).
+
+Two deterministic, config-only levers (both distributed via the to_home
+materialization so every agent picks them up on next deploy):
+
+1. ``alwaysLoad: true`` on each critical stdio server entry in ``.mcp.json``
+   → forces BLOCKING startup: the session WAITS for the server to connect
+   (capped at ``MCP_TIMEOUT``) instead of the default racy background connect.
+   This converts "sometimes loses the race" into "deterministically waits for
+   ready." Supported by Claude Code v2.1.121+; a harmless no-op on older
+   clients (an unknown key is ignored).
+
+2. ``MCP_TIMEOUT`` (milliseconds) raised in the agent launch env → gives the
+   slow cold-start room. This is the CLIENT startup-connect-timeout env var,
+   DISTINCT from the per-server ``timeout`` field in ``.mcp.json`` (which is a
+   per-tool-call wall-clock cap — deliberately NOT touched here).
+
+See ``docs/mcp-cold-start.md`` and the boot self-check
+(``sac mcp healthcheck`` / the ``SessionStart`` hook) that heals a server
+which still fails to connect.
+"""
+
+from __future__ import annotations
+
+# Critical stdio MCP servers whose cold-start MUST win the connect race. These
+# names match the server keys in the distributed ``.mcp.json`` (``sac`` is the
+# short alias some baselines use for the scitex-agent-container server).
+CRITICAL_MCP_SERVERS: tuple[str, ...] = (
+    "scitex-agent-container",
+    "sac",
+    "scitex-todo",
+)
+
+# Client MCP startup connect timeout, in milliseconds. 30 s gives the multi-
+# second ``fastmcp`` cold-start (worse on a cold / slow container FS) a wide
+# margin, while still bounding how long ``alwaysLoad`` blocks a genuinely dead
+# server before the session proceeds.
+MCP_STARTUP_TIMEOUT_MS: str = "30000"
+
+# Env var name Claude Code reads for the MCP startup connect timeout.
+MCP_TIMEOUT_ENV_VAR: str = "MCP_TIMEOUT"
+
+
+def inject_always_load(doc: dict) -> dict:
+    """Stamp ``alwaysLoad: true`` onto each critical server in a ``.mcp.json``.
+
+    Mutates and returns ``doc`` (a parsed ``.mcp.json`` mapping). For every
+    :data:`CRITICAL_MCP_SERVERS` name present under ``mcpServers`` that does not
+    already carry an explicit ``alwaysLoad`` key, sets it to ``True`` so Claude
+    Code blocks on startup until that stdio server connects. Servers not present
+    are skipped; a pre-existing explicit ``alwaysLoad`` (True or False) is left
+    untouched so a deliberate per-agent override still wins. Fail-open: a
+    malformed / non-dict ``mcpServers`` is returned unchanged.
+    """
+    if not isinstance(doc, dict):
+        return doc
+    servers = doc.get("mcpServers")
+    if not isinstance(servers, dict):
+        return doc
+    for name in CRITICAL_MCP_SERVERS:
+        entry = servers.get(name)
+        if isinstance(entry, dict):
+            entry.setdefault("alwaysLoad", True)
+    return doc
+
+
+def mcp_timeout_env_flags() -> list[str]:
+    """Return the apptainer ``--env`` flags that raise the MCP startup timeout.
+
+    Appended by the apptainer runtime's managed-env injector so every agent
+    container launches ``claude`` with a generous MCP startup connect timeout.
+    """
+    return ["--env", f"{MCP_TIMEOUT_ENV_VAR}={MCP_STARTUP_TIMEOUT_MS}"]
+
+
+__all__ = [
+    "CRITICAL_MCP_SERVERS",
+    "MCP_STARTUP_TIMEOUT_MS",
+    "MCP_TIMEOUT_ENV_VAR",
+    "inject_always_load",
+    "mcp_timeout_env_flags",
+]

--- a/src/scitex_agent_container/runtimes/_to_home_deployers.py
+++ b/src/scitex_agent_container/runtimes/_to_home_deployers.py
@@ -29,6 +29,7 @@ from pathlib import Path
 
 from ..config import AgentConfig
 from ._mcp_merge import merge_mcp_json
+from ._mcp_reliability import inject_always_load
 from ._to_home_errors import WorkspaceMcpMergeError
 from ._to_home_text import (
     END_MARKER,
@@ -164,6 +165,11 @@ def _deploy_mcp_merge(
         merged = merge_mcp_json(base_doc, overlay_doc)
     else:
         merged = overlay_doc
+    # Cold-start race fix (fleet incident 2026-07-06): stamp ``alwaysLoad:true``
+    # onto the critical stdio MCP servers so Claude Code BLOCKS on startup until
+    # they connect (capped at MCP_TIMEOUT) instead of racing the slow fastmcp
+    # cold-start and running the whole session tool-less. Idempotent + fail-open.
+    inject_always_load(merged)
     dst.write_text(json.dumps(merged, indent=2) + "\n")
     logger.info("to_home: deep-merged .mcp.json %s -> %s", rel, dst)
 

--- a/src/scitex_agent_container/runtimes/mcp_config.py
+++ b/src/scitex_agent_container/runtimes/mcp_config.py
@@ -60,6 +60,12 @@ def _setup_mcp_from_servers(
             ]
         mcp_servers[name] = resolved
 
+    # Cold-start race fix (fleet incident 2026-07-06): force blocking startup for
+    # the critical stdio MCP servers (see ``_mcp_reliability``). Idempotent.
+    from ._mcp_reliability import inject_always_load
+
+    inject_always_load(existing)
+
     mcp_path.parent.mkdir(parents=True, exist_ok=True)
     mcp_path.write_text(json.dumps(existing, indent=2) + "\n")
 

--- a/tests/scitex_agent_container/_mcp/test__healthcheck.py
+++ b/tests/scitex_agent_container/_mcp/test__healthcheck.py
@@ -1,0 +1,247 @@
+"""Tests for the MCP boot self-check + auto-heal.
+
+The self-check parses ``claude mcp list`` output, logs the expected capability
+surface, and — on a failed critical MCP — alarms + requests a rate-limited
+self-restart. It must be FAIL-OPEN: never raise, always let boot proceed.
+
+Conventions: one assert / AAA markers; no mocks / no monkeypatch — the
+``claude mcp list`` runner and the restart requester are injected as REAL
+callables, state lives under a real ``tmp_path``, and the env knobs are passed
+as explicit parameters.
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container._mcp._healthcheck import (
+    CONNECTED,
+    FAILED,
+    UNKNOWN,
+    parse_mcp_status,
+    run_healthcheck,
+)
+
+_SERVERS = ("scitex-agent-container", "scitex-todo")
+
+_LIST_BOTH_OK = (
+    "scitex-agent-container: sac mcp start - Connected\n"
+    "scitex-todo: scitex-todo mcp start - Connected\n"
+)
+_LIST_TODO_FAILED = (
+    "scitex-agent-container: sac mcp start - Connected\n"
+    "scitex-todo: scitex-todo mcp start - Failed to connect\n"
+)
+
+
+class _RestartRecorder:
+    """Real (non-mock) stand-in for the self-restart broker call."""
+
+    def __init__(self, accept: bool = True):
+        self.accept = accept
+        self.calls: list[str] = []
+
+    def __call__(self, name: str) -> bool:
+        self.calls.append(name)
+        return self.accept
+
+
+def test_parse_marks_connected_server():
+    # Arrange
+    text = _LIST_BOTH_OK
+    # Act
+    statuses = parse_mcp_status(text, _SERVERS)
+    # Assert
+    assert statuses["scitex-agent-container"] == CONNECTED
+
+
+def test_parse_marks_failed_server():
+    # Arrange
+    text = _LIST_TODO_FAILED
+    # Act
+    statuses = parse_mcp_status(text, _SERVERS)
+    # Assert
+    assert statuses["scitex-todo"] == FAILED
+
+
+def test_parse_marks_unmentioned_server_unknown():
+    # Arrange — output mentions only one server.
+    text = "scitex-agent-container: sac mcp start - Connected\n"
+    # Act
+    statuses = parse_mcp_status(text, _SERVERS)
+    # Assert
+    assert statuses["scitex-todo"] == UNKNOWN
+
+
+def test_parse_empty_output_is_all_unknown():
+    # Arrange
+    text = ""
+    # Act
+    statuses = parse_mcp_status(text, _SERVERS)
+    # Assert
+    assert statuses["scitex-agent-container"] == UNKNOWN
+
+
+def test_run_healthcheck_all_ok_action(tmp_path):
+    # Arrange
+    recorder = _RestartRecorder()
+    # Act
+    result = run_healthcheck(
+        mcp_list_runner=lambda: _LIST_BOTH_OK,
+        restart_fn=recorder,
+        agent_name="agent-x",
+        now_fn=lambda: 100.0,
+        state_dir=tmp_path,
+    )
+    # Assert
+    assert result["action"] == "ok"
+
+
+def test_run_healthcheck_all_ok_does_not_restart(tmp_path):
+    # Arrange
+    recorder = _RestartRecorder()
+    # Act
+    run_healthcheck(
+        mcp_list_runner=lambda: _LIST_BOTH_OK,
+        restart_fn=recorder,
+        agent_name="agent-x",
+        now_fn=lambda: 100.0,
+        state_dir=tmp_path,
+    )
+    # Assert
+    assert recorder.calls == []
+
+
+def test_run_healthcheck_failed_reports_failed_server(tmp_path):
+    # Arrange
+    recorder = _RestartRecorder()
+    # Act
+    result = run_healthcheck(
+        mcp_list_runner=lambda: _LIST_TODO_FAILED,
+        restart_fn=recorder,
+        agent_name="agent-x",
+        now_fn=lambda: 100.0,
+        state_dir=tmp_path,
+    )
+    # Assert
+    assert result["failed"] == ["scitex-todo"]
+
+
+def test_run_healthcheck_failed_requests_restart(tmp_path):
+    # Arrange
+    recorder = _RestartRecorder(accept=True)
+    # Act
+    run_healthcheck(
+        mcp_list_runner=lambda: _LIST_TODO_FAILED,
+        restart_fn=recorder,
+        agent_name="agent-x",
+        now_fn=lambda: 100.0,
+        state_dir=tmp_path,
+    )
+    # Assert
+    assert recorder.calls == ["agent-x"]
+
+
+def test_run_healthcheck_restart_accepted_action(tmp_path):
+    # Arrange
+    recorder = _RestartRecorder(accept=True)
+    # Act
+    result = run_healthcheck(
+        mcp_list_runner=lambda: _LIST_TODO_FAILED,
+        restart_fn=recorder,
+        agent_name="agent-x",
+        now_fn=lambda: 100.0,
+        state_dir=tmp_path,
+    )
+    # Assert
+    assert result["action"] == "restart-requested"
+
+
+def test_run_healthcheck_second_call_hits_cooldown(tmp_path):
+    # Arrange — first call stamps the sentinel; a near-in-time second must not
+    # restart again.
+    recorder = _RestartRecorder(accept=True)
+    run_healthcheck(
+        mcp_list_runner=lambda: _LIST_TODO_FAILED,
+        restart_fn=recorder,
+        agent_name="agent-x",
+        now_fn=lambda: 100.0,
+        state_dir=tmp_path,
+    )
+    # Act
+    result = run_healthcheck(
+        mcp_list_runner=lambda: _LIST_TODO_FAILED,
+        restart_fn=recorder,
+        agent_name="agent-x",
+        now_fn=lambda: 200.0,
+        state_dir=tmp_path,
+    )
+    # Assert
+    assert result["action"] == "restart-cooldown"
+
+
+def test_run_healthcheck_cooldown_does_not_restart_twice(tmp_path):
+    # Arrange
+    recorder = _RestartRecorder(accept=True)
+    run_healthcheck(
+        mcp_list_runner=lambda: _LIST_TODO_FAILED,
+        restart_fn=recorder,
+        agent_name="agent-x",
+        now_fn=lambda: 100.0,
+        state_dir=tmp_path,
+    )
+    # Act
+    run_healthcheck(
+        mcp_list_runner=lambda: _LIST_TODO_FAILED,
+        restart_fn=recorder,
+        agent_name="agent-x",
+        now_fn=lambda: 200.0,
+        state_dir=tmp_path,
+    )
+    # Assert — only the first call brokered a restart.
+    assert recorder.calls == ["agent-x"]
+
+
+def test_run_healthcheck_no_restart_alarms_only(tmp_path):
+    # Arrange
+    recorder = _RestartRecorder()
+    # Act
+    result = run_healthcheck(
+        mcp_list_runner=lambda: _LIST_TODO_FAILED,
+        restart_fn=recorder,
+        agent_name="agent-x",
+        now_fn=lambda: 100.0,
+        state_dir=tmp_path,
+        allow_restart=False,
+    )
+    # Assert
+    assert result["action"] == "alarm-only"
+
+
+def test_run_healthcheck_disabled(tmp_path):
+    # Arrange
+    recorder = _RestartRecorder()
+    # Act
+    result = run_healthcheck(
+        mcp_list_runner=lambda: _LIST_TODO_FAILED,
+        restart_fn=recorder,
+        agent_name="agent-x",
+        state_dir=tmp_path,
+        disabled=True,
+    )
+    # Assert
+    assert result["action"] == "disabled"
+
+
+def test_run_healthcheck_fail_open_when_runner_raises(tmp_path):
+    # Arrange — a runner that blows up must not crash the check.
+    def _boom() -> str:
+        raise RuntimeError("no claude binary")
+
+    # Act
+    result = run_healthcheck(
+        mcp_list_runner=_boom,
+        restart_fn=_RestartRecorder(),
+        agent_name="agent-x",
+        state_dir=tmp_path,
+    )
+    # Assert
+    assert result["action"] == "error"

--- a/tests/scitex_agent_container/runtimes/test__apptainer_listen_env.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_listen_env.py
@@ -66,6 +66,32 @@ def test_listen_env_flags_injects_testmon_cache_root_var(
     )
 
 
+def test_listen_env_flags_injects_mcp_timeout(
+    no_bus_config: SimpleNamespace,
+    sandboxed_home: Path,
+) -> None:
+    # Arrange — fixtures supply an empty-channel config + sandboxed $HOME.
+    _ = sandboxed_home
+    # Act
+    flags = listen_env_flags(no_bus_config)
+    # Assert — the raised MCP startup connect timeout reaches the launch env
+    # (fleet incident 2026-07-06 cold-start race fix).
+    assert "MCP_TIMEOUT=30000" in flags
+
+
+def test_listen_env_flags_mcp_timeout_follows_an_env_token(
+    no_bus_config: SimpleNamespace,
+    sandboxed_home: Path,
+) -> None:
+    # Arrange — apptainer consumes ``--env KEY=VALUE`` as two argv tokens.
+    _ = sandboxed_home
+    flags = listen_env_flags(no_bus_config)
+    # Act
+    idx = flags.index("MCP_TIMEOUT=30000")
+    # Assert
+    assert flags[idx - 1] == "--env"
+
+
 def test_listen_env_flags_testmon_var_follows_an_env_token(
     no_bus_config: SimpleNamespace,
     sandboxed_home: Path,

--- a/tests/scitex_agent_container/runtimes/test__mcp_merge.py
+++ b/tests/scitex_agent_container/runtimes/test__mcp_merge.py
@@ -104,3 +104,16 @@ def test_non_mcpservers_keys_are_preserved_from_both():
     merged = merge_mcp_json(base, overlay)
     # Assert
     assert merged["_note"] == "baseline"
+
+
+def test_baseline_always_load_survives_overlay_without_it():
+    # Arrange — the cold-start-race fix stamps ``alwaysLoad`` on the baseline
+    # server; an agent overlay that overrides only a leaf (env) must NOT drop
+    # it (fleet incident 2026-07-06 — the merge preserves unknown per-server
+    # fields).
+    base = {"mcpServers": {"scitex-todo": {"command": "st", "alwaysLoad": True}}}
+    overlay = {"mcpServers": {"scitex-todo": {"env": {"X": "1"}}}}
+    # Act
+    merged = merge_mcp_json(base, overlay)
+    # Assert
+    assert merged["mcpServers"]["scitex-todo"]["alwaysLoad"] is True

--- a/tests/scitex_agent_container/runtimes/test__mcp_reliability.py
+++ b/tests/scitex_agent_container/runtimes/test__mcp_reliability.py
@@ -1,0 +1,127 @@
+"""Tests for the fleet MCP cold-start reliability knobs.
+
+Two deterministic, config-only levers distributed via to_home:
+  * ``inject_always_load`` stamps ``alwaysLoad:true`` onto the critical stdio
+    MCP servers so Claude Code BLOCKS on startup until they connect.
+  * ``mcp_timeout_env_flags`` raises the client MCP startup connect timeout.
+
+Conventions: one assert / AAA markers; no mocks — pure dict / list inputs.
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container.runtimes._mcp_reliability import (
+    CRITICAL_MCP_SERVERS,
+    MCP_STARTUP_TIMEOUT_MS,
+    inject_always_load,
+    mcp_timeout_env_flags,
+)
+
+
+def test_inject_always_load_stamps_sac_server():
+    # Arrange
+    doc = {"mcpServers": {"scitex-agent-container": {"command": "sac"}}}
+    # Act
+    inject_always_load(doc)
+    # Assert
+    assert doc["mcpServers"]["scitex-agent-container"]["alwaysLoad"] is True
+
+
+def test_inject_always_load_stamps_todo_server():
+    # Arrange
+    doc = {"mcpServers": {"scitex-todo": {"command": "scitex-todo"}}}
+    # Act
+    inject_always_load(doc)
+    # Assert
+    assert doc["mcpServers"]["scitex-todo"]["alwaysLoad"] is True
+
+
+def test_inject_always_load_leaves_non_critical_servers_untouched():
+    # Arrange
+    doc = {"mcpServers": {"claude-code-telegrammer": {"command": "bun"}}}
+    # Act
+    inject_always_load(doc)
+    # Assert — a non-critical server must NOT be forced to block startup.
+    assert "alwaysLoad" not in doc["mcpServers"]["claude-code-telegrammer"]
+
+
+def test_inject_always_load_respects_explicit_override():
+    # Arrange — a deliberate per-agent opt-out must survive.
+    doc = {"mcpServers": {"scitex-todo": {"command": "x", "alwaysLoad": False}}}
+    # Act
+    inject_always_load(doc)
+    # Assert
+    assert doc["mcpServers"]["scitex-todo"]["alwaysLoad"] is False
+
+
+def test_inject_always_load_skips_absent_server():
+    # Arrange — only one of the two critical servers present.
+    doc = {"mcpServers": {"scitex-agent-container": {"command": "sac"}}}
+    # Act
+    inject_always_load(doc)
+    # Assert
+    assert "scitex-todo" not in doc["mcpServers"]
+
+
+def test_inject_always_load_fail_open_on_missing_mcpservers_key():
+    # Arrange — no mcpServers key at all.
+    doc = {"unrelated": 1}
+    # Act
+    out = inject_always_load(doc)
+    # Assert — returned unchanged, no raise.
+    assert out == {"unrelated": 1}
+
+
+def test_inject_always_load_fail_open_on_non_dict_mcpservers():
+    # Arrange — malformed mcpServers value.
+    doc = {"mcpServers": []}
+    # Act
+    out = inject_always_load(doc)
+    # Assert
+    assert out == {"mcpServers": []}
+
+
+def test_inject_always_load_is_idempotent():
+    # Arrange
+    doc = {"mcpServers": {"scitex-todo": {"command": "x"}}}
+    # Act
+    inject_always_load(doc)
+    inject_always_load(doc)
+    # Assert
+    assert doc["mcpServers"]["scitex-todo"]["alwaysLoad"] is True
+
+
+def test_mcp_timeout_env_flags_shape():
+    # Arrange
+    expected = ["--env", f"MCP_TIMEOUT={MCP_STARTUP_TIMEOUT_MS}"]
+    # Act
+    flags = mcp_timeout_env_flags()
+    # Assert — apptainer `--env KEY=VALUE` pair.
+    assert flags == expected
+
+
+def test_mcp_timeout_is_generous():
+    # Arrange
+    minimum_ms = 30000
+    # Act
+    value = int(MCP_STARTUP_TIMEOUT_MS)
+    # Assert — must cover the multi-second fastmcp cold-start.
+    assert value >= minimum_ms
+
+
+def test_critical_servers_include_sac():
+    # Arrange
+    server = "scitex-agent-container"
+    # Act
+    present = server in CRITICAL_MCP_SERVERS
+    # Assert
+    assert present is True
+
+
+def test_critical_servers_include_todo():
+    # Arrange
+    server = "scitex-todo"
+    # Act
+    present = server in CRITICAL_MCP_SERVERS
+    # Assert
+    assert present is True


### PR DESCRIPTION
## Fleet incident 2026-07-06 — intermittent MCP connect failure at agent launch

**Root cause (root-caused + verified):** the `scitex-agent-container` (`sac mcp start`)
and `scitex-todo` (`scitex-todo mcp start`) **stdio** MCP servers intermittently fail to
connect at Claude Code session start. The servers start healthy — this is a **client-side
cold-start connect-timing race**: the heavy `fastmcp` import makes the stdio server slow to
become ready and intermittently exceeds Claude Code's MCP startup/connect timeout. Claude
Code does **NOT** auto-reconnect a failed *stdio* MCP (its 3-initial / 5-mid-session retries
are HTTP/SSE only, confirmed via claude-code-guide), so the agent then runs its **entire
session** missing `host_exec` / `agent_spawn` / `db_*` / the todo tools.

**Profiling (this container's FS, coverage-free, `perf_counter`):**

| phase | ms |
|---|---|
| `import fastmcp` | 2113 |
| `from fastmcp import FastMCP` | 2334 |
| import all 9 sac tool modules (eager) | 42 |
| `FastMCP()` construct | 6 |
| `register_all_tools` schema-gen (~35 tools) | 297 |

→ **`import fastmcp` (~4.4 s combined) dominates cold-start** by ~100× over the tool
modules. So the decisive levers are the two config knobs + a raised timeout; lazy-import is a
smaller, correct-direction improvement.

## The fix (four parts)

1. **`.mcp.json` `alwaysLoad: true`** on the critical stdio servers → forces **blocking**
   startup (the session WAITS for connect, capped by `MCP_TIMEOUT`) instead of the default
   racy background connect. Real Claude Code field (v2.1.121+; harmless no-op on older
   clients). Landed:
   - source dotfiles `_shared/to_home/.mcp.json` (applied by the coordinator directly);
   - **sac-side defensive injection** in `runtimes/_to_home_deployers._deploy_mcp_merge` +
     `runtimes/mcp_config._setup_mcp_from_servers` via new
     `runtimes/_mcp_reliability.inject_always_load`, so it is stamped on at materialize time
     even if a source lacks it;
   - **verified the deep-merge PRESERVES it**: `merge_mcp_json` keeps unknown per-server
     fields when an agent overlay overrides only a leaf (regression test added).

2. **`MCP_TIMEOUT=30000` (ms)** in the agent **launch env** (the env Claude Code reads at
   startup — NOT the per-server `timeout` field, which is per-tool-call). Landed in
   `runtimes/_apptainer_listen_env.listen_env_flags` (the sac-managed `--env` injector that
   `_apptainer_build_argv` appends to `apptainer exec`), alongside the existing
   `DIRENV_CONFIG` / `UV_PROJECT_ENVIRONMENT` / … unconditional tooling knobs.

3. **Lazy-import** the `sac mcp start` server: `_mcp/server.py` no longer imports the tool
   modules at module top-level (`import scitex_agent_container._mcp` stays cheap); the 9 tool
   modules are imported inside `_build_server()`. The heavy per-tool implementations
   (`host_exec` / `agent_spawn` / db / image / template clients) were already lazy inside each
   tool body. Behavior identical; reduces how long `alwaysLoad` blocks.

4. **Auto-heal boot self-check** — `sac mcp healthcheck` (new, `_mcp/_healthcheck.py`),
   FAIL-OPEN throughout:
   - **logs the expected capability surface** so a missing tool reads as "MCP broken → heal",
     not "I lack that capability";
   - detects connect status via `claude mcp list` (Claude Code's live per-server check);
   - on a failed critical MCP: raises a loud alarm and requests a **rate-limited** (`<= 1 /
     30 min`, sentinel-guarded so no boot->restart loop) `--fresh` **self-restart** via the
     existing host `sac listen` broker (`_lifecycle/_restart_client.request_restart`, the same
     path `sac agents restart` uses).
   - Wired to run at boot via a `SessionStart` hook (see distribution note).

## Distribution (to_home materialization)

- alwaysLoad + MCP_TIMEOUT flow to every agent via the sac-side materialization above (pip /
  next deploy) — no dotfiles dependency for those two.
- The `sac mcp healthcheck` **command** ships in the package (tested). Its `SessionStart`
  hook **registration** should be added to the fleet baseline settings (dotfiles), consistent
  with how the other baseline hooks (escalate, honest-grounding Stop gate) are distributed —
  exact patch below. `settings_json.py` is already over the 512-line cap, so a package-side
  `_HOOKS_CONFIG` `SessionStart` entry is deferred to avoid dragging an unrelated refactor
  into this incident PR.

**Dotfiles patch (baseline `_shared/to_home/.claude/settings.json`), to run the boot check:**
```json
"SessionStart": [
  { "hooks": [ { "type": "command", "command": "sac mcp healthcheck" } ] }
]
```

## Notes

- **fastmcp is NOT pinned here** — the ecosystem-wide `fastmcp` version pin is scitex-dev's
  domain. Surfacing for traceability: sac's `pyproject.toml` carries an **unpinned
  `fastmcp>=2.0`** (no ceiling). scitex-dev confirmed identical `fastmcp 3.4.2` across current
  base SIFs (no version skew) — the race is pure cold-start timing. `sac versions --json
  --live --base-only` is the diagnostic that confirms the fastmcp version across SIFs.
- This is one of three coherent "detect-degraded -> auto-restart/heal" fixes today; it reuses
  the existing restart-broker + alarm + `SessionStart`-hook patterns rather than inventing a
  parallel mechanism.

## Tests

New `tests/.../runtimes/test__mcp_reliability.py` and `tests/.../_mcp/test__healthcheck.py`
(real callables / `tmp_path`, no mocks); regression tests added to `test__mcp_merge.py`
(alwaysLoad preserved through the deep-merge) and `test__apptainer_listen_env.py`
(`MCP_TIMEOUT` reaches the launch env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
