### PR TITLE
fix(lifecycle): persist start-failure pane tail to disk before raising

### DIFF
--- a/src/scitex_agent_container/_lifecycle/_start.py
+++ b/src/scitex_agent_container/_lifecycle/_start.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import threading
 import time
 import traceback
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Optional
 
@@ -419,6 +420,19 @@ def agent_start(
                 f" (tmux session_exists={TmuxManager.exists(_sess)})\n"
                 f"{_format_boot_stderr_section(_boot_log)}"
                 f"  pane tail:\n{_pane or '<empty>'}"
+            )
+            # Persist so this evidence outlives the tmux session. A
+            # false-negative start leaves no registry row (raised below,
+            # before registry.add()), so killing the session by hand is
+            # often the only way to stop the agent -- which destroys the
+            # live pane capture forever unless it's written to disk now.
+            # boot.stderr.log already survives pane death (see
+            # _format_boot_stderr_section); the pane tail did not until
+            # this. See sac-agent-start-false-negative-tui-registry-row.
+            _diag_log = state_dir_for_config(config) / "start_failure_diag.log"
+            _diag_log.write_text(
+                f"{datetime.now(timezone.utc).isoformat()} start failed for "
+                f"{config.name!r}: runtime.start() returned False.{diag}\n"
             )
         except Exception:  # stx-allow: fallback (reason: diagnostics must never mask the real start failure — degrade to no pane)
             diag = " (no pane diagnostics available)"

--- a/tests/scitex_agent_container/_lifecycle/test_lifecycle.py
+++ b/tests/scitex_agent_container/_lifecycle/test_lifecycle.py
@@ -29,7 +29,7 @@ import pytest
 
 from scitex_agent_container._lifecycle import lifecycle as lc
 from scitex_agent_container._state.registry import Registry
-from scitex_agent_container.config import AgentConfig
+from scitex_agent_container.config import AgentConfig, load_config
 
 # ---------------------------------------------------------------------------
 # Fixtures — real env, real Registry, real YAML on disk
@@ -820,9 +820,7 @@ def test_agent_start_runtime_failure_raises_runtime_error(
         call()
 
 
-def _start_with_failing_runtime(
-    spec: Path, registry: Registry, config: AgentConfig
-) -> None:
+def _start_with_failing_runtime(spec: Path, registry: Registry) -> None:
     """Drive a real ``agent_start`` failure, swallowing the expected
     ``RuntimeError`` -- the raise itself is covered by
     ``test_agent_start_runtime_failure_raises_runtime_error``; these
@@ -851,9 +849,9 @@ def test_agent_start_runtime_failure_persists_diag_file(
     from scitex_agent_container.runtimes.tui_session import state_dir_for_config
 
     spec = _write_spec(tmp_path)
-    config = lc.load_config(str(spec))
+    config = load_config(str(spec))
     # Act
-    _start_with_failing_runtime(spec, registry, config)
+    _start_with_failing_runtime(spec, registry)
     # Assert
     assert (state_dir_for_config(config) / "start_failure_diag.log").is_file()
 
@@ -865,9 +863,9 @@ def test_agent_start_runtime_failure_diag_names_the_reason(
     from scitex_agent_container.runtimes.tui_session import state_dir_for_config
 
     spec = _write_spec(tmp_path)
-    config = lc.load_config(str(spec))
+    config = load_config(str(spec))
     # Act
-    _start_with_failing_runtime(spec, registry, config)
+    _start_with_failing_runtime(spec, registry)
     # Assert
     diag_log = state_dir_for_config(config) / "start_failure_diag.log"
     assert "runtime.start() returned False" in diag_log.read_text()

--- a/tests/scitex_agent_container/_lifecycle/test_lifecycle.py
+++ b/tests/scitex_agent_container/_lifecycle/test_lifecycle.py
@@ -820,6 +820,59 @@ def test_agent_start_runtime_failure_raises_runtime_error(
         call()
 
 
+def _start_with_failing_runtime(
+    spec: Path, registry: Registry, config: AgentConfig
+) -> None:
+    """Drive a real ``agent_start`` failure, swallowing the expected
+    ``RuntimeError`` -- the raise itself is covered by
+    ``test_agent_start_runtime_failure_raises_runtime_error``; these
+    helpers only care about what got written to disk before it fired."""
+    runtime = FakeRuntime(running=False, start_result=False)
+    try:
+        lc.agent_start(
+            str(spec),
+            registry=registry,
+            runtime_factory=lambda _c: runtime,
+            handover_mod=FakeHandover(),
+            sleep_fn=_no_sleep,
+        )
+    except RuntimeError:
+        pass
+
+
+def test_agent_start_runtime_failure_persists_diag_file(
+    tmp_path: Path, registry: Registry
+) -> None:
+    # Arrange -- a false-negative start whose only evidence must survive
+    # past the raised exception (sac-agent-start-false-negative-tui-
+    # registry-row-20260710): killing the tmux session is often the only
+    # way to stop an agent with no registry row, which destroys a
+    # not-yet-persisted pane capture forever.
+    from scitex_agent_container.runtimes.tui_session import state_dir_for_config
+
+    spec = _write_spec(tmp_path)
+    config = lc.load_config(str(spec))
+    # Act
+    _start_with_failing_runtime(spec, registry, config)
+    # Assert
+    assert (state_dir_for_config(config) / "start_failure_diag.log").is_file()
+
+
+def test_agent_start_runtime_failure_diag_names_the_reason(
+    tmp_path: Path, registry: Registry
+) -> None:
+    # Arrange
+    from scitex_agent_container.runtimes.tui_session import state_dir_for_config
+
+    spec = _write_spec(tmp_path)
+    config = lc.load_config(str(spec))
+    # Act
+    _start_with_failing_runtime(spec, registry, config)
+    # Assert
+    diag_log = state_dir_for_config(config) / "start_failure_diag.log"
+    assert "runtime.start() returned False" in diag_log.read_text()
+
+
 def test_agent_start_dry_run_does_not_register(
     tmp_path: Path, registry: Registry
 ) -> None:


### PR DESCRIPTION
## Summary
- A false-negative `agent_start` (`runtime.start()` returns False even though the tmux session is genuinely alive) raises before `registry.add()`/`_record_local_instance()` ever run, so the agent gets no usable registry row. Killing the tmux session by hand is then often the only way to stop it -- which destroys the live pane capture forever, since it previously only ever lived in the raised exception's message text.
- `boot.stderr.log` already survives pane death (dedicated redirect); the pane tail did not. This adds `start_failure_diag.log` (same state dir) so the full diagnostic -- tmux session_exists, boot stderr section, and pane tail -- is persisted before the exception is raised.

## Motivation
Reported by paper-scitex-clew on card `sac-agent-start-false-negative-tui-registry-row-20260710`: the clew-a-004 incident's diagnostic evidence (2026-07-09) is unrecoverable because of exactly this gap, blocking root-cause work on a separate, harder bug (`tui_session.py::start_succeeded()`'s `reached_ready=False` branch). This PR only fixes the evidence-preservation gap; the underlying probe logic is tracked separately and intentionally not touched here (it has a documented false-success/false-negative history and deserves its own careful pass).

## Test plan
- [x] Two new single-assertion tests (STX-TQ007): file gets written, file names the failure reason.
- [x] Existing `test_agent_start_runtime_failure_raises_runtime_error` still passes unchanged.
- [x] ruff clean (`--select F401,F811`).
- [ ] Full local suite run was still in progress at push time (very slow un-parallelized locally); CI's pytest-matrix is the actual gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)