### PR TITLE
feat(experimental): codex app-server -> Anthropic Messages adapter (MVP/POC)

### DIFF
--- a/src/scitex_agent_container/_experimental/README_codex_anthropic_adapter.md
+++ b/src/scitex_agent_container/_experimental/README_codex_anthropic_adapter.md
@@ -1,0 +1,71 @@
+# Codex app-server → Anthropic Messages adapter (MVP / POC)
+
+**Status: experimental spike.** Not imported by the package, not wired into any
+spec or CLI. Lives under `_experimental/` on purpose. See the module docstring
+in `codex_anthropic_adapter.py` for the authoritative detail — this note is the
+one-screen summary.
+
+## What it proves
+
+The **engine-swap** path works end-to-end: a client that only speaks the
+Anthropic Messages API (the Claude Code box) can be driven by the **OpenAI
+Codex** engine (gpt-5.5) with **zero client changes** — just
+`ANTHROPIC_BASE_URL=http://127.0.0.1:8787`.
+
+```
+Claude Code / any Anthropic client
+   │  POST /v1/messages          (Anthropic Messages shape)
+   ▼
+codex_anthropic_adapter.py       (stdlib http.server, no new deps)
+   │  JSON-RPC 2.0 over stdio
+   ▼
+`codex app-server`               (OAuth auto-read from ~/.codex/auth.json)
+   ▼
+OpenAI Codex (gpt-5.5)
+```
+
+Auth reuses the operator's existing `~/.codex` login — no API key, no re-auth.
+The codex driver is a faithful reproduction of the proven probe
+`~/.scitex/agent-container/runtime/tmp/codex_appserver_test.py`.
+
+## Protocol (codex app-server)
+
+`initialize` → `initialized` → `thread/start{model}` (response `.result.thread.id`)
+→ `turn/start{threadId, input:[{type:text,text}]}` → reply streams as
+`item/agentMessage/delta` notifications, then `item/completed`
+(`item.type==agentMessage`, `.text` = full reply), then `turn/completed`.
+
+## Run
+
+```bash
+python -m scitex_agent_container._experimental.codex_anthropic_adapter serve
+python -m scitex_agent_container._experimental.codex_anthropic_adapter smoke  # in-process round-trip
+```
+
+## MVP simplifications (deliberate)
+
+- Non-streaming, text-only (`stream:true` ignored).
+- `system` + `messages[]` flattened into one role-tagged text prompt; every
+  request = a fresh codex thread (no 1:1 history mapping).
+- Thread-per-request (spawn + tear down codex per call; no reuse).
+- `usage` token counts estimated (~4 chars/token), not codex-reported.
+- No tool_use / tool_result bridging (rendered as text).
+- No endpoint auth / rate-limit / error mapping (loopback-only, generic 5xx).
+
+## Production follow-ups (NOT in this MVP)
+
+1. SSE streaming — emit the Anthropic event sequence from codex deltas.
+2. tool_use / tool_result bridging ↔ codex tool/exec items.
+3. Warm app-server + per-conversation thread reuse (latency/auth amortisation).
+4. Real usage accounting from codex `turn/completed`.
+5. Error + rate-limit + auth-expired mapping to Anthropic HTTP status/`error.type`.
+6. Endpoint auth (honour `x-api-key` / `authorization`).
+7. Coordinate with scitex-genai / litellm routing instead of a bespoke server;
+   multi-account `~/.codex` rotation (mirroring sac account rotation).
+
+## Verified
+
+Live round-trip captured (this branch): a `POST /v1/messages` with
+`{"model":"gpt-5.5", messages:[{role:user, content:"Reply with exactly one word: pong"}]}`
+returned a valid Anthropic response `content[0].text == "pong"` in ~2s, driven by
+`codex app-server` reading the operator's `~/.codex` OAuth. HTTP 200.

--- a/src/scitex_agent_container/_experimental/_codex_driver.py
+++ b/src/scitex_agent_container/_experimental/_codex_driver.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""codex app-server driver for the Anthropic Messages adapter (experimental).
+
+Extracted from ``codex_anthropic_adapter.py`` when SSE streaming pushed the
+single file over the line limit. This module owns the JSON-RPC-over-stdio
+conversation with ``codex app-server`` and nothing else:
+
+* :func:`iter_codex_events` — the ONE driver, a generator that yields the
+  app-server notifications (``item/agentMessage/delta`` / ``item/completed`` /
+  ``turn/completed``) as they arrive. Both the non-streaming path
+  (:func:`run_codex_turn`) and the SSE-streaming path consume this same
+  generator, so the wire behaviour can never diverge between them.
+* :func:`run_codex_turn` — non-streaming convenience: consume the generator
+  and return the final reply text.
+* per-event extraction helpers used by both the non-streaming path and the
+  pure SSE mapper in ``_codex_sse.py``.
+
+Faithful reproduction of the proven probe
+``~/.scitex/agent-container/runtime/tmp/codex_appserver_test.py``.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import threading
+import time
+from typing import Any, Optional
+
+DEFAULT_MODEL = "gpt-5.5"
+# Upper bound for how long we wait for codex to finish a turn.
+TURN_TIMEOUT_S = 120.0
+
+
+class CodexError(RuntimeError):
+    """Raised when the codex app-server turn fails or times out."""
+
+
+def iter_codex_events(
+    prompt: str,
+    model: str = DEFAULT_MODEL,
+    timeout_s: float = TURN_TIMEOUT_S,
+):
+    """Drive one ``codex app-server`` turn, yielding its JSON-RPC notifications.
+
+    initialize -> initialized -> thread/start(model) -> turn/start(prompt),
+    then yield each relevant app-server notification dict *as it arrives*:
+
+    * ``item/agentMessage/delta``  — one per incremental reply chunk
+    * ``item/completed`` / ``item/updated`` — the full agent-message item
+    * ``turn/completed`` — the final event (generator returns after yielding it)
+
+    Raises :class:`CodexError` on ``turn/failed`` / protocol error / timeout.
+    Spawn-per-call is an MVP simplification (see the adapter module docstring).
+    """
+    proc = subprocess.Popen(
+        ["codex", "app-server"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    lines: list[str] = []
+    lock = threading.Lock()
+
+    def reader(stream, tag: str) -> None:
+        for ln in stream:
+            with lock:
+                lines.append(f"{tag} {ln.rstrip()}")
+
+    threading.Thread(target=reader, args=(proc.stdout, "OUT"), daemon=True).start()
+    threading.Thread(target=reader, args=(proc.stderr, "ERR"), daemon=True).start()
+
+    def send(msg: dict[str, Any]) -> None:
+        assert proc.stdin is not None
+        proc.stdin.write(json.dumps(msg) + "\n")
+        proc.stdin.flush()
+
+    try:
+        send(
+            {
+                "method": "initialize",
+                "id": 0,
+                "params": {
+                    "clientInfo": {
+                        "name": "codex-anthropic-adapter",
+                        "title": "codex-anthropic-adapter",
+                        "version": "0.1.0",
+                    }
+                },
+            }
+        )
+        send({"method": "initialized", "params": {}})
+        send({"method": "thread/start", "id": 1, "params": {"model": model}})
+
+        thread_id: Optional[str] = None
+        turn_sent = False
+        seen = 0
+        deadline = time.time() + timeout_s
+        # Tight poll interval: keeps streamed deltas flowing to the client with
+        # low latency (the reader threads buffer between polls, so nothing is
+        # lost — this only bounds how quickly a buffered delta is surfaced).
+        while time.time() < deadline:
+            time.sleep(0.05)
+            with lock:
+                snapshot = lines[seen:]
+                seen = len(lines)
+            for raw in snapshot:
+                if raw.startswith("ERR "):
+                    continue
+                if not raw.startswith("OUT "):
+                    continue
+                try:
+                    msg = json.loads(raw[4:])
+                except Exception:
+                    continue
+
+                # thread/start response -> fire the turn
+                if (
+                    msg.get("id") == 1
+                    and isinstance(msg.get("result"), dict)
+                    and not turn_sent
+                ):
+                    tid = (msg["result"].get("thread") or {}).get("id")
+                    if tid:
+                        thread_id = tid
+                        send(
+                            {
+                                "method": "turn/start",
+                                "id": 2,
+                                "params": {
+                                    "threadId": tid,
+                                    "input": [{"type": "text", "text": prompt}],
+                                },
+                            }
+                        )
+                        turn_sent = True
+                    continue
+
+                method = msg.get("method")
+
+                if method == "item/agentMessage/delta":
+                    yield msg
+                    continue
+
+                if method in ("item/completed", "item/updated"):
+                    yield msg
+                    continue
+
+                if method == "turn/completed":
+                    yield msg
+                    return
+
+                if method == "turn/failed":
+                    raise CodexError(
+                        f"codex turn/failed: {json.dumps(msg.get('params') or {})[:500]}"
+                    )
+
+                if msg.get("error"):
+                    raise CodexError(f"codex error: {json.dumps(msg['error'])[:500]}")
+
+        with lock:
+            err_lines = [l for l in lines if l.startswith("ERR ")][-5:]
+        raise CodexError(
+            "codex turn timed out after "
+            f"{timeout_s:.0f}s (thread_id={thread_id}, turn_sent={turn_sent}); "
+            f"stderr tail: {err_lines}"
+        )
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except Exception:
+            proc.kill()
+
+
+# --------------------------------------------------------------------------- #
+# per-event extraction helpers (shared by the non-streaming path + SSE mapper)
+# --------------------------------------------------------------------------- #
+def _event_delta_text(msg: dict[str, Any]) -> str:
+    """Extract the incremental text from an ``item/agentMessage/delta`` event."""
+    params = msg.get("params") or {}
+    d = params.get("delta") or params.get("text") or ""
+    return d if isinstance(d, str) else ""
+
+
+def _event_completed_text(msg: dict[str, Any]) -> Optional[str]:
+    """Extract the full agent-message text from an ``item/completed`` event."""
+    item = (msg.get("params") or {}).get("item") or {}
+    if item.get("type") in ("agentMessage", "assistantMessage"):
+        txt = item.get("text")
+        if isinstance(txt, str) and txt:
+            return txt
+    return None
+
+
+def _event_output_tokens(msg: dict[str, Any]) -> Optional[int]:
+    """Best-effort real output-token count from a ``turn/completed`` event.
+
+    codex's usage shape is not contractually pinned here, so probe a few
+    plausible locations and fall back to ``None`` (caller then estimates).
+    """
+    params = msg.get("params") or {}
+    for container in (params, params.get("turn") or {}, params.get("usage") or {}):
+        if not isinstance(container, dict):
+            continue
+        usage = (
+            container.get("usage")
+            if isinstance(container.get("usage"), dict)
+            else container
+        )
+        for key in ("output_tokens", "outputTokens", "completion_tokens"):
+            val = usage.get(key)
+            if isinstance(val, int):
+                return val
+    return None
+
+
+def _estimate_tokens(text: str) -> int:
+    """Crude token estimate (~4 chars/token). MVP placeholder for real usage."""
+    if not text:
+        return 0
+    return max(len(text) // 4, len(text.split()))
+
+
+def run_codex_turn(
+    prompt: str,
+    model: str = DEFAULT_MODEL,
+    timeout_s: float = TURN_TIMEOUT_S,
+) -> str:
+    """Drive one ``codex app-server`` turn and return the agent's reply text.
+
+    Non-streaming: consumes :func:`iter_codex_events`, preferring the full
+    ``item/completed`` text and falling back to accumulated deltas. On a
+    timeout (``CodexError``) any partial reply is salvaged, else re-raised.
+    """
+    reply_text: Optional[str] = None
+    delta_buf: list[str] = []
+    try:
+        for msg in iter_codex_events(prompt, model=model, timeout_s=timeout_s):
+            method = msg.get("method")
+            if method == "item/agentMessage/delta":
+                delta_buf.append(_event_delta_text(msg))
+            elif method in ("item/completed", "item/updated"):
+                txt = _event_completed_text(msg)
+                if txt is not None:
+                    reply_text = txt
+            elif method == "turn/completed":
+                break
+    except CodexError:
+        # timed out / errored — salvage any partial reply, else fail loudly
+        if reply_text is not None:
+            return reply_text
+        if delta_buf:
+            return "".join(delta_buf)
+        raise
+    if reply_text is not None:
+        return reply_text
+    return "".join(delta_buf)

--- a/src/scitex_agent_container/_experimental/_codex_sse.py
+++ b/src/scitex_agent_container/_experimental/_codex_sse.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Anthropic Server-Sent-Events mapping for the codex adapter (experimental).
+
+Pure translation layer: given a sequence of ``codex app-server`` notification
+dicts (the same objects :func:`.._codex_driver.iter_codex_events` yields), emit
+the ordered Anthropic Messages *streaming* event sequence
+
+    message_start
+    content_block_start        (index 0, type text)
+    content_block_delta x N    (type text_delta — ONE per codex delta chunk)
+    content_block_stop
+    message_delta              (stop_reason=end_turn + final usage)
+    message_stop
+
+Deliberately network-free: :func:`codex_stream_to_anthropic_sse` is a generator
+over whatever iterable of codex events it is handed. The live path feeds it the
+real (lazy) ``iter_codex_events`` generator so frames stream in real time; a
+unit test feeds it a canned in-memory delta sequence and asserts the mapping —
+a real test of the translation with no mocked network.
+
+See the Anthropic Messages streaming spec for the frame wire format
+(``event: <type>\\ndata: <json>\\n\\n``).
+"""
+from __future__ import annotations
+
+import json
+import uuid
+from typing import Any, Iterable, Iterator
+
+from ._codex_driver import (
+    _estimate_tokens,
+    _event_completed_text,
+    _event_delta_text,
+    _event_output_tokens,
+)
+
+
+def format_sse_frame(event_type: str, data: dict[str, Any]) -> str:
+    """Serialise one Anthropic SSE frame: ``event: <type>\\ndata: <json>\\n\\n``."""
+    return f"event: {event_type}\ndata: {json.dumps(data)}\n\n"
+
+
+def parse_sse_stream(text: str) -> list[tuple[str, Any]]:
+    """Parse concatenated SSE frames back into ``(event_type, data)`` pairs.
+
+    Inverse of :func:`format_sse_frame`, used by the streaming smoke test and
+    unit tests to assert the emitted frame sequence. Blank-line-separated
+    frames; each frame carries an ``event:`` line and a JSON ``data:`` line.
+    """
+    events: list[tuple[str, Any]] = []
+    for block in text.split("\n\n"):
+        block = block.strip("\n")
+        if not block:
+            continue
+        event_type: str | None = None
+        data: Any = None
+        for line in block.split("\n"):
+            if line.startswith("event:"):
+                event_type = line[len("event:") :].strip()
+            elif line.startswith("data:"):
+                data = json.loads(line[len("data:") :].strip())
+        if event_type is not None:
+            events.append((event_type, data))
+    return events
+
+
+def codex_stream_to_anthropic_sse(
+    codex_events: Iterable[dict[str, Any]],
+    *,
+    model: str,
+    prompt: str = "",
+    message_id: str | None = None,
+) -> Iterator[tuple[str, dict[str, Any]]]:
+    """Map codex app-server events to ordered Anthropic streaming events.
+
+    Yields ``(event_type, data)`` tuples in the canonical Anthropic order. The
+    caller serialises each with :func:`format_sse_frame`. ``codex_events`` may
+    be a live generator (real-time streaming) or a canned list (unit testing);
+    the mapping logic is identical either way.
+
+    Mapping rules:
+    * ``item/agentMessage/delta`` -> one ``content_block_delta`` (text_delta).
+    * ``item/completed`` with agent text but no prior deltas -> emit that full
+      text as a single ``content_block_delta`` (non-streaming-codex fallback).
+    * ``turn/completed`` -> real output-token count if codex reports one, else
+      the estimate from the reassembled text is used in ``message_delta``.
+    """
+    message_id = message_id or f"msg_{uuid.uuid4().hex[:24]}"
+
+    # message_start — envelope with empty content + placeholder usage.
+    yield (
+        "message_start",
+        {
+            "type": "message_start",
+            "message": {
+                "id": message_id,
+                "type": "message",
+                "role": "assistant",
+                "model": model,
+                "content": [],
+                "stop_reason": None,
+                "stop_sequence": None,
+                "usage": {
+                    "input_tokens": _estimate_tokens(prompt),
+                    "output_tokens": 0,
+                },
+            },
+        },
+    )
+    yield (
+        "content_block_start",
+        {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {"type": "text", "text": ""},
+        },
+    )
+
+    acc: list[str] = []
+    saw_delta = False
+    reported_out_tokens: int | None = None
+
+    for msg in codex_events:
+        method = msg.get("method")
+        if method == "item/agentMessage/delta":
+            chunk = _event_delta_text(msg)
+            if chunk:
+                saw_delta = True
+                acc.append(chunk)
+                yield (
+                    "content_block_delta",
+                    {
+                        "type": "content_block_delta",
+                        "index": 0,
+                        "delta": {"type": "text_delta", "text": chunk},
+                    },
+                )
+        elif method in ("item/completed", "item/updated"):
+            # Fallback: codex that did NOT stream deltas still carries the full
+            # reply on the completed item — surface it as one delta so the
+            # client always receives the text.
+            if not saw_delta:
+                txt = _event_completed_text(msg)
+                if txt:
+                    saw_delta = True
+                    acc.append(txt)
+                    yield (
+                        "content_block_delta",
+                        {
+                            "type": "content_block_delta",
+                            "index": 0,
+                            "delta": {"type": "text_delta", "text": txt},
+                        },
+                    )
+        elif method == "turn/completed":
+            tok = _event_output_tokens(msg)
+            if tok is not None:
+                reported_out_tokens = tok
+
+    yield ("content_block_stop", {"type": "content_block_stop", "index": 0})
+
+    out_tokens = (
+        reported_out_tokens
+        if reported_out_tokens is not None
+        else _estimate_tokens("".join(acc))
+    )
+    yield (
+        "message_delta",
+        {
+            "type": "message_delta",
+            "delta": {"stop_reason": "end_turn", "stop_sequence": None},
+            "usage": {"output_tokens": out_tokens},
+        },
+    )
+    yield ("message_stop", {"type": "message_stop"})

--- a/src/scitex_agent_container/_experimental/codex_anthropic_adapter.py
+++ b/src/scitex_agent_container/_experimental/codex_anthropic_adapter.py
@@ -1,0 +1,472 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Codex app-server -> Anthropic Messages API adapter (MVP / proof-of-concept).
+
+Architecture
+------------
+
+    Claude Code (or any Anthropic Messages client)
+        │   POST /v1/messages   (Anthropic Messages shape)
+        │   ANTHROPIC_BASE_URL=http://127.0.0.1:8787
+        ▼
+    THIS adapter  (stdlib http.server, no new deps)
+        │   JSON-RPC 2.0 over stdio
+        ▼
+    `codex app-server`   (spawned as a subprocess)
+        │   OAuth read automatically from ~/.codex/auth.json
+        ▼
+    OpenAI Codex engine (gpt-5.5)
+
+The point this proves: the "engine swap" path works end-to-end. A client that
+only knows how to speak the Anthropic Messages API (the Claude Code box) can be
+pointed at this adapter via ``ANTHROPIC_BASE_URL`` and have its turns answered
+by the Codex engine, reusing the operator's existing ``~/.codex`` OAuth login.
+No API key, no re-auth: ``codex app-server`` reads ``~/.codex/auth.json`` itself.
+
+The codex driver here is a faithful reproduction of the proven probe at
+``~/.scitex/agent-container/runtime/tmp/codex_appserver_test.py`` (which showed
+gpt-5.5 returning "pong" in ~2s over the app-server protocol).
+
+MVP simplifications (documented, deliberate)
+--------------------------------------------
+This is an MVP / POC, NOT the production adapter. It is intentionally minimal:
+
+* NON-STREAMING, TEXT-ONLY. ``stream:true`` is ignored (we always return a
+  single non-streaming JSON body). Only text content blocks are handled.
+* Conversation flattening. The Anthropic ``system`` + ``messages[]`` array is
+  flattened into ONE role-tagged plain-text transcript that is sent as the
+  single ``turn/start`` input. We do NOT map the structured message history
+  onto codex threads/turns 1:1 — every request is a fresh codex thread.
+* Thread-per-request. A new ``codex app-server`` process + thread is spawned
+  for every HTTP request, then torn down. No thread reuse / no multi-turn state
+  is kept between requests. (Production should keep a warm app-server and reuse
+  a thread keyed by conversation.)
+* ``usage`` token counts are ESTIMATED (~4 chars/token, whitespace-split
+  fallback), not real. codex app-server does surface token usage in
+  ``turn/completed`` / usage notifications; wiring that through is a follow-up.
+* NO tool_use / tool_result mapping. Anthropic ``tool_use`` blocks and codex
+  tool/exec items are NOT bridged. Tool-call payloads in the request are
+  rendered as text only.
+* NO auth / rate-limit / error mapping on the HTTP endpoint. The endpoint is
+  unauthenticated and binds loopback by default. codex errors become a generic
+  500-ish Anthropic ``error`` body.
+
+Production follow-ups (do NOT do these in the MVP)
+--------------------------------------------------
+1. SSE streaming: honour ``stream:true`` and emit the Anthropic event sequence
+   (``message_start`` -> ``content_block_start`` -> ``content_block_delta`` x N
+   -> ``content_block_stop`` -> ``message_delta`` -> ``message_stop``) driven by
+   the codex ``item/agentMessage/delta`` notifications.
+2. tool_use / tool_result bridging: map Anthropic tool_use blocks <-> codex
+   tool/exec items so agentic tool loops work through the adapter.
+3. Warm app-server + thread reuse: keep one long-lived ``codex app-server`` and
+   reuse a thread per conversation instead of spawn-per-request (latency + auth
+   amortisation). Track thread ids keyed by the client conversation.
+4. Real usage accounting from codex ``turn/completed`` usage fields, mapped to
+   Anthropic ``usage.input_tokens`` / ``output_tokens``.
+5. Error + rate-limit mapping: translate codex ``turn/failed`` / auth-expired /
+   quota errors to the correct Anthropic HTTP status + ``error.type``.
+6. Endpoint auth: require the ``x-api-key`` / ``authorization`` header the
+   Anthropic client already sends, and bind non-loopback only behind that.
+7. Coordinate with the ecosystem's LLM plumbing (scitex-genai / litellm) rather
+   than a bespoke server: this adapter is the "prove the wire" spike, and the
+   production version should slot into that routing layer, including multi-account
+   ``~/.codex`` rotation (mirroring the sac account-rotation story).
+
+Usage
+-----
+    # start the adapter (needs `codex` on PATH + ~/.codex/auth.json)
+    python -m scitex_agent_container._experimental.codex_anthropic_adapter serve
+
+    # point a client at it
+    export ANTHROPIC_BASE_URL=http://127.0.0.1:8787
+    curl -s http://127.0.0.1:8787/v1/messages -H 'content-type: application/json' \
+      -d '{"model":"gpt-5.5","max_tokens":64,
+           "messages":[{"role":"user","content":"Reply with one word: pong"}]}'
+
+    # built-in smoke test (spins up the server in-process, does one round-trip)
+    python -m scitex_agent_container._experimental.codex_anthropic_adapter smoke
+
+Experimental: this module lives under ``_experimental/`` and is NOT imported by
+the package, wired into any spec, or covered by the CLI. It is a spike.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import threading
+import time
+import uuid
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any, Optional
+
+DEFAULT_MODEL = "gpt-5.5"
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 8787
+# Upper bound for how long we wait for codex to finish a turn.
+TURN_TIMEOUT_S = 120.0
+
+
+# --------------------------------------------------------------------------- #
+# codex app-server driver (reproduces the proven codex_appserver_test.py)
+# --------------------------------------------------------------------------- #
+class CodexError(RuntimeError):
+    """Raised when the codex app-server turn fails or times out."""
+
+
+def run_codex_turn(
+    prompt: str,
+    model: str = DEFAULT_MODEL,
+    timeout_s: float = TURN_TIMEOUT_S,
+) -> str:
+    """Drive one ``codex app-server`` turn and return the agent's reply text.
+
+    initialize -> initialized -> thread/start(model) -> turn/start(prompt),
+    then collect the ``agentMessage`` reply from the ``item/completed``
+    notification (falling back to accumulated ``item/agentMessage/delta``).
+
+    Spawn-per-call is an MVP simplification (see module docstring).
+    """
+    proc = subprocess.Popen(
+        ["codex", "app-server"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    lines: list[str] = []
+    lock = threading.Lock()
+
+    def reader(stream, tag: str) -> None:
+        for ln in stream:
+            with lock:
+                lines.append(f"{tag} {ln.rstrip()}")
+
+    threading.Thread(target=reader, args=(proc.stdout, "OUT"), daemon=True).start()
+    threading.Thread(target=reader, args=(proc.stderr, "ERR"), daemon=True).start()
+
+    def send(msg: dict[str, Any]) -> None:
+        assert proc.stdin is not None
+        proc.stdin.write(json.dumps(msg) + "\n")
+        proc.stdin.flush()
+
+    reply_text: Optional[str] = None
+    delta_buf: list[str] = []
+    error_detail: Optional[str] = None
+    try:
+        send(
+            {
+                "method": "initialize",
+                "id": 0,
+                "params": {
+                    "clientInfo": {
+                        "name": "codex-anthropic-adapter",
+                        "title": "codex-anthropic-adapter",
+                        "version": "0.1.0",
+                    }
+                },
+            }
+        )
+        send({"method": "initialized", "params": {}})
+        send({"method": "thread/start", "id": 1, "params": {"model": model}})
+
+        thread_id: Optional[str] = None
+        turn_sent = False
+        seen = 0
+        deadline = time.time() + timeout_s
+        while time.time() < deadline:
+            time.sleep(0.2)
+            with lock:
+                snapshot = lines[seen:]
+                seen = len(lines)
+            for raw in snapshot:
+                if raw.startswith("ERR "):
+                    continue
+                if not raw.startswith("OUT "):
+                    continue
+                try:
+                    msg = json.loads(raw[4:])
+                except Exception:
+                    continue
+
+                # thread/start response -> fire the turn
+                if (
+                    msg.get("id") == 1
+                    and isinstance(msg.get("result"), dict)
+                    and not turn_sent
+                ):
+                    tid = (msg["result"].get("thread") or {}).get("id")
+                    if tid:
+                        thread_id = tid
+                        send(
+                            {
+                                "method": "turn/start",
+                                "id": 2,
+                                "params": {
+                                    "threadId": tid,
+                                    "input": [{"type": "text", "text": prompt}],
+                                },
+                            }
+                        )
+                        turn_sent = True
+                    continue
+
+                method = msg.get("method")
+                params = msg.get("params") or {}
+
+                # streamed deltas — accumulate as a fallback reply source
+                if method == "item/agentMessage/delta":
+                    d = params.get("delta") or params.get("text") or ""
+                    if isinstance(d, str):
+                        delta_buf.append(d)
+                    continue
+
+                # completed item carries the full agent reply text
+                if method in ("item/completed", "item/updated"):
+                    item = params.get("item") or {}
+                    if item.get("type") in ("agentMessage", "assistantMessage"):
+                        txt = item.get("text")
+                        if isinstance(txt, str) and txt:
+                            reply_text = txt
+                    continue
+
+                if method == "turn/completed":
+                    if reply_text is None and delta_buf:
+                        reply_text = "".join(delta_buf)
+                    if reply_text is not None:
+                        return reply_text
+                    # no text but turn is done — return whatever we have
+                    return "".join(delta_buf)
+
+                if method == "turn/failed":
+                    error_detail = json.dumps(params)[:500]
+                    raise CodexError(f"codex turn/failed: {error_detail}")
+
+                if msg.get("error"):
+                    error_detail = json.dumps(msg["error"])[:500]
+                    raise CodexError(f"codex error: {error_detail}")
+
+        # timed out — salvage any partial reply, else fail loudly
+        if reply_text is not None:
+            return reply_text
+        if delta_buf:
+            return "".join(delta_buf)
+        with lock:
+            err_lines = [l for l in lines if l.startswith("ERR ")][-5:]
+        raise CodexError(
+            "codex turn timed out after "
+            f"{timeout_s:.0f}s (thread_id={thread_id}, turn_sent={turn_sent}); "
+            f"stderr tail: {err_lines}"
+        )
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except Exception:
+            proc.kill()
+
+
+# --------------------------------------------------------------------------- #
+# Anthropic Messages <-> flattened-prompt translation
+# --------------------------------------------------------------------------- #
+def _content_to_text(content: Any) -> str:
+    """Flatten an Anthropic message ``content`` (str OR block list) to text."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for block in content:
+            if not isinstance(block, dict):
+                parts.append(str(block))
+                continue
+            btype = block.get("type")
+            if btype == "text":
+                parts.append(block.get("text", ""))
+            elif btype == "tool_use":  # MVP: render, don't bridge
+                parts.append(
+                    f"[tool_use name={block.get('name')} "
+                    f"input={json.dumps(block.get('input', {}))}]"
+                )
+            elif btype == "tool_result":  # MVP: render, don't bridge
+                parts.append(f"[tool_result {_content_to_text(block.get('content', ''))}]")
+            else:
+                parts.append(json.dumps(block))
+        return "\n".join(p for p in parts if p)
+    return str(content)
+
+
+def flatten_request(body: dict[str, Any]) -> str:
+    """Flatten Anthropic ``system`` + ``messages[]`` into one text prompt.
+
+    MVP: a simple role-tagged transcript. System prompt first, then each turn
+    prefixed with its role, then a trailing ``Assistant:`` cue. This preserves
+    multi-turn context as plain text without mapping onto codex threads.
+    """
+    segments: list[str] = []
+
+    system = body.get("system")
+    if isinstance(system, list):  # system can be a content-block list too
+        system = _content_to_text(system)
+    if system:
+        segments.append(f"System: {system}")
+
+    for msg in body.get("messages", []) or []:
+        role = msg.get("role", "user")
+        text = _content_to_text(msg.get("content", ""))
+        label = "User" if role == "user" else "Assistant"
+        segments.append(f"{label}: {text}")
+
+    segments.append("Assistant:")
+    return "\n\n".join(segments)
+
+
+def _estimate_tokens(text: str) -> int:
+    """Crude token estimate (~4 chars/token). MVP placeholder for real usage."""
+    if not text:
+        return 0
+    return max(len(text) // 4, len(text.split()))
+
+
+def build_anthropic_response(
+    reply_text: str, model: str, prompt: str
+) -> dict[str, Any]:
+    """Wrap the codex reply in a non-streaming Anthropic Messages response."""
+    return {
+        "id": f"msg_{uuid.uuid4().hex[:24]}",
+        "type": "message",
+        "role": "assistant",
+        "model": model,
+        "content": [{"type": "text", "text": reply_text}],
+        "stop_reason": "end_turn",
+        "stop_sequence": None,
+        "usage": {
+            # MVP: estimated, not codex-reported. See follow-up #4.
+            "input_tokens": _estimate_tokens(prompt),
+            "output_tokens": _estimate_tokens(reply_text),
+        },
+    }
+
+
+# --------------------------------------------------------------------------- #
+# HTTP server
+# --------------------------------------------------------------------------- #
+class _Handler(BaseHTTPRequestHandler):
+    server_version = "codex-anthropic-adapter/0.1"
+
+    def _json(self, status: int, payload: dict[str, Any]) -> None:
+        data = json.dumps(payload).encode()
+        self.send_response(status)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def log_message(self, fmt: str, *args: Any) -> None:  # quieter default log
+        sys.stderr.write("[adapter] " + (fmt % args) + "\n")
+
+    def do_POST(self) -> None:  # noqa: N802 (stdlib signature)
+        if self.path.rstrip("/") != "/v1/messages":
+            self._json(404, {"type": "error", "error": {"type": "not_found_error", "message": self.path}})
+            return
+        try:
+            length = int(self.headers.get("content-length", 0))
+            body = json.loads(self.rfile.read(length) or b"{}")
+        except Exception as exc:  # malformed body
+            self._json(400, {"type": "error", "error": {"type": "invalid_request_error", "message": str(exc)}})
+            return
+
+        model = body.get("model") or DEFAULT_MODEL
+        # MVP: codex app-server drives its own model; we default gpt-5.5 unless
+        # the client model name looks like a gpt-* codex model.
+        codex_model = model if str(model).startswith("gpt-") else DEFAULT_MODEL
+        prompt = flatten_request(body)
+
+        try:
+            reply = run_codex_turn(prompt, model=codex_model)
+        except CodexError as exc:
+            self._json(502, {"type": "error", "error": {"type": "api_error", "message": str(exc)}})
+            return
+        except FileNotFoundError:
+            self._json(
+                500,
+                {"type": "error", "error": {"type": "api_error", "message": "`codex` binary not found on PATH"}},
+            )
+            return
+        except Exception as exc:  # noqa: BLE001 — MVP generic mapping
+            self._json(500, {"type": "error", "error": {"type": "api_error", "message": repr(exc)}})
+            return
+
+        self._json(200, build_anthropic_response(reply, model=model, prompt=prompt))
+
+
+def serve(host: str = DEFAULT_HOST, port: int = DEFAULT_PORT) -> ThreadingHTTPServer:
+    httpd = ThreadingHTTPServer((host, port), _Handler)
+    return httpd
+
+
+# --------------------------------------------------------------------------- #
+# Smoke test: start the server in-process, POST an Anthropic request, print reply
+# --------------------------------------------------------------------------- #
+def smoke(host: str = DEFAULT_HOST, port: int = DEFAULT_PORT) -> int:
+    import urllib.request
+
+    httpd = serve(host, port)
+    t = threading.Thread(target=httpd.serve_forever, daemon=True)
+    t.start()
+    try:
+        req_body = json.dumps(
+            {
+                "model": DEFAULT_MODEL,
+                "max_tokens": 64,
+                "messages": [
+                    {"role": "user", "content": "Reply with exactly one word: pong"}
+                ],
+            }
+        ).encode()
+        req = urllib.request.Request(
+            f"http://{host}:{port}/v1/messages",
+            data=req_body,
+            headers={"content-type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=TURN_TIMEOUT_S + 10) as resp:
+            payload = json.loads(resp.read())
+        print("=== Anthropic-shaped response from codex engine ===")
+        print(json.dumps(payload, indent=2))
+        text = (payload.get("content") or [{}])[0].get("text", "")
+        print("\n=== assistant reply ===")
+        print(text)
+        return 0
+    finally:
+        httpd.shutdown()
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    argv = list(sys.argv[1:] if argv is None else argv)
+    cmd = argv[0] if argv else "serve"
+    host = DEFAULT_HOST
+    port = DEFAULT_PORT
+    for a in argv[1:]:
+        if a.startswith("--host="):
+            host = a.split("=", 1)[1]
+        elif a.startswith("--port="):
+            port = int(a.split("=", 1)[1])
+
+    if cmd == "smoke":
+        return smoke(host, port)
+    if cmd == "serve":
+        httpd = serve(host, port)
+        print(f"[adapter] serving Anthropic Messages -> codex on http://{host}:{port}", file=sys.stderr)
+        print(f"[adapter] point clients at ANTHROPIC_BASE_URL=http://{host}:{port}", file=sys.stderr)
+        try:
+            httpd.serve_forever()
+        except KeyboardInterrupt:
+            httpd.shutdown()
+        return 0
+    print(f"unknown command: {cmd!r} (use 'serve' or 'smoke')", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/scitex_agent_container/_experimental/codex_anthropic_adapter.py
+++ b/src/scitex_agent_container/_experimental/codex_anthropic_adapter.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""Codex app-server -> Anthropic Messages API adapter (MVP / proof-of-concept).
+"""Codex app-server -> Anthropic Messages API adapter (experimental spike).
 
 Architecture
 ------------
@@ -23,52 +23,61 @@ pointed at this adapter via ``ANTHROPIC_BASE_URL`` and have its turns answered
 by the Codex engine, reusing the operator's existing ``~/.codex`` OAuth login.
 No API key, no re-auth: ``codex app-server`` reads ``~/.codex/auth.json`` itself.
 
-The codex driver here is a faithful reproduction of the proven probe at
-``~/.scitex/agent-container/runtime/tmp/codex_appserver_test.py`` (which showed
-gpt-5.5 returning "pong" in ~2s over the app-server protocol).
+Module layout
+-------------
+* ``_codex_driver.py`` — the ``codex app-server`` JSON-RPC driver
+  (:func:`iter_codex_events` + :func:`run_codex_turn`). Faithful reproduction
+  of the proven probe ``~/.scitex/agent-container/runtime/tmp/codex_appserver_test.py``.
+* ``_codex_sse.py`` — pure Anthropic-SSE mapping
+  (:func:`codex_stream_to_anthropic_sse` + :func:`format_sse_frame`).
+* this file — Anthropic<->prompt translation + the HTTP server that ties the
+  two together (non-streaming JSON and ``stream:true`` SSE).
+
+Supported
+---------
+* NON-STREAMING ``POST /v1/messages`` -> a single Anthropic Messages JSON body.
+* STREAMING ``POST /v1/messages`` with ``"stream": true`` -> ``text/event-stream``
+  emitting the Anthropic event sequence (``message_start`` ->
+  ``content_block_start`` -> ``content_block_delta`` x N -> ``content_block_stop``
+  -> ``message_delta`` -> ``message_stop``), driven off the codex
+  ``item/agentMessage/delta`` notifications one delta -> one SSE frame.
 
 MVP simplifications (documented, deliberate)
 --------------------------------------------
-This is an MVP / POC, NOT the production adapter. It is intentionally minimal:
+This is an experimental spike, NOT the production adapter:
 
-* NON-STREAMING, TEXT-ONLY. ``stream:true`` is ignored (we always return a
-  single non-streaming JSON body). Only text content blocks are handled.
+* TEXT-ONLY. Only text content blocks are handled (streaming + non-streaming).
 * Conversation flattening. The Anthropic ``system`` + ``messages[]`` array is
-  flattened into ONE role-tagged plain-text transcript that is sent as the
-  single ``turn/start`` input. We do NOT map the structured message history
-  onto codex threads/turns 1:1 — every request is a fresh codex thread.
+  flattened into ONE role-tagged plain-text transcript sent as the single
+  ``turn/start`` input. No structured 1:1 thread/turn mapping.
 * Thread-per-request. A new ``codex app-server`` process + thread is spawned
-  for every HTTP request, then torn down. No thread reuse / no multi-turn state
-  is kept between requests. (Production should keep a warm app-server and reuse
-  a thread keyed by conversation.)
-* ``usage`` token counts are ESTIMATED (~4 chars/token, whitespace-split
-  fallback), not real. codex app-server does surface token usage in
-  ``turn/completed`` / usage notifications; wiring that through is a follow-up.
+  for every HTTP request (streaming and non-streaming), then torn down. No
+  thread reuse / no multi-turn state kept between requests.
+* ``usage`` token counts are ESTIMATED (~4 chars/token) UNLESS codex reports a
+  real count on ``turn/completed`` (then that real ``output_tokens`` is used in
+  the streaming ``message_delta``).
 * NO tool_use / tool_result mapping. Anthropic ``tool_use`` blocks and codex
-  tool/exec items are NOT bridged. Tool-call payloads in the request are
-  rendered as text only.
-* NO auth / rate-limit / error mapping on the HTTP endpoint. The endpoint is
-  unauthenticated and binds loopback by default. codex errors become a generic
-  500-ish Anthropic ``error`` body.
+  tool/exec items are NOT bridged; tool payloads are rendered as text only.
+* NO auth / rate-limit / rich error mapping on the HTTP endpoint. The endpoint
+  is unauthenticated and binds loopback by default. A codex failure becomes a
+  generic Anthropic ``error`` (502 JSON, or an ``error`` SSE event mid-stream).
 
-Production follow-ups (do NOT do these in the MVP)
---------------------------------------------------
-1. SSE streaming: honour ``stream:true`` and emit the Anthropic event sequence
-   (``message_start`` -> ``content_block_start`` -> ``content_block_delta`` x N
-   -> ``content_block_stop`` -> ``message_delta`` -> ``message_stop``) driven by
-   the codex ``item/agentMessage/delta`` notifications.
-2. tool_use / tool_result bridging: map Anthropic tool_use blocks <-> codex
+Remaining production follow-ups (NOT done here)
+-----------------------------------------------
+1. tool_use / tool_result bridging: map Anthropic tool_use blocks <-> codex
    tool/exec items so agentic tool loops work through the adapter.
-3. Warm app-server + thread reuse: keep one long-lived ``codex app-server`` and
+2. Warm app-server + thread reuse: keep one long-lived ``codex app-server`` and
    reuse a thread per conversation instead of spawn-per-request (latency + auth
    amortisation). Track thread ids keyed by the client conversation.
-4. Real usage accounting from codex ``turn/completed`` usage fields, mapped to
-   Anthropic ``usage.input_tokens`` / ``output_tokens``.
-5. Error + rate-limit mapping: translate codex ``turn/failed`` / auth-expired /
-   quota errors to the correct Anthropic HTTP status + ``error.type``.
-6. Endpoint auth: require the ``x-api-key`` / ``authorization`` header the
+3. Full usage accounting: map codex ``turn/completed`` usage onto Anthropic
+   ``usage.input_tokens`` too (streaming currently reports only real output
+   tokens when codex supplies them; input tokens stay estimated).
+4. Error + rate-limit mapping: translate codex ``turn/failed`` / auth-expired /
+   quota errors to the correct Anthropic HTTP status + ``error.type`` (and the
+   correct SSE error framing) instead of a generic ``api_error``.
+5. Endpoint auth: require the ``x-api-key`` / ``authorization`` header the
    Anthropic client already sends, and bind non-loopback only behind that.
-7. Coordinate with the ecosystem's LLM plumbing (scitex-genai / litellm) rather
+6. Coordinate with the ecosystem's LLM plumbing (scitex-genai / litellm) rather
    than a bespoke server: this adapter is the "prove the wire" spike, and the
    production version should slot into that routing layer, including multi-account
    ``~/.codex`` rotation (mirroring the sac account-rotation story).
@@ -84,8 +93,14 @@ Usage
       -d '{"model":"gpt-5.5","max_tokens":64,
            "messages":[{"role":"user","content":"Reply with one word: pong"}]}'
 
-    # built-in smoke test (spins up the server in-process, does one round-trip)
+    # streaming round-trip
+    curl -N http://127.0.0.1:8787/v1/messages -H 'content-type: application/json' \
+      -d '{"model":"gpt-5.5","stream":true,
+           "messages":[{"role":"user","content":"Reply with one word: pong"}]}'
+
+    # built-in smoke tests (spin up the server in-process, one round-trip each)
     python -m scitex_agent_container._experimental.codex_anthropic_adapter smoke
+    python -m scitex_agent_container._experimental.codex_anthropic_adapter stream-smoke
 
 Experimental: this module lives under ``_experimental/`` and is NOT imported by
 the package, wired into any spec, or covered by the CLI. It is a spike.
@@ -93,178 +108,43 @@ the package, wired into any spec, or covered by the CLI. It is a spike.
 from __future__ import annotations
 
 import json
-import subprocess
 import sys
 import threading
-import time
-import uuid
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any, Optional
 
-DEFAULT_MODEL = "gpt-5.5"
+from ._codex_driver import (
+    DEFAULT_MODEL,
+    TURN_TIMEOUT_S,
+    CodexError,
+    _estimate_tokens,
+    iter_codex_events,
+    run_codex_turn,
+)
+from ._codex_sse import (
+    codex_stream_to_anthropic_sse,
+    format_sse_frame,
+    parse_sse_stream,
+)
+
+# Re-export the driver/SSE public API so existing
+# ``from ...codex_anthropic_adapter import run_codex_turn`` imports keep working.
+__all__ = [
+    "CodexError",
+    "run_codex_turn",
+    "iter_codex_events",
+    "codex_stream_to_anthropic_sse",
+    "format_sse_frame",
+    "flatten_request",
+    "build_anthropic_response",
+    "serve",
+    "smoke",
+    "stream_smoke",
+    "main",
+]
+
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8787
-# Upper bound for how long we wait for codex to finish a turn.
-TURN_TIMEOUT_S = 120.0
-
-
-# --------------------------------------------------------------------------- #
-# codex app-server driver (reproduces the proven codex_appserver_test.py)
-# --------------------------------------------------------------------------- #
-class CodexError(RuntimeError):
-    """Raised when the codex app-server turn fails or times out."""
-
-
-def run_codex_turn(
-    prompt: str,
-    model: str = DEFAULT_MODEL,
-    timeout_s: float = TURN_TIMEOUT_S,
-) -> str:
-    """Drive one ``codex app-server`` turn and return the agent's reply text.
-
-    initialize -> initialized -> thread/start(model) -> turn/start(prompt),
-    then collect the ``agentMessage`` reply from the ``item/completed``
-    notification (falling back to accumulated ``item/agentMessage/delta``).
-
-    Spawn-per-call is an MVP simplification (see module docstring).
-    """
-    proc = subprocess.Popen(
-        ["codex", "app-server"],
-        stdin=subprocess.PIPE,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-    )
-    lines: list[str] = []
-    lock = threading.Lock()
-
-    def reader(stream, tag: str) -> None:
-        for ln in stream:
-            with lock:
-                lines.append(f"{tag} {ln.rstrip()}")
-
-    threading.Thread(target=reader, args=(proc.stdout, "OUT"), daemon=True).start()
-    threading.Thread(target=reader, args=(proc.stderr, "ERR"), daemon=True).start()
-
-    def send(msg: dict[str, Any]) -> None:
-        assert proc.stdin is not None
-        proc.stdin.write(json.dumps(msg) + "\n")
-        proc.stdin.flush()
-
-    reply_text: Optional[str] = None
-    delta_buf: list[str] = []
-    error_detail: Optional[str] = None
-    try:
-        send(
-            {
-                "method": "initialize",
-                "id": 0,
-                "params": {
-                    "clientInfo": {
-                        "name": "codex-anthropic-adapter",
-                        "title": "codex-anthropic-adapter",
-                        "version": "0.1.0",
-                    }
-                },
-            }
-        )
-        send({"method": "initialized", "params": {}})
-        send({"method": "thread/start", "id": 1, "params": {"model": model}})
-
-        thread_id: Optional[str] = None
-        turn_sent = False
-        seen = 0
-        deadline = time.time() + timeout_s
-        while time.time() < deadline:
-            time.sleep(0.2)
-            with lock:
-                snapshot = lines[seen:]
-                seen = len(lines)
-            for raw in snapshot:
-                if raw.startswith("ERR "):
-                    continue
-                if not raw.startswith("OUT "):
-                    continue
-                try:
-                    msg = json.loads(raw[4:])
-                except Exception:
-                    continue
-
-                # thread/start response -> fire the turn
-                if (
-                    msg.get("id") == 1
-                    and isinstance(msg.get("result"), dict)
-                    and not turn_sent
-                ):
-                    tid = (msg["result"].get("thread") or {}).get("id")
-                    if tid:
-                        thread_id = tid
-                        send(
-                            {
-                                "method": "turn/start",
-                                "id": 2,
-                                "params": {
-                                    "threadId": tid,
-                                    "input": [{"type": "text", "text": prompt}],
-                                },
-                            }
-                        )
-                        turn_sent = True
-                    continue
-
-                method = msg.get("method")
-                params = msg.get("params") or {}
-
-                # streamed deltas — accumulate as a fallback reply source
-                if method == "item/agentMessage/delta":
-                    d = params.get("delta") or params.get("text") or ""
-                    if isinstance(d, str):
-                        delta_buf.append(d)
-                    continue
-
-                # completed item carries the full agent reply text
-                if method in ("item/completed", "item/updated"):
-                    item = params.get("item") or {}
-                    if item.get("type") in ("agentMessage", "assistantMessage"):
-                        txt = item.get("text")
-                        if isinstance(txt, str) and txt:
-                            reply_text = txt
-                    continue
-
-                if method == "turn/completed":
-                    if reply_text is None and delta_buf:
-                        reply_text = "".join(delta_buf)
-                    if reply_text is not None:
-                        return reply_text
-                    # no text but turn is done — return whatever we have
-                    return "".join(delta_buf)
-
-                if method == "turn/failed":
-                    error_detail = json.dumps(params)[:500]
-                    raise CodexError(f"codex turn/failed: {error_detail}")
-
-                if msg.get("error"):
-                    error_detail = json.dumps(msg["error"])[:500]
-                    raise CodexError(f"codex error: {error_detail}")
-
-        # timed out — salvage any partial reply, else fail loudly
-        if reply_text is not None:
-            return reply_text
-        if delta_buf:
-            return "".join(delta_buf)
-        with lock:
-            err_lines = [l for l in lines if l.startswith("ERR ")][-5:]
-        raise CodexError(
-            "codex turn timed out after "
-            f"{timeout_s:.0f}s (thread_id={thread_id}, turn_sent={turn_sent}); "
-            f"stderr tail: {err_lines}"
-        )
-    finally:
-        proc.terminate()
-        try:
-            proc.wait(timeout=5)
-        except Exception:
-            proc.kill()
 
 
 # --------------------------------------------------------------------------- #
@@ -289,7 +169,9 @@ def _content_to_text(content: Any) -> str:
                     f"input={json.dumps(block.get('input', {}))}]"
                 )
             elif btype == "tool_result":  # MVP: render, don't bridge
-                parts.append(f"[tool_result {_content_to_text(block.get('content', ''))}]")
+                parts.append(
+                    f"[tool_result {_content_to_text(block.get('content', ''))}]"
+                )
             else:
                 parts.append(json.dumps(block))
         return "\n".join(p for p in parts if p)
@@ -321,17 +203,12 @@ def flatten_request(body: dict[str, Any]) -> str:
     return "\n\n".join(segments)
 
 
-def _estimate_tokens(text: str) -> int:
-    """Crude token estimate (~4 chars/token). MVP placeholder for real usage."""
-    if not text:
-        return 0
-    return max(len(text) // 4, len(text.split()))
-
-
 def build_anthropic_response(
     reply_text: str, model: str, prompt: str
 ) -> dict[str, Any]:
     """Wrap the codex reply in a non-streaming Anthropic Messages response."""
+    import uuid
+
     return {
         "id": f"msg_{uuid.uuid4().hex[:24]}",
         "type": "message",
@@ -341,7 +218,7 @@ def build_anthropic_response(
         "stop_reason": "end_turn",
         "stop_sequence": None,
         "usage": {
-            # MVP: estimated, not codex-reported. See follow-up #4.
+            # MVP: estimated, not codex-reported. See follow-up #3.
             "input_tokens": _estimate_tokens(prompt),
             "output_tokens": _estimate_tokens(reply_text),
         },
@@ -352,7 +229,7 @@ def build_anthropic_response(
 # HTTP server
 # --------------------------------------------------------------------------- #
 class _Handler(BaseHTTPRequestHandler):
-    server_version = "codex-anthropic-adapter/0.1"
+    server_version = "codex-anthropic-adapter/0.2"
 
     def _json(self, status: int, payload: dict[str, Any]) -> None:
         data = json.dumps(payload).encode()
@@ -365,15 +242,54 @@ class _Handler(BaseHTTPRequestHandler):
     def log_message(self, fmt: str, *args: Any) -> None:  # quieter default log
         sys.stderr.write("[adapter] " + (fmt % args) + "\n")
 
+    def _stream(self, prompt: str, model: str, codex_model: str) -> None:
+        """Emit the Anthropic SSE event sequence for a ``stream:true`` request."""
+        self.send_response(200)
+        self.send_header("content-type", "text/event-stream")
+        self.send_header("cache-control", "no-cache")
+        self.send_header("connection", "keep-alive")
+        self.end_headers()
+        codex_events = iter_codex_events(prompt, model=codex_model)
+        try:
+            for etype, data in codex_stream_to_anthropic_sse(
+                codex_events, model=model, prompt=prompt
+            ):
+                self.wfile.write(format_sse_frame(etype, data).encode())
+                self.wfile.flush()
+        except (CodexError, FileNotFoundError) as exc:
+            # message_start already went out; surface the failure as an SSE
+            # error event per the Anthropic streaming error convention.
+            self.wfile.write(
+                format_sse_frame(
+                    "error",
+                    {"type": "error", "error": {"type": "api_error", "message": str(exc)}},
+                ).encode()
+            )
+            self.wfile.flush()
+        except Exception as exc:  # noqa: BLE001 — MVP generic mapping
+            self.wfile.write(
+                format_sse_frame(
+                    "error",
+                    {"type": "error", "error": {"type": "api_error", "message": repr(exc)}},
+                ).encode()
+            )
+            self.wfile.flush()
+
     def do_POST(self) -> None:  # noqa: N802 (stdlib signature)
         if self.path.rstrip("/") != "/v1/messages":
-            self._json(404, {"type": "error", "error": {"type": "not_found_error", "message": self.path}})
+            self._json(
+                404,
+                {"type": "error", "error": {"type": "not_found_error", "message": self.path}},
+            )
             return
         try:
             length = int(self.headers.get("content-length", 0))
             body = json.loads(self.rfile.read(length) or b"{}")
         except Exception as exc:  # malformed body
-            self._json(400, {"type": "error", "error": {"type": "invalid_request_error", "message": str(exc)}})
+            self._json(
+                400,
+                {"type": "error", "error": {"type": "invalid_request_error", "message": str(exc)}},
+            )
             return
 
         model = body.get("model") or DEFAULT_MODEL
@@ -381,6 +297,10 @@ class _Handler(BaseHTTPRequestHandler):
         # the client model name looks like a gpt-* codex model.
         codex_model = model if str(model).startswith("gpt-") else DEFAULT_MODEL
         prompt = flatten_request(body)
+
+        if body.get("stream"):
+            self._stream(prompt, model=model, codex_model=codex_model)
+            return
 
         try:
             reply = run_codex_turn(prompt, model=codex_model)
@@ -401,19 +321,19 @@ class _Handler(BaseHTTPRequestHandler):
 
 
 def serve(host: str = DEFAULT_HOST, port: int = DEFAULT_PORT) -> ThreadingHTTPServer:
-    httpd = ThreadingHTTPServer((host, port), _Handler)
-    return httpd
+    """Build (but do not start) the adapter's threading HTTP server."""
+    return ThreadingHTTPServer((host, port), _Handler)
 
 
 # --------------------------------------------------------------------------- #
-# Smoke test: start the server in-process, POST an Anthropic request, print reply
+# Smoke tests: start the server in-process, POST a request, print the reply
 # --------------------------------------------------------------------------- #
 def smoke(host: str = DEFAULT_HOST, port: int = DEFAULT_PORT) -> int:
+    """Non-streaming round-trip: one Anthropic request -> printed reply text."""
     import urllib.request
 
     httpd = serve(host, port)
-    t = threading.Thread(target=httpd.serve_forever, daemon=True)
-    t.start()
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
     try:
         req_body = json.dumps(
             {
@@ -442,7 +362,50 @@ def smoke(host: str = DEFAULT_HOST, port: int = DEFAULT_PORT) -> int:
         httpd.shutdown()
 
 
+def stream_smoke(host: str = DEFAULT_HOST, port: int = DEFAULT_PORT) -> int:
+    """Streaming round-trip: POST ``stream:true`` -> print the SSE event order."""
+    import urllib.request
+
+    httpd = serve(host, port)
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    try:
+        req_body = json.dumps(
+            {
+                "model": DEFAULT_MODEL,
+                "max_tokens": 64,
+                "stream": True,
+                "messages": [
+                    {"role": "user", "content": "Reply with exactly one word: pong"}
+                ],
+            }
+        ).encode()
+        req = urllib.request.Request(
+            f"http://{host}:{port}/v1/messages",
+            data=req_body,
+            headers={"content-type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=TURN_TIMEOUT_S + 10) as resp:
+            ctype = resp.headers.get("content-type", "")
+            raw = resp.read().decode()
+        print(f"=== content-type: {ctype} ===")
+        events = parse_sse_stream(raw)
+        text = "".join(
+            data["delta"]["text"]
+            for etype, data in events
+            if etype == "content_block_delta"
+        )
+        print("=== SSE event order ===")
+        print(" -> ".join(etype for etype, _ in events))
+        print("\n=== reassembled assistant reply ===")
+        print(text)
+        return 0
+    finally:
+        httpd.shutdown()
+
+
 def main(argv: Optional[list[str]] = None) -> int:
+    """CLI entry point: ``serve`` (default) / ``smoke`` / ``stream-smoke``."""
     argv = list(sys.argv[1:] if argv is None else argv)
     cmd = argv[0] if argv else "serve"
     host = DEFAULT_HOST
@@ -455,16 +418,24 @@ def main(argv: Optional[list[str]] = None) -> int:
 
     if cmd == "smoke":
         return smoke(host, port)
+    if cmd in ("stream-smoke", "stream_smoke"):
+        return stream_smoke(host, port)
     if cmd == "serve":
         httpd = serve(host, port)
-        print(f"[adapter] serving Anthropic Messages -> codex on http://{host}:{port}", file=sys.stderr)
-        print(f"[adapter] point clients at ANTHROPIC_BASE_URL=http://{host}:{port}", file=sys.stderr)
+        print(
+            f"[adapter] serving Anthropic Messages -> codex on http://{host}:{port}",
+            file=sys.stderr,
+        )
+        print(
+            f"[adapter] point clients at ANTHROPIC_BASE_URL=http://{host}:{port}",
+            file=sys.stderr,
+        )
         try:
             httpd.serve_forever()
         except KeyboardInterrupt:
             httpd.shutdown()
         return 0
-    print(f"unknown command: {cmd!r} (use 'serve' or 'smoke')", file=sys.stderr)
+    print(f"unknown command: {cmd!r} (use 'serve' / 'smoke' / 'stream-smoke')", file=sys.stderr)
     return 2
 
 

--- a/tests/scitex_agent_container/_experimental/test__codex_driver.py
+++ b/tests/scitex_agent_container/_experimental/test__codex_driver.py
@@ -1,0 +1,105 @@
+"""Tests for the codex app-server driver helpers (``_experimental._codex_driver``).
+
+No mocks (PA-306): the per-event extraction helpers are pure functions over the
+app-server notification dicts, so each test drives them with a real in-memory
+event dict — no ``codex`` subprocess, no network. AAA markers (TQ002),
+descriptive names (TQ003), one assertion per test (TQ007).
+
+The live ``iter_codex_events`` / ``run_codex_turn`` paths spawn a real
+``codex app-server`` and are exercised by the module's ``stream-smoke`` / ``smoke``
+entry points against the operator's ``~/.codex`` login, not from unit tests.
+"""
+from __future__ import annotations
+
+from scitex_agent_container._experimental._codex_driver import (
+    _estimate_tokens,
+    _event_completed_text,
+    _event_delta_text,
+    _event_output_tokens,
+)
+
+
+class TestEventDeltaText:
+    def test_reads_delta_field(self):
+        # Arrange
+        msg = {"method": "item/agentMessage/delta", "params": {"delta": "po"}}
+        # Act
+        text = _event_delta_text(msg)
+        # Assert
+        assert text == "po"
+
+    def test_falls_back_to_text_field(self):
+        # Arrange
+        msg = {"method": "item/agentMessage/delta", "params": {"text": "ng"}}
+        # Act
+        text = _event_delta_text(msg)
+        # Assert
+        assert text == "ng"
+
+    def test_missing_delta_yields_empty_string(self):
+        # Arrange
+        msg = {"method": "item/agentMessage/delta", "params": {}}
+        # Act
+        text = _event_delta_text(msg)
+        # Assert
+        assert text == ""
+
+
+class TestEventCompletedText:
+    def test_extracts_agent_message_text(self):
+        # Arrange
+        msg = {
+            "method": "item/completed",
+            "params": {"item": {"type": "agentMessage", "text": "pong"}},
+        }
+        # Act
+        text = _event_completed_text(msg)
+        # Assert
+        assert text == "pong"
+
+    def test_ignores_non_agent_message_item(self):
+        # Arrange
+        msg = {
+            "method": "item/completed",
+            "params": {"item": {"type": "reasoning", "text": "..."}},
+        }
+        # Act
+        text = _event_completed_text(msg)
+        # Assert
+        assert text is None
+
+
+class TestEventOutputTokens:
+    def test_reads_usage_output_tokens(self):
+        # Arrange
+        msg = {"method": "turn/completed", "params": {"usage": {"output_tokens": 7}}}
+        # Act
+        tokens = _event_output_tokens(msg)
+        # Assert
+        assert tokens == 7
+
+    def test_returns_none_when_usage_absent(self):
+        # Arrange
+        msg = {"method": "turn/completed", "params": {}}
+        # Act
+        tokens = _event_output_tokens(msg)
+        # Assert
+        assert tokens is None
+
+
+class TestEstimateTokens:
+    def test_empty_text_is_zero_tokens(self):
+        # Arrange
+        text = ""
+        # Act
+        tokens = _estimate_tokens(text)
+        # Assert
+        assert tokens == 0
+
+    def test_non_empty_text_is_at_least_one_token(self):
+        # Arrange
+        text = "hello world"
+        # Act
+        tokens = _estimate_tokens(text)
+        # Assert
+        assert tokens >= 1

--- a/tests/scitex_agent_container/_experimental/test__codex_sse.py
+++ b/tests/scitex_agent_container/_experimental/test__codex_sse.py
@@ -1,0 +1,250 @@
+"""Tests for the pure Anthropic-SSE mapping (``_experimental._codex_sse``).
+
+No mocks (PA-306): the SSE mapper is a pure function over a sequence of codex
+app-server events, so every test drives it with an in-memory canned delta
+sequence — a real test of the mapping logic with zero network. AAA markers
+(TQ002), descriptive names (TQ003), one assertion per test (TQ007).
+
+The canned sequences use the exact app-server notification shapes the live
+driver (``_codex_driver.iter_codex_events``) yields: ``item/agentMessage/delta``
+(with ``params.delta``), ``item/completed`` (agentMessage item ``.text``), then
+``turn/completed`` (optionally carrying a real ``usage.output_tokens``).
+"""
+from __future__ import annotations
+
+import pytest
+
+from scitex_agent_container._experimental._codex_sse import (
+    codex_stream_to_anthropic_sse,
+    format_sse_frame,
+    parse_sse_stream,
+)
+
+
+def _delta(text: str) -> dict:
+    return {"method": "item/agentMessage/delta", "params": {"delta": text}}
+
+
+def _completed(text: str) -> dict:
+    return {
+        "method": "item/completed",
+        "params": {"item": {"type": "agentMessage", "text": text}},
+    }
+
+
+def _turn_completed(usage: dict | None = None) -> dict:
+    params = {"usage": usage} if usage is not None else {}
+    return {"method": "turn/completed", "params": params}
+
+
+@pytest.fixture
+def two_chunk_stream() -> list[dict]:
+    """A canned codex stream: 'po' + 'ng' deltas, completed item, turn done."""
+    return [
+        _delta("po"),
+        _delta("ng"),
+        _completed("pong"),
+        _turn_completed(),
+    ]
+
+
+class TestEventOrder:
+    def test_emits_canonical_anthropic_event_sequence(self, two_chunk_stream):
+        # Arrange
+        events = list(
+            codex_stream_to_anthropic_sse(two_chunk_stream, model="gpt-5.5")
+        )
+        # Act
+        order = [etype for etype, _ in events]
+        # Assert
+        assert order == [
+            "message_start",
+            "content_block_start",
+            "content_block_delta",
+            "content_block_delta",
+            "content_block_stop",
+            "message_delta",
+            "message_stop",
+        ]
+
+    def test_one_content_block_delta_per_codex_delta(self, two_chunk_stream):
+        # Arrange
+        events = list(
+            codex_stream_to_anthropic_sse(two_chunk_stream, model="gpt-5.5")
+        )
+        # Act
+        deltas = [e for e in events if e[0] == "content_block_delta"]
+        # Assert
+        assert len(deltas) == 2
+
+    def test_first_event_is_message_start(self, two_chunk_stream):
+        # Arrange
+        stream = codex_stream_to_anthropic_sse(two_chunk_stream, model="gpt-5.5")
+        # Act
+        first_type = next(iter(stream))[0]
+        # Assert
+        assert first_type == "message_start"
+
+
+class TestReassembledText:
+    def test_content_block_deltas_reassemble_to_full_reply(self, two_chunk_stream):
+        # Arrange
+        events = list(
+            codex_stream_to_anthropic_sse(two_chunk_stream, model="gpt-5.5")
+        )
+        # Act
+        text = "".join(
+            data["delta"]["text"]
+            for etype, data in events
+            if etype == "content_block_delta"
+        )
+        # Assert
+        assert text == "pong"
+
+    def test_content_block_delta_uses_text_delta_type(self, two_chunk_stream):
+        # Arrange
+        events = list(
+            codex_stream_to_anthropic_sse(two_chunk_stream, model="gpt-5.5")
+        )
+        # Act
+        first_delta = next(
+            data for etype, data in events if etype == "content_block_delta"
+        )
+        # Assert
+        assert first_delta["delta"]["type"] == "text_delta"
+
+
+class TestMessageEnvelope:
+    def test_message_start_carries_assistant_role(self, two_chunk_stream):
+        # Arrange
+        events = list(
+            codex_stream_to_anthropic_sse(two_chunk_stream, model="gpt-5.5")
+        )
+        # Act
+        start = next(d for t, d in events if t == "message_start")
+        # Assert
+        assert start["message"]["role"] == "assistant"
+
+    def test_message_start_reports_requested_model(self, two_chunk_stream):
+        # Arrange
+        events = list(
+            codex_stream_to_anthropic_sse(two_chunk_stream, model="gpt-5.5")
+        )
+        # Act
+        start = next(d for t, d in events if t == "message_start")
+        # Assert
+        assert start["message"]["model"] == "gpt-5.5"
+
+    def test_message_start_has_empty_content(self, two_chunk_stream):
+        # Arrange
+        events = list(
+            codex_stream_to_anthropic_sse(two_chunk_stream, model="gpt-5.5")
+        )
+        # Act
+        start = next(d for t, d in events if t == "message_start")
+        # Assert
+        assert start["message"]["content"] == []
+
+    def test_message_delta_stop_reason_is_end_turn(self, two_chunk_stream):
+        # Arrange
+        events = list(
+            codex_stream_to_anthropic_sse(two_chunk_stream, model="gpt-5.5")
+        )
+        # Act
+        delta = next(d for t, d in events if t == "message_delta")
+        # Assert
+        assert delta["delta"]["stop_reason"] == "end_turn"
+
+
+class TestUsageAccounting:
+    def test_real_output_tokens_from_turn_completed_are_used(self):
+        # Arrange
+        stream = [_delta("pong"), _turn_completed({"output_tokens": 42})]
+        # Act
+        events = list(codex_stream_to_anthropic_sse(stream, model="gpt-5.5"))
+        delta = next(d for t, d in events if t == "message_delta")
+        # Assert
+        assert delta["usage"]["output_tokens"] == 42
+
+    def test_output_tokens_estimated_when_codex_reports_none(self):
+        # Arrange
+        stream = [_delta("hello world"), _turn_completed()]
+        # Act
+        events = list(codex_stream_to_anthropic_sse(stream, model="gpt-5.5"))
+        delta = next(d for t, d in events if t == "message_delta")
+        # Assert
+        assert delta["usage"]["output_tokens"] >= 1
+
+
+class TestCompletedFallback:
+    def test_completed_item_text_emitted_when_no_deltas_streamed(self):
+        # Arrange — codex that did not stream deltas, only a completed item
+        stream = [_completed("pong"), _turn_completed()]
+        # Act
+        events = list(codex_stream_to_anthropic_sse(stream, model="gpt-5.5"))
+        text = "".join(
+            d["delta"]["text"] for t, d in events if t == "content_block_delta"
+        )
+        # Assert
+        assert text == "pong"
+
+    def test_completed_item_not_double_emitted_after_deltas(self, two_chunk_stream):
+        # Arrange — deltas already streamed the text; completed carries the full
+        # text too, which must NOT be re-emitted as an extra delta.
+        events = list(
+            codex_stream_to_anthropic_sse(two_chunk_stream, model="gpt-5.5")
+        )
+        # Act
+        text = "".join(
+            d["delta"]["text"] for t, d in events if t == "content_block_delta"
+        )
+        # Assert
+        assert text == "pong"
+
+
+class TestFrameSerialisation:
+    def test_frame_has_event_and_data_lines(self):
+        # Arrange
+        event_type, data = "message_stop", {"type": "message_stop"}
+        # Act
+        frame = format_sse_frame(event_type, data)
+        # Assert
+        assert frame == 'event: message_stop\ndata: {"type": "message_stop"}\n\n'
+
+    def test_serialise_then_parse_roundtrips_event_order(self, two_chunk_stream):
+        # Arrange
+        wire = "".join(
+            format_sse_frame(t, d)
+            for t, d in codex_stream_to_anthropic_sse(
+                two_chunk_stream, model="gpt-5.5"
+            )
+        )
+        # Act
+        parsed = [etype for etype, _ in parse_sse_stream(wire)]
+        # Assert
+        assert parsed == [
+            "message_start",
+            "content_block_start",
+            "content_block_delta",
+            "content_block_delta",
+            "content_block_stop",
+            "message_delta",
+            "message_stop",
+        ]
+
+    def test_serialise_then_parse_roundtrips_reply_text(self, two_chunk_stream):
+        # Arrange
+        wire = "".join(
+            format_sse_frame(t, d)
+            for t, d in codex_stream_to_anthropic_sse(
+                two_chunk_stream, model="gpt-5.5"
+            )
+        )
+        # Act
+        text = "".join(
+            data["delta"]["text"]
+            for etype, data in parse_sse_stream(wire)
+            if etype == "content_block_delta"
+        )
+        # Assert
+        assert text == "pong"

--- a/tests/scitex_agent_container/_experimental/test_codex_anthropic_adapter.py
+++ b/tests/scitex_agent_container/_experimental/test_codex_anthropic_adapter.py
@@ -1,0 +1,130 @@
+"""Tests for the codex -> Anthropic Messages adapter translation + streaming.
+
+No mocks (PA-306): the request-flattening and response-building translation are
+pure functions, and the streaming pipeline is driven end-to-end with a canned
+in-memory codex event sequence (no ``codex`` subprocess, no network). AAA
+markers (TQ002), descriptive names (TQ003), one assertion per test (TQ007).
+
+The live HTTP round-trip (spawning a real ``codex app-server``) is exercised by
+the module's ``smoke`` / ``stream-smoke`` entry points, not from unit tests.
+"""
+from __future__ import annotations
+
+from scitex_agent_container._experimental import codex_anthropic_adapter as adapter
+from scitex_agent_container._experimental._codex_sse import (
+    codex_stream_to_anthropic_sse,
+    format_sse_frame,
+    parse_sse_stream,
+)
+
+
+class TestFlattenRequest:
+    def test_user_message_is_role_tagged(self):
+        # Arrange
+        body = {"messages": [{"role": "user", "content": "hi"}]}
+        # Act
+        prompt = adapter.flatten_request(body)
+        # Assert
+        assert "User: hi" in prompt
+
+    def test_system_prompt_is_prepended(self):
+        # Arrange
+        body = {"system": "be terse", "messages": [{"role": "user", "content": "hi"}]}
+        # Act
+        prompt = adapter.flatten_request(body)
+        # Assert
+        assert prompt.startswith("System: be terse")
+
+    def test_transcript_ends_with_assistant_cue(self):
+        # Arrange
+        body = {"messages": [{"role": "user", "content": "hi"}]}
+        # Act
+        prompt = adapter.flatten_request(body)
+        # Assert
+        assert prompt.rstrip().endswith("Assistant:")
+
+    def test_content_block_list_is_flattened_to_text(self):
+        # Arrange
+        body = {
+            "messages": [
+                {"role": "user", "content": [{"type": "text", "text": "blockish"}]}
+            ]
+        }
+        # Act
+        prompt = adapter.flatten_request(body)
+        # Assert
+        assert "blockish" in prompt
+
+
+class TestBuildAnthropicResponse:
+    def test_wraps_reply_as_text_content_block(self):
+        # Arrange
+        reply = "pong"
+        # Act
+        resp = adapter.build_anthropic_response(reply, model="gpt-5.5", prompt="ping")
+        # Assert
+        assert resp["content"] == [{"type": "text", "text": "pong"}]
+
+    def test_stop_reason_is_end_turn(self):
+        # Arrange
+        reply = "pong"
+        # Act
+        resp = adapter.build_anthropic_response(reply, model="gpt-5.5", prompt="ping")
+        # Assert
+        assert resp["stop_reason"] == "end_turn"
+
+
+class TestStreamingPipeline:
+    def test_stream_true_maps_to_ordered_sse_wire(self):
+        # Arrange — a canned codex event stream flattened through the SSE mapper
+        codex_events = [
+            {"method": "item/agentMessage/delta", "params": {"delta": "po"}},
+            {"method": "item/agentMessage/delta", "params": {"delta": "ng"}},
+            {"method": "turn/completed", "params": {}},
+        ]
+        # Act
+        wire = "".join(
+            format_sse_frame(t, d)
+            for t, d in codex_stream_to_anthropic_sse(codex_events, model="gpt-5.5")
+        )
+        parsed = [etype for etype, _ in parse_sse_stream(wire)]
+        # Assert
+        assert parsed[0] == "message_start" and parsed[-1] == "message_stop"
+
+    def test_stream_reassembles_reply_text(self):
+        # Arrange
+        codex_events = [
+            {"method": "item/agentMessage/delta", "params": {"delta": "po"}},
+            {"method": "item/agentMessage/delta", "params": {"delta": "ng"}},
+            {"method": "turn/completed", "params": {}},
+        ]
+        # Act
+        wire = "".join(
+            format_sse_frame(t, d)
+            for t, d in codex_stream_to_anthropic_sse(codex_events, model="gpt-5.5")
+        )
+        text = "".join(
+            data["delta"]["text"]
+            for etype, data in parse_sse_stream(wire)
+            if etype == "content_block_delta"
+        )
+        # Assert
+        assert text == "pong"
+
+
+class TestPublicApiReexports:
+    def test_run_codex_turn_is_reexported(self):
+        # Arrange
+        name = "run_codex_turn"
+        # Act
+        has_it = hasattr(adapter, name)
+        # Assert
+        assert has_it is True
+
+    def test_codex_error_is_reexported(self):
+        # Arrange
+        name = "CodexError"
+        # Act
+        has_it = hasattr(adapter, name)
+        # Assert
+        assert has_it is True


### PR DESCRIPTION
## What this proves

An engine-swap spike: a client that only speaks the Anthropic Messages API (the Claude Code box) can be driven end-to-end by the OpenAI Codex engine (gpt-5.5) with zero client changes -- just `ANTHROPIC_BASE_URL=http://127.0.0.1:8787`. Auth reuses the operator existing `~/.codex` OAuth login (no API key, no re-auth): `codex app-server` reads `~/.codex/auth.json` itself.

```
Claude Code / any Anthropic client
   |  POST /v1/messages       (Anthropic Messages shape)
   v
codex_anthropic_adapter.py    (stdlib http.server, no new deps)
   |  JSON-RPC 2.0 over stdio
   v
codex app-server              (OAuth from ~/.codex/auth.json)
   v
OpenAI Codex (gpt-5.5)
```

### Live round-trip captured
`POST /v1/messages` with `{"model":"gpt-5.5", messages:[{role:user, content:"Reply with exactly one word: pong"}]}` returned a valid Anthropic response `content[0].text == "pong"`, HTTP 200, in ~2s -- driven by a real `codex app-server` process using the operator `~/.codex` login. The codex driver is a faithful reproduction of the proven probe `~/.scitex/agent-container/runtime/tmp/codex_appserver_test.py`.

## MVP scope (deliberate simplifications, documented in-file)

- Non-streaming, text-only (`stream:true` ignored).
- `system` + `messages[]` flattened into one role-tagged text prompt; every request = a fresh codex thread (no 1:1 history mapping).
- Thread-per-request (spawn + tear down codex per call; no reuse).
- `usage` token counts estimated (~4 chars/token), not codex-reported.
- No tool_use / tool_result bridging (rendered as text).
- No endpoint auth / rate-limit / error mapping (loopback-only, generic 5xx).

## Production follow-ups (NOT in this MVP)

1. SSE streaming -- emit the Anthropic event sequence from codex deltas.
2. tool_use / tool_result bridging <-> codex tool/exec items.
3. Warm app-server + per-conversation thread reuse (latency/auth amortisation).
4. Real usage accounting from codex `turn/completed`.
5. Error + rate-limit + auth-expired mapping to Anthropic HTTP status/error.type.
6. Endpoint auth (honour `x-api-key` / `authorization`).
7. Coordinate with scitex-genai / litellm routing instead of a bespoke server; multi-account `~/.codex` rotation (mirroring sac account rotation).

## Experimental -- not wired in

Lives under `src/scitex_agent_container/_experimental/`. NOT imported by the package, NOT wired into any spec or the CLI. It is a spike: `codex_anthropic_adapter.py` + a companion README. Run it with `python -m scitex_agent_container._experimental.codex_anthropic_adapter serve` (or `smoke` for the in-process round-trip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
