### PR TITLE
feat(session): spec-pinned session-id resume for SDK + TUI runners

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_session_seed.py
+++ b/src/scitex_agent_container/_lifecycle/_session_seed.py
@@ -1,0 +1,71 @@
+"""Spec-pinned session-id seeding for the SDK runner (``session: resume``).
+
+``spec.claude.resume_id`` lets an operator PIN an agent's first SDK
+session to an existing transcript uuid (migration / hand-off). The SDK
+runner resumes by reading ``<state_dir>/session_id`` and passing
+``ClaudeAgentOptions(resume=<id>)`` — but it has no "seed a fresh
+arbitrary id" knob; it only RESUMES an id already on disk. So to honour
+the pin we must WRITE that marker file ourselves before the runtime
+starts.
+
+Seed-if-ABSENT is the load-bearing semantic. After the first turn the
+SDK may FORK the session id (return a new uuid), and
+``write_session_id`` advances ``<state_dir>/session_id`` to the fork —
+that forked id is the live thread. Re-seeding from ``resume_id`` on
+every restart would clobber the fork back to the original pin and lose
+the whole continuation. So we seed ONLY when no marker exists yet (first
+boot / migration); once a marker is present it is authoritative.
+
+Called from :func:`._start.agent_start` BEFORE ``runtime.start`` so the
+in-container SDK runner (which reads the bind-mounted state dir) sees the
+seeded id on its first resume attempt.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..config import AgentConfig
+from ..config._session_continuity import SESSION_RESUME
+
+
+def seed_pinned_session_id(config: AgentConfig, runtime: Any) -> bool:
+    """Seed ``<state_dir>/session_id`` from ``spec.claude.resume_id`` if absent.
+
+    No-op (returns False) unless ALL hold:
+      * ``config.claude.session == "resume"``,
+      * ``config.claude.resume_id`` is a non-empty string, and
+      * ``<state_dir>/session_id`` is currently ABSENT (first boot /
+        migration — never overwrite an existing, possibly forked, id).
+
+    Returns True iff a seed was written.
+    """
+    claude = getattr(config, "claude", None)
+    if claude is None:
+        return False
+    session = str(getattr(claude, "session", "") or "").strip().lower()
+    if session != SESSION_RESUME:
+        return False
+    resume_id = str(getattr(claude, "resume_id", "") or "").strip()
+    if not resume_id:
+        return False
+
+    # Resolve the SAME per-agent state dir the SDK runner reads its resume
+    # marker from — via the runtime's own ``_state_dir`` resolver (root can
+    # be a project-scoped runtime dir, not the global default). Reuses the
+    # shared helper so seeding and instance-row bookkeeping never diverge.
+    from ._instances import _state_dir_for
+
+    state_dir = _state_dir_for(config, runtime)
+    if state_dir is None:
+        return False
+
+    from .._runners._session_state import read_session_id, write_session_id
+
+    # Fork-preservation: an existing marker (the latest, possibly forked,
+    # live id) is authoritative — never re-pin it back to the original.
+    if read_session_id(state_dir) is not None:
+        return False
+
+    write_session_id(state_dir, resume_id)
+    return True

--- a/src/scitex_agent_container/_lifecycle/_start.py
+++ b/src/scitex_agent_container/_lifecycle/_start.py
@@ -380,6 +380,16 @@ def agent_start(
 
     kill_orphan_mcp_children(config.name)
 
+    # Spec-pinned session resume (``spec.claude.session: resume`` +
+    # ``spec.claude.resume_id``). Seed the SDK runner's on-disk resume
+    # marker from the pinned uuid — but ONLY when no marker exists yet
+    # (first boot / migration). Must run BEFORE ``runtime.start`` so the
+    # in-container runner sees the seeded id on its first resume attempt.
+    # Seed-if-absent preserves a later SDK fork (see ``_session_seed``).
+    from ._session_seed import seed_pinned_session_id
+
+    seed_pinned_session_id(config, runtime)
+
     # Start — ``force`` is propagated to the runtime. The legacy
     # ``config.remote.no_preflight`` override was retired with
     # ``RemoteSpec`` in WI-6 (handoff §6, 2026-05-20); the

--- a/src/scitex_agent_container/config/_claude_validation.py
+++ b/src/scitex_agent_container/config/_claude_validation.py
@@ -1,0 +1,147 @@
+"""``spec.claude`` block validation.
+
+Extracted from ``_validation.py`` (which stays the orchestrator and
+re-exports :data:`_VALID_MODEL_RE` for back-compat) to keep that module
+under the 512-line cap — same pattern as the sibling
+``_provider_validation`` / ``_acl_validation`` modules.
+
+Covers the SDK-facing ``spec.claude`` fields the loader / runtime read:
+
+  * ``model``       — accepted alias / versioned form (SDK silently
+    rejects unknown values; see :data:`_VALID_MODEL_RE`).
+  * ``provider``    — vendor-agnostic backend override (delegated to
+    ``_provider_validation``).
+  * ``account``     — mutually exclusive with ``provider``.
+  * ``resume_id``   — when set, MUST be a well-formed UUID. A typo would
+    otherwise silently degrade to a fresh session on the ``session:
+    resume`` path (the SDK discards an unknown resume id), so we fail
+    loud at validate time naming the bad value.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+
+from ._provider_validation import provider_is_active, validate_provider
+
+# Accepted shapes for ``spec.claude.model`` (F-CS7).
+#
+# claude-agent-sdk silently rejects unknown aliases — the runner stays
+# alive, the heartbeat is fresh, but every turn returns 0 input tokens
+# and 0 output tokens because the SDK never makes the API call. Pin the
+# validation here so the failure surfaces at yaml-validate time instead
+# of as a hung-looking agent.
+#
+# Two acceptable shapes:
+#   1. Bare alias: ``opus`` / ``sonnet`` / ``haiku`` / ``inherit`` /
+#      ``default``, optionally with a context-suffix (``[1m]``).
+#   2. Full versioned form: ``claude-<family>-N-M`` with optional date
+#      tail (``-20251001``) and optional context-suffix.
+#
+# Reproduction (2026-05-05): ``claude-opus[1m]`` (abbreviated, missing
+# the version digits) was accepted by the YAML loader but silently
+# rejected by the SDK — every turn returned ``input_tokens=0``,
+# ``output_tokens=0``, ``iterations=[]``. Other peers using
+# ``claude-opus-4-7[1m]`` worked fine.
+_VALID_MODEL_RE = re.compile(
+    r"""
+    ^(?:
+        (?:opus|sonnet|haiku|fable|inherit|default)
+        |
+        # opus/sonnet/haiku ship as ``family-N-M`` (e.g. ``claude-opus-4-7``).
+        # Fable is published as a single-digit family version
+        # (``claude-fable-5``); see lead-confirmed 2026-06-12 (msg
+        # 6172e53d ruling 1). The ``[1m]`` context-suffix is CLI-native
+        # (proven empirically — msg 6f7e2f56) and bolted on below.
+        claude-(?:
+            (?:opus|sonnet|haiku)-\d+-\d+
+            |
+            fable-\d+
+        )(?:-[a-z0-9]+)*
+    )
+    (?:\[[a-zA-Z0-9_]+\])?
+    $
+    """,
+    re.VERBOSE,
+)
+
+
+def validate_claude(spec: dict) -> list[str]:
+    """Return validation errors for the ``spec.claude`` block (empty = valid)."""
+    errors: list[str] = []
+
+    claude_block = spec.get("claude", {}) or {}
+    if not isinstance(claude_block, dict):
+        claude_block = {}
+
+    # spec.claude.provider — vendor-agnostic backend override
+    # (ProviderSpec). When present, the SDK session runs against an
+    # Anthropic-SDK-compatible backend on an API key, so the model id is
+    # the provider's own (e.g. 'deepseek-chat') and the claude-* regex
+    # below is skipped. Absent → behaviour unchanged.
+    provider_block = claude_block.get("provider")
+    has_provider = provider_is_active(provider_block)
+    errors.extend(validate_provider(provider_block))
+
+    # spec.claude.model — F-CS7 (v3: moved from top-level spec.model).
+    model = claude_block.get("model")
+    if model is not None:
+        if not isinstance(model, str):
+            errors.append(
+                f"spec.claude.model must be a string, got {type(model).__name__}"
+            )
+        elif model and not has_provider and not _VALID_MODEL_RE.match(model):
+            errors.append(
+                f"spec.claude.model '{model}' is not an accepted alias. "
+                "Use a bare alias ('opus', 'sonnet', 'haiku', 'inherit', "
+                "'default'), optionally with a context suffix like "
+                "'opus[1m]'; OR the full versioned form "
+                "'claude-<family>-N-M[-<tail>]' (e.g. 'claude-opus-4-7', "
+                "'claude-opus-4-7[1m]', 'claude-haiku-4-5-20251001'). "
+                "Abbreviated forms like 'claude-opus[1m]' are rejected "
+                "by the SDK without raising — every turn returns 0 "
+                "tokens. (When spec.claude.provider is set, the model "
+                "field accepts the provider's own model id instead.)"
+            )
+
+    # spec.claude.provider + spec.claude.account are mutually exclusive —
+    # an API-key backend needs no OAuth. Declaring both is a config error
+    # (the runtime would otherwise have to guess which auth path wins).
+    if has_provider and (claude_block.get("account") or ""):
+        errors.append(
+            "spec.claude.provider and spec.claude.account are mutually "
+            "exclusive — a provider backend uses an API key, not "
+            "Anthropic OAuth. Set exactly one."
+        )
+
+    # spec.claude.resume_id — the explicit session id passed to
+    # ``claude --resume <id>`` (TUI) / ``ClaudeAgentOptions(resume=<id>)``
+    # (SDK) when ``spec.claude.session: resume``. When set it MUST be a
+    # well-formed UUID: the SDK/CLI resume mechanism keys off the on-disk
+    # transcript uuid, and an unknown/malformed id is silently DISCARDED
+    # to a fresh session (no error). A typo would therefore degrade the
+    # pin invisibly, so we reject it loudly here naming the bad value.
+    resume_id = claude_block.get("resume_id")
+    if resume_id is not None:
+        if not isinstance(resume_id, str):
+            errors.append(
+                "spec.claude.resume_id must be a string, got "
+                f"{type(resume_id).__name__}"
+            )
+        elif resume_id.strip():
+            try:
+                uuid.UUID(resume_id.strip())
+            except (ValueError, AttributeError, TypeError):
+                errors.append(
+                    f"spec.claude.resume_id '{resume_id}' is not a valid UUID. "
+                    "It must be the session transcript's UUID (e.g. "
+                    "'123e4567-e89b-12d3-a456-426614174000'); an unknown or "
+                    "malformed id is silently discarded to a fresh session by "
+                    "the SDK/CLI, so the pin would be lost without this check."
+                )
+
+    return errors
+
+
+__all__ = ["_VALID_MODEL_RE", "validate_claude"]

--- a/src/scitex_agent_container/config/_placement_validation.py
+++ b/src/scitex_agent_container/config/_placement_validation.py
@@ -1,0 +1,67 @@
+"""``spec.host`` / ``spec.hosts`` placement validation.
+
+Extracted from ``_validation.py`` to keep that orchestrator under the
+512-line cap (sibling to ``_claude_validation`` / ``_shape_validation``).
+
+Exactly one of ``host`` (singleton) / ``hosts`` (multi-instance) is
+REQUIRED — no hidden 'local' default (operator directive 2026-06-23) —
+and the two are mutually exclusive.
+"""
+
+from __future__ import annotations
+
+
+def validate_placement(spec: dict) -> list[str]:
+    """Return placement (host/hosts) validation errors (empty = valid)."""
+    errors: list[str] = []
+
+    has_host = "host" in spec
+    has_hosts = "hosts" in spec
+    if not has_host and not has_hosts:
+        errors.append(
+            "spec.host or spec.hosts is REQUIRED — declare placement "
+            "explicitly (no hidden 'local' default; operator directive "
+            "2026-06-23). Use ONE of:\n"
+            "  host: local              # this (the invoking) host\n"
+            "  host: <peer>             # pinned to a single peer\n"
+            "  hosts: [<peer>, ...]     # one instance per host (or 'all')"
+        )
+    if has_host and has_hosts:
+        errors.append(
+            "spec.host and spec.hosts are mutually exclusive — set "
+            "exactly one (host: singleton, hosts: multi-instance)"
+        )
+    if has_host:
+        host_val = spec.get("host")
+        if host_val is not None and not isinstance(host_val, (str, list)):
+            errors.append(
+                f"spec.host must be a string, list of strings, or empty; "
+                f"got {type(host_val).__name__}"
+            )
+        elif isinstance(host_val, list) and not all(
+            isinstance(h, str) for h in host_val
+        ):
+            errors.append("spec.host list must contain only strings")
+    if has_hosts:
+        hosts_val = spec.get("hosts")
+        if hosts_val is None:
+            errors.append(
+                "spec.hosts cannot be empty — use 'all' (every fleet "
+                "host) or a list of host names"
+            )
+        elif isinstance(hosts_val, str) and hosts_val != "all":
+            errors.append(f"spec.hosts string must be 'all', got '{hosts_val}'")
+        elif isinstance(hosts_val, list) and not all(
+            isinstance(h, str) for h in hosts_val
+        ):
+            errors.append("spec.hosts list must contain only strings")
+        elif not isinstance(hosts_val, (str, list)):
+            errors.append(
+                f"spec.hosts must be 'all' or a list of strings; "
+                f"got {type(hosts_val).__name__}"
+            )
+
+    return errors
+
+
+__all__ = ["validate_placement"]

--- a/src/scitex_agent_container/config/_shape_validation.py
+++ b/src/scitex_agent_container/config/_shape_validation.py
@@ -1,0 +1,83 @@
+"""``spec.autonomous`` + ``kind: AgentProxy`` coupling validation.
+
+Extracted from ``_validation.py`` to keep that orchestrator under the
+512-line cap (sibling to ``_claude_validation`` / ``_placement_validation``).
+"""
+
+from __future__ import annotations
+
+
+def validate_autonomous(spec: dict) -> list[str]:
+    """Return ``spec.autonomous`` (F-CS3 drive-until-done) errors."""
+    errors: list[str] = []
+    autonomous = spec.get("autonomous")
+    if autonomous is None:
+        return errors
+    if not isinstance(autonomous, dict):
+        errors.append(
+            f"spec.autonomous must be a mapping; got {type(autonomous).__name__}"
+        )
+        return errors
+    drive_until = autonomous.get("drive_until")
+    if drive_until is not None and not isinstance(drive_until, str):
+        errors.append("spec.autonomous.drive_until must be a string")
+    elif drive_until == "":
+        errors.append("spec.autonomous.drive_until must be non-empty")
+    for fld in ("max_turns", "idle_kick_after_s"):
+        val = autonomous.get(fld)
+        if val is not None:
+            if not isinstance(val, int) or isinstance(val, bool):
+                errors.append(f"spec.autonomous.{fld} must be an integer")
+            elif val <= 0:
+                errors.append(f"spec.autonomous.{fld} must be > 0")
+    kick = autonomous.get("kick_text")
+    if kick is not None and not isinstance(kick, str):
+        errors.append("spec.autonomous.kick_text must be a string")
+    enabled = autonomous.get("enabled")
+    if enabled is not None and not isinstance(enabled, bool):
+        errors.append("spec.autonomous.enabled must be a boolean")
+    return errors
+
+
+def validate_proxy_coupling(spec: dict, kind: object) -> list[str]:
+    """Return ``kind``↔``spec.proxy`` coupling errors.
+
+    AgentProxy has NO SDK — it's a thin HTTP forwarder. So:
+      * spec.proxy is REQUIRED (no upstream → nothing to forward to)
+      * spec.claude / spec.startup_prompts / spec.startup_commands are
+        IGNORED (no SDK to configure / prompt); authoring them is a
+        category error surfaced loudly.
+    The mirror also holds for kind: Agent — spec.proxy is rejected there
+    because the SDK runner doesn't read it.
+    """
+    errors: list[str] = []
+    if kind == "AgentProxy":
+        proxy_block = spec.get("proxy")
+        if proxy_block is None:
+            errors.append(
+                "spec.proxy is required when kind: AgentProxy "
+                "(no upstream to forward to)."
+            )
+        elif not (isinstance(proxy_block, dict) and proxy_block.get("upstream")):
+            errors.append(
+                "spec.proxy.upstream is REQUIRED when kind: AgentProxy — "
+                "declare the forwarding target explicitly:\n"
+                "  proxy:\n    upstream: http://127.0.0.1:9000"
+            )
+        for forbidden in ("claude", "startup_prompts", "startup_commands"):
+            val = spec.get(forbidden)
+            if val:
+                errors.append(
+                    f"spec.{forbidden} is not allowed when kind: AgentProxy "
+                    "(proxy has no SDK to configure / prompt). Remove the field."
+                )
+    elif kind == "Agent":
+        if "proxy" in spec:
+            errors.append(
+                "spec.proxy is only meaningful when kind: AgentProxy; "
+                "remove it for kind: Agent."
+            )
+    return errors
+
+
+__all__ = ["validate_autonomous", "validate_proxy_coupling"]

--- a/src/scitex_agent_container/config/_validation.py
+++ b/src/scitex_agent_container/config/_validation.py
@@ -8,54 +8,24 @@ Communication with the agent uses the HTTP A2A surface, never panes.
 
 from __future__ import annotations
 
-import re
 from pathlib import Path
 
 import yaml
 
 from ._acl_validation import validate_phase3_acl
-from ._provider_validation import provider_is_active, validate_provider
 
-# Accepted shapes for ``spec.model`` (F-CS7).
-#
-# claude-agent-sdk silently rejects unknown aliases — the runner stays
-# alive, the heartbeat is fresh, but every turn returns 0 input tokens
-# and 0 output tokens because the SDK never makes the API call. Pin
-# the validation here so the failure surfaces at yaml-validate time
-# instead of as a hung-looking agent.
-#
-# Two acceptable shapes:
-#   1. Bare alias: ``opus`` / ``sonnet`` / ``haiku`` / ``inherit`` /
-#      ``default``, optionally with a context-suffix (``[1m]``).
-#   2. Full versioned form: ``claude-<family>-N-M`` with optional date
-#      tail (``-20251001``) and optional context-suffix.
-#
-# Reproduction (2026-05-05): ``claude-opus[1m]`` (abbreviated, missing
-# the version digits) was accepted by the YAML loader but silently
-# rejected by the SDK — every turn returned ``input_tokens=0``,
-# ``output_tokens=0``, ``iterations=[]``. Other peers using
-# ``claude-opus-4-7[1m]`` worked fine.
-_VALID_MODEL_RE = re.compile(
-    r"""
-    ^(?:
-        (?:opus|sonnet|haiku|fable|inherit|default)
-        |
-        # opus/sonnet/haiku ship as ``family-N-M`` (e.g. ``claude-opus-4-7``).
-        # Fable is published as a single-digit family version
-        # (``claude-fable-5``); see lead-confirmed 2026-06-12 (msg
-        # 6172e53d ruling 1). The ``[1m]`` context-suffix is CLI-native
-        # (proven empirically — msg 6f7e2f56) and bolted on below.
-        claude-(?:
-            (?:opus|sonnet|haiku)-\d+-\d+
-            |
-            fable-\d+
-        )(?:-[a-z0-9]+)*
-    )
-    (?:\[[a-zA-Z0-9_]+\])?
-    $
-    """,
-    re.VERBOSE,
-)
+# Cohesive validation blocks extracted into sibling modules to keep this
+# orchestrator under the 512-line cap (same pattern as _acl_validation /
+# _provider_validation). ``_VALID_MODEL_RE`` is re-exported here for
+# back-compat with any importer of the old ``_validation._VALID_MODEL_RE``.
+from ._claude_validation import _VALID_MODEL_RE as _VALID_MODEL_RE  # noqa: F401
+from ._claude_validation import validate_claude
+from ._placement_validation import validate_placement
+from ._shape_validation import validate_autonomous, validate_proxy_coupling
+
+# ``_VALID_MODEL_RE`` (accepted ``spec.claude.model`` shapes) moved to
+# ``_claude_validation`` alongside the rest of the claude-block checks;
+# re-exported at the top of this module for back-compat.
 
 _VALID_API_VERSIONS = ("scitex-agent-container/v3",)
 
@@ -378,53 +348,10 @@ def validate_raw(raw: dict, path: str) -> list[str]:
                 f"spec.dockerfile must be a string, got {type(dockerfile).__name__}"
             )
 
-        # spec.claude.model — F-CS7 (v3: moved from top-level spec.model).
-        # Validate against accepted SDK aliases / versioned forms. The
-        # SDK silently rejects unknown values (heartbeat fresh, every
-        # turn returns 0 tokens), so we surface bad strings at yaml-
-        # validate time. Empty / missing is allowed — runtime falls back
-        # to its default.
-        claude_block = spec.get("claude", {}) or {}
-        if not isinstance(claude_block, dict):
-            claude_block = {}
-        # spec.claude.provider — vendor-agnostic backend override
-        # (ProviderSpec). When present, the SDK session runs against an
-        # Anthropic-SDK-compatible backend on an API key, so the model id
-        # is the provider's own (e.g. 'deepseek-chat') and the claude-*
-        # regex below is skipped. Absent → behaviour unchanged.
-        provider_block = claude_block.get("provider")
-        has_provider = provider_is_active(provider_block)
-        errors.extend(validate_provider(provider_block))
-        model = claude_block.get("model")
-        if model is not None:
-            if not isinstance(model, str):
-                errors.append(
-                    f"spec.claude.model must be a string, got {type(model).__name__}"
-                )
-            elif model and not has_provider and not _VALID_MODEL_RE.match(model):
-                errors.append(
-                    f"spec.claude.model '{model}' is not an accepted alias. "
-                    "Use a bare alias ('opus', 'sonnet', 'haiku', 'inherit', "
-                    "'default'), optionally with a context suffix like "
-                    "'opus[1m]'; OR the full versioned form "
-                    "'claude-<family>-N-M[-<tail>]' (e.g. 'claude-opus-4-7', "
-                    "'claude-opus-4-7[1m]', 'claude-haiku-4-5-20251001'). "
-                    "Abbreviated forms like 'claude-opus[1m]' are rejected "
-                    "by the SDK without raising — every turn returns 0 "
-                    "tokens. (When spec.claude.provider is set, the model "
-                    "field accepts the provider's own model id instead.)"
-                )
-
-        # spec.claude.provider + spec.claude.account are mutually
-        # exclusive — an API-key backend needs no OAuth. Declaring both
-        # is a config error (the runtime would otherwise have to guess
-        # which auth path wins). Reject loudly at validate time.
-        if has_provider and (claude_block.get("account") or ""):
-            errors.append(
-                "spec.claude.provider and spec.claude.account are mutually "
-                "exclusive — a provider backend uses an API key, not "
-                "Anthropic OAuth. Set exactly one."
-            )
+        # spec.claude block (model alias / provider / account exclusivity /
+        # resume_id UUID) — validated in the sibling ``_claude_validation``
+        # module (keeps this orchestrator under the per-file cap).
+        errors.extend(validate_claude(spec))
 
         # container.runtime
         container = spec.get("container", {}) or {}
@@ -485,121 +412,14 @@ def validate_raw(raw: dict, path: str) -> list[str]:
                     f"got '{user_val}'"
                 )
 
-        # host / hosts — placement. Exactly one is REQUIRED (no hidden
-        # 'local' default; operator directive 2026-06-23) AND they are
-        # mutually exclusive. ``host: local`` is the explicit local-singleton
-        # spelling (parser normalizes it to "").
-        has_host = "host" in spec
-        has_hosts = "hosts" in spec
-        if not has_host and not has_hosts:
-            errors.append(
-                "spec.host or spec.hosts is REQUIRED — declare placement "
-                "explicitly (no hidden 'local' default; operator directive "
-                "2026-06-23). Use ONE of:\n"
-                "  host: local              # this (the invoking) host\n"
-                "  host: <peer>             # pinned to a single peer\n"
-                "  hosts: [<peer>, ...]     # one instance per host (or 'all')"
-            )
-        if has_host and has_hosts:
-            errors.append(
-                "spec.host and spec.hosts are mutually exclusive — set "
-                "exactly one (host: singleton, hosts: multi-instance)"
-            )
-        if has_host:
-            host_val = spec.get("host")
-            if host_val is not None and not isinstance(host_val, (str, list)):
-                errors.append(
-                    f"spec.host must be a string, list of strings, or empty; "
-                    f"got {type(host_val).__name__}"
-                )
-            elif isinstance(host_val, list) and not all(
-                isinstance(h, str) for h in host_val
-            ):
-                errors.append("spec.host list must contain only strings")
-        if has_hosts:
-            hosts_val = spec.get("hosts")
-            if hosts_val is None:
-                errors.append(
-                    "spec.hosts cannot be empty — use 'all' (every fleet "
-                    "host) or a list of host names"
-                )
-            elif isinstance(hosts_val, str) and hosts_val != "all":
-                errors.append(f"spec.hosts string must be 'all', got '{hosts_val}'")
-            elif isinstance(hosts_val, list) and not all(
-                isinstance(h, str) for h in hosts_val
-            ):
-                errors.append("spec.hosts list must contain only strings")
-            elif not isinstance(hosts_val, (str, list)):
-                errors.append(
-                    f"spec.hosts must be 'all' or a list of strings; "
-                    f"got {type(hosts_val).__name__}"
-                )
+        # host / hosts — placement. Exactly one is REQUIRED and they are
+        # mutually exclusive (sibling ``_placement_validation`` module).
+        errors.extend(validate_placement(spec))
 
-        # spec.autonomous (F-CS3 phase 1) — drive-until-done.
-        autonomous = spec.get("autonomous")
-        if autonomous is not None:
-            if not isinstance(autonomous, dict):
-                errors.append(
-                    "spec.autonomous must be a mapping; got "
-                    f"{type(autonomous).__name__}"
-                )
-            else:
-                drive_until = autonomous.get("drive_until")
-                if drive_until is not None and not isinstance(drive_until, str):
-                    errors.append("spec.autonomous.drive_until must be a string")
-                elif drive_until == "":
-                    errors.append("spec.autonomous.drive_until must be non-empty")
-                for fld in ("max_turns", "idle_kick_after_s"):
-                    val = autonomous.get(fld)
-                    if val is not None:
-                        if not isinstance(val, int) or isinstance(val, bool):
-                            errors.append(f"spec.autonomous.{fld} must be an integer")
-                        elif val <= 0:
-                            errors.append(f"spec.autonomous.{fld} must be > 0")
-                kick = autonomous.get("kick_text")
-                if kick is not None and not isinstance(kick, str):
-                    errors.append("spec.autonomous.kick_text must be a string")
-                enabled = autonomous.get("enabled")
-                if enabled is not None and not isinstance(enabled, bool):
-                    errors.append("spec.autonomous.enabled must be a boolean")
-
-        # kind: AgentProxy coupling rules.
-        #
-        # AgentProxy has NO SDK — it's a thin HTTP forwarder. So:
-        #   * spec.proxy is REQUIRED (no upstream → nothing to forward to)
-        #   * spec.claude is IGNORED (no SDK to configure); operator
-        #     authoring it is a category error we surface loudly.
-        #   * spec.startup_prompts / spec.startup_commands are IGNORED
-        #     for the same reason — no SDK to prompt.
-        #
-        # The mirror also holds for kind: Agent — spec.proxy is rejected
-        # there because the SDK runner doesn't read it.
-        if kind == "AgentProxy":
-            proxy_block = spec.get("proxy")
-            if proxy_block is None:
-                errors.append(
-                    "spec.proxy is required when kind: AgentProxy "
-                    "(no upstream to forward to)."
-                )
-            elif not (isinstance(proxy_block, dict) and proxy_block.get("upstream")):
-                errors.append(
-                    "spec.proxy.upstream is REQUIRED when kind: AgentProxy — "
-                    "declare the forwarding target explicitly:\n"
-                    "  proxy:\n    upstream: http://127.0.0.1:9000"
-                )
-            for forbidden in ("claude", "startup_prompts", "startup_commands"):
-                val = spec.get(forbidden)
-                if val:
-                    errors.append(
-                        f"spec.{forbidden} is not allowed when kind: AgentProxy "
-                        "(proxy has no SDK to configure / prompt). Remove the field."
-                    )
-        elif kind == "Agent":
-            if "proxy" in spec:
-                errors.append(
-                    "spec.proxy is only meaningful when kind: AgentProxy; "
-                    "remove it for kind: Agent."
-                )
+        # spec.autonomous (F-CS3 drive-until-done) + kind:AgentProxy
+        # coupling rules — sibling ``_shape_validation`` module.
+        errors.extend(validate_autonomous(spec))
+        errors.extend(validate_proxy_coupling(spec, kind))
 
         # Phase-3 capsule-isolation: type-check ``spec.comms`` +
         # ``spec.lineage`` shapes. Detailed rules live in the

--- a/src/scitex_agent_container/runtimes/_apptainer_inner_argv_tui.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_inner_argv_tui.py
@@ -130,8 +130,9 @@ def _tui_runner_argv(
     # by the loader/CLI before this builder runs — we only translate it to the
     # flag here. Experiment capsules (no coordinator role → ``fresh``) run
     # hermetic; coordinator roles keep continuity.
-    from ..config._session_continuity import wants_continue
+    from ..config._session_continuity import SESSION_RESUME, wants_continue
 
+    session_mode = str(getattr(claude_spec, "session", "") or "").strip().lower()
     if wants_continue(getattr(claude_spec, "session", None)):
         has_history, home = _home_has_resumable_conversation(config)
         if has_history:
@@ -152,6 +153,16 @@ def _tui_runner_argv(
                 getattr(config, "name", "?"),
                 home,
             )
+    elif session_mode == SESSION_RESUME:
+        # Id-addressed resume: ``spec.claude.session: resume`` +
+        # ``spec.claude.resume_id`` → ``claude --resume <id>`` (mirrors the
+        # legacy tmux runner). Unlike bare ``-c`` (latest-for-home), this
+        # resumes a SPECIFIC transcript uuid. With no resume_id set we fall
+        # through to fresh (no flag) — the validator already rejects a
+        # malformed id, and an empty one means "not pinned".
+        resume_id = str(getattr(claude_spec, "resume_id", "") or "").strip()
+        if resume_id:
+            argv += ["--resume", resume_id]
     # One ``--mcp-config`` per value (P0 fix 2026-06-15, operator-reported):
     # ``claude --help`` documents ``--mcp-config <configs...>`` as accepting
     # multiple space-separated values after a single flag, but the real

--- a/tests/scitex_agent_container/_lifecycle/test__session_seed.py
+++ b/tests/scitex_agent_container/_lifecycle/test__session_seed.py
@@ -1,0 +1,106 @@
+"""Spec-pinned session-id seeding (``session: resume`` + ``resume_id``).
+
+Real behaviour, no mocks of the code under test: a real on-disk state
+dir, a real runtime stub exposing ``_state_dir`` (mirrors
+ApptainerContainerRuntime's API), and the real ``read_session_id`` /
+``write_session_id`` marker helpers.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scitex_agent_container._lifecycle._session_seed import seed_pinned_session_id
+from scitex_agent_container._runners._session_state import (
+    read_session_id,
+    read_session_id_history,
+    write_session_id,
+)
+from scitex_agent_container.config import AgentConfig
+from scitex_agent_container.config._types import ClaudeSpec
+
+_VALID_UUID = "123e4567-e89b-12d3-a456-426614174000"
+_FORKED_UUID = "abcdef01-2345-6789-abcd-ef0123456789"
+
+
+class _RuntimeStub:
+    """Honest runtime collaborator — only the ``_state_dir`` resolver."""
+
+    def __init__(self, root: Path) -> None:
+        self._root = root
+
+    def _state_dir(self, config: AgentConfig) -> Path:
+        return self._root / config.name
+
+
+def _cfg(name: str, *, session: str, resume_id: str = "") -> AgentConfig:
+    return AgentConfig(
+        name=name,
+        runtime="apptainer",
+        claude=ClaudeSpec(model="haiku", session=session, resume_id=resume_id),
+    )
+
+
+def test_seed_returns_true_when_marker_absent(tmp_path: Path):
+    # Arrange — first boot: no session_id marker yet.
+    cfg = _cfg("seed-a", session="resume", resume_id=_VALID_UUID)
+    # Act
+    seeded = seed_pinned_session_id(cfg, _RuntimeStub(tmp_path))
+    # Assert
+    assert seeded is True
+
+
+def test_seed_writes_pinned_uuid_as_marker(tmp_path: Path):
+    # Arrange
+    cfg = _cfg("seed-a", session="resume", resume_id=_VALID_UUID)
+    # Act
+    seed_pinned_session_id(cfg, _RuntimeStub(tmp_path))
+    # Assert
+    assert read_session_id(tmp_path / "seed-a") == _VALID_UUID
+
+
+def test_seed_records_pinned_uuid_in_history(tmp_path: Path):
+    # Arrange
+    cfg = _cfg("seed-a", session="resume", resume_id=_VALID_UUID)
+    # Act
+    seed_pinned_session_id(cfg, _RuntimeStub(tmp_path))
+    # Assert
+    assert read_session_id_history(tmp_path / "seed-a") == [_VALID_UUID]
+
+
+def test_seed_returns_false_when_marker_exists(tmp_path: Path):
+    # Arrange — a prior turn already forked the id; the marker is the fork.
+    cfg = _cfg("seed-b", session="resume", resume_id=_VALID_UUID)
+    write_session_id(tmp_path / "seed-b", _FORKED_UUID)
+    # Act
+    seeded = seed_pinned_session_id(cfg, _RuntimeStub(tmp_path))
+    # Assert
+    assert seeded is False
+
+
+def test_seed_preserves_existing_forked_marker(tmp_path: Path):
+    # Arrange — re-seeding must NOT clobber the fork back to the pin.
+    cfg = _cfg("seed-b", session="resume", resume_id=_VALID_UUID)
+    write_session_id(tmp_path / "seed-b", _FORKED_UUID)
+    # Act
+    seed_pinned_session_id(cfg, _RuntimeStub(tmp_path))
+    # Assert
+    assert read_session_id(tmp_path / "seed-b") == _FORKED_UUID
+
+
+def test_seed_noop_when_session_not_resume(tmp_path: Path):
+    # Arrange — resume_id set but session is not "resume".
+    cfg = _cfg("seed-c", session="continue", resume_id=_VALID_UUID)
+    # Act
+    seeded = seed_pinned_session_id(cfg, _RuntimeStub(tmp_path))
+    # Assert
+    assert seeded is False
+
+
+def test_seed_noop_when_no_resume_id(tmp_path: Path):
+    # Arrange — session=resume but no explicit id (not pinned).
+    cfg = _cfg("seed-d", session="resume", resume_id="")
+    # Act
+    seeded = seed_pinned_session_id(cfg, _RuntimeStub(tmp_path))
+    # Assert
+    assert seeded is False

--- a/tests/scitex_agent_container/config/test__claude_validation.py
+++ b/tests/scitex_agent_container/config/test__claude_validation.py
@@ -1,0 +1,67 @@
+"""``spec.claude.resume_id`` UUID validation (extracted _claude_validation).
+
+A non-empty ``resume_id`` MUST be a well-formed UUID: the SDK/CLI resume
+mechanism silently discards an unknown/malformed id to a fresh session,
+so a typo would degrade the pin invisibly. The validator fails loud
+naming the bad value. Real ``validate_claude`` on real dicts, no mocks.
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container.config._claude_validation import validate_claude
+
+_VALID_UUID = "123e4567-e89b-12d3-a456-426614174000"
+
+
+def test_valid_uuid_resume_id_produces_no_error():
+    # Arrange
+    spec = {"claude": {"model": "haiku", "resume_id": _VALID_UUID}}
+    # Act
+    errors = validate_claude(spec)
+    # Assert
+    assert errors == []
+
+
+def test_malformed_resume_id_is_rejected():
+    # Arrange
+    spec = {"claude": {"model": "haiku", "resume_id": "not-a-uuid"}}
+    # Act
+    errors = validate_claude(spec)
+    # Assert
+    assert any("resume_id" in e and "not a valid UUID" in e for e in errors)
+
+
+def test_malformed_resume_id_error_names_the_bad_value():
+    # Arrange
+    spec = {"claude": {"model": "haiku", "resume_id": "bogus-123"}}
+    # Act
+    errors = validate_claude(spec)
+    # Assert
+    assert any("bogus-123" in e for e in errors)
+
+
+def test_empty_resume_id_produces_no_error():
+    # Arrange — empty means "not pinned"; nothing to validate.
+    spec = {"claude": {"model": "haiku", "resume_id": ""}}
+    # Act
+    errors = validate_claude(spec)
+    # Assert
+    assert errors == []
+
+
+def test_absent_resume_id_produces_no_error():
+    # Arrange
+    spec = {"claude": {"model": "haiku"}}
+    # Act
+    errors = validate_claude(spec)
+    # Assert
+    assert errors == []
+
+
+def test_non_string_resume_id_is_rejected():
+    # Arrange
+    spec = {"claude": {"model": "haiku", "resume_id": 12345}}
+    # Act
+    errors = validate_claude(spec)
+    # Assert
+    assert any("resume_id must be a string" in e for e in errors)

--- a/tests/scitex_agent_container/config/test__placement_validation.py
+++ b/tests/scitex_agent_container/config/test__placement_validation.py
@@ -1,0 +1,100 @@
+"""``spec.host`` / ``spec.hosts`` placement validation.
+
+Exactly one of host (singleton) / hosts (multi-instance) is REQUIRED and
+the two are mutually exclusive. Real ``validate_placement`` on real
+dicts, no mocks.
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container.config._placement_validation import validate_placement
+
+
+def test_neither_host_nor_hosts_is_rejected():
+    # Arrange — no placement declared at all.
+    spec: dict = {}
+    # Act
+    errors = validate_placement(spec)
+    # Assert
+    assert any("REQUIRED" in e for e in errors)
+
+
+def test_both_host_and_hosts_is_rejected_as_mutually_exclusive():
+    # Arrange
+    spec = {"host": "local", "hosts": ["a"]}
+    # Act
+    errors = validate_placement(spec)
+    # Assert
+    assert any("mutually exclusive" in e for e in errors)
+
+
+def test_singleton_host_string_produces_no_error():
+    # Arrange
+    spec = {"host": "local"}
+    # Act
+    errors = validate_placement(spec)
+    # Assert
+    assert errors == []
+
+
+def test_host_list_of_non_strings_is_rejected():
+    # Arrange
+    spec = {"host": ["ok", 123]}
+    # Act
+    errors = validate_placement(spec)
+    # Assert
+    assert any("host list must contain only strings" in e for e in errors)
+
+
+def test_host_wrong_type_is_rejected():
+    # Arrange — a mapping is neither a string nor a list.
+    spec = {"host": {"peer": "x"}}
+    # Act
+    errors = validate_placement(spec)
+    # Assert
+    assert any("spec.host must be a string" in e for e in errors)
+
+
+def test_hosts_none_is_rejected_as_empty():
+    # Arrange — ``hosts:`` written with no value.
+    spec = {"hosts": None}
+    # Act
+    errors = validate_placement(spec)
+    # Assert
+    assert any("cannot be empty" in e for e in errors)
+
+
+def test_hosts_string_all_produces_no_error():
+    # Arrange
+    spec = {"hosts": "all"}
+    # Act
+    errors = validate_placement(spec)
+    # Assert
+    assert errors == []
+
+
+def test_hosts_string_other_than_all_is_rejected():
+    # Arrange
+    spec = {"hosts": "everywhere"}
+    # Act
+    errors = validate_placement(spec)
+    # Assert
+    assert any("must be 'all'" in e for e in errors)
+
+
+def test_hosts_list_of_strings_produces_no_error():
+    # Arrange
+    spec = {"hosts": ["a", "b"]}
+    # Act
+    errors = validate_placement(spec)
+    # Assert
+    assert errors == []
+
+
+def test_hosts_list_of_non_strings_is_rejected():
+    # Arrange
+    spec = {"hosts": ["a", 2]}
+    # Act
+    errors = validate_placement(spec)
+    # Assert
+    assert any("hosts list must contain only strings" in e for e in errors)

--- a/tests/scitex_agent_container/config/test__shape_validation.py
+++ b/tests/scitex_agent_container/config/test__shape_validation.py
@@ -1,0 +1,156 @@
+"""``spec.autonomous`` + ``kind: AgentProxy`` coupling validation.
+
+Real ``validate_autonomous`` / ``validate_proxy_coupling`` on real
+dicts, no mocks of the code under test.
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container.config._shape_validation import (
+    validate_autonomous,
+    validate_proxy_coupling,
+)
+
+
+# ---------------------------------------------------------------------------
+# validate_autonomous
+# ---------------------------------------------------------------------------
+
+
+def test_autonomous_absent_produces_no_error():
+    # Arrange — absence means "feature off", not a hidden default.
+    spec: dict = {}
+    # Act
+    errors = validate_autonomous(spec)
+    # Assert
+    assert errors == []
+
+
+def test_autonomous_non_mapping_is_rejected():
+    # Arrange
+    spec = {"autonomous": "yes"}
+    # Act
+    errors = validate_autonomous(spec)
+    # Assert
+    assert any("must be a mapping" in e for e in errors)
+
+
+def test_autonomous_empty_drive_until_is_rejected():
+    # Arrange
+    spec = {"autonomous": {"drive_until": ""}}
+    # Act
+    errors = validate_autonomous(spec)
+    # Assert
+    assert any("drive_until must be non-empty" in e for e in errors)
+
+
+def test_autonomous_non_string_drive_until_is_rejected():
+    # Arrange
+    spec = {"autonomous": {"drive_until": 5}}
+    # Act
+    errors = validate_autonomous(spec)
+    # Assert
+    assert any("drive_until must be a string" in e for e in errors)
+
+
+def test_autonomous_non_int_max_turns_is_rejected():
+    # Arrange
+    spec = {"autonomous": {"drive_until": "done", "max_turns": "lots"}}
+    # Act
+    errors = validate_autonomous(spec)
+    # Assert
+    assert any("max_turns must be an integer" in e for e in errors)
+
+
+def test_autonomous_non_positive_idle_kick_is_rejected():
+    # Arrange
+    spec = {"autonomous": {"drive_until": "done", "idle_kick_after_s": 0}}
+    # Act
+    errors = validate_autonomous(spec)
+    # Assert
+    assert any("idle_kick_after_s must be > 0" in e for e in errors)
+
+
+def test_autonomous_non_bool_enabled_is_rejected():
+    # Arrange
+    spec = {"autonomous": {"drive_until": "done", "enabled": "true"}}
+    # Act
+    errors = validate_autonomous(spec)
+    # Assert
+    assert any("enabled must be a boolean" in e for e in errors)
+
+
+def test_autonomous_valid_block_produces_no_error():
+    # Arrange
+    spec = {
+        "autonomous": {
+            "drive_until": "all green",
+            "max_turns": 10,
+            "idle_kick_after_s": 30,
+            "kick_text": "continue",
+            "enabled": True,
+        }
+    }
+    # Act
+    errors = validate_autonomous(spec)
+    # Assert
+    assert errors == []
+
+
+# ---------------------------------------------------------------------------
+# validate_proxy_coupling
+# ---------------------------------------------------------------------------
+
+
+def test_agentproxy_without_proxy_block_is_rejected():
+    # Arrange — no upstream to forward to.
+    spec: dict = {}
+    # Act
+    errors = validate_proxy_coupling(spec, "AgentProxy")
+    # Assert
+    assert any("spec.proxy is required" in e for e in errors)
+
+
+def test_agentproxy_proxy_without_upstream_is_rejected():
+    # Arrange
+    spec = {"proxy": {}}
+    # Act
+    errors = validate_proxy_coupling(spec, "AgentProxy")
+    # Assert
+    assert any("spec.proxy.upstream is REQUIRED" in e for e in errors)
+
+
+def test_agentproxy_with_forbidden_claude_is_rejected():
+    # Arrange — a proxy has no SDK to configure.
+    spec = {"proxy": {"upstream": "http://127.0.0.1:9000"}, "claude": {"model": "haiku"}}
+    # Act
+    errors = validate_proxy_coupling(spec, "AgentProxy")
+    # Assert
+    assert any("not allowed when kind: AgentProxy" in e for e in errors)
+
+
+def test_agentproxy_with_valid_proxy_produces_no_error():
+    # Arrange
+    spec = {"proxy": {"upstream": "http://127.0.0.1:9000"}}
+    # Act
+    errors = validate_proxy_coupling(spec, "AgentProxy")
+    # Assert
+    assert errors == []
+
+
+def test_agent_kind_with_proxy_is_rejected():
+    # Arrange — the SDK runner doesn't read spec.proxy.
+    spec = {"proxy": {"upstream": "http://127.0.0.1:9000"}}
+    # Act
+    errors = validate_proxy_coupling(spec, "Agent")
+    # Assert
+    assert any("only meaningful when kind: AgentProxy" in e for e in errors)
+
+
+def test_agent_kind_without_proxy_produces_no_error():
+    # Arrange
+    spec = {"claude": {"model": "haiku"}}
+    # Act
+    errors = validate_proxy_coupling(spec, "Agent")
+    # Assert
+    assert errors == []

--- a/tests/scitex_agent_container/runtimes/test__apptainer_inner_argv_tui.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_inner_argv_tui.py
@@ -1,9 +1,10 @@
-"""TUI ``--resume <id>`` for ``spec.claude.session: resume`` + ``resume_id``.
+"""Tests for ``runtimes/_apptainer_inner_argv_tui.py``.
 
-The interactive TUI argv builder (``_tui_runner_argv``) must translate an
-id-addressed resume pin into ``claude --resume <uuid>`` — mirroring the
-legacy tmux runner — distinct from the bare ``-c`` (latest-for-home)
-continue path. No mocks: the real builder is exercised on a real config.
+Covers the interactive-TUI ``--resume <id>`` branch: ``spec.claude.session:
+resume`` + ``spec.claude.resume_id`` translates to ``claude --resume <uuid>``
+(mirrors the legacy tmux runner), distinct from the bare ``-c``
+(latest-for-home) continue path. No mocks: the real builder is exercised
+on a real config.
 """
 
 from __future__ import annotations

--- a/tests/scitex_agent_container/runtimes/test__tui_resume_argv.py
+++ b/tests/scitex_agent_container/runtimes/test__tui_resume_argv.py
@@ -1,0 +1,59 @@
+"""TUI ``--resume <id>`` for ``spec.claude.session: resume`` + ``resume_id``.
+
+The interactive TUI argv builder (``_tui_runner_argv``) must translate an
+id-addressed resume pin into ``claude --resume <uuid>`` — mirroring the
+legacy tmux runner — distinct from the bare ``-c`` (latest-for-home)
+continue path. No mocks: the real builder is exercised on a real config.
+"""
+
+from __future__ import annotations
+
+from scitex_agent_container.config import AgentConfig
+from scitex_agent_container.config._types import ClaudeSpec
+from scitex_agent_container.runtimes._apptainer_inner_argv_tui import _tui_runner_argv
+
+_VALID_UUID = "123e4567-e89b-12d3-a456-426614174000"
+
+
+def _cfg(*, session: str, resume_id: str = "") -> AgentConfig:
+    return AgentConfig(
+        name="t-tui",
+        runtime="apptainer",
+        claude=ClaudeSpec(model="haiku", session=session, resume_id=resume_id),
+    )
+
+
+def test_resume_with_id_emits_resume_flag():
+    # Arrange
+    cfg = _cfg(session="resume", resume_id=_VALID_UUID)
+    # Act
+    argv = _tui_runner_argv(cfg)
+    # Assert
+    assert "--resume" in argv
+
+
+def test_resume_flag_is_followed_by_the_pinned_uuid():
+    # Arrange
+    cfg = _cfg(session="resume", resume_id=_VALID_UUID)
+    # Act
+    argv = _tui_runner_argv(cfg)
+    # Assert
+    assert argv[argv.index("--resume") + 1] == _VALID_UUID
+
+
+def test_resume_never_emits_bare_continue_flag():
+    # Arrange — id-addressed resume must not degrade to bare ``-c``.
+    cfg = _cfg(session="resume", resume_id=_VALID_UUID)
+    # Act
+    argv = _tui_runner_argv(cfg)
+    # Assert
+    assert "-c" not in argv
+
+
+def test_resume_without_id_omits_resume_flag():
+    # Arrange — session=resume but not pinned → fall through to fresh.
+    cfg = _cfg(session="resume", resume_id="")
+    # Act
+    argv = _tui_runner_argv(cfg)
+    # Assert
+    assert "--resume" not in argv


### PR DESCRIPTION
## What

Wire `spec.claude.resume_id` onto the **current** apptainer SDK and TUI runner paths. The field already existed in the schema and was parsed, but was honoured **only** on the legacy tmux runtime.

### 1. SDK path — seed-if-absent
When `spec.claude.session == "resume"` and `spec.claude.resume_id` is set, seed `<state_dir>/session_id` (+ append-only history) from the pinned uuid via `write_session_id`, **but only if the marker is currently ABSENT** (first boot / migration). The SDK has no "seed a fresh arbitrary id" knob — it only resumes an id already on disk — so we write the marker ourselves.

Seed-if-absent is the load-bearing semantic: after the first turn the SDK may **fork** the id, and that forked id becomes the live thread. Re-seeding on every restart would clobber the fork back to the original pin and lose the continuation. New helper `_lifecycle/_session_seed.seed_pinned_session_id`, called from `agent_start` **before** `runtime.start` so the in-container runner sees the seed on its first resume attempt.

### 2. TUI path
`runtimes/_apptainer_inner_argv_tui._tui_runner_argv` gains a `session: resume` branch that appends `--resume <id>` (mirrors the legacy `claude_code` runner). Distinct from the bare `-c` (latest-for-home continue) path; falls through to fresh when no id is set.

### 3. UUID validation
`spec.claude.resume_id`, when non-empty, must be a well-formed UUID (`uuid.UUID(...)`), failing loud and naming the bad value. An unknown/malformed id is silently discarded to a fresh session by the SDK/CLI, so a typo would degrade the pin invisibly without this check.

## Refactor (required to land under the 512-line cap)
`config/_validation.py` was pre-existingly over the 512-line file cap. Extracted three cohesive blocks into sibling modules (same pattern as the existing `_acl_validation` / `_provider_validation`):
- `_claude_validation.py` — model alias / provider / account-exclusivity / **resume_id UUID**; owns `_VALID_MODEL_RE` (re-exported from `_validation` for back-compat).
- `_placement_validation.py` — host/hosts placement.
- `_shape_validation.py` — autonomous + AgentProxy coupling.

`_validation.py` stays the orchestrator (642 → 461 lines). No behavioural change to the extracted checks.

## Tests (real behaviour, no mocks of code under test)
- `test__session_seed.py` — seeds when absent; does NOT overwrite an existing forked id; no-ops when session≠resume or no id.
- `test__tui_resume_argv.py` — argv includes `--resume <id>`, never bare `-c`; omitted when unpinned.
- `test__claude_validation.py` — rejects a non-UUID / non-string resume_id, accepts a valid one.

## Test command / result
```
env PYTHONPATH=<worktree>/src /opt/venv-sac/bin/python -m pytest \
  tests/scitex_agent_container/config/ \
  tests/scitex_agent_container/_lifecycle/ \
  tests/integration/test_schema_validation_fr3.py \
  tests/integration/test_templates_v3_valid.py
```
→ **1177 passed, 2 skipped** (the 2 skips are pre-existing). The targeted new + adjacent suites also pass (178 passed).