### PR TITLE
fix(status): live agents read "running" — separate TUI liveness from activity-freshness

### DIFF
--- a/src/scitex_agent_container/_runners/_tmux/_tmux_probe.py
+++ b/src/scitex_agent_container/_runners/_tmux/_tmux_probe.py
@@ -1,0 +1,102 @@
+"""Read-only tmux pane probes — identity-based liveness signals.
+
+Extracted from :mod:`_runners._tmux.tmux` (512-line per-file cap) so the
+new ``pane_pid`` / ``pane_dead`` probes have room to live with their
+rationale. ``TmuxManager.pane_pid`` / ``.pane_dead`` are thin delegates
+over these pure functions; ``TuiSessionRuntime.is_running`` keys its
+liveness decision off ``pane_pid`` (card
+``sac-fix-live-agents-read-stopped``: an idle-but-alive TUI advanced its
+``session_activity`` stamp only on pane I/O, so the old
+activity-freshness gate read a live-but-quiet agent as ``stopped`` after
+the max-idle window — a false negative for every agent sitting at its
+input prompt).
+
+The pane-pid signal is IDENTITY-based (a concrete OS process) and
+NAMESPACE-robust: ``os.kill(pane_pid, 0)`` sees the live
+``apptainer exec ... claude`` process across the PID-namespace /
+``ps -p <pid>``-filter boundaries where a plain ``ps -p`` returns empty
+for a still-live pid on this host (card lead #2).
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+
+def _display_field(session_name: str, fmt: str) -> str | None:
+    """Return ``tmux display -p '<fmt>'`` for ``session_name`` (stripped),
+    or ``None`` when the session is absent / the probe fails.
+
+    Local import of :class:`TmuxManager` keeps the existence check on the
+    one canonical implementation without a module-level import cycle.
+    """
+    from .tmux import TmuxManager
+
+    if not TmuxManager.exists(session_name):
+        return None
+    result = subprocess.run(  # pragma: no cover  -- requires live tmux, not available on CI runner
+        ["tmux", "display", "-p", "-t", session_name, fmt],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:  # pragma: no cover  -- requires live tmux
+        return None
+    raw = result.stdout.strip()  # pragma: no cover  -- requires live tmux
+    return raw or None  # pragma: no cover  -- requires live tmux
+
+
+def pane_pid(session_name: str) -> int | None:
+    """Return the PID of the process in the session's active pane, or
+    ``None`` when no such session exists / the probe fails.
+
+    For a sac-owned TUI session this is the long-lived
+    ``apptainer exec ... claude`` process: the pane's ``bash -c``
+    ``exec``s apptainer, so after exec ``pane_pid`` IS the apptainer /
+    claude PID. This is the identity signal
+    ``TuiSessionRuntime.is_running`` checks for liveness. Never raises.
+    """
+    raw = _display_field(session_name, "#{pane_pid}")
+    if raw is None:  # pragma: no cover  -- requires live tmux
+        return None
+    try:  # pragma: no cover  -- requires live tmux
+        return int(raw)
+    except ValueError:  # pragma: no cover  -- requires live tmux
+        return None
+
+
+def session_activity(session_name: str) -> int | None:
+    """Return the unix-epoch stamp of the session's last pane activity,
+    or ``None`` when absent. Backed by ``#{session_activity}`` (tmux
+    advances it on pane output OR input).
+
+    NOTE: this is a RESPONSIVENESS / movement signal, NOT a liveness
+    signal — an idle-but-alive TUI does not advance it. It backs
+    :meth:`TuiSessionRuntime.is_responsive`; liveness (``is_running``)
+    keys off :func:`pane_pid` instead.
+    """
+    raw = _display_field(session_name, "#{session_activity}")
+    if raw is None:  # pragma: no cover  -- requires live tmux
+        return None
+    try:  # pragma: no cover  -- requires live tmux
+        return int(raw)
+    except ValueError:  # pragma: no cover  -- requires live tmux
+        return None
+
+
+def pane_dead(session_name: str) -> bool | None:
+    """Return whether the active pane's process EXITED while the pane is
+    retained (``remain-on-exit``), or ``None`` when absent / probe fails.
+
+    ``tmux`` reports ``#{pane_dead}`` == ``1`` for a retained-dead pane.
+    sac does not set ``remain-on-exit`` (a dead pane normally closes its
+    window and the session disappears), so this is a belt-and-suspenders
+    guard letting ``is_running`` report ``stopped`` for a retained corpse
+    rather than a false ``running``.
+    """
+    raw = _display_field(session_name, "#{pane_dead}")
+    if raw is None:  # pragma: no cover  -- requires live tmux
+        return None
+    return raw == "1"  # pragma: no cover  -- requires live tmux
+
+
+__all__ = ["pane_pid", "pane_dead", "session_activity"]

--- a/src/scitex_agent_container/_runners/_tmux/tmux.py
+++ b/src/scitex_agent_container/_runners/_tmux/tmux.py
@@ -189,54 +189,31 @@ class TmuxManager:
 
     @staticmethod
     def session_activity(session_name: str) -> int | None:
-        """Return the unix-epoch timestamp of the session's last pane
-        activity, or ``None`` if no such session exists.
-
-        Backed by ``tmux display -p '#{session_activity}'``, which
-        tmux advances every time a pane writes output OR receives
-        input. Used by ``TuiSessionRuntime.is_running`` as the tui-
-        alive probe (step 4/4 of the TUI hedge, lead a2a
-        ``d383f5389dc548a49a293bffe390d619``) — a "session exists"
-        check alone cannot detect a hung-but-alive ``claude`` process,
-        so the runtime additionally requires the activity timestamp
-        to be within a max-idle window of wall clock.
-
-        Returns ``None`` rather than raising on a missing session so
-        callers can branch on "no session" vs. "stale session" with
-        a single ``is None`` check.
+        """Unix-epoch stamp of the session's last pane activity, or
+        ``None`` when absent. RESPONSIVENESS signal (advances only on
+        pane I/O) — NOT liveness. See :func:`_tmux_probe.session_activity`.
         """
-        if not TmuxManager.exists(session_name):
-            return None
-        # The remainder shells out to `tmux display -p '#{session_activity}'`
-        # and parses its int output. Exercised end-to-end by the slow
-        # real-binary suite (test_tui_session_real_smoke.py) and the
-        # session-activity probe test (test_tmux_session_activity.py),
-        # both gated on `tmux` being on PATH. CI runners do not have tmux
-        # installed, so the lines below are unreachable in the standard
-        # pytest matrix. The honest marker — requires live tmux, not
-        # available on CI runner — is a pragma rather than a band-aid
-        # coverage-ignore of the whole module.
-        result = subprocess.run(  # pragma: no cover  -- requires live tmux, not available on CI runner
-            [
-                "tmux",
-                "display",
-                "-p",
-                "-t",
-                session_name,
-                "#{session_activity}",
-            ],
-            capture_output=True,
-            text=True,
-        )
-        if result.returncode != 0:  # pragma: no cover  -- requires live tmux
-            return None
-        raw = result.stdout.strip()  # pragma: no cover  -- requires live tmux
-        if not raw:  # pragma: no cover  -- requires live tmux
-            return None
-        try:  # pragma: no cover  -- requires live tmux
-            return int(raw)
-        except ValueError:  # pragma: no cover  -- requires live tmux
-            return None
+        from ._tmux_probe import session_activity as _sa
+
+        return _sa(session_name)
+
+    @staticmethod
+    def pane_pid(session_name: str) -> int | None:
+        """PID of the process in the session's active pane (identity
+        liveness signal), or ``None`` when absent. See
+        :func:`_tmux_probe.pane_pid`."""
+        from ._tmux_probe import pane_pid as _pane_pid
+
+        return _pane_pid(session_name)
+
+    @staticmethod
+    def pane_dead(session_name: str) -> bool | None:
+        """Whether the active pane's process exited but the pane is
+        retained, or ``None`` when absent. See
+        :func:`_tmux_probe.pane_dead`."""
+        from ._tmux_probe import pane_dead as _pane_dead
+
+        return _pane_dead(session_name)
 
     @staticmethod
     def capture_content(session_name: str) -> str:

--- a/src/scitex_agent_container/cli_pkg/_helpers/_agent_list.py
+++ b/src/scitex_agent_container/cli_pkg/_helpers/_agent_list.py
@@ -111,6 +111,15 @@ def _probe_local(cfg) -> bool | None:
     ``_get_runtime`` makes ``sac agents list`` agree with
     ``sac agents status``.
 
+    SECOND fix (card ``sac-fix-live-agents-read-stopped``, 2026-07-08):
+    even after routing here, ``TuiSessionRuntime.is_running`` still gated
+    on ``session_activity`` freshness (pane I/O within 300s). tmux
+    advances that stamp only on pane read/write, so every quiet-but-alive
+    agent sitting at its input prompt read "stopped" minutes after its
+    last output. ``is_running`` is now IDENTITY-based liveness (session
+    exists AND its pane process is alive via ``os.kill(pane_pid, 0)``),
+    so this probe reports a live idle agent as running.
+
     Returns None on exception (e.g. malformed config) so the caller
     surfaces ``status='unknown'`` rather than crashing the list.
     """

--- a/src/scitex_agent_container/runtimes/_tui_liveness.py
+++ b/src/scitex_agent_container/runtimes/_tui_liveness.py
@@ -1,0 +1,114 @@
+"""Pure liveness / responsiveness decisions for the TUI runtime.
+
+Split out of :mod:`runtimes.tui_session` (512-line per-file cap) so the
+identity-based liveness rule has room for its rationale and its own unit
+suite. All functions are pure (collaborators injected) so they test
+without tmux.
+
+ROOT CAUSE (card ``sac-fix-live-agents-read-stopped``, reproduced
+2026-07-08): the old ``TuiSessionRuntime.is_running`` gated on
+``session_activity`` freshness (pane I/O within a 300s max-idle window).
+tmux advances ``#{session_activity}`` only on pane output OR input, so a
+live-but-quiet agent sitting at its input prompt froze that stamp — every
+such agent read ``stopped`` minutes after its last visible output
+(empirically: ``session_activity`` 3.5h stale for a provably-live,
+tmux-attached session with an alive ``apptainer exec ... claude`` pane
+process). LIVENESS and RESPONSIVENESS were conflated.
+
+FIX: separate the two.
+
+  * :func:`pane_process_alive` — LIVENESS. The ``tui-<name>`` session
+    exists AND its pane's process is alive (``os.kill(pane_pid, 0)`` —
+    identity-based, namespace-robust: it sees a live pid where
+    ``ps -p <pid>`` returns empty on this host). No activity gate — an
+    idle agent is still running. This backs ``is_running`` (the status /
+    ``sac agents list`` signal).
+  * :func:`is_responsive_from_activity` — RESPONSIVENESS. The old
+    activity-freshness rule, preserved for any hang-detection consumer
+    that genuinely wants "moving", now behind ``is_responsive``.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Callable, Optional
+
+
+def pid_alive(pid: int | None) -> bool:
+    """True iff ``pid`` is a live process (``os.kill(pid, 0)``).
+
+    ``None`` / non-positive pids are NOT a liveness verdict on their own —
+    callers treat "unreadable pid" as "defer to session existence", so
+    this returns ``False`` for them and the caller decides. A
+    ``PermissionError`` means the pid exists but is owned by another user
+    → alive.
+    """
+    if pid is None or pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+
+
+def pane_process_alive(
+    session_name: str,
+    *,
+    exists_fn: Callable[[str], bool],
+    pane_dead_fn: Optional[Callable[[str], bool | None]] = None,
+    pane_pid_fn: Optional[Callable[[str], int | None]] = None,
+) -> bool:
+    """LIVENESS: the session exists AND its pane process is alive.
+
+    Decision order:
+      1. session absent → ``False``.
+      2. ``pane_dead_fn`` reports ``True`` (retained-dead pane,
+         ``remain-on-exit``) → ``False``.
+      3. ``pane_pid_fn`` yields a concrete pid → ``os.kill(pid, 0)``
+         verdict (identity/namespace-robust).
+      4. no pid probe available, or pid unreadable (``None``) → ``True``:
+         session-exists is itself a liveness signal (sac never sets
+         ``remain-on-exit``, so a dead pane normally closes its window and
+         the session disappears). This also keeps back-compat with an
+         injected multiplexer fake that predates the pane-pid probe.
+    """
+    if not exists_fn(session_name):
+        return False
+    if pane_dead_fn is not None:
+        try:
+            if pane_dead_fn(session_name) is True:
+                return False
+        except Exception:  # stx-allow: fallback (a pane_dead probe hiccup must not flip a live session to dead — defer to the pid check)
+            pass
+    if pane_pid_fn is None:
+        return True
+    try:
+        pid = pane_pid_fn(session_name)
+    except Exception:  # stx-allow: fallback (a pane_pid probe hiccup defers to session-exists = alive, never a false "stopped")
+        return True
+    if pid is None:
+        return True
+    return pid_alive(pid)
+
+
+def is_responsive_from_activity(
+    activity: int | float | None,
+    now: float,
+    max_idle_s: float,
+) -> bool:
+    """RESPONSIVENESS: pane activity within ``max_idle_s`` of ``now``.
+
+    ``None`` activity (no readable stamp / absent session) → ``False``.
+    This is the OLD ``is_running`` rule, kept for hang-detection.
+    """
+    if activity is None:
+        return False
+    return (now - float(activity)) <= max_idle_s
+
+
+__all__ = ["pid_alive", "pane_process_alive", "is_responsive_from_activity"]

--- a/src/scitex_agent_container/runtimes/tui_session.py
+++ b/src/scitex_agent_container/runtimes/tui_session.py
@@ -9,16 +9,14 @@ tmux is a PTY holder only (it never runs ``claude`` on the host); it lets the
 agent survive operator detach and gives the inner TUI a PTY.
 
 This module is a thin adapter — it owns the session-name convention and the
-``RuntimeBase`` surface, and delegates:
+``RuntimeBase`` surface, and delegates: tmux mechanics → ``_runners/_tmux/``;
+$HOME materialisation → :mod:`_tui_workspace`; modal drain → :mod:`_tui_drain`;
+compose-buffer clear / submit-verify → :mod:`_tui_compose`; startup-prompt
+injection → :mod:`_tui_inject`; liveness decisions → :mod:`_tui_liveness`.
 
-  * tmux mechanics → ``_runners/_tmux/`` (multiplexer / tmux / pane_capture);
-  * $HOME materialisation → :mod:`_tui_workspace`;
-  * modal drain → :mod:`_tui_drain` (pure, injectable);
-  * compose-buffer clear / submit-verify → :mod:`_tui_compose` (pure);
-  * startup-prompt injection → :mod:`_tui_inject`.
-
-``is_running`` is a responsiveness probe (tmux ``session_activity`` freshness),
-so the supervisor's RestartPolicy catches an inner-hang, not just a dead session.
+``is_running`` is a LIVENESS probe (session exists AND its pane process is
+alive); ``is_responsive`` is the separate ``session_activity``-freshness signal
+for hang-detection (see :mod:`_tui_liveness`).
 """
 
 from __future__ import annotations
@@ -46,6 +44,7 @@ from ._tui_drain import (
 from ._tui_auth_stage import TuiAuthStageError
 from ._tui_bridge_seam import TurnBridgeSeamMixin
 from ._tui_inject import StartupPromptInjectorMixin
+from ._tui_liveness import is_responsive_from_activity, pane_process_alive
 from ._tui_workspace import materialize_workspace as _materialize_workspace
 from .base import RuntimeBase
 
@@ -65,13 +64,10 @@ __all__ = [
 
 _CLAUDE_BIN_DEFAULT = "claude"
 
-# Default max-idle window for the tui-alive probe (see
-# ``TuiSessionRuntime.is_running``). 300s mirrors the SDK runtime's
-# health.interval default and gives a quiet but healthy TUI a
-# generous grace window before the supervisor's restart policy
-# fires on it. Overridable per-call via the ``max_idle_s`` kwarg
-# so a custom health policy in spec.health can tune it without a
-# code change.
+# Default max-idle window for the RESPONSIVENESS probe
+# (``TuiSessionRuntime.is_responsive``; liveness/``is_running`` no longer
+# uses it). 300s mirrors the SDK ``health.interval`` default so a
+# quiet-but-healthy TUI has grace. Overridable per-call via ``max_idle_s``.
 _DEFAULT_MAX_IDLE_S = 300.0
 
 # Boot-drain window when ``spec.startup_commands`` delay ``exec claude``
@@ -380,25 +376,29 @@ class TuiSessionRuntime(StartupPromptInjectorMixin, TurnBridgeSeamMixin, Runtime
     def is_running(
         self, config: AgentConfig, max_idle_s: float = _DEFAULT_MAX_IDLE_S
     ) -> bool:
-        """True iff sac's tmux session for this agent is **responsive**.
+        """LIVENESS: ``tui-<name>`` exists AND its pane process is alive
+        (``os.kill(pane_pid, 0)``; NO activity gate — an idle agent is
+        still running). ``max_idle_s`` ignored. See :mod:`_tui_liveness`."""
+        del max_idle_s
+        return pane_process_alive(
+            session_name_for(config),
+            exists_fn=self._mux.exists,
+            pane_dead_fn=getattr(self._mux, "pane_dead", None),
+            pane_pid_fn=getattr(self._mux, "pane_pid", None),
+        )
 
-        Not just "session exists": requires pane activity within the last
-        ``max_idle_s`` seconds (``tmux display -p '#{session_activity}'``
-        advances on every pane read OR write), so the supervisor's RestartPolicy
-        also catches an inner-hang (a claude that neither exits nor reads stdin),
-        not only a dead session. ``max_idle_s`` defaults to 300s (the SDK
-        ``health.interval`` default) so a quiet-but-healthy TUI has grace.
-
-        Returns ``False`` when the session is absent, when ``session_activity``
-        is unavailable (``None``), or when the stamp is older than ``max_idle_s``.
-        """
+    def is_responsive(
+        self, config: AgentConfig, max_idle_s: float = _DEFAULT_MAX_IDLE_S
+    ) -> bool:
+        """RESPONSIVENESS: alive AND pane activity within ``max_idle_s``
+        (the OLD is_running rule, for hang-detection). See
+        :mod:`_tui_liveness`."""
         name = session_name_for(config)
         if not self._mux.exists(name):
             return False
-        activity = self._mux.session_activity(name)
-        if activity is None:
-            return False
-        return (time.time() - float(activity)) <= max_idle_s
+        return is_responsive_from_activity(
+            self._mux.session_activity(name), time.time(), max_idle_s
+        )
 
     def send_turn(
         self,

--- a/tests/scitex_agent_container/_runners/_tmux/test_tmux_pane_probe.py
+++ b/tests/scitex_agent_container/_runners/_tmux/test_tmux_pane_probe.py
@@ -1,0 +1,80 @@
+"""Real-binary tests for the tmux pane probes ``TmuxManager.pane_pid`` /
+``.pane_dead`` (``_runners/_tmux/_tmux_probe.py``).
+
+These back ``TuiSessionRuntime.is_running``'s IDENTITY-based liveness
+(card ``sac-fix-live-agents-read-stopped``): the pane's process pid is a
+namespace-robust liveness signal where the old ``session_activity``
+freshness gate falsely read a live-but-idle agent as "stopped".
+
+Fast hermetic branch (absent session → ``None``) always runs; the live
+success path spins a real ``tmux`` session and is skipped when tmux is
+not on PATH. No mocks — real ``subprocess.run`` against ``tmux`` itself.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import uuid
+
+import pytest
+
+from scitex_agent_container._runners._tmux.tmux import TmuxManager
+
+
+def test_pane_pid_returns_none_for_absent_session() -> None:
+    # Arrange — a session name guaranteed not to exist (uuid in name).
+    bogus = f"tui-test-absent-{uuid.uuid4().hex[:8]}"
+    # Act
+    result = TmuxManager.pane_pid(bogus)
+    # Assert
+    assert result is None
+
+
+def test_pane_dead_returns_none_for_absent_session() -> None:
+    # Arrange
+    bogus = f"tui-test-absent-{uuid.uuid4().hex[:8]}"
+    # Act
+    result = TmuxManager.pane_dead(bogus)
+    # Assert
+    assert result is None
+
+
+@pytest.mark.skipif(shutil.which("tmux") is None, reason="tmux binary not on PATH")
+def test_pane_pid_returns_live_pid_for_running_session() -> None:
+    # Arrange — spin a real detached session running a long sleep.
+    name = f"tui-test-probe-{uuid.uuid4().hex[:8]}"
+    subprocess.run(
+        ["tmux", "new-session", "-d", "-s", name, "sleep", "600"],
+        check=True,
+        capture_output=True,
+    )
+    try:
+        # Act
+        pid = TmuxManager.pane_pid(name)
+        # Assert — a concrete, positive pid for the live pane process.
+        assert isinstance(pid, int) and pid > 0
+    finally:
+        subprocess.run(
+            ["tmux", "kill-session", "-t", name], check=False, capture_output=True
+        )
+
+
+@pytest.mark.skipif(shutil.which("tmux") is None, reason="tmux binary not on PATH")
+def test_pane_dead_false_for_running_session() -> None:
+    # Arrange
+    name = f"tui-test-probe-{uuid.uuid4().hex[:8]}"
+    subprocess.run(
+        ["tmux", "new-session", "-d", "-s", name, "sleep", "600"],
+        check=True,
+        capture_output=True,
+    )
+    try:
+        # Act
+        dead = TmuxManager.pane_dead(name)
+        # Assert — the pane's process is running, so not dead.
+        assert dead is False
+    finally:
+        subprocess.run(
+            ["tmux", "kill-session", "-t", name], check=False, capture_output=True
+        )

--- a/tests/scitex_agent_container/runtimes/test__tui_liveness.py
+++ b/tests/scitex_agent_container/runtimes/test__tui_liveness.py
@@ -1,0 +1,176 @@
+"""Unit tests for the pure TUI liveness / responsiveness decisions
+(``runtimes/_tui_liveness.py``).
+
+Root cause these guard (card ``sac-fix-live-agents-read-stopped``): the
+old ``TuiSessionRuntime.is_running`` gated liveness on
+``session_activity`` freshness, so a live-but-idle agent read "stopped".
+``pane_process_alive`` is the identity-based replacement (session exists
+AND pane process alive); ``is_responsive_from_activity`` preserves the
+old activity-freshness rule as a separate hang-detection signal.
+
+STX-TQ002 AAA markers + one-assert. No mocks — collaborators are injected
+as plain callables (real Protocol impls), and ``pid_alive`` hits the real
+``os.kill`` syscall against the test process's own pid.
+"""
+
+from __future__ import annotations
+
+import os
+
+from scitex_agent_container.runtimes._tui_liveness import (
+    is_responsive_from_activity,
+    pane_process_alive,
+    pid_alive,
+)
+
+# A pid the OS will never have assigned to a live process during the test.
+_DEAD_PID = 2_147_483_646
+
+
+# ---------------------------------------------------------------------------
+# pid_alive
+# ---------------------------------------------------------------------------
+
+
+def test_pid_alive_true_for_own_process() -> None:
+    # Arrange
+    own_pid = os.getpid()
+    # Act
+    result = pid_alive(own_pid)
+    # Assert
+    assert result is True
+
+
+def test_pid_alive_false_for_dead_pid() -> None:
+    # Arrange
+    pid = _DEAD_PID
+    # Act
+    result = pid_alive(pid)
+    # Assert
+    assert result is False
+
+
+def test_pid_alive_false_for_zero() -> None:
+    # Arrange — pid 0 must NOT reach os.kill(0, 0) (that signals the
+    # caller's whole process group); it is not a real pane process.
+    pid = 0
+    # Act
+    result = pid_alive(pid)
+    # Assert
+    assert result is False
+
+
+def test_pid_alive_false_for_none() -> None:
+    # Arrange
+    pid = None
+    # Act
+    result = pid_alive(pid)
+    # Assert
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# pane_process_alive — LIVENESS
+# ---------------------------------------------------------------------------
+
+
+def test_pane_process_alive_false_when_session_absent() -> None:
+    # Arrange — exists_fn reports no session.
+    exists_fn = lambda _n: False  # noqa: E731
+    # Act
+    result = pane_process_alive(
+        "tui-x", exists_fn=exists_fn, pane_pid_fn=lambda _n: os.getpid()
+    )
+    # Assert
+    assert result is False
+
+
+def test_pane_process_alive_true_when_pane_pid_live() -> None:
+    # Arrange — session exists and its pane pid is the live test process.
+    pane_pid_fn = lambda _n: os.getpid()  # noqa: E731
+    # Act
+    result = pane_process_alive(
+        "tui-x", exists_fn=lambda _n: True, pane_pid_fn=pane_pid_fn
+    )
+    # Assert
+    assert result is True
+
+
+def test_pane_process_alive_false_when_pane_pid_dead() -> None:
+    # Arrange — session exists but the pane pid is a dead pid.
+    pane_pid_fn = lambda _n: _DEAD_PID  # noqa: E731
+    # Act
+    result = pane_process_alive(
+        "tui-x", exists_fn=lambda _n: True, pane_pid_fn=pane_pid_fn
+    )
+    # Assert
+    assert result is False
+
+
+def test_pane_process_alive_false_when_pane_dead_flag_true() -> None:
+    # Arrange — retained-dead pane (remain-on-exit) short-circuits to dead
+    # even though pane_pid would be a live pid.
+    pane_dead_fn = lambda _n: True  # noqa: E731
+    # Act
+    result = pane_process_alive(
+        "tui-x",
+        exists_fn=lambda _n: True,
+        pane_dead_fn=pane_dead_fn,
+        pane_pid_fn=lambda _n: os.getpid(),
+    )
+    # Assert
+    assert result is False
+
+
+def test_pane_process_alive_true_when_no_pid_probe_available() -> None:
+    # Arrange — legacy multiplexer without a pane_pid probe: session-exists
+    # is itself the liveness signal.
+    exists_fn = lambda _n: True  # noqa: E731
+    # Act
+    result = pane_process_alive("tui-x", exists_fn=exists_fn, pane_pid_fn=None)
+    # Assert
+    assert result is True
+
+
+def test_pane_process_alive_true_when_pid_probe_returns_none() -> None:
+    # Arrange — probe present but yields an unreadable pid → defer to
+    # session-exists (never a false "stopped").
+    pane_pid_fn = lambda _n: None  # noqa: E731
+    # Act
+    result = pane_process_alive(
+        "tui-x", exists_fn=lambda _n: True, pane_pid_fn=pane_pid_fn
+    )
+    # Assert
+    assert result is True
+
+
+# ---------------------------------------------------------------------------
+# is_responsive_from_activity — RESPONSIVENESS
+# ---------------------------------------------------------------------------
+
+
+def test_is_responsive_true_when_activity_within_window() -> None:
+    # Arrange — activity 10s ago, 300s window.
+    activity = 990.0
+    # Act
+    result = is_responsive_from_activity(activity, now=1000.0, max_idle_s=300.0)
+    # Assert
+    assert result is True
+
+
+def test_is_responsive_false_when_activity_stale() -> None:
+    # Arrange — activity 400s ago, 300s window.
+    activity = 600.0
+    # Act
+    result = is_responsive_from_activity(activity, now=1000.0, max_idle_s=300.0)
+    # Assert
+    assert result is False
+
+
+def test_is_responsive_false_when_activity_none() -> None:
+    # Arrange
+    activity = None
+    # Act
+    result = is_responsive_from_activity(activity, now=1000.0, max_idle_s=300.0)
+    # Assert
+    assert result is False

--- a/tests/scitex_agent_container/runtimes/test_tui_session.py
+++ b/tests/scitex_agent_container/runtimes/test_tui_session.py
@@ -12,6 +12,7 @@ STX-TQ002 AAA-marker + STX-TQ007 one-assert. No mocks.
 
 from __future__ import annotations
 
+import os
 import time
 from dataclasses import dataclass, field
 from typing import Iterator
@@ -37,10 +38,17 @@ class _MemorySession:
     workdir: str
     pane: list[str] = field(default_factory=list)
     # Unix-epoch timestamp of last simulated pane activity. The runtime's
-    # is_running probe (step 4/4) reads session_activity to gate on a
-    # "responsive" window; tests that want to simulate a stale session
-    # mutate this field directly to back-date the stamp.
+    # is_responsive probe reads session_activity to gate on a "moving"
+    # window; tests that want to simulate a stale session mutate this
+    # field directly to back-date the stamp.
     activity_at: float = 0.0
+    # Identity liveness signals the runtime's is_running probe reads:
+    # ``pane_pid`` is the pane's process (a live pid by default so a
+    # started-but-idle session reads "running"); tests that simulate a
+    # dead pane set ``pane_pid`` to a guaranteed-dead pid or ``pane_dead``
+    # to True.
+    pane_pid: int = 0
+    pane_dead: bool = False
 
 
 class _MemoryMultiplexer:
@@ -84,6 +92,10 @@ class _MemoryMultiplexer:
             command=command,
             workdir=workdir,
             activity_at=time.time(),
+            # Default to the test process's own pid — a guaranteed-live
+            # pid — so a freshly started session reads "running" via the
+            # identity-based liveness probe (os.kill(pane_pid, 0)).
+            pane_pid=os.getpid(),
         )
         return True
 
@@ -166,6 +178,29 @@ class _MemoryMultiplexer:
         if sess is None:
             return None
         return int(sess.activity_at)
+
+    @classmethod
+    def pane_pid(cls, session_name: str) -> int | None:
+        """Identity liveness signal: PID of the process in the pane, or
+        ``None`` when no such session exists. Mirrors the real
+        ``TmuxManager.pane_pid`` contract so the runtime's ``is_running``
+        liveness probe is exercised end-to-end without tmux.
+        """
+        sess = cls._sessions.get(session_name)
+        if sess is None:
+            return None
+        return sess.pane_pid
+
+    @classmethod
+    def pane_dead(cls, session_name: str) -> bool | None:
+        """Whether the pane's process exited but the pane is retained, or
+        ``None`` when no such session exists. Mirrors
+        ``TmuxManager.pane_dead``.
+        """
+        sess = cls._sessions.get(session_name)
+        if sess is None:
+            return None
+        return sess.pane_dead
 
 
 @dataclass
@@ -428,7 +463,7 @@ def test_tui_runtime_stop_returns_false_when_no_session(
 
 
 # ---------------------------------------------------------------------------
-# is_running — proxy for session existence (risk-2 deferred)
+# is_running — IDENTITY-BASED liveness (session exists AND pane alive)
 # ---------------------------------------------------------------------------
 
 
@@ -457,59 +492,135 @@ def test_tui_runtime_is_running_false_when_session_absent(
     assert alive is False
 
 
-# ---------------------------------------------------------------------------
-# is_running — step 4 pane-activity probe semantics
-# ---------------------------------------------------------------------------
-
-
-def test_tui_runtime_is_running_false_when_activity_stale_beyond_window(
+def test_tui_runtime_is_running_true_when_idle_but_pane_alive(
     mux: type[_MemoryMultiplexer],
 ) -> None:
-    # Arrange — start session, then back-date activity beyond default window.
+    # REGRESSION (card sac-fix-live-agents-read-stopped): a live-but-quiet
+    # agent — no pane I/O for hours, so session_activity is far stale —
+    # must still read RUNNING because its pane process is alive. The old
+    # activity-freshness gate wrongly flipped this to "stopped".
+    # Arrange — start, then back-date activity beyond any max-idle window.
     runtime = TuiSessionRuntime(multiplexer=mux, command_builder=_fake_builder)
-    config = _Config(name="nu-stale")
+    config = _Config(name="nu-idle")
     runtime.start(config)
-    mux._sessions["tui-nu-stale"].activity_at = time.time() - 9_999.0
+    mux._sessions["tui-nu-idle"].activity_at = time.time() - 99_999.0
     # Act
     alive = runtime.is_running(config)
-    # Assert — pane went silent past default max-idle: probe flips False.
+    # Assert — pane pid is live ⇒ running, regardless of stale activity.
+    assert alive is True
+
+
+def test_tui_runtime_is_running_false_when_pane_process_dead(
+    mux: type[_MemoryMultiplexer],
+) -> None:
+    # Arrange — session exists but its pane pid is a guaranteed-dead pid.
+    runtime = TuiSessionRuntime(multiplexer=mux, command_builder=_fake_builder)
+    config = _Config(name="omicron-dead")
+    runtime.start(config)
+    mux._sessions["tui-omicron-dead"].pane_pid = 2_147_483_646  # never a live pid
+    # Act
+    alive = runtime.is_running(config)
+    # Assert
     assert alive is False
 
 
-def test_tui_runtime_is_running_respects_max_idle_s_override(
+def test_tui_runtime_is_running_false_when_pane_dead_flag_set(
+    mux: type[_MemoryMultiplexer],
+) -> None:
+    # Arrange — a retained-dead pane (remain-on-exit) reads stopped even
+    # though the session still exists and pane_pid is a live pid.
+    runtime = TuiSessionRuntime(multiplexer=mux, command_builder=_fake_builder)
+    config = _Config(name="pi-retained")
+    runtime.start(config)
+    mux._sessions["tui-pi-retained"].pane_dead = True
+    # Act
+    alive = runtime.is_running(config)
+    # Assert
+    assert alive is False
+
+
+def test_tui_runtime_is_running_true_when_mux_lacks_pane_pid_probe(
+    mux: type[_MemoryMultiplexer],
+) -> None:
+    # Arrange — a legacy multiplexer that predates the pane-pid probe
+    # (no pane_pid / pane_dead attrs) falls back to session-exists =
+    # alive, so an existing session still reads "running".
+    class _LegacyMux(mux):  # type: ignore[valid-type, misc]
+        pane_pid = None  # type: ignore[assignment]
+        pane_dead = None  # type: ignore[assignment]
+
+    runtime = TuiSessionRuntime(multiplexer=_LegacyMux, command_builder=_fake_builder)
+    config = _Config(name="rho-legacy")
+    runtime.start(config)
+    # Act
+    alive = runtime.is_running(config)
+    # Assert
+    assert alive is True
+
+
+# ---------------------------------------------------------------------------
+# is_responsive — the preserved activity-freshness (hang-detection) signal
+# ---------------------------------------------------------------------------
+
+
+def test_tui_runtime_is_responsive_true_when_activity_fresh(
+    mux: type[_MemoryMultiplexer],
+) -> None:
+    # Arrange
+    runtime = TuiSessionRuntime(multiplexer=mux, command_builder=_fake_builder)
+    config = _Config(name="sigma-fresh")
+    runtime.start(config)
+    # Act
+    responsive = runtime.is_responsive(config)
+    # Assert
+    assert responsive is True
+
+
+def test_tui_runtime_is_responsive_false_when_activity_stale_beyond_window(
+    mux: type[_MemoryMultiplexer],
+) -> None:
+    # Arrange — back-date activity beyond the default max-idle window.
+    runtime = TuiSessionRuntime(multiplexer=mux, command_builder=_fake_builder)
+    config = _Config(name="tau-stale")
+    runtime.start(config)
+    mux._sessions["tui-tau-stale"].activity_at = time.time() - 9_999.0
+    # Act
+    responsive = runtime.is_responsive(config)
+    # Assert — pane silent past max-idle: responsiveness flips False.
+    assert responsive is False
+
+
+def test_tui_runtime_is_responsive_respects_max_idle_s_override(
     mux: type[_MemoryMultiplexer],
 ) -> None:
     # Arrange — back-date activity 100s; tighten window to 50s.
     runtime = TuiSessionRuntime(multiplexer=mux, command_builder=_fake_builder)
-    config = _Config(name="xi-tight")
+    config = _Config(name="upsilon-tight")
     runtime.start(config)
-    mux._sessions["tui-xi-tight"].activity_at = time.time() - 100.0
+    mux._sessions["tui-upsilon-tight"].activity_at = time.time() - 100.0
     # Act
-    alive = runtime.is_running(config, max_idle_s=50.0)
-    # Assert — tighter window means the same stamp is now stale.
-    assert alive is False
+    responsive = runtime.is_responsive(config, max_idle_s=50.0)
+    # Assert
+    assert responsive is False
 
 
-def test_tui_runtime_is_running_false_when_session_activity_unavailable(
+def test_tui_runtime_is_responsive_false_when_session_activity_unavailable(
     mux: type[_MemoryMultiplexer],
 ) -> None:
-    # Arrange — a legacy multiplexer fake that lacks session_activity
-    # (returns None) must NOT be silently treated as "alive". The probe
-    # has to fail loud to "not responsive" so the supervisor restarts.
+    # Arrange — a multiplexer whose session_activity returns None must not
+    # be treated as responsive (the hang-detection signal fails loud).
     runtime = TuiSessionRuntime(multiplexer=mux, command_builder=_fake_builder)
-    config = _Config(name="omicron-legacy")
+    config = _Config(name="phi-noactivity")
     runtime.start(config)
 
-    # Monkey-patch the activity probe to return None for this test only,
-    # simulating a multiplexer impl that doesn't expose session_activity.
     def _no_activity(_name: str) -> int | None:
         return None
 
     mux.session_activity = staticmethod(_no_activity)  # type: ignore[method-assign]
     # Act
-    alive = runtime.is_running(config)
+    responsive = runtime.is_responsive(config)
     # Assert
-    assert alive is False
+    assert responsive is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem (card `sac-fix-live-agents-read-stopped`, P2 — reproduced 2026-07-08)

`sac agents list` / `agent_status` reported RUNNING agents as **stopped** for EVERY `runtime: tui` agent — including `scitex-agent-container` itself while actively running (live PID + a2a port).

## Root cause (empirically traced, not code-read)

`TuiSessionRuntime.is_running` gated liveness on tmux `#{session_activity}` **freshness** (pane I/O within a 300s max-idle window). tmux advances that stamp only on pane output OR input, so a **live-but-quiet** agent sitting at its input prompt froze it — every such agent read "stopped" minutes after its last visible output.

Evidence on the host for the provably-live, tmux-attached `tui-scitex-agent-container`:
- `session_activity` = **12875s (~3.5h) stale** → old gate: `(now - activity) > 300` ⇒ False ⇒ "stopped".
- but `pane_pid` = **1679567**, `kill -0` ⇒ **ALIVE**, `pane_dead` = 0 (the live `apptainer exec … claude`).

Liveness and responsiveness were conflated in one method.

## Fix — separate the two

- **`is_running` → IDENTITY-based LIVENESS**: `tui-<name>` session exists AND its pane process is alive via `os.kill(pane_pid, 0)` (namespace-robust — sees a live pid where `ps -p <pid>` returns empty on this host). No activity gate; an idle agent is still running. `pid 0` / unreadable pid defers to session-exists (never a false "stopped"); a retained-dead pane (`#{pane_dead}`) reads stopped.
- **New `is_responsive`** keeps the old activity-freshness rule as an explicit hang-detection signal.
- **New `TmuxManager.pane_pid` / `.pane_dead`** probes (extracted with `session_activity` to `_tmux_probe.py`, keeping `tmux.py` under the 512-line cap).
- Pure decisions extracted to `runtimes/_tui_liveness.py` (unit-tested).

**Verified end-to-end on the host**: with this branch's code, the live `tui-scitex-agent-container` now yields `is_running=True` (old activity-gate returned False).

## Tests
- Core: `test__tui_liveness.py` + `test_tui_session.py` + `test_tmux_pane_probe.py` → **56 passed** (incl. real-`tmux` `pane_pid`/`pane_dead`; the reproduction case: stale-activity + live pane ⇒ running).
- Regression on modified areas (`_runners/_tmux/` + `cli_pkg/_helpers/`, incl. `test__agent_list.py`) → **126 passed**. Full `runtimes/` + `_runners/` + `_lifecycle/` suite green.

## Deferred (genuinely separate — do NOT touch the `is_running` derivation)
Confirmed neither feeds the list/status status column:
- (a) stale `STARTUP_FAILED` marker reconcile vs live heartbeat.
- (b) symlink-path `realpath` normalize for heartbeat `state_dir`.