### PR TITLE
feat(a2a): expose agent role/responsibilities from spec (peers + AgentCard)

### DIFF
--- a/src/scitex_agent_container/_listen/_registry_endpoints.py
+++ b/src/scitex_agent_container/_listen/_registry_endpoints.py
@@ -164,9 +164,112 @@ def enrich_row_with_endpoint(row: dict) -> dict:
     return out
 
 
+def _load_spec_dict(agent_name: str) -> dict | None:
+    """Return the raw v3 spec dict for ``agent_name``, or ``None``.
+
+    Best-effort: resolves the agent's ``spec.yaml`` via the same
+    :func:`config._resolve.resolve_config` the status route uses, then
+    parses it. Every failure (unknown name, unreadable / malformed YAML,
+    ambiguous registry) degrades to ``None`` so a peers row is NEVER
+    blocked — the registry list is a discovery surface, not a gate.
+    """
+    try:
+        import yaml
+
+        from ..config._resolve import resolve_config
+
+        path = resolve_config(agent_name)
+        with open(path, encoding="utf-8") as fh:
+            data = yaml.safe_load(fh)
+        return data if isinstance(data, dict) else None
+    except Exception:  # stx-allow: fallback (reason: best-effort role/owner enrichment — a missing/unreadable spec surfaces as absent fields)
+        return None
+
+
+def resolve_agent_identity(agent_name: str) -> dict:
+    """Return the spec-authored identity for ``agent_name``, best-effort.
+
+    Operator directive 2026-07-06: an agent's ROLE (headline) +
+    RESPONSIBILITIES (bullets), plus its groups / purpose / owned repo,
+    must be discoverable fleet-wide via ``a2a peers`` so a peer sees who
+    does what without asking.
+
+    Field extraction is delegated to
+    :func:`a2a._card_identity.spec_identity` — the SAME projection the
+    AgentCard uses — so the two a2a surfaces (peer rows + AgentCard)
+    never drift. Returns only the keys the spec declares
+    (omit-if-missing); ``{}`` on any failure.
+    """
+    v3 = _load_spec_dict(agent_name)
+    if v3 is None:
+        return {}
+    try:
+        from ..a2a._card_identity import spec_identity
+
+        return spec_identity(v3)
+    except Exception:  # stx-allow: fallback (reason: best-effort — an identity-projection failure surfaces as absent fields)
+        return {}
+
+
+# Optional identity fields carried on a peers row IN ADDITION to the
+# always-present ``role`` headline. Each is added only when the spec
+# actually declares it (omit-if-missing), so a row never advertises a
+# blank.
+_OPTIONAL_IDENTITY_KEYS = ("responsibilities", "groups", "purpose", "project")
+
+
+def enrich_row_with_role_owner(row: dict, *, resolver=resolve_agent_identity) -> dict:
+    """Add the spec-authored identity fields to ``row`` (idempotent, best-effort).
+
+    Mirrors :func:`enrich_row_with_endpoint`: a row that already carries a
+    NON-NONE value for a field keeps its own (a self-peer / registry row
+    is the authoritative source for what it already knows). ``resolver``
+    is injectable so the pure enrichment logic is testable without an
+    on-disk spec.
+
+    ``role`` is ALWAYS emitted (``None`` when the agent has no resolvable
+    role) so the ``GET /agents`` response shape stays uniform — ``role``
+    is THE discovery headline. The remaining identity fields
+    (``responsibilities`` / ``groups`` / ``purpose`` / ``project``) are
+    added ONLY when the spec declares them (omit-if-missing).
+    """
+    if not isinstance(row, dict):
+        return row
+    out = dict(row)
+    name = row.get("name")
+    identity: dict = {}
+    if isinstance(name, str) and name:
+        identity = resolver(name) or {}
+    # role — the headline; always present, pre-existing non-None wins.
+    if out.get("role") is None:
+        out["role"] = identity.get("role")
+    # optional identity fields — omit-if-missing, pre-existing wins.
+    for key in _OPTIONAL_IDENTITY_KEYS:
+        if out.get(key) is None and key in identity:
+            out[key] = identity[key]
+    return out
+
+
+def enrich_row(row: dict) -> dict:
+    """Apply BOTH registry enrichments to ``row`` — the composed shape every
+    registry surface ships.
+
+    Layers the endpoint fields (``a2a_port`` / ``turn_url``) and the
+    spec-authored identity (``role`` + ``responsibilities`` / ``groups`` /
+    ``purpose`` / ``project``) in one call so the ``GET /agents`` list and
+    ``GET /agents/<name>/status`` bodies carry an identical, uniform shape.
+    Both layers are idempotent + best-effort, so this is safe to apply to
+    rows that already carry some of the fields.
+    """
+    return enrich_row_with_role_owner(enrich_row_with_endpoint(row))
+
+
 __all__ = [
     "derive_turn_url",
+    "enrich_row",
     "enrich_row_with_endpoint",
+    "enrich_row_with_role_owner",
     "resolve_a2a_host",
     "resolve_a2a_port",
+    "resolve_agent_identity",
 ]

--- a/src/scitex_agent_container/_listen/server.py
+++ b/src/scitex_agent_container/_listen/server.py
@@ -156,9 +156,9 @@ async def list_agents(_request: Request) -> JSONResponse:
     # Idempotent: self-peer rows that already carry a non-None value
     # keep theirs (the discovery layer is the authoritative source for
     # those).
-    from ._registry_endpoints import enrich_row_with_endpoint
+    from ._registry_endpoints import enrich_row
 
-    rows = [enrich_row_with_endpoint(row) for row in rows]
+    rows = [enrich_row(row) for row in rows]
     return JSONResponse({"agents": rows})
 
 
@@ -224,9 +224,9 @@ async def agent_status(request: Request) -> JSONResponse:
     # Q1 (lead dispatch a2a dc6fd23387f64e329049d218cf85a4d4): surface
     # ``a2a_port`` + derived ``turn_url`` so a status poll yields the
     # same endpoint shape ``GET /agents`` does.
-    from ._registry_endpoints import enrich_row_with_endpoint
+    from ._registry_endpoints import enrich_row
 
-    body = enrich_row_with_endpoint(body)
+    body = enrich_row(body)
     return JSONResponse(body)
 
 

--- a/src/scitex_agent_container/a2a/_card.py
+++ b/src/scitex_agent_container/a2a/_card.py
@@ -23,6 +23,8 @@ from typing import Any
 from a2a.types import AgentCard
 from google.protobuf.json_format import ParseDict
 
+from ._card_identity import as_str_list, spec_identity
+
 DEFAULT_INPUT_MODES = ["text/plain", "application/json"]
 DEFAULT_OUTPUT_MODES = ["text/plain", "application/json"]
 
@@ -65,7 +67,18 @@ def project_card(name: str, v3: dict[str, Any], base_url: str) -> dict[str, Any]
     label_skills = [s.strip() for s in skills_csv.split(",") if s.strip()]
     legacy_skills = (spec.get("skills") or {}).get("required") or []
     required_skills = list(label_skills) + list(legacy_skills)
-    role = labels.get("role", "agent")
+    # ``role`` here is the string ROLE-CLASS used for the skill id and the
+    # provider/description fallbacks — it must stay a scalar string. A
+    # (future) multi-role spec carries a list; collapse to its first entry
+    # so the string-typed skill fields stay proto-valid. The faithful
+    # value (string OR list) is surfaced separately under
+    # ``x-scitex-agent-container`` via :func:`spec_identity` below.
+    _role_label = labels.get("role")
+    if isinstance(_role_label, str) and _role_label.strip():
+        role = _role_label.strip()
+    else:
+        _roles = as_str_list(_role_label)
+        role = _roles[0] if _roles else "agent"
     function = labels.get("function", "")
 
     agent_base = f"{base}/agents/{name}"
@@ -106,6 +119,32 @@ def project_card(name: str, v3: dict[str, Any], base_url: str) -> dict[str, Any]
                 },
             }
         )
+
+    x_block: dict[str, Any] = {
+        "role_class": role,
+        "cardinality": labels.get("cardinality"),
+        "scheduling": _scheduling(spec),
+        "runtime": spec.get("runtime"),
+        # v3 moves model under spec.claude.model; legacy v2 had it at
+        # spec.model. Prefer v3, fall back to v2 for back-compat.
+        "model": (spec.get("claude") or {}).get("model") or spec.get("model"),
+        "multiplexer": spec.get("multiplexer"),
+        "required_skills": list(required_skills),
+        # D3 — structured isolation block (see
+        # docs/adr/0001-isolation-hardening.md). External verifiers (Clew,
+        # orochi attestation) read these booleans to attest specific
+        # properties; ``level`` is the human shorthand.
+        "isolation": _isolation_block(spec),
+    }
+    # Operator 2026-07-06: surface the spec-authored identity — the ROLE
+    # headline (string, or list for multi-role) + a RESPONSIBILITIES
+    # bullet list, plus groups / purpose / owned-repo — so a peer reading
+    # this agent's AgentCard sees who it is and what it owns. Same
+    # projection the ``a2a peers`` rows use, so the two a2a discovery
+    # surfaces never drift. Only spec-declared fields are added (the
+    # extension namespace is stripped before v1 proto validation, so this
+    # is schema-safe regardless of which fields appear).
+    x_block.update(spec_identity(v3))
 
     return {
         "name": name,
@@ -153,22 +192,7 @@ def project_card(name: str, v3: dict[str, Any], base_url: str) -> dict[str, Any]
                 "tags": sorted(set(capabilities_tags + list(required_skills))),
             }
         ],
-        "x-scitex-agent-container": {
-            "role_class": role,
-            "cardinality": labels.get("cardinality"),
-            "scheduling": _scheduling(spec),
-            "runtime": spec.get("runtime"),
-            # v3 moves model under spec.claude.model; legacy v2 had it at
-            # spec.model. Prefer v3, fall back to v2 for back-compat.
-            "model": (spec.get("claude") or {}).get("model") or spec.get("model"),
-            "multiplexer": spec.get("multiplexer"),
-            "required_skills": list(required_skills),
-            # D3 — structured isolation block (see
-            # docs/adr/0001-isolation-hardening.md). External
-            # verifiers (Clew, orochi attestation) read these booleans to
-            # attest specific properties; ``level`` is the human shorthand.
-            "isolation": _isolation_block(spec),
-        },
+        "x-scitex-agent-container": x_block,
     }
 
 

--- a/src/scitex_agent_container/a2a/_card_identity.py
+++ b/src/scitex_agent_container/a2a/_card_identity.py
@@ -1,0 +1,123 @@
+"""Spec → operator-facing identity projection (shared by both a2a surfaces).
+
+An agent's ROLE (headline) + RESPONSIBILITIES (bullets), plus its groups /
+purpose / owned-repo, are authored in its ``spec.yaml`` and must be
+discoverable fleet-wide via a2a (operator directive 2026-07-06) so a peer
+can see "who does what" without asking. Two surfaces expose them:
+
+* the AgentCard — :func:`a2a._card.project_card` merges these fields into
+  the card's ``x-scitex-agent-container`` block; and
+* the ``a2a peers`` rows — :func:`_listen._registry_endpoints`
+  ``.resolve_agent_identity`` adds them to each ``GET /agents`` row.
+
+Both call :func:`spec_identity` here, so the two surfaces never drift.
+This module is deliberately dependency-free (no a2a SDK proto import, no
+fleet imports) so the row surface can reuse it without dragging in the
+card's protobuf types.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+__all__ = ["spec_identity", "as_str_list"]
+
+
+def as_str_list(value: Any) -> list[str]:
+    """Coerce a CSV string / list into a clean ``list[str]`` (``[]`` else).
+
+    Pure. A ``str`` is split on commas; a ``list``/``tuple`` is filtered
+    to its non-empty stringifiable scalars. Anything else (``None``,
+    ``dict``, number) yields ``[]``. Whitespace is stripped and empties
+    dropped so a discovery surface never advertises a blank bullet.
+    """
+    if isinstance(value, str):
+        return [item.strip() for item in value.split(",") if item.strip()]
+    if isinstance(value, (list, tuple)):
+        out: list[str] = []
+        for item in value:
+            if isinstance(item, (list, dict)) or item is None:
+                continue
+            text = str(item).strip()
+            if text:
+                out.append(text)
+        return out
+    return []
+
+
+def spec_identity(v3: dict[str, Any]) -> dict[str, Any]:
+    """Project the operator-facing identity fields from a v3 spec dict.
+
+    Pure + best-effort. Returns ONLY the keys the spec actually declares
+    (omit-if-missing), so a surface advertises real data and never a
+    fabricated blank:
+
+    * ``role`` — ``metadata.labels.role``. A plain string for the common
+      single-role spec; a ``list[str]`` for a (future) multi-role spec
+      (the operator wants multi-role shown as bullets downstream). A
+      single-element list collapses to a bare string.
+    * ``responsibilities`` — a bullet ``list[str]``. Prefers the
+      top-level ``spec.responsibilities``; falls back to
+      ``metadata.labels.responsibilities`` (list or CSV string).
+    * ``groups`` — ``metadata.labels.groups`` (list) or the singular
+      ``metadata.labels.group`` (string), normalised to a ``list[str]``.
+    * ``purpose`` — ``metadata.labels.purpose`` (free-text string).
+    * ``project`` — basename of an explicit ``spec.workdir`` (the repo
+      the agent owns / works in). Absent when no workdir is declared.
+    """
+    if not isinstance(v3, dict):
+        return {}
+    metadata = v3.get("metadata") or {}
+    labels = metadata.get("labels") if isinstance(metadata, dict) else {}
+    spec = v3.get("spec") or {}
+    if not isinstance(labels, dict):
+        labels = {}
+    if not isinstance(spec, dict):
+        spec = {}
+
+    out: dict[str, Any] = {}
+
+    # role — headline. A non-empty string is kept verbatim; a list is
+    # normalised to a clean list[str] (multi-role) and a single element
+    # collapses to a bare string so common consumers stay simple.
+    raw_role = labels.get("role")
+    if isinstance(raw_role, str) and raw_role.strip():
+        out["role"] = raw_role.strip()
+    elif isinstance(raw_role, (list, tuple)):
+        roles = as_str_list(raw_role)
+        if len(roles) == 1:
+            out["role"] = roles[0]
+        elif roles:
+            out["role"] = roles
+
+    # responsibilities — prefer the top-level spec list; fall back to a
+    # labels entry (list or CSV) for specs that carry it there instead.
+    responsibilities = as_str_list(spec.get("responsibilities"))
+    if not responsibilities:
+        responsibilities = as_str_list(labels.get("responsibilities"))
+    if responsibilities:
+        out["responsibilities"] = responsibilities
+
+    # groups — plural list wins; singular ``group`` string as fallback.
+    groups = as_str_list(labels.get("groups"))
+    if not groups:
+        single = labels.get("group")
+        if isinstance(single, str) and single.strip():
+            groups = [single.strip()]
+    if groups:
+        out["groups"] = groups
+
+    # purpose — free-text one-liner.
+    purpose = labels.get("purpose")
+    if isinstance(purpose, str) and purpose.strip():
+        out["purpose"] = purpose.strip()
+
+    # project — the repo the agent owns (basename of an explicit workdir).
+    workdir = spec.get("workdir")
+    if isinstance(workdir, str) and workdir.strip():
+        base = Path(workdir.strip().rstrip("/")).name
+        if base:
+            out["project"] = base
+
+    return out

--- a/tests/scitex_agent_container/a2a/test__card.py
+++ b/tests/scitex_agent_container/a2a/test__card.py
@@ -372,3 +372,90 @@ def test_isolation_preflight_allow_surfaces_in_preflight_allowed(
     allowed = iso["preflight_allowed"]
     # Assert
     assert allowed == ["$HOME/.gitconfig"]
+
+
+# ---------------------------------------------------------------------------
+# Operator 2026-07-06 — spec-authored identity on the local-agent AgentCard.
+# The role HEADLINE + RESPONSIBILITIES bullets (plus groups/purpose/owner)
+# are surfaced under ``x-scitex-agent-container`` so a peer reading the card
+# sees who the agent is. The extension namespace is stripped before v1 proto
+# validation, so these fields are schema-safe.
+# ---------------------------------------------------------------------------
+
+
+def test_card_surfaces_role_headline_from_labels() -> None:
+    # Arrange
+    v3 = {
+        "metadata": {"labels": {"role": "project-maintainer"}},
+        "spec": {"runtime": "apptainer"},
+    }
+    # Act
+    card = project_card("alpha", v3, "http://127.0.0.1:7901")
+    # Assert
+    assert card["x-scitex-agent-container"]["role"] == "project-maintainer"
+
+
+def test_card_surfaces_responsibilities_bullets_from_spec() -> None:
+    # Arrange
+    v3 = {
+        "metadata": {"labels": {"role": "worker"}},
+        "spec": {
+            "runtime": "apptainer",
+            "responsibilities": ["triage CI", "review PRs"],
+        },
+    }
+    # Act
+    card = project_card("alpha", v3, "http://127.0.0.1:7901")
+    # Assert
+    assert card["x-scitex-agent-container"]["responsibilities"] == [
+        "triage CI",
+        "review PRs",
+    ]
+
+
+def test_card_omits_responsibilities_when_spec_declares_none() -> None:
+    # Arrange
+    v3 = {"metadata": {"labels": {"role": "worker"}}, "spec": {"runtime": "apptainer"}}
+    # Act
+    card = project_card("alpha", v3, "http://127.0.0.1:7901")
+    # Assert
+    assert "responsibilities" not in card["x-scitex-agent-container"]
+
+
+def test_card_surfaces_multi_role_list_without_crashing() -> None:
+    """A (future) multi-role spec surfaces ``role`` as a list, no crash."""
+    # Arrange
+    v3 = {
+        "metadata": {"labels": {"role": ["maintainer", "reviewer"]}},
+        "spec": {"runtime": "apptainer"},
+    }
+    # Act
+    card = project_card("alpha", v3, "http://127.0.0.1:7901")
+    # Assert
+    assert card["x-scitex-agent-container"]["role"] == ["maintainer", "reviewer"]
+
+
+def test_card_multi_role_skill_name_stays_a_string() -> None:
+    """The skills[0].name (a proto string field) collapses a role list to
+    its first entry so the card stays v1-schema valid."""
+    # Arrange
+    v3 = {
+        "metadata": {"labels": {"role": ["maintainer", "reviewer"]}},
+        "spec": {"runtime": "apptainer"},
+    }
+    # Act
+    card = project_card("alpha", v3, "http://127.0.0.1:7901")
+    # Assert
+    assert card["skills"][0]["name"] == "maintainer"
+
+
+def test_card_surfaces_project_owner_from_workdir() -> None:
+    # Arrange
+    v3 = {
+        "metadata": {"labels": {"role": "worker"}},
+        "spec": {"runtime": "apptainer", "workdir": "/home/u/proj/scitex-dev"},
+    }
+    # Act
+    card = project_card("alpha", v3, "http://127.0.0.1:7901")
+    # Assert
+    assert card["x-scitex-agent-container"]["project"] == "scitex-dev"

--- a/tests/scitex_agent_container/a2a/test__card_identity.py
+++ b/tests/scitex_agent_container/a2a/test__card_identity.py
@@ -1,0 +1,199 @@
+"""Unit tests for ``a2a/_card_identity.py`` — the spec → identity projection.
+
+``spec_identity`` is the single source of "who is this agent" shared by
+both a2a discovery surfaces (the AgentCard and the ``a2a peers`` rows), so
+its contract is pinned here with pure inputs — no mocks, no I/O.
+
+STX-TQ002 AAA markers + STX-TQ007 one-assert-per-test. Test names spell
+out the behaviour being verified (TQ003).
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container.a2a._card_identity import as_str_list, spec_identity
+
+# ---------------------------------------------------------------------------
+# as_str_list — CSV / list / junk coercion
+# ---------------------------------------------------------------------------
+
+
+def test_as_str_list_splits_and_strips_csv_string() -> None:
+    # Arrange
+    value = "triage CI,  review PRs , "
+    # Act
+    result = as_str_list(value)
+    # Assert
+    assert result == ["triage CI", "review PRs"]
+
+
+def test_as_str_list_filters_blanks_from_list() -> None:
+    # Arrange
+    value = ["a", "  ", "b", None]
+    # Act
+    result = as_str_list(value)
+    # Assert
+    assert result == ["a", "b"]
+
+
+def test_as_str_list_returns_empty_for_none() -> None:
+    # Arrange
+    value = None
+    # Act
+    result = as_str_list(value)
+    # Assert
+    assert result == []
+
+
+def test_as_str_list_returns_empty_for_dict() -> None:
+    # Arrange
+    value = {"x": 1}
+    # Act
+    result = as_str_list(value)
+    # Assert
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# spec_identity — role headline
+# ---------------------------------------------------------------------------
+
+
+def test_spec_identity_reads_role_string_from_labels() -> None:
+    # Arrange
+    v3 = {"metadata": {"labels": {"role": "project-maintainer"}}}
+    # Act
+    identity = spec_identity(v3)
+    # Assert
+    assert identity["role"] == "project-maintainer"
+
+
+def test_spec_identity_multi_role_list_stays_a_list() -> None:
+    # Arrange — a (future) multi-role spec must not crash and keeps the list.
+    v3 = {"metadata": {"labels": {"role": ["maintainer", "reviewer"]}}}
+    # Act
+    identity = spec_identity(v3)
+    # Assert
+    assert identity["role"] == ["maintainer", "reviewer"]
+
+
+def test_spec_identity_single_element_role_list_collapses_to_string() -> None:
+    # Arrange
+    v3 = {"metadata": {"labels": {"role": ["solo"]}}}
+    # Act
+    identity = spec_identity(v3)
+    # Assert
+    assert identity["role"] == "solo"
+
+
+def test_spec_identity_omits_role_when_absent() -> None:
+    # Arrange
+    v3 = {"metadata": {"labels": {}}, "spec": {}}
+    # Act
+    identity = spec_identity(v3)
+    # Assert
+    assert "role" not in identity
+
+
+# ---------------------------------------------------------------------------
+# spec_identity — responsibilities bullets
+# ---------------------------------------------------------------------------
+
+
+def test_spec_identity_reads_responsibilities_from_spec_list() -> None:
+    # Arrange
+    v3 = {"spec": {"responsibilities": ["triage CI", "review PRs"]}}
+    # Act
+    identity = spec_identity(v3)
+    # Assert
+    assert identity["responsibilities"] == ["triage CI", "review PRs"]
+
+
+def test_spec_identity_responsibilities_fall_back_to_labels_csv() -> None:
+    # Arrange — no spec.responsibilities; labels carries a CSV instead.
+    v3 = {"metadata": {"labels": {"responsibilities": "a, b"}}, "spec": {}}
+    # Act
+    identity = spec_identity(v3)
+    # Assert
+    assert identity["responsibilities"] == ["a", "b"]
+
+
+def test_spec_identity_omits_responsibilities_when_absent() -> None:
+    # Arrange
+    v3 = {"metadata": {"labels": {"role": "worker"}}, "spec": {}}
+    # Act
+    identity = spec_identity(v3)
+    # Assert
+    assert "responsibilities" not in identity
+
+
+# ---------------------------------------------------------------------------
+# spec_identity — groups / purpose / project
+# ---------------------------------------------------------------------------
+
+
+def test_spec_identity_reads_groups_plural_list() -> None:
+    # Arrange
+    v3 = {"metadata": {"labels": {"groups": ["sac", "fleet"]}}}
+    # Act
+    identity = spec_identity(v3)
+    # Assert
+    assert identity["groups"] == ["sac", "fleet"]
+
+
+def test_spec_identity_groups_fall_back_to_singular_group() -> None:
+    # Arrange — no plural ``groups``; a singular ``group`` string is used.
+    v3 = {"metadata": {"labels": {"group": "developers"}}}
+    # Act
+    identity = spec_identity(v3)
+    # Assert
+    assert identity["groups"] == ["developers"]
+
+
+def test_spec_identity_reads_purpose_string() -> None:
+    # Arrange
+    v3 = {"metadata": {"labels": {"purpose": "keep sac green"}}}
+    # Act
+    identity = spec_identity(v3)
+    # Assert
+    assert identity["purpose"] == "keep sac green"
+
+
+def test_spec_identity_reads_project_from_workdir_basename() -> None:
+    # Arrange
+    v3 = {"spec": {"workdir": "/home/u/proj/scitex-dev/"}}
+    # Act
+    identity = spec_identity(v3)
+    # Assert
+    assert identity["project"] == "scitex-dev"
+
+
+def test_spec_identity_omits_project_when_no_workdir() -> None:
+    # Arrange
+    v3 = {"spec": {"runtime": "apptainer"}}
+    # Act
+    identity = spec_identity(v3)
+    # Assert
+    assert "project" not in identity
+
+
+# ---------------------------------------------------------------------------
+# spec_identity — defensive input handling (best-effort, never crashes)
+# ---------------------------------------------------------------------------
+
+
+def test_spec_identity_returns_empty_for_non_dict_input() -> None:
+    # Arrange
+    value = None
+    # Act
+    identity = spec_identity(value)  # type: ignore[arg-type]
+    # Assert
+    assert identity == {}
+
+
+def test_spec_identity_tolerates_non_dict_labels() -> None:
+    # Arrange — a malformed spec whose labels is a list, not a mapping.
+    v3 = {"metadata": {"labels": ["oops"]}, "spec": {"workdir": "/x/repo"}}
+    # Act
+    identity = spec_identity(v3)
+    # Assert
+    assert identity == {"project": "repo"}


### PR DESCRIPTION
Operator directive (2026-07-06): make agent roles clear via a2a so agents do not get confused about who does what. Each agent writes its role in its spec (metadata.labels.role headline + purpose/groups, and a top-level spec.responsibilities bullet list); this surfaces on BOTH the a2a peer rows AND the /.well-known/agent-card.json AgentCard. New a2a/_card_identity.py resolves the fields best-effort: role is string-or-list (multi-role shown as bullets), responsibilities a bullet list (prefers spec.responsibilities, falls back to metadata.labels). 72 tests pass (a2a card + card_identity + registry_endpoints). Specs are populated per the operator-approved taxonomy in a follow-up.