### PR TITLE
feat(base): bake headless-Chromium runtime libs into sac-base (Playwright)

### DIFF
--- a/src/scitex_agent_container/containers/apptainer-base.def
+++ b/src/scitex_agent_container/containers/apptainer-base.def
@@ -71,6 +71,20 @@ From: ubuntu:24.04
     # Added on the lib row because it's a runtime system library (no
     # -dev companion needed for the consumers that hit the silent-
     # fallback path). Supersedes the standalone PR #322.
+    #
+    # The "playwright/headless-chromium runtime libs" group at the tail
+    # of the apt list is the shared-object set a headless Chromium needs
+    # to LAUNCH (equivalent to `npx playwright install-deps chromium`).
+    # Baked at :base — NOT via scitex_dev.system_deps — on purpose: the
+    # system-deps SSoT only runs at the :scitex layer (scitex-dev isn't
+    # installed here), but the operator wants ANY agent to screenshot /
+    # run browser e2e regardless of which scitex packages its overlay
+    # carries. Two consumers ALREADY baked into :base need exactly these
+    # libs — `@mermaid-js/mermaid-cli` (section 3) and puppeteer's
+    # `chrome-headless-shell` (section 3a) both drive a headless Chromium
+    # — so this also fixes their latent "libnspr4.so: cannot open shared
+    # object file" breakage, not just Playwright's. libglib2.0-0 is
+    # already on the lib row above; libcairo2/libpango pull it transitively.
     apt-get update
     apt-get install -y --no-install-recommends \
         ca-certificates curl wget gnupg \
@@ -86,7 +100,15 @@ From: ubuntu:24.04
         git-delta \
         direnv \
         tmux ncurses-term \
-        tini
+        tini \
+        libnss3 libnspr4 \
+        libatk1.0-0 libatk-bridge2.0-0 libatspi2.0-0 \
+        libcups2 libdrm2 libgbm1 libxshmfence1 \
+        libxkbcommon0 libasound2 \
+        libcairo2 libpango-1.0-0 \
+        libxcomposite1 libxdamage1 libxfixes3 libxrandr2 \
+        libxext6 libxrender1 \
+        fonts-liberation
     locale-gen en_US.UTF-8
 
     # ---- 1a. Canonical container user `agent` (UID 1000) --------------

--- a/tests/integration/test_apptainer_base_def_playwright_libs.py
+++ b/tests/integration/test_apptainer_base_def_playwright_libs.py
@@ -1,0 +1,104 @@
+"""Static contract: ``apptainer-base.def`` must install the headless-Chromium
+runtime libs.
+
+Operator directive (scitex-hub, 2026-07-09): ``sac-base.sif`` must carry the
+system shared objects a headless Chromium needs to LAUNCH, so ANY agent can
+take screenshots / run browser e2e (Playwright) regardless of which scitex
+packages its overlay installs. Without these, chrome dies at launch with
+``libnspr4.so: cannot open shared object file``.
+
+The set is the ``npx playwright install-deps chromium`` equivalent. It lands in
+the plain apt block of the :base layer (NOT via ``scitex_dev.system_deps`` —
+that SSoT only runs at the :scitex layer, where scitex-dev is installed; the
+base image predates it). Two consumers already baked into :base —
+``@mermaid-js/mermaid-cli`` and puppeteer's ``chrome-headless-shell`` — need the
+same libs, so this guard protects them too.
+
+This test pins the requirement as code: drop any of the critical libs from the
+.def and CI yells before a SIF rebuild ships a base image whose Chromium
+cannot launch.
+
+The sibling ``test_apptainer_base_def_scitex_todo.py`` sets the same static
+contract pattern for the scitex-todo[mcp] install at this layer.
+
+STX-TQ002 AAA + STX-TQ007 one-assert per test.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_BASE_DEF = (
+    _REPO_ROOT / "src" / "scitex_agent_container" / "containers" / "apptainer-base.def"
+)
+
+# The launch-critical subset of `npx playwright install-deps chromium`. Every
+# one of these was reported "not found" by `ldd` on the current SIF's chromium.
+_REQUIRED_LIBS = (
+    "libnss3",
+    "libnspr4",
+    "libatk1.0-0",
+    "libatk-bridge2.0-0",
+    "libatspi2.0-0",
+    "libcups2",
+    "libdrm2",
+    "libgbm1",
+    "libxshmfence1",
+    "libxkbcommon0",
+    "libasound2",
+    "libcairo2",
+    "libpango-1.0-0",
+    "libxcomposite1",
+    "libxdamage1",
+    "libxfixes3",
+    "libxrandr2",
+    "libxext6",
+    "libxrender1",
+    "fonts-liberation",
+)
+
+
+@pytest.fixture(scope="module")
+def base_def_text() -> str:
+    # Arrange
+    return _BASE_DEF.read_text()
+
+
+def _apt_install_block(text: str) -> str:
+    """Return the first ``apt-get install ...`` continuation chunk joined.
+
+    Section 1's apt block is the base OS package set; the playwright libs
+    are appended to its tail. Joining the ``\\``-continued lines lets a
+    single membership check see the whole package list.
+    """
+    lines = text.splitlines()
+    out: list[str] = []
+    in_block = False
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("apt-get install"):
+            in_block = True
+        if in_block:
+            out.append(stripped.rstrip("\\").strip())
+            if not stripped.endswith("\\"):
+                break
+    return " ".join(out)
+
+
+@pytest.mark.parametrize("lib", _REQUIRED_LIBS)
+def test_base_apt_block_installs_headless_chromium_lib(
+    base_def_text: str, lib: str
+) -> None:
+    # Arrange
+    block = _apt_install_block(base_def_text)
+    # Act
+    present = lib in block.split()
+    # Assert
+    assert present, (
+        f"{lib!r} missing from the section-1 apt install block in "
+        f"apptainer-base.def — headless Chromium (Playwright / mermaid-cli / "
+        f"chrome-headless-shell) will fail to launch. Block:\n{block}"
+    )


### PR DESCRIPTION
## What
Adds the `npx playwright install-deps chromium` shared-object set to the **section-1 apt block** of `apptainer-base.def` so a headless Chromium can **launch** inside `sac-base.sif`.

Agents already carry the python `playwright` package + the chromium binary (`~/.cache/ms-playwright/chromium-*/chrome-linux64/chrome`), but launch died with:
```
libnspr4.so: cannot open shared object file: No such file or directory
```

## Where + why (SSoT placement)
Inserted into the **plain apt block** in `apptainer-base.def` (section 1), grouped with a comment paragraph — **not** via the `scitex_dev.system_deps` SSoT.

- The `scitex_dev.system_deps` aggregate (`scitex-dev ecosystem system-deps install`) only runs at the **:scitex layer**, where `scitex-dev` is installed. The **base layer predates it** and legitimately hardcodes OS packages (this is the case the migration explicitly left as a plain apt block).
- The operator wants headless Chromium in **sac-BASE** so **any** agent can screenshot / run browser e2e regardless of which scitex packages its overlay carries. Base placement is therefore correct and intentional.
- Bonus: two consumers **already baked into :base** need these exact libs — `@mermaid-js/mermaid-cli` (section 3) and puppeteer's `chrome-headless-shell` (section 3a). Both drive a headless Chromium, so this fixes their latent launch breakage too, not just Playwright's.

**No SSoT tension for follow-up:** these are OS runtime libs for the base image, not a scitex leaf's Python deps, so they belong at base — nothing to relocate.

## Libs added
`libnss3 libnspr4 libatk1.0-0 libatk-bridge2.0-0 libatspi2.0-0 libcups2 libdrm2 libgbm1 libxshmfence1 libxkbcommon0 libasound2 libcairo2 libpango-1.0-0 libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libxext6 libxrender1 fonts-liberation`
(`libglib2.0-0` was already present on the lib row.)

## Tests
Adds `tests/integration/test_apptainer_base_def_playwright_libs.py` — a static contract mirroring the existing `test_apptainer_base_def_scitex_todo.py`, parametrized over the launch-critical libs so CI fails if any is dropped before a SIF rebuild.

```
23 passed in 0.61s
```
(20 lib checks + the 3 sibling scitex-todo contract tests, run with `/opt/venv-sac/bin/python -m pytest`.)

## Build note
No SIF build triggered here (builds run on Spartan via scitex-hpc); a separate build will pick up this merged change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)