### PR TITLE
fix(tui): scope boot modal detection to the live pane region

### DIFF
--- a/src/scitex_agent_container/runtimes/prompts.py
+++ b/src/scitex_agent_container/runtimes/prompts.py
@@ -384,6 +384,42 @@ def register_prompt(handler: PromptHandler) -> None:
     PROMPT_HANDLERS.sort(key=lambda h: h.priority)
 
 
+#: How many non-empty rows of a captured pane count as the LIVE region for
+#: modal detection. See :func:`_recent_tail` for the false-positive this
+#: guards against; sized with headroom over the tallest verified real modal
+#: capture (``_LIVE_BYPASS_PANE`` in ``test_prompts.py``, 9 non-empty rows).
+_LIVE_WINDOW_LINES = 15
+
+
+def _recent_tail(content: str, lines: int = _LIVE_WINDOW_LINES) -> str:
+    """Return the last ``lines`` non-empty rows of ``content``.
+
+    Scopes modal detection to the LIVE region of a captured pane instead of
+    the entire accumulated snapshot ``tmux capture-pane -p`` (no ``-S``)
+    returns the whole VISIBLE viewport, not just the freshest output. Once
+    Claude Code's Ink TUI has moved a first-run modal's rendered text
+    further up the screen — dismissed, but not yet scrolled past the
+    viewport — an unscoped substring match can still fire on it long after
+    the modal is gone, sending its registered digit+``Enter`` into what is
+    now the plain, empty compose box: card
+    ``sac-tui-stray-1-submitted-on-boot`` — a spurious ``"1"`` gets typed
+    and submitted as a user message during boot (observed with the
+    ``thinking-effort`` / ``file-trust-radio`` / ``theme-selection``
+    handlers, none of which scoped their match to the live screen).
+
+    ``_LIVE_WINDOW_LINES`` comfortably covers the tallest verified real
+    modal capture with headroom, while still excluding an EARLIER,
+    already-dismissed modal's text once enough new output has rendered
+    below it. Mirrors :func:`_detect_press_enter_continue`'s existing
+    last-N-lines window (same fix shape, wider here because these handlers
+    need a whole title+options+footer block, not one banner line) and
+    :func:`_tui_compose._compose_pending_live`'s bottom-anchored scoping for
+    the analogous Enter-drop bug (``sac-tui-enter-drop-on-boot``).
+    """
+    rows = [row for row in content.splitlines() if row.strip()]
+    return "\n".join(rows[-lines:])
+
+
 def detect_and_respond(
     content: str,
     accepted: set[str],
@@ -399,10 +435,11 @@ def detect_and_respond(
     Returns:
         Name of the matched prompt, or None if no match.
     """
+    tail = _recent_tail(content)
     for handler in sorted(PROMPT_HANDLERS, key=lambda h: h.priority):
         if handler.name in accepted:
             continue
-        if handler.detect(content):
+        if handler.detect(tail):
             for key in handler.keys:
                 send_keys_fn(key)
             logger.info("Auto-accepted prompt: %s", handler.name)
@@ -419,9 +456,14 @@ def detect(content: str) -> str | None:
     keystrokes once and assuming success. Claude's Ink TUI drops keys sent
     mid-render, so a fire-and-forget send silently leaves the modal up; the
     detect/respond/verify cycle is the no-silent-fallback fix.
+
+    Matches against :func:`_recent_tail` (the LIVE region), not the raw
+    ``content`` — see its docstring for the stray-boot-submit false
+    positive this prevents.
     """
+    tail = _recent_tail(content)
     for handler in sorted(PROMPT_HANDLERS, key=lambda h: h.priority):
-        if handler.detect(content):
+        if handler.detect(tail):
             return handler.name
     return None
 

--- a/tests/scitex_agent_container/runtimes/test_prompts.py
+++ b/tests/scitex_agent_container/runtimes/test_prompts.py
@@ -17,6 +17,7 @@ from scitex_agent_container.runtimes.prompts import (
     _detect_skip_permissions_yn,
     _detect_theme_selection,
     _detect_thinking_effort,
+    _recent_tail,
     detect,
     detect_and_respond,
     is_ready,
@@ -687,3 +688,93 @@ def test_resume_session_wins_over_compose_pending():
     name = detect(pane)
     # Assert
     assert name == "resume-session"
+
+
+# ── Stray-boot-submit regression (sac-tui-stray-1-submitted-on-boot) ──────────
+# ``tmux capture-pane -p`` (no ``-S``) returns the whole VISIBLE viewport, not
+# just the freshest output. A dismissed first-run modal's text can therefore
+# still sit in a LATER capture, well above the genuinely live (now empty)
+# compose box. Before the fix, an unscoped substring match kept firing on
+# that stale text and sent its digit + Enter into the live box, typing and
+# submitting a stray "1" during boot. ``_recent_tail`` scopes detection to
+# the live region; these tests pin both the false-positive it removes and
+# the true-positive it must not break.
+
+
+def test_recent_tail_drops_blank_lines_and_keeps_only_last_n():
+    # Arrange
+    content = "\n".join([f"line {i}" for i in range(20)])
+    # Act
+    tail = _recent_tail(content, lines=3)
+    # Assert
+    assert tail == "line 17\nline 18\nline 19"
+
+
+def test_recent_tail_passes_short_content_through_unchanged():
+    # Arrange — fewer non-empty rows than the window: nothing to trim.
+    content = "a\nb\nc"
+    # Act
+    tail = _recent_tail(content, lines=15)
+    # Assert
+    assert tail == "a\nb\nc"
+
+
+# A dismissed thinking-effort modal (content verified to match
+# _detect_thinking_effort in isolation by
+# test_startup_handler_matches_expected_prompt above), followed by enough
+# freshly-rendered boot chatter to push it out of the live window, then the
+# genuinely live, empty compose prompt.
+_STALE_THINKING_EFFORT = "1. * Medium (recommended)\nthinking effort\nEnter to confirm"
+_BOOT_FILLER = "\n".join(f"boot output line {i}" for i in range(20))
+
+
+def test_detect_ignores_stale_modal_scrolled_above_live_prompt():
+    """False-positive repro: a dismissed thinking-effort modal's text is
+    still in the pane capture, but the live compose box (bottom) is a
+    plain empty prompt — must NOT re-fire."""
+    # Arrange
+    pane = f"{_STALE_THINKING_EFFORT}\n{_BOOT_FILLER}\n❯ "
+    # Act
+    name = detect(pane)
+    # Assert
+    assert name is None
+
+
+def test_detect_still_matches_live_thinking_effort_modal():
+    """True-positive companion: the same modal text, genuinely live (no
+    filler pushing it off the live window), must still be auto-accepted."""
+    # Arrange
+    pane = _STALE_THINKING_EFFORT
+    # Act
+    name = detect(pane)
+    # Assert
+    assert name == "thinking-effort"
+
+
+# theme-selection is the loosest of the three handlers the maintainer named
+# as suspects — it doesn't even require "Enter to confirm" — so it is the
+# handler most exposed to firing on leftover on-screen text.
+_STALE_THEME_SELECTION = (
+    "Choose the text style that looks best with your terminal\n"
+    "1. Auto (match terminal)\n"
+    "2. Dark mode\n"
+    "3. Light mode"
+)
+
+
+def test_detect_ignores_stale_theme_modal_scrolled_above_live_prompt():
+    # Arrange
+    pane = f"{_STALE_THEME_SELECTION}\n{_BOOT_FILLER}\n❯ "
+    # Act
+    name = detect(pane)
+    # Assert
+    assert name is None
+
+
+def test_detect_still_matches_live_theme_selection_modal():
+    # Arrange
+    pane = _STALE_THEME_SELECTION
+    # Act
+    name = detect(pane)
+    # Assert
+    assert name == "theme-selection"


### PR DESCRIPTION
## Summary

Fixes scitex-todo card `sac-tui-stray-1-submitted-on-boot`: a fresh TUI boot could submit a spurious `"1"` as a user message (pane scrollback shows `❯ 1` above the startup prompt).

**Root cause**: `tmux capture-pane -p` (no `-S`) returns the whole *visible viewport*, not just the freshest output. `runtimes/prompts.py`'s `detect()` / `detect_and_respond()` matched each handler's pattern against the *entire* captured pane. Once a first-run modal (theme-selection, thinking-effort, file-trust-radio, dev-channels, ...) was dismissed, its rendered text could still sit in a *later* capture, above what is now the plain, empty compose box. The dispatcher would re-fire that handler and send its registered digit + `Enter` into the empty box -- typing and submitting a stray `"1"` during boot. (Mechanism: `_inject_startup_prompts` calls `wait_until_input_ready` multiple times -- once per startup prompt -- and each call starts its own fresh `accepted` set, so a modal already dismissed in an earlier call can be re-matched and re-fired in a later one.)

Verified live in `runtimes/tui_session.py` -> `_tui_drain.py` (`drain_modals_until_ready` / `wait_until_input_ready`) -> `runtimes/prompts.py` (`detect()` / `respond_modal()`) is the actual code path for `spec.runtime: tui`. (The similarly-named `_runners/_tmux/prompts.py` + `detect_and_respond` registry the card also mentioned is dead code -- its only caller, `ClaudeCodeRuntime`, is unreachable from `spec.runtime` dispatch and has broken imports already; left untouched to keep this PR focused.)

**Fix**: added `_recent_tail()` -- the last 15 non-empty rows of the captured pane, sized with headroom over the tallest verified real modal capture (`_LIVE_BYPASS_PANE` in `test_prompts.py`, 9 non-empty rows) -- and scoped both `detect()` and `detect_and_respond()` to it before checking handlers. Mirrors the existing last-N-lines pattern already used by `_detect_press_enter_continue` in the same file, and the bottom-anchored scoping already used for the analogous Enter-drop bug in `_tui_compose.py`.

## Test plan
- [x] New regression tests in `tests/scitex_agent_container/runtimes/test_prompts.py`: a false-positive repro (stale `thinking-effort` / `theme-selection` modal text pushed off the live window by boot filler + a live empty prompt -> `detect()` returns `None`) paired with a true-positive companion (the same modal text, genuinely live -> still auto-accepted), plus direct unit tests of `_recent_tail`. One assertion per test (AAA style, matching existing file convention).
- [x] Full existing `test_prompts.py` suite (60 tests) passes unchanged, including the real-capture fixtures (`_LIVE_BYPASS_PANE`, `_RESUME_MODAL`) -- confirms the fix doesn't break real modal dismissal.
- [x] Full `tests/scitex_agent_container/runtimes/` suite (1255 passed, 20 skipped, 0 failed) -- covers `_tui_drain.py`, `_tui_compose.py` (incl. the Esc-cancel guard), and every `test_tui_session*.py` file that exercises the boot-drain path end to end.
- [x] `ruff check --select F401,F811` clean on both changed files.