### PR TITLE
fix(account,creds,runtimes): incident 2026-07-10 — dead OAuth endpoint root cause, honest failure classes, loud refresh alarms, self-diagnosing picker, :rw credential bind

### DIFF
--- a/src/scitex_agent_container/_account/claude_usage.py
+++ b/src/scitex_agent_container/_account/claude_usage.py
@@ -31,7 +31,6 @@ returned dict for back-compat with downstream consumers, but are always
 
 from __future__ import annotations
 
-import fcntl
 import json
 import time
 import urllib.error
@@ -39,6 +38,39 @@ import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+
+# Headless OAuth token rotation lives in ``token_refresh`` (split for the
+# 512-line cap after INCIDENT 2026-07-10 — see that module's docstring).
+# Every moved name is re-exported here (``__all__``) so pre-split
+# importers (``cli_pkg/_account_refresh``, ``mint_token``, tests) keep
+# working unchanged.
+from .token_refresh import (
+    _CLAUDE_CODE_CLIENT_ID,
+    _REFRESH_USER_AGENT,
+    _TOKEN_URL,
+    _USAGE_BETA_HEADER,
+    _credentials_path,
+    _load_json,
+    _read_tokens_at,
+    _refresh_access_token,
+    _refresh_access_token_at,
+    refresh_account_credentials,
+)
+
+__all__ = [
+    "_CLAUDE_CODE_CLIENT_ID",
+    "_REFRESH_USER_AGENT",
+    "_TOKEN_URL",
+    "_USAGE_BETA_HEADER",
+    "_credentials_path",
+    "_load_json",
+    "_read_tokens_at",
+    "_refresh_access_token",
+    "_refresh_access_token_at",
+    "fetch_usage",
+    "fetch_usage_for_credentials",
+    "refresh_account_credentials",
+]
 
 # ---------------------------------------------------------------------------
 # Public return-shape sentinel keys
@@ -62,26 +94,14 @@ _EMPTY_RESULT: dict[str, Any] = {
 
 _CACHE_TTL_SECONDS = 300  # 5 minutes
 _USAGE_URL = "https://api.anthropic.com/api/oauth/usage"
-# Verified live 2026-05-30: the OAuth refresh endpoint is on the
-# Anthropic console, NOT claude.ai. claude.ai/api/auth/oauth/token is
-# Cloudflare-gated (403/404 for non-browser clients).
-_TOKEN_URL = "https://console.anthropic.com/v1/oauth/token"
-# Required by the OAuth usage endpoint; without it the API returns 4xx and
-# the response shape cannot be parsed. Tracked by Anthropic via the
-# anthropic-beta preview gating header.
-_USAGE_BETA_HEADER = "oauth-2025-04-20"
 # Match the user-agent claude-hud sends so the OAuth gateway treats sac
 # requests as a first-party CLI client.
 _USAGE_USER_AGENT = "claude-code/2.1"
-# Refresh endpoint Cloudflare-gates POSTs unless the client looks like
-# the real Claude Code CLI. Verified live 2026-05-30: bare Content-Type
-# is not enough — all four headers are required.
-_REFRESH_USER_AGENT = "claude-cli/2.1.0 (external, cli)"
-# Claude Code's well-known OAuth client_id. Used when the stored
-# credentials snapshot lacks an explicit `clientId` (current Claude Code
-# versions do not write one to ~/.claude/.credentials.json). Verified
-# live 2026-05-30 against the production refresh endpoint.
-_CLAUDE_CODE_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
+# The OAuth endpoint + refresh constants (`_TOKEN_URL`,
+# `_USAGE_BETA_HEADER`, `_REFRESH_USER_AGENT`, `_CLAUDE_CODE_CLIENT_ID`)
+# moved to ``token_refresh`` (INCIDENT 2026-07-10: the token endpoint
+# HOST changed and the refresh path needed its own reviewable module);
+# they are re-imported above for back-compat.
 
 # Substrings that must never appear in KEYS of the returned dict.
 # These are chosen to catch accidental token field leaks (e.g. "accessToken")
@@ -118,23 +138,6 @@ def _iso_now() -> str:
     return _now_utc().isoformat()
 
 
-def _load_json(path: Path) -> dict[str, Any] | None:
-    """Load JSON file; return None on any error."""
-    # stx-allow: fallback (reason: credentials or cache file may not exist or may be corrupt; None signals caller to skip caching)
-    try:
-        with path.open("r", encoding="utf-8") as fh:
-            data = json.load(fh)
-        if not isinstance(data, dict):
-            return None
-        return data
-    except Exception:  # stx-allow: fallback (reason: catch-all safety net — see inline comment for context)
-        return None
-
-
-def _credentials_path(home: Path) -> Path:
-    return home / ".claude" / ".credentials.json"
-
-
 def _cache_path(home: Path) -> Path:
     return home / ".scitex" / "cache" / "claude_usage.json"
 
@@ -142,34 +145,6 @@ def _cache_path(home: Path) -> Path:
 # ---------------------------------------------------------------------------
 # Token reading (internal only — tokens never returned)
 # ---------------------------------------------------------------------------
-
-
-def _read_tokens_at(
-    credentials_path: Path,
-) -> tuple[str | None, str | None, str | None, int | None]:
-    """Read OAuth tokens from a specific credentials.json file.
-
-    Returns ``(access_token, refresh_token, client_id, expires_at_ms)``.
-    All four are ``None`` if the file is missing/corrupt or lacks the
-    ``claudeAiOauth`` object. Values are consumed inside this module only;
-    tokens never leave the module.
-    """
-    data = _load_json(credentials_path)
-    if data is None:
-        return None, None, None, None
-    oauth = data.get("claudeAiOauth")
-    if not isinstance(oauth, dict):
-        return None, None, None, None
-    access = oauth.get("accessToken")
-    refresh = oauth.get("refreshToken")
-    client_id = oauth.get("clientId")
-    expires_at = oauth.get("expiresAt")  # milliseconds epoch
-    return (
-        access if isinstance(access, str) else None,
-        refresh if isinstance(refresh, str) else None,
-        client_id if isinstance(client_id, str) else None,
-        expires_at if isinstance(expires_at, int) else None,
-    )
 
 
 def _read_tokens(home: Path) -> tuple[str | None, str | None, str | None, int | None]:
@@ -187,126 +162,6 @@ def _is_token_expired(expires_at_ms: int | None) -> bool:
         return False  # unknown — try anyway
     now_ms = int(time.time() * 1000)
     return now_ms >= expires_at_ms - 30_000  # 30-second buffer
-
-
-# ---------------------------------------------------------------------------
-# Token refresh (atomic write with flock)
-# ---------------------------------------------------------------------------
-
-
-def _refresh_access_token_at(
-    credentials_path: Path,
-    refresh_token: str,
-    client_id: str | None,
-    *,
-    opener=None,
-) -> str | None:
-    """POST to token endpoint and atomically update the given credentials file.
-
-    Used by both the legacy ``_refresh_access_token`` wrapper (which
-    targets ``~/.claude/.credentials.json``) and ``fetch_usage_for_credentials``
-    (which targets a per-account snapshot at
-    ``~/.scitex/agent-container/accounts/<name>/.credentials.json``).
-    Returns the new access token string, or ``None`` on failure. Tokens
-    are never returned to the caller of ``fetch_usage`` — this is an
-    internal helper only.
-
-    Notes (verified live 2026-05-30):
-    - Endpoint is ``console.anthropic.com/v1/oauth/token``;
-      ``claude.ai/api/auth/oauth/token`` is Cloudflare-gated and fails for
-      non-browser clients.
-    - Four request headers are required to pass Cloudflare — bare
-      ``Content-Type: application/json`` returns 4xx.
-    - Anthropic does NOT include the OAuth ``clientId`` in the credentials
-      file. When ``client_id`` is None/empty, fall back to the well-known
-      Claude Code client_id.
-    - The refresh_token ROTATES on every successful refresh. The new
-      ``refresh_token`` MUST be persisted alongside the new access_token
-      or the NEXT refresh call will fail (server invalidates the old one).
-    """
-    effective_client_id = client_id or _CLAUDE_CODE_CLIENT_ID
-    body = json.dumps(
-        {
-            "grant_type": "refresh_token",
-            "refresh_token": refresh_token,
-            "client_id": effective_client_id,
-        }
-    ).encode()
-    req = urllib.request.Request(
-        _TOKEN_URL,
-        data=body,
-        headers={
-            "Content-Type": "application/json",
-            "Accept": "application/json",
-            "User-Agent": _REFRESH_USER_AGENT,
-            "anthropic-beta": _USAGE_BETA_HEADER,
-        },
-        method="POST",
-    )
-    _opener = opener if opener is not None else urllib.request.urlopen
-    # stx-allow: fallback (reason: token refresh endpoint may be unreachable or return malformed JSON; None causes caller to proceed with the old token)
-    try:
-        with _opener(req, timeout=15) as resp:
-            raw = resp.read()
-        payload = json.loads(raw)
-    except Exception:  # stx-allow: fallback (reason: catch-all safety net — see inline comment for context)
-        return None
-
-    new_access = payload.get("access_token")
-    new_refresh = payload.get("refresh_token")
-    expires_in = payload.get("expires_in")
-    if not isinstance(new_access, str):
-        return None
-
-    # Atomically update the credentials file. Persist the rotated
-    # refresh_token alongside — this is critical, the server invalidates
-    # the prior refresh_token on success.
-    # stx-allow: fallback (reason: credentials file may be read-only or locked by another process; new access token is still usable in memory even if disk write fails)
-    try:
-        with open(credentials_path, "r+", encoding="utf-8") as fh:
-            fcntl.flock(fh, fcntl.LOCK_EX)
-            try:
-                data = json.load(fh)
-                if not isinstance(data, dict):
-                    data = {}
-                oauth = data.setdefault("claudeAiOauth", {})
-                oauth["accessToken"] = new_access
-                if isinstance(new_refresh, str):
-                    oauth["refreshToken"] = new_refresh
-                if isinstance(expires_in, (int, float)):
-                    oauth["expiresAt"] = int(time.time() * 1000) + int(
-                        expires_in * 1000
-                    )
-                # Write to .tmp then rename for atomicity.
-                tmp_path = Path(str(credentials_path) + ".tmp")
-                with open(tmp_path, "w", encoding="utf-8") as tmp_fh:
-                    json.dump(data, tmp_fh, indent=2)
-                tmp_path.rename(credentials_path)
-            finally:
-                fcntl.flock(fh, fcntl.LOCK_UN)
-    except Exception:  # stx-allow: fallback (reason: catch-all safety net — see inline comment for context)
-        pass  # best-effort write; we still have the new token in memory
-
-    return new_access
-
-
-def _refresh_access_token(
-    home: Path,
-    refresh_token: str,
-    client_id: str,
-    *,
-    opener=None,
-) -> str | None:
-    """POST to token endpoint and atomically update credentials file.
-
-    Thin wrapper over ``_refresh_access_token_at`` resolved to
-    ``~/.claude/.credentials.json``. Returns the new access token string,
-    or ``None`` on failure. Tokens are never returned to the caller of
-    ``fetch_usage`` — this is an internal helper only.
-    """
-    return _refresh_access_token_at(
-        _credentials_path(home), refresh_token, client_id, opener=opener
-    )
 
 
 # ---------------------------------------------------------------------------
@@ -727,85 +582,3 @@ def fetch_usage_for_credentials(
 
     _write_per_account_cache(cache_path, result)
     return result
-
-
-# ---------------------------------------------------------------------------
-# Headless OAuth token refresh — used by `sac accounts refresh`
-# ---------------------------------------------------------------------------
-
-
-def refresh_account_credentials(
-    credentials_path: Path,
-    *,
-    opener=None,
-) -> dict[str, Any]:
-    """Refresh the OAuth access token for the credentials at ``credentials_path``.
-
-    Calls ``_refresh_access_token_at`` (which does the POST to the token
-    endpoint + atomic write-back to the SAME file) and returns a structured
-    result the CLI can render without ever surfacing token values.
-
-    Args:
-        credentials_path: Path to the per-account ``.credentials.json``
-            (typically ``~/.scitex/agent-container/accounts/<name>/.credentials.json``).
-        opener: Optional injection seam for tests.
-
-    Returns:
-        Dict with keys::
-
-            success      : bool — True iff a new access_token was minted.
-            expires_at   : ISO-8601 string of the new token's expiry, or None.
-            error        : str  — reason for failure, or None on success.
-            credentials_path : str — echo of the input path (for `--all` rendering).
-
-        Never raises. Token values are NEVER included.
-    """
-    creds = Path(credentials_path)
-    out: dict[str, Any] = {
-        "success": False,
-        "expires_at": None,
-        "error": None,
-        "credentials_path": str(creds),
-    }
-
-    if not creds.is_file():
-        out["error"] = f"credentials file not found: {creds}"
-        return out
-
-    _, refresh_token, client_id, _ = _read_tokens_at(creds)
-    if not refresh_token:
-        out["error"] = "no refresh_token in credentials — needs `claude /login`"
-        return out
-
-    # Claude Code does not write `clientId` to .credentials.json — use the
-    # stored value if present, else fall back to the constant well-known
-    # Claude Code client_id (verified live 2026-05-30).
-    new_access = _refresh_access_token_at(
-        creds, refresh_token, client_id, opener=opener
-    )
-    if not new_access:
-        out["error"] = (
-            "refresh endpoint rejected the refresh_token — needs `claude /login`"
-        )
-        return out
-
-    # Read back the freshly-written expiry; the token value itself is
-    # intentionally NOT touched (tokens never leave this module).
-    # stx-allow: fallback (reason: post-write read is best-effort; if the just-written file is unreadable the refresh still succeeded in memory)
-    try:
-        data = _load_json(creds) or {}
-        oauth = data.get("claudeAiOauth") if isinstance(data, dict) else None
-        expires_at_ms = (
-            oauth.get("expiresAt") if isinstance(oauth, dict) else None
-        )
-    except Exception:  # stx-allow: fallback (reason: catch-all safety net — see inline comment for context)
-        expires_at_ms = None
-
-    if isinstance(expires_at_ms, int):
-        out["expires_at"] = datetime.fromtimestamp(
-            expires_at_ms / 1000, tz=timezone.utc
-        ).isoformat()
-
-    out["success"] = True
-    return out
-

--- a/src/scitex_agent_container/_account/creds_sync.py
+++ b/src/scitex_agent_container/_account/creds_sync.py
@@ -106,14 +106,15 @@ def slugify_email(email: str) -> str:
     return email.strip().lower().replace("@", "-").replace(".", "-")
 
 
-def _read_oauth_expiry_seconds(path: Path) -> float | None:
-    """Return the OAuth ``expiresAt`` of ``path`` in unix seconds, or None.
+def _read_oauth_expiry_raw(path: Path) -> float | None:
+    """Return the RAW ``claudeAiOauth.expiresAt`` value stored in ``path``.
 
-    ``None`` when the file is missing, unparseable, or lacks a numeric
-    ``claudeAiOauth.expiresAt``. claude-code writes ``expiresAt`` as a
-    unix-MILLISECOND integer; any value above ``1e12`` is treated as
-    milliseconds and divided by 1000 (matching ``_preflight_creds``).
-    Never raises.
+    The value EXACTLY as found on disk (claude-code writes unix
+    MILLISECONDS) — no normalisation, so diagnostics can quote the
+    file's literal content (INCIDENT 2026-07-10: the boot picker's
+    "EXPIRED (-5.8h)" hid which file and which raw value it read, which
+    cost the investigation hours). ``None`` when the file is missing,
+    unparseable, or the field is not numeric. Never raises.
     """
     # stx-allow: fallback (reason: store-snapshot freshness probe is
     # best-effort; a missing/corrupt snapshot must read as "no expiry"
@@ -130,8 +131,30 @@ def _read_oauth_expiry_seconds(path: Path) -> float | None:
     raw = oauth.get("expiresAt")
     if not isinstance(raw, (int, float)) or isinstance(raw, bool):
         return None
-    val = float(raw)
-    return val / 1000.0 if val > 1e12 else val
+    return float(raw)
+
+
+def _oauth_expiry_to_seconds(raw: float) -> float:
+    """Normalise a raw ``expiresAt`` to unix SECONDS.
+
+    Any value above ``1e12`` is treated as milliseconds and divided by
+    1000 (matching ``_preflight_creds``). Single normalisation rule for
+    every freshness reader in the codebase.
+    """
+    return raw / 1000.0 if raw > 1e12 else raw
+
+
+def _read_oauth_expiry_seconds(path: Path) -> float | None:
+    """Return the OAuth ``expiresAt`` of ``path`` in unix seconds, or None.
+
+    ``None`` when the file is missing, unparseable, or lacks a numeric
+    ``claudeAiOauth.expiresAt``. One parse (:func:`_read_oauth_expiry_raw`)
+    + one normalisation (:func:`_oauth_expiry_to_seconds`). Never raises.
+    """
+    raw = _read_oauth_expiry_raw(path)
+    if raw is None:
+        return None
+    return _oauth_expiry_to_seconds(raw)
 
 
 def _read_access_token_fingerprint(path: Path) -> str | None:

--- a/src/scitex_agent_container/_account/refresh_alarm.py
+++ b/src/scitex_agent_container/_account/refresh_alarm.py
@@ -1,0 +1,255 @@
+"""Loud operator alerting for failed headless account refreshes.
+
+INCIDENT 2026-07-10 (card
+``incident-account-pool-all-expired-boot-failure-20260710``): the
+host-side ``sac.accounts-refresh`` systemd timer had been receiving
+failed refresh results for stored accounts for HOURS (the OAuth token
+endpoint had moved and every grant 404'd) and told nobody — the
+failures went to the journal each run, nothing pushed at the operator,
+and the first visible symptom was ``sac agents start --group infra``
+failing for every agent with ``NoHealthyAccountError``.
+
+This module turns a failed refresh into an IMMEDIATE push on the
+fleet's existing agent→lead ``blocker`` rail (ADR-0013,
+:func:`scitex_agent_container._state.lead_inbox.push_to_lead` — the
+same typed event agents already use for "creds expired", persisted
+durably in the lead listen's ``channel_events`` store and relayed to
+the operator by the lead session). No new delivery rail is invented.
+
+Dedupe contract (operator spec):
+
+* First failure for an account → ONE alert, recorded (with the failure
+  class + time) in a small JSON state file under the runtime dir
+  (``~/.scitex/agent-container/runtime/refresh-alarm-state.json``).
+* Subsequent failing runs for the SAME already-alerted account → no
+  re-alert (the timer fires every ~2h; a persistent failure would
+  otherwise page the operator 12x/day).
+* A successful refresh (or a skipped-still-fresh result) CLEARS the
+  account's entry — an account that recovers and later dies again
+  alerts again.
+* A FAILED alert delivery is NOT recorded, so the next run retries it;
+  the delivery failure itself is printed loudly to stderr.
+
+:func:`alert_failed_refreshes` never raises — alerting is a side rail
+and must never break the refresh run that feeds it.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any, Callable
+
+STATE_FILENAME = "refresh-alarm-state.json"
+
+# One-line recovery recipe included in every alert (operator spec: the
+# canonical fix line must ride with the alert). Only meaningful for the
+# token-dead classes; transport-class alerts carry their own "NOT a
+# token problem" wording from ``refresh_account_credentials``.
+RECOVERY_LINE = (
+    "Recovery: `claude /login` as {name}, then `sac accounts save {name}` "
+    "on the credential-holding host."
+)
+
+
+def _default_state_path(home: Path | None = None) -> Path:
+    base = home if home is not None else Path.home()
+    return base / ".scitex" / "agent-container" / "runtime" / STATE_FILENAME
+
+
+def _load_state(path: Path) -> dict[str, Any]:
+    """Read the alarm state file. Missing/corrupt reads as empty state."""
+    # stx-allow: fallback (reason: a missing or corrupt dedupe-state file must degrade to "nothing alerted yet" — worst case one duplicate alert, never a crashed refresh run)
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _save_state(path: Path, state: dict[str, Any]) -> None:
+    """Atomically persist the alarm state (tmp + rename)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(path.name + ".tmp")
+    tmp.write_text(json.dumps(state, indent=2), encoding="utf-8")
+    tmp.replace(path)
+
+
+def _notify_lead_blocker(summary: str, detail: str) -> None:
+    """Leg 1 — the agent→lead ``blocker`` rail (ADR-0013).
+
+    ``from_agent`` is ``$SAC_NAME`` when set (an in-container caller
+    passes the ACL as itself); the host-timer context has no SAC_NAME
+    and falls back to the LEAD's own name — a self-send, which the
+    message:send ACL always admits, so the host rail can never be
+    dropped by a group check. Raises (``LeadInboxError``) on any
+    delivery failure.
+    """
+    from .._state.lead_inbox import push_to_lead, resolve_lead
+
+    lead = resolve_lead()
+    sender = os.environ.get("SAC_NAME", "").strip() or lead.name
+    push_to_lead(
+        kind="blocker",
+        summary=summary,
+        detail=detail,
+        from_agent=sender,
+        lead=lead,
+    )
+
+
+def _notify_todo_help_card(account: str, summary: str, detail: str) -> None:
+    """Leg 2 — the scitex-todo BLOCKING-YOU card (first-tier nudge rail).
+
+    Upserts the canonical ``help-<agent>-waiting`` card via
+    :func:`scitex_todo._help_wait.help_wait` (idempotent; status
+    ``blocked`` / blocker ``operator-decision``) under the pseudo-agent
+    ``accounts-refresh-<account>``, so a dead account surfaces on the
+    board's BLOCKING-YOU view and rides scitex-todo's own card-event
+    delivery (digest/telegram). Lazy import — raises when scitex-todo
+    is not installed, letting the caller report the rail as down.
+    """
+    from scitex_todo._help_wait import help_wait
+
+    help_wait(
+        agent=f"accounts-refresh-{account}",
+        question=f"{summary}\n\n{detail}",
+    )
+
+
+def _default_notify(account: str, summary: str, detail: str) -> None:
+    """Deliver through the EXISTING rails, most direct first.
+
+    Leg 1 is the typed lead ``blocker`` push; a fleet without a
+    ``lead:`` block (this host, 2026-07-11) falls through to leg 2, the
+    scitex-todo help card — the board's standing "waiting on operator"
+    rail. Raises only when EVERY leg failed, so the caller leaves the
+    dedupe unmarked and retries next run.
+    """
+    # stx-allow: fallback (reason: multi-rail delivery — leg 1 being unconfigured/down must fall through to leg 2, not lose the alert; both failing raises loudly below)
+    try:
+        _notify_lead_blocker(summary, detail)
+        return
+    except Exception as lead_exc:  # stx-allow: fallback (reason: see inline comment)
+        lead_err = lead_exc
+    try:
+        _notify_todo_help_card(account, summary, detail)
+        return
+    except Exception as todo_exc:  # stx-allow: fallback (reason: re-raised with full context — both rails' failures are surfaced together)
+        raise RuntimeError(
+            f"every alert rail failed — lead blocker rail: {lead_err}; "
+            f"scitex-todo help-card rail: {todo_exc}"
+        ) from todo_exc
+
+
+def _build_summary(name: str, error: str) -> str:
+    fix = RECOVERY_LINE.format(name=name)
+    return (
+        f"[sac accounts refresh] account '{name}' headless refresh FAILED — "
+        f"{error} {fix}"
+    )
+
+
+def _build_detail(result: dict[str, Any], now_ts: float) -> str:
+    name = str(result.get("name") or "?")
+    lines = [
+        f"account: {name}",
+        f"credentials: {result.get('credentials_path')}",
+        f"failure_kind: {result.get('failure_kind')}",
+        f"error: {result.get('error')}",
+        f"detected_at_epoch: {now_ts:.0f}",
+        "impact: the sac.accounts-refresh timer can no longer keep this "
+        "account's token fresh; agents pinned to it fail to boot once the "
+        "current access token expires (NoHealthyAccountError).",
+        RECOVERY_LINE.format(name=name),
+    ]
+    return "\n".join(lines)
+
+
+def alert_failed_refreshes(
+    results: list[dict[str, Any]],
+    *,
+    state_path: Path | str | None = None,
+    notify: Callable[[str, str, str], None] | None = None,
+    now: float | None = None,
+    err_stream: Any = None,
+) -> list[str]:
+    """Alert the operator (via the lead blocker rail) about NEW failures.
+
+    ``results`` is the per-account list ``sac accounts refresh`` builds
+    (``{"name", "success", "skipped", "error", "failure_kind",
+    "credentials_path", ...}``). Returns the account names alerted this
+    run. Never raises.
+
+    Parameters
+    ----------
+    state_path, notify, now, err_stream
+        Test seams: an explicit dedupe-state file, a replacement
+        delivery callable (called as ``notify(account, summary,
+        detail)``), a fixed clock, and a replacement stderr.
+    """
+    stream = err_stream if err_stream is not None else sys.stderr
+    path = Path(state_path) if state_path is not None else _default_state_path()
+    send = notify if notify is not None else _default_notify
+    now_ts = now if now is not None else time.time()
+
+    state = _load_state(path)
+    alerted: list[str] = []
+    dirty = False
+
+    for result in results:
+        name = str(result.get("name") or "").strip()
+        if not name:
+            continue
+        ok = bool(result.get("skipped")) or bool(result.get("success"))
+        if ok:
+            # Recovery re-arms the alarm: a later death alerts again.
+            if name in state:
+                del state[name]
+                dirty = True
+            continue
+        if name in state:
+            continue  # already alerted for this outage — stay quiet
+        error = str(result.get("error") or "unknown error")
+        # stx-allow: fallback (reason: alert delivery failure must not crash the refresh run; it is reported loudly on stderr and retried on the next run because nothing is recorded)
+        try:
+            send(name, _build_summary(name, error), _build_detail(result, now_ts))
+        except Exception as exc:  # stx-allow: fallback (reason: see inline comment)
+            print(
+                f"  {name:20s}  ALERT DELIVERY FAILED — {exc} "
+                "(refresh failure NOT yet acknowledged; will retry on the "
+                "next refresh run)",
+                file=stream,
+            )
+            continue
+        state[name] = {
+            "alerted_at": now_ts,
+            "failure_kind": result.get("failure_kind"),
+            "error": error,
+        }
+        dirty = True
+        alerted.append(name)
+        print(
+            f"  {name:20s}  ALERTED operator (lead blocker rail / "
+            "scitex-todo help card; deduped until this account refreshes "
+            "OK again)",
+            file=stream,
+        )
+
+    if dirty:
+        # stx-allow: fallback (reason: a dedupe-state write failure may cause one duplicate alert next run — preferable to crashing the refresh; the failure itself is printed loudly)
+        try:
+            _save_state(path, state)
+        except OSError as exc:
+            print(
+                f"[refresh-alarm] failed to persist dedupe state at {path}: "
+                f"{exc}",
+                file=stream,
+            )
+    return alerted
+
+
+__all__ = ["RECOVERY_LINE", "STATE_FILENAME", "alert_failed_refreshes"]

--- a/src/scitex_agent_container/_account/token_refresh.py
+++ b/src/scitex_agent_container/_account/token_refresh.py
@@ -1,0 +1,424 @@
+"""Headless Claude OAuth token refresh — read, rotate, persist, classify.
+
+Split out of ``claude_usage.py`` (817 lines, over the 512-line cap;
+usage fetching and token rotation are separate concerns that only
+shared a module historically). ``claude_usage`` re-exports every moved
+name so existing importers (``cli_pkg/_account_refresh``, tests) are
+unchanged.
+
+INCIDENT 2026-07-10 (card
+``incident-account-pool-all-expired-boot-failure-20260710``): every
+headless refresh had been failing silently because Anthropic MOVED the
+OAuth token endpoint — the old
+``https://console.anthropic.com/v1/oauth/token`` host (verified live
+2026-05-30) now returns HTTP 404 ``not_found_error`` for EVERY
+refresh_token grant. The old error handling collapsed every failure
+(404s included) into ``None`` and the CLI labelled it "refresh endpoint
+rejected the refresh_token — needs ``claude /login``", so a dead
+ENDPOINT was misdiagnosed as dead TOKENS: stored account snapshots aged
+out unrefreshed and a fleet boot failed with ``NoHealthyAccountError``
+as the first visible symptom.
+
+Two structural fixes live here:
+
+* The endpoint constant points at the live host — verified 2026-07-11:
+  a bogus refresh_token gets HTTP 400 ``invalid_grant`` from
+  ``platform.claude.com/v1/oauth/token`` (endpoint alive, grant
+  evaluated) while the old console host 404s for ANY grant. It is
+  overridable via ``$SAC_ANTHROPIC_OAUTH_TOKEN_URL`` so the NEXT host
+  move needs an env var, not a release.
+* :func:`refresh_access_token_at_verbose` CLASSIFIES failures:
+  ``rejected`` (the endpoint evaluated the grant and refused it — the
+  refresh_token is genuinely dead, re-auth needed), ``transport``
+  (endpoint moved / unreachable / 5xx / network — NOT a token
+  problem), ``response`` (2xx but unusable body). Callers and alerts
+  can therefore never again tell the operator to re-login every
+  account when the URL is what died.
+
+Token values NEVER leave this module in return values or error strings.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+# Live OAuth token endpoint (see module docstring — verified 2026-07-11).
+_DEFAULT_TOKEN_URL = "https://platform.claude.com/v1/oauth/token"
+# Back-compat name: pre-split code and tests referenced
+# ``claude_usage._TOKEN_URL``. The wire path resolves per call through
+# :func:`resolve_token_url` so the env override always wins.
+_TOKEN_URL = _DEFAULT_TOKEN_URL
+# Env suffix read through the sac env helper — set
+# ``SAC_ANTHROPIC_OAUTH_TOKEN_URL`` (or the long-prefix twin) to repoint
+# the refresh path without a code change.
+_TOKEN_URL_ENV_SUFFIX = "ANTHROPIC_OAUTH_TOKEN_URL"
+
+# Required by the OAuth endpoints; without it the API returns 4xx.
+_USAGE_BETA_HEADER = "oauth-2025-04-20"
+# The refresh endpoint gates POSTs unless the client looks like the
+# real Claude Code CLI (verified live 2026-05-30: bare Content-Type is
+# not enough — all four request headers are required).
+_REFRESH_USER_AGENT = "claude-cli/2.1.0 (external, cli)"
+# Claude Code's well-known OAuth client_id, used when the stored
+# credentials snapshot lacks an explicit ``clientId`` (current Claude
+# Code versions do not write one).
+_CLAUDE_CODE_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
+
+# Failure classes returned by :func:`refresh_access_token_at_verbose`.
+FAILURE_REJECTED = "rejected"
+FAILURE_TRANSPORT = "transport"
+FAILURE_RESPONSE = "response"
+
+
+def resolve_token_url() -> str:
+    """Return the effective OAuth token endpoint (env override wins).
+
+    Reads ``SAC_ANTHROPIC_OAUTH_TOKEN_URL`` /
+    ``SCITEX_AGENT_CONTAINER_ANTHROPIC_OAUTH_TOKEN_URL`` through the sac
+    env helper; empty/unset falls back to :data:`_DEFAULT_TOKEN_URL`.
+    Resolved per call so a long-lived process honours a live change.
+    """
+    from .._env import getenv as _sac_env
+
+    raw = (_sac_env(_TOKEN_URL_ENV_SUFFIX, "") or "").strip()
+    return raw or _DEFAULT_TOKEN_URL
+
+
+def _load_json(path: Path) -> dict[str, Any] | None:
+    """Load JSON file; return None on any error."""
+    # stx-allow: fallback (reason: credentials or cache file may not exist or may be corrupt; None signals caller to skip)
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        if not isinstance(data, dict):
+            return None
+        return data
+    except Exception:  # stx-allow: fallback (reason: catch-all safety net — see inline comment for context)
+        return None
+
+
+def _credentials_path(home: Path) -> Path:
+    return home / ".claude" / ".credentials.json"
+
+
+def _read_tokens_at(
+    credentials_path: Path,
+) -> tuple[str | None, str | None, str | None, int | None]:
+    """Read OAuth tokens from a specific credentials.json file.
+
+    Returns ``(access_token, refresh_token, client_id, expires_at_ms)``.
+    All four are ``None`` if the file is missing/corrupt or lacks the
+    ``claudeAiOauth`` object. Values are consumed inside this package
+    only; tokens never leave it.
+    """
+    data = _load_json(credentials_path)
+    if data is None:
+        return None, None, None, None
+    oauth = data.get("claudeAiOauth")
+    if not isinstance(oauth, dict):
+        return None, None, None, None
+    access = oauth.get("accessToken")
+    refresh = oauth.get("refreshToken")
+    client_id = oauth.get("clientId")
+    expires_at = oauth.get("expiresAt")  # milliseconds epoch
+    return (
+        access if isinstance(access, str) else None,
+        refresh if isinstance(refresh, str) else None,
+        client_id if isinstance(client_id, str) else None,
+        expires_at if isinstance(expires_at, int) else None,
+    )
+
+
+def _persist_rotated_tokens(
+    credentials_path: Path, payload: dict[str, Any]
+) -> None:
+    """Atomically write the rotated token block back to the SAME file.
+
+    The refresh_token ROTATES on every successful refresh; the server
+    invalidates the previous one, so the new ``refresh_token`` MUST be
+    persisted alongside the new access_token or the NEXT refresh fails.
+    flock + write-to-tmp + rename keeps concurrent sac writers serialized
+    on the same inode and readers away from torn JSON.
+    """
+    new_access = payload.get("access_token")
+    new_refresh = payload.get("refresh_token")
+    expires_in = payload.get("expires_in")
+    # stx-allow: fallback (reason: credentials file may be read-only or locked by another process; new access token is still usable in memory even if disk write fails)
+    try:
+        with open(credentials_path, "r+", encoding="utf-8") as fh:
+            fcntl.flock(fh, fcntl.LOCK_EX)
+            try:
+                data = json.load(fh)
+                if not isinstance(data, dict):
+                    data = {}
+                oauth = data.setdefault("claudeAiOauth", {})
+                oauth["accessToken"] = new_access
+                if isinstance(new_refresh, str):
+                    oauth["refreshToken"] = new_refresh
+                if isinstance(expires_in, (int, float)):
+                    oauth["expiresAt"] = int(time.time() * 1000) + int(
+                        expires_in * 1000
+                    )
+                tmp_path = Path(str(credentials_path) + ".tmp")
+                with open(tmp_path, "w", encoding="utf-8") as tmp_fh:
+                    json.dump(data, tmp_fh, indent=2)
+                tmp_path.rename(credentials_path)
+            finally:
+                fcntl.flock(fh, fcntl.LOCK_UN)
+    except Exception:  # stx-allow: fallback (reason: catch-all safety net — see inline comment for context)
+        pass  # best-effort write; we still have the new token in memory
+
+
+def refresh_access_token_at_verbose(
+    credentials_path: Path,
+    refresh_token: str,
+    client_id: str | None,
+    *,
+    opener=None,
+) -> tuple[str | None, str | None, str | None]:
+    """POST the refresh grant; return ``(access_token, kind, reason)``.
+
+    On success: ``(token, None, None)`` and the rotated block has been
+    atomically persisted to ``credentials_path``. On failure the token
+    is ``None`` and ``kind`` is one of
+
+    * :data:`FAILURE_REJECTED` — the endpoint EVALUATED the grant and
+      refused it (HTTP 4xx carrying ``invalid_grant``/``invalid_request``
+      semantics). The stored refresh_token is genuinely dead; only a
+      re-auth fixes it.
+    * :data:`FAILURE_TRANSPORT` — the grant was never evaluated: HTTP
+      404 (endpoint moved — THE 2026-07-10 incident), 5xx, or a network
+      error. NOT a token problem; re-logging in cannot fix it.
+    * :data:`FAILURE_RESPONSE` — 2xx but the body was unparseable or
+      lacked ``access_token``.
+
+    ``reason`` is an operator-facing sentence naming the endpoint URL
+    and HTTP status. It NEVER contains token material (failure bodies
+    from the endpoint carry no tokens; success bodies are never quoted).
+    """
+    url = resolve_token_url()
+    effective_client_id = client_id or _CLAUDE_CODE_CLIENT_ID
+    body = json.dumps(
+        {
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+            "client_id": effective_client_id,
+        }
+    ).encode()
+    req = urllib.request.Request(
+        url,
+        data=body,
+        headers={
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "User-Agent": _REFRESH_USER_AGENT,
+            "anthropic-beta": _USAGE_BETA_HEADER,
+        },
+        method="POST",
+    )
+    _opener = opener if opener is not None else urllib.request.urlopen
+    try:
+        with _opener(req, timeout=15) as resp:
+            raw = resp.read()
+    except urllib.error.HTTPError as exc:
+        # stx-allow: fallback (reason: error body read is diagnostic-only; an unreadable body still classifies by status code)
+        try:
+            err_body = exc.read().decode("utf-8", "replace")[:200]
+        except Exception:  # stx-allow: fallback (reason: see inline comment)
+            err_body = ""
+        if exc.code in (400, 401, 403) and (
+            "invalid_grant" in err_body or "invalid_request" in err_body
+        ):
+            return (
+                None,
+                FAILURE_REJECTED,
+                f"token endpoint {url} evaluated and REFUSED the grant "
+                f"(HTTP {exc.code}: {err_body or exc.reason}) — the stored "
+                "refresh_token is dead",
+            )
+        return (
+            None,
+            FAILURE_TRANSPORT,
+            f"token endpoint {url} did not evaluate the grant "
+            f"(HTTP {exc.code}: {err_body or exc.reason}) — endpoint "
+            "moved/unavailable; this is NOT a token problem",
+        )
+    except Exception as exc:  # stx-allow: fallback (reason: network layer may raise OSError/URLError/timeout; classify as transport, never crash the refresh loop)
+        return (
+            None,
+            FAILURE_TRANSPORT,
+            f"token endpoint {url} unreachable ({exc.__class__.__name__}: "
+            f"{exc}) — network/endpoint failure; this is NOT a token problem",
+        )
+
+    # stx-allow: fallback (reason: a 2xx with an unparseable body must classify as FAILURE_RESPONSE, never crash)
+    try:
+        payload = json.loads(raw)
+    except Exception:  # stx-allow: fallback (reason: see inline comment)
+        return (
+            None,
+            FAILURE_RESPONSE,
+            f"token endpoint {url} returned 2xx with a non-JSON body",
+        )
+
+    new_access = payload.get("access_token") if isinstance(payload, dict) else None
+    if not isinstance(new_access, str):
+        return (
+            None,
+            FAILURE_RESPONSE,
+            f"token endpoint {url} returned 2xx without an access_token",
+        )
+
+    _persist_rotated_tokens(credentials_path, payload)
+    return new_access, None, None
+
+
+def _refresh_access_token_at(
+    credentials_path: Path,
+    refresh_token: str,
+    client_id: str | None,
+    *,
+    opener=None,
+) -> str | None:
+    """Back-compat wrapper: token-or-None (reason discarded).
+
+    Pre-incident callers (the usage-fetch retry paths) only need the
+    token; new code that must EXPLAIN a failure calls
+    :func:`refresh_access_token_at_verbose`.
+    """
+    new_access, _, _ = refresh_access_token_at_verbose(
+        credentials_path, refresh_token, client_id, opener=opener
+    )
+    return new_access
+
+
+def _refresh_access_token(
+    home: Path,
+    refresh_token: str,
+    client_id: str,
+    *,
+    opener=None,
+) -> str | None:
+    """POST to token endpoint and atomically update credentials file.
+
+    Thin wrapper over ``_refresh_access_token_at`` resolved to
+    ``~/.claude/.credentials.json``. Returns the new access token string,
+    or ``None`` on failure. Tokens are never returned to the caller of
+    ``fetch_usage`` — this is an internal helper only.
+    """
+    return _refresh_access_token_at(
+        _credentials_path(home), refresh_token, client_id, opener=opener
+    )
+
+
+def refresh_account_credentials(
+    credentials_path: Path,
+    *,
+    opener=None,
+) -> dict[str, Any]:
+    """Refresh the OAuth access token for the credentials at ``credentials_path``.
+
+    Calls :func:`refresh_access_token_at_verbose` (POST to the token
+    endpoint + atomic write-back to the SAME file) and returns a
+    structured result the CLI can render without ever surfacing token
+    values.
+
+    Returns:
+        Dict with keys::
+
+            success      : bool — True iff a new access_token was minted.
+            expires_at   : ISO-8601 string of the new token's expiry, or None.
+            error        : str  — reason for failure, or None on success.
+            failure_kind : str|None — ``rejected`` / ``transport`` /
+                           ``response`` / ``no-refresh-token`` /
+                           ``missing-file`` (see module docstring); the
+                           alerting rail and tests key off this.
+            credentials_path : str — echo of the input path.
+
+        Never raises. Token values are NEVER included.
+    """
+    creds = Path(credentials_path)
+    out: dict[str, Any] = {
+        "success": False,
+        "expires_at": None,
+        "error": None,
+        "failure_kind": None,
+        "credentials_path": str(creds),
+    }
+
+    if not creds.is_file():
+        out["error"] = f"credentials file not found: {creds}"
+        out["failure_kind"] = "missing-file"
+        return out
+
+    _, refresh_token, client_id, _ = _read_tokens_at(creds)
+    if not refresh_token:
+        out["error"] = "no refresh_token in credentials — needs `claude /login`"
+        out["failure_kind"] = "no-refresh-token"
+        return out
+
+    new_access, kind, reason = refresh_access_token_at_verbose(
+        creds, refresh_token, client_id, opener=opener
+    )
+    if not new_access and kind == FAILURE_REJECTED:
+        # Concurrent-writer mitigation (shared writable credential file,
+        # 2026-07-11): another refresher — the in-container claude, a
+        # sibling timer run, a live login — may have ROTATED the
+        # refresh_token between our read and our POST, making OUR copy
+        # stale (the server invalidates the old one on rotation). Re-read
+        # the file; if the on-disk refresh_token CHANGED, retry ONCE with
+        # the fresh value instead of declaring the account dead.
+        refresh_token_2, client_id_2 = _read_tokens_at(creds)[1:3]
+        if refresh_token_2 and refresh_token_2 != refresh_token:
+            new_access, kind, reason = refresh_access_token_at_verbose(
+                creds, refresh_token_2, client_id_2, opener=opener
+            )
+    if not new_access:
+        out["failure_kind"] = kind
+        if kind == FAILURE_REJECTED:
+            out["error"] = (
+                f"refresh endpoint rejected the refresh_token ({reason}) — "
+                "needs `claude /login` as this account, then "
+                "`sac accounts save <name>`"
+            )
+        else:
+            out["error"] = (
+                f"{reason}; re-login will NOT fix this class of failure "
+                "($SAC_ANTHROPIC_OAUTH_TOKEN_URL overrides the endpoint)"
+            )
+        return out
+
+    # Read back the freshly-written expiry; the token value itself is
+    # intentionally NOT touched (tokens never leave this module).
+    # stx-allow: fallback (reason: post-write read is best-effort; if the just-written file is unreadable the refresh still succeeded in memory)
+    try:
+        data = _load_json(creds) or {}
+        oauth = data.get("claudeAiOauth") if isinstance(data, dict) else None
+        expires_at_ms = oauth.get("expiresAt") if isinstance(oauth, dict) else None
+    except Exception:  # stx-allow: fallback (reason: catch-all safety net — see inline comment for context)
+        expires_at_ms = None
+
+    if isinstance(expires_at_ms, int):
+        out["expires_at"] = datetime.fromtimestamp(
+            expires_at_ms / 1000, tz=timezone.utc
+        ).isoformat()
+
+    out["success"] = True
+    return out
+
+
+__all__ = [
+    "FAILURE_REJECTED",
+    "FAILURE_RESPONSE",
+    "FAILURE_TRANSPORT",
+    "refresh_access_token_at_verbose",
+    "refresh_account_credentials",
+    "resolve_token_url",
+]

--- a/src/scitex_agent_container/_creds/_pick_healthy.py
+++ b/src/scitex_agent_container/_creds/_pick_healthy.py
@@ -56,10 +56,14 @@ from __future__ import annotations
 
 import time
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Mapping
 
-from .._account.creds_sync import _read_oauth_expiry_seconds
+from .._account.creds_sync import (
+    _oauth_expiry_to_seconds,
+    _read_oauth_expiry_raw,
+)
 from .._account.quota_cache import read_quota_entry
 from .._state.account_store import _store_path
 
@@ -107,11 +111,22 @@ class AccountHealth:
     hours_remaining
         Signed hours to expiry (positive = remaining, negative =
         past) for VALID/EXPIRED; ``None`` for ABSENT.
+    snapshot_path
+        The EXACT file this probe read (or looked for). INCIDENT
+        2026-07-10: the "EXPIRED (-5.8h)" boot error hid which file it
+        had evaluated, so a snapshot repaired minutes later looked like
+        a false read and cost the investigation hours. Every health
+        record now carries its evidence.
+    expires_at_raw
+        The literal ``claudeAiOauth.expiresAt`` value found in the file
+        (claude-code writes unix milliseconds); ``None`` for ABSENT.
     """
 
     name: str
     state: str
     hours_remaining: float | None
+    snapshot_path: str | None = None
+    expires_at_raw: float | None = None
 
     @property
     def is_healthy(self) -> bool:
@@ -140,12 +155,28 @@ def account_health(
 
     store = _store_path(store_dir, _home)
     snapshot = store / name / ".credentials.json"
-    expiry = _read_oauth_expiry_seconds(snapshot) if snapshot.is_file() else None
-    if expiry is None:
-        return AccountHealth(name=name, state=_ABSENT, hours_remaining=None)
+    # ONE read supplies BOTH the raw evidence value and the normalised
+    # expiry, so the record can never quote a different file state than
+    # the one it judged (a mid-probe rewrite yields a coherent record).
+    raw = _read_oauth_expiry_raw(snapshot) if snapshot.is_file() else None
+    if raw is None:
+        return AccountHealth(
+            name=name,
+            state=_ABSENT,
+            hours_remaining=None,
+            snapshot_path=str(snapshot),
+            expires_at_raw=None,
+        )
+    expiry = _oauth_expiry_to_seconds(raw)
     hours = (expiry - now_ts) / 3600.0
     state = _VALID if expiry > now_ts else _EXPIRED
-    return AccountHealth(name=name, state=state, hours_remaining=hours)
+    return AccountHealth(
+        name=name,
+        state=state,
+        hours_remaining=hours,
+        snapshot_path=str(snapshot),
+        expires_at_raw=raw,
+    )
 
 
 def _discover_candidates(
@@ -179,14 +210,36 @@ def _discover_candidates(
     return out
 
 
+def _iso_utc(seconds: float) -> str:
+    """Render a unix-seconds timestamp as a compact ISO-8601 UTC string."""
+    return datetime.fromtimestamp(seconds, tz=timezone.utc).isoformat(
+        timespec="seconds"
+    )
+
+
 def _format_states(healths: list[AccountHealth]) -> str:
-    """Render an operator-facing "name=STATE (+/-Xh)" list for the error."""
+    """Render the operator-facing per-account evidence list for the error.
+
+    Self-diagnosing (INCIDENT 2026-07-10): each entry names the file
+    that was read, the RAW ``expiresAt`` value found in it, and its UTC
+    rendering — so a "this account was fine minutes later!" report can
+    be adjudicated from the error line alone (the snapshot may simply
+    have been rewritten between the probe and the re-check).
+    """
     parts: list[str] = []
     for h in healths:
-        if h.hours_remaining is None:
-            parts.append(f"{h.name}={h.state}")
+        if h.hours_remaining is None or h.expires_at_raw is None:
+            parts.append(
+                f"{h.name}={h.state} (no numeric claudeAiOauth.expiresAt; "
+                f"file={h.snapshot_path})"
+            )
         else:
-            parts.append(f"{h.name}={h.state} ({h.hours_remaining:+.1f}h)")
+            expiry_s = _oauth_expiry_to_seconds(h.expires_at_raw)
+            parts.append(
+                f"{h.name}={h.state} ({h.hours_remaining:+.1f}h; "
+                f"expiresAt={h.expires_at_raw:.0f} = {_iso_utc(expiry_s)}; "
+                f"file={h.snapshot_path})"
+            )
     return ", ".join(parts) if parts else "(no candidates)"
 
 
@@ -382,10 +435,15 @@ def pick_healthy_account(
     fresh = [h for h in healths if h.is_healthy]
 
     # 3. Nothing token-fresh — fail loud BEFORE any quota logic (a stale
-    #    snapshot must never boot, regardless of headroom).
+    #    snapshot must never boot, regardless of headroom). The message
+    #    pins the probe time and quotes each snapshot's path + raw
+    #    expiresAt (INCIDENT 2026-07-10: without this evidence a snapshot
+    #    repaired minutes after the probe looked like a false-expired
+    #    read and cost the investigation hours).
     if not fresh:
+        probe_ts = now if now is not None else time.time()
         raise NoHealthyAccountError(
-            "no healthy stored account: "
+            f"no healthy stored account (probed at {_iso_utc(probe_ts)}): "
             f"{_format_states(healths)}. Fix: `claude /login` to one of "
             "them, then `sac accounts sync-live`, then restart the agent."
         )

--- a/src/scitex_agent_container/cli_pkg/_account_refresh.py
+++ b/src/scitex_agent_container/cli_pkg/_account_refresh.py
@@ -380,6 +380,16 @@ def account_refresh(
             else:
                 click.echo(f"  {r['name']:20s}  FAILED — {r['error']}", err=True)
 
+    # LOUD failure alerting (INCIDENT 2026-07-10): a failed refresh —
+    # most importantly a rejected/unreachable refresh grant — pushes an
+    # immediate typed ``blocker`` to the lead via the existing ADR-0013
+    # rail, deduped per account until that account refreshes OK again.
+    # Runs for EVERY invocation shape (timer --all, manual single name).
+    # Never raises; alert lines go to stderr under the results table.
+    from .._account.refresh_alarm import alert_failed_refreshes
+
+    alert_failed_refreshes(results)
+
     # Exit non-zero when EVERY *attempted* account failed (skipped-fresh
     # accounts don't count), OR when an active-login sync failed loud.
     # --all with mixed results is still a useful partial success.

--- a/src/scitex_agent_container/runtimes/_apptainer_auth.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_auth.py
@@ -120,23 +120,25 @@ def auth_argv(config: AgentConfig, state_dir: Path) -> list[str]:
     # CLAUDE_CONFIG_DIR points the SDK at this dir so it finds the
     # credentials file without needing $HOME pollution.
     #
-    # Mounted READ-ONLY (``:ro``) — master-host single-refresher model
-    # (operator 2026-07-08, credential-churn root-cause fix). The agent
-    # is a READ-ONLY CONSUMER of the credential: it NEVER refreshes or
-    # rotates the OAuth token. Previously this dir was bound ``:rw`` so
-    # the in-container Claude CLI could refresh the ``accessToken`` in
-    # place — but that made every running agent a refresher, and an
-    # agent refresh CONSUMES the single-use OAuth refresh_token: the
-    # instant an operator logged a fresh account in, a running agent ate
-    # its refresh_token (the "cred churn" disease). Now the host-side
-    # ``sac-accounts-refresh`` timer is the SOLE refresher; it rotates
-    # every account's snapshot on a fixed cadence, and the DIRECTORY
-    # bind (below) makes the timer's atomic-replace refreshes visible to
-    # the container on the next open — so a ``:ro`` agent still tracks
-    # the freshest token without ever writing one. The fail-loud expiry
-    # checks still apply: a ``:ro`` agent bound to an already-expired
-    # token cannot work, so an expired snapshot is an operator/timer
-    # problem to fix before launch, not something the agent can rescue.
+    # Mounted WRITABLE (``:rw``) — shared-credential model (operator
+    # 2026-07-11, reversing the 2026-07-08 ``:ro`` flip after INCIDENT
+    # 2026-07-10). A ``:ro`` bind cannot stop the in-container claude
+    # from POSTing a refresh — the server rotates and invalidates the
+    # old refresh_token chain regardless — it can only stop the rotation
+    # from being RECORDED, stranding the host snapshot on a dead
+    # refresh_token (worst of both worlds). A shared writable
+    # credentials file is the normal, supported Claude shape (several
+    # ``claude`` processes share one ``~/.claude/.credentials.json`` on
+    # any workstation): whoever refreshes writes the rotated pair back
+    # and every other consumer re-reads it. The host-side
+    # ``sac-accounts-refresh`` timer keeps refreshing on cadence with
+    # flock + atomic write (``_account.token_refresh``), and its
+    # ``refresh_account_credentials`` re-reads-and-retries once on
+    # ``invalid_grant`` so a concurrently-rotated token is recovered
+    # rather than declared dead. The fail-loud expiry checks still
+    # apply: an agent bound to an already-expired token cannot work, so
+    # an expired snapshot is an operator/timer problem to fix before
+    # launch, not something the agent can rescue.
     #
     # OAuth credentials bind shape: DIRECTORY bind, unconditionally
     # (operator task #11 + task #13).
@@ -145,7 +147,7 @@ def auth_argv(config: AgentConfig, state_dir: Path) -> list[str]:
     # both rewritten by host-side atomic-replace paths —
     # ``_account.creds_sync._atomic_copy`` (sync-live + watch-live),
     # ``_state.account_store.switch_account``,
-    # ``_account.claude_usage._refresh_access_token_at`` — all using
+    # ``_account.token_refresh._refresh_access_token_at`` — all using
     # ``tmp + os.replace``. A single-file bind mount is on the file's
     # dentry/inode; an atomic-replace orphans that inode (the bind
     # surfaces as ``...credentials.json//deleted`` in
@@ -154,13 +156,12 @@ def auth_argv(config: AgentConfig, state_dir: Path) -> list[str]:
     # collision-401 disease the snapshot model was meant to fix.
     # A DIRECTORY bind resolves child files by name through the
     # underlying filesystem on every open, so a host-side tmp+rename
-    # inside the dir is visible to the container immediately. Under the
-    # ``:ro`` single-refresher model this matters in ONE direction that
-    # counts: the host-side ``sac-accounts-refresh`` timer's atomic
-    # replace of ``.credentials.json`` is picked up by the container on
-    # the next open, so a read-only agent tracks the freshest token
-    # without a restart. The container no longer writes back (``:ro``),
-    # which is the whole point — no agent-side refresh, no churn.
+    # inside the dir is visible to the container immediately — the
+    # host-side ``sac-accounts-refresh`` timer's atomic replace of
+    # ``.credentials.json`` is picked up by the container on the next
+    # open, and (since the 2026-07-11 ``:rw`` restore) a rotation the
+    # container performs is likewise visible to the host and to every
+    # co-bound agent.
     #
     # PR #262 (task #11) made the PINNED branch dir-bind; this module
     # (task #13) makes the UNPINNED/host-live branch dir-bind too. The
@@ -219,11 +220,11 @@ def auth_argv(config: AgentConfig, state_dir: Path) -> list[str]:
 
     argv += [
         "--bind",
-        # READ-ONLY: the agent consumes the credential but never
-        # refreshes it (master-host single-refresher model). See the
-        # "Mounted READ-ONLY" rationale above. The host-side timer is
-        # the sole refresher; the dir bind surfaces its refreshes.
-        f"{bind_src}:{bind_dest}:ro",
+        # WRITABLE: the in-container claude shares the credential file
+        # like any co-resident claude process — a rotation it performs
+        # is written back instead of silently invalidating the stored
+        # refresh_token (see the "Mounted WRITABLE" rationale above).
+        f"{bind_src}:{bind_dest}:rw",
         "--env",
         "CLAUDE_CONFIG_DIR=/tmp/sac-claude",
     ]

--- a/src/scitex_agent_container/runtimes/_apptainer_auth_bind.py
+++ b/src/scitex_agent_container/runtimes/_apptainer_auth_bind.py
@@ -8,9 +8,9 @@ auth branch pushed it over; mirrors the existing helper-module split:
 resolving unchanged.
 
 This module owns ONE concern: rendering (and pre-creating the target
-for) the READ-ONLY ``.credentials.json`` file-bind at the container
-``$HOME/.claude/.credentials.json``. The per-launch backend env argv
-(``auth_argv``) stays in ``_apptainer_auth``.
+for) the shared WRITABLE ``.credentials.json`` file-bind at the
+container ``$HOME/.claude/.credentials.json``. The per-launch backend
+env argv (``auth_argv``) stays in ``_apptainer_auth``.
 """
 
 from __future__ import annotations
@@ -88,7 +88,7 @@ def _assert_credential_unexpired(
 def credentials_file_bind(
     config: AgentConfig, *, now: float | None = None
 ) -> list[str]:
-    """Render the READ-ONLY file-bind for the agent's credentials file.
+    """Render the WRITABLE file-bind for the agent's credentials file.
 
     Emitted LAST in :func:`_apptainer_build_argv.build_run_argv` (after
     the overlay-upper-home bind) so a relaxed ``--home`` tmpfs or
@@ -111,42 +111,48 @@ def credentials_file_bind(
          or the launch resolves to the ``openai`` agent-SDK family
          (openai-compat-3 — no Anthropic backend to auth to) → no bind.
 
-    Binds the resolved host file READ-ONLY (``:ro``) at
+    Binds the resolved host file WRITABLE (``:rw``) at
     ``<container_home>/.claude/.credentials.json`` so the in-container
-    ``claude`` (both SDK and TUI variants) READS that single file
-    directly but NEVER refreshes or rotates it. The SAME path the
-    interactive ``claude`` auto-discovers when no ``$CLAUDE_CONFIG_DIR``
-    redirect is set — operator-confirmed working shape (figrecipe +
-    scitex-todo manual test 2026-06-15).
+    ``claude`` (both SDK and TUI variants) shares that single file — the
+    SAME path the interactive ``claude`` auto-discovers when no
+    ``$CLAUDE_CONFIG_DIR`` redirect is set — operator-confirmed working
+    shape (figrecipe + scitex-todo manual test 2026-06-15).
 
-    Master-host single-refresher model (operator 2026-07-08, cred-churn
-    root-cause fix): the agent is a READ-ONLY CONSUMER. Previously this
-    file was bound ``:rw`` so the in-container CLI refreshed the OAuth
-    ``accessToken`` in place — but a refresh CONSUMES the single-use
-    OAuth refresh_token, so a running agent would eat the refresh_token
-    of a freshly-logged-in account (the churn). Now the host-side
-    ``sac-accounts-refresh`` timer is the SOLE refresher: it rotates the
-    account snapshot's access_token on a fixed cadence and writes it
-    back to the SAME snapshot file this bind sources, so a ``:ro`` agent
-    always reads a timer-kept-fresh token without ever writing one.
+    Why ``:rw`` (INCIDENT 2026-07-10 follow-up, operator 2026-07-11,
+    reversing the 2026-07-08 ``:ro`` flip): a read-only bind CANNOT
+    prevent the in-container ``claude`` from POSTing a token refresh —
+    the server rotates and invalidates the old refresh_token chain
+    regardless — it can only prevent the rotation from being RECORDED,
+    leaving the host snapshot holding a dead refresh_token (worst of
+    both worlds). A shared writable credentials file is the NORMAL,
+    supported Claude configuration (any workstation runs several
+    ``claude`` processes against one ``~/.claude/.credentials.json``):
+    whoever refreshes writes the rotated pair back, and every other
+    consumer re-reads it. sac's own refresher takes ``flock`` + atomic
+    write (:mod:`.._account.token_refresh`), and
+    ``refresh_account_credentials`` re-reads-and-retries once on
+    ``invalid_grant`` so a concurrently-rotated token is picked up
+    instead of being declared dead. Cross-HOST sharing remains unsolved
+    by design — that is the ``sac-host-token-broker-single-writer``
+    follow-up, not this bind.
 
     The fail-loud expiry gate (``_assert_credential_unexpired`` for the
     explicit-file branch, ``resolve_cred_file`` → ``PinnedAccountError``
-    for the account branch) is unchanged and still load-bearing: a
-    ``:ro`` agent bound to an already-expired token cannot work, so an
-    expired credential is refused at launch (an operator/timer problem
-    to fix first, not one the read-only agent can rescue).
+    for the account branch) is unchanged and still load-bearing: an
+    agent bound to an already-expired token cannot work, so an expired
+    credential is refused at launch (an operator/timer problem to fix
+    first, not one the agent can rescue).
 
-    Caveat: a single-file ``:ro`` bind is on the file's inode. A
-    host-side tmp+rename refresh (the timer's atomic-replace) orphans
-    the bind — the container keeps reading the pre-rename inode until it
-    restarts. For a ``:ro`` agent this is a staleness (not a corruption)
-    concern: the token is valid until its natural expiry, and the timer
-    keeps the snapshot fresh so a restart re-binds the current inode.
-    The account-pinned SDK path additionally gets the DIRECTORY bind at
-    ``/tmp/sac-claude`` (:func:`_apptainer_auth.auth_argv`), which
-    resolves the child file by name on every open and so DOES reflect
-    atomic-replace refreshes without a restart.
+    Caveat: a single-file bind is on the file's inode. A host-side
+    tmp+rename refresh (the timer's atomic-replace) orphans the bind —
+    the container keeps reading the pre-rename inode until it restarts.
+    This is a staleness (not a corruption) concern: the token is valid
+    until its natural expiry, and the timer keeps the snapshot fresh so
+    a restart re-binds the current inode. The account-pinned SDK path
+    additionally gets the DIRECTORY bind at ``/tmp/sac-claude``
+    (:func:`_apptainer_auth.auth_argv`), which resolves the child file
+    by name on every open and so DOES reflect atomic-replace refreshes
+    without a restart.
     """
     if provider_active(config) or openai_provider_active(config):
         return []
@@ -203,10 +209,12 @@ def credentials_file_bind(
 
     container_home = resolve_container_home(config).rstrip("/")
     dest = f"{container_home}/.claude/.credentials.json"
-    # READ-ONLY: the agent consumes the credential but never refreshes
-    # it (master-host single-refresher model — see the docstring). The
-    # host-side ``sac-accounts-refresh`` timer is the sole refresher.
-    return ["--bind", f"{src}:{dest}:ro"]
+    # WRITABLE: the in-container claude shares the credential file like
+    # any co-resident claude process would — whoever refreshes writes
+    # the rotated token pair back so no consumer is left holding a
+    # server-invalidated refresh_token (see the docstring's 2026-07-11
+    # rationale; ``:ro`` could not stop the rotation, only its recording).
+    return ["--bind", f"{src}:{dest}:rw"]
 
 
 def ensure_credentials_bind_target(
@@ -232,7 +240,7 @@ def ensure_credentials_bind_target(
     :func:`_apptainer_build_argv.build_run_argv`), else the workspace-home
     dir (``<state>/home``, bound at ``/home/agent``). This ensures an empty
     0-byte ``.claude/.credentials.json`` exists at that host path so the
-    ``:ro`` bind lands; the bind then SHADOWS this placeholder with the real
+    credentials bind lands; the bind then SHADOWS this placeholder with the real
     operator credential — the placeholder's contents never matter.
 
     CRITICAL — placement: the placeholder is written into the overlay
@@ -263,7 +271,7 @@ def ensure_credentials_bind_target(
     flags = bind_flags if bind_flags is not None else credentials_file_bind(config)
     if not flags:
         return None
-    # flags == ["--bind", "<src>:<container_home>/.claude/.credentials.json:ro"]
+    # flags == ["--bind", "<src>:<container_home>/.claude/.credentials.json:rw"]
     from ._to_home_overlay import resolve_container_home
 
     container_home = resolve_container_home(config).rstrip("/")

--- a/tests/integration/test_cross_package_imports.py
+++ b/tests/integration/test_cross_package_imports.py
@@ -31,6 +31,7 @@ CROSS_PACKAGE_IMPORTS = [
     "scitex_dev.linter.checker",
     "scitex_logging",
     "scitex_notification",
+    "scitex_todo._help_wait",
 ]
 # ===== END AUTO-GENERATED =====
 

--- a/tests/integration/test_provider_column_specs.py
+++ b/tests/integration/test_provider_column_specs.py
@@ -195,8 +195,9 @@ def test_claude_column_argv_carries_no_openai_wiring(_sandbox_env: Path) -> None
 
 
 def test_claude_column_argv_binds_oauth_credentials(_sandbox_env: Path) -> None:
-    # Arrange — a real host creds file: the Claude column's OAuth
-    # dir-bind must be UNCHANGED by the openai-compat-3 branch.
+    # Arrange — a real host creds file: the Claude column emits the OAuth
+    # dir-bind (:rw since the 2026-07-11 shared-credential model — a
+    # rotation performed in-container must be recorded, not dropped).
     creds = _sandbox_env / "home" / ".claude" / ".credentials.json"
     creds.parent.mkdir(parents=True, exist_ok=True)
     creds.write_text("{}")
@@ -204,7 +205,7 @@ def test_claude_column_argv_binds_oauth_credentials(_sandbox_env: Path) -> None:
     # Act
     argv = _column_argv(cfg, _sandbox_env)
     # Assert
-    assert any(a == f"{creds.parent}:/tmp/sac-claude:ro" for a in argv)
+    assert any(a == f"{creds.parent}:/tmp/sac-claude:rw" for a in argv)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scitex_agent_container/_account/test_claude_usage_refresh.py
+++ b/tests/scitex_agent_container/_account/test_claude_usage_refresh.py
@@ -146,17 +146,20 @@ def test_refresh_account_credentials_uses_default_client_id_when_missing(
     assert result["success"] is True
 
 
-def test_refresh_account_credentials_returns_error_when_endpoint_rejects(
+def test_refresh_account_credentials_reports_unusable_response_body(
     tmp_path: Path,
 ) -> None:
     # Arrange — refresh endpoint returns junk (no access_token field).
+    # INCIDENT 2026-07-10: this used to be labelled "refresh endpoint
+    # rejected the refresh_token — needs `claude /login`", conflating a
+    # server-side response problem with a dead token.
     creds = tmp_path / "acct" / ".credentials.json"
     _seed_creds(creds)
     opener = _opener_returning({"not_access_token": "x"})
     # Act
     result = cu.refresh_account_credentials(creds, opener=opener)
     # Assert
-    assert "refresh endpoint rejected" in (result["error"] or "")
+    assert "without an access_token" in (result["error"] or "")
 
 
 def test_refresh_account_credentials_returns_error_when_creds_file_missing(
@@ -170,18 +173,20 @@ def test_refresh_account_credentials_returns_error_when_creds_file_missing(
     assert "not found" in (result["error"] or "")
 
 
-def test_refresh_account_credentials_returns_error_when_endpoint_network_error(
+def test_refresh_account_credentials_classifies_network_error_as_transport(
     tmp_path: Path,
 ) -> None:
     # Arrange — opener raises OSError to simulate a network failure.
+    # INCIDENT 2026-07-10 regression lock: a transport failure must NEVER
+    # be labelled a token rejection (the old message told the operator to
+    # `claude /login` for a dead URL/network).
     creds = tmp_path / "acct" / ".credentials.json"
     _seed_creds(creds)
     opener = _opener_raising(OSError("boom"))
     # Act
     result = cu.refresh_account_credentials(creds, opener=opener)
-    # Assert — the inner refresh helper returns None on network error and the
-    # CLI helper reports endpoint rejection (no new token minted).
-    assert "refresh endpoint rejected" in (result["error"] or "")
+    # Assert — transport class, explicitly disclaiming a token problem.
+    assert "NOT a token problem" in (result["error"] or "")
 
 
 # ---------------------------------------------------------------------------
@@ -264,16 +269,17 @@ def _capturing_opener() -> tuple[dict, "callable"]:
     return state, opener
 
 
-def test_refresh_request_uses_console_anthropic_endpoint(tmp_path: Path) -> None:
-    # Arrange
+def test_refresh_request_uses_platform_claude_endpoint(tmp_path: Path) -> None:
+    # Arrange — INCIDENT 2026-07-10: the old console.anthropic.com host
+    # now 404s every refresh_token grant (endpoint MOVED); verified live
+    # 2026-07-11 that platform.claude.com answers the grant properly.
     creds = tmp_path / "acct" / ".credentials.json"
     _seed_creds(creds)
     state, opener = _capturing_opener()
     # Act
     cu.refresh_account_credentials(creds, opener=opener)
-    # Assert — claude.ai endpoint is Cloudflare-gated; the real endpoint
-    # lives on the Anthropic console.
-    assert state["url"] == "https://console.anthropic.com/v1/oauth/token"
+    # Assert — the moved endpoint, never the dead console host.
+    assert state["url"] == "https://platform.claude.com/v1/oauth/token"
 
 
 def test_refresh_request_sends_required_cloudflare_user_agent(

--- a/tests/scitex_agent_container/_account/test_refresh_alarm.py
+++ b/tests/scitex_agent_container/_account/test_refresh_alarm.py
@@ -1,0 +1,207 @@
+"""Tests for ``_account.refresh_alarm`` — loud refresh-failure alerting.
+
+INCIDENT 2026-07-10: the refresh timer collected failing results for
+hours and told nobody. These tests lock the alerting contract: first
+failure alerts once; repeats stay quiet; recovery re-arms; a failed
+delivery is retried because nothing was recorded.
+
+No-mocks (PA-306): real JSON state files on tmp_path; the delivery seam
+is a plain recording closure (the module's documented ``notify``
+injection point). AAA marker comments; one assertion per test.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+
+from scitex_agent_container._account.refresh_alarm import alert_failed_refreshes
+
+_ERROR_TEXT = (
+    "token endpoint https://platform.claude.com/v1/oauth/token did not "
+    "evaluate the grant (HTTP 404) — NOT a token problem"
+)
+
+
+def _failure(name: str) -> dict:
+    return {
+        "name": name,
+        "success": False,
+        "skipped": False,
+        "error": _ERROR_TEXT,
+        "failure_kind": "transport",
+        "credentials_path": f"/store/{name}/.credentials.json",
+    }
+
+
+def _success(name: str) -> dict:
+    return {
+        "name": name,
+        "success": True,
+        "skipped": False,
+        "error": None,
+        "failure_kind": None,
+        "credentials_path": f"/store/{name}/.credentials.json",
+    }
+
+
+def _recorder():
+    sent: list[tuple[str, str, str]] = []
+
+    def notify(account: str, summary: str, detail: str) -> None:
+        sent.append((account, summary, detail))
+
+    return sent, notify
+
+
+def test_first_failure_sends_exactly_one_alert(tmp_path: Path) -> None:
+    # Arrange
+    sent, notify = _recorder()
+    state = tmp_path / "state.json"
+    # Act
+    alert_failed_refreshes([_failure("acct-a")], state_path=state, notify=notify)
+    # Assert
+    assert len(sent) == 1
+
+
+def test_alert_summary_names_the_account(tmp_path: Path) -> None:
+    # Arrange
+    sent, notify = _recorder()
+    state = tmp_path / "state.json"
+    # Act
+    alert_failed_refreshes([_failure("acct-a")], state_path=state, notify=notify)
+    # Assert
+    assert "acct-a" in sent[0][1]
+
+
+def test_alert_summary_carries_the_error_text(tmp_path: Path) -> None:
+    # Arrange
+    sent, notify = _recorder()
+    state = tmp_path / "state.json"
+    # Act
+    alert_failed_refreshes([_failure("acct-a")], state_path=state, notify=notify)
+    # Assert
+    assert "NOT a token problem" in sent[0][1]
+
+
+def test_alert_summary_includes_login_recovery_line(tmp_path: Path) -> None:
+    # Arrange
+    sent, notify = _recorder()
+    state = tmp_path / "state.json"
+    # Act
+    alert_failed_refreshes([_failure("acct-a")], state_path=state, notify=notify)
+    # Assert
+    assert "`claude /login` as acct-a" in sent[0][1]
+
+
+def test_alert_summary_includes_accounts_save_recovery_line(
+    tmp_path: Path,
+) -> None:
+    # Arrange
+    sent, notify = _recorder()
+    state = tmp_path / "state.json"
+    # Act
+    alert_failed_refreshes([_failure("acct-a")], state_path=state, notify=notify)
+    # Assert
+    assert "`sac accounts save acct-a`" in sent[0][1]
+
+
+def test_alert_detail_carries_the_failure_kind(tmp_path: Path) -> None:
+    # Arrange — the error CLASS must ride in the alert so the operator
+    # knows whether re-login can even help (INCIDENT 2026-07-10).
+    sent, notify = _recorder()
+    state = tmp_path / "state.json"
+    # Act
+    alert_failed_refreshes([_failure("acct-a")], state_path=state, notify=notify)
+    # Assert
+    assert "failure_kind: transport" in sent[0][2]
+
+
+def test_repeat_failure_does_not_realert(tmp_path: Path) -> None:
+    # Arrange — the ~2h timer must not page the operator 12x/day for the
+    # same already-alerted dead account.
+    sent, notify = _recorder()
+    state = tmp_path / "state.json"
+    alert_failed_refreshes([_failure("acct-a")], state_path=state, notify=notify)
+    # Act
+    alert_failed_refreshes([_failure("acct-a")], state_path=state, notify=notify)
+    # Assert
+    assert len(sent) == 1
+
+
+def test_recovery_then_failure_alerts_again(tmp_path: Path) -> None:
+    # Arrange — an account that recovers and later dies again is a NEW
+    # outage and must page again.
+    sent, notify = _recorder()
+    state = tmp_path / "state.json"
+    alert_failed_refreshes([_failure("acct-a")], state_path=state, notify=notify)
+    alert_failed_refreshes([_success("acct-a")], state_path=state, notify=notify)
+    # Act
+    alert_failed_refreshes([_failure("acct-a")], state_path=state, notify=notify)
+    # Assert
+    assert len(sent) == 2
+
+
+def test_skipped_fresh_result_clears_the_dedupe_entry(tmp_path: Path) -> None:
+    # Arrange — a skipped-still-fresh result proves the account is alive
+    # again (the gate only skips fresh tokens), so the alarm re-arms.
+    sent, notify = _recorder()
+    state = tmp_path / "state.json"
+    alert_failed_refreshes([_failure("acct-a")], state_path=state, notify=notify)
+    skipped = {"name": "acct-a", "success": None, "skipped": True, "error": None}
+    # Act
+    alert_failed_refreshes([skipped], state_path=state, notify=notify)
+    # Assert
+    assert "acct-a" not in json.loads(state.read_text())
+
+
+def test_failed_delivery_is_not_recorded_so_next_run_retries(
+    tmp_path: Path,
+) -> None:
+    # Arrange — run 1's delivery rail is down (raises); nothing must be
+    # recorded so run 2 retries and succeeds.
+    state = tmp_path / "state.json"
+
+    def broken(account: str, summary: str, detail: str) -> None:
+        raise RuntimeError("rail down")
+
+    alert_failed_refreshes(
+        [_failure("acct-a")],
+        state_path=state,
+        notify=broken,
+        err_stream=io.StringIO(),
+    )
+    sent, notify = _recorder()
+    # Act
+    alert_failed_refreshes([_failure("acct-a")], state_path=state, notify=notify)
+    # Assert
+    assert len(sent) == 1
+
+
+def test_failed_delivery_prints_loud_stderr_line(tmp_path: Path) -> None:
+    # Arrange
+    state = tmp_path / "state.json"
+    stream = io.StringIO()
+
+    def broken(account: str, summary: str, detail: str) -> None:
+        raise RuntimeError("rail down")
+
+    # Act
+    alert_failed_refreshes(
+        [_failure("acct-a")], state_path=state, notify=broken, err_stream=stream
+    )
+    # Assert
+    assert "ALERT DELIVERY FAILED" in stream.getvalue()
+
+
+def test_alerted_account_names_are_returned(tmp_path: Path) -> None:
+    # Arrange
+    _, notify = _recorder()
+    state = tmp_path / "state.json"
+    # Act
+    alerted = alert_failed_refreshes(
+        [_failure("acct-a"), _success("acct-b")], state_path=state, notify=notify
+    )
+    # Assert
+    assert alerted == ["acct-a"]

--- a/tests/scitex_agent_container/_account/test_token_refresh_classification.py
+++ b/tests/scitex_agent_container/_account/test_token_refresh_classification.py
@@ -1,0 +1,225 @@
+"""Failure-class tests for ``_account.token_refresh`` (INCIDENT 2026-07-10).
+
+The incident: Anthropic moved the OAuth token endpoint; the old
+``console.anthropic.com`` host 404s every refresh_token grant, and the
+old error handling collapsed EVERY failure into "refresh endpoint
+rejected the refresh_token — needs `claude /login`". Operators were told
+to re-login healthy accounts while the URL was what had died. These
+tests lock the honest classification: transport/endpoint failures must
+NEVER read as token death, and only a genuine ``invalid_grant`` may
+prescribe a re-login.
+
+No-mocks (PA-306): real bytes on tmp_path; HTTP is injected as a plain
+opener callable raising REAL ``urllib.error.HTTPError`` objects (the
+production seam, same shape as the sibling refresh tests). AAA marker
+comments; one assertion per test.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import urllib.error
+from pathlib import Path
+from typing import Any
+
+from scitex_agent_container._account import token_refresh as tr
+
+_INCIDENT_404_BODY = (
+    b'{"type":"error","error":{"type":"not_found_error","message":"Not found"}}'
+)
+_INVALID_GRANT_BODY = (
+    b'{"error": "invalid_grant", '
+    b'"error_description": "Refresh token not found or invalid"}'
+)
+
+
+def _seed_creds(path: Path, *, refresh: str = "the-refresh") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "old-access",
+                    "refreshToken": refresh,
+                    "clientId": "cid",
+                }
+            }
+        )
+    )
+
+
+def _opener_http_error(code: int, body: bytes):
+    """Opener raising a REAL urllib HTTPError with the given body."""
+
+    def opener(req, timeout=None):
+        raise urllib.error.HTTPError(
+            req.full_url, code, "err", hdrs=None, fp=io.BytesIO(body)
+        )
+
+    return opener
+
+
+# ---------------------------------------------------------------------------
+# HTTP 404 (the incident shape) — transport class, never token death.
+# ---------------------------------------------------------------------------
+
+
+def test_http_404_classifies_as_transport_failure(tmp_path: Path) -> None:
+    # Arrange — the exact 404 body the dead console endpoint returns.
+    creds = tmp_path / "acct" / ".credentials.json"
+    _seed_creds(creds)
+    opener = _opener_http_error(404, _INCIDENT_404_BODY)
+    # Act
+    result = tr.refresh_account_credentials(creds, opener=opener)
+    # Assert
+    assert result["failure_kind"] == tr.FAILURE_TRANSPORT
+
+
+def test_http_404_error_never_prescribes_claude_login(tmp_path: Path) -> None:
+    # Arrange — INCIDENT 2026-07-10 regression lock: a 404 (endpoint
+    # moved/gone) must never tell the operator the token needs /login.
+    creds = tmp_path / "acct" / ".credentials.json"
+    _seed_creds(creds)
+    opener = _opener_http_error(404, _INCIDENT_404_BODY)
+    # Act
+    result = tr.refresh_account_credentials(creds, opener=opener)
+    # Assert
+    assert "claude /login" not in (result["error"] or "")
+
+
+def test_http_404_error_says_not_a_token_problem(tmp_path: Path) -> None:
+    # Arrange
+    creds = tmp_path / "acct" / ".credentials.json"
+    _seed_creds(creds)
+    opener = _opener_http_error(404, _INCIDENT_404_BODY)
+    # Act
+    result = tr.refresh_account_credentials(creds, opener=opener)
+    # Assert
+    assert "NOT a token problem" in (result["error"] or "")
+
+
+def test_http_404_error_names_the_endpoint_url(tmp_path: Path) -> None:
+    # Arrange — self-diagnosing errors: the message must carry the URL
+    # that failed so the next endpoint move is identified from one line.
+    creds = tmp_path / "acct" / ".credentials.json"
+    _seed_creds(creds)
+    opener = _opener_http_error(404, _INCIDENT_404_BODY)
+    # Act
+    result = tr.refresh_account_credentials(creds, opener=opener)
+    # Assert
+    assert "platform.claude.com" in (result["error"] or "")
+
+
+# ---------------------------------------------------------------------------
+# HTTP 400 invalid_grant — the ONE genuinely-dead-token class.
+# ---------------------------------------------------------------------------
+
+
+def test_http_400_invalid_grant_classifies_as_rejected(tmp_path: Path) -> None:
+    # Arrange — the live platform endpoint's answer for a dead token.
+    creds = tmp_path / "acct" / ".credentials.json"
+    _seed_creds(creds)
+    opener = _opener_http_error(400, _INVALID_GRANT_BODY)
+    # Act
+    result = tr.refresh_account_credentials(creds, opener=opener)
+    # Assert
+    assert result["failure_kind"] == tr.FAILURE_REJECTED
+
+
+def test_http_400_invalid_grant_prescribes_claude_login(tmp_path: Path) -> None:
+    # Arrange — a genuinely-dead refresh_token IS fixed by re-auth.
+    creds = tmp_path / "acct" / ".credentials.json"
+    _seed_creds(creds)
+    opener = _opener_http_error(400, _INVALID_GRANT_BODY)
+    # Act
+    result = tr.refresh_account_credentials(creds, opener=opener)
+    # Assert
+    assert "claude /login" in (result["error"] or "")
+
+
+# ---------------------------------------------------------------------------
+# Endpoint URL resolution — env override so the next move needs no release.
+# ---------------------------------------------------------------------------
+
+
+def test_default_token_url_targets_platform_claude_host() -> None:
+    # Arrange — INCIDENT 2026-07-10: console.anthropic.com is dead for
+    # refresh grants (404); the platform host is the verified-live one.
+    # Act
+    url = tr.resolve_token_url()
+    # Assert
+    assert url == "https://platform.claude.com/v1/oauth/token"
+
+
+def test_env_override_repoints_token_endpoint(
+    tmp_path: Path, env_save_restore
+) -> None:
+    # Arrange
+    env_save_restore.set(
+        "SAC_ANTHROPIC_OAUTH_TOKEN_URL", "https://example.test/oauth/token"
+    )
+    # Act
+    url = tr.resolve_token_url()
+    # Assert
+    assert url == "https://example.test/oauth/token"
+
+
+# ---------------------------------------------------------------------------
+# Concurrent-rotation retry — shared writable credential file (2026-07-11).
+# ---------------------------------------------------------------------------
+
+
+def test_rejected_grant_retries_once_with_rotated_on_disk_token(
+    tmp_path: Path,
+) -> None:
+    # Arrange — first POST gets invalid_grant; by then ANOTHER writer has
+    # rotated the on-disk refresh_token (shared :rw credential file). The
+    # refresher must re-read and succeed with the rotated token instead
+    # of declaring the account dead.
+    creds = tmp_path / "acct" / ".credentials.json"
+    _seed_creds(creds, refresh="STALE-REFRESH")
+    calls: list[dict[str, Any]] = []
+
+    class _Resp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def read(self):
+            return json.dumps(
+                {"access_token": "FRESH", "refresh_token": "R2", "expires_in": 3600}
+            ).encode()
+
+    def opener(req, timeout=None):
+        body = json.loads(req.data.decode())
+        calls.append(body)
+        if body["refresh_token"] == "STALE-REFRESH":
+            # Simulate the concurrent writer landing the rotation on disk
+            # BEFORE the failure returns, then refuse the stale grant.
+            _seed_creds(creds, refresh="ROTATED-BY-PEER")
+            raise urllib.error.HTTPError(
+                req.full_url, 400, "err", hdrs=None, fp=io.BytesIO(_INVALID_GRANT_BODY)
+            )
+        return _Resp()
+
+    # Act
+    result = tr.refresh_account_credentials(creds, opener=opener)
+    # Assert
+    assert result["success"] is True
+
+
+def test_rejected_grant_with_unchanged_disk_token_stays_rejected(
+    tmp_path: Path,
+) -> None:
+    # Arrange — invalid_grant with NO concurrent rotation on disk: there
+    # is nothing fresher to retry with; the account is genuinely dead.
+    creds = tmp_path / "acct" / ".credentials.json"
+    _seed_creds(creds, refresh="ONLY-REFRESH")
+    opener = _opener_http_error(400, _INVALID_GRANT_BODY)
+    # Act
+    result = tr.refresh_account_credentials(creds, opener=opener)
+    # Assert
+    assert result["failure_kind"] == tr.FAILURE_REJECTED

--- a/tests/scitex_agent_container/_creds/test__pick_healthy.py
+++ b/tests/scitex_agent_container/_creds/test__pick_healthy.py
@@ -44,6 +44,29 @@ def _isolate_home(tmp_path: Path):
             os.environ["HOME"] = saved
 
 
+@pytest.fixture(autouse=True)
+def _isolate_quota_cache(tmp_path: Path):
+    """Point the quota-cache reader at a nonexistent tmp file.
+
+    Hermeticity fix (found during INCIDENT 2026-07-10 follow-up): agent
+    containers bind the LIVE fleet ``/var/sac/quota-cache.json`` — the
+    reader's DEFAULT path — so unpatched quota-aware pick tests read
+    real production utilisation and flip winners depending on the
+    fleet's current load. An explicitly-absent path degrades every
+    lookup to ``None`` (freshness-only), the documented no-cache
+    behavior the affected tests assume.
+    """
+    saved = os.environ.get("SAC_QUOTA_CACHE_PATH")
+    os.environ["SAC_QUOTA_CACHE_PATH"] = str(tmp_path / "absent-quota-cache.json")
+    try:
+        yield
+    finally:
+        if saved is None:
+            os.environ.pop("SAC_QUOTA_CACHE_PATH", None)
+        else:
+            os.environ["SAC_QUOTA_CACHE_PATH"] = saved
+
+
 def _store_root(home: Path) -> Path:
     return home / ".scitex" / "agent-container" / "accounts"
 

--- a/tests/scitex_agent_container/_creds/test__pick_healthy_evidence.py
+++ b/tests/scitex_agent_container/_creds/test__pick_healthy_evidence.py
@@ -1,0 +1,238 @@
+"""Self-diagnosing-evidence tests for ``_creds._pick_healthy``.
+
+INCIDENT 2026-07-10 (``sac agents start --group infra`` total boot
+failure): the picker's "EXPIRED (-5.8h)" error hid WHICH file and WHICH
+raw ``expiresAt`` it evaluated. When the snapshot was rewritten by a
+login-capture minutes after the probe, the terse message made a correct
+read look like a false one and cost the investigation hours. These
+tests lock the evidence contract: every health record and every
+``NoHealthyAccountError`` names the file, the literal ``expiresAt``
+value, and the probe time — and a snapshot with a FUTURE expiry can
+never be reported expired.
+
+No mocks (PA-306): real JSON snapshots under a tmp store. AAA markers
+(TQ002); one assertion per test (TQ007). Same ``_isolate_home`` idiom as
+the sibling ``test__pick_healthy``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from scitex_agent_container._creds._pick_healthy import (
+    NoHealthyAccountError,
+    account_health,
+    pick_healthy_account,
+)
+
+
+@pytest.fixture
+def _isolate_home(tmp_path: Path):
+    """Force ``Path.home()`` inside ``tmp_path`` for the test's duration."""
+    saved = os.environ.get("HOME")
+    os.environ["HOME"] = str(tmp_path)
+    try:
+        yield tmp_path
+    finally:
+        if saved is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = saved
+
+
+@pytest.fixture(autouse=True)
+def _isolate_quota_cache(tmp_path: Path):
+    """Point the quota-cache reader at a nonexistent tmp file.
+
+    Agent containers bind the LIVE fleet ``/var/sac/quota-cache.json``
+    (the reader's default path); an explicitly-absent override keeps
+    these evidence tests independent of real production utilisation.
+    """
+    saved = os.environ.get("SAC_QUOTA_CACHE_PATH")
+    os.environ["SAC_QUOTA_CACHE_PATH"] = str(tmp_path / "absent-quota-cache.json")
+    try:
+        yield
+    finally:
+        if saved is None:
+            os.environ.pop("SAC_QUOTA_CACHE_PATH", None)
+        else:
+            os.environ["SAC_QUOTA_CACHE_PATH"] = saved
+
+
+def _snapshot_path(home: Path, name: str) -> Path:
+    return (
+        home / ".scitex" / "agent-container" / "accounts" / name / ".credentials.json"
+    )
+
+
+def _write_snapshot(home: Path, name: str, expires_at_ms: int) -> Path:
+    """Write a full-shape credential snapshot (incident-real fields)."""
+    path = _snapshot_path(home, name)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "sk-ant-oat-not-real",
+                    "refreshToken": "sk-ant-ort-not-real",
+                    "expiresAt": expires_at_ms,
+                    "scopes": ["user:inference"],
+                }
+            }
+        )
+    )
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Regression: a FUTURE expiresAt must never read as EXPIRED.
+# ---------------------------------------------------------------------------
+
+
+def test_future_expiry_snapshot_is_never_reported_expired(
+    _isolate_home: Path,
+) -> None:
+    # Arrange — the incident's healthy-account shape: a fresh ms-epoch
+    # expiry ~8h out (what the repaired wyusuuke snapshot held).
+    home = _isolate_home
+    _write_snapshot(home, "wyusuuke-gmail-com", int((time.time() + 8 * 3600) * 1000))
+    # Act
+    health = account_health("wyusuuke-gmail-com", home=home)
+    # Assert
+    assert health.state == "VALID"
+
+
+def test_future_expiry_snapshot_is_picked_not_refused(_isolate_home: Path) -> None:
+    # Arrange — one healthy candidate must always boot (no false
+    # NoHealthyAccountError on a future expiry).
+    home = _isolate_home
+    _write_snapshot(home, "wyusuuke-gmail-com", int((time.time() + 8 * 3600) * 1000))
+    # Act
+    picked = pick_healthy_account(
+        "wyusuuke-gmail-com", candidates=["wyusuuke-gmail-com"], home=home
+    )
+    # Assert
+    assert picked == "wyusuuke-gmail-com"
+
+
+# ---------------------------------------------------------------------------
+# Evidence on the health record itself.
+# ---------------------------------------------------------------------------
+
+
+def test_account_health_records_the_snapshot_file_it_read(
+    _isolate_home: Path,
+) -> None:
+    # Arrange
+    home = _isolate_home
+    written = _write_snapshot(home, "acct-a", int((time.time() + 3600) * 1000))
+    # Act
+    health = account_health("acct-a", home=home)
+    # Assert
+    assert health.snapshot_path == str(written)
+
+
+def test_account_health_records_the_raw_expires_at_value(
+    _isolate_home: Path,
+) -> None:
+    # Arrange — the incident's literal pre-repair value.
+    home = _isolate_home
+    _write_snapshot(home, "acct-a", 1783672205000)
+    # Act
+    health = account_health("acct-a", home=home)
+    # Assert
+    assert health.expires_at_raw == 1783672205000.0
+
+
+def test_absent_account_health_still_names_the_probed_path(
+    _isolate_home: Path,
+) -> None:
+    # Arrange — no snapshot written; the record must still say WHERE it
+    # looked so a wrong-store-resolution bug is visible from the record.
+    home = _isolate_home
+    # Act
+    health = account_health("ghost-account", home=home)
+    # Assert
+    assert health.snapshot_path == str(_snapshot_path(home, "ghost-account"))
+
+
+# ---------------------------------------------------------------------------
+# Evidence in the NoHealthyAccountError message.
+# ---------------------------------------------------------------------------
+
+
+def _pick_error_message(
+    home: Path, candidate: str, now: float | None = None
+) -> str:
+    """Run the picker expecting NoHealthyAccountError; return its message.
+
+    Returns ``""`` when no error was raised so a content assertion fails
+    loudly instead of passing vacuously. Keeps each test at exactly ONE
+    assertion (TQ007 counts ``pytest.raises`` blocks as assertions).
+    """
+    try:
+        pick_healthy_account(candidate, candidates=[candidate], home=home, now=now)
+    except NoHealthyAccountError as exc:
+        return str(exc)
+    return ""
+
+
+def test_no_healthy_error_names_the_snapshot_file_path(_isolate_home: Path) -> None:
+    # Arrange — one expired candidate (the incident shape).
+    home = _isolate_home
+    written = _write_snapshot(home, "acct-a", 1783672205000)
+    # Act
+    message = _pick_error_message(home, "acct-a")
+    # Assert
+    assert str(written) in message
+
+
+def test_no_healthy_error_quotes_the_raw_expires_at_value(
+    _isolate_home: Path,
+) -> None:
+    # Arrange
+    home = _isolate_home
+    _write_snapshot(home, "acct-a", 1783672205000)
+    # Act
+    message = _pick_error_message(home, "acct-a")
+    # Assert
+    assert "expiresAt=1783672205000" in message
+
+
+def test_no_healthy_error_renders_the_expiry_as_utc(_isolate_home: Path) -> None:
+    # Arrange — 1783672205000 ms = 2026-07-10T08:30:05+00:00 (the exact
+    # pre-repair wyusuuke expiry behind the incident's "-5.8h").
+    home = _isolate_home
+    _write_snapshot(home, "acct-a", 1783672205000)
+    # Act
+    message = _pick_error_message(home, "acct-a")
+    # Assert
+    assert "2026-07-10T08:30:05+00:00" in message
+
+
+def test_no_healthy_error_pins_the_probe_timestamp(_isolate_home: Path) -> None:
+    # Arrange — the probe time makes a probe-vs-recheck race
+    # adjudicable from the error line alone.
+    home = _isolate_home
+    _write_snapshot(home, "acct-a", 1783672205000)
+    # Act
+    message = _pick_error_message(home, "acct-a", now=1783693260.0)
+    # Assert
+    assert "probed at 2026-07-10T14:21:00+00:00" in message
+
+
+def test_no_healthy_error_marks_absent_snapshot_with_its_path(
+    _isolate_home: Path,
+) -> None:
+    # Arrange — ABSENT candidate: the error must name the path that was
+    # probed and found missing/unparseable.
+    home = _isolate_home
+    # Act
+    message = _pick_error_message(home, "ghost")
+    # Assert
+    assert str(_snapshot_path(home, "ghost")) in message

--- a/tests/scitex_agent_container/cli_pkg/test__account_refresh_alarm_wiring.py
+++ b/tests/scitex_agent_container/cli_pkg/test__account_refresh_alarm_wiring.py
@@ -1,0 +1,105 @@
+"""End-to-end wiring: ``sac accounts refresh`` fires the loud failure alarm.
+
+INCIDENT 2026-07-10: refresh failures reached only the journal; nothing
+paged the operator. These tests drive the REAL CLI against a real
+on-disk account store whose credentials lack a refresh_token (a genuine
+no-network failure path) and verify the alarm chain runs: the lead rail
+is unconfigured in the sandbox, so delivery falls through to the
+scitex-todo help card written into a sandboxed shared store — exactly
+the production fallback order.
+
+No-mocks (PA-306): real store, real CLI, real scitex-todo store file.
+AAA marker comments; one assertion per test.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from scitex_agent_container._state.account_store import save_account
+from scitex_agent_container.cli_pkg.account_group import account
+
+
+@pytest.fixture(autouse=True)
+def sandbox_env(tmp_path, env_save_restore):
+    """Isolate HOME + every store-resolution env the alarm chain reads."""
+    home = tmp_path / "home"
+    home.mkdir()
+    env_save_restore.set("HOME", str(home))
+    env_save_restore.set(
+        "SCITEX_TODO_TASKS_YAML_SHARED", str(tmp_path / "todo-tasks.yaml")
+    )
+    env_save_restore.delete("SCITEX_DIR")
+    env_save_restore.delete("SAC_NAME")
+    env_save_restore.delete("SCITEX_AGENT_CONTAINER_REGISTRY_DIR")
+    return home
+
+
+def _seed_stale_account_without_refresh_token(home: Path, name: str) -> None:
+    """A stale (past-expiry) account whose creds lack a refresh_token.
+
+    The --all gate refreshes it (stale), and the refresh fails BEFORE
+    any network call ("no refresh_token in credentials") — a real
+    failure result with zero network dependence.
+    """
+    save_account(name, {"email_address": f"{name}@x"}, home=home)
+    creds = (
+        home / ".scitex" / "agent-container" / "accounts" / name / ".credentials.json"
+    )
+    creds.write_text(
+        json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "OLD-ACCESS",
+                    "expiresAt": int(time.time() * 1000) - 3_600_000,
+                }
+            }
+        )
+    )
+
+
+def test_failed_refresh_prints_alerted_operator_line(
+    sandbox_env: Path, tmp_path: Path
+) -> None:
+    # Arrange
+    _seed_stale_account_without_refresh_token(sandbox_env, "stale-acct")
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(account, ["refresh", "--all"])
+    # Assert — the alarm ran and reported a delivered alert.
+    assert "ALERTED operator" in result.output
+
+
+def test_failed_refresh_upserts_help_card_into_todo_store(
+    sandbox_env: Path, tmp_path: Path
+) -> None:
+    # Arrange — the sandbox has no lead: block, so delivery falls
+    # through to the scitex-todo help-card rail (the production
+    # fallback), landing in the sandboxed shared store.
+    _seed_stale_account_without_refresh_token(sandbox_env, "stale-acct")
+    runner = CliRunner()
+    # Act
+    runner.invoke(account, ["refresh", "--all"])
+    # Assert — the canonical BLOCKING-YOU card exists for the account.
+    assert "help-accounts-refresh-stale-acct-waiting" in (
+        tmp_path / "todo-tasks.yaml"
+    ).read_text()
+
+
+def test_second_run_does_not_realert_for_same_dead_account(
+    sandbox_env: Path, tmp_path: Path
+) -> None:
+    # Arrange — dedupe across CLI invocations rides the state file under
+    # the sandbox HOME's runtime dir.
+    _seed_stale_account_without_refresh_token(sandbox_env, "stale-acct")
+    runner = CliRunner()
+    runner.invoke(account, ["refresh", "--all"])
+    # Act
+    second = runner.invoke(account, ["refresh", "--all"])
+    # Assert — quiet on the repeat run.
+    assert "ALERTED operator" not in second.output

--- a/tests/scitex_agent_container/cli_pkg/test__account_refresh_alarm_wiring.py
+++ b/tests/scitex_agent_container/cli_pkg/test__account_refresh_alarm_wiring.py
@@ -10,6 +10,15 @@ the production fallback order.
 
 No-mocks (PA-306): real store, real CLI, real scitex-todo store file.
 AAA marker comments; one assertion per test.
+
+The whole module requires the OPTIONAL ``scitex_todo`` peer (the
+fallback delivery leg under test) — leaf CI does not install it, so we
+skip there, exactly like ``tests/integration/test_cross_package_imports``
+does for peer modules; the fleet hosts and the umbrella CI (every peer
+installed) run it. Without the peer, the chain ends in the documented
+"ALERT DELIVERY FAILED — every alert rail failed" stderr path (verified
+in CI run 29106433698) instead of a delivered card, so the
+delivered-path assertions below cannot hold there.
 """
 
 from __future__ import annotations
@@ -20,6 +29,8 @@ from pathlib import Path
 
 import pytest
 from click.testing import CliRunner
+
+pytest.importorskip("scitex_todo", reason="alarm fallback leg needs scitex-todo")
 
 from scitex_agent_container._state.account_store import save_account
 from scitex_agent_container.cli_pkg.account_group import account

--- a/tests/scitex_agent_container/runtimes/test__apptainer_auth.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_auth.py
@@ -131,8 +131,9 @@ def test_oauth_argv_binds_credentials_when_present(tmp_path: Path, home_redirect
     # Act
     argv = auth_argv(cfg, state_dir=tmp_path / "state")
     # Assert — dir-bind at /tmp/sac-claude (NOT /tmp/sac-claude/.credentials.json),
-    # READ-ONLY (master-host single-refresher model: agents never refresh).
-    assert any(a == f"{creds.parent}:/tmp/sac-claude:ro" for a in argv)
+    # WRITABLE (shared-credential model, operator 2026-07-11: a rotation
+    # performed in-container must be recorded, not silently dropped).
+    assert any(a == f"{creds.parent}:/tmp/sac-claude:rw" for a in argv)
 
 
 def test_oauth_argv_does_not_emit_legacy_file_bind(tmp_path: Path, home_redirect: Path):

--- a/tests/scitex_agent_container/runtimes/test__apptainer_auth_dir_bind.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_auth_dir_bind.py
@@ -162,12 +162,13 @@ def test_pinned_bind_destination_is_directory_not_file_path(
     assert spec is not None and spec.split(":")[1] == "/tmp/sac-claude"
 
 
-def test_pinned_bind_is_ro(tmp_path: Path, home_redirect: Path) -> None:
-    # Arrange — master-host single-refresher model (operator 2026-07-08):
-    # the bind must be :ro so the agent NEVER refreshes/rotates the
-    # credential. The host-side sac-accounts-refresh timer is the sole
-    # refresher; the DIRECTORY bind still surfaces its atomic-replace
-    # refreshes to the container without a restart.
+def test_pinned_bind_is_rw(tmp_path: Path, home_redirect: Path) -> None:
+    # Arrange — shared-credential model (operator 2026-07-11, reversing
+    # the 2026-07-08 :ro flip): a :ro bind cannot stop the in-container
+    # claude from rotating the token server-side, it only stops the
+    # rotation from being RECORDED — stranding the snapshot on a dead
+    # refresh_token. The bind is therefore :rw so whoever refreshes
+    # writes the rotated pair back for every co-bound consumer.
     now = time.time()
     _write_snapshot(home_redirect, "alpha", now + 3_600)
     cfg = _pinned_config(tmp_path / "wd", account="alpha")
@@ -175,7 +176,7 @@ def test_pinned_bind_is_ro(tmp_path: Path, home_redirect: Path) -> None:
     argv = auth_argv(cfg, state_dir=tmp_path / "state")
     spec = _extract_bind_spec_for_target_prefix(argv, "/tmp/sac-claude")
     # Assert
-    assert spec is not None and spec.split(":")[-1] == "ro"
+    assert spec is not None and spec.split(":")[-1] == "rw"
 
 
 def test_pinned_claude_config_dir_env_unchanged(

--- a/tests/scitex_agent_container/runtimes/test__apptainer_build_argv.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_build_argv.py
@@ -306,7 +306,7 @@ def test_credentials_file_bind_mounts_designated_file_ro(tmp_path) -> None:
     # (master-host single-refresher model: the agent never refreshes).
     assert flags == [
         "--bind",
-        f"{creds}:/home/agent/.claude/.credentials.json:ro",
+        f"{creds}:/home/agent/.claude/.credentials.json:rw",
     ]
 
 
@@ -349,12 +349,12 @@ def test_credentials_file_bind_resolves_account_when_no_explicit_file(
     config = load_config(str(spec))
     # Act
     flags = credentials_file_bind(config)
-    # Assert — single-file :ro bind onto the canonical container creds path,
+    # Assert — single-file :rw bind onto the canonical container creds path,
     # source = the per-host snapshot. NO copy, NO CLAUDE_CONFIG_DIR redirect.
     # READ-ONLY: the agent reads the snapshot; the host timer refreshes it.
     assert flags == [
         "--bind",
-        f"{snap}:/home/agent/.claude/.credentials.json:ro",
+        f"{snap}:/home/agent/.claude/.credentials.json:rw",
     ]
 
 
@@ -389,7 +389,7 @@ def test_credentials_file_bind_explicit_file_wins_over_account(
     # Assert — explicit file path is the source, bound READ-ONLY.
     assert flags == [
         "--bind",
-        f"{explicit}:/home/agent/.claude/.credentials.json:ro",
+        f"{explicit}:/home/agent/.claude/.credentials.json:rw",
     ]
 
 
@@ -741,7 +741,7 @@ def test_build_run_argv_appends_credentials_bind_last(tmp_path) -> None:
     # Assert — the creds bind sits immediately before the sif path so no
     # later home bind can shadow it.
     sif_idx = argv.index("/img/sac.sif")
-    assert argv[sif_idx - 1] == f"{creds}:/home/agent/.claude/.credentials.json:ro"
+    assert argv[sif_idx - 1] == f"{creds}:/home/agent/.claude/.credentials.json:rw"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scitex_agent_container/runtimes/test__apptainer_runtime.py
+++ b/tests/scitex_agent_container/runtimes/test__apptainer_runtime.py
@@ -1083,7 +1083,7 @@ def test_argv_mounts_credentials_dir_when_present(
     # Act
     argv = rt.build_run_argv(cfg, state_dir=tmp_path, sif_path=tmp_path / "x.sif")
     # Assert — bind source is the credentials file's PARENT (~/.claude/).
-    assert any(a == f"{creds.parent}:/tmp/sac-claude:ro" for a in argv)
+    assert any(a == f"{creds.parent}:/tmp/sac-claude:rw" for a in argv)
 
 
 def test_argv_credentials_bind_is_read_only(
@@ -1103,7 +1103,7 @@ def test_argv_credentials_bind_is_read_only(
     argv = rt.build_run_argv(cfg, state_dir=tmp_path, sif_path=tmp_path / "x.sif")
     creds_arg = next(a for a in argv if ":/tmp/sac-claude:" in a)
     # Assert
-    assert creds_arg.endswith(":ro")
+    assert creds_arg.endswith(":rw")
 
 
 def test_argv_sets_claude_config_dir_when_credentials_present(
@@ -1182,7 +1182,7 @@ def test_argv_pins_account_binds_snapshot_directory_not_host_file(
     # atomic-replace writers in creds_sync / account_store /
     # claude_usage, regressing into the per-copy collision-401 disease
     # the snapshot model was meant to fix). The bound dir's child
-    # ``.credentials.json`` remains the snapshot itself, bound :ro; the
+    # ``.credentials.json`` remains the snapshot itself, bound :rw; the
     # host-side sac-accounts-refresh timer refreshes it and every
     # same-account agent reads the timer-kept-fresh token.
     host_creds = home_redirect / ".claude" / ".credentials.json"
@@ -1198,7 +1198,7 @@ def test_argv_pins_account_binds_snapshot_directory_not_host_file(
     creds_arg = next(
         a
         for a in argv
-        if a.startswith(str(snap.parent) + ":") and a.endswith(":/tmp/sac-claude:ro")
+        if a.startswith(str(snap.parent) + ":") and a.endswith(":/tmp/sac-claude:rw")
     )
     # Assert — the bound host-side source IS the account directory
     # (snapshot.parent), neither the snapshot file alone, a per-agent
@@ -1225,7 +1225,7 @@ def test_argv_pins_account_does_not_create_state_dir_copy(
     rt.build_run_argv(cfg, state_dir=state_dir, sif_path=tmp_path / "x.sif")
     legacy_copy = state_dir / "claude" / ".credentials.json"
     # Assert — no per-agent copy materialised; the snapshot is the
-    # single source the :ro agents read and the host timer refreshes.
+    # single source the agents share and the host timer refreshes.
     assert not legacy_copy.exists()
 
 
@@ -1245,7 +1245,7 @@ def test_argv_no_account_dir_binds_host_claude(
     argv = rt.build_run_argv(cfg, state_dir=tmp_path, sif_path=tmp_path / "x.sif")
     # Assert — bind source is the credentials file's PARENT (~/.claude/);
     # bind dest is the DIRECTORY /tmp/sac-claude, not the file inside it.
-    assert any(a == f"{host_creds.parent}:/tmp/sac-claude:ro" for a in argv)
+    assert any(a == f"{host_creds.parent}:/tmp/sac-claude:rw" for a in argv)
 
 
 def test_argv_pinned_account_missing_snapshot_raises_pinned_account_error(


### PR DESCRIPTION
## Incident

`incident-account-pool-all-expired-boot-failure-20260710` — 2026-07-10 ~23:2x JST: `sac agents start --group infra` failed for all 5 agents with `NoHealthyAccountError`; all 3 stored accounts read EXPIRED; the refresh timer had been failing silently for hours.

## Root cause (empirically verified, live)

Anthropic **moved the OAuth token endpoint**. The hardcoded `https://console.anthropic.com/v1/oauth/token` ("verified live 2026-05-30") now returns **HTTP 404 `not_found_error` for every refresh_token grant** — the exact body in the timer log for every "dead" account. Probe from this host (dummy token):

| endpoint | answer |
|---|---|
| `console.anthropic.com/v1/oauth/token` | **404 not_found_error** (gone) |
| `platform.claude.com/v1/oauth/token` | **400 invalid_grant** (alive, evaluates the grant) |

The old handler collapsed every failure into `None`, and the CLI labelled it *"refresh endpoint rejected the refresh_token — needs `claude /login`"* — a dead URL misdiagnosed as dead tokens. Nothing had refreshed headlessly for days; snapshots survived only via live-login captures, then aged out.

**Live validation of the fix:** running `refresh_account_credentials` from this branch against the two "dead" accounts **succeeded with their stored refresh_tokens** — the tokens were never invalid. All three accounts are VALID again (`ywata1989-gmail-com` +8h, `ywatanabe-scitex-ai` +8h, `wyusuuke-gmail-com` +7h). **No operator `claude /login` was needed for this incident.** Rotate-persist (write-back of the rotated refresh_token under flock + atomic rename) was verified present and exercised live.

## Changes (4 separable commits)

1. **Endpoint fix + honest failure classes** (`_account/token_refresh.py`, split out of the 817-line `claude_usage.py`; re-exports keep every importer unchanged)
   - `_TOKEN_URL` → `https://platform.claude.com/v1/oauth/token`, resolved per call, overridable via `$SAC_ANTHROPIC_OAUTH_TOKEN_URL` (next move needs no release)
   - failures classified: `rejected` (invalid_grant → genuinely-dead token, prescribes `claude /login` + `sac accounts save`) vs `transport` (404/5xx/network → message says **"NOT a token problem"** and names the URL + status) vs `response` (2xx without access_token); `failure_kind` rides the result dict
   - re-read-and-retry once on invalid_grant when the on-disk refresh_token changed under us (concurrent-writer rotation)
2. **Loud refresh-failure alerting** (`_account/refresh_alarm.py`, hooked into every `sac accounts refresh` invocation — the systemd timer runs exactly this CLI)
   - existing rails only: ADR-0013 lead `blocker` push (`push_to_lead`), falling back to the scitex-todo BLOCKING-YOU help card (`scitex_todo._help_wait.help_wait`, card `help-accounts-refresh-<account>-waiting`) since this fleet currently has **no `lead:` block configured**
   - alert = account name + classified error + canonical recovery line; dedupe via `runtime/refresh-alarm-state.json`; recovery re-arms (recover-then-die alerts again); failed delivery records nothing (retried next run) and prints loudly
3. **Self-diagnosing `NoHealthyAccountError`** (`_creds/_pick_healthy.py`, `_account/creds_sync.py`)
   - `AccountHealth` carries `snapshot_path` + `expires_at_raw` (one parse supplies judgment and evidence); the error quotes per account: file path, literal `expiresAt`, UTC rendering, and the probe timestamp
   - regression locks: a future `expiresAt` can never read EXPIRED / never raises
4. **Credential bind `:ro` → `:rw`** (operator decision 2026-07-11; both the single-file bind and the `/tmp/sac-claude` dir bind)
   - a read-only bind cannot stop the in-container claude from rotating the token server-side; it only stops the rotation being RECORDED, stranding the snapshot on a dead refresh_token — worst of both worlds. Shared-writable is the normal supported claude shape; flock + atomic write + the invalid_grant re-read-retry cover the narrow residual race. `config/_types.py` already documented the writable model (doc/code divergence resolved toward the doc). Evidence note: today's incident was **not** this path (both stored refresh_tokens were still redeemable — no in-container rotation had consumed them), so the flip removes a standing hazard, not the manifested one. Cross-host single-writer stays the `sac-host-token-broker-single-writer` follow-up.

## FACT 2 — the "false-EXPIRED" read of wyusuuke: resolved, no divergent reader

The picker's read was **correct at read time**; the file changed minutes later:

- creds-watch saved the wyusuuke snapshot at 00:30:07Z with `expires_at=1783672205` (= 08:30:05Z)
- creds-watch itself logged the live cred **"expired 20973 seconds ago"** (= 5.83h ≈ the reported **-5.8h**) at 14:19:38Z — a second reader independently confirming the same pre-repair value
- a fresh login/rotation landed at 14:22:23Z; creds-watch captured it into the snapshot at 14:22:24Z (`expires_at=1783722143` = 22:22:23Z — the +8h state the operator later probed)
- "-5.8h" against 1783672205 pins the picker's read to 14:15–14:21Z (23:15–23:21 JST); the dead pair's "-5.9h" (expiries 08:25/08:28Z) pins the same window — the group start probed *before/straddling* the 14:22:24Z capture, and the terse error hid the evidence needed to see that

Ruled out: ms/s unit bug (would render ±490,000h, not -5.8h); project-scope/`$SCITEX_DIR`/container-home store divergence (the infra specs pin absolute `credentials_files` under the host store and the pool derives `store_dir` from those exact paths; the `/home/agent` store is empty → would read ABSENT, not EXPIRED); quota-cache-as-expiry (quota data only orders fresh candidates, cannot mark EXPIRED); refresher-writes-elsewhere (same `store/<name>/.credentials.json`); dotfiles-git-revert (live snapshots are gitignored). Not fully adjudicable from surviving evidence: a stale mount-namespace view in whatever context ran the start vs. simple invocation-time uncertainty — which is exactly why the error now prints file + raw value + probe time (commit 3): the next occurrence is decidable from one line.

## Tests

- 214 passed across `_creds/` and `runtimes/` (bind flip) plus the new suites: token-refresh classification (404-never-says-login regression lock, invalid_grant classes, env override, rotation retry), refresh-alarm (dedupe / re-arm / retry / recovery), pick-healthy evidence (path + raw value + probe time in the error; future-expiry locks), CLI wiring (real CLI → real no-network failure → help card written into a sandboxed store; cross-run dedupe)
- new hermeticity fixture: the quota-aware pick tests were reading the LIVE fleet `/var/sac/quota-cache.json` bound into agent containers (pre-existing environment-dependent failures, reproduced on unmodified develop in-container); `SAC_QUOTA_CACHE_PATH` is now pinned to an absent tmp file
- `ruff --select F401,F811` clean; `scitex-dev ecosystem audit-all --path <worktree>`: project/skills/mcp-tools/python-apis clean after fixes (removed a stray root junk file; registered `scitex_todo._help_wait` in the PS-140 cross-package gate); `audit-cli: not-auditable: unknown` is pre-existing/environmental (fires identically before this branch); the `tests/develop/test_audit.py` one-shot hits its documented 120s subprocess cap under current host load

## Deploy notes / follow-ups

- the host timer keeps 404-ing until this deploys (host sac is an editable install → next timer tick after merge+pull uses the fixed URL); both revived accounts hold ~8h tokens meanwhile
- the dotfiles **hourly** snapshot-refresh script (`account-snapshots-refresh.log`, the "operator 1a" rail) hits the same dead URL — separate repo, needs the same one-line fix
- `lead:` block is unconfigured fleet-wide, so alert leg 1 is inert until configured; leg 2 (scitex-todo card) delivers today
- July-8 credential backups are **committed in the dotfiles git repo** (`src/.scitex/agent-container/accounts/_backup/.../*.credentials.json` tracked) — security-hygiene follow-up
- `claude_usage.py` is down 817 → 584 lines; step 2 of the split (per-account usage block) is the noted follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)
