### PR TITLE
fix(accounts): quota rotation selects healthy AND lowest-quota (never expired)

### DIFF
--- a/src/scitex_agent_container/_account/quota_watch.py
+++ b/src/scitex_agent_container/_account/quota_watch.py
@@ -32,14 +32,43 @@ _DEFAULT_LOG_PATH = (
 
 
 def _select_next_account(
-    accounts: list[dict], current_email: str | None
+    accounts: list[dict],
+    current_email: str | None,
+    *,
+    store_dir: Path | None = None,
+    home: Path | None = None,
+    now: float | None = None,
 ) -> dict | None:
-    """Pick the account with lowest 5h usage that isn't the current one."""
+    """Pick the HEALTHY account with lowest 5h usage that isn't the current one.
+
+    Health is credential-snapshot freshness — a non-expired
+    ``claudeAiOauth.expiresAt`` — reusing
+    :func:`.._creds._pick_healthy.account_health` (the same predicate the
+    boot-time picker uses). An account whose stored credential is EXPIRED
+    or ABSENT is NEVER selected, even when its usage reads 0.0%.
+
+    This is the fix for the 2026-07-06 rotation bug: the selector rotated
+    the live account to the EXPIRED account ``ywata1989-gmail-com`` purely
+    because its usage read 0.0%, handing the fleet a dead token. Freshness
+    now gates the candidate set before quota ordering.
+
+    Returns ``None`` when NO healthy non-current candidate exists — the
+    caller must stay put rather than rotate to an unhealthy account.
+    """
+    from .._creds._pick_healthy import account_health
+
     others = [a for a in accounts if a.get("email_address") != current_email]
-    if not others:
+    healthy = [
+        a
+        for a in others
+        if account_health(
+            a.get("name", ""), store_dir=store_dir, home=home, now=now
+        ).is_healthy
+    ]
+    if not healthy:
         return None
-    # Sort by quota_5h_used_pct (None treated as 0 = fresh)
-    return sorted(others, key=lambda a: a.get("quota_5h_used_pct") or 0)[0]
+    # Sort by quota_5h_used_pct (None treated as 0 = fresh) among HEALTHY only.
+    return sorted(healthy, key=lambda a: a.get("quota_5h_used_pct") or 0)[0]
 
 
 def check_and_rotate(
@@ -120,15 +149,25 @@ def check_and_rotate(
                 ),
             }
 
-        next_acct = _select_next_account(accounts, current_email)
+        next_acct = _select_next_account(
+            accounts, current_email, store_dir=store_dir, home=home
+        )
         if next_acct is None:
+            # No HEALTHY non-current candidate. This covers both "only one
+            # account stored" and "every other account's credential is
+            # EXPIRED/ABSENT". Staying put is the safe choice — rotating to
+            # an unhealthy account would hand the fleet a dead token
+            # (the 2026-07-06 expired-account bug). Never rotate here.
             return {
                 "action": "no_accounts",
                 "quota_5h_pct": q5,
                 "quota_7d_pct": q7,
                 "switched_to": None,
                 "message": (
-                    f"ALERT: quota {q5}% (5h) — only one account stored, cannot rotate"
+                    f"ALERT: quota {q5}% (5h) — no HEALTHY account to rotate to "
+                    "(other accounts absent or credential-expired); staying put. "
+                    "Refresh a stored account with `claude /login` + "
+                    "`sac accounts sync-live`."
                 ),
             }
 

--- a/tests/scitex_agent_container/_account/test_quota_watch.py
+++ b/tests/scitex_agent_container/_account/test_quota_watch.py
@@ -14,6 +14,7 @@ Same-shape result-field invariants over a single arrange/act collapse into
 from __future__ import annotations
 
 import json
+import time
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Iterator
@@ -53,15 +54,37 @@ def _make_home(tmp_path: Path, email: str = "test@example.com") -> Path:
 
 
 def _make_store(tmp_path: Path, accounts: list[dict]) -> Path:
-    """Create a fake account store populated with accounts."""
+    """Create a fake account store populated with accounts.
+
+    Each account dict may carry a ``_health`` control key (stripped before
+    it is written to ``account.json``):
+
+      * ``"valid"``  (default) — writes a ``.credentials.json`` whose
+        ``claudeAiOauth.expiresAt`` is 30 days in the FUTURE → healthy.
+      * ``"expired"`` — writes a snapshot whose ``expiresAt`` is in the
+        PAST → unhealthy (the exact shape of the 2026-07-06 bug).
+      * ``"absent"`` — writes NO ``.credentials.json`` → unhealthy.
+
+    Freshness is what :func:`_creds._pick_healthy.account_health` reads, so
+    this seam lets the tests exercise the health gate without any network.
+    """
+    future_ms = int((time.time() + 30 * 24 * 3600) * 1000)
+    past_ms = int((time.time() - 24 * 3600) * 1000)
     store = tmp_path / "store"
     store.mkdir()
-    for acct in accounts:
+    for raw in accounts:
+        acct = dict(raw)  # copy: never mutate the caller's dict
+        health = acct.pop("_health", "valid")
         name = acct["name"]
         cred_dir = store / name
         cred_dir.mkdir()
         (cred_dir / "account.json").write_text(json.dumps(acct))
-        (cred_dir / ".credentials.json").write_text(json.dumps({"claudeAiOauth": {}}))
+        if health == "absent":
+            continue  # no snapshot on disk → ABSENT → unhealthy
+        expires = future_ms if health == "valid" else past_ms
+        (cred_dir / ".credentials.json").write_text(
+            json.dumps({"claudeAiOauth": {"expiresAt": expires}})
+        )
     return store
 
 
@@ -277,25 +300,165 @@ def test_check_and_rotate_between_warn_and_threshold_returns_warning(
 # ---------------------------------------------------------------------------
 
 
-def test_select_next_account_skips_account_matching_current_email():
+def test_select_next_account_skips_account_matching_current_email(tmp_path):
     # Arrange
     accounts = [
         {"name": "a", "email_address": "a@x.com", "quota_5h_used_pct": 50.0},
         {"name": "b", "email_address": "b@x.com", "quota_5h_used_pct": 10.0},
     ]
+    store = _make_store(tmp_path, accounts)
     # Act
-    result = _select_next_account(accounts, current_email="a@x.com")
+    result = _select_next_account(accounts, current_email="a@x.com", store_dir=store)
     # Assert
     assert result["name"] == "b"
 
 
-def test_select_next_account_returns_none_when_only_current_account_present():
+def test_select_next_account_returns_none_when_only_current_account_present(tmp_path):
     # Arrange
     accounts = [{"name": "only", "email_address": "only@x.com"}]
+    store = _make_store(tmp_path, accounts)
     # Act
-    result = _select_next_account(accounts, current_email="only@x.com")
+    result = _select_next_account(accounts, current_email="only@x.com", store_dir=store)
     # Assert
     assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _select_next_account — credential-health gate (2026-07-06 regression)
+# ---------------------------------------------------------------------------
+
+
+def test_select_next_account_excludes_expired_account_even_at_zero_quota(tmp_path):
+    # Arrange — the EXACT bug: an EXPIRED account reads 0.0% and would win
+    # on pure-quota ordering, but must be excluded as unhealthy.
+    accounts = [
+        {
+            "name": "expired",
+            "email_address": "expired@x.com",
+            "quota_5h_used_pct": 0.0,
+            "_health": "expired",
+        },
+        {
+            "name": "healthy",
+            "email_address": "healthy@x.com",
+            "quota_5h_used_pct": 40.0,
+        },
+    ]
+    store = _make_store(tmp_path, accounts)
+    # Act
+    result = _select_next_account(
+        accounts, current_email="cur@x.com", store_dir=store
+    )
+    # Assert
+    assert result["name"] == "healthy"
+
+
+def test_select_next_account_picks_lowest_quota_among_healthy(tmp_path):
+    # Arrange
+    accounts = [
+        {"name": "high", "email_address": "high@x.com", "quota_5h_used_pct": 70.0},
+        {"name": "low", "email_address": "low@x.com", "quota_5h_used_pct": 5.0},
+        {
+            "name": "expired-zero",
+            "email_address": "ez@x.com",
+            "quota_5h_used_pct": 0.0,
+            "_health": "expired",
+        },
+    ]
+    store = _make_store(tmp_path, accounts)
+    # Act
+    result = _select_next_account(
+        accounts, current_email="cur@x.com", store_dir=store
+    )
+    # Assert
+    assert result["name"] == "low"
+
+
+def test_select_next_account_returns_none_when_all_non_current_unhealthy(tmp_path):
+    # Arrange — every non-current candidate is expired or absent.
+    accounts = [
+        {"name": "cur", "email_address": "cur@x.com", "quota_5h_used_pct": 90.0},
+        {
+            "name": "dead",
+            "email_address": "dead@x.com",
+            "quota_5h_used_pct": 0.0,
+            "_health": "expired",
+        },
+        {
+            "name": "gone",
+            "email_address": "gone@x.com",
+            "quota_5h_used_pct": 0.0,
+            "_health": "absent",
+        },
+    ]
+    store = _make_store(tmp_path, accounts)
+    # Act
+    result = _select_next_account(
+        accounts, current_email="cur@x.com", store_dir=store
+    )
+    # Assert
+    assert result is None
+
+
+def test_select_next_account_never_selects_current_even_if_lowest(tmp_path):
+    # Arrange — current account has the lowest quota AND is healthy.
+    accounts = [
+        {"name": "cur", "email_address": "cur@x.com", "quota_5h_used_pct": 1.0},
+        {"name": "other", "email_address": "other@x.com", "quota_5h_used_pct": 80.0},
+    ]
+    store = _make_store(tmp_path, accounts)
+    # Act
+    result = _select_next_account(
+        accounts, current_email="cur@x.com", store_dir=store
+    )
+    # Assert
+    assert result["name"] == "other"
+
+
+def test_check_and_rotate_over_threshold_excludes_expired_backup(tmp_path):
+    # Arrange — over threshold, but the ONLY other account has an expired
+    # credential at 0% quota. End-to-end guard against the live bug: stay
+    # put, never rotate to the dead token.
+    home = _make_home(tmp_path, email="primary@example.com")
+    (home / ".claude").mkdir()
+    store = _make_store(
+        tmp_path,
+        [
+            {
+                "name": "expired-backup",
+                "email_address": "backup@example.com",
+                "quota_5h_used_pct": 0.0,
+                "_health": "expired",
+            }
+        ],
+    )
+    # Act
+    with _fake_fetch_usage({"used_pct_5h": 92.0, "used_pct_7d": 70.0, "error": None}):
+        result = check_and_rotate(threshold=80.0, store_dir=store, home=home)
+    # Assert
+    assert result["action"] == "no_accounts"
+
+
+def test_check_and_rotate_over_threshold_expired_backup_does_not_switch(tmp_path):
+    # Arrange
+    home = _make_home(tmp_path, email="primary@example.com")
+    (home / ".claude").mkdir()
+    store = _make_store(
+        tmp_path,
+        [
+            {
+                "name": "expired-backup",
+                "email_address": "backup@example.com",
+                "quota_5h_used_pct": 0.0,
+                "_health": "expired",
+            }
+        ],
+    )
+    # Act
+    with _fake_fetch_usage({"used_pct_5h": 92.0, "used_pct_7d": 70.0, "error": None}):
+        result = check_and_rotate(threshold=80.0, store_dir=store, home=home)
+    # Assert
+    assert result["switched_to"] is None
 
 
 # ---------------------------------------------------------------------------
@@ -328,7 +491,7 @@ def test_check_and_rotate_only_current_account_message_mentions_cannot_rotate(tm
     with _fake_fetch_usage({"used_pct_5h": 92.0, "used_pct_7d": 70.0, "error": None}):
         result = check_and_rotate(threshold=80.0, store_dir=store, home=home)
     # Assert
-    assert "cannot rotate" in result["message"]
+    assert "staying put" in result["message"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Bug

`_account/quota_watch.py::_select_next_account` picked the rotation target as
"among accounts whose email != current, the one with the LOWEST
`quota_5h_used_pct` (None treated as 0)". It ignored credential
freshness/health entirely.

**Proven live failure** (`~/.scitex/agent-container/logs/quota-watch.log`,
2026-07-06): the watcher rotated the active account to the EXPIRED account
`ywata1989-gmail-com` purely because its usage read `0.0%` — handing the fleet
a dead token. An expired account always reads lowest, so it always won.

## Fix

`_select_next_account` now filters candidates to HEALTHY ones — non-current AND
non-expired credential snapshot — BEFORE ordering by quota, then picks the
lowest-quota among those. Health reuses `_creds._pick_healthy.account_health`
(non-expired `claudeAiOauth.expiresAt`), the same freshness notion the
boot-time picker uses — no reinvented expiry check. The selector now takes
`store_dir`/`home`/`now` so it can look up each candidate's snapshot freshness.

When NO healthy non-current candidate exists, it returns `None`, and
`check_and_rotate` treats that as "no safe rotation target — stay put" with a
clear `no_accounts` warning (never rotates to an unhealthy account, never
crashes).

## Tests

Extended `tests/scitex_agent_container/_account/test_quota_watch.py`. The
`_make_store` helper now writes real credential snapshots with controllable
freshness (`_health` = valid/expired/absent). New regression cases:

- expired/unhealthy account EXCLUDED even at 0% quota (the exact bug)
- lowest-quota among HEALTHY chosen (expired-at-0% skipped)
- only-unhealthy-non-current candidates -> `None`
- current account never selected (even when lowest + healthy)
- end-to-end `check_and_rotate`: over-threshold with an expired backup stays
  put (`action=no_accounts`, `switched_to=None`)

No real network; same in-module `fetch_usage` swap seam existing tests use.

Command:
`PYTHONPATH=./src /opt/venv-sac/bin/python -m pytest ./tests/scitex_agent_container/_account/test_quota_watch.py -q`
Result: **37 passed**.