### PR TITLE
ci: migrate to scitex-ai/.github reusable workflows

### DIFF
--- a/.github/workflows/auto-merge-to-develop.yaml
+++ b/.github/workflows/auto-merge-to-develop.yaml
@@ -4,6 +4,13 @@ name: auto-merge-to-develop
 # so this file lives on main but acts ONLY on PRs whose base is develop.
 # codecov + readthedocs checks are ignored (advisory). Fail-safe: if a merge
 # is blocked by branch policy the PR simply stays open.
+#
+# Reusable-workflow migration (2026-07-10 incident remediation, piloted at
+# scitex-ai/scitex-stats#69): the job body below is a byte-for-byte mechanical
+# extraction, now centrally maintained at scitex-ai/.github instead of
+# fleet-synced-by-copy. `on:` / `permissions:` are unchanged. This file MUST
+# stay on the repo's default branch (main) — GitHub only reads check_suite
+# triggers from there — only the job body moved to `uses:`.
 on:
   check_suite:
     types: [completed]
@@ -14,36 +21,8 @@ permissions:
   pull-requests: write
 
 jobs:
-  automerge:
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.check_suite.conclusion == 'success' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: merge green PRs targeting develop
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          HEAD_SHA: ${{ github.event.check_suite.head_sha }}
-        run: |
-          set -uo pipefail
-          if [ -n "${HEAD_SHA:-}" ]; then
-            prs=$(gh api "repos/$REPO/commits/$HEAD_SHA/pulls" --jq '.[] | select(.state=="open") | .number' 2>/dev/null || true)
-          else
-            prs=$(gh pr list --repo "$REPO" --base develop --state open --json number --jq '.[].number' 2>/dev/null || true)
-          fi
-          [ -z "${prs:-}" ] && { echo "no open PRs"; exit 0; }
-          for pr in $prs; do
-            base=$(gh pr view "$pr" --repo "$REPO" --json baseRefName --jq .baseRefName 2>/dev/null || echo "")
-            [ "$base" = "develop" ] || { echo "skip #$pr (base=$base, not develop)"; continue; }
-            draft=$(gh pr view "$pr" --repo "$REPO" --json isDraft --jq .isDraft 2>/dev/null || echo true)
-            [ "$draft" = "true" ] && continue
-            pending=$(gh pr view "$pr" --repo "$REPO" --json statusCheckRollup --jq '
-              [ .statusCheckRollup[]
-                | select(((.name // .context // "") | ascii_downcase | test("codecov|readthedocs")) | not)
-                | (.conclusion // .state // "")
-                | select(. != "SUCCESS" and . != "NEUTRAL" and . != "SKIPPED" and . != "") ] | length' 2>/dev/null || echo 1)
-            if [ "$pending" = "0" ]; then
-              gh pr merge "$pr" --repo "$REPO" --merge --admin --delete-branch && echo "MERGED #$pr -> develop" || echo "blocked #$pr"
-            else
-              echo "PR #$pr not green ($pending) — skip"
-            fi
-          done
+  call:
+    # New required-status-check context (if ever added to protection):
+    # "call / automerge"
+    uses: scitex-ai/.github/.github/workflows/auto-merge-to-develop.yml@main
+    secrets: inherit


### PR DESCRIPTION
## What

Slice of the fleet-wide CI-content-drift remediation (operator-approved, 2026-07-10 incident; pattern piloted at `scitex-ai/scitex-stats#69`). Converts local CI job bodies into thin `workflow_call` stubs against reusable workflows hosted at `scitex-ai/.github@main`, where they clearly match the generic pattern with no repo-specific behavior lost.

## Converted

- **`auto-merge-to-develop.yaml`** (`automerge` job → `call`): body is byte-identical to the generic reusable `auto-merge-to-develop.yml` (confirmed against its actual content), so this is a pure mechanical extraction. `on:`/`permissions:` preserved verbatim. The file **stays on the default branch (`main`)** per GitHub's check_suite-workflow-must-live-on-default-branch requirement — this PR only changes the job body; a human still needs to promote `develop`→`main` per this repo's existing workflow for the change to take effect.

## Left alone (repo diverges materially from the generic reusable workflow — converting would silently drop behavior)

- **`pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml`** (`tests` job): runs on `ubuntu-latest` (not the reusable workflow's `self-hosted spartan-cpu`), and has three repo-specific steps the generic `pytest-matrix.yml` doesn't support: `fd-find` apt install (required by the mandatory `test_audit.py` gate), Anthropic-credentials provisioning (needed for creds-gated tests to actually run instead of skip), and a template-validity smoke pre-step.
- **`import-smoke-on-ubuntu-py3-12.yml`** (`install-check` job): runs on `ubuntu-latest` (not self-hosted), and has an extra CLI entry-point smoke step (`sac --version`) the generic `import-smoke.yml` doesn't include.
- **`quality-audit-on-ubuntu-latest.yml`** (`audit` job): uses a completely different tool surface (`scitex-dev quality audit-cli/audit-frontmatter/audit-docs/audit-lines/audit-scope`, all `continue-on-error` / warn-only, weekly cadence) vs. the generic `quality-audit.yml`'s single hard-fail `scitex-dev ecosystem audit-all`. Not the same check at all.
- **`rtd-sphinx-build-on-ubuntu-latest.yml`** (`sphinx` job): builds AND commits the generated HTML back into `src/scitex_agent_container/_sphinx_html/` on push to the default branch — a repo-specific publish step entirely absent from the generic `rtd-sphinx-build.yml` (which only builds as a check). Converting would silently drop the self-publish step.
- **`cla.yml`**: this repo's `CLAssistant` job reads `secrets.SCITEX_AGENT_CONTAINER_GH_PERSONAL_ACCESS_TOKEN` (PS-168 §1 prefixed-secret convention), while the generic reusable `cla.yml` hardcodes the unprefixed `secrets.GH_PERSONAL_ACCESS_TOKEN` with no input to override the secret name. `secrets: inherit` does not rename secrets, so converting would leave the reusable workflow reading an unset secret — breaking the CLA-signature PAT for non-owner-allowlisted (external) contributors. Confirmed the fleet-reference (`scitex-stats`) does NOT use a prefixed secret name, so this is a real repo-specific divergence, not an oversight in the reusable workflow.
- **`lint.yml`, `live-haiku-api-integration-on-ubuntu-latest.yml`, `newb-docs-quality-on-ubuntu-latest.yml`, `sdk-runtime-smoke-on-ubuntu-latest.yml`**: none of these correspond to any of the 6 reusable-workflow families (ruff lint, manual Haiku e2e, weekly newb docs-quality, disabled sdk-smoke) — nothing to migrate.
- **`pypi-publish-and-github-release-on-tag.yml`**: PyPI OIDC trusted-publishing pipeline — untouched per task instructions (trusted publishing is not supported inside `workflow_call`).

## Branch protection

`develop` and `main` both currently require only `pytest-matrix-on-ubuntu-py3.11/.12/.13` as status checks. Since the `pytest-matrix` job was deliberately left unconverted (see above), **no branch-protection update was needed or made**. `automerge` was never a required check.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open(...))"` — passes for the one changed file.
- Diff is job-body-only; `on:`/`permissions:` blocks are byte-identical to the pre-migration file.

## Pre-existing CI status (not touched by this PR)

Not independently investigated beyond the branch-protection check above — no unrelated CI failures were observed while making this change.

Do not merge — left for review per task instructions.
