### PR TITLE
feat(creds): credentials_files (plural) — quota-aware account pool per spec

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_start_preflight.py
+++ b/src/scitex_agent_container/_lifecycle/_start_preflight.py
@@ -9,7 +9,8 @@ from __future__ import annotations
 
 import sys
 import traceback
-from typing import Any, Callable
+from pathlib import Path
+from typing import Any, Callable, Mapping
 
 from ..config import AgentConfig
 
@@ -86,46 +87,168 @@ def _resolve_strict_drift(strict_drift: bool | None) -> bool:
     return raw in ("1", "true", "yes", "on")
 
 
+def _slug_of_credentials_file(path: Path) -> str:
+    """Return the account slug for a ``.credentials.json`` path.
+
+    The slug is the file's PARENT directory name — the fleet layout is
+    ``~/.scitex/agent-container/accounts/<slug>/.credentials.json`` and
+    ``<slug>`` is exactly the stored-account name the quota-aware picker
+    (:func:`_creds.pick_healthy_account`) keys off (see
+    :func:`_creds._pick_healthy.account_health`).
+    """
+    return path.parent.name
+
+
+def _rotate_among_credentials_files(
+    config: AgentConfig,
+    paths: list[str],
+    *,
+    log_stream: Any = None,
+    now: float | None = None,
+    usage_7d: Mapping[str, float] | None = None,
+    quota_cache_path: Path | str | None = None,
+) -> None:
+    """Pick ONE credentials file from the pool, quota-aware, and bind it.
+
+    ``paths`` is the account POOL (``spec.claude.credentials_files``, or
+    the singular ``spec.claude.credentials_file`` treated as a 1-element
+    pool). Each entry's account SLUG is its parent-dir name. We hand the
+    slug list to :func:`_creds.pick_healthy_account` so the SAME
+    quota-aware pick used for named accounts (PR #583 — prefer the
+    token-fresh account with the most 7d weekly-cap headroom) chooses
+    among exactly the listed accounts, then collapse the pool down to the
+    picked entry by writing it into ``config.claude.credentials_file`` —
+    the field every downstream auth path (``runtimes._apptainer_auth.
+    auth_argv`` / ``credentials_file_bind``) already resolves. Downstream
+    binding is therefore UNCHANGED; this only decides WHICH file it binds.
+
+    Health probing reads each slug's snapshot from the pool's common
+    parent-of-parent directory (``store_dir``) so the freshness/quota
+    check inspects the EXACT listed files — this works for the fleet
+    ``accounts/`` layout and for custom locations alike. When the entries
+    span different parent dirs, ``store_dir`` falls back to the default
+    SciTeX account-store cascade.
+
+    Fail-loud: when NO listed entry has a usable (non-expired) snapshot,
+    :class:`_creds.NoHealthyAccountError` propagates (agent NOT started).
+    Back-compat: a 1-element pool whose one snapshot is healthy resolves
+    to that exact file (no-op — ``credentials_file`` unchanged, no log).
+    """
+    from .._creds import pick_healthy_account
+
+    entries: list[tuple[str, Path]] = []
+    grandparents: set[str] = set()
+    for raw in paths:
+        p = Path(str(raw)).expanduser()
+        entries.append((_slug_of_credentials_file(p), p))
+        grandparents.add(str(p.parent.parent))
+    slugs = [slug for slug, _ in entries]
+
+    # Common parent-of-parent = the account store dir. When every listed
+    # file lives under the same dir (the fleet layout), pass it so the
+    # health probe reads the EXACT listed files; otherwise degrade to the
+    # default store cascade (store_dir=None).
+    store_dir: Path | None = (
+        entries[0][1].parent.parent if len(grandparents) == 1 else None
+    )
+
+    claude = config.claude
+    # Preferred = the currently-effective account when it is one of the
+    # listed slugs (minimise churn); else the first listed entry.
+    account = str(getattr(claude, "account", "") or "").strip()
+    preferred = account if account in slugs else slugs[0]
+
+    picked = pick_healthy_account(
+        preferred,
+        candidates=slugs,
+        store_dir=store_dir,
+        now=now,
+        usage_7d=usage_7d,
+        quota_cache_path=quota_cache_path,
+    )
+
+    picked_path = next(p for slug, p in entries if slug == picked)
+    prior = str(getattr(claude, "credentials_file", "") or "").strip()
+    claude.credentials_file = str(picked_path)
+
+    if str(picked_path) == prior:
+        return  # 1-element / already-selected pool — no change, no log.
+
+    stream = log_stream if log_stream is not None else sys.stderr
+    print(
+        f"[sac:creds] agent '{config.name}' selected credentials_files pool "
+        f"entry: account {picked!r} ({picked_path}) among {len(slugs)} listed "
+        f"credentials_files (quota-aware pick — token-fresh account with the "
+        f"most 7d headroom)",
+        file=stream,
+    )
+
+
 def _rotate_to_healthy_account(
     config: AgentConfig,
     *,
     log_stream: Any = None,
+    now: float | None = None,
+    usage_7d: Mapping[str, float] | None = None,
+    quota_cache_path: Path | str | None = None,
 ) -> None:
-    """Rotate ``config.claude.account`` to a healthy stored account.
+    """Rotate the agent's credential to a healthy stored account.
 
-    CREDS-PHASE1 wiring. Only acts on PINNED agents
-    (``spec.claude.account`` non-empty). For an unpinned agent the
-    runtime continues to bind the host's live ``.credentials.json``
-    untouched.
+    CREDS-PHASE1 wiring. Two account-pool entry points, checked in order:
 
-    On a pinned agent:
+    1. **Account POOL** — ``spec.claude.credentials_files`` (plural), or
+       the singular ``spec.claude.credentials_file`` treated as a
+       1-element pool. When non-empty, delegate to
+       :func:`_rotate_among_credentials_files`: derive each entry's
+       account slug (parent-dir name), let :func:`_creds.
+       pick_healthy_account` choose the quota-aware winner among exactly
+       the listed accounts, and collapse the pool to the picked file via
+       ``config.claude.credentials_file``. THIS is the wiring that makes
+       the quota-aware pick (PR #583/#584) affect ``credentials_file``-
+       pinned fleet agents — previously such agents bypassed the pick
+       entirely (this function returned early on empty ``account``).
 
-    * If the pinned snapshot is healthy → no-op (config unchanged).
-    * If the pinned snapshot is EXPIRED/ABSENT but another stored
-      account has a fresh snapshot → ``config.claude.account`` is
-      mutated to that account and a one-line rotation notice is
-      printed to ``log_stream`` (default ``sys.stderr``). The runtime
-      then binds that account's snapshot ``:rw`` directly via
-      :func:`runtimes._apptainer_creds.resolve_cred_file` (operator
-      #15 — the prior boot-copy path was the root cause of the
-      2026-06-01 fleet outage; refreshes now write back to the
-      snapshot itself, never expiring).
-    * If NOTHING is healthy → :class:`_creds.NoHealthyAccountError`
-      propagates (fail loud, no silent stale-token launch). Agent is
-      NOT started.
+    2. **Named account** — ``spec.claude.account`` non-empty. Existing
+       behaviour, unchanged: keep the pinned account when its snapshot is
+       healthy; rotate ``config.claude.account`` to the fresh account with
+       the most 7d headroom otherwise. For an unpinned agent (no pool, no
+       account) the runtime continues to bind the host's live
+       ``.credentials.json`` untouched.
 
-    See :mod:`scitex_agent_container._creds._pick_healthy` for the
-    health model — non-expired snapshot = healthy. Cap-induced 429s
-    still surface from claude in-turn; the picker only avoids
-    known-stale auth at boot.
+    In every case a total absence of a usable (non-expired) snapshot
+    raises :class:`_creds.NoHealthyAccountError` (fail loud, no silent
+    stale-token launch). See :mod:`scitex_agent_container._creds.
+    _pick_healthy` for the health model. The ``now`` / ``usage_7d`` /
+    ``quota_cache_path`` params are the same test-injection seams
+    ``pick_healthy_account`` exposes; production passes ``None``.
     """
-    pinned = getattr(getattr(config, "claude", None), "account", "") or ""
+    claude = getattr(config, "claude", None)
+
+    # 1. Account POOL (plural, or the singular treated as a 1-element pool).
+    cred_files = list(getattr(claude, "credentials_files", []) or [])
+    single = str(getattr(claude, "credentials_file", "") or "").strip()
+    pool = cred_files if cred_files else ([single] if single else [])
+    if pool:
+        _rotate_among_credentials_files(
+            config,
+            pool,
+            log_stream=log_stream,
+            now=now,
+            usage_7d=usage_7d,
+            quota_cache_path=quota_cache_path,
+        )
+        return
+
+    # 2. Named account (legacy CREDS-PHASE1 path — unchanged).
+    pinned = getattr(claude, "account", "") or ""
     if not pinned:
         return  # unpinned agent — host live OAuth, untouched.
 
     from .._creds import pick_healthy_account
 
-    picked = pick_healthy_account(pinned)
+    picked = pick_healthy_account(
+        pinned, now=now, usage_7d=usage_7d, quota_cache_path=quota_cache_path
+    )
     if picked == pinned:
         return  # pinned is healthy — no rotation, no log line.
 

--- a/src/scitex_agent_container/config/_claude_validation.py
+++ b/src/scitex_agent_container/config/_claude_validation.py
@@ -115,6 +115,33 @@ def validate_claude(spec: dict) -> list[str]:
             "Anthropic OAuth. Set exactly one."
         )
 
+    # spec.claude.credentials_files — the account POOL (plural). Must be a
+    # list of non-empty strings (host paths to ``.credentials.json``). The
+    # start pre-flight picks ONE quota-aware; a malformed value would
+    # silently degrade the pool to empty, so we fail loud here.
+    cred_files = claude_block.get("credentials_files")
+    if cred_files is not None:
+        if not isinstance(cred_files, list):
+            errors.append(
+                "spec.claude.credentials_files must be a list of host paths "
+                f"to .credentials.json files, got {type(cred_files).__name__}"
+            )
+        else:
+            for i, entry in enumerate(cred_files):
+                if not isinstance(entry, str) or not entry.strip():
+                    errors.append(
+                        "spec.claude.credentials_files[%d] must be a "
+                        "non-empty string path, got %r" % (i, entry)
+                    )
+        # Mirror the account/provider exclusivity — a provider backend uses
+        # an API key, not an OAuth credentials pool.
+        if has_provider and cred_files:
+            errors.append(
+                "spec.claude.provider and spec.claude.credentials_files are "
+                "mutually exclusive — a provider backend uses an API key, "
+                "not an Anthropic OAuth credentials pool. Set exactly one."
+            )
+
     # spec.claude.resume_id — the explicit session id passed to
     # ``claude --resume <id>`` (TUI) / ``ClaudeAgentOptions(resume=<id>)``
     # (SDK) when ``spec.claude.session: resume``. When set it MUST be a

--- a/src/scitex_agent_container/config/_parsers/_claude.py
+++ b/src/scitex_agent_container/config/_parsers/_claude.py
@@ -98,6 +98,18 @@ def parse_claude(spec: dict) -> ClaudeSpec:
     raw_options = raw.get("raw_options", {}) or {}
     if not isinstance(raw_options, dict):
         raw_options = {}
+    # Account POOL — ``credentials_files`` (plural). A list of host paths
+    # to ``.credentials.json`` files; the start pre-flight picks one
+    # quota-aware. Coerce defensively to ``list[str]`` (the validator is
+    # the SSOT for the "must be a list of strings" diagnostic); a non-list
+    # / non-string entries degrade to an empty pool here so an unvalidated
+    # fixture path never crashes the loader.
+    raw_cred_files = raw.get("credentials_files", []) or []
+    credentials_files: list[str] = []
+    if isinstance(raw_cred_files, list):
+        credentials_files = [
+            str(p) for p in raw_cred_files if isinstance(p, str) and p.strip()
+        ]
     return ClaudeSpec(
         model=str(raw.get("model", "") or ""),
         channels=raw.get("channels", []) or [],
@@ -108,6 +120,7 @@ def parse_claude(spec: dict) -> ClaudeSpec:
         auto_accept=raw.get("auto_accept", True),
         account=str(raw.get("account", "") or ""),
         credentials_file=str(raw.get("credentials_file", "") or ""),
+        credentials_files=credentials_files,
         provider=_parse_provider(raw),
         raw_options=dict(raw_options),
     )

--- a/src/scitex_agent_container/config/_types.py
+++ b/src/scitex_agent_container/config/_types.py
@@ -111,6 +111,22 @@ class ClaudeSpec:
     # in-place is safe; designate a path NOT concurrently atomic-renamed
     # by host-side ``sac accounts``/watch-live tooling.
     credentials_file: str = ""
+    # Account POOL: a list of host paths to ``.credentials.json`` files
+    # (one per saved account). When non-empty, the start pre-flight picks
+    # ONE of them QUOTA-AWARE — the token-fresh account with the most 7d
+    # weekly-cap headroom (see ``_creds.pick_healthy_account`` +
+    # ``_lifecycle._start_preflight._rotate_to_healthy_account``) — and
+    # binds the PICKED file exactly as if it had been named in the singular
+    # ``credentials_file`` field. Each entry's ACCOUNT SLUG is its parent
+    # directory name (the fleet layout is
+    # ``~/.scitex/agent-container/accounts/<slug>/.credentials.json``), and
+    # that slug is the account name the quota-aware picker keys off. The
+    # singular ``credentials_file`` remains supported and is treated as a
+    # 1-element pool (pick returns it) for back-compat. Fail-loud: when NO
+    # listed entry has a usable (non-expired) snapshot the start aborts with
+    # ``_creds.NoHealthyAccountError``. Mutually exclusive with ``provider``
+    # (an API-key backend needs no OAuth).
+    credentials_files: list[str] = field(default_factory=list)
     # Vendor-agnostic backend override (see :class:`ProviderSpec`).
     # When set, the SDK session runs against an Anthropic-SDK-compatible
     # backend (DeepSeek, a gateway, ...) on an API key instead of

--- a/tests/scitex_agent_container/_lifecycle/test__start_creds_files_pool.py
+++ b/tests/scitex_agent_container/_lifecycle/test__start_creds_files_pool.py
@@ -1,0 +1,197 @@
+"""Tests for the ``credentials_files`` (plural) quota-aware account pool.
+
+This is the wiring that makes the quota-aware pick (PR #583/#584) affect
+``credentials_file``-pinned fleet agents: a spec lists MULTIPLE account
+credential files and the start pre-flight
+(:func:`_lifecycle._start_preflight._rotate_to_healthy_account`) picks ONE
+of them QUOTA-AWARE, collapsing the pool down to
+``config.claude.credentials_file`` (the field every downstream auth path
+already binds).
+
+PA-306: no mocks. Real config dataclasses, real store snapshots, real
+``_rotate_to_healthy_account`` mutation against an isolated ``$HOME``.
+Quota + freshness are injected via the picker's documented override params
+(``usage_7d`` / ``now``) — no real quota cache, no network. AAA markers,
+descriptive names, one assertion each.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import time
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from scitex_agent_container._creds import NoHealthyAccountError
+from scitex_agent_container._lifecycle._start import _rotate_to_healthy_account
+from scitex_agent_container.config import AgentConfig
+
+
+@pytest.fixture
+def _isolate_home(tmp_path: Path) -> Iterator[Path]:
+    saved = os.environ.get("HOME")
+    os.environ["HOME"] = str(tmp_path)
+    try:
+        yield tmp_path
+    finally:
+        if saved is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = saved
+
+
+def _snapshot_path(home: Path, slug: str) -> Path:
+    return (
+        home / ".scitex" / "agent-container" / "accounts" / slug / ".credentials.json"
+    )
+
+
+def _write_snapshot(home: Path, slug: str, expires_at_ms: int) -> Path:
+    path = _snapshot_path(home, slug)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"claudeAiOauth": {"expiresAt": expires_at_ms}}))
+    return path
+
+
+def _future_ms(seconds: float = 7200.0) -> int:
+    return int((time.time() + seconds) * 1_000)
+
+
+def _past_ms(seconds: float = 600.0) -> int:
+    return int((time.time() - seconds) * 1_000)
+
+
+def _make_pool_config(name: str, paths: list[Path]) -> AgentConfig:
+    cfg = AgentConfig(name=name)
+    cfg.claude.credentials_files = [str(p) for p in paths]
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# Pool of 3 fresh entries — quota-aware pick selects the most-headroom one.
+# ---------------------------------------------------------------------------
+
+
+def test_pool_picks_most_headroom_fresh_entry(_isolate_home: Path) -> None:
+    # Arrange — 3 fresh accounts; the FIRST (preferred) is near-capped so
+    # the pick must rotate off it to the lowest-7d fresh sibling.
+    home = _isolate_home
+    p_a = _write_snapshot(home, "acct-a", _future_ms())
+    p_b = _write_snapshot(home, "acct-b", _future_ms())
+    p_c = _write_snapshot(home, "acct-c", _future_ms())
+    cfg = _make_pool_config("alpha", [p_a, p_b, p_c])
+    # Act — inject per-account 7d utilisation (no real cache).
+    _rotate_to_healthy_account(
+        cfg,
+        log_stream=io.StringIO(),
+        usage_7d={"acct-a": 95.0, "acct-b": 10.0, "acct-c": 40.0},
+    )
+    # Assert — acct-b has the most 7d headroom → its file is bound.
+    assert cfg.claude.credentials_file == str(p_b)
+
+
+def test_pool_selection_emits_a_one_line_notice(_isolate_home: Path) -> None:
+    # Arrange
+    home = _isolate_home
+    p_a = _write_snapshot(home, "acct-a", _future_ms())
+    p_b = _write_snapshot(home, "acct-b", _future_ms())
+    cfg = _make_pool_config("alpha", [p_a, p_b])
+    log = io.StringIO()
+    # Act
+    _rotate_to_healthy_account(
+        cfg, log_stream=log, usage_7d={"acct-a": 95.0, "acct-b": 5.0}
+    )
+    # Assert — operator sees WHICH agent and WHICH account was selected.
+    msg = log.getvalue()
+    assert "alpha" in msg and "acct-b" in msg
+
+
+# ---------------------------------------------------------------------------
+# Only one entry is token-fresh — it is returned even when near-capped.
+# ---------------------------------------------------------------------------
+
+
+def test_pool_returns_capped_but_only_fresh_entry(_isolate_home: Path) -> None:
+    # Arrange — a + c EXPIRED, only b is fresh (and near its weekly cap).
+    home = _isolate_home
+    p_a = _write_snapshot(home, "acct-a", _past_ms(60))
+    p_b = _write_snapshot(home, "acct-b", _future_ms())
+    p_c = _write_snapshot(home, "acct-c", _past_ms(60))
+    cfg = _make_pool_config("alpha", [p_a, p_b, p_c])
+    # Act — headroom is a preference, not a hard gate.
+    _rotate_to_healthy_account(
+        cfg,
+        log_stream=io.StringIO(),
+        usage_7d={"acct-a": 5.0, "acct-b": 96.0, "acct-c": 5.0},
+    )
+    # Assert — the only fresh account wins despite being near-capped.
+    assert cfg.claude.credentials_file == str(p_b)
+
+
+# ---------------------------------------------------------------------------
+# Nothing fresh in the pool — fail loud.
+# ---------------------------------------------------------------------------
+
+
+def test_pool_all_expired_raises_no_healthy_account_error(_isolate_home: Path) -> None:
+    # Arrange — every listed snapshot is expired.
+    home = _isolate_home
+    p_a = _write_snapshot(home, "acct-a", _past_ms(60))
+    p_b = _write_snapshot(home, "acct-b", _past_ms(60))
+    cfg = _make_pool_config("alpha", [p_a, p_b])
+    # Act
+    ctx = pytest.raises(NoHealthyAccountError)
+    # Assert — no silent stale-token launch.
+    with ctx:
+        _rotate_to_healthy_account(cfg)
+
+
+# ---------------------------------------------------------------------------
+# Back-compat: singular credentials_file still resolves to its one account.
+# ---------------------------------------------------------------------------
+
+
+def test_singular_credentials_file_resolves_to_that_one_account(
+    _isolate_home: Path,
+) -> None:
+    # Arrange — legacy singular field, one fresh snapshot, no pool.
+    home = _isolate_home
+    p = _write_snapshot(home, "acct-solo", _future_ms())
+    cfg = AgentConfig(name="alpha")
+    cfg.claude.credentials_file = str(p)
+    # Act — treated as a 1-element pool; pick returns it.
+    _rotate_to_healthy_account(cfg, log_stream=io.StringIO())
+    # Assert — the designated file is unchanged (pure no-op).
+    assert cfg.claude.credentials_file == str(p)
+
+
+def test_singular_credentials_file_emits_no_notice(_isolate_home: Path) -> None:
+    # Arrange
+    home = _isolate_home
+    p = _write_snapshot(home, "acct-solo", _future_ms())
+    cfg = AgentConfig(name="alpha")
+    cfg.claude.credentials_file = str(p)
+    log = io.StringIO()
+    # Act
+    _rotate_to_healthy_account(cfg, log_stream=log)
+    # Assert — a 1-element pool that keeps its entry logs nothing.
+    assert log.getvalue() == ""
+
+
+# ---------------------------------------------------------------------------
+# Empty / absent — unchanged legacy behaviour (no pool, no pin).
+# ---------------------------------------------------------------------------
+
+
+def test_no_pool_no_pin_leaves_credentials_file_empty(_isolate_home: Path) -> None:
+    # Arrange — unpinned agent: no credentials_files, no credentials_file.
+    cfg = AgentConfig(name="alpha")
+    log = io.StringIO()
+    # Act
+    _rotate_to_healthy_account(cfg, log_stream=log)
+    # Assert — host live OAuth path untouched.
+    assert cfg.claude.credentials_file == "" and cfg.claude.account == ""


### PR DESCRIPTION
## What

Adds `spec.claude.credentials_files` (PLURAL) — an account POOL. A spec
lists MULTIPLE account credential files and the start pre-flight picks ONE
of them QUOTA-AWARE, then binds the picked file exactly as if it had been
named in the singular `credentials_file` field.

This is **the wiring that makes the quota-aware pick (#583/#584) actually
affect the fleet.** Previously `_rotate_to_healthy_account` returned early
whenever `spec.claude.account` was empty, so `credentials_file`-pinned
agents (what the fleet uses) BYPASSED the quota-aware pool pick entirely.

## How

- **`config._types.ClaudeSpec.credentials_files: list[str]`** (default `[]`)
  + parser (`config/_parsers/_claude.py`) + validation
  (`config/_claude_validation.py`: must be a list of non-empty strings;
  mutually exclusive with `provider`, mirroring `account`). The singular
  `credentials_file: str` is retained for back-compat.

- **Multi-account pick hooked in
  `_lifecycle/_start_preflight._rotate_to_healthy_account`** (new helper
  `_rotate_among_credentials_files`). When `credentials_files` is non-empty
  (OR the singular `credentials_file` is set — treated as a 1-element
  pool), each entry's ACCOUNT SLUG is derived from its parent-dir name
  (fleet layout: `~/.scitex/agent-container/accounts/<slug>/.credentials.json`),
  the slug list is handed to `pick_healthy_account(preferred, candidates=…)`
  (#583) so the SAME quota-aware pick — token-fresh account with the most
  7d weekly-cap headroom — chooses among exactly the listed accounts, and
  the pool is collapsed down to the picked entry by writing it into
  `config.claude.credentials_file`. **Every downstream auth path
  (`runtimes._apptainer_auth.auth_argv` / `credentials_file_bind`) is
  unchanged** — it already resolves `credentials_file`; this only decides
  WHICH file it binds.

  Health/quota probing reads each slug's snapshot from the pool's common
  parent dir (`store_dir`), so it inspects the EXACT listed files (works
  for the fleet `accounts/` layout and custom locations). `preferred` is
  the currently-effective account when it is one of the listed slugs
  (minimise churn), else the first listed entry.

- **Fail-loud:** no listed entry has a usable (non-expired) snapshot →
  `NoHealthyAccountError` propagates; the agent is NOT started.

## Back-compat

- A spec with only the singular `credentials_file` → 1-element pool; a
  healthy snapshot resolves to that exact file (pure no-op, `credentials_file`
  unchanged, no log line). *(Note: an EXPIRED singular now fails loud at
  pre-flight with `NoHealthyAccountError` instead of at bind time with
  `CredentialExpiredError` — both fail-loud, agent doesn't start either way.)*
- A spec with `account` (name) still works via the existing named-account
  path, unchanged.
- Empty/absent (no pool, no pin) → unpinned host-live OAuth path untouched.

## Tests (targeted only — full suite NOT run)

New `tests/…/_lifecycle/test__start_creds_files_pool.py`: 3-entry pool
picks the most-headroom fresh entry; a capped-but-only-fresh entry is still
returned; all-expired pool fails loud; singular `credentials_file`
back-compat no-op; empty/absent unchanged. Quota + freshness injected via
the picker's `usage_7d` / `now` override params — no real cache, no network.

```
35 passed  (7 new pool + 8 existing rotate + 20 pick)
270 passed (config parser + validation)
```

## Follow-up

Fleet specs still need migrating from `credentials_file:` → `credentials_files: [...]`
to opt into the pool (parent agent will do the spec edits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
