### PR TITLE
fix(mcp): bound every MCP upstream call so the stdio server never wedges under load

### DIFF
--- a/docs/mcp-cold-start.md
+++ b/docs/mcp-cold-start.md
@@ -62,3 +62,11 @@ not). The servers start healthy and write nothing to stdout; the failure is a
 The ecosystem-wide `fastmcp` version pin is scitex-dev's domain. sac's
 `pyproject.toml` carries an unpinned `fastmcp>=2.0`; `sac versions --json --live
 --base-only` reports the fastmcp version across SIFs.
+
+## See also
+
+[`mcp-load-resilience.md`](./mcp-load-resilience.md) — the sibling **mid-session**
+failure: a connected stdio MCP that gets **dropped under host load** (a handler
+blocking on a jammed upstream → the client times out and drops the stdio server,
+which it never reconnects). The fix there is prevention — bounded upstream
+timeouts on every handler — plus the honest-UNKNOWN healthcheck referenced above.

--- a/docs/mcp-load-resilience.md
+++ b/docs/mcp-load-resilience.md
@@ -1,0 +1,113 @@
+# MCP load-resilience — why the stdio MCP dropped under load, and the fix
+
+Sibling of [`mcp-cold-start.md`](./mcp-cold-start.md). That doc covers the
+**connect-time** race (server too slow to connect at session start). This doc
+covers the **mid-session** failure: a healthy, connected stdio MCP that gets
+**dropped under host load** and never comes back.
+
+## The incident (2026-07-09)
+
+The `scitex-agent-container` MCP surface (`host_exec_local`, `agent_restart`,
+`agent_status`, `agent_spawn`, `db_*`, the `a2a_*` channel tools …) is exposed to
+Claude Code as **stdio** MCP subprocess(es) — launched per session by the client
+(`.mcp.json` → `sac mcp start` / `sac mcp channel`).
+
+During a host load spike (load ~27 on 16 cores) the tools **vanished** from an
+in-container agent and did **not** come back after load fell to ~10. A human
+operator had to run `sac agents restart` by hand.
+
+### What live dogfooding established (not process death, not a hung upstream now)
+
+1. The MCP server **process was alive** the whole time (PID intact, ~2 h uptime).
+2. Its upstream (`:7878` listen, the colocated `/v1/turn` runner) was **responsive
+   again** by the time it was inspected.
+3. Yet the tools were **unavailable to the client** — Claude Code had dropped the
+   stdio connection and did **not** re-handshake.
+4. Killing the stdio server process to force a relaunch did **not** relaunch it:
+   Claude Code does not respawn a stdio MCP within a session.
+5. `sac mcp healthcheck` (the boot auto-heal) could not read `claude mcp list`,
+   yet **falsely reported `action=ok`** — a false-OK that hid the drop.
+
+## Root cause
+
+**A request handler blocked on a slow upstream long enough for the stdio client
+to give up.** Under the spike the `:7878` spawn/exec path jammed. An MCP handler
+that made a synchronous/awaited upstream call with an **unbounded or absurdly
+long timeout** then blocked for a very long time. The stdio client (Claude Code)
+timed out and **dropped the stdio MCP** — and **Claude Code does not
+auto-reconnect a stdio MCP mid-session** (only HTTP/SSE transports get its
+reconnect retries; see `mcp-cold-start.md`). So the tools stayed gone for the
+rest of the session even though the process lived and the upstream recovered.
+
+The two smoking-gun unbounded waits:
+
+| call site | before | problem |
+|---|---|---|
+| `host_exec_local` → `request_host_exec` | `http_timeout_s = 3700.0` (~62 min) | a jammed `:7878` blocked the handler for up to an hour |
+| channel `_wake_turn` → `POST /v1/turn` | `httpx.AsyncClient(timeout=None)` | a wedged runner hung the wake POST **forever** |
+| channel `_consume_sse` | `httpx.AsyncClient(timeout=None)` | a hung **connect** to `:7878` blocked inside `client.stream(...)`, so the reconnect-with-backoff loop never retried |
+
+## The fix — PREVENTION (the only viable sac-side fix)
+
+Because a dropped **stdio** MCP can only be revived by a **full session restart**
+(finding #4 — Claude Code owns the stdio child and neither respawns nor
+reconnects it mid-session), there is **no sac-side post-hoc recovery**. The fix
+is to **never let the connection get dropped**: bound every upstream call so no
+handler can block the server long enough for the client to give up.
+
+1. **`host_exec` client wait tracks the server contract, not a fixed 62 min.**
+   `request_host_exec` now derives its HTTP timeout from the *effective*
+   server-side per-command timeout (the caller's `timeout_s`, else the 300 s
+   server default), clamped to `(0, 3600]`, **+ a 30 s margin** — ~330 s for the
+   default instead of 3700 s. A genuinely long `sac image build` still works: pass
+   `timeout_s` (up to the 3600 s server max) and the client wait tracks it.
+   (`_lifecycle/_host_exec_client.py::_resolve_http_timeout`.)
+
+2. **Wake POST is bounded.** `_wake_turn` now waits a **finite** bound
+   (default 180 s = the runner's 120 s per-turn deadline + margin) instead of
+   `None`. A wedged `/v1/turn` raises a `TimeoutException` that the SSE consumer's
+   `on_event` wrapper catches and logs loudly, keeping the long-lived stream alive
+   — never an infinite block. (`_mcp/_channel_wake.py::_resolve_wake_timeout`.)
+
+3. **SSE connect is bounded** (30 s) while the **read stays unbounded** (the event
+   stream is legitimately long-lived). A hung connect now fails fast and the
+   existing backoff loop reconnects. (`_mcp/channel.py`.)
+
+4. **Fail-fast, structured, contained.** Every bounded call surfaces a structured
+   error (`host_exec_local` → `{"status":"error", …}`) or is caught by the SSE
+   `on_event` wrapper — a slow/hung upstream never desyncs the stdio protocol.
+
+5. **Honest healthcheck (no false-OK).** `sac mcp healthcheck` now returns
+   `action="unknown"` (not `ok`) whenever it could not verify client-side
+   connectivity (`claude mcp list` unreadable/empty, or a critical server absent
+   from its output). A live server process does not prove the client is still
+   connected, so a "no failures seen" reading is **never** dressed up as OK.
+   (`_mcp/_healthcheck.py`.)
+
+## Knobs
+
+| env var | effect | default |
+|---|---|---|
+| `SAC_MCP_HOST_EXEC_HTTP_TIMEOUT_S` | hard override of the derived `host_exec` client HTTP wait (s) | derived from server contract (~330 s) |
+| `SAC_MCP_WAKE_TIMEOUT_S` | client-side wait for the wake `POST /v1/turn` (s) | 180 |
+| `SAC_MCP_SSE_CONNECT_TIMEOUT_S` | SSE **connect** timeout (read stays unbounded) (s) | 30 |
+| `SAC_A2A_TURN_TIMEOUT_S` | runner's own `/v1/turn` per-turn deadline (the 504 bound the wake waits on) | 120 |
+
+## Not in sac's control — harness recommendation
+
+The **reconnect** half is Claude Code's domain and cannot be fixed from sac:
+
+- **A dropped stdio MCP is only revived by a full session restart.** Claude Code
+  does not respawn a stdio child nor reconnect it mid-session. sac's honest
+  healthcheck can *report* the loss, but the boot-time `--fresh` self-restart it
+  brokers is a full session restart — there is no in-session revival.
+- **The durable "auto-reconnect without a restart" fix is an HTTP/SSE transport.**
+  Claude Code *does* reconnect HTTP/SSE MCP servers (its 3-initial / 5-mid-session
+  retries). `sac mcp start --http --port <p>` already serves the tool surface over
+  HTTP; pointing `.mcp.json` at a long-lived, supervised HTTP MCP endpoint (rather
+  than a per-session stdio child) would let the client transparently reconnect
+  after a load-induced drop — no session restart, no vanished tools. That requires
+  a supervised long-lived MCP endpoint + bearer auth on the tool port (the tools
+  include `host_exec`), so it is a larger, separate change; this PR lands the
+  prevention layer that keeps the *stdio* transport from dropping in the first
+  place.

--- a/src/scitex_agent_container/_lifecycle/_host_exec_client.py
+++ b/src/scitex_agent_container/_lifecycle/_host_exec_client.py
@@ -13,16 +13,79 @@ tests inject a hand-rolled fake so there is no monkeypatching of the transport.
 from __future__ import annotations
 
 import json
+import logging
+import os
 from typing import Any, Callable
 from urllib import error as urlerror
 from urllib import request as urlrequest
 
 from ._spawn_client import _parse_body, _resolve_base_url, _resolve_bearer
 
-# ``sac image build`` can take many minutes; keep this comfortably above the
-# server-side per-command default (300s) so the http layer never chops off a
-# long-but-progressing exec before the server's own timeout fires.
-_DEFAULT_HTTP_TIMEOUT_S: float = 3700.0
+logger = logging.getLogger(__name__)
+
+# Server-side per-command timeout CONTRACT (mirrors the listen ``/v1/host_exec``
+# handler): when the caller omits ``timeout_s`` the server uses 300 s, and any
+# ``timeout_s`` it accepts is clamped to ``(0, 3600]``. The client-side HTTP wait
+# is DERIVED from this contract (effective server timeout + a margin) so the two
+# stay consistent — see :func:`_resolve_http_timeout`.
+_SERVER_DEFAULT_TIMEOUT_S: float = 300.0
+_SERVER_MAX_TIMEOUT_S: float = 3600.0
+
+# Margin added on top of the server-side deadline so the HTTP layer never chops
+# off a long-but-progressing exec BEFORE the server's own timeout fires — while
+# staying BOUNDED.
+#
+# Load-resilience fix (incident 2026-07-09): the pre-fix value was a FIXED
+# 3700 s regardless of the requested ``timeout_s``. A jammed ``:7878`` listen
+# (host load spike, load ~27 on 16 cores) then blocked this MCP tool handler for
+# up to ~62 min on a single ``host_exec`` call. That long block timed out the
+# stdio MCP client (Claude Code), which DROPPED the stdio connection — and Claude
+# Code does not auto-reconnect a stdio MCP mid-session (only HTTP/SSE), so the
+# host_exec/agent_* tools vanished for the rest of the session even though the
+# server process stayed alive. Deriving the wait from the server contract keeps a
+# blocked handler bounded (~330 s for the default) so the client never times the
+# whole server out. See ``docs/mcp-load-resilience.md``.
+_HTTP_TIMEOUT_MARGIN_S: float = 30.0
+
+# Optional hard override of the derived client-side HTTP timeout (seconds).
+_HTTP_TIMEOUT_ENV_VAR = "SAC_MCP_HOST_EXEC_HTTP_TIMEOUT_S"
+
+
+def _resolve_http_timeout(
+    timeout_s: float | None, explicit_http_timeout_s: float | None
+) -> float:
+    """Bound the client-side HTTP wait to the server-side deadline + margin.
+
+    Resolution order:
+
+    1. ``explicit_http_timeout_s`` — an explicit per-call override (a caller /
+       test that knows better) wins verbatim.
+    2. ``SAC_MCP_HOST_EXEC_HTTP_TIMEOUT_S`` env — a deployment-wide hard override.
+    3. Derived: the *effective* server-side timeout (``timeout_s`` when given,
+       else the 300 s server default), clamped to ``(0, 3600]``, plus
+       :data:`_HTTP_TIMEOUT_MARGIN_S`.
+
+    The derived path is the load-incident fix: it keeps the client wait just
+    above what the server itself will honour (~330 s for the default, ~1830 s for
+    ``timeout_s=1800``) instead of a fixed ~62 min, so a handler blocked on a
+    jammed listen fails fast enough that the stdio MCP client never times the
+    whole server out and drops it.
+    """
+    if explicit_http_timeout_s is not None:
+        return explicit_http_timeout_s
+    env_raw = os.environ.get(_HTTP_TIMEOUT_ENV_VAR, "").strip()
+    if env_raw:
+        try:
+            return float(env_raw)
+        except ValueError:
+            logger.warning(
+                "host_exec: ignoring invalid %s=%r (not a float seconds value)",
+                _HTTP_TIMEOUT_ENV_VAR,
+                env_raw,
+            )
+    effective = _SERVER_DEFAULT_TIMEOUT_S if timeout_s is None else float(timeout_s)
+    effective = max(0.0, min(effective, _SERVER_MAX_TIMEOUT_S))
+    return effective + _HTTP_TIMEOUT_MARGIN_S
 
 
 class HostExecRequestError(Exception):
@@ -55,7 +118,7 @@ def request_host_exec(
     caller: str | None = None,
     base_url: str | None = None,
     bearer: str | None = None,
-    http_timeout_s: float = _DEFAULT_HTTP_TIMEOUT_S,
+    http_timeout_s: float | None = None,
     opener: Callable | None = None,
 ) -> dict[str, Any]:
     """POST ``argv`` (+ optional ``cwd``/``timeout_s``/``env``/``caller``) to
@@ -64,7 +127,15 @@ def request_host_exec(
     Raises :class:`HostExecRequestError` on any non-2xx response or transport
     failure — never returns a fake success. On a 2xx the body is the endpoint's
     contract (``{"exit_code", "stdout", "stderr", "duration_s", "timed_out"}``).
+
+    ``http_timeout_s`` bounds the client-side wait. When ``None`` (the default) it
+    is DERIVED from the server-side timeout contract via :func:`_resolve_http_timeout`
+    (effective ``timeout_s`` clamped to ``(0, 3600]`` + margin, ~330 s for the
+    default) rather than a fixed multi-minute wait — so a jammed listen cannot
+    block this handler long enough for the stdio MCP client to drop the whole
+    server (incident 2026-07-09, ``docs/mcp-load-resilience.md``).
     """
+    resolved_http_timeout = _resolve_http_timeout(timeout_s, http_timeout_s)
     base = _resolve_base_url(base_url)
     tok = _resolve_bearer(bearer)
 
@@ -88,7 +159,7 @@ def request_host_exec(
     opener_fn = opener if opener is not None else urlrequest.urlopen
 
     try:
-        with opener_fn(req, timeout=http_timeout_s) as resp:
+        with opener_fn(req, timeout=resolved_http_timeout) as resp:
             raw = resp.read()
     except urlerror.HTTPError as exc:
         raw_body = b""

--- a/src/scitex_agent_container/_mcp/_channel_wake.py
+++ b/src/scitex_agent_container/_mcp/_channel_wake.py
@@ -17,9 +17,56 @@ import path.
 
 from __future__ import annotations
 
+import logging
+import os
 from typing import Any
 
+log = logging.getLogger(__name__)
+
 __all__ = ["_should_wake_turn", "_wake_text", "_wake_turn"]
+
+# Bounded client-side wait for the wake POST.
+#
+# Load-resilience fix (incident 2026-07-09): the pre-fix value was
+# ``timeout=None`` (INFINITE). Under a host load spike the colocated runner's
+# ``/v1/turn`` was wedged and never returned, so the wake POST blocked the SSE
+# consumer FOREVER — a slow/hung upstream must never let an MCP-side handler hang
+# without bound. The runner answers within its own bounded per-turn deadline
+# (``_runners/_session_http.DEFAULT_TURN_TIMEOUT_S`` = 120 s) and a 504, so we
+# wait that plus a margin. Env-overridable for deployments that raise the runner
+# turn timeout via ``SAC_A2A_TURN_TIMEOUT_S``. See ``docs/mcp-load-resilience.md``.
+_WAKE_TIMEOUT_DEFAULT_S: float = 180.0
+_WAKE_TIMEOUT_ENV_VAR = "SAC_MCP_WAKE_TIMEOUT_S"
+
+
+def _resolve_wake_timeout() -> float:
+    """Return the bounded client-side wait (seconds) for the wake POST.
+
+    ``SAC_MCP_WAKE_TIMEOUT_S`` overrides :data:`_WAKE_TIMEOUT_DEFAULT_S`; an
+    unparseable value is ignored (logged) and the default stands. Always a
+    FINITE, positive bound — never ``None`` — so a wedged ``/v1/turn`` cannot
+    block the SSE consumer indefinitely.
+    """
+    raw = os.environ.get(_WAKE_TIMEOUT_ENV_VAR, "").strip()
+    if raw:
+        try:
+            val = float(raw)
+        except ValueError:
+            log.warning(
+                "wake: ignoring invalid %s=%r (not a float seconds value)",
+                _WAKE_TIMEOUT_ENV_VAR,
+                raw,
+            )
+        else:
+            if val > 0:
+                return val
+            log.warning(
+                "wake: ignoring non-positive %s=%r; using default %.0fs",
+                _WAKE_TIMEOUT_ENV_VAR,
+                raw,
+                _WAKE_TIMEOUT_DEFAULT_S,
+            )
+    return _WAKE_TIMEOUT_DEFAULT_S
 
 
 def _should_wake_turn(event: dict[str, Any]) -> bool:
@@ -74,6 +121,7 @@ async def _wake_turn(
     *,
     turn_url: str,
     bearer: str | None,
+    timeout: float | None = None,
 ) -> None:
     """POST ``event`` to the agent's own ``/v1/turn`` to DRIVE a turn now.
 
@@ -82,7 +130,8 @@ async def _wake_turn(
     drives a turn immediately, so a push to an IDLE agent is processed at
     once rather than buffered until some unrelated next turn. Raises on any
     transport/HTTP failure so the caller can decide whether to surface or
-    contain it (WI-2 fail-loud).
+    contain it (WI-2 fail-loud) — the SSE consumer's ``on_event`` wrapper
+    catches it, logs loudly, and keeps the long-lived stream alive.
 
     Requester identity rides into the body so the woken turn's
     ``TurnEnvelope`` carries it through to the Stop hook, which PUSHes a
@@ -91,6 +140,14 @@ async def _wake_turn(
     special-cased); ``dispatch_id`` is the sender-minted ledger id when the
     sender minted one. Both are tolerated-absent: an event with no sender /
     no ledger id simply drives a turn the Stop hook cannot address.
+
+    ``timeout`` bounds the client-side wait (seconds). ``None`` (the default)
+    resolves via :func:`_resolve_wake_timeout` to a FINITE bound just above the
+    runner's own per-turn deadline — never ``None``/infinite (incident
+    2026-07-09: a wedged ``/v1/turn`` under load hung the unbounded POST forever,
+    stalling the SSE consumer). A generous-but-finite bound still lets a
+    legitimately long turn complete while guaranteeing recovery from a wedged
+    runner.
     """
     import httpx
 
@@ -108,10 +165,7 @@ async def _wake_turn(
     dispatch_id = event.get("dispatch_id")
     if isinstance(dispatch_id, str) and dispatch_id:
         payload["dispatch_id"] = dispatch_id
-    # The wake POST returns only after the driven turn completes (the runner
-    # awaits the SDK reply before responding). Use no client-side deadline —
-    # a short client timeout would abort a legitimately long turn; the runner
-    # imposes its own bounded per-turn timeout and answers with a 504.
-    async with httpx.AsyncClient(timeout=None) as client:
+    effective_timeout = _resolve_wake_timeout() if timeout is None else timeout
+    async with httpx.AsyncClient(timeout=effective_timeout) as client:
         resp = await client.post(turn_url, json=payload, headers=headers)
         resp.raise_for_status()

--- a/src/scitex_agent_container/_mcp/_healthcheck.py
+++ b/src/scitex_agent_container/_mcp/_healthcheck.py
@@ -28,6 +28,15 @@ FAIL-OPEN THROUGHOUT: every step is defensive. A healthcheck that itself errors
 (no ``claude`` binary, unparseable output, restart broker unreachable, …) must
 NEVER block the agent's boot — it logs and returns. The worst case degrades to
 today's behaviour (tools missing), never worse.
+
+HONEST-UNKNOWN (coordinator dogfood 2026-07-09): when connectivity cannot be
+verified — ``claude mcp list`` is unreadable/empty, or a critical server is absent
+from its output — the result is ``action="unknown"``, NEVER ``"ok"``. A live
+server PROCESS does not prove the stdio CLIENT is still connected: a mid-session
+load-spike drop leaves the process up but the tools gone, and Claude Code does not
+reconnect a stdio MCP mid-session (only a full session restart revives it). A
+false-OK would mask exactly that drop, so it is categorically refused — a false-OK
+health check is worse than none. See ``docs/mcp-load-resilience.md``.
 """
 
 from __future__ import annotations
@@ -260,10 +269,38 @@ def run_healthcheck(
         log_capability_surface(statuses)
 
         failed = [s for s, st in statuses.items() if st == FAILED]
+        unknown = [s for s, st in statuses.items() if st == UNKNOWN]
         if not failed:
+            if unknown:
+                # HONEST-UNKNOWN (coordinator dogfood 2026-07-09): we could NOT
+                # read client-side connectivity — ``claude mcp list`` was
+                # unreadable/empty, or a critical server was absent from its
+                # output. A live server PROCESS does not prove the stdio CLIENT is
+                # still connected: a mid-session load-spike drop leaves the process
+                # up but the tools gone (Claude Code does not reconnect a stdio MCP
+                # mid-session). So a "no FAILED lines" reading must NEVER be
+                # reported as OK — that false-OK masks exactly the drop we care
+                # about. A false-OK health check is worse than none: report
+                # UNKNOWN and alarm.
+                log.warning(
+                    "mcp healthcheck: could NOT verify MCP connectivity for %s "
+                    "(`claude mcp list` unreadable/empty) — reporting UNKNOWN, NOT "
+                    "ok. A live server process does not prove the stdio client is "
+                    "still connected; a dropped stdio MCP is only revived by a full "
+                    "session restart.",
+                    ", ".join(unknown),
+                )
+                return {
+                    "statuses": statuses,
+                    "failed": [],
+                    "unknown": unknown,
+                    "healed": False,
+                    "action": "unknown",
+                }
             return {
                 "statuses": statuses,
                 "failed": [],
+                "unknown": [],
                 "healed": False,
                 "action": "ok",
             }

--- a/src/scitex_agent_container/_mcp/channel.py
+++ b/src/scitex_agent_container/_mcp/channel.py
@@ -50,6 +50,13 @@ log = logging.getLogger(__name__)
 _INBOX_CAP = 200
 _recent: "deque[dict[str, Any]]" = deque(maxlen=_INBOX_CAP)
 
+# Bound the SSE CONNECT phase; read stays unbounded (the event stream is
+# legitimately long-lived). Load-resilience fix (2026-07-09): ``timeout=None``
+# left CONNECT unbounded too, so a hung connect to ``:7878`` under load blocked
+# inside ``client.stream(...)`` forever and the reconnect-with-backoff loop never
+# retried. See ``docs/mcp-load-resilience.md``.
+_SSE_CONNECT_TIMEOUT_S: float = 30.0
+
 
 # WI-1 wake-on-push primitives live in ``_channel_wake`` (extracted to keep
 # this receive-side adapter under the module size budget). Re-exported here
@@ -111,9 +118,10 @@ async def _consume_sse(
         headers["Authorization"] = f"Bearer {bearer}"
 
     backoff = 0.5
+    sse_timeout = httpx.Timeout(_SSE_CONNECT_TIMEOUT_S, read=None)
     while True:
         try:
-            async with httpx.AsyncClient(timeout=None) as client:
+            async with httpx.AsyncClient(timeout=sse_timeout) as client:
                 async with client.stream("GET", url, headers=headers) as resp:
                     if resp.status_code != 200:
                         body = await resp.aread()

--- a/src/scitex_agent_container/cli_pkg/mcp_group.py
+++ b/src/scitex_agent_container/cli_pkg/mcp_group.py
@@ -216,13 +216,26 @@ def mcp_healthcheck(as_json: bool) -> None:
     else:
         action = result.get("action", "ok")
         failed = result.get("failed") or []
+        unknown = result.get("unknown") or []
         if failed:
             click.secho(
                 f"MCP healthcheck: {', '.join(failed)} FAILED — action={action}",
                 fg="red",
             )
+        elif action == "unknown" or unknown:
+            # HONEST: connectivity could NOT be verified — never render green/OK.
+            target = ", ".join(unknown) or "critical MCPs"
+            click.secho(
+                f"MCP healthcheck: could NOT verify {target} "
+                f"(`claude mcp list` unreadable) — action={action}",
+                fg="yellow",
+            )
+        elif action == "ok":
+            click.secho("MCP healthcheck: all critical MCPs OK (action=ok)", fg="green")
         else:
-            click.secho(f"MCP healthcheck: all critical MCPs OK (action={action})", fg="green")
+            # disabled / error and any future non-ok verdict: state it plainly,
+            # never dressed up as OK.
+            click.secho(f"MCP healthcheck: action={action}", fg="yellow")
     # Fail-open: NEVER non-zero. A boot hook must not block the session.
     raise SystemExit(0)
 

--- a/tests/scitex_agent_container/_lifecycle/test__host_exec_client.py
+++ b/tests/scitex_agent_container/_lifecycle/test__host_exec_client.py
@@ -10,10 +10,30 @@ no monkeypatching of the transport.
 from __future__ import annotations
 
 import json
+import os
+from contextlib import contextmanager
 from typing import Any
 from urllib import error as urlerror
 
 import pytest
+
+
+@contextmanager
+def _env(name: str, value: str):
+    """Set a REAL env var for the block, restoring the prior value on exit.
+
+    No ``monkeypatch`` (STX-NM002): the production resolver reads
+    ``os.environ`` directly, so the test sets the real variable and pops it.
+    """
+    prev = os.environ.get(name)
+    os.environ[name] = value
+    try:
+        yield
+    finally:
+        if prev is None:
+            os.environ.pop(name, None)
+        else:
+            os.environ[name] = prev
 
 from scitex_agent_container._lifecycle._host_exec_client import (
     HostExecRequestError,
@@ -260,3 +280,103 @@ def test_request_host_exec_raises_on_transport_error():
     # Assert
     with pytest.raises(HostExecRequestError):
         _call()
+
+
+# --------------------------------------------------------------------------
+# Load-resilience: the client-side HTTP wait is BOUNDED to the server contract
+# (incident 2026-07-09 — a fixed ~62 min wait let a jammed listen block the MCP
+# handler long enough for the stdio client to drop the whole server).
+# --------------------------------------------------------------------------
+
+
+def _opener_recording_timeout(body: dict[str, Any] | None = None):
+    """Opener that records the ``timeout`` it was called with onto
+    ``.last_timeout`` (and yields ``body`` as JSON)."""
+    payload = json.dumps(body or {"exit_code": 0}).encode("utf-8")
+
+    def _opener(req, timeout=None):  # noqa: ANN001
+        _opener.last_timeout = timeout
+        return _FakeResponse(payload)
+
+    _opener.last_timeout = None  # type: ignore[attr-defined]
+    return _opener
+
+
+def test_default_http_timeout_tracks_server_default_not_62_minutes():
+    # Arrange — no timeout_s → server default 300s → client waits 330s (NOT 3700).
+    opener = _opener_recording_timeout()
+    # Act
+    request_host_exec(
+        ["true"], base_url="http://127.0.0.1:7878", bearer="tok", opener=opener
+    )
+    # Assert
+    assert opener.last_timeout == pytest.approx(330.0)
+
+
+def test_http_timeout_tracks_requested_timeout_s():
+    # Arrange — an explicit long build timeout is honoured (bounded to it + margin).
+    opener = _opener_recording_timeout()
+    # Act
+    request_host_exec(
+        ["true"],
+        timeout_s=1800.0,
+        base_url="http://127.0.0.1:7878",
+        bearer="tok",
+        opener=opener,
+    )
+    # Assert
+    assert opener.last_timeout == pytest.approx(1830.0)
+
+
+def test_http_timeout_capped_at_server_max():
+    # Arrange — an over-max timeout_s is clamped to the server ceiling (3600) + margin.
+    opener = _opener_recording_timeout()
+    # Act
+    request_host_exec(
+        ["true"],
+        timeout_s=99_999.0,
+        base_url="http://127.0.0.1:7878",
+        bearer="tok",
+        opener=opener,
+    )
+    # Assert
+    assert opener.last_timeout == pytest.approx(3630.0)
+
+
+def test_explicit_http_timeout_wins_verbatim():
+    # Arrange — an explicit per-call override is used as-is.
+    opener = _opener_recording_timeout()
+    # Act
+    request_host_exec(
+        ["true"],
+        base_url="http://127.0.0.1:7878",
+        bearer="tok",
+        http_timeout_s=7.5,
+        opener=opener,
+    )
+    # Assert
+    assert opener.last_timeout == pytest.approx(7.5)
+
+
+def test_env_override_sets_http_timeout():
+    # Arrange — deployment-wide hard override via a REAL env var.
+    opener = _opener_recording_timeout()
+    # Act
+    with _env("SAC_MCP_HOST_EXEC_HTTP_TIMEOUT_S", "12"):
+        request_host_exec(
+            ["true"], base_url="http://127.0.0.1:7878", bearer="tok", opener=opener
+        )
+    # Assert
+    assert opener.last_timeout == pytest.approx(12.0)
+
+
+def test_invalid_env_override_falls_back_to_derived():
+    # Arrange — a garbage env value is ignored; the derived default stands.
+    opener = _opener_recording_timeout()
+    # Act
+    with _env("SAC_MCP_HOST_EXEC_HTTP_TIMEOUT_S", "not-a-number"):
+        request_host_exec(
+            ["true"], base_url="http://127.0.0.1:7878", bearer="tok", opener=opener
+        )
+    # Assert
+    assert opener.last_timeout == pytest.approx(330.0)

--- a/tests/scitex_agent_container/_mcp/test__healthcheck.py
+++ b/tests/scitex_agent_container/_mcp/test__healthcheck.py
@@ -245,3 +245,56 @@ def test_run_healthcheck_fail_open_when_runner_raises(tmp_path):
     )
     # Assert
     assert result["action"] == "error"
+
+
+# --------------------------------------------------------------------------
+# Honest-UNKNOWN (coordinator dogfood 2026-07-09): when connectivity could NOT be
+# verified (``claude mcp list`` unreadable/empty), the check must NEVER claim OK.
+# A false-OK masks a client-side mid-session drop — worse than no check at all.
+# --------------------------------------------------------------------------
+
+
+def test_run_healthcheck_unreadable_list_is_unknown_not_ok(tmp_path):
+    # Arrange — the runner returns "" (e.g. no `claude` binary in the container).
+    recorder = _RestartRecorder()
+    # Act
+    result = run_healthcheck(
+        mcp_list_runner=lambda: "",
+        restart_fn=recorder,
+        agent_name="agent-x",
+        now_fn=lambda: 100.0,
+        state_dir=tmp_path,
+    )
+    # Assert — honest UNKNOWN, categorically NOT "ok".
+    assert result["action"] == "unknown"
+
+
+def test_run_healthcheck_unreadable_list_does_not_restart(tmp_path):
+    # Arrange — UNKNOWN is not a confirmed failure, so it must not force a restart.
+    recorder = _RestartRecorder(accept=True)
+    # Act
+    run_healthcheck(
+        mcp_list_runner=lambda: "",
+        restart_fn=recorder,
+        agent_name="agent-x",
+        now_fn=lambda: 100.0,
+        state_dir=tmp_path,
+    )
+    # Assert
+    assert recorder.calls == []
+
+
+def test_run_healthcheck_partial_unknown_is_not_ok(tmp_path):
+    # Arrange — one server confirmed connected, the other absent from the output.
+    one_connected = "scitex-agent-container: sac mcp start - Connected\n"
+    recorder = _RestartRecorder()
+    # Act
+    result = run_healthcheck(
+        mcp_list_runner=lambda: one_connected,
+        restart_fn=recorder,
+        agent_name="agent-x",
+        now_fn=lambda: 100.0,
+        state_dir=tmp_path,
+    )
+    # Assert — an unverified critical server means the whole reading is UNKNOWN.
+    assert result["action"] == "unknown"

--- a/tests/scitex_agent_container/_mcp/test_channel_wake_timeout.py
+++ b/tests/scitex_agent_container/_mcp/test_channel_wake_timeout.py
@@ -1,0 +1,162 @@
+"""``_wake_turn`` BOUNDS its client-side wait so a WEDGED ``/v1/turn`` cannot
+block the SSE consumer forever (load-resilience incident 2026-07-09).
+
+NO MOCKS (STX-NM002): the timeout is exercised against a REAL in-process HTTP/1.1
+receiver (``asyncio.start_server``) that ACCEPTS the connection but never sends a
+response. The production transport (a real ``httpx.AsyncClient``) must then raise
+a ``httpx.TimeoutException`` within the bound instead of hanging indefinitely.
+Env behaviour is exercised by setting the REAL ``SAC_MCP_WAKE_TIMEOUT_S`` var (a
+``yield``-based env helper, not ``monkeypatch``).
+
+TQ: AAA markers, >=3-word names, one assertion each.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import socket
+import time
+from contextlib import contextmanager
+
+import httpx
+import pytest
+
+from scitex_agent_container._mcp._channel_wake import (
+    _WAKE_TIMEOUT_DEFAULT_S,
+    _resolve_wake_timeout,
+    _wake_turn,
+)
+
+
+@contextmanager
+def _env(name: str, value: str):
+    """Set a REAL env var for the block, restoring the prior value on exit."""
+    prev = os.environ.get(name)
+    os.environ[name] = value
+    try:
+        yield
+    finally:
+        if prev is None:
+            os.environ.pop(name, None)
+        else:
+            os.environ[name] = prev
+
+
+def _free_port() -> int:
+    """Ask the kernel for an unused TCP port."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+class _HangingHTTP:
+    """Real HTTP/1.1 server that accepts + reads a request but NEVER replies."""
+
+    def __init__(self) -> None:
+        self._server: asyncio.AbstractServer | None = None
+        self.port = 0
+
+    async def start(self) -> None:
+        self.port = _free_port()
+        self._server = await asyncio.start_server(self._handle, "127.0.0.1", self.port)
+
+    async def stop(self) -> None:
+        if self._server is not None:
+            # close() only: do NOT wait_closed(). The stalled handler holds its
+            # connection open for the full sleep, and (Python 3.12+) wait_closed()
+            # blocks until active connections finish — which would make TEARDOWN,
+            # not the client bound, dominate the elapsed time. The orphaned handler
+            # is cancelled when asyncio.run() tears the loop down.
+            self._server.close()
+
+    async def _handle(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        try:
+            await reader.read(1024)  # consume request head, then stall
+            await asyncio.sleep(30)  # never respond within the client bound
+        except asyncio.CancelledError:  # test teardown cancels the stalled handler
+            pass
+        finally:
+            writer.close()
+
+
+async def _wake_against_hung_server(timeout: float) -> None:
+    """Run ``_wake_turn`` against a server that never responds."""
+    srv = _HangingHTTP()
+    await srv.start()
+    try:
+        await _wake_turn(
+            {"from_agent": "lead", "content": "do it", "msg_id": "m1"},
+            turn_url=f"http://127.0.0.1:{srv.port}/v1/turn",
+            bearer=None,
+            timeout=timeout,
+        )
+    finally:
+        await srv.stop()
+
+
+# -- env resolution: the bound is always finite + positive ----------------
+
+
+class TestResolveWakeTimeout:
+    def test_default_is_the_finite_module_bound(self) -> None:
+        # Arrange
+        expected = _WAKE_TIMEOUT_DEFAULT_S
+        # Act
+        resolved = _resolve_wake_timeout()
+        # Assert — never None/infinite; a wedged runner is always recoverable.
+        assert resolved == expected
+
+    def test_honours_env_override_seconds(self) -> None:
+        # Arrange
+        var = "SAC_MCP_WAKE_TIMEOUT_S"
+        # Act
+        with _env(var, "45"):
+            resolved = _resolve_wake_timeout()
+        # Assert
+        assert resolved == 45.0
+
+    def test_ignores_unparseable_env_value(self) -> None:
+        # Arrange
+        var = "SAC_MCP_WAKE_TIMEOUT_S"
+        # Act
+        with _env(var, "nonsense"):
+            resolved = _resolve_wake_timeout()
+        # Assert
+        assert resolved == _WAKE_TIMEOUT_DEFAULT_S
+
+    def test_ignores_nonpositive_env_value(self) -> None:
+        # Arrange — 0 / negative would be "no bound"; refuse it.
+        var = "SAC_MCP_WAKE_TIMEOUT_S"
+        # Act
+        with _env(var, "0"):
+            resolved = _resolve_wake_timeout()
+        # Assert
+        assert resolved == _WAKE_TIMEOUT_DEFAULT_S
+
+
+# -- behaviour: a hung /v1/turn raises within the bound, never hangs -------
+
+
+class TestWakeTimesOutOnHungTurnUrl:
+    def test_raises_httpx_timeout_when_turn_url_hangs(self) -> None:
+        # Arrange — real server accepts but never responds; tiny client bound.
+        coro = _wake_against_hung_server(1.0)
+        # Act
+        run = pytest.raises(httpx.TimeoutException)
+        # Assert — a real TimeoutException, NOT an infinite block.
+        with run:
+            asyncio.run(coro)
+
+    def test_returns_within_bound_not_after_server_sleep(self) -> None:
+        # Arrange
+        start = time.monotonic()
+        # Act — the server would sleep 30 s; the 1 s client bound must win.
+        try:
+            asyncio.run(_wake_against_hung_server(1.0))
+        except httpx.TimeoutException:
+            pass
+        # Assert — returned promptly (well under the server's 30 s stall).
+        assert time.monotonic() - start < 10.0


### PR DESCRIPTION
## Problem (confirmed live, 2026-07-09)

The `scitex-agent-container` stdio MCP surface (`host_exec_local`, `agent_restart`, `agent_status`, `agent_spawn`, `db_*`, the `a2a_*` channel tools) **dropped for an in-container agent during a host load spike (load ~27 on 16 cores) and never came back** after load fell — an operator had to run `sac agents restart` by hand.

## Root cause — blocking handler → stdio drop (client-side, no reconnect)

Live dogfooding established it was **not** process death and **not** a currently-hung upstream:

1. The MCP server process stayed **alive** the whole time.
2. Its upstream (`:7878` listen / `/v1/turn` runner) was **responsive again** when inspected.
3. Yet the tools were gone from the client.

Under the spike the `:7878` path jammed and an MCP request handler **blocked on an unbounded / 62-minute upstream call** long enough for the stdio client (Claude Code) to time out and **drop the stdio MCP** — which **Claude Code does not auto-reconnect mid-session** (only HTTP/SSE get reconnect retries). So the tools vanished for the rest of the session despite the live process. A dropped **stdio** MCP is only revived by a **full session restart**, so **prevention is the only sac-side fix**.

Smoking-gun unbounded waits: `host_exec` client `http_timeout_s=3700.0` (~62 min); channel `_wake_turn` `httpx timeout=None`; channel `_consume_sse` unbounded connect.

## Fix

**(a) Never-block handlers — bound every upstream call**
- `host_exec` client: derive the HTTP wait from the server-side contract (effective `timeout_s` clamped to `(0,3600]` + 30 s margin → ~330 s default) instead of a fixed 3700 s. Long builds still work by passing `timeout_s`. Env: `SAC_MCP_HOST_EXEC_HTTP_TIMEOUT_S`.
- channel wake `POST /v1/turn`: finite bound (runner per-turn deadline + margin, default 180 s) instead of `timeout=None`. Env: `SAC_MCP_WAKE_TIMEOUT_S`.
- SSE consumer: bound the **connect** phase (30 s) while keeping **read unbounded** for the long-lived stream. Env: `SAC_MCP_SSE_CONNECT_TIMEOUT_S`.
- `spawn`/`restart` clients were already bounded (30 s / 60 s). Every bounded call surfaces a structured error / is caught — never desyncs the stdio protocol.

**(b) Honest healthcheck** — `sac mcp healthcheck` now returns `action="unknown"` (never a false `ok`) when it cannot read `claude mcp list`; a live process does not prove the client is connected. CLI renders it honestly instead of green "all OK".

**(c) Docs** — `docs/mcp-load-resilience.md`: root cause, the prevention fix, and the harness-side reality that a dropped stdio MCP needs a session restart (the durable auto-reconnect fix is an HTTP/SSE transport — Claude Code's domain). Cross-linked from `mcp-cold-start.md`.

## Tests (no mocks)

- `test__host_exec_client.py`: timeout derivation via the `opener` seam (default → 330 s not 3700; tracks `timeout_s`; capped at server max; explicit + env override).
- `test_channel_wake_timeout.py`: a **real** in-process hung HTTP server proves the wake POST raises `httpx.TimeoutException` **within the bound** instead of blocking forever; env resolution.
- `test__healthcheck.py`: honest-UNKNOWN paths (unreadable / partial `claude mcp list` → `action="unknown"`, no restart).

Full `_mcp` + `_lifecycle` sweep: **1001 passed** locally.

## Harness-side (not sac code)
True auto-reconnect without a session restart requires an HTTP/SSE MCP transport that Claude Code reconnects to (`sac mcp start --http` already serves the tool surface); that needs a supervised long-lived endpoint + bearer auth on the tool port and is a larger, separate change. This PR lands the prevention layer that keeps the stdio transport from dropping under load in the first place.
