### PR TITLE
feat(cli): sac agents restart accepts multiple names + --all

### DIFF
--- a/src/scitex_agent_container/cli_pkg/lifecycle/_restart.py
+++ b/src/scitex_agent_container/cli_pkg/lifecycle/_restart.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""``sac agents restart`` — node-aware stop-then-start of a single agent.
+"""``sac agents restart`` — node-aware stop-then-start of agent(s).
+
+Accepts ONE OR MORE agent names (mirroring ``sac agents start``) plus an
+``--all`` flag that restarts every agent ``sac agents list`` shows. Each
+name is restarted independently: one agent failing does not abort the
+rest, and the command exits non-zero if ANY restart failed.
 
 Cross-host dispatch: when an agent's active ``state.db.instances`` row
 records ``host != current_host``, ``restart`` ssh's into that peer and
@@ -151,8 +156,152 @@ def _bypass_base_url_available() -> bool:
     return True
 
 
+def _enumerate_fleet() -> list[str]:
+    """Return every agent name ``sac agents list`` shows (the ``--all`` set).
+
+    Reuses the SAME data function the ``list`` command uses
+    (:func:`cli_pkg._helpers.get_agent_list_data`) so ``--all`` is exactly
+    "everything ``sac agents list`` shows" — registered/running agents plus
+    on-disk-defined ones — with no separate enumeration path to drift.
+    Order-preserving de-dup by name.
+    """
+    from .._helpers import get_agent_list_data
+    from ..._state.registry import Registry
+
+    seen: set[str] = set()
+    names: list[str] = []
+    for row in get_agent_list_data(Registry()):
+        name = row.get("name")
+        if name and name not in seen:
+            seen.add(name)
+            names.append(name)
+    return names
+
+
+def _restart_one(name: str, *, as_json: bool, fresh: bool) -> tuple[dict, bool]:
+    """Restart ONE agent; return ``(json_envelope, ok)``.
+
+    Preserves every single-name path — cross-host ssh dispatch, the
+    ``--fresh`` host-bypass, and the local→host-listen fallback. Human
+    console output is printed here when ``not as_json`` (byte-for-byte the
+    historical single-name output); JSON emission is left to the CALLER so
+    it can choose a bare object (single name) vs an array (batch / --all).
+    Never raises for an ordinary restart fault and never calls ``sys.exit``
+    — the caller aggregates the batch exit code.
+    """
+    if fresh:
+        # Fresh restart is the in-container recovery path: broker
+        # ``start --force --fresh`` to the host listen. On a bare host there is
+        # no listen to broker to, so fail loud with the direct command rather
+        # than silently doing a resuming restart (which would re-wedge).
+        if not _bypass_base_url_available():
+            msg = (
+                f"--fresh restart requires the host bypass (run inside a "
+                f"container). On a bare host run: sac agents start {name} "
+                f"--force --fresh"
+            )
+            if not as_json:
+                click.echo(msg, err=True)
+            return {"name": name, "error": msg, "fresh": True}, False
+        envelope = _restart_via_host_bypass(name, fresh=True)
+        out = {
+            "name": name,
+            "restarted": envelope.get("returncode") == 0,
+            "dispatched": False,
+            "via": "host-listen",
+            "fresh": True,
+            "host_response": envelope,
+        }
+        if not as_json:
+            console.print(
+                f"[green]Agent '{name}' fresh-restarted via host listen[/green]"
+            )
+        return out, bool(out["restarted"])
+    # stx-allow: fallback (reason: config resolution, cross-host ssh dispatch, or
+    # agent_restart can raise if the agent is not running or the session cannot be
+    # found; an error envelope is cleaner than an unhandled traceback)
+    try:
+        if "/" in name or name.endswith((".yaml", ".yml")):
+            config_path = resolve_with_prefix(name)
+            config = load_config(config_path)
+            name = config.name
+
+        # Cross-host: dispatch to the peer holding the agent's active row.
+        peers = _load_host_config().peers
+        envelope_holder: dict = {}
+
+        def _handler(peer, row, ps, _name=name, _holder=envelope_holder):
+            _holder.update(_dispatch_remote_restart(peer, row, ps, _name))
+            _holder["_peer"] = peer
+
+        dispatched = try_dispatch_remote(name, "restart", peers, handler=_handler)
+        if dispatched:
+            out = {
+                "name": name,
+                "restarted": True,
+                "host": envelope_holder.get("_peer"),
+                "a2a_port": envelope_holder.get("a2a_port"),
+                "dispatched": True,
+            }
+            if not as_json:
+                console.print(
+                    f"[green]Agent '{name}' restarted on "
+                    f"'{envelope_holder.get('_peer')}'[/green]"
+                )
+            return out, True
+
+        # Local restart (row on this host, or no row — spec fallback).
+        # When that LOCAL resolution fails (no registry row AND no
+        # resolvable spec) AND we are inside a container with the host
+        # listen reachable (SAC_LISTEN_BASE_URL injected), broker the
+        # restart to the HOST listen — exactly like the spawn bypass.
+        try:
+            agent_restart(name)
+        except RuntimeError as exc:
+            if not _should_try_host_bypass(exc):
+                raise
+            envelope = _restart_via_host_bypass(name)
+            out = {
+                "name": name,
+                "restarted": envelope.get("returncode") == 0,
+                "dispatched": False,
+                "via": "host-listen",
+                "host_response": envelope,
+            }
+            if not as_json:
+                console.print(
+                    f"[green]Agent '{name}' restarted via host listen[/green]"
+                )
+                console.print(_json.dumps(envelope))
+            return out, bool(out["restarted"])
+        out = {"name": name, "restarted": True, "dispatched": False}
+        if not as_json:
+            console.print(f"[green]Agent '{name}' restarted[/green]")
+        return out, True
+    except Exception as exc:  # stx-allow: fallback (reason: catch-all safety net — see inline comment for context)
+        if not as_json:
+            console.print(f"[red]Error: {exc}[/red]")
+        return {"name": name, "error": str(exc)}, False
+
+
 @click.command()
-@click.argument("name", shell_complete=agent_name_complete)
+@click.argument(
+    "names",
+    metavar="NAME...",
+    nargs=-1,
+    required=False,
+    shell_complete=agent_name_complete,
+)
+@click.option(
+    "--all",
+    "all_agents",
+    is_flag=True,
+    default=False,
+    help=(
+        "Restart EVERY agent 'sac agents list' shows. Mutually exclusive "
+        "with explicit NAME arguments. Still requires -y/--yes."
+    ),
+)
 @click.option(
     "--dry-run",
     "dry_run",
@@ -192,140 +341,86 @@ def _bypass_base_url_available() -> bool:
     ),
 )
 def restart(
-    name: str, dry_run: bool, yes: bool, as_json: bool, fresh: bool
+    names: tuple[str, ...],
+    all_agents: bool,
+    dry_run: bool,
+    yes: bool,
+    as_json: bool,
+    fresh: bool,
 ) -> None:
-    """Restart an agent.
+    """Restart one or more agents.
 
-    Resolves the agent's recorded host first: a row on a remote peer is
-    restarted over ssh on that peer (node-aware); otherwise the restart
-    runs locally.
+    Pass one or more NAMEs, or ``--all`` to restart every agent
+    ``sac agents list`` shows. For each name, the agent's recorded host is
+    resolved first: a row on a remote peer is restarted over ssh on that
+    peer (node-aware); otherwise the restart runs locally. Agents are
+    restarted independently — one failing does not abort the rest, and the
+    command exits non-zero if ANY restart failed.
 
     \b
     Example:
-      $ sac agent restart foo
-      $ sac agent restart foo --dry-run
-      $ sac agent restart foo --json
+      $ sac agents restart foo -y
+      $ sac agents restart foo bar baz -y     # several in one call
+      $ sac agents restart --all -y           # every registered agent
+      $ sac agents restart foo --dry-run
+      $ sac agents restart foo --json
     """
+    if all_agents and names:
+        raise click.UsageError(
+            "--all cannot be combined with explicit agent NAME arguments."
+        )
+
+    if all_agents:
+        targets = _enumerate_fleet()
+        if not targets:
+            if as_json:
+                click.echo(_json.dumps([]))
+            else:
+                console.print("[dim]No agents found to restart.[/dim]")
+            return
+    else:
+        targets = list(names)
+
+    if not targets:
+        raise click.UsageError(
+            "Missing argument 'NAME...'. Pass one or more agent names, or --all."
+        )
+
     if dry_run:
-        click.echo(f"[dry-run] would restart agent '{name}'")
+        for name in targets:
+            click.echo(f"[dry-run] would restart agent '{name}'")
         return
+
     if not yes:
-        click.echo(f"Refusing to restart agent '{name}' without --yes/-y.", err=True)
-        raise SystemExit(2)
-    if fresh:
-        # Fresh restart is the in-container recovery path: broker
-        # ``start --force --fresh`` to the host listen. On a bare host there is
-        # no listen to broker to, so fail loud with the direct command rather
-        # than silently doing a resuming restart (which would re-wedge).
-        if not _bypass_base_url_available():
+        if len(targets) == 1:
             click.echo(
-                f"--fresh restart requires the host bypass (run inside a "
-                f"container). On a bare host run: sac agents start {name} "
-                f"--force --fresh",
+                f"Refusing to restart agent '{targets[0]}' without --yes/-y.",
                 err=True,
             )
-            raise SystemExit(1)
-        envelope = _restart_via_host_bypass(name, fresh=True)
-        if as_json:
+        else:
             click.echo(
-                _json.dumps(
-                    {
-                        "name": name,
-                        "restarted": envelope.get("returncode") == 0,
-                        "dispatched": False,
-                        "via": "host-listen",
-                        "fresh": True,
-                        "host_response": envelope,
-                    }
-                )
+                f"Refusing to restart {len(targets)} agents without --yes/-y.",
+                err=True,
             )
+        raise SystemExit(2)
+
+    results: list[dict] = []
+    any_failed = False
+    for name in targets:
+        envelope, ok = _restart_one(name, as_json=as_json, fresh=fresh)
+        results.append(envelope)
+        if not ok:
+            any_failed = True
+
+    if as_json:
+        # Backward-compat: a SINGLE explicit name emits a bare object;
+        # multiple names or --all emit a JSON array of per-agent envelopes.
+        if len(results) == 1 and not all_agents:
+            click.echo(_json.dumps(results[0]))
         else:
-            console.print(
-                f"[green]Agent '{name}' fresh-restarted via host listen[/green]"
-            )
-        return
-    # stx-allow: fallback (reason: config resolution, cross-host ssh dispatch, or
-    # agent_restart can raise if the agent is not running or the session cannot be
-    # found; an error message + sys.exit(1) is cleaner than an unhandled traceback)
-    try:
-        if "/" in name or name.endswith((".yaml", ".yml")):
-            config_path = resolve_with_prefix(name)
-            config = load_config(config_path)
-            name = config.name
+            click.echo(_json.dumps(results))
 
-        # Cross-host: dispatch to the peer holding the agent's active row.
-        peers = _load_host_config().peers
-        envelope_holder: dict = {}
-
-        def _handler(peer, row, ps, _name=name, _holder=envelope_holder):
-            _holder.update(_dispatch_remote_restart(peer, row, ps, _name))
-            _holder["_peer"] = peer
-
-        dispatched = try_dispatch_remote(name, "restart", peers, handler=_handler)
-        if dispatched:
-            if as_json:
-                click.echo(
-                    _json.dumps(
-                        {
-                            "name": name,
-                            "restarted": True,
-                            "host": envelope_holder.get("_peer"),
-                            "a2a_port": envelope_holder.get("a2a_port"),
-                            "dispatched": True,
-                        }
-                    )
-                )
-            else:
-                console.print(
-                    f"[green]Agent '{name}' restarted on "
-                    f"'{envelope_holder.get('_peer')}'[/green]"
-                )
-            return
-
-        # Local restart (row on this host, or no row — spec fallback).
-        # When that LOCAL resolution fails (no registry row AND no
-        # resolvable spec) AND we are inside a container with the host
-        # listen reachable (SAC_LISTEN_BASE_URL injected), broker the
-        # restart to the HOST listen — exactly like the spawn bypass.
-        # This is what lets an in-SIF agent restart a peer whose registry
-        # row lives on the bare host (it is unresolvable from inside the
-        # container). The bare-host operator keeps the local path (the row
-        # IS resolvable there, so the bypass never fires).
-        try:
-            agent_restart(name)
-        except RuntimeError as exc:
-            if not _should_try_host_bypass(exc):
-                raise
-            envelope = _restart_via_host_bypass(name)
-            if as_json:
-                click.echo(
-                    _json.dumps(
-                        {
-                            "name": name,
-                            "restarted": envelope.get("returncode") == 0,
-                            "dispatched": False,
-                            "via": "host-listen",
-                            "host_response": envelope,
-                        }
-                    )
-                )
-            else:
-                console.print(
-                    f"[green]Agent '{name}' restarted via host listen[/green]"
-                )
-                console.print(_json.dumps(envelope))
-            return
-        if as_json:
-            click.echo(
-                _json.dumps({"name": name, "restarted": True, "dispatched": False})
-            )
-        else:
-            console.print(f"[green]Agent '{name}' restarted[/green]")
-    except Exception as exc:  # stx-allow: fallback (reason: catch-all safety net — see inline comment for context)
-        if as_json:
-            click.echo(_json.dumps({"name": name, "error": str(exc)}))
-        else:
-            console.print(f"[red]Error: {exc}[/red]")
+    if any_failed:
         sys.exit(1)
 
 

--- a/tests/scitex_agent_container/cli_pkg/lifecycle/test__restart.py
+++ b/tests/scitex_agent_container/cli_pkg/lifecycle/test__restart.py
@@ -615,3 +615,177 @@ def test_fresh_does_not_call_local_agent_restart():
         runner.invoke(restart, ["alpha", "-y", "--fresh"])
     # Assert
     assert called == []
+
+
+# ---------------------------------------------------------------------------
+# Variadic NAME... + --all (operator TODO 2026-07-04): restart accepts
+# multiple names in one call and an --all flag that enumerates the same
+# fleet ``sac agents list`` shows. The per-agent restart is exercised via
+# ``_restart_one``; the loop-level behaviour (fan-out, mutual exclusion,
+# fail-loud aggregate, JSON aggregation) is asserted by swapping that seam.
+# ---------------------------------------------------------------------------
+
+
+def _ok_restart_one(name, *, as_json, fresh):
+    """Recorder stand-in for ``_restart_one`` — always succeeds."""
+    return {"name": name, "restarted": True, "dispatched": False}, True
+
+
+def test_multiple_names_exit_zero():
+    # Arrange
+    runner = CliRunner()
+    # Act
+    with _swap("_restart_one", _ok_restart_one):
+        result = runner.invoke(restart, ["alpha", "beta", "-y"])
+    # Assert
+    assert result.exit_code == 0, result.output
+
+
+def test_multiple_names_restart_each_once():
+    # Arrange
+    seen: list[str] = []
+
+    def _rec(name, *, as_json, fresh):
+        seen.append(name)
+        return {"name": name, "restarted": True}, True
+
+    runner = CliRunner()
+    # Act
+    with _swap("_restart_one", _rec):
+        runner.invoke(restart, ["alpha", "beta", "-y"])
+    # Assert — each name restarted exactly once, in order.
+    assert seen == ["alpha", "beta"]
+
+
+def test_multiple_names_json_emits_array():
+    import json as _json
+
+    # Arrange
+    runner = CliRunner()
+    # Act
+    with _swap("_restart_one", _ok_restart_one):
+        result = runner.invoke(restart, ["alpha", "beta", "-y", "--json"])
+    payload = _json.loads(result.output.strip().splitlines()[-1])
+    # Assert — multiple names aggregate into a JSON array.
+    assert isinstance(payload, list) and len(payload) == 2
+
+
+def test_all_flag_restarts_every_enumerated_agent():
+    # Arrange
+    seen: list[str] = []
+
+    def _rec(name, *, as_json, fresh):
+        seen.append(name)
+        return {"name": name, "restarted": True}, True
+
+    runner = CliRunner()
+    # Act
+    with (
+        _swap("_enumerate_fleet", lambda: ["a1", "a2", "a3"]),
+        _swap("_restart_one", _rec),
+    ):
+        result = runner.invoke(restart, ["--all", "-y"])
+    # Assert — every enumerated agent restarted.
+    assert result.exit_code == 0 and seen == ["a1", "a2", "a3"]
+
+
+def test_all_flag_json_emits_array():
+    import json as _json
+
+    # Arrange
+    runner = CliRunner()
+    # Act
+    with (
+        _swap("_enumerate_fleet", lambda: ["only-one"]),
+        _swap("_restart_one", _ok_restart_one),
+    ):
+        result = runner.invoke(restart, ["--all", "-y", "--json"])
+    payload = _json.loads(result.output.strip().splitlines()[-1])
+    # Assert — --all always emits an array, even for a single enumerated agent.
+    assert isinstance(payload, list) and len(payload) == 1
+
+
+def test_all_with_explicit_names_is_usage_error():
+    # Arrange
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(restart, ["--all", "alpha", "-y"])
+    # Assert — --all and explicit NAMEs are mutually exclusive (exit 2).
+    assert result.exit_code == 2 and "cannot be combined" in result.output
+
+
+def test_all_without_yes_refuses_exit_two():
+    # Arrange
+    runner = CliRunner()
+    # Act
+    with _swap("_enumerate_fleet", lambda: ["a1", "a2"]):
+        result = runner.invoke(restart, ["--all"])
+    # Assert — a batch restart still requires -y/--yes.
+    assert result.exit_code == 2 and "Refusing to restart" in result.output
+
+
+def test_no_names_and_no_all_is_usage_error():
+    # Arrange
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(restart, ["-y"])
+    # Assert — nothing to restart is a usage error.
+    assert result.exit_code == 2
+
+
+def test_one_failure_still_attempts_rest():
+    # Arrange
+    seen: list[str] = []
+
+    def _rec(name, *, as_json, fresh):
+        seen.append(name)
+        if name == "bad":
+            return {"name": name, "error": "boom"}, False
+        return {"name": name, "restarted": True}, True
+
+    runner = CliRunner()
+    # Act
+    with _swap("_restart_one", _rec):
+        runner.invoke(restart, ["ok1", "bad", "ok2", "-y"])
+    # Assert — a mid-batch failure does not abort the remaining agents.
+    assert seen == ["ok1", "bad", "ok2"]
+
+
+def test_one_failure_exits_nonzero():
+    # Arrange
+    def _rec(name, *, as_json, fresh):
+        if name == "bad":
+            return {"name": name, "error": "boom"}, False
+        return {"name": name, "restarted": True}, True
+
+    runner = CliRunner()
+    # Act
+    with _swap("_restart_one", _rec):
+        result = runner.invoke(restart, ["ok1", "bad", "-y"])
+    # Assert — any failure surfaces as an overall non-zero exit.
+    assert result.exit_code == 1
+
+
+def test_dry_run_multiple_names_lists_each():
+    # Arrange
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(restart, ["alpha", "beta", "--dry-run"])
+    # Assert — dry-run announces every target and invokes no restart.
+    assert (
+        "would restart agent 'alpha'" in result.output
+        and "would restart agent 'beta'" in result.output
+    )
+
+
+def test_single_name_json_stays_bare_object():
+    import json as _json
+
+    # Arrange — single explicit name must keep the historical bare-object shape.
+    runner = CliRunner()
+    # Act
+    with _swap("agent_restart", lambda _name: None):
+        result = runner.invoke(restart, ["alpha", "-y", "--json"])
+    payload = _json.loads(result.output.strip().splitlines()[-1])
+    # Assert
+    assert isinstance(payload, dict) and payload.get("name") == "alpha"


### PR DESCRIPTION
## What & why

Operator request (Telegram, 2026-07-04): make `sac agents restart` accept multiple names and add `--all`. Previously it took a single `NAME` and errored on a second arg:

```
$ sac agents restart scitex-todo scitex-agent-container
Error: Got unexpected extra argument (scitex-agent-container)
```

`sac agents start` was already variadic; this brings `restart` to the same idiom.

## New usage

```
$ sac agents restart foo -y                 # single (unchanged)
$ sac agents restart foo bar baz -y          # several in one call
$ sac agents restart --all -y                # every agent `sac agents list` shows
```

## What changed

- **`_restart.py`**: refactored the whole single-name body into `_restart_one(name) -> (envelope, ok)`, preserving every existing path — cross-host ssh dispatch (`_dispatch_remote_restart` / `try_dispatch_remote`), the `--fresh` host-bypass, the `_should_try_host_bypass` local→host-listen fallback, `--dry-run`, `--json`, and the `-y/--yes` guard. The command now resolves a target list (explicit `NAME...` or `--all`) and loops the helper over it.
- **`--all`** enumerates the fleet via `_enumerate_fleet()`, which reuses the exact data function `sac agents list` uses (`cli_pkg._helpers.get_agent_list_data`) — no new enumeration path.
- **Fail-loud aggregate**: one agent failing does not abort the rest; the command exits non-zero if ANY restart failed.
- **`--json`**: a single explicit name keeps the historical bare-object shape; multiple names / `--all` emit a JSON array of per-agent envelopes.
- **Mutual exclusion**: `--all` + explicit `NAME`s → `UsageError` (exit 2). `-y/--yes` still required for the batch.
- Docstring, help text, and the `NAME...` metavar updated.

The MCP `agent_restart` tool is intentionally left single-name (it is a distinct per-agent Python API, not the variadic CLI). No skills docs referenced `restart NAME`.

## Tests

Added to `tests/scitex_agent_container/cli_pkg/lifecycle/test__restart.py` (mirroring the existing `_swap`-seam style, no `unittest.mock`):

- two explicit names → each restarted once, in order
- `--all` → enumerated fleet each restarted; `--all` JSON emits an array
- `--all` + explicit names → UsageError; `--all` without `-y` refuses (exit 2)
- no names + no `--all` → UsageError
- one mid-batch failure → remaining agents still attempted AND overall non-zero exit
- single-name `--json` output shape unchanged (bare object)
- multi-name `--json` emits an array; multi dry-run lists each

`test__restart.py`: **43 passed**. Full lifecycle suite: **380 passed** (no regressions).
