### PR TITLE
fix(mcp): raise MCP_TIMEOUT 30000->120000 for the scitex serve aggregator cold-start

### DIFF
--- a/src/scitex_agent_container/runtimes/_mcp_reliability.py
+++ b/src/scitex_agent_container/runtimes/_mcp_reliability.py
@@ -42,11 +42,17 @@ CRITICAL_MCP_SERVERS: tuple[str, ...] = (
     "scitex-todo",
 )
 
-# Client MCP startup connect timeout, in milliseconds. 30 s gives the multi-
-# second ``fastmcp`` cold-start (worse on a cold / slow container FS) a wide
-# margin, while still bounding how long ``alwaysLoad`` blocks a genuinely dead
-# server before the session proceeds.
-MCP_STARTUP_TIMEOUT_MS: str = "30000"
+# Client MCP startup connect timeout, in milliseconds. Raised to 120 s
+# (2026-07-07) for the single ``scitex serve`` aggregator: its cold start
+# (matplotlib font-cache build + ~30 heavy scientific peer imports + bounded
+# 8 s hung-peer resolve timeouts) can exceed 30 s on a fresh container home,
+# and under ``alwaysLoad`` a too-short timeout darkens the whole tool surface
+# (the same dark-tool-MCPs failure the aggregator is meant to close). 120 s
+# gives cold starts wide margin while still bounding a genuinely dead server.
+# Revert toward 30 s once the SIF bakes the matplotlib font cache and the
+# hung-import peers (types/resource/orochi) are fixed — both drop the
+# aggregator cold start to a few seconds.
+MCP_STARTUP_TIMEOUT_MS: str = "120000"
 
 # Env var name Claude Code reads for the MCP startup connect timeout.
 MCP_TIMEOUT_ENV_VAR: str = "MCP_TIMEOUT"

--- a/tests/scitex_agent_container/runtimes/test__apptainer_listen_env.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_listen_env.py
@@ -26,6 +26,9 @@ import pytest
 from scitex_agent_container.runtimes._apptainer_listen_env import (
     listen_env_flags,
 )
+from scitex_agent_container.runtimes._mcp_reliability import (
+    MCP_STARTUP_TIMEOUT_MS,
+)
 
 
 @pytest.fixture
@@ -76,7 +79,7 @@ def test_listen_env_flags_injects_mcp_timeout(
     flags = listen_env_flags(no_bus_config)
     # Assert — the raised MCP startup connect timeout reaches the launch env
     # (fleet incident 2026-07-06 cold-start race fix).
-    assert "MCP_TIMEOUT=30000" in flags
+    assert f"MCP_TIMEOUT={MCP_STARTUP_TIMEOUT_MS}" in flags
 
 
 def test_listen_env_flags_mcp_timeout_follows_an_env_token(
@@ -87,7 +90,7 @@ def test_listen_env_flags_mcp_timeout_follows_an_env_token(
     _ = sandboxed_home
     flags = listen_env_flags(no_bus_config)
     # Act
-    idx = flags.index("MCP_TIMEOUT=30000")
+    idx = flags.index(f"MCP_TIMEOUT={MCP_STARTUP_TIMEOUT_MS}")
     # Assert
     assert flags[idx - 1] == "--env"
 


### PR DESCRIPTION
## Summary
Raises the client MCP startup connect timeout (`MCP_STARTUP_TIMEOUT_MS` in `_mcp_reliability.py`, injected as `--env MCP_TIMEOUT`) from 30s to 120s.

## Why
The single `scitex serve` aggregator — the `.mcp.json` swap that structurally closes the 2026-07-06 dark-tool-MCPs incident (one hardened server mounting scitex-todo + agent-container + ~30 peers, so there's no standalone scitex-todo server to wedge at handshake) — has a slow **cold start**: matplotlib font-cache build + ~30 heavy scientific peer imports + bounded 8s hung-peer resolve timeouts. Smoke-tested in the new SIF: aggregator mounts `host_exec` + `add_task` + 564 tools, hardening skips 3 hung peers (types/resource/orochi) at 8s each, but cold start ~80s. Under `alwaysLoad`, a 30s timeout would dark the whole tool surface on a fresh-home first boot — the exact failure the aggregator closes. 120s gives margin.

## Temporary
120s is a heavy global default. Revert toward 30s once (a) the SIF bakes the matplotlib font cache + `MPLCONFIGDIR`, and (b) the hung-import peers are fixed (scitex-dev, carded) — both drop aggregator cold-start to ~8s.

## Test
Const-only change; smoke-tested the aggregator behavior in the rebuilt SIF (tools resolve, hardening degrades gracefully). No logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)