### PR TITLE
fix(tui): release + rebind the a2a port on restart (stop EADDRINUSE strand)

### DIFF
--- a/src/scitex_agent_container/runtimes/_tui_turn_bridge.py
+++ b/src/scitex_agent_container/runtimes/_tui_turn_bridge.py
@@ -1,31 +1,17 @@
 """Host-side A2A ``/v1/turn`` → tmux bridge for ``runtime: tui`` agents.
 
-Closes the wake-on-push gap that left interactive TUI agents reachable on
-the ``sac listen`` bus (via the ``sac mcp channel`` subscriber) but unable
-to ACT on a pushed message while idle.
+Closes the wake-on-push gap for interactive TUI agents. The SDK runtime
+serves ``/v1/turn`` from its in-SIF runner so the ``sac mcp channel``
+subscriber's wake POST (``_mcp/_channel_wake._wake_turn``) DRIVES an idle
+agent to act; the TUI runtime runs ``claude`` in tmux with no in-process
+HTTP server, so that POST hit a dead port and the message never woke it.
+This module gives TUI agents the SAME endpoint host-side (the in-SIF
+subscriber POSTs to ``127.0.0.1:<port>`` — apptainer shares the host net
+namespace): on ``POST /v1/turn`` it injects ``text`` into the tmux session
+via :meth:`TuiSessionRuntime.send_turn` and returns ``200`` once delivered.
 
-Background (2026-06-17). The SDK runtime serves a ``/v1/turn`` HTTP
-endpoint from its in-SIF runner (``_runners/_session_http.py``); the
-channel subscriber's wake primitive (``_mcp/_channel_wake._wake_turn``)
-POSTs each qualifying bus event there so an IDLE agent is DRIVEN to
-process it immediately. The TUI runtime runs interactive ``claude`` in
-tmux — no in-process HTTP server — so that wake POST hit a dead port
-(``[Errno 110] Connection timed out``) and the message only landed as a
-``notifications/claude/channel`` MCP notification, which (per channel.py)
-"cannot wake an idle session". Net effect: a TUI agent received nothing
-actionable until some unrelated next turn.
-
-This module gives TUI agents the SAME turn endpoint, host-side (where the
-tmux PTY lives — the in-SIF subscriber POSTs to ``127.0.0.1:<port>`` and
-apptainer shares the host net namespace). On ``POST /v1/turn`` it injects
-the ``text`` into the agent's tmux session via
-:meth:`TuiSessionRuntime.send_turn` — the exact delivery path an operator
-``sac agents send`` uses — and returns ``200`` as soon as the keystrokes
-are delivered (the driven turn runs asynchronously in the TUI; its own
-Stop hook PUSHes any completion report back, same as the SDK path).
-
-Wire format mirrors ``_session_http`` so ``_wake_turn`` and A2A clients
-work unchanged:
+Wire format mirrors ``_session_http`` so ``_wake_turn`` + A2A clients work
+unchanged:
 
     POST /v1/turn                      (bare — the port identifies the agent)
     POST /agents/<name>/turn           (canonical sac namespace)
@@ -39,12 +25,12 @@ work unchanged:
     502 {"error": "tui inject failed: ..."}               # session gone / input wedged
 
 Lifecycle mirrors :mod:`a2a_sidecar`: :func:`start_turn_bridge` spawns the
-server as a detached subprocess (so it outlives the ``sac agents start``
-process, like the tmux session it serves), writing a PID file + log under
-the agent's per-host state dir; :func:`stop_turn_bridge` SIGTERMs it.
-Both are best-effort — a failed bridge must never block agent start/stop.
-Bound to ``127.0.0.1`` (the wake POST is loopback; the bind is the
-security boundary, matching the SDK runner which does not auth /v1/turn).
+server as a detached subprocess writing a PID file + log under the agent's
+per-host state dir; :func:`stop_turn_bridge` SIGTERMs it AND waits for the
+port to release (see :mod:`_tui_turn_bridge_port` — the restart
+port-collision fix). Both are best-effort — a failed bridge must never
+block agent start/stop. Bound to ``127.0.0.1`` (loopback wake POST; the
+bind is the security boundary, matching the SDK runner's unauthed endpoint).
 """
 
 from __future__ import annotations
@@ -56,11 +42,21 @@ import os
 import signal
 import subprocess
 import sys
+import time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any, Callable
 
 from ..config import AgentConfig
+from ._tui_turn_bridge_port import (
+    _PORT_FREE_TIMEOUT_S,
+    _STOP_SIGTERM_GRACE_S,
+    TurnBridgePortBusyError,
+    await_bridge_release,
+    ensure_port_free_or_raise,
+    port_busy_error,
+    port_is_free,
+)
 
 log = logging.getLogger(__name__)
 
@@ -212,8 +208,16 @@ class _TurnBridgeHandler(BaseHTTPRequestHandler):
 def build_server(
     *, host: str, port: int, on_turn: Callable[..., None], agent_name: str
 ) -> _TurnBridgeServer:
-    """Construct (but do not run) the bridge server. Test seam."""
-    return _TurnBridgeServer((host, port), on_turn, agent_name)
+    """Construct (but do not run) the bridge server. Test seam.
+
+    A bind refusal (port still held by a lingering old bridge) is re-raised
+    as a :class:`TurnBridgePortBusyError` naming the port + holder +
+    remediation, not a bare ``OSError [Errno 98] Address already in use``.
+    """
+    try:
+        return _TurnBridgeServer((host, port), on_turn, agent_name)
+    except OSError as exc:
+        raise port_busy_error(host, port, agent_name, cause=exc) from exc
 
 
 def serve(  # pragma: no cover - integration entry: installs main-thread-only signal handlers + blocks in serve_forever; the server logic is unit-tested via build_server, the full serve path is exercised end-to-end
@@ -246,20 +250,14 @@ def _build_on_turn(
 ) -> Callable[..., None]:
     """Inject callback that drives one TUI turn via the tmux PTY.
 
-    Calls :meth:`TuiSessionRuntime.send_turn` with ``wait_ready=False``
-    (see the inline note). Raises when the session is gone so the handler
-    answers 502 (the channel subscriber's ``raise_for_status`` then
-    surfaces it loud rather than pretending the wake landed). ``runtime``
-    is a test seam — production constructs the real
-    :class:`TuiSessionRuntime`.
-
-    When the wake carries a ``from_agent`` (the dispatching peer), the
-    inbound is RECORDED into the DB-backed inbound ledger BEFORE the
-    inject, so the agent's ``Stop`` hook can push a dispatch-correlated
-    completion report back to that requester (SDK-parity outbound — see
-    :mod:`_tui_outbound`). Recording is best-effort: a ledger-write
-    failure logs but never blocks delivering the turn (the agent still
-    wakes; only the auto-report is lost).
+    Calls :meth:`TuiSessionRuntime.send_turn` with ``wait_ready=False`` (see
+    the inline note); raises when the session is gone so the handler answers
+    502 (the subscriber's ``raise_for_status`` surfaces it loud). ``runtime``
+    is a test seam. When the wake carries a ``from_agent``, the inbound is
+    RECORDED into the DB-backed ledger BEFORE the inject so the ``Stop`` hook
+    can push a dispatch-correlated report back (SDK-parity outbound — see
+    :mod:`_tui_outbound`); best-effort — a ledger failure never blocks the
+    turn (only the auto-report is lost).
     """
     if (
         runtime is None
@@ -292,15 +290,11 @@ def _build_on_turn(
                     exc,
                 )
         # ``wait_ready=False`` → the bare send_text_and_submit primitive
-        # (text + Enter), the operator-confirmed delivery path
-        # (``send_turn`` itself defaults to it for that reason). The full
-        # ``wait_until_input_ready`` drain blocks up to 60s polling for a
-        # "? for shortcuts" marker that an autonomous agent's idle pane may
-        # never render — fatal for a wake POST. First-launch modals are
-        # already drained by ``start()._drain_at_boot``; a live wake into
-        # an idle ❯ needs no drain. claude queues keystrokes typed mid-turn
-        # and submits them when the input rebinds, so a wake during an
-        # active turn is not dropped.
+        # (text + Enter). The full ``wait_until_input_ready`` drain blocks up
+        # to 60s on a "? for shortcuts" marker an idle autonomous pane may
+        # never render — fatal for a wake POST; boot modals are already
+        # drained by ``start()._drain_at_boot`` and claude queues keystrokes
+        # typed mid-turn, so a live wake needs no drain and is never dropped.
         delivered = runtime.send_turn(config, text, wait_ready=False)
         if not delivered:
             raise RuntimeError(
@@ -350,33 +344,49 @@ def start_turn_bridge(
     *,
     spawn: Callable[..., Any] = subprocess.Popen,
     host: str = DEFAULT_HOST,
+    port_free_timeout_s: float = _PORT_FREE_TIMEOUT_S,
+    sleep_fn: Callable[[float], None] = time.sleep,
+    now_fn: Callable[[], float] = time.monotonic,
+    port_free_fn: Callable[[str, int], bool] = port_is_free,
 ) -> int | None:
     """Spawn the detached turn bridge for ``config``; return its PID or None.
 
-    No-op (returns None) when the agent declares no resolved ``a2a.port``
-    — without an a2a port the channel subscriber has no ``--turn-url`` to
-    POST to, so there is nothing to serve. Best-effort: a spawn failure is
-    logged and swallowed (a dead bridge must not block agent start). The
-    ``spawn`` seam lets tests assert the argv without a real subprocess.
+    No-op (returns None) without a resolved ``a2a.port`` (nothing to serve).
+    Best-effort spawn: a failure is logged + swallowed (a dead bridge must
+    not block agent start); the ``spawn`` seam lets tests assert the argv.
 
-    Pre-existing-bridge teardown (2026-06-19 a2a mis-route fix): a restart
-    that does NOT route through :meth:`TuiSessionRuntime.stop` (e.g. the
-    supervisor's stale-lease path, or a flip that changes ``a2a.port``)
-    can leave the agent's PREVIOUS bridge process alive on the old port.
-    Writing the new PID over the pidfile would orphan it permanently — the
-    stale bridge keeps its old port bound, and a later fresh agent that
-    inherits that port collides and mis-routes traffic into the stale
-    bridge's tmux. So we ALWAYS :func:`stop_turn_bridge` first, making the
-    one-bridge-per-agent invariant hold regardless of how we got here.
+    We ALWAYS :func:`stop_turn_bridge` first (one-bridge-per-agent invariant)
+    AND then POLL until the a2a port is bindable before spawning. On the
+    2026-07-09 restart port-collision incident the old holder still owned the
+    port when the new child bound it → ``EADDRINUSE`` crash → agent stranded.
+    If the port cannot be freed within ``port_free_timeout_s`` we FAIL LOUD
+    (:class:`TurnBridgePortBusyError`, naming port + holder + remediation)
+    instead of spawning into that crash. ``*_fn`` seams are injected by tests.
     """
     port = resolved_a2a_port(config)
     if port is None:
         return None
-    # Deterministically tear down any prior bridge for THIS agent before we
-    # spawn (and overwrite the pidfile). The pidfile is keyed by the agent's
-    # per-host state dir, so this reliably kills the agent's own previous
-    # bridge — even one left on a now-stale port by a port-changing restart.
-    stop_turn_bridge(config)
+    # Tear down any prior bridge for THIS agent, now also WAITING for it to
+    # release the port.
+    stop_turn_bridge(
+        config,
+        host=host,
+        sleep_fn=sleep_fn,
+        now_fn=now_fn,
+        port_free_fn=port_free_fn,
+    )
+    # Bounded wait for the port to be bindable BEFORE we spawn — covers the
+    # async shutdown tail AND an untracked/orphaned holder. Fails loud instead
+    # of spawning a child into an EADDRINUSE crash.
+    ensure_port_free_or_raise(
+        host=host,
+        port=port,
+        agent_name=str(getattr(config, "name", "?")),
+        timeout_s=port_free_timeout_s,
+        sleep_fn=sleep_fn,
+        now_fn=now_fn,
+        port_free_fn=port_free_fn,
+    )
     config_path = str(getattr(config, "config_path", "") or "")
     if not config_path:
         log.warning(
@@ -422,12 +432,27 @@ def start_turn_bridge(
     return pid
 
 
-def stop_turn_bridge(config: AgentConfig) -> bool:
-    """SIGTERM the bridge recorded in the PID file; return True if one was.
+def stop_turn_bridge(
+    config: AgentConfig,
+    *,
+    host: str = DEFAULT_HOST,
+    grace_s: float = _STOP_SIGTERM_GRACE_S,
+    sleep_fn: Callable[[float], None] = time.sleep,
+    now_fn: Callable[[], float] = time.monotonic,
+    port_free_fn: Callable[[str, int], bool] = port_is_free,
+) -> bool:
+    """SIGTERM the recorded bridge, WAIT for it to RELEASE THE PORT (SIGKILL
+    if it overstays ``grace_s``), then drop the PID file; return True iff a
+    live PID was signalled. No-op (returns False) when no PID file exists.
 
-    No-op (returns False) when no PID file exists. The PID file is the
-    source of truth and is removed regardless of whether the process was
-    still alive, so a stop()->start() cycle never reuses a stale PID.
+    Incident fix (2026-07-09): the old code SIGTERMed and returned
+    IMMEDIATELY — the port stayed held during the async ``serve_forever``
+    shutdown, so a fast ``restart`` rebound straight into ``EADDRINUSE`` and
+    stranded the agent. Now :func:`await_bridge_release` blocks until the
+    port is bindable again (accurate even for a not-yet-reaped zombie, which
+    holds no socket; falls back to PID liveness when the agent has no a2a
+    port). The PID file is removed regardless, so a stop()->start() cycle
+    never reuses a stale PID. ``*_fn`` seams are injected for tests.
     """
     pid_path = _pid_path(config)
     if not pid_path.is_file():
@@ -440,6 +465,7 @@ def stop_turn_bridge(config: AgentConfig) -> bool:
         ValueError,
     ):  # stx-allow: fallback (reason: an unreadable/corrupt PID file is treated as "already stopped"; we still unlink it below so the next start is clean)
         pid = -1
+    port = resolved_a2a_port(config)
     if pid > 0:
         try:
             os.kill(pid, signal.SIGTERM)
@@ -448,6 +474,18 @@ def stop_turn_bridge(config: AgentConfig) -> bool:
             stopped = False
         except OSError as exc:  # stx-allow: fallback (reason: a permission/ESRCH error still means "not our live process"; log + treat as stopped so cleanup proceeds)
             log.warning("tui-turn-bridge: SIGTERM pid %d failed: %s", pid, exc)
+        if stopped:
+            # Block until the port is released (SIGKILL if SIGTERM ignored),
+            # so a fast restart never rebinds into a still-held port.
+            await_bridge_release(
+                pid,
+                port,
+                host=host,
+                grace_s=grace_s,
+                sleep_fn=sleep_fn,
+                now_fn=now_fn,
+                port_free_fn=port_free_fn,
+            )
     try:
         pid_path.unlink()
     except OSError:  # stx-allow: fallback (reason: unlink race is harmless — the file is gone either way)
@@ -467,4 +505,5 @@ __all__ = [
     "main",
     "start_turn_bridge",
     "stop_turn_bridge",
+    "TurnBridgePortBusyError",
 ]

--- a/src/scitex_agent_container/runtimes/_tui_turn_bridge_port.py
+++ b/src/scitex_agent_container/runtimes/_tui_turn_bridge_port.py
@@ -1,0 +1,271 @@
+"""Port release + bind-collision guards for the TUI A2A turn bridge.
+
+Extracted from :mod:`_tui_turn_bridge` (module line cap) — the machinery
+that makes ``sac agents restart`` reliably RELEASE + REBIND the agent's
+a2a/turn port.
+
+The incident this fixes (2026-07-09, scitex-todo stranded): a restart
+STOPPED the agent, but the new spawn failed with
+``post_ack_no_apptainer_pid`` — the container never came up. The real
+crash was in the child, logged to ``<runtime_dir>/tui-turn-bridge.log``::
+
+    OSError: [Errno 98] Address already in use
+      File ".../runtimes/_tui_turn_bridge.py", line ..., in __init__
+        super().__init__(server_address, _TurnBridgeHandler)
+      ...
+        self.socket.bind(self.server_address)
+
+The OLD instance's turn-bridge server was STILL holding the a2a port when
+the new instance booted, so the new bind was refused. ``SO_REUSEADDR``
+(``_TurnBridgeServer.allow_reuse_address``) covers only the ``TIME_WAIT``
+fast-restart case — it does NOT let a bind steal a port from a
+still-running listener, which is what bit us (the old process was alive,
+not merely lingering). So the stop path must actually TERMINATE the old
+holder and the start path must WAIT for the port to be bindable BEFORE it
+spawns — and FAIL LOUD (naming the port + holder + the exact remediation)
+if it cannot, rather than spawning straight into the crash.
+
+Everything here is pure + unit-testable with REAL sockets/processes
+(injectable ``sleep``/``now``/``port-free`` seams — no mocks):
+
+* :func:`port_is_free` — a fresh ``SO_REUSEADDR`` bind probe answering
+  "will the new bridge bind here right now?" faithfully.
+* :func:`await_bridge_release` — wait for a SIGTERM'd bridge to release the
+  port, escalating to SIGKILL past a grace (used by ``stop_turn_bridge``).
+* :func:`port_busy_error` — the actionable :class:`TurnBridgePortBusyError`
+  naming the port + holder PID(s) + the one-liner remediation.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import signal
+import socket
+from typing import Callable
+
+log = logging.getLogger(__name__)
+
+# Bounded waits (seconds). ``_STOP_SIGTERM_GRACE_S`` — how long
+# ``stop_turn_bridge`` waits for a SIGTERM'd bridge to release the port
+# before escalating to SIGKILL. ``_PORT_FREE_TIMEOUT_S`` — how long
+# ``start_turn_bridge`` polls for the port to become bindable before it
+# FAILS LOUD (never spawns into a guaranteed crash). ``_PORT_POLL_INTERVAL_S``
+# — poll cadence for both.
+_STOP_SIGTERM_GRACE_S = 5.0
+_PORT_FREE_TIMEOUT_S = 10.0
+_PORT_POLL_INTERVAL_S = 0.2
+
+
+class TurnBridgePortBusyError(RuntimeError):
+    """The a2a port is still held when a new turn bridge must bind it.
+
+    Raised (fail loud) by ``build_server`` when the bind is refused and by
+    ``start_turn_bridge`` when the old holder could not be freed within the
+    bounded wait. Carries ``port`` so a caller/log shows the exact
+    remediation instead of a bare ``OSError [Errno 98]``.
+    """
+
+    def __init__(self, message: str, *, port: int) -> None:
+        super().__init__(message)
+        self.port = port
+
+
+def _pid_alive(pid: int) -> bool:
+    """``kill -0`` liveness. ``ProcessLookupError`` = reaped/dead.
+
+    A not-yet-reaped zombie reads ALIVE here — which is why the PORT (a
+    zombie holds no socket) is the primary release signal; PID liveness is
+    only the fallback for an agent that declares no resolved a2a port.
+    """
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:  # stx-allow: fallback (reason: any other errno on kill -0 means "not our live process"; treat as dead so teardown proceeds)
+        return False
+    return True
+
+
+def port_is_free(host: str, port: int) -> bool:
+    """True iff a fresh ``SO_REUSEADDR`` socket can bind ``host:port`` now.
+
+    Mirrors the EXACT options ``_TurnBridgeServer`` uses
+    (``allow_reuse_address`` → ``SO_REUSEADDR``), so a True result means
+    "the new bridge WILL bind here": a still-running old listener makes
+    ``bind`` fail with ``EADDRINUSE`` (SO_REUSEADDR never steals a LIVE
+    listener), while a lingering ``TIME_WAIT`` socket is bindable (exactly
+    what SO_REUSEADDR permits — the fast-restart case). The probe socket is
+    never ``listen``-ed, so closing it leaves no ``TIME_WAIT`` of its own.
+    """
+    probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        probe.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        probe.bind((host, port))
+        return True
+    except OSError:
+        return False
+    finally:
+        probe.close()
+
+
+def poll_until(
+    predicate: Callable[[], bool],
+    *,
+    timeout_s: float,
+    poll_s: float,
+    sleep_fn: Callable[[float], None],
+    now_fn: Callable[[], float],
+) -> bool:
+    """Return True as soon as ``predicate()`` holds; False on timeout.
+
+    Seams (``sleep_fn``/``now_fn``) are injected so a wait is unit-testable
+    without real time; production passes ``time.sleep`` / ``time.monotonic``.
+    """
+    deadline = now_fn() + timeout_s
+    while True:
+        if predicate():
+            return True
+        if now_fn() >= deadline:
+            return False
+        sleep_fn(poll_s)
+
+
+def _safe_port_holder_pids(port: int) -> list[int]:
+    """Best-effort PID(s) LISTENING on ``port`` (lsof/ss/fuser); never raises.
+
+    Reuses the tested :func:`.._listen._port_holder.port_holder_pids`
+    finder so a fail-loud message can name the holder; an absent tool
+    degrades to an empty list (the message still names the port +
+    remediation).
+    """
+    try:
+        from .._listen._port_holder import port_holder_pids
+
+        return port_holder_pids(port)
+    except Exception:  # stx-allow: fallback (reason: holder discovery is diagnostic only; a missing lsof/ss/fuser must not mask the loud bind error)
+        return []
+
+
+def port_busy_error(
+    host: str, port: int, agent_name: str, *, cause: Exception | None = None
+) -> TurnBridgePortBusyError:
+    """Build the actionable :class:`TurnBridgePortBusyError` for ``port``.
+
+    Names the holder PID(s) and the exact one-liner remediation
+    (``fuser -k <port>/tcp; tmux kill-session -t tui-<name>``) so the
+    operator recovers without diagnosing a bare ``EADDRINUSE``.
+    """
+    holders = _safe_port_holder_pids(port)
+    who = (
+        ", ".join(str(p) for p in holders)
+        if holders
+        else "unknown (install lsof/ss/fuser to identify)"
+    )
+    session = f"tui-{agent_name}"
+    cause_txt = f" [{cause}]" if cause is not None else ""
+    return TurnBridgePortBusyError(
+        f"tui-turn-bridge: a2a port {port} on {host} for agent {agent_name!r} is "
+        f"STILL held by an old holder{cause_txt} — refusing to bind into an "
+        f"EADDRINUSE crash (the restart port-collision incident). Holder "
+        f"PID(s): {who}; tmux session: {session}. Free it, then restart: "
+        f"`fuser -k {port}/tcp; tmux kill-session -t {session}; "
+        f"sac agents restart {agent_name}`.",
+        port=port,
+    )
+
+
+def ensure_port_free_or_raise(
+    *,
+    host: str,
+    port: int,
+    agent_name: str,
+    timeout_s: float,
+    sleep_fn: Callable[[float], None],
+    now_fn: Callable[[], float],
+    port_free_fn: Callable[[str, int], bool] = port_is_free,
+    poll_s: float = _PORT_POLL_INTERVAL_S,
+) -> None:
+    """Poll (bounded) until ``host:port`` is bindable; else FAIL LOUD.
+
+    The pre-spawn gate for ``start_turn_bridge``: returns quietly once the
+    port is free, otherwise logs + raises :class:`TurnBridgePortBusyError`
+    (naming the port + holder + remediation) so the caller never spawns a
+    child straight into an ``EADDRINUSE`` crash.
+    """
+    if poll_until(
+        lambda: port_free_fn(host, port),
+        timeout_s=timeout_s,
+        poll_s=poll_s,
+        sleep_fn=sleep_fn,
+        now_fn=now_fn,
+    ):
+        return
+    err = port_busy_error(host, port, agent_name)
+    log.error("%s", err)
+    raise err
+
+
+def await_bridge_release(
+    pid: int,
+    port: int | None,
+    *,
+    host: str,
+    grace_s: float,
+    sleep_fn: Callable[[float], None],
+    now_fn: Callable[[], float],
+    port_free_fn: Callable[[str, int], bool] = port_is_free,
+    poll_s: float = _PORT_POLL_INTERVAL_S,
+) -> bool:
+    """Block until a SIGTERM'd bridge has RELEASED its port; SIGKILL if it
+    overstays ``grace_s``, then wait once more. Returns True iff released.
+
+    Uses the PORT as the release signal when the agent has a resolved a2a
+    port (accurate even for a not-yet-reaped zombie — a dead process holds
+    no socket); otherwise falls back to PID liveness. The SIGKILL branch is
+    what makes a bridge that IGNORES SIGTERM / hangs its ``serve_forever``
+    teardown actually give up the port before the caller rebinds.
+    """
+
+    def _released() -> bool:
+        if port is not None:
+            return port_free_fn(host, port)
+        return not _pid_alive(pid)
+
+    if poll_until(
+        _released, timeout_s=grace_s, poll_s=poll_s, sleep_fn=sleep_fn, now_fn=now_fn
+    ):
+        return True
+    # SIGTERM ignored / teardown hung past the grace — force it so the port
+    # is actually released before the caller rebinds.
+    try:
+        os.kill(pid, signal.SIGKILL)
+        log.warning(
+            "tui-turn-bridge: pid %d ignored SIGTERM after %.1fs; sent SIGKILL "
+            "to release port %s",
+            pid,
+            grace_s,
+            port,
+        )
+    except OSError:  # stx-allow: fallback (reason: SIGKILL of an already-gone/foreign pid is a no-op; the release re-poll below is the real check)
+        pass
+    return poll_until(
+        _released, timeout_s=grace_s, poll_s=poll_s, sleep_fn=sleep_fn, now_fn=now_fn
+    )
+
+
+__all__ = [
+    "TurnBridgePortBusyError",
+    "await_bridge_release",
+    "ensure_port_free_or_raise",
+    "poll_until",
+    "port_busy_error",
+    "port_is_free",
+    "_STOP_SIGTERM_GRACE_S",
+    "_PORT_FREE_TIMEOUT_S",
+    "_PORT_POLL_INTERVAL_S",
+]

--- a/tests/scitex_agent_container/runtimes/test__tui_turn_bridge.py
+++ b/tests/scitex_agent_container/runtimes/test__tui_turn_bridge.py
@@ -18,8 +18,11 @@ assert + STX-TQ003 descriptive names.
 from __future__ import annotations
 
 import json
+import socket
 import subprocess
+import sys
 import threading
+import time
 import urllib.error
 import urllib.request
 from pathlib import Path
@@ -418,3 +421,133 @@ def test_start_turn_bridge_records_new_pid_over_prior(
     bridge.start_turn_bridge(config, spawn=lambda argv, **kw: SimpleNamespace(pid=_PID))
     # Assert — pidfile now holds the new bridge's PID.
     assert pid_path.read_text(encoding="utf-8").strip() == str(_PID)
+
+
+# ---------------------------------------------------------------------------
+# Restart port-collision fix — SO_REUSEADDR + release/rebind/fail-loud
+# ---------------------------------------------------------------------------
+def _free_port() -> int:
+    """Return a currently-free ephemeral TCP port (bind :0, read, release)."""
+    probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    probe.bind(("127.0.0.1", 0))
+    port = int(probe.getsockname()[1])
+    probe.close()
+    return port
+
+
+def _wait_until_bound(port: int, timeout_s: float = 5.0) -> None:
+    """Block until ``port`` is no longer bindable (a listener has claimed it)."""
+    deadline = time.monotonic() + timeout_s
+    while bridge.port_is_free("127.0.0.1", port):
+        if time.monotonic() >= deadline:
+            return
+        time.sleep(0.05)
+
+
+def test_turn_bridge_server_sets_allow_reuse_address() -> None:
+    # Arrange
+    server_cls = bridge._TurnBridgeServer
+    # Act
+    reuse = server_cls.allow_reuse_address
+    # Assert — SO_REUSEADDR so a rebind is not blocked by a TIME_WAIT socket.
+    assert reuse is True
+
+
+def test_build_server_rebind_after_close_succeeds() -> None:
+    # Arrange — bind a real bridge server on an ephemeral port, then close it.
+    first = bridge.build_server(
+        host="127.0.0.1", port=0, on_turn=lambda *_a, **_k: None, agent_name="fig"
+    )
+    port = first.server_address[1]
+    first.server_close()
+    # Act — a fresh bind on the SAME port must succeed (allow_reuse_address).
+    second = bridge.build_server(
+        host="127.0.0.1", port=port, on_turn=lambda *_a, **_k: None, agent_name="fig"
+    )
+    rebound_port = second.server_address[1]
+    second.server_close()
+    # Assert
+    assert rebound_port == port
+
+
+def test_build_server_raises_named_error_when_port_held() -> None:
+    # Arrange — a REAL socket holds the port so the bridge bind is refused.
+    held = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    held.bind(("127.0.0.1", 0))
+    held.listen()
+    port = held.getsockname()[1]
+    # Act
+    # Assert
+    try:
+        with pytest.raises(bridge.TurnBridgePortBusyError):
+            bridge.build_server(
+                host="127.0.0.1",
+                port=port,
+                on_turn=lambda *_a, **_k: None,
+                agent_name="fig",
+            )
+    finally:
+        held.close()
+
+
+def test_start_turn_bridge_fails_loud_when_port_stays_busy(
+    tmp_path: Path, isolated_home: Path
+) -> None:
+    # Arrange — a REAL listener holds the agent's a2a port; spawn must NOT run.
+    spec = tmp_path / "spec.yaml"
+    spec.write_text("apiVersion: scitex-agent-container/v3\n", encoding="utf-8")
+    held = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    held.bind(("127.0.0.1", 0))
+    held.listen()
+    port = held.getsockname()[1]
+    config = SimpleNamespace(
+        a2a=SimpleNamespace(port=port), name="stuck", config_path=str(spec)
+    )
+    clock = {"t": 0.0}
+
+    def must_not_spawn(*_a, **_k):
+        raise AssertionError("start must not spawn a bridge into a held port")
+
+    # Act
+    # Assert
+    try:
+        with pytest.raises(bridge.TurnBridgePortBusyError):
+            bridge.start_turn_bridge(
+                config,
+                spawn=must_not_spawn,
+                port_free_timeout_s=0.5,
+                sleep_fn=lambda s: clock.__setitem__("t", clock["t"] + s),
+                now_fn=lambda: clock["t"],
+            )
+    finally:
+        held.close()
+
+
+def test_stop_turn_bridge_releases_held_a2a_port(
+    tmp_path: Path, isolated_home: Path
+) -> None:
+    # Arrange — a REAL listener subprocess bound to the agent's a2a port,
+    # recorded as the agent's bridge PID; stop must SIGTERM it AND wait for
+    # the port to release (the incident: stop returned before release).
+    port = _free_port()
+    listener_code = (
+        "import socket,time;"
+        "s=socket.socket();"
+        "s.setsockopt(socket.SOL_SOCKET,socket.SO_REUSEADDR,1);"
+        f"s.bind(('127.0.0.1',{port}));"
+        "s.listen();"
+        "time.sleep(60)"
+    )
+    proc = subprocess.Popen([sys.executable, "-c", listener_code])
+    _wait_until_bound(port)
+    config = SimpleNamespace(
+        a2a=SimpleNamespace(port=port), name="free-me", config_path=""
+    )
+    pid_path = bridge._pid_path(config)
+    pid_path.parent.mkdir(parents=True, exist_ok=True)
+    pid_path.write_text(str(proc.pid), encoding="utf-8")
+    # Act
+    bridge.stop_turn_bridge(config)
+    proc.wait(timeout=5)
+    # Assert — the a2a port is bindable again.
+    assert bridge.port_is_free("127.0.0.1", port) is True

--- a/tests/scitex_agent_container/runtimes/test__tui_turn_bridge_port.py
+++ b/tests/scitex_agent_container/runtimes/test__tui_turn_bridge_port.py
@@ -1,0 +1,276 @@
+"""Tests for the TUI turn-bridge port machinery (``_tui_turn_bridge_port``).
+
+This is the restart port-collision fix (2026-07-09): the OLD bridge still
+held the a2a port when the new one booted, so the child crashed with
+``OSError [Errno 98] Address already in use`` and the agent was stranded.
+The guards here make ``restart`` reliably RELEASE + REBIND the port.
+
+Real seams only (PA-306 no-mocks): the bind checks run against REAL sockets
+on ephemeral ports; the release path SIGKILLs a REAL listener subprocess; a
+fake clock (plain callables, not a mock) drives the bounded waits without
+real time. STX-TQ002 AAA markers + STX-TQ007 one observable assert +
+STX-TQ003 descriptive names.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import subprocess
+import sys
+import time
+from typing import Callable, Iterator
+
+import pytest
+
+from scitex_agent_container.runtimes import _tui_turn_bridge_port as portmod
+
+_HOST = "127.0.0.1"
+
+
+# ---------------------------------------------------------------------------
+# Helpers — real ephemeral ports + a real listener subprocess
+# ---------------------------------------------------------------------------
+def _free_port() -> int:
+    """Return a currently-free ephemeral TCP port (bind :0, read, release)."""
+    probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    probe.bind((_HOST, 0))
+    port = int(probe.getsockname()[1])
+    probe.close()
+    return port
+
+
+class _FakeClock:
+    """Deterministic monotonic clock — ``now``/``sleep`` are plain callables."""
+
+    def __init__(self) -> None:
+        self.t = 0.0
+
+    def now(self) -> float:
+        return self.t
+
+    def sleep(self, seconds: float) -> None:
+        self.t += seconds
+
+
+@pytest.fixture
+def listeners() -> Iterator[Callable[[int], subprocess.Popen]]:
+    """Spawn REAL listener subprocesses on a port; tear them all down."""
+    procs: list[subprocess.Popen] = []
+
+    def start(port: int) -> subprocess.Popen:
+        code = (
+            "import socket,time;"
+            "s=socket.socket();"
+            "s.setsockopt(socket.SOL_SOCKET,socket.SO_REUSEADDR,1);"
+            f"s.bind(('{_HOST}',{port}));"
+            "s.listen();"
+            "time.sleep(60)"
+        )
+        proc = subprocess.Popen([sys.executable, "-c", code])
+        procs.append(proc)
+        # Wait until it has actually bound (port no longer free) before use.
+        portmod.poll_until(
+            lambda: not portmod.port_is_free(_HOST, port),
+            timeout_s=5.0,
+            poll_s=0.05,
+            sleep_fn=time.sleep,
+            now_fn=time.monotonic,
+        )
+        return proc
+
+    yield start
+    for proc in procs:
+        if proc.poll() is None:
+            proc.kill()
+        proc.wait(timeout=5)
+
+
+# ---------------------------------------------------------------------------
+# port_is_free — the faithful "will the new bridge bind here?" probe
+# ---------------------------------------------------------------------------
+def test_port_is_free_true_on_unbound_port() -> None:
+    # Arrange
+    port = _free_port()
+    # Act
+    free = portmod.port_is_free(_HOST, port)
+    # Assert
+    assert free is True
+
+
+def test_port_is_free_false_while_listener_bound_true_after_close() -> None:
+    # Arrange — a REAL bound+listening socket holds the port.
+    held = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    held.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    held.bind((_HOST, 0))
+    held.listen()
+    port = int(held.getsockname()[1])
+    # Act
+    while_bound = portmod.port_is_free(_HOST, port)
+    held.close()
+    after_close = portmod.port_is_free(_HOST, port)
+    # Assert — held → not free; closed → bindable again (SO_REUSEADDR rebind).
+    assert (while_bound, after_close) == (False, True)
+
+
+# ---------------------------------------------------------------------------
+# poll_until — bounded wait with injected clock
+# ---------------------------------------------------------------------------
+def test_poll_until_true_when_predicate_flips_before_timeout() -> None:
+    # Arrange — predicate flips True on the 3rd call.
+    clock = _FakeClock()
+    calls = {"n": 0}
+
+    def predicate() -> bool:
+        calls["n"] += 1
+        return calls["n"] >= 3
+
+    # Act
+    ok = portmod.poll_until(
+        predicate, timeout_s=10.0, poll_s=0.2, sleep_fn=clock.sleep, now_fn=clock.now
+    )
+    # Assert
+    assert ok is True
+
+
+def test_poll_until_false_on_timeout() -> None:
+    # Arrange — predicate never holds; the fake clock advances past deadline.
+    clock = _FakeClock()
+    # Act
+    ok = portmod.poll_until(
+        lambda: False,
+        timeout_s=0.5,
+        poll_s=0.2,
+        sleep_fn=clock.sleep,
+        now_fn=clock.now,
+    )
+    # Assert
+    assert ok is False
+
+
+# ---------------------------------------------------------------------------
+# port_busy_error — the actionable fail-loud message
+# ---------------------------------------------------------------------------
+def test_port_busy_error_carries_port() -> None:
+    # Arrange
+    port = _free_port()
+    # Act
+    err = portmod.port_busy_error(_HOST, port, "figrecipe")
+    # Assert
+    assert err.port == port
+
+
+def test_port_busy_error_names_port_and_remediation() -> None:
+    # Arrange
+    port = _free_port()
+    # Act
+    msg = str(portmod.port_busy_error(_HOST, port, "figrecipe"))
+    # Assert — the operator gets the port + the exact one-liner remediation.
+    assert (
+        str(port) in msg
+        and f"fuser -k {port}/tcp" in msg
+        and "tmux kill-session -t tui-figrecipe" in msg
+        and "sac agents restart figrecipe" in msg
+    )
+
+
+# ---------------------------------------------------------------------------
+# ensure_port_free_or_raise — the pre-spawn gate
+# ---------------------------------------------------------------------------
+def test_ensure_port_free_or_raise_returns_when_free() -> None:
+    # Arrange — a free port; the gate must return quietly (no raise).
+    port = _free_port()
+    clock = _FakeClock()
+    # Act
+    portmod.ensure_port_free_or_raise(
+        host=_HOST,
+        port=port,
+        agent_name="figrecipe",
+        timeout_s=1.0,
+        sleep_fn=clock.sleep,
+        now_fn=clock.now,
+    )
+    # Assert — reaching here (no exception) is the observable success.
+    assert portmod.port_is_free(_HOST, port) is True
+
+
+def test_ensure_port_free_or_raise_fails_loud_when_held(listeners) -> None:
+    # Arrange — a REAL listener keeps the port bound for the whole wait.
+    port = _free_port()
+    listeners(port)
+    clock = _FakeClock()
+    # Act
+    # Assert
+    with pytest.raises(portmod.TurnBridgePortBusyError):
+        portmod.ensure_port_free_or_raise(
+            host=_HOST,
+            port=port,
+            agent_name="figrecipe",
+            timeout_s=0.5,
+            sleep_fn=clock.sleep,
+            now_fn=clock.now,
+        )
+
+
+# ---------------------------------------------------------------------------
+# await_bridge_release — SIGKILL escalation frees the port
+# ---------------------------------------------------------------------------
+def test_await_bridge_release_sigkills_overstaying_holder(listeners) -> None:
+    # Arrange — a REAL listener that never gives up the port on its own; the
+    # release wait must SIGKILL it after the grace and see the port freed.
+    # Real time here (not the fake clock) so the kernel gets real time to reap
+    # the SIGKILLed holder and close its socket — no race on the re-probe.
+    port = _free_port()
+    proc = listeners(port)
+    # Act
+    released = portmod.await_bridge_release(
+        proc.pid,
+        port,
+        host=_HOST,
+        grace_s=0.3,
+        sleep_fn=time.sleep,
+        now_fn=time.monotonic,
+    )
+    proc.wait(timeout=5)
+    # Assert — the holder was killed and the port is bindable again.
+    assert released is True and portmod.port_is_free(_HOST, port) is True
+
+
+def test_await_bridge_release_returns_true_when_already_free() -> None:
+    # Arrange — port already free + an already-dead pid; must return without
+    # signalling anything.
+    port = _free_port()
+    clock = _FakeClock()
+    # Act
+    released = portmod.await_bridge_release(
+        999_999,
+        port,
+        host=_HOST,
+        grace_s=0.4,
+        sleep_fn=clock.sleep,
+        now_fn=clock.now,
+    )
+    # Assert
+    assert released is True
+
+
+# ---------------------------------------------------------------------------
+# _pid_alive — liveness fallback
+# ---------------------------------------------------------------------------
+def test_pid_alive_true_for_self() -> None:
+    # Arrange
+    pid = os.getpid()
+    # Act
+    alive = portmod._pid_alive(pid)
+    # Assert
+    assert alive is True
+
+
+def test_pid_alive_false_for_reaped_pid() -> None:
+    # Arrange — a subprocess that has exited and been reaped.
+    proc = subprocess.Popen([sys.executable, "-c", "pass"])
+    proc.wait(timeout=5)
+    # Act
+    alive = portmod._pid_alive(proc.pid)
+    # Assert
+    assert alive is False


### PR DESCRIPTION
## Confirmed production incident

`sac agents restart <tui-agent>` stopped the agent but the new spawn failed with `post_ack_no_apptainer_pid` — the container never came up. The real crash was in the child, in `<runtime_dir>/tui-turn-bridge.log`:

```
OSError: [Errno 98] Address already in use
  File ".../runtimes/_tui_turn_bridge.py", ... in __init__
    super().__init__(server_address, _TurnBridgeHandler)
  ... self.socket.bind(self.server_address)
```

The **OLD** instance's TUI turn-bridge server was **still holding the agent's a2a/turn port** when the new instance booted, so the new bridge could not bind. This stranded agents live (scitex-todo). It is NOT a load problem.

## Root cause

`SO_REUSEADDR` (`_TurnBridgeServer.allow_reuse_address = True`, already present) only covers the `TIME_WAIT` fast-restart case — it does **not** let a bind steal a port from a still-**running** listener, which is what bit us (the old process was alive, not lingering).

`stop_turn_bridge` SIGTERMed the old bridge and **returned immediately**, so the port stayed held through the asynchronous `serve_forever` shutdown. `start_turn_bridge`'s own `stop_turn_bridge` call was then a no-op (pidfile already unlinked), and it spawned the new bridge straight into the `EADDRINUSE` bind crash.

## Fix — make the port release deterministic

New focused module `runtimes/_tui_turn_bridge_port.py` (extracted to keep `_tui_turn_bridge.py` under the line cap, mirroring the existing `_tui_bridge_seam` / `_tui_drain` extractions), wired into the lifecycle:

- **`stop_turn_bridge` now WAITS for the port to actually release.** After SIGTERM it polls a real `SO_REUSEADDR` bind probe (`port_is_free`) — the accurate signal, correct even for a not-yet-reaped zombie (which holds no socket) — and escalates **SIGTERM → SIGKILL** past a 5s grace for a bridge that ignores the term / hangs teardown.
- **`start_turn_bridge` polls the port bindable (bounded 10s) BEFORE spawning.** If it cannot be freed it **FAILS LOUD** — `TurnBridgePortBusyError` naming the port + holder PID(s) (via the existing `_port_holder` lsof/ss/fuser finder) + the exact remediation `fuser -k <port>/tcp; tmux kill-session -t tui-<name>; sac agents restart <name>` — instead of spawning a child into the crash (which is caught by the best-effort seam, so the container still comes up rather than stranding).
- **`build_server` re-raises a bind refusal as that same named error**, so if the bind still races at boot the log names the port + remediation instead of a bare `Errno 98`.

## Tests (real sockets / subprocesses, no mocks)

- `allow_reuse_address` is set + a real rebind after close succeeds
- `port_is_free` detects a real held listener and flips True after close
- `build_server` raises the named error against a real bound port
- `start_turn_bridge` fails loud (names port + remediation) against a real held port and never spawns
- `stop_turn_bridge` SIGTERMs a real listener subprocess and the port becomes bindable again
- `await_bridge_release` SIGKILL-escalates a real overstaying holder and frees the port

Full `tests/scitex_agent_container/runtimes/` suite: **1249 passed, 20 skipped**. The two turn-bridge test files pass 3×3 with no flakiness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
