### PR TITLE
feat(account): reactive per-agent 429 detection -> backoff or account rotation

### DIFF
--- a/src/scitex_agent_container/_account/_rotation_audit.py
+++ b/src/scitex_agent_container/_account/_rotation_audit.py
@@ -82,8 +82,13 @@ def _ensure_audit_logger() -> None:
     logger._sac_audit_configured = True  # type: ignore[attr-defined]
 
 #: The closed set of rotation events. See module docstring / task spec.
+#: ``reactive-rotate`` (task #13, op-2026-06-12-13) is the REACTIVE
+#: sibling of ``auto-rotate``: a live 429/403/textual/auth signal —
+#: classified via ``_account.rate_limit_classifier`` — forced the
+#: rotation, as opposed to ``auto-rotate``'s periodic threshold poll.
+#: See ``_account.rotate_account.ROTATE_EVENT``.
 _KNOWN_EVENTS = frozenset(
-    {"refresh", "switch", "auto-rotate", "save", "sync-live"}
+    {"refresh", "switch", "auto-rotate", "reactive-rotate", "save", "sync-live"}
 )
 
 

--- a/src/scitex_agent_container/_account/backoff_agent.py
+++ b/src/scitex_agent_container/_account/backoff_agent.py
@@ -1,0 +1,155 @@
+"""Mode A action: per-agent transient rate-limit backoff (task #13 action layer).
+
+Operator directive op-2026-06-12-13 (Telegram 12676 -> 12677) names two
+sibling action-layer modules that consume
+:func:`_account.rate_limit_classifier.classify_rate_limit_signal`'s
+verdict: Mode A ``backoff_agent`` (this module) and Mode B
+``rotate_account`` (:mod:`_account.rotate_account`). Mode A is the
+TRANSIENT case — a server-side throttle (529) or a 429/403 on an
+account that still has headroom. The account stays put; only the
+retrying agent's OWN next attempt is delayed.
+
+Why this needs to exist at all (not just reuse the generic supervisor
+backoff already in ``_runners._session_conversation.run_conversation``):
+that generic backoff is tuned for SDK/network blips and starts at
+``restart_backoff_s`` (default 1.0s), doubling per attempt — 1s, 2s,
+4s. A real Anthropic rate-limit window does not clear in 4 seconds;
+retrying that fast just re-trips the same limit (the "retry storm"
+the operator flagged). :func:`backoff_agent` enforces a floor
+(:data:`DEFAULT_MIN_BACKOFF_S`) so a REACTIVE rate-limit hit always
+waits long enough to have a real chance of clearing before the next
+attempt, while still growing exponentially on repeated hits.
+
+Consecutive-hit escalation
+---------------------------
+:mod:`_account.rate_limit_classifier`'s module docstring reserves one
+decision for the action layer, not the pure classifier: "5 backoffs in
+a row -> escalate to ROTATE — that lives on the backoff state machine,
+not here." :func:`backoff_agent` owns that accounting:
+``prior_consecutive_hits`` is the caller-maintained count of Mode-A
+outcomes seen back-to-back (reset to 0 by the caller on any non-rate-
+limit failure or a successful rotation); once the incremented count
+reaches :data:`DEFAULT_ESCALATE_AFTER` the returned
+:class:`BackoffDecision.escalate_to_rotate` flag is set. This covers a
+low-usage account that keeps tripping 529/overload even though the
+classifier's own usage-threshold check never fires (529 is ALWAYS
+Mode A regardless of usage%, so without this escalation a persistently
+overloaded account could retry forever without ever trying a
+healthier one).
+
+Pure function — no clock read (the caller supplies the "now" framing
+implicitly via when it calls this), no sleep, no IO, no mutation. The
+actual wait (``asyncio.sleep`` / ``asyncio.wait_for``) and the
+consecutive-hit bookkeeping across calls belong to the caller
+(:mod:`_runners._rate_limit_reactive`), mirroring how
+:mod:`_account.rate_limit_classifier` stays pure and pushes clock/DB/
+mutation to its callers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+__all__ = [
+    "DEFAULT_BASE_DELAY_S",
+    "DEFAULT_ESCALATE_AFTER",
+    "DEFAULT_MIN_BACKOFF_S",
+    "BackoffDecision",
+    "backoff_agent",
+]
+
+# Floor for a REACTIVE rate-limit backoff delay, in seconds. Deliberately
+# far above the generic supervisor's 1.0s starting point — see module
+# docstring. 30s gives a real Anthropic 429/529 window a chance to clear
+# without stalling a healthy agent for minutes on the first hit.
+DEFAULT_MIN_BACKOFF_S = 30.0
+
+# Base for the exponential ramp on repeated hits (doubles each time,
+# same shape as the generic supervisor backoff, just with a higher
+# floor applied via ``max()``).
+DEFAULT_BASE_DELAY_S = 1.0
+
+# Consecutive Mode-A hits (same signal classification, back-to-back,
+# no intervening non-rate-limit failure or successful rotation) after
+# which the caller should attempt Mode B (rotate) even though the
+# classifier itself said BACKOFF. See "Consecutive-hit escalation"
+# above.
+DEFAULT_ESCALATE_AFTER = 5
+
+
+@dataclass(frozen=True)
+class BackoffDecision:
+    """Mode A's decision for one reactive rate-limit hit.
+
+    Attributes
+    ----------
+    delay_s
+        Seconds the caller should wait before the next attempt on the
+        SAME account. Always >= the floor passed to
+        :func:`backoff_agent`.
+    hit_count
+        ``prior_consecutive_hits + 1`` — the new running count the
+        caller should persist and pass back in as
+        ``prior_consecutive_hits`` on the NEXT call (reset to 0 on any
+        non-rate-limit outcome or a successful rotation).
+    escalate_to_rotate
+        ``True`` once ``hit_count`` reaches the escalation threshold —
+        the caller should attempt Mode B (:func:`_account.rotate_account
+        .rotate_account`) in addition to / instead of waiting
+        ``delay_s`` on the same account.
+    """
+
+    delay_s: float
+    hit_count: int
+    escalate_to_rotate: bool
+
+
+def backoff_agent(
+    *,
+    prior_consecutive_hits: int = 0,
+    base_delay_s: float = DEFAULT_BASE_DELAY_S,
+    min_backoff_s: float = DEFAULT_MIN_BACKOFF_S,
+    escalate_after: int = DEFAULT_ESCALATE_AFTER,
+) -> BackoffDecision:
+    """Return Mode A's decision: how long to wait, on the SAME account.
+
+    Parameters
+    ----------
+    prior_consecutive_hits
+        The caller-maintained count of Mode-A outcomes already seen
+        back-to-back BEFORE this one (0 for the first hit). Must be
+        >= 0.
+    base_delay_s
+        Starting point for the exponential ramp (before the floor is
+        applied). Exposed for tests; production callers use the
+        default.
+    min_backoff_s
+        The floor — see :data:`DEFAULT_MIN_BACKOFF_S`.
+    escalate_after
+        Hit-count threshold for :attr:`BackoffDecision.escalate_to_rotate`.
+
+    Returns
+    -------
+    BackoffDecision
+
+    Raises
+    ------
+    ValueError
+        If ``prior_consecutive_hits`` is negative — a caller bug (the
+        counter is caller-maintained and should never go negative);
+        fail loud rather than silently treating it as 0.
+
+    Pure: no sleep, no IO, no clock read.
+    """
+    if prior_consecutive_hits < 0:
+        raise ValueError(
+            f"prior_consecutive_hits must be >= 0, got {prior_consecutive_hits}"
+        )
+    hit_count = prior_consecutive_hits + 1
+    exponential = base_delay_s * (2**prior_consecutive_hits)
+    delay_s = max(min_backoff_s, exponential)
+    return BackoffDecision(
+        delay_s=delay_s,
+        hit_count=hit_count,
+        escalate_to_rotate=hit_count >= escalate_after,
+    )

--- a/src/scitex_agent_container/_account/rate_limit_signals.py
+++ b/src/scitex_agent_container/_account/rate_limit_signals.py
@@ -37,6 +37,14 @@ Public surface:
 * :func:`scan_textual_cap_markers(text, patterns=DEFAULT_PATTERNS)`
   — case-insensitive regex scan over a multi-line blob. Returns
   ``RateLimitSignal.TEXTUAL_MATCH`` on any hit (or ``None``).
+* :func:`detect_signal_from_text(text)` — the REACTIVE entry point
+  for a stringified SDK failure (``str(exc)`` + captured stderr):
+  scans for an embedded HTTP-status signature FIRST
+  (:data:`_STATUS_TEXT_SIGNATURES`), then falls back to
+  :func:`scan_textual_cap_markers`. This is what closes the gap
+  between "the SDK never gives us a typed status code" (see
+  ``_runners/_auth_failure.py``'s identical 401 problem) and
+  :func:`classify_http_status`, which needs an already-parsed int.
 * :data:`DEFAULT_TEXTUAL_PATTERNS` — operator-tunable list of
   case-insensitive regex strings. Driven by data, not code, so
   adding "Xiaomi quota exhausted" or "DeepSeek 402 insufficient
@@ -48,9 +56,11 @@ Out of scope (deferred):
   ``_runners/_provider_dispatch``) owns 401/402/500-503 etc;
   THIS module concerns itself only with the subset that signals
   ACCOUNT cap (vs network blip, vs operator bug).
-* Action layer — Mode A backoff_agent and Mode B rotate_account
-  are sibling modules; this file feeds them through the
-  classifier.
+* Action layer — Mode A :func:`_account.backoff_agent.backoff_agent`
+  and Mode B :func:`_account.rotate_account.rotate_account` are
+  sibling modules; :mod:`_runners._rate_limit_reactive` wires this
+  file's detectors through :mod:`_account.rate_limit_classifier`
+  into those two.
 """
 
 from __future__ import annotations
@@ -174,9 +184,74 @@ def scan_textual_cap_markers(
     return None
 
 
+# Signatures that reveal an HTTP status embedded in a STRINGIFIED SDK
+# failure — ``str(exc)`` plus whatever stderr
+# ``_runners._stderr_capture.enrich_detail_with_stderr`` folded in. The
+# ``claude-agent-sdk`` does not surface a typed status code (identical
+# gap to the 401 problem ``_runners/_auth_failure.py`` already solves
+# with its own narrow substring list), so detection here is text-based
+# too.
+#
+# Provider ``error.type`` strings are checked FIRST — Anthropic's JSON
+# error body shape is ``{"type": "error", "error": {"type":
+# "rate_limit_error", ...}}`` for 429 and ``"overloaded_error"`` for
+# 529; these are unambiguous, provider-defined tokens with no realistic
+# false-positive risk. The bare status-code fallback is a
+# word-boundary match (``\b429\b`` etc) — narrower than a plain
+# substring so an unrelated "...429 lines changed..." in a tool-result
+# blob is far less likely to trip it, though — like the 401 list — it
+# is not a zero-risk heuristic. Order matters: first match wins.
+_STATUS_TEXT_SIGNATURES: tuple[tuple[str, RateLimitSignal], ...] = (
+    (r"rate_limit_error", RateLimitSignal.HTTP_429),
+    (r"overloaded_error", RateLimitSignal.HTTP_529),
+    (r"\b429\b", RateLimitSignal.HTTP_429),
+    (r"\b529\b", RateLimitSignal.HTTP_529),
+    (r"\b403\b", RateLimitSignal.HTTP_403),
+)
+
+
+def detect_signal_from_text(text: str) -> tuple[RateLimitSignal, str] | None:
+    """Detect a REACTIVE rate-limit signal in a stringified SDK failure.
+
+    Two-tier scan, first hit wins:
+
+    1. HTTP-status text signatures (:data:`_STATUS_TEXT_SIGNATURES`) —
+       provider ``error.type`` strings, then a bare status-code
+       fallback.
+    2. Textual cap markers (:func:`scan_textual_cap_markers`) —
+       unambiguous cap phrasing such as "hit your weekly limit".
+
+    Parameters
+    ----------
+    text
+        The failure text to scan — typically the exception's ``str()``
+        already enriched with captured subprocess stderr (see
+        ``_runners._stderr_capture.enrich_detail_with_stderr``).
+
+    Returns
+    -------
+    tuple[RateLimitSignal, str] | None
+        ``(signal, matched_pattern)`` on a hit, else ``None``. Empty /
+        whitespace-only input returns ``None``.
+
+    Never raises — a malformed pattern is skipped, same tolerance as
+    :func:`scan_textual_cap_markers`.
+    """
+    if not text or not text.strip():
+        return None
+    for pattern, signal in _STATUS_TEXT_SIGNATURES:
+        try:
+            if re.search(pattern, text, flags=re.IGNORECASE):
+                return signal, pattern
+        except re.error:  # stx-allow: fallback (reason: mirrors scan_textual_cap_markers's malformed-pattern tolerance — a bad signature must not crash the runner)
+            continue
+    return scan_textual_cap_markers(text)
+
+
 __all__ = [
     "DEFAULT_TEXTUAL_PATTERNS",
     "RateLimitSignal",
     "classify_http_status",
+    "detect_signal_from_text",
     "scan_textual_cap_markers",
 ]

--- a/src/scitex_agent_container/_account/rotate_account.py
+++ b/src/scitex_agent_container/_account/rotate_account.py
@@ -1,0 +1,177 @@
+"""Mode B action: reactive per-agent account rotation (task #13 action layer).
+
+Sibling of :mod:`_account.backoff_agent` (Mode A) — see that module's
+docstring for the operator directive (op-2026-06-12-13) both implement.
+Mode B is the SUSTAINED-cap case: the classifier decided the current
+account is genuinely capped (a 429/403 on an already-high-usage
+account, or an unambiguous textual/auth cap signal), so the agent
+needs to move to a DIFFERENT account right now rather than wait out a
+window that will not clear.
+
+This module deliberately does NOT duplicate account selection or
+credential-copy logic. It calls the two EXISTING primitives the
+proactive ``sac accounts watch-quota`` loop already relies on:
+
+* :func:`_account.quota_watch._select_next_account` — health-gated
+  (non-expired credential snapshot; see the 2026-07-06 expired-account
+  regression that primitive's docstring documents) pick of the
+  lowest-5h-usage account that isn't the current one. Returns
+  ``None`` when no healthy non-current candidate exists.
+* :func:`_state.account_store.switch_account` — copies the picked
+  account's credential snapshot into ``~/.claude/`` and appends a
+  structured rotation-audit record (:mod:`_account._rotation_audit`).
+
+The one thing THIS module adds on top of ``_select_next_account`` +
+``switch_account`` is the REACTIVE framing: :func:`rotate_account` skips
+the proactive threshold/``fetch_usage`` gate
+:func:`_account.quota_watch.check_and_rotate` applies, because a
+reactive caller already knows — from a live signal that has been run
+through :func:`_account.rate_limit_classifier.classify_rate_limit_signal`
+— that Mode B was decided. Re-running a threshold gate here would be
+redundant and could disagree with the live signal (e.g. a stale quota
+cache reading below-threshold while the account is demonstrably 429ing
+right now).
+
+Never raises — mirrors ``check_and_rotate``'s contract. The reactive
+caller invokes this from inside an SDK-conversation exception handler;
+a second exception escaping THIS function would mask the original
+failure.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .._state.account_store import list_accounts, switch_account
+from .credentials import read_credentials_metadata
+from .quota_watch import _select_next_account
+
+__all__ = ["ROTATE_EVENT", "RotateResult", "rotate_account"]
+
+# Rotation-audit ``event`` value for a REACTIVE rotate (distinct from
+# quota_watch's periodic ``"auto-rotate"`` so the audit trail — and any
+# operator grepping it — can tell "polled over threshold" apart from
+# "a live 429/403/textual/auth signal forced this"). Registered in
+# ``_account._rotation_audit._KNOWN_EVENTS`` so it doesn't log as an
+# unrecognised event on every reactive rotation.
+ROTATE_EVENT = "reactive-rotate"
+
+# Possible ``RotateResult.action`` values.
+ACTION_ROTATED = "rotated"
+ACTION_NO_ACCOUNTS = "no_accounts"
+
+
+@dataclass(frozen=True)
+class RotateResult:
+    """Outcome of one :func:`rotate_account` call.
+
+    Attributes
+    ----------
+    action
+        ``"rotated"`` on a successful credential switch, ``"no_accounts"``
+        when there was no healthy non-current candidate to rotate to
+        (per ``_select_next_account``'s documented contract: stay put
+        rather than rotate onto an unhealthy/expired account) or the
+        switch itself failed.
+    switched_to
+        The stored-account name we switched to, or ``None``.
+    from_account
+        The email of the account we were rotating away from (best
+        effort; ``None`` if unresolvable).
+    message
+        Human-readable summary for logs / session.jsonl events.
+    """
+
+    action: str
+    switched_to: str | None
+    from_account: str | None
+    message: str
+
+
+def rotate_account(
+    *,
+    reason: str,
+    store_dir: Path | None = None,
+    home: Path | None = None,
+    now: float | None = None,
+) -> RotateResult:
+    """Perform Mode B: rotate the CURRENT agent off its (capped) account.
+
+    Parameters
+    ----------
+    reason
+        WHY the rotation is happening (e.g. the triggering
+        :class:`_account.rate_limit_signals.RateLimitSignal` + the
+        matched pattern/status). Recorded verbatim on the rotation-audit
+        record (see :mod:`_account._rotation_audit`).
+    store_dir, home
+        Overrides for the accounts store / user home directory. ``None``
+        resolves via the same SciTeX local-state cascade
+        ``_select_next_account`` / ``switch_account`` already use.
+        Tests pass explicit ``tmp_path``-rooted values.
+    now
+        Wall-clock override (unix seconds) forwarded to
+        ``_select_next_account``'s credential-freshness check. Tests
+        only.
+
+    Returns
+    -------
+    RotateResult
+
+    Never raises.
+    """
+    # stx-allow: fallback (reason: this runs inside an SDK-conversation exception handler — a second exception here must never mask the original failure the caller is already handling)
+    try:
+        meta = read_credentials_metadata(home=home)
+        current_email = meta.get("email_address")
+        accounts: list[dict[str, Any]] = list_accounts(store_dir=store_dir, home=home)
+        next_acct = _select_next_account(
+            accounts, current_email, store_dir=store_dir, home=home, now=now
+        )
+        if next_acct is None:
+            return RotateResult(
+                action=ACTION_NO_ACCOUNTS,
+                switched_to=None,
+                from_account=current_email,
+                message=(
+                    "reactive-rotate: no HEALTHY non-current account "
+                    "available — staying put on "
+                    f"{current_email or '(unknown account)'}."
+                ),
+            )
+        switch_result = switch_account(
+            next_acct["name"],
+            store_dir=store_dir,
+            home=home,
+            event=ROTATE_EVENT,
+            reason=reason,
+            from_account=current_email,
+        )
+        if not switch_result.get("success"):
+            return RotateResult(
+                action=ACTION_NO_ACCOUNTS,
+                switched_to=None,
+                from_account=current_email,
+                message=(
+                    "reactive-rotate: switch_account failed: "
+                    f"{switch_result.get('message')}"
+                ),
+            )
+        return RotateResult(
+            action=ACTION_ROTATED,
+            switched_to=next_acct.get("name"),
+            from_account=current_email,
+            message=(
+                f"reactive-rotate: switched from {current_email!r} to "
+                f"{next_acct.get('name')!r} ({reason})"
+            ),
+        )
+    except Exception as exc:  # stx-allow: fallback (reason: see function docstring — never raise into the caller's own exception handler)
+        return RotateResult(
+            action=ACTION_NO_ACCOUNTS,
+            switched_to=None,
+            from_account=None,
+            message=f"reactive-rotate: unexpected error: {exc}",
+        )

--- a/src/scitex_agent_container/_runners/_rate_limit_reactive.py
+++ b/src/scitex_agent_container/_runners/_rate_limit_reactive.py
@@ -1,0 +1,334 @@
+# -*- coding: utf-8 -*-
+"""Reactive rate-limit wiring for the conversation supervisor (task #13).
+
+Extracted from :mod:`._session_conversation` (mirrors the sibling
+:mod:`._session_dead_recovery`) so the supervisor's outer ``except``
+block stays a thin dispatcher and this file stays under the project's
+per-file line cap.
+
+:func:`handle_rate_limit_failure` is the supervisor's SECOND recovery
+check — after ``handle_dead_session_resume`` (a stale ``--resume``
+target), before the auth-expired / generic-``sdk-crash``
+classification. Given the SAME ``enriched`` failure text every other
+classifier in that ``except`` block already sees (``str(exc)`` folded
+with captured subprocess stderr), it:
+
+1. detects a REACTIVE rate-limit signal via
+   :func:`_account.rate_limit_signals.detect_signal_from_text` (HTTP
+   status text signatures, then textual cap markers);
+2. joins it with the account's CACHED usage% via
+   :func:`_account.rate_limit_classifier.classify_rate_limit_signal`
+   to get Mode A (BACKOFF) vs Mode B (ROTATE);
+3. dispatches to the action layer — :func:`_account.backoff_agent
+   .backoff_agent` (Mode A) or :func:`_account.rotate_account
+   .rotate_account` (Mode B) — and emits the ``account_backoff`` /
+   ``account_rotated`` observability events via the SAME
+   ``append_session_message`` (session.jsonl) / ``report_sdk_error``
+   (``state.db.errors``) channels every other supervisor event in this
+   file already uses. No new event mechanism invented.
+
+Returns ``ReactiveOutcome(handled=False, ...)`` when ``enriched``
+carries no rate-limit signal — the caller's existing auth/sdk-crash
+classification applies completely unchanged; this module is a pure
+no-op in that case (no event emitted, no state mutated).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+from .._account.backoff_agent import backoff_agent
+from .._account.quota_cache import read_quota_entry
+from .._account.rate_limit_classifier import (
+    AccountUsageSnapshot,
+    Mode,
+    classify_rate_limit_signal,
+)
+from .._account.rate_limit_signals import RateLimitSignal, detect_signal_from_text
+from .._account.rotate_account import rotate_account
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["RATE_LIMITED_CAUSE", "ReactiveOutcome", "handle_rate_limit_failure"]
+
+# Short ``cause`` identifier written to ``state.db.errors`` — distinct
+# from ``auth-expired`` (``_auth_failure.AUTH_FAILURE_CAUSE``),
+# ``dead-session`` (``_dead_session.DEAD_SESSION_CAUSE``), and the
+# generic ``sdk-crash`` so the lead can group on it and the operator
+# immediately sees "this was a provider rate-limit, auto-handled"
+# rather than an ambiguous crash.
+RATE_LIMITED_CAUSE = "rate-limited"
+
+
+@dataclass(frozen=True)
+class ReactiveOutcome:
+    """What the supervisor loop should do after one exception.
+
+    Attributes
+    ----------
+    handled
+        ``False`` — ``enriched`` carried no rate-limit signal (or an
+        internal detector error occurred); the caller's existing
+        auth/sdk-crash classification applies unchanged.
+    reset_attempt
+        ``True`` only after a SUCCESSFUL Mode B rotation — the agent
+        is now on a fresh account, so the caller should reset its
+        ``attempt`` counter to 0 and retry IMMEDIATELY (same contract
+        as ``handle_dead_session_resume``'s ``True`` return), without
+        charging the ``max_restarts`` budget.
+    delay_s
+        Seconds the caller should wait before its next attempt, valid
+        when ``handled`` is ``True`` and ``reset_attempt`` is
+        ``False`` (Mode A, or Mode B with no healthy account to
+        rotate to — "never park" falls back to a backoff-and-retry on
+        the same account rather than giving up). ``None`` otherwise.
+    consecutive_hits
+        The new consecutive-Mode-A-hit count the caller must persist
+        and pass back in as ``consecutive_hits`` on its NEXT call
+        (see :func:`_account.backoff_agent.backoff_agent`). Always 0
+        when ``handled`` is ``False`` or after a successful rotation.
+    """
+
+    handled: bool
+    reset_attempt: bool
+    delay_s: float | None
+    consecutive_hits: int
+
+
+def _not_handled() -> ReactiveOutcome:
+    return ReactiveOutcome(
+        handled=False, reset_attempt=False, delay_s=None, consecutive_hits=0
+    )
+
+
+def _rotated_outcome() -> ReactiveOutcome:
+    return ReactiveOutcome(
+        handled=True, reset_attempt=True, delay_s=0.0, consecutive_hits=0
+    )
+
+
+def _usage_snapshot() -> AccountUsageSnapshot:
+    """Best-effort CACHED usage% for the current agent's account.
+
+    Reads ``quota-cache.json`` (no network call — see
+    :mod:`_account.quota_cache`) keyed by ``$CLAUDE_AGENT_ACCOUNT``.
+    Degrades to the classifier's own zero-usage default when the
+    cache is absent/stale/unreadable/has no matching entry. Zero is
+    the SAFE default here (never over-eagerly rotate when the real
+    usage% is unknown) — mirrors :class:`AccountUsageSnapshot`'s own
+    field defaults.
+    """
+    entry = read_quota_entry()
+    if entry is None:
+        return AccountUsageSnapshot()
+    return AccountUsageSnapshot(
+        used_pct_5h=float(entry.get("h5") or 0.0),
+        used_pct_7d=float(entry.get("d7") or 0.0),
+    )
+
+
+def _emit_error_event(
+    *,
+    state_dir: Path,
+    name: str,
+    host: str | None,
+    enriched: str,
+    attempt: int,
+    stderr_event_fields: dict[str, Any],
+    append_session_message: Callable[[Path, dict], None],
+    report_sdk_error: Callable[..., Any],
+    db_writer: Any,
+) -> None:
+    """Record the underlying failure — mirrors every other classifier
+    in the supervisor's except block: auto-recovering from a
+    rate-limit hit does not make it any less worth recording."""
+    append_session_message(
+        state_dir,
+        {
+            "type": "error",
+            "kind": "rate_limited",
+            "detail": enriched,
+            "attempt": attempt,
+            **stderr_event_fields,
+        },
+    )
+    if host:
+        report_sdk_error(
+            name=name,
+            host=host,
+            cause=RATE_LIMITED_CAUSE,
+            detail=enriched,
+            db_writer=db_writer,
+        )
+
+
+def _try_rotate(
+    *,
+    signal: RateLimitSignal,
+    pattern: str,
+    reason_suffix: str,
+    state_dir: Path,
+    append_session_message: Callable[[Path, dict], None],
+    account_home: Path | None,
+    account_store_dir: Path | None,
+):
+    """Call the Mode B action layer and emit its outcome event.
+
+    ``account_home`` / ``account_store_dir`` are test-injection seams
+    forwarded verbatim to :func:`_account.rotate_account.rotate_account`
+    (``None`` in production — the runner process's own ``$HOME`` IS the
+    agent's credential/account-store home, so no override is needed
+    there; tests pass explicit ``tmp_path``-rooted values so this NEVER
+    touches a real ``~/.claude`` / ``~/.scitex`` directory).
+
+    Returns the raw :class:`_account.rotate_account.RotateResult` so
+    the caller can branch on ``.action``.
+    """
+    result = rotate_account(
+        reason=f"reactive {signal.value} (pattern={pattern!r}) {reason_suffix}",
+        home=account_home,
+        store_dir=account_store_dir,
+    )
+    append_session_message(
+        state_dir,
+        {
+            "type": "supervisor",
+            "event": (
+                "account_rotated" if result.action == "rotated" else "account_rotate_skipped"
+            ),
+            "signal": signal.value,
+            "pattern": pattern,
+            "switched_to": result.switched_to,
+            "from_account": result.from_account,
+            "detail": result.message,
+        },
+    )
+    return result
+
+
+def handle_rate_limit_failure(
+    *,
+    enriched: str,
+    state_dir: Path,
+    name: str,
+    host: str | None,
+    attempt: int,
+    consecutive_hits: int,
+    stderr_event_fields: dict[str, Any],
+    append_session_message: Callable[[Path, dict], None],
+    report_sdk_error: Callable[..., Any],
+    db_writer: Any,
+    account_home: Path | None = None,
+    account_store_dir: Path | None = None,
+) -> ReactiveOutcome:
+    """Detect + auto-handle a reactive rate-limit failure, in place.
+
+    ``account_home`` / ``account_store_dir`` are forwarded verbatim to
+    every Mode B rotation attempt — see :func:`_try_rotate`. Both
+    default to ``None`` (production: the runner process's own
+    ``$HOME``); tests pass explicit ``tmp_path``-rooted values.
+
+    See module docstring for the full flow. Never raises — mirrors
+    every other classifier in the supervisor's ``except`` block: a
+    detector bug here must never mask the ORIGINAL SDK failure it is
+    trying to classify, so any internal error degrades to
+    ``handled=False`` (fall through to the caller's generic handling).
+    """
+    # stx-allow: fallback (reason: see function docstring — must never raise into the supervisor's own exception handler)
+    try:
+        hit = detect_signal_from_text(enriched)
+        if hit is None:
+            return _not_handled()
+        signal, pattern = hit
+        # NONE is currently unreachable for any signal
+        # detect_signal_from_text can produce (HTTP_429/403 are always
+        # BACKOFF-or-ROTATE, HTTP_529 is always BACKOFF, TEXTUAL_MATCH
+        # is always ROTATE) — kept as a defensive fall-through in case
+        # the detector grows a new signal type later.
+        mode = classify_rate_limit_signal(signal, _usage_snapshot())
+        if mode is Mode.NONE:
+            return _not_handled()
+
+        _emit_error_event(
+            state_dir=state_dir,
+            name=name,
+            host=host,
+            enriched=enriched,
+            attempt=attempt,
+            stderr_event_fields=stderr_event_fields,
+            append_session_message=append_session_message,
+            report_sdk_error=report_sdk_error,
+            db_writer=db_writer,
+        )
+        logger.warning(
+            "claude-session RATE LIMITED for %s: signal=%s pattern=%r mode=%s",
+            name,
+            signal.value,
+            pattern,
+            mode.value,
+        )
+
+        already_tried_rotate = False
+        if mode is Mode.ROTATE:
+            result = _try_rotate(
+                signal=signal,
+                pattern=pattern,
+                reason_suffix=f"attempt={attempt}",
+                state_dir=state_dir,
+                append_session_message=append_session_message,
+                account_home=account_home,
+                account_store_dir=account_store_dir,
+            )
+            already_tried_rotate = True
+            if result.action == "rotated":
+                return _rotated_outcome()
+            # No healthy account to rotate to — "never park": fall
+            # through to Mode A so the agent still retries instead of
+            # dying on the (still-capped) current account.
+
+        decision = backoff_agent(prior_consecutive_hits=consecutive_hits)
+        if decision.escalate_to_rotate and not already_tried_rotate:
+            result = _try_rotate(
+                signal=signal,
+                pattern=pattern,
+                reason_suffix=(
+                    f"escalated after {decision.hit_count} consecutive backoffs"
+                ),
+                state_dir=state_dir,
+                append_session_message=append_session_message,
+                account_home=account_home,
+                account_store_dir=account_store_dir,
+            )
+            if result.action == "rotated":
+                return _rotated_outcome()
+
+        append_session_message(
+            state_dir,
+            {
+                "type": "supervisor",
+                "event": "account_backoff",
+                "signal": signal.value,
+                "pattern": pattern,
+                "delay_s": decision.delay_s,
+                "hit_count": decision.hit_count,
+            },
+        )
+        return ReactiveOutcome(
+            handled=True,
+            reset_attempt=False,
+            delay_s=decision.delay_s,
+            consecutive_hits=decision.hit_count,
+        )
+    except Exception as exc:  # stx-allow: fallback (reason: see function docstring)
+        logger.warning(
+            "handle_rate_limit_failure: internal error (falling through to "
+            "generic sdk-crash classification): %s",
+            exc,
+        )
+        return _not_handled()
+
+
+# EOF

--- a/src/scitex_agent_container/_runners/_session_conversation.py
+++ b/src/scitex_agent_container/_runners/_session_conversation.py
@@ -22,16 +22,20 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import os
 from pathlib import Path
 from typing import Any
 
+from ._rate_limit_reactive import handle_rate_limit_failure
 from ._session_dead_recovery import handle_dead_session_resume
 from ._session_state import (
     append_session_message,
-    read_session_id,
-    read_session_id_history,
     report_sdk_error,
+)
+from ._session_supervisor_helpers import (
+    _drain_failed_inbox as _drain_failed_inbox,
+    _maybe_compact as _maybe_compact,
+    _resume_candidate as _resume_candidate,
+    _wake_on_inbound as _wake_on_inbound,
 )
 from ._session_tasks import (
     TaskObservations,
@@ -50,148 +54,6 @@ from ._stderr_capture import (
 )
 
 logger = logging.getLogger(__name__)
-
-
-async def _maybe_compact(client: Any, *, name: str) -> None:
-    """Proactively summarize the conversation when context nears the model
-    window. Provider-backed agents on a small window (e.g. Qwen36 at 128k
-    via the LiteLLM shim) overflow because the CLI's native auto-compaction
-    can't know a PROXIED model's real context size, so it never compacts
-    before the model rejects the prompt (cohort-A Qwen de-risk 2026-06-24:
-    122881 input + 8192 output > 131072 = ContextWindowExceededError).
-
-    Gated by ``SAC_AUTO_COMPACT_TOKENS`` (0/unset = off, so the Anthropic
-    path keeps the CLI's own window-aware auto-compaction). When >0, read
-    the live ``totalTokens`` from ``client.get_context_usage()`` — the
-    ABSOLUTE count, NOT the CLI's ``percentage``/``maxTokens`` which assume
-    the wrong window for a proxied model — and inject ``/compact`` once it
-    crosses the threshold. Best-effort: any failure here must never kill a
-    live solve.
-    """
-    try:
-        threshold = int(os.environ.get("SAC_AUTO_COMPACT_TOKENS", "0") or "0")
-    except ValueError:
-        threshold = 0
-    if threshold <= 0:
-        return
-    try:
-        usage = await client.get_context_usage()
-    except Exception as exc:  # stx-allow: fallback (reason: usage probe is best-effort; never fail a turn on it)
-        logger.debug("auto-compact: get_context_usage failed (skipping): %s", exc)
-        return
-    total = usage.get("totalTokens") if isinstance(usage, dict) else None
-    if not isinstance(total, (int, float)) or total < threshold:
-        return
-    max_tokens = usage.get("maxTokens") if isinstance(usage, dict) else None
-    pct = usage.get("percentage") if isinstance(usage, dict) else None
-    logger.warning(
-        "auto-compact: totalTokens=%d >= %d for %s (maxTokens=%s pct=%s) — injecting /compact",
-        int(total),
-        threshold,
-        name,
-        max_tokens,
-        pct,
-    )
-    try:
-        await client.query("/compact")
-        async for _msg in client.receive_response():
-            pass
-        logger.info("auto-compact: /compact completed for %s", name)
-    except Exception as exc:  # stx-allow: fallback (reason: compaction is best-effort; a failed /compact must not kill the solve)
-        logger.warning("auto-compact: /compact failed for %s: %s", name, exc)
-
-
-def _drain_failed_inbox(inbox: "asyncio.Queue", exc: BaseException) -> None:
-    """Resolve pending turn futures with the failure so producers don't hang."""
-    from ._session_inbox import TurnEnvelope
-
-    while not inbox.empty():
-        try:
-            env = inbox.get_nowait()
-        except asyncio.QueueEmpty:
-            break
-        if isinstance(env, TurnEnvelope) and not env.response.done():
-            env.response.set_exception(exc)
-
-
-async def _wake_on_inbound(inbox, client) -> None:
-    """Watch ``inbox`` while a turn is in flight; interrupt the SDK
-    when the next envelope arrives so the consumer loop can dequeue it.
-
-    Pairs 1:1 with each ``_drive_turn`` invocation (#41, lead a2a
-    ``f39bdcc5`` + ``b4e223e0``). The conversation loop spawns this as
-    a sibling task, lets it await on the inbox's non-destructive
-    "queue is non-empty" event, and cancels it in ``finally`` so it
-    cannot leak across turn boundaries.
-
-    Semantics:
-
-    * ``await inbox.wait_for_item()`` returns when the queue's
-      ``_not_empty`` event fires — i.e. the next envelope has been put
-      AND has not yet been consumed by the conversation loop. Because
-      this loop's ``inbox.get()`` already consumed the CURRENT
-      envelope, the wake fires only on a NEW envelope queued mid-turn.
-    * On wake, ``await client.interrupt()`` asks the SDK to stop the
-      current iterator. The SDK guarantee (verified empirically in
-      :mod:`_session_turn`) is that any in-flight assistant text /
-      tool-result is already captured in ``chunks`` by the time the
-      iterator returns — so the interrupt does NOT corrupt or tear
-      the current turn. The new envelope is then processed as a
-      clean FOLLOW-UP message in the next loop iteration.
-    * Exceptions from ``interrupt`` are swallowed (logged WARNING)
-      because the wake task must NEVER kill the conversation loop;
-      worst case the original turn finishes naturally and the new
-      envelope is processed one turn-cap later.
-
-    The wake task EXITS after one interrupt — there's only ever one
-    in-flight turn, and the consumer loop will spawn a fresh wake
-    task for the next turn.
-    """
-    try:
-        await inbox.wait_for_item()
-    except asyncio.CancelledError:
-        # Normal path when the turn completed before any new envelope
-        # arrived — the consumer cancels us in ``finally``.
-        raise
-    try:
-        await client.interrupt()
-    except asyncio.CancelledError:
-        raise
-    except Exception as exc:  # stx-allow: fallback (reason: wake task is best-effort; never let SDK interrupt failure kill the conversation loop — the original turn will finish naturally instead)
-        logger.warning(
-            "wake-on-inbound: client.interrupt() failed (turn will "
-            "finish naturally before the new envelope is processed): %s",
-            exc,
-        )
-
-
-def _resume_candidate(
-    state_dir: Path,
-    *,
-    attempt: int,
-    fallback: str | None,
-) -> str | None:
-    """Pick the resume session_id for supervisor restart ``attempt``.
-
-    Walks the append-only ``session_id_history`` from latest to oldest:
-    ``attempt`` 0 → latest, 1 → next-older, etc. This lets a supervised
-    restart retry a prior still-on-disk id when the latest one was
-    forked or aged out and its resume is rejected.
-
-    - ``attempt`` within the history range → that id (latest-first).
-    - ``attempt == 0`` with no history yet → ``read_session_id`` if
-      present else ``fallback`` (preserves the pre-history behaviour for
-      the very first start, before any turn has recorded an id).
-    - ``attempt`` beyond the history → ``None`` (history exhausted →
-      fresh start, resume disabled).
-    """
-    history = read_session_id_history(state_dir)
-    candidates = list(reversed(history))  # latest-first
-    if attempt < len(candidates):
-        return candidates[attempt]
-    if attempt == 0:
-        return read_session_id(state_dir) or fallback
-    return None
 
 
 async def run_conversation(
@@ -308,6 +170,11 @@ async def run_conversation(
     # terminates instead of spinning forever. One per distinct dead id is
     # the realistic ceiling — the latest + every forked id in the history.
     dead_session_recoveries = 0
+    # Consecutive REACTIVE rate-limit (Mode A backoff) hits, back-to-back
+    # with no intervening non-rate-limit failure or successful rotation.
+    # Owned by ``handle_rate_limit_failure`` / ``_account.backoff_agent``
+    # (task #13) — see ``_rate_limit_reactive`` module docstring.
+    consecutive_rate_limit_hits = 0
     last_exc: BaseException | None = None
     while True:
         # Resume target, with history fallback. On the first attempt this
@@ -530,6 +397,44 @@ async def run_conversation(
                 dead_session_recoveries += 1
                 attempt = 0
                 resume_session_id = None
+                continue
+
+            # Reactive rate-limit (task #13): detect + Mode A/B dispatch
+            # delegated to ``_rate_limit_reactive``. ``handled=False`` ->
+            # no rate-limit signal -> fall through unchanged below.
+            rl_outcome = handle_rate_limit_failure(
+                enriched=enriched,
+                state_dir=state_dir,
+                name=name,
+                host=host,
+                attempt=attempt,
+                consecutive_hits=consecutive_rate_limit_hits,
+                stderr_event_fields=stderr_event_fields,
+                append_session_message=append_session_message,
+                report_sdk_error=report_sdk_error,
+                db_writer=db_writer,
+            )
+            consecutive_rate_limit_hits = rl_outcome.consecutive_hits
+            if rl_outcome.handled and rl_outcome.reset_attempt:
+                # Mode B rotated onto a fresh account: retry now, same
+                # contract as a handled dead-session recovery.
+                attempt = 0
+                continue
+            if rl_outcome.handled:
+                # Mode A (or Mode B with nowhere to rotate to — "never
+                # park", fall back to same-account backoff). Respects
+                # max_restarts/stop; waits rl_outcome.delay_s instead of
+                # the generic exponential backoff.
+                if attempt >= max_restarts or stop.is_set():
+                    _drain_failed_inbox(inbox, exc)
+                    return
+                try:
+                    await asyncio.wait_for(stop.wait(), timeout=rl_outcome.delay_s)
+                    _drain_failed_inbox(inbox, last_exc)
+                    return
+                except asyncio.TimeoutError:
+                    pass
+                attempt += 1
                 continue
 
             auth_detail = classify_auth_failure(enriched)

--- a/src/scitex_agent_container/_runners/_session_supervisor_helpers.py
+++ b/src/scitex_agent_container/_runners/_session_supervisor_helpers.py
@@ -1,0 +1,185 @@
+# -*- coding: utf-8 -*-
+"""Supervisor-loop helpers for the claude-session conversation runner.
+
+Extracted from :mod:`._session_conversation` (which was over the
+project's per-file line cap) so that module stays focused on the
+``run_conversation`` orchestration itself. These four functions are
+pure relocations — none call back into ``run_conversation`` or hold
+module-level state, they take everything they need as parameters — so
+the split is not a behavioural change. ``_session_conversation``
+re-exports all four under their original names so every existing
+import site (``claude_session.py``'s ``_drain_failed_inbox``
+re-export, the test suite's direct ``_resume_candidate`` import, the
+``_wake_on_inbound`` behaviour exercised indirectly through
+``run_conversation``) keeps resolving unchanged.
+
+* :func:`_maybe_compact` — proactive auto-compaction for
+  provider-backed agents on a small context window.
+* :func:`_drain_failed_inbox` — resolve pending turn futures with a
+  failure so producers don't hang.
+* :func:`_wake_on_inbound` — watch the inbox mid-turn, interrupt the
+  SDK client when a new envelope arrives.
+* :func:`_resume_candidate` — pick the resume session_id for a
+  supervised restart attempt (walks session_id_history latest-first).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+from ._session_state import read_session_id, read_session_id_history
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "_drain_failed_inbox",
+    "_maybe_compact",
+    "_resume_candidate",
+    "_wake_on_inbound",
+]
+
+
+async def _maybe_compact(client: Any, *, name: str) -> None:
+    """Proactively summarize the conversation when context nears the model
+    window. Provider-backed agents on a small window (e.g. Qwen36 at 128k
+    via the LiteLLM shim) overflow because the CLI's native auto-compaction
+    can't know a PROXIED model's real context size, so it never compacts
+    before the model rejects the prompt (cohort-A Qwen de-risk 2026-06-24:
+    122881 input + 8192 output > 131072 = ContextWindowExceededError).
+
+    Gated by ``SAC_AUTO_COMPACT_TOKENS`` (0/unset = off, so the Anthropic
+    path keeps the CLI's own window-aware auto-compaction). When >0, read
+    the live ``totalTokens`` from ``client.get_context_usage()`` — the
+    ABSOLUTE count, NOT the CLI's ``percentage``/``maxTokens`` which assume
+    the wrong window for a proxied model — and inject ``/compact`` once it
+    crosses the threshold. Best-effort: any failure here must never kill a
+    live solve.
+    """
+    try:
+        threshold = int(os.environ.get("SAC_AUTO_COMPACT_TOKENS", "0") or "0")
+    except ValueError:
+        threshold = 0
+    if threshold <= 0:
+        return
+    try:
+        usage = await client.get_context_usage()
+    except Exception as exc:  # stx-allow: fallback (reason: usage probe is best-effort; never fail a turn on it)
+        logger.debug("auto-compact: get_context_usage failed (skipping): %s", exc)
+        return
+    total = usage.get("totalTokens") if isinstance(usage, dict) else None
+    if not isinstance(total, (int, float)) or total < threshold:
+        return
+    max_tokens = usage.get("maxTokens") if isinstance(usage, dict) else None
+    pct = usage.get("percentage") if isinstance(usage, dict) else None
+    logger.warning(
+        "auto-compact: totalTokens=%d >= %d for %s (maxTokens=%s pct=%s) — injecting /compact",
+        int(total),
+        threshold,
+        name,
+        max_tokens,
+        pct,
+    )
+    try:
+        await client.query("/compact")
+        async for _msg in client.receive_response():
+            pass
+        logger.info("auto-compact: /compact completed for %s", name)
+    except Exception as exc:  # stx-allow: fallback (reason: compaction is best-effort; a failed /compact must not kill the solve)
+        logger.warning("auto-compact: /compact failed for %s: %s", name, exc)
+
+
+def _drain_failed_inbox(inbox: "asyncio.Queue", exc: BaseException) -> None:
+    """Resolve pending turn futures with the failure so producers don't hang."""
+    from ._session_inbox import TurnEnvelope
+
+    while not inbox.empty():
+        try:
+            env = inbox.get_nowait()
+        except asyncio.QueueEmpty:
+            break
+        if isinstance(env, TurnEnvelope) and not env.response.done():
+            env.response.set_exception(exc)
+
+
+async def _wake_on_inbound(inbox, client) -> None:
+    """Watch ``inbox`` while a turn is in flight; interrupt the SDK
+    when the next envelope arrives so the consumer loop can dequeue it.
+
+    Pairs 1:1 with each ``_drive_turn`` invocation (#41, lead a2a
+    ``f39bdcc5`` + ``b4e223e0``). The conversation loop spawns this as
+    a sibling task, lets it await on the inbox's non-destructive
+    "queue is non-empty" event, and cancels it in ``finally`` so it
+    cannot leak across turn boundaries.
+
+    Semantics:
+
+    * ``await inbox.wait_for_item()`` returns when the queue's
+      ``_not_empty`` event fires — i.e. the next envelope has been put
+      AND has not yet been consumed by the conversation loop. Because
+      this loop's ``inbox.get()`` already consumed the CURRENT
+      envelope, the wake fires only on a NEW envelope queued mid-turn.
+    * On wake, ``await client.interrupt()`` asks the SDK to stop the
+      current iterator. The SDK guarantee (verified empirically in
+      :mod:`_session_turn`) is that any in-flight assistant text /
+      tool-result is already captured in ``chunks`` by the time the
+      iterator returns — so the interrupt does NOT corrupt or tear
+      the current turn. The new envelope is then processed as a
+      clean FOLLOW-UP message in the next loop iteration.
+    * Exceptions from ``interrupt`` are swallowed (logged WARNING)
+      because the wake task must NEVER kill the conversation loop;
+      worst case the original turn finishes naturally and the new
+      envelope is processed one turn-cap later.
+
+    The wake task EXITS after one interrupt — there's only ever one
+    in-flight turn, and the consumer loop will spawn a fresh wake
+    task for the next turn.
+    """
+    try:
+        await inbox.wait_for_item()
+    except asyncio.CancelledError:
+        # Normal path when the turn completed before any new envelope
+        # arrived — the consumer cancels us in ``finally``.
+        raise
+    try:
+        await client.interrupt()
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:  # stx-allow: fallback (reason: wake task is best-effort; never let SDK interrupt failure kill the conversation loop — the original turn will finish naturally instead)
+        logger.warning(
+            "wake-on-inbound: client.interrupt() failed (turn will "
+            "finish naturally before the new envelope is processed): %s",
+            exc,
+        )
+
+
+def _resume_candidate(
+    state_dir: Path,
+    *,
+    attempt: int,
+    fallback: str | None,
+) -> str | None:
+    """Pick the resume session_id for supervisor restart ``attempt``.
+
+    Walks the append-only ``session_id_history`` from latest to oldest:
+    ``attempt`` 0 → latest, 1 → next-older, etc. This lets a supervised
+    restart retry a prior still-on-disk id when the latest one was
+    forked or aged out and its resume is rejected.
+
+    - ``attempt`` within the history range → that id (latest-first).
+    - ``attempt == 0`` with no history yet → ``read_session_id`` if
+      present else ``fallback`` (preserves the pre-history behaviour for
+      the very first start, before any turn has recorded an id).
+    - ``attempt`` beyond the history → ``None`` (history exhausted →
+      fresh start, resume disabled).
+    """
+    history = read_session_id_history(state_dir)
+    candidates = list(reversed(history))  # latest-first
+    if attempt < len(candidates):
+        return candidates[attempt]
+    if attempt == 0:
+        return read_session_id(state_dir) or fallback
+    return None

--- a/tests/scitex_agent_container/_account/test_backoff_agent.py
+++ b/tests/scitex_agent_container/_account/test_backoff_agent.py
@@ -1,0 +1,188 @@
+"""Tests for the Mode A action layer (task #13, op-2026-06-12-13).
+
+``backoff_agent`` is the per-agent transient-rate-limit backoff
+decision: how long to wait before retrying the SAME account, plus the
+consecutive-hit escalation accounting the classifier's docstring
+reserves for the action layer ("5 backoffs in a row -> escalate to
+ROTATE"). Pure function — no sleep, no IO, no clock read.
+
+Test style (STX-TQ002 / STX-TQ007): explicit ``# Arrange`` / ``# Act``
+/ ``# Assert`` markers each on their own line, in order; one logical
+assertion per test. No mocks.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scitex_agent_container._account.backoff_agent import (
+    DEFAULT_ESCALATE_AFTER,
+    DEFAULT_MIN_BACKOFF_S,
+    BackoffDecision,
+    backoff_agent,
+)
+
+# ---------------------------------------------------------------------------
+# delay_s — floor vs exponential ramp
+# ---------------------------------------------------------------------------
+
+
+def test_first_hit_delay_is_the_floor_not_the_tiny_exponential_start():
+    # Arrange — base_delay_s=1.0 at prior_consecutive_hits=0 would be 1.0s,
+    # far too fast for a real provider rate-limit window.
+    decision = backoff_agent(prior_consecutive_hits=0)
+    # Act
+    delay = decision.delay_s
+    # Assert
+    assert delay == DEFAULT_MIN_BACKOFF_S
+
+
+def test_exponential_ramp_overtakes_the_floor_once_high_enough():
+    # Arrange — base=1.0, prior=5 -> exponential=32.0 > floor=30.0.
+    decision = backoff_agent(prior_consecutive_hits=5)
+    # Act
+    delay = decision.delay_s
+    # Assert
+    assert delay == 32.0
+
+
+def test_delay_never_drops_below_the_custom_floor():
+    # Arrange
+    decision = backoff_agent(prior_consecutive_hits=0, min_backoff_s=5.0)
+    # Act
+    delay = decision.delay_s
+    # Assert
+    assert delay == 5.0
+
+
+def test_custom_base_delay_feeds_the_exponential_ramp():
+    # Arrange — base=10.0, prior=1 -> exponential=20.0 > floor=5.0.
+    decision = backoff_agent(
+        prior_consecutive_hits=1, base_delay_s=10.0, min_backoff_s=5.0
+    )
+    # Act
+    delay = decision.delay_s
+    # Assert
+    assert delay == 20.0
+
+
+# ---------------------------------------------------------------------------
+# hit_count bookkeeping
+# ---------------------------------------------------------------------------
+
+
+def test_hit_count_increments_prior_by_one():
+    # Arrange
+    decision = backoff_agent(prior_consecutive_hits=2)
+    # Act
+    hit_count = decision.hit_count
+    # Assert
+    assert hit_count == 3
+
+
+def test_zero_prior_hits_yields_hit_count_one():
+    # Arrange
+    decision = backoff_agent(prior_consecutive_hits=0)
+    # Act
+    hit_count = decision.hit_count
+    # Assert
+    assert hit_count == 1
+
+
+def test_negative_prior_hits_raises_value_error():
+    # Arrange
+    raised: BaseException | None = None
+    # Act
+    try:
+        backoff_agent(prior_consecutive_hits=-1)
+    except ValueError as exc:  # stx-allow: test-capture (reason: STX-TQ002 splits Act from Assert; the raise IS the act, capturing lets the Assert check the type.)
+        raised = exc
+    # Assert
+    assert isinstance(raised, ValueError)
+
+
+# ---------------------------------------------------------------------------
+# escalate_to_rotate — consecutive-hit escalation guard
+# ---------------------------------------------------------------------------
+
+
+def test_escalation_does_not_fire_below_threshold():
+    # Arrange — prior=3 -> hit_count=4 < default escalate_after=5.
+    decision = backoff_agent(prior_consecutive_hits=3)
+    # Act
+    escalate = decision.escalate_to_rotate
+    # Assert
+    assert escalate is False
+
+
+def test_escalation_fires_exactly_at_threshold():
+    # Arrange — prior=4 -> hit_count=5 == default escalate_after=5.
+    decision = backoff_agent(prior_consecutive_hits=4)
+    # Act
+    escalate = decision.escalate_to_rotate
+    # Assert
+    assert escalate is True
+
+
+def test_escalation_stays_true_beyond_threshold():
+    # Arrange
+    decision = backoff_agent(prior_consecutive_hits=10)
+    # Act
+    escalate = decision.escalate_to_rotate
+    # Assert
+    assert escalate is True
+
+
+def test_custom_escalate_after_is_honoured():
+    # Arrange — prior=1 -> hit_count=2 == custom escalate_after=2.
+    decision = backoff_agent(prior_consecutive_hits=1, escalate_after=2)
+    # Act
+    escalate = decision.escalate_to_rotate
+    # Assert
+    assert escalate is True
+
+
+def test_default_escalate_after_constant_is_five():
+    # Arrange
+    value = DEFAULT_ESCALATE_AFTER
+    # Act
+    matches = value == 5
+    # Assert
+    assert matches is True
+
+
+# ---------------------------------------------------------------------------
+# BackoffDecision — frozen dataclass contract
+# ---------------------------------------------------------------------------
+
+
+def test_backoff_decision_is_frozen_against_mutation():
+    # Arrange
+    decision = backoff_agent(prior_consecutive_hits=0)
+    raised: BaseException | None = None
+    # Act
+    try:
+        decision.delay_s = 999.0  # type: ignore[misc]
+    except Exception as exc:  # stx-allow: test-capture (reason: STX-TQ002 splits Act from Assert; frozen mutation is the Act.)
+        raised = exc
+    # Assert
+    assert raised is not None
+
+
+def test_backoff_agent_returns_backoff_decision_instance():
+    # Arrange
+    decision = backoff_agent(prior_consecutive_hits=0)
+    # Act
+    is_decision = isinstance(decision, BackoffDecision)
+    # Assert
+    assert is_decision is True
+
+
+@pytest.mark.parametrize("prior", [0, 1, 2, 3, 4, 5, 100])
+def test_delay_s_is_always_at_least_the_floor(prior):
+    # Arrange
+    decision = backoff_agent(prior_consecutive_hits=prior)
+    # Act
+    at_least_floor = decision.delay_s >= DEFAULT_MIN_BACKOFF_S
+    # Assert
+    assert at_least_floor is True

--- a/tests/scitex_agent_container/_account/test_rate_limit_signals.py
+++ b/tests/scitex_agent_container/_account/test_rate_limit_signals.py
@@ -20,6 +20,7 @@ from scitex_agent_container._account.rate_limit_signals import (
     DEFAULT_TEXTUAL_PATTERNS,
     RateLimitSignal,
     classify_http_status,
+    detect_signal_from_text,
     scan_textual_cap_markers,
 )
 
@@ -200,3 +201,113 @@ def test_default_textual_patterns_is_a_tuple():
     is_tuple = isinstance(patterns, tuple)
     # Assert
     assert is_tuple is True
+
+
+# ---------------------------------------------------------------------------
+# detect_signal_from_text — REACTIVE entry point (task #13 wiring)
+# ---------------------------------------------------------------------------
+
+
+def test_detect_signal_from_text_empty_string_returns_none():
+    # Arrange
+    text = ""
+    # Act
+    result = detect_signal_from_text(text)
+    # Assert
+    assert result is None
+
+
+def test_detect_signal_from_text_unrelated_text_returns_none():
+    # Arrange
+    text = "connection reset by peer"
+    # Act
+    result = detect_signal_from_text(text)
+    # Assert
+    assert result is None
+
+
+def test_detect_signal_from_text_anthropic_rate_limit_error_type():
+    # Arrange — the real Anthropic JSON error body shape.
+    text = '{"type":"error","error":{"type":"rate_limit_error","message":"..."}}'
+    # Act
+    result = detect_signal_from_text(text)
+    # Assert
+    assert result is not None and result[0] is RateLimitSignal.HTTP_429
+
+
+def test_detect_signal_from_text_anthropic_overloaded_error_type():
+    # Arrange
+    text = '{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}'
+    # Act
+    result = detect_signal_from_text(text)
+    # Assert
+    assert result is not None and result[0] is RateLimitSignal.HTTP_529
+
+
+def test_detect_signal_from_text_bare_429_word_boundary():
+    # Arrange
+    text = "ProcessError: API Error: 429 Too Many Requests"
+    # Act
+    result = detect_signal_from_text(text)
+    # Assert
+    assert result is not None and result[0] is RateLimitSignal.HTTP_429
+
+
+def test_detect_signal_from_text_bare_529_word_boundary():
+    # Arrange
+    text = "ProcessError: API Error: 529 Overloaded"
+    # Act
+    result = detect_signal_from_text(text)
+    # Assert
+    assert result is not None and result[0] is RateLimitSignal.HTTP_529
+
+
+def test_detect_signal_from_text_bare_403_word_boundary():
+    # Arrange
+    text = "ProcessError: API Error: 403 Forbidden — organization rate limit"
+    # Act
+    result = detect_signal_from_text(text)
+    # Assert
+    assert result is not None and result[0] is RateLimitSignal.HTTP_403
+
+
+def test_detect_signal_from_text_does_not_misfire_on_unrelated_number():
+    # Arrange — "429" does NOT appear anywhere here; only an unrelated
+    # numeric substring risk-case ("42900" contains "429" but not as a
+    # word-boundary token).
+    text = "processed 42900 rows in 12ms"
+    # Act
+    result = detect_signal_from_text(text)
+    # Assert
+    assert result is None
+
+
+def test_detect_signal_from_text_falls_back_to_textual_cap_marker():
+    # Arrange — no HTTP-status signature present, only the textual marker.
+    text = "You've hit your weekly limit · resets 2026-06-18T05:00Z"
+    # Act
+    result = detect_signal_from_text(text)
+    # Assert
+    assert result is not None and result[0] is RateLimitSignal.TEXTUAL_MATCH
+
+
+def test_detect_signal_from_text_status_signature_wins_over_textual_order():
+    # Arrange — rate_limit_error appears first in the scan order; a
+    # textual marker later in the SAME text must not override it.
+    text = (
+        '{"type":"error","error":{"type":"rate_limit_error"}} '
+        "— quota exceeded"
+    )
+    # Act
+    result = detect_signal_from_text(text)
+    # Assert
+    assert result is not None and result[0] is RateLimitSignal.HTTP_429
+
+
+def test_detect_signal_from_text_returns_the_matched_pattern():
+    # Arrange
+    text = '{"error":{"type":"overloaded_error"}}'
+    # Act
+    result = detect_signal_from_text(text)
+    # Assert
+    assert result is not None and result[1] == "overloaded_error"

--- a/tests/scitex_agent_container/_account/test_rotate_account.py
+++ b/tests/scitex_agent_container/_account/test_rotate_account.py
@@ -1,0 +1,245 @@
+"""Tests for the Mode B action layer (task #13, op-2026-06-12-13).
+
+``rotate_account`` reuses ``quota_watch._select_next_account`` (health
+gate + lowest-5h-usage pick) and ``account_store.switch_account``
+(credential copy + rotation audit) — the SAME primitives the periodic
+``sac accounts watch-quota`` loop already relies on — skipping only
+the proactive threshold/``fetch_usage`` gate, because a REACTIVE
+caller already knows a rotation is warranted.
+
+Fixtures mirror ``test_quota_watch.py``'s ``_make_home`` / `_make_store`
+helpers exactly (same on-disk shapes ``_select_next_account`` /
+``switch_account`` already read) so this test suite exercises the
+real filesystem primitives, no mocks, and — critically — every call
+passes explicit ``home=`` / ``store_dir=`` so nothing ever falls back
+to the real ``Path.home()`` / SciTeX local-state cascade.
+
+Test style (STX-TQ002 / STX-TQ007): explicit ``# Arrange`` / ``# Act``
+/ ``# Assert`` markers each on their own line, in order; one logical
+assertion per test.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+from scitex_agent_container._account.rotate_account import (
+    ROTATE_EVENT,
+    RotateResult,
+    rotate_account,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures (mirrors test_quota_watch.py's _make_home / _make_store)
+# ---------------------------------------------------------------------------
+
+
+def _make_home(tmp_path: Path, email: str = "primary@example.com") -> Path:
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".claude").mkdir()
+    (home / ".claude.json").write_text(
+        json.dumps({"oauthAccount": {"emailAddress": email}})
+    )
+    return home
+
+
+def _make_store(tmp_path: Path, accounts: list[dict]) -> Path:
+    """Populate a fake accounts store. ``_health`` control key: see
+    test_quota_watch.py's identical helper for the full contract
+    (``"valid"`` / ``"expired"`` / ``"absent"``)."""
+    future_ms = int((time.time() + 30 * 24 * 3600) * 1000)
+    past_ms = int((time.time() - 24 * 3600) * 1000)
+    store = tmp_path / "store"
+    store.mkdir()
+    for raw in accounts:
+        acct = dict(raw)
+        health = acct.pop("_health", "valid")
+        name = acct["name"]
+        cred_dir = store / name
+        cred_dir.mkdir()
+        (cred_dir / "account.json").write_text(json.dumps(acct))
+        if health == "absent":
+            continue
+        expires = future_ms if health == "valid" else past_ms
+        (cred_dir / ".credentials.json").write_text(
+            json.dumps({"claudeAiOauth": {"expiresAt": expires}})
+        )
+    return store
+
+
+# ---------------------------------------------------------------------------
+# Successful rotation
+# ---------------------------------------------------------------------------
+
+
+def test_rotate_account_switches_to_healthy_candidate(tmp_path):
+    # Arrange
+    home = _make_home(tmp_path)
+    store = _make_store(
+        tmp_path, [{"name": "backup", "email_address": "backup@example.com"}]
+    )
+    # Act
+    result = rotate_account(reason="test", store_dir=store, home=home)
+    # Assert
+    assert result.action == "rotated"
+
+
+def test_rotate_account_switched_to_names_the_target_account(tmp_path):
+    # Arrange
+    home = _make_home(tmp_path)
+    store = _make_store(
+        tmp_path, [{"name": "backup", "email_address": "backup@example.com"}]
+    )
+    # Act
+    result = rotate_account(reason="test", store_dir=store, home=home)
+    # Assert
+    assert result.switched_to == "backup"
+
+
+def test_rotate_account_from_account_records_current_email(tmp_path):
+    # Arrange
+    home = _make_home(tmp_path, email="primary@example.com")
+    store = _make_store(
+        tmp_path, [{"name": "backup", "email_address": "backup@example.com"}]
+    )
+    # Act
+    result = rotate_account(reason="test", store_dir=store, home=home)
+    # Assert
+    assert result.from_account == "primary@example.com"
+
+
+def test_rotate_account_message_carries_the_reason(tmp_path):
+    # Arrange
+    home = _make_home(tmp_path)
+    store = _make_store(
+        tmp_path, [{"name": "backup", "email_address": "backup@example.com"}]
+    )
+    # Act
+    result = rotate_account(
+        reason="reactive http_429 (pattern='\\\\b429\\\\b')", store_dir=store, home=home
+    )
+    # Assert
+    assert "http_429" in result.message
+
+
+def test_rotate_account_actually_copies_credential_file(tmp_path):
+    # Arrange
+    home = _make_home(tmp_path)
+    store = _make_store(
+        tmp_path, [{"name": "backup", "email_address": "backup@example.com"}]
+    )
+    # Act
+    rotate_account(reason="test", store_dir=store, home=home)
+    # Assert — switch_account's real effect: the live credentials file
+    # now exists under home/.claude/ (copied from the backup snapshot).
+    assert (home / ".claude" / ".credentials.json").is_file()
+
+
+def test_rotate_account_picks_lowest_quota_among_multiple_healthy(tmp_path):
+    # Arrange
+    home = _make_home(tmp_path)
+    store = _make_store(
+        tmp_path,
+        [
+            {"name": "high", "email_address": "high@example.com", "quota_5h_used_pct": 70.0},
+            {"name": "low", "email_address": "low@example.com", "quota_5h_used_pct": 5.0},
+        ],
+    )
+    # Act
+    result = rotate_account(reason="test", store_dir=store, home=home)
+    # Assert
+    assert result.switched_to == "low"
+
+
+def test_rotate_account_writes_reactive_rotate_audit_event(tmp_path):
+    # Arrange
+    home = _make_home(tmp_path)
+    store = _make_store(
+        tmp_path, [{"name": "backup", "email_address": "backup@example.com"}]
+    )
+    # Act
+    rotate_account(reason="test", store_dir=store, home=home)
+    audit_lines = (store / "rotation-audit.jsonl").read_text(
+        encoding="utf-8"
+    ).strip().splitlines()
+    last_record = json.loads(audit_lines[-1])
+    # Assert
+    assert last_record["event"] == ROTATE_EVENT
+
+
+# ---------------------------------------------------------------------------
+# No healthy candidate — stay put (never rotate onto a dead/absent token)
+# ---------------------------------------------------------------------------
+
+
+def test_rotate_account_only_current_account_stored_stays_put(tmp_path):
+    # Arrange
+    home = _make_home(tmp_path, email="primary@example.com")
+    store = _make_store(
+        tmp_path, [{"name": "primary", "email_address": "primary@example.com"}]
+    )
+    # Act
+    result = rotate_account(reason="test", store_dir=store, home=home)
+    # Assert
+    assert result.action == "no_accounts"
+
+
+def test_rotate_account_expired_only_candidate_stays_put(tmp_path):
+    # Arrange — the 2026-07-06 regression shape: an EXPIRED account must
+    # never be selected, even as the only candidate.
+    home = _make_home(tmp_path)
+    store = _make_store(
+        tmp_path,
+        [
+            {
+                "name": "expired-backup",
+                "email_address": "backup@example.com",
+                "_health": "expired",
+            }
+        ],
+    )
+    # Act
+    result = rotate_account(reason="test", store_dir=store, home=home)
+    # Assert
+    assert result.action == "no_accounts"
+
+
+def test_rotate_account_no_candidate_does_not_touch_switched_to(tmp_path):
+    # Arrange
+    home = _make_home(tmp_path)
+    store = tmp_path / "empty_store"
+    store.mkdir()
+    # Act
+    result = rotate_account(reason="test", store_dir=store, home=home)
+    # Assert
+    assert result.switched_to is None
+
+
+def test_rotate_account_no_candidate_message_says_staying_put(tmp_path):
+    # Arrange
+    home = _make_home(tmp_path)
+    store = tmp_path / "empty_store"
+    store.mkdir()
+    # Act
+    result = rotate_account(reason="test", store_dir=store, home=home)
+    # Assert
+    assert "staying put" in result.message
+
+
+# ---------------------------------------------------------------------------
+# RotateResult — dataclass contract
+# ---------------------------------------------------------------------------
+
+
+def test_rotate_account_returns_rotate_result_instance(tmp_path):
+    # Arrange
+    home = _make_home(tmp_path)
+    store = tmp_path / "empty_store"
+    store.mkdir()
+    # Act
+    result = rotate_account(reason="test", store_dir=store, home=home)
+    # Assert
+    assert isinstance(result, RotateResult)

--- a/tests/scitex_agent_container/_runners/test__rate_limit_reactive.py
+++ b/tests/scitex_agent_container/_runners/test__rate_limit_reactive.py
@@ -114,29 +114,37 @@ def _call(
 
 
 def test_no_signal_is_not_handled(tmp_path):
-    # Arrange / Act
-    outcome, _events, _db = _call(tmp_path, enriched="connection reset by peer")
+    # Arrange
+    enriched = "connection reset by peer"
+    # Act
+    outcome, _events, _db = _call(tmp_path, enriched=enriched)
     # Assert
     assert outcome.handled is False
 
 
 def test_no_signal_emits_no_session_events(tmp_path):
-    # Arrange / Act
-    _outcome, events, _db = _call(tmp_path, enriched="connection reset by peer")
+    # Arrange
+    enriched = "connection reset by peer"
+    # Act
+    _outcome, events, _db = _call(tmp_path, enriched=enriched)
     # Assert
     assert events == []
 
 
 def test_no_signal_reports_no_db_errors(tmp_path):
-    # Arrange / Act
-    _outcome, _events, db_calls = _call(tmp_path, enriched="connection reset by peer")
+    # Arrange
+    enriched = "connection reset by peer"
+    # Act
+    _outcome, _events, db_calls = _call(tmp_path, enriched=enriched)
     # Assert
     assert db_calls == []
 
 
 def test_no_signal_returns_reactive_outcome_instance(tmp_path):
-    # Arrange / Act
-    outcome, _events, _db = _call(tmp_path, enriched="connection reset by peer")
+    # Arrange
+    enriched = "connection reset by peer"
+    # Act
+    outcome, _events, _db = _call(tmp_path, enriched=enriched)
     # Assert
     assert isinstance(outcome, ReactiveOutcome)
 
@@ -146,67 +154,68 @@ def test_no_signal_returns_reactive_outcome_instance(tmp_path):
 # ---------------------------------------------------------------------------
 
 
+_OVERLOADED_529_TEXT = '{"error":{"type":"overloaded_error"}}'
+
+
 def test_529_is_handled(tmp_path):
-    # Arrange / Act
-    outcome, _events, _db = _call(
-        tmp_path, enriched='{"error":{"type":"overloaded_error"}}'
-    )
+    # Arrange
+    enriched = _OVERLOADED_529_TEXT
+    # Act
+    outcome, _events, _db = _call(tmp_path, enriched=enriched)
     # Assert
     assert outcome.handled is True
 
 
 def test_529_does_not_reset_attempt(tmp_path):
-    # Arrange / Act
-    outcome, _events, _db = _call(
-        tmp_path, enriched='{"error":{"type":"overloaded_error"}}'
-    )
+    # Arrange
+    enriched = _OVERLOADED_529_TEXT
+    # Act
+    outcome, _events, _db = _call(tmp_path, enriched=enriched)
     # Assert
     assert outcome.reset_attempt is False
 
 
 def test_529_delay_is_at_least_the_backoff_floor(tmp_path):
-    # Arrange / Act
-    outcome, _events, _db = _call(
-        tmp_path, enriched='{"error":{"type":"overloaded_error"}}'
-    )
+    # Arrange
+    enriched = _OVERLOADED_529_TEXT
+    # Act
+    outcome, _events, _db = _call(tmp_path, enriched=enriched)
     # Assert
     assert outcome.delay_s >= DEFAULT_MIN_BACKOFF_S
 
 
 def test_529_emits_account_backoff_supervisor_event(tmp_path):
-    # Arrange / Act
-    _outcome, events, _db = _call(
-        tmp_path, enriched='{"error":{"type":"overloaded_error"}}'
-    )
+    # Arrange
+    enriched = _OVERLOADED_529_TEXT
+    # Act
+    _outcome, events, _db = _call(tmp_path, enriched=enriched)
     # Assert
     assert any(e.get("event") == "account_backoff" for e in events)
 
 
 def test_529_emits_error_kind_event(tmp_path):
-    # Arrange / Act
-    _outcome, events, _db = _call(
-        tmp_path, enriched='{"error":{"type":"overloaded_error"}}'
-    )
+    # Arrange
+    enriched = _OVERLOADED_529_TEXT
+    # Act
+    _outcome, events, _db = _call(tmp_path, enriched=enriched)
     # Assert
     assert any(e.get("kind") == "rate_limited" for e in events)
 
 
 def test_529_reports_rate_limited_cause_to_db(tmp_path):
-    # Arrange / Act
-    _outcome, _events, db_calls = _call(
-        tmp_path, enriched='{"error":{"type":"overloaded_error"}}'
-    )
+    # Arrange
+    enriched = _OVERLOADED_529_TEXT
+    # Act
+    _outcome, _events, db_calls = _call(tmp_path, enriched=enriched)
     # Assert
     assert any(c["cause"] == RATE_LIMITED_CAUSE for c in db_calls)
 
 
 def test_529_consecutive_hits_increments_from_prior(tmp_path):
-    # Arrange / Act
-    outcome, _events, _db = _call(
-        tmp_path,
-        enriched='{"error":{"type":"overloaded_error"}}',
-        consecutive_hits=2,
-    )
+    # Arrange
+    enriched = _OVERLOADED_529_TEXT
+    # Act
+    outcome, _events, _db = _call(tmp_path, enriched=enriched, consecutive_hits=2)
     # Assert
     assert outcome.consecutive_hits == 3
 
@@ -222,7 +231,7 @@ def test_529_escalates_to_rotate_after_five_consecutive_hits(tmp_path):
     # Act
     outcome, _events, _db = _call(
         tmp_path,
-        enriched='{"error":{"type":"overloaded_error"}}',
+        enriched=_OVERLOADED_529_TEXT,
         consecutive_hits=4,
         home=home,
         store_dir=store,

--- a/tests/scitex_agent_container/_runners/test__rate_limit_reactive.py
+++ b/tests/scitex_agent_container/_runners/test__rate_limit_reactive.py
@@ -1,0 +1,348 @@
+"""Tests for the reactive rate-limit supervisor wiring (task #13).
+
+``handle_rate_limit_failure`` is the glue between the pure detector
+(``_account.rate_limit_signals.detect_signal_from_text``), the pure
+classifier (``_account.rate_limit_classifier.classify_rate_limit_signal``),
+and the two action-layer functions (``_account.backoff_agent.backoff_agent``
+/ ``_account.rotate_account.rotate_account``). These tests exercise it
+end-to-end with REAL capturing callables (no mock libs) and, for the
+Mode B (rotate) cases, a REAL isolated ``tmp_path``-rooted account
+store — never the process's actual ``$HOME``.
+
+Deterministic-by-signal-choice: HTTP_529 is ALWAYS Mode A (BACKOFF)
+and TEXTUAL_MATCH is ALWAYS Mode B (ROTATE) regardless of usage%
+(see ``rate_limit_classifier``), so these tests don't need to control
+the cached usage-%% snapshot to get a deterministic Mode — the 429/403
+usage-threshold boundary itself is already fully covered by
+``test_rate_limit_classifier.py``.
+
+Test style (STX-TQ002 / STX-TQ007): explicit ``# Arrange`` / ``# Act``
+/ ``# Assert`` markers each on their own line, in order; one logical
+assertion per test.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+from scitex_agent_container._account.backoff_agent import DEFAULT_MIN_BACKOFF_S
+from scitex_agent_container._runners._rate_limit_reactive import (
+    RATE_LIMITED_CAUSE,
+    ReactiveOutcome,
+    handle_rate_limit_failure,
+)
+
+# ---------------------------------------------------------------------------
+# Capturing helpers (no mock libs — real callables recording real calls)
+# ---------------------------------------------------------------------------
+
+
+def _make_append_session_message(events: list):
+    def _append(state_dir, payload):
+        events.append(payload)
+
+    return _append
+
+
+def _make_report_sdk_error(calls: list):
+    def _report(*, name, host, cause, detail=None, turn_id=None, db_writer=None):
+        calls.append({"name": name, "host": host, "cause": cause, "detail": detail})
+        return len(calls)
+
+    return _report
+
+
+def _make_home(tmp_path: Path, email: str = "primary@example.com") -> Path:
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".claude").mkdir()
+    (home / ".claude.json").write_text(
+        json.dumps({"oauthAccount": {"emailAddress": email}})
+    )
+    return home
+
+
+def _make_store(tmp_path: Path, accounts: list[dict]) -> Path:
+    future_ms = int((time.time() + 30 * 24 * 3600) * 1000)
+    store = tmp_path / "store"
+    store.mkdir()
+    for raw in accounts:
+        acct = dict(raw)
+        name = acct["name"]
+        cred_dir = store / name
+        cred_dir.mkdir()
+        (cred_dir / "account.json").write_text(json.dumps(acct))
+        (cred_dir / ".credentials.json").write_text(
+            json.dumps({"claudeAiOauth": {"expiresAt": future_ms}})
+        )
+    return store
+
+
+def _call(
+    tmp_path,
+    *,
+    enriched: str,
+    consecutive_hits: int = 0,
+    attempt: int = 0,
+    home: Path | None = None,
+    store_dir: Path | None = None,
+):
+    events: list[dict] = []
+    db_calls: list[dict] = []
+    outcome = handle_rate_limit_failure(
+        enriched=enriched,
+        state_dir=tmp_path / "state",
+        name="agent-x",
+        host="testhost",
+        attempt=attempt,
+        consecutive_hits=consecutive_hits,
+        stderr_event_fields={},
+        append_session_message=_make_append_session_message(events),
+        report_sdk_error=_make_report_sdk_error(db_calls),
+        db_writer=None,
+        account_home=home,
+        account_store_dir=store_dir,
+    )
+    return outcome, events, db_calls
+
+
+# ---------------------------------------------------------------------------
+# No signal — pure no-op, falls through unchanged
+# ---------------------------------------------------------------------------
+
+
+def test_no_signal_is_not_handled(tmp_path):
+    # Arrange / Act
+    outcome, _events, _db = _call(tmp_path, enriched="connection reset by peer")
+    # Assert
+    assert outcome.handled is False
+
+
+def test_no_signal_emits_no_session_events(tmp_path):
+    # Arrange / Act
+    _outcome, events, _db = _call(tmp_path, enriched="connection reset by peer")
+    # Assert
+    assert events == []
+
+
+def test_no_signal_reports_no_db_errors(tmp_path):
+    # Arrange / Act
+    _outcome, _events, db_calls = _call(tmp_path, enriched="connection reset by peer")
+    # Assert
+    assert db_calls == []
+
+
+def test_no_signal_returns_reactive_outcome_instance(tmp_path):
+    # Arrange / Act
+    outcome, _events, _db = _call(tmp_path, enriched="connection reset by peer")
+    # Assert
+    assert isinstance(outcome, ReactiveOutcome)
+
+
+# ---------------------------------------------------------------------------
+# HTTP_529 — always Mode A (BACKOFF), same account
+# ---------------------------------------------------------------------------
+
+
+def test_529_is_handled(tmp_path):
+    # Arrange / Act
+    outcome, _events, _db = _call(
+        tmp_path, enriched='{"error":{"type":"overloaded_error"}}'
+    )
+    # Assert
+    assert outcome.handled is True
+
+
+def test_529_does_not_reset_attempt(tmp_path):
+    # Arrange / Act
+    outcome, _events, _db = _call(
+        tmp_path, enriched='{"error":{"type":"overloaded_error"}}'
+    )
+    # Assert
+    assert outcome.reset_attempt is False
+
+
+def test_529_delay_is_at_least_the_backoff_floor(tmp_path):
+    # Arrange / Act
+    outcome, _events, _db = _call(
+        tmp_path, enriched='{"error":{"type":"overloaded_error"}}'
+    )
+    # Assert
+    assert outcome.delay_s >= DEFAULT_MIN_BACKOFF_S
+
+
+def test_529_emits_account_backoff_supervisor_event(tmp_path):
+    # Arrange / Act
+    _outcome, events, _db = _call(
+        tmp_path, enriched='{"error":{"type":"overloaded_error"}}'
+    )
+    # Assert
+    assert any(e.get("event") == "account_backoff" for e in events)
+
+
+def test_529_emits_error_kind_event(tmp_path):
+    # Arrange / Act
+    _outcome, events, _db = _call(
+        tmp_path, enriched='{"error":{"type":"overloaded_error"}}'
+    )
+    # Assert
+    assert any(e.get("kind") == "rate_limited" for e in events)
+
+
+def test_529_reports_rate_limited_cause_to_db(tmp_path):
+    # Arrange / Act
+    _outcome, _events, db_calls = _call(
+        tmp_path, enriched='{"error":{"type":"overloaded_error"}}'
+    )
+    # Assert
+    assert any(c["cause"] == RATE_LIMITED_CAUSE for c in db_calls)
+
+
+def test_529_consecutive_hits_increments_from_prior(tmp_path):
+    # Arrange / Act
+    outcome, _events, _db = _call(
+        tmp_path,
+        enriched='{"error":{"type":"overloaded_error"}}',
+        consecutive_hits=2,
+    )
+    # Assert
+    assert outcome.consecutive_hits == 3
+
+
+def test_529_escalates_to_rotate_after_five_consecutive_hits(tmp_path):
+    # Arrange — a healthy backup account IS available, and this is the
+    # 5th consecutive Mode-A hit -> the action layer should escalate to
+    # Mode B even though the classifier itself said BACKOFF.
+    home = _make_home(tmp_path)
+    store = _make_store(
+        tmp_path, [{"name": "backup", "email_address": "backup@example.com"}]
+    )
+    # Act
+    outcome, _events, _db = _call(
+        tmp_path,
+        enriched='{"error":{"type":"overloaded_error"}}',
+        consecutive_hits=4,
+        home=home,
+        store_dir=store,
+    )
+    # Assert
+    assert outcome.reset_attempt is True
+
+
+# ---------------------------------------------------------------------------
+# TEXTUAL_MATCH — always Mode B (ROTATE)
+# ---------------------------------------------------------------------------
+
+_WEEKLY_LIMIT_TEXT = "You've hit your weekly limit · resets 2026-06-18T05:00Z"
+
+
+def test_textual_match_with_healthy_account_rotates(tmp_path):
+    # Arrange
+    home = _make_home(tmp_path)
+    store = _make_store(
+        tmp_path, [{"name": "backup", "email_address": "backup@example.com"}]
+    )
+    # Act
+    outcome, _events, _db = _call(
+        tmp_path, enriched=_WEEKLY_LIMIT_TEXT, home=home, store_dir=store
+    )
+    # Assert
+    assert outcome.reset_attempt is True
+
+
+def test_textual_match_rotation_zeroes_consecutive_hits(tmp_path):
+    # Arrange
+    home = _make_home(tmp_path)
+    store = _make_store(
+        tmp_path, [{"name": "backup", "email_address": "backup@example.com"}]
+    )
+    # Act
+    outcome, _events, _db = _call(
+        tmp_path,
+        enriched=_WEEKLY_LIMIT_TEXT,
+        consecutive_hits=3,
+        home=home,
+        store_dir=store,
+    )
+    # Assert
+    assert outcome.consecutive_hits == 0
+
+
+def test_textual_match_emits_account_rotated_event(tmp_path):
+    # Arrange
+    home = _make_home(tmp_path)
+    store = _make_store(
+        tmp_path, [{"name": "backup", "email_address": "backup@example.com"}]
+    )
+    # Act
+    _outcome, events, _db = _call(
+        tmp_path, enriched=_WEEKLY_LIMIT_TEXT, home=home, store_dir=store
+    )
+    # Assert
+    assert any(e.get("event") == "account_rotated" for e in events)
+
+
+def test_textual_match_actually_switches_the_credential_file(tmp_path):
+    # Arrange
+    home = _make_home(tmp_path)
+    store = _make_store(
+        tmp_path, [{"name": "backup", "email_address": "backup@example.com"}]
+    )
+    # Act
+    _call(tmp_path, enriched=_WEEKLY_LIMIT_TEXT, home=home, store_dir=store)
+    # Assert — the real effect: switch_account copied the backup snapshot in.
+    assert (home / ".claude" / ".credentials.json").is_file()
+
+
+def test_textual_match_no_healthy_account_falls_back_to_backoff(tmp_path):
+    # Arrange — "never park": no candidate to rotate to, must still retry.
+    home = _make_home(tmp_path)
+    store = tmp_path / "empty_store"
+    store.mkdir()
+    # Act
+    outcome, _events, _db = _call(
+        tmp_path, enriched=_WEEKLY_LIMIT_TEXT, home=home, store_dir=store
+    )
+    # Assert
+    assert outcome.reset_attempt is False
+
+
+def test_textual_match_no_healthy_account_still_handled(tmp_path):
+    # Arrange
+    home = _make_home(tmp_path)
+    store = tmp_path / "empty_store"
+    store.mkdir()
+    # Act
+    outcome, _events, _db = _call(
+        tmp_path, enriched=_WEEKLY_LIMIT_TEXT, home=home, store_dir=store
+    )
+    # Assert
+    assert outcome.handled is True
+
+
+def test_textual_match_no_healthy_account_emits_rotate_skipped_event(tmp_path):
+    # Arrange
+    home = _make_home(tmp_path)
+    store = tmp_path / "empty_store"
+    store.mkdir()
+    # Act
+    _outcome, events, _db = _call(
+        tmp_path, enriched=_WEEKLY_LIMIT_TEXT, home=home, store_dir=store
+    )
+    # Assert
+    assert any(e.get("event") == "account_rotate_skipped" for e in events)
+
+
+def test_textual_match_no_healthy_account_also_emits_backoff_event(tmp_path):
+    # Arrange
+    home = _make_home(tmp_path)
+    store = tmp_path / "empty_store"
+    store.mkdir()
+    # Act
+    _outcome, events, _db = _call(
+        tmp_path, enriched=_WEEKLY_LIMIT_TEXT, home=home, store_dir=store
+    )
+    # Assert
+    assert any(e.get("event") == "account_backoff" for e in events)


### PR DESCRIPTION
## Summary

Wires REACTIVE per-agent rate-limit handling into the conversation
supervisor: a live 429/403/529 or an unambiguous textual/auth cap
signal, hit mid-turn, now gets classified and auto-handled instead of
falling into the generic `sdk-crash` bucket (fast 1s/2s/4s retry on
the SAME capped account, then death once `max_restarts` — floor 3 —
is exhausted).

- **Mode A (`_account/backoff_agent.py`, new)** — transient burst
  (529, or 429/403 on a low-usage account): per-agent delay with a
  30s floor (not the generic exponential's 1s start) plus
  consecutive-hit escalation (5 backoffs in a row → try Mode B even
  though the classifier itself said BACKOFF — the accounting the
  classifier's own docstring reserves for the action layer).
- **Mode B (`_account/rotate_account.py`, new)** — sustained cap
  (429/403 on an already-high-usage account, or any textual/auth cap
  marker): reuses `quota_watch._select_next_account` (health-gated
  selection — the 2026-07-06 expired-account regression guard) and
  `account_store.switch_account` (credential copy + rotation audit,
  `event=reactive-rotate`, added to `_rotation_audit._KNOWN_EVENTS`),
  skipping only `quota_watch`'s proactive `fetch_usage` threshold
  gate since a reactive caller already has a live signal. No-ops
  safely — falls back to Mode A backoff-and-retry ("never park") —
  when `_select_next_account` finds no healthy non-current account.
- **`_account/rate_limit_signals.py`** gains `detect_signal_from_text`
  — the HTTP-status-in-text detector the module's own docstring
  called for but never implemented (the SDK never surfaces a typed
  status code — same gap `_auth_failure.py` already solves for 401).
  Anthropic `error.type` strings first (`rate_limit_error` /
  `overloaded_error`), then a word-boundary status-code fallback,
  then the existing textual cap scanner.
- **`_runners/_rate_limit_reactive.py`** (new) is the wiring: detects
  the signal, classifies Mode A/B via the existing (unmodified)
  `_account/rate_limit_classifier.py`, dispatches to the action
  layer, and emits `account_backoff` / `account_rotated` /
  `account_rotate_skipped` supervisor events via the SAME
  `append_session_message` (session.jsonl) / `report_sdk_error`
  (`state.db.errors`, `cause="rate-limited"`) channels every other
  supervisor event in this file already uses — no new event
  mechanism invented.
- Integration point: `_runners/_session_conversation.py`'s
  `run_conversation` supervisor `except` block, right after
  dead-session-resume recovery and before the auth-expired /
  generic-`sdk-crash` classification — confirmed by reading the full
  turn-execution path (`_drive_turn` → `run_conversation`) rather
  than guessing.

### Pre-existing file-cap fix (needed to land the above)

`_session_conversation.py` was already 601 lines — over the repo's
512-line cap — *before* this PR. Extracted four self-contained
supervisor helpers (`_maybe_compact`, `_drain_failed_inbox`,
`_wake_on_inbound`, `_resume_candidate`) into a new
`_session_supervisor_helpers.py`, re-exported under their original
names (mirrors the file's existing `_session_turn` re-export idiom)
so every existing import site keeps resolving unchanged. Pure
relocation, no behaviour change — verified by the full existing test
suite staying green.

## What I found investigating first (per the task brief)

- Part 1 (`_pick_healthy.pick_healthy_account` boot-time picker +
  `agent_account.py`'s account-label resolution) is a SEPARATE,
  already-live substrate — boot-time account selection, not a
  blocker for this reactive/mid-session feature. Confirmed by reading
  both modules fully rather than trusting the card's stale
  `blocked_by`.
- `agent_account.py`'s `resolve_agent_account_label` is read-only
  DISPLAY plumbing (for `sac agents list`), not a binding/switch
  primitive — nothing to reuse there beyond confirming
  `spec.claude.account` is the per-agent pin, which this PR doesn't
  need to touch (the reactive rotate mutates `~/.claude/` directly,
  same target `switch_account` already writes).
- `_heartbeat_fields.py`'s `capped` flag (via `scan_textual_cap_markers`)
  is a pure OBSERVABILITY signal for `sac agents list` — not
  currently wired to any action. Confirmed it's genuinely the only
  existing call site of the signal taxonomy, as the task brief
  suspected.

## Test plan

- [x] New unit tests: `test_backoff_agent.py` (15 tests, pure
      delay/escalation math), `test_rotate_account.py` (12 tests,
      real `tmp_path`-rooted account-store fixtures mirroring
      `test_quota_watch.py`'s established `_make_home`/`_make_store`
      pattern — every call passes explicit `home=`/`store_dir=` so
      nothing ever touches the real `$HOME`), extended
      `test_rate_limit_signals.py` (+11 tests for
      `detect_signal_from_text`), new
      `test__rate_limit_reactive.py` (20 tests, real capturing
      callables, no mocks).
- [x] `ruff check --select F401,F811 --extend-per-file-ignores
      '**/__init__.py:F401' src/ tests/` → clean.
- [x] `pytest tests/scitex_agent_container/_account/
      tests/scitex_agent_container/_runners/` → **1014 passed**
      (363 new/touched to this feature, 651 pre-existing
      regression-checked — confirms the `_session_conversation.py`
      split didn't break anything).
- [ ] `tests/develop/test_audit.py` (scitex-dev `audit-all`) timed
      out locally at 120s scanning the whole ecosystem — a known
      local-environment characteristic per prior operator note, not
      something this change caused. CI will be authoritative on the
      audit gate.

## Follow-ups (deliberately out of scope for this first PR)

- The 429/403 usage-threshold BOUNDARY behavior (already fully
  covered by `test_rate_limit_classifier.py` against
  `AccountUsageSnapshot` directly) isn't re-exercised at the
  `handle_rate_limit_failure` integration layer — that layer's tests
  deliberately use HTTP_529 (always BACKOFF) and TEXTUAL_MATCH
  (always ROTATE) so they're deterministic without needing to fake
  the live `quota-cache.json` snapshot the classifier reads for
  429/403 disambiguation.
- No end-to-end test drives a live 429 through the FULL
  `run_conversation` supervisor loop (the auth-failure sibling test
  file `test__session_conversation_auth.py` has that harness
  pattern; a follow-up could extend it with a rate-limit variant).
- The 4th provider (openai-compat) isn't addressed here — HTTP_403's
  detector is already in place for it (per `rate_limit_signals.py`'s
  own docstring: "OpenAI sometimes returns 403 for org-limit
  exceedance"), but there's no provider-specific dispatch yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)