### PR TITLE
docs(skills): skills de-bloat pilot — archive + lean-rewrite 3 top API-restatement leaves

### DIFF
--- a/skills-archive/README.md
+++ b/skills-archive/README.md
@@ -1,0 +1,19 @@
+# skills-archive — verbatim snapshot of the sac agent skills
+
+This directory is a **plain-text, uncompressed, verbatim copy** of the
+live sac agent skills as they existed immediately before the
+"skills de-bloat pilot" (see the PR that introduced this directory).
+
+- Source of truth (live, propagated to fleet agents):
+  `src/scitex_agent_container/_skills/scitex-agent-container/`
+- This archive: `skills-archive/scitex-agent-container/` — the **old**
+  versions, kept so nothing is lost and so the operator can read the
+  pre-rewrite text directly.
+
+The live skills remain in place and keep working. The de-bloat pilot
+rewrites only a small number of the most API-restatement-heavy skill
+files LEAN; every other live file is untouched in this first pass.
+
+If you want to see what a rewritten skill said before, read its twin
+here. This directory is not loaded by any agent and is not part of the
+skills propagation mechanism — it is a reference snapshot only.

--- a/skills-archive/scitex-agent-container/01_config-v3.md
+++ b/skills-archive/scitex-agent-container/01_config-v3.md
@@ -1,0 +1,137 @@
+---
+description: |
+  [TOPIC] v3 Config Format
+  [DETAILS] v3 YAML config format — apiVersion scitex-agent-container/v3, dir-as-SSoT (agent name from parent directory, not metadata.name), auto-derived fields, src_*.<ext> file deployment..
+tags: [scitex-agent-container-config-v3]
+---
+
+# v3 Config Format
+
+## `apiVersion: scitex-agent-container/v3`
+
+The current and only accepted apiVersion. The v3 loader **rejects**:
+
+- `apiVersion: scitex-agent-container/v2` (or earlier) — fails validation with a clear "must be one of ('scitex-agent-container/v3',)" error.
+- `metadata.name` field — agent name is derived from the YAML's parent directory (dir-as-SSoT). Including `metadata.name` triggers an error pointing the user at the dir-as-SSoT layout.
+
+### Layout (dir-as-SSoT)
+
+```
+<agent-root>/
+└── <name>/
+    ├── spec.yaml       # ← agent name comes from this directory
+    └── to_home/        # optional; auto-discovered next to spec.yaml; mirrors $HOME
+        ├── CLAUDE.md         # → $HOME/CLAUDE.md   (marker-protected)
+        ├── .mcp.json         # → $HOME/.mcp.json   (full overwrite)
+        ├── .env              # → $HOME/.env        (mode 0600)
+        ├── state.md          # → $HOME/state.md    (marker-protected)
+        └── .claude/
+            ├── hooks/         # → $HOME/.claude/hooks/
+            └── skills/        # → $HOME/.claude/skills/
+```
+
+`<agent-root>` is one of:
+- `~/.scitex/agent-container/agents/`
+- Any colon-separated directory in `$SCITEX_AGENT_CONTAINER_YAML_DIRS`
+
+### Minimal example
+
+```yaml
+apiVersion: scitex-agent-container/v3
+kind: Agent
+metadata:
+  labels:                 # optional; descriptive only
+    role: worker
+    machine: local
+spec:
+  runtime: apptainer      # apptainer (only accepted value)
+
+  claude:
+    model: opus[1m]            # v3-realign: moved from top-level spec.model
+    flags:
+      - --dangerously-skip-permissions
+    session: fresh             # fresh (default) | continue | resume  (aliases: new-session/new->fresh, continue-or-new->continue)
+
+  # Skills are file-based in v3: drop SKILL.md trees under
+  # to_home/.claude/skills/<id>/ and list ids in metadata.labels.skills.
+  # The validator rejects spec.skills.
+
+  health:
+    enabled: true
+    interval: 60
+    method: sdk-alive          # sole supported probe (heartbeat-file/healthz)
+
+  restart:
+    policy: on-failure
+    max_retries: 3
+```
+
+### `spec.claude` fields
+
+| Field | Type | Purpose |
+|---|---|---|
+| `model` | alias or full ID | `opus` / `sonnet` (default) / `haiku` (+ `[1m]` for 1M context), or a full ID like `claude-opus-4-7`. May also sit at `spec.model` (top level). Abbreviated IDs missing version digits (`claude-opus[1m]`) are rejected at validate-time. |
+| `session` | enum | `fresh` (default — independent session, no `-c`) \| `continue` (resume latest for this cwd; TUI `claude -c`) \| `resume` (with `resume_id`). Aliases: `new-session`/`new`→`fresh`, `continue-or-new`→`continue`. An OMITTED field defaults to `fresh` EXCEPT coordinator roles (lead/head/worker/telegrammer/project-maintainer/…), which the loader maps to `continue`. Per-start override: `sac start --continue` / `--fresh`. |
+| `resume_id` | string | Explicit session UUID for `session: resume` |
+| `continue_max_age_minutes` | int | Only resume if `session.jsonl` is newer than N minutes |
+| `flags[]` | list | Extra flags appended to the `claude` invocation |
+| `channels[]` | list | MCP push channels (`server:<name>` / `plugin:<id>@<v>`) |
+| `auto_accept` | bool (default `true`) | Auto-confirm TUI permission prompts |
+| `account` | string | Pin this agent to a stored OAuth account (`sac accounts` store-name). Credentials are **boot-copied** into the agent state dir, not live-bound. Mutually exclusive with `provider`. See [26_credentials-rotation.md](26_credentials-rotation.md). |
+| `provider` | string OR `{ base_url, auth_token_env }` | Point the SDK at any Anthropic-compatible backend. **Canonical (ADR-0011 extension, 2026-05-28):** registered name string, e.g. `provider: mimo` / `provider: deepseek`. sac resolves the base URL + auth env var name from the registry at `config/_provider_registry.py`. **Legacy dict shape** still accepted for back-compat: `base_url` endpoint + `auth_token_env` NAME of the host env var holding the key (never the key value). Mutually exclusive with `account`; relaxes the `claude-*` model-alias check. Auto-injects `ANTHROPIC_MODEL` from `spec.claude.model` (fixes the pitfall where the SDK's default model id silently won). Adding a new provider = add one entry `{base_url, auth_token_env}` to `PROVIDERS` in `_provider_registry.py`. See ADR-0011. |
+| `raw_options` | dict | Escape hatch — splatted into `ClaudeAgentOptions(**raw_options)` |
+
+## Auto-derived fields
+
+The v3 loader fills in defaults from the agent name (parent-directory stem):
+
+| Field | Auto-derived value |
+|---|---|
+| `screen_name` | the agent name itself (used for tmux/screen session) |
+| `workdir` | `~/.scitex/agent-container/runtime/workspaces/<name>/` |
+| `env.SCITEX_AGENT_CONTAINER_NAME` | `<name>` |
+| `env.SCITEX_AGENT_CONTAINER_AGENT` | `<name>` |
+| `env.SCITEX_AGENT_CONTAINER_ID` | `<name>` |
+| `hooks.pre_start` | a `mkdir -p <workdir>` shim |
+
+You can override any of these by setting them explicitly in the YAML. The auto-derivation is just a bottom layer of the resolution cascade.
+
+## `to_home/` deploy pipeline (ADR-0006)
+
+A sibling directory named `to_home/` (override path with
+`spec.to_home:`, default `./to_home`) is materialized into the agent's
+container `$HOME` (= `runtime/<name>/home/`) at `sac agents start` time.
+Every path under `to_home/` lands at the same relative path under
+`$HOME`. `CLAUDE.md` / `state.md` get a marker-protected merge; `.env`
+gets mode 0600; everything else is a full overwrite. `${VAR}` and
+`${metadata.name}` are interpolated in text files. A shared baseline
+`to_home/` (`<agents_dir>/_shared/to_home`, override `$SAC_TO_HOME_BASELINE`)
+is applied first; the per-agent `to_home/` overlays on top.
+
+| Source | Destination | Mode | Semantics |
+|---|---|---|---|
+| `to_home/CLAUDE.md` | `$HOME/CLAUDE.md` | 0644 | Marker-protected; preserves user tail past the End marker |
+| `to_home/.mcp.json` | `$HOME/.mcp.json` | 0644 | Full overwrite |
+| `to_home/.env` | `$HOME/.env` | **0600** | Full overwrite; sourceable by spawned shells |
+| `to_home/state.md` | `$HOME/state.md` | 0644 | Marker-protected (handover snapshot) |
+| `to_home/.claude/<x>/` | `$HOME/.claude/<x>/` | copy | `hooks/`, `skills/`, `commands/`, `agents/`, … |
+
+The legacy `dot_claude/` layout was removed (ADR-0006). A spec that
+still ships a `dot_claude/` dir is rejected with an error pointing at
+`to_home/`.
+
+See `06_env-injection-ports.md` for the four distinct env-injection ports and when to use each.
+
+## Migration from v2 → v3
+
+If you have legacy YAMLs:
+
+1. Change `apiVersion: scitex-agent-container/v2` → `apiVersion: scitex-agent-container/v3`.
+2. Delete the `metadata.name:` field. The agent name now comes from the parent directory; ensure the YAML lives at `<name>/<name>.yaml`.
+3. If your YAML was at a flat path like `~/.scitex/agent-container/agents/foo.yaml`, move it to `~/.scitex/agent-container/agents/foo/foo.yaml`.
+4. `sac agents check <new-path>` to confirm it parses (preflight).
+
+## See also
+
+- `08_templates.md` — six minimal pattern templates under `examples/agent-templates/`
+- `06_env-injection-ports.md` — yaml.env vs to_home/.mcp.json env vs to_home/.env vs hooks

--- a/skills-archive/scitex-agent-container/01_installation.md
+++ b/skills-archive/scitex-agent-container/01_installation.md
@@ -1,0 +1,113 @@
+---
+description: |
+  [TOPIC] Installing scitex-agent-container
+  [DETAILS] pip install + optional extras + auth setup (Pro/Max OAuth) + per-host hook convention. Three deployment shapes: local-only, remote via ssh, Spartan HPC compute.
+tags: [scitex-agent-container-installation]
+---
+
+# Installation
+
+## pip install
+
+```bash
+pip install scitex-agent-container          # core CLI + apptainer runtime + claude-agent-sdk
+pip install 'scitex-agent-container[all]'   # everything (mcp + telegram + slurm + dev + docs)
+```
+
+`claude-agent-sdk` and `uvicorn` (the inbound `/v1/turn` HTTP endpoint)
+are **core** dependencies — they ship in the base install, not behind an
+extra. The declared extras are `[mcp]`, `[telegram]`, `[slurm]`, `[dev]`,
+`[docs]`, and the `[all]` aggregate (see `pyproject.toml`). There is no
+`[sdk]` extra. The CLI ships as both `scitex-agent-container` and the
+short alias `sac`.
+
+## What ships in the wheel
+
+The pip install includes the layered runtime recipes, so you can build
+images without cloning the repo:
+
+```
+<site-packages>/scitex_agent_container/containers/
+  apptainer-base.def       # OS + dev tools
+  apptainer-scitex.def     # FROM :base + scitex[all] + sac
+```
+
+Built artifacts (SIFs, sandboxes) land under user state, never in the
+wheel. `sac image build` delegates to `scitex-container`, which owns the
+dir-per-layer layout (`cli_pkg/image_group.py`):
+
+```
+~/.scitex/agent-container/containers/
+  sac-base.sif        -> sac-base/sac-base.sif          (symlink)
+  sac-base/
+    sac-base.sif
+    sac-base.def                         # recipe snapshot at build time
+    .def-hash                            # def fingerprint; skips rebuild when unchanged
+    sac-base.build-YYYY-MMDD-HHMMSS.log  # full build log, one per build
+  sac-scitex.sif      -> sac-scitex/sac-scitex.sif      (symlink)
+  sac-scitex/
+    sac-scitex.{sif,def}, .def-hash, sac-scitex.build-*.log
+  overlays/<agent-name>/                 # per-agent directory overlays (upper/, work/)
+  dpkg-lock.txt  node-lock.txt  requirements-lock.txt   # build reproducibility locks
+  sac-*/*.sandbox/                       # optional writable sandbox builds (only when built)
+```
+
+The `.sif` symlinks at the `containers/` root are the stable paths specs
+reference; the dir-per-layer keeps each build's `.def` snapshot, hash,
+and logs alongside the image. `overlays/<agent-name>/upper/` is the
+relaxed-mode writable upper layer (see ADR-0009); `work/` is its
+apptainer overlay workdir.
+
+Build with `sac image build base -y && sac image build scitex -y`. See
+[`02_quick-start.md`](02_quick-start.md) for the full first-agent flow.
+
+## Auth (cost-critical)
+
+The SDK runtime reads Anthropic auth in this precedence (see
+`runtimes/_sdk_common.py::provision_anthropic_auth`):
+
+1. `~/.claude/.credentials.json` Pro/Max OAuth (default — flat-rate, no per-token billing). Run `claude /login` once to populate it.
+2. `SAC_ANTHROPIC_API_KEY` env (sac-namespaced handoff for headless contexts — CI, SLURM, cron — mirrored into `ANTHROPIC_API_KEY` for the SDK).
+
+A bare host `ANTHROPIC_API_KEY` is **never honoured**: if
+`SAC_ANTHROPIC_API_KEY` is unset, `provision_anthropic_auth` *pops*
+`ANTHROPIC_API_KEY` from the env so a stale dotfiles export can't
+silently switch you to pay-per-token billing or shadow a working OAuth
+credentials file. Set neither and you get a clear `SDKCommonError`.
+
+## Remote / HPC agents
+
+sac is apptainer-only: the runner always launches via `apptainer exec`
+inside the SIF — there is no host-side bare-Python launch path. The old
+per-host `~/.scitex/agent-container/hosts/$(hostname).sh` + `SAC_RUNNER_PREFIX`
+hook (a host-side `python -m ... claude_session` wrapper) was removed with
+the bare-metal/SSH-dispatch ripout (WI-6, 2026-05-20). The
+`_runners/_remote_launch` module that generated it still exists but is
+dead code (no live importers).
+
+Cross-host placement now goes through:
+
+- **`spec.host`** — pin an agent to a host (or a priority list). See
+  [11_remote-deploy.md](11_remote-deploy.md).
+- **`sac --on <peer>`** (F-CS12) — dispatch a `sac` command on a peer
+  defined in `config.yaml`'s `peers:` block.
+
+HPC-specific environment (Lmod modules, SLURM tenancy, etc.) belongs in
+the apptainer image / overlay or the agent's `to_home/` (see
+[25_claude-setup-delivery.md](25_claude-setup-delivery.md)), not in a
+host-side launch hook.
+
+## Verify
+
+```bash
+sac --version
+sac agents status           # fleet view — empty on a fresh install
+sac mcp list-tools         # confirms package internals importable
+sac image list             # built SIFs (none on a fresh install)
+```
+
+## See also
+
+- [02_quick-start.md](02_quick-start.md) — 30-second first-agent walkthrough
+- [03_python-api.md](03_python-api.md) — programmatic surface
+- [20_env-vars.md](20_env-vars.md) — full env-var reference

--- a/skills-archive/scitex-agent-container/02_multiplexer.md
+++ b/skills-archive/scitex-agent-container/02_multiplexer.md
@@ -1,0 +1,37 @@
+---
+description: |
+  [TOPIC] Multiplexer (vestigial for agents)
+  [DETAILS] SAC agents run via the apptainer SDK runtime (runtimes/claude_session.py) — NOT inside a terminal multiplexer. The tmux wrap is the lead session's launcher concern, outside this package. The spec.multiplexer key is a vestigial config field with no live consumer.
+tags: [scitex-agent-container-multiplexer]
+---
+
+# Multiplexer
+
+**A terminal multiplexer is not part of the SAC agent execution path.**
+SAC agents run via the apptainer SDK runtime
+(`runtimes/claude_session.py`), which drives `claude-agent-sdk` from a
+Python runner — no tmux, no screen, no pane scraping, no `send-keys`
+auto-accept. See [15_claude-session.md](15_claude-session.md).
+
+There is no `runtimes/multiplexer.py` module and nothing in the runtime
+imports a `get_multiplexer` / `TmuxManager` / `ScreenManager` API; that
+surface was removed when the SDK runtime replaced the legacy tmux-wrapped
+CLI runtime. The `spec.multiplexer` YAML key still parses (default
+`tmux`, in `config/_types.py`) but is **vestigial** — no agent code path
+consumes it, so setting it has no effect on how an agent runs.
+
+## Where tmux *is* used
+
+tmux is used only to wrap the **lead** Claude session — for session
+continuity (`--continue`) and remote (iPhone) attach. That wrapping lives
+in the lead's launcher (`scripts/deployment/claude.sh`, which wraps the
+session in a named tmux session `lead`), **outside** this package. It is
+an operator convenience for one interactive human-facing session, not an
+agent execution mechanism, and SAC does not manage it.
+
+## Attaching to a running agent
+
+Use the SDK runtime's own surfaces instead of `tmux attach`:
+
+- `sac agents tail <name>` — rendered transcript from `session.jsonl`.
+- `sac agents start <name> --foreground` — stream a turn to your terminal.

--- a/skills-archive/scitex-agent-container/02_quick-start.md
+++ b/skills-archive/scitex-agent-container/02_quick-start.md
@@ -1,0 +1,108 @@
+---
+description: |
+  [TOPIC] First agent in 30 seconds
+  [DETAILS] Build the layered :base/:scitex SIF once, then minimal spec.yaml + sac agents start + sac agents tail + sac agents stop. Three flavors: local apptainer agent, long-running with A2A inbound, remote agent via ssh.
+tags: [scitex-agent-container-quick-start]
+---
+
+# Quick Start
+
+## 0. One-time: build the runtime images
+
+```bash
+sac image build base   -y          # OS + dev tools             (~15-25 min, one-time)
+sac image build scitex -y          # FROM :base + scitex[all]   (~10-20 min with uv)
+```
+
+The `:scitex` def file uses **uv** (Rust-based parallel resolver) to
+install `scitex[all]`. uv finishes in 1-3 min what plain pip would
+spend 30+ min thrashing on (it walks version histories of the heavy
+transitive set — sphinx-rtd-theme, openalex-local, awscli/botocore,
+etc.). The def falls back to pip if uv is missing on the base layer.
+
+Sandbox builds (writable rootfs dirs, suffix `.sandbox/`):
+
+```bash
+sac image build scitex --sandbox -y    # writable :scitex rootfs
+```
+
+Skip if you already have `scitex-agent-container-scitex.sif` from a teammate or a published release.
+
+## 1. Local agent (30 seconds)
+
+```bash
+mkdir -p ~/.scitex/agent-container/agents/hello/
+cat > ~/.scitex/agent-container/agents/hello/spec.yaml <<'EOF'
+apiVersion: scitex-agent-container/v3
+kind: Agent
+spec:
+  runtime: apptainer                  # or docker for dev laptops
+  workdir: /tmp/hello-workspace
+  model: claude-haiku-4-5
+  startup_commands:
+    - command: "Reply with the string 'hello-ok' and nothing else."
+EOF
+
+sac agents start hello --foreground      # streams assistant chunks; exits when done
+```
+
+Expected: `hello-ok` in your terminal, runner exits with rc=0.
+
+## 2. Long-running agent with A2A inbound
+
+```yaml
+# ~/.scitex/agent-container/agents/worker/spec.yaml
+spec:
+  runtime: apptainer
+  workdir: /tmp/worker
+  model: claude-haiku-4-5
+  a2a:
+    port: 18888                       # enables POST /v1/turn
+```
+
+```bash
+sac agents start  worker                 # daemon mode
+sac agents status worker                 # registry + heartbeat + sdk_session block
+curl -sX POST http://127.0.0.1:18888/v1/turn \
+     -H 'Content-Type: application/json' \
+     -d '{"text": "what is 2+2?"}'
+# → {"reply": "4", "exit_after": false}
+sac agents tail   worker                 # render session.jsonl (structured transcript)
+sac agents stop   worker                 # graceful SIGTERM
+```
+
+## 3. Remote agent on another host
+
+```yaml
+spec:
+  runtime: apptainer
+  workdir: /tmp/head-mba
+  model: claude-haiku-4-5
+  remote:
+    host: mba                           # ssh alias
+    user: ywatanabe
+  a2a:
+    port: 18890                         # loopback on remote — unreachable from outside ssh
+```
+
+```bash
+sac agents start  head-mba               # ssh → bash render → runner survives ssh disconnect
+sac agents status head-mba               # ssh-reads remote state
+sac agents tail   head-mba               # ssh-tails remote session.jsonl
+sac agents stop   head-mba               # ssh + SIGTERM remote pid
+```
+
+Drive a remote agent's `/v1/turn` from Python:
+
+```python
+from scitex_agent_container._network.peer import post_turn
+reply = post_turn("head-mba", "summarize today's commits")
+# → ssh tunnel + curl on remote (loopback stays loopback)
+```
+
+## See also
+
+- [03_python-api.md](03_python-api.md) — full programmatic surface
+- [04_cli-reference.md](04_cli-reference.md) — every CLI subcommand
+- [06_http-api.md](06_http-api.md) — `POST /v1/turn` wire format
+- [11_remote-deploy.md](11_remote-deploy.md) — SSH deployment internals

--- a/skills-archive/scitex-agent-container/03_auto-accept.md
+++ b/skills-archive/scitex-agent-container/03_auto-accept.md
@@ -1,0 +1,78 @@
+---
+description: |
+  [TOPIC] Auto-Accept TUI Prompts
+  [DETAILS] Modular TUI prompt detection and auto-acceptance for Claude Code..
+tags: [scitex-agent-container-auto-accept]
+---
+
+# Auto-Accept TUI Prompts
+
+Claude Code shows confirmation prompts for dangerous flags. The auto-accept system handles them via modular handlers in `runtimes/prompts.py`.
+
+## Built-in Handlers
+
+Ordered by priority (lowest number runs first). See
+`src/scitex_agent_container/runtimes/prompts.py::PROMPT_HANDLERS` for
+the canonical list.
+
+| Priority | Name | Detects | Sends |
+|---:|------|---------|-------|
+| 1 | bypass-permissions   | "2. Yes, I accept" + "Bypass Permissions"         | `2`, `Enter` |
+| 2 | dev-channels         | "1. I am using this for local development"        | `1`, `Enter` |
+| 3 | thinking-effort      | "1. Medium (recommended)" + "thinking"            | `1`, `Enter` |
+| 4 | mcp-json-edit        | "1. Yes, proceed" in the `.mcp.json` edit dialog  | `1`, `Enter` |
+| 5 | skip-permissions-yn  | Legacy y/n skip-permissions / trust prompt        | `y`, `Enter` |
+| 6 | press-enter-continue | Informational banner / context-window warning     | `Enter` |
+| 7 | file-trust           | "Do you trust the files in this folder?" (y/n)    | `y`, `Enter` |
+| 8 | file-trust-radio     | "1. Yes, I trust this folder" (radio variant)     | `1`, `Enter` |
+| 9 | theme-selection      | "1. Auto (match terminal)" on first run           | `1`, `Enter` |
+| 10 | login-method        | "2. Anthropic Console account · API usage billing"| `2`, `Enter` |
+
+## Design
+
+- **Number keys** sent directly (not arrow keys) — cursor-position independent
+- **Order-agnostic** — all handlers checked each poll cycle
+- **Detects by option text** (e.g., "2. Yes, I accept") for reliability
+- Uses `capture-pane` (tmux) or `hardcopy` (screen) to read content
+
+## Adding New Handlers
+
+```python
+from scitex_agent_container.runtimes.prompts import register_prompt, PromptHandler
+
+register_prompt(PromptHandler(
+    name="my-new-prompt",
+    detect=lambda c: "3. My Option" in c and "Enter to confirm" in c,
+    keys=["3", "Enter"],
+    priority=4,
+))
+```
+
+## Runtime Prompt Detection (via mamba-healer)
+
+In addition to startup auto-accept, mamba-healer's health scan includes runtime permission prompt detection. This catches prompts that appear mid-session (e.g., new tool permissions, MCP reconnect confirmations).
+
+**Detection patterns** (checked every health scan cycle):
+- "Do you want to" — general permission prompt
+- "Allow X to" — tool/MCP permission
+- "Enter to confirm" — confirmation dialog
+
+**Excluded** (false positive prevention):
+- Status bar text like "bypass permissions on" — not an actual prompt
+
+If a runtime prompt is detected, healer reports `stuck_prompt` status and can auto-respond via tmux `stuff`. This complements the startup auto-accept handlers above.
+
+## Disabling Auto-Accept
+
+```yaml
+spec:
+  claude:
+    auto_accept: false   # Manual TUI acceptance required
+```
+
+## Diagnostics
+
+Logged to `~/.scitex/agent-container/runtime/logs/{name}/auto-accept.log`:
+- Every poll: pane content snapshot, elapsed time
+- Handler matches with timestamps
+- Timeout diagnostics with last captured content

--- a/skills-archive/scitex-agent-container/03_python-api.md
+++ b/skills-archive/scitex-agent-container/03_python-api.md
@@ -1,0 +1,104 @@
+---
+description: |
+  [TOPIC] Python programmatic surface
+  [DETAILS] AgentConfig + load_config/validate_config + the `agent` namespace (start/stop/restart/status/logs/...) + Registry + peer.post_turn for outbound A2A. Use when embedding sac in another Python process (orochi master, scripts, notebooks).
+tags: [scitex-agent-container-python-api]
+---
+
+# Python API
+
+## Lifecycle
+
+The lifecycle verbs live under the `agent` namespace and take an agent
+**name** (or YAML path), not a config object. Each returns a JSON-friendly
+`dict`.
+
+```python
+from scitex_agent_container import agent
+
+agent.start("worker")                     # daemon — returns once PID file lands
+agent.start("worker", foreground=True)    # streams stdio; blocks until runner exits
+
+state = agent.status("worker")            # → dict (heartbeat, sdk_session, quota, ...)
+print(state["sdk_session"]["quota"])
+
+print(agent.logs("worker", lines=50))     # rendered transcript
+
+agent.restart("worker")                   # stop + start, preserving session_id resume
+agent.stop("worker")                      # SIGTERM, escalate to SIGKILL after 5s
+
+agent.health("worker")                    # heartbeat freshness + restart policy
+agent.check("worker")                     # preflight: validate yaml + probe runtime deps
+agent.find("quality")                     # locate agents by capability label
+```
+
+`load_config(name_or_path)` (below) accepts either an agent name (resolved
+via the discovery chain — project-local → home → env → fleet dirs) or an
+explicit YAML path, and returns an `AgentConfig`. `validate_config(path)`
+returns a list of schema-violation strings (empty when valid).
+
+## Peer — drive another agent's `/v1/turn`
+
+For agent-to-agent communication (orochi master → workers, peer collaboration):
+
+```python
+from scitex_agent_container.peer import post_turn, post_turn_to_url, resolve_peer_url
+
+# By agent name — auto-resolves URL from spec.host (or spec.hosts) + spec.a2a.port
+reply = post_turn("worker", "summarize today's commits")
+
+# By URL — useful for ad-hoc peers
+reply = post_turn_to_url("http://127.0.0.1:18888/v1/turn", "hello")
+reply = post_turn_to_url("ssh://mba:18890/v1/turn", "hi")  # ssh-as-transport
+
+# Inspect resolution without sending
+print(resolve_peer_url("head-mba"))
+# → "ssh://mba:18890/v1/turn"   (remote → ssh transport, loopback agent stays secure)
+# → "http://127.0.0.1:18888/v1/turn"   (local)
+```
+
+`post_turn` raises `peer.PeerError` on resolution / transport failure with the server's error message included.
+
+## Registry
+
+```python
+from scitex_agent_container import Registry
+
+reg = Registry()
+for name in reg.list_agents():
+    print(name, reg.get(name).runtime)
+```
+
+The registry is the persistent source of truth for "who's currently running on this host"; lifecycle calls maintain it automatically.
+
+## Config types
+
+```python
+from scitex_agent_container import AgentConfig
+
+cfg: AgentConfig = load_config("worker")
+cfg.runtime          # "apptainer"
+cfg.model            # str
+cfg.expanded_workdir # str (~ resolved)
+cfg.a2a.port         # int | None
+cfg.remote.host      # str ("" if local)
+cfg.remote.is_remote # bool
+cfg.startup_commands # list[StartupCommand]
+```
+
+`AgentConfig` is a dataclass; mutation is supported but generally avoided in favor of editing the YAML.
+
+## Discovery
+
+```python
+from scitex_agent_container.config._resolve import resolve_config
+
+path = resolve_config("worker")  # → /path/to/worker.yaml or raises FileNotFoundError
+```
+
+## See also
+
+- [04_cli-reference.md](04_cli-reference.md) — CLI surface (mirror of these calls)
+- [06_http-api.md](06_http-api.md) — `POST /v1/turn` (peer ↔ runner protocol)
+- [13_observability.md](13_observability.md) — `agent_status` JSON shape
+- [15_claude-session.md](15_claude-session.md) — runtime-specific behavior

--- a/skills-archive/scitex-agent-container/04_cli-reference.md
+++ b/skills-archive/scitex-agent-container/04_cli-reference.md
@@ -1,0 +1,131 @@
+---
+description: |
+  [TOPIC] sac CLI reference
+  [DETAILS] Lifecycle (start/stop/restart/status/health/tail/recall/check/find), image lifecycle (build/sandbox/update/freeze/list/switch/rollback/status/snapshot — delegates to scitex-container), account/quota, network/peer/A2A, db, registry, event, MCP introspection. Long-form flag tables in 10_cli.md.
+tags: [scitex-agent-container-cli-reference]
+---
+
+# CLI Reference
+
+Entry: `sac` (alias for `scitex-agent-container`).
+
+```
+sac [OPTIONS] COMMAND [ARGS]...
+```
+
+Global flags:
+- `-h / --help` — show help
+- `--help-recursive` — show help for the root command and every subcommand
+- `--json` — emit structured JSON where supported (status / actions / events)
+- `--on PEER` — dispatch the rest of argv via ssh on `PEER` (defined in `config.yaml`'s `peers:` block)
+
+## Agent lifecycle (most-used)
+
+| Command | Purpose |
+|---|---|
+| `sac agents start <agent> [--foreground]` | Start the agent. Daemon by default; `--foreground` streams stdio + blocks. Honors `spec.host` / `spec.hosts` (cross-host placement; see [11_remote-deploy.md](11_remote-deploy.md)) and `spec.a2a.port` (HTTP inbound). |
+| `sac agents stop <agent>` | SIGTERM the runner; escalate to SIGKILL after 5 s. ssh-mediated for remote agents. |
+| `sac agents restart <agent>` | Stop + start, preserving session_id resume. |
+| `sac agents status [<agent>]` | Per-agent rich payload, or fleet view if no name. `--snapshot` persists a state capsule, `--priority` adds the singleton-yield report. |
+| `sac agents health <agent>` | Health-method poll (`sdk-alive`). |
+| `sac agents tail   <agent>` | Render `session.jsonl` (user / assistant / tool / result events). ssh-tails remote logs. |
+| `sac agents recall <agent>` | Human summary of the agent's session. |
+| `sac agents check  <agent>` | Preflight: validate yaml + probe runtime deps (docker/python). |
+| `sac agents find   <capability>` | Search agents by capability label. |
+
+Multi-target: `sac agents start a b c` works for daemon mode; `--foreground` is single-target only.
+
+The earlier verbs `validate`, `take-snapshot`, `check-priority`, `inspect`, `logs`, `list` were folded into `check`, `status --snapshot`, `status --priority`, `status` (per-agent), `tail`, and `status` (fleet view) respectively.
+
+## Image lifecycle (`sac image`)
+
+Delegates the heavy lifting to [`scitex-container`](https://github.com/ywatanabe1989/scitex-container).
+
+| Command | Purpose |
+|---|---|
+| `sac image build [base\|scitex] [--sandbox]` | Build a layered Apptainer image. Default target: `base`. `--sandbox` builds a writable rootfs directory instead of an immutable SIF. Sac is apptainer-only since 2026-05-13 — no `--runtime` flag. |
+| `sac image sandbox SOURCE` | Convert an existing SIF (or layer name) into a writable sandbox. |
+| `sac image update SANDBOX [-p PKG]` | Refresh packages inside a sandbox via `pip install --upgrade`. Default: `scitex[all]`. |
+| `sac image freeze SANDBOX OUT.sif` | Bake a sandbox back into an immutable SIF. |
+| `sac image list` | Installed SIF versions on disk. |
+| `sac image switch <version>` | Atomically switch the active SIF symlink to a different version. |
+| `sac image rollback` | Restore the previous active version. |
+| `sac image status` | Unified container dashboard (active version, sandboxes, sizes). |
+| `sac image snapshot [-o env.json]` | Reproducibility capsule: pip + apt + conda + git + active SIF hash. |
+
+Typical "scitex updates often" cycle:
+
+```
+sac image build scitex --sandbox       # one-time
+sac image update sandbox/              # any time
+sac image freeze sandbox/ scitex-X.sif # when stable
+sac image switch X
+```
+
+## Account / quota (`sac accounts`)
+
+| Command | Purpose |
+|---|---|
+| `sac accounts list` | Stored Claude Code accounts + active block; per-store freshness column (`VALID (+Xh)` / `EXPIRED (-Xh)` / `ABSENT`). |
+| `sac accounts save <name>` | Snapshot current credentials under `<name>` for later rotation. |
+| `sac accounts sync-live` | Snapshot the live credential into its matching store (store-name = email slugified). Idempotent; fails loud on an expired/absent live cred (never saves a stale token). |
+| `sac accounts watch-live` | Daemon: watch `~/.claude/.credentials.json` (inotify or poll) and auto-run `sync-live` on every change — "the moment I log in → auto-saved". |
+| `sac accounts switch <name>` | Switch active credentials to a stored account. |
+| `sac accounts delete <name>` | Remove a stored account. |
+| `sac accounts status` | One-shot quota snapshot (5h%, 7d%, account email + tier). |
+| `sac accounts watch-quota` | Monitor quota and auto-rotate when threshold exceeded. |
+
+## Network / peer / A2A
+
+| Command | Purpose |
+|---|---|
+| `sac host list / add / remove / set / probe / exec / validate` | Local hostname + peer machine routing (ssh round-trip / exec on PEER). |
+| `sac host add-peer / list-peers / remove-peer` | Cross-host `sac listen` bearer registry (who may push into this host). |
+| `sac host ssh-opts` | Print sac's ssh ControlMaster flags shell-quoted — use as `ssh $(sac host ssh-opts) host cmd`. |
+| `sac host probe-hub` | WSL → fleet-hub layered connectivity probe (DNS, gateway, TCP, HTTPS). |
+| `sac peer post-turn AGENT TEXT` | Outbound A2A — POST a turn to another agent's `/v1/turn`. |
+| `sac peer resolve-url AGENT` | Print the URL `peer post-turn` would target. |
+| `sac a2a serve <yamls...>` | A2A inbound HTTP server (sidecar mode for non-SDK runtimes). For `runtime: apptainer` agents the runner hosts `POST /v1/turn` itself. |
+| `sac a2a doctor AGENT` | Probe an agent's A2A AgentCard endpoint and report health. |
+
+## Fleet (`sac fleet`)
+
+| Command | Purpose |
+|---|---|
+| `sac fleet launch PEER <name>...` | Rsync each agent's spec to PEER and run `sac agents start <name>` there. |
+| `sac fleet notify done\|blocker\|status --summary "..."` | Agent→lead push channel (ADR-0013 Phase 1) — POST a typed event to the lead's `sac listen` inbox. `--detail`, `--conversation-id`, `--dry-run`, `--json`. |
+
+## State database / registry / events
+
+| Command | Purpose |
+|---|---|
+| `sac db query / show / clean / migrate / tick` | Inspect and maintain the sac state database (`state.db`). `db clean` replaces the legacy `registry clean`. |
+| `sac db export / import` | Dump state.db rows as a JSON delta / ingest a dump (cross-host registry sync). |
+| `sac registry reconcile` | Reconcile singleton agent placement across the fleet. |
+| `sac event ingest` | Append a Claude Code hook event to the per-agent ring buffer. |
+
+## Build / install / templates
+
+| Command | Purpose |
+|---|---|
+| `sac installation` | Bootstrap helpers for a new fleet host. |
+| `sac installation setup-cron` | Add (or remove) the post-merge-pull crontab entry. |
+| `sac template render-contributor-spec` | Materialize a contributor agent spec from the v3 template. |
+
+## Other
+
+| Command | Purpose |
+|---|---|
+| `sac doctor [--fleet]` | Diagnose agent-spec source drift (locally, or `--fleet` across peers). |
+| `sac subagent get-state` | Pure state data for every matching Claude Code Agent-tool subagent (Type 2). |
+| `sac mcp list-tools` | Local MCP introspection (no MCP server bundled — sac agents spawn their own via `to_home/.mcp.json`). |
+| `sac skills list / get` | Bundled agent-facing skills. |
+| `sac list-python-apis` | Enumerate the public Python API. |
+| `sac auto-accept` | Auto-accept TUI handler for legacy claude-code agents (the apptainer/SDK runner doesn't need it). |
+
+## See also
+
+- [10_cli.md](10_cli.md) — long-form flag tables + Python-API mirror
+- [03_python-api.md](03_python-api.md) — programmatic surface (mirrors the lifecycle commands)
+- [11_remote-deploy.md](11_remote-deploy.md) — SSH deployment internals
+- [13_observability.md](13_observability.md) — `status --json` contract

--- a/skills-archive/scitex-agent-container/04_resource-management.md
+++ b/skills-archive/scitex-agent-container/04_resource-management.md
@@ -1,0 +1,76 @@
+---
+description: |
+  [TOPIC] Resource Management
+  [DETAILS] How agents query machine + SLURM resources via the standalone scitex-resource package, and why live queries are banned on the hot path..
+tags: [scitex-agent-container-resource-management]
+---
+
+# Resource Management
+
+SciTeX agents never call `sinfo`/`squeue`/`nvidia-smi` directly on the hot path. They use the standalone [`scitex-resource`](https://github.com/ywatanabe1989/scitex-resource) package, which reads from a cache populated by a separate heartbeat process.
+
+## Why
+
+- Live SLURM queries are slow (seconds) and noisy on login nodes.
+- Multiple agents hammering `squeue` wastes the shared login node's budget.
+- A 60s-tick heartbeat is free, and agents read files in microseconds.
+- History accumulates in the cache → enables trend-based decisions.
+
+## API
+
+Three functions, all returning plain dicts (JSON-safe):
+
+```python
+from scitex_resource import machine_status, slurm_status, available
+
+machine_status()
+# {'timestamp': '...', 'cpu_pct': 12.3, 'ram_gib_used': 4.2,
+#  'ram_gib_total': 16.0, 'disk_gib_free': 120.5,
+#  'gpu_pct': None, 'vram_gib_used': None, 'vram_gib_total': None}
+
+slurm_status()
+# {'source': 'cache', 'cache_timestamp': '...',
+#  'nodes_raw': '<sinfo output>', 'my_jobs_raw': '<squeue output>'}
+
+available()
+# {'machine': machine_status(), 'slurm': slurm_status()}
+```
+
+CLI equivalents:
+
+```bash
+scitex-resource            # all resources
+scitex-resource machine    # machine only
+scitex-resource slurm      # SLURM only
+```
+
+## Cache Contract
+
+`scitex-resource` reads from `~/.scitex/cache/`:
+
+| File | Producer | Consumer |
+|------|----------|----------|
+| `machine_mem.txt` | `heartbeat/collect.sh` via `free -h` | (informational) |
+| `slurm_nodes.txt` | `sinfo -o "%N %t %C %m %G"` | `slurm_status()` |
+| `slurm_jobs.txt`  | `squeue -u $USER -o "%i %T %R %C %m"` | `slurm_status()` |
+| `last_update.txt` | ISO-8601 timestamp | staleness check |
+
+If the cache is missing, `slurm_status(use_cache=False)` falls back to a direct `sinfo`/`squeue` call (with 10s timeout). **Agents should not rely on the fallback** — it exists only for first-run bootstrap.
+
+## Staleness
+
+Callers inspect `cache_timestamp` themselves. Rules of thumb:
+- `< 2 * interval` — fresh
+- `< 5 * interval` — warn
+- `> 5 * interval` — escalate via `#escalation` (heartbeat process likely dead)
+
+## Not in this Package
+
+- Resource **acquisition** (`salloc`/`srun` wrappers, context managers) is out of scope for the initial release. For now, agents compose their own SLURM commands using info from `slurm_status()`.
+- Cross-fleet aggregation (rsync-ing caches between hosts) is handled by a downstream fleet hub (consumer of sac), not by sac itself.
+
+## Related
+
+- `resource-heartbeat.md` — how to install and run the heartbeat sampler
+- Downstream fleet hub docs — fleet-wide aggregation (sac is fleet-agnostic)
+- memory: `project_spartan_login_node.md` — login1 is controller-only; workloads go via SLURM

--- a/skills-archive/scitex-agent-container/05_mcp-tools.md
+++ b/skills-archive/scitex-agent-container/05_mcp-tools.md
@@ -1,0 +1,85 @@
+---
+description: |
+  [TOPIC] sac MCP server — exposed tools, transport, install snippet
+  [DETAILS] Convention §3-§5 surface: every `sac mcp <verb>` plus the
+  bare-name MCP tools (`agent_*`, `db_*`, `host_*`, `image_*`,
+  `template_*`, `account_*`, `quota_*`, `skills_*`, `mcp_*`,
+  `list_python_apis`). Both stdio and HTTP transports. Install with
+  `pip install scitex-agent-container[mcp]`.
+tags: [scitex-agent-container-mcp-tools]
+---
+
+# sac MCP server
+
+Implements convention §13 (CLI ↔ MCP parity). Every `sac <noun> <verb>`
+on the CLI is reachable as an MCP tool with the same parameter shape.
+
+## Install
+
+```bash
+pip install scitex-agent-container[mcp]   # adds fastmcp
+sac mcp doctor                             # verify
+```
+
+## Subcommands (CLI face)
+
+```bash
+sac mcp start                          # stdio (default)
+sac mcp start --http --port 8970       # HTTP transport
+sac mcp doctor                         # version + tool count + registration
+sac mcp list-tools [--json]            # enumerate tools
+sac mcp install [--claude-code]        # config snippet
+```
+
+## Claude Code config
+
+```json
+{
+  "mcpServers": {
+    "scitex-agent-container": {
+      "command": "sac",
+      "args": ["mcp", "start"]
+    }
+  }
+}
+```
+
+`sac mcp install --claude-code` prints the same snippet for copy-paste.
+
+## Tool inventory
+
+Bare-name `<verb>_<noun>` shape per Convention A. The sac umbrella mount
+adds the `agent_container_` prefix at scitex aggregator time.
+
+| Group       | Tools                                                                                                                                                                                                                                  |
+|-------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `agent`     | `list`, `status`, `logs`, `health`, `find`, `check`, `validate`, `inspect`, `recall`, `check_priority`, `take_snapshot`, `start`, `stop`, `restart`, `attach`                                                                          |
+| `db`        | `show`, `query`, `clean`, `tick`, `migrate`, `export`, `import`                                                                                                                                                                        |
+| `host`      | `list`, `validate`, `probe`, `exec`                                                                                                                                                                                            |
+| `image`     | `build`                                                                                                                                                                                                                                |
+| `template`  | `render_contributor_spec`                                                                                                                                                                                                              |
+| `account`   | `account_show`, `quota_watch`                                                                                                                                                                                                          |
+| `skills`    | `skills_list`, `skills_get` — convention §5 mandatory pair                                                                                                                                                                             |
+| `info`      | `list_python_apis`, `mcp_list_tools`, `mcp_doctor` — self-introspection                                                                                                                                                                |
+
+Get the live list any time with `sac mcp list-tools` (or, from Python,
+`scitex_agent_container._mcp.server.get_server().list_tools()`).
+
+## Implementation pointers
+
+- `src/scitex_agent_container/_mcp/server.py` — `FastMCP` instance,
+  lazy-built so the bare `import` doesn't require fastmcp.
+- `src/scitex_agent_container/_mcp/_tools/` — one file per noun group.
+  Each tool wraps the Click CLI through `_helpers.invoke_cli_*` so
+  CLI ↔ MCP parity stays automatic as new commands land.
+- `src/scitex_agent_container/cli_pkg/mcp_group.py` — Click face
+  (`start / doctor / list-tools / install`).
+- `src/scitex_agent_container/_mcp_server.py` — re-export shim so the
+  scitex-dev `audit-mcp-tools` linter's hard-coded path works.
+
+## Mutating verbs
+
+`agent_start`, `agent_stop`, `agent_restart`, `db_clean`, `db_export`,
+`db_import` mutate state. The MCP server itself does not gate them —
+the host (Claude Code, custom embedder) is expected to mediate via its
+own permission flow before invoking the tool.

--- a/skills-archive/scitex-agent-container/05_resource-heartbeat.md
+++ b/skills-archive/scitex-agent-container/05_resource-heartbeat.md
@@ -1,0 +1,101 @@
+---
+description: |
+  [TOPIC] Resource Heartbeat
+  [DETAILS] How to run the scitex-resource heartbeat collector so agents can read SLURM and machine state from ~/.scitex/cache/ instead of hammering sinfo/squeue..
+tags: [scitex-agent-container-resource-heartbeat]
+---
+
+# Resource Heartbeat
+
+A long-lived, lightweight collector that refreshes `~/.scitex/cache/` on a fixed interval. Never run it under Claude Code — it must outlive any agent session.
+
+## Cache Contract
+
+Path: `~/.scitex/cache/`
+
+| File | How it's produced | Consumed by |
+|------|-------------------|-------------|
+| `machine_mem.txt` | `free -h` | operators (informational) |
+| `slurm_nodes.txt` | `sinfo -o "%N %t %C %m %G"` | `scitex_resource.slurm_status()` |
+| `slurm_jobs.txt`  | `squeue -u $USER -o "%i %T %R %C %m"` | `scitex_resource.slurm_status()` |
+| `last_update.txt` | `date --iso-8601=seconds` | staleness check |
+
+Default interval: `SCITEX_HEARTBEAT_INTERVAL=60` (seconds). Set to `0` for a single-shot cron-driven run.
+
+## Collector Script
+
+Ships with the package at `scitex_resource/heartbeat/collect.sh`:
+
+```bash
+#!/usr/bin/env bash
+CACHE_DIR="${HOME}/.scitex/cache"
+INTERVAL="${SCITEX_HEARTBEAT_INTERVAL:-60}"
+mkdir -p "${CACHE_DIR}"
+
+collect_once() {
+    free -h > "${CACHE_DIR}/machine_mem.txt" 2>/dev/null
+    if command -v sinfo &>/dev/null; then
+        sinfo -o "%N %t %C %m %G" > "${CACHE_DIR}/slurm_nodes.txt" 2>/dev/null
+        squeue -u "${USER}" -o "%i %T %R %C %m" > "${CACHE_DIR}/slurm_jobs.txt" 2>/dev/null
+    fi
+    date --iso-8601=seconds > "${CACHE_DIR}/last_update.txt"
+}
+
+collect_once
+if [[ "${INTERVAL}" -gt 0 ]]; then
+    while true; do sleep "${INTERVAL}"; collect_once; done
+fi
+```
+
+## Launch Methods
+
+Pick one per host. Agents don't care which — they only read `~/.scitex/cache/`.
+
+### tmux (fastest bring-up, fine for dev/login nodes)
+```bash
+tmux new-session -d -s heartbeat \
+  'SCITEX_HEARTBEAT_INTERVAL=60 ~/.scitex/heartbeat/collect.sh'
+```
+
+### system cron (simplest, survives reboots)
+```cron
+* * * * * SCITEX_HEARTBEAT_INTERVAL=0 ~/.scitex/heartbeat/collect.sh >> ~/.scitex/cache/heartbeat.log 2>&1
+```
+`INTERVAL=0` makes `collect.sh` run once and exit, so cron can schedule it.
+
+### systemd user (Linux, production)
+`~/.config/systemd/user/scitex-heartbeat.service`:
+```ini
+[Unit]
+Description=SciTeX resource heartbeat
+[Service]
+Environment=SCITEX_HEARTBEAT_INTERVAL=60
+ExecStart=%h/.scitex/heartbeat/collect.sh
+Restart=always
+[Install]
+WantedBy=default.target
+```
+```bash
+systemctl --user enable --now scitex-heartbeat
+```
+
+### launchd (macOS)
+`~/Library/LaunchAgents/com.scitex.heartbeat.plist` with `KeepAlive=true`, `ProgramArguments` pointing at `collect.sh`.
+
+## Spartan-Specific Notes
+
+- Run the collector **on login1** only (agents there are controllers, not workloads — see memory `project_spartan_login_node.md`).
+- Never run `collect.sh` inside a compute allocation; compute nodes see a different SLURM view and will pollute the cache.
+- `SCITEX_HEARTBEAT_INTERVAL=60` is fine on login nodes. Go lower only if you have a specific reason.
+
+## Debugging
+
+- `cat ~/.scitex/cache/last_update.txt` — is it stale?
+- `ls -la ~/.scitex/cache/` — which files are present?
+- `python -c "from scitex_resource import slurm_status; print(slurm_status())"` — does the reader see `source=cache`?
+- If `source=direct` shows up unexpectedly, the cache is missing and the heartbeat has died → restart it.
+
+## Related
+
+- `resource-management.md` — the reader-side API
+- Downstream fleet hub — aggregating caches across the fleet (sac is fleet-agnostic)

--- a/skills-archive/scitex-agent-container/06_env-injection-ports.md
+++ b/skills-archive/scitex-agent-container/06_env-injection-ports.md
@@ -1,0 +1,50 @@
+---
+description: |
+  [TOPIC] Env-injection ports for agents
+  [DETAILS] Env-injection ports for agents — see file body for details..
+tags: [scitex-agent-container-env-injection-ports]
+---
+
+# Env-injection ports for agents
+
+Agents have **four distinct env-injection ports** with different reach and persistence.
+Pick the right one for the job — they are not interchangeable.
+
+| Port | File | Reaches | Persistent on disk? | Code path |
+| --- | --- | --- | --- | --- |
+| 1. **Agent shell env** | `<agent>.yaml` → `spec.env: {KEY: val}` | the multiplexer session running Claude (`os.environ`, Bash tool, child procs) | no — exports inline | `runtimes/claude_code.py::_build_env_exports` |
+| 2. **MCP server env** | `to_home/.mcp.json` → `mcpServers.<name>.env` | only the spawned MCP server process | no | MCP launcher reads it directly |
+| 3. **Home dotenv** | `to_home/.env` → `$HOME/.env` | anything the agent (or its subprocesses) chooses to source | **yes — file in $HOME** | `runtimes/_to_home.py::deploy_to_home` |
+| 4. **Hook env** | `<agent>.yaml` → `spec.hooks.pre_start: [cmd]` + `_run_hooks(extra_env=...)` | only the hook subprocess; **does not propagate back to the agent** | no | `lifecycle.py::_run_hooks`, `hooks.py` |
+
+The `to_home/` directory (override path with `spec.to_home:`) is sac's generic file-deploy convention: every path inside is materialized into the agent's `$HOME` at agent start, with `${VAR}` and `${metadata.name}` interpolation. sac does not know about any specific project — projects contribute the content.
+
+## Decision tree
+
+- Need it inside Claude's shell for the running session? → **port 1** (`spec.env`).
+- Need it inside an MCP server? → **port 2** (`to_home/.mcp.json` env).
+- Need it available to *any* subprocess the agent spawns later (cron, ssh-launched commands, fresh shells)? → **port 3** (`to_home/.env` → `$HOME/.env`).
+- Need to *do something at lifecycle moments* (notify, cleanup)? → **port 4** (`hooks`). Hooks fire-and-forget; cannot mutate agent env.
+
+## Value resolution
+
+`spec.env` values support:
+- `~` prefix → expanded to `$HOME`
+- `${VAR}` → resolved from `os.environ` at launch (sac side, not agent side)
+- `${metadata.name}` → substituted with the agent id
+
+`to_home/.mcp.json` env values use the same `${VAR}` syntax (resolved by the MCP launcher in the parent shell at spawn time).
+
+## Why hooks can't inject
+
+`_run_hooks` builds `extra_env` and passes it to `subprocess.run`. The hook process has it; nothing propagates upward. So hooks are useful for *side effects* (write a file, notify a service) — never for handing a secret to the agent.
+
+## Pattern: secrets in the dotfiles, paths in env
+
+Don't put raw tokens in YAML/JSON committed to git. Pattern:
+
+1. Token file at `~/.bash.d/secrets/010_scitex/.../<id>.<purpose>-token` (rides with dotfiles git, syncs across hosts).
+2. Inject the **path** via port 1 or 2 (e.g. `SCITEX_OROCHI_GITEA_TOKEN_PATH=~/.bash.d/secrets/.../${SAC_NAME}.gitea-token`), or read the file in the parent shell and inject the value via `${VAR}`.
+3. Consumer reads file on demand.
+
+Path-in-env is safer than value-in-env (`/proc/<pid>/environ` exposure), but value-in-env is fine when the consumer is short-lived (MCP server process).

--- a/skills-archive/scitex-agent-container/06_http-api.md
+++ b/skills-archive/scitex-agent-container/06_http-api.md
@@ -1,0 +1,76 @@
+---
+description: |
+  [TOPIC] HTTP surface — `POST /v1/turn` inbound endpoint
+  [DETAILS] Wire format, semantics, ssh-as-transport for remote agents, error codes. The full reference (curl examples, comparison vs legacy A2A sidecar, implementation files, SAC_RUNNER_PREFIX hook) lives in 17_inbound-turn-endpoint.md.
+tags: [scitex-agent-container-http-api]
+---
+
+# HTTP API
+
+Sac ships exactly two HTTP routes per agent (when `spec.a2a.port` is set):
+
+| Method + Path | Purpose |
+|---|---|
+| `POST /v1/turn` | Send one user turn to the runner's persistent SDK conversation; receive the assistant reply. Serial — turns queue. |
+| `GET /health` | Liveness probe → `{"status": "ok"}`. |
+
+## Wire format
+
+```bash
+# Local agent
+curl -sX POST http://127.0.0.1:18888/v1/turn \
+  -H 'Content-Type: application/json' \
+  -d '{"text": "your message", "exit_after": false}'
+# 200 OK → {"reply": "...", "exit_after": false}
+```
+
+Request body fields:
+
+| Field | Type | Default | Required |
+|---|---|---|---|
+| `text` | string | — | yes (non-empty) |
+| `exit_after` | bool | `false` | no — when `true` the runner shuts down after this turn |
+
+Response body fields:
+
+| Field | Type | Notes |
+|---|---|---|
+| `reply` | string | Concatenated `AssistantMessage.TextBlock` chunks for the turn |
+| `exit_after` | bool | Echo of the request flag |
+
+## Status codes
+
+| Code | When |
+|---|---|
+| 200 | Turn completed; `reply` carries the assistant text |
+| 400 | Missing or empty `text`, or malformed JSON |
+| 502 | Runtime error from the SDK (`turn failed: <detail>`); details also in `session.jsonl` (`type: error, kind: sdk_runtime`) |
+| 504 | Per-turn timeout (default 600 s); SDK hung |
+
+## Remote agents — ssh-as-transport
+
+For agents pinned to another host via `spec.host`, the runner stays on `127.0.0.1` (loopback only — no LAN exposure). Peers reach it through ssh:
+
+```python
+from scitex_agent_container.peer import post_turn
+reply = post_turn("head-mba", "your message")
+# resolves to ssh://mba:18888/v1/turn → ssh + curl on remote
+```
+
+This works for ssh aliases that aren't DNS-resolvable from the caller (e.g., `mba`, `head-spartan`) and survives NAT.
+
+## Concurrency / timeouts
+
+- **Serial drain**: a new POST waits for the previous turn's `receive_response()` to finish before the SDK is queried again. Matches Claude Code's "next prompt waits" UX.
+- **Per-turn cap**: 600 s (configurable via the runner's `turn_timeout_s`); the SDK call itself isn't capped — the cap is local to the HTTP handler.
+
+## Host-wide control plane — `sac listen`
+
+`/v1/turn` is the **per-agent** wire (one HTTP server per long-lived runner, bound to `spec.a2a.port`). The **host-wide control plane** is a separate process: `sac listen` exposes `/v1/sac/{health,agents,agents/<name>/{status,send,card}}` for orchestrators (e.g. orochi) to reach every agent on the host through one bearer-authenticated endpoint. `POST /agents/<name>/send` forwards turns into the live runner's `/v1/turn` when `spec.a2a.port` is set; otherwise it falls back to `claude --resume <sid> -p`. With `Accept: text/event-stream` it streams claude's stream-json output as SSE frames. See `10_cli.md` for the full route table.
+
+## See also
+
+- [10_cli.md](10_cli.md) — `sac listen` + `sac agents send` + `sac peer post-turn`
+- [17_inbound-turn-endpoint.md](17_inbound-turn-endpoint.md) — full reference: detailed wire examples, comparison vs legacy A2A sidecar, implementation files, cross-host (`spec.host` / `sac --on`)
+- [03_python-api.md](03_python-api.md) — `peer.post_turn()` + `peer.PeerError`
+- [07_a2a-protocol.md](07_a2a-protocol.md) — JSON-RPC `message/send` surface (sidecar path for non-SDK runtimes)

--- a/skills-archive/scitex-agent-container/07_a2a-protocol-extension-fields.md
+++ b/skills-archive/scitex-agent-container/07_a2a-protocol-extension-fields.md
@@ -1,0 +1,146 @@
+---
+description: |
+  [TOPIC] A2A AgentCard `x-scitex-agent-container.*` extension fields
+  [DETAILS] Per-agent / fleet / proxy field enumeration + concrete JSON example for the sac namespace projected into A2A v1 AgentCards.
+tags: [scitex-agent-container-a2a-protocol-extension-fields]
+---
+
+# A2A AgentCard — `x-scitex-agent-container.*` extension fields
+
+Companion to [`07_a2a-protocol.md`](07_a2a-protocol.md). That leaf documents the protocol surface (CLI, auto-launch, handlers); this leaf enumerates every vendor field projected under the sac namespace and shows one full card.
+
+A2A v1.0 reserves the AgentCard top level for spec-defined fields and funnels vendor data into a namespaced extension block. **sac uses exactly one namespace key: `x-scitex-agent-container`.** Every sac-specific datum lives under that key, never at the top level, never under another vendor namespace (e.g. `x-orochi` is owned by the orochi fleet hub, not by sac). See [ADR-0004](../../../../docs/adr/0004-a2a-v1-compliance.md).
+
+## v3 YAML — what gets projected
+
+| Field | Mapped to AgentCard |
+| --- | --- |
+| parent-directory stem (dir-as-SSoT) | `name` — v3 derives the agent name from the YAML's parent dir; the legacy `metadata.name` field is rejected by `_validation.py` |
+| `metadata.labels.capabilities` (CSV) | first item → `description`; all items → `skills[0].tags` |
+| `metadata.labels.team` | `provider.organization` |
+| `metadata.labels.role` | `skills[0].name`, `x-scitex-agent-container.role_class` |
+| `metadata.labels.function` (CSV) | `skills[0].description` |
+| `metadata.labels.skills` (CSV) | `skills[0].tags` ∪ `x-scitex-agent-container.required_skills` |
+| `spec.host` / `spec.hosts` | `x-scitex-agent-container.scheduling` |
+| `spec.runtime` / `claude.model` / `multiplexer` | `x-scitex-agent-container.runtime` / `.model` / `.multiplexer` |
+| `spec.apptainer.*` | `x-scitex-agent-container.isolation.*` (D3 attestation block) |
+| `spec.claude.channels: [server:sac]` | `capabilities.extensions[]` (sac-push-channel/v1) |
+
+## Per-agent card fields
+
+Emitted by `a2a/_card.py::project_card`. Every per-agent card served at `GET /agents/<name>/.well-known/agent-card.json` carries:
+
+| Field | Source | Description |
+| --- | --- | --- |
+| `x-scitex-agent-container.role_class` | `metadata.labels.role` | Operator-declared role taxonomy (e.g. `worker-telegrammer`). Mirrors `skills[0].name`. |
+| `x-scitex-agent-container.cardinality` | `metadata.labels.cardinality` | `singleton` / `multi-instance` hint for fleet schedulers. |
+| `x-scitex-agent-container.scheduling` | `spec.host` / `spec.hosts` | `{mode, priority|hosts}` placement hint. |
+| `x-scitex-agent-container.runtime` | `spec.runtime` | Runtime kind (`claude-code`, `agent-proxy`, etc.). |
+| `x-scitex-agent-container.model` | `spec.claude.model` ∨ `spec.model` (legacy) | LLM model identifier. |
+| `x-scitex-agent-container.multiplexer` | `spec.multiplexer` | tmux / zellij / none. |
+| `x-scitex-agent-container.required_skills` | `metadata.labels.skills` (CSV) — `spec.skills` is rejected in v3; skills now live as files under `to_home/.claude/skills/` | Skill IDs the agent loads at boot. |
+| `x-scitex-agent-container.isolation` | derived from `spec.apptainer.*` | D3 attestation block — `{level, containall, cleanenv, writable_tmpfs, preflight_passed, preflight_allowed, binds_count, binds_writable_count}`. External attestation surfaces (Clew, orochi) read these booleans. |
+
+## Per-agent `capabilities.extensions[]` entries
+
+The A2A v1 spec-defined `capabilities.extensions[]` array advertises sac extensions by URI (distinct from `x-scitex-agent-container`):
+
+| URI | Emitted when | Purpose |
+| --- | --- | --- |
+| `https://scitex.ai/a2a/extensions/sac-push-channel/v1` | `spec.claude.channels` contains `server:sac` | In-session MCP push: `sac mcp channel` SSE-subscribes to `/agents/<name>/inbox/stream` and forwards events as `notifications/claude/channel` to the agent's Claude session. `params.sse_path` + `params.mcp_tools` enumerate wire details. |
+
+## Fleet card fields
+
+Emitted by `a2a/_card.py::fleet_card` at `GET /.well-known/agent-card.json`:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `x-scitex-agent-container.agents` | list[object] | Member directory. Each entry has `name` + `supportedInterfaces[]`. Spec-aware clients walk this array to fetch each member's per-agent card. |
+
+Plus the fleet-level `capabilities.extensions[]`:
+
+| URI | Purpose |
+| --- | --- |
+| `https://scitex.ai/a2a/extensions/sac-fleet/v1` | Declares the multi-agent directory shape. `params.members_path` + `params.member_card_path` tell vendor-neutral clients how to walk the fleet. |
+
+## AgentProxy overlay (`kind: AgentProxy`)
+
+Emitted by `_runners/a2a_proxy.py::splice_card` when an AgentProxy runner serves its card:
+
+| Field | Source | Description |
+| --- | --- | --- |
+| `x-scitex-agent-container.kind` | runner constant | `"AgentProxy"` — distinguishes a proxy from a native sac runtime. |
+| `x-scitex-agent-container.upstream` | `--upstream` CLI arg | Upstream A2A URL the proxy forwards to. |
+| `x-scitex-agent-container.trust` | `--trust` CLI arg | Trust tier (`trusted` / `untrusted`). |
+| `x-scitex-agent-container.upstream_card_fetch_error` | runtime | Present only when boot-time fetch of the upstream card failed. |
+
+## Concrete example
+
+Per-agent card served at `GET /agents/my-agent/.well-known/agent-card.json`:
+
+```json
+{
+  "name": "my-agent",
+  "description": "sac agent: my-agent (worker-telegrammer)",
+  "version": "scitex-agent-container/v3",
+  "supportedInterfaces": [
+    {
+      "url": "http://127.0.0.1:8888/agents/my-agent",
+      "protocolBinding": "HTTP+JSON",
+      "tenant": "my-agent",
+      "protocolVersion": "1.0"
+    }
+  ],
+  "provider": {"organization": "scitex-agent-container", "url": "https://scitex.ai"},
+  "capabilities": {
+    "streaming": true,
+    "pushNotifications": true,
+    "extendedAgentCard": false,
+    "extensions": [
+      {
+        "uri": "https://scitex.ai/a2a/extensions/sac-push-channel/v1",
+        "description": "In-session MCP push: sac mcp channel subscribes ...",
+        "required": false,
+        "params": {
+          "sse_path": "/agents/my-agent/inbox/stream",
+          "mcp_tools": ["a2a_send", "a2a_reply", "a2a_ack", "a2a_peers", "a2a_inbox"]
+        }
+      }
+    ]
+  },
+  "defaultInputModes": ["text/plain", "application/json"],
+  "defaultOutputModes": ["text/plain", "application/json"],
+  "skills": [
+    {
+      "id": "my-agent.worker-telegrammer",
+      "name": "worker-telegrammer",
+      "description": "relays telegram messages",
+      "tags": ["a2a", "telegram"]
+    }
+  ],
+  "x-scitex-agent-container": {
+    "role_class": "worker-telegrammer",
+    "cardinality": "singleton",
+    "scheduling": {"mode": "singleton", "priority": ["ywata-note-win"]},
+    "runtime": "claude-code",
+    "model": "claude-opus-4-7",
+    "multiplexer": "tmux",
+    "required_skills": ["quality-guards", "autonomous", "speech", "scitex"],
+    "isolation": {
+      "level": "hardened",
+      "containall": true,
+      "cleanenv": true,
+      "writable_tmpfs": true,
+      "preflight_passed": ["uid-nonzero", "no-host-home"],
+      "preflight_allowed": [],
+      "binds_count": 3,
+      "binds_writable_count": 1
+    }
+  }
+}
+```
+
+## Cross-references
+
+- [ADR-0004](../../../../docs/adr/0004-a2a-v1-compliance.md) — A2A v1.0 compliance + the authoritative `x-scitex-agent-container.*` field enumeration this doc mirrors
+- Implementation source of truth: `a2a/_card.py::project_card`, `a2a/_card.py::fleet_card`, `_runners/a2a_proxy.py::splice_card`

--- a/skills-archive/scitex-agent-container/07_a2a-protocol.md
+++ b/skills-archive/scitex-agent-container/07_a2a-protocol.md
@@ -1,0 +1,145 @@
+---
+description: |
+  [TOPIC] A2A protocol — native sac surface
+  [DETAILS] CLI (`sac a2a serve` / `doctor`), auto-launch via `spec.a2a`, SDK 1.x methods, handler env vars, orochi boundary. AgentCard extension fields live in the sibling leaf.
+tags: [scitex-agent-container-a2a-protocol]
+---
+
+# A2A protocol — native sac surface
+
+[A2A](https://a2a-protocol.org/) is an open agent-to-agent JSON-RPC protocol. sac speaks it directly, with **zero fleet dependencies**: no orochi, no Cloudflare tunnel, no Gitea identity. A single agent YAML can expose its own A2A endpoint with one command.
+
+The per-card `x-scitex-agent-container.*` extension fields and a full JSON example live in [`07_a2a-protocol-extension-fields.md`](07_a2a-protocol-extension-fields.md).
+
+## Why sac knows A2A but not orochi
+
+A2A is a **protocol**; orochi is one **implementation** of a fleet hub on top of A2A. sac knowing A2A doesn't violate the layering — same as a generic HTTP library knowing HTTP without knowing nginx. By making A2A native to sac, a lab can adopt the *protocol* without adopting an entire fleet stack.
+
+Concrete value:
+
+- **Standalone agent deploy** — `sac a2a serve agent.yaml` boots one A2A agent. Done.
+- **Protocol-aware health check** — sac agents health can hit an AgentCard endpoint (future).
+- **Swappable fleet implementations** — orochi is one consumer of sac-served A2A endpoints; another fleet hub can be too.
+
+## CLI
+
+```bash
+sac a2a serve  <agent.yaml>... [--host 127.0.0.1] [--port 8888] [--handler {echo,claude_cli,exec}] [-v]
+sac a2a doctor <agent.yaml>    [--host H] [--port N] [--timeout 5.0] [--json]
+```
+
+`a2a doctor` GETs the AgentCard endpoint declared by `spec.a2a` and reports liveness + round-trip latency. Exit codes: `0` healthy, `1` unhealthy/unreachable, `2` config error (no `spec.a2a.port`).
+
+## Auto-launch via `spec.a2a`
+
+When a v3 YAML declares `spec.a2a.port`, `sac agents start` spawns the A2A server as a sidecar subprocess after the multiplexer is up. PID lives at `{workdir}/a2a-sidecar.pid`, output at `{workdir}/a2a-sidecar.log`; `sac agents stop` SIGTERMs it via the PID file.
+
+```yaml
+apiVersion: scitex-agent-container/v3
+kind: Agent
+metadata:
+  name: my-agent
+spec:
+  runtime: apptainer
+  a2a:
+    port: 8888
+    handler: echo          # echo (default) | claude_cli | exec
+    host: 127.0.0.1        # default; use 0.0.0.0 to expose externally
+```
+
+Disabled by default — the sidecar only starts when `spec.a2a` is present. Sidecar failures are logged and swallowed; agent start/stop is never blocked by A2A.
+
+| Handler | What it does | When to use |
+| --- | --- | --- |
+| `echo` (default) | canned reply with the user text | smoke-test the protocol surface; zero deps |
+| `claude_cli` | runs `claude --print` and forwards stdout | real LLM agent; needs `claude` on PATH |
+| `exec` | runs `$SAC_A2A_EXEC_COMMAND`, pipes user text on stdin, returns stdout | wire in any custom handler script |
+
+## HTTP routes
+
+| Method | Path | Returns |
+| --- | --- | --- |
+| GET | `/.well-known/agent-card.json` | fleet AgentCard listing all agents in this server |
+| GET | `/agents/` | JSON list of agents |
+| GET | `/agents/<name>/.well-known/agent-card.json` | per-agent AgentCard (sac dict shape; `x-scitex-agent-container` extension preserved) |
+| POST | `/agents/<name>/message:send` | A2A v1 REST binding — JSON-RPC SDK 1.x methods (see below) |
+| GET | `/agents/<name>/inbox/stream` | sac extension — SSE stream of inbound events (consumed by `sac mcp channel`) |
+| GET | `/agents/<name>/_active` | sac extension — observability snapshot of in-memory tasks |
+
+A2A v1.0 renamed the well-known file from `agent.json` (v0.x) to `agent-card.json`. sac serves the v1 path only; the v0 path is **not** backed by a compatibility shim. See [ADR-0004](../../../../docs/adr/0004-a2a-v1-compliance.md).
+
+## SDK 1.x methods (gRPC-style names)
+
+Pure `a2a-sdk>=1.0.2` — no v0.3 compat. Method names are gRPC-style:
+
+| Method | Purpose |
+| --- | --- |
+| `SendMessage` | unary task dispatch — synchronous reply |
+| `SendStreamingMessage` | SSE-streamed task — incremental progress + artifacts |
+| `GetTask` | poll task by id |
+| `CancelTask` | interrupt a running task |
+| `pushNotificationConfig/*` | webhook subscription |
+
+Clients MUST set `A2A-Version: 1.0` header. Params use proto **snake_case** (`message_id`, `role: "ROLE_USER"`, `parts: [{"text": ...}]`).
+
+## Quick verification
+
+```bash
+# Boot a standalone echo agent
+sac a2a serve my-agent.yaml --port 8888 &
+
+# Discovery (v1 path; agent.json is v0.x and no longer served)
+curl http://127.0.0.1:8888/.well-known/agent-card.json | jq .name
+
+# JSON-RPC SendMessage (SDK 1.x) — POSTed to the A2A v1 REST binding
+curl -s -X POST http://127.0.0.1:8888/agents/<name>/message:send \
+  -H 'Content-Type: application/json' \
+  -H 'A2A-Version: 1.0' \
+  -d '{"jsonrpc":"2.0","id":"t","method":"SendMessage",
+       "params":{"message":{"message_id":"m1","role":"ROLE_USER",
+                            "parts":[{"text":"hello"}]}}}' \
+  | jq '.result.task | {state: .status.state, reply: .status.message.parts[0].text}'
+
+# SSE streaming
+curl -N -X POST http://127.0.0.1:8888/agents/<name>/message:send \
+  -H 'Content-Type: application/json' \
+  -H 'A2A-Version: 1.0' \
+  -H 'Accept: text/event-stream' \
+  -d '{"jsonrpc":"2.0","id":"t","method":"SendStreamingMessage",
+       "params":{"message":{"message_id":"m1","role":"ROLE_USER",
+                            "parts":[{"text":"long-running"}]}}}'
+```
+
+## Handler env vars
+
+| Env var | Default | Read by |
+| --- | --- | --- |
+| `SAC_A2A_CLAUDE_BIN` | `claude` | `claude_cli` handler |
+| `SAC_A2A_CLAUDE_MODEL` | (unset → CLI default) | `claude_cli` handler |
+| `SAC_A2A_CLAUDE_SYSTEM` | a "be brief, no tools" prompt | `claude_cli` handler |
+| `SAC_A2A_CLAUDE_TIMEOUT_S` | 25 | `claude_cli` handler |
+| `SAC_A2A_EXEC_COMMAND` | (required) | `exec` handler — full `argv` (shell-quoted) |
+| `SAC_A2A_EXEC_TIMEOUT_S` | 25 | `exec` handler |
+
+## Implementation — `a2a-sdk` 1.x
+
+sac uses the official Python `a2a-sdk[http-server]>=1.0.2`. Handlers are `AgentExecutor` subclasses (`a2a/executors/{_echo,_claude_cli,_exec}.py`) with `async execute(context, event_queue)` that enqueues a `Task` (state `SUBMITTED`), drives status updates, and emits `TaskArtifactUpdateEvent` / `TaskStatusUpdateEvent` events. The SDK handles dispatch routing, SSE serialization, and task store wiring.
+
+### Known compatibility notes
+
+- **`protobuf<7` required**: a2a-sdk 1.0.2 reads `FieldDescriptor.label` which protobuf 7.x removed. Pinned in deps.
+- **`uvicorn ws="none"`**: A2A is HTTP+SSE only — uvicorn 0.27's WS protocol auto-loader breaks on websockets 15.x (`websockets.legacy` removed). Sac passes `ws="none"` so the sidecar boots cleanly.
+- **AgentCard is protobuf**: SDK 1.x expects a protobuf `AgentCard`, not pydantic dict. `_card.project_card_proto()` is the adapter; the dict form (`project_card()`) is what gets served at `/.well-known/agent-card.json` (v1 name).
+
+## Boundary with orochi
+
+orochi (the fleet hub) is **one consumer** of sac-served A2A endpoints. Its dispatch bridge serves the same SDK 1.x surface at `https://scitex-orochi.com/agents/<name>/` and proxies into the live agent's sidecar (Tier-3 HTTP-direct, or WS fallback). orochi adds workspace-token auth (`WorkspaceTokenContextBuilder`), agent registry resolution, and chat-room semantics on top. None of that is required for sac's A2A — those are orochi-side features layered on top.
+
+If you want a fleet, use orochi. If you want one agent on a laptop, use `sac a2a serve`.
+
+## Cross-references
+
+- [`07_a2a-protocol-extension-fields.md`](07_a2a-protocol-extension-fields.md) — `x-scitex-agent-container.*` per-agent / fleet / proxy field enumeration + full JSON card example
+- [ADR-0004](../../../../docs/adr/0004-a2a-v1-compliance.md) — A2A v1.0 compliance
+- [`06_env-injection-ports.md`](06_env-injection-ports.md) — the four env-injection ports (yaml.env / to_home/.mcp.json env / to_home/.env / hooks)
+- [scitex-orochi `docs/a2a-protocol.md`](https://github.com/ywatanabe1989/scitex-orochi/blob/develop/docs/a2a-protocol.md) — fleet-side architecture (Tier 3 dispatch bridge)

--- a/skills-archive/scitex-agent-container/08_templates.md
+++ b/skills-archive/scitex-agent-container/08_templates.md
@@ -1,0 +1,56 @@
+---
+description: |
+  [TOPIC] Templates and Examples
+  [DETAILS] Templates and Examples — see file body for details..
+tags: [scitex-agent-container-templates]
+---
+
+# Templates and Examples
+
+Two directories under `config/` ship YAML you can copy:
+
+- `examples/agent-templates/` — six minimal **pattern** templates (one per deployment pattern)
+- `examples/agents/` — concrete real-world configs
+
+Both are validated by `tests/test_templates_v3_valid.py`. The SLURM template additionally renders an sbatch script in CI to catch YAML/dataclass drift.
+
+## Pattern matrix
+
+| Template | Pattern | Distinguishing key |
+|---|---|---|
+| `apptainer.yaml` | claude-session inside Apptainer SIF | `spec.runtime: apptainer`, `spec.image: *.sif` (default) |
+| `ssh.yaml` | remote agent via SSH | dispatched cross-host via `sac --on <peer>` (F-CS12) |
+
+MCP wiring is no longer a separate template — drop a `.mcp.json` into the agent's `to_home/` directory and it lands at `$HOME/.mcp.json` at start (ADR-0006). Docker / podman / local-bare-metal patterns deleted after F-CS17 made sac apptainer-only.
+
+## Instantiating (dir-as-SSoT)
+
+The v3 loader derives the agent name from the parent directory, not from `metadata.name`. To instantiate:
+
+```bash
+mkdir -p ~/.scitex/agent-container/agents/my-agent
+cp examples/agent-templates/apptainer.yaml ~/.scitex/agent-container/agents/my-agent/spec.yaml
+# optional: add a to_home/ sibling for CLAUDE.md / .mcp.json / .env / .claude/{hooks,skills,commands}
+sac agents start my-agent
+```
+
+For SSH-deployed agents, drop a sibling `to_home/` directory next to `spec.yaml` — the whole directory rsyncs to the remote and is materialized into the agent's `$HOME` at start.
+
+## When to add a new template
+
+Add a new pattern template only when the new YAML shape isn't expressible by combining existing templates. If you find yourself documenting a specific operator decision, write to `examples/agents/` instead — examples are real configs frozen in time, templates are minimal patterns.
+
+When adding a template:
+
+1. Drop the YAML in `examples/agent-templates/<name>.yaml`.
+2. Add `<name>.yaml` to the `expected` set in `test_minimal_templates_cover_expected_patterns`.
+3. Add a runtime-specific assertion to `test_templates_v3_valid.py` that exercises the field shape unique to your pattern (e.g. for slurm, render the sbatch script and check for hardener strings).
+
+## Examples
+
+`examples/agents/` holds concrete configs that aren't patterns:
+
+- `newbie-docker.yaml` — Hawthorne-effect-free naive-user simulation; documents the 2026-04-12 contamination incident lesson.
+- `researcher-opus.yaml` — Opus-powered researcher with on-failure restart + backoff tuned for long sessions.
+
+Examples are loaded by `test_example_loads` to guard against schema drift, but they are not part of the pattern guarantee — feel free to add new ones for any non-trivial fleet member you ship.

--- a/skills-archive/scitex-agent-container/10_cli.md
+++ b/skills-archive/scitex-agent-container/10_cli.md
@@ -1,0 +1,138 @@
+---
+description: |
+  [TOPIC] scitex-agent-container CLI
+  [DETAILS] CLI commands and Python API for scitex-agent-container. Both the long form (`scitex-agent-container ...`) and the short alias (`sac ...`) are installed by the package..
+tags: [scitex-agent-container-cli]
+---
+
+# scitex-agent-container CLI
+
+Both the long form `scitex-agent-container` and the short alias `sac` are entry points to the same Click app. Examples below use `sac` for brevity.
+
+## Lifecycle
+
+```bash
+sac agents start <name|yaml>            # Launch one (or more) agents (dir-as-SSoT; name or YAML path)
+sac agents start <name> --foreground    # Stream stdio + block until the turn finishes
+sac agents stop <name|yaml>             # Stop a running agent (graceful SIGTERM → SIGKILL after 5 s)
+sac agents restart <name>               # Stop then start, preserving session_id resume
+sac agents delete <name> -y             # Stop, deregister, and remove the agent's dir
+sac db clean                            # Sweep dead instances from state.db (replaces legacy registry clean)
+```
+
+## Inspection
+
+```bash
+sac agents list                         # All registered agents + liveness (table)
+sac agents list --json                  # Machine-readable
+sac agents list --capability X          # Filter by capability label
+sac agents list --machine Y             # Filter by machine label
+sac agents status [name]                # Per-agent status (heartbeat, session id, quota), or fleet view
+sac agents status [name] --json         # Same, JSON
+sac agents tail <name> [-n LINES]       # Render session.jsonl (user / assistant / tool / result events)
+sac agents health <name>                # Run a health check (heartbeat freshness, restart policy)
+sac agents recall <name>                # Human-readable session summary
+sac agents check <name>                 # Preflight: validate yaml + probe runtime deps
+sac agents find <capability>            # Find agents with a specific capability label across YAML roots
+```
+
+## Interact (resume an existing session)
+
+```bash
+sac agents send <name> "<prompt>"          # Resume the agent's session for one more turn
+sac agents send <name> --key ESC           # Cancel the current turn (SIGINT to the runner pid)
+sac agents send <name> --no-stream         # Buffer the reply instead of streaming
+sac agents send <name> "..." -- --debug    # Anything after `--` is forwarded verbatim to claude
+```
+
+Reads `session_id` from the per-agent state dir and shells out to `claude --resume <sid> -p ...` inside the agent's `workdir`. See `15_claude-session.md` for the long-lived alternative that keeps the SDK client open across turns.
+
+## sac listen (HTTP/JSON control plane)
+
+```bash
+sac listen                                # Boot the local control-plane server (loopback only by default)
+sac listen --bind 127.0.0.1:7878          # Custom bind
+sac listen --print-token                  # Echo the bearer token & exit
+sac listen status                         # One-shot health report (UP/WEDGED/DOWN); exit 1 if not serving
+sac listen status --json                  # Machine-readable status envelope
+sac listen restart                        # Self-healing stop-clean-relaunch (clears stale pidfile, force-kills wedged port holder)
+sac listen restart --force                # SIGKILL the daemon + any wedged port holder immediately
+```
+
+`restart` is the deterministic incident-recovery verb: it clears a stale pidfile, force-kills an untracked remnant still holding the port (the "curl hangs forever" case), then relaunches and health-probes — failing loud (non-zero, `ERROR:` naming the real cause) if the daemon can't be brought up. `status` is the one-command diagnosis.
+
+When running, exposes (bearer-token authenticated, except the public health route):
+
+| Route | Purpose |
+|---|---|
+| `GET  /v1/health` | Liveness; public (unauthenticated) |
+| `GET  /agents` | List local registry |
+| `GET  /agents/<name>/status` | Spec path, workdir, session_id |
+| `GET  /agents/<name>/card` | A2A-compatible AgentCard |
+| `POST /agents` | Start (body: `{name}` or `{name, spec}` for inline-spec register-and-start) |
+| `POST /agents/<name>/send` | One turn — buffered JSON by default; `Accept: text/event-stream` → SSE frames |
+| `DELETE /agents/<name>` | SIGTERM the runner pid |
+
+## A2A protocol (sidecar)
+
+```bash
+sac a2a serve <agent.yaml>...    # Foreground A2A server for one or more agents
+sac a2a doctor <agent.yaml>      # Probe an agent's AgentCard endpoint, report health
+```
+
+Auto-launch is wired via `spec.a2a.port` — for SDK agents the runner hosts `POST /v1/turn` itself; `sac a2a serve` is the sidecar path for non-SDK runtimes. See `07_a2a-protocol.md`.
+
+## Build & deployment
+
+```bash
+sac image build                        # Build container base image
+sac agents check <yaml>                 # Run preflight checks (SSH reachability, claude on PATH, …)
+sac host probe-hub               # Probe WSL → fleet-hub connectivity (DNS, gateway, TCP, HTTPS)
+```
+
+## Operational tools
+
+```bash
+sac accounts list                     # Stored accounts + active one + freshness column
+sac accounts save <name>              # Snapshot current credentials for rotation
+sac accounts sync-live                # Mirror the live credential into its matching store (idempotent; fails loud on stale/absent)
+sac accounts watch-live               # Daemon: auto-sync the moment `claude /login` rewrites the live credential
+sac accounts switch <name>            # Switch active credentials
+sac accounts watch-quota              # Monitor quota and auto-rotate credentials
+sac db clean                          # Sweep dead instances from state.db
+sac db query --table instances        # Inspect state.db rows
+sac event ingest                        # Append a Claude Code hook event to the per-agent ring buffer
+```
+
+## Discoverability
+
+```bash
+sac list-python-apis [-v|-vv]    # List public Python APIs (v=docstrings, vv=full docs)
+sac --help                       # Top-level help
+sac <subcommand> --help          # Per-subcommand help
+```
+
+## Python API
+
+```python
+from scitex_agent_container import agent, load_config, Registry
+
+agent.start("my-agent")                 # name (dir-as-SSoT) or YAML path
+status = agent.status("my-agent")
+print(agent.logs("my-agent", lines=50))
+```
+
+The CLI is a thin wrapper over the namespaced API submodules
+(`agent`, `db`, `host`, `image`, `account`, `skills`, `mcp`, `peer`).
+Run `sac list-python-apis -vv` for the full signature tree.
+
+## Conventions
+
+- **Noun-verb subcommand structure** for grouped operations (`sac agents start`, `sac a2a serve`, `sac db query`).
+- **`--json` always available** on inspection commands so dashboards can consume them.
+- **Both `<name>` and `<yaml-path>` accepted** by `start`/`stop`/`restart` — the CLI resolves yaml paths to agent names internally.
+
+## See also
+
+- `01_config-v3.md` — the YAML schema the CLI consumes
+- `40_troubleshooting.md` — common launch failures

--- a/skills-archive/scitex-agent-container/11_remote-deploy.md
+++ b/skills-archive/scitex-agent-container/11_remote-deploy.md
@@ -1,0 +1,199 @@
+---
+description: |
+  [TOPIC] Cross-host agent placement (v3)
+  [DETAILS] Pinning an agent to one or more peers via spec.host / spec.hosts; the v2 spec.remote: block has been removed.
+tags: [scitex-agent-container-remote-deploy]
+---
+
+# Cross-host agent placement
+
+The v2 `spec.remote:` block (host / user / ssh timeout / remote venv) is
+**no longer accepted** by the v3 validator
+(`config/_validation.py::_V3_REMOVED_FIELDS["remote"]`). A spec that
+still ships `spec.remote` hard-errors at `sac agents check` time with a
+redirect to `spec.host` / `spec.hosts`.
+
+Cross-host placement is now declared with two mutually exclusive fields
+plus the `sac --on <peer>` dispatcher.
+
+## YAML — singleton on one peer
+
+```yaml
+apiVersion: scitex-agent-container/v3
+kind: Agent
+spec:
+  runtime: apptainer
+  host: gpu-box                 # singleton; only this peer runs it
+  # host: [gpu-box, laptop]     # singleton with fallback priority list
+  a2a:
+    host: 127.0.0.1             # inbound HTTP bind (loopback)
+    port: auto                  # or a fixed int
+  apptainer:
+    image: ~/.scitex/agent-container/containers/sac-base.sif
+  claude:
+    model: claude-opus-4-7[1m]
+```
+
+`spec.host` accepts a string (one peer) or a list of strings (try in
+order; first available wins). The agent runs on exactly one peer at a
+time.
+
+## How `spec.host` resolves — concrete hostname → local or remote
+
+`spec.host` is a CONCRETE hostname; `sac agents start` resolves *where it is*:
+
+| `spec.host` | Launch path |
+|---|---|
+| `local` / absent, or this machine's canonical name / alias | local `agent_start` (identical to `host: local`) |
+| a `peers:` key not this machine (incl. `spartan-*` globs) | ssh dispatch (`_dispatch_remote_start`) |
+| unregistered / typo | never ssh; defers to the liveness-gated singleton-skip |
+
+Identity is `config.yaml::host:` (canonical + aliases); peers are
+`config.yaml::peers:` (`ssh:` may be a `~/.ssh/config` alias). The local check
+precedes the peer table, so a self-registered peer (`ywata-note-win: {ssh:
+localhost}`) is never ssh'd to itself. Resolver:
+`_common.classify_dispatch_host` (`try_dispatch` dispatches only `remote`).
+
+## YAML — multi-instance, one per peer
+
+```yaml
+spec:
+  runtime: apptainer
+  hosts: [laptop, gpu-box, nas] # one independent instance per peer
+  # hosts: all                  # every peer in config.yaml peers:
+```
+
+`spec.hosts` accepts a list of peer names or the string `"all"` (every
+peer declared in `~/.scitex/agent-container/config.yaml` under `peers:`).
+Each peer gets its own runner with its own session state.
+
+`spec.host` and `spec.hosts` are mutually exclusive — declaring both
+fails validation.
+
+## Dispatch
+
+The `sac` CLI itself uses `--on <peer>` to ssh-dispatch any subcommand:
+
+```bash
+sac --on gpu-box agents start my-agent     # run "agents start my-agent" on gpu-box
+sac --on gpu-box agents status my-agent
+sac --on gpu-box agents stop my-agent
+```
+
+Under the hood `sac --on` ssh-hops with the peer's connection settings
+from `config.yaml::peers.<peer>` (host, user, identity, etc.) — no
+per-spec `remote:` block is involved.
+
+## How a multi-host start fans out
+
+When you `sac agents start <name>` with `spec.hosts`, the dispatcher:
+
+1. Resolves the peer list (`hosts: all` → every entry in `peers:`).
+2. For each peer, ssh-dispatches `sac agents start <name>` via the
+   `--on <peer>` machinery.
+3. Each remote `sac` reads the same agent dir (synced separately — sac
+   does not auto-rsync; use `sac fleet sync` or your own deploy
+   pipeline).
+4. Each peer runs an independent apptainer SIF instance.
+
+For singleton (`spec.host`), only one peer is dispatched (the first
+healthy entry in the priority list).
+
+## Requirements on each peer
+
+- `scitex-agent-container` installed (same version recommended)
+- `apptainer` ≥ 1.2 + the agent's `.sif` image present at
+  `spec.apptainer.image`
+- The peer is declared in `~/.scitex/agent-container/config.yaml`
+  under `peers:` with reachable SSH settings
+- SSH key-based auth from the dispatcher host to the peer
+
+## SSH connection multiplexing (ControlMaster)
+
+Every sac call that shells out to ssh — `sac host exec`, `sac host probe`,
+dispatch fan-out, drift probes, OAuth send-preflight, ssh+curl turn
+delivery — automatically prepends `-o ControlMaster=auto -o
+ControlPersist=60s -o ControlPath=<dir>/%C`. Concurrent calls against the
+same peer share one TCP+SSH master, which:
+
+- respects per-user `MaxSessions` caps on HPC heads (Spartan: typically
+  10) and `sshd_config` `MaxStartups`,
+- avoids the per-call TCP/cipher handshake when sac fans out across
+  several hosts in parallel, and
+- sidesteps the apptainer `control socket dir is read-only` failure
+  caused by the default `~/.ssh/sockets` ControlPath landing on the SIF
+  overlay.
+
+ControlPath resolution order: explicit caller arg → `$SAC_SSH_CONTROL_DIR`
+env → `${TMPDIR:-/tmp}/.sac-ssh-cm`. The dir is `mkdir -p`'d on first
+use; if the parent is read-only the function falls through to `[]` and
+sac's argv is byte-identical to the pre-patch shape (degrade, don't
+crash).
+
+### Opt out
+
+```
+export SAC_SSH_CONTROL_MASTER=0   # or 'no' / 'false' / 'off'
+```
+
+Useful when ssh is itself proxied through a wrapper that breaks
+ControlPath (rare).
+
+### Helper for agent prompts
+
+Agent prompts that shell out to ssh themselves shouldn't re-derive the
+flags. Use:
+
+```
+ssh   $(sac host ssh-opts) myhost cmd
+rsync -e "ssh $(sac host ssh-opts)" src/ myhost:dst/
+```
+
+`sac host ssh-opts` prints the flags shell-quoted; empty when the opt-out
+env is set so the splat is a no-op either way. The Python helper is
+`scitex_agent_container._state.host_config.ssh_control_options()` for
+in-process callers.
+
+## Migrating from `spec.remote`
+
+| v2 (removed) | v3 replacement |
+|---|---|
+| `spec.remote.host: mba` | `spec.host: mba` |
+| `spec.remote.host: [mba, laptop]` | `spec.host: [mba, laptop]` (singleton fallback) |
+| `spec.remote.host: [a, b]` + start-all | `spec.hosts: [a, b]` (one per peer) |
+| `spec.remote.user`, `spec.remote.timeout`, `spec.remote.login_shell` | declared in `config.yaml::peers.<peer>` (not per-agent) |
+| `spec.venv` (remote-only path) | `spec.apptainer.image` + in-container venv at `/opt/venv-agent` |
+
+## HPC deployment — no-sudo / no-subuid sites (Spartan etc.)
+
+On HPC sites where `sudo` is forbidden AND the user has no `/etc/subuid`
+mapping, `apptainer build` cannot run at all — neither sudo nor fakeroot
+namespace ops are available. You **cannot** `sac image build` on such
+hosts.
+
+The canonical workaround: bind-mount the host editable
+`scitex_agent_container` package over the SIF's site-packages copy, so
+the SIF's `/opt/venv-sac/bin/sac` runs HOST code without rebuild. Add to
+`spec.apptainer.binds`:
+
+```yaml
+spec:
+  apptainer:
+    binds:
+      - source: /abs/path/to/scitex-agent-container/src/scitex_agent_container
+        target: /opt/venv-sac/lib/python3.12/site-packages/scitex_agent_container
+        read_only: true
+```
+
+`git pull` on the host install is then the entire SIF-update loop.
+Caveats + the operator one-shot `apptainer exec --bind ...` form are
+in [24_image-build.md](24_image-build.md) under "When `sac image build`
+is impossible".
+
+## See also
+
+- `docs/spec-reference.md` "Top-level shape" — host/hosts canonical reference
+- `07_a2a-protocol-extension-fields.md` — `x-scitex-agent-container.scheduling`
+  card field derived from `spec.host` / `spec.hosts`
+- [24_image-build.md](24_image-build.md) — image build/rebuild + the
+  bind-editable workaround for no-sudo/no-subuid HPCs

--- a/skills-archive/scitex-agent-container/12_wsl-connectivity.md
+++ b/skills-archive/scitex-agent-container/12_wsl-connectivity.md
@@ -1,0 +1,183 @@
+---
+description: |
+  [TOPIC] WSL ↔ Fleet-Hub Connectivity (todo#457)
+  [DETAILS] WSL ↔ Fleet-Hub Connectivity (todo#457) — see file body for details..
+tags: [scitex-agent-container-wsl-connectivity]
+---
+
+# WSL ↔ Fleet-Hub Connectivity (todo#457)
+
+## Problem
+
+`ywata-note-win` (Windows 11 + WSL2) periodically drops WSL-side
+internet connectivity. The fleet sees this as "SSH dead" (banner-
+exchange timeout, then connection-refused), which is indistinguish-
+able from "host asleep" unless the WSL side leaves a local trail.
+
+## Baseline
+
+**Wired LAN + mirrored mode** (as of 2026-04-21, ywatanabe
+msg#15405). The host has been moved off Wi-Fi onto a stable wired
+Ethernet link; SSID-roam and 2.4 vs 5 GHz hand-off are no longer
+in scope. Remaining live failure modes are NIC-level power-save
+and DHCP lease churn.
+
+## What the evidence shows (from this host)
+
+One-shot diagnostics on 2026-04-21:
+
+- `/sbin/ip addr` → `eth0` has `192.168.11.28/24`, a LAN IP (NOT
+  the WSL NAT `172.x.x.x` range). This proves
+  **`networkingMode=mirrored` is already active** — the
+  `.wslconfig` at `/mnt/c/Users/wyusu/.wslconfig` contains
+  `[wsl2] networkingMode=mirrored`. Under mirrored mode WSL's
+  `eth0` reflects whichever Windows NIC is carrying traffic —
+  currently the wired Ethernet adapter.
+- `/sbin/ip route` → default via `192.168.11.1` (the home router)
+  on `eth0`. No separate WSL-bridge hop.
+- `/etc/resolv.conf` → `nameserver 8.8.8.8 / 8.8.4.4` (Google DNS,
+  static). `/etc/wsl.conf` has `generateResolvConf = false`, so
+  DNS is not rewritten on boot.
+- `ping $SAC_HUB_URL`'s host (when sac is configured to talk to a
+  fleet hub) → typically <50 ms RTT, 0% loss when healthy.
+- `cloudflared` → installed at `~/.local/bin/cloudflared`, **not a
+  systemd service and not currently running**. The cloudflared
+  tunnel failures described in todo#457 are on the **NAS side**
+  dialling *into* a WSL-hosted bastion; they are not owned by this
+  host's head agent.
+
+## What this means for the hypotheses in todo#457
+
+| # | Hypothesis | Status |
+|---|---|---|
+| 1 | WSL2 NAT bridge instability | **Eliminated.** Mirrored mode removes the NAT bridge. |
+| 2 | Hyper-V vswitch desync on NIC change | **Partly eliminated.** Mirrored mode uses the host's NIC directly; wired LAN means no Wi-Fi-driven NIC swaps. |
+| 3 | cloudflared tunnel uplink expiry | **N/A for this host.** No cloudflared service runs here. Belongs to head-nas. |
+| 4 | Windows NIC power-save | **Still live.** Applies equally to the wired Ethernet adapter — if Windows powers it down (selective-suspend / "allow the computer to turn off this device to save power"), WSL loses connectivity immediately. |
+| 5 | DHCP lease churn | **Still live, reduced scope.** With the host on a single wired link (no Wi-Fi roam), only lease-renewal on the Ethernet adapter remains. A static reservation removes this entirely. |
+
+## Mitigations that require ywatanabe-side Windows action
+
+These cannot be done from inside WSL. They are the actual root-
+cause fixes; everything below the line is WSL-side visibility.
+
+1. **Disable Windows NIC power-save on the wired Ethernet adapter.**
+   In PowerShell (admin):
+   ```powershell
+   Get-NetAdapter | Where-Object {$_.Status -eq "Up"} |
+     Set-NetAdapterPowerManagement -AllowComputerToTurnOffDevice Disabled
+   ```
+   One-shot, survives reboots. Targets all "Up" adapters, which on
+   a wired-only host is just the Ethernet NIC.
+2. **Static DHCP reservation on the router for this host's wired
+   MAC.** With mirrored mode, every DHCP renegotiation on the
+   Ethernet adapter re-IPs WSL's `eth0` directly and breaks any
+   TCP session crossing the transition. A static reservation
+   eliminates lease-expiry churn.
+3. **Leave `networkingMode=mirrored` as-is.** The alternative
+   (NAT bridge) is the *previous* failure mode the fleet was
+   hitting before this setting was applied.
+
+## Mitigations available on the WSL side (what this PR ships)
+
+Since the fleet-facing symptom is "SSH dead, cause unknown", the
+WSL-side contribution is **unambiguous evidence** that the outage
+is connectivity, not a crashed Claude process. Use the probe
+command shipped in this package.
+
+### One-shot manual probe
+
+```bash
+scitex-agent-container probe-network --agent head-$(hostname)
+```
+
+Output (when healthy):
+
+```json
+{
+  "ts": "2026-04-21T09:30:00+00:00",
+  "ok": true,
+  "probes": [
+    {"name": "dns", "ok": true, "latency_ms": 4.1, "extra": {"addrs": ["104.19.xx.xx", "172.67.xx.xx"]}},
+    {"name": "gateway", "ok": true, "latency_ms": 1.3, "extra": {"gateway": "192.168.11.1"}},
+    {"name": "tcp", "ok": true, "latency_ms": 13.2},
+    {"name": "https", "ok": true, "latency_ms": 45.0, "extra": {"status": 200}}
+  ]
+}
+```
+
+When the WSL side is broken, the first probe to fail tells you the
+layer that actually broke:
+
+| First failure | Diagnosis |
+|---|---|
+| `dns` | resolver unreachable — `/etc/resolv.conf` nameserver (8.8.8.8) is blocked or the wired link is actually down |
+| `gateway` (but `dns` ok) | rare — DNS is cached / UDP-only while LAN routing died |
+| `gateway` AND `dns` | Ethernet NIC power-save just kicked in, or DHCP lease renegotiation re-IP'd eth0 |
+| `tcp` (but `dns` + `gateway` ok) | hub unreachable: firewall / Cloudflare regional |
+| `https` only | TLS handshake or captive-portal interposing |
+
+The probe writes one JSONL line per run to
+`~/.scitex/agent-container/runtime/logs/network/<agent>.jsonl`. This is
+the ring the fleet correlates against its own SSH-dead timestamps.
+
+### Cron-style continuous probe
+
+To leave a timeline the fleet can grep after the next incident,
+run the probe every minute from WSL's user systemd / cron:
+
+```cron
+* * * * * /home/ywatanabe/.venv/bin/scitex-agent-container probe-network \
+            --agent head-ywata-note-win --quiet >/dev/null 2>&1
+```
+
+Or via tmux/screen one-liner for a single session:
+
+```bash
+while true; do
+  scitex-agent-container probe-network --agent head-ywata-note-win --quiet
+  sleep 60
+done &
+```
+
+### Exit-code behaviour for systemd/monit integration
+
+Pass `--exit-nonzero-on-fail` if you want a wrapper script to alert
+on sustained failure:
+
+```bash
+scitex-agent-container probe-network --agent head-ywata-note-win \
+    --quiet --exit-nonzero-on-fail \
+    || notify-send "WSL→hub down"
+```
+
+## Correlating with fleet-side SSH-dead events
+
+When the fleet reports `ssh ywata-note-win` timing out, the fleet
+cannot tell whether:
+
+- the laptop lid is closed (Windows asleep),
+- the laptop is awake but WSL lost its wired link (NIC power-save
+  or DHCP renegotiation),
+- the laptop is awake and WSL has internet but the SSH service
+  restarted,
+- or Claude Code TUI crashed while the rest of the host is fine.
+
+A minute-granular probe log on WSL disambiguates all four:
+
+- Absent log lines in the window → **Windows host was asleep**
+  (WSL was not running). Fix: disable lid-close / power settings.
+- Present lines but `ok=false` → **WSL lost external connectivity**.
+  Fix: apply one of the Windows-side mitigations above.
+- Present lines and `ok=true` → **WSL was fine**, so the SSH-dead
+  signal is a false positive. Fix: investigate the fleet's SSH
+  probe, not this host.
+
+## See also
+
+- `liveness_probe.py` — TUI-responsiveness probe (different scope:
+  "is Claude still echoing text inside tmux?"). Complements this
+  module: network-probe ensures WSL can REACH the hub; liveness-
+  probe ensures Claude can respond once reached.
+- Fleet-level tunnel setup is owned by the downstream fleet hub
+  (consumer of sac), not by sac itself.

--- a/skills-archive/scitex-agent-container/13_observability.md
+++ b/skills-archive/scitex-agent-container/13_observability.md
@@ -1,0 +1,76 @@
+---
+description: |
+  [TOPIC] Observability contract
+  [DETAILS] How `sac agents status <name> --json` merges registry + agent_meta + event_log into a single best-effort blob that downstream fleet hubs (any consumer) read without direct coupling — every field has a defaul....
+tags: [scitex-agent-container-observability, observability]
+---
+
+# Observability contract
+
+`sac agents status <name> --json` produces a single JSON blob by merging three
+sources:
+
+1. **Registry entry** — what was recorded at `sac agents start` time (name,
+   pid, session, runtime, host, started_at).
+2. **`agent_meta.collect_rich(name)`** — live process/session state
+   (pane_state, screen_idle_seconds, mcp_status, model, account, …).
+3. **`event_log.summarize(name)`** — recent lifecycle/health events
+   (restarts, last health-fail, last quota-watch tick, …).
+
+## Best-effort guarantee
+
+Every field is best-effort. If the underlying probe fails (multiplexer
+gone, log file missing, network unreachable), the field falls back to
+its type's empty value (`""`, `0`, `[]`, `{}`) rather than raising.
+This means consumers can rely on the **shape** of the output — they
+just need to treat empty values as "not observed."
+
+## Downstream coupling
+
+Downstream orchestrators (any fleet hub, dashboards) consume this JSON
+and **only** this JSON. They do not import
+`scitex_agent_container` Python objects, do not read the registry
+directly, and do not parse event-log files. The status JSON is the
+contract.
+
+This means:
+
+- Adding a field is a non-breaking change (consumers ignore unknown keys).
+- Renaming a field is a breaking change — bump the package minor and
+  document in CHANGELOG.
+- Removing a field is a breaking change.
+
+## tmp-pressure field (`sdk_session.heartbeat.tmp_used_pct`)
+
+For `runtime: apptainer` (claude-session) agents the per-beat heartbeat
+carries `tmp_used_pct` — the fill percentage of the container's `/tmp`.
+Surfaces as `sdk_session.heartbeat.tmp_used_pct` in `sac agents status
+--json` (the status surface echoes the heartbeat dict verbatim).
+
+Why it exists: inside the container `/tmp` is the RAM-backed tmpfs
+(apptainer `--containall` default, unbounded by sac). A heavy
+`run_in_background` Bash session writes per-command + task-output files
+there; once it fills, every shell command that needs a temp file fails
+with exit 1 + empty stdout — the silent "Class B" bash wedge (2026-05-22
+diagnosis §3). Watching `tmp_used_pct` climb toward 100 turns that
+silent failure into an observable precursor.
+
+Best-effort: the field is **absent** (not `0`) when the probe fails
+(e.g. read on the host, where there is no container `/tmp` tmpfs). Absent
+≠ 0% — a reader distinguishes "not probed" from "empty tmpfs".
+
+### Deferred: bounding the tmpfs (not in this change)
+
+The companion mitigation — capping `/tmp` so exhaustion surfaces as a
+loud `No space left on device` rather than a silent exit-1 — was
+**deliberately deferred**. It requires threading a
+`--mount type=tmpfs,…,size=…` (or sized `--writable-tmpfs`) into the
+apptainer raw_args, which touches the iso-flags / relaxed-vs-hardened
+launch path and risks regressing the live `--containall` behaviour.
+Instrumentation (this field) is the cheap, non-invasive first half; the
+bounding is tracked separately so it can be reviewed on its own.
+
+## See also
+
+- README "Rich Status" table — full field list with types and meanings.
+- [10_cli.md](10_cli.md) — `sac agents status` invocation and flags.

--- a/skills-archive/scitex-agent-container/14_claude-session-state.md
+++ b/skills-archive/scitex-agent-container/14_claude-session-state.md
@@ -1,0 +1,132 @@
+---
+description: |
+  [TOPIC] claude-session runner — state layout, auth, status JSON, supervisor
+  [DETAILS] Operational reference for the in-container claude-session SDK runner (see 15_claude-session.md for the overview). Covers the per-agent state dir (`pid`/`heartbeat.json`/`session.jsonl`/`session_id`/`quota.json`), scope resolution, the cost-critical auth precedence (`~/.claude/.credentials.json` OAuth vs `SAC_ANTHROPIC_API_KEY`), the `sdk_session` status-JSON block, the in-repo smoke test, the auto-restart supervisor, and the no-interactive-session constraint.
+tags: [scitex-agent-container-claude-session-state, claude-session, sdk]
+---
+
+# claude-session runner — state, auth, status, supervisor
+
+Operational reference for the in-container `claude-session` SDK runner.
+For the runtime overview, the canonical apptainer YAML, and operating
+modes, see [15_claude-session.md](15_claude-session.md).
+
+## State layout
+
+Per-agent state lives at `<scope>/runtime/<name>/`:
+
+| File | Contents |
+|---|---|
+| `pid` | Runner's PID (atomic write — tmp + rename). |
+| `heartbeat.json` | `{ts, pid, state}` plus `elapsed_s` (seconds since session start, from `started_at`) and the running token totals `input_tokens / output_tokens / total_tokens` (from `quota.json`). State ∈ `starting / idle / working / stopping`. Refreshed every 10 s (`--tick-seconds`). |
+| `started_at` | Session start time (unix seconds). Written once at startup; preserved across a resumed respawn so `elapsed_s` tracks the conversation, not the process. |
+| `session.jsonl` | One JSON object per turn event: `user / assistant / user_echo / result / error`. The transcript. |
+| `session_id` | Latest SDK session UUID. Auto-resumed by the next `sac agents start`. |
+| `quota.json` | Accumulated per-turn token totals (input / output / cache_creation / cache_read / turns). |
+
+Scope resolution (highest priority first):
+
+1. **Project-local**: walks up from cwd to a git repo containing
+   `.scitex/agent-container/`. State lands in
+   `<repo>/.scitex/agent-container/runtime/<name>/`.
+2. **Home**: `~/.scitex/agent-container/runtime/<name>/` (when no
+   project scope is available).
+3. Override via `$SCITEX_AGENT_CONTAINER_RUNTIME_DIR` (the runner reads
+   this verbatim — useful for ad-hoc tests).
+
+Symmetric: agent definitions follow the same resolution order
+(`<scope>/agents/<name>/<name>.yaml` first, then
+`~/.scitex/agent-container/agents/`, then env, then fleet dirs).
+
+## Auth (cost-critical)
+
+The SDK's authentication path, by precedence
+(`runtimes/_sdk_common.py::provision_anthropic_auth`):
+
+1. `~/.claude/.credentials.json` exists → SDK reads OAuth token
+   automatically (Pro/Max plan, **flat-rate**). The default on every
+   workstation that has run `claude /login`.
+2. `SAC_ANTHROPIC_API_KEY` (sac-namespaced handoff for headless
+   contexts — CI, SLURM, cron). When set it is mirrored into
+   `ANTHROPIC_API_KEY` for the SDK (an `sk-ant-api*` value is
+   **pay-per-token**, explicit opt-in only).
+
+A bare host `ANTHROPIC_API_KEY` is **never honoured**: the first thing
+`provision_anthropic_auth` does is overwrite it from
+`SAC_ANTHROPIC_API_KEY`, or *pop* it from the env when
+`SAC_ANTHROPIC_API_KEY` is unset — so a stale dotfiles export can't be
+picked up by the SDK auto-reader, shadow a working OAuth credentials
+file, or silently switch you to API-key billing. Set neither input and
+you get a clear `SDKCommonError`.
+
+## Status JSON addition
+
+`sac agents status <name> --json` carries an `sdk_session` field for
+agents on this runtime:
+
+```json
+{
+  "runtime": "apptainer",
+  "sdk_session": {
+    "session_id": "6ef8248f-1ccd-4877-934d-908e15333b52",
+    "quota": {
+      "input_tokens": 6,
+      "output_tokens": 14,
+      "cache_creation_input_tokens": 33003,
+      "cache_read_input_tokens": 0,
+      "turns": 1
+    },
+    "heartbeat": {
+      "ts": 1777766006.95, "pid": 3476972, "state": "idle",
+      "started_at": 1777765800.0, "elapsed_s": 206.95,
+      "input_tokens": 6000, "output_tokens": 1500, "total_tokens": 40503
+    },
+    "state_dir": "/path/to/.scitex/agent-container/runtime/<name>"
+  }
+}
+```
+
+`sdk_session` is populated for `kind: Agent` (SDK runner) and `null` for
+`kind: AgentProxy` (the HTTP forwarder, which has no SDK) — never absent
+— so dashboards can switch on its presence without parsing further.
+
+## In-repo smoke test
+
+`<repo>/.scitex/agent-container/agents/sdk-test/sdk-test.yaml` is a
+checked-in fixture that the project-local discovery picks up
+automatically when `sac` is invoked from inside the repo:
+
+```bash
+cd ~/proj/scitex-agent-container
+sac agents start sdk-test --foreground
+# expected: sdk-runtime-ok
+```
+
+The `sdk-runtime-smoke` GitHub workflow runs this exact command on every
+push to develop / main (and daily) so an upstream SDK breakage surfaces
+immediately rather than during the next manual fleet operation.
+
+## Supervisor — auto-restart on SDK crash
+
+`--max-restarts N` (default `0` = terminate on first failure) + `--restart-backoff-s S` (default `1.0`, doubles per attempt) let the runner reopen `ClaudeSDKClient` after a mid-session exception. On each retry it re-reads `session_id` from the state dir so the new client resumes the latest completed turn; the inbox is preserved across restarts. Each restart writes `{type: error, kind: sdk_runtime, attempt: N}` + `{type: supervisor, event: restarting, in_s: <delay>}` to `session.jsonl`. After `max_restarts` attempts the inbox is drained with the last exception and the runner exits. Init failures (missing SDK, bad options) stay terminal.
+
+## Constraints
+
+- **No human-typed interactive session.** There is no tmux pane to type
+  `/clear`, `/compact`, or paste into. The SDK runner takes one mission
+  prompt at start; subsequent turns arrive via A2A (`POST /v1/turn`,
+  `sac peer post-turn`, or another inbound channel).
+
+## Related skills
+
+- [15_claude-session.md](15_claude-session.md) — the runtime overview,
+  canonical apptainer YAML, and operating modes (this leaf is its
+  state/auth/status reference half).
+- [24_image-build.md](24_image-build.md) — building/rebuilding the
+  `sac-base.sif` the runner executes inside.
+- [25_claude-setup-delivery.md](25_claude-setup-delivery.md) — how
+  `to_home/`, settings, MCP, and credentials reach the in-container `$HOME`.
+- [03_auto-accept.md](03_auto-accept.md) — the auto-accept handler set is
+  vestigial for the SDK runner (it has no TUI prompts).
+- [13_observability.md](13_observability.md) — the broader status JSON
+  contract; this leaf describes the SDK-specific addition.

--- a/skills-archive/scitex-agent-container/15_claude-session.md
+++ b/skills-archive/scitex-agent-container/15_claude-session.md
@@ -1,0 +1,145 @@
+---
+description: |
+  [TOPIC] The claude-session SDK runner (inside apptainer)
+  [DETAILS] sac runs claude-agent-sdk via the claude_session runner INSIDE an apptainer SIF (sac-base.sif + relaxed directory overlay + uv-editable /opt/venv-agent). `runtime: apptainer` is the only operative runtime value; `claude-session` is the name of the in-container runner module, NOT a runtime you select. Covers state layout, auth, turn endpoint, status JSON.
+tags: [scitex-agent-container-claude-session, claude-session, sdk]
+---
+
+# The claude-session SDK runner (inside apptainer)
+
+`claude-session` is the **name of the in-container SDK runner module**
+(`scitex_agent_container._runners.claude_session`), driven by
+`claude-agent-sdk`. It is **not** a runtime you select in YAML.
+
+sac is **apptainer-only** (since 2026-05-13 — docker/podman ripped out).
+`runtime: apptainer` is the only value the validator accepts
+(`config/_validation.py` rejects everything else). When `sac agents start`
+runs an agent, `ClaudeSessionRuntime` delegates to
+`ApptainerContainerRuntime`, which `apptainer exec`s the runner **inside
+the SIF** — "The host side never spawns a Python subprocess; every
+`start` goes through `apptainer exec`" (`runtimes/claude_session.py`).
+
+The canonical container shape (see [24_image-build.md](24_image-build.md)
+and [25_claude-setup-delivery.md](25_claude-setup-delivery.md)):
+
+- **SIF**: `sac-base.sif` (OS + dev tools + uv + node). There is no
+  separate `sac-scitex.sif`.
+- **Overlay**: a relaxed directory overlay (`--overlay <dir>/`, NOT an
+  `.img`) holds the writable upper layer that persists across restarts.
+- **Code**: a uv-editable venv at `/opt/venv-agent`, bootstrapped once via
+  `uv pip install -e ".[all]"` from the repo mounted at `/work`, persisted
+  in the overlay. The package code the agent runs comes from this editable
+  venv, not from a pre-baked SIF layer.
+
+The SDK runner does not use a terminal multiplexer (no tmux/screen, no
+pane scraping, no auto-accept) — but it still runs **inside the
+container**, not as a bare host process. The `spec.multiplexer` field is
+vestigial for agents (see [02_multiplexer.md](02_multiplexer.md)).
+
+Same lifecycle CLI surface across every agent (`sac agents start`,
+`sac agents stop`, `sac agents status`, `sac agents tail`).
+
+## What the SDK runner gives you
+
+| Concern | Behaviour |
+|---|---|
+| Process | `claude_session` runner inside `apptainer exec` (no multiplexer) |
+| TUI prompts | none — `permission_mode='bypassPermissions'` (no auto-accept needed) |
+| Hooks | Python async callbacks (`_runners/_session_hooks.py`) |
+| Resume | `ClaudeAgentOptions(resume=...)` auto-loaded from `state_dir/session_id` |
+| Quota | accumulated from per-turn `usage` blocks in the SDK message stream |
+| Auth | `~/.claude/.credentials.json` OAuth (flat-rate) or `SAC_ANTHROPIC_API_KEY` — see below |
+| Human attach | `--foreground` / `sac agents tail` |
+
+## Minimal YAML (canonical apptainer pattern)
+
+```yaml
+apiVersion: scitex-agent-container/v3
+kind: Agent
+
+metadata:
+  labels: { project: my-project }
+
+spec:
+  runtime: apptainer
+  workdir: /home/me/proj/my-project
+
+  apptainer:
+    image: /home/me/.scitex/agent-container/containers/sac-base.sif
+    relaxed: true
+    raw_args:
+      - --userns
+      - --containall
+      - --home
+      - /home/agent
+      - --overlay
+      - /home/me/.scitex/agent-container/containers/overlays/my-agent/
+
+  claude:
+    model: claude-haiku-4-5
+
+  startup_commands:
+    # Idempotent venv bootstrap — only builds if missing (overlay persists it
+    # across restarts), so boots don't re-run a full install every time.
+    - command: '[ -x /opt/venv-agent/bin/python ] || { cd /work && uv venv /opt/venv-agent --python python3 && uv pip install --python /opt/venv-agent/bin/python -e ".[all]"; }'
+
+  startup_prompts:
+    - "Reply with the string 'hello' and nothing else."
+```
+
+`startup_commands` are SHELL commands run inside the container **before**
+the SDK starts (e.g. the `/opt/venv-agent` bootstrap above).
+`startup_prompts` carry the claude mission text. `delay` is ignored — the
+SDK takes a one-shot prompt, not a timed sequence.
+
+## Operating modes
+
+### Daemon (default — production fleet shape)
+
+```bash
+sac agents start my-agent          # detach, returns once PID file lands
+sac agents status my-agent    # heartbeat + sdk_session block
+sac agents tail my-agent      # rendered transcript from session.jsonl
+sac agents stop my-agent
+```
+
+### Foreground (interactive — terminal visibility)
+
+```bash
+sac agents start my-agent --foreground
+# assistant output streams to stdout; runner exits when the turn completes
+```
+
+`--foreground` is single-target only; multi-target / directory targets
+are rejected since the runner takes over the terminal.
+
+## Inbound-turn HTTP endpoint
+
+Add `spec.a2a.port` and the runner serves `POST /v1/turn` colocated
+with the SDK conversation — turns land on the same `ClaudeSDKClient`
+so resume id + quota are preserved. See
+[17_inbound-turn-endpoint.md](17_inbound-turn-endpoint.md) for wire
+format, semantics, ssh-as-transport for remote agents, and the
+`SAC_RUNNER_PREFIX` hook.
+
+## State, auth, status, supervisor
+
+The operational reference — per-agent state-dir layout
+(`pid`/`heartbeat.json`/`session.jsonl`/`session_id`/`quota.json`),
+scope resolution, the cost-critical auth precedence, the `sdk_session`
+status-JSON block, the in-repo smoke test, the auto-restart supervisor,
+and the no-interactive-session constraint — lives in the sibling leaf
+[14_claude-session-state.md](14_claude-session-state.md).
+
+## Related skills
+
+- [14_claude-session-state.md](14_claude-session-state.md) — state
+  layout, auth, status JSON, supervisor (this overview's reference half).
+- [24_image-build.md](24_image-build.md) — building/rebuilding the
+  `sac-base.sif` the runner executes inside.
+- [25_claude-setup-delivery.md](25_claude-setup-delivery.md) — how
+  `to_home/`, settings, MCP, and credentials reach the in-container `$HOME`.
+- [03_auto-accept.md](03_auto-accept.md) — the auto-accept handler set is
+  vestigial for the SDK runner (it has no TUI prompts).
+- [13_observability.md](13_observability.md) — the broader status JSON
+  contract; the state leaf describes the SDK-specific addition.

--- a/skills-archive/scitex-agent-container/16_claude-session-migration.md
+++ b/skills-archive/scitex-agent-container/16_claude-session-migration.md
@@ -1,0 +1,69 @@
+---
+description: |
+  [TOPIC] claude-session migration — historical (complete)
+  [DETAILS] The CLI/TUI (`claude-code`) → SDK (`claude-session`) migration is DONE and the host-side runtime choice no longer exists. sac is apptainer-only: `runtime: apptainer` is the sole accepted value and the SDK runner runs inside the SIF. There is no `runtime: claude-code` to migrate FROM and no YAML key to flip. This leaf is retained only to explain why old specs that set `runtime: claude-session`/`claude-code` are rejected.
+tags: [scitex-agent-container-claude-session-migration, claude-session, migration, fleet]
+---
+
+# claude-session migration — historical (complete)
+
+The migration this leaf used to describe — flipping
+`runtime: claude-code` → `runtime: claude-session` per agent — is **done
+and the runtime-choice no longer exists**. Do not look for a YAML key to
+flip.
+
+## Current reality (verify in `config/_validation.py`)
+
+- sac is **apptainer-only** since 2026-05-13. `config/_validation.py`
+  accepts only `runtime: apptainer` (empty/unset defaults to apptainer);
+  any other value — including `claude-code` and `claude-session` — is a
+  hard validation error.
+- The SDK runner (`scitex_agent_container._runners.claude_session`) is
+  **not a runtime you select**. It is the in-container runner module that
+  `ApptainerContainerRuntime` `apptainer exec`s inside the SIF for every
+  `kind: Agent`. See [15_claude-session.md](15_claude-session.md).
+- The legacy `claude-code` CLI/TUI runtime (the `claude` binary inside
+  tmux/screen with auto-accept + pane scraping) and the host-side
+  bare-Python runner were **removed**:
+  - docker/podman ripout — 2026-05-13 (`runtimes/__init__.py`,
+    `runtimes/claude_session.py`).
+  - bare-metal subprocess + SSH-dispatch (`spec.remote`) ripout — WI-6,
+    2026-05-20 (`config/_types.py`: `RemoteSpec` deleted; validator
+    rejects `spec.remote`).
+
+## If you hit `spec.runtime must be 'apptainer'`
+
+An old spec set `runtime: claude-code` or `runtime: claude-session`.
+Update it to the canonical apptainer shape (full template in
+[15_claude-session.md](15_claude-session.md)):
+
+```yaml
+spec:
+  runtime: apptainer
+  apptainer:
+    image: /home/me/.scitex/agent-container/containers/sac-base.sif
+    relaxed: true
+    raw_args: [--userns, --containall, --home, /home/agent,
+               --overlay, /home/me/.scitex/agent-container/containers/overlays/<name>/]
+  claude:
+    model: claude-opus-4-7[1m]
+  startup_commands:
+    - command: '[ -x /opt/venv-agent/bin/python ] || { cd /work && uv venv /opt/venv-agent --python python3 && uv pip install --python /opt/venv-agent/bin/python -e ".[all]"; }'
+```
+
+Drop any `multiplexer:` line (vestigial — [02_multiplexer.md](02_multiplexer.md))
+and any `spec.remote:` block (deleted — use `spec.host` / `sac --on <peer>`
+for cross-host placement).
+
+## Cross-host placement (replaces the old per-agent rollout)
+
+The old "migrate fleet agents one at a time, flip the runtime key" flow is
+obsolete. Cross-host work now goes through `spec.host` pinning and
+`sac --on <peer>` dispatch (F-CS12), not a runtime swap. See
+[11_remote-deploy.md](11_remote-deploy.md).
+
+## Related skills
+
+- [15_claude-session.md](15_claude-session.md) — the SDK runner inside apptainer.
+- [24_image-build.md](24_image-build.md) — building the `sac-base.sif`.
+- [01_config-v3.md](01_config-v3.md) — v3 config format.

--- a/skills-archive/scitex-agent-container/17_inbound-turn-endpoint.md
+++ b/skills-archive/scitex-agent-container/17_inbound-turn-endpoint.md
@@ -1,0 +1,130 @@
+---
+description: |
+  [TOPIC] Inbound-turn HTTP endpoint (`POST /v1/turn`)
+  [DETAILS] Reference for the in-runner HTTP inbound-turn endpoint served by the in-container claude-session SDK runner when ``spec.a2a.port`` is declared. Wire format, semantics, curl examples, and how it differs from the legacy A2A sidecar. Runs inside the apptainer SIF — `runtime: apptainer` is the operative runtime.
+tags: [scitex-agent-container-inbound-turn-endpoint, claude-session, a2a, inbound]
+---
+
+# Inbound-turn HTTP endpoint (`POST /v1/turn`)
+
+Long-living agents accept new turns over HTTP. The endpoint is
+**colocated with the SDK conversation** (no separate sidecar process) so
+each turn lands on the same persistent `ClaudeSDKClient` — the resume id,
+accumulated quota, and tool history are preserved across turns.
+
+The endpoint lives in `_runners/_session_http.py`, spawned by the SDK
+runner (`_runners/claude_session.py::run`) when its argv carries
+`--a2a-port N`. The runner — and therefore this HTTP server — runs
+**inside the apptainer container** (`apptainer exec`); the runtime adapter
+sets `--a2a-port` from `spec.a2a.port`. See
+[15_claude-session.md](15_claude-session.md) for the container shape.
+
+## YAML
+
+`runtime: apptainer` is the only accepted runtime (sac is apptainer-only;
+the SDK runner is invoked inside the SIF). Enable the endpoint with
+`spec.a2a.port`:
+
+```yaml
+spec:
+  runtime: apptainer
+  apptainer:
+    image: /home/me/.scitex/agent-container/containers/sac-base.sif
+    relaxed: true
+  a2a:
+    port: 18888         # int, or "auto" (default) — set to enable inbound HTTP
+    host: 127.0.0.1     # default; set to 0.0.0.0 for LAN exposure
+```
+
+`port: auto` (the default) lets sac allocate; clients then reach the agent
+through `sac listen` (one host port, name-in-path) rather than the
+per-agent port directly. Pin an int to bind a fixed port.
+
+## Wire format
+
+```bash
+# One turn → one assistant reply
+curl -sX POST http://127.0.0.1:18888/v1/turn \
+  -H 'Content-Type: application/json' \
+  -d '{"text": "summarize today commits", "exit_after": false}'
+# 200 → {"reply": "...", "exit_after": false}
+
+# Tell the runner to shut down after this turn (CI smokes use this)
+curl -sX POST http://127.0.0.1:18888/v1/turn \
+  -H 'Content-Type: application/json' \
+  -d '{"text": "echo done", "exit_after": true}'
+
+# Liveness
+curl -s http://127.0.0.1:18888/health
+# 200 → {"status": "ok"}
+```
+
+## Semantics
+
+- **Serial**, not interleaved. A new POST waits until the prior turn's `receive_response()` drains. Matches Claude Code's own UX (next prompt waits).
+- **Per-turn timeout: 600 s.** SDK hangs surface as `504` with `{"error": "turn timeout after 600s"}`.
+- **Validation:** missing or empty `text` → `400`.
+- **Errors:** SDK runtime errors surface as `502` with `{"error": "turn failed: <detail>"}` and the same envelope is appended to `session.jsonl` (kind: `sdk_runtime`).
+
+## How it differs from the legacy A2A sidecar
+
+The in-runner endpoint replaced the standalone A2A sidecar that the old
+CLI/TUI runtime used. For SDK agents (`kind: Agent`) the runner hosts
+`/v1/turn` itself; the `sac a2a serve` sidecar path is retained only for
+non-SDK runtimes (see [07_a2a-protocol.md](07_a2a-protocol.md)).
+
+| Aspect | Legacy `sac a2a serve` sidecar | In-runner (current) |
+|---|---|---|
+| Process | Separate `sac a2a serve` process | Asyncio task inside the SDK runner (in-container) |
+| Per-request transport | New `query()` per request — fresh conversation each time | `client.query()` on the persistent SDK client — turns share context |
+| Wire | A2A JSON-RPC `message/send` | Plain `{text, exit_after}` |
+| Concurrency | Each request spawns its own SDK call | Serial drain — turns queue |
+| Resume | None (each request is stateless) | Full — session_id persists across runs |
+
+## Wiring details
+
+The runner's argv `--a2a-port`/`--a2a-host` is set automatically by `runtimes/claude_session.py::start` from `spec.a2a.port` / `spec.a2a.host`. The handler enqueues a `TurnEnvelope` on the runner's `asyncio.Queue` and awaits `env.response`; the conversation task drains it, calls `client.query(text)`, drains `receive_response()`, and resolves the future.
+
+## Implementation files
+
+- `src/scitex_agent_container/_runners/_session_http.py` — Starlette app + uvicorn task
+- `src/scitex_agent_container/_runners/_session_inbox.py` — `TurnEnvelope` / `ShutdownEnvelope` / `make_inbox()`
+- `src/scitex_agent_container/_runners/claude_session.py::_run_conversation` — drains the inbox into the persistent `ClaudeSDKClient`
+- `tests/scitex_agent_container/_runners/test__session_http.py` — round-trip + 400 + health smoke tests
+
+## Cross-host placement
+
+The old host-side bare-Python launch (a `render_remote_launch` bash-script
+generator + `SAC_RUNNER_PREFIX` wrapper, exec'd over ssh) was **removed**
+with the bare-metal/SSH-dispatch ripout (WI-6, 2026-05-20). The runner
+only ever launches via `apptainer exec` now; there is no host-side
+`python -m ... claude_session` path.
+
+> Note: `_runners/_remote_launch.render_remote_launch` still exists as a
+> module with a unit test, but it is **not wired into any live launch
+> path** (no importers in `src/` outside its own test). Treat it as dead
+> code, not as the way agents start on remote hosts.
+
+Cross-host work goes through two mechanisms:
+
+- **`spec.host`** — pin an agent to a host (or a priority list). See
+  [11_remote-deploy.md](11_remote-deploy.md).
+- **`sac --on <peer>`** (F-CS12) — dispatch a `sac` command on a peer
+  defined in `config.yaml`'s `peers:` block.
+
+### Reaching a remote agent's `/v1/turn` — ssh-as-transport
+
+The runner binds `/v1/turn` on `127.0.0.1` inside its container — never on
+a LAN interface. A peer reaches a remote agent through ssh, resolved
+automatically by the peer helper:
+
+```python
+from scitex_agent_container.peer import post_turn
+reply = post_turn("head-mba", "your message")
+# resolves to ssh://mba:18888/v1/turn → ssh + curl on the remote loopback
+```
+
+This works for ssh aliases that aren't DNS-resolvable from the caller
+(e.g. `mba`, `head-spartan`) and survives NAT, while keeping the endpoint
+loopback-only. See [06_http-api.md](06_http-api.md) and
+[07_a2a-protocol.md](07_a2a-protocol.md).

--- a/skills-archive/scitex-agent-container/18_full-agent-delegation.md
+++ b/skills-archive/scitex-agent-container/18_full-agent-delegation.md
@@ -1,0 +1,189 @@
+---
+description: |
+  [TOPIC] Full-agent delegation via sac (vs subagent)
+  [DETAILS] How to delegate a multi-step task to *another full Claude Code agent* using sac, instead of spawning a Task-tool subagent. Covers the trade-off (full filesystem + bash + MCP vs. limited surface), the minimal YAML, lifecycle (validate → start → status → inspect → stop), prompt design, and when to choose this over Task. Use when a task needs autonomous read-write capability over many turns, parallel execution alongside the parent agent, or isolation from the parent's context budget.
+tags: [scitex-agent-container-full-agent-delegation, full-agent, claude-session, sac, vs-subagent]
+---
+
+# Full-agent delegation via sac
+
+When the parent agent needs to delegate a multi-step task to another agent
+that has the **same capabilities as itself** — full filesystem access,
+bash, all MCP tools, multi-turn iteration, independent context window —
+launch a fresh Claude Code agent through sac instead of spawning a
+Task-tool subagent.
+
+> Operational deep-dives (peer-stuck recovery, reaper fleet pattern,
+> hard/soft skill internals, observing peers via Monitor) live in the
+> sibling leaf [19_full-agent-troubleshooting.md](19_full-agent-troubleshooting.md).
+
+## Full-agent vs subagent — pick the right one
+
+| Concern | `Task` subagent | sac peer agent |
+|---|---|---|
+| Filesystem | Read/Edit/Write only | Full (Bash, NotebookEdit, …) |
+| Tools | Curated subset per agent type | Same as parent — all MCP, all built-ins |
+| Turns | One-shot reply (~minutes) | Hours to days |
+| Parent's context | Counts against parent | Independent — parent gets a small report |
+| Permission model | Inherits parent's | `bypassPermissions` available |
+| Parallel parent work | Parent blocks until reply | Parent stays free; check status async |
+| Per-agent state | Discarded after reply | Persisted under `~/.scitex/agent-container/runtime/<name>/` |
+| Cost | Same flat-rate Claude Code billing | Same flat-rate Claude Code billing |
+
+**Use a sac peer agent when**: the task is *substantial* (≥ a working
+day's worth of edits), needs *autonomous bash*, or you want the parent
+free to do other work in parallel. **Use Task** for short, well-scoped
+research or single-file edits.
+
+## Minimal YAML
+
+```yaml
+# ~/.scitex/agent-container/agents/<name>/<name>.yaml
+apiVersion: scitex-agent-container/v3
+kind: Agent
+
+metadata:
+  labels: { project: <my-project>, purpose: <one-line> }
+
+spec:
+  runtime: apptainer              # the only accepted runtime (sac is apptainer-only)
+  model: sonnet                   # alias for the latest Sonnet (4.6+)
+  workdir: /absolute/path/to/repo
+  # WARNING (F-CS8): NEVER point workdir at an umbrella directory
+  # that contains a heavy ``.claude/`` tree (e.g. ``~/proj/`` when
+  # ``~/proj/.claude/`` weighs tens of MB of hooks/skills).
+  # claude-agent-sdk auto-discovers ``<workdir>/.claude/`` and silently
+  # swallows errors when the tree is too large or contains a failing
+  # hook — every turn returns 0 tokens, no log line, heartbeat fresh.
+  # Use a project-specific subdir (e.g. ``~/proj/<this-project>/``) or
+  # ``/tmp/<scratch>/`` and reference other repos via absolute paths.
+  # ``sac agents start`` emits a stderr precheck warning when the
+  # workdir's ``.claude/`` exceeds 10 MB.
+
+  startup_commands:
+    - command: |
+        You are a SourceDeveloperAgent working on <package>.
+
+        TASK: <one paragraph>.
+
+        SCOPE: <bullets — what to do, what NOT to do>.
+
+        CONSTRAINTS:
+          - Read ~/.claude/skills/<relevant>/ first.
+          - Do not push to remote without explicit confirmation.
+          - Tests must pass before claiming DONE.
+          - If blocked by a design question, write to GITIGNORED/QUESTIONS.md
+            and stop — do NOT guess.
+
+        DELIVERABLES:
+          1. <output>
+          2. <output>
+          ...
+        Print on stdout: "DONE <name> <one-line summary>".
+
+        Begin by reading <pointer files>.
+
+  health: { enabled: true, interval: 60 }
+```
+
+The startup `command` *is* the delegation contract. Be specific:
+inputs, scope, constraints, deliverables, exit signal.
+
+## Why "peer" (not "subagent")
+
+A sac-launched agent is a **peer**, not a subordinate. With
+`spec.a2a.port` set, the agent serves `POST /v1/turn`; any other peer —
+including but not limited to the launching agent — can `sac peer
+post-turn <name> "..."` to drive a new turn into its live SDK session.
+Peers form a mesh: the launcher talks to peer A, peer A talks to peer
+B, peer B reports back to the launcher, etc. There is no hierarchy
+imposed by the runtime itself; structure is something *you* design on
+top.
+
+Contrast with the Task tool's `subagent`: a subagent runs once, replies
+to the parent, and disappears. Peers persist, accept multiple turns
+from multiple senders, and can themselves spawn further peers.
+
+## Lifecycle
+
+```bash
+# 1. Preflight (validates yaml + probes runtime deps)
+sac agents check ~/.scitex/agent-container/agents/<name>/<name>.yaml
+
+# 2. Start
+sac agents start ~/.scitex/agent-container/agents/<name>/<name>.yaml
+
+# 3. Verify it's running
+sac agents status <name>      # full status
+sac agents tail <name>        # last-N session.jsonl events (tool calls + current task)
+
+# 4. (optional) Talk to it
+sac peer post-turn <name> "How is the F2 implementation going?"
+sac a2a doctor <name>        # health probe
+
+# 5. Stop / restart
+sac agents stop <name>
+sac agents restart <name>
+```
+
+## How the agent runs — `runtime: apptainer`
+
+sac is **apptainer-only** (since 2026-05-13). `runtime: apptainer` is the
+only accepted value (`config/_validation.py` rejects everything else) —
+there is no runtime to choose between. The agent runs the
+`claude-agent-sdk` runner (`scitex_agent_container._runners.claude_session`)
+**inside** an apptainer SIF (`sac-base.sif` + relaxed directory overlay +
+uv-editable `/opt/venv-agent`), invoked via `apptainer exec`. No terminal
+multiplexer, no auto-accept, no pane scraping — but still in-container,
+not a bare host process. The legacy CLI/TUI (`claude-code`) and host-side
+bare-Python runtimes were removed.
+
+See [15_claude-session.md](15_claude-session.md) for the runner and
+container shape, and [24_image-build.md](24_image-build.md) for the SIF.
+
+## Model selection — `sonnet` vs `opus`
+
+Spell the alias, not a pinned version. `sonnet` and `opus` resolve to
+the latest production model at the time the agent connects to the SDK.
+Pin only when you need reproducibility (`claude-sonnet-4-6`,
+`claude-opus-4-7[1m]` for 1M-context Opus, etc.).
+
+| Task complexity | Default model |
+|---|---|
+| Mechanical (git commit, file rename, report formatting) | `haiku` |
+| Routine development (most peer scopes) | `sonnet` |
+| Hard reasoning, architecture, dep audits, foundation phase | `opus` (or `claude-opus-4-7[1m]` for very long-context tasks) |
+
+**Empirical lesson (2026-05-05)**: `sonnet` peers occasionally went
+idle mid-task on substantial scopes (the SDK turn returned with no
+assistant text and no tool calls). Re-spawning the same yaml on
+`claude-opus-4-7[1m]` shipped the work quickly. During foundation
+phase, prefer `opus` for non-trivial scopes — eliminates "is the model
+smart enough?" as a confounder. The cost of a failed-then-respawned
+peer is higher than launching with the larger model once.
+
+## A2A asymmetry — parent vs peers
+
+The relationship between the launcher and a peer depends on how the
+launcher is running:
+
+| Launcher kind | Outbound (drive a peer) | Inbound (receive from peer) |
+|---|---|---|
+| Another sac peer (claude-session) with `a2a.port` | `sac peer post-turn <other>` | peers can post to its `/v1/turn` |
+| **Claude Code CLI** (the human-facing supervisor) | `sac peer post-turn <peer>` (works) | **no native push** — CLI doesn't expose `/v1/turn` |
+| Plain shell script | `sac peer post-turn <peer>` (works) | no |
+
+Consequence: when the orchestrator is Claude Code CLI, peers cannot
+push state back to it. The orchestrator must **observe peers via the
+filesystem** — see [19_full-agent-troubleshooting.md](19_full-agent-troubleshooting.md)
+for the `Monitor`-based push-notification recipe.
+
+## Related
+
+- [15_claude-session.md](15_claude-session.md) — runtime details
+- [19_full-agent-troubleshooting.md](19_full-agent-troubleshooting.md) — stuck-peer recovery, reaper pattern, hard/soft skills, Monitor over polling
+- [07_a2a-protocol.md](07_a2a-protocol.md) — agent-to-agent message bus
+- [10_cli.md](10_cli.md) — full sac CLI reference
+- [20_env-vars.md](20_env-vars.md) — environment variables consumed by runners
+- `~/.claude/skills/ywatanabe/07_agent-rules/07_orchestrator_02_sac-peer-mesh.md` — the orchestrator-side counterpart of this leaf
+- `~/proj/scitex-agent-container/GITIGNORED/FEATURE_REQUESTS.md` — F-CS1..F-CS6 pending sac improvements (parameterised fleet, autonomous loop, verifier kind, A2A ACL, runtime rename)

--- a/skills-archive/scitex-agent-container/19_full-agent-troubleshooting.md
+++ b/skills-archive/scitex-agent-container/19_full-agent-troubleshooting.md
@@ -1,0 +1,117 @@
+---
+description: |
+  [TOPIC] Full-agent (sac peer) troubleshooting — operational recipes
+  [DETAILS] Companion to 18_full-agent-delegation.md. Operational deep-dives for running sac peer fleets in practice: observing peers via Monitor (push notifications over polling), hard/soft skill mode internals, the reaper pattern for fleets that don't self-exit, stuck-peer failure modes (idle SDK turns, registry-vs-reality drift, empty `--mission` results), and a consolidated common-pitfalls table. Use when 18_*.md got you started and you now need to diagnose a real peer that misbehaved or scale out a fleet.
+tags: [scitex-agent-container-full-agent-troubleshooting, full-agent, claude-session, sac, fleet, debugging]
+---
+
+# Full-agent (sac peer) troubleshooting
+
+This leaf is the operational companion to
+[18_full-agent-delegation.md](18_full-agent-delegation.md). 18 covers
+the *contract* (when to delegate, YAML, lifecycle); this one covers
+*what goes wrong in practice* and the patterns that fix it.
+
+## Observing peers — Monitor over polling
+
+Don't poll `heartbeat.json` in a tight loop. Use the parent's
+`Monitor` tool with `tail -F` on each peer's `session.jsonl` to get
+push notifications the moment a peer emits an assistant line, says
+`DONE`/`BLOCKER`, or ends a turn:
+
+```bash
+PEER_RUNTIME=$HOME/.scitex/agent-container/runtime
+for p in <peer1> <peer2> <peer3>; do
+  tail -F $PEER_RUNTIME/$p/session.jsonl 2>/dev/null \
+    | python3 -u -c "
+import json, sys
+for L in sys.stdin:
+    try: d=json.loads(L)
+    except: continue
+    t=d.get('type','?'); text=d.get('text','') or ''
+    if t=='assistant' and text.strip():
+        if 'DONE' in text or 'BLOCKER' in text:
+            print(f'[$p] *** ' + text.strip()[:300], flush=True)
+        else:
+            print(f'[$p] said: ' + text.strip()[:200], flush=True)
+    elif t=='result':
+        print(f'[$p] turn ended', flush=True)
+" &
+done
+wait
+```
+
+Wrap this whole block in a `Monitor` invocation. Each notification
+arrives in chat as it happens, no fixed-interval `ScheduleWakeup`
+needed.
+
+Why this matters: when the orchestrator is Claude Code CLI, peers
+cannot push state back to it (no `/v1/turn` endpoint on the CLI side —
+see "A2A asymmetry" in 18). Filesystem `tail -F` is the supported
+push channel.
+
+## Skill delivery (files under `to_home/.claude/skills/`)
+
+`spec.skills` was **removed in v3** — the validator rejects it with a
+redirect to the file-based layout. Skills are now plain directories
+under the agent's `to_home/.claude/skills/<skill-id>/` and are
+auto-discovered by the SDK at session start.
+
+| Mode | How to declare it | What materialises into the container | When to use |
+|---|---|---|---|
+| **hard** (required) | drop `to_home/.claude/skills/<id>/SKILL.md` + add the id to `metadata.labels.skills` (CSV) | `@$HOME/.claude/skills/<id>/SKILL.md` `@-import` in the generated CLAUDE.md so the SDK inlines content at session start | invariants the agent must apply (procedure, validity gate, security rule) |
+| **soft** (available) | drop the same files but omit the id from `metadata.labels.skills` | the SDK still auto-discovers `$HOME/.claude/skills/<id>/` and loads it on demand; no `@-import` in CLAUDE.md | references / examples / optional patterns |
+
+Delivery is handled by `runtimes/_to_home.py::deploy_to_home`
+(materialises the directory) and `setup_claude_md` (writes the
+`@-import` lines for ids listed in `metadata.labels.skills`). See
+[25_claude-setup-delivery.md](25_claude-setup-delivery.md) for the
+end-to-end pipeline.
+
+## Reaper pattern (when delegating multiple agents)
+
+If the parent launches a *fleet* of peer agents (one per capsule, per
+PR, per dataset), runners do not auto-exit when their mission ends — the
+SDK loop keeps polling for new instructions. To free slots:
+
+1. Have each agent write a sentinel file (`workdir/data/results/score.json`)
+   on completion.
+2. Run a watchdog (`sleep 30 && pgrep`) that kills runners whose sentinel
+   indicates done. See `paper-scitex-clew/GITIGNORED/FAILED_PATTERNS.md`
+   §6 for the failure mode and the schema-tolerant detection logic.
+
+## Stuck-peer failure modes
+
+The SDK loop is forgiving — it almost never crashes loudly. Instead,
+peers go quiet in a small handful of recognisable ways:
+
+| Symptom | Likely cause | First-line fix |
+|---|---|---|
+| Peer goes idle mid-task (no new assistant text, heartbeat still fresh) | model alias under-provisioned, or context drift | `sac peer post-turn <name> "Continue from where you left off..."`; if that fails, escalate the same yaml to `model: opus` (or `claude-opus-4-7[1m]`) |
+| Empty `result` after `--mission` (no assistant text, no tool calls) | model alias not resolving or prompt rejected silently | stop, restart with a shorter mission and `model: opus` |
+| `sac agents status` says `stopped` but `heartbeat.json` is fresh | sac registry-vs-reality drift | trust heartbeat over registry; `sac agents restart` only if heartbeat is also stale |
+| Long startup_command timing out | the SDK does ONE turn per `--mission` then idles | drive subsequent turns with `sac peer post-turn` rather than packing everything into the mission |
+| `nohup bash` loses login PATH → `sac` not found on the remote | login env not sourced | `bash -lc 'setsid nohup …'` or hard-code `~/.env-3.11/bin/sac` |
+
+Once you know which row you're in, the parent's `Monitor` view of
+`session.jsonl` will usually confirm — a "[result] turn ended" with no
+preceding "[assistant]" line is the signature of the empty-`--mission`
+mode.
+
+## Common pitfalls
+
+| Pitfall | Fix |
+|---|---|
+| `/tmp` fills mid-run — "No space left on device" during `pytest`, coverage XML, or tmp-heavy fixtures | a `--containall` container's `/tmp` is a 64 MB session tmpfs. sac now relocates it onto host disk by default via `spec.apptainer.tmpfs_size` (default `"2G"`) → `--workdir <state_dir>/tmp-scratch`. If you see this on an old spec, bump `tmpfs_size` or confirm it isn't set to `""` (opt-out). |
+| Heavy data under `~` on Spartan → quota | put workdirs under `/tmp` or project FS (`/data/gpfs/projects/<punim>/...`) |
+| Re-launching an already-passed agent | parent's done-detection must accept all score-schema variants |
+| Subagent-style narrow prompt | include "you are a *full* agent — use Bash, run tests, commit" explicitly |
+| Forgetting the exit signal | always require the agent to print `DONE <name> …` on stdout — gives the parent a clean handle |
+| Passing oracle path "for the verifier only" to an agent peer | honor-system masking — agent runs as same user, mere knowledge of path enables anchoring. Make the verifier a separate peer with separate identity; don't pass the path. |
+
+## Related
+
+- [18_full-agent-delegation.md](18_full-agent-delegation.md) — the contract this leaf troubleshoots
+- [15_claude-session.md](15_claude-session.md) — runtime details
+- [07_a2a-protocol.md](07_a2a-protocol.md) — agent-to-agent message bus
+- [40_troubleshooting.md](40_troubleshooting.md) — package-wide troubleshooting (multiplexer, auto-accept, etc.)

--- a/skills-archive/scitex-agent-container/20_env-vars.md
+++ b/skills-archive/scitex-agent-container/20_env-vars.md
@@ -1,0 +1,158 @@
+---
+description: |
+  [TOPIC] scitex-agent-container — Environment Variables
+  [DETAILS] Environment variables read by scitex-agent-container at import / runtime. Follow SCITEX_<MODULE>_* convention — see general/10_arch-environment-variables.md..
+tags: [scitex-agent-container-env-vars]
+---
+
+# scitex-agent-container — Environment Variables
+
+With ~40 sac-owned vars in source, this leaf groups them by purpose. For the
+exact authoritative list, run the audit snippet at the bottom.
+
+## Naming — `SAC_*` and `SCITEX_AGENT_CONTAINER_*` are interchangeable
+
+Every sac-owned env var has TWO equivalent names: a short `SAC_<X>` form
+and a long `SCITEX_AGENT_CONTAINER_<X>` form. Either reads to the same
+slot. The helper at `scitex_agent_container._env.getenv("X")` reads
+both.
+
+**Conflict detection.** If both forms are set with **different** values,
+sac raises `SacEnvConflict` at startup rather than silently picking one
+— a drifted alias is almost always a bug:
+
+```
+SAC_HUB_URL=https://hub-a.example
+SCITEX_AGENT_CONTAINER_HUB_URL=https://hub-b.example
+# → SacEnvConflict: SAC_HUB_URL=...hub-a... vs SCITEX_AGENT_CONTAINER_HUB_URL=...hub-b...
+```
+
+When set to the same value, either form (or both) is accepted.
+
+In every table below, the `Variable` column lists the long form for
+readability; the short `SAC_*` alias is always available.
+
+## Container identity / metadata
+
+| Variable | Purpose | Default | Type |
+|---|---|---|---|
+| `SCITEX_AGENT_CONTAINER_ID` | Stable container ID (auto-assigned on first boot). | auto | string |
+| `SCITEX_AGENT_CONTAINER_NAME` | Human-readable container name. | auto | string |
+| `SCITEX_AGENT_CONTAINER_HOSTNAME` | Override container hostname. | host | string |
+| `SCITEX_AGENT_CONTAINER_ROLE` | Role in fleet (e.g. `worker`, `observer`). | `worker` | string |
+| `SCITEX_AGENT_CONTAINER_META_VERSION` | Metadata schema version. | current | string |
+| `SCITEX_AGENT_CONTAINER_AGENT` | Agent engine (`claude` / `codex` / ...). | `claude` | string |
+| `SCITEX_AGENT_CONTAINER_AGENT_META_SCRIPT` | Path to agent-metadata generator script. | bundled | path |
+| `SCITEX_AGENT_CONTAINER_MODEL` | LLM model ID injected into the agent. | `—` | string |
+| `SCITEX_AGENT_CONTAINER_SCREEN_NAME` | GNU-screen session name attached to the agent. | auto | string |
+| `SAC_NAME` | Short agent identifier (used in telemetry). | auto | string |
+
+## Paths
+
+Canonical agent YAML location (fleet shared via dotfiles):
+`~/.scitex/agent-container/agents/<name>/<name>.yaml` — the dir-as-SSoT
+resolver walks per-host `<host>/agents/`, then `shared/agents/`, then
+`agents/`. See `01_config-v3.md` for the full search path.
+
+| Variable | Purpose | Default | Type |
+|---|---|---|---|
+| `SCITEX_AGENT_CONTAINER_CONFIG_PATH` | Path to the YAML config. | bundled | path |
+| `SCITEX_AGENT_CONTAINER_YAML_DIRS` | Extra dirs scanned for YAML overrides (colon-separated). | unset | string (paths) |
+| `SCITEX_AGENT_CONTAINER_REGISTRY_DIR` | Directory where the container registers its presence. | `~/.scitex/agent-container/runtime/registry` | path |
+| `SCITEX_AGENT_CONTAINER_RUNTIME_DIR` | Per-agent runtime state root for the claude-session runner (pid / heartbeat.json / session.jsonl / quota.json / session_id). | `~/.scitex/agent-container/runtime` | path |
+| `SCITEX_AGENT_CONTAINER_SLURM_STATE_DIR` | Directory for SLURM-job state handoff. | `~/.scitex/agent-container/slurm` | path |
+| `SAC_CACHE_DIR` | Agent-local cache directory. | `~/.cache/scitex-agent` | path |
+
+## Credentials
+
+Auth precedence (highest → lowest) in `runtimes/_sdk_common.py::provision_anthropic_auth`:
+
+1. `ANTHROPIC_API_KEY` already in env (caller pre-set; SDK uses it as-is).
+2. `~/.claude/.credentials.json` Pro/Max OAuth (preferred — no per-token billing).
+3. `SAC_ANTHROPIC_API_KEY` (sac-namespaced handoff). Accepts either form — `sk-ant-oat*` is synthesised back into a credentials file (OAuth path), `sk-ant-api*` is bridged straight to `ANTHROPIC_API_KEY`.
+
+**Spartan compute-node gotcha (2026-05-03):** the user's `~/.bash.d/secrets/` exports `SAC_ANTHROPIC_API_KEY` from `~/.claude/.credentials.json`. If the credentials file is stale, the runner can fail with "401 Invalid auth" or "Command failed exit 1". Fix: `unset SAC_ANTHROPIC_API_KEY` (or refresh credentials with `claude /login`) in the wrapper that starts the runner on Spartan.
+
+| Variable | Purpose | Default | Type |
+|---|---|---|---|
+| `ANTHROPIC_API_KEY` | Read directly by the SDK if pre-set. The runner does NOT export this; the SDK calls `claude` CLI which falls back to `~/.claude/.credentials.json` OAuth when this is unset. | `—` | string |
+| `SAC_ANTHROPIC_API_KEY` | Sac-namespaced auth handoff. Accepts both OAuth (`sk-ant-oat*`) and API-key (`sk-ant-api*`) forms; runner detects by prefix. Local shells populate via `sac dev credential2apikey`; CI populates via the GitHub Actions secret of the same name (rotate with `sac dev upload-apikey-from-credentials-to-github`). | `—` | string |
+| `SCITEX_AGENT_CONTAINER_TELEGRAM_BOT_TOKEN` | Telegram bot token for agent bridge. | `—` | string |
+
+## Context compaction
+
+| Variable | Purpose | Default | Type |
+|---|---|---|---|
+| `SAC_COMPACT_ENABLED` | Enable auto-compaction of context window. | `true` | bool |
+| `SAC_COMPACT_THRESHOLD_PCT` | Trigger compaction at this context % used. | `80` | int |
+| `SAC_COMPACT_MIN_DROP_PCT` | Minimum % that must drop per pass. | `20` | int |
+| `SAC_COMPACT_MIN_INTERVAL_S` | Minimum seconds between compactions. | `300` | int |
+| `SAC_COMPACT_TIMEOUT_S` | Timeout per compaction attempt. | `60` | int |
+
+## Action / probe / heartbeat timing
+
+| Variable | Purpose | Default | Type |
+|---|---|---|---|
+| `SAC_ACTION_RETENTION_DAYS` | How many days to keep action logs. | `30` | int |
+| `SAC_ACTION_SNAPSHOT_MAX_CHARS` | Truncate action snapshots above this size. | `8192` | int |
+| `SAC_AUTO_RESPONSE_TICK_S` | Auto-response poll interval. | `5` | int |
+| `SAC_KEY_DELAY_S` | Delay between simulated keystrokes. | `0.05` | float |
+| `SAC_SUBMIT_SETTLE_S` | Seconds to wait after submitting a prompt. | `1.0` | float |
+| `SAC_PROBE_INTERVAL_S` | Liveness probe interval. | `30` | int |
+| `SAC_PROBE_POLL_INTERVAL_S` | Fine-grained poll step inside a probe. | `1` | int |
+| `SAC_PROBE_TIMEOUT_S` | Probe timeout. | `10` | int |
+| `SCITEX_HEARTBEAT_INTERVAL` | Ecosystem-wide heartbeat interval (fleet-shared). | `60` | int |
+
+## Hook context (read-only, set by the harness)
+
+| Variable | Purpose |
+|---|---|
+| `SCITEX_HOOK` | Name of the hook currently running. |
+| `SCITEX_HOOK_CTX_*` | Per-hook context keys (dynamic prefix). |
+
+## Hub / fleet integration (optional)
+
+sac is fleet-agnostic. To join a fleet hub, set `SAC_HUB_URL` (or the
+long form `SCITEX_AGENT_CONTAINER_HUB_URL`) to the hub endpoint. **No
+default** — when unset, sac runs as a standalone agent and skips hub
+calls. When set but unreachable, sac logs and continues; it never hard-
+fails on hub absence.
+
+| Variable | Purpose | Default | Type |
+|---|---|---|---|
+| `SCITEX_AGENT_CONTAINER_HUB_URL` | Fleet hub endpoint (e.g. an orochi instance). | unset (standalone) | URL |
+| `SCITEX_AGENT_CONTAINER_HUB_TOKEN` | Bearer token for the hub. | `—` | string |
+
+Downstream fleet implementations (e.g. scitex-orochi) own their own env
+namespace; sac does not read fleet-specific vars directly.
+
+## Host listen — SAC-from-SAC broker
+
+When an agent runs INSIDE an apptainer SIF, ``sac agents start <child>``
+cannot ``apptainer exec`` locally (no nested apptainer on the supported
+HPC shape). The runtime injects the bare-host ``sac listen`` address +
+bearer into every container so the in-SIF CLI can POST the spawn RPC to
+the host instead; the host re-runs ``check_spawn``, records the
+``caller → child`` lineage edge, and shells the real ``sac agent
+start`` against the bare host's apptainer.
+
+| Variable | Purpose | Default | Type |
+|---|---|---|---|
+| `SAC_LISTEN_BASE_URL` | Host-stable ``sac listen`` base URL the in-SIF CLI POSTs spawn requests against (also used by the in-container channel adapter to subscribe to the bus). Auto-injected by the apptainer runtime from ``listen.host`` / ``listen.port`` in ``~/.scitex/agent-container/config.yaml``. | `http://127.0.0.1:7878` | URL |
+| `SAC_LISTEN_BEARER` | Bearer token presented as ``Authorization: Bearer ...`` to the host listen server. Auto-injected from the host's bearer-token file; required when ``server:sac`` is in ``spec.claude.channels`` (the runtime fails loud at launch otherwise). | `—` | string |
+
+Fail-loud: when the broker runs in a SIF and ``SAC_LISTEN_BASE_URL`` is
+unset, ``sac agents start`` raises ``InSifBrokerError`` (apptainer
+runtime forgot to inject it). Never silently downgrades to "skip the
+broker" / "try local apptainer anyway".
+
+## Feature flags
+
+- **opt-out:** `SAC_COMPACT_ENABLED=false` disables context compaction.
+- No opt-in flags in this package.
+
+## Audit
+
+```bash
+grep -rhoE 'SCITEX_[A-Z0-9_]+' $HOME/proj/scitex-agent-container/src/ | sort -u
+```

--- a/skills-archive/scitex-agent-container/21_cli-startup-budget.md
+++ b/skills-archive/scitex-agent-container/21_cli-startup-budget.md
@@ -1,0 +1,99 @@
+---
+description: |
+  [TOPIC] scitex-agent-container — CLI startup-time budget
+  [DETAILS] Why ``sac --help`` and tab-completion stay under 500 ms: the LazyGroup pattern in cli_pkg/_main.py, the LAZY_SHORT_HELPS cache, deferred shell-completion attach, and the pytest gate that prevents regressions.
+tags: [scitex-agent-container-cli-startup-budget]
+---
+
+# CLI startup budget — 500 ms ceiling
+
+`sac` is a daily-driver command. Every Tab press in a user shell
+re-runs the entry point, so a 2 s import graph is felt as visible
+lag. We hold a 500 ms ceiling on `sac --help` cold-start (Python
+boot + click + entry-point group + `--help` rendering, no
+subcommand work). A pytest test enforces it; this doc explains the
+mechanism so the rule is grokkable, not just a magic number.
+
+## Why this matters
+
+Tab completion and `--help` only need command **names** and
+**short_help strings**. They never invoke a subcommand. Importing the
+implementation module of every subcommand at entry-point load time is
+pure waste in the common path.
+
+Measured before LazyGroup: `time scitex-agent-container --help` ≈
+**2.5 s** (most of it `cli_pkg/_main` eagerly importing 30+
+subcommand modules, each pulling in rich/runtimes/a2a/_lifecycle/…).
+
+After LazyGroup: **~400 ms** (Python startup ~100 ms, click +
+LazyGroup ~50 ms, `_helpers` + rich ~150 ms, `--help` rendering
+~30 ms, headroom for slow disks).
+
+## How LazyGroup works
+
+`cli_pkg/_lazy_group.py` defines `LazyGroup`: a `click.Group`
+subclass that holds two registries instead of importing subcommands
+at module top.
+
+* `LAZY_COMMANDS = {"agent": "scitex_agent_container.cli_pkg.agent_group:agent_group", …}`
+  — visible top-level commands. The module is only imported when
+  `get_command(name)` is actually called (invocation or `--help <name>`).
+* `LAZY_RENAMED = {"start": ("…lifecycle_cmds:start", "sac agents start"), …}`
+  — legacy F-CS13 redirects. Same lazy mechanism; the renamed wrapper
+  is built on demand and cached.
+* `LAZY_SHORT_HELPS = {"agent": "Agent lifecycle, …", …}` — mirror of
+  each command's short_help, populated by hand. Without it,
+  `format_commands` would call `get_command(name).get_short_help_str()`
+  for every row, importing every module just to render `--help`.
+
+`format_commands` is overridden to read from `LAZY_SHORT_HELPS`
+directly. Eager / unmapped names fall back to per-command lookup.
+
+`scitex_dev._cli._completion.attach_shell_completion` is also
+deferred: it adds two top-level commands (`install-shell-completion`,
+`print-shell-completion`) but pulls in the full linter graph
+(~490 ms). `_MainGroup.get_command` triggers `_attach_completion()`
+only when one of those names is actually invoked — `--help` and tab
+completion list the names from the cache and skip the import.
+
+## Adding a new top-level command
+
+1. Add the entry to `LAZY_COMMANDS` in `cli_pkg/_main.py`.
+2. Add its `short_help` to `LAZY_SHORT_HELPS` in the same class.
+3. If it's a renamed legacy alias, use `LAZY_RENAMED` instead and
+   give it a hidden short_help (or omit — renamed entries are hidden
+   from `--help` and tab completion).
+4. Run `pytest tests/integration/test_cli_startup_budget.py` to
+   confirm the budget is still green.
+
+To refresh `LAZY_SHORT_HELPS` after editing a subcommand's docstring,
+re-run the snippet at the top of `cli_pkg/_main.py` (or just inspect
+`cmd.get_short_help_str()` from a Python REPL).
+
+## Why not …
+
+* **Auto-discovery via importlib.metadata entry-points.** Same
+  one-import-per-row cost, just spelled differently.
+* **Click's `MultiCommand.list_commands` returning a generator.** The
+  formatter still calls `get_command` on each name; the win is on
+  not-importing-everything-immediately, not on enumeration.
+* **Top-level `from .x import y` with `lazy_loader`.** Adds a
+  dependency for a single-file refactor.
+
+## Test enforcement
+
+`tests/integration/test_cli_startup_budget.py` measures cold-start
+time of `scitex-agent-container --help` and asserts it's below
+**500 ms** — a flat ceiling, same on a dev box and on CI.
+
+The timing loop runs in a *lean* Python child, not in the pytest
+process: it spawns `sac --help`, times it with `perf_counter`, and
+reports the floor of several runs. Measuring from the bloated pytest
+interpreter (typeguard + hypothesis + playwright + coverage tracing,
+all resident) inflated the wall clock by ~0.3 s — fork/scheduler tax
+of a large parent address space, not a CLI regression. That artifact
+was the historical CI flake. The child env is also scrubbed of
+`COVERAGE_PROCESS_START` / `COVERAGE_FILE` so the coverage `.pth`
+shim doesn't eagerly import `coverage` in the grandchild (it only
+imports inside that guard now). Set `SAC_STARTUP_BUDGET_S` to
+override the threshold (default: 0.5).

--- a/skills-archive/scitex-agent-container/22_host-passthrough.md
+++ b/skills-archive/scitex-agent-container/22_host-passthrough.md
@@ -1,0 +1,139 @@
+---
+description: |
+  [TOPIC] Host filesystem + git/gh access for SDK agents.
+  [DETAILS] How to give an SDK agent precise (or broad) access to host
+  paths via spec.mounts, spec.user, and spec.env — three orthogonal
+  primitives, no special "passthrough" flag.
+tags: [scitex-agent-container-host-passthrough]
+---
+
+# Host filesystem access for SDK agents
+
+The default sac SDK runner is **isolated**: only ``/work`` (workspace)
+and ``/state`` (sac state) plus the agent's auth credentials are mounted
+inside the container. Spawn an agent with a prompt that says "open
+``/home/me/proj/foo/README.md``" and it'll fail with "No such file or
+directory" because that path doesn't exist inside the container.
+
+Three YAML primitives give an SDK agent host-shaped access. Use them
+together when you need full path-mirroring (orchestrators), or just
+``spec.mounts`` alone when you want a worker scoped to a single repo.
+
+## ``spec.mounts`` — declarative bind mounts
+
+```yaml
+spec:
+  mounts:
+    - { src: ~/proj/scitex-stats, dst: ~/proj/scitex-stats, mode: rw }
+    - { src: /data/big-corpus,    dst: /data/big-corpus,    mode: ro }
+```
+
+Each entry becomes ``--mount type=bind,src,dst[,readonly]``. ``~`` and
+``$VAR`` are expanded on ``src`` so YAMLs stay portable across
+machines. ``mode`` defaults to ``rw``.
+
+If you don't list a path here, the agent **cannot see it**. That is the
+worker's primary safety boundary — no read-only re-binding, no opt-out
+flag. Just don't mount what the agent shouldn't reach.
+
+## ``spec.user`` — who the container runs as
+
+```yaml
+spec:
+  user: host         # operator's UID:GID — files written from inside
+                     # land as your user on the host
+  # OR
+  user: "1000:1000"  # explicit numeric
+  # OR (default)
+  user: ""           # image's USER (typically `agent`, uid 1000)
+```
+
+Required when ``spec.mounts`` grants host paths and you want writes
+from the agent to be owned by you, not by the image's `agent` user.
+
+## ``spec.env`` — environment variable forwarding
+
+```yaml
+spec:
+  env:
+    HOME: ${HOME}      # tools that read $HOME pick the operator's home
+    GH_TOKEN: ${GH_TOKEN}
+```
+
+When ``HOME`` is set, sac mounts the credential file (Anthropic
+OAuth) at ``${HOME}/.claude/.credentials.json`` so ``Path.home()``
+inside the container resolves to the same path the cred file is at.
+Without ``env.HOME``, the cred file lands at the image default
+(``/home/agent/.claude/.credentials.json``).
+
+## Composition examples
+
+### Worker scoped to one repo
+
+```yaml
+spec:
+  runtime: docker
+  image: scitex-agent-container:scitex
+  mounts:
+    - { src: ~/proj/scitex-stats, dst: ~/proj/scitex-stats, mode: rw }
+  startup_commands:
+    - command: |
+        Run scitex-dev ecosystem audit-all scitex-stats and fix any
+        violations. Commit and push when green.
+```
+
+The agent sees only scitex-stats and its own workspace + state. It
+cannot read sac source, other agents' definitions, your dotfiles,
+or any other project. Container's `agent` user (uid 1000) writes
+land as `agent` on the host filesystem — fine if the repo dir is
+group-writable or the operator runs sac as uid 1000 herself.
+
+### Orchestrator (host-shaped, host-owned)
+
+```yaml
+spec:
+  runtime: docker
+  image: scitex-agent-container:scitex
+  user: host                      # writes land as operator
+  env:
+    HOME: ${HOME}                  # tools resolve $HOME to host
+  mounts:
+    - { src: ~/.scitex/agent-container/agents,
+        dst: ~/.scitex/agent-container/agents, mode: ro }
+    # ^ orchestrator reads other agents' yamls to spawn them
+    - { src: ~/proj, dst: ~/proj, mode: rw }
+    # ^ broad project access; only set this for trusted orchestrators
+```
+
+## Required image bits
+
+The default ``scitex-agent-container:scitex`` image installs
+``gh`` (GitHub CLI), ``git``, and ``openssh-client`` so an agent given
+host-shaped access can immediately query CI, push commits over SSH,
+and pull skill content from private repos. If you build a custom
+image, keep these tools.
+
+## Watching the agent
+
+```bash
+sac agents start polish-stats
+sac agents tail polish-stats -n 30      # rendered transcript
+sac agents tail polish-stats --json     # raw session.jsonl records
+sac agents health polish-stats         # is it alive?
+sac agents stop polish-stats
+```
+
+## Caveats
+
+* **No magic flag.** There is no ``home_passthrough``, ``protect_self``,
+  or similar shortcut. ``spec.mounts`` + ``spec.user`` + ``spec.env``
+  are the only mechanisms. If a path isn't in ``spec.mounts``, the
+  agent cannot see it.
+* **UID alignment.** When ``spec.user: host`` is set, the container's
+  user is named ``agent`` in ``/etc/passwd`` even though it runs at
+  the operator's UID. Tools that read username via
+  ``getpass.getuser()`` may report ``agent`` while ``id -u`` reports
+  the host UID. Filesystem semantics still work.
+* **Multi-operator hosts.** ``${HOME}`` resolves to whoever invoked
+  sac. On shared machines, prefer explicit absolute paths in
+  ``spec.mounts`` for repeatable behaviour.

--- a/skills-archive/scitex-agent-container/23_telegram-integration.md
+++ b/skills-archive/scitex-agent-container/23_telegram-integration.md
@@ -1,0 +1,95 @@
+---
+description: |
+  [TOPIC] Per-agent Telegram bot wake contract — how an idle SDK agent picks up an inbound Telegram message.
+  [DETAILS] Each agent runs its OWN claude-code-telegrammer stdio MCP (declared in to_home/.mcp.json under the key `claude-code-telegrammer`). sac's runner injects `CLAUDE_CODE_TELEGRAMMER_TURN_URL=http://127.0.0.1:<a2a_port>/v1/turn` into that MCP's env when `spec.claude.channels` contains `server:claude-code-telegrammer` AND `spec.a2a.port` is set. The standalone telegrammer poller POSTs each inbound to that URL so an IDLE agent wakes (push ≡ in-session channel). The legacy in-sac `_telegram/` bridge was dropped (`refactor(telegram): drop telegram subsystem from sac`) — this skill documents the current per-agent path + the loud diagnostics that fire when any gate fails.
+tags: [scitex-agent-container-telegram-integration]
+---
+
+# Telegram integration — per-agent wake contract
+
+## Design
+
+Each agent runs its OWN Telegram bot via a `claude-code-telegrammer` stdio
+MCP declared in the spec's `to_home/.mcp.json`. The in-sac `_telegram/`
+bridge from earlier phases was retired (`refactor(telegram): drop telegram
+subsystem from sac`). The current path:
+
+1. Operator's `spec.claude.channels` lists `server:claude-code-telegrammer`.
+2. Operator's `to_home/.mcp.json` declares a stdio MCP under the key
+   `claude-code-telegrammer` (the bun/ts standalone telegrammer process).
+3. sac's runner (`runtimes/_sdk_channels.apply_channels`) injects
+   `CLAUDE_CODE_TELEGRAMMER_TURN_URL=http://127.0.0.1:<spec.a2a.port>/v1/turn`
+   into that MCP entry's env when (1) AND (2) hold AND `spec.a2a.port` is
+   set. Operator-pre-set value wins.
+4. Claude Code spawns the telegrammer MCP as a stdio subprocess.
+5. The telegrammer JS poller (`ts/lib/wake.ts` in the standalone repo) reads
+   `CLAUDE_CODE_TELEGRAMMER_TURN_URL` and on each allowed inbound POSTs the
+   message to that URL.
+6. The runner's `/v1/turn` handler (`_runners/_session_http.py::serve_inbound`)
+   queues a `TurnEnvelope` onto an `asyncio.Queue`. The conversation task
+   drains it, drives a turn through the persistent SDK client, replies.
+
+`<channel>` rendering in the AGENT's session requires the dev-channels
+flag, which `apply_channels` sets to the comma-joined channel set whenever
+ANY `spec.claude.channels` entry is present — the foreign-channel
+generalisation guarded by `test__sdk_channels.py`.
+
+## Required spec shape
+
+```yaml
+spec:
+  a2a:
+    port: auto          # MUST NOT be null/missing; the /v1/turn endpoint
+                        # is the wake URL the telegrammer POSTs to.
+  claude:
+    channels:
+      - server:claude-code-telegrammer  # exact string (whitespace tolerated)
+  # to_home/.mcp.json (sibling file) must contain:
+  #   "mcpServers": {"claude-code-telegrammer": {...stdio entry...}}
+```
+
+The MCP entry key MUST be `claude-code-telegrammer` (literal). Any other
+key — `telegrammer`, `claude-telegrammer`, `tg-bot`, etc. — bypasses the
+env injection and the JS poller has no wake URL.
+
+## Failure surface + diagnostics (bug #41 hardening, 2026-06-07)
+
+Each silent-skip in `_wire_telegrammer_wake` used to look identical at the
+operator level: "I message my bot, the agent doesn't reply." The wake
+helper now LOGs every skip path; the host-side preflight
+`validate_telegrammer_wake_wiring` (called from `_lifecycle/_start.py`)
+HARD-FAILS the start when the wiring provably won't succeed.
+
+| Failure | Where it surfaces | Operator fix |
+|---|---|---|
+| `server:claude-code-telegrammer` absent from channels | Silent no-op (intentional — channel not requested) | Add the channel to spec.claude.channels |
+| `spec.a2a.port` is null | `validate_telegrammer_wake_wiring` raises `TelegrammerWakeWiringError` at `sac agents start` time | Set spec.a2a.port to 'auto' or an explicit free int |
+| `to_home/.mcp.json` missing the `claude-code-telegrammer` MCP entry | Runner-side ERROR log: "no MCP entry keyed 'claude-code-telegrammer' found" | Add the MCP entry under the canonical key |
+| `to_home/.mcp.json` entry malformed (`env` not a dict) | Runner-side WARN log | Fix the entry's `env` to be an object |
+| Operator pre-set `CLAUDE_CODE_TELEGRAMMER_TURN_URL` | Runner-side INFO log: "pre-set by operator … not overridden" | Verify the pre-set URL actually points at THIS agent's /v1/turn |
+| Wake URL successfully wired | Runner-side INFO log: "telegrammer wake wired" | Nothing — verify by tailing runner stderr |
+
+## How to verify on a running agent
+
+```bash
+# 1. Confirm the channel + port are configured.
+sac agents inspect <name> --json | jq '.spec.claude.channels, .spec.a2a.port'
+
+# 2. Confirm the MCP entry key.
+jq '.mcpServers["claude-code-telegrammer"]' \
+  ~/.scitex/agent-container/agents/<name>/to_home/.mcp.json
+
+# 3. Tail the runner stderr for the wake-wiring log.
+sac agents logs <name> --stderr | grep -i 'telegrammer wake'
+
+# 4. End-to-end: message the bot when the agent is idle, watch for a reply.
+```
+
+## Out of scope (not in this repo)
+
+The JS-side telegrammer (`ts/lib/wake.ts`) is in the standalone
+[claude-code-telegrammer](https://github.com/ywatanabe1989/claude-code-telegrammer)
+repo. If the env var is set but the agent still doesn't wake, the JS
+poller may not be reading + POSTing — file that upstream. The Python-side
+INFO log "telegrammer wake wired" confirms sac did its half; an idle
+agent that still doesn't wake after that points at the JS side.

--- a/skills-archive/scitex-agent-container/24_image-build.md
+++ b/skills-archive/scitex-agent-container/24_image-build.md
@@ -1,0 +1,139 @@
+---
+description: |
+  [TOPIC] scitex-agent-container — agent image build & rebuild (apptainer .sif)
+  [DETAILS] Where sac-base / sac-scitex .def + .sif live (dotfiles containers/), how sac is installed from git@develop, the `sac image build scitex` / `scitex-container build` commands, the @develop→@tag stable pin, and the gotcha that runner/channel changes do NOT reach running agents until the image is rebuilt.
+tags: [scitex-agent-container-image-build]
+---
+
+# Image build & rebuild (apptainer .sif)
+
+The container images agents run are **apptainer** `.sif` files, defined in the
+dotfiles (canonical SSoT), **not** in this repo:
+
+```
+~/.dotfiles/src/.scitex/agent-container/containers/
+  sac-base/sac-base.def       sac-base.sif      # base layer (git, uv, node, …)
+  sac-scitex/sac-scitex.def   sac-scitex.sif    # default image (sac + scitex[all])
+  overlays/
+```
+
+An agent uses `sac-scitex` unless its `spec.yaml` sets `spec.image`.
+
+## How sac gets into the image
+
+`sac-scitex.def` (`%post`) installs the runner from **git, branch-pinned**:
+
+```bash
+uv pip install --python /opt/venv-sac/bin/python \
+    ... claude-agent-sdk "scitex[all]" \
+    "git+https://github.com/ywatanabe1989/scitex-agent-container.git@develop"
+```
+
+So the image is a **point-in-time snapshot of `@develop`** taken at build time —
+NOT an editable mount of the host checkout.
+
+## ⚠️ Critical gotcha — rebuild to ship runner/channel changes
+
+A merged change to the runner / channel adapter (e.g. a new `--channels` flag, the
+`sac mcp channel` auto-register, the auto-ack) **does NOT reach running agents**
+until the image is rebuilt. The in-container `/opt/venv-sac` runner stays at
+whatever `@develop` was when the `.sif` was last built. Symptom of the mismatch:
+the runner crash-loops at boot, e.g.
+
+```
+python -m scitex_agent_container._runners.claude_session: error:
+  unrecognized arguments: --channels server:sac
+```
+
+(host emits the new flag; stale container runner rejects it). Always rebuild the
+image after a runner/channel change before expecting agents to pick it up.
+
+## Build / rebuild commands
+
+```bash
+# Preferred (versioned):
+sac image build scitex            # or: scitex-container build scitex-agent-container-scitex
+sac image build base              # rebuild the base layer first if it changed
+
+# Raw apptainer (from the containers/ dir):
+apptainer build sac-base.sif   sac-base.def
+apptainer build sac-scitex.sif sac-scitex.def   # uses sac-base.sif as bootstrap
+```
+
+`sac-scitex.sif` is multi-GB; the build pulls `scitex[all]` (≈1–3 min with uv) plus
+apt deps — budget several minutes. Restart agents after a rebuild so they pick up
+the new `.sif`.
+
+## Pinning a stable version (vs tracking @develop)
+
+`@develop` means every rebuild tracks the tip of develop. For a reproducible
+**stable** image, edit the def to pin a release tag, then rebuild:
+
+```bash
+# in sac-scitex.def: change @develop → @v0.17.3 (a released tag)
+sac image build scitex -y
+```
+
+This is the concrete mechanism behind a "stable vs develop" SAC split: the agent
+image = the pinned stable runner; bump it deliberately.
+
+## When `sac image build` is impossible — bind the host editable over the SIF
+
+On HPC sites (e.g. Spartan) where `sudo` is forbidden AND the user has **no
+`/etc/subuid` mapping** (no unprivileged user-namespace), `apptainer build`
+cannot run at all — neither the sudo path nor the auto-fakeroot path from
+`sac image build` (PR #307) succeeds. Verify with:
+
+```bash
+grep "$USER" /etc/subuid /etc/subgid    # empty → fakeroot is unavailable
+```
+
+In that case you **cannot rebuild the SIF**. The canonical workaround is to
+**bind-mount the host editable `scitex_agent_container` package over the SIF's
+site-packages copy**. The SIF's `/opt/venv-sac/bin/sac` is a click entry-point
+wrapper that imports `scitex_agent_container`; if that package path is
+bind-overridden by the host editable, the SIF's `sac` transparently runs the
+host code without any rebuild — `git pull` + re-exec is the whole update loop.
+
+### Spec-level bind (recommended for fleet)
+
+Add to the agent's `spec.apptainer.binds` so every launch picks it up:
+
+```yaml
+spec:
+  apptainer:
+    binds:
+      - source: /abs/path/to/scitex-agent-container/src/scitex_agent_container
+        target: /opt/venv-sac/lib/python3.12/site-packages/scitex_agent_container
+        read_only: true
+```
+
+### Direct `apptainer exec` (operator one-shot)
+
+For a quick test before baking into spec:
+
+```bash
+apptainer exec \
+  --bind /abs/.../src/scitex_agent_container:/opt/venv-sac/lib/python3.12/site-packages/scitex_agent_container:ro \
+  sac-scitex.sif \
+  sac --version    # → reports the HOST editable's version, not the SIF-baked one
+```
+
+### Caveats
+
+* The host editable's **Python deps must be a subset** of what the SIF's venv
+  already has installed. If a sac PR adds a new dep (rare — most PRs are
+  code-only), `import scitex_agent_container` inside the SIF will hit
+  `ModuleNotFoundError` for the new dep. That's the signal a real rebuild
+  is needed.
+* The host repo's `src/scitex_agent_container/` path **must exist on a
+  filesystem the SIF can see** (typically a shared `/data/...` mount on HPC).
+* Use `read_only: true` (or `:ro` on the CLI) so the in-SIF process can't
+  mutate host source files.
+* This is a workaround for the no-sudo/no-subuid case; on hosts where
+  rebuild IS possible, prefer `sac image build` so the SIF is a real
+  point-in-time snapshot (auditability, reproducibility).
+
+This pattern is also documented in [11_remote-deploy.md](11_remote-deploy.md)
+under the HPC-deployment section — the deploy-side reader gets the same
+workaround without having to spelunk image-build docs first.

--- a/skills-archive/scitex-agent-container/25_claude-setup-delivery.md
+++ b/skills-archive/scitex-agent-container/25_claude-setup-delivery.md
@@ -1,0 +1,199 @@
+---
+description: |
+  [TOPIC] scitex-agent-container — how sac passes Claude setup explicitly into apptainer agents for reproducibility
+  [DETAILS] The to_home → container $HOME 1:1 mirror (general, not just .claude), overlay/--home delivery for relaxed specs, explicit --settings hook load, setting_sources=[] for machine-independence (no host ~/.claude auto-discovery), and the credentials/MCP/hooks loading model (credentials via auth layer, MCP via --mcp-config, hooks via --settings).
+tags: [scitex-agent-container-claude-setup-delivery]
+---
+
+# Claude setup delivery into apptainer agents
+
+## Core doctrine — the definition files are the single source of truth
+
+**To understand or reproduce an agent you should only ever need to read its
+definition: the `spec.yaml` plus its `to_home/`. Never the host machine.**
+Nothing about an agent is implicit or inherited from whatever box it happens
+to run on. This is *why* everything below exists — it is not a set of
+mechanisms first, it is this principle, enforced by mechanisms.
+
+SAC runs each agent's Claude session **inside** an apptainer container and
+never auto-discovers the host operator's `~/.claude` (the `claude --bare`
+philosophy). Every piece of Claude setup — settings, hooks, MCP config,
+credentials, CLAUDE.md, `.bashrc`, `.env` — is passed **explicitly**, declared
+in the agent's definition, so a run is identically reproducible on any host
+(machine-independence). If you find yourself reaching for host state to make
+an agent behave, that is the bug: put it in the definition (`to_home`/`spec`)
+and pass it explicitly.
+
+## `to_home`-first: the default, with a `ro`-bind exception
+
+**Default everything to `to_home`.** The whole agent `$HOME` — `.env`,
+`.mcp.json`, `CLAUDE.md`, `.claude/hooks`, instructions, `.bashrc` — is declared
+as `to_home` files; `spec.yaml` shrinks toward container wiring only. (Migration
+target: today's `raw_args: --env GIT_AUTHOR_*` → `to_home/.env`;
+`startup_prompts` → `to_home/CLAUDE.md`.) Why this beats stuffing config into
+`raw_args`: ordinary files (easy to handle), add a file to add a capability
+(easy to grow), self-contained (host-isolated), and **isomorphic to a normal
+`$HOME`** — standard tools and mental models apply with no special knowledge.
+
+The **only** exception is read-only `bind`s, for **host secrets** (`.ssh`,
+`.config/gh`, `.claude/.credentials.json`) — a copy would commit secrets into
+the git-tracked `to_home`; a `ro`-bind keeps them out and injects values at run
+time.
+
+Large shared trees such as `~/.claude/skills` are **not** an exception: they
+enter via an explicit `to_home` symlink that materialize resolves to real
+content (see "Symlink resolution" below), never via a host auto-read.
+
+### Placement vs precedence (two different axes)
+
+- **Placement (`to_home`-first):** *where* you put a setup. Default `to_home`.
+- **Precedence (which layer wins on conflict):**
+  `direct command args > spec.yaml fields > to_home/<files>`. `to_home` is the
+  base; `spec`/args are escape-hatch overrides (mirrors Claude's
+  `user < project < flag`). Clean layering still needs the runtime to merge +
+  resolve — today `spec.raw_args` and `to_home` are separate surfaces.
+
+### Scope / non-goals
+
+SAC guarantees this model only: per-agent `to_home` + the `_shared` baseline, with
+`ro`-binds for secrets/skills. Bolder patterns — a pooled **shared `to_home`**, or
+binding the **host `$HOME`** directly — are possible via raw escape hatches but
+are explicitly **out of scope** (operator's own risk). Keeps the guarantee crisp.
+
+### The secrets `ro`-bind reproducibility trade-off
+
+**Secrets** are correctly *outside* the reproducible artifact — you reproduce
+the structure; values are injected at run time. Not a gap.
+
+## The `to_home` 1:1 mirror (general, not just `.claude`)
+
+`<spec_dir>/to_home/` mirrors the container `$HOME` **1:1**. Every path under
+`to_home/` lands at the same relative path under the container `$HOME`:
+
+```
+agents/<name>/to_home/
+  .bashrc            → $HOME/.bashrc
+  .env               → $HOME/.env            (chmod 0600)
+  .mcp.json          → $HOME/.mcp.json
+  CLAUDE.md          → $HOME/CLAUDE.md        (marker-protected)
+  .claude/
+    CLAUDE.md        → $HOME/.claude/CLAUDE.md (marker-protected)
+    settings.local.json
+    hooks/
+    skills/          → $HOME/.claude/skills/  (commonly an explicit symlink,
+                       resolved to real content — see below)
+```
+
+A shared baseline (`<agents_dir>/_shared/to_home/`, or `$SAC_TO_HOME_BASELINE`)
+is applied first; the per-agent `to_home/` overlays on top (per-agent wins).
+See `runtimes/_to_home.py` and ADR-0006 for the per-entry semantics. **This
+is general** — `to_home` is not a `.claude` delivery mechanism, it is a `$HOME`
+delivery mechanism.
+
+## Symlink resolution — dereference-copy, fail loud on dangling
+
+The definition is the **sole source of truth**; the runtime **never auto-reads
+host state**. Materialization enforces this at the symlink level:
+
+- **Every** symlink under `_shared/to_home/` and per-agent `to_home/` is
+  **dereference-copied**: the target resolves to real content (a file or whole
+  tree, nested symlinks dereferenced too) and lands at the destination. The
+  container `$HOME` holds only real, self-contained files — closed to apptainer
+  regardless of host layout.
+- A **dangling** symlink hard-aborts the deploy with
+  `DanglingToHomeSymlinkError` (naming path, target, fix) — never silently
+  kept or skipped.
+- **No** keep-literal / warn-and-keep / naming behavior and **no** unconditional
+  host `~/.claude/skills` auto-read. Host content enters only via an
+  **explicit** `to_home/` symlink — e.g.
+  `_shared/to_home/.claude/skills -> ~/.claude/skills` — resolved at deploy time
+  (explicit-pass). Applies to skills, hooks, `.env`, etc. An in-container
+  literal symlink is made via `startup_commands`.
+
+See `runtimes/_symlink_resolve.py::deref_copy_symlink` and ADR-0009.
+
+## Two delivery paths into the container `$HOME`
+
+Where the materialized tree must physically land depends on how the container
+gets its `$HOME`.
+
+### Hardened mode — workspace-home bind
+
+By default the apptainer runtime binds the host workspace home at the
+container `$HOME`:
+
+```
+--bind <runtime/<name>/home/>:/home/agent
+```
+
+`deploy_to_home(config, <workspace_home>)` materializes the tree into
+`runtime/<name>/home/`, and the bind makes it visible at `/home/agent`. Done.
+
+### Relaxed mode — overlay upper home
+
+Relaxed specs (`apptainer.relaxed: true`) opt out of the hardened auto-flags
+and declare their own `raw_args`, typically:
+
+```yaml
+raw_args:
+  - --containall
+  - --home
+  - /home/agent
+  - --overlay
+  - .../containers/overlays/<name>/      # a DIRECTORY overlay
+```
+
+Under this combo the operator-declared `--home /home/agent` is satisfied by
+the **overlay's upper layer**, not by the earlier workspace-home bind — so the
+workspace-home delivery is shadowed and the `to_home` tree never reaches the
+container `$HOME`.
+
+Fix (`runtimes/_to_home_overlay.py`): before launch, `deploy_to_home_overlay`
+materializes the **same** tree into the overlay's upper home —
+
+```
+<overlay>/upper/<container_home>/      e.g. <overlay>/upper/home/agent/
+```
+
+— so the whole tree is part of the container filesystem. The container `$HOME`
+is resolved from the spec's `--home` (defaulting to `/home/agent`), **never**
+from the host operator's environment. This applies only to **directory**
+overlays; `.img` loopback overlays are a no-op (they can't host an upper layer
+writable from the host), and such specs don't use the `--home`-override
+pattern anyway.
+
+### Skills are materialized, not bind-mounted
+
+Skills are delivered like every other `to_home` payload: the explicit
+`to_home/.claude/skills` symlink is dereference-copied into the container
+`$HOME` *before* launch (see "Symlink resolution"). There is no
+`~/.claude/skills:...:ro` bind, so there is no bind-shadowing concern under
+either delivery path — the resolved real `.claude/skills/` tree is simply part
+of the container filesystem, current as of deploy time and self-contained.
+
+## Loading model — credentials, MCP, hooks
+
+The SDK runner is started with `setting_sources=[]` (see
+`runtimes/_sdk_common.py::build_sdk_options`). This is **intentional and must
+not change**: the default would load the host's `~/.claude` state files
+(`state.json`, `projects/`, `settings.json`) and treat "no state" as
+not-logged-in even when credentials are mounted. Empty `setting_sources` means
+the explicitly-passed setup is the entire context — no host auto-discovery.
+
+Each surface is therefore loaded explicitly:
+
+| Surface       | Mechanism                                                              |
+|---------------|------------------------------------------------------------------------|
+| Credentials   | The auth layer (`provision_anthropic_auth`): `~/.claude/.credentials.json` is bind-mounted at `/tmp/sac-claude/`, `CLAUDE_CONFIG_DIR` points the SDK there; or `SAC_ANTHROPIC_API_KEY` bridged into `ANTHROPIC_API_KEY`. A bare host `ANTHROPIC_API_KEY` is never honoured. |
+| MCP servers   | `--mcp-config` — parsed from the workspace `.mcp.json` (materialized by sac from `spec.mcp_servers`) into `ClaudeAgentOptions.mcp_servers`. The `sac` channel sidecar is auto-registered for `channels: [server:sac]`. |
+| Hooks/settings| `--settings <path>` — `ClaudeAgentOptions.settings` is set to the in-container `$HOME/.claude/settings.local.json`. This is the SDK's "flag settings" layer, the highest-priority user-controlled layer, loaded **independently** of `setting_sources`. Without it, `setting_sources=[]` would never load the delivered settings. |
+
+### `--settings` and hook paths
+
+`build_sdk_options` resolves the settings path from the in-container `$HOME`
+(`$HOME/.claude/settings.local.json`) and sets `ClaudeAgentOptions.settings`
+only when the file is present (so a spec without one doesn't aim `--settings`
+at a missing file). The hook `command`s inside `settings.local.json` use
+`$HOME/.claude/hooks/...`, so they resolve in-container regardless of what
+`$HOME` is — both the workspace-home bind and the overlay upper home put the
+hook scripts at exactly that path.

--- a/skills-archive/scitex-agent-container/26_credentials-rotation-host.md
+++ b/skills-archive/scitex-agent-container/26_credentials-rotation-host.md
@@ -1,0 +1,125 @@
+---
+description: |
+  [TOPIC] scitex-agent-container — host-side credential refresh ops + the one-refresher-per-account invariant.
+  [DETAILS] The bundled `claude` CLI's in-container access-token rotation + 30-min keepalive cron pattern; the one-account-one-refresher invariant that makes server-side refresh-token rotation safe; the `sac.accounts-refresh` host systemd-user timer with `--skip-active`; the `sac accounts watch-live` daemon that mirrors host re-logins into the sac store; `scitex-dev creds rotate-all` multi-account CI rotation. The on-disk model + auth mechanics live in [26_credentials-rotation.md](26_credentials-rotation.md).
+tags: [scitex-agent-container-credentials-rotation-host]
+---
+
+# SAC OAuth credentials: refresh + host-side ops
+
+> Companion to [26_credentials-rotation.md](26_credentials-rotation.md)
+> — that file covers what's on disk and how the SDK reaches it. This
+> file covers refresh mechanics, the rotation-race invariant, and the
+> host-side tooling that keeps the canonicals fresh.
+
+## 1. Auto-refresh — the bundled CLI does it; sac keeps a session live
+
+The bundled `claude` renews the **access** token in place ~5 min before
+expiry **while a session is active**. With the `:rw` snapshot bind the
+new token persists to the snapshot store; every other agent sharing
+that snapshot sees the fresh token on its next read.
+
+So the snapshot stays fresh **as long as something is talking to the
+account**. Standard pattern for **parked** accounts (no running pinned
+agent, not the host's interactive login):
+
+- **One per-account refresher agent** on the cheapest model
+  (`claude-haiku-4-5`), pinned via `spec.claude.account: <acct>`. Post-PR
+  #262 the live snapshot bind is automatic — no manual bind / custom
+  `CLAUDE_CONFIG_DIR` override needed.
+- **A 30-minute keepalive cron** that posts an A2A turn to each
+  refresher: `sac agents send <refresher> hello`. The turn forces the
+  bundled CLI to spin a session, observe the impending expiry, and
+  rotate the access token through the bind back to the snapshot.
+
+Every other agent on the same account benefits transparently — they all
+bind the same snapshot.
+
+> Mechanics note: the bundled `claude` CLI caches the refresh-token
+> **in memory** at session start; it does not re-read the snapshot
+> before each rotation. This is what makes the one-account-one-refresher
+> invariant load-bearing (§2). Any out-of-band rotator (e.g., a host
+> cron call against the same account) will invalidate the running
+> CLI's in-memory refresh-token server-side and 401 the next turn.
+
+## 2. One account, one refresher — the rotation-race invariant
+
+OAuth refresh-tokens **rotate server-side on every use**: each call to
+`/oauth/token` returns a new refresh-token AND invalidates the previous
+one with no grace window. Combined with the in-memory cache (§1), this
+means **at most one process can be the live refresher for any given
+account at any given time**:
+
+* **Pinned-and-running**: the in-container `claude` CLI inside the
+  pinned agent is the sole refresher. The host cron MUST skip the
+  account.
+* **Host's interactive login**: the operator's interactive `claude`
+  session is the sole refresher. The host cron MUST skip it (the
+  pre-existing `--skip-active` behaviour).
+* **Parked** (no pinned agent, no interactive session): the host cron
+  is the sole refresher. Safe to rotate; no in-memory cache to race.
+
+If two refreshers ever touch the same account concurrently, the loser's
+refresh-token is dead the moment the winner's `/oauth/token` returns.
+The loser then 401s on its next turn — even though the snapshot file
+on disk looks brand-new (the winner wrote it).
+
+**The host refresher cron** (`sac.accounts-refresh.service`, see §4)
+implements this invariant via `--skip-active`: the skip-set is the union
+of the host-active account and every account currently pinned by a
+running local agent (PR #299, commit `dea298d`). Stale-registry
+tolerance: a dead agent's leftover JSON over-skips its account
+(under-refresh — safe direction; recover with manual
+`sac accounts refresh <name>`). The opposite direction (over-refresh
+racing a live agent) was the 2026-06-03 ~hourly 401 storm that
+PR #299 closes structurally. See
+[ADR-0017](../../../../docs/adr/0017-credential-rotation-and-refresh-race.md)
+§ "Failure mode 2" + § "Why a symlink doesn't solve this".
+
+## 3. Multi-account CI rotation
+
+`for acct in ...; scitex-dev creds rotate-all --source $SAC_STORE --only pkgA --only pkgB ... --yes; done` splits CI auth across N Max accounts (lead 2026-05-29: 66 `scitex-*` divided 22-22-22 across 3). `--only` is repeatable.
+
+Non-negotiables:
+
+- **Silent-no-op trap.** Stale `--source` (`claudeAiOauth.expiresAt` in the past) exits **0 with zero stdout**. Verify first: `jq '.claudeAiOauth.expiresAt' <path>` vs `echo $(($(date +%s) * 1000))`.
+- **`--source` MUST be the sac store**, `~/.scitex/agent-container/accounts/<acct>/.credentials.json` (kept fresh by §5's daemon; what `sac accounts list` reads). The `~/.claude/.credentials-<acct>.json` canonicals from [26_credentials-rotation.md §1](26_credentials-rotation.md) are refreshed via `:rw` agent binds, NOT direct rotation — using them as `--source` silently fails when stale.
+
+## 4. The host refresher cron — `sac.accounts-refresh`
+
+A federated systemd-user timer fires `sac accounts refresh --all --skip-active` every 2h (`OnUnitActiveSec=2h`). It iterates the account store and rotates each unpinned account's tokens against `/oauth/token`. Registered as the `sac.accounts-refresh` JobSpec via `_jobs_plugin.py`; install with `sac dev systemd install --yes`.
+
+The `--skip-active` skip-set is the union of:
+
+1. **The host's interactive login** (`~/.claude/.credentials.json` resolved to a stored account name via `_resolve_active_account_name`).
+2. **Every account currently pinned by a running local agent** (`_collect_pinned_running_accounts`, post-PR #299, commit `dea298d`).
+
+Both subsets enforce the one-account-one-refresher invariant from §2. Diagnostic stderr lines name each excluded account with the reason so the operator can see what got skipped:
+
+```
+[skip-active] excluding active account 'ywatanabe-gmail-com'.
+[skip-active] excluding pinned-running account 'wyusuuke-gmail-com' (refresh-token rotation race guard).
+[skip-active] excluding pinned-running account 'ywatanabe-scitex-ai' (refresh-token rotation race guard).
+```
+
+Implementation: `cli_pkg/_account_refresh.py::account_refresh` (CLI wiring), `_collect_pinned_running_accounts(home)` (reads `~/.scitex/agent-container/runtime/registry/*.json` directly to avoid the `Registry` class's import-time `REGISTRY_DIR` freeze under pytest fixtures).
+
+## 5. The watch-live daemon — keeps the sac store fresh
+
+`sac accounts watch-live` runs `inotifywait -m ~/.claude/` for `close_write|moved_to|create` on `.credentials.json`; atomically copies each event into the matching sac-store path (slug-map e.g. `wyusuuke@gmail.com` → `wyusuuke-gmail-com`).
+
+Non-negotiables:
+
+- **NOT auto-started** — no systemd / launchd unit ships. If the daemon isn't running when `claude /login` refreshes, the sac store stays stale until `sac accounts sync-live` (one-shot fallback) or the daemon starts.
+
+Implementation: `_account/creds_watch.py` L140-152 (`watch_inotify()`), L99-133 (`watch_poll()` fallback); `_account/creds_sync.py` L141-244 (`sync_live()`), L69-77 (`slugify_email()`); `cli_pkg/_account_sync_live.py` L82-100+ (`account_watch_live` command).
+
+## See also
+
+- [26_credentials-rotation.md](26_credentials-rotation.md) — on-disk
+  model + auth mechanics (canonical → SDK + `:rw` bind + preflight).
+- [ADR-0017](../../../../docs/adr/0017-credential-rotation-and-refresh-race.md) —
+  canonical write-up of the rotation model + the two failure modes
+  (stale-COPY pre-#262, refresh-token race pre-#299).
+- [27_credentials-relogin.md](27_credentials-relogin.md) — verified
+  re-login flow (tmux code-paste) + 401-recovery design.

--- a/skills-archive/scitex-agent-container/26_credentials-rotation.md
+++ b/skills-archive/scitex-agent-container/26_credentials-rotation.md
@@ -1,0 +1,193 @@
+---
+description: |
+  [TOPIC] scitex-agent-container — SAC OAuth credentials on-disk model + how the SDK reaches them inside the container.
+  [DETAILS] Per-account `~/.claude/.credentials-<acct>.json` canonicals + mode-0600 symlinks; the `:rw` dir-bind at `/tmp/sac-claude/.credentials.json` that lets the bundled CLI refresh access tokens in place (~5 min skew); the per-account snapshot bind (post-PR #262 — the COPY caveat is fixed); the preflight (300s skew, access-token only); access vs refresh token life stages. Refresh mechanics + host-side ops live in [26_credentials-rotation-host.md](26_credentials-rotation-host.md). Re-login flow in 27_credentials-relogin.md.
+tags: [scitex-agent-container-credentials-rotation]
+---
+
+# SAC OAuth credentials: model + auth mechanics
+
+> Verified on `ywata-note-win` 2026-05-26.
+> Refresh + host-side ops (auto-refresh, the one-account-one-refresher
+> invariant, `sac.accounts-refresh` cron, `watch-live` daemon, CI
+> rotation): [26_credentials-rotation-host.md](26_credentials-rotation-host.md).
+> Re-login (after refresh-token death):
+> [27_credentials-relogin.md](27_credentials-relogin.md).
+
+Operator runbook for the **Anthropic OAuth credentials** SAC binds into
+every Claude-backed agent. Covers the on-disk model, the auth mechanics
+that make live refresh work, and what the preflight catches.
+
+Does **not** cover the API-key (`SAC_ANTHROPIC_API_KEY`) path — the
+preflight short-circuits on any API-key env (see
+`_state/_preflight_creds._api_key_env_is_set`).
+
+## 1. Model — one canonical per account, everything else symlinks
+
+Each Anthropic account has exactly one real file:
+
+```
+~/.claude/.credentials-<account>.json     # one per account
+```
+
+Mode **0600** on the canonical and every symlink. The active file
+`~/.claude/.credentials.json` is **always a symlink** to whichever
+canonical the host is currently logged in as; per-agent state dirs and
+lead session pointers are **also symlinks** to the same canonical. There
+is never a second real copy on disk.
+
+Non-negotiables:
+
+- **Never copy a credentials file into `to_home/`.** It's git-tracked
+  (see [25_claude-setup-delivery.md](25_claude-setup-delivery.md)) — a
+  commit leaks the token; the symlink-resolver dereferences and lands a
+  snapshot that loses write-back.
+- **Never bake credentials into the SIF image.** The image is shared
+  across accounts; baked creds are wrong for N-1 and unrotatable in any.
+
+## 2. Auth mechanics — canonical → SDK, stays fresh
+
+Three pieces in this repo cooperate:
+
+### `provision_anthropic_auth` (`runtimes/_sdk_common.py`)
+
+1. Pop any bare `ANTHROPIC_API_KEY` from env unconditionally — a stale
+   dotfiles export must not survive.
+2. Resolve the credentials path via `_cred_file_path()`; if the file
+   exists, call the preflight and return `"credentials_file"`. **No env
+   mirroring** — Anthropic rejects `sk-ant-oat*` OAuth tokens as bare env.
+3. Else, if `SAC_ANTHROPIC_API_KEY` is set, mirror it into
+   `ANTHROPIC_API_KEY` and return `"sac_env"`.
+4. Else, raise `SDKCommonError`.
+
+### `_cred_file_path` (`runtimes/_sdk_common.py`)
+
+```
+CLAUDE_CONFIG_DIR if set → <CLAUDE_CONFIG_DIR>/.credentials.json
+else                     → ~/.claude/.credentials.json
+```
+
+Same env as the bundled `claude` CLI, so SDK + CLI + helper all resolve
+to the same file.
+
+### Apptainer bind (`runtimes/_apptainer_auth.py::auth_argv`)
+
+Both paths (host-live AND pinned-account) dir-bind unconditionally
+(post task #13):
+
+```
+--bind <cred_file_parent>:/tmp/sac-claude:rw
+--env  CLAUDE_CONFIG_DIR=/tmp/sac-claude
+```
+
+* `cred_file_parent` = `~/.claude/` for unpinned / host-live (the
+  agent picks up whatever account the operator is currently logged
+  in as).
+* `cred_file_parent` = `~/.scitex/agent-container/accounts/<acct>/`
+  for pinned (the snapshot dir for the named account).
+
+The **`:rw`** is why live refresh works: when the bundled `claude`
+inside the container detects a near-expiry access token (~5 min skew),
+it writes the new token back through the bind to the host canonical.
+Without `:rw` the container 401s the moment the token expires.
+
+The **directory bind** (not a single-file bind) is required because
+host-side refreshes rotate atomically via `write-tmp + rename`
+(`_account/creds_watch.py`, `_account/creds_sync.py`,
+`_account/claude_usage._refresh_access_token_at`). A single-file bind
+would survive the rename pointing at the old inode — visible as
+`...credentials.json//deleted` in `/proc/<pid>/mountinfo` — and the
+container would read the stale pre-rename token forever → 401 at
+natural expiry. See [ADR-0017](../../../../docs/adr/0017-credential-rotation-and-refresh-race.md)
+§ "Failure mode 1" for the 2026-06-04 03:00 fleet-wide storm empirical
+anchor.
+
+Scope of the unpinned dir-bind: `~/.claude/` also contains
+settings.json, projects DB, chat history, MCP config — the dir-bind
+exposes (and now allows writes to) these. Recommended deployment is
+`spec.claude.account` pinning + the watch-live daemon
+([26_credentials-rotation-host.md §5](26_credentials-rotation-host.md))
+so the unpinned dir-bind is a degraded fallback only.
+
+Target lives under `/tmp/` (not `$HOME`) because D2 hardened preflight
+requires `$HOME` empty; `CLAUDE_CONFIG_DIR=/tmp/sac-claude` keeps SDK and
+CLI in sync without polluting `$HOME`.
+
+### Per-account bind — **live snapshot, not a copy** (post-PR #262)
+
+When `spec.claude.account` is non-empty,
+`runtimes/_apptainer_creds.resolve_cred_file` returns the **snapshot
+path itself** (`~/.scitex/agent-container/accounts/<acct>/.credentials.json`).
+`runtimes/_apptainer_auth.auth_argv` then binds the snapshot's **parent
+directory** `:rw`:
+
+```
+--bind <snapshot_parent>:/tmp/sac-claude:rw
+--env  CLAUDE_CONFIG_DIR=/tmp/sac-claude
+```
+
+So:
+
+- The container's refresh writes through the bind to the **same
+  snapshot file** every other reader looks at.
+- The snapshot stays current. Every other agent on the same account
+  sees the new tokens on its next read.
+- Directory bind, not single-file: same atomic-rename reason as above.
+
+PR #262 (commits `d70e608` + `acf2cbb`) eliminated an earlier
+`shutil.copy2` snapshot-into-agent-state-dir path that caused the
+2026-06-01 silent outage. See [ADR-0017](../../../../docs/adr/0017-credential-rotation-and-refresh-race.md)
+§ "Failure mode 1" for the historical story.
+
+### Preflight (`_state/_preflight_creds.check_oauth_token_expiry`)
+
+`EXPIRY_SKEW_SECONDS = 300`. Reads `data["claudeAiOauth"]["expiresAt"]`
+(ms or s, auto-detected via `> 1e12`) and refuses to start if the
+**access** token is within 300 s of expiring or already dead. Skipped
+entirely when any API-key env is set.
+
+It does **not** inspect the refresh token. It does **not** make a
+network call. So:
+
+> A direct-bind agent **starts** (preflight passes if access still has
+> more than five minutes of life) then fails **LOUD** at the **first
+> turn** with 401 if the bound file is in fact dead (refresh token
+> expired, account revoked).
+
+The first 401 is the first authoritative signal that the canonical
+needs operator recovery → see
+[27_credentials-relogin.md](27_credentials-relogin.md).
+
+## 3. Expired ≠ unrecoverable — until the refresh token dies
+
+Credentials JSON carries `accessToken` (~8 h life) and `refreshToken`
+(multi-hour to multi-day). The bundled CLI quietly swaps an expired
+access token for a new one using the refresh token.
+
+Stages of death:
+
+- **Access expired, refresh alive** → CLI rotates silently; no operator
+  action.
+- **Access expired, refresh expired** → CLI cannot self-revive; the next
+  session 401s. **Re-login required** — see
+  [27_credentials-relogin.md](27_credentials-relogin.md).
+
+Refresh mechanics, the one-account-one-refresher invariant, and host-side
+ops (cron, watch-live daemon, CI rotation) are in
+[26_credentials-rotation-host.md](26_credentials-rotation-host.md).
+
+## See also
+
+- [26_credentials-rotation-host.md](26_credentials-rotation-host.md) —
+  refresh mechanics + one-refresher invariant + host cron / watch-live /
+  CI rotation.
+- [ADR-0017](../../../../docs/adr/0017-credential-rotation-and-refresh-race.md) —
+  canonical write-up of the rotation model + the two failure modes
+  (stale-COPY pre-#262, refresh-token race pre-#299).
+- [27_credentials-relogin.md](27_credentials-relogin.md) — re-login
+  (tmux code-paste) + 401-recovery design.
+- [25_claude-setup-delivery.md](25_claude-setup-delivery.md) — why
+  `to_home/` is the wrong place for credentials; `setting_sources=[]`.
+- Source files cited: `runtimes/_sdk_common.py`,
+  `runtimes/_apptainer_auth.py`, `runtimes/_apptainer_creds.py`,
+  `_state/_preflight_creds.py`.

--- a/skills-archive/scitex-agent-container/27_credentials-relogin.md
+++ b/skills-archive/scitex-agent-container/27_credentials-relogin.md
@@ -1,0 +1,142 @@
+---
+description: |
+  [TOPIC] scitex-agent-container — verified re-login flow + 401-recovery design for SAC OAuth credentials.
+  [DETAILS] Headless tmux-based code-paste flow; the auth subcommand surface; isolated `CLAUDE_CONFIG_DIR` so the host canonical is never disturbed; `/bin/cp -f` and `--yes` gotchas; 401-recovery hook design via Telegram for operator-in-loop. Companion to 26_credentials-rotation.md, which covers the on-disk model + auto-refresh mechanics.
+tags: [scitex-agent-container-credentials-relogin]
+---
+
+# SAC OAuth credentials: re-login + 401 recovery
+
+> Companion to [26_credentials-rotation.md](26_credentials-rotation.md).
+> 26_ covers the canonical-symlink model, the `:rw` bind, and the auto-refresh
+> path. This skill covers what to do when **the refresh token has actually
+> died** and the bundled CLI can't self-revive.
+
+## Verified re-login flow — headless, operator-in-loop
+
+Verified on `ywata-note-win` 2026-05-26.
+
+The bundled CLI's auth surface:
+
+```
+claude auth login        # OAuth login (code-paste flow)
+claude auth logout
+claude auth status
+```
+
+`login` is **not** a localhost redirect — `redirect_uri` is
+`https://platform.claude.com/oauth/code/callback`, which shows a **code**
+of the form `<code>#<state>` for the operator to paste back. The URL alone
+is not enough; the operator needs a way to **return the code into the
+CLI's prompt**. A direct-injection path (`tmux send-keys`, or an A2A turn
+piped to the running `claude auth login` process) is required.
+
+### Step-by-step
+
+1. **Back up the live canonical** so the lead/host session is never
+   disturbed by a botched login:
+
+   ```
+   /bin/cp -f ~/.claude/.credentials.json ~/.claude/.credentials.json.bak
+   ```
+
+2. **Run login in an isolated `CLAUDE_CONFIG_DIR` via tmux**, so the
+   host `~/.claude/` is untouched:
+
+   ```
+   tmux new -d -s login-<acct> "
+     CLAUDE_CONFIG_DIR=/tmp/login-<acct> claude auth login
+   "
+   ```
+
+3. **Capture the pane and reassemble the OAuth URL.** The URL **wraps
+   across pane lines** (no inserted spaces). Join the wrapped lines
+   programmatically — do **not** rely on a single-line grep.
+
+4. **Surface only the URL** to the operator with **which account** is
+   being logged in (so the operator picks the right Anthropic account in
+   the browser). Do **not** print token values.
+
+5. **Operator authorizes** the correct account; `platform.claude.com`
+   shows a code as `<code>#<state>` (single-use, never log it).
+
+6. **Inject the full `<code>#<state>` into the prompt**:
+
+   ```
+   tmux send-keys -t login-<acct> "<code>#<state>" Enter
+   ```
+
+   The CLI prints `Login successful` and writes
+   `/tmp/login-<acct>/.credentials.json` (`expiresAt` ~+8 h).
+
+7. **Promote to the canonical** (`/bin/cp` to bypass any aliased `cp`):
+
+   ```
+   /bin/cp -f /tmp/login-<acct>/.credentials.json \
+             ~/.claude/.credentials-<acct>.json
+   chmod 600 ~/.claude/.credentials-<acct>.json
+   ```
+
+   If `<acct>` is the active account, re-point the symlink:
+
+   ```
+   ln -sfn ~/.claude/.credentials-<acct>.json ~/.claude/.credentials.json
+   ```
+
+8. **Restart the per-account refresher** (the `--yes` is mandatory):
+
+   ```
+   sac agents restart cred-refresher-<acct> --yes
+   ```
+
+9. **Verify**:
+
+   ```
+   sac agents send cred-refresher-<acct> hello
+   # expect a plain `ok`-style reply, NOT a 401
+   ```
+
+## 401-recovery layer (design)
+
+Hook the refresher (or the keepalive cron) so that on a 401 it:
+
+1. Spawns `claude auth login` in an isolated `CLAUDE_CONFIG_DIR`.
+2. Captures + reassembles the wrapped URL.
+3. Notifies the operator with `{machine, host, agent, account, URL}` —
+   typically via Telegram MCP tools (see
+   [23_telegram-integration.md](23_telegram-integration.md)) for one-click
+   + reply with the code.
+4. Pastes the returned `<code>#<state>` via `tmux send-keys` (or an A2A
+   turn carrying the code) into the running login process.
+5. Promotes the new credentials JSON to the canonical (step 7 above) and
+   restarts the refresher (step 8 above).
+6. The whole fleet on that account recovers automatically — every agent
+   binds the same canonical.
+
+Because the flow is **code-paste**, URL-click-only is insufficient. Plan
+for a direct-injection return path from day one.
+
+## Gotchas
+
+- **`/bin/cp -f` (not `cp -f`).** A host `cp` alias/function commonly maps
+  to `cp -i`, which prompts in non-interactive contexts and silently
+  no-ops. Always promote via the bare binary.
+- **`sac agents restart` needs `--yes`.** Without it the CLI prompts and a
+  non-interactive call hangs.
+- **The URL wraps across tmux pane lines.** Reassemble by joining lines
+  (no inserted spaces); a naive `grep '^https://'` sees only the first
+  fragment.
+- **The pasted value is `<code>#<state>`** — the literal `#` and
+  `<state>` are part of the payload, not a comment or shell pipe.
+- **Never print token values.** Log only `expiresAt` and
+  `subscriptionType`. The OAuth code is single-use but still sensitive.
+- **Always log in inside an isolated `CLAUDE_CONFIG_DIR`** and back up the
+  live canonical first.
+
+## See also
+
+- [26_credentials-rotation.md](26_credentials-rotation.md) — on-disk
+  model, auto-refresh mechanics, the per-account COPY caveat.
+- [25_claude-setup-delivery.md](25_claude-setup-delivery.md) — why
+  `to_home/` is the wrong place for credentials.
+- [40_troubleshooting.md](40_troubleshooting.md) — generic 401 debugging.

--- a/skills-archive/scitex-agent-container/28_credential-refresh.md
+++ b/skills-archive/scitex-agent-container/28_credential-refresh.md
@@ -1,0 +1,106 @@
+---
+description: |
+  [TOPIC] Refreshing Anthropic credentials for SAC agents — without restart churn
+  [DETAILS] When the host `~/.claude/.credentials.json` is refreshed (OAuth token expiry → re-login / rotation), a RUNNING agent re-reads the fresh MOUNTED credential on its NEXT turn — so `sac agents send <name> "continue"` resumes it, NO restart needed. Cold `sac agents start` is only for `defined`/parked (never-run or stopped) agents. Covers how to tell running from parked, that all three resume paths preserve session_id, the Spartan shared-home propagation shortcut, the credential-mount mechanism, and the `${VAR:+SET}` safe-presence-check rule.
+tags: [scitex-agent-container-credential-refresh, credentials, auth, refresh]
+---
+
+# Refreshing Anthropic credentials for SAC agents
+
+When a SAC agent's host `~/.claude/.credentials.json` is refreshed
+(OAuth token expired and you re-ran `claude /login`, or you rotated the
+credential), you do **not** need to reboot the agent. A **running**
+agent re-reads the fresh **mounted** credential file on its next turn —
+so a single `sac agents send <name> "continue"` resumes it from where it
+left off. Restart is reserved for cold/parked agents.
+
+Avoiding the restart matters: rebooting churns the SIF, drops the live
+A2A sidecar, and re-pays startup cost — pure waste when the only stale
+thing is the auth token.
+
+## TL;DR decision
+
+| Agent state | What it has | Command to resume after creds refresh |
+|---|---|---|
+| **running** | live A2A sidecar; PID alive | `sac agents send <name> "continue from where you left off"` |
+| **defined / parked** (never-run or stopped) | no live sidecar | `sac agents start <name>` |
+
+`sac agents restart <name>` errors `not found in registry` on a
+non-running agent — use `start` there, not `restart`.
+
+All three (`send "continue"` / `start` / `restart`) **resume the
+agent's `session_id`**, so its conversation and work progress are
+preserved.
+
+## Why "continue" works without a restart
+
+The `claude_session` runner provisions auth **at boot** from
+`~/.claude/.credentials.json` (see
+`runtimes/_sdk_common.py::provision_anthropic_auth` and the
+delivery mechanics in [25_claude-setup-delivery.md](25_claude-setup-delivery.md)).
+That credential file is **bind-mounted** into the container, not copied,
+so the host-side file and the in-container view are the same bytes. A
+live runner re-reads the mounted file on its **next turn** — driving one
+more turn with `sac agents send <name> "continue"` is enough to pick up
+the fresh token. A cold `start` re-reads the file at boot, which is why
+parked agents just need `start`.
+
+## Telling running from parked — the send-answers test
+
+A **running** agent's A2A sidecar answers `sac agents send`. The reply
+content does not matter for this test:
+
+```bash
+sac agents send <name> "continue from where you left off"
+```
+
+- Any `status: ok` reply — including an **auth error** or
+  *"out of extra usage"* message — means **the sidecar is alive** (the
+  agent answered the turn) → the agent is **running** → `continue` was
+  the right call; just re-send once more after the creds are fresh.
+- A transport failure (no sidecar / connection refused) → the agent is
+  **parked** → use `sac agents start <name>` instead.
+
+`sac agents status <name>` (or `sac agents list --json`) also
+distinguishes the states, but the send-answers test is the most direct
+signal that the *running runner* will see the refreshed mount.
+
+## Spartan: refresh once, propagate everywhere
+
+Spartan's home filesystem is **shared across compute nodes**. So
+refreshing `~/.claude/.credentials.json` **once** on Spartan propagates
+the fresh token to **every** compute-node agent at the same path — no
+per-node copy. Then `sac agents send <name> "continue"` each running
+agent (or `start` the parked ones).
+
+Push the fresh creds with `scp -p` (preserve mode — the file is `0600`)
+from a host that already has them:
+
+```bash
+scp -p ~/.claude/.credentials.json spartan:~/.claude/.credentials.json
+```
+
+Never `cat`, `echo`, or otherwise print the file contents — `scp` moves
+the bytes without exposing them in logs or terminal scrollback.
+
+## Security: checking secret env-var presence
+
+When you need to confirm an auth env var is *set* (e.g. debugging which
+auth path the runner will take), check **presence only** with
+`${VAR:+SET}` — it expands to the literal `SET` when the var is
+non-empty and to nothing otherwise, never the secret value:
+
+```bash
+echo "SAC_ANTHROPIC_API_KEY=${SAC_ANTHROPIC_API_KEY:+SET}"
+echo "ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:+SET}"
+```
+
+Do **not** use `${VAR:-...}` (expands the value when set) or a bare
+`$VAR` / `echo "$VAR"` — those leak the credential into logs.
+
+## See also
+
+- [01_installation.md](01_installation.md) — auth precedence (`~/.claude/.credentials.json` OAuth vs `SAC_ANTHROPIC_API_KEY`)
+- [25_claude-setup-delivery.md](25_claude-setup-delivery.md) — how the credential file is mounted into the agent container
+- [14_claude-session-state.md](14_claude-session-state.md) — `session_id` resume, runner state layout
+- [20_env-vars.md](20_env-vars.md) — `SAC_ANTHROPIC_API_KEY` and the auth precedence table

--- a/skills-archive/scitex-agent-container/29_progress-reporting-to-lead.md
+++ b/skills-archive/scitex-agent-container/29_progress-reporting-to-lead.md
@@ -1,0 +1,98 @@
+---
+description: |
+  [TOPIC] Push progress reports to the lead's a2a inbox at every milestone, so fleet coordination stops requiring polls.
+  [DETAILS] sac agents send `mcp__sac__a2a_send(target='lead', ...)` push updates on PR open/merge/close, BLOCKED, DONE, or any significant context change. The lead reads its inbox to coordinate the fleet without reading every agent's `agent_logs` / `gh` state by hand. Speak/Telegram are for the OPERATOR; a2a push is for the LEAD. Both happen at milestones — not exclusive channels. Includes the KIND vocabulary, when-to / when-not-to thresholds, the one-time per-agent ACL grant the lead has to issue (`sac a2a grant --sender <name> --target lead`), and pointers to the companion Stop-hook reminder shipped via the dotfiles `_shared/to_home/` overlay.
+tags: [scitex-agent-container-progress-reporting-to-lead]
+---
+
+# Progress reporting to the lead
+
+Push a structured update to the lead's a2a inbox whenever a milestone fires. The lead polls its inbox at every Stop and uses these to coordinate the fleet without reading every agent's session.jsonl by hand.
+
+## Tool
+
+```python
+mcp__sac__a2a_send(
+    target='lead',
+    content='<KIND>: <one-line summary>\n<evidence>',
+    priority='normal',   # or 'high' for blockers
+)
+```
+
+## When to push
+
+Push at these events, **as soon as they happen** (don't batch):
+
+| Event | KIND | content shape |
+|---|---|---|
+| PR opened | `PR_OPENED` | `repo#N branch/<name> title` |
+| PR merged | `PR_MERGED` | `repo#N commit/<sha> title` |
+| PR closed (not merged) | `PR_CLOSED` | `repo#N reason` |
+| Task BLOCKED | `BLOCKED` | one-line reason + numbered options if applicable |
+| Task DONE | `DONE` | task identifier + evidence (PR#/commit/file) |
+| Major context change | `CONTEXT` | what shifted and why it matters |
+
+## Format examples
+
+```python
+# DONE with PR
+mcp__sac__a2a_send(target='lead',
+    content='DONE feat/lmod-apptainer-helpers\nscitex-hpc#8 merged commit 5c9ca5e, all 20 tests pass')
+
+# BLOCKED needing operator decision
+mcp__sac__a2a_send(target='lead', priority='high',
+    content='BLOCKED scitex-hpc PR #10\nbelt-and-suspenders PR redundant after #9 turned tests green; options: a) close, b) keep open as belt')
+
+# PR opened
+mcp__sac__a2a_send(target='lead',
+    content='PR_OPENED scitex-agent-container#241 docs/adr-0016-provider-and-account-axes\ntitle: docs(adr): 0012 -> 0016 renumber + provider×account axes')
+
+# Context shift
+mcp__sac__a2a_send(target='lead',
+    content='CONTEXT scitex-hpc tests workflow was red 4 days due to MCP-coverage gap; fixed via PR #9 zero-growth + PR #10 closed as belt-and-suspenders')
+```
+
+## Why push, not poll
+
+The lead currently polls `agent_logs` and `gh` to track progress. That's slow:
+
+- `agent_logs` is stale-cached (status / latest_event fields don't reflect the most recent in-turn state; the transcript is the ground truth — see memory `reference_sac_status_fields_stale_use_transcript`).
+- `gh` PR API requires the lead to know which repo / PR# to check.
+- Each poll burns the lead's context.
+
+Push closes this gap. The lead's inbox is a small bounded queue; one push per milestone is essentially free.
+
+## Don't push for
+
+- Every Bash tool call (way too noisy).
+- Every assistant text line.
+- Speculative progress ("might finish in 5 min").
+- Intermediate-state status that's about to change ("CI is running").
+
+The threshold is: would a human supervisor want to know this RIGHT NOW so they could intervene or move on?
+
+## Don't forget operator-facing channels
+
+- **Speak (audio)** and **Telegram** are the OPERATOR's channels.
+- **a2a_send** is the LEAD's channel.
+- For DONE / BLOCKED / major milestones: do **both** — speak + a2a_send.
+
+## Conflict resolution
+
+If you already pushed a milestone earlier in this turn, you can skip the next Stop's reminder for that same milestone. A *new* milestone since the last push → push.
+
+## ACL note
+
+ACL-based send restrictions are not currently enforced in sac (verified 2026-05-28: no `scitex_agent_container.comms.acl` module, no `sac a2a grant` subcommand). If a future sac release adds an enforced ACL and you hit 403, file an issue against scitex-agent-container for the grant-CLI + Python API to be implemented — don't try to work around it manually.
+
+## Companion Stop-hook reminder
+
+A turn-end reminder hook ships via the dotfiles `_shared/to_home/` overlay at `~/.claude/hooks/stop/report_to_lead_on_stop.{sh,md}`. The shell shim emits a stderr nudge at every Stop; the `.md` is the agent-facing protocol crib pointing right back to this skill. The hook is gated on `SCITEX_AGENT_CONTAINER_NAME` so non-sac sessions (including the lead session itself) do not inherit the reminder.
+
+## Cross-references
+
+- `mcp__sac__a2a_inbox()` — what the lead reads (the destination of every push).
+- `mcp__sac__a2a_reply(in_reply_to=..., ...)` — for follow-up replies in a conversation, NOT for fresh milestones.
+- Telegram + scitex-notification audio: the OPERATOR-facing channels; a2a push complements them, doesn't replace.
+- Lead doctrine `~/.claude/skills/scitex-lead/SKILL.md` — operator-facing communication rules.
+- `26_credentials-rotation.md`, `27_credentials-relogin.md`, `28_credential-refresh.md` — sibling skills for the credential side of the agent lifecycle.

--- a/skills-archive/scitex-agent-container/30_responsiveness-background-work.md
+++ b/skills-archive/scitex-agent-container/30_responsiveness-background-work.md
@@ -1,0 +1,200 @@
+---
+description: |
+  [TOPIC] Stay responsive to the operator by doing every heavy job in the background.
+  [DETAILS] Default doctrine for every sac agent: never block the main conversation turn on long-running work (LaTeX compile, figure builds, pytest, training, big git ops, image builds, large data downloads). Launch heavy work as a BACKGROUND process — `Bash run_in_background=true` or `Agent run_in_background=true` — end the current turn promptly, and handle the result when the runtime delivers the completion notification. The operator's Telegram message is delivered to the same inbox the conversation reads; while a turn is in flight, new Telegram messages QUEUE and are not picked up until the turn ends. The cure is a short turn, not a more clever interrupt. Short turns also keep the prompt cache warm (5-min TTL) and let other peers/the lead drive the agent without waiting minutes per round-trip.
+tags: [scitex-agent-container-responsiveness-background-work, telegram-latency, short-turns]
+---
+
+# Responsiveness — short turns + background heavy work
+
+> Operator UX rule (lead directive, 2026-06-04): the operator's
+> Telegram message must be answered within seconds, never minutes.
+
+> **Structural enforcement**: a pre-tool-use hook
+> ``~/.claude/hooks/pre-tool-use/force_background_bash.sh`` (shipped
+> under ``examples/agents/full-agent/to_home/.claude/hooks/`` and
+> deployed fleet-wide via the ``agents/_shared/to_home/`` overlay)
+> BLOCKS any unbounded foreground Bash with a WHY message that
+> explains the relaunch routes. This skill explains the rationale;
+> the hook is the wall. If the hook blocks you, the relaunch
+> guidance comes from the hook itself — don't fight it, do not
+> bypass except via the documented escape hatch.
+>
+> **Hook layering** (PreToolUse on the Bash matcher):
+>   1. ``enforce_delegation.sh`` (lead-side, dotfiles) — fires only
+>      for coordinator roles (``lead``, ``head-*``, ``telegram``,
+>      ``proj-*``). Adds the coordinator-extra "delegate to a SAC
+>      peer" guidance on top of the bounded-foreground rule.
+>   2. ``force_background_bash.sh`` (this hook, role-agnostic) —
+>      fires for every agent regardless of role, applies the same
+>      bounded-foreground policy verbatim. The fleet's safety net.
+>   3. ``force_background_agents_always.sh`` (sibling, Agent/Task
+>      matcher) — forces every Agent/Task subagent invocation to use
+>      ``run_in_background=true`` so the parent never blocks on
+>      child work.
+>
+> The three hooks compose: 1 + 2 give "no unbounded foreground
+> Bash"; 3 gives "no foreground subagents".
+
+## The problem (why this rule exists)
+
+The conversation runner reads its inbox sequentially:
+``_runners/_session_conversation.py`` blocks on ``await inbox.get()``
+between turns. Telegram messages, A2A turns, and the autonomous loop
+all post ``TurnEnvelope``s onto the SAME inbox. While ``_drive_turn``
+is running, new envelopes are accepted and queued but **NOT
+processed** until the current turn finishes.
+
+So if your turn is a 4-minute LaTeX compile, the operator's "stop
+that and check this instead" arrives, sits in the queue, and is
+answered four minutes later. The operator hits this repeatedly and
+loses trust in the agent.
+
+The fix is not a smarter interrupt — it is a shorter turn.
+
+## The rule
+
+**Never block the main turn on long-running work.** Launch it in the
+background, end the turn promptly, and handle the result when the
+notification fires.
+
+### Heavy work that MUST go to the background
+
+| Operation | Tool | Background invocation |
+|---|---|---|
+| ``pytest`` (anything > 7s) | Bash | ``Bash(... , run_in_background=True)`` |
+| LaTeX compile (``pdflatex`` / ``xelatex`` / ``latexmk`` / ``tectonic``) | Bash | ``Bash(... , run_in_background=True)`` |
+| Figure build, mermaid render, nbconvert | Bash | ``Bash(... , run_in_background=True)`` |
+| ``make`` / ``cmake`` / ``ninja`` / ``sphinx-build`` | Bash | ``Bash(... , run_in_background=True)`` |
+| Training / inference / large numpy jobs | Bash | ``Bash(... , run_in_background=True)`` |
+| Big git ops (clone of multi-GB repo, ``git filter-repo``) | Bash | ``Bash(... , run_in_background=True)`` |
+| Apptainer / Docker image build | Bash | ``Bash(... , run_in_background=True)`` |
+| ``cargo`` / ``npm`` / ``yarn`` / ``pnpm`` / ``pip install`` | Bash | ``Bash(... , run_in_background=True)`` |
+| ``jupyter`` / nbconvert long render | Bash | ``Bash(... , run_in_background=True)`` |
+| ``sleep N`` for N ≥ 1 | Bash | ``Bash(... , run_in_background=True)`` |
+| Multi-step research / code-review delegation | Agent | ``Agent(... , run_in_background=True)`` |
+| ``gh pr checks --watch`` / CI poll | Bash | ``Bash(... , run_in_background=True)`` |
+| Any download > 100 MB | Bash | ``Bash(... , run_in_background=True)`` |
+| Anything chained with ``&&`` / ``||`` / ``;`` or piped | Bash | ``Bash(... , run_in_background=True)`` |
+
+If you are not sure whether the job is heavy, assume it is. The cost
+of mis-classifying a 2-second job as background is one extra
+notification round-trip; the cost of mis-classifying a 4-minute job
+as foreground is operator frustration.
+
+### Foreground is fine for
+
+Short trivial checks — defined by the hook as ≤50 characters, no
+pipe/redirect/chain (``|`` / ``<`` / ``>`` / ``&&`` / ``;``), and
+no first-token in the known long-runner set:
+
+- Single ``Read`` / ``Edit`` / ``Write`` / ``Grep`` calls (non-Bash).
+- ``pwd``, ``date``, ``whoami``, ``hostname``, ``id``, ``uname``.
+- ``ls -la``, ``cat /etc/hostname``, ``echo ...``, ``head -5 file``.
+- ``git -C /work status -s``, ``git log --oneline -5``, ``git diff HEAD~1``.
+- Anything wrapped in ``timeout N`` where N is 1–7 (with or without
+  the ``s`` suffix).
+
+If the trivial-foreground check fails, the hook blocks you and asks
+you to relaunch via mechanism (1)–(4) above.
+
+## The shape of a responsive turn
+
+```
+Turn N    (operator: "audit the build")
+  ├─ Acknowledge in one line via Telegram reply.
+  ├─ Spawn Agent(run_in_background=true, prompt="audit ...").
+  └─ END THE TURN. ← critical
+        (Inbox is now free; if the operator follows up,
+         it is processed immediately.)
+
+Turn N+1  (notification: agent completed)
+  ├─ Read the agent's report.
+  ├─ Relay summary to operator via Telegram.
+  └─ END THE TURN.
+```
+
+The wrong shape — and the one that produces operator frustration:
+
+```
+Turn N    (operator: "audit the build")
+  ├─ Acknowledge.
+  ├─ Run pytest in the foreground for 90 seconds.
+  ├─ Run gh pr checks --watch for 3 minutes.
+  ├─ Compile LaTeX for another 4 minutes.
+  └─ ... operator's "actually never mind, check X" sat in the queue
+        the whole time.
+```
+
+## Available mechanisms (in claude-agent-sdk + sac runner)
+
+Verified for the bundled Claude Code CLI ``2.1.150`` shipped with
+``claude-agent-sdk 0.2.87`` (the version sac runs inside its SIF):
+
+1. **``Bash(..., run_in_background=True)``** — primary; ~95% of
+   cases. Pure shell command (LaTeX compile, image build, ``pytest``,
+   training, CI watch, large download). The CLI binary 2.1.150
+   exposes ``run_in_background`` on Bash; the sac runner does not
+   strip the parameter (``runtimes/_sdk_common.py:475-478`` only
+   appends "Agent" to ``allowed_tools``). The runtime delivers a
+   completion notification with stdout/stderr on a later turn.
+
+2. **``setsid nohup <cmd> >log 2>&1 </dev/null &``** — explicit
+   detach. Use when the job must survive the agent process itself
+   restarting (e.g. a multi-hour training that should outlive a
+   credential rotation). Pair with a ``tail`` / status-file pattern
+   on a later turn to pick up results. Recognised by the
+   ``force_background_bash.sh`` hook as a valid background route.
+
+3. **``Task`` / ``Agent(..., run_in_background=True)``** — for
+   genuine MULTI-STEP delegated work (research, audits, code
+   review, compile-and-report). The runner explicitly enables
+   Subagents (same line above); the CLI exposes ``run_in_background``
+   on Task. Don't spawn a subagent just to run pytest — use (1).
+   Right when the work has reasoning around it.
+
+4. **``timeout N <cmd>``** where N is 1–7 seconds — bounded
+   foreground. The ``force_background_bash.sh`` hook treats this as
+   an allowed foreground variant. Use only when you genuinely
+   expect the command to finish in ≤7s.
+
+5. **Full-agent peer delegation (`sac peer post-turn ...`)** — for
+   the heaviest, longest-horizon work (days). Spawns another sac
+   agent. See ``18_full-agent-delegation.md``.
+
+Pick the highest-level mechanism that fits. (1) is almost always
+right; (3) when the work has multi-step reasoning around it; (2)
+when the job must survive a restart.
+
+## What "end the turn promptly" means
+
+End the turn as soon as you have:
+
+1. Acknowledged the request (one short reply to the operator).
+2. Spawned the background work.
+3. Done any sub-5-second foreground prep needed to start the
+   background job correctly.
+
+Do **not** stay in the turn to "watch" the background job. The
+runtime delivers a ``<task-notification>`` (for Agent runs) or a
+shell-completion notification (for Bash ``run_in_background``)
+automatically; you will be woken when there is something to do.
+
+## Cache + responsiveness side benefit
+
+Short turns also keep the Anthropic prompt cache warm. The TTL is
+five minutes; a long uninterrupted turn that reads many files at the
+start eats the cache budget even when the model is idle between tool
+calls. Short turns + background offload keep more of the next turn's
+input on cache hits.
+
+## Cross-references
+
+- ``18_full-agent-delegation.md`` — full-agent peer pattern (also
+  inherently async; the launcher's turn ends, the peer runs for hours).
+- ``17_inbound-turn-endpoint.md`` — ``POST /v1/turn`` lands in the
+  same inbox Telegram does; short turns matter for ALL inbound.
+- ``29_progress-reporting-to-lead.md`` — push milestones to the lead;
+  don't make peers poll while a heavy compile blocks your inbox.
+- ``23_telegram-integration.md`` — the delivery path this rule
+  exists to keep responsive.

--- a/skills-archive/scitex-agent-container/31_worktree-path-safety.md
+++ b/skills-archive/scitex-agent-container/31_worktree-path-safety.md
@@ -1,0 +1,95 @@
+---
+description: |
+  [TOPIC] Where agent git-worktrees must (and must NOT) live to avoid silent reaping by the Claude Code harness.
+  [DETAILS] The Claude Code SDK runtime auto-manages files under any `.claude*`-prefixed path (file-history GC + session-dir cleanup). Worktrees created at `<workdir>/.claude/worktrees/`, `<workdir>/.claude-worktrees/`, or any other `.claude*` path are visible to that machinery and can be reaped on an idle-time heuristic — losing uncommitted/unpushed work. Use a NEUTRAL path instead (`<workdir>/worktrees/`, `/tmp/<agent>-worktrees/`).
+tags: [scitex-agent-container-worktree-path-safety]
+---
+
+# Worktree path safety — don't put worktrees under `.claude*/`
+
+> Verified anchor: proj-paper-scitex-clew capsule-0220918 cohort-A
+> incident, 2026-06-06. A worktree at
+> `/work/.claude-worktrees/clear-stale-submission/` with uncommitted
+> changes + a running pytest was reaped by the Claude Code harness on
+> an "agent main-loop idle = stale" heuristic. Clew recovered via a
+> last-minute `cp → /tmp/`; the next agent in the same shape won't be
+> so lucky.
+
+## The rule
+
+**Never create a git worktree at any path whose name starts with
+`.claude`.** That includes the obvious slash variant
+`<workdir>/.claude/worktrees/` AND the hyphen sibling
+`<workdir>/.claude-worktrees/`, AND any `.claude-*` parked-style dir.
+
+## Why
+
+The Claude Code SDK runtime owns the `.claude*` namespace inside an
+agent's workdir. It walks those paths for file-history GC, session-dir
+cleanup, and project-state snapshots; the operator's host-side
+investigation (2026-06-06) traced clew's reaped worktree to harness
+internals (`~/.claude/file-history/`, `~/.claude/projects/...-claude-
+worktrees-agent-...`). The harness is not patchable from this
+package's surface — sidestep it.
+
+## Use a neutral path
+
+The sac convention is **`<workdir>/worktrees/<branch-slug>/`** (no
+`.claude` prefix). This is what `sac` and the in-container runner both
+expect; the harness leaves it alone.
+
+```bash
+# RIGHT — outside the .claude namespace
+git -C /work worktree add -b fix/my-thing /work/worktrees/fix-my-thing origin/develop
+
+# WRONG — inside .claude/, the harness can reap this
+git -C /work worktree add -b fix/my-thing /work/.claude/worktrees/agent-fix-my-thing origin/develop
+
+# WRONG — inside .claude-*, the harness can reap this too
+git -C /work worktree add -b fix/my-thing /work/.claude-worktrees/fix-my-thing origin/develop
+```
+
+For sandbox / scratch work that doesn't need to be next to the repo,
+`/tmp/<agent>-worktrees/<branch>` is also safe — `/tmp` is outside any
+`.claude` namespace.
+
+## Defence-in-depth (already in place for the slash variant)
+
+The in-package pruner `sac agents prune-claude` (the only thing in
+THIS repo that reaps `.claude/worktrees/`) carries lead's five safety
+predicates as of 2026-06-06: a worktree is preserved if (1) it has
+uncommitted changes, (2) it has unpushed commits, (3) a live process
+holds an fd into the dir, or (4) its branch is not merged into
+`origin/develop`/`origin/main`. Idle-time is intentionally NOT used as
+a primary signal; the work-loss predicates fire first. See
+`cli_pkg/_agent_prune_claude.py`.
+
+That defence covers the slash variant `.claude/worktrees/agent-*` that
+sac itself manages. It does NOT cover the harness's reaping of
+arbitrary `.claude*` paths — only the path-placement rule above does.
+Both layers are load-bearing.
+
+## What to do if you find a worktree already under `.claude*/`
+
+1. **Stop and commit + push first** (`git -C <wt> status`,
+   `git add -A && git commit -m "wip rescue"`, `git push -u origin <branch>`).
+   The harness can reap the dir at any moment; salvage state before
+   moving anything.
+2. **Re-anchor under a neutral path:**
+
+   ```bash
+   git -C /work worktree add -b <branch> /work/worktrees/<slug> <branch>
+   git -C /work worktree remove --force /work/.claude*/...   # only after #1
+   ```
+
+3. **Verify** with `git -C /work worktree list` that the new path
+   sticks and the `.claude*` entry is gone.
+
+## See also
+
+- [40_troubleshooting.md](40_troubleshooting.md) — adjacent agent-launch
+  troubleshooting; the worktree-path rule is structural and lives here
+  rather than there.
+- `cli_pkg/_agent_prune_claude.py` — slash-variant pruner with lead's
+  five safety predicates; tests in
+  `tests/scitex_agent_container/cli_pkg/test__agent_prune_claude.py`.

--- a/skills-archive/scitex-agent-container/32_nested-apptainer-builds.md
+++ b/skills-archive/scitex-agent-container/32_nested-apptainer-builds.md
@@ -1,0 +1,76 @@
+---
+description: |
+  [TOPIC] Nested apptainer builds — `spec.apptainer.nested_build`
+  [DETAILS] Let a solver agent build/pull a research capsule's PINNED
+  environment from INSIDE its own SAC apptainer container (pull a CodeOcean
+  published image, or build a Dockerfile-derived def whose %post runs as
+  root), then exec it — so the agent reproduces real outputs to ground its
+  claims instead of fabricating. The recipe, the knob, the hard limit
+  (docker is impossible), and how it pairs with the clew verify gate.
+tags: [scitex-agent-container-nested-apptainer-builds, nested-apptainer, nested-build]
+---
+
+# Nested apptainer builds (`spec.apptainer.nested_build`)
+
+A SAC agent already runs inside an apptainer SIF. With
+`spec.apptainer.nested_build: true` it can run **nested** `apptainer
+build`/`pull`+`exec` to reproduce a capsule's pinned environment ITSELF —
+the alternative to the harness pre-building it (babysitting + overfit) and
+to the agent fabricating when the env won't run in the default interpreter.
+
+## What the knob grants (verified 2026-06-20 in `sac-scitex.sif`)
+
+`nested_build_flags` (`runtimes/_apptainer_nested.py`) adds, at the
+`build_run_argv` seam:
+
+- `--bind /dev/fuse` — `--containall` omits it; the squashfuse mount of a
+  pulled/built SIF needs it (fail-loud if the host lacks `/dev/fuse`).
+- empty-file masks over `/etc/subuid` + `/etc/subgid` — the SIF's
+  `newuidmap` is `agent`-owned (not root), so plain `--fakeroot` FATALs
+  ("newuidmap must be owned by the root user"). Masking subuid drops the
+  user out of `/etc/subuid`, which makes apptainer fall back to the
+  **root-mapped namespace + `fakeroot` command** path — no setuid
+  `newuidmap` needed. `%post`/`RUN` steps then run as (faked) root.
+- `APPTAINER_TMPDIR=/tmp` + `APPTAINER_CACHEDIR=/tmp/.apptainer-cache` —
+  build scratch + OCI cache on the real-disk `/tmp` (relocated there by the
+  `tmpfs_size` `--workdir`). Size `tmpfs_size` up (the 2G default is too
+  small for a multi-GB image).
+
+It adds **no host-FS bind** → composes with `access: capsule` (leak-safety
+preserved). It is **infrastructure → give it to BOTH arms**; the *treatment*
+is the scitexification skill + clew gate, not the capability.
+
+## The agent recipe
+
+```bash
+export APPTAINER_TMPDIR=/tmp APPTAINER_CACHEDIR=/tmp/.apptainer-cache
+# (a) pull a pre-built PUBLISHED image (preferred; CodeOcean capsules name one
+#     in input/REPRODUCING.md, anonymously pullable — no %post, rootless):
+apptainer build env.sif docker://registry.codeocean.com/published/<uuid>:v1
+# (b) OR build the capsule's Dockerfile (convert to a def: `Bootstrap: docker`
+#     + `%post` with the RUN/conda/pip lines — runs as fakeroot):
+apptainer build env.sif env.def
+# run the REAL code, read REAL outputs:
+apptainer exec --bind <data>:/data --bind <code>:/code --bind "$PWD/results":/results \
+  env.sif bash -lc 'cd /code && bash run'
+```
+
+## Hard limit — no Docker
+
+You **cannot** run Docker nested: there is no Docker daemon inside the
+unprivileged container, and none is grantable (it needs root + cgroup/iptables
+control). It is also unnecessary — `apptainer build docker://…` pulls the same
+OCI layers with no daemon. Build-from-Dockerfile needs the base image to carry
+`/etc/subuid` (every real distro base — debian/ubuntu/miniconda/python — does;
+busybox does not).
+
+## Pairs with the clew verify gate
+
+`nested_build` is the *capability*; the honest-grounding **gate** (a `Stop`
+hook running `clew verify --strict`, env-gated by `SCITEX_CLEW_VERIFY_GATE`)
+is what *forces* the agent to use it: a fabricated value has no
+`@stx.session` lineage → `NO_LINEAGE` → `DONE` refused → reproduce (via the
+recipe above) or abstain (`null` + reason). See the `scitex-clew`
+(`21_agentic-reasoning`) and `scitexification` (`04_repro-clew`, Stage 4.0)
+skills. Field reference: [`spec-reference.md`](../../../docs/spec-reference.md)
+(`spec.apptainer.nested_build`).

--- a/skills-archive/scitex-agent-container/40_periodic-drive-consumer.md
+++ b/skills-archive/scitex-agent-container/40_periodic-drive-consumer.md
@@ -1,0 +1,69 @@
+---
+description: |
+  [TOPIC] Periodic-drive turn consumer (agent-side)
+  [DETAILS] How to interpret incoming a2a inbox events with `kind == "periodic_drive"` — re-injection of standing rules, mission, and current work state from the sac periodic-drive lane (not a new task from lead/operator).
+tags: [scitex-agent-container-periodic-drive-consumer]
+---
+
+# Periodic-drive turn consumer (agent-side)
+
+When you (the agent) receive an a2a inbox event with
+`kind == "periodic_drive"`, treat its `body` as a SYSTEM RE-INJECTION
+of your standing rules, current mission, and current work state.
+This is NOT a new task from the lead/operator — it's the sac
+periodic-drive lane keeping you on-mission across context churn.
+
+The envelope:
+
+```json
+{
+  "kind": "periodic_drive",
+  "body": "[sac periodic drive — <name>]\n\n## Standing rules\n…\n## Current mission\n…\n## Current work (state.db + git)\n…\n## Action\n…",
+  "generated_at": <unix_ts>,
+  "from_agent": "sac-periodic-drive"
+}
+```
+
+## What to do on receipt
+
+1. **Re-read your state** as described in the body. The fields are
+   pulled mechanically from your `spec.yaml` + the registry's
+   active git worktree — they are the AUTHORITATIVE current view.
+
+2. **Decide your next action** toward your mission, using the
+   re-injected rules. Common patterns:
+   - Mid-task → CONTINUE the task; the drive is a heartbeat, not
+     a context switch.
+   - Waiting on Spartan/CI/lead → CHECK status, report if changed,
+     otherwise stay idle.
+   - Idle without pending work → re-read your mission, propose
+     the next concrete action to lead via a2a.
+   - Mission complete → SIGNAL lead via a2a; do not start a new
+     mission unilaterally.
+
+3. **Do NOT echo the body back**. The drive lane is a one-way
+   reminder; replying to `sac-periodic-drive` is a no-op (the
+   sender is a daemon, not an agent).
+
+## What NOT to do
+
+- Do not treat the drive turn as a new directive from the lead.
+- Do not start a new mission you weren't already on.
+- Do not flood the lead with status reports — only when the state
+  changed.
+- Do not modify code in response to the drive turn unless the
+  body's `Action` section tells you to.
+
+## Opt-out
+
+The lane is opt-in by default (`spec.periodic_drive.enabled: true`).
+To disable per-agent: `spec.periodic_drive.enabled: false`.
+Operator can pause the whole fleet via
+`SAC_PERIODIC_DRIVE_DISABLED=1` on the listen process env.
+
+## See also
+
+- `_lifecycle/_periodic_drive.py` — sweep + envelope builder.
+- `_lifecycle/_periodic_drive_loop.py` — listen-server lifespan
+  ticker.
+- Lead a2a: `4973264a`, `12a0d8f6`, `7916f486`.

--- a/skills-archive/scitex-agent-container/40_troubleshooting.md
+++ b/skills-archive/scitex-agent-container/40_troubleshooting.md
@@ -1,0 +1,179 @@
+---
+description: |
+  [TOPIC] Agent Launch Troubleshooting
+  [DETAILS] Common launch failures and their fixes for scitex-agent-container agents..
+tags: [scitex-agent-container-troubleshooting]
+---
+
+# Agent Launch Troubleshooting
+
+## Session dies during auto-accept
+
+The multiplexer session dies before prompts are accepted.
+
+### Cause 1: `--continue` with no valid session
+
+Claude Code's `--continue` flag fails if there's no resumable session.
+
+**Fix:** Set `session: new` in the YAML.
+
+### Cause 2: Startup commands sent into TUI prompt
+
+If auto-accept times out (e.g., `hardcopy` fails on macOS with screen), startup commands get typed into the TUI prompt, selecting wrong options.
+
+**Fix:** Use `multiplexer: tmux` (default) instead of screen. tmux's `capture-pane` works reliably on macOS.
+
+### Cause 3: Wrong python / missing packages
+
+**Fix:** Set `spec.venv` to activate the correct virtualenv:
+
+```yaml
+spec:
+  venv: ~/.venv
+```
+
+## Auto-accept logs
+
+Check `~/.scitex/agent-container/runtime/logs/{name}/auto-accept.log`:
+
+```bash
+cat ~/.scitex/agent-container/runtime/logs/my-agent/auto-accept.log
+```
+
+Shows every poll cycle: pane content, matched handlers, timeouts.
+
+## Debugging a failed launch
+
+### With tmux (recommended)
+
+```bash
+# Kill stale session
+tmux kill-session -t <name> 2>/dev/null
+
+# Launch manually
+cd <workdir>
+tmux new-session -d -s <name>-debug "bash -l -c 'claude --model opus[1m] --dangerously-skip-permissions; sleep 30'"
+
+# Check content
+sleep 5
+tmux capture-pane -t <name>-debug -p
+
+# Send keystrokes manually
+tmux send-keys -t <name>-debug 2 Enter    # Select option 2
+```
+
+### With screen (legacy)
+
+```bash
+screen -dmS <name>-debug bash -l -c 'claude --model opus[1m] --dangerously-skip-permissions; exec bash'
+sleep 10
+screen -S <name>-debug -X hardcopy /tmp/<name>-debug.txt
+cat /tmp/<name>-debug.txt
+```
+
+## TUI prompt handling
+
+Claude Code shows confirmation prompts for dangerous flags. The auto-accept system (`runtimes/prompts.py`) handles them:
+
+| Prompt | Option | Keys |
+|--------|--------|------|
+| Bypass Permissions | "2. Yes, I accept" | `2`, `Enter` |
+| Dev channels | "1. I am using this for local development" | `1`, `Enter` |
+| Thinking effort | "1. Medium (recommended)" | `1`, `Enter` |
+
+Prompts may appear in any order. New prompts can be added to `PROMPT_HANDLERS` in `prompts.py`.
+
+**Manual keystroke sending (tmux):**
+```bash
+tmux send-keys -t <name> 2 Enter     # Select option 2
+tmux send-keys -t <name> 1 Enter     # Select option 1
+```
+
+## macOS screen issues
+
+`screen -X hardcopy` returns empty on macOS. Additionally, SSH-started screens use `/var/folders/...` while local terminals use `~/.screen`.
+
+**Fix:** Use `multiplexer: tmux` (default since v0.7).
+
+## Workspace CLAUDE.md marker abort (`WorkspaceCLAUDEMarkerError`)
+
+`scitex-agent-container start` refuses to deploy when the existing
+`~/.scitex/agent-container/runtime/workspaces/<agent>/CLAUDE.md` is non-empty but does not
+contain the canonical marker pair:
+
+```
+<!-- Start of scitex-agent-container generated section (<ts>) -->
+...managed block, overwritten on every deploy...
+<!-- End of scitex-agent-container generated section -->
+...user tail, preserved across restarts...
+```
+
+Hard-fail contract (see `runtimes/_to_home.py::_validate_marker_invariants`,
+per ywatanabe spec msg 5250–5260):
+
+- exactly **one** Start marker
+- exactly **one** End marker
+- Start before End
+
+Any violation aborts the deploy rather than guessing, because the tail past
+the End marker is user-editable content and silent overwrite would destroy
+work.
+
+### Symptom
+
+```
+WorkspaceCLAUDEMarkerError: /Users/.../workspaces/<agent>/CLAUDE.md:
+expected exactly 1 Start marker and 1 End marker, found Start=0 End=0.
+Refusing to deploy to avoid data loss.
+```
+
+Agents that hit this stay down (session fails to start, no tmux pane).
+
+### Root cause (observed 2026-04-15, head-mba restart batch)
+
+Legacy workspace CLAUDE.md files from older agent-container versions were
+~7-line placeholders with zero custom content and no markers at all. The
+validator does not distinguish placeholder from contaminated, so any
+markerless non-empty file blocks the deploy.
+
+### Recovery procedure
+
+1. **Inspect first.** Check whether there is any content worth keeping:
+   ```bash
+   cat ~/.scitex/agent-container/runtime/workspaces/<agent>/CLAUDE.md
+   ```
+   Typical placeholder is 5–10 lines of boilerplate; if so, nothing to save.
+2. **Back up custom tail** (if any real content exists):
+   ```bash
+   cp ~/.scitex/agent-container/runtime/workspaces/<agent>/CLAUDE.md \
+      ~/.scitex/agent-container/runtime/workspaces/<agent>/CLAUDE.md.bak
+   ```
+3. **Remove the unmarked file:**
+   ```bash
+   rm ~/.scitex/agent-container/runtime/workspaces/<agent>/CLAUDE.md
+   ```
+4. **Re-run start.** Deploy will now treat the workspace as empty and
+   write a fresh managed section with both markers:
+   ```bash
+   # shared definition (or swap `shared` -> `<host>` for a host-specific agent)
+   scitex-agent-container start ~/.scitex/agent-container/agents/<agent>/<agent>.yaml
+   ```
+5. **Re-append custom tail** (if you backed up real content) **below** the
+   End marker in the newly written file, not above it.
+
+### Never do
+
+- Do not delete workspace CLAUDE.md files in bulk without inspecting — a
+  real custom tail looks just like a placeholder in a directory listing.
+- Do not hand-patch the start marker onto a placeholder. A start marker
+  without the matching canonical end marker is still a hard-fail, and
+  hand-rolled timestamps drift from the generated ones.
+- Do not edit anything between the markers. That block is regenerated on
+  every restart and changes are lost.
+
+### Prevention
+
+Agents that need persistent per-workspace notes should write them strictly
+**below** the End marker. The guide comment immediately after the End
+marker spells this out — if you see an agent editing above it, flag the
+error and move the content down.

--- a/skills-archive/scitex-agent-container/41_claude-worktree-relocation.md
+++ b/skills-archive/scitex-agent-container/41_claude-worktree-relocation.md
@@ -1,0 +1,96 @@
+---
+description: |
+  [TOPIC] Claude Code worktree relocation hooks (F-CS8 prevention)
+  [DETAILS] Canonical WorktreeCreate/WorktreeRemove hook scripts that relocate
+  Claude Code's default `.claude/worktrees/<name>` creations to
+  `<git-root>/.worktrees/<name>` where the operator's prune cron maintains
+  hygiene. Stops the recurring multi-GB / 100k-file accumulation that wedges
+  agents (F-CS8 recurrence ~100×, neurovista wedge 22.9 GB / 80k files).
+tags: [scitex-agent-container-claude-worktree-relocation]
+---
+
+# Claude Code worktree relocation — F-CS8 prevention
+
+Claude Code's bundled binary creates session/agent worktrees under
+`.claude/worktrees/<name>` by default. That tree is never self-cleaned
+and accumulates multi-GB / 100k-file bloat that wedges agents (F-CS8
+recurrence ~100×; wedged neurovista at 22.9 GB / 80k files → 0-output
+turns). The operator's daily prune cron maintains hygiene on
+`<root>/.worktrees/` (mtime-gated, never touches `.claude/`). The
+`WorktreeCreate` / `WorktreeRemove` hooks land the prevention side of
+the same policy: relocate every creation to the cron-maintained tree.
+
+## Canonical asset location
+
+The verified hook scripts + settings fragment live in this repo at:
+
+    src/scitex_agent_container/_baseline_assets/claude_worktree_hooks/
+      ├── worktree_create.py
+      ├── worktree_remove.py
+      ├── settings.local.json.fragment.json
+      └── README.md
+
+Regression tests:
+
+    tests/scitex_agent_container/_baseline_assets/claude_worktree_hooks/
+      └── test_worktree_hooks.py
+
+The tests drive the real scripts as subprocesses against an ephemeral
+on-disk git repo (`tmp_path` + `git init`) — no mocks, no patches. They
+pin the I/O contract, the relocation invariant, the `claude/<name>`
+branch policy, the idempotence guarantees, and the loud-fail
+diagnostics.
+
+## Deployment (operator-side)
+
+1. Copy both `worktree_create.py` and `worktree_remove.py` into the
+   baseline to_home tree:
+
+       <agents_dir>/_shared/to_home/.claude/hooks/claude_worktree_hooks/
+
+2. Merge the `hooks` block from
+   `settings.local.json.fragment.json` into
+   `<agents_dir>/_shared/to_home/.claude/settings.local.json` (under the
+   top-level `hooks` key). Preserve the `_comment_worktree_hooks`
+   string — it carries the source-of-truth audit trail.
+
+3. Restart agents (or wait for next natural restart). NO SIF REBUILD.
+   The runtime's `deploy_to_home` (see `runtimes/_to_home.py`)
+   materializes the baseline tree into every agent's `$HOME` on every
+   start, so the hooks + settings land before Claude Code reads its
+   config.
+
+## Verification before fleet-wide
+
+The hook event names + the I/O shape were verified 2026-06-06 against
+the deobfuscated `executeWorktreeCreateHook` (`VRH`) function in the
+`claude_agent_sdk._bundled.claude` binary shipped with the runner's
+venv. The regression tests pin both. The live-probe on
+proj-scitex-agent-container's runtime container (2026-06-06) drove the
+real hook against the real `/work` repo and:
+
+* `worktree_create.py` echoed `/work/.worktrees/live-probe-1`, created
+  the dir, registered it in `git worktree list`, and put it on branch
+  `claude/live-probe-1` based at `origin/develop`.
+* `worktree_remove.py` unregistered the worktree on the matching
+  payload, exited 0.
+
+Before broad deploy on any new SDK version, re-run the live-probe and
+the regression tests — the SDK is the contract source-of-truth and
+silent schema drift would break the relocation.
+
+## Why this lives in sac, not in dotfiles
+
+The hook scripts are canonical, version-controlled, regression-tested
+implementations of a fleet-wide policy. Shipping them here (instead of
+ad-hoc in the operator's dotfiles `_shared/to_home/`) means:
+
+* The implementation has an audit trail (commit history + PR review).
+* The hook contract is pinned by tests, not by the operator's memory.
+* SDK upgrades have a single place to re-verify.
+* The dotfiles baseline syncs from a single source-of-truth path.
+
+The deployment step (copy + settings-merge) is operator-driven because
+the dotfiles tree is the operator's, not sac's. Future work could
+package this as a `sac to_home seed-baseline` CLI command that pulls
+the canonical assets into the dotfiles baseline tree automatically.

--- a/skills-archive/scitex-agent-container/SKILL.md
+++ b/skills-archive/scitex-agent-container/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: scitex-agent-container
+description: |
+  [WHAT] Declarative YAML AI-agent lifecycle — define an agent in one `spec.yaml`; `sac agents start` runs it as a long-lived Claude SDK session inside Apptainer, with A2A inbound (`POST /v1/turn`), SSH remote deploy, JSON status.
+  [WHEN] Launching/managing a Claude Code agent or fleet, running one on a remote host, wiring MCP, talking over A2A, or any mention of `sac agents start`, `scitex-agent-container`, `spec.yaml`, fleet head/worker.
+  [HOW] `pip install scitex-agent-container`, then `sac agents start <name>` or `import scitex_agent_container`.
+tags: [scitex-agent-container]
+primary_interface: cli
+interfaces:
+  python: 2
+  cli: 3
+  mcp: 1
+  skills: 2
+  http: 0
+---
+
+# scitex-agent-container
+
+> **Interfaces:** Python ⭐⭐ · CLI ⭐⭐⭐ (primary) · MCP ⭐ · Skills ⭐⭐ · Hook — · HTTP —
+
+Declarative lifecycle management for AI coding agents (Claude Code):
+define an agent in `spec.yaml`, launch it as a long-lived Claude SDK
+session inside Apptainer (local or remote via SSH), observe via
+`sac agents list`/`tail`/`health`.
+
+## What the package ships
+
+| Surface | Location |
+|---|---|
+| Python API | `scitex_agent_container` (`AgentConfig`, `load_config`, `Registry`; `agent.*`/`peer.*`/`host.*`) |
+| CLI | `scitex-agent-container`, `sac` — see [10_cli.md](10_cli.md) |
+| MCP servers | None bundled — agents spawn their own via `to_home/.mcp.json` |
+| Config format | v3 `scitex-agent-container/v3` only — v2 rejected |
+
+## Sub-skills
+
+### Onboarding & interfaces
+- [01_installation.md](01_installation.md) — pip install + auth + per-host hook
+- [02_quick-start.md](02_quick-start.md) — first agent in 30 seconds
+- [03_python-api.md](03_python-api.md) — programmatic surface (`agent.start`, `peer.post_turn`, ...)
+- [04_cli-reference.md](04_cli-reference.md) — every `sac` subcommand
+- [05_mcp-tools.md](05_mcp-tools.md) — `sac mcp` server, tool inventory, install snippet
+- [06_http-api.md](06_http-api.md) — `POST /v1/turn` wire format (`spec.a2a.port` enables)
+
+### Core
+- [01_config-v3.md](01_config-v3.md) — v3 format; dir-as-SSoT; rejects v2-era keys
+- [02_multiplexer.md](02_multiplexer.md) — vestigial; lead-only tmux wrap
+- [03_auto-accept.md](03_auto-accept.md) — modular prompt handlers
+- [04_resource-management.md](04_resource-management.md) — resource management
+- [05_resource-heartbeat.md](05_resource-heartbeat.md) — resource heartbeat
+- [06_env-injection-ports.md](06_env-injection-ports.md) — four env-injection ports + decision tree
+- [07_a2a-protocol.md](07_a2a-protocol.md) — native A2A protocol (`sac a2a serve`)
+- [07_a2a-protocol-extension-fields.md](07_a2a-protocol-extension-fields.md) — `x-scitex-agent-container.*` AgentCard fields
+- [08_templates.md](08_templates.md) — six pattern templates + examples
+- [14_claude-session-state.md](14_claude-session-state.md) — state-dir layout, auth precedence, `sdk_session` status
+- [15_claude-session.md](15_claude-session.md) — SDK runner (in-SIF) + `POST /v1/turn` inbound
+- [16_claude-session-migration.md](16_claude-session-migration.md) — historical: claude-code → SDK migration
+- [17_inbound-turn-endpoint.md](17_inbound-turn-endpoint.md) — `POST /v1/turn` wire format + sidecar replacement
+- [18_full-agent-delegation.md](18_full-agent-delegation.md) — delegate to another *full* agent (vs Task subagent)
+- [19_full-agent-troubleshooting.md](19_full-agent-troubleshooting.md) — stuck-peer recovery + reaper pattern
+
+### Workflows
+- [10_cli.md](10_cli.md) — CLI commands and Python API
+- [11_remote-deploy.md](11_remote-deploy.md) — SSH deployment, src files, venv
+- [12_wsl-connectivity.md](12_wsl-connectivity.md) — WSL connectivity notes
+- [24_image-build.md](24_image-build.md) — apptainer `.sif` build/rebuild, rebuild-to-ship gotcha
+- [25_claude-setup-delivery.md](25_claude-setup-delivery.md) — `to_home`→`$HOME`, overlay/`--home`, settings hook
+- [26_credentials-rotation.md](26_credentials-rotation.md) — OAuth + auth mechanics
+- [26_credentials-rotation-host.md](26_credentials-rotation-host.md) — refresh + one-refresher invariant + host cron / watch-live / CI rotation
+- [27_credentials-relogin.md](27_credentials-relogin.md) — verified re-login (tmux code-paste) + 401-recovery
+- [28_credential-refresh.md](28_credential-refresh.md) — refresh creds without restart; running agents re-read on next turn
+- [29_progress-reporting-to-lead.md](29_progress-reporting-to-lead.md) — milestone push to lead via a2a_send
+- [30_responsiveness-background-work.md](30_responsiveness-background-work.md) — short turns; long work backgrounded so Telegram answers fast
+- [31_worktree-path-safety.md](31_worktree-path-safety.md) — keep worktrees outside `.claude*/`; harness reaps that namespace
+- [32](32_nested-apptainer-builds.md)
+
+### Reference
+- [13_observability.md](13_observability.md) — `sac agents status` JSON contract
+
+### Lessons
+- [40_troubleshooting.md](40_troubleshooting.md) — Common issues and debugging
+- [40_periodic-drive-consumer.md](40_periodic-drive-consumer.md)
+- [41](41_claude-worktree-relocation.md)
+
+## Environment
+
+- [20_env-vars.md](20_env-vars.md) — `SCITEX_*` env vars read at runtime
+- [21_cli-startup-budget.md](21_cli-startup-budget.md) — keep `sac --help` < 500 ms via LazyGroup
+- [22_host-passthrough.md](22_host-passthrough.md) — `spec.mounts`/`spec.user`/`spec.env` for host fs/git/gh access
+- [23_telegram-integration.md](23_telegram-integration.md) — Telegram bridge (`_telegram/`), `telegram_*` MCP tools, channel-push, lead-only auth
+
+## 30-second start
+
+```bash
+pip install scitex-agent-container
+# Each agent lives in its own dir; the dir name is the agent name.
+mkdir -p ~/.scitex/agent-container/agents/my-agent
+$EDITOR ~/.scitex/agent-container/agents/my-agent/spec.yaml   # see 01_config-v3.md
+sac agents start my-agent          # daemon by default; --foreground streams stdio
+sac agents list my-agent --json    # status view
+sac agents tail my-agent           # render session.jsonl transcript
+```

--- a/skills-archive/scitex-agent-container/responsiveness_doctrine.py
+++ b/skills-archive/scitex-agent-container/responsiveness_doctrine.py
@@ -1,0 +1,47 @@
+"""Programmatic surface for the fleet-wide responsiveness doctrine.
+
+The responsiveness doctrine is shipped as a skill markdown file
+(``30_responsiveness-background-work.md``) and a CLAUDE.md template
+section in the example agent (``examples/agents/full-agent/to_home/
+CLAUDE.md``). Both surfaces are static text — they ship to every
+agent on next restart via the package's ``_skills`` rollout and the
+``to_home`` materialisation.
+
+This module gives test code (and any tooling that wants to verify
+the doctrine is materially present in a deployed agent) a single
+import-able handle: the canonical title string, the four relaunch
+routes, and the operator-wording marker.
+
+The doctrine itself reads:
+
+  Never block the main turn on long-running work. If a Bash command
+  would run for more than ~7 seconds, launch it in the background
+  and end your turn promptly; the runtime delivers the completion as
+  a ``<task-notification>`` on a later turn. The operator's Telegram
+  message must NOT wait until your heavy turn finishes — the runner
+  reads ONE inbox sequentially. Operator wording (8843 / 8845):
+  ``作業中断はしてほしくない``.
+
+Reference: ``30_responsiveness-background-work.md`` (canonical body).
+"""
+
+from __future__ import annotations
+
+DOCTRINE_TITLE: str = "Responsiveness — keep the main turn free"
+
+# The four canonical relaunch routes the force_background_bash hook
+# offers when it blocks a heavy foreground Bash. Pinned here so test
+# code and tooling can detect drift in the hook's block-message.
+RELAUNCH_ROUTES: tuple[str, ...] = (
+    "Bash(..., run_in_background=True)",
+    "setsid nohup <cmd> >/tmp/job.log 2>&1 </dev/null &",
+    "Task / Agent(..., run_in_background=True)",
+    "timeout 7 <cmd>",
+)
+
+# Operator's exact wording the hook quotes — pinned so a future
+# rewrite that drops it surfaces as a test failure.
+OPERATOR_WORDING_MARKER: str = "作業中断はしてほしくない"
+
+# The escape-hatch env var the hook honours.
+ESCAPE_HATCH_ENV: str = "CC_ALLOW_FOREGROUND_HEAVY"

--- a/skills-archive/scitex-agent-container/scitex_smoke_test.py
+++ b/skills-archive/scitex-agent-container/scitex_smoke_test.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Smoke test for scitex ecosystem packages.
+
+For each package, attempts:
+  1. `import <module>`
+  2. CLI `<entry> --help`
+
+Packages not installed are reported as SKIP. Exit 0 if no FAIL, else 1.
+
+Fleet regression prevention script. Validated across the Orochi fleet
+(Spartan, NAS, MBA, ywata-note-win) prior to landing here. Lives beside
+the scitex-agent-container skill so agents and CI can discover it.
+
+Tracks: ywatanabe1989/todo#194
+Origin: authored by head-spartan in the Orochi fleet.
+Usage:
+    ./scitex-smoke-test.py            # human-readable
+    ./scitex-smoke-test.py --json     # machine-readable
+"""
+
+import importlib
+import json
+import shutil
+import subprocess
+import sys
+
+import click
+
+# (pip-name, import-module, cli-entry)
+PACKAGES = [
+    ("scitex", "scitex", "scitex"),
+    ("scitex-agent-container", "scitex_agent_container", "scitex-agent-container"),
+    ("scitex-container", "scitex_container", "scitex-container"),
+    ("scitex-dev", "scitex_dev", "scitex-dev"),
+    ("scitex-orochi", "scitex_orochi", "scitex-orochi"),
+    ("scitex-ui", "scitex_ui", "scitex-ui"),
+    ("scitex-io", "scitex_io", "scitex-io"),
+    ("scitex-plt", "scitex_plt", "scitex-plt"),
+    ("scitex-stats", "scitex_stats", "scitex-stats"),
+    ("scitex-pd", "scitex_pd", "scitex-pd"),
+    ("scitex-str", "scitex_str", "scitex-str"),
+    ("scitex-path", "scitex_path", "scitex-path"),
+    ("scitex-dict", "scitex_dict", "scitex-dict"),
+    ("scitex-gen", "scitex_gen", "scitex-gen"),
+    ("scitex-dsp", "scitex_dsp", "scitex-dsp"),
+    ("scitex-torch", "scitex_torch", "scitex-torch"),
+]
+
+
+def _try_import(module):
+    try:
+        importlib.import_module(module)
+        return True, ""
+    except (
+        ImportError
+    ):  # stx-allow: fallback (reason: optional dependency not installed)
+        return None, "not installed"
+    except Exception as e:  # stx-allow: fallback (reason: catch-all safety net — see inline comment for context)
+        return False, f"{type(e).__name__}: {e}"
+
+
+def _try_cli(entry, timeout=15):
+    path = shutil.which(entry)
+    if not path:
+        return None, "cli not found"
+    try:
+        r = subprocess.run(
+            [path, "--help"], capture_output=True, text=True, timeout=timeout
+        )
+        if r.returncode == 0:
+            return True, ""
+        tail = (r.stderr or r.stdout).strip().splitlines()[-1:] or [""]
+        return False, f"exit {r.returncode}: {tail[0][:160]}"
+    except (
+        subprocess.TimeoutExpired
+    ):  # stx-allow: fallback (reason: subprocess execution failure)
+        return False, f"timeout after {timeout}s"
+    except Exception as e:  # stx-allow: fallback (reason: catch-all safety net — see inline comment for context)
+        return False, f"{type(e).__name__}: {e}"
+
+
+@click.command(context_settings={"help_option_names": ["-h", "--help"]})
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Machine-readable output.",
+)
+def main(as_json: bool) -> None:
+    """Smoke-test all SciTeX ecosystem packages and report PASS/FAIL/SKIP.
+
+    \b
+    Example:
+      $ scitex-smoke-test
+      $ scitex-smoke-test --json
+    """
+    results = []
+    for pip_name, module, entry in PACKAGES:
+        imp_ok, imp_msg = _try_import(module)
+        if imp_ok is None:
+            status, detail = "SKIP", imp_msg
+        else:
+            cli_ok, cli_msg = _try_cli(entry)
+            if imp_ok and (cli_ok or cli_ok is None):
+                status = "PASS"
+                detail = cli_msg if cli_ok is None else ""
+            else:
+                status = "FAIL"
+                detail = "; ".join(
+                    x
+                    for x in [
+                        f"import: {imp_msg}" if not imp_ok else "",
+                        f"cli: {cli_msg}" if cli_ok is False else "",
+                    ]
+                    if x
+                )
+        results.append({"package": pip_name, "status": status, "detail": detail})
+
+    counts = {"PASS": 0, "FAIL": 0, "SKIP": 0}
+    for r in results:
+        counts[r["status"]] += 1
+
+    if as_json:
+        click.echo(json.dumps({"results": results, "summary": counts}, indent=2))
+    else:
+        width = max(len(r["package"]) for r in results)
+        for r in results:
+            line = f"  {r['status']:4}  {r['package']:<{width}}"
+            if r["detail"]:
+                line += f"  ({r['detail']})"
+            click.echo(line)
+        print(
+            f"\nSummary: {counts['PASS']} pass, {counts['FAIL']} fail, "
+            f"{counts['SKIP']} skip (of {len(results)})"
+        )
+
+    if counts["FAIL"]:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/scitex_agent_container/_skills/scitex-agent-container/04_cli-reference.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/04_cli-reference.md
@@ -1,131 +1,75 @@
 ---
 description: |
-  [TOPIC] sac CLI reference
-  [DETAILS] Lifecycle (start/stop/restart/status/health/tail/recall/check/find), image lifecycle (build/sandbox/update/freeze/list/switch/rollback/status/snapshot — delegates to scitex-container), account/quota, network/peer/A2A, db, registry, event, MCP introspection. Long-form flag tables in 10_cli.md.
+  [TOPIC] sac CLI — map of command groups + the non-obvious gotchas
+  [DETAILS] Which `sac` group does which job (agents / image / accounts / host / peer / a2a / fleet / db / mcp), plus renamed-verb history, apptainer-only build, the image sandbox cycle, and other judgment the `--help` output does NOT tell you. The exhaustive per-command flag list is self-describing — run `sac --help-recursive`.
 tags: [scitex-agent-container-cli-reference]
 ---
 
-# CLI Reference
+# CLI Reference — intent map, not a flag dump
 
-Entry: `sac` (alias for `scitex-agent-container`).
+Entry point: `sac` (alias for `scitex-agent-container`) — one Click app.
 
-```
-sac [OPTIONS] COMMAND [ARGS]...
-```
+**The authoritative, always-current command + flag list is the CLI
+itself.** Do not read it from a skill (it drifts):
 
-Global flags:
-- `-h / --help` — show help
-- `--help-recursive` — show help for the root command and every subcommand
-- `--json` — emit structured JSON where supported (status / actions / events)
-- `--on PEER` — dispatch the rest of argv via ssh on `PEER` (defined in `config.yaml`'s `peers:` block)
-
-## Agent lifecycle (most-used)
-
-| Command | Purpose |
-|---|---|
-| `sac agents start <agent> [--foreground]` | Start the agent. Daemon by default; `--foreground` streams stdio + blocks. Honors `spec.host` / `spec.hosts` (cross-host placement; see [11_remote-deploy.md](11_remote-deploy.md)) and `spec.a2a.port` (HTTP inbound). |
-| `sac agents stop <agent>` | SIGTERM the runner; escalate to SIGKILL after 5 s. ssh-mediated for remote agents. |
-| `sac agents restart <agent>` | Stop + start, preserving session_id resume. |
-| `sac agents status [<agent>]` | Per-agent rich payload, or fleet view if no name. `--snapshot` persists a state capsule, `--priority` adds the singleton-yield report. |
-| `sac agents health <agent>` | Health-method poll (`sdk-alive`). |
-| `sac agents tail   <agent>` | Render `session.jsonl` (user / assistant / tool / result events). ssh-tails remote logs. |
-| `sac agents recall <agent>` | Human summary of the agent's session. |
-| `sac agents check  <agent>` | Preflight: validate yaml + probe runtime deps (docker/python). |
-| `sac agents find   <capability>` | Search agents by capability label. |
-
-Multi-target: `sac agents start a b c` works for daemon mode; `--foreground` is single-target only.
-
-The earlier verbs `validate`, `take-snapshot`, `check-priority`, `inspect`, `logs`, `list` were folded into `check`, `status --snapshot`, `status --priority`, `status` (per-agent), `tail`, and `status` (fleet view) respectively.
-
-## Image lifecycle (`sac image`)
-
-Delegates the heavy lifting to [`scitex-container`](https://github.com/ywatanabe1989/scitex-container).
-
-| Command | Purpose |
-|---|---|
-| `sac image build [base\|scitex] [--sandbox]` | Build a layered Apptainer image. Default target: `base`. `--sandbox` builds a writable rootfs directory instead of an immutable SIF. Sac is apptainer-only since 2026-05-13 — no `--runtime` flag. |
-| `sac image sandbox SOURCE` | Convert an existing SIF (or layer name) into a writable sandbox. |
-| `sac image update SANDBOX [-p PKG]` | Refresh packages inside a sandbox via `pip install --upgrade`. Default: `scitex[all]`. |
-| `sac image freeze SANDBOX OUT.sif` | Bake a sandbox back into an immutable SIF. |
-| `sac image list` | Installed SIF versions on disk. |
-| `sac image switch <version>` | Atomically switch the active SIF symlink to a different version. |
-| `sac image rollback` | Restore the previous active version. |
-| `sac image status` | Unified container dashboard (active version, sandboxes, sizes). |
-| `sac image snapshot [-o env.json]` | Reproducibility capsule: pip + apt + conda + git + active SIF hash. |
-
-Typical "scitex updates often" cycle:
-
-```
-sac image build scitex --sandbox       # one-time
-sac image update sandbox/              # any time
-sac image freeze sandbox/ scitex-X.sif # when stable
-sac image switch X
+```bash
+sac --help-recursive        # root + every subcommand, one shot
+sac <group> --help          # e.g. sac agents --help
 ```
 
-## Account / quota (`sac accounts`)
+This leaf keeps only what `--help` can't tell you: which group to
+reach for, and the gotchas.
 
-| Command | Purpose |
+## Which group for which job
+
+| Job | Group |
 |---|---|
-| `sac accounts list` | Stored Claude Code accounts + active block; per-store freshness column (`VALID (+Xh)` / `EXPIRED (-Xh)` / `ABSENT`). |
-| `sac accounts save <name>` | Snapshot current credentials under `<name>` for later rotation. |
-| `sac accounts sync-live` | Snapshot the live credential into its matching store (store-name = email slugified). Idempotent; fails loud on an expired/absent live cred (never saves a stale token). |
-| `sac accounts watch-live` | Daemon: watch `~/.claude/.credentials.json` (inotify or poll) and auto-run `sync-live` on every change — "the moment I log in → auto-saved". |
-| `sac accounts switch <name>` | Switch active credentials to a stored account. |
-| `sac accounts delete <name>` | Remove a stored account. |
-| `sac accounts status` | One-shot quota snapshot (5h%, 7d%, account email + tier). |
-| `sac accounts watch-quota` | Monitor quota and auto-rotate when threshold exceeded. |
+| Start/stop/inspect an agent | `sac agents …` (start, stop, restart, status, health, tail, recall, check, find, send) |
+| Resume a running agent for one more turn | `sac agents send <name> "…"` (see [15_claude-session.md](15_claude-session.md)) |
+| Build / switch the Apptainer image | `sac image …` (delegates to [scitex-container](https://github.com/ywatanabe1989/scitex-container)) |
+| Rotate / snapshot Claude credentials | `sac accounts …` (see [26_credentials-rotation.md](26_credentials-rotation.md)) |
+| Host routing / cross-host exec | `sac host …` |
+| Drive another agent's `/v1/turn` | `sac peer post-turn`, `sac a2a …` (see [07_a2a-protocol.md](07_a2a-protocol.md)) |
+| Push a typed event to the lead | `sac fleet notify done\|blocker\|status` |
+| Inspect the state DB | `sac db …` |
+| HTTP/JSON control plane | `sac listen …` (see [10_cli.md](10_cli.md)) |
 
-## Network / peer / A2A
+Global flags worth knowing: `--json` (structured output where
+supported), `--on PEER` (dispatch the rest of argv over ssh to a peer
+from `config.yaml`).
 
-| Command | Purpose |
-|---|---|
-| `sac host list / add / remove / set / probe / exec / validate` | Local hostname + peer machine routing (ssh round-trip / exec on PEER). |
-| `sac host add-peer / list-peers / remove-peer` | Cross-host `sac listen` bearer registry (who may push into this host). |
-| `sac host ssh-opts` | Print sac's ssh ControlMaster flags shell-quoted — use as `ssh $(sac host ssh-opts) host cmd`. |
-| `sac host probe-hub` | WSL → fleet-hub layered connectivity probe (DNS, gateway, TCP, HTTPS). |
-| `sac peer post-turn AGENT TEXT` | Outbound A2A — POST a turn to another agent's `/v1/turn`. |
-| `sac peer resolve-url AGENT` | Print the URL `peer post-turn` would target. |
-| `sac a2a serve <yamls...>` | A2A inbound HTTP server (sidecar mode for non-SDK runtimes). For `runtime: apptainer` agents the runner hosts `POST /v1/turn` itself. |
-| `sac a2a doctor AGENT` | Probe an agent's A2A AgentCard endpoint and report health. |
+## Gotchas the help text won't warn you about
 
-## Fleet (`sac fleet`)
+- **Renamed verbs.** The old `validate` / `take-snapshot` /
+  `check-priority` / `inspect` / `logs` / `list` were folded into
+  `check` / `status --snapshot` / `status --priority` / `status` /
+  `tail` / `status` (fleet view). If a script calls an old verb, this
+  is why it broke.
+- **`--foreground` is single-target only.** `sac agents start a b c`
+  works in daemon mode; `--foreground` streams stdio and blocks, so
+  one agent at a time.
+- **Apptainer-only since 2026-05-13.** `sac image build` has no
+  `--runtime` flag; there is no docker path.
+- **`sac a2a serve` is the sidecar path only.** For `runtime:
+  apptainer` (SDK) agents the runner hosts `POST /v1/turn` itself —
+  you don't run `a2a serve` for them.
+- **`sac accounts sync-live` fails loud on a stale/absent live
+  credential** — it never snapshots a stale token. That's intentional.
 
-| Command | Purpose |
-|---|---|
-| `sac fleet launch PEER <name>...` | Rsync each agent's spec to PEER and run `sac agents start <name>` there. |
-| `sac fleet notify done\|blocker\|status --summary "..."` | Agent→lead push channel (ADR-0013 Phase 1) — POST a typed event to the lead's `sac listen` inbox. `--detail`, `--conversation-id`, `--dry-run`, `--json`. |
+## The image sandbox cycle (workflow, not obvious from --help)
 
-## State database / registry / events
+`scitex[all]` updates often; rebuild-per-change is slow. The pattern:
 
-| Command | Purpose |
-|---|---|
-| `sac db query / show / clean / migrate / tick` | Inspect and maintain the sac state database (`state.db`). `db clean` replaces the legacy `registry clean`. |
-| `sac db export / import` | Dump state.db rows as a JSON delta / ingest a dump (cross-host registry sync). |
-| `sac registry reconcile` | Reconcile singleton agent placement across the fleet. |
-| `sac event ingest` | Append a Claude Code hook event to the per-agent ring buffer. |
-
-## Build / install / templates
-
-| Command | Purpose |
-|---|---|
-| `sac installation` | Bootstrap helpers for a new fleet host. |
-| `sac installation setup-cron` | Add (or remove) the post-merge-pull crontab entry. |
-| `sac template render-contributor-spec` | Materialize a contributor agent spec from the v3 template. |
-
-## Other
-
-| Command | Purpose |
-|---|---|
-| `sac doctor [--fleet]` | Diagnose agent-spec source drift (locally, or `--fleet` across peers). |
-| `sac subagent get-state` | Pure state data for every matching Claude Code Agent-tool subagent (Type 2). |
-| `sac mcp list-tools` | Local MCP introspection (no MCP server bundled — sac agents spawn their own via `to_home/.mcp.json`). |
-| `sac skills list / get` | Bundled agent-facing skills. |
-| `sac list-python-apis` | Enumerate the public Python API. |
-| `sac auto-accept` | Auto-accept TUI handler for legacy claude-code agents (the apptainer/SDK runner doesn't need it). |
+```bash
+sac image build scitex --sandbox        # one-time writable rootfs
+sac image update sandbox/               # pip --upgrade any time
+sac image freeze sandbox/ scitex-X.sif  # bake when stable
+sac image switch X                      # atomically flip the symlink
+```
 
 ## See also
 
-- [10_cli.md](10_cli.md) — long-form flag tables + Python-API mirror
-- [03_python-api.md](03_python-api.md) — programmatic surface (mirrors the lifecycle commands)
+- [10_cli.md](10_cli.md) — `sac listen` control-plane + Python-API mirror
+- [03_python-api.md](03_python-api.md) — the programmatic surface
 - [11_remote-deploy.md](11_remote-deploy.md) — SSH deployment internals
 - [13_observability.md](13_observability.md) — `status --json` contract

--- a/src/scitex_agent_container/_skills/scitex-agent-container/05_mcp-tools.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/05_mcp-tools.md
@@ -1,85 +1,55 @@
 ---
 description: |
-  [TOPIC] sac MCP server — exposed tools, transport, install snippet
-  [DETAILS] Convention §3-§5 surface: every `sac mcp <verb>` plus the
-  bare-name MCP tools (`agent_*`, `db_*`, `host_*`, `image_*`,
-  `template_*`, `account_*`, `quota_*`, `skills_*`, `mcp_*`,
-  `list_python_apis`). Both stdio and HTTP transports. Install with
-  `pip install scitex-agent-container[mcp]`.
+  [TOPIC] sac MCP server — how it relates to the CLI, and the gotchas
+  [DETAILS] CLI↔MCP parity (every `sac <noun> <verb>` is an MCP tool of the same shape), install extra, Claude Code config, which verbs mutate state, and where the impl lives. The live tool list is self-describing — call `sac mcp list-tools` (or read the MCP schema); this leaf does NOT re-table it.
 tags: [scitex-agent-container-mcp-tools]
 ---
 
-# sac MCP server
+# sac MCP server — the parity contract
 
-Implements convention §13 (CLI ↔ MCP parity). Every `sac <noun> <verb>`
-on the CLI is reachable as an MCP tool with the same parameter shape.
+Implements convention §13 (CLI ↔ MCP parity): **every `sac <noun>
+<verb>` on the CLI is reachable as an MCP tool with the same parameter
+shape** (bare `<verb>_<noun>` name per Convention A; the scitex
+aggregator adds the `agent_container_` prefix at mount time).
 
-## Install
+Because of that parity, the tool inventory and every tool's parameters
+are self-describing. Get the live list — never a stale hand-copied
+table:
+
+```bash
+sac mcp list-tools [--json]     # or, from the host, read the MCP tool schema
+```
+
+## Install + wire into Claude Code
 
 ```bash
 pip install scitex-agent-container[mcp]   # adds fastmcp
-sac mcp doctor                             # verify
+sac mcp doctor                             # verify registration
+sac mcp install --claude-code             # prints the mcpServers snippet
 ```
 
-## Subcommands (CLI face)
+The Claude Code config just runs `sac mcp start` (stdio; `--http
+--port N` for HTTP transport) as the server command — `sac mcp
+install` emits the exact snippet, so there's nothing to memorize here.
 
-```bash
-sac mcp start                          # stdio (default)
-sac mcp start --http --port 8970       # HTTP transport
-sac mcp doctor                         # version + tool count + registration
-sac mcp list-tools [--json]            # enumerate tools
-sac mcp install [--claude-code]        # config snippet
-```
+## Gotchas
 
-## Claude Code config
+- **Mutating verbs are NOT gated by the server.** `agent_start`,
+  `agent_stop`, `agent_restart`, `db_clean`, `db_export`, `db_import`
+  change state, and the MCP server invokes them unconditionally — the
+  host (Claude Code / your embedder) is expected to mediate via its own
+  permission flow before the call.
+- **No MCP server is bundled with agents.** sac agents spawn their own
+  via `to_home/.mcp.json`; `sac mcp start` is the server you point a
+  host at, not something the runner auto-launches.
 
-```json
-{
-  "mcpServers": {
-    "scitex-agent-container": {
-      "command": "sac",
-      "args": ["mcp", "start"]
-    }
-  }
-}
-```
+## Where it lives (read the code for the how)
 
-`sac mcp install --claude-code` prints the same snippet for copy-paste.
-
-## Tool inventory
-
-Bare-name `<verb>_<noun>` shape per Convention A. The sac umbrella mount
-adds the `agent_container_` prefix at scitex aggregator time.
-
-| Group       | Tools                                                                                                                                                                                                                                  |
-|-------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `agent`     | `list`, `status`, `logs`, `health`, `find`, `check`, `validate`, `inspect`, `recall`, `check_priority`, `take_snapshot`, `start`, `stop`, `restart`, `attach`                                                                          |
-| `db`        | `show`, `query`, `clean`, `tick`, `migrate`, `export`, `import`                                                                                                                                                                        |
-| `host`      | `list`, `validate`, `probe`, `exec`                                                                                                                                                                                            |
-| `image`     | `build`                                                                                                                                                                                                                                |
-| `template`  | `render_contributor_spec`                                                                                                                                                                                                              |
-| `account`   | `account_show`, `quota_watch`                                                                                                                                                                                                          |
-| `skills`    | `skills_list`, `skills_get` — convention §5 mandatory pair                                                                                                                                                                             |
-| `info`      | `list_python_apis`, `mcp_list_tools`, `mcp_doctor` — self-introspection                                                                                                                                                                |
-
-Get the live list any time with `sac mcp list-tools` (or, from Python,
-`scitex_agent_container._mcp.server.get_server().list_tools()`).
-
-## Implementation pointers
-
-- `src/scitex_agent_container/_mcp/server.py` — `FastMCP` instance,
-  lazy-built so the bare `import` doesn't require fastmcp.
-- `src/scitex_agent_container/_mcp/_tools/` — one file per noun group.
-  Each tool wraps the Click CLI through `_helpers.invoke_cli_*` so
-  CLI ↔ MCP parity stays automatic as new commands land.
-- `src/scitex_agent_container/cli_pkg/mcp_group.py` — Click face
-  (`start / doctor / list-tools / install`).
-- `src/scitex_agent_container/_mcp_server.py` — re-export shim so the
-  scitex-dev `audit-mcp-tools` linter's hard-coded path works.
-
-## Mutating verbs
-
-`agent_start`, `agent_stop`, `agent_restart`, `db_clean`, `db_export`,
-`db_import` mutate state. The MCP server itself does not gate them —
-the host (Claude Code, custom embedder) is expected to mediate via its
-own permission flow before invoking the tool.
+- `_mcp/server.py` — `FastMCP` instance, lazy-built so a bare `import`
+  doesn't require fastmcp.
+- `_mcp/_tools/` — one file per noun group; each tool wraps the Click
+  CLI through `_helpers.invoke_cli_*`, which is *why* parity stays
+  automatic as new commands land.
+- `cli_pkg/mcp_group.py` — the `sac mcp` Click face.
+- `_mcp_server.py` — re-export shim for the scitex-dev
+  `audit-mcp-tools` linter's hard-coded path.

--- a/src/scitex_agent_container/_skills/scitex-agent-container/20_env-vars.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/20_env-vars.md
@@ -1,158 +1,84 @@
 ---
 description: |
-  [TOPIC] scitex-agent-container — Environment Variables
-  [DETAILS] Environment variables read by scitex-agent-container at import / runtime. Follow SCITEX_<MODULE>_* convention — see general/10_arch-environment-variables.md..
+  [TOPIC] scitex-agent-container — Environment Variables (behavior + gotchas)
+  [DETAILS] The two-name aliasing rule + SacEnvConflict, auth precedence, hub fail-soft, the in-SIF listen-broker fail-loud, the compaction opt-out, and the Spartan stale-cred gotcha. The full ~40-var enumeration is derivable from source — run the audit grep; this leaf does NOT table every var.
 tags: [scitex-agent-container-env-vars]
 ---
 
 # scitex-agent-container — Environment Variables
 
-With ~40 sac-owned vars in source, this leaf groups them by purpose. For the
-exact authoritative list, run the audit snippet at the bottom.
+sac reads ~40 env vars. The **exhaustive list is derivable from
+source**, so this leaf keeps only the behaviors and gotchas you can't
+read off a name. For the authoritative current list:
 
-## Naming — `SAC_*` and `SCITEX_AGENT_CONTAINER_*` are interchangeable
-
-Every sac-owned env var has TWO equivalent names: a short `SAC_<X>` form
-and a long `SCITEX_AGENT_CONTAINER_<X>` form. Either reads to the same
-slot. The helper at `scitex_agent_container._env.getenv("X")` reads
-both.
-
-**Conflict detection.** If both forms are set with **different** values,
-sac raises `SacEnvConflict` at startup rather than silently picking one
-— a drifted alias is almost always a bug:
-
-```
-SAC_HUB_URL=https://hub-a.example
-SCITEX_AGENT_CONTAINER_HUB_URL=https://hub-b.example
-# → SacEnvConflict: SAC_HUB_URL=...hub-a... vs SCITEX_AGENT_CONTAINER_HUB_URL=...hub-b...
+```bash
+grep -rhoE 'SCITEX_[A-Z0-9_]+|SAC_[A-Z0-9_]+' \
+  "$HOME/proj/scitex-agent-container/src/" | sort -u
 ```
 
-When set to the same value, either form (or both) is accepted.
+The reader/alias/conflict logic lives in
+`scitex_agent_container._env`.
 
-In every table below, the `Variable` column lists the long form for
-readability; the short `SAC_*` alias is always available.
+## `SAC_*` and `SCITEX_AGENT_CONTAINER_*` are interchangeable
 
-## Container identity / metadata
+Every sac-owned var has two equivalent names — a short `SAC_<X>` and a
+long `SCITEX_AGENT_CONTAINER_<X>`. Both read the same slot via
+`_env.getenv("X")`.
 
-| Variable | Purpose | Default | Type |
-|---|---|---|---|
-| `SCITEX_AGENT_CONTAINER_ID` | Stable container ID (auto-assigned on first boot). | auto | string |
-| `SCITEX_AGENT_CONTAINER_NAME` | Human-readable container name. | auto | string |
-| `SCITEX_AGENT_CONTAINER_HOSTNAME` | Override container hostname. | host | string |
-| `SCITEX_AGENT_CONTAINER_ROLE` | Role in fleet (e.g. `worker`, `observer`). | `worker` | string |
-| `SCITEX_AGENT_CONTAINER_META_VERSION` | Metadata schema version. | current | string |
-| `SCITEX_AGENT_CONTAINER_AGENT` | Agent engine (`claude` / `codex` / ...). | `claude` | string |
-| `SCITEX_AGENT_CONTAINER_AGENT_META_SCRIPT` | Path to agent-metadata generator script. | bundled | path |
-| `SCITEX_AGENT_CONTAINER_MODEL` | LLM model ID injected into the agent. | `—` | string |
-| `SCITEX_AGENT_CONTAINER_SCREEN_NAME` | GNU-screen session name attached to the agent. | auto | string |
-| `SAC_NAME` | Short agent identifier (used in telemetry). | auto | string |
+**Gotcha:** if both forms are set to **different** values, sac raises
+`SacEnvConflict` at startup rather than silently picking one — a
+drifted alias is almost always a bug. Same value on both forms is fine.
 
-## Paths
+## Credentials — the precedence that decides which auth wins
 
-Canonical agent YAML location (fleet shared via dotfiles):
-`~/.scitex/agent-container/agents/<name>/<name>.yaml` — the dir-as-SSoT
-resolver walks per-host `<host>/agents/`, then `shared/agents/`, then
-`agents/`. See `01_config-v3.md` for the full search path.
+`runtimes/_sdk_common.py::provision_anthropic_auth`, highest → lowest:
 
-| Variable | Purpose | Default | Type |
-|---|---|---|---|
-| `SCITEX_AGENT_CONTAINER_CONFIG_PATH` | Path to the YAML config. | bundled | path |
-| `SCITEX_AGENT_CONTAINER_YAML_DIRS` | Extra dirs scanned for YAML overrides (colon-separated). | unset | string (paths) |
-| `SCITEX_AGENT_CONTAINER_REGISTRY_DIR` | Directory where the container registers its presence. | `~/.scitex/agent-container/runtime/registry` | path |
-| `SCITEX_AGENT_CONTAINER_RUNTIME_DIR` | Per-agent runtime state root for the claude-session runner (pid / heartbeat.json / session.jsonl / quota.json / session_id). | `~/.scitex/agent-container/runtime` | path |
-| `SCITEX_AGENT_CONTAINER_SLURM_STATE_DIR` | Directory for SLURM-job state handoff. | `~/.scitex/agent-container/slurm` | path |
-| `SAC_CACHE_DIR` | Agent-local cache directory. | `~/.cache/scitex-agent` | path |
+1. `ANTHROPIC_API_KEY` already in env — SDK uses it as-is.
+2. `~/.claude/.credentials.json` Pro/Max OAuth — preferred (no
+   per-token billing).
+3. `SAC_ANTHROPIC_API_KEY` (sac-namespaced handoff). `sk-ant-oat*` is
+   synthesised back into a credentials file (OAuth path); `sk-ant-api*`
+   is bridged straight to `ANTHROPIC_API_KEY`.
 
-## Credentials
+**Spartan stale-cred gotcha (2026-05-03):** the user's
+`~/.bash.d/secrets/` exports `SAC_ANTHROPIC_API_KEY` from
+`~/.claude/.credentials.json`. If that file is stale the runner fails
+with "401 Invalid auth" / "Command failed exit 1". Fix: `unset
+SAC_ANTHROPIC_API_KEY` (or `claude /login` to refresh) in the wrapper
+that starts the runner.
 
-Auth precedence (highest → lowest) in `runtimes/_sdk_common.py::provision_anthropic_auth`:
+## Hub integration is fail-soft
 
-1. `ANTHROPIC_API_KEY` already in env (caller pre-set; SDK uses it as-is).
-2. `~/.claude/.credentials.json` Pro/Max OAuth (preferred — no per-token billing).
-3. `SAC_ANTHROPIC_API_KEY` (sac-namespaced handoff). Accepts either form — `sk-ant-oat*` is synthesised back into a credentials file (OAuth path), `sk-ant-api*` is bridged straight to `ANTHROPIC_API_KEY`.
+sac is fleet-agnostic. Set `SAC_HUB_URL` (long: `…_HUB_URL`) +
+`…_HUB_TOKEN` to join a fleet hub. **No default** — unset ⇒ standalone,
+hub calls skipped; set-but-unreachable ⇒ log and continue. sac never
+hard-fails on hub absence. Downstream fleets (orochi) own their own env
+namespace; sac does not read fleet-specific vars.
 
-**Spartan compute-node gotcha (2026-05-03):** the user's `~/.bash.d/secrets/` exports `SAC_ANTHROPIC_API_KEY` from `~/.claude/.credentials.json`. If the credentials file is stale, the runner can fail with "401 Invalid auth" or "Command failed exit 1". Fix: `unset SAC_ANTHROPIC_API_KEY` (or refresh credentials with `claude /login`) in the wrapper that starts the runner on Spartan.
+## In-SIF listen-broker is fail-loud
 
-| Variable | Purpose | Default | Type |
-|---|---|---|---|
-| `ANTHROPIC_API_KEY` | Read directly by the SDK if pre-set. The runner does NOT export this; the SDK calls `claude` CLI which falls back to `~/.claude/.credentials.json` OAuth when this is unset. | `—` | string |
-| `SAC_ANTHROPIC_API_KEY` | Sac-namespaced auth handoff. Accepts both OAuth (`sk-ant-oat*`) and API-key (`sk-ant-api*`) forms; runner detects by prefix. Local shells populate via `sac dev credential2apikey`; CI populates via the GitHub Actions secret of the same name (rotate with `sac dev upload-apikey-from-credentials-to-github`). | `—` | string |
-| `SCITEX_AGENT_CONTAINER_TELEGRAM_BOT_TOKEN` | Telegram bot token for agent bridge. | `—` | string |
+When an agent runs inside an Apptainer SIF, `sac agents start <child>`
+can't `apptainer exec` locally (no nested apptainer on the supported
+HPC shape). The runtime injects `SAC_LISTEN_BASE_URL` (+ `SAC_LISTEN_BEARER`)
+so the in-SIF CLI POSTs the spawn RPC to the bare host, which re-runs
+`check_spawn`, records the `caller → child` lineage edge, and shells
+the real start against the host's apptainer.
 
-## Context compaction
+**Contract:** in a SIF with `SAC_LISTEN_BASE_URL` unset, `sac agents
+start` raises `InSifBrokerError` — it never silently downgrades to
+"skip the broker" or "try local apptainer anyway". `SAC_LISTEN_BEARER`
+is required when `server:sac` is in `spec.claude.channels` (fails loud
+at launch otherwise).
 
-| Variable | Purpose | Default | Type |
-|---|---|---|---|
-| `SAC_COMPACT_ENABLED` | Enable auto-compaction of context window. | `true` | bool |
-| `SAC_COMPACT_THRESHOLD_PCT` | Trigger compaction at this context % used. | `80` | int |
-| `SAC_COMPACT_MIN_DROP_PCT` | Minimum % that must drop per pass. | `20` | int |
-| `SAC_COMPACT_MIN_INTERVAL_S` | Minimum seconds between compactions. | `300` | int |
-| `SAC_COMPACT_TIMEOUT_S` | Timeout per compaction attempt. | `60` | int |
+## Var groups (for orientation only — see the audit grep for the list)
 
-## Action / probe / heartbeat timing
-
-| Variable | Purpose | Default | Type |
-|---|---|---|---|
-| `SAC_ACTION_RETENTION_DAYS` | How many days to keep action logs. | `30` | int |
-| `SAC_ACTION_SNAPSHOT_MAX_CHARS` | Truncate action snapshots above this size. | `8192` | int |
-| `SAC_AUTO_RESPONSE_TICK_S` | Auto-response poll interval. | `5` | int |
-| `SAC_KEY_DELAY_S` | Delay between simulated keystrokes. | `0.05` | float |
-| `SAC_SUBMIT_SETTLE_S` | Seconds to wait after submitting a prompt. | `1.0` | float |
-| `SAC_PROBE_INTERVAL_S` | Liveness probe interval. | `30` | int |
-| `SAC_PROBE_POLL_INTERVAL_S` | Fine-grained poll step inside a probe. | `1` | int |
-| `SAC_PROBE_TIMEOUT_S` | Probe timeout. | `10` | int |
-| `SCITEX_HEARTBEAT_INTERVAL` | Ecosystem-wide heartbeat interval (fleet-shared). | `60` | int |
-
-## Hook context (read-only, set by the harness)
-
-| Variable | Purpose |
-|---|---|
-| `SCITEX_HOOK` | Name of the hook currently running. |
-| `SCITEX_HOOK_CTX_*` | Per-hook context keys (dynamic prefix). |
-
-## Hub / fleet integration (optional)
-
-sac is fleet-agnostic. To join a fleet hub, set `SAC_HUB_URL` (or the
-long form `SCITEX_AGENT_CONTAINER_HUB_URL`) to the hub endpoint. **No
-default** — when unset, sac runs as a standalone agent and skips hub
-calls. When set but unreachable, sac logs and continues; it never hard-
-fails on hub absence.
-
-| Variable | Purpose | Default | Type |
-|---|---|---|---|
-| `SCITEX_AGENT_CONTAINER_HUB_URL` | Fleet hub endpoint (e.g. an orochi instance). | unset (standalone) | URL |
-| `SCITEX_AGENT_CONTAINER_HUB_TOKEN` | Bearer token for the hub. | `—` | string |
-
-Downstream fleet implementations (e.g. scitex-orochi) own their own env
-namespace; sac does not read fleet-specific vars directly.
-
-## Host listen — SAC-from-SAC broker
-
-When an agent runs INSIDE an apptainer SIF, ``sac agents start <child>``
-cannot ``apptainer exec`` locally (no nested apptainer on the supported
-HPC shape). The runtime injects the bare-host ``sac listen`` address +
-bearer into every container so the in-SIF CLI can POST the spawn RPC to
-the host instead; the host re-runs ``check_spawn``, records the
-``caller → child`` lineage edge, and shells the real ``sac agent
-start`` against the bare host's apptainer.
-
-| Variable | Purpose | Default | Type |
-|---|---|---|---|
-| `SAC_LISTEN_BASE_URL` | Host-stable ``sac listen`` base URL the in-SIF CLI POSTs spawn requests against (also used by the in-container channel adapter to subscribe to the bus). Auto-injected by the apptainer runtime from ``listen.host`` / ``listen.port`` in ``~/.scitex/agent-container/config.yaml``. | `http://127.0.0.1:7878` | URL |
-| `SAC_LISTEN_BEARER` | Bearer token presented as ``Authorization: Bearer ...`` to the host listen server. Auto-injected from the host's bearer-token file; required when ``server:sac`` is in ``spec.claude.channels`` (the runtime fails loud at launch otherwise). | `—` | string |
-
-Fail-loud: when the broker runs in a SIF and ``SAC_LISTEN_BASE_URL`` is
-unset, ``sac agents start`` raises ``InSifBrokerError`` (apptainer
-runtime forgot to inject it). Never silently downgrades to "skip the
-broker" / "try local apptainer anyway".
+Container identity/metadata · paths (config / registry / runtime /
+cache) · credentials · context-compaction knobs (`SAC_COMPACT_*`) ·
+probe/heartbeat timing (`SAC_PROBE_*`, `SCITEX_HEARTBEAT_INTERVAL`) ·
+read-only hook context (`SCITEX_HOOK*`, set by the harness) · hub ·
+listen-broker.
 
 ## Feature flags
 
-- **opt-out:** `SAC_COMPACT_ENABLED=false` disables context compaction.
+- Opt-out: `SAC_COMPACT_ENABLED=false` disables context compaction.
 - No opt-in flags in this package.
-
-## Audit
-
-```bash
-grep -rhoE 'SCITEX_[A-Z0-9_]+' $HOME/proj/scitex-agent-container/src/ | sort -u
-```


### PR DESCRIPTION
## Skills de-bloat pilot — reference implementation

Bounded pilot for a fleet-wide skills de-bloat. **No code behavior changes** — docs/skills only. Live skills stay valid + loadable (frontmatter intact, `SKILL.md` links resolve, propagation mechanism untouched).

### Governing principle
Three sources of truth, each owning only what it can express:
- **code** = truth of behavior (read on demand)
- **MCP** = truth of capability — tool schemas self-describe, cannot drift
- **skills** = truth of JUDGMENT/INTENT: when/why/doctrine/gotchas/sequencing/workflow

Rewrite rule: a skill keeps ONLY doctrine/when/why/gotchas/workflow; it DELETES API-signature restatement, CLI flag tables, MCP tool-parameter tables, and JSON wire-format dumps that code/MCP already own — replaced with a one-line pointer.

### (0) Safety net — `skills-archive/`
All **45** current skill files copied VERBATIM, uncompressed, into top-level `skills-archive/scitex-agent-container/` (plus a `README.md` explaining provenance). Plain readable text; not loaded by any agent, not part of propagation. Nothing is lost; the operator can read the pre-rewrite text directly.

### (a) Survey table (file → lines → classification)

Classification: **D** = doctrine-heavy (keep) · **A** = API-restatement-heavy (prime target) · **M** = mixed.

| file | lines | class | recommended action |
|---|---|---|---|
| 01_config-v3.md | 137 | M | lean-rewrite (trim spec field tables; keep dir-as-SSoT + migration doctrine) |
| 01_installation.md | 113 | M | lean-rewrite (keep auth cost-doctrine; cut pip/verify dumps) |
| 02_multiplexer.md | 37 | D | keep |
| 02_quick-start.md | 108 | M | keep (light trim) |
| 03_auto-accept.md | 78 | A | **delete-as-dead** (vestigial for SDK runner; fold 1 note into 40_troubleshooting) |
| 03_python-api.md | 104 | A | lean-rewrite (signatures derivable from `list-python-apis`) |
| **04_cli-reference.md** | 131 | A | **REWRITTEN** (dup of 10_cli.md) |
| 04_resource-management.md | 76 | M | lean-rewrite (different package; keep cache doctrine) |
| **05_mcp-tools.md** | 85 | A | **REWRITTEN** |
| 05_resource-heartbeat.md | 101 | A | lean-rewrite (keep operational units; different package) |
| 06_env-injection-ports.md | 50 | D | keep |
| 06_http-api.md | 76 | A | **merge into** 17_inbound-turn-endpoint.md |
| 07_a2a-protocol-extension-fields.md | 146 | A | lean-rewrite (pure field enum + JSON; "mirrors ADR-0004/_card.py") — **top next target** |
| 07_a2a-protocol.md | 145 | M | lean-rewrite (keep why-A2A boundary; cut route/method/env tables) |
| 08_templates.md | 56 | M | keep (light trim) |
| **10_cli.md** | 138 | A | **merge into** 04_cli-reference.md |
| 11_remote-deploy.md | 199 | M | lean-rewrite (keep ControlMaster/host-resolution doctrine) |
| 12_wsl-connectivity.md | 183 | D | delete-as-dead / move to host memory (single-laptop incident narrative) |
| 13_observability.md | 76 | D | keep |
| 14_claude-session-state.md | 132 | M | lean-rewrite (cut sdk_session JSON schema; keep auth doctrine) |
| 15_claude-session.md | 145 | M | keep (trim duplicated YAML) |
| 16_claude-session-migration.md | 69 | D | delete-as-dead (migration complete; fold 1 line into 01_config-v3) |
| 17_inbound-turn-endpoint.md | 130 | A | lean-rewrite + absorb 06_http-api.md |
| 18_full-agent-delegation.md | 189 | D | keep |
| 19_full-agent-troubleshooting.md | 117 | D | keep |
| **20_env-vars.md** | 158 | A | **REWRITTEN** (top offender — self-regenerating grep) |
| 21_cli-startup-budget.md | 99 | D | keep |
| 22_host-passthrough.md | 139 | M | lean-rewrite (keep safety-boundary doctrine; cut spec schema; stale `runtime: docker`) |
| 23_telegram-integration.md | 95 | M | keep (light trim) |
| 24_image-build.md | 139 | M | keep (trim build-command restatement; keep rebuild-to-ship gotcha) |
| 25_claude-setup-delivery.md | 199 | D | keep |
| 26_credentials-rotation-host.md | 125 | D | keep |
| 26_credentials-rotation.md | 193 | M | keep (light trim) |
| 27_credentials-relogin.md | 142 | D | keep |
| 28_credential-refresh.md | 106 | D | keep |
| 29_progress-reporting-to-lead.md | 98 | D | keep (minor ACL staleness) |
| 30_responsiveness-background-work.md | 200 | D | keep |
| 31_worktree-path-safety.md | 95 | D | keep |
| 32_nested-apptainer-builds.md | 76 | M | keep |
| 40_periodic-drive-consumer.md | 69 | D | keep |
| 40_troubleshooting.md | 179 | M | lean-rewrite (strip dead tmux/screen/auto-accept half) |
| 41_claude-worktree-relocation.md | 96 | D | keep |

Structural notes flagged by the survey: **04_cli-reference.md ≈ 10_cli.md** (duplicate CLI reference — merge pair); **06_http-api.md ⊂ 17_inbound-turn-endpoint.md** (merge pair); two files share the `40_` prefix (see "flagged" below).

### (b) Rewritten this pilot (before → after)

| file | before | after | Δ |
|---|---|---|---|
| 04_cli-reference.md | 131 | 75 | −56 (−43%) |
| 05_mcp-tools.md | 85 | 55 | −30 (−35%) |
| 20_env-vars.md | 158 | 84 | −74 (−47%) |
| **total** | **374** | **214** | **−160 (−43%)** |

Chosen to cover three distinct restatement surfaces as the reference pattern: **CLI** (code/`--help`), **MCP** (tool schema), **env-vars** (source). 20_env-vars was the survey's #1; 04_cli-reference its #3. (07_a2a-protocol-extension-fields, the survey's #2, is left as the strongest next target — see recommendations — to keep this pilot to one example per surface.)

### (c) What was CUT → pointer it was replaced with

**04_cli-reference.md**
- Exhaustive per-subcommand purpose tables (agents/image/accounts/host/peer/a2a/fleet/db/registry/event/build/other) → `sac --help-recursive` + `sac <group> --help`, plus a small "which group for which job" table.
- KEPT (doctrine): renamed-verb history (validate→check, logs→tail, list→status…), `--foreground` single-target-only, apptainer-only-no-`--runtime`, `a2a serve` is sidecar-only, `accounts sync-live` fails-loud-on-stale, the image sandbox→update→freeze→switch cycle.

**05_mcp-tools.md**
- The full tool-inventory table (`agent`/`db`/`host`/`image`/… verbs) → `sac mcp list-tools` (or read the MCP schema).
- The verbatim `mcpServers` JSON snippet → `sac mcp install --claude-code` (it prints the exact snippet).
- KEPT (doctrine): the CLI↔MCP parity contract, the mutating-verbs-are-NOT-gated gotcha, no-server-bundled note, and impl pointers (`_mcp/server.py`, `_mcp/_tools/`, `cli_pkg/mcp_group.py`, `_mcp_server.py`).

**20_env-vars.md**
- All per-variable `Variable | Purpose | Default | Type` tables (~40 vars: identity/paths/compaction/timing/hub/listen) → the audit grep + `_env.py` as source of truth, with a one-line group-orientation list.
- KEPT (doctrine): `SAC_*`↔`SCITEX_AGENT_CONTAINER_*` aliasing + `SacEnvConflict`, the auth precedence order, the Spartan stale-cred gotcha, hub fail-soft, in-SIF listen-broker fail-loud (`InSifBrokerError`), the `SAC_COMPACT_ENABLED=false` opt-out.

### (d) Flagged as uncertain (kept — for human review)
- **Auth precedence list (20_env-vars.md)** — arguably derivable from `provision_anthropic_auth`, but it's load-bearing sequencing judgment ("which credential wins"), so KEPT. Reviewer may prefer a pure pointer.
- **Impl-pointer file lists (05, 20)** — kept as one-line "read the code here" pointers, not restatement; confirm the paths are the ones you want agents sent to.
- **04's "which group for which job" table** — a compressed orientation aid, not a flag dump; if even that reads as restatement it can shrink to prose.
- **The `40_` prefix collision** (`40_troubleshooting.md` + `40_periodic-drive-consumer.md`) and 8 other duplicate-prefix pairs are **pre-existing** (`§2.duplicate-prefix`), unrelated to this PR. NOT touched — renaming would break `SKILL.md` links + propagation. Flagging for a dedicated pass.

### (e) Recommended actions for not-yet-rewritten leaves
See the survey table's "recommended action" column. Highest-value next steps:
1. **Lean-rewrite 07_a2a-protocol-extension-fields.md** (survey #2) — collapse the field tables + full JSON card to a pointer at ADR-0004 + `a2a/_card.py`; keep the one-namespace-key rule + isolation-attestation "why".
2. **Merge 10_cli.md → 04_cli-reference.md** (near-duplicate CLI references).
3. **Merge 06_http-api.md → 17_inbound-turn-endpoint.md** (subset).
4. **Lean-rewrite 03_python-api.md** — signatures → `sac list-python-apis -vv`.
5. **Delete-as-dead**: 03_auto-accept.md, 16_claude-session-migration.md, 12_wsl-connectivity.md (each removal must also drop its `SKILL.md` link to keep the index clean).

Deletes/merges are deferred because removing a leaf requires editing `SKILL.md`'s index in the same change (the quality check flags orphan leaves + dead links), and this pilot deliberately touches no live leaf it isn't rewriting.

### Validation
- `check_package(repo_root)` (the `scitex_dev` skills-quality auditor behind `tests/develop/test_skills_quality.py`): **no NEW violations** introduced. The only failures are 9 **pre-existing** `§2.duplicate-prefix` pairs (present before this PR, untouched).
- Frontmatter of all 3 rewrites parses as a valid dict (`parse_frontmatter_yaml`), keys `[description, tags]` intact.
- `python -m pytest tests/develop/test_skills_quality.py tests/scitex_agent_container/_state/_meta/test_skills.py tests/scitex_agent_container/cli_pkg/test_skills_group.py` → **all green** (`test_skills_quality` currently self-skips: its `package_root` resolves to `tests/`, which has no `src/*/_skills` — flagged separately; the meaningful gate is `check_package` run against the real skills dir, reported above).

Do NOT merge — for review.
