### PR TITLE
feat(accounts): semi-automated `claude /login` re-auth (sac accounts login)

### DIFF
--- a/src/scitex_agent_container/_account/interactive_login.py
+++ b/src/scitex_agent_container/_account/interactive_login.py
@@ -1,0 +1,501 @@
+"""Semi-automated ``claude /login`` re-auth driver.
+
+The ONE step an agent cannot do is the browser authorization that trips
+bot-detection. This module automates everything around it: it drives an
+interactive ``claude`` session inside a tmux pane, extracts the OAuth
+*authorize* URL, delivers it to the operator (so all he does is tap the
+link on his phone), then waits for the login to complete — either the
+browser-only flow (the CLI finishes on its own) or the code-paste flow
+(the operator sends back a code that gets typed into the pane).
+
+Design rules (mirror the fleet's fail-loud + no-secret-leak doctrine):
+
+* **Never** print / log / notify a token or credential value. Only the
+  auth URL (a public authorization URL) and the account name are
+  emitted. Any pane text shown on failure is run through
+  :func:`redact_pane` first (the shared secret-shaped matcher).
+* Every wait is time-bounded and fails loud with a redacted pane tail —
+  never an unbounded interactive hang (the "silent stall" class).
+* The tmux automation is REUSED, not re-invented:
+  :class:`~scitex_agent_container._runners._tmux.tmux.TmuxManager` owns
+  session lifecycle + keystrokes; this module only adds a ``-J`` (joined)
+  capture so a long, wrapped OAuth URL reconstructs exactly.
+
+The credential *save* (snapshot the fresh ``~/.claude/.credentials.json``
+into the account store) is intentionally NOT done here — the CLI wrapper
+runs the existing ``sac accounts save`` logic after this returns, so this
+flow stays driveable end-to-end against a fake ``claude`` in tests.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+from .._runners._tmux.tmux import TmuxManager, TuiInputNotReadyError
+
+# ---------------------------------------------------------------------------
+# Detection markers + the strict OAuth-URL regex
+# ---------------------------------------------------------------------------
+
+# Known OAuth hosts for Claude Code. ``platform.claude.com`` is the live
+# endpoint (``console.anthropic.com`` was retired — it 404s, per the
+# 2026-07-10 account-pool incident); ``claude.ai`` serves the
+# subscription authorize page. Anchored on ``https://`` + a known host +
+# a ``/oauth`` or ``/authorize`` path so a stray string can never be
+# mistaken for the auth URL — we fail loud rather than deliver a wrong one.
+_OAUTH_URL_RE = re.compile(
+    r"https://(?:claude\.ai|platform\.claude\.com|console\.anthropic\.com)"
+    r"/(?:oauth|authorize)[^\s'\"<>\\]*"
+)
+
+_INPUT_READY_MARKER = "? for shortcuts"
+
+# The login-method picker shown by ``/login`` (or auto-shown at boot when
+# credentials are expired). The subscription (Pro/Max) flow is option 1.
+_LOGIN_METHOD_MARKER = "select login method"
+
+# The pane is asking the operator to paste the authorization code back.
+# Matched case-insensitively; deliberately distinct from the URL's own
+# ``code=true`` query param so the URL never trips the code-paste branch.
+_CODE_PROMPT_MARKERS = (
+    "paste code",
+    "paste the code",
+    "paste your code",
+    "enter the code",
+    "authorization code",
+    "paste it below",
+)
+
+# Login completed successfully. Broad on purpose (the exact wording has
+# varied across Claude Code builds); overridable by a caller that has
+# verified a newer marker against a live TUI.
+_SUCCESS_MARKERS = (
+    "login successful",
+    "logged in as",
+    "successfully logged in",
+    "you are now logged in",
+    "already logged in",
+    "authentication successful",
+)
+
+
+class LoginError(RuntimeError):
+    """A ``claude /login`` drive failed loud (start / channel / usage)."""
+
+
+class LoginTimeoutError(LoginError):
+    """A bounded wait elapsed — carries a redacted pane tail in its text."""
+
+
+@dataclass
+class LoginResult:
+    """Outcome of a completed interactive login (no secret material)."""
+
+    url: str
+    status: str
+    code_used: bool
+
+
+# ---------------------------------------------------------------------------
+# Pure detection / redaction helpers (unit-testable without tmux)
+# ---------------------------------------------------------------------------
+
+
+def extract_oauth_url(text: str) -> str | None:
+    """Return the first OAuth authorize URL in ``text``, or ``None``.
+
+    Strict: only a ``https://<known-host>/oauth|authorize...`` token
+    matches. Everything else — including an unrelated ``https://`` URL —
+    yields ``None`` so the caller fails loud instead of delivering a
+    wrong string.
+    """
+    if not text:
+        return None
+    match = _OAUTH_URL_RE.search(text)
+    return match.group(0) if match else None
+
+
+def is_login_method_picker(text: str) -> bool:
+    """True iff the ``Select login method:`` picker is on screen."""
+    return _LOGIN_METHOD_MARKER in (text or "").lower()
+
+
+def is_code_prompt(text: str) -> bool:
+    """True iff the pane is prompting for the pasted authorization code."""
+    low = (text or "").lower()
+    return any(marker in low for marker in _CODE_PROMPT_MARKERS)
+
+
+def is_login_success(text: str) -> bool:
+    """True iff the pane shows a completed-login marker."""
+    low = (text or "").lower()
+    return any(marker in low for marker in _SUCCESS_MARKERS)
+
+
+def redact_pane(text: str, *extra_secrets: str) -> str:
+    """Redact secret-shaped substrings from ``text`` before it is shown.
+
+    Reuses the shared multi-line secret matcher
+    (``_state._meta.secrets._redact_secrets`` — the same one that
+    sanitises captured pane text elsewhere) and additionally masks any
+    ``extra_secrets`` the caller knows are sensitive (e.g. a just-typed
+    auth code, which is not token-shaped and would otherwise survive).
+    """
+    from .._state._meta.secrets import _redact_secrets
+
+    out = _redact_secrets(text or "")
+    for secret in extra_secrets:
+        if secret and secret.strip():
+            out = out.replace(secret, "***REDACTED***")
+    return out
+
+
+def _pane_tail(text: str, lines: int = 25) -> str:
+    """Last ``lines`` non-empty rows of ``text`` (the actionable tail)."""
+    rows = [row for row in (text or "").splitlines() if row.strip()]
+    return "\n".join(rows[-lines:])
+
+
+# ---------------------------------------------------------------------------
+# tmux capture / sizing (the only additions on top of TmuxManager)
+# ---------------------------------------------------------------------------
+
+
+def _capture_joined(session: str) -> str:
+    """``capture-pane -p -J`` — join soft-wrapped rows into logical lines.
+
+    A real OAuth URL is ~300 chars and soft-wraps across several pane
+    rows; ``-J`` reconstructs it as one line so :func:`extract_oauth_url`
+    sees the whole URL, not a truncated first fragment.
+    """
+    result = subprocess.run(
+        ["tmux", "capture-pane", "-t", session, "-p", "-J"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.stdout if result.returncode == 0 else ""
+
+
+def _resize_wide(session: str, width: int = 400, height: int = 50) -> None:
+    """Best-effort: widen the detached pane so the URL avoids a hard wrap.
+
+    Belt-and-suspenders with the ``-J`` capture — a no-op / error on a
+    session whose ``window-size`` forbids manual sizing is fine.
+    """
+    # stx-allow: fallback (reason: cosmetic pane widening; the -J capture
+    # is the real de-wrap safety net, so a resize failure is irrelevant.)
+    try:
+        subprocess.run(
+            ["tmux", "resize-window", "-t", session, "-x", str(width), "-y", str(height)],
+            capture_output=True,
+            check=False,
+        )
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Delivery — URL to the operator without importing claude-code-telegrammer
+# ---------------------------------------------------------------------------
+
+
+def _default_notifier(url: str, name: str) -> None:
+    """Push the auth URL to the operator via the existing lead-inbox rail.
+
+    Uses :func:`scitex_agent_container._state.lead_inbox.push_to_lead` —
+    the same operator-visible A2A push ``sac fleet notify`` uses. The
+    lead session surfaces it on the operator's Telegram bridge; NOTHING
+    imports claude-code-telegrammer. Raises ``LeadInboxError`` on
+    failure, which the caller downgrades to a stdout-only warning.
+    """
+    from .._state.lead_inbox import push_to_lead
+
+    sender = os.environ.get("SAC_NAME", "").strip() or "sac-accounts-login"
+    push_to_lead(
+        kind="status",
+        summary=f"claude /login: authorize account '{name}' (tap to open in browser)",
+        from_agent=sender,
+        detail=url,
+    )
+
+
+def deliver_url(
+    url: str,
+    name: str,
+    *,
+    notify: bool = True,
+    notifier: Callable[[str, str], None] | None = None,
+    echo: Callable[[str], None],
+) -> None:
+    """Emit the auth URL: ALWAYS to stdout, and (best-effort) the rail.
+
+    stdout is the guaranteed channel (a terminal operator sees it); the
+    notify rail is a pluggable enhancement. A notify failure is logged
+    and swallowed — it must never abort a login whose URL already
+    reached stdout.
+    """
+    echo("")
+    echo(f"[sac accounts login] Authorize account '{name}' — open this URL in a browser:")
+    echo(url)
+    echo("")
+    if not notify:
+        return
+    fn = notifier or _default_notifier
+    # stx-allow: fallback (reason: the notify rail is a best-effort
+    # enhancement; stdout already delivered the URL, so a rail outage must
+    # be a warning, never a failed login.)
+    try:
+        fn(url, name)
+        echo("[sac accounts login] URL also pushed to the operator via the notify rail.")
+    except Exception as exc:  # stx-allow: fallback (reason: see inline comment)
+        echo(
+            "[sac accounts login] warning: notify rail unavailable "
+            f"({type(exc).__name__}: {exc}); the URL above on stdout is authoritative."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Code acquisition (stdin prompt + file/env drop point)
+# ---------------------------------------------------------------------------
+
+
+def _read_text(path: Path) -> str:
+    """Best-effort read of ``path``; ``""`` when missing/unreadable."""
+    # stx-allow: fallback (reason: the code-file is polled while a remote
+    # deliverer writes it; a not-yet-present / mid-write file is expected
+    # and must read as empty, never raise.)
+    try:
+        return path.read_text(encoding="utf-8")
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        return ""
+
+
+def _acquire_code(
+    *,
+    code_file: str | None,
+    env_var: str | None,
+    deadline: float,
+    poll_s: float,
+    echo: Callable[[str], None],
+    isatty_fn: Callable[[], bool] = lambda: os.isatty(0),
+    prompt_fn: Callable[[str], str] = input,
+    read_fn: Callable[[Path], str] = _read_text,
+    sleep_fn: Callable[[float], None] = time.sleep,
+    time_fn: Callable[[], float] = time.monotonic,
+) -> str:
+    """Obtain the pasted auth code from an env var, a polled file, or stdin.
+
+    Precedence: ``$env_var`` (immediate) → ``--code-file`` (polled until
+    non-empty or ``deadline``) → interactive stdin prompt (only when
+    stdin is a tty). Raises loud when none is available so the flow can't
+    stall on an unanswerable prompt. The code is never echoed.
+    """
+    if env_var:
+        val = os.environ.get(env_var, "").strip()
+        if val:
+            return val
+    if code_file:
+        path = Path(code_file)
+        echo(f"[sac accounts login] waiting for the auth code at {path} ...")
+        while time_fn() < deadline:
+            content = read_fn(path)
+            if content and content.strip():
+                return content.strip().splitlines()[0].strip()
+            sleep_fn(poll_s)
+        raise LoginTimeoutError(
+            f"no auth code appeared in {path} before the timeout elapsed."
+        )
+    if isatty_fn():
+        return prompt_fn(
+            "Paste the auth code from the browser and press Enter: "
+        ).strip()
+    raise LoginError(
+        "claude is asking for an auth code but no delivery channel is available. "
+        "Re-run with --code-file PATH (a deliverer writes the code there), set "
+        f"${env_var or 'SAC_LOGIN_CODE'}, or run in an interactive terminal."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Drive loops
+# ---------------------------------------------------------------------------
+
+
+def _await_oauth_url(
+    session: str,
+    *,
+    url_timeout_s: float,
+    poll_s: float,
+    echo: Callable[[str], None],
+    capture_fn: Callable[[str], str] = _capture_joined,
+    send_keys_fn: Callable[..., None] = TmuxManager.send_keys,
+    send_text_fn: Callable[[str, str], None] = TmuxManager.send_text_and_submit,
+    sleep_fn: Callable[[float], None] = time.sleep,
+    time_fn: Callable[[], float] = time.monotonic,
+) -> str:
+    """Drive the pane to the OAuth URL and return it.
+
+    Handles both entry states: a healthy REPL (send ``/login`` once the
+    input marker is up) and an expired-credential boot (claude auto-shows
+    the login picker without a REPL). Answers the login-method picker
+    with the subscription option (1). Fails loud with a redacted tail if
+    no URL appears within ``url_timeout_s``.
+    """
+    deadline = time_fn() + url_timeout_s
+    login_sent = False
+    picker_answered = False
+    last = ""
+    while time_fn() < deadline:
+        last = capture_fn(session)
+        url = extract_oauth_url(last)
+        if url:
+            return url
+        if is_login_method_picker(last) and not picker_answered:
+            send_keys_fn(session, "1", "Enter")  # subscription flow
+            picker_answered = True
+            sleep_fn(poll_s)
+            continue
+        if not login_sent and _INPUT_READY_MARKER in last:
+            send_text_fn(session, "/login")
+            login_sent = True
+            sleep_fn(poll_s)
+            continue
+        sleep_fn(poll_s)
+    raise LoginTimeoutError(
+        f"the OAuth authorize URL never appeared within {url_timeout_s:.0f}s "
+        f"(login_sent={login_sent}, picker_answered={picker_answered}). "
+        f"Pane tail:\n{redact_pane(_pane_tail(last))}"
+    )
+
+
+def _await_completion(
+    session: str,
+    name: str,
+    *,
+    code_file: str | None,
+    env_var: str | None,
+    human_timeout_s: float,
+    poll_s: float,
+    echo: Callable[[str], None],
+    capture_fn: Callable[[str], str] = _capture_joined,
+    send_text_fn: Callable[[str, str], None] = TmuxManager.send_text_and_submit,
+    sleep_fn: Callable[[float], None] = time.sleep,
+    time_fn: Callable[[], float] = time.monotonic,
+) -> bool:
+    """Wait for login to complete; type the code if a code-prompt appears.
+
+    Returns whether a code was pasted. Bounded by ``human_timeout_s`` (the
+    human browser step) and fails loud with a redacted tail — the pasted
+    code is scrubbed from that tail too.
+    """
+    deadline = time_fn() + human_timeout_s
+    code_sent = False
+    sent_code: str | None = None
+    last = ""
+    while time_fn() < deadline:
+        last = capture_fn(session)
+        if is_login_success(last):
+            return code_sent
+        if not code_sent and is_code_prompt(last):
+            sent_code = _acquire_code(
+                code_file=code_file,
+                env_var=env_var,
+                deadline=deadline,
+                poll_s=poll_s,
+                echo=echo,
+            )
+            send_text_fn(session, sent_code)
+            code_sent = True
+            echo("[sac accounts login] auth code delivered to the pane; waiting for completion ...")
+            sleep_fn(poll_s)
+            continue
+        sleep_fn(poll_s)
+    raise LoginTimeoutError(
+        f"login for account {name!r} did not complete within {human_timeout_s:.0f}s "
+        f"(code_pasted={code_sent}). Pane tail:\n"
+        f"{redact_pane(_pane_tail(last), sent_code or '')}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator
+# ---------------------------------------------------------------------------
+
+
+def _session_name(name: str) -> str:
+    """A tmux-safe unique session name for this login attempt."""
+    slug = re.sub(r"[^A-Za-z0-9_-]", "-", name)[:32]
+    return f"sac-login-{slug}-{uuid.uuid4().hex[:8]}"
+
+
+def run_interactive_login(
+    name: str,
+    *,
+    notify: bool = True,
+    notifier: Callable[[str, str], None] | None = None,
+    code_file: str | None = None,
+    env_var: str | None = "SAC_LOGIN_CODE",
+    human_timeout_s: float = 600.0,
+    url_timeout_s: float = 120.0,
+    poll_s: float = 0.5,
+    claude_bin: str = "claude",
+    workdir: str | None = None,
+    session_name: str | None = None,
+    echo: Callable[[str], None] | None = None,
+) -> LoginResult:
+    """Drive ``claude /login`` end-to-end and return the outcome.
+
+    Spawns ``claude`` in a tmux pane, extracts + delivers the OAuth URL,
+    waits for the operator to authorize (browser-only or code-paste),
+    and returns a :class:`LoginResult`. Does NOT touch the credential
+    store — the caller runs ``sac accounts save`` after this returns.
+
+    Raises :class:`LoginError` / :class:`LoginTimeoutError` (loud, with a
+    redacted pane tail) on any failure; the tmux session is always
+    cleaned up.
+    """
+    import click
+
+    say = echo or click.echo
+    session = session_name or _session_name(name)
+    work = workdir or str(Path.home())
+
+    started = TmuxManager.start(session, command=claude_bin, workdir=work)
+    if not started:
+        raise LoginError(
+            f"failed to start a tmux session for claude (session={session!r}, "
+            f"workdir={work!r}). Is tmux installed and is {claude_bin!r} on PATH?"
+        )
+    try:
+        _resize_wide(session)
+        try:
+            url = _await_oauth_url(
+                session,
+                url_timeout_s=url_timeout_s,
+                poll_s=poll_s,
+                echo=say,
+            )
+        except TuiInputNotReadyError as exc:  # never raised here today, kept for safety
+            raise LoginTimeoutError(str(exc)) from exc
+        deliver_url(url, name, notify=notify, notifier=notifier, echo=say)
+        code_used = _await_completion(
+            session,
+            name,
+            code_file=code_file,
+            env_var=env_var,
+            human_timeout_s=human_timeout_s,
+            poll_s=poll_s,
+            echo=say,
+        )
+        say(f"[sac accounts login] login completed for account '{name}'.")
+        return LoginResult(url=url, status="success", code_used=code_used)
+    finally:
+        TmuxManager.stop(session)

--- a/src/scitex_agent_container/cli_pkg/_account_login.py
+++ b/src/scitex_agent_container/cli_pkg/_account_login.py
@@ -1,0 +1,168 @@
+"""``sac accounts login`` — semi-automated ``claude /login`` re-auth.
+
+Split out of ``account_group.py`` to keep that orchestrator under the
+per-file line cap; the command is attached onto the ``account`` group at
+import time via :func:`register_login_command` (same pattern as
+``_account_refresh.register_refresh_command``).
+
+The heavy lifting — driving the interactive ``claude`` in a tmux pane,
+extracting + delivering the OAuth URL, and awaiting completion — lives in
+:mod:`scitex_agent_container._account.interactive_login`. This wrapper is
+a thin click front that, on success, reuses the existing ``sac accounts
+save`` logic to snapshot the fresh credential and then prints its expiry.
+
+The account NAME and the (public) auth URL are the only things ever
+emitted — never a token/credential value.
+"""
+
+from __future__ import annotations
+
+import click
+
+__all__ = ["account_login", "register_login_command"]
+
+
+def _print_expiry(name: str) -> None:
+    """Print the freshly-saved credential's expiry (never the token)."""
+    from datetime import datetime, timezone
+
+    from .._account.credentials import read_credentials_metadata
+
+    # stx-allow: fallback (reason: the login + save already succeeded;
+    # a cosmetic expiry read that hiccups must not turn a good login into
+    # a non-zero exit — degrade to a plain "saved" line.)
+    try:
+        meta = read_credentials_metadata()
+        expires_ms = meta.get("oauth_expires_at")
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        expires_ms = None
+    if isinstance(expires_ms, int):
+        expires_at = datetime.fromtimestamp(expires_ms / 1000, tz=timezone.utc)
+        hours = (expires_at - datetime.now(timezone.utc)).total_seconds() / 3600
+        click.echo(
+            f"[sac accounts login] account '{name}' credential expires "
+            f"{expires_at.isoformat()} (~{hours:.1f}h from now)."
+        )
+    else:
+        click.echo(
+            f"[sac accounts login] account '{name}' saved (expiry unavailable)."
+        )
+
+
+@click.command("login")
+@click.argument("name")
+@click.option(
+    "--notify/--no-notify",
+    "notify",
+    default=True,
+    show_default=True,
+    help=(
+        "Push the auth URL to the operator via the notify rail (in addition "
+        "to always printing it to stdout). --no-notify prints to stdout only."
+    ),
+)
+@click.option(
+    "--code-file",
+    "code_file",
+    type=click.Path(),
+    default=None,
+    help=(
+        "Path polled for the pasted authorization code when the CLI uses the "
+        "code-paste flow. A remote deliverer (the operator / a bridge) writes "
+        "the code here; the first non-empty line is typed into the pane."
+    ),
+)
+@click.option(
+    "--timeout",
+    "human_timeout",
+    type=float,
+    default=600.0,
+    show_default=True,
+    help="Seconds to wait for the human browser/code step before failing loud.",
+)
+@click.option(
+    "--url-timeout",
+    "url_timeout",
+    type=float,
+    default=120.0,
+    show_default=True,
+    help="Seconds to wait for the OAuth URL to appear after /login.",
+)
+@click.option(
+    "--claude-bin",
+    "claude_bin",
+    default="claude",
+    show_default=True,
+    help="The claude executable to drive (override for testing / alt installs).",
+)
+@click.option(
+    "--workdir",
+    "workdir",
+    default=None,
+    help="Working directory for the claude session (defaults to $HOME).",
+)
+@click.option(
+    "--save/--no-save",
+    "save",
+    default=True,
+    show_default=True,
+    help="On success, snapshot the fresh credential into the account store.",
+)
+def account_login(
+    name: str,
+    notify: bool,
+    code_file: str | None,
+    human_timeout: float,
+    url_timeout: float,
+    claude_bin: str,
+    workdir: str | None,
+    save: bool,
+) -> None:
+    """Re-authenticate account NAME via a semi-automated ``claude /login``.
+
+    Drives ``claude`` in a tmux pane, extracts the OAuth authorize URL and
+    delivers it to the operator (stdout + notify rail), then waits for the
+    login to complete — either the browser-only flow or the code-paste
+    flow (supply the code via --code-file, $SAC_LOGIN_CODE, or an
+    interactive prompt). On success the fresh credential is snapshotted
+    with the existing ``sac accounts save`` logic and its expiry printed.
+
+    \b
+    Examples:
+      $ sac accounts login work
+      $ sac accounts login work --code-file /run/sac/login-code.txt
+      $ sac accounts login work --no-notify --timeout 300
+    """
+    from .._account.interactive_login import LoginError, run_interactive_login
+
+    try:
+        run_interactive_login(
+            name,
+            notify=notify,
+            code_file=code_file,
+            human_timeout_s=human_timeout,
+            url_timeout_s=url_timeout,
+            claude_bin=claude_bin,
+            workdir=workdir,
+            echo=click.echo,
+        )
+    except LoginError as exc:
+        click.echo(f"error: {exc}", err=True)
+        raise SystemExit(1) from exc
+
+    if not save:
+        click.echo(f"[sac accounts login] --no-save: skipped snapshotting '{name}'.")
+        return
+
+    # Reuse the existing `sac accounts save` logic (import the function,
+    # do not shell out) so the fresh ~/.claude/.credentials.json lands in
+    # the account store exactly as a manual `sac accounts save` would.
+    from .account_group import account_save
+
+    account_save.callback(name=name, email=None, dry_run=False, yes=True)
+    _print_expiry(name)
+
+
+def register_login_command(group: click.Group) -> None:
+    """Attach the ``login`` command onto the ``account`` group."""
+    group.add_command(account_login)

--- a/src/scitex_agent_container/cli_pkg/account_group.py
+++ b/src/scitex_agent_container/cli_pkg/account_group.py
@@ -320,6 +320,17 @@ register_mint_token_command(account)
 
 
 # ---------------------------------------------------------------------------
+# login — semi-automated `claude /login` re-auth. Drives claude in a tmux
+# pane, extracts + delivers the OAuth URL to the operator, awaits the
+# browser/code step, then reuses `account save`. Lives in its own module
+# (per-file line cap); attached at import time like refresh / mint-token.
+# ---------------------------------------------------------------------------
+from ._account_login import register_login_command
+
+register_login_command(account)
+
+
+# ---------------------------------------------------------------------------
 # quota-watch — exposed both at top-level (legacy `quota_watch`, re-exported
 # below) and under ``account``. Bodies extracted to ``_account_quota_watch``
 # to keep this file under the per-file line cap.

--- a/tests/scitex_agent_container/_account/test_interactive_login.py
+++ b/tests/scitex_agent_container/_account/test_interactive_login.py
@@ -1,0 +1,184 @@
+"""Tests for the semi-automated ``claude /login`` driver.
+
+Two layers, no mocks:
+
+* Pure detection / redaction functions are exercised with real string
+  inputs (the exact shapes a real pane produces).
+* ``run_interactive_login`` is driven end-to-end against REAL tmux and a
+  REAL fake-``claude`` bash script (a subprocess that emits a known OAuth
+  URL and accepts a pasted code) — real subprocess, real tmux, real
+  regex. Skipped when the ``tmux`` binary is absent.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._account.interactive_login import (
+    extract_oauth_url,
+    is_code_prompt,
+    is_login_method_picker,
+    is_login_success,
+    redact_pane,
+    run_interactive_login,
+)
+
+_EXPECTED_URL = (
+    "https://claude.ai/oauth/authorize?code=true&client_id=fake&state=NONCE123abc"
+)
+
+# A real bash stand-in for ``claude``: prints the input-ready marker, then
+# reacts to ``/login`` (login picker) → ``1`` (OAuth URL + code prompt) →
+# any code (login success). Drives the whole flow through real tmux.
+_FAKE_CLAUDE = f"""\
+echo "Fake Claude Code"
+echo "? for shortcuts"
+while IFS= read -r line; do
+  if [ "$line" = "/login" ]; then
+    echo "Select login method:"
+    echo "  1. Claude account with subscription"
+    echo "  2. Anthropic Console account"
+  elif [ "$line" = "1" ]; then
+    echo "Visit: {_EXPECTED_URL}"
+    echo "Paste code here if prompted >"
+  elif [ -n "$line" ]; then
+    echo "Login successful!"
+  fi
+done
+"""
+
+
+def _write_fake_claude(directory: Path) -> Path:
+    """Write the fake-claude bash script into ``directory`` and return it."""
+    script = directory / "fake-claude.sh"
+    script.write_text(_FAKE_CLAUDE, encoding="utf-8")
+    return script
+
+
+def test_extract_oauth_url_returns_claude_ai_authorize_url() -> None:
+    # Arrange
+    pane = f"Open your browser: {_EXPECTED_URL}\nwaiting..."
+    # Act
+    found = extract_oauth_url(pane)
+    # Assert
+    assert found == _EXPECTED_URL
+
+
+def test_extract_oauth_url_returns_platform_claude_host_url() -> None:
+    # Arrange
+    url = "https://platform.claude.com/oauth/authorize?x=1&state=zz"
+    pane = f"visit {url} now"
+    # Act
+    found = extract_oauth_url(pane)
+    # Assert
+    assert found == url
+
+
+def test_extract_oauth_url_ignores_unrelated_https_url() -> None:
+    # Arrange
+    pane = "some log line https://example.com/oauth/authorize?x=1 not ours"
+    # Act
+    found = extract_oauth_url(pane)
+    # Assert
+    assert found is None
+
+
+def test_is_code_prompt_ignores_oauth_url_code_param() -> None:
+    # Arrange
+    pane = f"Visit: {_EXPECTED_URL}"
+    # Act
+    detected = is_code_prompt(pane)
+    # Assert
+    assert detected is False
+
+
+def test_is_code_prompt_detects_paste_code_marker() -> None:
+    # Arrange
+    pane = "Paste code here if prompted >"
+    # Act
+    detected = is_code_prompt(pane)
+    # Assert
+    assert detected is True
+
+
+def test_is_login_success_detects_login_successful_marker() -> None:
+    # Arrange
+    pane = "Login successful! Welcome back."
+    # Act
+    detected = is_login_success(pane)
+    # Assert
+    assert detected is True
+
+
+def test_is_login_method_picker_detects_select_method_marker() -> None:
+    # Arrange
+    pane = "Select login method:\n  1. Claude account with subscription"
+    # Act
+    detected = is_login_method_picker(pane)
+    # Assert
+    assert detected is True
+
+
+def test_redact_pane_masks_anthropic_api_key_token() -> None:
+    # Arrange
+    pane = "leaked sk-ant-SECRETVALUE0123456789 in the pane"
+    # Act
+    cleaned = redact_pane(pane)
+    # Assert
+    assert "sk-ant-SECRETVALUE0123456789" not in cleaned
+
+
+def test_redact_pane_masks_supplied_extra_secret_value() -> None:
+    # Arrange
+    pane = "the code was AUTHCODE-xyz-999 typed in"
+    # Act
+    cleaned = redact_pane(pane, "AUTHCODE-xyz-999")
+    # Assert
+    assert "AUTHCODE-xyz-999" not in cleaned
+
+
+@pytest.mark.skipif(shutil.which("tmux") is None, reason="tmux binary not on PATH")
+def test_run_interactive_login_extracts_oauth_url_from_pane(tmp_path: Path) -> None:
+    # Arrange
+    fake = _write_fake_claude(tmp_path)
+    code_file = tmp_path / "code.txt"
+    code_file.write_text("auth-code-abc123\n", encoding="utf-8")
+    # Act
+    result = run_interactive_login(
+        "testacct",
+        notify=False,
+        code_file=str(code_file),
+        claude_bin=f"bash {fake}",
+        workdir=str(tmp_path),
+        url_timeout_s=20.0,
+        human_timeout_s=20.0,
+        poll_s=0.3,
+        echo=lambda *a, **k: None,
+    )
+    # Assert
+    assert result.url == _EXPECTED_URL
+
+
+@pytest.mark.skipif(shutil.which("tmux") is None, reason="tmux binary not on PATH")
+def test_run_interactive_login_completes_via_code_file_drop(tmp_path: Path) -> None:
+    # Arrange
+    fake = _write_fake_claude(tmp_path)
+    code_file = tmp_path / "code.txt"
+    code_file.write_text("auth-code-abc123\n", encoding="utf-8")
+    # Act
+    result = run_interactive_login(
+        "testacct",
+        notify=False,
+        code_file=str(code_file),
+        claude_bin=f"bash {fake}",
+        workdir=str(tmp_path),
+        url_timeout_s=20.0,
+        human_timeout_s=20.0,
+        poll_s=0.3,
+        echo=lambda *a, **k: None,
+    )
+    # Assert
+    assert result.status == "success"


### PR DESCRIPTION
## What

Adds `sac accounts login <name>` — a semi-automated `claude /login` re-auth so that ONLY the browser-authorize step (the part that can trip bot-detection) is done by a human. Turns a full manual `claude /login` + `sac accounts save` into two taps on the operator's phone.

Motivated by the 2026-07-10 account-pool incident (`incident-account-pool-all-expired-boot-failure-20260710`), which left 2 of 3 pool accounts needing a manual `claude /login` + `sac accounts save` — the one step an agent can't do.

## Verb / flags

`sac accounts login <name>` (attaches to the existing `account` group, consistent with `save`/`switch`/`refresh`):

- `--notify/--no-notify` (default notify) — push the URL to the operator via the notify rail in addition to always printing it to stdout.
- `--code-file PATH` — a drop point a remote deliverer writes the pasted code into (polled with timeout).
- `--timeout` (default 600s) — the human browser/code step.
- `--url-timeout` (default 120s) — wait for the URL to appear after `/login`.
- `--claude-bin` (default `claude`), `--workdir` (default `$HOME`), `--save/--no-save` (default save).

## Flow

1. Spawn `claude` in a tmux pane (reuses `TmuxManager`; no new PTY layer).
2. Drive to the OAuth URL: send `/login` once the REPL input marker is up, or — on an expired-credential boot where `claude` auto-shows the login-method picker without a REPL — answer the picker (subscription = option 1). Extract the URL with a strict host-anchored regex (`claude.ai` / `platform.claude.com` / `console.anthropic.com` + a `/oauth`|`/authorize` path); capture with `capture-pane -J` so a long, wrapped URL reconstructs exactly. Fail loud if no URL appears within `--url-timeout`.
3. Deliver the URL: ALWAYS to stdout; ALSO (pluggable) via the existing notify rail. No `claude-code-telegrammer` import.
4. Await completion: browser-only (detect a success marker) OR code-paste (accept the code via `--code-file`, `$SAC_LOGIN_CODE`, or an interactive stdin prompt), type it into the pane, then detect success. Everything is time-bounded and fails loud with a redacted pane tail.
5. On success, reuse the existing `sac accounts save` logic (imported, not shelled) and print the resulting expiry.

## Delivery without importing claude-code-telegrammer

`_default_notifier` calls `scitex_agent_container._state.lead_inbox.push_to_lead(kind="status", ...)` — the sanctioned operator-visible push (the same rail `sac fleet notify` uses; the lead session surfaces it on the operator's Telegram bridge). It is pluggable via a `notifier` argument, and a rail outage downgrades to a stdout-only warning — a notify failure never fails a login whose URL already reached stdout.

## Success detection

A broad marker set (`login successful`, `logged in as`, `successfully logged in`, …) matched case-insensitively, deliberately distinct from the OAuth URL's own `code=true` query param so the URL never trips the code-paste branch. Documented as overridable since the exact wording varies across Claude Code builds (could not be verified against a live login without tripping the real flow).

## Timeout / failure behavior

- `--url-timeout` (120s) bounds the URL-appears step; `--timeout` (600s) bounds the human step; `--code-file` polling is bounded by the same deadline.
- Every wait raises `LoginTimeoutError` carrying a **redacted** pane tail — never an unbounded interactive hang (the "silent stall" class).

## Security (no credential leak)

- Never prints/logs/notifies a token or the pasted code — only the (public) auth URL and the account name.
- Pane tails shown on failure are redacted via the shared `_redact_secrets` matcher (the secret-shaped pattern set), plus the just-typed code is scrubbed defensively.

## Tests

`tests/scitex_agent_container/_account/test_interactive_login.py` — 11 tests, no mocks:
- Pure detection/redaction functions on real pane-shaped strings (incl. the URL-`code=true`-is-not-a-code-prompt guard and the strict-host rejection).
- 2 real-tmux integration tests drive a real fake-`claude` bash subprocess end-to-end (`/login` → picker → URL extract → code-file drop → success), skip-if-no-tmux.

All 11 pass locally (~12s). `scitex-dev ecosystem audit-python-apis` (the STX-TQ / AAA-marker gate — the one that failed prior PRs) passes clean; audit-skills / audit-project pass clean; audit-cli passes clean under `audit-all`. The full `tests/develop/test_audit.py` locally hits the 120s subprocess timeout under host load — an environmental artifact, not a rule violation. ruff `--select F401,F811` clean.

## Files

- `src/scitex_agent_container/_account/interactive_login.py` — the flow (501 lines, under the cap).
- `src/scitex_agent_container/cli_pkg/_account_login.py` — the `login` command + `register_login_command`.
- `src/scitex_agent_container/cli_pkg/account_group.py` — attach the command (register pattern).
- `tests/scitex_agent_container/_account/test_interactive_login.py` — tests.

Does NOT touch `_account/claude_usage.py` (concurrently owned by a sibling agent); for the regex host list it uses `platform.claude.com` (the live OAuth host) as directed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
