### PR TITLE
fix(mcp): channel meta.source is the fixed sac identity, not the raw sender

### DIFF
--- a/src/scitex_agent_container/_mcp/channel.py
+++ b/src/scitex_agent_container/_mcp/channel.py
@@ -50,6 +50,13 @@ log = logging.getLogger(__name__)
 _INBOX_CAP = 200
 _recent: "deque[dict[str, Any]]" = deque(maxlen=_INBOX_CAP)
 
+# Operator directive (2026-07-09): rendered <channel source="..."> must be
+# the fixed SYSTEM identity ("sac"), not a raw agent name -- matches cct's
+# source="cct" / scitex-todo's source="stodo". Sender identity moves to a
+# separate from_agent meta key. Env-overridable (SAC_MCP_* convention, #591).
+_CHANNEL_SOURCE_ENV_VAR = "SAC_MCP_CHANNEL_SOURCE"
+_CHANNEL_SOURCE_DEFAULT = "sac"
+
 # Bound the SSE CONNECT phase; read stays unbounded (the event stream is
 # legitimately long-lived). Load-resilience fix (2026-07-09): ``timeout=None``
 # left CONNECT unbounded too, so a hung connect to ``:7878`` under load blocked
@@ -180,7 +187,12 @@ def _meta_str(value: Any) -> str:
 
 def _build_notification(event: dict[str, Any]) -> dict[str, Any]:
     """Project a bus event onto the Claude Code channel notification
-    shape: ``{content, meta: {source, chat_id, ts, ...}}``.
+    shape: ``{content, meta: {source, from_agent, chat_id, ts, ...}}``.
+
+    ``meta.source`` is the fixed system identity ("sac", overridable via
+    :data:`_CHANNEL_SOURCE_ENV_VAR`) — the sender's own identity lives in
+    ``meta.from_agent`` instead, so the two never collide in the rendered
+    ``<channel source="..." from_agent="..." ...>`` tag.
 
     Every ``meta`` value is stringified via :func:`_meta_str` — the
     client schema rejects non-string values (see that helper).
@@ -193,8 +205,10 @@ def _build_notification(event: dict[str, Any]) -> dict[str, Any]:
     """
     from .._state.state_db_channel import format_ts_iso
 
+    source = os.environ.get(_CHANNEL_SOURCE_ENV_VAR, "").strip() or _CHANNEL_SOURCE_DEFAULT
     meta: dict[str, Any] = {
-        "source": _meta_str(event.get("from_agent", "unknown")),
+        "source": source,
+        "from_agent": _meta_str(event.get("from_agent", "unknown")),
         "ts": format_ts_iso(event.get("ts", "")),
         "msg_id": _meta_str(event.get("msg_id", "")),
     }

--- a/tests/scitex_agent_container/_mcp/test_channel.py
+++ b/tests/scitex_agent_container/_mcp/test_channel.py
@@ -211,22 +211,59 @@ def test_build_notification_missing_content_defaults_to_empty_string():
     assert notif["content"] == ""
 
 
-def test_build_notification_source_carries_from_agent():
-    # Arrange
+def test_build_notification_source_is_the_fixed_system_identity():
+    # Arrange — source must be "sac" regardless of who sent the message
+    # (operator directive 2026-07-09: source names the adapter, not the
+    # sender; matches cct's source="cct" / scitex-todo's source="stodo").
     event = {"from_agent": "bob", "content": "x"}
     # Act
     meta = _build_notification(event)["meta"]
     # Assert
-    assert meta["source"] == "bob"
+    assert meta["source"] == "sac"
 
 
-def test_build_notification_missing_from_agent_marks_unknown_source():
+def test_build_notification_source_ignores_missing_from_agent():
+    # Arrange
+    event = {"content": "x"}
+    # Act
+    meta = _build_notification(event)["meta"]
+    # Assert — source is fixed; a missing sender does not change it.
+    assert meta["source"] == "sac"
+
+
+def test_build_notification_from_agent_carries_the_sender():
+    # Arrange
+    event = {"from_agent": "bob", "content": "x"}
+    # Act
+    meta = _build_notification(event)["meta"]
+    # Assert — the sender's own identity moved here, not into source.
+    assert meta["from_agent"] == "bob"
+
+
+def test_build_notification_missing_from_agent_marks_unknown():
     # Arrange
     event = {"content": "x"}
     # Act
     meta = _build_notification(event)["meta"]
     # Assert
-    assert meta["source"] == "unknown"
+    assert meta["from_agent"] == "unknown"
+
+
+def test_build_notification_source_honours_env_override():
+    # Arrange
+    event = {"from_agent": "bob", "content": "x"}
+    saved = os.environ.get("SAC_MCP_CHANNEL_SOURCE")
+    os.environ["SAC_MCP_CHANNEL_SOURCE"] = "custom-label"
+    try:
+        # Act
+        meta = _build_notification(event)["meta"]
+    finally:
+        if saved is None:
+            os.environ.pop("SAC_MCP_CHANNEL_SOURCE", None)
+        else:
+            os.environ["SAC_MCP_CHANNEL_SOURCE"] = saved
+    # Assert
+    assert meta["source"] == "custom-label"
 
 
 def test_build_notification_carries_msg_id():

--- a/tests/smoke/test_node_comms_e2e_mcp.py
+++ b/tests/smoke/test_node_comms_e2e_mcp.py
@@ -160,8 +160,14 @@ def test_a2a_send_tool_same_group_delivers_and_projects_notification(comms_env):
     with _run_loopback(app, port):
         event = asyncio.run(driver())
     notif = _build_notification(event)
-    # Assert — delivered content survives, and the projection names the sender.
-    assert notif["content"] == "hello via mcp" and notif["meta"]["source"] == "alpha"
+    # Assert — delivered content survives; source is the fixed system
+    # identity, from_agent names the real sender (operator directive
+    # 2026-07-09 — source must never leak a raw agent name).
+    assert (
+        notif["content"] == "hello via mcp"
+        and notif["meta"]["source"] == "sac"
+        and notif["meta"]["from_agent"] == "alpha"
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `_build_notification` set `meta["source"] = event["from_agent"]`, so every a2a notification rendered as `<channel source="<raw-agent-name>" ...>` in the receiving session -- indistinguishable from that agent's own output, and colliding with whatever else labels the tag with the delivering MCP server's own identity (the confusing duplicate `source="sac" source="<agent>"` visible fleet-wide all session).
- Operator directive (2026-07-09): `source` must be the fixed SYSTEM identity, matching claude-code-telegrammer's `source="cct"` and scitex-todo's `source="stodo"` -- sac was the only package leaking a raw sender name.
- Fix: `source` is now a fixed `"sac"` (env-overridable via `SAC_MCP_CHANNEL_SOURCE`, matching the `SAC_MCP_*` convention from #591); the sender's identity moves to a new `from_agent` meta key so it renders as its own tag attribute instead of colliding with `source`.

Handoff: scitex-todo (2026-07-09), while closing its fleet-load incident.

## Test plan
- [x] `tests/scitex_agent_container/_mcp/test_channel.py` (extended) -- source is fixed regardless of sender, from_agent carries the real sender, missing-sender still marks from_agent unknown, env override works.
- [x] `tests/smoke/test_node_comms_e2e_mcp.py` (updated) -- real end-to-end a2a_send delivery asserts both the fixed source and the correct from_agent.
- [x] 74/74 passed locally; ruff (F401/F811) clean.
- [x] Swept both `src/` and `tests/` for any other consumer of the old `meta["source"] == from_agent` semantics -- none found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)