### PR TITLE
feat(accounts): refresh-quota-cache — populate quota-cache.json for the quota-aware picker

### DIFF
--- a/src/scitex_agent_container/_account/quota_cache.py
+++ b/src/scitex_agent_container/_account/quota_cache.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import json
 import os
+import time
 from pathlib import Path
 from typing import Any
 
@@ -178,8 +179,85 @@ def build_a2a_metadata() -> dict[str, Any]:
     }
 
 
+# ---------------------------------------------------------------------------
+# Writer side — the POPULATOR that produces the aggregate quota-cache.json
+# the reader above consumes. The reader's DEFAULT_QUOTA_CACHE_PATH
+# (/var/sac/quota-cache.json) is the *in-container* bind target; the writer
+# runs on the HOST (via `sac accounts refresh-quota-cache`, typically a cron)
+# and writes the canonical host file ``~/.scitex/quota-cache.json`` that the
+# apptainer runtime binds into each agent at the in-container path. Both ends
+# honour the ``SAC_QUOTA_CACHE_PATH`` override so host-side readers/writers and
+# tests can co-locate on one path.
+DEFAULT_HOST_QUOTA_CACHE_SUBPATH = Path(".scitex") / "quota-cache.json"
+
+
+def default_host_cache_path(home: Path | None = None) -> Path:
+    """Canonical HOST path the populator writes (``~/.scitex/quota-cache.json``)."""
+    _home = home if home is not None else Path.home()
+    return _home / DEFAULT_HOST_QUOTA_CACHE_SUBPATH
+
+
+def _resolve_write_cache_path(
+    override: Path | str | None,
+    home: Path | None,
+) -> Path:
+    """Resolve where the populator writes: explicit → env → host default.
+
+    Deliberately distinct from :func:`_resolve_cache_path` (the reader): the
+    reader's no-env default is the in-container bind path, but the writer's
+    no-env default is the host canonical file. ``SAC_QUOTA_CACHE_PATH`` is the
+    shared override so a host that reads AND writes (or a test) lines both up.
+    """
+    if override is not None:
+        return Path(override)
+    env_path = os.environ.get(ENV_QUOTA_CACHE_PATH, "").strip()
+    if env_path:
+        return Path(env_path)
+    return default_host_cache_path(home)
+
+
+def write_quota_cache(
+    accounts: dict[str, Any],
+    *,
+    cache_path: Path | str | None = None,
+    home: Path | None = None,
+    written_at: float | None = None,
+) -> Path:
+    """Atomically write the aggregate quota cache and return the path written.
+
+    ``accounts`` is the ``{"<key>": {"short", "h5", "d7", "ttl_h"}}`` mapping
+    the reader's :func:`read_quota_entry` iterates. The file is wrapped as
+    ``{"written_at": <epoch>, "accounts": {...}}`` — the exact shape the
+    reader (and the TS bridge) expect. Write is tmp+rename atomic and the file
+    is chmod 0o600 (conservative: it holds only percentages + TTL hours, no
+    token material, but it lives under the operator's home so we match the
+    credential store's private-by-default posture).
+    """
+    path = _resolve_write_cache_path(cache_path, home)
+    payload = {
+        "written_at": written_at if written_at is not None else time.time(),
+        "accounts": dict(accounts),
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = Path(str(path) + ".tmp")
+    tmp.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    # stx-allow: fallback (reason: chmod is a best-effort hardening step; on a
+    # filesystem that doesn't support POSIX modes the atomic rename below still
+    # publishes the cache, which holds no secrets.)
+    try:
+        os.chmod(tmp, 0o600)
+    except OSError:
+        pass
+    tmp.rename(path)
+    return path
+
+
 __all__ = [
     "DEFAULT_QUOTA_CACHE_PATH",
+    "DEFAULT_HOST_QUOTA_CACHE_SUBPATH",
     "ENV_QUOTA_CACHE_PATH",
     "ENV_ACCOUNT",
     "META_KEY_ACCOUNT",
@@ -188,4 +266,6 @@ __all__ = [
     "META_KEY_TTL_H",
     "read_quota_entry",
     "build_a2a_metadata",
+    "default_host_cache_path",
+    "write_quota_cache",
 ]

--- a/src/scitex_agent_container/_account/quota_cache_refresh.py
+++ b/src/scitex_agent_container/_account/quota_cache_refresh.py
@@ -1,0 +1,234 @@
+"""Populate the aggregate ``quota-cache.json`` the quota-aware picker reads.
+
+The boot-time account picker (:mod:`_creds._pick_healthy`) and the a2a
+metadata enricher both read per-account 5h/7d utilisation + token TTL from an
+aggregate ``quota-cache.json`` via :func:`_account.quota_cache.read_quota_entry`.
+Nothing in the repo WROTE that file — it was documented as "the host-cron
+schema" but no code produced it, so every reader saw "unknown" and the
+quota-awareness was inert.
+
+This module closes that gap. :func:`refresh_quota_cache` walks every stored
+account (the same store :func:`_creds._pick_healthy.pick_healthy_account`
+discovers), fetches each one's live 5h/7d utilisation from the Anthropic usage
+API via the EXISTING :func:`_account.claude_usage.fetch_usage_for_credentials`
+(reusing its per-account credential swap + 5-min cache — no reinvented API
+call), reads the token TTL from the same snapshot, and writes the aggregate
+cache through :func:`_account.quota_cache.write_quota_cache`.
+
+Fail-loud, per account
+----------------------
+A single account's fetch failure (network error, lapsed refresh_token,
+missing snapshot) is recorded against THAT account and never blocks the
+others or corrupts the cache. The write is MERGE-preserving: an account that
+fails this round keeps whatever entry it had from a prior successful round
+(a transient blip must not wipe good data the picker relies on). The caller
+(the CLI) exits non-zero only when EVERY attempted account failed.
+
+Token material never leaves :mod:`_account.claude_usage`; this module handles
+only percentages + TTL hours.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any, Callable
+
+from .claude_usage import _read_tokens_at, fetch_usage_for_credentials
+from .quota_cache import read_quota_entry, write_quota_cache
+
+# Type of the injectable usage fetcher — takes a per-account credentials path,
+# returns the ``fetch_usage_for_credentials`` result dict (``used_pct_5h`` /
+# ``used_pct_7d`` / ``error`` / ...). Injected in tests to avoid the network.
+UsageFetcher = Callable[[Path], dict[str, Any]]
+
+_CREDENTIALS_FILENAME = ".credentials.json"
+
+
+def _short_of(account_name: str) -> str:
+    """First dash-segment of the account slug — the reader's match key.
+
+    Mirrors :func:`_account.quota_cache.read_quota_entry`'s rule
+    (``ywatanabe-scitex-ai`` → ``ywatanabe``) so a written entry's ``short``
+    is exactly what the reader looks up ``$CLAUDE_AGENT_ACCOUNT`` against.
+    """
+    return account_name.split("-", 1)[0]
+
+
+def _ttl_hours(credentials_path: Path, now: float) -> float | None:
+    """Hours until the snapshot's OAuth access token expires, or ``None``.
+
+    Reads ONLY the non-secret ``expiresAt`` (ms epoch) via the shared
+    token reader; the token values themselves are discarded. ``None`` when
+    the snapshot lacks a parseable expiry.
+    """
+    _, _, _, expires_at_ms = _read_tokens_at(credentials_path)
+    if not isinstance(expires_at_ms, int):
+        return None
+    return round((expires_at_ms / 1000.0 - now) / 3600.0, 2)
+
+
+def refresh_quota_cache(
+    *,
+    home: Path | None = None,
+    store_dir: Path | None = None,
+    cache_path: Path | str | None = None,
+    usage_fetcher: UsageFetcher | None = None,
+    now: float | None = None,
+    merge: bool = True,
+) -> dict[str, Any]:
+    """Fetch usage for every stored account and (re)write ``quota-cache.json``.
+
+    Args:
+        home: Home dir override (tests). Defaults to ``Path.home()``.
+        store_dir: Account-store dir override (tests). ``None`` walks the
+            SciTeX local-state cascade like the picker does.
+        cache_path: Where to write. ``None`` → ``$SAC_QUOTA_CACHE_PATH`` →
+            ``~/.scitex/quota-cache.json`` (see
+            :func:`_account.quota_cache._resolve_write_cache_path`).
+        usage_fetcher: Injection seam for the usage-fetch boundary. Defaults
+            to :func:`_account.claude_usage.fetch_usage_for_credentials`.
+        now: Epoch-seconds override for the TTL math (tests).
+        merge: When ``True`` (default) preserve prior entries for accounts
+            that FAIL this round, so a transient error never drops good data.
+
+    Returns:
+        ``{"cache_path": str, "written": bool, "ok": int, "failed": int,
+           "results": [{"name", "short", "h5", "d7", "ttl_h", "error"}]}``.
+        ``error`` is ``None`` on success. Never raises.
+    """
+    from .._state.account_store import list_accounts
+
+    _home = home if home is not None else Path.home()
+    _now = now if now is not None else time.time()
+    _fetch = usage_fetcher if usage_fetcher is not None else fetch_usage_for_credentials
+
+    store = _store_dir(store_dir, _home)
+
+    # Seed with prior entries so a per-account failure preserves good data.
+    accounts_out: dict[str, Any] = {}
+    if merge:
+        accounts_out = _load_existing_accounts(cache_path, _home)
+
+    results: list[dict[str, Any]] = []
+    ok = 0
+    failed = 0
+    for meta in list_accounts(store_dir=store_dir, home=_home):
+        name = meta.get("name")
+        if not isinstance(name, str) or not name:
+            continue
+        row = _refresh_one(name, store, _fetch, _now)
+        results.append(row)
+        if row["error"] is None:
+            accounts_out[name] = {
+                "short": row["short"],
+                "h5": row["h5"],
+                "d7": row["d7"],
+                "ttl_h": row["ttl_h"],
+            }
+            ok += 1
+        else:
+            failed += 1
+
+    written_path = write_quota_cache(
+        accounts_out, cache_path=cache_path, home=_home, written_at=_now
+    )
+    return {
+        "cache_path": str(written_path),
+        "written": True,
+        "ok": ok,
+        "failed": failed,
+        "results": results,
+    }
+
+
+def _store_dir(store_dir: Path | None, home: Path) -> Path:
+    """Resolve the account-store directory (shared with the picker)."""
+    from .._state.account_store import _store_path
+
+    return _store_path(store_dir, home)
+
+
+def _load_existing_accounts(
+    cache_path: Path | str | None,
+    home: Path,
+) -> dict[str, Any]:
+    """Best-effort read of the current cache's ``accounts`` map for merging."""
+    import json
+
+    from .quota_cache import _resolve_write_cache_path
+
+    path = _resolve_write_cache_path(cache_path, home)
+    # stx-allow: fallback (reason: a missing/corrupt prior cache is the normal
+    # cold-start case; degrade to an empty seed rather than fail the refresh.)
+    try:
+        parsed = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:  # stx-allow: fallback (reason: catch-all safety net — see inline comment)
+        return {}
+    accounts = parsed.get("accounts") if isinstance(parsed, dict) else None
+    return dict(accounts) if isinstance(accounts, dict) else {}
+
+
+def _refresh_one(
+    name: str,
+    store: Path,
+    fetch: UsageFetcher,
+    now: float,
+) -> dict[str, Any]:
+    """Fetch one account's usage + TTL into a result row. Never raises."""
+    row: dict[str, Any] = {
+        "name": name,
+        "short": _short_of(name),
+        "h5": None,
+        "d7": None,
+        "ttl_h": None,
+        "error": None,
+    }
+    creds_path = store / name / _CREDENTIALS_FILENAME
+    if not creds_path.is_file():
+        row["error"] = f"no credentials snapshot at {creds_path}"
+        return row
+
+    # stx-allow: fallback (reason: the injected fetcher is documented
+    # never-raise, but defence-in-depth so one bad account never aborts the
+    # whole refresh loop or corrupts the cache.)
+    try:
+        usage = fetch(creds_path)
+    except Exception as exc:  # stx-allow: fallback (reason: catch-all safety net — see inline comment)
+        row["error"] = f"usage fetch raised: {exc}"
+        return row
+
+    if not isinstance(usage, dict):
+        row["error"] = "usage fetch returned no data"
+        return row
+    if usage.get("error"):
+        row["error"] = str(usage["error"])
+        return row
+
+    h5 = usage.get("used_pct_5h")
+    d7 = usage.get("used_pct_7d")
+    if not _is_pct(h5) or not _is_pct(d7):
+        row["error"] = "usage response missing 5h/7d utilisation"
+        return row
+
+    ttl_h = _ttl_hours(creds_path, now)
+    if ttl_h is None:
+        row["error"] = "no parseable token expiry in snapshot"
+        return row
+
+    row["h5"] = float(h5)
+    row["d7"] = float(d7)
+    row["ttl_h"] = ttl_h
+    return row
+
+
+def _is_pct(value: Any) -> bool:
+    """A real number (bool rejected — it's an int in Python)."""
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+__all__ = [
+    "refresh_quota_cache",
+    "read_quota_entry",  # re-export for callers verifying round-trips
+    "UsageFetcher",
+]

--- a/src/scitex_agent_container/cli_pkg/_account_refresh_quota_cache.py
+++ b/src/scitex_agent_container/cli_pkg/_account_refresh_quota_cache.py
@@ -1,0 +1,102 @@
+"""``sac accounts refresh-quota-cache`` — populate the aggregate quota cache.
+
+Split out of ``account_group.py`` to keep that orchestrator under the
+per-file line cap; the command is attached onto the ``account`` group at
+import time via :func:`register_refresh_quota_cache_command` (same pattern as
+``_account_refresh.register_refresh_command``).
+
+This is the missing PRODUCER for the aggregate ``quota-cache.json`` that the
+quota-aware boot picker (:mod:`_creds._pick_healthy`) and the a2a metadata
+enricher read via :func:`_account.quota_cache.read_quota_entry`. Without a
+periodic run of this command that file never exists → the picker sees
+"unknown" for every account and silently degrades to freshness-only. A host
+cron (every 15-30 min) should run this so the picker stays current.
+
+Fail-loud per account: one account's fetch failure is printed and the loop
+continues; the run exits non-zero only when EVERY attempted account failed.
+Token values are never printed — only percentages + TTL hours.
+"""
+
+from __future__ import annotations
+
+import click
+
+
+@click.command("refresh-quota-cache")
+@click.option(
+    "--cache-path",
+    "cache_path",
+    default=None,
+    help=(
+        "Override where the aggregate quota-cache.json is written. Defaults "
+        "to $SAC_QUOTA_CACHE_PATH, then ~/.scitex/quota-cache.json (the host "
+        "file the apptainer runtime binds into each agent)."
+    ),
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Emit a JSON object on stdout instead of human prose.",
+)
+def account_refresh_quota_cache(cache_path: str | None, as_json: bool) -> None:
+    """Fetch each stored account's usage and (re)write quota-cache.json.
+
+    Walks every stored account, fetches its live 5h/7d utilisation from the
+    Anthropic usage API (reusing the per-account credential-swap fetch), reads
+    the token TTL from the snapshot, and writes the aggregate quota-cache.json
+    that the quota-aware boot picker reads. A host cron should run this every
+    15-30 minutes so the picker stays current.
+
+    \b
+    Examples:
+      $ sac accounts refresh-quota-cache
+      $ sac accounts refresh-quota-cache --json
+    """
+    import json as _json
+
+    from .._account.quota_cache_refresh import refresh_quota_cache
+
+    result = refresh_quota_cache(cache_path=cache_path)
+
+    if as_json:
+        click.echo(_json.dumps(result, ensure_ascii=False, indent=2))
+    else:
+        results = result["results"]
+        if not results:
+            click.echo(
+                "No accounts stored. Use: sac accounts save <name> "
+                f"(wrote empty cache to {result['cache_path']})"
+            )
+        for row in results:
+            if row["error"] is None:
+                click.echo(
+                    f"  {row['name']:20s}  5h={row['h5']:.0f}% "
+                    f"7d={row['d7']:.0f}% ttl={row['ttl_h']:.2f}h"
+                )
+            else:
+                click.echo(
+                    f"  {row['name']:20s}  FAILED — {row['error']}", err=True
+                )
+        click.echo(
+            f"wrote {result['ok']} account(s) to {result['cache_path']} "
+            f"({result['failed']} failed)"
+        )
+
+    # Exit non-zero only when EVERY attempted account failed — a partial
+    # success (some accounts written) is still useful for the picker.
+    attempted = result["ok"] + result["failed"]
+    if attempted > 0 and result["ok"] == 0:
+        raise SystemExit(1)
+
+
+def register_refresh_quota_cache_command(group: click.Group) -> None:
+    """Attach the ``refresh-quota-cache`` command onto the ``account`` group."""
+    group.add_command(account_refresh_quota_cache)
+
+
+__all__ = [
+    "account_refresh_quota_cache",
+    "register_refresh_quota_cache_command",
+]

--- a/src/scitex_agent_container/cli_pkg/account_group.py
+++ b/src/scitex_agent_container/cli_pkg/account_group.py
@@ -368,6 +368,18 @@ register_refresh_command(account)
 
 
 # ---------------------------------------------------------------------------
+# refresh-quota-cache — the PRODUCER for the aggregate quota-cache.json that
+# the quota-aware boot picker (_creds/_pick_healthy) + a2a metadata enricher
+# read. Without a periodic run of this, that file never exists and the picker
+# degrades to freshness-only. Lives in its own module (per-file line cap);
+# attached at import time like refresh / sync-live. A host cron runs it.
+# ---------------------------------------------------------------------------
+from ._account_refresh_quota_cache import register_refresh_quota_cache_command
+
+register_refresh_quota_cache_command(account)
+
+
+# ---------------------------------------------------------------------------
 # quota — agent self-awareness: read THIS agent's own account quota from
 # the bound quota-cache.json (#16 PART 4). Reads $CLAUDE_AGENT_ACCOUNT
 # (injected by SAC at launch; see config/_loaders.py) and looks up the

--- a/tests/scitex_agent_container/_account/test_quota_cache_refresh.py
+++ b/tests/scitex_agent_container/_account/test_quota_cache_refresh.py
@@ -1,0 +1,286 @@
+"""Tests for :mod:`scitex_agent_container._account.quota_cache_refresh`.
+
+The populator that writes the aggregate ``quota-cache.json`` the quota-aware
+boot picker reads. The usage-fetch boundary is INJECTED (a fake fetcher
+returning canned 5h/7d values) so no test hits the network.
+
+Coverage:
+  * a successful run writes a well-formed cache that ``read_quota_entry``
+    reads back (the round-trip contract with the picker/reader);
+  * a per-account failure is isolated — the other accounts are still written
+    and the cache is not corrupted;
+  * the write is atomic (no ``.tmp`` residue, file parses);
+  * an empty store does not crash and writes an empty ``accounts`` map;
+  * a missing per-account snapshot is a recorded failure, not a crash;
+  * merge preserves a prior good entry for an account that fails this round.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from scitex_agent_container._account.quota_cache import read_quota_entry
+from scitex_agent_container._account.quota_cache_refresh import refresh_quota_cache
+
+# Deterministic clock so TTL math is exact.
+_NOW = 1_000_000.0
+
+
+def _make_account(store: Path, slug: str, *, ttl_hours: float = 7.5) -> None:
+    """Create a stored-account dir with a snapshot whose token expires in
+    ``ttl_hours`` from ``_NOW``."""
+    acct = store / slug
+    acct.mkdir(parents=True, exist_ok=True)
+    expires_at_ms = int((_NOW + ttl_hours * 3600.0) * 1000)
+    creds = {
+        "claudeAiOauth": {
+            "accessToken": "sk-ant-FAKE-do-not-log",
+            "refreshToken": "refresh-FAKE",
+            "expiresAt": expires_at_ms,
+        }
+    }
+    (acct / ".credentials.json").write_text(json.dumps(creds), encoding="utf-8")
+
+
+def _fetcher(canned: dict[str, dict[str, Any]]):
+    """Return a usage_fetcher keyed by the account slug (creds parent dir)."""
+
+    def _fetch(credentials_path: Path) -> dict[str, Any]:
+        slug = credentials_path.parent.name
+        return canned[slug]
+
+    return _fetch
+
+
+def _ok(h5: float, d7: float) -> dict[str, Any]:
+    return {"used_pct_5h": h5, "used_pct_7d": d7, "error": None}
+
+
+# ---------------------------------------------------------------------------
+# Happy path — round-trip through the reader
+# ---------------------------------------------------------------------------
+
+
+def test_refresh_writes_entry_read_back_by_reader(tmp_path: Path) -> None:
+    # Arrange
+    store = tmp_path / "store"
+    _make_account(store, "ywatanabe-scitex-ai", ttl_hours=7.5)
+    cache = tmp_path / "quota-cache.json"
+    fetch = _fetcher({"ywatanabe-scitex-ai": _ok(19.0, 3.0)})
+    # Act
+    refresh_quota_cache(
+        home=tmp_path,
+        store_dir=store,
+        cache_path=cache,
+        usage_fetcher=fetch,
+        now=_NOW,
+    )
+    entry = read_quota_entry(account="ywatanabe-scitex-ai", cache_path=cache)
+    # Assert
+    assert entry is not None and entry["short"] == "ywatanabe"
+
+
+def test_refresh_entry_carries_h5_d7_and_ttl(tmp_path: Path) -> None:
+    # Arrange
+    store = tmp_path / "store"
+    _make_account(store, "ywatanabe-scitex-ai", ttl_hours=7.5)
+    cache = tmp_path / "quota-cache.json"
+    fetch = _fetcher({"ywatanabe-scitex-ai": _ok(19.0, 3.0)})
+    # Act
+    refresh_quota_cache(
+        home=tmp_path,
+        store_dir=store,
+        cache_path=cache,
+        usage_fetcher=fetch,
+        now=_NOW,
+    )
+    entry = read_quota_entry(account="ywatanabe-scitex-ai", cache_path=cache)
+    # Assert
+    assert entry == {"short": "ywatanabe", "h5": 19.0, "d7": 3.0, "ttl_h": 7.5}
+
+
+def test_refresh_reports_ok_count(tmp_path: Path) -> None:
+    # Arrange
+    store = tmp_path / "store"
+    _make_account(store, "a-gmail-com")
+    _make_account(store, "b-gmail-com")
+    cache = tmp_path / "quota-cache.json"
+    fetch = _fetcher(
+        {"a-gmail-com": _ok(10.0, 1.0), "b-gmail-com": _ok(20.0, 2.0)}
+    )
+    # Act
+    result = refresh_quota_cache(
+        home=tmp_path, store_dir=store, cache_path=cache,
+        usage_fetcher=fetch, now=_NOW,
+    )
+    # Assert
+    assert result["ok"] == 2 and result["failed"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Per-account failure isolation
+# ---------------------------------------------------------------------------
+
+
+def test_per_account_failure_does_not_block_others(tmp_path: Path) -> None:
+    # Arrange — account b's fetch errors; a must still be written.
+    store = tmp_path / "store"
+    _make_account(store, "a-gmail-com")
+    _make_account(store, "b-gmail-com")
+    cache = tmp_path / "quota-cache.json"
+    fetch = _fetcher(
+        {
+            "a-gmail-com": _ok(10.0, 1.0),
+            "b-gmail-com": {"used_pct_5h": None, "used_pct_7d": None, "error": "HTTP 429"},
+        }
+    )
+    # Act
+    refresh_quota_cache(
+        home=tmp_path, store_dir=store, cache_path=cache,
+        usage_fetcher=fetch, now=_NOW,
+    )
+    entry = read_quota_entry(account="a-gmail-com", cache_path=cache)
+    # Assert
+    assert entry is not None and entry["h5"] == 10.0
+
+
+def test_per_account_failure_is_counted(tmp_path: Path) -> None:
+    # Arrange
+    store = tmp_path / "store"
+    _make_account(store, "a-gmail-com")
+    _make_account(store, "b-gmail-com")
+    cache = tmp_path / "quota-cache.json"
+    fetch = _fetcher(
+        {
+            "a-gmail-com": _ok(10.0, 1.0),
+            "b-gmail-com": {"used_pct_5h": None, "used_pct_7d": None, "error": "HTTP 429"},
+        }
+    )
+    # Act
+    result = refresh_quota_cache(
+        home=tmp_path, store_dir=store, cache_path=cache,
+        usage_fetcher=fetch, now=_NOW,
+    )
+    # Assert
+    assert result["ok"] == 1 and result["failed"] == 1
+
+
+def test_failed_account_absent_from_cache_when_no_prior(tmp_path: Path) -> None:
+    # Arrange
+    store = tmp_path / "store"
+    _make_account(store, "b-gmail-com")
+    cache = tmp_path / "quota-cache.json"
+    fetch = _fetcher(
+        {"b-gmail-com": {"used_pct_5h": None, "used_pct_7d": None, "error": "boom"}}
+    )
+    # Act
+    refresh_quota_cache(
+        home=tmp_path, store_dir=store, cache_path=cache,
+        usage_fetcher=fetch, now=_NOW,
+    )
+    entry = read_quota_entry(account="b-gmail-com", cache_path=cache)
+    # Assert
+    assert entry is None
+
+
+def test_missing_snapshot_is_recorded_failure(tmp_path: Path) -> None:
+    # Arrange — account dir exists (metadata only) but no .credentials.json.
+    store = tmp_path / "store"
+    (store / "a-gmail-com").mkdir(parents=True)
+    cache = tmp_path / "quota-cache.json"
+    fetch = _fetcher({})  # never called — snapshot missing short-circuits
+    # Act
+    result = refresh_quota_cache(
+        home=tmp_path, store_dir=store, cache_path=cache,
+        usage_fetcher=fetch, now=_NOW,
+    )
+    # Assert
+    assert result["failed"] == 1 and "no credentials snapshot" in result["results"][0]["error"]
+
+
+# ---------------------------------------------------------------------------
+# Atomic write + empty store
+# ---------------------------------------------------------------------------
+
+
+def test_write_is_atomic_no_tmp_residue(tmp_path: Path) -> None:
+    # Arrange
+    store = tmp_path / "store"
+    _make_account(store, "a-gmail-com")
+    cache = tmp_path / "quota-cache.json"
+    fetch = _fetcher({"a-gmail-com": _ok(10.0, 1.0)})
+    # Act
+    refresh_quota_cache(
+        home=tmp_path, store_dir=store, cache_path=cache,
+        usage_fetcher=fetch, now=_NOW,
+    )
+    # Assert — the tmp sidecar was renamed away; only the final file remains.
+    assert cache.is_file() and not Path(str(cache) + ".tmp").exists()
+
+
+def test_written_file_has_accounts_and_written_at(tmp_path: Path) -> None:
+    # Arrange
+    store = tmp_path / "store"
+    _make_account(store, "a-gmail-com")
+    cache = tmp_path / "quota-cache.json"
+    fetch = _fetcher({"a-gmail-com": _ok(10.0, 1.0)})
+    # Act
+    refresh_quota_cache(
+        home=tmp_path, store_dir=store, cache_path=cache,
+        usage_fetcher=fetch, now=_NOW,
+    )
+    parsed = json.loads(cache.read_text(encoding="utf-8"))
+    # Assert
+    assert parsed["written_at"] == _NOW and "a-gmail-com" in parsed["accounts"]
+
+
+def test_empty_store_does_not_crash(tmp_path: Path) -> None:
+    # Arrange — store dir exists but holds no accounts.
+    store = tmp_path / "store"
+    store.mkdir()
+    cache = tmp_path / "quota-cache.json"
+    # Act
+    result = refresh_quota_cache(
+        home=tmp_path, store_dir=store, cache_path=cache,
+        usage_fetcher=_fetcher({}), now=_NOW,
+    )
+    parsed = json.loads(cache.read_text(encoding="utf-8"))
+    # Assert
+    assert result["ok"] == 0 and result["failed"] == 0 and parsed["accounts"] == {}
+
+
+# ---------------------------------------------------------------------------
+# Merge — prior good data survives a transient failure
+# ---------------------------------------------------------------------------
+
+
+def test_merge_preserves_prior_entry_on_failure(tmp_path: Path) -> None:
+    # Arrange — seed a cache with a good entry, then a run where that
+    # account's fetch fails. The prior entry must survive.
+    store = tmp_path / "store"
+    _make_account(store, "a-gmail-com")
+    cache = tmp_path / "quota-cache.json"
+    cache.write_text(
+        json.dumps(
+            {
+                "written_at": 1.0,
+                "accounts": {
+                    "a-gmail-com": {"short": "a", "h5": 5.0, "d7": 1.0, "ttl_h": 3.0}
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    fetch = _fetcher(
+        {"a-gmail-com": {"used_pct_5h": None, "used_pct_7d": None, "error": "boom"}}
+    )
+    # Act
+    refresh_quota_cache(
+        home=tmp_path, store_dir=store, cache_path=cache,
+        usage_fetcher=fetch, now=_NOW,
+    )
+    entry = read_quota_entry(account="a-gmail-com", cache_path=cache)
+    # Assert — the stale-but-good prior entry is still there.
+    assert entry is not None and entry["h5"] == 5.0


### PR DESCRIPTION
## What

Adds `sac accounts refresh-quota-cache` — the missing **producer** for the aggregate `quota-cache.json` that PR #583's quota-aware boot picker (`_creds/_pick_healthy.py`) and the a2a metadata enricher read via `_account/quota_cache.py::read_quota_entry`.

## Why (the gap)

PR #583 wired the **reader** side of the quota cache, but nothing in the repo ever **wrote** that file — the schema was only documented as "the host-cron schema" and the file did not exist on disk. So `read_quota_entry` always returned "unknown", and the quota-awareness had **zero effect** (the picker silently degraded to freshness-only). This closes that gap.

## What it does

For **each** stored account (same store `pick_healthy_account` discovers):
1. Fetches live 5h/7d utilisation by **reusing** `_account/claude_usage.py::fetch_usage_for_credentials` — the exact per-account credential-swap fetch `sac accounts list` already uses. No reinvented API call.
2. Reads the token TTL (hours) from the same snapshot's non-secret `expiresAt` (token values never leave `claude_usage`).
3. Writes the entry `{short, h5, d7, ttl_h}` into `quota-cache.json` in the **exact** shape `read_quota_entry` expects (`{"written_at":…, "accounts": {"<slug>": {…}}}`).

**Path written:** `~/.scitex/quota-cache.json` (override via `--cache-path` or `$SAC_QUOTA_CACHE_PATH`). This is the canonical host file the apptainer runtime binds into each agent at `/var/sac/quota-cache.json` (the reader's in-container default) — the two are the two ends of one bind.

## Fail-loud, per account

- One account's fetch failure (network error, lapsed refresh_token, missing snapshot) is **printed** and the loop continues; the run exits non-zero **only when every attempted account failed**.
- The write is **merge-preserving**: an account that fails this round keeps its prior good entry, so a transient blip never wipes data the picker relies on.
- Write is atomic (tmp + rename) and chmod `0o600` (conservative — the file holds only percentages + TTL hours, no token material, but lives under the operator's home so it matches the credential store's private-by-default posture).

## Design choices (where the brief was unspecified)

- Outer map is keyed by account **slug** (unique/stable); `read_quota_entry` matches on the per-entry `short` field and ignores the key.
- Writer default path is the **host** canonical file, deliberately distinct from the reader's in-container default — both honour `$SAC_QUOTA_CACHE_PATH`.

## Tests (targeted only)

New `tests/scitex_agent_container/_account/test_quota_cache_refresh.py` (11 tests) mocks the usage-fetch boundary (injected fake fetcher, no network): round-trips a well-formed cache back through `read_quota_entry`, per-account failure isolation + counting, atomic write (no `.tmp` residue), empty store, missing snapshot, and merge-preserve-on-failure.

```
11 passed in 2.26s
```
Existing `test_quota_cache.py` reader tests still pass (28 passed).

## Follow-up (parent agent)

A **host cron** must run `sac accounts refresh-quota-cache` periodically (e.g. every 15-30 min) for the picker to stay current — this PR only adds the command; the parent agent will wire the host cron.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
