### PR TITLE
build(sif): floor scitex-todo>=0.7.38 in sac-scitex.def to fix dark tool-MCPs (#338)

### DIFF
--- a/src/scitex_agent_container/containers/apptainer-scitex.def
+++ b/src/scitex_agent_container/containers/apptainer-scitex.def
@@ -145,11 +145,22 @@ From: ./sac-base.sif
         #   scitex-writer>=2.22.0 — texlive provider (ships the soul.sty fix)
         #   scitex-audio >=0.3.0  — ffmpeg/portaudio provider
         #   scitex-cv    >=0.2.0  — opencv-python-headless; provider declares []
+        # scitex-todo >=0.7.36 is floored for a DIFFERENT reason (NOT a
+        # system-deps provider): 0.7.36 carries #338 (the store critical-section
+        # to_thread offload). Below 0.7.36 the ``scitex-todo mcp start`` server
+        # wedges on the ~22s synchronous store write during its MCP init
+        # handshake; with .mcp.json ``alwaysLoad: true`` doing a BLOCKING serial
+        # load, that stalled init cascades and starves sibling tool-MCP servers'
+        # registration too → ToolSearch finds zero tools ("dark tool-MCPs"
+        # incident, 2026-07-06, root-caused on scitex-clew). Flooring here
+        # upgrades past whatever scitex[all] pulls — same OVERRIDE pattern as
+        # the providers, decoupled from the umbrella re-pin.
         uv pip install --python /opt/venv-sac/bin/python \
             "scitex-dev>=0.20.1" \
             "scitex-writer>=2.22.0" \
             "scitex-audio>=0.3.0" \
-            "scitex-cv>=0.2.0"
+            "scitex-cv>=0.2.0" \
+            "scitex-todo>=0.7.36"
     else
         /opt/venv-sac/bin/pip install --no-cache-dir --upgrade \
             pip setuptools wheel
@@ -169,11 +180,15 @@ From: ./sac-base.sif
         # install in section 3 can discover every leaf's
         # ``scitex_dev.system_deps`` entry-point. Floors mirror the uv branch
         # above. Matches this branch's plain ``pip install`` style.
+        # scitex-todo >=0.7.36 floored for the store-wedge #338 fix — see the
+        # uv branch above for the full rationale (MCP-init wedge → alwaysLoad
+        # serial-load cascade → dark tool-MCPs). Same OVERRIDE pattern.
         /opt/venv-sac/bin/pip install --no-cache-dir \
             "scitex-dev>=0.20.1" \
             "scitex-writer>=2.22.0" \
             "scitex-audio>=0.3.0" \
-            "scitex-cv>=0.2.0"
+            "scitex-cv>=0.2.0" \
+            "scitex-todo>=0.7.36"
     fi
 
     # ---- 3. Federated system (apt) deps — SSoT install -----------------

--- a/src/scitex_agent_container/containers/apptainer-scitex.def
+++ b/src/scitex_agent_container/containers/apptainer-scitex.def
@@ -145,9 +145,9 @@ From: ./sac-base.sif
         #   scitex-writer>=2.22.0 — texlive provider (ships the soul.sty fix)
         #   scitex-audio >=0.3.0  — ffmpeg/portaudio provider
         #   scitex-cv    >=0.2.0  — opencv-python-headless; provider declares []
-        # scitex-todo >=0.7.36 is floored for a DIFFERENT reason (NOT a
-        # system-deps provider): 0.7.36 carries #338 (the store critical-section
-        # to_thread offload). Below 0.7.36 the ``scitex-todo mcp start`` server
+        # scitex-todo >=0.7.38 is floored for a DIFFERENT reason (NOT a
+        # system-deps provider): 0.7.38 carries #338 (the store critical-section
+        # to_thread offload). Below 0.7.38 the ``scitex-todo mcp start`` server
         # wedges on the ~22s synchronous store write during its MCP init
         # handshake; with .mcp.json ``alwaysLoad: true`` doing a BLOCKING serial
         # load, that stalled init cascades and starves sibling tool-MCP servers'
@@ -160,7 +160,7 @@ From: ./sac-base.sif
             "scitex-writer>=2.22.0" \
             "scitex-audio>=0.3.0" \
             "scitex-cv>=0.2.0" \
-            "scitex-todo>=0.7.36"
+            "scitex-todo>=0.7.38"
     else
         /opt/venv-sac/bin/pip install --no-cache-dir --upgrade \
             pip setuptools wheel
@@ -180,7 +180,7 @@ From: ./sac-base.sif
         # install in section 3 can discover every leaf's
         # ``scitex_dev.system_deps`` entry-point. Floors mirror the uv branch
         # above. Matches this branch's plain ``pip install`` style.
-        # scitex-todo >=0.7.36 floored for the store-wedge #338 fix — see the
+        # scitex-todo >=0.7.38 floored for the store-wedge #338 fix — see the
         # uv branch above for the full rationale (MCP-init wedge → alwaysLoad
         # serial-load cascade → dark tool-MCPs). Same OVERRIDE pattern.
         /opt/venv-sac/bin/pip install --no-cache-dir \
@@ -188,7 +188,7 @@ From: ./sac-base.sif
             "scitex-writer>=2.22.0" \
             "scitex-audio>=0.3.0" \
             "scitex-cv>=0.2.0" \
-            "scitex-todo>=0.7.36"
+            "scitex-todo>=0.7.38"
     fi
 
     # ---- 3. Federated system (apt) deps — SSoT install -----------------


### PR DESCRIPTION
## Summary
Root-cause fix for the 2026-07-06 **dark tool-MCPs** incident (scitex-clew). Its `scitex-todo mcp start` server wedged on the ~22s synchronous store critical-section during MCP init; with `.mcp.json` `alwaysLoad:true` doing a **blocking serial load**, the stalled scitex-todo init cascaded and starved sibling tool-MCP servers' registration too → ToolSearch found **zero** scitex-todo AND scitex-agent-container tools (host_exec etc.) despite a2a up and the server PIDs alive (confirmed host-side).

## Fix
Floor `scitex-todo>=0.7.36` (carries #338 — store write offloaded to `to_thread`) in the SIF override block, both uv + pip branches — the **same proven OVERRIDE pattern** as scitex-dev/-writer/-audio/-cv over `scitex[all]`'s transitive pins. Upgrades past whatever `scitex[all]` pulls → **decoupled from the stuck v2.30.6 umbrella re-pin**.

## Deploy (gated)
Takes effect only after **scitex-todo publishes 0.7.36** — a rebuild before then would fail to resolve the floor. Sequence: 0.7.36 on PyPI → rebuild sac-scitex → rolling restart → verify clew's `add_task` + `host_exec` resolve → incident closes. The dotfiles `sac-scitex.def` (the copy `sac image build` reads) is mirrored at rebuild time.

## Test
`.def`-only build-recipe change (no code); sac CI does not build the SIF. Verified: build-recipe floor follows the established override precedent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)