### PR TITLE
feat(accounts): sac accounts mint-token — access-only credential artifact (strip refresh_token)

### DIFF
--- a/src/scitex_agent_container/_account/mint_token.py
+++ b/src/scitex_agent_container/_account/mint_token.py
@@ -1,0 +1,188 @@
+"""Master-side ACCESS-ONLY credential minting for host cred-distribution.
+
+This is the *master-side generation primitive* of a master→compute-host
+credential-distribution scheme (co-designed with scitex-dev). The master
+host mints an **access-only** credential artifact that compute hosts
+consume READ-ONLY. The whole point is structural: the artifact carries
+the OAuth ``accessToken`` (the distributable) but the ``refreshToken`` is
+STRIPPED, so nothing on a compute host can ever trigger the single-use
+refresh-token rotation that would invalidate the master's token.
+
+Design rules (security-sensitive)
+---------------------------------
+1. The ``refreshToken`` MUST NEVER appear in the minted artifact. The
+   ``accessToken`` leaves by design (it is the distributable). Neither
+   token is ever logged.
+2. MINT-ON-DEMAND: the CURRENT stored ``.credentials.json`` is read at
+   call time (freshest token). No caching.
+3. EXCLUSIVE-STRICT health gate: if the requested account's stored
+   credential is UNHEALTHY (expired per
+   :func:`_creds._pick_healthy.account_health`), minting FAILS loudly.
+   A dead/expired token is NEVER minted.
+4. Unknown account label fails loudly, listing available labels.
+
+The consumer-side ``pull-token`` primitive is a SEPARATE later change —
+this module only mints.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any
+
+from .._creds._pick_healthy import account_health
+from .._state.account_store import _store_path, list_accounts
+from .claude_usage import _load_json, _read_tokens_at
+
+#: Structural marker for the artifact kind. The refresh_token is stripped.
+_ARTIFACT_KIND = "access-only"
+#: Bump when the envelope shape changes; consumers gate on this.
+_ARTIFACT_VERSION = 1
+
+
+class MintError(RuntimeError):
+    """Raised when an access-only artifact cannot be minted.
+
+    Carries an operator-facing message (never any token material). The
+    CLI renders it to stderr and exits non-zero. Distinct exit paths:
+    unknown label, unhealthy (expired) credential, missing accessToken.
+    """
+
+
+def _read_scopes(credentials_path: Path) -> list[str]:
+    """Read ``claudeAiOauth.scopes`` (a non-secret list) from disk.
+
+    Best-effort: a missing / malformed field yields an empty list. Only
+    the scopes list leaves this helper — no token material is read here.
+    """
+    data = _load_json(credentials_path)
+    if not isinstance(data, dict):
+        return []
+    oauth = data.get("claudeAiOauth")
+    if not isinstance(oauth, dict):
+        return []
+    scopes = oauth.get("scopes")
+    if not isinstance(scopes, list):
+        return []
+    return [s for s in scopes if isinstance(s, str)]
+
+
+def _resolve_master_host(hostname: str | None) -> str:
+    """Resolve the master host label stamped into the artifact meta.
+
+    Delegates to :func:`_state.state_db_hostname.resolve_host` — the
+    canonical single-name resolver (``$SAC_HOST`` → config.yaml canonical
+    → short ``socket.gethostname()``). ``hostname`` is an explicit
+    override / test seam.
+    """
+    from .._state.state_db_hostname import resolve_host
+
+    return resolve_host(hostname)
+
+
+def mint_access_only_artifact(
+    account: str,
+    *,
+    store_dir: Path | None = None,
+    home: Path | None = None,
+    hostname: str | None = None,
+    now: float | None = None,
+) -> dict[str, Any]:
+    """Mint the wrapped ``{artifact, meta}`` access-only envelope.
+
+    Reads the CURRENT stored ``.credentials.json`` for ``account`` (a
+    store slug, e.g. ``wyusuuke-gmail-com``), gates on health, strips the
+    refresh_token, and returns the distributable envelope. The returned
+    dict is safe to serialise to stdout — it contains the accessToken
+    (by design) but NEVER the refreshToken.
+
+    Parameters
+    ----------
+    account
+        The stored-account slug to mint from.
+    store_dir, home, hostname, now
+        Test seams. ``store_dir=None`` uses the SciTeX local-state
+        cascade; ``home=None`` uses ``Path.home()``; ``hostname=None``
+        resolves the canonical host; ``now=None`` uses ``time.time()``
+        (SECONDS since epoch).
+
+    Raises
+    ------
+    MintError
+        * unknown ``account`` label (message lists available labels),
+        * UNHEALTHY (expired/absent) stored credential — never mints a
+          dead token,
+        * a stored credential with no usable ``accessToken`` / expiry.
+    """
+    _home = home if home is not None else Path.home()
+    now_s = now if now is not None else time.time()
+
+    store = _store_path(store_dir, _home)
+    account_dir = store / account
+    creds_path = account_dir / ".credentials.json"
+
+    # --- unknown label -----------------------------------------------------
+    if not account_dir.is_dir():
+        available = [a.get("name", "?") for a in list_accounts(store_dir, _home)]
+        avail_str = ", ".join(sorted(available)) if available else "(none)"
+        raise MintError(
+            f"unknown account '{account}' — available labels: {avail_str}"
+        )
+
+    # --- EXCLUSIVE-STRICT health gate --------------------------------------
+    health = account_health(account, store_dir=store_dir, home=_home, now=now_s)
+    if not health.is_healthy:
+        if health.state == "EXPIRED":
+            hrs = (
+                f" (expired {abs(health.hours_remaining or 0):.1f}h ago)"
+                if health.hours_remaining is not None
+                else " (expired)"
+            )
+            detail = hrs
+        else:  # ABSENT — dir exists but snapshot is missing/unparseable
+            detail = " (no credential snapshot on disk)"
+        raise MintError(
+            f"cannot mint: account '{account}' credential is unhealthy"
+            f"{detail} — run `claude /login` then `sac accounts sync-live`"
+        )
+
+    # --- read FRESH tokens at call time (mint-on-demand) -------------------
+    # `_read_tokens_at` returns (access, refresh, client_id, expires_at_ms).
+    # The refresh token is deliberately discarded here — it must NEVER reach
+    # the artifact. Only the access token + expiry are carried forward.
+    access_token, _refresh_token, _client_id, expires_at_ms = _read_tokens_at(
+        creds_path
+    )
+    if not access_token or expires_at_ms is None:
+        raise MintError(
+            f"cannot mint: account '{account}' has no usable accessToken/"
+            "expiresAt in its stored credential — run `claude /login`"
+        )
+
+    scopes = _read_scopes(creds_path)
+    minted_at_ms = int(now_s * 1000)
+    master_host = _resolve_master_host(hostname)
+
+    # The envelope: `artifact` is the distributable (access-only), `meta`
+    # is provenance. `refreshToken` is structurally absent from `artifact`.
+    return {
+        "artifact": {
+            "claudeAiOauth": {
+                "accessToken": access_token,
+                "expiresAt": expires_at_ms,
+                "scopes": scopes,
+            }
+        },
+        "meta": {
+            "account": account,
+            "master_host": master_host,
+            "minted_at": minted_at_ms,
+            "expires_at": expires_at_ms,
+            "artifact": _ARTIFACT_KIND,
+            "artifact_version": _ARTIFACT_VERSION,
+        },
+    }
+
+
+__all__ = ["MintError", "mint_access_only_artifact"]

--- a/src/scitex_agent_container/cli_pkg/_account_mint_token.py
+++ b/src/scitex_agent_container/cli_pkg/_account_mint_token.py
@@ -1,0 +1,62 @@
+"""``sac accounts mint-token`` — master-side ACCESS-ONLY credential minting.
+
+Emits ONE wrapped ``{artifact, meta}`` JSON envelope on stdout for the
+named stored account. The artifact carries the OAuth ``accessToken`` (the
+distributable) but the ``refreshToken`` is STRIPPED — so a compute host
+that consumes the artifact can never trigger the single-use refresh-token
+rotation that would invalidate the master's token.
+
+Fails loudly (non-zero exit) on an unknown label or an unhealthy/expired
+credential; a dead token is NEVER minted. Lives in its own module (like
+``_account_refresh`` / ``_account_sync_live``) to keep ``account_group``
+under the per-file line cap; attached onto the group at import time.
+"""
+
+from __future__ import annotations
+
+import click
+
+
+def register_mint_token_command(group: click.Group) -> None:
+    """Attach the ``mint-token`` subcommand onto ``group``."""
+
+    @group.command("mint-token")
+    @click.option(
+        "--account",
+        "account_label",
+        required=True,
+        help="Stored account slug to mint from (e.g. wyusuuke-gmail-com).",
+    )
+    def account_mint_token(account_label: str) -> None:
+        """Mint an ACCESS-ONLY credential artifact (refresh_token stripped).
+
+        Reads the CURRENT stored ``.credentials.json`` for the account
+        (mint-on-demand — freshest token), gates on health, strips the
+        refreshToken, and emits ONE JSON envelope on stdout::
+
+            {"artifact": {"claudeAiOauth": {"accessToken", "expiresAt",
+                                            "scopes"}},
+             "meta": {"account", "master_host", "minted_at", "expires_at",
+                      "artifact": "access-only", "artifact_version": 1}}
+
+        \b
+        Examples:
+          $ sac accounts mint-token --account wyusuuke-gmail-com
+        """
+        import json as _json
+        import sys
+
+        from .._account.mint_token import MintError, mint_access_only_artifact
+
+        try:
+            envelope = mint_access_only_artifact(account_label)
+        except MintError as exc:
+            click.echo(f"error: {exc}", err=True)
+            sys.exit(1)
+
+        # The envelope contains the accessToken by design; the refreshToken
+        # is structurally absent. Never log either — only emit the envelope.
+        click.echo(_json.dumps(envelope, ensure_ascii=False, indent=2))
+
+
+__all__ = ["register_mint_token_command"]

--- a/src/scitex_agent_container/cli_pkg/_account_quota_watch.py
+++ b/src/scitex_agent_container/cli_pkg/_account_quota_watch.py
@@ -1,0 +1,162 @@
+"""``watch-quota`` CLI commands (extracted from ``account_group``).
+
+Both the ``account watch-quota`` subcommand and the legacy top-level
+``quota_watch`` command live here to keep ``account_group.py`` under the
+per-file line cap. ``account_group`` re-exports ``quota_watch`` so the
+lazy entry-point path ``account_group:quota_watch`` (see ``_main.py``)
+keeps resolving unchanged.
+"""
+
+from __future__ import annotations
+
+import click
+
+
+@click.command("watch-quota")
+@click.option(
+    "--threshold",
+    default=80.0,
+    show_default=True,
+    help="Rotate when usage exceeds this %.",
+)
+@click.option(
+    "--interval",
+    default=300,
+    show_default=True,
+    help="Check interval in seconds.",
+)
+@click.option("--dry-run", is_flag=True, help="Check but do not actually rotate.")
+@click.option("--once", is_flag=True, help="Run once instead of looping.")
+@click.option(
+    "--daemon",
+    is_flag=True,
+    help="Double-fork into background (UNIX only). Logs to --log-file.",
+)
+@click.option(
+    "--log-file",
+    default=None,
+    show_default=False,
+    help="Log file path when running as daemon (default: ~/.scitex/logs/quota-watch.log).",
+)
+def quota_watch(
+    threshold: float,
+    interval: int,
+    dry_run: bool,
+    once: bool,
+    daemon: bool,
+    log_file: str | None,
+) -> None:
+    """Monitor quota and auto-rotate credentials when threshold exceeded.
+
+    \b
+    Examples:
+      # single check
+      scitex-agent-container watch-quota --once
+      # foreground loop every 5 min
+      scitex-agent-container watch-quota
+      # background daemon
+      scitex-agent-container watch-quota --daemon
+    """
+    from pathlib import Path
+
+    from .._account.quota_watch import check_and_rotate, run_loop, survival_mode_check
+
+    if once or dry_run:
+        result = check_and_rotate(threshold=threshold, dry_run=dry_run)
+        click.echo(f"[{result['action']}] {result['message']}")
+        # Also report survival mode in single-check mode
+        sv = survival_mode_check()
+        if sv["survival_mode"]:
+            click.echo(f"[SURVIVAL] {sv['message']}", err=True)
+        return
+
+    log_path = Path(log_file) if log_file else None
+    if daemon:
+        click.echo(
+            f"Forking quota-watch daemon (interval={interval}s, threshold={threshold}%). "
+            f"Log: {log_path or '~/.scitex/logs/quota-watch.log'}"
+        )
+    run_loop(
+        threshold=threshold,
+        interval=interval,
+        daemon=daemon,
+        log_path=log_path,
+    )
+
+
+def register_quota_watch_commands(group: click.Group) -> None:
+    """Attach the ``account watch-quota`` subcommand onto ``group``."""
+
+    @group.command("watch-quota")
+    @click.option(
+        "--threshold",
+        default=80.0,
+        show_default=True,
+        help="Rotate when usage exceeds this %.",
+    )
+    @click.option(
+        "--interval",
+        default=300,
+        show_default=True,
+        help="Check interval in seconds.",
+    )
+    @click.option("--dry-run", is_flag=True, help="Check but do not actually rotate.")
+    @click.option("--once", is_flag=True, help="Run once instead of looping.")
+    @click.option(
+        "--daemon",
+        is_flag=True,
+        help="Double-fork into background (UNIX only). Logs to --log-file.",
+    )
+    @click.option(
+        "--log-file",
+        default=None,
+        show_default=False,
+        help="Log file path when running as daemon (default: ~/.scitex/logs/quota-watch.log).",
+    )
+    def account_watch_quota(
+        threshold: float,
+        interval: int,
+        dry_run: bool,
+        once: bool,
+        daemon: bool,
+        log_file: str | None,
+    ) -> None:
+        """Monitor quota and auto-rotate credentials when threshold exceeded.
+
+        \b
+        Examples:
+          $ sac account watch-quota --once
+          $ sac account watch-quota
+          $ sac account watch-quota --daemon
+        """
+        from pathlib import Path
+
+        from .._account.quota_watch import (
+            check_and_rotate,
+            run_loop,
+            survival_mode_check,
+        )
+
+        if once or dry_run:
+            result = check_and_rotate(threshold=threshold, dry_run=dry_run)
+            click.echo(f"[{result['action']}] {result['message']}")
+            sv = survival_mode_check()
+            if sv["survival_mode"]:
+                click.echo(f"[SURVIVAL] {sv['message']}", err=True)
+            return
+
+        log_path = Path(log_file) if log_file else None
+        if daemon:
+            click.echo(
+                f"Forking quota-watch daemon (interval={interval}s, threshold={threshold}%). "
+                f"Log: {log_path or '~/.scitex/logs/quota-watch.log'}"
+            )
+        run_loop(
+            threshold=threshold,
+            interval=interval,
+            daemon=daemon,
+            log_path=log_path,
+        )
+
+
+__all__ = ["quota_watch", "register_quota_watch_commands"]

--- a/src/scitex_agent_container/cli_pkg/account_group.py
+++ b/src/scitex_agent_container/cli_pkg/account_group.py
@@ -255,76 +255,23 @@ def account_switch(name: str) -> None:
 
 
 # ---------------------------------------------------------------------------
-# quota-watch — exposed both at top-level (legacy) and under ``account``.
+# mint-token — master-side ACCESS-ONLY credential minting. Lives in its own
+# module (like refresh / sync-live) to keep this file under the per-file
+# line cap; attached onto the group at import time.
 # ---------------------------------------------------------------------------
+from ._account_mint_token import register_mint_token_command
+
+register_mint_token_command(account)
 
 
-@account.command("watch-quota")
-@click.option(
-    "--threshold",
-    default=80.0,
-    show_default=True,
-    help="Rotate when usage exceeds this %.",
-)
-@click.option(
-    "--interval",
-    default=300,
-    show_default=True,
-    help="Check interval in seconds.",
-)
-@click.option("--dry-run", is_flag=True, help="Check but do not actually rotate.")
-@click.option("--once", is_flag=True, help="Run once instead of looping.")
-@click.option(
-    "--daemon",
-    is_flag=True,
-    help="Double-fork into background (UNIX only). Logs to --log-file.",
-)
-@click.option(
-    "--log-file",
-    default=None,
-    show_default=False,
-    help="Log file path when running as daemon (default: ~/.scitex/logs/quota-watch.log).",
-)
-def account_watch_quota(
-    threshold: float,
-    interval: int,
-    dry_run: bool,
-    once: bool,
-    daemon: bool,
-    log_file: str | None,
-) -> None:
-    """Monitor quota and auto-rotate credentials when threshold exceeded.
+# ---------------------------------------------------------------------------
+# quota-watch — exposed both at top-level (legacy `quota_watch`, re-exported
+# below) and under ``account``. Bodies extracted to ``_account_quota_watch``
+# to keep this file under the per-file line cap.
+# ---------------------------------------------------------------------------
+from ._account_quota_watch import quota_watch, register_quota_watch_commands
 
-    \b
-    Examples:
-      $ sac account watch-quota --once
-      $ sac account watch-quota
-      $ sac account watch-quota --daemon
-    """
-    from pathlib import Path
-
-    from .._account.quota_watch import check_and_rotate, run_loop, survival_mode_check
-
-    if once or dry_run:
-        result = check_and_rotate(threshold=threshold, dry_run=dry_run)
-        click.echo(f"[{result['action']}] {result['message']}")
-        sv = survival_mode_check()
-        if sv["survival_mode"]:
-            click.echo(f"[SURVIVAL] {sv['message']}", err=True)
-        return
-
-    log_path = Path(log_file) if log_file else None
-    if daemon:
-        click.echo(
-            f"Forking quota-watch daemon (interval={interval}s, threshold={threshold}%). "
-            f"Log: {log_path or '~/.scitex/logs/quota-watch.log'}"
-        )
-    run_loop(
-        threshold=threshold,
-        interval=interval,
-        daemon=daemon,
-        log_path=log_path,
-    )
+register_quota_watch_commands(account)
 
 
 # ---------------------------------------------------------------------------
@@ -380,78 +327,6 @@ def account_status(host: str | None, as_json: bool) -> None:
         click.echo(_json.dumps(snapshot, ensure_ascii=False, indent=2))
     else:
         click.echo(format_status_prose(snapshot))
-
-
-@click.command("watch-quota")
-@click.option(
-    "--threshold",
-    default=80.0,
-    show_default=True,
-    help="Rotate when usage exceeds this %.",
-)
-@click.option(
-    "--interval",
-    default=300,
-    show_default=True,
-    help="Check interval in seconds.",
-)
-@click.option("--dry-run", is_flag=True, help="Check but do not actually rotate.")
-@click.option("--once", is_flag=True, help="Run once instead of looping.")
-@click.option(
-    "--daemon",
-    is_flag=True,
-    help="Double-fork into background (UNIX only). Logs to --log-file.",
-)
-@click.option(
-    "--log-file",
-    default=None,
-    show_default=False,
-    help="Log file path when running as daemon (default: ~/.scitex/logs/quota-watch.log).",
-)
-def quota_watch(
-    threshold: float,
-    interval: int,
-    dry_run: bool,
-    once: bool,
-    daemon: bool,
-    log_file: str | None,
-) -> None:
-    """Monitor quota and auto-rotate credentials when threshold exceeded.
-
-    \b
-    Examples:
-      # single check
-      scitex-agent-container watch-quota --once
-      # foreground loop every 5 min
-      scitex-agent-container watch-quota
-      # background daemon
-      scitex-agent-container watch-quota --daemon
-    """
-    from pathlib import Path
-
-    from .._account.quota_watch import check_and_rotate, run_loop, survival_mode_check
-
-    if once or dry_run:
-        result = check_and_rotate(threshold=threshold, dry_run=dry_run)
-        click.echo(f"[{result['action']}] {result['message']}")
-        # Also report survival mode in single-check mode
-        sv = survival_mode_check()
-        if sv["survival_mode"]:
-            click.echo(f"[SURVIVAL] {sv['message']}", err=True)
-        return
-
-    log_path = Path(log_file) if log_file else None
-    if daemon:
-        click.echo(
-            f"Forking quota-watch daemon (interval={interval}s, threshold={threshold}%). "
-            f"Log: {log_path or '~/.scitex/logs/quota-watch.log'}"
-        )
-    run_loop(
-        threshold=threshold,
-        interval=interval,
-        daemon=daemon,
-        log_path=log_path,
-    )
 
 
 # ---------------------------------------------------------------------------
@@ -549,3 +424,10 @@ def account_quota(json_out: bool, strict: bool) -> None:
             f"7d={round(meta['used_pct_7d'])} percent "
             f"ttl={meta['token_ttl_hours']:.2f}h"
         )
+
+
+# ``quota_watch`` is re-exported (defined in ``_account_quota_watch``) so the
+# lazy entry-point path ``account_group:quota_watch`` in ``_main.py`` keeps
+# resolving after the body was extracted. Named in ``__all__`` so linters do
+# not flag the re-export as an unused import.
+__all__ = ["account", "quota_watch"]

--- a/tests/scitex_agent_container/_account/test_mint_token.py
+++ b/tests/scitex_agent_container/_account/test_mint_token.py
@@ -1,0 +1,361 @@
+"""Tests for ``sac accounts mint-token`` — access-only credential minting.
+
+Security-critical invariant under test: the ``refreshToken`` NEVER appears
+in the minted artifact (that is the whole point of the access-only
+scheme). Fixtures use synthetic token strings — ``oat-test-access`` (the
+distributable, allowed to leave) and ``oat-test-refresh`` (the sentinel
+that must NEVER leak). No network, no real tokens, no monkeypatching:
+the pure function takes ``store_dir`` / ``home`` / ``now`` / ``hostname``
+as real injectable parameters, and the CLI is driven against a real
+temp store routed via ``$SCITEX_DIR``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from scitex_agent_container._account.mint_token import (
+    MintError,
+    mint_access_only_artifact,
+)
+
+_ACCESS = "oat-test-access"
+_REFRESH_SENTINEL = "oat-test-refresh"
+_SCOPES = ["user:inference", "user:profile"]
+_LABEL = "wyusuuke-gmail-com"
+
+
+def _write_account(
+    store: Path,
+    label: str,
+    *,
+    expires_at_ms: int,
+) -> None:
+    """Materialise a synthetic stored account under ``store/<label>/``."""
+    acct = store / label
+    acct.mkdir(parents=True, exist_ok=True)
+    creds = {
+        "claudeAiOauth": {
+            "accessToken": _ACCESS,
+            "refreshToken": _REFRESH_SENTINEL,
+            "expiresAt": expires_at_ms,
+            "scopes": list(_SCOPES),
+        }
+    }
+    (acct / ".credentials.json").write_text(json.dumps(creds), encoding="utf-8")
+    (acct / "account.json").write_text(
+        json.dumps({"name": label, "email_address": f"{label}@example.com"}),
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture
+def store(tmp_path):
+    d = tmp_path / "accounts"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture
+def healthy_env(store, tmp_path):
+    """A minted envelope for a healthy account, plus the expiry it used."""
+    now_s = time.time()
+    future_ms = int((now_s + 3600) * 1000)
+    _write_account(store, _LABEL, expires_at_ms=future_ms)
+    env = mint_access_only_artifact(
+        _LABEL,
+        store_dir=store,
+        home=tmp_path,
+        hostname="master-host-1",
+        now=now_s,
+    )
+    return env, future_ms
+
+
+# ---------------------------------------------------------------------------
+# Core function — healthy account emits the correct envelope shape
+# ---------------------------------------------------------------------------
+
+
+def test_mint_healthy_carries_access_token(healthy_env):
+    # Arrange
+    env, _future = healthy_env
+    # Act
+    oauth = env["artifact"]["claudeAiOauth"]
+    # Assert
+    assert oauth["accessToken"] == _ACCESS
+
+
+def test_mint_healthy_carries_expires_at(healthy_env):
+    # Arrange
+    env, future_ms = healthy_env
+    # Act
+    oauth = env["artifact"]["claudeAiOauth"]
+    # Assert
+    assert oauth["expiresAt"] == future_ms
+
+
+def test_mint_healthy_carries_scopes(healthy_env):
+    # Arrange
+    env, _future = healthy_env
+    # Act
+    oauth = env["artifact"]["claudeAiOauth"]
+    # Assert
+    assert oauth["scopes"] == _SCOPES
+
+
+def test_mint_healthy_meta_account(healthy_env):
+    # Arrange
+    env, _future = healthy_env
+    # Act
+    meta = env["meta"]
+    # Assert
+    assert meta["account"] == _LABEL
+
+
+def test_mint_healthy_meta_artifact_kind(healthy_env):
+    # Arrange
+    env, _future = healthy_env
+    # Act
+    meta = env["meta"]
+    # Assert
+    assert meta["artifact"] == "access-only"
+
+
+def test_mint_healthy_meta_artifact_version(healthy_env):
+    # Arrange
+    env, _future = healthy_env
+    # Act
+    meta = env["meta"]
+    # Assert
+    assert meta["artifact_version"] == 1
+
+
+def test_mint_healthy_meta_master_host(healthy_env):
+    # Arrange
+    env, _future = healthy_env
+    # Act
+    meta = env["meta"]
+    # Assert
+    assert meta["master_host"] == "master-host-1"
+
+
+def test_mint_healthy_meta_expires_at(healthy_env):
+    # Arrange
+    env, future_ms = healthy_env
+    # Act
+    meta = env["meta"]
+    # Assert
+    assert meta["expires_at"] == future_ms
+
+
+def test_mint_healthy_meta_minted_at_is_int(healthy_env):
+    # Arrange
+    env, _future = healthy_env
+    # Act
+    meta = env["meta"]
+    # Assert
+    assert isinstance(meta["minted_at"], int)
+
+
+# ---------------------------------------------------------------------------
+# Core function — SECURITY: refreshToken never leaves
+# ---------------------------------------------------------------------------
+
+
+def test_mint_healthy_omits_refresh_token_key(healthy_env):
+    # Arrange
+    env, _future = healthy_env
+    # Act
+    oauth = env["artifact"]["claudeAiOauth"]
+    # Assert
+    assert "refreshToken" not in oauth
+
+
+def test_mint_healthy_never_leaks_refresh_sentinel(healthy_env):
+    # Arrange
+    env, _future = healthy_env
+    # Act
+    blob = json.dumps(env)
+    # Assert
+    assert _REFRESH_SENTINEL not in blob
+
+
+def test_mint_healthy_access_token_present_in_blob(healthy_env):
+    # Arrange
+    env, _future = healthy_env
+    # Act
+    blob = json.dumps(env)
+    # Assert
+    assert _ACCESS in blob
+
+
+# ---------------------------------------------------------------------------
+# Core function — health gate + unknown label fail loudly
+# ---------------------------------------------------------------------------
+
+
+def test_mint_expired_account_raises(store, tmp_path):
+    # Arrange
+    now_s = time.time()
+    _write_account(store, "stale", expires_at_ms=int((now_s - 3600) * 1000))
+
+    def _call():
+        mint_access_only_artifact(
+            "stale", store_dir=store, home=tmp_path, now=now_s
+        )
+
+    # Act
+    action = _call
+    # Assert
+    with pytest.raises(MintError, match="unhealthy"):
+        action()
+
+
+def test_mint_unknown_label_raises(store, tmp_path):
+    # Arrange
+    now_s = time.time()
+    _write_account(store, "known-one", expires_at_ms=int((now_s + 3600) * 1000))
+
+    def _call():
+        mint_access_only_artifact(
+            "does-not-exist", store_dir=store, home=tmp_path, now=now_s
+        )
+
+    # Act
+    action = _call
+    # Assert
+    with pytest.raises(MintError, match="unknown account"):
+        action()
+
+
+def test_mint_unknown_label_lists_available(store, tmp_path):
+    # Arrange
+    now_s = time.time()
+    _write_account(store, "known-one", expires_at_ms=int((now_s + 3600) * 1000))
+
+    def _call():
+        mint_access_only_artifact(
+            "does-not-exist", store_dir=store, home=tmp_path, now=now_s
+        )
+
+    # Act
+    action = _call
+    # Assert
+    with pytest.raises(MintError, match="known-one"):
+        action()
+
+
+# ---------------------------------------------------------------------------
+# CLI wrapper — driven against a real temp store via $SCITEX_DIR
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def sac_store(tmp_path):
+    """Route the store to a temp dir via $SCITEX_DIR (yield-based, restores)."""
+    prev = os.environ.get("SCITEX_DIR")
+    os.environ["SCITEX_DIR"] = str(tmp_path / "sac")
+    accounts = tmp_path / "sac" / "agent-container" / "accounts"
+    accounts.mkdir(parents=True)
+    yield accounts
+    if prev is None:
+        os.environ.pop("SCITEX_DIR", None)
+    else:
+        os.environ["SCITEX_DIR"] = prev
+
+
+def _invoke_mint():
+    from scitex_agent_container.cli_pkg.account_group import account
+
+    runner = CliRunner()
+    # isolated_filesystem gives a git-less cwd so the local-state cascade
+    # falls back to $SCITEX_DIR instead of any project-scope store.
+    with runner.isolated_filesystem():
+        return runner.invoke(account, ["mint-token", "--account", _LABEL])
+
+
+def test_cli_healthy_exit_zero(sac_store):
+    # Arrange
+    now_s = time.time()
+    _write_account(sac_store, _LABEL, expires_at_ms=int((now_s + 3600) * 1000))
+    # Act
+    result = _invoke_mint()
+    # Assert
+    assert result.exit_code == 0, result.output
+
+
+def test_cli_healthy_stdout_is_access_only(sac_store):
+    # Arrange
+    now_s = time.time()
+    _write_account(sac_store, _LABEL, expires_at_ms=int((now_s + 3600) * 1000))
+    # Act
+    payload = json.loads(_invoke_mint().output)
+    # Assert
+    assert payload["meta"]["artifact"] == "access-only"
+
+
+def test_cli_healthy_stdout_has_access_token(sac_store):
+    # Arrange
+    now_s = time.time()
+    _write_account(sac_store, _LABEL, expires_at_ms=int((now_s + 3600) * 1000))
+    # Act
+    payload = json.loads(_invoke_mint().output)
+    # Assert
+    assert payload["artifact"]["claudeAiOauth"]["accessToken"] == _ACCESS
+
+
+def test_cli_healthy_master_host_present(sac_store):
+    # Arrange
+    now_s = time.time()
+    _write_account(sac_store, _LABEL, expires_at_ms=int((now_s + 3600) * 1000))
+    # Act
+    payload = json.loads(_invoke_mint().output)
+    # Assert
+    assert isinstance(payload["meta"]["master_host"], str)
+
+
+def test_cli_healthy_stdout_omits_refresh_sentinel(sac_store):
+    # Arrange
+    now_s = time.time()
+    _write_account(sac_store, _LABEL, expires_at_ms=int((now_s + 3600) * 1000))
+    # Act
+    output = _invoke_mint().output
+    # Assert
+    assert _REFRESH_SENTINEL not in output
+
+
+def test_cli_expired_exit_nonzero(sac_store):
+    # Arrange
+    now_s = time.time()
+    _write_account(sac_store, _LABEL, expires_at_ms=int((now_s - 60) * 1000))
+    # Act
+    result = _invoke_mint()
+    # Assert
+    assert result.exit_code != 0
+
+
+def test_cli_expired_prints_no_artifact(sac_store):
+    # Arrange
+    now_s = time.time()
+    _write_account(sac_store, _LABEL, expires_at_ms=int((now_s - 60) * 1000))
+    # Act
+    output = _invoke_mint().output
+    # Assert
+    assert "claudeAiOauth" not in output
+
+
+def test_cli_unknown_label_exit_nonzero(sac_store):
+    # Arrange
+    now_s = time.time()
+    _write_account(sac_store, "other", expires_at_ms=int((now_s + 3600) * 1000))
+    # Act
+    result = _invoke_mint()
+    # Assert
+    assert result.exit_code != 0


### PR DESCRIPTION
## Purpose

Master-side generation primitive for a **master-host credential-distribution
scheme** (co-designed with scitex-dev). The master mints an ACCESS-ONLY
credential artifact that compute hosts consume READ-ONLY, so nothing on a
compute host can trigger the single-use refresh-token rotation that would
invalidate the master's token.

A later PR adds the consumer-side `pull-token`; this PR is **mint-only**.

## Command

```
sac accounts mint-token --account <label>
```

Emits ONE wrapped `{artifact, meta}` JSON envelope on stdout:

```json
{
  "artifact": { "claudeAiOauth": { "accessToken": "<redacted>", "expiresAt": 1783436214140, "scopes": ["user:inference", "user:profile"] } },
  "meta": { "account": "wyusuuke-gmail-com", "master_host": "ywata-note-win", "minted_at": 1783432614275, "expires_at": 1783436214140, "artifact": "access-only", "artifact_version": 1 }
}
```

## Structural guarantee: access-only + refresh stripped

- The `refreshToken` is **structurally absent** from the artifact — the
  minting code reads `(access, refresh, client_id, expires)` and discards
  `refresh` before building the envelope. The `accessToken` leaves by design
  (it is the distributable). Neither token is ever logged.
- **Mint-on-demand**: the CURRENT stored `.credentials.json` is read at call
  time (freshest token). No caching.

## Exclusive-strict health gate

Reuses `_creds._pick_healthy.account_health` (the existing non-expired
`claudeAiOauth.expiresAt` predicate). If the requested account's stored
credential is UNHEALTHY (expired/absent), the command FAILS loudly to stderr
with a non-zero exit — a dead/expired token is NEVER minted. Unknown label
gives a clear error listing available labels + non-zero exit.

## stdout shape

The wrapped `{artifact, meta}` envelope shown above. `master_host` is
resolved via the canonical single-host resolver (`$SAC_HOST` then config.yaml
canonical then short `socket.gethostname()`).

## Files

- `_account/mint_token.py` — `mint_access_only_artifact()` + `MintError`.
- `cli_pkg/_account_mint_token.py` — the `mint-token` click subcommand.
- `cli_pkg/_account_quota_watch.py` — extracted the two `watch-quota` command
  bodies out of `account_group.py` (that file was already over the 512-line
  cap; adding a subcommand required getting it back under). `quota_watch` is
  re-exported so the `account_group:quota_watch` entry-point path is unchanged.
- `tests/scitex_agent_container/_account/test_mint_token.py` — 23 tests
  (healthy shape, **refresh-never-leaks** security regression guard,
  expired to non-zero, unknown to non-zero; CLI end-to-end via a real
  `$SCITEX_DIR` temp store).

## Tests

Ran the new suite plus the surrounding account + CLI suites with an absolute
interpreter path. New suite: 23 passed. Full `_account/` dir: 405 passed.
`cli_pkg/test_account_group.py`: 57 passed (watch-quota extraction verified
non-regressing).
