### PR TITLE
feat(image): self-demote sac image build to low priority by default

### DIFF
--- a/src/scitex_agent_container/_build_priority.py
+++ b/src/scitex_agent_container/_build_priority.py
@@ -1,0 +1,195 @@
+"""Low-priority self-demotion for CPU/IO-heavy container image builds.
+
+incident-local-heavy-build (2026-07-10): ``sac image build`` ran a full
+SIF bake (apt + pip + mksquashfs, ~40 min of sustained CPU + IO) at
+NORMAL priority on the operator's already-loaded interactive host — load
+spiked 27 → 50+ and interactive latency tanked. Permanent fix #1: the
+build path self-demotes BY DEFAULT so a bake only consumes CPU/IO the
+host isn't using interactively. Dedicated build machines / CI opt out
+explicitly (GitHub-hosted runners are single-purpose, so default-on is
+harmless there — the opt-out just has to exist).
+
+IO class choice — best-effort lowest, NOT idle (field-tested the same
+night): a host SIF build run at ``ionice -c 3`` (idle class) died
+silently at the "Creating SIF file..." (mksquashfs) stage on the loaded
+host — process vanished, no error in the build log, no OOM trace, the
+publish symlink never swapped. Idle-class IO is only serviced when the
+disk is otherwise idle, so under sustained load it can starve
+INDEFINITELY (and apparently got the squash stage killed or
+wedged-then-reaped). Best-effort lowest (``ionice -c 2 -n 7``) still
+yields to all higher-priority interactive IO but is guaranteed forward
+progress; that is the setting this module bakes in.
+
+Two demotion mechanisms, one per spawn shape:
+
+* :func:`demote_current_process_to_low_priority` — for build work whose
+  heavy subprocess is spawned BELOW an API boundary sac cannot reach.
+  ``sac image build`` delegates to ``scitex_container.build()`` (a
+  Python function of the separately-installed scitex-container package)
+  whose internal ``subprocess.run(["apptainer", "build", ...])`` sac
+  never sees, so an argv prefix is impossible there. Both the CPU nice
+  value and the IO scheduling class/level are INHERITED across
+  fork/exec, so demoting the calling process covers the entire
+  descendant tree (apptainer build → apt/pip in %post → mksquashfs)
+  plus the in-process build-context staging copy. Demotion is ONE-WAY
+  for unprivileged processes (renicing back down needs CAP_SYS_NICE),
+  so only call this from a short-lived CLI process that exits after the
+  build — NEVER from a long-lived server (MCP server, listen daemon,
+  agent runner).
+
+* :func:`low_priority_build_prefix` — for ``apptainer build`` argvs sac
+  composes itself (``runtimes/_apptainer_build.py``, the agent-start
+  lazy SIF builds). Prefixing ``nice -n 19 ionice -c 2 -n 7`` demotes
+  ONLY the spawned build; the calling process — and the agent container
+  it goes on to launch — stays at normal priority.
+
+CPU demotion is pure-stdlib (``os.setpriority``). IO demotion has no
+stdlib binding, so both paths use util-linux ``ionice``; when ``ionice``
+is not on PATH they degrade gracefully to nice-only with a warning
+line, never a crash (macOS, minimal containers).
+
+Opt-out surfaces: ``--no-nice`` on ``sac image build``, or
+``SAC_BUILD_NO_NICE=1`` in the environment (covers the agent-start
+build path too, and lets a dedicated build box disable self-demotion
+fleet-wide without touching every invocation).
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+
+BUILD_NICENESS = 19
+
+# Best-effort class (2), lowest level (7) — deliberately NOT the idle
+# class (3): idle-class IO can starve indefinitely on a loaded host and
+# killed/wedged a real mksquashfs stage in the field (module docstring).
+BUILD_IONICE_CLASS = "2"
+BUILD_IONICE_LEVEL = "7"
+
+# Environment opt-out — equivalent to ``--no-nice`` everywhere sac
+# demotes a build. Any value other than empty/"0" disables demotion.
+NO_NICE_ENV = "SAC_BUILD_NO_NICE"
+
+# The loud one-line notices ``sac image build`` prints when self-demotion
+# is active, so nobody is surprised by a slower build.
+LOW_PRIORITY_NOTICE = (
+    "building at low priority (nice 19 + ionice best-effort low); "
+    "pass --no-nice for full speed"
+)
+LOW_PRIORITY_NOTICE_NICE_ONLY = (
+    "building at low CPU priority (nice 19; ionice unavailable); "
+    "pass --no-nice for full speed"
+)
+
+
+def _no_nice_env_set() -> bool:
+    """``True`` when :data:`NO_NICE_ENV` requests normal-priority builds."""
+    return os.environ.get(NO_NICE_ENV, "").strip() not in ("", "0")
+
+
+def _set_io_low_on_self() -> str | None:
+    """Move THIS process to best-effort-lowest IO priority.
+
+    Shells out to ``ionice -c 2 -n 7 -p <own-pid>`` (there is no stdlib
+    ``ioprio_set`` binding, and hand-rolling the syscall number is
+    arch-fragile). Best-effort lowest, deliberately NOT the idle class —
+    see the module docstring for the field incident behind that choice.
+    Returns a one-line warning on graceful degrade (``ionice`` missing /
+    failed — CPU nice still applies), ``None`` on success.
+    """
+    ionice = shutil.which("ionice")
+    if ionice is None:
+        return (
+            "warning: ionice not found on PATH — IO priority stays at the "
+            "default (CPU nice 19 still applies)"
+        )
+    result = subprocess.run(
+        [
+            ionice,
+            "-c",
+            BUILD_IONICE_CLASS,
+            "-n",
+            BUILD_IONICE_LEVEL,
+            "-p",
+            str(os.getpid()),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return (
+            f"warning: ionice -c {BUILD_IONICE_CLASS} -n {BUILD_IONICE_LEVEL} "
+            f"failed (rc={result.returncode}: {result.stderr.strip()}) — IO "
+            "priority stays at the default (CPU nice 19 still applies)"
+        )
+    return None
+
+
+def demote_current_process_to_low_priority(*, skip: bool = False) -> list[str]:
+    """Self-demote the CURRENT process to low CPU + IO priority.
+
+    Sets CPU nice to :data:`BUILD_NICENESS` via ``os.setpriority`` and
+    IO to best-effort lowest (``ionice -c 2 -n 7``) on our own PID —
+    NOT the idle IO class, which starved/killed a real mksquashfs stage
+    under load (module docstring). Every subprocess spawned afterwards
+    inherits both, so the whole build tree (apptainer build → %post
+    apt/pip → mksquashfs) runs at low priority without sac touching the
+    spawn site.
+
+    Returns the notice/warning lines the caller should print — the loud
+    :data:`LOW_PRIORITY_NOTICE` one-liner on full success, a degrade
+    warning plus :data:`LOW_PRIORITY_NOTICE_NICE_ONLY` when ``ionice``
+    is unavailable, and an empty list when demotion was skipped
+    (``skip=True`` from ``--no-nice``, or :data:`NO_NICE_ENV` set).
+
+    One-way for unprivileged processes — call only from short-lived CLI
+    processes that exit after the build (see module docstring).
+    """
+    if skip or _no_nice_env_set():
+        return []
+    try:
+        os.setpriority(os.PRIO_PROCESS, 0, BUILD_NICENESS)
+    except OSError as exc:
+        return [
+            f"warning: could not self-demote to nice {BUILD_NICENESS} "
+            f"({exc}); building at normal priority"
+        ]
+    warning = _set_io_low_on_self()
+    if warning is not None:
+        return [warning, LOW_PRIORITY_NOTICE_NICE_ONLY]
+    return [LOW_PRIORITY_NOTICE]
+
+
+def low_priority_build_prefix() -> list[str]:
+    """argv prefix that runs ONE spawned build at low priority.
+
+    ``["nice", "-n", "19", "ionice", "-c", "2", "-n", "7"]`` when both
+    tools are on PATH (best-effort lowest — never the starvation-prone
+    idle class; see module docstring); degrades to nice-only when
+    ``ionice`` is absent; empty (no demotion) when ``nice`` itself is
+    absent or :data:`NO_NICE_ENV` opts out. Prepend to an ``apptainer
+    build`` argv so only the build subprocess is demoted — the calling
+    process keeps normal priority.
+    """
+    if _no_nice_env_set():
+        return []
+    if shutil.which("nice") is None:
+        return []
+    prefix = ["nice", "-n", str(BUILD_NICENESS)]
+    if shutil.which("ionice") is not None:
+        prefix += ["ionice", "-c", BUILD_IONICE_CLASS, "-n", BUILD_IONICE_LEVEL]
+    return prefix
+
+
+__all__ = [
+    "BUILD_IONICE_CLASS",
+    "BUILD_IONICE_LEVEL",
+    "BUILD_NICENESS",
+    "LOW_PRIORITY_NOTICE",
+    "LOW_PRIORITY_NOTICE_NICE_ONLY",
+    "NO_NICE_ENV",
+    "demote_current_process_to_low_priority",
+    "low_priority_build_prefix",
+]

--- a/src/scitex_agent_container/_skills/scitex-agent-container/24_image-build.md
+++ b/src/scitex_agent_container/_skills/scitex-agent-container/24_image-build.md
@@ -64,6 +64,36 @@ apptainer build sac-scitex.sif sac-scitex.def   # uses sac-base.sif as bootstrap
 apt deps — budget several minutes. Restart agents after a rebuild so they pick up
 the new `.sif`.
 
+### Low-priority default (incident-local-heavy-build)
+
+`sac image build` **self-demotes by default** — the whole bake (staging copy,
+`apptainer build`, `%post` apt/pip, mksquashfs) runs at CPU `nice 19` + IO
+best-effort lowest (`ionice -c 2 -n 7`) so a ~40-min build can't starve an
+interactive host (2026-07-10: load 27 → 50+ during a normal-priority bake).
+A one-line notice is printed when demotion is active:
+
+```
+building at low priority (nice 19 + ionice best-effort low); pass --no-nice for full speed
+```
+
+**Why best-effort-low and NOT the idle IO class (`-c 3`)**: field-tested the
+same night — a host SIF build at `ionice -c 3` died silently at the
+"Creating SIF file..." (mksquashfs) stage on the loaded host: process
+vanished, no error in the build log, no OOM trace, the publish symlink never
+swapped. Idle-class IO is only serviced when the disk is otherwise idle, so
+under sustained load it can starve indefinitely (and appears to have gotten
+the squash stage killed or wedged-then-reaped). `-c 2 -n 7` still yields to
+all interactive IO but is guaranteed forward progress. If you ever *want*
+harder demotion, run the build under `ionice -c 3` yourself and accept the
+starvation risk.
+
+Opt out on dedicated build machines / CI with `sac image build ... --no-nice`,
+or fleet-wide via `SAC_BUILD_NO_NICE=1`. When `ionice` is missing the build
+degrades gracefully to nice-only (warning line, no crash). Agent-start lazy SIF
+builds (`resolve_sif` → `apptainer build` for a cold `docker://` image or
+`def_file`) are prefixed with `nice -n 19 ionice -c 2 -n 7` the same way; the
+same env var opts out.
+
 ## Pinning a stable version (vs tracking @develop)
 
 `@develop` means every rebuild tracks the tip of develop. For a reproducible

--- a/src/scitex_agent_container/cli_pkg/_image_inventory_cmds.py
+++ b/src/scitex_agent_container/cli_pkg/_image_inventory_cmds.py
@@ -1,0 +1,153 @@
+"""``sac image list / status / snapshot`` — installed-image reporting verbs.
+
+Extracted from :mod:`image_group` (512-line budget) when the
+incident-local-heavy-build low-priority default pushed the group module
+over the cap; registered back onto the ``sac image`` group via
+``image_group.add_command`` so the CLI surface is unchanged. One cohesive
+responsibility: read-only reporting over already-built artefacts (no
+build/mutate verbs here).
+
+Shared constants and backend seams (``_CONTAINERS_DIR``,
+``_SCITEX_USER_STATE_ROOT``, ``_ensure_containers_dir``,
+``_load_apptainer``, ``_load_env_snapshot``) stay in :mod:`image_group` —
+the mutating verbs share them, and the test suite swaps them there via the
+save/restore pattern. Each command body therefore imports
+:mod:`image_group` lazily at call time: the swap stays effective and there
+is no import-time cycle (image_group imports THIS module to register the
+commands).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import click
+
+from ._helpers import console
+
+
+@click.command("list")
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON.")
+def image_list(as_json: bool) -> None:
+    """List installed SIFs across every scitex-* package.
+
+    Discovers via the ``~/.scitex/<pkg>/containers/*.sif`` convention
+    (operator design 8566) — sac does NOT know any other package by
+    name; new packages light up automatically.
+
+    \b
+    Example:
+      $ sac image list
+      $ sac image list --json
+    """
+    from . import image_group as ig
+
+    ig._ensure_containers_dir()
+    root = ig._SCITEX_USER_STATE_ROOT
+    entries: list[Path] = []
+    entries.extend(sorted(root.glob("*/containers/*.sif")))
+    entries.extend(
+        sorted(p for p in root.glob("*/containers/*.sandbox") if p.is_dir())
+    )
+
+    def _dir_size_bytes(d: Path) -> int:
+        total = 0
+        for p in d.rglob("*"):
+            try:
+                if p.is_file() and not p.is_symlink():
+                    total += p.stat().st_size
+            except OSError:
+                pass
+        return total
+
+    versions = []
+    for p in entries:
+        is_sandbox = p.is_dir()
+        size_bytes = _dir_size_bytes(p) if is_sandbox else p.stat().st_size
+        versions.append(
+            {
+                "package": p.parent.parent.name,
+                "name": p.name,
+                "path": str(p),
+                "kind": "sandbox" if is_sandbox else "sif",
+                "size_bytes": size_bytes,
+                "mtime": p.stat().st_mtime,
+            }
+        )
+    console.print(f"[dim]scan root: {root}/*/containers/[/dim]")
+    if as_json:
+        click.echo(json.dumps(versions, indent=2, default=str))
+        return
+    if not versions:
+        console.print(
+            f"[dim](no SIFs under {root}/*/containers/ — "
+            f"run `sac image build base -y && sac image build scitex -y` to "
+            f"populate; downstream packages populate their own siblings)[/dim]"
+        )
+        return
+    for v in versions:
+        size_mb = v["size_bytes"] / (1024 * 1024)
+        tag = "sandbox" if v["kind"] == "sandbox" else "sif"
+        label = f"{v['package']}/{v['name']}"
+        console.print(f"  {tag:<7s}  {label:50s} {size_mb:>8.1f} MB")
+
+
+@click.command("status")
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON.")
+def image_status(as_json: bool) -> None:
+    """Unified container dashboard (active version, sandboxes, sizes).
+
+    \b
+    Example:
+      $ sac image status
+      $ sac image status --json
+    """
+    from . import image_group as ig
+
+    sc_status = ig._load_apptainer().status
+
+    info = sc_status(containers_dir=ig._CONTAINERS_DIR)
+    if as_json:
+        click.echo(json.dumps(info, indent=2, default=str))
+        return
+    if not info:
+        console.print(f"[dim](no containers in {ig._CONTAINERS_DIR})[/dim]")
+        return
+    for entry in info:
+        name = entry.get("name", "?")
+        size = entry.get("sif_size", "-")
+        rebuild = "REBUILD" if entry.get("needs_rebuild") else "ok"
+        console.print(f"  {name:30s}  {size!s:>10}  {rebuild}")
+
+
+@click.command("snapshot")
+@click.option(
+    "--output",
+    "-o",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=None,
+    help="Write JSON to this path instead of stdout.",
+)
+def image_snapshot(output: Path | None) -> None:
+    """Capture a reproducibility snapshot (pip + apt + conda + git + ...).
+
+    \b
+    Example:
+      $ sac image snapshot
+      $ sac image snapshot -o env.json
+    """
+    from . import image_group as ig
+
+    env_snapshot = ig._load_env_snapshot()
+
+    snap = env_snapshot(containers_dir=ig._CONTAINERS_DIR)
+    payload = json.dumps(snap, indent=2, default=str)
+    if output:
+        output.write_text(payload)
+        console.print(f"[green]wrote[/green] {output}")
+    else:
+        click.echo(payload)
+
+
+__all__ = ["image_list", "image_snapshot", "image_status"]

--- a/src/scitex_agent_container/cli_pkg/image_group.py
+++ b/src/scitex_agent_container/cli_pkg/image_group.py
@@ -24,7 +24,8 @@ from pathlib import Path
 
 import click
 
-from . import _image_source_build
+from .. import _build_priority
+from . import _image_inventory_cmds, _image_source_build
 from ._helpers import HelpRecursiveGroup, console
 
 # Module-level overridable reference for the source-bundled build path.
@@ -32,6 +33,11 @@ from ._helpers import HelpRecursiveGroup, console
 # pattern as ``_load_apptainer``); production code calls through it so
 # tests don't need to patch the cli_pkg._image_source_build module.
 _build_layer_from_source = _image_source_build.build_layer_from_source
+
+# Same seam pattern for the low-priority self-demotion
+# (incident-local-heavy-build) — tests swap in a recording fake so the
+# pytest process itself never gets demoted (demotion is one-way).
+_demote_build_priority = _build_priority.demote_current_process_to_low_priority
 
 # Recipes ship inside the wheel (read-only, package-relative).
 _RECIPES_DIR = Path(__file__).resolve().parent.parent / "containers"
@@ -129,6 +135,14 @@ def image_group() -> None:
     """Container image lifecycle (apptainer + docker; delegates to scitex-container)."""
 
 
+# Read-only reporting verbs (list / status / snapshot) — extracted to
+# _image_inventory_cmds (512-line budget); registered here so the CLI
+# surface is unchanged.
+image_group.add_command(_image_inventory_cmds.image_list)
+image_group.add_command(_image_inventory_cmds.image_status)
+image_group.add_command(_image_inventory_cmds.image_snapshot)
+
+
 # ---------------------------------------------------------------------------
 # build
 # ---------------------------------------------------------------------------
@@ -148,10 +162,21 @@ def image_group() -> None:
     default=False,
     help="Skip confirmation. Also implies overwrite of any existing SIF.",
 )
-def image_build(layer: str, sandbox: bool, dry_run: bool, yes: bool) -> None:
+@click.option(
+    "--no-nice",
+    is_flag=True,
+    default=False,
+    help="Build at normal priority (skip the default nice-19 + ionice "
+    "best-effort-low self-demotion; for dedicated build machines / CI).",
+)
+def image_build(
+    layer: str, sandbox: bool, dry_run: bool, yes: bool, no_nice: bool
+) -> None:
     """Build the :LAYER Apptainer SIF (default: base).
 
     Sac is apptainer-only since the 2026-05-13 docker/podman ripout.
+    Builds self-demote to low CPU/IO priority by default so a bake
+    can't starve an interactive host; ``--no-nice`` restores full speed.
 
     \b
     Examples:
@@ -224,6 +249,16 @@ def image_build(layer: str, sandbox: bool, dry_run: bool, yes: bool) -> None:
     except _image_source_build.BootstrapSifMissing as exc:
         click.echo(f"error: {exc}", err=True)
         sys.exit(1)
+
+    # incident-local-heavy-build: self-demote NOW — after every cheap
+    # validation/refusal path, right before the heavy work — so the whole
+    # bake (staging copytree + scitex-container's apptainer build →
+    # %post apt/pip → mksquashfs, which all inherit this process's
+    # priority) runs at low CPU/IO priority by default. Best-effort-low
+    # IO, not idle class — idle starved/killed a real mksquashfs stage
+    # under load (see _build_priority module docstring).
+    for line in _demote_build_priority(skip=no_nice):
+        click.echo(line)
 
     try:
         output = _build_layer_from_source(
@@ -321,76 +356,6 @@ def image_freeze(sandbox_dir: Path, output_sif: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# list
-# ---------------------------------------------------------------------------
-@image_group.command("list")
-@click.option("--json", "as_json", is_flag=True, help="Output as JSON.")
-def image_list(as_json: bool) -> None:
-    """List installed SIFs across every scitex-* package.
-
-    Discovers via the ``~/.scitex/<pkg>/containers/*.sif`` convention
-    (operator design 8566) — sac does NOT know any other package by
-    name; new packages light up automatically.
-
-    \b
-    Example:
-      $ sac image list
-      $ sac image list --json
-    """
-    _ensure_containers_dir()
-    entries: list[Path] = []
-    entries.extend(sorted(_SCITEX_USER_STATE_ROOT.glob("*/containers/*.sif")))
-    entries.extend(
-        sorted(
-            p
-            for p in _SCITEX_USER_STATE_ROOT.glob("*/containers/*.sandbox")
-            if p.is_dir()
-        )
-    )
-
-    def _dir_size_bytes(d: Path) -> int:
-        total = 0
-        for p in d.rglob("*"):
-            try:
-                if p.is_file() and not p.is_symlink():
-                    total += p.stat().st_size
-            except OSError:
-                pass
-        return total
-
-    versions = []
-    for p in entries:
-        is_sandbox = p.is_dir()
-        size_bytes = _dir_size_bytes(p) if is_sandbox else p.stat().st_size
-        versions.append(
-            {
-                "package": p.parent.parent.name,
-                "name": p.name,
-                "path": str(p),
-                "kind": "sandbox" if is_sandbox else "sif",
-                "size_bytes": size_bytes,
-                "mtime": p.stat().st_mtime,
-            }
-        )
-    console.print(f"[dim]scan root: {_SCITEX_USER_STATE_ROOT}/*/containers/[/dim]")
-    if as_json:
-        click.echo(json.dumps(versions, indent=2, default=str))
-        return
-    if not versions:
-        console.print(
-            f"[dim](no SIFs under {_SCITEX_USER_STATE_ROOT}/*/containers/ — "
-            f"run `sac image build base -y && sac image build scitex -y` to "
-            f"populate; downstream packages populate their own siblings)[/dim]"
-        )
-        return
-    for v in versions:
-        size_mb = v["size_bytes"] / (1024 * 1024)
-        tag = "sandbox" if v["kind"] == "sandbox" else "sif"
-        label = f"{v['package']}/{v['name']}"
-        console.print(f"  {tag:<7s}  {label:50s} {size_mb:>8.1f} MB")
-
-
-# ---------------------------------------------------------------------------
 # switch
 # ---------------------------------------------------------------------------
 @image_group.command("switch")
@@ -423,65 +388,6 @@ def image_rollback() -> None:
 
     prev = rollback(containers_dir=_CONTAINERS_DIR)
     console.print(f"[green]rolled back[/green] -> {prev}")
-
-
-# ---------------------------------------------------------------------------
-# status
-# ---------------------------------------------------------------------------
-@image_group.command("status")
-@click.option("--json", "as_json", is_flag=True, help="Output as JSON.")
-def image_status(as_json: bool) -> None:
-    """Unified container dashboard (active version, sandboxes, sizes).
-
-    \b
-    Example:
-      $ sac image status
-      $ sac image status --json
-    """
-    sc_status = _load_apptainer().status
-
-    info = sc_status(containers_dir=_CONTAINERS_DIR)
-    if as_json:
-        click.echo(json.dumps(info, indent=2, default=str))
-        return
-    if not info:
-        console.print(f"[dim](no containers in {_CONTAINERS_DIR})[/dim]")
-        return
-    for entry in info:
-        name = entry.get("name", "?")
-        size = entry.get("sif_size", "-")
-        rebuild = "REBUILD" if entry.get("needs_rebuild") else "ok"
-        console.print(f"  {name:30s}  {size!s:>10}  {rebuild}")
-
-
-# ---------------------------------------------------------------------------
-# snapshot
-# ---------------------------------------------------------------------------
-@image_group.command("snapshot")
-@click.option(
-    "--output",
-    "-o",
-    type=click.Path(dir_okay=False, path_type=Path),
-    default=None,
-    help="Write JSON to this path instead of stdout.",
-)
-def image_snapshot(output: Path | None) -> None:
-    """Capture a reproducibility snapshot (pip + apt + conda + git + ...).
-
-    \b
-    Example:
-      $ sac image snapshot
-      $ sac image snapshot -o env.json
-    """
-    env_snapshot = _load_env_snapshot()
-
-    snap = env_snapshot(containers_dir=_CONTAINERS_DIR)
-    payload = json.dumps(snap, indent=2, default=str)
-    if output:
-        output.write_text(payload)
-        console.print(f"[green]wrote[/green] {output}")
-    else:
-        click.echo(payload)
 
 
 # ---------------------------------------------------------------------------

--- a/src/scitex_agent_container/runtimes/_apptainer_build.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_build.py
@@ -98,13 +98,26 @@ def _should_use_fakeroot_for_build(
 
 
 def _build_argv_prefix() -> list[str]:
-    """Return ``["apptainer", "build"]`` plus ``--fakeroot`` when needed.
+    """Return the demoted ``apptainer build`` argv head.
+
+    ``nice -n 19 ionice -c 2 -n 7 apptainer build [--fakeroot]`` — the
+    low-priority prefix (incident-local-heavy-build: a full SIF bake at
+    normal priority starved the operator's loaded interactive host)
+    demotes ONLY the spawned build subprocess; the calling process — and
+    the agent container it goes on to launch — keeps normal priority.
+    IO runs at best-effort lowest, NOT the idle class: idle-class IO
+    starved/killed a real mksquashfs stage under sustained load (see
+    :mod:`scitex_agent_container._build_priority`). Degrades to
+    nice-only when ``ionice`` is off PATH, and to no prefix at all
+    under ``SAC_BUILD_NO_NICE=1``.
 
     Used by both :func:`_build_sif_from_def` and
-    :func:`_build_sif_from_uri` so the fakeroot logic stays in one
-    place.
+    :func:`_build_sif_from_uri` so the fakeroot + priority logic stays
+    in one place.
     """
-    argv = ["apptainer", "build"]
+    from .._build_priority import low_priority_build_prefix
+
+    argv = low_priority_build_prefix() + ["apptainer", "build"]
     if _should_use_fakeroot_for_build():
         argv.append("--fakeroot")
     return argv

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,15 @@ _COVERAGE_DIR.mkdir(parents=True, exist_ok=True)
 os.environ["COVERAGE_PROCESS_START"] = str(_PROJECT_ROOT / "pyproject.toml")
 os.environ["COVERAGE_FILE"] = str(_COVERAGE_DIR / ".coverage")
 
+# incident-local-heavy-build: `sac image build` self-demotes its own
+# process (CPU nice 19 + IO best-effort lowest) by default, and demotion
+# is ONE-WAY for unprivileged processes. Tests drive the real CLI
+# in-process via CliRunner, so without this opt-out the first build test
+# would demote the entire remaining pytest run. The real demotion
+# behavior is exercised in CHILD interpreters with a curated env — see
+# tests/scitex_agent_container/test__build_priority.py.
+os.environ.setdefault("SAC_BUILD_NO_NICE", "1")
+
 
 def _ensure_subprocess_coverage_shim() -> None:
     """Drop an idempotent ``.pth`` shim in site-packages so every child

--- a/tests/scitex_agent_container/cli_pkg/test_image_group.py
+++ b/tests/scitex_agent_container/cli_pkg/test_image_group.py
@@ -153,6 +153,31 @@ def _use_source_builder(
         ig._build_layer_from_source = saved  # type: ignore[assignment]
 
 
+@contextmanager
+def _use_demoter(*, lines: list[str] | None = None) -> Iterator[list[dict]]:
+    """Swap ``image_group._demote_build_priority`` for a recording fake.
+
+    Same save/restore pattern as ``_use_source_builder``. The fake
+    records each call's kwargs into the yielded list and returns
+    ``lines`` (default: none) — it NEVER demotes, so the pytest process
+    keeps its priority (real demotion is one-way; see
+    tests/scitex_agent_container/test__build_priority.py for the real
+    child-process behavior tests).
+    """
+    calls: list[dict] = []
+
+    def _fake_demoter(**kw):
+        calls.append(kw)
+        return list(lines or [])
+
+    saved = ig._demote_build_priority
+    ig._demote_build_priority = _fake_demoter  # type: ignore[assignment]
+    try:
+        yield calls
+    finally:
+        ig._demote_build_priority = saved  # type: ignore[assignment]
+
+
 # ---------------------------------------------------------------------------
 # tmp-rooted HOME so every command writes into ``tmp_path``.
 # Real env var, real bootstrap, real ``.gitignore``. No monkeypatch.
@@ -345,6 +370,57 @@ def test_build_scitex_errors_loud_when_base_sif_missing(home_tmp):
     result = runner.invoke(image_group, ["build", "scitex", "--yes"])
     # Assert
     assert result.exit_code == 1 and "sac image build base" in result.output
+
+
+# ---------------------------------------------------------------------------
+# build — low-priority self-demotion (incident-local-heavy-build)
+# ---------------------------------------------------------------------------
+
+
+def test_build_default_calls_priority_demoter_with_skip_false(home_tmp):
+    # Arrange
+    runner = CliRunner()
+    # Act
+    with _use_source_builder(result=Path("/tmp/sac-base.sif")):
+        with _use_demoter() as calls:
+            runner.invoke(image_group, ["build", "base", "--yes"])
+    # Assert — self-demotion is the DEFAULT (no flag needed).
+    assert calls == [{"skip": False}]
+
+
+def test_build_no_nice_flag_forwards_skip_true_to_demoter(home_tmp):
+    # Arrange
+    runner = CliRunner()
+    # Act
+    with _use_source_builder(result=Path("/tmp/sac-base.sif")):
+        with _use_demoter() as calls:
+            runner.invoke(image_group, ["build", "base", "--yes", "--no-nice"])
+    # Assert — the explicit opt-out for dedicated build machines / CI.
+    assert calls == [{"skip": True}]
+
+
+def test_build_dry_run_never_calls_priority_demoter(home_tmp):
+    # Arrange — a dry run does no heavy work, so it must not demote.
+    runner = CliRunner()
+    # Act
+    with _use_demoter() as calls:
+        runner.invoke(image_group, ["build", "--dry-run"])
+    # Assert
+    assert calls == []
+
+
+def test_build_echoes_low_priority_notice_from_demoter(home_tmp):
+    # Arrange — the loud one-line notice must land in the build output
+    # so nobody is surprised by a slower build.
+    from scitex_agent_container._build_priority import LOW_PRIORITY_NOTICE
+
+    runner = CliRunner()
+    # Act
+    with _use_source_builder(result=Path("/tmp/sac-base.sif")):
+        with _use_demoter(lines=[LOW_PRIORITY_NOTICE]):
+            result = runner.invoke(image_group, ["build", "base", "--yes"])
+    # Assert
+    assert LOW_PRIORITY_NOTICE in result.output
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scitex_agent_container/runtimes/test__apptainer_build_fakeroot.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_build_fakeroot.py
@@ -213,13 +213,63 @@ def _current_username() -> str:
 # ---------------------------------------------------------------------------
 
 
-def test_build_argv_prefix_starts_with_apptainer_build() -> None:
-    # Arrange — fakeroot probe forced off so the head is the minimum.
+def test_build_argv_prefix_starts_with_apptainer_build(env_save_restore) -> None:
+    # Arrange — fakeroot probe forced off + low-priority demotion
+    # opted out (explicitly, not just via the suite-wide conftest env)
+    # so the head is the minimum.
+    env_save_restore.set("SAC_BUILD_NO_NICE", "1")
     # Act
     with _swap_module_attr("_should_use_fakeroot_for_build", lambda: False):
         argv = _build_argv_prefix()
     # Assert
     assert argv[:2] == ["apptainer", "build"]
+
+
+def test_build_argv_prefix_demotes_spawned_build_when_tools_present(
+    tmp_path: Path, env_save_restore
+) -> None:
+    # Arrange — incident-local-heavy-build: builds sac spawns itself run
+    # under `nice -n 19 ionice -c 2 -n 7` BY DEFAULT so a SIF bake can't
+    # starve the interactive host (best-effort lowest, NOT idle class —
+    # idle IO starved/killed a real mksquashfs stage under load).
+    # Deterministic PATH (fake nice + ionice only); the suite-wide
+    # opt-out env cleared.
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    for tool in ("nice", "ionice"):
+        script = bin_dir / tool
+        script.write_text("#!/bin/sh\nexit 0\n")
+        script.chmod(0o755)
+    env_save_restore.delete("SAC_BUILD_NO_NICE")
+    env_save_restore.set("PATH", str(bin_dir))
+    # Act
+    with _swap_module_attr("_should_use_fakeroot_for_build", lambda: False):
+        argv = _build_argv_prefix()
+    # Assert
+    assert argv == [
+        "nice",
+        "-n",
+        "19",
+        "ionice",
+        "-c",
+        "2",
+        "-n",
+        "7",
+        "apptainer",
+        "build",
+    ]
+
+
+def test_build_argv_prefix_plain_under_no_nice_env_opt_out(
+    env_save_restore,
+) -> None:
+    # Arrange — SAC_BUILD_NO_NICE=1 restores the undemoted argv head.
+    env_save_restore.set("SAC_BUILD_NO_NICE", "1")
+    # Act
+    with _swap_module_attr("_should_use_fakeroot_for_build", lambda: False):
+        argv = _build_argv_prefix()
+    # Assert
+    assert argv == ["apptainer", "build"]
 
 
 def test_build_argv_prefix_includes_fakeroot_when_probe_true() -> None:
@@ -243,6 +293,39 @@ def test_build_argv_prefix_omits_fakeroot_when_probe_false() -> None:
 # ---------------------------------------------------------------------------
 # _build_sif_from_def — end-to-end argv shape
 # ---------------------------------------------------------------------------
+
+
+def test_build_sif_from_def_spawns_build_under_nice_ionice(
+    tmp_path: Path, env_save_restore, subprocess_shim
+) -> None:
+    # Arrange — REAL subprocess path: with demotion on (env opt-out
+    # cleared) the first binary subprocess.run execs must be `nice`,
+    # carrying the full demoted apptainer argv behind it. Recording
+    # `nice` + `ionice` shims sit first on PATH; `nice` exits 0 without
+    # exec'ing onward, which the production code reads as build success.
+    subprocess_shim.install("nice")
+    subprocess_shim.install("ionice")
+    env_save_restore.delete("SAC_BUILD_NO_NICE")
+    def_file = tmp_path / "x.def"
+    def_file.write_text("Bootstrap: docker\n")
+    sif_path = tmp_path / "out.sif"
+    # Act
+    with _swap_module_attr("_should_use_fakeroot_for_build", lambda: False):
+        _build_sif_from_def(sif_path, def_file)
+    # Assert
+    assert subprocess_shim.argv_for("nice") == [
+        "-n",
+        "19",
+        "ionice",
+        "-c",
+        "2",
+        "-n",
+        "7",
+        "apptainer",
+        "build",
+        str(sif_path),
+        str(def_file),
+    ]
 
 
 def test_build_sif_from_def_passes_fakeroot_when_probe_true(

--- a/tests/scitex_agent_container/test__build_priority.py
+++ b/tests/scitex_agent_container/test__build_priority.py
@@ -1,0 +1,246 @@
+"""Tests for ``_build_priority`` — low-priority build self-demotion.
+
+incident-local-heavy-build: ``sac image build`` ran a full SIF bake at
+normal priority on the loaded interactive host. The fix self-demotes the
+build path (CPU nice 19 + IO best-effort lowest, ``ionice -c 2 -n 7``)
+by default. NOT the idle IO class: a field build at ``-c 3`` starved and
+died silently at the mksquashfs stage under sustained load.
+
+No mocks (PA-306). Self-demotion is ONE-WAY for unprivileged processes,
+so the REAL ``demote_current_process_to_low_priority`` behavior is
+exercised in CHILD interpreters (``sys.executable -c``) with a curated
+env — the pytest process itself is never demoted (tests/conftest.py
+additionally sets ``SAC_BUILD_NO_NICE=1`` as suite-wide protection).
+``low_priority_build_prefix`` only does PATH lookups, so it is tested
+in-process against tmp bin dirs. AAA + ≥3-word names + one assert per
+test (PA-307 / STX-TQ002).
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container import _build_priority as bp
+from scitex_agent_container._build_priority import low_priority_build_prefix
+
+_SRC_DIR = Path(bp.__file__).resolve().parents[1]
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _run_child(code: str, *, env_overrides: dict[str, str | None]) -> str:
+    """Run ``code`` in a fresh interpreter; return its stripped stdout.
+
+    The child gets the current env with ``SAC_BUILD_NO_NICE`` REMOVED
+    (tests/conftest.py sets it for suite hygiene; the child is where the
+    real demotion is allowed to happen) and the package src dir on
+    PYTHONPATH so it imports the same module under test. Entries in
+    ``env_overrides`` with a ``None`` value are removed, others set.
+    """
+    env = os.environ.copy()
+    env.pop(bp.NO_NICE_ENV, None)
+    env["PYTHONPATH"] = str(_SRC_DIR) + os.pathsep + env.get("PYTHONPATH", "")
+    for key, value in env_overrides.items():
+        if value is None:
+            env.pop(key, None)
+        else:
+            env[key] = value
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        env=env,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"child interpreter failed: {result.stderr}")
+    return result.stdout.strip()
+
+
+def _make_fake_exec(bin_dir: Path, name: str) -> None:
+    """Drop an executable no-op shell script named ``name`` in ``bin_dir``."""
+    script = bin_dir / name
+    script.write_text("#!/bin/sh\nexit 0\n")
+    script.chmod(0o755)
+
+
+_IMPORT = (
+    "from scitex_agent_container._build_priority "
+    "import demote_current_process_to_low_priority"
+)
+
+
+# ---------------------------------------------------------------------------
+# demote_current_process_to_low_priority — REAL demotion, seen in a child
+# ---------------------------------------------------------------------------
+
+
+def test_demote_sets_cpu_nice_19_on_calling_process() -> None:
+    # Arrange
+    code = (
+        "import os\n"
+        f"{_IMPORT}\n"
+        "demote_current_process_to_low_priority()\n"
+        "print(os.getpriority(os.PRIO_PROCESS, 0))\n"
+    )
+    # Act
+    out = _run_child(code, env_overrides={})
+    # Assert
+    assert out == "19"
+
+
+@pytest.mark.skipif(shutil.which("ionice") is None, reason="ionice not on PATH")
+def test_demote_moves_calling_process_to_lowest_best_effort_io() -> None:
+    # Arrange — after demotion, util-linux `ionice -p <pid>` reports the
+    # process's IO scheduling class + level; best-effort lowest prints
+    # "best-effort: prio 7". Deliberately NOT the idle class — idle IO
+    # starved/killed a real mksquashfs stage under load.
+    code = (
+        "import os, subprocess\n"
+        f"{_IMPORT}\n"
+        "demote_current_process_to_low_priority()\n"
+        "out = subprocess.run(['ionice', '-p', str(os.getpid())],\n"
+        "                     capture_output=True, text=True)\n"
+        "print(out.stdout.strip())\n"
+    )
+    # Act
+    out = _run_child(code, env_overrides={})
+    # Assert
+    assert "best-effort" in out and "7" in out
+
+
+def test_demote_returns_loud_notice_naming_no_nice_flag() -> None:
+    # Arrange — the operator-facing one-liner must say the build is at
+    # low priority AND name the opt-out flag, on both the full and the
+    # ionice-degraded path.
+    code = (
+        f"{_IMPORT}\nprint('\\n'.join(demote_current_process_to_low_priority()))\n"
+    )
+    # Act
+    out = _run_child(code, env_overrides={})
+    # Assert
+    assert "low" in out and "pass --no-nice for full speed" in out
+
+
+def test_demote_env_opt_out_leaves_priority_untouched() -> None:
+    # Arrange — SAC_BUILD_NO_NICE=1 must skip demotion entirely: no
+    # notice lines AND an unchanged nice value.
+    code = (
+        "import os\n"
+        f"{_IMPORT}\n"
+        "before = os.getpriority(os.PRIO_PROCESS, 0)\n"
+        "lines = demote_current_process_to_low_priority()\n"
+        "after = os.getpriority(os.PRIO_PROCESS, 0)\n"
+        "print(f'{lines}|{before == after}')\n"
+    )
+    # Act
+    out = _run_child(code, env_overrides={bp.NO_NICE_ENV: "1"})
+    # Assert
+    assert out == "[]|True"
+
+
+def test_demote_skip_kwarg_returns_no_lines_without_demoting() -> None:
+    # Arrange — skip=True is the `--no-nice` CLI path; env cleared so
+    # ONLY the kwarg drives the skip.
+    code = (
+        "import os\n"
+        f"{_IMPORT}\n"
+        "before = os.getpriority(os.PRIO_PROCESS, 0)\n"
+        "lines = demote_current_process_to_low_priority(skip=True)\n"
+        "after = os.getpriority(os.PRIO_PROCESS, 0)\n"
+        "print(f'{lines}|{before == after}')\n"
+    )
+    # Act
+    out = _run_child(code, env_overrides={})
+    # Assert
+    assert out == "[]|True"
+
+
+# ---------------------------------------------------------------------------
+# low_priority_build_prefix — argv prefix for builds sac spawns itself
+# ---------------------------------------------------------------------------
+
+
+def test_prefix_full_when_nice_and_ionice_on_path(
+    tmp_path: Path, env_save_restore
+) -> None:
+    # Arrange
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _make_fake_exec(bin_dir, "nice")
+    _make_fake_exec(bin_dir, "ionice")
+    env_save_restore.delete(bp.NO_NICE_ENV)
+    env_save_restore.set("PATH", str(bin_dir))
+    # Act
+    prefix = low_priority_build_prefix()
+    # Assert
+    assert prefix == ["nice", "-n", "19", "ionice", "-c", "2", "-n", "7"]
+
+
+def test_prefix_degrades_to_nice_only_when_ionice_missing(
+    tmp_path: Path, env_save_restore
+) -> None:
+    # Arrange — graceful degrade, not a crash: minimal hosts without
+    # util-linux still get CPU demotion.
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _make_fake_exec(bin_dir, "nice")
+    env_save_restore.delete(bp.NO_NICE_ENV)
+    env_save_restore.set("PATH", str(bin_dir))
+    # Act
+    prefix = low_priority_build_prefix()
+    # Assert
+    assert prefix == ["nice", "-n", "19"]
+
+
+def test_prefix_empty_when_nice_itself_missing(
+    tmp_path: Path, env_save_restore
+) -> None:
+    # Arrange
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    env_save_restore.delete(bp.NO_NICE_ENV)
+    env_save_restore.set("PATH", str(bin_dir))
+    # Act
+    prefix = low_priority_build_prefix()
+    # Assert
+    assert prefix == []
+
+
+def test_prefix_empty_under_env_opt_out(tmp_path: Path, env_save_restore) -> None:
+    # Arrange — both tools present, but SAC_BUILD_NO_NICE=1 wins.
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _make_fake_exec(bin_dir, "nice")
+    _make_fake_exec(bin_dir, "ionice")
+    env_save_restore.set("PATH", str(bin_dir))
+    env_save_restore.set(bp.NO_NICE_ENV, "1")
+    # Act
+    prefix = low_priority_build_prefix()
+    # Assert
+    assert prefix == []
+
+
+def test_prefix_env_value_zero_means_no_opt_out(
+    tmp_path: Path, env_save_restore
+) -> None:
+    # Arrange — "0" is documented as NOT opting out (only empty/"0" keep
+    # demotion on).
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _make_fake_exec(bin_dir, "nice")
+    _make_fake_exec(bin_dir, "ionice")
+    env_save_restore.set("PATH", str(bin_dir))
+    env_save_restore.set(bp.NO_NICE_ENV, "0")
+    # Act
+    prefix = low_priority_build_prefix()
+    # Assert
+    assert prefix == ["nice", "-n", "19", "ionice", "-c", "2", "-n", "7"]


### PR DESCRIPTION
## Why

incident-local-heavy-build (2026-07-10): `sac image build` ran a full SIF bake (apt + pip + mksquashfs, ~40 min CPU+IO) at normal priority on the already-loaded interactive host — load spiked 27 → 50+ and the operator's interactive latency tanked. Permanent fix #1: make the build self-demote by default.

## What

**`sac image build` self-demotes its own process by default** — `os.setpriority(PRIO_PROCESS, 0, 19)` + `ionice -c 2 -n 7 -p <own pid>` right after the cheap validation/refusal paths, immediately before the heavy work.

*Why self-demotion and not an argv prefix here:* the heavy subprocess is spawned **inside `scitex_container.build()`** — a Python API of the separately-installed scitex-container package (`scitex_container/apptainer/_build.py::_build_sif` → `subprocess.run([..., "apptainer", "build", ...])`) — so sac never sees that argv. CPU nice and IO class/level are inherited across fork/exec, so demoting the CLI process covers the whole descendant tree (apptainer build → `%post` apt/pip → mksquashfs) plus the in-process staging copytree. `sac image build` is a terminal command that exits after the build, so the one-way demotion is safe there.

**IO = best-effort lowest (`-c2 -n7`), deliberately NOT idle class (`-c3`)** — live field data from the same night: a host SIF build at `ionice -c 3` died silently at the "Creating SIF file..." (mksquashfs) stage on the loaded host (process vanished, no error in the build log, no OOM trace, publish symlink never swapped). Idle-class IO is only serviced when the disk is otherwise idle → can starve indefinitely under sustained load. `-c2 -n7` still yields to all interactive IO but guarantees forward progress. Trade-off documented in the `_build_priority` module docstring and the 24_image-build skill.

**Loud one-line notice** when demotion is active:

```
building at low priority (nice 19 + ionice best-effort low); pass --no-nice for full speed
```

**Opt-out**: `--no-nice` flag. Name chosen over `--foreground-priority`: it names the exact mechanism being skipped and matches the notice text, while "foreground" collides with sac's existing `agent start --foreground` TTY-attach concept and wrongly suggests a fg/bg process distinction. `SAC_BUILD_NO_NICE=1` is the env equivalent (dedicated build boxes / CI images; also covers the non-CLI path below). Default-on everywhere incl. GitHub-hosted runners (single-purpose; harmless).

**Graceful degrade**: `ionice` missing from PATH → warning line + nice-only (never a crash). `setpriority` failure → warning + normal priority.

**Agent-start lazy SIF builds too** (`runtimes/_apptainer_build.py::_build_argv_prefix`, used by `resolve_sif` for cold `docker://` pulls and `def_file` builds): prefixed with `nice -n 19 ionice -c 2 -n 7`. Prefix-argv there (not self-demotion) because that CLI process goes on to launch the agent, which must NOT inherit nice 19.

**512-line budget**: the flag + demotion pushed `image_group.py` (506 lines) over the cap, so the read-only reporting verbs (`list` / `status` / `snapshot`) are extracted to `cli_pkg/_image_inventory_cmds.py` and registered back onto the group — CLI surface unchanged; test seams (`_load_apptainer`, `_load_env_snapshot`, `_CONTAINERS_DIR`, ...) stay on `image_group` and are read lazily at call time so existing swap-and-restore tests keep working. `build` stays in `image_group.py` so its `click.Choice(_LAYERS)` keeps its decoration-time constants without an import cycle.

## Tests (no mocks, 1 assert each, AAA)

- `tests/scitex_agent_container/test__build_priority.py` (new, mirrors `_build_priority.py`): REAL demotion exercised in **child interpreters** (demotion is one-way — never in the pytest process): child nice becomes 19; `ionice -p` reports `best-effort: prio 7`; notice line names `--no-nice`; env opt-out and `skip=True` leave priority untouched. Prefix composition tested against tmp bin dirs (full / nice-only degrade / empty / env opt-out / `"0"` ≠ opt-out).
- `test_image_group.py`: default calls the demoter with `skip=False`; `--no-nice` forwards `skip=True`; dry-run never demotes; the notice line lands in build output.
- `test__apptainer_build_fakeroot.py`: demoted argv head (`nice -n 19 ionice -c 2 -n 7 apptainer build`), env opt-out restores the plain head, and a real-subprocess test proving `subprocess.run` execs `nice` carrying the full demoted apptainer argv.
- `tests/conftest.py` sets `SAC_BUILD_NO_NICE=1` suite-wide: CliRunner runs the CLI **in the pytest process**, and demotion is irreversible — without this the first build test would demote the rest of the run.

Results: 73/73 targeted (`test__build_priority` + `test_image_group` + `test__apptainer_build_fakeroot`); neighboring suites (`cli_pkg` + `runtimes` + `_mcp` + `_api`) 3484 passed / 22 skipped; ruff `--select F401,F811` clean. Live-verified on the host: after `demote_current_process_to_low_priority()` → `nice: 19`, `ionice: best-effort: prio 7`, correct notice line.

Audit: direct `scitex-dev ecosystem audit-all scitex-agent-container` from this tree exits 0 (all sections SUCC). The pytest audit-gate wrapper hit its hardcoded 120 s subprocess timeout twice tonight — host load 40–60 from the incident itself; not a rule violation.

## Pre-existing problems surfaced (not addressed here)

1. `audit-cli` reports `not-auditable: unknown` — reproduces identically on the clean develop checkout; non-fatal (audit still exits 0).
2. The MCP tool `_mcp/_tools/_image.py::image_build` passes `--runtime/--target/--image` flags the current CLI does not accept — it errors before reaching any build code (stale tool surface). Worth a separate card. (Also means the in-process MCP path cannot accidentally self-demote the MCP server; `_build_priority`'s docstring additionally warns against calling the demoter from long-lived servers.)
3. A stray `--fakeroot` file appeared in the repo root during a test run (the known artifact `_apptainer_argv_guard` guards against); removed from this branch, not investigated further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
