### PR TITLE
fix(mcp,cli): skip empty channel notifications; unicode-safe status table

### DIFF
--- a/src/scitex_agent_container/_mcp/channel.py
+++ b/src/scitex_agent_container/_mcp/channel.py
@@ -305,14 +305,16 @@ async def _push_channel_event(
         # Notification-only delivery (no colocated runner to wake, or an
         # ack/empty event that does not warrant a driven turn).
         params = _build_notification(event)
-        msg = JSONRPCMessage(
-            JSONRPCNotification(
-                jsonrpc="2.0",
-                method="notifications/claude/channel",
-                params=params,
+        content = params.get("content", "")
+        if isinstance(content, str) and content.strip():
+            msg = JSONRPCMessage(
+                JSONRPCNotification(
+                    jsonrpc="2.0",
+                    method="notifications/claude/channel",
+                    params=params,
+                )
             )
-        )
-        await session.send_message(SessionMessage(msg))
+            await session.send_message(SessionMessage(msg))
 
     # Post-delivery receipts: contentless auto-ack (legacy noise-filtered
     # path) + structural reaction-ack (the comm-miss-detectable signal,

--- a/src/scitex_agent_container/cli_pkg/status_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/status_cmds.py
@@ -55,6 +55,30 @@ def _status_via_host_listen(name: str) -> None:
     sys.exit(outcome.exit_code)
 
 
+def _encode_safe_cell(value: object, encoding: str) -> str:
+    """Stringify ``value`` for a rich table cell, coerced to round-trip
+    through ``encoding``.
+
+    ``agent_status()`` surfaces free-form runtime content verbatim
+    (``extensions``, tmux ``pane_text``, ``CLAUDE.md`` snippets, tool-input
+    previews, ...) that can carry non-ASCII characters -- including the
+    Claude Code TUI's own prompt glyph, which shows up in almost every
+    live agent's captured pane text. When the process's stdout encoding
+    is not UTF-8 (locale-stripped containers, cron, some SSH sessions --
+    exactly this project's own apptainer SIF deployments), rendering that
+    text raises ``UnicodeEncodeError`` partway through ``console.print``.
+    Replacing unencodable characters here -- before the cell is ever
+    added to the table -- prevents the crash instead of masking it with
+    a broad try/except around the print call.
+    """
+    text = str(value)
+    try:
+        text.encode(encoding)
+    except (UnicodeEncodeError, LookupError):
+        return text.encode(encoding, errors="replace").decode(encoding)
+    return text
+
+
 def _format_claude_account_block(meta: dict) -> list[str]:
     """Render the ``Claude Code account`` section as a list of text lines.
 
@@ -327,11 +351,17 @@ def status(
 
         table = Table(title=f"Agent: {name}")
         table.add_column("Field", style="bold")
-        table.add_column("Value")
+        # overflow="fold" (not the default "ellipsis"): a too-wide cell
+        # (e.g. a long config path) is hard-wrapped instead of truncated
+        # with Rich's own "…" marker, which is itself non-ASCII and would
+        # defeat the encode-safety below.
+        table.add_column("Value", overflow="fold")
+        cell_encoding = getattr(console.file, "encoding", None) or "utf-8"
         for key, value in info.items():
             style = "green" if key == "status" and value == "running" else ""
             style = "red" if key == "status" and value == "stopped" else style
-            table.add_row(key, str(value), style=style)
+            cell = _encode_safe_cell(value, cell_encoding)
+            table.add_row(key, cell, style=style)
         console.print(table)
     else:
         # `agents status` only shows agents now. Claude-account info

--- a/tests/scitex_agent_container/_mcp/test_channel.py
+++ b/tests/scitex_agent_container/_mcp/test_channel.py
@@ -1027,6 +1027,32 @@ async def test_push_channel_event_still_injects_notification(fake_listen):
     assert len(session.sent) == 1
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("blank_content", ["", "   ", "\n\t"])
+async def test_push_channel_event_skips_notification_for_blank_content(
+    fake_listen, blank_content
+):
+    """Bug 1 (sac-fleet-ux-misc-2026-06-24): an empty/whitespace-only
+    content must not push a notification -- it used to render as a bare
+    "<- sac:" line with nothing after it. Distinct from the wake-loop /
+    auto-ack logic covered elsewhere in this module."""
+    # Arrange
+    from scitex_agent_container._mcp.channel import _push_channel_event
+
+    session = _CapturingSession()
+    event = {"from_agent": "bob", "content": blank_content, "msg_id": "m1"}
+    # Act
+    await _push_channel_event(
+        session,
+        event,
+        agent_name="alice",
+        listen_url=fake_listen.base_url,
+        bearer=None,
+    )
+    # Assert — no notification was pushed for blank content.
+    assert session.sent == []
+
+
 def _contentless_ack_posts(fake_listen) -> list:
     """Filter the fake listen's posts down to contentless legacy acks.
 

--- a/tests/scitex_agent_container/cli_pkg/test_status_cmds.py
+++ b/tests/scitex_agent_container/cli_pkg/test_status_cmds.py
@@ -446,6 +446,52 @@ def test_status_per_agent_table_includes_stopped_status(tmp_path, tmp_registry):
     assert "stopped" in result.output
 
 
+def test_status_per_agent_table_survives_non_ascii_extensions_on_ascii_stdout(
+    tmp_path, tmp_registry
+):
+    """Bug 2 (sac-fleet-ux-misc-2026-06-24): ``spec.extensions`` is an
+    opaque pass-through echoed verbatim into the status table -- real
+    agents commonly carry non-ASCII content there (and in pane_text /
+    CLAUDE.md snippets, which are harder to control deterministically in
+    a test). ``CliRunner(charset="ascii")`` gives ``sys.stdout`` a real
+    strict-ASCII ``TextIOWrapper`` -- the same shape a locale-stripped
+    container/cron invocation produces -- so ``console.print(table)``
+    used to raise ``UnicodeEncodeError`` partway through rendering."""
+    # Arrange
+    spec = _write_spec(
+        tmp_path,
+        "unicode-agent",
+        body=(
+            "apiVersion: scitex-agent-container/v3\n"
+            "kind: Agent\n"
+            "metadata: {}\n"
+            "spec:\n"
+            "  runtime: apptainer\n"
+            "  host: local\n"
+            "  workdir: /home/agent/work\n"
+            "  apptainer:\n"
+            "    image: /x.sif\n"
+            "    binds: []\n"
+            "  claude:\n"
+            "    model: sonnet\n"
+            "  health:\n"
+            "    enabled: true\n"
+            "    interval: 60\n"
+            "  restart:\n"
+            "    policy: on-failure\n"
+            "    max_retries: 3\n"
+            "  extensions:\n"
+            "    note: \"❯ ready\"\n"
+        ),
+    )
+    _register(tmp_registry, "unicode-agent", spec)
+    runner = CliRunner(charset="ascii")
+    # Act
+    result = runner.invoke(status, ["unicode-agent"])
+    # Assert
+    assert result.exit_code == 0, repr(result.exception)
+
+
 def test_status_per_agent_not_in_registry_json_exits_one(tmp_registry):
     # Arrange -- empty registry; real ``agent_status`` raises
     # ``RuntimeError("Agent 'ghost' not found in registry")``.


### PR DESCRIPTION
Fixes the two remaining open sub-items of scitex-todo card `sac-fleet-ux-misc-2026-06-24`.

## Bug 1 — empty `<- sac:` channel line

`_push_channel_event`'s notification-only branch pushed every bus event verbatim, so an empty-content event from source `sac` rendered as a bare `<- sac:` line in the recipient's terminal. The fix skips the `notifications/claude/channel` push when the built content is empty or whitespace-only. Wake-loop logic is untouched (`_should_wake_turn` already refuses blank content on the wake path, and the reaction-ack absorption path is upstream of this branch).

## Bug 2 — `sac agents status <name>` crash at `console.print(table)`

Reproduced the reported rich-render crash: `agent_status()` echoes free-form runtime content verbatim into the per-agent table — `extensions`, tmux `pane_text` (which routinely contains the Claude TUI's own `U+276F` prompt glyph), `CLAUDE.md` snippets, tool-input previews. When stdout's encoding is not UTF-8 (locale-stripped container / cron — this project's own SIF deployment shape), `console.print(table)` raises `UnicodeEncodeError` partway through rendering.

Root-cause fix (no broad try/except):
- coerce each cell through the console's real output encoding (`errors='replace'`) **before** `add_row`, via the new `_encode_safe_cell` helper;
- `overflow='fold'` on the Value column so rich's own ellipsis marker (`U+2026`, injected when truncating long single-token cells like config paths) cannot re-introduce non-encodable output after sanitization.

## Tests (no mocks; one assert per test)

- `test_push_channel_event_skips_notification_for_blank_content` — parametrized over `""`, spaces, `\n\t`; drives the real `_push_channel_event` against the suite's real loopback listen server.
- `test_status_per_agent_table_survives_non_ascii_extensions_on_ascii_stdout` — end-to-end through `CliRunner(charset='ascii')`, which gives `sys.stdout` a real strict-ASCII `TextIOWrapper` (the same shape that crashed in production). Fails with the exact production `UnicodeEncodeError` on pre-fix code.

Full targeted run: 114/114 passed (`tests/scitex_agent_container/cli_pkg/test_status_cmds.py` + `tests/scitex_agent_container/_mcp/test_channel.py`). Ruff `F401,F811`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)