### PR TITLE
feat(account): read-only agent cred bind + refresh-all timer (master-host single-refresher)

### DIFF
--- a/src/scitex_agent_container/cli_pkg/_account_refresh.py
+++ b/src/scitex_agent_container/cli_pkg/_account_refresh.py
@@ -166,6 +166,20 @@ def _collect_pinned_running_accounts(home: Path | None = None) -> set[str]:
     ),
 )
 @click.option(
+    "--include-active",
+    "include_active",
+    is_flag=True,
+    default=False,
+    help=(
+        "With --all, refresh EVERY stored account INCLUDING the active "
+        "and any pinned-running one (skip nothing). This is the mode the "
+        "host-side sac-accounts-refresh timer runs under the master-host "
+        "single-refresher model: agents bind the credential :ro and never "
+        "refresh, so the timer must refresh the active account too or its "
+        "agents die at token expiry. Mutually exclusive with --skip-active."
+    ),
+)
+@click.option(
     "--json",
     "as_json",
     is_flag=True,
@@ -173,7 +187,11 @@ def _collect_pinned_running_accounts(home: Path | None = None) -> set[str]:
     help="Emit a JSON array on stdout instead of human prose.",
 )
 def account_refresh(
-    name: str | None, do_all: bool, skip_active: bool, as_json: bool
+    name: str | None,
+    do_all: bool,
+    skip_active: bool,
+    include_active: bool,
+    as_json: bool,
 ) -> None:
     """Mint a fresh access_token from the stored refresh_token, headlessly.
 
@@ -189,11 +207,21 @@ def account_refresh(
     the currently-active ``~/.claude`` login, so the refresh job never
     rotates the in-use refresh_token out from under the live session.
 
+    ``--include-active`` (with ``--all``) is the opposite intent, made
+    explicit: refresh EVERY account including the active + pinned-running
+    ones (skip nothing). Under the master-host single-refresher model
+    (2026-07-08) agents bind the credential ``:ro`` and never refresh, so
+    the host-side ``sac-accounts-refresh`` timer is the SOLE refresher and
+    MUST refresh the active account too — otherwise the active account's
+    agents die when its access_token expires. The timer's ExecStart uses
+    this flag. Mutually exclusive with ``--skip-active``.
+
     \b
     Examples:
       $ sac accounts refresh work
       $ sac accounts refresh --all
       $ sac accounts refresh --all --skip-active
+      $ sac accounts refresh --all --include-active   # timer mode
       $ sac accounts refresh --all --json
     """
     import json as _json
@@ -211,6 +239,13 @@ def account_refresh(
     if do_all and name:
         click.echo("error: pass either a name or --all, not both", err=True)
         raise SystemExit(2)
+    if skip_active and include_active:
+        click.echo(
+            "error: --skip-active and --include-active are mutually "
+            "exclusive (one skips the active account, the other forces it in)",
+            err=True,
+        )
+        raise SystemExit(2)
 
     home = Path.home()
     store = _store_path(None, home)
@@ -218,6 +253,14 @@ def account_refresh(
     if do_all:
         accounts = list_accounts(home=home)
         targets = [a["name"] for a in accounts]
+        if include_active:
+            # Master-host single-refresher: refresh everything, skip
+            # nothing. Log it so the operator can see the timer's intent.
+            click.echo(
+                "[include-active] refreshing ALL accounts including the "
+                "active + pinned-running ones (single-refresher model).",
+                err=True,
+            )
         if skip_active:
             active_name = _resolve_active_account_name(home, accounts)
             pinned_running = _collect_pinned_running_accounts(home)

--- a/src/scitex_agent_container/runtimes/_apptainer_auth.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_auth.py
@@ -87,13 +87,23 @@ def auth_argv(config: AgentConfig, state_dir: Path) -> list[str]:
     # CLAUDE_CONFIG_DIR points the SDK at this dir so it finds the
     # credentials file without needing $HOME pollution.
     #
-    # Mounted RW (no ``:ro``) so the in-container Claude CLI can
-    # refresh the OAuth ``accessToken`` in place when the host's
-    # token expires (~1h cadence). Without RW the bind-mounted file
-    # is frozen and every container 401s after token-expiry, forcing
-    # a manual scp-from-lead dance to re-seed peers. The CLI's
-    # refresh code-path itself is responsible for any concurrency
-    # locking — the bind is just a file passthrough.
+    # Mounted READ-ONLY (``:ro``) — master-host single-refresher model
+    # (operator 2026-07-08, credential-churn root-cause fix). The agent
+    # is a READ-ONLY CONSUMER of the credential: it NEVER refreshes or
+    # rotates the OAuth token. Previously this dir was bound ``:rw`` so
+    # the in-container Claude CLI could refresh the ``accessToken`` in
+    # place — but that made every running agent a refresher, and an
+    # agent refresh CONSUMES the single-use OAuth refresh_token: the
+    # instant an operator logged a fresh account in, a running agent ate
+    # its refresh_token (the "cred churn" disease). Now the host-side
+    # ``sac-accounts-refresh`` timer is the SOLE refresher; it rotates
+    # every account's snapshot on a fixed cadence, and the DIRECTORY
+    # bind (below) makes the timer's atomic-replace refreshes visible to
+    # the container on the next open — so a ``:ro`` agent still tracks
+    # the freshest token without ever writing one. The fail-loud expiry
+    # checks still apply: a ``:ro`` agent bound to an already-expired
+    # token cannot work, so an expired snapshot is an operator/timer
+    # problem to fix before launch, not something the agent can rescue.
     #
     # OAuth credentials bind shape: DIRECTORY bind, unconditionally
     # (operator task #11 + task #13).
@@ -110,10 +120,14 @@ def auth_argv(config: AgentConfig, state_dir: Path) -> list[str]:
     # silently loses the shared file, regressing into the per-copy
     # collision-401 disease the snapshot model was meant to fix.
     # A DIRECTORY bind resolves child files by name through the
-    # underlying filesystem on every open, so a tmp+rename inside the
-    # dir is visible to the container immediately — in BOTH directions
-    # (host writes seen by the container, and in-container CLI refresh
-    # writes seen by host writers).
+    # underlying filesystem on every open, so a host-side tmp+rename
+    # inside the dir is visible to the container immediately. Under the
+    # ``:ro`` single-refresher model this matters in ONE direction that
+    # counts: the host-side ``sac-accounts-refresh`` timer's atomic
+    # replace of ``.credentials.json`` is picked up by the container on
+    # the next open, so a read-only agent tracks the freshest token
+    # without a restart. The container no longer writes back (``:ro``),
+    # which is the whole point — no agent-side refresh, no churn.
     #
     # PR #262 (task #11) made the PINNED branch dir-bind; this module
     # (task #13) makes the UNPINNED/host-live branch dir-bind too. The
@@ -172,7 +186,11 @@ def auth_argv(config: AgentConfig, state_dir: Path) -> list[str]:
 
     argv += [
         "--bind",
-        f"{bind_src}:{bind_dest}:rw",
+        # READ-ONLY: the agent consumes the credential but never
+        # refreshes it (master-host single-refresher model). See the
+        # "Mounted READ-ONLY" rationale above. The host-side timer is
+        # the sole refresher; the dir bind surfaces its refreshes.
+        f"{bind_src}:{bind_dest}:ro",
         "--env",
         "CLAUDE_CONFIG_DIR=/tmp/sac-claude",
     ]
@@ -246,7 +264,7 @@ def _assert_credential_unexpired(
 def credentials_file_bind(
     config: AgentConfig, *, now: float | None = None
 ) -> list[str]:
-    """Render the writable file-bind for the agent's credentials file.
+    """Render the READ-ONLY file-bind for the agent's credentials file.
 
     Emitted LAST in :func:`_apptainer_build_argv.build_run_argv` (after
     the overlay-upper-home bind) so a relaxed ``--home`` tmpfs or
@@ -267,22 +285,42 @@ def credentials_file_bind(
          AUTOMATICALLY without any manual ``credentials_file:`` line.
       3. Neither set or a provider backend is active → no bind.
 
-    Binds the resolved host file ``rw`` at ``<container_home>/.claude/
-    .credentials.json`` so the in-container ``claude`` (both SDK and
-    TUI variants) reads AND refreshes that single file directly. The
-    SAME path the interactive ``claude`` auto-discovers when no
-    ``$CLAUDE_CONFIG_DIR`` redirect is set — operator-confirmed working
-    shape (figrecipe + scitex-todo manual test 2026-06-15).
+    Binds the resolved host file READ-ONLY (``:ro``) at
+    ``<container_home>/.claude/.credentials.json`` so the in-container
+    ``claude`` (both SDK and TUI variants) READS that single file
+    directly but NEVER refreshes or rotates it. The SAME path the
+    interactive ``claude`` auto-discovers when no ``$CLAUDE_CONFIG_DIR``
+    redirect is set — operator-confirmed working shape (figrecipe +
+    scitex-todo manual test 2026-06-15).
 
-    Caveat: a single-file bind is on the file's inode. An in-container
-    refresh that rewrites in-place persists to the source; one that
-    does tmp+rename orphans the bind (the source keeps the pre-rename
-    token). For account-pinned mode the snapshot dir is owned by
-    sac-account tooling that the operator controls; coordinate writers
-    accordingly. For explicit ``credentials_file:`` the path SHOULD
-    NOT be one concurrently atomic-renamed by host-side
-    ``sac accounts``/watch-live tooling — it is the agent's private,
-    operator-rotated credentials file.
+    Master-host single-refresher model (operator 2026-07-08, cred-churn
+    root-cause fix): the agent is a READ-ONLY CONSUMER. Previously this
+    file was bound ``:rw`` so the in-container CLI refreshed the OAuth
+    ``accessToken`` in place — but a refresh CONSUMES the single-use
+    OAuth refresh_token, so a running agent would eat the refresh_token
+    of a freshly-logged-in account (the churn). Now the host-side
+    ``sac-accounts-refresh`` timer is the SOLE refresher: it rotates the
+    account snapshot's access_token on a fixed cadence and writes it
+    back to the SAME snapshot file this bind sources, so a ``:ro`` agent
+    always reads a timer-kept-fresh token without ever writing one.
+
+    The fail-loud expiry gate (``_assert_credential_unexpired`` for the
+    explicit-file branch, ``resolve_cred_file`` → ``PinnedAccountError``
+    for the account branch) is unchanged and still load-bearing: a
+    ``:ro`` agent bound to an already-expired token cannot work, so an
+    expired credential is refused at launch (an operator/timer problem
+    to fix first, not one the read-only agent can rescue).
+
+    Caveat: a single-file ``:ro`` bind is on the file's inode. A
+    host-side tmp+rename refresh (the timer's atomic-replace) orphans
+    the bind — the container keeps reading the pre-rename inode until it
+    restarts. For a ``:ro`` agent this is a staleness (not a corruption)
+    concern: the token is valid until its natural expiry, and the timer
+    keeps the snapshot fresh so a restart re-binds the current inode.
+    The account-pinned SDK path additionally gets the DIRECTORY bind at
+    ``/tmp/sac-claude`` (:func:`auth_argv`), which resolves the child
+    file by name on every open and so DOES reflect atomic-replace
+    refreshes without a restart.
     """
     if provider_active(config):
         return []
@@ -339,7 +377,10 @@ def credentials_file_bind(
 
     container_home = resolve_container_home(config).rstrip("/")
     dest = f"{container_home}/.claude/.credentials.json"
-    return ["--bind", f"{src}:{dest}:rw"]
+    # READ-ONLY: the agent consumes the credential but never refreshes
+    # it (master-host single-refresher model — see the docstring). The
+    # host-side ``sac-accounts-refresh`` timer is the sole refresher.
+    return ["--bind", f"{src}:{dest}:ro"]
 
 
 def ensure_credentials_bind_target(
@@ -365,7 +406,7 @@ def ensure_credentials_bind_target(
     :func:`_apptainer_build_argv.build_run_argv`), else the workspace-home
     dir (``<state>/home``, bound at ``/home/agent``). This ensures an empty
     0-byte ``.claude/.credentials.json`` exists at that host path so the
-    ``:rw`` bind lands; the bind then SHADOWS this placeholder with the real
+    ``:ro`` bind lands; the bind then SHADOWS this placeholder with the real
     operator credential — the placeholder's contents never matter.
 
     CRITICAL — placement: the placeholder is written into the overlay
@@ -396,7 +437,7 @@ def ensure_credentials_bind_target(
     flags = bind_flags if bind_flags is not None else credentials_file_bind(config)
     if not flags:
         return None
-    # flags == ["--bind", "<src>:<container_home>/.claude/.credentials.json:rw"]
+    # flags == ["--bind", "<src>:<container_home>/.claude/.credentials.json:ro"]
     from ._to_home_overlay import resolve_container_home
 
     container_home = resolve_container_home(config).rstrip("/")

--- a/src/scitex_agent_container/runtimes/_apptainer_creds.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_creds.py
@@ -9,14 +9,16 @@ host-side ``.credentials.json`` gets bound into an agent container:
 
 * ``spec.claude.account`` empty → the host's live
   ``~/.claude/.credentials.json`` (shared OAuth — current default).
-  Bound ``:rw`` by the caller so the in-container Claude CLI's ~1h
-  OAuth refresh writes back to the host live file.
+  Bound ``:ro`` by the caller (master-host single-refresher model): the
+  agent READS the host live file but never refreshes it.
 
 * ``spec.claude.account`` set → the saved account's snapshot itself at
   ``~/.scitex/agent-container/accounts/<acct>/.credentials.json``,
-  bound ``:rw`` by the caller. Refresh writes by the in-container
-  Claude CLI land on the snapshot **directly** so the snapshot is
-  self-healing and never expires while the agent keeps running.
+  bound ``:ro`` by the caller. The agent reads the snapshot but never
+  writes it; the host-side ``sac-accounts-refresh`` timer is the SOLE
+  refresher and keeps the snapshot fresh (a DIRECTORY bind on the
+  snapshot's parent makes the timer's atomic-replace refreshes visible
+  to the container without a restart — see ``_apptainer_auth``).
 
 Fix for the 2026-06-01 fleet-wide silent outage (operator task #15):
 the prior implementation COPIED the snapshot into a per-agent state-dir
@@ -24,10 +26,15 @@ the prior implementation COPIED the snapshot into a per-agent state-dir
 snapshot drifted stale. After ~8h, every SDK turn 401'd silently (the
 telegram bridge still marked inbound 👀, but the agent could not
 complete a turn). The fix is structural — bind the snapshot itself.
-With the ``:rw`` bind the in-container CLI keeps the snapshot fresh
-for ALL agents pinned to that account, and an agent crash/restart
-cycle no longer loses the freshly-refreshed token (it was always
-written to the snapshot, not a per-agent copy).
+The snapshot is the single source of truth for ALL agents pinned to
+that account; under the master-host single-refresher model the
+host-side ``sac-accounts-refresh`` timer keeps that one snapshot fresh
+and the ``:ro`` agents read it. (Before 2026-07-08 the bind was ``:rw``
+and the in-container CLI refreshed the snapshot itself — that kept it
+fresh but made every agent a refresher, and an agent refresh consumes
+the single-use OAuth refresh_token, churning any freshly-logged-in
+account. The ``:ro`` flip moves refresh responsibility to the sole
+host-side timer.)
 
 Fail-loud (no silent fallbacks): when ``spec.claude.account`` is set
 but the pinned snapshot is ABSENT, has no numeric ``expiresAt``, or is
@@ -37,17 +44,15 @@ back to the host live file (a different account) or run with a stale
 token — that would defeat the whole point of account pinning and hand
 the agent the wrong identity.
 
-Sharing semantics with the :rw bind:
+Sharing semantics with the :ro bind:
 
 * Different accounts → different snapshot files → no conflict.
-* Same account, multiple agents → all share the SAME snapshot mount.
-  The in-container Claude CLI uses an atomic write (tmp + rename) for
-  refresh writeback, so concurrent refreshes converge on whichever
-  finishes last — the token is fungible across agents pinned to the
-  same account by definition, so a refresh by agent A is also fresh
-  for agent B. The shared-mount footgun the prior copy avoided does
-  not apply here: same-account agents share an IDENTITY, sharing the
-  file matches the model.
+* Same account, multiple agents → all share the SAME snapshot mount,
+  READ-ONLY. None of them refresh it; the host-side timer does. The
+  token is fungible across agents pinned to the same account by
+  definition, so the timer's single refresh serves every pinned agent
+  at once. Same-account agents share an IDENTITY, so sharing the file
+  matches the model.
 """
 
 from __future__ import annotations
@@ -81,10 +86,11 @@ def resolve_cred_file(
     (``None`` only when it does not exist — caller skips the bind).
 
     With ``spec.claude.account`` set, returns the per-account SNAPSHOT
-    file directly (no per-agent copy). The caller binds it ``:rw`` so
-    the in-container Claude CLI's ~1h OAuth refresh writes back to the
-    snapshot itself — the snapshot is the single source of truth for
-    every agent pinned to this account.
+    file directly (no per-agent copy). The caller binds it ``:ro`` — the
+    agent reads the snapshot but never refreshes it. The snapshot is the
+    single source of truth for every agent pinned to this account, kept
+    fresh by the host-side ``sac-accounts-refresh`` timer (the sole
+    refresher under the master-host single-refresher model).
 
     Raises :class:`PinnedAccountError` when the snapshot is absent, has
     no numeric ``expiresAt``, or is already expired — NEVER falls back
@@ -134,9 +140,9 @@ def resolve_cred_file(
             f"`sac accounts sync-live`, and restart this agent."
         )
 
-    # Return the SNAPSHOT itself — the caller binds it ``:rw``, so the
-    # in-container Claude CLI's refresh writes land on this file
-    # directly. No per-agent copy, no stale-copy clobber risk, no
+    # Return the SNAPSHOT itself — the caller binds it ``:ro``. The
+    # agent reads this file directly; the host-side timer refreshes it.
+    # No per-agent copy, no stale-copy clobber risk, no
     # auth-dies-after-8h failure mode (operator task #15).
     return snapshot
 

--- a/tests/scitex_agent_container/cli_pkg/test_account_group_refresh_include_active.py
+++ b/tests/scitex_agent_container/cli_pkg/test_account_group_refresh_include_active.py
@@ -1,0 +1,177 @@
+"""Tests for ``sac accounts refresh --all --include-active``.
+
+Master-host single-refresher model (operator 2026-07-08, credential-churn
+root-cause fix): agents bind the credential ``:ro`` and NEVER refresh it,
+so the host-side ``sac-accounts-refresh`` timer becomes the SOLE refresher
+and MUST refresh the active account too — otherwise the active account's
+agents die when its access_token expires. ``--include-active`` makes that
+intent explicit and forces every stored account (active + pinned-running
+included) through the refresh, writing the fresh access_token back to each
+account's snapshot file (the file agents ``:ro``-read).
+
+``--include-active`` is mutually exclusive with ``--skip-active``.
+
+No-mocks (PA-306): real on-disk credentials + real account-store layout
+via ``$HOME`` redirection; HTTP injected at the ``urllib.request.urlopen``
+boundary.
+
+AAA marker comments; one assertion per test.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Iterator
+
+import pytest
+from click.testing import CliRunner
+
+from scitex_agent_container._state.account_store import save_account
+from scitex_agent_container.cli_pkg.account_group import account
+
+
+@pytest.fixture(autouse=True)
+def sandbox_home(tmp_path, env_save_restore):
+    """Redirect ``$HOME`` so ``Path.home()`` lands inside ``tmp_path``."""
+    home = tmp_path / "home"
+    home.mkdir()
+    env_save_restore.set("HOME", str(home))
+    return home
+
+
+def _store_dir(home: Path) -> Path:
+    return home / ".scitex" / "agent-container" / "accounts"
+
+
+def _seed_account(home: Path, name: str, *, email: str) -> Path:
+    save_account(name, {"email_address": email}, home=home)
+    creds = _store_dir(home) / name / ".credentials.json"
+    creds.write_text(
+        json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "OLD-ACCESS",
+                    "refreshToken": "the-refresh",
+                    "clientId": "cid",
+                }
+            }
+        )
+    )
+    return creds
+
+
+def _set_active_login(home: Path, *, email: str) -> None:
+    """Write ``~/.claude.json`` so the active-account email resolves."""
+    (home / ".claude.json").write_text(
+        json.dumps({"oauthAccount": {"emailAddress": email}})
+    )
+
+
+class _FakeResp:
+    def __init__(self, body: bytes):
+        self._body = body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return False
+
+    def read(self):
+        return self._body
+
+
+@pytest.fixture
+def opener_swap() -> Iterator[dict]:
+    import urllib.request
+
+    state: dict[str, Any] = {"response": {"access_token": "NEW", "expires_in": 3600}}
+    saved = urllib.request.urlopen
+
+    def fake_urlopen(req, timeout=None):
+        resp = state["response"]
+        if isinstance(resp, Exception):
+            raise resp
+        return _FakeResp(json.dumps(resp).encode())
+
+    urllib.request.urlopen = fake_urlopen  # type: ignore[assignment]
+    try:
+        yield state
+    finally:
+        urllib.request.urlopen = saved  # type: ignore[assignment]
+
+
+# ---------------------------------------------------------------------------
+# --include-active refreshes the active account (the whole point)
+# ---------------------------------------------------------------------------
+
+
+def test_include_active_rotates_active_account(sandbox_home, opener_swap) -> None:
+    # Arrange — alpha is the active login. Under the :ro model nobody
+    # else refreshes it, so the timer's --include-active run must.
+    creds_a = _seed_account(sandbox_home, "alpha", email="alpha@x.io")
+    _seed_account(sandbox_home, "beta", email="beta@x.io")
+    _set_active_login(sandbox_home, email="alpha@x.io")
+    runner = CliRunner()
+    # Act
+    runner.invoke(account, ["refresh", "--all", "--include-active"])
+    # Assert — the active account's token IS rotated (written to snapshot).
+    written = json.loads(creds_a.read_text())["claudeAiOauth"]["accessToken"]
+    assert written == "NEW"
+
+
+def test_include_active_writes_fresh_token_to_snapshot_file(
+    sandbox_home, opener_swap
+) -> None:
+    # Arrange — the snapshot file agents :ro-read must carry the fresh
+    # access_token after the refresh (this is the load-bearing invariant:
+    # the timer's refresh must update the file agents consume).
+    creds_a = _seed_account(sandbox_home, "alpha", email="alpha@x.io")
+    _set_active_login(sandbox_home, email="alpha@x.io")
+    runner = CliRunner()
+    # Act
+    runner.invoke(account, ["refresh", "--all", "--include-active"])
+    # Assert — the snapshot at the canonical account-store path was updated.
+    snapshot = _store_dir(sandbox_home) / "alpha" / ".credentials.json"
+    written = json.loads(snapshot.read_text())["claudeAiOauth"]["accessToken"]
+    assert written == "NEW"
+
+
+def test_include_active_also_rotates_idle_account(sandbox_home, opener_swap) -> None:
+    # Arrange — alpha active, beta idle; --include-active refreshes both.
+    _seed_account(sandbox_home, "alpha", email="alpha@x.io")
+    creds_b = _seed_account(sandbox_home, "beta", email="beta@x.io")
+    _set_active_login(sandbox_home, email="alpha@x.io")
+    runner = CliRunner()
+    # Act
+    runner.invoke(account, ["refresh", "--all", "--include-active"])
+    # Assert — the idle account IS refreshed too.
+    written = json.loads(creds_b.read_text())["claudeAiOauth"]["accessToken"]
+    assert written == "NEW"
+
+
+def test_include_active_reports_intent(sandbox_home, opener_swap) -> None:
+    # Arrange
+    _seed_account(sandbox_home, "alpha", email="alpha@x.io")
+    _set_active_login(sandbox_home, email="alpha@x.io")
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(account, ["refresh", "--all", "--include-active"])
+    # Assert — the operator is told the single-refresher intent.
+    text = (result.output or "") + (getattr(result, "stderr", "") or "")
+    assert "include-active" in text
+
+
+def test_include_active_conflicts_with_skip_active(sandbox_home, opener_swap) -> None:
+    # Arrange — the two flags express opposite intents; combining them is
+    # a usage error (exit 2), not a silent last-wins surprise.
+    _seed_account(sandbox_home, "alpha", email="alpha@x.io")
+    _set_active_login(sandbox_home, email="alpha@x.io")
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(
+        account, ["refresh", "--all", "--include-active", "--skip-active"]
+    )
+    # Assert — non-zero exit; the flags are mutually exclusive.
+    assert result.exit_code == 2

--- a/tests/scitex_agent_container/runtimes/test__apptainer_auth.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_auth.py
@@ -130,8 +130,9 @@ def test_oauth_argv_binds_credentials_when_present(tmp_path: Path, home_redirect
     cfg = _oauth_config(tmp_path / "wd")
     # Act
     argv = auth_argv(cfg, state_dir=tmp_path / "state")
-    # Assert — dir-bind at /tmp/sac-claude (NOT /tmp/sac-claude/.credentials.json).
-    assert any(a == f"{creds.parent}:/tmp/sac-claude:rw" for a in argv)
+    # Assert — dir-bind at /tmp/sac-claude (NOT /tmp/sac-claude/.credentials.json),
+    # READ-ONLY (master-host single-refresher model: agents never refresh).
+    assert any(a == f"{creds.parent}:/tmp/sac-claude:ro" for a in argv)
 
 
 def test_oauth_argv_does_not_emit_legacy_file_bind(tmp_path: Path, home_redirect: Path):

--- a/tests/scitex_agent_container/runtimes/test__apptainer_auth_dir_bind.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_auth_dir_bind.py
@@ -162,9 +162,12 @@ def test_pinned_bind_destination_is_directory_not_file_path(
     assert spec is not None and spec.split(":")[1] == "/tmp/sac-claude"
 
 
-def test_pinned_bind_is_rw(tmp_path: Path, home_redirect: Path) -> None:
-    # Arrange — the bind must stay :rw so refresh writeback by the
-    # in-container Claude CLI lands on the shared snapshot.
+def test_pinned_bind_is_ro(tmp_path: Path, home_redirect: Path) -> None:
+    # Arrange — master-host single-refresher model (operator 2026-07-08):
+    # the bind must be :ro so the agent NEVER refreshes/rotates the
+    # credential. The host-side sac-accounts-refresh timer is the sole
+    # refresher; the DIRECTORY bind still surfaces its atomic-replace
+    # refreshes to the container without a restart.
     now = time.time()
     _write_snapshot(home_redirect, "alpha", now + 3_600)
     cfg = _pinned_config(tmp_path / "wd", account="alpha")
@@ -172,7 +175,7 @@ def test_pinned_bind_is_rw(tmp_path: Path, home_redirect: Path) -> None:
     argv = auth_argv(cfg, state_dir=tmp_path / "state")
     spec = _extract_bind_spec_for_target_prefix(argv, "/tmp/sac-claude")
     # Assert
-    assert spec is not None and spec.split(":")[-1] == "rw"
+    assert spec is not None and spec.split(":")[-1] == "ro"
 
 
 def test_pinned_claude_config_dir_env_unchanged(

--- a/tests/scitex_agent_container/runtimes/test__apptainer_build_argv.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_build_argv.py
@@ -285,7 +285,7 @@ def test_credentials_file_bind_empty_when_unset(tui_config) -> None:
     assert flags == []
 
 
-def test_credentials_file_bind_mounts_designated_file_rw(tmp_path) -> None:
+def test_credentials_file_bind_mounts_designated_file_ro(tmp_path) -> None:
     # Arrange — a designated credentials file on disk carrying a valid,
     # unexpired OAuth token (the bind now fails loud on a stale or
     # unverifiable pinned credential — see the expiry tests below).
@@ -302,10 +302,11 @@ def test_credentials_file_bind_mounts_designated_file_rw(tmp_path) -> None:
     config = load_config(str(spec))
     # Act
     flags = credentials_file_bind(config)
-    # Assert — writable bind onto the canonical container creds path.
+    # Assert — READ-ONLY bind onto the canonical container creds path
+    # (master-host single-refresher model: the agent never refreshes).
     assert flags == [
         "--bind",
-        f"{creds}:/home/agent/.claude/.credentials.json:rw",
+        f"{creds}:/home/agent/.claude/.credentials.json:ro",
     ]
 
 
@@ -348,11 +349,12 @@ def test_credentials_file_bind_resolves_account_when_no_explicit_file(
     config = load_config(str(spec))
     # Act
     flags = credentials_file_bind(config)
-    # Assert — single-file rw bind onto the canonical container creds path,
+    # Assert — single-file :ro bind onto the canonical container creds path,
     # source = the per-host snapshot. NO copy, NO CLAUDE_CONFIG_DIR redirect.
+    # READ-ONLY: the agent reads the snapshot; the host timer refreshes it.
     assert flags == [
         "--bind",
-        f"{snap}:/home/agent/.claude/.credentials.json:rw",
+        f"{snap}:/home/agent/.claude/.credentials.json:ro",
     ]
 
 
@@ -384,10 +386,10 @@ def test_credentials_file_bind_explicit_file_wins_over_account(
     config = load_config(str(spec))
     # Act
     flags = credentials_file_bind(config)
-    # Assert — explicit file path is the source.
+    # Assert — explicit file path is the source, bound READ-ONLY.
     assert flags == [
         "--bind",
-        f"{explicit}:/home/agent/.claude/.credentials.json:rw",
+        f"{explicit}:/home/agent/.claude/.credentials.json:ro",
     ]
 
 
@@ -739,7 +741,7 @@ def test_build_run_argv_appends_credentials_bind_last(tmp_path) -> None:
     # Assert — the creds bind sits immediately before the sif path so no
     # later home bind can shadow it.
     sif_idx = argv.index("/img/sac.sif")
-    assert argv[sif_idx - 1] == f"{creds}:/home/agent/.claude/.credentials.json:rw"
+    assert argv[sif_idx - 1] == f"{creds}:/home/agent/.claude/.credentials.json:ro"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scitex_agent_container/runtimes/test__apptainer_runtime.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_runtime.py
@@ -1083,15 +1083,17 @@ def test_argv_mounts_credentials_dir_when_present(
     # Act
     argv = rt.build_run_argv(cfg, state_dir=tmp_path, sif_path=tmp_path / "x.sif")
     # Assert — bind source is the credentials file's PARENT (~/.claude/).
-    assert any(a == f"{creds.parent}:/tmp/sac-claude:rw" for a in argv)
+    assert any(a == f"{creds.parent}:/tmp/sac-claude:ro" for a in argv)
 
 
-def test_argv_credentials_bind_is_read_write(
+def test_argv_credentials_bind_is_read_only(
     tmp_path: Path, home_redirect: Path
 ) -> None:
-    # Arrange — RW lets the in-container CLI refresh the OAuth
-    # accessToken in place when it expires (~1h cadence), avoiding the
-    # manual scp-from-lead dance to re-seed expired peers.
+    # Arrange — master-host single-refresher model (operator 2026-07-08):
+    # the credential bind is READ-ONLY so the in-container CLI can never
+    # refresh/rotate the OAuth token (that consumed the single-use
+    # refresh_token = the "cred churn"). The host-side timer is the sole
+    # refresher; the DIRECTORY bind still surfaces its refreshes.
     creds = home_redirect / ".claude" / ".credentials.json"
     creds.parent.mkdir(parents=True, exist_ok=True)
     creds.write_text("{}")
@@ -1101,7 +1103,7 @@ def test_argv_credentials_bind_is_read_write(
     argv = rt.build_run_argv(cfg, state_dir=tmp_path, sif_path=tmp_path / "x.sif")
     creds_arg = next(a for a in argv if ":/tmp/sac-claude:" in a)
     # Assert
-    assert ":ro" not in creds_arg
+    assert creds_arg.endswith(":ro")
 
 
 def test_argv_sets_claude_config_dir_when_credentials_present(
@@ -1180,9 +1182,9 @@ def test_argv_pins_account_binds_snapshot_directory_not_host_file(
     # atomic-replace writers in creds_sync / account_store /
     # claude_usage, regressing into the per-copy collision-401 disease
     # the snapshot model was meant to fix). The bound dir's child
-    # ``.credentials.json`` remains the snapshot itself; refresh
-    # writeback by the in-container CLI lands in the same on-disk file
-    # every same-account agent reads from.
+    # ``.credentials.json`` remains the snapshot itself, bound :ro; the
+    # host-side sac-accounts-refresh timer refreshes it and every
+    # same-account agent reads the timer-kept-fresh token.
     host_creds = home_redirect / ".claude" / ".credentials.json"
     host_creds.parent.mkdir(parents=True, exist_ok=True)
     host_creds.write_text('{"host": true}')
@@ -1196,7 +1198,7 @@ def test_argv_pins_account_binds_snapshot_directory_not_host_file(
     creds_arg = next(
         a
         for a in argv
-        if a.startswith(str(snap.parent) + ":") and a.endswith(":/tmp/sac-claude:rw")
+        if a.startswith(str(snap.parent) + ":") and a.endswith(":/tmp/sac-claude:ro")
     )
     # Assert — the bound host-side source IS the account directory
     # (snapshot.parent), neither the snapshot file alone, a per-agent
@@ -1223,7 +1225,7 @@ def test_argv_pins_account_does_not_create_state_dir_copy(
     rt.build_run_argv(cfg, state_dir=state_dir, sif_path=tmp_path / "x.sif")
     legacy_copy = state_dir / "claude" / ".credentials.json"
     # Assert — no per-agent copy materialised; the snapshot is the
-    # only place the in-container CLI's :rw refresh writeback lands.
+    # single source the :ro agents read and the host timer refreshes.
     assert not legacy_copy.exists()
 
 
@@ -1243,7 +1245,7 @@ def test_argv_no_account_dir_binds_host_claude(
     argv = rt.build_run_argv(cfg, state_dir=tmp_path, sif_path=tmp_path / "x.sif")
     # Assert — bind source is the credentials file's PARENT (~/.claude/);
     # bind dest is the DIRECTORY /tmp/sac-claude, not the file inside it.
-    assert any(a == f"{host_creds.parent}:/tmp/sac-claude:rw" for a in argv)
+    assert any(a == f"{host_creds.parent}:/tmp/sac-claude:ro" for a in argv)
 
 
 def test_argv_pinned_account_missing_snapshot_raises_pinned_account_error(


### PR DESCRIPTION
## What & why

Operator-designed credential-hardening change on the credential path every
agent depends on. **This is the code + unit tests only — the fleet canary,
the `:ro` flip restart, and the bootstrap re-login are the coordinator's, not
this PR's.**

### Root cause (credential "churn")
Agents bound the host credential file `:rw`, so the in-container `claude`
refreshed it and **consumed the single-use OAuth `refresh_token`**. The
instant an operator logged a fresh account in, a running agent ate its
`refresh_token`, invalidating it fleet-wide.

### The operator-designed model
- **Agents become READ-ONLY consumers** — they can't rotate anything.
- **The existing host-side `sac-accounts-refresh` timer is the SOLE
  refresher**, and now refreshes the *active* account too (nobody else does
  anymore).

## Change 1 — flip every agent-facing credential bind `:rw` → `:ro`
Both agent-facing credential binds live in `runtimes/_apptainer_auth.py`:

| function | bind | before | after |
|---|---|---|---|
| `auth_argv` | `<cred-dir>:/tmp/sac-claude` (CLAUDE_CONFIG_DIR dir bind; unpinned host-live + account-pinned SDK path) | `:rw` | `:ro` |
| `credentials_file_bind` | `<src>:$HOME/.claude/.credentials.json` (designated `credentials_file:` + account-pinned TUI) | `:rw` | `:ro` |

Docstrings in `_apptainer_auth.py` and `_apptainer_creds.py` updated to the
new model. The **fail-loud expiry checks are unchanged** — a `:ro` agent
bound to an already-expired token still refuses to launch.

Searched the whole `runtimes/` package + `src/`: these two are the **only**
agent-facing credential `:rw` binds. Unrelated `:rw` binds (workdir, state,
overlay-home) were left untouched.

## Change 2 — refresh timer must refresh ALL accounts incl. active
Added an explicit, self-documenting `--include-active` flag
(`cli_pkg/_account_refresh.py`): with `--all`, refresh EVERY stored account
including the active + pinned-running ones (skip nothing). Mutually exclusive
with `--skip-active` (usage error, exit 2). The existing `--skip-active`
default is untouched. The systemd timer's `ExecStart` should move to
`sac accounts refresh --all --include-active` (host-side, coordinator's).

Verified snapshot write-back: `refresh_account_credentials` →
`_refresh_access_token_at` atomically `tmp + rename`s the fresh `access_token`
(and rotated `refresh_token` + `expiresAt`) onto the SAME per-account snapshot
file agents `:ro`-read. Tests assert this explicitly.

## Tests
- Flipped every `:rw` assertion to `:ro` across `test__apptainer_auth.py`,
  `test__apptainer_auth_dir_bind.py` (`test_pinned_bind_is_rw` → `_is_ro`),
  `test__apptainer_build_argv.py` (`..._file_rw` → `..._file_ro`),
  `test__apptainer_runtime.py` (`..._is_read_write` → `..._is_read_only`).
- New `test_account_group_refresh_include_active.py`: `--include-active`
  refreshes the active account, writes the fresh token to the snapshot file,
  also refreshes idle accounts, reports intent, conflicts with
  `--skip-active` (exit 2).
- All existing tests kept green.

## Bootstrap caveat (operational — NOT in this PR)
After this lands the 3 stored accounts have **dead `refresh_token`s**
(already churned). Coordinator rollout order: deploy code → flip agents `:ro`
(restart) → operator does ONE `claude /login` per account to seed fresh
`refresh_token`s → agents now `:ro`, nothing churns them, the
`--include-active` timer maintains them forever.

## Honest uncertainties
- **`auth_argv` is a DIRECTORY bind, not a pure file bind.** It binds the
  whole `CLAUDE_CONFIG_DIR` (`/tmp/sac-claude`). `:ro` stops credential
  refresh (intended) but also makes the entire config dir read-only. Session/
  projects state lives under `$HOME/.claude/projects/` (separate writable
  location), so this *should* be fine — but the **canary must confirm
  `claude -p` tolerates a read-only `CLAUDE_CONFIG_DIR`**. If not, the
  fallback is a targeted per-file `:ro` bind, which reintroduces the
  atomic-rename inode-orphan bug the dir bind was created to fix; `:ro`-dir is
  preferred if `claude` tolerates it.
- The **TUI auth path** (`_tui_auth_stage.py`) COPIES the snapshot into the
  container `$HOME` (no bind), so there was no `:rw` bind to flip. An
  in-container TUI `claude` can still refresh its COPY and consume the shared
  `refresh_token` — a separate churn vector not addressed here; flag for
  follow-up if TUI agents are in scope.

## Audit note
`tests/develop/test_audit.py` gate: the `scitex-dev ecosystem audit-all`
subprocess **times out at the gate's 120s limit on this host** (the tool
takes ~2min). Run directly with no timeout it completes and reports only
**pre-existing** issues unrelated to this change (an `audit-cli
not-auditable: unknown`, and a `PS-103` stray `--fakeroot` junk file at the
repo root created by an apptainer arg-guard scenario). No new violation is
introduced by this PR; the new test file follows the existing
`test_account_group_refresh_*` naming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
