### PR TITLE
fix(acl): in-place restart keeps lineage (no re-parent 409)

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_spawn_gate.py
+++ b/src/scitex_agent_container/_lifecycle/_spawn_gate.py
@@ -142,8 +142,8 @@ def enforce_spawn_gate(
 
     Raises:
         SpawnDeniedError: when the spawn is not permitted by current
-            policy, or when the lineage edge conflicts with an existing
-            different parent.
+            policy. (A re-parent attempt no longer raises — record_lineage
+            keeps the existing parent in-place, so restarts are allowed.)
     """
     from .._listen._acl import check_spawn
     from .._state.state_db_nodes import record_lineage
@@ -162,9 +162,9 @@ def enforce_spawn_gate(
         try:
             record_lineage(child=child_name, parent=caller, db_path=db_path)
         except ValueError as exc:
-            # A child that switches parents is exactly the identity drift
-            # the ACL is meant to prevent — reject loudly, never silently
-            # re-parent.
+            # record_lineage keeps the existing parent on a re-parent
+            # attempt (restart-in-place) rather than raising; this except
+            # now only guards the empty child/parent programming error.
             raise SpawnDeniedError(str(exc)) from exc
 
     return caller

--- a/src/scitex_agent_container/_state/state_db_nodes.py
+++ b/src/scitex_agent_container/_state/state_db_nodes.py
@@ -37,6 +37,7 @@ All times stored as ``REAL`` unix-seconds (float).
 
 from __future__ import annotations
 
+import logging
 import secrets
 import time
 from pathlib import Path
@@ -49,6 +50,8 @@ from .state_db_acl_policy import (
     record_comms_policy,
     sender_target_relationship,
 )
+
+_logger = logging.getLogger(__name__)
 
 __all__ = [
     "CommsNodeConflictError",
@@ -169,13 +172,13 @@ def record_lineage(
     parent: str,
     db_path: Path | None = None,
 ) -> None:
-    """Record ``parent`` as the parent of ``child``.
+    """Record ``parent`` as ``child``'s parent (keep-first-parent).
 
-    Idempotent — a second call with the same child+parent leaves the
-    row untouched. A different parent for an existing child raises
-    ``ValueError`` (re-parenting is not a quiet operation; a child
-    that "switches groups" is exactly the kind of identity drift the
-    ACL is meant to prevent).
+    Idempotent; a child's parent is set once and immutable. A DIFFERENT
+    parent KEEPS the existing one (logged, not raised) so a restart by a
+    non-original-parent caller works in-place without re-parenting;
+    identity drift stays impossible. Permission is gated upstream by
+    ``check_spawn``.
     """
     if not child or not parent:
         raise ValueError("record_lineage: child and parent must be non-empty")
@@ -188,11 +191,11 @@ def record_lineage(
         if existing is not None:
             if existing["parent_name"] == parent:
                 return  # idempotent no-op
-            raise ValueError(
-                f"record_lineage: child {child!r} already has parent "
-                f"{existing['parent_name']!r}; refusing to re-parent to "
-                f"{parent!r}"
+            _logger.warning(
+                "record_lineage: child %r keeps parent %r (ignored re-parent to %r)",
+                child, existing["parent_name"], parent,
             )
+            return
         conn.execute(
             "INSERT INTO lineage (child_name, parent_name, created_at) "
             "VALUES (?, ?, ?)",

--- a/tests/scitex_agent_container/_lifecycle/test__spawn_gate.py
+++ b/tests/scitex_agent_container/_lifecycle/test__spawn_gate.py
@@ -175,16 +175,17 @@ def test_gate_denies_child_caller_under_root_only_policy(db_path, sac_name) -> N
         enforce_spawn_gate("grandchild")
 
 
-def test_gate_denies_reparent_to_different_caller(db_path, sac_name) -> None:
-    # Arrange — child-f already parented to "root-1"; re-spawn under a
-    # different root must be rejected (identity drift the ACL prevents).
+def test_gate_allows_restart_keeps_existing_parent(db_path, sac_name) -> None:
+    # Arrange — child-f already parented to "root-1"; a restart by a
+    # different-lineage caller must SUCCEED in-place (no re-parent, no
+    # SpawnDeniedError) — the 409 the ACL previously raised is now gone,
+    # so a developer/research peer can restart a down agent.
     record_lineage(child="child-f", parent="root-1", db_path=db_path)
     sac_name("root-2")
-    # Act
-    ctx = pytest.raises(SpawnDeniedError)
-    # Assert
-    with ctx:
-        enforce_spawn_gate("child-f")
+    # Act — must not raise; record_lineage keeps the existing parent
+    result = enforce_spawn_gate("child-f")
+    # Assert — the restart proceeded, returning the resolved caller
+    assert result == "root-2"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scitex_agent_container/_state/test_state_db_nodes.py
+++ b/tests/scitex_agent_container/_state/test_state_db_nodes.py
@@ -126,14 +126,25 @@ def test_record_lineage_idempotent_no_duplicate_rows(db_path: Path) -> None:
     assert len(rows) == 1
 
 
-def test_record_lineage_re_parent_raises(db_path: Path) -> None:
-    """A child cannot silently switch parents."""
+def test_record_lineage_re_parent_keeps_existing_parent(db_path: Path) -> None:
+    """A re-parent attempt keeps the original parent (no raise, no switch).
+
+    A restart of an existing agent by a different-lineage caller must not
+    be blocked and must not re-parent — the original parent is kept, so
+    identity drift stays impossible while restarts succeed. (No raise is
+    implicit: a raising record_lineage would error this test.)
+    """
     # Arrange
     record_lineage(child="bob", parent="alice", db_path=db_path)
-    # Act
-    # Assert
-    with pytest.raises(ValueError, match="refusing to re-parent"):
-        record_lineage(child="bob", parent="other-root", db_path=db_path)
+    # Act — a different parent must NOT raise; it keeps "alice"
+    record_lineage(child="bob", parent="other-root", db_path=db_path)
+    # Assert — original parent kept, not switched to the new caller
+    conn_ctx = state_db.open_db(db_path)
+    with conn_ctx as conn:
+        row = conn.execute(
+            "SELECT parent_name FROM lineage WHERE child_name='bob'"
+        ).fetchone()
+    assert row["parent_name"] == "alice"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Second gap of the 2026-07-06 ACL incident. #559 fixed spawn_allowed (developer/research groups pass the spawn permission gate), but a cross-lineage RESTART still 409d: record_lineage(child, parent=caller) raised refusing-to-re-parent when the caller was not the child original parent (always true for a peer restarting a down agent). Fix: record_lineage is keep-first-parent (parent immutable; a different parent keeps the existing one, logged, no raise); _spawn_gate no longer turns that into SpawnDeniedError. Permission stays gated upstream by check_spawn; identity drift stays impossible. Tests: record_lineage keep-existing + spawn_gate restart-in-place (50 passed). Enables a developer/research peer to restart a down agent (e.g. scitex-clew) without operator/host_exec.