### PR TITLE
fix(runtimes): auto-degrade to no-bus on listen-less node instead of fatal abort

### DIFF
--- a/src/scitex_agent_container/runtimes/_apptainer_listen_env.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_listen_env.py
@@ -21,12 +21,17 @@ specs (``--containall`` + explicit ``raw_args``) bypass the preflight
 wrapper but still need bus auth, otherwise their adapter can never
 subscribe.
 
-Fail-loud contract: when ``server:sac`` is registered but the bearer
-cannot be resolved, this raises ``RuntimeError`` rather than launching an
-agent whose adapter can never authenticate (the silent wake-on-push
-failure this guard exists to prevent). When ``server:sac`` is absent a
-missing token is harmless (nothing subscribes) — we inject only the base
-URL and log a loud warning.
+Auto-degrade contract: when ``server:sac`` is registered but the bearer
+cannot be resolved (e.g. a Spartan SLURM compute node running a one-shot
+cohort-solver capsule, where there is no per-node ``sac listen``), this
+DROPS ``server:sac`` from the agent's channel set and launches normally
+with the bus disabled — rather than raising and sending the capsule
+supervisor into an infinite fresh-restart loop. A loud warning explains
+the degrade. When ``server:sac`` is absent a missing token is harmless
+(nothing subscribes) — we inject only the base URL and log a warning.
+The ``sac-builtin: "off"`` label remains the pre-existing FULL opt-out
+(see ``config/_loaders.py``); this branch is the graceful fallback for a
+listen-less node that never got the opt-out label.
 """
 
 from __future__ import annotations
@@ -57,8 +62,11 @@ def listen_env_flags(config) -> list[str]:
     are visible in-container via the host-home bind.
 
     Pure except for reading the host token file, config, host env, and
-    host home; raises ``RuntimeError`` when a ``server:sac`` spec has no
-    resolvable bearer.
+    host home, plus one in-place mutation of ``config.claude.channels``
+    on the auto-degrade path (dropping ``server:sac`` when the bus is
+    wanted but no bearer resolves), so downstream inner-argv builders —
+    which read the same ``channels`` list AFTER this helper runs — never
+    register the un-authable bus adapter.
     """
     # Local imports keep these resolvable even if a formatter strips
     # module-level unused imports during a refactor, and avoid a circular
@@ -192,15 +200,30 @@ def listen_env_flags(config) -> list[str]:
     if bearer:
         flags += ["--env", f"SAC_LISTEN_BEARER={bearer}"]
     elif wants_bus:
-        raise RuntimeError(
-            "spec.claude.channels includes 'server:sac' but the bus bearer "
-            f"token file {_listen_token_path()} is absent or empty, so the "
-            "in-container channel adapter could never authenticate to "
-            "`sac listen` (401). Subscriptions would never land and every "
-            "pushed turn would report delivered_subscriber_count=0 — "
-            "refusing to launch an agent whose adapter can never subscribe. "
-            "Start `sac listen` to generate the token, then restart this "
-            "agent."
+        # AUTO-DEGRADE (was: fatal RuntimeError). This node has no
+        # resolvable `sac listen` bearer — e.g. a Spartan SLURM compute
+        # node running a one-shot cohort-solver capsule, where there is no
+        # per-node `sac listen`. Raising here aborted launch, and the
+        # capsule supervisor then restarted straight back into the same
+        # abort → an infinite fresh-restart loop. Instead, DROP `server:sac`
+        # from the channel set so the in-container bus adapter is never
+        # registered (no 401 auth attempt, no message-reader fatal), and
+        # fall through to launch normally with the bus disabled. The
+        # `sac-builtin: "off"` label is the pre-existing FULL opt-out; this
+        # is the graceful fallback for a listen-less node without it.
+        remaining = [c for c in channels if str(c).strip() != "server:sac"]
+        if claude_spec is not None:
+            claude_spec.channels = remaining
+        logger.warning(
+            "SAC_LISTEN_BEARER not injected: bus token file %s is absent, so "
+            "'server:sac' has been DROPPED from this agent's channels — the "
+            "in-container bus adapter is NOT registered and pushed turns are "
+            "disabled. This is the expected auto-degrade on a node with no "
+            "`sac listen` (e.g. a Spartan SLURM compute node running a "
+            "one-shot capsule). Start `sac listen` and restart to re-enable "
+            "the bus, or set the label 'sac-builtin: \"off\"' to opt out "
+            "entirely.",
+            _listen_token_path(),
         )
     else:
         logger.warning(

--- a/tests/scitex_agent_container/runtimes/test__apptainer_listen_env.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_listen_env.py
@@ -280,6 +280,112 @@ def test_listen_env_flags_direnv_config_follows_an_env_token(
     assert flags[idx - 1] == "--env"
 
 
+@pytest.fixture
+def bus_config() -> SimpleNamespace:
+    """A config whose ``claude.channels`` requests the bus (``server:sac``).
+
+    Used by the listen-less auto-degrade tests: with a bus channel wanted
+    but no bearer token on the node, ``listen_env_flags`` must DROP
+    ``server:sac`` and launch (no longer raise).
+    """
+    return SimpleNamespace(
+        name="cohort-solver",
+        claude=SimpleNamespace(channels=["server:sac", "server:other"]),
+    )
+
+
+@pytest.fixture
+def present_token(sandboxed_home: Path) -> Path:
+    """Materialise a host ``sac listen`` bearer under the sandboxed $HOME.
+
+    Yields the token path so the bearer-PRESENT regression tests exercise
+    the unchanged inject-``server:sac``+bearer path.
+    """
+    from scitex_agent_container._listen.tokens import default_token_path
+
+    path = default_token_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("test-bearer-token", encoding="utf-8")
+    return path
+
+
+def test_listen_env_flags_no_raise_when_bus_wanted_but_token_absent(
+    bus_config: SimpleNamespace,
+    sandboxed_home: Path,
+) -> None:
+    # Arrange — bus wanted (server:sac in channels) + sandboxed $HOME with
+    # NO token file (a listen-less Spartan SLURM compute node).
+    _ = sandboxed_home
+    # Act — must AUTO-DEGRADE, not raise (the old infinite fresh-restart loop).
+    flags = listen_env_flags(bus_config)
+    # Assert — no bearer was injected (there is none to inject).
+    assert not any(f.startswith("SAC_LISTEN_BEARER=") for f in flags)
+
+
+def test_listen_env_flags_drops_server_sac_when_token_absent(
+    bus_config: SimpleNamespace,
+    sandboxed_home: Path,
+) -> None:
+    # Arrange — bus wanted but no token on this node.
+    _ = sandboxed_home
+    # Act — the helper mutates config.claude.channels in place.
+    listen_env_flags(bus_config)
+    # Assert — server:sac dropped so the inner-argv builders never register
+    # the un-authable bus adapter (other channels untouched).
+    assert "server:sac" not in bus_config.claude.channels
+
+
+def test_listen_env_flags_keeps_other_channels_on_degrade(
+    bus_config: SimpleNamespace,
+    sandboxed_home: Path,
+) -> None:
+    # Arrange — bus wanted but no token; a non-bus channel is also present.
+    _ = sandboxed_home
+    # Act
+    listen_env_flags(bus_config)
+    # Assert — only server:sac is dropped; unrelated channels survive.
+    assert bus_config.claude.channels == ["server:other"]
+
+
+def test_listen_env_flags_warns_on_bus_degrade(
+    bus_config: SimpleNamespace,
+    sandboxed_home: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # Arrange — bus wanted but no token; capture the degrade warning.
+    _ = sandboxed_home
+    # Act
+    with caplog.at_level("WARNING"):
+        listen_env_flags(bus_config)
+    # Assert — the loud warning names the dropped channel.
+    assert any("server:sac" in rec.message for rec in caplog.records)
+
+
+def test_listen_env_flags_injects_bearer_when_token_present(
+    bus_config: SimpleNamespace,
+    present_token: Path,
+) -> None:
+    # Arrange — bus wanted AND a host bearer token is present (token-PRESENT
+    # path must be UNCHANGED: still inject server:sac + bearer).
+    _ = present_token
+    # Act
+    flags = listen_env_flags(bus_config)
+    # Assert — the bearer is injected unchanged.
+    assert "SAC_LISTEN_BEARER=test-bearer-token" in flags
+
+
+def test_listen_env_flags_keeps_server_sac_when_token_present(
+    bus_config: SimpleNamespace,
+    present_token: Path,
+) -> None:
+    # Arrange — bus wanted AND bearer present; server:sac must NOT be dropped.
+    _ = present_token
+    # Act
+    listen_env_flags(bus_config)
+    # Assert — the bus channel survives so the adapter is registered.
+    assert "server:sac" in bus_config.claude.channels
+
+
 def test_listen_env_flags_injects_uv_project_environment(
     no_bus_config: SimpleNamespace,
     sandboxed_home: Path,


### PR DESCRIPTION
## What fataled

`runtimes/_apptainer_listen_env.py::listen_env_flags` guarded the bus:
when `spec.claude.channels` contained `server:sac` but no `sac listen`
bearer token resolved on the node, it RAISED `RuntimeError`, aborting
the container launch. On a node with no `sac listen` — e.g. a Spartan
SLURM compute node running a one-shot cohort-solver capsule (no per-node
`sac listen`) — the capsule supervisor restarted straight back into the
same abort, producing an **infinite fresh-restart loop**. `channels: []`
did not help because `config/_loaders.py` force-appends `server:sac` onto
every agent's channels unless the label `sac-builtin: "off"` is set.

## The fix (drop + warn + continue)

In the `elif wants_bus:` branch, instead of raising:
1. DROP `server:sac` from `config.claude.channels` in place. This helper
   runs (build argv line ~327) BEFORE the inner-argv builders
   (`tui_channel_config`, `build_inner_argv`) read the same `channels`
   list, so the bus adapter is never registered — no 401 auth attempt,
   no message-reader fatal.
2. Emit a loud WARNING explaining the bus is disabled because no
   `sac listen` token is present.
3. Fall through and launch normally (bus disabled).

A listen-less node now **auto-degrades to "no bus"** instead of aborting.

The token-PRESENT path is UNCHANGED: `server:sac` + `SAC_LISTEN_BEARER`
are still injected. The `config/_loaders.py` force-append is untouched,
and the label `sac-builtin: "off"` remains the pre-existing FULL opt-out.

## Tests

Extended `tests/scitex_agent_container/runtimes/test__apptainer_listen_env.py`:
- bus wanted + token ABSENT → no `RuntimeError`, `server:sac` dropped,
  other channels kept, warning emitted.
- bus wanted + token PRESENT → `server:sac` + bearer still injected
  (regression guards).

No existing test asserted the raise behavior, so none needed updating.
Only existing files were edited (no new source/test files → orphan
test-parity holds).

```
PYTHONPATH=<worktree>/src /opt/venv-sac/bin/python3 -m pytest \
  <worktree>/tests/scitex_agent_container/runtimes/test__apptainer_listen_env.py -q
# 24 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
