### PR TITLE
refactor(config): route load-time advisories through scitex-logging

### DIFF
--- a/src/scitex_agent_container/config/__init__.py
+++ b/src/scitex_agent_container/config/__init__.py
@@ -86,6 +86,22 @@ def load_config(path: str | Path) -> AgentConfig:
     return config
 
 
+def _config_logger():
+    """Logger for load-time advisories, routed through scitex-logging.
+
+    scitex-logging gives the fleet-consistent coloured ``WARN:``/``ERRO:``
+    stderr lines (operator directive 2026-07-10) instead of raw
+    ``warnings.warn`` UserWarning spew with its ``file:line`` + source-echo
+    framing. Imported lazily: the package auto-configures handlers on first
+    import (~300 ms), which must not tax ``import scitex_agent_container.config``
+    itself (see ``21_cli-startup-budget.md``); CLI paths have usually paid it
+    already via ``cli_pkg._helpers._console``.
+    """
+    import scitex_logging
+
+    return scitex_logging.getLogger(__name__)
+
+
 def _warn_if_assigned_account_missing(config: AgentConfig) -> None:
     """Soft-WARN (never fail) when ``spec.claude.account`` names an
     account whose snapshot dir is absent at load time.
@@ -101,20 +117,17 @@ def _warn_if_assigned_account_missing(config: AgentConfig) -> None:
     # stx-allow: fallback (reason: store-path resolution is best-effort
     # advisory only; a hiccup must never break config loading.)
     try:
-        import warnings
-
         from .._state.account_store import _store_path
 
         store = _store_path(None, Path.home())
         if not (store / acct).is_dir():
-            warnings.warn(
+            _config_logger().warning(
                 f"spec.claude.account='{acct}' has no saved-account "
                 f"snapshot at {store / acct}; the agent will fall back "
                 "to the host live ~/.claude/.credentials.json at start. "
-                "Create it with `sac account save {acct}` (on the host "
+                f"Create it with `sac account save {acct}` (on the host "
                 "that holds those credentials), or ignore if the account "
-                "is provisioned on the target host.",
-                stacklevel=2,
+                "is provisioned on the target host."
             )
     except Exception:  # stx-allow: fallback (reason: see inline comment)
         pass
@@ -141,8 +154,6 @@ def _warn_if_startup_prompt_long(config: AgentConfig) -> None:
     start). Best-effort: any hiccup must never break config loading.
     """
     try:
-        import warnings
-
         for idx, prompt in enumerate(getattr(config, "startup_prompts", []) or []):
             text = str(prompt)
             n_chars = len(text)
@@ -151,7 +162,7 @@ def _warn_if_startup_prompt_long(config: AgentConfig) -> None:
                 n_lines <= _STARTUP_PROMPT_WARN_LINES
             ):
                 continue
-            warnings.warn(
+            _config_logger().warning(
                 f"spec.startup_prompts[{idx}] for agent "
                 f"'{getattr(config, 'name', '?')}' is long "
                 f"({n_chars} chars, {n_lines} lines). startup_prompts are pasted "
@@ -159,8 +170,7 @@ def _warn_if_startup_prompt_long(config: AgentConfig) -> None:
                 "belongs in the auto-loaded $HOME/.claude/CLAUDE.md (role + skill "
                 "@-imports) and reusable rules in .claude/skills/, which claude "
                 "re-reads every session. Keep startup_prompts to a short boot-KICK "
-                "(what to DO on start); move the prose to CLAUDE.md + skills.",
-                stacklevel=2,
+                "(what to DO on start); move the prose to CLAUDE.md + skills."
             )
     except Exception:  # stx-allow: fallback (reason: advisory only; never break load)
         pass

--- a/tests/scitex_agent_container/config/test__loaders.py
+++ b/tests/scitex_agent_container/config/test__loaders.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+import scitex_logging
 import yaml
 
 from scitex_agent_container.config import load_config
@@ -442,7 +443,13 @@ def test_load_config_v3_multi_host_appends_hostname(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# spec.claude.account soft-WARN (missing snapshot warns, never fails)
+# spec.claude.account soft-WARN (missing snapshot warns, never fails).
+# Load-time advisories are scitex-logging WARN lines (operator directive
+# 2026-07-10, consistent colour coding) — captured here via ``caplog``
+# through standard logging propagation, not ``pytest.warns``. The
+# module-top ``import scitex_logging`` guarantees its one-time root-handler
+# configure() ran at collection time, i.e. BEFORE caplog attaches its
+# per-test root handler (configure() would strip that handler mid-test).
 # ---------------------------------------------------------------------------
 
 
@@ -470,62 +477,60 @@ def _v3_yaml(tmp_path: Path, name: str, spec_extra: dict) -> Path:
     return p
 
 
-def test_load_config_warns_when_pinned_account_snapshot_absent(tmp_path: Path):
+def test_load_config_warns_when_pinned_account_snapshot_absent(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+):
     # Arrange — pin an account with no saved snapshot anywhere.
     p = _v3_yaml(tmp_path, "pinned", {"claude": {"account": "ghost"}})
     # Act
-    ctx = pytest.warns(UserWarning, match="ghost")
-    # Assert
-    with ctx:
+    with caplog.at_level(scitex_logging.WARNING):
         load_config(p)
+    # Assert
+    assert "ghost" in caplog.text
 
 
 def test_load_config_pinned_account_still_loads_despite_missing_snapshot(
     tmp_path: Path,
 ):
     # Arrange — the soft-WARN must NOT escalate to a load failure. The
-    # warning itself is asserted by the sibling test; here we suppress
-    # it (catch_warnings, not pytest.warns) so the single assertion is
-    # purely "the config loaded with the pin intact".
-    import warnings
-
+    # WARN line itself is asserted by the sibling test; the single
+    # assertion here is purely "the config loaded with the pin intact".
     p = _v3_yaml(tmp_path, "pinned", {"claude": {"account": "ghost"}})
     # Act
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        cfg = load_config(p)
+    cfg = load_config(p)
     # Assert
     assert cfg.claude.account == "ghost"
 
 
-def test_load_config_warns_when_startup_prompt_is_long(tmp_path: Path):
+def test_load_config_warns_when_startup_prompt_is_long(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+):
     # Arrange — a long role/rules PROSE startup_prompt (belongs in CLAUDE.md +
     # skills, not a per-boot turn).
     p = _v3_yaml(
         tmp_path, "verbose", {"startup_prompts": ["You are X. " + "rule. " * 120]}
     )
     # Act
-    ctx = pytest.warns(UserWarning, match="startup_prompts")
-    # Assert
-    with ctx:
+    with caplog.at_level(scitex_logging.WARNING):
         load_config(p)
+    # Assert
+    assert "startup_prompts" in caplog.text
 
 
-def test_load_config_no_warn_for_short_startup_kick(tmp_path: Path):
+def test_load_config_no_warn_for_short_startup_kick(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+):
     # Arrange — a short boot-KICK must NOT trip the long-prompt warning.
-    import warnings
-
     p = _v3_yaml(
         tmp_path,
         "kick",
         {"startup_prompts": ["You restarted — check inbox + todo; report readiness."]},
     )
     # Act
-    with warnings.catch_warnings(record=True) as rec:
-        warnings.simplefilter("always")
+    with caplog.at_level(scitex_logging.WARNING):
         load_config(p)
     # Assert
-    assert not any("startup_prompts" in str(w.message) for w in rec)
+    assert "startup_prompts" not in caplog.text
 
 
 def test_load_config_defaults_startup_prompt_when_omitted(tmp_path: Path):
@@ -563,13 +568,9 @@ def test_load_config_injects_claude_agent_account_when_spec_pins_account(
     tmp_path: Path,
 ):
     # Arrange
-    import warnings
-
     p = _v3_yaml(tmp_path, "pinned", {"claude": {"account": "wyusuuke-gmail-com"}})
     # Act
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        cfg = load_config(p)
+    cfg = load_config(p)
     # Assert
     assert cfg.env["CLAUDE_AGENT_ACCOUNT"] == "wyusuuke-gmail-com"
 
@@ -590,15 +591,11 @@ def test_load_config_strips_whitespace_from_account_before_injection(
     # Arrange — defensive trim so a spec with a stray newline / space
     # does not leak into the quota-cache lookup (which uses a strict
     # ``split('-')[0] == short`` match — a leading space would break it).
-    import warnings
-
     p = _v3_yaml(
         tmp_path, "trimmed", {"claude": {"account": "  ywata1989-gmail-com  "}}
     )
     # Act
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        cfg = load_config(p)
+    cfg = load_config(p)
     # Assert
     assert cfg.env["CLAUDE_AGENT_ACCOUNT"] == "ywata1989-gmail-com"
 


### PR DESCRIPTION
## Why

Operator directive (2026-07-10, Telegram, verbatim): *"use scitex-logger logger.warning | logger.error for consistent warnings/error color coding."*

`sac agents list`/`start` previously spewed raw Python `UserWarning` lines — e.g.

```
config/__init__.py:85: UserWarning: spec.startup_prompts[0] for agent 'proj-neurovista' is long (7708 chars...)
  _warn_if_startup_prompt_long(config)
```

Uncoloured, with `file:line` framing + a source-line echo — inconsistent with the rest of the CLI, which already routes its lifecycle prose through `scitex-logging` (`cli_pkg/_helpers/_console.py`).

## What changed

Both user-facing `warnings.warn(UserWarning)` sites in `config/__init__.py` now emit via `scitex_logging.getLogger(__name__).warning(...)`:

- `_warn_if_startup_prompt_long` — the exact advisory the operator pasted.
- `_warn_if_assigned_account_missing` — the sibling account-snapshot advisory.

Output is now a clean, colour-coded `WARN: <msg>` line on stderr (yellow on a TTY, per scitex-logging's `SciTeXConsoleFormatter`), with **no** stacklevel / source-line echo. **Message text is byte-for-byte unchanged** — only the channel moved, so any downstream grep still matches.

A small `_config_logger()` helper imports `scitex_logging` **lazily** so `import scitex_agent_container.config` doesn't pay scitex-logging's ~300 ms auto-configure on the CLI hot path (`21_cli-startup-budget.md`, 500 ms budget). CLI paths have already paid it via `_console`.

Drive-by: fixed a pre-existing non-f-string bug in the account advisory — `` `sac account save {acct}` `` was on a plain (non-`f`) string line, so `{acct}` rendered literally. Now interpolates the real account name.

## scitex-logging API used

`scitex-logging` (already a declared dep: `scitex-logging>=0.1.5`; 0.1.7 in the SIF) auto-configures a root logger on import with a stderr `LazyStderrStreamHandler` + rotating file handler. Canonical consumer pattern (matches sac's own `_console.py`): `logger = scitex_logging.getLogger(name)` then `logger.warning(...)`. Level constants (`scitex_logging.WARNING` etc.) are re-exported. Colour is per-level ANSI in `SciTeXConsoleFormatter`; `WARN` -> yellow.

## Scope decisions

- **Migrated:** the two `config/__init__.py` advisories (the only two `warnings.warn(` sites in `src/`).
- **Error-level output (X blocks in `sac agents list`):** already rich-styled (`_agent_list_render.py` — `[bold red]... [/bold red]`), left untouched per task guidance ("do not restyle working rich tables").
- **Skipped `a2a/_handlers.py` `catch_warnings().simplefilter("ignore")`:** internal per-call suppressor of noisy SDK/asyncio *shutdown* warnings, not a user-facing emission — out of scope.
- **Skipped the two `logging.basicConfig` calls** (`a2a serve --verbose`, `quota-watch` daemon): daemon/file logging setup, not warning-channel emission.
- **No one-time CLI setup needed:** `scitex_logging` self-configures on first import; nothing to wire into `_main.py`.

## Tests

The four `pytest.warns` / `catch_warnings` assertions on these two advisories switch to `caplog` via standard-logging propagation. `import scitex_logging` at the test module top guarantees its one-time root-handler `configure()` ran at collection — before `caplog` attaches its per-test handler (otherwise `configure(force=True)` would strip it mid-test). Each test keeps one assertion + AAA markers.

Green locally (worktree, `/opt/venv-sac`):
- `tests/scitex_agent_container/config/` — **661 passed**
- `tests/scitex_agent_container/cli_pkg/lifecycle/` — **415 passed**
- `scitex-dev ecosystem audit-all scitex-agent-container` — **clean (exit 0, all SUCC)**
- `ruff check --select F401,F811` — clean
- Live smoke: loading a long-prompt + missing-account spec through the worktree emits two `WARN:` lines and **zero** `UserWarning` (verified under `-W error::UserWarning`).
