### PR TITLE
fix(accounts): identity-guard sync-live so it never clobbers the wrong account store

### DIFF
--- a/src/scitex_agent_container/_account/account_identity.py
+++ b/src/scitex_agent_container/_account/account_identity.py
@@ -1,0 +1,104 @@
+"""Best-effort OAuth "whoami" — the email a credential's token authenticates as.
+
+The credential auto-sync identity-guard (``_account.creds_sync.sync_live``)
+must derive the TARGET account store from the LIVE TOKEN's ACTUAL identity,
+NOT from ``~/.claude.json``'s ``oauthAccount.emailAddress`` metadata — which
+drifts out of sync with the token across logins/account switches. On
+2026-07 that drift caused ``sync_live`` to snapshot one account's live
+token into ANOTHER account's store (the metadata still named the previous
+account), silently clobbering the second account's credential.
+
+This module queries the OAuth profile endpoint with the token and returns
+ONLY the resolved account email. Like :mod:`claude_usage`, the access token
+is read from disk inside this module and is **never** returned to callers —
+only the email leaves.
+
+Best-effort + offline-safe: any failure (network down, non-2xx, malformed
+body, absent token) returns ``None`` so the caller falls back to its
+metadata-based path without crashing. Reuses the stdlib-urllib OAuth call
+pattern + gating headers from :mod:`claude_usage`.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.request
+from pathlib import Path
+
+from .claude_usage import (
+    _USAGE_BETA_HEADER,
+    _USAGE_USER_AGENT,
+    _read_tokens_at,
+)
+
+# Identity ("whoami") endpoint: returns the account the OAuth token
+# authenticates as, under ``account.email``. Same anthropic-beta gating +
+# user-agent as the usage endpoint on the same host.
+_PROFILE_URL = "https://api.anthropic.com/api/oauth/profile"
+
+
+def _fetch_email_from_api(access_token: str, *, opener=None) -> str | None:
+    """GET the OAuth profile and return ``account.email``, or None on failure.
+
+    Best-effort: every failure mode (network error, non-2xx, non-JSON body,
+    unexpected shape) collapses to ``None``. The token is used only to build
+    the ``Authorization`` header here and never leaves the function.
+    """
+    req = urllib.request.Request(
+        _PROFILE_URL,
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "anthropic-beta": _USAGE_BETA_HEADER,
+            "User-Agent": _USAGE_USER_AGENT,
+        },
+        method="GET",
+    )
+    _opener = opener if opener is not None else urllib.request.urlopen
+    # stx-allow: fallback (reason: whoami is best-effort; any network/parse
+    # failure returns None so the identity-guard falls back to its offline
+    # metadata path instead of crashing the credential sync.)
+    try:
+        with _opener(req, timeout=15) as resp:
+            raw = resp.read()
+        payload = json.loads(raw)
+    except Exception:  # stx-allow: fallback (reason: catch-all safety net — see inline comment for context)
+        return None
+
+    if not isinstance(payload, dict):
+        return None
+    account = payload.get("account")
+    if not isinstance(account, dict):
+        return None
+    email = account.get("email")
+    if isinstance(email, str) and email.strip():
+        return email.strip()
+    return None
+
+
+def fetch_account_email(credentials_path: Path, *, opener=None) -> str | None:
+    """Return the email the token in ``credentials_path`` authenticates as.
+
+    Reads the OAuth access token from ``credentials_path`` internally (the
+    token is NEVER returned), queries the OAuth profile endpoint, and returns
+    ``response['account']['email']``.
+
+    Best-effort: returns ``None`` when the token is absent, the network is
+    unreachable, or the response is malformed. Never raises — the caller
+    (the credential identity-guard) treats ``None`` as "identity could not
+    be verified" and falls back to its offline path.
+
+    Args:
+        credentials_path: Path to a ``.credentials.json`` (the live cred, or
+            a per-account snapshot).
+        opener: Optional injection seam for tests (an ``urlopen``-alike).
+
+    Returns:
+        The account email string, or ``None`` on any failure/offline path.
+    """
+    access_token, _, _, _ = _read_tokens_at(Path(credentials_path))
+    if not access_token:
+        return None
+    return _fetch_email_from_api(access_token, opener=opener)
+
+
+__all__ = ["fetch_account_email"]

--- a/src/scitex_agent_container/_account/creds_sync.py
+++ b/src/scitex_agent_container/_account/creds_sync.py
@@ -16,18 +16,34 @@ Fail-loud contract (no silent fallbacks): an EXPIRED or ABSENT live
 credential is a hard error (:class:`LiveCredInvalidError`), never a
 silent save of a stale token.
 
-Pure stdlib. No network call. The store-name is the account email
-slugified (``wyusuuke@gmail.com`` → ``wyusuuke-gmail-com``), matching
-the layout the rest of sac already uses on disk.
+The store-name is the account email slugified (``wyusuuke@gmail.com`` →
+``wyusuuke-gmail-com``), matching the layout the rest of sac already uses
+on disk.
+
+Identity guard (2026-07)
+------------------------
+The TARGET store is derived from the LIVE TOKEN's ACTUAL identity — a
+best-effort OAuth "whoami" (:func:`_account.account_identity.fetch_account_email`)
+— NOT from ``~/.claude.json``'s ``oauthAccount.emailAddress`` metadata,
+which drifts out of sync with the token across logins/switches. That drift
+caused ``sync_live`` to snapshot one account's token into ANOTHER account's
+store (clobbering it) on 2026-07. A single best-effort network call is made
+per sync; when it FAILS (offline), the code falls back to the metadata email
+BUT refuses any write that would change a store's recorded identity. A
+store's credential must always authenticate as that store's own account.
 """
 
 from __future__ import annotations
 
 import json
+import logging
 import shutil
 import time
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 
 class LiveCredInvalidError(RuntimeError):
@@ -36,6 +52,19 @@ class LiveCredInvalidError(RuntimeError):
     The message names the live path and tells the operator how to fix
     it (``claude /login``). Surfaced as a non-zero CLI exit so the
     operator never mistakes a stale token for a successful sync.
+    """
+
+
+class AccountIdentityError(LiveCredInvalidError):
+    """Raised when a sync would change a store's recorded account identity.
+
+    Subclasses :class:`LiveCredInvalidError` so the ``watch-live`` loop and
+    the ``sync-live`` CLI already treat it as a soft, LOGGED failure — the
+    write is refused (never corrupt a store on identity uncertainty), never
+    crashed. This is the offline-path safety net for the 2026-07
+    credential-clobber bug: when the live token's identity cannot be
+    verified (whoami offline) AND the target store already records a
+    different account, we abort rather than overwrite.
     """
 
 
@@ -138,21 +167,66 @@ def _atomic_copy(src: Path, dst: Path) -> None:
     tmp.replace(dst)
 
 
+def _read_store_email(account_dir: Path) -> str | None:
+    """Return the ``email_address`` recorded in a store's ``account.json``.
+
+    ``None`` when the metadata file is missing, unparseable, or lacks a
+    non-empty ``email_address``. Never raises. Used by the offline safety
+    guard to detect that a target store already belongs to a different
+    account before overwriting its credential.
+    """
+    # stx-allow: fallback (reason: a store's account.json may be absent or
+    # mid-rewrite; a missing/corrupt identity reads as None so the offline
+    # guard treats it as "no recorded identity" rather than crashing.)
+    try:
+        data = json.loads((account_dir / "account.json").read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    email = data.get("email_address")
+    if isinstance(email, str) and email.strip():
+        return email.strip()
+    return None
+
+
+def _default_identity_fn(live_path: Path) -> str | None:
+    """Best-effort whoami for the live credential (lazy import, offline-safe).
+
+    Imported lazily so importing this module never triggers the network
+    dependency, and so ``sync_live`` makes the OAuth call only when actually
+    run. Returns ``None`` on any failure — the caller falls back to the
+    metadata email under the offline guard.
+    """
+    from .account_identity import fetch_account_email
+
+    return fetch_account_email(live_path)
+
+
 def sync_live(
     home: Path | None = None,
     store_dir: Path | None = None,
     *,
     now: float | None = None,
+    identity_fn: Callable[[Path], str | None] | None = None,
 ) -> SyncResult:
     """Mirror the live credential into its matching store when warranted.
 
-    Reads the live ``~/.claude/.credentials.json`` and the active email
-    from ``~/.claude.json``. The live cred must be VALID (``expiresAt``
-    strictly in the future) — otherwise :class:`LiveCredInvalidError`.
-    Derives the store-name from the email; if the store is ABSENT, OR
-    its snapshot is OLDER (earlier ``expiresAt``) than the live cred,
-    OR the store snapshot is itself expired, the live cred is
-    atomically snapshotted in and the account metadata refreshed.
+    Reads the live ``~/.claude/.credentials.json``. The live cred must be
+    VALID (``expiresAt`` strictly in the future) — otherwise
+    :class:`LiveCredInvalidError`.
+
+    Derives the target store from the live TOKEN's ACTUAL identity via a
+    best-effort whoami (``identity_fn``), NOT from the possibly-stale
+    ``~/.claude.json`` metadata email — this is the fix for the 2026-07
+    wrong-store clobber. When the whoami is offline it falls back to the
+    metadata email but refuses any write that would change a store's
+    recorded identity (:class:`AccountIdentityError`).
+
+    If the target store is ABSENT, OR its snapshot is OLDER (earlier
+    ``expiresAt``) than the live cred, OR the store snapshot is itself
+    expired, the live cred is atomically snapshotted in and the account
+    metadata refreshed.
 
     Idempotent: when the store snapshot already has an ``expiresAt`` >=
     the live cred's, returns ``action="up-to-date"`` without writing.
@@ -168,6 +242,11 @@ def sync_live(
     now
         Override for the wall clock (unix seconds). Defaults to
         ``time.time()``.
+    identity_fn
+        Best-effort whoami: ``live_path -> account_email | None``. Injected
+        in tests; defaults to :func:`_default_identity_fn` (an OAuth profile
+        call). Returns ``None`` when the identity cannot be verified
+        (offline), triggering the metadata-based fallback + safety guard.
 
     Returns
     -------
@@ -180,9 +259,15 @@ def sync_live(
         When the live credential is absent, malformed, expired, or the
         active email cannot be determined. The message tells the
         operator to ``claude /login``.
+    AccountIdentityError
+        (Subclass of ``LiveCredInvalidError``.) When the live token's
+        identity could not be verified (offline) AND the target store
+        already records a DIFFERENT account — the write is refused rather
+        than clobber that store's credential.
     """
     _home = home or Path.home()
     now_ts = now if now is not None else time.time()
+    _identity_fn = identity_fn if identity_fn is not None else _default_identity_fn
 
     live_path = _home / ".claude" / ".credentials.json"
     if not live_path.is_file():
@@ -204,20 +289,49 @@ def sync_live(
             "refusing to sync a stale token. Run `claude /login` to refresh."
         )
 
-    email = _read_active_email(_home)
-    if email is None:
-        raise LiveCredInvalidError(
-            f"cannot determine the active account email from "
-            f"{(_home / '.claude.json')!s} (missing "
-            "`oauthAccount.emailAddress`). Run `claude /login`."
-        )
+    metadata_email = _read_active_email(_home)
 
-    store_name = slugify_email(email)
+    # --- Identity guard: derive the target store from the TOKEN, not the
+    #     (possibly stale) ~/.claude.json metadata. ------------------------
+    # stx-allow: fallback (reason: whoami is best-effort; a None return means
+    # the token identity is unverifiable (offline) and we drop to the guarded
+    # metadata fallback below — never crash the sync on a network hiccup.)
+    token_email = _identity_fn(live_path)
+
+    if token_email is not None:
+        # Trust the live token's actual identity. If the metadata disagrees,
+        # it is stale — warn and write to the TOKEN-identity store anyway
+        # (this is the fix for the 2026-07 wrong-store clobber).
+        if metadata_email and metadata_email.lower() != token_email.lower():
+            logger.warning(
+                "sync-live: ~/.claude.json email %r disagrees with the live "
+                "token's actual account %r; trusting the token and syncing "
+                "into its store (metadata is stale).",
+                metadata_email,
+                token_email,
+            )
+        target_email = token_email
+        identity_verified = True
+    else:
+        # Offline / whoami failed — fall back to metadata selection under the
+        # safety guard below.
+        if metadata_email is None:
+            raise LiveCredInvalidError(
+                f"cannot determine the active account email from "
+                f"{(_home / '.claude.json')!s} (missing "
+                "`oauthAccount.emailAddress`) and the live token's identity "
+                "could not be verified. Run `claude /login`."
+            )
+        target_email = metadata_email
+        identity_verified = False
+
+    store_name = slugify_email(target_email)
 
     from .._state.account_store import _store_path, save_account
 
     store = _store_path(store_dir, _home)
-    snapshot = store / store_name / ".credentials.json"
+    account_dir = store / store_name
+    snapshot = account_dir / ".credentials.json"
     store_expiry = _read_oauth_expiry_seconds(snapshot) if snapshot.is_file() else None
 
     # Idempotent: store already matches or is fresher than live → no-op.
@@ -225,20 +339,37 @@ def sync_live(
         return SyncResult(
             action="up-to-date",
             store_name=store_name,
-            email=email,
+            email=target_email,
             live_expires_at=live_expiry,
             store_expires_at=store_expiry,
         )
 
+    # Offline safety guard: when the token identity is UNVERIFIED, never
+    # overwrite a store whose recorded account differs from where the
+    # metadata points — that is the exact shape of the 2026-07 clobber.
+    if not identity_verified:
+        recorded = _read_store_email(account_dir)
+        if recorded is not None and recorded.lower() != target_email.lower():
+            raise AccountIdentityError(
+                f"refusing to sync into store {store_name!r}: it already "
+                f"records account {recorded!r}, which differs from the "
+                f"metadata email {target_email!r}, and the live token's "
+                "identity could not be verified (offline). Refusing to change "
+                "a store's identity. Run `claude /login` or restore network "
+                "so the token can be verified."
+            )
+
     _atomic_copy(live_path, snapshot)
     # Refresh the safe metadata (email label) so `account list` resolves
     # the email even for a store created purely by auto-sync.
-    save_account(store_name, {"email_address": email}, store_dir=store_dir, home=_home)
+    save_account(
+        store_name, {"email_address": target_email}, store_dir=store_dir, home=_home
+    )
 
     return SyncResult(
         action="saved",
         store_name=store_name,
-        email=email,
+        email=target_email,
         live_expires_at=live_expiry,
         store_expires_at=store_expiry,
     )
@@ -296,6 +427,7 @@ def account_freshness(
 
 
 __all__ = [
+    "AccountIdentityError",
     "Freshness",
     "LiveCredInvalidError",
     "SyncResult",

--- a/tests/scitex_agent_container/_account/test_account_identity.py
+++ b/tests/scitex_agent_container/_account/test_account_identity.py
@@ -1,0 +1,118 @@
+"""Tests for the best-effort OAuth whoami (``_account.account_identity``).
+
+No mocks of our own code (PA-306): the ONLY seam is the injected ``opener``
+(an ``urlopen``-alike), which stands in for the network boundary — real
+tests must never hit ``api.anthropic.com``. AAA markers (TQ002), descriptive
+names (TQ003), one assertion each (TQ007).
+
+Security invariant: ``fetch_account_email`` reads the token from disk but
+returns ONLY the email — these tests assert the email leaks out and nothing
+token-shaped does.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scitex_agent_container._account.account_identity import fetch_account_email
+
+
+class _FakeResponse:
+    """Minimal context-manager response exposing ``.read()`` bytes."""
+
+    def __init__(self, body: bytes) -> None:
+        self._body = body
+
+    def __enter__(self) -> "_FakeResponse":
+        return self
+
+    def __exit__(self, *_exc: object) -> bool:
+        return False
+
+    def read(self) -> bytes:
+        return self._body
+
+
+def _opener_returning(payload: dict) -> object:
+    """Build an ``urlopen``-alike that returns ``payload`` as JSON."""
+
+    def _opener(_req: object, timeout: int = 0) -> _FakeResponse:  # noqa: ARG001
+        return _FakeResponse(json.dumps(payload).encode())
+
+    return _opener
+
+
+def _write_creds(path: Path, access_token: str | None) -> None:
+    """Write a ``.credentials.json`` with (or without) an access token."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    oauth: dict = {}
+    if access_token is not None:
+        oauth["accessToken"] = access_token
+    path.write_text(json.dumps({"claudeAiOauth": oauth}))
+
+
+def test_returns_email_from_profile_payload(tmp_path: Path) -> None:
+    # Arrange
+    creds = tmp_path / ".credentials.json"
+    _write_creds(creds, "sk-ant-live-token")
+    opener = _opener_returning({"account": {"email": "ywatanabe@scitex.ai"}})
+    # Act
+    email = fetch_account_email(creds, opener=opener)
+    # Assert
+    assert email == "ywatanabe@scitex.ai"
+
+
+def test_returns_none_when_no_access_token(tmp_path: Path) -> None:
+    # Arrange — credentials file exists but carries no accessToken.
+    creds = tmp_path / ".credentials.json"
+    _write_creds(creds, None)
+    # Act — opener is never reached; a bare urlopen would fail the test.
+    email = fetch_account_email(creds, opener=_opener_returning({"account": {}}))
+    # Assert
+    assert email is None
+
+
+def test_returns_none_when_credentials_file_missing(tmp_path: Path) -> None:
+    # Arrange
+    creds = tmp_path / "absent" / ".credentials.json"
+    # Act
+    email = fetch_account_email(creds, opener=_opener_returning({}))
+    # Assert
+    assert email is None
+
+
+def test_returns_none_on_network_error(tmp_path: Path) -> None:
+    # Arrange
+    creds = tmp_path / ".credentials.json"
+    _write_creds(creds, "sk-ant-live-token")
+
+    def _boom(_req: object, timeout: int = 0):  # noqa: ARG001
+        raise OSError("network unreachable")
+
+    # Act
+    email = fetch_account_email(creds, opener=_boom)
+    # Assert
+    assert email is None
+
+
+def test_returns_none_on_malformed_payload(tmp_path: Path) -> None:
+    # Arrange — well-formed JSON but missing the account.email shape.
+    creds = tmp_path / ".credentials.json"
+    _write_creds(creds, "sk-ant-live-token")
+    opener = _opener_returning({"unexpected": "shape"})
+    # Act
+    email = fetch_account_email(creds, opener=opener)
+    # Assert
+    assert email is None
+
+
+def test_does_not_return_the_access_token(tmp_path: Path) -> None:
+    # Arrange — the token must never leak out as the "email".
+    creds = tmp_path / ".credentials.json"
+    _write_creds(creds, "sk-ant-secret-token")
+    opener = _opener_returning({"account": {"email": "a@b.com"}})
+    # Act
+    email = fetch_account_email(creds, opener=opener)
+    # Assert
+    assert email is not None and "sk-ant-" not in email

--- a/tests/scitex_agent_container/_account/test_creds_sync.py
+++ b/tests/scitex_agent_container/_account/test_creds_sync.py
@@ -19,6 +19,7 @@ from pathlib import Path
 import pytest
 
 from scitex_agent_container._account.creds_sync import (
+    AccountIdentityError,
     Freshness,
     LiveCredInvalidError,
     account_freshness,
@@ -257,6 +258,131 @@ def test_sync_live_raises_when_email_missing(_isolate_home: Path) -> None:
     # Assert
     with ctx:
         sync_live(home=home)
+
+
+# ---------------------------------------------------------------------------
+# sync_live — identity guard (regression for the 2026-07 wrong-store clobber)
+# ---------------------------------------------------------------------------
+
+
+def _write_store_account_json(home: Path, slug: str, email: str) -> None:
+    """Write a store's ``account.json`` recording its owning account email."""
+    acct = home / ".scitex" / "agent-container" / "accounts" / slug
+    acct.mkdir(parents=True, exist_ok=True)
+    (acct / "account.json").write_text(
+        json.dumps({"name": slug, "email_address": email})
+    )
+
+
+def test_sync_live_matched_identity_writes_correct_store(_isolate_home: Path) -> None:
+    # Arrange — token identity agrees with the metadata email.
+    home = _isolate_home
+    future_ms = int((time.time() + 3_600) * 1_000)
+    _write_live(home, "wyusuuke@gmail.com", future_ms)
+    # Act
+    result = sync_live(home=home, identity_fn=lambda _p: "wyusuuke@gmail.com")
+    # Assert
+    assert result.store_name == "wyusuuke-gmail-com"
+
+
+def test_sync_live_mismatched_identity_writes_token_store_not_metadata(
+    _isolate_home: Path,
+) -> None:
+    # Arrange — stale metadata says wyusuuke, but the live token is ywatanabe.
+    home = _isolate_home
+    future_ms = int((time.time() + 3_600) * 1_000)
+    _write_live(home, "wyusuuke@gmail.com", future_ms)
+    # Act
+    result = sync_live(home=home, identity_fn=lambda _p: "ywatanabe@scitex.ai")
+    # Assert — the token's identity wins, not the stale metadata email.
+    assert result.store_name == "ywatanabe-scitex-ai"
+
+
+def test_sync_live_mismatched_identity_does_not_corrupt_wrong_store(
+    _isolate_home: Path,
+) -> None:
+    # Arrange — a healthy wyusuuke store already exists; metadata is stale
+    # (says wyusuuke) but the live token authenticates as ywatanabe.
+    home = _isolate_home
+    wyusuuke_ms = int((time.time() + 5_000) * 1_000)
+    live_ms = int((time.time() + 3_600) * 1_000)
+    wyusuuke_snap = _store_snapshot_path(home, "wyusuuke-gmail-com")
+    wyusuuke_snap.parent.mkdir(parents=True, exist_ok=True)
+    wyusuuke_snap.write_text(json.dumps({"claudeAiOauth": {"expiresAt": wyusuuke_ms}}))
+    _write_live(home, "wyusuuke@gmail.com", live_ms)
+    # Act
+    sync_live(home=home, identity_fn=lambda _p: "ywatanabe@scitex.ai")
+    # Assert — the wyusuuke store's credential is untouched (not clobbered).
+    assert (
+        json.loads(wyusuuke_snap.read_text())["claudeAiOauth"]["expiresAt"]
+        == wyusuuke_ms
+    )
+
+
+def test_sync_live_mismatched_identity_writes_token_store_snapshot(
+    _isolate_home: Path,
+) -> None:
+    # Arrange
+    home = _isolate_home
+    live_ms = int((time.time() + 3_600) * 1_000)
+    _write_live(home, "wyusuuke@gmail.com", live_ms)
+    # Act
+    sync_live(home=home, identity_fn=lambda _p: "ywatanabe@scitex.ai")
+    # Assert — the token-identity store received the live credential.
+    token_snap = _store_snapshot_path(home, "ywatanabe-scitex-ai")
+    assert json.loads(token_snap.read_text())["claudeAiOauth"]["expiresAt"] == live_ms
+
+
+def test_sync_live_offline_aborts_when_store_identity_differs(
+    _isolate_home: Path,
+) -> None:
+    # Arrange — whoami offline (None); metadata points at the wyusuuke store,
+    # but that store already records a DIFFERENT account (ywatanabe).
+    home = _isolate_home
+    live_ms = int((time.time() + 3_600) * 1_000)
+    _write_live(home, "wyusuuke@gmail.com", live_ms)
+    _write_store_account_json(home, "wyusuuke-gmail-com", "ywatanabe@scitex.ai")
+    # Act
+    ctx = pytest.raises(AccountIdentityError)
+    # Assert
+    with ctx:
+        sync_live(home=home, identity_fn=lambda _p: None)
+
+
+def test_sync_live_offline_abort_does_not_overwrite_snapshot(
+    _isolate_home: Path,
+) -> None:
+    # Arrange — same offline mismatch, plus a pre-existing snapshot to protect.
+    home = _isolate_home
+    guarded_ms = int((time.time() + 5_000) * 1_000)
+    live_ms = int((time.time() + 3_600) * 1_000)
+    snap = _store_snapshot_path(home, "wyusuuke-gmail-com")
+    snap.parent.mkdir(parents=True, exist_ok=True)
+    snap.write_text(json.dumps({"claudeAiOauth": {"expiresAt": guarded_ms}}))
+    _write_store_account_json(home, "wyusuuke-gmail-com", "ywatanabe@scitex.ai")
+    _write_live(home, "wyusuuke@gmail.com", live_ms)
+    # Act
+    try:
+        sync_live(home=home, identity_fn=lambda _p: None)
+    except AccountIdentityError:
+        pass
+    # Assert — the guarded snapshot survived the aborted sync.
+    assert json.loads(snap.read_text())["claudeAiOauth"]["expiresAt"] == guarded_ms
+
+
+def test_sync_live_offline_saves_when_store_identity_matches(
+    _isolate_home: Path,
+) -> None:
+    # Arrange — whoami offline, but the target store records the SAME account,
+    # so the metadata fallback may safely save.
+    home = _isolate_home
+    live_ms = int((time.time() + 3_600) * 1_000)
+    _write_live(home, "wyusuuke@gmail.com", live_ms)
+    _write_store_account_json(home, "wyusuuke-gmail-com", "wyusuuke@gmail.com")
+    # Act
+    result = sync_live(home=home, identity_fn=lambda _p: None)
+    # Assert
+    assert result.action == "saved"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## The bug (confirmed in production, 2026-07)

After the operator logged into account **ywatanabe**, `sac accounts sync-live` (and the `watch-live` daemon that calls the same code) wrote the live token into **both** the `ywatanabe` store **and** the `wyusuuke` store. Both stores' tokens then authenticated as ywatanabe (verified via the OAuth profile endpoint: both returned account uuid `c06732da` / `ywatanabe@scitex.ai`). **The wyusuuke credential was lost.**

### Root cause
`_account/creds_sync.py::sync_live` derived the **target** store-name from `~/.claude.json`'s `oauthAccount.emailAddress` (stale metadata) rather than from the actual token in `~/.claude/.credentials.json`. Across logins/switches the metadata email drifts out of sync with the token, so sync_live snapshotted the live token into the store matching the **stale** email — changing that store's account identity.

## The fix — identity guard

Invariant enforced: *a stored account's credential must always authenticate as that store's own account; a write must never change a store's identity.*

- **New `_account/account_identity.fetch_account_email(credentials_path)`** — best-effort OAuth whoami (`GET /api/oauth/profile`, `anthropic-beta: oauth-2025-04-20`) returning **only** the account email. Reuses `claude_usage`'s stdlib-urllib token reader + gating headers; the token is read internally and **never** returned. Offline-safe (returns `None` on any failure). (Lives in a new focused module because `claude_usage.py` is already over the repo's 512-line file cap — refactoring an unrelated file was out of scope.)
- **`sync_live` derives the target store from the live TOKEN's actual identity**, not the metadata email. On token/metadata disagreement it **trusts the token** (writes to the token-identity store) and logs a warning about the stale metadata.
- **Offline safety fallback**: when the whoami network call fails, fall back to the metadata email **but** refuse (new `AccountIdentityError`, a `LiveCredInvalidError` subclass so `watch-live` logs-and-survives) any write that would overwrite a store whose recorded account differs — never corrupt a store on uncertainty.

`watch-live` calls `sync_live`, so this fixes both surfaces (confirmed: `creds_watch.run_sync_once` → `sync_live`).

## Tests (regression for today's clobber)

Identity function is injected — **no real network in tests**:
- (a) matched identity → writes to the correct store;
- (b) mismatched identity (token != metadata store) → writes to the token-identity store; the wrong store's snapshot is **untouched**;
- (c) offline/whoami-failure with a differing store identity → **aborts** rather than corrupting; the guarded snapshot survives.

New source module ships its sibling test `test_account_identity.py` (source-parity audit).

### Test command & result
```
PYTHONPATH=src python -m pytest \
  tests/scitex_agent_container/_account/test_creds_sync.py \
  tests/scitex_agent_container/_account/test_account_identity.py -q
# 34 passed
```
`test_creds_watch.py` (9 passed) also green. The one `test_audit_all_clean` failure is a pre-existing **120s subprocess timeout** of the whole-ecosystem `scitex-dev ecosystem audit-all` in this environment (not a source-parity violation) — the new module has its sibling test, so the deterministic parity check is clean.