### PR TITLE
fix(lifecycle): pre-stop rescue never commits on develop/main (route to rescue/ side-branch)

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_pre_stop_rescue.py
+++ b/src/scitex_agent_container/_lifecycle/_pre_stop_rescue.py
@@ -13,12 +13,20 @@ This module is the SAC-side auto-rescue. It runs once per
 walks every git worktree under the agent's work roots, and for each
 DIRTY worktree:
 
-* Commits the dirty changes locally with a stable rescue message.
-* Pushes the branch to its tracking remote IF the branch is non-
-  protected (no ``main`` / ``master`` / ``release/*``).
-* On push failure or protected branch: writes a diff-tarball under
+* On a NON-protected topic branch: commits the dirty changes locally
+  with a stable rescue message and pushes the branch to its tracking
+  remote.
+* On a PROTECTED branch (``develop`` / ``main`` / ``master`` /
+  ``release/*``): carries the dirty tree onto a dedicated
+  ``rescue/<agent>-<utc>`` side-branch, commits + pushes it THERE, and
+  returns the checkout to the protected branch with a clean tree — so
+  the protected branch NEVER gains a local-only commit that would
+  diverge it from origin and break ``git pull --ff-only`` + the
+  deploy-freshness cron (the root cause this module was hardened to
+  prevent, fleet-wide 2026-07).
+* On push failure (offline / no remote): writes a diff-tarball under
   ``<state_dir>/rescue/<branch>-<utc>.tar.gz`` so the next start can
-  re-apply.
+  re-apply. The dirty work is never dropped.
 
 The whole pass is bounded by ``RESCUE_GRACE_SECONDS`` (default 60s)
 so the rescue can NEVER wedge a restart — if the budget elapses,
@@ -46,10 +54,12 @@ from pathlib import Path
 from typing import Iterable
 
 from ._pre_stop_rescue_git import (
+    checkout_branch,
     commit_dirty,
     current_branch,
     is_dirty,
     is_git_worktree,
+    move_dirty_to_side_branch,
     push_branch,
     write_diff_tarball,
 )
@@ -69,9 +79,16 @@ __all__ = [
 RESCUE_GRACE_SECONDS: float = 60.0
 RESCUE_DIR_NAME: str = "rescue"
 
-# Branch-name protection list — operator-mandated. Auto-COMMIT on these
-# branches is fine; auto-PUSH is refused; diff-tarball fallback used.
+# Branch-name protection list — operator-mandated. On these SHARED
+# branches the rescue must NEVER leave a local-only commit: doing so
+# diverges the branch from its remote and breaks ``git pull --ff-only``
+# + the deploy-freshness cron (root cause of undeployed merged PRs,
+# fleet-wide, 2026-07). Instead the dirty tree is carried onto a
+# dedicated ``rescue/<agent>-<ts>`` side-branch (see ``rescue_worktree``)
+# so the protected branch stays clean + ff-able. ``develop`` is the
+# shared work checkout and MUST be on this list.
 _PROTECTED_BRANCH_PREFIXES: tuple[str, ...] = (
+    "develop",
     "main",
     "master",
     "release",
@@ -79,11 +96,11 @@ _PROTECTED_BRANCH_PREFIXES: tuple[str, ...] = (
 
 
 def is_protected_branch(branch: str) -> bool:
-    """Return True if ``branch`` matches the push-deny list.
+    """Return True if ``branch`` matches the protected list.
 
     Exact match OR prefix-with-``/`` (``release`` matches ``release``
     and ``release/2.0`` but NOT ``release-notes``). Empty / detached
-    (``""``) → True (refuse to push the unclassifiable).
+    (``""``) → True (refuse to commit-in-place on the unclassifiable).
     """
     if not branch:
         return True
@@ -104,8 +121,17 @@ def rescue_worktree(
     """Run the rescue sequence on a single git worktree.
 
     Returns a dict with: ``path``, ``branch``, ``committed``,
-    ``pushed``, ``tarball`` (Path or None), ``protected``, ``error``.
-    NEVER raises.
+    ``pushed``, ``tarball`` (Path or None), ``protected``,
+    ``rescue_branch`` (str; the ``rescue/`` side-branch used on a
+    protected branch, else ``""``), ``error``. NEVER raises.
+
+    On a NON-protected topic branch the dirty tree is committed in place
+    and pushed (existing behavior). On a PROTECTED branch (``develop`` /
+    ``main`` / ``master`` / ``release/*``) the dirty tree is instead
+    carried onto a fresh ``rescue/<agent>-<ts>`` side-branch, committed +
+    pushed there, and the checkout is returned to the protected branch
+    with a clean tree — so the protected branch NEVER gains a local-only
+    commit and stays ``git pull --ff-only`` friendly.
     """
     result: dict[str, object] = {
         "path": path,
@@ -114,6 +140,7 @@ def rescue_worktree(
         "pushed": False,
         "tarball": None,
         "protected": False,
+        "rescue_branch": "",
         "error": "",
     }
     if not is_git_worktree(path):
@@ -123,6 +150,19 @@ def rescue_worktree(
         return result  # clean — nothing to rescue
     branch = current_branch(path, timeout=timeout)
     result["branch"] = branch
+    protected = is_protected_branch(branch)
+    result["protected"] = protected
+    if protected:
+        return _rescue_protected(
+            path,
+            result=result,
+            branch=branch,
+            agent_name=agent_name,
+            timestamp=timestamp,
+            rescue_root=rescue_root,
+            timeout=timeout,
+        )
+    # --- non-protected topic branch: commit in place + push -----------
     ok_commit, commit_msg = commit_dirty(
         path, agent_name=agent_name, timestamp=timestamp, timeout=timeout
     )
@@ -130,18 +170,6 @@ def rescue_worktree(
     if not ok_commit:
         result["error"] = commit_msg
         # Even when commit fails, write a tarball so work survives.
-        result["tarball"] = write_diff_tarball(
-            path,
-            rescue_root=rescue_root,
-            branch=branch,
-            agent_name=agent_name,
-            timestamp=timestamp,
-            timeout=timeout,
-        )
-        return result
-    protected = is_protected_branch(branch)
-    result["protected"] = protected
-    if protected:
         result["tarball"] = write_diff_tarball(
             path,
             rescue_root=rescue_root,
@@ -163,6 +191,70 @@ def rescue_worktree(
             timestamp=timestamp,
             timeout=timeout,
         )
+    return result
+
+
+def _rescue_protected(
+    path: Path,
+    *,
+    result: dict[str, object],
+    branch: str,
+    agent_name: str,
+    timestamp: str,
+    rescue_root: Path,
+    timeout: float,
+) -> dict[str, object]:
+    """Rescue a dirty tree that sits on a PROTECTED branch, without polluting it.
+
+    Carries the tree onto a ``rescue/<agent>-<ts>`` side-branch, commits
+    + pushes it there, then returns the checkout to ``branch`` so the
+    protected ref is unchanged from origin (``ff-only`` pull still
+    works). Falls back to the diff-tarball if the side-branch can't be
+    created / committed / pushed — the dirty work is never dropped. The
+    protected branch is restored on EVERY path.
+    """
+    ok_side, rescue_branch, side_err = move_dirty_to_side_branch(
+        path, agent_name=agent_name, timestamp=timestamp, timeout=timeout
+    )
+    result["rescue_branch"] = rescue_branch
+    if not ok_side:
+        # Could not carry the work onto a side-branch (checkout -b or the
+        # commit failed). The tree is still uncommitted, so the tarball is
+        # the last line of defense; then restore the protected branch.
+        result["error"] = side_err
+        result["tarball"] = write_diff_tarball(
+            path,
+            rescue_root=rescue_root,
+            branch=branch,
+            agent_name=agent_name,
+            timestamp=timestamp,
+            timeout=timeout,
+        )
+        checkout_branch(path, branch, timeout=timeout)
+        return result
+    # Work is committed on the rescue side-branch; protected HEAD untouched.
+    result["committed"] = True
+    ok_push, push_err = push_branch(path, rescue_branch, timeout=timeout)
+    result["pushed"] = ok_push
+    if not ok_push:
+        # Offline / no remote: keep the local rescue branch AND drop a
+        # tarball so the work survives even if that branch is pruned.
+        # HEAD is still the rescue commit here, so the tarball captures it.
+        result["error"] = push_err
+        result["tarball"] = write_diff_tarball(
+            path,
+            rescue_root=rescue_root,
+            branch=rescue_branch,
+            agent_name=agent_name,
+            timestamp=timestamp,
+            timeout=timeout,
+        )
+    # ALWAYS return to the protected branch so its ref equals origin's and
+    # ``git pull --ff-only`` keeps working.
+    ok_back, back_err = checkout_branch(path, branch, timeout=timeout)
+    if not ok_back:
+        prefix = f"{result['error']}; " if result["error"] else ""
+        result["error"] = f"{prefix}restore to {branch} failed: {back_err}"
     return result
 
 
@@ -227,6 +319,7 @@ def rescue_worktrees_for_agent(
                     "pushed": False,
                     "tarball": None,
                     "protected": False,
+                    "rescue_branch": "",
                     "error": "grace budget elapsed",
                 }
             )

--- a/src/scitex_agent_container/_lifecycle/_pre_stop_rescue_git.py
+++ b/src/scitex_agent_container/_lifecycle/_pre_stop_rescue_git.py
@@ -12,17 +12,21 @@ No mocks. Real subprocesses against real git worktrees.
 from __future__ import annotations
 
 import logging
+import re
 import subprocess
 from pathlib import Path
 
 log = logging.getLogger(__name__)
 
 __all__ = [
+    "checkout_branch",
     "commit_dirty",
     "current_branch",
     "is_dirty",
     "is_git_worktree",
+    "move_dirty_to_side_branch",
     "push_branch",
+    "rescue_branch_name",
     "write_diff_tarball",
 ]
 
@@ -95,6 +99,62 @@ def commit_dirty(
     return (True, msg)
 
 
+def rescue_branch_name(agent_name: str, timestamp: str) -> str:
+    """Return the dedicated side-branch name ``rescue/<agent>-<timestamp>``.
+
+    ``agent_name`` is sanitised to the git ref-safe alphabet so a stray
+    space / slash / colon in an agent id can't produce an invalid ref.
+    """
+    safe_agent = re.sub(r"[^A-Za-z0-9._-]", "-", agent_name).strip("-") or "agent"
+    return f"rescue/{safe_agent}-{timestamp}"
+
+
+def checkout_branch(path: Path, branch: str, *, timeout: float) -> tuple[bool, str]:
+    """``git checkout <branch>`` (existing branch). Returns (ok, error)."""
+    rc, _, err = _run(["git", "checkout", branch], cwd=path, timeout=timeout)
+    if rc != 0:
+        return (False, err.strip() or "checkout failed")
+    return (True, "")
+
+
+def move_dirty_to_side_branch(
+    path: Path, *, agent_name: str, timestamp: str, timeout: float
+) -> tuple[bool, str, str]:
+    """Carry the dirty tree onto a fresh ``rescue/`` side-branch and commit it.
+
+    Used when the checkout sits on a PROTECTED branch (``develop`` /
+    ``main`` / ``master`` / ``release/*``): committing the rescue there
+    would leave a local-only commit that diverges the branch from its
+    remote and breaks ``git pull --ff-only`` + the deploy-freshness
+    cron. Instead we ``git checkout -b rescue/<agent>-<ts>`` (which
+    CARRIES the uncommitted tree — tracked + untracked — onto the new
+    branch off the same HEAD, so no conflict is possible), then commit
+    the dirty tree THERE with the stable rescue message.
+
+    On success the caller is left standing ON the rescue branch (HEAD =
+    the rescue commit) so a subsequent ``push_branch`` / diff-tarball
+    captures the right commit; the caller MUST call ``checkout_branch``
+    to return to the protected branch — which then reverts to a clean,
+    ff-able tree since all the work is now committed on the side branch.
+
+    Returns ``(ok, rescue_branch, error)``. On failure the rescue branch
+    name is still returned (best effort) and ``error`` is populated; the
+    caller decides on the tarball fallback.
+    """
+    rescue_branch = rescue_branch_name(agent_name, timestamp)
+    rc, _, err = _run(
+        ["git", "checkout", "-b", rescue_branch], cwd=path, timeout=timeout
+    )
+    if rc != 0:
+        return (False, rescue_branch, f"git checkout -b failed: {err.strip()}")
+    ok_commit, commit_msg = commit_dirty(
+        path, agent_name=agent_name, timestamp=timestamp, timeout=timeout
+    )
+    if not ok_commit:
+        return (False, rescue_branch, commit_msg)
+    return (True, rescue_branch, "")
+
+
 def push_branch(path: Path, branch: str, *, timeout: float) -> tuple[bool, str]:
     """Push ``branch`` to ``origin`` with ``--force-with-lease -u``."""
     rc, _, err = _run(
@@ -133,7 +193,7 @@ def write_diff_tarball(
     if rc != 0:
         # No parent commit (first commit case) — fall back to diff HEAD.
         rc_diff, out_diff, _ = _run(["git", "diff", "HEAD"], cwd=path, timeout=timeout)
-        diff_path.write_text(out_diff if rc_diff == 0 else "")
+        patch_text = out_diff if rc_diff == 0 else ""
     else:
         # Re-run capturing stdout to file — single source of truth.
         proc = subprocess.run(
@@ -143,7 +203,18 @@ def write_diff_tarball(
             capture_output=True,
             text=True,
         )
-        diff_path.write_text(proc.stdout)
+        patch_text = proc.stdout
+    # ALSO capture any still-uncommitted work. On the happy path (rescue
+    # committed on a side-branch) this is empty; on the rare path where
+    # the commit never landed it is the ONLY copy of the dirty tree, so
+    # appending it guarantees the tarball never silently loses work.
+    _, out_uncommitted, _ = _run(["git", "diff", "HEAD"], cwd=path, timeout=timeout)
+    if out_uncommitted.strip():
+        patch_text += (
+            "\n### pre-stop rescue: uncommitted working-tree diff ###\n"
+            + out_uncommitted
+        )
+    diff_path.write_text(patch_text)
     manifest_path = rescue_root / f".{safe_branch}-{timestamp}.manifest"
     manifest_path.write_text(
         f"agent: {agent_name}\nbranch: {branch}\ntimestamp: {timestamp}\n"

--- a/tests/scitex_agent_container/_lifecycle/test__pre_stop_rescue.py
+++ b/tests/scitex_agent_container/_lifecycle/test__pre_stop_rescue.py
@@ -87,6 +87,23 @@ def _make_dirty(root: Path) -> None:
     (root / "README.md").write_text("# tmp\n# rescue-target\n")
 
 
+def _git_out(args: list[str], *, cwd: Path) -> str:
+    """Run ``git <args>`` and return stdout (raises on non-zero — fail loud)."""
+    return subprocess.check_output(["git", *args], cwd=str(cwd), text=True)
+
+
+def _init_repo_with_origin(
+    root: Path, remote: Path, *, branch: str = "develop"
+) -> Path:
+    """Create a repo on ``branch`` wired to a bare ``origin`` with ``branch`` pushed."""
+    remote.mkdir(parents=True, exist_ok=True)
+    _git(["init", "--bare", "--quiet"], cwd=remote)
+    _init_repo(root, branch=branch)
+    _git(["remote", "add", "origin", str(remote)], cwd=root)
+    _git(["push", "-u", "origin", branch, "--quiet"], cwd=root)
+    return root
+
+
 # ---------------------------------------------------------------------------
 # is_protected_branch — denylist policy
 # ---------------------------------------------------------------------------
@@ -136,6 +153,16 @@ def test_is_protected_branch_release_notes_is_not_protected():
     result = is_protected_branch(branch)
     # Assert
     assert result is False
+
+
+def test_is_protected_branch_develop_is_protected():
+    # Arrange — develop is the shared work checkout; a rescue commit here
+    # diverges it from origin and breaks ff-only pull (the root-cause bug).
+    branch = "develop"
+    # Act
+    result = is_protected_branch(branch)
+    # Assert
+    assert result is True
 
 
 def test_is_protected_branch_empty_branch_is_protected():
@@ -369,3 +396,256 @@ def test_rescue_for_agent_rescue_dir_named_correctly(
     )
     # Assert
     assert (state_dir / RESCUE_DIR_NAME).is_dir()
+
+
+# ---------------------------------------------------------------------------
+# rescue_worktree on a PROTECTED branch — route to rescue/ side-branch,
+# NEVER leave a local-only commit on develop/main (root-cause fix)
+# ---------------------------------------------------------------------------
+
+
+def test_rescue_protected_develop_no_local_only_commit(
+    git_env_save_restore, tmp_path: Path
+) -> None:
+    # Arrange — dirty checkout on develop wired to an origin remote.
+    repo = _init_repo_with_origin(tmp_path / "repo", tmp_path / "remote.git")
+    _make_dirty(repo)
+    rescue_root = tmp_path / "state" / RESCUE_DIR_NAME
+    # Act
+    rescue_worktree(
+        repo,
+        agent_name="agent-x",
+        timestamp="20260709T000000Z",
+        rescue_root=rescue_root,
+        timeout=15.0,
+    )
+    # Assert — develop carries NO commit that origin/develop lacks.
+    ahead = _git_out(["rev-list", "origin/develop..develop"], cwd=repo)
+    assert ahead.strip() == ""
+
+
+def test_rescue_protected_develop_pull_ff_only_succeeds(
+    git_env_save_restore, tmp_path: Path
+) -> None:
+    # Arrange
+    repo = _init_repo_with_origin(tmp_path / "repo", tmp_path / "remote.git")
+    _make_dirty(repo)
+    rescue_root = tmp_path / "state" / RESCUE_DIR_NAME
+    # Act
+    rescue_worktree(
+        repo,
+        agent_name="agent-x",
+        timestamp="20260709T000000Z",
+        rescue_root=rescue_root,
+        timeout=15.0,
+    )
+    # Assert — the exact operation the bug broke now succeeds (rc 0).
+    rc = subprocess.call(["git", "pull", "--ff-only", "--quiet"], cwd=str(repo))
+    assert rc == 0
+
+
+def test_rescue_protected_develop_worktree_clean_after(
+    git_env_save_restore, tmp_path: Path
+) -> None:
+    # Arrange
+    repo = _init_repo_with_origin(tmp_path / "repo", tmp_path / "remote.git")
+    _make_dirty(repo)
+    rescue_root = tmp_path / "state" / RESCUE_DIR_NAME
+    # Act
+    rescue_worktree(
+        repo,
+        agent_name="agent-x",
+        timestamp="20260709T000000Z",
+        rescue_root=rescue_root,
+        timeout=15.0,
+    )
+    # Assert — checkout restored to a clean tree (porcelain empty).
+    porcelain = _git_out(["status", "--porcelain"], cwd=repo)
+    assert porcelain.strip() == ""
+
+
+def test_rescue_protected_develop_still_on_develop_after(
+    git_env_save_restore, tmp_path: Path
+) -> None:
+    # Arrange
+    repo = _init_repo_with_origin(tmp_path / "repo", tmp_path / "remote.git")
+    _make_dirty(repo)
+    rescue_root = tmp_path / "state" / RESCUE_DIR_NAME
+    # Act
+    rescue_worktree(
+        repo,
+        agent_name="agent-x",
+        timestamp="20260709T000000Z",
+        rescue_root=rescue_root,
+        timeout=15.0,
+    )
+    # Assert — the checkout ends back on the original protected branch.
+    branch = _git_out(["rev-parse", "--abbrev-ref", "HEAD"], cwd=repo)
+    assert branch.strip() == "develop"
+
+
+def test_rescue_protected_develop_work_preserved_on_rescue_branch(
+    git_env_save_restore, tmp_path: Path
+) -> None:
+    # Arrange
+    repo = _init_repo_with_origin(tmp_path / "repo", tmp_path / "remote.git")
+    _make_dirty(repo)
+    rescue_root = tmp_path / "state" / RESCUE_DIR_NAME
+    # Act
+    result = rescue_worktree(
+        repo,
+        agent_name="agent-x",
+        timestamp="20260709T000000Z",
+        rescue_root=rescue_root,
+        timeout=15.0,
+    )
+    # Assert — the rescue branch's tip carries the dirty content.
+    content = _git_out(
+        ["show", f"{result['rescue_branch']}:README.md"], cwd=repo
+    )
+    assert "rescue-target" in content
+
+
+def test_rescue_protected_develop_rescue_branch_named_by_convention(
+    git_env_save_restore, tmp_path: Path
+) -> None:
+    # Arrange
+    repo = _init_repo_with_origin(tmp_path / "repo", tmp_path / "remote.git")
+    _make_dirty(repo)
+    rescue_root = tmp_path / "state" / RESCUE_DIR_NAME
+    # Act
+    result = rescue_worktree(
+        repo,
+        agent_name="agent-x",
+        timestamp="20260709T000000Z",
+        rescue_root=rescue_root,
+        timeout=15.0,
+    )
+    # Assert
+    assert result["rescue_branch"] == "rescue/agent-x-20260709T000000Z"
+
+
+def test_rescue_protected_develop_pushes_rescue_branch_to_origin(
+    git_env_save_restore, tmp_path: Path
+) -> None:
+    # Arrange
+    repo = _init_repo_with_origin(tmp_path / "repo", tmp_path / "remote.git")
+    _make_dirty(repo)
+    rescue_root = tmp_path / "state" / RESCUE_DIR_NAME
+    # Act
+    result = rescue_worktree(
+        repo,
+        agent_name="agent-x",
+        timestamp="20260709T000000Z",
+        rescue_root=rescue_root,
+        timeout=15.0,
+    )
+    # Assert — the rescue branch actually landed on origin.
+    remote_heads = _git_out(
+        ["ls-remote", "--heads", "origin", str(result["rescue_branch"])],
+        cwd=repo,
+    )
+    assert remote_heads.strip() != ""
+
+
+def test_rescue_protected_develop_no_remote_writes_tarball(
+    git_env_save_restore, tmp_path: Path
+) -> None:
+    # Arrange — develop but NO origin: push MUST fail, tarball MUST land,
+    # develop MUST stay pristine (no local-only commit vs its init tip).
+    repo = _init_repo(tmp_path / "repo", branch="develop")
+    _make_dirty(repo)
+    rescue_root = tmp_path / "state" / RESCUE_DIR_NAME
+    # Act
+    result = rescue_worktree(
+        repo,
+        agent_name="agent-x",
+        timestamp="20260709T000000Z",
+        rescue_root=rescue_root,
+        timeout=15.0,
+    )
+    # Assert — work still captured on disk despite no remote.
+    assert isinstance(result.get("tarball"), Path) and Path(result["tarball"]).is_file()
+
+
+def test_rescue_protected_develop_no_remote_keeps_develop_clean(
+    git_env_save_restore, tmp_path: Path
+) -> None:
+    # Arrange — no remote; capture develop's tip before + after.
+    repo = _init_repo(tmp_path / "repo", branch="develop")
+    tip_before = _git_out(["rev-parse", "develop"], cwd=repo).strip()
+    _make_dirty(repo)
+    rescue_root = tmp_path / "state" / RESCUE_DIR_NAME
+    # Act
+    rescue_worktree(
+        repo,
+        agent_name="agent-x",
+        timestamp="20260709T000000Z",
+        rescue_root=rescue_root,
+        timeout=15.0,
+    )
+    # Assert — develop's tip is unchanged (no rescue commit landed on it).
+    tip_after = _git_out(["rev-parse", "develop"], cwd=repo).strip()
+    assert tip_after == tip_before
+
+
+def test_rescue_protected_develop_no_remote_preserves_on_rescue_branch(
+    git_env_save_restore, tmp_path: Path
+) -> None:
+    # Arrange — no remote: the local rescue branch is the durable copy.
+    repo = _init_repo(tmp_path / "repo", branch="develop")
+    _make_dirty(repo)
+    rescue_root = tmp_path / "state" / RESCUE_DIR_NAME
+    # Act
+    result = rescue_worktree(
+        repo,
+        agent_name="agent-x",
+        timestamp="20260709T000000Z",
+        rescue_root=rescue_root,
+        timeout=15.0,
+    )
+    # Assert — the local rescue branch still carries the dirty content.
+    content = _git_out(
+        ["show", f"{result['rescue_branch']}:README.md"], cwd=repo
+    )
+    assert "rescue-target" in content
+
+
+def test_rescue_nonprotected_topic_branch_commits_in_place(
+    git_env_save_restore, tmp_path: Path
+) -> None:
+    # Arrange — a normal topic branch: the rescue commit lands IN PLACE,
+    # existing behavior, no side-branch.
+    repo = _init_repo(tmp_path / "repo", branch="feature/topic")
+    _make_dirty(repo)
+    rescue_root = tmp_path / "state" / RESCUE_DIR_NAME
+    # Act
+    result = rescue_worktree(
+        repo,
+        agent_name="agent-x",
+        timestamp="20260709T000000Z",
+        rescue_root=rescue_root,
+        timeout=15.0,
+    )
+    # Assert — no rescue side-branch was created for a topic branch.
+    assert result["rescue_branch"] == ""
+
+
+def test_rescue_nonprotected_topic_branch_leaves_commit_on_that_branch(
+    git_env_save_restore, tmp_path: Path
+) -> None:
+    # Arrange
+    repo = _init_repo(tmp_path / "repo", branch="feature/topic")
+    _make_dirty(repo)
+    rescue_root = tmp_path / "state" / RESCUE_DIR_NAME
+    # Act
+    rescue_worktree(
+        repo,
+        agent_name="agent-x",
+        timestamp="20260709T000000Z",
+        rescue_root=rescue_root,
+        timeout=15.0,
+    )
+    # Assert — HEAD's newest commit is the rescue autosave on feature/topic.
+    subject = _git_out(["log", "-1", "--pretty=%s"], cwd=repo)
+    assert subject.strip() == "rescue: pre-stop autosave agent-x@20260709T000000Z"


### PR DESCRIPTION
## Root cause

The pre-stop rescue (`_lifecycle/_pre_stop_rescue.py`) committed an agent's dirty working tree onto the **current branch**. Agents' checkouts commonly sit on `develop` (the shared work branch), so the rescue commit `rescue: pre-stop autosave <agent>@<ts>` landed **on `develop`**, which then diverged from `origin/develop`.

## Today's evidence (fleet-wide, 2026-07)

- `git pull --ff-only` fails ("Not possible to fast-forward") -> merged PRs stay undeployed on the host editable install. **PR #576 sat undeployed** until a manual `git reset --hard origin/develop`.
- The `deploy-freshness --apply` cron (every 30 min) is **defeated** — it cannot auto-reconcile a diverged branch, so the whole auto-deploy safety net silently no-ops.
- Confirmed on multiple agents' `develop`: sac had `ef5c07a9`, cct had `75ad860` — both `rescue: pre-stop autosave` commits.

## What changed

- **`develop` added to the protected-branch set** (was `main`/`master`/`release/*` only) — that omission is why rescues landed on the shared work checkout.
- On **any protected branch** (`develop`/`main`/`master`/`release/*`), the rescue now routes the dirty tree to a dedicated **`rescue/<agent>-<ts>` side-branch** instead of committing in place:
  - `git checkout -b rescue/<agent>-<ts>` — carries the tracked **and** untracked tree onto the new branch off the same HEAD (no conflict possible).
  - commit the dirty tree there (same stable rescue message).
  - push the rescue branch (`push_branch`, existing force-with-lease `-u origin`).
  - `git checkout <protected>` back — the protected branch reverts to a **clean, ff-able** tree since all work is now committed on the side branch.
  - The protected ref **never moves**: `git rev-list origin/<branch>..<branch>` stays empty, `git pull --ff-only` keeps working.
- New git primitives in `_pre_stop_rescue_git.py`: `move_dirty_to_side_branch`, `checkout_branch`, `rescue_branch_name` (ref-name sanitised).
- Result dict gains a `rescue_branch` field.

## How the rescue guarantee is preserved (never lose dirty work)

- If the side-branch can't be created / committed / **pushed** (offline / no remote), fall back to the existing `write_diff_tarball` path — work is still captured on disk, never silently dropped.
- `write_diff_tarball` now **also** appends the uncommitted `git diff HEAD` as a belt-and-suspenders copy for the rare path where a commit never lands.
- The protected branch is restored on **every** exit path.
- **Non-protected topic branches are unchanged**: commit-in-place + push as before.

## Test coverage (real temp git repos + bare `origin`, no mocks)

- Protected `develop`: no local-only commit (`rev-list origin/develop..develop` empty); `git pull --ff-only` returns 0; worktree ends clean back on `develop`; work preserved + pushed on the `rescue/` branch; rescue branch named by convention.
- No-remote protected `develop`: tarball written, `develop` tip unchanged, work preserved on the local `rescue/` branch.
- Non-protected topic branch: no side-branch, rescue commit lands in place (existing behavior).
- `develop` added to `is_protected_branch` denylist tests.

pytest: `30 passed` (this suite) / `574 passed` (full `_lifecycle/` suite), no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
