### PR TITLE
fix(to_home): SAC_USER_TO_HOME_BASELINE opt-out + exempt _comment keys from layer merge

### DIFF
--- a/src/scitex_agent_container/runtimes/_layer_merge.py
+++ b/src/scitex_agent_container/runtimes/_layer_merge.py
@@ -14,6 +14,8 @@ Merge rules (one model for every mergeable config file):
   * the ``hooks`` block        → per-event concatenate + dedupe (additive;
                                  delegates to ``settings_json._merge_hooks_blocks``)
   * ``list`` + ``list``        → append uniques, order-preserving (additive)
+  * ``_comment`` / ``_comment_*`` key → keep first layer's (self-describing
+                                 documentation, not config; never a conflict)
   * scalar == scalar           → keep (idempotent; first layer owns it)
   * scalar != scalar           → raise :class:`LayerMergeConflict`
 
@@ -99,6 +101,14 @@ def _merge_into(
             continue
 
         cur = acc[key]
+        # Documentation keys (``_comment``, ``_comment_*``) are self-describing
+        # prose, not config. Two layers each carrying their own ``_comment``
+        # must NOT hard-fail the cascade — keep the first (lowest) layer's value
+        # (layer-local; same ownership rule as an idempotent scalar), regardless
+        # of value type, so a doc key never routes into the conflict raise
+        # below. (paper-scitex-clew 2026-07-06)
+        if isinstance(key, str) and key.startswith("_comment"):
+            continue
         if isinstance(cur, dict) and isinstance(val, dict):
             _merge_into(cur, prov, val, layer, path)
         elif isinstance(cur, list) and isinstance(val, list):

--- a/src/scitex_agent_container/runtimes/_to_home.py
+++ b/src/scitex_agent_container/runtimes/_to_home.py
@@ -58,7 +58,6 @@ content — see ``_to_home_errors.py`` for context.
 from __future__ import annotations
 
 import logging
-import os
 from pathlib import Path
 
 from ..config import AgentConfig
@@ -79,6 +78,13 @@ from ._to_home_errors import (
     WorkspaceCLAUDEMarkerError,
     WorkspaceCredentialLeakError,
     WorkspaceMcpMergeError,
+)
+from ._to_home_resolve import (
+    _spec_dir,
+    _user_baseline_to_home_dir,
+    resolve_baseline_to_home_dir,
+    resolve_to_home_dir,
+    settings_layer_dirs,
 )
 from ._to_home_settings import deploy_settings_cascade
 from ._to_home_text import (
@@ -138,91 +144,15 @@ _VERBATIM_SECRET_BASENAMES = frozenset({".envrc"})
 # accepted as a layer source but never plain-copied.
 _CASCADE_DEPLOYED_BASENAMES = frozenset({"settings.json", "settings.local.json"})
 
-# Env var: explicit override for the shared/common baseline to_home dir.
-# Absolute path. When unset we fall back to ``<agents_dir>/_shared/to_home``
-# (or the legacy ``_base`` sibling).
-_BASELINE_ENV_VAR = "SAC_TO_HOME_BASELINE"
-
-# Names of the sibling dir (under the agents root) that holds the common
-# baseline. Agents live at ``<agents_dir>/<name>/``, so the agents root
-# is the spec dir's parent and the baseline is ``<parent>/_shared/to_home``.
-# ``_shared`` is the current name; ``_base`` is retained as a
-# backward-compat fallback for hosts/fleets not yet renamed (first match
-# under the agents root wins, in declared order).
-_BASELINE_DIR_NAMES = ("_shared", "_base")
+# Path-resolution helpers (``resolve_to_home_dir`` /
+# ``resolve_baseline_to_home_dir`` / ``_user_baseline_to_home_dir`` /
+# ``settings_layer_dirs`` / ``_spec_dir``) + their env/dir-name constants live
+# in :mod:`._to_home_resolve` and are imported + re-exported above, so the
+# legacy ``from ...runtimes._to_home import resolve_baseline_to_home_dir``
+# contract keeps resolving. This module owns the materialize/deploy side only.
 
 
 # --- public API ------------------------------------------------------------
-
-
-def resolve_to_home_dir(config: AgentConfig) -> Path | None:
-    """Resolve ``spec.to_home`` to an absolute directory.
-
-    Resolution order:
-      1. Absolute path: use as-is.
-      2. Relative path: resolve against the directory containing
-         ``spec.yaml``.
-      3. Empty: auto-discover ``./to_home`` next to ``spec.yaml``.
-
-    Returns ``None`` if no directory can be resolved (legacy specs
-    without a to_home/ dir simply skip materialization).
-    """
-    spec_dir = _spec_dir(config)
-    raw = (getattr(config, "to_home", "") or "").strip()
-    if not raw:
-        if spec_dir is not None and (spec_dir / "to_home").is_dir():
-            return spec_dir / "to_home"
-        return None
-    p = Path(raw).expanduser()
-    if not p.is_absolute():
-        if spec_dir is None:
-            return None
-        p = spec_dir / p
-    return p if p.is_dir() else None
-
-
-def resolve_baseline_to_home_dir(spec_dir: Path | None) -> Path | None:
-    """Resolve the shared/common baseline ``to_home/`` directory.
-
-    Resolution order:
-      1. ``$SAC_TO_HOME_BASELINE`` (absolute dir) — explicit override.
-      2. ``<agents_dir>/_shared/to_home`` — a sibling ``_shared`` dir
-         under the agents root (``_base`` accepted as a backward-compat
-         fallback). Agents live at ``<agents_dir>/<name>/``, so the
-         agents root is ``spec_dir.parent``.
-
-    Returns ``None`` when no baseline dir can be resolved (no baseline =
-    current behavior; fully backward compatible).
-    """
-    override = (os.environ.get(_BASELINE_ENV_VAR, "") or "").strip()
-    if override:
-        p = Path(override).expanduser()
-        return p if p.is_dir() else None
-    if spec_dir is None:
-        return None
-    for name in _BASELINE_DIR_NAMES:
-        p = spec_dir.parent / name / "to_home"
-        if p.is_dir():
-            return p
-    return None
-
-
-def _user_baseline_to_home_dir() -> Path | None:
-    """The USER-level shared baseline ``to_home`` — applies to every agent
-    regardless of where its spec lives: ``~/.scitex/agent-container/agents/
-    {_shared,_base}/to_home`` (first match wins). Returns ``None`` when absent.
-
-    Distinct from :func:`resolve_baseline_to_home_dir`, which resolves the
-    baseline *relative to the spec's* agents root (project-local for a
-    project-local spec). The ``.envrc`` cascade sources BOTH so a user-global
-    default and a project ``_shared`` both apply, lowest precedence first.
-    """
-    base = Path("~/.scitex/agent-container/agents").expanduser()
-    for name in _BASELINE_DIR_NAMES:
-        p = base / name / "to_home"
-        if p.is_dir():
-            return p
-    return None
 
 
 def materialize_to_home(spec_dir: Path, workspace_home: Path) -> None:
@@ -389,22 +319,6 @@ def _apply_host_merge_with_drift_guard(config: AgentConfig, dest: Path) -> None:
         )
 
 
-def settings_layer_dirs(config: AgentConfig) -> "list[tuple[str, Path | None]]":
-    """The ordered settings.json cascade layers (lowest precedence first).
-
-    ``(name, dir)`` pairs for the user-level ``_shared`` baseline, the spec's
-    ``_shared`` baseline, and the per-agent ``to_home`` — the inputs to
-    :func:`_to_home_settings.deploy_settings_cascade` /
-    :func:`_to_home_settings.settings_cascade_provenance`. Shared by
-    ``deploy_to_home`` and ``sac agents explain`` so both resolve identically.
-    """
-    return [
-        ("user-shared", _user_baseline_to_home_dir()),
-        ("project-shared", resolve_baseline_to_home_dir(_spec_dir(config))),
-        ("per-agent", resolve_to_home_dir(config)),
-    ]
-
-
 # --- traversal -------------------------------------------------------------
 
 
@@ -488,15 +402,6 @@ def _walk_and_apply(
 # re-imported above and re-exported below so legacy import paths still resolve.
 # Symlinks are dereference-copied to real content via
 # :func:`_symlink_resolve.deref_copy_symlink`, called directly by the traversal.
-
-
-# --- internal helpers ------------------------------------------------------
-
-
-def _spec_dir(config: AgentConfig) -> Path | None:
-    if not getattr(config, "config_path", ""):
-        return None
-    return Path(config.config_path).parent
 
 
 __all__ = [

--- a/src/scitex_agent_container/runtimes/_to_home_resolve.py
+++ b/src/scitex_agent_container/runtimes/_to_home_resolve.py
@@ -1,0 +1,160 @@
+"""Resolve WHICH ``to_home`` directories apply to an agent (ADR-0006/0018).
+
+Pure path-resolution helpers, split out of :mod:`._to_home` (which kept
+growing past the line cap). No I/O beyond ``Path.is_dir`` probes; no
+deploy side effects. :mod:`._to_home` imports and re-exports these so the
+legacy ``from ...runtimes._to_home import resolve_baseline_to_home_dir``
+contract (and ``sac agents explain``) keeps resolving unchanged.
+
+Three baseline layers feed the settings/.envrc/.mcp cascade, lowest
+precedence first:
+
+    user      ~/.scitex/agent-container/agents/_shared/to_home
+    project   <proj>/.scitex/agent-container/agents/_shared/to_home
+    per-agent <spec_dir>/to_home
+
+Each layer has an explicit env override / opt-out so an agent can pin its
+home by spec alone (see the two ``*_ENV_VAR`` constants).
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from ..config import AgentConfig
+
+# Env var: explicit override for the shared/common baseline to_home dir.
+# Absolute path. When unset we fall back to ``<agents_dir>/_shared/to_home``
+# (or the legacy ``_base`` sibling).
+_BASELINE_ENV_VAR = "SAC_TO_HOME_BASELINE"
+
+# Env var: explicit override / opt-out for the USER-level shared baseline
+# (``~/.scitex/agent-container/agents/_shared/to_home``). Mirrors
+# ``_BASELINE_ENV_VAR`` exactly: set to an absolute dir → use it; set to a
+# NON-dir (e.g. ``/nonexistent``) → the user baseline is ABSENT (opt-out);
+# unset → the default ``~`` search. This lets a sandboxed agent pin its home
+# by spec ALONE — excluding the fleet-wide user baseline whose
+# coordinator-discipline hooks (e.g. force_background_bash) are wrong for a
+# long-foreground benchmark solver and, worse, would be an uncontrolled
+# confound between runs of the same experimental arm (a solver started before
+# the baseline landed vs after). The spec-relative baseline already had this
+# escape hatch via ``_BASELINE_ENV_VAR``; the user layer lacked it. (2026-07-06)
+_USER_BASELINE_ENV_VAR = "SAC_USER_TO_HOME_BASELINE"
+
+# Names of the sibling dir (under the agents root) that holds the common
+# baseline. Agents live at ``<agents_dir>/<name>/``, so the agents root
+# is the spec dir's parent and the baseline is ``<parent>/_shared/to_home``.
+# ``_shared`` is the current name; ``_base`` is retained as a
+# backward-compat fallback for hosts/fleets not yet renamed (first match
+# under the agents root wins, in declared order).
+_BASELINE_DIR_NAMES = ("_shared", "_base")
+
+
+def resolve_to_home_dir(config: AgentConfig) -> Path | None:
+    """Resolve ``spec.to_home`` to an absolute directory.
+
+    Resolution order:
+      1. Absolute path: use as-is.
+      2. Relative path: resolve against the directory containing
+         ``spec.yaml``.
+      3. Empty: auto-discover ``./to_home`` next to ``spec.yaml``.
+
+    Returns ``None`` if no directory can be resolved (legacy specs
+    without a to_home/ dir simply skip materialization).
+    """
+    spec_dir = _spec_dir(config)
+    raw = (getattr(config, "to_home", "") or "").strip()
+    if not raw:
+        if spec_dir is not None and (spec_dir / "to_home").is_dir():
+            return spec_dir / "to_home"
+        return None
+    p = Path(raw).expanduser()
+    if not p.is_absolute():
+        if spec_dir is None:
+            return None
+        p = spec_dir / p
+    return p if p.is_dir() else None
+
+
+def resolve_baseline_to_home_dir(spec_dir: Path | None) -> Path | None:
+    """Resolve the shared/common baseline ``to_home/`` directory.
+
+    Resolution order:
+      1. ``$SAC_TO_HOME_BASELINE`` (absolute dir) — explicit override.
+      2. ``<agents_dir>/_shared/to_home`` — a sibling ``_shared`` dir
+         under the agents root (``_base`` accepted as a backward-compat
+         fallback). Agents live at ``<agents_dir>/<name>/``, so the
+         agents root is ``spec_dir.parent``.
+
+    Returns ``None`` when no baseline dir can be resolved (no baseline =
+    current behavior; fully backward compatible).
+    """
+    override = (os.environ.get(_BASELINE_ENV_VAR, "") or "").strip()
+    if override:
+        p = Path(override).expanduser()
+        return p if p.is_dir() else None
+    if spec_dir is None:
+        return None
+    for name in _BASELINE_DIR_NAMES:
+        p = spec_dir.parent / name / "to_home"
+        if p.is_dir():
+            return p
+    return None
+
+
+def _user_baseline_to_home_dir() -> Path | None:
+    """The USER-level shared baseline ``to_home`` — applies to every agent
+    regardless of where its spec lives: ``~/.scitex/agent-container/agents/
+    {_shared,_base}/to_home`` (first match wins). Returns ``None`` when absent.
+
+    Honors ``$SAC_USER_TO_HOME_BASELINE`` (mirrors ``resolve_baseline_to_home_dir``'s
+    ``$SAC_TO_HOME_BASELINE``): set to an absolute dir → use it; set to a NON-dir
+    → the user baseline is ABSENT (opt-out); unset → the default ``~`` search.
+    A sandboxed solver sets it to a non-dir to exclude the fleet-wide baseline
+    and keep its home spec-pinned (arm-consistency across benchmark runs).
+
+    Distinct from :func:`resolve_baseline_to_home_dir`, which resolves the
+    baseline *relative to the spec's* agents root (project-local for a
+    project-local spec). The ``.envrc`` cascade sources BOTH so a user-global
+    default and a project ``_shared`` both apply, lowest precedence first.
+    """
+    override = (os.environ.get(_USER_BASELINE_ENV_VAR, "") or "").strip()
+    if override:
+        p = Path(override).expanduser()
+        return p if p.is_dir() else None
+    base = Path("~/.scitex/agent-container/agents").expanduser()
+    for name in _BASELINE_DIR_NAMES:
+        p = base / name / "to_home"
+        if p.is_dir():
+            return p
+    return None
+
+
+def settings_layer_dirs(config: AgentConfig) -> "list[tuple[str, Path | None]]":
+    """The ordered settings.json cascade layers (lowest precedence first).
+
+    ``(name, dir)`` pairs for the user-level ``_shared`` baseline, the spec's
+    ``_shared`` baseline, and the per-agent ``to_home`` — the inputs to
+    :func:`_to_home_settings.deploy_settings_cascade` /
+    :func:`_to_home_settings.settings_cascade_provenance`. Shared by
+    ``deploy_to_home`` and ``sac agents explain`` so both resolve identically.
+    """
+    return [
+        ("user-shared", _user_baseline_to_home_dir()),
+        ("project-shared", resolve_baseline_to_home_dir(_spec_dir(config))),
+        ("per-agent", resolve_to_home_dir(config)),
+    ]
+
+
+def _spec_dir(config: AgentConfig) -> Path | None:
+    if not getattr(config, "config_path", ""):
+        return None
+    return Path(config.config_path).parent
+
+
+__all__ = [
+    "resolve_to_home_dir",
+    "resolve_baseline_to_home_dir",
+    "settings_layer_dirs",
+]

--- a/tests/scitex_agent_container/runtimes/test__layer_merge.py
+++ b/tests/scitex_agent_container/runtimes/test__layer_merge.py
@@ -81,6 +81,36 @@ def test_lists_union_preserving_order() -> None:
     assert merged["xs"] == [1, 2, 3]
 
 
+def test_comment_key_conflict_is_exempt_and_keeps_first() -> None:
+    # Arrange — two layers each document themselves via ``_comment``.
+    layers = [("user", {"_comment": "user layer"}), ("agent", {"_comment": "agent layer"})]
+    # Act
+    merged, _ = deep_merge_layers(layers)
+    # Assert
+    assert merged["_comment"] == "user layer"
+
+
+def test_comment_prefixed_key_conflict_is_exempt() -> None:
+    # Arrange — ``_comment_*`` documentation keys are also exempt.
+    layers = [("user", {"_comment_note": "a"}), ("agent", {"_comment_note": "b"})]
+    # Act
+    merged, _ = deep_merge_layers(layers)
+    # Assert
+    assert merged["_comment_note"] == "a"
+
+
+def test_comment_conflict_does_not_hard_fail_the_cascade() -> None:
+    # Arrange — a doc-key clash must not abort the surrounding real merge.
+    layers = [
+        ("user", {"_comment": "x", "k": 1}),
+        ("agent", {"_comment": "y", "j": 2}),
+    ]
+    # Act
+    merged, _ = deep_merge_layers(layers)
+    # Assert
+    assert merged == {"_comment": "x", "k": 1, "j": 2}
+
+
 def test_hooks_block_is_additive_per_event() -> None:
     # Arrange
     grp_a = {"matcher": "Bash", "hooks": [{"type": "command", "command": "a"}]}

--- a/tests/scitex_agent_container/runtimes/test__to_home_resolve.py
+++ b/tests/scitex_agent_container/runtimes/test__to_home_resolve.py
@@ -1,0 +1,62 @@
+"""Tests for the to_home path-resolution helpers (``_to_home_resolve``).
+
+Focused on ``_user_baseline_to_home_dir``'s ``$SAC_USER_TO_HOME_BASELINE``
+override / opt-out — the escape hatch that lets a sandboxed agent pin its
+home by spec alone (mirrors ``resolve_baseline_to_home_dir``'s
+``$SAC_TO_HOME_BASELINE``). Also pins the ``_to_home`` re-export contract so
+the split from ``_to_home`` stays import-compatible.
+
+PA-306 no-mocks: real paths against ``tmp_path``; env-driven tests use the
+project-wide ``env_save_restore`` fixture (POSIX-honest ``setenv``/``delenv``).
+STX-TQ002 / TQ007: AAA markers, one fact per test.
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container.runtimes._to_home_resolve import (
+    _user_baseline_to_home_dir,
+)
+
+
+class TestUserBaselineOptOut:
+    """``$SAC_USER_TO_HOME_BASELINE``: a dir overrides the ``~`` default; a
+    NON-dir opts the user layer OUT so a sandboxed solver's home is
+    spec-pinned (arm-consistency across benchmark runs)."""
+
+    def test_env_override_takes_precedence(self, tmp_path, env_save_restore):
+        # Arrange — an explicit user baseline dir wins over the ~ default.
+        custom = tmp_path / "user_baseline" / "to_home"
+        custom.mkdir(parents=True)
+        env_save_restore.set("SAC_USER_TO_HOME_BASELINE", str(custom))
+        # Act
+        resolved = _user_baseline_to_home_dir()
+        # Assert
+        assert resolved == custom
+
+    def test_env_set_to_missing_dir_opts_out_returns_none(
+        self, tmp_path, env_save_restore
+    ):
+        # Arrange — set to a non-dir ⇒ user baseline absent (the opt-out).
+        env_save_restore.set("SAC_USER_TO_HOME_BASELINE", str(tmp_path / "nope"))
+        # Act
+        resolved = _user_baseline_to_home_dir()
+        # Assert
+        assert resolved is None
+
+
+class TestToHomeReExportContract:
+    """The resolvers moved to ``_to_home_resolve`` but ``_to_home`` must keep
+    re-exporting them (legacy import path + ``sac agents explain``)."""
+
+    def test_to_home_reexports_resolvers(self):
+        # Arrange
+        from scitex_agent_container.runtimes import _to_home
+        # Act
+        names = [
+            _to_home.resolve_to_home_dir,
+            _to_home.resolve_baseline_to_home_dir,
+            _to_home.settings_layer_dirs,
+            _to_home._user_baseline_to_home_dir,
+        ]
+        # Assert
+        assert all(callable(n) for n in names)


### PR DESCRIPTION
## Summary
Two operator-blocking fixes for sandboxed benchmark **solver** agents (paper-scitex-clew capsule-002), plus the refactor the first requires.

### ASK 2 (the blocker) — `$SAC_USER_TO_HOME_BASELINE` opt-out
`_user_baseline_to_home_dir()` was unconditional. It now honors `$SAC_USER_TO_HOME_BASELINE`, mirroring the spec-relative `$SAC_TO_HOME_BASELINE` exactly:
- absolute dir → use it
- **non-dir** (e.g. `/nonexistent`) → the user baseline is **absent** (opt-out)
- unset → the default `~/.scitex/agent-container/agents/{_shared,_base}/to_home` search

**Why:** a solver must pin its home by spec alone. The fleet-wide user baseline injects coordinator-discipline hooks (`force_background_bash` etc.) that are wrong for a long-foreground solver and — worse — an uncontrolled **confound** between runs of the same experimental arm (capsule-001 ran before the baseline landed; capsule-002 would run after). Covers both the settings and `.envrc` cascades (both source the user layer).

### ASK 1 — exempt `_comment` keys from the layer-merge conflict
`deep_merge_layers` hard-fails on a cross-layer scalar mismatch. `_comment` / `_comment_*` keys are self-describing documentation, not config — two layers each documenting themselves must not abort the whole cascade. Now keeps the first (lowest) layer's value (layer-local), same ownership rule as an idempotent scalar.

### Refactor (required by ASK 2)
`_to_home.py` was already >512 lines. Extracted the path-resolution helpers (`resolve_*` / `_user_baseline_to_home_dir` / `settings_layer_dirs` / `_spec_dir` + constants) to a new `_to_home_resolve.py`; `_to_home.py` re-exports them so every legacy import path (and `sac agents explain`) is unchanged.

## Test
- `_comment` exemption: 3 tests
- `$SAC_USER_TO_HOME_BASELINE` override / opt-out: 2 tests
- re-export contract: 1 test
- **Full `runtimes/` suite: 1210 passed, 20 skipped** (validates the re-export contract fleet-wide)

## Deploy note
Unblocks paper-scitex-clew capsule-002: on merge they `git pull --ff-only` the host sac checkout and start `clew-a-002` with `SAC_USER_TO_HOME_BASELINE=/nonexistent`. Independent of the in-flight SIF rebuild (host `sac agents start` uses the host checkout, not the SIF).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
