### PR TITLE
fix(a2a): read agent responsibilities from spec.extensions

### DIFF
--- a/src/scitex_agent_container/a2a/_card_identity.py
+++ b/src/scitex_agent_container/a2a/_card_identity.py
@@ -91,9 +91,15 @@ def spec_identity(v3: dict[str, Any]) -> dict[str, Any]:
         elif roles:
             out["role"] = roles
 
-    # responsibilities — prefer the top-level spec list; fall back to a
+    # responsibilities — prefer spec.extensions.responsibilities (the
+    # schema-valid custom-data slot; a bare top-level spec.responsibilities
+    # is rejected by the strict v3 validator). Then a top-level list, then a
     # labels entry (list or CSV) for specs that carry it there instead.
-    responsibilities = as_str_list(spec.get("responsibilities"))
+    extensions = spec.get("extensions")
+    extensions = extensions if isinstance(extensions, dict) else {}
+    responsibilities = as_str_list(extensions.get("responsibilities"))
+    if not responsibilities:
+        responsibilities = as_str_list(spec.get("responsibilities"))
     if not responsibilities:
         responsibilities = as_str_list(labels.get("responsibilities"))
     if responsibilities:

--- a/tests/scitex_agent_container/a2a/test__card_identity.py
+++ b/tests/scitex_agent_container/a2a/test__card_identity.py
@@ -108,6 +108,15 @@ def test_spec_identity_reads_responsibilities_from_spec_list() -> None:
     assert identity["responsibilities"] == ["triage CI", "review PRs"]
 
 
+def test_spec_identity_prefers_responsibilities_from_extensions() -> None:
+    # Arrange — spec.extensions.responsibilities is the schema-valid slot.
+    v3 = {"spec": {"extensions": {"responsibilities": ["own X", "own Y"]}}}
+    # Act
+    identity = spec_identity(v3)
+    # Assert
+    assert identity["responsibilities"] == ["own X", "own Y"]
+
+
 def test_spec_identity_responsibilities_fall_back_to_labels_csv() -> None:
     # Arrange — no spec.responsibilities; labels carries a CSV instead.
     v3 = {"metadata": {"labels": {"responsibilities": "a, b"}}, "spec": {}}


### PR DESCRIPTION
Follow-up to #561. The merged role-exposure mechanism read a top-level spec.responsibilities, but the strict v3 schema REJECTS that field (agents fail to start: Unknown spec field responsibilities). The valid slot is spec.extensions.responsibilities. This reads from extensions first, keeping the top-level + labels fallbacks (existing tests still pass) + an extensions-path test. Aligns with the 9 anchor specs now populated under spec.extensions.responsibilities so roles actually surface on the AgentCard + peers.