### PR TITLE
feat(accounts): refresh all snapshots + sync active ~/.claude login (fix rotation-strands-fleet)

### DIFF
--- a/src/scitex_agent_container/_account/active_login_write.py
+++ b/src/scitex_agent_container/_account/active_login_write.py
@@ -1,0 +1,269 @@
+"""Push a freshly-rotated token block into the operator's LIVE ``~/.claude`` login.
+
+This is the REVERSE of :mod:`_account.creds_sync` (which snapshots the
+live credential INTO a per-account store). Here, after the refresher
+rotates the SNAPSHOT of the account whose ``refreshToken`` matches the
+active ``~/.claude`` login, the live file still holds the now-invalidated
+(rotated) ``refreshToken`` — the very next live refresh would then 401 and
+strand the operator's session. This module copies the three freshly-minted
+token fields (``accessToken`` / ``refreshToken`` / ``expiresAt``) from the
+rotated snapshot into ``~/.claude/.credentials.json`` so the live session
+is never stranded by a rotation.
+
+Only ever call this with a snapshot whose PRE-refresh ``refreshToken``
+equalled the live login's ``refreshToken`` (the "active family") — the
+caller establishes that equality; this module does not cross accounts.
+
+Safety contract (the live login is IRREPLACEABLE — corruption is
+catastrophic, so every write is defended):
+
+1. back up the existing live file to a sibling ``.bak`` before writing;
+2. write to a ``.tmp`` then atomically :func:`os.replace` it into place;
+3. re-open the written file and VERIFY it parses as JSON and the three
+   token fields are present + non-empty; on ANY verification failure,
+   RESTORE from the ``.bak`` and raise :class:`ActiveLoginSyncError`.
+
+The existing live JSON structure is preserved byte-for-byte except the
+three mutated token fields (mutated inside the ``claudeAiOauth`` block, or
+at the document root when the file is stored unwrapped).
+
+Token VALUES are never printed, logged, or returned.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+from pathlib import Path
+from typing import Any, Callable
+
+_TOKEN_FIELDS = ("accessToken", "refreshToken", "expiresAt")
+
+
+def _default_serialize(data: dict[str, Any]) -> str:
+    """Serialize the mutated live document to text (the production writer).
+
+    Kept as a module-level function (not an inline lambda) so it is a
+    swappable production boundary: a test can replace this attribute to
+    simulate a corrupt write and exercise the verify-or-restore path
+    end-to-end through the CLI — the same swap-the-boundary convention the
+    suite uses for ``urllib.request.urlopen``.
+    """
+    return json.dumps(data, indent=2)
+
+
+class ActiveLoginSyncError(RuntimeError):
+    """Raised when the live ``~/.claude`` write fails post-write verification.
+
+    By the time this is raised the original file has already been RESTORED
+    from the ``.bak`` backup, so the live login is intact — the exception
+    exists to fail the run loudly (non-zero exit) so the operator knows the
+    sync did not take, without ever exposing a token value in its message.
+    """
+
+
+def _oauth_block(data: Any) -> dict[str, Any] | None:
+    """Return the dict that HOLDS the token fields, or ``None``.
+
+    Prefers the wrapped ``claudeAiOauth`` object (the shape Claude Code
+    writes); falls back to the document root when the file is stored
+    unwrapped (root already carries ``accessToken``). Never raises.
+    """
+    if not isinstance(data, dict):
+        return None
+    inner = data.get("claudeAiOauth")
+    if isinstance(inner, dict):
+        return inner
+    if "accessToken" in data:
+        return data
+    return None
+
+
+def read_refresh_token(path: Path) -> str | None:
+    """Return the ``refreshToken`` stored at ``path``, or ``None``.
+
+    Reads ``claudeAiOauth.refreshToken`` (or the root ``refreshToken`` for
+    an unwrapped file). ``None`` when the file is missing, unparseable, or
+    lacks a non-empty refresh token. The value is used ONLY for opaque
+    equality comparison by the caller — never printed. Never raises.
+    """
+    # stx-allow: fallback (reason: a missing / mid-rewrite credential file
+    # must read as "no token" (None) so the active-family match simply
+    # finds no match, never crashes the refresher.)
+    try:
+        data = json.loads(Path(path).read_text(encoding="utf-8"))
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        return None
+    block = _oauth_block(data)
+    if block is None:
+        return None
+    tok = block.get("refreshToken")
+    return tok if isinstance(tok, str) and tok.strip() else None
+
+
+def _read_token_fields(path: Path) -> tuple[str | None, str | None, int | None]:
+    """Return ``(accessToken, refreshToken, expiresAt)`` from ``path``.
+
+    ``expiresAt`` is the raw millisecond-epoch integer (or ``None``).
+    Never raises.
+    """
+    # stx-allow: fallback (reason: the freshly-written snapshot is read back
+    # to lift its rotated tokens; an unreadable snapshot maps to all-None so
+    # the caller aborts the sync loudly instead of crashing.)
+    try:
+        data = json.loads(Path(path).read_text(encoding="utf-8"))
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        return None, None, None
+    block = _oauth_block(data)
+    if block is None:
+        return None, None, None
+    access = block.get("accessToken")
+    refresh = block.get("refreshToken")
+    expires = block.get("expiresAt")
+    return (
+        access if isinstance(access, str) else None,
+        refresh if isinstance(refresh, str) else None,
+        expires if isinstance(expires, int) and not isinstance(expires, bool) else None,
+    )
+
+
+def _block_is_valid(block: Any) -> bool:
+    """True iff ``block`` carries all three token fields, present + non-empty."""
+    if not isinstance(block, dict):
+        return False
+    access = block.get("accessToken")
+    refresh = block.get("refreshToken")
+    expires = block.get("expiresAt")
+    if not (isinstance(access, str) and access.strip()):
+        return False
+    if not (isinstance(refresh, str) and refresh.strip()):
+        return False
+    if isinstance(expires, bool) or not isinstance(expires, (int, float)):
+        return False
+    return expires > 0
+
+
+def sync_active_login(
+    live_path: Path,
+    snapshot_path: Path,
+    *,
+    serialize: Callable[[dict[str, Any]], str] | None = None,
+) -> dict[str, Any]:
+    """Copy the rotated token block from ``snapshot_path`` into ``live_path``.
+
+    ``live_path`` is the operator's live ``~/.claude/.credentials.json``;
+    ``snapshot_path`` is the just-refreshed per-account snapshot whose
+    pre-refresh ``refreshToken`` matched the live login (the caller
+    establishes that equality). Only the three token fields are mutated;
+    every other key in the live file is preserved.
+
+    Follows the backup → atomic-replace → verify-or-restore contract in the
+    module docstring. Returns a small status dict (never containing token
+    values); raises :class:`ActiveLoginSyncError` when the post-write
+    verification fails (after restoring the original from ``.bak``).
+
+    Args:
+        live_path: the live ``~/.claude/.credentials.json`` (resolved by
+            the caller; symlinks are followed on read/write).
+        snapshot_path: the freshly-rotated per-account snapshot.
+        serialize: injection seam for tests — serializes the mutated live
+            document to text. Defaults to pretty ``json.dumps``. A test can
+            pass a serializer that returns malformed / field-stripped text
+            to exercise the verify-or-restore path.
+
+    Returns:
+        ``{"synced": True, "live_path": <str>}`` on success.
+
+    Raises:
+        ActiveLoginSyncError: the snapshot lacked fresh tokens, the live
+            file was unreadable, or the post-write verification failed
+            (the original is restored from ``.bak`` first).
+    """
+    live = Path(live_path)
+    snap = Path(snapshot_path)
+    _serialize = serialize if serialize is not None else _default_serialize
+
+    access, refresh, expires_ms = _read_token_fields(snap)
+    if not access or not refresh:
+        raise ActiveLoginSyncError(
+            f"refusing to sync active login: snapshot {snap!s} lacks a fresh "
+            "access/refresh token after refresh"
+        )
+
+    if not live.is_file():
+        raise ActiveLoginSyncError(
+            f"refusing to sync active login: live file not found at {live!s}"
+        )
+
+    # Read the ORIGINAL bytes once — this is both the structure we preserve
+    # and the exact content we restore on verification failure.
+    original_text = live.read_text(encoding="utf-8")
+    try:
+        live_data = json.loads(original_text)
+    except Exception as exc:  # stx-allow: fallback (reason: a corrupt live file is a hard, loud error — never overwrite it blindly)
+        raise ActiveLoginSyncError(
+            f"refusing to sync active login: live file {live!s} is not valid "
+            f"JSON ({exc.__class__.__name__}); leaving it untouched"
+        ) from exc
+
+    block = _oauth_block(live_data)
+    if block is None:
+        raise ActiveLoginSyncError(
+            f"refusing to sync active login: live file {live!s} has no "
+            "recognisable OAuth token block"
+        )
+
+    # Mutate ONLY the three token fields, preserving every other key.
+    block["accessToken"] = access
+    block["refreshToken"] = refresh
+    if expires_ms is not None:
+        block["expiresAt"] = expires_ms
+
+    bak = Path(str(live) + ".bak")
+    tmp = Path(str(live) + ".tmp")
+
+    # (a) back up the existing file BEFORE writing.
+    shutil.copyfile(live, bak)
+    # stx-allow: fallback (reason: chmod is best-effort hardening of the
+    # backup copy; a filesystem that rejects it must not abort the sync.)
+    try:
+        os.chmod(bak, 0o600)
+    except OSError:  # stx-allow: fallback (reason: see inline comment)
+        pass
+
+    # (b) write to .tmp then atomically replace.
+    tmp.write_text(_serialize(live_data), encoding="utf-8")
+    # stx-allow: fallback (reason: chmod is best-effort hardening; the
+    # atomic replace below is what matters for correctness.)
+    try:
+        os.chmod(tmp, 0o600)
+    except OSError:  # stx-allow: fallback (reason: see inline comment)
+        pass
+    os.replace(tmp, live)
+
+    # (c) verify-or-restore.
+    verified = False
+    # stx-allow: fallback (reason: ANY failure to re-read/parse the written
+    # file counts as a failed verification and triggers the restore below;
+    # we never leave a possibly-corrupt live login in place.)
+    try:
+        written = json.loads(live.read_text(encoding="utf-8"))
+        verified = _block_is_valid(_oauth_block(written))
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        verified = False
+
+    if not verified:
+        # Restore the operator's original login from the backup, then fail
+        # loud. The restore is itself atomic (copy to .tmp + replace).
+        shutil.copyfile(bak, tmp)
+        os.replace(tmp, live)
+        raise ActiveLoginSyncError(
+            f"active-login write to {live!s} FAILED verification; restored "
+            "the original from .bak. The live login was NOT changed."
+        )
+
+    return {"synced": True, "live_path": str(live)}
+
+
+__all__ = ["ActiveLoginSyncError", "read_refresh_token", "sync_active_login"]

--- a/src/scitex_agent_container/cli_pkg/_account_refresh.py
+++ b/src/scitex_agent_container/cli_pkg/_account_refresh.py
@@ -14,135 +14,13 @@ per-account credentials file — eliminating routine manual ``claude
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
 
 import click
 
-
-def _resolve_active_account_name(
-    home: Path, accounts: list[dict[str, Any]]
-) -> str | None:
-    """Return the stored-account NAME whose identity matches the live login.
-
-    The active account is the one currently logged in under ``~/.claude/``
-    — identified by the email surfaced in ``~/.claude.json``
-    (``oauthAccount.emailAddress``), the same field ``sac accounts list``
-    and ``sac accounts sync-live`` key off. We compare that email against
-    each stored account's ``email_address`` (saved into ``account.json`` by
-    ``sac accounts save`` / auto-sync), case-insensitively.
-
-    Returns the matching stored name, or ``None`` when no active email can
-    be resolved (no live login, malformed file) or when no stored account
-    carries that email — in which case the caller skips nothing and logs
-    it. Never raises.
-    """
-    # stx-allow: fallback (reason: active-account resolution is a
-    # best-effort guard for --skip-active; any read/parse failure maps to
-    # "cannot resolve" so refresh proceeds without skipping, never crashes.)
-    try:
-        from .._account.credentials import read_credentials_metadata
-
-        active = read_credentials_metadata(home=home)
-    except Exception:  # stx-allow: fallback (reason: see inline comment)
-        return None
-    active_email = active.get("email_address")
-    if not isinstance(active_email, str) or not active_email.strip():
-        return None
-    active_email_norm = active_email.strip().lower()
-    for acct in accounts:
-        stored_email = acct.get("email_address")
-        if (
-            isinstance(stored_email, str)
-            and stored_email.strip().lower() == active_email_norm
-        ):
-            name = acct.get("name")
-            return name if isinstance(name, str) else None
-    return None
-
-
-def _resolve_registry_dir(home: Path) -> Path:
-    """Resolve the file-based agent registry directory.
-
-    Mirrors the ``Registry`` class's path-resolution rule (honors
-    ``SCITEX_AGENT_CONTAINER_REGISTRY_DIR``, else
-    ``<home>/.scitex/agent-container/runtime/registry``), but READ per
-    call rather than frozen at module-import time. The freeze on
-    ``Registry`` is fine in production (HOME doesn't change) but is
-    brittle under pytest where the sandbox HOME is set after the test
-    process started.
-    """
-    import os
-
-    env_override = os.environ.get("SCITEX_AGENT_CONTAINER_REGISTRY_DIR")
-    if env_override:
-        return Path(env_override)
-    return home / ".scitex" / "agent-container" / "runtime" / "registry"
-
-
-def _collect_pinned_running_accounts(home: Path | None = None) -> set[str]:
-    """Return stored-account NAMES currently pinned by running local agents.
-
-    Closes the refresh-token rotation race: when an agent is spawned with
-    ``spec.claude.account: <name>``, its in-container Claude CLI refreshes
-    that account's token through the live :rw dir-bind on the snapshot.
-    If the host ``sac accounts refresh --all --skip-active`` cron ALSO
-    refreshes the same account every 2h, the two refreshers rotate each
-    other's refresh_token (OAuth refresh-tokens invalidate on use) and
-    whichever raced last leaves the other with a now-invalid token —
-    next API call hits 401.
-
-    This helper enumerates the local file-based agent registry (the same
-    JSON files ``sac status`` reads, written by ``_lifecycle/_start`` at
-    spawn time), loads each entry's ``config`` spec, and extracts
-    ``spec.claude.account`` when set. The caller unions the result with
-    the host-active account into a single skip-set so the cron never
-    refreshes a token currently in use by a running agent.
-
-    Cross-host scope: only LOCAL running agents matter — the cron runs
-    against the LOCAL snapshot store, and agents on other hosts have
-    their own local snapshot stores (and their own refresher cron).
-
-    Stale-registry tolerance: a registry entry left behind by a crashed
-    agent will over-skip its account (the cron won't refresh it until
-    the stale entry is cleaned via ``Registry.cleanup_stale``). The
-    failure mode is safe: under-refresh, eventually requiring manual
-    ``sac accounts refresh <name>``. The opposite (over-refresh racing
-    a live agent) is the bug we're fixing.
-
-    Tolerant: any registry / spec read failure is mapped to "this entry
-    contributes nothing" so refresh proceeds against the rest of the
-    set rather than crashing on one bad row.
-    """
-    import json as _json
-
-    home = home if home is not None else Path.home()
-    reg_dir = _resolve_registry_dir(home)
-    pinned: set[str] = set()
-    if not reg_dir.is_dir():
-        return pinned
-    # stx-allow: fallback (reason: skip-set construction is best-effort;
-    # any registry / spec read failure maps to "skip nothing extra" so
-    # refresh proceeds against the remaining accounts.)
-    try:
-        from ..config import load_config
-    except Exception:  # stx-allow: fallback (reason: see inline comment)
-        return pinned
-    for entry_path in sorted(reg_dir.glob("*.json")):
-        try:
-            entry = _json.loads(entry_path.read_text())
-        except Exception:  # stx-allow: fallback (reason: see inline comment)
-            continue
-        cfg_path = entry.get("config") if isinstance(entry, dict) else None
-        if not isinstance(cfg_path, str) or not cfg_path:
-            continue
-        try:
-            cfg = load_config(Path(cfg_path))
-        except Exception:  # stx-allow: fallback (reason: see inline comment)
-            continue
-        acct = getattr(getattr(cfg, "claude", None), "account", "") or ""
-        if isinstance(acct, str) and acct.strip():
-            pinned.add(acct.strip())
-    return pinned
+from ._account_refresh_skip import (
+    _collect_pinned_running_accounts,
+    _resolve_active_account_name,
+)
 
 
 @click.command("refresh")
@@ -180,6 +58,43 @@ def _collect_pinned_running_accounts(home: Path | None = None) -> set[str]:
     ),
 )
 @click.option(
+    "--min-ttl-hours",
+    "min_ttl_hours",
+    type=float,
+    default=2.0,
+    show_default=True,
+    help=(
+        "With --all, refresh a snapshot ONLY when its access token has less "
+        "than this many hours of life remaining (a token with unknown/absent "
+        "expiry is always refreshed). Fresh tokens are left untouched — this "
+        "is the daemon's rotate-only-when-stale gate, which also avoids "
+        "needlessly rotating a single-use refresh_token. Ignored for a "
+        "single named account (an explicit request always refreshes)."
+    ),
+)
+@click.option(
+    "--force",
+    "force",
+    is_flag=True,
+    default=False,
+    help="With --all, ignore --min-ttl-hours and refresh every account.",
+)
+@click.option(
+    "--sync-active-login",
+    "sync_active_login_flag",
+    is_flag=True,
+    default=False,
+    help=(
+        "After refreshing the account whose snapshot refresh_token matches "
+        "the live ~/.claude login, ALSO write the freshly-rotated token block "
+        "into ~/.claude/.credentials.json so the operator's live session is "
+        "never stranded by the rotation (single-use refresh_token). The write "
+        "is defended: backup -> atomic replace -> verify-or-restore. This is "
+        "the flag the host-side refresher timer passes. Mutually exclusive "
+        "with --skip-active."
+    ),
+)
+@click.option(
     "--json",
     "as_json",
     is_flag=True,
@@ -191,6 +106,9 @@ def account_refresh(
     do_all: bool,
     skip_active: bool,
     include_active: bool,
+    min_ttl_hours: float,
+    force: bool,
+    sync_active_login_flag: bool,
     as_json: bool,
 ) -> None:
     """Mint a fresh access_token from the stored refresh_token, headlessly.
@@ -216,17 +134,38 @@ def account_refresh(
     agents die when its access_token expires. The timer's ExecStart uses
     this flag. Mutually exclusive with ``--skip-active``.
 
+    ``--min-ttl-hours`` (with --all) makes the refresh a rotate-only-when-
+    stale gate: an account whose snapshot access token still has more than
+    the threshold left is skipped (no network call, no refresh_token
+    rotation), a token with unknown/absent expiry is always refreshed. A
+    single named account ignores the gate (an explicit request always
+    refreshes). ``--force`` bypasses the gate under --all.
+
+    ``--sync-active-login`` (with --all) additionally keeps the operator's
+    live ``~/.claude/.credentials.json`` in sync: before refreshing, the
+    account whose snapshot refresh_token EQUALS the live login's is
+    identified (equality only — the value is never printed); when THAT
+    account is refreshed, its freshly-rotated token block is also written
+    into the live file (backup -> atomic replace -> verify-or-restore) so a
+    single-use refresh_token rotation never strands the live session.
+
     \b
     Examples:
       $ sac accounts refresh work
       $ sac accounts refresh --all
       $ sac accounts refresh --all --skip-active
-      $ sac accounts refresh --all --include-active   # timer mode
+      $ sac accounts refresh --all --include-active   # legacy timer mode
+      $ sac accounts refresh --all --sync-active-login  # daemon mode
       $ sac accounts refresh --all --json
     """
     import json as _json
 
     from .._account._rotation_audit import fingerprint_token, log_rotation_event
+    from .._account.active_login_write import (
+        ActiveLoginSyncError,
+        read_refresh_token,
+        sync_active_login,
+    )
     from .._account.claude_usage import _read_tokens_at, refresh_account_credentials
     from .._state.account_store import _store_path, list_accounts
 
@@ -244,6 +183,14 @@ def account_refresh(
         click.echo(
             "error: --skip-active and --include-active are mutually "
             "exclusive (one skips the active account, the other forces it in)",
+            err=True,
+        )
+        raise SystemExit(2)
+    if sync_active_login_flag and skip_active:
+        click.echo(
+            "error: --sync-active-login and --skip-active are mutually "
+            "exclusive (syncing the live login requires refreshing the active "
+            "account, which --skip-active excludes)",
             err=True,
         )
         raise SystemExit(2)
@@ -289,11 +236,77 @@ def account_refresh(
     else:
         targets = [name]  # type: ignore[list-item]
 
+    # Active-login family detection (for --sync-active-login). Read the live
+    # ~/.claude login's refresh_token ONCE (realpath, symlinks followed) and
+    # find the target account whose snapshot refresh_token EQUALS it —
+    # equality only, the value is never printed. That is the SOLE account
+    # whose rotation may be mirrored into the live login (never cross-account).
+    live_path = (home / ".claude" / ".credentials.json").resolve()
+    active_family: str | None = None
+    if sync_active_login_flag:
+        live_refresh = read_refresh_token(live_path)
+        if live_refresh:
+            for t in targets:
+                snap_refresh = read_refresh_token(store / t / ".credentials.json")
+                if snap_refresh is not None and snap_refresh == live_refresh:
+                    active_family = t
+                    break
+        if active_family is not None:
+            click.echo(
+                f"[sync-active-login] live ~/.claude login matches account "
+                f"'{active_family}'; its rotation will be mirrored into the "
+                "live login.",
+                err=True,
+            )
+        else:
+            click.echo(
+                "[sync-active-login] no stored account matches the live "
+                "~/.claude login (or no live login); nothing to mirror.",
+                err=True,
+            )
+
+    import time as _time
+    from datetime import datetime as _dt
+    from datetime import timezone as _tz
+
+    def _needs_refresh(expires_ms: int | None) -> bool:
+        """Rotate-only-when-stale gate. A single named account or --force
+        always refreshes; under --all a token with more than
+        ``min_ttl_hours`` left is left untouched (unknown expiry -> refresh)."""
+        if force or not do_all:
+            return True
+        if expires_ms is None:
+            return True
+        hours_left = (expires_ms / 1000.0 - _time.time()) / 3600.0
+        return hours_left < min_ttl_hours
+
+    def _iso_ms(expires_ms: int | None) -> str | None:
+        if not isinstance(expires_ms, int):
+            return None
+        return _dt.fromtimestamp(expires_ms / 1000, tz=_tz).isoformat()
+
     results: list[dict] = []
+    sync_failed = False
     for acct_name in targets:
         creds_path = store / acct_name / ".credentials.json"
-        # OUTGOING token fingerprint (before the refresh POST rotates it).
-        old_access, old_refresh, _, _ = _read_tokens_at(creds_path)
+        # OUTGOING token fingerprint + expiry (before the refresh rotates it).
+        old_access, old_refresh, _, old_expires = _read_tokens_at(creds_path)
+
+        # Rotate-only-when-stale gate: leave a still-fresh snapshot untouched
+        # so a single-use refresh_token is never needlessly rotated.
+        if not _needs_refresh(old_expires):
+            results.append(
+                {
+                    "name": acct_name,
+                    "success": None,
+                    "skipped": True,
+                    "expires_at": _iso_ms(old_expires),
+                    "error": None,
+                    "credentials_path": str(creds_path),
+                }
+            )
+            continue
+
         # stx-allow: fallback (reason: refresh_account_credentials is documented never-raise, but defence-in-depth so one bad row never crashes --all)
         try:
             r = refresh_account_credentials(creds_path)
@@ -305,6 +318,7 @@ def account_refresh(
                 "credentials_path": str(creds_path),
             }
         r["name"] = acct_name
+        r["skipped"] = False
         results.append(r)
 
         # Rotation audit: a successful refresh IS a single-use refresh_token
@@ -323,13 +337,42 @@ def account_refresh(
                 refresh_token_fp=fingerprint_token(new_refresh or old_refresh),
             )
 
+            # Active-login mirror: ONLY the matched active-family account, and
+            # ONLY after its snapshot rotated. The freshly-minted token block
+            # is copied into the live ~/.claude login under the
+            # backup -> atomic replace -> verify-or-restore contract. A
+            # verification failure restores the original and fails the run.
+            if sync_active_login_flag and acct_name == active_family:
+                # stx-allow: fallback (reason: ActiveLoginSyncError is the ONLY expected failure — it has already restored the live file from .bak; we record it, fail the run loud, and never crash mid-loop.)
+                try:
+                    sync_active_login(live_path, creds_path)
+                    r["synced_live_login"] = True
+                    click.echo(
+                        f"  [sync-active-login] mirrored '{acct_name}' rotation "
+                        "into the live ~/.claude login.",
+                        err=True,
+                    )
+                except ActiveLoginSyncError as exc:  # stx-allow: fallback (reason: see inline comment)
+                    sync_failed = True
+                    r["synced_live_login"] = False
+                    r["sync_error"] = str(exc)
+                    click.echo(
+                        f"  [sync-active-login] FAILED for '{acct_name}': {exc}",
+                        err=True,
+                    )
+
     if as_json:
         click.echo(_json.dumps(results, ensure_ascii=False, indent=2))
     else:
         if not results:
             click.echo("No accounts stored. Use: sac accounts save <name>")
         for r in results:
-            if r["success"]:
+            if r.get("skipped"):
+                click.echo(
+                    f"  {r['name']:20s}  skipped; token still fresh "
+                    f"(TTL >= {min_ttl_hours:g}h)"
+                )
+            elif r["success"]:
                 click.echo(
                     f"  {r['name']:20s}  refreshed; new expiry "
                     f"{r['expires_at'] or '(unknown)'}"
@@ -337,9 +380,14 @@ def account_refresh(
             else:
                 click.echo(f"  {r['name']:20s}  FAILED — {r['error']}", err=True)
 
-    # Exit non-zero only if EVERY target failed; --all with mixed results
-    # is still a useful partial success.
-    if results and not any(r["success"] for r in results):
+    # Exit non-zero when EVERY *attempted* account failed (skipped-fresh
+    # accounts don't count), OR when an active-login sync failed loud.
+    # --all with mixed results is still a useful partial success.
+    attempted = [r for r in results if not r.get("skipped")]
+    all_attempted_failed = bool(attempted) and not any(
+        r.get("success") for r in attempted
+    )
+    if all_attempted_failed or sync_failed:
         raise SystemExit(1)
 
 

--- a/src/scitex_agent_container/cli_pkg/_account_refresh_skip.py
+++ b/src/scitex_agent_container/cli_pkg/_account_refresh_skip.py
@@ -1,0 +1,154 @@
+"""Skip-set helpers for ``sac accounts refresh --all --skip-active``.
+
+Extracted from ``_account_refresh.py`` to keep that command module under
+the per-file line cap. These three helpers build the set of stored
+accounts that ``--skip-active`` must EXCLUDE from an ``--all`` refresh:
+
+* :func:`_resolve_active_account_name` — the account matching the live
+  ``~/.claude`` login (by email);
+* :func:`_resolve_registry_dir` / :func:`_collect_pinned_running_accounts`
+  — accounts currently pinned by a running local agent (refresh-token
+  rotation-race guard).
+
+None of this is used by the daemon's ``--sync-active-login`` mode (which
+refreshes the active account on purpose); it remains for the explicit
+``--skip-active`` opt-in.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+
+def _resolve_active_account_name(
+    home: Path, accounts: list[dict[str, Any]]
+) -> str | None:
+    """Return the stored-account NAME whose identity matches the live login.
+
+    The active account is the one currently logged in under ``~/.claude/``
+    — identified by the email surfaced in ``~/.claude.json``
+    (``oauthAccount.emailAddress``), the same field ``sac accounts list``
+    and ``sac accounts sync-live`` key off. We compare that email against
+    each stored account's ``email_address`` (saved into ``account.json`` by
+    ``sac accounts save`` / auto-sync), case-insensitively.
+
+    Returns the matching stored name, or ``None`` when no active email can
+    be resolved (no live login, malformed file) or when no stored account
+    carries that email — in which case the caller skips nothing and logs
+    it. Never raises.
+    """
+    # stx-allow: fallback (reason: active-account resolution is a
+    # best-effort guard for --skip-active; any read/parse failure maps to
+    # "cannot resolve" so refresh proceeds without skipping, never crashes.)
+    try:
+        from .._account.credentials import read_credentials_metadata
+
+        active = read_credentials_metadata(home=home)
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        return None
+    active_email = active.get("email_address")
+    if not isinstance(active_email, str) or not active_email.strip():
+        return None
+    active_email_norm = active_email.strip().lower()
+    for acct in accounts:
+        stored_email = acct.get("email_address")
+        if (
+            isinstance(stored_email, str)
+            and stored_email.strip().lower() == active_email_norm
+        ):
+            name = acct.get("name")
+            return name if isinstance(name, str) else None
+    return None
+
+
+def _resolve_registry_dir(home: Path) -> Path:
+    """Resolve the file-based agent registry directory.
+
+    Mirrors the ``Registry`` class's path-resolution rule (honors
+    ``SCITEX_AGENT_CONTAINER_REGISTRY_DIR``, else
+    ``<home>/.scitex/agent-container/runtime/registry``), but READ per
+    call rather than frozen at module-import time. The freeze on
+    ``Registry`` is fine in production (HOME doesn't change) but is
+    brittle under pytest where the sandbox HOME is set after the test
+    process started.
+    """
+    import os
+
+    env_override = os.environ.get("SCITEX_AGENT_CONTAINER_REGISTRY_DIR")
+    if env_override:
+        return Path(env_override)
+    return home / ".scitex" / "agent-container" / "runtime" / "registry"
+
+
+def _collect_pinned_running_accounts(home: Path | None = None) -> set[str]:
+    """Return stored-account NAMES currently pinned by running local agents.
+
+    Closes the refresh-token rotation race: when an agent is spawned with
+    ``spec.claude.account: <name>``, its in-container Claude CLI refreshes
+    that account's token through the live :rw dir-bind on the snapshot.
+    If the host ``sac accounts refresh --all --skip-active`` cron ALSO
+    refreshes the same account every 2h, the two refreshers rotate each
+    other's refresh_token (OAuth refresh-tokens invalidate on use) and
+    whichever raced last leaves the other with a now-invalid token —
+    next API call hits 401.
+
+    This helper enumerates the local file-based agent registry (the same
+    JSON files ``sac status`` reads, written by ``_lifecycle/_start`` at
+    spawn time), loads each entry's ``config`` spec, and extracts
+    ``spec.claude.account`` when set. The caller unions the result with
+    the host-active account into a single skip-set so the cron never
+    refreshes a token currently in use by a running agent.
+
+    Cross-host scope: only LOCAL running agents matter — the cron runs
+    against the LOCAL snapshot store, and agents on other hosts have
+    their own local snapshot stores (and their own refresher cron).
+
+    Stale-registry tolerance: a registry entry left behind by a crashed
+    agent will over-skip its account (the cron won't refresh it until
+    the stale entry is cleaned via ``Registry.cleanup_stale``). The
+    failure mode is safe: under-refresh, eventually requiring manual
+    ``sac accounts refresh <name>``. The opposite (over-refresh racing
+    a live agent) is the bug we're fixing.
+
+    Tolerant: any registry / spec read failure is mapped to "this entry
+    contributes nothing" so refresh proceeds against the rest of the
+    set rather than crashing on one bad row.
+    """
+    import json as _json
+
+    home = home if home is not None else Path.home()
+    reg_dir = _resolve_registry_dir(home)
+    pinned: set[str] = set()
+    if not reg_dir.is_dir():
+        return pinned
+    # stx-allow: fallback (reason: skip-set construction is best-effort;
+    # any registry / spec read failure maps to "skip nothing extra" so
+    # refresh proceeds against the remaining accounts.)
+    try:
+        from ..config import load_config
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        return pinned
+    for entry_path in sorted(reg_dir.glob("*.json")):
+        try:
+            entry = _json.loads(entry_path.read_text())
+        except Exception:  # stx-allow: fallback (reason: see inline comment)
+            continue
+        cfg_path = entry.get("config") if isinstance(entry, dict) else None
+        if not isinstance(cfg_path, str) or not cfg_path:
+            continue
+        try:
+            cfg = load_config(Path(cfg_path))
+        except Exception:  # stx-allow: fallback (reason: see inline comment)
+            continue
+        acct = getattr(getattr(cfg, "claude", None), "account", "") or ""
+        if isinstance(acct, str) and acct.strip():
+            pinned.add(acct.strip())
+    return pinned
+
+
+__all__ = [
+    "_collect_pinned_running_accounts",
+    "_resolve_active_account_name",
+    "_resolve_registry_dir",
+]

--- a/tests/scitex_agent_container/_account/test_active_login_write.py
+++ b/tests/scitex_agent_container/_account/test_active_login_write.py
@@ -1,0 +1,206 @@
+"""Unit tests for ``_account.active_login_write``.
+
+The module mirrors a freshly-rotated snapshot token block into the
+operator's LIVE ``~/.claude/.credentials.json`` under a
+backup -> atomic-replace -> verify-or-restore contract. These tests run
+entirely on tmp files — they NEVER touch a real ``~/.claude`` or real
+snapshot — and drive the corrupt-write path through the injectable
+``serialize`` production seam (not a mock).
+
+AAA marker comments; one assertion per test.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scitex_agent_container._account.active_login_write import (
+    ActiveLoginSyncError,
+    read_refresh_token,
+    sync_active_login,
+)
+
+_FUTURE_MS = 9_999_999_999_000  # far-future expiry
+
+
+def _write_creds(
+    path: Path,
+    *,
+    access: str,
+    refresh: str,
+    expires_ms: int = _FUTURE_MS,
+    extra: dict | None = None,
+    wrapped: bool = True,
+) -> Path:
+    block = {
+        "accessToken": access,
+        "refreshToken": refresh,
+        "expiresAt": expires_ms,
+    }
+    data: dict = {"claudeAiOauth": block} if wrapped else dict(block)
+    if extra:
+        data.update(extra)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    return path
+
+
+def _run_expecting_error(live: Path, snap: Path, serialize=None) -> Exception | None:
+    """Run the sync and RETURN any ActiveLoginSyncError (else None)."""
+    try:
+        if serialize is None:
+            sync_active_login(live, snap)
+        else:
+            sync_active_login(live, snap, serialize=serialize)
+    except ActiveLoginSyncError as exc:
+        return exc
+    return None
+
+
+# ---------------------------------------------------------------------------
+# read_refresh_token
+# ---------------------------------------------------------------------------
+
+
+def test_read_refresh_token_returns_wrapped_value(tmp_path) -> None:
+    # Arrange
+    p = _write_creds(tmp_path / "c.json", access="A", refresh="THE-REFRESH")
+    # Act
+    got = read_refresh_token(p)
+    # Assert
+    assert got == "THE-REFRESH"
+
+
+def test_read_refresh_token_missing_file_is_none(tmp_path) -> None:
+    # Arrange
+    missing = tmp_path / "nope.json"
+    # Act
+    got = read_refresh_token(missing)
+    # Assert
+    assert got is None
+
+
+# ---------------------------------------------------------------------------
+# Happy path: mirror + structure preservation
+# ---------------------------------------------------------------------------
+
+
+def test_sync_writes_new_access_token_into_live(tmp_path) -> None:
+    # Arrange
+    snap = _write_creds(tmp_path / "snap.json", access="NEW-ACCESS", refresh="NEW-REF")
+    live = _write_creds(tmp_path / "live.json", access="OLD-ACCESS", refresh="OLD-REF")
+    # Act
+    sync_active_login(live, snap)
+    # Assert
+    got = json.loads(live.read_text())["claudeAiOauth"]["accessToken"]
+    assert got == "NEW-ACCESS"
+
+
+def test_sync_writes_rotated_refresh_token_into_live(tmp_path) -> None:
+    # Arrange
+    snap = _write_creds(tmp_path / "snap.json", access="NEW-ACCESS", refresh="NEW-REF")
+    live = _write_creds(tmp_path / "live.json", access="OLD-ACCESS", refresh="OLD-REF")
+    # Act
+    sync_active_login(live, snap)
+    # Assert
+    got = json.loads(live.read_text())["claudeAiOauth"]["refreshToken"]
+    assert got == "NEW-REF"
+
+
+def test_sync_preserves_other_live_keys(tmp_path) -> None:
+    # Arrange
+    snap = _write_creds(tmp_path / "snap.json", access="NEW-ACCESS", refresh="NEW-REF")
+    live = _write_creds(
+        tmp_path / "live.json",
+        access="OLD-ACCESS",
+        refresh="OLD-REF",
+        extra={"unrelatedRootKey": "keep-me"},
+    )
+    # Act
+    sync_active_login(live, snap)
+    # Assert
+    assert json.loads(live.read_text())["unrelatedRootKey"] == "keep-me"
+
+
+def test_sync_preserves_sibling_oauth_fields(tmp_path) -> None:
+    # Arrange
+    snap = _write_creds(tmp_path / "snap.json", access="NEW-ACCESS", refresh="NEW-REF")
+    live = tmp_path / "live.json"
+    live.write_text(
+        json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "OLD-ACCESS",
+                    "refreshToken": "OLD-REF",
+                    "expiresAt": _FUTURE_MS,
+                    "clientId": "keep-this-cid",
+                }
+            }
+        )
+    )
+    # Act
+    sync_active_login(live, snap)
+    # Assert
+    assert json.loads(live.read_text())["claudeAiOauth"]["clientId"] == "keep-this-cid"
+
+
+# ---------------------------------------------------------------------------
+# Verify-or-restore
+# ---------------------------------------------------------------------------
+
+
+def test_corrupt_write_raises(tmp_path) -> None:
+    # Arrange
+    snap = _write_creds(tmp_path / "snap.json", access="NEW-ACCESS", refresh="NEW-REF")
+    live = _write_creds(tmp_path / "live.json", access="OLD-ACCESS", refresh="OLD-REF")
+    # Act
+    err = _run_expecting_error(live, snap, serialize=lambda _d: "{}")
+    # Assert
+    assert isinstance(err, ActiveLoginSyncError)
+
+
+def test_corrupt_write_restores_original_live_content(tmp_path) -> None:
+    # Arrange
+    snap = _write_creds(tmp_path / "snap.json", access="NEW-ACCESS", refresh="NEW-REF")
+    live = _write_creds(tmp_path / "live.json", access="OLD-ACCESS", refresh="OLD-REF")
+    # Act
+    _run_expecting_error(live, snap, serialize=lambda _d: "not json at all {")
+    # Assert
+    assert json.loads(live.read_text())["claudeAiOauth"]["accessToken"] == "OLD-ACCESS"
+
+
+def test_corrupt_write_leaves_backup_alongside(tmp_path) -> None:
+    # Arrange
+    snap = _write_creds(tmp_path / "snap.json", access="NEW-ACCESS", refresh="NEW-REF")
+    live = _write_creds(tmp_path / "live.json", access="OLD-ACCESS", refresh="OLD-REF")
+    # Act
+    _run_expecting_error(live, snap, serialize=lambda _d: "{}")
+    # Assert
+    assert Path(str(live) + ".bak").is_file()
+
+
+# ---------------------------------------------------------------------------
+# Guard rails
+# ---------------------------------------------------------------------------
+
+
+def test_missing_snapshot_tokens_raises(tmp_path) -> None:
+    # Arrange
+    snap = tmp_path / "snap.json"
+    snap.write_text(json.dumps({"claudeAiOauth": {}}))
+    live = _write_creds(tmp_path / "live.json", access="OLD-ACCESS", refresh="OLD-REF")
+    # Act
+    err = _run_expecting_error(live, snap)
+    # Assert
+    assert isinstance(err, ActiveLoginSyncError)
+
+
+def test_missing_live_file_raises(tmp_path) -> None:
+    # Arrange
+    snap = _write_creds(tmp_path / "snap.json", access="NEW-ACCESS", refresh="NEW-REF")
+    absent = tmp_path / "absent.json"
+    # Act
+    err = _run_expecting_error(absent, snap)
+    # Assert
+    assert isinstance(err, ActiveLoginSyncError)

--- a/tests/scitex_agent_container/cli_pkg/test__account_refresh_pinned_running.py
+++ b/tests/scitex_agent_container/cli_pkg/test__account_refresh_pinned_running.py
@@ -29,7 +29,7 @@ import pytest
 from click.testing import CliRunner
 
 from scitex_agent_container._state.account_store import save_account
-from scitex_agent_container.cli_pkg._account_refresh import (
+from scitex_agent_container.cli_pkg._account_refresh_skip import (
     _collect_pinned_running_accounts,
     _resolve_registry_dir,
 )

--- a/tests/scitex_agent_container/cli_pkg/test_account_group_refresh_sync_active.py
+++ b/tests/scitex_agent_container/cli_pkg/test_account_group_refresh_sync_active.py
@@ -1,0 +1,348 @@
+"""Tests for ``sac accounts refresh`` TTL gating + ``--sync-active-login``.
+
+Fleet credential-rotation fix (2026-07): the host refresher must
+(1) refresh every stored snapshot ONLY when its token is stale
+(``--min-ttl-hours`` gate) and (2) when it rotates the account whose
+snapshot refresh_token matches the LIVE ``~/.claude`` login, ALSO write
+the freshly-rotated token block into ``~/.claude/.credentials.json`` so
+the operator's live session is never stranded by the single-use
+refresh_token rotation.
+
+No-mocks (PA-306): real on-disk credentials + a real (redirected) HOME.
+HTTP is injected at the ``urllib.request.urlopen`` production boundary;
+the corrupt-write path is driven by save/restore-swapping the
+``active_login_write._default_serialize`` production seam (the same
+boundary-swap convention as the urlopen fixture — NOT the forbidden
+``monkeypatch`` fixture). Tests NEVER touch a real ``~/.claude``.
+
+AAA marker comments; one assertion per test.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Iterator
+
+import pytest
+from click.testing import CliRunner
+
+from scitex_agent_container._state.account_store import save_account
+from scitex_agent_container.cli_pkg.account_group import account
+
+_FUTURE_MS = 9_999_999_999_000  # far-future expiry (plenty of TTL left)
+_PAST_MS = 1_000_000_000_000  # 2001 — long expired
+
+
+@pytest.fixture(autouse=True)
+def sandbox_home(tmp_path, env_save_restore):
+    """Redirect ``$HOME`` so ``Path.home()`` lands inside ``tmp_path``."""
+    home = tmp_path / "home"
+    home.mkdir()
+    env_save_restore.set("HOME", str(home))
+    return home
+
+
+def _store_dir(home: Path) -> Path:
+    return home / ".scitex" / "agent-container" / "accounts"
+
+
+def _seed_account(
+    home: Path,
+    name: str,
+    *,
+    refresh: str | None = "the-refresh",
+    expires_ms: int | None = None,
+    seed_file: bool = True,
+) -> Path:
+    save_account(name, {"email_address": f"{name}@x"}, home=home)
+    creds = _store_dir(home) / name / ".credentials.json"
+    if not seed_file:
+        return creds
+    oauth: dict[str, Any] = {"accessToken": "OLD-ACCESS", "clientId": "cid"}
+    if refresh is not None:
+        oauth["refreshToken"] = refresh
+    if expires_ms is not None:
+        oauth["expiresAt"] = expires_ms
+    creds.write_text(json.dumps({"claudeAiOauth": oauth}))
+    return creds
+
+
+def _set_live(
+    home: Path,
+    *,
+    refresh: str,
+    access: str = "LIVE-OLD-ACCESS",
+    extra: dict | None = None,
+) -> Path:
+    live = home / ".claude" / ".credentials.json"
+    live.parent.mkdir(parents=True, exist_ok=True)
+    data: dict[str, Any] = {
+        "claudeAiOauth": {
+            "accessToken": access,
+            "refreshToken": refresh,
+            "expiresAt": _FUTURE_MS,
+        }
+    }
+    if extra:
+        data.update(extra)
+    live.write_text(json.dumps(data))
+    return live
+
+
+class _FakeResp:
+    def __init__(self, body: bytes):
+        self._body = body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return False
+
+    def read(self):
+        return self._body
+
+
+@pytest.fixture
+def opener_swap() -> Iterator[dict]:
+    """Swap ``urllib.request.urlopen`` at the production boundary.
+
+    Default response rotates BOTH tokens so the snapshot's refresh_token
+    is genuinely rotated (mirroring the real single-use behaviour).
+    """
+    import urllib.request
+
+    state: dict[str, Any] = {
+        "response": {
+            "access_token": "NEW-ACCESS",
+            "refresh_token": "NEW-REFRESH",
+            "expires_in": 3600,
+        }
+    }
+    saved = urllib.request.urlopen
+
+    def fake_urlopen(req, timeout=None):
+        resp = state["response"]
+        if isinstance(resp, Exception):
+            raise resp
+        return _FakeResp(json.dumps(resp).encode())
+
+    urllib.request.urlopen = fake_urlopen  # type: ignore[assignment]
+    try:
+        yield state
+    finally:
+        urllib.request.urlopen = saved  # type: ignore[assignment]
+
+
+@pytest.fixture
+def corrupt_serialize() -> Iterator[None]:
+    """Save/restore-swap the live-login serializer to emit corrupt content.
+
+    Same production-boundary-swap convention as ``opener_swap`` — exercises
+    the verify-or-restore path end-to-end through the CLI without a mock.
+    """
+    from scitex_agent_container._account import active_login_write as alw
+
+    saved = alw._default_serialize
+    alw._default_serialize = lambda _d: "{}"  # valid JSON, tokens stripped
+    try:
+        yield
+    finally:
+        alw._default_serialize = saved
+
+
+# ---------------------------------------------------------------------------
+# TTL gating (--min-ttl-hours)
+# ---------------------------------------------------------------------------
+
+
+def test_all_skips_account_with_ample_ttl(sandbox_home, opener_swap) -> None:
+    # Arrange — one account whose token is nowhere near expiry.
+    creds = _seed_account(sandbox_home, "fresh", expires_ms=_FUTURE_MS)
+    runner = CliRunner()
+    # Act
+    runner.invoke(account, ["refresh", "--all"])
+    # Assert — a fresh token is left untouched (no rotation).
+    assert json.loads(creds.read_text())["claudeAiOauth"]["accessToken"] == "OLD-ACCESS"
+
+
+def test_all_refreshes_account_with_low_ttl(sandbox_home, opener_swap) -> None:
+    # Arrange — one account whose token is already expired (TTL < threshold).
+    creds = _seed_account(sandbox_home, "stale", expires_ms=_PAST_MS)
+    runner = CliRunner()
+    # Act
+    runner.invoke(account, ["refresh", "--all"])
+    # Assert
+    assert json.loads(creds.read_text())["claudeAiOauth"]["accessToken"] == "NEW-ACCESS"
+
+
+def test_force_refreshes_fresh_account(sandbox_home, opener_swap) -> None:
+    # Arrange — a fresh token that would otherwise be skipped.
+    creds = _seed_account(sandbox_home, "fresh", expires_ms=_FUTURE_MS)
+    runner = CliRunner()
+    # Act
+    runner.invoke(account, ["refresh", "--all", "--force"])
+    # Assert — --force bypasses the TTL gate.
+    assert json.loads(creds.read_text())["claudeAiOauth"]["accessToken"] == "NEW-ACCESS"
+
+
+# ---------------------------------------------------------------------------
+# Active-login sync (--sync-active-login)
+# ---------------------------------------------------------------------------
+
+
+def test_sync_writes_new_token_into_live_login(sandbox_home, opener_swap) -> None:
+    # Arrange — the stored account shares the live login's refresh_token.
+    _seed_account(sandbox_home, "work", refresh="SHARED-REF")
+    live = _set_live(sandbox_home, refresh="SHARED-REF")
+    runner = CliRunner()
+    # Act
+    runner.invoke(account, ["refresh", "--all", "--sync-active-login"])
+    # Assert — the live login received the freshly-rotated access token.
+    got = json.loads(live.read_text())["claudeAiOauth"]["accessToken"]
+    assert got == "NEW-ACCESS"
+
+
+def test_sync_writes_rotated_refresh_token_into_live_login(
+    sandbox_home, opener_swap
+) -> None:
+    # Arrange
+    _seed_account(sandbox_home, "work", refresh="SHARED-REF")
+    live = _set_live(sandbox_home, refresh="SHARED-REF")
+    runner = CliRunner()
+    # Act
+    runner.invoke(account, ["refresh", "--all", "--sync-active-login"])
+    # Assert — the rotated refresh_token is what keeps the live login alive.
+    got = json.loads(live.read_text())["claudeAiOauth"]["refreshToken"]
+    assert got == "NEW-REFRESH"
+
+
+def test_sync_preserves_other_live_keys(sandbox_home, opener_swap) -> None:
+    # Arrange — the live file carries an unrelated key that must survive.
+    _seed_account(sandbox_home, "work", refresh="SHARED-REF")
+    live = _set_live(
+        sandbox_home, refresh="SHARED-REF", extra={"unrelatedKey": "keep-me"}
+    )
+    runner = CliRunner()
+    # Act
+    runner.invoke(account, ["refresh", "--all", "--sync-active-login"])
+    # Assert
+    assert json.loads(live.read_text())["unrelatedKey"] == "keep-me"
+
+
+def test_sync_exits_zero_on_success(sandbox_home, opener_swap) -> None:
+    # Arrange
+    _seed_account(sandbox_home, "work", refresh="SHARED-REF")
+    _set_live(sandbox_home, refresh="SHARED-REF")
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(account, ["refresh", "--all", "--sync-active-login"])
+    # Assert
+    assert result.exit_code == 0
+
+
+def test_non_active_account_does_not_touch_live_login(
+    sandbox_home, opener_swap
+) -> None:
+    # Arrange — the ONLY stored account does NOT match the live refresh_token.
+    _seed_account(sandbox_home, "other", refresh="OTHER-REF")
+    live = _set_live(sandbox_home, refresh="LIVE-REF", access="LIVE-OLD-ACCESS")
+    runner = CliRunner()
+    # Act
+    runner.invoke(account, ["refresh", "--all", "--sync-active-login"])
+    # Assert — the live login is left completely untouched.
+    got = json.loads(live.read_text())["claudeAiOauth"]["accessToken"]
+    assert got == "LIVE-OLD-ACCESS"
+
+
+def test_sync_does_not_leak_token_values(sandbox_home, opener_swap) -> None:
+    # Arrange
+    _seed_account(sandbox_home, "work", refresh="SHARED-REF")
+    _set_live(sandbox_home, refresh="SHARED-REF")
+    opener_swap["response"] = {
+        "access_token": "SECRET-ACCESS-XYZ",
+        "refresh_token": "SECRET-REFRESH-XYZ",
+        "expires_in": 3600,
+    }
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(account, ["refresh", "--all", "--sync-active-login"])
+    # Assert — no token bytes surface in the command output.
+    leaks = ("SECRET-ACCESS-XYZ", "SECRET-REFRESH-XYZ", "SHARED-REF")
+    assert not any(leak in (result.output or "") for leak in leaks)
+
+
+# ---------------------------------------------------------------------------
+# Verify-or-restore (corrupt live-login write)
+# ---------------------------------------------------------------------------
+
+
+def test_sync_verify_failure_exits_nonzero(
+    sandbox_home, opener_swap, corrupt_serialize
+) -> None:
+    # Arrange — the live-login write will produce token-stripped JSON.
+    _seed_account(sandbox_home, "work", refresh="SHARED-REF")
+    _set_live(sandbox_home, refresh="SHARED-REF")
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(account, ["refresh", "--all", "--sync-active-login"])
+    # Assert — the failed sync fails the whole run loud.
+    assert result.exit_code != 0
+
+
+def test_sync_verify_failure_restores_live_login(
+    sandbox_home, opener_swap, corrupt_serialize
+) -> None:
+    # Arrange
+    _seed_account(sandbox_home, "work", refresh="SHARED-REF")
+    live = _set_live(sandbox_home, refresh="SHARED-REF", access="LIVE-OLD-ACCESS")
+    runner = CliRunner()
+    # Act
+    runner.invoke(account, ["refresh", "--all", "--sync-active-login"])
+    # Assert — the original live login is restored from the .bak backup.
+    got = json.loads(live.read_text())["claudeAiOauth"]["accessToken"]
+    assert got == "LIVE-OLD-ACCESS"
+
+
+# ---------------------------------------------------------------------------
+# Graceful skips
+# ---------------------------------------------------------------------------
+
+
+def test_missing_snapshot_does_not_block_other_accounts(
+    sandbox_home, opener_swap
+) -> None:
+    # Arrange — 'gone' has account.json but NO credentials file; 'ok' is healthy.
+    _seed_account(sandbox_home, "gone", seed_file=False)
+    creds_ok = _seed_account(sandbox_home, "ok", expires_ms=_PAST_MS)
+    runner = CliRunner()
+    # Act
+    runner.invoke(account, ["refresh", "--all"])
+    # Assert — the healthy account is still refreshed despite the missing one.
+    assert json.loads(creds_ok.read_text())["claudeAiOauth"]["accessToken"] == "NEW-ACCESS"
+
+
+def test_no_refresh_token_does_not_block_other_accounts(
+    sandbox_home, opener_swap
+) -> None:
+    # Arrange — 'norefresh' lacks a refresh_token; 'ok' is healthy.
+    _seed_account(sandbox_home, "norefresh", refresh=None, expires_ms=_PAST_MS)
+    creds_ok = _seed_account(sandbox_home, "ok", expires_ms=_PAST_MS)
+    runner = CliRunner()
+    # Act
+    runner.invoke(account, ["refresh", "--all"])
+    # Assert
+    assert json.loads(creds_ok.read_text())["claudeAiOauth"]["accessToken"] == "NEW-ACCESS"
+
+
+def test_sync_active_login_rejects_skip_active(sandbox_home, opener_swap) -> None:
+    # Arrange
+    _seed_account(sandbox_home, "work", refresh="SHARED-REF")
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(
+        account, ["refresh", "--all", "--sync-active-login", "--skip-active"]
+    )
+    # Assert — the two flags are mutually exclusive.
+    assert result.exit_code != 0


### PR DESCRIPTION
## Verified root cause

sac agents read Anthropic OAuth creds from per-account **snapshots**
(`~/.scitex/agent-container/accounts/<acct>/.credentials.json`). The operator's
LIVE login is a *separate* file (`~/.claude/.credentials.json`, a different
inode — not a symlink to any snapshot). Anthropic OAuth **rotates the
refresh_token on every refresh (single-use)**: when the operator manually
`/login`s an account, that account's prior refresh_token is invalidated
server-side, so any snapshot still holding the old token then fails to refresh
and running agents on it 401. The reverse also strands the operator: when the
host refresher rotates the snapshot of the account currently logged into
`~/.claude`, the live file is left holding the now-invalidated refresh_token.

## Two operator directives implemented

1. **Refresh all accounts uniformly (msg 986)** — no default active-login
   skip. Plain `--all` already refreshes every stored account (active
   included); the only skip is the explicit opt-in `--skip-active`, which the
   daemon does not use. `--sync-active-login` is mutually exclusive with it.

2. **Keep `~/.claude/.credentials.json` in sync (msg 990)** — new
   `--sync-active-login` flag. Before refreshing, the live login's
   `refreshToken` (realpath) is matched by **value-equality only** (never
   printed/logged) against each snapshot's `refreshToken` to find the "active
   family" account. When THAT account's snapshot rotates, its three
   freshly-minted token fields (`accessToken`/`refreshToken`/`expiresAt`) are
   also written into `~/.claude/.credentials.json`, preserving the exact
   existing JSON structure (only those three fields inside `claudeAiOauth`, or
   the root if unwrapped). Only ever the matched account's own rotated tokens —
   never cross-account.

Also added a **rotate-only-when-stale gate** (`--min-ttl-hours`, default 2.0,
reusing the proven headless-OAuth recipe in
`claude_usage.refresh_account_credentials`): under `--all` a snapshot with more
than the threshold left is skipped (no network call, no needless single-use
rotation); unknown/absent expiry is always refreshed; `--force` bypasses it.

## Safety design for the `~/.claude` write (irreplaceable)

New module `_account/active_login_write.py`:
- **(a)** back up the existing live file to a sibling `.bak` before writing;
- **(b)** write to a `.tmp` then atomic `os.replace`;
- **(c)** re-open + **verify** it parses as JSON and the three token fields are
  present + non-empty; on ANY failure **restore from the `.bak`** and raise
  `ActiveLoginSyncError` (fails the run non-zero). Token values never printed;
  files chmod 600.

## New invocation

- Daemon / timer mode: `sac accounts refresh --all --sync-active-login`
  (defaults `--min-ttl-hours 2`).

## Exit semantics (noted divergence)

Kept the existing rule — non-zero only when *every attempted* account failed
(TTL-skipped don't count) — since the existing suite asserts partial success =
exit 0. Per-account failures print loudly. A failed active-login sync fails the
whole run non-zero (new path). Safest option that keeps the suite green.

## Tests (no mocks)

New `test_active_login_write.py` (helper unit: verify-or-restore + structure
preservation) and `test_account_group_refresh_sync_active.py` (CLI: TTL gating,
active-login sync, non-active-does-not-touch-live, verify-or-restore exits
non-zero + restores, graceful skips). HTTP swapped at the
`urllib.request.urlopen` boundary; corrupt-write via the injectable `serialize`
seam. Tests never touch a real `~/.claude` or real snapshots. Full account +
`cli_pkg` suites: **445 passed**.

## Follow-up (host-side, for the parent agent)

The host cron currently calls the loose
`~/.scitex/agent-container/bin/refresh-account-snapshots.py`. It should be
repointed to `sac accounts refresh --all --sync-active-login` (the tested SSOT).
This PR does not touch the host cron.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
