### PR TITLE
feat(config,runtimes): land ProviderConfig + ProviderSession Protocol foundation

### DIFF
--- a/src/scitex_agent_container/_runners/_provider_session.py
+++ b/src/scitex_agent_container/_runners/_provider_session.py
@@ -1,0 +1,211 @@
+"""Provider-agnostic session Protocol + normalized event/message shapes.
+
+Foundation for the ``openai`` agent SDK family (scitex-todo card
+``openai-compat-1``, "Land ProviderConfig + ProviderSession Protocol").
+This module defines the SHAPES a future ``openai-agents``-backed session
+(openai-compat-2) will produce and consume, so that both the existing
+``claude-agent-sdk`` path and the future OpenAI path can eventually be
+driven through one uniform turn-loop.
+
+Landed foundation-only: nothing in the live runner (``_runners/
+claude_session.py`` → ``_session_conversation.py`` → ``_session_turn.py``)
+imports or calls anything in this module yet. It is pure, additive,
+unused-by-default code — behaviourally a no-op for existing Claude
+agents. openai-compat-2 will add a concrete ``OpenAISession`` class that
+satisfies :class:`ProviderSession`, wrapping ``openai-agents``'
+``Runner.run_streamed()``. A concrete Claude-side implementation MAY be
+added later as a retrofit of ``_drive_turn`` (see "Composition with
+RuntimeBase" below) — that retrofit is explicitly NOT part of this phase,
+to keep the no-op guarantee airtight (zero live call sites touched).
+
+Shape rationale (informed by both SDKs' REAL vocabularies, not guessed)
+------------------------------------------------------------------------
+``claude-agent-sdk`` (installed in this repo — see ``runtimes/
+_sdk_common.py`` and ``_runners/_session_turn.py::_drive_turn``) streams
+``AssistantMessage`` (content blocks: ``TextBlock`` / ``ThinkingBlock`` /
+``ToolUseBlock`` / ``ToolResultBlock``), ``UserMessage`` (echo),
+``ResultMessage`` (terminal — carries ``session_id`` + ``usage``), and
+background-subagent lifecycle messages (``TaskStartedMessage`` /
+``TaskProgressMessage`` / ``TaskNotificationMessage``). The ``openai-
+agents`` SDK's ``Runner.run_streamed()`` streams an analogous mix of raw
+deltas and semantic "run items" (message / tool-call / tool-call-output /
+reasoning / handoff), then exposes a terminal aggregate (``final_output``
+et al.) once the stream is exhausted. :class:`NormalizedEvent` models the
+shared shape both vocabularies reduce to; :class:`RunResult` is the
+terminal aggregate, carried on the LAST event of ``kind="result"`` (both
+SDKs already stream their terminal info as part of the same sequence —
+this mirrors that, needing no second method on the Protocol).
+
+Composition with RuntimeBase
+-----------------------------
+:class:`ProviderSession` is deliberately NOT a subtype of, or a
+replacement for, :class:`runtimes.base.RuntimeBase`. They operate at
+different layers of the stack:
+
+* ``RuntimeBase`` (``ClaudeSessionRuntime`` / ``TuiSessionRuntime``) is
+  PROCESS lifecycle — ``start`` / ``stop`` / ``is_running`` / ``logs`` for
+  one whole agent's container, driven from the HOST/CLI side
+  (``sac agents start <name>``).
+* ``ProviderSession`` is CONVERSATION lifecycle — one provider SDK
+  connection's turn-taking, driven INSIDE the running container by the
+  runner (today: ``_session_conversation.py`` opening one
+  ``ClaudeSDKClient`` and calling ``_drive_turn`` per inbound message).
+
+They compose VERTICALLY, not by inheritance: a future runner selects a
+``ProviderSession`` implementation based on ``AgentConfig.provider``
+(``config._provider_types.AgentProvider`` — see the naming-collision
+note there against the unrelated ``ClaudeSpec.provider``) and drives it
+from inside the process that ``RuntimeBase.start()`` launched. Reusing
+``ProviderSession`` for both providers (rather than only using it as an
+OpenAI-side implementation detail) is what keeps ``openai-compat-2``
+from having to reinvent the turn-loop contract.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, AsyncIterator, Literal, Protocol, runtime_checkable
+
+__all__ = [
+    "ToolSpec",
+    "Message",
+    "NormalizedEvent",
+    "RunResult",
+    "ProviderSession",
+]
+
+# Chat-message role vocabulary — the intersection both SDKs accept
+# (Claude: UserMessage/AssistantMessage content-block roles; OpenAI:
+# chat-style role field on TResponseInputItem). "tool" carries a
+# tool-result being fed back to the model (Message.tool_call_id set).
+MessageRole = Literal["system", "user", "assistant", "tool"]
+
+# NormalizedEvent discriminator. See the module docstring's "Shape
+# rationale" for how each kind maps onto both SDKs' native vocabularies.
+EventKind = Literal[
+    "text_delta",  # streaming assistant text chunk
+    "reasoning",  # thinking/reasoning content (ThinkingBlock / reasoning_item)
+    "tool_call",  # the model requested a tool invocation
+    "tool_result",  # a tool's output being fed back into the conversation
+    "task",  # background subagent / task lifecycle notification
+    "error",  # a fatal or recoverable error surfaced mid-stream
+    "result",  # terminal event; NormalizedEvent.result is populated
+]
+
+
+@dataclass(frozen=True)
+class ToolSpec:
+    """A tool definition, provider-agnostic.
+
+    Maps onto ``claude-agent-sdk``'s MCP tool registration
+    (``create_sdk_mcp_server`` / ``SdkMcpTool``: name, description, a JSON
+    Schema for inputs, and a handler) and onto ``openai-agents``'
+    ``FunctionTool`` (name, description, ``params_json_schema``,
+    ``on_invoke_tool``) closely enough that openai-compat-2's
+    ``ToolSpec -> FunctionTool`` conversion (per its scitex-todo card) is
+    a near-direct field mapping.
+    """
+
+    name: str
+    description: str = ""
+    # JSON Schema (``{"type": "object", "properties": {...}, ...}``) for
+    # the tool's input. Kept as a plain dict (not a nested dataclass) so
+    # any tool author can hand it the schema shape their MCP server /
+    # framework already produces without an extra conversion step.
+    parameters: dict[str, Any] = field(default_factory=dict)
+    # Optional local callable — undefined (``None``) for tools that are
+    # ALWAYS invoked through an external MCP server rather than in-process.
+    handler: Any = None
+
+
+@dataclass(frozen=True)
+class Message:
+    """One chat-history entry, provider-agnostic.
+
+    ``tool_call_id`` is set only on ``role="tool"`` messages (the result
+    being fed back for a specific prior tool call); ``name`` is set only
+    when the message originates from a named tool/subagent.
+    """
+
+    role: MessageRole
+    content: str
+    name: str | None = None
+    tool_call_id: str | None = None
+
+
+@dataclass(frozen=True)
+class RunResult:
+    """Terminal aggregate for one completed turn.
+
+    Mirrors what both SDKs already surface once a turn's stream is
+    exhausted: Claude's ``ResultMessage`` (``session_id`` + ``usage``)
+    and ``openai-agents``' ``RunResultStreaming`` (``final_output`` +
+    usage on ``raw_responses``). Carried on the terminal
+    ``NormalizedEvent`` (``kind="result"``) rather than returned via a
+    separate Protocol method — see the module docstring.
+    """
+
+    text: str = ""
+    session_id: str | None = None
+    usage: dict[str, Any] = field(default_factory=dict)
+    stop_reason: str = ""
+
+
+@dataclass(frozen=True)
+class NormalizedEvent:
+    """One provider-agnostic event in a session's turn stream.
+
+    ``kind`` discriminates which fields are meaningful (see
+    :data:`EventKind`); unused fields keep their default. ``raw`` is an
+    escape hatch — the provider-native object, kept for debugging /
+    forward-compat — and is NEVER required for correct handling of a
+    known ``kind``.
+    """
+
+    kind: EventKind
+    text: str = ""
+    tool_name: str = ""
+    tool_input: dict[str, Any] = field(default_factory=dict)
+    tool_output: Any = None
+    error: str = ""
+    result: RunResult | None = None
+    raw: Any = None
+
+
+@runtime_checkable
+class ProviderSession(Protocol):
+    """Provider-agnostic conversational session.
+
+    Wraps a single provider SDK's client/session object with a uniform
+    surface: one :meth:`start`, N :meth:`send` turns (each an async
+    stream of :class:`NormalizedEvent`, terminating in a ``kind="result"``
+    event carrying a :class:`RunResult`), then :meth:`close`. Mirrors the
+    ``ClaudeSDKClient`` open → ``query``/``receive_response`` (repeated
+    per turn) → close lifecycle already in production use (see
+    ``_runners/_session_conversation.py`` / ``_session_turn.py``), so a
+    future runner can drive EITHER provider through the same loop shape.
+
+    Concrete implementations are NOT required in this phase (foundation
+    only — see the module docstring). openai-compat-2 lands the first
+    concrete implementation, wrapping ``openai-agents``'
+    ``Runner.run_streamed()``.
+    """
+
+    async def start(self) -> None:
+        """Open the underlying provider connection (auth + client init)."""
+        ...
+
+    def send(self, message: Message) -> AsyncIterator[NormalizedEvent]:
+        """Send one turn; the caller iterates the yielded events.
+
+        Implementations are async generators. The last event of a
+        completed turn has ``kind="result"`` with :attr:`NormalizedEvent.result`
+        populated; a turn that errors yields a ``kind="error"`` event
+        instead (implementations MAY still raise for unrecoverable
+        failures — callers should treat both as turn-ending).
+        """
+        ...
+
+    async def close(self) -> None:
+        """Tear down the underlying provider connection."""
+        ...

--- a/src/scitex_agent_container/config/_loaders.py
+++ b/src/scitex_agent_container/config/_loaders.py
@@ -352,6 +352,10 @@ def load_v3(raw: dict, path: Path) -> AgentConfig:
     return AgentConfig(
         name=name,
         runtime=str(spec.get("runtime") or "tui"),
+        # Agent SDK family (top-level; NOT spec.claude.provider — see the
+        # naming-collision note in config._provider_types.AgentProvider).
+        # Default mirrors the dataclass default; openai-compat-1 foundation.
+        provider=str(spec.get("provider") or "anthropic"),
         # spec.access REMOVED 2026-06-23 — host access + cwd are declared
         # explicitly via apptainer.binds + spec.workdir (SSoT). A spec still
         # carrying `access:` is rejected loud in _validation.validate_raw.

--- a/src/scitex_agent_container/config/_parsers/_claude.py
+++ b/src/scitex_agent_container/config/_parsers/_claude.py
@@ -10,6 +10,16 @@ from .._types import ClaudeSpec
 def _parse_provider(raw: dict) -> ProviderSpec | None:
     """Parse ``spec.claude.provider`` into a ``ProviderSpec`` or ``None``.
 
+    NAMING COLLISION NOTE (openai-compat-1): this is the NESTED
+    ``spec.claude.provider`` — a vendor-agnostic Anthropic-COMPATIBLE
+    backend override (DeepSeek, Mimo/Xiaomi, ...) that still runs the
+    Claude Agent SDK. It is unrelated to the TOP-LEVEL ``spec.provider``
+    (``AgentConfig.provider`` / ``config._provider_types.AgentProvider``),
+    which selects WHICH agent SDK family (``anthropic`` vs ``openai``)
+    backs the session at all. The top-level field is parsed directly in
+    ``_loaders.load_v3`` (mirroring ``spec.runtime``), NOT here — this
+    function's scope stays exactly ``spec.claude.provider``.
+
     Accepts two shapes (back-compat — see ADR-0011 extension):
 
     * **string** (new shape, operator directive 2026-05-28 msg 6783):

--- a/src/scitex_agent_container/config/_provider_registry.py
+++ b/src/scitex_agent_container/config/_provider_registry.py
@@ -77,4 +77,41 @@ def list_providers() -> list[str]:
     return sorted(PROVIDERS)
 
 
-__all__ = ["PROVIDERS", "resolve_provider", "list_providers"]
+# ---------------------------------------------------------------------------
+# Agent SDK family registry — spec.provider (TOP-LEVEL; openai-compat-1
+# foundation)
+# ---------------------------------------------------------------------------
+#
+# Deliberately a SEPARATE, flat constant from :data:`PROVIDERS` above:
+# ``PROVIDERS`` resolves a vendor BACKEND (base_url + auth_token_env) that
+# the Claude Agent SDK talks to; :data:`AGENT_SDK_PROVIDERS` is the closed
+# set of AGENT SDK FAMILIES sac knows how to run a session through at all
+# (see the naming-collision note in ``config._provider_types.AgentProvider``
+# for why these are two different axes sharing an unfortunately similar
+# name). Landed foundation-only — ``"openai"`` validates but has no runner
+# implementation until openai-compat-2.
+AGENT_SDK_PROVIDERS: tuple[str, ...] = ("anthropic", "openai")
+
+
+def is_known_agent_provider(name: str) -> bool:
+    """True when ``name`` is a recognized ``spec.provider`` SDK family."""
+    return name in AGENT_SDK_PROVIDERS
+
+
+def list_agent_providers() -> list[str]:
+    """Return the recognized ``spec.provider`` SDK families, sorted.
+
+    Used by the spec validator's "unknown provider" error message —
+    mirrors :func:`list_providers` for the (distinct) vendor-backend axis.
+    """
+    return sorted(AGENT_SDK_PROVIDERS)
+
+
+__all__ = [
+    "PROVIDERS",
+    "resolve_provider",
+    "list_providers",
+    "AGENT_SDK_PROVIDERS",
+    "is_known_agent_provider",
+    "list_agent_providers",
+]

--- a/src/scitex_agent_container/config/_provider_types.py
+++ b/src/scitex_agent_container/config/_provider_types.py
@@ -4,11 +4,50 @@ Lives in its own module to keep ``_types.py`` under the project's
 512-line cap (mirrors ``_proxy_types.py``). Re-exported from
 :mod:`scitex_agent_container.config` alongside the rest of the spec
 dataclasses.
+
+Also home to :data:`AgentProvider` (``spec.provider``, TOP-LEVEL) — see
+the naming-collision note below before touching either symbol.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import Literal
+
+# ---------------------------------------------------------------------------
+# Agent SDK family selector — spec.provider (TOP-LEVEL; openai-compat-1
+# foundation, scitex-todo card)
+# ---------------------------------------------------------------------------
+#
+# NAMING COLLISION WARNING: this module ALSO defines :class:`ProviderSpec`
+# below, for the pre-existing ``spec.claude.provider`` (nested) — a vendor-
+# agnostic ANTHROPIC-COMPATIBLE backend override (DeepSeek, Mimo/Xiaomi, a
+# self-hosted gateway, ...). That field still runs the SAME
+# ``claude-agent-sdk``, just pointed at a different ``base_url`` via an API
+# key instead of Anthropic OAuth (see ``_provider_registry.PROVIDERS`` /
+# ``runtimes/_apptainer_provider.py``).
+#
+# :data:`AgentProvider` is a DIFFERENT axis entirely: ``spec.provider``
+# (top-level, sibling of ``spec.runtime`` — see ``config._types.AgentConfig``)
+# selects WHICH AGENT SDK / tool-calling framework backs the session at all —
+# ``anthropic`` (``claude-agent-sdk``, talking to Anthropic OR an Anthropic-
+# compatible gateway) vs ``openai`` (the ``openai-agents`` SDK, talking to
+# OpenAI's Agents/Responses API). The two axes COMPOSE, they don't collide in
+# practice — e.g. ``provider: anthropic`` (top-level, default) +
+# ``claude.provider: mimo`` (nested) runs the Claude Agent SDK against
+# Xiaomi's Anthropic-compatible endpoint. Do not conflate the two fields when
+# reading/writing either one.
+#
+# Landed foundation-only: the schema + dataclass field exist and validate,
+# but nothing branches on ``AgentConfig.provider`` yet — selecting
+# ``"openai"`` today only affects `sac agents explain` / config introspection.
+# openai-compat-2 lands the concrete ``openai`` runner (see
+# ``_runners/_provider_session.py`` for the ``ProviderSession`` Protocol it
+# will implement); openai-compat-3 wires the selection into the apptainer
+# entrypoint + container image.
+AgentProvider = Literal["anthropic", "openai"]
+
+DEFAULT_AGENT_PROVIDER: AgentProvider = "anthropic"
 
 
 @dataclass

--- a/src/scitex_agent_container/config/_types.py
+++ b/src/scitex_agent_container/config/_types.py
@@ -9,7 +9,7 @@ from typing import Any, Dict
 # Phase-3 ACL dataclasses (kept in a sibling module under the per-file
 # line cap; re-exported here for the :class:`AgentConfig` field defaults).
 from ._acl_types import CommsSpec, LineageSpec  # noqa: E402,F401
-from ._provider_types import ProviderSpec
+from ._provider_types import AgentProvider, DEFAULT_AGENT_PROVIDER, ProviderSpec
 
 # ApptainerSpec extracted to a sibling module (per-file line cap);
 # re-exported here so ``from ...config._types import ApptainerSpec`` resolves.
@@ -366,6 +366,13 @@ class AgentConfig:
     # TUI — operator directive 2026-06-15). ``"claude-agent-sdk"`` =
     # headless SDK runner; legacy ``"apptainer"`` maps to the SDK runner.
     runtime: str = "tui"
+    # Agent SDK family selector (top-level, sibling of ``runtime`` — NOT
+    # the same field as ``claude.provider`` below; see the naming-collision
+    # note in ``config._provider_types.AgentProvider``). Default
+    # "anthropic" = claude-agent-sdk, the only implemented family today.
+    # "openai" validates (openai-compat-1 foundation) but has no runner
+    # until openai-compat-2 lands — this field is inert until then.
+    provider: AgentProvider = DEFAULT_AGENT_PROVIDER
     # spec.access REMOVED 2026-06-23 — host access + cwd are the single
     # source of truth in apptainer.binds + spec.workdir. There is no posture
     # enum: a "full" agent declares ``- /home/<user>:/home/<user>:rw``; a

--- a/src/scitex_agent_container/config/_validation.py
+++ b/src/scitex_agent_container/config/_validation.py
@@ -21,6 +21,12 @@ from ._acl_validation import validate_phase3_acl
 from ._claude_validation import _VALID_MODEL_RE as _VALID_MODEL_RE  # noqa: F401
 from ._claude_validation import validate_claude
 from ._placement_validation import validate_placement
+
+# spec.provider (TOP-LEVEL agent-SDK-family selector; openai-compat-1
+# foundation) — distinct from spec.claude.provider (validated inside
+# validate_claude via _provider_validation). See the naming-collision
+# note in config._provider_types.AgentProvider.
+from ._provider_registry import is_known_agent_provider, list_agent_providers
 from ._shape_validation import validate_autonomous, validate_proxy_coupling
 
 # ``_VALID_MODEL_RE`` (accepted ``spec.claude.model`` shapes) moved to
@@ -53,6 +59,9 @@ _SDK_IMAGE = "scitex-agent-container:scitex"
 _KNOWN_SPEC_KEYS = frozenset(
     {
         "runtime",
+        "provider",  # agent SDK family: anthropic (default) | openai — see
+        # config._provider_types.AgentProvider for the naming-collision
+        # note against the unrelated, nested spec.claude.provider.
         "access",  # host-access posture: full (default) | capsule
         "workdir",
         "python-venv",
@@ -295,6 +304,24 @@ def validate_raw(raw: dict, path: str) -> list[str]:
                 "= headless SDK runner; 'apptainer' = back-compat for the "
                 "pre-2026-06-13 container-engine field, mapped to "
                 "'claude-agent-sdk' at dispatch."
+            )
+
+        # spec.provider — AGENT SDK FAMILY selector (openai-compat-1
+        # foundation). Distinct from spec.claude.provider (ProviderSpec,
+        # validated inside validate_claude) — see the naming-collision
+        # note in config._provider_types.AgentProvider. Optional and
+        # NOT in _REQUIRED_FIELDS_BOTH_KINDS on purpose: the whole point
+        # of this field is a safe, backward-compatible default so no
+        # existing spec needs to change while openai-compat-2/3 land the
+        # actual "openai" runner + entrypoint wiring.
+        provider = spec.get("provider")
+        if provider and not is_known_agent_provider(str(provider)):
+            errors.append(
+                f"spec.provider must be one of {list_agent_providers()} "
+                f"(got '{provider}'). 'anthropic' (default) = "
+                "claude-agent-sdk, the only implemented family today; "
+                "'openai' is accepted by the schema but has no runner yet "
+                "(openai-compat-2)."
             )
 
         # spec.access — REMOVED 2026-06-23 (SSoT: explicit binds + workdir).

--- a/src/scitex_agent_container/runtimes/_provider_common.py
+++ b/src/scitex_agent_container/runtimes/_provider_common.py
@@ -1,0 +1,138 @@
+"""Provider-agnostic session-workspace helpers.
+
+Extracted from ``runtimes/_sdk_common.py`` (openai-compat-1 foundation —
+scitex-todo card ``openai-compat-1``, "Land ProviderConfig + ProviderSession
+Protocol"). ``_sdk_common.py`` bundled three concerns: auth provisioning,
+workspace/MCP resolution, and ``ClaudeAgentOptions`` composition. Of those,
+workspace/MCP resolution never referenced ``claude_agent_sdk`` or any other
+Anthropic-specific type — ANY provider's runner needs to resolve an agent's
+workspace ``cwd`` and its ``.mcp.json`` server map the same way. That
+provider-agnostic core now lives HERE so the ``openai`` runner
+(openai-compat-2's ``runtimes/_openai_sdk_common.py``) can reuse it verbatim
+instead of duplicating it.
+
+``_sdk_common.py`` re-exports every public name below (unchanged import
+paths for every existing caller) and layers the Claude/Anthropic-SPECIFIC
+concerns (auth provisioning, ``ClaudeAgentOptions`` composition) on top of
+it. This is a pure, byte-identical-behavior EXTRACTION, not a rewrite —
+see the module docstring of ``_sdk_common.py`` for the full concern split.
+
+Nothing in this module imports ``claude_agent_sdk`` (even lazily) or any
+other provider SDK — that is the whole point of the split.
+"""
+
+from __future__ import annotations
+
+import json as _json
+import os
+import re as _re
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover — typing only
+    from ..config._types import AgentConfig
+
+__all__ = [
+    "project_runtime_root",
+    "resolve_agent_workspace",
+]
+
+
+def project_runtime_root(config: "AgentConfig") -> "Path | None":
+    """If the agent's YAML lives under a project-scope
+    ``.scitex/agent-container/`` tree, return the sibling ``runtime/``
+    so per-agent state lands inside the same repo. Otherwise None.
+
+    In-repo test agents get in-repo state, keeping ``~/.scitex`` clean
+    and letting CI snapshot transcripts as build artifacts.
+    """
+    src = getattr(config, "config_path", "") or ""
+    if not src:
+        return None
+    try:
+        from scitex_config._ecosystem import local_state
+    except Exception:  # stx-allow: fallback (reason: scitex-config optional; degrade to home-scope state)
+        return None
+    scope = local_state.find_project_scope("agent-container", start=Path(src).parent)
+    return (scope / "runtime") if scope is not None else None
+
+
+def _resolve_env_refs(value: Any) -> Any:
+    """Substitute ``${VAR}`` references against the current process env.
+
+    Strings, dicts, and lists are walked recursively. Any other type is
+    passed through unchanged. Unresolved references are left literal so
+    misconfigurations are visible at the SDK call rather than silently
+    becoming empty strings.
+    """
+    if isinstance(value, str):
+        return _re.sub(
+            r"\$\{(\w+)\}",
+            lambda m: os.environ.get(m.group(1), m.group(0)),
+            value,
+        )
+    if isinstance(value, dict):
+        return {k: _resolve_env_refs(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_resolve_env_refs(v) for v in value]
+    return value
+
+
+def resolve_agent_workspace(agent_name: str) -> tuple[dict, str | None]:
+    """Resolve ``(mcp_servers, cwd)`` for a registered agent.
+
+    Returns ``({}, None)`` if the agent isn't registered or its workspace
+    has no ``.mcp.json``. Best-effort: any IO / parse failure produces
+    the empty result rather than raising — the caller (option-builder)
+    decides what to do with an unknown workspace.
+
+    The ``mcp_servers`` dict matches the SDK's expected shape: each
+    entry has ``type`` defaulted to ``"stdio"`` if absent, and any
+    ``${VAR}`` references resolved.
+    """
+    try:
+        from scitex_agent_container._state.registry import Registry
+    except Exception:  # stx-allow: fallback (reason: optional dep at runtime; broaden beyond ImportError so a misbuilt transitive dep can't crash the option-builder)
+        return {}, None
+
+    try:
+        entry = Registry().get(agent_name)
+    except Exception:  # stx-allow: fallback (reason: registry IO best-effort)
+        return {}, None
+    if not entry:
+        return {}, None
+    config_path = entry.get("config")
+    if not config_path:
+        return {}, None
+
+    try:
+        from scitex_agent_container.config import load_config
+
+        cfg = load_config(config_path)
+        workdir = str(Path(cfg.expanded_workdir).expanduser())
+    except Exception:  # stx-allow: fallback (reason: config load best-effort)
+        return {}, None
+
+    mcp_path = Path(workdir) / ".mcp.json"
+    if not mcp_path.is_file():
+        return {}, workdir
+    try:
+        raw = _json.loads(mcp_path.read_text(encoding="utf-8"))
+    except (
+        OSError,
+        _json.JSONDecodeError,
+    ):  # stx-allow: fallback (reason: malformed JSON tolerated)
+        return {}, workdir
+
+    mcp_servers = raw.get("mcpServers", {}) if isinstance(raw, dict) else {}
+    if not isinstance(mcp_servers, dict):
+        return {}, workdir
+
+    resolved: dict = {}
+    for name, entry_dict in mcp_servers.items():
+        if not isinstance(entry_dict, dict):
+            continue
+        e = _resolve_env_refs(dict(entry_dict))
+        e.setdefault("type", "stdio")
+        resolved[name] = e
+    return resolved, workdir

--- a/src/scitex_agent_container/runtimes/_sdk_common.py
+++ b/src/scitex_agent_container/runtimes/_sdk_common.py
@@ -31,16 +31,18 @@ lifecycle path.
 The ``claude-agent-sdk`` import is **lazy**: importing this module does
 not require the SDK to be installed. Each public helper imports the SDK
 on demand and raises a clear error otherwise.
+
+openai-compat-1: concern (2) is extracted (verbatim) to
+``runtimes._provider_common``, re-exported below unchanged.
 """
 
 from __future__ import annotations
 
-import json as _json
 import os
-import re as _re
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
+from ._provider_common import project_runtime_root, resolve_agent_workspace
 from ._sdk_channels import apply_channels, merge_home_mcp_servers
 
 if TYPE_CHECKING:  # pragma: no cover — typing only
@@ -96,23 +98,9 @@ __all__ = [
 ]
 
 
-def project_runtime_root(config: "AgentConfig") -> "Path | None":
-    """If the agent's YAML lives under a project-scope
-    ``.scitex/agent-container/`` tree, return the sibling ``runtime/``
-    so per-agent state lands inside the same repo. Otherwise None.
-
-    In-repo test agents get in-repo state, keeping ``~/.scitex`` clean
-    and letting CI snapshot transcripts as build artifacts.
-    """
-    src = getattr(config, "config_path", "") or ""
-    if not src:
-        return None
-    try:
-        from scitex_config._ecosystem import local_state
-    except Exception:  # stx-allow: fallback (reason: scitex-config optional; degrade to home-scope state)
-        return None
-    scope = local_state.find_project_scope("agent-container", start=Path(src).parent)
-    return (scope / "runtime") if scope is not None else None
+# NOTE: project_runtime_root is imported from ._provider_common above and
+# re-exported via __all__ (openai-compat-1 extraction — see module
+# docstring). Its definition used to live here, verbatim, unchanged.
 
 
 def _cred_file_path() -> Path:
@@ -299,29 +287,10 @@ def provision_anthropic_auth() -> str:
 
 
 # ---------------------------------------------------------------------------
-# Workspace + MCP wiring
+# Workspace + MCP wiring — see runtimes/_provider_common (openai-compat-1
+# extraction). resolve_agent_workspace is imported above; nothing
+# Claude-specific lives in this concern anymore.
 # ---------------------------------------------------------------------------
-
-
-def _resolve_env_refs(value: Any) -> Any:
-    """Substitute ``${VAR}`` references against the current process env.
-
-    Strings, dicts, and lists are walked recursively. Any other type is
-    passed through unchanged. Unresolved references are left literal so
-    misconfigurations are visible at the SDK call rather than silently
-    becoming empty strings.
-    """
-    if isinstance(value, str):
-        return _re.sub(
-            r"\$\{(\w+)\}",
-            lambda m: os.environ.get(m.group(1), m.group(0)),
-            value,
-        )
-    if isinstance(value, dict):
-        return {k: _resolve_env_refs(v) for k, v in value.items()}
-    if isinstance(value, list):
-        return [_resolve_env_refs(v) for v in value]
-    return value
 
 
 def _load_agent_config_silent(agent_name: str) -> "AgentConfig | None":
@@ -356,64 +325,9 @@ def _load_agent_config_silent(agent_name: str) -> "AgentConfig | None":
         return None
 
 
-def resolve_agent_workspace(agent_name: str) -> tuple[dict, str | None]:
-    """Resolve ``(mcp_servers, cwd)`` for a registered agent.
-
-    Returns ``({}, None)`` if the agent isn't registered or its workspace
-    has no ``.mcp.json``. Best-effort: any IO / parse failure produces
-    the empty result rather than raising — the caller (option-builder)
-    decides what to do with an unknown workspace.
-
-    The ``mcp_servers`` dict matches the SDK's expected shape: each
-    entry has ``type`` defaulted to ``"stdio"`` if absent, and any
-    ``${VAR}`` references resolved.
-    """
-    try:
-        from scitex_agent_container._state.registry import Registry
-    except Exception:  # stx-allow: fallback (reason: optional dep at runtime; broaden beyond ImportError so a misbuilt transitive dep can't crash the option-builder)
-        return {}, None
-
-    try:
-        entry = Registry().get(agent_name)
-    except Exception:  # stx-allow: fallback (reason: registry IO best-effort)
-        return {}, None
-    if not entry:
-        return {}, None
-    config_path = entry.get("config")
-    if not config_path:
-        return {}, None
-
-    try:
-        from scitex_agent_container.config import load_config
-
-        cfg = load_config(config_path)
-        workdir = str(Path(cfg.expanded_workdir).expanduser())
-    except Exception:  # stx-allow: fallback (reason: config load best-effort)
-        return {}, None
-
-    mcp_path = Path(workdir) / ".mcp.json"
-    if not mcp_path.is_file():
-        return {}, workdir
-    try:
-        raw = _json.loads(mcp_path.read_text(encoding="utf-8"))
-    except (
-        OSError,
-        _json.JSONDecodeError,
-    ):  # stx-allow: fallback (reason: malformed JSON tolerated)
-        return {}, workdir
-
-    mcp_servers = raw.get("mcpServers", {}) if isinstance(raw, dict) else {}
-    if not isinstance(mcp_servers, dict):
-        return {}, workdir
-
-    resolved: dict = {}
-    for name, entry_dict in mcp_servers.items():
-        if not isinstance(entry_dict, dict):
-            continue
-        e = _resolve_env_refs(dict(entry_dict))
-        e.setdefault("type", "stdio")
-        resolved[name] = e
-    return resolved, workdir
+# NOTE: resolve_agent_workspace is imported from ._provider_common above
+# and re-exported via __all__ (openai-compat-1 extraction). Its definition
+# used to live here, verbatim, unchanged.
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scitex_agent_container/_runners/test__provider_session.py
+++ b/tests/scitex_agent_container/_runners/test__provider_session.py
@@ -1,0 +1,357 @@
+"""Tests for ``_runners/_provider_session.py`` (openai-compat-1 foundation).
+
+Covers the four dataclasses (``ToolSpec``, ``Message``, ``NormalizedEvent``,
+``RunResult``) and the ``ProviderSession`` Protocol. No mocks — the
+Protocol is exercised against a REAL, hand-written implementation
+(``_FakeSession``, mirroring the ``_ScriptedClient`` pattern in
+``tests/.../test__session_turn.py``), proving the shape is actually
+drivable end-to-end, not just structurally declared.
+
+Landed foundation-only: nothing in production yet implements or calls
+this Protocol (see the module docstring for why) — these tests pin the
+SHAPE the openai-compat-2 runner will build against.
+
+STX-TQ002 AAA + STX-TQ007 one-assert-per-test. Async tests follow the
+``asyncio.run(_go())`` convention already used in
+``tests/.../_runners/test__session_turn.py`` rather than pytest-asyncio
+markers.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator
+
+from scitex_agent_container._runners._provider_session import (
+    Message,
+    NormalizedEvent,
+    ProviderSession,
+    RunResult,
+    ToolSpec,
+)
+
+# ---------------------------------------------------------------------------
+# ToolSpec
+# ---------------------------------------------------------------------------
+
+
+def test_tool_spec_carries_supplied_name():
+    # Arrange
+    # Act
+    spec = ToolSpec(name="search")
+    # Assert
+    assert spec.name == "search"
+
+
+def test_tool_spec_description_defaults_to_empty_string():
+    # Arrange
+    # Act
+    spec = ToolSpec(name="search")
+    # Assert
+    assert spec.description == ""
+
+
+def test_tool_spec_parameters_defaults_to_empty_dict():
+    # Arrange
+    # Act
+    spec = ToolSpec(name="search")
+    # Assert
+    assert spec.parameters == {}
+
+
+def test_tool_spec_parameters_default_is_not_shared_between_instances():
+    # Arrange
+    a = ToolSpec(name="a")
+    b = ToolSpec(name="b")
+    # Act
+    a.parameters["x"] = 1
+    # Assert
+    assert "x" not in b.parameters
+
+
+def test_tool_spec_handler_defaults_to_none():
+    # Arrange
+    # Act
+    spec = ToolSpec(name="search")
+    # Assert
+    assert spec.handler is None
+
+
+def test_tool_spec_is_frozen():
+    # Arrange
+    spec = ToolSpec(name="search")
+    raised: BaseException | None = None
+    # Act
+    try:
+        spec.name = "renamed"  # type: ignore[misc]
+    except Exception as exc:  # stx-allow: test-capture (reason: STX-TQ002 splits Act from Assert; dataclass frozen contract is to raise.)
+        raised = exc
+    # Assert
+    assert raised is not None
+
+
+# ---------------------------------------------------------------------------
+# Message
+# ---------------------------------------------------------------------------
+
+
+def test_message_carries_supplied_role():
+    # Arrange
+    # Act
+    msg = Message(role="user", content="hello")
+    # Assert
+    assert msg.role == "user"
+
+
+def test_message_carries_supplied_content():
+    # Arrange
+    # Act
+    msg = Message(role="user", content="hello")
+    # Assert
+    assert msg.content == "hello"
+
+
+def test_message_name_defaults_to_none():
+    # Arrange
+    # Act
+    msg = Message(role="user", content="hi")
+    # Assert
+    assert msg.name is None
+
+
+def test_message_tool_call_id_defaults_to_none():
+    # Arrange
+    # Act
+    msg = Message(role="user", content="hi")
+    # Assert
+    assert msg.tool_call_id is None
+
+
+def test_message_tool_role_carries_tool_call_id():
+    # Arrange
+    # Act
+    msg = Message(role="tool", content="42", tool_call_id="call_1")
+    # Assert
+    assert msg.tool_call_id == "call_1"
+
+
+# ---------------------------------------------------------------------------
+# RunResult
+# ---------------------------------------------------------------------------
+
+
+def test_run_result_text_defaults_to_empty_string():
+    # Arrange
+    # Act
+    result = RunResult()
+    # Assert
+    assert result.text == ""
+
+
+def test_run_result_session_id_defaults_to_none():
+    # Arrange
+    # Act
+    result = RunResult()
+    # Assert
+    assert result.session_id is None
+
+
+def test_run_result_usage_defaults_to_empty_dict():
+    # Arrange
+    # Act
+    result = RunResult()
+    # Assert
+    assert result.usage == {}
+
+
+def test_run_result_stop_reason_defaults_to_empty_string():
+    # Arrange
+    # Act
+    result = RunResult()
+    # Assert
+    assert result.stop_reason == ""
+
+
+def test_run_result_carries_supplied_session_id():
+    # Arrange
+    # Act
+    result = RunResult(session_id="sess-1")
+    # Assert
+    assert result.session_id == "sess-1"
+
+
+# ---------------------------------------------------------------------------
+# NormalizedEvent
+# ---------------------------------------------------------------------------
+
+
+def test_normalized_event_carries_supplied_kind():
+    # Arrange
+    # Act
+    event = NormalizedEvent(kind="text_delta")
+    # Assert
+    assert event.kind == "text_delta"
+
+
+def test_normalized_event_text_defaults_to_empty_string():
+    # Arrange
+    # Act
+    event = NormalizedEvent(kind="text_delta")
+    # Assert
+    assert event.text == ""
+
+
+def test_normalized_event_tool_input_defaults_to_empty_dict():
+    # Arrange
+    # Act
+    event = NormalizedEvent(kind="tool_call")
+    # Assert
+    assert event.tool_input == {}
+
+
+def test_normalized_event_result_defaults_to_none():
+    # Arrange
+    # Act
+    event = NormalizedEvent(kind="text_delta")
+    # Assert
+    assert event.result is None
+
+
+def test_normalized_event_raw_defaults_to_none():
+    # Arrange
+    # Act
+    event = NormalizedEvent(kind="text_delta")
+    # Assert
+    assert event.raw is None
+
+
+def test_normalized_event_terminal_result_kind_carries_run_result():
+    # Arrange
+    result = RunResult(text="hi", session_id="s1")
+    # Act
+    event = NormalizedEvent(kind="result", result=result)
+    # Assert
+    assert event.result is result
+
+
+# ---------------------------------------------------------------------------
+# ProviderSession Protocol — exercised against a REAL implementation
+# ---------------------------------------------------------------------------
+
+
+class _FakeSession:
+    """A real, minimal ``ProviderSession`` implementation for shape-testing.
+
+    Mirrors the ``_ScriptedClient`` pattern in
+    ``tests/.../_runners/test__session_turn.py`` — a hand-written stand-in,
+    not a mock, so the test exercises the actual Protocol shape end-to-end.
+    """
+
+    def __init__(self) -> None:
+        self.started = False
+        self.closed = False
+        self.sent: list[Message] = []
+
+    async def start(self) -> None:
+        self.started = True
+
+    async def send(self, message: Message) -> AsyncIterator[NormalizedEvent]:
+        self.sent.append(message)
+        yield NormalizedEvent(kind="text_delta", text="hel")
+        yield NormalizedEvent(kind="text_delta", text="lo")
+        yield NormalizedEvent(
+            kind="result",
+            result=RunResult(text="hello", session_id="sess-abc"),
+        )
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def test_fake_session_satisfies_provider_session_isinstance_check():
+    # Arrange
+    session = _FakeSession()
+    # Act
+    conforms = isinstance(session, ProviderSession)
+    # Assert
+    assert conforms is True
+
+
+def test_plain_object_does_not_satisfy_provider_session_isinstance_check():
+    # Arrange
+    class _NotASession:
+        pass
+
+    # Act
+    conforms = isinstance(_NotASession(), ProviderSession)
+    # Assert
+    assert conforms is False
+
+
+def test_provider_session_start_sets_started_flag():
+    # Arrange
+    async def _go() -> bool:
+        session = _FakeSession()
+        await session.start()
+        return session.started
+
+    # Act
+    started = asyncio.run(_go())
+    # Assert
+    assert started is True
+
+
+def test_provider_session_close_sets_closed_flag():
+    # Arrange
+    async def _go() -> bool:
+        session = _FakeSession()
+        await session.close()
+        return session.closed
+
+    # Act
+    closed = asyncio.run(_go())
+    # Assert
+    assert closed is True
+
+
+def _drive_one_turn() -> list[NormalizedEvent]:
+    async def _go() -> list[NormalizedEvent]:
+        session = _FakeSession()
+        await session.start()
+        events = [e async for e in session.send(Message(role="user", content="hi"))]
+        await session.close()
+        return events
+
+    return asyncio.run(_go())
+
+
+def test_provider_session_send_yields_text_delta_events_in_order():
+    # Arrange
+    # Act
+    events = _drive_one_turn()
+    # Assert
+    assert [e.text for e in events if e.kind == "text_delta"] == ["hel", "lo"]
+
+
+def test_provider_session_send_terminates_with_result_kind():
+    # Arrange
+    # Act
+    events = _drive_one_turn()
+    # Assert
+    assert events[-1].kind == "result"
+
+
+def test_provider_session_terminal_event_carries_run_result_text():
+    # Arrange
+    # Act
+    events = _drive_one_turn()
+    # Assert
+    assert events[-1].result.text == "hello"
+
+
+def test_provider_session_terminal_event_carries_session_id():
+    # Arrange
+    # Act
+    events = _drive_one_turn()
+    # Assert
+    assert events[-1].result.session_id == "sess-abc"

--- a/tests/scitex_agent_container/config/test__loaders.py
+++ b/tests/scitex_agent_container/config/test__loaders.py
@@ -715,3 +715,44 @@ def test_load_config_without_access_field_loads(tmp_path: Path) -> None:
     cfg = load_config(p)
     # Assert — loads cleanly; host access is whatever apptainer.binds declares.
     assert cfg.name == "acc-absent"
+
+
+# ---------------------------------------------------------------------------
+# spec.provider — agent SDK family selector (openai-compat-1 foundation).
+# TOP-LEVEL field, sibling of spec.runtime; distinct from the pre-existing
+# spec.claude.provider (vendor backend override — see the naming-collision
+# note in config._provider_types.AgentProvider).
+# ---------------------------------------------------------------------------
+
+
+def test_load_config_provider_defaults_to_anthropic_when_omitted(
+    tmp_path: Path,
+) -> None:
+    # Arrange — no-op guarantee: every existing spec omits spec.provider.
+    p = _v3_yaml(tmp_path, "provider-default", {})
+    # Act
+    cfg = load_config(p)
+    # Assert
+    assert cfg.provider == "anthropic"
+
+
+def test_load_config_provider_threads_through_when_declared_openai(
+    tmp_path: Path,
+) -> None:
+    # Arrange
+    p = _v3_yaml(tmp_path, "provider-openai", {"provider": "openai"})
+    # Act
+    cfg = load_config(p)
+    # Assert
+    assert cfg.provider == "openai"
+
+
+def test_load_config_provider_threads_through_when_declared_anthropic(
+    tmp_path: Path,
+) -> None:
+    # Arrange — explicit "anthropic" (spelled out, not relying on default).
+    p = _v3_yaml(tmp_path, "provider-explicit-anthropic", {"provider": "anthropic"})
+    # Act
+    cfg = load_config(p)
+    # Assert
+    assert cfg.provider == "anthropic"

--- a/tests/scitex_agent_container/config/test__provider_registry.py
+++ b/tests/scitex_agent_container/config/test__provider_registry.py
@@ -9,7 +9,10 @@ lines (TQ002), descriptive name with ≥3 tokens (TQ003).
 from __future__ import annotations
 
 from scitex_agent_container.config._provider_registry import (
+    AGENT_SDK_PROVIDERS,
     PROVIDERS,
+    is_known_agent_provider,
+    list_agent_providers,
     list_providers,
     resolve_provider,
 )
@@ -90,3 +93,62 @@ def test_xiaomi_alias_resolves_to_same_backend_as_mimo():
     xiaomi = resolve_provider("xiaomi")
     # Assert
     assert xiaomi == resolve_provider("mimo")
+
+
+# ---------------------------------------------------------------------------
+# AGENT_SDK_PROVIDERS — spec.provider (TOP-LEVEL agent SDK family selector;
+# openai-compat-1 foundation). A SEPARATE, flat registry from PROVIDERS
+# above — see the naming-collision note in config._provider_types.AgentProvider.
+# ---------------------------------------------------------------------------
+
+
+def test_agent_sdk_providers_is_exactly_anthropic_and_openai():
+    # Arrange
+    expected = {"anthropic", "openai"}
+    # Act
+    names = set(AGENT_SDK_PROVIDERS)
+    # Assert
+    assert names == expected
+
+
+def test_is_known_agent_provider_true_for_anthropic():
+    # Arrange
+    name = "anthropic"
+    # Act
+    known = is_known_agent_provider(name)
+    # Assert
+    assert known is True
+
+
+def test_is_known_agent_provider_true_for_openai():
+    # Arrange
+    name = "openai"
+    # Act
+    known = is_known_agent_provider(name)
+    # Assert
+    assert known is True
+
+
+def test_is_known_agent_provider_false_for_unregistered_name():
+    # Arrange
+    name = "totally-made-up-sdk"
+    # Act
+    known = is_known_agent_provider(name)
+    # Assert
+    assert known is False
+
+
+def test_list_agent_providers_returns_sorted_order():
+    # Arrange
+    # Act
+    names = list_agent_providers()
+    # Assert
+    assert names == sorted(names)
+
+
+def test_list_agent_providers_matches_agent_sdk_providers_set():
+    # Arrange
+    # Act
+    names = set(list_agent_providers())
+    # Assert
+    assert names == set(AGENT_SDK_PROVIDERS)

--- a/tests/scitex_agent_container/config/test__validation.py
+++ b/tests/scitex_agent_container/config/test__validation.py
@@ -246,6 +246,81 @@ def test_validate_raw_accepts_runtime_apptainer_for_backcompat():
 
 
 # ---------------------------------------------------------------------------
+# spec.provider — agent SDK family selector (openai-compat-1 foundation).
+# Distinct from spec.claude.provider (vendor backend override, tested in
+# test__validation_provider.py) — see the naming-collision note in
+# config._provider_types.AgentProvider.
+# ---------------------------------------------------------------------------
+
+
+def test_validate_raw_absent_provider_is_not_an_error():
+    # Arrange — no-op guarantee: omitting spec.provider adds zero errors.
+    raw = {
+        "apiVersion": "scitex-agent-container/v3",
+        "kind": "Agent",
+        "spec": {"runtime": "tui"},
+    }
+    # Act
+    errors = validate_raw(raw, path="<test>")
+    # Assert
+    assert not [e for e in errors if "spec.provider" in e]
+
+
+def test_validate_raw_accepts_provider_anthropic():
+    # Arrange
+    raw = {
+        "apiVersion": "scitex-agent-container/v3",
+        "kind": "Agent",
+        "spec": {"runtime": "tui", "provider": "anthropic"},
+    }
+    # Act
+    errors = validate_raw(raw, path="<test>")
+    # Assert
+    assert not [e for e in errors if "spec.provider" in e]
+
+
+def test_validate_raw_accepts_provider_openai():
+    # Arrange — schema-valid even though openai-compat-2 hasn't landed
+    # a runner for it yet (foundation phase).
+    raw = {
+        "apiVersion": "scitex-agent-container/v3",
+        "kind": "Agent",
+        "spec": {"runtime": "tui", "provider": "openai"},
+    }
+    # Act
+    errors = validate_raw(raw, path="<test>")
+    # Assert
+    assert not [e for e in errors if "spec.provider" in e]
+
+
+def test_validate_raw_rejects_unknown_provider_value():
+    # Arrange
+    raw = {
+        "apiVersion": "scitex-agent-container/v3",
+        "kind": "Agent",
+        "spec": {"runtime": "tui", "provider": "bogus-sdk"},
+    }
+    # Act
+    errors = validate_raw(raw, path="<test>")
+    # Assert
+    assert [e for e in errors if "spec.provider" in e]
+
+
+def test_validate_raw_unknown_provider_error_echoes_offending_value():
+    # Arrange
+    raw = {
+        "apiVersion": "scitex-agent-container/v3",
+        "kind": "Agent",
+        "spec": {"runtime": "tui", "provider": "bogus-sdk"},
+    }
+    # Act
+    errors = validate_raw(raw, path="<test>")
+    # Assert
+    provider_errors = [e for e in errors if "spec.provider" in e]
+    assert "bogus-sdk" in provider_errors[0]
+
+
+# ---------------------------------------------------------------------------
 # F-CS3 — autonomous spec block (phase 1: schema only)
 # ---------------------------------------------------------------------------
 
@@ -669,6 +744,19 @@ def test_host_local_passes_validation():
     errors = validate_raw(raw, path="<test>")
     # Assert
     assert not [e for e in errors if "host" in e.lower()]
+
+
+def test_complete_spec_with_explicit_provider_openai_has_no_errors():
+    # Arrange — a fully-valid spec that ALSO opts into the (not-yet-
+    # runnable) openai SDK family must still validate clean.
+    import copy
+
+    raw = copy.deepcopy(_COMPLETE_SPEC)
+    raw["spec"]["provider"] = "openai"
+    # Act
+    errors = validate_raw(raw, path="<test>")
+    # Assert
+    assert errors == []
 
 
 def test_missing_host_and_hosts_is_rejected():

--- a/tests/scitex_agent_container/runtimes/test__provider_common.py
+++ b/tests/scitex_agent_container/runtimes/test__provider_common.py
@@ -1,0 +1,181 @@
+"""Tests for ``runtimes/_provider_common.py`` (openai-compat-1 extraction).
+
+These exercise the module DIRECTLY (not via the ``_sdk_common`` re-export)
+to prove the split is standalone-importable and behaviorally unchanged —
+the openai-compat-2 runner will import this module on its own, without
+pulling in ``_sdk_common``'s Anthropic-specific auth/options code.
+
+``test__sdk_common.py`` already covers ``resolve_agent_workspace`` /
+``project_runtime_root`` end-to-end through the ``_sdk_common`` re-export
+(regression coverage for the extraction); this file adds direct-import
+coverage plus the ``project_runtime_root`` no-config-path case, which had
+no prior test anywhere in the suite.
+
+PA-306: no ``monkeypatch`` — env/attribute mutations use an explicit
+save/restore fixture, matching ``test__sdk_common.py``'s ``_Env`` pattern.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from scitex_agent_container.runtimes import _provider_common
+from scitex_agent_container.runtimes._provider_common import (
+    project_runtime_root,
+    resolve_agent_workspace,
+)
+
+
+class _Env:
+    """Records attribute mutations and reverses them on teardown."""
+
+    def __init__(self) -> None:
+        self._attr_snapshots: list[tuple[Any, str, Any]] = []
+
+    def setattr_module(self, obj: Any, name: str, value: Any) -> None:
+        if not any(a is obj and n == name for a, n, _ in self._attr_snapshots):
+            self._attr_snapshots.append((obj, name, getattr(obj, name)))
+        setattr(obj, name, value)
+
+    def restore(self) -> None:
+        for obj, name, prev in self._attr_snapshots:
+            setattr(obj, name, prev)
+
+
+@pytest.fixture
+def env():
+    e = _Env()
+    try:
+        yield e
+    finally:
+        e.restore()
+
+
+def _swap_registry(env: _Env, entry: Any) -> None:
+    import scitex_agent_container._state.registry as reg_mod
+
+    class _FakeRegistry:
+        def get(self, _name):
+            return entry
+
+    env.setattr_module(reg_mod, "Registry", _FakeRegistry)
+
+
+def _swap_load_config(env: _Env, workdir: str) -> None:
+    import scitex_agent_container.config as cfg_mod
+
+    env.setattr_module(
+        cfg_mod, "load_config", lambda _path: SimpleNamespace(expanded_workdir=workdir)
+    )
+
+
+# ---------------------------------------------------------------------------
+# resolve_agent_workspace — direct import, standalone behavior
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_agent_workspace_unknown_agent_returns_empty(env: _Env):
+    # Arrange
+    _swap_registry(env, None)
+    # Act
+    result = resolve_agent_workspace("nope")
+    # Assert
+    assert result == ({}, None)
+
+
+def test_resolve_agent_workspace_returns_cwd_without_mcp_json(
+    env: _Env, tmp_path: Path
+):
+    # Arrange
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    _swap_registry(env, {"config": "cfg.yaml"})
+    _swap_load_config(env, str(ws))
+    # Act
+    result = resolve_agent_workspace("alpha")
+    # Assert
+    assert result == ({}, str(ws))
+
+
+def test_resolve_agent_workspace_substitutes_env_var(env: _Env, tmp_path: Path):
+    # Arrange
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    (ws / ".mcp.json").write_text(
+        json.dumps(
+            {"mcpServers": {"stx": {"command": "scitex", "args": ["${MY_TOKEN}"]}}}
+        )
+    )
+    import os as _os
+
+    prev = _os.environ.get("MY_TOKEN")
+    _os.environ["MY_TOKEN"] = "tk-123"
+    try:
+        _swap_registry(env, {"config": "cfg.yaml"})
+        _swap_load_config(env, str(ws))
+        # Act
+        servers, _cwd = resolve_agent_workspace("alpha")
+    finally:
+        if prev is None:
+            _os.environ.pop("MY_TOKEN", None)
+        else:
+            _os.environ["MY_TOKEN"] = prev
+    # Assert
+    assert servers["stx"]["args"] == ["tk-123"]
+
+
+def test_resolve_agent_workspace_defaults_type_to_stdio(env: _Env, tmp_path: Path):
+    # Arrange
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    (ws / ".mcp.json").write_text(
+        json.dumps({"mcpServers": {"stx": {"command": "scitex"}}})
+    )
+    _swap_registry(env, {"config": "cfg.yaml"})
+    _swap_load_config(env, str(ws))
+    # Act
+    servers, _cwd = resolve_agent_workspace("alpha")
+    # Assert
+    assert servers["stx"]["type"] == "stdio"
+
+
+# ---------------------------------------------------------------------------
+# project_runtime_root
+# ---------------------------------------------------------------------------
+
+
+def test_project_runtime_root_returns_none_without_config_path():
+    # Arrange
+    config = SimpleNamespace(config_path="")
+    # Act
+    result = project_runtime_root(config)
+    # Assert
+    assert result is None
+
+
+def test_project_runtime_root_returns_none_for_unscoped_path(tmp_path: Path):
+    # Arrange — a tmp dir with no ``.scitex/agent-container`` marker
+    # anywhere in its ancestry.
+    config = SimpleNamespace(config_path=str(tmp_path / "spec.yaml"))
+    # Act
+    result = project_runtime_root(config)
+    # Assert
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Module surface — the pieces openai-compat-2 will import directly
+# ---------------------------------------------------------------------------
+
+
+def test_module_all_exports_project_runtime_root_and_resolve_workspace():
+    # Arrange
+    # Act
+    exported = set(_provider_common.__all__)
+    # Assert
+    assert exported == {"project_runtime_root", "resolve_agent_workspace"}


### PR DESCRIPTION
## Summary

Foundation-only phase 1 of 3 for OpenAI-provider compatibility (scitex-todo card `openai-compat-1`). Lands the shapes `openai-compat-2` (the actual OpenAI adapter) and `openai-compat-3` (entrypoint wiring) will build on, with zero behavior change for existing Claude agents.

- Add `src/scitex_agent_container/_runners/_provider_session.py`: `ToolSpec`, `Message`, `NormalizedEvent`, `RunResult` dataclasses + the `ProviderSession` Protocol. Informed by the REAL `claude_agent_sdk` message vocabulary (`AssistantMessage`/`ToolUseBlock`/`ResultMessage`/task-lifecycle messages, inspected directly from the installed package) and `openai-agents`' documented `Runner.run_streamed()` shape. Not wired into any live call path yet — pure additive code.
- Add `spec.provider: anthropic | openai` (default `anthropic`) as a **top-level**, `AgentConfig` field (sibling of `spec.runtime`), threaded through `config/_provider_types.py` (`AgentProvider` Literal), `config/_provider_registry.py` (`AGENT_SDK_PROVIDERS`), `config/_validation.py`, and `config/_loaders.py`. See "Design notes" below for why this is *not* `spec.claude.provider`.
- Refactor `runtimes/_sdk_common.py` (extract, don't rewrite): the workspace/`.mcp.json`-resolution helpers (`project_runtime_root`, `resolve_agent_workspace`) never referenced `claude_agent_sdk` — moved verbatim to a new `runtimes/_provider_common.py`, re-exported from `_sdk_common.py` unchanged. This was also required independently: `_sdk_common.py` was already at 594 lines (over the repo's 512-line cap) before this change.

## Design notes (non-obvious calls)

**Why `spec.provider` (top-level), not `spec.claude.provider`:** the card's literal wording said "extend `config/_provider_types.py` with `provider: Literal[...]`", but that module already defines `ProviderSpec` for the *existing* `spec.claude.provider` — a vendor-agnostic Anthropic-**compatible** backend override (DeepSeek/Mimo/Xiaomi, still the Claude Agent SDK, just a different `base_url`+API key). Reusing that exact field name for "which agent SDK family" would collide both semantically and at the YAML-key level. `openai-compat-3`'s own card text ("...based on `spec.provider`") confirms the intended field is top-level, sibling to `spec.runtime` — so that's what landed, mirroring `spec.runtime`'s existing flow (`_types.py` -> `_validation.py` -> `_loaders.py` -> `_lifecycle/_runtime_select.py`) exactly. The two `provider` concepts compose rather than collide: `spec.provider: anthropic` + `spec.claude.provider: mimo` runs the Claude SDK against Xiaomi's endpoint. Every touch point has a naming-collision docstring pointing at this note.

**Not required in `_REQUIRED_FIELDS_BOTH_KINDS`:** unlike `spec.runtime` (required under the 2026-06-23 "no hidden defaults" directive), `spec.provider` is deliberately optional with a safe default — the entire point of a foundation phase is zero changes to the existing spec corpus.

**`ProviderSession` vs `RuntimeBase`:** not a subtype/replacement. `RuntimeBase` is PROCESS lifecycle (start/stop/is_running/logs for a whole container, host-side). `ProviderSession` is CONVERSATION lifecycle (one SDK client's turn-taking, driven inside the running container). They compose vertically -- a future runner picks a `ProviderSession` impl based on `AgentConfig.provider` and drives it from inside the process `RuntimeBase.start()` launched. Documented in the module docstring for `openai-compat-2`.

**No concrete Claude-side `ProviderSession` implementation landed.** Retrofitting `_drive_turn` to go through the Protocol is explicitly out of scope here -- it would touch the live turn-loop, which is the one way this "no-op" phase could regress a running agent. `_provider_session.py` is pure, additive, unused-by-default code.

## No-op verification

- `runtimes/_sdk_common.py`'s public surface (`__all__`) is byte-identical; `resolve_agent_workspace`/`project_runtime_root` bodies moved verbatim (not rewritten) to `_provider_common.py` and are re-exported.
- `tests/.../runtimes/test__sdk_common.py` (the full pre-existing suite covering auth/workspace/options-building) passes unchanged -- no test edits needed there.
- `AgentConfig.provider` defaults to `"anthropic"`; every existing YAML spec (none of which declares `provider:`) round-trips identically. New tests pin this (`test_load_config_provider_defaults_to_anthropic_when_omitted`) and the pre-existing `test_complete_spec_has_no_errors` (a full valid spec with no `provider:` key) still asserts `errors == []` unchanged.
- Ran the full suite three ways in the dev sandbox (serial+cov, `-n auto` parallel, and a serial run targeted at every directory this PR touches: `config/`, `runtimes/`, `_runners/`, `a2a/`, `_lifecycle/`, `_state/` + the v3-spec integration tests) -- 4394/4404 and 8647/8750 passed respectively across the two full runs. Every failure was individually root-caused and is **pre-existing / environment-specific, not caused by this diff**:
  - `tests/develop/test_audit.py` -- `scitex-dev ecosystem audit-all` subprocess times out at 120s; reproduces identically on a `git stash`-clean tree (confirmed by running the same test both with and without this diff applied).
  - `_runners/test_claude_session.py::test_state_dir_for_default_root_is_under_user_home` -- looked suspicious (only failure inside a file this PR is adjacent to) until the assertion diff showed a path fragment (`test_image_cache_dir_is_named_0`) from an *unrelated* test's `tmp_path` -- cross-test state pollution from the batch run. Passes deterministically in two consecutive isolated re-runs with this diff applied.
  - The rest (`_lifecycle/test__broker_self.py`, `_lifecycle/test__tui_heartbeat_loop.py`/`test__sdk_heartbeat_loop.py`, `_state/snapshot/test__io.py`, various `smoke/`/`_listen/` tests, `test_subprocess_runner_*`) are real-subprocess/real-server startup timeouts (`sac listen` not healthy within 15s, pid-file-write timeouts, `tmux` genuinely absent from this sandbox) -- none touch code this PR changes.
- `ruff check --select F401,F811 --extend-per-file-ignores '**/__init__.py:F401' src/ tests/` -- clean.

## Test plan

- [x] `pytest tests/integration/test_templates_v3_valid.py -q` (CI smoke step) -- 17 passed
- [x] Full suite, three configurations (serial+cov, `-n auto`, targeted-serial) -- every failure individually root-caused as pre-existing/environmental, none in code this PR touches (see above)
- [x] `ruff check --select F401,F811 --extend-per-file-ignores '**/__init__.py:F401' src/ tests/` -- clean
- [x] New tests for the Protocol/dataclass shapes, the registry additions, the validation block, and the extracted module -- no mocks, real hand-written Protocol conformance
