### PR TITLE
fix(tui): wait out the fresh-boot welcome screen before the compose-buffer clear

### DIFF
--- a/src/scitex_agent_container/runtimes/_tui_compose.py
+++ b/src/scitex_agent_container/runtimes/_tui_compose.py
@@ -7,7 +7,7 @@ cohesive place. The :class:`TuiSessionRuntime` wires the real tmux callables
 into these functions (``_verify_submitted`` → :func:`verify_submit_by_advancement`,
 ``_clear_compose_buffer`` → :func:`clear_compose_buffer`).
 
-Two boot fixes live here:
+Boot fixes live here:
 
   * :func:`verify_submit_by_advancement` — the boot Enter-drop fix
     (sac-tui-enter-drop-on-boot): wait-for-idle + verify-by-advancement so the
@@ -19,6 +19,15 @@ Two boot fixes live here:
     the pane was busy) ACROSS an agent restart; the boot Enter would otherwise
     submit that whole stale stack. Clearing the compose buffer at the TOP of
     startup-prompt injection drops the stale text before the boot submit.
+  * :func:`is_fresh_boot_welcome_screen` (+ its
+    :func:`_wait_for_welcome_screen_to_clear` helper) — a second fix under the
+    SAME card: on a FRESH (no ``--continue``) boot the first-launch
+    welcome/model-info/promo screen can still be up, with the Ink TUI's input
+    not yet bound, when :func:`clear_compose_buffer` runs — Escape sent into
+    that window is not reliably delivered, so the clear would exhaust its
+    resend budget against a screen it can never actually clear. Waiting for
+    that screen to clear FIRST fixes the false "did NOT clear" failure without
+    touching the already-working resumed-session path.
 """
 
 from __future__ import annotations
@@ -29,6 +38,7 @@ from typing import Callable
 
 __all__ = [
     "clear_compose_buffer",
+    "is_fresh_boot_welcome_screen",
     "verify_submit_by_advancement",
 ]
 
@@ -105,6 +115,57 @@ def _pane_is_input_idle(pane: str) -> bool:
     return _prompts.is_ready(pane) or _compose_pending_live(pane)
 
 
+def is_fresh_boot_welcome_screen(pane: str) -> bool:
+    """True iff a first-launch welcome/model-info/promo screen is on screen.
+
+    Distinguishes a FRESH boot's ``Welcome to Claude Code!`` header box from
+    a RESUMED session's ``Welcome back <name>!`` variant — both render the
+    same boxed ``Claude Code v<version>`` banner (real capture:
+    ``_V2_READY_PANE``, ``test_tui_session_v2_ready_marker.py``), differing
+    only in the greeting.
+
+    Card ``sac-tui-clear-compose-buffer-on-boot``: on a FRESH boot (no prior
+    session, ``--continue`` omitted) this banner — plus any promo line under
+    it, e.g. "Fable 5 is included in your weekly limit" — can still be up,
+    with the Ink TUI's input not yet bound, when :func:`clear_compose_buffer`
+    runs. Escape sent into that window does not reliably reach (or clear)
+    the real compose box, so its "did NOT clear after N attempts" failure
+    fires even though there is nothing genuine to clear yet. RESUMED
+    sessions say "Welcome back" instead and never match here — the
+    already-working resumed boot path is untouched.
+
+    Scoped to :func:`_pane_tail` (the LIVE region), mirroring why
+    ``prompts.detect`` scopes to its own tail (card
+    ``sac-tui-stray-1-submitted-on-boot`, PR #598): once this banner has
+    scrolled out of the live viewport it must stop matching.
+    """
+    tail = _pane_tail(pane)
+    return "Claude Code v" in tail and "Welcome back" not in tail
+
+
+def _wait_for_welcome_screen_to_clear(
+    name: str,
+    *,
+    capture_fn: Callable[[str], str],
+    max_wait_s: float,
+    poll_s: float,
+    sleep_fn: Callable[[float], None],
+    time_fn: Callable[[], float],
+) -> str:
+    """Poll until :func:`is_fresh_boot_welcome_screen` is False, bounded by
+    ``max_wait_s``. Returns the last captured pane either way — fail-soft,
+    mirroring :func:`_tui_drain.wait_for_settle`: the caller acts on
+    whatever the pane shows once the bound is hit, it never blocks forever.
+    """
+    deadline = time_fn() + max_wait_s
+    pane = capture_fn(name)
+    while is_fresh_boot_welcome_screen(pane) and time_fn() < deadline:
+        if poll_s > 0:
+            sleep_fn(poll_s)
+        pane = capture_fn(name)
+    return pane
+
+
 def clear_compose_buffer(
     name: str,
     *,
@@ -112,6 +173,7 @@ def clear_compose_buffer(
     send_keys_fn: Callable[[str], None],
     max_attempts: int = 5,
     poll_s: float = 0.4,
+    welcome_wait_s: float = 2.5,
     sleep_fn: Callable[[float], None] = time.sleep,
     time_fn: Callable[[], float] = time.monotonic,
 ) -> bool:
@@ -156,6 +218,22 @@ def clear_compose_buffer(
     is present we REFUSE to Esc (log LOUD, return ``False``): the dev-channels
     modal must be dismissed by the modal drainer (Enter to confirm option 1)
     FIRST; the compose clear runs only once no cancelable modal remains.
+
+    **BUG 3 guard (fresh-boot welcome screen):** on a FRESH boot (no prior
+    session, ``--continue`` omitted) the first-launch welcome/model-info
+    screen — see :func:`is_fresh_boot_welcome_screen` — can still be up, with
+    the Ink TUI's input not yet bound, when this runs. ``Escape`` sent into
+    that window is not reliably delivered to (or cleared from) the real
+    compose box, so the resend loop below would exhaust ``max_attempts``
+    against a screen it can never actually clear (card
+    ``sac-tui-clear-compose-buffer-on-boot``, reproduced live 2026-07-05 /
+    2026-07-08: "did NOT clear after 5 attempts" against a pane showing the
+    welcome banner + a "Fable 5 is included in your weekly limit" promo
+    line). So BEFORE the pending check — on the initial capture AND before
+    every resend — we wait (bounded by ``welcome_wait_s``) for that screen to
+    clear via :func:`_wait_for_welcome_screen_to_clear`, then re-evaluate the
+    ACTUAL live box once it is gone. RESUMED sessions never show this banner
+    (they render "Welcome back" instead), so this adds no latency there.
     """
     import logging
 
@@ -180,6 +258,18 @@ def clear_compose_buffer(
             _pane_tail(pane),
         )
         return False
+    if is_fresh_boot_welcome_screen(pane):
+        # BUG 3 — the fresh-boot welcome/model-info/promo screen is up and
+        # the Ink TUI's input is not reliably bound yet; wait it out before
+        # trusting any read of the live compose box.
+        pane = _wait_for_welcome_screen_to_clear(
+            name,
+            capture_fn=capture_fn,
+            max_wait_s=welcome_wait_s,
+            poll_s=poll_s,
+            sleep_fn=sleep_fn,
+            time_fn=time_fn,
+        )
     if not _compose_pending_live(pane):
         # Common case: nothing stale in the live box — no-op.
         return True
@@ -198,6 +288,15 @@ def clear_compose_buffer(
                 _pane_tail(current),
             )
             return False
+        if is_fresh_boot_welcome_screen(current):
+            # BUG 3 — (re)appeared mid-loop (a slow mount can outlast the
+            # pre-loop wait). Skip this attempt WITHOUT sending Escape — it
+            # cannot land on this screen — and let the next iteration's
+            # capture see whether it has cleared by then.
+            last_pane = current
+            if poll_s > 0:
+                sleep_fn(poll_s)
+            continue
         for key in _COMPOSE_CLEAR_KEYS:
             send_keys_fn(key)
         # Let the clear render, then re-capture and verify the live box is empty.
@@ -206,6 +305,25 @@ def clear_compose_buffer(
         last_pane = capture_fn(name)
         if not _compose_pending_live(last_pane):
             return True
+
+    if is_fresh_boot_welcome_screen(last_pane):
+        # Distinct from the generic exhaustion message below: we withheld
+        # every Escape send (BUG 3 guard), so it would be misleading to blame
+        # "the Ink TUI kept dropping the clear keystroke" — no keystroke was
+        # ever sent. The welcome screen itself never released within budget.
+        log.error(
+            "TuiSessionRuntime: compose-buffer clear for %s gave up after "
+            "%d attempts — the fresh-boot welcome/model-info screen never "
+            "cleared within the wait budget, so no Escape was sent at all "
+            "(sending it would not have landed). Boot will proceed "
+            "(verify_submit_by_advancement is the next net). Attach to "
+            "inspect: `tmux attach -t %s`. Pane tail:\n%s",
+            name,
+            max_attempts,
+            name,
+            _pane_tail(last_pane),
+        )
+        return False
 
     log.error(
         "TuiSessionRuntime: stale compose buffer for %s did NOT clear after "

--- a/tests/scitex_agent_container/runtimes/test__tui_compose_welcome_guard.py
+++ b/tests/scitex_agent_container/runtimes/test__tui_compose_welcome_guard.py
@@ -1,0 +1,382 @@
+"""Unit tests for the BUG 3 fresh-boot-welcome-screen guard in
+``clear_compose_buffer`` / ``is_fresh_boot_welcome_screen``.
+
+Card ``sac-tui-clear-compose-buffer-on-boot``: on a FRESH boot (no prior
+session, ``--continue`` omitted) Claude Code's first-launch welcome/
+model-info/promo screen can still be up — with the Ink TUI's input not yet
+bound — when the Escape-based compose-buffer clear runs. Reproduced live
+2026-07-05 and 2026-07-08 (scitex-todo, scitex-db, scitex-session, scitex-io,
+figrecipe, scitex-stats, paper-neurovista): "stale compose buffer ... did NOT
+clear after 5 attempts of ['Escape', 'Escape']" against a pane showing the
+welcome banner + a "Fable 5 is included in your weekly limit" promo line.
+ONLY fresh/no-transcript boots showed this; resumed-session boots never did.
+
+Real recording fakes (no mocks / no monkeypatch — STX-NM002) + a fake
+monotonic clock so the bounded-wait paths run instantly. AAA markers, one
+assert each (STX-TQ002 / STX-TQ007).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from scitex_agent_container.runtimes._tui_compose import (
+    _COMPOSE_CLEAR_KEYS,
+    clear_compose_buffer,
+    is_fresh_boot_welcome_screen,
+)
+
+# ── Real(istic) pane snapshots ──────────────────────────────────────────────
+
+# FRESH boot: first-launch welcome/model-info box + the exact promo-banner
+# line from the live 2026-07-08 repro on this card, reconstructed on the box
+# shape CONFIRMED real by `_V2_READY_PANE` (test_tui_session_v2_ready_marker.py,
+# captured live 2026-06-20) with "Welcome back Yusuke!" swapped for the
+# first-launch greeting.
+_FRESH_BOOT_WELCOME_PANE = (
+    "╭─── Claude Code v2.1.198 ───╮\n"
+    "│   Welcome to Claude Code!  │\n"
+    "╰─────────────────────────────╯\n"
+    "  Fable 5 is included in your weekly limit\n"
+    "\n"
+    "❯ Try \"fix the failing tests\"\n"
+    "  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents\n"
+)
+
+# RESUMED session: the CONFIRMED real capture's own greeting variant — must
+# stay untouched by this guard (the already-working resumed boot path).
+_RESUMED_WELCOME_PANE = (
+    "╭─── Claude Code v2.1.150 ───╮\n"
+    "│      Welcome back Yusuke!  │  What's new\n"
+    "╰────────────────────────────╯\n"
+    "❯ \n"
+    "  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents\n"
+)
+
+_BOOTING_PANE = "uv pip install -e .[all,dev]\nResolving dependencies ..."
+
+_DEV_CHANNELS_MODAL = (
+    "1. I am using this for local development\n2. Exit\nEnter to confirm"
+)
+
+# Once the welcome screen clears, the real live box underneath — empty, the
+# common fresh-boot case (nothing was ever pasted into it yet).
+_CLEARED = "❯ \n  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents\n"
+
+# Once the welcome screen clears, a GENUINELY stale multi-line buffer sitting
+# in the persistent tmux pane (the ORIGINAL /compact-burst bug this whole
+# mechanism exists for) — must still be clearable once the welcome screen is
+# out of the way.
+_STALE_MULTILINE = (
+    "❯\xa0/compact\n"
+    "  /compact\n"
+    "  2\n"
+    "  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents\n"
+)
+
+
+# ── Fakes (real callables, not mocks) ───────────────────────────────────────
+
+
+@dataclass
+class _RecordingSend:
+    keys: list[str] = field(default_factory=list)
+
+    def __call__(self, key: str) -> None:
+        self.keys.append(key)
+
+
+@dataclass
+class _FakeClock:
+    """Deterministic ``time_fn``/``sleep_fn`` pair: ``sleep`` advances ``now``
+    synthetically so a bounded wall-clock wait resolves instantly in tests,
+    no real sleeping required."""
+
+    now: float = 0.0
+
+    def sleep(self, seconds: float) -> None:
+        self.now += seconds
+
+    def time(self) -> float:
+        return self.now
+
+
+class _WelcomeThenAfter:
+    """capture_fn: the fresh-boot welcome pane for the first
+    ``welcome_captures`` calls, then ``after`` for every call thereafter.
+    Models the Ink TUI mounting its real input once the welcome/promo screen
+    finishes its render window."""
+
+    def __init__(self, welcome_captures: int, after: str) -> None:
+        self._remaining = welcome_captures
+        self._after = after
+        self.captures = 0
+
+    def __call__(self, _name: str) -> str:
+        self.captures += 1
+        if self._remaining > 0:
+            self._remaining -= 1
+            return _FRESH_BOOT_WELCOME_PANE
+        return self._after
+
+
+class _WelcomeThenStaleUntilCleared:
+    """capture_fn: welcome pane for the first ``welcome_captures`` calls,
+    then the REAL stale multiline buffer until ``release_after_gestures``
+    full Escape-Escape gestures have been sent, then cleared."""
+
+    def __init__(
+        self, sender: _RecordingSend, *, welcome_captures: int, release_after_gestures: int = 1
+    ) -> None:
+        self._sender = sender
+        self._welcome_captures = welcome_captures
+        self._release = release_after_gestures
+        self.captures = 0
+
+    def __call__(self, _name: str) -> str:
+        self.captures += 1
+        if self.captures <= self._welcome_captures:
+            return _FRESH_BOOT_WELCOME_PANE
+        gestures = len(self._sender.keys) // len(_COMPOSE_CLEAR_KEYS)
+        return _CLEARED if gestures >= self._release else _STALE_MULTILINE
+
+
+class _AlwaysWelcome:
+    """capture_fn: the welcome screen never clears (pathological slow/dead
+    mount) — the worst case this guard must still fail loud on, not hang."""
+
+    def __call__(self, _name: str) -> str:
+        return _FRESH_BOOT_WELCOME_PANE
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# is_fresh_boot_welcome_screen — the predicate itself
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def test_predicate_matches_fresh_boot_welcome_pane() -> None:
+    # Arrange
+    pane = _FRESH_BOOT_WELCOME_PANE
+    # Act
+    matched = is_fresh_boot_welcome_screen(pane)
+    # Assert
+    assert matched is True
+
+
+def test_predicate_does_not_match_resumed_welcome_back_pane() -> None:
+    # Arrange — the already-working resumed path must stay untouched.
+    pane = _RESUMED_WELCOME_PANE
+    # Act
+    matched = is_fresh_boot_welcome_screen(pane)
+    # Assert
+    assert matched is False
+
+
+def test_predicate_does_not_match_plain_booting_pane() -> None:
+    # Arrange
+    pane = _BOOTING_PANE
+    # Act
+    matched = is_fresh_boot_welcome_screen(pane)
+    # Assert
+    assert matched is False
+
+
+def test_predicate_does_not_match_dev_channels_modal() -> None:
+    # Arrange — no accidental overlap with an unrelated known modal.
+    pane = _DEV_CHANNELS_MODAL
+    # Act
+    matched = is_fresh_boot_welcome_screen(pane)
+    # Assert
+    assert matched is False
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# clear_compose_buffer — waits out the welcome screen, then no-ops on an
+# actually-empty live box (the common fresh-boot case)
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def test_clear_returns_true_once_welcome_screen_clears_to_empty_box() -> None:
+    # Arrange — welcome screen for 2 captures, then the real (empty) box.
+    clock = _FakeClock()
+    capture = _WelcomeThenAfter(welcome_captures=2, after=_CLEARED)
+    sender = _RecordingSend()
+    # Act
+    ok = clear_compose_buffer(
+        "tui-x",
+        capture_fn=capture,
+        send_keys_fn=sender,
+        max_attempts=5,
+        poll_s=0.1,
+        welcome_wait_s=2.0,
+        sleep_fn=clock.sleep,
+        time_fn=clock.time,
+    )
+    # Assert
+    assert ok is True
+
+
+def test_clear_sends_no_escape_while_welcome_screen_is_up() -> None:
+    # Arrange — same scenario: nothing to clear once the real box is seen.
+    clock = _FakeClock()
+    capture = _WelcomeThenAfter(welcome_captures=2, after=_CLEARED)
+    sender = _RecordingSend()
+    # Act
+    clear_compose_buffer(
+        "tui-x",
+        capture_fn=capture,
+        send_keys_fn=sender,
+        max_attempts=5,
+        poll_s=0.1,
+        welcome_wait_s=2.0,
+        sleep_fn=clock.sleep,
+        time_fn=clock.time,
+    )
+    # Assert — no Escape was ever sent into the welcome screen.
+    assert sender.keys == []
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# clear_compose_buffer — waits out the welcome screen, THEN still clears a
+# GENUINE stale buffer underneath (the original /compact-burst fix preserved)
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def test_clear_still_clears_real_stale_buffer_once_welcome_screen_is_gone() -> None:
+    # Arrange — welcome screen for 1 capture, then a real stale stack that
+    # clears on the first Escape-Escape gesture.
+    clock = _FakeClock()
+    sender = _RecordingSend()
+    capture = _WelcomeThenStaleUntilCleared(
+        sender, welcome_captures=1, release_after_gestures=1
+    )
+    # Act
+    ok = clear_compose_buffer(
+        "tui-x",
+        capture_fn=capture,
+        send_keys_fn=sender,
+        max_attempts=5,
+        poll_s=0.1,
+        welcome_wait_s=2.0,
+        sleep_fn=clock.sleep,
+        time_fn=clock.time,
+    )
+    # Assert
+    assert ok is True
+
+
+def test_clear_sends_the_clear_gesture_only_after_welcome_screen_clears() -> None:
+    # Arrange — same scenario as above.
+    clock = _FakeClock()
+    sender = _RecordingSend()
+    capture = _WelcomeThenStaleUntilCleared(
+        sender, welcome_captures=1, release_after_gestures=1
+    )
+    # Act
+    clear_compose_buffer(
+        "tui-x",
+        capture_fn=capture,
+        send_keys_fn=sender,
+        max_attempts=5,
+        poll_s=0.1,
+        welcome_wait_s=2.0,
+        sleep_fn=clock.sleep,
+        time_fn=clock.time,
+    )
+    # Assert — exactly one verified clear gesture, sent once the screen was gone.
+    assert sender.keys == list(_COMPOSE_CLEAR_KEYS)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# clear_compose_buffer — welcome screen NEVER clears: bounded, fail-loud, not
+# fatal (no worse than the pre-fix worst case; must not hang)
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def test_clear_returns_false_when_welcome_screen_never_clears() -> None:
+    # Arrange — pathological: the welcome screen is stuck forever.
+    clock = _FakeClock()
+    sender = _RecordingSend()
+    capture = _AlwaysWelcome()
+    # Act
+    ok = clear_compose_buffer(
+        "tui-x",
+        capture_fn=capture,
+        send_keys_fn=sender,
+        max_attempts=3,
+        poll_s=0.1,
+        welcome_wait_s=1.0,
+        sleep_fn=clock.sleep,
+        time_fn=clock.time,
+    )
+    # Assert — bounded give-up, never a silent/blocking hang.
+    assert ok is False
+
+
+def test_clear_sends_no_escape_when_welcome_screen_never_clears() -> None:
+    # Arrange — same pathological scenario.
+    clock = _FakeClock()
+    sender = _RecordingSend()
+    capture = _AlwaysWelcome()
+    # Act
+    clear_compose_buffer(
+        "tui-x",
+        capture_fn=capture,
+        send_keys_fn=sender,
+        max_attempts=3,
+        poll_s=0.1,
+        welcome_wait_s=1.0,
+        sleep_fn=clock.sleep,
+        time_fn=clock.time,
+    )
+    # Assert — never blind-fires Escape into a screen that can't consume it.
+    assert sender.keys == []
+
+
+def test_clear_does_not_raise_when_welcome_screen_never_clears() -> None:
+    # Arrange — fail-loud-not-fatal: boot must still proceed.
+    clock = _FakeClock()
+    sender = _RecordingSend()
+    capture = _AlwaysWelcome()
+    # Act
+    raised = False
+    try:
+        clear_compose_buffer(
+            "tui-x",
+            capture_fn=capture,
+            send_keys_fn=sender,
+            max_attempts=3,
+            poll_s=0.1,
+            welcome_wait_s=1.0,
+            sleep_fn=clock.sleep,
+            time_fn=clock.time,
+        )
+    except Exception:  # noqa: BLE001 — the whole point is nothing escapes.
+        raised = True
+    # Assert
+    assert raised is False
+
+
+def test_clear_logs_welcome_specific_message_when_screen_never_clears(caplog) -> None:
+    # Arrange — the exhaustion message must name the ACTUAL cause (the
+    # welcome screen never releasing), not misreport "Ink TUI kept dropping
+    # the clear keystroke" when no keystroke was ever sent.
+    import logging
+
+    clock = _FakeClock()
+    sender = _RecordingSend()
+    capture = _AlwaysWelcome()
+    # Act
+    with caplog.at_level(logging.ERROR):
+        clear_compose_buffer(
+            "tui-x",
+            capture_fn=capture,
+            send_keys_fn=sender,
+            max_attempts=3,
+            poll_s=0.1,
+            welcome_wait_s=1.0,
+            sleep_fn=clock.sleep,
+            time_fn=clock.time,
+        )
+    # Assert
+    assert any("welcome" in r.message.lower() for r in caplog.records)


### PR DESCRIPTION
## Summary

Fixes scitex-todo card `sac-tui-clear-compose-buffer-on-boot`: on a **fresh** TUI boot (no prior session transcript, `--continue` omitted) the compose-buffer-clear mechanism reliably fails with `"stale compose buffer for tui-<name> did NOT clear after 5 attempts of ['Escape', 'Escape']"`. Reproduced live 2026-07-05 and again 2026-07-08 across multiple real agents (paper-neurovista, scitex-db, scitex-session, scitex-todo, scitex-io, figrecipe, scitex-stats). Not currently a hard failure — `verify_submit_by_advancement` is a working fallback net — but the primary mechanism was broken specifically for fresh boots, the common case for every newly-created agent.

**Root cause**: on a fresh boot, Claude Code's first-launch welcome/model-info/promo screen (e.g. `Welcome to Claude Code!` + a `"Fable 5 is included in your weekly limit"` promo line) can still be up — with the Ink TUI's real input not yet bound — when `clear_compose_buffer` runs. `Escape` sent into that window is not reliably delivered to (or cleared from) the real compose box, so the resend loop exhausts its budget against a screen it can never actually clear. **Only** fresh/no-transcript boots show this; resumed sessions render a different greeting (`Welcome back <name>!`) and never hit it — matching the observed pattern exactly.

**Fix**: added `is_fresh_boot_welcome_screen()` to `runtimes/_tui_compose.py` — distinguishes the fresh-boot header from the resumed-session variant (both render the same boxed `Claude Code v<version>` banner; real capture: `_V2_READY_PANE`, `test_tui_session_v2_ready_marker.py`, differing only in the greeting). `clear_compose_buffer` now waits (bounded by a new `welcome_wait_s` param, default 2.5s) for that screen to clear — on the initial capture **and** before every resend — before trusting any read of the live compose box. Once it's gone, the existing clear/verify logic runs completely unchanged, so the original `/compact-burst-on-restart` fix this mechanism exists for is fully preserved. The exhaustion log path also now names the actual cause when the welcome screen itself never releases, instead of misreporting "the Ink TUI kept dropping the clear keystroke" when no keystroke was ever sent.

Composes with #598 (`_recent_tail` scoping in `prompts.py`, merged just before this PR was opened) without touching it: same LIVE-region principle, but a different function serving a different purpose (compose-buffer clearing vs. modal auto-accept) — zero overlap, zero conflict. `_tui_inject.py`, `prompts.py`, `_tui_drain.py`, and `tui_session.py` are all untouched — the fix is fully contained in `_tui_compose.py` plus one new test file, to keep blast radius minimal on this high-traffic boot path.

## Test plan
- [x] New `tests/scitex_agent_container/runtimes/test__tui_compose_welcome_guard.py` (12 tests, real recording fakes + a deterministic fake clock, no mocks): predicate correctness (fresh-welcome matches; resumed "Welcome back", plain booting pane, and an unrelated modal all do not), waits-out-then-no-ops on an actually-empty box (zero Escape sent), waits-out-then-still-clears-a-genuine-stale-buffer underneath (the original bug's fix preserved), and the pathological never-clears case (bounded, fails loud with the welcome-specific message, never raises, never blind-fires Escape).
- [x] Full existing `tests/scitex_agent_container/runtimes/` suite: **1267 passed, 20 skipped (real-tmux integration tests, expected to skip in this sandbox), 0 failed** — including `test_tui_session_clear_compose.py` (the original `/compact-burst` fix, unchanged), `test__tui_compose_esc_guard.py` (the Esc-cancel guard, unchanged), `test_prompts.py` (60 tests incl. PR #598's `_recent_tail` fix, unchanged), `test_tui_session_v2_ready_marker.py` (**resumed-session** ready state, unchanged — proves the already-working resumed boot path is untouched), and `test_tui_session_verify_advancement.py` (the `verify_submit_by_advancement` **fallback net**, unchanged).
- [x] `ruff check --select F401,F811` clean on both changed files.