### PR TITLE
fix(listen): in-SIF restart/spawn broker passes --yes to host-side launch

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_stop.py
+++ b/src/scitex_agent_container/_lifecycle/_stop.py
@@ -360,9 +360,26 @@ def agent_restart(
     from ._session_reset import _clear_persisted_session_id
 
     _clear_persisted_session_id(name)
+    # ``assume_yes=True`` — a restart is an ALREADY-authorized action: the
+    # ``sac agents restart`` CLI refuses without ``-y`` (see
+    # ``cli_pkg/lifecycle/_restart.py``) and the MCP / public-API restart
+    # paths carry the same intent, so consent is given by the time control
+    # reaches here. It must be threaded into the start leg because, when
+    # this runs INSIDE an apptainer SIF, ``agent_start`` brokers the start
+    # to the host's ``sac listen`` ``POST /agents`` handler, which shells a
+    # FRESH ``sac agents start <name>`` subprocess that re-runs the SAME
+    # interactive refuse-without-``--yes`` gate
+    # (``cli_pkg/lifecycle/_start_single.py::should_preview_and_require_yes``).
+    # Without this, an in-SIF restart brokered through ``/agents`` refused
+    # itself with "refusing to start <name> without --yes/-y" → HTTP 502,
+    # even though the restart was explicitly authorized (repro 2026-07-09).
+    # This does NOT weaken the human-at-a-TTY guard: a bare ``sac agents
+    # start``/``restart`` with no consent still refuses — only the
+    # pre-authorized restart's own start leg asserts the consent already given.
     return agent_start(
         config_path,
         registry,
+        assume_yes=True,
         runtime_factory=runtime_factory,
         sleep_fn=sleep_fn,
         handover_mod=handover_mod,

--- a/tests/scitex_agent_container/_lifecycle/test_lifecycle.py
+++ b/tests/scitex_agent_container/_lifecycle/test_lifecycle.py
@@ -1417,6 +1417,60 @@ def test_agent_restart_no_row_uses_default_resolver_discovery_chain(
     assert ok is True and len(runtime.start_calls) == 1
 
 
+def test_agent_restart_passes_assume_yes_to_start_leg(
+    tmp_path: Path, registry: Registry
+) -> None:
+    """A restart's inner ``agent_start`` MUST carry ``assume_yes=True``.
+
+    Regression guard for the in-SIF broker 502 reproduced 2026-07-09: a
+    ``sac agents restart <name>`` run inside an apptainer SIF reaches the
+    LOCAL ``agent_restart`` → ``agent_start`` path; ``agent_start`` then
+    brokers the start to the host's ``sac listen`` ``POST /agents``
+    handler, which shells a FRESH ``sac agents start <name>`` subprocess.
+    That subprocess re-runs the interactive refuse-without-``--yes`` gate,
+    so unless the ORIGINAL restart's consent is threaded through as
+    ``assume_yes`` the host refused itself with "refusing to start <name>
+    without --yes/-y" → HTTP 502 — even though the restart was explicitly
+    authorized. The host-side ``assume_yes`` → ``--yes`` argv plumbing is
+    proven in ``test__agent_exec_subprocess.py``; this pins the missing
+    link: ``agent_restart`` actually SETS ``assume_yes=True``.
+
+    Real seam (no MagicMock): the ``_start.agent_start`` module attribute
+    is swapped for a capture callable and restored in ``finally`` — the
+    same save/restore-a-real-callable pattern the
+    ``test_fire_forget_hook_swallows_run_hook_exceptions`` test uses.
+    """
+    # Arrange — a real on-disk spec so the pre-start stop/settle legs run
+    # against a real FakeRuntime, then capture the kwargs the (swapped)
+    # start leg receives.
+    spec = _write_spec(tmp_path)
+    from scitex_agent_container._lifecycle import _start as _start_mod
+
+    captured: dict[str, Any] = {}
+    original_start = _start_mod.agent_start
+
+    def _capture_start(config_path: str, registry: Any = None, **kwargs: Any) -> bool:
+        captured["config_path"] = config_path
+        captured.update(kwargs)
+        return True
+
+    _start_mod.agent_start = _capture_start  # real callable, not Mock
+    try:
+        # Act
+        lc.agent_restart(
+            "alpha",
+            registry=registry,
+            runtime_factory=lambda _c: FakeRuntime(start_result=True),
+            sleep_fn=_no_sleep,
+            handover_mod=FakeHandover(),
+            config_resolver=lambda _name: str(spec),
+        )
+    finally:
+        _start_mod.agent_start = original_start
+    # Assert — the restart's start leg asserted the already-given consent.
+    assert captured.get("assume_yes") is True, captured
+
+
 class _StaggeredRuntime(FakeRuntime):
     """Real fake whose ``is_running`` returns the next bool from a stage list.
 


### PR DESCRIPTION
## Reproduced 502 (from inside a container)

```
WARN: spawn_client: POST http://127.0.0.1:7878/agents returned HTTP 502
  body={'name':'scitex-todo','returncode':1, ...
        'stderr':'WARN: refusing to start scitex-todo without --yes/-y — ...
                  re-run with --yes to launch.'}
Error: spawn of 'scitex-todo' rejected: listen returned HTTP 502 (...)
```

Meanwhile `sac agents restart scitex-todo --yes` run DIRECTLY on the host works (exit 0).

## Root cause

An in-container `sac agents restart <name>` reaches the **LOCAL** `agent_restart` → `agent_start` path (`_restart_one` in `cli_pkg/lifecycle/_restart.py` calls `agent_restart(name)`; the `/agents/<name>/restart` bypass only fires on a "not found in registry" miss). When running inside an apptainer SIF, `agent_start` brokers the start to the host `sac listen` **`POST /agents`** handler (hence the 502 came from `/agents`, not `/agents/<name>/restart`). That handler shells a **fresh** `sac agents start <name>` subprocess which re-runs the interactive refuse-without-`--yes` gate (`cli_pkg/lifecycle/_start_single.py::should_preview_and_require_yes`).

`agent_restart` (`_lifecycle/_stop.py`) called `agent_start` **without** `assume_yes=True`, so the broker POST body carried no consent and the host's already-present `assume_yes`→`--yes` argv (+ `SAC_ASSUME_YES=1` env) plumbing never fired → the host refused itself → 502.

The `/agents/<name>/restart` server handler already always passes `--yes` (`_listen/_agent_restart.py`), and the `/agents` spawn handler already appends `--yes` when the body carries `assume_yes: true` (`_listen/_agent_exec.py`, tested in `test__agent_exec_subprocess.py`). The **only** missing link was `agent_restart` not setting `assume_yes=True` on its internal start leg.

## What changed

- `src/scitex_agent_container/_lifecycle/_stop.py` — `agent_restart` now calls `agent_start(..., assume_yes=True, ...)`. A restart is an already-authorized action: the `sac agents restart` CLI refuses without `-y`, and the MCP / public-API restart paths carry the same intent, so by the time control reaches `agent_restart` consent is given.

## Safety

The interactive human guard is unchanged: a bare `sac agents start` / `sac agents restart` with no `-y` still refuses. The server-side ACL gate (`check_spawn` for `/agents`, `check_lineage_acl` for `/agents/<name>/restart`) runs BEFORE the inner argv is built, so consent only skips the redundant interactive confirmation — it never bypasses authorization. Fail-loud is preserved: a genuine host-side failure still surfaces as 502 with the host stderr.

## Test coverage

- New: `test_agent_restart_passes_assume_yes_to_start_leg` (`tests/.../_lifecycle/test_lifecycle.py`) — pins that `agent_restart`'s inner `agent_start` receives `assume_yes=True`, using a real save/restore seam on `_start.agent_start` (no MagicMock).
- The host-side `assume_yes`→`--yes` argv + `SAC_ASSUME_YES=1` env plumbing is already covered by `test__agent_exec_subprocess.py`.
- Full run: **213 passed** across `test_lifecycle.py`, `test__agent_exec_subprocess.py`, `test__in_sif_broker.py`, `test__spawn_client.py`, `test__restart_client.py`, `cli_pkg/lifecycle/test__restart.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
